### PR TITLE
Less hostile workaround for dot-in-inc

### DIFF
--- a/dist/base/t/extra_inc_via_base.t
+++ b/dist/base/t/extra_inc_via_base.t
@@ -1,0 +1,30 @@
+#!/usr/bin/perl -w
+
+use strict;
+use Test::More tests => 10;  # one test is in each BaseInc* itself
+
+use lib qw(t/lib);
+
+# make it look like an older perl
+BEGIN {
+    push @INC, '.'
+        if $INC[-1] ne '.';
+}
+
+use base 'BaseIncExtender';
+
+BEGIN {
+    is $INC[0], 't/libleblab', 'Expected head @INC adjustment from within `use base`';
+    is $INC[1], 't/lib', 'Preexisting @INC adjustment still in @INC';
+    is $INC[-1], '.', 'Trailing . still in @INC ater `use base`'; 
+}
+
+use base 'BaseIncDoubleExtender';
+
+BEGIN {
+    is $INC[0], 't/libloblub', 'Expected head @INC adjustment from within `use base`';
+    is $INC[1], 't/libleblab', 'Preexisting @INC adjustment still in @INC';
+    is $INC[2], 't/lib', 'Preexisting @INC adjustment still in @INC';
+    cmp_ok $INC[-2], 'ne', '.', 'Trailing . not reinserted erroneously'; 
+    is $INC[-1], 't/libonend', 'Expected tail @INC adjustment from within `use base`';
+}

--- a/dist/base/t/lib/BaseIncDoubleExtender.pm
+++ b/dist/base/t/lib/BaseIncDoubleExtender.pm
@@ -1,0 +1,14 @@
+package BaseIncDoubleExtender;
+
+BEGIN {
+    ::ok(
+        ( $INC[-1] ne '.' ),
+        '. not at @INCs tail during `use base ...`',
+    );
+}
+
+use lib 't/libloblub';
+
+push @INC, 't/libonend';
+
+1;

--- a/dist/base/t/lib/BaseIncExtender.pm
+++ b/dist/base/t/lib/BaseIncExtender.pm
@@ -1,0 +1,12 @@
+package BaseIncExtender;
+
+BEGIN {
+    ::ok(
+        ( $INC[-1] ne '.' ),
+        '. not at @INCs tail during `use base ...`',
+    );
+}
+
+use lib 't/libleblab';
+
+1;


### PR DESCRIPTION
**NOTE** - this is a workaround for the current version of `base.pm` in blead. I do not endorse, agree or condone the original changeset from 362f3f74 / bca5527 / 8901dde. Simply popping '.' is shortsighted and wrong

With that said - the current implementation has a pretty serious regression, hence this PR as an attempt at damage control. The original local()-based implementation would mask away any `@INC`
manipulation within a require()d chain.

@xsawyerx _PLEASE_ do not ship the maint-perls without implementing this or a similar fix.

@haarg, @kentfredric, @ap, @Leont, @karenetheridge : I wrote this in the past hour literally in a moving vehicle, with a mild headache. **Please scrutinize** the changeset. I would be very surprised if it doesn't contain problems.
