### PR TITLE
Prevent a previous set ErrorLevel=9009 from causing spurious "You do not have Perl in your PATH"

### DIFF
--- a/win32/bin/pl2bat.pl
+++ b/win32/bin/pl2bat.pl
@@ -52,6 +52,7 @@ EOT
     $head = <<EOT;
 	\@rem = '--*-Perl-*--
 	\@echo off
+	set errorlevel=
 	if "%OS%" == "Windows_NT" goto WinNT
 	perl $OPT{'o'}
 	goto endofperl


### PR DESCRIPTION
Without this fix, if the environment variable ErrorLevel was already 9009, running any batch file created by pl2bat will erroneously report "You do not have Perl in your PATH".