### PR TITLE
skip shadow call when euid > 0 on linux

### DIFF
--- a/pp_sys.c
+++ b/pp_sys.c
@@ -5509,7 +5509,11 @@ PP(pp_gpwent)
 	 * --jhi */
 	/* Some AIX setups falsely(?) detect some getspnam(), which
 	 * has a different API than the Solaris/IRIX one. */
+
 #   if defined(HAS_GETSPNAM) && !defined(_AIX)
+#      ifdef __linux__
+    if (!PerlProc_geteuid())
+#      endif
 	{
 	    dSAVE_ERRNO;
 	    const struct spwd * const spwent = getspnam(pwent->pw_name);


### PR DESCRIPTION
maybe __linux__ is not restrictive enough
and we could consider using a hint sh file
to enable it only on some specific distro?