### PR TITLE
toke.c: fixed warning in ternary operator.

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -9491,9 +9491,9 @@ S_scan_ident(pTHX_ char *s, char *dest, STRLEN destlen, I32 ck_uni)
             s = skipspace(s);
         }
     }
-    if ((s <= PL_bufend - (is_utf8)
+    if ((s <= PL_bufend - ((is_utf8)
                           ? UTF8SKIP(s)
-                          : 1)
+                          : 1))
         && VALID_LEN_ONE_IDENT(s, PL_bufend, is_utf8))
     {
         if (is_utf8) {


### PR DESCRIPTION
Developers team of the [PVS-Studio](https://www.viva64.com/en/pvs-studio/) static code analyzer for C/C++/C#/Java checked the Perl 5 source code and found some errors.

All examples are available in the article: [Perl 5: How to Hide Errors in Macros](https://www.viva64.com/en/b/0583/). 