### PR TITLE
Add Socket.so link to perlembed doc

### DIFF
--- a/pod/perlembed.pod
+++ b/pod/perlembed.pod
@@ -1069,10 +1069,15 @@ Once you have this code, slap it into the second argument of I<perl_parse()>:
 
  perl_parse(my_perl, xs_init, argc, my_argv, NULL);
 
+To avoid the error C<undefined reference to `boot_Socket> you would also
+need to link your binary with the C<Socket.so> file. You can use the handy
+one-liner C<perl -MSocket -e 'print @DynaLoader::dl_shared_objects'> to get
+its location.
 
 Then compile:
 
- % cc -o interp interp.c `perl -MExtUtils::Embed -e ccopts -e ldopts`
+ % cc -o interp interp.c `perl -MExtUtils::Embed -e ccopts -e ldopts` \
+    `perl -MSocket -e 'print @DynaLoader::dl_shared_objects'`
 
  % interp
    use Socket;


### PR DESCRIPTION
When using xs_init we need to link the
binary to the .so files in order to be able
to call the boot_* function.

Note: not sure if ExtUtils::Embed can provide
a way to get the path of the .so file