### PR TITLE
Adjust perlvar doc for @INC

### DIFF
--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -494,12 +494,13 @@ The array C<@INC> contains the list of places that the C<do EXPR>,
 C<require>, or C<use> constructs look for their library files.  It
 initially consists of the arguments to any B<-I> command-line
 switches, followed by the default Perl library, probably
-F</usr/local/lib/perl>, followed by ".", to represent the current
-directory.  ("." will not be appended if taint checks are enabled,
-either by C<-T> or by C<-t>, or if configured not to do so by the
-C<-Ddefault_inc_excludes_dot> compile time option.)  If you need to
-modify this at runtime, you should use the C<use lib> pragma to get
-the machine-dependent library properly loaded also:
+F</usr/local/lib/perl>.
+Since Perl 5.26 '.' which represents the current directory
+is not appended anymore to C<@INC>. This is not recommended to change
+this behavior and you can read more about it from
+L<C<PERL_USE_UNSAFE_INC>|perlrun/PERL_USE_UNSAFE_INC>
+If you need to modify C<@INC> at runtime, you should use
+the C<use lib> pragma to get the machine-dependent library properly loaded also:
 
     use lib '/mypath/libdir/';
     use SomeMod;


### PR DESCRIPTION
RT #134108

dot is not in @INC anymore since 5.26

Note: just using this PR for review & comments before pushing to blead