### PR TITLE
Update URLs and labels in a few documents

### DIFF
--- a/README.bs2000
+++ b/README.bs2000
@@ -227,7 +227,7 @@ To subscribe, send an empty message to perl-mvs-subscribe@perl.org.
 
 See also:
 
-    http://lists.perl.org/list/perl-mvs.html
+    https://lists.perl.org/list/perl-mvs.html
 
 There are web archives of the mailing list at:
 

--- a/README.cn
+++ b/README.cn
@@ -57,7 +57,7 @@ Perl 也内附了 "piconv", 一支完全以 Perl 写成的字符转换工具程�
 
 =head2 额外的中文编码
 
-如果需要更多的中文编码, 可以从 CPAN (L<http://www.cpan.org/>) 下载
+如果需要更多的中文编码, 可以从 CPAN (L<https://www.cpan.org/>) 下载
 Encode::HanExtra 模块. 它目前提供下列编码方式:
 
     gb18030	扩充过的国标码, 包含繁体中文
@@ -81,17 +81,21 @@ Perl 的知识, 以及 Unicode 的使用方式. 不过, 外部的资源相当丰
 
 =head2 提供 Perl 资源的网址
 
+=item L<https://www.perl.org/>
+
+Perl 的首页
+
 =over 4
 
-=item L<http://www.perl.com/>
+=item L<https://www.perl.com/>
 
-Perl 的首页 (由欧莱礼公司维护)
+由 Perl 基金会所营运的文章辑录
 
-=item L<http://www.cpan.org/>
+=item L<https://www.cpan.org/>
 
 Perl 综合典藏网 (Comprehensive Perl Archive Network)
 
-=item L<http://lists.perl.org/>
+=item L<https://lists.perl.org/>
 
 Perl 邮递论坛一览
 
@@ -111,7 +115,7 @@ Perl 邮递论坛一览
 
 =over 4
 
-=item L<http://www.pm.org/groups/asia.html>
+=item L<https://www.pm.org/groups/asia.html>
 
 中国 Perl 推广组一览
 
@@ -121,11 +125,11 @@ Perl 邮递论坛一览
 
 =over 4
 
-=item L<http://www.unicode.org/>
+=item L<https://www.unicode.org/>
 
 Unicode 学术学会 (Unicode 标准的制定者)
 
-=item L<http://www.cl.cam.ac.uk/%7Emgk25/unicode.html>
+=item L<https://www.cl.cam.ac.uk/%7Emgk25/unicode.html>
 
 Unix/Linux 上的 UTF-8 及 Unicode 答客问
 

--- a/README.jp
+++ b/README.jp
@@ -120,15 +120,19 @@ Perlには膨大な資料が付属しており、Perlの新機能やUnicodeサ�
 
 =over 4
 
-=item L<http://www.perl.com/>
+=item L<https://www.perl.org/>
 
-Perl ホームページ (O'Reilly and Associates)
+Perl ホームページ
 
-=item L<http://www.cpan.org/>
+=item L<https://www.perl.com/>
+
+Perl 財団が営業する文章作品集
+
+=item L<https://www.cpan.org/>
 
 CPAN (Comprehensive Perl Archive Network)
 
-=item L<http://lists.perl.org/>
+=item L<https://lists.perl.org/>
 
 Perl メーリングリスト集
 
@@ -146,7 +150,7 @@ O'Reilly 社のPerl関連書籍(繁体字中国語)
 
 O'Reilly 社のPerl関連書籍(簡体字中国語)
 
-=item L<http://www.oreilly.co.jp/catalog/>
+=item L<https://www.oreilly.co.jp/catalog/>
 
 オライリー社のPerl関連書籍(日本語)
 
@@ -156,7 +160,7 @@ O'Reilly 社のPerl関連書籍(簡体字中国語)
 
 =over 4
 
-=item L<http://www.pm.org/groups/asia.html>
+=item L<https://www.pm.org/groups/asia.html>
 
 =back
 
@@ -164,15 +168,15 @@ O'Reilly 社のPerl関連書籍(簡体字中国語)
 
 =over 4
 
-=item L<http://www.unicode.org/>
+=item L<https://www.unicode.org/>
 
 Unicode コンソーシアム (Unicode規格の選定団体)
 
-=item L<http://www.cl.cam.ac.uk/%7Emgk25/unicode.html>
+=item L<https://www.cl.cam.ac.uk/%7Emgk25/unicode.html>
 
 UTF-8 and Unicode FAQ for Unix/Linux
 
-=item L<http://wiki.kldp.org/Translations/html/UTF8-Unicode-KLDP/UTF8-Unicode-KLDP.html>
+=item L<https://wiki.kldp.org/Translations/html/UTF8-Unicode-KLDP/UTF8-Unicode-KLDP.html>
 
 UTF-8 and Unicode FAQ for Unix/Linux (ハングル訳)
 

--- a/README.ko
+++ b/README.ko
@@ -218,16 +218,16 @@ Perl은 기본적으로 내부에서 UTF-8을 사용하며 Encode 모듈을 통�
 
 =item * L<encoding>
 
-=item * L<http://www.unicode.org/>
+=item * L<https://www.unicode.org/>
 
 유니코드 컨소시엄
 
-=item * L<http://std.dkuug.dk/JTC1/SC2/WG2>
+=item * L<https://std.dkuug.dk/JTC1/SC2/WG2>
 
 기본적으로 Unicode와 같은 ISO 표준인  ISO/IEC 10646 UCS(Universal
 Character Set)을 만드는 ISO/IEC JTC1/SC2/WG2의 웹 페이지
 
-=item * L<http://www.cl.cam.ac.uk/~mgk25/unicode.html>
+=item * L<https://www.cl.cam.ac.uk/~mgk25/unicode.html>
 
 유닉스/리눅스 사용자를 위한 UTF-8 및 유니코드 관련 FAQ
 
@@ -244,35 +244,35 @@ Character Set)을 만드는 ISO/IEC JTC1/SC2/WG2의 웹 페이지
 
 =over 4
 
-=item * L<http://www.perl.org/>
+=item * L<https://www.perl.org/>
 
 Perl 공식 홈페이지
 
-=item * L<http://www.perl.com/>
+=item * L<https://www.perl.com/>
 
 O'Reilly의 Perl 웹 페이지
 
-=item * L<http://www.cpan.org/>
+=item * L<https://www.cpan.org/>
 
 CPAN - Comprehensive Perl Archive Network, 통합적 Perl 파일 보관 네트워크
 
-=item * L<http://metacpan.org>
+=item * L<https://metacpan.org>
 
 메타 CPAN
 
-=item * L<http://lists.perl.org/>
+=item * L<https://lists.perl.org/>
 
 Perl 메일링 리스트
 
-=item * L<http://blogs.perl.org/>
+=item * L<https://blogs.perl.org/>
 
 Perl 메타 블로그
 
-=item * L<http://www.perlmonks.org/>
+=item * L<https://www.perlmonks.org/>
 
 Perl 수도승들을 위한 수도원
 
-=item * L<http://www.pm.org/groups/asia.html>
+=item * L<https://www.pm.org/groups/asia.html>
 
 아시아 지역 Perl 몽거스 모임
 
@@ -287,15 +287,15 @@ Perl 크리스마스 달력
 
 =over 4
 
-=item * L<http://perl.kr/>
+=item * L<https://perl.kr/>
 
 한국 Perl 커뮤니티 공식 포털
 
-=item * L<http://doc.perl.kr/>
+=item * L<https://doc.perl.kr/>
 
 Perl 문서 한글화 프로젝트
 
-=item * L<http://cafe.naver.com/perlstudy.cafe>
+=item * L<https://cafe.naver.com/perlstudy.cafe>
 
 네이버 Perl 카페
 
@@ -303,17 +303,13 @@ Perl 문서 한글화 프로젝트
 
 한국 Perl 사용자 모임
 
-=item * L<http://advent.perl.kr>
+=item * L<https://advent.perl.kr>
 
 Seoul.pm Perl 크리스마스 달력 (2010 ~ 2012)
 
 =item * L<http://gypark.pe.kr/wiki/Perl>
 
 GYPARK(Geunyoung Park)의 Perl 관련 한글 문서 저장소
-
-=item * L<http://seoul.pm.org>
-
-Seoul.pm - 서울 Perl 몽거스
 
 =back
 

--- a/README.os390
+++ b/README.os390
@@ -422,7 +422,7 @@ To subscribe, send an empty message to perl-mvs-subscribe@perl.org.
 
 See also:
 
-    http://lists.perl.org/list/perl-mvs.html
+    https://lists.perl.org/list/perl-mvs.html
 
 There are web archives of the mailing list at:
 

--- a/README.tw
+++ b/README.tw
@@ -139,10 +139,6 @@ Unix/Linux 上的 UTF-8 及 Unicode 答客問
 
 L<http://www.cpatch.org/>
 
-=item Linux 軟體中文化計劃
-
-L<http://www.linux.org.tw/CLDP/>
-
 =back
 
 =head1 SEE ALSO

--- a/README.tw
+++ b/README.tw
@@ -79,9 +79,13 @@ Perl 的知識, 以及 Unicode 的使用方式. 不過, 外部的資源相當豐
 
 =over 4
 
+=item L<https://www.perl.org/>
+
+Perl 的首頁
+
 =item L<https://www.perl.com/>
 
-Perl 的首頁 (由歐萊禮公司維護)
+由 Perl 基金會所營運的文章輯錄
 
 =item L<https://www.cpan.org/>
 

--- a/README.tw
+++ b/README.tw
@@ -50,7 +50,7 @@ Perl 也內附了 "piconv", 一支完全以 Perl 寫成的字符轉換工具程�
 
 =head2 額外的中文編碼
 
-如果需要更多的中文編碼, 可以從 CPAN (L<http://www.cpan.org/>) 下載
+如果需要更多的中文編碼, 可以從 CPAN (L<https://www.cpan.org/>) 下載
 Encode::HanExtra 模組. 它目前提供下列編碼方式:
 
     cccii	1980 年文建會的中文資訊交換碼

--- a/README.tw
+++ b/README.tw
@@ -79,15 +79,15 @@ Perl 的知識, 以及 Unicode 的使用方式. 不過, 外部的資源相當豐
 
 =over 4
 
-=item L<http://www.perl.com/>
+=item L<https://www.perl.com/>
 
 Perl 的首頁 (由歐萊禮公司維護)
 
-=item L<http://www.cpan.org/>
+=item L<https://www.cpan.org/>
 
 Perl 綜合典藏網 (Comprehensive Perl Archive Network)
 
-=item L<http://lists.perl.org/>
+=item L<https://lists.perl.org/>
 
 Perl 郵遞論壇一覽
 
@@ -107,7 +107,7 @@ Perl 郵遞論壇一覽
 
 =over 4
 
-=item L<http://www.pm.org/groups/taiwan.html>
+=item L<https://www.pm.org/groups/taiwan.html>
 
 臺灣 Perl 推廣組一覽
 
@@ -121,7 +121,7 @@ Perl.tw 線上聊天室
 
 =over 4
 
-=item L<http://www.unicode.org/>
+=item L<https://www.unicode.org/>
 
 Unicode 學術學會 (Unicode 標準的制定者)
 

--- a/pod/perl.pod
+++ b/pod/perl.pod
@@ -374,10 +374,10 @@ see L<perlvar> for more information.
 
 =head1 SEE ALSO
 
- http://www.perl.org/       the Perl homepage
- http://www.perl.com/       Perl articles (O'Reilly)
- http://www.cpan.org/       the Comprehensive Perl Archive
- http://www.pm.org/         the Perl Mongers
+ https://www.perl.org/       the Perl homepage
+ https://www.perl.com/       Perl articles
+ https://www.cpan.org/       the Comprehensive Perl Archive
+ https://www.pm.org/         the Perl Mongers
 
 =head1 DIAGNOSTICS
 

--- a/pod/perlhack.pod
+++ b/pod/perlhack.pod
@@ -145,7 +145,7 @@ L<http://archive.develooper.com/perl5-porters@perl.org/>.
 
 The perl5-changes mailing list receives a copy of each patch that gets
 submitted to the maintenance and development branches of the perl
-repository.  See L<http://lists.perl.org/list/perl5-changes.html> for
+repository.  See L<https://lists.perl.org/list/perl5-changes.html> for
 subscription and archive information.
 
 =head2 #p5p on IRC

--- a/pod/perlmodstyle.pod
+++ b/pod/perlmodstyle.pod
@@ -182,9 +182,9 @@ been done in Perl, and avoid re-inventing the wheel unless you have a
 good reason.
 
 Good places to look for pre-existing modules include
-L<http://search.cpan.org/> and L<https://metacpan.org>
+L<MetaCPAN|https://metacpan.org> and L<PrePAN|http://prepan.org>
 and asking on C<module-authors@perl.org>
-(L<http://lists.perl.org/list/module-authors.html>).
+(L<https://lists.perl.org/list/module-authors.html>).
 
 If an existing module B<almost> does what you want, consider writing a
 patch, writing a subclass, or otherwise extending the existing module
@@ -255,7 +255,7 @@ developers.
 You should also try to get feedback from people who are already familiar
 with the module's application domain and the CPAN naming system.  Authors
 of similar modules, or modules with similar names, may be a good place to
-start, as are community sites like L<Perl Monks|http://www.perlmonks.org>.
+start, as are community sites like L<Perl Monks|https://www.perlmonks.org>.
 
 =head1 DESIGNING AND WRITING YOUR MODULE
 
@@ -798,7 +798,7 @@ L<ExtUtils::MakeMaker>, L<Module::Build>
 
 L<Test::Simple>, L<Test::Inline>, L<Carp::Assert>, L<Test::More>, L<Test::MockObject>
 
-=item L<http://pause.perl.org/>
+=item L<https://pause.perl.org/>
 
 Perl Authors Upload Server.  Contains links to information for module
 authors.

--- a/pod/perlnewmod.pod
+++ b/pod/perlnewmod.pod
@@ -98,7 +98,7 @@ might not actually be any real demand for it out there. If you're unsure
 about the demand your module will have, consider asking the
 C<module-authors@perl.org> mailing list (send an email to
 C<module-authors-subscribe@perl.org> to subscribe; see
-L<http://lists.perl.org/list/module-authors.html> for more information
+L<https://lists.perl.org/list/module-authors.html> for more information
 and a link to the archives).
 
 =item Choose a name

--- a/pod/perlthrtut.pod
+++ b/pod/perlthrtut.pod
@@ -1093,7 +1093,7 @@ Latest version of L<threads::shared> on CPAN:
 L<http://search.cpan.org/search?module=threads%3A%3Ashared>
 
 Perl threads mailing list:
-L<http://lists.perl.org/list/ithreads.html>
+L<https://lists.perl.org/list/ithreads.html>
 
 =head1 Bibliography
 


### PR DESCRIPTION
A dead link in the documentation README.tw is found, and I could not find known alternativess. Leaving it in the document unchanged makes less sense to me.

Other than that, other urls are changed to be https instead if they are reachable.
