### PR TITLE
Fix setting EFFECTIVE_GROUP_ID to a list

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5765,6 +5765,7 @@ t/op/goto_xs.t			See if "goto &sub" works on XSUBs
 t/op/grent.t			See if getgr*() functions work
 t/op/grep.t			See if grep() and map() work
 t/op/groups.t			See if $( works
+t/op/groups-setegid.t   See if $( works
 t/op/gv.t			See if typeglobs work
 t/op/hash.t			See if the complexity attackers are repelled
 t/op/hash-rt85026.t		See if hash iteration/deletion works

--- a/mg.c
+++ b/mg.c
@@ -3180,6 +3180,7 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
             Groups_t *gary = NULL;
             const char* p_end = p + len;
             const char* endptr = p_end;
+            const char* backup_endptr = endptr;
             UV uv;
 #ifdef _SC_NGROUPS_MAX
            int maxgrp = sysconf(_SC_NGROUPS_MAX);
@@ -3211,6 +3212,7 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
                     Newx(gary, i + 1, Groups_t);
                 else
                     Renew(gary, i + 1, Groups_t);
+                endptr = backup_endptr; /* we know where the end is */
                 if (grok_atoUV(p, &uv, &endptr))
                     gary[i] = (Groups_t)uv;
                 else {

--- a/t/op/groups-setegid.t
+++ b/t/op/groups-setegid.t
@@ -1,0 +1,41 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc( '../lib' );
+    skip_all_if_miniperl("no dynamic loading on miniperl, no POSIX");
+}
+
+use 5.010;
+use strict;
+use Config ();
+use POSIX ();
+
+skip_all('getgrgid() not implemented')
+    unless eval { my($foo) = getgrgid(0); 1 };
+
+skip_all("No 'id' or 'groups'") if
+    $^O eq 'MSWin32' || $^O eq 'NetWare' || $^O eq 'VMS' || $^O =~ /lynxos/i;
+
+skip_all('need to be root') if $> != 0;
+
+Test();
+exit;
+
+
+
+sub Test {
+
+    plan 2;
+
+    $) = "123";
+    is $), "123", "can change egid to '123'";
+
+    $) = "123 123";
+    is $), "123 123", "can change egid to '123 123'";
+
+    return;
+}
+
+# ex: set ts=8 sts=4 sw=4 et:


### PR DESCRIPTION
RT 134486

This is a regression introduced in 5.29.0
by 5d4a52b5 `grok_atoUV: allow non-C strings and document`

Making sure we backup the end pointer and restore it
before calling multiple times grok_atoUV should fix it.

URL: https://rt.perl.org/Ticket/Display.html?id=134486

fixing this as root: `perl -E '$) = "123 456"; say $)'`