### PR TITLE
Fix libperl.t 'no symbols' warning on darwin

### DIFF
--- a/t/porting/libperl.t
+++ b/t/porting/libperl.t
@@ -581,9 +581,11 @@ if (defined $nm_err_tmp) {
         while (<$nm_err_fh>) {
             # OS X has weird error where nm warns about
             # "no name list" but then outputs fine.
-            if (/nm: no name list/ && $^O eq 'darwin') {
-                print "# $^O ignoring $nm output: $_";
-                next;
+            if ( $^O eq 'darwin' ) {
+                if (/nm: no name list/ || /^no symbols$/ ) {
+                    print "# $^O ignoring $nm output: $_";
+                    next;
+                }
             }
             warn "$0: Unexpected $nm error: $_";
             $error++;


### PR DESCRIPTION
darwin can compile perlapi.o without any symbols.
libperl.t is running  'mm -m ./libperl.a' and is
is viewing the 'no symbols' stderr output from perlapi.o
then fail.

'nm -g perlapi.o'

We can either add a dummy symbol to libperl via
regen/embed.pl or simply ignore that error in a generic way,
or avoid compiling that file when not needed.