### PR TITLE
Update documentation, comments, metadata to reference GitHub as canonical repository

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,9 +8,8 @@ For a list of contributors to perl, see AUTHORS.
 
 If you need a detailed commit history (i.e. descriptions of each
 individual commit),  you can view the git version control history online
-at https://perl5.git.perl.org/perl.git (follow the 'shortlog' link beside
-the relevant tag). Or, you can download a copy of the git repository and
-then run a command like
+at https://github.com/Perl/perl5.  Or, you can download a copy of the git
+repository and then run a command like
 
     git log --name-status v5.12.0..v5.14.0
 

--- a/META.json
+++ b/META.json
@@ -117,14 +117,14 @@
    "release_status" : "unstable",
    "resources" : {
       "bugtracker" : {
-         "web" : "https://rt.perl.org/"
+         "web" : "https://github.com/Perl/perl5/issues"
       },
       "homepage" : "https://www.perl.org/",
       "license" : [
          "https://dev.perl.org/licenses/"
       ],
       "repository" : {
-         "url" : "https://perl5.git.perl.org/"
+         "url" : "https://github.com/Perl/perl5"
       }
    },
    "version" : "5.031006",

--- a/META.yml
+++ b/META.yml
@@ -110,9 +110,9 @@ no_index:
     - vutil.h
     - vxs.inc
 resources:
-  bugtracker: https://rt.perl.org/
+  bugtracker: https://github.com/Perl/perl5/issues
   homepage: https://www.perl.org/
   license: https://dev.perl.org/licenses/
-  repository: https://perl5.git.perl.org/
+  repository: https://github.com/Perl/perl5
 version: '5.031006'
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/Porting/README.pod
+++ b/Porting/README.pod
@@ -361,7 +361,7 @@ A helper tool for perl's 2038 support See F<Porting/README.y2038> for details.
 =head2 F<todo.pod>
 
 This is a list of wishes for Perl. The most up-to-date version of this file is
-at L<https://perl5.git.perl.org/perl.git/blob_plain/HEAD:/Porting/todo.pod>.
+at L<https://github.com/Perl/perl5/blob/blead/Porting/todo.pod>.
 The tasks we think are smaller or easier are listed first.  Anyone is welcome
 to work on any of these, but it's a good idea to first contact
 I<perl5-porters@perl.org> to avoid duplication of effort, and to learn from

--- a/Porting/corelist.pl
+++ b/Porting/corelist.pl
@@ -291,6 +291,7 @@ foreach my $module ( sort keys %module_to_upstream ) {
     $bug_tracker = $bug_tracker->{web} if ref($bug_tracker) eq "HASH";
 
     $bug_tracker = defined $bug_tracker ? quote($bug_tracker) : 'undef';
+    next if $bug_tracker eq "'https://github.com/Perl/perl5/issues'";
 	next if $bug_tracker eq "'http://rt.perl.org/perlbug/'";
 	next if $bug_tracker eq "'https://rt.perl.org/perlbug/'";
     $tracker .= sprintf "    %-24s=> %s,\n", "'$module'", $bug_tracker;

--- a/Porting/makemeta
+++ b/Porting/makemeta
@@ -47,11 +47,11 @@ my $distmeta = {
   'dynamic_config' => 1,
   'resources' => {
     'repository' => {
-      'url' => 'https://perl5.git.perl.org/'
+      'url' => 'https://github.com/Perl/perl5'
     },
     'homepage' => 'https://www.perl.org/',
     'bugtracker' => {
-      'web' => 'https://rt.perl.org/'
+      'web' => 'https://github.com/Perl/perl5/issues'
     },
     'license' => [
       'https://dev.perl.org/licenses/'

--- a/Porting/todo.pod
+++ b/Porting/todo.pod
@@ -5,7 +5,7 @@ todo - Perl TO-DO list
 =head1 DESCRIPTION
 
 This is a list of wishes for Perl. The most up to date version of this file
-is at L<https://perl5.git.perl.org/perl.git/blob_plain/HEAD:/Porting/todo.pod>
+is at L<https://github.com/Perl/perl5/blob/blead/Porting/todo.pod>.
 
 The tasks we think are smaller or easier are listed first. Anyone is welcome
 to work on any of these, but it's a good idea to first contact

--- a/configpm
+++ b/configpm
@@ -150,7 +150,7 @@ $config_txt .= sprintf << 'EOT', $], $export_funcs;
 
 # for a description of the variables, please have a look at the
 # Glossary file, as written in the Porting folder, or use the url:
-# https://perl5.git.perl.org/perl.git/blob/HEAD:/Porting/Glossary
+# https://github.com/Perl/perl5/blob/blead/Porting/Glossary
 
 package Config;
 use strict;
@@ -896,7 +896,7 @@ named variable exists.
 
 For a description of the variables, please have a look at the
 Glossary file, as written in the Porting folder, or use the url:
-https://perl5.git.perl.org/perl.git/blob/HEAD:/Porting/Glossary
+https://github.com/Perl/perl5/blob/blead/Porting/Glossary
 
 =over 4
 

--- a/cop.h
+++ b/cop.h
@@ -103,8 +103,8 @@ typedef struct jmpenv JMPENV;
  *
  * The original patches that introduces flexible exceptions were:
  *
- * https://perl5.git.perl.org/perl.git/commit/312caa8e97f1c7ee342a9895c2f0e749625b4929
- * https://perl5.git.perl.org/perl.git/commit/14dd3ad8c9bf82cf09798a22cc89a9862dfd6d1a
+ * https://github.com/Perl/perl5/commit/312caa8e97f1c7ee342a9895c2f0e749625b4929
+ * https://github.com/Perl/perl5/commit/14dd3ad8c9bf82cf09798a22cc89a9862dfd6d1a
  *
  */
 

--- a/hints/dec_osf.sh
+++ b/hints/dec_osf.sh
@@ -263,7 +263,7 @@ toke_cflags='optimize=-O2'
 esac
 
 # The patch 23787
-# https://perl5.git.perl.org/perl.git/commit/73cb726371990cd489597c4fee405a9815abf4da
+# https://github.com/Perl/perl5/commit/73cb726371990cd489597c4fee405a9815abf4da
 # broke things for gcc (at least gcc 3.3) so that many of the pack()
 # checksum tests for formats L, j, J, especially when combined
 # with the < and > specifiers, started to fail if compiled with plain -O3.

--- a/pod/perlgit.pod
+++ b/pod/perlgit.pod
@@ -18,18 +18,18 @@ Perl, including those with write access to the git repository.
 =head1 CLONING THE REPOSITORY
 
 All of Perl's source code is kept centrally in a Git repository at
-I<perl5.git.perl.org>.
+I<github.com>.
 
 You can make a read-only clone of the repository by running:
 
-  % git clone git://perl5.git.perl.org/perl.git perl
+  % git clone git://github.com/Perl/perl5.git perl
 
 This uses the git protocol (port 9418).
 
 If you cannot use the git protocol for firewall reasons, you can also
-clone via http, though this is much slower:
+clone via http:
 
-  % git clone https://perl5.git.perl.org/perl.git perl
+  % git clone https://github.com/Perl/perl5.git perl
 
 =head1 WORKING WITH THE REPOSITORY
 
@@ -341,12 +341,12 @@ patch will be destroyed.
 Someone may download your patch from RT, which will result in the
 subject (the first line of the commit message) being omitted.  See
 L<RT #74192|https://rt.perl.org/Ticket/Display.html?id=74192> and
-L<commit a4583001|https://perl5.git.perl.org/perl.git/commitdiff/a4583001>
+L<commit a4583001|https://github.com/Perl/perl5/commit/a4583001>
 for an example. Alternatively someone may
 apply your patch from RT after it arrived in their mailbox, by which
 time RT will have modified the inline content of the message.  See
 L<RT #74532|https://rt.perl.org/Ticket/Display.html?id=74532> and
-L<commit f9bcfeac|https://perl5.git.perl.org/perl.git/commitdiff/f9bcfeac>
+L<commit f9bcfeac|https://github.com/Perl/perl5/commit/f9bcfeac>
 for a bad example of this failure mode.
 
 =head2 A note on derived files
@@ -586,7 +586,7 @@ Once you have write access, you will need to modify the URL for the
 origin remote to enable pushing. Edit F<.git/config> with the
 git-config(1) command:
 
-  % git config remote.origin.url ssh://perl5.git.perl.org/perl.git
+  % git config remote.origin.url git@github.com:Perl/perl5.git
 
 You can also set up your user name and e-mail address. Most people do
 this once globally in their F<~/.gitconfig> by doing something like:
@@ -602,7 +602,7 @@ execute something like the following in F<perl>:
 It is also possible to keep C<origin> as a git remote, and add a new
 remote for ssh access:
 
-  % git remote add camel perl5.git.perl.org:/perl.git
+  % git remote add camel git@github.com:Perl/perl5.git
 
 This allows you to update your local repository by pulling from
 C<origin>, which is faster and doesn't require you to authenticate, and
@@ -814,35 +814,6 @@ original commit in the new commit message.
 Before pushing any change to a maint version, make sure you've
 satisfied the steps in L</Committing to blead> above.
 
-=head2 Merging from a branch via GitHub
-
-While we don't encourage the submission of patches via GitHub, that
-will still happen. Here is a guide to merging patches from a GitHub
-repository.
-
-  % git remote add avar git://github.com/avar/perl.git
-  % git fetch avar
-
-Now you can see the differences between the branch and blead:
-
-  % git diff avar/orange
-
-And you can see the commits:
-
-  % git log avar/orange
-
-If you approve of a specific commit, you can cherry pick it:
-
-  % git cherry-pick 0c24b290ae02b2ab3304f51d5e11e85eb3659eae
-
-Or you could just merge the whole branch if you like it all:
-
-  % git merge avar/orange
-
-And then push back to the repository:
-
-  % git push origin blead
-
 =head2 Using a smoke-me branch to test changes
 
 Sometimes a change affects code paths which you cannot test on the OSes
@@ -853,7 +824,7 @@ Fortunately, there is a way to get your change smoke-tested on various
 OSes: push it to a "smoke-me" branch and wait for certain automated
 smoke-testers to report the results from their OSes.
 A "smoke-me" branch is identified by the branch name: specifically, as
-seen on perl5.git.perl.org it must be a local branch whose first name
+seen on github.com it must be a local branch whose first name
 component is precisely C<smoke-me>.
 
 The procedure for doing this is roughly as follows (using the example of

--- a/pod/perlgit.pod
+++ b/pod/perlgit.pod
@@ -220,7 +220,8 @@ git will open a text editor for you to compose the message
 interactively. This is useful when the changes are more complex than
 the sample given here, and, depending on the editor, to know that the
 first line of the commit message doesn't exceed the 50 character legal
-maximum.
+maximum. See L<perlhack/Commit message> for more information about what
+makes a good commit message.
 
 Once you've finished writing your commit message and exited your
 editor, git will write your change to disk and tell you something like
@@ -283,47 +284,6 @@ If you want to delete your temporary branch, you may do so with:
  If you are sure you want to delete it, run 'git branch -D orange'.
  % git branch -D orange
  Deleted branch orange.
-
-=head2 Committing your changes
-
-Assuming that you'd like to commit all the changes you've made as a
-single atomic unit, run this command:
-
-  % git commit -a
-
-(That C<-a> tells git to add every file you've changed to this commit.
-New files aren't automatically added to your commit when you use
-C<commit -a> If you want to add files or to commit some, but not all of
-your changes, have a look at the documentation for C<git add>.)
-
-Git will start up your favorite text editor, so that you can craft a
-commit message for your change. See L<perlhack/Commit message> for more
-information about what makes a good commit message.
-
-Once you've finished writing your commit message and exited your
-editor, git will write your change to disk and tell you something like
-this:
-
- Created commit daf8e63: explain git status and stuff about remotes
-  1 files changed, 83 insertions(+), 3 deletions(-)
-
-If you re-run C<git status>, you should see something like this:
-
- % git status
- On branch blead
- Your branch is ahead of 'origin/blead' by 2 commits.
-   (use "git push" to publish your local commits)
- Untracked files:
-   (use "git add <file>..." to include in what will be committed)
-
-       deliberate.untracked
-
- nothing added to commit but untracked files present (use "git add" to
-                                                                  track)
-
-When in doubt, before you do anything else, check your status and read
-it carefully, many questions are answered directly by the git status
-output.
 
 =head2 Sending patch emails
 

--- a/pod/perlgit.pod
+++ b/pod/perlgit.pod
@@ -888,26 +888,3 @@ Finally, you should then delete the remote smoke-me branch:
 ) and then delete your local branch:
 
   % git branch -d win32stat
-
-=head2 A note on camel and dromedary
-
-The committers have SSH access to the two servers that serve
-C<perl5.git.perl.org>. One is C<perl5.git.perl.org> itself (I<camel>),
-which is the 'master' repository. The second one is
-C<users.perl5.git.perl.org> (I<dromedary>), which can be used for
-general testing and development. Dromedary syncs the git tree from
-camel every few minutes, you should not push there. Both machines also
-have a full CPAN mirror in F</srv/CPAN>, please use this. To share files
-with the general public, dromedary serves your F<~/public_html/> as
-C<L<https://users.perl5.git.perl.org/~yourlogin/>>
-
-These hosts have fairly strict firewalls to the outside. Outgoing, only
-rsync, ssh and git are allowed. For http and ftp, you can use
-L<http://webproxy:3128> as proxy. Incoming, the firewall tries to detect
-attacks and blocks IP addresses with suspicious activity. This
-sometimes (but very rarely) has false positives and you might get
-blocked. The quickest way to get unblocked is to notify the admins.
-
-These two boxes are owned, hosted, and operated by booking.com. You can
-reach the sysadmins in #p5p on irc.perl.org or via mail to
-L<perl5-porters@perl.org|mailto:perl5-porters@perl.org>.

--- a/pod/perlhack.pod
+++ b/pod/perlhack.pod
@@ -27,7 +27,7 @@ for a bug, comment fixes, etc., it's easy! Here's how:
 The perl source is in a git repository.  You can clone the repository
 with the following command:
 
-  % git clone git://perl5.git.perl.org/perl.git perl
+  % git clone https://github.com/Perl/perl5.git perl
 
 =item * Ensure you're following the latest advice
 
@@ -157,7 +157,7 @@ Perl core.
 =head1 GETTING THE PERL SOURCE
 
 All of Perl's source code is kept centrally in a Git repository at
-I<perl5.git.perl.org>.  The repository contains many Perl revisions
+I<github.com>.  The repository contains many Perl revisions
 from Perl 1 onwards and all the revisions from Perforce, the previous
 version control system.
 
@@ -169,23 +169,22 @@ L<perlgit>.
 You will need a copy of Git for your computer.  You can fetch a copy of
 the repository using the git protocol:
 
-  % git clone git://perl5.git.perl.org/perl.git perl
+  % git clone git://github.com/Perl/perl5.git perl
 
 This clones the repository and makes a local copy in the F<perl>
 directory.
 
 If you cannot use the git protocol for firewall reasons, you can also
-clone via http, though this is much slower:
+clone via http:
 
-  % git clone https://perl5.git.perl.org/perl.git perl
+  % git clone https://github.com/Perl/perl5.git perl
 
 =head2 Read access via the web
 
 You may access the repository over the web.  This allows you to browse
-the tree, see recent commits, subscribe to RSS feeds for the changes,
+the tree, see recent commits, subscribe to repository notifications,
 search for particular commits and more.  You may access it at
-L<https://perl5.git.perl.org/perl.git>.  A mirror of the repository is
-found at L<https://github.com/Perl/perl5>.
+L<https://github.com/Perl/perl5>.
 
 =head2 Read access via rsync
 

--- a/pod/perlsource.pod
+++ b/pod/perlsource.pod
@@ -214,7 +214,7 @@ platform-specific Configure-like scripts, as well as F<Configure>
 itself.
 
 The metaconfig system has its own git repository. Please see its README
-file in L<https://perl5.git.perl.org/metaconfig.git/> for more details.
+file in L<https://github.com/Perl/metaconfig> for more details.
 
 The F<Cross> directory contains various files related to
 cross-compiling Perl. See F<Cross/README> for more details.

--- a/pod/perltodo.pod
+++ b/pod/perltodo.pod
@@ -5,7 +5,7 @@ perltodo - Link to the Perl to-do list
 =head1 DESCRIPTION
 
 The Perl 5 to-do list is maintained in the git repository, and can
-be viewed at L<https://perl5.git.perl.org/perl.git/blob/HEAD:/Porting/todo.pod>
+be viewed at L<https://github.com/Perl/perl5/blob/blead/Porting/todo.pod>.
 
 (The to-do list used to be here in perltodo. That has stopped, as installing a
 snapshot that becomes increasingly out of date isn't that useful to anyone.)


### PR DESCRIPTION
These changes are primarily to POD and comments.

The "Merging from a branch via GitHub" section is removed because it's not really relevant when GitHub is the standard repository.

I'm not sure what to do with the "A note on camel and dromedary" section in perlgit or the "Read access via rsync" section in perlhack.

References to cloning via HTTP being "slower" were removed as I see no evidence of this with the GitHub repository.

Additional updates are needed to reference the GitHub pull request workflow, I may work on this in a future patch.

Updating documentation to reference using GitHub to submit bug reports (other than the metadata entry) is not part of this patch and will be a significant undertaking that needs to start with the perlbug utility.