### PR TITLE
Add feature "noindirect" that disables indirect method calls

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5616,6 +5616,7 @@ t/lib/Devel/switchd_goto.pm	Module for t/run/switchd.t
 t/lib/feature/bits		Tests for feature bit handling
 t/lib/feature/bundle		Tests for feature bundles
 t/lib/feature/implicit		Tests for implicit loading of feature.pm
+t/lib/feature/noindirect	Tests for enabling/disabling indirect method calls
 t/lib/feature/nonesuch		Tests for enabling/disabling nonexistent feature
 t/lib/feature/removed		Tests for enabling/disabling removed feature
 t/lib/feature/say		Tests for enabling/disabling say feature

--- a/feature.h
+++ b/feature.h
@@ -18,14 +18,15 @@
 #define FEATURE_EVALBYTES_BIT       0x0008
 #define FEATURE_FC_BIT              0x0010
 #define FEATURE_ISA_BIT             0x0020
-#define FEATURE_POSTDEREF_QQ_BIT    0x0040
-#define FEATURE_REFALIASING_BIT     0x0080
-#define FEATURE_SAY_BIT             0x0100
-#define FEATURE_SIGNATURES_BIT      0x0200
-#define FEATURE_STATE_BIT           0x0400
-#define FEATURE_SWITCH_BIT          0x0800
-#define FEATURE_UNIEVAL_BIT         0x1000
-#define FEATURE_UNICODE_BIT         0x2000
+#define FEATURE_NOINDIRECT_BIT      0x0040
+#define FEATURE_POSTDEREF_QQ_BIT    0x0080
+#define FEATURE_REFALIASING_BIT     0x0100
+#define FEATURE_SAY_BIT             0x0200
+#define FEATURE_SIGNATURES_BIT      0x0400
+#define FEATURE_STATE_BIT           0x0800
+#define FEATURE_SWITCH_BIT          0x1000
+#define FEATURE_UNIEVAL_BIT         0x2000
+#define FEATURE_UNICODE_BIT         0x4000
 
 #define FEATURE_BUNDLE_DEFAULT	0
 #define FEATURE_BUNDLE_510	1
@@ -98,6 +99,12 @@
 	 CURRENT_FEATURE_BUNDLE <= FEATURE_BUNDLE_527) \
      || (CURRENT_FEATURE_BUNDLE == FEATURE_BUNDLE_CUSTOM && \
 	 FEATURE_IS_ENABLED_MASK(FEATURE_EVALBYTES_BIT)) \
+    )
+
+#define FEATURE_NOINDIRECT_IS_ENABLED \
+    ( \
+	CURRENT_FEATURE_BUNDLE == FEATURE_BUNDLE_CUSTOM && \
+	 FEATURE_IS_ENABLED_MASK(FEATURE_NOINDIRECT_BIT) \
     )
 
 #define FEATURE_SIGNATURES_IS_ENABLED \
@@ -255,6 +262,14 @@ S_magic_sethint_feature(pTHX_ SV *keysv, const char *keypv, STRLEN keylen,
             if (keylen == sizeof("feature_myref")-1
                  && memcmp(subf+1, "yref", keylen - sizeof("feature_")) == 0) {
                 mask = FEATURE_MYREF_BIT;
+                break;
+            }
+            return;
+
+        case 'n':
+            if (keylen == sizeof("feature_noindirect")-1
+                 && memcmp(subf+1, "oindirect", keylen - sizeof("feature_")) == 0) {
+                mask = FEATURE_NOINDIRECT_BIT;
                 break;
             }
             return;

--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -5,7 +5,7 @@
 
 package feature;
 
-our $VERSION = '1.57';
+our $VERSION = '1.58';
 
 our %feature = (
     fc              => 'feature_fc',
@@ -15,6 +15,7 @@ our %feature = (
     switch          => 'feature_switch',
     bitwise         => 'feature_bitwise',
     evalbytes       => 'feature_evalbytes',
+    noindirect      => 'feature_noindirect',
     signatures      => 'feature_signatures',
     current_sub     => 'feature___SUB__',
     refaliasing     => 'feature_refaliasing',
@@ -30,7 +31,7 @@ our %feature_bundle = (
     "5.15"    => [qw(current_sub evalbytes fc say state switch unicode_eval unicode_strings)],
     "5.23"    => [qw(current_sub evalbytes fc postderef_qq say state switch unicode_eval unicode_strings)],
     "5.27"    => [qw(bitwise current_sub evalbytes fc postderef_qq say state switch unicode_eval unicode_strings)],
-    "all"     => [qw(bitwise current_sub declared_refs evalbytes fc isa postderef_qq refaliasing say signatures state switch unicode_eval unicode_strings)],
+    "all"     => [qw(bitwise current_sub declared_refs evalbytes fc isa noindirect postderef_qq refaliasing say signatures state switch unicode_eval unicode_strings)],
     "default" => [qw()],
 );
 
@@ -356,6 +357,20 @@ This feature is available from Perl 5.26 onwards.
 This allows the use of the C<isa> infix operator, which tests whether the
 scalar given by the left operand is an object of the class given by the
 right operand. See L<perlop/Class Instance Operator> for more details.
+
+This feature is available from Perl 5.32 onwards.
+
+=head2 The 'noindirect' feature
+
+This feature removes the indirect notation for method invocation, so
+that bareword sequences like:
+
+  new Foo;
+
+will only be accepted if a function new() is defined.
+
+Perl operators that have a similar syntax such as C<print> and C<exec>
+continue to work.
 
 This feature is available from Perl 5.32 onwards.
 

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -36,6 +36,7 @@ my %feature = (
     fc              => 'fc',
     signatures      => 'signatures',
     isa             => 'isa',
+    noindirect      => 'noindirect',
 );
 
 # NOTE: If a feature is ever enabled in a non-contiguous range of Perl
@@ -468,7 +469,7 @@ read_only_bottom_close_and_rename($h);
 __END__
 package feature;
 
-our $VERSION = '1.57';
+our $VERSION = '1.58';
 
 FEATURES
 
@@ -758,6 +759,20 @@ This feature is available from Perl 5.26 onwards.
 This allows the use of the C<isa> infix operator, which tests whether the
 scalar given by the left operand is an object of the class given by the
 right operand. See L<perlop/Class Instance Operator> for more details.
+
+This feature is available from Perl 5.32 onwards.
+
+=head2 The 'noindirect' feature
+
+This feature removes the indirect notation for method invocation, so
+that bareword sequences like:
+
+  new Foo;
+
+will only be accepted if a function new() is defined.
+
+Perl operators that have a similar syntax such as C<print> and C<exec>
+continue to work.
 
 This feature is available from Perl 5.32 onwards.
 

--- a/t/lib/feature/noindirect
+++ b/t/lib/feature/noindirect
@@ -1,0 +1,29 @@
+Test noindirect feature
+
+__END__
+# NAME feature noindirect
+use feature 'say';
+package Foo {
+  sub new { bless {}, shift }
+}
+# various indirect object look-alikes
+my $foox = "foox";
+print STDERR "Hello\n";
+printf STDERR "Test%s\n", "x";
+say STDERR "Hello";
+exec $foox "foo", "bar";
+system $foox "foo", "bar";
+my $x = new Foo;
+use feature "noindirect";
+print STDERR "Hello\n";
+printf STDERR "Test%s\n", "x";
+say STDERR "Hello";
+exec $foox "foo", "bar";
+system $foox "foo", "bar";
+my $y = new Foo;
+EXPECT
+OPTIONS fatal
+Bareword found where operator expected at - line 19, near "new Foo"
+	(Do you need to predeclare new?)
+syntax error at - line 19, near "new Foo"
+Execution of - aborted due to compilation errors.

--- a/toke.c
+++ b/toke.c
@@ -4408,8 +4408,9 @@ S_intuit_method(pTHX_ char *start, SV *ioname, CV *cv)
 	indirgv = gv_fetchpvn_flags(tmpbuf, len,
 				    GV_NOADD_NOINIT|( UTF ? SVf_UTF8 : 0 ),
 				    SVt_PVCV);
-	if (indirgv && SvTYPE(indirgv) != SVt_NULL
-	 && (!isGV(indirgv) || GvCVu(indirgv)))
+        if ((indirgv && SvTYPE(indirgv) != SVt_NULL
+             && (!isGV(indirgv) || GvCVu(indirgv)))
+            || FEATURE_NOINDIRECT_IS_ENABLED)
 	    return 0;
 	/* filehandle or package name makes it a method */
 	if (!cv || GvIO(indirgv) || gv_stashpvn(tmpbuf, len, UTF ? SVf_UTF8 : 0)) {


### PR DESCRIPTION
A first go at optionally disabling indirect notation in core