### PR TITLE
Smaller toke

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -6596,9 +6596,12 @@ yyl_try(pTHX_ char initial_state, char *s, STRLEN len,
                           UTF8fARG(UTF, (s - d), d),
                          (int) len + 1);
     }
+
     case 4:
     case 26:
+        fake_eof = LEX_FAKE_EOF;
 	goto fake_eof;			/* emulate EOF on ^D or ^Z */
+
     case 0:
 	if ((!PL_rsfp || PL_lex_inwhat)
 	 && (!PL_parser->filtered || s+1 < PL_bufend)) {
@@ -6701,10 +6704,7 @@ yyl_try(pTHX_ char initial_state, char *s, STRLEN len,
 	do {
 	    fake_eof = 0;
 	    bof = cBOOL(PL_rsfp);
-	    if (0) {
-	      fake_eof:
-		fake_eof = LEX_FAKE_EOF;
-	    }
+          fake_eof:
 	    PL_bufptr = PL_bufend;
 	    COPLINE_INC_WITH_HERELINES;
 	    if (!lex_next_chunk(fake_eof)) {
@@ -7890,6 +7890,7 @@ yyl_try(pTHX_ char initial_state, char *s, STRLEN len,
 #endif
 		PL_rsfp = NULL;
 	    }
+            fake_eof = LEX_FAKE_EOF;
 	    goto fake_eof;
 	}
 

--- a/toke.c
+++ b/toke.c
@@ -6511,6 +6511,25 @@ yyl_dblquote(pTHX_ char *s, STRLEN len)
     TERM(sublex_start());
 }
 
+static int
+yyl_backtick(pTHX_ char *s)
+{
+    s = scan_str(s,FALSE,FALSE,FALSE,NULL);
+    DEBUG_T( {
+        if (s)
+            printbuf("### Saw backtick string before %s\n", s);
+        else
+            PerlIO_printf(Perl_debug_log,
+                         "### Saw unterminated backtick string\n");
+    } );
+    if (PL_expect == XOPERATOR)
+        no_op("Backticks",s);
+    if (!s)
+        missingterm(NULL, 0);
+    pl_yylval.ival = OP_BACKTICK;
+    TERM(sublex_start());
+}
+
 /*
   yylex
 
@@ -7531,20 +7550,7 @@ Perl_yylex(pTHX)
         return yyl_dblquote(aTHX_ s, len);
 
     case '`':
-	s = scan_str(s,FALSE,FALSE,FALSE,NULL);
-	DEBUG_T( {
-            if (s)
-                printbuf("### Saw backtick string before %s\n", s);
-            else
-		PerlIO_printf(Perl_debug_log,
-			     "### Saw unterminated backtick string\n");
-        } );
-	if (PL_expect == XOPERATOR)
-	    no_op("Backticks",s);
-	if (!s)
-	    missingterm(NULL, 0);
-	pl_yylval.ival = OP_BACKTICK;
-	TERM(sublex_start());
+        return yyl_backtick(aTHX_ s);
 
     case '\\':
 	s++;

--- a/toke.c
+++ b/toke.c
@@ -5616,6 +5616,23 @@ yyl_percent(pTHX_ char *s)
 }
 
 static int
+yyl_caret(pTHX_ char *s)
+{
+    char *d = s;
+    const bool bof = cBOOL(FEATURE_BITWISE_IS_ENABLED);
+    if (bof && s[1] == '.')
+        s++;
+    if (!PL_lex_allbrackets && PL_lex_fakeeof >=
+            (s[1] == '=' ? LEX_FAKEEOF_ASSIGN : LEX_FAKEEOF_BITWISE))
+    {
+        s = d;
+        TOKEN(0);
+    }
+    s++;
+    BOop(bof ? d == s-2 ? OP_SBIT_XOR : OP_NBIT_XOR : OP_BIT_XOR);
+}
+
+static int
 yyl_subproto(pTHX_ char *s, CV *cv)
 {
     STRLEN protolen = CvPROTOLEN(cv);
@@ -6443,18 +6460,8 @@ Perl_yylex(pTHX)
         return yyl_percent(aTHX_ s);
 
     case '^':
-	d = s;
-	bof = FEATURE_BITWISE_IS_ENABLED;
-	if (bof && s[1] == '.')
-	    s++;
-	if (!PL_lex_allbrackets && PL_lex_fakeeof >=
-		(s[1] == '=' ? LEX_FAKEEOF_ASSIGN : LEX_FAKEEOF_BITWISE))
-	{
-	    s = d;
-	    TOKEN(0);
-	}
-	s++;
-	BOop(bof ? d == s-2 ? OP_SBIT_XOR : OP_NBIT_XOR : OP_BIT_XOR);
+        return yyl_caret(aTHX_ s);
+
     case '[':
 	if (PL_lex_brackets > 100)
 	    Renew(PL_lex_brackstack, PL_lex_brackets + 10, char);

--- a/toke.c
+++ b/toke.c
@@ -5516,6 +5516,34 @@ yyl_hyphen(pTHX_ char *s)
 }
 
 static int
+yyl_plus(pTHX_ char *s)
+{
+    const char tmp = *s++;
+    if (*s == tmp) {
+        s++;
+        if (PL_expect == XOPERATOR)
+            TERM(POSTINC);
+        else
+            OPERATOR(PREINC);
+    }
+    if (PL_expect == XOPERATOR) {
+        if (*s == '='
+            && !PL_lex_allbrackets
+            && PL_lex_fakeeof >= LEX_FAKEEOF_ASSIGN)
+        {
+            s--;
+            TOKEN(0);
+        }
+        Aop(OP_ADD);
+    }
+    else {
+        if (isSPACE(*s) || !isSPACE(*PL_bufptr))
+            check_uni();
+        OPERATOR('+');
+    }
+}
+
+static int
 yyl_subproto(pTHX_ char *s, CV *cv)
 {
     STRLEN protolen = CvPROTOLEN(cv);
@@ -6334,31 +6362,7 @@ Perl_yylex(pTHX)
         return yyl_hyphen(aTHX_ s);
 
     case '+':
-	{
-	    const char tmp = *s++;
-	    if (*s == tmp) {
-		s++;
-		if (PL_expect == XOPERATOR)
-		    TERM(POSTINC);
-		else
-		    OPERATOR(PREINC);
-	    }
-	    if (PL_expect == XOPERATOR) {
-		if (*s == '='
-                    && !PL_lex_allbrackets
-                    && PL_lex_fakeeof >= LEX_FAKEEOF_ASSIGN)
-                {
-		    s--;
-		    TOKEN(0);
-		}
-		Aop(OP_ADD);
-	    }
-	    else {
-		if (isSPACE(*s) || !isSPACE(*PL_bufptr))
-		    check_uni();
-		OPERATOR('+');
-	    }
-	}
+        return yyl_plus(aTHX_ s);
 
     case '*':
 	if (PL_expect == XPOSTDEREF) POSTDEREF('*');

--- a/toke.c
+++ b/toke.c
@@ -6316,6 +6316,29 @@ yyl_leftsquare(pTHX_ char *s)
 }
 
 static int
+yyl_rightsquare(pTHX_ char *s)
+{
+    if (PL_lex_brackets && PL_lex_brackstack[PL_lex_brackets-1] == XFAKEEOF)
+        TOKEN(0);
+    s++;
+    if (PL_lex_brackets <= 0)
+        /* diag_listed_as: Unmatched right %s bracket */
+        yyerror("Unmatched right square bracket");
+    else
+        --PL_lex_brackets;
+    PL_lex_allbrackets--;
+    if (PL_lex_state == LEX_INTERPNORMAL) {
+        if (PL_lex_brackets == 0) {
+            if (*s == '-' && s[1] == '>')
+                PL_lex_state = LEX_INTERPENDMAYBE;
+            else if (*s != '[' && *s != '{')
+                PL_lex_state = LEX_INTERPEND;
+        }
+    }
+    TERM(']');
+}
+
+static int
 yyl_tilde(pTHX_ char *s)
 {
     bool bof;
@@ -7154,25 +7177,10 @@ Perl_yylex(pTHX)
 	if (*s == '{')
 	    PREBLOCK(')');
 	TERM(')');
+
     case ']':
-	if (PL_lex_brackets && PL_lex_brackstack[PL_lex_brackets-1] == XFAKEEOF)
-	    TOKEN(0);
-	s++;
-	if (PL_lex_brackets <= 0)
-	    /* diag_listed_as: Unmatched right %s bracket */
-	    yyerror("Unmatched right square bracket");
-	else
-	    --PL_lex_brackets;
-	PL_lex_allbrackets--;
-	if (PL_lex_state == LEX_INTERPNORMAL) {
-	    if (PL_lex_brackets == 0) {
-		if (*s == '-' && s[1] == '>')
-		    PL_lex_state = LEX_INTERPENDMAYBE;
-		else if (*s != '[' && *s != '{')
-		    PL_lex_state = LEX_INTERPEND;
-	    }
-	}
-	TERM(']');
+        return yyl_rightsquare(aTHX_ s);
+
     case '{':
 	s++;
       leftbracket:

--- a/toke.c
+++ b/toke.c
@@ -5885,14 +5885,9 @@ Perl_yylex(pTHX)
   retry:
     switch (*s) {
     default:
-	if (UTF) {
-            if (isIDFIRST_utf8_safe(s, PL_bufend)) {
-                goto keylookup;
-            }
+        if (UTF ? isIDFIRST_utf8_safe(s, PL_bufend) : isALNUMC(*s)) {
+            goto keylookup;
         }
-        else if (isALNUMC(*s)) {
-	    goto keylookup;
-	}
     {
         SV *dsv = newSVpvs_flags("", SVs_TEMP);
         const char *c;

--- a/toke.c
+++ b/toke.c
@@ -5052,8 +5052,9 @@ Perl_yylex(pTHX)
 	    return yylex();
 	}
 	else {
-	    DEBUG_T({ PerlIO_printf(Perl_debug_log,
-              "### Saw case modifier\n"); });
+	    DEBUG_T({
+                PerlIO_printf(Perl_debug_log, "### Saw case modifier\n");
+            });
 	    s = PL_bufptr + 1;
 	    if (s[1] == '\\' && s[2] == 'E') {
 	        PL_bufptr = s + 3;
@@ -5117,8 +5118,10 @@ Perl_yylex(pTHX)
     case LEX_INTERPSTART:
 	if (PL_bufptr == PL_bufend)
 	    return REPORT(sublex_done());
-	DEBUG_T({ if(*PL_bufptr != '(') PerlIO_printf(Perl_debug_log,
-              "### Interpolated variable\n"); });
+	DEBUG_T({
+            if(*PL_bufptr != '(')
+                PerlIO_printf(Perl_debug_log, "### Interpolated variable\n");
+        });
 	PL_expect = XTERM;
         /* for /@a/, we leave the joining for the regex engine to do
          * (unless we're within \Q etc) */
@@ -5353,9 +5356,9 @@ Perl_yylex(pTHX)
 			 ? "Format not terminated"
 			 : "Missing right curly or square bracket"));
 	    }
-            DEBUG_T( { PerlIO_printf(Perl_debug_log,
-                        "### Tokener got EOF\n");
-            } );
+            DEBUG_T({
+                PerlIO_printf(Perl_debug_log, "### Tokener got EOF\n");
+            });
 	    TOKEN(0);
 	}
 	if (s++ < PL_bufend)
@@ -5801,15 +5804,16 @@ Perl_yylex(pTHX)
 	    if (ftst) {
                 PL_last_uni = PL_oldbufptr;
 		PL_last_lop_op = (OPCODE)ftst;
-		DEBUG_T( { PerlIO_printf(Perl_debug_log,
-                        "### Saw file test %c\n", (int)tmp);
+		DEBUG_T( {
+                    PerlIO_printf(Perl_debug_log, "### Saw file test %c\n", (int)tmp);
 		} );
 		FTST(ftst);
 	    }
 	    else {
 		/* Assume it was a minus followed by a one-letter named
 		 * subroutine call (or a -bareword), then. */
-		DEBUG_T( { PerlIO_printf(Perl_debug_log,
+		DEBUG_T( {
+                    PerlIO_printf(Perl_debug_log,
 			"### '-%c' looked like a file test but was not\n",
 			(int) tmp);
 		} );

--- a/toke.c
+++ b/toke.c
@@ -6530,6 +6530,17 @@ yyl_backtick(pTHX_ char *s)
     TERM(sublex_start());
 }
 
+static int
+yyl_backslash(pTHX_ char *s)
+{
+    if (PL_lex_inwhat == OP_SUBST && PL_lex_repl == PL_linestr && isDIGIT(*s))
+        Perl_ck_warner(aTHX_ packWARN(WARN_SYNTAX),"Can't use \\%c to mean $%c in expression",
+                       *s, *s);
+    if (PL_expect == XOPERATOR)
+        no_op("Backslash",s);
+    OPERATOR(REFGEN);
+}
+
 /*
   yylex
 
@@ -7553,14 +7564,7 @@ Perl_yylex(pTHX)
         return yyl_backtick(aTHX_ s);
 
     case '\\':
-	s++;
-	if (PL_lex_inwhat == OP_SUBST && PL_lex_repl == PL_linestr
-	 && isDIGIT(*s))
-	    Perl_ck_warner(aTHX_ packWARN(WARN_SYNTAX),"Can't use \\%c to mean $%c in expression",
-			   *s, *s);
-	if (PL_expect == XOPERATOR)
-	    no_op("Backslash",s);
-	OPERATOR(REFGEN);
+        return yyl_backslash(aTHX_ s + 1);
 
     case 'v':
 	if (isDIGIT(s[1]) && PL_expect != XOPERATOR) {

--- a/toke.c
+++ b/toke.c
@@ -6302,6 +6302,19 @@ yyl_slash(pTHX_ char *s)
     }
 }
 
+static int
+yyl_leftsquare(pTHX_ char *s)
+{
+    char tmp;
+
+    if (PL_lex_brackets > 100)
+        Renew(PL_lex_brackstack, PL_lex_brackets + 10, char);
+    PL_lex_brackstack[PL_lex_brackets++] = 0;
+    PL_lex_allbrackets++;
+    tmp = *s++;
+    OPERATOR(tmp);
+}
+
 /*
   yylex
 
@@ -7078,14 +7091,8 @@ Perl_yylex(pTHX)
         return yyl_caret(aTHX_ s);
 
     case '[':
-	if (PL_lex_brackets > 100)
-	    Renew(PL_lex_brackstack, PL_lex_brackets + 10, char);
-	PL_lex_brackstack[PL_lex_brackets++] = 0;
-	PL_lex_allbrackets++;
-	{
-	    const char tmp = *s++;
-	    OPERATOR(tmp);
-	}
+        return yyl_leftsquare(aTHX_ s);
+
     case '~':
 	if (s[1] == '~'
 	    && (PL_expect == XOPERATOR || PL_expect == XTERMORDORDOR))

--- a/toke.c
+++ b/toke.c
@@ -6466,6 +6466,21 @@ yyl_rightpointy(pTHX_ char *s)
 }
 
 static int
+yyl_sglquote(pTHX_ char *s)
+{
+    s = scan_str(s,FALSE,FALSE,FALSE,NULL);
+    if (!s)
+        missingterm(NULL, 0);
+    COPLINE_SET_FROM_MULTI_END;
+    DEBUG_T( { printbuf("### Saw string before %s\n", s); } );
+    if (PL_expect == XOPERATOR) {
+        no_op("String",s);
+    }
+    pl_yylval.ival = OP_CONST;
+    TERM(sublex_start());
+}
+
+static int
 yyl_dblquote(pTHX_ char *s, STRLEN len)
 {
     char *d;
@@ -7510,16 +7525,7 @@ Perl_yylex(pTHX)
 	TERM(THING);
 
     case '\'':
-	s = scan_str(s,FALSE,FALSE,FALSE,NULL);
-	if (!s)
-	    missingterm(NULL, 0);
-	COPLINE_SET_FROM_MULTI_END;
-	DEBUG_T( { printbuf("### Saw string before %s\n", s); } );
-	if (PL_expect == XOPERATOR) {
-            no_op("String",s);
-	}
-	pl_yylval.ival = OP_CONST;
-	TERM(sublex_start());
+        return yyl_sglquote(aTHX_ s);
 
     case '"':
         return yyl_dblquote(aTHX_ s, len);

--- a/toke.c
+++ b/toke.c
@@ -7213,16 +7213,17 @@ Perl_yylex(pTHX)
         return yyl_verticalbar(aTHX_ s);
 
     case '=':
+        if (s[1] == '=' && (s == PL_linestart || s[-1] == '\n')
+            && memBEGINs(s + 2, (STRLEN) (PL_bufend - s + 2), "====="))
+        {
+            s = vcs_conflict_marker(s + 7);
+            goto retry;
+        }
+
 	s++;
 	{
 	    const char tmp = *s++;
 	    if (tmp == '=') {
-                if (   (s == PL_linestart+2 || s[-3] == '\n')
-                    && memBEGINs(s, (STRLEN) (PL_bufend - s), "====="))
-                {
-	            s = vcs_conflict_marker(s + 5);
-	            goto retry;
-	        }
 		if (!PL_lex_allbrackets
                     && PL_lex_fakeeof >= LEX_FAKEEOF_COMPARE)
                 {
@@ -7307,18 +7308,18 @@ Perl_yylex(pTHX)
         return yyl_bang(aTHX_ s + 1);
 
     case '<':
+        if (s[1] == '<' && (s == PL_linestart || s[-1] == '\n')
+            && memBEGINs(s+2, (STRLEN) (PL_bufend - (s+2)), "<<<<<"))
+        {
+            s = vcs_conflict_marker(s + 7);
+            goto retry;
+        }
+
 	if (PL_expect != XOPERATOR) {
 	    if (s[1] != '<' && !memchr(s,'>', PL_bufend - s))
 		check_uni();
-	    if (s[1] == '<' && s[2] != '>') {
-                if (   (s == PL_linestart || s[-1] == '\n')
-                    && memBEGINs(s+2, (STRLEN) (PL_bufend - (s+2)), "<<<<<"))
-                {
-	            s = vcs_conflict_marker(s + 7);
-	            goto retry;
-	        }
+	    if (s[1] == '<' && s[2] != '>')
 		s = scan_heredoc(s);
-	    }
 	    else
 		s = scan_inputsymbol(s);
 	    PL_expect = XOPERATOR;
@@ -7328,12 +7329,6 @@ Perl_yylex(pTHX)
 	{
 	    char tmp = *s++;
 	    if (tmp == '<') {
-                if (   (s == PL_linestart+2 || s[-3] == '\n')
-                    && memBEGINs(s, (STRLEN) (PL_bufend - s), "<<<<<"))
-                {
-                    s = vcs_conflict_marker(s + 5);
-	            goto retry;
-	        }
 		if (*s == '=' && !PL_lex_allbrackets
                     && PL_lex_fakeeof >= LEX_FAKEEOF_ASSIGN)
                 {
@@ -7369,17 +7364,19 @@ Perl_yylex(pTHX)
 	    TOKEN(0);
 	}
 	Rop(OP_LT);
+
     case '>':
+        if (s[1] == '>' && (s == PL_linestart || s[-1] == '\n')
+            && memBEGINs(s + 2, (STRLEN) (PL_bufend - s + 2), ">>>>>"))
+        {
+            s = vcs_conflict_marker(s + 7);
+            goto retry;
+        }
+
 	s++;
 	{
 	    const char tmp = *s++;
 	    if (tmp == '>') {
-	        if (   (s == PL_linestart+2 || s[-3] == '\n')
-                    && memBEGINs(s, (STRLEN) (PL_bufend - s), ">>>>>"))
-                {
-	            s = vcs_conflict_marker(s + 5);
-	            goto retry;
-	        }
 		if (*s == '=' && !PL_lex_allbrackets
                     && PL_lex_fakeeof >= LEX_FAKEEOF_ASSIGN)
                 {

--- a/toke.c
+++ b/toke.c
@@ -6913,7 +6913,6 @@ Perl_yylex(pTHX)
 	    PREREF('$');
 	}
 
-	d = s;
 	{
 	    const char tmp = *s;
 	    if (PL_lex_state == LEX_NORMAL || PL_lex_brackets)

--- a/toke.c
+++ b/toke.c
@@ -4936,6 +4936,12 @@ yyl_sigvar(pTHX_ char *s)
 		  - cases for built-in keywords
 */
 
+#ifdef NETWARE
+#define RSFP_FILENO (PL_rsfp)
+#else
+#define RSFP_FILENO (PerlIO_fileno(PL_rsfp))
+#endif
+
 
 int
 Perl_yylex(pTHX)
@@ -7794,11 +7800,7 @@ Perl_yylex(pTHX)
 			loc = PerlIO_tell(PL_rsfp);
 			(void)PerlIO_seek(PL_rsfp, 0L, 0);
 		    }
-#ifdef NETWARE
-			if (PerlLIO_setmode(PL_rsfp, O_TEXT) != -1) {
-#else
-		    if (PerlLIO_setmode(PerlIO_fileno(PL_rsfp), O_TEXT) != -1) {
-#endif	/* NETWARE */
+                    if (PerlLIO_setmode(RSFP_FILENO, O_TEXT) != -1) {
 			if (loc > 0)
 			    PerlIO_seek(PL_rsfp, loc, 0);
 		    }

--- a/toke.c
+++ b/toke.c
@@ -6371,6 +6371,19 @@ yyl_leftparen(pTHX_ char *s)
     TOKEN('(');
 }
 
+static int
+yyl_rightparen(pTHX_ char *s)
+{
+    if (!PL_lex_allbrackets && PL_lex_fakeeof >= LEX_FAKEEOF_CLOSING)
+        TOKEN(0);
+    s++;
+    PL_lex_allbrackets--;
+    s = skipspace(s);
+    if (*s == '{')
+        PREBLOCK(')');
+    TERM(')');
+}
+
 /*
   yylex
 
@@ -7174,15 +7187,9 @@ Perl_yylex(pTHX)
 	s++;
 	PL_expect = XSTATE;
 	TOKEN(';');
+
     case ')':
-	if (!PL_lex_allbrackets && PL_lex_fakeeof >= LEX_FAKEEOF_CLOSING)
-	    TOKEN(0);
-	s++;
-	PL_lex_allbrackets--;
-	s = skipspace(s);
-	if (*s == '{')
-	    PREBLOCK(')');
-	TERM(')');
+        return yyl_rightparen(aTHX_ s);
 
     case ']':
         return yyl_rightsquare(aTHX_ s);

--- a/toke.c
+++ b/toke.c
@@ -6436,6 +6436,35 @@ yyl_leftpointy(pTHX_ char *s)
     Rop(OP_LT);
 }
 
+static int
+yyl_rightpointy(pTHX_ char *s)
+{
+    const char tmp = *s++;
+
+    if (tmp == '>') {
+        if (*s == '=' && !PL_lex_allbrackets && PL_lex_fakeeof >= LEX_FAKEEOF_ASSIGN) {
+            s -= 2;
+            TOKEN(0);
+        }
+        SHop(OP_RIGHT_SHIFT);
+    }
+    else if (tmp == '=') {
+        if (!PL_lex_allbrackets && PL_lex_fakeeof >= LEX_FAKEEOF_COMPARE) {
+            s -= 2;
+            TOKEN(0);
+        }
+        Rop(OP_GE);
+    }
+
+    s--;
+    if (!PL_lex_allbrackets && PL_lex_fakeeof >= LEX_FAKEEOF_COMPARE) {
+        s--;
+        TOKEN(0);
+    }
+
+    Rop(OP_GT);
+}
+
 /*
   yylex
 
@@ -7375,35 +7404,7 @@ Perl_yylex(pTHX)
             s = vcs_conflict_marker(s + 7);
             goto retry;
         }
-
-	s++;
-	{
-	    const char tmp = *s++;
-	    if (tmp == '>') {
-		if (*s == '=' && !PL_lex_allbrackets
-                    && PL_lex_fakeeof >= LEX_FAKEEOF_ASSIGN)
-                {
-		    s -= 2;
-		    TOKEN(0);
-		}
-		SHop(OP_RIGHT_SHIFT);
-	    }
-	    else if (tmp == '=') {
-		if (!PL_lex_allbrackets
-                    && PL_lex_fakeeof >= LEX_FAKEEOF_COMPARE)
-                {
-		    s -= 2;
-		    TOKEN(0);
-		}
-		Rop(OP_GE);
-	    }
-	}
-	s--;
-	if (!PL_lex_allbrackets && PL_lex_fakeeof >= LEX_FAKEEOF_COMPARE) {
-	    s--;
-	    TOKEN(0);
-	}
-	Rop(OP_GT);
+        return yyl_rightpointy(aTHX_ s + 1);
 
     case '$':
         return yyl_dollar(aTHX_ s);

--- a/toke.c
+++ b/toke.c
@@ -6359,6 +6359,18 @@ yyl_tilde(pTHX_ char *s)
     BCop(bof ? OP_NCOMPLEMENT : OP_COMPLEMENT);
 }
 
+static int
+yyl_leftparen(pTHX_ char *s)
+{
+    if (PL_last_lop == PL_oldoldbufptr || PL_last_uni == PL_oldoldbufptr)
+        PL_oldbufptr = PL_oldoldbufptr;		/* allow print(STDOUT 123) */
+    else
+        PL_expect = XTERM;
+    s = skipspace(s);
+    PL_lex_allbrackets++;
+    TOKEN('(');
+}
+
 /*
   yylex
 
@@ -7153,14 +7165,8 @@ Perl_yylex(pTHX)
         return yyl_colon(aTHX_ s + 1);
 
     case '(':
-	s++;
-	if (PL_last_lop == PL_oldoldbufptr || PL_last_uni == PL_oldoldbufptr)
-	    PL_oldbufptr = PL_oldoldbufptr;		/* allow print(STDOUT 123) */
-	else
-	    PL_expect = XTERM;
-	s = skipspace(s);
-	PL_lex_allbrackets++;
-	TOKEN('(');
+        return yyl_leftparen(aTHX_ s + 1);
+
     case ';':
 	if (!PL_lex_allbrackets && PL_lex_fakeeof >= LEX_FAKEEOF_NONEXPR)
 	    TOKEN(0);


### PR DESCRIPTION
This branch factors lots of code out of `Perl_yylex()`, which started at 4166 lines. It's now split into multiple functions; the largest remaining one is 2159 lines. There's still plenty of work that could be done here, but I hope this makes it easier to understand the lexer without having to understand the whole thing simultaneously.