### PR TITLE
add git commit info into archive exports to allow building outside git

### DIFF
--- a/.git_patch
+++ b/.git_patch
@@ -1,0 +1,1 @@
+$Format:%H|%ci|%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_patch export-subst

--- a/Porting/manicheck
+++ b/Porting/manicheck
@@ -20,6 +20,8 @@ find {
         my $x = $File::Find::name; $x =~ s/^..//;
         return if -d;
         return if $_ eq '.gitignore';
+        return if $_ eq '.gitattributes';
+        return if $_ eq '.git_patch';
         return if $x =~ /^\.git\b/;
         return if $x =~ m{^\.github/};
         print "$x\t\tnot in MANIFEST\n" if !$files{$x};

--- a/t/porting/manifest.t
+++ b/t/porting/manifest.t
@@ -87,6 +87,8 @@ SKIP: {
     find_git_or_skip(6);
     my %seen; # De-dup ls-files output (can appear more than once)
     chomp(my @repo= grep {
+        !m{\.git_patch$} &&
+        !m{\.gitattributes$} &&
         !m{\.gitignore$} &&
         !m{^\.github/} &&
         !$seen{$_}++


### PR DESCRIPTION
Normally, builds require either a .patch file or to be built out of git
when not a proper release.  We can use git attributes to make a file
that will give partial information about the commit when an archive is
created.  This allows downloads from github to build.