### PR TITLE
Fix taint mode @INC documentation

### DIFF
--- a/pod/perlsec.pod
+++ b/pod/perlsec.pod
@@ -245,8 +245,8 @@ Unix-like environments that support #! and setuid or setgid scripts.)
 
 =head2 Taint mode and @INC
 
-When the taint mode (C<-T>) is in effect, the "." directory is removed
-from C<@INC>, and the environment variables C<PERL5LIB> and C<PERLLIB>
+When the taint mode (C<-T>) is in effect, the environment variables
+C<PERL5LIB> and C<PERLLIB>
 are ignored by Perl.  You can still adjust C<@INC> from outside the
 program by using the C<-I> command line option as explained in
 L<perlrun>.  The two environment variables are ignored because
@@ -267,6 +267,10 @@ Note that if a tainted string is added to C<@INC>, the following
 problem will be reported:
 
   Insecure dependency in require while running with -T switch
+
+On versions of Perl before 5.26, activating taint mode will also remove
+the current directory (".") from C<@INC>. Since version 5.26, the
+current directory isn't included in C<@INC>.
 
 =head2 Cleaning Up Your Path
 

--- a/pod/perlsec.pod
+++ b/pod/perlsec.pod
@@ -269,8 +269,9 @@ problem will be reported:
   Insecure dependency in require while running with -T switch
 
 On versions of Perl before 5.26, activating taint mode will also remove
-the current directory (".") from C<@INC>. Since version 5.26, the
-current directory isn't included in C<@INC>.
+the current directory (".") from the default value of C<@INC>. Since
+version 5.26, the current directory isn't included in C<@INC> by
+default.
 
 =head2 Cleaning Up Your Path
 


### PR DESCRIPTION
Explain that -T no longer removes '.' from @INC because, since
5.26, '.' isn't in @INC to start with.