### PR TITLE
Move keywords from a regexp to a qw() list

### DIFF
--- a/t/op/coreamp.t
+++ b/t/op/coreamp.t
@@ -1158,20 +1158,20 @@ like $@, qr'^Undefined format "STDOUT" called',
    File::Spec::Functions::catfile(
       File::Spec::Functions::updir,'regen','keywords.pl'
    );
+  my %nottest_words = map { $_ => 1 } qw(
+    AUTOLOAD BEGIN CHECK CORE DESTROY END INIT UNITCHECK
+    __DATA__ __END__
+    and cmp default do dump else elsif eq eval for foreach format ge given goto
+    grep gt if last le local lt m map my ne next no or our package print printf
+    q qq qr qw qx redo require return s say sort state sub tr unless until use
+    when while x xor y
+  );
   open my $kh, $keywords_file
     or die "$0 cannot open $keywords_file: $!";
   while(<$kh>) {
     if (m?__END__?..${\0} and /^[-+](.*)/) {
       my $word = $1;
-      next if
-       $word =~ /^(?:s(?:tate|ort|ay|ub)?|d(?:ef
-                  ault|ump|o)|p(?:rintf?|ackag
-                  e)|e(?:ls(?:if|e)|val|q)|g(?:[et]|iven|oto
-                  |rep)|u(?:n(?:less|til)|se)|l(?:(?:as)?t|ocal|e)|re
-                  (?:quire|turn|do)|__(?:DATA|END)__|for(?:each|mat)?|(?:
-                  AUTOLOA|EN)D|n(?:e(?:xt)?|o)|C(?:HECK|ORE)|wh(?:ile|en)
-                  |(?:ou?|t)r|m(?:ap|y)?|UNITCHECK|q[qrwx]?|x(?:or)?|DEST
-                  ROY|BEGIN|INIT|and|cmp|if|y)\z/x;
+      next if $nottest_words{$word};
       $tests ++;
       ok   exists &{"my$word"}
         || (eval{&{"CORE::$word"}}, $@ =~ /cannot be called directly/),


### PR DESCRIPTION
The regexp was a) hard to read, b) hard to maintain, c) impossible to `grep` for.

It was also unnecessary; that was hardly a high-performance CPU-critical code path.

The new `qw()` list is much neater more maintainable and behaves nicely when `grep`ing for keyword names.