### PR TITLE
[PATCH] Improve warnings for undefined class in @isa

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -7741,6 +7741,18 @@ can be determined from the template alone.  This is not possible if
 it contains any of the codes @, /, U, u, w or a *-length.  Redesign
 the template.
 
+=item While trying to resolve method call %s->%s() can not locate package "%s" yet it is mentioned in @%s::ISA (perhaps you forgot to load "%s"?)
+
+(W syntax) It is possible that the @ISA contains a misspelled or never loaded
+package name, which can result in perl choosing an unexpected parent
+classes method to resolve the method call. If this is deliberate you
+can do something like
+
+  @Missing::Package::ISA = ();
+
+to silence the warnings, otherwise you should correct the package name, or
+ensure that the package is loaded prior to the method call.
+
 =item %s() with negative argument
 
 (S misc) Certain operations make no sense with negative arguments.

--- a/t/lib/warnings/gv
+++ b/t/lib/warnings/gv
@@ -16,7 +16,6 @@ __END__
 use warnings 'syntax' ;
 @ISA = qw(Fred); joe()
 EXPECT
-Can't locate package Fred for @main::ISA at - line 3.
 Undefined subroutine &main::joe called at - line 3.
 ########
 # gv.c
@@ -24,6 +23,86 @@ no warnings 'syntax' ;
 @ISA = qw(Fred); joe()
 EXPECT
 Undefined subroutine &main::joe called at - line 3.
+########
+# gv.c
+use warnings 'syntax' ;
+@ISA = qw(Fred); __PACKAGE__->joe()
+EXPECT
+While trying to resolve method call main->joe() can not locate package "Fred" yet it is mentioned in @main::ISA (perhaps you forgot to load "Fred"?) at - line 3.
+Can't locate object method "joe" via package "main" at - line 3.
+########
+# gv.c
+no warnings 'syntax' ;
+@ISA = qw(Fred); __PACKAGE__->joe()
+EXPECT
+Can't locate object method "joe" via package "main" at - line 3.
+########
+# gv.c
+use warnings 'syntax' ;
+{
+    package AA;    # this is a deliberate error
+#   package A;     # should be this
+    sub foo {
+       print STDERR "I'm in A's foo\n";
+    }
+}
+{
+   package B;
+   sub foo {
+       print STDERR "I'm in B's foo\n";
+   }
+}
+@C::ISA = qw(A B);
+$a = bless [], 'C';
+$a->foo();
+__END__
+EXPECT
+While trying to resolve method call C->foo() can not locate package "A" yet it is mentioned in @C::ISA (perhaps you forgot to load "A"?) at - line 18.
+I'm in B's foo
+########
+# gv.c
+no warnings 'syntax' ;
+{
+    package AA;    # this is a deliberate error
+#   package A;     # should be this
+    sub foo {
+       print STDERR "I'm in A's foo\n";
+    }
+}
+{
+   package B;
+   sub foo {
+       print STDERR "I'm in B's foo\n";
+   }
+}
+@C::ISA = qw(A B);
+$a = bless [], 'C';
+$a->foo();
+__END__
+EXPECT
+I'm in B's foo
+########
+# gv.c
+use warnings 'syntax' ;
+{
+#   package AA;    # this would be an error
+    package A;     # the right thing
+    sub foo {
+       print STDERR "I'm in A's foo\n";
+    }
+}
+{
+   package B;
+   sub foo {
+       print STDERR "I'm in B's foo\n";
+   }
+}
+@C::ISA = qw(A B);
+$a = bless [], 'C';
+$a->foo();
+__END__
+EXPECT
+I'm in A's foo
 ########
 # gv.c
 $a = ${^ENCODING};
@@ -38,7 +117,6 @@ use open qw( :utf8 :std );
 package Ｙ;
 @ISA = qw(Fred); joe()
 EXPECT
-Can't locate package Fred for @Ｙ::ISA at - line 6.
 Undefined subroutine &Ｙ::joe called at - line 6.
 ########
 # gv.c


### PR DESCRIPTION
And silence some silly examples.

From RT88754

Adapted to the current Perl by Max Maischein

Created from https://github.com/Perl/perl5/issues/11259