### PR TITLE
win32: separate $Config{ccflags} and $Config{optimize}

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -600,8 +600,9 @@ LIBFILES	= $(LIBC) -lmoldname -lkernel32 -luser32 -lgdi32 -lwinspool \
 	-luuid -lws2_32 -lmpr -lwinmm -lversion -lodbc32 -lodbccp32 -lcomctl32
 
 ifeq ($(CFG),Debug)
-OPTIMIZE	= -g -O2 -DDEBUGGING
+OPTIMIZE	= -g -O2
 LINK_DBG	= -g
+DEFINES		+= -DDEBUGGING
 else
 OPTIMIZE	= -s -O2
 LINK_DBG	= -s
@@ -681,6 +682,7 @@ INCLUDES	= -I.\include -I. -I..
 DEFINES		= -DWIN32 -D_CONSOLE -DNO_STRICT
 LOCDEFS		= -DPERLDLL -DPERL_CORE
 CXX_FLAG	= -TP -EHsc
+EXTRACFLAGS	= -nologo -GF -W3
 
 ifeq ($(CCTYPE),MSVC140)
 LIBC		= ucrt.lib
@@ -693,11 +695,14 @@ LIBC		= msvcrt.lib
 endif
 
 ifeq ($(CFG),Debug)
-OPTIMIZE	= -Od -MD -Zi -DDEBUGGING
+OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
+DEFINES		+= -DDEBUGGING
+EXTRACFLAGS	+= -MD
 else ifeq ($(CFG),DebugSymbols)
-OPTIMIZE	= -Od -MD -Zi
+OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
+EXTRACFLAGS	+= -MD
 else ifeq ($(CFG),DebugFull)
 ifeq ($(CCTYPE),MSVC140)
 LIBC		= ucrtd.lib
@@ -708,12 +713,15 @@ LIBC		= ucrtd.lib
 else
 LIBC		= msvcrtd.lib
 endif
-OPTIMIZE	= -Od -MDd -Zi -D_DEBUG -DDEBUGGING
+OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
+DEFINES		+= -D_DEBUG -DDEBUGGING
+EXTRACFLAGS	+= -MDd
+
 else
 # Enable Whole Program Optimizations (WPO) and Link Time Code Generation (LTCG).
 # -O1 yields smaller code, which turns out to be faster than -O2 on x86 and x64
-OPTIMIZE	= -O1 -MD -Zi -DNDEBUG -GL
+OPTIMIZE	= -O1 -Zi -GL
 # we enable debug symbols in release builds also
 LINK_DBG	= -debug -opt:ref,icf -ltcg
 # you may want to enable this if you want COFF symbols in the executables
@@ -723,6 +731,7 @@ LINK_DBG	= -debug -opt:ref,icf -ltcg
 # avoid the bloat of COFF symbols by default.
 #LINK_DBG	+= -debugtype:both
 LIB_FLAGS	= -ltcg
+EXTRACFLAGS	+= -MD
 endif
 
 ifeq ($(WIN64),define)
@@ -811,7 +820,6 @@ endif
 
 LIBFILES	= $(LIBBASEFILES) $(LIBC)
 
-EXTRACFLAGS	= -nologo -GF -W3
 ifeq ($(__ICC),define)
 EXTRACFLAGS	+= -Qstd=c99
 endif
@@ -1185,7 +1193,7 @@ CFG_VARS	=					\
 		"archname=$(ARCHNAME)"			\
 		"cc=$(CC)"				\
 		"ld=$(LINK32)"				\
-		"ccflags=$(subst ",\",$(EXTRACFLAGS) $(OPTIMIZE) $(DEFINES) $(BUILDOPT))" \
+		"ccflags=$(subst ",\",$(EXTRACFLAGS) $(DEFINES) $(BUILDOPT))" \
 		"usecplusplus=$(USE_CPLUSPLUS)"		\
 		"cf_email=$(EMAIL)"			\
 		"d_mymalloc=$(PERL_MALLOC)"		\

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -475,6 +475,7 @@ INCLUDES	= -I$(COREDIR) -I.\include -I. -I..
 DEFINES		= -DWIN32 -D_CONSOLE -DNO_STRICT
 LOCDEFS		= -DPERLDLL -DPERL_CORE
 CXX_FLAG	= -TP -EHsc
+EXTRACFLAGS	= -nologo -GF -W3
 
 !IF "$(CCTYPE)" == "MSVC140" || "$(CCTYPE)" == "MSVC141" || "$(CCTYPE)" == "MSVC142"
 LIBC		= ucrt.lib
@@ -483,23 +484,28 @@ LIBC		= msvcrt.lib
 !ENDIF
 
 !IF  "$(CFG)" == "Debug"
-OPTIMIZE	= -Od -MD -Zi -DDEBUGGING
+OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
+DEFINES		= $(DEFINES) -DDEBUGGING
+EXTRACFLAGS	= $(EXTRACFLAGS) -MD
 !ELSEIF  "$(CFG)" == "DebugSymbols"
-OPTIMIZE	= -Od -MD -Zi
+OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
+EXTRACFLAGS	= $(EXTRACFLAGS) -MD
 !ELSEIF  "$(CFG)" == "DebugFull"
 !  IF "$(CCTYPE)" == "MSVC140" || "$(CCTYPE)" == "MSVC141" || "$(CCTYPE)" == "MSVC142"
 LIBC		= ucrtd.lib
 !  ELSE
 LIBC		= msvcrtd.lib
 !  ENDIF
-OPTIMIZE	= -Od -MDd -Zi -D_DEBUG -DDEBUGGING
+OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
+DEFINES		= $(DEFINES) -D_DEBUG -DDEBUGGING
+EXTRACFLAGS	= $(EXTRACFLAGS) -MDd
 !ELSE
 # Enable Whole Program Optimizations (WPO) and Link Time Code Generation (LTCG).
 # -O1 yields smaller code, which turns out to be faster than -O2 on x86 and x64
-OPTIMIZE	= -O1 -MD -Zi -DNDEBUG -GL
+OPTIMIZE	= -O1 -Zi -GL
 # we enable debug symbols in release builds also
 LINK_DBG	= -debug -opt:ref,icf -ltcg
 # you may want to enable this if you want COFF symbols in the executables
@@ -509,6 +515,7 @@ LINK_DBG	= -debug -opt:ref,icf -ltcg
 # avoid the bloat of COFF symbols by default.
 #LINK_DBG	= $(LINK_DBG) -debugtype:both
 LIB_FLAGS	= -ltcg
+EXTRACFLAGS	= $(EXTRACFLAGS) -MD
 !ENDIF
 
 !IF "$(WIN64)" == "define"
@@ -580,8 +587,6 @@ LIBBASEFILES    = $(LIBBASEFILES) bufferoverflowU.lib
 
 LIBFILES	= $(LIBBASEFILES) $(LIBC)
 
-#EXTRACFLAGS	= -nologo -GF -W4 -wd4127 -wd4706
-EXTRACFLAGS	= -nologo -GF -W3
 !IF "$(__ICC)" == "define"
 EXTRACFLAGS	= $(EXTRACFLAGS) -Qstd=c99
 !ENDIF
@@ -893,7 +898,7 @@ CFG_VARS	=					\
 		"archname=$(ARCHNAME)"			\
 		"cc=$(CC)"				\
 		"ld=$(LINK32)"				\
-		"ccflags=$(EXTRACFLAGS) $(OPTIMIZE:"=\") $(DEFINES) $(BUILDOPT)"	\
+		"ccflags=$(EXTRACFLAGS) $(DEFINES) $(BUILDOPT)"	\
 		"usecplusplus=$(USE_CPLUSPLUS)"		\
 		"cf_email=$(EMAIL)"	 		\
 		"d_mymalloc=$(PERL_MALLOC)"		\

--- a/win32/makefile.mk
+++ b/win32/makefile.mk
@@ -576,8 +576,9 @@ LIBFILES	= $(LIBC) -lmoldname -lkernel32 -luser32 -lgdi32 -lwinspool \
 	-luuid -lws2_32 -lmpr -lwinmm -lversion -lodbc32 -lodbccp32 -lcomctl32
 
 .IF  "$(CFG)" == "Debug"
-OPTIMIZE	= -g -O2 -DDEBUGGING
+OPTIMIZE	= -g -O2
 LINK_DBG	= -g
+DEFINES		+= -DDEBUGGING
 .ELIF  "$(CFG)" == "DebugSymbols"
 OPTIMIZE	= -g -O2
 LINK_DBG	= -g
@@ -656,6 +657,7 @@ INCLUDES	= -I.\include -I. -I..
 DEFINES		= -DWIN32 -D_CONSOLE -DNO_STRICT
 LOCDEFS		= -DPERLDLL -DPERL_CORE
 CXX_FLAG	= -TP -EHsc
+EXTRACFLAGS	= -nologo -GF -W3
 
 .IF "$(CCTYPE)" == "MSVC140" || "$(CCTYPE)" == "MSVC141" || "$(CCTYPE)" == "MSVC142"
 LIBC		= ucrt.lib
@@ -664,23 +666,28 @@ LIBC		= msvcrt.lib
 .ENDIF
 
 .IF  "$(CFG)" == "Debug"
-OPTIMIZE	= -Od -MD -Zi -DDEBUGGING
+OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
+DEFINES		+= -DDEBUGGING
+EXTRACFLAGS	+= -MD
 .ELIF  "$(CFG)" == "DebugSymbols"
-OPTIMIZE	= -Od -MD -Zi
+OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
+EXTRACFLAGS	+= -MD
 .ELIF  "$(CFG)" == "DebugFull"
 .IF "$(CCTYPE)" == "MSVC140" || "$(CCTYPE)" == "MSVC141" || "$(CCTYPE)" == "MSVC142"
 LIBC		= ucrtd.lib
 .ELSE
 LIBC		= msvcrtd.lib
 .ENDIF
-OPTIMIZE	= -Od -MDd -Zi -D_DEBUG -DDEBUGGING
+OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
+DEFINES		+= -D_DEBUG -DDEBUGGING
+EXTRACFLAGS	+= -MDd
 .ELSE
 # Enable Whole Program Optimizations (WPO) and Link Time Code Generation (LTCG).
 # -O1 yields smaller code, which turns out to be faster than -O2 on x86 and x64
-OPTIMIZE	= -O1 -MD -Zi -DNDEBUG -GL
+OPTIMIZE	= -O1 -Zi -GL
 # we enable debug symbols in release builds also
 LINK_DBG	= -debug -opt:ref,icf -ltcg
 # you may want to enable this if you want COFF symbols in the executables
@@ -690,6 +697,7 @@ LINK_DBG	= -debug -opt:ref,icf -ltcg
 # avoid the bloat of COFF symbols by default.
 #LINK_DBG	+= -debugtype:both
 LIB_FLAGS	= -ltcg
+EXTRACFLAGS	+= -MD
 .ENDIF
 
 .IF "$(WIN64)" == "define"
@@ -762,7 +770,6 @@ LIBBASEFILES    += bufferoverflowU.lib
 
 LIBFILES	= $(LIBBASEFILES) $(LIBC)
 
-EXTRACFLAGS	= -nologo -GF -W3
 .IF "$(__ICC)" == "define"
 EXTRACFLAGS	+= -Qstd=c99
 .ENDIF
@@ -1129,7 +1136,7 @@ CFG_VARS	=					\
 		archname=$(ARCHNAME)		~	\
 		cc=$(CC)			~	\
 		ld=$(LINK32)			~	\
-		ccflags=$(EXTRACFLAGS) $(OPTIMIZE) $(DEFINES) $(BUILDOPT)	~	\
+		ccflags=$(EXTRACFLAGS) $(DEFINES) $(BUILDOPT)	~	\
 		usecplusplus=$(USE_CPLUSPLUS)	~	\
 		cf_email=$(EMAIL)		~	\
 		d_mymalloc=$(PERL_MALLOC)	~	\


### PR DESCRIPTION
(see #17156 for more details, it's the same patch as in that ticket except it was rebased on blead)

Optimization flags don't belong in $Config{ccflags}, while
defines and CRT flags don't belong in $Config{optimize}.

This change makes overriding optimization flags in Makefile.PL
and Build.PL on win32 just as easy as on unix-likes.

Additionally, don't define NDEBUG, perl.h already takes care of
that.

(gh #17156)