### PR TITLE
Tie::StdHandle::BINMODE: handle layer argument

### DIFF
--- a/lib/Tie/Handle/stdhandle.t
+++ b/lib/Tie/Handle/stdhandle.t
@@ -5,7 +5,7 @@ BEGIN {
     @INC = '../lib';
 }
 
-use Test::More tests => 27;
+use Test::More tests => 29;
 
 use_ok('Tie::StdHandle');
 
@@ -71,6 +71,17 @@ is($b, "rhubarbX\n", "b eq rhubarbX");
 
 $b = <$f>;
 is($b, "89\n", "b eq 89");
+
+# binmode should pass through layer argument
+
+binmode $f, ':raw';
+ok !grep( $_ eq 'utf8', PerlIO::get_layers(tied(*$f)) ),
+    'no utf8 in layers after binmode :raw';
+binmode $f, ':utf8';
+ok grep( $_ eq 'utf8', PerlIO::get_layers(tied(*$f)) ),
+    'utf8 is in layers after binmode :utf8';
+
+# finish up
 
 ok(eof($f), "eof");
 ok(close($f), "close");

--- a/lib/Tie/StdHandle.pm
+++ b/lib/Tie/StdHandle.pm
@@ -4,7 +4,7 @@ use strict;
 
 use Tie::Handle;
 our @ISA = 'Tie::Handle';
-our $VERSION = '4.5';
+our $VERSION = '4.6';
 
 =head1 NAME
 
@@ -48,7 +48,7 @@ sub TELL    { tell($_[0]) }
 sub FILENO  { fileno($_[0]) }
 sub SEEK    { seek($_[0],$_[1],$_[2]) }
 sub CLOSE   { close($_[0]) }
-sub BINMODE { binmode($_[0]) }
+sub BINMODE { &CORE::binmode(shift, @_) }
 
 sub OPEN
 {


### PR DESCRIPTION
Fixes #16262

BINMODE was not handling the LAYER argument.
Also bump the version number.

(cherry picked from commit 479d04b98e5b747e5c9ead7368d3e132f524a2b7)
Signed-off-by: Nicolas R <atoomic@cpan.org>