### PR TITLE
Even smaller toke

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -357,17 +357,17 @@ XXX
 
 =head1 Internal Changes
 
-XXX Changes which affect the interface available to C<XS> code go here.  Other
-significant internal changes for future core maintainers should be noted as
-well.
-
-[ List each change as an =item entry ]
-
 =over 4
 
 =item *
 
-XXX
+The lexer (C<Perl_yylex()> in F<toke.c>) was previously a single 4100-line
+function, relying heavily on C<goto> and a lot of widely-scoped local variables
+to do its work. It has now been pulled apart into a few dozen smaller static
+functions; the largest remaining chunk (C<yyl_word_or_keyword()>) is a little
+over 900 lines, and consists of a single C<switch> statement, all of whose
+C<case> groups are independent. This should be much easier to understand and
+maintain.
 
 =back
 

--- a/toke.c
+++ b/toke.c
@@ -6779,9 +6779,7 @@ yyl_my(pTHX_ char *s, I32 my)
     OPERATOR(MY);
 }
 
-static int yyl_try(pTHX_ char*, STRLEN, U8, const bool);
-
-#define RETRY() yyl_try(aTHX_ s, len, 0, 0)
+static int yyl_try(pTHX_ char*, STRLEN, const bool);
 
 static int
 yyl_eol(pTHX_ char *s, STRLEN len)
@@ -6824,7 +6822,7 @@ yyl_eol(pTHX_ char *s, STRLEN len)
                 incline(s, PL_bufend);
         }
     }
-    return RETRY();
+    return yyl_try(aTHX_ s, len, 0);
 }
 
 static int
@@ -7076,7 +7074,7 @@ yyl_fake_eof(pTHX_ U32 fake_eof, bool bof, char *s, STRLEN len)
                         PL_preambled = FALSE;
                         if (PERLDB_LINE_OR_SAVESRC)
                             (void)gv_fetchfile(PL_origfilename);
-                        return RETRY();
+                        return yyl_try(aTHX_ s, len, 0);
                     }
                 }
             }
@@ -7089,7 +7087,7 @@ yyl_fake_eof(pTHX_ U32 fake_eof, bool bof, char *s, STRLEN len)
         TOKEN(';');
     }
 
-    return RETRY();
+    return yyl_try(aTHX_ s, len, 0);
 }
 
 static int
@@ -8525,7 +8523,7 @@ yyl_keylookup(pTHX_ char *s, GV *gv, bool bof, bool saw_infix_sigil)
 }
 
 static int
-yyl_try(pTHX_ char *s, STRLEN len, U8 formbrack, const bool saw_infix_sigil)
+yyl_try(pTHX_ char *s, STRLEN len, const bool saw_infix_sigil)
 {
     char *d;
     bool bof = FALSE;
@@ -8561,7 +8559,7 @@ yyl_try(pTHX_ char *s, STRLEN len, U8 formbrack, const bool saw_infix_sigil)
 	    TOKEN(0);
 	}
 	if (s++ < PL_bufend)
-	    return RETRY();			/* ignore stray nulls */
+	    return yyl_try(aTHX_ s, len, 0);  /* ignore stray nulls */
 	PL_last_uni = 0;
 	PL_last_lop = 0;
 	if (!PL_in_eval && !PL_preambled) {
@@ -8639,7 +8637,7 @@ yyl_try(pTHX_ char *s, STRLEN len, U8 formbrack, const bool saw_infix_sigil)
 	    PL_last_lop = PL_last_uni = NULL;
 	    if (PERLDB_LINE_OR_SAVESRC && PL_curstash != PL_debstash)
 		update_debugger_info(PL_linestr, NULL, 0);
-	    return RETRY();
+	    return yyl_try(aTHX_ s, len, 0);
 	}
         return yyl_fake_eof(aTHX_ 0, cBOOL(PL_rsfp), s, len);
 
@@ -8651,7 +8649,7 @@ yyl_try(pTHX_ char *s, STRLEN len, U8 formbrack, const bool saw_infix_sigil)
 #endif
     case ' ': case '\t': case '\f': case '\v':
 	s++;
-	return RETRY();
+	return yyl_try(aTHX_ s, len, 0);
 
     case '#':
     case '\n':
@@ -8706,12 +8704,12 @@ yyl_try(pTHX_ char *s, STRLEN len, U8 formbrack, const bool saw_infix_sigil)
         return yyl_rightsquare(aTHX_ s);
 
     case '{':
-        return yyl_leftcurly(aTHX_ s + 1, formbrack);
+        return yyl_leftcurly(aTHX_ s + 1, 0);
 
     case '}':
 	if (PL_lex_brackets && PL_lex_brackstack[PL_lex_brackets-1] == XFAKEEOF)
 	    TOKEN(0);
-        return yyl_rightcurly(aTHX_ s, formbrack);
+        return yyl_rightcurly(aTHX_ s, 0);
 
     case '&':
         return yyl_ampersand(aTHX_ s);
@@ -8724,7 +8722,7 @@ yyl_try(pTHX_ char *s, STRLEN len, U8 formbrack, const bool saw_infix_sigil)
             && memBEGINs(s + 2, (STRLEN) (PL_bufend - s + 2), "====="))
         {
             s = vcs_conflict_marker(s + 7);
-            return RETRY();
+            return yyl_try(aTHX_ s, len, 0);
         }
 
 	s++;
@@ -8774,15 +8772,15 @@ yyl_try(pTHX_ char *s, STRLEN len, U8 formbrack, const bool saw_infix_sigil)
                                 else
                                     s = d;
                                 incline(s, PL_bufend);
-                                return RETRY();
+                                return yyl_try(aTHX_ s, len, 0);
                             }
                         }
                     }
-                    return RETRY();
+                    return yyl_try(aTHX_ s, len, 0);
                 }
                 s = PL_bufend;
                 PL_parser->in_pod = 1;
-                return RETRY();
+                return yyl_try(aTHX_ s, len, 0);
             }
 	}
 	if (PL_expect == XBLOCK) {
@@ -8794,14 +8792,13 @@ yyl_try(pTHX_ char *s, STRLEN len, U8 formbrack, const bool saw_infix_sigil)
 #endif
 		t++;
 	    if (*t == '\n' || *t == '#') {
-		formbrack = 1;
 		ENTER_with_name("lex_format");
 		SAVEI8(PL_parser->form_lex_state);
 		SAVEI32(PL_lex_formbrack);
 		PL_parser->form_lex_state = PL_lex_state;
 		PL_lex_formbrack = PL_lex_brackets + 1;
                 PL_parser->sub_error_count = PL_error_count;
-                return yyl_leftcurly(aTHX_ s, formbrack);
+                return yyl_leftcurly(aTHX_ s, 1);
 	    }
 	}
 	if (!PL_lex_allbrackets && PL_lex_fakeeof >= LEX_FAKEEOF_ASSIGN) {
@@ -8819,7 +8816,7 @@ yyl_try(pTHX_ char *s, STRLEN len, U8 formbrack, const bool saw_infix_sigil)
             && memBEGINs(s+2, (STRLEN) (PL_bufend - (s+2)), "<<<<<"))
         {
             s = vcs_conflict_marker(s + 7);
-            return RETRY();
+            return yyl_try(aTHX_ s, len, 0);
         }
         return yyl_leftpointy(aTHX_ s);
 
@@ -8828,7 +8825,7 @@ yyl_try(pTHX_ char *s, STRLEN len, U8 formbrack, const bool saw_infix_sigil)
             && memBEGINs(s + 2, (STRLEN) (PL_bufend - s + 2), ">>>>>"))
         {
             s = vcs_conflict_marker(s + 7);
-            return RETRY();
+            return yyl_try(aTHX_ s, len, 0);
         }
         return yyl_rightpointy(aTHX_ s + 1);
 
@@ -8862,8 +8859,8 @@ yyl_try(pTHX_ char *s, STRLEN len, U8 formbrack, const bool saw_infix_sigil)
 	    && (s == PL_linestart || s[-1] == '\n') )
 	{
 	    PL_expect = XSTATE;
-	    formbrack = 2; /* dot seen where arguments expected */
-            return yyl_rightcurly(aTHX_ s, formbrack);
+            /* formbrack==2 means dot seen where arguments expected */
+            return yyl_rightcurly(aTHX_ s, 2);
 	}
 	if (PL_expect == XSTATE && s[1] == '.' && s[2] == '.') {
 	    s += 3;
@@ -9284,7 +9281,7 @@ Perl_yylex(pTHX)
         return yyl_sigvar(aTHX_ s);
     }
 
-    return yyl_try(aTHX_ s, 0, 0, saw_infix_sigil);
+    return yyl_try(aTHX_ s, 0, saw_infix_sigil);
 }
 
 

--- a/toke.c
+++ b/toke.c
@@ -5577,7 +5577,6 @@ yyl_star(pTHX_ char *s)
         TOKEN(0);
     }
 
-    PL_parser->saw_infix_sigil = 1;
     Mop(OP_MULTIPLY);
 }
 
@@ -5592,7 +5591,6 @@ yyl_percent(pTHX_ char *s)
             TOKEN(0);
         }
         ++s;
-        PL_parser->saw_infix_sigil = 1;
         Mop(OP_MODULO);
     }
     else if (PL_expect == XPOSTDEREF)
@@ -6145,10 +6143,8 @@ yyl_ampersand(pTHX_ char *s)
             s--;
             TOKEN(0);
         }
-        if (d == s) {
-            PL_parser->saw_infix_sigil = 1;
+        if (d == s)
             BAop(bof ? OP_NBIT_AND : OP_BIT_AND);
-        }
         else
             BAop(OP_SBIT_AND);
     }
@@ -6779,7 +6775,7 @@ yyl_my(pTHX_ char *s, I32 my)
     OPERATOR(MY);
 }
 
-static int yyl_try(pTHX_ char*, STRLEN, const bool);
+static int yyl_try(pTHX_ char*, STRLEN);
 
 static int
 yyl_eol(pTHX_ char *s, STRLEN len)
@@ -6822,7 +6818,7 @@ yyl_eol(pTHX_ char *s, STRLEN len)
                 incline(s, PL_bufend);
         }
     }
-    return yyl_try(aTHX_ s, len, 0);
+    return yyl_try(aTHX_ s, len);
 }
 
 static int
@@ -7074,7 +7070,7 @@ yyl_fake_eof(pTHX_ U32 fake_eof, bool bof, char *s, STRLEN len)
                         PL_preambled = FALSE;
                         if (PERLDB_LINE_OR_SAVESRC)
                             (void)gv_fetchfile(PL_origfilename);
-                        return yyl_try(aTHX_ s, len, 0);
+                        return yyl_try(aTHX_ s, len);
                     }
                 }
             }
@@ -7087,7 +7083,7 @@ yyl_fake_eof(pTHX_ U32 fake_eof, bool bof, char *s, STRLEN len)
         TOKEN(';');
     }
 
-    return yyl_try(aTHX_ s, len, 0);
+    return yyl_try(aTHX_ s, len);
 }
 
 static int
@@ -7102,10 +7098,10 @@ yyl_fatcomma(pTHX_ char *s, STRLEN len)
 }
 
 static int
-yyl_safe_bareword(pTHX_ char *s, const char lastchar, const bool saw_infix_sigil)
+yyl_safe_bareword(pTHX_ char *s, const char lastchar)
 {
     if ((lastchar == '*' || lastchar == '%' || lastchar == '&')
-        && saw_infix_sigil)
+        && PL_parser->saw_infix_sigil)
     {
         Perl_ck_warner_d(aTHX_ packWARN(WARN_AMBIGUOUS),
                          "Operator or semicolon missing before %c%" UTF8f,
@@ -7197,8 +7193,7 @@ yyl_strictwarn_bareword(pTHX_ const char lastchar)
 }
 
 static int
-yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword,
-                struct code c, const bool saw_infix_sigil)
+yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword, struct code c)
 {
     int pkgname = 0;
     const char lastchar = (PL_bufptr == PL_oldoldbufptr ? 0 : PL_bufptr[-1]);
@@ -7278,7 +7273,7 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword,
 
     /* And if "Foo::", then that's what it certainly is. */
     if (safebw)
-        return yyl_safe_bareword(aTHX_ s, lastchar, saw_infix_sigil);
+        return yyl_safe_bareword(aTHX_ s, lastchar);
 
     if (!c.off) {
         OP *const_op = newSVOP(OP_CONST, 0, SvREFCNT_inc_NN(c.sv));
@@ -7345,7 +7340,7 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword,
             PL_expect = (PL_last_lop == PL_oldoldbufptr) ? XTERM : XOPERATOR;
             yyl_strictwarn_bareword(aTHX_ lastchar);
             op_free(c.rv2cv_op);
-            return yyl_safe_bareword(aTHX_ s, lastchar, saw_infix_sigil);
+            return yyl_safe_bareword(aTHX_ s, lastchar);
         }
     }
 
@@ -7445,17 +7440,15 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword,
 
     op_free(c.rv2cv_op);
 
-    return yyl_safe_bareword(aTHX_ s, lastchar, saw_infix_sigil);
+    return yyl_safe_bareword(aTHX_ s, lastchar);
 }
 
 static int
-yyl_word_or_keyword(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword,
-                    struct code c, bool bof, const bool saw_infix_sigil)
+yyl_word_or_keyword(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword, struct code c, bool bof)
 {
     switch (key) {
     default:			/* not a keyword */
-        return yyl_just_a_word(aTHX_ s, len, key, orig_keyword,
-                               c, saw_infix_sigil);
+        return yyl_just_a_word(aTHX_ s, len, key, orig_keyword, c);
 
     case KEY___FILE__:
         FUN0OP( newSVOP(OP_CONST, 0, newSVpv(CopFILE(PL_curcop),0)) );
@@ -7493,8 +7486,7 @@ yyl_word_or_keyword(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword,
     case KEY_END:
         if (PL_expect == XSTATE)
             return yyl_sub(aTHX_ PL_bufptr, key);
-        return yyl_just_a_word(aTHX_ s, len, key, orig_keyword,
-                               c, saw_infix_sigil);
+        return yyl_just_a_word(aTHX_ s, len, key, orig_keyword, c);
 
     case KEY_abs:
         UNI(OP_ABS);
@@ -8349,8 +8341,7 @@ yyl_word_or_keyword(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword,
             Mop(OP_REPEAT);
         }
         check_uni();
-        return yyl_just_a_word(aTHX_ s, len, key, orig_keyword,
-                               c, saw_infix_sigil);
+        return yyl_just_a_word(aTHX_ s, len, key, orig_keyword, c);
 
     case KEY_xor:
         if (!PL_lex_allbrackets && PL_lex_fakeeof >= LEX_FAKEEOF_LOWLOGIC)
@@ -8361,8 +8352,7 @@ yyl_word_or_keyword(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword,
 }
 
 static int
-yyl_key_core(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword,
-             struct code c, bool bof, const bool saw_infix_sigil)
+yyl_key_core(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword, struct code c, bool bof)
 {
     STRLEN olen = len;
     char *d = s;
@@ -8372,7 +8362,7 @@ yyl_key_core(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword,
         || (!(key = keyword(PL_tokenbuf, len, 1)) && *s == '\''))
     {
         Copy(PL_bufptr, PL_tokenbuf, olen, char);
-        return yyl_just_a_word(aTHX_ d, olen, key, orig_keyword, c, saw_infix_sigil);
+        return yyl_just_a_word(aTHX_ d, olen, key, orig_keyword, c);
     }
     if (!key)
         Perl_croak(aTHX_ "CORE::%" UTF8f " is not a keyword",
@@ -8385,12 +8375,11 @@ yyl_key_core(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword,
         orig_keyword = key;
 
     /* Known to be a reserved word at this point */
-    return yyl_word_or_keyword(aTHX_ s, len, key, orig_keyword, c,
-                               bof, saw_infix_sigil);
+    return yyl_word_or_keyword(aTHX_ s, len, key, orig_keyword, c, bof);
 }
 
 static int
-yyl_keylookup(pTHX_ char *s, GV *gv, bool bof, bool saw_infix_sigil)
+yyl_keylookup(pTHX_ char *s, GV *gv, bool bof)
 {
     STRLEN len;
     bool anydelim;
@@ -8410,8 +8399,8 @@ yyl_keylookup(pTHX_ char *s, GV *gv, bool bof, bool saw_infix_sigil)
     /* x::* is just a word, unless x is "CORE" */
     if (!anydelim && *s == ':' && s[1] == ':') {
         if (memEQs(PL_tokenbuf, len, "CORE"))
-            return yyl_key_core(aTHX_ s, len, tmp, 0, c, bof, saw_infix_sigil);
-        return yyl_just_a_word(aTHX_ s, len, 0, 0, c, saw_infix_sigil);
+            return yyl_key_core(aTHX_ s, len, tmp, 0, c, bof);
+        return yyl_just_a_word(aTHX_ s, len, 0, 0, c);
     }
 
     d = s;
@@ -8484,7 +8473,7 @@ yyl_keylookup(pTHX_ char *s, GV *gv, bool bof, bool saw_infix_sigil)
                 if (!c.gv) {
                     sv_free(c.sv);
                     c.sv = NULL;
-                    return yyl_just_a_word(aTHX_ s, len, tmp, 0, c, saw_infix_sigil);
+                    return yyl_just_a_word(aTHX_ s, len, tmp, 0, c);
                 }
             }
             else {
@@ -8493,7 +8482,7 @@ yyl_keylookup(pTHX_ char *s, GV *gv, bool bof, bool saw_infix_sigil)
                 c.cv = find_lexical_cv(c.off);
             }
             c.lex = TRUE;
-            return yyl_just_a_word(aTHX_ s, len, tmp, 0, c, saw_infix_sigil);
+            return yyl_just_a_word(aTHX_ s, len, tmp, 0, c);
         }
         c.off = 0;
     }
@@ -8516,12 +8505,11 @@ yyl_keylookup(pTHX_ char *s, GV *gv, bool bof, bool saw_infix_sigil)
             return yyl_fatcomma(aTHX_ s, len);
     }
 
-    return yyl_word_or_keyword(aTHX_ s, len, tmp, orig_keyword,
-                               c, bof, saw_infix_sigil);
+    return yyl_word_or_keyword(aTHX_ s, len, tmp, orig_keyword, c, bof);
 }
 
 static int
-yyl_try(pTHX_ char *s, STRLEN len, const bool saw_infix_sigil)
+yyl_try(pTHX_ char *s, STRLEN len)
 {
     char *d;
     bool bof = FALSE;
@@ -8530,7 +8518,7 @@ yyl_try(pTHX_ char *s, STRLEN len, const bool saw_infix_sigil)
     switch (*s) {
     default:
         if (UTF ? isIDFIRST_utf8_safe(s, PL_bufend) : isALNUMC(*s))
-            return yyl_keylookup(aTHX_ s, gv, bof, saw_infix_sigil);
+            return yyl_keylookup(aTHX_ s, gv, bof);
         yyl_croak_unrecognised(aTHX_ s);
 
     case 4:
@@ -8557,7 +8545,7 @@ yyl_try(pTHX_ char *s, STRLEN len, const bool saw_infix_sigil)
 	    TOKEN(0);
 	}
 	if (s++ < PL_bufend)
-	    return yyl_try(aTHX_ s, len, 0);  /* ignore stray nulls */
+	    return yyl_try(aTHX_ s, len);  /* ignore stray nulls */
 	PL_last_uni = 0;
 	PL_last_lop = 0;
 	if (!PL_in_eval && !PL_preambled) {
@@ -8635,7 +8623,7 @@ yyl_try(pTHX_ char *s, STRLEN len, const bool saw_infix_sigil)
 	    PL_last_lop = PL_last_uni = NULL;
 	    if (PERLDB_LINE_OR_SAVESRC && PL_curstash != PL_debstash)
 		update_debugger_info(PL_linestr, NULL, 0);
-	    return yyl_try(aTHX_ s, len, 0);
+	    return yyl_try(aTHX_ s, len);
 	}
         return yyl_fake_eof(aTHX_ 0, cBOOL(PL_rsfp), s, len);
 
@@ -8647,7 +8635,7 @@ yyl_try(pTHX_ char *s, STRLEN len, const bool saw_infix_sigil)
 #endif
     case ' ': case '\t': case '\f': case '\v':
 	s++;
-	return yyl_try(aTHX_ s, len, 0);
+	return yyl_try(aTHX_ s, len);
 
     case '#':
     case '\n':
@@ -8681,7 +8669,7 @@ yyl_try(pTHX_ char *s, STRLEN len, const bool saw_infix_sigil)
 	OPERATOR(',');
     case ':':
 	if (s[1] == ':')
-            return yyl_just_a_word(aTHX_ s, 0, 0, 0, no_code, saw_infix_sigil);
+            return yyl_just_a_word(aTHX_ s, 0, 0, 0, no_code);
         return yyl_colon(aTHX_ s + 1);
 
     case '(':
@@ -8720,7 +8708,7 @@ yyl_try(pTHX_ char *s, STRLEN len, const bool saw_infix_sigil)
             && memBEGINs(s + 2, (STRLEN) (PL_bufend - s + 2), "====="))
         {
             s = vcs_conflict_marker(s + 7);
-            return yyl_try(aTHX_ s, len, 0);
+            return yyl_try(aTHX_ s, len);
         }
 
 	s++;
@@ -8770,15 +8758,15 @@ yyl_try(pTHX_ char *s, STRLEN len, const bool saw_infix_sigil)
                                 else
                                     s = d;
                                 incline(s, PL_bufend);
-                                return yyl_try(aTHX_ s, len, 0);
+                                return yyl_try(aTHX_ s, len);
                             }
                         }
                     }
-                    return yyl_try(aTHX_ s, len, 0);
+                    return yyl_try(aTHX_ s, len);
                 }
                 s = PL_bufend;
                 PL_parser->in_pod = 1;
-                return yyl_try(aTHX_ s, len, 0);
+                return yyl_try(aTHX_ s, len);
             }
 	}
 	if (PL_expect == XBLOCK) {
@@ -8814,7 +8802,7 @@ yyl_try(pTHX_ char *s, STRLEN len, const bool saw_infix_sigil)
             && memBEGINs(s+2, (STRLEN) (PL_bufend - (s+2)), "<<<<<"))
         {
             s = vcs_conflict_marker(s + 7);
-            return yyl_try(aTHX_ s, len, 0);
+            return yyl_try(aTHX_ s, len);
         }
         return yyl_leftpointy(aTHX_ s);
 
@@ -8823,7 +8811,7 @@ yyl_try(pTHX_ char *s, STRLEN len, const bool saw_infix_sigil)
             && memBEGINs(s + 2, (STRLEN) (PL_bufend - s + 2), ">>>>>"))
         {
             s = vcs_conflict_marker(s + 7);
-            return yyl_try(aTHX_ s, len, 0);
+            return yyl_try(aTHX_ s, len);
         }
         return yyl_rightpointy(aTHX_ s + 1);
 
@@ -8922,12 +8910,12 @@ yyl_try(pTHX_ char *s, STRLEN len, const bool saw_infix_sigil)
 	    }
 	    else if ((*start == ':' && start[1] == ':')
 		  || (PL_expect == XSTATE && *start == ':'))
-                return yyl_keylookup(aTHX_ s, gv, bof, saw_infix_sigil);
+                return yyl_keylookup(aTHX_ s, gv, bof);
 	    else if (PL_expect == XSTATE) {
 		d = start;
 		while (d < PL_bufend && isSPACE(*d)) d++;
 		if (*d == ':')
-                    return yyl_keylookup(aTHX_ s, gv, bof, saw_infix_sigil);
+                    return yyl_keylookup(aTHX_ s, gv, bof);
 	    }
 	    /* avoid v123abc() or $h{v1}, allow C<print v10;> */
 	    if (!isALPHA(*start) && (PL_expect == XTERM
@@ -8941,14 +8929,14 @@ yyl_try(pTHX_ char *s, STRLEN len, const bool saw_infix_sigil)
 		}
 	    }
 	}
-        return yyl_keylookup(aTHX_ s, gv, bof, saw_infix_sigil);
+        return yyl_keylookup(aTHX_ s, gv, bof);
 
     case 'x':
 	if (isDIGIT(s[1]) && PL_expect == XOPERATOR) {
 	    s++;
 	    Mop(OP_REPEAT);
 	}
-        return yyl_keylookup(aTHX_ s, gv, bof, saw_infix_sigil);
+        return yyl_keylookup(aTHX_ s, gv, bof);
 
     case '_':
     case 'a': case 'A':
@@ -8977,7 +8965,7 @@ yyl_try(pTHX_ char *s, STRLEN len, const bool saw_infix_sigil)
 	      case 'X':
     case 'y': case 'Y':
     case 'z': case 'Z':
-        return yyl_keylookup(aTHX_ s, gv, bof, saw_infix_sigil);
+        return yyl_keylookup(aTHX_ s, gv, bof);
     }
 }
 
@@ -9038,7 +9026,6 @@ Perl_yylex(pTHX)
 {
     dVAR;
     char *s = PL_bufptr;
-    const bool saw_infix_sigil = cBOOL(PL_parser->saw_infix_sigil);
 
     if (UNLIKELY(PL_parser->recheck_utf8_validity)) {
         const U8* first_bad_char_loc;
@@ -9273,13 +9260,35 @@ Perl_yylex(pTHX)
     s = PL_bufptr;
     PL_oldoldbufptr = PL_oldbufptr;
     PL_oldbufptr = s;
-    PL_parser->saw_infix_sigil = 0;
 
     if (PL_in_my == KEY_sigvar) {
+        PL_parser->saw_infix_sigil = 0;
         return yyl_sigvar(aTHX_ s);
     }
 
-    return yyl_try(aTHX_ s, 0, saw_infix_sigil);
+    {
+        /* yyl_try() and its callees might consult PL_parser->saw_infix_sigil.
+           On its return, we then need to set it to indicate whether the token
+           we just encountered was an infix operator that (if we hadn't been
+           expecting an operator) have been a sigil.
+        */
+        bool expected_operator = (PL_expect == XOPERATOR);
+        int ret = yyl_try(aTHX_ s, 0);
+        switch (pl_yylval.ival) {
+        case OP_BIT_AND:
+        case OP_MODULO:
+        case OP_MULTIPLY:
+        case OP_NBIT_AND:
+            if (expected_operator) {
+                PL_parser->saw_infix_sigil = 1;
+                break;
+            }
+            /* FALLTHROUGH */
+        default:
+            PL_parser->saw_infix_sigil = 0;
+        }
+        return ret;
+    }
 }
 
 

--- a/toke.c
+++ b/toke.c
@@ -290,6 +290,37 @@ static const char* const lex_state_names[] = {
     } STMT_END
 
 
+/* A file-local structure for passing around information about subroutines and
+ * related definable words */
+struct code {
+    SV *sv;
+    CV *cv;
+    GV *gv, **gvp;
+    OP *rv2cv_op;
+    PADOFFSET off;
+    bool lex;
+};
+
+static const struct code no_code = { NULL, NULL, NULL, NULL, NULL, 0, FALSE };
+
+PERL_STATIC_INLINE struct code
+make_code(SV *sv, CV *cv, GV *gv, GV **gvp, OP *rv2cv_op, PADOFFSET off, bool lex)
+{
+    struct code c;
+    c.sv = sv;
+    c.sv = sv;
+    c.cv = cv;
+    c.gv = gv;
+    c.gvp = gvp;
+    c.rv2cv_op = rv2cv_op;
+    c.off = off;
+    c.lex = lex;
+    return c;
+}
+
+#define MAKE_CODE(lEx) make_code(sv, cv, gv, gvp, rv2cv_op, off, lEx)
+
+
 #ifdef DEBUGGING
 
 /* how to interpret the pl_yylval associated with the token */
@@ -7182,9 +7213,8 @@ yyl_strictwarn_bareword(pTHX_ const char lastchar)
 }
 
 static int
-yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, PADOFFSET off,
-                I32 orig_keyword, SV *sv, CV *cv, GV *gv, GV **gvp,
-                OP *rv2cv_op, const bool lex, const bool saw_infix_sigil)
+yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword,
+                struct code c, const bool saw_infix_sigil)
 {
     int pkgname = 0;
     const char lastchar = (PL_bufptr == PL_oldoldbufptr ? 0 : PL_bufptr[-1]);
@@ -7238,8 +7268,8 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, PADOFFSET off,
                         UTF8fARG(UTF, len, PL_tokenbuf));
         len -= 2;
         PL_tokenbuf[len] = '\0';
-        gv = NULL;
-        gvp = 0;
+        c.gv = NULL;
+        c.gvp = 0;
         safebw = TRUE;
     }
     else {
@@ -7248,35 +7278,35 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, PADOFFSET off,
 
     /* if we saw a global override before, get the right name */
 
-    if (!sv)
-        sv = S_newSV_maybe_utf8(aTHX_ PL_tokenbuf, len);
-    if (gvp) {
-        SV * const tmp_sv = sv;
-        sv = newSVpvs("CORE::GLOBAL::");
-        sv_catsv(sv, tmp_sv);
-        SvREFCNT_dec(tmp_sv);
+    if (!c.sv)
+        c.sv = S_newSV_maybe_utf8(aTHX_ PL_tokenbuf, len);
+    if (c.gvp) {
+        SV *sv = newSVpvs("CORE::GLOBAL::");
+        sv_catsv(sv, c.sv);
+        SvREFCNT_dec(c.sv);
+        c.sv = sv;
     }
 
     /* Presume this is going to be a bareword of some sort. */
     CLINE;
-    pl_yylval.opval = newSVOP(OP_CONST, 0, sv);
+    pl_yylval.opval = newSVOP(OP_CONST, 0, c.sv);
     pl_yylval.opval->op_private = OPpCONST_BARE;
 
     /* And if "Foo::", then that's what it certainly is. */
     if (safebw)
         return yyl_safe_bareword(aTHX_ s, lastchar, saw_infix_sigil);
 
-    if (!off) {
-        OP *const_op = newSVOP(OP_CONST, 0, SvREFCNT_inc_NN(sv));
+    if (!c.off) {
+        OP *const_op = newSVOP(OP_CONST, 0, SvREFCNT_inc_NN(c.sv));
         const_op->op_private = OPpCONST_BARE;
-        rv2cv_op = newCVREF(OPpMAY_RETURN_CONSTANT<<8, const_op);
-        cv = lex
-            ? isGV(gv)
-                ? GvCV(gv)
-                : SvROK(gv) && SvTYPE(SvRV(gv)) == SVt_PVCV
-                    ? (CV *)SvRV(gv)
-                    : ((CV *)gv)
-            : rv2cv_op_cv(rv2cv_op, RV2CVOPCV_RETURN_STUB);
+        c.rv2cv_op = newCVREF(OPpMAY_RETURN_CONSTANT<<8, const_op);
+        c.cv = c.lex
+            ? isGV(c.gv)
+                ? GvCV(c.gv)
+                : SvROK(c.gv) && SvTYPE(SvRV(c.gv)) == SVt_PVCV
+                    ? (CV *)SvRV(c.gv)
+                    : ((CV *)c.gv)
+            : rv2cv_op_cv(c.rv2cv_op, RV2CVOPCV_RETURN_STUB);
     }
 
     /* Use this var to track whether intuit_method has been
@@ -7307,7 +7337,7 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, PADOFFSET off,
         /* Two barewords in a row may indicate method call. */
         if (   (   isIDFIRST_lazy_if_safe(s, PL_bufend, UTF)
                 || *s == '$')
-            && (key = intuit_method(s, lex ? NULL : sv, cv)))
+            && (key = intuit_method(s, c.lex ? NULL : c.sv, c.cv)))
         {
             /* the code at method: doesn't use s */
             goto method;
@@ -7320,7 +7350,7 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, PADOFFSET off,
 
         if (
             ( !immediate_paren && (PL_last_lop_op == OP_SORT
-             || (!cv
+             || (!c.cv
                  && (PL_last_lop_op != OP_MAPSTART
                      && PL_last_lop_op != OP_GREPSTART))))
            || (PL_tokenbuf[0] == '_' && PL_tokenbuf[1] == '\0'
@@ -7330,7 +7360,7 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, PADOFFSET off,
         {
             PL_expect = (PL_last_lop == PL_oldoldbufptr) ? XTERM : XOPERATOR;
             yyl_strictwarn_bareword(aTHX_ lastchar);
-            op_free(rv2cv_op);
+            op_free(c.rv2cv_op);
             return yyl_safe_bareword(aTHX_ s, lastchar, saw_infix_sigil);
         }
     }
@@ -7340,18 +7370,18 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, PADOFFSET off,
 
     /* Is this a word before a => operator? */
     if (*s == '=' && s[1] == '>' && !pkgname) {
-        op_free(rv2cv_op);
+        op_free(c.rv2cv_op);
         CLINE;
-        if (gvp || (lex && !off)) {
-            assert (cSVOPx(pl_yylval.opval)->op_sv == sv);
+        if (c.gvp || (c.lex && !c.off)) {
+            assert (cSVOPx(pl_yylval.opval)->op_sv == c.sv);
             /* This is our own scalar, created a few lines
                above, so this is safe. */
-            SvREADONLY_off(sv);
-            sv_setpv(sv, PL_tokenbuf);
+            SvREADONLY_off(c.sv);
+            sv_setpv(c.sv, PL_tokenbuf);
             if (UTF && !IN_BYTES
              && is_utf8_string((U8*)PL_tokenbuf, len))
-                  SvUTF8_on(sv);
-            SvREADONLY_on(sv);
+                  SvUTF8_on(c.sv);
+            SvREADONLY_on(c.sv);
         }
         TERM(BAREWORD);
     }
@@ -7359,26 +7389,26 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, PADOFFSET off,
     /* If followed by a paren, it's certainly a subroutine. */
     if (*s == '(') {
         CLINE;
-        if (cv) {
+        if (c.cv) {
             char *d = s + 1;
             while (SPACE_OR_TAB(*d))
                 d++;
-            if (*d == ')' && (sv = cv_const_sv_or_av(cv)))
-                return yyl_constant_op(aTHX_ d + 1, sv, cv, rv2cv_op, off);
+            if (*d == ')' && (c.sv = cv_const_sv_or_av(c.cv)))
+                return yyl_constant_op(aTHX_ d + 1, c.sv, c.cv, c.rv2cv_op, c.off);
         }
         NEXTVAL_NEXTTOKE.opval =
-            off ? rv2cv_op : pl_yylval.opval;
-        if (off)
+            c.off ? c.rv2cv_op : pl_yylval.opval;
+        if (c.off)
              op_free(pl_yylval.opval), force_next(PRIVATEREF);
-        else op_free(rv2cv_op),	   force_next(BAREWORD);
+        else op_free(c.rv2cv_op),      force_next(BAREWORD);
         pl_yylval.ival = 0;
         TOKEN('&');
     }
 
     /* If followed by var or block, call it a method (unless sub) */
 
-    if ((*s == '$' || *s == '{') && !cv) {
-        op_free(rv2cv_op);
+    if ((*s == '$' || *s == '{') && !c.cv) {
+        op_free(c.rv2cv_op);
         PL_last_lop = PL_oldbufptr;
         PL_last_lop_op = OP_METHOD;
         if (!PL_lex_allbrackets && PL_lex_fakeeof > LEX_FAKEEOF_LOWLOGIC)
@@ -7393,19 +7423,19 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, PADOFFSET off,
     if (   key == 1
         && !orig_keyword
         && (isIDFIRST_lazy_if_safe(s, PL_bufend, UTF) || *s == '$')
-        && (key = intuit_method(s, lex ? NULL : sv, cv)))
+        && (key = intuit_method(s, c.lex ? NULL : c.sv, c.cv)))
     {
       method:
-        if (lex && !off) {
-            assert(cSVOPx(pl_yylval.opval)->op_sv == sv);
-            SvREADONLY_off(sv);
-            sv_setpvn(sv, PL_tokenbuf, len);
+        if (c.lex && !c.off) {
+            assert(cSVOPx(pl_yylval.opval)->op_sv == c.sv);
+            SvREADONLY_off(c.sv);
+            sv_setpvn(c.sv, PL_tokenbuf, len);
             if (UTF && !IN_BYTES
              && is_utf8_string((U8*)PL_tokenbuf, len))
-                SvUTF8_on (sv);
-            else SvUTF8_off(sv);
+                SvUTF8_on(c.sv);
+            else SvUTF8_off(c.sv);
         }
-        op_free(rv2cv_op);
+        op_free(c.rv2cv_op);
         if (key == METHOD && !PL_lex_allbrackets
             && PL_lex_fakeeof > LEX_FAKEEOF_LOWLOGIC)
         {
@@ -7416,10 +7446,10 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, PADOFFSET off,
 
     /* Not a method, so call it a subroutine (if defined) */
 
-    if (cv) {
+    if (c.cv) {
         /* Check for a constant sub */
-        sv = cv_const_sv_or_av(cv);
-        return yyl_constant_op(aTHX_ s, sv, cv, rv2cv_op, off);
+        c.sv = cv_const_sv_or_av(c.cv);
+        return yyl_constant_op(aTHX_ s, c.sv, c.cv, c.rv2cv_op, c.off);
     }
 
     /* Call it a bare word */
@@ -7429,7 +7459,7 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 key, PADOFFSET off,
     else
         yyl_strictwarn_bareword(aTHX_ lastchar);
 
-    op_free(rv2cv_op);
+    op_free(c.rv2cv_op);
 
     return yyl_safe_bareword(aTHX_ s, lastchar, saw_infix_sigil);
 }
@@ -7600,8 +7630,7 @@ yyl_try(pTHX_ char initial_state, char *s, STRLEN len,
 	OPERATOR(',');
     case ':':
 	if (s[1] == ':')
-            return yyl_just_a_word(aTHX_ s, 0, 0, 0, 0, 0, NULL, NULL, NULL,
-                                   NULL, NULL, saw_infix_sigil);
+            return yyl_just_a_word(aTHX_ s, 0, 0, 0, no_code, saw_infix_sigil);
         return yyl_colon(aTHX_ s + 1);
 
     case '(':
@@ -7922,8 +7951,7 @@ yyl_try(pTHX_ char initial_state, char *s, STRLEN len,
 	/* x::* is just a word, unless x is "CORE" */
 	if (!anydelim && *s == ':' && s[1] == ':') {
 	    if (memEQs(PL_tokenbuf, len, "CORE")) goto case_KEY_CORE;
-            return yyl_just_a_word(aTHX_ s, len, 0, off, orig_keyword, sv, cv,
-                                   gv, gvp, rv2cv_op, FALSE, saw_infix_sigil);
+            return yyl_just_a_word(aTHX_ s, len, 0, orig_keyword, MAKE_CODE(FALSE), saw_infix_sigil);
 	}
 
 	d = s;
@@ -7996,9 +8024,9 @@ yyl_try(pTHX_ char initial_state, char *s, STRLEN len,
 		    off = 0;
 		    if (!gv) {
 			sv_free(sv);
-                        return yyl_just_a_word(aTHX_ s, len, tmp, off,
-                                               orig_keyword, NULL, cv, gv, gvp,
-                                               rv2cv_op, FALSE, saw_infix_sigil);
+                        sv = NULL;
+                        return yyl_just_a_word(aTHX_ s, len, tmp, orig_keyword,
+                                               MAKE_CODE(FALSE), saw_infix_sigil);
 		    }
 		}
 		else {
@@ -8006,8 +8034,8 @@ yyl_try(pTHX_ char initial_state, char *s, STRLEN len,
 		    rv2cv_op->op_targ = off;
 		    cv = find_lexical_cv(off);
 		}
-                return yyl_just_a_word(aTHX_ s, len, tmp, off, orig_keyword, sv,
-                                       cv, gv, gvp, rv2cv_op, TRUE, saw_infix_sigil);
+                return yyl_just_a_word(aTHX_ s, len, tmp, orig_keyword,
+                                       MAKE_CODE(TRUE), saw_infix_sigil);
 	    }
 	    off = 0;
 	}
@@ -8033,8 +8061,8 @@ yyl_try(pTHX_ char initial_state, char *s, STRLEN len,
       reserved_word:
 	switch (tmp) {
 	default:			/* not a keyword */
-            return yyl_just_a_word(aTHX_ s, len, tmp, off, orig_keyword, sv, cv,
-                                   gv, gvp, rv2cv_op, FALSE, saw_infix_sigil);
+            return yyl_just_a_word(aTHX_ s, len, tmp, orig_keyword,
+                                   MAKE_CODE(FALSE), saw_infix_sigil);
 
 	case KEY___FILE__:
 	    FUN0OP(
@@ -8075,8 +8103,8 @@ yyl_try(pTHX_ char initial_state, char *s, STRLEN len,
 	case KEY_END:
 	    if (PL_expect == XSTATE)
 		return yyl_sub(aTHX_ PL_bufptr, tmp);
-            return yyl_just_a_word(aTHX_ s, len, tmp, off, orig_keyword, sv, cv,
-                                   gv, gvp, rv2cv_op, FALSE, saw_infix_sigil);
+            return yyl_just_a_word(aTHX_ s, len, tmp, orig_keyword,
+                                   MAKE_CODE(FALSE), saw_infix_sigil);
 
 	case_KEY_CORE:
 	    {
@@ -8088,9 +8116,8 @@ yyl_try(pTHX_ char initial_state, char *s, STRLEN len,
 		 || (!(tmp = keyword(PL_tokenbuf, len, 1)) && *s == '\''))
 		{
 		    Copy(PL_bufptr, PL_tokenbuf, olen, char);
-                    return yyl_just_a_word(aTHX_ d, olen, tmp, off, orig_keyword,
-                                           sv, cv, gv, gvp, rv2cv_op, FALSE,
-                                           saw_infix_sigil);
+                    return yyl_just_a_word(aTHX_ d, olen, tmp, orig_keyword,
+                                           MAKE_CODE(FALSE), saw_infix_sigil);
 		}
 		if (!tmp)
 		    Perl_croak(aTHX_ "CORE::%" UTF8f " is not a keyword",
@@ -8965,8 +8992,8 @@ yyl_try(pTHX_ char initial_state, char *s, STRLEN len,
 		Mop(OP_REPEAT);
 	    }
 	    check_uni();
-            return yyl_just_a_word(aTHX_ s, len, tmp, off, orig_keyword, sv, cv,
-                                   gv, gvp, rv2cv_op, FALSE, saw_infix_sigil);
+            return yyl_just_a_word(aTHX_ s, len, tmp, orig_keyword,
+                                   MAKE_CODE(FALSE), saw_infix_sigil);
 
 	case KEY_xor:
 	    if (!PL_lex_allbrackets && PL_lex_fakeeof >= LEX_FAKEEOF_LOWLOGIC)

--- a/toke.c
+++ b/toke.c
@@ -8410,8 +8410,8 @@ yyl_keylookup(pTHX_ char *s, GV *gv, bool bof, bool saw_infix_sigil)
     /* x::* is just a word, unless x is "CORE" */
     if (!anydelim && *s == ':' && s[1] == ':') {
         if (memEQs(PL_tokenbuf, len, "CORE"))
-            return yyl_key_core(aTHX_ s, len, tmp, orig_keyword, c, bof, saw_infix_sigil);
-        return yyl_just_a_word(aTHX_ s, len, 0, orig_keyword, c, saw_infix_sigil);
+            return yyl_key_core(aTHX_ s, len, tmp, 0, c, bof, saw_infix_sigil);
+        return yyl_just_a_word(aTHX_ s, len, 0, 0, c, saw_infix_sigil);
     }
 
     d = s;
@@ -8484,8 +8484,7 @@ yyl_keylookup(pTHX_ char *s, GV *gv, bool bof, bool saw_infix_sigil)
                 if (!c.gv) {
                     sv_free(c.sv);
                     c.sv = NULL;
-                    return yyl_just_a_word(aTHX_ s, len, tmp, orig_keyword,
-                                           c, saw_infix_sigil);
+                    return yyl_just_a_word(aTHX_ s, len, tmp, 0, c, saw_infix_sigil);
                 }
             }
             else {
@@ -8494,8 +8493,7 @@ yyl_keylookup(pTHX_ char *s, GV *gv, bool bof, bool saw_infix_sigil)
                 c.cv = find_lexical_cv(c.off);
             }
             c.lex = TRUE;
-            return yyl_just_a_word(aTHX_ s, len, tmp, orig_keyword,
-                                   c, saw_infix_sigil);
+            return yyl_just_a_word(aTHX_ s, len, tmp, 0, c, saw_infix_sigil);
         }
         c.off = 0;
     }

--- a/toke.c
+++ b/toke.c
@@ -5855,7 +5855,7 @@ yyl_subproto(pTHX_ char *s, CV *cv)
 }
 
 static int
-yyl_leftcurly(pTHX_ char *s, U8 formbrack)
+yyl_leftcurly(pTHX_ char *s, const U8 formbrack)
 {
     char *d;
     if (PL_lex_brackets > 100) {
@@ -6059,7 +6059,7 @@ yyl_leftcurly(pTHX_ char *s, U8 formbrack)
 }
 
 static int
-yyl_rightcurly(pTHX_ char *s, U8 formbrack)
+yyl_rightcurly(pTHX_ char *s, const U8 formbrack)
 {
     assert(s != PL_bufend);
     s++;

--- a/toke.c
+++ b/toke.c
@@ -7567,21 +7567,16 @@ yyl_try(pTHX_ char initial_state, char *s, STRLEN len,
 
       keylookup: {
 	bool anydelim;
-	bool lex;
+	bool lex = FALSE;
 	I32 tmp;
-	SV *sv;
-	CV *cv;
-	PADOFFSET off;
-	OP *rv2cv_op;
+	SV *sv = NULL;
+	CV *cv = NULL;
+	PADOFFSET off = 0;
+	OP *rv2cv_op = NULL;
 
-	lex = FALSE;
 	orig_keyword = 0;
-	off = 0;
-	sv = NULL;
-	cv = NULL;
 	gv = NULL;
 	gvp = NULL;
-	rv2cv_op = NULL;
 
 	PL_bufptr = s;
 	s = scan_word(s, PL_tokenbuf, sizeof PL_tokenbuf, FALSE, &len);


### PR DESCRIPTION
This branch continues the work merged in 5015bd0bb5ee7e0fa1ede1669bdfcd7bb5f10ebd, factoring code out of `Perl_yylex()` and its callees, in the hope of making the lexer easier to understand locally.

After these changes, the largest remaining piece of `Perl_yylex()` is just over 900 lines (down from originally >4100), and consists of a single switch statement, all of whose `case` groups are independent.

This branch also contains a note in perldelta that this major refactoring has taken place.