### PR TITLE
Cast STRLEN to int in 

### DIFF
--- a/gv.c
+++ b/gv.c
@@ -816,10 +816,10 @@ S_gv_fetchmeth_internal(pTHX_ HV* stash, SV* meth, const char* name, STRLEN len,
                         "While trying to resolve method call %.*s->%.*s()"
                         " can not locate package \"%"SVf"\" yet it is mentioned in @%.*s::ISA"
                          " (perhaps you forgot to load \"%"SVf"\"?)",
-                         hvnamelen, hvname,
-                         len, name,
+                         (int) hvnamelen, hvname,
+                         (int) len, name,
                         SVfARG(linear_sv),
-                         hvnamelen, hvname,
+                         (int) hvnamelen, hvname,
                          SVfARG(linear_sv));
                 }
             }


### PR DESCRIPTION
Fixes #17250

cast STRLEN to int

Fix warnings from recent change GH #17222
We could also consider casting it using '
x & PERL_INT_MAX'