### PR TITLE
enforce strict for barewords in multiconcat

### DIFF
--- a/op.c
+++ b/op.c
@@ -3118,6 +3118,8 @@ S_maybe_multiconcat(pTHX_ OP *o)
             && (SvPOK(sv) || SvIOK(sv))
             && (!SvGMAGICAL(sv))
         ) {
+            if (argop->op_private & OPpCONST_STRICT)
+                no_bareword_allowed(argop);
             argp++->p = sv;
             utf8   |= cBOOL(SvUTF8(sv));
             nconst++;

--- a/t/lib/strict/subs
+++ b/t/lib/strict/subs
@@ -475,3 +475,11 @@ my $y = !BARE2;
 EXPECT
 Bareword "BARE2" not allowed while "strict subs" in use at - line 3.
 Execution of - aborted due to compilation errors.
+########
+# NAME multiconcat and barewords gh #17254
+use strict;
+sub foo { "foo" }
+print foo() . SLASH . "bar";
+EXPECT
+Bareword "SLASH" not allowed while "strict subs" in use at - line 3.
+Execution of - aborted due to compilation errors.


### PR DESCRIPTION
gh #17254