### PR TITLE
Remove compiler  in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,8 @@ env:
         - CONFIGURE_ARGS='-DPERL_GLOBAL_STRUCT_PRIVATE'
         - CONFIGURE_ARGS='-Duseshrplib -Dusesitecustomize'
 
-# only use gcc on linux, and only use clang on osx for now
 matrix:
   fast_finish: true
-  exclude:
-  - compiler: clang
-    os: linux
-  - compiler: gcc
-    os: osx
 
 script:
   - ./Configure -des -Dusedevel -Uversiononly -Dcc="ccache $CC" $CONFIGURE_ARGS -Dprefix=$HOME/perl-blead -DDEBUGGING


### PR DESCRIPTION
Since `clang` was removed as a compiler option in the previous change to `.travis.yml`, no need to exclude Linux from using it.  Also, no need for the excludes for OS X since was removed.