### PR TITLE
Link to more useful section of perlop from readpipe

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -6272,7 +6272,7 @@ multi-line) string.  In list context, returns a list of lines
 C<$INPUT_RECORD_SEPARATOR> in L<English>)).
 This is the internal function implementing the C<qx/EXPR/>
 operator, but you can use it directly.  The C<qx/EXPR/>
-operator is discussed in more detail in L<perlop/"I/O Operators">.
+operator is discussed in more detail in L<perlop/"C<qx/I<STRING>/>">.
 If EXPR is omitted, uses L<C<$_>|perlvar/$_>.
 
 =item recv SOCKET,SCALAR,LENGTH,FLAGS


### PR DESCRIPTION
qx is only briefly mentioned in the "I/O Operators" section of perlop. It is better to link to the section where it is discussed in detail.