### PR TITLE
Smoke me/jkeenan/local variable warnings

### DIFF
--- a/hv.c
+++ b/hv.c
@@ -2396,17 +2396,17 @@ Perl_hv_name_set(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
 	if (iter->xhv_name_u.xhvnameu_name) {
 	    if(iter->xhv_name_count) {
 	      if(flags & HV_NAME_SETALL) {
-		HEK ** const name = HvAUX(hv)->xhv_name_u.xhvnameu_names;
-		HEK **hekp = name + (
+		HEK ** const this_name = HvAUX(hv)->xhv_name_u.xhvnameu_names;
+		HEK **hekp = this_name + (
 		    iter->xhv_name_count < 0
 		     ? -iter->xhv_name_count
 		     :  iter->xhv_name_count
 		   );
-		while(hekp-- > name+1) 
+		while(hekp-- > this_name+1) 
 		    unshare_hek_or_pvn(*hekp, 0, 0, 0);
 		/* The first elem may be null. */
-		if(*name) unshare_hek_or_pvn(*name, 0, 0, 0);
-		Safefree(name);
+		if(*this_name) unshare_hek_or_pvn(*this_name, 0, 0, 0);
+		Safefree(this_name);
                 iter = HvAUX(hv); /* may been realloced */
 		spot = &iter->xhv_name_u.xhvnameu_name;
 		iter->xhv_name_count = 0;

--- a/hv.c
+++ b/hv.c
@@ -2402,7 +2402,7 @@ Perl_hv_name_set(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
 		     ? -iter->xhv_name_count
 		     :  iter->xhv_name_count
 		   );
-		while(hekp-- > this_name+1) 
+		while(hekp-- > this_name+1)
 		    unshare_hek_or_pvn(*hekp, 0, 0, 0);
 		/* The first elem may be null. */
 		if(*this_name) unshare_hek_or_pvn(*this_name, 0, 0, 0);

--- a/mg.c
+++ b/mg.c
@@ -1933,8 +1933,8 @@ Perl_magic_methcall(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags,
 	va_start(args, argc);
 
 	do {
-	    SV *const sv = va_arg(args, SV *);
-	    PUSHs(sv);
+	    SV *const this_sv = va_arg(args, SV *);
+	    PUSHs(this_sv);
 	} while (--argc);
 
 	va_end(args);

--- a/mro_core.c
+++ b/mro_core.c
@@ -859,15 +859,15 @@ Perl_mro_package_moved(pTHX_ HV * const stash, HV * const oldstash,
        mro_isa_changed_in on each. */
     hv_iterinit(stashes);
     while((iter = hv_iternext(stashes))) {
-	HV * const stash = *(HV **)HEK_KEY(HeKEY_hek(iter));
-	if(HvENAME(stash)) {
+	HV * const this_stash = *(HV **)HEK_KEY(HeKEY_hek(iter));
+	if(HvENAME(this_stash)) {
 	    /* We have to restore the original meta->isa (that
 	       mro_gather_and_rename set aside for us) this way, in case
 	       one class in this list is a superclass of a another class
 	       that we have already encountered. In such a case, meta->isa
 	       will have been overwritten without old entries being deleted
 	       from PL_isarev. */
-	    struct mro_meta * const meta = HvMROMETA(stash);
+	    struct mro_meta * const meta = HvMROMETA(this_stash);
 	    if(meta->isa != (HV *)HeVAL(iter)){
 		SvREFCNT_dec(meta->isa);
 		meta->isa
@@ -876,7 +876,7 @@ Perl_mro_package_moved(pTHX_ HV * const stash, HV * const oldstash,
 		    : (HV *)HeVAL(iter);
 		HeVAL(iter) = NULL; /* We donated our reference count. */
 	    }
-	    mro_isa_changed_in(stash);
+	    mro_isa_changed_in(this_stash);
 	}
     }
 }

--- a/sv.c
+++ b/sv.c
@@ -12188,15 +12188,15 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
             /* the asterisk specified a width */
             {
                 int i = 0;
-                SV *sv = NULL;
+                SV *this_sv = NULL;
                 if (args)
                     i = va_arg(*args, int);
                 else {
                     ix = ix ? ix - 1 : svix++;
-                    sv = (ix < sv_count) ? svargs[ix]
+                    this_sv = (ix < sv_count) ? svargs[ix]
                                       : (arg_missing = TRUE, (SV*)NULL);
                 }
-                width = S_sprintf_arg_num_val(aTHX_ args, i, sv, &left);
+                width = S_sprintf_arg_num_val(aTHX_ args, i, this_sv, &left);
             }
         }
 	else if (*q == 'v') {

--- a/sv.c
+++ b/sv.c
@@ -12243,17 +12243,17 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
 
                 {
                     int i = 0;
-                    SV *sv = NULL;
+                    SV *this_sv = NULL;
                     bool neg = FALSE;
 
                     if (args)
                         i = va_arg(*args, int);
                     else {
                         ix = ix ? ix - 1 : svix++;
-                        sv = (ix < sv_count) ? svargs[ix]
+                        this_sv = (ix < sv_count) ? svargs[ix]
                                           : (arg_missing = TRUE, (SV*)NULL);
                     }
-                    precis = S_sprintf_arg_num_val(aTHX_ args, i, sv, &neg);
+                    precis = S_sprintf_arg_num_val(aTHX_ args, i, this_sv, &neg);
                     has_precis = !neg;
                     /* ignore negative precision */
                     if (!has_precis)

--- a/sv.c
+++ b/sv.c
@@ -12188,15 +12188,15 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
             /* the asterisk specified a width */
             {
                 int i = 0;
-                SV *this_sv = NULL;
+                SV *width_sv = NULL;
                 if (args)
                     i = va_arg(*args, int);
                 else {
                     ix = ix ? ix - 1 : svix++;
-                    this_sv = (ix < sv_count) ? svargs[ix]
+                    width_sv = (ix < sv_count) ? svargs[ix]
                                       : (arg_missing = TRUE, (SV*)NULL);
                 }
-                width = S_sprintf_arg_num_val(aTHX_ args, i, this_sv, &left);
+                width = S_sprintf_arg_num_val(aTHX_ args, i, width_sv, &left);
             }
         }
 	else if (*q == 'v') {
@@ -12243,17 +12243,17 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
 
                 {
                     int i = 0;
-                    SV *this_sv = NULL;
+                    SV *width_sv = NULL;
                     bool neg = FALSE;
 
                     if (args)
                         i = va_arg(*args, int);
                     else {
                         ix = ix ? ix - 1 : svix++;
-                        this_sv = (ix < sv_count) ? svargs[ix]
+                        width_sv = (ix < sv_count) ? svargs[ix]
                                           : (arg_missing = TRUE, (SV*)NULL);
                     }
-                    precis = S_sprintf_arg_num_val(aTHX_ args, i, this_sv, &neg);
+                    precis = S_sprintf_arg_num_val(aTHX_ args, i, width_sv, &neg);
                     has_precis = !neg;
                     /* ignore negative precision */
                     if (!has_precis)

--- a/toke.c
+++ b/toke.c
@@ -9711,11 +9711,11 @@ S_parse_ident(pTHX_ char **s, char **d, char * const e, int allow_package,
     }
     if (UNLIKELY(tick_warn && saw_tick && PL_lex_state == LEX_INTERPNORMAL
               && !PL_lex_brackets && ckWARN(WARN_SYNTAX))) {
-        char *d;
+        char *this_d;
 	char *d2;
-        Newx(d, *s - olds + saw_tick + 2, char); /* +2 for $# */
-        d2 = d;
-        SAVEFREEPV(d);
+        Newx(this_d, *s - olds + saw_tick + 2, char); /* +2 for $# */
+        d2 = this_d;
+        SAVEFREEPV(this_d);
         Perl_warner(aTHX_ packWARN(WARN_SYNTAX),
                          "Old package separator used in string");
         if (olds[-1] == '#')
@@ -9731,7 +9731,7 @@ S_parse_ident(pTHX_ char **s, char **d, char * const e, int allow_package,
         }
         Perl_warner(aTHX_ packWARN(WARN_SYNTAX),
                          "\t(Did you mean \"%" UTF8f "\" instead?)\n",
-                          UTF8fARG(is_utf8, d2-d, d));
+                          UTF8fARG(is_utf8, d2-this_d, this_d));
     }
     return;
 }

--- a/utf8.c
+++ b/utf8.c
@@ -3881,8 +3881,8 @@ Perl__to_utf8_fold_flags(pTHX_ const U8 *p,
 	    /* Look at every character in the result; if any cross the
 	    * boundary, the whole thing is disallowed */
 	    U8* s = ustrp;
-	    U8* e = ustrp + *lenp;
-	    while (s < e) {
+	    U8* this_e = ustrp + *lenp;
+	    while (s < this_e) {
 		if (isASCII(*s)) {
 		    /* Crossed, have to return the original */
 		    original = valid_utf8_to_uvchr(p, lenp);

--- a/utf8.c
+++ b/utf8.c
@@ -3881,8 +3881,8 @@ Perl__to_utf8_fold_flags(pTHX_ const U8 *p,
 	    /* Look at every character in the result; if any cross the
 	    * boundary, the whole thing is disallowed */
 	    U8* s = ustrp;
-	    U8* this_e = ustrp + *lenp;
-	    while (s < this_e) {
+	    U8* send = ustrp + *lenp;
+	    while (s < send) {
 		if (isASCII(*s)) {
 		    /* Crossed, have to return the original */
 		    original = valid_utf8_to_uvchr(p, lenp);

--- a/util.c
+++ b/util.c
@@ -2377,23 +2377,23 @@ Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
     /* If we managed to get status pipe check for exec fail */
     if (did_pipes && pid > 0) {
 	int errkid;
-	unsigned n = 0;
+	unsigned this_n = 0;
 
-	while (n < sizeof(int)) {
+	while (this_n < sizeof(int)) {
             const SSize_t n1 = PerlLIO_read(pp[0],
-			      (void*)(((char*)&errkid)+n),
-			      (sizeof(int)) - n);
+			      (void*)(((char*)&errkid)+this_n),
+			      (sizeof(int)) - this_n);
 	    if (n1 <= 0)
 		break;
-	    n += n1;
+	    this_n += n1;
 	}
 	PerlLIO_close(pp[0]);
 	did_pipes = 0;
-	if (n) {			/* Error */
+	if (this_n) {			/* Error */
 	    int pid2, status;
 	    PerlLIO_close(p[This]);
-	    if (n != sizeof(int))
-		Perl_croak(aTHX_ "panic: kid popen errno read, n=%u", n);
+	    if (this_n != sizeof(int))
+		Perl_croak(aTHX_ "panic: kid popen errno read, n=%u", this_n);
 	    do {
 		pid2 = wait4pid(pid, &status, 0);
 	    } while (pid2 == -1 && errno == EINTR);

--- a/util.c
+++ b/util.c
@@ -2377,23 +2377,23 @@ Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
     /* If we managed to get status pipe check for exec fail */
     if (did_pipes && pid > 0) {
 	int errkid;
-	unsigned this_n = 0;
+	unsigned read_total = 0;
 
-	while (this_n < sizeof(int)) {
+	while (read_total < sizeof(int)) {
             const SSize_t n1 = PerlLIO_read(pp[0],
-			      (void*)(((char*)&errkid)+this_n),
-			      (sizeof(int)) - this_n);
+			      (void*)(((char*)&errkid)+read_total),
+			      (sizeof(int)) - read_total);
 	    if (n1 <= 0)
 		break;
-	    this_n += n1;
+	    read_total += n1;
 	}
 	PerlLIO_close(pp[0]);
 	did_pipes = 0;
-	if (this_n) {			/* Error */
+	if (read_total) {			/* Error */
 	    int pid2, status;
 	    PerlLIO_close(p[This]);
-	    if (this_n != sizeof(int))
-		Perl_croak(aTHX_ "panic: kid popen errno read, n=%u", this_n);
+	    if (read_total != sizeof(int))
+		Perl_croak(aTHX_ "panic: kid popen errno read, n=%u", read_total);
 	    do {
 		pid2 = wait4pid(pid, &status, 0);
 	    } while (pid2 == -1 && errno == EINTR);


### PR DESCRIPTION
[lgtm](https://lgtm.com/) is a code analysis platform, free for open source projects, which we have used to identify weaknesses in the Perl 5 source code.  Its analysis categorizes problems into three categories:  errors, warnings and recommendations.  Periodically I take a look at these [reports](https://lgtm.com/projects/g/Perl/perl5/) and have a go at fixing them.

One problem that falls into the recommendations category is _[Declaration hides parameter](https://lgtm.com/rules/2156240606/)_ , whose rule states:
`A local variable hides a parameter. This may be confusing. Consider renaming one of them.
`
As of Nov 07, there were 12 instances of this in our *.c files (see attachment).  This pull request fixes about 8 of those instances.  These have been smoke-tested in the smoke-me/jkeenan/local-variable-warnings branch; no test failures have been observed which are attributable to the changes made in the branch.

Please review and merge to blead.  I believe lgtm scans our source code on a weekly basis, so we'll be able to get feedback as to the elimination of these problems fairly quickly.

Thank you very much.
Jim Keenan
[lgtm.recommendations.2019-11-07.json.txt](https://github.com/Perl/perl5/files/3827361/lgtm.recommendations.2019-11-07.json.txt)
