### PR TITLE
t/op/fork.t: fix skip condition

### DIFF
--- a/t/op/fork.t
+++ b/t/op/fork.t
@@ -10,7 +10,7 @@ BEGIN {
     skip_all('no fork')
 	unless ($Config::Config{d_fork} or $Config::Config{d_pseudofork});
     skip_all('no fork')
-        if $^O eq 'MSWin32' && is_miniperl;
+        if $^O eq 'MSWin32' && is_miniperl();
 }
 
 $|=1;


### PR DESCRIPTION
`is_miniperl` was being parsed as a bareword so the condition was
always true on Windows.