### PR TITLE
clean up quadmath_format_*() functions

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3310,8 +3310,8 @@ XEopxR	|STRLEN *|new_warnings_bitfield|NULLOK STRLEN *buffer \
 AMpTdf	|int	|my_snprintf	|NN char *buffer|const Size_t len|NN const char *format|...
 AMpTd	|int	|my_vsnprintf	|NN char *buffer|const Size_t len|NN const char *format|va_list ap
 #ifdef USE_QUADMATH
-ApTd	|const char*	|quadmath_format_single|NN const char* format
-ApTd	|bool|quadmath_format_needed|NN const char* format
+pTd	|bool	|quadmath_format_valid|NN const char* format
+pTd	|bool|quadmath_format_needed|NN const char* format
 #endif
 
 : Used in mg.c, sv.c

--- a/embed.h
+++ b/embed.h
@@ -905,10 +905,6 @@
 #define PerlIO_unread(a,b,c)	Perl_PerlIO_unread(aTHX_ a,b,c)
 #define PerlIO_write(a,b,c)	Perl_PerlIO_write(aTHX_ a,b,c)
 #endif
-#if defined(USE_QUADMATH)
-#define quadmath_format_needed	Perl_quadmath_format_needed
-#define quadmath_format_single	Perl_quadmath_format_single
-#endif
 #if defined(WIN32) || defined(__SYMBIAN32__) || defined(VMS)
 #define do_aspawn(a,b,c)	Perl_do_aspawn(aTHX_ a,b,c)
 #define do_spawn(a)		Perl_do_spawn(aTHX_ a)
@@ -1966,6 +1962,10 @@
 #  if defined(USE_PERLIO)
 #define PerlIO_restore_errno(a)	Perl_PerlIO_restore_errno(aTHX_ a)
 #define PerlIO_save_errno(a)	Perl_PerlIO_save_errno(aTHX_ a)
+#  endif
+#  if defined(USE_QUADMATH)
+#define quadmath_format_needed	Perl_quadmath_format_needed
+#define quadmath_format_valid	Perl_quadmath_format_valid
 #  endif
 #  if defined(_MSC_VER)
 #define magic_regdatum_set(a,b)	Perl_magic_regdatum_set(aTHX_ a,b)

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -881,15 +881,12 @@ PP(pp_formline)
                 arg &= ~(FORM_NUM_POINT|FORM_NUM_BLANK);
 #ifdef USE_QUADMATH
                 {
-                    const char* qfmt = quadmath_format_single(fmt);
                     int len;
-                    if (!qfmt)
+                    if (!quadmath_format_valid(fmt))
                         Perl_croak_nocontext("panic: quadmath invalid format \"%s\"", fmt);
-                    len = quadmath_snprintf(t, max, qfmt, (int) fieldsize, (int) arg, value);
+                    len = quadmath_snprintf(t, max, fmt, (int) fieldsize, (int) arg, value);
                     if (len == -1)
-                        Perl_croak_nocontext("panic: quadmath_snprintf failed, format \"%s\"", qfmt);
-                    if (qfmt != fmt)
-                        Safefree(fmt);
+                        Perl_croak_nocontext("panic: quadmath_snprintf failed, format \"%s\"", fmt);
                 }
 #else
                 /* we generate fmt ourselves so it is safe */

--- a/proto.h
+++ b/proto.h
@@ -6670,8 +6670,8 @@ PERL_CALLCONV SSize_t	Perl_PerlIO_write(pTHX_ PerlIO *f, const void *vbuf, Size_
 PERL_CALLCONV bool	Perl_quadmath_format_needed(const char* format);
 #define PERL_ARGS_ASSERT_QUADMATH_FORMAT_NEEDED	\
 	assert(format)
-PERL_CALLCONV const char*	Perl_quadmath_format_single(const char* format);
-#define PERL_ARGS_ASSERT_QUADMATH_FORMAT_SINGLE	\
+PERL_CALLCONV bool	Perl_quadmath_format_valid(const char* format);
+#define PERL_ARGS_ASSERT_QUADMATH_FORMAT_VALID	\
 	assert(format)
 #endif
 #if defined(WIN32)

--- a/sv.c
+++ b/sv.c
@@ -13195,20 +13195,15 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                 GCC_DIAG_IGNORE_STMT(-Wformat-nonliteral);
 #ifdef USE_QUADMATH
                 {
-                    const char* qfmt = quadmath_format_single(ptr);
-                    if (!qfmt)
+                    if (!quadmath_format_valid(ptr))
                         Perl_croak_nocontext("panic: quadmath invalid format \"%s\"", ptr);
                     WITH_LC_NUMERIC_SET_TO_NEEDED_IN(in_lc_numeric,
                         elen = quadmath_snprintf(PL_efloatbuf, PL_efloatsize,
-                                                 qfmt, nv);
+                                                 ptr, nv);
                     );
                     if ((IV)elen == -1) {
-                        if (qfmt != ptr)
-                            SAVEFREEPV(qfmt);
-                        Perl_croak_nocontext("panic: quadmath_snprintf failed, format \"%s\"", qfmt);
+                        Perl_croak_nocontext("panic: quadmath_snprintf failed, format \"%s\"", ptr);
                     }
-                    if (qfmt != ptr)
-                        Safefree(qfmt);
                 }
 #elif defined(HAS_LONG_DOUBLE)
                 WITH_LC_NUMERIC_SET_TO_NEEDED_IN(in_lc_numeric,


### PR DESCRIPTION
This includes:

- remove them from the API

- simplify quadmath_format_single()'s interface, and rename it
  to match the new interface

fixes #17288