### PR TITLE
Adapt Configure to GCC version 10

### DIFF
--- a/Configure
+++ b/Configure
@@ -4701,7 +4701,7 @@ else
 fi
 $rm -f try try.*
 case "$gccversion" in
-1*) cpp=`./loc gcc-cpp $cpp $pth` ;;
+1.*) cpp=`./loc gcc-cpp $cpp $pth` ;;
 esac
 case "$gccversion" in
 '') gccosandvers='' ;;
@@ -4741,7 +4741,7 @@ esac
 # gcc 3.* complain about adding -Idirectories that they already know about,
 # so we will take those off from locincpth.
 case "$gccversion" in
-3*)
+3.*)
     echo "main(){}">try.c
     for incdir in $locincpth; do
        warn=`$cc $ccflags -I$incdir -c try.c 2>&1 | \
@@ -5467,13 +5467,13 @@ fi
 case "$hint" in
 default|recommended)
 	case "$gccversion" in
-	1*) dflt="$dflt -fpcc-struct-return" ;;
+	1.*) dflt="$dflt -fpcc-struct-return" ;;
 	esac
 	case "$optimize:$DEBUGGING" in
 	*-g*:old) dflt="$dflt -DDEBUGGING";;
 	esac
 	case "$gccversion" in
-	2*) if $test -d /etc/conf/kconfig.d &&
+	2.*) if $test -d /etc/conf/kconfig.d &&
 			$contains _POSIX_VERSION $usrinc/sys/unistd.h >/dev/null 2>&1
 		then
 			# Interactive Systems (ISC) POSIX mode.
@@ -5482,7 +5482,7 @@ default|recommended)
 		;;
 	esac
 	case "$gccversion" in
-	1*) ;;
+	1.*) ;;
 	2.[0-8]*) ;;
 	?*)	set strict-aliasing -fno-strict-aliasing
 		eval $checkccflag
@@ -5600,7 +5600,7 @@ case "$cppflags" in
     ;;
 esac
 case "$gccversion" in
-1*) cppflags="$cppflags -D__GNUC__"
+1.*) cppflags="$cppflags -D__GNUC__"
 esac
 case "$mips_type" in
 '');;
@@ -23103,7 +23103,7 @@ fi
 
 : add -D_FORTIFY_SOURCE if feasible and not already there
 case "$gccversion" in
-[456789].*)	case "$optimize$ccflags" in
+[456789].*|[1-9][0-9]*)	case "$optimize$ccflags" in
 	*-O*)	case "$ccflags$cppsymbols" in
 		*_FORTIFY_SOURCE=*) # Don't add it again.
 			echo "You seem to have -D_FORTIFY_SOURCE already, not adding it." >&4

--- a/cflags.SH
+++ b/cflags.SH
@@ -156,7 +156,7 @@ esac
 
 case "$gccversion" in
 '') ;;
-[12]*) ;; # gcc versions 1 (gasp!) and 2 are not good for this.
+[12].*) ;; # gcc versions 1 (gasp!) and 2 are not good for this.
 Intel*) ;; # # Is that you, Intel C++?
 #
 # NOTE 1: the -std=c89 without -pedantic is a bit pointless.


### PR DESCRIPTION
I got a notice from Jeff Law <law@redhat.com>:

    Your particular package fails its testsuite. This was ultimately
    tracked down to a Configure problem. The perl configure script treated
    gcc-10 as gcc-1 and turned on -fpcc-struct-return. This is an ABI
    changing flag and caused Perl to not be able to interact properly with
    the dbm libraries on the system leading to a segfault.

His proposed patch corrected only this one instance of the version
mismatch. Reading the Configure script revealed more issues. This
patch fixes all of them I found.

Please note I do not have GCC 10 available, I tested it by faking the version
with:

~~~~
--- a/Configure
+++ b/Configure
@@ -4672,7 +4672,7 @@ $cat >try.c <<EOM
 int main() {
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER)
 #ifdef __VERSION__
-       printf("%s\n", __VERSION__);
+       printf("%s\n", "10.0.0");
 #else
        printf("%s\n", "1");
 #endif
~~~~