### PR TITLE
Add missing <wchar.h> includes to fix c++ build on Cygwin

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1265,6 +1265,12 @@ use File::Glob qw(:case);
         'EXCLUDED'     => [
             qr{^ex/},
         ],
+        # https://rt.cpan.org/Ticket/Display.html?id=127837
+        'CUSTOMIZED'   => [
+            qw( File.pm
+                File.xs
+                ),
+        ],
     },
 
     'XSLoader' => {

--- a/cpan/Win32API-File/File.pm
+++ b/cpan/Win32API-File/File.pm
@@ -10,7 +10,7 @@ use Fcntl qw( O_RDONLY O_RDWR O_WRONLY O_APPEND O_BINARY O_TEXT );
 use vars qw( $VERSION @ISA );
 use vars qw( @EXPORT @EXPORT_OK @EXPORT_FAIL %EXPORT_TAGS );
 
-$VERSION= '0.1203';
+$VERSION= '0.1203_01';
 
 use base qw( Exporter DynaLoader Tie::Handle IO::File );
 

--- a/cpan/Win32API-File/File.xs
+++ b/cpan/Win32API-File/File.xs
@@ -14,6 +14,7 @@
 #endif
 
 #define  WIN32_LEAN_AND_MEAN	/* Tell windows.h to skip much */
+#include <wchar.h>
 #include <windows.h>
 #include <winioctl.h>
 

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -21,6 +21,8 @@ Pod::Checker cpan/Pod-Checker/t/pod/testcmp.pl a0cd5c8eca775c7753f4464eee96fa916
 Pod::Checker cpan/Pod-Checker/t/pod/testpchk.pl b2072c7f4379fd050e15424175d7cac5facf5b3b
 Pod::Perldoc cpan/Pod-Perldoc/lib/Pod/Perldoc.pm 582be34c077c9ff44d99914724a0cc2140bcd48c
 Pod::Usage cpan/Pod-Usage/t/pod/testp2pt.pl d43ea8391bd95aefdb710ab2947771155a88d424
+Win32API::File cpan/Win32API-File/File.pm 8fd212857f821cb26648878b96e57f13bf21b99e
+Win32API::File cpan/Win32API-File/File.xs beb870fed4490d2faa547b4a8576b8d64d1d27c5
 autodie cpan/autodie/lib/autodie/exception.pm b99e4e35a9ed36de94d54437888822ced4936207
 autodie cpan/autodie/lib/autodie/hints.pm e1998fec61fb4e82fe46585bd82c73200be6f262
 autodie cpan/autodie/t/exceptions.t ad315a208f875e06b0964012ce8d65daa438c036

--- a/win32/perlhost.h
+++ b/win32/perlhost.h
@@ -13,6 +13,7 @@
 #define ___PerlHost_H___
 
 #include <signal.h>
+#include <wchar.h>
 #include "iperlsys.h"
 #include "vmem.h"
 #include "vdir.h"

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -64,6 +64,7 @@
 #include <float.h>
 #include <time.h>
 #include <sys/utime.h>
+#include <wchar.h>
 
 #ifdef __GNUC__
 /* Mingw32 defaults to globing command line

--- a/win32/win32sck.c
+++ b/win32/win32sck.c
@@ -15,6 +15,7 @@
 #ifdef __GNUC__
 #define Win32_Winsock
 #endif
+#include <wchar.h>
 #include <windows.h>
 #include <ws2spi.h>
 


### PR DESCRIPTION
The `Win32API::File` is from an upstream bug report: https://rt.cpan.org/Public/Bug/Display.html?id=127837