### PR TITLE
Initial Windows Github action, adapted from skaji

### DIFF
--- a/.github/workflows/smoke-windows-cygwin.yml
+++ b/.github/workflows/smoke-windows-cygwin.yml
@@ -1,0 +1,44 @@
+name: smoke-windows-cygwin-amd64
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  perl:
+
+    runs-on: windows-latest
+
+    steps:
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@master
+        with:
+            fetch-depth: 10
+      - name: Set up Cygwin
+        run: |
+          choco install cygwin cyg-get
+          cyg-get cygwin-devel gcc-core gcc gcc-g++ make cygwin64-w32api-headers binutils libtool git ccache
+      - name: Find out environment
+        shell: cmd
+        run: |
+          dir c:\tools\cygwin
+          path
+      - name: Configure
+        shell: cmd
+        run: |
+            path c:\tools\cygwin\bin;c:\tools\cygwin\usr\bin
+            c:\tools\cygwin\bin\sh.exe ./Configure -des -Dusedevel -Dissymlink='test -h' -Doptimize=-g
+      - name: Build
+        shell: cmd
+        run: |
+            path c:\tools\cygwin\bin;c:\tools\cygwin\usr\bin
+            make -j2
+      - name: Run Tests
+        shell: cmd
+        run: |
+            path c:\tools\cygwin\bin;c:\tools\cygwin\usr\bin
+            make -j2 test

--- a/.github/workflows/smoke-windows-mingw64.yml
+++ b/.github/workflows/smoke-windows-mingw64.yml
@@ -1,0 +1,39 @@
+name: smoke-windows-mingw64
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  perl:
+
+    runs-on: windows-latest
+
+    steps:
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@master
+        with:
+            fetch-depth: 10
+      - name: Set up Perl build environment
+        run: |
+          choco install strawberryperl
+          echo "##[add-path]C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin"
+      - name: Host perl -V
+        run: perl -V
+      - name: gcc --version
+        run: gcc --version
+      - name: Build
+        shell: cmd
+        run: |
+            cd win32
+            gmake -f GNUMakefile -j4
+      - name: Run Tests
+        shell: cmd
+        run: |
+            cd win32
+            set HARNESS_OPTIONS=j4
+            gmake -f GNUMakefile test

--- a/.github/workflows/smoke-windows-msvc100.yml
+++ b/.github/workflows/smoke-windows-msvc100.yml
@@ -1,0 +1,39 @@
+name: smoke-windows-msvc100-x86
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  perl:
+
+    runs-on: windows-latest
+
+    steps:
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@master
+        with:
+            fetch-depth: 10
+      - name: Set up MSVC100
+        run: |
+          choco install vcexpress2010
+      - name: Help
+        shell: cmd
+        run: |
+            call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" /help
+      - name: Build
+        shell: cmd
+        run: |
+            call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
+            cd win32
+            nmake CCTYPE=MSVC100FREE WIN64=undef
+      - name: Run Tests
+        shell: cmd
+        run: |
+            call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
+            cd win32
+            nmake CCTYPE=MSVC100FREE WIN64=undef test

--- a/.github/workflows/smoke-windows-msvc142.yml
+++ b/.github/workflows/smoke-windows-msvc142.yml
@@ -1,0 +1,53 @@
+name: smoke-windows-msvc142-amd64
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  perl:
+
+    runs-on: windows-latest
+
+    steps:
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@master
+        with:
+            fetch-depth: 10
+      #- name: Install clcache
+      #  shell: cmd
+      #  run: |
+      #    curl -L https://github.com/frerich/clcache/releases/download/v4.2.0/clcache.4.2.0.nupkg --output clcache.4.2.0.nupkg
+      #    choco install clcache --source=.
+      #- name: find home directory
+      #  shell: cmd
+      #  run: |
+      #    set
+      #- name: C compiler cache
+      #  id: clcache
+      #  uses: actions/cache@v1
+      #  with:
+      #    path: $HOME\clcache
+      #    key: ${{ runner.os }}-x64
+      #- name: Set up Perl build environment
+      #  # pushd "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+      #  # for /f "delims=" %%x in ('.\vswhere.exe -latest -property InstallationPath') do set VSPATH=%%x
+      #  # popd
+      #  # call "%VSPATH%\VC\Auxiliary\Build\vcvarsall.bat" x64
+      #  #run: |
+      - name: Build
+        shell: cmd
+        run: |
+            call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+            cd win32
+            nmake CCTYPE=MSVC142
+      - name: Run Tests
+        shell: cmd
+        run: |
+            call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+            cd win32
+            nmake CCTYPE=MSVC142 test


### PR DESCRIPTION
This supports

    * 64bit MSVC 2019 (MSVC142)
    * 64bit Mingw64 as supplied by Strawberry Perl
    * 64bit Cygwin gcc
    * 32bit MSVC 2010 (MSVC100FREE)

Characteristics

    * Only clone the repo 10 levels deep (we need only one?)
    * Parallel build on the one environment where it works (Cygwin)
    * Ready for clcache / ccache, but these need a 100% pass before
      Github saves the results to the cache

This was done with the moral and intellectual support from xenu, TonyC and BinGOs