### PR TITLE
More smoke test improvements

### DIFF
--- a/.github/workflows/smoke-macos-xcode11.yml
+++ b/.github/workflows/smoke-macos-xcode11.yml
@@ -1,0 +1,32 @@
+name: smoke-macos-xcode11
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+env:
+    PERL_SKIP_TTY_TEST: 1
+
+jobs:
+  perl:
+
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@master
+        with:
+            fetch-depth: 10
+      - name: Configure
+        run: |
+            export SDK=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk
+            sh ./Configure -des -Dusedevel
+      - name: Build
+        run: |
+            make -j2
+      - name: Run Tests
+        run: |
+            make -j2 test

--- a/.github/workflows/smoke-windows-cygwin.yml
+++ b/.github/workflows/smoke-windows-cygwin.yml
@@ -27,6 +27,11 @@ jobs:
         run: |
           dir c:\tools\cygwin
           path
+      - name: Check out again, using Cygwin git, to reset file permissions
+        shell: cmd
+        run: |
+            path c:\tools\cygwin\bin;c:\tools\cygwin\usr\bin
+            git checkout --force
       - name: Configure
         shell: cmd
         run: |

--- a/.github/workflows/smoke-windows-mingw64.yml
+++ b/.github/workflows/smoke-windows-mingw64.yml
@@ -39,4 +39,5 @@ jobs:
         run: |
             cd win32
             set HARNESS_OPTIONS=j2
+            set CCHOME=C:\strawberry\c\bin
             gmake -f GNUMakefile test

--- a/.github/workflows/smoke-windows-mingw64.yml
+++ b/.github/workflows/smoke-windows-mingw64.yml
@@ -33,10 +33,10 @@ jobs:
         shell: cmd
         run: |
             cd win32
-            gmake -f GNUMakefile -j4
+            gmake -f GNUMakefile -j2
       - name: Run Tests
         shell: cmd
         run: |
             cd win32
-            set HARNESS_OPTIONS=j4
+            set HARNESS_OPTIONS=j2
             gmake -f GNUMakefile test

--- a/.github/workflows/smoke-windows-mingw64.yml
+++ b/.github/workflows/smoke-windows-mingw64.yml
@@ -8,6 +8,9 @@ on:
       - '*'
   pull_request:
 
+env:
+    PERL_SKIP_TTY_TEST: 1
+
 jobs:
   perl:
 

--- a/.github/workflows/smoke-windows-msvc100.yml
+++ b/.github/workflows/smoke-windows-msvc100.yml
@@ -33,10 +33,10 @@ jobs:
         run: |
             call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
             cd win32
-            nmake CCTYPE=MSVC100FREE WIN64=undef
+            nmake CCTYPE=MSVC100 WIN64=undef
       - name: Run Tests
         shell: cmd
         run: |
             call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
             cd win32
-            nmake CCTYPE=MSVC100FREE WIN64=undef test
+            nmake CCTYPE=MSVC100 WIN64=undef test

--- a/.github/workflows/smoke-windows-msvc100.yml
+++ b/.github/workflows/smoke-windows-msvc100.yml
@@ -8,6 +8,9 @@ on:
       - '*'
   pull_request:
 
+env:
+    PERL_SKIP_TTY_TEST: 1
+
 jobs:
   perl:
 

--- a/.github/workflows/smoke-windows-msvc142.yml
+++ b/.github/workflows/smoke-windows-msvc142.yml
@@ -8,6 +8,9 @@ on:
       - '*'
   pull_request:
 
+env:
+    PERL_SKIP_TTY_TEST: 1
+
 jobs:
   perl:
 


### PR DESCRIPTION
These two patches fix some smoke tests and bring the MSVC 2019 smoke test to green. Also, OSX added.

Mingw still fails `op/taint.t` , because the test cleans out `$ENV{PATH}` and the required DLLs for Perl still to load live somewhere in there. Diagnosed by @xenu , a fix would likely involve either finding the relevant DLLs in '$ENV{PATH}` or by iteratively finding the relevant components in `$ENV{PATH}` and untainting them there.