### PR TITLE
Filter::Simple: fix and sanity check for executable_no_comments

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3593,6 +3593,7 @@ dist/Filter-Simple/t/filter.t					See if Filter::Simple works
 dist/Filter-Simple/t/filter_only.t				See if Filter::Simple works
 dist/Filter-Simple/t/import.t					See if Filter::Simple works
 dist/Filter-Simple/t/lib/Filter/Simple/CodeNoComments.pm	Helper file for Filter::Simple tests
+dist/Filter-Simple/t/lib/Filter/Simple/ExeNoComments.pm		Helper file for Filter::Simple tests
 dist/Filter-Simple/t/lib/Filter/Simple/ExportTest.pm		Helper file for Filter::Simple tests
 dist/Filter-Simple/t/lib/Filter/Simple/FilterOnlyTest.pm	Helper file for Filter::Simple tests
 dist/Filter-Simple/t/lib/Filter/Simple/FilterTest.pm		Helper file for Filter::Simple tests

--- a/dist/Filter-Simple/lib/Filter/Simple.pm
+++ b/dist/Filter-Simple/lib/Filter/Simple.pm
@@ -2,7 +2,7 @@ package Filter::Simple;
 
 use Text::Balanced ':ALL';
 
-our $VERSION = '0.95';
+our $VERSION = '0.96';
 
 use Filter::Util::Call;
 use Carp;
@@ -70,6 +70,7 @@ my %extractor_for = (
 my %selector_for = (
     all   => sub { my ($t)=@_; sub{ $_=$$_; $t->(@_); $_} },
     executable=> sub { my ($t)=@_; sub{ref() ? $_=$$_ : $t->(@_); $_} }, 
+    executable_no_comments=> sub { my ($t)=@_; sub{ref() ? $_=$$_ : $t->(@_); $_} },
     quotelike => sub { my ($t)=@_; sub{ref() && do{$_=$$_; $t->(@_)}; $_} },
     regex     => sub { my ($t)=@_;
                sub{ref() or return $_;

--- a/dist/Filter-Simple/t/filter_only.t
+++ b/dist/Filter-Simple/t/filter_only.t
@@ -4,7 +4,7 @@ BEGIN {
 
 use Filter::Simple::FilterOnlyTest qr/not ok/ => "ok", 
                                    "bad" => "ok", fail => "die";
-print "1..9\n";
+print "1..11\n";
 
 sub fail { print "ok ", $_[0], "\n" }
 sub ok { print "ok ", $_[0], "\n" }
@@ -41,3 +41,20 @@ print "ok 8\n";
 
 print "not " unless "bad" =~ /bad/;
 print "ok 9\n";
+
+use Filter::Simple::ExeNoComments;
+
+=for us
+
+shromplex
+
+=cut
+
+# shromplex
+
+# test the difference from code*
+my $x = "ABC";
+
+print $x eq "TEST" ? "" : "not ", "ok 10 # check strings processed\n";
+
+print "ok 11 # executable_no_comments\n";

--- a/dist/Filter-Simple/t/lib/Filter/Simple/ExeNoComments.pm
+++ b/dist/Filter-Simple/t/lib/Filter/Simple/ExeNoComments.pm
@@ -1,0 +1,11 @@
+package Filter::Simple::ExeNoComments;
+
+use Filter::Simple;
+
+FILTER_ONLY
+  executable_no_comments => sub {
+            $_ =~ /shromplex/ and die "We wants no shromplexes!";
+            s/ABC/TEST/g;
+	};
+
+1;


### PR DESCRIPTION
doesn't try to fix the errors and warnings being eaten, which I couldn't reproduce