### PR TITLE
handle overflow of vstring lengths

### DIFF
--- a/dist/Storable/Storable.pm
+++ b/dist/Storable/Storable.pm
@@ -28,7 +28,7 @@ our @EXPORT_OK = qw(
 our ($canonical, $forgive_me);
 
 BEGIN {
-  our $VERSION = '3.17';
+  our $VERSION = '3.18';
 }
 
 our $recursion_limit;


### PR DESCRIPTION
also prevents writing overlarge vstrings to avoid problems with older Storable.