### PR TITLE
Fix GitHub Actions emails

### DIFF
--- a/.github/workflows/smoke-information.yml
+++ b/.github/workflows/smoke-information.yml
@@ -22,4 +22,7 @@ jobs:
             fetch-depth: 10
       - name: Involved authors
         run: |
-            if \! -z "${GITHUB_HEAD_REF}" ; then git log --pretty=format:"Author: %an <%ae>" ${GITHUB_BASE_REF}..${GITHUB_HEAD_REF}; fi
+            if [ -n "${GITHUB_HEAD_REF}" ]; then
+                echo "Pull request"
+                git log --pretty=format:"Author: %an <%ae>" ${GITHUB_BASE_REF}..${GITHUB_HEAD_REF}
+            fi

--- a/.github/workflows/smoke-information.yml
+++ b/.github/workflows/smoke-information.yml
@@ -1,0 +1,25 @@
+name: smoke-information
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+env:
+    PERL_SKIP_TTY_TEST: 1
+
+jobs:
+  perl:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+        with:
+            fetch-depth: 10
+      - name: Involved authors
+        run: |
+            if \! -z "${GITHUB_HEAD_REF}" ; then git log --pretty=format:"Author: %an <%ae>" ${GITHUB_BASE_REF}..${GITHUB_HEAD_REF}; fi

--- a/t/porting/authors.t
+++ b/t/porting/authors.t
@@ -24,6 +24,11 @@ if ( $ENV{TRAVIS} && defined $ENV{TRAVIS_COMMIT_RANGE} ) {
 	#	all the more a pull request should not be impacted by blead being incorrect
 	$revision_range = $ENV{TRAVIS_COMMIT_RANGE};
 }
+elsif( $ENV{GITHUB_ACTIONS} && defined $ENV{GITHUB_HEAD_REF} ) {
+    # Same as above, except for Github Actions
+    # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables
+	$revision_range = join '..', $ENV{GITHUB_BASE_REF}, $ENV{GITHUB_HEAD_REF};
+}
 
 # This is the subset of "pretty=fuller" that checkAUTHORS.pl actually needs:
 print qx{git log --pretty=format:"Author: %an <%ae>" $revision_range | $^X Porting/checkAUTHORS.pl --tap -};


### PR DESCRIPTION
This is a first attempt at fixing the patch author email addresses in Github pull requests. It does two things:

* in `t/porting/authors.t`, it tries to treat Github Actions like Travis CI.

* It adds `smoke-information.yml`, a file that will output the Travis environment variables for the pull request, in the hope of becoming better at debugging this.