### PR TITLE
Try to find the appropriate SHAs

### DIFF
--- a/.github/workflows/smoke-information.yml
+++ b/.github/workflows/smoke-information.yml
@@ -25,7 +25,11 @@ jobs:
             if [ -n "${GITHUB_HEAD_REF}" ]; then
                 echo "Pull request"
                 env
-                echo git merge-base ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}
-                branch_off=$(git merge-base ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF})
+                # Create the names of the branches here, as they don't seem
+                # to exist properly?!
+                git switch -c $GITHUB_HEAD_REF
+                git checkout $GITHUB_HEAD_REF
+                echo git merge-base origin/${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}
+                branch_off=$(git merge-base origin/${GITHUB_BASE_REF} ${GITHUB_HEAD_REF})
                 git log --pretty=format:"Author: %an <%ae>" $branch_off..${GITHUB_SHA}
             fi

--- a/.github/workflows/smoke-information.yml
+++ b/.github/workflows/smoke-information.yml
@@ -30,5 +30,5 @@ jobs:
                 git switch -c $GITHUB_HEAD_REF
                 echo git merge-base origin/${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}
                 branch_off=$(git merge-base origin/${GITHUB_BASE_REF} ${GITHUB_HEAD_REF})
-                git log --pretty=format:"Author: %an <%ae>" $branch_off..HEAD^1
+                git log --pretty=format:"Author: %an <%ae>" $branch_off..${GITHUB_SHA}^2
             fi

--- a/.github/workflows/smoke-information.yml
+++ b/.github/workflows/smoke-information.yml
@@ -28,8 +28,7 @@ jobs:
                 # Create the names of the branches here, as they don't seem
                 # to exist properly?!
                 git switch -c $GITHUB_HEAD_REF
-                git checkout $GITHUB_HEAD_REF
                 echo git merge-base origin/${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}
                 branch_off=$(git merge-base origin/${GITHUB_BASE_REF} ${GITHUB_HEAD_REF})
-                git log --pretty=format:"Author: %an <%ae>" $branch_off..${GITHUB_SHA}^1
+                git log --pretty=format:"Author: %an <%ae>" $branch_off..HEAD^1
             fi

--- a/.github/workflows/smoke-information.yml
+++ b/.github/workflows/smoke-information.yml
@@ -24,6 +24,8 @@ jobs:
         run: |
             if [ -n "${GITHUB_HEAD_REF}" ]; then
                 echo "Pull request"
+                env
+                echo git merge-base ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}
                 branch_off=$(git merge-base ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF})
                 git log --pretty=format:"Author: %an <%ae>" $branch_off..${GITHUB_SHA}
             fi

--- a/.github/workflows/smoke-information.yml
+++ b/.github/workflows/smoke-information.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Involved authors
         run: |
             if [ -n "${GITHUB_HEAD_REF}" ]; then
-                echo "Pull request"
-                env
+                echo "Pull request authors"
+                # env
                 # Create the names of the branches here, as they don't seem
                 # to exist properly?!
                 git switch -c $GITHUB_HEAD_REF
                 git checkout $GITHUB_HEAD_REF
                 echo git merge-base origin/${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}
                 branch_off=$(git merge-base origin/${GITHUB_BASE_REF} ${GITHUB_HEAD_REF})
-                git log --pretty=format:"Author: %an <%ae>" $branch_off..${GITHUB_SHA}
+                git log --pretty=format:"Author: %an <%ae>" $branch_off..${GITHUB_SHA}^1
             fi

--- a/.github/workflows/smoke-information.yml
+++ b/.github/workflows/smoke-information.yml
@@ -24,5 +24,6 @@ jobs:
         run: |
             if [ -n "${GITHUB_HEAD_REF}" ]; then
                 echo "Pull request"
-                git log --pretty=format:"Author: %an <%ae>" ${GITHUB_BASE_REF}..${GITHUB_HEAD_REF}
+                branch_off=$(git merge-base ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF})
+                git log --pretty=format:"Author: %an <%ae>" $branch_off..${GITHUB_SHA}
             fi

--- a/t/porting/authors.t
+++ b/t/porting/authors.t
@@ -27,7 +27,9 @@ if ( $ENV{TRAVIS} && defined $ENV{TRAVIS_COMMIT_RANGE} ) {
 elsif( $ENV{GITHUB_ACTIONS} && defined $ENV{GITHUB_HEAD_REF} ) {
     # Same as above, except for Github Actions
     # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables
-	$revision_range = join '..', $ENV{GITHUB_BASE_REF}, $ENV{GITHUB_HEAD_REF};
+    my $common_ancestor = `git merge-base $ENV{GITHUB_BASE_REF} $ENV{GITHUB_HEAD_REF}`
+    $common_ancestor =~ s!\s+!!g;
+	$revision_range = join '..', $common_ancestor, $ENV{GITHUB_SHA};
 }
 
 # This is the subset of "pretty=fuller" that checkAUTHORS.pl actually needs:

--- a/t/porting/authors.t
+++ b/t/porting/authors.t
@@ -27,9 +27,15 @@ if ( $ENV{TRAVIS} && defined $ENV{TRAVIS_COMMIT_RANGE} ) {
 elsif( $ENV{GITHUB_ACTIONS} && defined $ENV{GITHUB_HEAD_REF} ) {
     # Same as above, except for Github Actions
     # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables
-    my $common_ancestor = `git merge-base $ENV{GITHUB_BASE_REF} $ENV{GITHUB_HEAD_REF}`
+    system(qw( git switch -c  ), $ENV{GITHUB_HEAD_REF});
+    system(qw( git checkout ), $ENV{GITHUB_HEAD_REF});
+
+    # This hardcoded origin/ isn't great, but I'm not sure how to better fix it
+    my $common_ancestor = `git merge-base origin/$ENV{GITHUB_BASE_REF} $ENV{GITHUB_HEAD_REF}`
     $common_ancestor =~ s!\s+!!g;
-	$revision_range = join '..', $common_ancestor, $ENV{GITHUB_SHA};
+
+    # We want one before the GITHUB_SHA, as the github-SHA is a merge commit
+	$revision_range = join '..', $common_ancestor, $ENV{GITHUB_SHA} . '^1';
 }
 
 # This is the subset of "pretty=fuller" that checkAUTHORS.pl actually needs:

--- a/t/porting/authors.t
+++ b/t/porting/authors.t
@@ -35,7 +35,7 @@ elsif( $ENV{GITHUB_ACTIONS} && defined $ENV{GITHUB_HEAD_REF} ) {
     $common_ancestor =~ s!\s+!!g;
 
     # We want one before the GITHUB_SHA, as the github-SHA is a merge commit
-	$revision_range = join '..', $common_ancestor, $ENV{GITHUB_SHA} . '^1';
+	$revision_range = join '..', $common_ancestor, 'HEAD^1';
 }
 
 # This is the subset of "pretty=fuller" that checkAUTHORS.pl actually needs:

--- a/t/porting/authors.t
+++ b/t/porting/authors.t
@@ -31,11 +31,11 @@ elsif( $ENV{GITHUB_ACTIONS} && defined $ENV{GITHUB_HEAD_REF} ) {
     system(qw( git checkout ), $ENV{GITHUB_HEAD_REF});
 
     # This hardcoded origin/ isn't great, but I'm not sure how to better fix it
-    my $common_ancestor = `git merge-base origin/$ENV{GITHUB_BASE_REF} $ENV{GITHUB_HEAD_REF}`
+    my $common_ancestor = `git merge-base origin/$ENV{GITHUB_BASE_REF} $ENV{GITHUB_HEAD_REF}`;
     $common_ancestor =~ s!\s+!!g;
 
     # We want one before the GITHUB_SHA, as the github-SHA is a merge commit
-	$revision_range = join '..', $common_ancestor, 'HEAD^1';
+	$revision_range = join '..', $common_ancestor, $ENV{GITHUB_SHA} . '^2';
 }
 
 # This is the subset of "pretty=fuller" that checkAUTHORS.pl actually needs:


### PR DESCRIPTION
We want all the patches between the branch-off point from
blead and the current branch. The current branch position lives in
$ENV{GITHUB_SHA}, and the (latest) branch-off point from blead is
found by running

    git merge-base $ENV{GITHUB_BASE_REF} $ENV{GITHUB_HEAD_REF}