### PR TITLE
Adapt authors.t email address extraction to Github Actions

### DIFF
--- a/.github/workflows/smoke-information.yml
+++ b/.github/workflows/smoke-information.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Involved authors
         run: |
             if [ -n "${GITHUB_HEAD_REF}" ]; then
-                echo "Pull request"
-                git log --pretty=format:"Author: %an <%ae>" ${GITHUB_BASE_REF}..${GITHUB_HEAD_REF}
+                echo "Pull request authors"
+                # env
+                # Create the names of the branches here, as they don't seem
+                # to exist properly?!
+                git switch -c $GITHUB_HEAD_REF
+                echo git merge-base origin/${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}
+                branch_off=$(git merge-base origin/${GITHUB_BASE_REF} ${GITHUB_HEAD_REF})
+                git log --pretty=format:"Author: %an <%ae>" $branch_off..${GITHUB_SHA}^2
             fi

--- a/t/porting/authors.t
+++ b/t/porting/authors.t
@@ -27,7 +27,15 @@ if ( $ENV{TRAVIS} && defined $ENV{TRAVIS_COMMIT_RANGE} ) {
 elsif( $ENV{GITHUB_ACTIONS} && defined $ENV{GITHUB_HEAD_REF} ) {
     # Same as above, except for Github Actions
     # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables
-	$revision_range = join '..', $ENV{GITHUB_BASE_REF}, $ENV{GITHUB_HEAD_REF};
+    system(qw( git switch -c  ), $ENV{GITHUB_HEAD_REF});
+    system(qw( git checkout ), $ENV{GITHUB_HEAD_REF});
+
+    # This hardcoded origin/ isn't great, but I'm not sure how to better fix it
+    my $common_ancestor = `git merge-base origin/$ENV{GITHUB_BASE_REF} $ENV{GITHUB_HEAD_REF}`;
+    $common_ancestor =~ s!\s+!!g;
+
+    # We want one before the GITHUB_SHA, as the github-SHA is a merge commit
+	$revision_range = join '..', $common_ancestor, $ENV{GITHUB_SHA} . '^2';
 }
 
 # This is the subset of "pretty=fuller" that checkAUTHORS.pl actually needs:


### PR DESCRIPTION
We want all the patches between the branch-off point from
blead and the current branch. The current branch position lives in
$ENV{GITHUB_SHA}, and the (latest) branch-off point from blead is
found by running

    git merge-base $ENV{GITHUB_BASE_REF} $ENV{GITHUB_HEAD_REF}

We don't want to use the last commit, as it's a merge commit.

That commit will also have the Github mail address, not the real
git mail address of the author . Instead we use the (second)
parent commit to that merge commit.