### PR TITLE
error check the calls to sigaddset in POSIX::SigSet->new

### DIFF
--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -1844,8 +1844,11 @@ new(packname = "POSIX::SigSet", ...)
 					       sizeof(sigset_t),
 					       packname);
 	    sigemptyset(s);
-	    for (i = 1; i < items; i++)
-		sigaddset(s, SvIV(ST(i)));
+	    for (i = 1; i < items; i++) {
+                IV sig = SvIV(ST(i));
+		if (sigaddset(s, sig) < 0)
+                    croak("POSIX::Sigset->new: failed to add signal %" IVdf, sig);
+            }
 	    XSRETURN(1);
 	}
 

--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our ($AUTOLOAD, %SIGRT);
 
-our $VERSION = '1.90';
+our $VERSION = '1.91';
 
 require XSLoader;
 

--- a/ext/POSIX/lib/POSIX.pod
+++ b/ext/POSIX/lib/POSIX.pod
@@ -2257,6 +2257,9 @@ Create a set with C<SIGUSR1>.
 
 	$sigset = POSIX::SigSet->new( &POSIX::SIGUSR1 );
 
+Throws an error if any of the signals supplied cannot be added to the
+set.
+
 =item C<addset>
 
 Add a signal to a SigSet object.


### PR DESCRIPTION
Coverity complained that SvIV() could return negative numbers,
but doesn't complain about the similar call in the sigaddset()
method, which is error checked.

So error check sigaddset() and throw an error if it fails.

CID 244386.