### PR TITLE
Remove -Dissymlink='test -h'

### DIFF
--- a/.github/workflows/smoke-windows-cygwin.yml
+++ b/.github/workflows/smoke-windows-cygwin.yml
@@ -30,7 +30,7 @@ jobs:
         shell: cmd
         run: |
             path %GITHUB_WORKSPACE%\cygwin\bin;%GITHUB_WORKSPACE%\cygwin\usr\bin
-            sh.exe -c "cd ~/work; ./Configure -des -Dusedevel -Dissymlink='test -h' -Doptimize=-g -DDEBUGGING"
+            sh.exe -c "cd ~/work; ./Configure -des -Dusedevel -Doptimize=-g -DDEBUGGING"
       - name: Build
         shell: cmd
         run: |

--- a/t/porting/authors.t
+++ b/t/porting/authors.t
@@ -27,8 +27,6 @@ if ( $ENV{TRAVIS} && defined $ENV{TRAVIS_COMMIT_RANGE} ) {
 elsif( $ENV{GITHUB_ACTIONS} && defined $ENV{GITHUB_HEAD_REF} ) {
     # Same as above, except for Github Actions
     # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables
-    system(qw( git switch -c  ), $ENV{GITHUB_HEAD_REF});
-    system(qw( git checkout ), $ENV{GITHUB_HEAD_REF});
 
     # This hardcoded origin/ isn't great, but I'm not sure how to better fix it
     my $common_ancestor = `git merge-base origin/$ENV{GITHUB_BASE_REF} $ENV{GITHUB_HEAD_REF}`;


### PR DESCRIPTION
This is a vestige of previously failed attempts. The previous attempts
failed due to non-Cygwin test.exe being in $ENV{PATH}.