### PR TITLE
Update Porting documents to reference GitHub issues

### DIFF
--- a/Porting/checkURL.pl
+++ b/Porting/checkURL.pl
@@ -56,6 +56,10 @@ foreach my $filename (@filenames) {
         next
             if $uri =~ m{^https?://rt.perl.org/(?:rt3/)?Ticket/Display.html?id=\d+$};
 
+        # no need to hit github
+        next
+            if $uri =~ m{^https?://(?:www\.)?github\.com/[pP]erl/perl5/issues/\d+$};
+
         # no need to hit rt.cpan.org
         next
             if $uri =~ m{^https?://rt.cpan.org/Public/Bug/Display.html?id=\d+$};

--- a/Porting/perldelta_template.pod
+++ b/Porting/perldelta_template.pod
@@ -408,7 +408,7 @@ XXX Generate this with:
 =head1 Reporting Bugs
 
 If you find what you think is a bug, you might check the perl bug database
-at L<https://rt.perl.org/>.  There may also be information at
+at L<https://github.com/Perl/perl5/issues>.  There may also be information at
 L<http://www.perl.org/>, the Perl Home Page.
 
 If you believe you have an unreported bug, please run the L<perlbug> program

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -141,11 +141,11 @@ Andreas' email address at:
 
     https://pause.perl.org/pause/query?ACTION=pause_04imprint
 
-=head3 rt.perl.org update access
+=head3 GitHub issue management access
 
-Make sure you have permission to close tickets on L<https://rt.perl.org/>
+Make sure you have permission to close tickets on L<https://github.com/Perl/perl5/issues>
 so you can respond to bug reports as necessary during your stint.  If you
-don't, make an account (if you don't have one) and contact the pumpking
+don't, make a GitHub account (if you don't have one) and contact the pumpking
 with your username to get ticket-closing permission.
 
 =head3 git checkout and commit bit
@@ -750,9 +750,9 @@ formatting, e.g.
     $ ./perl -Ilib ext/Pod-Html/bin/pod2html pod/perldelta.pod > \
         ~/perldelta.html
 
-You can add pod links for RT references thusly:
+You can add pod links for GitHub issue references thusly:
 
-    $ perl -p -i -e'BEGIN{undef $/}; s{(\[perl\s+#)(\d+)\]}{L<$1$2\]|https://rt.perl.org/Ticket/Display.html?id=$2>}mg' pod/perldelta.pod
+    $ perl -p -i -e'BEGIN{undef $/}; s{(\[perl\s+#)(\d+)\]}{L<$1$2\]|https://github.com/Perl/perl5/issues/$2>}mg' pod/perldelta.pod
 
 If you make changes, be sure to commit them.
 

--- a/Porting/todo.pod
+++ b/Porting/todo.pod
@@ -25,17 +25,18 @@ programming languages offer you 1 line of immortality?
 
 =head1 Tasks that only need Perl knowledge
 
-=head2 Classify bug tickets by type
+=head2 Label bug tickets by type
 
-Known bugs in Perl are tracked by L<https://rt.perl.org/> (which also
-includes Perl 6).  A summary can be found at
-L<https://rt.perl.org/NoAuth/perl5/Overview.html>.
-It shows bugs classified by "type".  However, the type of many of the
-bugs is "unknown".  This greatly lowers the chances of them getting
+Known bugs in Perl are tracked by L<https://github.com/Perl/perl5/issues>.
+It shows bugs and can be filtered by assigned labels.  However, many are
+L<unlabeled|https://github.com/Perl/perl5/issues?q=is%3Aopen+is%3Aissue+no%3Alabel>
+or have the label L<"Needs Triage"|https://github.com/Perl/perl5/issues?q=is%3Aopen+is%3Aissue+label%3A%22Needs+Triage%22>.
+This greatly lowers the chances of them getting
 fixed, as the number of open bugs is overwhelming -- too many to wade
 through for someone to try to find the bugs in the parts of
 Perl that s/he knows well enough to try to fix.  This task involves
-going through these bugs and classifying them into one or more types.
+going through these bugs and assigning one or more labels, and removing the
+"Needs Triage" label if present.
 
 =head2 Ongoing: investigate new bug reports
 
@@ -44,8 +45,8 @@ a quick investigation to see if it is a real problem, and to reply to
 the poster about it, asking for example code that reproduces the
 problem.  Such code should be added to the test suite as TODO tests, and
 the ticket should be classified by type.  To get started on this task,
-look at the tickets that are marked as "New Issues" in
-L<https://rt.perl.org/NoAuth/perl5/Overview.html>.
+look at the issues with no comments at
+L<https://github.com/Perl/perl5/issues?q=is%3Aopen+is%3Aissue+comments%3A0>.
 
 =head2 Migrate t/ from custom TAP generation
 


### PR DESCRIPTION
Still needed: Update Porting/how_to_write_a_perldelta.pod to indicate the style to be used for referencing GitHub issues, rather than rt.perl.org tickets.