### PR TITLE
Convert issue links from rt.perl.org to GitHub

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5485,7 +5485,7 @@ t/base/rs.t			See if record-read works
 t/base/term.t			See if various terms work
 t/base/translate.t		See if character set translation works
 t/base/while.t			See if while work
-t/benchmark/rt26188-speed-up-keys-on-empty-hash.t	Benchmark if keys on empty hashes is fast enough
+t/benchmark/gh7094-speed-up-keys-on-empty-hash.t	Benchmark if keys on empty hashes is fast enough
 t/bigmem/hash.t			Check hashing too large strings throws an exception
 t/bigmem/index.t		Check that index() handles large offsets
 t/bigmem/pos.t			Check that pos() handles large offsets
@@ -5783,7 +5783,7 @@ t/op/exec.t			See if exec, system and qx work
 t/op/exists_sub.t		See if exists(&sub) works
 t/op/exp.t			See if math functions work
 t/op/fh.t			See if filehandles work
-t/op/filehandle.t		Tests for https://rt.perl.org/rt3/Ticket/Display.html?id=72586
+t/op/filehandle.t		Tests for https://github.com/Perl/perl5/issues/10133
 t/op/filetest.t			See if file tests work
 t/op/filetest_stack_ok.t	See if file tests leave their argument on the stack
 t/op/filetest_t.t		See if -t file test works

--- a/cygwin/cygwin.c
+++ b/cygwin/cygwin.c
@@ -219,7 +219,7 @@ XS(Cygwin_cwd)
     dXSARGS;
     char *cwd;
 
-    /* See https://rt.perl.org/rt3/Ticket/Display.html?id=38628
+    /* See https://github.com/Perl/perl5/issues/8345
        There is Cwd->cwd() usage in the wild, and previous versions didn't die.
      */
     if(items > 1)

--- a/handy.h
+++ b/handy.h
@@ -2089,7 +2089,7 @@ END_EXTERN_C
 
 /* To prevent S_scan_word in toke.c from hanging, we have to make sure that
  * IDFIRST is an alnum.  See
- * https://rt.perl.org/rt3/Ticket/Display.html?id=74022 for more detail than you
+ * https://github.com/Perl/perl5/issues/10275 for more detail than you
  * ever wanted to know about.  (In the ASCII range, there isn't a difference.)
  * This used to be not the XID version, but we decided to go with the more
  * modern Unicode definition */

--- a/hints/freebsd.sh
+++ b/hints/freebsd.sh
@@ -335,7 +335,7 @@ then
     d_uselocale='undef'
 fi
 
-# https://rt.perl.org/Ticket/Display.html?id=131337
+# https://github.com/Perl/perl5/issues/15984
 # Reported in 11.0-CURRENT with g++-4.8.5:
 # If using g++, the Configure scan for dlopen() fails.
 # Easier for now to just to forcibly set it.

--- a/hints/hpux.sh
+++ b/hints/hpux.sh
@@ -486,7 +486,7 @@ case "$ccisgcc" in
 			# > cc --version
 			# cc: HP C/aC++ B3910B A.06.15 [May 16 2007]
 			# Has optimizing problems with +O2 for blead (5.17.4),
-			# see https://rt.perl.org:443/rt3/Ticket/Display.html?id=103668.
+			# see https://github.com/Perl/perl5/issues/11748.
 			#
 			# +O2 +Onolimit +Onoprocelim  +Ostore_ordering \
 			# +Onolibcalls=strcmp

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -408,7 +408,7 @@ XXX Generate this with:
 =head1 Reporting Bugs
 
 If you find what you think is a bug, you might check the perl bug database
-at L<https://rt.perl.org/>.  There may also be information at
+at L<https://github.com/Perl/perl5/issues>.  There may also be information at
 L<http://www.perl.org/>, the Perl Home Page.
 
 If you believe you have an unreported bug, please run the L<perlbug> program

--- a/pod/perlexperiment.pod
+++ b/pod/perlexperiment.pod
@@ -26,12 +26,12 @@ Using this feature triggers warnings in the category
 C<experimental::smartmatch>.
 
 The ticket for this feature is
-L<[perl #119317]|https://rt.perl.org/rt3/Ticket/Display.html?id=119317>.
+L<[perl #13173]|https://github.com/Perl/perl5/issues/13173>.
 
 =item Pluggable keywords
 
 The ticket for this feature is
-L<[perl #119455]|https://rt.perl.org/rt3/Ticket/Display.html?id=119455>.
+L<[perl #13199]|https://github.com/Perl/perl5/issues/13199>.
 
 See L<perlapi/PL_keyword_plugin> for the mechanism.
 
@@ -42,7 +42,7 @@ Introduced in Perl 5.11.2
 Introduced in Perl 5.18
 
 The ticket for this feature is
-L<[perl #119451]|https://rt.perl.org/rt3/Ticket/Display.html?id=119451>.
+L<[perl #13197]|https://github.com/Perl/perl5/issues/13197>.
 
 See also: L<perlrecharclass/Extended Bracketed Character Classes>
 
@@ -57,7 +57,7 @@ Using this feature triggers warnings in the category
 C<experimental::signatures>.
 
 The ticket for this feature is
-L<[perl #121481]|https://rt.perl.org/Ticket/Display.html?id=121481>.
+L<[perl #13681]|https://github.com/Perl/perl5/issues/13681>.
 
 =item Aliasing via reference
 
@@ -67,7 +67,7 @@ Using this feature triggers warnings in the category
 C<experimental::refaliasing>.
 
 The ticket for this feature is
-L<[perl #122947]|https://rt.perl.org/rt3/Ticket/Display.html?id=122947>.
+L<[perl #14150]|https://github.com/Perl/perl5/issues/14150>.
 
 See also: L<perlref/Assigning to References>
 
@@ -79,7 +79,7 @@ Using this feature triggers warnings in the category
 C<experimental::const_attr>.
 
 The ticket for this feature is
-L<[perl #123630]|https://rt.perl.org/rt3/Ticket/Display.html?id=123630>.
+L<[perl #14428]|https://github.com/Perl/perl5/issues/14428>.
 
 See also: L<perlsub/Constant Functions>
 
@@ -95,7 +95,7 @@ See L<re/'strict' mode>
 =item The <:win32> IO pseudolayer
 
 The ticket for this feature is
-L<[perl #119453]|https://rt.perl.org/rt3/Ticket/Display.html?id=119453>.
+L<[perl #13198]|https://github.com/Perl/perl5/issues/13198>.
 
 See also L<perlrun>
 
@@ -107,14 +107,14 @@ Using this feature triggers warnings in the category
 C<experimental::declared_refs>.
 
 The ticket for this feature is
-L<[perl #128654]|https://rt.perl.org/rt3/Ticket/Display.html?id=128654>.
+L<[perl #15458]|https://github.com/Perl/perl5/issues/15458>.
 
 See also: L<perlref/Declaring a Reference to a Variable>
 
 =item There is an C<installhtml> target in the Makefile.
 
 The ticket for this feature is
-L<[perl #116487]|https://rt.perl.org/rt3/Ticket/Display.html?id=116487>.
+L<[perl #12726]|https://github.com/Perl/perl5/issues/12726>.
 
 =item (Limited) Variable-length look-behind
 

--- a/pod/perlhack.pod
+++ b/pod/perlhack.pod
@@ -122,7 +122,7 @@ command line tool.  This tool will ensure that your bug report includes
 all the relevant system and configuration information.
 
 To browse existing Perl bugs and patches, you can use the web interface
-at L<https://rt.perl.org/>.
+at L<https://github.com/perl/perl5/issues>.
 
 Please check the archive of the perl5-porters list (see below) and/or
 the bug tracking system before submitting a bug report.  Often, you'll
@@ -1056,7 +1056,7 @@ situation by using the Devel::PatchPerl library from CPAN (not included in the
 core) to bring the source code at that commit to a buildable state.
 
 Here's a real world example, taken from work done to resolve
-L<perl #72414|https://rt.perl.org/Ticket/Display.html?id=72414>.
+L<perl #10118|https://github.com/Perl/perl5/issues/10118>.
 Use of F<Porting/bisect.pl> had identified commit
 C<ba77e4cc9d1ceebf472c9c5c18b2377ee47062e6> as the commit in which a bug was
 corrected.  To confirm, a P5P developer wanted to configure and build perl at

--- a/pod/perlport.pod
+++ b/pod/perlport.pod
@@ -2277,7 +2277,7 @@ Some tests are known to fail:
 =item *
 
 F<ext/XS-APItest/t/call_checker.t> - see
-L<https://rt.perl.org/Ticket/Display.html?id=78502>
+L<https://github.com/Perl/perl5/issues/10750>
 
 =item *
 

--- a/t/base/lex.t
+++ b/t/base/lex.t
@@ -396,7 +396,7 @@ for(qw< require goto last next redo CORE::dump >) {
     print "# $@" if $@;
 }
 
-# https://rt.perl.org/rt3/Ticket/Display.html?id=56880
+# https://github.com/Perl/perl5/issues/9415
 my $counter = 0;
 eval 'v23: $counter++; goto v23 unless $counter == 2';
 print "not " unless $counter == 2;

--- a/t/benchmark/gh7094-speed-up-keys-on-empty-hash.t
+++ b/t/benchmark/gh7094-speed-up-keys-on-empty-hash.t
@@ -7,7 +7,7 @@ plan(tests => 6);
 
 =head1 NAME
 
-rt26188 - benchmark speed for keys() on empty hashes
+gh7094 - benchmark speed for keys() on empty hashes
 
 =head1 DESCRIPTION
 
@@ -23,9 +23,9 @@ the number or list of keys from an empty hash is about the same
 
 =head1 REFERENCE
 
-This test tests against RT ticket #26188
+This test tests against GitHub ticket #7094
 
-L<https://rt.perl.org/rt3/Public/Bug/Display.html?id=26188>
+L<https://github.com/Perl/perl5/issues/7094>
 
 =cut
 

--- a/t/io/data.t
+++ b/t/io/data.t
@@ -20,7 +20,7 @@ run_multiple_progs('', \*DATA);
 done_testing();
 
 __END__
-# https://rt.perl.org/rt3/Ticket/Display.html?id=28106#txn-82657
+# https://github.com/Perl/perl5/issues/7207#issuecomment-543940952
 while (<DATA>) {
     chomp;
     print "$.: '$_'\n";
@@ -35,7 +35,7 @@ EXPECT
 2: '2'
 3: '3'
 ########
-# https://rt.perl.org/rt3/Ticket/Display.html?id=28106#txn-83113
+# https://github.com/Perl/perl5/issues/7207#issuecomment-543940955
 my $line1 = <DATA>;
 `echo foo`;
 my $line2 = <DATA>;
@@ -48,7 +48,7 @@ EXPECT
 ok 1
 ok 2
 ########
-# https://rt.perl.org/rt3/Ticket/Attachment/828796/403048/perlbug.rep.txt
+# https://github.com/Perl/perl5/issues/7207#issuecomment-543940992
 my @data_positions = tell(DATA);
 while (<DATA>){
     if (/^__DATA__$/) {

--- a/t/io/eintr_print.t
+++ b/t/io/eintr_print.t
@@ -1,7 +1,7 @@
 #!./perl
 
 # print should not return EINTR
-# fails under 5.14.x see https://rt.perl.org/rt3/Ticket/Display.html?id=119097
+# fails under 5.14.x see https://github.com/Perl/perl5/issues/13142
 # also fails under 5.8.x
 
 BEGIN {

--- a/t/io/errno.t
+++ b/t/io/errno.t
@@ -2,7 +2,7 @@
 # vim: ts=4 sts=4 sw=4:
 
 # $! may not be set if EOF was reached without any error.
-# https://rt.perl.org/rt3/Ticket/Display.html?id=39060
+# https://github.com/Perl/perl5/issues/8431
 
 use strict;
 use Config;

--- a/t/op/gv.t
+++ b/t/op/gv.t
@@ -184,7 +184,7 @@ is (*{*x{GLOB}}, "*main::STDOUT");
     my $val = *x{FILEHANDLE};
 
     # deprecation warning removed in v5.23 -- rjbs, 2015-12-31
-    # https://rt.perl.org/Ticket/Display.html?id=127060
+    # https://github.com/Perl/perl5/issues/15105
     print {*x{IO}} (! defined $warn
 		    ? "ok $test\n" : "not ok $test\n");
     curr_test(++$test);

--- a/t/op/readdir.t
+++ b/t/op/readdir.t
@@ -58,8 +58,8 @@ isnt("$fh", "$fh[0]");
 isnt("$fh", "$fh{abc}");
 
 # See that perl does not segfault upon readdir($x=".");
-# https://rt.perl.org/rt3/Ticket/Display.html?id=68182
-fresh_perl_like(<<'EOP', qr/^no crash/, {}, 'RT #68182');
+# https://github.com/Perl/perl5/issues/9813
+fresh_perl_like(<<'EOP', qr/^no crash/, {}, 'GH #9813');
   eval {
     my $x = ".";
     my @files = readdir($x);

--- a/t/op/write.t
+++ b/t/op/write.t
@@ -1912,7 +1912,7 @@ like $@, qr'Undefined format',
 # This syntax error used to cause a crash, double free, or a least
 # a bad read.
 # See the long-winded explanation at:
-#   https://rt.perl.org/rt3/Ticket/Display.html?id=43425#txn-1144500
+#   https://github.com/Perl/perl5/issues/8953#issuecomment-543978716
 eval q|
 format =
 @

--- a/t/porting/extrefs.t
+++ b/t/porting/extrefs.t
@@ -6,7 +6,7 @@
 # code on CPAN, and can break cflags.SH.
 #
 # Why do we test this?
-# See https://rt.perl.org/rt3/Ticket/Display.html?id=116989
+# See https://github.com/Perl/perl5/issues/12824
 #
 # It's broken - how do I fix it?
 # You added an initializer or static function to a header file that

--- a/t/uni/gv.t
+++ b/t/uni/gv.t
@@ -192,7 +192,7 @@ is (*{*Ẋ{GLOB}}, "*main::STDOUT");
     my $val = *Ẋ{FILEHANDLE};
 
     # deprecation warning removed in v5.23 -- rjbs, 2015-12-31
-    # https://rt.perl.org/Ticket/Display.html?id=127060
+    # https://github.com/Perl/perl5/issues/15105
     print {*Ẋ{IO}} (! defined $warn
 		    ? "ok $test\n" : "not ok $test\n");
     curr_test(++$test);

--- a/t/uni/variables.t
+++ b/t/uni/variables.t
@@ -303,7 +303,7 @@ for my $i (0x100..0xffff) {
 
 {
     # Bleadperl v5.17.9-109-g3283393 breaks ZEFRAM/Module-Runtime-0.013.tar.gz
-    # https://rt.perl.org/rt3/Public/Bug/Display.html?id=117101
+    # https://github.com/Perl/perl5/issues/12841
     no strict;
 
     local $@;
@@ -336,7 +336,7 @@ EOP
 
 {    
     # bleadperl v5.17.9-109-g3283393 breaks JEREMY/File-Signature-1.009.tar.gz
-    # https://rt.perl.org/rt3/Ticket/Display.html?id=117145
+    # https://github.com/Perl/perl5/issues/12849
     local $@;
     my $var = 10;
     eval ' ${  var  }';

--- a/utils/perlbug.PL
+++ b/utils/perlbug.PL
@@ -1448,7 +1448,8 @@ offers of frosty beverages.  (Please do be kind to the maintainers.
 Harassing or flaming them is likely to have the opposite effect of the
 one you want.)
 
-Feel free to update the ticket about your bug on https://rt.perl.org
+Feel free to update the ticket about your bug on
+L<https://github.com/Perl/perl5/issues>
 if a new version of Perl is released and your bug is still present.
 
 =head1 OPTIONS

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -570,7 +570,7 @@ GCCVER2   := $(shell for /f "delims=. tokens=1,2,3" %%i in ('gcc -dumpversion') 
 GCCVER3   := $(shell for /f "delims=. tokens=1,2,3" %%i in ('gcc -dumpversion') do echo %%k)
 
 # If you are using GCC, 4.3 or later by default we add the -fwrapv option.
-# See https://rt.perl.org/Ticket/Display.html?id=121505
+# See https://github.com/Perl/perl5/issues/13690
 #
 GCCWRAPV := $(shell if "$(GCCVER1)"=="4" (if "$(GCCVER2)" geq "3" echo define) else if "$(GCCVER1)" geq "5" (echo define))
 

--- a/win32/makefile.mk
+++ b/win32/makefile.mk
@@ -158,7 +158,7 @@ DEFAULT_INC_EXCLUDES_DOT *= define
 
 #
 # If you are using GCC, 4.3 or later by default we add the -fwrapv option.
-# See https://rt.perl.org/Ticket/Display.html?id=121505
+# See https://github.com/Perl/perl5/issues/13690
 #
 #GCCWRAPV       *= define
 
@@ -540,7 +540,7 @@ GCCVER2:= $(shell for /f "delims=. tokens=1,2,3" %i in ('gcc -dumpversion') do @
 GCCVER3:= $(shell for /f "delims=. tokens=1,2,3" %i in ('gcc -dumpversion') do @echo %k)
 
 # If you are using GCC, 4.3 or later by default we add the -fwrapv option.
-# See https://rt.perl.org/Ticket/Display.html?id=121505
+# See https://github.com/Perl/perl5/issues/13690
 #
 GCCWRAPV *= $(shell if "$(GCCVER1)"=="4" (if "$(GCCVER2)" geq "3" echo define) else if "$(GCCVER1)" geq "5" (echo define))
 

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -1349,7 +1349,7 @@ get_hwnd_delay(pTHX, long child, DWORD tries)
      * caching reasons, and the child thread was attached to a different CPU
      * therefore there is no workload on that CPU and Sleep(0) returns control
      * without yielding the time slot.
-     * https://rt.perl.org/rt3/Ticket/Display.html?id=88840
+     * https://github.com/Perl/perl5/issues/11267
      */
     Sleep(0);
     win32_async_check(aTHX);


### PR DESCRIPTION
Conversions of direct links to tickets. These are all in comments or POD. Additionally, one test file was renamed from 'rt26188' to 'gh7094' in accordance with the update.