### PR TITLE
Made string multiplication more clear in perlintro

### DIFF
--- a/pod/perlintro.pod
+++ b/pod/perlintro.pod
@@ -473,7 +473,7 @@ detail.)
 
  =   assignment
  .   string concatenation
- x   string multiplication
+ x   string multiplication (repeats strings)
  ..  range operator (creates a list of numbers or strings)
 
 =back


### PR DESCRIPTION
Added "repeats strings" in parenthesis to make it more unambiguous.