### PR TITLE
Faster feature again

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5594,6 +5594,7 @@ t/lib/Devel/nodb.pm		Module for t/run/switchd.t
 t/lib/Devel/switchd.pm		Module for t/run/switchd.t
 t/lib/Devel/switchd_empty.pm	Module for t/run/switchd.t
 t/lib/Devel/switchd_goto.pm	Module for t/run/switchd.t
+t/lib/feature/bits		Tests for feature bit handling
 t/lib/feature/bundle		Tests for feature bundles
 t/lib/feature/implicit		Tests for implicit loading of feature.pm
 t/lib/feature/nonesuch		Tests for enabling/disabling nonexistent feature

--- a/feature.h
+++ b/feature.h
@@ -190,6 +190,123 @@ S_enable_feature_bundle(pTHX_ SV *ver)
 }
 #endif /* PERL_IN_OP_C */
 
+#ifdef PERL_IN_MG_C
+
+#define magic_sethint_feature(keysv, keypv, keylen, valsv, valbool) \
+    S_magic_sethint_feature(aTHX_ (keysv), (keypv), (keylen), (valsv), (valbool))
+PERL_STATIC_INLINE void
+S_magic_sethint_feature(pTHX_ SV *keysv, const char *keypv, STRLEN keylen,
+                        SV *valsv, bool valbool) {
+    if (keysv)
+      keypv = SvPV_const(keysv, keylen);
+
+    if (memBEGINs(keypv, keylen, "feature_")) {
+        const char *subf = keypv + (sizeof("feature_")-1);
+        U32 mask = 0;
+        switch (*subf) {
+        case '_':
+            if (keylen == sizeof("feature___SUB__")-1
+                 && memcmp(subf+1, "_SUB__", keylen - sizeof("feature_")) == 0) {
+                mask = FEATURE___SUB___BIT;
+                break;
+            }
+            return;
+
+        case 'b':
+            if (keylen == sizeof("feature_bitwise")-1
+                 && memcmp(subf+1, "itwise", keylen - sizeof("feature_")) == 0) {
+                mask = FEATURE_BITWISE_BIT;
+                break;
+            }
+            return;
+
+        case 'e':
+            if (keylen == sizeof("feature_evalbytes")-1
+                 && memcmp(subf+1, "valbytes", keylen - sizeof("feature_")) == 0) {
+                mask = FEATURE_EVALBYTES_BIT;
+                break;
+            }
+            return;
+
+        case 'f':
+            if (keylen == sizeof("feature_fc")-1
+                 && memcmp(subf+1, "c", keylen - sizeof("feature_")) == 0) {
+                mask = FEATURE_FC_BIT;
+                break;
+            }
+            return;
+
+        case 'm':
+            if (keylen == sizeof("feature_myref")-1
+                 && memcmp(subf+1, "yref", keylen - sizeof("feature_")) == 0) {
+                mask = FEATURE_MYREF_BIT;
+                break;
+            }
+            return;
+
+        case 'p':
+            if (keylen == sizeof("feature_postderef_qq")-1
+                 && memcmp(subf+1, "ostderef_qq", keylen - sizeof("feature_")) == 0) {
+                mask = FEATURE_POSTDEREF_QQ_BIT;
+                break;
+            }
+            return;
+
+        case 'r':
+            if (keylen == sizeof("feature_refaliasing")-1
+                 && memcmp(subf+1, "efaliasing", keylen - sizeof("feature_")) == 0) {
+                mask = FEATURE_REFALIASING_BIT;
+                break;
+            }
+            return;
+
+        case 's':
+            if (keylen == sizeof("feature_say")-1
+                 && memcmp(subf+1, "ay", keylen - sizeof("feature_")) == 0) {
+                mask = FEATURE_SAY_BIT;
+                break;
+            }
+            else if (keylen == sizeof("feature_signatures")-1
+                 && memcmp(subf+1, "ignatures", keylen - sizeof("feature_")) == 0) {
+                mask = FEATURE_SIGNATURES_BIT;
+                break;
+            }
+            else if (keylen == sizeof("feature_state")-1
+                 && memcmp(subf+1, "tate", keylen - sizeof("feature_")) == 0) {
+                mask = FEATURE_STATE_BIT;
+                break;
+            }
+            else if (keylen == sizeof("feature_switch")-1
+                 && memcmp(subf+1, "witch", keylen - sizeof("feature_")) == 0) {
+                mask = FEATURE_SWITCH_BIT;
+                break;
+            }
+            return;
+
+        case 'u':
+            if (keylen == sizeof("feature_unicode")-1
+                 && memcmp(subf+1, "nicode", keylen - sizeof("feature_")) == 0) {
+                mask = FEATURE_UNICODE_BIT;
+                break;
+            }
+            else if (keylen == sizeof("feature_unieval")-1
+                 && memcmp(subf+1, "nieval", keylen - sizeof("feature_")) == 0) {
+                mask = FEATURE_UNIEVAL_BIT;
+                break;
+            }
+            return;
+
+        default:
+            return;
+        }
+        if (valsv ? SvTRUE(valsv) : valbool)
+            PL_compiling.cop_features |= mask;
+        else
+            PL_compiling.cop_features &= ~mask;
+    }
+}
+#endif /* PERL_IN_MG_C */
+
 #endif /* PERL_FEATURE_H_ */
 
 /* ex: set ro: */

--- a/gv.c
+++ b/gv.c
@@ -2069,10 +2069,6 @@ S_gv_magicalize(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len,
                 if (memEQs(name, len, "\005NCODING"))
 		    goto magicalize;
 		break;
-            case '\006':
-                if (memEQs(name, len, "\006EATURE_BITS"))
-		    goto magicalize;
-                break;
 	    case '\007':	/* $^GLOBAL_PHASE */
                 if (memEQs(name, len, "\007LOBAL_PHASE"))
 		    goto ro_magicalize;

--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -5,7 +5,7 @@
 
 package feature;
 
-our $VERSION = '1.56';
+our $VERSION = '1.57';
 
 our %feature = (
     fc              => 'feature_fc',
@@ -21,23 +21,6 @@ our %feature = (
     unicode_eval    => 'feature_unieval',
     declared_refs   => 'feature_myref',
     unicode_strings => 'feature_unicode',
-);
-
-
-my %feature_bits = (
-    bitwise         => 0x0001,
-    current_sub     => 0x0002,
-    declared_refs   => 0x0004,
-    evalbytes       => 0x0008,
-    fc              => 0x0010,
-    postderef_qq    => 0x0020,
-    refaliasing     => 0x0040,
-    say             => 0x0080,
-    signatures      => 0x0100,
-    state           => 0x0200,
-    switch          => 0x0400,
-    unicode_eval    => 0x0800,
-    unicode_strings => 0x1000,
 );
 
 our %feature_bundle = (
@@ -503,16 +486,13 @@ sub __common {
     my $bundle_number = $^H & $hint_mask;
     my $features = $bundle_number != $hint_mask
       && $feature_bundle{$hint_bundles[$bundle_number >> $hint_shift]};
-    my $bits = ${^FEATURE_BITS};
     if ($features) {
 	# Features are enabled implicitly via bundle hints.
 	# Delete any keys that may be left over from last time.
 	delete @^H{ values(%feature) };
-        $bits = 0;
 	$^H |= $hint_mask;
 	for (@$features) {
 	    $^H{$feature{$_}} = 1;
-            $bits |= $feature_bits{$_};
 	    $^H |= $hint_uni8bit if $_ eq 'unicode_strings';
 	}
     }
@@ -540,15 +520,12 @@ sub __common {
         }
 	if ($import) {
 	    $^H{$feature{$name}} = 1;
-            $bits |= $feature_bits{$name};
 	    $^H |= $hint_uni8bit if $name eq 'unicode_strings';
 	} else {
             delete $^H{$feature{$name}};
-            $bits &= ~$feature_bits{$name};
             $^H &= ~ $hint_uni8bit if $name eq 'unicode_strings';
         }
     }
-    ${^FEATURE_BITS} = $bits;
 }
 
 sub unknown_feature {

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -2068,16 +2068,6 @@ function.
 This variable was added in Perl 5.8.2 and removed in 5.26.0.
 Setting it to anything other than C<undef> was made fatal in Perl 5.28.0.
 
-=item ${^FEATURE_BITS}
-X<${^FEATURE_BITS}>
-
-The current set of features enabled by the C<use feature> pragma.  It
-has the same scoping as the C<$^H> and C<%^H> variables.  The exact
-values are considered internal to the L<feature> pragma and may change
-between versions of Perl.
-
-This variable was added in Perl v5.32.0.
-
 =item ${^GLOBAL_PHASE}
 X<${^GLOBAL_PHASE}>
 

--- a/t/lib/feature/bits
+++ b/t/lib/feature/bits
@@ -1,0 +1,48 @@
+Test specifically for things that cop_features broke
+
+__END__
+# NAME check clearing $^H clears the bits
+# TODO this is broken
+use feature 'say';
+BEGIN { %^H = () }
+say "Fail";
+EXPECT
+String found where operator expected at - line 3, near "say "Fail""
+	(Do you need to predeclare say?)
+syntax error at - line 3, near "say "Fail""
+Execution of - aborted due to compilation errors.
+########
+# NAME check copying $^H restores the bits
+# TODO this isn't fixed yet
+use feature 'say';
+say "Hello";
+BEGIN { our %work = %^H; }
+no feature 'say';
+BEGIN { %^H = our %work }
+say "Goodbye";
+EXPECT
+Hello
+Goodbye
+########
+# NAME check deleting entries (via feature.pm) clears the bits
+use feature 'say';
+say "Hello";
+no feature 'say';
+say "Goodbye";
+EXPECT
+String found where operator expected at - line 4, near "say "Goodbye""
+	(Do you need to predeclare say?)
+syntax error at - line 4, near "say "Goodbye""
+Execution of - aborted due to compilation errors.
+########
+# NAME check deleting entries (bypass feature.pm) clears the bits
+# TODO this doesn't work yet
+use feature 'say';
+say "Hello";
+BEGIN { delete $^H{feature_say}; }
+say "Goodbye";
+EXPECT
+String found where operator expected at - line 4, near "say "Goodbye""
+	(Do you need to predeclare say?)
+syntax error at - line 4, near "say "Goodbye""
+Execution of - aborted due to compilation errors.

--- a/t/lib/feature/bits
+++ b/t/lib/feature/bits
@@ -2,7 +2,6 @@ Test specifically for things that cop_features broke
 
 __END__
 # NAME check clearing $^H clears the bits
-# TODO this is broken
 use feature 'say';
 BEGIN { %^H = () }
 say "Fail";
@@ -13,7 +12,6 @@ syntax error at - line 3, near "say "Fail""
 Execution of - aborted due to compilation errors.
 ########
 # NAME check copying $^H restores the bits
-# TODO this isn't fixed yet
 use feature 'say';
 say "Hello";
 BEGIN { our %work = %^H; }
@@ -36,7 +34,6 @@ syntax error at - line 4, near "say "Goodbye""
 Execution of - aborted due to compilation errors.
 ########
 # NAME check deleting entries (bypass feature.pm) clears the bits
-# TODO this doesn't work yet
 use feature 'say';
 say "Hello";
 BEGIN { delete $^H{feature_say}; }


### PR DESCRIPTION
sprout suggested there's code that saves and restores %^H, and that the ${^FEATURE_BITS} implementation doesn't handle that.

so re-work it so cop_features is updated automatically when %^H is modified.