### PR TITLE
Fix compile warnings for 32bit Perl in Storable module

### DIFF
--- a/dist/Storable/Storable.xs
+++ b/dist/Storable/Storable.xs
@@ -3443,7 +3443,7 @@ static int get_regexp(pTHX_ stcxt_t *cxt, SV* sv, SV **re, SV **flags) {
     count = call_sv((SV*)cv, G_ARRAY);
     SPAGAIN;
     if (count < 2)
-      CROAK(("re::regexp_pattern returned only %d results", count));
+      CROAK(("re::regexp_pattern returned only %d results", (int)count));
     *flags = POPs;
     SvREFCNT_inc(*flags);
     *re = POPs;
@@ -6864,7 +6864,7 @@ static SV *retrieve_regexp(pTHX_ stcxt_t *cxt, const char *cname) {
     SPAGAIN;
 
     if (count != 1)
-        CROAK(("Bad count %d calling _make_re", count));
+        CROAK(("Bad count %d calling _make_re", (int)count));
 
     re_ref = POPs;
 

--- a/dist/Storable/Storable.xs
+++ b/dist/Storable/Storable.xs
@@ -5958,7 +5958,7 @@ static SV *retrieve_lvstring(pTHX_ stcxt_t *cxt, const char *cname)
     }
 
     New(10003, s, len+1, char);
-    SAFEPVREAD(s, len, s);
+    SAFEPVREAD(s, (I32)len, s);
 
     sv = retrieve(aTHX_ cxt, cname);
     if (!sv) {


### PR DESCRIPTION
printf format `"%d"` expects `int`, not `I32` type. And `SAFEPVREAD` as its second argument expects signed ignored (not unsigned). `len` in `retrieve_lvstring` is already checked that is not larger then `I32_MAX`, so casting it to `I32` type is safe.