### PR TITLE
Local variable 'imode' hides a parameter of the same name

### DIFF
--- a/perlio.c
+++ b/perlio.c
@@ -1490,7 +1490,7 @@ PerlIO_openn(pTHX_ const char *layers, const char *mode, int fd,
 	     int imode, int perm, PerlIO *f, int narg, SV **args)
 {
     if (!f && narg == 1 && *args == &PL_sv_undef) {
-        int imode = PerlIOUnix_oflags(mode);
+        imode = PerlIOUnix_oflags(mode);
 
 	if (imode != -1 && (f = PerlIO_tmpfile_flags(imode))) {
 	    if (!layers || !*layers)


### PR DESCRIPTION
LGTM static code analysis of Perl 5 source code issued this
recommendation.  Implement fix.

https://lgtm.com/projects/g/Perl/perl5/rev/ae73d7ec2329275a2dba4be24415743f884d9dfd