### PR TITLE
APItest.xs: Fix compile warning: format ‘%d’ expects argument of type‘int’, but argument 2 has type ‘line_t {aka long unsigned int}’

### DIFF
--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.04';
+our $VERSION = '1.05';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -1084,7 +1084,7 @@ static OP *THX_parse_keyword_subsignature(pTHX)
 		seen_nextstate++;
 		retop = op_append_list(OP_LIST, retop, newSVOP(OP_CONST, 0,
 		    /* newSVpvf("nextstate:%s:%d", CopFILE(cCOPx(kid)), cCOPx(kid)->cop_line))); */
-		    newSVpvf("nextstate:%d", cCOPx(kid)->cop_line)));
+		    newSVpvf("nextstate:%u", (unsigned int)cCOPx(kid)->cop_line)));
 		break;
 	    case OP_ARGCHECK: {
 		UNOP_AUX_item *aux = cUNOP_AUXx(kid)->op_aux;


### PR DESCRIPTION
Use "%u" format modifier instead of "%d" as line_t is unsigned. Type line_t
is of U32 type and therefore casting it to unsigned int is safe on most
platforms.

Fixes: https://github.com/Perl/perl5/issues/17347