### PR TITLE
harden IO's cachepropagate-tcp

### DIFF
--- a/dist/IO/t/cachepropagate-tcp.t
+++ b/dist/IO/t/cachepropagate-tcp.t
@@ -9,7 +9,7 @@ use Socket;
 use Test::More;
 use Config;
 
-plan tests => 8;
+plan tests => 9;
 
 my $listener = IO::Socket::INET->new(Listen => 1,
                                      LocalAddr => '127.0.0.1',
@@ -36,12 +36,23 @@ SKIP: {
 	my $connector = IO::Socket::INET->new(PeerAddr => '127.0.0.1',
 					      PeerPort => $port,
 					      Proto => 'tcp');
+        if ($connector) {
+            my $buf;
+            # wait for parent to close its end
+            $connector->read($buf, 1);
+        }
+        else {
+            diag "child failed to connect to parent: $@";
+        }
 	exit(0);
     } else {;
 	    ok(defined($cpid), 'spawned a child');
     }
 
     my $new = $listener->accept();
+
+    ok($new, "got a socket from accept")
+      or diag "accept failed: $@";
 
     is($new->sockdomain(), $d, 'domain match');
   SKIP: {
@@ -52,6 +63,7 @@ SKIP: {
       skip "no Socket::SO_TYPE", 1 if !defined(eval { Socket::SO_TYPE });
       is($new->socktype(), $s, 'type match');
     }
+    $new->close;
 
     wait();
 }


### PR DESCRIPTION
This failed on Win32 like in the #17351 CI checks with:

../dist/if/t/if.t .................................................. ok
Can't call method "sockdomain" on an undefined value at t/cachepropagate-tcp.t line 46.
# Looks like your test exited with 9 just after 5.
../dist/IO/t/cachepropagate-tcp.t ..................................
Dubious, test returned 9 (wstat 2304, 0x900)
Failed 3/8 subtests

I suspect what happened is there was a race between the parent
accepting the connection and the child exiting and closing the
connection.

The Microsoft documentation for accept() indicates one possible
reason for failure is:

WSAECONNRESET
	An incoming connection was indicated, but was subsequently
        terminated by the remote peer prior to accepting the call.

which I suspect happened here.

So I've:

- added a basic error check for the result of accept()
- made the child to wait for the parent to close the socket
- the parent explicitly closes the socket