### PR TITLE
treat TAINT_get and TAINTING_get as unlikely

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -642,8 +642,8 @@ out of them.
                                     taint_proper(NULL, s);                  \
                                 }
 #   define TAINT_set(s)		(PL_tainted = (s))
-#   define TAINT_get		(PL_tainted)    /* Is something tainted? */
-#   define TAINTING_get		(PL_tainting)   /* Is taint checking enabled? */
+#   define TAINT_get		(cBOOL(UNLIKELY(PL_tainted)))    /* Is something tainted? */
+#   define TAINTING_get		(cBOOL(UNLIKELY(PL_tainting)))   /* Is taint checking enabled? */
 #   define TAINTING_set(s)	(PL_tainting = (s))
 #   define TAINT_WARN_get       (PL_taint_warn) /* FALSE => tainting violations
                                                             are fatal

--- a/scope.c
+++ b/scope.c
@@ -1053,7 +1053,7 @@ Perl_leave_scope(pTHX_ I32 base)
 #ifdef NO_TAINT_SUPPORT
             PERL_UNUSED_VAR(was);
 #else
-	    if (UNLIKELY(a0.any_ptr == &(TAINT_get))) {
+	    if (UNLIKELY(a0.any_ptr == &(PL_tainted))) {
 		/* If we don't update <was>, to reflect what was saved on the
 		 * stack for PL_tainted, then we will overwrite this attempt to
 		 * restore it when we exit this routine.  Note that this won't


### PR DESCRIPTION
While testing #17359 it appeared that inlining of SvTRUE was being
suppressed (indicated by -Winline) by being used in the statement:

  if (TAINT_get || SvTRUE(error)) {

but making TAINT_get unlikely allowed it to be inlined.

I expect even in a program that does use taint the vast majority
of data will be untainted, so I think it's safe to make TAINT_get
UNLIKELY().

TAINTING_get is a harder case, but it's only used in a relatively
much smaller number of cases, and I expect most runs of a system
perl will have neither -T nor -t.