### PR TITLE
Update documentation, readmes, comments, and utilities to reference the GitHub issue tracker

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,7 +3,8 @@
 # (hopefully) current and preferred email addresses from the commits.
 # These people have either submitted patches or suggestions, or their bug
 # reports or comments have inspired the appropriate patches.  Corrections,
-# additions, deletions welcome; send them to perlbug@perl.org, preferably
+# additions, deletions welcome; send them as a pull request to
+# https://github.com/Perl/perl5, or to perl5-porters@perl.org, preferably
 # as the output of diff(1), diff -u or diff -c between the original and a
 # corrected version of this file.
 #

--- a/Configure
+++ b/Configure
@@ -1537,8 +1537,8 @@ case "$sh" in
 $me:  Fatal Error:  I can't find a Bourne Shell anywhere.
 
 Usually it's in /bin/sh.  How did you even get this far?
-Please contact me (Perl Maintainers) at perlbug@perl.org and
-we'll try to straighten this all out.
+Please contact me (Perl Maintainers) at https://github.com/Perl/perl5/issues
+and we'll try to straighten this all out.
 EOM
 	exit 1
 	;;
@@ -2121,7 +2121,7 @@ THIS PACKAGE SEEMS TO BE INCOMPLETE.
 You have the option of continuing the configuration process, despite the
 distinct possibility that your kit is damaged, by typing 'y'es.  If you
 do, don't blame me if something goes wrong.  I advise you to type 'n'o
-and contact the author (perlbug@perl.org).
+and contact the author (https://github.com/Perl/perl5/issues).
 
 EOM
 		echo $n "Continue? [n] $c" >&4
@@ -2401,7 +2401,7 @@ Much effort has been expended to ensure that this shell script will run on any
 Unix system.  If despite that it blows up on yours, your best bet is to edit
 Configure and run it again.  If you can't run Configure for some reason,
 you'll have to generate a config.sh file by hand.  Whatever problems you
-have, let me (perlbug@perl.org) know how I blew it.
+have, let me (https://github.com/Perl/perl5/issues) know how I blew it.
 
 This installation script affects things in two ways:
 
@@ -3370,7 +3370,7 @@ EOM
 	(cd $src/hints; ls -C *.sh) | $sed 's/\.sh/   /g' >&4
 	dflt=''
 	: Half the following guesses are probably wrong... If you have better
-	: tests or hints, please send them to perlbug@perl.org
+	: tests or hints, please send them to https://github.com/Perl/perl5/issues
 	: The metaconfig authors would also appreciate a copy...
 	$test -f /irix && osname=irix
 	$test -f /xenix && osname=sco_xenix
@@ -5788,7 +5788,7 @@ compile='
 mc_file=$1;
 shift;
 case "$usedevel" in $define|true|[yY]*) if $test ! -f "${mc_file}.c"; then
-echo "Internal Configure script bug - compiler test file ${mc_file}.c is missing. Please report this to perlbug@perl.org" >&4;
+echo "Internal Configure script bug - compiler test file ${mc_file}.c is missing. Please report this to https://github.com/Perl/perl5/issues" >&4;
 exit 1;
 fi;
 esac;
@@ -8784,7 +8784,7 @@ case "$shrpdir" in
 *)	$cat >&4 <<EOM
 WARNING:  Use of the shrpdir variable for the installation location of
 the shared $libperl is not supported.  It was never documented and
-will not work in this version.  Let me (perlbug@perl.org)
+will not work in this version.  Let me (https://github.com/Perl/perl5/issues)
 know of any problems this may cause.
 
 EOM

--- a/INSTALL
+++ b/INSTALL
@@ -2384,30 +2384,28 @@ settings"> above.
 
 =head1 Reporting Problems
 
-Wherever possible please use the perlbug tool supplied with this Perl
-to report problems, as it automatically includes summary configuration
-information about your perl, which may help us track down problems far
-more quickly. But first you should read the advice in this file,
-carefully re-read the error message and check the relevant manual pages
-on your system, as these may help you find an immediate solution.
-Once you've exhausted the documentation, please report bugs to us using
-the 'perlbug' tool.
+Please report problems to the GitHub issue tracker at
+https://github.com/Perl/perl5/issues, which will ask for the
+appropriate summary configuration information about your perl, which
+may help us track down problems far more quickly.  But first you should
+read the advice in this file, carefully re-read the error message and
+check the relevant manual pages on your system, as these may help you
+find an immediate solution.  Once you've exhausted the documentation,
+please report bugs to us using the GitHub tracker.
 
-The perlbug tool is installed along with perl, so after you have
-completed C<make install> it should be possible to run it with plain
-C<perlbug>.  If the install fails, or you want to report problems with
-C<make test> without installing perl, then you can use C<make nok> to
-run perlbug to report the problem, or run it by hand from this source
-directory with C<./perl -Ilib utils/perlbug>
+The summary configuration information can be printed with C<perl -V>.
+If the install fails, or you want to report problems with C<make test>
+without installing perl, then you can run it by hand from this source
+directory with C<./perl -V>.
 
-If the build fails too early to run perlbug uninstalled, then please
-B<run> the C<./myconfig> shell script, and mail its output along with
-an accurate description of your problem to perlbug@perl.org
+If the build fails too early to run perl, then please
+B<run> the C<./myconfig> shell script, and include its output along
+with an accurate description of your problem.
 
 If Configure itself fails, and does not generate a config.sh file
-(needed to run C<./myconfig>), then please mail perlbug@perl.org the
+(needed to run C<./myconfig>), then please open an issue with the
 description of how Configure fails along with details of your system
--- for example the output from running C<uname -a>
+-- for example the output from running C<uname -a>.
 
 Please try to make your message brief but clear.  Brief, clear bug
 reports tend to get answered more quickly.  Please don't worry if your
@@ -2420,13 +2418,10 @@ config.sh or a complete Configure or make log) unless absolutely
 necessary.  Do not include a complete transcript of your build
 session.  Just include the failing commands, the relevant error
 messages, and whatever preceding commands are necessary to give the
-appropriate context.  Plain text should usually be sufficient -- fancy
-attachments or encodings may actually reduce the number of people who
-read your message.  Your message will get relayed to over 400
-subscribers around the world so please try to keep it brief but clear.
+appropriate context.
 
 If the bug you are reporting has security implications which make it
-inappropriate to send to a publicly archived mailing list, then see
+inappropriate to send to a public issue tracker, then see
 L<perlsec/SECURITY VULNERABILITY CONTACT INFORMATION>
 for details of how to report the issue.
 

--- a/Porting/how_to_write_a_perldelta.pod
+++ b/Porting/how_to_write_a_perldelta.pod
@@ -165,7 +165,7 @@ for the particular file in core.)
 
 =item Utility Changes
 
-Changes to installed programs such as F<perlbug> and F<xsubpp> go here. Most
+Changes to installed programs such as F<perldoc> and F<xsubpp> go here. Most
 of these are built within the directory F<utils>.
 
 =item New Documentation

--- a/Porting/perldelta_template.pod
+++ b/Porting/perldelta_template.pod
@@ -157,8 +157,8 @@ XXX Description of the purpose of the new file here
 =head2 Changes to Existing Documentation
 
 We have attempted to update the documentation to reflect the changes
-listed in this document.  If you find any we have missed, send email
-to L<perlbug@perl.org|mailto:perlbug@perl.org>.
+listed in this document.  If you find any we have missed, open an issue
+at L<https://github.com/Perl/perl5/issues>.
 
 XXX Changes which significantly change existing files in F<pod/> go here.
 However, any changes to F<pod/perldiag.pod> should go in the L</Diagnostics>
@@ -224,7 +224,7 @@ XXX Describe change here
 
 =head1 Utility Changes
 
-XXX Changes to installed programs such as F<perlbug> and F<xsubpp> go here.
+XXX Changes to installed programs such as F<perldoc> and F<xsubpp> go here.
 Most of these are built within the directory F<utils>.
 
 [ List utility changes as a =head2 entry for each utility and =item
@@ -411,13 +411,12 @@ If you find what you think is a bug, you might check the perl bug database
 at L<https://github.com/Perl/perl5/issues>.  There may also be information at
 L<http://www.perl.org/>, the Perl Home Page.
 
-If you believe you have an unreported bug, please run the L<perlbug> program
-included with your release.  Be sure to trim your bug down to a tiny but
-sufficient test case.  Your bug report, along with the output of C<perl -V>,
-will be sent off to perlbug@perl.org to be analysed by the Perl porting team.
+If you believe you have an unreported bug, please open an issue at
+L<https://github.com/Perl/perl5/issues>.  Be sure to trim your bug down to a
+tiny but sufficient test case.
 
 If the bug you are reporting has security implications which make it
-inappropriate to send to a publicly archived mailing list, then see
+inappropriate to send to a public issue tracker, then see
 L<perlsec/SECURITY VULNERABILITY CONTACT INFORMATION>
 for details of how to report the issue.
 

--- a/Porting/pod_lib.pl
+++ b/Porting/pod_lib.pl
@@ -547,7 +547,7 @@ Hash reference; each element provides either a list or a lookup table for
 information about various types of POD files.
 
   'aux'             => [ # utility programs like
-                            'h2xs' and 'perlbug' ]
+                            'h2xs' and 'perldoc' ]
   'generated'       => { # lookup table for generated POD files
                             like 'perlapi.pod' }
   'ignore'          => { # lookup table for files to be ignored }

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -1109,9 +1109,7 @@ Test L<perlbug> with the following:
     Action (Send/Display/Edit/Subject/Save to File): Q
 
 and carefully examine the output (in F<perlbug.rep]>), especially
-the "Locally applied patches" section. If everything appears okay, then
-delete the file, and try it again, this time actually submitting the bug
-report. Check that it shows up, then remember to close it!
+the "Locally applied patches" section.
 
 =for checklist skip BLEAD-POINT
 

--- a/README
+++ b/README
@@ -61,8 +61,7 @@ Perl is a large and complex system that's used for everything from
 knitting to rocket science.  If you run into trouble, it's quite
 likely that someone else has already solved the problem you're
 facing. Once you've exhausted the documentation, please report bugs to us
-using the 'perlbug' tool. For more information about perlbug, either type
-'perldoc perlbug' or just 'perlbug' on a line by itself.
+at the GitHub issue tracker at https://github.com/Perl/perl5/issues
 
 While it was current when we made it available, Perl is constantly evolving
 and there may be a more recent version that fixes bugs you've run into or

--- a/README.bs2000
+++ b/README.bs2000
@@ -8,7 +8,7 @@ about pod in pod/perlpod.pod or the short summary in the INSTALL file.
 perlbs2000 - building and installing Perl for BS2000.
 
 B<This document needs to be updated, but we don't know what it should say.
-Please email comments to L<perlbug@perl.org|mailto:perlbug@perl.org>.>
+Please submit comments to L<https://github.com/Perl/perl5/issues>.>
 
 =head1 SYNOPSIS
 

--- a/README.freebsd
+++ b/README.freebsd
@@ -36,5 +36,6 @@ C<argv[0]> value for C<$^X>.
 Nicholas Clark <nick@ccl4.org>, collating wisdom supplied by Slaven Rezic
 and Tim Bunce.
 
-Please report any errors, updates, or suggestions to L<mailto:perlbug@perl.org>.
+Please report any errors, updates, or suggestions to
+L<https://github.com/Perl/perl5/issues>.
 

--- a/README.irix
+++ b/README.irix
@@ -134,5 +134,6 @@ at least the shuffle.t and sort.t failures.
 
 Jarkko Hietaniemi <jhi@iki.fi>
 
-Please report any errors, updates, or suggestions to F<perlbug@perl.org>.
+Please report any errors, updates, or suggestions to
+L<https://github.com/Perl/perl5/issues>.
 

--- a/README.linux
+++ b/README.linux
@@ -35,5 +35,6 @@ is needed to get this working better.
 
 Steve Peters <steve@fisharerojo.org>
 
-Please report any errors, updates, or suggestions to F<perlbug@perl.org>.
+Please report any errors, updates, or suggestions to
+L<https://github.com/Perl/perl5/issues>.
 

--- a/README.macosx
+++ b/README.macosx
@@ -122,8 +122,8 @@ on G5-based hosts.
 
 Support for 64-bit addressing is experimental: some aspects of Perl may be
 omitted or buggy. Note the messages output by F<Configure> for further 
-information. Please use C<perlbug> to submit a problem report in the
-event that you encounter difficulties.
+information. Please use L<https://github.com/Perl/perl5/issues> to submit a
+problem report in the event that you encounter difficulties.
 
 When building 64-bit modules, it is your responsibility to ensure that linked
 external libraries and frameworks provide 64-bit support: if they do not,

--- a/README.openbsd
+++ b/README.openbsd
@@ -26,5 +26,6 @@ will run into this problem.  If you want to run a threaded Perl on OpenBSD
 
 Steve Peters <steve@fisharerojo.org>
 
-Please report any errors, updates, or suggestions to F<perlbug@perl.org>.
+Please report any errors, updates, or suggestions to
+L<https://github.com/Perl/perl5/issues>.
 

--- a/README.os390
+++ b/README.os390
@@ -13,7 +13,7 @@ This document will help you Configure, build, test and install Perl
 on OS/390 (aka z/OS) Unix System Services.
 
 B<This document needs to be updated, but we don't know what it should say.
-Please email comments to L<perlbug@perl.org|mailto:perlbug@perl.org>.>
+Please submit comments to L<https://github.com/Perl/perl5/issues>.>
 
 =head1 DESCRIPTION
 

--- a/README.os400
+++ b/README.os400
@@ -7,7 +7,7 @@ designed to be readable as is.
 perlos400 - Perl version 5 on OS/400
 
 B<This document needs to be updated, but we don't know what it should say.
-Please email comments to L<perlbug@perl.org|mailto:perlbug@perl.org>.>
+Please submit comments to L<https://github.com/Perl/perl5/issues>.>
 
 =head1 DESCRIPTION
 

--- a/README.solaris
+++ b/README.solaris
@@ -709,4 +709,5 @@ The original was written by Andy Dougherty F<doughera@lafayette.edu>
 drawing heavily on advice from Alan Burlison, Nick Ing-Simmons, Tim Bunce,
 and many other Solaris users over the years.
 
-Please report any errors, updates, or suggestions to F<perlbug@perl.org>.
+Please report any errors, updates, or suggestions to
+L<https://github.com/Perl/perl5/issues>.

--- a/README.vms
+++ b/README.vms
@@ -467,10 +467,9 @@ of the GNU cc headers.
 =head1 Reporting Bugs
 
 If you come across what you think might be a bug in Perl, please report
-it. There's a script in PERL_ROOT:[UTILS], perlbug, that walks you through
-the process of creating a bug report. This script includes details of your
-installation, and is very handy. Completed bug reports should go to
-perlbug@perl.org.
+it. The issue tracker at L<https://github.com/Perl/perl5/issues> walks you
+through the process of creating a bug report and including details of your
+installation.
 
 =head1 CAVEATS
 

--- a/README.win32
+++ b/README.win32
@@ -685,8 +685,8 @@ or any invocation of make.
 If a module does not build for some reason, look carefully for
 why it failed, and report problems to the module author.  If
 it looks like the extension building support is at fault, report
-that with full details of how the build failed using the perlbug
-utility.
+that with full details of how the build failed using the GitHub
+issue tracker at L<https://github.com/Perl/perl5/issues>.
 
 =item Command-line Wildcard Expansion
 
@@ -874,9 +874,8 @@ executable built during the installation process.  Usage is exactly
 the same as normal C<perl> on Windows, except that options like C<-h>
 don't work (since they need a command-line window to print to).
 
-If you find bugs in perl, you can run C<perlbug> to create a
-bug report (you may have to send it manually if C<perlbug> cannot
-find a mailer on your system).
+If you find bugs in perl, you can report them to
+L<https://github.com/Perl/perl5/issues>.
 
 =head1 BUGS AND CAVEATS
 
@@ -924,8 +923,8 @@ variable in the handler.  Using signals under this port should
 currently be considered unsupported.
 
 Please send detailed descriptions of any problems and solutions that
-you may find to E<lt>F<perlbug@perl.org>E<gt>, along with the output
-produced by C<perl -V>.
+you may find to E<lt>L<https://github.com/Perl/perl5/issues>E<gt>,
+along with the output produced by C<perl -V>.
 
 =head1 ACKNOWLEDGEMENTS
 

--- a/hints/README.hints
+++ b/hints/README.hints
@@ -9,7 +9,8 @@ can't or doesn't guess properly.  Most of these hint files have been
 tested with at least some version of perl5, but some are still left
 over from perl4.
 
-Please send any problems or suggested changes to perlbug@perl.org.
+Please send any problems or suggested changes to
+L<https://github.com/Perl/perl5/issues>.
 
 =head1 Hint file naming convention.
 

--- a/hints/bsdos.sh
+++ b/hints/bsdos.sh
@@ -125,7 +125,7 @@ $define|true|[yY]*)
 	*)   cat <<EOM >&4
 I did not know that BSD/OS $osvers supports POSIX threads.
 
-Feel free to tell perlbug@perl.org otherwise.
+Feel free to tell https://github.com/Perl/perl5/issues otherwise.
 EOM
 	    exit 1
 	    ;;

--- a/hints/freebsd.sh
+++ b/hints/freebsd.sh
@@ -207,7 +207,7 @@ $define|true|[yY]*)
 	0.*|1.*|2.0*|2.1*)   cat <<EOM >&4
 I did not know that FreeBSD $osvers supports POSIX threads.
 
-Feel free to tell perlbug@perl.org otherwise.
+Feel free to tell https://github.com/Perl/perl5/issues otherwise.
 EOM
 	      exit 1
 	      ;;

--- a/pod/perl.pod
+++ b/pod/perl.pod
@@ -428,11 +428,9 @@ displayed by diagnostics are internally stored as short integers,
 so they are limited to a maximum of 65535 (higher numbers usually being
 affected by wraparound).
 
-You may mail your bug reports (be sure to include full configuration
+You may submit your bug reports (be sure to include full configuration
 information as output by the myconfig program in the perl source
-tree, or by C<perl -V>) to perlbug@perl.org .  If you've succeeded
-in compiling perl, the L<perlbug> script in the F<utils/> subdirectory
-can be used to help mail in a bug report.
+tree, or by C<perl -V>) to L<https://github.com/Perl/perl5/issues>.
 
 Perl actually stands for Pathologically Eclectic Rubbish Lister, but
 don't tell anyone I said that.

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -158,7 +158,7 @@ XXX Description of the purpose of the new file here
 
 We have attempted to update the documentation to reflect the changes
 listed in this document.  If you find any we have missed, send email
-to L<perlbug@perl.org|mailto:perlbug@perl.org>.
+to L<https://github.com/Perl/perl5/issues>.
 
 XXX Changes which significantly change existing files in F<pod/> go here.
 However, any changes to F<pod/perldiag.pod> should go in the L</Diagnostics>
@@ -224,7 +224,7 @@ XXX Describe change here
 
 =head1 Utility Changes
 
-XXX Changes to installed programs such as F<perlbug> and F<xsubpp> go here.
+XXX Changes to installed programs such as F<perldoc> and F<xsubpp> go here.
 Most of these are built within the directory F<utils>.
 
 [ List utility changes as a =head2 entry for each utility and =item
@@ -411,13 +411,12 @@ If you find what you think is a bug, you might check the perl bug database
 at L<https://github.com/Perl/perl5/issues>.  There may also be information at
 L<http://www.perl.org/>, the Perl Home Page.
 
-If you believe you have an unreported bug, please run the L<perlbug> program
-included with your release.  Be sure to trim your bug down to a tiny but
-sufficient test case.  Your bug report, along with the output of C<perl -V>,
-will be sent off to perlbug@perl.org to be analysed by the Perl porting team.
+If you believe you have an unreported bug, please open an issue at
+L<https://github.com/Perl/perl5/issues>.  Be sure to trim your bug down to a
+tiny but sufficient test case.
 
 If the bug you are reporting has security implications which make it
-inappropriate to send to a publicly archived mailing list, then see
+inappropriate to send to a public issue tracker, then see
 L<perlsec/SECURITY VULNERABILITY CONTACT INFORMATION>
 for details of how to report the issue.
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -1923,7 +1923,7 @@ called as barewords.  Something like this will work:
 
 (P) This is either an error in Perl, or, if you're using
 one, your L<custom regular expression engine|perlreapi>.  If not the
-latter, report the problem through the L<perlbug> utility.
+latter, report the problem to L<https://github.com/Perl/perl5/issues>.
 
 =item corrupted regexp pointers
 
@@ -4866,7 +4866,7 @@ utility to report; in regex; marked by S<<-- HERE> in m/%s/
 (S regexp) You used a regular expression with case-insensitive matching,
 and there is a bug in Perl in which the built-in regular expression
 folding rules are not accurate.  This may lead to incorrect results.
-Please report this as a bug using the L<perlbug> utility.
+Please report this as a bug to L<https://github.com/Perl/perl5/issues>.
 
 =item PerlIO layer ':win32' is experimental
 

--- a/pod/perlebcdic.pod
+++ b/pod/perlebcdic.pod
@@ -19,7 +19,7 @@ not all
 the modules found on CPAN but shipped with core Perl work on z/OS.
 
 If you want to use Perl on a non-z/OS EBCDIC machine, please let us know
-by sending mail to perlbug@perl.org
+at L<https://github.com/Perl/perl5/issues>.
 
 Writing Perl on an EBCDIC platform is really no different than writing
 on an L</ASCII> one, but with different underlying numbers, as we'll see

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -2404,8 +2404,8 @@ part of the API.  (See L</Internal
 Functions>.)  The easiest way to be B<sure> a
 function is part of the API is to find its entry in L<perlapi>.
 If it exists in L<perlapi>, it's part of the API.  If it doesn't, and you
-think it should be (i.e., you need it for your extension), send mail via
-L<perlbug> explaining why you think it should be.
+think it should be (i.e., you need it for your extension), submit an issue at
+L<https://github.com/Perl/perl5/issues> explaining why you think it should be.
 
 Second problem: there must be a syntax so that the same subroutine
 declarations and calls can pass a structure as their first argument,

--- a/pod/perlhack.pod
+++ b/pod/perlhack.pod
@@ -117,12 +117,9 @@ these commands:
 
 =head1 BUG REPORTING
 
-If you want to report a bug in Perl, you must use the F<perlbug>
-command line tool.  This tool will ensure that your bug report includes
-all the relevant system and configuration information.
-
-To browse existing Perl bugs and patches, you can use the web interface
-at L<https://github.com/perl/perl5/issues>.
+If you want to report a bug in Perl, or browse existing Perl bugs and
+patches, use the GitHub issue tracker at
+L<https://github.com/perl/perl5/issues>.
 
 Please check the archive of the perl5-porters list (see below) and/or
 the bug tracking system before submitting a bug report.  Often, you'll

--- a/pod/perllocale.pod
+++ b/pod/perllocale.pod
@@ -1699,7 +1699,8 @@ effect.  See L<perlembed/Using embedded Perl with POSIX locales>.
 It becomes more important for perl to know about all the possible
 locale categories on the platform, even if they aren't apparently used
 in your program.  Perl knows all of the Linux ones.  If your platform
-has others, you can send email to L<mailto:perlbug@perl.org> for
+has others, you can submit an issue at
+L<https://github.com/Perl/perl5/issues> for
 inclusion of it in the next release.  In the meantime, it is possible to
 edit the Perl source to teach it about the category, and then recompile.
 Search for instances of, say, C<LC_PAPER> in the source, and use that as
@@ -1720,11 +1721,12 @@ In certain systems, the operating system's locale support
 is broken and cannot be fixed or used by Perl.  Such deficiencies can
 and will result in mysterious hangs and/or Perl core dumps when
 C<use locale> is in effect.  When confronted with such a system,
-please report in excruciating detail to <F<perlbug@perl.org>>, and
+please report in excruciating detail to
+<L<https://github.com/Perl/perl5/issues>>, and
 also contact your vendor: bug fixes may exist for these problems
 in your operating system.  Sometimes such bug fixes are called an
 operating system upgrade.  If you have the source for Perl, include in
-the perlbug email the output of the test described above in L</Testing
+the bug report the output of the test described above in L</Testing
 for broken locales>.
 
 =head1 SEE ALSO

--- a/pod/perlport.pod
+++ b/pod/perlport.pod
@@ -1234,8 +1234,8 @@ character sets internally (usually Character Code Set ID 0037 for OS/400
 and either 1047 or POSIX-BC for S/390 systems).
 
 The rest of this section may need updating, but we don't know what it
-should say.  Please email comments to
-L<perlbug@perl.org|mailto:perlbug@perl.org>.
+should say.  Please submit comments to
+L<https://github.com/Perl/perl5/issues>.
 
 On the mainframe Perl currently works under the "Unix system
 services for OS/390" (formerly known as OpenEdition), VM/ESA OpenEdition, or
@@ -2475,7 +2475,8 @@ the past (5.005_03 and earlier), but we haven't been able to verify
 their status for the current release, either because the
 hardware/software platforms are rare or because we don't have an
 active champion on these platforms--or both.  They used to work,
-though, so go ahead and try compiling them, and let perlbug@perl.org
+though, so go ahead and try compiling them, and let
+L<https://github.com/Perl/perl5/issues> know
 of any trouble.
 
         3b1

--- a/pod/perlrecharclass.pod
+++ b/pod/perlrecharclass.pod
@@ -1214,8 +1214,8 @@ illustrated above.
 
 Due to the way that Perl parses things, your parentheses and brackets
 may need to be balanced, even including comments.  If you run into any
-examples, please send them to C<perlbug@perl.org>, so that we can have a
-concrete example for this man page.
+examples, please submit them to L<https://github.com/Perl/perl5/issues>,
+so that we can have a concrete example for this man page.
 
 We may change it so that things that remain legal uses in normal bracketed
 character classes might become illegal within this experimental

--- a/pod/perlutil.pod
+++ b/pod/perlutil.pod
@@ -98,10 +98,10 @@ and in particular, extending Perl with C.
 
 =item L<perlbug|perlbug>
 
-F<perlbug> is the recommended way to report bugs in the perl interpreter
-itself or any of the standard library modules back to the developers;
-please read through the documentation for F<perlbug> thoroughly before
-using it to submit a bug report.
+F<perlbug> used to be the recommended way to report bugs in the perl
+interpreter itself or any of the standard library modules back to the
+developers; bug reports and patches should now be submitted to
+L<https://github.com/Perl/perl5/issues>.
 
 =item L<perlthanks|perlbug>
 

--- a/t/README
+++ b/t/README
@@ -19,7 +19,8 @@ will fail, you may want to use Test::Harness thusly:
         ./perl harness
 This method pinpoints failed tests automatically.
 
-If you come up with new tests, please send them to perlbug@perl.org.
+If you come up with new tests, please submit them to
+https://github.com/Perl/perl5/issues.
 
 Tests in the t/base/ directory ought to be runnable with plain miniperl.
 That is, they should not require Config.pm nor should they require any

--- a/t/op/groups.t
+++ b/t/op/groups.t
@@ -234,7 +234,7 @@ sub _system_groups {
 #
 # If these tests fail, report the particular incantation you use
 # on this platform to find *all* the groups that an arbitrary
-# user may belong to, using the 'perlbug' program.
+# user may belong to, using the issue tracker.
 EOM
         }
         return ( $cmd, $str );

--- a/utils/h2xs.PL
+++ b/utils/h2xs.PL
@@ -1999,7 +1999,7 @@ $generate_code
 __END__
 gave unexpected error $@
 Please report the circumstances of this bug in h2xs version $H2XS_VERSION
-using the perlbug script.
+using the issue tracker at https://github.com/Perl/perl5/issues.
 EOM
   } else {
     my $fail;
@@ -2020,7 +2020,7 @@ the files $ext$modpname/$constscfname and $ext$modpname/$constsxsfname
 correctly.
 
 Please report the circumstances of this bug in h2xs version $H2XS_VERSION
-using the perlbug script.
+using the issue tracker at https://github.com/Perl/perl5/issues.
 EOM
     } else {
       unlink $constscfname, $constsxsfname;

--- a/utils/perlbug.PL
+++ b/utils/perlbug.PL
@@ -1278,7 +1278,7 @@ B<perlthanks>
 =head1 DESCRIPTION
 
 
-This program is designed to help you generate and send bug reports
+This program is designed to help you generate bug reports
 (and thank-you notes) about perl5 and the modules which ship with it.
 
 In most cases, you can just run it interactively from a command
@@ -1290,17 +1290,16 @@ non-core module (such as Tk, DBI, etc), then please see the
 documentation that came with that distribution to determine the
 correct place to report bugs.
 
-If you are unable to send your report using B<perlbug> (most likely
-because your system doesn't have a way to send mail that perlbug
-recognizes), you may be able to use this tool to compose your report
-and save it to a file which you can then send to B<perlbug@perl.org>
-using your regular mail client.
+Bug reports should be submitted to the GitHub issue tracker at
+L<https://github.com/Perl/perl5/issues>. The B<perlbug@perl.org>
+address no longer automatically opens tickets. You can use this tool
+to compose your report and save it to a file which you can then submit
+to the issue tracker.
 
 In extreme cases, B<perlbug> may not work well enough on your system
 to guide you through composing a bug report. In those cases, you
-may be able to use B<perlbug -d> to get system configuration
-information to include in a manually composed bug report to
-B<perlbug@perl.org>.
+may be able to use B<perlbug -d> or B<perl -V> to get system
+configuration information to include in your issue report.
 
 
 When reporting a bug, please run through this checklist:
@@ -1374,7 +1373,7 @@ Be sure to include the B<exact> error messages, if any.
 
 If you get a core dump (or equivalent), you may use a debugger
 (B<dbx>, B<gdb>, etc) to produce a stack trace to include in the bug
-report.  
+report.
 
 NOTE: unless your Perl has been compiled with debug info
 (often B<-g>), the stack trace is likely to be somewhat hard to use
@@ -1393,9 +1392,11 @@ will help a great deal.  In other words, try to analyze the problem
 
 If so, that's great news; bug reports with patches are likely to
 receive significantly more attention and interest than those without
-patches.  Please attach your patch to the report using the C<-p> option.
-When sending a patch, create it using C<git format-patch> if possible,
-though a unified diff created with C<diff -pu> will do nearly as well.
+patches.  Please submit your patch via the GitHub Pull Request workflow
+as described in B<perldoc> L<perlhack>.  You may also send patches to
+B<perl5-porters@perl.org>.  When sending a patch, create it using
+C<git format-patch> if possible, though a unified diff created with
+C<diff -pu> will do nearly as well.
 
 Your patch may be returned with requests for changes, or requests for more
 detailed explanations about your fix.
@@ -1410,21 +1411,6 @@ same style as the code you are trying to patch.  Make sure your patch
 really does work (C<make test>, if the thing you're patching is covered
 by Perl's test suite).
 
-=item Can you use C<perlbug> to submit the report?
-
-B<perlbug> will, amongst other things, ensure your report includes
-crucial information about your version of perl.  If C<perlbug> is
-unable to mail your report after you have typed it in, you may have
-to compose the message yourself, add the output produced by C<perlbug
--d> and email it to B<perlbug@perl.org>.  If, for some reason, you
-cannot run C<perlbug> at all on your system, be sure to include the
-entire output produced by running C<perl -V> (note the uppercase V).
-
-Whether you use C<perlbug> or send the email manually, please make
-your Subject line informative.  "a bug" is not informative.  Neither
-is "perl crashes" nor is "HELP!!!".  These don't help.  A compact
-description of what's wrong is fine.
-
 =item Can you use C<perlbug> to submit a thank-you note?
 
 Yes, you can do this by either using the C<-T> option, or by invoking
@@ -1432,6 +1418,10 @@ the program as C<perlthanks>. Thank-you notes are good. It makes people
 smile. 
 
 =back
+
+Please make your issue title informative.  "a bug" is not informative.
+Neither is "perl crashes" nor is "HELP!!!".  These don't help.  A compact
+description of what's wrong is fine.
 
 Having done your bit, please be prepared to wait, to be told the
 bug is in your code, or possibly to get no reply at all.  The
@@ -1441,8 +1431,8 @@ a duplicate of an existing report, you may not receive a personal
 reply.
 
 If it is important to you that your bug be fixed, do monitor the
-perl5-porters@perl.org mailing list (mailing lists are moderated, your
-message may take a while to show up) and the commit logs to development
+issue tracker (you will be subscribed to notifications for issues you
+submit or comment on) and the commit logs to development
 versions of Perl, and encourage the maintainers with kind words or
 offers of frosty beverages.  (Please do be kind to the maintainers.
 Harassing or flaming them is likely to have the opposite effect of the


### PR DESCRIPTION
The perlbug utility and perlbug@perl.org should no longer be used to submit bug reports or patches.

This implements the documentation component of https://github.com/Perl/perl5/issues/17197.