### PR TITLE
Document that epoch is always 1970

### DIFF
--- a/pod/perlport.pod
+++ b/pod/perlport.pod
@@ -670,7 +670,7 @@ When calculating specific times, such as for tests in time or date modules,
 it may be appropriate to calculate an offset for the epoch.
 
     use Time::Local qw(timegm);
-    my $offset = timegm(0, 0, 0, 1, 0, 70);
+    my $offset = timegm(0, 0, 0, 1, 0, 1970);
 
 The value for C<$offset> in Unix will be C<0>, but in Mac OS Classic
 will be some large number.  C<$offset> can then be added to a Unix time


### PR DESCRIPTION
Document that epoch is always 1970
and not meant to be interpreted as 2070 in 2020 because of rolling century.

Fixes #16431