### PR TITLE
Change various search.cpan.org references to metacpan.org and www.cpan.org

### DIFF
--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -1569,8 +1569,8 @@ If they haven't, ask Ask <ask@perl.org>.
 
 =item *
 
-Check L<https://search.cpan.org> to see if it has indexed the distribution.
-It should be visible at a URL like C<https://search.cpan.org/dist/perl-5.10.1/>.
+Check L<https://metacpan.org> to see if it has indexed the distribution.
+It should be visible at a URL like C<https://metacpan.org/release/DAPM/perl-5.10.1>.
 
 =back
 

--- a/README.win32
+++ b/README.win32
@@ -109,7 +109,7 @@ polling loop.
 
 A port of dmake for Windows is available from:
 
-L<https://search.cpan.org/dist/dmake/>
+L<https://metacpan.org/release/dmake>
 
 Fetch and install dmake somewhere on your path.
 

--- a/pod/perlhack.pod
+++ b/pod/perlhack.pod
@@ -1169,11 +1169,11 @@ configurations.
 
 Both efforts welcome volunteers.  In order to get involved in smoke
 testing of the perl itself visit
-L<https://search.cpan.org/dist/Test-Smoke/>.  In order to start smoke
+L<https://metacpan.org/release/Test-Smoke>.  In order to start smoke
 testing CPAN modules visit
-L<https://search.cpan.org/dist/CPANPLUS-YACSmoke/> or
-L<https://search.cpan.org/dist/minismokebox/> or
-L<https://search.cpan.org/dist/CPAN-Reporter/>.
+L<https://metacpan.org/release/CPANPLUS-YACSmoke> or
+L<https://metacpan.org/release/minismokebox> or
+L<https://metacpan.org/release/CPAN-Reporter>.
 
 =head1 WHAT NEXT?
 

--- a/pod/perlmodinstall.pod
+++ b/pod/perlmodinstall.pod
@@ -142,7 +142,7 @@ If you used WinZip, this was already done for you.
 You'll need the C<nmake> utility, available at
 L<http://download.microsoft.com/download/vc15/Patch/1.52/W95/EN-US/nmake15.exe>
 or dmake, available on CPAN.
-L<https://search.cpan.org/dist/dmake/>
+L<https://metacpan.org/release/dmake>
 
 Does the module require compilation (i.e. does it have files that end
 in .xs, .c, .h, .y, .cc, .cxx, or .C)?  If it does, life is now

--- a/pod/perlmodlib.PL
+++ b/pod/perlmodlib.PL
@@ -118,7 +118,7 @@ push @mod, "=item Config\n\nAccess Perl configuration information\n\n";
 # parse as (reasonably) sane Pod as-is to anything that attempts to
 # brute-force treat it as such. The content is already useful - this just
 # makes it tidier, by stopping anything doing this mistaking the rest of the
-# Perl code for Pod. eg https://search.cpan.org/dist/perl/pod/perlmodlib.PL
+# Perl code for Pod. eg https://metacpan.org/pod/perlmodlib
 
 print $out <<'=cut';
 =head1 NAME

--- a/pod/perlootut.pod
+++ b/pod/perlootut.pod
@@ -23,7 +23,7 @@ version.
 This document provides an introduction to object-oriented programming
 in Perl. It begins with a brief overview of the concepts behind object
 oriented design. Then it introduces several different OO systems from
-L<CPAN|https://search.cpan.org> which build on top of what Perl
+L<CPAN|https://www.cpan.org> which build on top of what Perl
 provides.
 
 By default, Perl's built-in OO system is very minimal, leaving you to
@@ -547,7 +547,7 @@ C<Moose> itself.
 =item * Rich ecosystem
 
 There is a rich ecosystem of C<Moose> extensions on CPAN under the
-L<MooseX|https://search.cpan.org/search?query=MooseX&mode=dist>
+L<MooseX|https://metacpan.org/search?q=MooseX>
 namespace. In addition, many modules on CPAN already use C<Moose>,
 providing you with lots of examples to learn from.
 
@@ -556,7 +556,7 @@ providing you with lots of examples to learn from.
 C<Moose> is a very powerful tool, and we can't cover all of its
 features here. We encourage you to learn more by reading the C<Moose>
 documentation, starting with
-L<Moose::Manual|https://search.cpan.org/perldoc?Moose::Manual>.
+L<Moose::Manual|https://metacpan.org/pod/Moose::Manual>.
 
 =back
 

--- a/pod/perlthrtut.pod
+++ b/pod/perlthrtut.pod
@@ -1084,13 +1084,13 @@ Annotated POD for L<threads>:
 L<https://web.archive.org/web/20171028020148/http://annocpan.org/?mode=search&field=Module&name=threads>
 
 Latest version of L<threads> on CPAN:
-L<https://search.cpan.org/search?module=threads>
+L<https://metacpan.org/pod/threads>
 
 Annotated POD for L<threads::shared>:
 L<https://web.archive.org/web/20171028020148/http://annocpan.org/?mode=search&field=Module&name=threads%3A%3Ashared>
 
 Latest version of L<threads::shared> on CPAN:
-L<https://search.cpan.org/search?module=threads%3A%3Ashared>
+L<https://metacpan.org/pod/threads::shared>
 
 Perl threads mailing list:
 L<https://lists.perl.org/list/ithreads.html>

--- a/t/porting/podcheck.t
+++ b/t/porting/podcheck.t
@@ -78,7 +78,7 @@ points to just one target.  (The destination pod could have two targets with
 the same name.)
 
 The way that the C<LE<lt>E<gt>> pod command works (for links outside the pod)
-is to actually create a link to C<search.cpan.org> with an embedded query for
+is to actually create a link to C<metacpan.org> with an embedded query for
 the desired pod or man page.  That means that links outside the distribution
 are valid.  podcheck.t doesn't verify the validity of such links, but instead
 keeps a database of those known to be valid.  This means that if a link to a

--- a/utils/h2xs.PL
+++ b/utils/h2xs.PL
@@ -1937,7 +1937,7 @@ WriteMakefile(
     AUTHOR            => '$author <$email>',
     #LICENSE           => 'perl',
     #Value must be from legacy list of licenses here
-    #http://search.cpan.org/perldoc?Module%3A%3ABuild%3A%3AAPI
+    #https://metacpan.org/pod/Module::Build::API
 END
 if (!$opt_X) { # print C stuff, unless XS is disabled
   $opt_F = '' unless defined $opt_F;

--- a/win32/makefile.mk
+++ b/win32/makefile.mk
@@ -821,7 +821,7 @@ BLINK_FLAGS	= $(PRIV_LINK_FLAGS) $(LINK_FLAGS)
 ############# NO USER-SERVICEABLE PARTS BEYOND THIS POINT ##############
 
 # Some old dmakes (including Sarathy's one at
-# http://search.cpan.org/CPAN/authors/id/G/GS/GSAR/dmake-4.1pl1-win32.zip)
+# https://www.cpan.org/authors/id/G/GS/GSAR/dmake-4.1pl1-win32.zip)
 # don't support logical OR (||) or logical AND (&&) in conditional
 # expressions and hence don't process this makefile correctly. Determine
 # whether this is the case so that we can give the user an error message.
@@ -1210,7 +1210,7 @@ CHECKDMAKE :
 	$(NOOP)
 .ELSE
 	@echo Your dmake doesn't support ^|^| or ^&^& in conditional expressions.
-	@echo Please get the latest dmake from http://search.cpan.org/dist/dmake/
+	@echo Please get the latest dmake from https://metacpan.org/release/dmake
 	@exit 1
 .ENDIF
 


### PR DESCRIPTION
Updated links in pod and some other references. Link to illguts (https://search.cpan.org/dist/illguts/) not changed because there isn't a good way to link directly to it on metacpan.