### PR TITLE
Add update action to Porting/checkAUTHORS.pl

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,1316 +15,1315 @@
 # This should contain the preferred addresses.  Alternate addresses are in
 # Porting/checkAUTHORS.pl.
 #
-# After editing, please run: make test_porting
+# updated_by: ./Porting/checkAUTHORS.pl --update --from=v5.30.0
 -- 
-A. C. Yardley			<yardley@tanet.net>
-A. Sinan Unur			<nanis@cpan.org>
-Aaron B. Dossett		<aaron@iglou.com>
-Aaron Crane			<arc@cpan.org>
-Aaron J. Mackey			<ajm6q@virginia.edu>
-Aaron Priven			<aaron@priven.com>
-Aaron Trevena			<aaaron.trevena@gmail.com>
-Abe Timmerman			<abe@ztreet.demon.nl>
-Abhijit Menon-Sen		<ams@toroid.org>
-Abigail				<abigail@abigail.be>
-Abir Viqar			<abiviq@hushmail.com>
-Achim Bohnet			<ach@mpe.mpg.de>
-Achim Gratz			<achim.gratz@stromeko.de>
-Adam Flott			<adam@npjh.com>
-Adam Kennedy			<adam@ali.as>
-Adam Krolnik			<adamk@gypsy.cyrix.com>
-Adam Milner			<carmiac@nmt.edu>
-Adam Russell			<arussell@cs.uml.edu>
+A. C. Yardley                  <yardley@tanet.net>
+A. Sinan Unur                  <nanis@cpan.org>
+Aaron B. Dossett               <aaron@iglou.com>
+Aaron Crane                    <arc@cpan.org>
+Aaron J. Mackey                <ajm6q@virginia.edu>
+Aaron Priven                   <aaron@priven.com>
+Aaron Trevena                  <aaaron.trevena@gmail.com>
+Abe Timmerman                  <abe@ztreet.demon.nl>
+Abhijit Menon-Sen              <ams@toroid.org>
+Abigail                        <abigail@abigail.be>
+Abir Viqar                     <abiviq@hushmail.com>
+Achim Bohnet                   <ach@mpe.mpg.de>
+Achim Gratz                    <achim.gratz@stromeko.de>
+Adam Flott                     <adam@npjh.com>
+Adam Kennedy                   <adam@ali.as>
+Adam Krolnik                   <adamk@gypsy.cyrix.com>
+Adam Milner                    <carmiac@nmt.edu>
+Adam Russell                   <arussell@cs.uml.edu>
 Adam Spiers
-Adrian M. Enache		<enache@rdslink.ro>
-Adriano Ferreira		<a.r.ferreira@gmail.com>
-Akim Demaille			<akim@epita.fr>
-Alain Barbet			<alian@cpan.org>
-Alan Burlison			<Alan.Burlison@uk.sun.com>
-Alan Champion			<achampio@lehman.com>
-Alan Ferrency			<alan@pair.com>
-Alan Grover			<awgrover@gmail.com>
-Alan Grow			<agrow@thegotonerd.com>
-Alan Haggai Alavi		<haggai@cpan.org>
-Alan Harder			<Alan.Harder@Ebay.Sun.COM>
-Alan Hourihane			<alanh@fairlite.co.uk>
+Adrian M. Enache               <enache@rdslink.ro>
+Adriano Ferreira               <a.r.ferreira@gmail.com>
+Akim Demaille                  <akim@epita.fr>
+Alain Barbet                   <alian@cpan.org>
+Alan Burlison                  <alan.burlison@sun.com>
+Alan Champion                  <achampio@lehman.com>
+Alan Ferrency                  <alan@pair.com>
+Alan Grover                    <awgrover@gmail.com>
+Alan Grow                      <agrow@thegotonerd.com>
+Alan Haggai Alavi              <haggai@cpan.org>
+Alan Harder                    <Alan.Harder@Ebay.Sun.COM>
+Alan Hourihane                 <alanh@fairlite.co.uk>
 Alan Modra
-Alastair Douglas		<alastair.douglas@gmail.com>
-Albert Chin-A-Young		<china@thewrittenword.com>
-Albert Dvornik			<bert@alum.mit.edu>
-Alberto Simões			<ambs@cpan.org>
-Alessandro Forghieri		<alf@orion.it>
-Alex Davies			<adavies@ptc.com>
-Alex Gough			<alex@rcon.org>
-Alex Solovey			<a.solovey@gmail.com>
-Alex Vandiver			<alexmv@mit.edu>
-Alex Waugh			<alex@alexwaugh.com>
-Alexander Alekseev		<alex@alemate.ru>
-Alexander Bluhm			<alexander_bluhm@genua.de>
-Alexander D'Archangel		<darksuji@gmail.com>
-Alexander Gernler		<alexander_gernler@genua.de>
-Alexander Gough			<alex-p5p@earth.li>
-Alexander Hartmaier		<abraxxa@cpan.org>
-Alexander Klimov		<ask@wisdom.weizmann.ac.il>
-Alexander Smishlajev		<als@turnhere.com>
-Alexander Voronov		<alexander-voronov@yandex.ru>
-Alexandr Ciornii		<alexchorny@gmail.com>
-Alexandr Savca			<alexandr.savca89@gmail.com>
-Alexandre (Midnite) Jousset	<mid@gtmp.org>
-Alexei Alexandrov		<alexei.alexandrov@gmail.com>
-Alexey Mahotkin			<alexm@netli.com>
-Alexey Toptygin			<alexeyt@freeshell.org>
-Alexey Tourbin			<at@altlinux.ru>
-Alexey V. Barantsev		<barancev@kazbek.ispras.ru>
-Ali Polatel			<alip@exherbo.org>
-Allen Smith			<allens@cpan.org>
+Alastair Douglas               <alastair.douglas@gmail.com>
+Albert Chin-A-Young            <china@thewrittenword.com>
+Albert Dvornik                 <bert@alum.mit.edu>
+Alberto Simões                 <ambs@cpan.org>
+Alessandro Forghieri           <alf@orion.it>
+Alex Davies                    <adavies@ptc.com>
+Alex Gough                     <alex@rcon.org>
+Alex Solovey                   <a.solovey@gmail.com>
+Alex Vandiver                  <alexmv@mit.edu>
+Alex Waugh                     <alex@alexwaugh.com>
+Alexander Alekseev             <alex@alemate.ru>
+Alexander Bluhm                <alexander_bluhm@genua.de>
+Alexander D'Archangel          <darksuji@gmail.com>
+Alexander Gernler              <alexander_gernler@genua.de>
+Alexander Gough                <alex-p5p@earth.li>
+Alexander Hartmaier            <abraxxa@cpan.org>
+Alexander Klimov               <ask@wisdom.weizmann.ac.il>
+Alexander Smishlajev           <als@turnhere.com>
+Alexander Voronov              <alexander-voronov@yandex.ru>
+Alexandr Ciornii               <alexchorny@gmail.com>
+Alexandr Savca                 <alexandr.savca89@gmail.com>
+Alexandre (Midnite) Jousset    <mid@gtmp.org>
+Alexei Alexandrov              <alexei.alexandrov@gmail.com>
+Alexey Mahotkin                <alexm@netli.com>
+Alexey Toptygin                <alexeyt@freeshell.org>
+Alexey Tourbin                 <at@altlinux.ru>
+Alexey V. Barantsev            <barancev@kazbek.ispras.ru>
+Ali Polatel                    <alip@exherbo.org>
+Allen Smith                    <allens@cpan.org>
 Ambrose Kofi Laing
-Ammon Riley			<ammon@rhythm.com>
-Ananth Kesari			<HYanantha@novell.com>
-Anders Johnson			<ajohnson@nvidia.com>
-Andreas Guðmundsson		<andreasg@nasarde.org>
-Andreas Karrer			<karrer@ife.ee.ethz.ch>
-Andreas Klussmann		<andreas@infosys.heitec.de>
-Andreas König			<a.koenig@mind.de>
-Andreas Marienborg		<andreas.marienborg@gmail.com>
-Andreas Schwab			<schwab@suse.de>
-Andreas Voegele			<andreas@andreasvoegele.com>
-Andrei Yelistratov		<andrew@sundale.net>
-Andrej Borsenkow		<Andrej.Borsenkow@mow.siemens.ru>
-Andrew Bettison			<andrewb@zip.com.au>
-Andrew Burt			<aburt@isis.cs.du.edu>
-Andrew Cohen			<cohen@andy.bu.edu>
-andrew deryabin			<djsf@technarchy.ru>
-Andrew Fresh			<afresh1@openbsd.org>
-Andrew Hamm			<AHamm@civica.com.au>
-Andrew M. Langmead		<aml@world.std.com>
-Andrew Pimlott			<pimlott@idiomtech.com>
-Andrew Rodland			<arodland@cpan.org>
-Andrew Savige			<ajsavige@yahoo.com.au>
-Andrew Tam			<andrewtam000@gmail.com>
-Andrew Vignaux			<ajv@nz.sangacorp.com>
-Andrew Wilcox			<awilcox@maine.com>
-Andrey Sapozhnikov		<sapa@icb.chel.su>
-Andy Armstrong			<andy@hexten.net>
-Andy Broad 			<andy@broad.ology.org.uk>
-Andy Bussey			<andybussey@yahoo.co.uk>
-Andy Dougherty			<doughera@lafayette.edu>
-Andy Lester			<andy@petdance.com>
-Anno Siegel			<anno4000@lublin.zrz.tu-berlin.de>
-Anthony David			<adavid@netinfo.com.au>
-Anthony Heading			<anthony@ajrh.net>
-Anton Berezin			<tobez@tobez.org>
-Anton Nikishaev			<me@lelf.lu>
-Anton Tagunov			<tagunov@motor.ru>
-Archer Sully			<archer@meer.net>
-Aristotle Pagaltzis		<pagaltzis@gmx.de>
-Arjen Laarhoven			<arjen@nl.demon.net>
-Arkturuz			<arkturuz@gmail.com>
-Arne Ahrend			<aahrend@web.de>
-Arnold D. Robbins		<arnold@gnu.ai.mit.edu>
-Art Green			<Art_Green@mercmarine.com>
-Art Haas			<ahaas@airmail.net>
-Arthur Axel 'fREW' Schmidt	<frioux@gmail.com>
-Artiom Morozov			<artiom@phreaker.net>
-Artur Bergman			<artur@contiller.se>
-Arvan				<apritchard@zeus.com>
-Ash Berlin			<ash@cpan.org>
-Ask Bjørn Hansen		<ask@develooper.com>
-Audrey Tang			<cpan@audreyt.org>
-Augustina Blair			<auggy@cpan.org>
+Ammon Riley                    <ammon@rhythm.com>
+Ananth Kesari                  <HYanantha@novell.com>
+Anders Johnson                 <ajohnson@nvidia.com>
+Andreas Guðmundsson            <andreasg@nasarde.org>
+Andreas Karrer                 <karrer@ife.ee.ethz.ch>
+Andreas Klussmann              <andreas@infosys.heitec.de>
+Andreas König                  <a.koenig@mind.de>
+Andreas Marienborg             <andreas.marienborg@gmail.com>
+Andreas Schwab                 <schwab@suse.de>
+Andreas Voegele                <andreas@andreasvoegele.com>
+Andrei Yelistratov             <andrew@sundale.net>
+Andrej Borsenkow               <Andrej.Borsenkow@mow.siemens.ru>
+Andrew Bettison                <andrewb@zip.com.au>
+Andrew Burt                    <aburt@isis.cs.du.edu>
+Andrew Cohen                   <cohen@andy.bu.edu>
+andrew deryabin                <djsf@technarchy.ru>
+Andrew Fresh                   <afresh1@openbsd.org>
+Andrew Hamm                    <AHamm@civica.com.au>
+Andrew M. Langmead             <aml@world.std.com>
+Andrew Pimlott                 <pimlott@idiomtech.com>
+Andrew Rodland                 <arodland@cpan.org>
+Andrew Savige                  <ajsavige@yahoo.com.au>
+Andrew Tam                     <andrewtam000@gmail.com>
+Andrew Vignaux                 <ajv@nz.sangacorp.com>
+Andrew Wilcox                  <awilcox@maine.com>
+Andrey Sapozhnikov             <sapa@icb.chel.su>
+Andy Armstrong                 <andy@hexten.net>
+Andy Broad                     <andy@broad.ology.org.uk>
+Andy Bussey                    <andybussey@yahoo.co.uk>
+Andy Dougherty                 <doughera@lafayette.edu>
+Andy Lester                    <andy@petdance.com>
+Anno Siegel                    <anno4000@lublin.zrz.tu-berlin.de>
+Anthony David                  <adavid@netinfo.com.au>
+Anthony Heading                <anthony@ajrh.net>
+Anton Berezin                  <tobez@tobez.org>
+Anton Nikishaev                <me@lelf.lu>
+Anton Tagunov                  <tagunov@motor.ru>
+Archer Sully                   <archer@meer.net>
+Aristotle Pagaltzis            <pagaltzis@gmx.de>
+Arjen Laarhoven                <arjen@nl.demon.net>
+Arkturuz                       <arkturuz@gmail.com>
+Arne Ahrend                    <aahrend@web.de>
+Arnold D. Robbins              <arnold@gnu.ai.mit.edu>
+Art Green                      <Art_Green@mercmarine.com>
+Art Haas                       <ahaas@airmail.net>
+Arthur Axel 'fREW' Schmidt     <frioux@gmail.com>
+Artiom Morozov                 <artiom@phreaker.net>
+Artur Bergman                  <artur@contiller.se>
+Arvan                          <apritchard@zeus.com>
+Ash Berlin                     <ash@cpan.org>
+Ask Bjørn Hansen               <ask@develooper.com>
+Audrey Tang                    <cpan@audreyt.org>
+Augustina Blair                <auggy@cpan.org>
 Axel Boldt
-Barrie Slaymaker		<barries@slaysys.com>
+Barrie Slaymaker               <barries@slaysys.com>
 Barry Friedman
-Bart Kedryna			<bkedryna@home.com>
-Bas van Sisseren		<bas@quarantainenet.nl>
+Bart Kedryna                   <bkedryna@home.com>
+Bas van Sisseren               <bas@quarantainenet.nl>
 Beau Cox
-Ben Carter			<bcarter@gumdrop.flyinganvil.org>
-Ben Hengst			<notbenh@cpan.org>
-Ben Morrow			<ben@morrow.me.uk>
-Ben Okopnik			<ben@linuxgazette.net>
-Ben Tilly			<ben_tilly@operamail.com>
-Benjamin Goldberg		<goldbb2@earthlink.net>
-Benjamin Holzman		<bah@ecnvantage.com>
-Benjamin Low			<b.d.low@unsw.edu.au>
-Benjamin Smith			<bsmith@cabbage.org.uk>
-Benjamin Stuhl			<sho_pi@hotmail.com>
-Benjamin Sugars			<bsugars@canoe.ca>
-Bernard Quatermass		<bernard@quatermass.co.uk>
-Bernhard M. Wiedemann			<bwiedemann@suse.de>
-Bill Campbell			<bill@celestial.com>
-Bill Glicker			<billg@burrelles.com>
-Billy Constantine		<wdconsta@cs.adelaide.edu.au>
-Blair Zajac			<blair@orcaware.com>
-Bo Borgerson			<gigabo@gmail.com>
-Bo Johansson			<bo.johansso@lsn.se>
-Bo Lindbergh			<blgl@stacken.kth.se>
-Bob Dalgleish			<Robert.Dalgleish@sk.sympatico.ca>
-Bob Ernst			<bobernst@cpan.org>
-Bob Wilkinson			<bob@fourtheye.org>
-Boris Ratner			<ratner2@gmail.com>
-Boris Zentner			<bzm@2bz.de>
-Boyd Gerber			<gerberb@zenez.com>
-Brad Appleton			<bradapp@enteract.com>
-Brad Gilbert			<b2gills@gmail.com>
-Brad Howerter			<bhower@wgc.woodward.com>
-Brad Hughes			<brad@tgsmc.com>
-Brad Lanam			<bll@gentoo.com>
-Bradley Dean			<bjdean@bjdean.id.au>
-Bram				<perl-rt@wizbit.be>
-Brandon Black			<blblack@gmail.com>
-Brendan Byrd			<BBYRD@CPAN.org>
-Brendan O'Dea			<bod@debian.org>
-Breno G. de Oliveira		<garu@cpan.org>
-Brent B. Powers			<powers@ml.com>
-Brent Dax			<brentdax@cpan.org>
-Brian Callaghan			<callagh@itginc.com>
-Brian Carlson			<brian.carlson@cpanel.net>
-Brian Childs			<brian@rentec.com>
-Brian Clarke			<clarke@appliedmeta.com>
-brian d foy			<brian.d.foy@gmail.com>
-Brian Fraser			<fraserbn@gmail.com>
-Brian Gottreu			<gottreu@gmail.com>
-Brian Greenfield		<briang@cpan.org>
+Ben Carter                     <bcarter@gumdrop.flyinganvil.org>
+Ben Hengst                     <notbenh@cpan.org>
+Ben Morrow                     <ben@morrow.me.uk>
+Ben Okopnik                    <ben@linuxgazette.net>
+Ben Tilly                      <ben_tilly@operamail.com>
+Benjamin Goldberg              <goldbb2@earthlink.net>
+Benjamin Holzman               <bah@ecnvantage.com>
+Benjamin Low                   <b.d.low@unsw.edu.au>
+Benjamin Smith                 <bsmith@cabbage.org.uk>
+Benjamin Stuhl                 <sho_pi@hotmail.com>
+Benjamin Sugars                <bsugars@canoe.ca>
+Bernard Quatermass             <bernard@quatermass.co.uk>
+Bernhard M. Wiedemann          <bwiedemann@suse.de>
+Bill Campbell                  <bill@celestial.com>
+Bill Glicker                   <billg@burrelles.com>
+Billy Constantine              <wdconsta@cs.adelaide.edu.au>
+Blair Zajac                    <blair@orcaware.com>
+Bo Borgerson                   <gigabo@gmail.com>
+Bo Johansson                   <bo.johansso@lsn.se>
+Bo Lindbergh                   <blgl@stacken.kth.se>
+Bob Dalgleish                  <Robert.Dalgleish@sk.sympatico.ca>
+Bob Ernst                      <bobernst@cpan.org>
+Bob Wilkinson                  <bob@fourtheye.org>
+Boris Ratner                   <ratner2@gmail.com>
+Boris Zentner                  <bzm@2bz.de>
+Boyd Gerber                    <gerberb@zenez.com>
+Brad Appleton                  <bradapp@enteract.com>
+Brad Gilbert                   <b2gills@gmail.com>
+Brad Howerter                  <bhower@wgc.woodward.com>
+Brad Hughes                    <brad@tgsmc.com>
+Brad Lanam                     <bll@gentoo.com>
+Bradley Dean                   <bjdean@bjdean.id.au>
+Bram                           <perl-rt@wizbit.be>
+Brandon Black                  <blblack@gmail.com>
+Brendan Byrd                   <BBYRD@CPAN.org>
+Brendan O'Dea                  <bod@debian.org>
+Breno G. de Oliveira           <garu@cpan.org>
+Brent B. Powers                <powers@ml.com>
+Brent Dax                      <brentdax@cpan.org>
+Brian Callaghan                <callagh@itginc.com>
+Brian Carlson                  <brian.carlson@cpanel.net>
+Brian Childs                   <brian@rentec.com>
+Brian Clarke                   <clarke@appliedmeta.com>
+brian d foy                    <brian.d.foy@gmail.com>
+Brian Fraser                   <fraserbn@gmail.com>
+Brian Gottreu                  <gottreu@gmail.com>
+Brian Greenfield               <briang@cpan.org>
 Brian Grossman
-Brian Harrison			<brie@corp.home.net>
-Brian Jepson			<bjepson@oreilly.com>
+Brian Harrison                 <brie@corp.home.net>
+Brian Jepson                   <bjepson@oreilly.com>
 Brian Katzung
-Brian McCauley			<nobull@mail.com>
-Brian Phillips			<bphillips@cpan.org>
-Brian Reichert			<reichert@internet.com>
-Brian S. Cashman		<bsc@umich.edu>
-Brian Strand			<bstrand@switchmanagement.com>
+Brian McCauley                 <nobull@mail.com>
+Brian Phillips                 <bphillips@cpan.org>
+Brian Reichert                 <reichert@internet.com>
+Brian S. Cashman               <bsc@umich.edu>
+Brian Strand                   <bstrand@switchmanagement.com>
 Brooks D Boyd
-Bruce Barnett			<barnett@grymoire.crd.ge.com>
-Bruce J. Keeler			<bkeelerx@iwa.dp.intel.com>
-Bruce P. Schuck			<bruce@aps.org>
-Bryan Stenson			<bryan@siliconvortex.com>
-Bud Huff			<BAHUFF@us.oracle.com>
-Byron Brummer			<byron@omix.com>
-C Aditya			<caditya@novell.com>
-Calle Dybedahl			<calle@lysator.liu.se>
-Campo Weijerman			<rfc822@nl.ibm.com>
-Carl Eklof			<CEklof@endeca.com>
-Carl Hayter			<hayter@usc.edu>
-Carl M. Fongheiser		<cmf@ins.infonet.net>
-Carl Witty			<cwitty@newtonlabs.com>
-Cary D. Renzema			<caryr@mxim.com>
-Casey R. Tweten			<crt@kiski.net>
-Casey West			<casey@geeknest.com>
+Bruce Barnett                  <barnett@grymoire.crd.ge.com>
+Bruce J. Keeler                <bkeelerx@iwa.dp.intel.com>
+Bruce P. Schuck                <bruce@aps.org>
+Bryan Stenson                  <bryan@siliconvortex.com>
+Bud Huff                       <BAHUFF@us.oracle.com>
+Byron Brummer                  <byron@omix.com>
+C Aditya                       <caditya@novell.com>
+Calle Dybedahl                 <calle@lysator.liu.se>
+Campo Weijerman                <rfc822@nl.ibm.com>
+Carl Eklof                     <CEklof@endeca.com>
+Carl Hayter                    <hayter@usc.edu>
+Carl M. Fongheiser             <cmf@ins.infonet.net>
+Carl Witty                     <cwitty@newtonlabs.com>
+Cary D. Renzema                <caryr@mxim.com>
+Casey R. Tweten                <crt@kiski.net>
+Casey West                     <casey@geeknest.com>
 Castor Fu
-Chad Granum			<chad.granum@dreamhost.com>
-Chaim Frenkel			<chaimf@pobox.com>
-Charles Bailey			<bailey@newman.upenn.edu>
-Charles F. Randall		<crandall@free.click-n-call.com>
-Charles Lane			<lane@DUPHY4.Physics.Drexel.Edu>
-Charles Randall			<cfriv@yahoo.com>
-Charles Wilson			<cwilson@ece.gatech.edu>
-Charlie Gonzalez		<itcharlie@gmail.com>
-Chas. Owens			<chas.owens@gmail.com>
-Chase Whitener			<cwhitener@gmail.com>
+Chad Granum                    <chad.granum@dreamhost.com>
+Chaim Frenkel                  <chaimf@pobox.com>
+Charles Bailey                 <bailey@newman.upenn.edu>
+Charles F. Randall             <crandall@free.click-n-call.com>
+Charles Lane                   <lane@DUPHY4.Physics.Drexel.Edu>
+Charles Randall                <cfriv@yahoo.com>
+Charles Wilson                 <cwilson@ece.gatech.edu>
+Charlie Gonzalez               <itcharlie@gmail.com>
+Chas. Owens                    <chas.owens@gmail.com>
+Chase Whitener                 <cwhitener@gmail.com>
 Chaskiel M Grundman
-Chia-liang Kao			<clkao@clkao.org>
-Chip Salzenberg			<chip@pobox.com>
-Chip Turner			<cturner@redhat.com>
-chocolateboy			<chocolateboy@chocolatey.com>
-Chris Ball			<chris@cpan.org>
-Chris 'BinGOs' Williams		<chris@bingosnet.co.uk>
-Chris Bongaarts			<cab@tc.umn.edu>
-Chris Dolan			<chris@chrisdolan.net>
-Chris Faylor			<cgf@bbc.com>
-Chris Heath			<chris@heathens.co.nz>
-Chris Lamb			<lamby@debian.org>
-Chris Lightfoot			<chris@ex-parrot.com>
-Chris Nandor			<pudge@pobox.com>
+Chia-liang Kao                 <clkao@clkao.org>
+Chip Salzenberg                <chip@pobox.com>
+Chip Turner                    <cturner@redhat.com>
+chocolateboy                   <chocolateboy@chocolatey.com>
+Chris 'BinGOs' Williams        <chris@bingosnet.co.uk>
+Chris Ball                     <chris@cpan.org>
+Chris Bongaarts                <cab@tc.umn.edu>
+Chris Dolan                    <chris@chrisdolan.net>
+Chris Faylor                   <cgf@bbc.com>
+Chris Heath                    <chris@heathens.co.nz>
+Chris Lamb                     <lamby@debian.org>
+Chris Lightfoot                <chris@ex-parrot.com>
+Chris Nandor                   <pudge@pobox.com>
 Chris Pepper
-Chris R. Donnelly		<chris.donnelly@vauto.com>
-Chris Travers			<chris.travers@gmail.com>
-Chris Tubutis			<chris@broadband.att.com>
-Chris Wick			<cwick@lmc.com>
-Chris Williams			<chrisw@netinfo.com.au>
-Christian Burger		<burger@terra.mpikg-teltow.mpg.de>
-Christian Hansen		<chansen@cpan.org>
-Christian Kirsch		<ck@held.mind.de>
-Christian Millour		<cm.perl@abtela.com>
-Christian Winter		<bitpoet@linux-config.de>
-Christoph Lamprecht		<ch.l.ngre@online.de>
-Christophe Grosjean		<christophe.grosjean@gmail.com>
-Christopher Chavez		<chrischavez@gmx.us>
-Christopher Chan-Nui		<channui@austin.ibm.com>
-Christopher Davis		<ckd@loiosh.kei.com>
-Christopher J. Madsen		<perl@cjmweb.net>
-chromatic			<chromatic@wgz.org>
-Chuck Phillips			<perl@cadop.com>
-Chun Bing Ge			<gecb@cn.ibm.com>
-Chunhui Teng			<cteng@nortel.ca>
-Claes Jacobsson			<claes@surfar.nu>
-Clark Cooper			<coopercc@netheaven.com>
-Claudio Ramirez			<nxadm@cpan.org>
-Clinton A. Pierce		<clintp@geeksalad.org>
-Colin Kuskie			<ckuskie@cadence.com>
-Colin McMillen			<mcmi0073@tc.umn.edu>
-Colin Meyer			<cmeyer@helvella.org>
-Colin Newell			<colin.newell@gmail.com>
-Colin Watson			<colinw@zeus.com>
+Chris R. Donnelly              <chris.donnelly@vauto.com>
+Chris Travers                  <chris.travers@gmail.com>
+Chris Tubutis                  <chris@broadband.att.com>
+Chris Wick                     <cwick@lmc.com>
+Chris Williams                 <chrisw@netinfo.com.au>
+Christian Burger               <burger@terra.mpikg-teltow.mpg.de>
+Christian Hansen               <chansen@cpan.org>
+Christian Kirsch               <ck@held.mind.de>
+Christian Millour              <cm.perl@abtela.com>
+Christian Winter               <bitpoet@linux-config.de>
+Christoph Lamprecht            <ch.l.ngre@online.de>
+Christophe Grosjean            <christophe.grosjean@gmail.com>
+Christopher Chan-Nui           <channui@austin.ibm.com>
+Christopher Chavez             <chrischavez@gmx.us>
+Christopher Davis              <ckd@loiosh.kei.com>
+Christopher J. Madsen          <perl@cjmweb.net>
+chromatic                      <chromatic@wgz.org>
+Chuck Phillips                 <perl@cadop.com>
+Chun Bing Ge                   <gecb@cn.ibm.com>
+Chunhui Teng                   <cteng@nortel.ca>
+Claes Jacobsson                <claes@surfar.nu>
+Clark Cooper                   <coopercc@netheaven.com>
+Claudio Ramirez                <nxadm@cpan.org>
+Clinton A. Pierce              <clintp@geeksalad.org>
+Colin Kuskie                   <ckuskie@cadence.com>
+Colin McMillen                 <mcmi0073@tc.umn.edu>
+Colin Meyer                    <cmeyer@helvella.org>
+Colin Newell                   <colin.newell@gmail.com>
+Colin Watson                   <colinw@zeus.com>
 Conrad Augustin
-Conrad E. Kimball		<cek@tblv021.ca.boeing.com>
-Craig A. Berry			<craigberry@mac.com>
-Craig DeForest			<zowie@euterpe.boulder.swri.edu>
-Craig Milo Rogers		<Rogers@ISI.EDU>
-Curtis Jewell			<perl@csjewell.fastmail.us>
-Curtis Poe			<cp@onsitetech.com>
-Dabrien 'Dabe' Murphy		<dabe@dabe.com>
-Dagfinn Ilmari Mannsåker	<ilmari@ilmari.org>
-Dale Amon			<amon@vnl.com>
-Damian Conway			<damian@conway.org>
-Damon Atkins			<Damon.Atkins@nabaus.com.au>
-Dan Book			<grinnz@grinnz.com>
-Dan Boorstein			<dan_boo@bellsouth.net>
-Dan Brook			<dbrook@easyspace.com>
-Dan Collins			<dcollinsn@gmail.com>
-Dan Dascalescu			<bigbang7@gmail.com>
-Dan Dedrick			<ddedrick@lexmark.com>
-Dan Hale			<danhale@us.ibm.com>
-Dan Jacobson			<jidanni@jidanni.org>
-Dan Kogai			<dankogai@dan.co.jp>
-Dan Schmidt			<dfan@harmonixmusic.com>
-Dan Sugalski			<dan@sidhe.org>
-Daniel Berger			<djberg86@attbi.com>
-Daniel Chetlin			<daniel@chetlin.com>
-Daniel Dragan			<bulk88@hotmail.com>
-Daniel Frederick Crisman	<daniel@crisman.org>
-Daniel Grisinger		<dgris@dimensional.com>
-Daniel Kahn Gillmor		<dkg@fifthhorseman.net>
-Daniel Lieberman		<daniel@bitpusher.com>
-Daniel Muiño			<dmuino@afip.gov.ar>
-Daniel P. Berrange		<dan@berrange.com>
-Daniel Perrett			<perrettdl@googlemail.com>
-Daniel S. Lewart		<lewart@uiuc.edu>
-Daniel Yacob			<perl@geez.org>
-Danny R. Faught			<faught@mailhost.rsn.hp.com>
-Danny Sadinoff			<danny-cpan@sadinoff.com>
-Darin McBride			<dmcbride@cpan.org>
-Darrell Kindred			<dkindred+@cmu.edu>
-Darrell Schiebel		<drs@nrao.edu>
-Darren/Torin/Who Ever...	<torin@daft.com>
+Conrad E. Kimball              <cek@tblv021.ca.boeing.com>
+Craig A. Berry                 <craigberry@mac.com>
+Craig DeForest                 <zowie@euterpe.boulder.swri.edu>
+Craig Milo Rogers              <Rogers@ISI.EDU>
+Curtis Jewell                  <perl@csjewell.fastmail.us>
+Curtis Poe                     <cp@onsitetech.com>
+Dabrien 'Dabe' Murphy          <dabe@dabe.com>
+Dagfinn Ilmari Mannsåker       <ilmari@ilmari.org>
+Dale Amon                      <amon@vnl.com>
+Damian Conway                  <damian@conway.org>
+Damon Atkins                   <Damon.Atkins@nabaus.com.au>
+Dan Book                       <grinnz@grinnz.com>
+Dan Boorstein                  <dan_boo@bellsouth.net>
+Dan Brook                      <dbrook@easyspace.com>
+Dan Collins                    <dcollinsn@gmail.com>
+Dan Dascalescu                 <bigbang7@gmail.com>
+Dan Dedrick                    <ddedrick@lexmark.com>
+Dan Hale                       <danhale@us.ibm.com>
+Dan Jacobson                   <jidanni@jidanni.org>
+Dan Kogai                      <dankogai@dan.co.jp>
+Dan Schmidt                    <dfan@harmonixmusic.com>
+Dan Sugalski                   <dan@sidhe.org>
+Daniel Berger                  <djberg86@attbi.com>
+Daniel Chetlin                 <daniel@chetlin.com>
+Daniel Dragan                  <bulk88@hotmail.com>
+Daniel Frederick Crisman       <daniel@crisman.org>
+Daniel Grisinger               <dgris@dimensional.com>
+Daniel Kahn Gillmor            <dkg@fifthhorseman.net>
+Daniel Lieberman               <daniel@bitpusher.com>
+Daniel Muiño                   <dmuino@afip.gov.ar>
+Daniel P. Berrange             <dan@berrange.com>
+Daniel Perrett                 <perrettdl@googlemail.com>
+Daniel S. Lewart               <lewart@uiuc.edu>
+Daniel Yacob                   <perl@geez.org>
+Danny R. Faught                <faught@mailhost.rsn.hp.com>
+Danny Sadinoff                 <danny-cpan@sadinoff.com>
+Darin McBride                  <dmcbride@cpan.org>
+Darrell Kindred                <dkindred+@cmu.edu>
+Darrell Schiebel               <drs@nrao.edu>
+Darren/Torin/Who Ever...       <torin@daft.com>
 Dave Bianchi
-Dave Cross			<dave@mag-sol.com>
-Dave Hartnoll			<Dave_Hartnoll@3b2.com>
-Dave Liney			<dave.liney@gbr.conoco.com>
-Dave Nelson			<David.Nelson@bellcow.com>
+Dave Cross                     <dave@mag-sol.com>
+Dave Hartnoll                  <Dave_Hartnoll@3b2.com>
+Dave Liney                     <dave.liney@gbr.conoco.com>
+Dave Nelson                    <David.Nelson@bellcow.com>
 Dave Paris
-Dave Rolsky			<autarch@urth.org>
-Dave Schweisguth		<dcs@neutron.chem.yale.edu>
-Dave Shariff Yadallee		<doctor@doctor.nl2k.ab.ca>
-David Billinghurst		<David.Billinghurst@riotinto.com.au>
-David Caldwell			<david@porkrind.org>
+Dave Rolsky                    <autarch@urth.org>
+Dave Schweisguth               <dcs@neutron.chem.yale.edu>
+Dave Shariff Yadallee          <doctor@doctor.nl2k.ab.ca>
+David Billinghurst             <David.Billinghurst@riotinto.com.au>
+David Caldwell                 <david@porkrind.org>
 David Campbell
-David Cannings			<lists@edeca.net>
-David Cantrell			<david@cantrell.org.uk>
+David Cannings                 <lists@edeca.net>
+David Cantrell                 <david@cantrell.org.uk>
 David Couture
-David D. Kilzer			<ddkilzer@lubricants-oil.com>
-David Denholm			<denholm@conmat.phys.soton.ac.uk>
-David Dyck			<david.dyck@fluke.com>
-David F. Haertig		<dfh@dwroll.lucent.com>
-David Favor			<david@davidfavor.com>
-David Feldman			<david.feldman@tudor.com>
-David Fifield			<david@bamsoftware.com>
+David D. Kilzer                <ddkilzer@lubricants-oil.com>
+David Denholm                  <denholm@conmat.phys.soton.ac.uk>
+David Dyck                     <david.dyck@fluke.com>
+David F. Haertig               <dfh@dwroll.lucent.com>
+David Favor                    <david@davidfavor.com>
+David Feldman                  <david.feldman@tudor.com>
+David Fifield                  <david@bamsoftware.com>
 David Filo
-David Formosa			<dformosa@dformosa.zeta.org.au>
-David Gay			<dgay@acm.org>
-David Glasser			<me@davidglasser.net>
-David Golden			<dagolden@cpan.org>
-David H. Adler			<dha@panix.com>
-David H. Gutteridge		<dhgutteridge@sympatico.ca>
-David Hammen			<hammen@gothamcity.jsc.nasa.gov>
-David J. Fiander		<davidf@mks.com>
-David Kerry			<davidk@tor.securecomputing.com>
-David Landgren			<david@landgren.net>
-David Leadbeater		<dgl@dgl.cx>
-David M. Syzdek			<david@syzdek.net>
-David Manura			<dm.list@math2.org>
-David McLean			<davem@icc.gsfc.nasa.gov>
-David Mitchell			<davem@iabyn.nospamdeletethisbit.com>
-David Muir Sharnoff		<muir@idiom.com>
-David Nicol			<whatever@davidnicol.com>
-David R. Favor			<dfavor@austin.ibm.com>
-David Sparks			<daves@ca.sophos.com>
-David Starks-Browning		<dstarks@rc.tudelft.nl>
-David Steinbrunner		<dsteinbrunner@pobox.com>
-David Sundstrom			<sunds@asictest.sc.ti.com>
-David Wheeler			<david@justatheory.com>
-Davin Milun			<milun@cs.Buffalo.EDU>
-Dean Roehrich			<roehrich@cray.com>
-Dee Newcum			<perl.org@paperlined.org>
-deekoo				<deekoo@tentacle.net>
-Dennis Kaarsemaker		<dennis@booking.com>
-Dennis Marsa			<dennism@cyrix.com>
-Devin Heitmueller		<devin.heitmueller@gmail.com>
-DH				<crazyinsomniac@yahoo.com>
-Diab Jerius			<dj@head-cfa.harvard.edu>
-dLux				<dlux@spam.sch.bme.hu>
-Dmitri Tikhonov			<dmitri@cpan.org>
-Dmitry Karasik			<dk@tetsuo.karasik.eu.org>
-Dmitry Ulanov			<zprogd@gmail.com>
-Dominic Dunlop			<domo@computer.org>
-Dominic Hargreaves		<dom@earth.li>
-Dominique Dumont		<Dominique_Dumont@grenoble.hp.com>
+David Formosa                  <dformosa@dformosa.zeta.org.au>
+David Gay                      <dgay@acm.org>
+David Glasser                  <me@davidglasser.net>
+David Golden                   <dagolden@cpan.org>
+David H. Adler                 <dha@panix.com>
+David H. Gutteridge            <dhgutteridge@sympatico.ca>
+David Hammen                   <hammen@gothamcity.jsc.nasa.gov>
+David J. Fiander               <davidf@mks.com>
+David Kerry                    <davidk@tor.securecomputing.com>
+David Landgren                 <david@landgren.net>
+David Leadbeater               <dgl@dgl.cx>
+David M. Syzdek                <david@syzdek.net>
+David Manura                   <dm.list@math2.org>
+David McLean                   <davem@icc.gsfc.nasa.gov>
+David Mitchell                 <davem@iabyn.nospamdeletethisbit.com>
+David Muir Sharnoff            <muir@idiom.com>
+David Nicol                    <whatever@davidnicol.com>
+David R. Favor                 <dfavor@austin.ibm.com>
+David Sparks                   <daves@ca.sophos.com>
+David Starks-Browning          <dstarks@rc.tudelft.nl>
+David Steinbrunner             <dsteinbrunner@pobox.com>
+David Sundstrom                <sunds@asictest.sc.ti.com>
+David Wheeler                  <david@justatheory.com>
+Davin Milun                    <milun@cs.Buffalo.EDU>
+Dean Roehrich                  <roehrich@cray.com>
+Dee Newcum                     <perl.org@paperlined.org>
+deekoo                         <deekoo@tentacle.net>
+Dennis Kaarsemaker             <dennis@booking.com>
+Dennis Marsa                   <dennism@cyrix.com>
+Devin Heitmueller              <devin.heitmueller@gmail.com>
+DH                             <crazyinsomniac@yahoo.com>
+Diab Jerius                    <dj@head-cfa.harvard.edu>
+dLux                           <dlux@spam.sch.bme.hu>
+Dmitri Tikhonov                <dmitri@cpan.org>
+Dmitry Karasik                 <dk@tetsuo.karasik.eu.org>
+Dmitry Ulanov                  <zprogd@gmail.com>
+Dominic Dunlop                 <domo@computer.org>
+Dominic Hargreaves             <dom@earth.li>
+Dominique Dumont               <Dominique_Dumont@grenoble.hp.com>
 Dominique Quatravaux
-Doug Bell			<madcityzen@gmail.com>
-Doug Campbell			<soup@ampersand.com>
-Doug MacEachern			<dougm@covalent.net>
-Douglas Christopher Wilson	<doug@somethingdoug.com>
-Douglas E. Wegscheid		<dwegscheid@qtm.net>
-Douglas Lankshear		<doug@lankshear.net>
-Douglas Wilson			<dougw@cpan.org>
-Dov Grobgeld			<dov@Orbotech.Co.IL>
-Dr.Ruud				<rvtol+news@isolution.nl>
-Drago Goricanec			<drago@raptor.otsd.ts.fujitsu.co.jp>
-Drew Stephens			<drewgstephens@gmail.com>
-Duke Leto			<jonathan@leto.net>
-Duncan Findlay			<duncf@debian.org>
-E. Choroba			<choroba@cpan.org>
-Ed Avis				<eda@waniasset.com>
-Ed J				<etj@cpan.org>
-Ed Mooring			<mooring@Lynx.COM>
-Ed Santiago			<esm@pobox.com>
-Eddy Tan			<eddy.net@gmail.com>
-Edgar Bering			<trizor@gmail.com>
+Doug Bell                      <madcityzen@gmail.com>
+Doug Campbell                  <soup@ampersand.com>
+Doug MacEachern                <dougm@covalent.net>
+Douglas Christopher Wilson     <doug@somethingdoug.com>
+Douglas E. Wegscheid           <dwegscheid@qtm.net>
+Douglas Lankshear              <doug@lankshear.net>
+Douglas Wilson                 <dougw@cpan.org>
+Dov Grobgeld                   <dov@Orbotech.Co.IL>
+Dr.Ruud                        <rvtol+news@isolution.nl>
+Drago Goricanec                <drago@raptor.otsd.ts.fujitsu.co.jp>
+Drew Stephens                  <drewgstephens@gmail.com>
+Duke Leto                      <jonathan@leto.net>
+Duncan Findlay                 <duncf@debian.org>
+E. Choroba                     <choroba@cpan.org>
+Ed Avis                        <eda@waniasset.com>
+Ed J                           <etj@cpan.org>
+Ed Mooring                     <mooring@Lynx.COM>
+Ed Santiago                    <esm@pobox.com>
+Eddy Tan                       <eddy.net@gmail.com>
+Edgar Bering                   <trizor@gmail.com>
 Edmund Bacon
-Edward Avis			<ed@membled.com>
-Edward Moy			<emoy@apple.com>
-Edward Peschko			<edwardp@excitehome.net>
-Elaine -HFB- Ashton		<elaine@chaos.wustl.edu>
-Elizabeth Mattijsen		<liz@dijkmat.nl>
-Enrico Sorcinelli		<bepi@perl.it>
+Edward Avis                    <ed@membled.com>
+Edward Moy                     <emoy@apple.com>
+Edward Peschko                 <edwardp@excitehome.net>
+Elaine -HFB- Ashton            <elaine@chaos.wustl.edu>
+Elizabeth Mattijsen            <liz@dijkmat.nl>
+Enrico Sorcinelli              <bepi@perl.it>
 Eric Amick
-Eric Arnold			<eric.arnold@sun.com>
-Eric Bartley			<bartley@icd.cc.purdue.edu>
-Eric Brine			<ikegami@adaelis.com>
-Eric E. Coe			<Eric.Coe@oracle.com>
-Eric Fifer			<egf7@columbia.edu>
-Eric Herman			<eric@freesa.org>
+Eric Arnold                    <eric.arnold@sun.com>
+Eric Bartley                   <bartley@icd.cc.purdue.edu>
+Eric Brine                     <ikegami@adaelis.com>
+Eric E. Coe                    <Eric.Coe@oracle.com>
+Eric Fifer                     <egf7@columbia.edu>
+Eric Herman                    <eric@freesa.org>
 Eric Melville
-Eric Promislow			<ericp@ActiveState.com>
+Eric Promislow                 <ericp@ActiveState.com>
 Erich Rickheit
-Eryq				<eryq@zeegee.com>
-Etienne Grossman		<etienne@isr.isr.ist.utl.pt>
-Eugen Konkov			<kes-kes@yandex.ru>
-Eugene Alterman			<Eugene.Alterman@bremer-inc.com>
-Evan Miller			<eam@frap.net>
-Evan Zacks			<zackse@cpan.org>
-Fabien Tassin			<tassin@eerie.fr>
-Father Chrysostomos		<sprout@cpan.org>
-Felipe Gasper			<felipe@felipegasper.com>
-Felix Gallo			<fgallo@etoys.com>
-Fergal Daly			<fergal@esatclear.ie>
-Fingle Nark			<finglenark@gmail.com>
+Eryq                           <eryq@zeegee.com>
+Etienne Grossman               <etienne@isr.isr.ist.utl.pt>
+Eugen Konkov                   <kes-kes@yandex.ru>
+Eugene Alterman                <Eugene.Alterman@bremer-inc.com>
+Evan Miller                    <eam@frap.net>
+Evan Zacks                     <zackse@cpan.org>
+Fabien Tassin                  <tassin@eerie.fr>
+Father Chrysostomos            <sprout@cpan.org>
+Felipe Gasper                  <felipe@felipegasper.com>
+Felix Gallo                    <fgallo@etoys.com>
+Fergal Daly                    <fergal@esatclear.ie>
+Fingle Nark                    <finglenark@gmail.com>
 Florent Guillaume
-Florian Ragwitz			<rafl@debian.org>
-Florian Weimer			<fweimer@redhat.com>
-François Désarménien		<desar@club-internet.fr>
-François Perrad			<francois.perrad@gadz.org>
+Florian Ragwitz                <rafl@debian.org>
+Florian Weimer                 <fweimer@redhat.com>
 Frank Crawford
-Frank Ridderbusch		<Frank.Ridderbusch@pdb.siemens.de>
-Frank Tobin			<ftobin@uiuc.edu>
-Frank Wiegand			<frank.wiegand@gmail.com>
-Franklin Chen			<chen@adi.com>
-Franz Fasching			<perldev@drfasching.com>
-Frederic Briere			<fbriere@fbriere.net>
-Fréderic Chauveau		<fmc@pasteur.fr>
-Fyodor Krasnov			<fyodor@aha.ru>
-G. Del Merritt			<del@intranetics.com>
+Frank Ridderbusch              <Frank.Ridderbusch@pdb.siemens.de>
+Frank Tobin                    <ftobin@uiuc.edu>
+Frank Wiegand                  <frank.wiegand@gmail.com>
+Franklin Chen                  <chen@adi.com>
+Franz Fasching                 <perldev@drfasching.com>
+François Désarménien           <desar@club-internet.fr>
+François Perrad                <francois.perrad@gadz.org>
+Frederic Briere                <fbriere@fbriere.net>
+Fréderic Chauveau              <fmc@pasteur.fr>
+Fyodor Krasnov                 <fyodor@aha.ru>
+G. Del Merritt                 <del@intranetics.com>
 Gabe Schaffer
-Gabor Szabo			<szabgab@gmail.com>
-Garry T. Williams		<garry@zvolve.com>
-Gary Clark			<GaryC@mail.jeld-wen.com>
+Gabor Szabo                    <szabgab@gmail.com>
+Garry T. Williams              <garry@zvolve.com>
+Gary Clark                     <GaryC@mail.jeld-wen.com>
 Gary L. Armstrong
-Gary Ng				<71564.1743@compuserve.com>
-Gavin Shelley			<columbusmonkey@me.com>
-Gene Sullivan			<genesullivan50@yahoo.com>
-Geoffrey F. Green		<geoff-public@stuebegreen.com>
-Geoffrey T. Dairiki		<dairiki@dairiki.org>
-Georg Schwarz			<geos@epost.de>
-George Greer			<perl@greerga.m-l.org>
-George Hartzell			<georgewh@gene.com>
-George Necula			<necula@eecs.berkeley.edu>
-Geraint A Edwards		<gedge@serf.org>
-Gerard Goossen			<gerard@ggoossen.net>
-Gerben Wierda			<G.C.Th.Wierda@AWT.nl>
-Gerd Knops			<gerti@BITart.com>
-Gerrit P. Haase			<gp@familiehaase.de>
-Gideon Israel Dsouza		<gideon@cpan.org>
-Giles Lean			<giles@nemeton.com.au>
-Gisle Aas			<gisle@aas.no>
-Glenn D. Golden			<gdg@zplane.com>
-Glenn Linderman			<perl@nevcal.com>
-Gordon J. Miller		<gjm@cray.com>
-Gordon Lack			<gml4410@ggr.co.uk>
-Goro Fuji			<gfuji@cpan.org>
-Grace Lee			<grace@hal.com>
-Graham Barr			<gbarr@pobox.com>
-Graham Knop			<haarg@haarg.org>
-Graham TerMarsch		<graham@howlingfrog.com>
-Grant McLean			<grantm@cpan.org>
-Greg Bacon			<gbacon@itsc.uah.edu>
-Greg Chapman			<glc@well.com>
+Gary Ng                        <71564.1743@compuserve.com>
+Gavin Shelley                  <columbusmonkey@me.com>
+Gene Sullivan                  <genesullivan50@yahoo.com>
+Geoffrey F. Green              <geoff-public@stuebegreen.com>
+Geoffrey T. Dairiki            <dairiki@dairiki.org>
+Georg Schwarz                  <geos@epost.de>
+George Greer                   <perl@greerga.m-l.org>
+George Hartzell                <georgewh@gene.com>
+George Necula                  <necula@eecs.berkeley.edu>
+Geraint A Edwards              <gedge@serf.org>
+Gerard Goossen                 <gerard@ggoossen.net>
+Gerben Wierda                  <G.C.Th.Wierda@AWT.nl>
+Gerd Knops                     <gerti@BITart.com>
+Gerrit P. Haase                <gp@familiehaase.de>
+Gideon Israel Dsouza           <gideon@cpan.org>
+Giles Lean                     <giles@nemeton.com.au>
+Gisle Aas                      <gisle@aas.no>
+Glenn D. Golden                <gdg@zplane.com>
+Glenn Linderman                <perl@nevcal.com>
+Gordon J. Miller               <gjm@cray.com>
+Gordon Lack                    <gml4410@ggr.co.uk>
+Goro Fuji                      <gfuji@cpan.org>
+Grace Lee                      <grace@hal.com>
+Graham Barr                    <gbarr@pobox.com>
+Graham Knop                    <haarg@haarg.org>
+Graham TerMarsch               <graham@howlingfrog.com>
+Grant McLean                   <grantm@cpan.org>
+Greg Bacon                     <gbacon@itsc.uah.edu>
+Greg Chapman                   <glc@well.com>
 Greg Earle
 Greg Kuperberg
-Greg Matheson			<lang@ms.chinmin.edu.tw>
-Greg Seibert			<seibert@Lynx.COM>
-Greg Ward			<gward@ase.com>
-Gregor Chrupala			<gregor.chrupala@star-group.net>
-gregor herrmann			<gregoa@debian.org>
-Gregory Martin Pfeil		<pfeilgm@technomadic.org>
-Guenter Schmidt			<gsc@bruker.de>
-Guido Flohr			<guido@imperia.net>
-Guruprasad S			<SGURUPRASAD@novell.com>
-Gurusamy Sarathy		<gsar@cpan.org>
+Greg Matheson                  <lang@ms.chinmin.edu.tw>
+Greg Seibert                   <seibert@Lynx.COM>
+Greg Ward                      <gward@ase.com>
+Gregor Chrupala                <gregor.chrupala@star-group.net>
+gregor herrmann                <gregoa@debian.org>
+Gregory Martin Pfeil           <pfeilgm@technomadic.org>
+Guenter Schmidt                <gsc@bruker.de>
+Guido Flohr                    <guido@imperia.net>
+Guruprasad S                   <SGURUPRASAD@novell.com>
+Gurusamy Sarathy               <gsar@cpan.org>
 Gustaf Neumann
-Guy Decoux			<decoux@moulon.inra.fr>
-Gwyn Judd			<b.judd@xtra.co.nz>
-H.J. Lu				<hjl@nynexst.com>
-H.Merijn Brand			<h.m.brand@xs4all.nl>
-Hal Morris			<hom00@utsglobal.com>
-Hal Pomeranz			<pomeranz@netcom.com>
-Hallvard B Furuseth		<h.b.furuseth@usit.uio.no>
-Hannu Napari			<Hannu.Napari@hut.fi>
-Hans de Graaff			<J.J.deGraaff@twi.tudelft.nl>
-Hans Dieter Pearcey		<hdp@pobox.com>
-Hans Ginzel			<hans@kolej.mff.cuni.cz>
-Hans Mulder			<hansmu@xs4all.nl>
-Hans Ranke			<Hans.Ranke@ei.tum.de>
-Harald Jörg			<Harald.Joerg@arcor.de>
-Harmen				<harm@dds.nl>
-Harmon S. Nine			<hnine@netarx.com>
-Harri Pasanen			<harri.pasanen@trema.com>
-Harry Edmon			<harry@atmos.washington.edu>
-Hauke D				<haukex@zero-g.net>
-Heiko Eissfeldt			<heiko.eissfeldt@hexco.de>
-Helmut Jarausch			<jarausch@numa1.igpm.rwth-aachen.de>
-Henrik Tougaard			<ht.000@foa.dk>
-Herbert Breunung		<lichtkind@cpan.org>
-Hernan Perez Masci		<hmasci@uolsinectis.com.ar>
-Hershel Walters			<walters@smd4d.wes.army.mil>
-Hio				<hio@hio.jp>
-Hiroo Hayashi			<hiroo.hayashi@computer.org>
-Hojung Youn			<amoc.yn@gmail.com>
+Guy Decoux                     <decoux@moulon.inra.fr>
+Gwyn Judd                      <b.judd@xtra.co.nz>
+H.J. Lu                        <hjl@nynexst.com>
+H.Merijn Brand                 <h.m.brand@xs4all.nl>
+Hal Morris                     <hom00@utsglobal.com>
+Hal Pomeranz                   <pomeranz@netcom.com>
+Hallvard B Furuseth            <h.b.furuseth@usit.uio.no>
+Hannu Napari                   <Hannu.Napari@hut.fi>
+Hans de Graaff                 <J.J.deGraaff@twi.tudelft.nl>
+Hans Dieter Pearcey            <hdp@pobox.com>
+Hans Ginzel                    <hans@kolej.mff.cuni.cz>
+Hans Mulder                    <hansmu@xs4all.nl>
+Hans Ranke                     <Hans.Ranke@ei.tum.de>
+Harald Jörg                    <Harald.Joerg@arcor.de>
+Harmen                         <harm@dds.nl>
+Harmon S. Nine                 <hnine@netarx.com>
+Harri Pasanen                  <harri.pasanen@trema.com>
+Harry Edmon                    <harry@atmos.washington.edu>
+Hauke D                        <haukex@zero-g.net>
+Heiko Eissfeldt                <heiko.eissfeldt@hexco.de>
+Helmut Jarausch                <jarausch@numa1.igpm.rwth-aachen.de>
+Henrik Tougaard                <ht.000@foa.dk>
+Herbert Breunung               <lichtkind@cpan.org>
+Hernan Perez Masci             <hmasci@uolsinectis.com.ar>
+Hershel Walters                <walters@smd4d.wes.army.mil>
+Hiroo Hayashi                  <hiroo.hayashi@computer.org>
+Hojung Youn                    <amoc.yn@gmail.com>
 Holger Bechtold
-Hongwen Qiu			<qiuhongwen@gmail.com>
-Horst von Brand			<vonbrand@sleipnir.valparaiso.cl>
+Hongwen Qiu                    <qiuhongwen@gmail.com>
+Horst von Brand                <vonbrand@sleipnir.valparaiso.cl>
 Hrunting Jonhson
-Hubert Feyrer			<hubert.feyrer@informatik.fh-regensburg.de>
-Hugo van der Sanden		<hv@crypt.org>
-Hunter Kelly			<retnuh@zule.pixar.com>
-Huw Rogers			<count0@gremlin.straylight.co.jp>
+Hubert Feyrer                  <hubert.feyrer@informatik.fh-regensburg.de>
+Hugo van der Sanden            <hv@crypt.org>
+Hunter Kelly                   <retnuh@zule.pixar.com>
+Huw Rogers                     <count0@gremlin.straylight.co.jp>
 Iain Truskett
-Ian Goodacre			<ian.goodacre@xtra.co.nz>
-Ian Maloney			<ian.malonet@ubs.com>
-Ian Phillipps			<Ian.Phillipps@iname.com>
-Ichinose Shogo			<shogo82148@gmail.com>
-Ignasi Roca Carrió		<ignasi.roca@fujitsu-siemens.com>
-Igor Sutton			<izut@cpan.org>
-Igor Zaytsev			<igor.zaytsev@gmail.com>
-Ilmari Karonen			<iltzu@sci.fi>
-Ilya Martynov			<ilya@martynov.org>
-Ilya N. Golubev			<gin@mo.msk.ru>
-Ilya Sandler			<Ilya.Sandler@etak.com>
-Ilya Zakharevich		<ilya@math.berkeley.edu>
-Inaba Hiroto			<inaba@st.rim.or.jp>
-Indy Singh			<indy@nusphere.com>
-Ingo Weinhold			<ingo_weinhold@gmx.de>
-Ingy döt Net			<ingy@ttul.org>
-insecure			<insecure@mail.od.ua>
-Irving Reid			<irving@tor.securecomputing.com>
-Ivan Kurmanov			<kurmanov@openlib.org>
-Ivan Pozdeev			<vano@mail.mipt.ru>
-Ivan Tubert-Brohman		<itub@cpan.org>
-J. David Blackstone		<jdb@dfwnet.sbms.sbc.com>
-J. Nick Koston			<nick@cpanel.net>
-J. van Krieken			<John.van.Krieken@ATComputing.nl>
-Jacinta Richardson		<jarich@perltraining.com.au>
-Jack Shirazi			<JackS@GemStone.com>
-Jacques Germishuys		<jacquesg@striata.com>
-Jacqui Caren			<Jacqui.Caren@ig.co.uk>
-Jake Hamby			<jehamby@lightside.com>
-Jakub Wilk			<jwilk@jwilk.net>
-James				<james@rf.net>
-James A. Duncan			<jduncan@fotango.com>
-James Clarke			<jrtc27@jrtc27.com>
-James E Keenan			<jkeenan@cpan.org>
-James FitzGibbon		<james@ican.net>
-James Jurach			<muaddib@erf.net>
-James Mastros			<james@mastros.biz>
-James McCoy			<vega.james@gmail.com>
-James Raspass			<jraspass@gmail.com>
+Ian Goodacre                   <ian.goodacre@xtra.co.nz>
+Ian Maloney                    <ian.malonet@ubs.com>
+Ian Phillipps                  <Ian.Phillipps@iname.com>
+Ichinose Shogo                 <shogo82148@gmail.com>
+Ignasi Roca Carrió             <ignasi.roca@fujitsu-siemens.com>
+Igor Sutton                    <izut@cpan.org>
+Igor Zaytsev                   <igor.zaytsev@gmail.com>
+Ilmari Karonen                 <iltzu@sci.fi>
+Ilya Martynov                  <ilya@martynov.org>
+Ilya N. Golubev                <gin@mo.msk.ru>
+Ilya Sandler                   <Ilya.Sandler@etak.com>
+Ilya Zakharevich               <ilya@math.berkeley.edu>
+Inaba Hiroto                   <inaba@st.rim.or.jp>
+Indy Singh                     <indy@nusphere.com>
+Ingo Weinhold                  <ingo_weinhold@gmx.de>
+Ingy döt Net                   <ingy@ttul.org>
+insecure                       <insecure@mail.od.ua>
+Irving Reid                    <irving@tor.securecomputing.com>
+Ivan Kurmanov                  <kurmanov@openlib.org>
+Ivan Pozdeev                   <vano@mail.mipt.ru>
+Ivan Tubert-Brohman            <itub@cpan.org>
+J. David Blackstone            <jdb@dfwnet.sbms.sbc.com>
+J. Nick Koston                 <nick@cpanel.net>
+J. van Krieken                 <John.van.Krieken@ATComputing.nl>
+Jacinta Richardson             <jarich@perltraining.com.au>
+Jack Shirazi                   <JackS@GemStone.com>
+Jacques Germishuys             <jacquesg@striata.com>
+Jacqui Caren                   <Jacqui.Caren@ig.co.uk>
+Jake Hamby                     <jehamby@lightside.com>
+Jakub Wilk                     <jwilk@jwilk.net>
+James                          <james@rf.net>
+James A. Duncan                <jduncan@fotango.com>
+James Clarke                   <jrtc27@jrtc27.com>
+James E Keenan                 <jkeenan@cpan.org>
+James FitzGibbon               <james@ican.net>
+James Jurach                   <muaddib@erf.net>
+James Mastros                  <james@mastros.biz>
+James McCoy                    <vega.james@gmail.com>
+James Raspass                  <jraspass@gmail.com>
 Jamshid Afshar
-Jan D.				<jan.djarv@mbox200.swipnet.se>
-Jan Dubois			<jan@jandubois.com>
-Jan Pazdziora			<adelton@fi.muni.cz>
-Jan Starzynski			<jan@planet.de>
-Jan-Erik Karlsson		<trg@privat.utfors.se>
-Jan-Pieter Cornet		<johnpc@xs4all.nl>
-Jared Rhine			<jared@organic.com>
-Jari Aalto			<jari.aalto@poboxes.com>
-Jarkko Hietaniemi		<jhi@iki.fi>
-Jasmine Ahuja			<jasmine.ahuja11@gmail.com>
-Jasmine Ngan			<jasmine.ngan@outlook.com>
-Jason A. Smith			<smithj4@rpi.edu>
-Jason E. Stewart		<jason@openinformatics.com>
+Jan D.                         <jan.djarv@mbox200.swipnet.se>
+Jan Dubois                     <jan@jandubois.com>
+Jan Pazdziora                  <adelton@fi.muni.cz>
+Jan Starzynski                 <jan@planet.de>
+Jan-Erik Karlsson              <trg@privat.utfors.se>
+Jan-Pieter Cornet              <johnpc@xs4all.nl>
+Jared Rhine                    <jared@organic.com>
+Jari Aalto                     <jari.aalto@poboxes.com>
+Jarkko Hietaniemi              <jhi@iki.fi>
+Jasmine Ahuja                  <jasmine.ahuja11@gmail.com>
+Jasmine Ngan                   <jasmine.ngan@outlook.com>
+Jason A. Smith                 <smithj4@rpi.edu>
+Jason E. Stewart               <jason@openinformatics.com>
 Jason Shirk
-Jason Stewart			<jasons@cs.unm.edu>
-Jason Varsoke			<jjv@caesun10.msd.ray.com>
-Jay Hannah			<jhannah@mutationgrid.com>
-Jay Rogers			<jay@rgrs.com>
-JD Laub				<jdl@access-health.com>
+Jason Stewart                  <jasons@cs.unm.edu>
+Jason Varsoke                  <jjv@caesun10.msd.ray.com>
+Jay Hannah                     <jhannah@mutationgrid.com>
+Jay Rogers                     <jay@rgrs.com>
+JD Laub                        <jdl@access-health.com>
 Jeff Bouis
-Jeff McDougal			<jmcdo@cris.com>
-Jeff Okamoto			<okamoto@corp.hp.com>
-Jeff Pinyan			<japhy@pobox.com>
-Jeff Siegal			<jbs@eddie.mit.edu>
-Jeff Urlwin			<jurlwin@access.digex.net>
-Jeffrey Friedl			<jfriedl@regex.info>
-Jeffrey S. Haemer		<jsh@woodcock.boulder.qms.com>
-Jens Hamisch			<jens@Strawberry.COM>
-Jens Stavnstrup			<js@ddre.dk>
-Jens T. Berger Thielemann	<jensthi@ifi.uio.no>
-Jens Thomsen			<jens@fiend.cis.com>
-Jens-Uwe Mager			<jum@helios.de>
-Jeremy D. Zawodny		<jeremy@zawodny.com>
-Jeremy H. Brown			<jhbrown@ai.mit.edu>
-Jeremy Madea			<jmadea@inktomi.com>
-Jerome Abela			<abela@hsc.fr>
-Jerome Duval			<jerome.duval@gmail.com>
-Jerrad Pierce			<belg4mit@MIT.EDU>
-Jerry D. Hedden			<jdhedden@cpan.org>
-Jess Robinson			<castaway@desert-island.me.uk>
-Jesse Glick			<jesse@sig.bsh.com>
-Jesse Luehrs			<doy@tozt.net>
-Jesse Vincent			<jesse@fsck.com>
-Jesús Quiroga			<jquiroga@pobox.com>
-Jilles Tjoelker			<jilles@stack.nl>
-Jim Anderson			<jander@ml.com>
-Jim Avera			<avera@hal.com>
+Jeff McDougal                  <jmcdo@cris.com>
+Jeff Okamoto                   <okamoto@corp.hp.com>
+Jeff Pinyan                    <japhy@pobox.com>
+Jeff Siegal                    <jbs@eddie.mit.edu>
+Jeff Urlwin                    <jurlwin@access.digex.net>
+Jeffrey Friedl                 <jfriedl@regex.info>
+Jeffrey S. Haemer              <jsh@woodcock.boulder.qms.com>
+Jens Hamisch                   <jens@Strawberry.COM>
+Jens Stavnstrup                <js@ddre.dk>
+Jens T. Berger Thielemann      <jensthi@ifi.uio.no>
+Jens Thomsen                   <jens@fiend.cis.com>
+Jens-Uwe Mager                 <jum@helios.de>
+Jeremy D. Zawodny              <jeremy@zawodny.com>
+Jeremy H. Brown                <jhbrown@ai.mit.edu>
+Jeremy Madea                   <jmadea@inktomi.com>
+Jerome Abela                   <abela@hsc.fr>
+Jerome Duval                   <jerome.duval@gmail.com>
+Jerrad Pierce                  <belg4mit@MIT.EDU>
+Jerry D. Hedden                <jdhedden@cpan.org>
+Jess Robinson                  <castaway@desert-island.me.uk>
+Jesse Glick                    <jesse@sig.bsh.com>
+Jesse Luehrs                   <doy@tozt.net>
+Jesse Vincent                  <jesse@fsck.com>
+Jesús Quiroga                  <jquiroga@pobox.com>
+Jilles Tjoelker                <jilles@stack.nl>
+Jim Anderson                   <jander@ml.com>
+Jim Avera                      <avera@hal.com>
 Jim Balter
-Jim Cromie			<jcromie@cpan.org>
-Jim Meyering			<meyering@asic.sc.ti.com>
-Jim Miner			<jfm@winternet.com>
+Jim Cromie                     <jcromie@cpan.org>
+Jim Meyering                   <meyering@asic.sc.ti.com>
+Jim Miner                      <jfm@winternet.com>
 Jim Richardson
-Jim Schneider			<james.schneider@db.com>
-Jirka Hruška			<jirka@fud.cz>
+Jim Schneider                  <james.schneider@db.com>
+Jirka Hruška                   <jirka@fud.cz>
 Joachim Huober
-Joaquin Ferrero			<explorer@joaquinferrero.com>
-Jochen Wiedmann			<joe@ispsoft.de>
-Jody Belka			<dev-perl@pimb.org>
-Joe Buehler			<jbuehler@hekimian.com>
-Joe McMahon			<mcmahon@ibiblio.org>
-Joe Orton			<jorton@redhat.com>
-Joe Schaefer			<joe+perl@sunstarsys.com>
-Joe Smith			<jsmith@inwap.com>
-Joel Berger			<joel.a.berger@gmail.com>
-Joel Rosi-Schwartz		<j.schwartz@agonet.it>
-Joerg Porath			<Joerg.Porath@informatik.tu-chemnitz.de>
+Joaquin Ferrero                <explorer@joaquinferrero.com>
+Jochen Wiedmann                <joe@ispsoft.de>
+Jody Belka                     <dev-perl@pimb.org>
+Joe Buehler                    <jbuehler@hekimian.com>
+Joe McMahon                    <mcmahon@ibiblio.org>
+Joe Orton                      <jorton@redhat.com>
+Joe Schaefer                   <joe+perl@sunstarsys.com>
+Joe Smith                      <jsmith@inwap.com>
+Joel Berger                    <joel.a.berger@gmail.com>
+Joel Rosi-Schwartz             <j.schwartz@agonet.it>
+Joerg Porath                   <Joerg.Porath@informatik.tu-chemnitz.de>
 Joergen Haegg
 Johan Holtman
-Johan Vromans			<jvromans@squirrel.nl>
-Johann Klasek			<jk@auto.tuwien.ac.at>
-Johann 'Myrkraverk' Oskarsson			<johann@myrkraverk.com>
-Johannes Plunien		<plu@pqpq.de>
-John Bley			<jbb6@acpub.duke.edu>
-John Borwick			<jhborwic@unity.ncsu.edu>
-John Cerney			<j-cerney1@ti.com>
-John D Groenveld		<groenvel@cse.psu.edu>
-John E. Malmberg		<wb8tyw@qsl.net>
-John Gardiner Myers		<jgmyers@proofpoint.com>
-John Goodyear			<johngood@us.ibm.com>
-John Hasstedt			<John.Hasstedt@sunysb.edu>
-John Hawkinson			<jhawk@mit.edu>
-John Heidemann			<johnh@isi.edu>
-John Holdsworth			<coldwave@bigfoot.com>
-John Hughes			<john@AtlanTech.COM>
-John Kristian			<jmk2001@engineer.com>
-John L. Allen			<allen@grumman.com>
-John Lightsey			<jd@cpanel.net>
-John Macdonald			<jmm@revenge.elegant.com>
-John Malmberg			<wb8tyw@gmail.com>
-John Nolan			<jpnolan@Op.Net>
-John P. Linderman		<jpl.jpl@gmail.com>
-John Peacock			<jpeacock@messagesystems.com>
-John Pfuntner			<pfuntner@vnet.ibm.com>
-John Poltorak			<jp@eyup.org>
-John Q. Linux			<jql@accessone.com>
-John Redford			<jmr@whirlwind.fmr.com>
+Johan Vromans                  <jvromans@squirrel.nl>
+Johann 'Myrkraverk' Oskarsson  <johann@myrkraverk.com>
+Johann Klasek                  <jk@auto.tuwien.ac.at>
+Johannes Plunien               <plu@pqpq.de>
+John Bley                      <jbb6@acpub.duke.edu>
+John Borwick                   <jhborwic@unity.ncsu.edu>
+John Cerney                    <j-cerney1@ti.com>
+John D Groenveld               <groenvel@cse.psu.edu>
+John E. Malmberg               <wb8tyw@qsl.net>
+John Gardiner Myers            <jgmyers@proofpoint.com>
+John Goodyear                  <johngood@us.ibm.com>
+John Hasstedt                  <John.Hasstedt@sunysb.edu>
+John Hawkinson                 <jhawk@mit.edu>
+John Heidemann                 <johnh@isi.edu>
+John Holdsworth                <coldwave@bigfoot.com>
+John Hughes                    <john@AtlanTech.COM>
+John Kristian                  <jmk2001@engineer.com>
+John L. Allen                  <allen@grumman.com>
+John Lightsey                  <jd@cpanel.net>
+John Macdonald                 <jmm@revenge.elegant.com>
+John Malmberg                  <wb8tyw@gmail.com>
+John Nolan                     <jpnolan@Op.Net>
+John P. Linderman              <jpl.jpl@gmail.com>
+John Peacock                   <jpeacock@messagesystems.com>
+John Pfuntner                  <pfuntner@vnet.ibm.com>
+John Poltorak                  <jp@eyup.org>
+John Q. Linux                  <jql@accessone.com>
+John Redford                   <jmr@whirlwind.fmr.com>
 John Rowe
-John Salinas			<jsalinas@cray.com>
-John SJ Anderson		<genehack@genehack.org>
-John Stoffel			<jfs@fluent.com>
-John Stumbles			<jstumbles@bluearc.com>
-John Tobey			<jtobey@john-edwin-tobey.org>
-John Wright			<john@johnwright.org>
-Johnny Lam			<jlam@jgrind.org>
-Jon Eveland			<jweveland@yahoo.com>
-Jon Gunnip			<jongunnip@hotmail.com>
-Jon Orwant			<orwant@oreilly.com>
-Jonathan Biggar			<jon@sems.com>
-Jonathan D Johnston		<jdjohnston2@juno.com>
-Jonathan Fine			<jfine@borders.com>
-Jonathan Hudson			<jonathan.hudson@jrhudson.demon.co.uk>
-Jonathan I. Kamens		<jik@kamens.brookline.ma.us>
-Jonathan Roy			<roy@idle.com>
-Jonathan Stowe			<jns@integration-house.com>
-Joost van Baal			<J.E.vanBaal@uvt.nl>
-Jörg Walter			<jwalt@cpan.org>
-Jos I. Boumans			<kane@dwim.org>
-Jose Auguste-Etienne		<Jose.auguste-etienne@cgss-guyane.fr>
-José Pedro Oliveira		<jpo@di.uminho.pt>
-Joseph N. Hall			<joseph@cscaper.com>
-Joseph S. Myers			<jsm28@hermes.cam.ac.uk>
-Joshua ben Jore			<jjore@cpan.org>
-Joshua Juran			<jjuran@gmail.com>
-Joshua Pritikin			<joshua@paloalto.com>
-Joshua Rodd			<joshua@rodd.us>
-JT McDuffie			<jt@kpc.com>
-Juan Gallego			<Little.Boss@physics.mcgill.ca>
-Juerd Waalboer			<#####@juerd.nl>
-Juha Laiho			<juha.laiho@Elma.Net>
-Julian Yip			<julian@imoney.com>
-juna				<ggl.20.jj...@spamgourmet.com>
-Jungshik Shin			<jshin@mailaps.org>
-Justin Banks			<justinb@cray.com>
-Ka-Ping Yee			<kpyee@aw.sgi.com>
-kafka				<kafka@madrognon.net>
-Kang-min Liu			<gugod@gugod.org>
-Kaoru Maeda			<maeda@src.ricoh.co.jp>
-Karen Etheridge			<ether@cpan.org>
-Karl Glazebrook			<kgb@aaossz.aao.GOV.AU>
-Karl Heuer			<kwzh@gnu.org>
-Karl Simon Berg			<karl@it.kth.se>
-Karl Williamson			<khw@cpan.org>
-Karsten Sperling		<spiff@phreax.net>
-Karthik Rajagopalan		<rajagopa@pauline.schrodinger.com>
-Kaveh Ghazi			<ghazi@caip.rutgers.edu>
-KAWAI Takanori			<GCD00051@nifty.ne.jp>
-Kay Röpke			<kroepke@dolphin-services.de>
-Keedi Kim			<keedi@cpan.org>
-Keith Neufeld			<neufeld@fast.pvi.org>
-Keith Thompson			<Keith.S.Thompson@gmail.com>
-Ken Brown			<kbrown@cornell.edu>
-Ken Cotterill			<kencotterill@netspace.net.au>
-Ken Estes			<estes@ms.com>
-Ken Fox				<kfox@ford.com>
-Ken Hirsch			<kenhirsch@ftml.net>
-Ken MacLeod			<ken@bitsko.slc.ut.us>
+John Salinas                   <jsalinas@cray.com>
+John SJ Anderson               <genehack@genehack.org>
+John Stoffel                   <jfs@fluent.com>
+John Stumbles                  <jstumbles@bluearc.com>
+John Tobey                     <jtobey@john-edwin-tobey.org>
+John Wright                    <john@johnwright.org>
+Johnny Lam                     <jlam@jgrind.org>
+Jon Eveland                    <jweveland@yahoo.com>
+Jon Gunnip                     <jongunnip@hotmail.com>
+Jon Orwant                     <orwant@oreilly.com>
+Jonathan Biggar                <jon@sems.com>
+Jonathan D Johnston            <jdjohnston2@juno.com>
+Jonathan Fine                  <jfine@borders.com>
+Jonathan Hudson                <jonathan.hudson@jrhudson.demon.co.uk>
+Jonathan I. Kamens             <jik@kamens.brookline.ma.us>
+Jonathan Roy                   <roy@idle.com>
+Jonathan Stowe                 <jns@integration-house.com>
+Joost van Baal                 <J.E.vanBaal@uvt.nl>
+Jos I. Boumans                 <kane@dwim.org>
+Jose Auguste-Etienne           <Jose.auguste-etienne@cgss-guyane.fr>
+Joseph N. Hall                 <joseph@cscaper.com>
+Joseph S. Myers                <jsm28@hermes.cam.ac.uk>
+Joshua ben Jore                <jjore@cpan.org>
+Joshua Juran                   <jjuran@gmail.com>
+Joshua Pritikin                <joshua@paloalto.com>
+Joshua Rodd                    <joshua@rodd.us>
+José Pedro Oliveira            <jpo@di.uminho.pt>
+JT McDuffie                    <jt@kpc.com>
+Juan Gallego                   <Little.Boss@physics.mcgill.ca>
+Juerd Waalboer                 <#####@juerd.nl>
+Juha Laiho                     <juha.laiho@Elma.Net>
+Julian Yip                     <julian@imoney.com>
+juna                           <ggl.20.jj...@spamgourmet.com>
+Jungshik Shin                  <jshin@mailaps.org>
+Justin Banks                   <justinb@cray.com>
+Jörg Walter                    <jwalt@cpan.org>
+Ka-Ping Yee                    <kpyee@aw.sgi.com>
+kafka                          <kafka@madrognon.net>
+Kang-min Liu                   <gugod@gugod.org>
+Kaoru Maeda                    <maeda@src.ricoh.co.jp>
+Karen Etheridge                <ether@cpan.org>
+Karl Glazebrook                <kgb@aaossz.aao.GOV.AU>
+Karl Heuer                     <kwzh@gnu.org>
+Karl Simon Berg                <karl@it.kth.se>
+Karl Williamson                <khw@cpan.org>
+Karsten Sperling               <spiff@phreax.net>
+Karthik Rajagopalan            <rajagopa@pauline.schrodinger.com>
+Kaveh Ghazi                    <ghazi@caip.rutgers.edu>
+KAWAI Takanori                 <GCD00051@nifty.ne.jp>
+Kay Röpke                      <kroepke@dolphin-services.de>
+Keedi Kim                      <keedi@cpan.org>
+Keith Neufeld                  <neufeld@fast.pvi.org>
+Keith Thompson                 <Keith.S.Thompson@gmail.com>
+Ken Brown                      <kbrown@cornell.edu>
+Ken Cotterill                  <kencotterill@netspace.net.au>
+Ken Estes                      <estes@ms.com>
+Ken Fox                        <kfox@ford.com>
+Ken Hirsch                     <kenhirsch@ftml.net>
+Ken MacLeod                    <ken@bitsko.slc.ut.us>
 Ken Neighbors
-Ken Shan			<ken@digitas.harvard.edu>
-Ken Williams			<ken@mathforum.org>
-Kenichi Ishigaki		<ishigaki@cpan.org>
-Kenneth Albanowski		<kjahds@kjahds.com>
-Kenneth Duda			<kjd@cisco.com>
-Kent Fredric			<kentfredric@gmail.com>
-Keong Lim			<Keong.Lim@sr.com.au>
-Kevin Brintnall			<kbrint@rufus.net>
-Kevin Chase			<kevincha99@hotmail.com>
-kevin dawson			<bowtie@cpan.org>
-Kevin Falcone			<falcone@bestpractical.com>
-Kevin J. Woolley		<kjw@pathillogical.com>
-Kevin O'Gorman			<kevin.kosman@nrc.com>
-Kevin Ruscoe			<Kevin.Ruscoe@ubsw.com>
-Kevin Ryde			<user42@zip.com.au>
-Kevin White			<klwhite@magnus.acs.ohio-state.edu>
+Ken Shan                       <ken@digitas.harvard.edu>
+Ken Williams                   <ken@mathforum.org>
+Kenichi Ishigaki               <ishigaki@cpan.org>
+Kenneth Albanowski             <kjahds@kjahds.com>
+Kenneth Duda                   <kjd@cisco.com>
+Kent Fredric                   <kentfredric@gmail.com>
+Keong Lim                      <Keong.Lim@sr.com.au>
+Kevin Brintnall                <kbrint@rufus.net>
+Kevin Chase                    <kevincha99@hotmail.com>
+kevin dawson                   <bowtie@cpan.org>
+Kevin Falcone                  <falcone@bestpractical.com>
+Kevin J. Woolley               <kjw@pathillogical.com>
+Kevin O'Gorman                 <kevin.kosman@nrc.com>
+Kevin Ruscoe                   <Kevin.Ruscoe@ubsw.com>
+Kevin Ryde                     <user42@zip.com.au>
+Kevin White                    <klwhite@magnus.acs.ohio-state.edu>
 Kim Frutiger
-Kingpin				<mthurn@copper.dulles.tasc.com>
-Kirrily Robert			<skud@infotrope.net>
-Kiyotaka Sakai			<ksakai@netwk.ntt-at.co.jp>
-kmx				<kmx@volny.cz>
-Kragen Sitaker			<kragen@pobox.com>
-Krishna Sethuraman		<krishna@sgi.com>
-Kriton Kyrimis			<kyrimis@princeton.edu>
-Kurt D. Starsinic		<kstar@wolfetech.com>
+Kingpin                        <mthurn@copper.dulles.tasc.com>
+Kirrily Robert                 <skud@infotrope.net>
+Kiyotaka Sakai                 <ksakai@netwk.ntt-at.co.jp>
+kmx                            <kmx@volny.cz>
+Kragen Sitaker                 <kragen@pobox.com>
+Krishna Sethuraman             <krishna@sgi.com>
+Kriton Kyrimis                 <kyrimis@princeton.edu>
+Kurt D. Starsinic              <kstar@wolfetech.com>
 Kyriakos Georgiou
-Lajos Veres			<vlajos@gmail.com>
-Larry Parmelee			<parmelee@CS.Cornell.EDU>
+Lajos Veres                    <vlajos@gmail.com>
+Larry Parmelee                 <parmelee@CS.Cornell.EDU>
 Larry Schuler
-Larry Schwimmer			<rosebud@cyclone.Stanford.EDU>
-Larry Shatzer			<fugazi@zyx.net>
-Larry W. Virden			<lvirden@cas.org>
-Larry Wall			<larry@wall.org>
-Lars Dɪᴇᴄᴋᴏᴡ 迪拉斯		<daxim@cpan.org>
-Lars Hecking			<lhecking@nmrc.ucc.ie>
-Larwan Berke			<apocal@cpan.org>
-Laszlo Molnar			<laszlo.molnar@eth.ericsson.se>
-Laurent Dami			<dami@cpan.org>
-Leif Huhn			<leif@hale.dkstat.com>
-Len Johnson			<lenjay@ibm.net>
-Leo Lapworth			<leo@cuckoo.org>
-Leon Brocard			<acme@astray.com>
-Leon Timmermans			<fawaka@gmail.com>
-Les Peters			<lpeters@aol.net>
-Lesley Binks			<lesley.binks@gmail.com>
-Lincoln D. Stein		<lstein@cshl.org>
-Lionel Cons			<lionel.cons@cern.ch>
-Louis Strous			<louis.strous@gmail.com>
-Lubomir Rintel			<lkundrak@v3.sk>
-Luc St-Louis			<luc.st-louis@ca.transport.bombardier.com>
+Larry Schwimmer                <rosebud@cyclone.Stanford.EDU>
+Larry Shatzer                  <fugazi@zyx.net>
+Larry W. Virden                <lvirden@cas.org>
+Larry Wall                     <larry@wall.org>
+Lars Dɪᴇᴄᴋᴏᴡ 迪拉斯               <daxim@cpan.org>
+Lars Hecking                   <lhecking@nmrc.ucc.ie>
+Larwan Berke                   <apocal@cpan.org>
+Laszlo Molnar                  <laszlo.molnar@eth.ericsson.se>
+Laurent Dami                   <dami@cpan.org>
+Leif Huhn                      <leif@hale.dkstat.com>
+Len Johnson                    <lenjay@ibm.net>
+Leo Lapworth                   <leo@cuckoo.org>
+Leon Brocard                   <acme@astray.com>
+Leon Timmermans                <fawaka@gmail.com>
+Les Peters                     <lpeters@aol.net>
+Lesley Binks                   <lesley.binks@gmail.com>
+Lincoln D. Stein               <lstein@cshl.org>
+Lionel Cons                    <lionel.cons@cern.ch>
+Louis Strous                   <louis.strous@gmail.com>
+Lubomir Rintel                 <lkundrak@v3.sk>
+Luc St-Louis                   <luc.st-louis@ca.transport.bombardier.com>
 Luca Fini
-Lucas Holt			<luke@foolishgames.com>
-Ludovic E. R. Tolhurst-Cleaver			<camel@ltcdev.com>
-Lukas Mai			<l.mai@web.de>
-Luke Closs			<lukec@cpan.org>
-Luke Ross			<lukeross@gmail.com>
-Lupe Christoph			<lupe@lupe-christoph.de>
-Luther Huffman			<lutherh@stratcom.com>
-Maik Hentsche			<maik@mm-double.de>
-Major Sébastien			<sebastien.major@crdp.ac-caen.fr>
-Makoto MATSUSHITA		<matusita@ics.es.osaka-u.ac.jp>
-Malcolm Beattie			<mbeattie@sable.ox.ac.uk>
-Manuel Mausz			<manuel@mausz.at>
-Manuel Valente			<mvalente@idealx.com>
-Marc Green			<marcgreen@cpan.org>
-Marc Lehmann			<pcg@goof.com>
-Marc Paquette			<Marc.Paquette@Softimage.COM>
-Marc Simpson			<marc@0branch.com>
-Marc-Philip Werner		<marc-philip.werner@sap.com>
-Marcel Grünauer			<marcel@codewerk.com>
-Marco Fontani			<MFONTANI@cpan.org>
-Marco Peereboom			<marco@conformal.com>
-Marcus Holland-Moritz		<mhx-perl@gmx.net>
-Marek Rouchal			<marek.rouchal@infineon.com>
-Mark A Biggar			<mab@wdl.loral.com>
-Mark A. Hershberger		<mah@everybody.org>
-Mark A. Stratman		<stratman@gmail.com>
-Mark Aufflick			<mark@aufflick.com>
-Mark Bixby			<mark@bixby.org>
-Mark Dickinson			<dickins3@fas.harvard.edu>
-Mark Dootson			<mdootson@cpan.org>
-Mark Fowler			<mark@twoshortplanks.com>
+Lucas Holt                     <luke@foolishgames.com>
+Ludovic E. R. Tolhurst-Cleaver <camel@ltcdev.com>
+Lukas Mai                      <l.mai@web.de>
+Luke Closs                     <lukec@cpan.org>
+Luke Ross                      <lukeross@gmail.com>
+Lupe Christoph                 <lupe@lupe-christoph.de>
+Luther Huffman                 <lutherh@stratcom.com>
+Maik Hentsche                  <maik@mm-double.de>
+Major Sébastien                <sebastien.major@crdp.ac-caen.fr>
+Makoto MATSUSHITA              <matusita@ics.es.osaka-u.ac.jp>
+Malcolm Beattie                <mbeattie@sable.ox.ac.uk>
+Manuel Mausz                   <manuel@mausz.at>
+Manuel Valente                 <mvalente@idealx.com>
+Marc Green                     <marcgreen@cpan.org>
+Marc Lehmann                   <pcg@goof.com>
+Marc Paquette                  <Marc.Paquette@Softimage.COM>
+Marc Simpson                   <marc@0branch.com>
+Marc-Philip Werner             <marc-philip.werner@sap.com>
+Marcel Grünauer                <marcel@codewerk.com>
+Marco Fontani                  <MFONTANI@cpan.org>
+Marco Peereboom                <marco@conformal.com>
+Marcus Holland-Moritz          <mhx-perl@gmx.net>
+Marek Rouchal                  <marek.rouchal@infineon.com>
+Mark A Biggar                  <mab@wdl.loral.com>
+Mark A. Hershberger            <mah@everybody.org>
+Mark A. Stratman               <stratman@gmail.com>
+Mark Aufflick                  <mark@aufflick.com>
+Mark Bixby                     <mark@bixby.org>
+Mark Dickinson                 <dickins3@fas.harvard.edu>
+Mark Dootson                   <mdootson@cpan.org>
+Mark Fowler                    <mark@twoshortplanks.com>
 Mark Hanson
-Mark J. Reed			<mreed@strange.turner.com>
-Mark Jason Dominus		<mjd@plover.com>
-Mark K Trettin			<mkt@lucent.com>
-Mark Kaehny			<kaehny@execpc.com>
-Mark Kettenis			<kettenis@wins.uva.nl>
-Mark Klein			<mklein@dis.com>
-Mark Knutsen			<knutsen@pilot.njin.net>
-Mark Kvale			<kvale@phy.ucsf.edu>
-Mark Leighton Fisher		<markleightonfisher@gmail.com>
-Mark Mielke			<mark@mark.mielke.cc>
-Mark Murray			<mark@grondar.za>
-Mark Overmeer			<mark@overmeer.net>
-Mark P. Lutz			<mark.p.lutz@boeing.com>
-Mark Pease			<peasem@primenet.com>
-Mark Pizzolato			<mark@infocomm.com>
-Mark R. Levinson		<mrl@isc.upenn.edu>
-Mark Stosberg			<mark@summersault.com>
-Marko Asplund			<aspa@merlot.kronodoc.fi>
-Markus Jansen			<Markus.Jansen@ericsson.com>
-Marnix van Ammers		<marnix@gmail.com>
-Martien Verbruggen		<mgjv@comdyn.com.au>
-Martijn Koster			<mak@excitecorp.com>
-Martijn Lievaart		<m@rtij.nl>
-Martin Hasch			<mhasch@cpan.org>
-Martin Husemann			<martin@duskware.de>
-Martin J. Bligh			<mbligh@us.ibm.com>
-Martin Jost			<Martin.Jost@icn.siemens.de>
-Martin Lichtin			<lichtin@bivio.com>
-Martin McGrath			<mcgrath.martin@gmail.com>
-Martin Plechsmid		<plechsmi@karlin.mff.cuni.cz>
-Martin Pool			<mbp@samba.org>
-Martti Rahkila			<martti.rahkila@hut.fi>
-Marty Lucich			<marty@netcom.com>
-Marty Pauley			<marty+p5p@kasei.com>
-Martyn Pearce			<martyn@inpharmatica.co.uk>
-Marvin Humphrey			<marvin@rectangular.com>
-Masahiro KAJIURA		<masahiro.kajiura@toshiba.co.jp>
-Mashrab Kuvatov			<kmashrab@uni-bremen.de>
-Matthias Bethke			<matthias@towiski.de>
-Mathias Koerber			<mathias@dnssec1.singnet.com.sg>
-Mathieu Arnold			<m@absolight.fr>
-Mats Peterson			<mats@sm6sxl.net>
-Matsumoto Yasuhiro		<mattn.jp@gmail.com>
-Matt Johnson			<matt.w.johnson@gmail.com>
+Mark J. Reed                   <mreed@strange.turner.com>
+Mark Jason Dominus             <mjd@plover.com>
+Mark K Trettin                 <mkt@lucent.com>
+Mark Kaehny                    <kaehny@execpc.com>
+Mark Kettenis                  <kettenis@wins.uva.nl>
+Mark Klein                     <mklein@dis.com>
+Mark Knutsen                   <knutsen@pilot.njin.net>
+Mark Kvale                     <kvale@phy.ucsf.edu>
+Mark Leighton Fisher           <markleightonfisher@gmail.com>
+Mark Mielke                    <mark@mark.mielke.cc>
+Mark Murray                    <mark@grondar.za>
+Mark Overmeer                  <mark@overmeer.net>
+Mark P. Lutz                   <mark.p.lutz@boeing.com>
+Mark Pease                     <peasem@primenet.com>
+Mark Pizzolato                 <mark@infocomm.com>
+Mark R. Levinson               <mrl@isc.upenn.edu>
+Mark Stosberg                  <mark@summersault.com>
+Marko Asplund                  <aspa@merlot.kronodoc.fi>
+Markus Jansen                  <Markus.Jansen@ericsson.com>
+Marnix van Ammers              <marnix@gmail.com>
+Martien Verbruggen             <mgjv@comdyn.com.au>
+Martijn Koster                 <mak@excitecorp.com>
+Martijn Lievaart               <m@rtij.nl>
+Martin Hasch                   <mhasch@cpan.org>
+Martin Husemann                <martin@duskware.de>
+Martin J. Bligh                <mbligh@us.ibm.com>
+Martin Jost                    <Martin.Jost@icn.siemens.de>
+Martin Lichtin                 <lichtin@bivio.com>
+Martin McGrath                 <mcgrath.martin@gmail.com>
+Martin Plechsmid               <plechsmi@karlin.mff.cuni.cz>
+Martin Pool                    <mbp@samba.org>
+Martti Rahkila                 <martti.rahkila@hut.fi>
+Marty Lucich                   <marty@netcom.com>
+Marty Pauley                   <marty+p5p@kasei.com>
+Martyn Pearce                  <martyn@inpharmatica.co.uk>
+Marvin Humphrey                <marvin@rectangular.com>
+Masahiro KAJIURA               <masahiro.kajiura@toshiba.co.jp>
+Mashrab Kuvatov                <kmashrab@uni-bremen.de>
+Mathias Koerber                <mathias@dnssec1.singnet.com.sg>
+Mathieu Arnold                 <m@absolight.fr>
+Mats Peterson                  <mats@sm6sxl.net>
+Matsumoto Yasuhiro             <mattn.jp@gmail.com>
+Matt Johnson                   <matt.w.johnson@gmail.com>
 Matt Kimball
-Matt Kraai			<kraai@ftbfs.org>
-Matt S Trout			<mst@shadowcat.co.uk>
-Matt Sergeant			<matt@sergeant.org>
-Matt Taggart			<taggart@debian.org>
-Matt Turner			<mattst88@gmail.com>
-Matthew Black			<black@csulb.edu>
-Matthew Green			<mrg@splode.eterna.com.au>
-Matthew Horsfall		<wolfsage@gmail.com>
-Matthew Sachs			<matthewg@zevils.com>
-Matthew T Harden		<mthard@mthard1.monsanto.com>
-Matthias Ulrich Neeracher	<neeracher@mac.com>
-Matthias Urlichs		<smurf@noris.net>
-Matthijs van Duin		<xmath@cpan.org>
-Mattia Barbon			<mbarbon@dsi.unive.it>
-Maurizio Loreti			<maurizio.loreti@pd.infn.it>
-Max Baker			<max@warped.org>
-Max Maischein			<corion@corion.net>
-Maxwell Carey			<maxwellhaydn@gmail.com>
-Merijn Broeren			<merijnb@iloquent.nl>
-Michael A Chase			<mchase@ix.netcom.com>
-Michael Breen			<perl@mbreen.com>
-Michael Bunk			<bunk@iat.uni-leipzig.de>
-Michael Carman			<mjcarman@home.com>
-Michael Cook			<mcook@cognex.com>
-Michael Cummings		<mcummings@gentoo.org>
-Michael De La Rue		<mikedlr@tardis.ed.ac.uk>
-Michael Engel			<engel@nms1.cc.huji.ac.il>
-Michael Fig			<michael@liveblockauctions.com>
-Michael G Schwern		<schwern@pobox.com>
-Michael H. Moran		<mhm@austin.ibm.com>
-Michael Haardt			<michael@moria.de>
-Michael King			<mike808@users.sourceforge.net>
-Michael Lemke			<lemkemch@t-online.de>
-Michael Mahan			<mahanm@nextwork.rose-hulman.edu>
-Michael Parker			<michael.parker@st.com>
-Michael Schroeder		<Michael.Schroeder@informatik.uni-erlangen.de>
-Michael Somos			<somos@grail.cba.csuohio.edu>
-Michael Stevens			<mstevens@etla.org>
-Michael van Elst		<mlelstv@serpens.de>
-Michael Witten			<mfwitten@gmail.com>
+Matt Kraai                     <kraai@ftbfs.org>
+Matt S Trout                   <mst@shadowcat.co.uk>
+Matt Sergeant                  <matt@sergeant.org>
+Matt Taggart                   <taggart@debian.org>
+Matt Turner                    <mattst88@gmail.com>
+Matthew Black                  <black@csulb.edu>
+Matthew Green                  <mrg@splode.eterna.com.au>
+Matthew Horsfall               <wolfsage@gmail.com>
+Matthew Sachs                  <matthewg@zevils.com>
+Matthew T Harden               <mthard@mthard1.monsanto.com>
+Matthias Bethke                <matthias@towiski.de>
+Matthias Ulrich Neeracher      <neeracher@mac.com>
+Matthias Urlichs               <smurf@noris.net>
+Matthijs van Duin              <xmath@cpan.org>
+Mattia Barbon                  <mbarbon@dsi.unive.it>
+Maurizio Loreti                <maurizio.loreti@pd.infn.it>
+Max Baker                      <max@warped.org>
+Max Maischein                  <corion@corion.net>
+Maxwell Carey                  <maxwellhaydn@gmail.com>
+Merijn Broeren                 <merijnb@iloquent.nl>
+Michael A Chase                <mchase@ix.netcom.com>
+Michael Breen                  <perl@mbreen.com>
+Michael Bunk                   <bunk@iat.uni-leipzig.de>
+Michael Carman                 <mjcarman@home.com>
+Michael Cook                   <mcook@cognex.com>
+Michael Cummings               <mcummings@gentoo.org>
+Michael De La Rue              <mikedlr@tardis.ed.ac.uk>
+Michael Engel                  <engel@nms1.cc.huji.ac.il>
+Michael Fig                    <michael@liveblockauctions.com>
+Michael G Schwern              <schwern@pobox.com>
+Michael H. Moran               <mhm@austin.ibm.com>
+Michael Haardt                 <michael@moria.de>
+Michael King                   <mike808@users.sourceforge.net>
+Michael Lemke                  <lemkemch@t-online.de>
+Michael Mahan                  <mahanm@nextwork.rose-hulman.edu>
+Michael Parker                 <michael.parker@st.com>
+Michael Schroeder              <Michael.Schroeder@informatik.uni-erlangen.de>
+Michael Somos                  <somos@grail.cba.csuohio.edu>
+Michael Stevens                <mstevens@etla.org>
+Michael van Elst               <mlelstv@serpens.de>
+Michael Witten                 <mfwitten@gmail.com>
 Michele Sardo
-Mik Firestone			<fireston@lexmark.com>
-Mike Doherty			<mike@mikedoherty.ca>
-Mike Fletcher			<fletch@phydeaux.org>
-Mike Giroux			<rmgiroux@acm.org>
-Mike Guy			<mjtg@cam.ac.uk>
-Mike Heins			<mike@bill.iac.net>
-Mike Hopkirk			<hops@sco.com>
-Mike Kelly			<pioto@pioto.org>
-Mike Mestnik			<MMestnik@rustconsulting.com>
-Mike Pomraning			<mjp@pilcrow.madison.wi.us>
+Mik Firestone                  <fireston@lexmark.com>
+Mike Doherty                   <mike@mikedoherty.ca>
+Mike Fletcher                  <fletch@phydeaux.org>
+Mike Giroux                    <rmgiroux@acm.org>
+Mike Guy                       <mjtg@cam.ac.uk>
+Mike Heins                     <mike@bill.iac.net>
+Mike Hopkirk                   <hops@sco.com>
+Mike Kelly                     <pioto@pioto.org>
+Mike Mestnik                   <MMestnik@rustconsulting.com>
+Mike Pomraning                 <mjp@pilcrow.madison.wi.us>
 Mike Rogers
-Mike Schilli			<m@perlmeister.com>
-Mike Sheldrake			<mike@sheldrake.net>
-Mike Stok			<mike@stok.co.uk>
-Mike W Ellwood			<mwe@rl.ac.uk>
-Mikhail Zabaluev		<mhz@alt-linux.org>
-Milosz Tanski			<mtanski@gridapp.com>
-Milton L. Hankins		<mlh@swl.msd.ray.com>
-Misty De Meo			<mistydemeo@github.com>
-Mohammed El-Afifi		<mohammed_elafifi@yahoo.com>
-Moritz Lenz			<moritz@casella.verplant.org>
-Moshe Kaminsky			<kaminsky@math.huji.ac.il>
-Mottaqui Karim			<taqqui.karim@gmail.com>
-Mr. Nobody			<mrnobo1024@yahoo.com>
-Murray Nesbitt			<murray@nesbitt.ca>
-Nathan Glenn			<garfieldnate@gmail.com>
-Nathan Kurz			<nate@valleytel.net>
-Nathan Torkington		<gnat@frii.com>
-Nathan Trapuzzano		<nbtrap@nbtrap.com>
-Neale Ferguson			<neale@VMA.TABNSW.COM.AU>
-Neil Bowers			<neil@bowers.com>
-Neil Watkiss			<neil.watkiss@sophos.com>
-Neil Williams			<codehelp@debian.org>
-Nicholas Clark			<nick@ccl4.org>
+Mike Schilli                   <m@perlmeister.com>
+Mike Sheldrake                 <mike@sheldrake.net>
+Mike Stok                      <mike@stok.co.uk>
+Mike W Ellwood                 <mwe@rl.ac.uk>
+Mikhail Zabaluev               <mhz@alt-linux.org>
+Milosz Tanski                  <mtanski@gridapp.com>
+Milton L. Hankins              <mlh@swl.msd.ray.com>
+Misty De Meo                   <mistydemeo@github.com>
+Mohammed El-Afifi              <mohammed_elafifi@yahoo.com>
+Moritz Lenz                    <moritz@casella.verplant.org>
+Moshe Kaminsky                 <kaminsky@math.huji.ac.il>
+Mottaqui Karim                 <taqqui.karim@gmail.com>
+Mr. Nobody                     <mrnobo1024@yahoo.com>
+Murray Nesbitt                 <murray@nesbitt.ca>
+Nathan Glenn                   <garfieldnate@gmail.com>
+Nathan Kurz                    <nate@valleytel.net>
+Nathan Torkington              <gnat@frii.com>
+Nathan Trapuzzano              <nbtrap@nbtrap.com>
+Neale Ferguson                 <neale@VMA.TABNSW.COM.AU>
+Neil Bowers                    <neil@bowers.com>
+Neil Watkiss                   <neil.watkiss@sophos.com>
+Neil Williams                  <codehelp@debian.org>
+Nicholas Clark                 <nick@ccl4.org>
 Nicholas Oxhøj
-Nicholas Perez			<nperez@cpan.org>
-Nick Cleaton			<nick@cleaton.net>
+Nicholas Perez                 <nperez@cpan.org>
+Nick Cleaton                   <nick@cleaton.net>
 Nick Duffek
 Nick Gianniotis
 Nick Ing-Simmons
-Nick Johnston			<nickjohnstonsky@gmail.com>
-Nick Logan			<ugexe@cpan.org>
-Nick Williams			<Nick.Williams@morganstanley.com>
-Nicolas Kaiser			<nikai@nikai.net>
-Nicolas R.			<atoomic@cpan.org>
-Niels Thykier			<niels@thykier.net>
-Nigel Sandever			<njsandever@hotmail.com>
-Niko Tyni			<ntyni@debian.org>
-Nikola Knezevic			<indy@tesla.rcub.bg.ac.yu>
+Nick Johnston                  <nickjohnstonsky@gmail.com>
+Nick Logan                     <ugexe@cpan.org>
+Nick Williams                  <Nick.Williams@morganstanley.com>
+Nicolas Kaiser                 <nikai@nikai.net>
+Nicolas R.                     @atoomic
+Niels Thykier                  <niels@thykier.net>
+Nigel Sandever                 <njsandever@hotmail.com>
+Niko Tyni                      <ntyni@debian.org>
+Nikola Knezevic                <indy@tesla.rcub.bg.ac.yu>
 Nikola Milutinovic
-Nikolai Eipel			<eipel@web.de>
-Noah				<sitz@onastick.net>
+Nikolai Eipel                  <eipel@web.de>
+Noah                           <sitz@onastick.net>
 Nobuhiro Iwamatsu
-Noirin Shirley			<colmsbook@nerdchic.net>
-Norbert Pueschel		<pueschel@imsdd.meb.uni-bonn.de>
-Norio Suzuki			<kipp@shonanblue.ne.jp>
-Norman Koch			<kochnorman@rocketmail.com>
-Norton T. Allen			<allen@huarp.harvard.edu>
-Nuno Carvalho			<mestre.smash@gmail.com>
-Offer Kaye			<offer.kaye@gmail.com>
-Olaf Flebbe			<o.flebbe@science-computing.de>
-Olaf Titz			<olaf@bigred.inka.de>
-Oleg Nesterov			<oleg@redhat.com>
-Olivier Blin			<blino@mandriva.com>
-Olivier Mengué			<dolmen@cpan.org>
-Olivier Thauvin			<olivier.thauvin@aerov.jussieu.fr>
+Noirin Shirley                 <colmsbook@nerdchic.net>
+Norbert Pueschel               <pueschel@imsdd.meb.uni-bonn.de>
+Norio Suzuki                   <kipp@shonanblue.ne.jp>
+Norman Koch                    <kochnorman@rocketmail.com>
+Norton T. Allen                <allen@huarp.harvard.edu>
+Nuno Carvalho                  <mestre.smash@gmail.com>
+Offer Kaye                     <offer.kaye@gmail.com>
+Olaf Flebbe                    <o.flebbe@science-computing.de>
+Olaf Titz                      <olaf@bigred.inka.de>
+Oleg Nesterov                  <oleg@redhat.com>
+Olivier Blin                   <blino@mandriva.com>
+Olivier Mengué                 <dolmen@cpan.org>
+Olivier Thauvin                <olivier.thauvin@aerov.jussieu.fr>
 Olli Savia
-Ollivier Robert			<roberto@keltia.freenix.fr>
-Osvaldo Villalon		<ovillalon@dextratech.com>
-Owain G. Ainsworth		<oga@nicotinebsd.org>
-Owen Taylor			<owt1@cornell.edu>
-Pali				<pali@cpan.org>
-Papp Zoltan			<padre@elte.hu>
-parv				<parv@pair.com>
-Pascal Rigaux			<pixel@mandriva.com>
-Patrick Donelan			<pat@patspam.com>
-Patrick Dugnolle		<patrick.dugnolle@bnpparibas.com>
-Patrick Hayes			<Patrick.Hayes.CAP_SESA@renault.fr>
-Patrick O'Brien			<pdo@cs.umd.edu>
-Patrik Hägglund			<patrik.h.hagglund@ericsson.com>
-Pau Amma			<pauamma@gundo.com>
-Paul A Sand			<pas@unh.edu>
-Paul Boven			<p.boven@sara.nl>
-Paul David Fardy		<pdf@morgan.ucs.mun.ca>
-Paul Eggert			<eggert@twinsun.com>
-Paul Evans			<leonerd@leonerd.org.uk>
-Paul Fenwick			<pjf@perltraining.com.au>
-Paul Gaborit			<paul.gaborit@enstimac.fr>
-Paul Green			<Paul.Green@stratus.com>
-Paul Hoffman			<phoffman@proper.com>
-Paul Holser			<Paul.Holser.pholser@nortelnetworks.com>
-Paul Johnson			<paul@pjcj.net>
-Paul Lindner			<lindner@inuus.com>
-Paul Marquess			<pmqs@cpan.org>
-Paul Moore			<Paul.Moore@uk.origin-it.com>
-Paul Rogers			<Paul.Rogers@Central.Sun.COM>
-Paul Saab			<ps@yahoo-inc.com>
-Paul Schinder			<schinder@pobox.com>
-Paul Szabo			<psz@maths.usyd.edu.au>
-Pavel Kaňkovský			<kan@dcit.cz>
-Pavel Zakouril			<Pavel.Zakouril@mff.cuni.cz>
-Pedro Felipe Horrillo Guerra	<pancho@pancho.name>
-Per Einar Ellefsen		<per.einar@skynet.be>
-Perlover			<perlover@perlover.com>
-Pete Peterson			<petersonp@genrad.com>
-Peter Avalos			<peter@theshell.com>
+Ollivier Robert                <roberto@keltia.freenix.fr>
+Osvaldo Villalon               <ovillalon@dextratech.com>
+Owain G. Ainsworth             <oga@nicotinebsd.org>
+Owen Taylor                    <owt1@cornell.edu>
+Pali                           <pali@cpan.org>
+Papp Zoltan                    <padre@elte.hu>
+parv                           <parv@pair.com>
+Pascal Rigaux                  <pixel@mandriva.com>
+Patrick Donelan                <pat@patspam.com>
+Patrick Dugnolle               <patrick.dugnolle@bnpparibas.com>
+Patrick Hayes                  <Patrick.Hayes.CAP_SESA@renault.fr>
+Patrick O'Brien                <pdo@cs.umd.edu>
+Patrik Hägglund                <patrik.h.hagglund@ericsson.com>
+Pau Amma                       <pauamma@gundo.com>
+Paul A Sand                    <pas@unh.edu>
+Paul Boven                     <p.boven@sara.nl>
+Paul David Fardy               <pdf@morgan.ucs.mun.ca>
+Paul Eggert                    <eggert@twinsun.com>
+Paul Evans                     <leonerd@leonerd.org.uk>
+Paul Fenwick                   <pjf@perltraining.com.au>
+Paul Gaborit                   <paul.gaborit@enstimac.fr>
+Paul Green                     <Paul.Green@stratus.com>
+Paul Hoffman                   <phoffman@proper.com>
+Paul Holser                    <Paul.Holser.pholser@nortelnetworks.com>
+Paul Johnson                   <paul@pjcj.net>
+Paul Lindner                   <lindner@inuus.com>
+Paul Marquess                  <pmqs@cpan.org>
+Paul Moore                     <Paul.Moore@uk.origin-it.com>
+Paul Rogers                    <Paul.Rogers@Central.Sun.COM>
+Paul Saab                      <ps@yahoo-inc.com>
+Paul Schinder                  <schinder@pobox.com>
+Paul Szabo                     <psz@maths.usyd.edu.au>
+Pavel Kaňkovský                <kan@dcit.cz>
+Pavel Zakouril                 <Pavel.Zakouril@mff.cuni.cz>
+Pedro Felipe Horrillo Guerra   <pancho@pancho.name>
+Per Einar Ellefsen             <per.einar@skynet.be>
+Perlover                       <perlover@perlover.com>
+Pete Peterson                  <petersonp@genrad.com>
+Peter Avalos                   <peter@theshell.com>
 Peter BARABAS
-Peter Chines			<pchines@nhgri.nih.gov>
-Peter Dintelmann		<Peter.Dintelmann@Dresdner-Bank.com>
-Peter E. Yee			<yee@trident.arc.nasa.gov>
-Peter Eisentraut			<peter@eisentraut.org>
-Peter Gessner			<peter.gessner@post.rwth-aachen.de>
-Peter Gordon			<peter@valor.com>
-Peter Haworth			<pmh@edison.ioppublishing.com>
-Peter J. Farley III		<pjfarley@banet.net>
-Peter J. Holzer			<hjp@hjp.at>
+Peter Chines                   <pchines@nhgri.nih.gov>
+Peter Dintelmann               <peter.dintelmann@dresdner-bank.com>
+Peter E. Yee                   <yee@trident.arc.nasa.gov>
+Peter Eisentraut               <peter@eisentraut.org>
+Peter Gessner                  <peter.gessner@post.rwth-aachen.de>
+Peter Gordon                   <peter@valor.com>
+Peter Haworth                  <pmh@edison.ioppublishing.com>
+Peter J. Farley III            <pjfarley@banet.net>
+Peter J. Holzer                <hjp@hjp.at>
 Peter Jaspers-Fayer
-Peter John Acklam		<pjacklam@online.no>
+Peter John Acklam              <pjacklam@online.no>
 Peter Liscovius
-Peter Martini			<PeterCMartini@GMail.com>
-Peter O'Gorman			<peter@pogma.com>
-Peter Prymmer			<PPrymmer@factset.com>
-Peter Rabbitson			<ribasushi@cpan.org>
-Peter Scott			<Peter@PSDT.com>
-Peter Valdemar Mørch		<pm@capmon.dk>
-Peter van Heusden		<pvh@junior.uwc.ac.za>
-Peter Wolfe			<wolfe@teloseng.com>
-Petr Písař			<ppisar@redhat.com>
-Petter Reinholdtsen		<pere@hungry.com>
-Phil Lobbes			<phil@perkpartners.com>
-Phil Monsen			<philip.monsen@pobox.com>
-Phil Pearl (Lobbes)			<plobbes@gmail.com>
-Philip Boulain			<philip.boulain@smoothwall.net>
-Philip Guenther			<guenther@openbsd.org>
-Philip Hazel			<ph10@cus.cam.ac.uk>
-Philip M. Gollucci		<pgollucci@p6m7g8.com>
-Philip Newton			<pne@cpan.org>
-Philippe Bruhat (BooK)		<book@cpan.org>
-Philippe M. Chiasson		<gozer@ActiveState.com>
-Pierre Bogossian		<bogossian@mail.com>
-Piers Cawley			<pdcawley@bofh.org.uk>
-Pino Toscano			<pino@debian.org>
-Piotr Fusik			<pfusik@op.pl>
-Piotr Klaban			<makler@oryl.man.torun.pl>
-Piotr Roszatycki		<piotr.roszatycki@gmail.com>
-Pip Cet				<pipcet@gmail.com>
-Pradeep Hodigere		<phodigere@yahoo.com>
-Prymmer/Kahn			<pvhp@best.com>
-Quentin Fennessy		<quentin@arrakeen.amd.com>
-Radu Greab			<radu@netsoft.ro>
-Rafael Garcia-Suarez		<rgs@consttype.org>
-Rainer Keuchel			<keuchel@allgeier.com>
-Rainer Orth			<ro@TechFak.Uni-Bielefeld.DE>
-Rainer Tammer			<tammer@tammer.net>
-Rajesh Mandalemula		<rajesh.mandalemula@deshaw.com>
-Rajesh Vaidheeswarran		<rv@gnu.org>
-Ralf S. Engelschall		<rse@engelschall.com>
-Randal L. Schwartz		<merlyn@stonehenge.com>
-Randall Gellens			<randy@qualcomm.com>
-Randolf Werner			<randolf.werner@sap.com>
-Randy J. Ray			<rjray@redhat.com>
-Randy Stauner			<rwstauner@cpan.org>
+Peter Martini                  <PeterCMartini@GMail.com>
+Peter O'Gorman                 <peter@pogma.com>
+Peter Prymmer                  <PPrymmer@factset.com>
+Peter Rabbitson                <ribasushi@cpan.org>
+Peter Scott                    <Peter@PSDT.com>
+Peter Valdemar Mørch           <pm@capmon.dk>
+Peter van Heusden              <pvh@junior.uwc.ac.za>
+Peter Wolfe                    <wolfe@teloseng.com>
+Petr Písař                     <ppisar@redhat.com>
+Petter Reinholdtsen            <pere@hungry.com>
+Phil Lobbes                    <phil@perkpartners.com>
+Phil Monsen                    <philip.monsen@pobox.com>
+Phil Pearl (Lobbes)            <plobbes@gmail.com>
+Philip Boulain                 <philip.boulain@smoothwall.net>
+Philip Guenther                <guenther@openbsd.org>
+Philip Hazel                   <ph10@cus.cam.ac.uk>
+Philip M. Gollucci             <pgollucci@p6m7g8.com>
+Philip Newton                  <pne@cpan.org>
+Philippe Bruhat (BooK)         <book@cpan.org>
+Philippe M. Chiasson           <gozer@ActiveState.com>
+Pierre Bogossian               <bogossian@mail.com>
+Piers Cawley                   <pdcawley@bofh.org.uk>
+Pino Toscano                   <pino@debian.org>
+Piotr Fusik                    <pfusik@op.pl>
+Piotr Klaban                   <makler@oryl.man.torun.pl>
+Piotr Roszatycki               <piotr.roszatycki@gmail.com>
+Pip Cet                        <pipcet@gmail.com>
+Pradeep Hodigere               <phodigere@yahoo.com>
+Prymmer/Kahn                   <pvhp@best.com>
+Quentin Fennessy               <quentin@arrakeen.amd.com>
+Radu Greab                     <radu@netsoft.ro>
+Rafael Garcia-Suarez           <rgs@consttype.org>
+Rainer Keuchel                 <keuchel@allgeier.com>
+Rainer Orth                    <ro@TechFak.Uni-Bielefeld.DE>
+Rainer Tammer                  <tammer@tammer.net>
+Rajesh Mandalemula             <rajesh.mandalemula@deshaw.com>
+Rajesh Vaidheeswarran          <rv@gnu.org>
+Ralf S. Engelschall            <rse@engelschall.com>
+Randal L. Schwartz             <merlyn@stonehenge.com>
+Randall Gellens                <randy@qualcomm.com>
+Randolf Werner                 <randolf.werner@sap.com>
+Randy J. Ray                   <rjray@redhat.com>
+Randy Stauner                  <rwstauner@cpan.org>
 Randy W. Sims
-Raphael Manfredi		<Raphael.Manfredi@pobox.com>
-Raul Dias			<raul@dias.com.br>
-Raymund Will			<ray@caldera.de>
-Redvers Davies			<red@criticalintegration.com>
-Reini Urban			<rurban@cpan.org>
-Renee Baecker			<module@renee-baecker.de>
-Reuben Thomas			<rrt@sc3d.org>
-Rex Dieter			<rdieter@math.unl.edu>
-Rhesa Rozendaal			<perl@rhesa.com>
-Ricardo Signes			<rjbs@cpan.org>
-Rich Morin			<rdm@cfcl.com>
-Rich Rauenzahn			<rrauenza@hp.com>
-Rich Salz			<rsalz@bbn.com>
-Richard A. Wells		<Rwells@uhs.harvard.edu>
-Richard Clamp			<richardc@unixbeard.net>
-Richard Foley			<richard.foley@rfi.net>
-Richard Hatch			<rhatch@austin.ibm.com>
-Richard Hitt			<rbh00@utsglobal.com>
-Richard Kandarian		<richard.kandarian@lanl.gov>
-Richard L. England		<richard_england@mentorg.com>
-Richard L. Maus, Jr.		<rmaus@monmouth.com>
-Richard Leach			<rich+perl@hyphen-dash-hyphen.info>
-Richard Levitte			<levitte@openssl.org>
-Richard Möhn			<richard.moehn@fu-berlin.de>
-Richard Ohnemus			<richard_ohnemus@dallas.csd.sterling.com>
-Richard Soderberg		<p5-authors@crystalflame.net>
-Richard Yeh			<rcyeh@cco.caltech.edu>
-Rick Delaney			<rick@consumercontact.com>
+Raphael Manfredi               <Raphael.Manfredi@pobox.com>
+Raul Dias                      <raul@dias.com.br>
+Raymund Will                   <ray@caldera.de>
+Redvers Davies                 <red@criticalintegration.com>
+Reini Urban                    <rurban@cpan.org>
+Renee Baecker                  <module@renee-baecker.de>
+Reuben Thomas                  <rrt@sc3d.org>
+Rex Dieter                     <rdieter@math.unl.edu>
+Rhesa Rozendaal                <perl@rhesa.com>
+Ricardo Signes                 <rjbs@cpan.org>
+Rich Morin                     <rdm@cfcl.com>
+Rich Rauenzahn                 <rrauenza@hp.com>
+Rich Salz                      <rsalz@bbn.com>
+Richard A. Wells               <Rwells@uhs.harvard.edu>
+Richard Clamp                  <richardc@unixbeard.net>
+Richard Foley                  <richard.foley@rfi.net>
+Richard Hatch                  <rhatch@austin.ibm.com>
+Richard Hitt                   <rbh00@utsglobal.com>
+Richard Kandarian              <richard.kandarian@lanl.gov>
+Richard L. England             <richard_england@mentorg.com>
+Richard L. Maus, Jr.           <rmaus@monmouth.com>
+Richard Leach                  <rich+perl@hyphen-dash-hyphen.info>
+Richard Levitte                <levitte@openssl.org>
+Richard Möhn                   <richard.moehn@fu-berlin.de>
+Richard Ohnemus                <richard_ohnemus@dallas.csd.sterling.com>
+Richard Soderberg              <p5-authors@crystalflame.net>
+Richard Yeh                    <rcyeh@cco.caltech.edu>
+Rick Delaney                   <rick@consumercontact.com>
 Rick Pluta
-Rick Smith			<ricks@sd.znet.com>
+Rick Smith                     <ricks@sd.znet.com>
 Rickard Westman
-Rob Brown			<bbb@cpan.org>
-Rob Henderson			<robh@cs.indiana.edu>
-Rob Hoelz			<rob@hoelz.ro>
-Rob Napier			<rnapier@employees.org>
-Robert May			<robertmay@cpan.org>
-Robert Millan			<rmh@debian.org>
-Robert Partington		<rjp@riffraff.plig.net>
-Robert Sanders			<Robert.Sanders@linux.org>
-Robert Sebastian Gerus		<arachnist@gmail.com>
-Robert Spier			<rspier@pobox.com>
-Roberto C. Sanchez		<roberto@connexer.com>
-Robin Barker			<RMBarker@cpan.org>
-Robin Houston			<robin@cpan.org>
-Rocco Caputo			<troc@netrus.net>
-Roderick Schertler		<roderick@argon.org>
-Rodger Anderson			<rodger@boi.hp.com>
-Rodolfo Carvalho		<rhcarvalho@gmail.com>
-Ronald F. Guilmette		<rfg@monkeys.com>
-Ronald J. Kimball		<rjk@linguist.dartmouth.edu>
-Ronald Schmidt			<RonaldWS@aol.com>
-Rostislav Skudnov		<skrostislav@gmail.com>
-Ruben Schattevoy		<schattev@imb-jena.de>
-Rudolph Todd Maceyko		<rm55+@pitt.edu>
-Rujith S. de Silva		<desilva@netbox.com>
-Ruslan Zakirov			<ruz@bestpractical.com>
-Russ Allbery			<rra@stanford.edu>
-Russel O'Connor			<roconnor@world.std.com>
-Russell Fulton			<russell@ccu1.auckland.ac.nz>
-Russell Mosemann		<mose@ccsn.edu>
-Ryan Herbert			<rherbert@sycamorehq.com>
-Ryan Voots			<simcop2387@simcop2387.info>
-Salvador Fandiño		<sfandino@yahoo.com>
-Salvador Ortiz Garcia		<sog@msg.com.mx>
-Sam Kimbrel			<kimbrel@me.com>
-Sam Tregar			<sam@tregar.com>
-Sam Vilain			<sam@vilain.net>
-Samuel Thibault			<sthibault@debian.org>
-Samuli Kärkkäinen		<skarkkai@woods.iki.fi>
-Santtu Ojanperä			<santtuojanpera98@gmail.com>
-Sawyer X			<xsawyerx@cpan.org>
-Schuyler Erle			<schuyler@oreilly.com>
-Scott A Crosby			<scrosby@cs.rice.edu>
-Scott Bronson			<bronson@rinspin.com>
-Scott Gifford			<sgifford@tir.com>
-Scott Henry			<scotth@sgi.com>
-Scott L. Miller			<Scott.L.Miller@Compaq.com>
-Scott Lanning			<lannings@who.int>
-Scott Wiersdorf			<scott@perlcode.org>
-Sean Boudreau			<seanb@qnx.com>
-Sean Dague			<sean@dague.net>
-Sean Davis			<dive@ender.com>
-Sean M. Burke			<sburke@cpan.org>
-Sean Robinson			<robinson_s@sc.maricopa.edu>
-Sean Sheedy			<seans@ncube.com>
-Sebastian Schmidt		<yath@yath.de>
-Sebastian Steinlechner		<steinlechner@gmx.net>
-Sebastian Wittmeier		<Sebastian.Wittmeier@ginko.de>
-Sébastien Aperghis-Tramoni	<saper@cpan.org>
-Sebastien Barre			<Sebastien.Barre@utc.fr>
-Sergey Alekseev			<varnie29a@mail.ru>
-Sergey Aleynikov		<sergey.aleynikov@gmail.com>
-Sérgio Durigan Júnior		<sergiodj@linux.vnet.ibm.com>
-Shawn				<svicalifornia@gmail.com>
-Shawn M Moore			<sartak@gmail.com>
-Sherm Pendley			<sherm@dot-app.org>
-Shigeya Suzuki			<shigeya@wide.ad.jp>
-Shimpei Yamashita		<shimpei@socrates.patnet.caltech.edu>
-Shinya Hayakawa			<hayakawa@livedoor.jp>
-Shirakata Kentaro		<argrath@ub32.org>
-Shishir Gundavaram		<shishir@ruby.ora.com>
-Shlomi Fish			<shlomif@cpan.org>
-Shoichi Kaji			<skaji@cpan.org>
-Simon Cozens			<simon@netthink.co.uk>
-Simon Glover			<scog@roe.ac.uk>
+Rob Brown                      <bbb@cpan.org>
+Rob Henderson                  <robh@cs.indiana.edu>
+Rob Hoelz                      <rob@hoelz.ro>
+Rob Napier                     <rnapier@employees.org>
+Robert May                     <robertmay@cpan.org>
+Robert Millan                  <rmh@debian.org>
+Robert Partington              <rjp@riffraff.plig.net>
+Robert Sanders                 <Robert.Sanders@linux.org>
+Robert Sebastian Gerus         <arachnist@gmail.com>
+Robert Spier                   <rspier@pobox.com>
+Roberto C. Sanchez             <roberto@connexer.com>
+Robin Barker                   <RMBarker@cpan.org>
+Robin Houston                  <robin@cpan.org>
+Rocco Caputo                   <troc@netrus.net>
+Roderick Schertler             <roderick@argon.org>
+Rodger Anderson                <rodger@boi.hp.com>
+Rodolfo Carvalho               <rhcarvalho@gmail.com>
+Ronald F. Guilmette            <rfg@monkeys.com>
+Ronald J. Kimball              <rjk@linguist.dartmouth.edu>
+Ronald Schmidt                 <RonaldWS@aol.com>
+Rostislav Skudnov              <skrostislav@gmail.com>
+Ruben Schattevoy               <schattev@imb-jena.de>
+Rudolph Todd Maceyko           <rm55+@pitt.edu>
+Rujith S. de Silva             <desilva@netbox.com>
+Ruslan Zakirov                 <ruz@bestpractical.com>
+Russ Allbery                   <rra@stanford.edu>
+Russel O'Connor                <roconnor@world.std.com>
+Russell Fulton                 <russell@ccu1.auckland.ac.nz>
+Russell Mosemann               <mose@ccsn.edu>
+Ryan Herbert                   <rherbert@sycamorehq.com>
+Ryan Voots                     <simcop2387@simcop2387.info>
+Salvador Fandiño               <sfandino@yahoo.com>
+Salvador Ortiz Garcia          <sog@msg.com.mx>
+Sam Kimbrel                    <kimbrel@me.com>
+Sam Tregar                     <sam@tregar.com>
+Sam Vilain                     <sam@vilain.net>
+Samuel Thibault                <sthibault@debian.org>
+Samuli Kärkkäinen              <skarkkai@woods.iki.fi>
+Santtu Ojanperä                <santtuojanpera98@gmail.com>
+Sawyer X                       <xsawyerx@cpan.org>
+Schuyler Erle                  <schuyler@oreilly.com>
+Scott A Crosby                 <scrosby@cs.rice.edu>
+Scott Bronson                  <bronson@rinspin.com>
+Scott Gifford                  <sgifford@tir.com>
+Scott Henry                    <scotth@sgi.com>
+Scott L. Miller                <Scott.L.Miller@Compaq.com>
+Scott Lanning                  <lannings@who.int>
+Scott Wiersdorf                <scott@perlcode.org>
+Sean Boudreau                  <seanb@qnx.com>
+Sean Dague                     <sean@dague.net>
+Sean Davis                     <dive@ender.com>
+Sean M. Burke                  <sburke@cpan.org>
+Sean Robinson                  <robinson_s@sc.maricopa.edu>
+Sean Sheedy                    <seans@ncube.com>
+Sebastian Schmidt              <yath@yath.de>
+Sebastian Steinlechner         <steinlechner@gmx.net>
+Sebastian Wittmeier            <Sebastian.Wittmeier@ginko.de>
+Sebastien Barre                <Sebastien.Barre@utc.fr>
+Sergey Alekseev                <varnie29a@mail.ru>
+Sergey Aleynikov               <sergey.aleynikov@gmail.com>
+Shawn                          <svicalifornia@gmail.com>
+Shawn M Moore                  <sartak@gmail.com>
+Sherm Pendley                  <sherm@dot-app.org>
+Shigeya Suzuki                 <shigeya@wide.ad.jp>
+Shimpei Yamashita              <shimpei@socrates.patnet.caltech.edu>
+Shinya Hayakawa                <hayakawa@livedoor.jp>
+Shirakata Kentaro              <argrath@ub32.org>
+Shishir Gundavaram             <shishir@ruby.ora.com>
+Shlomi Fish                    <shlomif@cpan.org>
+Shoichi Kaji                   <skaji@cpan.org>
+Simon Cozens                   <simon@netthink.co.uk>
+Simon Glover                   <scog@roe.ac.uk>
 Simon Leinen
-Simon Parsons			<S.Parsons@ftel.co.uk>
-Simon Schubert			<corecode@fs.ei.tum.de>
-Sinan Unur			<sinan@unur.com>
-Sisyphus			<sisyphus@cpan.org>
-Slaven Rezic			<slaven@rezic.de>
-Smylers				<smylers@stripey.com>
-Solar Designer			<solar@openwall.com>
-Spider Boardman			<spider@orb.nashua.nh.us>
-Spiros Denaxas			<s.denaxas@gmail.com>
-Sreeji K Das			<sreeji_k@yahoo.com>
-Stanislaw Pusep			<stas@sysd.org>
-Stas Bekman			<stas@stason.org>
-Stefan Seifert			<nine@detonation.org>
-Steffen Müller			<smueller@cpan.org>
-Steffen Schwigon		<ss5@renormalist.net>
-Steffen Ullrich			<coyote.frank@gmx.net>
-Stepan Kasal			<skasal@redhat.com>
-Stéphane Payrard		<stef@mongueurs.net>
-Stephanie Beals			<bealzy@us.ibm.com>
-Stephen Bennett			<sbp@exherbo.com>
-Stephen Clouse			<stephenc@theiqgroup.com>
-Stephen McCamant		<smcc@mit.edu>
-Stephen O. Lidie		<lusol@turkey.cc.Lehigh.EDU>
-Stephen Oberholtzer		<oliverklozoff@gmail.com>
-Stephen P. Potter		<spp@ds.net>
-Stephen Zander			<gibreel@pobox.com>
-Stevan Little			<stevan@cpan.org>
-Steve A Fink			<sfink@cs.berkeley.edu>
-Steve Grazzini			<grazz@pobox.com>
-Steve Hay			<steve.m.hay@googlemail.com>
-Steve Kelem			<steve.kelem@xilinx.com>
-Steve McDougall			<swmcd@world.std.com>
-Steve Nielsen			<spn@enteract.com>
+Simon Parsons                  <S.Parsons@ftel.co.uk>
+Simon Schubert                 <corecode@fs.ei.tum.de>
+Sinan Unur                     <sinan@unur.com>
+Sisyphus                       <sisyphus@cpan.org>
+Slaven Rezic                   <slaven@rezic.de>
+Smylers                        <smylers@stripey.com>
+Solar Designer                 <solar@openwall.com>
+Spider Boardman                <spider@orb.nashua.nh.us>
+Spiros Denaxas                 <s.denaxas@gmail.com>
+Sreeji K Das                   <sreeji_k@yahoo.com>
+Stanislaw Pusep                <stas@sysd.org>
+Stas Bekman                    <stas@stason.org>
+Stefan Seifert                 <nine@detonation.org>
+Steffen Müller                 <smueller@cpan.org>
+Steffen Schwigon               <ss5@renormalist.net>
+Steffen Ullrich                <coyote.frank@gmx.net>
+Stepan Kasal                   <skasal@redhat.com>
+Stephanie Beals                <bealzy@us.ibm.com>
+Stephen Bennett                <sbp@exherbo.com>
+Stephen Clouse                 <stephenc@theiqgroup.com>
+Stephen McCamant               <smcc@mit.edu>
+Stephen O. Lidie               <lusol@turkey.cc.Lehigh.EDU>
+Stephen Oberholtzer            <oliverklozoff@gmail.com>
+Stephen P. Potter              <spp@ds.net>
+Stephen Zander                 <gibreel@pobox.com>
+Stevan Little                  <stevan@cpan.org>
+Steve A Fink                   <sfink@cs.berkeley.edu>
+Steve Grazzini                 <grazz@pobox.com>
+Steve Hay                      <steve.m.hay@googlemail.com>
+Steve Kelem                    <steve.kelem@xilinx.com>
+Steve McDougall                <swmcd@world.std.com>
+Steve Nielsen                  <spn@enteract.com>
 Steve Pearlmutter
-Steve Peters			<steve@fisharerojo.org>
-Steve Purkis			<Steve.Purkis@multimap.com>
+Steve Peters                   <steve@fisharerojo.org>
+Steve Purkis                   <Steve.Purkis@multimap.com>
 Steve Vinoski
-Steven Hirsch			<hirschs@btv.ibm.com>
-Steven Humphrey			<catchperl@33k.co.uk>
-Steven Knight			<knight@theopera.baldmt.citilink.com>
-Steven Morlock			<newspost@morlock.net>
-Steven N. Hirsch		<hirschs@stargate.btv.ibm.com>
-Steven Parkes			<parkes@sierravista.com>
-Steven Schubiger		<schubiger@cpan.org>
-Stian Seeberg			<sseeberg@nimsoft.no>
-Sullivan Beck			<sbeck@cpan.org>
-Svyatoslav			<razmyslov@viva64.com>
-Sven Strickroth			<sven.strickroth@tu-clausthal.de>
-Sven Verdoolaege		<skimo@breughel.ufsia.ac.be>
-syber				<syber@crazypanda.ru>
-SynaptiCAD, Inc.		<sales@syncad.com>
-Tadeusz Sośnierz		<tadeusz.sosnierz@onet.pl>
-Takis Psarogiannakopoulos	<takis@xfree86.org>
+Steven Hirsch                  <hirschs@btv.ibm.com>
+Steven Humphrey                <catchperl@33k.co.uk>
+Steven Knight                  <knight@theopera.baldmt.citilink.com>
+Steven Morlock                 <newspost@morlock.net>
+Steven N. Hirsch               <hirschs@stargate.btv.ibm.com>
+Steven Parkes                  <parkes@sierravista.com>
+Steven Schubiger               <schubiger@cpan.org>
+Stian Seeberg                  <sseeberg@nimsoft.no>
+Stéphane Payrard               <stef@mongueurs.net>
+Sullivan Beck                  <sbeck@cpan.org>
+Sven Strickroth                <sven.strickroth@tu-clausthal.de>
+Sven Verdoolaege               <skimo@breughel.ufsia.ac.be>
+Svyatoslav                     <razmyslov@viva64.com>
+syber                          <syber@crazypanda.ru>
+SynaptiCAD, Inc.               <sales@syncad.com>
+Sébastien Aperghis-Tramoni     <sebastien@aperghis.net>
+Sérgio Durigan Júnior          <sergiodj@linux.vnet.ibm.com>
+Tadeusz Sośnierz               <tadeusz.sosnierz@onet.pl>
+Takis Psarogiannakopoulos      <takis@xfree86.org>
 Taro KAWAGISHI
-Tassilo von Parseval		<tassilo.parseval@post.rwth-aachen.de>
-Tatsuhiko Miyagawa		<miyagawa@bulknews.net>
-Ted Ashton			<ashted@southern.edu>
-Ted Law				<tedlaw@cibcwg.com>
-Tels				<nospam-abuse@bloodgate.com>
-Teun Burgers			<burgers@ecn.nl>
-Thad Floryan			<thad@thadlabs.com>
-Theo Buehler			<theo@math.ethz.ch>
-Thomas Bowditch			<bowditch@inmet.com>
-Thomas Conté			<tom@fr.uu.net>
-Thomas Dorner			<Thomas.Dorner@start.de>
+Tassilo von Parseval           <tassilo.parseval@post.rwth-aachen.de>
+Tatsuhiko Miyagawa             <miyagawa@bulknews.net>
+Ted Ashton                     <ashted@southern.edu>
+Ted Law                        <tedlaw@cibcwg.com>
+Tels                           <nospam-abuse@bloodgate.com>
+Teun Burgers                   <burgers@ecn.nl>
+Thad Floryan                   <thad@thadlabs.com>
+Theo Buehler                   <theo@math.ethz.ch>
+Thomas Bowditch                <bowditch@inmet.com>
+Thomas Conté                   <tom@fr.uu.net>
+Thomas Dorner                  <Thomas.Dorner@start.de>
 Thomas Kofler
 Thomas König
-Thomas Pfau			<pfau@nbpfaus.net>
-Thomas Sibley			<tsibley@cpan.org>
-Thomas Wegner			<wegner_thomas@yahoo.com>
-Thorsten Glaser			<tg@mirbsd.org>
-Tim Adye			<T.J.Adye@rl.ac.uk>
-Tim Ayers			<tayers@bridge.com>
-Tim Bunce			<Tim.Bunce@pobox.com>
-Tim Conrow			<tim@spindrift.srl.caltech.edu>
-Tim Freeman			<tfreeman@infoseek.com>
-Tim Jenness			<tjenness@cpan.org>
-Tim Mooney			<mooney@dogbert.cc.ndsu.NoDak.edu>
-Tim Sweetman			<tim@aldigital.co.uk>
-Tim Witham			<twitham@pcocd2.intel.com>
-Timothe Litt			<litt@acm.org>
-Timur I. Bakeyev		<bsdi@listserv.bat.ru>
-Tina Müller			<cpan2@tinita.de>
-Tkil				<tkil@reptile.scrye.com>
-Tobias Leich			<email@froggs.de>
-Toby Inkster			<mail@tobyinkster.co.uk>
-Todd C. Miller			<Todd.Miller@courtesan.com>
-Todd Rinaldo			<toddr@cpan.org>
-Todd T. Fries			<todd@fries.int.mrleng.com>
-Todd Vierling			<tv@duh.org>
-Tokuhiro Matsuno		<tokuhirom@gmail.com>
-Tom Bates			<tom_bates@att.net>
-Tom Brown			<thecap@peach.ece.utexas.edu>
-Tom Christiansen		<tchrist@perl.com>
+Thomas Pfau                    <pfau@nbpfaus.net>
+Thomas Sibley                  <tsibley@cpan.org>
+Thomas Wegner                  <wegner_thomas@yahoo.com>
+Thorsten Glaser                <tg@mirbsd.org>
+Tim Adye                       <T.J.Adye@rl.ac.uk>
+Tim Ayers                      <tayers@bridge.com>
+Tim Bunce                      <tim.bunce@pobox.com>
+Tim Conrow                     <tim@spindrift.srl.caltech.edu>
+Tim Freeman                    <tfreeman@infoseek.com>
+Tim Jenness                    <tjenness@cpan.org>
+Tim Mooney                     <mooney@dogbert.cc.ndsu.NoDak.edu>
+Tim Sweetman                   <tim@aldigital.co.uk>
+Tim Witham                     <twitham@pcocd2.intel.com>
+Timothe Litt                   <litt@acm.org>
+Timur I. Bakeyev               <bsdi@listserv.bat.ru>
+Tina Müller                    <cpan2@tinita.de>
+Tkil                           <tkil@reptile.scrye.com>
+Tobias Leich                   <email@froggs.de>
+Toby Inkster                   <mail@tobyinkster.co.uk>
+Todd C. Miller                 <Todd.Miller@courtesan.com>
+Todd Rinaldo                   <toddr@cpan.org>
+Todd T. Fries                  <todd@fries.int.mrleng.com>
+Todd Vierling                  <tv@duh.org>
+Tokuhiro Matsuno               <tokuhirom@gmail.com>
+Tom Bates                      <tom_bates@att.net>
+Tom Brown                      <thecap@peach.ece.utexas.edu>
+Tom Christiansen               <tchrist@perl.com>
 Tom Dinger
-Tom Horsley			<Tom.Horsley@mail.ccur.com>
-Tom Hughes			<tom@compton.nu>
-Tom Hukins			<tom@eborcom.com>
-Tom Phoenix			<rootbeer@teleport.com>
-Tom Spindler			<dogcow@isi.net>
-Tom Wyant			<wyant@cpan.org>
-Tomasz Konojacki		<me@xenu.pl>
-Tomoyuki Sadahiro		<BQW10602@nifty.com>
-Ton Hospel			<cpan@ton.iguana.be>
-Tony Bowden			<tony@kasei.com>
+Tom Horsley                    <Tom.Horsley@mail.ccur.com>
+Tom Hughes                     <tom@compton.nu>
+Tom Hukins                     <tom@eborcom.com>
+Tom Phoenix                    <rootbeer@teleport.com>
+Tom Spindler                   <dogcow@isi.net>
+Tom Wyant                      <wyant@cpan.org>
+Tomasz Konojacki               <me@xenu.pl>
+Tomoyuki Sadahiro              <BQW10602@nifty.com>
+Ton Hospel                     <cpan@ton.iguana.be>
+Tony Bowden                    <tony@kasei.com>
 Tony Camas
-Tony Cook			<tony@develop-help.com>
-Tony Sanders			<sanders@bsdi.com>
-Tor Lillqvist			<tml@hemuli.tte.vtt.fi>
-Torsten Foertsch		<torsten.foertsch@gmx.net>
-Torsten Schönfeld		<kaffeetisch@gmx.de>
-Trevor Blackwell		<tlb@viaweb.com>
-Tsutomu IKEGAMI			<t-ikegami@aist.go.jp>
-Tuomas J. Lukka			<tjl@lukka.student.harvard.edu>
-Tye McQueen			<tye@metronet.com>
-Ulrich Habel			<rhaen@NetBSD.org>
-Ulrich Kunitz			<kunitz@mai-koeln.com>
-Ulrich Pfeifer			<pfeifer@wait.de>
-Unicode Consortium		<unicode.org>
-Vadim Konovalov			<vkonovalov@lucent.com>
-Valeriy E. Ushakov		<uwe@ptc.spbu.ru>
-VanL				<van@scratch.space>
-Vernon Lyon			<vlyon@cpan.org>
-Vickenty Fesunov			<kent@setattr.net>
-Victor Adam			<victor@drawall.cc>
-Victor Efimov			<victor@vsespb.ru>
-Viktor Turskyi			<koorchik@gmail.com>
-Ville Skyttä			<scop@cs132170.pp.htv.fi>
-Vincent Pit			<perl@profvince.com>
-Vishal Bhatia			<vishal@deja.com>
-Vitali Peil			<vitali.peil@uni-bielefeld.de>
-Vlad Harchev			<hvv@hippo.ru>
-Vladimir Alexiev		<vladimir@cs.ualberta.ca>
-Vladimir Marek			<vlmarek@volny.cz>
-Vladimir Timofeev		<vovkasm@gmail.com>
-Volker Schatz			<perldoc@volkerschatz.com>
-W. Geoffrey Rommel		<grommel@sears.com>
-W. Phillip Moore		<wpm@ms.com>
-Wallace Reis			<wreis@cpan.org>
-Walt Mankowski			<waltman@pobox.com>
-Walter Briscoe			<w.briscoe@ponl.com>
-Warren Hyde			<whyde@pezz.sps.mot.com>
-Warren Jones			<wjones@tc.fluke.com>
-Wayne Berke			<berke@panix.com>
-Wayne Scott			<wscott@ichips.intel.com>
-Wayne Thompson			<Wayne.Thompson@Ebay.sun.com>
-Wilfredo Sánchez		<wsanchez@mit.edu>
-William J. Middleton		<William.Middleton@oslo.mobil.telenor.no>
-William Mann			<wmann@avici.com>
-William Middleton		<wmiddlet@adobe.com>
-William R Ward			<hermit@BayView.COM>
-William Setzer			<William_Setzer@ncsu.edu>
-William Williams		<biwillia@cisco.com>
-William Yardley			<perlbug@veggiechinese.net>
-Winfried König			<win@in.rhein-main.de>
-Wolfgang Laun			<Wolfgang.Laun@alcatel.at>
-Wolfram Humann			<w.c.humann@arcor.de>
-Xavier Noria			<fxn@hashref.com>
-YAMASHINA Hio			<hio@ymir.co.jp>
-Yaroslav Kuzmin			<ykuzmin@rocketsoftware.com>
+Tony Cook                      <tony@develop-help.com>
+Tony Sanders                   <sanders@bsdi.com>
+Tor Lillqvist                  <tml@hemuli.tte.vtt.fi>
+Torsten Foertsch               <torsten.foertsch@gmx.net>
+Torsten Schönfeld              <kaffeetisch@gmx.de>
+Trevor Blackwell               <tlb@viaweb.com>
+Tsutomu IKEGAMI                <t-ikegami@aist.go.jp>
+Tuomas J. Lukka                <tjl@lukka.student.harvard.edu>
+Tye McQueen                    <tye@metronet.com>
+Ulrich Habel                   <rhaen@NetBSD.org>
+Ulrich Kunitz                  <kunitz@mai-koeln.com>
+Ulrich Pfeifer                 <pfeifer@wait.de>
+Unicode Consortium             <unicode.org>
+Vadim Konovalov                <vkonovalov@lucent.com>
+Valeriy E. Ushakov             <uwe@ptc.spbu.ru>
+VanL                           <van@scratch.space>
+Vernon Lyon                    <vlyon@cpan.org>
+Vickenty Fesunov               <kent@setattr.net>
+Victor Adam                    <victor@drawall.cc>
+Victor Efimov                  <victor@vsespb.ru>
+Viktor Turskyi                 <koorchik@gmail.com>
+Ville Skyttä                   <scop@cs132170.pp.htv.fi>
+Vincent Pit                    <perl@profvince.com>
+Vishal Bhatia                  <vishal@deja.com>
+Vitali Peil                    <vitali.peil@uni-bielefeld.de>
+Vlad Harchev                   <hvv@hippo.ru>
+Vladimir Alexiev               <vladimir@cs.ualberta.ca>
+Vladimir Marek                 <vlmarek@volny.cz>
+Vladimir Timofeev              <vovkasm@gmail.com>
+Volker Schatz                  <perldoc@volkerschatz.com>
+W. Geoffrey Rommel             <grommel@sears.com>
+W. Phillip Moore               <wpm@ms.com>
+Wallace Reis                   <wreis@cpan.org>
+Walt Mankowski                 <waltman@pobox.com>
+Walter Briscoe                 <w.briscoe@ponl.com>
+Warren Hyde                    <whyde@pezz.sps.mot.com>
+Warren Jones                   <wjones@tc.fluke.com>
+Wayne Berke                    <berke@panix.com>
+Wayne Scott                    <wscott@ichips.intel.com>
+Wayne Thompson                 <Wayne.Thompson@Ebay.sun.com>
+Wilfredo Sánchez               <wsanchez@mit.edu>
+William J. Middleton           <William.Middleton@oslo.mobil.telenor.no>
+William Mann                   <wmann@avici.com>
+William Middleton              <wmiddlet@adobe.com>
+William R Ward                 <hermit@BayView.COM>
+William Setzer                 <William_Setzer@ncsu.edu>
+William Williams               <biwillia@cisco.com>
+William Yardley                <perlbug@veggiechinese.net>
+Winfried König                 <win@in.rhein-main.de>
+Wolfgang Laun                  <Wolfgang.Laun@alcatel.at>
+Wolfram Humann                 <w.c.humann@arcor.de>
+Xavier Noria                   <fxn@hashref.com>
+YAMASHINA Hio                  <hio@ymir.co.jp>
+Yaroslav Kuzmin                <ykuzmin@rocketsoftware.com>
 Yary Hluchan
-Yasushi Nakajima		<sey@jkc.co.jp>
-Yitzchak Scott-Thoennes		<sthoenna@efn.org>
-Yutaka OIWA			<oiwa@is.s.u-tokyo.ac.jp>
+Yasushi Nakajima               <sey@jkc.co.jp>
+Yitzchak Scott-Thoennes        <sthoenna@efn.org>
+Yutaka OIWA                    <oiwa@is.s.u-tokyo.ac.jp>
 Yutaka OKAIE
 Yutao Feng
-Yuval Kogman			<nothingmuch@woobling.org>
-Yves Orton			<demerphq@gmail.com>
-Zachary Miller			<zcmiller@simon.er.usgs.gov>
-Zachary Storer			<zacts.3.14159@gmail.com>
-Zak B. Elep			<zakame@zakame.net>
-Zbynek Vyskovsky		<kvr@centrum.cz>
-Zefram				<zefram@fysh.org>
-Zsbán Ambrus			<ambrus@math.bme.hu>
-Ævar Arnfjörð Bjarmason		<avar@cpan.org>
+Yuval Kogman                   <nothingmuch@woobling.org>
+Yves Orton                     <demerphq@gmail.com>
+Zachary Miller                 <zcmiller@simon.er.usgs.gov>
+Zachary Storer                 <zacts.3.14159@gmail.com>
+Zak B. Elep                    <zakame@zakame.net>
+Zbynek Vyskovsky               <kvr@centrum.cz>
+Zefram                         <zefram@fysh.org>
+Zsbán Ambrus                   <ambrus@math.bme.hu>
+Ævar Arnfjörð Bjarmason        <avar@cpan.org>

--- a/Porting/checkAUTHORS.pl
+++ b/Porting/checkAUTHORS.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w
 use strict;
+use warnings;
+
+use v5.026;
+
 my ($committer, $patch, $author);
 use utf8;
 use Getopt::Long;
@@ -7,9 +11,10 @@ use Unicode::Collate;
 use Text::Wrap;
 $Text::Wrap::columns = 80;
 
-my ($rank, $ta, $ack, $who, $tap) = (0) x 5;
+my ($rank, $ta, $ack, $who, $tap, $update) = (0) x 6;
 my ($author_file, $percentage, $cumulative, $reverse);
 my (%authors, %untraced, %patchers, %committers, %real_names);
+my ( $from_commit, $to_commit );
 
 my $result = GetOptions (
              # modes
@@ -18,15 +23,25 @@ my $result = GetOptions (
              "thanks-applied" => \$ta,
              "missing"        => \$ack ,
              "tap"            => \$tap,
+             "update"         => \$update,
 
              # modifiers
              "authors=s"      => \$author_file,
              "percentage"     => \$percentage,      # show as %age
              "cumulative"     => \$cumulative,
              "reverse"        => \$reverse,
+             "from=s"           => \$from_commit,
+             "to=s"             => \$to_commit,
+
             );
 
-if (!$result or ( $rank + $ta + $who + $ack + $tap != 1 ) or !@ARGV) {
+
+my $has_from_commit = defined $from_commit ? 1 : 0;
+
+if ( !$result # GetOptions failed
+    or ( $rank + $ta + $who + $ack + $tap + $update != 1 ) # use one and one exactly 'mode'
+    or !( scalar @ARGV + $has_from_commit )  # gitlog provided from --from or stdin
+    ) {
     usage();
 }
 
@@ -34,26 +49,30 @@ $author_file ||= './AUTHORS';
 die "Can't locate '$author_file'. Specify it with '--authors <path>'."
   unless -f $author_file;
 
-my $map = generate_known_author_map();
+my ( $map, $preferred_email_or_github ) = generate_known_author_map();
 
-read_authors_files($author_file);
-
+my $preserve_case = $update ? 1 : 0;
+my $AUTHORS_header = read_authors_file($author_file, $preserve_case);
 
 if ($rank) {
-  parse_commits_from_stdin();
+  parse_commits();
   display_ordered(\%patchers);
 } elsif ($ta) {
-  parse_commits_from_stdin();
+  parse_commits();
   display_ordered(\%committers);
 } elsif ($tap) {
-  parse_commits_from_stdin_authors();
+  parse_commits_authors();
   display_test_output(\%patchers, \%authors, \%real_names);
 } elsif ($ack) {
-  parse_commits_from_stdin();
+  parse_commits();
   display_missing_authors(\%patchers, \%authors, \%real_names);
 } elsif ($who) {
-  parse_commits_from_stdin();
+  parse_commits();
   list_authors(\%patchers, \%authors);
+} elsif ( $update ) {
+  update_authors_files( \%authors, $map, $preferred_email_or_github, $author_file );
+} else {
+    die "unknown mode";
 }
 
 exit(0);
@@ -69,17 +88,33 @@ Modes (use only one):
    --thanks-applied               # ranks committers of others' patches
    --missing                      # display authors not in AUTHORS
    --tap                          # show authors present/missing as TAP
+   --update                       # update the AUTHORS file with missing
 
 Modifiers:
    --authors <authors-file>       # path to authors file (default: ./AUTHORS)
    --percentage                   # show rankings as percentages
    --cumulative                   # show rankings cumulatively
    --reverse                      # show rankings in reverse
+   --from                         # git commit ID used for 'git log' source (use file from STDIN when missing)
+   --to[=HEAD]                    # git commit ID used for 'git log' destination, default to HEAD.
+
+Sample Usages:
+
+  \$ perl Porting/checkAUTHORS.pl --who --from=v5.31.6 --to=v5.31.7
+  \$ perl Porting/checkAUTHORS.pl --rank --percentage --from=v5.31.6
+  \$ perl Porting/checkAUTHORS.pl --thanks-applied --from=v5.31.6
+  \$ perl Porting/checkAUTHORS.pl --missing --from=v5.31.6
+  \$ perl Porting/checkAUTHORS.pl --tap --from=v5.31.6
+  \$ perl Porting/checkAUTHORS.pl --update --from=v5.31.6
+
+or the split int two and generate your own git log output
 
 Generate git-log-output-file with git log --pretty=fuller rev1..rev2
 (or pipe by specifying '-' for stdin).  For example:
-  \$ git log --pretty=fuller v5.12.0..v5.12.1 > gitlog
+  \$ git log --pretty=fuller v5.31.6..v5.31.7 > gitlog
   \$ perl Porting/checkAUTHORS.pl --rank --percentage gitlog
+
+
 EOS
 }
 
@@ -88,12 +123,33 @@ sub list_authors {
     binmode(STDOUT, ":utf8");
     print wrap '', '', join(', ', Unicode::Collate->new(level => 1)->sort(
                       map { $authors->{$_} }
+                      grep { length $_ > 1 } # skip the exception '!' and '?'
                       keys %$patchers)) . ".\n";
 }
 
-sub parse_commits_from_stdin {
-    my @lines = split( /^commit\s*/sm, join( '', <> ) );
-    for (@lines) {
+# use --from [and --to] if provided
+# otherwise fallback to stdin for backward compatibility
+sub _git_log {
+    if ( length $from_commit ) {
+        my ( $from, $to ) = ( $from_commit, $to_commit );
+        $to //= 'HEAD';
+        my $gitlog = [ qx{git log --pretty=fuller $from..$to} ];
+        die "git log failed: $!" unless $? == 0;
+        return $gitlog;
+    }
+
+    return [ <> ];
+}
+
+sub parse_commits {
+    my ( $process ) = @_;
+
+    $process //= \&process; # default processor
+
+    my $git_log = _git_log();
+
+    my @lines = split( /^commit\s*/sm, join( '', $git_log->@* ) );
+    foreach (@lines) {
         next if m/^$/;
         next if m/^(\S*?)^Merge:/ism;    # skip merge commits
         if (m/^(.*?)^Author:\s*(.*?)^AuthorDate:\s*.*?^Commit:\s*(.*?)^(.*)$/gism) {
@@ -104,39 +160,70 @@ sub parse_commits_from_stdin {
             unless ($author) { die $_ }
             chomp($committer);
             unless ($committer) { die $_ }
-            process( $committer, $patch, $author );
+
+            $process->( $committer, $patch, $author );
         } else {
             die "XXX $_ did not match";
         }
     }
 
+    return;
 }
 
-# just grab authors. Quicker than parse_commits_from_stdin
+# just grab authors. Quicker than parse_commits
 
-sub parse_commits_from_stdin_authors {
-    while (<>) {
+sub parse_commits_authors {
+
+    my $git_log = _git_log();
+
+    foreach ($git_log->@*) {
         next unless /^Author:\s*(.*)$/;
-	my $author = $1;
-	$author = _raw_address($author);
-	$patchers{$author}++;
+        my $author = $1;
+        $author = _raw_address($author);
+        $patchers{$author}++;
     }
-}
 
+    return;
+}
 
 sub generate_known_author_map {
     my %map;
 
-    my $prev = "";
+    my %preferred_email_or_github;
+
+    my $previous_name = "";
+    my $previous_preferred_contact = "";
     while (<DATA>) {
+        next if m{^\s*#};
+
         chomp;
         s/\\100/\@/g;
+
         $_ = lc;
-        if ( my ( $correct, $alias ) = /^\s*([^#\s]\S*)\s+(.*\S)/ ) {
-            $correct =~ s/^\\043/#/;
-            if   ( $correct eq '+' ) { $correct = $prev }
-            else                     { $prev    = $correct }
-            $map{$alias} = $correct;
+        if ( my ( $name, $contact ) = /^\s*([^#\s]\S*)\s+(.*\S)/ ) {
+
+            $name =~ s/^\\043/#/;
+            # use the previous stored email if the line starts by a '+'
+            if   ( $name eq '+' ) {
+                $name             = $previous_name;
+            }
+            else {
+                $previous_name              = $name;
+                $previous_preferred_contact = $contact;
+                if ( index($name, '@' ) > 0 ) {
+                    # if name is an email, then this is our preferred email... legacy list
+                    $previous_preferred_contact = $name;
+                }
+            }
+
+            $map{$contact} = $name;
+
+            if ( $contact ne $previous_preferred_contact ) {
+                $preferred_email_or_github{$contact} = $previous_preferred_contact;
+            }
+            if ( $name ne '+' ) {
+                $preferred_email_or_github{$name} = $previous_preferred_contact;
+            }
         }
     }
 
@@ -210,25 +297,34 @@ sub generate_known_author_map {
         "(none)",
         ;
 
-    return \%map;
+    return ( \%map, \%preferred_email_or_github );
 }
 
-sub read_authors_files {
-    my @authors = (@_);
-    return unless (@authors);
+sub read_authors_file {
+    my ( $filename, $preserve_case ) = @_;
+    return unless defined $filename;
+
+    my @headers;
+
     my (%count, %raw);
-    foreach my $filename (@authors) {
-        open FH, '<', $filename or die "Can't open $filename: $!";
-        binmode FH, ':encoding(UTF-8)';
-        while (<FH>) {
+    {
+        open my $fh, '<', $filename or die "Can't open $filename: $!";
+        binmode $fh, ':encoding(UTF-8)';
+        my $in_header = 1;
+        while (<$fh>) {
             next if /^\#/;
-            next if /^-- /;
+            do { $in_header = 0; next } if /^-- /;
             if (/^([^<]+)<([^>]+)>/) {
                 # Easy line.
                 my ($name, $email) = ($1, $2);
                 $name =~ s/\s*\z//;
                 $raw{$email} = $name;
                 $count{$email}++;
+            } elsif ( /^([^@]+)\s+(\@\S+)\s*$/ ) {
+                my ($name, $github) = ($1, $2);
+                $name =~ s/\s*\z//;
+                $raw{$github} = $name;
+                $count{$github}++;
             } elsif (/^([- .'\w]+)[\t\n]/) {
 
                 # Name only
@@ -240,14 +336,167 @@ sub read_authors_files {
                 next;
             }
         }
+        continue {
+            push @headers, $_ if $in_header;
+        }
     }
-    foreach ( keys %raw ) {
-        print "E-mail $_ occurs $count{$_} times\n" if $count{$_} > 1;
-        my $lc = lc $_;
-        $authors{ $map->{$lc} || $lc } = $raw{$_};
+    foreach my $contact ( sort keys %raw ) {
+        print "E-mail $contact occurs $count{$contact} times\n" if $count{$contact} > 1;
+        my $lc = lc $contact;
+        my $key = $preserve_case ? $contact : $lc;
+        $authors{ $map->{$lc} || $key } = $raw{$contact};
     }
     $authors{$_} = $_ for qw(? !);
+
+    push @headers, '-- ', "\n";
+
+    return join( '', @headers );
 }
+
+sub update_authors_files {
+    my ( $authors, $known_authors, $preferred_email_or_github, $author_file ) = @_;
+
+    die qq[Cannot find AUTHORS file '$author_file'] unless -f $author_file;
+    binmode(STDOUT, ":utf8");
+
+    # add missing authors from the recent commits
+    _detect_new_authors_from_recent_commit( $authors, $known_authors );
+
+    my @author_names = sort { $a cmp $b } values %$authors;
+    my $maxlen = length [ sort { length $b <=> length $a } @author_names ]->[0];
+
+    my @list;
+    foreach my $github_or_email ( sort keys %authors ) {
+
+        next if length $github_or_email == 1;
+
+        my $name = $authors{$github_or_email};
+        $name =~ s{\s+$}{};
+
+        #$github_or_email = $known_authors->{ $github_or_email } // $github_or_email;
+        $github_or_email = $preferred_email_or_github->{ $github_or_email } // $github_or_email;
+
+        if ( index( $github_or_email, '@' ) != 0 ) { # preserve '<>' for unicode consortium
+            $github_or_email = '<' . $github_or_email . '>';
+        }
+
+        push @list, sprintf( "%-${maxlen}s %s\n", $name, $github_or_email);
+    }
+
+    # preserve the untraced authors :-) [without email or GitHub account]
+    push @list, map { "$_\n" } keys %untraced;
+
+    {
+        open my $fh, '>', $author_file or die "Can't open $author_file: $!";
+        binmode $fh, ':encoding(UTF-8)';
+
+        print {$fh} $AUTHORS_header;
+
+        map { print {$fh} $_ } sort { lc $a cmp lc $b } @list;
+
+        close $fh;
+
+    }
+
+    return;
+}
+
+# read all recent commits and check if the author email is known
+#   if the email is unknown add the author's GitHub account if possible or his email
+sub _detect_new_authors_from_recent_commit {
+    my ( $authors, $known_authors ) = @_;
+
+    my $check_if_email_known = sub {
+        my ( $email ) = @_;
+
+        my $preferred = $map->{$email} // $map->{lc $email}
+            // $preferred_email_or_github->{$email}
+            // $preferred_email_or_github->{lc $email}
+            // $email;
+
+        return $authors{$preferred} || $authors{ lc $preferred } ? 1 : 0;
+    };
+
+    my $already_checked = {};
+    my $process = sub {
+        my ( $committer, $patch, $author ) = @_;
+
+        foreach my $person ( $author, $committer ) {
+            next unless length $person;
+            next if $already_checked->{$person};
+            $already_checked->{$person} = 1;
+
+            my $is_author = $person eq $author;
+
+            if ( $person =~ m{^(.+)\s+<(.+)>$} ) {
+                my ( $name, $email ) = ( $1, $2 );
+
+                # skip unicode consortium and bad emails
+                if ( index( $email, '@' ) <= 0 ) {
+                    warn "# Skipping new author: $person - bad email";
+                    next;
+                }
+
+                next if $check_if_email_known->( $email );
+
+                # for new users we would prefer using the GitHub account
+                my $github_or_email = _commit_to_github_id( $patch, $is_author ) // $email;
+
+                next if $check_if_email_known->( $github_or_email );
+
+                print "# Detected a new author: $name using email $email [ $github_or_email ]\n";
+                $authors{$github_or_email} = $name; # add it to the list of authors
+            } else {
+                warn "Fail to parse author: $person";
+            }
+        }
+    };
+
+    parse_commits( $process );
+
+    return;
+}
+
+sub _commit_to_github_id {
+    my ( $commit, $is_author ) = @_;
+
+    chomp $commit if defined $commit;
+    return unless length $commit;
+
+    eval { require HTTP::Tiny; 1 } or do {
+        warn "HTTP::Tiny is missing, cannot detect GitHub account from commit id.";
+        no warnings;
+        *_commit_to_github_id = sub {};
+        return;
+    };
+
+    my $github_url_for_commit = q[https://github.com/Perl/perl5/commit/] . $commit;
+    my $response = HTTP::Tiny->new->get( $github_url_for_commit );
+
+    if ( ! $response->{success} ) {
+        warn "HTTP Request Failed: '$github_url_for_commit'";
+        return;
+    }
+
+    my $content = $response->{content} // '';
+
+    # poor man scrapping - probably have to be improved over time
+    # try to parse something like: <a href="/Perl/perl5/commits?author=ThisIsMyGitHubID"
+    my @github_ids; # up to two entries author and committer
+    while ( $content =~ s{\Q<a href="/Perl/perl5/commits?author=\E(.+)"}{} ) {
+        push @github_ids, '@' . $1;
+    }
+
+    warn "Found more than two github ids for $github_url_for_commit" if scalar @github_ids > 2;
+
+    return $github_ids[0] if $is_author;
+    if ( !$is_author && scalar @github_ids >= 2 ) {
+        return $github_ids[1]; # committer is the second entry
+    }
+
+    return $github_ids[0];
+}
+
 
 sub display_test_output {
     my $patchers   = shift;
@@ -255,16 +504,18 @@ sub display_test_output {
     my $real_names = shift;
     my $count = 0;
     printf "1..%d\n", scalar keys %$patchers;
-    foreach ( sort keys %$patchers ) {
-        $count++;
-        if ($authors->{$_}) {
-            print "ok $count - ".$real_names->{$_} ." $_\n";
-        } else {
-            print "not ok $count - Contributor not found in AUTHORS: $_ ".($real_names->{$_} || '???' )."\n";
-            print STDERR ($real_names->{$_} || '???' )." <$_> not found in AUTHORS\n";
-        }
 
+    foreach my $email ( sort keys %$patchers ) {
+        $count++;
+        if ($authors->{$email}) {
+            print "ok $count - ".$real_names->{$email} ." $email\n";
+        } else {
+            print "not ok $count - Contributor not found in AUTHORS: $email ".($real_names->{$email} || '???' )."\n";
+            print STDERR ($real_names->{$email} || '???' )." <$email> not found in AUTHORS\n";
+        }
     }
+
+    return;
 }
 
 sub display_missing_authors {
@@ -286,6 +537,8 @@ sub display_missing_authors {
             print "" . ( $real_names->{$author} || $author ) . "\t\t\t<" . $xauthor . ">\n";
         }
     }
+
+    return;
 }
 
 sub display_ordered {
@@ -315,6 +568,8 @@ sub display_ordered {
         }
         print wrap ( $prefix, "\t", join( " ", sort @{ $sorted[$i] } ), "\n" );
     }
+
+    return;
 }
 
 sub process {
@@ -331,6 +586,8 @@ sub process {
         # separate commit credit only if committing someone else's patch
         $committers{$committer}++;
     }
+
+    return;
 }
 
 sub _raw_address {
@@ -367,6 +624,7 @@ sub _raw_address {
     $addr =~ s/\\100/@/g;    # Sometimes, there are encoded @ signs in the git log.
 
     if ($real_name) { $real_names{$addr} = $real_name }
+
     return $addr;
 }
 
@@ -374,8 +632,8 @@ sub _raw_address {
 __DATA__
 
 #
-# List of mappings. First entry the "correct" email address, as appears
-# in the AUTHORS file. Second is any "alias" mapped to it.
+# List of mappings. First entry the "correct" email address or GitHub account,
+# as appears in the AUTHORS file. Other lines are "alias" mapped to it.
 #
 # If the "correct" email address is a '+', the entry above it is reused;
 # this for addresses with more than one alias.
@@ -392,6 +650,10 @@ alanbur                                 alan.burlison\100sun.com
 +                                       aburlison\100cix.compulink.co.uk
 ams                                     ams\100toroid.org
 +                                       ams\100wiw.org
+atoomic                                 \100atoomic
++                                       atoomic\100cpan.org
++                                       cpan\100atoomic.org
++                                       nicolas\100atoomic.org
 chip                                    chip\100pobox.com
 +                                       chip\100perl.com
 +                                       salzench\100nielsenmedia.com
@@ -399,14 +661,14 @@ chip                                    chip\100pobox.com
 +                                       chip\100rio.atlantic.net
 +                                       salzench\100dun.nielsen.com
 +                                       chip\100ci005.sv2.upperbeyond.com
-craigb                                  craig.berry\100psinetcs.com
+craigb                                  craigberry\100mac.com
 +                                       craig.berry\100metamorgs.com
 +                                       craig.berry\100signaltreesolutions.com
-+                                       craigberry\100mac.com
++                                       craig.berry\100psinetcs.com
 +                                       craig.a.berry\100gmail.com
 +                                       craig a. berry)
-davem                                   davem\100fdgroup.com
-+                                       davem\100iabyn.nospamdeletethisbit.com
+davem                                   davem\100iabyn.nospamdeletethisbit.com
++                                       davem\100fdgroup.com
 +                                       davem\100iabyn.com
 +                                       davem\100fdgroup.co.uk
 +                                       davem\100fdisolutions.com
@@ -430,15 +692,15 @@ gbarr                                   gbarr\100pobox.com
 +                                       gbarr\100ti.com
 +                                       graham.barr\100tiuk.ti.com
 +                                       gbarr\100monty.mutatus.co.uk
-gisle                                   gisle\100activestate.com
-+                                       gisle\100aas.no
+gisle                                   gisle\100aas.no
++                                       gisle\100activestate.com
 +                                       aas\100aas.no
 +                                       aas\100bergen.sn.no
-gsar                                    gsar\100activestate.com
-+                                       gsar\100cpan.org
+gsar                                    gsar\100cpan.org
++                                       gsar\100activestate.com
 +                                       gsar\100engin.umich.edu
-hv                                      hv\100crypt.compulink.co.uk
-+                                       hv\100crypt.org
+hv                                      hv\100crypt.org
++                                       hv\100crypt.compulink.co.uk
 +                                       hv\100iii.co.uk
 jhi                                     jhi\100iki.fi
 +                                       jhietaniemi\100gmail.com
@@ -449,8 +711,8 @@ jhi                                     jhi\100iki.fi
 +                                       jarkko.hietaniemi\100nokia.com
 +                                       jarkko.hietaniemi\100cc.hut.fi
 +                                       jarkko.hietaniemi\100booking.com
-jesse                                   jesse\100bestpractical.com
-+                                       jesse\100fsck.com
+jesse                                   jesse\100fsck.com
++                                       jesse\100bestpractical.com
 +                                       jesse\100perl.org
 merijn                                  h.m.brand\100xs4all.nl
 +                                       h.m.brand\100procura.nl
@@ -462,8 +724,8 @@ mhx                                     mhx-perl\100gmx.net
 +                                       mhx\100r2d2.(none)
 mst                                     mst\100shadowcat.co.uk
 +                                       matthewt\100hercule.scsys.co.uk
-nicholas                                nick\100unfortu.net
-+                                       nick\100ccl4.org
+nicholas                                nick\100ccl4.org
++                                       nick\100unfortu.net
 +                                       nick\100talking.bollo.cx
 +                                       nick\100plum.flirble.org
 +                                       nick\100babyhippo.co.uk
@@ -472,21 +734,21 @@ nicholas                                nick\100unfortu.net
 +                                       nicholas\100dromedary.ams6.corp.booking.com
 +                                       Nicholas Clark (sans From field in mail header)
 pudge                                   pudge\100pobox.com
-rgs                                     rgarciasuarez\100free.fr
+rgs                                     rgs@consttype.org
++                                       rgarciasuarez\100free.fr
 +                                       rgarciasuarez\100mandrakesoft.com
 +                                       rgarciasuarez\100mandriva.com
 +                                       rgarciasuarez\100gmail.com
 +                                       raphel.garcia-suarez\100hexaflux.com
-+                                       rgs@consttype.org
-sky                                     sky\100nanisky.com
-+                                       artur\100contiller.se
+sky                                     artur\100contiller.se
++                                       sky\100nanisky.com
 +                                       arthur\100contiller.se
-smueller                                7k8lrvf02\100sneakemail.com
+smueller                                smueller\100cpan.org
++                                       7k8lrvf02\100sneakemail.com
 +                                       kjx9zthh3001\100sneakemail.com
 +                                       dtr8sin02\100sneakemail.com
 +                                       rt8363b02\100sneakemail.com
 +                                       o6hhmk002\100sneakemail.com
-+                                       smueller\100cpan.org
 +                                       l2ot9pa02\100sneakemail.com
 +                                       wyp3rlx02\100sneakemail.com
 +                                       0mgwtfbbq\100sneakemail.com
@@ -530,7 +792,9 @@ allen\100huarp.harvard.edu              nort\100bottesini.harvard.edu
 allens\100cpan.org                      easmith\100beatrice.rutgers.edu
 +                                       root\100dogberry.rutgers.edu
 ambs\100cpan.org                        hashashin\100gmail.com
-andreas.koenig\100anima.de              andreas.koenig.gmwojprw\100franz.ak.mind.de
+andrea                                  a.koenig@mind.de
++                                       andreas.koenig\100anima.de
++                                       andreas.koenig.gmwojprw\100franz.ak.mind.de
 +                                       andreas.koenig.7os6vvqr\100franz.ak.mind.de
 +                                       a.koenig\100mind.de
 +                                       k\100anna.in-berlin.de
@@ -551,8 +815,8 @@ arnold\100gnu.ai.mit.edu                arnold\100emoryu2.arpa
 arodland\100cpan.org                    andrew\100hbslabs.com
 arussell\100cs.uml.edu                  adam\100adam-pc.(none)
 ash\100cpan.org                         ash_cpan\100firemirror.com
-avarab\100gmail.com                     avar\100cpan.org
-
+avar                                    avar\100cpan.org
++                                       avarab\100gmail.com
 bailey\100newman.upenn.edu              bailey\100hmivax.humgen.upenn.edu
 +                                       bailey\100genetics.upenn.edu
 +                                       bailey.charles\100gmail.com
@@ -581,6 +845,7 @@ claes\100surfar.nu                      claes\100versed.se
 clintp\100geeksalad.org                 cpierce1\100ford.com
 clkao\100clkao.org                      clkao\100bestpractical.com
 corion\100corion.net                    corion\100cpan.org
++                                       github@corion.net
 cp\100onsitetech.com                    publiustemp-p5p\100yahoo.com
 +                                       publiustemp-p5p3\100yahoo.com
 cpan\100audreyt.org                     autrijus\100egb.elixus.org
@@ -668,7 +933,7 @@ jari.aalto\100poboxes.com               jari.aalto\100cante.net
 jarausch\100numa1.igpm.rwth-aachen.de   helmutjarausch\100unknown
 jasons\100cs.unm.edu                    jasons\100sandy-home.arc.unm.edu
 jbuehler\100hekimian.com                jhpb\100hekimian.com
-jcromie\100100divsol.com                jcromie\100cpan.org
+jcromie\100cpan.org                      jcromie\100100divsol.com
 +                                       jim.cromie\100gmail.com
 jd\100cpanel.net                        lightsey\100debian.org
 jdhedden\100cpan.org                    jerry\100hedden.us
@@ -786,7 +1051,7 @@ ilya\100math.berkeley.edu               ilya\100math.ohio-state.edu
 +                                       [9]ilya\100math.ohio-state.edu
 ilya\100martynov.org                    ilya\100juil.nonet
 
-joshua.pritikin\100db.com               joshua\100paloalto.com
+joshua\100paloalto.com                  joshua.pritikin\100db.com
 
 litt\100acm.org                         tlhackque\100yahoo.com
 
@@ -803,7 +1068,9 @@ p5-authors\100crystalflame.net          perl\100crystalflame.net
 +                                       rs\100topsy.com
 paul.green\100stratus.com               paul_greenvos\100vos.stratus.com
 +                                       pgreen\100seussnt.stratus.com
-paul.marquess\100btinternet.com         paul_marquess\100yahoo.co.uk
+pmqs                                    pmqs\100cpan.org
++                                       paul.marquess\100btinternet.com
++                                       paul_marquess\100yahoo.co.uk
 +                                       paul.marquess\100ntlworld.com
 +                                       paul.marquess\100openwave.com
 +                                       pmarquess\100bfsec.bt.co.uk
@@ -822,7 +1089,8 @@ pfeifer\100wait.de                      pfeifer\100charly.informatik.uni-dortmun
 +                                       upf\100de.uu.net
 ribasushi@cpan.org			rabbit\100rabbit.us
 +					rabbit+bugs\100rabbit.us
-perl\100aaroncrane.co.uk		arc\100cpan.org
+arc\100cpan.org                         perl\100aaroncrane.co.uk
++                                       arc@users.noreply.github.com
 phil\100perkpartners.com                phil\100finchcomputer.com
 pimlott\100idiomtech.com                andrew\100pimlott.net
 +                                       pimlott\100abel.math.harvard.edu
@@ -875,12 +1143,12 @@ argrath\100ub32.org                     root\100ub32.org
 rootbeer\100teleport.com                rootbeer\100redcat.com
 +                                       tomphoenix\100unknown
 rra\100stanford.edu                     rra\100cpan.org
-rurban\100x-ray.at                      rurban\100cpan.org
+rurban\100cpan.org                      rurban\100x-ray.at
 +                                       rurban\100cpanel.net
 rvtol+news\100isolution.nl              rvtol\100isolution.nl
-sartak\100bestpractical.com             sartak\100gmail.com
+sartak\100gmail.com                     sartak\100bestpractical.com
 +                                       code\100sartak.org
-sadinoff\100olf.com                     danny-cpan\100sadinoff.com
+danny-cpan\100sadinoff.com              sadinoff\100olf.com
 schubiger\100cpan.org                   steven\100accognoscere.org
 +                                       sts\100accognoscere.org
 +                                       schubiger\100gmail.com
@@ -901,11 +1169,12 @@ shlomif\100cpan.org                     shlomif\100vipe.technion.ac.il
 +                                       shlomif\100iglu.org.il
 +                                       shlomif+processed-by-perl\100gmail.com
 +                                       shlomif\100shlomifish.org
-simon\100simon-cozens.org               simon\100pembro4.pmb.ox.ac.uk
+simon\100netthink.co.uk                 simon\100simon-cozens.org
++                                       simon\100pembro4.pmb.ox.ac.uk
 +                                       simon\100brecon.co.uk
 +                                       simon\100othersideofthe.earth.li
 +                                       simon\100cozens.net
-+                                       simon\100netthink.co.uk
++
 sisyphus\100cpan.org                    sisyphus1\100optusnet.com.au
 +                                       sisyphus359\100gmail.com
 lannings\100who.int                     lannings\100gmail.com
@@ -927,7 +1196,7 @@ spider\100orb.nashua.nh.us              spider\100web.zk3.dec.com
 +                                       spidb\100cpan.org
 +                                       spider.boardman\100orb.nashua.nh.us
 +                                       root\100peano.zk3.dec.com
-spiros\100lokku.com			s.denaxas\100gmail.com
+s.denaxas\100gmail.com                  spiros\100lokku.com
 spp\100ds.net                           spp\100psa.pencom.com
 +                                       spp\100psasolar.colltech.com
 +                                       spp\100spotter.yi.org

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -508,6 +508,33 @@ release (so for 5.15.3 this would be 5.15.2).  If the last release manager
 followed instructions, this should have already been done after the last
 blead release, so you may find nothing to do here.
 
+=head3 update AUTHORS
+
+AUTHORS file can be updated by running C<Porting/checkAUTHORS.pl --update>
+The script detects missing authors or commiters since the last release using
+a known tag provided by the C<--from=v5.X.Y> argument, and will add missing
+entries to the AUTHORS file.
+
+    $ perl Porting/checkAUTHORS.pl --update --from=v5.X.Y
+
+For MAINT and BLEAD-FINAL releases, C<v5.X.Y> needs to refer to the last
+release in the previous development cycle (so for example, for a 5.14.x
+release, this would be 5.13.11).
+
+BLEAD-POINT releases, it needs to refer to the previous BLEAD-POINT
+release (so for 5.15.3 this would be 5.15.2).
+
+Note: this should not be harmful to use a wider range.
+
+Note: if you have uncommited changes this could cause some warnings,
+and you would like to use the addtional argument C<--to=upstream/blead>
+to use the last known git commit by GitHub.
+
+Review the changes to the AUTHORS file, be sure you are not adding duplicates
+entries or removing some AUTHORS, then commit your changes.
+
+    $ git commit -a AUTHORS -m 'Update AUTHORS list for 5.x.y'
+
 =head3 Check copyright years
 
 Check that the copyright years are up to date by running:


### PR DESCRIPTION
Fixes #17206

AUTHORS can now be updated by 'Porting/checkAUTHORS.pl' using
the new 'update' action.

Example: perl Porting/checkAUTHORS.pl --update --from=v5.31.6

The changes to the file AUTHORS is better read by ommitting whitespaces.
The changes to AUTHORS are the following:
- authors are sorted
- some emails changed to reflect the preferred email set in the <DATA> section
of checkAUTHORS.pl

When detecting a new author, we will list the GitHub account instead of the email.
Anyone can replace his email by the GitHub account by directly editing AUTHORS file.

Note that the <DATA> section has been adjusted to accomodate several
existing emails in the AUTHORS file to avoid selecting a different email.