### PR TITLE
PATCH: gh#17218 memory leak

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -18116,6 +18116,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
 
                 /* Likewise for 'posixes' */
                 _invlist_union(posixes, cp_list, &cp_list);
+                SvREFCNT_dec(posixes);
 
                 /* Likewise for anything else in the range that matched only
                  * under UTF-8 */


### PR DESCRIPTION
Just a trivial `git cherry-pick` to backport an important fix.

See https://github.com/Perl/perl5/issues/17218.