### PR TITLE
Update links to perlrun to link to specific items

### DIFF
--- a/pod/perl.pod
+++ b/pod/perl.pod
@@ -360,7 +360,7 @@ for a listing.
 
 =head1 ENVIRONMENT
 
-See L<perlrun>.
+See L<perlrun/ENVIRONMENT>.
 
 =head1 AUTHOR
 

--- a/pod/perldebguts.pod
+++ b/pod/perldebguts.pod
@@ -14,9 +14,9 @@ Caveat lector.
 
 Perl has special debugging hooks at compile-time and run-time used
 to create debugging environments.  These hooks are not to be confused
-with the I<perl -Dxxx> command described in L<perlrun>, which is
-usable only if a special Perl is built per the instructions in the
-F<INSTALL> podpage in the Perl source tree.
+with the I<perl -Dxxx> command described in L<perlrun|perlrun/-Dletters>,
+which is usable only if a special Perl is built per the instructions in
+the F<INSTALL> podpage in the Perl source tree.
 
 For example, whenever you call Perl's built-in C<caller> function
 from the package C<DB>, the arguments that the corresponding stack

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -3270,7 +3270,7 @@ given.  This is usually a mistake, since editing STDIN in place doesn't
 make sense, and can be confusing because it can make perl look like
 it is hanging when it is really just trying to read from STDIN.  You
 should either pass a filename to edit, or remove C<-i> from the command
-line.  See L<perlrun> for more details.
+line.  See L<perlrun|perlrun/-i[extension]> for more details.
 
 =item Junk on end of regexp in regex m/%s/
 
@@ -3839,8 +3839,8 @@ couldn't be created for some peculiar reason.
 =item Module name required with -%c option
 
 (F) The C<-M> or C<-m> options say that Perl should load some module, but
-you omitted the name of the module.  Consult L<perlrun> for full details
-about C<-M> and C<-m>.
+you omitted the name of the module.  Consult
+L<perlrun|perlrun/-m[-]module> for full details about C<-M> and C<-m>.
 
 =item More than one argument to '%s' open
 
@@ -6846,13 +6846,15 @@ discovered.  See L<perlre>.
 
 =item Unknown Unicode option letter '%c'
 
-(F) You specified an unknown Unicode option.  See L<perlrun> documentation
-of the C<-C> switch for the list of known options.
+(F) You specified an unknown Unicode option.  See
+L<perlrun|perlrun/-C [numberE<sol>list]> documentation of the C<-C> switch
+for the list of known options.
 
 =item Unknown Unicode option value %d
 
-(F) You specified an unknown Unicode option.  See L<perlrun> documentation
-of the C<-C> switch for the list of known options.
+(F) You specified an unknown Unicode option.  See
+L<perlrun|perlrun/-C [numberE<sol>list]> documentation of the C<-C> switch
+for the list of known options.
 
 =item Unknown verb pattern '%s' in regex; marked by S<<-- HERE> in m/%s/
 

--- a/pod/perlexperiment.pod
+++ b/pod/perlexperiment.pod
@@ -97,7 +97,7 @@ See L<re/'strict' mode>
 The ticket for this feature is
 L<[perl #13198]|https://github.com/Perl/perl5/issues/13198>.
 
-See also L<perlrun>
+See also L<perlrun/PERLIO>
 
 =item Declaring a reference to a variable
 
@@ -223,7 +223,7 @@ Accepted in Perl 5.20.0
 
 =item The <:pop> IO pseudolayer
 
-See also L<perlrun>
+See also L<perlrun/PERLIO>
 
 Accepted in Perl 5.20.0
 

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -2736,7 +2736,7 @@ compiled with C++, to maintain compliance with its standard.
 Note that any filehandle being printed to under UTF-8 must be expecting
 UTF-8 in order to get good results and avoid Wide-character warnings.
 One way to do this for typical filehandles is to invoke perl with the
-C<-C>> parameter.  (See L<perlrun/-C [number/list]>.
+C<-C>> parameter.  (See L<perlrun/-C [numberE<sol>list]>.
 
 You can use this to concatenate two scalars:
 
@@ -2774,7 +2774,7 @@ string.
 Note that any filehandle being printed to under UTF-8 must be expecting
 UTF-8 in order to get good results and avoid Wide-character warnings.
 One way to do this for typical filehandles is to invoke perl with the
-C<-C>> parameter.  (See L<perlrun/-C [number/list]>.
+C<-C>> parameter.  (See L<perlrun/-C [numberE<sol>list]>.
 
 =head2 Formatted Printing of C<Size_t> and C<SSize_t>
 

--- a/pod/perlhacktips.pod
+++ b/pod/perlhacktips.pod
@@ -777,9 +777,10 @@ program, and to see in which C function we are at (without the debugging
 information we might see only the numerical addresses of the functions,
 which is not very helpful). It will also turn on the C<DEBUGGING>
 compilation symbol which enables all the internal debugging code in Perl.
-There are a whole bunch of things you can debug with this: L<perlrun>
-lists them all, and the best way to find out about them is to play about
-with them.  The most useful options are probably
+There are a whole bunch of things you can debug with this:
+L<perlrun|perlrun/-Dletters> lists them all, and the best way to find out
+about them is to play about with them.  The most useful options are
+probably
 
     l  Context (loop) stack processing
     s  Stack snapshots (with v, displays all stacks)

--- a/pod/perllocale.pod
+++ b/pod/perllocale.pod
@@ -1533,8 +1533,8 @@ instead use the L<PerlIO::locale> module, or the L<Encode::Locale>
 module, both available from CPAN.  The latter module also has methods to
 ease the handling of C<ARGV> and environment variables, and can be used
 on individual strings.  If you know that all your locales will be
-UTF-8, as many are these days, you can use the L<B<-C>|perlrun/-C>
-command line switch.
+UTF-8, as many are these days, you can use the
+L<B<-C>|perlrun/-C [numberE<sol>list]> command line switch.
 
 This form of the pragma allows essentially seamless handling of locales
 with Unicode.  The collation order will be by Unicode code point order.
@@ -1610,7 +1610,8 @@ lowercase of U+0178 is itself.
 The same problems ensue if you enable automatic UTF-8-ification of your
 standard file handles, default C<open()> layer, and C<@ARGV> on non-ISO8859-1,
 non-UTF-8 locales (by using either the B<-C> command line switch or the
-C<PERL_UNICODE> environment variable; see L<perlrun>).
+C<PERL_UNICODE> environment variable; see
+L<perlrun|perlrun/-C [numberE<sol>list]>).
 Things are read in as UTF-8, which would normally imply a Unicode
 interpretation, but the presence of a locale causes them to be interpreted
 in that locale instead.  For example, a 0xD7 code point in the Unicode

--- a/pod/perlsec.pod
+++ b/pod/perlsec.pod
@@ -249,10 +249,10 @@ When the taint mode (C<-T>) is in effect, the environment variables
 C<PERL5LIB> and C<PERLLIB>
 are ignored by Perl.  You can still adjust C<@INC> from outside the
 program by using the C<-I> command line option as explained in
-L<perlrun>.  The two environment variables are ignored because
-they are obscured, and a user running a program could be unaware that
-they are set, whereas the C<-I> option is clearly visible and
-therefore permitted.
+L<perlrun|perlrun/-Idirectory>.  The two environment variables are
+ignored because they are obscured, and a user running a program could
+be unaware that they are set, whereas the C<-I> option is clearly
+visible and therefore permitted.
 
 Another way to modify C<@INC> without modifying the program, is to use
 the C<lib> pragma, e.g.:
@@ -626,4 +626,5 @@ the issues overlap.
 
 =head1 SEE ALSO
 
-L<perlrun> for its description of cleaning up environment variables.
+L<perlrun/ENVIRONMENT> for its description of cleaning up environment
+variables.

--- a/pod/perltrap.pod
+++ b/pod/perltrap.pod
@@ -5,7 +5,7 @@ perltrap - Perl traps for the unwary
 =head1 DESCRIPTION
 
 The biggest trap of all is forgetting to C<use warnings> or use the B<-w>
-switch; see L<warnings> and L<perlrun>. The second biggest trap is not
+switch; see L<warnings> and L<perlrun/-w>. The second biggest trap is not
 making your entire program runnable under C<use strict>.  The third biggest
 trap is not reading the list of changes in this version of Perl; see
 L<perldelta>.

--- a/pod/perlunifaq.pod
+++ b/pod/perlunifaq.pod
@@ -277,7 +277,7 @@ but this is considered bad style. Especially C<_utf8_on> can be dangerous, for
 the same reason that C<:utf8> can.
 
 There are some shortcuts for oneliners;
-see L<-C|perlrun/-C [numberE<sol>list]> in L<perlrun>.
+see L<-C in perlrun|perlrun/-C [numberE<sol>list]>.
 
 =head2 What's the difference between C<UTF-8> and C<utf8>?
 

--- a/pod/perluniintro.pod
+++ b/pod/perluniintro.pod
@@ -220,7 +220,8 @@ and removes the program's warning.
 You can enable automatic UTF-8-ification of your standard file
 handles, default C<open()> layer, and C<@ARGV> by using either
 the C<-C> command line switch or the C<PERL_UNICODE> environment
-variable, see L<perlrun> for the documentation of the C<-C> switch.
+variable, see L<perlrun|perlrun/-C [numberE<sol>list]> for the
+documentation of the C<-C> switch.
 
 Note that this means that Perl expects other software to work the same
 way:

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -483,9 +483,9 @@ time of the C<exec()>.
 X<@F>
 
 The array C<@F> contains the fields of each line read in when autosplit
-mode is turned on.  See L<perlrun> for the B<-a> switch.  This array
-is package-specific, and must be declared or given a full package name
-if not in package main when running under C<strict 'vars'>.
+mode is turned on.  See L<perlrun|perlrun/-a> for the B<-a> switch.  This
+array is package-specific, and must be declared or given a full package
+name if not in package main when running under C<strict 'vars'>.
 
 =item @INC
 X<@INC>
@@ -577,7 +577,7 @@ built, as determined during the configuration process.  For examples
 see L<perlport/PLATFORMS>.
 
 The value is identical to C<$Config{'osname'}>.  See also L<Config>
-and the B<-V> command-line switch documented in L<perlrun>.
+and the B<-V> command-line switch documented in L<perlrun|perlrun/-V>.
 
 In Windows platforms, C<$^O> is not very helpful: since it is always
 C<MSWin32>, it doesn't tell the difference between
@@ -762,9 +762,8 @@ is considerably faster, especially for files on network drives.
 
 This variable could be set in the F<sitecustomize.pl> file to
 configure the local Perl installation to use "sloppy" C<stat()> by
-default.  See the documentation for B<-f> in
-L<perlrun|perlrun/"Command Switches"> for more information about site
-customization.
+default.  See the documentation for B<-f> in L<perlrun|perlrun/-f>
+for more information about site customization.
 
 This variable was added in Perl v5.10.0.
 
@@ -1436,7 +1435,7 @@ X<ARGVOUT>
 The special filehandle that points to the currently open output file
 when doing edit-in-place processing with B<-i>.  Useful when you have
 to do a lot of inserting and don't want to keep modifying C<$_>.  See
-L<perlrun> for the B<-i> switch.
+L<perlrun|perlrun/-i[extension]> for the B<-i> switch.
 
 =item IO::Handle->output_field_separator( EXPR )
 
@@ -2350,9 +2349,9 @@ This variable was added in Perl v5.28.0.
 =item ${^UNICODE}
 X<${^UNICODE}>
 
-Reflects certain Unicode settings of Perl.  See L<perlrun>
-documentation for the C<-C> switch for more information about
-the possible values.
+Reflects certain Unicode settings of Perl.  See
+L<perlrun|perlrun/-C [numberE<sol>list]> documentation for the C<-C>
+switch for more information about the possible values.
 
 This variable is set during Perl startup and is thereafter read-only.
 
@@ -2375,7 +2374,8 @@ X<${^UTF8LOCALE}>
 This variable indicates whether a UTF-8 locale was detected by perl at
 startup.  This information is used by perl when it's in
 adjust-utf8ness-to-locale mode (as when run with the C<-CL> command-line
-switch); see L<perlrun> for more info on this.
+switch); see L<perlrun|perlrun/-C [numberE<sol>list]> for more info on
+this.
 
 This variable was added in Perl v5.8.8.
 


### PR DESCRIPTION
perlrun is a somewhat difficult page to navigate, covering lots of different things with weird headings. This updates various links to perlrun to link directly to the referenced item or section, plus a couple corrections. In most cases this does not change the page text, with a couple exceptions where the section name added clarity.