### PR TITLE
Create crosslinks betwen perlrun sections

### DIFF
--- a/pod/perlrun.pod
+++ b/pod/perlrun.pod
@@ -28,7 +28,8 @@ places:
 
 =item 1.
 
-Specified line by line via B<-e> or B<-E> switches on the command line.
+Specified line by line via L<-e|/-e commandline> or L<-E|/-E commandline>
+switches on the command line.
 
 =item 2.
 
@@ -45,7 +46,7 @@ must explicitly specify a "-" for the program name.
 =back
 
 With methods 2 and 3, Perl starts parsing the input file from the
-beginning, unless you've specified a B<-x> switch, in which case it
+beginning, unless you've specified a L</-x> switch, in which case it
 scans for the first line starting with C<#!> and containing the word
 "perl", and starts there instead.  This is useful for running a program
 embedded in a larger message.  (In this case you would indicate the end
@@ -55,7 +56,7 @@ The C<#!> line is always examined for switches as the line is being
 parsed.  Thus, if you're on a machine that allows only one argument
 with the C<#!> line, or worse, doesn't even recognize the C<#!> line, you
 still can get consistent switch behaviour regardless of how Perl was
-invoked, even if B<-x> was used to find the beginning of the program.
+invoked, even if L</-x> was used to find the beginning of the program.
 
 Because historically some operating systems silently chopped off
 kernel interpretation of the C<#!> line after 32 characters, some
@@ -65,13 +66,14 @@ You probably want to make sure that all your switches fall either
 before or after that 32-character boundary.  Most switches don't
 actually care if they're processed redundantly, but getting a "-"
 instead of a complete switch could cause Perl to try to execute
-standard input instead of your program.  And a partial B<-I> switch
-could also cause odd results.
+standard input instead of your program.  And a partial L<-I|/-Idirectory>
+switch could also cause odd results.
 
 Some switches do care if they are processed twice, for instance
-combinations of B<-l> and B<-0>.  Either put all the switches after
-the 32-character boundary (if applicable), or replace the use of
-B<-0>I<digits> by C<BEGIN{ $/ = "\0digits"; }>.
+combinations of L<-l|/-l[octnum]> and L<-0|/-0[octalE<sol>hexadecimal]>.
+Either put all the switches after the 32-character boundary (if
+applicable), or replace the use of B<-0>I<digits> by
+C<BEGIN{ $/ = "\0digits"; }>.
 
 Parsing of the C<#!> switches starts wherever "perl" is mentioned in the line.
 The sequences "-*" and "- " are specifically ignored so that you could,
@@ -82,7 +84,7 @@ if you were so inclined, say
     eval 'exec perl -x -wS $0 ${1+"$@"}'
         if 0;
 
-to let Perl see the B<-p> switch.
+to let Perl see the L</-p> switch.
 
 A similar trick involves the I<env> program, if you have it.
 
@@ -122,7 +124,7 @@ Put
 
     extproc perl -S -your_switches
 
-as the first line in C<*.cmd> file (B<-S> due to a bug in cmd.exe's
+as the first line in C<*.cmd> file (L</-S> due to a bug in cmd.exe's
 `extproc' handling).
 
 =item MS-DOS
@@ -246,16 +248,16 @@ You can also specify the separator character using hexadecimal notation:
 B<-0xI<HHH...>>, where the C<I<H>> are valid hexadecimal digits.  Unlike
 the octal form, this one may be used to specify any Unicode character, even
 those beyond 0xFF.  So if you I<really> want a record separator of 0777,
-specify it as B<-0x1FF>.  (This means that you cannot use the B<-x> option
+specify it as B<-0x1FF>.  (This means that you cannot use the L</-x> option
 with a directory name that consists of hexadecimal digits, or else Perl
 will think you have specified a hex number to B<-0>.)
 
 =item B<-a>
 X<-a> X<autosplit>
 
-turns on autosplit mode when used with a B<-n> or B<-p>.  An implicit
+turns on autosplit mode when used with a L</-n> or L</-p>.  An implicit
 split command to the @F array is done as the first thing inside the
-implicit while loop produced by the B<-n> or B<-p>.
+implicit while loop produced by the L</-n> or L</-p>.
 
     perl -ane 'print pop(@F), "\n";'
 
@@ -266,9 +268,9 @@ is equivalent to
 	print pop(@F), "\n";
     }
 
-An alternate delimiter may be specified using B<-F>.
+An alternate delimiter may be specified using L<-F|/-Fpattern>.
 
-B<-a> implicitly sets B<-n>.
+B<-a> implicitly sets L</-n>.
 
 =item B<-C [I<number/list>]>
 X<-C>
@@ -315,7 +317,7 @@ the default, with explicit layers in open() and with binmode() one can
 manipulate streams as usual.
 
 B<-C> on its own (not followed by any number or option list), or the
-empty string C<""> for the C<PERL_UNICODE> environment variable, has the
+empty string C<""> for the L</PERL_UNICODE> environment variable, has the
 same effect as B<-CSDL>.  In other words, the standard I/O handles and
 the default C<open()> layer are UTF-8-fied I<but> only if the locale
 environment variables indicate a UTF-8 locale.  This behaviour follows
@@ -366,13 +368,13 @@ X<-d> X<-dt>
 
 runs the program under the control of a debugging, profiling, or tracing
 module installed as C<Devel::I<MOD>>. E.g., B<-d:DProf> executes the
-program using the C<Devel::DProf> profiler.  As with the B<-M> flag, options
-may be passed to the C<Devel::I<MOD>> package where they will be received
-and interpreted by the C<Devel::I<MOD>::import> routine.  Again, like B<-M>,
-use -B<-d:-I<MOD>> to call C<Devel::I<MOD>::unimport> instead of import.  The
-comma-separated list of options must follow a C<=> character.  If B<t> is
-specified, it indicates to the debugger that threads will be used in the
-code being debugged.  See L<perldebug>.
+program using the C<Devel::DProf> profiler.  As with the L<-M|/-M[-]module>
+flag, options may be passed to the C<Devel::I<MOD>> package where they will
+be received and interpreted by the C<Devel::I<MOD>::import> routine.  Again,
+like B<-M>, use -B<-d:-I<MOD>> to call C<Devel::I<MOD>::unimport> instead of
+import.  The comma-separated list of options must follow a C<=> character.
+If B<t> is specified, it indicates to the debugger that threads will be used
+in the code being debugged.  See L<perldebug>.
 
 =item B<-D>I<letters>
 X<-D> X<DEBUGGING> X<-DDEBUGGING>
@@ -462,8 +464,9 @@ to use semicolons where you would in a normal program.
 =item B<-E> I<commandline>
 X<-E>
 
-behaves just like B<-e>, except that it implicitly enables all
-optional features (in the main compilation unit). See L<feature>.
+behaves just like L<-e|/-e commandline>, except that it implicitly
+enables all optional features (in the main compilation unit). See
+L<feature>.
 
 =item B<-f>
 X<-f> X<sitecustomize> X<sitecustomize.pl>
@@ -501,11 +504,11 @@ perl, you can check the value of C<$Config{usesitecustomize}>.
 =item B<-F>I<pattern>
 X<-F>
 
-specifies the pattern to split on for B<-a>. The pattern may be
+specifies the pattern to split on for L</-a>. The pattern may be
 surrounded by C<//>, C<"">, or C<''>, otherwise it will be put in single
 quotes. You can't use literal whitespace or NUL characters in the pattern.
 
-B<-F> implicitly sets both B<-a> and B<-n>.
+B<-F> implicitly sets both L</-a> and L</-n>.
 
 =item B<-h>
 X<-h>
@@ -640,7 +643,7 @@ X<-l> X<$/> X<$\>
 
 enables automatic line-ending processing.  It has two separate
 effects.  First, it automatically chomps C<$/> (the input record
-separator) when used with B<-n> or B<-p>.  Second, it assigns C<$\>
+separator) when used with L</-n> or L</-p>.  Second, it assigns C<$\>
 (the output record separator) to have the value of I<octnum> so
 that any print statements will have that separator added back on.
 If I<octnum> is omitted, sets C<$\> to the current value of
@@ -650,7 +653,8 @@ C<$/>.  For instance, to trim lines to 80 columns:
 
 Note that the assignment C<$\ = $/> is done when the switch is processed,
 so the input record separator can be different than the output record
-separator if the B<-l> switch is followed by a B<-0> switch:
+separator if the B<-l> switch is followed by a
+L<-0|/-0[octalE<sol>hexadecimal]> switch:
 
     gnufind / -print0 | perl -ln0e 'print "found $_" if -p'
 
@@ -722,7 +726,8 @@ This is faster than using the B<-exec> switch of I<find> because you don't
 have to start a process on every filename found (but it's not faster
 than using the B<-delete> switch available in newer versions of I<find>.
 It does suffer from the bug of mishandling newlines in pathnames, which
-you can fix if you follow the example under B<-0>.
+you can fix if you follow the example under
+L<-0|/-0[octalE<sol>hexadecimal]>.
 
 C<BEGIN> and C<END> blocks may be used to capture control before or after
 the implicit program loop, just as in I<awk>.
@@ -744,7 +749,7 @@ makes it iterate over filename arguments somewhat like I<sed>:
 If a file named by an argument cannot be opened for some reason, Perl
 warns you about it, and moves on to the next file.  Note that the
 lines are printed automatically.  An error occurring during printing is
-treated as fatal.  To suppress printing use the B<-n> switch.  A B<-p>
+treated as fatal.  To suppress printing use the L</-n> switch.  A B<-p>
 overrides a B<-n> switch.
 
 C<BEGIN> and C<END> blocks may be used to capture control before or after
@@ -771,7 +776,7 @@ warnings.
 =item B<-S>
 X<-S>
 
-makes Perl use the PATH environment variable to search for the
+makes Perl use the L</PATH> environment variable to search for the
 program unless the name of the program contains path separators.
 
 On some platforms, this also makes Perl append suffixes to the
@@ -779,7 +784,8 @@ filename while searching for it.  For example, on Win32 platforms,
 the ".bat" and ".cmd" suffixes are appended if a lookup for the
 original name fails, and if the name does not already end in one
 of those suffixes.  If your Perl was compiled with C<DEBUGGING> turned
-on, using the B<-Dp> switch to Perl shows how the search progresses.
+on, using the L<-Dp|/-Dletters> switch to Perl shows how the search
+progresses.
 
 Typically this is used to emulate C<#!> startup on platforms that don't
 support C<#!>.  It's also convenient when debugging a script that uses C<#!>,
@@ -796,7 +802,7 @@ The system ignores the first line and feeds the program to F</bin/sh>,
 which proceeds to try to execute the Perl program as a shell script.
 The shell executes the second line as a normal shell command, and thus
 starts up the Perl interpreter.  On some systems $0 doesn't always
-contain the full pathname, so the B<-S> tells Perl to search for the
+contain the full pathname, so the L</-S> tells Perl to search for the
 program if necessary.  After Perl locates the program, it parses the
 lines and ignores them because the variable $running_under_some_shell
 is never true.  If the program will be interpreted by csh, you will need
@@ -824,14 +830,14 @@ program will be searched for strictly on the PATH.
 =item B<-t>
 X<-t>
 
-Like B<-T>, but taint checks will issue warnings rather than fatal
+Like L</-T>, but taint checks will issue warnings rather than fatal
 errors.  These warnings can now be controlled normally with C<no warnings
 qw(taint)>.
 
 B<Note: This is not a substitute for C<-T>!> This is meant to be
 used I<only> as a temporary development aid while securing legacy code:
 for real production code and for new secure code written from scratch,
-always use the real B<-T>.
+always use the real L</-T>.
 
 =item B<-T>
 X<-T>
@@ -994,12 +1000,12 @@ Used if C<chdir> has no argument.
 =item LOGDIR
 X<LOGDIR>
 
-Used if C<chdir> has no argument and HOME is not set.
+Used if C<chdir> has no argument and L</HOME> is not set.
 
 =item PATH
 X<PATH>
 
-Used in executing subprocesses, and in finding the program if B<-S> is
+Used in executing subprocesses, and in finding the program if L</-S> is
 used.
 
 =item PERL5LIB
@@ -1015,14 +1021,14 @@ matching the entries in C<$Config{inc_version_list}> are added.
 (These typically would be for older compatible perl versions installed
 in the same directory tree.)
 
-If PERL5LIB is not defined, PERLLIB is used.  Directories are separated
+If PERL5LIB is not defined, L</PERLLIB> is used.  Directories are separated
 (like in PATH) by a colon on Unixish platforms and by a semicolon on
 Windows (the proper path separator being given by the command C<perl
 -V:I<path_sep>>).
 
 When running taint checks, either because the program was running setuid or
-setgid, or the B<-T> or B<-t> switch was specified, neither PERL5LIB nor
-PERLLIB is consulted. The program should instead say:
+setgid, or the L</-T> or L</-t> switch was specified, neither PERL5LIB nor
+L</PERLLIB> is consulted. The program should instead say:
 
     use lib "/my/directory";
 
@@ -1032,7 +1038,7 @@ X<PERL5OPT>
 Command-line options (switches).  Switches in this variable are treated
 as if they were on every Perl command line.  Only the B<-[CDIMTUWdmtw]>
 switches are allowed.  When running taint checks (either because the
-program was running setuid or setgid, or because the B<-T> or B<-t>
+program was running setuid or setgid, or because the L</-T> or L</-t>
 switch was used), this variable is ignored.  If PERL5OPT begins with
 B<-T>, tainting will be enabled and subsequent options ignored.  If
 PERL5OPT begins with B<-t>, tainting will be enabled, a writable dot
@@ -1168,8 +1174,8 @@ is run in taint mode.
 X<PERLIO_DEBUG>
 
 If set to the name of a file or device when Perl is run with the
-B<-Di> command-line switch, the logging of certain operations of
-the PerlIO subsystem will be redirected to the specified file rather
+L<-Di|/-Dletters> command-line switch, the logging of certain operations
+of the PerlIO subsystem will be redirected to the specified file rather
 than going to stderr, which is the default. The file is opened in append
 mode. Typical uses are in Unix:
 
@@ -1181,7 +1187,7 @@ and under Win32, the approximately equivalent:
    perl -Di script ...
 
 This functionality is disabled for setuid scripts, for scripts run
-with B<-T>, and for scripts run on a Perl built without C<-DDEBUGGING>
+with L</-T>, and for scripts run on a Perl built without C<-DDEBUGGING>
 support.
 
 =item PERLLIB
@@ -1189,7 +1195,7 @@ X<PERLLIB>
 
 A list of directories in which to look for Perl library
 files before looking in the standard library.
-If PERL5LIB is defined, PERLLIB is not used.
+If L</PERL5LIB> is defined, PERLLIB is not used.
 
 The PERLLIB environment variable is completely ignored when Perl
 is run in taint mode.
@@ -1202,7 +1208,7 @@ The command used to load the debugger code.  The default is:
 	BEGIN { require "perl5db.pl" }
 
 The PERL5DB environment variable is only used when Perl is started with
-a bare B<-d> switch.
+a bare L</-d> switch.
 
 =item PERL5DB_THREADED
 X<PERL5DB_THREADED>
@@ -1302,7 +1308,7 @@ L</PERL_HASH_SEED_DEBUG> for more information.
 X<PERL_PERTURB_KEYS>
 
 (Since Perl 5.18.0)  Set to C<"0"> or C<"NO"> then traversing keys
-will be repeatable from run to run for the same PERL_HASH_SEED.
+will be repeatable from run to run for the same C<PERL_HASH_SEED>.
 Insertion into a hash will not change the order, except to provide
 for more space in the hash. When combined with setting PERL_HASH_SEED
 this mode is as close to pre 5.18 behavior as you can get.
@@ -1381,12 +1387,12 @@ L<perlipc/"Deferred Signals (Safe Signals)">.
 =item PERL_UNICODE
 X<PERL_UNICODE>
 
-Equivalent to the B<-C> command-line switch.  Note that this is not
-a boolean variable. Setting this to C<"1"> is not the right way to
-"enable Unicode" (whatever that would mean).  You can use C<"0"> to
-"disable Unicode", though (or alternatively unset PERL_UNICODE in
-your shell before starting Perl).  See the description of the B<-C>
-switch for more information.
+Equivalent to the L<-C|/-C [numberE<sol>list]> command-line switch.  Note
+that this is not a boolean variable. Setting this to C<"1"> is not the
+right way to "enable Unicode" (whatever that would mean).  You can use
+C<"0"> to "disable Unicode", though (or alternatively unset PERL_UNICODE
+in your shell before starting Perl).  See the description of the
+L<-C|/-C [numberE<sol>list]> switch for more information.
 
 =item PERL_USE_UNSAFE_INC
 X<PERL_USE_UNSAFE_INC>
@@ -1400,7 +1406,7 @@ C<@INC> and should not be set in the environment for day-to-day use.
 =item SYS$LOGIN (specific to the VMS port)
 X<SYS$LOGIN>
 
-Used if chdir has no argument and HOME and LOGDIR are not set.
+Used if chdir has no argument and L</HOME> and L</LOGDIR> are not set.
 
 =item PERL_INTERNAL_RAND_SEED
 X<PERL_INTERNAL_RAND_SEED>


### PR DESCRIPTION
Allow for easier navigation between different sections of perlrun by linking to switches or environment variables when they are referenced outside of their section.