### PR TITLE
move and clean-up macros wrapping __attribute__()

### DIFF
--- a/win32/win32.h
+++ b/win32/win32.h
@@ -70,11 +70,6 @@
 #    define __int64 long long
 #  endif
 #  define Win32_Winsock
-#ifdef __cplusplus
-/* Mingw32 gcc -xc++ objects to __attribute((unused)) at least */
-#undef  PERL_UNUSED_DECL
-#define PERL_UNUSED_DECL
-#endif
 #endif
 
 


### PR DESCRIPTION
`__attribute__()` detection fallback for non-Configure platforms
(such as Windows) in perl.h was moved above the `PERL_UNUSED_DECL`
definition. That fixed two problems:

- `PERL_UNUSED_DECL` was undefined on those platforms
- `__attribute__*` macros weren't working properly inside headers
  included above their definitions (e.g. `win32.h`)

Also, redundant checks for pre-3.4 g++ versions were removed.