### PR TITLE
only install ExtUtils::XSSymSet man page on VMS

### DIFF
--- a/Porting/pod_lib.pl
+++ b/Porting/pod_lib.pl
@@ -330,6 +330,8 @@ sub pods_to_install {
     # manpages not to be installed
     my %do_not_install = map { ($_ => 1) }
         qw(Pod::Functions XS::APItest XS::Typemap);
+    $do_not_install{"ExtUtils::XSSymSet"} = 1
+        unless $^O eq "VMS";
 
     my (%done, %found);
 


### PR DESCRIPTION
This module is only installed on VMS, so there's not much point in
installing the man page.

An alternative would be to install the module on VMS, but it tries
to use configuration only set on VMS.

fixes #17424