### PR TITLE
study_chunk: panic on unknown REGNODE_VARIES node

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -5774,10 +5774,8 @@ Perl_re_printf( aTHX_  "LHS=%" UVuf " RHS=%" UVuf "\n",
 		continue;
 
 	    default:
-#ifdef DEBUGGING
                 Perl_croak(aTHX_ "panic: unexpected varying REx opcode %d",
                                                                     OP(scan));
-#endif
             case REF:
             case CLUMP:
 		if (flags & SCF_DO_SUBSTR) {


### PR DESCRIPTION
This has panicked on DEBUGGING builds since 56fcde2d6ae (August 2013);
as far as I know we've never seen the panic. It is easy to verify the
possible node types with "grep -P '\bV\b' regcomp.sym".

If you ever see this, it'll be because you just changed something wrongly,
or runaway corruption has occurred.

I don't think this is controversial, but just in case ...