### PR TITLE
fix protocol() caching and tests

### DIFF
--- a/dist/IO/IO.pm
+++ b/dist/IO/IO.pm
@@ -7,7 +7,7 @@ use Carp;
 use strict;
 use warnings;
 
-our $VERSION = "1.42";
+our $VERSION = "1.43";
 XSLoader::load 'IO', $VERSION;
 
 sub import {

--- a/dist/IO/lib/IO/Socket.pm
+++ b/dist/IO/lib/IO/Socket.pm
@@ -82,7 +82,12 @@ sub socket {
 
     ${*$sock}{'io_socket_domain'} = $domain;
     ${*$sock}{'io_socket_type'}   = $type;
-    ${*$sock}{'io_socket_proto'}  = $protocol;
+
+    # "A value of 0 for protocol will let the system select an
+    # appropriate protocol"
+    # so we need to look up what the system selected,
+    # not cache PF_UNSPEC.
+    ${*$sock}{'io_socket_proto'} = $protocol if $protocol;
 
     $sock;
 }

--- a/dist/IO/lib/IO/Socket.pm
+++ b/dist/IO/lib/IO/Socket.pm
@@ -23,7 +23,7 @@ require IO::Socket::UNIX if ($^O ne 'epoc' && $^O ne 'symbian');
 
 our @ISA = qw(IO::Handle);
 
-our $VERSION = "1.42";
+our $VERSION = "1.43";
 
 our @EXPORT_OK = qw(sockatmark);
 

--- a/dist/IO/t/cachepropagate-unix.t
+++ b/dist/IO/t/cachepropagate-unix.t
@@ -40,7 +40,19 @@ my $listener = IO::Socket::UNIX->new(Type => SOCK_STREAM,
 ok(defined($listener), 'stream socket created');
 
 my $p = $listener->protocol();
-ok(defined($p), 'protocol defined');
+{
+    # the value of protocol isn't well defined for AF_UNIX, when we
+    # create the socket we supply 0, which leaves it up to the implementation
+    # to select a protocol, so we (now) don't save a 0 protocol during socket
+    # creation.  This test then breaks if the implementation doesn't support
+    # SO_SOCKET (at least on AF_UNIX).
+    # This specifically includes NetBSD, Darwin and cygwin.
+    # This is a TODO instead of a skip so if these ever implement SO_PROTOCOL
+    # we'll be notified about the passing TODO so the test can be updated.
+    local $TODO = "$^O doesn't support SO_PROTOCOL on AF_UNIX"
+        if $^O =~ /^(netbsd|darwin|cygwin)$/;
+    ok(defined($p), 'protocol defined');
+}
 my $d = $listener->sockdomain();
 ok(defined($d), 'domain defined');
 my $s = $listener->socktype();
@@ -90,7 +102,12 @@ SKIP: {
     ok(defined($listener), 'datagram socket created');
 
     $p = $listener->protocol();
-    ok(defined($p), 'protocol defined');
+    {
+        # see comment above
+        local $TODO = "$^O doesn't support SO_PROTOCOL on AF_UNIX"
+            if $^O =~ /^(netbsd|darwin|cygwin)$/;
+        ok(defined($p), 'protocol defined');
+    }
     $d = $listener->sockdomain();
     ok(defined($d), 'domain defined');
     $s = $listener->socktype();


### PR DESCRIPTION
This fixes two problems
- we were caching a zero protocol, but zero means the implementation gets to select a protocol, so the cached protocol was a lie.
- without a cached protocol, protocol() would return undef on systems that don't implement `SO_PROTOCOL` which appears to be NetBSD at this point.