### PR TITLE
add casts to the definitions of IV_MAX/MIN and UV_MAX/MIN to match their underlying types

### DIFF
--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.06';
+our $VERSION = '1.07';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -4499,6 +4499,17 @@ PerlIO_stdin()
 FILE *
 PerlIO_exportFILE(PerlIO *f, const char *mode)
 
+SV *
+test_MAX_types()
+    CODE:
+        /* tests that IV_MAX and UV_MAX have types suitable
+           for the IVdf and UVdf formats.
+           If this warns then don't add casts here.
+        */
+        RETVAL = newSVpvf("iv %" IVdf " uv %" UVuf, IV_MAX, UV_MAX);
+    OUTPUT:
+	RETVAL
+
 MODULE = XS::APItest PACKAGE = XS::APItest::AUTOLOADtest
 
 int

--- a/ext/XS-APItest/t/printf.t
+++ b/ext/XS-APItest/t/printf.t
@@ -6,7 +6,7 @@ BEGIN {
   }
 }
 
-use Test::More tests => 11;
+use Test::More tests => 12;
 
 BEGIN { use_ok('XS::APItest') };
 
@@ -51,3 +51,15 @@ SKIP: {
    is($output[4], "7.000", "print_long_double");
 }
 
+{
+    # GH #17338
+    # This is unlikely to fail here since int and long are the
+    # same size on our usual platforms, but it's less likely to
+    # be ignored than the warning that's the real diagnostic
+    # for this bug.
+    my $uv_max = ~0;
+    my $iv_max = $uv_max >> 1;
+    my $max_out = "iv $iv_max uv $uv_max";
+    is(test_MAX_types(), $max_out,
+       "check types for IV_MAX and UV_MAX match IVdf/UVuf");
+}

--- a/perl.h
+++ b/perl.h
@@ -1873,13 +1873,13 @@ typedef UVTYPE UV;
 
 #if defined(USE_64_BIT_INT) && defined(HAS_QUAD)
 #  if QUADKIND == QUAD_IS_INT64_T && defined(INT64_MAX)
-#    define IV_MAX INT64_MAX
-#    define IV_MIN INT64_MIN
-#    define UV_MAX UINT64_MAX
+#    define IV_MAX ((IV)INT64_MAX)
+#    define IV_MIN ((IV)INT64_MIN)
+#    define UV_MAX ((UV)UINT64_MAX)
 #    ifndef UINT64_MIN
 #      define UINT64_MIN 0
 #    endif
-#    define UV_MIN UINT64_MIN
+#    define UV_MIN ((UV)UINT64_MIN)
 #  else
 #    define IV_MAX PERL_QUAD_MAX
 #    define IV_MIN PERL_QUAD_MIN
@@ -1890,17 +1890,17 @@ typedef UVTYPE UV;
 #  define UV_IS_QUAD
 #else
 #  if defined(INT32_MAX) && IVSIZE == 4
-#    define IV_MAX INT32_MAX
-#    define IV_MIN INT32_MIN
+#    define IV_MAX ((IV)INT32_MAX)
+#    define IV_MIN ((IV)INT32_MIN)
 #    ifndef UINT32_MAX_BROKEN /* e.g. HP-UX with gcc messes this up */
-#        define UV_MAX UINT32_MAX
+#        define UV_MAX ((UV)UINT32_MAX)
 #    else
-#        define UV_MAX 4294967295U
+#        define UV_MAX ((UV)4294967295U)
 #    endif
 #    ifndef UINT32_MIN
 #      define UINT32_MIN 0
 #    endif
-#    define UV_MIN UINT32_MIN
+#    define UV_MIN ((UV)UINT32_MIN)
 #  else
 #    define IV_MAX PERL_LONG_MAX
 #    define IV_MIN PERL_LONG_MIN


### PR DESCRIPTION
fixes #17338 so the types of these constants matches the IVdf/IVuf macros.

Note that the PERL_*_(MAX|MIN) constants used before we started using `inttypes.h` already included casts.