### PR TITLE
win32: don't set the base address of perl5xx.dll

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1572,7 +1572,7 @@ ifeq ($(CCTYPE),GCC)
 else
 	$(LINK32) -dll -out:$@ $(BLINK_FLAGS) \
 	    @Extensions_static \
-	    -base:0x28000000 $(DELAYLOAD) $(LIBFILES) \
+	    $(DELAYLOAD) $(LIBFILES) \
 	    $(PERLDLL_RES) $(PERLDLL_OBJ) $(PERLEXPLIB)
 	$(EMBED_DLL_MANI)
 endif

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -1130,7 +1130,7 @@ perldll.def : $(MINIPERL) $(CONFIGPM) ..\embed.fnc ..\makedef.pl create_perllibs
 	    CCTYPE=$(CCTYPE) TARG_DIR=..\ > perldll.def
 
 $(PERLDLL): perldll.def $(PERLDLL_OBJ) $(PERLDLL_RES) Extensions_static
-	$(LINK32) -dll -def:perldll.def -base:0x28000000 -out:$@ @Extensions_static @<<
+	$(LINK32) -dll -def:perldll.def -out:$@ @Extensions_static @<<
 		$(BLINK_FLAGS) $(DELAYLOAD) $(LIBFILES) $(PERLDLL_OBJ) $(PERLDLL_RES)
 <<
 	$(EMBED_DLL_MANI)

--- a/win32/makefile.mk
+++ b/win32/makefile.mk
@@ -1498,7 +1498,7 @@ $(PERLDLL): $(PERLEXPLIB) $(PERLDLL_OBJ) $(PERLDLL_RES) Extensions_static
 .ELSE
 	$(LINK32) -dll -out:$@ $(BLINK_FLAGS) \
 	    @Extensions_static \
-	    @$(mktmp -base:0x28000000 $(DELAYLOAD) $(LIBFILES) \
+	    @$(mktmp $(DELAYLOAD) $(LIBFILES) \
 		$(PERLDLL_RES) $(PERLDLL_OBJ) $(PERLEXPLIB))
 	$(EMBED_DLL_MANI)
 .ENDIF


### PR DESCRIPTION
It was causing LNK4281 warning on modern Visual C++ versions. Also,
`-base` is a security risk because it opt-outs from ASLR.

That switch was added as an optimization 20 years ago, but I don't
think the potential benefits are worth the trouble.

For reference, this is the full warning:
```
LINK : warning LNK4281: undesirable base address 0x28000000 for x64 image; set base address above 4GB for best ASLR optimization
```

Commit that introduced `-base`: 9d2428989d95cd0d9d5fc1f1fcf60ab67cde0b7f