### PR TITLE
perlio.c: make :unix close method call underlaying layers as well

### DIFF
--- a/perlio.c
+++ b/perlio.c
@@ -2818,6 +2818,7 @@ PerlIOUnix_close(pTHX_ PerlIO *f)
     const int fd = PerlIOSelf(f, PerlIOUnix)->fd;
     int code = 0;
     if (PerlIOBase(f)->flags & PERLIO_F_OPEN) {
+        code = PerlIOBase_close(aTHX_ f);
 	if (PerlIOUnix_refcnt_dec(fd) > 0) {
 	    PerlIOBase(f)->flags &= ~PERLIO_F_OPEN;
 	    return 0;


### PR DESCRIPTION
This should fix the «binmode(IO, ':unix') and open(IO, '+>:unix', undef) leak» reported on the mailing list.

Can't think of a portable way to test this, though I have confirmed using strace that it performs one more `close()` than without the test.