### PR TITLE
Do not ignore non-zero error code from 'make minitest'

### DIFF
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -1657,15 +1657,15 @@ minitest_prep:
 	@echo "You may see some irrelevant test failures if you have been unable"
 	@echo "to build lib/Config.pm, or the Unicode data files."
 	@echo " "
-	- cd t && (rm -f $(PERL_EXE); $(LNS) ../$(MINIPERL_EXE) $(PERL_EXE))
+	cd t && (rm -f $(PERL_EXE); $(LNS) ../$(MINIPERL_EXE) $(PERL_EXE))
 
 MINITEST_TESTS = base/*.t comp/*.t cmd/*.t run/*.t io/*.t re/*.t opbasic/*.t op/*.t uni/*.t perf/*.t
 
 minitest: $(MINIPERL_EXE) minitest_prep
-	- cd t && $(RUN_PERL) TEST $(MINITEST_TESTS) <$(devtty)
+	cd t && $(RUN_PERL) TEST $(MINITEST_TESTS) <$(devtty)
 
 minitest-notty minitest_notty: $(MINIPERL_EXE) minitest_prep
-	- cd t && PERL_SKIP_TTY_TEST=1 $(RUN_PERL) TEST $(MINITEST_TESTS)
+	cd t && PERL_SKIP_TTY_TEST=1 $(RUN_PERL) TEST $(MINITEST_TESTS)
 
 # Test via harness
 


### PR DESCRIPTION
In pipelines like:

    $ sh ./Configure -des -Dusedevel && \
        make minitest && make test_harness

... we don't want to run 'make test_harness' unless 'make minitest' has
succeeded.

To test:

    $ echo "exit(1);" >> t/base/cond.t
    $ make minitest && echo "hello world"
    # [note that minitest fails quickly and 'echo' is not reached]

    $ git checkout -- t/base/cond.t
    $ make minitest && echo "hello world"
    # [note that minitest runs and 'echo' is reached]

For: [16160](https://github.com/perl/perl5/issues/16160)
Originally: https://rt-archive.perl.org/perl5/Ticket/Display.html?id=132139