### PR TITLE
Add a missing switch to a documentation example

### DIFF
--- a/pod/perlrun.pod
+++ b/pod/perlrun.pod
@@ -80,7 +80,7 @@ The sequences "-*" and "- " are specifically ignored so that you could,
 if you were so inclined, say
 
     #!/bin/sh
-    #! -*-perl-*-
+    #! -*- perl -*- -p
     eval 'exec perl -x -wS $0 ${1+"$@"}'
         if 0;
 


### PR DESCRIPTION
The switch is mentioned in the next paragraph.

It was removed in 428bacd701ef45155f9dfd0d9c3d063dc305de00, probably
by accident (the commit message isn't much informative).