### PR TITLE
Tie::File - Document use of binmode on filehandles

### DIFF
--- a/dist/Tie-File/lib/Tie/File.pm
+++ b/dist/Tie-File/lib/Tie/File.pm
@@ -2323,6 +2323,11 @@ internally.  If you passed it a filehandle as above, you "own" the
 filehandle, and are responsible for closing it after you have untied
 the @array.
 
+Tie::File calls C<binmode> on filehandles that it opens internally, 
+but not on filehandles passed in by the user. For consistency,
+especially if using the tied files cross-platform, you may wish to
+call C<binmode> on the filehandle prior to tying the file. 
+
 =head1 Deferred Writing
 
 (This is an advanced feature.  Skip this section on first reading.)


### PR DESCRIPTION
Documentation fix for #17497, where the user passed a filehandle in, but the lack of binmode meant that the :crlf layer on Windows caused problems when the file was later used on Linux.