### PR TITLE
Smoke me/fix 17537

### DIFF
--- a/lib/B/Deparse.pm
+++ b/lib/B/Deparse.pm
@@ -3393,7 +3393,7 @@ sub pp_glob {
     my $kid = $op->first->sibling;  # skip pushmark
     my $keyword =
 	$op->flags & OPf_SPECIAL ? 'glob' : $self->keyword('glob');
-    my $text = $self->deparse($kid);
+    my $text = $self->deparse($kid, $cx);
     return $cx >= 5 || $self->{'parens'}
 	? "$keyword($text)"
 	: "$keyword $text";

--- a/lib/B/Deparse.pm
+++ b/lib/B/Deparse.pm
@@ -52,7 +52,7 @@ use B qw(class main_root main_start main_cv svref_2object opnumber perlstring
         MDEREF_SHIFT
     );
 
-$VERSION = '1.52';
+$VERSION = '1.53';
 use strict;
 our $AUTOLOAD;
 use warnings ();

--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -20,6 +20,8 @@ my $deparse = B::Deparse->new();
 isa_ok($deparse, 'B::Deparse', 'instantiate a B::Deparse object');
 my %deparse;
 
+sub dummy_sub {42}
+
 $/ = "\n####\n";
 while (<DATA>) {
     chomp;
@@ -678,6 +680,19 @@ $_ .= readline(ARGV) . readline(ARGV) . readline($foo);
 readline $foo;
 glob $foo;
 glob $foo;
+####
+# more <>
+no warnings;
+no strict;
+my $fh;
+if (dummy_sub < $fh > /bar/g) { 1 }
+>>>>
+no warnings;
+no strict;
+my $fh;
+if (dummy_sub(glob((' ' . $fh . ' ')) / 'bar' / 'g')) {
+    1;
+}
 ####
 # readline
 readline 'FH';


### PR DESCRIPTION
Hi, can you please review this patch to B::Deparse which happens to throw warnings from the multiconcat code in B::Deparse.

Thanks!
Yves