### PR TITLE
fix defines for PERL_BITFIELDxx on Linux and Win32

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -3827,13 +3827,13 @@ typedef        struct crypt_data {     /* straight from /usr/include/crypt.h */
 
 /* macros to define bit-fields in structs. */
 #ifndef PERL_BITFIELD8
-#  define PERL_BITFIELD8 unsigned
+#  define PERL_BITFIELD8 unsigned char
 #endif
 #ifndef PERL_BITFIELD16
-#  define PERL_BITFIELD16 unsigned
+#  define PERL_BITFIELD16 unsigned short int
 #endif
 #ifndef PERL_BITFIELD32
-#  define PERL_BITFIELD32 unsigned
+#  define PERL_BITFIELD32 unsigned long int
 #endif
 
 #include "sv.h"

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -255,8 +255,8 @@ struct utsname {
 /* VC uses non-standard way to determine the size and alignment if bit-fields */
 /* MinGW will compile with -mms-bitfields, so should use the same types */
 #define PERL_BITFIELD8  unsigned char
-#define PERL_BITFIELD16 unsigned short
-#define PERL_BITFIELD32 unsigned int
+#define PERL_BITFIELD16 unsigned short int
+#define PERL_BITFIELD32 unsigned long int
 
 #ifdef _MSC_VER			/* Microsoft Visual C++ */
 


### PR DESCRIPTION
for some reason PERL_BITFIELD32 is defined as "unsigned" which is
defined to be the same as "unsigned int" which could be 16 bits.

This changes the definition for PERL_BITFIELDxx to be the same
on both platforms and to use the full names for the type, and to
use a type which is guaranteed to be at least 32 bits long for
PERL_BITFIELD32.