### PR TITLE
Make pl2bat use ExtUtils::PL2Bat

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -876,6 +876,8 @@ cpan/ExtUtils-MakeMaker/t/writemakefile_args.t			See if WriteMakefile works
 cpan/ExtUtils-Manifest/lib/ExtUtils/Manifest.pm			Utilities to write MANIFEST files
 cpan/ExtUtils-Manifest/lib/ExtUtils/MANIFEST.SKIP		The default MANIFEST.SKIP
 cpan/ExtUtils-Manifest/t/Manifest.t				See if ExtUtils::Manifest works
+cpan/ExtUtils-PL2Bat/lib/ExtUtils/PL2Bat.pm	Implement pl2bat
+cpan/ExtUtils-PL2Bat/t/make_executable.t	Tests if ExtUtils::PL2Bat makes bat files that are executable
 cpan/File-Fetch/lib/File/Fetch.pm	File::Fetch
 cpan/File-Fetch/t/01_File-Fetch.t	File::Fetch tests
 cpan/File-Fetch/t/null_subclass.t

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -485,6 +485,14 @@ use File::Glob qw(:case);
         ],
     },
 
+	'ExtUtils::PL2Bat' => {
+		'DISTRIBUTION' => 'LEONT/ExtUtils-PL2Bat-0.002.tar.gz',
+		'FILES'        => q[cpan/ExtUtils-PL2Bat],
+		'EXCLUDED'     => [
+			't/00-compile.t',
+		],
+	},
+
     'ExtUtils::Manifest' => {
         'DISTRIBUTION' => 'ETHER/ExtUtils-Manifest-1.72.tar.gz',
         'FILES'        => q[cpan/ExtUtils-Manifest],

--- a/cpan/ExtUtils-PL2Bat/lib/ExtUtils/PL2Bat.pm
+++ b/cpan/ExtUtils-PL2Bat/lib/ExtUtils/PL2Bat.pm
@@ -1,0 +1,194 @@
+package ExtUtils::PL2Bat;
+$ExtUtils::PL2Bat::VERSION = '0.002';
+use strict;
+use warnings;
+
+use 5.006;
+
+use Config;
+use Carp qw/croak/;
+
+# In core, we can't use any other modules except those that already live in
+# lib/, so Exporter is not available to us.
+sub import {
+	my ($self, @functions) = @_;
+	@functions = 'pl2bat' if not @functions;
+	my $caller = caller;
+	for my $function (@functions) {
+		no strict 'refs';
+		*{"$caller\::$function"} = \&{$function};
+	}
+}
+
+sub pl2bat {
+	my %opts = @_;
+
+	# NOTE: %0 is already enclosed in doublequotes by cmd.exe, as appropriate
+	$opts{ntargs}    = '-x -S %0 %*' unless exists $opts{ntargs};
+	$opts{otherargs} = '-x -S "%0" %1 %2 %3 %4 %5 %6 %7 %8 %9' unless exists $opts{otherargs};
+
+	$opts{stripsuffix} = qr/\.plx?/ unless exists $opts{stripsuffix};
+
+	if (not exists $opts{out}) {
+		$opts{out} = $opts{in};
+		$opts{out} =~ s/$opts{stripsuffix}$//i;
+		$opts{out} .= '.bat' unless $opts{in} =~ /\.bat$/i or $opts{in} eq '-';
+	}
+
+	my $head = <<"EOT";
+	\@rem = '--*-Perl-*--
+	\@set "ErrorLevel="
+	\@if "%OS%" == "Windows_NT" \@goto WinNT
+	\@perl $opts{otherargs}
+	\@set ErrorLevel=%ErrorLevel%
+	\@goto endofperl
+	:WinNT
+	\@perl $opts{ntargs}
+	\@set ErrorLevel=%ErrorLevel%
+	\@if NOT "%COMSPEC%" == "%SystemRoot%\\system32\\cmd.exe" \@goto endofperl
+	\@if %ErrorLevel% == 9009 \@echo You do not have Perl in your PATH.
+	\@goto endofperl
+	\@rem ';
+EOT
+
+	$head =~ s/^\s+//gm;
+	my $headlines = 2 + ($head =~ tr/\n/\n/);
+	my $tail = <<'EOT';
+	__END__
+	:endofperl
+	@set "ErrorLevel=" & @goto _undefined_label_ 2>NUL || @"%COMSPEC%" /d/c @exit %ErrorLevel%
+EOT
+	$tail =~ s/^\s+//gm;
+
+	my $linedone = 0;
+	my $taildone = 0;
+	my $linenum = 0;
+	my $skiplines = 0;
+
+	my $start = $Config{startperl};
+	$start = '#!perl' unless $start =~ /^#!.*perl/;
+
+	open my $in, '<', $opts{in} or croak "Can't open $opts{in}: $!";
+	my @file = <$in>;
+	close $in;
+
+	foreach my $line ( @file ) {
+		$linenum++;
+		if ( $line =~ /^:endofperl\b/ ) {
+			if (!exists $opts{update}) {
+				warn "$opts{in} has already been converted to a batch file!\n";
+				return;
+			}
+			$taildone++;
+		}
+		if ( not $linedone and $line =~ /^#!.*perl/ ) {
+			if (exists $opts{update}) {
+				$skiplines = $linenum - 1;
+				$line .= '#line '.(1+$headlines)."\n";
+			} else {
+	$line .= '#line '.($linenum+$headlines)."\n";
+			}
+	$linedone++;
+		}
+		if ( $line =~ /^#\s*line\b/ and $linenum == 2 + $skiplines ) {
+			$line = '';
+		}
+	}
+
+	open my $out, '>', $opts{out} or croak "Can't open $opts{out}: $!";
+	print $out $head;
+	print $out $start, ( $opts{usewarnings} ? ' -w' : '' ),
+						 "\n#line ", ($headlines+1), "\n" unless $linedone;
+	print $out @file[$skiplines..$#file];
+	print $out $tail unless $taildone;
+	close $out;
+
+	return $opts{out};
+}
+
+1;
+
+# ABSTRACT: Batch file creation to run perl scripts on Windows
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+ExtUtils::PL2Bat - Batch file creation to run perl scripts on Windows
+
+=head1 VERSION
+
+version 0.002
+
+=head1 OVERVIEW
+
+This module converts a perl script into a batch file that can be executed on Windows/DOS-like operating systems.  This is intended to allow you to use a Perl script like regular programs and batch files where you just enter the name of the script [probably minus the extension] plus any command-line arguments and the script is found in your B<PATH> and run.
+
+=head1 FUNCTIONS
+
+=head2 pl2bat(%opts)
+
+This function takes a perl script and write a batch file that contains the script. This is sometimes necessary
+
+=over 8
+
+=item * C<in>
+
+The name of the script that is to be batchified. This argument is mandatory.
+
+=item * C<out>
+
+The name of the output batch file. If not given, it will be generated using C<in> and C<stripsuffix>.
+
+=item * C<ntargs>
+
+Arguments to invoke perl with in generated batch file when run from
+Windows NT.  Defaults to S<'-x -S %0 %*'>.
+
+=item * C<otherargs>
+
+Arguments to invoke perl with in generated batch file except when
+run from Windows NT (ie. when run from DOS, Windows 3.1, or Windows 95).
+Defaults to S<'-x -S "%0" %1 %2 %3 %4 %5 %6 %7 %8 %9'>.
+
+=item * C<stripsuffix>
+
+Strip a suffix string from file name before appending a ".bat"
+suffix.  The suffix is not case-sensitive.  It can be a regex or a string and a trailing
+C<$> is always assumed).  Defaults to C<qr/\.plx?/>.
+
+=item * C<usewarnings>
+
+With the C<usewarnings>
+option, C<" -w"> is added after the value of C<$Config{startperl}>.
+If a line matching C</^#!.*perl/> already exists in the script,
+then it is not changed and the B<-w> option is ignored.
+
+=item * C<update>
+
+If the script appears to have already been processed by B<pl2bat>,
+then the script is skipped and not processed unless C<update> was
+specified.  If C<update> is specified, the existing preamble is replaced.
+
+=back
+
+=head1 ACKNOWLEDGEMENTS
+
+This code was taken from Module::Build and then modified; which had taken it from perl's pl2bat script. This module is an attempt at unifying all three implementations.
+
+=head1 AUTHOR
+
+Leon Timmermans <leont@cpan.org>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2015 by Leon Timmermans.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/cpan/ExtUtils-PL2Bat/t/make_executable.t
+++ b/cpan/ExtUtils-PL2Bat/t/make_executable.t
@@ -1,0 +1,33 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings FATAL => 'all';
+
+use Config;
+use Test::More;
+use ExtUtils::PL2Bat;
+use Cwd qw/cwd/;
+
+plan($^O eq 'MSWin32' ? (tests => 7) : skip_all => 'Only usable on Windows');
+
+my $filename = 'test_exec';
+my @files;
+
+open my $out, '>', $filename or die "Couldn't create $filename: $!";
+print $out "#! perl -w\nexit \$ARGV[0];\n";
+close $out;
+
+pl2bat(in => $filename);
+
+foreach my $i (42, 51, 0) {
+	my $cwd = cwd;
+	local $ENV{PATH} = join $Config{path_sep}, $cwd, $ENV{PATH};
+	my $ret = system $filename, $i;
+	is $ret & 0xff, 0, 'test_exec executed successfully';
+	is $ret >> 8, $i, "test_exec $i return value ok";
+}
+
+push @files, grep { -f } map { $filename.$_ } split / $Config{path_sep} /x, $ENV{PATHEXT} || '';
+is scalar(@files), 1, "Executable file exists";
+
+unlink $filename, @files;

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -73,6 +73,7 @@
 /ExtUtils/Miniperl.pm
 /ExtUtils/Mkbootstrap.pm
 /ExtUtils/Mksymlists.pm
+/ExtUtils/PL2Bat.pm
 /ExtUtils/Packlist.pm
 /ExtUtils/ParseXS.pm
 /ExtUtils/ParseXS.pod

--- a/make_ext.pl
+++ b/make_ext.pl
@@ -168,7 +168,7 @@ if (IS_WIN32) {
     $ENV{PATH} = "$topdir;$topdir\\win32\\bin;$ENV{PATH}";
     my $pl2bat = "$topdir\\win32\\bin\\pl2bat";
     unless (-f "$pl2bat.bat") {
-	my @args = ($perl, "-I$topdir\\lib", ("$pl2bat.pl") x 2);
+	my @args = ($perl, "-I$topdir\\lib", "-I$topdir\\cpan\\ExtUtils-PL2Bat\\lib", ("$pl2bat.pl") x 2);
 	print "@args\n" if $verbose;
 	system(@args) unless IS_CROSS;
     }

--- a/win32/bin/pl2bat.pl
+++ b/win32/bin/pl2bat.pl
@@ -2,8 +2,8 @@
 	if 0;	# In case running under some shell
 
 require 5;
+use ExtUtils::PL2Bat;
 use Getopt::Std;
-use Config;
 
 $0 =~ s|.*[/\\]||;
 
@@ -30,82 +30,30 @@ EOT
 
 my %OPT = ();
 warn($usage), exit(0) if !getopts('whun:o:a:s:',\%OPT) or $OPT{'h'};
-# NOTE: %0 is already enclosed in double quotes by cmd.exe, as appropriate
-$OPT{'n'} = '-x -S %0 %*' unless exists $OPT{'n'};
-$OPT{'o'} = '-x -S "%0" %1 %2 %3 %4 %5 %6 %7 %8 %9' unless exists $OPT{'o'};
-$OPT{'s'} = '/\\.plx?/' unless exists $OPT{'s'};
-$OPT{'s'} = ($OPT{'s'} =~ m#^/([^/]*[^/\$]|)\$?/?$# ? $1 : "\Q$OPT{'s'}\E");
-
 die '-a option has been removed' if $OPT{a};
 
-my $head = <<EOT;
-\@rem = '--*-Perl-*--
-\@echo off
-if "%OS%" == "Windows_NT" goto WinNT
-perl $OPT{'o'}
-goto endofperl
-:WinNT
-perl $OPT{'n'}
-if NOT "%COMSPEC%" == "%SystemRoot%\\system32\\cmd.exe" goto endofperl
-if %errorlevel% == 9009 echo You do not have Perl in your PATH.
-if errorlevel 1 goto script_failed_so_exit_with_non_zero_val 2>nul
-goto endofperl
-\@rem ';
-EOT
-my $headlines = 2 + ($head =~ tr/\n/\n/);
-my $tail = "\n__END__\n:endofperl\n";
+my %key_for = (
+	n => 'ntargs',
+	o => 'otherargs',
+	a => 'argstring',
+	u => 'update',
+	w => 'usewarnings'
+);
 
-@ARGV = ('-') unless @ARGV;
-
-foreach ( @ARGV ) {
-    process($_);
+my %args;
+for my $old_key (keys %key_for) {
+	if (exists $OPT{$old_key}) {
+		$args{$key_for{$old_key}} = $OPT{$old_key};
+	}
+}
+if (exists $OPT{s}) {
+	$args{strip_suffix} = $OPT{'s'} =~ m#^/([^/]*[^/\$]|)\$?/?$# ? qr/$1/ : qr/\Q$OPT{'s'}\E/;
 }
 
-sub process {
- my( $file )= @_;
-    my $myhead = $head;
-    my $linedone = 0;
-    my $taildone = 0;
-    my $linenum = 0;
-    my $skiplines = 0;
-    my $line;
-    my $start= $Config{startperl};
-    $start= "#!perl"   unless  $start =~ /^#!.*perl/;
-    open( FILE, '<', $file ) or die "$0: Can't open $file: $!";
-    @file = <FILE>;
-    foreach $line ( @file ) {
-	$linenum++;
-	if ( $line =~ /^:endofperl\b/ ) {
-	    if(  ! exists $OPT{'u'}  ) {
-		warn "$0: $file has already been converted to a batch file!\n";
-		return;
-	    }
-	    $taildone++;
-	}
-	if ( not $linedone and $line =~ /^#!.*perl/ ) {
-	    if(  exists $OPT{'u'}  ) {
-		$skiplines = $linenum - 1;
-		$line .= "#line ".(1+$headlines)."\n";
-	    } else {
-		$line .= "#line ".($linenum+$headlines)."\n";
-	    }
-	    $linedone++;
-	}
-	if ( $line =~ /^#\s*line\b/ and $linenum == 2 + $skiplines ) {
-	    $line = "";
-	}
-    }
-    close( FILE );
-    $file =~ s/$OPT{'s'}$//oi;
-    $file .= '.bat' unless $file =~ /\.bat$/i or $file =~ /^-$/;
-    open( FILE, '>', $file ) or die "Can't open $file: $!";
-    print FILE $myhead;
-    print FILE $start, ( $OPT{'w'} ? " -w" : "" ),
-	       "\n#line ", ($headlines+1), "\n" unless $linedone;
-    print FILE @file[$skiplines..$#file];
-    print FILE $tail unless $taildone;
-    close( FILE );
+for my $file (@ARGV) {
+	pl2bat(%args, in => $file);
 }
+
 __END__
 
 =head1 NAME


### PR DESCRIPTION
This adds a new module called `ExtUtils::PL2Bat`, and refactors the pl2bat to use it.

This way, we can finally unify all three implementations of pl2bat into one codebase that has tests

This is probably too late for 5.32 though