### PR TITLE
gh#10059 - potentially reduce -Wall warnings on plan9. Not tested.

### DIFF
--- a/plan9/config.plan9
+++ b/plan9/config.plan9
@@ -244,7 +244,7 @@
  *	This symbol, if defined, indicates that the link routine is
  *	available to create hard links.
  */
-/* #define HAS_LINK	/**/
+/* #define HAS_LINK	/ **/
 
 /* HAS_LOCALECONV:
  *	This symbol, if defined, indicates that the localeconv routine is
@@ -262,7 +262,7 @@
  *	This symbol, if defined, indicates that the lstat routine is
  *	available to do file stats on symbolic links.
  */
-/*#define HAS_LSTAT		/**/
+/*#define HAS_LSTAT		/ **/
 
 /* HAS_MBLEN:
  *	This symbol, if defined, indicates that the mblen routine is available
@@ -382,7 +382,7 @@
  *	This symbol, if defined, indicates that the readlink routine is
  *	available to read the value of a symbolic link.
  */
-/*#define HAS_READLINK		/**/
+/*#define HAS_READLINK		/ **/
 
 /* HAS_RENAME:
  *	This symbol, if defined, indicates that the rename routine is available
@@ -434,7 +434,7 @@
  *	This symbol, if defined, indicates that the setpgid(pid, gpid)
  *	routine is available to set process group ID.
  */
-#define HAS_SETPGID	/**/
+#define HAS_SETPGID	/ **/
 
 /* HAS_SETPGRP2:
  *	This symbol, if defined, indicates that the setpgrp2() (as in DG/UX)
@@ -520,7 +520,7 @@
  *	This symbol, if defined, indicates that the symlink routine is available
  *	to create symbolic links.
  */
-/*#define HAS_SYMLINK	/**/
+/*#define HAS_SYMLINK	/ **/
 
 /* HAS_SYSCALL:
  *	This symbol, if defined, indicates that the syscall routine is
@@ -1233,7 +1233,7 @@
  *	This symbol, if defined, indicates that the "fast stdio"
  *	is available to manipulate the stdio buffers directly.
  */
-/*#define HAS_FAST_STDIO		/**/
+/*#define HAS_FAST_STDIO		/ **/
 
 /* HAS_FCHDIR:
  *	This symbol, if defined, indicates that the fchdir routine is
@@ -1754,7 +1754,7 @@
  *	This symbol, if defined, indicates that the ilogbl routine is
  *	available.  If scalbnl is also present we can emulate frexpl.
  */
-/*#define HAS_ILOGBL		/**/
+/*#define HAS_ILOGBL		/ **/
 
 /* HAS_INT64_T:
  *     This symbol will defined if the C compiler supports int64_t.
@@ -2024,7 +2024,7 @@
  *	This symbol, if defined, indicates that the scalbnl routine is
  *	available.  If ilogbl is also present we can emulate frexpl.
  */
-/*#define HAS_SCALBNL		/**/
+/*#define HAS_SCALBNL		/ **/
 
 /* HAS_SENDMSG:
  *	This symbol, if defined, indicates that the sendmsg routine is
@@ -3549,13 +3549,13 @@
  *	This symbol, if defined, indicates that the copysignl routine is
  *	available.  If aintl is also present we can emulate modfl.
  */
-/*#define HAS_COPYSIGNL		/**/
+/*#define HAS_COPYSIGNL		/ **/
 
 /* USE_CPLUSPLUS:
  *	This symbol, if defined, indicates that a C++ compiler was
  *	used to compiled Perl and will be used to compile extensions.
  */
-/*#define USE_CPLUSPLUS		/**/
+/*#define USE_CPLUSPLUS		/ **/
 
 /* HAS_DBMINIT_PROTO:
  *	This symbol, if defined, indicates that the system provides

--- a/plan9/plan9ish.h
+++ b/plan9/plan9ish.h
@@ -25,14 +25,14 @@
  *	getgrgid() routines are available to get group entries.
  *	The getgrent() has a separate definition, HAS_GETGRENT.
  */
-/*#define HAS_GROUP		/**/
+/*#define HAS_GROUP		/ **/
 
 /* HAS_PASSWD
  *	This symbol, if defined, indicates that the getpwnam() and
  *	getpwuid() routines are available to get password entries.
  *	The getpwent() has a separate definition, HAS_GETPWENT.
  */
-/*#define HAS_PASSWD		/**/
+/*#define HAS_PASSWD		/ **/
 
 #define HAS_KILL
 #define HAS_WAIT
@@ -42,7 +42,7 @@
  *	to remove all versions of a file if unlink() is called.  This is
  *	probably only relevant for VMS.
  */
-/* #define UNLINK_ALL_VERSIONS		/**/
+/* #define UNLINK_ALL_VERSIONS		/ **/
 
 /* PLAN9:
  *	This symbol, if defined, indicates that the program is running under


### PR DESCRIPTION
The edits in this commit seem like the only ones remaining for #10059. I don't have the means to do a test build on plan9 though, or know how to reliably regenerate ./plan9/config_h.sample.

Don't mind if this PR is not applied, but just sits in GitHub for reference and #10059 is closed.