### PR TITLE
fix VC perlglob.exe segv with wrong default libc

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1268,9 +1268,9 @@ static: $(PERLEXESTATIC)
 
 $(GLOBEXE) : perlglob.c
 ifeq ($(CCTYPE),GCC)
-	$(LINK32) $(OPTIMIZE) $(BLINK_FLAGS) -mconsole -o $@ perlglob.c $(LIBFILES)
+	$(LINK32) $(EXTRACFLAGS) $(OPTIMIZE) $(BLINK_FLAGS) -mconsole -o $@ perlglob.c $(LIBFILES)
 else
-	$(CC) $(OPTIMIZE) $(PDBOUT) -Fe$@ perlglob.c -link $(BLINK_FLAGS) \
+	$(CC) $(EXTRACFLAGS) $(OPTIMIZE) $(PDBOUT) -Fe$@ perlglob.c -link $(BLINK_FLAGS) \
 	setargv$(o) $(LIBFILES) && $(EMBED_EXE_MANI)
 endif
 

--- a/win32/makefile.mk
+++ b/win32/makefile.mk
@@ -1216,9 +1216,9 @@ CHECKDMAKE :
 
 $(GLOBEXE) : perlglob.c
 .IF "$(CCTYPE)" == "GCC"
-	$(LINK32) $(OPTIMIZE) $(BLINK_FLAGS) -mconsole -o $@ perlglob.c $(LIBFILES)
+	$(LINK32) $(EXTRACFLAGS) $(OPTIMIZE) $(BLINK_FLAGS) -mconsole -o $@ perlglob.c $(LIBFILES)
 .ELSE
-	$(CC) $(OPTIMIZE) $(PDBOUT) -Fe$@ perlglob.c -link $(BLINK_FLAGS) \
+	$(CC) $(EXTRACFLAGS) $(OPTIMIZE) $(PDBOUT) -Fe$@ perlglob.c -link $(BLINK_FLAGS) \
 	setargv$(o) $(LIBFILES) && $(EMBED_EXE_MANI)
 .ENDIF
 

--- a/win32/perlglob.c
+++ b/win32/perlglob.c
@@ -20,6 +20,8 @@
 #include <stdio.h>
 #include <io.h>
 #include <fcntl.h>
+#include <assert.h>
+#include <limits.h>
 #include <string.h>
 #include <windows.h>
 
@@ -33,6 +35,7 @@ main(int argc, char *argv[])
     char volname[MAX_PATH];
     DWORD serial, maxname, flags;
     BOOL downcase = TRUE;
+    int fd;
 
     /* check out the file system characteristics */
     if (GetFullPathName(".", MAX_PATH, root, &dummy)) {
@@ -45,7 +48,13 @@ main(int argc, char *argv[])
 	}
     }
 
-    setmode(fileno(stdout), O_BINARY);
+    fd = fileno(stdout);
+    /* rare VC linker bug causes uninit global FILE *s
+       fileno() implementation in VC 2003 is 2 blind pointer derefs so it will
+       never return -1 error as POSIX says, to be compliant fail for -1 and
+       for absurdly high FDs which are actually pointers */
+    assert(fd >= 0 && fd < SHRT_MAX);
+    setmode(fd, O_BINARY);
     for (i = 1; i < argc; i++) {
 	len = strlen(argv[i]);
 	if (downcase)


### PR DESCRIPTION
commit "win32: separate $Config{ccflags} and $Config{optimize}"
4be1bfd74 removed -Md and -MDd from $(OPTIMIZE), so perlglob.exe whose
build recipe is special in that it is compiled and linked in 1 step lost
the -Md flag, this causes "stdout" global var that is linked in from MSVC
libc to resolve to a broken symbol and segv since the FILE * is a pointer
to machine code instead to a FILE struct in the CRT DLL. This is with MSVC
2003 32b CC.

Disassembly shows that after that commit perlglob.exe is
push    8000h
mov     edi, offset __imp____getmainargs
push    edi             ; File
call    _fileno_0

which is a pointer to machine code instead of

mov     eax, ds:__imp___iob
add     eax, 20h
push    8000h           ; int
push    eax             ; File
call    ds:__imp___fileno

where _iob is a pointer to start of static global array of FH structs in
MS CRT.

-Md controls ".drectve" section in .obj file that contains
"/DEFAULTLIB:"MSVCRT"" (proper) or "/DEFAULTLIB:"LIBC"" (SEGV)

crash stack
ntdll.dll!_RtlpWaitForCriticalSection@4
ntdll.dll!_RtlEnterCriticalSection@4
msvcr71.dll!_lock_file
msvcr71.dll!fwrite
perlglob.exe!main
perlglob.exe!mainCRTStartup
kernel32.dll!_BaseProcessStart@4

The CS struct is gibberish because the FILE * is gibberish.