### PR TITLE
op.h -reorder pmop to close alignment holes on x86-64

### DIFF
--- a/op.h
+++ b/op.h
@@ -250,6 +250,7 @@ struct methop {
 
 struct pmop {
     BASEOP
+    U32         op_pmflags;
     OP *	op_first;
     OP *	op_last;
 #ifdef USE_ITHREADS
@@ -257,7 +258,6 @@ struct pmop {
 #else
     REGEXP *    op_pmregexp;            /* compiled expression */
 #endif
-    U32         op_pmflags;
     union {
 	OP *	op_pmreplroot;		/* For OP_SUBST */
 	PADOFFSET op_pmtargetoff;	/* For OP_SPLIT lex ary or thr GV */


### PR DESCRIPTION
As outlined in #17576, the _pahole_ tool shows alignment holes on x86-64. This commit moves the **op_pmflags** member of the **pmop** struct, saving 8 bytes on that architecture. 

I'm not sure if this change could be detrimental for other architectures, or what the best time in the release cycle would be to apply this kind of change.

pahole analysis before this change:
```
struct pmop {
	OP *                       op_next;              /*     0     8 */
	OP *                       op_sibparent;         /*     8     8 */
	OP *                       (*op_ppaddr)(void);   /*    16     8 */
	PADOFFSET                  op_targ;              /*    24     8 */
	U16                        op_type:9;            /*    32: 0  2 */
	U16                        op_opt:1;             /*    32: 9  2 */
	U16                        op_slabbed:1;         /*    32:10  2 */
	U16                        op_savefree:1;        /*    32:11  2 */
	U16                        op_static:1;          /*    32:12  2 */
	U16                        op_folded:1;          /*    32:13  2 */
	U16                        op_moresib:1;         /*    32:14  2 */
	U16                        op_spare:1;           /*    32:15  2 */
	U8                         op_flags;             /*    34     1 */
	U8                         op_private;           /*    35     1 */

	/* XXX 4 bytes hole, try to pack */

	OP *                       op_first;             /*    40     8 */
	OP *                       op_last;              /*    48     8 */
	REGEXP *                   op_pmregexp;          /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	U32                        op_pmflags;           /*    64     4 */

	/* XXX 4 bytes hole, try to pack */

	union {
		OP *               op_pmreplroot;        /*    72     8 */
		PADOFFSET          op_pmtargetoff;       /*    72     8 */
		GV *               op_pmtargetgv;        /*    72     8 */
	} op_pmreplrootu;                                /*    72     8 */
	union {
		OP *               op_pmreplstart;       /*    80     8 */
		HV *               op_pmstash;           /*    80     8 */
	} op_pmstashstartu;                              /*    80     8 */
	OP *                       op_code_list;         /*    88     8 */

	/* size: 96, cachelines: 2, members: 21 */
	/* sum members: 86, holes: 2, sum holes: 8 */
	/* sum bitfield members: 16 bits (2 bytes) */
	/* last cacheline: 32 bytes */
};
```
This change closes the 2x 4 bytes holes.
