### PR TITLE
parser.h -reorder yy_parser to close x86-64 alignment holes

### DIFF
--- a/parser.h
+++ b/parser.h
@@ -42,13 +42,14 @@ typedef struct yy_parser {
     /* Number of tokens to shift before error messages enabled.  */
     int		    yyerrstatus;
 
-    int		    yylen;	/* length of active reduction */
     yy_stack_frame  *stack;	/* base of stack */
     yy_stack_frame  *stack_max1;/* (top-1)th element of allocated stack */
     yy_stack_frame  *ps;	/* current stack frame */
+    int		    yylen;	/* length of active reduction */
 
     /* lexer state */
 
+    I32		lex_formbrack;	/* bracket count at outer format level */
     I32		lex_brackets;	/* square and curly bracket count */
     I32		lex_casemods;	/* casemod count */
     char	*lex_brackstack;/* what kind of brackets to pop */
@@ -59,7 +60,7 @@ typedef struct yy_parser {
     U8		expect;		/* how to interpret ambiguous tokens */
     bool	preambled;
     bool        sub_no_recover; /* can't recover from a sublex error */
-    I32		lex_formbrack;	/* bracket count at outer format level */
+    U8		sub_error_count; /* the number of errors before sublexing */
     OP		*lex_inpat;	/* in pattern $) and $| are special */
     OP		*lex_op;	/* extra info to pass back on op */
     SV		*lex_repl;	/* runtime replacement from s/// */
@@ -96,7 +97,6 @@ typedef struct yy_parser {
     U16		in_my;		/* we're compiling a "my"/"our" declaration */
     U8		lex_state;	/* next token is determined */
     U8		error_count;	/* how many compile errors so far, max 10 */
-    U8		sub_error_count; /* the number of errors before sublexing */
     HV		*in_my_stash;	/* declared class of this "my" declaration */
     PerlIO	*rsfp;		/* current source file pointer */
     AV		*rsfp_filters;	/* holds chain of active source filters */
@@ -112,11 +112,11 @@ typedef struct yy_parser {
     line_t	herelines;	/* number of lines in here-doc */
     line_t	preambling;	/* line # when processing $ENV{PERL5DB} */
 
-    bool        sig_seen;       /* the currently parsing sub has a signature */
     /* these are valid while parsing a subroutine signature */
     UV          sig_elems;      /* number of signature elements seen so far */
     UV          sig_optelems;   /* number of optional signature elems seen */
     char        sig_slurpy;     /* the sigil of the slurpy var (or null) */
+    bool        sig_seen;       /* the currently parsing sub has a signature */
 
     bool        recheck_utf8_validity;
 


### PR DESCRIPTION
As outlined in #17576, the pahole tool shows alignment holes on x86-64. This commit moves 4 members of the **yy_parser** struct, saving 24 bytes and potentially a cacheline.

I'm not sure if this change could be detrimental for other architectures, or what the best time in the release cycle would be to apply this kind of change.

Also, I tried to move things sympathetically, but apologies if the moves break up deliberate orderings/groupings.

pahole analysis before these changes:
```
struct yy_parser {
	struct yy_parser *         old_parser;           /*     0     8 */
	YYSTYPE                    yylval;               /*     8     8 */
	int                        yychar;               /*    16     4 */
	int                        yyerrstatus;          /*    20     4 */
	int                        yylen;                /*    24     4 */

	/* XXX 4 bytes hole, try to pack */

	yy_stack_frame *           stack;                /*    32     8 */
	yy_stack_frame *           stack_max1;           /*    40     8 */
	yy_stack_frame *           ps;                   /*    48     8 */
	I32                        lex_brackets;         /*    56     4 */
	I32                        lex_casemods;         /*    60     4 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	char *                     lex_brackstack;       /*    64     8 */
	char *                     lex_casestack;        /*    72     8 */
	U8                         lex_defer;            /*    80     1 */
	U8                         lex_dojoin;           /*    81     1 */
	U8                         expect;               /*    82     1 */
	_Bool                      preambled;            /*    83     1 */
	_Bool                      sub_no_recover;       /*    84     1 */

	/* XXX 3 bytes hole, try to pack */

	I32                        lex_formbrack;        /*    88     4 */

	/* XXX 4 bytes hole, try to pack */

	OP *                       lex_inpat;            /*    96     8 */
	OP *                       lex_op;               /*   104     8 */
	SV *                       lex_repl;             /*   112     8 */
	U16                        lex_inwhat;           /*   120     2 */
	U16                        last_lop_op;          /*   122     2 */
	I32                        lex_starts;           /*   124     4 */
	/* --- cacheline 2 boundary (128 bytes) --- */
	SV *                       lex_stuff;            /*   128     8 */
	I32                        multi_start;          /*   136     4 */
	I32                        multi_end;            /*   140     4 */
	UV                         multi_open;           /*   144     8 */
	UV                         multi_close;          /*   152     8 */
	_Bool                      lex_re_reparsing;     /*   160     1 */
	U8                         lex_super_state;      /*   161     1 */
	U16                        lex_sub_inwhat;       /*   162     2 */
	I32                        lex_allbrackets;      /*   164     4 */
	OP *                       lex_sub_op;           /*   168     8 */
	SV *                       lex_sub_repl;         /*   176     8 */
	LEXSHARED *                lex_shared;           /*   184     8 */
	/* --- cacheline 3 boundary (192 bytes) --- */
	SV *                       linestr;              /*   192     8 */
	char *                     bufptr;               /*   200     8 */
	char *                     oldbufptr;            /*   208     8 */
	char *                     oldoldbufptr;         /*   216     8 */
	char *                     bufend;               /*   224     8 */
	char *                     linestart;            /*   232     8 */
	char *                     last_uni;             /*   240     8 */
	char *                     last_lop;             /*   248     8 */
	/* --- cacheline 4 boundary (256 bytes) --- */
	line_t                     copline;              /*   256     4 */
	U16                        in_my;                /*   260     2 */
	U8                         lex_state;            /*   262     1 */
	U8                         error_count;          /*   263     1 */
	U8                         sub_error_count;      /*   264     1 */

	/* XXX 7 bytes hole, try to pack */

	HV *                       in_my_stash;          /*   272     8 */
	PerlIO *                   rsfp;                 /*   280     8 */
	AV *                       rsfp_filters;         /*   288     8 */
	YYSTYPE                    nextval[5];           /*   296    40 */
	/* --- cacheline 5 boundary (320 bytes) was 16 bytes ago --- */
	I32                        nexttype[5];          /*   336    20 */
	U8                         nexttoke;             /*   356     1 */
	U8                         form_lex_state;       /*   357     1 */
	U8                         lex_fakeeof;          /*   358     1 */
	U8                         lex_flags;            /*   359     1 */
	COP *                      saved_curcop;         /*   360     8 */
	char                       tokenbuf[256];        /*   368   256 */
	/* --- cacheline 9 boundary (576 bytes) was 48 bytes ago --- */
	line_t                     herelines;            /*   624     4 */
	line_t                     preambling;           /*   628     4 */
	_Bool                      sig_seen;             /*   632     1 */

	/* XXX 7 bytes hole, try to pack */

	/* --- cacheline 10 boundary (640 bytes) --- */
	UV                         sig_elems;            /*   640     8 */
	UV                         sig_optelems;         /*   648     8 */
	char                       sig_slurpy;           /*   656     1 */
	_Bool                      recheck_utf8_validity; /*   657     1 */
	U16                        in_pod:1;             /*   658: 0  2 */
	U16                        filtered:1;           /*   658: 1  2 */
	U16                        saw_infix_sigil:1;    /*   658: 2  2 */
	U16                        parsed_sub:1;         /*   658: 3  2 */

	/* size: 664, cachelines: 11, members: 71 */
	/* sum members: 633, holes: 5, sum holes: 25 */
	/* sum bitfield members: 4 bits (0 bytes) */
	/* padding: 4 */
	/* bit_padding: 12 bits */
	/* last cacheline: 24 bytes */
};
```
pahole analysis after these changes:
```
struct yy_parser {
	struct yy_parser *         old_parser;           /*     0     8 */
	YYSTYPE                    yylval;               /*     8     8 */
	int                        yychar;               /*    16     4 */
	int                        yyerrstatus;          /*    20     4 */
	yy_stack_frame *           stack;                /*    24     8 */
	yy_stack_frame *           stack_max1;           /*    32     8 */
	yy_stack_frame *           ps;                   /*    40     8 */
	int                        yylen;                /*    48     4 */
	I32                        lex_formbrack;        /*    52     4 */
	I32                        lex_brackets;         /*    56     4 */
	I32                        lex_casemods;         /*    60     4 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	char *                     lex_brackstack;       /*    64     8 */
	char *                     lex_casestack;        /*    72     8 */
	U8                         lex_defer;            /*    80     1 */
	U8                         lex_dojoin;           /*    81     1 */
	U8                         expect;               /*    82     1 */
	_Bool                      preambled;            /*    83     1 */
	_Bool                      sub_no_recover;       /*    84     1 */
	U8                         sub_error_count;      /*    85     1 */

	/* XXX 2 bytes hole, try to pack */

	OP *                       lex_inpat;            /*    88     8 */
	OP *                       lex_op;               /*    96     8 */
	SV *                       lex_repl;             /*   104     8 */
	U16                        lex_inwhat;           /*   112     2 */
	U16                        last_lop_op;          /*   114     2 */
	I32                        lex_starts;           /*   116     4 */
	SV *                       lex_stuff;            /*   120     8 */
	/* --- cacheline 2 boundary (128 bytes) --- */
	I32                        multi_start;          /*   128     4 */
	I32                        multi_end;            /*   132     4 */
	UV                         multi_open;           /*   136     8 */
	UV                         multi_close;          /*   144     8 */
	_Bool                      lex_re_reparsing;     /*   152     1 */
	U8                         lex_super_state;      /*   153     1 */
	U16                        lex_sub_inwhat;       /*   154     2 */
	I32                        lex_allbrackets;      /*   156     4 */
	OP *                       lex_sub_op;           /*   160     8 */
	SV *                       lex_sub_repl;         /*   168     8 */
	LEXSHARED *                lex_shared;           /*   176     8 */
	SV *                       linestr;              /*   184     8 */
	/* --- cacheline 3 boundary (192 bytes) --- */
	char *                     bufptr;               /*   192     8 */
	char *                     oldbufptr;            /*   200     8 */
	char *                     oldoldbufptr;         /*   208     8 */
	char *                     bufend;               /*   216     8 */
	char *                     linestart;            /*   224     8 */
	char *                     last_uni;             /*   232     8 */
	char *                     last_lop;             /*   240     8 */
	line_t                     copline;              /*   248     4 */
	U16                        in_my;                /*   252     2 */
	U8                         lex_state;            /*   254     1 */
	U8                         error_count;          /*   255     1 */
	/* --- cacheline 4 boundary (256 bytes) --- */
	HV *                       in_my_stash;          /*   256     8 */
	PerlIO *                   rsfp;                 /*   264     8 */
	AV *                       rsfp_filters;         /*   272     8 */
	YYSTYPE                    nextval[5];           /*   280    40 */
	/* --- cacheline 5 boundary (320 bytes) --- */
	I32                        nexttype[5];          /*   320    20 */
	U8                         nexttoke;             /*   340     1 */
	U8                         form_lex_state;       /*   341     1 */
	U8                         lex_fakeeof;          /*   342     1 */
	U8                         lex_flags;            /*   343     1 */
	COP *                      saved_curcop;         /*   344     8 */
	char                       tokenbuf[256];        /*   352   256 */
	/* --- cacheline 9 boundary (576 bytes) was 32 bytes ago --- */
	line_t                     herelines;            /*   608     4 */
	line_t                     preambling;           /*   612     4 */
	UV                         sig_elems;            /*   616     8 */
	UV                         sig_optelems;         /*   624     8 */
	char                       sig_slurpy;           /*   632     1 */
	_Bool                      sig_seen;             /*   633     1 */
	_Bool                      recheck_utf8_validity; /*   634     1 */

	/* Bitfield combined with previous fields */

	U16                        in_pod:1;             /*   634: 8  2 */
	U16                        filtered:1;           /*   634: 9  2 */
	U16                        saw_infix_sigil:1;    /*   634:10  2 */
	U16                        parsed_sub:1;         /*   634:11  2 */

	/* size: 640, cachelines: 10, members: 71 */
	/* sum members: 633, holes: 1, sum holes: 2 */
	/* sum bitfield members: 4 bits (0 bytes) */
	/* padding: 4 */
	/* bit_padding: 4 bits */
};
```
