### PR TITLE
regcomp.c -reorder RExC_state_t to close x86-64 alignment holes

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -139,11 +139,16 @@ struct RExC_state_t {
     regnode_offset emit;		/* Code-emit pointer */
     I32		naughty;		/* How bad is this pattern? */
     I32		sawback;		/* Did we see \1, ...? */
-    U32		seen;
     SSize_t	size;			/* Number of regnode equivalents in
                                            pattern */
     Size_t      sets_depth;              /* Counts recursion depth of already-
                                            compiled regex set patterns */
+    U32		seen;
+
+    I32      parens_buf_size;           /* #slots malloced open/close_parens */
+    regnode_offset *open_parens;	/* offsets to open parens */
+    regnode_offset *close_parens;	/* offsets to close parens */
+    HV		*paren_names;		/* Paren names */
 
     /* position beyond 'precomp' of the warning message furthest away from
      * 'precomp'.  During the parse, no warnings are raised for any problems
@@ -164,9 +169,6 @@ struct RExC_state_t {
     I32		nestroot;		/* root parens we are in - used by
                                            accept */
     I32		seen_zerolen;
-    regnode_offset *open_parens;	/* offsets to open parens */
-    regnode_offset *close_parens;	/* offsets to close parens */
-    I32      parens_buf_size;           /* #slots malloced open/close_parens */
     regnode     *end_op;                /* END node in program */
     I32		utf8;		/* whether the pattern is utf8 or not */
     I32		orig_utf8;	/* whether the pattern was originally in utf8 */
@@ -175,10 +177,9 @@ struct RExC_state_t {
     I32		uni_semantics;	/* If a d charset modifier should use unicode
 				   rules, even if the pattern is not in
 				   utf8 */
-    HV		*paren_names;		/* Paren names */
 
-    regnode	**recurse;		/* Recurse regops */
     I32         recurse_count;          /* Number of recurse regops we have generated */
+    regnode	**recurse;		/* Recurse regops */
     U8          *study_chunk_recursed;  /* bitmap of which subs we have moved
                                            through */
     U32         study_chunk_recursed_bytes;  /* bytes in bitmap */
@@ -188,9 +189,9 @@ struct RExC_state_t {
     I32		override_recoding;
     I32         recode_x_to_native;
     I32		in_multi_char_class;
+    int		code_index;		/* next code_blocks[] slot */
     struct reg_code_blocks *code_blocks;/* positions of literal (?{})
 					    within pattern */
-    int		code_index;		/* next code_blocks[] slot */
     SSize_t     maxlen;                        /* mininum possible number of chars in string to match */
     scan_frame *frame_head;
     scan_frame *frame_last;
@@ -205,8 +206,8 @@ struct RExC_state_t {
 #ifdef DEBUGGING
     const char  *lastparse;
     I32         lastnum;
-    AV          *paren_name_list;       /* idx -> name */
     U32         study_chunk_recursed_count;
+    AV          *paren_name_list;       /* idx -> name */
     SV          *mysv1;
     SV          *mysv2;
 


### PR DESCRIPTION
As outlined in #17576, the pahole tool shows alignment holes on x86-64. This commit moves members of the **RExC_state_t** struct, saving 24 bytes (non-debugging builds) or 32 bytes and potentially a cacheline (debugging builds), on this architecture.

I'm not sure if this change could be detrimental for other architectures, or what the best time in the release cycle would be to apply this kind of change.

Also, I tried to move things sympathetically, but apologies if the moves break up deliberate orderings/groupings.

pahole analysis before these changes:
```
struct RExC_state_t {
	U32                        flags;                /*     0     4 */
	U32                        pm_flags;             /*     4     4 */
	char *                     precomp;              /*     8     8 */
	char *                     precomp_end;          /*    16     8 */
	REGEXP *                   rx_sv;                /*    24     8 */
	regexp *                   rx;                   /*    32     8 */
	regexp_internal *          rxi;                  /*    40     8 */
	char *                     start;                /*    48     8 */
	char *                     end;                  /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	char *                     parse;                /*    64     8 */
	char *                     copy_start;           /*    72     8 */
	char *                     save_copy_start;      /*    80     8 */
	char *                     copy_start_in_input;  /*    88     8 */
	ssize_t                    whilem_seen;          /*    96     8 */
	regnode *                  emit_start;           /*   104     8 */
	regnode_offset             emit;                 /*   112     8 */
	I32                        naughty;              /*   120     4 */
	I32                        sawback;              /*   124     4 */
	/* --- cacheline 2 boundary (128 bytes) --- */
	U32                        seen;                 /*   128     4 */

	/* XXX 4 bytes hole, try to pack */

	ssize_t                    size;                 /*   136     8 */
	size_t                     sets_depth;           /*   144     8 */
	size_t                     latest_warn_offset;   /*   152     8 */
	I32                        npar;                 /*   160     4 */
	I32                        total_par;            /*   164     4 */
	I32                        nestroot;             /*   168     4 */
	I32                        seen_zerolen;         /*   172     4 */
	regnode_offset *           open_parens;          /*   176     8 */
	regnode_offset *           close_parens;         /*   184     8 */
	/* --- cacheline 3 boundary (192 bytes) --- */
	I32                        parens_buf_size;      /*   192     4 */

	/* XXX 4 bytes hole, try to pack */

	regnode *                  end_op;               /*   200     8 */
	I32                        utf8;                 /*   208     4 */
	I32                        orig_utf8;            /*   212     4 */
	I32                        uni_semantics;        /*   216     4 */

	/* XXX 4 bytes hole, try to pack */

	HV *                       paren_names;          /*   224     8 */
	regnode * *                recurse;              /*   232     8 */
	I32                        recurse_count;        /*   240     4 */

	/* XXX 4 bytes hole, try to pack */

	U8 *                       study_chunk_recursed; /*   248     8 */
	/* --- cacheline 4 boundary (256 bytes) --- */
	U32                        study_chunk_recursed_bytes; /*   256     4 */
	I32                        in_lookbehind;        /*   260     4 */
	I32                        in_lookahead;         /*   264     4 */
	I32                        contains_locale;      /*   268     4 */
	I32                        override_recoding;    /*   272     4 */
	I32                        recode_x_to_native;   /*   276     4 */
	I32                        in_multi_char_class;  /*   280     4 */

	/* XXX 4 bytes hole, try to pack */

	struct reg_code_blocks *   code_blocks;          /*   288     8 */
	int                        code_index;           /*   296     4 */

	/* XXX 4 bytes hole, try to pack */

	ssize_t                    maxlen;               /*   304     8 */
	scan_frame *               frame_head;           /*   312     8 */
	/* --- cacheline 5 boundary (320 bytes) --- */
	scan_frame *               frame_last;           /*   320     8 */
	U32                        frame_count;          /*   328     4 */

	/* XXX 4 bytes hole, try to pack */

	AV *                       warn_text;            /*   336     8 */
	HV *                       unlexed_names;        /*   344     8 */
	SV *                       runtime_code_qr;      /*   352     8 */
#ifdef DEBUGGING <---- manually added this to show that the holes below only appear in DEBUGGING builds
	const char  *              lastparse;            /*   360     8 */
	I32                        lastnum;              /*   368     4 */

	/* XXX 4 bytes hole, try to pack */

	AV *                       paren_name_list;      /*   376     8 */
	/* --- cacheline 6 boundary (384 bytes) --- */
	U32                        study_chunk_recursed_count; /*   384     4 */

	/* XXX 4 bytes hole, try to pack */

	SV *                       mysv1;                /*   392     8 */
	SV *                       mysv2;                /*   400     8 */
#endif  <---- manually added this to show that the holes above only appear in DEBUGGING builds
	_Bool                      seen_d_op;            /*   408     1 */
	_Bool                      strict;               /*   409     1 */
	_Bool                      study_started;        /*   410     1 */
	_Bool                      in_script_run;        /*   411     1 */
	_Bool                      use_BRANCHJ;          /*   412     1 */
	_Bool                      sWARN_EXPERIMENTAL__VLB; /*   413     1 */
	_Bool                      sWARN_EXPERIMENTAL__REGEX_SETS; /*   414     1 */

	/* size: 416, cachelines: 7, members: 66 */
	/* sum members: 379, holes: 9, sum holes: 36 */
	/* padding: 1 */
	/* last cacheline: 32 bytes */
};
```
pahole analysis after these changes:
```
struct RExC_state_t {
	U32                        flags;                /*     0     4 */
	U32                        pm_flags;             /*     4     4 */
	char *                     precomp;              /*     8     8 */
	char *                     precomp_end;          /*    16     8 */
	REGEXP *                   rx_sv;                /*    24     8 */
	regexp *                   rx;                   /*    32     8 */
	regexp_internal *          rxi;                  /*    40     8 */
	char *                     start;                /*    48     8 */
	char *                     end;                  /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	char *                     parse;                /*    64     8 */
	char *                     copy_start;           /*    72     8 */
	char *                     save_copy_start;      /*    80     8 */
	char *                     copy_start_in_input;  /*    88     8 */
	ssize_t                    whilem_seen;          /*    96     8 */
	regnode *                  emit_start;           /*   104     8 */
	regnode_offset             emit;                 /*   112     8 */
	I32                        naughty;              /*   120     4 */
	I32                        sawback;              /*   124     4 */
	/* --- cacheline 2 boundary (128 bytes) --- */
	ssize_t                    size;                 /*   128     8 */
	size_t                     sets_depth;           /*   136     8 */
	U32                        seen;                 /*   144     4 */
	I32                        parens_buf_size;      /*   148     4 */
	regnode_offset *           open_parens;          /*   152     8 */
	regnode_offset *           close_parens;         /*   160     8 */
	HV *                       paren_names;          /*   168     8 */
	size_t                     latest_warn_offset;   /*   176     8 */
	I32                        npar;                 /*   184     4 */
	I32                        total_par;            /*   188     4 */
	/* --- cacheline 3 boundary (192 bytes) --- */
	I32                        nestroot;             /*   192     4 */
	I32                        seen_zerolen;         /*   196     4 */
	regnode *                  end_op;               /*   200     8 */
	I32                        utf8;                 /*   208     4 */
	I32                        orig_utf8;            /*   212     4 */
	I32                        uni_semantics;        /*   216     4 */
	I32                        recurse_count;        /*   220     4 */
	regnode * *                recurse;              /*   224     8 */
	U8 *                       study_chunk_recursed; /*   232     8 */
	U32                        study_chunk_recursed_bytes; /*   240     4 */
	I32                        in_lookbehind;        /*   244     4 */
	I32                        in_lookahead;         /*   248     4 */
	I32                        contains_locale;      /*   252     4 */
	/* --- cacheline 4 boundary (256 bytes) --- */
	I32                        override_recoding;    /*   256     4 */
	I32                        recode_x_to_native;   /*   260     4 */
	I32                        in_multi_char_class;  /*   264     4 */
	int                        code_index;           /*   268     4 */
	struct reg_code_blocks *   code_blocks;          /*   272     8 */
	ssize_t                    maxlen;               /*   280     8 */
	scan_frame *               frame_head;           /*   288     8 */
	scan_frame *               frame_last;           /*   296     8 */
	U32                        frame_count;          /*   304     4 */

	/* XXX 4 bytes hole, try to pack */

	AV *                       warn_text;            /*   312     8 */
	/* --- cacheline 5 boundary (320 bytes) --- */
	HV *                       unlexed_names;        /*   320     8 */
	SV *                       runtime_code_qr;      /*   328     8 */
#ifdef DEBUGGING <---- manually added this to show that the holes [previously] below only appear in DEBUGGING builds
	const char  *              lastparse;            /*   336     8 */
	I32                        lastnum;              /*   344     4 */
	U32                        study_chunk_recursed_count; /*   348     4 */
	AV *                       paren_name_list;      /*   352     8 */
	SV *                       mysv1;                /*   360     8 */
	SV *                       mysv2;                /*   368     8 */
#endif  <---- manually added this to show that the holes [previously] above only appear in DEBUGGING builds
	_Bool                      seen_d_op;            /*   376     1 */
	_Bool                      strict;               /*   377     1 */
	_Bool                      study_started;        /*   378     1 */
	_Bool                      in_script_run;        /*   379     1 */
	_Bool                      use_BRANCHJ;          /*   380     1 */
	_Bool                      sWARN_EXPERIMENTAL__VLB; /*   381     1 */
	_Bool                      sWARN_EXPERIMENTAL__REGEX_SETS; /*   382     1 */

	/* size: 384, cachelines: 6, members: 66 */
	/* sum members: 379, holes: 1, sum holes: 4 */
	/* padding: 1 */
};
```
