### PR TITLE
regcomp.h -reorder regexp_internal to close x86-64 alignment holes

### DIFF
--- a/regcomp.h
+++ b/regcomp.h
@@ -95,7 +95,6 @@
    private to the engine itself. It now lives here. */
 
  typedef struct regexp_internal {
-        int name_list_idx;	/* Optional data index of an array of paren names */
         union {
 	    U32 *offsets;           /* offset annotations 20001228 MJD
                                        data about mapping the program to the
@@ -112,6 +111,7 @@
                                    data that the regops need. Often the ARG field of
                                    a regop is an index into this structure */
 	struct reg_code_blocks *code_blocks;/* positions of literal (?{}) */
+        int name_list_idx;	/* Optional data index of an array of paren names */
 	regnode program[1];	/* Unwarranted chumminess with compiler. */
 } regexp_internal;
 


### PR DESCRIPTION
As outlined in #17576, the pahole tool shows alignment holes on x86-64. This commit moves the **name_list_idx** member of the **regexp_internal** struct, saving 8 bytes on that architecture.

I'm not sure if this change could be detrimental for other architectures, or what the best time in the release cycle would be to apply this kind of change.

pahole analysis before this change:
```
struct regexp_internal {
	int                        name_list_idx;        /*     0     4 */

	/* XXX 4 bytes hole, try to pack */

	union {
		U32 *              offsets;              /*     8     8 */
		U32                proglen;              /*     8     4 */
	} u;                                             /*     8     8 */
	regnode *                  regstclass;           /*    16     8 */
	struct reg_data *          data;                 /*    24     8 */
	struct reg_code_blocks *   code_blocks;          /*    32     8 */
	regnode                    program[1];           /*    40     4 */

	/* size: 48, cachelines: 1, members: 6 */
	/* sum members: 40, holes: 1, sum holes: 4 */
	/* padding: 4 */
	/* last cacheline: 48 bytes */
};
```
pahole analysis after this change:
```
struct regexp_internal {
	union {
		U32 *              offsets;              /*     0     8 */
		U32                proglen;              /*     0     4 */
	} u;                                             /*     0     8 */
	regnode *                  regstclass;           /*     8     8 */
	struct reg_data *          data;                 /*    16     8 */
	struct reg_code_blocks *   code_blocks;          /*    24     8 */
	int                        name_list_idx;        /*    32     4 */
	regnode                    program[1];           /*    36     4 */

	/* size: 40, cachelines: 1, members: 6 */
	/* last cacheline: 40 bytes */
};
```