### PR TITLE
regexp.h -reorder regexp to close x86-64 alignment holes

### DIFF
--- a/regexp.h
+++ b/regexp.h
@@ -118,40 +118,28 @@ typedef struct regexp {
      */
 
     U32 extflags;      /* Flags used both externally and internally */
+    U32 nparens;       /* number of capture buffers */
     SSize_t minlen;    /* minimum possible number of chars in string to match */
     SSize_t minlenret; /* mininum possible number of chars in $& */
     STRLEN gofs;       /* chars left of pos that we search from */
                        /* substring data about strings that must appear in
                         * the final match, used for optimisations */
     struct reg_substr_data *substrs;
-    U32 nparens;       /* number of capture buffers */
 
     /* private engine specific data */
 
-    U32 intflags;      /* Engine Specific Internal flags */
     void *pprivate;    /* Data private to the regex engine which
                         * created this object. */
+    U32 intflags;      /* Engine Specific Internal flags */
 
     /*----------------------------------------------------------------------
      * Data about the last/current match. These are modified during matching
      */
 
     U32 lastparen;           /* highest close paren matched ($+) */
-    U32 lastcloseparen;      /* last close paren matched ($^N) */
     regexp_paren_pair *offs; /* Array of offsets for (@-) and (@+) */
     char **recurse_locinput; /* used to detect infinite recursion, XXX: move to internal */
-
-    /*---------------------------------------------------------------------- */
-
-    char *subbeg;       /* saved or original string so \digit works forever. */
-    SV_SAVED_COPY       /* If non-NULL, SV which is COW from original */
-    SSize_t sublen;     /* Length of string pointed by subbeg */
-    SSize_t suboffset;  /* byte offset of subbeg from logical start of str */
-    SSize_t subcoffset; /* suboffset equiv, but in chars (for @-/@+) */
-
-    /* Information about the match that isn't often used */
-
-    SSize_t maxlen;  /* minimum possible number of chars in string to match */
+    U32 lastcloseparen;      /* last close paren matched ($^N) */
 
     /*---------------------------------------------------------------------- */
 
@@ -163,6 +151,19 @@ typedef struct regexp {
     PERL_BITFIELD32 compflags:9;
 
     /*---------------------------------------------------------------------- */
+
+    SV_SAVED_COPY       /* If non-NULL, SV which is COW from original */
+    SSize_t sublen;     /* Length of string pointed by subbeg */
+    SSize_t suboffset;  /* byte offset of subbeg from logical start of str */
+    SSize_t subcoffset; /* suboffset equiv, but in chars (for @-/@+) */
+
+    /* Information about the match that isn't often used */
+
+    SSize_t maxlen;  /* minimum possible number of chars in string to match */
+    char *subbeg;       /* saved or original string so \digit works forever. */
+
+    /*---------------------------------------------------------------------- */
+
 
     CV *qr_anoncv;      /* the anon sub wrapped round qr/(?{..})/ */
 } regexp;

--- a/regexp.h
+++ b/regexp.h
@@ -152,6 +152,7 @@ typedef struct regexp {
 
     /*---------------------------------------------------------------------- */
 
+    char *subbeg;       /* saved or original string so \digit works forever. */
     SV_SAVED_COPY       /* If non-NULL, SV which is COW from original */
     SSize_t sublen;     /* Length of string pointed by subbeg */
     SSize_t suboffset;  /* byte offset of subbeg from logical start of str */
@@ -160,7 +161,6 @@ typedef struct regexp {
     /* Information about the match that isn't often used */
 
     SSize_t maxlen;  /* minimum possible number of chars in string to match */
-    char *subbeg;       /* saved or original string so \digit works forever. */
 
     /*---------------------------------------------------------------------- */
 


### PR DESCRIPTION
As outlined in #17576, the pahole tool shows alignment holes on x86-64. This commit moves 6 members of the **regexp** struct, saving 8 bytes and potentially a cacheline.

I'm not sure if this change could be detrimental for other architectures, or what the best time in the release cycle would be to apply this kind of change.

Also, I tried to move things sympathetically, but apologies if the moves break up deliberate orderings/groupings.

pahole analysis before these changes:
```
struct regexp {
	HV *                       xmg_stash;            /*     0     8 */
	union _xmgu        xmg_u;                        /*     8     8 */
	STRLEN                     xpv_cur;              /*    16     8 */
	union {
		STRLEN             xpvlenu_len;          /*    24     8 */
		struct regexp *    xpvlenu_rx;           /*    24     8 */
	} xpv_len_u;                                     /*    24     8 */
	const struct regexp_engine  * engine;            /*    32     8 */
	REGEXP *                   mother_re;            /*    40     8 */
	HV *                       paren_names;          /*    48     8 */
	U32                        extflags;             /*    56     4 */

	/* XXX 4 bytes hole, try to pack */

	/* --- cacheline 1 boundary (64 bytes) --- */
	ssize_t                    minlen;               /*    64     8 */
	ssize_t                    minlenret;            /*    72     8 */
	STRLEN                     gofs;                 /*    80     8 */
	struct reg_substr_data *   substrs;              /*    88     8 */
	U32                        nparens;              /*    96     4 */
	U32                        intflags;             /*   100     4 */
	void *                     pprivate;             /*   104     8 */
	U32                        lastparen;            /*   112     4 */
	U32                        lastcloseparen;       /*   116     4 */
	regexp_paren_pair *        offs;                 /*   120     8 */
	/* --- cacheline 2 boundary (128 bytes) --- */
	char * *                   recurse_locinput;     /*   128     8 */
	char *                     subbeg;               /*   136     8 */
	SV *                       saved_copy;           /*   144     8 */
	ssize_t                    sublen;               /*   152     8 */
	ssize_t                    suboffset;            /*   160     8 */
	ssize_t                    subcoffset;           /*   168     8 */
	ssize_t                    maxlen;               /*   176     8 */
	U32                        pre_prefix:4;         /*   184: 0  4 */
	U32                        compflags:9;          /*   184: 4  4 */

	/* XXX 19 bits hole, try to pack */
	/* XXX 4 bytes hole, try to pack */

	/* --- cacheline 3 boundary (192 bytes) --- */
	CV *                       qr_anoncv;            /*   192     8 */

	/* size: 200, cachelines: 4, members: 28 */
	/* sum members: 188, holes: 2, sum holes: 8 */
	/* sum bitfield members: 13 bits, bit holes: 1, sum bit holes: 19 bits */
	/* last cacheline: 8 bytes */
};
```

pahole analysis after these changes:
```
struct regexp {
	HV *                       xmg_stash;            /*     0     8 */
	union _xmgu        xmg_u;                        /*     8     8 */
	STRLEN                     xpv_cur;              /*    16     8 */
	union {
		STRLEN             xpvlenu_len;          /*    24     8 */
		struct regexp *    xpvlenu_rx;           /*    24     8 */
	} xpv_len_u;                                     /*    24     8 */
	const struct regexp_engine  * engine;            /*    32     8 */
	REGEXP *                   mother_re;            /*    40     8 */
	HV *                       paren_names;          /*    48     8 */
	U32                        extflags;             /*    56     4 */
	U32                        nparens;              /*    60     4 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	ssize_t                    minlen;               /*    64     8 */
	ssize_t                    minlenret;            /*    72     8 */
	STRLEN                     gofs;                 /*    80     8 */
	struct reg_substr_data *   substrs;              /*    88     8 */
	void *                     pprivate;             /*    96     8 */
	U32                        intflags;             /*   104     4 */
	U32                        lastparen;            /*   108     4 */
	regexp_paren_pair *        offs;                 /*   112     8 */
	char * *                   recurse_locinput;     /*   120     8 */
	/* --- cacheline 2 boundary (128 bytes) --- */
	U32                        lastcloseparen;       /*   128     4 */
	U32                        pre_prefix:4;         /*   132: 0  4 */
	U32                        compflags:9;          /*   132: 4  4 */

	/* XXX 19 bits hole, try to pack */

	SV *                       saved_copy;           /*   136     8 */
	ssize_t                    sublen;               /*   144     8 */
	ssize_t                    suboffset;            /*   152     8 */
	ssize_t                    subcoffset;           /*   160     8 */
	ssize_t                    maxlen;               /*   168     8 */
	char *                     subbeg;               /*   176     8 */
	CV *                       qr_anoncv;            /*   184     8 */

	/* size: 192, cachelines: 3, members: 28 */
	/* sum members: 188 */
	/* sum bitfield members: 13 bits, bit holes: 1, sum bit holes: 19 bits */
};
```
