### PR TITLE
make freed op re-use closer to O(1)

### DIFF
--- a/op.h
+++ b/op.h
@@ -703,8 +703,9 @@ struct opslot {
 struct opslab {
     OPSLAB *	opslab_next;		/* next slab */
     OPSLAB *	opslab_head;		/* first slab in chain */
-    OP *	opslab_freed;		/* chain of freed ops (head only)*/
+    OP **	opslab_freed;		/* array of sized chains of freed ops (head only)*/
     size_t	opslab_refcnt;		/* number of ops (head slab only) */
+    U16         opslab_freed_size;      /* allocated size of opslab_freed */
     U16		opslab_size;		/* size of slab in pointers,
                                            including header */
     U16         opslab_free_space;	/* space available in this slab


### PR DESCRIPTION
fixes #17555

Benchmarks, before is before the faster features change, blead is with this commit:

tony@mars:.../git/perl$ time ~/perl/before/bin/perl5.31.6 -MNumber::Phone::StubCountry::CN -e0

real    0m4.935s
user    0m3.688s
sys     0m0.264s
tony@mars:.../git/perl$ time ~/perl/before/bin/perl5.31.6 -MNumber::Phone::StubCountry::CN -e0

real    0m3.987s
user    0m3.788s
sys     0m0.197s
tony@mars:.../git/perl$ time ~/perl/before/bin/perl5.31.6 -MNumber::Phone::StubCountry::CN -e0

real    0m3.964s
user    0m3.748s
sys     0m0.212s

tony@mars:.../git/perl$ time ~/perl/blead/bin/perl5.31.10 -MNumber::Phone::StubCountry::CN -e0

real    0m3.580s
user    0m3.361s
sys     0m0.212s
tony@mars:.../git/perl$ time ~/perl/blead/bin/perl5.31.10 -MNumber::Phone::StubCountry::CN -e0

real    0m3.607s
user    0m3.395s
sys     0m0.208s
tony@mars:.../git/perl$ time ~/perl/blead/bin/perl5.31.10 -MNumber::Phone::StubCountry::CN -e0

real    0m3.604s
user    0m3.410s
sys     0m0.188s
