### PR TITLE
Revert "Test 32bit Perl build on Travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
   - linux
 
 compiler:
-  - "gcc -m32"
   - gcc
 
 install:
@@ -13,11 +12,6 @@ install:
   # install & enable ccache on osx
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install ccache; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="/usr/local/opt/ccache/libexec:$PATH"; fi
-  - if [[ "$CC" =~ -m32 ]]; then
-      sudo apt-get install -yq --no-install-suggests --no-install-recommends libdb-dev:i386 libgdbm-dev:i386 zlib1g-dev:i386 libbz2-dev:i386 libc6-dev:i386 gcc-multilib ;
-    else
-      sudo apt-get install -yq --no-install-suggests --no-install-recommends libdb-dev libgdbm-dev zlib1g-dev libbz2-dev ;
-    fi
 
 env:
     global:
@@ -50,6 +44,10 @@ addons:
         packages:
             - file
             - cpio
+            - libdb-dev
+            - libgdbm-dev
+            - zlib1g-dev
+            - libbz2-dev
 
 notifications:
 ## use dedicated email for smoking ?


### PR DESCRIPTION
Reverts Perl/perl5#17348

This was reverted at the request of Tony Cook, because CI should be used for finding new breakage, and this commit caused every new commit to appear broken.

 I think tickets should be created for those things that this commit showed were broken, and that this PR be re-merged after they get fixed.  Then it truly will show new breakage in an under-tested configuration