### PR TITLE
Fix wrong operator in perlop documentation

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -655,7 +655,7 @@ the table is sorted on the right operand instead of on the left.
  Left      Right      Description and pseudocode
  ===============================================================
  HASH1     HASH2      all same keys in both HASHes
-                like: keys HASH1 ==
+                like: keys HASH1 ~~
                          grep { exists HASH2->{$_} } keys HASH1
  ARRAY     HASH       any ARRAY elements exist as HASH keys
                 like: grep { exists HASH->{$_} } ARRAY


### PR DESCRIPTION
The example for equivalent code uses `==` for two containers, which
would erroneously just compare their lengths. The other examples of
equivalent code for the smartmatch operator seem correct.