### PR TITLE
decrease github actions timeout to 120 minutes

### DIFF
--- a/.github/workflows/smoke-linux.yml
+++ b/.github/workflows/smoke-linux.yml
@@ -11,8 +11,8 @@ on:
 
 jobs:
   perl:
-
     runs-on: ubuntu-latest
+    timeout-minutes: 120
 
     env:
         PERL_SKIP_TTY_TEST: 1

--- a/.github/workflows/smoke-macos-xcode11.yml
+++ b/.github/workflows/smoke-macos-xcode11.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   perl:
     runs-on: macos-latest
+    timeout-minutes: 120
 
     env:
         PERL_SKIP_TTY_TEST: 1

--- a/.github/workflows/smoke-windows-cygwin.yml
+++ b/.github/workflows/smoke-windows-cygwin.yml
@@ -10,8 +10,8 @@ on:
 
 jobs:
   perl:
-
     runs-on: windows-latest
+    timeout-minutes: 120
 
     env:
         PERL_SKIP_TTY_TEST: 1

--- a/.github/workflows/smoke-windows-mingw64.yml
+++ b/.github/workflows/smoke-windows-mingw64.yml
@@ -10,8 +10,8 @@ on:
 
 jobs:
   perl:
-
     runs-on: windows-latest
+    timeout-minutes: 120
 
     env:
         PERL_SKIP_TTY_TEST: 1

--- a/.github/workflows/smoke-windows-msvc100.yml
+++ b/.github/workflows/smoke-windows-msvc100.yml
@@ -11,8 +11,8 @@ on:
 
 jobs:
   perl:
-
     runs-on: windows-latest
+    timeout-minutes: 120
 
     env:
         PERL_SKIP_TTY_TEST: 1

--- a/.github/workflows/smoke-windows-msvc142.yml
+++ b/.github/workflows/smoke-windows-msvc142.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   perl:
     runs-on: windows-latest
+    timeout-minutes: 120
 
     env:
         PERL_SKIP_TTY_TEST: 1


### PR DESCRIPTION
That will make hung actions fail faster. The default 360 minutes
timeout was way too generous, typically none of our actions needs
more than 1 hour to complete.