### PR TITLE
regcomp.c: Get rid of meaningless test

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -1434,14 +1434,14 @@ S_scan_commit(pTHX_ const RExC_state_t *pRExC_state, scan_data_t *data,
 	if (!i) /* fixed */
 	    data->substrs[0].max_offset = data->substrs[0].min_offset;
 	else { /* float */
-	    data->substrs[1].max_offset = (l
+	    data->substrs[1].max_offset =
+                      (is_inf)
+                       ? OPTIMIZE_INFTY
+                       : (l
                           ? data->last_start_max
                           : (data->pos_delta > OPTIMIZE_INFTY - data->pos_min
 					 ? OPTIMIZE_INFTY
 					 : data->pos_min + data->pos_delta));
-	    if (is_inf
-		 || (STRLEN)data->substrs[1].max_offset > (STRLEN)OPTIMIZE_INFTY)
-		data->substrs[1].max_offset = OPTIMIZE_INFTY;
         }
 
         if (data->flags & SF_BEFORE_EOL)


### PR DESCRIPTION
Since ea3daa5, parts of this test became nonsensical as max_offset
cannot be larger than OPTIMIZE_INFIINITY.  (I don't know why compilers
didn't say that this branch is always false.)

Hugo van der Sanden suggested something like this commit to keep the
still valid part of the test.