### PR TITLE
Allow wildcard pattern debugging

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1934,7 +1934,7 @@ ES	|SV *	|handle_user_defined_property|NN const char * name	    \
 					     |NN bool *user_defined_ptr	    \
 					     |NN SV * msg		    \
 					     |const STRLEN level
-ERS	|REGEXP*|compile_wildcard|NN const char * name|const STRLEN len	    \
+ERS	|REGEXP*|compile_wildcard|NN const char * subpattern|const STRLEN len\
 				 |const bool ignore_case
 ES	|I32	|execute_wildcard|NN REGEXP * const prog|NN char* stringarg \
 				|NN char* strend|NN char* strbeg \

--- a/ext/re/re.pm
+++ b/ext/re/re.pm
@@ -4,7 +4,7 @@ package re;
 use strict;
 use warnings;
 
-our $VERSION     = "0.38";
+our $VERSION     = "0.39";
 our @ISA         = qw(Exporter);
 our @EXPORT_OK   = ('regmust',
                     qw(is_regexp regexp_pattern
@@ -67,7 +67,7 @@ my %flags = (
     MATCH             => 0x000200,
     TRIEE             => 0x000400,
 
-    EXTRA             => 0x1FF0000,
+    EXTRA             => 0x3FF0000,
     TRIEM             => 0x0010000,
     OFFSETS           => 0x0020000,
     OFFSETSDBG        => 0x0040000,
@@ -77,9 +77,14 @@ my %flags = (
     BUFFERS           => 0x0400000,
     GPOS              => 0x0800000,
     DUMP_PRE_OPTIMIZE => 0x1000000,
+    WILDCARD          => 0x2000000,
 );
-$flags{ALL} = -1 &
- ~($flags{OFFSETS}|$flags{OFFSETSDBG}|$flags{BUFFERS}|$flags{DUMP_PRE_OPTIMIZE});
+$flags{ALL} = -1 & ~($flags{OFFSETS}
+                    |$flags{OFFSETSDBG}
+                    |$flags{BUFFERS}
+                    |$flags{DUMP_PRE_OPTIMIZE}
+                    |$flags{WILDCARD}
+                    );
 $flags{All} = $flags{all} = $flags{DUMP} | $flags{EXECUTE};
 $flags{Extra} = $flags{EXECUTE} | $flags{COMPILE} | $flags{GPOS};
 $flags{More} = $flags{MORE} =
@@ -623,6 +628,19 @@ on the offsets part of the debug engine.
 =item DUMP_PRE_OPTIMIZE
 
 Enable the dumping of the compiled pattern before the optimization phase.
+
+=item WILDCARD
+
+Normally, all debugging is turned off during the handling of subpatterns in
+Unicode property wildcards.  Specifying this, enables it.  See
+L<perlunicode/Wildcards in Property Values>.
+
+Note that this option alone doesn't cause any debugging information to be
+output.  What it does is enable other debugging options to have effect in the
+compilation of wildcards.
+
+Especially on the name property, which has hundreds of thousands of possible
+names, this can cause a lot of output.
 
 =back
 

--- a/proto.h
+++ b/proto.h
@@ -5590,10 +5590,10 @@ STATIC AV*	S_add_multi_match(pTHX_ AV* multi_char_matches, SV* multi_string, con
 STATIC void	S_change_engine_size(pTHX_ RExC_state_t *pRExC_state, const Ptrdiff_t size);
 #define PERL_ARGS_ASSERT_CHANGE_ENGINE_SIZE	\
 	assert(pRExC_state)
-STATIC REGEXP*	S_compile_wildcard(pTHX_ const char * name, const STRLEN len, const bool ignore_case)
+STATIC REGEXP*	S_compile_wildcard(pTHX_ const char * subpattern, const STRLEN len, const bool ignore_case)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_COMPILE_WILDCARD	\
-	assert(name)
+	assert(subpattern)
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
 PERL_STATIC_INLINE U8	S_compute_EXACTish(RExC_state_t *pRExC_state);

--- a/regcomp.c
+++ b/regcomp.c
@@ -23013,11 +23013,21 @@ S_get_extended_utf8_msg(pTHX_ const UV cp)
 #endif /* end of ! PERL_IN_XSUB_RE */
 
 STATIC REGEXP *
-S_compile_wildcard(pTHX_ const char * name, const STRLEN len,
+S_compile_wildcard(pTHX_ const char * subpattern, const STRLEN len,
                          const bool ignore_case)
 {
+    /* Pretends that the input subpattern is qr/subpattern/aam, compiling it
+     * possibly with /i if the 'ignore_case' parameter is true.  Sets up the
+     * debugging info */
+
     U32 flags = PMf_MULTILINE|PMf_WILDCARD;
     REGEXP * subpattern_re;
+
+#  ifdef DEBUGGING
+    bool turned_off_PL_debug = FALSE;
+    bool turned_off_RE_DEBUG_FLAGS = FALSE;
+    GET_RE_DEBUG_FLAGS_DECL;
+#  endif
 
     PERL_ARGS_ASSERT_COMPILE_WILDCARD;
 
@@ -23026,10 +23036,31 @@ S_compile_wildcard(pTHX_ const char * name, const STRLEN len,
     }
     set_regex_charset(&flags, REGEX_ASCII_MORE_RESTRICTED_CHARSET);
 
-    subpattern_re = re_op_compile_wrapper(sv_2mortal(newSVpvn(name, len)),
+#  ifdef DEBUGGING
+    if (! isDEBUG_WILDCARD) {
+        if (DEBUG_r_TEST) {
+            PL_debug &= ~ DEBUG_r_FLAG;
+            turned_off_PL_debug = TRUE;
+        }
+        else if (re_debug_flags) {
+            turned_off_RE_DEBUG_FLAGS = TRUE;
+            sv_setuv_mg(get_sv(RE_DEBUG_FLAGS, GV_ADD), 0);
+        }
+    }
+#  endif
+
+    subpattern_re = re_op_compile_wrapper(sv_2mortal(newSVpvn(subpattern, len)),
                                         /* Like in op.c, we copy the compile
                                          * time pm flags to the rx ones */
                                         (flags & RXf_PMf_COMPILETIME), flags);
+#  ifdef DEBUGGING
+    if (turned_off_PL_debug) {
+        PL_debug |= DEBUG_r_FLAG;
+    }
+    else if (turned_off_RE_DEBUG_FLAGS) {
+        sv_setuv_mg(get_sv(RE_DEBUG_FLAGS, GV_ADD), re_debug_flags);
+    }
+#  endif
 
     assert(subpattern_re);  /* Should have died if didn't compile successfully */
     return subpattern_re;
@@ -23041,9 +23072,36 @@ S_execute_wildcard(pTHX_ REGEXP * const prog, char* stringarg, char *strend,
 {
     I32 result;
 
+#  ifdef DEBUGGING
+    bool turned_off_PL_debug = FALSE;
+    bool turned_off_RE_DEBUG_FLAGS = FALSE;
+    GET_RE_DEBUG_FLAGS_DECL;
+
+    if (! isDEBUG_WILDCARD) {
+        if (DEBUG_r_TEST) {
+            PL_debug &= ~ DEBUG_r_FLAG;
+            turned_off_PL_debug = TRUE;
+        }
+        else if (re_debug_flags) {
+            turned_off_RE_DEBUG_FLAGS = TRUE;
+            sv_setuv_mg(get_sv(RE_DEBUG_FLAGS, GV_ADD), 0);
+        }
+    }
+#  endif
+
     PERL_ARGS_ASSERT_EXECUTE_WILDCARD;
 
-    result = pregexec(prog, stringarg, strend, strbeg, minend, screamer, nosave);
+    result = CALLREGEXEC(prog, stringarg, strend, strbeg, minend, screamer,
+                         NULL, nosave);
+
+#  ifdef DEBUGGING
+    if (turned_off_PL_debug) {
+        PL_debug |= DEBUG_r_FLAG;
+    }
+    else if (turned_off_RE_DEBUG_FLAGS) {
+        sv_setuv_mg(get_sv(RE_DEBUG_FLAGS, GV_ADD), re_debug_flags);
+    }
+#  endif
 
     return result;
 }

--- a/regcomp.h
+++ b/regcomp.h
@@ -1059,7 +1059,7 @@ re.pm, especially to the documentation.
 #define RE_DEBUG_EXECUTE_TRIE      0x000400
 
 /* Extra */
-#define RE_DEBUG_EXTRA_MASK              0x1FF0000
+#define RE_DEBUG_EXTRA_MASK              0x3FF0000
 #define RE_DEBUG_EXTRA_TRIE              0x0010000
 #define RE_DEBUG_EXTRA_OFFSETS           0x0020000
 #define RE_DEBUG_EXTRA_OFFDEBUG          0x0040000
@@ -1068,6 +1068,7 @@ re.pm, especially to the documentation.
 #define RE_DEBUG_EXTRA_BUFFERS           0x0400000
 #define RE_DEBUG_EXTRA_GPOS              0x0800000
 #define RE_DEBUG_EXTRA_DUMP_PRE_OPTIMIZE 0x1000000
+#define RE_DEBUG_EXTRA_WILDCARD          0x2000000
 /* combined */
 #define RE_DEBUG_EXTRA_STACK             0x0280000
 
@@ -1143,6 +1144,8 @@ re.pm, especially to the documentation.
 
 #ifdef DEBUGGING
 
+#define isDEBUG_WILDCARD (DEBUG_v_TEST || RE_DEBUG_FLAG(RE_DEBUG_EXTRA_WILDCARD))
+
 #define GET_RE_DEBUG_FLAGS_DECL volatile IV re_debug_flags = 0; \
         PERL_UNUSED_VAR(re_debug_flags); GET_RE_DEBUG_FLAGS;
 
@@ -1179,6 +1182,7 @@ re.pm, especially to the documentation.
 #define RE_PV_QUOTED_DECL(rpv,isuni,dsv,pv,l,m)
 #define RE_SV_DUMPLEN(ItEm)
 #define RE_SV_TAIL(ItEm)
+#define isDEBUG_WILDCARD 0
 
 #endif /* DEBUG RELATED DEFINES */
 


### PR DESCRIPTION
This fixes #17026

Patterns can now have subpatterns, called wildcards by Unicode.  Prior
to this commit debugging info was only available under DEBUGGING builds
with -Drv.  This commit adds a new keyword, WILDCARD for
'use re qw(Debug ...)' so that whatever other debugging options have
been turned on will show up when a wildcard subpattern is compiled.

The output of this may be voluminous, which is why you have to ask for
it specifically.  Or, the EXTRA option turns it on along with several
other things.