### PR TITLE
Fix pp_match to recognize re.pm debugging 

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2840,6 +2840,9 @@ pReo	|GV*	|softref2xv	|NN SV *const sv|NN const char *const what \
 				|const svtype type|NN SV ***spp
 iTR	|bool	|lossless_NV_to_IV|const NV nv|NN IV * ivp
 #endif
+#if defined(PERL_IN_PP_HOT_C)
+IR	|bool	|should_we_output_Debug_r|NN regexp * prog
+#endif
 
 #if defined(PERL_IN_PP_PACK_C)
 S	|SSize_t|unpack_rec	|NN struct tempsym* symptr|NN const char *s \

--- a/embed.h
+++ b/embed.h
@@ -1832,6 +1832,7 @@
 #  if defined(PERL_IN_PP_HOT_C)
 #define do_oddball(a,b)		S_do_oddball(aTHX_ a,b)
 #define opmethod_stash(a)	S_opmethod_stash(aTHX_ a)
+#define should_we_output_Debug_r(a)	S_should_we_output_Debug_r(aTHX_ a)
 #  endif
 #  if defined(PERL_IN_PP_PACK_C)
 #define div128(a,b)		S_div128(aTHX_ a,b)

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -2966,9 +2966,9 @@ PP(pp_match)
     }
 
     if (RXp_MINLEN(prog) >= 0 && (STRLEN)RXp_MINLEN(prog) > len) {
-        DEBUG_r(PerlIO_printf(Perl_debug_log, "String shorter than min possible regex match (%"
-                                              UVuf " < %" IVdf ")\n",
-                                              (UV)len, (IV)RXp_MINLEN(prog)));
+        DEBUG_r(PerlIO_printf(Perl_debug_log,
+                "String shorter than min possible regex match (%zd < %zd)\n",
+                                                        len, RXp_MINLEN(prog)));
 	goto nope;
     }
 

--- a/proto.h
+++ b/proto.h
@@ -5506,6 +5506,14 @@ PERL_STATIC_INLINE HV*	S_opmethod_stash(pTHX_ SV* meth);
 #define PERL_ARGS_ASSERT_OPMETHOD_STASH	\
 	assert(meth)
 #endif
+#ifndef PERL_NO_INLINE_FUNCTIONS
+PERL_STATIC_FORCE_INLINE bool	S_should_we_output_Debug_r(pTHX_ regexp * prog)
+			__attribute__warn_unused_result__
+			__attribute__always_inline__;
+#define PERL_ARGS_ASSERT_SHOULD_WE_OUTPUT_DEBUG_R	\
+	assert(prog)
+#endif
+
 #endif
 #if defined(PERL_IN_PP_PACK_C)
 STATIC int	S_div128(pTHX_ SV *pnum, bool *done);

--- a/regcomp.h
+++ b/regcomp.h
@@ -1101,8 +1101,24 @@ re.pm, especially to the documentation.
     if (DEBUG_v_TEST || RE_DEBUG_FLAG(RE_DEBUG_EXTRA_DUMP_PRE_OPTIMIZE)) x )
 
 /* initialization */
+/* Get the debug flags for code not in regcomp.c nor regexec.c.  This doesn't
+ * initialize the variable if it isn't already there, instead it just assumes
+ * the flags are 0 */
+#define DECLARE_AND_GET_RE_DEBUG_FLAGS_NON_REGEX                               \
+    volatile IV re_debug_flags = 0;  PERL_UNUSED_VAR(re_debug_flags);          \
+    STMT_START {                                                               \
+        SV * re_debug_flags_sv = NULL;                                         \
+                     /* get_sv() can return NULL during global destruction. */ \
+        re_debug_flags_sv = PL_curcop ? get_sv(RE_DEBUG_FLAGS, GV_ADD) : NULL; \
+        if (re_debug_flags_sv && SvIOK(re_debug_flags_sv))                     \
+            re_debug_flags=SvIV(re_debug_flags_sv);                            \
+    } STMT_END
+
+
 #ifdef DEBUGGING
 
+/* For use in regcomp.c and regexec.c,  Get the debug flags, and initialize to
+ * the defaults if not done already */
 #define DECLARE_AND_GET_RE_DEBUG_FLAGS                                         \
     volatile IV re_debug_flags = 0;  PERL_UNUSED_VAR(re_debug_flags);          \
     STMT_START {                                                               \


### PR DESCRIPTION
This takes into account the comments received so far from @hvds.

The changes introduce minimal performance changes.

 ```
Key:
    Ir   Instruction read
    Dr   Data read
    Dw   Data write
    COND conditional branches
    IND  indirect branches
    _m   branch predict miss
    _m1  level 1 cache miss
    _mm  last cache (e.g. L3) miss
    -    indeterminate percentage (e.g. 1/0)

The numbers represent raw counts per loop iteration.

Not using -Dr

          old    new Ratio %
       ------ ------ -------
    Ir 1919.0 1919.0   100.0
    Dr  600.0  600.0   100.0
    Dw  373.0  373.0   100.0
  COND  325.0  325.0   100.0
   IND   18.0   18.0   100.0

COND_m    2.8    5.0    56.0
 IND_m    8.0    8.0   100.0

 Ir_m1    0.0    0.0   100.0
 Dr_m1    0.0    0.0   100.0
 Dw_m1    0.0    0.0   100.0

 Ir_mm    0.0    0.0   100.0
 Dr_mm    0.0    0.0   100.0
 Dw_mm    0.0    0.0   100.0

WIth -Dr
         old_r   new_r Ratio %
       ------- ------- -------
    Ir 31964.0 31946.0   100.1
    Dr  7393.0  7389.0   100.1
    Dw  4368.0  4367.0   100.0
  COND  6226.0  6224.0   100.0
   IND   275.0   275.0   100.0

COND_m   319.9   358.0    89.4
 IND_m    31.0    31.0   100.0

 Ir_m1   388.0   358.0   108.4
 Dr_m1     6.1     0.0     Inf
 Dw_m1     2.0     0.0     Inf

 Ir_mm     0.0     0.0   100.0
 Dr_mm     0.0     0.0   100.0
 Dw_mm     0.0     0.0   100.0

```