### PR TITLE
Add macro to free and set cop_warnings

### DIFF
--- a/mg.c
+++ b/mg.c
@@ -2966,9 +2966,7 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
 	else if (strEQ(mg->mg_ptr+1, "ARNING_BITS")) {
 	    if ( ! (PL_dowarn & G_WARN_ALL_MASK)) {
 		if (!SvPOK(sv)) {
-                    if (!specialWARN(PL_compiling.cop_warnings))
-                        PerlMemShared_free(PL_compiling.cop_warnings);
-	            PL_compiling.cop_warnings = pWARN_STD;
+            free_and_set_cop_warnings(PL_compiling, pWARN_STD);
 		    break;
 		}
 		{
@@ -2980,26 +2978,22 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
 			not_all |= ptr[i] ^ 0x55;
 		    }
 		    if (!not_none) {
-		        if (!specialWARN(PL_compiling.cop_warnings))
-			    PerlMemShared_free(PL_compiling.cop_warnings);
-			PL_compiling.cop_warnings = pWARN_NONE;
+                free_and_set_cop_warnings(PL_compiling, pWARN_NONE);
 		    } else if (len >= WARNsize && !not_all) {
-		        if (!specialWARN(PL_compiling.cop_warnings))
-			    PerlMemShared_free(PL_compiling.cop_warnings);
-	                PL_compiling.cop_warnings = pWARN_ALL;
-	                PL_dowarn |= G_WARN_ONCE ;
-	            }
-                    else {
-			STRLEN len;
-			const char *const p = SvPV_const(sv, len);
+                free_and_set_cop_warnings(PL_compiling, pWARN_ALL);
+	            PL_dowarn |= G_WARN_ONCE ;
+	        }
+            else {
+			     STRLEN len;
+			     const char *const p = SvPV_const(sv, len);
 
-			PL_compiling.cop_warnings
-			    = Perl_new_warnings_bitfield(aTHX_ PL_compiling.cop_warnings,
+			     PL_compiling.cop_warnings
+			         = Perl_new_warnings_bitfield(aTHX_ PL_compiling.cop_warnings,
 							 p, len);
 
-	                if (isWARN_on(PL_compiling.cop_warnings, WARN_ONCE))
+	             if (isWARN_on(PL_compiling.cop_warnings, WARN_ONCE))
 	                    PL_dowarn |= G_WARN_ONCE ;
-	            }
+	       }
 
 		}
 	    }

--- a/perl.c
+++ b/perl.c
@@ -1245,9 +1245,7 @@ perl_destruct(pTHXx)
         }
     }
 
-    if (!specialWARN(PL_compiling.cop_warnings))
-	PerlMemShared_free(PL_compiling.cop_warnings);
-    PL_compiling.cop_warnings = NULL;
+    free_and_set_cop_warnings(PL_compiling, NULL);
     cophh_free(CopHINTHASH_get(&PL_compiling));
     CopHINTHASH_set(&PL_compiling, cophh_new_empty());
     CopFILE_free(&PL_compiling);
@@ -3740,16 +3738,12 @@ Perl_moreswitches(pTHX_ const char *s)
 	return s;
     case 'W':
 	PL_dowarn = G_WARN_ALL_ON|G_WARN_ON;
-        if (!specialWARN(PL_compiling.cop_warnings))
-            PerlMemShared_free(PL_compiling.cop_warnings);
-	PL_compiling.cop_warnings = pWARN_ALL ;
+    free_and_set_cop_warnings(PL_compiling, pWARN_ALL);
 	s++;
 	return s;
     case 'X':
 	PL_dowarn = G_WARN_ALL_OFF;
-        if (!specialWARN(PL_compiling.cop_warnings))
-            PerlMemShared_free(PL_compiling.cop_warnings);
-	PL_compiling.cop_warnings = pWARN_NONE ;
+    free_and_set_cop_warnings(PL_compiling, pWARN_NONE);
 	s++;
 	return s;
     case '*':

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -392,6 +392,11 @@ EOM
 
 #define DUP_WARNINGS(p) Perl_dup_warnings(aTHX_ p)
 
+#define free_and_set_cop_warnings(cmp,w) STMT_START { \
+  if (!specialWARN(cmp.cop_warnings)) PerlMemShared_free(cmp.cop_warnings); \
+  cmp.cop_warnings = w; \
+} STMT_END
+
 /*
 
 =head1 Warning and Dieing

--- a/scope.c
+++ b/scope.c
@@ -1448,9 +1448,7 @@ Perl_leave_scope(pTHX_ I32 base)
 
 	case SAVEt_COMPILE_WARNINGS:
             a0 = ap[0];
-	    if (!specialWARN(PL_compiling.cop_warnings))
-		PerlMemShared_free(PL_compiling.cop_warnings);
-	    PL_compiling.cop_warnings = (STRLEN*)a0.any_ptr;
+        free_and_set_cop_warnings(PL_compiling, (STRLEN*) a0.any_ptr);
 	    break;
 
 	case SAVEt_PARSER:

--- a/utf8.c
+++ b/utf8.c
@@ -55,9 +55,8 @@ within non-zero characters.
 static void
 S_restore_cop_warnings(pTHX_ void *p)
 {
-    if (!specialWARN(PL_curcop->cop_warnings))
-        PerlMemShared_free(PL_curcop->cop_warnings);
-    PL_curcop->cop_warnings = (STRLEN*)p;
+    COP curcop = *PL_curcop;
+    free_and_set_cop_warnings(curcop, (STRLEN*) p);
 }
 
 

--- a/warnings.h
+++ b/warnings.h
@@ -225,6 +225,11 @@
 
 #define DUP_WARNINGS(p) Perl_dup_warnings(aTHX_ p)
 
+#define free_and_set_cop_warnings(cmp,w) STMT_START { \
+  if (!specialWARN(cmp.cop_warnings)) PerlMemShared_free(cmp.cop_warnings); \
+  cmp.cop_warnings = w; \
+} STMT_END
+
 /*
 
 =head1 Warning and Dieing


### PR DESCRIPTION
This is avoiding the boilerplate to free
the cop_warning string when setting it.