### PR TITLE
pp_sort.c: silence the "unused parameter" warning

### DIFF
--- a/pp_sort.c
+++ b/pp_sort.c
@@ -347,6 +347,7 @@ S_sortsv_flags_impl(pTHX_ gptr *base, size_t nmemb, SVCOMPARE_t cmp, U32 flags)
     gptr *which[3];
     off_runs stack[60], *stackp;
 
+    PERL_UNUSED_ARG(flags);
     PERL_ARGS_ASSERT_SORTSV_FLAGS_IMPL;
     if (nmemb <= 1) return;                     /* sorted trivially */
 


### PR DESCRIPTION
The 'flags' argument has been unused since 044d25c73ce10d2b29008b875209d414303ccff7 but we can't remove it because it's a public API.

Fixes #17632