### PR TITLE
runtests using current ./lib and ./t directories

### DIFF
--- a/runtests.SH
+++ b/runtests.SH
@@ -74,6 +74,9 @@ if test X"$TESTFILE" = X; then
     TESTFILE=TEST
 fi
 
+PERL_LIB=${PWD}/lib
+PERL_T=${PWD}/t
+
 cd t
 
 # If this is run under an old shell that doesn't automatically 
@@ -92,9 +95,9 @@ $spitshell >>runtests <<!GROK!THIS!
 # The second branch is for testing without a tty or controlling terminal,
 # see t/op/stat.t
 if test \$tty = Y; then
-    ./perl$_exe \$TESTFILE \$TEST_ARGS \$TEST_FILES </dev/tty
+    ./perl$_exe -I\$PERL_LIB -I\$PERL_T \$TESTFILE \$TEST_ARGS \$TEST_FILES </dev/tty
 else
-    PERL_SKIP_TTY_TEST=1 ./perl$_exe \$TESTFILE \$TEST_ARGS \$TEST_FILES
+    PERL_SKIP_TTY_TEST=1 ./perl$_exe -I\$PERL_LIB -I\$PERL_T \$TESTFILE \$TEST_ARGS \$TEST_FILES
 fi
 
 echo "Ran tests" > rantests

--- a/t/comp/parser_run.t
+++ b/t/comp/parser_run.t
@@ -7,7 +7,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( qw(. ../lib ) );
 }
 
 plan(6);

--- a/t/io/argv.t
+++ b/t/io/argv.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
 }
 
 plan(tests => 37);

--- a/t/io/binmode.t
+++ b/t/io/binmode.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc(qw(. ../lib));
     eval 'use Errno';
     die $@ if $@ and !is_miniperl();
 }

--- a/t/io/bom.t
+++ b/t/io/bom.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
     require "./charset_tools.pl";
 }
 

--- a/t/io/closepid.t
+++ b/t/io/closepid.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
 }
 
 if ($^O eq 'dos') {

--- a/t/io/crlf.t
+++ b/t/io/crlf.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
     require "./charset_tools.pl";
     skip_all_without_perlio();
 }

--- a/t/io/data.t
+++ b/t/io/data.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
 }
 
 $|=1;

--- a/t/io/defout.t
+++ b/t/io/defout.t
@@ -9,7 +9,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 $|=0;   # test.pl makes it 1, and that conflicts with the below.

--- a/t/io/dup.t
+++ b/t/io/dup.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc(qw(. ../lib));
 }
 
 use Config;

--- a/t/io/eintr.t
+++ b/t/io/eintr.t
@@ -9,7 +9,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_without_dynamic_extension('Fcntl');
 }
 

--- a/t/io/eintr_print.t
+++ b/t/io/eintr_print.t
@@ -7,7 +7,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
     skip_all_if_miniperl("No XS under miniperl");
 }
 

--- a/t/io/errnosig.t
+++ b/t/io/errnosig.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc( qw(. ../lib) );
 }
 
 require Config; import Config;

--- a/t/io/fflush.t
+++ b/t/io/fflush.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 # Script to test auto flush on fork/exec/system/qx.  The idea is to

--- a/t/io/fs.t
+++ b/t/io/fs.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
 }
 
 use Config;

--- a/t/io/getcwd.t
+++ b/t/io/getcwd.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
 }
 
 use Config;

--- a/t/io/iofile.t
+++ b/t/io/iofile.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_if_miniperl("miniperl can't load IO::File");
 }
 

--- a/t/io/layers.t
+++ b/t/io/layers.t
@@ -5,7 +5,6 @@ my $PERLIO;
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_without_perlio();
     # FIXME - more of these could be tested without Encode or full perl
     skip_all_without_dynamic_extension('Encode');

--- a/t/io/nargv.t
+++ b/t/io/nargv.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
 }
 
 print "1..7\n";

--- a/t/io/open.t
+++ b/t/io/open.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 $|  = 1;

--- a/t/io/openpid.t
+++ b/t/io/openpid.t
@@ -10,7 +10,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 if ($^O eq 'dos') {

--- a/t/io/paragraph_mode.t
+++ b/t/io/paragraph_mode.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests =>  80;

--- a/t/io/perlio.t
+++ b/t/io/perlio.t
@@ -2,7 +2,6 @@ BEGIN {
 	chdir 't' if -d 't';
 	require Config; import Config;
     require './test.pl';
-    set_up_inc('../lib');
 	skip_all_without_perlio();
 }
 

--- a/t/io/perlio_fail.t
+++ b/t/io/perlio_fail.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "../t/test.pl";
-    set_up_inc('../lib');
     skip_all_without_perlio();
 }
 

--- a/t/io/perlio_leaks.t
+++ b/t/io/perlio_leaks.t
@@ -4,7 +4,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/io/perlio_open.t
+++ b/t/io/perlio_open.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_without_perlio();
     skip_all_without_dynamic_extension('Fcntl'); # how did you get this far?
 }

--- a/t/io/pipe.t
+++ b/t/io/pipe.t
@@ -4,7 +4,6 @@ BEGIN {
     chdir 't' if -d 't';
     require Config; import Config;
     require './test.pl';
-    set_up_inc('../lib');
 }
 if (!$Config{'d_fork'}) {
     skip_all("fork required to pipe");

--- a/t/io/print.t
+++ b/t/io/print.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     eval 'use Errno';
     die $@ if $@ and !is_miniperl();
 }

--- a/t/io/pvbm.t
+++ b/t/io/pvbm.t
@@ -6,7 +6,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc(qw(. ../lib));
 }
 
 BEGIN { $| = 1 }

--- a/t/io/read.t
+++ b/t/io/read.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     eval 'use Errno';
     die $@ if $@ and !is_miniperl();
 }

--- a/t/io/say.t
+++ b/t/io/say.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     eval 'use Errno';
     die $@ if $@ and !is_miniperl();
 }

--- a/t/io/sem.t
+++ b/t/io/sem.t
@@ -4,7 +4,6 @@ BEGIN {
   chdir 't' if -d 't';
 
   require "./test.pl";
-  set_up_inc( '../lib' ) if -d '../lib' && -d '../ext';
   require Config; import Config;
 
   if ($ENV{'PERL_CORE'} && $Config{'extensions'} !~ m[\bIPC/SysV\b]) {

--- a/t/io/shm.t
+++ b/t/io/shm.t
@@ -17,7 +17,6 @@
 BEGIN {
   chdir 't' if -d 't' && $ENV{'PERL_CORE'};
   require "./test.pl";
-  set_up_inc('../lib') if $ENV{'PERL_CORE'} && -d '../lib' && -d '../ext';
 
   require Config; import Config;
 

--- a/t/io/socket.t
+++ b/t/io/socket.t
@@ -6,7 +6,6 @@ BEGIN {
     chdir 't' if -d 't';
 
     require "./test.pl";
-    set_up_inc( '../lib' ) if -d '../lib' && -d '../ext';
     require Config; import Config;
 
     skip_all_if_miniperl();

--- a/t/io/socketpair.t
+++ b/t/io/socketpair.t
@@ -4,7 +4,6 @@ BEGIN {
     chdir 't' if -d 't';
     require Config; import Config;
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_if_miniperl();
     for my $needed (qw(d_socket)) {
 	if ($Config{$needed} ne 'define') {

--- a/t/io/tell.t
+++ b/t/io/tell.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan(36);

--- a/t/io/through.t
+++ b/t/io/through.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all("VMS too picky about line endings for record-oriented pipes")
 	if $^O eq 'VMS';
 }

--- a/t/io/utf8.t
+++ b/t/io/utf8.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl'; require './charset_tools.pl';
-    set_up_inc('../lib');
 }
 skip_all_without_perlio();
 

--- a/t/mro/basic.t
+++ b/t/mro/basic.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require q(./test.pl);
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/mro/inconsistent_c3.t
+++ b/t/mro/inconsistent_c3.t
@@ -5,7 +5,6 @@ BEGIN {
         chdir 't' if -d 't';
     }
     require q(./test.pl);
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/mro/inconsistent_c3_utf8.t
+++ b/t/mro/inconsistent_c3_utf8.t
@@ -5,7 +5,6 @@ BEGIN {
         chdir 't' if -d 't';
     }
     require q(./test.pl);
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/mro/isa_aliases.t
+++ b/t/mro/isa_aliases.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan 13;

--- a/t/mro/isa_aliases_utf8.t
+++ b/t/mro/isa_aliases_utf8.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use utf8;

--- a/t/mro/isa_c3.t
+++ b/t/mro/isa_c3.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/mro/isa_c3_utf8.t
+++ b/t/mro/isa_c3_utf8.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/mro/isa_dfs.t
+++ b/t/mro/isa_dfs.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/mro/isa_dfs_utf8.t
+++ b/t/mro/isa_dfs_utf8.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/mro/isarev.t
+++ b/t/mro/isarev.t
@@ -5,7 +5,6 @@ BEGIN {
         chdir 't' if -d 't';
     }
     require q(./test.pl);
-    set_up_inc('../lib') unless -d 'blib';
 }
 
 use strict;

--- a/t/mro/isarev_utf8.t
+++ b/t/mro/isarev_utf8.t
@@ -5,7 +5,6 @@ BEGIN {
         chdir 't' if -d 't';
     }
     require q(./test.pl);
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/mro/method_caching.t
+++ b/t/mro/method_caching.t
@@ -5,7 +5,6 @@ BEGIN {
         chdir 't' if -d 't';
     }
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/mro/method_caching_utf8.t
+++ b/t/mro/method_caching_utf8.t
@@ -5,7 +5,6 @@ BEGIN {
         chdir 't' if -d 't';
     }
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use utf8;

--- a/t/mro/next_edgecases.t
+++ b/t/mro/next_edgecases.t
@@ -3,8 +3,9 @@
 use strict;
 use warnings;
 
-BEGIN { chdir 't' if -d 't'; require q(./test.pl);
-set_up_inc('../lib', 'lib');
+BEGIN {
+    chdir 't' if -d 't';
+    require q(./test.pl);
 }
 
 plan(tests => 12);

--- a/t/mro/next_edgecases_utf8.t
+++ b/t/mro/next_edgecases_utf8.t
@@ -6,7 +6,6 @@ use warnings;
 BEGIN {
     chdir 't' if -d 't';
     require q(./test.pl);
-    set_up_inc('../lib', 'lib');
 }
 
 use utf8;

--- a/t/mro/overload_c3.t
+++ b/t/mro/overload_c3.t
@@ -7,7 +7,6 @@ BEGIN {
         chdir 't' if -d 't';
     }
     require q(./test.pl);
-    set_up_inc('../lib');
 }
 
 plan(tests => 7);

--- a/t/mro/overload_c3_utf8.t
+++ b/t/mro/overload_c3_utf8.t
@@ -7,7 +7,6 @@ BEGIN {
         chdir 't' if -d 't';
     }
     require q(./test.pl);
-    set_up_inc('../lib');
 }
 
 use utf8;

--- a/t/mro/overload_dfs.t
+++ b/t/mro/overload_dfs.t
@@ -7,7 +7,6 @@ BEGIN {
         chdir 't' if -d 't';
     }
     require q(./test.pl);
-    set_up_inc('../lib');
 }
 
 plan(tests => 7);

--- a/t/mro/package_aliases.t
+++ b/t/mro/package_aliases.t
@@ -5,7 +5,6 @@ BEGIN {
         chdir 't' if -d 't';
     }
     require q(./test.pl);
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/mro/package_aliases_utf8.t
+++ b/t/mro/package_aliases_utf8.t
@@ -6,7 +6,6 @@ BEGIN {
         chdir 't' if -d 't';
     }
     require q(./test.pl);
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/mro/recursion_c3.t
+++ b/t/mro/recursion_c3.t
@@ -5,7 +5,6 @@ BEGIN {
     unless (-d 'blib') {
         chdir 't' if -d 't';
     }
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/mro/recursion_c3_utf8.t
+++ b/t/mro/recursion_c3_utf8.t
@@ -7,7 +7,6 @@ BEGIN {
         chdir 't' if -d 't';
     }
     require './test.pl';
-    set_up_inc('../lib');
 }
 use utf8;
 use open qw( :utf8 :std );

--- a/t/mro/recursion_dfs.t
+++ b/t/mro/recursion_dfs.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/mro/recursion_dfs_utf8.t
+++ b/t/mro/recursion_dfs_utf8.t
@@ -7,7 +7,6 @@ BEGIN {
         chdir 't' if -d 't';
     }
     require './test.pl';
-    set_up_inc('../lib');
 }
 use utf8;
 use open qw( :utf8 :std );

--- a/t/op/64bitint.t
+++ b/t/op/64bitint.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     eval { my $q = pack "q", 0 };
     skip_all('no 64-bit types') if $@;
 }

--- a/t/op/aassign.t
+++ b/t/op/aassign.t
@@ -16,7 +16,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib')
 }
 
 use warnings;

--- a/t/op/alarm.t
+++ b/t/op/alarm.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 

--- a/t/op/anonconst.t
+++ b/t/op/anonconst.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't';
     require './test.pl';
-    set_up_inc("../lib");
 }
 
 plan 8;

--- a/t/op/anonsub.t
+++ b/t/op/anonsub.t
@@ -2,7 +2,6 @@
 
 chdir 't' if -d 't';
 require './test.pl';
-set_up_inc('../lib');
 
 use strict;
 

--- a/t/op/append.t
+++ b/t/op/append.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 ##Literal test count since evals below can fail

--- a/t/op/args.t
+++ b/t/op/args.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan( tests => 23 );

--- a/t/op/array.t
+++ b/t/op/array.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('.', '../lib');
 }
 
 plan (194);

--- a/t/op/assignwarn.t
+++ b/t/op/assignwarn.t
@@ -10,7 +10,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/attrhand.t
+++ b/t/op/attrhand.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_if_miniperl("miniperl can't load attributes");
 }
 

--- a/t/op/attrproto.t
+++ b/t/op/attrproto.t
@@ -6,7 +6,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_if_miniperl("miniperl can't load attributes");
 }
 use warnings;

--- a/t/op/attrs.t
+++ b/t/op/attrs.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_if_miniperl("miniperl can't load attributes");
 }
 

--- a/t/op/auto.t
+++ b/t/op/auto.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc(qw(. ../lib));
 }
 
 plan( tests => 47 );

--- a/t/op/avhv.t
+++ b/t/op/avhv.t
@@ -6,7 +6,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 require Tie::Array;

--- a/t/op/bless.t
+++ b/t/op/bless.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan (118);

--- a/t/op/blocks.t
+++ b/t/op/blocks.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 22;

--- a/t/op/bop.t
+++ b/t/op/bop.t
@@ -9,7 +9,6 @@ use warnings;
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
     require "./charset_tools.pl";
     require Config;
 }

--- a/t/op/caller.t
+++ b/t/op/caller.t
@@ -4,7 +4,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     plan( tests => 109 ); # some tests are run in a BEGIN block
 }
 

--- a/t/op/catch.t
+++ b/t/op/catch.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use warnings;

--- a/t/op/chars.t
+++ b/t/op/chars.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 34;

--- a/t/op/chop.t
+++ b/t/op/chop.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     require './charset_tools.pl';
 }
 

--- a/t/op/chr.t
+++ b/t/op/chr.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc(qw(. ../lib)); # ../lib needed for test.deparse
 }
 
 plan tests => 45;

--- a/t/op/closure.t
+++ b/t/op/closure.t
@@ -9,7 +9,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use Config;

--- a/t/op/concat2.t
+++ b/t/op/concat2.t
@@ -9,7 +9,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan 4;

--- a/t/op/cond.t
+++ b/t/op/cond.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 is( 1 ? 1 : 0, 1, 'compile time, true' );

--- a/t/op/const-optree.t
+++ b/t/op/const-optree.t
@@ -6,7 +6,6 @@
 BEGIN {
     chdir 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 plan 148;
 

--- a/t/op/context.t
+++ b/t/op/context.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc( qw(. ../lib) );
 }
 
 require "./test.pl";

--- a/t/op/coresubs.t
+++ b/t/op/coresubs.t
@@ -7,7 +7,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc(qw(. ../lib));
     skip_all_without_dynamic_extension('B');
     $^P |= 0x100;
 }

--- a/t/op/cproto.t
+++ b/t/op/cproto.t
@@ -4,7 +4,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 254;

--- a/t/op/crypt.t
+++ b/t/op/crypt.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc( qw(. ../lib) );
     use Config;
 }
 

--- a/t/op/current_sub.t
+++ b/t/op/current_sub.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( qw(../lib) );
     plan (tests => 22); # some tests are run in BEGIN block
 }
 

--- a/t/op/dbm.t
+++ b/t/op/dbm.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 
     eval { require AnyDBM_File }; # not all places have dbm* functions
     skip_all("No dbm functions") if $@;

--- a/t/op/decl-refs.t
+++ b/t/op/decl-refs.t
@@ -1,7 +1,6 @@
 BEGIN {
     chdir 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan 402;

--- a/t/op/defins.t
+++ b/t/op/defins.t
@@ -7,7 +7,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( qw(. ../lib) );
     $SIG{__WARN__} = sub { $warns++; warn $_[0] };
 }
 

--- a/t/op/delete.t
+++ b/t/op/delete.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc( qw(. ../lib) );
 }
 
 plan( tests => 56 );

--- a/t/op/die.t
+++ b/t/op/die.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 21;

--- a/t/op/die_exit.t
+++ b/t/op/die_exit.t
@@ -8,7 +8,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/do.t
+++ b/t/op/do.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( '../lib' );
 }
 use strict;
 no warnings 'void';

--- a/t/op/dor.t
+++ b/t/op/dor.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
 }
 
 package main;

--- a/t/op/dump.t
+++ b/t/op/dump.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( qw(. ../lib) );
     skip_all_if_miniperl();
 }
 

--- a/t/op/each.t
+++ b/t/op/each.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 59;

--- a/t/op/each_array.t
+++ b/t/op/each_array.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 use strict;
 use warnings;

--- a/t/op/eval.t
+++ b/t/op/eval.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan(tests => 140);

--- a/t/op/evalbytes.t
+++ b/t/op/evalbytes.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     require './charset_tools.pl';
 }
 

--- a/t/op/exec.t
+++ b/t/op/exec.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 my $vms_exit_mode = 0;

--- a/t/op/exists_sub.t
+++ b/t/op/exists_sub.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 sub t1;

--- a/t/op/exp.t
+++ b/t/op/exp.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use Config;

--- a/t/op/fh.t
+++ b/t/op/fh.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 8;

--- a/t/op/filehandle.t
+++ b/t/op/filehandle.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_if_miniperl("no dynamic loading on miniperl, no IO, hence no FileHandle");
 }
 

--- a/t/op/filetest_stack_ok.t
+++ b/t/op/filetest_stack_ok.t
@@ -7,7 +7,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 my @ops = split //, 'rwxoRWXOezsfdlpSbctugkTMBAC';

--- a/t/op/filetest_t.t
+++ b/t/op/filetest_t.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/fork.t
+++ b/t/op/fork.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     require Config;
     skip_all('no fork')
 	unless ($Config::Config{d_fork} or $Config::Config{d_pseudofork});

--- a/t/op/fresh_perl_utf8.t
+++ b/t/op/fresh_perl_utf8.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan 1;

--- a/t/op/getpid.t
+++ b/t/op/getpid.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( qw(../lib) );
     skip_all_if_miniperl(
 	"no dynamic loading on miniperl, no threads/attributes"
     );

--- a/t/op/getppid.t
+++ b/t/op/getppid.t
@@ -13,7 +13,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( qw(../lib) );
 }
 
 use strict;

--- a/t/op/glob.t
+++ b/t/op/glob.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( qw(. ../lib) );
 }
 
 plan( tests => 18 );

--- a/t/op/gmagic.t
+++ b/t/op/gmagic.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/goto.t
+++ b/t/op/goto.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl"; require './charset_tools.pl';
-    set_up_inc( qw(. ../lib) );
 }
 
 use warnings;

--- a/t/op/goto_xs.t
+++ b/t/op/goto_xs.t
@@ -12,7 +12,6 @@ BEGIN {
     require './test.pl';
 # turn warnings into fatal errors
     $SIG{__WARN__} = sub { die "WARNING: @_" } ;
-    set_up_inc('../lib');
     skip_all_if_miniperl("no dynamic loading on miniperl, no Fcntl");
     require Fcntl;
 }

--- a/t/op/grent.t
+++ b/t/op/grent.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 eval {my @n = getgrgid 0};

--- a/t/op/grep.t
+++ b/t/op/grep.t
@@ -7,7 +7,6 @@
 BEGIN {
     chdir 't' if -d 't'; 
     require "./test.pl";
-    set_up_inc( qw(. ../lib) );
 }
 
 plan( tests => 67 );

--- a/t/op/groups.t
+++ b/t/op/groups.t
@@ -12,7 +12,6 @@ BEGIN {
 
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( '../lib' );
     skip_all_if_miniperl("no dynamic loading on miniperl, no POSIX");
 }
 

--- a/t/op/gv.t
+++ b/t/op/gv.t
@@ -7,7 +7,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use warnings;

--- a/t/op/hash-rt85026.t
+++ b/t/op/hash-rt85026.t
@@ -3,7 +3,6 @@
 BEGIN {
   chdir 't' if -d 't';
   require './test.pl';
-  set_up_inc( '../lib' );
   skip_all_without_dynamic_extension("Devel::Peek");
 }
 

--- a/t/op/hash.t
+++ b/t/op/hash.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/hashassign.t
+++ b/t/op/hashassign.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 # use strict;

--- a/t/op/hashwarn.t
+++ b/t/op/hashwarn.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( qw(. ../lib) );
 }
 
 plan( tests => 18 );

--- a/t/op/heredoc.t
+++ b/t/op/heredoc.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/hexfp.t
+++ b/t/op/hexfp.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/inc.t
+++ b/t/op/inc.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/inccode.t
+++ b/t/op/inccode.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use Config;

--- a/t/op/incfilter.t
+++ b/t/op/incfilter.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( qw(. ../lib) );
     skip_all_if_miniperl(
 	'no dynamic loading on miniperl, no Filter::Util::Call'
     );

--- a/t/op/index.t
+++ b/t/op/index.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     require './charset_tools.pl';
 }
 

--- a/t/op/infnan.t
+++ b/t/op/infnan.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/int.t
+++ b/t/op/int.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     require Config;
 }
 

--- a/t/op/isa.t
+++ b/t/op/isa.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     require Config;
 }
 

--- a/t/op/join.t
+++ b/t/op/join.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 29;

--- a/t/op/kill0.t
+++ b/t/op/kill0.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 BEGIN {

--- a/t/op/kvaslice.t
+++ b/t/op/kvaslice.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 # use strict;

--- a/t/op/kvhslice.t
+++ b/t/op/kvhslice.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 # use strict;

--- a/t/op/lc.t
+++ b/t/op/lc.t
@@ -8,7 +8,6 @@ use strict;
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     require Config; import Config;
     skip_all_without_unicode_tables();
     require './charset_tools.pl';

--- a/t/op/leaky-magic.t
+++ b/t/op/leaky-magic.t
@@ -7,7 +7,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 # Hack to allow test counts to be specified piecemeal

--- a/t/op/length.t
+++ b/t/op/length.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan (tests => 41);

--- a/t/op/lex_assign.t
+++ b/t/op/lex_assign.t
@@ -6,7 +6,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 $| = 1;

--- a/t/op/lexsub.t
+++ b/t/op/lexsub.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     *bar::is = *is;
     *bar::like = *like;
 }

--- a/t/op/lfs.t
+++ b/t/op/lfs.t
@@ -5,7 +5,6 @@
 BEGIN {
 	chdir 't' if -d 't';
 	require './test.pl';
-	set_up_inc('../lib');
     require Config;
 	# Don't bother if there are no quad offsets.
 	skip_all('no 64-bit file offsets')

--- a/t/op/list.t
+++ b/t/op/list.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc(qw(. ../lib));
 }
 
 plan( tests => 73 );

--- a/t/op/local.t
+++ b/t/op/local.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc(  qw(. ../lib) );
 }
 plan tests => 319;
 

--- a/t/op/lock.t
+++ b/t/op/lock.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( qw(. ../lib) );
 }
 plan tests => 5;
 

--- a/t/op/loopctl.t
+++ b/t/op/loopctl.t
@@ -33,7 +33,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc(qw(. ../lib));
 }
 
 plan( tests => 67 );

--- a/t/op/lop.t
+++ b/t/op/lop.t
@@ -7,7 +7,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 33;

--- a/t/op/lvref.t
+++ b/t/op/lvref.t
@@ -2,7 +2,6 @@
 BEGIN {
     chdir 't';
     require './test.pl';
-    set_up_inc("../lib");
 }
 
 plan 167;

--- a/t/op/magic.t
+++ b/t/op/magic.t
@@ -4,7 +4,6 @@ BEGIN {
     $| = 1;
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( '../lib' );
     plan (tests => 192); # some tests are run in BEGIN block
 }
 

--- a/t/op/mkdir.t
+++ b/t/op/mkdir.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 17;

--- a/t/op/multideref.t
+++ b/t/op/multideref.t
@@ -12,7 +12,6 @@
 BEGIN {
     chdir 't';
     require './test.pl';
-    set_up_inc("../lib");
 }
 
 use warnings;

--- a/t/op/my.t
+++ b/t/op/my.t
@@ -2,7 +2,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 sub foo {

--- a/t/op/my_stash.t
+++ b/t/op/my_stash.t
@@ -5,7 +5,6 @@ package Foo;
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan 9;

--- a/t/op/mydef.t
+++ b/t/op/mydef.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 1;

--- a/t/op/negate.t
+++ b/t/op/negate.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 48;

--- a/t/op/not.t
+++ b/t/op/not.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 24;

--- a/t/op/numconvert.t
+++ b/t/op/numconvert.t
@@ -41,7 +41,6 @@ BEGIN {
     if (pack("d", 1) =~ /^[\x80\10]\x40/) {
         skip_all("VAX float cannot do infinity");
     }
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/or.t
+++ b/t/op/or.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 

--- a/t/op/ord.t
+++ b/t/op/ord.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc(qw(. ../lib)); # ../lib needed for test.deparse
 }
 
 plan tests => 38;

--- a/t/op/pos.t
+++ b/t/op/pos.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 33;

--- a/t/op/postfixderef.t
+++ b/t/op/postfixderef.t
@@ -11,7 +11,6 @@ this file contains all dereferencing tests from ref.t but using postfix instead 
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc(qw(. ../lib));
 }
 
 use strict qw(refs subs);

--- a/t/op/pow.t
+++ b/t/op/pow.t
@@ -4,7 +4,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 # This calculation ought to be within 0.001 of the right answer.

--- a/t/op/protowarn.t
+++ b/t/op/protowarn.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( qw(. ../lib) );
 }
 
 use strict;

--- a/t/op/push.t
+++ b/t/op/push.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 @tests = split(/\n/, <<EOF);

--- a/t/op/pwent.t
+++ b/t/op/pwent.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/quotemeta.t
+++ b/t/op/quotemeta.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc(  qw(../lib .) );
     require Config; import Config;
     require "./loc_tools.pl";
 }

--- a/t/op/rand.t
+++ b/t/op/rand.t
@@ -18,7 +18,6 @@
 BEGIN {
     chdir "t" if -d "t";
     require "./test.pl";
-    set_up_inc( qw(. ../lib) );
 }
 
 use strict;

--- a/t/op/range.t
+++ b/t/op/range.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib', '.');
 }   
 # Avoid using eq_array below as it uses .. internally.
 

--- a/t/op/read.t
+++ b/t/op/read.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 use strict;
 

--- a/t/op/readdir.t
+++ b/t/op/readdir.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/readline.t
+++ b/t/op/readline.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 32;

--- a/t/op/recurse.t
+++ b/t/op/recurse.t
@@ -7,7 +7,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc(qw(. ../lib));
 }
 
 plan(tests => 28);

--- a/t/op/ref.t
+++ b/t/op/ref.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( qw(. ../lib) );
 }
 
 use strict qw(refs subs);

--- a/t/op/repeat.t
+++ b/t/op/repeat.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( '../lib' );
 }
 
 plan(tests => 50);

--- a/t/op/require_errors.t
+++ b/t/op/require_errors.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( qw(../lib) );
 }
 
 use strict;

--- a/t/op/reset.t
+++ b/t/op/reset.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 use strict;
 

--- a/t/op/reverse.t
+++ b/t/op/reverse.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 24;

--- a/t/op/runlevel.t
+++ b/t/op/runlevel.t
@@ -8,7 +8,6 @@
 
 chdir 't' if -d 't';
 require './test.pl';
-set_up_inc('../lib');
 
 $|=1;
 

--- a/t/op/setpgrpstack.t
+++ b/t/op/setpgrpstack.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_without_config('d_setpgrp');
 }
 

--- a/t/op/signatures.t
+++ b/t/op/signatures.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use warnings;

--- a/t/op/sleep.t
+++ b/t/op/sleep.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc( qw(. ../lib) );
 }
 
 plan( tests => 4 );

--- a/t/op/smartkve.t
+++ b/t/op/smartkve.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 use strict;
 use warnings;

--- a/t/op/smartmatch.t
+++ b/t/op/smartmatch.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 use strict;
 use warnings;

--- a/t/op/sort.t
+++ b/t/op/sort.t
@@ -4,7 +4,6 @@ $|=1;
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 use warnings;
 plan(tests => 203);

--- a/t/op/splice.t
+++ b/t/op/splice.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 $|  = 1;

--- a/t/op/split.t
+++ b/t/op/split.t
@@ -4,7 +4,6 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     require './charset_tools.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 176;

--- a/t/op/sprintf2.t
+++ b/t/op/sprintf2.t
@@ -6,7 +6,6 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     require './charset_tools.pl';
-    set_up_inc('../lib');
 }   
 
 # We'll run 12 extra tests (see below) if $Q is false.

--- a/t/op/srand.t
+++ b/t/op/srand.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir "t" if -d "t";
     require "./test.pl";
-    set_up_inc( qw(. ../lib) );
 }
 
 # Test srand.

--- a/t/op/sselect.t
+++ b/t/op/sselect.t
@@ -6,7 +6,6 @@ my $hires;
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('.', '../lib');
     $hires = eval 'use Time::HiResx "time"; 1';
 }
 

--- a/t/op/stash.t
+++ b/t/op/stash.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc( qw(../lib) );
 }
 
 plan( tests => 55 );

--- a/t/op/stash_parse_gv.t
+++ b/t/op/stash_parse_gv.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc(qw(../lib));
 }
 
 plan( tests => 5 );

--- a/t/op/stat.t
+++ b/t/op/stat.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';	# for which_perl() etc
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/stat_errors.t
+++ b/t/op/stat_errors.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_if_miniperl("miniperl can't load PerlIO::scalar");
 }
 

--- a/t/op/state.t
+++ b/t/op/state.t
@@ -4,7 +4,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/study.t
+++ b/t/op/study.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 watchdog(10);

--- a/t/op/studytied.t
+++ b/t/op/studytied.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/sub.t
+++ b/t/op/sub.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan(tests => 62);

--- a/t/op/sub_lval.t
+++ b/t/op/sub_lval.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 plan tests=>211;
 

--- a/t/op/substr.t
+++ b/t/op/substr.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 use warnings ;
 

--- a/t/op/switch.t
+++ b/t/op/switch.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/symbolcache.t
+++ b/t/op/symbolcache.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan( tests => 8 );

--- a/t/op/sysio.t
+++ b/t/op/sysio.t
@@ -3,7 +3,6 @@
 BEGIN {
   chdir 't' if -d 't';
   require './test.pl';
-  set_up_inc('../lib');
 }
 
 plan tests => 45;

--- a/t/op/taint.t
+++ b/t/op/taint.t
@@ -10,7 +10,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     require './loc_tools.pl';
 }
 

--- a/t/op/threads.t
+++ b/t/op/threads.t
@@ -3,7 +3,6 @@
 BEGIN {
      chdir 't' if -d 't';
      require './test.pl';
-     set_up_inc( '../lib' );
      $| = 1;
 
      skip_all_without_config('useithreads');

--- a/t/op/tie.t
+++ b/t/op/tie.t
@@ -11,7 +11,6 @@
 
 chdir 't' if -d 't';
 require './test.pl';
-set_up_inc('../lib');
 
 $|=1;
 

--- a/t/op/tie_fetch_count.t
+++ b/t/op/tie_fetch_count.t
@@ -6,7 +6,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan (tests => 343);

--- a/t/op/tiearray.t
+++ b/t/op/tiearray.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan(tests => 75);

--- a/t/op/time.t
+++ b/t/op/time.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 72;

--- a/t/op/tr.t
+++ b/t/op/tr.t
@@ -4,7 +4,6 @@ $|=1;
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     if (is_miniperl()) {
 	eval 'require utf8';
         if ($@) { skip_all("miniperl, no 'utf8'") }

--- a/t/op/tr_latin1.t
+++ b/t/op/tr_latin1.t
@@ -4,7 +4,6 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     skip_all('ASCII sensitive') if $::IS_EBCDIC;
-    set_up_inc('../lib');
 }
 
 plan tests => 2;

--- a/t/op/undef.t
+++ b/t/op/undef.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/unlink.t
+++ b/t/op/unlink.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan 6;

--- a/t/op/upgrade.t
+++ b/t/op/upgrade.t
@@ -7,7 +7,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/utf8cache.t
+++ b/t/op/utf8cache.t
@@ -4,7 +4,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/utf8decode.t
+++ b/t/op/utf8decode.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 $|=1;

--- a/t/op/utf8magic.t
+++ b/t/op/utf8magic.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     require './charset_tools.pl';
 }
 

--- a/t/op/utfhash.t
+++ b/t/op/utfhash.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan(tests => 99);

--- a/t/op/utftaint.t
+++ b/t/op/utftaint.t
@@ -4,7 +4,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/vec.t
+++ b/t/op/vec.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use Config;

--- a/t/op/ver.t
+++ b/t/op/ver.t
@@ -4,7 +4,6 @@ BEGIN {
     chdir 't' if -d 't';
     $SIG{'__WARN__'} = sub { warn $_[0] if $DOWARN };
     require "./test.pl";
-    set_up_inc( qw(. ../lib) );
     require "./charset_tools.pl";
 }
 

--- a/t/op/waitpid.t
+++ b/t/op/waitpid.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     require Config;
     skip_all('no Errno')
 	unless eval 'use Errno qw(EINVAL); 1';

--- a/t/op/wantarray.t
+++ b/t/op/wantarray.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/op/while.t
+++ b/t/op/while.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib');
 }
 
 plan(26);

--- a/t/op/write.t
+++ b/t/op/write.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 $| = 0; # test.pl now sets it on, which causes problems here.

--- a/t/op/yadayada.t
+++ b/t/op/yadayada.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/opbasic/arith.t
+++ b/t/opbasic/arith.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 # This file has been placed in t/opbasic to indicate that it should not use

--- a/t/porting/authors.t
+++ b/t/porting/authors.t
@@ -4,7 +4,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc('../lib', '..');
 }
 
 use TestInit qw(T);    # T is chdir to the top level

--- a/t/re/fold_grind.pl
+++ b/t/re/fold_grind.pl
@@ -11,7 +11,6 @@ binmode STDOUT, ":utf8";
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     require Config; import Config;
     skip_all_if_miniperl("no dynamic loading on miniperl, no Encode nor POSIX");
     if ($^O eq 'dec_osf') {

--- a/t/re/fold_grind_8.t
+++ b/t/re/fold_grind_8.t
@@ -10,7 +10,6 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     require './loc_tools.pl';
-    set_up_inc('../lib');
 }
 
 skip_all "No locales" unless locales_enabled('LC_CTYPE');

--- a/t/re/fold_grind_T.t
+++ b/t/re/fold_grind_T.t
@@ -10,7 +10,6 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     require './loc_tools.pl';
-    set_up_inc('../lib');
 }
 
 skip_all "No locales" unless locales_enabled('LC_CTYPE');

--- a/t/re/fold_grind_a.t
+++ b/t/re/fold_grind_a.t
@@ -8,7 +8,6 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     require './loc_tools.pl';
-    set_up_inc('../lib');
 }
 
 $::TEST_CHUNK = 'a';

--- a/t/re/fold_grind_aa.t
+++ b/t/re/fold_grind_aa.t
@@ -10,7 +10,6 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     require './loc_tools.pl';
-    set_up_inc('../lib');
 }
 
 $::TEST_CHUNK = 'aa';

--- a/t/re/fold_grind_d.t
+++ b/t/re/fold_grind_d.t
@@ -8,7 +8,6 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     require './loc_tools.pl';
-    set_up_inc('../lib');
 }
 
 $::TEST_CHUNK = 'd';

--- a/t/re/fold_grind_l.t
+++ b/t/re/fold_grind_l.t
@@ -8,7 +8,6 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     require './loc_tools.pl';
-    set_up_inc('../lib');
 }
 
 skip_all "No locales" unless locales_enabled('LC_CTYPE');

--- a/t/re/fold_grind_u.t
+++ b/t/re/fold_grind_u.t
@@ -8,7 +8,6 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     require './loc_tools.pl';
-    set_up_inc('../lib');
 }
 
 $::TEST_CHUNK = 'u';

--- a/t/re/no_utf8_pm.t
+++ b/t/re/no_utf8_pm.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 1;

--- a/t/re/pat_advanced.t
+++ b/t/re/pat_advanced.t
@@ -8,7 +8,6 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     require './charset_tools.pl';
-    set_up_inc(qw '../lib .');
     skip_all_if_miniperl("miniperl can't load Tie::Hash::NamedCapture, need for %+ and %-");
 }
 

--- a/t/re/pat_psycho.t
+++ b/t/re/pat_psycho.t
@@ -20,7 +20,6 @@ $| = 1;
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib', '.');
     if ($^O eq 'dec_osf') {
         skip_all("$^O cannot handle this test");
     }

--- a/t/re/pat_re_eval.t
+++ b/t/re/pat_re_eval.t
@@ -18,7 +18,6 @@ $| = 1;
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl'; require './charset_tools.pl';
-    set_up_inc('../lib');
 }
 
 our @global;

--- a/t/re/pat_rt_report.t
+++ b/t/re/pat_rt_report.t
@@ -11,7 +11,6 @@ $| = 1;
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( '../lib', '.' );
     skip_all_if_miniperl("miniperl can't load Tie::Hash::NamedCapture, need for %+ and %-");
 }
 

--- a/t/re/pat_special_cc.t
+++ b/t/re/pat_special_cc.t
@@ -8,7 +8,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( '../lib', '.' );
 }
 
 use strict;

--- a/t/re/pos.t
+++ b/t/re/pos.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 8;

--- a/t/re/qr.t
+++ b/t/re/qr.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 4;

--- a/t/re/qr_gc.t
+++ b/t/re/qr_gc.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     undef &Regexp::DESTROY;
 }
 

--- a/t/re/qrstack.t
+++ b/t/re/qrstack.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 1;

--- a/t/re/recompile.t
+++ b/t/re/recompile.t
@@ -13,7 +13,6 @@ $| = 1;
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc( '../lib', '.' );
     skip_all_if_miniperl("no dynamic loading on miniperl, no re");
 }
 

--- a/t/re/reg_60508.t
+++ b/t/re/reg_60508.t
@@ -7,7 +7,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use utf8;

--- a/t/re/reg_email.t
+++ b/t/re/reg_email.t
@@ -6,7 +6,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/re/reg_eval_scope.t
+++ b/t/re/reg_eval_scope.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc(qw(lib ../lib));
     if (is_miniperl()) {
         eval 'require re';
         if ($@) { skip_all("miniperl, no 're'") }

--- a/t/re/reg_fold.t
+++ b/t/re/reg_fold.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_if_miniperl("no dynamic loading on miniperl, no File::Spec");
 }
 

--- a/t/re/reg_nc_tie.t
+++ b/t/re/reg_nc_tie.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_if_miniperl("no dynamic loading on miniperl, no Tie::Hash::NamedCapture");
 }
 

--- a/t/re/reg_nocapture.t
+++ b/t/re/reg_nocapture.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/re/reg_pmod.t
+++ b/t/re/reg_pmod.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/re/reg_posixcc.t
+++ b/t/re/reg_posixcc.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/re/rxcode.t
+++ b/t/re/rxcode.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 42;

--- a/t/re/script_run.t
+++ b/t/re/script_run.t
@@ -1,7 +1,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/re/subst.t
+++ b/t/re/subst.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     require Config; import Config;
     require constant;
     constant->import(constcow => *Config::{NAME});

--- a/t/re/subst_amp.t
+++ b/t/re/subst_amp.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use strict;

--- a/t/uni/attrs.t
+++ b/t/uni/attrs.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_if_miniperl("miniperl can't load attributes");
 }
 

--- a/t/uni/bless.t
+++ b/t/uni/bless.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use utf8;

--- a/t/uni/caller.t
+++ b/t/uni/caller.t
@@ -4,7 +4,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use utf8;

--- a/t/uni/case.pl
+++ b/t/uni/case.pl
@@ -1,6 +1,5 @@
 BEGIN {
     require "./test.pl";
-    set_up_inc(qw(../lib .));
     skip_all_without_unicode_tables();
 }
 use strict;

--- a/t/uni/class.t
+++ b/t/uni/class.t
@@ -1,7 +1,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc(qw(../lib .));
     skip_all_without_unicode_tables();
 }
 

--- a/t/uni/fold.t
+++ b/t/uni/fold.t
@@ -7,7 +7,6 @@ use warnings;
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_without_unicode_tables();
     skip_all_if_miniperl("miniperl, no Unicode::Normalize");
     require Config; import Config;

--- a/t/uni/gv.t
+++ b/t/uni/gv.t
@@ -7,7 +7,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_without_unicode_tables();
 }
 

--- a/t/uni/labels.t
+++ b/t/uni/labels.t
@@ -5,7 +5,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     skip_all_without_unicode_tables();
 }
 

--- a/t/uni/lex_utf8.t
+++ b/t/uni/lex_utf8.t
@@ -7,7 +7,6 @@ BEGIN {
 
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
     require './charset_tools.pl';
     skip_all('no re module') unless defined &DynaLoader::boot_DynaLoader;
     skip_all_without_unicode_tables();

--- a/t/uni/overload.t
+++ b/t/uni/overload.t
@@ -6,7 +6,6 @@ BEGIN {
     require './test.pl';
     require './charset_tools.pl';
     require './loc_tools.pl';
-    set_up_inc( '../lib' );
 }
 
 plan(tests => 193);

--- a/t/uni/readline.t
+++ b/t/uni/readline.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 plan tests => 7;

--- a/t/uni/select.t
+++ b/t/uni/select.t
@@ -7,7 +7,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use utf8;

--- a/t/uni/sprintf.t
+++ b/t/uni/sprintf.t
@@ -3,7 +3,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
-    set_up_inc(qw(../lib .));
 }
 
 plan tests => 52;

--- a/t/uni/stash.t
+++ b/t/uni/stash.t
@@ -7,7 +7,6 @@
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    set_up_inc('../lib');
 }
 
 use utf8;


### PR DESCRIPTION
Add current ./lib and ./t directories to @INC when running tests
avoiding set_up_inc boilerplate in many tests.