### PR TITLE
Fix language referring to GitHub issue tracker in various places

### DIFF
--- a/Configure
+++ b/Configure
@@ -1537,7 +1537,7 @@ case "$sh" in
 $me:  Fatal Error:  I can't find a Bourne Shell anywhere.
 
 Usually it's in /bin/sh.  How did you even get this far?
-Please contact me (Perl Maintainers) at https://github.com/Perl/perl5/issues
+Please report this issue at https://github.com/Perl/perl5/issues
 and we'll try to straighten this all out.
 EOM
 	exit 1

--- a/README.win32
+++ b/README.win32
@@ -922,8 +922,8 @@ Thus, signals may work only for simple things like setting a flag
 variable in the handler.  Using signals under this port should
 currently be considered unsupported.
 
-Please send detailed descriptions of any problems and solutions that
-you may find to E<lt>L<https://github.com/Perl/perl5/issues>E<gt>,
+Please report detailed descriptions of any problems and solutions that
+you may find at E<lt>L<https://github.com/Perl/perl5/issues>E<gt>,
 along with the output produced by C<perl -V>.
 
 =head1 ACKNOWLEDGEMENTS

--- a/hints/README.hints
+++ b/hints/README.hints
@@ -9,7 +9,7 @@ can't or doesn't guess properly.  Most of these hint files have been
 tested with at least some version of perl5, but some are still left
 over from perl4.
 
-Please send any problems or suggested changes to
+Please report any problems or suggested changes at
 L<https://github.com/Perl/perl5/issues>.
 
 =head1 Hint file naming convention.

--- a/hints/bsdos.sh
+++ b/hints/bsdos.sh
@@ -125,7 +125,7 @@ $define|true|[yY]*)
 	*)   cat <<EOM >&4
 I did not know that BSD/OS $osvers supports POSIX threads.
 
-Feel free to tell https://github.com/Perl/perl5/issues otherwise.
+Feel free report that at https://github.com/Perl/perl5/issues otherwise.
 EOM
 	    exit 1
 	    ;;

--- a/hints/freebsd.sh
+++ b/hints/freebsd.sh
@@ -207,7 +207,7 @@ $define|true|[yY]*)
 	0.*|1.*|2.0*|2.1*)   cat <<EOM >&4
 I did not know that FreeBSD $osvers supports POSIX threads.
 
-Feel free to tell https://github.com/Perl/perl5/issues otherwise.
+Feel free to report that at https://github.com/Perl/perl5/issues otherwise.
 EOM
 	      exit 1
 	      ;;


### PR DESCRIPTION
There were a number of spots that used language more appropriate for an email
address than a web-based tracker.

I noticed this because of the recent 5.30.2 release, which has a perldelta
containing the sentence "If you find any we have missed, send email to
https://github.com/Perl/perl5/issues."

But I think that was because the 5.30.2 branch did not include
8166b4e0bc220e759aa233af54ac1e60cc510f0c.