### PR TITLE
intrpvar.h -reorder PERLVARS to close x86-64 alignment holes

### DIFF
--- a/intrpvar.h
+++ b/intrpvar.h
@@ -53,12 +53,12 @@ PERLVARI(I, tmps_ix,	SSize_t,	-1)
 PERLVARI(I, tmps_floor,	SSize_t,	-1)
 PERLVAR(I, tmps_max,	SSize_t)        /* first unalloced slot in tmps stack */
 
-PERLVARI(I, sub_generation, U32, 1)	/* incr to invalidate method cache */
-
 PERLVAR(I, markstack,	I32 *)		/* stack_sp locations we're
 					   remembering */
 PERLVAR(I, markstack_ptr, I32 *)
 PERLVAR(I, markstack_max, I32 *)
+
+PERLVARI(I, sub_generation, U32, 1)	/* incr to invalidate method cache */
 
 #ifdef PERL_HASH_RANDOMIZE_KEYS
 #ifdef USE_PERL_PERTURB_KEYS
@@ -94,18 +94,6 @@ PERLVARI(I, tainted,	bool, FALSE)	/* using variables controlled by $< */
 PERLVAR(I, delaymagic,	U16)		/* ($<,$>) = ... */
 
 /*
-=for apidoc Amn|GV *|PL_defgv
-
-The GV representing C<*_>.  Useful for access to C<$_>.
-
-=cut
-*/
-
-PERLVAR(I, localizing,	U8)		/* are we processing a local() list? */
-PERLVAR(I, in_eval,	U8)		/* trap "fatal" errors? */
-PERLVAR(I, defgv,	GV *)           /* the *_ glob */
-/*
-
 =for apidoc mn|U8|PL_dowarn
 
 The C variable that roughly corresponds to Perl's C<$^W> warning variable.
@@ -124,6 +112,18 @@ PERLVAR(I, dowarn,	U8)
 #endif
 PERLVARI(I, utf8cache, I8, PERL___I)	/* Is the utf8 caching code enabled? */
 #undef PERL___I
+
+/*
+=for apidoc Amn|GV *|PL_defgv
+
+The GV representing C<*_>.  Useful for access to C<$_>.
+
+=cut
+*/
+
+PERLVAR(I, localizing,	U8)		/* are we processing a local() list? */
+PERLVAR(I, in_eval,	U8)		/* trap "fatal" errors? */
+PERLVAR(I, defgv,	GV *)           /* the *_ glob */
 
 /*
 =for apidoc Amn|HV*|PL_curstash
@@ -680,15 +680,15 @@ PERLVARI(I, setlocale_bufsize, Size_t, 0)
 PERLVAR(I, sawampersand, U8)		/* must save all match strings */
 #endif
 
-PERLVAR(I, unsafe,	bool)
-PERLVAR(I, colorset,	bool)		/* PERL_RE_COLORS env var is in use */
-
 /* current phase the interpreter is in
    for ordering this structure to remove holes, we're assuming that this is 4
    bytes.  */
 PERLVARI(I, phase,	enum perl_phase, PERL_PHASE_CONSTRUCT)
 
 PERLVARI(I, in_load_module, bool, FALSE)	/* to prevent recursions in PerlIO_find_layer */
+
+PERLVAR(I, unsafe,	bool)
+PERLVAR(I, colorset,	bool)		/* PERL_RE_COLORS env var is in use */
 
 /*
 =for apidoc Amn|signed char|PL_perl_destruct_level
@@ -715,13 +715,24 @@ value of C<PL_perl_destruct_level> its value is used instead.
 /* mod_perl is special, and also assigns a meaning -1 */
 PERLVARI(I, perl_destruct_level, signed char,	0)
 
+PERLVAR(I, pad_reset_pending, bool)	/* reset pad on next attempted alloc */
+
+PERLVAR(I, srand_called, bool)
+
+#ifdef FCRYPT
+PERLVARI(I, cryptseen,	bool,	FALSE)	/* has fast crypt() been initialized? */
+/* Seven byte hole in the interpreter structure.  */
+/* GH#17623 - FCRYPT may never be defined, consequently may be removed soon.  */
+#endif
+
 #ifdef USE_LOCALE_NUMERIC
 
-PERLVARI(I, numeric_standard, int, TRUE)
-					/* Assume C locale numerics */
 PERLVARI(I, numeric_underlying, bool, TRUE)
 					/* Assume underlying locale numerics */
 PERLVARI(I, numeric_underlying_is_standard, bool, TRUE)
+
+PERLVARI(I, numeric_standard, int, TRUE)
+					/* Assume C locale numerics */
 PERLVAR(I, numeric_name, char *)	/* Name of current numeric locale */
 PERLVAR(I, numeric_radix_sv, SV *)	/* The radix separator if not '.' */
 
@@ -731,15 +742,6 @@ PERLVARI(I, underlying_numeric_obj, locale_t, NULL)
 
 #  endif
 #endif /* !USE_LOCALE_NUMERIC */
-
-#ifdef FCRYPT
-PERLVARI(I, cryptseen,	bool,	FALSE)	/* has fast crypt() been initialized? */
-#else
-/* One byte hole in the interpreter structure.  */
-#endif
-
-PERLVAR(I, pad_reset_pending, bool)	/* reset pad on next attempted alloc */
-PERLVAR(I, srand_called, bool)
 
 /* Array of signal handlers, indexed by signal number, through which the C
    signal handler dispatches.  */


### PR DESCRIPTION
As outlined in #17576, the pahole tool shows alignment holes on x86-64. This commit moves 10 PERLVAR/PERLVARI entries, saving 32 bytes and a cacheline in the **interpreter** struct on threaded builds. Holes remain, but there didn't seem to be any small moves that could close them.

I'm not sure if this change could be detrimental for other architectures, or what the best time in the release cycle would be to apply this kind of change.

Also, I tried to move things sympathetically, but apologies if the moves break up deliberate orderings/groupings.

A general observation: as a newcomer to hacking on the core, it is difficult to identify which items in this file are hot (and how hot) during (i) compilation phase (ii) runtime (iii) both (iv) only when running the debugger (v) never. From some point near the middle of the file, the entries _seem_ like a bit of a mish-mash at times. There may be scope to reorder further to improve locality, potentially freeing up some L1 cache lines during the respective execution phases. 

pahole analysis before these changes:
```
struct interpreter {
	SV * *                     Istack_sp;            /*     0     8 */
	OP *                       Iop;                  /*     8     8 */
	SV * *                     Icurpad;              /*    16     8 */
	SV * *                     Istack_base;          /*    24     8 */
	SV * *                     Istack_max;           /*    32     8 */
	ANY *                      Isavestack;           /*    40     8 */
	I32                        Isavestack_ix;        /*    48     4 */
	I32                        Isavestack_max;       /*    52     4 */
	I32 *                      Iscopestack;          /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	I32                        Iscopestack_ix;       /*    64     4 */
	I32                        Iscopestack_max;      /*    68     4 */
	SV * *                     Itmps_stack;          /*    72     8 */
	ssize_t                    Itmps_ix;             /*    80     8 */
	ssize_t                    Itmps_floor;          /*    88     8 */
	ssize_t                    Itmps_max;            /*    96     8 */
	U32                        Isub_generation;      /*   104     4 */

	/* XXX 4 bytes hole, try to pack */

	I32 *                      Imarkstack;           /*   112     8 */
	I32 *                      Imarkstack_ptr;       /*   120     8 */
	/* --- cacheline 2 boundary (128 bytes) --- */
	I32 *                      Imarkstack_max;       /*   128     8 */
	U8                         Ihash_rand_bits_enabled; /*   136     1 */

	/* XXX 7 bytes hole, try to pack */

	UV                         Ihash_rand_bits;      /*   144     8 */
	HV *                       Istrtab;              /*   152     8 */
	UNOP_AUX_item *            Imultideref_pc;       /*   160     8 */
	PMOP *                     Icurpm;               /*   168     8 */
	PMOP *                     Icurpm_under;         /*   176     8 */
	_Bool                      Itainting;            /*   184     1 */
	_Bool                      Itainted;             /*   185     1 */
	U16                        Idelaymagic;          /*   186     2 */
	U8                         Ilocalizing;          /*   188     1 */
	U8                         Iin_eval;             /*   189     1 */

	/* XXX 2 bytes hole, try to pack */

	/* --- cacheline 3 boundary (192 bytes) --- */
	GV *                       Idefgv;               /*   192     8 */
	U8                         Idowarn;              /*   200     1 */
	I8                         Iutf8cache;           /*   201     1 */

	/* XXX 6 bytes hole, try to pack */

	HV *                       Idefstash;            /*   208     8 */
	HV *                       Icurstash;            /*   216     8 */
	COP *                      Icurcop;              /*   224     8 */
	AV *                       Icurstack;            /*   232     8 */
	PERL_SI *                  Icurstackinfo;        /*   240     8 */
	AV *                       Imainstack;           /*   248     8 */
	/* --- cacheline 4 boundary (256 bytes) --- */
	IV                         Isv_count;            /*   256     8 */
	SV *                       Isv_root;             /*   264     8 */
	SV *                       Isv_arenaroot;        /*   272     8 */
	PMOP *                     Ireg_curpm;           /*   280     8 */
	regmatch_slab *            Iregmatch_slab;       /*   288     8 */
	regmatch_state *           Iregmatch_state;      /*   296     8 */
	PAD *                      Icomppad;             /*   304     8 */
	SV                         Isv_yes;              /*   312    24 */
	/* --- cacheline 5 boundary (320 bytes) was 16 bytes ago --- */
	SV                         Isv_undef;            /*   336    24 */
	SV                         Isv_no;               /*   360    24 */
	/* --- cacheline 6 boundary (384 bytes) --- */
	SV                         Isv_zero;             /*   384    24 */
	PADNAME                    Ipadname_undef;       /*   408    48 */
	/* --- cacheline 7 boundary (448 bytes) was 8 bytes ago --- */
	PADNAME                    Ipadname_const;       /*   456    48 */
	SV *                       ISv;                  /*   504     8 */
	/* --- cacheline 8 boundary (512 bytes) --- */
	yy_parser *                Iparser;              /*   512     8 */
	HV *                       Istashcache;          /*   520     8 */
	STRLEN                     Ina;                  /*   528     8 */
	struct stat        Istatcache;                   /*   536   144 */
	/* --- cacheline 10 boundary (640 bytes) was 40 bytes ago --- */
	GV *                       Istatgv;              /*   680     8 */
	SV *                       Istatname;            /*   688     8 */
	SV *                       Irs;                  /*   696     8 */
	/* --- cacheline 11 boundary (704 bytes) --- */
	GV *                       Ilast_in_gv;          /*   704     8 */
	GV *                       Iofsgv;               /*   712     8 */
	GV *                       Idefoutgv;            /*   720     8 */
	const char  *              Ichopset;             /*   728     8 */
	SV *                       Iformtarget;          /*   736     8 */
	SV *                       Ibodytarget;          /*   744     8 */
	SV *                       Itoptarget;           /*   752     8 */
	OP *                       Irestartop;           /*   760     8 */
	/* --- cacheline 12 boundary (768 bytes) --- */
	JMPENV *                   Irestartjmpenv;       /*   768     8 */
	JMPENV *                   Itop_env;             /*   776     8 */
	JMPENV                     Istart_env;           /*   784   224 */
	/* --- cacheline 15 boundary (960 bytes) was 48 bytes ago --- */
	SV *                       Ierrors;              /*  1008     8 */
	HE *                       Ihv_fetch_ent_mh;     /*  1016     8 */
	/* --- cacheline 16 boundary (1024 bytes) --- */
	OP *                       Ilastgotoprobe;       /*  1024     8 */
	OP *                       Isortcop;             /*  1032     8 */
	HV *                       Isortstash;           /*  1040     8 */
	GV *                       Ifirstgv;             /*  1048     8 */
	GV *                       Isecondgv;            /*  1056     8 */
	char *                     Iefloatbuf;           /*  1064     8 */
	STRLEN                     Iefloatsize;          /*  1072     8 */
	U16                        Idumpindent;          /*  1080     2 */
	U8                         Iexit_flags;          /*  1082     1 */
	_Bool                      Iutf8locale;          /*  1083     1 */
	_Bool                      Iin_utf8_CTYPE_locale; /*  1084     1 */
	_Bool                      Iin_utf8_COLLATE_locale; /*  1085     1 */
	_Bool                      Iin_utf8_turkic_locale; /*  1086     1 */
	char                       Ilocale_utf8ness[256]; /*  1087   256 */

	/* XXX 1 byte hole, try to pack */

	/* --- cacheline 21 boundary (1344 bytes) --- */
	SV *                       Iwarn_locale;         /*  1344     8 */
	char *                     Icolors[6];           /*  1352    48 */
	peep_t                     Ipeepp;               /*  1400     8 */
	/* --- cacheline 22 boundary (1408 bytes) --- */
	peep_t                     Irpeepp;              /*  1408     8 */
	Perl_ophook_t              Iopfreehook;          /*  1416     8 */
	char * *                   Iwatchaddr;           /*  1424     8 */
	char *                     Iwatchok;             /*  1432     8 */
	U32                        Iperldb;              /*  1440     4 */
	U32                        Isignals;             /*  1444     4 */
	int                        Ireentrant_retint;    /*  1448     4 */
	int                        Iorigargc;            /*  1452     4 */
	char * *                   Iorigargv;            /*  1456     8 */
	GV *                       Ienvgv;               /*  1464     8 */
	/* --- cacheline 23 boundary (1472 bytes) --- */
	GV *                       Iincgv;               /*  1472     8 */
	GV *                       Ihintgv;              /*  1480     8 */
	char *                     Iorigfilename;        /*  1488     8 */
	const char  *              Ixsubfilename;        /*  1496     8 */
	SV *                       Idiehook;             /*  1504     8 */
	SV *                       Iwarnhook;            /*  1512     8 */
	SV *                       Ipatchlevel;          /*  1520     8 */
	const char  * const *      Ilocalpatches;        /*  1528     8 */
	/* --- cacheline 24 boundary (1536 bytes) --- */
	const char  *              Isplitstr;            /*  1536     8 */
	_Bool                      Iminus_c;             /*  1544     1 */
	_Bool                      Iminus_n;             /*  1545     1 */
	_Bool                      Iminus_p;             /*  1546     1 */
	_Bool                      Iminus_l;             /*  1547     1 */
	_Bool                      Iminus_a;             /*  1548     1 */
	_Bool                      Iminus_F;             /*  1549     1 */
	_Bool                      Idoswitches;          /*  1550     1 */
	_Bool                      Iminus_E;             /*  1551     1 */
	char *                     Iinplace;             /*  1552     8 */
	SV *                       Ie_script;            /*  1560     8 */
	time_t                     Ibasetime;            /*  1568     8 */
	I32                        Imaxsysfd;            /*  1576     4 */
	I32                        Istatusvalue;         /*  1580     4 */
	I32                        Istatusvalue_posix;   /*  1584     4 */
	int                        Isig_pending;         /*  1588     4 */
	int *                      Ipsig_pend;           /*  1592     8 */
	/* --- cacheline 25 boundary (1600 bytes) --- */
	GV *                       Istdingv;             /*  1600     8 */
	GV *                       Istderrgv;            /*  1608     8 */
	GV *                       Iargvgv;              /*  1616     8 */
	GV *                       Iargvoutgv;           /*  1624     8 */
	AV *                       Iargvout_stack;       /*  1632     8 */
	GV *                       Ireplgv;              /*  1640     8 */
	GV *                       Ierrgv;               /*  1648     8 */
	GV *                       IDBgv;                /*  1656     8 */
	/* --- cacheline 26 boundary (1664 bytes) --- */
	GV *                       IDBline;              /*  1664     8 */
	GV *                       IDBsub;               /*  1672     8 */
	SV *                       IDBsingle;            /*  1680     8 */
	SV *                       IDBtrace;             /*  1688     8 */
	SV *                       IDBsignal;            /*  1696     8 */
	AV *                       Idbargs;              /*  1704     8 */
	IV                         IDBcontrol[3];        /*  1712    24 */
	/* --- cacheline 27 boundary (1728 bytes) was 8 bytes ago --- */
	HV *                       Idebstash;            /*  1736     8 */
	HV *                       Iglobalstash;         /*  1744     8 */
	SV *                       Icurstname;           /*  1752     8 */
	AV *                       Ibeginav;             /*  1760     8 */
	AV *                       Iendav;               /*  1768     8 */
	AV *                       Iunitcheckav;         /*  1776     8 */
	AV *                       Icheckav;             /*  1784     8 */
	/* --- cacheline 28 boundary (1792 bytes) --- */
	AV *                       Iinitav;              /*  1792     8 */
	AV *                       Ifdpid;               /*  1800     8 */
	char *                     Iop_mask;             /*  1808     8 */
	CV *                       Imain_cv;             /*  1816     8 */
	OP *                       Imain_root;           /*  1824     8 */
	OP *                       Imain_start;          /*  1832     8 */
	OP *                       Ieval_root;           /*  1840     8 */
	OP *                       Ieval_start;          /*  1848     8 */
	/* --- cacheline 29 boundary (1856 bytes) --- */
	COP *                      Icurcopdb;            /*  1856     8 */
	int                        Ifilemode;            /*  1864     4 */
	int                        Ilastfd;              /*  1868     4 */
	char *                     Ioldname;             /*  1872     8 */
	AV *                       Ipreambleav;          /*  1880     8 */
	SV *                       Imess_sv;             /*  1888     8 */
	SV *                       Iors_sv;              /*  1896     8 */
	int                        Iforkprocess;         /*  1904     4 */
	I32                        Igensym;              /*  1908     4 */
	_Bool                      Icv_has_eval;         /*  1912     1 */
	_Bool                      Itaint_warn;          /*  1913     1 */
	U16                        Ilaststype;           /*  1914     2 */
	int                        Ilaststatval;         /*  1916     4 */
	/* --- cacheline 30 boundary (1920 bytes) --- */
	I32                        Imodcount;            /*  1920     4 */
	I32                        Iexitlistlen;         /*  1924     4 */
	PerlExitListEntry *        Iexitlist;            /*  1928     8 */
	HV *                       Imodglobal;           /*  1936     8 */
	U32 *                      Iprofiledata;         /*  1944     8 */
	COP                        Icompiling;           /*  1952    88 */
	/* --- cacheline 31 boundary (1984 bytes) was 56 bytes ago --- */
	CV *                       Icompcv;              /*  2040     8 */
	/* --- cacheline 32 boundary (2048 bytes) --- */
	PADNAMELIST *              Icomppad_name;        /*  2048     8 */
	PADOFFSET                  Icomppad_name_fill;   /*  2056     8 */
	PADOFFSET                  Icomppad_name_floor;  /*  2064     8 */
	CV *                       IDBcv;                /*  2072     8 */
	int                        Igeneration;          /*  2080     4 */
	U32                        Iunicode;             /*  2084     4 */
	_Bool                      Iin_clean_objs;       /*  2088     1 */
	_Bool                      Iin_clean_all;        /*  2089     1 */
	_Bool                      Inomemok;             /*  2090     1 */
	_Bool                      Isavebegin;           /*  2091     1 */
	uid_t                      Idelaymagic_uid;      /*  2092     4 */
	uid_t                      Idelaymagic_euid;     /*  2096     4 */
	gid_t                      Idelaymagic_gid;      /*  2100     4 */
	gid_t                      Idelaymagic_egid;     /*  2104     4 */
	U32                        Ian;                  /*  2108     4 */
	/* --- cacheline 33 boundary (2112 bytes) --- */
	U32                        Ibreakable_sub_gen;   /*  2112     4 */
	U32                        Icop_seqmax;          /*  2116     4 */
	U32                        Ievalseq;             /*  2120     4 */
	U32                        Iorigalen;            /*  2124     4 */
	char * *                   Iorigenviron;         /*  2128     8 */
	char *                     Iosname;              /*  2136     8 */
	Sighandler_t               Isighandlerp;         /*  2144     8 */
	Sighandler1_t              Isighandler1p;        /*  2152     8 */
	Sighandler3_t              Isighandler3p;        /*  2160     8 */
	void *                     Ibody_roots[16];      /*  2168   128 */
	/* --- cacheline 35 boundary (2240 bytes) was 56 bytes ago --- */
	volatile U32               Idebug;               /*  2296     4 */
	U32                        Ipadlist_generation;  /*  2300     4 */
	/* --- cacheline 36 boundary (2304 bytes) --- */
	runops_proc_t              Irunops;              /*  2304     8 */
	SV *                       Isubname;             /*  2312     8 */
	I32                        Isubline;             /*  2320     4 */

	/* XXX 4 bytes hole, try to pack */

	PADOFFSET                  Imin_intro_pending;   /*  2328     8 */
	PADOFFSET                  Imax_intro_pending;   /*  2336     8 */
	PADOFFSET                  Ipadix;               /*  2344     8 */
	PADOFFSET                  Iconstpadix;          /*  2352     8 */
	PADOFFSET                  Ipadix_floor;         /*  2360     8 */
	/* --- cacheline 37 boundary (2368 bytes) --- */
	char *                     Icurlocales[12];      /*  2368    96 */
	/* --- cacheline 38 boundary (2432 bytes) was 32 bytes ago --- */
	char *                     Icollation_name;      /*  2464     8 */
	size_t                     Icollxfrm_base;       /*  2472     8 */
	size_t                     Icollxfrm_mult;       /*  2480     8 */
	U32                        Icollation_ix;        /*  2488     4 */
	U8                         Istrxfrm_NUL_replacement; /*  2492     1 */
	_Bool                      Istrxfrm_is_behaved;  /*  2493     1 */
	U8                         Istrxfrm_max_cp;      /*  2494     1 */
	_Bool                      Icollation_standard;  /*  2495     1 */
	/* --- cacheline 39 boundary (2496 bytes) --- */
	char *                     Ilanginfo_buf;        /*  2496     8 */
	size_t                     Ilanginfo_bufsize;    /*  2504     8 */
	char *                     Isetlocale_buf;       /*  2512     8 */
	size_t                     Isetlocale_bufsize;   /*  2520     8 */
	_Bool                      Iunsafe;              /*  2528     1 */
	_Bool                      Icolorset;            /*  2529     1 */

	/* XXX 2 bytes hole, try to pack */

	enum perl_phase    Iphase;                       /*  2532     4 */
	_Bool                      Iin_load_module;      /*  2536     1 */
	signed char                Iperl_destruct_level; /*  2537     1 */

	/* XXX 2 bytes hole, try to pack */

	int                        Inumeric_standard;    /*  2540     4 */
	_Bool                      Inumeric_underlying;  /*  2544     1 */
	_Bool                      Inumeric_underlying_is_standard; /*  2545     1 */

	/* XXX 6 bytes hole, try to pack */

	char *                     Inumeric_name;        /*  2552     8 */
	/* --- cacheline 40 boundary (2560 bytes) --- */
	SV *                       Inumeric_radix_sv;    /*  2560     8 */
	locale_t                   Iunderlying_numeric_obj; /*  2568     8 */
	_Bool                      Ipad_reset_pending;   /*  2576     1 */
	_Bool                      Isrand_called;        /*  2577     1 */

	/* XXX 6 bytes hole, try to pack */

	SV * *                     Ipsig_ptr;            /*  2584     8 */
	SV * *                     Ipsig_name;           /*  2592     8 */
	PTR_TBL_t *                Iptr_table;           /*  2600     8 */
	AV *                       Ibeginav_save;        /*  2608     8 */
	void *                     Ibody_arenas;         /*  2616     8 */
	/* --- cacheline 41 boundary (2624 bytes) --- */
	SV * *                     Iregex_pad;           /*  2624     8 */
	AV *                       Iregex_padav;         /*  2632     8 */
	HV * *                     Istashpad;            /*  2640     8 */
	PADOFFSET                  Istashpadmax;         /*  2648     8 */
	PADOFFSET                  Istashpadix;          /*  2656     8 */
	REENTR *                   Ireentrant_buffer;    /*  2664     8 */
	HV *                       Icustom_op_names;     /*  2672     8 */
	HV *                       Icustom_op_descs;     /*  2680     8 */
	/* --- cacheline 42 boundary (2688 bytes) --- */
	PerlIOl *                  Iperlio;              /*  2688     8 */
	PerlIO_list_t *            Iknown_layers;        /*  2696     8 */
	PerlIO_list_t *            Idef_layerlist;       /*  2704     8 */
	SVCOMPARE_t                Isort_RealCmp;        /*  2712     8 */
	AV *                       Icheckav_save;        /*  2720     8 */
	AV *                       Iunitcheckav_save;    /*  2728     8 */
	long int                   Iclocktick;           /*  2736     8 */
	share_proc_t               Isharehook;           /*  2744     8 */
	/* --- cacheline 43 boundary (2752 bytes) --- */
	share_proc_t               Ilockhook;            /*  2752     8 */
	share_proc_t               Iunlockhook;          /*  2760     8 */
	thrhook_proc_t             Ithreadhook;          /*  2768     8 */
	destroyable_proc_t         Idestroyhook;         /*  2776     8 */
	despatch_signals_proc_t    Isignalhook;          /*  2784     8 */
	HV *                       Iisarev;              /*  2792     8 */
	HV *                       Iregistered_mros;     /*  2800     8 */
	AV *                       Iblockhooks;          /*  2808     8 */
	/* --- cacheline 44 boundary (2816 bytes) --- */
	HV *                       Icustom_ops;          /*  2816     8 */
	XPV *                      IXpv;                 /*  2824     8 */
	const char  * *            Iscopestack_name;     /*  2832     8 */
	struct perl_debug_pad Idebug_pad;                /*  2840    72 */
	/* --- cacheline 45 boundary (2880 bytes) was 32 bytes ago --- */
	globhook_t                 Iglobhook;            /*  2912     8 */
	void * *                   Imy_cxt_list;         /*  2920     8 */
	int                        Imy_cxt_size;         /*  2928     4 */

	/* XXX 4 bytes hole, try to pack */

	struct perl_memory_debug_header Imemory_debug_header; /*  2936    24 */
	/* --- cacheline 46 boundary (2944 bytes) was 16 bytes ago --- */
	SV *                       Isv_consts[35];       /*  2960   280 */
	/* --- cacheline 50 boundary (3200 bytes) was 40 bytes ago --- */
	perl_drand48_t             Irandom_state;        /*  3240     8 */
	STRLEN                     Idump_re_max_len;     /*  3248     8 */
	perl_drand48_t             Iinternal_random_state; /*  3256     8 */
	/* --- cacheline 51 boundary (3264 bytes) --- */
	char                       ITR_SPECIAL_HANDLING_UTF8[13]; /*  3264    13 */

	/* XXX 3 bytes hole, try to pack */

	SV *                       IAboveLatin1;         /*  3280     8 */
	SV *                       IAssigned_invlist;    /*  3288     8 */
	SV *                       IGCB_invlist;         /*  3296     8 */
	SV *                       IHasMultiCharFold;    /*  3304     8 */
	SV *                       IInMultiCharFold;     /*  3312     8 */
	SV *                       ILatin1;              /*  3320     8 */
	/* --- cacheline 52 boundary (3328 bytes) --- */
	SV *                       ILB_invlist;          /*  3328     8 */
	SV *                       ISB_invlist;          /*  3336     8 */
	SV *                       ISCX_invlist;         /*  3344     8 */
	SV *                       IUpperLatin1;         /*  3352     8 */
	SV *                       Iin_some_fold;        /*  3360     8 */
	SV *                       Iutf8_idcont;         /*  3368     8 */
	SV *                       Iutf8_idstart;        /*  3376     8 */
	SV *                       Iutf8_perl_idcont;    /*  3384     8 */
	/* --- cacheline 53 boundary (3392 bytes) --- */
	SV *                       Iutf8_perl_idstart;   /*  3392     8 */
	SV *                       Iutf8_xidcont;        /*  3400     8 */
	SV *                       Iutf8_xidstart;       /*  3408     8 */
	SV *                       IWB_invlist;          /*  3416     8 */
	SV *                       IXPosix_ptrs[16];     /*  3424   128 */
	/* --- cacheline 55 boundary (3520 bytes) was 32 bytes ago --- */
	SV *                       IPosix_ptrs[16];      /*  3552   128 */
	/* --- cacheline 57 boundary (3648 bytes) was 32 bytes ago --- */
	SV *                       Iutf8_toupper;        /*  3680     8 */
	SV *                       Iutf8_totitle;        /*  3688     8 */
	SV *                       Iutf8_tolower;        /*  3696     8 */
	SV *                       Iutf8_tofold;         /*  3704     8 */
	/* --- cacheline 58 boundary (3712 bytes) --- */
	SV *                       Iutf8_tosimplefold;   /*  3712     8 */
	SV *                       Iutf8_charname_begin; /*  3720     8 */
	SV *                       Iutf8_charname_continue; /*  3728     8 */
	SV *                       Iutf8_mark;           /*  3736     8 */
	SV *                       IInBitmap;            /*  3744     8 */
	SV *                       ICCC_non0_non230;     /*  3752     8 */
	SV *                       IPrivate_Use;         /*  3760     8 */
	mbstate_t                  Imbrlen_ps;           /*  3768     8 */
	/* --- cacheline 59 boundary (3776 bytes) --- */
	mbstate_t                  Imbrtowc_ps;          /*  3776     8 */
	mbstate_t                  Iwcrtomb_ps;          /*  3784     8 */

	/* size: 3792, cachelines: 60, members: 312 */
	/* sum members: 3745, holes: 12, sum holes: 47 */
	/* last cacheline: 16 bytes */
};
```
pahole analysis after these changes:
```
struct interpreter {
	SV * *                     Istack_sp;            /*     0     8 */
	OP *                       Iop;                  /*     8     8 */
	SV * *                     Icurpad;              /*    16     8 */
	SV * *                     Istack_base;          /*    24     8 */
	SV * *                     Istack_max;           /*    32     8 */
	ANY *                      Isavestack;           /*    40     8 */
	I32                        Isavestack_ix;        /*    48     4 */
	I32                        Isavestack_max;       /*    52     4 */
	I32 *                      Iscopestack;          /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	I32                        Iscopestack_ix;       /*    64     4 */
	I32                        Iscopestack_max;      /*    68     4 */
	SV * *                     Itmps_stack;          /*    72     8 */
	ssize_t                    Itmps_ix;             /*    80     8 */
	ssize_t                    Itmps_floor;          /*    88     8 */
	ssize_t                    Itmps_max;            /*    96     8 */
	I32 *                      Imarkstack;           /*   104     8 */
	I32 *                      Imarkstack_ptr;       /*   112     8 */
	I32 *                      Imarkstack_max;       /*   120     8 */
	/* --- cacheline 2 boundary (128 bytes) --- */
	U32                        Isub_generation;      /*   128     4 */
	U8                         Ihash_rand_bits_enabled; /*   132     1 */

	/* XXX 3 bytes hole, try to pack */

	UV                         Ihash_rand_bits;      /*   136     8 */
	HV *                       Istrtab;              /*   144     8 */
	UNOP_AUX_item *            Imultideref_pc;       /*   152     8 */
	PMOP *                     Icurpm;               /*   160     8 */
	PMOP *                     Icurpm_under;         /*   168     8 */
	_Bool                      Itainting;            /*   176     1 */
	_Bool                      Itainted;             /*   177     1 */
	U16                        Idelaymagic;          /*   178     2 */
	U8                         Idowarn;              /*   180     1 */
	I8                         Iutf8cache;           /*   181     1 */
	U8                         Ilocalizing;          /*   182     1 */
	U8                         Iin_eval;             /*   183     1 */
	GV *                       Idefgv;               /*   184     8 */
	/* --- cacheline 3 boundary (192 bytes) --- */
	HV *                       Idefstash;            /*   192     8 */
	HV *                       Icurstash;            /*   200     8 */
	COP *                      Icurcop;              /*   208     8 */
	AV *                       Icurstack;            /*   216     8 */
	PERL_SI *                  Icurstackinfo;        /*   224     8 */
	AV *                       Imainstack;           /*   232     8 */
	IV                         Isv_count;            /*   240     8 */
	SV *                       Isv_root;             /*   248     8 */
	/* --- cacheline 4 boundary (256 bytes) --- */
	SV *                       Isv_arenaroot;        /*   256     8 */
	PMOP *                     Ireg_curpm;           /*   264     8 */
	regmatch_slab *            Iregmatch_slab;       /*   272     8 */
	regmatch_state *           Iregmatch_state;      /*   280     8 */
	PAD *                      Icomppad;             /*   288     8 */
	SV                         Isv_yes;              /*   296    24 */
	/* --- cacheline 5 boundary (320 bytes) --- */
	SV                         Isv_undef;            /*   320    24 */
	SV                         Isv_no;               /*   344    24 */
	SV                         Isv_zero;             /*   368    24 */
	/* --- cacheline 6 boundary (384 bytes) was 8 bytes ago --- */
	PADNAME                    Ipadname_undef;       /*   392    48 */
	PADNAME                    Ipadname_const;       /*   440    48 */
	/* --- cacheline 7 boundary (448 bytes) was 40 bytes ago --- */
	SV *                       ISv;                  /*   488     8 */
	yy_parser *                Iparser;              /*   496     8 */
	HV *                       Istashcache;          /*   504     8 */
	/* --- cacheline 8 boundary (512 bytes) --- */
	STRLEN                     Ina;                  /*   512     8 */
	struct stat        Istatcache;                   /*   520   144 */
	/* --- cacheline 10 boundary (640 bytes) was 24 bytes ago --- */

	GV *                       Ilast_in_gv;          /*   688     8 */
	GV *                       Iofsgv;               /*   696     8 */
	/* --- cacheline 11 boundary (704 bytes) --- */
	GV *                       Idefoutgv;            /*   704     8 */
	const char  *              Ichopset;             /*   712     8 */
	SV *                       Iformtarget;          /*   720     8 */
	SV *                       Ibodytarget;          /*   728     8 */
	SV *                       Itoptarget;           /*   736     8 */
	OP *                       Irestartop;           /*   744     8 */
	JMPENV *                   Irestartjmpenv;       /*   752     8 */
	JMPENV *                   Itop_env;             /*   760     8 */
	/* --- cacheline 12 boundary (768 bytes) --- */
	JMPENV                     Istart_env;           /*   768   224 */
	/* --- cacheline 15 boundary (960 bytes) was 32 bytes ago --- */
	SV *                       Ierrors;              /*   992     8 */
	HE *                       Ihv_fetch_ent_mh;     /*  1000     8 */
	OP *                       Ilastgotoprobe;       /*  1008     8 */
	OP *                       Isortcop;             /*  1016     8 */
	/* --- cacheline 16 boundary (1024 bytes) --- */
	HV *                       Isortstash;           /*  1024     8 */
	GV *                       Ifirstgv;             /*  1032     8 */
	GV *                       Isecondgv;            /*  1040     8 */
	char *                     Iefloatbuf;           /*  1048     8 */
	STRLEN                     Iefloatsize;          /*  1056     8 */
	U16                        Idumpindent;          /*  1064     2 */
	U8                         Iexit_flags;          /*  1066     1 */
	_Bool                      Iutf8locale;          /*  1067     1 */
	_Bool                      Iin_utf8_CTYPE_locale; /*  1068     1 */
	_Bool                      Iin_utf8_COLLATE_locale; /*  1069     1 */
	_Bool                      Iin_utf8_turkic_locale; /*  1070     1 */
	char                       Ilocale_utf8ness[256]; /*  1071   256 */

	/* XXX 1 byte hole, try to pack */

	/* --- cacheline 20 boundary (1280 bytes) was 48 bytes ago --- */
	SV *                       Iwarn_locale;         /*  1328     8 */
	char *                     Icolors[6];           /*  1336    48 */
	/* --- cacheline 21 boundary (1344 bytes) was 40 bytes ago --- */
	peep_t                     Ipeepp;               /*  1384     8 */
	peep_t                     Irpeepp;              /*  1392     8 */
	Perl_ophook_t              Iopfreehook;          /*  1400     8 */
	/* --- cacheline 22 boundary (1408 bytes) --- */
	char * *                   Iwatchaddr;           /*  1408     8 */
	char *                     Iwatchok;             /*  1416     8 */
	U32                        Iperldb;              /*  1424     4 */
	U32                        Isignals;             /*  1428     4 */
	int                        Ireentrant_retint;    /*  1432     4 */
	int                        Iorigargc;            /*  1436     4 */
	char * *                   Iorigargv;            /*  1440     8 */
	GV *                       Ienvgv;               /*  1448     8 */
	GV *                       Iincgv;               /*  1456     8 */
	GV *                       Ihintgv;              /*  1464     8 */
	/* --- cacheline 23 boundary (1472 bytes) --- */
	char *                     Iorigfilename;        /*  1472     8 */
	const char  *              Ixsubfilename;        /*  1480     8 */
	SV *                       Idiehook;             /*  1488     8 */
	SV *                       Iwarnhook;            /*  1496     8 */
	SV *                       Ipatchlevel;          /*  1504     8 */
	const char  * const *      Ilocalpatches;        /*  1512     8 */
	const char  *              Isplitstr;            /*  1520     8 */
	_Bool                      Iminus_c;             /*  1528     1 */
	_Bool                      Iminus_n;             /*  1529     1 */
	_Bool                      Iminus_p;             /*  1530     1 */
	_Bool                      Iminus_l;             /*  1531     1 */
	_Bool                      Iminus_a;             /*  1532     1 */
	_Bool                      Iminus_F;             /*  1533     1 */
	_Bool                      Idoswitches;          /*  1534     1 */
	_Bool                      Iminus_E;             /*  1535     1 */
	/* --- cacheline 24 boundary (1536 bytes) --- */
	char *                     Iinplace;             /*  1536     8 */
	SV *                       Ie_script;            /*  1544     8 */
	time_t                     Ibasetime;            /*  1552     8 */
	I32                        Imaxsysfd;            /*  1560     4 */
	I32                        Istatusvalue;         /*  1564     4 */
	I32                        Istatusvalue_posix;   /*  1568     4 */
	int                        Isig_pending;         /*  1572     4 */
	int *                      Ipsig_pend;           /*  1576     8 */
	GV *                       Istdingv;             /*  1584     8 */
	GV *                       Istderrgv;            /*  1592     8 */
	/* --- cacheline 25 boundary (1600 bytes) --- */
	GV *                       Iargvgv;              /*  1600     8 */
	GV *                       Iargvoutgv;           /*  1608     8 */
	AV *                       Iargvout_stack;       /*  1616     8 */
	GV *                       Ireplgv;              /*  1624     8 */
	GV *                       Ierrgv;               /*  1632     8 */
	GV *                       IDBgv;                /*  1640     8 */
	GV *                       IDBline;              /*  1648     8 */
	GV *                       IDBsub;               /*  1656     8 */
	/* --- cacheline 26 boundary (1664 bytes) --- */
	SV *                       IDBsingle;            /*  1664     8 */
	SV *                       IDBtrace;             /*  1672     8 */
	SV *                       IDBsignal;            /*  1680     8 */
	AV *                       Idbargs;              /*  1688     8 */
	IV                         IDBcontrol[3];        /*  1696    24 */
	HV *                       Idebstash;            /*  1720     8 */
	/* --- cacheline 27 boundary (1728 bytes) --- */
	HV *                       Iglobalstash;         /*  1728     8 */
	SV *                       Icurstname;           /*  1736     8 */
	AV *                       Ibeginav;             /*  1744     8 */
	AV *                       Iendav;               /*  1752     8 */
	AV *                       Iunitcheckav;         /*  1760     8 */
	AV *                       Icheckav;             /*  1768     8 */
	AV *                       Iinitav;              /*  1776     8 */
	AV *                       Ifdpid;               /*  1784     8 */
	/* --- cacheline 28 boundary (1792 bytes) --- */
	char *                     Iop_mask;             /*  1792     8 */
	CV *                       Imain_cv;             /*  1800     8 */
	OP *                       Imain_root;           /*  1808     8 */
	OP *                       Imain_start;          /*  1816     8 */
	OP *                       Ieval_root;           /*  1824     8 */
	OP *                       Ieval_start;          /*  1832     8 */
	COP *                      Icurcopdb;            /*  1840     8 */
	int                        Ifilemode;            /*  1848     4 */
	int                        Ilastfd;              /*  1852     4 */
	/* --- cacheline 29 boundary (1856 bytes) --- */
	char *                     Ioldname;             /*  1856     8 */
	AV *                       Ipreambleav;          /*  1864     8 */
	SV *                       Imess_sv;             /*  1872     8 */
	SV *                       Iors_sv;              /*  1880     8 */
	int                        Iforkprocess;         /*  1888     4 */
	I32                        Igensym;              /*  1892     4 */
	_Bool                      Icv_has_eval;         /*  1896     1 */
	_Bool                      Itaint_warn;          /*  1897     1 */
	U16                        Ilaststype;           /*  1898     2 */
	int                        Ilaststatval;         /*  1900     4 */
	I32                        Imodcount;            /*  1904     4 */
	I32                        Iexitlistlen;         /*  1908     4 */
	PerlExitListEntry *        Iexitlist;            /*  1912     8 */
	/* --- cacheline 30 boundary (1920 bytes) --- */
	HV *                       Imodglobal;           /*  1920     8 */
	U32 *                      Iprofiledata;         /*  1928     8 */
	COP                        Icompiling;           /*  1936    88 */
	/* --- cacheline 31 boundary (1984 bytes) was 40 bytes ago --- */
	CV *                       Icompcv;              /*  2024     8 */
	PADNAMELIST *              Icomppad_name;        /*  2032     8 */
	PADOFFSET                  Icomppad_name_fill;   /*  2040     8 */
	/* --- cacheline 32 boundary (2048 bytes) --- */
	PADOFFSET                  Icomppad_name_floor;  /*  2048     8 */
	CV *                       IDBcv;                /*  2056     8 */
	int                        Igeneration;          /*  2064     4 */
	U32                        Iunicode;             /*  2068     4 */
	_Bool                      Iin_clean_objs;       /*  2072     1 */
	_Bool                      Iin_clean_all;        /*  2073     1 */
	_Bool                      Inomemok;             /*  2074     1 */
	_Bool                      Isavebegin;           /*  2075     1 */
	uid_t                      Idelaymagic_uid;      /*  2076     4 */
	uid_t                      Idelaymagic_euid;     /*  2080     4 */
	gid_t                      Idelaymagic_gid;      /*  2084     4 */
	gid_t                      Idelaymagic_egid;     /*  2088     4 */
	U32                        Ian;                  /*  2092     4 */
	U32                        Ibreakable_sub_gen;   /*  2096     4 */
	U32                        Icop_seqmax;          /*  2100     4 */
	U32                        Ievalseq;             /*  2104     4 */
	U32                        Iorigalen;            /*  2108     4 */
	/* --- cacheline 33 boundary (2112 bytes) --- */
	char * *                   Iorigenviron;         /*  2112     8 */
	char *                     Iosname;              /*  2120     8 */
	Sighandler_t               Isighandlerp;         /*  2128     8 */
	Sighandler1_t              Isighandler1p;        /*  2136     8 */
	Sighandler3_t              Isighandler3p;        /*  2144     8 */
	void *                     Ibody_roots[16];      /*  2152   128 */
	/* --- cacheline 35 boundary (2240 bytes) was 40 bytes ago --- */
	volatile U32               Idebug;               /*  2280     4 */
	U32                        Ipadlist_generation;  /*  2284     4 */
	runops_proc_t              Irunops;              /*  2288     8 */
	SV *                       Isubname;             /*  2296     8 */
	/* --- cacheline 36 boundary (2304 bytes) --- */
	I32                        Isubline;             /*  2304     4 */

	/* XXX 4 bytes hole, try to pack */

	PADOFFSET                  Imin_intro_pending;   /*  2312     8 */
	PADOFFSET                  Imax_intro_pending;   /*  2320     8 */
	PADOFFSET                  Ipadix;               /*  2328     8 */
	PADOFFSET                  Iconstpadix;          /*  2336     8 */
	PADOFFSET                  Ipadix_floor;         /*  2344     8 */
	char *                     Icurlocales[12];      /*  2352    96 */
	/* --- cacheline 38 boundary (2432 bytes) was 16 bytes ago --- */
	char *                     Icollation_name;      /*  2448     8 */
	size_t                     Icollxfrm_base;       /*  2456     8 */
	size_t                     Icollxfrm_mult;       /*  2464     8 */
	U32                        Icollation_ix;        /*  2472     4 */
	U8                         Istrxfrm_NUL_replacement; /*  2476     1 */
	_Bool                      Istrxfrm_is_behaved;  /*  2477     1 */
	U8                         Istrxfrm_max_cp;      /*  2478     1 */
	_Bool                      Icollation_standard;  /*  2479     1 */
	char *                     Ilanginfo_buf;        /*  2480     8 */
	size_t                     Ilanginfo_bufsize;    /*  2488     8 */
	/* --- cacheline 39 boundary (2496 bytes) --- */
	char *                     Isetlocale_buf;       /*  2496     8 */
	size_t                     Isetlocale_bufsize;   /*  2504     8 */
	enum perl_phase    Iphase;                       /*  2512     4 */
	_Bool                      Iin_load_module;      /*  2516     1 */
	_Bool                      Iunsafe;              /*  2517     1 */
	_Bool                      Icolorset;            /*  2518     1 */
	signed char                Iperl_destruct_level; /*  2519     1 */
	_Bool                      Ipad_reset_pending;   /*  2520     1 */
	_Bool                      Isrand_called;        /*  2521     1 */
	_Bool                      Inumeric_underlying;  /*  2522     1 */
	_Bool                      Inumeric_underlying_is_standard; /*  2523     1 */
	int                        Inumeric_standard;    /*  2524     4 */
	char *                     Inumeric_name;        /*  2528     8 */
	SV *                       Inumeric_radix_sv;    /*  2536     8 */
	locale_t                   Iunderlying_numeric_obj; /*  2544     8 */
	SV * *                     Ipsig_ptr;            /*  2552     8 */
	/* --- cacheline 40 boundary (2560 bytes) --- */
	SV * *                     Ipsig_name;           /*  2560     8 */
	PTR_TBL_t *                Iptr_table;           /*  2568     8 */
	AV *                       Ibeginav_save;        /*  2576     8 */
	void *                     Ibody_arenas;         /*  2584     8 */
	SV * *                     Iregex_pad;           /*  2592     8 */
	AV *                       Iregex_padav;         /*  2600     8 */
	HV * *                     Istashpad;            /*  2608     8 */
	PADOFFSET                  Istashpadmax;         /*  2616     8 */
	/* --- cacheline 41 boundary (2624 bytes) --- */
	PADOFFSET                  Istashpadix;          /*  2624     8 */
	REENTR *                   Ireentrant_buffer;    /*  2632     8 */
	HV *                       Icustom_op_names;     /*  2640     8 */
	HV *                       Icustom_op_descs;     /*  2648     8 */
	PerlIOl *                  Iperlio;              /*  2656     8 */
	PerlIO_list_t *            Iknown_layers;        /*  2664     8 */
	PerlIO_list_t *            Idef_layerlist;       /*  2672     8 */
	SVCOMPARE_t                Isort_RealCmp;        /*  2680     8 */
	/* --- cacheline 42 boundary (2688 bytes) --- */
	AV *                       Icheckav_save;        /*  2688     8 */
	AV *                       Iunitcheckav_save;    /*  2696     8 */
	long int                   Iclocktick;           /*  2704     8 */
	share_proc_t               Isharehook;           /*  2712     8 */
	share_proc_t               Ilockhook;            /*  2720     8 */
	share_proc_t               Iunlockhook;          /*  2728     8 */
	thrhook_proc_t             Ithreadhook;          /*  2736     8 */
	destroyable_proc_t         Idestroyhook;         /*  2744     8 */
	/* --- cacheline 43 boundary (2752 bytes) --- */
	despatch_signals_proc_t    Isignalhook;          /*  2752     8 */
	HV *                       Iisarev;              /*  2760     8 */
	HV *                       Iregistered_mros;     /*  2768     8 */
	AV *                       Iblockhooks;          /*  2776     8 */
	HV *                       Icustom_ops;          /*  2784     8 */
	XPV *                      IXpv;                 /*  2792     8 */
	const char  * *            Iscopestack_name;     /*  2800     8 */
	struct perl_debug_pad Idebug_pad;                /*  2808    72 */
	/* --- cacheline 45 boundary (2880 bytes) --- */
	globhook_t                 Iglobhook;            /*  2880     8 */
	void * *                   Imy_cxt_list;         /*  2888     8 */
	int                        Imy_cxt_size;         /*  2896     4 */

	/* XXX 4 bytes hole, try to pack */

	struct perl_memory_debug_header Imemory_debug_header; /*  2904    24 */
	SV *                       Isv_consts[35];       /*  2928   280 */
	/* --- cacheline 50 boundary (3200 bytes) was 8 bytes ago --- */
	perl_drand48_t             Irandom_state;        /*  3208     8 */
	STRLEN                     Idump_re_max_len;     /*  3216     8 */
	perl_drand48_t             Iinternal_random_state; /*  3224     8 */
	char                       ITR_SPECIAL_HANDLING_UTF8[13]; /*  3232    13 */

	/* XXX 3 bytes hole, try to pack */

	SV *                       IAboveLatin1;         /*  3248     8 */
	SV *                       IAssigned_invlist;    /*  3256     8 */
	/* --- cacheline 51 boundary (3264 bytes) --- */
	SV *                       IGCB_invlist;         /*  3264     8 */
	SV *                       IHasMultiCharFold;    /*  3272     8 */
	SV *                       IInMultiCharFold;     /*  3280     8 */
	SV *                       ILatin1;              /*  3288     8 */
	SV *                       ILB_invlist;          /*  3296     8 */
	SV *                       ISB_invlist;          /*  3304     8 */
	SV *                       ISCX_invlist;         /*  3312     8 */
	SV *                       IUpperLatin1;         /*  3320     8 */
	/* --- cacheline 52 boundary (3328 bytes) --- */
	SV *                       Iin_some_fold;        /*  3328     8 */
	SV *                       Iutf8_idcont;         /*  3336     8 */
	SV *                       Iutf8_idstart;        /*  3344     8 */
	SV *                       Iutf8_perl_idcont;    /*  3352     8 */
	SV *                       Iutf8_perl_idstart;   /*  3360     8 */
	SV *                       Iutf8_xidcont;        /*  3368     8 */
	SV *                       Iutf8_xidstart;       /*  3376     8 */
	SV *                       IWB_invlist;          /*  3384     8 */
	/* --- cacheline 53 boundary (3392 bytes) --- */
	SV *                       IXPosix_ptrs[16];     /*  3392   128 */
	/* --- cacheline 55 boundary (3520 bytes) --- */
	SV *                       IPosix_ptrs[16];      /*  3520   128 */
	/* --- cacheline 57 boundary (3648 bytes) --- */
	SV *                       Iutf8_toupper;        /*  3648     8 */
	SV *                       Iutf8_totitle;        /*  3656     8 */
	SV *                       Iutf8_tolower;        /*  3664     8 */
	SV *                       Iutf8_tofold;         /*  3672     8 */
	SV *                       Iutf8_tosimplefold;   /*  3680     8 */
	SV *                       Iutf8_charname_begin; /*  3688     8 */
	SV *                       Iutf8_charname_continue; /*  3696     8 */
	SV *                       Iutf8_mark;           /*  3704     8 */
	/* --- cacheline 58 boundary (3712 bytes) --- */
	SV *                       IInBitmap;            /*  3712     8 */
	SV *                       ICCC_non0_non230;     /*  3720     8 */
	SV *                       IPrivate_Use;         /*  3728     8 */
	mbstate_t                  Imbrlen_ps;           /*  3736     8 */
	mbstate_t                  Imbrtowc_ps;          /*  3744     8 */
	mbstate_t                  Iwcrtomb_ps;          /*  3752     8 */

	/* size: 3760, cachelines: 59, members: 312 */
	/* sum members: 3745, holes: 5, sum holes: 15 */
	/* last cacheline: 48 bytes */
};
```