### PR TITLE
POSIX.xs: Never pass NULL to ctermid()

### DIFF
--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -3820,14 +3820,14 @@ char *
 ctermid(s = 0)
 	char *          s = 0;
     CODE:
-#ifdef HAS_CTERMID_R
+#ifdef I_TERMIOS
 	s = (char *) safemalloc((size_t) L_ctermid);
 #endif
 	RETVAL = ctermid(s);
     OUTPUT:
 	RETVAL
     CLEANUP:
-#ifdef HAS_CTERMID_R
+#ifdef I_TERMIOS
 	Safefree(s);
 #endif
 

--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our ($AUTOLOAD, %SIGRT);
 
-our $VERSION = '1.92';
+our $VERSION = '1.93';
 
 require XSLoader;
 


### PR DESCRIPTION
Doing so can cause races.

It is interesting that POSIX:ctermid() takes a parameter, but the
pod doesn't indicate that it does.  Prior to this commit the parameter
was ignored if and only if the platform contains a ctermid_r()
function, and hence on such platforms there was no possibility of a race
here.  The man pages I've seen for ctermid_r() indicate that it differs
from regular ctermid() only in that it will fail if the input is NULL,
and hence a race could occur.

The situation prior to this commit is that if you followed the pod on a
non-ctermid_r() platform, and called this without a parameter, it would
call ctermid with NULL, creating a potential race.  This commit changes
so that a race is never possible.