### PR TITLE
Time-HiRes: Harden vms from races

### DIFF
--- a/dist/Time-HiRes/HiRes.pm
+++ b/dist/Time-HiRes/HiRes.pm
@@ -50,7 +50,7 @@ our @EXPORT_OK = qw (usleep sleep ualarm alarm gettimeofday time tv_interval
                  stat lstat utime
                 );
 
-our $VERSION = '1.9764';
+our $VERSION = '1.9765';
 our $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 


### PR DESCRIPTION
This includes reentr.h to get any available reentrant functions used
automatically.

The only ones I noticed that are problematic are compiled only under VMS,
and there do not appear to be reentrant versions.  These are localtime()
and gmtime().  Should VMS create ones, they will be used automatically.

But to get some thread-safety it wraps calls to those time functions with
mutexes.  Since the functions aren't reentrant, they can't be read
mutexes.