### PR TITLE
perl5db.pl: the "i" command must load mro.pm before use

### DIFF
--- a/Porting/checkAUTHORS.pl
+++ b/Porting/checkAUTHORS.pl
@@ -1126,6 +1126,7 @@ rick\100consumercontact.com             rick\100bort.ca
 +                                       rick.delaney\100home.com
 rjbs\100cpan.org                        rjbs-perl-p5p\100lists.manxome.org
 +                                       perl.p5p\100rjbs.manxome.org
++                                       rjbs\100semiotic.systems
 rjk\100linguist.dartmouth.edu           rjk\100linguist.thayer.dartmouth.edu
 +                                       rjk-perl-p5p\100tamias.net
 +                                       rjk\100tamias.net

--- a/lib/perl5db.pl
+++ b/lib/perl5db.pl
@@ -529,7 +529,7 @@ BEGIN {
 use vars qw($VERSION $header);
 
 # bump to X.XX in blead, only use X.XX_XX in maint
-$VERSION = '1.55';
+$VERSION = '1.56';
 
 $header = "perl5db.pl version $VERSION";
 
@@ -5480,6 +5480,9 @@ Display the (nested) parentage of the module or object given.
 sub cmd_i {
     my $cmd  = shift;
     my $line = shift;
+
+    require mro;
+
     foreach my $isa ( split( /\s+/, $line ) ) {
         $evalarg = $isa;
         # The &-call is here to ascertain the mutability of @_.


### PR DESCRIPTION
The `i` command has apparently been broken _either_ since

```
commit 8b2b9f856f78ceb0ba1881ae5d55c96b0833425d
Author: Steffen Mueller <smueller@cpan.org>
Date:   Mon Sep 21 16:40:48 2009 +0200

    Remove use of Class::ISA from the debugger

    Instead, use mro::get_linear_isa which accomplishes the same feat. This
    allows us to remove another module from core.
```

…or since some commit subsequent to that, removing the accidental loading of mro.