### PR TITLE
Fix memory leak in Data::Dumper::Dumper

### DIFF
--- a/dist/Data-Dumper/Dumper.xs
+++ b/dist/Data-Dumper/Dumper.xs
@@ -1733,6 +1733,8 @@ Data_Dumper_Dumpxs(href, ...)
 		croak("Call to new() method failed to return HASH ref");
 	    if (gimme != G_ARRAY)
 		XPUSHs(sv_2mortal(retval));
+            else if (imax < 0) /* Would leak if there was nothing to dump */
+                SvREFCNT_dec(retval);
 	}
 
 SV *


### PR DESCRIPTION
When Dumper was called without arguments and in list context it leaked the
preallocated retval scalar.