### PR TITLE
don't export PL_mbrlen_ps, PL_mbrtowc, PL_wcrtomb if not defined

### DIFF
--- a/makedef.pl
+++ b/makedef.pl
@@ -741,6 +741,18 @@ unless ($define{'USE_QUADMATH'}) {
   ++$skip{Perl_quadmath_format_single};
 }
 
+unless ($Config{d_mbrlen}) {
+    ++$skip{PL_mbrlen_ps};
+}
+
+unless ($Config{d_mbrtowc}) {
+    ++$skip{PL_mbrtowc_ps};
+}
+
+unless ($Config{d_wcrtomb}) {
+    ++$skip{PL_wcrtomb_ps};
+}
+
 ###############################################################################
 
 # At this point all skip lists should be completed, as we are about to test


### PR DESCRIPTION
These variables are only defined when the appropriate symbols are
defined in config.h, which are controled by their respective names
in config.sh/%Config.

Note that the earlier code in makedef.pl only defines the intrpvar.h
symbols for non-multiplicity builds, so there's no need to special
case this check for threaded/multiplicity builds where these symbols
are never defined.

A sufficiently modern MSVC CRT does turn out to define these symbols,
but fixing this error first.