### PR TITLE
Win32: Skip tests that rely upon short names if these are unavailable

### DIFF
--- a/cpan/Win32/t/GetShortPathName.t
+++ b/cpan/Win32/t/GetShortPathName.t
@@ -2,6 +2,16 @@ use strict;
 use Test;
 use Win32;
 
+BEGIN {
+    Win32::CreateFile("8dot3test_canary_GetShortPathName $$");
+    my $canary = Win32::GetShortPathName("8dot3test_canary_GetShortPathName $$");
+    unlink("8dot3test_canary_GetShortPathName $$");
+    if ( length $canary > 12 ) {
+        print "1..0 # Skip: The system and/or current volume is not configured to support short names.\n";
+        exit 0;
+    }
+}
+
 my $path = "Long Path $$";
 unlink($path);
 END { unlink $path }

--- a/cpan/Win32/t/Unicode.t
+++ b/cpan/Win32/t/Unicode.t
@@ -18,6 +18,13 @@ BEGIN {
 	print "1..0 # Skip: Unicode support requires Windows 2000 or later\n";
 	exit 0;
     }
+    Win32::CreateFile("8dot3test_canary_Unicode $$");
+    my $canary = Win32::GetShortPathName("8dot3test_canary_Unicode $$");
+    unlink("8dot3test_canary_Unicode $$");
+    if ( length $canary > 12 ) {
+        print "1..0 # Skip: The system and/or current volume is not configured to support short names.\n";
+        exit 0;
+    }
 }
 
 my $home = Win32::GetCwd();


### PR DESCRIPTION
Intended for smoking and only merging if an upstream release is unlikely in time for v5.32.

This commit makes GetShortPathName.t and Unicode.t test whether short path names are currently available. If not, the tests in these files are skipped.