### PR TITLE
Fix for https://github.com/Perl/perl5/issues/17667

### DIFF
--- a/hv_macro.h
+++ b/hv_macro.h
@@ -31,7 +31,6 @@
 
 #ifndef U8TO16_LE
   #define _shifted_octet(type,ptr,idx,shift) (((type)(((U8*)(ptr))[(idx)]))<<(shift))
-  #if (BYTEORDER == 0x1234 || BYTEORDER == 0x12345678)
     #ifdef USE_UNALIGNED_PTR_DEREF
         #define U8TO16_LE(ptr)   (*((const U16*)(ptr)))
         #define U8TO32_LE(ptr)   (*((const U32*)(ptr)))
@@ -54,24 +53,6 @@
                                   _shifted_octet(U64,(ptr),6,48)|\
                                   _shifted_octet(U64,(ptr),7,56))
     #endif
-  #elif (BYTEORDER == 0x4321 || BYTEORDER == 0x87654321)
-        #define U8TO16_LE(ptr)   (_shifted_octet(U16,(ptr),1, 0)|\
-                                  _shifted_octet(U16,(ptr),0, 8))
-
-        #define U8TO32_LE(ptr)   (_shifted_octet(U32,(ptr),3, 0)|\
-                                  _shifted_octet(U32,(ptr),2, 8)|\
-                                  _shifted_octet(U32,(ptr),1,16)|\
-                                  _shifted_octet(U32,(ptr),0,24))
-
-        #define U8TO64_LE(ptr)   (_shifted_octet(U64,(ptr),7, 0)|\
-                                  _shifted_octet(U64,(ptr),6, 8)|\
-                                  _shifted_octet(U64,(ptr),5,16)|\
-                                  _shifted_octet(U64,(ptr),4,24)|\
-                                  _shifted_octet(U64,(ptr),3,32)|\
-                                  _shifted_octet(U64,(ptr),2,40)|\
-                                  _shifted_octet(U64,(ptr),1,48)|\
-                                  _shifted_octet(U64,(ptr),0,56))
-  #endif
 #endif
 
 /* Find best way to ROTL32/ROTL64 */


### PR DESCRIPTION
This fixes the failure of ext/XS-APItest/t/hv_macro.t on big endian architectures ( #17667 ).

Apologies - seems that the execute bit is set on APItest.xs - at least 'make test' reports the following failure:
```
t/porting/cmp_version ..... # not ok 67 - ext/XS-APItest/APItest.pm version 1.08
FAILED at test 67
```
I still don't know how to deal with that - how it's getting there, how to negate it.
I suspect it has something to do with having cloned my fork to Windows rather than to linux.
I'll try to get on top of it.
I can even make another attempt at getting it right if need be. (Just let me know.)

Cheers,
Rob
