### PR TITLE
DragonFly BSD doesn't support SO_PROTOCOL for AF_UNIX sockets

### DIFF
--- a/dist/IO/t/cachepropagate-unix.t
+++ b/dist/IO/t/cachepropagate-unix.t
@@ -50,7 +50,7 @@ my $p = $listener->protocol();
     # This is a TODO instead of a skip so if these ever implement SO_PROTOCOL
     # we'll be notified about the passing TODO so the test can be updated.
     local $TODO = "$^O doesn't support SO_PROTOCOL on AF_UNIX"
-        if $^O =~ /^(netbsd|darwin|cygwin|hpux|solaris)$/;
+        if $^O =~ /^(netbsd|darwin|cygwin|hpux|solaris|dragonfly)$/;
     ok(defined($p), 'protocol defined');
 }
 my $d = $listener->sockdomain();
@@ -105,7 +105,7 @@ SKIP: {
     {
         # see comment above
         local $TODO = "$^O doesn't support SO_PROTOCOL on AF_UNIX"
-            if $^O =~ /^(netbsd|darwin|cygwin|hpux|solaris)$/;
+            if $^O =~ /^(netbsd|darwin|cygwin|hpux|solaris|dragonfly)$/;
         ok(defined($p), 'protocol defined');
     }
     $d = $listener->sockdomain();


### PR DESCRIPTION
This fixes dist/IO/t/cachepropagate-unix.t failure