### PR TITLE
Configure can't find dlopen() on DragonFly BSD when using g++

### DIFF
--- a/hints/dragonfly.sh
+++ b/hints/dragonfly.sh
@@ -79,3 +79,11 @@ case "$usemallocwrap" in
 esac
 
 test "$optimize" || optimize='-O2'
+
+# Configure can't find dlopen() when using g++
+# linux, freebsd and solaris hints have the same workaround
+case "$cc" in
+*g++*)
+  d_dlopen='define'
+  ;;
+esac


### PR DESCRIPTION
linux, freebsd and solaris hints have the same workaround