### PR TITLE
disable __attribute__((always_inline)) for gcc <= 4.6

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -340,7 +340,8 @@
 #  if __GNUC__ == 3 && __GNUC_MINOR__ >= 4 || __GNUC__ > 3 /* 3.4 -> */
 #    define HASATTRIBUTE_WARN_UNUSED_RESULT
 #  endif
-#  if __GNUC__ == 3 && __GNUC_MINOR__ >= 1 || __GNUC__ > 3 /* 3.1 -> */
+/* always_inline is buggy in gcc <= 4.6 and causes compilation errors */
+#  if __GNUC__ == 4 && __GNUC_MINOR__ >= 7 || __GNUC__ > 4 /* 4.7 -> */
 #    define HASATTRIBUTE_ALWAYS_INLINE
 #  endif
 #endif
@@ -371,7 +372,10 @@
 #  define __attribute__warn_unused_result__ __attribute__((warn_unused_result))
 #endif
 #ifdef HASATTRIBUTE_ALWAYS_INLINE
-#  define __attribute__always_inline__      __attribute__((always_inline))
+/* always_inline is buggy in gcc <= 4.6 and causes compilation errors */
+#  if __GNUC__ == 4 && __GNUC_MINOR__ >= 7 || __GNUC__ > 4
+#    define __attribute__always_inline__      __attribute__((always_inline))
+#  endif
 #endif
 
 /* If we haven't defined the attributes yet, define them to blank. */


### PR DESCRIPTION
It was causing compilation errors in DEBUGGING builds:
```
pp_sort.c: In function 'sortsv_cmp_locale_desc':
pp_sort.c:1329:1: sorry, unimplemented: inlining failed in call to 'S_cmp_locale_desc': function not inlinable
pp_sort.c:188:17: sorry, unimplemented: called from here
pp_sort.c:1329:1: sorry, unimplemented: inlining failed in call to 'S_cmp_locale_desc': function not inlinable
pp_sort.c:194:21: sorry, unimplemented: called from here
(...)
```

Failing smoke: https://perl5.test-smoke.org/report/110764