### PR TITLE
perl5db: allow the recorded history item length to be configured

### DIFF
--- a/lib/perl5db.pl
+++ b/lib/perl5db.pl
@@ -643,6 +643,7 @@ use vars qw(
     $filename
     $histfile
     $histsize
+    $histitemminlength
     $IN
     $inhibit_exit
     @ini_INC
@@ -938,6 +939,7 @@ are to be accepted.
 
 @options = qw(
   CommandSet   HistFile      HistSize
+  HistItemMinLength
   hashDepth    arrayDepth    dumpDepth
   DumpDBFiles  DumpPackages  DumpReused
   compactDump  veryCompact   quote
@@ -986,6 +988,7 @@ use vars qw(%optionVars);
     windowSize    => \$window,
     HistFile      => \$histfile,
     HistSize      => \$histsize,
+    HistItemMinLength => \$histitemminlength
 );
 
 =pod
@@ -2820,7 +2823,7 @@ it up.
                 $cmd = $laststep;
             }
             chomp($cmd);    # get rid of the annoying extra newline
-            if (length($cmd) >= 2) {
+            if (length($cmd) >= option_val('HistItemMinLength', 2)) {
                 push( @hist, $cmd );
             }
             push( @truehist, $cmd );
@@ -3734,10 +3737,7 @@ sub _handle_H_command {
         my $i;
 
         for ( $i = $#hist ; $i > $end ; $i-- ) {
-
-            # Print the command  unless it has no arguments.
-            print $OUT "$i: ", $hist[$i], "\n"
-            unless $hist[$i] =~ /^.?$/;
+            print $OUT "$i: ", $hist[$i], "\n";
         }
 
         next CMD;
@@ -7330,7 +7330,7 @@ sub readline {
 
         # Add it to the terminal history (if possible).
         $term->AddHistory($got)
-          if length($got) > 1
+          if length($got) >= option_val("HistItemMinLength", 2)
           and defined $term->Features->{addHistory};
         return $got;
     } ## end if (@typeahead)


### PR DESCRIPTION
This requires a few small changes.

1. add a new option, which I stored in what looked like one of the
   standard ways
2. only store the item in terminal history if >= this length
3. only add to @hist if >= this length
4. only display hist item if >= this length

I believe #4 is redundant and should be removed, but the code was
already effectively there.