### PR TITLE
Fix typo in perlretut.pod. C<'$'> to C<$'>.

### DIFF
--- a/pod/perlretut.pod
+++ b/pod/perlretut.pod
@@ -939,7 +939,7 @@ prints
 Even if there are no groupings in a regexp, it is still possible to
 find out what exactly matched in a string.  If you use them, Perl
 will set C<$`> to the part of the string before the match, will set C<$&>
-to the part of the string that matched, and will set C<'$'> to the part
+to the part of the string that matched, and will set C<$'> to the part
 of the string after the match.  An example:
 
     $x = "the cat caught the mouse";
@@ -951,7 +951,7 @@ first character position in the string and stopped; it never saw the
 second "the".
 
 If your code is to run on Perl versions earlier than
-5.20, it is worthwhile to note that using C<$`> and C<'$'>
+5.20, it is worthwhile to note that using C<$`> and C<$'>
 slows down regexp matching quite a bit, while C<$&> slows it down to a
 lesser extent, because if they are used in one regexp in a program,
 they are generated for I<all> regexps in the program.  So if raw
@@ -968,7 +968,7 @@ variables may be used.  These are only set if the C</p> modifier is
 present.  Consequently they do not penalize the rest of the program.  In
 Perl 5.20, C<${^PREMATCH}>, C<${^MATCH}> and C<${^POSTMATCH}> are available
 whether the C</p> has been used or not (the modifier is ignored), and
-C<$`>, C<'$'> and C<$&> do not cause any speed difference.
+C<$`>, C<$'> and C<$&> do not cause any speed difference.
 
 =head2 Non-capturing groupings
 


### PR DESCRIPTION
Hi.
In the paragraphs, we are talking about a postmatch variable $' not an anchor '$'.
So we only need just 1 apostrophe.
