### PR TITLE
t/TEST: Unset PERL_UNICODE

### DIFF
--- a/cpan/Test-Harness/lib/TAP/Formatter/Session.pm
+++ b/cpan/Test-Harness/lib/TAP/Formatter/Session.pm
@@ -189,29 +189,36 @@ sub _make_ok_line {
 }
 
 sub time_report {
+    use Data::Dumper;
+    #print STDERR __FILE__, __LINE__, Dumper \@_;
     my ( $self, $formatter, $parser ) = @_;
 
     my @time_report;
     if ( $formatter->timer ) {
         my $start_time = $parser->start_time;
         my $end_time   = $parser->end_time;
-        if ( defined $start_time and defined $end_time ) {
-            my $elapsed = $end_time - $start_time;
-            push @time_report,
-              $self->time_is_hires
-                ? sprintf( ' %8d ms', $elapsed * 1000 )
-                : sprintf( ' %8s s', $elapsed || '<1' );
-        }
         my $start_times = $parser->start_times();
         my $end_times   = $parser->end_times();
         my $usr  = $end_times->[0] - $start_times->[0];
         my $sys  = $end_times->[1] - $start_times->[1];
         my $cusr = $end_times->[2] - $start_times->[2];
         my $csys = $end_times->[3] - $start_times->[3];
+        my $total = $usr + $sys + $cusr + $csys;
+        use Data::Dumper;
+
+        if ( defined $start_time and defined $end_time ) {
+            my $elapsed = $end_time - $start_time;
+            printf STDERR "%d: ratio=%g, cpu=%g, wall=%g %s\n", __LINE__, $total/ $elapsed, $total, $elapsed, $self->{name}, if $total > $elapsed;
+            $elapsed = $total if $total > $elapsed;
+            push @time_report,
+              $self->time_is_hires
+                ? sprintf( ' %8d ms', $elapsed * 1000 )
+                : sprintf( ' %8s s', $elapsed || '<1' );
+        }
         push @time_report,
           sprintf('(%5.2f usr %5.2f sys + %5.2f cusr %5.2f csys = %5.2f CPU)',
                   $usr, $sys, $cusr, $csys,
-                  $usr + $sys + $cusr + $csys);
+                  $total);
     }
 
     return "@time_report";

--- a/cpan/Test-Harness/lib/TAP/Parser.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser.pm
@@ -312,6 +312,8 @@ module and related classes for more information on how to use them.
 
 sub next {
     my $self = shift;
+    use Data::Dumper;
+    #print STDERR __FILE__, __LINE__, ": ", time(), " ", Dumper $self if grep { /podcheck/ } @{$self->_iterator->{command}};
     return ( $self->{_iter} ||= $self->_iter )->();
 }
 
@@ -327,6 +329,7 @@ This method merely runs the parser and parses all of the TAP.
 
 sub run {
     my $self = shift;
+    #print STDERR __FILE__, __LINE__, ": ", time(), " ", Dumper $self;
     while ( defined( my $result = $self->next ) ) {
 
         # do nothing
@@ -1384,8 +1387,11 @@ sub _iter {
     my $state       = 'INIT';
     my $state_table = $self->_make_state_table;
 
-    $self->start_time( $self->get_time );
-    $self->start_times( $self->get_times );
+    use Data::Dumper;
+    #print STDERR __FILE__, __LINE__, Dumper $self;
+    $self->start_time( $self->get_time ) unless $self->{start_time};
+    $self->start_times( $self->get_times ) unless $self->{start_times};
+    #print STDERR __FILE__, __LINE__, Dumper $self if grep { /podcheck/ } @{$self->_iterator->{command}};
 
     # Make next_state closure
     my $next_state = sub {
@@ -1479,6 +1485,21 @@ sub _finish {
 
     $self->end_time( $self->get_time );
     $self->end_times( $self->get_times );
+    use Data::Dumper;
+    #print STDERR __FILE__, __LINE__, Dumper $self if grep { /podcheck/ } @{$self->_iterator->{command}};
+#        my $usr  = $end_times->[0] - $start_times->[0];
+#        my $sys  = $end_times->[1] - $start_times->[1];
+#        my $cusr = $end_times->[2] - $start_times->[2];
+#        my $csys = $end_times->[3] - $start_times->[3];
+#        my $total = $usr + $sys + $cusr + $csys;
+#            printf STDERR "%d: cpu=%g, wall=%g ", __LINE__, $total, $elapsed if $total > $elapsed;
+#            print STDERR Dumper $self if $total > $elapsed;
+#            $elapsed = $total if $total > $elapsed;
+#            push @time_report,
+#              $self->time_is_hires
+#                ? sprintf( ' %8d ms', $elapsed * 1000 )
+#                : sprintf( ' %8s s', $elapsed || '<1' );
+#        }
 
     # Avoid leaks
     $self->_iterator(undef);

--- a/ebcdic_tables.h
+++ b/ebcdic_tables.h
@@ -413,60 +413,6 @@ SOFTWARE.
 };
 #  endif
 
-/* This table partitions all the code points of the platform into ranges which
- * have the property that all the code points in each range have the same
- * number of bytes in their UTF-EBCDIC representations, and the adjacent
- * ranges have a different number of bytes.
- *
- * Each number in the table begins such a range, which extends up to just
- * before the following table entry, except the final entry is understood to
- * extend to the platform's infinity
- */
-#  ifndef DOINIT
-    EXTCONST UV PL_partition_by_byte_length[38];
-#  else
-    EXTCONST UV PL_partition_by_byte_length[38] = {
-	0x00,
-	0x41,
-	0x4b,
-	0x51,
-	0x5a,
-	0x62,
-	0x6b,
-	0x70,
-	0x79,
-	0x80,
-	0x81,
-	0x8a,
-	0x91,
-	0x9a,
-	0xa1,
-	0xaa,
-	0xad,
-	0xae,
-	0xbd,
-	0xbe,
-	0xc0,
-	0xca,
-	0xd0,
-	0xda,
-	0xe0,
-	0xe1,
-	0xe2,
-	0xea,
-	0xf0,
-	0xfa,
-	0xff,
-	0x100,
-	0x400,
-	0x4000,
-	0x40000,
-	0x400000,
-	0x4000000,
-	0x40000000
-};
-#  endif
-
 #endif	/* EBCDIC 1047 */
 
 #if 'A' == 193 /* EBCDIC 037 */ \
@@ -842,62 +788,6 @@ SOFTWARE.
 /*N6=84*/  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 42, 42, 42,
 /*N7=98*/  1,  1,  1,  1,  1,  1,  1,  1,  1, 42,  1,  1,  1,  1
 /*         0   1   2   3   4   5   6   7   8   9  10  11  12 13*/
-};
-#  endif
-
-/* This table partitions all the code points of the platform into ranges which
- * have the property that all the code points in each range have the same
- * number of bytes in their UTF-EBCDIC representations, and the adjacent
- * ranges have a different number of bytes.
- *
- * Each number in the table begins such a range, which extends up to just
- * before the following table entry, except the final entry is understood to
- * extend to the platform's infinity
- */
-#  ifndef DOINIT
-    EXTCONST UV PL_partition_by_byte_length[40];
-#  else
-    EXTCONST UV PL_partition_by_byte_length[40] = {
-	0x00,
-	0x41,
-	0x4b,
-	0x51,
-	0x5a,
-	0x5f,
-	0x60,
-	0x62,
-	0x6b,
-	0x70,
-	0x79,
-	0x80,
-	0x81,
-	0x8a,
-	0x91,
-	0x9a,
-	0xa1,
-	0xaa,
-	0xb0,
-	0xb1,
-	0xba,
-	0xbc,
-	0xc0,
-	0xca,
-	0xd0,
-	0xda,
-	0xe0,
-	0xe1,
-	0xe2,
-	0xea,
-	0xf0,
-	0xfa,
-	0xff,
-	0x100,
-	0x400,
-	0x4000,
-	0x40000,
-	0x400000,
-	0x4000000,
-	0x40000000
 };
 #  endif
 

--- a/regen/ebcdic.pl
+++ b/regen/ebcdic.pl
@@ -779,56 +779,6 @@ END
         output_table(\@C9_utf8_dfa, "PL_c9_utf8_dfa_tab", $NUM_CLASSES);
     }
 
-    {
-        print $out_fh <<EOF;
-/* This table partitions all the code points of the platform into ranges which
- * have the property that all the code points in each range have the same
- * number of bytes in their UTF-EBCDIC representations, and the adjacent
- * ranges have a different number of bytes.
- *
- * Each number in the table begins such a range, which extends up to just
- * before the following table entry, except the final entry is understood to
- * extend to the platform's infinity
- */
-EOF
-        # The lengths of the characters between 0 and 255 are either 1 or 2,
-        # with those whose ASCII platform equivalents below 160 being 1, and
-        # the rest being 2.
-        my @list;
-        push @list, 0;
-        my $pushed_range_is_length_1 = 1;
-
-        for my $i (1 .. 0xFF) {
-            my $this_code_point_is_length_1 = ($e2a[$i] < 160);
-            if ($pushed_range_is_length_1 != $this_code_point_is_length_1) {
-                push @list, $i;
-                $pushed_range_is_length_1 = $this_code_point_is_length_1;
-            }
-        }
-
-        # Starting at 256, the length is 2.
-        push @list, 0x100 if $pushed_range_is_length_1;
-
-        # These are based on the fundamental properties of UTF-EBCDIC.  Each
-        # continuation byte has 5 bits of information.  Comments in utf8.h
-        # explain the rest.
-        my $UTF_ACCUMULATION_SHIFT = 5;
-        push @list, (32 * (1 << (    $UTF_ACCUMULATION_SHIFT)));
-        push @list, (16 * (1 << (2 * $UTF_ACCUMULATION_SHIFT)));
-        push @list, ( 8 * (1 << (3 * $UTF_ACCUMULATION_SHIFT)));
-        push @list, ( 4 * (1 << (4 * $UTF_ACCUMULATION_SHIFT)));
-        push @list, ( 2 * (1 << (5 * $UTF_ACCUMULATION_SHIFT)));
-        push @list, (     (1 << (6 * $UTF_ACCUMULATION_SHIFT)));
-
-        output_table_start($out_fh, "UV", "PL_partition_by_byte_length", scalar @list);
-        print $out_fh "\t";
-
-        print $out_fh join ",\n\t", map { sprintf "0x%02x", $_ } @list;
-        print $out_fh "\n";
-
-        output_table_end($out_fh);
-    }
-
     print $out_fh get_conditional_compile_line_end();
 }
 

--- a/t/TEST
+++ b/t/TEST
@@ -90,7 +90,7 @@ my %temp_needs_dot  = map { $_ => 1 } qw(
 # but allow override via *_TEST env var if wanted
 # (e.g. PERL5OPT_TEST=-d:NYTProf)
 my @bad_env_vars = qw(
-    PERL5LIB PERLLIB PERL5OPT
+    PERL5LIB PERLLIB PERL5OPT PERL_UNICODE
     PERL_YAML_BACKEND PERL_JSON_BACKEND
 );
 

--- a/t/TEST
+++ b/t/TEST
@@ -466,7 +466,7 @@ unless (@ARGV) {
     # then comp, to validate that require works
     # then run, to validate that -M works
     # then we know we can -MTestInit for everything else, making life simpler
-    foreach my $dir (qw(base comp run cmd io re opbasic op uni mro perf)) {
+    foreach my $dir (qw(base comp run re uni cmd io opbasic op mro perf)) {
 	_find_tests($dir);
     }
     unless ($::core) {
@@ -514,6 +514,7 @@ unless (@ARGV) {
 	"cmd",
 	"io",
 	"re",
+	"porting",
 	"opbasic",
 	"op",
 	"uni",
@@ -523,7 +524,6 @@ unless (@ARGV) {
 	"dist",
 	"cpan",
 	"perf",
-	"porting",
     );
     my %order= map { $order[$_] => 1+$_ } 0..$#order;
     my $idx= 0;
@@ -609,6 +609,7 @@ EOT
         my ($test_start_time, @starttimes) = 0;
 	if ($show_elapsed_time) {
 	    $test_start_time = Time::HiRes::time();
+	    print STDERR "test=$test: $max, $test_start_time\n";
 	    # times() reports usage by TEST, but we want usage of each
 	    # testprog it calls, so record accumulated times now,
 	    # subtract them out afterwards.  Ideally, we'd take times
@@ -776,6 +777,7 @@ EOT
 	    $failed_tests{$test} = 1;
 	}
 	else {
+	    print STDERR "test=$test, max=$max, $test_start_time\n";
 	    if ($max) {
 		my ($elapsed, $etms) = ("", 0);
 		if ( $show_elapsed_time ) {

--- a/t/harness
+++ b/t/harness
@@ -117,17 +117,26 @@ if (@ARGV) {
     unless (@tests) {
 	my @seq = <base/*.t>;
 
-	my @next = qw(comp run cmd io re opbasic op uni mro lib porting perf);
-	push @next, 'japh' if $torture;
-	push @next, 'win32' if $^O eq 'MSWin32';
-	push @next, 'benchmark' if $ENV{PERL_BENCHMARK};
-	push @next, 'bigmem' if $ENV{PERL_TEST_MEMORY};
+	my @next = qw(comp run cmd);
+        my @last = qw(io re opbasic op uni mro lib porting perf);
+	push @last, 'japh' if $torture;
+	push @last, 'win32' if $^O eq 'MSWin32';
+	push @last, 'benchmark' if $ENV{PERL_BENCHMARK};
+	push @last, 'bigmem' if $ENV{PERL_TEST_MEMORY};
 	# Hopefully TAP::Parser::Scheduler will support this syntax soon.
 	# my $next = { par => '{' . join (',', @next) . '}/*.t' };
 	my $next = { par => [
 			     map { "$_/*.t" } @next
 			    ] };
 	@tests = _extract_tests ($next);
+	my $last = { par => [
+			     map { "$_/*.t" } @last
+			    ] };
+	@last = _extract_tests ($last);
+        #use Data::Dumper;
+        #$Data::Dumper::Sortkeys=1;
+        #print STDERR __FILE__, __LINE__, Dumper \@last;
+
 
 	# This is a bit of a game, because we only want to sort these tests in
 	# speed order. base/*.t wants to run first, and ext,lib etc last and in
@@ -147,7 +156,7 @@ if (@ARGV) {
 	@tests = (@seq, @tests);
 	push @seq, $next;
 
-	my @last;
+	#my @last;
 	push @last,
 	    _tests_from_manifest($Config{extensions}, $Config{known_extensions});
 	my %times;
@@ -171,7 +180,8 @@ if (@ARGV) {
 
             # Keep a list of the distinct directory names, and another list of
             # those which contain a file whose name begins with a 0
-            if ( m! \A \.\. /
+            #use re qw(Debug ALL);
+            if ( m! \A (?: \.\. / )?
                                 ( .*? )         # $1 is the directory path name
                             /
                                 ( [^/]* \.t )   # $2 is the .t name
@@ -183,6 +193,7 @@ if (@ARGV) {
                 $serials{$path} = 1 if $2 =~ / \A 0 /x;
             }
         }
+        #print STDERR __FILE__, __LINE__, Dumper \%all_dirs, \%serials;
 
         # We assume that the reason a test file's name begins with a 0 is to
         # order its execution among the tests in its directory.  Hence, a
@@ -207,10 +218,11 @@ if (@ARGV) {
         undef %all_dirs;
         undef %serials;
 
+        #print STDERR __FILE__, __LINE__, Dumper \@last;
 	for (@last) {
             # Treat every file in each non-serial directory as its own
             # "directory", so that it can be executed in parallel
-            m! \A ( \.\. / (?: $non_serials )
+            m! \A ( (?: \.\. / )? (?: $non_serials )
                          / [^/]+ \.t \z | .* [/] ) !x
                 or die "'$_'";
 	    push @{$dir{$1}}, $_;
@@ -219,7 +231,8 @@ if (@ARGV) {
             # as a whole
 	    $total_time{$1} += $times{$_} || 0;
 	}
-        #print STDERR __LINE__, join "\n", sort { $total_time{$b} <=> $total_time{$a} } keys %dir, "  ";
+        #print STDERR __FILE__, __LINE__, Dumper \%dir, \%total_time;
+        #print STDERR __FILE__, __LINE__, join "\n", sort { print STDERR "a='$a'\n" unless defined $total_time{$a};print STDERR "b='$b'\n" unless defined $total_time{$b}; $total_time{$b} <=> $total_time{$a} } keys %dir; #, "  ";
 
 	push @tests, @last;
 
@@ -320,6 +333,9 @@ if ($ENV{PERL_VALGRIND}) {
 if ($state) {
     $h->callback(
 		 after_test => sub {
+                    use Data::Dumper;
+                    use Time::HiRes;
+                    #print STDERR __FILE__, __LINE__,  ": After test: ", time(), "\n", Dumper \@_ if grep { $_ =~ /podcheck/ } @{$_[0]};
 		     $state->observe_test(@_);
 		 }
 		 );
@@ -335,6 +351,9 @@ $h->callback(
 		 my ($args, $job) = @_;
 		 my $test = $job->[0];
 		 _before_fork($options{$test});
+                use Data::Dumper;
+                use Time::HiRes;
+                #print STDERR __FILE__, __LINE__,  ": After fork: ", time(), "\n", Dumper $_[0]->{exec} if grep { $_ =~ /podcheck/ } @{$_[0]->{exec}};
 		 push @{ $args->{switches} }, "-I../../lib";
 	     }
 	     );
@@ -345,9 +364,14 @@ $h->callback(
 		 my $test = $job->[0];
 		 my $options = delete $options{$test};
 		 _after_fork($options);
+                use Data::Dumper;
+                use Time::HiRes;
+                #print STDERR __FILE__, __LINE__,  ": After parser made: ", time(), "\n", Dumper \@_ if grep { $_ =~ /podcheck/ } @{$_[1]};
 	     }
 	     );
 
+use Data::Dumper;
+#print STDERR __FILE__, __LINE__, Dumper \@tests;
 my $agg = $h->runtests(@tests);
 _cleanup_valgrind(\$htoolnm, \$hgrind_ct);
 exit $agg->has_errors ? 1 : 0;

--- a/t/porting/podcheck.t
+++ b/t/porting/podcheck.t
@@ -1,3 +1,4 @@
+
 #!/usr/bin/perl -w
 
 package main;
@@ -35,6 +36,8 @@ BEGIN {
     }
     require '../regen/regen_lib.pl';
 }
+BEGIN{ print STDOUT __FILE__, __LINE__, ": podcheck compilation, execution start_time ", time(), "\n"; }
+#END{ print STDERR __FILE__, __LINE__, ": podcheck execution end_time ", time(), "\n"; }
 
 sub DEBUG { 0 };
 


### PR DESCRIPTION
This commit adds this environment variable to the list of the ones that
are generally unset during the test suite execution.  Tests shouldn't
have to consider, for example, if PERL5OPT has something set like -w,
and the same for PERL_UNICODE, as its being set causes all filehandles
to have :utf8 set by default.

This should fix test suite smoke faiures we are getting in IO::Socket