### PR TITLE
op/exec.t: ENOTDIR is a legit errno

### DIFF
--- a/t/op/exec.t
+++ b/t/op/exec.t
@@ -113,6 +113,8 @@ unless( ok($rc == 255 << 8 or $rc == -1 or $rc == 256 or $rc == 512) ) {
 
 unless ( ok( $! == 2  or  $! =~ /\bno\b.*\bfile/i or  
              $! == 13 or  $! =~ /permission denied/i or
+             $! == 20 or  $! =~ /not a directory/i or   # If PATH component is
+                                                        # a non-directory
              $! == 22 or  $! =~ /invalid argument/i  ) ) {
     diag sprintf "\$! eq %d, '%s'\n", $!, $!;
 }


### PR DESCRIPTION
If PATH contains a component that is non-existent, this errno can be
returned in addition to the ones it already checked forodified:   .

I examined the possible errnos listed in a Linux man page for this, and
this looked to be the only one that is likely to come up that weren't
already covered.

This fixes GH #17515