### PR TITLE
perlsyn - Mention that postfix foreach cannot specify a lexical variable

### DIFF
--- a/pod/perlsyn.pod
+++ b/pod/perlsyn.pod
@@ -144,6 +144,8 @@ the condition is true (that is, if the condition is false).
 
 The C<for(each)> modifier is an iterator: it executes the statement once
 for each item in the LIST (with C<$_> aliased to each item in turn).
+There is no syntax to specify a C-style for loop or a lexically scoped
+iteration variable in this form.
 
     print "Hello $_!\n" for qw(world Dolly nurse);
 


### PR DESCRIPTION
Resolves #17703 