### PR TITLE
HTTP::Tiny needs two modules for https support

### DIFF
--- a/Porting/sync-with-cpan
+++ b/Porting/sync-with-cpan
@@ -301,6 +301,8 @@ if ($cpan_mod =~ /-/ && $cpan_mod !~ /::/) {
 sub wget {
     my ($url, $saveas) = @_;
     eval {
+        require IO::Socket::SSL;
+        require Net::SSLeay;
         require HTTP::Tiny;
         my $http= HTTP::Tiny->new();
         $http->mirror( $url => $saveas );


### PR DESCRIPTION
When running sync-with-cpan on a machine for the first time, internal
subroutine wget() was silently failing.  After adding debugging code and
running through the debugger, the HTTP::Tiny mirror() method call
displayed this error message:

  IO::Socket::SSL 1.42 must be installed for https support
  Net::SSLeay 1.49 must be installed for https support