### PR TITLE
study_chunk: do not rewrite for trie while enframed

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -4804,9 +4804,10 @@ S_study_chunk(pTHX_ RExC_state_t *pRExC_state, regnode **scanp,
 		    }
 		}
 
-                if (PERL_ENABLE_TRIE_OPTIMISATION &&
-                        OP( startbranch ) == BRANCH )
-                {
+                if (PERL_ENABLE_TRIE_OPTIMISATION
+                    && OP(startbranch) == BRANCH
+                    && !frame
+                ) {
 		/* demq.
 
                    Assuming this was/is a branch we are dealing with: 'scan'

--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -24,7 +24,7 @@ BEGIN {
 
 skip_all_without_unicode_tables();
 
-plan tests => 1017;  # Update this when adding/deleting tests.
+plan tests => 1018;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -2250,6 +2250,13 @@ SKIP:
         my $result = eval qq{"foo" =~ /$re/};
         is($@ // '', '', "many evals did not die");
         ok($result, "regexp correctly matched");
+    }
+
+    # gh16947: test regexp corruption
+    {
+        fresh_perl_is(q{
+            'xy' =~ /x(?0)|x(?|y|y)/ && print 'ok'
+        }, 'ok', {}, 'gh16947: test regexp corruption');
     }
 
 } # End of sub run_tests


### PR DESCRIPTION
gh16947: the outer frame may be in the middle of looking at the part
of the program we would rewrite. Let the outer frame deal with it.