### PR TITLE
Fix TAP::Harness elapsed time calc; speed up test suite execution

### DIFF
--- a/cpan/Test-Harness/lib/App/Prove.pm
+++ b/cpan/Test-Harness/lib/App/Prove.pm
@@ -18,11 +18,11 @@ App::Prove - Implements the C<prove> command.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/App/Prove/State.pm
+++ b/cpan/Test-Harness/lib/App/Prove/State.pm
@@ -25,11 +25,11 @@ App::Prove::State - State storage for the C<prove> command.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/App/Prove/State/Result.pm
+++ b/cpan/Test-Harness/lib/App/Prove/State/Result.pm
@@ -14,11 +14,11 @@ App::Prove::State::Result - Individual test suite results.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/App/Prove/State/Result/Test.pm
+++ b/cpan/Test-Harness/lib/App/Prove/State/Result/Test.pm
@@ -9,11 +9,11 @@ App::Prove::State::Result::Test - Individual test results.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Base.pm
+++ b/cpan/Test-Harness/lib/TAP/Base.pm
@@ -12,11 +12,11 @@ and L<TAP::Harness>
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 use constant GOT_TIME_HIRES => do {
     eval 'use Time::HiRes qw(time);';

--- a/cpan/Test-Harness/lib/TAP/Formatter/Base.pm
+++ b/cpan/Test-Harness/lib/TAP/Formatter/Base.pm
@@ -58,11 +58,11 @@ TAP::Formatter::Base - Base class for harness output delegates
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Formatter/Color.pm
+++ b/cpan/Test-Harness/lib/TAP/Formatter/Color.pm
@@ -39,11 +39,11 @@ TAP::Formatter::Color - Run Perl test scripts with color
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Formatter/Console.pm
+++ b/cpan/Test-Harness/lib/TAP/Formatter/Console.pm
@@ -11,11 +11,11 @@ TAP::Formatter::Console - Harness output delegate for default console output
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Formatter/Console/ParallelSession.pm
+++ b/cpan/Test-Harness/lib/TAP/Formatter/Console/ParallelSession.pm
@@ -41,11 +41,11 @@ TAP::Formatter::Console::ParallelSession - Harness output delegate for parallel 
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Formatter/Console/Session.pm
+++ b/cpan/Test-Harness/lib/TAP/Formatter/Console/Session.pm
@@ -26,11 +26,11 @@ TAP::Formatter::Console::Session - Harness output delegate for default console o
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Formatter/File.pm
+++ b/cpan/Test-Harness/lib/TAP/Formatter/File.pm
@@ -13,11 +13,11 @@ TAP::Formatter::File - Harness output delegate for file output
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Formatter/File/Session.pm
+++ b/cpan/Test-Harness/lib/TAP/Formatter/File/Session.pm
@@ -10,11 +10,11 @@ TAP::Formatter::File::Session - Harness output delegate for file output
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Formatter/Session.pm
+++ b/cpan/Test-Harness/lib/TAP/Formatter/Session.pm
@@ -23,11 +23,11 @@ TAP::Formatter::Session - Abstract base class for harness output delegate
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 METHODS
 

--- a/cpan/Test-Harness/lib/TAP/Harness.pm
+++ b/cpan/Test-Harness/lib/TAP/Harness.pm
@@ -16,11 +16,11 @@ TAP::Harness - Run test scripts with statistics
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 $ENV{HARNESS_ACTIVE}  = 1;
 $ENV{HARNESS_VERSION} = $VERSION;
@@ -619,6 +619,10 @@ sub _aggregate_parallel {
 
             my ( $parser, $session ) = $self->make_parser($job);
             $mux->add( $parser, [ $session, $job ] );
+
+            # The job has started: begin the timers
+            $parser->start_time( $parser->get_time );
+            $parser->start_times( $parser->get_times );
         }
 
         if ( my ( $parser, $stash, $result ) = $mux->next ) {

--- a/cpan/Test-Harness/lib/TAP/Harness/Env.pm
+++ b/cpan/Test-Harness/lib/TAP/Harness/Env.pm
@@ -7,7 +7,7 @@ use constant IS_VMS => ( $^O eq 'VMS' );
 use TAP::Object;
 use Text::ParseWords qw/shellwords/;
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 # Get the parts of @INC which are changed from the stock list AND
 # preserve reordering of stock directories.
@@ -126,7 +126,7 @@ TAP::Harness::Env - Parsing harness related environmental variables where approp
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Object.pm
+++ b/cpan/Test-Harness/lib/TAP/Object.pm
@@ -9,11 +9,11 @@ TAP::Object - Base class that provides common functionality to all C<TAP::*> mod
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser.pm
@@ -27,11 +27,11 @@ TAP::Parser - Parse L<TAP|Test::Harness::TAP> output
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 my $DEFAULT_TAP_VERSION = 12;
 my $MAX_TAP_VERSION     = 13;
@@ -1384,8 +1384,8 @@ sub _iter {
     my $state       = 'INIT';
     my $state_table = $self->_make_state_table;
 
-    $self->start_time( $self->get_time );
-    $self->start_times( $self->get_times );
+    $self->start_time( $self->get_time ) unless $self->{start_time};
+    $self->start_times( $self->get_times ) unless $self->{start_times};
 
     # Make next_state closure
     my $next_state = sub {

--- a/cpan/Test-Harness/lib/TAP/Parser/Aggregator.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Aggregator.pm
@@ -12,11 +12,11 @@ TAP::Parser::Aggregator - Aggregate TAP::Parser results
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Grammar.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Grammar.pm
@@ -14,11 +14,11 @@ TAP::Parser::Grammar - A grammar for the Test Anything Protocol.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Iterator.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Iterator.pm
@@ -11,11 +11,11 @@ TAP::Parser::Iterator - Base class for TAP source iterators
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Iterator/Array.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Iterator/Array.pm
@@ -11,11 +11,11 @@ TAP::Parser::Iterator::Array - Iterator for array-based TAP sources
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Iterator/Process.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Iterator/Process.pm
@@ -16,11 +16,11 @@ TAP::Parser::Iterator::Process - Iterator for process-based TAP sources
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Iterator/Stream.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Iterator/Stream.pm
@@ -11,11 +11,11 @@ TAP::Parser::Iterator::Stream - Iterator for filehandle-based TAP sources
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/IteratorFactory.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/IteratorFactory.pm
@@ -16,11 +16,11 @@ TAP::Parser::IteratorFactory - Figures out which SourceHandler objects to use fo
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Multiplexer.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Multiplexer.pm
@@ -17,11 +17,11 @@ TAP::Parser::Multiplexer - Multiplex multiple TAP::Parsers
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Result.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Result.pm
@@ -24,11 +24,11 @@ TAP::Parser::Result - Base class for TAP::Parser output objects
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Result/Bailout.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Result/Bailout.pm
@@ -11,11 +11,11 @@ TAP::Parser::Result::Bailout - Bailout result token.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Result/Comment.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Result/Comment.pm
@@ -11,11 +11,11 @@ TAP::Parser::Result::Comment - Comment result token.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Result/Plan.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Result/Plan.pm
@@ -11,11 +11,11 @@ TAP::Parser::Result::Plan - Plan result token.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Result/Pragma.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Result/Pragma.pm
@@ -11,11 +11,11 @@ TAP::Parser::Result::Pragma - TAP pragma token.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Result/Test.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Result/Test.pm
@@ -11,11 +11,11 @@ TAP::Parser::Result::Test - Test result token.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Result/Unknown.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Result/Unknown.pm
@@ -11,11 +11,11 @@ TAP::Parser::Result::Unknown - Unknown result token.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Result/Version.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Result/Version.pm
@@ -11,11 +11,11 @@ TAP::Parser::Result::Version - TAP syntax version token.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Result/YAML.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Result/YAML.pm
@@ -11,11 +11,11 @@ TAP::Parser::Result::YAML - YAML result token.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Parser/ResultFactory.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/ResultFactory.pm
@@ -29,11 +29,11 @@ TAP::Parser::ResultFactory - Factory for creating TAP::Parser output objects
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head2 DESCRIPTION
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Scheduler.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Scheduler.pm
@@ -13,11 +13,11 @@ TAP::Parser::Scheduler - Schedule tests during parallel testing
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Scheduler/Job.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Scheduler/Job.pm
@@ -10,11 +10,11 @@ TAP::Parser::Scheduler::Job - A single testing job.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Scheduler/Spinner.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Scheduler/Spinner.pm
@@ -10,11 +10,11 @@ TAP::Parser::Scheduler::Spinner - A no-op job.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/Source.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/Source.pm
@@ -14,11 +14,11 @@ TAP::Parser::Source - a TAP source & meta data about it
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/SourceHandler.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/SourceHandler.pm
@@ -12,11 +12,11 @@ TAP::Parser::SourceHandler - Base class for different TAP source handlers
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/SourceHandler/Executable.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/SourceHandler/Executable.pm
@@ -16,11 +16,11 @@ TAP::Parser::SourceHandler::Executable - Stream output from an executable TAP so
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/SourceHandler/File.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/SourceHandler/File.pm
@@ -16,11 +16,11 @@ TAP::Parser::SourceHandler::File - Stream TAP from a text file.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/SourceHandler/Handle.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/SourceHandler/Handle.pm
@@ -16,11 +16,11 @@ TAP::Parser::SourceHandler::Handle - Stream TAP from an IO::Handle or a GLOB.
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/SourceHandler/Perl.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/SourceHandler/Perl.pm
@@ -21,11 +21,11 @@ TAP::Parser::SourceHandler::Perl - Stream TAP from a Perl executable
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/SourceHandler/RawTAP.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/SourceHandler/RawTAP.pm
@@ -16,11 +16,11 @@ TAP::Parser::SourceHandler::RawTAP - Stream output from raw TAP in a scalar/arra
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/YAMLish/Reader.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/YAMLish/Reader.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base 'TAP::Object';
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 # TODO:
 #   Handle blessed object syntax
@@ -269,7 +269,7 @@ TAP::Parser::YAMLish::Reader - Read YAMLish data from iterator
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/TAP/Parser/YAMLish/Writer.pm
+++ b/cpan/Test-Harness/lib/TAP/Parser/YAMLish/Writer.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base 'TAP::Object';
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 my $ESCAPE_CHAR = qr{ [ \x00-\x1f \" ] }x;
 my $ESCAPE_KEY  = qr{ (?: ^\W ) | $ESCAPE_CHAR }x;
@@ -146,7 +146,7 @@ TAP::Parser::YAMLish::Writer - Write YAMLish data
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =head1 SYNOPSIS
 

--- a/cpan/Test-Harness/lib/Test/Harness.pm
+++ b/cpan/Test-Harness/lib/Test/Harness.pm
@@ -31,11 +31,11 @@ Test::Harness - Run Perl standard test scripts with statistics
 
 =head1 VERSION
 
-Version 3.42
+Version 3.43
 
 =cut
 
-our $VERSION = '3.42';
+our $VERSION = '3.43';
 
 # Backwards compatibility for exportable variable names.
 *verbose  = *Verbose;

--- a/t/harness
+++ b/t/harness
@@ -117,17 +117,29 @@ if (@ARGV) {
     unless (@tests) {
 	my @seq = <base/*.t>;
 
-	my @next = qw(comp run cmd io re opbasic op uni mro lib porting perf);
-	push @next, 'japh' if $torture;
-	push @next, 'win32' if $^O eq 'MSWin32';
-	push @next, 'benchmark' if $ENV{PERL_BENCHMARK};
-	push @next, 'bigmem' if $ENV{PERL_TEST_MEMORY};
+        my @last;
+	my @next = qw(comp run cmd);
+
+        # The remaining core tests are either intermixed with the non-core for
+        # more parallelism (if HARNESS_QUICK is set non-zero) or done after
+        # the above basic sanity tests before any non-core ones.
+        my $which = $ENV{HARNESS_QUICK} ? \@last : \@next;
+
+        push @$which, qw(io re opbasic op uni mro lib porting perf);
+	push @$which, 'japh' if $torture;
+	push @$which, 'win32' if $^O eq 'MSWin32';
+	push @$which, 'benchmark' if $ENV{PERL_BENCHMARK};
+	push @$which, 'bigmem' if $ENV{PERL_TEST_MEMORY};
+
 	# Hopefully TAP::Parser::Scheduler will support this syntax soon.
 	# my $next = { par => '{' . join (',', @next) . '}/*.t' };
 	my $next = { par => [
 			     map { "$_/*.t" } @next
 			    ] };
 	@tests = _extract_tests ($next);
+
+	my $last = { par => '{' . join (',', @last) . '}/*.t' };
+	@last = _extract_tests ($last);
 
 	# This is a bit of a game, because we only want to sort these tests in
 	# speed order. base/*.t wants to run first, and ext,lib etc last and in
@@ -147,7 +159,6 @@ if (@ARGV) {
 	@tests = (@seq, @tests);
 	push @seq, $next;
 
-	my @last;
 	push @last,
 	    _tests_from_manifest($Config{extensions}, $Config{known_extensions});
 	my %times;
@@ -171,7 +182,7 @@ if (@ARGV) {
 
             # Keep a list of the distinct directory names, and another list of
             # those which contain a file whose name begins with a 0
-            if ( m! \A \.\. /
+            if ( m! \A (?: \.\. / )?
                                 ( .*? )         # $1 is the directory path name
                             /
                                 ( [^/]* \.t )   # $2 is the .t name
@@ -210,7 +221,7 @@ if (@ARGV) {
 	for (@last) {
             # Treat every file in each non-serial directory as its own
             # "directory", so that it can be executed in parallel
-            m! \A ( \.\. / (?: $non_serials )
+            m! \A ( (?: \.\. / )? (?: $non_serials )
                          / [^/]+ \.t \z | .* [/] ) !x
                 or die "'$_'";
 	    push @{$dir{$1}}, $_;


### PR DESCRIPTION
This has two independent but related commits in it.

The first, after factoring in comments, would be submitted to upstream CPAN.  It fixes the bug that the timers are wrong, especially for test files that have lengthy front-loaded calculations before doing output.   The commit message gives the details.  I'm unsure if I got the exact correct spot to start the timing of a running job.  I'd like someone to check.  Possibilities include @Leont. @nwc10.  Please forward this request to others you think would be interested/knowledgeable

The second commit increases the CPU utilisation of parallel testing in t/harness.  Again, the commit message has the details.  In working on this, I noticed the bug the first commit fixes, so without the TAP::Harness changes, this is not all that effective.  I especially am looking for feedback about the API.  I chose an environment variable,  but am unclear on exactly how it would best work.