### PR TITLE
Rearranging and revising the "open" section of perlfunc.pod for clarity

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -242,7 +242,7 @@ L<C<chroot>|/chroot FILENAME>,
 L<C<fcntl>|/fcntl FILEHANDLE,FUNCTION,SCALAR>, L<C<glob>|/glob EXPR>,
 L<C<ioctl>|/ioctl FILEHANDLE,FUNCTION,SCALAR>,
 L<C<link>|/link OLDFILE,NEWFILE>, L<C<lstat>|/lstat FILEHANDLE>,
-L<C<mkdir>|/mkdir FILENAME,MODE>, L<C<open>|/open FILEHANDLE,EXPR>,
+L<C<mkdir>|/mkdir FILENAME,MODE>, L<C<open>|/open FILEHANDLE,MODE,EXPR>,
 L<C<opendir>|/opendir DIRHANDLE,EXPR>, L<C<readlink>|/readlink EXPR>,
 L<C<rename>|/rename OLDNAME,NEWNAME>, L<C<rmdir>|/rmdir FILENAME>,
 L<C<select>|/select FILEHANDLE>, L<C<stat>|/stat FILEHANDLE>,
@@ -471,7 +471,7 @@ L<C<kill>|/kill SIGNAL, LIST>, L<C<link>|/link OLDFILE,NEWFILE>,
 L<C<lstat>|/lstat FILEHANDLE>, L<C<msgctl>|/msgctl ID,CMD,ARG>,
 L<C<msgget>|/msgget KEY,FLAGS>,
 L<C<msgrcv>|/msgrcv ID,VAR,SIZE,TYPE,FLAGS>,
-L<C<msgsnd>|/msgsnd ID,MSG,FLAGS>, L<C<open>|/open FILEHANDLE,EXPR>,
+L<C<msgsnd>|/msgsnd ID,MSG,FLAGS>, L<C<open>|/open FILEHANDLE,MODE,EXPR>,
 L<C<pipe>|/pipe READHANDLE,WRITEHANDLE>, L<C<readlink>|/readlink EXPR>,
 L<C<rename>|/rename OLDNAME,NEWNAME>,
 L<C<select>|/select RBITS,WBITS,EBITS,TIMEOUT>,
@@ -839,7 +839,7 @@ while C<:encoding(UTF-8)> checks the data for actually being valid
 UTF-8.  More details can be found in L<PerlIO::encoding>.
 
 In general, L<C<binmode>|/binmode FILEHANDLE, LAYER> should be called
-after L<C<open>|/open FILEHANDLE,EXPR> but before any I/O is done on the
+after L<C<open>|/open FILEHANDLE,MODE,EXPR> but before any I/O is done on the
 filehandle.  Calling L<C<binmode>|/binmode FILEHANDLE, LAYER> normally
 flushes any pending buffered output data (and perhaps pending input
 data) on the handle.  An exception to this is the C<:encoding> layer
@@ -1253,12 +1253,12 @@ layer.  Closes the currently selected filehandle if the argument is
 omitted.
 
 You don't have to close FILEHANDLE if you are immediately going to do
-another L<C<open>|/open FILEHANDLE,EXPR> on it, because
-L<C<open>|/open FILEHANDLE,EXPR> closes it for you.  (See
-L<C<open>|/open FILEHANDLE,EXPR>.) However, an explicit
+another L<C<open>|/open FILEHANDLE,MODE,EXPR> on it, because
+L<C<open>|/open FILEHANDLE,MODE,EXPR> closes it for you.  (See
+L<C<open>|/open FILEHANDLE,MODE,EXPR>.) However, an explicit
 L<C<close>|/close FILEHANDLE> on an input file resets the line counter
 (L<C<$.>|perlvar/$.>), while the implicit close done by
-L<C<open>|/open FILEHANDLE,EXPR> does not.
+L<C<open>|/open FILEHANDLE,MODE,EXPR> does not.
 
 If the filehandle came from a piped open, L<C<close>|/close FILEHANDLE>
 returns false if one of the other syscalls involved fails or if its
@@ -1481,7 +1481,7 @@ L<C<tie>|/tie VARIABLE,CLASSNAME,LIST> function.]
 
 This binds a L<dbm(3)>, L<ndbm(3)>, L<sdbm(3)>, L<gdbm(3)>, or Berkeley
 DB file to a hash.  HASH is the name of the hash.  (Unlike normal
-L<C<open>|/open FILEHANDLE,EXPR>, the first argument is I<not> a
+L<C<open>|/open FILEHANDLE,MODE,EXPR>, the first argument is I<not> a
 filehandle, even though it looks like one).  DBNAME is the name of the
 database (without the F<.dir> or F<.pag> extension if any).  If the
 database does not exist, it is created with protection specified by MASK
@@ -2719,7 +2719,7 @@ Returns the file descriptor for a filehandle or directory handle,
 or undefined if the
 filehandle is not open.  If there is no real file descriptor at the OS
 level, as can happen with filehandles connected to memory objects via
-L<C<open>|/open FILEHANDLE,EXPR> with a reference for the third
+L<C<open>|/open FILEHANDLE,MODE,EXPR> with a reference for the third
 argument, -1 is returned.
 
 This is mainly useful for constructing bitmaps for
@@ -4553,11 +4553,11 @@ More examples of different modes in action:
 =item Checking the return value
 
 Open returns nonzero on success, the undefined value otherwise.  If
-the L<C<open>|/open FILEHANDLE,EXPR> involved a pipe, the return value
+the L<C<open>|/open FILEHANDLE,MODE,EXPR> involved a pipe, the return value
 happens to be the pid of the subprocess.
 
 When opening a file, it's seldom a good idea to continue
-if the request failed, so L<C<open>|/open FILEHANDLE,EXPR> is frequently
+if the request failed, so L<C<open>|/open FILEHANDLE,MODE,EXPR> is frequently
 used with L<C<die>|/die LIST>. Even if you want your code to do
 something other than C<die> on a failed open, you should still always
 check
@@ -4643,7 +4643,7 @@ is C<-|>, the filename is interpreted as a command that pipes
 output to us.  In the two-argument (and one-argument) form, one should
 replace dash (C<->) with the command.
 See L<perlipc/"Using open() for IPC"> for more examples of this.
-(You are not allowed to L<C<open>|/open FILEHANDLE,EXPR> to a command
+(You are not allowed to L<C<open>|/open FILEHANDLE,MODE,EXPR> to a command
 that pipes both in I<and> out, but see L<IPC::Open2>, L<IPC::Open3>, and
 L<perlipc/"Bidirectional Communication with Another Process"> for
 alternatives.)
@@ -4663,14 +4663,14 @@ alternatives.)
 In the form of pipe opens taking three or more arguments, if LIST is specified
 (extra arguments after the command name) then LIST becomes arguments
 to the command invoked if the platform supports it.  The meaning of
-L<C<open>|/open FILEHANDLE,EXPR> with more than three arguments for
+L<C<open>|/open FILEHANDLE,MODE,EXPR> with more than three arguments for
 non-pipe modes is not yet defined, but experimental "layers" may give
 extra LIST arguments meaning.
 
 If you open a pipe on the command C<-> (that is, specify either C<|-> or C<-|>
 with the one- or two-argument forms of
-L<C<open>|/open FILEHANDLE,EXPR>), an implicit L<C<fork>|/fork> is done,
-so L<C<open>|/open FILEHANDLE,EXPR> returns twice: in the parent process
+L<C<open>|/open FILEHANDLE,MODE,EXPR>), an implicit L<C<fork>|/fork> is done,
+so L<C<open>|/open FILEHANDLE,MODE,EXPR> returns twice: in the parent process
 it returns the pid
 of the child process, and in the child process it returns (a defined) C<0>.
 Use C<defined($pid)> or C<//> to determine whether the open was successful.
@@ -4811,7 +4811,7 @@ In the one- and two-argument forms of the call, the mode and filename
 should be concatenated (in that order), preferably separated by white
 space.  You can--but shouldn't--omit the mode in these forms when that mode
 is C<< < >>.  It is safe to use the two-argument form of
-L<C<open>|/open FILEHANDLE,EXPR> if the filename argument is a known literal.
+L<C<open>|/open FILEHANDLE,MODE,EXPR> if the filename argument is a known literal.
 
  open(my $dbase, "+<dbase.mine")          # ditto
      or die "Can't open 'dbase.mine' for update: $!";
@@ -4892,7 +4892,7 @@ symbolic reference, so C<use strict "refs"> should I<not> be in effect.)
 =item Whitespace and special characters in the filename argument
 
 The filename passed to the one- and two-argument forms of
-L<C<open>|/open FILEHANDLE,EXPR> will
+L<C<open>|/open FILEHANDLE,MODE,EXPR> will
 have leading and trailing whitespace deleted and normal
 redirection characters honored.  This property, known as "magic open",
 can often be used to good effect.  A user could specify a filename of
@@ -4914,7 +4914,7 @@ otherwise it's necessary to protect any leading and trailing whitespace:
 
 (this may not work on some bizarre filesystems).  One should
 conscientiously choose between the I<magic> and I<three-argument> form
-of L<C<open>|/open FILEHANDLE,EXPR>:
+of L<C<open>|/open FILEHANDLE,MODE,EXPR>:
 
     open(my $in, $ARGV[0]) || die "Can't open $ARGV[0]: $!";
 
@@ -4933,7 +4933,7 @@ produces a filename that can be opened normally.)
 If you want a "real" C L<open(2)>, then you should use the
 L<C<sysopen>|/sysopen FILEHANDLE,FILENAME,MODE> function, which involves
 no such magic (but uses different filemodes than Perl
-L<C<open>|/open FILEHANDLE,EXPR>, which corresponds to C L<fopen(3)>).
+L<C<open>|/open FILEHANDLE,MODE,EXPR>, which corresponds to C L<fopen(3)>).
 This is another way to protect your filenames from interpretation.  For
 example:
 
@@ -6250,7 +6250,7 @@ Note the I<characters>: depending on the status of the filehandle,
 either (8-bit) bytes or characters are read.  By default, all
 filehandles operate on bytes, but for example if the filehandle has
 been opened with the C<:utf8> I/O layer (see
-L<C<open>|/open FILEHANDLE,EXPR>, and the L<open>
+L<C<open>|/open FILEHANDLE,MODE,EXPR>, and the L<open>
 pragma), the I/O will operate on UTF8-encoded Unicode
 characters, not bytes.  Similarly for the C<:encoding> layer:
 in that case pretty much any characters can be read.
@@ -8743,7 +8743,7 @@ parameters FILENAME, MODE, and PERMS.
 Returns true on success and L<C<undef>|/undef EXPR> otherwise.
 
 L<PerlIO> layers will be applied to the handle the same way they would in an
-L<C<open>|/open FILEHANDLE,EXPR> call that does not specify layers. That is,
+L<C<open>|/open FILEHANDLE,MODE,EXPR> call that does not specify layers. That is,
 the current value of L<C<${^OPEN}>|perlvar/${^OPEN}> as set by the L<open>
 pragma in a lexical scope, or the C<-C> commandline option or C<PERL_UNICODE>
 environment variable in the main program scope, falling back to the platform
@@ -8770,7 +8770,7 @@ OS/390 and on the Macintosh; you probably don't want to
 use them in new code.
 
 If the file named by FILENAME does not exist and the
-L<C<open>|/open FILEHANDLE,EXPR> call creates
+L<C<open>|/open FILEHANDLE,MODE,EXPR> call creates
 it (typically because MODE includes the C<O_CREAT> flag), then the value of
 PERMS specifies the permissions of the newly created file.  If you omit
 the PERMS argument to L<C<sysopen>|/sysopen FILEHANDLE,FILENAME,MODE>,
@@ -8805,7 +8805,7 @@ L<C<sysread>|/sysread FILEHANDLE,SCALAR,LENGTH,OFFSET>,
 L<C<syswrite>|/syswrite FILEHANDLE,SCALAR,LENGTH,OFFSET>,
 or L<C<sysseek>|/sysseek FILEHANDLE,POSITION,WHENCE>.  A handle opened with
 this function can be used with buffered IO just as one opened with
-L<C<open>|/open FILEHANDLE,EXPR> can be used with unbuffered IO.
+L<C<open>|/open FILEHANDLE,MODE,EXPR> can be used with unbuffered IO.
 
 Note that under Perls older than 5.8.0,
 L<C<sysopen>|/sysopen FILEHANDLE,FILENAME,MODE> depends on the
@@ -8857,7 +8857,7 @@ Note that if the filehandle has been marked as C<:utf8>, C<sysread> will
 throw an exception.  The C<:encoding(...)> layer implicitly
 introduces the C<:utf8> layer.  See
 L<C<binmode>|/binmode FILEHANDLE, LAYER>,
-L<C<open>|/open FILEHANDLE,EXPR>, and the L<open> pragma.
+L<C<open>|/open FILEHANDLE,MODE,EXPR>, and the L<open> pragma.
 
 =item sysseek FILEHANDLE,POSITION,WHENCE
 X<sysseek> X<lseek>
@@ -9022,7 +9022,7 @@ The C<:encoding(...)> layer implicitly introduces the C<:utf8> layer.
 Alternately, if the handle is not marked with an encoding but you
 attempt to write characters with code points over 255, raises an exception.
 See L<C<binmode>|/binmode FILEHANDLE, LAYER>,
-L<C<open>|/open FILEHANDLE,EXPR>, and the L<open> pragma.
+L<C<open>|/open FILEHANDLE,MODE,EXPR>, and the L<open> pragma.
 
 =item tell FILEHANDLE
 X<tell>

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4844,7 +4844,7 @@ An older style is to use a bareword as the filehandle, as
 
 Then you can use C<FH> as the filehandle, in C<< close FH >> and C<<
 <FH> >> and so on.  Note that it's a global variable, so this form is
-not recommended in new code.
+not recommended when dealing with filehandles other than Perl's built-in ones (e.g. STDOUT and STDIN).
 
 =back
 

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4607,8 +4607,8 @@ L<C<seek>|/seek FILEHANDLE,POSITION,WHENCE> to do the reading.
 =item Opening a filehandle into an in-memory scalar
 
 You can open filehandles directly to Perl scalars instead of a file or
-other resource external to the program. Accomplish this by providing a
-reference to that scalar as the third argument to C<open>, like so:
+other resource external to the program. To do so, provide a reference to
+that scalar as the third argument to C<open>, like so:
 
  open(my $memory, ">", \$var)
      or die "Can't open memory file: $!";
@@ -4717,14 +4717,15 @@ The following blocks are more or less equivalent:
     open(my $fh, "-|") || exec "cat", "-n", $file;
     open(my $fh, "-|", "cat", "-n", $file);
 
-The last two examples in each block show the pipe as "list form", which is
-not yet supported on all platforms.  A good rule of thumb is that if
-your platform has a real L<C<fork>|/fork> (in other words, if your platform is
-Unix, including Linux and MacOS X), you can use the list form.  You would
-want to use the list form of the pipe so you can pass literal arguments
-to the command without risk of the shell interpreting any shell metacharacters
-in them.  However, this also bars you from opening pipes to commands
-that intentionally contain shell metacharacters, such as:
+The last two examples in each block show the pipe as "list form", which
+is not yet supported on all platforms.  A good rule of thumb is that if
+your platform has a real L<C<fork>|/fork> (e.g. your platform is Unix,
+including Linux and macOS, or you're using Perl 5.22 or later with
+Windows), you can use the list form.  You would want to use the list
+form of the pipe so you can pass literal arguments to the command
+without risk of the shell interpreting any shell metacharacters in them.
+However, this also bars you from opening pipes to commands that
+intentionally contain shell metacharacters, such as:
 
     open(my $fh, "|cat -n | expand -4 | lpr")
 	|| die "Can't open pipeline to lpr: $!";
@@ -4854,12 +4855,11 @@ not recommended when dealing with filehandles other than Perl's built-in ones (e
 
 =item Automatic filehandle closure
 
-The filehandle will be closed when its reference count reaches zero.
-If it is a lexically scoped variable declared with L<C<my>|/my VARLIST>,
-that usually
-means the end of the enclosing scope.  However, this automatic close
-does not check for errors, so it is better to explicitly close
-filehandles, especially those used for writing:
+The filehandle will be closed when its reference count reaches zero. If
+it is a lexically scoped variable declared with L<C<my>|/my VARLIST>,
+that usually means the end of the enclosing scope.  However, this
+automatic close does not check for errors, so it is better to explicitly
+close filehandles, especially those used for writing:
 
     close($handle)
        || warn "close failed: $!";

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4469,8 +4469,8 @@ A thorough reference to C<open> follows. For a gentler introduction to
 the basics of C<open>, see also the L<perlopentut> manual page.
 
 =over
- 
-=item Common usage: working with files
+
+=item Working with files
 
 Most often, C<open> gets invoked with three arguments: the required
 FILEHANDLE (usually an empty scalar variable), followed by MODE (usually
@@ -4484,8 +4484,8 @@ filename  that the new filehandle will refer to.
 Reading from a file:
 
     open(my $fh, "<", "input.txt")
-    	or die "Can't open < input.txt: $!";
-	
+        or die "Can't open < input.txt: $!";
+
     # Process every line in input.txt
     while (my $line = <$fh>) {
         #
@@ -4497,7 +4497,7 @@ or writing to one:
 
     open(my $fh, ">", "output.txt")
         or die "Can't open > output.txt: $!";
-	
+
     print $fh "This line gets printed directly into output.txt.\n";
 
 For a summary of common filehandle operations such as these, see
@@ -4552,9 +4552,9 @@ More examples of different modes in action:
 
 =item Checking the return value
 
-Open returns nonzero on success, the undefined value otherwise.  If
-the L<C<open>|/open FILEHANDLE,MODE,EXPR> involved a pipe, the return value
-happens to be the pid of the subprocess.
+Open returns nonzero on success, the undefined value otherwise.  If the
+C<open> involved a pipe, the return value happens to be the pid of the
+subprocess.
 
 When opening a file, it's seldom a good idea to continue
 if the request failed, so L<C<open>|/open FILEHANDLE,MODE,EXPR> is frequently
@@ -4569,7 +4569,7 @@ the return value from opening a file.
 
 You can use the three-argument form of open to specify
 I/O layers (sometimes referred to as "disciplines") to apply to the new
-filehanle. These affect how the input and output are processed (see
+filehandle. These affect how the input and output are processed (see
 L<open> and
 L<PerlIO> for more details).  For example:
 
@@ -4653,7 +4653,7 @@ alternatives.)
  open(my $article_fh, "-|", "caesar <$article")  # decrypt
                                                  # article
      or die "Can't start caesar: $!";
-     
+
  open(my $article_fh, "caesar <$article |")      # ditto
      or die "Can't start caesar: $!";
 

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4718,13 +4718,12 @@ The following blocks are more or less equivalent:
     open(my $fh, "-|", "cat", "-n", $file);
 
 The last two examples in each block show the pipe as "list form", which
-is not yet supported on all platforms.  A good rule of thumb is that if
-your platform has a real L<C<fork>|/fork> (e.g. your platform is Unix,
-including Linux and macOS, or you're using Perl 5.22 or later with
-Windows), you can use the list form.  You would want to use the list
-form of the pipe so you can pass literal arguments to the command
-without risk of the shell interpreting any shell metacharacters in them.
-However, this also bars you from opening pipes to commands that
+is not yet supported on all platforms. (If your platform has a real
+L<C<fork>|/fork>, such as Linux and macOS, you can use the list form; it
+also works on Windows with Perl 5.22 or later.) You would want to use
+the list form of the pipe so you can pass literal arguments to the
+command without risk of the shell interpreting any shell metacharacters
+in them. However, this also bars you from opening pipes to commands that
 intentionally contain shell metacharacters, such as:
 
     open(my $fh, "|cat -n | expand -4 | lpr")

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4498,7 +4498,7 @@ or writing to one:
     open(my $fh, ">", "output.txt")
         or die "Can't open > output.txt: $!";
 
-    print $fh "This line gets printed directly into output.txt.\n";
+    print $fh "This line gets printed into output.txt.\n";
 
 For a summary of common filehandle operations such as these, see
 L<perlintro/Files and I/O>.
@@ -4544,7 +4544,7 @@ More examples of different modes in action:
 
  # Open a file for concatenation
  open(my $log, ">>", "/usr/spool/news/twitlog")
-     or warn "Couldn't open log file; input will be discarded";
+     or warn "Couldn't open log file; discarding input";
 
  # Open a file for reading and writing
  open(my $dbase, "+<", "dbase.mine")
@@ -4556,12 +4556,10 @@ Open returns nonzero on success, the undefined value otherwise.  If the
 C<open> involved a pipe, the return value happens to be the pid of the
 subprocess.
 
-When opening a file, it's seldom a good idea to continue
-if the request failed, so L<C<open>|/open FILEHANDLE,MODE,EXPR> is frequently
-used with L<C<die>|/die LIST>. Even if you want your code to do
-something other than C<die> on a failed open, you should still always
-check
-the return value from opening a file.
+When opening a file, it's seldom a good idea to continue if the request
+failed, so C<open> is frequently used with L<C<die>|/die LIST>. Even if
+you want your code to do something other than C<die> on a failed open,
+you should still always check the return value from opening a file.
 
 =back
 
@@ -4573,8 +4571,8 @@ filehandle. These affect how the input and output are processed (see
 L<open> and
 L<PerlIO> for more details).  For example:
 
-  open(my $fh, "<:encoding(UTF-8)", $filename)
-    || die "Can't open UTF-8 encoded $filename: $!";
+    open(my $fh, "<:encoding(UTF-8)", $filename)
+        || die "Can't open UTF-8 encoded $filename: $!";
 
 This opens the UTF8-encoded file containing Unicode characters;
 see L<perluniintro>.  Note that if layers are specified in the
@@ -4612,7 +4610,7 @@ that scalar as the third argument to C<open>, like so:
 
  open(my $memory, ">", \$var)
      or die "Can't open memory file: $!";
- print $memory "foo!\n";              # output will appear in $var
+ print $memory "foo!\n";    # output will appear in $var
 
 To (re)open C<STDOUT> or C<STDERR> as an in-memory file, close it first:
 
@@ -4629,10 +4627,10 @@ any other C<open>, check the return value for success.
 
 I<Technical note>: This feature works only when Perl is built with
 PerlIO -- the default, except with older (pre-5.16) Perl installations
-specifically built without it (e.g. via C<Configure -Uuseperlio>). You
-can see whether your Perl was built with PerlIO by running C<perl
--V:useperlio>.  If it says C<'define'>, you have PerlIO; otherwise you
-don't.
+that were configured to not include it (e.g. via C<Configure
+-Uuseperlio>). You can see whether your Perl was built with PerlIO by
+running C<perl -V:useperlio>.  If it says C<'define'>, you have PerlIO;
+otherwise you don't.
 
 See L<perliol> for detailed info on PerlIO.
 
@@ -4678,11 +4676,13 @@ Use C<defined($pid)> or C<//> to determine whether the open was successful.
 
 For example, use either
 
-   my $child_pid = open(my $from_kid, "-|") // die "Can't fork: $!";
+   my $child_pid = open(my $from_kid, "-|")
+        // die "Can't fork: $!";
 
 or
 
-   my $child_pid = open(my $to_kid,   "|-") // die "Can't fork: $!";
+   my $child_pid = open(my $to_kid,   "|-")
+        // die "Can't fork: $!";
 
 followed by
 
@@ -4728,7 +4728,7 @@ However, this also bars you from opening pipes to commands that
 intentionally contain shell metacharacters, such as:
 
     open(my $fh, "|cat -n | expand -4 | lpr")
-	|| die "Can't open pipeline to lpr: $!";
+    	|| die "Can't open pipeline to lpr: $!";
 
 See L<perlipc/"Safe Pipe Opens"> for more examples of this.
 
@@ -4749,11 +4749,15 @@ Here is a script that saves, redirects, and restores C<STDOUT> and
 C<STDERR> using various methods:
 
     #!/usr/bin/perl
-    open(my $oldout, ">&STDOUT")     or die "Can't dup STDOUT: $!";
-    open(OLDERR,     ">&", \*STDERR) or die "Can't dup STDERR: $!";
+    open(my $oldout, ">&STDOUT")
+        or die "Can't dup STDOUT: $!";
+    open(OLDERR,     ">&", \*STDERR)
+        or die "Can't dup STDERR: $!";
 
-    open(STDOUT, '>', "foo.out") or die "Can't redirect STDOUT: $!";
-    open(STDERR, ">&STDOUT")     or die "Can't dup STDOUT: $!";
+    open(STDOUT, '>', "foo.out")
+        or die "Can't redirect STDOUT: $!";
+    open(STDERR, ">&STDOUT")
+        or die "Can't dup STDOUT: $!";
 
     select STDERR; $| = 1;  # make unbuffered
     select STDOUT; $| = 1;  # make unbuffered
@@ -4761,8 +4765,10 @@ C<STDERR> using various methods:
     print STDOUT "stdout 1\n";  # this works for
     print STDERR "stderr 1\n";  # subprocesses too
 
-    open(STDOUT, ">&", $oldout) or die "Can't dup \$oldout: $!";
-    open(STDERR, ">&OLDERR")    or die "Can't dup OLDERR: $!";
+    open(STDOUT, ">&", $oldout)
+        or die "Can't dup \$oldout: $!";
+    open(STDERR, ">&OLDERR")
+        or die "Can't dup OLDERR: $!";
 
     print STDOUT "stdout 2\n";
     print STDERR "stderr 2\n";
@@ -4831,7 +4837,8 @@ As a shortcut, a one-argument call takes the filename from the global
 scalar variable of the same name as the filehandle:
 
     $ARTICLE = 100;
-    open(ARTICLE) or die "Can't find article $ARTICLE: $!\n";
+    open(ARTICLE)
+        or die "Can't find article $ARTICLE: $!\n";
 
 Here C<$ARTICLE> must be a global (package) scalar variable - not one
 declared with L<C<my>|/my VARLIST> or L<C<state>|/state VARLIST>.
@@ -4900,18 +4907,19 @@ can often be used to good effect.  A user could specify a filename of
 F<"rsh cat file |">, or you could change certain filenames as needed:
 
     $filename =~ s/(.*\.gz)\s*$/gzip -dc < $1|/;
-    open(my $fh, $filename) or die "Can't open $filename: $!";
+    open(my $fh, $filename)
+        or die "Can't open $filename: $!";
 
 Use the three-argument form to open a file with arbitrary weird characters in it,
 
     open(my $fh, "<", $file)
-	|| die "Can't open $file: $!";
+    	|| die "Can't open $file: $!";
 
 otherwise it's necessary to protect any leading and trailing whitespace:
 
     $file =~ s#^(\s)#./$1#;
     open(my $fh, "< $file\0")
-	|| die "Can't open $file: $!";
+    	|| die "Can't open $file: $!";
 
 (this may not work on some bizarre filesystems).  One should
 conscientiously choose between the I<magic> and I<three-argument> form
@@ -4923,7 +4931,7 @@ will allow the user to specify an argument of the form C<"rsh cat file |">,
 but will not work on a filename that happens to have a trailing space, while
 
     open(my $in, "<", $ARGV[0])
-	|| die "Can't open $ARGV[0]: $!";
+    	|| die "Can't open $ARGV[0]: $!";
 
 will have exactly the opposite restrictions. (However, some shells
 support the syntax C<< perl your_program.pl <( rsh cat file ) >>, which

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4444,46 +4444,84 @@ Leading white space is ignored without warning, as too are any trailing
 non-digits, such as a decimal point (L<C<oct>|/oct EXPR> only handles
 non-negative integers, not negative integers or floating point).
 
-=item open FILEHANDLE,EXPR
-X<open> X<pipe> X<file, open> X<fopen>
-
 =item open FILEHANDLE,MODE,EXPR
+X<open> X<pipe> X<file, open> X<fopen>
 
 =item open FILEHANDLE,MODE,EXPR,LIST
 
 =item open FILEHANDLE,MODE,REFERENCE
 
+=item open FILEHANDLE,EXPR
+
 =item open FILEHANDLE
 
 =for Pod::Functions open a file, pipe, or descriptor
 
-Opens the file whose filename is given by EXPR, and associates it with
-FILEHANDLE.
+Associates an internal FILEHANDLE with the external file specified by
+EXPR. That filehandle will subsequently allow you to perform
+I/O operations on that file, such as reading from it or writing to it.
 
-Simple examples to open a file for reading:
+Instead of a filename, you may specify an external command
+(plus an optional argument list) or a scalar reference, in order to open
+filehandles on commands or in-memory scalars, respectively.
+
+A thorough reference to C<open> follows. For a gentler introduction to
+the basics of C<open>, see also the L<perlopentut> manual page.
+
+=over
+ 
+=item Common usage: working with files
+
+Most often, C<open> gets invoked with three arguments: the required
+FILEHANDLE (usually an empty scalar variable), followed by MODE (usually
+a literal describing the I/O mode the filehandle will use), and then the
+filename  that the new filehandle will refer to.
+
+=over
+
+=item Simple examples
+
+Reading from a file:
 
     open(my $fh, "<", "input.txt")
-	or die "Can't open < input.txt: $!";
+    	or die "Can't open < input.txt: $!";
+	
+    # Process every line in input.txt
+    while (my $line = <$fh>) {
+        #
+        # ... do something interesting with $line here ...
+        #
+    }
 
-and for writing:
+or writing to one:
 
     open(my $fh, ">", "output.txt")
-	or die "Can't open > output.txt: $!";
+        or die "Can't open > output.txt: $!";
+	
+    print $fh "This line gets printed directly into output.txt.\n";
 
-(The following is a comprehensive reference to
-L<C<open>|/open FILEHANDLE,EXPR>: for a gentler introduction you may
-consider L<perlopentut>.)
+For a summary of common filehandle operations such as these, see
+L<perlintro/Files and I/O>.
 
-If FILEHANDLE is an undefined scalar variable (or array or hash element), a
-new filehandle is autovivified, meaning that the variable is assigned a
-reference to a newly allocated anonymous filehandle.  Otherwise if
-FILEHANDLE is an expression, its value is the real filehandle.  (This is
-considered a symbolic reference, so C<use strict "refs"> should I<not> be
-in effect.)
+=item About filehandles
 
-If three (or more) arguments are specified, the open mode (including
-optional encoding) in the second argument are distinct from the filename in
-the third.  If MODE is C<< < >> or nothing, the file is opened for input.
+The first argument to C<open>, labeled FILEHANDLE in this reference, is
+usually a scalar variable. (Exceptions exist, described in "Other
+considerations", below.) If the call to C<open> succeeds, then the
+expression provided as FILEHANDLE will get assigned an open
+I<filehandle>. That filehandle provides an internal reference to the
+specified external file, conveniently stored in a Perl variable, and
+ready for I/O operations such as reading and writing.
+
+=item About modes
+
+When calling C<open> with three or more arguments, the second argument
+-- labeled MODE here -- defines the I<open mode>. MODE is usually a
+literal string comprising special characters that define the intended
+I/O role of the filehandle being created: whether it's read-only, or
+read-and-write, and so on.
+
+If MODE is C<< < >>, the file is opened for input (read-only).
 If MODE is C<< > >>, the file is opened for output, with existing files
 first being truncated ("clobbered") and nonexisting files newly created.
 If MODE is C<<< >> >>>, the file is opened for appending, again being
@@ -4502,52 +4540,49 @@ L<C<umask>|/umask EXPR> value.
 These various prefixes correspond to the L<fopen(3)> modes of C<r>,
 C<r+>, C<w>, C<w+>, C<a>, and C<a+>.
 
-In the one- and two-argument forms of the call, the mode and filename
-should be concatenated (in that order), preferably separated by white
-space.  You can--but shouldn't--omit the mode in these forms when that mode
-is C<< < >>.  It is safe to use the two-argument form of
-L<C<open>|/open FILEHANDLE,EXPR> if the filename argument is a known literal.
+More examples of different modes in action:
 
-For three or more arguments if MODE is C<|->, the filename is
-interpreted as a command to which output is to be piped, and if MODE
-is C<-|>, the filename is interpreted as a command that pipes
-output to us.  In the two-argument (and one-argument) form, one should
-replace dash (C<->) with the command.
-See L<perlipc/"Using open() for IPC"> for more examples of this.
-(You are not allowed to L<C<open>|/open FILEHANDLE,EXPR> to a command
-that pipes both in I<and> out, but see L<IPC::Open2>, L<IPC::Open3>, and
-L<perlipc/"Bidirectional Communication with Another Process"> for
-alternatives.)
+ # Open a file for concatenation
+ open(my $log, ">>", "/usr/spool/news/twitlog")
+     or warn "Couldn't open log file; input will be discarded";
 
-In the form of pipe opens taking three or more arguments, if LIST is specified
-(extra arguments after the command name) then LIST becomes arguments
-to the command invoked if the platform supports it.  The meaning of
-L<C<open>|/open FILEHANDLE,EXPR> with more than three arguments for
-non-pipe modes is not yet defined, but experimental "layers" may give
-extra LIST arguments meaning.
+ # Open a file for reading and writing
+ open(my $dbase, "+<", "dbase.mine")
+     or die "Can't open 'dbase.mine' for update: $!";
 
-In the two-argument (and one-argument) form, opening C<< <- >>
-or C<-> opens STDIN and opening C<< >- >> opens STDOUT.
+=item Checking the return value
 
-You may (and usually should) use the three-argument form of open to specify
-I/O layers (sometimes referred to as "disciplines") to apply to the handle
-that affect how the input and output are processed (see L<open> and
+Open returns nonzero on success, the undefined value otherwise.  If
+the L<C<open>|/open FILEHANDLE,EXPR> involved a pipe, the return value
+happens to be the pid of the subprocess.
+
+When opening a file, it's seldom a good idea to continue
+if the request failed, so L<C<open>|/open FILEHANDLE,EXPR> is frequently
+used with L<C<die>|/die LIST>. Even if you want your code to do
+something other than C<die> on a failed open, you should still always
+check
+the return value from opening a file.
+
+=back
+
+=item Specifying I/O layers in MODE
+
+You can use the three-argument form of open to specify
+I/O layers (sometimes referred to as "disciplines") to apply to the new
+filehanle. These affect how the input and output are processed (see
+L<open> and
 L<PerlIO> for more details).  For example:
 
   open(my $fh, "<:encoding(UTF-8)", $filename)
     || die "Can't open UTF-8 encoded $filename: $!";
 
-opens the UTF8-encoded file containing Unicode characters;
+This opens the UTF8-encoded file containing Unicode characters;
 see L<perluniintro>.  Note that if layers are specified in the
 three-argument form, then default layers stored in ${^OPEN} (see L<perlvar>;
 usually set by the L<open> pragma or the switch C<-CioD>) are ignored.
 Those layers will also be ignored if you specify a colon with no name
 following it.  In that case the default layer for the operating system
 (:raw on Unix, :crlf on Windows) is used.
-
-Open returns nonzero on success, the undefined value otherwise.  If
-the L<C<open>|/open FILEHANDLE,EXPR> involved a pipe, the return value
-happens to be the pid of the subprocess.
 
 On some systems (in general, DOS- and Windows-based systems)
 L<C<binmode>|/binmode FILEHANDLE, LAYER> is necessary when you're not
@@ -4556,41 +4591,7 @@ always to use it when appropriate, and never to use it when it isn't
 appropriate.  Also, people can set their I/O to be by default
 UTF8-encoded Unicode, not bytes.
 
-When opening a file, it's seldom a good idea to continue
-if the request failed, so L<C<open>|/open FILEHANDLE,EXPR> is frequently
-used with L<C<die>|/die LIST>.  Even if L<C<die>|/die LIST> won't do
-what you want (say, in a CGI script,
-where you want to format a suitable error message (but there are
-modules that can help with that problem)) always check
-the return value from opening a file.
-
-The filehandle will be closed when its reference count reaches zero.
-If it is a lexically scoped variable declared with L<C<my>|/my VARLIST>,
-that usually
-means the end of the enclosing scope.  However, this automatic close
-does not check for errors, so it is better to explicitly close
-filehandles, especially those used for writing:
-
-    close($handle)
-       || warn "close failed: $!";
-
-An older style is to use a bareword as the filehandle, as
-
-    open(FH, "<", "input.txt")
-       or die "Can't open < input.txt: $!";
-
-Then you can use C<FH> as the filehandle, in C<< close FH >> and C<<
-<FH> >> and so on.  Note that it's a global variable, so this form is
-not recommended in new code.
-
-As a shortcut a one-argument call takes the filename from the global
-scalar variable of the same name as the filehandle:
-
-    $ARTICLE = 100;
-    open(ARTICLE) or die "Can't find article $ARTICLE: $!\n";
-
-Here C<$ARTICLE> must be a global (package) scalar variable - not one
-declared with L<C<my>|/my VARLIST> or L<C<state>|/state VARLIST>.
+=item Using C<undef> for temporary files
 
 As a special case the three-argument form with a read/write mode and the third
 argument being L<C<undef>|/undef EXPR>:
@@ -4602,11 +4603,16 @@ opens a filehandle to a newly created empty anonymous temporary file.
 sensible mode to use.)  You will need to
 L<C<seek>|/seek FILEHANDLE,POSITION,WHENCE> to do the reading.
 
-Perl is built using PerlIO by default.  Unless you've
-changed this (such as building Perl with C<Configure -Uuseperlio>), you can
-open filehandles directly to Perl scalars via:
 
-    open(my $fh, ">", \$variable) || ..
+=item Opening a filehandle into an in-memory scalar
+
+You can open filehandles directly to Perl scalars instead of a file or
+other resource external to the program. Accomplish this by providing a
+reference to that scalar as the third argument to C<open>, like so:
+
+ open(my $memory, ">", \$var)
+     or die "Can't open memory file: $!";
+ print $memory "foo!\n";              # output will appear in $var
 
 To (re)open C<STDOUT> or C<STDERR> as an in-memory file, close it first:
 
@@ -4621,33 +4627,110 @@ any code points over 0xFF.
 Opening in-memory files I<can> fail for a variety of reasons.  As with
 any other C<open>, check the return value for success.
 
+I<Technical note>: This feature works only when Perl is built with
+PerlIO -- the default, unless you've changed this (such as building Perl
+with C<Configure -Uuseperlio>). You can see whether your Perl was built
+with PerlIO by running C<perl -V:useperlio>.  If it says C<'define'>,
+you have PerlIO; otherwise you don't.
+
 See L<perliol> for detailed info on PerlIO.
 
-General examples:
+=item Opening a filehandle into a command
 
- open(my $log, ">>", "/usr/spool/news/twitlog");
- # if the open fails, output is discarded
+If MODE is C<|->, then the filename is
+interpreted as a command to which output is to be piped, and if MODE
+is C<-|>, the filename is interpreted as a command that pipes
+output to us.  In the two-argument (and one-argument) form, one should
+replace dash (C<->) with the command.
+See L<perlipc/"Using open() for IPC"> for more examples of this.
+(You are not allowed to L<C<open>|/open FILEHANDLE,EXPR> to a command
+that pipes both in I<and> out, but see L<IPC::Open2>, L<IPC::Open3>, and
+L<perlipc/"Bidirectional Communication with Another Process"> for
+alternatives.)
 
- open(my $dbase, "+<", "dbase.mine")      # open for update
-     or die "Can't open 'dbase.mine' for update: $!";
-
- open(my $dbase, "+<dbase.mine")          # ditto
-     or die "Can't open 'dbase.mine' for update: $!";
 
  open(my $article_fh, "-|", "caesar <$article")  # decrypt
                                                  # article
      or die "Can't start caesar: $!";
-
+     
  open(my $article_fh, "caesar <$article |")      # ditto
      or die "Can't start caesar: $!";
 
  open(my $out_fh, "|-", "sort >Tmp$$")    # $$ is our process id
      or die "Can't start sort: $!";
 
- # in-memory files
- open(my $memory, ">", \$var)
-     or die "Can't open memory file: $!";
- print $memory "foo!\n";              # output will appear in $var
+
+In the form of pipe opens taking three or more arguments, if LIST is specified
+(extra arguments after the command name) then LIST becomes arguments
+to the command invoked if the platform supports it.  The meaning of
+L<C<open>|/open FILEHANDLE,EXPR> with more than three arguments for
+non-pipe modes is not yet defined, but experimental "layers" may give
+extra LIST arguments meaning.
+
+If you open a pipe on the command C<-> (that is, specify either C<|-> or C<-|>
+with the one- or two-argument forms of
+L<C<open>|/open FILEHANDLE,EXPR>), an implicit L<C<fork>|/fork> is done,
+so L<C<open>|/open FILEHANDLE,EXPR> returns twice: in the parent process
+it returns the pid
+of the child process, and in the child process it returns (a defined) C<0>.
+Use C<defined($pid)> or C<//> to determine whether the open was successful.
+
+For example, use either
+
+   my $child_pid = open(my $from_kid, "-|") // die "Can't fork: $!";
+
+or
+
+   my $child_pid = open(my $to_kid,   "|-") // die "Can't fork: $!";
+
+followed by
+
+    if ($child_pid) {
+	# am the parent:
+	# either write $to_kid or else read $from_kid
+	...
+       waitpid $child_pid, 0;
+    } else {
+	# am the child; use STDIN/STDOUT normally
+	...
+	exit;
+    }
+
+The filehandle behaves normally for the parent, but I/O to that
+filehandle is piped from/to the STDOUT/STDIN of the child process.
+In the child process, the filehandle isn't opened--I/O happens from/to
+the new STDOUT/STDIN.  Typically this is used like the normal
+piped open when you want to exercise more control over just how the
+pipe command gets executed, such as when running setuid and
+you don't want to have to scan shell commands for metacharacters.
+
+The following blocks are more or less equivalent:
+
+    open(my $fh, "|tr '[a-z]' '[A-Z]'");
+    open(my $fh, "|-", "tr '[a-z]' '[A-Z]'");
+    open(my $fh, "|-") || exec 'tr', '[a-z]', '[A-Z]';
+    open(my $fh, "|-", "tr", '[a-z]', '[A-Z]');
+
+    open(my $fh, "cat -n '$file'|");
+    open(my $fh, "-|", "cat -n '$file'");
+    open(my $fh, "-|") || exec "cat", "-n", $file;
+    open(my $fh, "-|", "cat", "-n", $file);
+
+The last two examples in each block show the pipe as "list form", which is
+not yet supported on all platforms.  A good rule of thumb is that if
+your platform has a real L<C<fork>|/fork> (in other words, if your platform is
+Unix, including Linux and MacOS X), you can use the list form.  You would
+want to use the list form of the pipe so you can pass literal arguments
+to the command without risk of the shell interpreting any shell metacharacters
+in them.  However, this also bars you from opening pipes to commands
+that intentionally contain shell metacharacters, such as:
+
+    open(my $fh, "|cat -n | expand -4 | lpr")
+	|| die "Can't open pipeline to lpr: $!";
+
+See L<perlipc/"Safe Pipe Opens"> for more examples of this.
+
+=item Duping filehandles
 
 You may also, in the Bourne shell tradition, specify an EXPR beginning
 with C<< >& >>, in which case the rest of the string is interpreted
@@ -4713,72 +4796,74 @@ L<fdopen(3)> to implement the C<=> functionality.  On many Unix systems,
 L<fdopen(3)> fails when file descriptors exceed a certain value, typically 255.
 For Perls 5.8.0 and later, PerlIO is (most often) the default.
 
-You can see whether your Perl was built with PerlIO by running
-C<perl -V:useperlio>.  If it says C<'define'>, you have PerlIO;
-otherwise you don't.
+=item Legacy usage
 
-If you open a pipe on the command C<-> (that is, specify either C<|-> or C<-|>
-with the one- or two-argument forms of
-L<C<open>|/open FILEHANDLE,EXPR>), an implicit L<C<fork>|/fork> is done,
-so L<C<open>|/open FILEHANDLE,EXPR> returns twice: in the parent process
-it returns the pid
-of the child process, and in the child process it returns (a defined) C<0>.
-Use C<defined($pid)> or C<//> to determine whether the open was successful.
+This section describes ways to call C<open> outside of best practices;
+you may encounter these uses in older code. Perl does not consider their
+use deprecated, exactly, but neither is it recommended in new code, for
+the sake of clarity and readability.
 
-For example, use either
+=over
 
-   my $child_pid = open(my $from_kid, "-|") // die "Can't fork: $!";
+=item Specifying mode and filename as a single argument
 
-or
+In the one- and two-argument forms of the call, the mode and filename
+should be concatenated (in that order), preferably separated by white
+space.  You can--but shouldn't--omit the mode in these forms when that mode
+is C<< < >>.  It is safe to use the two-argument form of
+L<C<open>|/open FILEHANDLE,EXPR> if the filename argument is a known literal.
 
-   my $child_pid = open(my $to_kid,   "|-") // die "Can't fork: $!";
+ open(my $dbase, "+<dbase.mine")          # ditto
+     or die "Can't open 'dbase.mine' for update: $!";
 
-followed by
+In the two-argument (and one-argument) form, opening C<< <- >>
+or C<-> opens STDIN and opening C<< >- >> opens STDOUT.
 
-    if ($child_pid) {
-	# am the parent:
-	# either write $to_kid or else read $from_kid
-	...
-       waitpid $child_pid, 0;
-    } else {
-	# am the child; use STDIN/STDOUT normally
-	...
-	exit;
-    }
+New code should favor the three-argument form of C<open> over this older
+form. Declaring the mode and the filename as two distinct arguments
+avoids any confusion between the two.
 
-The filehandle behaves normally for the parent, but I/O to that
-filehandle is piped from/to the STDOUT/STDIN of the child process.
-In the child process, the filehandle isn't opened--I/O happens from/to
-the new STDOUT/STDIN.  Typically this is used like the normal
-piped open when you want to exercise more control over just how the
-pipe command gets executed, such as when running setuid and
-you don't want to have to scan shell commands for metacharacters.
+=item Calling C<open> with one argument via global variables
 
-The following blocks are more or less equivalent:
+As a shortcut, a one-argument call takes the filename from the global
+scalar variable of the same name as the filehandle:
 
-    open(my $fh, "|tr '[a-z]' '[A-Z]'");
-    open(my $fh, "|-", "tr '[a-z]' '[A-Z]'");
-    open(my $fh, "|-") || exec 'tr', '[a-z]', '[A-Z]';
-    open(my $fh, "|-", "tr", '[a-z]', '[A-Z]');
+    $ARTICLE = 100;
+    open(ARTICLE) or die "Can't find article $ARTICLE: $!\n";
 
-    open(my $fh, "cat -n '$file'|");
-    open(my $fh, "-|", "cat -n '$file'");
-    open(my $fh, "-|") || exec "cat", "-n", $file;
-    open(my $fh, "-|", "cat", "-n", $file);
+Here C<$ARTICLE> must be a global (package) scalar variable - not one
+declared with L<C<my>|/my VARLIST> or L<C<state>|/state VARLIST>.
 
-The last two examples in each block show the pipe as "list form", which is
-not yet supported on all platforms.  A good rule of thumb is that if
-your platform has a real L<C<fork>|/fork> (in other words, if your platform is
-Unix, including Linux and MacOS X), you can use the list form.  You would
-want to use the list form of the pipe so you can pass literal arguments
-to the command without risk of the shell interpreting any shell metacharacters
-in them.  However, this also bars you from opening pipes to commands
-that intentionally contain shell metacharacters, such as:
+=item Assigning a filehandle to a bareword
 
-    open(my $fh, "|cat -n | expand -4 | lpr")
-	|| die "Can't open pipeline to lpr: $!";
+An older style is to use a bareword as the filehandle, as
 
-See L<perlipc/"Safe Pipe Opens"> for more examples of this.
+    open(FH, "<", "input.txt")
+       or die "Can't open < input.txt: $!";
+
+Then you can use C<FH> as the filehandle, in C<< close FH >> and C<<
+<FH> >> and so on.  Note that it's a global variable, so this form is
+not recommended in new code.
+
+=back
+
+=item Other considerations
+
+=over
+
+=item Automatic filehandle closure
+
+The filehandle will be closed when its reference count reaches zero.
+If it is a lexically scoped variable declared with L<C<my>|/my VARLIST>,
+that usually
+means the end of the enclosing scope.  However, this automatic close
+does not check for errors, so it is better to explicitly close
+filehandles, especially those used for writing:
+
+    close($handle)
+       || warn "close failed: $!";
+
+=item Automatic pipe flushing
 
 Perl will attempt to flush all files opened for
 output before any operation that may do a fork, but this may not be
@@ -4794,6 +4879,17 @@ of L<C<$^F>|perlvar/$^F>.  See L<perlvar/$^F>.
 Closing any piped filehandle causes the parent process to wait for the
 child to finish, then returns the status value in L<C<$?>|perlvar/$?> and
 L<C<${^CHILD_ERROR_NATIVE}>|perlvar/${^CHILD_ERROR_NATIVE}>.
+
+=item Direct versus by-reference assignment of filehandles
+
+If FILEHANDLE -- the first argument in a call to C<open> -- is an
+undefined scalar variable (or array or hash element), a new filehandle
+is autovivified, meaning that the variable is assigned a reference to a
+newly allocated anonymous filehandle.  Otherwise if FILEHANDLE is an
+expression, its value is the real filehandle.  (This is considered a
+symbolic reference, so C<use strict "refs"> should I<not> be in effect.)
+
+=item Whitespace and special characters in the filename argument
 
 The filename passed to the one- and two-argument forms of
 L<C<open>|/open FILEHANDLE,EXPR> will
@@ -4832,6 +4928,8 @@ will have exactly the opposite restrictions. (However, some shells
 support the syntax C<< perl your_program.pl <( rsh cat file ) >>, which
 produces a filename that can be opened normally.)
 
+=item Invoking C-style C<open>
+
 If you want a "real" C L<open(2)>, then you should use the
 L<C<sysopen>|/sysopen FILEHANDLE,FILENAME,MODE> function, which involves
 no such magic (but uses different filemodes than Perl
@@ -4850,7 +4948,14 @@ example:
 See L<C<seek>|/seek FILEHANDLE,POSITION,WHENCE> for some details about
 mixing reading and writing.
 
-Portability issues: L<perlport/open>.
+=item Portability issues
+
+See L<perlport/open>.
+
+=back
+
+=back
+
 
 =item opendir DIRHANDLE,EXPR
 X<opendir>

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4628,10 +4628,11 @@ Opening in-memory files I<can> fail for a variety of reasons.  As with
 any other C<open>, check the return value for success.
 
 I<Technical note>: This feature works only when Perl is built with
-PerlIO -- the default, unless you've changed this (such as building Perl
-with C<Configure -Uuseperlio>). You can see whether your Perl was built
-with PerlIO by running C<perl -V:useperlio>.  If it says C<'define'>,
-you have PerlIO; otherwise you don't.
+PerlIO -- the default, except with older (pre-5.16) Perl installations
+specifically built without it (e.g. via C<Configure -Uuseperlio>). You
+can see whether your Perl was built with PerlIO by running C<perl
+-V:useperlio>.  If it says C<'define'>, you have PerlIO; otherwise you
+don't.
 
 See L<perliol> for detailed info on PerlIO.
 

--- a/pod/perlport.pod
+++ b/pod/perlport.pod
@@ -364,15 +364,15 @@ filenames.
 
 Don't assume C<< > >> won't be the first character of a filename.
 Always use the three-arg version of
-L<C<open>|perlfunc/open FILEHANDLE,EXPR>:
+L<C<open>|perlfunc/open FILEHANDLE,MODE,EXPR>:
 
     open my $fh, '<', $existing_file) or die $!;
 
-Two-arg L<C<open>|perlfunc/open FILEHANDLE,EXPR> is magic and can
+Two-arg L<C<open>|perlfunc/open FILEHANDLE,MODE,EXPR> is magic and can
 translate characters like C<< > >>, C<< < >>, and C<|> in filenames,
 which is usually the wrong thing to do.
 L<C<sysopen>|perlfunc/sysopen FILEHANDLE,FILENAME,MODE> and three-arg
-L<C<open>|perlfunc/open FILEHANDLE,EXPR> don't have this problem.
+L<C<open>|perlfunc/open FILEHANDLE,MODE,EXPR> don't have this problem.
 
 Don't use C<:> as a part of a filename since many systems use that for
 their own semantics (Mac OS Classic for separating pathname components,
@@ -413,7 +413,7 @@ L<C<close>|perlfunc/close FILEHANDLE> files when you are done with them.
 Don't L<C<unlink>|perlfunc/unlink LIST> or
 L<C<rename>|perlfunc/rename OLDNAME,NEWNAME> an open file.  Don't
 L<C<tie>|perlfunc/tie VARIABLE,CLASSNAME,LIST> or
-L<C<open>|perlfunc/open FILEHANDLE,EXPR> a file already tied or opened;
+L<C<open>|perlfunc/open FILEHANDLE,MODE,EXPR> a file already tied or opened;
 L<C<untie>|perlfunc/untie VARIABLE> or
 L<C<close>|perlfunc/close FILEHANDLE> it first.
 
@@ -561,7 +561,7 @@ portable.  That means, no L<C<system>|perlfunc/system LIST>,
 L<C<exec>|perlfunc/exec LIST>, L<C<fork>|perlfunc/fork>,
 L<C<pipe>|perlfunc/pipe READHANDLE,WRITEHANDLE>,
 L<C<``> or C<qxE<sol>E<sol>>|perlop/C<qxE<sol>I<STRING>E<sol>>>,
-L<C<open>|perlfunc/open FILEHANDLE,EXPR> with a C<|>, nor any of the other
+L<C<open>|perlfunc/open FILEHANDLE,MODE,EXPR> with a C<|>, nor any of the other
 things that makes being a Perl hacker worth being.
 
 Commands that launch external processes are generally supported on
@@ -917,7 +917,7 @@ The DOS FAT filesystem can accommodate only "8.3" style filenames.  Under
 the "case-insensitive, but case-preserving" HPFS (OS/2) and NTFS (NT)
 filesystems you may have to be careful about case returned with functions
 like L<C<readdir>|perlfunc/readdir DIRHANDLE> or used with functions like
-L<C<open>|perlfunc/open FILEHANDLE,EXPR> or
+L<C<open>|perlfunc/open FILEHANDLE,MODE,EXPR> or
 L<C<opendir>|perlfunc/opendir DIRHANDLE,EXPR>.
 
 DOS also treats several filenames as special, such as F<AUX>, F<PRN>,
@@ -1378,7 +1378,7 @@ expand system variables in filenames if enclosed in angle brackets, so
 C<< <System$Dir>.Modules >> would look for the file
 S<C<$ENV{'System$Dir'} . 'Modules'>>.  The obvious implication of this is
 that B<fully qualified filenames can start with C<< <> >>> and the
-three-argument form of L<C<open>|perlfunc/open FILEHANDLE,EXPR> should
+three-argument form of L<C<open>|perlfunc/open FILEHANDLE,MODE,EXPR> should
 always be used.
 
 Because C<.> was in use as a directory separator and filenames could not


### PR DESCRIPTION
The `open` section of the `perlfunc` manual page comprises a single, very long section of text, interspersed with example-code blocks, covering many features of this complex and core Perl function. While every individual sentence or example within this text is factually accurate, the whole page makes for quite a daunting read. It runs for the length-equivalent of six printed pages with no sub-headings, frequently changing its focus on different aspects of `open` while not necessarily clarifying which construe common cases or best practices.

This pull request proposes revisions to address these issues. It aims to make this documentation section more approachable to Perl newcomers, without losing its value as a thorough reference.

Most significantly, this work rearranges the content into several nested sub-sections. Since `perlfunc` lists all its functions as `=item` entries within one single and enormously long `=over/=back` pair, I have implemented these sub-sections as `=over/=back` sub-lists, with `=item`s serving as headers. (A handful of other `perlfunc` sections, such as `eval`, do something like this already.)

I ordered these sections, and rearranged the existing documentation under them, so as to put `open` best practices and most-common use-cases first. After it explains using `open` with normal files, the text describes somewhat less-common use-cases of opening filehandles into commands and scalar references, before getting into rarer uses like duping. It ends with "legacy syntax" of calling `open` with less than three arguments, and then a miscellany of other considerations and cross-references.

While most of the text is unchanged from that currently found in `blead`, I did add or update some text for the sake of improved flow within this new arrangement. I also took the liberty to rewrite the introductory paragraphs, prior to the first sub-header, making an effort to define and demystify "filehandle" as soon as possible.

An aside, for transparency's sake: I submit this work as part of a TPF-funded project, [whose original proposal you can read online](https://news.perlfoundation.org/post/gp_jan_2020_open_docs).