### PR TITLE
Store github token after workflow v1 checkout.

### DIFF
--- a/.github/workflows/smoke-linux-i386.yml
+++ b/.github/workflows/smoke-linux-i386.yml
@@ -38,6 +38,8 @@ jobs:
       - uses: actions/checkout@v1
         with:
             fetch-depth: 0
+      - name: fix git remote credential
+        run: git remote set-url origin "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
       - name: git cfg + fetch tags
         run: |
           git config diff.renameLimit 999999


### PR DESCRIPTION
The i386 smoke runs uses the v1 checkout action to function on
an i386 base OS. The v1 checkout action did not persist credentials,
making the subsequent git commands fail on private repos.