### PR TITLE
Allow debugger aliases that start with '-' and '.'

### DIFF
--- a/lib/perl5db.pl
+++ b/lib/perl5db.pl
@@ -1874,7 +1874,7 @@ sub _DB__trim_command_and_return_first_component {
     # A single-character debugger command can be immediately followed by its
     # argument if they aren't both alphanumeric; otherwise require space
     # between commands and arguments:
-    my ($verb, $args) = $cmd =~ m{\A(.\b|\S*)\s*(.*)}s;
+    my ($verb, $args) = $cmd =~ m{\A([^\.-]\b|\S*)\s*(.*)}s;
 
     $obj->cmd_verb($verb);
     $obj->cmd_args($args);


### PR DESCRIPTION
Since the '.' and '-' commands don't take any arguments and don't run if any are provided, don't treat commands starting with these characters as the single commands '.' and '-'. Restores behavior that existed prior to https://github.com/Perl/perl5/commit/7fdd4f080863703d44282c6988834455d129040 (v5.27) at least back to v5.8.8

#17723