### PR TITLE
Updating perlopentut.pod for completeness

### DIFF
--- a/pod/perlopentut.pod
+++ b/pod/perlopentut.pod
@@ -358,19 +358,22 @@ elements, rather than combining them into a single string as in the
 examples above. For instance, we could have phrased the C<open> call in
 the first example like this:
 
-    open(my $sort_fh, '-|', 'sort', '-u', 'unsorted/*.txt')
+    open(my $sort_fh, '-|', 'sort', '-u', glob('unsorted/*.txt'))
         or die "Couldn't open a pipe into sort: $!";
 
-When you call C<open> this way, Perl takes care of escaping any
-characters within that list of arguments that the shell might interpret
-as metacharacters with special meaning, which may otherwise cause
-unwanted behavior. This can make for safer, less error-prone C<open>
-calls, especially when passing in variables as arguments.
+When you call C<open> this way, Perl invokes the given command directly,
+bypassing the shell. As such, the shell won't try to interpret any
+special characters within the command's argument list, which might
+overwise have unwanted effects. This can make for safer, less
+error-prone C<open> calls, useful in cases such as passing in variables
+as arguments, or even just referring to filenames with spaces in them.
 
-Note the side-effect this implies, though: If you I<really do> want to
-pass a meaningful metacharacter to the shell, as we do in the write-pipe
-example with our C<cat -n > numbered.txt> argument, then we can't take
-advantage of this alternate syntax.
+However, when you I<do> want to pass a meaningful metacharacter to the
+shell, such with the C<"*"> inside that final C<unsorted/*.txt> argument
+here, you can't use this alternate syntax. In this case, we have worked
+around it via Perl's handy C<glob> built-in function, which evaluates
+its argument into a list of filenames — and we can safely pass that
+resulting list right into C<open>, as shown above.
 
 Note also that representing piped-command arguments in list form like
 this doesn't work on every platform. It will work on any Unix-based OS

--- a/pod/perlopentut.pod
+++ b/pod/perlopentut.pod
@@ -259,15 +259,129 @@ Here's an example of how to copy a binary file:
 
 =head1 Opening Pipes
 
-To be announced.
+Perl also lets you open a filehandle into an external program or shell
+command rather than into a file. You can do this in order to pass data
+from your Perl program to an external command for further processing, or
+to receive data from another program for your own Perl program to
+process.
 
-=head1 Low-level File Opens via sysopen
+Filehandles into commands are also known as I<pipes>, since they work on
+similar inter-process communication principles as Unix pipelines. Such a
+filehandle has an active program instead of a static file on its
+external end, but in every other sense it works just like a more typical
+file-based filehandle, with all the techniques discussed earlier in this
+article just as applicable.
 
-To be announced.  Or deleted.
+As such, you open a pipe using the same C<open> call that you use for
+opening files, setting the second (C<MODE>) argument to special
+characters that indicate either an input or an output pipe. Use C<"-|"> for a
+filehandle that will let your Perl program read data from an external
+program, and C<"|-"> for a filehandle that will send data to that
+program instead.
+
+=head2 Opening a pipe for reading
+
+Let's say you'd like your Perl program to process data stored a nearby
+directory called C<unsorted>, which contains a number of textfiles.
+You'd also like your program to sort all the contents from these files
+into a single, alphabetically sorted list of unique lines before it
+starts processing them.
+
+You could do this through opening an ordinary filehandle into each of
+those files, gradually building up an in-memory array of all the file
+contents you load this way, and finally sorting and filtering that array
+when you've run out of files to load. I<Or>, you could offload all that
+merging and sorting into your operating system's own C<sort> command by
+opening a pipe directly into its output, and get to work that much
+faster.
+
+Here's how that might look:
+
+    open(my $sort_fh, '-|', 'sort -u unsorted/*.txt')
+        or die "Couldn't open a pipe into sort: $!";
+
+    # And right away, we can start reading sorted lines:
+    while (my $line = <$sort_fh>) {
+        #
+        # ... Do something interesting with each $line here ...
+        #
+    }
+
+The second argument to C<open>, C<"-|">, makes it a read-pipe into a
+separate program, rather than an ordinary filehandle into a file.
+
+Note that the third argument to C<open> is a string containing the
+program name (C<sort>) plus all its arguments: in this case, C<-u> to
+specify unqiue sort, and then a fileglob specifying the files to sort.
+The resulting filehandle C<$sort_fh> works just like a read-only (C<<
+"<" >>) filehandle, and your your program can subsequently read data
+from it as if it were opened onto an ordinary, single file.
+
+=head2 Opening a pipe for writing
+
+Continuing the previous example, let's say that your program has
+completed its processing, and the results sit in an array called
+C<@processed>. You want to print these lines to a file called
+C<numbered.txt> with a neatly formatted column of line-numbers.
+
+Certainly you could write your own code to do this — or, once again,
+you could kick that work over to another program. In this case, C<cat>,
+running with its own C<-n> option to activate line numbering, should do
+the trick:
+
+    open(my $cat_fh, '|-', 'cat -n > numbered.txt')
+        or die "Couldn't open a pipe into cat: $!";
+
+    for my $line (@processed) {
+        print $cat_fh $line;
+    }
+
+Here, we use a second C<open> argument of C<"|-">, signifying that the
+filehandle assigned to C<$cat_fh> should be a write-pipe. We can then
+use it just as we would a write-only ordinary filehandle, including the
+basic function of C<print>-ing data to it.
+
+Note that the third argument, specifying the command that we wish to
+pipe to, sets up C<cat> to redirect its output via that C<< ">" >>
+symbol into the file C<numbered.txt>. This can start to look a little
+tricky, because that that same symbol would have meant something
+entirely different had it showed it in the second argument to C<open>!
+But here in the third argument, it's simply part of the shell command that
+Perl will open the pipe into, and Perl itself doesn't invest any special
+meaning to it.
+
+=head2 Expressing the command as a list
+
+For opening pipes, Perl offers the option to call C<open> with a list
+comprising the desired command and all its own arguments as separate
+elements, rather than combining them into a single string as in the
+examples above. For instance, we could have phrased the C<open> call in
+the first example like this:
+
+    open(my $sort_fh, '-|', 'sort', '-u', 'unsorted/*.txt')
+        or die "Couldn't open a pipe into sort: $!";
+
+When you call C<open> this way, Perl takes care of escaping any
+characters within that list of arguments that the shell might interpret
+as metacharacters with special meaning, which may otherwise cause
+unwanted behavior. This can make for safer, less error-prone C<open>
+calls, especially when passing in variables as arguments.
+
+Note the side-effect this implies, though: If you I<really do> want to
+pass a meaningful metacharacter to the shell, as we do in the write-pipe
+example with our C<cat -n > numbered.txt> argument, then we can't take
+advantage of this alternate syntax.
+
+Note also that representing piped-command arguments in list form like
+this doesn't work on every platform. It will work on any Unix-based OS
+that provides a real C<fork> function (e.g. macOS or Linux), as well as
+on Windows when running Perl 5.22 or later.
 
 =head1 SEE ALSO
 
-To be announced.
+The full documentation for L<C<open>|perlfunc/open FILEHANDLE,MODE,EXPR>
+provides a thorough reference to this function, beyond the best-practice
+basics covered here.
 
 =head1 AUTHOR and COPYRIGHT
 

--- a/pod/perlopentut.pod
+++ b/pod/perlopentut.pod
@@ -259,15 +259,102 @@ Here's an example of how to copy a binary file:
 
 =head1 Opening Pipes
 
-To be announced.
+Perl also lets you open a filehandle into an external program or shell
+command rather than into a file. You can do this in order to pass data
+from your Perl program to an external command for further processing, or
+to receive data from another program for your own Perl program to
+process.
 
-=head1 Low-level File Opens via sysopen
+Filehandles into commands are also known as I<pipes>, since they work on
+similar inter-process communication principles as Unix pipelines. Such a
+filehandle has an active program instead of a static file on its
+external end, but in every other sense it works just like a more typical
+file-based filehandle, with all the techniques discussed earlier in this
+article just as applicable.
 
-To be announced.  Or deleted.
+As such, you open a pipe using the same C<open> call that you use for
+opening files, setting the second (C<MODE>) argument to special
+characters that indicate either an input or an output pipe. Use C<"-|"> for a
+filehandle that will let your Perl program read data from an external
+program, and C<"|-"> for a filehandle that will send data to that
+program instead.
+
+=head2 Opening a pipe for reading
+
+Let's say you'd like your Perl program to process data stored a nearby
+directory called C<unsorted>, which contains a number of textfiles.
+You'd also like your program to sort all the contents from these files
+into a single, alphabetically sorted list of unique lines before it
+starts processing them.
+
+You could do this through opening an ordinary filehandle into each of
+those files, gradually building up an in-memory array of all the file
+contents you load this way, and finally sorting and filtering that array
+when you've run out of files to load. I<Or>, you could offload all that
+merging and sorting into your operating system's own C<sort> command by
+opening a pipe directly into its output, and get to work that much
+faster.
+
+Here's how that might look:
+
+    open(my $sort_fh, '-|', 'sort -u unsorted/*.txt')
+        or die "Couldn't open a pipe into sort: $!";
+
+    # And right away, we can start reading sorted lines:
+    while (my $line = <$sort_fh>) {
+        #
+        # ... Do something interesting with each $line here ...
+        #
+    }
+
+The second argument to C<open>, C<"-|">, makes it a read-pipe into a
+separate program, rather than an ordinary filehandle into a file.
+
+Note that the third argument to C<open> is a string containing the
+program name (C<sort>) plus all its arguments: in this case, C<-u> to
+specify unqiue sort, and then a fileglob specifying the files to sort.
+The resulting filehandle C<$sort_fh> works just like a read-only (C<<
+"<" >>) filehandle, and your your program can subsequently read data
+from it as if it were opened onto an ordinary, single file.
+
+=head2 Opening a pipe for writing
+
+Continuing the previous example, let's say that your program has
+completed its processing, and the results sit in an array called
+C<@processed>. You want to print these lines to a file called
+C<numbered.txt> with a neatly formatted column of line-numbers.
+
+Certainly you could write your own code to do this — or, once again,
+you could kick that work over to another program. In this case, C<cat>,
+running with its own C<-n> option to activate line numbering, should do
+the trick:
+
+    open(my $cat_fh, '|-', 'cat -n > numbered.txt')
+        or die "Couldn't open a pipe into cat: $!";
+
+    for my $line (@processed) {
+        print $cat_fh $line;
+    }
+
+Here, we use a second C<open> argument of C<"|-">, signifying that the
+filehandle assigned to C<$cat_fh> should be a write-pipe. We can then
+use it just as we would a write-only ordinary filehandle, including the
+basic function of C<print>-ing data to it.
+
+Note that the third argument, specifying the command that we wish to
+pipe to, sets up C<cat> to redirect its output via that C<< ">" >>
+symbol into the file C<numbered.txt>. This can start to look a little
+tricky, because that that same symbol would have meant something
+entirely different had it showed it in the second argument to C<open>!
+But here in the third argument, it's simply part of the shell command that
+Perl will open the pipe into, and Perl itself doesn't invest any special
+meaning to it.
 
 =head1 SEE ALSO
 
-To be announced.
+The full documentation for L<C<open>|perlfunc/open FILEHANDLE,MODE,EXPR>
+provides a thorough reference to this function, beyond the best-practice
+basics covered here.
 
 =head1 AUTHOR and COPYRIGHT
 


### PR DESCRIPTION
This pull request updates the three "To Be Announced" sections at the end of perlopentut.pod:

* Fills out the section "Opening Pipes" with a short tutorial on that very topic. It explains the purpose of pipe-style file handles, and shows input and output examples.

* Deletes "Low-level File Opens via sysopen" entirely. (This accepts the invitation to do so that the section's placeholder text has held since 2013.)

* Adds a cross-reference to the `open` section of perlfunc.pod to the (heretofore empty) "SEE ALSO" section. (Note that the cross reference assumes the merge of #17717.)

I note that this work leaves the document's personal and dated copyright notice in place, despite proposing to add a significant amount of new content. I neither wish to claim copyright over this material nor deprive Tom Christiansen of his own claim, so it seemed simplest just to leave it be.

An aside, for transparency's sake: I submit this work as part of a TPF-funded project, [whose original proposal you can read online](https://news.perlfoundation.org/post/gp_jan_2020_open_docs).