### PR TITLE
17708 search libs

### DIFF
--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Cygwin.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Cygwin.pm
@@ -100,6 +100,17 @@ sub init_linker {
     $self->{EXPORT_LIST}  ||= '';
 }
 
+sub init_others {
+    my $self = shift;
+
+    $self->SUPER::init_others;
+
+    # As with Win32, any DLLs also need to link to libraries
+    $self->{LDLOADLIBS} ||= $Config{libs};
+
+    return;
+}
+
 =item maybe_command
 
 Determine whether a file is native to Cygwin by checking whether it

--- a/hints/cygwin.sh
+++ b/hints/cygwin.sh
@@ -11,13 +11,23 @@ esac
 archobjs='cygwin.o'
 
 # mandatory (overrides incorrect defaults)
-test -z "$cc" && cc='gcc'
-if test -z "$plibpth"
-then
-    plibpth=`gcc -print-file-name=libc.a`
-    plibpth=`dirname $plibpth`
-    plibpth=`cd $plibpth && pwd`
+if [ -x /usr/bin/gcc ] ; then
+    gcc=/usr/bin/gcc
+# clang also provides -print-search-dirs
+elif ${cc:-cc} --version 2>/dev/null | grep -q '^clang ' ; then
+    gcc=${cc:-cc}
+else
+    gcc=gcc
 fi
+
+case "$plibpth" in
+'') plibpth=`LANG=C LC_ALL=C $gcc $ccflags $ldflags -print-search-dirs | grep libraries |
+	cut -f2- -d= | tr ':' $trnl | sed -e 's:/$::'`
+    set X $plibpth # Collapse all entries on one line
+    shift
+    plibpth="$*"
+    ;;
+esac
 so='dll'
 # - eliminate -lc, implied by gcc and a symlink to libcygwin.a
 libswanted=`echo " $libswanted " | sed -e 's/ c / /g'`


### PR DESCRIPTION
fixes Configure not finding libquadmath on cygwin by default by asking gcc for library search directories.  This includes the gcc specific directories where that library lives, unlike the similar code in hints/linux.sh.  Unfortunately this may cause problems if gcc is upgraded since these paths are version specific.

The second commits modifies EU::MM_Cygwin to default LDLOADLIBS to $Config{libs} as on Win32 which fixes building the re module, unfortunately POSIX overrides LIBS, so the special code that includes to add quadmath can't be trivially removed.