### PR TITLE
Null pointer deref in handle_regex_sets()

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -16508,6 +16508,10 @@ redo_curchar:
                     goto regclass_failed;
                 }
 
+                if (! current) {
+                    break;
+                }
+
                 /* regclass() will return with parsing just the \ sequence,
                  * leaving the parse pointer at the next thing to parse */
                 RExC_parse--;


### PR DESCRIPTION
When called with the optional argument to provide an inversion list,
regclass() may return successfully but leave the inversion list pointer
null.

Fixes #17732

This change corrects the segfault so that single character unicode wildcard name matches fail cleanly, but does not correct the wildcard match behavior.