### PR TITLE
gh16947: avoid mutating regexp program only within GOSUB

### DIFF
--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -24,7 +24,7 @@ BEGIN {
 
 skip_all_without_unicode_tables();
 
-plan tests => 1018;  # Update this when adding/deleting tests.
+plan tests => 1019;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -2252,11 +2252,16 @@ SKIP:
         ok($result, "regexp correctly matched");
     }
 
-    # gh16947: test regexp corruption
+    # gh16947: test regexp corruption (GOSUB)
     {
         fresh_perl_is(q{
             'xy' =~ /x(?0)|x(?|y|y)/ && print 'ok'
-        }, 'ok', {}, 'gh16947: test regexp corruption');
+        }, 'ok', {}, 'gh16947: test regexp corruption (GOSUB)');
+    }
+    # gh16947: test fix doesn't break SUSPEND
+    {
+        fresh_perl_is(q{ 'sx' =~ m{ss++}i; print 'ok' },
+                'ok', {}, "gh16947: test fix doesn't break SUSPEND");
     }
 
 } # End of sub run_tests


### PR DESCRIPTION
Commits 3bc2a7809d and bdb91f3f96 used the existence of a frame to
decide when it was unsafe to mutate the regexp program, due to having
recursed for as GOSUB. However the frame recursion mechanism is also
used for SUSPEND.

Refine it further to avoid mutation only when within a GOSUB by saving
a new boolean in the frame structure, and using that to derive a "mutate_ok"
flag.