### PR TITLE
fix set magic handling for scalar reverse and an index() optimization

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -3520,11 +3520,16 @@ PP(pp_index)
   push_result:
     /* OPpTRUEBOOL indicates an '== -1' has been optimised away */
     if (PL_op->op_private & OPpTRUEBOOL) {
-        PUSHs( ((retval != -1) ^ cBOOL(PL_op->op_private & OPpINDEX_BOOLNEG))
-                    ? &PL_sv_yes : &PL_sv_no);
-        if (PL_op->op_private & OPpTARGET_MY)
+        SV *result = ((retval != -1) ^ cBOOL(PL_op->op_private & OPpINDEX_BOOLNEG))
+            ? &PL_sv_yes : &PL_sv_no;
+        if (PL_op->op_private & OPpTARGET_MY) {
             /* $lex = (index() == -1) */
-            sv_setsv(TARG, TOPs);
+            sv_setsv_mg(TARG, result);
+            PUSHs(TARG);
+        }
+        else {
+            PUSHs(result);
+        }
     }
     else
         PUSHi(retval);

--- a/pp.c
+++ b/pp.c
@@ -5898,6 +5898,7 @@ PP(pp_reverse)
 	    sv_setsv(TARG, DEFSV);
 	    XPUSHs(TARG);
 	}
+        SvSETMAGIC(TARG); /* remove any utf8 length magic */
 
 	up = SvPV_force(TARG, len);
 	if (len > 1) {

--- a/t/op/index.t
+++ b/t/op/index.t
@@ -8,7 +8,7 @@ BEGIN {
 }
 
 use strict;
-plan( tests => 412 );
+plan( tests => 414 );
 
 run_tests() unless caller;
 
@@ -330,6 +330,32 @@ sub run_tests {
         is($r, 4,                          "(r = index(a)) == -1 - r value");
 
 
+    }
+
+    {
+        my $store = 100;
+        package MyTie {
+            require Tie::Scalar;
+            our @ISA = qw(Tie::StdScalar);
+            sub STORE {
+                my ($self, $value) = @_;
+
+                $store = $value;
+            }
+        };
+        my $x;
+        tie $x, "MyTie";
+        $x = (index("foo", "o") == -1);
+        ok(!$store, 'magic called on $lexical = (index(...) == -1)');
+    }
+    {
+        is(eval <<'EOS', "a", 'optimized $lex = (index(...) == -1) is an lvalue');
+my $y = "foo";
+my $z = "o";
+my $x;
+($x = (index($y, $z) == -1)) =~ s/^/a/;
+$x;
+EOS
     }
 
 } # end of sub run_tests

--- a/t/op/reverse.t
+++ b/t/op/reverse.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan tests => 24;
+plan tests => 25;
 
 is(reverse("abc"), "cba", 'simple reverse');
 
@@ -90,6 +90,15 @@ use Tie::Array;
     my $b = scalar reverse($a);
     my $c = scalar reverse($b);
     is($a, $c, 'Unicode string double reversal matches original');
+}
+
+{
+    # https://github.com/Perl/perl5/issues/17737
+    # utf8 length magic handling
+    # threw an assertion failure with -DDEBUGGING
+    my @x;
+    push @x, length reverse for split "-", "\x{100}--0";
+    is($x[1], 0, "check set magic being called to clear length magic");
 }
 
 # [perl #132544] stack pointer used to go wild when nullary reverse


### PR DESCRIPTION
fixes #17737 fixes #17739 (github didn't pick it up from the commits)