### PR TITLE
gh17730: regcomp overflow/underflow

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -1498,6 +1498,8 @@ S_scan_commit(pTHX_ const RExC_state_t *pRExC_state, scan_data_t *data,
                        ? OPTIMIZE_INFTY
                        : (l
                           ? data->last_start_max
+                          /* temporary underflow guard for 5.32 */
+                          : data->pos_delta < 0 ? OPTIMIZE_INFTY
                           : (data->pos_delta > OPTIMIZE_INFTY - data->pos_min
 					 ? OPTIMIZE_INFTY
 					 : data->pos_min + data->pos_delta));

--- a/regcomp.c
+++ b/regcomp.c
@@ -5306,8 +5306,10 @@ S_study_chunk(pTHX_ RExC_state_t *pRExC_state, regnode **scanp,
 		   offset, later match for variable offset.  */
 		if (data->last_end == -1) { /* Update the start info. */
 		    data->last_start_min = data->pos_min;
- 		    data->last_start_max = is_inf
-                        ? OPTIMIZE_INFTY : data->pos_min + data->pos_delta;
+                    data->last_start_max =
+                        is_inf ? OPTIMIZE_INFTY
+                        : (data->pos_delta > OPTIMIZE_INFTY - data->pos_min)
+                            ? OPTIMIZE_INFTY : data->pos_min + data->pos_delta;
 		}
 		sv_catpvn(data->last_found, STRING(scan), bytelen);
 		if (UTF)

--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -24,7 +24,7 @@ BEGIN {
 
 skip_all_without_unicode_tables();
 
-plan tests => 1019;  # Update this when adding/deleting tests.
+plan tests => 1020;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -2262,6 +2262,13 @@ SKIP:
     {
         fresh_perl_is(q{ 'sx' =~ m{ss++}i; print 'ok' },
                 'ok', {}, "gh16947: test fix doesn't break SUSPEND");
+    }
+
+    # gh17730: should not crash
+    {
+        fresh_perl_is(q{
+            "q00" =~ m{(((*ACCEPT)0)*00)?0(?1)}; print "ok"
+        }, 'ok', {}, 'gh17730: should not crash');
     }
 
 } # End of sub run_tests


### PR DESCRIPTION
Avoid overflow when setting last_start_max; add temporary underflow guard in scan_commit.