### PR TITLE
Add github issue template config, removing blank issue option and adding CPAN module link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a CPAN Module Issue
+    url: https://metacpan.org
+    about: Please report issues with CPAN modules to their preferred bugtracker as indicated on their MetaCPAN page


### PR DESCRIPTION
This config allows the "open a blank issue" option to be removed (the available options are already comprehensive) and adds a contact link to direct people where to report CPAN module issues.