### PR TITLE
regcomp.c: Fix named sequences in (?[...])

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -6756,6 +6756,15 @@ The closing delimtter to match the opening one was not found.  If the
 opening one is escaped by preceding it with a backslash, the closing one
 must also be so escaped.
 
+=item Unicode string properties are not implemented in (?[...]) in
+regex; marked by <-- HERE in m/%s/
+
+(F) A Unicode string property is one which expands to a sequence of
+multiple characters.  An example is C<\p{name=KATAKANA LETTER AINU P}>,
+which is comprised of the sequence C<\N{KATAKANA LETTER SMALL H}>
+followed by C<\N{COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK}>.
+Extended character classes, C<(?[...])> currently cannot handle these.
+
 =item Unicode surrogate U+%X is illegal in UTF-8
 
 (S surrogate) You had a UTF-16 surrogate in a context where they are
@@ -7478,6 +7487,22 @@ the whole thing correctly, except when the class is inverted
 a range.  For these, what should happen isn't clear at all.  In
 these circumstances, Perl discards all but the first character
 of the returned sequence, which is not likely what you want.
+
+=item Using just the single character results returned by \p{} in
+(?[...]) in regex; marked by S<<-- HERE> in m/%s/
+
+(W regexp) Extended character classes currently cannot handle operands
+that evaluate to more than one character.  These are removed from the
+results of the expansion of the C<\p{}>.
+
+This situation can happen, for example, in
+
+ (?[ \p{name=/KATAKANA/} ])
+
+"KATAKANA LETTER AINU P" is a legal Unicode name (technically a "named
+sequence"), but it is actually two characters.  The above expression
+with match only the Unicode names containing KATAKANA that represent
+single characters.
 
 =item Using /u for '%s' instead of /%s in regex; marked by S<<-- HERE> in m/%s/
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -17371,6 +17371,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
     PERL_UNUSED_ARG(depth);
 #endif
 
+    assert(! (ret_invlist && allow_mutiple_chars));
 
     /* If wants an inversion list returned, we can't optimize to something
      * else. */

--- a/t/re/reg_mesg.t
+++ b/t/re/reg_mesg.t
@@ -331,6 +331,7 @@ my @death =
  '/\p{gc=:\PS:}/' => 'Use of \'\\PS\' is not allowed in Unicode property wildcard subpatterns {#} m/\\PS{#}/',
  '/\p{gc=:[\pS]:}/' => 'Use of \'\\pS\' is not allowed in Unicode property wildcard subpatterns {#} m/[\\pS{#}]/',
  '/\p{gc=:[\PS]:}/' => 'Use of \'\\PS\' is not allowed in Unicode property wildcard subpatterns {#} m/[\\PS{#}]/',
+ '/(?[\p{name=KATAKANA LETTER AINU P}])/' => 'Unicode string properties are not implemented in (?[...]) {#} m/(?[\p{name=KATAKANA LETTER AINU P}{#}])/',
 );
 
 # These are messages that are death under 'use re "strict"', and may or may
@@ -708,6 +709,15 @@ my @experimental_regex_sets = (
     '/noutf8 ネ (?[ [\tネ] ])/' => 'The regex_sets feature is experimental {#} m/noutf8 ネ (?[{#} [\tネ] ])/',
 );
 
+my @wildcard = (
+    'm!(?[\p{name=/KATAKANA/}])$!' =>
+    [
+     'The regex_sets feature is experimental {#} m/(?[{#}\p{name=/KATAKANA/}])$/',
+     'The Unicode property wildcards feature is experimental',
+     'Using just the single character results returned by \p{} in (?[...]) {#} m/(?[\p{name=/KATAKANA/}{#}])$/'
+    ], # [GH #17732] Null pointer deref
+);
+
 my @deprecated = (
  '/^{/'          => "",
  '/foo|{/'       => "",
@@ -797,6 +807,7 @@ for my $strict ("",  "no warnings 'experimental::re_strict'; use re 'strict';") 
 
     foreach my $ref (\@warning_tests,
                      \@experimental_regex_sets,
+                     \@wildcard,
                      \@deprecated)
     {
         my $warning_type;
@@ -813,6 +824,10 @@ for my $strict ("",  "no warnings 'experimental::re_strict'; use re 'strict';") 
         }
         elsif ($ref == \@experimental_regex_sets) {
             $warning_type = 'experimental::regex_sets';
+            $default_on = 1;
+        }
+        elsif ($ref == \@wildcard) {
+            $warning_type = 'experimental::regex_sets, experimental::uniprop_wildcards';
             $default_on = 1;
         }
         else {


### PR DESCRIPTION
The regex_sets feature cannot yet handle named sequences possibly
returned by \p{name=...}.  I forgot to check for this possibility which
led to a null pointer dereference.  Also, the called function was
returning success when it should have failed in this circumstance.

This fixes #17732