### PR TITLE
Fix panic in Unicode wildcard matching

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -13565,8 +13565,8 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                 /* SBOL is shared with /^/ so we set the flags so we can tell
                  * /\A/ from /^/ in split. */
                 FLAGS(REGNODE_p(ret)) = 1;
+                *flagp |= SIMPLE;   /* Wrong, but too late to fix for 5.32 */
             }
-	    *flagp |= SIMPLE;
 	    goto finish_meta_pat;
 	case 'G':
             if (RExC_pm_flags & PMf_WILDCARD) {
@@ -13604,8 +13604,8 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
             }
             else {
                 ret = reg_node(pRExC_state, SEOL);
+                *flagp |= SIMPLE;   /* Wrong, but too late to fix for 5.32 */
             }
-	    *flagp |= SIMPLE;
 	    RExC_seen_zerolen++;		/* Do not optimize RE away */
 	    goto finish_meta_pat;
 	case 'z':
@@ -13615,8 +13615,8 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
             }
             else {
                 ret = reg_node(pRExC_state, EOS);
+                *flagp |= SIMPLE;   /* Wrong, but too late to fix for 5.32 */
             }
-	    *flagp |= SIMPLE;
 	    RExC_seen_zerolen++;		/* Do not optimize RE away */
 	    goto finish_meta_pat;
 	case 'C':


### PR DESCRIPTION
The reason this bug occurs is that wildcard matching changes the anchor
assertions \A, \Z, and \z, without corresponding changes in regexec.c.

We earlier noticed that all these were being marked SIMPLE, and a
zero-width construct shouldn't really be.  But it was considered too
late in the development cycle to make that change.  So the plan was to
live with this bug in an experimental feature in 5.32.

But I eventually realized that the change could be effected for just the
wildcard versions, and this commit does that.  If there is some issue
with making these non-SIMPLE, it will affect only the wildcard feature,
and those potential bugs are better than a known bug.  I also seems
unlikely that this will introduce any bug.  What removing SIMPLE does is
merely remove potential optimizations in the handling.  The most general
case should work.; it's doing an improper optimization that gets one
into trouble.

This fixes #17677