### PR TITLE
Link to the definition of true and false from perlsyn

### DIFF
--- a/pod/perlsyn.pod
+++ b/pod/perlsyn.pod
@@ -137,7 +137,8 @@ Its truth or falsehood determines how the modifier will behave.
 
 C<if> executes the statement once I<if> and only if the condition is
 true.  C<unless> is the opposite, it executes the statement I<unless>
-the condition is true (that is, if the condition is false).
+the condition is true (that is, if the condition is false).  See
+L<perldata/Scalar values> for definitions of true and false.
 
     print "Basset hounds got long ears" if length $ear >= 10;
     go_outside() and play() unless $is_raining;


### PR DESCRIPTION
There used to be a section on Truth and Falsehood there, as the
following paragraphs talk about conditions and booleans a lot. It was
moved to perldata in 77fae4394e3ad9f159a74a6731a8d347cd2466c7, but
without a trace. Let's have a link to the new destination in the old one.