### PR TITLE
regcomp.c: incr ref cnt of re_intuit_string() return

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -21491,7 +21491,9 @@ SV *
 Perl_re_intuit_string(pTHX_ REGEXP * const r)
 {				/* Assume that RE_INTUIT is set */
     /* Returns an SV containing a string that must appear in the target for it
-     * to match */
+     * to match, or NULL if nothing is known that must match.
+     *
+     * CAUTION: the SV can be freed during execution of the regex engine */
 
     struct regexp *const prog = ReANY(r);
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
@@ -25078,6 +25080,12 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
     /* Compile the subpattern consisting of the name being looked for */
     subpattern_re = compile_wildcard(wname, wname_len, FALSE /* /-i */ );
     must = re_intuit_string(subpattern_re);
+
+    /* (Note: 'must' could contain a NUL.  And yet we use strspn() below on it.
+     * This works because the NUL causes the function to return early, thus
+     * showing that there are characters in it other than the acceptable ones,
+     * which is our desired result.) */
+
     prog = ReANY(subpattern_re);
 
     /* If only nothing is matched, skip to where empty names are looked for */

--- a/t/re/pat_advanced.t
+++ b/t/re/pat_advanced.t
@@ -2553,6 +2553,15 @@ EOF
                       {}, "Too large negative relative group number");
     }
 
+    {   # GH #17734, ASAN use after free
+        fresh_perl_like('no warnings "experimental::uniprop_wildcards";
+                         my $re = q<[[\p{name=/[Y-]+Z/}]]>;
+                         eval { "\N{BYZANTINE MUSICAL SYMBOL PSILI}"
+                                =~ /$re/ }; print $@ if $@; print "Done\n";',
+                         qr/Done/,
+                         {}, "GH #17734");
+    }
+
 
     # !!! NOTE that tests that aren't at all likely to crash perl should go
     # a ways above, above these last ones.  There's a comment there that, like


### PR DESCRIPTION
This function returns an SV that it turns out may have its reference
count decremented by a future call to re_intuit_start().  Thus, the
caller doesn't get clear title to the returned SV.  This is not
documented.

It is too late in the development cycle to properly fix this, but in
this instance, it is a simple matter to increment the ref count of the
returned scalar

This fixes #17734.