### PR TITLE
Fixed typemap in perlxs.

### DIFF
--- a/dist/ExtUtils-ParseXS/lib/perlxs.pod
+++ b/dist/ExtUtils-ParseXS/lib/perlxs.pod
@@ -1748,8 +1748,8 @@ example.
         if( sv_isobject($arg) && (SvTYPE(SvRV($arg)) == SVt_PVMG) )
             $var = ($type)SvIV((SV*)SvRV( $arg ));
         else{
-            warn("${Package}::$func_name() -- " .
-                "$var is not a blessed SV reference");
+            warn(\"${Package}::$func_name() -- \"
+                \"$var is not a blessed SV reference\");
             XSRETURN_UNDEF;
         }
 


### PR DESCRIPTION
Fixed quoting and string concatenation bugs in C++ typemap in `perlxs`. 

The typemap code will be eval'd by `xsubpp` within double quotes so double quotes needs to be escaped. Also the dot is not a valid string concatenation operator in C.