### PR TITLE
make IO::Handle::error report errors from both input and output streams

### DIFF
--- a/dist/IO/ChangeLog
+++ b/dist/IO/ChangeLog
@@ -1,3 +1,16 @@
+IO 1.44
+  * IO::Handle::error() now checks both the input and output stream
+    for error.  This is an issue for sockets and character devices.  GH #6799
+  * IO::Handle::clearerr() now clears the error on both input and
+    output streams.
+
+IO 1.43
+  * only cache the protocol for sockets when one is supplied,
+    otherwise protocol could return an incorrect protocol.  This means
+    that on platforms that don't support SO_PROTOCOL (or don't support
+    it for some socket types) protocol() can now return undef.
+
+
 IO 1.42 - Jan 20 2020 - Todd Rinaldo
   * Point IO support to perl/perl5 not dual-life/IO
 

--- a/dist/IO/IO.pm
+++ b/dist/IO/IO.pm
@@ -7,7 +7,7 @@ use Carp;
 use strict;
 use warnings;
 
-our $VERSION = "1.43";
+our $VERSION = "1.44";
 XSLoader::load 'IO', $VERSION;
 
 sub import {

--- a/dist/IO/IO.xs
+++ b/dist/IO/IO.xs
@@ -410,13 +410,21 @@ ferror(handle)
 
 int
 clearerr(handle)
-	InputStream	handle
+	SV *	handle
+    PREINIT:
+        IO *io = sv_2io(handle);
+        InputStream in = IoIFP(io);
+        OutputStream out = IoOFP(io);
     CODE:
 	if (handle) {
 #ifdef PerlIO
-	    PerlIO_clearerr(handle);
+	    PerlIO_clearerr(in);
+            if (in != out)
+                PerlIO_clearerr(out);
 #else
-	    clearerr(handle);
+	    clearerr(in);
+            if (in != out)
+                clearerr(out);
 #endif
 	    RETVAL = 0;
 	}

--- a/dist/IO/IO.xs
+++ b/dist/IO/IO.xs
@@ -389,13 +389,17 @@ ungetc(handle, c)
 
 int
 ferror(handle)
-	InputStream	handle
+	SV *	handle
+    PREINIT:
+        IO *io = sv_2io(handle);
+        InputStream in = IoIFP(io);
+        OutputStream out = IoOFP(io);
     CODE:
-	if (handle)
+	if (in)
 #ifdef PerlIO
-	    RETVAL = PerlIO_error(handle);
+	    RETVAL = PerlIO_error(in) || (in != out && PerlIO_error(out));
 #else
-	    RETVAL = ferror(handle);
+	    RETVAL = ferror(in) || (in != out && ferror(out));
 #endif
 	else {
 	    RETVAL = -1;

--- a/dist/IO/t/io_xs.t
+++ b/dist/IO/t/io_xs.t
@@ -11,7 +11,7 @@ BEGIN {
     }
 }
 
-use Test::More tests => 7;
+use Test::More tests => 8;
 use IO::File;
 use IO::Seekable;
 
@@ -58,12 +58,14 @@ SKIP: {
     # This isn't really a Linux/BSD specific test, but /dev/full is (I
     # hope) reasonably well defined on these.  Patches welcome if your platform
     # also supports it (or something like it)
-    skip "no /dev/full or not a /dev/full platform", 2
+    skip "no /dev/full or not a /dev/full platform", 3
       unless $^O =~ /^(linux|netbsd|freebsd)$/ && -c "/dev/full";
     open my $fh, ">", "/dev/full"
-      or skip "Could not open /dev/full: $!", 2;
+      or skip "Could not open /dev/full: $!", 3;
     $fh->print("a" x 1024);
     ok(!$fh->flush, "should fail to flush");
     ok($fh->error, "stream should be in error");
+    $fh->clearerr;
+    ok(!$fh->error, "check clearerr removed the error");
     close $fh; # silently ignore the error
 }

--- a/dist/IO/t/io_xs.t
+++ b/dist/IO/t/io_xs.t
@@ -11,7 +11,7 @@ BEGIN {
     }
 }
 
-use Test::More tests => 5;
+use Test::More tests => 7;
 use IO::File;
 use IO::Seekable;
 
@@ -49,4 +49,21 @@ SKIP:
        or skip "Cannot open t/io_xs.t read-only: $!", 1;
     ok($fh->sync, "sync to a read only handle")
 	or diag "sync(): ", $!;
+}
+
+
+SKIP: {
+    # gh 6799
+    #
+    # This isn't really a Linux/BSD specific test, but /dev/full is (I
+    # hope) reasonably well defined on these.  Patches welcome if your platform
+    # also supports it (or something like it)
+    skip "no /dev/full or not a /dev/full platform", 2
+      unless $^O =~ /^(linux|netbsd|freebsd)$/ && -c "/dev/full";
+    open my $fh, ">", "/dev/full"
+      or skip "Could not open /dev/full: $!", 2;
+    $fh->print("a" x 1024);
+    ok(!$fh->flush, "should fail to flush");
+    ok($fh->error, "stream should be in error");
+    close $fh; # silently ignore the error
 }


### PR DESCRIPTION
The perl IO SV has slots for an input PerlIO object and an output PerlIO object.

For normal files this is always the same PerlIO object, but for character devices and sockets a second PerlIO object is created for the same fd and stored in the output slot, this allows input and output to be buffered separately.

The IO::Handle::error() method however only checks the input handle, so if there's an error writing to a socket or character device that isn't reflected in the result of calling error() on the handle.

Similarly IO::Handle::clearerr() only clears the error/eof state on the input handle, but for character devices and sockets this meant only half the error state was reset.

This PR adjusts those methods to work on both the input and output streams if they're different.