### PR TITLE
Always expose the perl_tsa_mutex_* functions in the API

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1257,6 +1257,7 @@ Tom Hughes                     <tom@compton.nu>
 Tom Hukins                     <tom@eborcom.com>
 Tom Phoenix                    <rootbeer@teleport.com>
 Tom Spindler                   <dogcow@isi.net>
+Tom Stellard                   <tstellar@redhat.com>
 Tom Wyant                      <wyant@cpan.org>
 Tomasz Konojacki               <me@xenu.pl>
 Tomoyuki Sadahiro              <BQW10602@nifty.com>

--- a/util.c
+++ b/util.c
@@ -6552,7 +6552,7 @@ Perl_dump_c_backtrace(pTHX_ PerlIO* fp, int depth, int skip)
 
 #endif /* #ifdef USE_C_BACKTRACE */
 
-#ifdef PERL_TSA_ACTIVE
+#if defined(USE_ITHREADS) && defined(I_PTHREAD)
 
 /* pthread_mutex_t and perl_mutex are typedef equivalent
  * so casting the pointers is fine. */
@@ -6573,7 +6573,6 @@ int perl_tsa_mutex_destroy(perl_mutex* mutex)
 }
 
 #endif
-
 
 #ifdef USE_DTRACE
 


### PR DESCRIPTION
These functions were only part of the API if perl is built with clang.
However perl modules built with clang still try to use them even
when perl itself is built with gcc.  This patch removes the #ifdef PERL_TSA_ACTIVE
around these functions so they are always available and fixes the build of
perl modules with clang when perl is built with gcc.