### PR TITLE
Sync Configure with metaconfig

### DIFF
--- a/Configure
+++ b/Configure
@@ -28,7 +28,7 @@
 # Porting/pumpkin.pod.
 
 # Generated using [metaconfig 3.5 PL0]
-# (with additional metaconfig patches by perlbug@perl.org)
+# (with additional metaconfig patches by https://github.com/Perl/perl5/issues)
 
 cat >c1$$ <<EOF
 ARGGGHHHH!!!!!


### PR DESCRIPTION
This brings Configure in line with
<https://github.com/Perl/metaconfig/tree/maint-5.30>