### PR TITLE
Metaconfig tidiness

### DIFF
--- a/config_h.SH
+++ b/config_h.SH
@@ -1491,6 +1491,10 @@ sed <<!GROK!THIS! >$CONFIG_H -e 's!^#undef\(.*/\)\*!/\*#define\1 \*!' -e 's!^#un
 /* HASATTRIBUTE_WARN_UNUSED_RESULT:
  *	Can we handle GCC attribute for warning on unused results
  */
+/* HASATTRIBUTE_ALWAYS_INLINE:
+ *	Can we handle GCC attribute for functions that should always be
+ *	inlined.
+ */
 #$d_attribute_deprecated HASATTRIBUTE_DEPRECATED	/**/
 #$d_attribute_format HASATTRIBUTE_FORMAT	/**/
 #$d_printf_format_null PRINTF_FORMAT_NULL_OK	/**/

--- a/config_h.SH
+++ b/config_h.SH
@@ -5,13 +5,6 @@
 #
 # See Porting/config_h.pl
 
-#!/bin/sh
-#
-# THIS IS A GENERATED FILE
-# DO NOT HAND-EDIT
-#
-# See Porting/config_h.pl
-
 : Set up for generating config_h.SH
 case "$CONFIG_SH" in
 '') CONFIG_SH=config.sh;;
@@ -35,9 +28,6 @@ esac
 case "$0" in
 */*) cd `expr X$0 : 'X\(.*\)/'` ;;
 esac
-case "$CONFIG_H" in
-already-done) echo "Not re-extracting config.h" ;;
-*)
 case "$CONFIG_H" in
 already-done) echo "Not re-extracting config.h" ;;
 *)
@@ -5300,7 +5290,5 @@ sed <<!GROK!THIS! >$CONFIG_H -e 's!^#undef\(.*/\)\*!/\*#define\1 \*!' -e 's!^#un
 
 #endif
 !GROK!THIS!
-;;
-esac
 ;;
 esac

--- a/uconfig.h
+++ b/uconfig.h
@@ -5256,6 +5256,6 @@
 #endif
 
 /* Generated from:
- * 15acb59ff9e808ff9fbebc95510c0bed8b1de705034bf4b22482bfa431da15b6 config_h.SH
+ * cc910600600e832a5ad4789896a093ec8e001c4dec9ee3c7d7a3e6ba880651c7 config_h.SH
  * e598046e9da73796e21226371ce26e8f2144852e0f5da7f00e52e1dbe1eaeaa6 uconfig.sh
  * ex: set ro: */

--- a/uconfig.h
+++ b/uconfig.h
@@ -1456,6 +1456,10 @@
 /* HASATTRIBUTE_WARN_UNUSED_RESULT:
  *	Can we handle GCC attribute for warning on unused results
  */
+/* HASATTRIBUTE_ALWAYS_INLINE:
+ *	Can we handle GCC attribute for functions that should always be
+ *	inlined.
+ */
 /*#define HASATTRIBUTE_DEPRECATED	/ **/
 /*#define HASATTRIBUTE_FORMAT	/ **/
 /*#define PRINTF_FORMAT_NULL_OK	/ **/
@@ -5256,6 +5260,6 @@
 #endif
 
 /* Generated from:
- * cc910600600e832a5ad4789896a093ec8e001c4dec9ee3c7d7a3e6ba880651c7 config_h.SH
+ * 14796a77fb4ae3335f5e589a98445bc6e838b688194f6f112537495f0814f5d5 config_h.SH
  * e598046e9da73796e21226371ce26e8f2144852e0f5da7f00e52e1dbe1eaeaa6 uconfig.sh
  * ex: set ro: */


### PR DESCRIPTION
While testing regeneration of Configure and friends with 5.3.11 I noticed a couple of quirks in config_h.SH. Here are targeted fixes, but re-generating from current metaconfig would also do of course.