### PR TITLE
corelist - print a better error message if unknown versions are passed to corelist --diff

### DIFF
--- a/dist/Module-CoreList/corelist
+++ b/dist/Module-CoreList/corelist
@@ -224,7 +224,15 @@ if ($Opts{diff}) {
     my ($old_ver, $new_ver) = @ARGV;
 
     my $old = numify_version($old_ver);
+    if ( !Module::CoreList->find_version($old) ) {
+        print "\nModule::CoreList has no info on perl $old_ver\n\n";
+        exit 1;
+    }
     my $new = numify_version($new_ver);
+    if ( !Module::CoreList->find_version($new) ) {
+        print "\nModule::CoreList has no info on perl $new_ver\n\n";
+        exit 1;
+    }
 
     my %diff = Module::CoreList::changes_between($old, $new);
 

--- a/dist/Module-CoreList/lib/Module/CoreList.pm
+++ b/dist/Module-CoreList/lib/Module/CoreList.pm
@@ -134,8 +134,8 @@ sub changes_between {
   my $left_ver = shift;
   my $right_ver = shift;
 
-  my $left  = $version{ $left_ver };
-  my $right = $version{ $right_ver };
+  my $left  = $version{ $left_ver } || {};
+  my $right = $version{ $right_ver } || {};
 
   my %uniq = (%$left, %$right);
 


### PR DESCRIPTION
Resolves #17792

None of the Module::CoreList functions throw exceptions so for the changes_between function, I just changed it to treat unknown versions as versions that contain no modules.

changes_between and the --diff option do not appear to currently be tested.