### PR TITLE
Cleanup perldeprecation

### DIFF
--- a/ext/File-Glob/Glob.pm
+++ b/ext/File-Glob/Glob.pm
@@ -35,7 +35,7 @@ $EXPORT_TAGS{bsd_glob} = [@{$EXPORT_TAGS{glob}}];
 
 @EXPORT_OK   = (@{$EXPORT_TAGS{'glob'}}, 'csh_glob');
 
-$VERSION = '1.32';
+$VERSION = '1.33';
 
 sub import {
     require Exporter;

--- a/ext/File-Glob/Glob.pm
+++ b/ext/File-Glob/Glob.pm
@@ -70,13 +70,6 @@ if ($^O =~ /^(?:MSWin32|VMS|os2|dos|riscos)$/) {
     $DEFAULT_FLAGS |= GLOB_NOCASE();
 }
 
-# File::Glob::glob() removed in perl-5.30 because its prototype is different
-# from CORE::glob() (use bsd_glob() instead)
-sub glob {
-    die "File::Glob::glob() was removed in perl 5.30. " .
-         "Use File::Glob::bsd_glob() instead. $!";
-}
-
 1;
 __END__
 

--- a/ext/File-Glob/t/basic.t
+++ b/ext/File-Glob/t/basic.t
@@ -44,14 +44,13 @@ if (opendir(D, ".")) {
    @correct = grep { !/^\./ } sort readdir(D);
    closedir D;
 }
-{
-    local $@;
-    my $expect =
-        qr/File::Glob::glob\(\) was removed in perl 5\.30\. Use File::Glob::bsd_glob\(\) instead/;
-    eval { File::Glob::glob("*", 0); };
-    like $@, $expect,
-        "Got expected error message for removal of File::Glob::glob()";
-}
+
+is(
+    File::Glob->can('glob'),
+    undef,
+    'Did not find glob() function in File::Glob',
+);
+
 chdir '..' or die "chdir .. $!";
 
 # look up the user's home directory

--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -242,7 +242,7 @@ See L<perlfunc/dump>.
 There has been a long-standing bug in Perl that causes a lexical variable
 not to be cleared at scope exit when its declaration includes a false
 conditional.  Some people have exploited this bug to achieve a kind of
-static variable.  Since we intend to fix this bug, we don't want people
+static variable.  To allow us to fix this bug, people should not be
 relying on this behavior.
 
 Instead, it's recommended one uses C<state> variables to achieve the
@@ -256,7 +256,7 @@ same effect:
 C<state> variables were introduced in Perl 5.10.
 
 Alternatively, you can achieve a similar static effect by
-declaring the variable in a separate block outside the function, eg
+declaring the variable in a separate block outside the function, e.g.,
 
     sub f { my $x if 0; return $x++ }
 
@@ -265,7 +265,7 @@ becomes
     { my $x; sub f { return $x++ } }
 
 The use of C<my()> in a false conditional has been deprecated in
-Perl 5.10, and it will become a fatal error in Perl 5.30.
+Perl 5.10, and became a fatal error in Perl 5.30.
 
 
 =head3 Reading/writing bytes from/to :utf8 handles.

--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -165,6 +165,18 @@ L<perlapi/Character classification>.
 This change was originally scheduled for 5.30, but was delayed until
 5.32.
 
+=head3 C<< File::Glob::glob() >> was removed
+
+C<< File::Glob >> has a function called C<< glob >>, which just calls
+C<< bsd_glob >>.
+
+C<< File::Glob::glob() >> was deprecated in Perl 5.8. A deprecation
+message was issued from Perl 5.26 onwards, and the function has now
+disappeared in Perl 5.30.
+
+Code using C<< File::Glob::glob() >> should call
+C<< File::Glob::bsd_glob() >> instead.
+
 =head2 Perl 5.30
 
 =head3 C<< $* >> is no longer supported


### PR DESCRIPTION
This fixed the following to resolve #17757:

* Correct language on deprecation of `my()` in false conditional
* Remove `File::Glob::glob()`
* Correct language on removal of `File::Glob::glob()`