### PR TITLE
Add dualvar-creating newSVpviv and friends

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4498,6 +4498,7 @@ ext/XS-APItest/t/my_cxt.t	XS::APItest: test MY_CXT interface
 ext/XS-APItest/t/my_exit.t	XS::APItest: test my_exit
 ext/XS-APItest/t/newCONSTSUB.t	XS::APItest: test newCONSTSUB(_flags)
 ext/XS-APItest/t/newDEFSVOP.t	XS::APItest: test newDEFSVOP
+ext/XS-APItest/t/newSVpviv.t	XS::APItest: test newSVpviv and similar
 ext/XS-APItest/t/Null.pm	Helper for ./blockhooks.t
 ext/XS-APItest/t/op.t		XS::APItest: tests for OP related APIs
 ext/XS-APItest/t/op_contextualize.t	test op_contextualize() API

--- a/embed.fnc
+++ b/embed.fnc
@@ -1378,6 +1378,8 @@ ApdR	|OP*	|newSVOP	|I32 type|I32 flags|NN SV* sv
 ApdR	|OP*	|newDEFSVOP
 pR	|SV*	|newSVavdefelem	|NN AV *av|SSize_t ix|bool extendible
 ApdR	|SV*	|newSViv	|const IV i
+ApdR	|SV*	|newSVpviv	|NULLOK const char *const s|const IV i
+ApdR	|SV*	|newSVpvniv	|NULLOK const char *const s|const STRLEN len|const IV i
 ApdR	|SV*	|newSVuv	|const UV u
 ApdR	|SV*	|newSVnv	|const NV n
 ApdR	|SV*	|newSVpv	|NULLOK const char *const s|const STRLEN len

--- a/embed.h
+++ b/embed.h
@@ -380,9 +380,11 @@
 #ifndef PERL_IMPLICIT_CONTEXT
 #define newSVpvf		Perl_newSVpvf
 #endif
+#define newSVpviv(a,b)		Perl_newSVpviv(aTHX_ a,b)
 #define newSVpvn(a,b)		Perl_newSVpvn(aTHX_ a,b)
 #define newSVpvn_flags(a,b,c)	Perl_newSVpvn_flags(aTHX_ a,b,c)
 #define newSVpvn_share(a,b,c)	Perl_newSVpvn_share(aTHX_ a,b,c)
+#define newSVpvniv(a,b,c)	Perl_newSVpvniv(aTHX_ a,b,c)
 #define newSVrv(a,b)		Perl_newSVrv(aTHX_ a,b)
 #define newSVsv_flags(a,b)	Perl_newSVsv_flags(aTHX_ a,b)
 #define newSVuv(a)		Perl_newSVuv(aTHX_ a)

--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.09';
+our $VERSION = '1.10';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -2651,6 +2651,25 @@ newCONSTSUB(stash, name, flags, sv)
         PUSHs( CvCONST(mycv) ? &PL_sv_yes : &PL_sv_no );
         PUSHs((SV*)CvGV(mycv));
 
+SV *
+newSVpviv(s, i)
+    const char *s
+    int i
+    CODE:
+        RETVAL = newSVpviv(s, i);
+    OUTPUT:
+        RETVAL
+
+SV *
+newSVpvniv(s, len, i)
+    const char *s
+    STRLEN len
+    int i
+    CODE:
+        RETVAL = newSVpvniv(s, len, i);
+    OUTPUT:
+        RETVAL
+
 void
 gv_init_type(namesv, multi, flags, type)
     SV* namesv

--- a/ext/XS-APItest/t/newSVpviv.t
+++ b/ext/XS-APItest/t/newSVpviv.t
@@ -1,0 +1,21 @@
+#!perl
+
+use strict;
+use warnings;
+use Test::More tests => 5;
+
+use XS::APItest;
+
+{
+   my $sv = newSVpviv("one-two-three", 456);
+   ok($sv eq "one-two-three", '$sv stringily from newSVpviv');
+   ok($sv == 456,             '$sv numerically from newSVpviv');
+}
+
+{
+   my $sv = newSVpvniv("seven\0eight", 11, 90);
+   ok($sv eq "seven\0eight", '$sv stringily from newSVpvniv');
+   ok($sv == 90,             '$sv numerically from newSVpvniv');
+}
+
+ok(newSVpviv("string", -25) == -25, 'newSVpviv* can make negative numbers');

--- a/handy.h
+++ b/handy.h
@@ -305,6 +305,10 @@ a string/length pair.
 Like C<newSVpvn_share>, but takes a literal string instead of
 a string/length pair and omits the hash parameter.
 
+=for apidoc Ama|SV*|newSVpvsiv|"literal string"|IV i
+Like C<newSVpvniv>, but takes a literal string instead of
+a string/length pair.
+
 =for apidoc Am|void|sv_catpvs_flags|SV* sv|"literal string"|I32 flags
 Like C<sv_catpvn_flags>, but takes a literal string instead
 of a string/length pair.
@@ -394,6 +398,8 @@ Perl_xxx(aTHX_ ...) form for any API calls where it's used.
 #define newSVpvs_share(str) Perl_newSVpvn_share(aTHX_ STR_WITH_LEN(str), 0)
 #define sv_catpvs_flags(sv, str, flags) \
     Perl_sv_catpvn_flags(aTHX_ sv, STR_WITH_LEN(str), flags)
+#define newSVpvsiv(str,i) \
+    Perl_newSVpvniv(aTHX_ STR_WITH_LEN(str), i)
 #define sv_catpvs_nomg(sv, str) \
     Perl_sv_catpvn_flags(aTHX_ sv, STR_WITH_LEN(str), 0)
 #define sv_catpvs(sv, str) \

--- a/proto.h
+++ b/proto.h
@@ -2426,6 +2426,10 @@ PERL_CALLCONV SV*	Perl_newSVpvf(pTHX_ const char *const pat, ...)
 #define PERL_ARGS_ASSERT_NEWSVPVF	\
 	assert(pat)
 
+PERL_CALLCONV SV*	Perl_newSVpviv(pTHX_ const char *const s, const IV i)
+			__attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_NEWSVPVIV
+
 PERL_CALLCONV SV*	Perl_newSVpvn(pTHX_ const char *const buffer, const STRLEN len)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVPVN
@@ -2437,6 +2441,10 @@ PERL_CALLCONV SV*	Perl_newSVpvn_flags(pTHX_ const char *const s, const STRLEN le
 PERL_CALLCONV SV*	Perl_newSVpvn_share(pTHX_ const char* s, I32 len, U32 hash)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVPVN_SHARE
+
+PERL_CALLCONV SV*	Perl_newSVpvniv(pTHX_ const char *const s, const STRLEN len, const IV i)
+			__attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_NEWSVPVNIV
 
 PERL_CALLCONV SV*	Perl_newSVrv(pTHX_ SV *const rv, const char *const classname);
 #define PERL_ARGS_ASSERT_NEWSVRV	\

--- a/sv.c
+++ b/sv.c
@@ -9689,6 +9689,56 @@ Perl_newSViv(pTHX_ const IV i)
 }
 
 /*
+=for apidoc newSVpviv
+
+Creates a new dualvar SV and copies both a NUL-terminated string and a signed
+integer into it.
+The reference count for the new SV is set to 1.
+
+=cut
+*/
+
+SV *
+Perl_newSVpviv(pTHX_ const char *const s, const IV i)
+{
+    SV *sv;
+    if(!s) return newSViv(i);
+
+    sv = newSVpv(s, 0);
+
+    SvUPGRADE(sv, SVt_PVIV);
+    SvIV_set(sv, i);
+    SvIOK_on(sv);
+
+    return sv;
+}
+
+/*
+=for apidoc newSVpvniv
+
+Creates a new dualvar SV and copies both a string and a signed integer into
+it. The string may contain C<NUL> characters or other binary data.
+The reference count for the new SV is set to 1.
+
+=cut
+*/
+
+SV *
+Perl_newSVpvniv(pTHX_ const char *const s, const STRLEN len, const IV i)
+{
+    SV *sv = newSViv(i);
+    if(!sv) return newSViv(i);
+
+    sv = newSVpvn(s, len);
+
+    SvUPGRADE(sv, SVt_PVIV);
+    SvIV_set(sv, i);
+    SvIOK_on(sv);
+
+    return sv;
+}
+
+/*
 =for apidoc newSVuv
 
 Creates a new SV and copies an unsigned integer into it.


### PR DESCRIPTION
These two new functions and one macro create PV-and-IV dualvars, in similar style to the other `newSV*()` family.

They are most convenient for wrapping error values from external libraries, to create dual number/string values in a similar style to core's `$!` wrapping of `errno`.

For example:

    int err = uv_...();
    if(err != 0) return newSVpviv(uv_strerr(err), err);

This makes the usual style of error-type dualvar that can both be tested for numerical equality and additionally used as a string to yield its human-readable error message

    croak "Unable to complete: $err" unless $err == UV::UV_EAGAIN;

(this PR is a continuation of https://github.com/Perl/perl5/pull/17807 which I shall now close)