### PR TITLE
Minor tweaks to perldelta.pod

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -57,13 +57,6 @@ that aren't part of the strict UCD (Unicode character database). These
 two are used for examining inputs for security purposes. Details on
 their usage is at L<https://www.unicode.org/reports/tr39/proposed.html>.
 
-=head2 It is now possible to write C<qr/\p{Name=...}/>, or C<\p{Na=...}>
-
-The Unicode Name property is now accessible in regular expression
-patterns using the above syntaxes, as an alternative to C<\N{...}>.
-A comparison of the two methods is given in
-L<perlunicode/Comparison of \N{...} and \p{name=...}>.
-
 =head2 The C<POSIX::mblen()>, C<mbtowc>, and C<wctomb> functions now
 work on shift state locales and are thread-safe on C99 and above
 compilers when executed on a platform that has locale thread-safety; the
@@ -111,7 +104,7 @@ changes needed. Enabling the category has no effect.
 =head2 Feature checks are now faster
 
 Previously feature checks in the parser required a hash lookup when
-features we set outside of a feature bundle, this has been optimized
+features were set outside of a feature bundle, this has been optimized
 to a bit mask check. [L<GH #17229|https://github.com/Perl/perl5/issues/17229>]
 
 =head2 Perl is now developed on GitHub
@@ -1137,6 +1130,21 @@ covered by the earlier wording.
 
 =back
 
+=head2 L<streamzip>
+
+=over 4
+
+=item *
+
+This is a new utility, included as part of an
+L<IO::Compress::Base> upgrade.
+
+L<streamzip> creates a zip file from stdin. The program will read data
+from stdin, compress it into a zip container and, by default, write a
+streamed zip file to stdout.
+
+=back
+
 =head1 Configuration and Compilation
 
 =head2 F<Configure>
@@ -1167,21 +1175,6 @@ Check if the compiler can handle inline attribute.
 =item *
 
 Check for character data alignment.
-
-=back
-
-=head2 L<streamzip>
-
-=over 4
-
-=item *
-
-This is a new utility, included as part of an
-L<IO::Compress::Base> upgrade.
-
-L<streamzip> creates a zip file from stdin. The program will read data
-from stdin, compress it into a zip container and, by default, write a
-streamed zip file to stdout.
 
 =item *
 


### PR DESCRIPTION
Remove duplicate entry of "It is now possible to write C<qr/\p{Name=...}/>, or C<\p{Na=...}>"
Fix probable typo in "features *we* set outside of a feature bundle"
Move streamzip entry from "Configure and Compilation" to "Utility Changes"