### PR TITLE
Update "Module removals" section of perldelta.pod

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -228,25 +228,13 @@ could define what the desired behaviour should be.
 
 =head2 Module removals
 
-The following modules will be removed from the core distribution in a
-future release, and will at that time need to be installed from CPAN.
-Distributions on CPAN which require these modules will need to list them as
-prerequisites.
+No modules currently included in the core distribution are expected to be 
+removed within the next release cycle. 
 
-The core versions of these modules will now issue C<"deprecated">-category
-warnings to alert you to this fact. To silence these deprecation warnings,
-install the modules in question from CPAN.
+No changes to the list of modules issuing C<"deprecated">-category warnings 
+have been made in this release cycle.
 
-Note that these are (with rare exceptions) fine modules that you are encouraged
-to continue to use. Their disinclusion from core primarily hinges on their
-necessity to bootstrapping a fully functional, CPAN-capable Perl installation,
-not usually on concerns over their design.
-
-=over
-
-=item B::Debug
-
-C<B::Debug> is no longer shipped with Perl. You can still install it from CPAN.
+No modules have been removed from the core distribution in this release cycle.
 
 =back
 


### PR DESCRIPTION
B::Debug was removed in v5.30, according to that release's perldelta and https://github.com/Perl/perl5/commits/903b1101f7c2c55545e6cfd3eb5dfd564e1befd2

Warning: I've improvised the replacement text and have not yet had time to check if it's accurate.