### PR TITLE
report the index for not found hash/array index lookups in report_uninit()

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -16809,6 +16809,34 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
 		    return varname(agg_gv, '@', agg_targ,
 					NULL, index, FUV_SUBSCRIPT_ARRAY);
 	    }
+            /* look for an element not found */
+            if (!SvMAGICAL(sv)) {
+                SV *index_sv = NULL;
+                if (index_targ) {
+                    index_sv = PL_curpad[index_targ];
+                }
+                else if (index_gv) {
+                    index_sv = GvSV(index_gv);
+                }
+                if (index_sv && !SvMAGICAL(index_sv) && !SvROK(index_sv)) {
+                    if (is_hv) {
+                        HE *he = hv_fetch_ent(MUTABLE_HV(sv), index_sv, 0, 0);
+                        if (!he) {
+                            return varname(agg_gv, '%', agg_targ,
+                                           index_sv, 0, FUV_SUBSCRIPT_HASH);
+                        }
+                    }
+                    else {
+                        SSize_t index = SvIV(index_sv);
+                        SV * const * const svp =
+                            av_fetch(MUTABLE_AV(sv), index, FALSE);
+                        if (!svp) {
+                            return varname(agg_gv, '@', agg_targ,
+                                           NULL, index, FUV_SUBSCRIPT_ARRAY);
+                        }
+                    }
+                }
+            }
 	    if (match)
 		break;
 	    return varname(agg_gv,

--- a/t/lib/warnings/sv
+++ b/t/lib/warnings/sv
@@ -108,7 +108,7 @@ no warnings 'uninitialized' ;
 my $Y = 1 ; 
 $x = 1 | $b[$Y] ;
 EXPECT
-Use of uninitialized value within @a in bitwise or (|) at - line 4.
+Use of uninitialized value $a[1] in bitwise or (|) at - line 4.
 ########
 # sv.c
 use warnings 'uninitialized' ;
@@ -118,7 +118,7 @@ no warnings 'uninitialized' ;
 my $Y = 1 ; 
 $x = 1 & $b[$Y] ;
 EXPECT
-Use of uninitialized value within @a in bitwise and (&) at - line 4.
+Use of uninitialized value $a[1] in bitwise and (&) at - line 4.
 ########
 # sv.c
 use warnings 'uninitialized' ;
@@ -128,7 +128,7 @@ no warnings 'uninitialized' ;
 my $Y = 1 ; 
 $x = ~$b[$Y] ;
 EXPECT
-Use of uninitialized value within @a in 1's complement (~) at - line 4.
+Use of uninitialized value $a[1] in 1's complement (~) at - line 4.
 ########
 # sv.c
 use warnings 'uninitialized' ;


### PR DESCRIPTION
fixes #17818 (partly, anyway)

where the index is a non-magical, non-reference variable.

This only works where the op is converted to OP_MULTIDEREF, but that
should be happening for the simple cases this handles.

An alternative would be to report the index variable name rather than
the index, but that seems less useful to me.