### PR TITLE
Smoke me/khw ebcdic

### DIFF
--- a/ext/XS-APItest/t/utf16_to_utf8.t
+++ b/ext/XS-APItest/t/utf16_to_utf8.t
@@ -4,6 +4,8 @@ use strict;
 use Test::More;
 use Encode;
 
+plan skip_all => 'Unclear how EBCIDC should behave' if ord "A" != 65;
+
 use XS::APItest qw(utf16_to_utf8 utf16_to_utf8_reversed);
 
 for my $ord (0, 10, 13, 78, 255, 256, 0xD7FF, 0xE000, 0xFFFD,


### PR DESCRIPTION
These two commit are for EBCDIC; skipping one test entirely on that platform, and fixing another .t to actually do what it purports to do on EBCDIC.

These did not show up before, because they require a dynamic build to run which we had not successfully done.