### PR TITLE
(perl #17844) don't update SvCUR until after we've done moving

### DIFF
--- a/doop.c
+++ b/doop.c
@@ -1090,7 +1090,6 @@ Perl_do_vop(pTHX_ I32 optype, SV *sv, SV *left, SV *right)
     lsave = lc;
     rsave = rc;
 
-    SvCUR_set(sv, len);
     (void)SvPOK_only(sv);
     if (SvOK(sv) || SvTYPE(sv) > SVt_PVMG) {
 	dc = SvPV_force_nomg_nolen(sv);
@@ -1106,6 +1105,7 @@ Perl_do_vop(pTHX_ I32 optype, SV *sv, SV *left, SV *right)
 	sv_usepvn_flags(sv, dc, needlen, SV_HAS_TRAILING_NUL);
 	dc = SvPVX(sv);		/* sv_usepvn() calls Renew() */
     }
+    SvCUR_set(sv, len);
 
     if (len >= sizeof(long)*4 &&
 	!(PTR2nat(dc) % sizeof(long)) &&

--- a/t/op/bop.t
+++ b/t/op/bop.t
@@ -18,7 +18,7 @@ BEGIN {
 # If you find tests are failing, please try adding names to tests to track
 # down where the failure is, and supply your new names as a patch.
 # (Just-in-time test naming)
-plan tests => 501;
+plan tests => 502;
 
 # numerics
 ok ((0xdead & 0xbeef) == 0x9ead);
@@ -668,4 +668,13 @@ foreach my $op_info ([and => "&"], [or => "|"], [xor => "^"]) {
         eval $h->{string};
         like $@, $expected, $description;
     }
+}
+
+{
+    # perl #17844 - only visible with valgrind/ASAN
+    fresh_perl_is(<<'EOS',
+formline X000n^\\0,\\0^\\0for\0,0..10
+EOS
+                  '',
+                  {}, "[perl #17844] access beyond end of block");
 }


### PR DESCRIPTION
`SvCUR()` before the `SvGROW()` calls could result in reading beyond the
end of a buffer.

It wasn't a problem in the normal case, since `sv_grow()` just calls
`realloc()` which has its own notion of how big the memory block is, but
if the SV is `SvOOK()`, `sv_backoff()` tries to move `SvCUR()+1` bytes, which
might be larger than the currently allocated size of the PV.

Note: Tony's original patch did not apply cleanly, but the changes required to correct this were trivial. I also altered the commit message and comments to use the new issue number.