### PR TITLE
Correct my_rpeep example in perlguts

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -537,6 +537,7 @@ Ingo Weinhold                  <ingo_weinhold@gmx.de>
 Ingy döt Net                   <ingy@ttul.org>
 insecure                       <insecure@mail.od.ua>
 Irving Reid                    <irving@tor.securecomputing.com>
+Ivan Baidakou                  @basiliscos
 Ivan Kurmanov                  <kurmanov@openlib.org>
 Ivan Pozdeev                   <vano@mail.mipt.ru>
 Ivan Tubert-Brohman            <itub@cpan.org>

--- a/AUTHORS
+++ b/AUTHORS
@@ -537,7 +537,7 @@ Ingo Weinhold                  <ingo_weinhold@gmx.de>
 Ingy döt Net                   <ingy@ttul.org>
 insecure                       <insecure@mail.od.ua>
 Irving Reid                    <irving@tor.securecomputing.com>
-Ivan Baidakou                  @basiliscos
+Ivan Baidakou                  <the.dmol@yandex.by>
 Ivan Kurmanov                  <kurmanov@openlib.org>
 Ivan Pozdeev                   <vano@mail.mipt.ru>
 Ivan Tubert-Brohman            <itub@cpan.org>

--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.09';
+our $VERSION = '1.10';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -482,7 +482,8 @@ my_rpeep (pTHX_ OP *first)
     if (!MY_CXT.peep_recording)
 	return;
 
-    for (OP *o = first, *t = first; o; o = o->op_next, t = t->op_next) {
+    OP *o = first, *t = first;
+    for (; o = o->op_next, t = t->op_next) {
 	if (o->op_type == OP_CONST && cSVOPx_sv(o) && SvPOK(cSVOPx_sv(o))) {
 	    av_push(MY_CXT.rpeep_recorder, newSVsv(cSVOPx_sv(o)));
 	}

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -473,6 +473,7 @@ STATIC void
 my_rpeep (pTHX_ OP *first)
 {
     dMY_CXT;
+    OP *o, *t;
 
     if (!first)
 	return;
@@ -482,8 +483,7 @@ my_rpeep (pTHX_ OP *first)
     if (!MY_CXT.peep_recording)
 	return;
 
-    OP *o = first, *t = first;
-    for (; o = o->op_next, t = t->op_next) {
+    for (o = first, t = first; o; o = o->op_next, t = t->op_next) {
 	if (o->op_type == OP_CONST && cSVOPx_sv(o) && SvPOK(cSVOPx_sv(o))) {
 	    av_push(MY_CXT.rpeep_recorder, newSVsv(cSVOPx_sv(o)));
 	}

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -470,19 +470,24 @@ my_peep (pTHX_ OP *o)
 }
 
 STATIC void
-my_rpeep (pTHX_ OP *o)
+my_rpeep (pTHX_ OP *first)
 {
     dMY_CXT;
 
-    if (!o)
+    if (!first)
 	return;
 
-    MY_CXT.orig_rpeep(aTHX_ o);
+    MY_CXT.orig_rpeep(aTHX_ first);
 
     if (!MY_CXT.peep_recording)
 	return;
 
-    for (; o; o = o->op_next) {
+    for (OP *o = first, *t = first; o; o = o->op_next, t = t->op_next) {
+	if (o->op_type == OP_CONST && cSVOPx_sv(o) && SvPOK(cSVOPx_sv(o))) {
+	    av_push(MY_CXT.rpeep_recorder, newSVsv(cSVOPx_sv(o)));
+	}
+	o = o->op_next;
+	if (!o || o == t) break;
 	if (o->op_type == OP_CONST && cSVOPx_sv(o) && SvPOK(cSVOPx_sv(o))) {
 	    av_push(MY_CXT.rpeep_recorder, newSVsv(cSVOPx_sv(o)));
 	}

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -2195,11 +2195,14 @@ per-subroutine or recursive stage, like this:
         PL_peepp = my_peep;
 
     static peep_t prev_rpeepp;
-    static void my_rpeep(pTHX_ OP *o)
+    static void my_rpeep(pTHX_ OP *first)
     {
-        OP *orig_o = o;
-        for(; o; o = o->op_next) {
+        OP *o = first, *t = first;
+        for(; o = o->op_next, t = t->op_next) {
             /* custom per-op optimisation goes here */
+            o = o->op_next;
+            if (!o || o == t) break;
+            /* custom per-op optimisation goes AND here */
         }
         prev_rpeepp(aTHX_ orig_o);
     }


### PR DESCRIPTION
The example of my_rpeep in perlguts has an issue that
it might never stop iterating if there is a cycle in
OP tree. For example in the repository

https://github.com/basiliscos/p5-PeepholeTest

it hangs when starts executing test.pl

The right traversal was originally taken from

https://metacpan.org/source/ZEFRAM/Devel-GoFaster-0.001/lib/Devel/GoFaster.xs#L330
