### PR TITLE
Fix haiku beta 2 build

### DIFF
--- a/Configure
+++ b/Configure
@@ -5508,6 +5508,7 @@ default|recommended)
 	# thing. (NWC)
 	case "$osname" in
 	amigaos) ;; # -fstack-protector builds but doesn't work
+	haiku) ;;   #
 	*)	case "$gccversion" in
 		?*)	set stack-protector-strong -fstack-protector-strong
 			eval $checkccflag

--- a/ext/Errno/Errno_pm.PL
+++ b/ext/Errno/Errno_pm.PL
@@ -143,7 +143,7 @@ sub get_files {
 	$file{$linux_errno_h} = 1;
     } elsif ($^O eq 'haiku') {
 	# hidden in a special place
-	$file{'/boot/develop/headers/posix/errno.h'} = 1;
+	$file{'/boot/system/develop/headers/posix/errno.h'} = 1;
 
     } elsif ($^O eq 'vos') {
 	# avoid problem where cpp returns non-POSIX pathnames

--- a/hints/haiku.sh
+++ b/hints/haiku.sh
@@ -8,7 +8,7 @@ esac
 
 libpth='/boot/home/config/lib /boot/common/lib /system/lib'
 usrinc='/boot/system/develop/headers/posix'
-locinc='/boot/home/config/include /boot/common/include /boot/develop/headers'
+locinc='/boot/home/config/include /boot/common/include /boot/system/develop/headers'
 
 libc='/system/lib/libroot.so'
 libs='-lnetwork'

--- a/hints/haiku.sh
+++ b/hints/haiku.sh
@@ -7,7 +7,7 @@ case "$prefix" in
 esac
 
 libpth='/boot/home/config/lib /boot/common/lib /system/lib'
-usrinc='/boot/develop/headers/posix'
+usrinc='/boot/system/develop/headers/posix'
 locinc='/boot/home/config/include /boot/common/include /boot/develop/headers'
 
 libc='/system/lib/libroot.so'


### PR DESCRIPTION
Hello,

This is a simple fix to get a build OK on Haiku beta.

It was tested on a very recent Haiku beta 2 with : 

1. `./Configure -de`
2. `make`
3. ```export set LIBRARY_PATH=`pwd`:$LIBRARY_PATH```
4. `./perl -Ilib -V`

Seems like `/boot/develop` moved for `/boot/system/develop` between Haiku Alpha and Haiku Beta.

I made this fix copying a small portion of haiku ports then later I discovered the [Tom Bryant patch](https://www.nntp.perl.org/group/perl.perl5.porters/2019/03/msg253987.html). My fix for Errno is simpler and more limited (only support beta errno.h location, no support for alpha, not needed IMHO).
My stack-protector fix is the same.

I know that a perl porter asked to possibly move this second fix to `hints/haiku.sh` but it's seems not easy at all (I tried :grimacing:). It seems there is no variable to set/unset that enable/disable -fstack-protector-* family but it is added directly in variables ccflags/cppflags/ldflags/lddflags. And it seems very easy to add flags or libs thanks to hints mechanism but much harder to remove things :grimacing: 

I would be very happy if I'm wrong and any of you have a clear idea on how to fix it in a different manner.
If anyone can share an example from the past with the same kind of task on a hints file (I browsed a bit the recent commits in hints dir but haven't found anything relevant) it would be perfect !

But honestly, the current code change seems a small and reasonable fix that could maybe be merged as is :smiley: 

Please tell me what you think, I can rework this !

References :
- [Message + patch by Tom Bryant](https://www.nntp.perl.org/group/perl.perl5.porters/2019/03/msg253987.html) and [associated ticket](https://github.com/Perl/perl5/issues/16900)
- [haiku ports patch for 5.30.2](https://github.com/haikuports/haikuports/blob/master/dev-lang/perl/patches/perl-5.30.2.patchset) (contains much more changes)