### PR TITLE
Fix build on Haiku beta alternative

### DIFF
--- a/Configure
+++ b/Configure
@@ -5506,23 +5506,24 @@ default|recommended)
 	# is to add the flag to the flags passed to the compiler at link time,
 	# as that way the compiler can do the right implementation dependant
 	# thing. (NWC)
-	case "$osname" in
-	amigaos) ;; # -fstack-protector builds but doesn't work
-	*)	case "$gccversion" in
-		?*)	set stack-protector-strong -fstack-protector-strong
-			eval $checkccflag
-			case "$dflt" in
-			*-fstack-protector-strong*) ;; # It got added.
-			*) # Try the plain/older -fstack-protector.
-			   set stack-protector -fstack-protector
-			   eval $checkccflag
-			   ;;
-			esac
-			;;
+	case "$ccflags" in
+	*-fno-stack-protector*)
+	    echo "Do not add -fstack-protector nor -fstack-protector-strong" 2>&1
+	    ;;
+	*) case "$gccversion" in
+	   ?*)	set stack-protector-strong -fstack-protector-strong
+		eval $checkccflag
+		case "$dflt" in
+		*-fstack-protector-strong*) ;; # It got added.
+		*) # Try the plain/older -fstack-protector.
+		   set stack-protector -fstack-protector
+		   eval $checkccflag
+		   ;;
 		esac
 		;;
+	    esac
+	    ;;
 	esac
-	;;
 esac
 
 case "$mips_type" in

--- a/ext/Errno/Errno_pm.PL
+++ b/ext/Errno/Errno_pm.PL
@@ -140,7 +140,7 @@ sub get_files {
 	$file{$linux_errno_h} = 1;
     } elsif ($^O eq 'haiku') {
 	# hidden in a special place
-	$file{'/boot/develop/headers/posix/errno.h'} = 1;
+	$file{'/boot/system/develop/headers/posix/errno.h'} = 1;
 
     } elsif ($^O eq 'vos') {
 	# avoid problem where cpp returns non-POSIX pathnames

--- a/hints/amigaos.sh
+++ b/hints/amigaos.sh
@@ -6,3 +6,5 @@ for f in amigaos4/*.h amigaos4/*.c
 do
   cp -f $f .
 done
+
+ccflags="$ccflags -fno-stack-protector"

--- a/hints/haiku.sh
+++ b/hints/haiku.sh
@@ -6,7 +6,6 @@ case "$prefix" in
 *) ;; # pass the user supplied value through
 esac
 
-
 libpth="$(finddir B_USER_DEVELOP_DIRECTORY)/lib $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/lib $(finddir B_COMMON_DIRECTORY)/lib /system/lib"
 usrinc="$(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers/posix"
 locinc="$(finddir B_USER_CONFIG_DIRECTORY)/develop/headers $(finddir B_COMMON_DIRECTORY)/headers $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers"
@@ -31,6 +30,8 @@ d_syserrlst='undef'
 # Haiku uses gcc.
 cc="gcc"
 ld='gcc'
+
+ccflags="$ccflags -fno-stack-protector"
 
 # The runtime loader library path variable is LIBRARY_PATH.
 case "$ldlibpthname" in


### PR DESCRIPTION
Hello,

This is an alternative code change related to #17857 

The implementation is different, by adding `-fno-stack-protector` to `ccflags` in hint files (currently `amigaos.sh` and `haiku.sh` but if any other platform needs it, no `Configure` change will be required then) and it inhibits the add of `-fstack-protector*` family in `Configure` script.

It still contains Haiku fixes (errno fix and location changes).

Best regards.

Thibault