### PR TITLE
Haiku hints set lipth, locinc, usrinc and libc dynamically

### DIFF
--- a/hints/haiku.sh
+++ b/hints/haiku.sh
@@ -2,7 +2,7 @@
 # $Id$
 
 case "$prefix" in
-'') prefix="/boot/common" ;;
+'') prefix="$(finddir B_COMMON_DIRECTORY)" ;;
 *) ;; # pass the user supplied value through
 esac
 

--- a/hints/haiku.sh
+++ b/hints/haiku.sh
@@ -6,11 +6,12 @@ case "$prefix" in
 *) ;; # pass the user supplied value through
 esac
 
-libpth='/boot/home/config/lib /boot/common/lib /system/lib'
-usrinc='/boot/develop/headers/posix'
-locinc='/boot/home/config/include /boot/common/include /boot/develop/headers'
 
-libc='/system/lib/libroot.so'
+libpth="$(finddir B_USER_DEVELOP_DIRECTORY)/lib $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/lib $(finddir B_COMMON_DIRECTORY)/lib /system/lib"
+usrinc="$(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers/posix"
+locinc="$(finddir B_USER_CONFIG_DIRECTORY)/develop/headers $(finddir B_COMMON_DIRECTORY)/headers $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers"
+
+libc="$(finddir B_SYSTEM_LIB_DIRECTORY)/libroot.so"
 libs='-lnetwork'
 
 # Use Haiku's malloc() by default.


### PR DESCRIPTION
Hello,

This PR does not fix Haiku build but is intended to be an improvement. 
I separated from other Haiku related PR to make it easier to review and merge.

After reading Haiku docs, testing fresh new haiku beta 2 and discussing with Haiku folks, I noticed that some locations were no longer correct. 

This PR fixes the places (e.g. `/boot/system/develop` instead of `/boot/develop`, `develop/headers` instead of `include`), migrate to `finddir` (a tool to avoid hard-coding paths) and I align on what is done on haiku ports (plus I keep some extra locations like `/system/lib`).

I'm not 100% sure about which location to keep or remove (haiku ports has less items, is our list better or worse ?), but I think this PR is a good enough.

Tested with Haiku beta 2 (using fixes from other PR)

Regards.

Thibault