### PR TITLE
use absolute paths in ExtUtils::ParseXS tests on all platforms

### DIFF
--- a/dist/ExtUtils-ParseXS/t/001-basic.t
+++ b/dist/ExtUtils-ParseXS/t/001-basic.t
@@ -15,13 +15,14 @@ push @INC, '.';
 
 use Carp; $SIG{__WARN__} = \&Carp::cluck;
 
-# Some trickery for Android. If we leave @INC as-is, it'll have '.' in it.
-# Later on, the 'require XSTest' end up in DynaLoader looking for
-# ./PL_XSTest.so, but unless our current directory happens to be in
-# LD_LIBRARY_PATH, Android's linker will never find the file, and the test
-# will fail.  Instead, if we have all absolute paths, it'll just work.
-@INC = map { File::Spec->rel2abs($_) } @INC
-    if $^O =~ /android/;
+# The linker on some platforms doesn't like loading libraries using relative
+# paths. Android won't find relative paths, and system perl on macOS will
+# refuse to load relative paths. The path that DynaLoader uses to load the
+# .so or .bundle file is based on the @INC path that the library is loaded
+# from. The XSTest module we're using for testing is in the current directory,
+# so we need an absolute path in @INC rather than '.'. Just convert all of the
+# paths to absolute for simplicity.
+@INC = map { File::Spec->rel2abs($_) } @INC;
 
 #########################
 

--- a/dist/ExtUtils-ParseXS/t/002-more.t
+++ b/dist/ExtUtils-ParseXS/t/002-more.t
@@ -22,8 +22,7 @@ push @INC, '.';
 use Carp; $SIG{__WARN__} = \&Carp::cluck;
 
 # See the comments about this in 001-basics.t
-@INC = map { File::Spec->rel2abs($_) } @INC
-    if $^O =~ /android/;
+@INC = map { File::Spec->rel2abs($_) } @INC;
 
 #########################
 

--- a/dist/ExtUtils-ParseXS/t/003-usage.t
+++ b/dist/ExtUtils-ParseXS/t/003-usage.t
@@ -23,8 +23,7 @@ push @INC, '.';
 use Carp; $SIG{__WARN__} = \&Carp::cluck;
 
 # See the comments about this in 001-basics.t
-@INC = map { File::Spec->rel2abs($_) } @INC
-    if $^O =~ /android/;
+@INC = map { File::Spec->rel2abs($_) } @INC;
 
 #########################
 


### PR DESCRIPTION
System perl on macOS also doesn't like linking libraries using relative
paths. The tests for ExtUtils::ParseXS already converted to absolute
paths on android, but it doesn't hurt to do that on all platforms.

Remove the platform conditional, and update the comment.