### PR TITLE
Teach pipe() to accept an optional FLAGS argument

### DIFF
--- a/doio.c
+++ b/doio.c
@@ -296,7 +296,7 @@ Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd, int flags)
 	pipe2(pipefd, O_CLOEXEC | flags),
 	PerlProc_pipe(pipefd));
 #  else
-    if (flags) DIE(aTHX_ PL_no_func, "pipe with flags");
+    if (flags) DIE(aTHX_ PL_no_func, "pipe with flags redux");
 
     DO_PIPEOPEN_THEN_CLOEXEC(pipefd, PerlProc_pipe(pipefd));
 #  endif

--- a/doio.c
+++ b/doio.c
@@ -296,7 +296,7 @@ Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd, int flags)
 	pipe2(pipefd, O_CLOEXEC | flags),
 	PerlProc_pipe(pipefd));
 #  else
-    if (flags) DIE(aTHX_ PL_no_func, "pipe with flags redux");
+    if (flags) DIE(aTHX_ PL_no_func, "pipe with flags");
 
     DO_PIPEOPEN_THEN_CLOEXEC(pipefd, PerlProc_pipe(pipefd));
 #  endif

--- a/doio.c
+++ b/doio.c
@@ -282,7 +282,7 @@ Perl_my_mkostemp_cloexec(char *templte, int flags)
 
 #ifdef HAS_PIPE
 int
-Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd)
+Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd, int flags)
 {
     dVAR;
     PERL_ARGS_ASSERT_PERLPROC_PIPE_CLOEXEC;
@@ -293,9 +293,11 @@ Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd)
      */
 #  if !defined(PERL_IMPLICIT_SYS) && defined(HAS_PIPE2) && defined(O_CLOEXEC)
     DO_PIPEOPEN_EXPERIMENTING_CLOEXEC(PL_strategy_pipe, pipefd,
-	pipe2(pipefd, O_CLOEXEC),
+	pipe2(pipefd, O_CLOEXEC | flags),
 	PerlProc_pipe(pipefd));
 #  else
+    if (flags) DIE(aTHX_ PL_no_func, "pipe with flags");
+
     DO_PIPEOPEN_THEN_CLOEXEC(pipefd, PerlProc_pipe(pipefd));
 #  endif
 }

--- a/embed.fnc
+++ b/embed.fnc
@@ -731,7 +731,7 @@ pR	|int	|PerlLIO_open3_cloexec|NN const char *file|int flag|int perm
 pToR	|int	|my_mkstemp_cloexec|NN char *templte
 pToR	|int	|my_mkostemp_cloexec|NN char *templte|int flags
 #ifdef HAS_PIPE
-pR	|int	|PerlProc_pipe_cloexec|NN int *pipefd
+pR	|int	|PerlProc_pipe_cloexec|NN int *pipefd|int flags
 #endif
 #ifdef HAS_SOCKET
 pR	|int	|PerlSock_socket_cloexec|int domain|int type|int protocol

--- a/embed.h
+++ b/embed.h
@@ -1589,7 +1589,7 @@
 #    endif
 #  endif
 #  if defined(HAS_PIPE)
-#define PerlProc_pipe_cloexec(a)	Perl_PerlProc_pipe_cloexec(aTHX_ a)
+#define PerlProc_pipe_cloexec(a,b)	Perl_PerlProc_pipe_cloexec(aTHX_ a,b)
 #  endif
 #  if defined(HAS_SOCKET)
 #define PerlSock_accept_cloexec(a,b,c)	Perl_PerlSock_accept_cloexec(aTHX_ a,b,c)

--- a/opcode.h
+++ b/opcode.h
@@ -2027,7 +2027,7 @@ EXTCONST U32 PL_opargs[] = {
 	0x00000000,	/* continue */
 	0x0029640d,	/* open */
 	0x0000eb04,	/* close */
-	0x00066404,	/* pipe_op */
+	0x00966404,	/* pipe_op */
 	0x00006b0c,	/* fileno */
 	0x00009b0c,	/* umask */
 	0x00096404,	/* binmode */

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -674,7 +674,7 @@ PP(pp_close)
 PP(pp_pipe_op)
 {
 #ifdef HAS_PIPE
-    dSP;
+    dSP; dMARK;
     IO *rstio;
     IO *wstio;
     int fd[2];

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -679,14 +679,14 @@ PP(pp_pipe_op)
     IO *wstio;
     int fd[2];
 
-    GV * const wgv = MUTABLE_GV(POPs);
-    GV * const rgv = MUTABLE_GV(POPs);
+    GV * const rgv = MUTABLE_GV(*++MARK);
+    GV * const wgv = MUTABLE_GV(*++MARK);
 
     int flags = 0;
 
     if (SP > MARK) {
         #ifdef HAS_PIPE2
-            flags = SvIVx(POPs);
+            flags = SvIVx(*++MARK);
         #else
             DIE(aTHX_ PL_no_func, "pipe with flags");
         #endif

--- a/proto.h
+++ b/proto.h
@@ -4652,7 +4652,7 @@ PERL_CALLCONV const char*	Perl_langinfo(const nl_item item);
 #define PERL_ARGS_ASSERT_PERL_LANGINFO
 #endif
 #if defined(HAS_PIPE)
-PERL_CALLCONV int	Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd)
+PERL_CALLCONV int	Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd, int flags)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_PERLPROC_PIPE_CLOEXEC	\
 	assert(pipefd)

--- a/regen/opcodes
+++ b/regen/opcodes
@@ -337,7 +337,7 @@ continue	continue		ck_null		0
 
 open		open			ck_open		ismt@	F S? L
 close		close			ck_fun		is%	F?
-pipe_op		pipe			ck_fun		is@	F F
+pipe_op		pipe			ck_fun		is@	F F S?
 
 fileno		fileno			ck_fun		ist%	F
 umask		umask			ck_fun		ist%	S?

--- a/util.c
+++ b/util.c
@@ -2331,10 +2331,10 @@ Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
 	taint_env();
 	taint_proper("Insecure %s%s", "EXEC");
     }
-    if (PerlProc_pipe_cloexec(p) < 0)
+    if (PerlProc_pipe_cloexec(p, 0) < 0)
 	return NULL;
     /* Try for another pipe pair for error return */
-    if (PerlProc_pipe_cloexec(pp) >= 0)
+    if (PerlProc_pipe_cloexec(pp, 0) >= 0)
 	did_pipes = 1;
     while ((pid = PerlProc_fork()) < 0) {
 	if (errno != EAGAIN) {
@@ -2473,9 +2473,9 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode)
 	taint_env();
 	taint_proper("Insecure %s%s", "EXEC");
     }
-    if (PerlProc_pipe_cloexec(p) < 0)
+    if (PerlProc_pipe_cloexec(p, 0) < 0)
 	return NULL;
-    if (doexec && PerlProc_pipe_cloexec(pp) >= 0)
+    if (doexec && PerlProc_pipe_cloexec(pp, 0) >= 0)
 	did_pipes = 1;
     while ((pid = PerlProc_fork()) < 0) {
 	if (errno != EAGAIN) {


### PR DESCRIPTION
It’s a bit annoying that I can create a non-blocking socket in Linux thus:
```
socket( my $s, AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0 );
```
… but I can’t do that for pipes.

Linux and the *BSDs (but not macOS, alas) support the `pipe2` system call which extends similar functionality to the creation of pipes. It’d be nice to have this ability in the Perl core.

This PR extends Perl’s `pipe()` built-in so that it optionally accepts `pipe( READFILEHANDLE, WRITEFILEHANDLE, FLAGS )`, which allows, e.g.:
```
pipe my $r, my $w, O_NONBLOCK;
```
… to work.

I’ll tidy this up if it’s something p5p will accept, but before I do docs etc. I wanted to see what folks think of the idea.

Thank you!