### PR TITLE
avoid using C99/C11 functions that NetBSD doesn't define

### DIFF
--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -422,6 +422,22 @@ static int not_here(const char *s);
 #  undef c99_trunc
 #endif
 
+/* The cc with NetBSD 8.0 and 9.0 claims to be a C11 hosted compiler,
+ * but doesn't define several functions required by C99, let alone C11.
+ * http://gnats.netbsd.org/53234
+ */
+#if defined(USE_LONG_DOUBLE) && defined(__NetBSD__) \
+  && !defined(NETBSD_HAVE_FIXED_LONG_DOUBLE_MATH)
+#  undef c99_expm1
+#  undef c99_lgamma
+#  undef c99_log1p
+#  undef c99_log2
+#  undef c99_nexttoward
+#  undef c99_remainder
+#  undef c99_remquo
+#  undef c99_tgamma
+#endif
+
 #ifndef isunordered
 #  ifdef Perl_isnan
 #    define isunordered(x, y) (Perl_isnan(x) || Perl_isnan(y))


### PR DESCRIPTION
Neither NetBSD 8.0 not 9.0 define several C99/C11 long double math
functions.

This is already a known issue upstream, see http://gnats.netbsd.org/53234

Fixes #17854 (at least for our purposes)

This will require some updates to hints/netbsd.sh once (if) NetBSD fix it
at their end.