### PR TITLE
warn users about NetBSD long double support and skip the failing test

### DIFF
--- a/t/op/sprintf2.t
+++ b/t/op/sprintf2.t
@@ -684,6 +684,13 @@ for my $t (@hexfloat) {
             }
         }
     }
+    if (!$ok && $^O eq "netbsd" && $t->[1] eq "exp(1)") {
+      SKIP:
+        {
+            skip "NetBSD's expl() is just exp() in disguise", 1;
+        }
+        next;
+    }
     ok($ok, "'$format' '$arg' -> '$result' cf '$expected'");
 }
 


### PR DESCRIPTION
Fixes #17853 (as far as we can)

The real fix will need to come from NetBSD at which point the hints should stop warning.