### PR TITLE
perldelta: minor pod fix

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -1572,6 +1572,7 @@ replaced by a reliable method, and hence the diagnostics generated have
 changed. See L</Diagnostics>.
 
 =item *
+
 The debug display (say by specifying C<-Dr> or S<C<use re>> (with
 appropriate options) of compiled Unicode property wildcard subpatterns no
 longer has extraneous output.


### PR DESCRIPTION
`=item *` should be a independent paragraph.
This PR fixes this.