### PR TITLE
op.h: Add additional padding to struct opslab to ensure proper alignment

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -651,6 +651,7 @@ John Macdonald                 <jmm@revenge.elegant.com>
 John Malmberg                  <wb8tyw@gmail.com>
 John Nolan                     <jpnolan@Op.Net>
 John P. Linderman              <jpl.jpl@gmail.com>
+John Paul Adrian Glaubitz      <glaubitz@physik.fu-berlin.de>
 John Peacock                   <jpeacock@messagesystems.com>
 John Pfuntner                  <pfuntner@vnet.ibm.com>
 John Poltorak                  <jp@eyup.org>

--- a/op.h
+++ b/op.h
@@ -713,6 +713,9 @@ struct opslab {
                                            units) */
 # ifdef PERL_DEBUG_READONLY_OPS
     bool	opslab_readonly;
+    U8          opslab_padding;         /* padding to ensure that opslab_slots is always */
+# else
+    U16         opslab_padding;         /* located at an offset with 32-bit alignment */
 # endif
     OPSLOT	opslab_slots;		/* slots begin here */
 };


### PR DESCRIPTION
On m68k, the natural alignment is 16 bits which causes the opslab_opslot
member of "struct opslab" to be aligned at a 16-bit offset. Other 32-bit
and 64-bit architectures have a natural alignment of at least 32 bits, so
the offset is always guaranteed to be at least 32-bit-aligned.

Fix this by adding additional padding bytes before the opslab_opslot
member, both for cases when PERL_DEBUG_READONLY_OPS defined and not
defined to ensure the offset of oplab_slots is always 32-bit-aligned.
On architectures which have a natural alignment of at least 32 bits,
the padding does not affect the alignment, offsets or struct size.