### PR TITLE
time64: declare `tm_zone` as `const char*` unconditionally

### DIFF
--- a/time64.c
+++ b/time64.c
@@ -374,7 +374,7 @@ struct TM *Perl_gmtime64_r (const Time64_T *in_time, struct TM *p)
     p->tm_isdst  = 0;
 
 #ifdef HAS_TM_TM_ZONE
-    p->tm_zone   = (char *)"UTC";
+    p->tm_zone   = "UTC";
 #endif
 
     v_tm_sec  = (int)Perl_fmod(time, 60.0);

--- a/time64.h
+++ b/time64.h
@@ -28,15 +28,7 @@ struct TM64 {
 #endif
 
 #ifdef HAS_TM_TM_ZONE
-/* If glibc is defined or we are on QNX, use const.
- * Otherwise, if we are on android, use const but
- * not with g++.
- */
-#  if defined(__GLIBC__) || (defined(__ANDROID__) && !defined(__cplusplus)) \
-    || defined(__QNX__) || defined(__CYGWIN__)
-        const
-#  endif
-        char    *tm_zone;
+        const char *tm_zone;
 #endif
 };
 


### PR DESCRIPTION
We only ever assign from `struct tm` to `struct TM`, not the other way
around, so making this const regardless of what `struct tm` has should
be safe.

This fixes the build under C++ on musl libc and other systems with `const char *tm_zone` that weren't explicitly listed in the conditional.