### PR TITLE
After running an action in the debugger, turn it off

### DIFF
--- a/lib/perl5db.pl
+++ b/lib/perl5db.pl
@@ -3347,10 +3347,6 @@ use B<o> I<inhibit_exit> to avoid stopping after program termination,
 B<h q>, B<h R> or B<h o> to get additional info.
 EOP
 
-        # Set the DB::eval context appropriately.
-        # At program termination disable any user actions.
-        $DB::action = undef;
-
         $DB::package     = 'main';
         $DB::usercontext = DB::_calc_usercontext($DB::package);
     } ## end elsif ($package eq 'DB::fake')

--- a/lib/perl5db.pl
+++ b/lib/perl5db.pl
@@ -529,7 +529,7 @@ BEGIN {
 use vars qw($VERSION $header);
 
 # bump to X.XX in blead, only use X.XX_XX in maint
-$VERSION = '1.57';
+$VERSION = '1.58';
 
 $header = "perl5db.pl version $VERSION";
 
@@ -2708,6 +2708,7 @@ If there are any preprompt actions, execute those as well.
         # The &-call is here to ascertain the mutability of @_.
         &DB::eval;
     }
+    undef $action;
 
     # Are we nested another level (e.g., did we evaluate a function
     # that had a breakpoint in it at the debugger prompt)?

--- a/lib/perl5db.t
+++ b/lib/perl5db.t
@@ -2800,6 +2800,28 @@ SKIP:
 }
 
 {
+    # GitHub #17901
+    my $wrapper = DebugWrap->new(
+        {
+            cmds =>
+            [
+                'a 4 $s++',
+                ('s') x 5,
+                'x $s',
+                'q'
+            ],
+            prog => '../lib/perl5db/t/test-a-statement-3',
+            switches => [ '-d' ],
+            stderr => 0,
+        }
+    );
+    $wrapper->contents_like(
+        qr/^0 +2$/m,
+        'Test that the a command runs only on the given lines.',
+    );
+}
+
+{
     # perl 5 RT #126735 regression bug.
     local $ENV{PERLDB_OPTS} = "NonStop=0 RemotePort=non-existent-host.tld:9001";
     my $output = runperl( stdin => "q\n", stderr => 1, switches => [ '-d' ], prog => '../lib/perl5db/t/fact' );

--- a/lib/perl5db/t/test-a-statement-3
+++ b/lib/perl5db/t/test-a-statement-3
@@ -1,0 +1,6 @@
+use strict; use warnings;
+
+for my $x (1 .. 2) {
+    my $y = $x + 1;
+    my $x = $x - 1;
+}


### PR DESCRIPTION
When running with "c", there was no problem, but when running with "n"
or "s", once the action was executed, it kept executing on the
following lines, which wasn't expected. Clearing $action here prevents
this unwanted behaviour.