### PR TITLE
Add `SAVEt_STRLEN_SMALL` type

### DIFF
--- a/scope.c
+++ b/scope.c
@@ -512,14 +512,22 @@ Perl_save_I32(pTHX_ I32 *intp)
 void
 Perl_save_strlen(pTHX_ STRLEN *ptr)
 {
+    const IV i = *ptr;
+    UV type = ((I32)((U32)i << SAVE_TIGHT_SHIFT) | SAVEt_STRLEN_SMALL);
+    int size = 2;
     dSS_ADD;
 
     PERL_ARGS_ASSERT_SAVE_STRLEN;
 
-    SS_ADD_IV(*ptr);
+    if (UNLIKELY((I32)(type >> SAVE_TIGHT_SHIFT) != i)) {
+        SS_ADD_IV(*ptr);
+        type = SAVEt_STRLEN;
+        size++;
+    }
+
     SS_ADD_PTR(ptr);
-    SS_ADD_UV(SAVEt_STRLEN);
-    SS_ADD_END(3);
+    SS_ADD_UV(type);
+    SS_ADD_END(size);
 }
 
 void
@@ -833,6 +841,7 @@ static const U8 arg_counts[] = {
     1, /* SAVEt_STACK_POS          */
     1, /* SAVEt_READONLY_OFF       */
     1, /* SAVEt_FREEPADNAME        */
+    1, /* SAVEt_STRLEN_SMALL       */
     2, /* SAVEt_AV                 */
     2, /* SAVEt_DESTRUCTOR         */
     2, /* SAVEt_DESTRUCTOR_X       */
@@ -1036,6 +1045,11 @@ Perl_leave_scope(pTHX_ I32 base)
             a0 = ap[0]; a1 = ap[1];
 	    *(int*)a1.any_ptr = (int)a0.any_i32;
 	    break;
+
+        case SAVEt_STRLEN_SMALL:
+	    a0 = ap[0];
+	    *(STRLEN*)a0.any_ptr = (STRLEN)(uv >> SAVE_TIGHT_SHIFT);
+            break;
 
 	case SAVEt_STRLEN:			/* STRLEN/size_t ref */
             a0 = ap[0]; a1 = ap[1];

--- a/scope.h
+++ b/scope.h
@@ -38,43 +38,44 @@
 #define SAVEt_STACK_POS		20
 #define SAVEt_READONLY_OFF	21
 #define SAVEt_FREEPADNAME	22
+#define SAVEt_STRLEN_SMALL      23
 
 /* two args */
 
-#define SAVEt_AV		23
-#define SAVEt_DESTRUCTOR	24
-#define SAVEt_DESTRUCTOR_X	25
-#define SAVEt_GENERIC_PVREF	26
-#define SAVEt_GENERIC_SVREF	27
-#define SAVEt_GP		28
-#define SAVEt_GVSV		29
-#define SAVEt_HINTS		30
-#define SAVEt_HPTR		31
-#define SAVEt_HV		32
-#define SAVEt_I32		33
-#define SAVEt_INT		34
-#define SAVEt_ITEM		35
-#define SAVEt_IV		36
-#define SAVEt_LONG		37
-#define SAVEt_PPTR		38
-#define SAVEt_SAVESWITCHSTACK	39
-#define SAVEt_SHARED_PVREF	40
-#define SAVEt_SPTR		41
-#define SAVEt_STRLEN		42
-#define SAVEt_SV		43
-#define SAVEt_SVREF		44
-#define SAVEt_VPTR		45
-#define SAVEt_ADELETE		46
-#define SAVEt_APTR		47
+#define SAVEt_AV		24
+#define SAVEt_DESTRUCTOR	25
+#define SAVEt_DESTRUCTOR_X	26
+#define SAVEt_GENERIC_PVREF	27
+#define SAVEt_GENERIC_SVREF	28
+#define SAVEt_GP		29
+#define SAVEt_GVSV		30
+#define SAVEt_HINTS		31
+#define SAVEt_HPTR		32
+#define SAVEt_HV		33
+#define SAVEt_I32		34
+#define SAVEt_INT		35
+#define SAVEt_ITEM		36
+#define SAVEt_IV		37
+#define SAVEt_LONG		38
+#define SAVEt_PPTR		39
+#define SAVEt_SAVESWITCHSTACK	40
+#define SAVEt_SHARED_PVREF	41
+#define SAVEt_SPTR		42
+#define SAVEt_STRLEN		43
+#define SAVEt_SV		44
+#define SAVEt_SVREF		45
+#define SAVEt_VPTR		46
+#define SAVEt_ADELETE		47
+#define SAVEt_APTR		48
 
 /* three args */
 
-#define SAVEt_HELEM		48
-#define SAVEt_PADSV_AND_MORTALIZE 49
-#define SAVEt_SET_SVFLAGS	50
-#define SAVEt_GVSLOT		51
-#define SAVEt_AELEM		52
-#define SAVEt_DELETE		53
+#define SAVEt_HELEM		49
+#define SAVEt_PADSV_AND_MORTALIZE 50
+#define SAVEt_SET_SVFLAGS	51
+#define SAVEt_GVSLOT		52
+#define SAVEt_AELEM		53
+#define SAVEt_DELETE		54
 
 
 #define SAVEf_SETMAGIC		1

--- a/sv.c
+++ b/sv.c
@@ -14912,6 +14912,7 @@ Perl_ss_dup(pTHX_ PerlInterpreter *proto_perl, CLONE_PARAMS* param)
 	    ptr = POPPTR(ss,ix);
 	    TOPPTR(nss,ix) = any_dup(ptr, proto_perl);
 	    /* FALLTHROUGH */
+	case SAVEt_STRLEN_SMALL:
 	case SAVEt_INT_SMALL:
 	case SAVEt_I32_SMALL:
 	case SAVEt_I16:				/* I16 reference */


### PR DESCRIPTION
Adds a new `SAVEt_STRLEN_SMALL`, based on the observation that most `SAVEt_STRLEN`s are small numbers (quite often zero in fact), so an extra savestack cell is a little wasteful. May provide a small performance boost in terms of CPU time and memory allocation, around places like `pad_block_start` which uses four of them in a row.

This does come at the tiny cost of using another `SAVEt_*` type, of which there are now only 10 remaining.

I wrote this PR as a practice before attacking the larger task of #17895, for which I shall have to add another one. If we don't want to add two then this PR can be ignored in favour of the other; which will actually fix a bug rather than just this performance help.

This PR fixes #17896