### PR TITLE
Signal readdir() errors by clearing/setting errno

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -6295,6 +6295,8 @@ value, not for its regular truth value.
     while (readdir $dh) {
         print "$some_dir/$_\n";
     }
+    die "Got error while reading '$some_dir': $!"
+        if $!;
     closedir $dh;
 
 To avoid confusing would-be users of your code who are running earlier
@@ -6303,6 +6305,8 @@ top of your file to signal that your code will work I<only> on Perls of a
 recent vintage:
 
     use 5.012; # so readdir assigns to $_ in a lone while test
+
+In the case of an error, C<undef> will be returned and $! will be non-zero.
 
 =item readline EXPR
 

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -4041,6 +4041,7 @@ PP(pp_readdir)
     }
 
     do {
+        SETERRNO(0,0);
         dp = (Direntry_t *)PerlDir_read(IoDIRP(io));
         if (!dp)
             break;


### PR DESCRIPTION
At least for Linux, distinguishing an error from the end of the
directory listing is done by setting errno to 0 and then calling
readdir(). Errno will then be set in the case of an error.

https://linux.die.net/man/3/readdir

This adresses

https://github.com/Perl/perl5/issues/17907

but unfortunately, there are no tests to (re)produce the behaviour at
all.