### PR TITLE
Fix Math-Complex issue in test suite

### DIFF
--- a/cpan/Math-Complex/lib/Math/Complex.pm
+++ b/cpan/Math-Complex/lib/Math/Complex.pm
@@ -10,7 +10,7 @@ package Math::Complex;
 { use 5.006; }
 use strict;
 
-our $VERSION = 1.59_01;
+our $VERSION = 1.59_02;
 
 use Config;
 

--- a/cpan/Math-Complex/t/Complex.t
+++ b/cpan/Math-Complex/t/Complex.t
@@ -6,12 +6,20 @@
 # -- Jarkko Hietaniemi	since Mar 1997
 # -- Daniel S. Lewart	since Sep 1997
 
+use strict;
+use warnings;
+
 use Math::Complex 1.54;
+
+# they are used later in the test and not exported by Math::Complex
+*_stringify_cartesian = \&Math::Complex::_stringify_cartesian;
+*_stringify_polar     = \&Math::Complex::_stringify_polar;
 
 our $vax_float = (pack("d",1) =~ /^[\x80\x10]\x40/);
 our $has_inf   = !$vax_float;
 
 my ($args, $op, $target, $test, $test_set, $try, $val, $zvalue, @set, @val);
+my ($bad, $z);
 
 $test = 0;
 $| = 1;

--- a/cpan/Math-Complex/t/Trig.t
+++ b/cpan/Math-Complex/t/Trig.t
@@ -8,6 +8,8 @@
 # 
 # -- Jarkko Hietaniemi, April 1997
 
+use strict;
+use warnings;
 use Test::More tests => 153;
 
 use Math::Trig 1.18;
@@ -28,7 +30,7 @@ if ($^O eq 'unicos') { # See lib/Math/Complex.pm and t/lib/complex.t.
     $eps = 1e-10;
 }
 
-sub near ($$;$) {
+sub near {
     my $e = defined $_[2] ? $_[2] : $eps;
     my $d = $_[1] ? abs($_[0]/$_[1] - 1) : abs($_[0]);
     print "# near? $_[0] $_[1] : $d : $e\n";

--- a/cpan/Math-Complex/t/underbar.t
+++ b/cpan/Math-Complex/t/underbar.t
@@ -5,11 +5,12 @@
 
 use Test::More;
 
+use strict;
+use warnings;
+
 my @f = qw(abs cos exp log sin sqrt);
 
 plan tests => scalar @f;
-
-use strict;
 
 use Math::Complex;
 

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -9,9 +9,9 @@ Digest::MD5 cpan/Digest-MD5/MD5.xs 249bed648232192ce018f7f894ad127c3a639831
 Digest::MD5 cpan/Digest-MD5/t/files.t e987329d2411ff60ad9a2bdf93fdf5f6943467e8
 Filter::Util::Call pod/perlfilter.pod e9833bf4ebc51087dfee5c553e0f8a5eef67212d
 Locale::Maketext::Simple cpan/Locale-Maketext-Simple/lib/Locale/Maketext/Simple.pm 57ed38905791a17c150210cd6f42ead22a7707b6
-Math::Complex cpan/Math-Complex/lib/Math/Complex.pm 198ea6c6c584f5ea79a0fd7e9d411d0878f3b2af
-Math::Complex cpan/Math-Complex/t/Complex.t 4f307ed6fc59f1e5fb0e6b11103fc631b6bdb335
-Math::Complex cpan/Math-Complex/t/Trig.t 2682526e23a161d54732c2a66393fe4a234d1865
+Math::Complex cpan/Math-Complex/lib/Math/Complex.pm 66f28a17647e2de166909ca66e4ced26f8a0a62e
+Math::Complex cpan/Math-Complex/t/Complex.t 17039e03ee798539e770ea9a0d19a99364278306
+Math::Complex cpan/Math-Complex/t/Trig.t 508f8e27373c08228be13ca5d42b28812ab0e020
 Memoize cpan/Memoize/Memoize.pm 902092ff91cdec9c7b4bd06202eb179e1ce26ca2
 NEXT cpan/NEXT/lib/NEXT.pm 2c83d03ee361816e53ccb931137d314ab878d19f
 NEXT cpan/NEXT/t/next.t 66fd60eb0f75b6f3eea95d1dee745f9a7a348146


### PR DESCRIPTION
By enabling strict and warnings in the testsuite
we could notice that t/Complex.t was testing
some functions not exported by Math::Complex:
- _stringify_cartesian
- _stringify_polar

This commit enable strict/warnings for the testsuite
and fix the test issue.

The customized VERSION is also bumped.