### PR TITLE
Make perl compile under minix again

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -2968,6 +2968,9 @@ typedef struct padname PADNAME;
 #if defined(HAS_SIGACTION) && defined(SA_SIGINFO)
     typedef siginfo_t Siginfo_t;
 #else
+#ifdef si_signo /* minix */
+#undef si_signo
+#endif
     typedef struct {
         int si_signo;
     } Siginfo_t;


### PR DESCRIPTION
This fixes #17908 

This should be merged to blead and backported to 5.32.1 once @bingos has confirmed that this fixes the issue.