### PR TITLE
Io core p7 20200630

### DIFF
--- a/t/io/argv.t
+++ b/t/io/argv.t
@@ -79,7 +79,7 @@ TODO: {
 {
     # 5.10 stopped autovivifying scalars in globs leading to a
     # segfault when $ARGV is written to.
-    runperl( prog => 'eof()', stdin => "nothing\n" );
+    runperl( prog => 'no warnings q|void|; eof()', stdin => "nothing\n" );
     is( 0+$?, 0, q(eof() doesn't segfault) );
 }
 
@@ -260,7 +260,7 @@ unlink "tmpIo_argv3.tmp";
 # ++$x vivifies it, reusing the just-deleted GV that PL_argvgv still points
 # to.  The BEGIN block ensures it is freed late enough that nothing else
 # has reused it yet.
-is runperl(prog => 'my $x; undef *x; delete $::{ARGV}; $x++;'
+is runperl(prog => 'my $x; no warnings q|once|; undef *x; delete $::{ARGV}; $x++;'
                   .'eval q-BEGIN{undef *x} readline-; print qq-ok\n-'),
   "ok\n", 'deleting $::{ARGV}';
 

--- a/t/io/argv.t
+++ b/t/io/argv.t
@@ -129,7 +129,9 @@ open STDIN, 'tmpIo_argv1.tmp' or die $!;
 @ARGV = ();
 ok( !eof(),     'STDIN has something' );
 
-is( <>, "ok 11\n" );
+my $stdin = <>;
+my $expect = "ok 11\n";
+is( $stdin, $expect, "Got what was expected from STDIN" );
 
 SKIP: {
     skip_if_miniperl($no_devnull, 4);
@@ -138,10 +140,10 @@ SKIP: {
     ok( eof(),      'eof() true with empty @ARGV' );
 
     @ARGV = ('tmpIo_argv1.tmp');
-    ok( !eof() );
+    ok( !eof(), 'one file in @ARGV' );
 
     @ARGV = ($devnull, $devnull);
-    ok( !eof() );
+    ok( !eof(), 'nothing but /dev/null in @ARGV' );
 
     close ARGV or die $!;
     ok( eof(),      'eof() true after closing ARGV' );
@@ -151,19 +153,19 @@ SKIP: {
     local $/;
     open my $fh, 'tmpIo_argv1.tmp' or die "Could not open tmpIo_argv1.tmp: $!";
     <$fh>;	# set $. = 1
-    is( <$fh>, undef );
+    is( <$fh>, undef, 'read from tempfile exhausted' );
 
     skip_if_miniperl($no_devnull, 5);
 
     open $fh, $devnull or die;
-    ok( defined(<$fh>) );
+    ok( defined(<$fh>), 'read from /dev/null defined' );
 
-    is( <$fh>, undef );
-    is( <$fh>, undef );
+    is( <$fh>, undef, 'read from tempfile exhausted' );
+    is( <$fh>, undef, 'read from tempfile still exhausted' );
 
     open $fh, $devnull or die;	# restart cycle again
-    ok( defined(<$fh>) );
-    is( <$fh>, undef );
+    ok( defined(<$fh>), 'read from /dev/null defined'  );
+    is( <$fh>, undef, 'read from tempfile again exhausted' );
     close $fh or die "Could not close: $!";
 }
 

--- a/t/io/layers.t
+++ b/t/io/layers.t
@@ -35,7 +35,7 @@ if (${^UNICODE} & 1) {
 } else {
     $UTF8_STDIN = 0;
 }
-my $NTEST = 60 - (($DOSISH || !$FASTSTDIO) ? 7 : 0) - ($DOSISH ? 7 : 0)
+my $NTEST = 63 - (($DOSISH || !$FASTSTDIO) ? 7 : 0) - ($DOSISH ? 7 : 0)
     + $UTF8_STDIN;
 
 sub PerlIO::F_UTF8 () { 0x00008000 } # from perliol.h
@@ -235,17 +235,29 @@ EOT
     sub STORE { $_[0][0] }
     tie my $t, "";
     $t = *f;
-    $f = 0; PerlIO::get_layers $t;
-    is $f, 1, '1 fetch on tied glob';
+    ok(! defined $t, "tie object is undefined" );
+    {
+        no warnings 'uninitialized';
+        $f = 0; PerlIO::get_layers $t;
+        is $f, 1, '1 fetch on tied glob';
+    }
     $t = \*f;
-    $f = 0; PerlIO::get_layers $t;
-    is $f, 1, '1 fetch on tied globref';
+    ok(! defined $t, "tie object is undefined" );
+    {
+        no warnings 'uninitialized';
+        $f = 0; PerlIO::get_layers $t;
+        is $f, 1, '1 fetch on tied globref';
+    }
     $t = *f;
     $f = 0; PerlIO::get_layers \$t;
     is $f, 1, '1 fetch on referenced tied glob';
     $t = '';
-    $f = 0; PerlIO::get_layers $t;
-    is $f, 1, '1 fetch on tied string';
+    ok(! defined $t, "tie object is undefined" );
+    {
+        no warnings 'uninitialized';
+        $f = 0; PerlIO::get_layers $t;
+        is $f, 1, '1 fetch on tied string';
+    }
 
     # No distinction between nums and strings
     open "12", "<:crlf", "test.pl" or die "$0 cannot open test.pl: $!";

--- a/t/io/pipe.t
+++ b/t/io/pipe.t
@@ -240,7 +240,10 @@ $? = 0;
 # check that child is reaped if the piped program can't be executed
 SKIP: {
   skip "/no_such_process exists", 1 if -e "/no_such_process";
+  # Suppress: Can't exec "/no_such_process": No such file or directory at io/pipe.t line NNN
+  no warnings 'exec';
   open NIL, '/no_such_process |';
+  use warnings;
   close NIL;
 
   my $child = 0;

--- a/t/io/print.t
+++ b/t/io/print.t
@@ -19,8 +19,13 @@ print $foo "ok 1\n";
 print "ok 2\n","ok 3\n","ok 4\n";
 print STDOUT "ok 5\n";
 
-open(foo,">-");
-print foo "ok 6\n";
+{
+    # Suppress twice:
+    # Unquoted string "foo" may clash with future reserved word at t/io/print.t
+    no warnings;
+    open(foo,">-");
+    print foo "ok 6\n";
+}
 
 printf "ok %d\n",7;
 printf("ok %d\n",8);
@@ -51,6 +56,7 @@ if (!exists &Errno::EBADF) {
 } else {
     $! = 0;
     no warnings 'unopened';
+    no warnings 'once';
     print NONEXISTENT "foo";
     print "not " if ($! != &Errno::EBADF);
     print "ok 19\n";

--- a/t/io/read.t
+++ b/t/io/read.t
@@ -32,6 +32,7 @@ SKIP: {
 
     $! = 0;
     no warnings 'unopened';
+    no warnings 'once';
     read(B,$b,1);
     ok($! == &Errno::EBADF);
 }

--- a/t/io/read.t
+++ b/t/io/read.t
@@ -10,22 +10,25 @@ BEGIN {
 
 use strict;
 
-plan tests => 2;
+plan tests => 4;
 
 my $tmpfile = tempfile();
 
 open(A,"+>$tmpfile");
 print A "_";
-seek(A,0,0);
+my $rv = seek(A,0,0);
+ok($rv, "seek() succeeded");
 
 my $b = "abcd"; 
 $b = "";
 
-read(A,$b,1,4);
+my $length = 1;
+$rv = read(A,$b,$length,4);
+is($rv, $length, "Read $length character into scalar, as expected");
 
 close(A);
 
-is($b,"\000\000\000\000_"); # otherwise probably "\000bcd_"
+is($b,"\000\000\000\000_", "scalar modified as expected"); # otherwise probably "\000bcd_"
 
 SKIP: {
     skip "no EBADF", 1 if (!exists &Errno::EBADF);
@@ -34,5 +37,5 @@ SKIP: {
     no warnings 'unopened';
     no warnings 'once';
     read(B,$b,1);
-    ok($! == &Errno::EBADF);
+    ok($! == &Errno::EBADF, "Errno::EBADF works");
 }

--- a/t/io/say.t
+++ b/t/io/say.t
@@ -13,15 +13,12 @@ BEGIN {
 # a print opcode, so it's more or less guaranteed to behave
 # the same way as print in any case.
 
-use strict 'vars';
-use feature "say";
-
-no strict 'refs';
-
 say "1..13";
 
 my $foo = 'STDOUT';
+no strict 'refs';
 say $foo "ok 1";
+use strict 'refs';
 
 say "ok 2\n","ok 3\n","ok 4";
 say STDOUT "ok 5";
@@ -32,13 +29,16 @@ say FOO "ok 6";
 open(my $bar,">-");
 say $bar "ok 7";
 
+no strict 'refs';
 say {"STDOUT"} "ok 8";
+use strict 'refs';
 
 if (!exists &Errno::EBADF) {
     print "ok 9 # skipped: no EBADF\n";
 } else {
     $! = 0;
     no warnings 'unopened';
+    no warnings 'once';
     say NONEXISTENT "foo";
     print "not " if ($! != &Errno::EBADF);
     say "ok 9";

--- a/t/io/tell.t
+++ b/t/io/tell.t
@@ -8,15 +8,14 @@ BEGIN {
 
 plan(36);
 
-no strict 'refs';
-
-my $TST = 'TST';
-
 my $Is_Dosish = ($^O eq 'MSWin32' or $^O eq 'NetWare' or $^O eq 'dos' or
               $^O eq 'os2' or $^O eq 'cygwin' or
               $^O =~ /^uwin/);
 
+my $TST = 'TST';
+no strict 'refs';
 open($TST, 'harness') || (die "Can't open harness");
+use strict 'refs';
 binmode $TST if $Is_Dosish;
 ok(!eof(TST), "eof is false after open() non-empty file");
 
@@ -64,7 +63,9 @@ binmode OTHER if (($^O eq 'MSWin32') || ($^O eq 'NetWare'));
 
     ok($., "open() doesn't change filehandler for \$.");
 
+    no warnings 'void';
     tell OTHER;
+    use warnings 'void';
     ok(!$., "tell() does change filehandler for \$.");
 
     $. = 5;
@@ -86,7 +87,9 @@ is($., $curline, "the 'local' correctly restores old value of filehandler for \$
 {
     local($.);
 
+    no warnings 'void';
     tell OTHER;
+    use warnings 'void';
     is($., 7, "tell() inside 'local' change filehandler for \$.");
 }
 
@@ -97,6 +100,7 @@ close(OTHER);
 }
 {
     no warnings 'unopened';
+    no warnings 'once';
     # this must be a handle that has never been opened
     is(tell(UNOPENED), -1, "tell() for unopened file returns -1");
 }
@@ -179,11 +183,14 @@ open FH, "test.pl";
 my $fh = *FH; # coercible glob
 is(tell($fh), 0, "tell on coercible glob");
 is(tell, 0, "argless tell after tell \$coercible");
-tell *$fh;
-is(tell, 0, "argless tell after tell *\$coercible");
-eof $fh;
-is(tell, 0, "argless tell after eof \$coercible");
-eof *$fh;
+{
+    no warnings 'void';
+    tell *$fh;
+    is(tell, 0, "argless tell after tell *\$coercible");
+    eof $fh;
+    is(tell, 0, "argless tell after eof \$coercible");
+    eof *$fh;
+}
 is(tell, 0, "argless tell after eof *\$coercible");
 seek $fh,0,0;
 is(tell, 0, "argless tell after seek \$coercible...");


### PR DESCRIPTION
With the exception of `t/io/semctl.t`, the `t/io/*.t` tests should now run under `use strict; use warnings;`.