### PR TITLE
Misc core p7 202007011716

### DIFF
--- a/t/uni/parser.t
+++ b/t/uni/parser.t
@@ -284,6 +284,7 @@ SKIP: {
     }
 }
 no strict 'refs';
+no warnings 'uninitialized';
 fresh_perl_is(<<'EOS', <<'EXPECT', { run_as_five => 1 }, 'no panic in pad_findmy_pvn (#134061)');
 use utf8;
 eval "sort \x{100}%";
@@ -303,5 +304,6 @@ ${
 qq ϟϟ }
 END
 is __LINE__, 59, '#line directive and qq with uni delims inside heredoc';
+use warnings;
 
 # Put new tests above the line number tests.


### PR DESCRIPTION
@khwilliamson , running `t/uni/variables.t` with warnings enabled by default leads to some test failures in circumstances where we are *currently* testing that no warnings are generated (notwithstanding syntax errors).  Could you take a look?
[t-uni-variables-core-p7-new-warnings.txt](https://github.com/Perl/perl5/files/4861125/t-uni-variables-core-p7-new-warnings.txt)
