### PR TITLE
Fix 404 and text in New Unicode properties section

### DIFF
--- a/pod/perl5320delta.pod
+++ b/pod/perl5320delta.pod
@@ -48,12 +48,12 @@ L<perlop/Operator Precedence and Associativity>.
 
 =head2 New Unicode properties C<Identifier_Status> and C<Identifier_Type> supported
 
-Unicode is in the process of revising its regular expression
-requirements: L<https://www.unicode.org/draft/reports/tr18/tr18.html>.
+Unicode has revised its regular expression requirements:
+L<https://www.unicode.org/reports/tr18/tr18-21.html>.
 As part of that they are wanting more properties to be exposed, ones
 that aren't part of the strict UCD (Unicode character database). These
 two are used for examining inputs for security purposes. Details on
-their usage is at L<https://www.unicode.org/reports/tr39/proposed.html>.
+their usage is at L<https://www.unicode.org/reports/tr39/>.
 
 =head2 It is now possible to write C<qr/\p{Name=...}/>, or
 C<qr!\p{na=/(SMILING|GRINNING) FACE/}!>


### PR DESCRIPTION
See https://github.com/Perl/perl5/issues/17881

I found a 404, and an "old" link. I investigated.

My conclusion was UC have landed new TR18 and TR39 since text in section
  New Unicode properties Identifier_Status and Identifier_Type supported
was written.

I've guessed at a suitable update.