### PR TITLE
groups.t:  Correct one syntax error which was warning

### DIFF
--- a/t/op/groups.t
+++ b/t/op/groups.t
@@ -136,7 +136,7 @@ sub Test {
         endgrent;
         skip "No group found we could add as a supplementary group", 1
             if (!@sup_group);
-        $) = "$) @sup_group[2]";
+        $) = "$) $sup_group[2]";
         my $ok = grep { $_ == $sup_group[2] } split ' ', $);
         ok $ok, "Group `$sup_group[0]' added as supplementary group";
     }


### PR DESCRIPTION
When run with warnings, this file would get:

        Scalar value @sup_group[2] better written as $sup_group[2]

Using '@' rather than '$' was probably unintentional.  Let's fix it.