### PR TITLE
Remove unneccessary capture on split

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -327,6 +327,7 @@ David D. Kilzer                <ddkilzer@lubricants-oil.com>
 David Denholm                  <denholm@conmat.phys.soton.ac.uk>
 David Dyck                     <david.dyck@fluke.com>
 David F. Haertig               <dfh@dwroll.lucent.com>
+David Farrell                  <davidnmfarrell@gmail.com>
 David Favor                    <david@davidfavor.com>
 David Feldman                  <david.feldman@tudor.com>
 David Fifield                  <david@bamsoftware.com>

--- a/cpan/Term-Cap/Cap.pm
+++ b/cpan/Term-Cap/Cap.pm
@@ -19,7 +19,7 @@ use strict;
 use vars qw($VERSION $VMS_TERMCAP);
 use vars qw($termpat $state $first $entry);
 
-$VERSION = '1.17';
+$VERSION = '1.18';
 
 # TODO:
 # support Berkeley DB termcaps
@@ -91,7 +91,7 @@ sub termcap_path
     {
 
         # Add the users $TERMPATH
-        push( @termcap_path, split( /(:|\s+)/, $ENV{TERMPATH} ) );
+        push( @termcap_path, split( /:|\s+/, $ENV{TERMPATH} ) );
     }
     else
     {


### PR DESCRIPTION
This has the effect of inserting the separator into @termcap_path but it
is never used, and in fact it is later removed via the last line in the
sub:

    return grep { defined $_ && -f $_ } @termcap_path;

This prevents lib/Term/Cap.pm from attempting to parse the file `:`
when `$ENV{TERMPATH}` contains a colon-delimited list.
