### PR TITLE
Document warning 'readline() on unopened filehandle %s'

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -5302,6 +5302,11 @@ a dirhandle.  Check your control flow.
 (W closed) The filehandle you're reading from got itself closed sometime
 before now.  Check your control flow.
 
+=item readline() on unopened filehandle %s
+
+(W unopened) The filehandle you're reading from was never opened.  Check your
+control flow.
+
 =item read() on closed filehandle %s
 
 (W closed) You tried to read from a closed filehandle.


### PR DESCRIPTION
Place it in category: (W unopened).

Signed-off-by: James E Keenan <jkeenan@cpan.org>

For: https://github.com/Perl/perl5/issues/17935