### PR TITLE
Add 11.x support for darwin.sh

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Abir Viqar                     <abiviq@hushmail.com>
 Achim Bohnet                   <ach@mpe.mpg.de>
 Achim Gratz                    <achim.gratz@stromeko.de>
 Adam Flott                     <adam@npjh.com>
+Adam Hartley                   <git@ahartley.com>
 Adam Kennedy                   <adam@ali.as>
 Adam Krolnik                   <adamk@gypsy.cyrix.com>
 Adam Milner                    <carmiac@nmt.edu>

--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -313,7 +313,7 @@ case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
 
 *** Unexpected MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET
 ***
-*** Please either set it to 10.something, or to empty.
+*** Please either set it to 10.something, 11.something or to empty.
 
 EOM
       exit 1

--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -342,11 +342,10 @@ EOM
       exit 1
     esac
 
-    prodvers_major=$(echo $prodvers|awk -F. '{print $1}')
-    prodvers_minor=$(echo $prodvers|awk -F. '{print $2}')
+    darwin_major=$(echo $osvers|awk -F. '{print $1}')
 
-    # macOS (10.12) deprecated syscall().
-    if [[ ( "$prodvers_minor" -ge 12 && "$prodvers_major" -eq 10 ) || "$prodvers_major" -ge 11 ]]; then
+    # macOS 10.12 (darwin 6.0.0) deprecated syscall().
+    if [ "$darwin_major" -ge 6 ]; then
         d_syscall='undef'
         # If deploying to pre-10.12, suppress Time::HiRes's detection of the system clock_gettime()
         case "$MACOSX_DEPLOYMENT_TARGET" in

--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -342,11 +342,11 @@ EOM
       exit 1
     esac
 
-    # The X in 10.X
+    prodvers_major=$(echo $prodvers|awk -F. '{print $1}')
     prodvers_minor=$(echo $prodvers|awk -F. '{print $2}')
 
     # macOS (10.12) deprecated syscall().
-    if [ "$prodvers_minor" -ge 12 ]; then
+    if [[ ( "$prodvers_minor" -ge 12 && "$prodvers_major" -eq 10 ) || "$prodvers_major" -ge 11 ]]; then
         d_syscall='undef'
         # If deploying to pre-10.12, suppress Time::HiRes's detection of the system clock_gettime()
         case "$MACOSX_DEPLOYMENT_TARGET" in

--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -344,8 +344,8 @@ EOM
 
     darwin_major=$(echo $osvers|awk -F. '{print $1}')
 
-    # macOS 10.12 (darwin 6.0.0) deprecated syscall().
-    if [ "$darwin_major" -ge 6 ]; then
+    # macOS 10.12 (darwin 16.0.0) deprecated syscall().
+    if [ "$darwin_major" -ge 16 ]; then
         d_syscall='undef'
         # If deploying to pre-10.12, suppress Time::HiRes's detection of the system clock_gettime()
         case "$MACOSX_DEPLOYMENT_TARGET" in

--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -301,7 +301,7 @@ case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
    # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
    # capturing its value and adding it to the flags.
     case "$MACOSX_DEPLOYMENT_TARGET" in
-    10.*)
+    10.* | 11.*)
       add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
       add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
       ;;
@@ -327,7 +327,7 @@ EOM
     # "ProductVersion:    10.11"     "10.11"
         prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
     case "$prodvers" in
-    10.*)
+    10.* | 11.*)
       add_macosx_version_min ccflags $prodvers
       add_macosx_version_min ldflags $prodvers
       ;;

--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -301,7 +301,7 @@ case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
    # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
    # capturing its value and adding it to the flags.
     case "$MACOSX_DEPLOYMENT_TARGET" in
-    10.* | 11.*)
+    [1-9][0-9].*)
       add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
       add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
       ;;
@@ -313,7 +313,7 @@ case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
 
 *** Unexpected MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET
 ***
-*** Please either set it to 10.something, 11.something or to empty.
+*** Please either set it to a valid macOS version number (e.g., 10.15) or to empty.
 
 EOM
       exit 1
@@ -327,7 +327,7 @@ EOM
     # "ProductVersion:    10.11"     "10.11"
         prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
     case "$prodvers" in
-    10.* | 11.*)
+    [1-9][0-9].*)
       add_macosx_version_min ccflags $prodvers
       add_macosx_version_min ldflags $prodvers
       ;;


### PR DESCRIPTION
Attempting to build on macOS Big Sur will currently fail with:

```
Unexpected product version 11.0
```

This is due to Apple bumping the version number to `11.0` (instead of the expected `10.16`).

This is a quick fix to resolve the issue and build Perl successfully.