### PR TITLE
core-p7: Do not alter Devel-PPPort default PERL_REVISION

### DIFF
--- a/dist/Devel-PPPort/parts/inc/version
+++ b/dist/Devel-PPPort/parts/inc/version
@@ -36,7 +36,7 @@ PERL_PATCHLEVEL_H_IMPLICIT
 #    include <could_not_find_Perl_patchlevel.h>
 #  endif
 #  ifndef PERL_REVISION
-#    define PERL_REVISION       (7)
+#    define PERL_REVISION       (5)
      /* Replace: 1 */
 #    define PERL_VERSION        PATCHLEVEL
 #    define PERL_SUBVERSION     SUBVERSION


### PR DESCRIPTION
Since Perl 5.6 `PERL_REVISION` is defined.

As this is a dual life module, and the block
exists to support older Perl versions,
we should not bump the default `PERL_REVISION` number

This should address the issues pointed by @tonycoz here
https://github.com/Perl/perl5/commit/fccf733aba1917e62cff9dd46399d76269bb530a#commitcomment-40411924

