### PR TITLE
put version directly in Exporter::Heavy

### DIFF
--- a/dist/Exporter/lib/Exporter.pm
+++ b/dist/Exporter/lib/Exporter.pm
@@ -9,7 +9,7 @@ require 5.006;
 our $Debug = 0;
 our $ExportLevel = 0;
 our $Verbose ||= 0;
-our $VERSION = '5.74';
+our $VERSION = '5.75';
 our (%Cache);
 
 sub as_heavy {

--- a/dist/Exporter/lib/Exporter/Heavy.pm
+++ b/dist/Exporter/lib/Exporter/Heavy.pm
@@ -4,7 +4,7 @@ use strict;
 no strict 'refs';
 
 # On one line so MakeMaker will see it.
-require Exporter;  our $VERSION = $Exporter::VERSION;
+our $VERSION = '5.75';
 
 =head1 NAME
 

--- a/dist/Exporter/t/Exporter.t
+++ b/dist/Exporter/t/Exporter.t
@@ -18,7 +18,7 @@ sub ok ($;$) {
 
 BEGIN {
     $test = 1;
-    print "1..33\n";
+    print "1..34\n";
     require Exporter;
     ok( 1, 'Exporter compiled' );
 }
@@ -253,3 +253,8 @@ sub TIESCALAR{bless[]}
  }
 }
 ::ok(1, 'import with tied $_');
+
+# this should be loaded, but make sure
+require Exporter::Heavy;
+::ok(Exporter->VERSION eq Exporter::Heavy->VERSION,
+    'Exporter and Exporter::Heavy have matching versions');


### PR DESCRIPTION
Modules should have their version number directly in the module, not try
to pull it in from another module. The Exporter module that would be
loaded may not correspond to the Exporter::Heavy that is having its
version checked. Generally, pulling a version from another module would
fail on something like PAUSE or a CPAN client, but because Exporter is
probably already loaded, the old code would usually just pick the
version of the currently installed Exporter, rather than the one
corresponding to the Exporter::Heavy module that is being checked.