### PR TITLE
Fix indirect method call in ExtUtils::Constant test

### DIFF
--- a/cpan/ExtUtils-Constant/t/Constant.t
+++ b/cpan/ExtUtils-Constant/t/Constant.t
@@ -435,7 +435,7 @@ EOT
   print FH ");\n";
   # Print the AUTOLOAD subroutine ExtUtils::Constant generated for us
   print FH autoload ($package, $]);
-  print FH "bootstrap $package \$VERSION;\n1;\n__END__\n";
+  print FH "$package->bootstrap(\$VERSION);\n1;\n__END__\n";
   close FH or die "close $pm: $!\n";
 
   ################ test.pl


### PR DESCRIPTION
It puts both "use $];" and "bootstrap $package \$VERSION;" in the
generated test module, which is going to break if we ever remove
`indirect` from the current feature bundle.

Fix by making the method call direct instead.

Also submitted upstream at https://rt.cpan.org/Public/Bug/Display.html?id=132995