### PR TITLE
Update Safe.pm to use tr/// to trigger loading utf8_heavy.pl.

### DIFF
--- a/dist/Safe/Safe.pm
+++ b/dist/Safe/Safe.pm
@@ -67,7 +67,7 @@ require utf8;
 # particular code points don't cause it to load.
 # (Swashes are cached internally by perl in PL_utf8_* variables
 # independent of being inside/outside of Safe. So once loaded they can be)
-do { my $a = pack('U',0x100); my $b = chr 0x101; utf8::upgrade $b; $a =~ /$b/i };
+do { my $a = pack('U',0x100); $a =~ tr/\x{1234}//; };
 # now we can safely include utf8::SWASHNEW in $default_share defined below.
 
 my $default_root  = 0;

--- a/dist/Safe/Safe.pm
+++ b/dist/Safe/Safe.pm
@@ -3,7 +3,7 @@ package Safe;
 use 5.003_11;
 use Scalar::Util qw(reftype refaddr);
 
-$Safe::VERSION = "2.41";
+$Safe::VERSION = "2.42";
 
 # *** Don't declare any lexicals above this point ***
 #
@@ -67,7 +67,7 @@ require utf8;
 # particular code points don't cause it to load.
 # (Swashes are cached internally by perl in PL_utf8_* variables
 # independent of being inside/outside of Safe. So once loaded they can be)
-do { my $a = pack('U',0x100); $a =~ tr/\x{1234}//; };
+do { my $a = pack('U',0x100); $a =~ m/\x{1234}/; $a =~ tr/\x{1234}//; };
 # now we can safely include utf8::SWASHNEW in $default_share defined below.
 
 my $default_root  = 0;

--- a/dist/Safe/Safe.pm
+++ b/dist/Safe/Safe.pm
@@ -67,7 +67,7 @@ require utf8;
 # particular code points don't cause it to load.
 # (Swashes are cached internally by perl in PL_utf8_* variables
 # independent of being inside/outside of Safe. So once loaded they can be)
-do { my $a = pack('U',0x100); $a =~ m/\x{1234}/; $a =~ tr/\x{1234}//; };
+do { my $a = pack('U',0x100); utf8->import; require 'utf8_heavy.pl' };
 # now we can safely include utf8::SWASHNEW in $default_share defined below.
 
 my $default_root  = 0;

--- a/dist/Safe/t/safeutf8.t
+++ b/dist/Safe/t/safeutf8.t
@@ -22,11 +22,7 @@ $safe->deny_only();
 # Fails with "Undefined subroutine PLPerl::utf8::SWASHNEW called"
 # if SWASHNEW is not shared, else returns true if unicode logic is working.
 # (For early Perls we don't take into account EBCDIC, so will fail there
-my $trigger = q{ my $a = pack('U',0xC4); my $b = chr }
-            . (($] lt 5.007_003) ? "" : 'utf8::unicode_to_native(')
-            . '0xE4'
-            . (($] lt 5.007_003) ? "" : ')')
-            . q{; utf8::upgrade $b; $a =~ /$b/i };
+my $trigger = q{ my $a = pack('U',0xC4); $a =~ tr/\x{1234}//rd };
 
 ok $safe->reval( $trigger ), 'trigger expression should return true';
 is $@, '', 'trigger expression should not die';

--- a/dist/Safe/t/safeutf8.t
+++ b/dist/Safe/t/safeutf8.t
@@ -22,7 +22,7 @@ $safe->deny_only();
 # Fails with "Undefined subroutine PLPerl::utf8::SWASHNEW called"
 # if SWASHNEW is not shared, else returns true if unicode logic is working.
 # (For early Perls we don't take into account EBCDIC, so will fail there
-my $trigger = q{ my $a = pack('U',0xC4); $a =~ tr/\x{1234}//rd };
+my $trigger = q{ my $a = pack('U',0xC4); $a =~ tr/\x{1234}//d; 1 };
 
 ok $safe->reval( $trigger ), 'trigger expression should return true';
 is $@, '', 'trigger expression should not die';


### PR DESCRIPTION
This was previously [PR#17291](https://github.com/Perl/perl5/pull/17291) which got automatically closed when I was cleaning up branches on my fork of the repository.  Reopening again here from the new branch since I can't change the original PR and re-open.

Original message below.  The state of this seems to be ok, but I believe I needed to make some more tests and fix a warning in 5.16 below.  I'll try to get to that quickly so that this is actually good to merge and release.

------------

This would fix #17271

I've probably not done this PR correctly, not sure if it should be going to a smoke-me branch or anything first either. I've tested the changed bits of code in 5.6 and they seem to work fine (still working on testing the whole module, my 5.6.2 install is missing some needed modules).

With the change to using tr/// like this there doesn't seem to be any real reason to keep the stuff conditional on earlier than 5.7.3, but I can fix that if I'm missing something there.