### PR TITLE
Fix warnings from Module::CoreList::Utils

### DIFF
--- a/dist/Module-CoreList/lib/Module/CoreList/Utils.pm
+++ b/dist/Module-CoreList/lib/Module/CoreList/Utils.pm
@@ -1662,7 +1662,7 @@ sub _create_aliases {
     }
 }
 
-'foo';
+1;
 
 =pod
 


### PR DESCRIPTION
This is fixing a warning from Module/CoreList/Utils.pm

```
> ./perl -cw dist/Module-CoreList/lib/Module/CoreList/Utils.pm
Useless use of a constant ("foo") in void context at dist/Module-CoreList/lib/Module/CoreList/Utils.pm line 1665.
```