### PR TITLE
Support Bison up to version 3.7

### DIFF
--- a/perly.act
+++ b/perly.act
@@ -2130,5 +2130,5 @@ case 2:
 
 /* Generated from:
  * f83d884147747f2d8f5a62eebc4ccd07d71b6b34e5ba1a8d7559526ad864dc97 perly.y
- * 1b401b34e1842dd8814919ea427f1b13abc479699495e6e88f8fe4c7ab2f838f regen_perly.pl
+ * 40aee1e96522879ab043fac10286df9e97b2db0197ad63dc6946ae7a61444afb regen_perly.pl
  * ex: set ro: */

--- a/perly.act
+++ b/perly.act
@@ -2129,6 +2129,6 @@ case 2:
     
 
 /* Generated from:
- * e5b801fdebce5c77dd8e644fc5a489cbea6af33db180e771dd9d669b12bbe0cf perly.y
- * 0947213b55d0ed11693554bea04987e886cf285f5c14cf9075fa1e7acc3f4061 regen_perly.pl
+ * f83d884147747f2d8f5a62eebc4ccd07d71b6b34e5ba1a8d7559526ad864dc97 perly.y
+ * 1b401b34e1842dd8814919ea427f1b13abc479699495e6e88f8fe4c7ab2f838f regen_perly.pl
  * ex: set ro: */

--- a/perly.c
+++ b/perly.c
@@ -53,6 +53,24 @@ typedef signed char yysigned_char;
 # define YY_NULLPTR NULL
 #endif
 
+#ifndef YY_CAST
+# ifdef __cplusplus
+#  define YY_CAST(Type, Val) static_cast<Type> (Val)
+#  define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
+# else
+#  define YY_CAST(Type, Val) ((Type) (Val))
+#  define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
+# endif
+#endif
+
+#ifndef YY_ATTRIBUTE_UNUSED
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
+# else
+#  define YY_ATTRIBUTE_UNUSED
+# endif
+#endif
+
 /* contains all the parser state tables; auto-generated from perly.y */
 #include "perly.tab"
 

--- a/perly.h
+++ b/perly.h
@@ -195,6 +195,6 @@ int yyparse (void);
 
 
 /* Generated from:
- * e5b801fdebce5c77dd8e644fc5a489cbea6af33db180e771dd9d669b12bbe0cf perly.y
- * 0947213b55d0ed11693554bea04987e886cf285f5c14cf9075fa1e7acc3f4061 regen_perly.pl
+ * f83d884147747f2d8f5a62eebc4ccd07d71b6b34e5ba1a8d7559526ad864dc97 perly.y
+ * 1b401b34e1842dd8814919ea427f1b13abc479699495e6e88f8fe4c7ab2f838f regen_perly.pl
  * ex: set ro: */

--- a/perly.h
+++ b/perly.h
@@ -196,5 +196,5 @@ int yyparse (void);
 
 /* Generated from:
  * f83d884147747f2d8f5a62eebc4ccd07d71b6b34e5ba1a8d7559526ad864dc97 perly.y
- * 1b401b34e1842dd8814919ea427f1b13abc479699495e6e88f8fe4c7ab2f838f regen_perly.pl
+ * 40aee1e96522879ab043fac10286df9e97b2db0197ad63dc6946ae7a61444afb regen_perly.pl
  * ex: set ro: */

--- a/perly.tab
+++ b/perly.tab
@@ -1189,6 +1189,6 @@ static const toketypes yy_type_tab[] =
 };
 
 /* Generated from:
- * e5b801fdebce5c77dd8e644fc5a489cbea6af33db180e771dd9d669b12bbe0cf perly.y
- * 0947213b55d0ed11693554bea04987e886cf285f5c14cf9075fa1e7acc3f4061 regen_perly.pl
+ * f83d884147747f2d8f5a62eebc4ccd07d71b6b34e5ba1a8d7559526ad864dc97 perly.y
+ * 1b401b34e1842dd8814919ea427f1b13abc479699495e6e88f8fe4c7ab2f838f regen_perly.pl
  * ex: set ro: */

--- a/perly.tab
+++ b/perly.tab
@@ -1190,5 +1190,5 @@ static const toketypes yy_type_tab[] =
 
 /* Generated from:
  * f83d884147747f2d8f5a62eebc4ccd07d71b6b34e5ba1a8d7559526ad864dc97 perly.y
- * 1b401b34e1842dd8814919ea427f1b13abc479699495e6e88f8fe4c7ab2f838f regen_perly.pl
+ * 40aee1e96522879ab043fac10286df9e97b2db0197ad63dc6946ae7a61444afb regen_perly.pl
  * ex: set ro: */

--- a/perly.y
+++ b/perly.y
@@ -31,7 +31,7 @@
 
 /*  Make the parser re-entrant. */
 
-%pure-parser
+%define api.pure
 
 %start grammar
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -254,7 +254,7 @@ L</Platform Support> section, instead.
 
 =item *
 
-The minimum supported Bison version is now 2.4.
+The minimum supported Bison version is now 2.4, and the maxiumm is 3.7.
 
 =back
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -254,7 +254,7 @@ L</Platform Support> section, instead.
 
 =item *
 
-XXX
+The minimum supported Bison version is now 2.4.
 
 =back
 

--- a/regen_perly.pl
+++ b/regen_perly.pl
@@ -76,11 +76,11 @@ EOF
 
 # Don't change this to add new bison versions without testing that the generated
 # files actually work :-) Win32 in particular may not like them. :-(
-unless ($version =~ /\b(1\.875[a-z]?|2\.[0134567]|3\.[0-4])\b/) { die <<EOF; }
+unless ($version =~ /\b(2\.[4567]|3\.[0-4])\b/) { die <<EOF; }
 
 You have the wrong version of bison in your path; currently versions
-1.875, 2.0-2.7 or 3.0-3.4 are known to work.  Try installing
-    http://ftp.gnu.org/gnu/bison/bison-2.5.1.tar.gz
+2.4-2.7 or 3.0-3.4 are known to work.  Try installing
+    http://ftp.gnu.org/gnu/bison/bison-3.3.tar.gz
 or similar.  Your bison identifies itself as:
 
 $version
@@ -133,8 +133,7 @@ open my $tmph_fh, '<', $tmph_file or die "Can't open $tmph_file: $!\n";
 }
 
 my $endcore_done = 0;
-# Token macros need to be generated manually from bison 2.4 on
-my $gather_tokens = $version >= 2.4 ? undef : 0;
+my $gather_tokens = 0;
 my $tokens;
 while (<$tmph_fh>) {
     # bison 2.6 adds header guards, which break things because of where we
@@ -163,10 +162,10 @@ j
 	$endcore_done = 1;
     }
     next if /^#line \d+ ".*"/;
-    if (not defined $gather_tokens) {
+    if (!$gather_tokens) {
 	$gather_tokens = 1 if /^\s* enum \s* yytokentype \s* \{/x;
     }
-    elsif ($gather_tokens) {
+    else {
 	if (/^\# \s* endif/x) { # The #endif just after the end of the token enum
 	    $gather_tokens = 0;
 	    $_ .= "\n/* Tokens.  */\n$tokens";


### PR DESCRIPTION
This requires copying the `YY_CAST` and `YY_ATTRIBUTE_UNUSED` macros
from the generated code, and extracting the `yysymbol_kind_t` enum if
it's defined.

We must also handle token type names with escaped double-quotes in
them, since it now names the `YYEOF` and `YYUNDEF` tokens `"end of
file"` and `"invalid token"` instead of `$end` and `$undefined`,
respectively.