### PR TITLE
Improve detection of Intel C/C++ compilers.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -465,6 +465,7 @@ Goro Fuji                      <gfuji@cpan.org>
 Grace Lee                      <grace@hal.com>
 Graham Barr                    <gbarr@pobox.com>
 Graham Knop                    <haarg@haarg.org>
+Graham Ollis                   <plicease@cpan.org>
 Graham TerMarsch               <graham@howlingfrog.com>
 Grant McLean                   <grantm@cpan.org>
 Greg Bacon                     <gbacon@itsc.uah.edu>

--- a/hints/linux.sh
+++ b/hints/linux.sh
@@ -85,7 +85,7 @@ uname_minus_m="${uname_minus_m:-"$targetarch"}"
 
 # Check if we're about to use Intel's ICC compiler
 case "`${cc:-cc} -V 2>&1`" in
-*"Intel(R) C++ Compiler"*|*"Intel(R) C Compiler"*)
+*"Intel(R) C++ Compiler"*|*"Intel(R) C++ Intel(R) 64 Compiler"*|*"Intel(R) C Compiler"*|*"Intel(R) C Intel(R) 64 Compiler"*)
     # record the version, formats:
     # icc (ICC) 10.1 20080801
     # icpc (ICC) 10.1 20080801

--- a/hints/linux.sh
+++ b/hints/linux.sh
@@ -85,7 +85,7 @@ uname_minus_m="${uname_minus_m:-"$targetarch"}"
 
 # Check if we're about to use Intel's ICC compiler
 case "`${cc:-cc} -V 2>&1`" in
-*"Intel(R) C++ Compiler"*|*"Intel(R) C++ Intel(R) 64 Compiler"*|*"Intel(R) C Compiler"*|*"Intel(R) C Intel(R) 64 Compiler"*)
+*"Intel(R) C"*" Compiler"*)
     # record the version, formats:
     # icc (ICC) 10.1 20080801
     # icpc (ICC) 10.1 20080801


### PR DESCRIPTION
My version of Intel C/C++ reports these versions:

✅ starscream% icc -V
Intel(R) C Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 19.1.1.217 Build 20200306
Copyright (C) 1985-2020 Intel Corporation.  All rights reserved.
FOR NON-COMMERCIAL USE ONLY

✅ starscream% icpc -V
Intel(R) C++ Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 19.1.1.217 Build 20200306
Copyright (C) 1985-2020 Intel Corporation.  All rights reserved.
FOR NON-COMMERCIAL USE ONLY

This patch matches these so that the right flags are used.  In particular without this patch `-fPIC` isn't added to `cccdlflags`, which results in a failed build.