### PR TITLE
Widen the feature bundle hint mask to 4 bits

### DIFF
--- a/ext/B/t/concise.t
+++ b/ext/B/t/concise.t
@@ -521,7 +521,7 @@ like $out, qr/$end/, 'OP_AND->op_other points correctly';
     is(scalar(@hints), 3, "3 hints");
     is($hints[0], 'v:{',                           "hints[0]");
     is($hints[1], 'v:*,&,{,x*,x&,x$,$',            "hints[1]");
-    is($hints[2], 'v:us,*,&,{,x*,x&,x$,$,fea=7', "hints[2]");
+    is($hints[2], 'v:us,*,&,{,x*,x&,x$,$,fea=15',  "hints[2]");
 }
 
 __END__

--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -65,7 +65,7 @@ my %removed = (
 );
 
 our $hint_shift   = 26;
-our $hint_mask    = 0x1c000000;
+our $hint_mask    = 0x3c000000;
 our @hint_bundles = qw( default 5.10 5.11 5.15 5.23 5.27 );
 
 # This gets set (for now) in $^H as well as in %^H,

--- a/perl.h
+++ b/perl.h
@@ -5179,7 +5179,7 @@ typedef enum {
 
 #define HINT_RE_FLAGS		0x02000000 /* re '/xism' pragma */
 
-#define HINT_FEATURE_MASK	0x1c000000 /* 3 bits for feature bundles */
+#define HINT_FEATURE_MASK	0x3c000000 /* 4 bits for feature bundles */
 
 				/* Note: Used for HINT_M_VMSISH_*,
 				   currently defined by vms/vmsish.h:


### PR DESCRIPTION
VMS only uses two bits for its hints, so we can steal one more for the
feature bundles.  This is necessary if we want to remove features from
a future bundle, e.g. `indirect` and `switch`.