### PR TITLE
Add mutex locking for many-reader/1-writer

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -3137,6 +3137,15 @@ typedef pthread_mutex_t PERL_TSA_CAPABILITY("mutex") perl_mutex;
 typedef pthread_cond_t	perl_cond;
 typedef pthread_key_t	perl_key;
 #  endif
+
+/* Many readers; single writer */
+typedef struct perl_RnW1_mutex {
+    perl_mutex lock;
+    perl_cond  zero_readers;
+    Size_t     readers_count;
+} Perl_W1Rn_mutex_t;
+
+
 #endif /* USE_ITHREADS */
 
 #ifdef PERL_TSA_ACTIVE


### PR DESCRIPTION
The mutex macros already in perl are sufficient to allow us to emulate
this type of locking, which may also be available natively, but I don't
think it is worth the effort to use the native calls.