### PR TITLE
perlfunc.pod - when sleep() is called with a negative int

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -7403,6 +7403,14 @@ X<sleep> X<pause>
 Causes the script to sleep for (integer) EXPR seconds, or forever if no
 argument is given.  Returns the integer number of seconds actually slept.
 
+EXPR should be a positive integer. If called with a negative integer,
+L<C<sleep>|/sleep EXPR> does not sleep but instead emits a warning, sets 
+$! (C<errno>), and returns zero.
+
+C<sleep 0> is permitted, but a function call to the underlying platform 
+implementation still occurs, with any side effects that may have. 
+C<sleep 0> is therefore not exactly identical to not sleeping at all.
+
 May be interrupted if the process receives a signal such as C<SIGALRM>.
 
     eval {


### PR DESCRIPTION
Intended to address #18010