### PR TITLE
Move PL_curstack code from Perl_av_extend_guts to Perl_stack_grow

### DIFF
--- a/av.c
+++ b/av.c
@@ -169,12 +169,6 @@ Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp,
             to_null += newmax - *maxp;
             *maxp = newmax;
 
-            /* See GH#18014 for discussion of when this might be needed: */
-            if (av == PL_curstack) { /* Oops, grew stack (via av_store()?) */
-                PL_stack_sp = *allocp + (PL_stack_sp - PL_stack_base);
-                PL_stack_base = *allocp;
-                PL_stack_max = PL_stack_base + newmax;
-            }
         } else { /* there is no SV* array yet */
             *maxp = key < 3 ? 3 : key;
             {

--- a/scope.c
+++ b/scope.c
@@ -56,6 +56,11 @@ Perl_stack_grow(pTHX_ SV **sp, SV **p, SSize_t n)
         Perl_croak(aTHX_ "Out of memory during stack extend");
 
     av_extend(PL_curstack, current + n + extra);
+
+    PL_stack_sp = AvALLOC(PL_curstack) + (PL_stack_sp - PL_stack_base);
+    PL_stack_base = AvALLOC(PL_curstack);
+    PL_stack_max = PL_stack_base + AvMAX(PL_curstack);
+
 #ifdef DEBUGGING
         PL_curstackinfo->si_stack_hwm = current + n + extra;
 #endif


### PR DESCRIPTION
The extend-an-existing-array code in _Perl_av_extend_guts_ contains the following:
```
		if (av == PL_curstack) {	/* Oops, grew stack (via av_store()?) */
		    PL_stack_sp = *allocp + (PL_stack_sp - PL_stack_base);
		    PL_stack_base = *allocp;
		    PL_stack_max = PL_stack_base + newmax;
		}
```
However, the stack probably represents a small proportion of calls to _Perl_av_extend_guts_.

At least nowadays, the `via av_store()?` comment seems to be a red herring, as all in-core instances where (av == PL_curstack) seem to originate from _Perl_stack_grow_.

This commit therefore moves the PL_stack* allocations to _Perl_stack_grow_.

Local test builds of this commit were successful, but this commit should be:

- thoroughly smoked
- reviewed by someone very familiar with the stacks.