### PR TITLE
Switch EXTENDED_TESTING logic to avoid failure notifications.

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -60,6 +60,9 @@ jobs:
       CONTINUOUS_INTEGRATION: 1
       WORKSPACE: ${{ github.workspace }}
 
+    outputs:
+      run_all_jobs: ${{ steps.check_extended_testing.outputs.run_all_jobs }}
+
     steps:
       - name: Dump GitHub context
         env:
@@ -84,30 +87,20 @@ jobs:
         run: |
           TEST_JOBS=2 make -j2 test
 
-  # use a dedicated job to check if full testsuite is enabled
-  #   avoid starting VMs if not neeced
-  #   and also provide the same check for all platforms
-  # the job fails when EXTENDED_TESTING is unset and run on fork repo
-  # note: secrets come from fork repositories
-
-  check_extended_testing:
-    name: "Run EXTENDED_TESTING"
-    runs-on: ubuntu-latest
-
-    steps:
-      # --------------------------------------------------------------------------------------------
-      # cannot use secrets earlier as part of 'if:' condition
-      - name: "Runs if EXTENDED_TESTING is set"
+      # Set a variable for dependent jobs to signal if full testsuite is enabled
+      - name: "Check if EXTENDED_TESTING is set"
+        id: check_extended_testing
         env:
           EXTENDED_TESTING: ${{ secrets.EXTENDED_TESTING }}
           CURRENT_REPOSITORY: ${{ github.repository }}
         run: |
           if [[ -z "${EXTENDED_TESTING}" && "${CURRENT_REPOSITORY}" != 'Perl/perl5' ]]; then
-            echo "[Warning] Only run extended tests on 'Perl/perl5' PRs or when secrets.EXTENDED_TESTING is set. Stopping."
-            exit 78
+            echo "Skipping extended test jobs."
+            echo "::set-output name=run_all_jobs::false"
+          else
+            echo "Running all test jobs"
+            echo "::set-output name=run_all_jobs::true"
           fi
-      - run: echo "Running EXTENDED_TESTING tests"
-      # --------------------------------------------------------------------------------------------
 
   #  _ _
   # | (_)_ _ _  ___ __
@@ -117,7 +110,8 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    needs: [sanity_check, check_extended_testing]
+    needs: sanity_check
+    if: needs.sanity_check.outputs.run_all_jobs == 'true'
 
     env:
       PERL_SKIP_TTY_TEST: 1
@@ -161,7 +155,8 @@ jobs:
     name: "linux i386/ubuntu"
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    needs: [sanity_check, check_extended_testing]
+    needs: sanity_check
+    if: needs.sanity_check.outputs.run_all_jobs == 'true'
 
     # https://hub.docker.com/r/i386/ubuntu/
     container:
@@ -210,7 +205,8 @@ jobs:
     name: "macOS xcode 11"
     runs-on: macos-latest
     timeout-minutes: 120
-    needs: [sanity_check, check_extended_testing]
+    needs: sanity_check
+    if: needs.sanity_check.outputs.run_all_jobs == 'true'
 
     env:
       PERL_SKIP_TTY_TEST: 1
@@ -240,7 +236,8 @@ jobs:
     name: "Windows msvc142"
     runs-on: windows-latest
     timeout-minutes: 120
-    needs: [sanity_check, check_extended_testing]
+    needs: sanity_check
+    if: needs.sanity_check.outputs.run_all_jobs == 'true'
 
     env:
       PERL_SKIP_TTY_TEST: 1
@@ -291,7 +288,8 @@ jobs:
     name: "Windows msvc100"
     runs-on: windows-latest
     timeout-minutes: 120
-    needs: [sanity_check, check_extended_testing]
+    needs: sanity_check
+    if: needs.sanity_check.outputs.run_all_jobs == 'true'
 
     env:
       PERL_SKIP_TTY_TEST: 1
@@ -328,7 +326,8 @@ jobs:
     name: "Windows mingw64"
     runs-on: windows-latest
     timeout-minutes: 120
-    needs: [sanity_check, check_extended_testing]
+    needs: sanity_check
+    if: needs.sanity_check.outputs.run_all_jobs == 'true'
 
     env:
       PERL_SKIP_TTY_TEST: 1
@@ -366,7 +365,8 @@ jobs:
     name: "cygwin"
     runs-on: windows-latest
     timeout-minutes: 120
-    needs: [sanity_check, check_extended_testing]
+    needs: sanity_check
+    if: needs.sanity_check.outputs.run_all_jobs == 'true'
 
     env:
       PERL_SKIP_TTY_TEST: 1


### PR DESCRIPTION
This sets a variable to skip or run jobs in the github workflow rather
using a workflow failure to stop early. Failing the workflow sends
unnecessary notifications.