### PR TITLE
Devel-PPPort: Bump to upstream at 7180c297

### DIFF
--- a/dist/Devel-PPPort/Changes
+++ b/dist/Devel-PPPort/Changes
@@ -1,5 +1,11 @@
 Revision history for Devel-PPPort
 
+ 3.58 - 2020-03-09
+
+ * Safer definition of UVCHR_SKIP
+ * Make sure WIDEST_UTYPE is unsigned
+ * Avoid Pax Header in tarballs
+
  3.57 - 2020-01-31
 
  * Fix eval_sv for Perl versions prior to 5.6.0 (Pali)

--- a/dist/Devel-PPPort/HACKERS
+++ b/dist/Devel-PPPort/HACKERS
@@ -204,20 +204,24 @@ Perl public API.
 
 =item Version numbers
 
-Version checking can be tricky to get correct (besides being buggy in some perl
-versions).
-C<ivers()> is used in the C<=tests> section to overcome this, and constructs
+Version checking used to be tricky to get correct (besides being buggy in some
+perl versions).
+C<ivers()> is used in the C<=tests> section to overcome this. and constructs
 like the following in the C language sections.
+
+  #if PERL_VERSION_EQ(5,9,3)
+  #if PERL_VERSION_NE(5,9,3)
+  #if PERL_VERSION_LT(5,9,3)
+  #if PERL_VERSION_GT(5,9,3)
+  #if PERL_VERSION_LE(5,9,3)
+  #if PERL_VERSION_GE(5,9,3)
+
+An alternative way of saying things like these is
 
   #if { VERSION < 5.9.3 }
 
-instead of
-
-  #if ((PERL_VERSION < 9) \
-    || (PERL_VERSION == 9 && PERL_SUBVERSION < 3))
-
-The version number can be either of the new form C<5.x.x> or the older
-form C<5.00x_yy>. Both are translated into the correct preprocessor
+In this form, the version number can be either of the new form C<5.x.x> or the
+older form C<5.00x_yy>. Both are translated into the correct preprocessor
 statements. It is also possible to combine this with other statements:
 
   #if { VERSION >= 5.004 } && !defined(sv_vcatpvf)
@@ -399,7 +403,7 @@ collect the remaining information in F<parts/apidoc.fnc>.
 =item *
 
 The final step before regenerating everything is to run
-F</devel/mkppport_fnc.pl> to update the F</parts/ppport.fnc> file.
+F<devel/mkppport_fnc.pl> to update the F</parts/ppport.fnc> file.
 
 =back
 

--- a/dist/Devel-PPPort/Makefile.PL
+++ b/dist/Devel-PPPort/Makefile.PL
@@ -219,6 +219,8 @@ sub MY::dist_core
     if ( $rule =~ m{^\s*^dist\s+:}m ) {
         $rule =~ s{:}{: PPPort.pm manifest}; # make sure we update PPPort.pm
         $rule .= qq[\t].q[$(NOECHO) $(ECHO) "Warning: Please check '__MAX_PERL__' value in PPPort_pm.PL"].qq[\n];
+        # checking that the tarball has no Pax Header - avoid false positives by using [P]axHEader
+        $rule .= qq[\t].q[$(NOECHO) zgrep -a -e '[P]axHeader' $(DISTVNAME).tar$(SUFFIX) && ( $(ECHO) "ERROR: Pax Header detected in tarball"; rm -f $(DISTVNAME).tar$(SUFFIX) ) ||:].qq[\n];
     }
     $updated .= $rule;
   }

--- a/dist/Devel-PPPort/PPPort_pm.PL
+++ b/dist/Devel-PPPort/PPPort_pm.PL
@@ -711,7 +711,7 @@ package Devel::PPPort;
 use strict;
 use vars qw($VERSION $data);
 
-$VERSION = '3.57';
+$VERSION = '3.58';
 
 sub _init_data
 {
@@ -747,7 +747,7 @@ sub WriteFile
 
 __DATA__
 #if 0
-<<'SKIP';
+my $void = <<'SKIP';
 #endif
 /*
 ----------------------------------------------------------------------

--- a/dist/Devel-PPPort/devel/mkapidoc.pl
+++ b/dist/Devel-PPPort/devel/mkapidoc.pl
@@ -23,7 +23,10 @@ use warnings;
 use strict;
 
 my $PERLROOT = $ARGV[0];
-$PERLROOT = '../..' unless $PERLROOT;
+unless ($PERLROOT) {
+    $PERLROOT = '../..';
+    print STDERR "$0: perl directory root argument not specified. Assuming '$PERLROOT'\n";
+}
 
 die "'$PERLROOT' is invalid, or you haven't successfully run 'make' in it"
                                                 unless -e "$PERLROOT/warnings.h";

--- a/dist/Devel-PPPort/mktests.PL
+++ b/dist/Devel-PPPort/mktests.PL
@@ -78,7 +78,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -110,7 +110,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/parts/apicheck.pl
+++ b/dist/Devel-PPPort/parts/apicheck.pl
@@ -339,7 +339,13 @@ HEAD
   # #ifdef out if marked as todo (not known in) this version
   if (exists $todo{$f->{'name'}}) {
     my($five, $ver,$sub) = parse_version($todo{$f->{'name'}}{'version'});
-    print OUT "#if PERL_VERSION > $ver || (PERL_VERSION == $ver && PERL_SUBVERSION >= $sub) /* TODO */\n";
+    print OUT <<EOT;
+#if       PERL_REVISION > $five                             \\
+   || (   PERL_REVISION == $five                            \\
+       && (   PERL_VERSION > $ver                           \\
+           || (   PERL_VERSION == $ver                      \\
+               && PERL_SUBVERSION >= $sub))) /* TODO */
+EOT
   }
 
   my $final = $varargs

--- a/dist/Devel-PPPort/parts/apidoc.fnc
+++ b/dist/Devel-PPPort/parts/apidoc.fnc
@@ -20,6 +20,7 @@ Amd|void|__ASSERT_|bool expr
 Amnhd||aTHX
 Amnhd||aTHX_
 Amd|int|AvFILL|AV* av
+md|int|AvFILLp|AV* av
 Amnd|I32|ax
 Amxud|void|BhkDISABLE|BHK *hk|which
 Amxud|void|BhkENABLE|BHK *hk|which
@@ -583,13 +584,23 @@ AmnUhd||PERL_UQUAD_MIN
 AmnUhd||PERL_USHORT_MAX
 AmnUhd||PERL_USHORT_MIN
 hAmnd|int|PERL_VERSION
+AmdR|bool|PERL_VERSION_EQ|const int r|const int v|const int s
+AmdR|bool|PERL_VERSION_GE|const int r|const int v|const int s
+AmdR|bool|PERL_VERSION_GT|const int r|const int v|const int s
+AmdR|bool|PERL_VERSION_LE|const int r|const int v|const int s
+AmdR|bool|PERL_VERSION_LT|const int r|const int v|const int s
+AmdR|bool|PERL_VERSION_NE|const int r|const int v|const int s
 AmnUd|Perl_check_t *|PL_check
 AmnxUd|PAD *|PL_comppad
 AmnxUd|PADNAMELIST *|PL_comppad_name
 Amnd|COP*|PL_curcop
 AmnxUd|SV **|PL_curpad
 Amnd|HV*|PL_curstash
+mnd|SV *|PL_DBsingle
+mnd|GV *|PL_DBsub
+mnd|SV *|PL_DBtrace
 Amnd|GV *|PL_defgv
+mnd|U8|PL_dowarn
 Amnhd|GV *|PL_errgv
 Amnd|U8|PL_exit_flags
 AmnUxd|Perl_keyword_plugin_t|PL_keyword_plugin

--- a/dist/Devel-PPPort/parts/base/5017006
+++ b/dist/Devel-PPPort/parts/base/5017006
@@ -1,5 +1,4 @@
 5.017006
-croak_memory_wrap              # U
 READ_XDIGIT                    # U
 croak_no_mem                   # F added by devel/scanprov
 get_and_check_backslash_N_name # F added by devel/scanprov

--- a/dist/Devel-PPPort/parts/base/5019003
+++ b/dist/Devel-PPPort/parts/base/5019003
@@ -2,6 +2,7 @@
 PERL_EXIT_ABORT                # E
 PERL_EXIT_WARN                 # E
 sv_pos_b2u_flags               # U
+croak_memory_wrap              # M added by devel/scanprov
 adjust_size_and_find_bucket    # F added by devel/scanprov
 cv_const_sv_or_av              # F added by devel/scanprov
 _invlist_dump                  # F added by devel/scanprov

--- a/dist/Devel-PPPort/parts/base/5019009
+++ b/dist/Devel-PPPort/parts/base/5019009
@@ -1,4 +1,3 @@
 5.019009
 WARN_EXPERIMENTAL__SIGNATURES  # E
-_get_regclass_nonbitmap_data   # F added by devel/scanprov
 put_range                      # F added by devel/scanprov

--- a/dist/Devel-PPPort/parts/base/5031006
+++ b/dist/Devel-PPPort/parts/base/5031006
@@ -1,10 +1,5 @@
 5.031006
 UTF8_CHK_SKIP                  # U
-do_trans_count_invmap          # F added by devel/scanprov
-do_trans_invmap                # F added by devel/scanprov
-invmap_dump                    # F added by devel/scanprov
 _is_utf8_FOO                   # F added by devel/scanprov
 _is_utf8_perl_idcont           # F added by devel/scanprov
 _is_utf8_perl_idstart          # F added by devel/scanprov
-make_exactf_invlist            # F added by devel/scanprov
-sv_derived_from_svpvn          # F added by devel/scanprov

--- a/dist/Devel-PPPort/parts/base/5031007
+++ b/dist/Devel-PPPort/parts/base/5031007
@@ -2,12 +2,18 @@
 csighandler                    # E (Perl_csighandler)
 csighandler1                   # U
 csighandler3                   # E
+memCHRs                        # U
 perly_sighandler               # E
 sv_isa_sv                      # U
 WARN_EXPERIMENTAL__ISA         # E
+do_trans_count_invmap          # F added by devel/scanprov
+do_trans_invmap                # F added by devel/scanprov
 find_first_differing_byte_pos  # F added by devel/scanprov
 invlist_lowest                 # F added by devel/scanprov
+invmap_dump                    # F added by devel/scanprov
 is_grapheme                    # F added by devel/scanprov
+make_exactf_invlist            # F added by devel/scanprov
 quadmath_format_valid          # F added by devel/scanprov
 sighandler1                    # F added by devel/scanprov
 sighandler3                    # F added by devel/scanprov
+sv_derived_from_svpvn          # F added by devel/scanprov

--- a/dist/Devel-PPPort/parts/base/5031008
+++ b/dist/Devel-PPPort/parts/base/5031008
@@ -1,4 +1,3 @@
 5.031008
-memCHRs                        # U
 grok_bin_oct_hex               # F added by devel/scanprov
 output_non_portable            # F added by devel/scanprov

--- a/dist/Devel-PPPort/parts/inc/inctools
+++ b/dist/Devel-PPPort/parts/inc/inctools
@@ -1,5 +1,12 @@
 # These are tools that must be included in ppport.h.  It doesn't work if given
-# a .pl suffix
+# a .pl suffix.
+#
+# WARNING: Use only constructs that are legal as far back as D:P handles, as
+# this is run in the perl version being tested.
+
+# What revisions are legal, to be output as-is and converted into a pattern
+# that matches them precisely
+my $r_pat = "[57]";
 
 sub format_version
 {
@@ -20,43 +27,43 @@ sub format_version
 
 sub parse_version
 {
-  # Returns a triplet, (5, major, minor) from the input, treated as a string,
-  # which can be in any of several typical formats.
+  # Returns a triplet, (revision, major, minor) from the input, treated as a
+  # string, which can be in any of several typical formats.
 
   my $ver = shift;
   $ver = "" unless defined $ver;
 
   my($r,$v,$s);
 
-  if (   ($r, $v, $s) = $ver =~ /^(5)(\d{3})(\d{3})$/ # 5029010, from the file
+  if (   ($r, $v, $s) = $ver =~ /^([0-9]+)([0-9]{3})([0-9]{3})$/ # 5029010, from the file
                                                       # names in our
                                                       # parts/base/ and
                                                       # parts/todo directories
-      or ($r, $v, $s) = $ver =~ /^(\d+)\.(\d+)\.(\d+)$/   # 5.25.7
-      or ($r, $v, $s) = $ver =~ /^(\d+)\.(\d{3})(\d{3})$/ # 5.025008, from the
-                                                          # output of $]
-      or ($r, $v, $s) = $ver =~ /^(\d+)\.(\d{1,3})()$/    # 5.24, 5.004
-      or ($r, $v, $s) = $ver =~ /^(\d+)\.(00[1-5])_?(\d{2})$/  # 5.003_07
+      or ($r, $v, $s) = $ver =~ /^([0-9]+)\.([0-9]+)\.([0-9]+)$/  # 5.25.7
+      or ($r, $v, $s) = $ver =~ /^([0-9]+)\.([0-9]{3})([0-9]{3})$/ # 5.025008, from the
+                                                           # output of $]
+      or ($r, $v, $s) = $ver =~ /^([0-9]+)\.([0-9]{1,3})()$/    # 5.24, 5.004
+      or ($r, $v, $s) = $ver =~ /^([0-9]+)\.(00[1-5])_?([0-9]{2})$/ # 5.003_07
   ) {
 
     $s = 0 unless $s;
 
-    die "Only Perl 5 is supported '$ver'\n" if $r != 5;
+    die "Only Perl $r_pat are supported '$ver'\n" unless $r =~ / ^ $r_pat $ /x;
     die "Invalid version number: $ver\n" if $v >= 1000 || $s >= 1000;
-    return (5, 0 + $v, 0 + $s);
+    return (0 +$r, 0 + $v, 0 + $s);
   }
 
   # For some safety, don't assume something is a version number if it has a
   # literal dot as one of the three characters.  This will have to be fixed
-  # when we reach 5.46
+  # when we reach x.46 (since 46 is ord('.'))
   if ($ver !~ /\./ && (($r, $v, $s) = $ver =~ /^(.)(.)(.)$/))  # vstring 5.25.7
   {
     $r = ord $r;
     $v = ord $v;
     $s = ord $s;
 
-    die "Only Perl 5 is supported '$ver'\n" if $r != 5;
-    return (5, $v, $s);
+    die "Only Perl $r_pat are supported '$ver'\n" unless $r =~ / ^ $r_pat $ /x;
+    return ($r, $v, $s);
   }
 
   my $mesg = "";
@@ -82,24 +89,30 @@ sub format_version_line
     # Returns a floating point representation of the input version
 
     my $version = int_parse_version(shift);
-    $version =~ s/^5\B/5./;
+    $version =~ s/ ^  ( $r_pat ) \B /$1./x;
     return $version;
 }
 
-sub dictionary_order($$)    # Sort caselessly, ignoring punct
-{
-    my ($lc_a, $lc_b);
-    my ($squeezed_a, $squeezed_b);
-    my ($valid_a, $valid_b);    # Meaning valid for all releases
-
+BEGIN {
+  if ("$]" < "5.006" ) {
     # On early perls, the implicit pass by reference doesn't work, so we have
     # to use the globals to initialize.
-    if ("$]" < "5.006" ) {
-        $valid_a = $a; $valid_b = $b;
-    }
-    else {
-        ($valid_a, $valid_b) = @_;
-    }
+    eval q[sub dictionary_order($$) { _dictionary_order($a, $b) } ];
+  } elsif ("$]" < "5.022" ) {
+    eval q[sub dictionary_order($$) { _dictionary_order(@_) } ];
+  } else {
+    eval q[sub dictionary_order :prototype($$) { _dictionary_order(@_) } ];
+  }
+}
+
+sub _dictionary_order { # Sort caselessly, ignoring punct
+    my ($valid_a, $valid_b) = @_;
+
+    my ($lc_a, $lc_b);
+    my ($squeezed_a, $squeezed_b);
+
+    $valid_a = '' unless defined $valid_a;
+    $valid_b = '' unless defined $valid_b;
 
     $lc_a = lc $valid_a;
     $lc_b = lc $valid_b;

--- a/dist/Devel-PPPort/parts/inc/misc
+++ b/dist/Devel-PPPort/parts/inc/misc
@@ -50,6 +50,18 @@ __UNDEFINED__ __ASSERT_(statement)  assert(statement),
 __UNDEFINED__ __ASSERT_(statement)
 #endif
 
+#ifndef WIDEST_UTYPE
+# ifdef QUADKIND
+#  ifdef U64TYPE
+#   define WIDEST_UTYPE U64TYPE
+#  else
+#   define WIDEST_UTYPE unsigned Quad_t
+#  endif
+# else
+#  define WIDEST_UTYPE U32
+# endif
+#endif
+
 /* These could become provided if/when they become part of the public API */
 __UNDEF_NOT_PROVIDED__ withinCOUNT(c, l, n)                                    \
    (((WIDEST_UTYPE) (((c)) - ((l) | 0))) <= (((WIDEST_UTYPE) ((n) | 0))))
@@ -346,18 +358,6 @@ typedef OP* (CPERLscope(*Perl_ppaddr_t))(pTHX);
 
 typedef OP* (CPERLscope(*Perl_check_t)) (pTHX_ OP*);
 
-#endif
-
-#ifndef WIDEST_UTYPE
-# ifdef QUADKIND
-#  ifdef U64TYPE
-#   define WIDEST_UTYPE U64TYPE
-#  else
-#   define WIDEST_UTYPE Quad_t
-#  endif
-# else
-#  define WIDEST_UTYPE U32
-# endif
 #endif
 
 /* On versions without NATIVE_TO_ASCII, only ASCII is supported */

--- a/dist/Devel-PPPort/parts/inc/ppphbin
+++ b/dist/Devel-PPPort/parts/inc/ppphbin
@@ -117,7 +117,7 @@ my($hint, $define, $function);
 
 sub find_api
 {
-  BEGIN { 'warnings'->unimport('uninitialized') if "$]" > '5.006' }
+  BEGIN { 'warnings'->unimport('uninitialized') if "$]" > 5.006 }
   my $code = shift;
   $code =~ s{
     / (?: \*[^*]*\*+(?:[^$ccs][^*]*\*+)* / | /[^\r\n]*)
@@ -594,7 +594,7 @@ for $filename (@files) {
         diag("Uses $func");
       }
     }
-    $warnings += hint($func);
+    $warnings += (hint($func) || 0);
   }
 
   unless ($opt{quiet}) {
@@ -882,7 +882,7 @@ sub hint
     $hint =~ s/^/   /mg;
     print "   --- hint for $func ---\n", $hint;
   }
-  $rv;
+  $rv || 0;
 }
 
 sub usage

--- a/dist/Devel-PPPort/parts/inc/ppphtest
+++ b/dist/Devel-PPPort/parts/inc/ppphtest
@@ -614,8 +614,8 @@ ok($o !~ /Uses SvPVutf8_force/m);
 $o = ppport(qw(--nochanges --compat-version=5.999.999));
 ok($o !~ /Uses SvPVutf8_force/m);
 
-$o = ppport(qw(--nochanges --compat-version=6.0.0));
-ok($o =~ /Only Perl 5 is supported/m);
+$o = ppport(qw(--nochanges --compat-version=8.0.0));
+ok($o =~ /Only Perl \[57\] are supported/m);
 
 $o = ppport(qw(--nochanges --compat-version=5.1000.999));
 ok($o =~ /Invalid version number: 5.1000.999/m);
@@ -680,7 +680,7 @@ my %p;
 my $fail = 0;
 for (@o) {
   my($name, $flags) = /^(\w+)(?:\s+\[(\w+(?:,\s+\w+)*)\])?$/ or $fail++;
-  exists $p{$name} and $fail++;
+  { exists $p{$name} and $fail++; }
   $p{$name} = defined $flags ? { map { ($_ => 1) } $flags =~ /(\w+)/g } : '';
 }
 ok(@o > 100);
@@ -721,7 +721,7 @@ my %p;
 my $fail = 0;
 for (@o) {
   my($name, $ver) = /^(\w+)\s*\.+\s*([\d._]+)$/ or $fail++;
-  exists $p{$name} and $fail++;
+  { exists $p{$name} and $fail++; }
   $p{$name} = $ver;
 }
 ok(@o > 100);

--- a/dist/Devel-PPPort/parts/inc/utf8
+++ b/dist/Devel-PPPort/parts/inc/utf8
@@ -127,17 +127,14 @@ __UNDEFINED__ UTF8_IS_INVARIANT(c)  (isASCII(c) || isCNTRL_L1(c))
 __UNDEFINED__ UVCHR_IS_INVARIANT(c)  UTF8_IS_INVARIANT(c)
 
 #ifdef UVCHR_IS_INVARIANT
-#  if 'A' == 65
-#    ifdef QUADKIND
-#      define D_PPP_UVCHR_SKIP_UPPER(c)                                         \
-          (WIDEST_UTYPE) (c) <                                                  \
-        (((WIDEST_UTYPE) 1) << (6 * D_PPP_BYTE_INFO_BITS)) ? 7 : 13
-#    else
-#      define D_PPP_UVCHR_SKIP_UPPER(c) 7  /* 32 bit platform */
-#    endif
-#  else
-     /* In the releases this is backported to, UTF-EBCDIC had a max of 2**31-1 */
+#  if 'A' != 65 || UVSIZE < 8
+     /* 32 bit platform, which includes UTF-EBCDIC on the releases this is
+      * backported to */
 #    define D_PPP_UVCHR_SKIP_UPPER(c) 7
+#  else
+#    define D_PPP_UVCHR_SKIP_UPPER(c)                                       \
+        (((WIDEST_UTYPE) (c)) <                                             \
+         (((WIDEST_UTYPE) 1) << (6 * D_PPP_BYTE_INFO_BITS)) ? 7 : 13)
 #  endif
 
 __UNDEFINED__ UVCHR_SKIP(c)                                                     \
@@ -821,7 +818,7 @@ else {
 
     # An empty input is an assertion failure on debugging builds.  It is
     # deliberately the first test.
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
 
     # VMS doesn't put DEBUGGING in ccflags, and Windows doesn't have

--- a/dist/Devel-PPPort/parts/inc/version
+++ b/dist/Devel-PPPort/parts/inc/version
@@ -15,6 +15,7 @@ PERL_REVISION
 PERL_VERSION
 PERL_SUBVERSION
 PERL_BCDVERSION
+__UNDEFINED__
 
 =dontwarn
 
@@ -41,11 +42,12 @@ PERL_PATCHLEVEL_H_IMPLICIT
 #endif
 
 #define D_PPP_DEC2BCD(dec) ((((dec)/100)<<8)|((((dec)%100)/10)<<4)|((dec)%10))
-#define PERL_BCDVERSION ((D_PPP_DEC2BCD(PERL_REVISION)<<24)|(D_PPP_DEC2BCD(PERL_VERSION)<<12)|D_PPP_DEC2BCD(PERL_SUBVERSION))
+#define D_PPP_RVS_TO_BCD(r,v,s) ((D_PPP_DEC2BCD(r)<<24)|(D_PPP_DEC2BCD(v)<<12)|D_PPP_DEC2BCD(s))
+#define PERL_BCDVERSION D_PPP_RVS_TO_BCD(PERL_REVISION, PERL_VERSION, PERL_SUBVERSION)
 
-/* It is very unlikely that anyone will try to use this with Perl 6
-   (or greater), but who knows.
- */
-#if PERL_REVISION != 5
-#  error ppport.h only works with Perl version 5
-#endif /* PERL_REVISION != 5 */
+__UNDEFINED__ PERL_VERSION_EQ(r,v,s) (PERL_BCDVERSION == D_PPP_RVS_TO_BCD(r,v,s))
+__UNDEFINED__ PERL_VERSION_NE(r,v,s) (! PERL_VERSION_EQ(r,v,s))
+__UNDEFINED__ PERL_VERSION_LT(r,v,s) (PERL_BCDVERSION < D_PPP_RVS_TO_BCD(r,v,s))
+__UNDEFINED__ PERL_VERSION_LE(r,v,s) (PERL_BCDVERSION <= D_PPP_RVS_TO_BCD(r,v,s))
+__UNDEFINED__ PERL_VERSION_GT(r,v,s) (! PERL_VERSION_LE(r,v,s))
+__UNDEFINED__ PERL_VERSION_GE(r,v,s) (! PERL_VERSION_LT(r,v,s))

--- a/dist/Devel-PPPort/parts/ppptools.pl
+++ b/dist/Devel-PPPort/parts/ppptools.pl
@@ -80,7 +80,7 @@ sub expand_version
 {
   my($op, $ver) = @_;
   my($r, $v, $s) = parse_version($ver);
-  $r == 5 or die "only Perl revision 5 is supported\n";
+  $r =~ / ^ [57] $ /x  or die "only Perl revisions [57] are supported\n";
   my $bcdver = sprintf "0x%d%03d%03d", $r, $v, $s;
   return "(PERL_BCDVERSION $op $bcdver)";
 }

--- a/dist/Devel-PPPort/parts/todo/5003007
+++ b/dist/Devel-PPPort/parts/todo/5003007
@@ -39,7 +39,6 @@ CopyD                          # T
 CPPMINUS                       # T
 CPPSTDIN                       # T
 croak                          # T
-croak_memory_wrap              # T
 croak_no_modify                # T
 croak_sv                       # T
 croak_xs_usage                 # T
@@ -480,6 +479,12 @@ PERL_UQUAD_MIN                 # T
 PERL_USHORT_MAX                # T
 PERL_USHORT_MIN                # T
 PERL_VERSION                   # T
+PERL_VERSION_EQ                # T
+PERL_VERSION_GE                # T
+PERL_VERSION_GT                # T
+PERL_VERSION_LE                # T
+PERL_VERSION_LT                # T
+PERL_VERSION_NE                # T
 PL_bufend                      # T
 PL_bufptr                      # T
 PL_compiling                   # T

--- a/dist/Devel-PPPort/t/01_test.t
+++ b/dist/Devel-PPPort/t/01_test.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/HvNAME.t
+++ b/dist/Devel-PPPort/t/HvNAME.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/MY_CXT.t
+++ b/dist/Devel-PPPort/t/MY_CXT.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/SvPV.t
+++ b/dist/Devel-PPPort/t/SvPV.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/SvREFCNT.t
+++ b/dist/Devel-PPPort/t/SvREFCNT.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/Sv_set.t
+++ b/dist/Devel-PPPort/t/Sv_set.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/call.t
+++ b/dist/Devel-PPPort/t/call.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/cop.t
+++ b/dist/Devel-PPPort/t/cop.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/exception.t
+++ b/dist/Devel-PPPort/t/exception.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/format.t
+++ b/dist/Devel-PPPort/t/format.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/grok.t
+++ b/dist/Devel-PPPort/t/grok.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/gv.t
+++ b/dist/Devel-PPPort/t/gv.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/limits.t
+++ b/dist/Devel-PPPort/t/limits.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/locale.t
+++ b/dist/Devel-PPPort/t/locale.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/mPUSH.t
+++ b/dist/Devel-PPPort/t/mPUSH.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/magic.t
+++ b/dist/Devel-PPPort/t/magic.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/memory.t
+++ b/dist/Devel-PPPort/t/memory.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/mess.t
+++ b/dist/Devel-PPPort/t/mess.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/misc.t
+++ b/dist/Devel-PPPort/t/misc.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/newCONSTSUB.t
+++ b/dist/Devel-PPPort/t/newCONSTSUB.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/newRV.t
+++ b/dist/Devel-PPPort/t/newRV.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/newSV_type.t
+++ b/dist/Devel-PPPort/t/newSV_type.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/newSVpv.t
+++ b/dist/Devel-PPPort/t/newSVpv.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/podtest.t
+++ b/dist/Devel-PPPort/t/podtest.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/ppphtest.t
+++ b/dist/Devel-PPPort/t/ppphtest.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 
@@ -655,8 +655,8 @@ ok($o !~ /Uses SvPVutf8_force/m);
 $o = ppport(qw(--nochanges --compat-version=5.999.999));
 ok($o !~ /Uses SvPVutf8_force/m);
 
-$o = ppport(qw(--nochanges --compat-version=6.0.0));
-ok($o =~ /Only Perl 5 is supported/m);
+$o = ppport(qw(--nochanges --compat-version=8.0.0));
+ok($o =~ /Only Perl \[57\] are supported/m);
 
 $o = ppport(qw(--nochanges --compat-version=5.1000.999));
 ok($o =~ /Invalid version number: 5.1000.999/m);
@@ -721,7 +721,7 @@ my %p;
 my $fail = 0;
 for (@o) {
   my($name, $flags) = /^(\w+)(?:\s+\[(\w+(?:,\s+\w+)*)\])?$/ or $fail++;
-  exists $p{$name} and $fail++;
+  { exists $p{$name} and $fail++; }
   $p{$name} = defined $flags ? { map { ($_ => 1) } $flags =~ /(\w+)/g } : '';
 }
 ok(@o > 100);
@@ -762,7 +762,7 @@ my %p;
 my $fail = 0;
 for (@o) {
   my($name, $ver) = /^(\w+)\s*\.+\s*([\d._]+)$/ or $fail++;
-  exists $p{$name} and $fail++;
+  { exists $p{$name} and $fail++; }
   $p{$name} = $ver;
 }
 ok(@o > 100);

--- a/dist/Devel-PPPort/t/pv_tools.t
+++ b/dist/Devel-PPPort/t/pv_tools.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/pvs.t
+++ b/dist/Devel-PPPort/t/pvs.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/shared_pv.t
+++ b/dist/Devel-PPPort/t/shared_pv.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/snprintf.t
+++ b/dist/Devel-PPPort/t/snprintf.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/sprintf.t
+++ b/dist/Devel-PPPort/t/sprintf.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/strlfuncs.t
+++ b/dist/Devel-PPPort/t/strlfuncs.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/sv_xpvf.t
+++ b/dist/Devel-PPPort/t/sv_xpvf.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/threads.t
+++ b/dist/Devel-PPPort/t/threads.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/utf8.t
+++ b/dist/Devel-PPPort/t/utf8.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 
@@ -194,7 +194,7 @@ else {
 
     # An empty input is an assertion failure on debugging builds.  It is
     # deliberately the first test.
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
 
     # VMS doesn't put DEBUGGING in ccflags, and Windows doesn't have

--- a/dist/Devel-PPPort/t/uv.t
+++ b/dist/Devel-PPPort/t/uv.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/variables.t
+++ b/dist/Devel-PPPort/t/variables.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 

--- a/dist/Devel-PPPort/t/warn.t
+++ b/dist/Devel-PPPort/t/warn.t
@@ -16,7 +16,7 @@ BEGIN {
   if ($ENV{'PERL_CORE'}) {
     chdir 't' if -d 't';
     unshift @INC, '../lib' if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
     use vars '%Config';
     if (" $Config{'extensions'} " !~ m[ Devel/PPPort ]) {
       print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";
@@ -48,7 +48,7 @@ package Devel::PPPort;
 use vars '@ISA';
 require DynaLoader;
 @ISA = qw(DynaLoader);
-bootstrap Devel::PPPort;
+Devel::PPPort->bootstrap;
 
 package main;
 


### PR DESCRIPTION
These changes from Devel-PPPort are adding support for Perl 7.0 and fixes the testsuite with a Perl 7.0.0 binary.
A new version of Devel-PPPort would be publish soon.

Pre required changes for #18020 but can be submitted and reviewed as their own earlier.