### PR TITLE
threads: use PERL_VERSION compare macros

### DIFF
--- a/dist/threads/lib/threads.pm
+++ b/dist/threads/lib/threads.pm
@@ -5,7 +5,7 @@ use 5.008;
 use strict;
 use warnings;
 
-our $VERSION = '2.25';      # remember to update version in POD!
+our $VERSION = '2.26';      # remember to update version in POD!
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -134,7 +134,7 @@ threads - Perl interpreter-based threads
 
 =head1 VERSION
 
-This document describes threads version 2.25
+This document describes threads version 2.26
 
 =head1 WARNING
 

--- a/dist/threads/threads.xs
+++ b/dist/threads/threads.xs
@@ -421,7 +421,7 @@ STATIC const MGVTBL ithread_vtbl = {
     ithread_mg_free,    /* free */
     0,                  /* copy */
     ithread_mg_dup,     /* dup */
-#if (PERL_VERSION > 8) || (PERL_VERSION == 8 && PERL_SUBVERSION > 8)
+#if PERL_VERSION_GT(5,8,8)
     0                   /* local */
 #endif
 };
@@ -751,7 +751,7 @@ S_ithread_create(
     AV          *params;
     SV          **array;
 
-#if PERL_VERSION <= 8 && PERL_SUBVERSION <= 7
+#if PERL_VERSION_LE(5,8,7)
     SV         **tmps_tmp = PL_tmps_stack;
     IV           tmps_ix  = PL_tmps_ix;
 #endif
@@ -849,7 +849,7 @@ S_ithread_create(
      * context for the duration of our work for new interpreter.
      */
     {
-#if (PERL_VERSION > 13) || (PERL_VERSION == 13 && PERL_SUBVERSION > 1)
+#if PERL_VERSION_GE(5,13,2)
         CLONE_PARAMS *clone_param = Perl_clone_params_new(aTHX, thread->interp);
 #else
         CLONE_PARAMS clone_param_s;
@@ -859,7 +859,7 @@ S_ithread_create(
 
         MY_CXT_CLONE;
 
-#if (PERL_VERSION < 13) || (PERL_VERSION == 13 && PERL_SUBVERSION <= 1)
+#if PERL_VERSION_LT(5,13,2)
         clone_param->flags = 0;
 #endif
 
@@ -886,7 +886,7 @@ S_ithread_create(
            perl_clone() and sv_dup_inc(). Hence copy the parameters
            somewhere under our control first, before duplicating.  */
         if (num_params) {
-#if (PERL_VERSION > 8)
+#if PERL_VERSION_GE(5,9,0)
             Copy(parent_perl->Istack_base + params_start, array, num_params, SV *);
 #else
             Copy(parent_perl->Tstack_base + params_start, array, num_params, SV *);
@@ -897,11 +897,11 @@ S_ithread_create(
             }
         }
 
-#if (PERL_VERSION > 13) || (PERL_VERSION == 13 && PERL_SUBVERSION > 1)
+#if PERL_VERSION_GE(5,13,2)
         Perl_clone_params_del(clone_param);
 #endif
 
-#if PERL_VERSION <= 8 && PERL_SUBVERSION <= 7
+#if PERL_VERSION_LT(5,8,8)
         /* The code below checks that anything living on the tmps stack and
          * has been cloned (so it lives in the ptr_table) has a refcount
          * higher than 0.
@@ -1339,7 +1339,7 @@ ithread_join(...)
         /* Get the return value from the call_sv */
         /* Objects do not survive this process - FIXME */
         if ((thread->gimme & G_WANT) != G_VOID) {
-#if (PERL_VERSION < 13) || (PERL_VERSION == 13 && PERL_SUBVERSION <= 1)
+#if PERL_VERSION_LT(5,13,2)
             AV *params_copy;
             PerlInterpreter *other_perl;
             CLONE_PARAMS clone_params;
@@ -1766,7 +1766,7 @@ ithread_error(...)
 
         /* If thread died, then clone the error into the calling thread */
         if (thread->state & PERL_ITHR_DIED) {
-#if (PERL_VERSION < 13) || (PERL_VERSION == 13 && PERL_SUBVERSION <= 1)
+#if PERL_VERSION_LT(5,13,2)
             PerlInterpreter *other_perl;
             CLONE_PARAMS clone_params;
             ithread *current_thread;


### PR DESCRIPTION
Use new core PERL_VERSION compare macros rather than a direct check using `PERL_VERSION` without checking `PERL_REVISION`.

When bumping thread with this change we need to make sure to use the last version of `ppport.h`

Pre required changes for #18020 but can be submitted and reviewed as their own earlier.