### PR TITLE
Storable: use PERL_COMPARE macros

### DIFF
--- a/dist/Storable/Storable.pm
+++ b/dist/Storable/Storable.pm
@@ -27,8 +27,9 @@ our @EXPORT_OK = qw(
 
 our ($canonical, $forgive_me);
 
+our $VERSION;
 BEGIN {
-  our $VERSION = '3.21';
+  $VERSION = '3.22';
 }
 
 our $recursion_limit;

--- a/dist/Storable/t/malice.t
+++ b/dist/Storable/t/malice.t
@@ -63,7 +63,7 @@ sub test_hash {
   is (ref $clone, "HASH", "Get hash back");
   is (scalar keys %$clone, 1, "with 1 key");
   is ((keys %$clone)[0], "perl", "which is correct");
-  is ($clone->{perl}, "rules");
+  is ($clone->{perl}, "rules", "Got expected value when looking up key in clone");
 }
 
 sub test_header {
@@ -238,7 +238,7 @@ sub test_things {
   }
 }
 
-ok (defined store(\%hash, $file));
+ok (defined store(\%hash, $file), "store() returned defined value");
 
 my $expected = 20 + length ($file_magic_str) + $other_magic + $fancy;
 my $length = -s $file;
@@ -266,7 +266,7 @@ test_things($stored, \&freeze_and_thaw, 'string');
 # Network order.
 unlink $file or die "Can't unlink '$file': $!";
 
-ok (defined nstore(\%hash, $file));
+ok (defined nstore(\%hash, $file), "nstore() returned defined value");
 
 $expected = 20 + length ($file_magic_str) + $network_magic + $fancy;
 $length = -s $file;


### PR DESCRIPTION
Use new PERL_COMPARE macros in Storable, and fix an issue where a variable is defined inside a `BEGIN` block.
When bumping Storable with this change we would need to make sure to use the last version of ppport.h

Tag some unit tests with some missing ~labels.