### PR TITLE
skip flaky port test on windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -248,6 +248,7 @@ Christian Burger               <burger@terra.mpikg-teltow.mpg.de>
 Christian Hansen               <chansen@cpan.org>
 Christian Kirsch               <ck@held.mind.de>
 Christian Millour              <cm.perl@abtela.com>
+Christian Walde (Mithaldu)     <walde.christian@gmail.com>
 Christian Winter               <bitpoet@linux-config.de>
 Christoph Lamprecht            <ch.l.ngre@online.de>
 Christophe Grosjean            <christophe.grosjean@gmail.com>

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -852,6 +852,7 @@ use File::Glob qw(:case);
                 t/000_load.t
                 t/001_new.t
                 t/010_pingecho.t
+                t/450_service.t
                 t/500_ping_icmp.t
                 t/501_ping_icmpv6.t
             }

--- a/dist/Net-Ping/lib/Net/Ping.pm
+++ b/dist/Net-Ping/lib/Net/Ping.pm
@@ -21,7 +21,7 @@ use Time::HiRes;
 @ISA = qw(Exporter);
 @EXPORT = qw(pingecho);
 @EXPORT_OK = qw(wakeonlan);
-$VERSION = "2.73";
+$VERSION = "2.73_01";
 
 # Globals
 

--- a/dist/Net-Ping/t/450_service.t
+++ b/dist/Net-Ping/t/450_service.t
@@ -78,7 +78,7 @@ is($p->ping("127.0.0.1"), 1, 'first port is reachable');
 $p->{port_num} = $port2;
 
 {
-    local $TODO = "Believed not to work on $^O" if $^O =~ /^(?:hpux|os390|freebsd)$/;
+    local $TODO = "Believed not to work on $^O" if $^O =~ /^(?:hpux|MSWin32|os390|freebsd)$/;
     is($p->ping("127.0.0.1"), 1, 'second port is reachable');
 }
 

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -18,6 +18,7 @@ NEXT cpan/NEXT/t/next.t 66fd60eb0f75b6f3eea95d1dee745f9a7a348146
 Net::Ping dist/Net-Ping/t/000_load.t deff5dc2ca54dae28cb19d3631427db127279ac2
 Net::Ping dist/Net-Ping/t/001_new.t 7b24e05672e22edfe3e6b5cc0277f815efe557e5
 Net::Ping dist/Net-Ping/t/010_pingecho.t 218d7a9ee5b6d03ba2544210acaf6585f8dc5503
+Net::Ping dist/Net-Ping/t/450_service.t f6578680f2872d7fc9f24dd75388d55654761875
 Net::Ping dist/Net-Ping/t/500_ping_icmp.t 3eeb60181c01b85f876bd6658644548fdf2e24d4
 Net::Ping dist/Net-Ping/t/501_ping_icmpv6.t 54373de5858f8fb7e078e4998a4b3b8dbca91783
 Pod::Checker cpan/Pod-Checker/t/pod/contains_bad_pod.xr 73538fd80dfe6e19ad561fe034009b44460208f6


### PR DESCRIPTION
Fix #17992

The test being skipped there is unreliable on windows.
Possibly @leonerd has a better idea, but in the meantime
I think it's fine to simply skip that one.

(cherry picked from commit 10e96ffd8a056ee32854ea3dcb89d99d9411ac67)
Signed-off-by: Nicolas R <atoomic@cpan.org>