### PR TITLE
Add a hint to t/porting/regen.t

### DIFF
--- a/regen/regen_lib.pl
+++ b/regen/regen_lib.pl
@@ -96,7 +96,7 @@ sub close_and_rename {
         }
         if ($fail) {
             print STDOUT "not ok - $0 $final_name\n";
-            print STDERR "$fail\n";
+            die "$fail\n";
         } else {
             print STDOUT "ok - $0 $final_name\n";
         }
@@ -204,6 +204,8 @@ sub read_only_bottom_close_and_rename {
     print $fh "\n$comment\n";
 
     close_and_rename($fh);
+
+    return;
 }
 
 sub tab {

--- a/t/porting/regen.t
+++ b/t/porting/regen.t
@@ -105,7 +105,12 @@ OUTER: foreach my $file (@files) {
 }
 
 foreach (@progs) {
-    my $command = "$^X -I. $_ --tap";
+    my $args = qq[-Ilib $_ --tap];
+    diag("./perl $args");
+    my $command = "$^X $args";
     system $command
-        and die "Failed to run $command: $?";
+        and die <<~"HINT";
+    Hint:  A failure in this file can often be corrected by running:
+     ./perl -Ilib $_
+HINT
 }


### PR DESCRIPTION
Also use 'lib' instead of '.'
when running the regen script with tap output
abort on the first failure so we advertise
the command to run to fix the issue.