### PR TITLE
Make pod2html remove leading whitespace from literal blocks

### DIFF
--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -367,6 +367,9 @@ sub pod2html {
 
     # set options for input parser
     my $parser = Pod::Simple::SimpleTree->new;
+    # Normalize whitespace indenting
+    $parser->strip_verbatim_indent(\&trim_leading_whitespace);
+
     $parser->codes_in_verbatim(0);
     $parser->accept_targets(qw(html HTML));
     $parser->no_errata_section(!$Poderrors); # note the inverse
@@ -840,6 +843,35 @@ sub relativize_url {
     }
 
     return $rel_path;
+}
+
+# Remove any level of indentation (spaces or tabs) from each code block consistently
+# Borrowed from: https://metacpan.org/source/HAARG/MetaCPAN-Pod-XHTML-0.002001/lib/Pod/Simple/Role/StripVerbatimIndent.pm
+sub trim_leading_whitespace {
+    my ($para)    = @_;
+    my $tab_width = 4;
+
+    # Start by converting tabs to spaces
+    for my $line (@$para) {
+        # Count how many tabs on the beginnging of the line
+        my ($tabs)    = $line =~ /^(\t*)/;
+        my $tab_count = length($tabs);
+
+        # Remove all the tabs, and add them back as spaces
+        $line =~ s/^\t+//g;
+        $line = (" " x ($tab_count * $tab_width)) . $line;
+    }
+
+    # Find the line with the least amount of indent, as that's our "base"
+    my @indent_levels = (sort(map { $_ =~ /^( *)./mg } @$para));
+    my $indent        = $indent_levels[0] || "";
+
+    # Remove the "base" amount of indent from each line
+    foreach (@$para) {
+        $_ =~ s/^\Q$indent//mg;
+    }
+
+    return;
 }
 
 1;

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -846,7 +846,7 @@ sub relativize_url {
 }
 
 # Remove any level of indentation (spaces or tabs) from each code block consistently
-# Borrowed from: https://metacpan.org/source/HAARG/MetaCPAN-Pod-XHTML-0.002001/lib/Pod/Simple/Role/StripVerbatimIndent.pm
+# Adapted from: https://metacpan.org/source/HAARG/MetaCPAN-Pod-XHTML-0.002001/lib/Pod/Simple/Role/StripVerbatimIndent.pm
 sub trim_leading_whitespace {
     my ($para)    = @_;
     my $tab_width = 4;

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -16,6 +16,7 @@ use File::Spec::Unix;
 use Getopt::Long;
 use Pod::Simple::Search;
 use Pod::Simple::SimpleTree ();
+use Text::Tabs;
 use locale; # make \w work right in non-ASCII lands
 
 =head1 NAME
@@ -848,19 +849,11 @@ sub relativize_url {
 # Remove any level of indentation (spaces or tabs) from each code block consistently
 # Adapted from: https://metacpan.org/source/HAARG/MetaCPAN-Pod-XHTML-0.002001/lib/Pod/Simple/Role/StripVerbatimIndent.pm
 sub trim_leading_whitespace {
-    my ($para)    = @_;
-    my $tab_width = 4;
+    my ($para) = @_;
 
     # Start by converting tabs to spaces
-    for my $line (@$para) {
-        # Count how many tabs on the beginnging of the line
-        my ($tabs)    = $line =~ /^(\t*)/;
-        my $tab_count = length($tabs);
-
-        # Remove all the tabs, and add them back as spaces
-        $line =~ s/^\t+//g;
-        $line = (" " x ($tab_count * $tab_width)) . $line;
-    }
+	$tabstop = 4;
+	@$para   = Text::Tabs::expand(@$para);
 
     # Find the line with the least amount of indent, as that's our "base"
     my @indent_levels = (sort(map { $_ =~ /^( *)./mg } @$para));

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -852,8 +852,7 @@ sub trim_leading_whitespace {
     my ($para) = @_;
 
     # Start by converting tabs to spaces
-	$tabstop = 4;
-	@$para   = Text::Tabs::expand(@$para);
+    @$para = Text::Tabs::expand(@$para);
 
     # Find the line with the least amount of indent, as that's our "base"
     my @indent_levels = (sort(map { $_ =~ /^( *)./mg } @$para));

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -2,7 +2,7 @@ package Pod::Html;
 use strict;
 require Exporter;
 
-our $VERSION = 1.25;
+our $VERSION = 1.26;
 our @ISA = qw(Exporter);
 our @EXPORT = qw(pod2html htmlify);
 our @EXPORT_OK = qw(anchorify relativize_url);

--- a/ext/Pod-Html/t/htmldir1.t
+++ b/ext/Pod-Html/t/htmldir1.t
@@ -72,7 +72,7 @@ __DATA__
 
 <h1 id="LINKS">LINKS</h1>
 
-<pre><code>  Verbatim B&lt;means&gt; verbatim.</code></pre>
+<pre><code>Verbatim B&lt;means&gt; verbatim.</code></pre>
 
 <p>Normal text, a <a>link</a> to nowhere,</p>
 

--- a/ext/Pod-Html/t/htmlview.t
+++ b/ext/Pod-Html/t/htmlview.t
@@ -47,7 +47,7 @@ __DATA__
 
 <pre><code>use My::Module;
 
-    my $module = My::Module-&gt;new();</code></pre>
+my $module = My::Module-&gt;new();</code></pre>
 
 <h1 id="DESCRIPTION">DESCRIPTION</h1>
 

--- a/ext/Pod-Html/t/htmlview.t
+++ b/ext/Pod-Html/t/htmlview.t
@@ -45,7 +45,7 @@ __DATA__
 
 <h1 id="SYNOPSIS">SYNOPSIS</h1>
 
-<pre><code>    use My::Module;
+<pre><code>use My::Module;
 
     my $module = My::Module-&gt;new();</code></pre>
 
@@ -53,7 +53,7 @@ __DATA__
 
 <p>This is the description.</p>
 
-<pre><code>    Here is a verbatim section.</code></pre>
+<pre><code>Here is a verbatim section.</code></pre>
 
 <p>This is some more regular text.</p>
 
@@ -207,7 +207,7 @@ some text
 
 <p>This is an email link: mailto:foo@bar.com</p>
 
-<pre><code>    This is a link in a verbatim block &lt;a href=&quot;http://perl.org&quot;&gt; Perl &lt;/a&gt;</code></pre>
+<pre><code>This is a link in a verbatim block &lt;a href=&quot;http://perl.org&quot;&gt; Perl &lt;/a&gt;</code></pre>
 
 <h1 id="SEE-ALSO">SEE ALSO</h1>
 


### PR DESCRIPTION
`pod2html` leaves the leading whitespace indentation in the HTML output. This PR removes leading whitespace so the \<pre\> output has an appropriate level of indentation.

This brings pod2html functionality similar to how Metacpan handles whitespace