### PR TITLE
IO::Handle: Fix a spurious error reported for regular file handles

### DIFF
--- a/dist/IO/IO.xs
+++ b/dist/IO/IO.xs
@@ -397,9 +397,9 @@ ferror(handle)
     CODE:
 	if (in)
 #ifdef PerlIO
-	    RETVAL = PerlIO_error(in) || (in != out && PerlIO_error(out));
+	    RETVAL = PerlIO_error(in) || (out && in != out && PerlIO_error(out));
 #else
-	    RETVAL = ferror(in) || (in != out && ferror(out));
+	    RETVAL = ferror(in) || (out && in != out && ferror(out));
 #endif
 	else {
 	    RETVAL = -1;

--- a/dist/IO/t/io_xs.t
+++ b/dist/IO/t/io_xs.t
@@ -11,7 +11,7 @@ BEGIN {
     }
 }
 
-use Test::More tests => 8;
+use Test::More tests => 10;
 use IO::File;
 use IO::Seekable;
 
@@ -68,4 +68,12 @@ SKIP: {
     $fh->clearerr;
     ok(!$fh->error, "check clearerr removed the error");
     close $fh; # silently ignore the error
+}
+
+{
+    # [GH #18019] IO::Handle->error misreported an error after successully
+    # opening a regular file for reading. It was a regression in GH #6799 fix.
+    ok(open(my $fh, '<', __FILE__), "a regular file opened for reading");
+    ok(!$fh->error, "no spurious error reported by error()");
+    close $fh;
 }


### PR DESCRIPTION
89341f87 fix for GH #6799 introduced a regression when calling error()
on an IO::Handle object that was opened for reading a regular file:

$ perl -e 'open my $f, q{<}, q{/etc/hosts} or die; print qq{error\n} if $f->error'
error

In case of a regular file opened for reading, IoOFP() returns NULL and
PerlIO_error(NULL) reports -1. Compare to the case of a file opened
for writing when both IoIFP() and IoOFP() return non-NULL, equaled
pointer.

This patch fixes handling the case of the NULL output stream.

GH #18019