### PR TITLE
Provide a better recommendation for 'Run only under a shell'

### DIFF
--- a/Porting/Glossary
+++ b/Porting/Glossary
@@ -5268,7 +5268,7 @@ startperl (startperl.U):
 	shell. Of course, that leading line must be followed by the classical
 	perl idiom:
 	eval 'exec perl -S $0 ${1+"$@"}'
-	if $running_under_some_shell;
+	if 0; # ^ Run only under a shell
 	to guarantee perl startup should the shell execute the script. Note
 	that this magic incantation is not understood by csh.
 

--- a/README.bs2000
+++ b/README.bs2000
@@ -137,7 +137,7 @@ instead:
 
 : # use perl
     eval 'exec /usr/local/bin/perl -S $0 ${1+"$@"}'
-        if $running_under_some_shell;
+        if 0; # ^ Run only under a shell
 
 =head2 Using Perl in "native" BS2000
 

--- a/pod/perlrun.pod
+++ b/pod/perlrun.pod
@@ -797,7 +797,7 @@ Bourne shell:
 
     #!/usr/bin/perl
     eval 'exec /usr/bin/perl -wS $0 ${1+"$@"}'
-	    if $running_under_some_shell;
+	    if 0; # ^ Run only under a shell
 
 The system ignores the first line and feeds the program to F</bin/sh>,
 which proceeds to try to execute the Perl program as a shell script.
@@ -805,8 +805,8 @@ The shell executes the second line as a normal shell command, and thus
 starts up the Perl interpreter.  On some systems $0 doesn't always
 contain the full pathname, so the L</-S> tells Perl to search for the
 program if necessary.  After Perl locates the program, it parses the
-lines and ignores them because the variable $running_under_some_shell
-is never true.  If the program will be interpreted by csh, you will need
+lines and ignores them because the check 'if 0' is never true.
+If the program will be interpreted by csh, you will need
 to replace C<${1+"$@"}> with C<$*>, even though that doesn't understand
 embedded spaces (and such) in the argument list.  To start up I<sh> rather
 than I<csh>, some systems may have to replace the C<#!> line with a line
@@ -816,7 +816,7 @@ will work under any of I<csh>, I<sh>, or Perl, such as the following:
 
 	eval '(exit $?0)' && eval 'exec perl -wS $0 ${1+"$@"}'
 	& eval 'exec /usr/bin/perl -wS $0 $argv:q'
-		if $running_under_some_shell;
+		if 0; # ^ Run only under a shell
 
 If the filename supplied contains directory separators (and so is an
 absolute or relative pathname), and if that file is not found,

--- a/utils/corelist.PL
+++ b/utils/corelist.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;

--- a/utils/cpan.PL
+++ b/utils/cpan.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;

--- a/utils/enc2xs.PL
+++ b/utils/enc2xs.PL
@@ -31,7 +31,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;

--- a/utils/encguess.PL
+++ b/utils/encguess.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;

--- a/utils/h2ph.PL
+++ b/utils/h2ph.PL
@@ -32,7 +32,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 # In the following, perl variables are not expanded during extraction.

--- a/utils/h2xs.PL
+++ b/utils/h2xs.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 # In the following, perl variables are not expanded during extraction.

--- a/utils/instmodsh.PL
+++ b/utils/instmodsh.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;

--- a/utils/json_pp.PL
+++ b/utils/json_pp.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;

--- a/utils/libnetcfg.PL
+++ b/utils/libnetcfg.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 # In the following, perl variables are not expanded during extraction.

--- a/utils/perlbug.PL
+++ b/utils/perlbug.PL
@@ -47,7 +47,7 @@ my $extract_version = sprintf("%vd", $^V);
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 
 my \$config_tag1 = '$extract_version - $Config{cf_time}';
 

--- a/utils/perlivp.PL
+++ b/utils/perlivp.PL
@@ -30,7 +30,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{'startperl'}
     eval 'exec $Config{'perlpath'} -S \$0 \${1+"\$@"}'
-        if \$running_under_some_shell;
+        if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 print OUT "\n# perlivp $^V\n";

--- a/utils/piconv.PL
+++ b/utils/piconv.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;

--- a/utils/pl2pm.PL
+++ b/utils/pl2pm.PL
@@ -31,7 +31,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 # In the following, perl variables are not expanded during extraction.

--- a/utils/pod2html.PL
+++ b/utils/pod2html.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;

--- a/utils/prove.PL
+++ b/utils/prove.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;

--- a/utils/ptar.PL
+++ b/utils/ptar.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;

--- a/utils/ptardiff.PL
+++ b/utils/ptardiff.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;

--- a/utils/ptargrep.PL
+++ b/utils/ptargrep.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;

--- a/utils/shasum.PL
+++ b/utils/shasum.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;

--- a/utils/splain.PL
+++ b/utils/splain.PL
@@ -38,7 +38,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 print OUT <<'!NO!SUBS!';

--- a/utils/streamzip.PL
+++ b/utils/streamzip.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;

--- a/utils/xsubpp.PL
+++ b/utils/xsubpp.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;

--- a/utils/zipdetails.PL
+++ b/utils/zipdetails.PL
@@ -28,7 +28,7 @@ print "Extracting $file (with variable substitutions)\n";
 print OUT <<"!GROK!THIS!";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-	if \$running_under_some_shell;
+	if 0; # ^ Run only under a shell
 !GROK!THIS!
 
 use File::Spec;


### PR DESCRIPTION
Using an unset variable hides the true intent and
also requires an extra backslash `\$running_under_some_shell`
when used in heredoc.

Note that this could also lead to mistake when using
`\$` in a regular Perl program, as this would be true
and not false as it should be.

Stop recommending the use of an undefined variable for
the shell fallback. Use '0', with a comment
making clear the goal of 'if 0'.