### PR TITLE
Rewrite delimcpy to use memchr and Copy, not per-byte

### DIFF
--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -6795,6 +6795,29 @@ test_toTITLE_utf8(SV * p, int type)
     OUTPUT:
         RETVAL
 
+AV *
+test_delimcpy(SV * from_sv, char delim, STRLEN to_len)
+    PREINIT:
+        char * from;
+        STRLEN from_len;
+        AV *av;
+        I32 retlen;
+        char * from_pos_after_copy;
+        char * to;
+    CODE:
+        Newx(to, to_len, char);
+        from = SvPV(from_sv, from_len);
+        from_pos_after_copy = delimcpy(to, to + to_len,
+                                       from, SvEND(from_sv), delim, &retlen);
+        av = newAV();
+        av_push(av, newSVpvn(to, retlen));
+        av_push(av, newSVuv(retlen));
+        av_push(av, newSVuv(from_pos_after_copy - from));
+        Safefree(to);
+        RETVAL = av;
+    OUTPUT:
+        RETVAL
+
 SV *
 test_Gconvert(SV * number, SV * num_digits)
     PREINIT:

--- a/ext/XS-APItest/t/delimcpy.t
+++ b/ext/XS-APItest/t/delimcpy.t
@@ -1,0 +1,13 @@
+#!perl -w
+use strict;
+
+use Test::More;
+use XS::APItest;
+
+
+my @ret;
+@ret = test_delimcpy('\x\\\x\\x', 'x', 100);
+use Data::Dumper;
+print STDERR Dumper \@ret;
+
+done_testing();

--- a/util.c
+++ b/util.c
@@ -533,45 +533,6 @@ Free_t   Perl_mfree (Malloc_t where)
 
 #endif
 
-/* copy a string up to some (non-backslashed) delimiter, if any.
- * With allow_escape, converts \<delimiter> to <delimiter>, while leaves
- * \<non-delimiter> as-is.
- * Returns the position in the src string of the closing delimiter, if
- * any, or returns fromend otherwise.
- * This is the internal implementation for Perl_delimcpy and
- * Perl_delimcpy_no_escape.
- */
-
-static char *
-S_delimcpy_intern(char *to, const char *toend, const char *from,
-	   const char *fromend, int delim, I32 *retlen,
-	   const bool allow_escape)
-{
-    I32 tolen;
-
-    PERL_ARGS_ASSERT_DELIMCPY;
-
-    for (tolen = 0; from < fromend; from++, tolen++) {
-	if (allow_escape && *from == '\\' && from + 1 < fromend) {
-	    if (from[1] != delim) {
-		if (to < toend)
-		    *to++ = *from;
-		tolen++;
-	    }
-	    from++;
-	}
-	else if (*from == delim)
-	    break;
-	if (to < toend)
-	    *to++ = *from;
-    }
-    if (to < toend)
-	*to = '\0';
-    *retlen = tolen;
-    return (char *)from;
-}
-
-
 /*
 =for apidoc delimcpy_no_escape
 
@@ -626,12 +587,95 @@ Perl_delimcpy_no_escape(char *to, const char *toend, const char *from,
     return (char *) from + copy_len;
 }
 
+/*
+=for apidoc delimcpy
+
+Copy a source buffer to a destination buffer, stopping at (but not including)
+the first occurrence in the source of an unescaped delimiter byte, C<delim>, in
+the source.  By "unescaped", we mean not immediately preceded by a backslash.
+This function does not consider the possibility of the backslash itself being
+escaped.  That is, there is no difference between having an even or odd number
+of backslashes preceding the delimiter  (That may actually be unintended by the
+original authors of this function, and be a bug.)  The distinction is between
+having zero, and non-zero.
+
+The source is the bytes between C<from> and C<fromend> inclusive.  The dest is
+C<to> through C<toend>.
+
+Nothing is copied beyond what fits between C<to> through C<toend>.  If an
+unescaped C<delim> doesn't occur in the source buffer, as much of the source as
+will fit is copied to the destination.
+
+B<The copy strips the escaping backslash from any escaped delimiter>.
+
+The actual number of bytes copied is written to C<*retlen>.  T
+
+If there is room in the destination available after the copy, an extra
+terminating safety NUL byte is written (not included in the returned length).
+
+=cut
+*/
 char *
 Perl_delimcpy(char *to, const char *toend, const char *from, const char *fromend, int delim, I32 *retlen)
 {
+    Ptrdiff_t from_len = fromend - from;
+    Ptrdiff_t to_len = toend - to;
+    char * const orig_to = to;
+
+    /* Only use the minimum of the available source/dest */
+    Ptrdiff_t copy_len = MIN(from_len, to_len);
+
     PERL_ARGS_ASSERT_DELIMCPY;
 
-    return S_delimcpy_intern(to, toend, from, fromend, delim, retlen, 1);
+    assert(copy_len >= 0);
+
+    while (copy_len > 0) {
+        const char * delim_pos;
+        Size_t segment_len;
+
+        /* Look for the next delimiter in the remaining portion of the source
+         * we are allowed to look at (determined by the input bounds). */
+        delim_pos = (const char *) memchr(from, delim, copy_len);
+
+        /* If didn't find it, done looking */
+        if (! delim_pos) {
+            break;
+        }
+
+        /* If the delimiter is not preceeded by a backslash; have found an
+         * unescaped one that ends the copy */
+        if (delim_pos == from || *(delim_pos - 1) != '\\') {
+            copy_len = delim_pos - from;
+            break;
+        }
+
+        /* Copy up to but not including the backslash, then the delimiter.
+         * This has the effect of stripping off the backslash in the copy */
+        segment_len = delim_pos - from;
+
+        Copy(from, to, segment_len, char);
+
+        to += segment_len;
+        *to++ = delim;
+
+        /* Adjust for next iteration */
+        from += segment_len + 1;
+        copy_len -= segment_len;
+    }
+
+    /* Copy anything remaining */
+    Copy(from, to, copy_len, char);
+
+    if (retlen) {
+        *retlen = to + copy_len - orig_to;
+    }
+
+    /* If there is extra space available, add a trailing NUL */
+    if (copy_len < to_len) {
+        to[copy_len] = '\0';
+    }
+
+    return (char *) from + copy_len;
 }
 
 /*


### PR DESCRIPTION
Prior to this commit delimcpy() parsed its input byte-by-byte, looking
for a particular character, and copies the input to the output stopping
just before the first such occurrence.

memchr() is much faster for finding a single character.

The complication is that if the character is preceded by a backslash,
it doesn't count as that character, it is considered to be escaped, and
parsing continues to the first unescaped occurrence, if any.  Each
escaping backslash is not copied.

The new routine looks for the character with memchr, sees if it is
escaped.  If not, Copy does the whole copy at once.  If it is escaped,
it uses Copy up to that backslash, and repeats the process.

I suspect that it is a bug that the routine did not consider the
possibility of the escape itself being escaped, so not counting as
escaping the searched for character.  But I have retained that behavior.