### PR TITLE
use PERL_VERSION compare macro in dual life modules in dist

### DIFF
--- a/dist/Data-Dumper/Dumper.pm
+++ b/dist/Data-Dumper/Dumper.pm
@@ -10,7 +10,7 @@
 package Data::Dumper;
 
 BEGIN {
-    $VERSION = '2.174'; # Don't forget to set version and release
+    $VERSION = '2.175'; # Don't forget to set version and release
 }               # date in POD below!
 
 #$| = 1;
@@ -1467,7 +1467,7 @@ modify it under the same terms as Perl itself.
 
 =head1 VERSION
 
-Version 2.174
+Version 2.175
 
 =head1 SEE ALSO
 

--- a/dist/Data-Dumper/Dumper.xs
+++ b/dist/Data-Dumper/Dumper.xs
@@ -8,7 +8,7 @@
 #  include "ppport.h"
 #endif
 
-#if PERL_VERSION < 8
+#if PERL_VERSION_LT(5,8,0)
 #  define DD_USE_OLD_ID_FORMAT
 #endif
 
@@ -109,7 +109,7 @@ static I32 DD_dump (pTHX_ SV *val, const char *name, STRLEN namelen, SV *retval,
  * length parameter.  This wrongly allowed reading beyond the end of buffer
  * given malformed input */
 
-#if PERL_VERSION <= 6 /* Perl 5.6 and earlier */
+#if PERL_VERSION_LE(5,6,'*') /* Perl 5.6 and earlier */
 
 UV
 Perl_utf8_to_uvchr_buf(pTHX_ U8 *s, U8 *send, STRLEN *retlen)
@@ -125,10 +125,10 @@ Perl_utf8_to_uvchr_buf(pTHX_ U8 *s, U8 *send, STRLEN *retlen)
 #  define utf8_to_uvchr_buf(a,b,c) Perl_utf8_to_uvchr_buf(aTHX_ a,b,c)
 # endif
 
-#endif /* PERL_VERSION <= 6 */
+#endif /* PERL_VERSION_LE(5,6,'*') */
 
 /* Perl 5.7 through part of 5.15 */
-#if PERL_VERSION > 6 && PERL_VERSION <= 15 && ! defined(utf8_to_uvchr_buf)
+#if PERL_VERSION_GE(5,7,0) && PERL_VERSION_LE(5,15,'*') && ! defined(utf8_to_uvchr_buf)
 
 UV
 Perl_utf8_to_uvchr_buf(pTHX_ U8 *s, U8 *send, STRLEN *retlen)
@@ -146,12 +146,12 @@ Perl_utf8_to_uvchr_buf(pTHX_ U8 *s, U8 *send, STRLEN *retlen)
 #  define utf8_to_uvchr_buf(a,b,c) Perl_utf8_to_uvchr_buf(aTHX_ a,b,c)
 # endif
 
-#endif /* PERL_VERSION > 6 && <= 15 */
+#endif /* Perl 5.7 through part of 5.15 */
 
 /* Changes in 5.7 series mean that now IOK is only set if scalar is
    precisely integer but in 5.6 and earlier we need to do a more
    complex test  */
-#if PERL_VERSION <= 6
+#if PERL_VERSION_LT(5,7,0)
 #define DD_is_integer(sv) (SvIOK(sv) && (SvIsUV(val) ? SvUV(sv) == SvNV(sv) : SvIV(sv) == SvNV(sv)))
 #else
 #define DD_is_integer(sv) SvIOK(sv)
@@ -429,7 +429,7 @@ esc_q_utf8(pTHX_ SV* sv, const char *src, STRLEN slen, I32 do_utf8, I32 useqq)
                 * first byte */
                 increment = (k == 0 && *s != '\0') ? 1 : UTF8SKIP(s);
 
-#if PERL_VERSION < 10
+#if PERL_VERSION_LT(5,10,0)
                 sprintf(r, "\\x{%" UVxf "}", k);
                 r += strlen(r);
                 /* my_sprintf is not supported by ppport.h */
@@ -565,13 +565,13 @@ deparsed_output(pTHX_ SV *val)
      * the stack moving underneath anything that directly or indirectly calls
      * Perl_load_module()". If we're in an older Perl, we can't rely on that
      * stack, and must create a fresh sacrificial stack of our own. */
-#if PERL_VERSION < 20
+#if PERL_VERSION_LT(5,20,0)
     PUSHSTACKi(PERLSI_REQUIRE);
 #endif
 
     load_module(PERL_LOADMOD_NOIMPORT, pkg, 0);
 
-#if PERL_VERSION < 20
+#if PERL_VERSION_LT(5,20,0)
     POPSTACK;
     SPAGAIN;
 #endif
@@ -768,9 +768,9 @@ DD_dump(pTHX_ SV *val, const char *name, STRLEN namelen, SV *retval, HV *seenhv,
         /* regexps dont have to be blessed into package "Regexp"
          * they can be blessed into any package. 
          */
-#if PERL_VERSION < 8
+#if PERL_VERSION_LT(5,8,0)
 	if (realpack && *realpack == 'R' && strEQ(realpack, "Regexp")) 
-#elif PERL_VERSION < 11
+#elif PERL_VERSION_LT(5,11,0)
         if (realpack && realtype == SVt_PVMG && mg_find(ival, PERL_MAGIC_qr))
 #else        
         if (realpack && realtype == SVt_REGEXP) 
@@ -872,7 +872,7 @@ DD_dump(pTHX_ SV *val, const char *name, STRLEN namelen, SV *retval, HV *seenhv,
 	      sv_catsv(retval, sv_flags);
 	} 
         else if (
-#if PERL_VERSION < 9
+#if PERL_VERSION_LT(5,9,0)
 		realtype <= SVt_PVBM
 #else
 		realtype <= SVt_PVMG
@@ -955,7 +955,7 @@ DD_dump(pTHX_ SV *val, const char *name, STRLEN namelen, SV *retval, HV *seenhv,
 		
 		ilen = inamelen;
 		sv_setiv(ixsv, ix);
-#if PERL_VERSION < 10
+#if PERL_VERSION_LT(5,10,0)
                 (void) sprintf(iname+ilen, "%" IVdf, (IV)ix);
 		ilen = strlen(iname);
 #else
@@ -1027,7 +1027,7 @@ DD_dump(pTHX_ SV *val, const char *name, STRLEN namelen, SV *retval, HV *seenhv,
 	
 	    /* If requested, get a sorted/filtered array of hash keys */
 	    if (style->sortkeys) {
-#if PERL_VERSION >= 8
+#if PERL_VERSION_GE(5,8,0)
 		if (style->sortkeys == &PL_sv_yes) {
 		    keys = newAV();
 		    (void)hv_iterinit((HV*)ival);
@@ -1347,7 +1347,7 @@ DD_dump(pTHX_ SV *val, const char *name, STRLEN namelen, SV *retval, HV *seenhv,
 	    if(i) ++c, --i;			/* just get the name */
 	    if (memBEGINs(c, i, "main::")) {
 		c += 4;
-#if PERL_VERSION < 7
+#if PERL_VERSION_LT(5,7,0)
 		if (i == 6 || (i == 7 && c[6] == '\0'))
 #else
 		if (i == 6)
@@ -1424,9 +1424,9 @@ DD_dump(pTHX_ SV *val, const char *name, STRLEN namelen, SV *retval, HV *seenhv,
 	}
 #ifdef SvVOK
 	else if (SvMAGICAL(val) && (mg = mg_find(val, 'V'))) {
-# if !defined(PL_vtbl_vstring) && PERL_VERSION < 17
+# if !defined(PL_vtbl_vstring) && PERL_VERSION_LT(5,17,0)
 	    SV * const vecsv = sv_newmortal();
-#  if PERL_VERSION < 10
+#  if PERL_VERSION_LT(5,10,0)
 	    scan_vstring(mg->mg_ptr, vecsv);
 #  else
 	    scan_vstring(mg->mg_ptr, mg->mg_ptr + mg->mg_len, vecsv);
@@ -1600,7 +1600,8 @@ Data_Dumper_Dumpxs(href, ...)
                         style.sortkeys = NULL;
                     else if (SvROK(sv) && SvTYPE(SvRV(sv)) == SVt_PVCV)
                         style.sortkeys = sv;
-                    else if (PERL_VERSION < 8)
+                    else
+#if PERL_VERSION_LT(5,8,0)
                         /* 5.6 doesn't make sortsv() available to XS code,
                          * so we must use this helper instead. Note that we
                          * always allocate this mortal SV, but it will be
@@ -1608,9 +1609,10 @@ Data_Dumper_Dumpxs(href, ...)
                          * while dumping recursively; an older version
                          * allocated it lazily as needed. */
                         style.sortkeys = sv_2mortal(newSVpvs("Data::Dumper::_sortkeys"));
-                    else
+#else
                         /* flag to use sortsv() for sorting hash keys */
                         style.sortkeys = &PL_sv_yes;
+#endif
 		}
 		postav = newAV();
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -11,7 +11,7 @@ use Symbol;
 
 our $VERSION;
 BEGIN {
-  $VERSION = '3.40';
+  $VERSION = '3.41';
   require ExtUtils::ParseXS::Constants; ExtUtils::ParseXS::Constants->VERSION($VERSION);
   require ExtUtils::ParseXS::CountLines; ExtUtils::ParseXS::CountLines->VERSION($VERSION);
   require ExtUtils::ParseXS::Utilities; ExtUtils::ParseXS::Utilities->VERSION($VERSION);
@@ -911,7 +911,7 @@ EOF
   #-Wall: if there is no $self->{Full_func_name} there are no xsubs in this .xs
   #so 'file' is unused
   print Q(<<"EOF") if $self->{Full_func_name};
-##if (PERL_REVISION == 5 && PERL_VERSION < 9)
+##if PERL_VERSION_LT(5, 9, 0)
 #    char* file = __FILE__;
 ##else
 #    const char* file = __FILE__;
@@ -954,7 +954,7 @@ EOF
 
   print Q(<<"EOF") if ($self->{Overload});
 #    /* register the overloading (type 'A') magic */
-##if (PERL_REVISION == 5 && PERL_VERSION < 9)
+##if PERL_VERSION_LT(5, 9, 0)
 #    PL_amagic_generation++;
 ##endif
 #    /* The magic for overload gets a GV* via gv_fetchmeth as */

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Symbol;
 
-our $VERSION = '3.40';
+our $VERSION = '3.41';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
@@ -1,7 +1,7 @@
 package ExtUtils::ParseXS::CountLines;
 use strict;
 
-our $VERSION = '3.40';
+our $VERSION = '3.41';
 
 our $SECTION_END_MARKER;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
@@ -2,7 +2,7 @@ package ExtUtils::ParseXS::Eval;
 use strict;
 use warnings;
 
-our $VERSION = '3.40';
+our $VERSION = '3.41';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
@@ -5,7 +5,7 @@ use Exporter;
 use File::Spec;
 use ExtUtils::ParseXS::Constants ();
 
-our $VERSION = '3.40';
+our $VERSION = '3.41';
 
 our (@ISA, @EXPORT_OK);
 @ISA = qw(Exporter);

--- a/dist/IO/IO.xs
+++ b/dist/IO/IO.xs
@@ -194,7 +194,7 @@ fgetpos(handle)
     CODE:
 	if (handle) {
 #ifdef PerlIO
-#if PERL_VERSION < 8
+#if PERL_VERSION_LT(5,8,0)
 	    Fpos_t pos;
 	    ST(0) = sv_newmortal();
 	    if (PerlIO_getpos(handle, &pos) != 0) {
@@ -214,7 +214,7 @@ fgetpos(handle)
 	    if (fgetpos(handle, &pos)) {
 		ST(0) = &PL_sv_undef;
 	    } else {
-#  if PERL_VERSION >= 11
+#  if PERL_VERSION_GE(5,11,0)
 		ST(0) = newSVpvn_flags((char*)&pos, sizeof(Fpos_t), SVs_TEMP);
 #  else
 		ST(0) = sv_2mortal(newSVpvn((char*)&pos, sizeof(Fpos_t)));
@@ -234,7 +234,7 @@ fsetpos(handle, pos)
     CODE:
 	if (handle) {
 #ifdef PerlIO
-#if PERL_VERSION < 8
+#if PERL_VERSION_LT(5,8,0)
 	    char *p;
 	    STRLEN len;
 	    if (SvOK(pos) && (p = SvPV(pos,len)) && len == sizeof(Fpos_t)) {

--- a/dist/Unicode-Normalize/Normalize.pm
+++ b/dist/Unicode-Normalize/Normalize.pm
@@ -16,7 +16,7 @@ use Carp;
 
 no warnings 'utf8';
 
-our $VERSION = '1.27';
+our $VERSION = '1.28';
 our $PACKAGE = __PACKAGE__;
 
 our @EXPORT = qw( NFC NFD NFKC NFKD );

--- a/dist/Unicode-Normalize/Normalize.xs
+++ b/dist/Unicode-Normalize/Normalize.xs
@@ -23,7 +23,7 @@
 /* The generated normalization tables since v5.20 are in native character set
  * terms.  Prior to that, they were in Unicode terms.  So we use 'uvchr' for
  * later perls, and redefine that to be 'uvuni' for earlier ones */
-#if PERL_VERSION < 20
+#if PERL_VERSION_LT(5,20,0)
 #   undef uvchr_to_utf8
 #   ifdef uvuni_to_utf8
 #       define uvchr_to_utf8   uvuni_to_utf8

--- a/dist/threads-shared/lib/threads/shared.pm
+++ b/dist/threads-shared/lib/threads/shared.pm
@@ -8,7 +8,7 @@ use Config;
 
 use Scalar::Util qw(reftype refaddr blessed);
 
-our $VERSION = '1.61'; # Please update the pod, too.
+our $VERSION = '1.62'; # Please update the pod, too.
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -196,7 +196,7 @@ threads::shared - Perl extension for sharing data structures between threads
 
 =head1 VERSION
 
-This document describes threads::shared version 1.61
+This document describes threads::shared version 1.62
 
 =head1 SYNOPSIS
 

--- a/dist/threads-shared/shared.xs
+++ b/dist/threads-shared/shared.xs
@@ -1183,7 +1183,7 @@ sharedsv_array_mg_free(pTHX_ SV *sv, MAGIC *mg)
  * This is called when perl is about to access an element of
  * the array -
  */
-#if PERL_VERSION >= 11
+#if PERL_VERSION_GE(5,11,0)
 static int
 sharedsv_array_mg_copy(pTHX_ SV *sv, MAGIC* mg,
                        SV *nsv, const char *name, I32 namlen)


### PR DESCRIPTION
Use the PERL_VERSION_* compare macro instead of using `PERL_VERSION` in Dual Life modules from dist/
