### PR TITLE
lib/Symbol.t: Exercise qualify_to_ref()

### DIFF
--- a/lib/Symbol.t
+++ b/lib/Symbol.t
@@ -5,7 +5,7 @@ BEGIN {
     @INC = '../lib';
 }
 
-use Test::More tests => 26;
+use Test::More tests => 31;
 
 BEGIN { $_ = 'foo'; }  # because Symbol used to clobber $_
 
@@ -15,10 +15,10 @@ ok( $_ eq 'foo', 'check $_ clobbering' );
 
 
 # First test gensym()
-$sym1 = gensym;
+my $sym1 = gensym;
 ok( ref($sym1) eq 'GLOB', 'gensym() returns a GLOB' );
 
-$sym2 = gensym;
+my $sym2 = gensym;
 
 ok( $sym1 ne $sym2, 'gensym() returns a different GLOB' );
 
@@ -33,7 +33,7 @@ use Symbol qw(geniosym);
 $sym1 = geniosym;
 like( $sym1, qr/=IO\(/, 'got an IO ref' );
 
-$FOO = 'Eymascalar';
+our $FOO = 'Eymascalar';
 *FOO = $sym1;
 
 is( $sym1, *FOO{IO}, 'assigns into glob OK' );
@@ -51,7 +51,7 @@ is( $FOO, 'Eymascalar', 'leaves scalar alone' );
 # Test qualify()
 package foo;
 
-use Symbol qw(qualify);  # must import into this package too
+use Symbol qw(qualify qualify_to_ref);  # must import into this package too
 
 ::ok( qualify("x") eq "foo::x",		'qualify() with a simple identifier' );
 ::ok( qualify("x", "FOO") eq "FOO::x",	'qualify() with a package' );
@@ -65,6 +65,25 @@ use Symbol qw(qualify);  # must import into this package too
     'qualify() with an identifier starting with a _' );
 ::ok( qualify("^FOO") eq "main::\cFOO",
     'qualify() with an identifier starting with a ^' );
+::is( qualify('\*x'), 'foo::\*x',
+    'qualify() reference to a typeglob' );
+::is( qualify('\*x', 'FOO'), 'FOO::\*x',
+    'qualify() reference to a typeglob' );
+{
+    use strict 'refs';
+    my $fhref = qualify_to_ref("main::STDOUT");
+    ::is( ref($fhref), 'GLOB',
+        'qualify_to_ref() returned ref to typeglob (1 argument)');
+
+    my $key = 'baz';
+    my $ref_to_key  = qualify_to_ref( $key, __PACKAGE__ );
+    ::is( ref($ref_to_key), 'GLOB',
+        'qualify_to_ref() returned ref to typeglob (2 arguments)');
+
+    my $ref_to_key_scalar = *{$ref_to_key}{SCALAR};
+    ::is( ref($ref_to_key_scalar), 'SCALAR',
+        'able to get SCALAR entry in typeglob');
+}
 
 # tests for delete_package
 package main;


### PR DESCRIPTION
Symbol::qualify_to_ref() has not previously been exercised in this test
file.  Do so.  Also, exercise certain usages of qualify() that are
documented in SYNOPSIS but were also previously unexercised.

Bring test file into compliance with strictures.

For: https://github.com/Perl/perl5/issues/18065