### PR TITLE
Perl_av_extend_guts: initialize elements via Zero() rather than while loop(s)

### DIFF
--- a/av.c
+++ b/av.c
@@ -97,7 +97,7 @@ Perl_av_extend(pTHX_ AV *av, SSize_t key)
 /* The guts of av_extend.  *Not* for general use! */
 void
 Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp,
-			  SV ***arrayp)
+                      SV ***arrayp)
 {
     PERL_ARGS_ASSERT_AV_EXTEND_GUTS;
 
@@ -106,102 +106,98 @@ Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp,
             "panic: av_extend_guts() negative count (%" IVdf ")", (IV)key);
 
     if (key > *maxp) {
-	SV** ary;
-	SSize_t tmp;
-	SSize_t newmax;
+        SV** ary;
+        SSize_t tmp;
+        SSize_t newmax;
 
-	if (av && *allocp != *arrayp) {
-	    ary = *allocp + AvFILLp(av) + 1;
-	    tmp = *arrayp - *allocp;
-	    Move(*arrayp, *allocp, AvFILLp(av)+1, SV*);
-	    *maxp += tmp;
-	    *arrayp = *allocp;
-	    if (AvREAL(av)) {
-		while (tmp)
-		    ary[--tmp] = NULL;
-	    }
-	    if (key > *maxp - 10) {
-		newmax = key + *maxp;
-		goto resize;
-	    }
-	}
-	else {
-	    if (*allocp) {
+        if (av && *allocp != *arrayp) {
+            ary = *allocp + AvFILLp(av) + 1;
+            tmp = *arrayp - *allocp;
+            Move(*arrayp, *allocp, AvFILLp(av)+1, SV*);
+            *maxp += tmp;
+            *arrayp = *allocp;
+            if (AvREAL(av)) {
+                while (tmp)
+                    ary[--tmp] = NULL;
+            }
+            if (key > *maxp - 10) {
+                newmax = key + *maxp;
+                goto resize;
+            }
+        } else if (*allocp) {
 
 #ifdef Perl_safesysmalloc_size
-		/* Whilst it would be quite possible to move this logic around
-		   (as I did in the SV code), so as to set AvMAX(av) early,
-		   based on calling Perl_safesysmalloc_size() immediately after
-		   allocation, I'm not convinced that it is a great idea here.
-		   In an array we have to loop round setting everything to
-		   NULL, which means writing to memory, potentially lots
-		   of it, whereas for the SV buffer case we don't touch the
-		   "bonus" memory. So there there is no cost in telling the
-		   world about it, whereas here we have to do work before we can
-		   tell the world about it, and that work involves writing to
-		   memory that might never be read. So, I feel, better to keep
-		   the current lazy system of only writing to it if our caller
-		   has a need for more space. NWC  */
-		newmax = Perl_safesysmalloc_size((void*)*allocp) /
-		    sizeof(const SV *) - 1;
+            /* Whilst it would be quite possible to move this logic around
+               (as I did in the SV code), so as to set AvMAX(av) early,
+               based on calling Perl_safesysmalloc_size() immediately after
+               allocation, I'm not convinced that it is a great idea here.
+               In an array we have to loop round setting everything to
+               NULL, which means writing to memory, potentially lots
+               of it, whereas for the SV buffer case we don't touch the
+               "bonus" memory. So there there is no cost in telling the
+               world about it, whereas here we have to do work before we can
+               tell the world about it, and that work involves writing to
+               memory that might never be read. So, I feel, better to keep
+               the current lazy system of only writing to it if our caller
+               has a need for more space. NWC  */
+            newmax = Perl_safesysmalloc_size((void*)*allocp) /
+                sizeof(const SV *) - 1;
 
-		if (key <= newmax) 
-		    goto resized;
+            if (key <= newmax)
+                goto resized;
 #endif 
-                /* overflow-safe version of newmax = key + *maxp/5 */
-		newmax = *maxp / 5;
-                newmax = (key > SSize_t_MAX - newmax)
-                            ? SSize_t_MAX : key + newmax;
-	      resize:
-		{
-                    /* it should really be newmax+1 here, but if newmax
-                     * happens to equal SSize_t_MAX, then newmax+1 is
-                     * undefined. This means technically we croak one
-                     * index lower than we should in theory; in practice
-                     * its unlikely the system has SSize_t_MAX/sizeof(SV*)
-                     * bytes to spare! */
-		    MEM_WRAP_CHECK_s(newmax, SV*, "Out of memory during array extend");
-		}
+            /* overflow-safe version of newmax = key + *maxp/5 */
+            newmax = *maxp / 5;
+            newmax = (key > SSize_t_MAX - newmax)
+                        ? SSize_t_MAX : key + newmax;
+          resize:
+            {
+                /* it should really be newmax+1 here, but if newmax
+                 * happens to equal SSize_t_MAX, then newmax+1 is
+                 * undefined. This means technically we croak one
+                 * index lower than we should in theory; in practice
+                 * its unlikely the system has SSize_t_MAX/sizeof(SV*)
+                 * bytes to spare! */
+                MEM_WRAP_CHECK_s(newmax, SV*, "Out of memory during array extend");
+            }
 #ifdef STRESS_REALLOC
-		{
-		    SV ** const old_alloc = *allocp;
-		    Newx(*allocp, newmax+1, SV*);
-		    Copy(old_alloc, *allocp, *maxp + 1, SV*);
-		    Safefree(old_alloc);
-		}
+            {
+                SV ** const old_alloc = *allocp;
+                Newx(*allocp, newmax+1, SV*);
+                Copy(old_alloc, *allocp, *maxp + 1, SV*);
+                Safefree(old_alloc);
+            }
 #else
-		Renew(*allocp,newmax+1, SV*);
+            Renew(*allocp,newmax+1, SV*);
 #endif
 #ifdef Perl_safesysmalloc_size
-	      resized:
+          resized:
 #endif
-		ary = *allocp + *maxp + 1;
-		tmp = newmax - *maxp;
-		if (av == PL_curstack) {	/* Oops, grew stack (via av_store()?) */
-		    PL_stack_sp = *allocp + (PL_stack_sp - PL_stack_base);
-		    PL_stack_base = *allocp;
-		    PL_stack_max = PL_stack_base + newmax;
-		}
-	    }
-	    else {
-		newmax = key < 3 ? 3 : key;
-		{
-                    /* see comment above about newmax+1*/
-		    MEM_WRAP_CHECK_s(newmax, SV*, "Out of memory during array extend");
-		}
-		Newx(*allocp, newmax+1, SV*);
-		ary = *allocp + 1;
-		tmp = newmax;
-		*allocp[0] = NULL;	/* For the stacks */
-	    }
-	    if (av && AvREAL(av)) {
-		while (tmp)
-		    ary[--tmp] = NULL;
-	    }
-	    
-	    *arrayp = *allocp;
-	    *maxp = newmax;
-	}
+            ary = *allocp + *maxp + 1;
+            tmp = newmax - *maxp;
+            if (av == PL_curstack) {  /* Oops, grew stack (via av_store()?) */
+                PL_stack_sp = *allocp + (PL_stack_sp - PL_stack_base);
+                PL_stack_base = *allocp;
+                PL_stack_max = PL_stack_base + newmax;
+            }
+        } else {
+            newmax = key < 3 ? 3 : key;
+            {
+                /* see comment above about newmax+1*/
+                MEM_WRAP_CHECK_s(newmax, SV*, "Out of memory during array extend");
+            }
+            Newx(*allocp, newmax+1, SV*);
+            ary = *allocp + 1;
+            tmp = newmax;
+            *allocp[0] = NULL;  /* For the stacks */
+        }
+        if (av && AvREAL(av)) {
+            while (tmp)
+               ary[--tmp] = NULL;
+        }
+
+        *arrayp = *allocp;
+        *maxp = newmax;
     }
 }
 


### PR DESCRIPTION
This PR has two commits, a tabs-to-spaces commit, followed by a refactoring commit. The latter:
 * Changes the means of fresh array element initialization from the previous per-element loop, below, to the Zero() macro (i.e. memzero/memset)
```
                while (tmp)
                    ary[--tmp] = NULL;
```
 * Refactors slightly, such that when a shifted array is unshifted, but also has to be grown, there's only one use of Zero() rather than two.

No change in behaviour is intended, this PR is solely intended to improve performance when large arrays are created or resized. 

However, the performance difference will be dependent upon the underlying memset/memzero implementation. It would be great if this PR could get some testing on different platforms in order to see if any show worse performance than before.

**Local perf testing**
On a Core i5 x86-64 Linux VM:
* Repeatedly creating a new, small SV* array uses ~7 fewer instructions & ~3 fewer branches per iteration, but there's no discernible wallclock change.
`my @ary; for (1 .. 1_000_000) { @ary = (1); undef @ary; }`
* Repeatedly shifting a small array and pushing to it uses ~6 fewer instructions & ~1 fewer branch per iteration, but again, no discernible wallclock change.
`my @ary = (1,2,3); for (1 .. 1_000_000) { shift @ary; shift @ary; push @ary, (4,5); }`
* Doing things that involve creating many more fresh array elements, such as pre-extending the array, have bigger effects, as would be expected. For the following, the wallclock times were all over the place, but the numbers of instructions and branches were consistent:
`my @ary; for (1 .. 1_000_000) { @ary = (1); $ary[1024] = 1; undef @ary; }`

blead:
```
    11,897,373,171      instructions              #    3.89  insn per cycle         
     3,387,878,697      branches                  # 4147.263 M/sec                  
         2,043,989      branch-misses             #    0.06% of all branches    
```    
patched:
```
     9,098,175,244      instructions              #    3.54  insn per cycle         
     2,444,838,567      branches                  # 3505.562 M/sec                  
         1,569,350      branch-misses             #    0.06% of all branches 
```

**Questions/scope for additional commit(s)?**
1. Can _*maxp_ can ever be < -1? If it can't, the `(UNLIKELY(key < -1))` test could be made an else branch off the if `(key > *maxp) {` test.

2. When a shifted array `(*allocp != *arrayp)` has to be grown:
* Why is the test for `(key > *maxp - 10)` and not just a repeat of `(key > *maxp)` ? Seems like this will cause small arrays to be always be grown, even if there's no actual need.
* Why is the growth factor `newmax = key + *maxp`, but for an unshifted array it's `newmax = *maxp / 5` ?
* Why is the Perl_safesysmalloc_size check (where present) skipped?

If shifted arrays were treated the same as unshifted arrays in those regards, it would simplify the function and could reduce unnecessary array growth.