### PR TITLE
Run multiple progs improvements

### DIFF
--- a/t/test.pl
+++ b/t/test.pl
@@ -1355,19 +1355,21 @@ sub run_multiple_progs {
 	local $::TODO = $reason{todo};
 
 	unless ($ok) {
-	    my $err_line = "PROG: $switch\n$prog\n" .
-			   "EXPECTED:\n$expected\n";
-	    $err_line   .= "EXIT STATUS: != 0\n" if $fatal;
-	    $err_line   .= "GOT:\n$results\n";
-	    $err_line   .= "EXIT STATUS: " . ($status >> 8) . "\n" if $fatal;
-	    if ($::TODO) {
-		$err_line =~ s/^/# /mg;
-		print $err_line;  # Harness can't filter it out from STDERR.
-	    }
-	    else {
-		print STDERR $err_line;
-	    }
-	}
+        my $err_line = '';
+        $err_line   .= "FILE: $file ; line $line\n" if defined $file;
+        $err_line   .= "PROG: $switch\n$prog\n" .
+			           "EXPECTED:\n$expected\n";
+        $err_line   .= "EXIT STATUS: != 0\n" if $fatal;
+        $err_line   .= "GOT:\n$results\n";
+        $err_line   .= "EXIT STATUS: " . ($status >> 8) . "\n" if $fatal;
+        if ($::TODO) {
+            $err_line =~ s/^/# /mg;
+            print $err_line;  # Harness can't filter it out from STDERR.
+        }
+        else {
+            print STDERR $err_line;
+        }
+    }
 
         if (defined $file) {
             _ok($ok, "at $file line $line", $name);

--- a/t/test.pl
+++ b/t/test.pl
@@ -1230,10 +1230,12 @@ sub run_multiple_progs {
 	    }
 	}
 
-	my $name = '';
-	if ($prog =~ s/^#\s*NAME\s+(.+)\n//m) {
-	    $name = $1;
-	}
+    my $name = '';
+    if ($prog =~ s/^#\s*NAME\s+(.+)\n//m) {
+        $name = $1;
+    } elsif (defined $file) {
+        $name = "test from $file at line $line";
+    }
 
 	if ($reason{skip}) {
 	SKIP:

--- a/t/test.pl
+++ b/t/test.pl
@@ -1197,6 +1197,7 @@ sub run_multiple_progs {
 
     my $tmpfile = tempfile();
 
+    my $count_failures = 0;
     my ($file, $line);
   PROGRAM:
     while (defined ($line = shift @prgs)) {
@@ -1368,6 +1369,9 @@ sub run_multiple_progs {
         }
         else {
             print STDERR $err_line;
+            ++$count_failures;
+            die "PERL_TEST_ABORT_FIRST_FAILURE set Test Failure"
+                if $ENV{PERL_TEST_ABORT_FIRST_FAILURE};
         }
     }
 
@@ -1387,6 +1391,20 @@ sub run_multiple_progs {
 	    File::Path::rmtree $_ if -d $_;
 	}
     }
+
+    if ( $count_failures ) {
+        print STDERR <<'EOS';
+#
+# Note: 'run_multiple_progs' run has one or more failures
+#        you can consider setting the environment variable
+#        PERL_TEST_ABORT_FIRST_FAILURE=1 before running the test
+#        to stop on the first error.
+#
+EOS
+    }
+
+
+    return;
 }
 
 sub can_ok ($@) {


### PR DESCRIPTION
The helper `run_multiple_progs` is used by several core test using set of files describing some individual subtests to run.
On failure it's hard to debug and even know the source file and location where the code is, even if an extract of the `CODE` is displayed.

This Pull Request provides three improvements (as individual commit):
- advertise source file and line number on failures
- automatically name test when no custom name is set
- provide an environment variable `PERL_TEST_ABORT_FIRST_FAILURE` to debug and  stop on the first failure
with also a hint at the end of the test to use it on failures
