### PR TITLE
prefer postfix dereferencing in documentation

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2000,12 +2000,12 @@ such as:
 or a hash or array slice, such as:
 
     @foo[$bar, $baz, $xyzzy]
-    @{$ref->[12]}{"susie", "queue"}
+    $ref->[12]->@{"susie", "queue"}
 
 or a hash key/value or array index/value slice, such as:
 
     %foo[$bar, $baz, $xyzzy]
-    %{$ref->[12]}{"susie", "queue"}
+    $ref->[12]->%{"susie", "queue"}
 
 =item Delimiter for here document is too long
 

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -1675,10 +1675,10 @@ The EXPR can be arbitrarily complicated provided its
 final operation is an element or slice of an aggregate:
 
     delete $ref->[$x][$y]{$key};
-    delete @{$ref->[$x][$y]}{$key1, $key2, @morekeys};
+    delete $ref->[$x][$y]->@{$key1, $key2, @morekeys};
 
     delete $ref->[$x][$y][$index];
-    delete @{$ref->[$x][$y]}[$index1, $index2, @moreindices];
+    delete $ref->[$x][$y]->@[$index1, $index2, @moreindices];
 
 =item die LIST
 X<die> X<throw> X<exception> X<raise> X<$@> X<abort>

--- a/pod/perllol.pod
+++ b/pod/perllol.pod
@@ -168,7 +168,7 @@ If you wanted just to append to a row, you'd have
 to do something a bit funnier looking:
 
     # add new columns to an existing row
-    push @{ $AoA[0] }, "wilma", "betty";   # explicit deref
+    push $AoA[0]->@*, "wilma", "betty";   # explicit deref
 
 =head2 Access and Printing
 
@@ -252,7 +252,7 @@ parsable Perl code.  For example:
 	   [ "george", "jane", "elroy" ],
 	   [ "homer", "marge", "bart" ],
  );
- push @{ $AoA[0] }, "wilma", "betty";
+ push $AoA[0]->@*, "wilma", "betty";
  show @AoA;
 
 will print out:
@@ -296,15 +296,9 @@ variable as before.
 
 That same loop could be replaced with a slice operation:
 
-    @part = @{$AoA[4]}[7..12];
+    @part = $AoA[4]->@[ 7..12 ];
 
-or spaced out a bit:
-
-    @part = @{ $AoA[4] } [ 7..12 ];
-
-But as you might well imagine, this can get pretty rough on the reader.
-
-Ah, but what if you wanted a I<two-dimensional slice>, such as having
+Now, what if you wanted a I<two-dimensional slice>, such as having
 $x run from 4..8 and $y run from 7 to 12?  Hmm... here's the simple way:
 
     @newAoA = ();
@@ -317,13 +311,13 @@ $x run from 4..8 and $y run from 7 to 12?  Hmm... here's the simple way:
 We can reduce some of the looping through slices
 
     for ($x = 4; $x <= 8; $x++) {
-	push @newAoA, [ @{ $AoA[$x] } [ 7..12 ] ];
+	push @newAoA, [ $AoA[$x]->@[ 7..12 ] ];
     }
 
 If you were into Schwartzian Transforms, you would probably
 have selected map for that
 
-    @newAoA = map { [ @{ $AoA[$_] } [ 7..12 ] ] } 4 .. 8;
+    @newAoA = map { [ $AoA[$_]->@[ 7..12 ] ] } 4 .. 8;
 
 Although if your manager accused you of seeking job security (or rapid
 insecurity) through inscrutable code, it would be hard to argue. :-)
@@ -336,7 +330,7 @@ If I were you, I'd put that in a function:
 	    $y_lo, $y_hi) = @_;
 
 	return map {
-	    [ @{ $lrr->[$_] } [ $y_lo .. $y_hi ] ]
+	    [ $lrr->[$_]->@[ $y_lo .. $y_hi ] ]
 	} $x_lo .. $x_hi;
     }
 

--- a/pod/perlobj.pod
+++ b/pod/perlobj.pod
@@ -1013,7 +1013,7 @@ Here's an example of a module as a blessed scalar:
 
   sub epoch {
       my $self = shift;
-      return ${ $self };
+      return $$self;
   }
 
   my $time = Time->new();

--- a/pod/perlperf.pod
+++ b/pod/perlperf.pod
@@ -318,7 +318,7 @@ report on the contents.
      my %rep;
 
      foreach my $line ( keys %report ) {
-         foreach my $key ( keys %{ $report{$line} } ) {
+         foreach my $key ( keys $report{$line}->%* ) {
              $rep{$key} += $report{$line}{$key};
          }
      }

--- a/pod/perlretut.pod
+++ b/pod/perlretut.pod
@@ -928,7 +928,8 @@ this code
     $x = "Mmm...donut, thought Homer";
     $x =~ /^(Mmm|Yech)\.\.\.(donut|peas)/; # matches
     foreach $exp (1..$#-) {
-        print "Match $exp: '${$exp}' at position ($-[$exp],$+[$exp])\n";
+        no strict 'refs';
+        print "Match $exp: '$$exp' at position ($-[$exp],$+[$exp])\n";
     }
 
 prints

--- a/pod/perlsub.pod
+++ b/pod/perlsub.pod
@@ -1467,7 +1467,7 @@ corresponding built-in.
    sub myjoin ($@)	   myjoin ":", $a, $b, $c
    sub mypop (\@)	   mypop @array
    sub mysplice (\@$$@)	   mysplice @array, 0, 2, @pushme
-   sub mykeys (\[%@])	   mykeys %{$hashref}
+   sub mykeys (\[%@])	   mykeys $hashref->%*
    sub myopen (*;$)	   myopen HANDLE, $name
    sub mypipe (**)	   mypipe READHANDLE, WRITEHANDLE
    sub mygrep (&@)	   mygrep { /foo/ } $a, $b, $c

--- a/pod/perltie.pod
+++ b/pod/perltie.pod
@@ -316,7 +316,7 @@ object I<this>. (Equivalent to C<scalar(@array)>).  For example:
 
     sub FETCHSIZE {
       my $self = shift;
-      return scalar @{$self->{ARRAY}};
+      return scalar $self->{ARRAY}->@*;
     }
 
 =item STORESIZE this, count
@@ -429,7 +429,7 @@ Remove last element of the array and return it.  For example:
 
     sub POP {
       my $self = shift;
-      return pop @{$self->{ARRAY}};
+      return pop $self->{ARRAY}->@*;
     }
 
 =item SHIFT this
@@ -440,7 +440,7 @@ and return it.  For example:
 
     sub SHIFT {
       my $self = shift;
-      return shift @{$self->{ARRAY}};
+      return shift $self->{ARRAY}->@*;
     }
 
 =item UNSHIFT this, LIST 
@@ -454,8 +454,8 @@ up to make room.  For example:
       my @list = @_;
       my $size = scalar( @list );
       # make room for our list
-      @{$self->{ARRAY}}[ $size .. $#{$self->{ARRAY}} + $size ]
-       = @{$self->{ARRAY}};
+      $self->{ARRAY}[ $size .. $self->{ARRAY}->$#* + $size ]->@*
+       = $self->{ARRAY}->@*
       $self->STORE( $_, $list[$_] ) foreach 0 .. $#list;
     }
 
@@ -484,7 +484,7 @@ In our example, we'll use a little shortcut if there is a I<LIST>:
         tie @list, __PACKAGE__, $self->{ELEMSIZE};
         @list   = @_;
       }
-      return splice @{$self->{ARRAY}}, $offset, $length, @list;
+      return splice $self->{ARRAY}->@*, $offset, $length, @list;
     }
 
 =item UNTIE this
@@ -754,7 +754,7 @@ dangerous thing that they'll have to set CLOBBER to something higher than
      croak "@{[&whowasi]}: won't remove all dot files for $self->{USER}"
          unless $self->{CLOBBER} > 1;
      my $dot;
-     foreach $dot ( keys %{$self->{LIST}}) {
+     foreach $dot ( keys $self->{LIST}->%* ) {
          $self->DELETE($dot);
      }
  }
@@ -782,8 +782,8 @@ to iterate through the hash, such as via a keys(), values(), or each() call.
     sub FIRSTKEY {
 	carp &whowasi if $DEBUG;
 	my $self = shift;
-	my $a = keys %{$self->{LIST}};  # reset each() iterator
-	each %{$self->{LIST}}
+	my $a = keys $self->{LIST}->%*;  # reset each() iterator
+	each $self->{LIST}->%*
     }
 
 FIRSTKEY is always called in scalar context and it should just
@@ -808,7 +808,7 @@ thing, but we'll have to go through the LIST field indirectly.
     sub NEXTKEY  {
 	carp &whowasi if $DEBUG;
 	my $self = shift;
-	return each %{ $self->{LIST} }
+	return each $self->{LIST}->%*
     }
 
 =item SCALAR this
@@ -835,7 +835,7 @@ referenced by C<$self-E<gt>{LIST}>:
     sub SCALAR {
 	carp &whowasi if $DEBUG;
 	my $self = shift;
-	return scalar %{ $self->{LIST} }
+	return scalar $self->{LIST}->%*
     }
 
 NOTE: In perl 5.25 the behavior of scalar %hash on an untied hash changed


### PR DESCRIPTION
I've begun flipping through the documentation to look at places that have fallen out of date.  This is a pretty minor change, here, just updating documentation to prefer postfix dereference to circumfix.  (I have generally left prefix dereference untouched.)

There are a few more documents that could benefit from more substantial updates for this, but I didn't get into it until we know whether we like this change _in general_.