### PR TITLE
Stop implying "." belongs in $ENV{PATH}

### DIFF
--- a/dist/Env/lib/Env.pm
+++ b/dist/Env/lib/Env.pm
@@ -1,6 +1,6 @@
 package Env;
 
-our $VERSION = '1.04';
+our $VERSION = '1.05';
 
 =head1 NAME
 
@@ -35,7 +35,7 @@ You may access its value
 
 or modify it
 
-    $PATH .= ":.";
+    $PATH .= ":/any/path";
     push @LD_LIBRARY_PATH, $dir;
 
 however you'd like. Bear in mind, however, that each access to a tied array
@@ -44,15 +44,16 @@ variable requires splitting the environment variable's string anew.
 The code:
 
     use Env qw(@PATH);
-    push @PATH, '.';
+    push @PATH, '/any/path';
 
-is equivalent to:
+is almost equivalent to:
 
     use Env qw(PATH);
-    $PATH .= ":.";
+    $PATH .= ":/any/path";
 
 except that if C<$ENV{PATH}> started out empty, the second approach leaves
-it with the (odd) value "C<:.>", but the first approach leaves it with "C<.>".
+it with the (odd) value "C<:/any/path>", but the first approach leaves it with
+"C</any/path>".
 
 To remove a tied environment variable from
 the environment, assign it the undefined value

--- a/t/porting/known_pod_issues.dat
+++ b/t/porting/known_pod_issues.dat
@@ -371,6 +371,7 @@ dist/data-dumper/dumper.pm	? Should you be using L<...> instead of	1
 dist/devel-ppport/parts/inc/ppphdoc	Unknown directive: =dontwarn	1
 dist/devel-ppport/parts/inc/ppphdoc	Unknown directive: =implementation	1
 dist/devel-ppport/parts/inc/ppphdoc	Unknown directive: =provides	1
+dist/env/lib/env.pm	? Should you be using F<...> or maybe L<...> instead of	1
 dist/exporter/lib/exporter.pm	Verbatim line length including indents exceeds 79 by	2
 dist/net-ping/lib/net/ping.pm	Apparent broken link	2
 ext/amiga-exec/exec.pm	Verbatim line length including indents exceeds 79 by	1


### PR DESCRIPTION
Instead, use an arbitrary path that has less chance of encouraging
people to allow the current directory in their path.

This was prompted by #16951 and attached as a patch to that issue which
was mistakenly closde without fixing the problem.