### PR TITLE
pp_split: assign to temp AV in @ary = split(...) optimisation

### DIFF
--- a/t/op/split.t
+++ b/t/op/split.t
@@ -7,7 +7,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan tests => 176;
+plan tests => 178;
 
 $FS = ':';
 
@@ -667,3 +667,10 @@ CODE
         ok(eq_array(\@result,['a','b']), "Resulting in ('a','b')");
     }
 }
+
+# check that the (@ary = split) optimisation survives @ary being modified
+
+fresh_perl_is('my @ary; @ary = split(/\w(?{ @ary[1000] = 1 })/, "abc");',
+        '',{},'(@ary = split ...) survives @ary being Renew()ed');
+fresh_perl_is('my @ary; @ary = split(/\w(?{ undef @ary })/, "abc");',
+        '',{},'(@ary = split ...) survives an (undef @ary)');


### PR DESCRIPTION
The @ary = split(...) optimisation uses SWITCHSTACK to make @ary masquerade as the value stack. However, code that is not aware of this could modify @ary during the split and cause perl to segfault/panic/catch fire. (e.g. see added tests)

This commit makes SWITCHSTACK operate on a temporary AV instead, then swap over the relevant pointers towards the end of the function.

No user-visible changes - besides perl not crashing - are intended.

Note: this PR is standalone but comes from the discussion in #18014 