### PR TITLE
release announcement: waffle on perl5 v perl7 for now

### DIFF
--- a/Porting/release_announcement_template.txt
+++ b/Porting/release_announcement_template.txt
@@ -22,8 +22,7 @@ https://metacpan.org/pod/release/[AUTHOR]/perl-5.[VERSION.SUBVERSION]/pod/perlde
 
 [ACKNOWLEDGEMENTS SECTION FROM PERLDELTA]
 
-We expect to release version [NEXT BLEAD VERSION.SUBVERSION] on [FUTURE
-DATE].  The next major stable release of Perl 5, version 34.0, should
-appear in May 2021.
+We expect to release version [NEXT BLEAD VERSION.SUBVERSION] on [FUTURE DATE].
+The next major stable release of Perl will appear in the first half of 2021.
 
 [YOUR SALUTATION HERE]


### PR DESCRIPTION
Will the next release be in January or May?  Perl 7.0 or Perl 5.34?  Rather than have a firm answer now, just remove some concreteness.