### PR TITLE
Cannot reproduce run with PERL_HASH_SEED when using PERL_PERTURB_KEYS=DETERMINISTIC

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6077,6 +6077,7 @@ t/run/fresh_perl.t		Tests that require a fresh perl.
 t/run/locale.t		Tests related to locale handling
 t/run/noswitch.t		Test aliasing ARGV for other switch tests
 t/run/runenv.t			Test if perl honors its environment variables.
+t/run/runenv_hashseed.t	Test if perl honors PERL_HASH_SEED.
 t/run/script.t			See if script invocation works
 t/run/switch0.t			Test the -0 switch
 t/run/switcha.t			Test the -a switch

--- a/hv.c
+++ b/hv.c
@@ -842,7 +842,7 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
      * reset the iterator randomizer if there is one.
      */
     in_collision = *oentry != NULL;
-    if ( *oentry && PL_HASH_RAND_BITS_ENABLED) {
+    if ( *oentry && PL_HASH_RAND_BITS_ENABLED == 1 ) {
         PL_hash_rand_bits++;
         PL_hash_rand_bits= ROTL_UV(PL_hash_rand_bits,1);
         if ( PL_hash_rand_bits & 1 ) {

--- a/t/run/runenv.t
+++ b/t/run/runenv.t
@@ -24,43 +24,6 @@ delete $ENV{PERL5LIB};
 delete $ENV{PERL5OPT};
 delete $ENV{PERL_USE_UNSAFE_INC};
 
-
-# Run perl with specified environment and arguments, return (STDOUT, STDERR)
-sub runperl_and_capture {
-  local *F;
-  my ($env, $args) = @_;
-
-  local %ENV = %ENV;
-  delete $ENV{PERLLIB};
-  delete $ENV{PERL5LIB};
-  delete $ENV{PERL5OPT};
-  delete $ENV{PERL_USE_UNSAFE_INC};
-  my $pid = fork;
-  return (0, "Couldn't fork: $!") unless defined $pid;   # failure
-  if ($pid) {                   # parent
-    wait;
-    return (0, "Failure in child.\n") if ($?>>8) == $FAILURE_CODE;
-
-    open my $stdout, '<', $STDOUT
-	or return (0, "Couldn't read $STDOUT file: $!");
-    open my $stderr, '<', $STDERR
-	or return (0, "Couldn't read $STDERR file: $!");
-    local $/;
-    # Empty file with <$stderr> returns nothing in list context
-    # (because there are no lines) Use scalar to force it to ''
-    return (scalar <$stdout>, scalar <$stderr>);
-  } else {                      # child
-    for my $k (keys %$env) {
-      $ENV{$k} = $env->{$k};
-    }
-    open STDOUT, '>', $STDOUT or exit $FAILURE_CODE;
-    open STDERR, '>', $STDERR and do { exec $PERL, @$args };
-    # it did not work:
-    print STDOUT "IWHCWJIHCI\cNHJWCJQWKJQJWCQW\n";
-    exit $FAILURE_CODE;
-  }
-}
-
 sub try {
   my ($env, $args, $stdout, $stderr) = @_;
   my ($actual_stdout, $actual_stderr) = runperl_and_capture($env, $args);

--- a/t/run/runenv_hashseed.t
+++ b/t/run/runenv_hashseed.t
@@ -1,0 +1,77 @@
+#!./perl
+#
+# Tests for Perl run-time environment variable settings
+#
+# $PERL5OPT, $PERL5LIB, etc.
+
+BEGIN {
+    chdir 't' if -d 't';
+    @INC = '../lib';
+    require './test.pl';
+    require Config;
+    Config->import;
+}
+
+skip_all_without_config('d_fork');
+skip_all("NO_PERL_HASH_ENV or NO_PERL_HASH_SEED_DEBUG set")
+    if $Config{ccflags} =~ /-DNO_PERL_HASH_ENV\b/
+    || $Config{ccflags} =~ /-DNO_PERL_HASH_SEED_DEBUG\b/;
+
+plan tests => 12;
+
+our $TODO;
+# Test that PERL_PERTURB_KEYS works as expected.  We check that we get the same
+# results if we use PERL_PERTURB_KEYS = 0 or 2 and we reuse the seed from previous run.
+my @print_keys = ( '-e', 'my %h; @h{"A".."Z", "a".."z"}=(); print keys %h' );
+for my $mode (qw{NO RANDOM DETERMINISTIC}) {    # 0, 1 and 2 respectively
+    my %base_opts;
+    %base_opts = ( PERL_PERTURB_KEYS => $mode, PERL_HASH_SEED_DEBUG => 1 ),
+        my ( $out, $err )
+        = runperl_and_capture( {%base_opts}, [@print_keys] );
+    if ( $err =~ /HASH_SEED = (0x[a-f0-9]+)/ ) {
+        my $seed = $1;
+        {
+            # Reusing the same HASH_SEED
+            my ( $out2, $err2 )
+                = runperl_and_capture(
+                { %base_opts, PERL_HASH_SEED => $seed },
+                [@print_keys] );
+            if ( $mode eq 'RANDOM' ) {
+                isnt( $out, $out2,
+                    "PERL_PERTURB_KEYS = $mode results in different key order with the same key"
+                );
+            }
+            elsif ( $mode eq 'NO' ) {
+                is( $out, $out2,
+                    "PERL_PERTURB_KEYS = $mode allows one to recreate a random hash"
+                );
+            }
+            elsif ( $mode eq 'DETERMINISTIC' ) {
+                local $TODO = q[This test is flapping when using PERL_PERTURB_KEYS=DETERMINISTIC];
+                is( $out, $out2,
+                    "PERL_PERTURB_KEYS = $mode allows one to recreate a random hash"
+                );
+            }
+
+            is( $err, $err2,
+                "Got the same debug output when we set PERL_HASH_SEED and PERL_PERTURB_KEYS"
+            );
+        }
+        {
+            # Using a different HASH_SEED
+            my @chars = split //, $seed;
+
+            # increase by 1 the last digit (only)
+            $chars[-1] = sprintf( "%x", ( hex( $chars[-1] ) + 1 ) % 15 );
+            my $updated_seed = join '', @chars;
+            isnt $updated_seed, $seed, "got a different seed";
+            my ( $out2, $err2 )
+                = runperl_and_capture(
+                { %base_opts, PERL_HASH_SEED => $updated_seed },
+                [@print_keys] );
+            isnt( $out, $out2,
+                "PERL_PERTURB_KEYS = $mode results in different order with a different key"
+            );
+        }
+    }
+}

--- a/t/run/runenv_hashseed.t
+++ b/t/run/runenv_hashseed.t
@@ -19,7 +19,6 @@ skip_all("NO_PERL_HASH_ENV or NO_PERL_HASH_SEED_DEBUG set")
 
 plan tests => 12;
 
-our $TODO;
 # Test that PERL_PERTURB_KEYS works as expected.  We check that we get the same
 # results if we use PERL_PERTURB_KEYS = 0 or 2 and we reuse the seed from previous run.
 my @print_keys = ( '-e', 'my %h; @h{"A".."Z", "a".."z"}=(); print keys %h' );
@@ -41,13 +40,7 @@ for my $mode (qw{NO RANDOM DETERMINISTIC}) {    # 0, 1 and 2 respectively
                     "PERL_PERTURB_KEYS = $mode results in different key order with the same key"
                 );
             }
-            elsif ( $mode eq 'NO' ) {
-                is( $out, $out2,
-                    "PERL_PERTURB_KEYS = $mode allows one to recreate a random hash"
-                );
-            }
-            elsif ( $mode eq 'DETERMINISTIC' ) {
-                local $TODO = q[This test is flapping when using PERL_PERTURB_KEYS=DETERMINISTIC];
+            else {
                 is( $out, $out2,
                     "PERL_PERTURB_KEYS = $mode allows one to recreate a random hash"
                 );

--- a/t/test.pl
+++ b/t/test.pl
@@ -806,6 +806,46 @@ sub runperl {
 # Nice alias
 *run_perl = *run_perl = \&runperl; # shut up "used only once" warning
 
+# Run perl with specified environment and arguments, return (STDOUT, STDERR)
+sub runperl_and_capture {
+  my ($env, $args) = @_;
+
+  my $STDOUT = tempfile();
+  my $STDERR = tempfile();
+  my $PERL   = $^X;
+  my $FAILURE_CODE = 119;
+
+  local %ENV = %ENV;
+  delete $ENV{PERLLIB};
+  delete $ENV{PERL5LIB};
+  delete $ENV{PERL5OPT};
+  delete $ENV{PERL_USE_UNSAFE_INC};
+  my $pid = fork;
+  return (0, "Couldn't fork: $!") unless defined $pid;   # failure
+  if ($pid) {                   # parent
+    wait;
+    return (0, "Failure in child.\n") if ($?>>8) == $FAILURE_CODE;
+
+    open my $stdout, '<', $STDOUT
+    or return (0, "Couldn't read $STDOUT file: $!");
+    open my $stderr, '<', $STDERR
+    or return (0, "Couldn't read $STDERR file: $!");
+    local $/;
+    # Empty file with <$stderr> returns nothing in list context
+    # (because there are no lines) Use scalar to force it to ''
+    return (scalar <$stdout>, scalar <$stderr>);
+  } else {                      # child
+    for my $k (keys %$env) {
+      $ENV{$k} = $env->{$k};
+    }
+    open STDOUT, '>', $STDOUT or exit $FAILURE_CODE;
+    open STDERR, '>', $STDERR and do { exec $PERL, @$args };
+    # it did not work:
+    print STDOUT "IWHCWJIHCI\cNHJWCJQWKJQJWCQW\n"; # not really needed?
+    exit $FAILURE_CODE;
+  }
+}
+
 sub DIE {
     _print_stderr "# @_\n";
     exit 1;


### PR DESCRIPTION
This is either an issue in the documentation or a bug in the source code itself. 
After reading the documentation about PERL_PERTURB_KEYS I lean to the second option.
view `PERL_PERTURB_KEYS` section from https://github.com/Perl/perl5/blob/blead/pod/perlrun.pod for more details.

PERL_PERTURB_KEYS can be one of the three possible values:
- 0: NO 
- 1: RANDOM
- 2: DETERMINISTIC

When using `RANDOM` the doc in `perlrun/PERL_PERTURB_KEYS` makes it clear that `the order may not be repeatable in a following program run even if the PERL_HASH_SEED has been specified.`

But `NO` and `DETERMINISTIC` modes are supposed to be `repeatable` when preserving PERL_HASH_SEED.
As shown by the additional unit test this is not the case for `DETERMINISTIC`. (you may have to run it multiple times)

This pull request adds three commits:

1. move `runperl_and_capture` helper to a generic location
2. add `t/run/runenv_hashseed.t` to show the limitation when using `DETERMINISTIC` mode
3. provide a fix candidate to honor `PERL_HASH_SEED` under `DETERMINISTIC` mode

This is clearly a change that needs to be reviewed by @demerphq before being merged.

Thanks to @jkeenan for discovering this issue while working on https://github.com/atoomic/perl/issues/250
