### PR TITLE
pp_akeys: use av_top_index rather than Perl_av_len

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -5027,7 +5027,7 @@ PP(pp_akeys)
                       "Can't modify keys on array in list assignment");
       }
       {
-        IV n = Perl_av_len(aTHX_ array);
+        IV n = av_top_index(array);
         IV i;
 
         EXTEND(SP, n + 1);


### PR DESCRIPTION
_Perl_av_len_ and _av_top_index_ both return` AvFILL(array)`, but _av_top_index_ is (now) a macro and _Perl_av_len_ is a function call.