### PR TITLE
av_create_and_push: faster path for newAV case

### DIFF
--- a/av.c
+++ b/av.c
@@ -639,9 +639,11 @@ Perl_av_create_and_push(pTHX_ AV **const avp, SV *const val)
 {
     PERL_ARGS_ASSERT_AV_CREATE_AND_PUSH;
 
-    if (!*avp)
-        *avp = newAV();
-    av_push(*avp, val);
+    if (!*avp) {
+        *avp = newAV_alloc_xz(4);
+        AvARRAY(*avp)[ ++AvFILLp(*avp) ] = val;
+    } else
+        av_push(*avp, val);
 }
 
 /*
@@ -728,10 +730,14 @@ Perl_av_create_and_unshift_one(pTHX_ AV **const avp, SV *const val)
 {
     PERL_ARGS_ASSERT_AV_CREATE_AND_UNSHIFT_ONE;
 
-    if (!*avp)
-        *avp = newAV();
-    av_unshift(*avp, 1);
-    return av_store(*avp, 0, val);
+    if (!*avp) {
+        *avp = newAV_alloc_xz(4);
+        AvARRAY(*avp)[ ++AvFILLp(*avp) ] = val;
+        return val;
+    } else {
+        av_unshift(*avp, 1);
+        return av_store(*avp, 0, val);
+    }
 }
 
 /*

--- a/embed.fnc
+++ b/embed.fnc
@@ -639,7 +639,7 @@ ApdR	|AV*	|av_make	|SSize_t size|NN SV **strp
 ApdR	|AV*	|av_new_alloc	|SSize_t size|bool zeroflag
 p	|SV*	|av_nonelem	|NN AV *av|SSize_t ix
 Apd	|SV*	|av_pop		|NN AV *av
-Apdoex	|void	|av_create_and_push|NN AV **const avp|NN SV *const val
+Apdoe	|void	|av_create_and_push|NN AV **const avp|NN SV *const val
 Apd	|void	|av_push	|NN AV *av|NN SV *val
 : Used in scope.c, and by Data::Alias
 EXp	|void	|av_reify	|NN AV *av
@@ -649,7 +649,7 @@ AmdR	|SSize_t|av_top_index	|NN AV *av
 AidRp	|Size_t	|av_count	|NN AV *av
 AmdR	|SSize_t|av_tindex	|NN AV *av
 Apd	|void	|av_undef	|NN AV *av
-Apdoex	|SV**	|av_create_and_unshift_one|NN AV **const avp|NN SV *const val
+Apdoe	|SV**	|av_create_and_unshift_one|NN AV **const avp|NN SV *const val
 Apd	|void	|av_unshift	|NN AV *av|SSize_t num
 Cpo	|SV**	|av_arylen_p	|NN AV *av
 Cpo	|IV*	|av_iter_p	|NN AV *av


### PR DESCRIPTION
For a new, vanilla AV, _av_push()_ is a winding path of checks for conditions that we know are not going to be true. It's therefore more efficient to do the nuts and bolts work inline.

That said, _Perl_av_create_and_push_ doesn't seem to be all that commonly used, so if it's not worth the code bloat (here it's an extra 9 instructions and 24 bytes on av.o), I can swap this PR for a "Don't bother optimizing this" code comment.
