### PR TITLE
Heap buffer overflow in regex bracket group whitespace handling

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -17228,10 +17228,10 @@ S_add_multi_match(pTHX_ AV* multi_char_matches, SV* multi_string, const STRLEN c
  *
  * There is a line below that uses the same white space criteria but is outside
  * this macro.  Both here and there must use the same definition */
-#define SKIP_BRACKETED_WHITE_SPACE(do_skip, p)                          \
+#define SKIP_BRACKETED_WHITE_SPACE(do_skip, p, stop_p)                  \
     STMT_START {                                                        \
         if (do_skip) {                                                  \
-            while (isBLANK_A(UCHARAT(p)))                               \
+            while (p < stop_p && isBLANK_A(UCHARAT(p)))                 \
             {                                                           \
                 p++;                                                    \
             }                                                           \
@@ -17406,7 +17406,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
     initial_listsv_len = SvCUR(listsv);
     SvTEMP_off(listsv); /* Grr, TEMPs and mortals are conflated.  */
 
-    SKIP_BRACKETED_WHITE_SPACE(skip_white, RExC_parse);
+    SKIP_BRACKETED_WHITE_SPACE(skip_white, RExC_parse, RExC_end);
 
     assert(RExC_parse <= RExC_end);
 
@@ -17415,7 +17415,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
         invert = TRUE;
         allow_mutiple_chars = FALSE;
         MARK_NAUGHTY(1);
-        SKIP_BRACKETED_WHITE_SPACE(skip_white, RExC_parse);
+        SKIP_BRACKETED_WHITE_SPACE(skip_white, RExC_parse, RExC_end);
     }
 
     /* Check that they didn't say [:posix:] instead of [[:posix:]] */
@@ -17462,11 +17462,11 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
             output_posix_warnings(pRExC_state, posix_warnings);
         }
 
+        SKIP_BRACKETED_WHITE_SPACE(skip_white, RExC_parse, RExC_end);
+
         if  (RExC_parse >= stop_ptr) {
             break;
         }
-
-        SKIP_BRACKETED_WHITE_SPACE(skip_white, RExC_parse);
 
         if  (UCHARAT(RExC_parse) == ']') {
             break;
@@ -18156,7 +18156,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
 	    }
 	} /* end of namedclass \blah */
 
-        SKIP_BRACKETED_WHITE_SPACE(skip_white, RExC_parse);
+        SKIP_BRACKETED_WHITE_SPACE(skip_white, RExC_parse, RExC_end);
 
         /* If 'range' is set, 'value' is the ending of a range--check its
          * validity.  (If value isn't a single code point in the case of a
@@ -18199,7 +18199,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                 char* next_char_ptr = RExC_parse + 1;
 
                 /* Get the next real char after the '-' */
-                SKIP_BRACKETED_WHITE_SPACE(skip_white, next_char_ptr);
+                SKIP_BRACKETED_WHITE_SPACE(skip_white, next_char_ptr, RExC_end);
 
                 /* If the '-' is at the end of the class (just before the ']',
                  * it is a literal minus; otherwise it is a range */


### PR DESCRIPTION
The code for skipping whitespace in regex bracket character groups
was walking past the end of the regex in some cases.

This shows up with address sanitizer when the regex ends with a partial bracket group and trailing whitespace under the "xx" and "l" modifiers.

Example:
```
jd@afl:~/perl-fuzz/builds/tags/v5.32.0/32-asan/bin (master)$ ./perl -e 'q{} =~ /[\s /xxl'
=================================================================
==12452==ERROR: AddressSanitizer: heap-buffer-overflow on address 0xf59011f5 at pc 0x0846d94c bp 0xffffbd48 sp 0xffffbd40
READ of size 1 at 0xf59011f5 thread T0
    #0 0x846d94b in S_regclass /home/jd/perl-fuzz/perl5/regcomp.c:18182:9
    #1 0x8436b6d in S_regatom /home/jd/perl-fuzz/perl5/regcomp.c:13522:15
    #2 0x842b16b in S_regpiece /home/jd/perl-fuzz/perl5/regcomp.c:12635:11
    #3 0x842b16b in S_regbranch /home/jd/perl-fuzz/perl5/regcomp.c:12555
    #4 0x839606a in S_reg /home/jd/perl-fuzz/perl5/regcomp.c:12257:10
    #5 0x8380243 in Perl_re_op_compile /home/jd/perl-fuzz/perl5/regcomp.c:7882:9
    #6 0x817d562 in Perl_pmruntime /home/jd/perl-fuzz/perl5/op.c:8375:6
    #7 0x83566e7 in Perl_yyparse /home/jd/perl-fuzz/perl5/perly.y:1293:23
    #8 0x822c0fe in S_parse_body /home/jd/perl-fuzz/perl5/perl.c:2576:9
    #9 0x822c0fe in perl_parse /home/jd/perl-fuzz/perl5/perl.c:1871
    #10 0x8154da3 in main /home/jd/perl-fuzz/perl5/perlmain.c:126:10
    #11 0xf7cb7b40 in __libc_start_main (/lib32/libc.so.6+0x1ab40)
    #12 0x8080cd1 in _start (/home/jd/perl-fuzz/builds/tags/v5.32.0/32-asan/bin/perl+0x8080cd1)
```