### PR TITLE
perldsc.pod: prefer postfix to circumfix deref

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2000,12 +2000,12 @@ such as:
 or a hash or array slice, such as:
 
     @foo[$bar, $baz, $xyzzy]
-    @{$ref->[12]}{"susie", "queue"}
+    $ref->[12]->@{"susie", "queue"}
 
 or a hash key/value or array index/value slice, such as:
 
     %foo[$bar, $baz, $xyzzy]
-    %{$ref->[12]}{"susie", "queue"}
+    $ref->[12]->%{"susie", "queue"}
 
 =item Delimiter for here document is too long
 

--- a/pod/perldsc.pod
+++ b/pod/perldsc.pod
@@ -711,7 +711,7 @@ many different sorts:
      print $rec->{TEXT};
 
      print $rec->{SEQUENCE}[0];
-     $last = pop @ { $rec->{SEQUENCE} };
+     $last = pop $rec->{SEQUENCE}->@*;
 
      print $rec->{LOOKUP}{"key"};
      ($first_k, $first_v) = each $rec->{LOOKUP}->%*;

--- a/pod/perldsc.pod
+++ b/pod/perldsc.pod
@@ -340,9 +340,8 @@ For example, given the assignment to $AoA above, here's the debugger output:
 
 =head1 CODE EXAMPLES
 
-Presented with little comment (these will get their own manpages someday)
-here are short code examples illustrating access of various
-types of data structures.
+Presented with little comment here are short code examples illustrating
+access of various types of data structures.
 
 =head1 ARRAYS OF ARRAYS
 X<array of arrays> X<AoA>

--- a/pod/perldsc.pod
+++ b/pod/perldsc.pod
@@ -666,9 +666,7 @@ X<hash of hashes> X<HoH>
 
 
  # print the whole thing sorted by number of members
- foreach $family ( sort { keys %{$HoH{$b}} <=> keys %{$HoH{$a}} }
-                                                             keys %HoH )
- {
+ foreach $family ( sort { $HoH{$b}->%* <=> $HoH{$a}->%* } keys %HoH ) {
      print "$family: { ";
      for $role ( sort keys $HoH{$family}->%* ) {
          print "$role=$HoH{$family}{$role} ";
@@ -681,9 +679,7 @@ X<hash of hashes> X<HoH>
  for ( qw(lead wife son daughter pal pet) ) { $rank{$_} = ++$i }
 
  # now print the whole thing sorted by number of members
- foreach $family ( sort { keys %{ $HoH{$b} } <=> keys %{ $HoH{$a} } }
-                                                             keys %HoH )
- {
+ foreach $family ( sort { $HoH{$b}->%* <=> $HoH{$a}->%* } keys %HoH ) {
      print "$family: { ";
      # and print these according to rank order
      for $role ( sort { $rank{$a} <=> $rank{$b} }

--- a/pod/perldsc.pod
+++ b/pod/perldsc.pod
@@ -288,9 +288,8 @@ reading left to right.
 
 If this is starting to sound scarier than it's worth, relax.  Perl has
 some features to help you avoid its most common pitfalls.  The best
-way to avoid getting confused is to start every program like this:
+way to avoid getting confused is to start every program with:
 
-    #!/usr/bin/perl -w
     use strict;
 
 This way, you'll be forced to declare all your variables with my() and

--- a/pod/perldsc.pod
+++ b/pod/perldsc.pod
@@ -183,31 +183,30 @@ The square brackets make a reference to a new array with a I<copy>
 of what's in @array at the time of the assignment.  This is what
 you want.
 
-Note that this will produce something similar, but it's
-much harder to read:
+Note that this will produce something similar:
 
     # Either without strict or having an outer-scope my @array;
     # declaration.
     for my $i (1..10) {
         @array = 0 .. $i;
-        @{$AoA[$i]} = @array;
+        $AoA[$i]->@* = @array;
     }
 
 Is it the same?  Well, maybe so--and maybe not.  The subtle difference
 is that when you assign something in square brackets, you know for sure
 it's always a brand new reference with a new I<copy> of the data.
-Something else could be going on in this new case with the C<@{$AoA[$i]}>
-dereference on the left-hand-side of the assignment.  It all depends on
-whether C<$AoA[$i]> had been undefined to start with, or whether it
-already contained a reference.  If you had already populated @AoA with
-references, as in
+Something else could be going on in this new case with the
+C<< $AoA[$i]->@* >> dereference on the left-hand-side of the assignment.
+It all depends on whether C<$AoA[$i]> had been undefined to start with,
+or whether it already contained a reference.  If you had already
+populated @AoA with references, as in
 
     $AoA[3] = \@another_array;
 
 Then the assignment with the indirection on the left-hand-side would
 use the existing reference that was already there:
 
-    @{$AoA[3]} = @array;
+    $AoA[3]->@* = @array;
 
 Of course, this I<would> have the "interesting" effect of clobbering
 @another_array.  (Have you ever noticed how when a programmer says
@@ -241,12 +240,24 @@ much more easily understood constructors C<[]> and C<{}> instead of
 relying upon lexical (or dynamic) scoping and hidden reference-counting to
 do the right thing behind the scenes.
 
+Note also that there exists another way to write a dereference!  These
+two lines are equivalent:
+
+    $AoA[$i]->@* = @array;
+    @{ $AoA[$i] } = @array;
+
+The first form, called I<postfix dereference> is generally easier to
+read, because the expression can be read from left to right, and there
+are no enclosing braces to balance.  On the other hand, it is also
+newer.  It was added to the language in 2014, so you will often
+encounter the other form, I<circumfix dereference>, in older code.
+
 In summary:
 
     $AoA[$i] = [ @array ];     # usually best
     $AoA[$i] = \@array;        # perilous; just how my() was that array?
-    @{ $AoA[$i] } = @array;    # way too tricky for most programmers
-
+    $AoA[$i]->@*  = @array;    # way too tricky for most programmers
+    @{ $AoA[$i] } = @array;    # just as tricky, and also harder to read
 
 =head1 CAVEAT ON PRECEDENCE
 X<dereference, precedence> X<dereferencing, precedence>
@@ -269,9 +280,9 @@ dereference the thing at that subscript.  That's fine in C, but this isn't C.
 The seemingly equivalent construct in Perl, C<$$aref[$i]> first does
 the deref of $aref, making it take $aref as a reference to an
 array, and then dereference that, and finally tell you the I<i'th> value
-of the array pointed to by $AoA. If you wanted the C notion, you'd have to
-write C<${$AoA[$i]}> to force the C<$AoA[$i]> to get evaluated first
-before the leading C<$> dereferencer.
+of the array pointed to by $AoA. If you wanted the C notion, you could
+write C<< $AoA[$i]->$* >> to explicitly dereference the I<i'th> item,
+reading left to right.
 
 =head1 WHY YOU SHOULD ALWAYS C<use strict>
 
@@ -364,7 +375,7 @@ X<array of arrays> X<AoA>
  }
 
  # add to an existing row
- push @{ $AoA[0] }, "wilma", "betty";
+ push $AoA[0]->@*, "wilma", "betty";
 
 =head2 Access and Printing of an ARRAY OF ARRAYS
 
@@ -381,7 +392,7 @@ X<array of arrays> X<AoA>
 
  # print the whole thing with indices
  for $i ( 0 .. $#AoA ) {
-     print "\t [ @{$AoA[$i]} ],\n";
+     print "\t [ $AoA[$i]->@* ],\n";
  }
 
  # print the whole thing one at a time
@@ -431,7 +442,7 @@ X<hash of arrays> X<HoA>
  }
 
  # append new members to an existing family
- push @{ $HoA{"flintstones"} }, "wilma", "betty";
+ push $HoA{flintstones}->@*, "wilma", "betty";
 
 =head2 Access and Printing of a HASH OF ARRAYS
 
@@ -443,31 +454,31 @@ X<hash of arrays> X<HoA>
 
  # print the whole thing
  foreach $family ( keys %HoA ) {
-     print "$family: @{ $HoA{$family} }\n"
+     print "$family: $HoA{$family}->@* \n"
  }
 
  # print the whole thing with indices
  foreach $family ( keys %HoA ) {
      print "family: ";
-     foreach $i ( 0 .. $#{ $HoA{$family} } ) {
+     foreach $i ( 0 .. $HoA{$family}->$#* ) {
          print " $i = $HoA{$family}[$i]";
      }
      print "\n";
  }
 
  # print the whole thing sorted by number of members
- foreach $family ( sort { @{$HoA{$b}} <=> @{$HoA{$a}} } keys %HoA ) {
-     print "$family: @{ $HoA{$family} }\n"
+ foreach $family ( sort { $HoA{$b}->@* <=> $HoA{$a}->@* } keys %HoA ) {
+     print "$family: $HoA{$family}->@* \n"
  }
 
  # print the whole thing sorted by number of members and name
  foreach $family ( sort {
-                            @{$HoA{$b}} <=> @{$HoA{$a}}
-                                        ||
-                                    $a cmp $b
+                            $HoA{$b}->@* <=> $HoA{$a}->@*
+                                          ||
+                                      $a cmp $b
             } keys %HoA )
  {
-     print "$family: ", join(", ", sort @{ $HoA{$family} }), "\n";
+     print "$family: ", join(", ", sort $HoA{$family}->@* ), "\n";
  }
 
 =head1 ARRAYS OF HASHES
@@ -548,7 +559,7 @@ X<array of hashes> X<AoH>
  # print the whole thing with indices
  for $i ( 0 .. $#AoH ) {
      print "$i is { ";
-     for $role ( keys %{ $AoH[$i] } ) {
+     for $role ( keys $AoH[$i]->%* ) {
          print "$role=$AoH[$i]{$role} ";
      }
      print "}\n";
@@ -640,7 +651,7 @@ X<hash of hashes> X<HoH>
  # print the whole thing
  foreach $family ( keys %HoH ) {
      print "$family: { ";
-     for $role ( keys %{ $HoH{$family} } ) {
+     for $role ( keys $HoH{$family}->%* ) {
          print "$role=$HoH{$family}{$role} ";
      }
      print "}\n";
@@ -649,7 +660,7 @@ X<hash of hashes> X<HoH>
  # print the whole thing  somewhat sorted
  foreach $family ( sort keys %HoH ) {
      print "$family: { ";
-     for $role ( sort keys %{ $HoH{$family} } ) {
+     for $role ( sort keys $HoH{$family}->%* ) {
          print "$role=$HoH{$family}{$role} ";
      }
      print "}\n";
@@ -661,7 +672,7 @@ X<hash of hashes> X<HoH>
                                                              keys %HoH )
  {
      print "$family: { ";
-     for $role ( sort keys %{ $HoH{$family} } ) {
+     for $role ( sort keys $HoH{$family}->%* ) {
          print "$role=$HoH{$family}{$role} ";
      }
      print "}\n";
@@ -678,7 +689,7 @@ X<hash of hashes> X<HoH>
      print "$family: { ";
      # and print these according to rank order
      for $role ( sort { $rank{$a} <=> $rank{$b} }
-                                               keys %{ $HoH{$family} } )
+                                               keys $HoH{$family}->%* )
      {
          print "$role=$HoH{$family}{$role} ";
      }
@@ -709,7 +720,7 @@ many different sorts:
      $last = pop @ { $rec->{SEQUENCE} };
 
      print $rec->{LOOKUP}{"key"};
-     ($first_k, $first_v) = each %{ $rec->{LOOKUP} };
+     ($first_k, $first_v) = each $rec->{LOOKUP}->%*;
 
      $answer = $rec->{THATCODE}->($arg);
      $answer = $rec->{THISCODE}->($arg1, $arg2);
@@ -790,7 +801,7 @@ many different sorts:
      foreach $family (keys %TV) {
          $rec = $TV{$family}; # temp pointer
          @kids = ();
-         for $person ( @{ $rec->{members} } ) {
+         for $person ( $rec->{members}->@* ) {
              if ($person->{role} =~ /kid|son|daughter/) {
                  push @kids, $person;
              }
@@ -814,14 +825,14 @@ many different sorts:
      # print the whole thing
      foreach $family ( keys %TV ) {
          print "the $family";
-         print " is on during @{ $TV{$family}{nights} }\n";
+         print " is on during $TV{$family}{nights}->@*\n";
          print "its members are:\n";
-         for $who ( @{ $TV{$family}{members} } ) {
+         for $who ( $TV{$family}{members}->@* ) {
              print " $who->{name} ($who->{role}), age $who->{age}\n";
          }
          print "it turns out that $TV{$family}{lead} has ";
-         print scalar ( @{ $TV{$family}{kids} } ), " kids named ";
-         print join (", ", map { $_->{name} } @{ $TV{$family}{kids} } );
+         print scalar ( $TV{$family}{kids}->@* ), " kids named ";
+         print join (", ", map { $_->{name} } $TV{$family}{kids}->@* );
          print "\n";
      }
 

--- a/pod/perldsc.pod
+++ b/pod/perldsc.pod
@@ -395,8 +395,8 @@ X<array of arrays> X<AoA>
 
  # print the whole thing one at a time
  for $i ( 0 .. $#AoA ) {
-     for $j ( 0 .. $#{ $AoA[$i] } ) {
-         print "elt $i $j is $AoA[$i][$j]\n";
+     for $j ( 0 .. $AoA[$i]->$#* ) {
+         print "elem at ($i, $j) is $AoA[$i][$j]\n";
      }
  }
 
@@ -565,8 +565,8 @@ X<array of hashes> X<AoH>
 
  # print the whole thing one at a time
  for $i ( 0 .. $#AoH ) {
-     for $role ( keys %{ $AoH[$i] } ) {
-         print "elt $i $role is $AoH[$i]{$role}\n";
+     for $role ( keys $AoH[$i]->%* ) {
+         print "elem at ($i, $role) is $AoH[$i]{$role}\n";
      }
  }
 

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -1675,10 +1675,10 @@ The EXPR can be arbitrarily complicated provided its
 final operation is an element or slice of an aggregate:
 
     delete $ref->[$x][$y]{$key};
-    delete @{$ref->[$x][$y]}{$key1, $key2, @morekeys};
+    delete $ref->[$x][$y]->@{$key1, $key2, @morekeys};
 
     delete $ref->[$x][$y][$index];
-    delete @{$ref->[$x][$y]}[$index1, $index2, @moreindices];
+    delete $ref->[$x][$y]->@[$index1, $index2, @moreindices];
 
 =item die LIST
 X<die> X<throw> X<exception> X<raise> X<$@> X<abort>

--- a/pod/perllol.pod
+++ b/pod/perllol.pod
@@ -168,7 +168,7 @@ If you wanted just to append to a row, you'd have
 to do something a bit funnier looking:
 
     # add new columns to an existing row
-    push @{ $AoA[0] }, "wilma", "betty";   # explicit deref
+    push $AoA[0]->@*, "wilma", "betty";   # explicit deref
 
 =head2 Access and Printing
 
@@ -252,7 +252,7 @@ parsable Perl code.  For example:
 	   [ "george", "jane", "elroy" ],
 	   [ "homer", "marge", "bart" ],
  );
- push @{ $AoA[0] }, "wilma", "betty";
+ push $AoA[0]->@*, "wilma", "betty";
  show @AoA;
 
 will print out:
@@ -296,15 +296,9 @@ variable as before.
 
 That same loop could be replaced with a slice operation:
 
-    @part = @{$AoA[4]}[7..12];
+    @part = $AoA[4]->@[ 7..12 ];
 
-or spaced out a bit:
-
-    @part = @{ $AoA[4] } [ 7..12 ];
-
-But as you might well imagine, this can get pretty rough on the reader.
-
-Ah, but what if you wanted a I<two-dimensional slice>, such as having
+Now, what if you wanted a I<two-dimensional slice>, such as having
 $x run from 4..8 and $y run from 7 to 12?  Hmm... here's the simple way:
 
     @newAoA = ();
@@ -317,13 +311,13 @@ $x run from 4..8 and $y run from 7 to 12?  Hmm... here's the simple way:
 We can reduce some of the looping through slices
 
     for ($x = 4; $x <= 8; $x++) {
-	push @newAoA, [ @{ $AoA[$x] } [ 7..12 ] ];
+	push @newAoA, [ $AoA[$x]->@[ 7..12 ] ];
     }
 
 If you were into Schwartzian Transforms, you would probably
 have selected map for that
 
-    @newAoA = map { [ @{ $AoA[$_] } [ 7..12 ] ] } 4 .. 8;
+    @newAoA = map { [ $AoA[$_]->@[ 7..12 ] ] } 4 .. 8;
 
 Although if your manager accused you of seeking job security (or rapid
 insecurity) through inscrutable code, it would be hard to argue. :-)
@@ -336,7 +330,7 @@ If I were you, I'd put that in a function:
 	    $y_lo, $y_hi) = @_;
 
 	return map {
-	    [ @{ $lrr->[$_] } [ $y_lo .. $y_hi ] ]
+	    [ $lrr->[$_]->@[ $y_lo .. $y_hi ] ]
 	} $x_lo .. $x_hi;
     }
 

--- a/pod/perlobj.pod
+++ b/pod/perlobj.pod
@@ -1013,7 +1013,7 @@ Here's an example of a module as a blessed scalar:
 
   sub epoch {
       my $self = shift;
-      return ${ $self };
+      return $$self;
   }
 
   my $time = Time->new();

--- a/pod/perlperf.pod
+++ b/pod/perlperf.pod
@@ -318,7 +318,7 @@ report on the contents.
      my %rep;
 
      foreach my $line ( keys %report ) {
-         foreach my $key ( keys %{ $report{$line} } ) {
+         foreach my $key ( keys $report{$line}->%* ) {
              $rep{$key} += $report{$line}{$key};
          }
      }

--- a/pod/perlretut.pod
+++ b/pod/perlretut.pod
@@ -928,7 +928,8 @@ this code
     $x = "Mmm...donut, thought Homer";
     $x =~ /^(Mmm|Yech)\.\.\.(donut|peas)/; # matches
     foreach $exp (1..$#-) {
-        print "Match $exp: '${$exp}' at position ($-[$exp],$+[$exp])\n";
+        no strict 'refs';
+        print "Match $exp: '$$exp' at position ($-[$exp],$+[$exp])\n";
     }
 
 prints

--- a/pod/perlsub.pod
+++ b/pod/perlsub.pod
@@ -1467,7 +1467,7 @@ corresponding built-in.
    sub myjoin ($@)	   myjoin ":", $a, $b, $c
    sub mypop (\@)	   mypop @array
    sub mysplice (\@$$@)	   mysplice @array, 0, 2, @pushme
-   sub mykeys (\[%@])	   mykeys %{$hashref}
+   sub mykeys (\[%@])	   mykeys $hashref->%*
    sub myopen (*;$)	   myopen HANDLE, $name
    sub mypipe (**)	   mypipe READHANDLE, WRITEHANDLE
    sub mygrep (&@)	   mygrep { /foo/ } $a, $b, $c

--- a/pod/perltie.pod
+++ b/pod/perltie.pod
@@ -316,7 +316,7 @@ object I<this>. (Equivalent to C<scalar(@array)>).  For example:
 
     sub FETCHSIZE {
       my $self = shift;
-      return scalar @{$self->{ARRAY}};
+      return scalar $self->{ARRAY}->@*;
     }
 
 =item STORESIZE this, count
@@ -429,7 +429,7 @@ Remove last element of the array and return it.  For example:
 
     sub POP {
       my $self = shift;
-      return pop @{$self->{ARRAY}};
+      return pop $self->{ARRAY}->@*;
     }
 
 =item SHIFT this
@@ -440,7 +440,7 @@ and return it.  For example:
 
     sub SHIFT {
       my $self = shift;
-      return shift @{$self->{ARRAY}};
+      return shift $self->{ARRAY}->@*;
     }
 
 =item UNSHIFT this, LIST 
@@ -454,8 +454,8 @@ up to make room.  For example:
       my @list = @_;
       my $size = scalar( @list );
       # make room for our list
-      @{$self->{ARRAY}}[ $size .. $#{$self->{ARRAY}} + $size ]
-       = @{$self->{ARRAY}};
+      $self->{ARRAY}[ $size .. $self->{ARRAY}->$#* + $size ]->@*
+       = $self->{ARRAY}->@*
       $self->STORE( $_, $list[$_] ) foreach 0 .. $#list;
     }
 
@@ -484,7 +484,7 @@ In our example, we'll use a little shortcut if there is a I<LIST>:
         tie @list, __PACKAGE__, $self->{ELEMSIZE};
         @list   = @_;
       }
-      return splice @{$self->{ARRAY}}, $offset, $length, @list;
+      return splice $self->{ARRAY}->@*, $offset, $length, @list;
     }
 
 =item UNTIE this
@@ -754,7 +754,7 @@ dangerous thing that they'll have to set CLOBBER to something higher than
      croak "@{[&whowasi]}: won't remove all dot files for $self->{USER}"
          unless $self->{CLOBBER} > 1;
      my $dot;
-     foreach $dot ( keys %{$self->{LIST}}) {
+     foreach $dot ( keys $self->{LIST}->%* ) {
          $self->DELETE($dot);
      }
  }
@@ -782,8 +782,8 @@ to iterate through the hash, such as via a keys(), values(), or each() call.
     sub FIRSTKEY {
 	carp &whowasi if $DEBUG;
 	my $self = shift;
-	my $a = keys %{$self->{LIST}};  # reset each() iterator
-	each %{$self->{LIST}}
+	my $a = keys $self->{LIST}->%*;  # reset each() iterator
+	each $self->{LIST}->%*
     }
 
 FIRSTKEY is always called in scalar context and it should just
@@ -808,7 +808,7 @@ thing, but we'll have to go through the LIST field indirectly.
     sub NEXTKEY  {
 	carp &whowasi if $DEBUG;
 	my $self = shift;
-	return each %{ $self->{LIST} }
+	return each $self->{LIST}->%*
     }
 
 =item SCALAR this
@@ -835,7 +835,7 @@ referenced by C<$self-E<gt>{LIST}>:
     sub SCALAR {
 	carp &whowasi if $DEBUG;
 	my $self = shift;
-	return scalar %{ $self->{LIST} }
+	return scalar $self->{LIST}->%*
     }
 
 NOTE: In perl 5.25 the behavior of scalar %hash on an untied hash changed


### PR DESCRIPTION
I believe the updated document shows simpler code and will show people how to use postfix deref in the future, which will produce clearer code.

These changes should be read for correctness.  I think they're right, but it's just a little hairy!