### PR TITLE
t/op/taint.t:  Avert uninitialized value warning

### DIFF
--- a/t/op/taint.t
+++ b/t/op/taint.t
@@ -1565,7 +1565,7 @@ SKIP: {
         }
 
         skip "SysV shared memory operation failed", 1 unless 
-          $rcvd eq $sent;
+          ($rcvd // '') eq $sent;
 
         is_tainted($rcvd, "shmread");
     }

--- a/t/op/taint.t
+++ b/t/op/taint.t
@@ -1564,8 +1564,8 @@ SKIP: {
             warn "# shmget failed: $!\n";
         }
 
-        skip "SysV shared memory operation failed", 1 unless 
-          ($rcvd // '') eq $sent;
+        skip "SysV shared memory operation failed", 1
+            unless defined $rcvd and $rcvd eq $sent;
 
         is_tainted($rcvd, "shmread");
     }


### PR DESCRIPTION
In the test of shmread, if $id is undefined after the attempted
assignment by shmget(), we get the "# shmget failed" warning and, since
nothing has been read into $rcvd, that variable remains undefined.  If
$rcvd is undefined it will never be string-equal to $sent, which
means the 'skip' condition will be exercised.

Commit 56249513ac made this file run with warnings enabled, so now the
lack of assignment to $rcvd generates an uninitialized value warning
(observed in smoke-test reports on FreeBSD).  This patch accounts for
non-definition of $rcvd and prevents that warning from being emitted.