### PR TITLE
pp_modulo: some microoptimizations

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -1564,6 +1564,7 @@ PP(pp_modulo)
                 right_neg = TRUE;
 		dright = -dright;
             }
+            assert(dright >= UV_MAX_P1 || dright == 0);
 	}
 
         /* At this point, right is in range for a UV. (A in-range NV has been
@@ -1610,6 +1611,8 @@ PP(pp_modulo)
 		left_neg = TRUE;
 		dleft = -dleft;
             }
+
+            assert(dleft >= UV_MAX_P1 || dleft == 0);
 
             /* This should be exactly the 5.6 behaviour - if left and right are
                both in range for UV then use U_V() rather than floor.


### PR DESCRIPTION
This commit bundles three minor changes. The first two should be uncontroversial:
- Remove unnecessary stack pointer operations: `TOPs` & `TOPm1s`, `sp =-2`, `PUSHTARG` replace by `POPs`, `TOPs`, `SETTARG`
- Remove double negatives when determining if `svr` or `svl` is negative ( !!SvUOK(x) ) and in the process potentially avoid changing the relevant boolean to only change it back again almost immediately.

The third might need more scrutiny - the change is logical in itself, but why was this dead code present in the first place? (_Update: the initial analysis was incorrect and this third change will be/has been backed out._)
- Remove unreachable code and the therefore unnecessary `dright_valid` boolean. The rationale being that after initialization, that bool is set only once:
```
            if (dright < UV_MAX_P1) {
                right = U_V(dright);
                dright_valid = TRUE; /* In case we need to use double below.  */
            } else {
                use_double = TRUE;
            }
```
It's plain there that either `dright_valid` is true _or_ `use_double` is true. The bool is used in only one place:
```
            /* This should be exactly the 5.6 behaviour - if left and right are
               both in range for UV then use U_V() rather than floor.  */
            if (!use_double) {
                if (dleft < UV_MAX_P1) {
                    ...
                }
                /* left is out of range for UV, right was in range, so promote
                   right (back) to double.  */
                else {
                    /* The +0.5 is used in 5.6 even though it is not strictly
                       consistent with the implicit +0 floor in the U_V()
                       inside the #if 1. */
                    dleft = Perl_floor(dleft + 0.5);
                    use_double = TRUE;
                    if (dright_valid)
                        dright = Perl_floor(dright + 0.5);
                    else
                        dright = right;
                }
            }
```
Since we know that `use_double` is not true when if `(!use_double)` succeeds, `if (dright_valid)` must therefore always be true.