### PR TITLE
Update Archive-Tar to CPAN version 2.38

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -123,7 +123,7 @@ use File::Glob qw(:case);
 %Modules = (
 
     'Archive::Tar' => {
-        'DISTRIBUTION' => 'BINGOS/Archive-Tar-2.36.tar.gz',
+        'DISTRIBUTION' => 'BINGOS/Archive-Tar-2.38.tar.gz',
         'FILES'        => q[cpan/Archive-Tar],
         'BUGS'         => 'bug-archive-tar@rt.cpan.org',
         'EXCLUDED'     => [

--- a/cpan/Archive-Tar/bin/ptar
+++ b/cpan/Archive-Tar/bin/ptar
@@ -1,5 +1,6 @@
 #!/usr/bin/perl
 use strict;
+use warnings;
 
 BEGIN { pop @INC if $INC[-1] eq '.' }
 use File::Find;

--- a/cpan/Archive-Tar/bin/ptardiff
+++ b/cpan/Archive-Tar/bin/ptardiff
@@ -2,6 +2,7 @@
 
 BEGIN { pop @INC if $INC[-1] eq '.' }
 use strict;
+use warnings;
 use Archive::Tar;
 use Getopt::Std;
 

--- a/cpan/Archive-Tar/lib/Archive/Tar.pm
+++ b/cpan/Archive-Tar/lib/Archive/Tar.pm
@@ -31,7 +31,7 @@ use vars qw[$DEBUG $error $VERSION $WARN $FOLLOW_SYMLINK $CHOWN $CHMOD
 $DEBUG                  = 0;
 $WARN                   = 1;
 $FOLLOW_SYMLINK         = 0;
-$VERSION                = "2.36";
+$VERSION                = "2.38";
 $CHOWN                  = 1;
 $CHMOD                  = 1;
 $SAME_PERMISSIONS       = $> == 0 ? 1 : 0;
@@ -48,7 +48,7 @@ BEGIN {
     ### switch between perlio and IO::String
     $HAS_IO_STRING = eval {
         require IO::String;
-        import IO::String;
+        IO::String->import;
         1;
     } || 0;
 }
@@ -918,7 +918,7 @@ sub _extract_file {
     }
 
     if( $CHOWN && CAN_CHOWN->() and not -l $full ) {
-        chown $entry->uid, $entry->gid, $full or
+        CORE::chown( $entry->uid, $entry->gid, $full ) or
             $self->_error( qq[Could not set uid/gid on '$full'] );
     }
 
@@ -929,7 +929,7 @@ sub _extract_file {
         unless ($SAME_PERMISSIONS) {
             $mode &= ~(oct(7000) | umask);
         }
-        chmod $mode, $full or
+        CORE::chmod( $mode, $full ) or
             $self->_error( qq[Could not chown '$full' to ] . $entry->mode );
     }
 
@@ -2284,7 +2284,7 @@ write a C<.tar.Z> file
     use Archive::Tar;
     use IO::File;
 
-    my $fh = new IO::File "| compress -c >$filename";
+    my $fh = IO::File->new( "| compress -c >$filename" );
     my $tar = Archive::Tar->new();
     ...
     $tar->write($fh);

--- a/cpan/Archive-Tar/lib/Archive/Tar/Constant.pm
+++ b/cpan/Archive-Tar/lib/Archive/Tar/Constant.pm
@@ -1,18 +1,20 @@
 package Archive::Tar::Constant;
 
+use strict;
+use warnings;
+
+use vars qw[$VERSION @ISA @EXPORT];
+
 BEGIN {
     require Exporter;
 
-    $VERSION    = '2.36';
+    $VERSION    = '2.38';
     @ISA        = qw[Exporter];
 
     require Time::Local if $^O eq "MacOS";
 }
 
 @EXPORT = Archive::Tar::Constant->_list_consts( __PACKAGE__ );
-
-use strict;
-use warnings;
 
 use constant FILE           => 0;
 use constant HARDLINK       => 1;

--- a/cpan/Archive-Tar/lib/Archive/Tar/File.pm
+++ b/cpan/Archive-Tar/lib/Archive/Tar/File.pm
@@ -7,13 +7,11 @@ use File::Spec::Unix    ();
 use File::Spec          ();
 use File::Basename      ();
 
-### avoid circular use, so only require;
-require Archive::Tar;
 use Archive::Tar::Constant;
 
 use vars qw[@ISA $VERSION];
 #@ISA        = qw[Archive::Tar];
-$VERSION    = '2.36';
+$VERSION    = '2.38';
 
 ### set value to 1 to oct() it during the unpack ###
 
@@ -469,6 +467,8 @@ sub extract {
 
     local $Carp::CarpLevel += 1;
 
+    ### avoid circular use, so only require;
+    require Archive::Tar;
     return Archive::Tar->_extract_file( $self, @_ );
 }
 

--- a/cpan/Archive-Tar/t/01_use.t
+++ b/cpan/Archive-Tar/t/01_use.t
@@ -3,5 +3,5 @@ use strict;
 
 use_ok('Archive::Tar') or diag 'Archive::Tar not found -- exit' && die;
 
-my $tar = new Archive::Tar;
+my $tar = Archive::Tar->new;
 isa_ok( $tar, 'Archive::Tar', 'Object created' );

--- a/cpan/Archive-Tar/t/02_methods.t
+++ b/cpan/Archive-Tar/t/02_methods.t
@@ -805,7 +805,7 @@ sub slurp_compressed_file {
     ### gzip
     } else {
         require IO::Zlib;
-        $fh = new IO::Zlib;
+        $fh = IO::Zlib->new();
         $fh->open( $file, READ_ONLY->(1) )
             or warn( "Error opening '$file' with IO::Zlib" ), return
     }

--- a/cpan/Archive-Tar/t/99_pod.t
+++ b/cpan/Archive-Tar/t/99_pod.t
@@ -16,6 +16,8 @@ find( sub { push @files, File::Spec->catfile(
                     File::Spec->splitdir( $File::Find::dir ), $_
                 ) if /\.p(?:l|m|od)$/ }, File::Spec->catdir(qw(.. blib lib) ));
 
+plan skip_all => "No tests to run" unless scalar @files;
+
 plan tests => scalar @files;
 for my $file ( @files ) {
     pod_file_ok( $file );


### PR DESCRIPTION
[DELTA]

2.38  25/06/2020 (ATOOMIC)
- Avoid indirect calls
- Add use warnings to bin/ptar*