### PR TITLE
perlapi: croak_nocontext is preferred over plain croak

### DIFF
--- a/util.c
+++ b/util.c
@@ -1873,8 +1873,10 @@ or build an error message in an SV yourself, it is preferable to use
 the C<L</croak_sv>> function, which does not involve clobbering C<ERRSV>.
 
 The two forms differ only in that C<croak_nocontext> does not take a thread
-context (C<aTHX>) parameter, so is used in situations where the caller doesn't
-already have the thread context.
+context (C<aTHX>) parameter.  It is hence slightly smaller, and slightly
+slower than plain C<Perl_croak>.  When choosing which of the two to use,
+consider that saving space may very well be more important than saving time at
+the point of death.
 
 =cut
 */


### PR DESCRIPTION
When you are about to die, the time/space tradeoff goes towards space.