### PR TITLE
t/op/svleak.t: Remove superfluous 'no strict' and 'no warnings'

### DIFF
--- a/t/op/svleak.t
+++ b/t/op/svleak.t
@@ -508,8 +508,6 @@ leak(5, 0, sub { scalar &const_av_xsub_leaked }, "const_av_sub in scalar context
 # check that OP_MULTIDEREF doesn't leak when compiled and then freed
 
 eleak(2, 0, <<'EOF', 'OP_MULTIDEREF');
-no strict;
-no warnings;
 my ($x, @a, %h, $r, $k, $i);
 $x = $a[0]{foo}{$k}{$i};
 $x = $h[0]{foo}{$k}{$i};


### PR DESCRIPTION
It turns out that the code within the heredoc is already strict- and
warnings-compliant, so there's no need to relax strictures or warnings
within the block.