### PR TITLE
Update ExtUtils-Install to CPAN version 2.18

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -462,7 +462,7 @@ use File::Glob qw(:case);
     },
 
     'ExtUtils::Install' => {
-        'DISTRIBUTION' => 'BINGOS/ExtUtils-Install-2.16.tar.gz',
+        'DISTRIBUTION' => 'BINGOS/ExtUtils-Install-2.18.tar.gz',
         'FILES'        => q[cpan/ExtUtils-Install],
         'EXCLUDED'     => [
             qw( t/lib/Test/Builder.pm

--- a/cpan/ExtUtils-Install/lib/ExtUtils/Install.pm
+++ b/cpan/ExtUtils-Install/lib/ExtUtils/Install.pm
@@ -32,11 +32,11 @@ ExtUtils::Install - install files from here to there
 
 =head1 VERSION
 
-2.16
+2.18
 
 =cut
 
-our $VERSION = '2.16';  # <-- do not forget to update the POD section just above this line!
+our $VERSION = '2.18';  # <-- do not forget to update the POD section just above this line!
 $VERSION = eval $VERSION;
 
 =pod

--- a/cpan/ExtUtils-Install/lib/ExtUtils/Installed.pm
+++ b/cpan/ExtUtils-Install/lib/ExtUtils/Installed.pm
@@ -1,7 +1,6 @@
+use strict;
 package ExtUtils::Installed;
 
-use 5.00503;
-use strict;
 #use warnings; # XXX requires 5.6
 use Carp qw();
 use ExtUtils::Packlist;
@@ -16,8 +15,7 @@ my $DOSISH = ($^O =~ /^(MSWin\d\d|os2|dos|mint)$/);
 
 require VMS::Filespec if $Is_VMS;
 
-use vars qw($VERSION);
-$VERSION = '2.16';
+our $VERSION = '2.18';
 $VERSION = eval $VERSION;
 
 sub _is_prefix {

--- a/cpan/ExtUtils-Install/lib/ExtUtils/Packlist.pm
+++ b/cpan/ExtUtils-Install/lib/ExtUtils/Packlist.pm
@@ -1,11 +1,10 @@
 package ExtUtils::Packlist;
-
-use 5.00503;
 use strict;
+
 use Carp qw();
 use Config;
-use vars qw($VERSION $Relocations);
-$VERSION = '2.16';
+our $Relocations;
+our $VERSION = '2.18';
 $VERSION = eval $VERSION;
 
 # Used for generating filehandle globs.  IO::File might not be available!

--- a/cpan/ExtUtils-Install/t/Install.t
+++ b/cpan/ExtUtils-Install/t/Install.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl -w
+use strict;
 
 # Test ExtUtils::Install.
 
@@ -6,7 +7,6 @@ BEGIN {
     unshift @INC, 't/lib';
 }
 
-use strict;
 use TieOut;
 use File::Path;
 use File::Spec;

--- a/cpan/ExtUtils-Install/t/InstallWithMM.t
+++ b/cpan/ExtUtils-Install/t/InstallWithMM.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl -w
+use strict;
 
 # Make sure EUI works with MakeMaker
 
@@ -6,7 +7,6 @@ BEGIN {
     unshift @INC, 't/lib';
 }
 
-use strict;
 use Config;
 use ExtUtils::MakeMaker;
 

--- a/cpan/ExtUtils-Install/t/Installapi2.t
+++ b/cpan/ExtUtils-Install/t/Installapi2.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl -w
+use strict;
 
 # Test ExtUtils::Install.
 
@@ -6,7 +7,6 @@ BEGIN {
     unshift @INC, 't/lib';
 }
 
-use strict;
 use TieOut;
 use File::Path;
 use File::Spec;

--- a/cpan/ExtUtils-Install/t/Installed.t
+++ b/cpan/ExtUtils-Install/t/Installed.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl -w
+use strict;
 
 # Test ExtUtils::Installed
 
@@ -9,7 +10,6 @@ BEGIN {
 
 my $Is_VMS = $^O eq 'VMS';
 
-use strict;
 
 use Config;
 use Cwd;
@@ -92,16 +92,17 @@ END { ok(chdir $startdir, "Return to where we started"); }
     my $fakepath = File::Spec->catdir('auto', $fakedir);
     ok( mkpath($fakepath), "Able to create directory $fakepath for testing" );
 
-    ok(open(PACKLIST, '>', File::Spec->catfile($fakepath, '.packlist')));
+    ok(open(PACKLIST, '>', File::Spec->catfile($fakepath, '.packlist')),
+        "Able to open .packlist for writing");
     print PACKLIST 'list';
     close PACKLIST;
 
-    ok(open(FAKEMOD, '>', File::Spec->catfile($fakepath, 'FakeMod.pm')));
+    ok(open(FAKEMOD, '>', File::Spec->catfile($fakepath, 'FakeMod.pm')),
+        "Able to open FakeMod.pm for writing");
 
     print FAKEMOD <<'FAKE';
 package FakeMod;
-use vars qw( $VERSION );
-$VERSION = '1.1.1';
+our $VERSION = '1.1.1';
 1;
 FAKE
 

--- a/cpan/ExtUtils-Install/t/Packlist.t
+++ b/cpan/ExtUtils-Install/t/Packlist.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl -w
+use strict;
 
 BEGIN {
     unshift @INC, 't/lib';
@@ -162,6 +163,7 @@ is( ExtUtils::Packlist::packlist_file({ packfile => 'pl' }), 'pl',
 is( ExtUtils::Packlist::packlist_file($pl), 'eplist',
 	'packlist_file() should fetch packlist from ExtUtils::Packlist object' );
 
+my $w  = 0;
 BEGIN {
 	# Call mkfh at BEGIN time, to make sure it does not trigger "Used
 	# once" warnings.

--- a/cpan/ExtUtils-Install/t/lib/MakeMaker/Test/Setup/BFD.pm
+++ b/cpan/ExtUtils-Install/t/lib/MakeMaker/Test/Setup/BFD.pm
@@ -1,10 +1,10 @@
 package MakeMaker::Test::Setup::BFD;
-
-@ISA = qw(Exporter);
-require Exporter;
-@EXPORT = qw(setup_recurs teardown_recurs);
-
 use strict;
+
+our @ISA = qw(Exporter);
+require Exporter;
+our @EXPORT = qw(setup_recurs teardown_recurs);
+
 use File::Path;
 use File::Basename;
 use MakeMaker::Test::Utils;

--- a/cpan/ExtUtils-Install/t/lib/MakeMaker/Test/Utils.pm
+++ b/cpan/ExtUtils-Install/t/lib/MakeMaker/Test/Utils.pm
@@ -1,7 +1,7 @@
 package MakeMaker::Test::Utils;
+use strict;
 
 use File::Spec;
-use strict;
 use Config;
 
 require Exporter;

--- a/cpan/ExtUtils-Install/t/lib/TieOut.pm
+++ b/cpan/ExtUtils-Install/t/lib/TieOut.pm
@@ -1,4 +1,5 @@
 package TieOut;
+use strict;
 
 sub TIEHANDLE {
     my $scalar = '';


### PR DESCRIPTION
[DELTA]

2.18

- Add descriptions for 3 tests lacking them
- Removed bundled Test::More from t/lib
- 'use strict' added to all files where missing
- 'use vars' replaced with 'our'
- Properly scope all variables
- Minimal supported perl version is now v5.6.0