### PR TITLE
prevent a spurious error output from test.pl when killing a cygwin process

### DIFF
--- a/t/test.pl
+++ b/t/test.pl
@@ -1716,7 +1716,7 @@ sub watchdog ($;$)
 		if ($is_cygwin) {
 		    # sometimes the above isn't enough on cygwin
 		    sleep 1; # wait a little, it might have worked after all
-		    system("/bin/kill -f $pid_to_kill");
+		    system("/bin/kill -f $pid_to_kill") if kill(0, $pid_to_kill);
 		}
             }
 


### PR DESCRIPTION
Under Cygwin a process can sometimes take a little while to spool down after being killed. There already is code to wait a second and retry. However if the process has already disappeared in the wait second, then the retry is engaged anyhow and will then complain it can't find the process.

This change makes it so test.pl only truly attempts to kill a cygwin process if it actually is still around.

This resolves the secondary bug in #18129.