### PR TITLE
prevent regex/alarm test from timing out on cygwin

### DIFF
--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -1904,7 +1904,7 @@ EOP
         {
             fresh_perl_is('
                 BEGIN{require q(test.pl);}
-                watchdog(3);
+                watchdog( $^O eq "cygwin" ? 60 : 3 );
                 $SIG{ALRM} = sub {print "Timeout\n"; exit(1)};
                 alarm 1;
                 $_ = "a" x 1000 . "b" x 1000 . "c" x 1000;


### PR DESCRIPTION
This is an attempt to see if the primary issue of #18129 can be fixed with an increased watchdog timeout.