### PR TITLE
Trap SIGBUS when Configure checks for va_copy

### DIFF
--- a/Configure
+++ b/Configure
@@ -21511,6 +21511,9 @@ int
 main(int ac, char **av)
 {
   signal(SIGSEGV, exit);
+#ifdef SIGBUS
+  signal(SIGBUS, exit);
+#endif
 
   myprintf("%s%cs all right, then\n", "that", '\'');
   exit(0);


### PR DESCRIPTION
On several systems the attempt to determine if we "need va_copy() or
similar" results in a SIGBUS instead of a SIGSEGV because the fault
happens pointing at an io device address.

While reviewing accounting logs during the OpenBSD system build, bluhm@
noticed a core dump and deraadt@ tracked it down.

While researching it was discovered that this is a fairly common case in
other systems as well.

Original diff by deraadt@

[This was committed to OpenBSD already](https://github.com/openbsd/src/commit/20d289b5b98feec663b37dcc4dc5660605573276).