### PR TITLE
skip the failing dynamic vs static tests on Win32

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -488,6 +488,11 @@ use File::Glob qw(:case);
             'README.packaging',
             'lib/ExtUtils/MakeMaker/version/vpp.pm',
         ],
+        'CUSTOMIZED' => [
+            # https://github.com/Perl/perl5/issues/17601
+            # https://rt.cpan.org/Ticket/Display.html?id=115321
+            't/lib/MakeMaker/Test/Setup/XS.pm',
+        ],
     },
 
 	'ExtUtils::PL2Bat' => {

--- a/cpan/ExtUtils-MakeMaker/t/lib/MakeMaker/Test/Setup/XS.pm
+++ b/cpan/ExtUtils-MakeMaker/t/lib/MakeMaker/Test/Setup/XS.pm
@@ -400,11 +400,17 @@ sub list_dynamic {
         $^O !~ m!^(VMS|aix)$! ? ([ 'subdirscomplex', '', '' ]) : (),
     ) : (), # DynaLoader different
     [ 'subdirs', '', '' ],
-    [ 'subdirsstatic', ' LINKTYPE=dynamic', ' LINKTYPE=dynamic' ],
-    [ 'subdirsstatic', ' dynamic', '_dynamic' ],
+    # https://github.com/Perl/perl5/issues/17601
+    # https://rt.cpan.org/Ticket/Display.html?id=115321
+    $^O ne 'MSWin32' ? (
+        [ 'subdirsstatic', ' LINKTYPE=dynamic', ' LINKTYPE=dynamic' ],
+        [ 'subdirsstatic', ' dynamic', '_dynamic' ],
+    ) : (),
     [ 'multi', '', '' ],
-    [ 'staticmulti', ' LINKTYPE=dynamic', ' LINKTYPE=dynamic' ],
-    [ 'staticmulti', ' dynamic', '_dynamic' ],
+    $^O ne 'MSWin32' ? (
+        [ 'staticmulti', ' LINKTYPE=dynamic', ' LINKTYPE=dynamic' ],
+        [ 'staticmulti', ' dynamic', '_dynamic' ],
+    ) : (),
     [ 'xsbuild', '', '' ],
     [ 'subdirsskip', '', '' ],
   );

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -9,6 +9,7 @@ Digest::MD5 cpan/Digest-MD5/MD5.pm df5f0663f0f755be7eda6e3d2f008f2629246b19
 Digest::MD5 cpan/Digest-MD5/MD5.xs 249bed648232192ce018f7f894ad127c3a639831
 Digest::MD5 cpan/Digest-MD5/t/files.t e987329d2411ff60ad9a2bdf93fdf5f6943467e8
 ExtUtils::Constant cpan/ExtUtils-Constant/t/Constant.t d5c75c41d6736a0c5897130f534af0896a7d6f4d
+ExtUtils::MakeMaker cpan/ExtUtils-MakeMaker/t/lib/MakeMaker/Test/Setup/XS.pm 9dd84951b7602239516659c15d23c3c9eeebd1ab
 ExtUtils::PL2Bat cpan/ExtUtils-PL2Bat/t/make_executable.t 6e63dbf43ee7ff5a54e615a576360cb0f1825694
 Filter::Util::Call pod/perlfilter.pod 9b4aec0d8518274ddb0dd37e3b770fe13a44dd1f
 Locale::Maketext::Simple cpan/Locale-Maketext-Simple/lib/Locale/Maketext/Simple.pm 57ed38905791a17c150210cd6f42ead22a7707b6


### PR DESCRIPTION
workaround for #17601

The test only fails for non-threaded builds, but if the code accessed non-interprete global variables rather than just interpreter globals, it would fail for threaded builds too.