### PR TITLE
pp_split: reify using NULL rather than PL_sv_undef (gh#18077)

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -6045,11 +6045,15 @@ PP(pp_split)
 	}
 	else {
 	    if (!AvREAL(ary)) {
-		I32 i;
 		AvREAL_on(ary);
 		AvREIFY_off(ary);
-		for (i = AvFILLp(ary); i >= 0; i--)
-		    AvARRAY(ary)[i] = &PL_sv_undef; /* don't free mere refs */
+
+		/* Note: the above av_clear(ary) above should */
+		/* have set AvFILLp(ary) = -1, so this Zero() */
+		/* may well be superfluous.                   */
+
+		/* don't free mere refs */
+		Zero(AvARRAY(ary), AvFILLp(ary) + 1, SV*);
 	    }
 	    /* temporarily switch stacks */
 	    SAVESWITCHSTACK(PL_curstack, ary);


### PR DESCRIPTION
Non-existent array elements have been represented by `NULL `rather than `&PL_sv_undef` since ce0d59f. As discussed in #18077, an instance of reification in pp_split seems to have not been updated to match.

I'm not sure what ideal Perl code for performance testing is, but trying with @_ suggested that there's little difference between:
```
        for (i = AvFILLp(ary); i >= 0; i--)
	    AvARRAY(ary)[i] = NULL;
```
and
```
        Zero(AvARRAY(ary),AvFILLp(ary) + 1,SV*);
```
I just went with the latter because it results in a very slightly (16 bytes) smaller pp.o.

_make test_ succeeds locally (64 bit Linux).