### PR TITLE
Last bits of Perl 6 -> Raku

### DIFF
--- a/ext/mro/mro.pm
+++ b/ext/mro/mro.pm
@@ -12,7 +12,7 @@ use warnings;
 
 # mro.pm versions < 1.00 reserved for MRO::Compat
 #  for partial back-compat to 5.[68].x
-our $VERSION = '1.24';
+our $VERSION = '1.25';
 
 require XSLoader;
 XSLoader::load('mro');
@@ -89,7 +89,7 @@ resolution order under multiple inheritance. It was first introduced in
 the language Dylan (see links in the L</"SEE ALSO"> section), and then
 later adopted as the preferred MRO (Method Resolution Order) for the
 new-style classes in Python 2.3. Most recently it has been adopted as the
-"canonical" MRO for Perl 6 classes, and the default MRO for Parrot objects
+"canonical" MRO for Raku classes, and the default MRO for Parrot objects
 as well.
 
 =head2 How does C3 work

--- a/ext/mro/mro.pm
+++ b/ext/mro/mro.pm
@@ -89,8 +89,7 @@ resolution order under multiple inheritance. It was first introduced in
 the language Dylan (see links in the L</"SEE ALSO"> section), and then
 later adopted as the preferred MRO (Method Resolution Order) for the
 new-style classes in Python 2.3. Most recently it has been adopted as the
-"canonical" MRO for Raku classes, and the default MRO for Parrot objects
-as well.
+"canonical" MRO for Raku classes.
 
 =head2 How does C3 work
 

--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -5,7 +5,7 @@
 
 package feature;
 
-our $VERSION = '1.60';
+our $VERSION = '1.61';
 
 our %feature = (
     fc               => 'feature_fc',
@@ -138,7 +138,7 @@ disable I<all> features (an unusual request!) use C<no feature ':all'>.
 
 =head2 The 'say' feature
 
-C<use feature 'say'> tells the compiler to enable the Perl 6 style
+C<use feature 'say'> tells the compiler to enable the Raku-inspired
 C<say> function.
 
 See L<perlfunc/say> for details.
@@ -162,7 +162,7 @@ explicitly disabled the warning:
 
     no warnings "experimental::smartmatch";
 
-C<use feature 'switch'> tells the compiler to enable the Perl 6
+C<use feature 'switch'> tells the compiler to enable the Raku
 given/when construct.
 
 See L<perlsyn/"Switch Statements"> for details.

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -476,7 +476,7 @@ read_only_bottom_close_and_rename($h);
 __END__
 package feature;
 
-our $VERSION = '1.60';
+our $VERSION = '1.61';
 
 FEATURES
 
@@ -544,7 +544,7 @@ disable I<all> features (an unusual request!) use C<no feature ':all'>.
 
 =head2 The 'say' feature
 
-C<use feature 'say'> tells the compiler to enable the Perl 6 style
+C<use feature 'say'> tells the compiler to enable the Raku-inspired
 C<say> function.
 
 See L<perlfunc/say> for details.
@@ -568,7 +568,7 @@ explicitly disabled the warning:
 
     no warnings "experimental::smartmatch";
 
-C<use feature 'switch'> tells the compiler to enable the Perl 6
+C<use feature 'switch'> tells the compiler to enable the Raku
 given/when construct.
 
 See L<perlsyn/"Switch Statements"> for details.


### PR DESCRIPTION
In #17868, we addressed a few lingering "Perl 6" references and changed them Raku. It was done further down the release cycle so changes that required bumping versions were not allowed. This included `feature` and `mro`, which this PR updates.