### PR TITLE
GH #18109: Detect failures with HTTP::Tiny in sync-with-cpan:

### DIFF
--- a/Porting/sync-with-cpan
+++ b/Porting/sync-with-cpan
@@ -300,20 +300,30 @@ if ($cpan_mod =~ /-/ && $cpan_mod !~ /::/) {
 
 sub wget {
     my ($url, $saveas) = @_;
+    my $ht_res;
     eval {
         require IO::Socket::SSL;
         require Net::SSLeay;
         require HTTP::Tiny;
-        my $http= HTTP::Tiny->new();
-        $http->mirror( $url => $saveas );
-        1
+        my $http = HTTP::Tiny->new();
+        $ht_res  = $http->mirror( $url => $saveas );
+        1;
     } or
+       # Try harder to download the file
        # Some system do not have wget.  Fall back to curl if we do not
        # have it.  On Windows, `which wget` is not going to work, so
        # just use wget, as this script has always done.
        WIN32 || -x substr(`which wget`, 0, -1)
          ? system wget => $url, '-qO', $saveas
          : system curl => $url, '-sSo', $saveas;
+
+    # We were able to use HTTP::Tiny and it didn't have fatal errors,
+    # but we failed the request
+    if ( $ht_res && ! $ht_res->{'success'} ) {
+        die "Cannot retrieve file: $url\n" .
+            sprintf "Status: %s\nReason: %s\nContent: %s\n",
+            map $_ // '(unavailable)', @{$ht_res}{qw< status reason content >};
+    }
 }
 
 #


### PR DESCRIPTION
The original code uses `HTTP::Tiny` and if it fails, we try alternatives.

This isn't the best strategy because it might fail for legitimate
reasons and we need to separate whether it failed for a reason that
other user agents will fail or if it failed without crashing.

But, meh. We try to detect whether it succeeded in the function call
(as in, didn't crash) but failed in the request itself, and then we
surface it.

I've enabled an unavailable proxy configuration and tested it. This
is what it looks like:

    $ perl Porting/sync-with-cpan CPAN
    Cannot retrieve file: http://www.cpan.org/modules/02packages.details.txt
    Status: 599
    Reason: Internal Exception
    Content: Could not connect to 'proxy.xxx.yyy.com:8080': No address associated with hostname

Removing the proxy configuration, it succeeded.