### PR TITLE
Update MIME-Base64 to CPAN version 3.16

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1453,10 +1453,11 @@ cpan/Memoize/t/tie_sdbm.t		Memoize SDBM interface test
 cpan/Memoize/t/tie_storable.t		Memoize Storable interface test
 cpan/Memoize/t/tiefeatures.t		Memoize FAULT / MERGE / HASH options test
 cpan/Memoize/t/unmemoize.t		Memoize 'unmemoize' function test
-cpan/MIME-Base64/Base64.pm		MIME::Base64 extension
 cpan/MIME-Base64/Base64.xs		MIME::Base64 extension
-cpan/MIME-Base64/QuotedPrint.pm		MIME::Base64 extension
+cpan/MIME-Base64/lib/MIME/Base64.pm
+cpan/MIME-Base64/lib/MIME/QuotedPrint.pm
 cpan/MIME-Base64/t/base64.t		See whether MIME::Base64 works
+cpan/MIME-Base64/t/base64url.t
 cpan/MIME-Base64/t/length.t	See whether MIME::QuotedPrint works
 cpan/MIME-Base64/t/quoted-print.t	See whether MIME::QuotedPrint works
 cpan/MIME-Base64/t/unicode.t		See whether MIME::Base64 works

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -816,9 +816,9 @@ use File::Glob qw(:case);
     },
 
     'MIME::Base64' => {
-        'DISTRIBUTION' => 'GAAS/MIME-Base64-3.15.tar.gz',
+        'DISTRIBUTION' => 'CAPOEIRAB/MIME-Base64-3.16.tar.gz',
         'FILES'        => q[cpan/MIME-Base64],
-        'EXCLUDED'     => ['t/bad-sv.t'],
+        'EXCLUDED'     => [ qr{^xt/}, 'benchmark', 'benchmark-qp', qr{^t/00-report-prereqs} ],
     },
 
     'Module::CoreList' => {

--- a/cpan/MIME-Base64/Base64.xs
+++ b/cpan/MIME-Base64/Base64.xs
@@ -25,16 +25,10 @@ metamail, which comes with this message:
 */
 
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 #define PERL_NO_GET_CONTEXT     /* we want efficiency */
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
-#ifdef __cplusplus
-}
-#endif
 
 #define MAX_LINE  76 /* size of encoded lines */
 

--- a/cpan/MIME-Base64/lib/MIME/Base64.pm
+++ b/cpan/MIME-Base64/lib/MIME/Base64.pm
@@ -1,14 +1,14 @@
 package MIME::Base64;
 
 use strict;
-use vars qw(@ISA @EXPORT @EXPORT_OK $VERSION);
+use warnings;
 
 require Exporter;
-@ISA = qw(Exporter);
-@EXPORT = qw(encode_base64 decode_base64);
-@EXPORT_OK = qw(encode_base64url decode_base64url encoded_base64_length decoded_base64_length);
+our @ISA = qw(Exporter);
+our @EXPORT = qw(encode_base64 decode_base64);
+our @EXPORT_OK = qw(encode_base64url decode_base64url encoded_base64_length decoded_base64_length);
 
-$VERSION = '3.15';
+our $VERSION = '3.16';
 
 require XSLoader;
 XSLoader::load('MIME::Base64', $VERSION);

--- a/cpan/MIME-Base64/lib/MIME/QuotedPrint.pm
+++ b/cpan/MIME-Base64/lib/MIME/QuotedPrint.pm
@@ -1,13 +1,13 @@
 package MIME::QuotedPrint;
 
 use strict;
-use vars qw(@ISA @EXPORT $VERSION);
+use warnings;
 
 require Exporter;
-@ISA = qw(Exporter);
-@EXPORT = qw(encode_qp decode_qp);
+our @ISA = qw(Exporter);
+our @EXPORT = qw(encode_qp decode_qp);
 
-$VERSION = "3.13";
+our $VERSION = '3.16';
 
 use MIME::Base64;  # will load XS version of {en,de}code_qp()
 

--- a/cpan/MIME-Base64/t/base64.t
+++ b/cpan/MIME-Base64/t/base64.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 BEGIN {
     if ($ENV{'PERL_CORE'}){
         chdir 't' if -d 't';
@@ -5,7 +8,6 @@ BEGIN {
     }
 }
 
-use strict;
 use MIME::Base64;
 
 print "1..283\n";

--- a/cpan/MIME-Base64/t/base64url.t
+++ b/cpan/MIME-Base64/t/base64url.t
@@ -1,0 +1,34 @@
+#!perl -w
+
+use strict;
+use warnings;
+use Test qw(plan ok);
+
+use MIME::Base64 qw(encode_base64url decode_base64url);
+
+my @tests;
+while (<DATA>) {
+    next if /^#/;
+    chomp;
+    push(@tests, [split]);
+}
+
+plan tests => 2 * @tests;
+
+for (@tests) {
+    my($name, $input, $output) = @$_;
+    print "# $name\n";
+    ok(decode_base64url($input), $output);
+    ok(encode_base64url($output), $input);
+}
+
+__END__
+# https://github.com/ptarjan/base64url/blob/master/tests.txt
+# Name <space> Input <space> Ouput <newline>
+len1 YQ a
+len2 YWE aa
+len3 YWFh aaa
+no_padding YWJj abc
+padding YQ a
+hyphen fn5- ~~~
+underscore Pz8_ ???

--- a/cpan/MIME-Base64/t/length.t
+++ b/cpan/MIME-Base64/t/length.t
@@ -1,6 +1,7 @@
 #!perl -w
 
 use strict;
+use warnings;
 use Test qw(plan ok);
 
 plan tests => 129;

--- a/cpan/MIME-Base64/t/quoted-print.t
+++ b/cpan/MIME-Base64/t/quoted-print.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 BEGIN {
         if ($ENV{PERL_CORE}) {
                 chdir 't' if -d 't';
@@ -7,10 +10,12 @@ BEGIN {
 
 use MIME::QuotedPrint;
 
-$x70 = "x" x 70;
+my $x70 = "x" x 70;
 
-$IsASCII  = ord('A') == 65;
-$IsEBCDIC = ord('A') == 193;
+my $IsASCII  = ord('A') == 65;
+my $IsEBCDIC = ord('A') == 193;
+
+my @tests;
 
 if ($IsASCII) {
 
@@ -191,18 +196,18 @@ y. -- H. L. Mencken=\n"],
   die sprintf "Unknown character set: ord('A') == %d\n", ord('A');
 }
 
-$notests = @tests + 16;
+my $notests = @tests + 16;
 print "1..$notests\n";
 
-$testno = 0;
+my $testno = 0;
 for (@tests) {
     $testno++;
-    ($plain, $encoded) = @$_;
+    my ($plain, $encoded) = @$_;
     if (ord('A') == 193) {  # EBCDIC 8 bit chars are different
         if ($testno == 2) { $plain =~ s/\xe5/\x47/; $plain =~ s/\xe6/\x9c/g; $plain =~ s/\xf8/\x70/; }
         if ($testno == 7) { $plain =~ s/\xff/\xdf/; }
     }
-    $x = encode_qp($plain);
+    my $x = encode_qp($plain);
     if ($x ne $encoded) {
 	print "Encode test failed\n";
 	print "Got:      '$x'\n";

--- a/cpan/MIME-Base64/t/unicode.t
+++ b/cpan/MIME-Base64/t/unicode.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 BEGIN {
 	unless ($] >= 5.006) {
 		print "1..0\n";


### PR DESCRIPTION
[DELTA]

3.16 2020-09-26
  - Convert the build to Dist::Zilla to ensure we're releasing well built packages
  - Ensure all tests are using strict and warnings (thanks, Nicolas R).
  - Cleanup this change log
  - Add a .mailmap to cleanup our contributors list
  - Use `our` instead of `use vars`
  - Bump the required Perl version to v5.6.2