### PR TITLE
Document "x" and "b" prefixes for oct()

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4433,8 +4433,8 @@ X<oct> X<octal> X<hex> X<hexadecimal> X<binary> X<bin>
 =for Pod::Functions convert a string to an octal number
 
 Interprets EXPR as an octal string and returns the corresponding
-value.  (If EXPR happens to start off with C<0x>, interprets it as a
-hex string.  If EXPR starts off with C<0b>, it is interpreted as a
+value.  (If EXPR happens to start off with C<0x> or C<x>, interprets it as a
+hex string.  If EXPR starts off with C<0b> or C<b>, it is interpreted as a
 binary string.  Leading whitespace is ignored in all three cases.)
 The following will handle decimal, binary, octal, and hex in standard
 Perl notation:


### PR DESCRIPTION
The `oct EXPR` entry in perlfunc.pod didn't refer to "x" and "b" prefixes (they actually work, and the `hex EXPR` entry already has a reference to "x" prefix).
This PR will fix #18111 .