### PR TITLE
Test split on empty pattern with varying field counts

### DIFF
--- a/t/op/split.t
+++ b/t/op/split.t
@@ -7,7 +7,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan tests => 178;
+plan tests => 187;
 
 $FS = ':';
 
@@ -68,11 +68,19 @@ $cnt = split(' ','1 2 3 4 5 6', $x);
 is($cnt, scalar(@ary), "Check element count from previous test");
 
 # Can we do it with the empty pattern?
+$_ = join(':', split(//, '123', -1));
+is($_, '1:2:3:', "Split with empty pattern and LIMIT == -1");
+$_ = join(':', split(//, '123', 0));
+is($_, '1:2:3', "Split with empty pattern and LIMIT == 0");
 $_ = join(':', split(//, '123', 2));
 is($_, '1:23', "Split into specified number of fields with empty pattern");
-@ary = split(//, '123', 2);
-$cnt = split(//, '123', 2);
-is($cnt, scalar(@ary), "Check element count from previous test");
+$_ = join(':', split(//, '123', 6));
+is($_, '1:2:3:', "Split with empty pattern and LIMIT > length");
+for (-1..5) {
+    @ary = split(//, '123', $_);
+    $cnt = split(//, '123', $_);
+    is($cnt, scalar(@ary), "Check empty pattern element count with LIMIT == $_");
+}
 
 # Does the 999 suppress null field chopping?
 $_ = join(':', split(/:/,'1:2:3:4:5:6:::', 999));


### PR DESCRIPTION
This builds on https://github.com/Perl/perl5/commit/04b729c025ff8e603d17d10088b5379837ec644e to add additional coverage of the null pattern split. Specifically:
* Check that trailing element behaviour (LIMIT > length) is correct
* Check that scalar & non-scalar context produce similar counts across the range of LIMIT-to-string-length possibilities