### PR TITLE
Make Exporter strict and warnings compliant

### DIFF
--- a/dist/Exporter/lib/Exporter.pm
+++ b/dist/Exporter/lib/Exporter.pm
@@ -1,16 +1,13 @@
 package Exporter;
 
-require 5.006;
-
-# Be lean.
-#use strict;
-#no strict 'refs';
+use strict;
+no strict 'refs';
 
 our $Debug = 0;
 our $ExportLevel = 0;
 our $Verbose ||= 0;
-our $VERSION = '5.75';
-our (%Cache);
+our $VERSION = '5.76';
+our %Cache;
 
 sub as_heavy {
   require Exporter::Heavy;

--- a/dist/Exporter/lib/Exporter/Heavy.pm
+++ b/dist/Exporter/lib/Exporter/Heavy.pm
@@ -4,7 +4,7 @@ use strict;
 no strict 'refs';
 
 # On one line so MakeMaker will see it.
-our $VERSION = '5.75';
+our $VERSION = '5.76';
 
 =head1 NAME
 

--- a/dist/Exporter/t/Exporter.t
+++ b/dist/Exporter/t/Exporter.t
@@ -1,5 +1,8 @@
 #!perl -w
 
+use strict;
+use warnings;
+
 # Can't use Test::Simple/More, they depend on Exporter.
 my $test;
 sub ok ($;$) {
@@ -24,33 +27,30 @@ BEGIN {
 }
 
 
-BEGIN {
-    # Methods which Exporter says it implements.
-    @Exporter_Methods = qw(import
+our @Exporter_Methods = qw(import
                            export_to_level
                            require_version
                            export_fail
                           );
-}
 
 
 package Testing;
 require Exporter;
-@ISA = qw(Exporter);
+our @ISA = qw(Exporter);
 
 # Make sure Testing can do everything its supposed to.
 foreach my $meth (@::Exporter_Methods) {
     ::ok( Testing->can($meth), "subclass can $meth()" );
 }
 
-%EXPORT_TAGS = (
+our %EXPORT_TAGS = (
                 This => [qw(stuff %left)],
                 That => [qw(Above the @wailing)],
                 tray => [qw(Fasten $seatbelt)],
                );
-@EXPORT    = qw(lifejacket is);
-@EXPORT_OK = qw(under &your $seat);
-$VERSION = '1.05';
+our @EXPORT    = qw(lifejacket is);
+our @EXPORT_OK = qw(under &your $seat);
+our $VERSION = '1.05';
 
 ::ok( Testing->require_version(1.05),   'require_version()' );
 eval { Testing->require_version(1.11); 1 };
@@ -168,15 +168,15 @@ Testing->import('!/e/');
 
 
 package More::Testing;
-@ISA = qw(Exporter);
-$VERSION = 0;
+our @ISA = qw(Exporter);
+our $VERSION = 0;
 eval { More::Testing->require_version(0); 1 };
 ::ok(!$@,       'require_version(0) and $VERSION = 0');
 
 
 package Yet::More::Testing;
-@ISA = qw(Exporter);
-$VERSION = 0;
+our @ISA = qw(Exporter);
+our $VERSION = 0;
 eval { Yet::More::Testing->require_version(10); 1 };
 ::ok($@ !~ /\(undef\)/,       'require_version(10) and $VERSION = 0');
 
@@ -185,8 +185,8 @@ my $warnings;
 BEGIN {
     local $SIG{__WARN__} = sub { $warnings = join '', @_ };
     package Testing::Unused::Vars;
-    @ISA = qw(Exporter);
-    @EXPORT = qw(this $TODO that);
+    our @ISA = qw(Exporter);
+    our @EXPORT = qw(this $TODO that);
 
     package Foo;
     Testing::Unused::Vars->import;
@@ -196,8 +196,8 @@ BEGIN {
   print "# $warnings\n";
 
 package Moving::Target;
-@ISA = qw(Exporter);
-@EXPORT_OK = qw (foo);
+our @ISA = qw(Exporter);
+our @EXPORT_OK = qw (foo);
 
 sub foo {"This is foo"};
 sub bar {"This is bar"};
@@ -215,12 +215,11 @@ Moving::Target->import ('bar');
 ::ok (bar() eq "This is bar", "imported bar after EXPORT_OK changed");
 
 package The::Import;
-
 use Exporter 'import';
 
 ::ok(\&import == \&Exporter::import, "imported the import routine");
 
-@EXPORT = qw( wibble );
+our @EXPORT = qw( wibble );
 sub wibble {return "wobble"};
 
 package Use::The::Import;
@@ -238,8 +237,8 @@ eval { Carp::croak() };
 
 package Exporter::for::Tied::_;
 
-@ISA = 'Exporter';
-@EXPORT = 'foo';
+our @ISA = 'Exporter';
+our @EXPORT = 'foo';
 
 package Tied::_;
 

--- a/dist/Exporter/t/warn.t
+++ b/dist/Exporter/t/warn.t
@@ -25,7 +25,8 @@ BEGIN {
 
 package Foo;
 Exporter->import("import");
-@EXPORT_OK = "bar";
+our @EXPORT_OK = qw/bar/;
+
 
 package main;
 

--- a/ext/B/t/optree_specials.t
+++ b/ext/B/t/optree_specials.t
@@ -45,52 +45,54 @@ checkOptree ( name	=> 'BEGIN',
 	      prog	=> $src,
 	      strip_open_hints => 1,
 	      expect	=> <<'EOT_EOT', expect_nt => <<'EONT_EONT');
-# -     <@> lineseq KP ->7
-# 1        <;> nextstate(B::Concise -1151 Concise.pm:116) v:*,&,{,x*,x&,x$,$ ->2
-# 6        <2> sassign sKS/2 ->7
-# 4           <1> srefgen sK/1 ->5
-# -              <1> ex-list lKRM ->4
-# 3                 <1> rv2gv sKRM/STRICT,1 ->4
-# 2                    <#> gv[*STDOUT] s ->3
-# -           <1> ex-rv2sv sKRM*/STRICT,1 ->6
-# 5              <#> gvsv[*B::Concise::walkHandle] s ->6
-# BEGIN 2:
-# h  <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq K ->h
-# 8        <;> nextstate(B::Concise -1113 Concise.pm:181) v:*,&,x*,x&,x$,$ ->9
-# a        <1> require sK/1 ->b
-# 9           <$> const[PV "strict.pm"] s/BARE ->a
-# -        <;> ex-nextstate(B::Concise -1113 Concise.pm:181) v:*,&,x*,x&,x$,$ ->b
+# BEGIN 1:
+# a  <1> leavesub[1 ref] K/REFC,1 ->(end)
+# -     <@> lineseq KP ->a
+# 1        <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$ ->2
+# 3        <1> require sK/1 ->4
+# 2           <$> const[PV "strict.pm"] s/BARE ->3
+# -        <;> ex-nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$ ->4
 # -        <@> lineseq K ->-
-# b           <;> nextstate(B::Concise -1113 Concise.pm:181) :*,&,x*,x&,x$,$ ->c
-# g           <1> entersub[t1] KRS*/TARG,STRICT ->h
-# c              <0> pushmark s ->d
-# d              <$> const[PV "strict"] sM ->e
-# e              <$> const[PV "refs"] sM ->f
-# f              <.> method_named[PV "unimport"] ->g
+# 4           <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) :*,&,{,x*,x&,x$,$ ->5
+# 9           <1> entersub[t1] KRS*/TARG,STRICT ->a
+# 5              <0> pushmark s ->6
+# 6              <$> const[PV "strict"] sM ->7
+# 7              <$> const[PV "refs"] sM ->8
+# 8              <.> method_named[PV "unimport"] ->9
+# BEGIN 2:
+# k  <1> leavesub[1 ref] K/REFC,1 ->(end)
+# -     <@> lineseq KP ->k
+# b        <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$ ->c
+# d        <1> require sK/1 ->e
+# c           <$> const[PV "warnings.pm"] s/BARE ->d
+# -        <;> ex-nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$ ->e
+# -        <@> lineseq K ->-
+# e           <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) :*,&,{,x*,x&,x$ ->f
+# j           <1> entersub[t1] KRS*/TARG ->k
+# f              <0> pushmark s ->g
+# g              <$> const[PV "warnings"] sM ->h
+# h              <$> const[PV "once"] sM ->i
+# i              <.> method_named[PV "unimport"] ->j
 # BEGIN 3:
 # r  <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq K ->r
-# i        <;> nextstate(B::Concise -1010 Concise.pm:303) v:*,&,x*,x&,x$,$ ->j
-# k        <1> require sK/1 ->l
-# j           <$> const[PV "strict.pm"] s/BARE ->k
-# -        <;> ex-nextstate(B::Concise -1010 Concise.pm:303) v:*,&,x*,x&,x$,$ ->l
-# -        <@> lineseq K ->-
-# l           <;> nextstate(B::Concise -1010 Concise.pm:303) :*,&,x*,x&,x$,$ ->m
-# q           <1> entersub[t1] KRS*/TARG,STRICT ->r
-# m              <0> pushmark s ->n
-# n              <$> const[PV "strict"] sM ->o
-# o              <$> const[PV "refs"] sM ->p
-# p              <.> method_named[PV "unimport"] ->q
+# -     <@> lineseq KP ->r
+# l        <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$ ->m
+# q        <2> sassign sKS/2 ->r
+# o           <1> srefgen sK/1 ->p
+# -              <1> ex-list lKRM ->o
+# n                 <1> rv2gv sKRM/STRICT,1 ->o
+# m                    <#> gv[*STDOUT] s ->n
+# -           <1> ex-rv2sv sKRM*/STRICT,1 ->q
+# p              <#> gvsv[*B::Concise::walkHandle] s ->q
 # BEGIN 4:
 # 11 <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->11
-# s        <;> nextstate(B::Concise -963 Concise.pm:368) v:*,&,{,x*,x&,x$,$ ->t
+# -     <@> lineseq K ->11
+# s        <;> nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$ ->t
 # u        <1> require sK/1 ->v
 # t           <$> const[PV "strict.pm"] s/BARE ->u
-# -        <;> ex-nextstate(B::Concise -963 Concise.pm:368) v:*,&,{,x*,x&,x$,$ ->v
+# -        <;> ex-nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$ ->v
 # -        <@> lineseq K ->-
-# v           <;> nextstate(B::Concise -963 Concise.pm:368) :*,&,{,x*,x&,x$,$ ->w
+# v           <;> nextstate(B::Concise -1134 Concise.pm:183) :*,&,x*,x&,x$,$ ->w
 # 10          <1> entersub[t1] KRS*/TARG,STRICT ->11
 # w              <0> pushmark s ->x
 # x              <$> const[PV "strict"] sM ->y
@@ -99,12 +101,12 @@ checkOptree ( name	=> 'BEGIN',
 # BEGIN 5:
 # 1b <1> leavesub[1 ref] K/REFC,1 ->(end)
 # -     <@> lineseq K ->1b
-# 12       <;> nextstate(B::Concise -938 Concise.pm:388) v:*,&,x*,x&,x$,$ ->13
+# 12       <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$ ->13
 # 14       <1> require sK/1 ->15
 # 13          <$> const[PV "strict.pm"] s/BARE ->14
-# -        <;> ex-nextstate(B::Concise -938 Concise.pm:388) v:*,&,x*,x&,x$,$ ->15
+# -        <;> ex-nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$ ->15
 # -        <@> lineseq K ->-
-# 15          <;> nextstate(B::Concise -938 Concise.pm:388) :*,&,x*,x&,x$,$ ->16
+# 15          <;> nextstate(B::Concise -1031 Concise.pm:305) :*,&,x*,x&,x$,$ ->16
 # 1a          <1> entersub[t1] KRS*/TARG,STRICT ->1b
 # 16             <0> pushmark s ->17
 # 17             <$> const[PV "strict"] sM ->18
@@ -113,73 +115,101 @@ checkOptree ( name	=> 'BEGIN',
 # BEGIN 6:
 # 1l <1> leavesub[1 ref] K/REFC,1 ->(end)
 # -     <@> lineseq KP ->1l
-# 1c       <;> nextstate(B::Concise -924 Concise.pm:408) v:*,&,{,x*,x&,x$,$ ->1d
+# 1c       <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$ ->1d
 # 1e       <1> require sK/1 ->1f
-# 1d          <$> const[PV "warnings.pm"] s/BARE ->1e
-# -        <;> ex-nextstate(B::Concise -924 Concise.pm:408) v:*,&,{,x*,x&,x$,$ ->1f
+# 1d          <$> const[PV "strict.pm"] s/BARE ->1e
+# -        <;> ex-nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$ ->1f
 # -        <@> lineseq K ->-
-# 1f          <;> nextstate(B::Concise -924 Concise.pm:408) :*,&,{,x*,x&,x$,$ ->1g
+# 1f          <;> nextstate(B::Concise -984 Concise.pm:370) :*,&,{,x*,x&,x$,$ ->1g
 # 1k          <1> entersub[t1] KRS*/TARG,STRICT ->1l
 # 1g             <0> pushmark s ->1h
-# 1h             <$> const[PV "warnings"] sM ->1i
-# 1i             <$> const[PV "qw"] sM ->1j
+# 1h             <$> const[PV "strict"] sM ->1i
+# 1i             <$> const[PV "refs"] sM ->1j
 # 1j             <.> method_named[PV "unimport"] ->1k
 # BEGIN 7:
-# 1p <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->1p
-# 1m       <;> nextstate(main 3 -e:1) v:>,<,%,{ ->1n
-# 1o       <1> postinc[t3] sK/1 ->1p
-# -           <1> ex-rv2sv sKRM/1 ->1o
-# 1n             <#> gvsv[*beg] s ->1o
+# 1v <1> leavesub[1 ref] K/REFC,1 ->(end)
+# -     <@> lineseq K ->1v
+# 1m       <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$ ->1n
+# 1o       <1> require sK/1 ->1p
+# 1n          <$> const[PV "strict.pm"] s/BARE ->1o
+# -        <;> ex-nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$ ->1p
+# -        <@> lineseq K ->-
+# 1p          <;> nextstate(B::Concise -959 Concise.pm:390) :*,&,x*,x&,x$,$ ->1q
+# 1u          <1> entersub[t1] KRS*/TARG,STRICT ->1v
+# 1q             <0> pushmark s ->1r
+# 1r             <$> const[PV "strict"] sM ->1s
+# 1s             <$> const[PV "refs"] sM ->1t
+# 1t             <.> method_named[PV "unimport"] ->1u
+# BEGIN 8:
+# 25 <1> leavesub[1 ref] K/REFC,1 ->(end)
+# -     <@> lineseq KP ->25
+# 1w       <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$ ->1x
+# 1y       <1> require sK/1 ->1z
+# 1x          <$> const[PV "warnings.pm"] s/BARE ->1y
+# -        <;> ex-nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$ ->1z
+# -        <@> lineseq K ->-
+# 1z          <;> nextstate(B::Concise -945 Concise.pm:410) :*,&,{,x*,x&,x$,$ ->20
+# 24          <1> entersub[t1] KRS*/TARG,STRICT ->25
+# 20             <0> pushmark s ->21
+# 21             <$> const[PV "warnings"] sM ->22
+# 22             <$> const[PV "qw"] sM ->23
+# 23             <.> method_named[PV "unimport"] ->24
+# BEGIN 9:
+# 29 <1> leavesub[1 ref] K/REFC,1 ->(end)
+# -     <@> lineseq KP ->29
+# 26       <;> nextstate(main 3 -e:1) v:{ ->27
+# 28       <1> postinc[t3] sK/1 ->29
+# -           <1> ex-rv2sv sKRM/1 ->28
+# 27             <#> gvsv[*beg] s ->28
 EOT_EOT
 # BEGIN 1:
-# 7  <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->7
-# 1        <;> nextstate(B::Concise -1151 Concise.pm:116) v:*,&,{,x*,x&,x$,$ ->2
-# 6        <2> sassign sKS/2 ->7
-# 4           <1> srefgen sK/1 ->5
-# -              <1> ex-list lKRM ->4
-# 3                 <1> rv2gv sKRM/STRICT,1 ->4
-# 2                    <$> gv(*STDOUT) s ->3
-# -           <1> ex-rv2sv sKRM*/STRICT,1 ->6
-# 5              <$> gvsv(*B::Concise::walkHandle) s ->6
-# BEGIN 2:
-# h  <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq K ->h
-# 8        <;> nextstate(B::Concise -1113 Concise.pm:181) v:*,&,x*,x&,x$,$ ->9
-# a        <1> require sK/1 ->b
-# 9           <$> const(PV "strict.pm") s/BARE ->a
-# -        <;> ex-nextstate(B::Concise -1113 Concise.pm:181) v:*,&,x*,x&,x$,$ ->b
+# a  <1> leavesub[1 ref] K/REFC,1 ->(end)
+# -     <@> lineseq KP ->a
+# 1        <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$ ->2
+# 3        <1> require sK/1 ->4
+# 2           <$> const(PV "strict.pm") s/BARE ->3
+# -        <;> ex-nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$ ->4
 # -        <@> lineseq K ->-
-# b           <;> nextstate(B::Concise -1113 Concise.pm:181) :*,&,x*,x&,x$,$ ->c
-# g           <1> entersub[t1] KRS*/TARG,STRICT ->h
-# c              <0> pushmark s ->d
-# d              <$> const(PV "strict") sM ->e
-# e              <$> const(PV "refs") sM ->f
-# f              <.> method_named(PV "unimport") ->g
+# 4           <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) :*,&,{,x*,x&,x$,$ ->5
+# 9           <1> entersub[t1] KRS*/TARG,STRICT ->a
+# 5              <0> pushmark s ->6
+# 6              <$> const(PV "strict") sM ->7
+# 7              <$> const(PV "refs") sM ->8
+# 8              <.> method_named(PV "unimport") ->9
+# BEGIN 2:
+# k  <1> leavesub[1 ref] K/REFC,1 ->(end)
+# -     <@> lineseq KP ->k
+# b        <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$ ->c
+# d        <1> require sK/1 ->e
+# c           <$> const(PV "warnings.pm") s/BARE ->d
+# -        <;> ex-nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$ ->e
+# -        <@> lineseq K ->-
+# e           <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) :*,&,{,x*,x&,x$ ->f
+# j           <1> entersub[t1] KRS*/TARG ->k
+# f              <0> pushmark s ->g
+# g              <$> const(PV "warnings") sM ->h
+# h              <$> const(PV "once") sM ->i
+# i              <.> method_named(PV "unimport") ->j
 # BEGIN 3:
 # r  <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq K ->r
-# i        <;> nextstate(B::Concise -1010 Concise.pm:303) v:*,&,x*,x&,x$,$ ->j
-# k        <1> require sK/1 ->l
-# j           <$> const(PV "strict.pm") s/BARE ->k
-# -        <;> ex-nextstate(B::Concise -1010 Concise.pm:303) v:*,&,x*,x&,x$,$ ->l
-# -        <@> lineseq K ->-
-# l           <;> nextstate(B::Concise -1010 Concise.pm:303) :*,&,x*,x&,x$,$ ->m
-# q           <1> entersub[t1] KRS*/TARG,STRICT ->r
-# m              <0> pushmark s ->n
-# n              <$> const(PV "strict") sM ->o
-# o              <$> const(PV "refs") sM ->p
-# p              <.> method_named(PV "unimport") ->q
+# -     <@> lineseq KP ->r
+# l        <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$ ->m
+# q        <2> sassign sKS/2 ->r
+# o           <1> srefgen sK/1 ->p
+# -              <1> ex-list lKRM ->o
+# n                 <1> rv2gv sKRM/STRICT,1 ->o
+# m                    <$> gv(*STDOUT) s ->n
+# -           <1> ex-rv2sv sKRM*/STRICT,1 ->q
+# p              <$> gvsv(*B::Concise::walkHandle) s ->q
 # BEGIN 4:
 # 11 <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->11
-# s        <;> nextstate(B::Concise -963 Concise.pm:368) v:*,&,{,x*,x&,x$,$ ->t
+# -     <@> lineseq K ->11
+# s        <;> nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$ ->t
 # u        <1> require sK/1 ->v
 # t           <$> const(PV "strict.pm") s/BARE ->u
-# -        <;> ex-nextstate(B::Concise -963 Concise.pm:368) v:*,&,{,x*,x&,x$,$ ->v
+# -        <;> ex-nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$ ->v
 # -        <@> lineseq K ->-
-# v           <;> nextstate(B::Concise -963 Concise.pm:368) :*,&,{,x*,x&,x$,$ ->w
+# v           <;> nextstate(B::Concise -1134 Concise.pm:183) :*,&,x*,x&,x$,$ ->w
 # 10          <1> entersub[t1] KRS*/TARG,STRICT ->11
 # w              <0> pushmark s ->x
 # x              <$> const(PV "strict") sM ->y
@@ -188,12 +218,12 @@ EOT_EOT
 # BEGIN 5:
 # 1b <1> leavesub[1 ref] K/REFC,1 ->(end)
 # -     <@> lineseq K ->1b
-# 12       <;> nextstate(B::Concise -938 Concise.pm:388) v:*,&,x*,x&,x$,$ ->13
+# 12       <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$ ->13
 # 14       <1> require sK/1 ->15
 # 13          <$> const(PV "strict.pm") s/BARE ->14
-# -        <;> ex-nextstate(B::Concise -938 Concise.pm:388) v:*,&,x*,x&,x$,$ ->15
+# -        <;> ex-nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$ ->15
 # -        <@> lineseq K ->-
-# 15          <;> nextstate(B::Concise -938 Concise.pm:388) :*,&,x*,x&,x$,$ ->16
+# 15          <;> nextstate(B::Concise -1031 Concise.pm:305) :*,&,x*,x&,x$,$ ->16
 # 1a          <1> entersub[t1] KRS*/TARG,STRICT ->1b
 # 16             <0> pushmark s ->17
 # 17             <$> const(PV "strict") sM ->18
@@ -202,24 +232,52 @@ EOT_EOT
 # BEGIN 6:
 # 1l <1> leavesub[1 ref] K/REFC,1 ->(end)
 # -     <@> lineseq KP ->1l
-# 1c       <;> nextstate(B::Concise -924 Concise.pm:408) v:*,&,{,x*,x&,x$,$ ->1d
+# 1c       <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$ ->1d
 # 1e       <1> require sK/1 ->1f
-# 1d          <$> const(PV "warnings.pm") s/BARE ->1e
-# -        <;> ex-nextstate(B::Concise -924 Concise.pm:408) v:*,&,{,x*,x&,x$,$ ->1f
+# 1d          <$> const(PV "strict.pm") s/BARE ->1e
+# -        <;> ex-nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$ ->1f
 # -        <@> lineseq K ->-
-# 1f          <;> nextstate(B::Concise -924 Concise.pm:408) :*,&,{,x*,x&,x$,$ ->1g
+# 1f          <;> nextstate(B::Concise -984 Concise.pm:370) :*,&,{,x*,x&,x$,$ ->1g
 # 1k          <1> entersub[t1] KRS*/TARG,STRICT ->1l
 # 1g             <0> pushmark s ->1h
-# 1h             <$> const(PV "warnings") sM ->1i
-# 1i             <$> const(PV "qw") sM ->1j
+# 1h             <$> const(PV "strict") sM ->1i
+# 1i             <$> const(PV "refs") sM ->1j
 # 1j             <.> method_named(PV "unimport") ->1k
 # BEGIN 7:
-# 1p <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->1p
-# 1m       <;> nextstate(main 3 -e:1) v:>,<,%,{ ->1n
-# 1o       <1> postinc[t2] sK/1 ->1p
-# -           <1> ex-rv2sv sKRM/1 ->1o
-# 1n             <$> gvsv(*beg) s ->1o
+# 1v <1> leavesub[1 ref] K/REFC,1 ->(end)
+# -     <@> lineseq K ->1v
+# 1m       <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$ ->1n
+# 1o       <1> require sK/1 ->1p
+# 1n          <$> const(PV "strict.pm") s/BARE ->1o
+# -        <;> ex-nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$ ->1p
+# -        <@> lineseq K ->-
+# 1p          <;> nextstate(B::Concise -959 Concise.pm:390) :*,&,x*,x&,x$,$ ->1q
+# 1u          <1> entersub[t1] KRS*/TARG,STRICT ->1v
+# 1q             <0> pushmark s ->1r
+# 1r             <$> const(PV "strict") sM ->1s
+# 1s             <$> const(PV "refs") sM ->1t
+# 1t             <.> method_named(PV "unimport") ->1u
+# BEGIN 8:
+# 25 <1> leavesub[1 ref] K/REFC,1 ->(end)
+# -     <@> lineseq KP ->25
+# 1w       <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$ ->1x
+# 1y       <1> require sK/1 ->1z
+# 1x          <$> const(PV "warnings.pm") s/BARE ->1y
+# -        <;> ex-nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$ ->1z
+# -        <@> lineseq K ->-
+# 1z          <;> nextstate(B::Concise -945 Concise.pm:410) :*,&,{,x*,x&,x$,$ ->20
+# 24          <1> entersub[t1] KRS*/TARG,STRICT ->25
+# 20             <0> pushmark s ->21
+# 21             <$> const(PV "warnings") sM ->22
+# 22             <$> const(PV "qw") sM ->23
+# 23             <.> method_named(PV "unimport") ->24
+# BEGIN 9:
+# 29 <1> leavesub[1 ref] K/REFC,1 ->(end)
+# -     <@> lineseq KP ->29
+# 26       <;> nextstate(main 3 -e:1) v:{ ->27
+# 28       <1> postinc[t2] sK/1 ->29
+# -           <1> ex-rv2sv sKRM/1 ->28
+# 27             <$> gvsv(*beg) s ->28
 EONT_EONT
 
 checkOptree ( name	=> 'END',
@@ -317,40 +375,40 @@ checkOptree ( name	=> 'all of BEGIN END INIT CHECK UNITCHECK -exec',
 	      strip_open_hints => 1,
 	      expect	=> <<'EOT_EOT', expect_nt => <<'EONT_EONT');
 # BEGIN 1:
-# 1  <;> nextstate(B::Concise -1151 Concise.pm:116) v:*,&,{,x*,x&,x$,$
-# 2  <#> gv[*STDOUT] s
-# 3  <1> rv2gv sKRM/STRICT,1
-# 4  <1> srefgen sK/1
-# 5  <#> gvsv[*B::Concise::walkHandle] s
-# 6  <2> sassign sKS/2
-# 7  <1> leavesub[1 ref] K/REFC,1
+# 1  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$
+# 2  <$> const[PV "strict.pm"] s/BARE
+# 3  <1> require sK/1
+# 4  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) :*,&,{,x*,x&,x$,$
+# 5  <0> pushmark s
+# 6  <$> const[PV "strict"] sM
+# 7  <$> const[PV "refs"] sM
+# 8  <.> method_named[PV "unimport"] 
+# 9  <1> entersub[t1] KRS*/TARG,STRICT
+# a  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 2:
-# 8  <;> nextstate(B::Concise -1113 Concise.pm:181) v:*,&,x*,x&,x$,$
-# 9  <$> const[PV "strict.pm"] s/BARE
-# a  <1> require sK/1
-# b  <;> nextstate(B::Concise -1113 Concise.pm:181) :*,&,x*,x&,x$,$
-# c  <0> pushmark s
-# d  <$> const[PV "strict"] sM
-# e  <$> const[PV "refs"] sM
-# f  <.> method_named[PV "unimport"] 
-# g  <1> entersub[t1] KRS*/TARG,STRICT
-# h  <1> leavesub[1 ref] K/REFC,1
+# b  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$
+# c  <$> const[PV "warnings.pm"] s/BARE
+# d  <1> require sK/1
+# e  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) :*,&,{,x*,x&,x$
+# f  <0> pushmark s
+# g  <$> const[PV "warnings"] sM
+# h  <$> const[PV "once"] sM
+# i  <.> method_named[PV "unimport"] 
+# j  <1> entersub[t1] KRS*/TARG
+# k  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 3:
-# i  <;> nextstate(B::Concise -1010 Concise.pm:303) v:*,&,x*,x&,x$,$
-# j  <$> const[PV "strict.pm"] s/BARE
-# k  <1> require sK/1
-# l  <;> nextstate(B::Concise -1010 Concise.pm:303) :*,&,x*,x&,x$,$
-# m  <0> pushmark s
-# n  <$> const[PV "strict"] sM
-# o  <$> const[PV "refs"] sM
-# p  <.> method_named[PV "unimport"] 
-# q  <1> entersub[t1] KRS*/TARG,STRICT
+# l  <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$
+# m  <#> gv[*STDOUT] s
+# n  <1> rv2gv sKRM/STRICT,1
+# o  <1> srefgen sK/1
+# p  <#> gvsv[*B::Concise::walkHandle] s
+# q  <2> sassign sKS/2
 # r  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 4:
-# s  <;> nextstate(B::Concise -963 Concise.pm:368) v:*,&,{,x*,x&,x$,$
+# s  <;> nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$
 # t  <$> const[PV "strict.pm"] s/BARE
 # u  <1> require sK/1
-# v  <;> nextstate(B::Concise -963 Concise.pm:368) :*,&,{,x*,x&,x$,$
+# v  <;> nextstate(B::Concise -1134 Concise.pm:183) :*,&,x*,x&,x$,$
 # w  <0> pushmark s
 # x  <$> const[PV "strict"] sM
 # y  <$> const[PV "refs"] sM
@@ -358,10 +416,10 @@ checkOptree ( name	=> 'all of BEGIN END INIT CHECK UNITCHECK -exec',
 # 10 <1> entersub[t1] KRS*/TARG,STRICT
 # 11 <1> leavesub[1 ref] K/REFC,1
 # BEGIN 5:
-# 12 <;> nextstate(B::Concise -938 Concise.pm:388) v:*,&,x*,x&,x$,$
+# 12 <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$
 # 13 <$> const[PV "strict.pm"] s/BARE
 # 14 <1> require sK/1
-# 15 <;> nextstate(B::Concise -938 Concise.pm:388) :*,&,x*,x&,x$,$
+# 15 <;> nextstate(B::Concise -1031 Concise.pm:305) :*,&,x*,x&,x$,$
 # 16 <0> pushmark s
 # 17 <$> const[PV "strict"] sM
 # 18 <$> const[PV "refs"] sM
@@ -369,77 +427,99 @@ checkOptree ( name	=> 'all of BEGIN END INIT CHECK UNITCHECK -exec',
 # 1a <1> entersub[t1] KRS*/TARG,STRICT
 # 1b <1> leavesub[1 ref] K/REFC,1
 # BEGIN 6:
-# 1c <;> nextstate(B::Concise -924 Concise.pm:408) v:*,&,{,x*,x&,x$,$
-# 1d <$> const[PV "warnings.pm"] s/BARE
+# 1c <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$
+# 1d <$> const[PV "strict.pm"] s/BARE
 # 1e <1> require sK/1
-# 1f <;> nextstate(B::Concise -924 Concise.pm:408) :*,&,{,x*,x&,x$,$
+# 1f <;> nextstate(B::Concise -984 Concise.pm:370) :*,&,{,x*,x&,x$,$
 # 1g <0> pushmark s
-# 1h <$> const[PV "warnings"] sM
-# 1i <$> const[PV "qw"] sM
+# 1h <$> const[PV "strict"] sM
+# 1i <$> const[PV "refs"] sM
 # 1j <.> method_named[PV "unimport"] 
 # 1k <1> entersub[t1] KRS*/TARG,STRICT
 # 1l <1> leavesub[1 ref] K/REFC,1
 # BEGIN 7:
-# 1m <;> nextstate(main 3 -e:1) v:>,<,%,{
-# 1n <#> gvsv[*beg] s
-# 1o <1> postinc[t3] sK/1
-# 1p <1> leavesub[1 ref] K/REFC,1
-# END 1:
-# 1q <;> nextstate(main 9 -e:1) v:>,<,%,{
-# 1r <#> gvsv[*end] s
-# 1s <1> postinc[t3] sK/1
-# 1t <1> leavesub[1 ref] K/REFC,1
-# INIT 1:
-# 1u <;> nextstate(main 7 -e:1) v:>,<,%,{
-# 1v <#> gvsv[*init] s
-# 1w <1> postinc[t3] sK/1
-# 1x <1> leavesub[1 ref] K/REFC,1
-# CHECK 1:
-# 1y <;> nextstate(main 5 -e:1) v:>,<,%,{
-# 1z <#> gvsv[*chk] s
-# 20 <1> postinc[t3] sK/1
-# 21 <1> leavesub[1 ref] K/REFC,1
-# UNITCHECK 1:
-# 22 <;> nextstate(main 11 -e:1) v:>,<,%,{
-# 23 <#> gvsv[*uc] s
-# 24 <1> postinc[t3] sK/1
+# 1m <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$
+# 1n <$> const[PV "strict.pm"] s/BARE
+# 1o <1> require sK/1
+# 1p <;> nextstate(B::Concise -959 Concise.pm:390) :*,&,x*,x&,x$,$
+# 1q <0> pushmark s
+# 1r <$> const[PV "strict"] sM
+# 1s <$> const[PV "refs"] sM
+# 1t <.> method_named[PV "unimport"] 
+# 1u <1> entersub[t1] KRS*/TARG,STRICT
+# 1v <1> leavesub[1 ref] K/REFC,1
+# BEGIN 8:
+# 1w <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$
+# 1x <$> const[PV "warnings.pm"] s/BARE
+# 1y <1> require sK/1
+# 1z <;> nextstate(B::Concise -945 Concise.pm:410) :*,&,{,x*,x&,x$,$
+# 20 <0> pushmark s
+# 21 <$> const[PV "warnings"] sM
+# 22 <$> const[PV "qw"] sM
+# 23 <.> method_named[PV "unimport"] 
+# 24 <1> entersub[t1] KRS*/TARG,STRICT
 # 25 <1> leavesub[1 ref] K/REFC,1
+# BEGIN 9:
+# 26 <;> nextstate(main 3 -e:1) v:{
+# 27 <#> gvsv[*beg] s
+# 28 <1> postinc[t3] sK/1
+# 29 <1> leavesub[1 ref] K/REFC,1
+# END 1:
+# 2a <;> nextstate(main 9 -e:1) v:{
+# 2b <#> gvsv[*end] s
+# 2c <1> postinc[t3] sK/1
+# 2d <1> leavesub[1 ref] K/REFC,1
+# INIT 1:
+# 2e <;> nextstate(main 7 -e:1) v:{
+# 2f <#> gvsv[*init] s
+# 2g <1> postinc[t3] sK/1
+# 2h <1> leavesub[1 ref] K/REFC,1
+# CHECK 1:
+# 2i <;> nextstate(main 5 -e:1) v:{
+# 2j <#> gvsv[*chk] s
+# 2k <1> postinc[t3] sK/1
+# 2l <1> leavesub[1 ref] K/REFC,1
+# UNITCHECK 1:
+# 2m <;> nextstate(main 11 -e:1) v:{
+# 2n <#> gvsv[*uc] s
+# 2o <1> postinc[t3] sK/1
+# 2p <1> leavesub[1 ref] K/REFC,1
 EOT_EOT
 # BEGIN 1:
-# 1  <;> nextstate(B::Concise -1151 Concise.pm:116) v:*,&,{,x*,x&,x$,$
-# 2  <$> gv(*STDOUT) s
-# 3  <1> rv2gv sKRM/STRICT,1
-# 4  <1> srefgen sK/1
-# 5  <$> gvsv(*B::Concise::walkHandle) s
-# 6  <2> sassign sKS/2
-# 7  <1> leavesub[1 ref] K/REFC,1
+# 1  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$
+# 2  <$> const(PV "strict.pm") s/BARE
+# 3  <1> require sK/1
+# 4  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) :*,&,{,x*,x&,x$,$
+# 5  <0> pushmark s
+# 6  <$> const(PV "strict") sM
+# 7  <$> const(PV "refs") sM
+# 8  <.> method_named(PV "unimport") 
+# 9  <1> entersub[t1] KRS*/TARG,STRICT
+# a  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 2:
-# 8  <;> nextstate(B::Concise -1113 Concise.pm:181) v:*,&,x*,x&,x$,$
-# 9  <$> const(PV "strict.pm") s/BARE
-# a  <1> require sK/1
-# b  <;> nextstate(B::Concise -1113 Concise.pm:181) :*,&,x*,x&,x$,$
-# c  <0> pushmark s
-# d  <$> const(PV "strict") sM
-# e  <$> const(PV "refs") sM
-# f  <.> method_named(PV "unimport") 
-# g  <1> entersub[t1] KRS*/TARG,STRICT
-# h  <1> leavesub[1 ref] K/REFC,1
+# b  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$
+# c  <$> const(PV "warnings.pm") s/BARE
+# d  <1> require sK/1
+# e  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) :*,&,{,x*,x&,x$
+# f  <0> pushmark s
+# g  <$> const(PV "warnings") sM
+# h  <$> const(PV "once") sM
+# i  <.> method_named(PV "unimport") 
+# j  <1> entersub[t1] KRS*/TARG
+# k  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 3:
-# i  <;> nextstate(B::Concise -1010 Concise.pm:303) v:*,&,x*,x&,x$,$
-# j  <$> const(PV "strict.pm") s/BARE
-# k  <1> require sK/1
-# l  <;> nextstate(B::Concise -1010 Concise.pm:303) :*,&,x*,x&,x$,$
-# m  <0> pushmark s
-# n  <$> const(PV "strict") sM
-# o  <$> const(PV "refs") sM
-# p  <.> method_named(PV "unimport") 
-# q  <1> entersub[t1] KRS*/TARG,STRICT
+# l  <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$
+# m  <$> gv(*STDOUT) s
+# n  <1> rv2gv sKRM/STRICT,1
+# o  <1> srefgen sK/1
+# p  <$> gvsv(*B::Concise::walkHandle) s
+# q  <2> sassign sKS/2
 # r  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 4:
-# s  <;> nextstate(B::Concise -963 Concise.pm:368) v:*,&,{,x*,x&,x$,$
+# s  <;> nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$
 # t  <$> const(PV "strict.pm") s/BARE
 # u  <1> require sK/1
-# v  <;> nextstate(B::Concise -963 Concise.pm:368) :*,&,{,x*,x&,x$,$
+# v  <;> nextstate(B::Concise -1134 Concise.pm:183) :*,&,x*,x&,x$,$
 # w  <0> pushmark s
 # x  <$> const(PV "strict") sM
 # y  <$> const(PV "refs") sM
@@ -447,10 +527,10 @@ EOT_EOT
 # 10 <1> entersub[t1] KRS*/TARG,STRICT
 # 11 <1> leavesub[1 ref] K/REFC,1
 # BEGIN 5:
-# 12 <;> nextstate(B::Concise -938 Concise.pm:388) v:*,&,x*,x&,x$,$
+# 12 <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$
 # 13 <$> const(PV "strict.pm") s/BARE
 # 14 <1> require sK/1
-# 15 <;> nextstate(B::Concise -938 Concise.pm:388) :*,&,x*,x&,x$,$
+# 15 <;> nextstate(B::Concise -1031 Concise.pm:305) :*,&,x*,x&,x$,$
 # 16 <0> pushmark s
 # 17 <$> const(PV "strict") sM
 # 18 <$> const(PV "refs") sM
@@ -458,41 +538,63 @@ EOT_EOT
 # 1a <1> entersub[t1] KRS*/TARG,STRICT
 # 1b <1> leavesub[1 ref] K/REFC,1
 # BEGIN 6:
-# 1c <;> nextstate(B::Concise -924 Concise.pm:408) v:*,&,{,x*,x&,x$,$
-# 1d <$> const(PV "warnings.pm") s/BARE
+# 1c <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$
+# 1d <$> const(PV "strict.pm") s/BARE
 # 1e <1> require sK/1
-# 1f <;> nextstate(B::Concise -924 Concise.pm:408) :*,&,{,x*,x&,x$,$
+# 1f <;> nextstate(B::Concise -984 Concise.pm:370) :*,&,{,x*,x&,x$,$
 # 1g <0> pushmark s
-# 1h <$> const(PV "warnings") sM
-# 1i <$> const(PV "qw") sM
+# 1h <$> const(PV "strict") sM
+# 1i <$> const(PV "refs") sM
 # 1j <.> method_named(PV "unimport") 
 # 1k <1> entersub[t1] KRS*/TARG,STRICT
 # 1l <1> leavesub[1 ref] K/REFC,1
 # BEGIN 7:
-# 1m <;> nextstate(main 3 -e:1) v:>,<,%,{
-# 1n <$> gvsv(*beg) s
-# 1o <1> postinc[t2] sK/1
-# 1p <1> leavesub[1 ref] K/REFC,1
-# END 1:
-# 1q <;> nextstate(main 9 -e:1) v:>,<,%,{
-# 1r <$> gvsv(*end) s
-# 1s <1> postinc[t2] sK/1
-# 1t <1> leavesub[1 ref] K/REFC,1
-# INIT 1:
-# 1u <;> nextstate(main 7 -e:1) v:>,<,%,{
-# 1v <$> gvsv(*init) s
-# 1w <1> postinc[t2] sK/1
-# 1x <1> leavesub[1 ref] K/REFC,1
-# CHECK 1:
-# 1y <;> nextstate(main 5 -e:1) v:>,<,%,{
-# 1z <$> gvsv(*chk) s
-# 20 <1> postinc[t2] sK/1
-# 21 <1> leavesub[1 ref] K/REFC,1
-# UNITCHECK 1:
-# 22 <;> nextstate(main 11 -e:1) v:>,<,%,{
-# 23 <$> gvsv(*uc) s
-# 24 <1> postinc[t2] sK/1
+# 1m <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$
+# 1n <$> const(PV "strict.pm") s/BARE
+# 1o <1> require sK/1
+# 1p <;> nextstate(B::Concise -959 Concise.pm:390) :*,&,x*,x&,x$,$
+# 1q <0> pushmark s
+# 1r <$> const(PV "strict") sM
+# 1s <$> const(PV "refs") sM
+# 1t <.> method_named(PV "unimport") 
+# 1u <1> entersub[t1] KRS*/TARG,STRICT
+# 1v <1> leavesub[1 ref] K/REFC,1
+# BEGIN 8:
+# 1w <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$
+# 1x <$> const(PV "warnings.pm") s/BARE
+# 1y <1> require sK/1
+# 1z <;> nextstate(B::Concise -945 Concise.pm:410) :*,&,{,x*,x&,x$,$
+# 20 <0> pushmark s
+# 21 <$> const(PV "warnings") sM
+# 22 <$> const(PV "qw") sM
+# 23 <.> method_named(PV "unimport") 
+# 24 <1> entersub[t1] KRS*/TARG,STRICT
 # 25 <1> leavesub[1 ref] K/REFC,1
+# BEGIN 9:
+# 26 <;> nextstate(main 3 -e:1) v:{
+# 27 <$> gvsv(*beg) s
+# 28 <1> postinc[t2] sK/1
+# 29 <1> leavesub[1 ref] K/REFC,1
+# END 1:
+# 2a <;> nextstate(main 9 -e:1) v:{
+# 2b <$> gvsv(*end) s
+# 2c <1> postinc[t2] sK/1
+# 2d <1> leavesub[1 ref] K/REFC,1
+# INIT 1:
+# 2e <;> nextstate(main 7 -e:1) v:{
+# 2f <$> gvsv(*init) s
+# 2g <1> postinc[t2] sK/1
+# 2h <1> leavesub[1 ref] K/REFC,1
+# CHECK 1:
+# 2i <;> nextstate(main 5 -e:1) v:{
+# 2j <$> gvsv(*chk) s
+# 2k <1> postinc[t2] sK/1
+# 2l <1> leavesub[1 ref] K/REFC,1
+# UNITCHECK 1:
+# 2m <;> nextstate(main 11 -e:1) v:{
+# 2n <$> gvsv(*uc) s
+# 2o <1> postinc[t2] sK/1
+# 2p <1> leavesub[1 ref] K/REFC,1
 EONT_EONT
 
 # perl "-I../lib" -MO=Concise,BEGIN,CHECK,INIT,END,-exec -e '$a=$b && print q/foo/'
@@ -502,40 +604,40 @@ checkOptree ( name	=> 'regression test for patch 25352',
 	      prog	=> 'print q/foo/',
 	      expect	=> <<'EOT_EOT', expect_nt => <<'EONT_EONT');
 # BEGIN 1:
-# 1  <;> nextstate(B::Concise -275 Concise.pm:356) v:*,&,{,x*,x&,x$,$
-# 2  <#> gv[*STDOUT] s
-# 3  <1> rv2gv sKRM/STRICT,1
-# 4  <1> srefgen sK/1
-# 5  <#> gvsv[*B::Concise::walkHandle] s
-# 6  <2> sassign sKS/2
-# 7  <1> leavesub[1 ref] K/REFC,1
+# 1  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$
+# 2  <$> const[PV "strict.pm"] s/BARE
+# 3  <1> require sK/1
+# 4  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) :*,&,{,x*,x&,x$,$
+# 5  <0> pushmark s
+# 6  <$> const[PV "strict"] sM
+# 7  <$> const[PV "refs"] sM
+# 8  <.> method_named[PV "unimport"] 
+# 9  <1> entersub[t1] KRS*/TARG,STRICT
+# a  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 2:
-# 8  <;> nextstate(B::Concise -1113 Concise.pm:181) v:*,&,x*,x&,x$,$
-# 9  <$> const[PV "strict.pm"] s/BARE
-# a  <1> require sK/1
-# b  <;> nextstate(B::Concise -1113 Concise.pm:181) :*,&,x*,x&,x$,$
-# c  <0> pushmark s
-# d  <$> const[PV "strict"] sM
-# e  <$> const[PV "refs"] sM
-# f  <.> method_named[PV "unimport"] 
-# g  <1> entersub[t1] KRS*/TARG,STRICT
-# h  <1> leavesub[1 ref] K/REFC,1
+# b  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$
+# c  <$> const[PV "warnings.pm"] s/BARE
+# d  <1> require sK/1
+# e  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) :*,&,{,x*,x&,x$
+# f  <0> pushmark s
+# g  <$> const[PV "warnings"] sM
+# h  <$> const[PV "once"] sM
+# i  <.> method_named[PV "unimport"] 
+# j  <1> entersub[t1] KRS*/TARG
+# k  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 3:
-# i  <;> nextstate(B::Concise -1010 Concise.pm:303) v:*,&,x*,x&,x$,$
-# j  <$> const[PV "strict.pm"] s/BARE
-# k  <1> require sK/1
-# l  <;> nextstate(B::Concise -1010 Concise.pm:303) :*,&,x*,x&,x$,$
-# m  <0> pushmark s
-# n  <$> const[PV "strict"] sM
-# o  <$> const[PV "refs"] sM
-# p  <.> method_named[PV "unimport"] 
-# q  <1> entersub[t1] KRS*/TARG,STRICT
+# l  <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$
+# m  <#> gv[*STDOUT] s
+# n  <1> rv2gv sKRM/STRICT,1
+# o  <1> srefgen sK/1
+# p  <#> gvsv[*B::Concise::walkHandle] s
+# q  <2> sassign sKS/2
 # r  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 4:
-# s  <;> nextstate(B::Concise -963 Concise.pm:368) v:*,&,{,x*,x&,x$,$
+# s  <;> nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$
 # t  <$> const[PV "strict.pm"] s/BARE
 # u  <1> require sK/1
-# v  <;> nextstate(B::Concise -963 Concise.pm:368) :*,&,{,x*,x&,x$,$
+# v  <;> nextstate(B::Concise -1134 Concise.pm:183) :*,&,x*,x&,x$,$
 # w  <0> pushmark s
 # x  <$> const[PV "strict"] sM
 # y  <$> const[PV "refs"] sM
@@ -543,10 +645,10 @@ checkOptree ( name	=> 'regression test for patch 25352',
 # 10 <1> entersub[t1] KRS*/TARG,STRICT
 # 11 <1> leavesub[1 ref] K/REFC,1
 # BEGIN 5:
-# 12 <;> nextstate(B::Concise -938 Concise.pm:388) v:*,&,x*,x&,x$,$
+# 12 <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$
 # 13 <$> const[PV "strict.pm"] s/BARE
 # 14 <1> require sK/1
-# 15 <;> nextstate(B::Concise -938 Concise.pm:388) :*,&,x*,x&,x$,$
+# 15 <;> nextstate(B::Concise -1031 Concise.pm:305) :*,&,x*,x&,x$,$
 # 16 <0> pushmark s
 # 17 <$> const[PV "strict"] sM
 # 18 <$> const[PV "refs"] sM
@@ -554,52 +656,74 @@ checkOptree ( name	=> 'regression test for patch 25352',
 # 1a <1> entersub[t1] KRS*/TARG,STRICT
 # 1b <1> leavesub[1 ref] K/REFC,1
 # BEGIN 6:
-# 1c <;> nextstate(B::Concise -924 Concise.pm:408) v:*,&,{,x*,x&,x$,$
-# 1d <$> const[PV "warnings.pm"] s/BARE
+# 1c <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$
+# 1d <$> const[PV "strict.pm"] s/BARE
 # 1e <1> require sK/1
-# 1f <;> nextstate(B::Concise -924 Concise.pm:408) :*,&,{,x*,x&,x$,$
+# 1f <;> nextstate(B::Concise -984 Concise.pm:370) :*,&,{,x*,x&,x$,$
 # 1g <0> pushmark s
-# 1h <$> const[PV "warnings"] sM
-# 1i <$> const[PV "qw"] sM
+# 1h <$> const[PV "strict"] sM
+# 1i <$> const[PV "refs"] sM
 # 1j <.> method_named[PV "unimport"] 
 # 1k <1> entersub[t1] KRS*/TARG,STRICT
 # 1l <1> leavesub[1 ref] K/REFC,1
+# BEGIN 7:
+# 1m <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$
+# 1n <$> const[PV "strict.pm"] s/BARE
+# 1o <1> require sK/1
+# 1p <;> nextstate(B::Concise -959 Concise.pm:390) :*,&,x*,x&,x$,$
+# 1q <0> pushmark s
+# 1r <$> const[PV "strict"] sM
+# 1s <$> const[PV "refs"] sM
+# 1t <.> method_named[PV "unimport"] 
+# 1u <1> entersub[t1] KRS*/TARG,STRICT
+# 1v <1> leavesub[1 ref] K/REFC,1
+# BEGIN 8:
+# 1w <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$
+# 1x <$> const[PV "warnings.pm"] s/BARE
+# 1y <1> require sK/1
+# 1z <;> nextstate(B::Concise -945 Concise.pm:410) :*,&,{,x*,x&,x$,$
+# 20 <0> pushmark s
+# 21 <$> const[PV "warnings"] sM
+# 22 <$> const[PV "qw"] sM
+# 23 <.> method_named[PV "unimport"] 
+# 24 <1> entersub[t1] KRS*/TARG,STRICT
+# 25 <1> leavesub[1 ref] K/REFC,1
 EOT_EOT
 # BEGIN 1:
-# 1  <;> nextstate(B::Concise -1151 Concise.pm:116) v:*,&,{,x*,x&,x$,$
-# 2  <$> gv(*STDOUT) s
-# 3  <1> rv2gv sKRM/STRICT,1
-# 4  <1> srefgen sK/1
-# 5  <$> gvsv(*B::Concise::walkHandle) s
-# 6  <2> sassign sKS/2
-# 7  <1> leavesub[1 ref] K/REFC,1
+# 1  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$
+# 2  <$> const(PV "strict.pm") s/BARE
+# 3  <1> require sK/1
+# 4  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) :*,&,{,x*,x&,x$,$
+# 5  <0> pushmark s
+# 6  <$> const(PV "strict") sM
+# 7  <$> const(PV "refs") sM
+# 8  <.> method_named(PV "unimport") 
+# 9  <1> entersub[t1] KRS*/TARG,STRICT
+# a  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 2:
-# 8  <;> nextstate(B::Concise -1113 Concise.pm:181) v:*,&,x*,x&,x$,$
-# 9  <$> const(PV "strict.pm") s/BARE
-# a  <1> require sK/1
-# b  <;> nextstate(B::Concise -1113 Concise.pm:181) :*,&,x*,x&,x$,$
-# c  <0> pushmark s
-# d  <$> const(PV "strict") sM
-# e  <$> const(PV "refs") sM
-# f  <.> method_named(PV "unimport") 
-# g  <1> entersub[t1] KRS*/TARG,STRICT
-# h  <1> leavesub[1 ref] K/REFC,1
+# b  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$
+# c  <$> const(PV "warnings.pm") s/BARE
+# d  <1> require sK/1
+# e  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) :*,&,{,x*,x&,x$
+# f  <0> pushmark s
+# g  <$> const(PV "warnings") sM
+# h  <$> const(PV "once") sM
+# i  <.> method_named(PV "unimport") 
+# j  <1> entersub[t1] KRS*/TARG
+# k  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 3:
-# i  <;> nextstate(B::Concise -1010 Concise.pm:303) v:*,&,x*,x&,x$,$
-# j  <$> const(PV "strict.pm") s/BARE
-# k  <1> require sK/1
-# l  <;> nextstate(B::Concise -1010 Concise.pm:303) :*,&,x*,x&,x$,$
-# m  <0> pushmark s
-# n  <$> const(PV "strict") sM
-# o  <$> const(PV "refs") sM
-# p  <.> method_named(PV "unimport") 
-# q  <1> entersub[t1] KRS*/TARG,STRICT
+# l  <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$
+# m  <$> gv(*STDOUT) s
+# n  <1> rv2gv sKRM/STRICT,1
+# o  <1> srefgen sK/1
+# p  <$> gvsv(*B::Concise::walkHandle) s
+# q  <2> sassign sKS/2
 # r  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 4:
-# s  <;> nextstate(B::Concise -963 Concise.pm:368) v:*,&,{,x*,x&,x$,$
+# s  <;> nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$
 # t  <$> const(PV "strict.pm") s/BARE
 # u  <1> require sK/1
-# v  <;> nextstate(B::Concise -963 Concise.pm:368) :*,&,{,x*,x&,x$,$
+# v  <;> nextstate(B::Concise -1134 Concise.pm:183) :*,&,x*,x&,x$,$
 # w  <0> pushmark s
 # x  <$> const(PV "strict") sM
 # y  <$> const(PV "refs") sM
@@ -607,10 +731,10 @@ EOT_EOT
 # 10 <1> entersub[t1] KRS*/TARG,STRICT
 # 11 <1> leavesub[1 ref] K/REFC,1
 # BEGIN 5:
-# 12 <;> nextstate(B::Concise -938 Concise.pm:388) v:*,&,x*,x&,x$,$
+# 12 <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$
 # 13 <$> const(PV "strict.pm") s/BARE
 # 14 <1> require sK/1
-# 15 <;> nextstate(B::Concise -938 Concise.pm:388) :*,&,x*,x&,x$,$
+# 15 <;> nextstate(B::Concise -1031 Concise.pm:305) :*,&,x*,x&,x$,$
 # 16 <0> pushmark s
 # 17 <$> const(PV "strict") sM
 # 18 <$> const(PV "refs") sM
@@ -618,14 +742,36 @@ EOT_EOT
 # 1a <1> entersub[t1] KRS*/TARG,STRICT
 # 1b <1> leavesub[1 ref] K/REFC,1
 # BEGIN 6:
-# 1c <;> nextstate(B::Concise -924 Concise.pm:408) v:*,&,{,x*,x&,x$,$
-# 1d <$> const(PV "warnings.pm") s/BARE
+# 1c <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$
+# 1d <$> const(PV "strict.pm") s/BARE
 # 1e <1> require sK/1
-# 1f <;> nextstate(B::Concise -924 Concise.pm:408) :*,&,{,x*,x&,x$,$
+# 1f <;> nextstate(B::Concise -984 Concise.pm:370) :*,&,{,x*,x&,x$,$
 # 1g <0> pushmark s
-# 1h <$> const(PV "warnings") sM
-# 1i <$> const(PV "qw") sM
+# 1h <$> const(PV "strict") sM
+# 1i <$> const(PV "refs") sM
 # 1j <.> method_named(PV "unimport") 
 # 1k <1> entersub[t1] KRS*/TARG,STRICT
 # 1l <1> leavesub[1 ref] K/REFC,1
+# BEGIN 7:
+# 1m <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$
+# 1n <$> const(PV "strict.pm") s/BARE
+# 1o <1> require sK/1
+# 1p <;> nextstate(B::Concise -959 Concise.pm:390) :*,&,x*,x&,x$,$
+# 1q <0> pushmark s
+# 1r <$> const(PV "strict") sM
+# 1s <$> const(PV "refs") sM
+# 1t <.> method_named(PV "unimport") 
+# 1u <1> entersub[t1] KRS*/TARG,STRICT
+# 1v <1> leavesub[1 ref] K/REFC,1
+# BEGIN 8:
+# 1w <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$
+# 1x <$> const(PV "warnings.pm") s/BARE
+# 1y <1> require sK/1
+# 1z <;> nextstate(B::Concise -945 Concise.pm:410) :*,&,{,x*,x&,x$,$
+# 20 <0> pushmark s
+# 21 <$> const(PV "warnings") sM
+# 22 <$> const(PV "qw") sM
+# 23 <.> method_named(PV "unimport") 
+# 24 <1> entersub[t1] KRS*/TARG,STRICT
+# 25 <1> leavesub[1 ref] K/REFC,1
 EONT_EONT


### PR DESCRIPTION
Update optree_specials since OptreeCheck.pm uses Exporter.