### PR TITLE
ignore cygwin files that cannot be stat()ed in t/op/stat.t

### DIFF
--- a/t/op/stat.t
+++ b/t/op/stat.t
@@ -299,6 +299,11 @@ SKIP: {
     $DEV =~ s{^.+?\s\..+?$}{}m;
     @DEV =  grep { ! m{^\..+$} } @DEV;
 
+    # sometimes files cannot be stat'd on cygwin, making inspecting pointless
+    # remove them from both @DEV and $DEV
+    @DEV = grep $DEV =~ s/^.\?{9}.*\s$_(?: -> .*)?$//m ? () : $_, @DEV
+      if $Is_Cygwin;
+
     # Irix ls -l marks sockets with 'S' while 's' is a 'XENIX semaphore'.
     if ($^O eq 'irix') {
         $DEV =~ s{^S(.+?)}{s$1}mg;
@@ -309,7 +314,8 @@ SKIP: {
 	my @c2 = eval qq[grep { $_[1] "/dev/\$_" } \@DEV];
 	my $c1 = scalar @c1;
 	my $c2 = scalar @c2;
-	is($c1, $c2, "ls and $_[1] agreeing on /dev ($c1 $c2)");
+	diag "= before", $DEV, "-", @DEV, "= after", @c1, "-", @c2, "="
+	  unless is($c1, $c2, "ls and $_[1] agreeing on /dev ($c1 $c2)");
     };
 
 {


### PR DESCRIPTION
This is a fix for github cygwin vm smoke runs, specifically the issue in: https://github.com/Perl/perl5/issues/18193

The original cause of the issue was an update github did to their windows vm image with version 20200920.1, wherein the status of a console being attached is now unclear.

This has affected other projects as well (example: https://github.com/actions/virtual-environments/issues/1679 ) and, relevant for us, shows itself as /dev/con(in|out|sole) not being stat()able under cygwin.

As such, the fix for the test is to, under cygwin, identify such files, and remove them from the dataset altogether before checking stat operations on them.

(As a small freebie, this also dumps diagnostics of the check on failure.)