### PR TITLE
Update Digest::MD5 to CPAN version 2.57

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -493,6 +493,7 @@ cpan/Digest-MD5/t/files.t		See if Digest::MD5 extension works
 cpan/Digest-MD5/t/md5-aaa.t		See if Digest::MD5 extension works
 cpan/Digest-MD5/t/threads.t		See if Digest::MD5 extension works
 cpan/Digest-MD5/t/utf8.t		See if Digest::MD5 extension works
+cpan/Digest-MD5/t/warns.t
 cpan/Digest-MD5/typemap			Digest::MD5 extension
 cpan/Digest-SHA/lib/Digest/SHA.pm	Digest::SHA extension
 cpan/Digest-SHA/Makefile.PL		Digest::SHA Makefile.PL

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -364,14 +364,9 @@ use File::Glob qw(:case);
     },
 
     'Digest::MD5' => {
-        'DISTRIBUTION' => 'GAAS/Digest-MD5-2.55.tar.gz',
+        'DISTRIBUTION' => 'TODDR/Digest-MD5-2.58.tar.gz',
         'FILES'        => q[cpan/Digest-MD5],
-        'EXCLUDED'     => ['rfc1321.txt'],
-        'CUSTOMIZED'   => [
-            # RT #133495
-            qw(MD5.xs MD5.pm),
-            qw(Makefile.PL t/files.t)
-         ],
+        'EXCLUDED'     => [ 'rfc1321.txt', 'bin/md5sum.pl' ],
     },
 
     'Digest::SHA' => {

--- a/cpan/Digest-MD5/MD5.pm
+++ b/cpan/Digest-MD5/MD5.pm
@@ -1,17 +1,18 @@
 package Digest::MD5;
 
 use strict;
-use vars qw($VERSION @ISA @EXPORT_OK);
+use warnings;
 
-$VERSION = '2.55_01';
+our $VERSION = '2.58';
 
 require Exporter;
 *import = \&Exporter::import;
-@EXPORT_OK = qw(md5 md5_hex md5_base64);
+our @EXPORT_OK = qw(md5 md5_hex md5_base64);
 
+our @ISA;
 eval {
     require Digest::base;
-    push(@ISA, 'Digest::base');
+    @ISA = qw/Digest::base/;
 };
 if ($@) {
     my $err = $@;
@@ -231,11 +232,13 @@ md5 digests you might want to append the string "==" to the result.
 
 =item $md5->context(@ctx)
 
-Saves or restores the internal state.  When called with no arguments,
-returns a 3-element list: number of blocks processed, a 16-byte
-internal state buffer, then up to 63 bytes of unprocessed data.  When
-passed those same arguments, restores the state.  This is only useful
-for specialised operations.
+Saves or restores the internal state.
+When called with no arguments, returns a list:
+number of blocks processed,
+a 16-byte internal state buffer,
+then optionally up to 63 bytes of unprocessed data if there are any.
+When passed those same arguments, restores the state.
+This is only useful for specialised operations.
 
 =back
 

--- a/cpan/Digest-MD5/MD5.xs
+++ b/cpan/Digest-MD5/MD5.xs
@@ -720,15 +720,19 @@ context(ctx, ...)
 	    XSRETURN(0);
 	}
 
-        w=ctx->A; out[ 0]=w; out[ 1]=(w>>8); out[ 2]=(w>>16); out[ 3]=(w>>24);
-        w=ctx->B; out[ 4]=w; out[ 5]=(w>>8); out[ 6]=(w>>16); out[ 7]=(w>>24);
-        w=ctx->C; out[ 8]=w; out[ 9]=(w>>8); out[10]=(w>>16); out[11]=(w>>24);
-        w=ctx->D; out[12]=w; out[13]=(w>>8); out[14]=(w>>16); out[15]=(w>>24);
+        w=ctx->A; out[ 0]=(char)w; out[ 1]=(char)(w>>8); out[ 2]=(char)(w>>16); out[ 3]=(char)(w>>24);
+        w=ctx->B; out[ 4]=(char)w; out[ 5]=(char)(w>>8); out[ 6]=(char)(w>>16); out[ 7]=(char)(w>>24);
+        w=ctx->C; out[ 8]=(char)w; out[ 9]=(char)(w>>8); out[10]=(char)(w>>16); out[11]=(char)(w>>24);
+        w=ctx->D; out[12]=(char)w; out[13]=(char)(w>>8); out[14]=(char)(w>>16); out[15]=(char)(w>>24);
 
 	EXTEND(SP, 3);
 	ST(0) = sv_2mortal(newSVuv(ctx->bytes_high << 26 |
 				   ctx->bytes_low >> 6));
 	ST(1) = sv_2mortal(newSVpv(out, 16));
+
+	if ((ctx->bytes_low & 0x3F) == 0)
+	    XSRETURN(2);
+
 	ST(2) = sv_2mortal(newSVpv((char *)ctx->buffer,
 				   ctx->bytes_low & 0x3F));
 	XSRETURN(3);

--- a/cpan/Digest-MD5/Makefile.PL
+++ b/cpan/Digest-MD5/Makefile.PL
@@ -1,6 +1,8 @@
 #!perl -w
 
 use strict;
+use warnings;
+
 use Config qw(%Config);
 use ExtUtils::MakeMaker;
 
@@ -30,7 +32,9 @@ WriteMakefile(
 		      },
     'META_MERGE'   => {
         resources  => {
-            repository => 'https://github.com/gisle/digest-md5',
+            license    => 'http://dev.perl.org/licenses/',
+            bugtracker => 'https://github.com/Dual-Life/digest-md5/issues',
+            repository => 'https://github.com/dual-Life/digest-md5/',
         }
     },
     @extra,

--- a/cpan/Digest-MD5/hints/MacOS.pl
+++ b/cpan/Digest-MD5/hints/MacOS.pl
@@ -1,3 +1,5 @@
 # MWCPPC compiler needs to crank down the optimizations
 
+use strict;
+no strict 'vars';
 $self->{MWCPPCOptimize} = "-O1";

--- a/cpan/Digest-MD5/hints/irix_6.pl
+++ b/cpan/Digest-MD5/hints/irix_6.pl
@@ -1,6 +1,10 @@
 # The Mongoose v7.1 compiler freezes up somewhere in the optimization of
 # MD5Transform() in MD5.c with optimization -O3.  This is a workaround:
 
-if ($Config{cc} =~ /64|n32/ && `$Config{cc} -version 2>&1` =~ /\s7\.1/) {
-    $self->{OPTIMIZE} = "-O1";
+use strict;
+no strict 'vars';
+if ( $Config{cc} =~ /64|n32/ && `$Config{cc} -version 2>&1` =~ /\s7\.1/ ) {
+    my $optimize = $Config{optimize};
+    $optimize =~ s/(^| )-O[2-9]\b/$1-O1/g
+      and $self->{OPTIMIZE} = $optimize;
 }

--- a/cpan/Digest-MD5/t/align.t
+++ b/cpan/Digest-MD5/t/align.t
@@ -1,8 +1,10 @@
 # Test that md5 works on unaligned memory blocks
 
+use strict;
+use warnings;
+
 print "1..1\n";
 
-use strict;
 use Digest::MD5 qw(md5_hex);
 
 my $str = "\100" x 20;

--- a/cpan/Digest-MD5/t/badfile.t
+++ b/cpan/Digest-MD5/t/badfile.t
@@ -1,8 +1,10 @@
-print "1..2\n";
+use strict;
+use warnings;
 
 use Digest::MD5 ();
 
-$md5 = Digest::MD5->new;
+print "1..2\n";
+my $md5 = Digest::MD5->new;
 
 eval {
    use vars qw(*FOO);

--- a/cpan/Digest-MD5/t/bits.t
+++ b/cpan/Digest-MD5/t/bits.t
@@ -1,5 +1,8 @@
 #!perl -w
 
+use strict;
+use warnings;
+
 use Test qw(plan ok);
 plan tests => 2;
 

--- a/cpan/Digest-MD5/t/clone.t
+++ b/cpan/Digest-MD5/t/clone.t
@@ -1,9 +1,11 @@
 #!perl -w
 
-print "1..6\n";
-
 use strict;
+use warnings;
+
 use Digest::MD5 qw(md5_hex);
+
+print "1..6\n";
 
 my $a = Digest::MD5->new;
 $a->add("a");

--- a/cpan/Digest-MD5/t/files.t
+++ b/cpan/Digest-MD5/t/files.t
@@ -1,8 +1,9 @@
+use strict;
+use warnings;
+
+use Digest::MD5 qw(md5 md5_hex md5_base64);
 
 print "1..3\n";
-
-use strict;
-use Digest::MD5 qw(md5 md5_hex md5_base64);
 
 # To update the EBCDIC section even on a Latin 1 platform,
 # run this script with $ENV{EBCDIC_MD5SUM} set to a true value.
@@ -14,14 +15,14 @@ my $EXPECT;
 if (ord "A" == 193) { # EBCDIC
     $EXPECT = <<EOT;
 0956ffb4f6416082b27d6680b4cf73fc  README
-60a80f534f0017745eb755f36a946fe7  MD5.xs
+3fce99bf3f4df26d65843a6990849df0  MD5.xs
 276da0aa4e9a08b7fe09430c9c5690aa  rfc1321.txt
 EOT
 } else {
     # This is the output of: 'md5sum README MD5.xs rfc1321.txt'
     $EXPECT = <<EOT;
 2f93400875dbb56f36691d5f69f3eba5  README
-5b8b4f96bc27a425501307c5461970db  MD5.xs
+3fce99bf3f4df26d65843a6990849df0  MD5.xs
 754b9db19f79dbc4992f7166eb0f37ce  rfc1321.txt
 EOT
 }

--- a/cpan/Digest-MD5/t/md5-aaa.t
+++ b/cpan/Digest-MD5/t/md5-aaa.t
@@ -1,7 +1,9 @@
 use strict;
-print "1..256\n";
+use warnings;
 
 use Digest::MD5 qw(md5_hex);
+
+print "1..256\n";
 
 my $Is_EBCDIC = ord('A') == 193;
 

--- a/cpan/Digest-MD5/t/threads.t
+++ b/cpan/Digest-MD5/t/threads.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+
 use Test::More;
 use Config;
 

--- a/cpan/Digest-MD5/t/utf8.t
+++ b/cpan/Digest-MD5/t/utf8.t
@@ -7,10 +7,12 @@ BEGIN {
     }
 }
 
-print "1..5\n";
-
 use strict;
+use warnings;
+
 use Digest::MD5 qw(md5_hex);
+
+print "1..5\n";
 
 my $str;
 $str = "foo\xFF\x{100}";

--- a/cpan/Digest-MD5/t/warns.t
+++ b/cpan/Digest-MD5/t/warns.t
@@ -1,0 +1,62 @@
+use Digest::MD5;
+use Test::More tests => 6;
+
+$^W = 0; # No warnings
+{
+  local *STDERR;
+  my $stderr_seen = "";
+  open STDERR, '>', \$stderr_seen;
+  $str = Digest::MD5->md5_hex("foo");
+  is($stderr_seen,'','No warnings');
+}
+
+{
+  $^W = 1; # magic turn on warnings
+  local *STDERR;
+  my $stderr_seen = "";
+  open STDERR, '>', \$stderr_seen;
+  $str = Digest::MD5->md5_hex("foo");
+  like($stderr_seen,qr/Digest::MD5::md5_hex function probably called as class method/,
+        'Lexical warning passed to XSUB');
+}
+
+{
+  $^W = 0; # No warnings
+  local *STDERR;
+  my $stderr_seen = "";
+  open STDERR, '>', \$stderr_seen;
+  $str = Digest::MD5->md5_hex("foo");
+  is($stderr_seen,'','No warnings again');
+}
+
+{
+  use warnings;
+  local *STDERR;
+  my $stderr_seen = "";
+  open STDERR, '>', \$stderr_seen;
+  $str = Digest::MD5->md5_hex("foo");
+  like($stderr_seen,qr/Digest::MD5::md5_hex function probably called as class method/,
+        'use warnings passed to XSUB');
+}
+
+{
+  use strict;
+  $^W = 0; # No warnings
+  local *STDERR;
+  my $stderr_seen = "";
+  open STDERR, '>', \$stderr_seen;
+  my $str = Digest::MD5->md5_hex("foo");
+  is($stderr_seen,'','No warnings and strict');
+}
+
+{
+  use strict;
+  use warnings;
+  local *STDERR;
+  my $stderr_seen = "";
+  open STDERR, '>', \$stderr_seen;
+  my $str = Digest::MD5->md5_hex("foo");
+  like($stderr_seen, qr/Digest::MD5::md5_hex function probably called as class method/,
+        'use warnings passed to XSUB while use strict');
+}
+

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -4,10 +4,6 @@
 Config::Perl::V cpan/Config-Perl-V/V.pm 0a0f7207e6505b78ee345a933acb0246a13579f5
 Devel::PPPort dist/Devel-PPPort/Makefile.PL c939c8d33d11994c06f546869df63d4518ece797
 Digest cpan/Digest/Digest.pm 43f7f544cb11842b2f55c73e28930da50774e081
-Digest::MD5 cpan/Digest-MD5/Makefile.PL 3bf781444ee671da63f1c6360e0a31f11d9ba520
-Digest::MD5 cpan/Digest-MD5/MD5.pm df5f0663f0f755be7eda6e3d2f008f2629246b19
-Digest::MD5 cpan/Digest-MD5/MD5.xs 249bed648232192ce018f7f894ad127c3a639831
-Digest::MD5 cpan/Digest-MD5/t/files.t e987329d2411ff60ad9a2bdf93fdf5f6943467e8
 ExtUtils::Constant cpan/ExtUtils-Constant/t/Constant.t d5c75c41d6736a0c5897130f534af0896a7d6f4d
 ExtUtils::MakeMaker cpan/ExtUtils-MakeMaker/t/lib/MakeMaker/Test/Setup/XS.pm 9dd84951b7602239516659c15d23c3c9eeebd1ab
 ExtUtils::PL2Bat cpan/ExtUtils-PL2Bat/t/make_executable.t 6e63dbf43ee7ff5a54e615a576360cb0f1825694


### PR DESCRIPTION
[DELTA]

2020-10-05 Todd Rinaldo <toddr@cpan.org> 2.57

- Merge change submitted to blead

2020-10-05 Todd Rinaldo <toddr@cpan.org> 2.56

- Github CI Perl 5.6..5.32
- Fixup MANIFEST/MANIFEST.SKIP/.gitignore
- Enable strict and warnings on all code. Drop vars.pm
- Preserve OPTIMIZE in hints/irix_6.pl
- Don't return context buffer if there isn't one
- Silence possible loss of data warnings on Win32