### PR TITLE
Update Pod::Checker to CPAN version 1.74

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1551,6 +1551,7 @@ cpan/Pod-Checker/t/pod/podchkenc.xr
 cpan/Pod-Checker/t/pod/podchklink.t
 cpan/Pod-Checker/t/pod/poderrs.t
 cpan/Pod-Checker/t/pod/poderrs.xr
+cpan/Pod-Checker/t/pod/podname.t
 cpan/Pod-Checker/t/pod/selfcheck.t
 cpan/Pod-Checker/t/pod/testcmp.pl
 cpan/Pod-Checker/t/pod/testpchk.pl

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -920,14 +920,8 @@ use File::Glob qw(:case);
     },
 
     'Pod::Checker' => {
-        'DISTRIBUTION' => 'MAREKR/Pod-Checker-1.73.tar.gz',
+        'DISTRIBUTION' => 'MAREKR/Pod-Checker-1.74.tar.gz',
         'FILES'        => q[cpan/Pod-Checker],
-        'CUSTOMIZED'   => [ qw[
-            t/pod/contains_bad_pod.xr
-            t/pod/selfcheck.t
-            t/pod/testcmp.pl
-            t/pod/testpchk.pl
-        ] ],
     },
 
     'Pod::Escapes' => {

--- a/cpan/Pod-Checker/lib/Pod/Checker.pm
+++ b/cpan/Pod-Checker/lib/Pod/Checker.pm
@@ -10,7 +10,7 @@ package Pod::Checker;
 use strict;
 use warnings;
 
-our $VERSION = '1.73';  ## Current version of this package
+our $VERSION = '1.74';  ## Current version of this package
 
 =head1 NAME
 
@@ -197,10 +197,6 @@ The I<STRING> found cannot be interpreted as a character entity.
 
 There needs to be content inside E, L, and X formatting codes.
 
-=item * A non-empty ZE<lt>E<gt>
-
-The C<ZE<lt>E<gt>> sequence is supposed to be empty.
-
 =item * Spurious text after =pod / =cut
 
 The commands C<=pod> and C<=cut> do not take any arguments.
@@ -299,6 +295,12 @@ description of what the thing is good for.
 For example if there is a C<=head2> in the POD file prior to a
 C<=head1>.
 
+=item * A non-empty ZE<lt>E<gt>
+
+The C<ZE<lt>E<gt>> sequence is supposed to be empty. Caveat: this issue is
+detected in L<Pod::Simple> and will be flagged as an I<ERROR> by any client
+code; any contents of C<ZE<lt>...E<gt>> will be disregarded, anyway.
+
 =back
 
 =head2 Hyperlinks
@@ -361,10 +363,121 @@ B<podchecker> (the script). This allows users of B<Pod::Checker> to
 control completely the output behavior. Users of B<podchecker> (the script)
 get the well-known behavior.
 
-v1.45 inherits from Pod::Simple as opposed to all previous versions
+v1.45 inherits from L<Pod::Simple> as opposed to all previous versions
 inheriting from Pod::Parser. Do B<not> use Pod::Simple's interface when
 using Pod::Checker unless it is documented somewhere on this page. I
 repeat, DO B<NOT> USE POD::SIMPLE'S INTERFACE.
+
+The following list documents the overrides to Pod::Simple, primarily to
+make L<Pod::Coverage> happy:
+
+=over 4
+
+=item end_B
+
+=item end_C
+
+=item end_Document
+
+=item end_F
+
+=item end_I
+
+=item end_L
+
+=item end_Para
+
+=item end_S
+
+=item end_X
+
+=item end_fcode
+
+=item end_for
+
+=item end_head
+
+=item end_head1
+
+=item end_head2
+
+=item end_head3
+
+=item end_head4
+
+=item end_item
+
+=item end_item_bullet
+
+=item end_item_number
+
+=item end_item_text
+
+=item handle_pod_and_cut
+
+=item handle_text
+
+=item handle_whiteline
+
+=item hyperlink
+
+=item scream
+
+=item start_B
+
+=item start_C
+
+=item start_Data
+
+=item start_F
+
+=item start_I
+
+=item start_L
+
+=item start_Para
+
+=item start_S
+
+=item start_Verbatim
+
+=item start_X
+
+=item start_fcode
+
+=item start_for
+
+=item start_head
+
+=item start_head1
+
+=item start_head2
+
+=item start_head3
+
+=item start_head4
+
+=item start_item_bullet
+
+=item start_item_number
+
+=item start_item_text
+
+=item start_over
+
+=item start_over_block
+
+=item start_over_bullet
+
+=item start_over_empty
+
+=item start_over_number
+
+=item start_over_text
+
+=item whine
+
+=back
 
 =cut
 
@@ -662,6 +775,9 @@ sub whine {
           $complaint =~ /^You can't have =items \(as at line .+?\) unless the first thing after the =over is an =item$/ ||
           $complaint =~ /^You have '=item .+?' instead of the expected '=item .+?'$/;
     }
+
+    # rt.cpan.org #98326 - errors about Z<> ("non-empty")
+    $severity = 'WARNING' if $complaint =~ /\bZ\<\>/;
 
     $self->poderror({ -line => $line,
                       -severity => $severity,

--- a/cpan/Pod-Checker/scripts/podchecker.PL
+++ b/cpan/Pod-Checker/scripts/podchecker.PL
@@ -1,5 +1,5 @@
 #!/usr/local/bin/perl
-
+use strict;
 use Config;
 use File::Basename qw(&basename &dirname);
 use Cwd;
@@ -13,6 +13,7 @@ use Cwd;
 
 # This forces PL files to create target in same directory as PL file.
 # This is so that make depend always knows where to find PL derivatives.
+my ($origdir, $file);
 $origdir = cwd;
 chdir(dirname($0));
 ($file = basename($0)) =~ s/\.PL$//;

--- a/cpan/Pod-Checker/t/pod/poderrs.t
+++ b/cpan/Pod-Checker/t/pod/poderrs.t
@@ -121,6 +121,8 @@ L</OoPs>
 L<abc
 def>
 L<>
+L</>
+L<wheeee|/>
 L<   aha>
 L<oho   >
 L<  weehee  >

--- a/cpan/Pod-Checker/t/pod/poderrs.xr
+++ b/cpan/Pod-Checker/t/pod/poderrs.xr
@@ -33,38 +33,40 @@
 *** ERROR: An E<...> surrounding strange content at line 105 in file t/pod/poderrs.t
 *** ERROR: Unknown E content in E<unknown_entity> at line 105 in file t/pod/poderrs.t
 *** ERROR: An empty L<> at line 121 in file t/pod/poderrs.t
+*** ERROR: L<> contains only '/' at line 121 in file t/pod/poderrs.t
 *** ERROR: L<> starts or ends with whitespace at line 121 in file t/pod/poderrs.t
 *** ERROR: L<> starts or ends with whitespace at line 121 in file t/pod/poderrs.t
 *** ERROR: L<> starts or ends with whitespace at line 121 in file t/pod/poderrs.t
-*** ERROR: Unterminated L<<< ... >>> sequence at line 137 in file t/pod/poderrs.t
+*** WARNING: empty link at line 121 in file t/pod/poderrs.t
 *** ERROR: Unterminated L<<< ... >>> sequence at line 139 in file t/pod/poderrs.t
-*** ERROR: alternative text 'some text with / in it' contains non-escaped | or / at line 143 in file t/pod/poderrs.t
-*** ERROR: =back doesn't take any parameters, but you said =back 200 at line 150 in file t/pod/poderrs.t
-*** ERROR: A non-empty Z<> at line 158 in file t/pod/poderrs.t
-*** ERROR: An empty X<> at line 160 in file t/pod/poderrs.t
-*** ERROR: An empty E<> at line 164 in file t/pod/poderrs.t
-*** ERROR: =over should be: '=over' or '=over positive_number' at line 166 in file t/pod/poderrs.t
-*** ERROR: You can't have =items (as at line 170) unless the first thing after the =over is an =item at line 166 in file t/pod/poderrs.t
-*** WARNING: =item has no contents at line 176 in file t/pod/poderrs.t
-*** ERROR: Expected '=item *' at line 178 in file t/pod/poderrs.t
+*** ERROR: Unterminated L<<< ... >>> sequence at line 141 in file t/pod/poderrs.t
+*** ERROR: alternative text 'some text with / in it' contains non-escaped | or / at line 145 in file t/pod/poderrs.t
+*** ERROR: =back doesn't take any parameters, but you said =back 200 at line 152 in file t/pod/poderrs.t
+*** WARNING: A non-empty Z<> at line 160 in file t/pod/poderrs.t
+*** ERROR: An empty X<> at line 162 in file t/pod/poderrs.t
+*** ERROR: An empty E<> at line 166 in file t/pod/poderrs.t
+*** ERROR: =over should be: '=over' or '=over positive_number' at line 168 in file t/pod/poderrs.t
+*** ERROR: You can't have =items (as at line 172) unless the first thing after the =over is an =item at line 168 in file t/pod/poderrs.t
+*** WARNING: =item has no contents at line 178 in file t/pod/poderrs.t
 *** ERROR: Expected '=item *' at line 180 in file t/pod/poderrs.t
-*** WARNING: line containing nothing but whitespace in paragraph at line 187 in file t/pod/poderrs.t
-*** ERROR: You can't have =items (as at line 188) unless the first thing after the =over is an =item at line 184 in file t/pod/poderrs.t
-*** ERROR: Expected '=item *' at line 204 in file t/pod/poderrs.t
-*** ERROR: Expected '=item *' at line 208 in file t/pod/poderrs.t
-*** ERROR: You have '=item 3' instead of the expected '=item 2' at line 218 in file t/pod/poderrs.t
-*** ERROR: Expected '=item 3' at line 222 in file t/pod/poderrs.t
-*** ERROR: Expected '=item 4' at line 224 in file t/pod/poderrs.t
-*** ERROR: Expected text after =item, not a bullet at line 234 in file t/pod/poderrs.t
-*** ERROR: Expected text after =item, not a number at line 238 in file t/pod/poderrs.t
-*** WARNING: empty =over/=back block at line 253 in file t/pod/poderrs.t
-*** ERROR: Spurious text after =pod at line 263 in file t/pod/poderrs.t
-*** ERROR: Spurious text after =cut at line 267 in file t/pod/poderrs.t
-*** WARNING: empty section in previous paragraph at line 283 in file t/pod/poderrs.t
-*** ERROR: empty =head1 at line 305 in file t/pod/poderrs.t
-*** ERROR: =over without closing =back at line 311 in file t/pod/poderrs.t
-*** ERROR: =begin :xml without matching =end :xml at line 317 in file t/pod/poderrs.t
-*** ERROR: =begin html without matching =end html at line 313 in file t/pod/poderrs.t
+*** ERROR: Expected '=item *' at line 182 in file t/pod/poderrs.t
+*** WARNING: line containing nothing but whitespace in paragraph at line 189 in file t/pod/poderrs.t
+*** ERROR: You can't have =items (as at line 190) unless the first thing after the =over is an =item at line 186 in file t/pod/poderrs.t
+*** ERROR: Expected '=item *' at line 206 in file t/pod/poderrs.t
+*** ERROR: Expected '=item *' at line 210 in file t/pod/poderrs.t
+*** ERROR: You have '=item 3' instead of the expected '=item 2' at line 220 in file t/pod/poderrs.t
+*** ERROR: Expected '=item 3' at line 224 in file t/pod/poderrs.t
+*** ERROR: Expected '=item 4' at line 226 in file t/pod/poderrs.t
+*** ERROR: Expected text after =item, not a bullet at line 236 in file t/pod/poderrs.t
+*** ERROR: Expected text after =item, not a number at line 240 in file t/pod/poderrs.t
+*** WARNING: empty =over/=back block at line 255 in file t/pod/poderrs.t
+*** ERROR: Spurious text after =pod at line 265 in file t/pod/poderrs.t
+*** ERROR: Spurious text after =cut at line 269 in file t/pod/poderrs.t
+*** WARNING: empty section in previous paragraph at line 285 in file t/pod/poderrs.t
+*** ERROR: empty =head1 at line 307 in file t/pod/poderrs.t
+*** ERROR: =over without closing =back at line 313 in file t/pod/poderrs.t
+*** ERROR: =begin :xml without matching =end :xml at line 319 in file t/pod/poderrs.t
+*** ERROR: =begin html without matching =end html at line 315 in file t/pod/poderrs.t
 *** ERROR: unresolved internal link 'begin or begin' at line 115 in file t/pod/poderrs.t
 *** ERROR: unresolved internal link 'end with begin' at line 115 in file t/pod/poderrs.t
 *** ERROR: unresolved internal link 'OoPs' at line 115 in file t/pod/poderrs.t
@@ -72,7 +74,7 @@
 *** ERROR: unresolved internal link ' aha' at line 121 in file t/pod/poderrs.t
 *** ERROR: unresolved internal link 'oho ' at line 121 in file t/pod/poderrs.t
 *** ERROR: unresolved internal link ' weehee ' at line 121 in file t/pod/poderrs.t
-*** ERROR: unresolved internal link 'link_to_nowhere' at line 319 in file t/pod/poderrs.t
+*** ERROR: unresolved internal link 'link_to_nowhere' at line 321 in file t/pod/poderrs.t
 *** WARNING: multiple occurrences (2) of link target '*' at line - in file t/pod/poderrs.t
 *** WARNING: multiple occurrences (2) of link target '1' at line - in file t/pod/poderrs.t
 *** WARNING: multiple occurrences (2) of link target 'Misc' at line - in file t/pod/poderrs.t

--- a/cpan/Pod-Checker/t/pod/podname.t
+++ b/cpan/Pod-Checker/t/pod/podname.t
@@ -1,0 +1,42 @@
+#!/usr/bin/perl
+
+use strict;
+use Test::More tests => 4;
+
+require_ok('Pod::Checker');
+
+my $infile  = $0; # self
+(my $outfile = $infile) =~ s/\..*?$/.OUT/;
+
+if ($^O eq 'VMS') {
+    for ($infile, $outfile) {
+        $_ = VMS::Filespec::unixify($_)  unless  ref;
+    }
+}
+
+my $checker = Pod::Checker->new();
+ok($checker, 'Checker object successfully created');
+
+ok($checker->parse_from_file($infile, $outfile), "$0 successfully parsed");
+
+is($checker->name(), 'podname');
+
+$checker->{'-quiet'} = 1; # we can't write now
+$checker->poderror('* HORROR: You better run');
+
+END {
+  unlink($outfile);
+}
+
+__END__
+
+# this lone =cut triggers the call to scream()
+
+=cut
+
+=head1 NAME
+
+podname - check the name() method of Pod::Checker
+
+=cut
+

--- a/cpan/Pod-Checker/t/pod/testpchk.pl
+++ b/cpan/Pod-Checker/t/pod/testpchk.pl
@@ -1,8 +1,10 @@
 package TestPodChecker;
 
+use strict;
+use File::Basename qw(basename dirname fileparse);
+use File::Spec;
+
 BEGIN {
-   use File::Basename;
-   use File::Spec;
    push @INC, '..';
    my $THISDIR = dirname $0;
    unshift @INC, $THISDIR;
@@ -14,7 +16,7 @@ BEGIN {
 }
 
 use Pod::Checker;
-use vars qw(@ISA @EXPORT $MYPKG);
+use vars qw(@ISA @EXPORT @EXPORT_OK $MYPKG);
 #use strict;
 #use diagnostics;
 use Carp;


### PR DESCRIPTION
[DELTA]

+ CPAN#133312: Add strict compliance to Pod-Checker
  Thanks TODDR for the patch to make the code "use strict" compliant
+ CPAN#98326: Can we make “A non-empty Z<>” a warning and not an error
  This is a corner case... and since Pod::Simple anyway "nixes" anything
  inside Z<...>, this is a warning, not an error. Mind the caveats.
+ Added an additional test to achieve 100% statement coverage and added
  some POD to also have 100% POD coverage
+ Made all text files unixish, no CRLF