### PR TITLE
Add crosslinks between perl5db.pl and perldebug-related docs

### DIFF
--- a/lib/perl5db.pl
+++ b/lib/perl5db.pl
@@ -14,6 +14,8 @@ you invoke a script with C<perl -d>. This documentation tries to outline the
 structure and services provided by C<perl5db.pl>, and to describe how you
 can use them.
 
+See L<perldebug> for an overview of how to use the debugger.
+
 =head1 GENERAL NOTES
 
 The debugger can look pretty forbidding to many Perl programmers. There are
@@ -529,7 +531,7 @@ BEGIN {
 use vars qw($VERSION $header);
 
 # bump to X.XX in blead, only use X.XX_XX in maint
-$VERSION = '1.58';
+$VERSION = '1.59';
 
 $header = "perl5db.pl version $VERSION";
 

--- a/pod/perldebguts.pod
+++ b/pod/perldebguts.pod
@@ -1089,8 +1089,9 @@ never touched.
 =head1 SEE ALSO
 
 L<perldebug>,
+L<perl5db.pl>,
 L<perlguts>,
-L<perlrun>
+L<perlrun>,
 L<re>,
 and
 L<Devel::DProf>.

--- a/pod/perldebtut.pod
+++ b/pod/perldebtut.pod
@@ -715,6 +715,7 @@ place to go), and of course, experiment.
 
 L<perldebug>, 
 L<perldebguts>, 
+L<perl5db.pl>,
 L<perldiag>,
 L<perlrun>
 

--- a/pod/perldebug.pod
+++ b/pod/perldebug.pod
@@ -14,6 +14,9 @@ L<perldebtut>, which is a tutorial introduction to the debugger.
 If you're looking for the nitty gritty details of how the debugger is
 I<implemented>, you may prefer to read L<perldebguts>.
 
+For in-depth technical usage details, see L<perl5db.pl>, the documentation
+of the debugger itself.
+
 =head1 The Perl Debugger
 
 If you invoke Perl with the B<-d> switch, your script runs under the
@@ -1206,6 +1209,7 @@ You do have C<use strict> and C<use warnings> enabled, don't you?
 
 L<perldebtut>,
 L<perldebguts>,
+L<perl5db.pl>,
 L<re>,
 L<DB>,
 L<Devel::NYTProf>,


### PR DESCRIPTION
perl5db.pl is an odd case as it's a .pl script that gets installed into lib, but it contains extensive documentation which is not currently linked from anywhere useful. `L<perl5db.pl>` appears to work on metacpan and perldoc.pl. Added a bidirectional reference to the beginning of perldebug and perl5db.pl, and added perl5db.pl to the SEE ALSO for perldebug/perldebguts/perldebtut.