### PR TITLE
Missing braces in sv_inc_nomg()

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -8959,9 +8959,10 @@ Perl_sv_inc_nomg(pTHX_ SV *const sv)
 	if (SvIsUV(sv)) {
 	    if (SvUVX(sv) == UV_MAX)
 		sv_setnv(sv, UV_MAX_P1);
-	    else
+            else {
 		(void)SvIOK_only_UV(sv);
 		SvUV_set(sv, SvUVX(sv) + 1);
+            }
 	} else {
 	    if (SvIVX(sv) == IV_MAX)
 		sv_setuv(sv, (UV)IV_MAX + 1);

--- a/t/op/inc.t
+++ b/t/op/inc.t
@@ -385,4 +385,22 @@ is $store::called, 4, 'STORE called on "my" target';
     like $@, qr/Modification of a read-only value/, 'use int; *GLOB126637--';
 }
 
+# Exercises sv_inc() incrementing UV to UV, UV to NV
+SKIP: {
+    $a = ~1; # assumed to be UV_MAX - 1
+
+    if ($Config{uvsize} eq '4') {
+        cmp_ok(++$a, '==', 4294967295, "preincrement to UV_MAX");
+        cmp_ok(++$a, '==', 4294967296, "preincrement past UV_MAX");
+    }
+    elsif ($Config{uvsize} eq '8') {
+        cmp_ok(++$a, '==', 18446744073709551615, "preincrement to UV_MAX");
+        # assumed that NV can hold 2 ** 64 without rounding.
+        cmp_ok(++$a, '==', 18446744073709551616, "preincrement past UV_MAX");
+    }
+    else {
+        skip "the uvsize $Config{uvsize} is neither 4 nor 8", 2;
+    }
+} # SKIP
+
 done_testing();


### PR DESCRIPTION
I found an ambiguous indentation in `Perl_sv_inc_nomg()` at sv.c, and guessed that braces were forgotten here.  (Doing `SvUV_set` on PVNV seems to be harmless, so that this had not caused a real problem for a long time, I think.)
I also added some tests to exercise this `if` statement.