### PR TITLE
don't check for Windows NT in tests

### DIFF
--- a/t/io/fs.t
+++ b/t/io/fs.t
@@ -42,14 +42,12 @@ my $accurate_timestamps =
 	  $wd =~ m#$Config{afsroot}/#
      );
 
-if (defined &Win32::IsWinNT && Win32::IsWinNT()) {
-    if (Win32::FsType() eq 'NTFS') {
-        $has_link            = 1;
-        $accurate_timestamps = 1;
-    }
-    else {
-        $has_link            = 0;
-    }
+if ($^O eq 'MSWin32' && Win32::FsType() eq 'NTFS') {
+    $has_link            = 1;
+    $accurate_timestamps = 1;
+}
+else {
+    $has_link            = 0;
 }
 
 my $needs_fh_reopen =

--- a/t/op/stat.t
+++ b/t/op/stat.t
@@ -105,11 +105,9 @@ sleep 2;
 
 my $has_link = 1;
 my $inaccurate_atime = 0;
-if (defined &Win32::IsWinNT && Win32::IsWinNT()) {
-    if (Win32::FsType() ne 'NTFS') {
-        $has_link            = 0;
-	$inaccurate_atime    = 1;
-    }
+if ($Is_MSWin32 && Win32::FsType() ne 'NTFS') {
+    $has_link            = 0;
+    $inaccurate_atime    = 1;
 }
 
 SKIP: {


### PR DESCRIPTION
We dropped support for Win9x a long time ago.