### PR TITLE
remove deprecated GitHub Actions Command and some improvements

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -352,7 +352,8 @@ jobs:
           echo @"
           C:\strawberry\c\bin
           C:\strawberry\perl\site\bin
-          C:\strawberry\perl\bin" |
+          C:\strawberry\perl\bin
+          "@ |
             Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Host perl -V
         run: perl -V

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -349,7 +349,10 @@ jobs:
           if (!(Test-Path "C:\strawberry\perl\bin")) {
             choco install strawberryperl
           }
-          echo "C:\strawberry\c\bin`nC:\strawberry\perl\site\bin`nC:\strawberry\perl\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo @"C:\strawberry\c\bin
+          C:\strawberry\perl\site\bin
+          C:\strawberry\perl\bin" |
+            Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Host perl -V
         run: perl -V
       - name: gcc --version
@@ -395,7 +398,8 @@ jobs:
         shell: cmd
         run: |
           path %GITHUB_WORKSPACE%\cygwin\bin;%GITHUB_WORKSPACE%\cygwin\usr\bin
-          sh -c "mkdir -p ~; cd ~; echo \"$GITHUB_REPOSITORY\"; git config --global core.autocrlf false; git clone -qn \"https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY\" work ; cd work ; if [ \"$GITHUB_EVENT_NAME\" = pull_request ] ; then git fetch origin \"$GITHUB_REF\" && git checkout FETCH_HEAD ; else  git checkout \"$GITHUB_SHA\" ; fi"
+          sh -c "git config --global core.autocrlf false"
+          sh -c "mkdir -p ~; cd ~; git clone -qn \"https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY\" work ; cd work ; if [ \"$GITHUB_EVENT_NAME\" = pull_request ] ; then git fetch origin \"$GITHUB_REF\" && git checkout FETCH_HEAD ; else  git checkout \"$GITHUB_SHA\" ; fi"
       - name: Configure
         shell: cmd
         run: |

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -31,7 +31,6 @@ jobs:
         run: |
           echo "Pull request authors"
           echo "# git merge-base origin/${BASE_REF} HEAD"
-          git remote set-url origin "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
           git config diff.renameLimit 999999
           git fetch --depth=1000 origin ${BASE_REF}
         env:
@@ -177,9 +176,9 @@ jobs:
         run: |
           apt-get update ||:
           apt-get -y install build-essential git-core
+
+      # actions/checkout@v2 doesn't work in a container, so we use v1.
       - uses: actions/checkout@v1
-        with:
-          fetch-depth: 0
       - name: fix git remote credential
         run: git remote set-url origin "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
       - name: git cfg + fetch tags
@@ -213,7 +212,7 @@ jobs:
       CONTINUOUS_INTEGRATION: 1
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 10
       - name: Configure
@@ -245,7 +244,7 @@ jobs:
 
     steps:
       - run: git config --global core.autocrlf false
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 10
       #- name: Install clcache
@@ -297,7 +296,7 @@ jobs:
 
     steps:
       - run: git config --global core.autocrlf false
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 10
       - name: Set up MSVC100
@@ -335,7 +334,7 @@ jobs:
 
     steps:
       - run: git config --global core.autocrlf false
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 10
       - name: Set up Perl build environment

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -349,7 +349,8 @@ jobs:
           if (!(Test-Path "C:\strawberry\perl\bin")) {
             choco install strawberryperl
           }
-          echo @"C:\strawberry\c\bin
+          echo @"
+          C:\strawberry\c\bin
           C:\strawberry\perl\site\bin
           C:\strawberry\perl\bin" |
             Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -299,8 +299,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 10
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ${{ github.workspace }}\choco-cache
+          key: v2-msvc100
       - name: Set up MSVC100
         run: |
+          choco config set cacheLocation "${{ github.workspace }}\choco-cache"
           choco install vcexpress2010
       - name: Help
         shell: cmd

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -340,8 +340,11 @@ jobs:
           fetch-depth: 10
       - name: Set up Perl build environment
         run: |
-          choco install strawberryperl
-          echo "##[add-path]C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin"
+          # skip installing perl if it is already installed.
+          if (!(Test-Path "C:\strawberry\perl\bin")) {
+            choco install strawberryperl
+          }
+          echo "C:\strawberry\c\bin`nC:\strawberry\perl\site\bin`nC:\strawberry\perl\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Host perl -V
         run: perl -V
       - name: gcc --version

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -381,7 +381,8 @@ jobs:
       CONTINUOUS_INTEGRATION: 1
 
     steps:
-      - run: git config --global core.autocrlf false
+      # we use Cygwin git, so no need to configure git here.
+
       - name: Set up Cygwin
         shell: cmd
         run: |
@@ -394,7 +395,7 @@ jobs:
         shell: cmd
         run: |
           path %GITHUB_WORKSPACE%\cygwin\bin;%GITHUB_WORKSPACE%\cygwin\usr\bin
-          sh -c "mkdir -p ~; cd ~; echo \"$GITHUB_REPOSITORY\"; git clone -qn \"https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY\" work ; cd work ; if [ \"$GITHUB_EVENT_NAME\" = pull_request ] ; then git fetch origin \"$GITHUB_REF\" && git checkout FETCH_HEAD ; else  git checkout \"$GITHUB_SHA\" ; fi"
+          sh -c "mkdir -p ~; cd ~; echo \"$GITHUB_REPOSITORY\"; git config --global core.autocrlf false; git clone -qn \"https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY\" work ; cd work ; if [ \"$GITHUB_EVENT_NAME\" = pull_request ] ; then git fetch origin \"$GITHUB_REF\" && git checkout FETCH_HEAD ; else  git checkout \"$GITHUB_SHA\" ; fi"
       - name: Configure
         shell: cmd
         run: |


### PR DESCRIPTION
This pull request fixes the following warning message.

> https://github.com/Perl/perl5/actions/runs/296812857
>
> The `add-path` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

And replace `actions/checkout@master` into `actions/checkout@v2`.
Because GitHub recommends use tag names rather than branch names.