### PR TITLE
Smoke me/jkeenan/version warnings 20201010

### DIFF
--- a/cpan/version/t/09_list_util.t
+++ b/cpan/version/t/09_list_util.t
@@ -4,8 +4,8 @@
 #########################
 
 use strict;
-use_ok("version", 0.9928);
 use Test::More;
+use_ok("version", 0.9928);
 
 BEGIN {
     eval "use List::Util qw(reduce)";

--- a/cpan/version/t/10_lyon.t
+++ b/cpan/version/t/10_lyon.t
@@ -24,13 +24,19 @@ if ($] >= 5.008_001) {
 cmp_ok('version'->new('1.0203')->numify, '==', '1.0203');
 is('version'->new('1.0203')->normal, 'v1.20.300');
 
-cmp_ok('version'->new('1.02_03')->numify, '==', '1.0203');
-is('version'->new('1.02_03')->normal, 'v1.20.300');
+{
+    no warnings 'numeric';
+    cmp_ok('version'->new('1.02_03')->numify, '==', '1.0203');
+    is('version'->new('1.02_03')->normal, 'v1.20.300');
+}
 
 cmp_ok('version'->new('v1.2.30')->numify, '==', '1.002030');
 is('version'->new('v1.2.30')->normal, 'v1.2.30');
-cmp_ok('version'->new('v1.2.3_0')->numify, '==', '1.002030');
-is('version'->new('v1.2.3_0')->normal, 'v1.2.30');
+{
+    no warnings 'numeric';
+    cmp_ok('version'->new('v1.2.3_0')->numify, '==', '1.002030');
+    is('version'->new('v1.2.3_0')->normal, 'v1.2.30');
+}
 
 is('version'->new("1.0203")->stringify, "1.0203");
 is('version'->new("1.02_03")->stringify, "1.02_03");


### PR DESCRIPTION
https://metacpan.org/source/LEONT/version-0.9928/META.json indicates that the bugtracker for this distribution is rt.cpan.org -- but the repository is blead.  I'll try my luck here first.

If the tests for this distribution are run with warnings enabled, two files generate warnings.  Patches correct this.

Thank you very much.
Jim Keenan