### PR TITLE
perl5db.pl - remove redundant share()

### DIFF
--- a/lib/perl5db.pl
+++ b/lib/perl5db.pl
@@ -1091,7 +1091,6 @@ share($signalLevel);
 share($pre);
 share($post);
 share($pretype);
-share($rl);
 share($CreateTTY);
 share($CommandSet);
 


### PR DESCRIPTION
As pointed out in #18214, the second instance seems unnecessary.

(Caveat: I am unfamiliar with the debugger internals.)