### PR TITLE
pp_split: no SWITCHSTACK in @ary = split(...) optimisation

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -6389,13 +6389,13 @@ PP(pp_split)
 		mg_set(MUTABLE_SV(ary));
 		SPAGAIN;
             }
+
             if (gimme != G_ARRAY) {
                 /* SP points to the final SV* pushed to the stack. But the SV*  */
                 /* are not going to be used from the stack. Point SP to below   */
                 /* the first of these SV*.                                      */
-                SP = SP + 1 - iters;
+                SP -= iters;
                 PUTBACK;
-                PUSHMARK(SP);
             }
 	}
 	else {
@@ -6418,12 +6418,10 @@ PP(pp_split)
 		}
 		RETURN;
 	    }
-	    PUSHMARK(SP);
 	}
     }
 
     if (gimme != G_ARRAY) {
-
         GETTARGET;
         XPUSHi(iters);
      }

--- a/pp.c
+++ b/pp.c
@@ -6395,6 +6395,7 @@ PP(pp_split)
                 /* the first of these SV*.                                      */
                 SP = SP + 1 - iters;
                 PUTBACK;
+                PUSHMARK(SP);
             }
 	}
 	else {
@@ -6417,11 +6418,12 @@ PP(pp_split)
 		}
 		RETURN;
 	    }
+	    PUSHMARK(SP);
 	}
     }
 
     if (gimme != G_ARRAY) {
-        PUSHMARK(SP);
+
         GETTARGET;
         XPUSHi(iters);
      }

--- a/pp.c
+++ b/pp.c
@@ -6034,6 +6034,9 @@ PP(pp_split)
             oldsave = PL_savestack_ix;
         }
 
+	/* Some defence against stack-not-refcounted bugs */
+	(void)sv_2mortal(SvREFCNT_inc_simple_NN(ary));
+
 	if ((mg = SvTIED_mg((const SV *)ary, PERL_MAGIC_tied))) {
 	    PUSHMARK(SP);
 	    XPUSHs(SvTIED_obj(MUTABLE_SV(ary), mg));
@@ -6356,7 +6359,7 @@ PP(pp_split)
     }
 
     PUTBACK;
-    LEAVE_SCOPE(oldsave); /* may undo an earlier SWITCHSTACK */
+    LEAVE_SCOPE(oldsave);
     SPAGAIN;
     if (realarray) {
         if (!mg) {

--- a/t/op/split.t
+++ b/t/op/split.t
@@ -7,7 +7,7 @@ BEGIN {
     require './charset_tools.pl';
 }
 
-plan tests => 191;
+plan tests => 192;
 
 $FS = ':';
 
@@ -661,6 +661,13 @@ is "@a", '1 2 3', 'assignment to split-to-array (stacked)';
     chop $s;
     my @a = split ' ', $s;
     is (+@a, 0, "empty utf8 string");
+}
+
+# correct use of PUSHMARKs (gh#18232)
+{
+    sub foo { return @_ }
+    my @a = foo(1, scalar split " ", "a b");
+    is(join('', @a), "12", "No PUSHMARK when splitting to a sub parameter");
 }
 
 fresh_perl_is(<<'CODE', '', {}, "scalar split stack overflow");

--- a/t/op/split.t
+++ b/t/op/split.t
@@ -7,7 +7,7 @@ BEGIN {
     require './charset_tools.pl';
 }
 
-plan tests => 189;
+plan tests => 191;
 
 $FS = ':';
 
@@ -690,3 +690,8 @@ fresh_perl_is('my @ary; @ary = split(/\w(?{ @ary[1000] = 1 })/, "abc");',
 fresh_perl_is('my @ary; @ary = split(/\w(?{ undef @ary })/, "abc");',
         '',{},'(@ary = split ...) survives an (undef @ary)');
 
+# check the (@ary = split) optimisation survives stack-not-refcounted bugs
+fresh_perl_is('our @ary; @ary = split(/\w(?{ *ary = 0 })/, "abc");',
+        '',{},'(@ary = split ...) survives @ary destruction via typeglob');
+fresh_perl_is('my $ary = []; @$ary = split(/\w(?{ $ary = [] })/, "abc");',
+        '',{},'(@ary = split ...) survives @ary destruction via reassignment');

--- a/t/op/split.t
+++ b/t/op/split.t
@@ -7,7 +7,7 @@ BEGIN {
     require './charset_tools.pl';
 }
 
-plan tests => 192;
+plan tests => 193;
 
 $FS = ':';
 
@@ -663,11 +663,17 @@ is "@a", '1 2 3', 'assignment to split-to-array (stacked)';
     is (+@a, 0, "empty utf8 string");
 }
 
-# correct use of PUSHMARKs (gh#18232)
+# correct stack adjustments (gh#18232)
 {
     sub foo { return @_ }
     my @a = foo(1, scalar split " ", "a b");
-    is(join('', @a), "12", "No PUSHMARK when splitting to a sub parameter");
+    is(join('', @a), "12", "Scalar split to a sub parameter");
+}
+
+{
+    sub foo { return @_ }
+    my @a = foo(1, scalar(@x = split " ", "a b"));
+    is(join('', @a), "12", "Split to @x then use scalar result as a sub parameter");
 }
 
 fresh_perl_is(<<'CODE', '', {}, "scalar split stack overflow");

--- a/t/op/split.t
+++ b/t/op/split.t
@@ -7,7 +7,7 @@ BEGIN {
     require './charset_tools.pl';
 }
 
-plan tests => 187;
+plan tests => 189;
 
 $FS = ':';
 
@@ -682,3 +682,11 @@ CODE
         ok(eq_array(\@result,['a','b']), "Resulting in ('a','b')");
     }
 }
+
+# check that the (@ary = split) optimisation survives @ary being modified
+
+fresh_perl_is('my @ary; @ary = split(/\w(?{ @ary[1000] = 1 })/, "abc");',
+        '',{},'(@ary = split ...) survives @ary being Renew()ed');
+fresh_perl_is('my @ary; @ary = split(/\w(?{ undef @ary })/, "abc");',
+        '',{},'(@ary = split ...) survives an (undef @ary)');
+


### PR DESCRIPTION
The `@ary = split(...)` optimisation uses **SWITCHSTACK** to make `@ary`
 masquerade as the value stack. However, code that is not aware of this
could modify `@ary` during the split and cause perl to segfault/panic.
(e.g. see added tests)

This commit essentially removes that SWITCHSTACK and then reverses
some operations (e.g. Copy stack<->array) towards the end of the function.
There is also some refactoring to consolidate all changes to `@ary` at the
end of the function, rather than having some at the beginning (previously
essential) and some at the end.

No user-visible changes - besides perl not crashing in the tests - are 
intended. However, there is the unavoidable side effect that a large split 
will now permanently grow the stack when that might previously not have
happened.

Note: this PR is standalone but comes from the discussion in #18014. 
Use of a temporary AV was previously suggested (#18090) but rejected as
adding too much complexity to an already complex OP. Should a temp 
AV be needed in the future, #18090 could probably be improved upon 
by some of the refactoring in this commit.

**Basic Performance Measurements**
* A small split was about 10% faster:
`$str = "perl"; my @ary; for (1 .. 1_000_000) { @ary = split(//, $str); }`
* A mid-sized split was about 5% slower:
`$str = "perl" x 1000; for (1 .. 1_000) { my @ary = split(//, $str); }`
* No meaningful difference for splits where the resulting SVs have to be 
on both `@ary` and the stack. e.g.
`for ( @ary = split(//, $str) ){ }`
(There should be no performance difference other than noise for any 
gimme_scalar split that does not generate SVs.)

On x64 Linux with gcc, there was no size difference in the perl binary, 
although disassembly suggests that _pp_split_ itself has fewer instructions.