### PR TITLE
Fix enough code to get make test_prep working with -Dusedefaultstrict

### DIFF
--- a/dist/if/if.pm
+++ b/dist/if/if.pm
@@ -1,6 +1,6 @@
 package if;
-
-$VERSION = '0.0608';
+use strict;
+our $VERSION = '0.0609';
 
 sub work {
   my $method = shift() ? 'import' : 'unimport';

--- a/lib/Getopt/Std.pm
+++ b/lib/Getopt/Std.pm
@@ -1,5 +1,8 @@
 package Getopt::Std;
-require 5.000;
+
+use strict;
+use warnings;
+
 require Exporter;
 
 =head1 NAME
@@ -79,9 +82,9 @@ and version_mess() with the switches string as an argument.
 
 =cut
 
-@ISA = qw(Exporter);
-@EXPORT = qw(getopt getopts);
-$VERSION = '1.12';
+our @ISA = qw(Exporter);
+our @EXPORT = qw(getopt getopts);
+our $VERSION = '1.13';
 # uncomment the next line to disable 1.03-backward compatibility paranoia
 # $STANDARD_HELP_VERSION = 1;
 
@@ -119,6 +122,7 @@ sub getopt (;$$) {
 	        $$hash{$first} = $rest;
 	    }
 	    else {
+            no strict 'refs';
 	        ${"opt_$first"} = $rest;
 	        push( @EXPORT, "\$opt_$first" );
 	    }
@@ -128,6 +132,7 @@ sub getopt (;$$) {
 	        $$hash{$first} = 1;
 	    }
 	    else {
+            no strict 'refs';
 	        ${"opt_$first"} = 1;
 	        push( @EXPORT, "\$opt_$first" );
 	    }
@@ -145,6 +150,7 @@ sub getopt (;$$) {
     }
 }
 
+our ($OUTPUT_HELP_VERSION, $STANDARD_HELP_VERSION);
 sub output_h () {
   return $OUTPUT_HELP_VERSION if defined $OUTPUT_HELP_VERSION;
   return \*STDOUT if $STANDARD_HELP_VERSION;
@@ -251,6 +257,7 @@ sub getopts ($;$) {
 		    $$hash{$first} = $rest;
 		}
 		else {
+            no strict 'refs';
 		    ${"opt_$first"} = $rest;
 		    push( @EXPORT, "\$opt_$first" );
 		}
@@ -260,6 +267,7 @@ sub getopts ($;$) {
 		    $$hash{$first} = 1;
 		}
 		else {
+            no strict 'refs';
 		    ${"opt_$first"} = 1;
 		    push( @EXPORT, "\$opt_$first" );
 		}

--- a/lib/Getopt/Std.t
+++ b/lib/Getopt/Std.t
@@ -6,6 +6,8 @@ BEGIN {
 }
 
 use strict;
+use warnings;
+
 use Test::More tests => 22;
 use Getopt::Std;
 

--- a/lib/Symbol.pm
+++ b/lib/Symbol.pm
@@ -1,5 +1,8 @@
 package Symbol;
 
+use strict;
+use warnings;
+
 =head1 NAME
 
 Symbol - manipulate Perl symbols and their names
@@ -78,14 +81,12 @@ you reload the C<Foo> module afterwards.
 
 =cut
 
-BEGIN { require 5.005; }
-
 require Exporter;
-@ISA = qw(Exporter);
-@EXPORT = qw(gensym ungensym qualify qualify_to_ref);
-@EXPORT_OK = qw(delete_package geniosym);
+our @ISA = qw(Exporter);
+our @EXPORT = qw(gensym ungensym qualify qualify_to_ref);
+our @EXPORT_OK = qw(delete_package geniosym);
 
-$VERSION = '1.08';
+our $VERSION = '1.09';
 
 my $genpkg = "Symbol::";
 my $genseq = 0;
@@ -99,6 +100,7 @@ my %global = map {$_ => 1} qw(ARGV ARGVOUT ENV INC SIG STDERR STDIN STDOUT);
 #
 sub gensym () {
     my $name = "GEN" . $genseq++;
+    no strict 'refs';
     my $ref = \*{$genpkg . $name};
     delete $$genpkg{$name};
     $ref;
@@ -132,6 +134,7 @@ sub qualify ($;$) {
 }
 
 sub qualify_to_ref ($;$) {
+    no strict 'refs';
     return \*{ qualify $_[0], @_ > 1 ? $_[1] : caller };
 }
 
@@ -150,6 +153,7 @@ sub delete_package ($) {
     }
 
     my($stem, $leaf) = $pkg =~ m/(.*::)(\w+::)$/;
+    no strict 'refs';
     my $stem_symtab = *{$stem}{HASH};
     return unless defined $stem_symtab and exists $stem_symtab->{$leaf};
 
@@ -160,6 +164,7 @@ sub delete_package ($) {
     foreach my $name (keys %$leaf_symtab) {
         undef *{$pkg . $name};
     }
+    use strict 'refs';
 
     # delete the symbol table
 

--- a/lib/Symbol.t
+++ b/lib/Symbol.t
@@ -1,5 +1,8 @@
 #!./perl
 
+use strict;
+use warnings;
+
 BEGIN {
     chdir 't' if -d 't';
     @INC = '../lib';
@@ -87,6 +90,7 @@ use Symbol qw(qualify qualify_to_ref);  # must import into this package too
 
 # tests for delete_package
 package main;
+no warnings 'once';
 $Transient::variable = 42;
 ok( exists $::{'Transient::'}, 'transient stash exists' );
 ok( defined $Transient::{variable}, 'transient variable in stash' );

--- a/lib/bytes.pm
+++ b/lib/bytes.pm
@@ -1,6 +1,9 @@
 package bytes;
 
-our $VERSION = '1.07';
+use strict;
+use warnings;
+
+our $VERSION = '1.08';
 
 $bytes::hint_bits = 0x00000008;
 
@@ -12,6 +15,7 @@ sub unimport {
     $^H &= ~$bytes::hint_bits;
 }
 
+our $AUTOLOAD;
 sub AUTOLOAD {
     require "bytes_heavy.pl";
     goto &$AUTOLOAD if defined &$AUTOLOAD;

--- a/lib/bytes.t
+++ b/lib/bytes.t
@@ -1,3 +1,7 @@
+#!perl
+
+use strict;
+use warnings;
 
 BEGIN {
     chdir 't' if -d 't';
@@ -14,8 +18,11 @@ is(length($a), 1,  "length sanity check");
 is(substr($a, 0, 1), "\x{100}",  "substr sanity check");
 is(index($a, "\x{100}"),  0, "index sanity check");
 is(rindex($a, "\x{100}"), 0, "rindex sanity check");
-is(bytes::length($a), 2,  "bytes::length sanity check");
-is(bytes::chr(0x100), chr(0),  "bytes::chr sanity check");
+{
+    no warnings 'prototype'; # bytes::length() called too early to check prototype at...
+    is(bytes::length($a), 2,  "bytes::length sanity check");
+    is(bytes::chr(0x100), chr(0),  "bytes::chr sanity check");
+}
 
 {
     use bytes;

--- a/lib/locale.pm
+++ b/lib/locale.pm
@@ -1,6 +1,9 @@
 package locale;
 
-our $VERSION = '1.09';
+use strict;
+use warnings;
+
+our $VERSION = '1.10';
 use Config;
 
 $Carp::Internal{ (__PACKAGE__) } = 1;
@@ -70,7 +73,7 @@ sub import {
                               :numeric :monetary :time) );
         for (my $i = 0; $i < @_; $i++) {
             my $arg = $_[$i];
-            $complement = $arg =~ s/ : ( ! | not_ ) /:/x;
+            my $complement = $arg =~ s/ : ( ! | not_ ) /:/x;
             if (! grep { $arg eq $_ } @categories, ":characters") {
                 require Carp;
                 Carp::croak("Unknown parameter '$_[$i]' to 'use locale'");

--- a/lib/locale.t
+++ b/lib/locale.t
@@ -1,5 +1,8 @@
 #!./perl -wT
 
+use strict;
+use warnings;
+
 # This tests plain 'use locale' and adorned 'use locale ":not_characters"'
 # Because these pragmas are compile time, and I (khw) am trying to test
 # without using 'eval' as much as possible, which might cloud the issue,  the
@@ -50,7 +53,6 @@ BEGIN {
     require Config; import Config;
 }
 
-use strict;
 use feature 'fc';
 
 # =1 adds debugging output; =2 increases the verbosity somewhat

--- a/lib/overload.pm
+++ b/lib/overload.pm
@@ -1,8 +1,11 @@
 package overload;
 
-our $VERSION = '1.32';
+use strict;
+no strict 'refs';
 
-%ops = (
+our $VERSION = '1.33';
+
+our %ops = (
     with_assign         => "+ - * / % ** << >> x .",
     assign              => "+= -= *= /= %= **= <<= >>= x= .=",
     num_comparison      => "< <= >  >= == !=",
@@ -26,7 +29,7 @@ my %ops_seen;
 sub nil {}
 
 sub OVERLOAD {
-  $package = shift;
+  my $package = shift;
   my %arg = @_;
   my $sub;
   *{$package . "::(("} = \&nil; # Make it findable via fetchmethod.
@@ -51,14 +54,14 @@ sub OVERLOAD {
 }
 
 sub import {
-  $package = (caller())[0];
+  my $package = (caller())[0];
   # *{$package . "::OVERLOAD"} = \&OVERLOAD;
   shift;
   $package->overload::OVERLOAD(@_);
 }
 
 sub unimport {
-  $package = (caller())[0];
+  my $package = (caller())[0];
   shift;
   *{$package . "::(("} = \&nil;
   for (@_) {
@@ -131,7 +134,7 @@ sub mycan {				# Real can would leave stubs.
   return undef;
 }
 
-%constants = (
+my %constants = (
 	      'integer'	  =>  0x1000, # HINT_NEW_INTEGER
 	      'float'	  =>  0x2000, # HINT_NEW_FLOAT
 	      'binary'	  =>  0x4000, # HINT_NEW_BINARY

--- a/lib/subs.pm
+++ b/lib/subs.pm
@@ -1,6 +1,9 @@
 package subs;
 
-our $VERSION = '1.03';
+use strict;
+use warnings;
+
+our $VERSION = '1.04';
 
 =head1 NAME
 
@@ -27,14 +30,13 @@ See L<perlmodlib/Pragmatic Modules> and L<strict/strict subs>.
 
 =cut
 
-require 5.000;
-
 sub import {
     my $callpack = caller;
     my $pack = shift;
     my @imports = @_;
     foreach my $sym (@imports) {
-	*{"${callpack}::$sym"} = \&{"${callpack}::$sym"};
+        no strict 'refs';
+        *{"${callpack}::$sym"} = \&{"${callpack}::$sym"};
     }
 };
 

--- a/lib/utf8.pm
+++ b/lib/utf8.pm
@@ -1,15 +1,19 @@
 package utf8;
 
-$utf8::hint_bits = 0x00800000;
+use strict;
+use warnings;
 
-our $VERSION = '1.23';
+our $hint_bits = 0x00800000;
+
+our $VERSION = '1.24';
+our $AUTOLOAD;
 
 sub import {
-    $^H |= $utf8::hint_bits;
+    $^H |= $hint_bits;
 }
 
 sub unimport {
-    $^H &= ~$utf8::hint_bits;
+    $^H &= ~$hint_bits;
 }
 
 sub AUTOLOAD {


### PR DESCRIPTION
This change fixes enough code that it's possible to run make test_prep when perl is compiled with -Dusedefaultstrict.

There are 2 caveats to this:

 - Does not address XSLoader/DynaLoader already submitted in another PR (#18221)
 - Does not address cpan/Pod-Usage or  cpan/Text-Tabs which continue to be outstanding upstream.