### PR TITLE
perlsub - Link to constant pragma

### DIFF
--- a/pod/perlsub.pod
+++ b/pod/perlsub.pod
@@ -1652,7 +1652,7 @@ inlining.  If the result after optimization and constant folding
 is either a constant or a lexically-scoped scalar which has no other
 references, then it will be used in place of function calls made
 without C<&>.  Calls made using C<&> are never inlined.  (See
-F<constant.pm> for an easy way to declare most constants.)
+L<constant> for an easy way to declare most constants.)
 
 The following functions would all be inlined:
 


### PR DESCRIPTION
The `constant` pragma is alluded to here but should be linked to directly.