### PR TITLE
Remove EOL Windows Versions From Supported List.

### DIFF
--- a/pod/perlport.pod
+++ b/pod/perlport.pod
@@ -2251,17 +2251,15 @@ at L<http://www.cpan.org/src>
 
 =over
 
-=item Windows 2000
-
-=item Windows XP
-
-=item Windows Server 2003
-
-=item Windows Vista
-
-=item Windows Server 2008
+=item Windows Server 2008/R2
 
 =item Windows 7
+
+=item Windows Server 2012
+
+=item Windows 8
+
+=item Windows 10
 
 =back
 
@@ -2372,6 +2370,14 @@ have worked in 5.12, but supporting code has been removed for 5.14:
 =item Windows ME
 
 =item Windows NT4
+
+=item Windows 2000
+
+=item Windows XP
+
+=item Windows Server 2003
+
+=item Windows Vista
 
 =back
 

--- a/pod/perlport.pod
+++ b/pod/perlport.pod
@@ -2344,6 +2344,24 @@ ensure you have that library installed when building perl.
 
 =head1 EOL Platforms
 
+=head2 (Perl 5.34)
+
+The following platforms were supported by a previous version of
+Perl but have been officially removed from Perl's source code
+as of 5.34:
+
+=over
+
+=item Windows 2000
+
+=item Windows XP
+
+=item Windows Server 2003
+
+=item Windows Vista
+
+=back
+
 =head2 (Perl 5.20)
 
 The following platforms were supported by a previous version of
@@ -2370,14 +2388,6 @@ have worked in 5.12, but supporting code has been removed for 5.14:
 =item Windows ME
 
 =item Windows NT4
-
-=item Windows 2000
-
-=item Windows XP
-
-=item Windows Server 2003
-
-=item Windows Vista
 
 =back
 


### PR DESCRIPTION
As discussed on the P5P mailing list here:
https://www.nntp.perl.org/group/perl.perl5.porters/2020/10/msg258453.html

This just removes the declaration that we support the very old versions of Windows that have long since been EOLed.

For reference, here's a short list of problems related to maintaining the EOLed Windows versions:
https://github.com/Perl/perl5/issues/4145
https://github.com/Perl/perl5/issues/6080
https://github.com/Perl/perl5/issues/7410
https://github.com/Perl/perl5/issues/8502
https://github.com/Perl/perl5/issues/9025
https://github.com/Perl/perl5/issues/12431
https://github.com/Perl/perl5/issues/14687

Note that this only removes the requirement that we must keep new versions of Perl fully functional on those old operating systems. It doesn't actually make them immediately non-functional.