### PR TITLE
perlbug - remove obsolete paragraph

### DIFF
--- a/utils/perlbug.PL
+++ b/utils/perlbug.PL
@@ -1316,9 +1316,6 @@ release of Perl, are likely to receive less attention from the
 volunteers who build and maintain Perl than reports about bugs in
 the current release.
 
-This tool isn't appropriate for reporting bugs in any version
-prior to Perl 5.0.
-
 =item Are you sure what you have is a bug?
 
 A significant number of the bug reports we get turn out to be


### PR DESCRIPTION
The concern about Perls older than 5.0 is not worth mentioning anymore.