### PR TITLE
perlintro - Use single hyphen in NAME section

### DIFF
--- a/pod/perlintro.pod
+++ b/pod/perlintro.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-perlintro -- a brief introduction and overview of Perl
+perlintro - a brief introduction and overview of Perl
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
According to the [man format](https://man7.org/linux/man-pages/man7/man.7.html#DESCRIPTION) which pod style follows, the page name should be followed by a single dash.