### PR TITLE
Octal constants with "0o" prefix

### DIFF
--- a/pod/perldata.pod
+++ b/pod/perldata.pod
@@ -444,6 +444,7 @@ integer formats:
  0xff                # hex
  0xdead_beef         # more hex
  0377                # octal (only numbers, begins with 0)
+ 0o12_345            # alternative octal (introduced in Perl 5.XXX)
  0b011011            # binary
  0x1.999ap-4         # hexadecimal floating point (the 'p' is required)
 

--- a/pod/perldata.pod
+++ b/pod/perldata.pod
@@ -444,7 +444,7 @@ integer formats:
  0xff                # hex
  0xdead_beef         # more hex
  0377                # octal (only numbers, begins with 0)
- 0o12_345            # alternative octal (introduced in Perl 5.XXX)
+ 0o12_345            # alternative octal (introduced in Perl 5.33.5)
  0b011011            # binary
  0x1.999ap-4         # hexadecimal floating point (the 'p' is required)
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -27,6 +27,15 @@ here, but most should go in the L</Performance Enhancements> section.
 
 [ List each enhancement as a =head2 entry ]
 
+=head2 New octal syntax C<0oI<ddddd>>
+
+It is now possible to specify octal literals with C<0o> prefixes,
+as in C<0o123_456>, parallel to the existing construct to specify
+hexadecimal literal C<0xI<ddddd>> and binary literal C<0bI<ddddd>>.
+Also, the builtin C<oct()> function now accepts this new syntax.
+
+See L<perldata/Scalar value constructors> and L<perlfunc/oct EXPR>.
+
 =head1 Security
 
 XXX Any security-related notices go here.  In particular, any security

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4432,7 +4432,10 @@ X<oct> X<octal> X<hex> X<hexadecimal> X<binary> X<bin>
 =for Pod::Functions convert a string to an octal number
 
 Interprets EXPR as an octal string and returns the corresponding
-value.  (If EXPR happens to start off with C<0x> or C<x>, interprets it as a
+value.  An octal string consists of octal digits and, as of Perl 5.XXX,
+an optional C<0o> or C<o> prefix.  Each octal digit may be preceded by
+a single underscore, which will be ignored.
+(If EXPR happens to start off with C<0x> or C<x>, interprets it as a
 hex string.  If EXPR starts off with C<0b> or C<b>, it is interpreted as a
 binary string.  Leading whitespace is ignored in all three cases.)
 The following will handle decimal, binary, octal, and hex in standard

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4432,7 +4432,7 @@ X<oct> X<octal> X<hex> X<hexadecimal> X<binary> X<bin>
 =for Pod::Functions convert a string to an octal number
 
 Interprets EXPR as an octal string and returns the corresponding
-value.  An octal string consists of octal digits and, as of Perl 5.XXX,
+value.  An octal string consists of octal digits and, as of Perl 5.33.5,
 an optional C<0o> or C<o> prefix.  Each octal digit may be preceded by
 a single underscore, which will be ignored.
 (If EXPR happens to start off with C<0x> or C<x>, interprets it as a

--- a/pp.c
+++ b/pp.c
@@ -3099,8 +3099,12 @@ PP(pp_oct)
         flags |= PERL_SCAN_DISALLOW_PREFIX;
         result_uv = grok_bin (tmps, &len, &flags, &result_nv);
     }
-    else
+    else {
+        if (isALPHA_FOLD_EQ(*tmps, 'o')) {
+            tmps++, len--;
+        }
         result_uv = grok_oct (tmps, &len, &flags, &result_nv);
+    }
 
     if (flags & PERL_SCAN_GREATER_THAN_UV_MAX) {
         SETn(result_nv);

--- a/t/base/num.t
+++ b/t/base/num.t
@@ -1,6 +1,6 @@
 #!./perl
 
-print "1..53\n";
+print "1..56\n";
 
 # First test whether the number stringification works okay.
 # (Testing with == would exercise the IV/NV part, not the PV.)
@@ -211,3 +211,14 @@ print $a eq "16702650"     ? "ok 52\n" : "not ok 52 # $a\n";
 
 $a = 0B1101; "$a";
 print $a eq "13"           ? "ok 53\n" : "not ok 53 # $a\n";
+
+# 0odddd octal constants
+
+$a = 0o100; "$a";
+print $a eq "64"       ? "ok 54\n" : "not ok 54 # $a\n";
+
+$a = 0o100; "$a";
+print $a + 1 == 0o101  ? "ok 55\n" : "not ok 55 #" . $a + 1 . "\n";
+
+$a = 0O1703; "$a";
+print $a eq "963"      ? "ok 56\n" : "not ok 56 # $a\n";

--- a/t/op/oct.t
+++ b/t/op/oct.t
@@ -1,12 +1,12 @@
 #!./perl
 
-# Tests 51 onwards are intentionally not all-warnings-clean
+# Tests 53 onwards are intentionally not all-warnings-clean
 
 chdir 't' if -d 't';
 require './test.pl';
 use strict;
 
-plan(tests => 77);
+plan(tests => 79);
 
 foreach(['0b1_0101', 0b101_01],
 	['0b10_101', 0_2_5],
@@ -55,6 +55,9 @@ foreach(['0b1_0101', 0b101_01],
 	["XCAFE", 0xCAFE],
 	["0B101001", 0b101001],
 	["B101001", 0b101001],
+        # Additional syntax for octals
+        ["0o7_654_321", 2054353],
+        ["O4567", 0o4_567],
        ) {
     my ($string, $value) = @$_;
     my $result = oct $string;

--- a/toke.c
+++ b/toke.c
@@ -11460,7 +11460,6 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 		"",
 		"037777777777",
 		"0xffffffff" };
-	    const char *base, *Base, *max;
 
 	    /* check for hex */
 	    if (isALPHA_FOLD_EQ(s[1], 'x')) {
@@ -11490,10 +11489,6 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 		WARN_ABOUT_UNDERSCORE();
 	       lastub = s++;
 	    }
-
-	    base = bases[shift];
-	    Base = Bases[shift];
-	    max  = new_octal ? "0o37777777777" : maxima[shift];
 
 	    /* read the rest of the number */
 	    for (;;) {
@@ -11558,7 +11553,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 			    n = (NV) u;
 			    Perl_ck_warner_d(aTHX_ packWARN(WARN_OVERFLOW),
 					     "Integer overflow in %s number",
-					     base);
+                                             bases[shift]);
 			} else
 			    u = x | b;		/* add the digit to the end */
 		    }
@@ -11772,7 +11767,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
                 if (*d) ++d; /* so the user sees the bad non-digit */
                 PL_bufptr = (char *)d; /* so yyerror reports the context */
                 yyerror(Perl_form(aTHX_ "No digits found for %s literal",
-                                  base));
+                                  bases[shift]));
                 PL_bufptr = oldbp;
             }
 
@@ -11780,7 +11775,8 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 		if (n > 4294967295.0)
 		    Perl_ck_warner(aTHX_ packWARN(WARN_PORTABLE),
 				   "%s number > %s non-portable",
-				   Base, max);
+                                   Bases[shift],
+                                   new_octal ? "0o37777777777" : maxima[shift]);
 		sv = newSVnv(n);
 	    }
 	    else {
@@ -11788,7 +11784,8 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 		if (u > 0xffffffff)
 		    Perl_ck_warner(aTHX_ packWARN(WARN_PORTABLE),
 				   "%s number > %s non-portable",
-				   Base, max);
+                                   Bases[shift],
+                                   new_octal ? "0o37777777777" : maxima[shift]);
 #endif
 		sv = newSVuv(u);
 	    }

--- a/toke.c
+++ b/toke.c
@@ -11422,6 +11422,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
     NV hexfp_mult = 1.0;
     UV high_non_zero = 0; /* highest digit */
     int non_zero_integer_digits = 0;
+    bool new_octal = FALSE;     /* octal with "0o" prefix */
 
     PERL_ARGS_ASSERT_SCAN_NUM;
 
@@ -11481,6 +11482,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
                 if (isALPHA_FOLD_EQ(*s, 'o')) {
                     s++;
                     just_zero = FALSE;
+                    new_octal = TRUE;
                 }
 	    }
 
@@ -11491,7 +11493,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 
 	    base = bases[shift];
 	    Base = Bases[shift];
-	    max  = maxima[shift];
+	    max  = new_octal ? "0o37777777777" : maxima[shift];
 
 	    /* read the rest of the number */
 	    for (;;) {
@@ -11818,6 +11820,11 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
                 s = start + 2;
                 break;
             case 3:
+                if (new_octal) {
+                    *d++ = 'o';
+                    s = start + 2;
+                    break;
+                }
                 s = start + 1;
                 break;
             case 1:


### PR DESCRIPTION
I suggest this pr to support octal constants through `0odddd` syntax, as described in Porting/todo.pod.

Modifications consist of two parts:
- octal literals in the script can be specified with `0o` prefix
- `oct()` will accept (simply skip) `0o` or `o` prefix.