### PR TITLE
t/loc_tools.pl: De-prototype to allow for array ref

### DIFF
--- a/ext/POSIX/t/posix.t
+++ b/ext/POSIX/t/posix.t
@@ -354,7 +354,7 @@ eval { use strict; POSIX->import("S_ISBLK"); my $x = S_ISBLK };
 unlike( $@, qr/Can't use string .* as a symbol ref/, "Can import autoloaded constants" );
 
 SKIP: {
-    skip("locales not available", 26) unless locales_enabled(qw(NUMERIC MONETARY));
+    skip("locales not available", 26) unless locales_enabled([qw(NUMERIC MONETARY)]);
     skip("localeconv() not available", 26) unless $Config{d_locconv};
     my $conv = localeconv;
     is(ref $conv, 'HASH', 'localeconv returns a hash reference');

--- a/t/loc_tools.pl
+++ b/t/loc_tools.pl
@@ -186,7 +186,7 @@ sub valid_locale_categories() {
     return @platform_categories;
 }
 
-sub locales_enabled(;$) {
+sub locales_enabled {
     # Returns 0 if no locale handling is available on this platform; otherwise
     # 1.
     #
@@ -245,8 +245,13 @@ sub locales_enabled(;$) {
         my @local_categories_copy;
 
         if (ref $categories_ref) {
-            @local_categories_copy = @$$categories_ref;
-            $return_categories_numbers = 1;
+            if (ref $categories_ref eq 'ARRAY') {
+                @local_categories_copy = @$categories_ref;
+            }
+            else {
+                @local_categories_copy = @$$categories_ref;
+                $return_categories_numbers = 1;
+            }
         }
         else {  # Single category passed in
             @local_categories_copy = $categories_ref;


### PR DESCRIPTION
Running ext/POSIX/t/posix.t with warnings enabled generated a
compile-time error, "Useless use of a constant ("NUMERIC") in void
context".  Analysis suggested it was a problem with t/loc_tools.pl
function locales_enabled(), which was prototyped to accept an optional
scalar reference but not an array reference.  Experimentation suggested
that the best way out of this problem was not to prototype the function.
Rather, account for the possibility that locales_enabled() would take an
array reference as well as existing cases of scalar and no argument at
all.

For : GH #18245