### PR TITLE
Fix unitialized warnings in S_pmtrans

### DIFF
--- a/op.c
+++ b/op.c
@@ -7021,7 +7021,7 @@ S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
     UV* t_array;
     SV* t_invlist;
     UV* r_map;
-    UV r_cp, t_cp;
+    UV r_cp = 0, t_cp = 0;
     UV t_cp_end = (UV) -1;
     UV r_cp_end;
     Size_t len;


### PR DESCRIPTION
noticed these errors while compiling
these warnings are coming from `S_pmtrans` and not from `Perl_pmruntime`
```
op.c: In function ‘Perl_pmruntime’:
op.c:7448:15: warning: ‘t_cp’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             j = _invlist_search(t_invlist, t_cp);
               ^
op.c:7024:14: note: ‘t_cp’ was declared here
     UV r_cp, t_cp;
              ^
op.c:7851:22: warning: ‘r_cp’ may be used uninitialized in this function [-Wmaybe-uninitialized]
                 r_cp += span;
                      ^
op.c:7024:8: note: ‘r_cp’ was declared here
     UV r_cp, t_cp;
        ^
op.c: In function ‘Perl_pmruntime’:
op.c:7448:15: warning: ‘t_cp’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             j = _invlist_search(t_invlist, t_cp);
               ^
op.c:7024:14: note: ‘t_cp’ was declared here
     UV r_cp, t_cp;
              ^
op.c:7851:22: warning: ‘r_cp’ may be used uninitialized in this function [-Wmaybe-uninitialized]
                 r_cp += span;
                      ^
op.c:7024:8: note: ‘r_cp’ was declared here
     UV r_cp, t_cp;
        ^
```