### PR TITLE
Fix wrong Config names in regression tests

### DIFF
--- a/t/op/hexfp.t
+++ b/t/op/hexfp.t
@@ -246,7 +246,7 @@ SKIP: {
     skip("non-80-bit-long-double", 4)
         unless ($Config{uselongdouble} &&
 		($Config{nvsize} == 16 || $Config{nvsize} == 12) &&
-		($Config{long_double_style_ieee_extended}));
+		($Config{d_long_double_style_ieee_extended}));
     is(0x1p-1074,  4.94065645841246544e-324);
     is(0x1p-1075,  2.47032822920623272e-324, '[perl #128919]');
     is(0x1p-1076,  1.23516411460311636e-324);

--- a/t/op/inc.t
+++ b/t/op/inc.t
@@ -188,10 +188,10 @@ cmp_ok($a, '==', 2147483647, "postdecrement properly downgrades from double");
 
 SKIP: {
     if ($Config{uselongdouble} &&
-        ($Config{long_double_style_ieee_doubledouble})) {
+        ($Config{d_long_double_style_ieee_doubledouble})) {
         skip "the double-double format is weird", 1;
     }
-    unless ($Config{double_style_ieee}) {
+    unless ($Config{d_double_style_ieee}) {
         skip "the doublekind $Config{doublekind} is not IEEE", 1;
     }
 

--- a/t/op/sprintf2.t
+++ b/t/op/sprintf2.t
@@ -701,7 +701,7 @@ SKIP: {
     skip("uselongdouble=" . ($Config{uselongdouble} ? 'define' : 'undef')
          . " longdblkind=$Config{longdblkind} os=$^O", 6)
         unless ($Config{uselongdouble} &&
-                ($Config{long_double_style_ieee_doubledouble})
+                ($Config{d_long_double_style_ieee_doubledouble})
                 # Gating on 'linux' (ppc) here is due to the differing
                 # double-double implementations: other (also big-endian)
                 # double-double platforms (e.g. AIX on ppc or IRIX on mips)
@@ -892,7 +892,7 @@ SKIP: {
     skip("non-80-bit-long-double", 17)
         unless ($Config{uselongdouble} &&
 		($Config{nvsize} == 16 || $Config{nvsize} == 12) &&
-		($Config{long_double_style_ieee_extended}));
+		($Config{d_long_double_style_ieee_extended}));
 
     {
         # The last normal for this format.


### PR DESCRIPTION
I've noticed that some tests in `t/op/inc.t` are skipped due to lacking of `d_` prefixes in referencing `d_double_style_ieee` Config variable.  I further found similar bug for `long_double_style_*` around it.