### PR TITLE
perlop: Enhance a tr/// example

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -2670,8 +2670,8 @@ If the C</s> modifier is specified, sequences of characters, all in a
 row, that were transliterated to the same character are squashed down to
 a single instance of that character.
 
- my $a = "aaaba"
- $a =~ tr/a/a/s     # $a now is "aba"
+ my $a = "aaabbbca";
+ $a =~ tr/ab/dd/s;     # $a now is "dcd"
 
 If the C</d> modifier is used, the I<REPLACEMENTLIST> is always interpreted
 exactly as specified.  Otherwise, if the I<REPLACEMENTLIST> is shorter


### PR DESCRIPTION
This more clearly demonstrates that the /s option squeezes based on
the result rather than the source