### PR TITLE
mkheader: Prevent 'print on closed filehandle' messages

### DIFF
--- a/cpan/Unicode-Collate/mkheader
+++ b/cpan/Unicode-Collate/mkheader
@@ -140,7 +140,8 @@ foreach my $tbl (@tripletable) {
     my $init = $tbl->{init};
 
     open my $fh_h, ">$file" or croak "$PACKAGE: $file can't be made";
-    binmode $fh_h; select $fh_h;
+    binmode $fh_h;
+    my $old_fh = select $fh_h;
     my %val;
 
     print << 'EOF';
@@ -195,6 +196,7 @@ EOF
     }
     print "};\n\n";
     close $fh_h;
+    select $old_fh;
 }
 
 1;


### PR DESCRIPTION
Program 'mkheader' is called from cpan/Unicode-Collate/Makefile.PL,
which was recently revised to run with both strictures and warnings.
Makefile.PL executes mkheader via a 'do'.  This was causing the
following statements to be printed during 'make' in the Perl
5 build process:

printf() on closed filehandle $fh_h at .../cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker.pm line 1233.
print() on closed filehandle $fh_h at .../cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker.pm line 1234.

Storing the original filehandle during select(), then restoring it at
the end of the loop, clears up those statements.