### PR TITLE
fix context of caller call in Carp

### DIFF
--- a/dist/Carp/lib/Carp.pm
+++ b/dist/Carp/lib/Carp.pm
@@ -284,7 +284,7 @@ sub shortmess {
     my $cgc = _cgc();
 
     # Icky backwards compatibility wrapper. :-(
-    local @CARP_NOT = $cgc ? $cgc->() : caller();
+    local @CARP_NOT = scalar( $cgc ? $cgc->() : caller() );
     shortmess_heavy(@_);
 }
 


### PR DESCRIPTION
Carp's CARP_NOT variable is meant to have package names. caller in list
context returns the calling file and line in addition to the package
name.

Enforce scalar context on the call to caller to fix this.