### PR TITLE
restore compatibility with old versions of ExtUtils::ParseXS

### DIFF
--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -42,6 +42,7 @@ use ExtUtils::ParseXS::Utilities qw(
 our @EXPORT_OK = qw(
   process_file
   report_error_count
+  errors
 );
 
 ##############################
@@ -1012,6 +1013,7 @@ sub report_error_count {
     return $Singleton->{errors}||0;
   }
 }
+*errors = \&report_error_count;
 
 # Input:  ($self, $_, @{ $self->{line} }) == unparsed input.
 # Output: ($_, @{ $self->{line} }) == (rest of line, following lines).

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -11,7 +11,7 @@ use Symbol;
 
 our $VERSION;
 BEGIN {
-  $VERSION = '3.41';
+  $VERSION = '3.42';
   require ExtUtils::ParseXS::Constants; ExtUtils::ParseXS::Constants->VERSION($VERSION);
   require ExtUtils::ParseXS::CountLines; ExtUtils::ParseXS::CountLines->VERSION($VERSION);
   require ExtUtils::ParseXS::Utilities; ExtUtils::ParseXS::Utilities->VERSION($VERSION);

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Symbol;
 
-our $VERSION = '3.41';
+our $VERSION = '3.42';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
@@ -1,7 +1,7 @@
 package ExtUtils::ParseXS::CountLines;
 use strict;
 
-our $VERSION = '3.41';
+our $VERSION = '3.42';
 
 our $SECTION_END_MARKER;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
@@ -2,7 +2,7 @@ package ExtUtils::ParseXS::Eval;
 use strict;
 use warnings;
 
-our $VERSION = '3.41';
+our $VERSION = '3.42';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
@@ -5,7 +5,7 @@ use Exporter;
 use File::Spec;
 use ExtUtils::ParseXS::Constants ();
 
-our $VERSION = '3.41';
+our $VERSION = '3.42';
 
 our (@ISA, @EXPORT_OK);
 @ISA = qw(Exporter);


### PR DESCRIPTION
ExtUtils::ParseXS used to include a function called "errors", which was
documented. In was renamed to report_error_count in version 3.01 (perl
5.15.1) although the documentation wasn't fixed until 3.21 (perl 5.19.2).
As a documented function, this is a backwards compatibility issue.

It is possible for this to lead to errors when installing modules from
CPAN. If you are using the version of ExtUtils::ParseXS that comes with
core, between running the Makefile.PL and make, fulfilling prereqs can
result in upgrading ExtUtils::ParseXS. When Makefile.PL is run, the
generated Makefile gets the full path to xsubpp saved in it. Then when
upgraded from CPAN, ExtUtils::ParseXS and xsubpp will be in a new
location (site_perl or a local::lib). Running make will run the old
xsubpp, but it will then try to use the new ExtUtils::ParseXS which has
broken compatibility.

Restore the errors function as a compatibility shim to fix this.