### PR TITLE
perlsub - indicate version requirement for "delete local"

### DIFF
--- a/pod/perlsub.pod
+++ b/pod/perlsub.pod
@@ -1032,6 +1032,8 @@ also accepted.
     }
     # %hash is back to its original state
 
+This construct is supported since Perl v5.12.
+
 =head2 Lvalue subroutines
 X<lvalue> X<subroutine, lvalue>
 


### PR DESCRIPTION
There's currently no indication in the `delete` function docs or referenced `perlsub` entry to the version requirement for this feature.