### PR TITLE
Explicitly specify the Catalina operating system version and update the default Xcode version in the test suite Workflow

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -200,9 +200,9 @@ jobs:
   # | '  \/ _` / _| (_) \__ \
   # |_|_|_\__,_\__|\___/|___/
 
-  smoke-macos-xcode11:
-    name: "macOS xcode 11"
-    runs-on: macos-latest
+  smoke-macos-catalina-xcode11:
+    name: "macOS (catalina) xcode 11"
+    runs-on: macos-10.0
     timeout-minutes: 120
     needs: sanity_check
     if: needs.sanity_check.outputs.run_all_jobs == 'true'

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -200,8 +200,8 @@ jobs:
   # | '  \/ _` / _| (_) \__ \
   # |_|_|_\__,_\__|\___/|___/
 
-  smoke-macos-catalina-xcode11:
-    name: "macOS (catalina) xcode 11"
+  smoke-macos-catalina-xcode12:
+    name: "macOS (catalina) xcode 12"
     runs-on: macos-10.15
     timeout-minutes: 120
     needs: sanity_check

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -202,7 +202,7 @@ jobs:
 
   smoke-macos-catalina-xcode11:
     name: "macOS (catalina) xcode 11"
-    runs-on: macos-10.0
+    runs-on: macos-10.15
     timeout-minutes: 120
     needs: sanity_check
     if: needs.sanity_check.outputs.run_all_jobs == 'true'

--- a/AUTHORS
+++ b/AUTHORS
@@ -557,6 +557,7 @@ Jacques Germishuys             <jacquesg@striata.com>
 Jacqui Caren                   <Jacqui.Caren@ig.co.uk>
 Jake Hamby                     <jehamby@lightside.com>
 Jakub Wilk                     <jwilk@jwilk.net>
+Jae Bradley                    <jae.b.bradley@gmail.com>
 James                          <james@rf.net>
 James A. Duncan                <jduncan@fotango.com>
 James Clarke                   <jrtc27@jrtc27.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -555,9 +555,9 @@ Jacinta Richardson             <jarich@perltraining.com.au>
 Jack Shirazi                   <JackS@GemStone.com>
 Jacques Germishuys             <jacquesg@striata.com>
 Jacqui Caren                   <Jacqui.Caren@ig.co.uk>
+Jae Bradley                    <jae.b.bradley@gmail.com>
 Jake Hamby                     <jehamby@lightside.com>
 Jakub Wilk                     <jwilk@jwilk.net>
-Jae Bradley                    <jae.b.bradley@gmail.com>
 James                          <james@rf.net>
 James A. Duncan                <jduncan@fotango.com>
 James Clarke                   <jrtc27@jrtc27.com>


### PR DESCRIPTION
### Summary

While [the `macos-latest` GitHub Actions workflow label](https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources) still is a valid reference for the `macOS Catalina 10.15` virtual environment, with the advent of `macOS Big Sur 11.x` `macos-latest` may be a confusing label to use.

It might be clearer to simply use the explicit workflow label containing the major + minor version.

![image](https://user-images.githubusercontent.com/8136030/100810252-0ef02780-3406-11eb-94ca-7568bafd6da0.jpeg)

Additionally, this PR updates the job name, as the latest default Xcode version to ship with the `macos-10.15` environment is actually `12.0.1` (and not `11` as the job name would suggest).

See: https://github.com/actions/virtual-environments/issues/2056 and https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode

### Issues When Attempting To Add Big Sur Job

As part of the changes in this PR, I wanted to also add some tests for Big Sur but failed to complete this task with a passing build.

What I found was interesting (and I could definitely be doing something incorrectly).

It is interesting to note that the [the default Xcode version for the `macos-11.0` GitHub Actions workflow label is `11.7`](https://github.com/actions/virtual-environments/blob/319f36857788e2a03502da1a12c0eb37f32113b8/images/macos/macos-11.0-Readme.md#xcode).

#### Attempt adding `macos-11.0` job without setting Xcode to `12.2` explicitly

When the job using Big Sur with the default Xcode version runs its configuration step, I see the following errors

![image](https://user-images.githubusercontent.com/8136030/100811068-ca658b80-3407-11eb-8aa6-8d73a038f02c.png)

Additional data:

* [That specific workflow's raw logs](https://pipelines.actions.githubusercontent.com/DJ3aousunboTWBYEogwOhf6HaYxfNYMETE4msHAg8S9xaA9ian/_apis/pipelines/1/runs/13/signedlogcontent/23?urlExpires=2020-12-02T00%3A03%3A05.4769628Z&urlSigningMethod=HMACV1&urlSignature=r6oqgDs5WCOxLvynhYQAsOEn59W3SSfSr%2BG1nilftdg%3D)
* [That specific GitHub Actions Workflow](https://github.com/jaebradley/perl5/runs/1481111450)
* [The commit associated with that workflow](https://github.com/jaebradley/perl5/commit/3c7dbda2d2dd6d8b99fb76436291c65adf2675d6)
* Can verify that the `macos-11.0` environment has a default Xcode version of `11.7` by looking at the output of `xcodebuild -version` for [this failed configuration step](https://github.com/jaebradley/perl5/runs/1483413368?check_suite_focus=true)

##### Attempt adding `macos-11.0` job after setting Xcode to `12.2` explicitly

After `sudo xcode select`-ing `/Applications/Xcode_12.2.app`, the configuration step runs successfully, but I see a test failure

![image](https://user-images.githubusercontent.com/8136030/100811657-1bc24a80-3409-11eb-8095-1896df6a4e85.png)


Additional data:

* [That specific workflow's raw logs](https://pipelines.actions.githubusercontent.com/DJ3aousunboTWBYEogwOhf6HaYxfNYMETE4msHAg8S9xaA9ian/_apis/pipelines/1/runs/18/signedlogcontent/23?urlExpires=2020-12-02T00%3A12%3A36.5043921Z&urlSigningMethod=HMACV1&urlSignature=tAmIqFwKe7gVLvir3mdnwGwbKVCwCVjuUTIdbqpDirE%3D)
* [That specific GitHub Actions Workflow](https://github.com/jaebradley/perl5/runs/1481311777?check_suite_focus=true)
* [The commit associated with the workflow](https://github.com/jaebradley/perl5/commit/facf4fc4ffb6b0b5a63b8710186d57519c84269d)

Hopefully this section on investigating trying to add a job for Big Sur makes sense and is at least somewhat coherent. I could very well be doing something incorrectly but was hoping to get some feedback on what that "something" is, if possible.
