### PR TITLE
Detect GCC as compiler to use

### DIFF
--- a/hints/solaris_2.sh
+++ b/hints/solaris_2.sh
@@ -90,7 +90,8 @@ END
 `
 
 case "$cc" in
-'')    for i in `ls -r /opt/*studio*/bin/cc` /opt/SUNWspro/bin/cc
+'')    for i in `ls -r /opt/*studio*/bin/cc` /opt/SUNWspro/bin/cc \
+		`which gcc`
        do
 	       if test -f "$i"; then
 		       cc=$i


### PR DESCRIPTION
On Illumos based distributions GCC is likely the compiler available on the system.
Change tested on SmartOS