### PR TITLE
Improve "Lost precision" warnings on increment/decrement

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -8952,9 +8952,11 @@ Perl_sv_inc_nomg(pTHX_ SV *const sv)
         if (NV_OVERFLOWS_INTEGERS_AT != 0.0 &&
             /* If NVX was NaN, the following comparisons return always false */
             UNLIKELY(was >= NV_OVERFLOWS_INTEGERS_AT ||
-                     was < -NV_OVERFLOWS_INTEGERS_AT)
+                     was < -NV_OVERFLOWS_INTEGERS_AT) &&
 #if defined(NAN_COMPARE_BROKEN) && defined(Perl_isnan)
-            && LIKELY(!Perl_isnan(was))
+            LIKELY(!Perl_isinfnan(was))
+#else
+            LIKELY(!Perl_isinf(was))
 #endif
             ) {
 	    /* diag_listed_as: Lost precision when %s %f by 1 */
@@ -9136,9 +9138,11 @@ Perl_sv_dec_nomg(pTHX_ SV *const sv)
             if (NV_OVERFLOWS_INTEGERS_AT != 0.0 &&
                 /* If NVX was NaN, these comparisons return always false */
                 UNLIKELY(was <= -NV_OVERFLOWS_INTEGERS_AT ||
-                         was > NV_OVERFLOWS_INTEGERS_AT)
+                         was > NV_OVERFLOWS_INTEGERS_AT) &&
 #if defined(NAN_COMPARE_BROKEN) && defined(Perl_isnan)
-                && LIKELY(!Perl_isnan(was)))
+                LIKELY(!Perl_isinfnan(was)))
+#else
+                LIKELY(!Perl_isinf(was))
 #endif
                 ) {
 		/* diag_listed_as: Lost precision when %s %f by 1 */

--- a/sv.c
+++ b/sv.c
@@ -8953,7 +8953,7 @@ Perl_sv_inc_nomg(pTHX_ SV *const sv)
             /* If NVX was NaN, the following comparisons return always false */
             UNLIKELY(was >= NV_OVERFLOWS_INTEGERS_AT ||
                      was < -NV_OVERFLOWS_INTEGERS_AT) &&
-#if defined(NAN_COMPARE_BROKEN) && defined(Perl_isnan)
+#if defined(NAN_COMPARE_BROKEN)
             LIKELY(!Perl_isinfnan(was))
 #else
             LIKELY(!Perl_isinf(was))
@@ -9139,7 +9139,7 @@ Perl_sv_dec_nomg(pTHX_ SV *const sv)
                 /* If NVX was NaN, these comparisons return always false */
                 UNLIKELY(was <= -NV_OVERFLOWS_INTEGERS_AT ||
                          was > NV_OVERFLOWS_INTEGERS_AT) &&
-#if defined(NAN_COMPARE_BROKEN) && defined(Perl_isnan)
+#if defined(NAN_COMPARE_BROKEN)
                 LIKELY(!Perl_isinfnan(was)))
 #else
                 LIKELY(!Perl_isinf(was))

--- a/t/op/inc.t
+++ b/t/op/inc.t
@@ -255,6 +255,26 @@ EOC
 		      "$description under use warnings 'imprecision'");
     }
 
+    # Verify warnings on incrementing/decrementing large values
+    # whose integral part will not fit in NVs. [GH #18333]
+    foreach ([$start_n - 4, '$i++', 'negative large value', 'inc'],
+             ['+Inf' + 0,   '$i++', '+Inf', 'inc'],
+             ['-Inf' + 0,   '$i++', '-Inf', 'inc'],
+             [$start_p + 4, '$i--', 'positive large value', 'dec'],
+             ['+Inf' + 0,   '$i--', '+Inf', 'dec'],
+             ['-Inf' + 0,   '$i--', '-Inf', 'dec']) {
+	my ($start, $action, $description, $act) = @$_;
+	my $code = eval << "EOC" or die $@;
+sub {
+    use warnings 'imprecision';
+    my \$i = \$start;
+    $action;
+}
+EOC
+        warning_like($code, qr/Lost precision when ${act}rementing /,
+                     "${act}rementing $description under use warnings 'imprecision'");
+    }
+
     $found = 1;
     last;
 }

--- a/t/op/inc.t
+++ b/t/op/inc.t
@@ -258,11 +258,7 @@ EOC
     # Verify warnings on incrementing/decrementing large values
     # whose integral part will not fit in NVs. [GH #18333]
     foreach ([$start_n - 4, '$i++', 'negative large value', 'inc'],
-             ['+Inf' + 0,   '$i++', '+Inf', 'inc'],
-             ['-Inf' + 0,   '$i++', '-Inf', 'inc'],
-             [$start_p + 4, '$i--', 'positive large value', 'dec'],
-             ['+Inf' + 0,   '$i--', '+Inf', 'dec'],
-             ['-Inf' + 0,   '$i--', '-Inf', 'dec']) {
+             [$start_p + 4, '$i--', 'positive large value', 'dec']) {
 	my ($start, $action, $description, $act) = @$_;
 	my $code = eval << "EOC" or die $@;
 sub {
@@ -422,5 +418,29 @@ SKIP: {
         skip "the uvsize $Config{uvsize} is neither 4 nor 8", 2;
     }
 } # SKIP
+
+# Incrementing/decrementing Inf/NaN should not trigger 'imprecision' warnings
+# [GH #18333, #18388]
+# Note these tests only check for warnings; t/op/infnan.t has tests that
+# checks the result of incrementing/decrementing Inf/NaN.
+foreach my $infnan ('+Inf', '-Inf', 'NaN') {
+    my $start = $infnan + 0;
+  SKIP: {
+      skip "NV does not have $infnan", 2
+          unless ($infnan eq 'NaN' ? $Config{d_double_has_nan} : $Config{d_double_has_inf});
+      foreach (['$i++', 'inc'],
+               ['$i--', 'dec']) {
+          my ($action, $act) = @$_;
+          my $code = eval <<"EOC" or die $@;
+sub {
+    use warnings 'imprecision';
+    my \$i = \$start;
+    $action;
+}
+EOC
+          warning_is($code, undef, "${act}rementing $infnan under use warnings 'imprecision'");
+      }
+    } # SKIP
+}
 
 done_testing();


### PR DESCRIPTION
Previously, imprecision warnings on increment (`Lost precision when incrementing %f by 1`) were only issued on positive finite values, and, on decrement, only issued on negative finite values.
This commit extends this warnings on both sign and infinite values so that perl will warn on all cases of losing precision.

This fixes #18333.