### PR TITLE
t/lib/croak/toke: Correct test label

### DIFF
--- a/t/lib/croak/toke
+++ b/t/lib/croak/toke
@@ -503,7 +503,7 @@ EXPECT
 syntax error at - line 4, next token ???
 Execution of - aborted due to compilation errors.
 ########
-# NAME [perl #134045] incomplete hex number
+# NAME [perl #134125] [gh #17010] incomplete hex number
 0x x 2;
 0xx 2;
 0x_;


### PR DESCRIPTION
The RT ticket number cited in the test's label is wrong.  The body of
the commit message for commit 7259f4194f3131957240f6b3dba47b74f53ac660
shows the correct RT number.  Provide GH number as well.