### PR TITLE
Make DynaLoader on MacOS check library existence with dlopen

### DIFF
--- a/ext/DynaLoader/DynaLoader_pm.PL
+++ b/ext/DynaLoader/DynaLoader_pm.PL
@@ -88,7 +88,7 @@ package DynaLoader;
 # Tim.Bunce@ig.co.uk, August 1994
 
 BEGIN {
-    $VERSION = '1.49';
+    $VERSION = '1.50';
 }
 
 EOT
@@ -494,12 +494,20 @@ sub dl_findfile {
             foreach $name (@names) {
 		my($file) = "$dir$dirsep$name";
                 print STDERR " checking in $dir for $name\n" if $dl_debug;
-		$file = ($do_expand) ? dl_expandspec($file) : (-f $file && $file);
-		#$file = _check_file($file);
-		if ($file) {
+		if ($do_expand && ($file = dl_expandspec($file))) {
+                    push @found, $file;
+                    next arg; # no need to look any further
+		}
+		elsif (-f $file) {
                     push(@found, $file);
                     next arg; # no need to look any further
                 }
+		<<$^O-eq-darwin>>
+		elsif (dl_load_file($file, 0)) {
+                    push @found, $file;
+                    next arg; # no need to look any further
+		}
+		<</$^O-eq-darwin>>
             }
         }
     }


### PR DESCRIPTION
A number of system libraries no longer exist as actual files on Big Sur, even though dlopen will pretend they do, so now we fall back to dlopen if a library file can not be found.

[CI](https://github.com/Perl/perl5/runs/1572311015?check_suite_focus=true) suggests this works on Big Sur but this probably needs human confirmation that it will fix the issue from someone who actually runs Big Sur before being merged.