### PR TITLE
Define integer constants as IV rather than NV in POSIX

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4350,6 +4350,7 @@ ext/POSIX/Makefile.PL		POSIX extension makefile writer
 ext/POSIX/POSIX.xs		POSIX extension external subroutines
 ext/POSIX/t/export.t		Test @EXPORT and @EXPORT_OK
 ext/POSIX/t/iscrash		See if POSIX isxxx() crashes with threads on Win32
+ext/POSIX/t/iv_const.t		See if integer constants of POSIX are IV
 ext/POSIX/t/math.t		Basic math tests for POSIX
 ext/POSIX/t/mb.t		Multibyte function tests for POSIX
 ext/POSIX/t/posix.t		See if POSIX works

--- a/ext/POSIX/Makefile.PL
+++ b/ext/POSIX/Makefile.PL
@@ -116,15 +116,18 @@ push @names, {name=>$_, type=>"NV", not_constant=>1}
   foreach (qw(DBL_MAX FLT_MAX LDBL_MAX LDBL_MIN LDBL_EPSILON
 	       DBL_EPSILON DBL_MIN FLT_EPSILON FLT_MIN));
 
-push @names, {name=>$_, type=>"NV"}
+push @names, {name=>$_, type=>"IV"}
   foreach (qw(DBL_DIG DBL_MANT_DIG DBL_MAX_10_EXP DBL_MAX_EXP DBL_MIN_10_EXP
 	      DBL_MIN_EXP FLT_DIG FLT_MANT_DIG FLT_MAX_10_EXP FLT_MAX_EXP
 	      FLT_MIN_10_EXP FLT_MIN_EXP FLT_RADIX LDBL_DIG LDBL_MANT_DIG
 	      LDBL_MAX_10_EXP LDBL_MAX_EXP LDBL_MIN_10_EXP LDBL_MIN_EXP));
 
-push @names, {name=>$_, type=>"NV"}
+push @names, {name=>$_, type=>"IV"}
   foreach (qw(FP_ILOGB0 FP_ILOGBNAN FP_INFINITE FP_NAN FP_NORMAL
-              FP_SUBNORMAL FP_ZERO M_1_PI M_2_PI M_2_SQRTPI M_E M_LN10 M_LN2
+              FP_SUBNORMAL FP_ZERO));
+
+push @names, {name=>$_, type=>"NV"}
+  foreach (qw(M_1_PI M_2_PI M_2_SQRTPI M_E M_LN10 M_LN2
               M_LOG10E M_LOG2E M_PI M_PI_2 M_PI_4 M_SQRT1_2 M_SQRT2));
 
 push @names, {name=>$_, type=>"IV"}

--- a/ext/POSIX/t/iv_const.t
+++ b/ext/POSIX/t/iv_const.t
@@ -1,0 +1,69 @@
+#! perl -w
+
+# Test integer constants (DBL_DIG, DBL_MAX_EXP, FP_*, ...) are IV, not NV.
+
+use strict;
+use Test::More;
+use Devel::Peek;
+use POSIX;
+use Config;
+
+# Capture output from Devel::Peek::Dump() into Perl string
+sub capture_dump
+{
+    open my $olderr, '>&', *STDERR
+        or die "Can't save STDERR: $!";
+    my $str;
+    my $result = eval {
+        local $SIG{__DIE__};
+        close STDERR;
+        open STDERR, '>', \$str
+            or die "Can't redirect STDERR: $!";
+        Dump($_[0]);
+        1;
+    };
+    my $reason = $@;
+    open STDERR, '>&', $olderr
+        or die "Can't restore STDERR: $!";
+    $result or die $reason;
+    $str;
+}
+
+# Avoid die() in a test harness.
+sub capture_dump_in_test
+{
+    my $str;
+    eval { $str = capture_dump($_[0]); 1 } or BAIL_OUT $@;
+    $str;
+}
+
+sub is_iv ($$)
+{
+    # We would write "ok(SvIOK($_[0]), ...)",
+    # but unfortunately SvIOK is not available in Perl.
+
+    my $dump = capture_dump_in_test($_[0]);
+    #note($dump);
+    ok($dump =~ /^\h*FLAGS = .*\bIOK\b/m && $dump =~ /^\h*IV =/m, $_[1]);
+}
+
+my @tests = qw(EXIT_SUCCESS);
+
+push @tests, qw(FLT_RADIX FP_NORMAL FP_ZERO FP_SUBNORMAL FP_INFINITE FP_NAN);
+
+if ($Config{uselongdouble} ? $Config{d_ilogbl} : $Config{d_ilogb}) {
+    push @tests, qw(FP_ILOGB0);
+    push @tests, qw(FP_ILOGBNAN) if $Config{d_double_has_nan};
+}
+
+foreach my $flt ('FLT', 'DBL', ($Config{d_longdbl} ? ('LDBL') : ())) {
+    push @tests, "${flt}_$_"
+        foreach qw(DIG MANT_DIG MAX_10_EXP MAX_EXP MIN_10_EXP MIN_EXP);
+}
+
+push @tests, qw(FE_TONEAREST FE_TOWARDZERO FE_UPWARD FE_DOWNWARD)
+    if $Config{d_fegetround};
+
+is_iv(eval "POSIX::$_", "$_ is an integer") foreach @tests;
+
+done_testing();


### PR DESCRIPTION
In `POSIX` module, some constants related to floating-point types such as `DBL_DIG`, `FLT_RADIX`, `FP_*` (return values for `fpclassify`), etc. had been defined as NV, but these are actually integer constants.  This PR changes these constants to IV.

This change should not affect the behavior of user programs.