### PR TITLE
Fix RT number in perl5260delta.pod

### DIFF
--- a/pod/perl5260delta.pod
+++ b/pod/perl5260delta.pod
@@ -2630,7 +2630,7 @@ L<[perl #126697]|https://rt.perl.org/Public/Bug/Display.html?id=126697>
 
 Using C<substr()> to modify a magic variable could access freed memory
 in some cases.
-L<[perl #129340]|https://rt.perl.org/Public/Bug/Display.html?id=129340>
+L<[perl #130766]|https://rt.perl.org/Public/Bug/Display.html?id=130766>
 
 =item *
 


### PR DESCRIPTION
Hello,

I propose this documentation change since 129340 is a dead link and 130766 seems to be the corresponding issue and was merged in 5.24.1 and 5.26.0

Thibault