### PR TITLE
Porting/pod_rules.pl: no '--test' command-line switch

### DIFF
--- a/Porting/pod_rules.pl
+++ b/Porting/pod_rules.pl
@@ -18,8 +18,6 @@ if (ord("A") == 193) {
 # --build-all tries to build everything
 # --build-foo updates foo as follows
 # --showfiles shows the files to be changed
-# --test exit if perl.pod, MANIFEST are consistent, and regenerated
-#   files are up to date, die otherwise.
 
 %Targets = (
             manifest => 'MANIFEST',


### PR DESCRIPTION
As is illustrated by the following (trimmed) invocation:

        ./perl -Ilib Porting/pod_rules.pl --test
        Unknown option: test

... there is no '--test' option available for this program.  Remove
inaccurate inline documentation.

In partial satisfaction of https://github.com/Perl/perl5/issues/18413.