### PR TITLE
Improve GDBM_File

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1159,6 +1159,7 @@ Sebastian Wittmeier            <Sebastian.Wittmeier@ginko.de>
 Sebastien Barre                <Sebastien.Barre@utc.fr>
 Sergey Alekseev                <varnie29a@mail.ru>
 Sergey Aleynikov               <sergey.aleynikov@gmail.com>
+Sergey Poznyakoff              <gray@gnu.org>
 Sergiy Borodych                <bor@cpan.org>
 Sevan Janiyan                  <venture37@geeklan.co.uk>
 Shawn                          <svicalifornia@gmail.com>

--- a/MANIFEST
+++ b/MANIFEST
@@ -4220,8 +4220,10 @@ ext/GDBM_File/GDBM_File.pm	GDBM extension Perl module
 ext/GDBM_File/GDBM_File.xs	GDBM extension external subroutines
 ext/GDBM_File/hints/sco.pl	Hint for GDBM_File for named architecture
 ext/GDBM_File/Makefile.PL	GDBM extension makefile writer
+ext/GDBM_File/t/count.t		Test if the count method works
 ext/GDBM_File/t/fatal.t		Test the fatal_func argument to gdbm_open
 ext/GDBM_File/t/gdbm.t		See if GDBM_File works
+ext/GDBM_File/t/opt.t		Test if gdbm_setopt and derived methods work
 ext/GDBM_File/typemap		GDBM extension interface types
 ext/Hash-Util/Changes		Change history of Hash::Util
 ext/Hash-Util/lib/Hash/Util.pm	Hash::Util

--- a/ext/GDBM_File/GDBM_File.pm
+++ b/ext/GDBM_File/GDBM_File.pm
@@ -6,9 +6,47 @@ GDBM_File - Perl5 access to the gdbm library.
 
 =head1 SYNOPSIS
 
-    use GDBM_File ;
-    tie %hash, 'GDBM_File', $filename, &GDBM_WRCREAT, 0640;
+    use GDBM_File;
+    [$db =] tie %hash, 'GDBM_File', $filename, &GDBM_WRCREAT, 0640;
     # Use the %hash array.
+
+    $e = $db->errno;
+    $e = $db->syserrno;
+    $str = $db->strerror;
+    $bool = $db->needs_recovery;
+
+    $db->clear_error;
+
+    $db->reorganize;
+    $db->sync;
+
+    $n = $db->count;
+
+    $n = $db->flags;
+
+    $str = $db->dbname;
+
+    $db->cache_size;
+    $db->cache_size($newsize);
+
+    $n = $db->block_size;
+
+    $bool = $db->sync_mode;
+    $db->sync_mode($bool);
+
+    $bool = $db->centfree;
+    $db->centfree($bool);
+
+    $bool = $db->coalesce;
+    $db->coalesce($bool);
+
+    $bool = $db->mmap;
+
+    $size = $db->mmapsize;
+    $db->mmapsize($newsize);
+
+    $db->recover(%args);
+
     untie %hash ;
 
 =head1 DESCRIPTION
@@ -23,6 +61,250 @@ interface.
 Unlike Perl's built-in hashes, it is not safe to C<delete> the current
 item from a GDBM_File tied hash while iterating over it with C<each>.
 This is a limitation of the gdbm library.
+
+=head1 STATIC METHODS
+
+=head2 GDBM_version
+
+    $str = GDBM_File->GDBM_version;
+    @ar = GDBM_File->GDBM_version;
+
+Returns the version number of the underlying B<libgdbm> library. In scalar
+context, returns the library version formatted as string:
+
+    MINOR.MAJOR[.PATCH][ (GUESS)]
+
+where I<MINOR>, I<MAJOR>, and I<PATCH> are version numbers, and I<GUESS> is
+a guess level (see below).
+
+In list context, returns a list:
+
+    ( MINOR, MAJOR, PATCH [, GUESS] )
+
+The I<GUESS> component is present only if B<libgdbm> version is 1.8.3 or
+earlier. This is because earlier releases of B<libgdbm> did not include
+information about their version and the B<GDBM_File> module has to implement
+certain guesswork in order to determine it. I<GUESS> is a textual description
+in string context, and a positive number indicating how rough the guess is
+in list context. Possible values are:
+
+=over 4
+
+=item 1  - exact guess
+
+The major and minor version numbers are guaranteed to be correct. The actual
+patchlevel is most probably guessed right, but can be 1-2 less than indicated.
+
+=item 2  - approximate
+
+The major and minor number are guaranteed to be correct. The patchlevel is
+set to the upper bound.
+
+=item 3  - rough guess
+
+The version is guaranteed to be not newer than B<I<MAJOR>.I<MINOR>>.
+
+=back
+
+=head1 METHODS
+
+=head2 close
+
+    $db->close;
+
+Closes the database. You are not advised to use this method directly. Please,
+use B<untie> instead.
+
+=head2 errno
+
+    $db->errno
+
+Returns the last error status associated with this database.
+
+=head2 syserrno
+
+    $db->syserrno
+
+Returns the last system error status (C C<errno> variable), associated with
+this database,
+
+=head2 strerror
+
+    $db->strerror
+
+Returns textual description of the last error that occurred in this database.
+
+=head2 clear_error
+
+    $db->clear_error
+
+Clear error status.
+
+=head2 needs_recovery
+
+    $db->needs_recovery
+
+Returns true if the database needs recovery.
+
+=head2 reorganize
+
+    $db->reorganize;
+
+Reorganizes the database.
+
+=head2 sync
+
+    $db->sync;
+
+Synchronizes recent changes to the database with its disk copy.
+
+=head2 count
+
+    $n = $db->count;
+
+Returns number of keys in the database.
+
+=head2 flags
+
+    $db->flags;
+
+Returns flags passed as 4th argument to B<tie>.
+
+=head2 dbname
+
+    $db->dbname;
+
+Returns the database name (i.e. 3rd argument to B<tie>.
+
+=head2 cache_size
+
+    $db->cache_size;
+    $db->cache_size($newsize);
+
+Returns the size of the internal B<GDBM> cache for that database.
+
+Called with argument, sets the size to I<$newsize>.
+
+=head2 block_size
+
+    $db->block_size;
+
+Returns the block size of the database.
+
+=head2 sync_mode
+
+    $db->sync_mode;
+    $db->sync_mode($bool);
+
+Returns the status of the automatic synchronization mode. Called with argument,
+enables or disables the sync mode, depending on whether $bool is B<true> or
+B<false>.
+
+When synchronization mode is on (B<true>), any changes to the database are
+immediately written to the disk. This ensures database consistency in case
+of any unforeseen errors (e.g. power failures), at the expense of considerable
+slowdown of operation.
+
+Synchronization mode is off by default.
+
+=head2 centfree
+
+    $db->centfree;
+    $db->centfree($bool);
+
+Returns status of the central free block pool (B<0> - disabled,
+B<1> - enabled).
+
+With argument, changes its status.
+
+By default, central free block pool is disabled.
+
+=head2 coalesce
+
+    $db->coalesce;
+    $db->coalesce($bool);
+
+=head2 mmap
+
+    $db->mmap;
+
+Returns true if memory mapping is enabled.
+
+This method will B<croak> if the B<libgdbm> library is complied without
+memory mapping support.
+
+=head2 mmapsize
+
+    $db->mmapsize;
+    $db->mmapsize($newsize);
+
+If memory mapping is enabled, returns the size of memory mapping. With
+argument, sets the size to B<$newsize>.
+
+This method will B<croak> if the B<libgdbm> library is complied without
+memory mapping support.
+
+=head2 recover
+
+    $db->recover(%args);
+
+Recovers data from a failed database. B<%args> is optional and can contain
+following keys:
+
+=over 4
+
+=item err => sub { ... }
+
+Reference to code for detailed error reporting. Upon encountering an error,
+B<recover> will call this sub with a single argument - a description of the
+error.
+
+=item backup => \$str
+
+Creates a backup copy of the database before recovery and returns its
+filename in B<$str>.
+
+=item max_failed_keys => $n
+
+Maximum allowed number of failed keys. If the actual number becomes equal
+to I<$n>, B<recover> aborts and returns error.
+
+=item max_failed_buckets => $n
+
+Maximum allowed number of failed buckets. If the actual number becomes equal
+to I<$n>, B<recover> aborts and returns error.
+
+=item max_failures => $n
+
+Maximum allowed number of failures during recovery.
+
+=item stat => \%hash
+
+Return recovery statistics in I<%hash>. Upon return, the following keys will
+be present:
+
+=over 8
+
+=item recovered_keys
+
+Number of successfully recovered keys.
+
+=item recovered_buckets
+
+Number of successfully recovered buckets.
+
+=item failed_keys
+
+Number of keys that failed to be retrieved.
+
+=item failed_buckets
+
+Number of buckets that failed to be retrieved.
+
+=back
+
+=back
+
 
 =head1 AVAILABILITY
 
@@ -43,15 +325,11 @@ can be safely used with C<libgdbm>.
 A maliciously crafted file might cause perl to crash or even expose a
 security vulnerability.
 
-=head1 BUGS
-
-The available functions and the gdbm/perl interface need to be documented.
-
-The GDBM error number and error message interface needs to be added.
-
 =head1 SEE ALSO
 
-L<perl(1)>, L<DB_File(3)>, L<perldbmfilter>. 
+L<perl(1)>, L<DB_File(3)>, L<perldbmfilter>,
+L<gdbm(3)>,
+L<https://www.gnu.org.ua/software/gdbm/manual.html>.
 
 =cut
 
@@ -67,25 +345,25 @@ require Exporter;
 require XSLoader;
 @ISA = qw(Tie::Hash Exporter);
 @EXPORT = qw(
-	GDBM_CACHESIZE
-	GDBM_CENTFREE
-	GDBM_COALESCEBLKS
-	GDBM_FAST
-	GDBM_FASTMODE
-	GDBM_INSERT
-	GDBM_NEWDB
-	GDBM_NOLOCK
-	GDBM_OPENMASK
-	GDBM_READER
-	GDBM_REPLACE
-	GDBM_SYNC
-	GDBM_SYNCMODE
-	GDBM_WRCREAT
-	GDBM_WRITER
+        GDBM_CACHESIZE
+        GDBM_CENTFREE
+        GDBM_COALESCEBLKS
+        GDBM_FAST
+        GDBM_FASTMODE
+        GDBM_INSERT
+        GDBM_NEWDB
+        GDBM_NOLOCK
+        GDBM_OPENMASK
+        GDBM_READER
+        GDBM_REPLACE
+        GDBM_SYNC
+        GDBM_SYNCMODE
+        GDBM_WRCREAT
+        GDBM_WRITER
 );
 
 # This module isn't dual life, so no need for dev version numbers.
-$VERSION = '1.18';
+$VERSION = '1.19';
 
 XSLoader::load();
 

--- a/ext/GDBM_File/GDBM_File.xs
+++ b/ext/GDBM_File/GDBM_File.xs
@@ -23,21 +23,104 @@ typedef datum datum_key ;
 typedef datum datum_value ;
 typedef datum datum_key_copy;
 
-#if defined(GDBM_VERSION_MAJOR) && defined(GDBM_VERSION_MINOR) \
-    && GDBM_VERSION_MAJOR > 1 || \
-    (GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 9)
-typedef void (*FATALFUNC)(const char *);
+/* Indexes for gdbm_flags aliases */
+enum {
+    opt_flags = 0,
+    opt_cache_size,
+    opt_sync_mode,
+    opt_centfree,
+    opt_coalesce,
+    opt_dbname,
+    opt_block_size,
+    opt_mmap,
+    opt_mmapsize
+};
+
+/* Names of gdbm_flags aliases, for error reporting.
+   Indexed by opt_ constants above.
+*/
+char const *opt_names[] = {
+    "GDBM_File::flags",
+    "GDBM_File::cache_size",
+    "GDBM_File::sync_mode",
+    "GDBM_File::centfree",
+    "GDBM_File::coalesce",
+    "GDBM_File::dbname",
+    "GDBM_File::block_size",
+    "GDBM_File::mmap",
+    "GDBM_File::mmapsize"
+};    
+
+#ifdef GDBM_VERSION_MAJOR
+# define GDBM_VERSION_GUESS 0
 #else
-typedef void (*FATALFUNC)();
+/* Try educated guess
+ * The value of GDBM_VERSION_GUESS indicates how rough the guess is:
+ *   1 - Precise; based on the CVS logs and existing archives
+ *   2 - Moderate. The major and minor number are correct. The patchlevel
+ *       is set to the upper bound.
+ *   3 - Rough; The version is guaranteed to be not newer than major.minor.
+ */
+# if defined(GDBM_SYNCMODE)
+/* CHANGES from 1.7.3 to 1.8
+ *   1.  Added GDBM_CENTFREE functionality and option.
+ */  
+#  define GDBM_VERSION_MAJOR 1
+#  define GDBM_VERSION_MINOR 8
+#  define GDBM_VERSION_PATCH 3
+#  define GDBM_VERSION_GUESS 1
+# elif defined(GDBM_FASTMODE)
+/* CHANGES from 1.7.2 to 1.7.3
+ *  1.  Fixed a couple of last minute problems. (Namely, no autoconf.h in
+ *      version.c, and no GDBM_FASTMODE in gdbm.h!)
+ */
+#  define GDBM_VERSION_MAJOR 1
+#  define GDBM_VERSION_MINOR 7
+#  define GDBM_VERSION_PATCH 3
+#  define GDBM_VERSION_GUESS 1
+# elif defined(GDBM_FAST)
+/* From CVS logs:
+ * Mon May 17 12:32:02 1993  Phil Nelson  (phil at cs.wwu.edu)
+ *
+ * * gdbm.proto: Added GDBM_FAST to the read_write flags.
+ */
+#  define GDBM_VERSION_MAJOR 1
+#  define GDBM_VERSION_MINOR 7
+#  define GDBM_VERSION_PATCH 2
+#  define GDBM_VERSION_GUESS 2
+# else
+#  define GDBM_VERSION_MAJOR 1
+#  define GDBM_VERSION_MINOR 6
+#  define GDBM_VERSION_GUESS 3
+# endif
 #endif
 
-#ifndef GDBM_FAST
-static int
-not_here(char *s)
-{
-    croak("GDBM_File::%s not implemented on this architecture", s);
-    return -1;
+#ifndef GDBM_VERSION_PATCH
+# define GDBM_VERSION_PATCH 0
+#endif
+
+/* The use of fatal_func argument to gdbm_open is deprecated since 1.13 */
+#if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 13
+# define FATALFUNC NULL
+#elif GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 9
+# define FATALFUNC croak_string
+# define NEED_FATALFUNC 1
+#else
+# define FATALFUNC (void (*)()) croak_string
+# define NEED_FATALFUNC 1
+#endif
+
+#ifdef NEED_FATALFUNC
+static void
+croak_string(const char *message) {
+    Perl_croak_nocontext("%s", message);
 }
+#endif
+
+#define not_here(s) (croak("GDBM_File::%s not implemented", #s),-1)
+
+#if ! (GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 11)
+typedef unsigned gdbm_count_t;
 #endif
 
 /* GDBM allocates the datum with system malloc() and expects the user
@@ -62,10 +145,72 @@ output_datum(pTHX_ SV *arg, char *str, int size)
 #define gdbm_setopt(db,optflag,optval,optlen) not_here("gdbm_setopt")
 #endif
 
+#ifndef GDBM_ITEM_NOT_FOUND
+# define GDBM_ITEM_NOT_FOUND GDBM_NO_ERROR
+#endif
+
+/* Prior to 1.13, gdbm_fetch family functions set gdbm_errno to GDBM_NO_ERROR
+   if the requested key did not exist */
+#define ITEM_NOT_FOUND()                                                \
+    (gdbm_errno == GDBM_ITEM_NOT_FOUND || gdbm_errno == GDBM_NO_ERROR)
+
+#define CHECKDB(db) do {                        \
+    if (!db->dbp) {                             \
+        croak("database was closed");           \
+    }                                           \
+ } while (0)
+
 static void
-croak_string(const char *message) {
-    Perl_croak_nocontext("%s", message);
+dbcroak(GDBM_File db, char const *func)
+{
+#if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 13        
+    croak("%s: %s", func, gdbm_db_strerror(db->dbp));
+#else
+    (void)db;
+    croak("%s: %s", func, gdbm_strerror(gdbm_errno));
+#endif
 }
+
+#if GDBM_VERSION_MAJOR == 1 && (GDBM_VERSION_MINOR > 16 || GDBM_VERSION_PATCH >= 90)
+# define gdbm_close(db)    gdbm_close(db->dbp)
+#else
+# define gdbm_close(db)    (gdbm_close(db->dbp),0)
+#endif
+static int
+gdbm_file_close(GDBM_File db)
+{
+    int rc = 0;
+    if (db->dbp) {
+        rc = gdbm_close(db);
+        db->dbp = NULL;
+    }
+    return rc;
+}
+
+#if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 13
+/* Error-reporting wrapper for gdbm_recover */
+static void
+rcvr_errfun(void *cv, char const *fmt, ...)
+{
+    va_list ap;
+
+    dSP;
+
+    ENTER;
+    SAVETMPS;
+
+    PUSHMARK(SP);
+    va_start(ap, fmt);
+    XPUSHs(sv_2mortal(vnewSVpvf(fmt, &ap)));
+    va_end(ap);
+    PUTBACK;
+
+    call_sv((SV*)cv, G_DISCARD);
+
+    FREETMPS;
+    LEAVE;
+}
+#endif
 
 #include "const-c.inc"
 
@@ -73,6 +218,41 @@ MODULE = GDBM_File	PACKAGE = GDBM_File	PREFIX = gdbm_
 
 INCLUDE: const-xs.inc
 
+void
+gdbm_GDBM_version(package)
+        char *package;
+    PPCODE:
+	I32 gimme = GIMME_V;
+        if (gimme == G_VOID) {
+	    /* nothing */;
+        } else if (gimme == G_SCALAR) {
+	    static char const *guess[] = {
+		    "",
+		    " (exact guess)",
+		    " (approximate)",
+		    " (rough guess)"
+	    };
+ 	    if (GDBM_VERSION_PATCH > 0) {
+		XPUSHs(sv_2mortal(newSVpvf("%d.%d.%d%s",
+					   GDBM_VERSION_MAJOR,
+					   GDBM_VERSION_MINOR,
+					   GDBM_VERSION_PATCH,
+					   guess[GDBM_VERSION_GUESS])));
+	    } else {
+		XPUSHs(sv_2mortal(newSVpvf("%d.%d%s",
+					   GDBM_VERSION_MAJOR,
+					   GDBM_VERSION_MINOR,
+					   guess[GDBM_VERSION_GUESS])));
+	    }
+	} else {
+		XPUSHs(sv_2mortal(newSVuv(GDBM_VERSION_MAJOR)));
+		XPUSHs(sv_2mortal(newSVuv(GDBM_VERSION_MINOR)));
+		XPUSHs(sv_2mortal(newSVuv(GDBM_VERSION_PATCH)));
+		if (GDBM_VERSION_GUESS > 0) {
+			XPUSHs(sv_2mortal(newSVuv(GDBM_VERSION_GUESS)));
+		}
+	}
+	
 GDBM_File
 gdbm_TIEHASH(dbtype, name, read_write, mode)
 	char *		dbtype
@@ -82,7 +262,7 @@ gdbm_TIEHASH(dbtype, name, read_write, mode)
 	PREINIT:
 	GDBM_FILE dbp;
 	CODE:
-	dbp = gdbm_open(name, 0, read_write, mode, (FATALFUNC)croak_string);
+	dbp = gdbm_open(name, 0, read_write, mode, FATALFUNC);
 	if (!dbp && gdbm_errno == GDBM_BLOCK_SIZE_ERROR) {
 	    /*
 	     * By specifying a block size of 0 above, we asked gdbm to
@@ -93,8 +273,7 @@ gdbm_TIEHASH(dbtype, name, read_write, mode)
 	     * defaulting to fail.  In that case, force an acceptable
 	     * block size.
 	     */
-	    dbp = gdbm_open(name, 4096, read_write, mode,
-		    (FATALFUNC)croak_string);
+	    dbp = gdbm_open(name, 4096, read_write, mode, FATALFUNC);
 	}
 	if (dbp) {
 	    RETVAL = (GDBM_File)safecalloc(1, sizeof(GDBM_File_type));
@@ -105,31 +284,46 @@ gdbm_TIEHASH(dbtype, name, read_write, mode)
 	OUTPUT:
 	  RETVAL
 	
-
-#define gdbm_close(db)			gdbm_close(db->dbp)
-void
-gdbm_close(db)
-	GDBM_File	db
-	CLEANUP:
-
 void
 gdbm_DESTROY(db)
 	GDBM_File	db
 	PREINIT:
 	int i = store_value;
-	CODE:
-	gdbm_close(db);
+    CODE:
+        if (gdbm_file_close(db)) {
+            croak("gdbm_close: %s; %s", gdbm_strerror(gdbm_errno),
+                  strerror(errno));
+	}
 	do {
 	    if (db->filter[i])
 		SvREFCNT_dec(db->filter[i]);
 	} while (i-- > 0);
 	safefree(db);
 
+void
+gdbm_UNTIE(db, count)
+	GDBM_File	db
+        unsigned count
+    CODE:
+        if (count == 0) {
+            if (gdbm_file_close(db))
+                croak("gdbm_close: %s; %s",
+                      gdbm_strerror(gdbm_errno),
+                      strerror(errno));
+	}
+
+
 #define gdbm_FETCH(db,key)			gdbm_fetch(db->dbp,key)
 datum_value
 gdbm_FETCH(db, key)
 	GDBM_File	db
 	datum_key_copy	key
+    INIT:
+        CHECKDB(db);
+    CLEANUP:
+        if (RETVAL.dptr == NULL && !ITEM_NOT_FOUND()) {
+            dbcroak(db, "gdbm_fetch");
+        }
 
 #define gdbm_STORE(db,key,value,flags)		gdbm_store(db->dbp,key,value,flags)
 int
@@ -138,12 +332,11 @@ gdbm_STORE(db, key, value, flags = GDBM_REPLACE)
 	datum_key	key
 	datum_value	value
 	int		flags
+    INIT:
+        CHECKDB(db);
     CLEANUP:
 	if (RETVAL) {
-	    if (RETVAL < 0 && errno == EPERM)
-		croak("No write permission to gdbm file");
-	    croak("gdbm store returned %d, errno %d, key \"%.*s\"",
-			RETVAL,errno,key.dsize,key.dptr);
+	    dbcroak(db, "gdbm_store");
 	}
 
 #define gdbm_DELETE(db,key)			gdbm_delete(db->dbp,key)
@@ -151,35 +344,468 @@ int
 gdbm_DELETE(db, key)
 	GDBM_File	db
 	datum_key	key
+    INIT:
+        CHECKDB(db);
+    CLEANUP:
+        if (RETVAL && !ITEM_NOT_FOUND()) {
+            dbcroak(db, "gdbm_delete");
+        }
 
 #define gdbm_FIRSTKEY(db)			gdbm_firstkey(db->dbp)
 datum_key
 gdbm_FIRSTKEY(db)
 	GDBM_File	db
+    INIT:
+        CHECKDB(db);
+    CLEANUP:
+        if (RETVAL.dptr == NULL && !ITEM_NOT_FOUND()) {
+            dbcroak(db, "gdbm_firstkey");
+        }
 
 #define gdbm_NEXTKEY(db,key)			gdbm_nextkey(db->dbp,key)
 datum_key
 gdbm_NEXTKEY(db, key)
 	GDBM_File	db
 	datum_key	key 
-
-#define gdbm_reorganize(db)			gdbm_reorganize(db->dbp)
-int
-gdbm_reorganize(db)
-	GDBM_File	db
-
-
-#define gdbm_sync(db)				gdbm_sync(db->dbp)
-void
-gdbm_sync(db)
-	GDBM_File	db
+    INIT:
+        CHECKDB(db);
+    CLEANUP:
+        if (RETVAL.dptr == NULL && !ITEM_NOT_FOUND()) {
+            dbcroak(db, "gdbm_nextkey");
+        }
 
 #define gdbm_EXISTS(db,key)			gdbm_exists(db->dbp,key)
 int
 gdbm_EXISTS(db, key)
 	GDBM_File	db
 	datum_key	key
+    INIT:
+        CHECKDB(db);
 
+##
+    
+int
+gdbm_close(db)
+	GDBM_File	db
+    INIT:
+        CHECKDB(db);
+    CODE:
+        RETVAL = gdbm_file_close(db);
+    OUTPUT:
+        RETVAL
+
+int
+gdbm_errno(db)
+	GDBM_File	db
+    INIT:
+        CHECKDB(db);
+    CODE:
+#if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 13        
+        RETVAL = gdbm_last_errno(db->dbp);
+#else
+        RETVAL = gdbm_errno;
+#endif
+    OUTPUT:
+        RETVAL
+
+int
+gdbm_syserrno(db)
+	GDBM_File	db
+    INIT:
+        CHECKDB(db);
+    CODE:
+#if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 13
+    {
+        int ec = gdbm_last_errno(db->dbp);
+        if (gdbm_check_syserr(ec)) {
+            RETVAL = gdbm_last_syserr(db->dbp);
+        } else {
+            RETVAL = 0;
+        }
+    }
+#else
+        not_here("syserrno");
+#endif
+    OUTPUT:
+        RETVAL
+
+SV *
+gdbm_strerror(db)
+	GDBM_File	db
+    PREINIT:
+        char const *errstr;
+    INIT:
+        CHECKDB(db);
+    CODE:
+#if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 13        
+        errstr = gdbm_db_strerror(db->dbp);
+#else
+        errstr = gdbm_strerror(gdbm_errno);
+#endif
+        RETVAL = newSVpv(errstr, 0);            
+    OUTPUT:
+        RETVAL
+
+#if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 13        
+# define gdbm_clear_error(db)        gdbm_clear_error(db->dbp)
+#else
+# define gdbm_clear_error(db)        (gdbm_errno = 0)
+#endif        
+void
+gdbm_clear_error(db)
+	GDBM_File	db
+    INIT:
+        CHECKDB(db);
+
+#if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 13        
+# define gdbm_needs_recovery(db)     gdbm_needs_recovery(db->dbp)
+#else
+# define gdbm_needs_recovery(db)     not_here("gdbm_needs_recovery")
+#endif        
+int            
+gdbm_needs_recovery(db)
+	GDBM_File	db
+    INIT:
+        CHECKDB(db);
+            
+#define gdbm_reorganize(db)			gdbm_reorganize(db->dbp)
+int
+gdbm_reorganize(db)
+	GDBM_File	db
+    INIT:
+        CHECKDB(db);
+
+
+# Arguments:
+#   err => sub { ... }
+#   max_failed_keys => $n
+#   max_failed_buckets => $n
+#   max_failures => $n
+#   backup => \$str
+#   stat => \%hash            
+
+#if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 13
+
+void
+gdbm_recover(db, ...)
+	GDBM_File	db
+    PREINIT:
+        int flags = GDBM_RCVR_FORCE;
+        SV *backup_ref = &PL_sv_undef;
+        SV *stat_ref = &PL_sv_undef;
+        gdbm_recovery rcvr;
+    INIT:
+        CHECKDB(db);
+    CODE:
+        if (items > 1) {
+            int i;
+            if ((items % 2) == 0) {
+                croak("bad number of arguments");
+            }
+            for (i = 1; i < items; i += 2) {
+                char *kw;
+                SV *sv = ST(i);
+                SV *val = ST(i+1);
+
+                if (!SvPOK(sv))
+                    croak("bad arguments near #%d", i);
+                kw = SvPV_nolen(sv);
+                if (strcmp(kw, "err") == 0) {
+                    if (SvROK(val) && SvTYPE(SvRV(val)) == SVt_PVCV) {
+                        rcvr.data = SvRV(val);
+                    } else {
+                        croak("%s must be a code ref", kw);
+                    }
+                    rcvr.errfun = rcvr_errfun;
+                    flags |= GDBM_RCVR_ERRFUN;
+                } else if (strcmp(kw, "max_failed_keys") == 0) {
+                    if (SvIOK(val)) {
+                        rcvr.max_failed_keys = SvUV(val);
+                    } else {
+                        croak("max_failed_keys must be numeric");
+                    }
+                    flags |= GDBM_RCVR_MAX_FAILED_KEYS;
+                } else if (strcmp(kw, "max_failed_buckets") == 0) {
+                    if (SvIOK(val)) {
+                        rcvr.max_failed_buckets = SvUV(val);
+                    } else {
+                        croak("max_failed_buckets must be numeric");
+                    }
+                    flags |= GDBM_RCVR_MAX_FAILED_BUCKETS;
+                } else if (strcmp(kw, "max_failures") == 0) {
+                    if (SvIOK(val)) {
+                        rcvr.max_failures = SvUV(val);
+                    } else {
+                        croak("max_failures must be numeric");
+                    }
+                    flags |= GDBM_RCVR_MAX_FAILURES;
+                } else if (strcmp(kw, "backup") == 0) {
+                    if (SvROK(val) && SvTYPE(SvRV(val)) < SVt_PVAV) {
+                        backup_ref = val;
+                    } else {
+                        croak("backup must be a scalar reference");
+                    } 
+                    flags |= GDBM_RCVR_BACKUP;
+                } else if (strcmp(kw, "stat") == 0) {
+                    if (SvROK(val) && SvTYPE(SvRV(val)) == SVt_PVHV) {
+                        stat_ref = val;
+                    } else {
+                        croak("backup must be a scalar reference");
+                    } 
+                } else {
+                    croak("%s: unrecognized argument", kw);
+                }
+            }
+        }
+        if (gdbm_recover(db->dbp, &rcvr, flags)) {
+            dbcroak(db, "gdbm_recover");
+        }
+        if (stat_ref != &PL_sv_undef) {
+            HV *hv = (HV*)SvRV(stat_ref);
+#define STAT_RECOVERED_KEYS_STR "recovered_keys"
+#define STAT_RECOVERED_KEYS_LEN (sizeof(STAT_RECOVERED_KEYS_STR)-1)
+#define STAT_RECOVERED_BUCKETS_STR "recovered_buckets"
+#define STAT_RECOVERED_BUCKETS_LEN (sizeof(STAT_RECOVERED_BUCKETS_STR)-1)
+#define STAT_FAILED_KEYS_STR "failed_keys"
+#define STAT_FAILED_KEYS_LEN (sizeof(STAT_FAILED_KEYS_STR)-1)
+#define STAT_FAILED_BUCKETS_STR "failed_buckets"
+#define STAT_FAILED_BUCKETS_LEN (sizeof(STAT_FAILED_BUCKETS_STR)-1)
+            hv_store(hv, STAT_RECOVERED_KEYS_STR, STAT_RECOVERED_KEYS_LEN,
+                     newSVuv(rcvr.recovered_keys), 0);
+            hv_store(hv,
+                     STAT_RECOVERED_BUCKETS_STR,
+                     STAT_RECOVERED_BUCKETS_LEN,
+                     newSVuv(rcvr.recovered_buckets), 0);
+            hv_store(hv,
+                     STAT_FAILED_KEYS_STR,
+                     STAT_FAILED_KEYS_LEN,
+                     newSVuv(rcvr.failed_keys), 0);
+            hv_store(hv,
+                     STAT_FAILED_BUCKETS_STR,
+                     STAT_FAILED_BUCKETS_LEN,
+                     newSVuv(rcvr.failed_buckets), 0);
+        }
+        if (backup_ref != &PL_sv_undef) {
+            SV *sv = SvRV(backup_ref);
+            sv_setpv(sv, rcvr.backup_name);
+            free(rcvr.backup_name);
+        }
+
+#endif
+
+#if GDBM_VERSION_MAJOR == 1 && (GDBM_VERSION_MINOR > 16 || GDBM_VERSION_PATCH >= 90)
+# define gdbm_sync(db)				gdbm_sync(db->dbp)
+#else
+# define gdbm_sync(db)				(gdbm_sync(db->dbp),0)
+#endif
+int
+gdbm_sync(db)
+	GDBM_File	db
+    INIT:
+        CHECKDB(db);
+    CLEANUP:
+        if (RETVAL) {
+            dbcroak(db, "gdbm_sync");
+        }
+
+#if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 11
+
+gdbm_count_t
+gdbm_count(db)            
+	GDBM_File	db
+   PREINIT:
+        gdbm_count_t c;
+   INIT:
+        CHECKDB(db);
+   CODE:
+        if (gdbm_count(db->dbp, &c)) {
+            dbcroak(db, "gdbm_count");
+        }
+        RETVAL = c;
+   OUTPUT:
+        RETVAL
+
+#endif
+        
+#define OPTNAME(a,b) a ## b        
+#define INTOPTSETUP(opt)                                           \
+        do {                                                       \
+            if (items == 1) {                                      \
+                opcode = OPTNAME(GDBM_GET, opt);                   \
+            } else {                                               \
+                opcode = OPTNAME(GDBM_SET, opt);                   \
+                sv = ST(1);                                        \
+                if (!SvIOK(sv)) {                                  \
+                    croak("%s: bad argument type", opt_names[ix]); \
+                }                                                  \
+                c_iv = SvIV(sv);                                   \
+            }                                                      \
+        } while (0)
+
+#if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 9
+# define OPTVALPTR void *
+#else
+# define OPTVALPTR int *
+#endif        
+        
+# GDBM_GET defines appeared in version 1.9 (2011-08-12).
+#
+# Provide definitions for earlier versions. These will cause gdbm_setopt
+# to fail with GDBM_OPT_ILLEGAL
+
+#ifndef GDBM_GETFLAGS        
+# define GDBM_GETFLAGS        -1
+#endif
+#ifndef GDBM_GETMMAP        
+# define GDBM_GETMMAP         -1
+#endif
+#ifndef GDBM_GETCACHESIZE        
+# define GDBM_GETCACHESIZE    -1
+#endif
+#ifndef GDBM_GETSYNCMODE
+# define GDBM_GETSYNCMODE     -1
+#endif
+#ifndef GDBM_GETCENTFREE              
+# define GDBM_GETCENTFREE     -1
+#endif
+#ifndef GDBM_GETCOALESCEBLKS
+# define GDBM_GETCOALESCEBLKS -1
+#endif
+#ifndef GDBM_GETMAXMAPSIZE
+# define GDBM_GETMAXMAPSIZE   -1
+#endif
+#ifndef GDBM_GETDBNAME
+# define GDBM_GETDBNAME       -1
+#endif
+#ifndef GDBM_GETBLOCKSIZE
+# define GDBM_GETBLOCKSIZE    -1
+#endif
+
+# These two appeared in version 1.10:
+        
+#ifndef GDBM_SETMAXMAPSIZE        
+# define GDBM_SETMAXMAPSIZE   -1
+#endif
+#ifndef GDBM_SETMMAP        
+# define GDBM_SETMMAP         -1
+#endif
+        
+# These GDBM_SET defines appeared in 1.10, replacing obsolete opcodes.
+# Provide definitions for older versions
+        
+#ifndef GDBM_SETCACHESIZE        
+# define GDBM_SETCACHESIZE    GDBM_CACHESIZE
+#endif        
+#ifndef GDBM_SETSYNCMODE
+# define GDBM_SETSYNCMODE     GDBM_SYNCMODE
+#endif        
+#ifndef GDBM_SETCENTFREE
+# define GDBM_SETCENTFREE     GDBM_CENTFREE
+#endif        
+#ifndef GDBM_SETCOALESCEBLKS
+# define GDBM_SETCOALESCEBLKS GDBM_COALESCEBLKS
+#endif
+
+SV *
+gdbm_flags(db, ...)       
+	GDBM_File	db
+	SV *		RETVAL = &PL_sv_undef;
+    ALIAS:
+        GDBM_File::cache_size = opt_cache_size 
+        GDBM_File::sync_mode  = opt_sync_mode  
+        GDBM_File::centfree   = opt_centfree   
+        GDBM_File::coalesce   = opt_coalesce
+        GDBM_File::dbname     = opt_dbname
+        GDBM_File::block_size = opt_block_size
+        GDBM_File::mmap       = opt_mmap    
+        GDBM_File::mmapsize   = opt_mmapsize
+    PREINIT:
+        int opcode = -1;
+        int c_iv;
+        unsigned c_uv;
+        char *c_cv;
+        OPTVALPTR vptr = (OPTVALPTR) &c_iv;
+        size_t vsiz = sizeof(c_iv);
+        SV *sv;
+    INIT:
+        CHECKDB(db);
+    CODE:
+        if (items > 2) {
+            croak("%s: too many arguments", opt_names[ix]);
+        }
+            
+        switch (ix) {
+        case opt_flags:
+            if (items > 1) {
+                croak("%s: too many arguments", opt_names[ix]);
+            }
+            opcode = GDBM_GETFLAGS;
+            break;
+        case opt_cache_size:
+            INTOPTSETUP(CACHESIZE);
+            break;
+        case opt_sync_mode:
+            INTOPTSETUP(SYNCMODE);
+            break;
+        case opt_centfree:
+            INTOPTSETUP(CENTFREE);
+            break;
+        case opt_coalesce:
+            INTOPTSETUP(COALESCEBLKS);
+            break;
+        case opt_dbname:
+            if (items > 1) {
+                croak("%s: too many arguments", opt_names[ix]);
+            }
+            opcode = GDBM_GETDBNAME;
+            vptr = (OPTVALPTR) &c_cv;
+            vsiz = sizeof(c_cv);
+            break;
+        case opt_block_size:
+            if (items > 1) {
+                croak("%s: too many arguments", opt_names[ix]);
+            }
+            opcode = GDBM_GETBLOCKSIZE;
+            break;
+        case opt_mmap:
+            if (items > 1) {
+                croak("%s: too many arguments", opt_names[ix]);
+            }
+            opcode = GDBM_GETMMAP;
+            break;
+        case opt_mmapsize:
+            vptr = (OPTVALPTR) &c_uv;
+            vsiz = sizeof(c_uv);
+            if (items == 1) {                             
+                opcode = GDBM_GETMAXMAPSIZE;
+            } else {                                      
+                opcode = GDBM_SETMAXMAPSIZE;
+                sv = ST(1);                               
+                if (!SvUOK(sv)) {                         
+                    croak("%s: bad argument type", opt_names[ix]);           
+                }                                         
+                c_uv = SvUV(sv);                          
+            }                                             
+            break;
+        }
+
+        if (gdbm_setopt(db->dbp, opcode, vptr, vsiz)) {
+            if (gdbm_errno == GDBM_OPT_ILLEGAL)
+                croak("%s not implemented", opt_names[ix]);
+            dbcroak(db, "gdbm_setopt");
+        }
+
+        if (vptr == (OPTVALPTR) &c_iv) {
+            RETVAL = newSViv(c_iv);
+        } else if (vptr == (OPTVALPTR) &c_uv) {
+            RETVAL = newSVuv(c_uv);
+        } else {
+            RETVAL = newSVpv(c_cv, 0);
+            free(c_cv);
+        }
+    OUTPUT:
+        RETVAL
+            
 #define gdbm_setopt(db,optflag, optval, optlen)	gdbm_setopt(db->dbp,optflag, optval, optlen)
 int
 gdbm_setopt (db, optflag, optval, optlen)
@@ -187,17 +813,23 @@ gdbm_setopt (db, optflag, optval, optlen)
 	int		optflag
 	int		&optval
 	int		optlen
-
+    INIT:
+        CHECKDB(db);
+    CLEANUP:
+        if (RETVAL) {
+            dbcroak(db, "gdbm_setopt");
+        }
 
 SV *
 filter_fetch_key(db, code)
 	GDBM_File	db
 	SV *		code
 	SV *		RETVAL = &PL_sv_undef ;
-	ALIAS:
+    ALIAS:
 	GDBM_File::filter_fetch_key = fetch_key
 	GDBM_File::filter_store_key = store_key
 	GDBM_File::filter_fetch_value = fetch_value
 	GDBM_File::filter_store_value = store_value
-	CODE:
-	    DBM_setFilter(db->filter[ix], code);
+    CODE:
+        DBM_setFilter(db->filter[ix], code);
+

--- a/ext/GDBM_File/GDBM_File.xs
+++ b/ext/GDBM_File/GDBM_File.xs
@@ -192,9 +192,9 @@ gdbm_file_close(GDBM_File db)
 static void
 rcvr_errfun(void *cv, char const *fmt, ...)
 {
-    va_list ap;
-
+    dTHX;
     dSP;
+    va_list ap;
 
     ENTER;
     SAVETMPS;
@@ -220,7 +220,6 @@ INCLUDE: const-xs.inc
 
 void
 gdbm_GDBM_version(package)
-        char *package;
     PPCODE:
 	I32 gimme = GIMME_V;
         if (gimme == G_VOID) {

--- a/ext/GDBM_File/t/count.t
+++ b/ext/GDBM_File/t/count.t
@@ -3,6 +3,8 @@ use strict;
 
 use Test::More;
 use Config;
+use File::Temp 'tempdir';
+use File::Spec;
 
 BEGIN {
     plan(skip_all => "GDBM_File was not built")
@@ -16,10 +18,12 @@ BEGIN {
     use_ok('GDBM_File');
  }
 
-unlink <Op_dbmx*>;
+my $wd = tempdir(CLEANUP => 1);
 
 my %h;
-my $db = tie(%h, 'GDBM_File', 'Op_dbmx', GDBM_WRCREAT, 0640);
+my $db = tie(%h, 'GDBM_File', File::Spec->catfile($wd, 'Op_dbmx'),
+             GDBM_WRCREAT, 0640);
+
 isa_ok($db, 'GDBM_File');
 SKIP: {
      skip 'GDBM_File::count not available', 1
@@ -31,4 +35,3 @@ SKIP: {
      is($db->count, 3, 'count');
 }
 
-unlink <Op_dbmx*>;

--- a/ext/GDBM_File/t/count.t
+++ b/ext/GDBM_File/t/count.t
@@ -1,0 +1,34 @@
+#!./perl -w
+use strict;
+
+use Test::More;
+use Config;
+
+BEGIN {
+    plan(skip_all => "GDBM_File was not built")
+	unless $Config{extensions} =~ /\bGDBM_File\b/;
+
+    # https://rt.perl.org/Public/Bug/Display.html?id=117967
+    plan(skip_all => "GDBM_File is flaky in $^O")
+        if $^O =~ /darwin/;
+
+    plan(tests => 3);
+    use_ok('GDBM_File');
+ }
+
+unlink <Op_dbmx*>;
+
+my %h;
+my $db = tie(%h, 'GDBM_File', 'Op_dbmx', GDBM_WRCREAT, 0640);
+isa_ok($db, 'GDBM_File');
+SKIP: {
+     skip 'GDBM_File::count not available', 1
+        unless $db->can('count'); 
+
+     $h{one} = '1';
+     $h{two} = '2';
+     $h{three} = '3';
+     is($db->count, 3, 'count');
+}
+
+unlink <Op_dbmx*>;

--- a/ext/GDBM_File/t/fatal.t
+++ b/ext/GDBM_File/t/fatal.t
@@ -11,6 +11,8 @@ use strict;
 
 use Test::More;
 use Config;
+use File::Temp 'tempdir';
+use File::Spec;
 
 BEGIN {
     plan(skip_all => "GDBM_File was not built")
@@ -24,8 +26,6 @@ BEGIN {
     use_ok('GDBM_File');
 }
 
-unlink <fatal_dbmx*>;
-
 open my $fh, '<', $^X or die "Can't open $^X: $!";
 my $fileno = fileno $fh;
 isnt($fileno, undef, "Can find next available file descriptor");
@@ -35,8 +35,10 @@ is((open $fh, "<&=$fileno"), undef,
    "Check that we cannot open fileno $fileno. \$! is $!");
 
 umask(0);
+my $wd = tempdir(CLEANUP => 1);
 my %h;
-isa_ok(tie(%h, 'GDBM_File', 'fatal_dbmx', GDBM_WRCREAT, 0640), 'GDBM_File');
+isa_ok(tie(%h, 'GDBM_File', File::Spec->catfile($wd, 'fatal_dbmx'),
+           GDBM_WRCREAT, 0640), 'GDBM_File');
 
 isnt((open $fh, "<&=$fileno"), undef, "dup fileno $fileno")
     or diag("\$! = $!");
@@ -63,4 +65,3 @@ SKIP: {
          'expected error message from GDBM_File');
 }
 
-unlink <fatal_dbmx*>;

--- a/ext/GDBM_File/t/opt.t
+++ b/ext/GDBM_File/t/opt.t
@@ -1,0 +1,37 @@
+#!./perl -w
+use strict;
+
+use Test::More;
+use Config;
+
+BEGIN {
+    plan(skip_all => "GDBM_File was not built")
+	unless $Config{extensions} =~ /\bGDBM_File\b/;
+
+    # https://rt.perl.org/Public/Bug/Display.html?id=117967
+    plan(skip_all => "GDBM_File is flaky in $^O")
+        if $^O =~ /darwin/;
+
+    plan(tests => 8);
+    use_ok('GDBM_File');
+}
+
+unlink <Op_dbmx*>;
+
+my %h;
+my $db = tie(%h, 'GDBM_File', 'Op_dbmx', GDBM_WRCREAT, 0640);
+isa_ok($db, 'GDBM_File');
+SKIP: {
+     my $name = eval { $db->dbname } or do {
+         skip "gdbm_setopt GET calls not implemented", 6
+             if $@ =~ /GDBM_File::dbname not implemented/;
+     };
+     is($db->dbname, 'Op_dbmx', 'get dbname');
+     is(eval { $db->dbname("a"); }, undef, 'dbname - bad usage');
+     is($db->flags, GDBM_WRCREAT, 'get flags');
+     is($db->sync_mode, 0, 'get sync_mode');
+     is($db->sync_mode(1), 1, 'set sync_mode');
+     is($db->sync_mode, 1, 'get sync_mode');
+}
+
+unlink <Op_dbmx*>;

--- a/ext/GDBM_File/t/opt.t
+++ b/ext/GDBM_File/t/opt.t
@@ -3,6 +3,8 @@ use strict;
 
 use Test::More;
 use Config;
+use File::Temp 'tempdir';
+use File::Spec;
 
 BEGIN {
     plan(skip_all => "GDBM_File was not built")
@@ -16,22 +18,20 @@ BEGIN {
     use_ok('GDBM_File');
 }
 
-unlink <Op_dbmx*>;
-
+my $wd = tempdir(CLEANUP => 1);
+my $dbname = File::Spec->catfile($wd, 'Op_dbmx');
 my %h;
-my $db = tie(%h, 'GDBM_File', 'Op_dbmx', GDBM_WRCREAT, 0640);
+my $db = tie(%h, 'GDBM_File', $dbname, GDBM_WRCREAT, 0640);
 isa_ok($db, 'GDBM_File');
 SKIP: {
      my $name = eval { $db->dbname } or do {
          skip "gdbm_setopt GET calls not implemented", 6
              if $@ =~ /GDBM_File::dbname not implemented/;
      };
-     is($db->dbname, 'Op_dbmx', 'get dbname');
+     is($db->dbname, $dbname, 'get dbname');
      is(eval { $db->dbname("a"); }, undef, 'dbname - bad usage');
      is($db->flags, GDBM_WRCREAT, 'get flags');
      is($db->sync_mode, 0, 'get sync_mode');
      is($db->sync_mode(1), 1, 'set sync_mode');
      is($db->sync_mode, 1, 'get sync_mode');
 }
-
-unlink <Op_dbmx*>;

--- a/ext/GDBM_File/typemap
+++ b/ext/GDBM_File/typemap
@@ -11,6 +11,7 @@ SDBM_File		T_PTROBJ
 ODBM_File		T_PTROBJ
 DB_File			T_PTROBJ
 DBZ_File		T_PTROBJ
+gdbm_count_t            T_COUNT
 
 INPUT
 T_DATUM_K
@@ -54,3 +55,5 @@ T_DATUM_V
 	DBM_ckFilter($arg, filter[fetch_value],\"filter_fetch_value\");
 T_PTROBJ
         sv_setref_pv($arg, dbtype, (void*)$var);
+T_COUNT
+        sv_setuv($arg, (UV)$var);

--- a/ext/GDBM_File/typemap
+++ b/ext/GDBM_File/typemap
@@ -11,7 +11,7 @@ SDBM_File		T_PTROBJ
 ODBM_File		T_PTROBJ
 DB_File			T_PTROBJ
 DBZ_File		T_PTROBJ
-gdbm_count_t            T_COUNT
+gdbm_count_t            T_UV
 
 INPUT
 T_DATUM_K
@@ -55,5 +55,3 @@ T_DATUM_V
 	DBM_ckFilter($arg, filter[fetch_value],\"filter_fetch_value\");
 T_PTROBJ
         sv_setref_pv($arg, dbtype, (void*)$var);
-T_COUNT
-        sv_setuv($arg, (UV)$var);


### PR DESCRIPTION
This patch implements new functions and improves compatibility with new versions of GDBM.

* ext/GDBM_File/GDBM_File.xs: Define interface methods for
functions in newer GDBM versions.
(GDBM_version): New static method.  Return the version number
(string in scalar, array of numbers in list context).  Provide
heurisics for determining the library version for GDBM prior
to 1.9.
(gdbm_close): Propagate return value from the library call.
(gdbm_DESTROY): Croak if closing the database fails.
(gdbm_UNTIE): New method.
(gdbm_FETCH): Check database validity. Croak if gdbm_fetch returns
error (except GDBM_ITEM_NOT_FOUND).
(gdbm_STORE,gdbm_DELETE): Likewise.
(gdbm_FIRSTKEY,gdbm_NEXTKEY): Likewise.
(gdbm_EXISTS): Check database validity.
(gdbm_errno): New function.
(gdbm_syserrno): New function.
(gdbm_strerror): New function.
(gdbm_clear_error): New function.
(gdbm_needs_recovery): New function.
(gdbm_recover): New function.
(gdbm_count): New function.
* ext/GDBM_File/typemap (gdbm_count_t): Map to T_COUNT.
* ext/GDBM_File/GDBM_File.pm: Document everything. Raise $VERSION.

* MANIFEST: Update.
* AUTHORS: Update.