### PR TITLE
perlfunc: explicitly warn against redeclaring lexical variables with my()

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -166,6 +166,19 @@ section.
 
 Additionally, the following selected changes have been made:
 
+=head3 L<perlfunc>
+
+=over 4
+
+=item *
+
+L<my()|perlfunc/my> and L<state()|perlfunc/state> now explicitly warn
+the reader that lexical variables should typically not be redeclared
+within the same scope or statement.
+L<[#18389]|https://github.com/Perl/perl5/issues/18389>
+
+=back
+
 =head3 L<XXX>
 
 =over 4

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4350,6 +4350,17 @@ A L<C<my>|/my VARLIST> declares the listed variables to be local
 more than one variable is listed, the list must be placed in
 parentheses.
 
+Note that with a parenthesised list, L<C<undef>|/undef EXPR> can be used
+as a dummy placeholder, for example to skip assignment of initial
+values:
+
+    my ( undef, $min, $hour ) = localtime;
+
+Redeclaring a variable in the same scope or statement will "shadow" the
+previous declaration, creating a new instance and preventing access to
+the previous one. This is usually undesired and, if warnings are enabled,
+will result in a warning in the C<shadow> category.
+
 The exact semantics and interface of TYPE and ATTRS are still
 evolving.  TYPE may be a bareword, a constant declared
 with L<C<use constant>|constant>, or L<C<__PACKAGE__>|/__PACKAGE__>.  It
@@ -4358,12 +4369,6 @@ currently bound to the use of the L<fields> pragma,
 and attributes are handled using the L<attributes> pragma, or starting
 from Perl 5.8.0 also via the L<Attribute::Handlers> module.  See
 L<perlsub/"Private Variables via my()"> for details.
-
-Note that with a parenthesised list, L<C<undef>|/undef EXPR> can be used
-as a dummy placeholder, for example to skip assignment of initial
-values:
-
-    my ( undef, $min, $hour ) = localtime;
 
 =item next LABEL
 X<next> X<continue>
@@ -8577,6 +8582,11 @@ parentheses.  With a parenthesised list, L<C<undef>|/undef EXPR> can be
 used as a
 dummy placeholder.  However, since initialization of state variables in
 such lists is currently not possible this would serve no purpose.
+
+Redeclaring a variable in the same scope or statement will "shadow" the
+previous declaration, creating a new instance and preventing access to
+the previous one. This is usually undesired and, if warnings are enabled,
+will result in a warning in the C<shadow> category.
 
 L<C<state>|/state VARLIST> is available only if the
 L<C<"state"> feature|feature/The 'state' feature> is enabled or if it is

--- a/t/lib/warnings/pad
+++ b/t/lib/warnings/pad
@@ -47,11 +47,13 @@ EXPECT
 "my" variable $p masks earlier declaration in same scope at - line 8.
 ########
 # pad.c
+use feature 'state' ;
 use warnings 'shadow' ;
 our $x ;
 my $x ;
+state $x ;
 our $y = my $y ;
-our $p ;
+our $p = state $p ;
 package X ;
 my $p ;
 package main ;
@@ -59,20 +61,51 @@ no warnings 'shadow' ;
 our $z ;
 my $z ;
 our $t = my $t ;
-our $q ;
+our $q = state $q ;
 package X ;
 my $q ;
+state $q;
 EXPECT
-"my" variable $x masks earlier declaration in same scope at - line 4.
-"my" variable $y masks earlier declaration in same statement at - line 5.
-"my" variable $p masks earlier declaration in same scope at - line 8.
+"my" variable $x masks earlier declaration in same scope at - line 5.
+"state" variable $x masks earlier declaration in same scope at - line 6.
+"my" variable $y masks earlier declaration in same statement at - line 7.
+"state" variable $p masks earlier declaration in same statement at - line 8.
+"my" variable $p masks earlier declaration in same scope at - line 10.
 ########
 # pad.c
+use feature 'state' ;
+use warnings 'shadow';
+state $x ;
+state $x ;
+my $x ;
+our $x ;
+state $y = state $y ;
+state $p = my $p ;
+state $z = our $z ;
+package X ;
+state $p ;
+package main ;
+no warnings 'shadow' ;
+state $x ;
+state $y ;
+state $p ;
+EXPECT
+"state" variable $x masks earlier declaration in same scope at - line 5.
+"my" variable $x masks earlier declaration in same scope at - line 6.
+"our" variable $x masks earlier declaration in same scope at - line 7.
+"state" variable $y masks earlier declaration in same statement at - line 8.
+"my" variable $p masks earlier declaration in same statement at - line 9.
+"our" variable $z masks earlier declaration in same statement at - line 10.
+"state" variable $p masks earlier declaration in same scope at - line 12.
+########
+# pad.c
+use feature 'state';
 use warnings 'shadow' ;
 my $x ;
 our $x ;
+state $x;
 my $y = our $y ;
-my $p ;
+my $p = state $p ;
 package X ;
 our $p ;
 package main ;
@@ -80,13 +113,17 @@ no warnings 'shadow' ;
 my $z ;
 our $z ;
 my $t = our $t ;
-my $q ;
+my $z = state $z;
+my $q;
+state $q;
 package X ;
 our $q ;
 EXPECT
-"our" variable $x masks earlier declaration in same scope at - line 4.
-"our" variable $y masks earlier declaration in same statement at - line 5.
-"our" variable $p masks earlier declaration in same scope at - line 8.
+"our" variable $x masks earlier declaration in same scope at - line 5.
+"state" variable $x masks earlier declaration in same scope at - line 6.
+"our" variable $y masks earlier declaration in same statement at - line 7.
+"state" variable $p masks earlier declaration in same statement at - line 8.
+"our" variable $p masks earlier declaration in same scope at - line 10.
 ########
 # pad.c
 use warnings 'closure' ;


### PR DESCRIPTION
Addresses a concern raised in #18389. The new text is based upon the already-existing error description in perldiag.pod.