### PR TITLE
Use perl.h versions of PERL_UNUSED_foo in XSUB.h

### DIFF
--- a/XSUB.h
+++ b/XSUB.h
@@ -108,10 +108,10 @@ is a lexical C<$_> in scope.
 */
 
 #ifndef PERL_UNUSED_ARG
-#  define PERL_UNUSED_ARG(x) ((void)x)
+#  define PERL_UNUSED_ARG(x) ((void)sizeof(x))
 #endif
 #ifndef PERL_UNUSED_VAR
-#  define PERL_UNUSED_VAR(x) ((void)x)
+#  define PERL_UNUSED_VAR(x) ((void)sizeof(x))
 #endif
 
 #define ST(off) PL_stack_base[ax + (off)]


### PR DESCRIPTION
This commit was applied to perl.h, but not to XSUB.h:

commit a730e3f230f364cffe49370f816f975ae7c9c403
Author: Jarkko Hietaniemi <jhi@iki.fi>
Date:   Thu Sep 4 09:08:33 2014 -0400

Use sizeof() in UNUSED_ARG and UNUSED_VAR to avoid accessing the values.

The values might even be uninitialized in the case of PERL_UNUSED_VAR.