### PR TITLE
Remove inheritance from Exporter in ext/ modules

### DIFF
--- a/ext/Amiga-ARexx/ARexx.pm
+++ b/ext/Amiga-ARexx/ARexx.pm
@@ -5,10 +5,7 @@ use strict;
 use warnings;
 use Carp;
 
-require Exporter;
-#use AutoLoader;
-
-our @ISA = qw(Exporter);
+use Exporter 'import';
 
 # Items to export into callers namespace by default. Note: do not export
 # names by default without a very good reason. Use EXPORT_OK instead.
@@ -26,7 +23,7 @@ our @EXPORT_OK = ( @{ $EXPORT_TAGS{'all'} } );
 our @EXPORT = qw(
 );
 
-our $VERSION = '0.05';
+our $VERSION = '0.06';
 
 require XSLoader;
 XSLoader::load('Amiga::ARexx', $VERSION);

--- a/ext/Amiga-Exec/Exec.pm
+++ b/ext/Amiga-Exec/Exec.pm
@@ -5,10 +5,7 @@ use strict;
 use warnings;
 use Carp;
 
-require Exporter;
-#use AutoLoader;
-
-our @ISA = qw(Exporter);
+use Exporter 'import';
 
 # Items to export into callers namespace by default. Note: do not export
 # names by default without a very good reason. Use EXPORT_OK instead.
@@ -26,7 +23,7 @@ our @EXPORT_OK = ( @{ $EXPORT_TAGS{'all'} } );
 our @EXPORT = qw(
 );
 
-our $VERSION = '0.02';
+our $VERSION = '0.03';
 
 require XSLoader;
 XSLoader::load('Amiga::Exec', $VERSION);

--- a/ext/B/B/Concise.pm
+++ b/ext/B/B/Concise.pm
@@ -12,10 +12,9 @@ package B::Concise;
 use strict; # use #2
 use warnings; # uses #3 and #4, since warnings uses Carp
 
-use Exporter (); # use #5
+use Exporter 'import'; # use #5
 
-our $VERSION   = "1.004";
-our @ISA       = qw(Exporter);
+our $VERSION   = "1.005";
 our @EXPORT_OK = qw( set_style set_style_standard add_callback
 		     concise_subref concise_cv concise_main
 		     add_style walk_output compile reset_sequence );

--- a/ext/Devel-Peek/Peek.pm
+++ b/ext/Devel-Peek/Peek.pm
@@ -3,14 +3,13 @@
 
 package Devel::Peek;
 
-$VERSION = '1.30';
+$VERSION = '1.31';
 $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
 require Exporter;
 require XSLoader;
 
-@ISA = qw(Exporter);
 @EXPORT = qw(Dump mstat DeadCode DumpArray DumpWithOP DumpProg
 	     fill_mstats mstats_fillhash mstats2hash runops_debug debug_flags);
 @EXPORT_OK = qw(SvREFCNT CvGV);

--- a/ext/Errno/Errno_pm.PL
+++ b/ext/Errno/Errno_pm.PL
@@ -2,7 +2,7 @@ use ExtUtils::MakeMaker;
 use Config;
 use strict;
 
-our $VERSION = "1.33";
+our $VERSION = "1.34";
 
 my %err = ();
 
@@ -284,7 +284,7 @@ sub write_errno_pm {
 #
 
 package Errno;
-require Exporter;
+use Exporter 'import';
 use strict;
 
 EDQ
@@ -305,7 +305,6 @@ CONFIG_CHECK_END
     print <<"EDQ";
 our \$VERSION = "$VERSION";
 \$VERSION = eval \$VERSION;
-our \@ISA = 'Exporter';
 
 my %err;
 

--- a/ext/ExtUtils-Miniperl/lib/ExtUtils/Miniperl.pm
+++ b/ext/ExtUtils-Miniperl/lib/ExtUtils/Miniperl.pm
@@ -1,12 +1,11 @@
 #!./perl -w
 package ExtUtils::Miniperl;
 use strict;
-require Exporter;
+use Exporter 'import';
 use ExtUtils::Embed 1.31, qw(xsi_header xsi_protos xsi_body);
 
-our @ISA = qw(Exporter);
 our @EXPORT = qw(writemain);
-our $VERSION = '1.10';
+our $VERSION = '1.11';
 
 # blead will run this with miniperl, hence we can't use autodie or File::Temp
 my $temp;

--- a/ext/Fcntl/Fcntl.pm
+++ b/ext/Fcntl/Fcntl.pm
@@ -56,17 +56,15 @@ See L<perlfunc/stat> about the S_I* constants.
 =cut
 
 use strict;
-our($VERSION, @ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
 
-require Exporter;
+use Exporter 'import';
 require XSLoader;
-@ISA = qw(Exporter);
-$VERSION = '1.14';
+our $VERSION = '1.15';
 
 XSLoader::load();
 
 # Named groups of exports
-%EXPORT_TAGS = (
+our %EXPORT_TAGS = (
     'flock'   => [qw(LOCK_SH LOCK_EX LOCK_NB LOCK_UN)],
     'Fcompat' => [qw(FAPPEND FASYNC FCREAT FDEFER FDSYNC FEXCL FLARGEFILE
 		     FNDELAY FNONBLOCK FRSYNC FSYNC FTRUNC)],
@@ -87,7 +85,7 @@ XSLoader::load();
 
 # Items to export into callers namespace by default
 # (move infrequently used names to @EXPORT_OK below)
-@EXPORT =
+our @EXPORT =
   qw(
 	FD_CLOEXEC
 	F_ALLOCSP
@@ -160,7 +158,7 @@ XSLoader::load();
      );
 
 # Other items we are prepared to export if requested
-@EXPORT_OK = (qw(
+our @EXPORT_OK = (qw(
 	DN_ACCESS
 	DN_ATTRIB
 	DN_CREATE

--- a/ext/File-Find/lib/File/Find.pm
+++ b/ext/File-Find/lib/File/Find.pm
@@ -3,11 +3,10 @@ use 5.006;
 use strict;
 use warnings;
 use warnings::register;
-our $VERSION = '1.39';
-require Exporter;
+our $VERSION = '1.39_01';
+use Exporter 'import';
 require Cwd;
 
-our @ISA = qw(Exporter);
 our @EXPORT = qw(find finddepth);
 
 

--- a/ext/File-Find/t/lib/Testing.pm
+++ b/ext/File-Find/t/lib/Testing.pm
@@ -2,8 +2,7 @@ package Testing;
 use 5.006_001;
 use strict;
 use warnings;
-require Exporter;
-our @ISA = qw(Exporter);
+use Exporter 'import';
 our @EXPORT_OK = qw(
     create_file_ok
     mkdir_ok

--- a/ext/File-Glob/Glob.pm
+++ b/ext/File-Glob/Glob.pm
@@ -1,16 +1,14 @@
 package File::Glob;
 
 use strict;
-our($VERSION, @ISA, @EXPORT_OK, @EXPORT_FAIL, %EXPORT_TAGS, $DEFAULT_FLAGS);
+our($DEFAULT_FLAGS);
 
 require XSLoader;
-
-@ISA = qw(Exporter);
 
 # NOTE: The glob() export is only here for compatibility with 5.6.0.
 # csh_glob() should not be used directly, unless you know what you're doing.
 
-%EXPORT_TAGS = (
+our %EXPORT_TAGS = (
     'glob' => [ qw(
         GLOB_ABEND
         GLOB_ALPHASORT
@@ -33,9 +31,9 @@ require XSLoader;
 );
 $EXPORT_TAGS{bsd_glob} = [@{$EXPORT_TAGS{glob}}];
 
-@EXPORT_OK   = (@{$EXPORT_TAGS{'glob'}}, 'csh_glob');
+our @EXPORT_OK   = (@{$EXPORT_TAGS{'glob'}}, 'csh_glob');
 
-$VERSION = '1.35';
+our $VERSION = '1.36';
 
 sub import {
     require Exporter;

--- a/ext/GDBM_File/GDBM_File.pm
+++ b/ext/GDBM_File/GDBM_File.pm
@@ -341,9 +341,9 @@ our($VERSION, @ISA, @EXPORT);
 
 require Carp;
 require Tie::Hash;
-require Exporter;
+use Exporter 'import';
 require XSLoader;
-@ISA = qw(Tie::Hash Exporter);
+@ISA = qw(Tie::Hash);
 @EXPORT = qw(
         GDBM_CACHESIZE
         GDBM_CENTFREE
@@ -363,7 +363,7 @@ require XSLoader;
 );
 
 # This module isn't dual life, so no need for dev version numbers.
-$VERSION = '1.19';
+$VERSION = '1.20';
 
 XSLoader::load();
 

--- a/ext/Hash-Util-FieldHash/lib/Hash/Util/FieldHash.pm
+++ b/ext/Hash-Util-FieldHash/lib/Hash/Util/FieldHash.pm
@@ -5,10 +5,9 @@ use strict;
 use warnings;
 use Scalar::Util qw( reftype);
 
-our $VERSION = '1.21';
+our $VERSION = '1.22';
 
-require Exporter;
-our @ISA = qw(Exporter);
+use Exporter 'import';
 our %EXPORT_TAGS = (
     'all' => [ qw(
         fieldhash

--- a/ext/Hash-Util/lib/Hash/Util.pm
+++ b/ext/Hash-Util/lib/Hash/Util.pm
@@ -9,7 +9,6 @@ use warnings::register;
 use Scalar::Util qw(reftype);
 
 require Exporter;
-our @ISA        = qw(Exporter);
 our @EXPORT_OK  = qw(
                      fieldhash fieldhashes
 
@@ -42,7 +41,7 @@ our @EXPORT_OK  = qw(
 BEGIN {
     # make sure all our XS routines are available early so their prototypes
     # are correctly applied in the following code.
-    our $VERSION = '0.25';
+    our $VERSION = '0.26';
     require XSLoader;
     XSLoader::load();
 }

--- a/ext/I18N-Langinfo/Langinfo.pm
+++ b/ext/I18N-Langinfo/Langinfo.pm
@@ -5,10 +5,8 @@ use strict;
 use warnings;
 use Carp;
 
-require Exporter;
+use Exporter 'import';
 require XSLoader;
-
-our @ISA = qw(Exporter);
 
 our @EXPORT = qw(langinfo);
 
@@ -72,7 +70,7 @@ our @EXPORT_OK = qw(
 	YESSTR
 );
 
-our $VERSION = '0.19';
+our $VERSION = '0.20';
 
 XSLoader::load();
 

--- a/ext/IPC-Open3/lib/IPC/Open2.pm
+++ b/ext/IPC-Open3/lib/IPC/Open2.pm
@@ -1,14 +1,12 @@
 package IPC::Open2;
 
 use strict;
-our ($VERSION, @ISA, @EXPORT);
 
-require 5.000;
-require Exporter;
+require 5.006;
+use Exporter 'import';
 
-$VERSION	= 1.05;
-@ISA		= qw(Exporter);
-@EXPORT		= qw(open2);
+our $VERSION	= 1.06;
+our @EXPORT		= qw(open2);
 
 =head1 NAME
 

--- a/ext/IPC-Open3/lib/IPC/Open3.pm
+++ b/ext/IPC-Open3/lib/IPC/Open3.pm
@@ -2,16 +2,14 @@ package IPC::Open3;
 
 use strict;
 no strict 'refs'; # because users pass me bareword filehandles
-our ($VERSION, @ISA, @EXPORT);
 
-require Exporter;
+use Exporter 'import';
 
 use Carp;
 use Symbol qw(gensym qualify);
 
-$VERSION	= '1.21';
-@ISA		= qw(Exporter);
-@EXPORT		= qw(open3);
+our $VERSION	= '1.22';
+our @EXPORT		= qw(open3);
 
 =head1 NAME
 

--- a/ext/Opcode/Opcode.pm
+++ b/ext/Opcode/Opcode.pm
@@ -6,14 +6,13 @@ use strict;
 
 our($VERSION, @ISA, @EXPORT_OK);
 
-$VERSION = "1.51";
+$VERSION = "1.52";
 
 use Carp;
-use Exporter ();
+use Exporter 'import';
 use XSLoader;
 
 BEGIN {
-    @ISA = qw(Exporter);
     @EXPORT_OK = qw(
 	opset ops_to_opset
 	opset_to_ops opset_to_hex invert_opset

--- a/ext/Pod-Functions/Functions_pm.PL
+++ b/ext/Pod-Functions/Functions_pm.PL
@@ -207,11 +207,10 @@ L<perlfunc/"Perl Functions by Category"> section.
 
 =cut
 
-our $VERSION = '1.13';
+our $VERSION = '1.14';
 
-require Exporter;
+use Exporter 'import';
 
-our @ISA = qw(Exporter);
 our @EXPORT = qw(%Kinds %Type %Flavor %Type_Description @Type_Order);
 
 our(%Kinds, %Type, %Flavor, %Type_Description, @Type_Order);

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -1,9 +1,8 @@
 package Pod::Html;
 use strict;
-require Exporter;
+use Exporter 'import';
 
-our $VERSION = 1.27;
-our @ISA = qw(Exporter);
+our $VERSION = 1.28;
 our @EXPORT = qw(pod2html htmlify);
 our @EXPORT_OK = qw(anchorify relativize_url);
 

--- a/ext/Sys-Hostname/Hostname.pm
+++ b/ext/Sys-Hostname/Hostname.pm
@@ -4,9 +4,8 @@ use strict;
 
 use Carp;
 
-require Exporter;
+use Exporter 'import';
 
-our @ISA     = qw/ Exporter /;
 our @EXPORT  = qw/ hostname /;
 
 our $VERSION;
@@ -16,7 +15,7 @@ use warnings ();
 our $host;
 
 BEGIN {
-    $VERSION = '1.23';
+    $VERSION = '1.24';
     {
 	local $SIG{__DIE__};
 	eval {

--- a/ext/VMS-Filespec/lib/VMS/Filespec.pm
+++ b/ext/VMS-Filespec/lib/VMS/Filespec.pm
@@ -221,19 +221,18 @@ This document was last revised 8-DEC-2007, for Perl 5.10.0
 =cut
 
 package VMS::Filespec;
-require 5.002;
+require 5.006;
 
-our $VERSION = '1.12';
+our $VERSION = '1.13';
 
 # If you want to use this package on a non-VMS system,
 # uncomment the following line.
 # use AutoLoader;
-require Exporter;
+use Exporter 'import';
 
-@ISA = qw( Exporter );
-@EXPORT = qw( &vmsify &unixify &pathify &fileify
+our @EXPORT = qw( &vmsify &unixify &pathify &fileify
               &vmspath &unixpath &candelete &rmsexpand );
-@EXPORT_OK = qw( &unixrealpath &vmsrealpath &case_tolerant_process );
+our @EXPORT_OK = qw( &unixrealpath &vmsrealpath &case_tolerant_process );
 1;
 
 

--- a/ext/VMS-Stdio/Stdio.pm
+++ b/ext/VMS-Stdio/Stdio.pm
@@ -7,13 +7,13 @@
 
 package VMS::Stdio;
 
-require 5.002;
+require 5.006;
 use Carp '&croak';
 use DynaLoader ();
-use Exporter ();
+use Exporter 'import';
 
-our $VERSION = '2.45';
-our @ISA = qw( Exporter DynaLoader IO::File );
+our $VERSION = '2.46';
+our @ISA = qw( DynaLoader IO::File );
 our @EXPORT = qw( &O_APPEND &O_CREAT &O_EXCL  &O_NDELAY &O_NOWAIT
               &O_RDONLY &O_RDWR  &O_TRUNC &O_WRONLY );
 our @EXPORT_OK = qw( &binmode &flush &getname &remove &rewind &sync &setdef &tmpnam


### PR DESCRIPTION
Inheriting from Exporter adds several subroutines that are not really
needed by these modules.

The remaining uses of inheritance from Exporter are:

re.pm - this uses export_to_level(), which really, really wants
the inheritance