### PR TITLE
style: Add an EditorConfig file for the C code.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[**/*.[ch]]
+charset = utf-8
+indent_style = space
+indent_size = 4
+tab_width = 8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,5 @@
 .dir-locals.el			Emacs control file
-.editorconfig			EditorConifg style file
+.editorconfig			EditorConfig style file
 .lgtm.yml			LGTM.com configuration file
 .metaconf-exclusions.txt	Symbols that should ignored when generating Configure
 .travis.yml		continuous integration on github (where enabled)

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,4 +1,5 @@
 .dir-locals.el			Emacs control file
+.editorconfig			EditorConifg style file
 .lgtm.yml			LGTM.com configuration file
 .metaconf-exclusions.txt	Symbols that should ignored when generating Configure
 .travis.yml		continuous integration on github (where enabled)

--- a/Porting/manifest_lib.pl
+++ b/Porting/manifest_lib.pl
@@ -44,7 +44,8 @@ sub sort_manifest {
         $m =~ s!/!\0!g;
         # replace the extension (only one) by null null extension.
         # this puts any foo/blah.ext before any files in foo/blah/
-        $m =~ s!(\.[^.]+\z)!\0\0$1!;
+        $m =~ s{(?<!\A)(\.[^.]+\z)}{\0\0$1};
+
         # return the original string, and the munged filename
         [ $_, $m ];
     } @_;


### PR DESCRIPTION
EditorConfig lets editors automatically configure themselves to the
project standard. Like embedded VIM and emacs mode lines, but
universal. Many editors support it out of the box. Most everything
else has a plugin. https://editorconfig.org/

It makes contributing with proper style easier. Pretty basic stuff. Start with the C code. It can be expanded to the Perl code.

* 4 spaces for indentation
* UTF-8
* Unix newlines
* Strip trailing whitespace
* Add a final newline on the file