### PR TITLE
Fix windows compilation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -300,6 +300,7 @@ Daniel Dragan                  <bulk88@hotmail.com>
 Daniel Frederick Crisman       <daniel@crisman.org>
 Daniel Grisinger               <dgris@dimensional.com>
 Daniel Kahn Gillmor            <dkg@fifthhorseman.net>
+Daniel Laügt                   <daniel.laugt@gmail.com>
 Daniel Lieberman               <daniel@bitpusher.com>
 Daniel Muiño                   <dmuino@afip.gov.ar>
 Daniel P. Berrange             <dan@berrange.com>

--- a/toke.c
+++ b/toke.c
@@ -6696,6 +6696,12 @@ yyl_backslash(pTHX_ char *s)
     OPERATOR(REFGEN);
 }
 
+#ifdef NETWARE
+#define RSFP_FILENO (PL_rsfp)
+#else
+#define RSFP_FILENO (PerlIO_fileno(PL_rsfp))
+#endif
+
 static void
 yyl_data_handle(pTHX)
 {
@@ -9206,13 +9212,6 @@ yyl_try(pTHX_ char *s)
 		      fall back to bareword
 		  - cases for built-in keywords
 */
-
-#ifdef NETWARE
-#define RSFP_FILENO (PL_rsfp)
-#else
-#define RSFP_FILENO (PerlIO_fileno(PL_rsfp))
-#endif
-
 
 int
 Perl_yylex(pTHX)


### PR DESCRIPTION
MSVC gives the following compilation error when PERL_TEXTMODE_SCRIPTS is not defined:
..\toke.c(6701) : error C2065: 'RSFP_FILENO' : undeclared identifier