### PR TITLE
Generate lib/Config.pod with unix format to be read with pod/buildtoc

### DIFF
--- a/configpm
+++ b/configpm
@@ -856,7 +856,7 @@ tie %%Config, 'Config', {
 ENDOFTIE
 
 
-open(CONFIG_POD, '>', $Config_POD) or die "Can't open $Config_POD: $!";
+open(CONFIG_POD, '>:raw', $Config_POD) or die "Can't open $Config_POD: $!";
 print CONFIG_POD <<'ENDOFTAIL';
 =head1 NAME
 


### PR DESCRIPTION
I have the following errors when I compile perl on windows:

> ..\perl.exe -f ..\pod\buildtoc -q
> Use of uninitialized value $_ in substitution (s///) at ..\pod\buildtoc line 215, <$fh> chunk 2.
> Use of uninitialized value $_ in pattern match (m//) at ..\pod\buildtoc line 216, <$fh> chunk 2.
> Use of uninitialized value $_ in substitution (s///) at ..\pod\buildtoc line 219, <$fh> chunk 2.
> Use of uninitialized value $_ in substitution (s///) at ..\pod\buildtoc line 219, <$fh> chunk 2.

On windows, lib/Config.pod is generated with CRLF.
pod/buildtoc reads the files with unix format ([2fb0e7e](https://github.com/Perl/perl5/commit/2fb0e7e4fee5700b0271b577a2e729301b7f483e)).

