### PR TITLE
Tests and documentation for Getopt::Long behaviour when the same option appears twice, but is not multi-valued.

### DIFF
--- a/cpan/Getopt-Long/lib/Getopt/Long.pm
+++ b/cpan/Getopt-Long/lib/Getopt/Long.pm
@@ -1714,6 +1714,9 @@ disable C<$verbose> by setting its value to C<0>. Using a suitable
 default value, the program can find out whether C<$verbose> is false
 by default, or disabled by using C<--noverbose>.
 
+(If both C<--verbose> and C<--noverbose> are given, the later option
+takes precedence.)
+
 An incremental option is specified with a plus C<+> after the
 option name:
 
@@ -1765,6 +1768,10 @@ values, and C<f> for floating point values. Using a colon C<:> instead
 of the equals sign indicates that the option value is optional. In
 this case, if no suitable value is supplied, string valued options get
 an empty string C<''> assigned, while numeric options are set to C<0>.
+
+(If the same option appears more than once on the command line, the
+last given value is used.  If you want to take all the values, see
+below.)
 
 =head2 Options with multiple values
 

--- a/cpan/Getopt-Long/t/gol-basic.t
+++ b/cpan/Getopt-Long/t/gol-basic.t
@@ -15,7 +15,7 @@ die("Getopt::Long version $want_version required--this is only version ".
     $Getopt::Long::VERSION)
   unless $Getopt::Long::VERSION ge $want_version;
 
-print "1..12\n";
+print "1..18\n";
 
 @ARGV = qw(-Foo -baR --foo bar);
 undef $opt_baR;
@@ -43,3 +43,26 @@ print ($rv ? "" : "not "); print "ok 10\n";
 print ("@ARGV" eq 'file' ? "" : "not ", "ok 11\n");
 ( $HELP && $FOO && !$BAR && $FILE eq 'foo' && $NO == 5 )
     ? print "" : print "not "; print "ok 12\n";
+
+# Test behaviour when the same option name is given twice, but not an multi-value option.
+# The option given later on the command line is used.
+#
+{
+    my $foo;
+
+    @ARGV = qw(--foo a --foo b);
+    $rd = GetOptions('foo=s' => \$foo);
+    print ($rv ? "" : "not "); print "ok 13\n";
+    print ($foo eq 'b' ? "" : "not ", "ok 14\n");
+
+    @ARGV = qw(--no-foo --foo);
+    $rd = GetOptions('foo!' => \$foo);
+    print ($rv ? "" : "not "); print "ok 15\n";
+    print ($foo eq '1' ? "" : "not ", "ok 16\n");
+
+    @ARGV = qw(--foo --no-foo);
+    $rd = GetOptions('foo!' => \$foo);
+    print ($rv ? "" : "not "); print "ok 17\n";
+    # Check it is set to an explicit 0.
+    print ($foo eq '0' ? "" : "not ", "ok 18\n");
+}


### PR DESCRIPTION
<https://github.com/Perl/perl5/issues/18469>