### PR TITLE
update the links to freenode

### DIFF
--- a/README.tw
+++ b/README.tw
@@ -115,7 +115,7 @@ Perl 郵遞論壇一覽
 
 臺灣 Perl 推廣組一覽
 
-=item L<irc://irc.freenode.org/#perl.tw>
+=item L<irc://chat.freenode.org/#perl.tw>
 
 Perl.tw 線上聊天室
 

--- a/pod/perlcommunity.pod
+++ b/pod/perlcommunity.pod
@@ -44,7 +44,7 @@ own IRC network, L<irc://irc.perl.org>. General (not help-oriented) chat can be
 found at L<irc://irc.perl.org/#perl>. Many other more specific chats are also
 hosted on the network. Information about irc.perl.org is located on the
 network's website: L<https://www.irc.perl.org>. For a more help-oriented #perl,
-check out L<irc://irc.freenode.net/#perl>. Most Perl-related channels
+check out L<irc://chat.freenode.net/#perl>. Most Perl-related channels
 will be kind enough to point you in the right direction if you ask nicely.
 
 Any large IRC network (Dalnet, EFnet) is also likely to have a #perl channel,


### PR DESCRIPTION
Hi comitters,

I found two irc URLs that ref to the old hostname of freenome (`"irc.freenode.net"`) and they are replaced with the preferred one now (that  is `"chat.freenode.net"`).
