### PR TITLE
perlre: Note the other forms of \k<name>

### DIFF
--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -1000,6 +1000,8 @@ X<\g> X<\k> X<\K> X<backreference>
                    curly brackets for safer parsing.
   \g{name}  [5]  Named backreference
   \k<name>  [5]  Named backreference
+  \k'name'  [5]  Named backreference
+  \k{name}  [5]  Named backreference
   \K        [6]  Keep the stuff left of the \K, don't include it in $&
   \N        [7]  Any character but \n.  Not affected by /s modifier
   \v        [3]  Vertical whitespace
@@ -1760,6 +1762,8 @@ support the use of single quotes as a delimiter for the name.
 
 =item C<< \k'I<NAME>' >>
 
+=item C<< \k{I<NAME>} >>
+
 Named backreference. Similar to numeric backreferences, except that
 the group is designated by name and not number. If multiple groups
 have the same name then it refers to the leftmost defined group in
@@ -1768,7 +1772,7 @@ the current match.
 It is an error to refer to a name not defined by a C<< (?<I<NAME>>) >>
 earlier in the pattern.
 
-Both forms are equivalent.
+All three forms are equivalent.
 
 B<NOTE:> In order to make things easier for programmers with experience
 with the Python or PCRE regex engines, the pattern C<< (?P=I<NAME>) >>

--- a/regcomp.c
+++ b/regcomp.c
@@ -13857,8 +13857,8 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
             RExC_parse = parse_start;
             goto defchar;
 
-	case 'k':    /* Handle \k<NAME> and \k'NAME' */
-      parse_named_seq:
+	case 'k':    /* Handle \k<NAME> and \k'NAME' and \k{NAME} */
+      parse_named_seq:  /* Also handle non-numeric \g{...} */
         {
             char ch;
             if (   RExC_parse >= RExC_end - 1


### PR DESCRIPTION
Not all three synonyms were documented.

This also fixes up related comments in regcomp.c to correspond