### PR TITLE
Fix POD for $Carp::RefArgFormatter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -295,6 +295,7 @@ Dan Kogai                      <dankogai@dan.co.jp>
 Dan Schmidt                    <dfan@harmonixmusic.com>
 Dan Sugalski                   <dan@sidhe.org>
 Daniel Berger                  <djberg86@attbi.com>
+Daniel Böhmer                  <post@daniel-boehmer.de>
 Daniel Chetlin                 <daniel@chetlin.com>
 Daniel Dragan                  <bulk88@hotmail.com>
 Daniel Frederick Crisman       <daniel@crisman.org>

--- a/dist/Carp/lib/Carp.pm
+++ b/dist/Carp/lib/Carp.pm
@@ -211,7 +211,7 @@ BEGIN {
 }
 
 
-our $VERSION = '1.51';
+our $VERSION = '1.52';
 $VERSION =~ tr/_//d;
 
 our $MaxEvalLen = 0;
@@ -944,10 +944,10 @@ This variable sets a general argument formatter to display references.
 Plain scalars and objects that implement C<CARP_TRACE> will not go through
 this formatter.  Calling C<Carp> from within this function is not supported.
 
-local $Carp::RefArgFormatter = sub {
-    require Data::Dumper;
-    Data::Dumper::Dump($_[0]); # not necessarily safe
-};
+    local $Carp::RefArgFormatter = sub {
+        require Data::Dumper;
+        Data::Dumper->Dump($_[0]); # not necessarily safe
+    };
 
 =head2 @CARP_NOT
 

--- a/dist/Carp/lib/Carp/Heavy.pm
+++ b/dist/Carp/lib/Carp/Heavy.pm
@@ -2,7 +2,7 @@ package Carp::Heavy;
 
 use Carp ();
 
-our $VERSION = '1.51';
+our $VERSION = '1.52';
 $VERSION =~ tr/_//d;
 
 # Carp::Heavy was merged into Carp in version 1.12.  Any mismatched versions


### PR DESCRIPTION
- Data::Dumper::Dump() MUST be called as class method

- indent example for code markup