### PR TITLE
ExtUtils-CBuilder: Remove image-base generation on Win32/gcc

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1356,6 +1356,7 @@ Yves Orton                     <demerphq@gmail.com>
 Zachary Miller                 <zcmiller@simon.er.usgs.gov>
 Zachary Storer                 <zacts.3.14159@gmail.com>
 Zak B. Elep                    <zakame@zakame.net>
+Zakariyya Mughal               <zmughal@cpan.org>
 Zbynek Vyskovsky               <kvr@centrum.cz>
 Zefram                         <zefram@fysh.org>
 Zsbán Ambrus                   <ambrus@math.bme.hu>

--- a/dist/ExtUtils-CBuilder/Changes
+++ b/dist/ExtUtils-CBuilder/Changes
@@ -1,5 +1,12 @@
 Revision history for Perl extension ExtUtils::CBuilder.
 
+0.280236 - 2021-02-12
+
+  Fix:
+
+  - Remove image-base generation on Win32/gcc and instead use GCC's built-in
+    `--enable-auto-image-base` linker option.
+
 0.280235 - 2020-11-01
 
   Fix:

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder.pm
@@ -7,7 +7,7 @@ use Perl::OSType qw/os_type/;
 
 use warnings;
 use strict;
-our $VERSION = '0.280235'; # VERSION
+our $VERSION = '0.280236'; # VERSION
 our @ISA;
 
 # We only use this once - don't waste a symbol table entry on it.

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
@@ -9,7 +9,7 @@ use Text::ParseWords;
 use IPC::Cmd qw(can_run);
 use File::Temp qw(tempfile);
 
-our $VERSION = '0.280235'; # VERSION
+our $VERSION = '0.280236'; # VERSION
 
 # More details about C/C++ compilers:
 # http://developers.sun.com/sunstudio/documentation/product/compiler.jsp

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Unix.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Unix.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Base;
 
-our $VERSION = '0.280235'; # VERSION
+our $VERSION = '0.280236'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Base);
 
 sub link_executable {

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/VMS.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/VMS.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Base;
 
-our $VERSION = '0.280235'; # VERSION
+our $VERSION = '0.280236'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Base);
 
 use File::Spec::Functions qw(catfile catdir);

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows.pm
@@ -8,7 +8,7 @@ use File::Spec;
 use ExtUtils::CBuilder::Base;
 use IO::File;
 
-our $VERSION = '0.280235'; # VERSION
+our $VERSION = '0.280236'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Base);
 
 =begin comment

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/BCC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/BCC.pm
@@ -1,6 +1,6 @@
 package ExtUtils::CBuilder::Platform::Windows::BCC;
 
-our $VERSION = '0.280235'; # VERSION
+our $VERSION = '0.280236'; # VERSION
 
 use strict;
 use warnings;

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/GCC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/GCC.pm
@@ -1,6 +1,6 @@
 package ExtUtils::CBuilder::Platform::Windows::GCC;
 
-our $VERSION = '0.280235'; # VERSION
+our $VERSION = '0.280236'; # VERSION
 
 use warnings;
 use strict;
@@ -40,15 +40,6 @@ sub format_linker_cmd {
   unshift( @{$spec{other_ldflags}}, '-nostartfiles' )
     if ( $spec{startup} && @{$spec{startup}} );
 
-  # From ExtUtils::MM_Win32:
-  #
-  ## one thing for GCC/Mingw32:
-  ## we try to overcome non-relocateable-DLL problems by generating
-  ##    a (hopefully unique) image-base from the dll's name
-  ## -- BKS, 10-19-1999
-  File::Basename::basename( $spec{output} ) =~ /(....)(.{0,4})/;
-  $spec{image_base} = sprintf( "0x%x0000", unpack('n', $1 ^ $2) );
-
   %spec = $self->write_linker_script(%spec)
     if $spec{use_scripts};
 
@@ -72,7 +63,7 @@ sub format_linker_cmd {
     @ld                       ,
     '-o', $spec{output}       ,
     "-Wl,--base-file,$spec{base_file}"   ,
-    "-Wl,--image-base,$spec{image_base}" ,
+    "-Wl,--enable-auto-image-base" ,
     @{$spec{lddlflags}}       ,
     @{$spec{libpath}}         ,
     @{$spec{startup}}         ,
@@ -93,7 +84,7 @@ sub format_linker_cmd {
   push @cmds, [ grep {defined && length} (
     @ld                       ,
     '-o', $spec{output}       ,
-    "-Wl,--image-base,$spec{image_base}" ,
+    "-Wl,--enable-auto-image-base" ,
     @{$spec{lddlflags}}       ,
     @{$spec{libpath}}         ,
     @{$spec{startup}}         ,

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/MSVC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/MSVC.pm
@@ -1,6 +1,6 @@
 package ExtUtils::CBuilder::Platform::Windows::MSVC;
 
-our $VERSION = '0.280235'; # VERSION
+our $VERSION = '0.280236'; # VERSION
 
 use warnings;
 use strict;

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/aix.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/aix.pm
@@ -5,7 +5,7 @@ use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 use File::Spec;
 
-our $VERSION = '0.280235'; # VERSION
+our $VERSION = '0.280236'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub need_prelink { 1 }

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/android.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/android.pm
@@ -6,7 +6,7 @@ use File::Spec;
 use ExtUtils::CBuilder::Platform::Unix;
 use Config;
 
-our $VERSION = '0.280235'; # VERSION
+our $VERSION = '0.280236'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 # The Android linker will not recognize symbols from

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/cygwin.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/cygwin.pm
@@ -5,7 +5,7 @@ use strict;
 use File::Spec;
 use ExtUtils::CBuilder::Platform::Unix;
 
-our $VERSION = '0.280235'; # VERSION
+our $VERSION = '0.280236'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 # TODO: If a specific exe_file name is requested, if the exe created

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/darwin.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/darwin.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 
-our $VERSION = '0.280235'; # VERSION
+our $VERSION = '0.280236'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub compile {

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/dec_osf.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/dec_osf.pm
@@ -5,7 +5,7 @@ use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 use File::Spec;
 
-our $VERSION = '0.280235'; # VERSION
+our $VERSION = '0.280236'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub link_executable {

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/os2.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/os2.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 
-our $VERSION = '0.280235'; # VERSION
+our $VERSION = '0.280236'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub need_prelink { 1 }


### PR DESCRIPTION
Switches from generating an image-base address using the basename of the
output file to using GCC's built-in `--enable-auto-image-base` linker
option.

This aligns the linking behaviour for Win32/gcc with that of
ExtUtils-MakeMaker which removed image-base generation in commit
<https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/commit/343d21a453c4d03cf7304dbd4c4dd8180df574ad>.

CC: @ambs, @Leont, @plicease

Connects with: <https://github.com/PerlAlien/Alien-Build/pull/243#issuecomment-758193294>