### PR TITLE
Make PerlIO::encoding::fallback more robust

### DIFF
--- a/ext/PerlIO-encoding/encoding.pm
+++ b/ext/PerlIO-encoding/encoding.pm
@@ -1,7 +1,7 @@
 package PerlIO::encoding;
 
 use strict;
-our $VERSION = '0.28';
+our $VERSION = '0.29';
 our $DEBUG = 0;
 $DEBUG and warn __PACKAGE__, " called by ", join(", ", caller), "\n";
 
@@ -13,8 +13,7 @@ $DEBUG and warn __PACKAGE__, " called by ", join(", ", caller), "\n";
 require XSLoader;
 XSLoader::load();
 
-our $fallback =
-    Encode::PERLQQ()|Encode::WARN_ON_ERR()|Encode::ONLY_PRAGMA_WARNINGS()|Encode::STOP_AT_PARTIAL();
+our $fallback = Encode::PERLQQ()|Encode::WARN_ON_ERR()|Encode::ONLY_PRAGMA_WARNINGS();
 
 1;
 __END__

--- a/ext/PerlIO-encoding/encoding.xs
+++ b/ext/PerlIO-encoding/encoding.xs
@@ -168,6 +168,8 @@ PerlIOEncode_pushed(pTHX_ PerlIO * f, const char *mode, SV * arg, PerlIO_funcs *
     }
 
     e->chk = newSVsv(get_sv("PerlIO::encoding::fallback", 0));
+    if (SvROK(e->chk))
+        Perl_croak(aTHX_ "PerlIO::encoding::fallback must be an integer");
     SvUV_set(e->chk, SvUV(e->chk) | encode_stop_at_partial);
     e->inEncodeCall = 0;
 

--- a/ext/PerlIO-encoding/encoding.xs
+++ b/ext/PerlIO-encoding/encoding.xs
@@ -652,23 +652,11 @@ BOOT:
      * is invoked without prior "use Encode". -- dankogai
      */
     PUSHSTACKi(PERLSI_MAGIC);
-    if (!get_cvs(OUR_DEFAULT_FB, 0)) {
-#if 0
-	/* This would just be an irritant now loading works */
-	Perl_warner(aTHX_ packWARN(WARN_IO), ":encoding without 'use Encode'");
-#endif
+    if (!get_cvs(OUR_STOP_AT_PARTIAL, 0)) {
 	/* The SV is magically freed by load_module */
 	load_module(PERL_LOADMOD_NOIMPORT, newSVpvs("Encode"), Nullsv, Nullsv);
 	assert(sp == PL_stack_sp);
     }
-    PUSHMARK(sp);
-    PUTBACK;
-    if (call_pv(OUR_DEFAULT_FB, G_SCALAR) != 1) {
-	    /* should never happen */
-	    Perl_die(aTHX_ "%s did not return a value",OUR_DEFAULT_FB);
-    }
-    SPAGAIN;
-    sv_setsv(chk, POPs);
 
     PUSHMARK(sp);
     PUTBACK;


### PR DESCRIPTION
This branch
* Forces `$fallback` to always contain `STOP_AT_PARTIAL`, as without it multibyte characters spanning buffer boundaries will not be correctly read
* Disallows setting `$fallback` to a subroutine. This is incompatible with `STOP_AT_PARTIAL` and as such inherently buggy.
* Removes setting `$fallback` from `encoding.xs`, as it's already set from `encoding.pm`.
* Ignores the LEAVE_SRC bit if it's set, as it leads to the issue described in #18495