### PR TITLE
Allow pack 'D' on all systems with long doubles

### DIFF
--- a/packsizetables.inc
+++ b/packsizetables.inc
@@ -19,7 +19,7 @@ STATIC const packprops_t packprops[512] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0,
     /* C */ sizeof(unsigned char),
-#if defined(HAS_LONG_DOUBLE) && defined(USE_LONG_DOUBLE)
+#if defined(HAS_LONG_DOUBLE)
     /* D */ LONG_DOUBLESIZE,
 #else
     0,
@@ -154,7 +154,7 @@ STATIC const packprops_t packprops[512] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     /* C */ sizeof(unsigned char),
-#if defined(HAS_LONG_DOUBLE) && defined(USE_LONG_DOUBLE)
+#if defined(HAS_LONG_DOUBLE)
     /* D */ LONG_DOUBLESIZE,
 #else
     0,

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -390,7 +390,15 @@ XXX
 XXX Important bug fixes in the core language are summarized here.  Bug fixes in
 files in F<ext/> and F<lib/> are best summarized in L</Modules and Pragmata>.
 
-[ List each fix as an =item entry ]
+=over 4
+
+=item * pack/unpack format 'D' now works on all systems that could support it
+
+Previously if C<NV == long double>, now it is supported on all platforms that
+have long doubles. In particular that means it is now also supported on
+quadmath platforms.
+
+=back
 
 =over 4
 

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -5205,8 +5205,7 @@ of values, as follows:
     F  A Perl internal floating-point value (NV) in native format
     D  A float of long-double precision in native format.
          (Long doubles are available only if your system supports
-          long double values _and_ if Perl has been compiled to
-          support those.  Raises an exception otherwise.
+          long double values. Raises an exception otherwise.
           Note that there are different long double formats.)
 
     p  A pointer to a null-terminated string.

--- a/pp_pack.c
+++ b/pp_pack.c
@@ -75,7 +75,7 @@ typedef union {
     U8 bytes[sizeof(NV)];
 } NV_bytes;
 
-#if defined(HAS_LONG_DOUBLE) && defined(USE_LONG_DOUBLE)
+#if defined(HAS_LONG_DOUBLE)
 typedef union {
     long double ld;
     U8 bytes[sizeof(long double)];
@@ -1696,7 +1696,7 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
                     cdouble += anv.nv;
             }
             break;
-#if defined(HAS_LONG_DOUBLE) && defined(USE_LONG_DOUBLE)
+#if defined(HAS_LONG_DOUBLE)
         case 'D':
             while (len-- > 0) {
                 ld_bytes aldouble;
@@ -2759,7 +2759,7 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
             }
             break;
         }
-#if defined(HAS_LONG_DOUBLE) && defined(USE_LONG_DOUBLE)
+#if defined(HAS_LONG_DOUBLE)
         case 'D': {
             ld_bytes aldouble;
             /* long doubles can have unused bits, which may be nonzero */

--- a/regen/genpacksizetables.pl
+++ b/regen/genpacksizetables.pl
@@ -125,4 +125,4 @@ Q			Uquad_t	IVSIZE >= 8
 f			float
 d			double
 F			=NVSIZE
-D			=LONG_DOUBLESIZE	defined(HAS_LONG_DOUBLE) && defined(USE_LONG_DOUBLE)
+D			=LONG_DOUBLESIZE	defined(HAS_LONG_DOUBLE)


### PR DESCRIPTION
Previously it was only supported if `NV` itself also was `long double`, but not when it is either `double` or `__float128`.

This intends to fix #18512