### PR TITLE
files in t/opbasic shouldn't load test.pl

### DIFF
--- a/t/opbasic/arith.t
+++ b/t/opbasic/arith.t
@@ -2,8 +2,12 @@
 
 BEGIN {
     chdir 't' if -d 't';
-    require './test.pl';
-    set_up_inc('../lib');
+    # we can't use test.pl here (see the comment below)
+    #require './test.pl';
+    #set_up_inc('../lib');
+    # so inline set_up_inc() and its call to is_miniperl
+    @INC = () if defined &DynaLoader::boot_DynaLoader;
+    unshift @INC, "../lib";
 }
 
 # This file has been placed in t/opbasic to indicate that it should not use


### PR DESCRIPTION
since they're the most basic of tests, it should avoid loading
any modules.

It currently loads Config (conditionally), but there's no way to avoid
that at this point.