### PR TITLE
pp_split: calculate flags just once and other minor tweaks

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -6005,14 +6005,13 @@ PP(pp_split)
     I32 trailing_empty = 0;
     const char *orig;
     const IV origlimit = limit;
-    I32 realarray = 0;
+    bool realarray = 0;
     I32 base;
     const U8 gimme = GIMME_V;
     bool gimme_scalar;
     I32 oldsave = PL_savestack_ix;
     U32 flags = (do_utf8 ? SVf_UTF8 : 0) |
          SVs_TEMP; /* Make mortal SVs by default */
-    bool multiline = 0;
     MAGIC *mg = NULL;
 
     rx = PM_GETRE(pm);
@@ -6075,9 +6074,6 @@ PP(pp_split)
 	    while (s < strend && isSPACE(*s))
 		s++;
 	}
-    }
-    if (RX_EXTFLAGS(rx) & RXf_PMf_MULTILINE) {
-	multiline = 1;
     }
 
     gimme_scalar = gimme == G_SCALAR && !ary;
@@ -6254,6 +6250,8 @@ PP(pp_split)
 	    }
 	}
 	else {
+	    const bool multiline = (RX_EXTFLAGS(rx) & RXf_PMf_MULTILINE) ? 1 : 0;
+
 	    while (s < strend && --limit &&
 	      (m = fbm_instr((unsigned char*)s, (unsigned char*)strend,
 			     csv, multiline ? FBMrf_MULTILINE : 0)) )


### PR DESCRIPTION
The commits in this PR:
* calculate the flags for `newSVpvn_flags` just once, rather than at every call.
* make `realarray` a bool, rather than an I32.
* move the definition of `multiline` to the only branch that actually uses it.

These changes result in a smaller _pp.o_, although not a smaller _miniperl_/_perl_ (with gcc at -O2).
Simple benchmarks on x64 Linux don't show a change to run time performance.