### PR TITLE
Jkeenan/pod html convert n test 20210208

### DIFF
--- a/ext/Pod-Html/t/crossref.t
+++ b/ext/Pod-Html/t/crossref.t
@@ -22,12 +22,11 @@ SKIP: {
     shift @dirs if $dirs[0] eq '';
     my $relcwd = join '/', @dirs;
         
-    convert_n_test("crossref", "cross references", 
-     "--podpath=". File::Spec::Unix->catdir($relcwd, 't') . ":"
-                 . File::Spec::Unix->catdir($relcwd, 'testdir/test.lib'),
-     "--podroot=". catpath($v, '/', ''),
-     "--quiet",
-    );
+    convert_n_test("crossref", "cross references", {
+        podpath => File::Spec::Unix->catdir($relcwd, 't') . ":" . File::Spec::Unix->catdir($relcwd, 'testdir/test.lib'),
+        podroot => catpath($v, '/', ''),
+        quiet   => 1,
+ } );
 }
 
 __DATA__

--- a/ext/Pod-Html/t/crossref2.t
+++ b/ext/Pod-Html/t/crossref2.t
@@ -19,10 +19,12 @@ SKIP: {
     my $cwd = Pod::Html::_unixify(cwd());
 
     convert_n_test("crossref", "cross references",
-     "--podpath=t:testdir/test.lib",
-     "--podroot=$cwd",
-     "--htmldir=$cwd",
-     "--quiet",
+        {
+            podpath    => 't:testdir/test.lib',
+            podroot    => $cwd,
+            htmldir    => $cwd,
+            quiet      => 1,
+        }
     );
 }
 

--- a/ext/Pod-Html/t/crossref3.t
+++ b/ext/Pod-Html/t/crossref3.t
@@ -18,12 +18,12 @@ SKIP: {
     
     my $cwd = cwd();
 
-    convert_n_test("crossref", "cross references", 
-     "--podpath=t:testdir/test.lib",
-     "--podroot=$cwd",
-     "--htmlroot=$cwd",
-     "--quiet",
-    );
+    convert_n_test("crossref", "cross references", {
+         podpath    => 't:testdir/test.lib',
+         podroot    => $cwd,
+         htmlroot   => $cwd,
+         quiet      => 1,
+ } );
 }
 
 __DATA__

--- a/ext/Pod-Html/t/feature.t
+++ b/ext/Pod-Html/t/feature.t
@@ -11,17 +11,17 @@ use Test::More tests => 1;
 
 my $cwd = cwd();
 
-convert_n_test("feature", "misc pod-html features", 
- "--backlink",
- "--css=style.css",
- "--header", # no styling b/c of --ccs
- "--htmldir=". catdir($cwd, 't'),
- "--noindex",
- "--podpath=t",
- "--podroot=$cwd",
- "--title=a title",
- "--quiet",
- );
+convert_n_test("feature", "misc pod-html features", {
+    backlink        => 1,
+    css             => 'style.css',
+    header          => 1, # no styling b/c of --ccs
+    htmldir         => catdir($cwd, 't'),
+    noindex         => 1,
+    podpath         => 't',
+    podroot         => $cwd,
+    title           => 'a title',
+    quiet           => 1,
+} );
 
 __DATA__
 <?xml version="1.0" ?>

--- a/ext/Pod-Html/t/feature2.t
+++ b/ext/Pod-Html/t/feature2.t
@@ -14,16 +14,15 @@ my $cwd = cwd();
 my $warn;
 $SIG{__WARN__} = sub { $warn .= $_[0] };
 
-convert_n_test("feature2", "misc pod-html features 2", 
- "--backlink",
- "--header",
- "--podpath=.",
- "--podroot=$cwd",
- "--norecurse",
- "--verbose",
- "--quiet",
- );
-
+convert_n_test("feature2", "misc pod-html features 2", {
+    backlink    => 1,
+    header      => 1,
+    podpath     => '.',
+    podroot     => $cwd,
+    norecurse   => 1,
+    verbose     => 1,
+    quiet       => 1,
+} );
 like($warn,
     qr(
     \Acaching\ directories\ for\ later\ use\n

--- a/ext/Pod-Html/t/htmldir1.t
+++ b/ext/Pod-Html/t/htmldir1.t
@@ -28,23 +28,23 @@ SKIP: {
     my $data_pos = tell DATA; # to read <DATA> twice
 
 
-    convert_n_test("htmldir1", "test --htmldir and --htmlroot 1a", 
-     "--podpath=". File::Spec::Unix->catdir($relcwd, 't') . ":"
-                 . File::Spec::Unix->catdir($relcwd, 'testdir/test.lib'),
-     "--podroot=". catpath($v, '/', ''),
-     "--htmldir=t",
-     "--quiet",
-    );
+    convert_n_test("htmldir1", "test --htmldir and --htmlroot 1a", {
+        podpath => File::Spec::Unix->catdir($relcwd, 't') . ":" .
+                   File::Spec::Unix->catdir($relcwd, 'testdir/test.lib'),
+        podroot => catpath($v, '/', ''),
+        htmldir => 't',
+        quiet   => 1,
+ } );
 
     seek DATA, $data_pos, 0; # to read <DATA> twice (expected output is the same)
 
-    convert_n_test("htmldir1", "test --htmldir and --htmlroot 1b", 
-     "--podpath=$relcwd",
-     "--podroot=". catpath($v, '/', ''),
-     "--htmldir=". catdir($relcwd, 't'),
-     "--htmlroot=/",
-     "--quiet",
-    );
+    convert_n_test("htmldir1", "test --htmldir and --htmlroot 1b", {
+        podpath     => $relcwd,
+        podroot     => catpath($v, '/', ''),
+        htmldir     => catdir($relcwd, 't'),
+        htmlroot    => '/',
+        quiet       => 1,
+    } );
 }
 
 __DATA__

--- a/ext/Pod-Html/t/htmldir2.t
+++ b/ext/Pod-Html/t/htmldir2.t
@@ -11,28 +11,28 @@ use Test::More tests => 3;
 my $cwd = cwd();
 my $data_pos = tell DATA; # to read <DATA> twice
 
-convert_n_test("htmldir2", "test --htmldir and --htmlroot 2a", 
- "--podpath=t",
- "--htmldir=t",
- "--quiet",
-);
+convert_n_test("htmldir2", "test --htmldir and --htmlroot 2a", {
+    podpath => 't',
+    htmldir => 't',
+    quiet   => 1,
+} );
 
 seek DATA, $data_pos, 0; # to read <DATA> twice (expected output is the same)
 
-convert_n_test("htmldir2", "test --htmldir and --htmlroot 2b", 
- "--podpath=t",
- "--quiet",
-);
+convert_n_test("htmldir2", "test --htmldir and --htmlroot 2b", {
+    podpath => 't',
+    quiet   => 1,
+} );
 
 seek DATA, $data_pos, 0; # to read <DATA> thrice (expected output is the same)
 
 # this test makes sure paths are absolute unless --htmldir is specified
-convert_n_test("htmldir2", "test --htmldir and --htmlroot 2c", 
- "--podpath=t",
- "--podroot=$cwd",
- "--norecurse", # testing --norecurse, too
- "--quiet",
-);
+convert_n_test("htmldir2", "test --htmldir and --htmlroot 2c", {
+    podpath     => 't',
+    podroot     => $cwd,
+    norecurse   => 1, # testing --norecurse, too
+    quiet       => 1,
+} );
 
 __DATA__
 <?xml version="1.0" ?>

--- a/ext/Pod-Html/t/htmldir3.t
+++ b/ext/Pod-Html/t/htmldir3.t
@@ -25,22 +25,22 @@ SKIP: {
 
     my $data_pos = tell DATA; # to read <DATA> twice
 
-    convert_n_test("htmldir3", "test --htmldir and --htmlroot 3a", 
-     "--podpath=$relcwd",
-     "--podroot=". catpath($v, '/', ''),
-     "--htmldir=". catdir($cwd, 't', ''), # test removal trailing slash,
-     "--quiet",
-    );
+    convert_n_test("htmldir3", "test --htmldir and --htmlroot 3a", {
+         podpath    => $relcwd,
+         podroot    => catpath($v, '/', ''),
+         htmldir    => catdir($cwd, 't', ''), # test removal trailing slash,
+         quiet      => 1,
+    } );
 
     seek DATA, $data_pos, 0; # to read <DATA> twice (expected output is the same)
 
-    convert_n_test("htmldir3", "test --htmldir and --htmlroot 3b", 
-     "--podpath=". catdir($relcwd, 't'),
-     "--podroot=". catpath($v, '/', ''),
-     "--htmldir=t",
-     "--outfile=t/htmldir3.html",
-     "--quiet",
-    );
+    convert_n_test("htmldir3", "test --htmldir and --htmlroot 3b", {
+         podpath    => catdir($relcwd, 't'),
+         podroot    => catpath($v, '/', ''),
+         htmldir    => 't',
+         outfile    => 't/htmldir3.html',
+         quiet      => 1,
+    } );
 }
 
 __DATA__

--- a/ext/Pod-Html/t/htmldir4.t
+++ b/ext/Pod-Html/t/htmldir4.t
@@ -12,22 +12,22 @@ use Test::More tests => 2;
 my $cwd = cwd();
 my $data_pos = tell DATA; # to read <DATA> twice
 
-convert_n_test("htmldir4", "test --htmldir and --htmlroot 4a", 
- "--podpath=t",
- "--htmldir=t",
- "--outfile=". catfile('t', 'htmldir4.html'),
- "--quiet",
-);
+convert_n_test("htmldir4", "test --htmldir and --htmlroot 4a", {
+    podpath     => 't',
+    htmldir     => 't',
+    outfile     => catfile('t', 'htmldir4.html'),
+    quiet       => 1,
+} );
 
 seek DATA, $data_pos, 0; # to read <DATA> twice (expected output is the same)
 
-convert_n_test("htmldir4", "test --htmldir and --htmlroot 4b", 
- "--podpath=t",
- "--podroot=$cwd",
- "--htmldir=". catdir($cwd, 't'),
- "--norecurse",
- "--quiet",
-);
+convert_n_test("htmldir4", "test --htmldir and --htmlroot 4b", {
+    podpath     => 't',
+    podroot     => $cwd,
+    htmldir     => catdir($cwd, 't'),
+    norecurse   => 1,
+    quiet       => 1,
+} );
 
 __DATA__
 <?xml version="1.0" ?>

--- a/ext/Pod-Html/t/htmldir5.t
+++ b/ext/Pod-Html/t/htmldir5.t
@@ -23,13 +23,13 @@ SKIP: {
                             # XXX but why don't the other tests complain about
                             # this?
 
-    convert_n_test("htmldir5", "test --htmldir and --htmlroot 5", 
-     "--podpath=t:testdir/test.lib",
-     "--podroot=$cwd",
-     "--htmldir=$cwd",
-     "--htmlroot=/",
-     "--quiet",
-    );
+    convert_n_test("htmldir5", "test --htmldir and --htmlroot 5", {
+        podpath     => 't:testdir/test.lib',
+        podroot     => $cwd,
+        htmldir     => $cwd,
+        htmlroot    => '/',
+        quiet       => 1,
+    } );
 }
 
 __DATA__

--- a/ext/Pod-Html/t/htmlview.t
+++ b/ext/Pod-Html/t/htmlview.t
@@ -7,7 +7,9 @@ BEGIN {
 use strict;
 use Test::More tests => 1;
 
-convert_n_test("htmlview", "html rendering", "--quiet");
+convert_n_test("htmlview", "html rendering", {
+     quiet  => 1,
+} );
 
 __DATA__
 <?xml version="1.0" ?>

--- a/ext/Pod-Html/t/pod2html-lib.pl
+++ b/ext/Pod-Html/t/pod2html-lib.pl
@@ -41,13 +41,18 @@ sub convert_n_test {
     my $infile   = catpath $vol, $new_dir, "$podfile.pod";
     my $outfile  = catpath $vol, $new_dir, "$podfile.html";
 
+    my %default_args_table = (
+        infile      =>    $infile,
+        outfile     =>    $outfile,
+        podpath     =>    't',
+        htmlroot    =>    '/',
+        podroot     =>    $cwd,
+    );
+    my @default_args_list = map { "--${_}=" . $default_args_table{$_} }
+        keys %default_args_table;
     # To add/modify args to p2h, use @p2h_args
     Pod::Html::pod2html(
-        "--infile=$infile",
-        "--outfile=$outfile",
-        "--podpath=t",
-        "--htmlroot=/",
-        "--podroot=$cwd",
+        @default_args_list,
         @p2h_args,
     );
 

--- a/ext/Pod-Html/t/pod2html-lib.pl
+++ b/ext/Pod-Html/t/pod2html-lib.pl
@@ -52,11 +52,11 @@ sub convert_n_test {
         htmlroot    =>    '/',
         podroot     =>    $cwd,
     );
-    my %no_arg_switches = map { substr($_,2) => 1 } ( qw|
-           --flush --recurse --norecurse
-           --quiet --noquiet --verbose --noverbose
-           --index --noindex --backlink --nobacklink
-           --header --noheader --poderrors --nopoderrors
+    my %no_arg_switches = map { $_ => 1 } ( qw|
+           flush recurse norecurse
+           quiet noquiet verbose noverbose
+           index noindex backlink nobacklink
+           header noheader poderrors nopoderrors
     | );
     if (defined $p2h_args_ref) {
         for my $sw (keys %{$p2h_args_ref}) {

--- a/ext/Pod-Html/t/pod2html-lib.pl
+++ b/ext/Pod-Html/t/pod2html-lib.pl
@@ -62,8 +62,7 @@ sub convert_n_test {
         for my $sw (keys %{$p2h_args_ref}) {
             if ($no_arg_switches{$sw}) {
                 $args_table{$sw} = undef;
-            }
-            else {
+            } else {
                 $args_table{$sw} = $p2h_args_ref->{$sw};
             }
         }
@@ -72,8 +71,7 @@ sub convert_n_test {
     for my $k (keys %args_table) {
         if (defined $args_table{$k}) {
             push @args_list, "--" . $k . "=" . $args_table{$k};
-        }
-        else {
+        } else {
             push @args_list, "--" . $k;
         }
     }

--- a/ext/Pod-Html/t/podnoerr.t
+++ b/ext/Pod-Html/t/podnoerr.t
@@ -7,9 +7,9 @@ BEGIN {
 use strict;
 use Test::More tests => 1;
 
-convert_n_test("podnoerr", "pod error section",
-	"--nopoderrors",
-);
+convert_n_test("podnoerr", "pod error section", {
+	nopoderrors => 1,
+} );
 
 __DATA__
 <?xml version="1.0" ?>


### PR DESCRIPTION
In this pull request I propose to change the interface to a function used inside the test suite for `ext/Pod-Html`.

Function `convert_n_test` currently takes a list of any number of arguments, the first of which is the stem of the basename of a given test file in `t/` and the second of which is the test description.  All remaining arguments are strings in the format `--XXX` where `XXX` is a switch for `Pod::Html::pod2html()`, the principal function within that module and the essence of the command-line utility `pod2html`.

IMO, the fact that `Pod::Html::pod2html()` takes a list of strings which look like command-line options is a bug, not a feature.  However, the ship that bug sailed on left a quarter-century ago.  I'm not proposing to change that function's interface at this date.  But I don't think we should be afraid of changing the interface to testing function `convert_n_test()` to something more rational and Perlish, *i.e.,* a hash reference.

This pull request consolidates all the arguments to `convert_n_test()` other than the first two into a hash reference.  We then parse these arguments into a format acceptable to an internal call to `Pod::Html::pod2html()`.  We adapt all existing files in the module's test suite to this new interface.

I believe that this new interface will make debugging `pod2html` calls easier and will facilitate adding more test files to the test suite.  We will more easily be able to dump the arguments which `convert_n_test()` is passing to `pod2html` before we make that function call.

And, take it from me, we *do* need more tests of Pod-Html.  This [link](https://github.com/Perl/perl5/issues?q=is%3Aissue+label%3Adist%2FPod-Html+is%3Aopen+sort%3Acreated-asc) shows the open issues bearing the 'dist/Pod-Html' link.  Some of these issues date back to 2012 and were some of the first RT tickets I worked on.  The 'dist/Pod-Html` label is a replacement for the META ticket in the old RT system whose name, per @rjbs, was "Pod-Html is a mess."

It's less of a mess now, mainly due to work by Marc Green, Zefram and others.  But it's still messy, and I would like to make the test suite a bit more rational before working on tickets like those in the label URL above.  Please review.

Thank you very much.
Jim Keenan