### PR TITLE
Save and restore errno around DEBUG statements

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -4484,7 +4484,7 @@ Gid_t getegid (void);
 
 #  define DEBUG__(t, a)                                                 \
         STMT_START {                                                    \
-                if (t) STMT_START {a;} STMT_END;                        \
+          if (t) STMT_START { dSAVE_ERRNO; a; RESTORE_ERRNO;} STMT_END; \
         } STMT_END
 
 #  define DEBUG_f(a) DEBUG__(DEBUG_f_TEST, a)


### PR DESCRIPTION
Adding DEBUG statements should not affect errno.  But it could.  I have
in the past wrapped them in save/restores when it's become a problem.
But that is effort that could have been conserved by just always doing
it automatically.