### PR TITLE
Smoke me/yves hash and build fixes

### DIFF
--- a/ext/Hash-Util/Changes
+++ b/ext/Hash-Util/Changes
@@ -1,5 +1,14 @@
 Revision history for Perl extension Hash::Util.
 
+0.25, 0.24
+    Build fixes.
+
+0.23
+    Doc Fixes.
+
+0.22, 0.21
+    Build Fixes.
+
 0.20
     Add bucket_ratio, num_buckets, used_buckets as a back-compat
     shin for 5.25 where we remove the bucket data from scalar(%hash)

--- a/ext/Hash-Util/Util.xs
+++ b/ext/Hash-Util/Util.xs
@@ -95,8 +95,8 @@ hash_value(string,...)
         U8 *seedbuf= (U8 *)SvPV(ST(1),seedlen);
         if ( seedlen < PERL_HASH_SEED_BYTES ) {
             sv_dump(ST(1));
-            Perl_croak(aTHX_ "seed len must be at least %d long only got %"
-                             UVuf " bytes", PERL_HASH_SEED_BYTES, (UV)seedlen);
+            Perl_croak(aTHX_ "seed len must be at least %" UVuf " long only got %"
+                             UVuf " bytes", (UV)PERL_HASH_SEED_BYTES, (UV)seedlen);
         }
 
         PERL_HASH_WITH_SEED(seedbuf, uv, pv, len);

--- a/ext/Hash-Util/lib/Hash/Util.pm
+++ b/ext/Hash-Util/lib/Hash/Util.pm
@@ -42,7 +42,7 @@ our @EXPORT_OK  = qw(
 BEGIN {
     # make sure all our XS routines are available early so their prototypes
     # are correctly applied in the following code.
-    our $VERSION = '0.24';
+    our $VERSION = '0.25';
     require XSLoader;
     XSLoader::load();
 }

--- a/ext/Hash-Util/t/Util.t
+++ b/ext/Hash-Util/t/Util.t
@@ -46,7 +46,7 @@ BEGIN {
                      lock_hash_recurse unlock_hash_recurse
                      lock_hashref_recurse unlock_hashref_recurse
                     );
-    plan tests => 244 + @Exported_Funcs;
+    plan tests => 250 + @Exported_Funcs;
     use_ok 'Hash::Util', @Exported_Funcs;
 }
 foreach my $func (@Exported_Funcs) {
@@ -597,7 +597,27 @@ ok(defined($hash_seed) && $hash_seed ne '', "hash_seed $hash_seed");
     my $h2= hash_value("bar");
     is( $h1, hash_value("foo") );
     is( $h2, hash_value("bar") );
+
+    my $seed= hash_seed();
+    my $h1s= hash_value("foo",$seed);
+    my $h2s= hash_value("bar",$seed);
+
+    is( $h1s, hash_value("foo",$seed) );
+    is( $h2s, hash_value("bar",$seed) );
+
+    $seed= join "", map { chr $_ } 1..length($seed);
+
+    my $h1s2= hash_value("foo",$seed);
+    my $h2s2= hash_value("bar",$seed);
+
+    is( $h1s2, hash_value("foo",$seed) );
+    is( $h2s2, hash_value("bar",$seed) );
+
+    isnt($h1s,$h1s2);
+    isnt($h1s,$h1s2);
+
 }
+
 {
     my @info1= bucket_info({});
     my @info2= bucket_info({1..10});

--- a/ext/PerlIO-encoding/encoding.pm
+++ b/ext/PerlIO-encoding/encoding.pm
@@ -1,7 +1,7 @@
 package PerlIO::encoding;
 
 use strict;
-our $VERSION = '0.29';
+our $VERSION = '0.30';
 our $DEBUG = 0;
 $DEBUG and warn __PACKAGE__, " called by ", join(", ", caller), "\n";
 

--- a/ext/PerlIO-encoding/encoding.xs
+++ b/ext/PerlIO-encoding/encoding.xs
@@ -647,7 +647,6 @@ PROTOTYPES: ENABLE
 
 BOOT:
 {
-    SV *chk = get_sv("PerlIO::encoding::fallback", GV_ADD|GV_ADDMULTI);
     /*
      * we now "use Encode ()" here instead of
      * PerlIO/encoding.pm.  This avoids SEGV when ":encoding()"

--- a/ext/PerlIO-encoding/encoding.xs
+++ b/ext/PerlIO-encoding/encoding.xs
@@ -172,7 +172,7 @@ PerlIOEncode_pushed(pTHX_ PerlIO * f, const char *mode, SV * arg, PerlIO_funcs *
     e->chk = newSVsv(get_sv("PerlIO::encoding::fallback", 0));
     if (SvROK(e->chk))
         Perl_croak(aTHX_ "PerlIO::encoding::fallback must be an integer");
-    SvUV_set(e->chk, SvUV(e->chk) & ~encode_leave_src | encode_stop_at_partial);
+    SvUV_set(e->chk, ((SvUV(e->chk) & ~encode_leave_src) | encode_stop_at_partial));
     e->inEncodeCall = 0;
 
     FREETMPS;

--- a/hv_func.h
+++ b/hv_func.h
@@ -105,14 +105,6 @@
 
 #endif
 
-PERL_STATIC_INLINE
-U32 S_perl_hash_with_seed(const U8 * const seed, const U8 * const str, const STRLEN len)
-{
-    U8 state[_PERL_HASH_STATE_BYTES];
-    _PERL_HASH_SEED_STATE(seed,state);
-    return _PERL_HASH_WITH_STATE(state,str,len);
-}
-
 #define PERL_HASH_WITH_SEED(seed,hash,str,len) \
     (hash) = S_perl_hash_with_seed((const U8 *) seed, (const U8 *) str,len)
 #define PERL_HASH_WITH_STATE(state,hash,str,len) \
@@ -159,6 +151,13 @@ U32 S_perl_hash_with_seed(const U8 * const seed, const U8 * const str, const STR
 #ifdef PERL_HASH_INTERNAL_ACCESS
 #define PERL_HASH_INTERNAL(hash,str,len) PERL_HASH(hash,str,len)
 #endif
+
+PERL_STATIC_INLINE U32
+S_perl_hash_with_seed(const U8 * seed, const U8 *str, STRLEN len) {
+    U8 state[_PERL_HASH_STATE_BYTES];
+    _PERL_HASH_SEED_STATE(seed,state);
+    return _PERL_HASH_WITH_STATE(state,str,len);
+}
 
 #endif /*compile once*/
 

--- a/hv_func.h
+++ b/hv_func.h
@@ -36,27 +36,31 @@
 
 #if defined(PERL_HASH_FUNC_SIPHASH)
 # define __PERL_HASH_FUNC "SIPHASH_2_4"
-# define __PERL_HASH_SEED_BYTES 16
-# define __PERL_HASH_STATE_BYTES 32
+# define __PERL_HASH_WORD_SIZE sizeof(U64)
+# define __PERL_HASH_SEED_BYTES (__PERL_HASH_WORD_SIZE * 2)
+# define __PERL_HASH_STATE_BYTES (__PERL_HASH_WORD_SIZE * 4)
 # define __PERL_HASH_SEED_STATE(seed,state) S_perl_siphash_seed_state(seed,state)
 # define __PERL_HASH_WITH_STATE(state,str,len) S_perl_hash_siphash_2_4_with_state((state),(U8*)(str),(len))
 #elif defined(PERL_HASH_FUNC_SIPHASH13)
 # define __PERL_HASH_FUNC "SIPHASH_1_3"
-# define __PERL_HASH_SEED_BYTES 16
-# define __PERL_HASH_STATE_BYTES 32
+# define __PERL_HASH_WORD_SIZE sizeof(U64)
+# define __PERL_HASH_SEED_BYTES (__PERL_HASH_WORD_SIZE * 2)
+# define __PERL_HASH_STATE_BYTES (__PERL_HASH_WORD_SIZE * 4)
 # define __PERL_HASH_SEED_STATE(seed,state) S_perl_siphash_seed_state(seed,state)
 # define __PERL_HASH_WITH_STATE(state,str,len) S_perl_hash_siphash_1_3_with_state((state),(U8*)(str),(len))
 #elif defined(PERL_HASH_FUNC_STADTX)
 # define __PERL_HASH_FUNC "STADTX"
-# define __PERL_HASH_SEED_BYTES 16
-# define __PERL_HASH_STATE_BYTES 32
+# define __PERL_HASH_WORD_SIZE sizeof(U64)
+# define __PERL_HASH_SEED_BYTES (__PERL_HASH_WORD_SIZE * 2)
+# define __PERL_HASH_STATE_BYTES (__PERL_HASH_WORD_SIZE * 4)
 # define __PERL_HASH_SEED_STATE(seed,state) stadtx_seed_state(seed,state)
 # define __PERL_HASH_WITH_STATE(state,str,len) (U32)stadtx_hash_with_state((state),(U8*)(str),(len))
 # include "stadtx_hash.h"
 #elif defined(PERL_HASH_FUNC_ZAPHOD32)
 # define __PERL_HASH_FUNC "ZAPHOD32"
-# define __PERL_HASH_SEED_BYTES 12
-# define __PERL_HASH_STATE_BYTES 12
+# define __PERL_HASH_WORD_SIZE sizeof(U32)
+# define __PERL_HASH_SEED_BYTES (__PERL_HASH_WORD_SIZE * 3)
+# define __PERL_HASH_STATE_BYTES (__PERL_HASH_WORD_SIZE * 3)
 # define __PERL_HASH_SEED_STATE(seed,state) zaphod32_seed_state(seed,state)
 # define __PERL_HASH_WITH_STATE(state,str,len) (U32)zaphod32_hash_with_state((state),(U8*)(str),(len))
 # include "zaphod32_hash.h"
@@ -87,8 +91,10 @@
 #else
 
 #define _PERL_HASH_FUNC         "SBOX32_WITH_" __PERL_HASH_FUNC
-
-#define _PERL_HASH_SEED_BYTES   ( __PERL_HASH_SEED_BYTES + (int)( 3 * sizeof(U32) ) )
+#define __PERL_HASH_SEED_roundup(x, y)   ((((x)+((y)-1))/(y))*(y))
+#define _PERL_HASH_SEED_roundup(x) __PERL_HASH_SEED_roundup(x,__PERL_HASH_WORD_SIZE)
+/* note the 3 in the below code comes from the fact the seed to initialize the SBOX is 96 bits */
+#define _PERL_HASH_SEED_BYTES   ( _PERL_HASH_SEED_roundup(__PERL_HASH_SEED_BYTES + (int)( 3 * sizeof(U32)) ) )
 
 #define _PERL_HASH_STATE_BYTES  \
     ( __PERL_HASH_STATE_BYTES + ( ( 1 + ( 256 * SBOX32_MAX_LEN ) ) * sizeof(U32) ) )

--- a/t/opbasic/arith.t
+++ b/t/opbasic/arith.t
@@ -442,7 +442,8 @@ if ($^O eq 'VMS') {
 if ($^O eq 'vos') {
   print "not ok ", $T++, " # TODO VOS raises SIGFPE instead of producing infinity.\n";
 }
-elsif ($vms_no_ieee || !$Config{d_double_has_inf}) {
+elsif ($vms_no_ieee || !$Config::Config{d_double_has_inf}) {
+ # note Config.pm is only loaded under VMS and via a require.
  print "ok ", $T++, " # SKIP -- the IEEE infinity model is unavailable in this configuration.\n"
 }
 elsif ($^O eq 'ultrix') {
@@ -472,7 +473,8 @@ else {
 # [perl #120426]
 # small numbers shouldn't round to zero if they have extra floating digits
 
-unless ($Config{d_double_style_ieee}) {
+# note Config.pm is only loaded under VMS and via a require.
+unless ($Config::Config{d_double_style_ieee}) {
 for (1..8) { print "ok ", $T++, " # SKIP -- not IEEE\n" }
 } else {
 try $T++,  0.153e-305 != 0.0,              '0.153e-305';


### PR DESCRIPTION
This addresses a number of hash related issues and a few minor build issues I noticed along the way.

1. It hard caps the max size of a hash bucket array at 2**28 to prevent various forms of overflow.
2. It fixes the way siphash is set up so that -Accflags=-DPERL_HASH_FUNC_SIPHASH13 works as expected.
3. It ensures that seed and state variables are sized such that they align correctly.
4. Implements S_perl_hash_with_seed() which was not implemented leaving an untested branch in Hash::Util::hash_value() liable to fault, and adds tests.
5. Fixes some build warnings in PerlIO::encoding related to the fallback variable.
6. Fixes t/opbasic/arith.t to not warn and to use the right %Config::Config hash since %Config isn't imported.

Note that the above point 3 is related to issue #18555

