### PR TITLE
Smoke me/fix caller issues

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5639,6 +5639,9 @@ t/lib/feature/nonesuch		Tests for enabling/disabling nonexistent feature
 t/lib/feature/removed		Tests for enabling/disabling removed feature
 t/lib/feature/say		Tests for enabling/disabling say feature
 t/lib/feature/switch		Tests for enabling/disabling switch feature
+t/lib/GH_15109/Apack.pm		test Module for caller.t
+t/lib/GH_15109/Bpack.pm		test Module for caller.t
+t/lib/GH_15109/Cpack.pm		test Module for caller.t
 t/lib/h2ph.h			Test header file for h2ph
 t/lib/h2ph.pht			Generated output from h2ph.h by h2ph, for comparison
 t/lib/locale/latin1		Part of locale.t in Latin 1

--- a/MANIFEST
+++ b/MANIFEST
@@ -5642,6 +5642,7 @@ t/lib/feature/switch		Tests for enabling/disabling switch feature
 t/lib/GH_15109/Apack.pm		test Module for caller.t
 t/lib/GH_15109/Bpack.pm		test Module for caller.t
 t/lib/GH_15109/Cpack.pm		test Module for caller.t
+t/lib/GH_15109/Foo.pm		test Module for caller.t
 t/lib/h2ph.h			Test header file for h2ph
 t/lib/h2ph.pht			Generated output from h2ph.h by h2ph, for comparison
 t/lib/locale/latin1		Part of locale.t in Latin 1

--- a/op.c
+++ b/op.c
@@ -11759,10 +11759,9 @@ S_process_special_blocks(pTHX_ I32 floor, const char *const fullname,
                  * to PL_compiling, IN_PERL_COMPILETIME/IN_PERL_RUNTIME
                  * will give the wrong answer.
                  */
-                Newx(PL_curcop, 1, COP);
-                StructCopy(&PL_compiling, PL_curcop, COP);
-                PL_curcop->op_slabbed = 0;
-                SAVEFREEPV(PL_curcop);
+                PL_curcop = (COP*)newSTATEOP(PL_compiling.op_flags, NULL, NULL);
+                CopLINE_set(PL_curcop, CopLINE(&PL_compiling));
+                SAVEFREEOP(PL_curcop);
             }
 
             PUSHSTACKi(PERLSI_REQUIRE);

--- a/op.c
+++ b/op.c
@@ -11742,10 +11742,32 @@ S_process_special_blocks(pTHX_ I32 floor, const char *const fullname,
             (void)CvGV(cv);
 	    if (floor) LEAVE_SCOPE(floor);
 	    ENTER;
+
+            SAVEVPTR(PL_curcop);
+            if (PL_curcop == &PL_compiling) {
+                /* Avoid pushing the "global" &PL_compiling onto the
+                 * context stack. For example, a stack trace inside
+                 * nested use's would show all calls coming from whoever
+                 * most recently updated PL_compiling.cop_file and
+                 * cop_line.  So instead, temporarily set PL_curcop to a
+                 * private copy of &PL_compiling. PL_curcop will soon be
+                 * set to point back to &PL_compiling anyway but only
+                 * after the temp value has been pushed onto the context
+                 * stack as blk_oldcop.
+                 * This is slightly hacky, but necessary. Note also
+                 * that in the brief window before PL_curcop is set back
+                 * to PL_compiling, IN_PERL_COMPILETIME/IN_PERL_RUNTIME
+                 * will give the wrong answer.
+                 */
+                Newx(PL_curcop, 1, COP);
+                StructCopy(&PL_compiling, PL_curcop, COP);
+                PL_curcop->op_slabbed = 0;
+                SAVEFREEPV(PL_curcop);
+            }
+
             PUSHSTACKi(PERLSI_REQUIRE);
 	    SAVECOPFILE(&PL_compiling);
 	    SAVECOPLINE(&PL_compiling);
-	    SAVEVPTR(PL_curcop);
 
 	    DEBUG_x( dump_sub(gv) );
 	    Perl_av_create_and_push(aTHX_ &PL_beginav, MUTABLE_SV(cv));

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -1879,6 +1879,10 @@ It has the same scoping as the C<$^H> and C<%^H> variables.  The exact
 values are considered internal to the L<warnings> pragma and may change
 between versions of Perl.
 
+Each time a statement completes being compiled, the current value of
+C<${^WARNING_BITS}> is stored with that statement, and can later be
+retrieved via C<(caller($level))[9]>.
+
 This variable was added in Perl v5.6.0.
 
 =item $OS_ERROR
@@ -2175,6 +2179,10 @@ This variable contains compile-time hints for the Perl interpreter.  At the
 end of compilation of a BLOCK the value of this variable is restored to the
 value when the interpreter started to compile the BLOCK.
 
+Each time a statement completes being compiled, the current value of
+C<$^H> is stored with that statement, and can later be retrieved via
+C<(caller($level))[8]>.
+
 When perl begins to parse any block construct that provides a lexical scope
 (e.g., eval body, required file, subroutine body, loop body, or conditional
 block), the existing value of C<$^H> is saved, but its value is left unchanged.
@@ -2222,6 +2230,10 @@ it useful for implementation of lexically scoped pragmas.  See
 L<perlpragma>.   All the entries are stringified when accessed at
 runtime, so only simple values can be accommodated.  This means no
 pointers to objects, for example.
+
+Each time a statement completes being compiled, the current value of
+C<%^H> is stored with that statement, and can later be retrieved via
+C<(caller($level))[10]>.
 
 When putting items into C<%^H>, in order to avoid conflicting with other
 users of the hash there is a convention regarding which keys to use.

--- a/t/lib/GH_15109/Apack.pm
+++ b/t/lib/GH_15109/Apack.pm
@@ -1,0 +1,4 @@
+# for use by caller.t for GH #15109
+package Apack;
+use Bpack;
+1;

--- a/t/lib/GH_15109/Bpack.pm
+++ b/t/lib/GH_15109/Bpack.pm
@@ -1,0 +1,4 @@
+# for use by caller.t for GH #15109
+package Bpack;
+use Cpack;
+1;

--- a/t/lib/GH_15109/Cpack.pm
+++ b/t/lib/GH_15109/Cpack.pm
@@ -1,0 +1,11 @@
+# for use by caller.t for GH #15109
+package Cpack;
+
+
+my $i = 0;
+
+while (my ($package, $file, $line) = caller($i++)) {
+    push @Cpack::callers, "$file:$line";
+}
+
+1;

--- a/t/lib/GH_15109/Foo.pm
+++ b/t/lib/GH_15109/Foo.pm
@@ -1,0 +1,9 @@
+# for use by caller.t for GH #15109
+
+package Foo;
+
+sub import {
+    use warnings; # restore default warnings
+    () = caller(1); # this used to cause valgrind errors
+}
+1;


### PR DESCRIPTION
There are and have been multiple bug reports over the years related to caller() showing bogus data about require call frames.

For example issue #15109 and I believe #4125 and someewhere there is one I created as well. I am sure if we dig we will find more. The issue comes from using a single global variable to store the file and line data for the "fake" parts of the expansion of 

  use Foo;

into

  BEGIN{ require Foo; } 

Using one variable meant that certain exceptions were correct, but walking the callstack would end up pointers to the same data structure from multiple distinct frames in the stack, thus making *every* require in the call stack look as though there were "from" the same line and file, that of the most recent require. For the exact same code, depending on where in the call stack an exception is thrown mutliple frames will appear to change their origin. 

This is not and cannot be correct. A given BEGIN block fires only once, it cannot appear in the callstack more than one, and it cannot  be recursive. 

Dave M then fixed the problem with various patches. These fixes then broke modules which had come to depend on the buggy implementation and the patches were reverted at the time. This PR reverts those reverts. The code which depends on the buggy stack data  should be fixed so the rest of us have sane callstacks to debug our code with.

See Issue #17663 for details on the revert. I believe the statement contained in #15109 outlines the problem sufficiently. See also the test in the PR.



