### PR TITLE
Smoke me/jkeenan/gh 18570 t op magic

### DIFF
--- a/t/op/magic.t
+++ b/t/op/magic.t
@@ -797,48 +797,48 @@ SKIP: {
 	env_is(__NoNeLoCaL => '');
 
     SKIP: {
-	    skip("\$0 check only on Linux, Dragonfly BSD and FreeBSD", 2)
-		unless $^O =~ /^(linux|android|dragonfly|freebsd)$/;
+        skip("\$0 check only on Linux, Dragonfly BSD and FreeBSD", 2)
+        unless $^O =~ /^(linux|android|dragonfly|freebsd)$/;
 
-            SKIP: {
-                skip("No procfs cmdline support", 1)
-                    unless open CMDLINE, "/proc/$$/cmdline";
+        SKIP: {
+            skip("No procfs cmdline support", 1)
+                unless open CMDLINE, "/proc/$$/cmdline";
 
-                chomp(my $line = scalar <CMDLINE>);
-                my $me = (split /\0/, $line)[0];
-                is $me, $0, 'altering $0 is effective (testing with /proc/)';
-                close CMDLINE;
-            }
-            skip("No \$0 check with 'ps' on Android", 1) if $^O eq 'android';
-            # perlbug #22811
-            my $mydollarzero = sub {
-              my($arg) = shift;
-              $0 = $arg if defined $arg;
-	      # In FreeBSD the ps -o command= will cause
-	      # an empty header line, grab only the last line.
-              my $ps = (`ps -o command= -p $$`)[-1];
-              return if $?;
-              chomp $ps;
-              $ps;
-            };
-            my $ps = $mydollarzero->("x");
-            # we allow that something goes wrong with the ps command
-            !$ps && skip("The ps command failed", 1);
-            my $ps_re = ( $^O =~ /^(dragonfly|freebsd)$/ )
-                # FreeBSD cannot get rid of both the leading "perl :"
-                # and the trailing " (perl)": some FreeBSD versions
-                # can get rid of the first one.
-                ? qr/^(?:perl: )?x(?: \(perl\))?$/
-                # In Linux 2.4 we would get an exact match ($ps eq 'x') but
-                # in Linux 2.2 there seems to be something funny going on:
-                # it seems as if the original length of the argv[] would
-                # be stored in the proc struct and then used by ps(1),
-                # no matter what characters we use to pad the argv[].
-                # (And if we use \0:s, they are shown as spaces.)  Sigh.
-               : qr/^x\s*$/
-            ;
-            like($ps, $ps_re, 'altering $0 is effective (testing with `ps`)');
-	}
+            chomp(my $line = scalar <CMDLINE>);
+            my $me = (split /\0/, $line)[0];
+            is $me, $0, 'altering $0 is effective (testing with /proc/)';
+            close CMDLINE;
+        }
+        skip("No \$0 check with 'ps' on Android", 1) if $^O eq 'android';
+        # perlbug #22811
+        my $mydollarzero = sub {
+            my($arg) = shift;
+            $0 = $arg if defined $arg;
+            # In FreeBSD the ps -o command= will cause
+            # an empty header line, grab only the last line.
+            my $ps = (`ps -o command= -p $$`)[-1];
+            return if $?;
+            chomp $ps;
+            $ps;
+        };
+        my $ps = $mydollarzero->("x");
+        # we allow that something goes wrong with the ps command
+        !$ps && skip("The ps command failed", 1);
+        my $ps_re = ( $^O =~ /^(dragonfly|freebsd)$/ )
+            # FreeBSD cannot get rid of both the leading "perl :"
+            # and the trailing " (perl)": some FreeBSD versions
+            # can get rid of the first one.
+            ? qr/^(?:perl: )?x(?: \(perl\))?$/
+            # In Linux 2.4 we would get an exact match ($ps eq 'x') but
+            # in Linux 2.2 there seems to be something funny going on:
+            # it seems as if the original length of the argv[] would
+            # be stored in the proc struct and then used by ps(1),
+            # no matter what characters we use to pad the argv[].
+            # (And if we use \0:s, they are shown as spaces.)  Sigh.
+           : qr/^x\s*$/
+        ;
+        like($ps, $ps_re, 'altering $0 is effective (testing with `ps`)');
+    }
 }
 
 # test case-insignificance of %ENV (these tests must be enabled only

--- a/t/op/magic.t
+++ b/t/op/magic.t
@@ -828,7 +828,7 @@ SKIP: {
             # FreeBSD cannot get rid of both the leading "perl :"
             # and the trailing " (perl)": some FreeBSD versions
             # can get rid of the first one.
-            ? qr/^(?:perl: )?x(?: \(perl\))?$/
+            ? qr/^(?:(?:mini)?perl: )?x(?: \((?:mini)?perl\))?$/
             # In Linux 2.4 we would get an exact match ($ps eq 'x') but
             # in Linux 2.2 there seems to be something funny going on:
             # it seems as if the original length of the argv[] would


### PR DESCRIPTION
@tomhukins, with this patch `t/op/magic.t` once again PASSes on FreeBSD-12 when invoked via `./miniperl -Ilib t/op/magic.t` and during `make minitest`.  It continues to pass when run with `./perl`.

However, your inline comments suggest that this might need to be tested on other (older ?) FreeBSDs and on Dragonfly BSD.  Can you review?

For: https://github.com/Perl/perl5/issues/18570

Thank you very much.
Jim Keenan