### PR TITLE
Update search.cpan.org URLs

### DIFF
--- a/dist/Devel-PPPort/HACKERS
+++ b/dist/Devel-PPPort/HACKERS
@@ -617,7 +617,7 @@ variable C<DPPP_CHECK_LEVEL> to 1 or 2.
 All of these files could be generated on the fly while building
 C<Devel::PPPort>, but not having the tests in F<t/> will confuse
 TEST/harness in the core. Not having F<PPPort.pm> will be bad for
-viewing the docs on C<search.cpan.org>. So unfortunately, it's
+viewing the docs on C<metacpan.org>. So unfortunately, it's
 unavoidable to put some redundancy into the package.
 
 =head2 Submitting Patches

--- a/dist/IO/IO.pm
+++ b/dist/IO/IO.pm
@@ -7,7 +7,7 @@ use Carp;
 use strict;
 use warnings;
 
-our $VERSION = "1.45_001";
+our $VERSION = "1.46";
 XSLoader::load 'IO', $VERSION;
 
 sub import {

--- a/dist/IO/IO.pm
+++ b/dist/IO/IO.pm
@@ -7,7 +7,7 @@ use Carp;
 use strict;
 use warnings;
 
-our $VERSION = "1.45";
+our $VERSION = "1.45_001";
 XSLoader::load 'IO', $VERSION;
 
 sub import {
@@ -53,7 +53,7 @@ in one go.  The IO modules belonging to the core are:
 
 Some other IO modules don't belong to the perl core but can be loaded
 as well if they have been installed from CPAN.  You can discover which
-ones exist by searching for "^IO::" on L<http://search.cpan.org>.
+ones exist with this query:  L<https://metacpan.org/search?q=IO%3A%3A>.
 
 For more information on any of these modules, please see its respective
 documentation.

--- a/dist/IO/lib/IO/Dir.pm
+++ b/dist/IO/lib/IO/Dir.pm
@@ -18,7 +18,7 @@ use File::stat;
 use File::Spec;
 
 our @ISA = qw(Tie::Hash Exporter);
-our $VERSION = "1.45";
+our $VERSION = "1.46";
 
 our @EXPORT_OK = qw(DIR_UNLINK);
 

--- a/dist/IO/lib/IO/File.pm
+++ b/dist/IO/lib/IO/File.pm
@@ -135,7 +135,7 @@ require Exporter;
 
 our @ISA = qw(IO::Handle IO::Seekable Exporter);
 
-our $VERSION = "1.45";
+our $VERSION = "1.46";
 
 our @EXPORT = @IO::Seekable::EXPORT;
 

--- a/dist/IO/lib/IO/Handle.pm
+++ b/dist/IO/lib/IO/Handle.pm
@@ -270,7 +270,7 @@ use IO ();	# Load the XS module
 require Exporter;
 our @ISA = qw(Exporter);
 
-our $VERSION = "1.45";
+our $VERSION = "1.46";
 
 our @EXPORT_OK = qw(
     autoflush

--- a/dist/IO/lib/IO/Pipe.pm
+++ b/dist/IO/lib/IO/Pipe.pm
@@ -13,7 +13,7 @@ use strict;
 use Carp;
 use Symbol;
 
-our $VERSION = "1.45";
+our $VERSION = "1.46";
 
 sub new {
     my $type = shift;

--- a/dist/IO/lib/IO/Poll.pm
+++ b/dist/IO/lib/IO/Poll.pm
@@ -12,7 +12,7 @@ use IO::Handle;
 use Exporter ();
 
 our @ISA = qw(Exporter);
-our $VERSION = "1.45";
+our $VERSION = "1.46";
 
 our @EXPORT = qw( POLLIN
 	      POLLOUT

--- a/dist/IO/lib/IO/Seekable.pm
+++ b/dist/IO/lib/IO/Seekable.pm
@@ -106,7 +106,7 @@ require Exporter;
 our @EXPORT = qw(SEEK_SET SEEK_CUR SEEK_END);
 our @ISA = qw(Exporter);
 
-our $VERSION = "1.45";
+our $VERSION = "1.46";
 
 sub seek {
     @_ == 3 or croak 'usage: $io->seek(POS, WHENCE)';

--- a/dist/IO/lib/IO/Select.pm
+++ b/dist/IO/lib/IO/Select.pm
@@ -10,7 +10,7 @@ use     strict;
 use warnings::register;
 require Exporter;
 
-our $VERSION = "1.45";
+our $VERSION = "1.46";
 
 our @ISA = qw(Exporter); # This is only so we can do version checking
 

--- a/dist/IO/lib/IO/Socket.pm
+++ b/dist/IO/lib/IO/Socket.pm
@@ -23,7 +23,7 @@ require IO::Socket::UNIX if ($^O ne 'epoc' && $^O ne 'symbian');
 
 our @ISA = qw(IO::Handle);
 
-our $VERSION = "1.45";
+our $VERSION = "1.46";
 
 our @EXPORT_OK = qw(sockatmark);
 

--- a/dist/IO/lib/IO/Socket/INET.pm
+++ b/dist/IO/lib/IO/Socket/INET.pm
@@ -14,7 +14,7 @@ use Exporter;
 use Errno;
 
 our @ISA = qw(IO::Socket);
-our $VERSION = "1.45";
+our $VERSION = "1.46";
 
 my $EINVAL = exists(&Errno::EINVAL) ? Errno::EINVAL() : 1;
 

--- a/dist/IO/lib/IO/Socket/UNIX.pm
+++ b/dist/IO/lib/IO/Socket/UNIX.pm
@@ -11,7 +11,7 @@ use IO::Socket;
 use Carp;
 
 our @ISA = qw(IO::Socket);
-our $VERSION = "1.45";
+our $VERSION = "1.46";
 
 IO::Socket::UNIX->register_domain( AF_UNIX );
 

--- a/ext/mro/mro.pm
+++ b/ext/mro/mro.pm
@@ -12,7 +12,7 @@ use warnings;
 
 # mro.pm versions < 1.00 reserved for MRO::Compat
 #  for partial back-compat to 5.[68].x
-our $VERSION = '1.25';
+our $VERSION = '1.25_001';
 
 require XSLoader;
 XSLoader::load('mro');

--- a/ext/mro/mro.xs
+++ b/ext/mro/mro.xs
@@ -63,8 +63,9 @@ S_mro_get_linear_isa_c3(pTHX_ HV* stash, U32 level)
 
     /* For a better idea how the rest of this works, see the much clearer
        pure perl version in Algorithm::C3 0.01:
-       http://search.cpan.org/src/STEVAN/Algorithm-C3-0.01/lib/Algorithm/C3.pm
-       (later versions go about it differently than this code for speed reasons)
+       https://fastapi.metacpan.org/source/STEVAN/Algorithm-C3-0.01/lib/Algorithm/C3.pm
+       (later versions of this module go about it differently than this code
+       for speed reasons)
     */
 
     if(isa && AvFILLp(isa) >= 0) {

--- a/pod/perlhack.pod
+++ b/pod/perlhack.pod
@@ -1166,7 +1166,7 @@ source, and we'll do that later on.
 Gisle Aas's "illustrated perlguts", also known as I<illguts>, has very
 helpful pictures:
 
-L<https://search.cpan.org/dist/illguts/>
+L<https://metacpan.org/release/RURBAN/illguts-0.49>
 
 =item * L<perlxstut> and L<perlxs>
 


### PR DESCRIPTION
search.cpan.org has (sadly) been gone for several years now.  This patch
updates the remaining important instances of that URL found in the parts
of the core distribution under the control of Perl 5 Porters, i.e.,
excluding the cpan/ directory.

The patch does not attempt to update URLs in "historical" data, e.g.,
older perldeltas.  Nor does it attempt to deal with results produced by
Porting/checkURL.pl.