### PR TITLE
Disallow double signs and spaces between a sign and number in my_atof3

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5885,6 +5885,7 @@ t/op/mydef.t			See if "my $_" works
 t/op/negate.t			See if unary minus works
 t/op/not.t			See if not works
 t/op/numconvert.t		See if accessing fields does not change numeric values
+t/op/numify.t			See if string-to-number conversion works
 t/op/oct.t			See if oct and hex work
 t/op/or.t			See if || works in weird situations
 t/op/ord.t			See if ord works

--- a/numeric.c
+++ b/numeric.c
@@ -1675,6 +1675,10 @@ Perl_my_atof3(pTHX_ const char* orig, NV* value, const STRLEN len)
             return (char *)s+1;
         }
 
+        /* strtod will parse a sign (and skip leading whitespaces) by itself,
+         * so rewind s to the beginning of the string. */
+        s = orig;
+
         /* If the length is passed in, the input string isn't NUL-terminated,
          * and in it turns out the function below assumes it is; therefore we
          * create a copy and NUL-terminate that */
@@ -1682,7 +1686,7 @@ Perl_my_atof3(pTHX_ const char* orig, NV* value, const STRLEN len)
             Newx(copy, len + 1, char);
             Copy(orig, copy, len, char);
             copy[len] = '\0';
-            s = copy + (s - orig);
+            s = copy;
         }
 
         result[2] = S_strtod(aTHX_ s, &endp);
@@ -1696,7 +1700,8 @@ Perl_my_atof3(pTHX_ const char* orig, NV* value, const STRLEN len)
         }
 
         if (s != endp) {
-            *value = negative ? -result[2] : result[2];
+            /* Note that negation is handled by strtod. */
+            *value = result[2];
             return endp;
         }
         return NULL;

--- a/t/op/numify.t
+++ b/t/op/numify.t
@@ -1,0 +1,42 @@
+#! ./perl
+
+# Test string-to-number conversions.
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+}
+
+use strict;
+use warnings;
+
+foreach ([' +3', 3, 0],
+         ["10.\t", 10, 0],
+         ['abc', 0, 1],
+         ['- +3', 0, 1],        # GH 18584
+         ['++4', 0, 1],
+         ['0x123', 0, 1],
+         ['1x123', 1, 1],
+         ['+0x456', 0, 1],
+         ['- 0x789', 0, 1],
+         ['0b101', 0, 1],
+         ['-3.14', -3.14, 0],
+         ['- 3.14', 0, 1]) {
+    my ($str, $num, $warn) = @$_;
+
+    my $code = sub {
+        cmp_ok($str + 0, '==', $num, "numifying '$str'");
+    };
+
+    if ($warn) {
+        warning_like($code, qr/^Argument ".*" isn't numeric/,
+                     "numifying '$str' trigger a warning");
+    }
+    else {
+        warning_is($code, undef,
+                   "numifying '$str' does not trigger warnings");
+    }
+}
+
+done_testing();

--- a/t/op/numify.t
+++ b/t/op/numify.t
@@ -11,6 +11,11 @@ BEGIN {
 use strict;
 use warnings;
 
+# Quick test if NV supports infinities.
+# Note that this would be $Config{d_double_has_inf}, but this is only valid
+# if NV is configured as double.
+my $nv_has_inf = do { no warnings; 'inf' > 0 };
+
 foreach ([' +3', 3, 0],
          ["10.\t", 10, 0],
          ['abc', 0, 1],
@@ -22,7 +27,14 @@ foreach ([' +3', 3, 0],
          ['- 0x789', 0, 1],
          ['0b101', 0, 1],
          ['-3.14', -3.14, 0],
-         ['- 3.14', 0, 1]) {
+         ['- 3.14', 0, 1],
+         ($nv_has_inf ?
+          (['+infinity ', '+Inf', 0],
+           ['  -infin', '-Inf', 1],
+           ['+ inf', 0, 1],
+           ['+-inf', 0, 1]) :
+          ())
+    ) {
     my ($str, $num, $warn) = @$_;
 
     my $code = sub {


### PR DESCRIPTION
`Perl_my_atof3` used to pass a substring after the first (optional) sign to `S_strtod`, which causes wrong numifications for strings like `"-+3"` or `"+ 0x123"` (for the latter case, while `Perl_my_atof3 already` had the code to block `"0x"` prefixes, this string will slip through due to the space character in it).

Will fix #18584.
