### PR TITLE
Add ability to easily add info to DEBUG output

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -4487,16 +4487,22 @@ Gid_t getegid (void);
                               }                                         \
     } STMT_END
 
+#ifndef DEBUG_PRE
+#  define DEBUG_PRE
+#endif
+#ifndef DEBUG_POST
+#  define DEBUG_POST
+#endif
 #  define DEBUG__(t, a)                                                 \
         STMT_START {                                                    \
-                if (t) STMT_START {a;} STMT_END;                        \
+                if (t) STMT_START {DEBUG_PRE a; DEBUG_POST} STMT_END;   \
         } STMT_END
 
 #  define DEBUG_f(a) DEBUG__(DEBUG_f_TEST, a)
 
 /* For re_comp.c, re_exec.c, assume -Dr has been specified */
 #  ifdef PERL_EXT_RE_BUILD
-#    define DEBUG_r(a) STMT_START {a;} STMT_END
+#    define DEBUG_r(a) STMT_START {DEBUG_PRE a; DEBUG_POST} STMT_END;
 #  else
 #    define DEBUG_r(a) DEBUG__(DEBUG_r_TEST, a)
 #  endif /* PERL_EXT_RE_BUILD */


### PR DESCRIPTION
This commit adds two macros that a user can define and recompile Perl to
get every active DEBUG statement to do  something beyond what it would
normally do.

This allows someone to recompile Perl when they need to delve deeper
into fixing a bug without increasing memory use or slowing execution
otherwise.

This could be used to save and restore the errno around debugging, or to print location information about the DEBUG macro calls:
```#dedine DEBUG_PRE   PerlIO_printf(Perl_debug_log, "%s:%d: ", __FILE__, __LINE__);```

or some other variable, like aTHX, or some PL_foo.

I would prefer better names than DEBUG_PRE and POST, suggestions welcome
`