### PR TITLE
Vulnerabilities in cpan/ modules still affect perl; we should handle them

### DIFF
--- a/pod/perlsecpolicy.pod
+++ b/pod/perlsecpolicy.pod
@@ -92,8 +92,10 @@ core Perl repository
 =back
 
 Files under the F<cpan/> directory in Perl's repository and release tarballs are
-developed and maintained independently. The Perl security team does not handle
-security issues for these modules.
+developed and maintained independently. The Perl security team does not
+directly handle security issues for these modules, but since this code is
+bundled with Perl, we will assist in forwarding the issue to the relevant
+maintainer(s) and you can still report these issues to us in secrecy.
 
 =head2 Bugs that may qualify as security issues in Perl
 


### PR DESCRIPTION
This is a proposed wording change for perlsecpolicy.pod regarding issues in modules shipped under the cpan/ directory, which are dual-life but generally shipped to CPAN first and then copied here.

Since these modules are bundled with perl, any security issues with them can still be seen as security issues of perl itself, as we should not wash our hands of these issues entirely. It would be beneficial to still report the issue to the closed security list, which can then coordinate with the respective author(s) to get the issue fixed, or potentially if the module is not actively maintained, someone from p5p itself can take on the task of fixing the bug and submitting it upstream to the author (and potentially shipping the patched version in perl itself before the cpan version has been released).