### PR TITLE
Mark Data::Dumper output as UTF-8 when the regex requires it

### DIFF
--- a/dist/Data-Dumper/Dumper.pm
+++ b/dist/Data-Dumper/Dumper.pm
@@ -29,7 +29,7 @@ our ( $Indent, $Trailingcomma, $Purity, $Pad, $Varname, $Useqq, $Terse, $Freezer
 our ( @ISA, @EXPORT, @EXPORT_OK, $VERSION );
 
 BEGIN {
-    $VERSION = '2.176'; # Don't forget to set version and release
+    $VERSION = '2.177'; # Don't forget to set version and release
                         # date in POD below!
 
     @ISA = qw(Exporter);
@@ -1477,7 +1477,7 @@ modify it under the same terms as Perl itself.
 
 =head1 VERSION
 
-Version 2.175
+Version 2.177
 
 =head1 SEE ALSO
 

--- a/dist/Data-Dumper/Dumper.xs
+++ b/dist/Data-Dumper/Dumper.xs
@@ -651,6 +651,10 @@ dump_regexp(pTHX_ SV *retval, SV *val)
 
     assert(sv_pattern);
 
+    if (SvUTF8(sv_pattern)) {
+        sv_utf8_upgrade(retval);
+    }
+
     rval = SvPV(sv_pattern, rlen);
     rend = rval+rlen;
     slash = rval;

--- a/dist/Data-Dumper/t/dumper.t
+++ b/dist/Data-Dumper/t/dumper.t
@@ -139,7 +139,7 @@ sub SKIP_TEST {
   ++$TNUM; print "ok $TNUM # skip $reason\n";
 }
 
-$TMAX = 468;
+$TMAX = 474;
 
 # Force Data::Dumper::Dump to use perl. We test Dumpxs explicitly by calling
 # it direct. Out here it lets us knobble the next if to test that the perl
@@ -1704,6 +1704,29 @@ EOW
 
   TEST q(Data::Dumper->Dumpxs([0, 1, 90, -10, "010", "112345678", "1234567890" ])),
     "numbers and number-like scalars"
+    if $XS;
+}
+#############
+{
+  # [github #18614 - handling of Unicode characters in regexes]
+  if ($] lt '5.010') {
+      SKIP_TEST "Incomplete support for UTF-8 in old perls";
+      SKIP_TEST "Incomplete support for UTF-8 in old perls";
+      last;
+  }
+$WANT = <<"EOW";
+#\$VAR1 = [
+#  "\\x{41f}",
+#  qr/\x{8b80}/,
+#  qr/\x{41f}/
+#];
+EOW
+  $WANT =~ s{/(,?)$}{/u$1}mg if $] gt '5.014';
+  TEST qq(Data::Dumper->Dump([ [qq/\x{41f}/, qr/\x{8b80}/, qr/\x{41f}/] ])),
+    "string with Unicode + regexp with Unicode";
+
+  TEST qq(Data::Dumper->Dumpxs([ [qq/\x{41f}/, qr/\x{8b80}/, qr/\x{41f}/] ])),
+    "string with Unicode + regexp with Unicode, XS"
     if $XS;
 }
 #############


### PR DESCRIPTION
When adding a `qr//` to the output, Data::Dumper extracts the SV of the pattern, but was failing to do anything with the UTF8 flag as it then copied it to the return value. This PR fixes that.