### PR TITLE
Add cop_hints_exists_* functions

### DIFF
--- a/cop.h
+++ b/cop.h
@@ -630,6 +630,58 @@ string/length pair.
     cophh_fetch_sv(CopHINTHASH_get(cop), key, hash, flags)
 
 /*
+=for apidoc Am|bool|cop_hints_exists_pvn|const COP *cop|const char *keypv|STRLEN keylen|U32 hash|U32 flags
+
+Look up the hint entry in the cop C<cop> with the key specified by
+C<keypv> and C<keylen>.  If C<flags> has the C<COPHH_KEY_UTF8> bit set,
+the key octets are interpreted as UTF-8, otherwise they are interpreted
+as Latin-1.  C<hash> is a precomputed hash of the key string, or zero if
+it has not been precomputed.  Returns true if a value exists, and false
+otherwise.
+
+=cut
+*/
+
+#define cop_hints_exists_pvn(cop, keypv, keylen, hash, flags) \
+    cophh_exists_pvn(CopHINTHASH_get(cop), keypv, keylen, hash, flags)
+
+/*
+=for apidoc Am|bool|cop_hints_exists_pvs|const COP *cop|"key"|U32 flags
+
+Like L</cop_hints_exists_pvn>, but takes a literal string
+instead of a string/length pair, and no precomputed hash.
+
+=cut
+*/
+
+#define cop_hints_exists_pvs(cop, key, flags) \
+    cophh_exists_pvs(CopHINTHASH_get(cop), key, flags)
+
+/*
+=for apidoc Am|bool|cop_hints_exists_pv|const COP *cop|const char *key|U32 hash|U32 flags
+
+Like L</cop_hints_exists_pvn>, but takes a nul-terminated string instead
+of a string/length pair.
+
+=cut
+*/
+
+#define cop_hints_exists_pv(cop, key, hash, flags) \
+    cophh_exists_pv(CopHINTHASH_get(cop), key, hash, flags)
+
+/*
+=for apidoc Am|bool|cop_hints_exists_sv|const COP *cop|SV *key|U32 hash|U32 flags
+
+Like L</cop_hints_exists_pvn>, but takes a Perl scalar instead of a
+string/length pair.
+
+=cut
+*/
+
+#define cop_hints_exists_sv(cop, key, hash, flags) \
+    cophh_exists_sv(CopHINTHASH_get(cop), key, hash, flags)
+
+/*
 =for apidoc Am|HV *|cop_hints_2hv|const COP *cop|U32 flags
 
 Generates and returns a standard Perl hash representing the full set of

--- a/cop.h
+++ b/cop.h
@@ -172,6 +172,7 @@ typedef struct jmpenv JMPENV;
 typedef struct refcounted_he COPHH;
 
 #define COPHH_KEY_UTF8 REFCOUNTED_HE_KEY_UTF8
+#define COPHH_EXISTS REFCOUNTED_HE_EXISTS
 
 /*
 =for apidoc Amx|SV *|cophh_fetch_pvn|const COPHH *cophh|const char *keypv|STRLEN keylen|U32 hash|U32 flags
@@ -227,6 +228,58 @@ string/length pair.
 
 #define cophh_fetch_sv(cophh, key, hash, flags) \
     Perl_refcounted_he_fetch_sv(aTHX_ cophh, key, hash, flags)
+
+/*
+=for apidoc Amx|bool|cophh_exists_pvn|const COPHH *cophh|const char *keypv|STRLEN keylen|U32 hash|U32 flags
+
+Look up the entry in the cop hints hash C<cophh> with the key specified by
+C<keypv> and C<keylen>.  If C<flags> has the C<COPHH_KEY_UTF8> bit set,
+the key octets are interpreted as UTF-8, otherwise they are interpreted
+as Latin-1.  C<hash> is a precomputed hash of the key string, or zero if
+it has not been precomputed.  Returns true if a value exists, and false
+otherwise.
+
+=cut
+*/
+
+#define cophh_exists_pvn(cophh, keypv, keylen, hash, flags) \
+    cBOOL(Perl_refcounted_he_fetch_pvn(aTHX_ cophh, keypv, keylen, hash, flags | COPHH_EXISTS))
+
+/*
+=for apidoc Amx|bool|cophh_exists_pvs|const COPHH *cophh|"key"|U32 flags
+
+Like L</cophh_exists_pvn>, but takes a literal string instead
+of a string/length pair, and no precomputed hash.
+
+=cut
+*/
+
+#define cophh_exists_pvs(cophh, key, flags) \
+    cBOOL(Perl_refcounted_he_fetch_pvn(aTHX_ cophh, STR_WITH_LEN(key), 0, flags | COPHH_EXISTS))
+
+/*
+=for apidoc Amx|bool|cophh_exists_pv|const COPHH *cophh|const char *key|U32 hash|U32 flags
+
+Like L</cophh_exists_pvn>, but takes a nul-terminated string instead of
+a string/length pair.
+
+=cut
+*/
+
+#define cophh_exists_pv(cophh, key, hash, flags) \
+    cBOOL(Perl_refcounted_he_fetch_pv(aTHX_ cophh, key, hash, flags | COPHH_EXISTS))
+
+/*
+=for apidoc Amx|bool|cophh_exists_sv|const COPHH *cophh|SV *key|U32 hash|U32 flags
+
+Like L</cophh_exists_pvn>, but takes a Perl scalar instead of a
+string/length pair.
+
+=cut
+*/
+
+#define cophh_exists_sv(cophh, key, hash, flags) \
+    cBOOL(Perl_refcounted_he_fetch_sv(aTHX_ cophh, key, hash, flags | COPHH_EXISTS))
 
 /*
 =for apidoc Amx|HV *|cophh_2hv|const COPHH *cophh|U32 flags

--- a/hv.h
+++ b/hv.h
@@ -545,9 +545,7 @@ struct refcounted_he;
 
 /* flags for the refcounted_he API */
 #define REFCOUNTED_HE_KEY_UTF8		0x00000001
-#ifdef PERL_CORE
-# define REFCOUNTED_HE_EXISTS		0x00000002
-#endif
+#define REFCOUNTED_HE_EXISTS		0x00000002
 
 #ifdef PERL_CORE
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -342,7 +342,16 @@ XXX Changes which affect the interface available to C<XS> code go here.  Other
 significant internal changes for future core maintainers should be noted as
 well.
 
-[ List each change as an =item entry ]
+=over 4
+
+=item *
+
+A set of cop_hints_exists_{pv,pvn,pvs,sv} functions was added, to support checking
+for the existence of keys in the hints hash of a specific cop without needing to
+create a mortal copy of said value.
+
+=back
+
 
 =over 4
 


### PR DESCRIPTION
This adds a set of cop_hints_exists_{pv,pvn,pvs,sv} functions to support checking for the existence of keys in the hints hash of a specific cop without needing to create a mortal copy of said value.

This resolves #18615