### PR TITLE
Remove duplicate call to init_globals()

### DIFF
--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -2,7 +2,7 @@ package Pod::Html;
 use strict;
 require Exporter;
 
-our $VERSION = 1.26;
+our $VERSION = 1.27;
 our @ISA = qw(Exporter);
 our @EXPORT = qw(pod2html htmlify);
 our @EXPORT_OK = qw(anchorify relativize_url);
@@ -257,8 +257,6 @@ my %Pages = ();                 # associative array used to find the location
                                 #   of pages referenced by L<> links.
 
 my $Curdir = File::Spec->curdir;
-
-init_globals();
 
 sub init_globals {
     $Cachedir = ".";            # The directory to which directory caches


### PR DESCRIPTION
The first call was added in a 2003 refactoring of the code in commit
99cb6bd822.  It doesn't do anything other than what the second, older
invocation does, so it's superfluous and deletable.