### PR TITLE
Eliminate double assignment from @_

### DIFF
--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -2,7 +2,7 @@ package Pod::Html;
 use strict;
 require Exporter;
 
-our $VERSION = 1.26;
+our $VERSION = 1.27;
 our @ISA = qw(Exporter);
 our @EXPORT = qw(pod2html htmlify);
 our @EXPORT_OK = qw(anchorify relativize_url);
@@ -583,13 +583,12 @@ my $Saved_Cache_Key;
 
 sub get_cache {
     my($dircache, $podpath, $podroot, $recurse) = @_;
-    my @cache_key_args = @_;
 
     # A first-level cache:
     # Don't bother reading the cache files if they still apply
     # and haven't changed since we last read them.
 
-    my $this_cache_key = cache_key(@cache_key_args);
+    my $this_cache_key = cache_key($dircache, $podpath, $podroot, $recurse);
     return 1 if $Saved_Cache_Key and $this_cache_key eq $Saved_Cache_Key;
     $Saved_Cache_Key = $this_cache_key;
 


### PR DESCRIPTION
In lib/Pod/Html.pm's get_cache(), the arguments from @_ were being read
into the file twice:  once assigned to four distinct scalars, once to an
array.  That array was in turn fed into an internal subroutine -- which
within itself assigned its elements to four distinct scalars.

    sub get_cache {
        my($dircache, $podpath, $podroot, $recurse) = @_;
        my @cache_key_args = @_;

This approach may have made sense back in 1997 when the code first
entered the core distribution.  Some of the four scalars were and are
used within get_cache(), while the array was at that time provided as
argument for two internal subroutines.

This approach, however, is of limited value today.  We will likely to
want to bundle up all these lexical variables into a hash or an object
and just pass a single reference to internal subroutines.  So let's
eliminate the double assignment and eliminate one variable.

Increment $VERSION.