### PR TITLE
warn when using each on an anonymous hash

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2144,6 +2144,12 @@ already been freed.
 (W unpack) You have applied the same modifier more than once after a
 type in a pack template.  See L<perlfunc/pack>.
 
+=item each on anonymous %s will always start from the beginning
+
+(W syntax) You called L<each|perlfunc/each> on an anonymous hash or
+array.  Since a new hash or array is created each time, each() will
+restart iterating over your hash or array every time.
+
 =item elseif should be elsif
 
 (S syntax) There is no keyword "elseif" in Perl because Larry thinks

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -2012,6 +2012,15 @@ the iterator state used by anything else that might execute during the
 loop body.  To avoid these problems, use a C<foreach> loop rather than
 C<while>-C<each>.
 
+This extends to using C<each> on the result of an anonymous hash or
+array constructor.  A new underlying array or hash is created each
+time so each will always start iterating from scratch, eg:
+
+  # loops forever
+  while (my ($key, $value) = each @{ +{ a => 1 } }) {
+      print "$key=$value\n";
+  }
+
 This prints out your environment like the L<printenv(1)> program,
 but in a different order:
 

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -2063,3 +2063,83 @@ Useless use of a constant (32) in void context at - line 11.
 Useless use of a constant (41) in void context at - line 14.
 Useless use of a constant (42) in void context at - line 14.
 Useless use of a constant (51) in void context at - line 16.
+########
+# NAME warn on each on anonymous hash (simple)
+{
+    while (my ($k, $v) = each %{ +{ a => 1 }}) {
+        print $k, "\n";
+        last;
+    }
+}
+use warnings;
+{
+    while (my ($k, $v) = each %{ +{ b => 1 }}) {
+        print $k, "\n";
+        last;
+    }
+}
+EXPECT
+each on anonymous hash will always start from the beginning at - line 9.
+a
+b
+########
+# NAME warn each on anonymous hash (more complex)
+{
+    while (my ($k, $v) = each %{; print "c\n"; +{ a => 1 } }) {
+        print $k, "\n";
+        last;
+    }
+}
+use warnings;
+{
+    while (my ($k, $v) = each %{; print "d\n"; +{ b => 1 } }) {
+        print $k, "\n";
+        last
+    }
+}
+EXPECT
+each on anonymous hash will always start from the beginning at - line 9.
+c
+a
+d
+b
+########
+# NAME warn on each on anonymous array (simple)
+{
+    while (my ($k, $v) = each @{ [ "a", "b" ] }) {
+        print $v, "\n";
+        last;
+    }
+}
+use warnings;
+{
+    while (my ($k, $v) = each @{ [ "b", "a" ] }) {
+        print $v, "\n";
+        last;
+    }
+}
+EXPECT
+each on anonymous array will always start from the beginning at - line 9.
+a
+b
+########
+# NAME warn on each on anonymous array (more complex)
+{
+    while (my ($k, $v) = each @{; print "c\n"; [ "a", "b" ] }) {
+        print $v, "\n";
+        last;
+    }
+}
+use warnings;
+{
+    while (my ($k, $v) = each @{; print "d\n"; [ "b", "a" ] }) {
+        print $v, "\n";
+        last;
+    }
+}
+EXPECT
+each on anonymous array will always start from the beginning at - line 9.
+c
+a
+d
+b


### PR DESCRIPTION
We've had at least three tickets (#18557, #14706, #8051 from a quick search) over the years where the user has been confused by the behaviour of each on an anonymous array or hash, there's no way to tell if other users have been struck by the same issue.

This change checks the op tree during compilation to try and detect the simple cases, I don't see a way to tell if the hash reference was returned by a function or similar.

If this receives positive feedback (on the idea anyway), I'll add the same check for each on anonymous arrays.

I welcome alternatives to the warning message (or opinions if you think it's fine.)