### PR TITLE
fix magic and upgraded SV handling for setsockopt()'s OPTVAL

### DIFF
--- a/pp_sys.c
+++ b/pp_sys.c
@@ -2707,13 +2707,14 @@ PP(pp_ssockopt)
     case OP_SSOCKOPT: {
             const char *buf;
             int aint;
+            SvGETMAGIC(sv);
             if (SvPOKp(sv)) {
                 STRLEN l;
-                buf = SvPV_const(sv, l);
+                buf = SvPVbyte_nomg(sv, l);
                 len = l;
             }
             else {
-                aint = (int)SvIV(sv);
+                aint = (int)SvIV_nomg(sv);
                 buf = (const char *) &aint;
                 len = sizeof(int);
             }


### PR DESCRIPTION
The code here checked SV flags before fetching magic, potentially
getting confused if magic fetched changed flags.

This also fixes handling for upgraded SVs, but I'm not sure that can
be tested sufficiently portably.