### PR TITLE
Provide strict compliance for DynaLoader and XSLoader

### DIFF
--- a/dist/XSLoader/Makefile.PL
+++ b/dist/XSLoader/Makefile.PL
@@ -8,6 +8,8 @@
 use strict;
 use warnings;
 
+use v5.6;
+
 use ExtUtils::MakeMaker;
 use ExtUtils::MM_Unix;
 
@@ -101,11 +103,7 @@ WriteMakefile(
         my @perls = ($orig_perl);
         push @perls, qw(bleadperl 
                         perl5.6.1
-                        perl5.6.0
-                        perl5.005_03 
-                        perl5.004_05 
-                        perl5.004_04
-                        perl5.004)
+                        perl5.6.0)
           if $ENV{PERL_TEST_ALL};
 
         my $out;

--- a/dist/XSLoader/XSLoader_pm.PL
+++ b/dist/XSLoader/XSLoader_pm.PL
@@ -20,29 +20,6 @@ our $VERSION = "0.31"; # remember to update version in POD!
 
 package DynaLoader;
 
-EOT
-
-# dlutils.c before 5.006 has this:
-#
-#    #ifdef DEBUGGING
-#        dl_debug = SvIV( perl_get_sv("DynaLoader::dl_debug", 0x04) );
-#    #endif
-#
-# where 0x04 is GV_ADDWARN, which causes a warning to be issued by the call
-# into XS below, if DynaLoader.pm hasn't been loaded.
-# It was changed to 0 in the commit(s) that added XSLoader to the core
-# (9cf41c4d23a47c8b and its parent 9426adcd48655815)
-# Hence to backport XSLoader to work silently with earlier DynaLoaders we need
-# to ensure that the variable exists:
-
-print OUT <<'EOT' if $] < 5.006;
-
-# enable debug/trace messages from DynaLoader perl code
-$dl_debug = $ENV{PERL_DL_DEBUG} || 0 unless defined $dl_debug;
-
-EOT
-
-print OUT <<'EOT';
 # No prizes for guessing why we don't say 'bootstrap DynaLoader;' here.
 # NOTE: All dl_*.xs (including dl_none.xs) define a dl_error() XSUB
 boot_DynaLoader('DynaLoader') if defined(&boot_DynaLoader) &&
@@ -211,41 +188,16 @@ print OUT <<'EOT';
     push(@DynaLoader::dl_shared_objects, $file); # record files loaded
     return &$xs(@_);
 }
-EOT
 
 # Can't test with DynaLoader->can('bootstrap_inherit') when building in the
 # core, as XSLoader gets built before DynaLoader.
-
-if ($] >= 5.006) {
-    print OUT <<'EOT';
 
 sub bootstrap_inherit {
     require DynaLoader;
     goto \&DynaLoader::bootstrap_inherit;
 }
 
-EOT
-} else {
-    print OUT <<'EOT';
-
-sub bootstrap_inherit {
-    # Versions of DynaLoader prior to 5.6.0 don't have bootstrap_inherit.
-    package DynaLoader;
-
-    my $module = $_[0];
-    local *DynaLoader::isa = *{"$module\::ISA"};
-    local @DynaLoader::isa = (@DynaLoader::isa, 'DynaLoader');
-    # Cannot goto due to delocalization.  Will report errors on a wrong line?
-    require DynaLoader;
-    DynaLoader::bootstrap(@_);
-}
-
-EOT
-}
-
-print OUT <<'EOT';
 1;
-
 
 __END__
 

--- a/dist/XSLoader/XSLoader_pm.PL
+++ b/dist/XSLoader/XSLoader_pm.PL
@@ -1,4 +1,6 @@
 use strict;
+use warnings;
+
 use Config;
 # We require DynaLoader to make sure that mod2fname is loaded
 eval { require DynaLoader };
@@ -9,11 +11,12 @@ print OUT <<'EOT';
 # Generated from XSLoader_pm.PL (resolved %Config::Config value)
 # This file is unique for every OS
 
+use strict;
+no strict 'refs';
+
 package XSLoader;
 
-$VERSION = "0.30"; # remember to update version in POD!
-
-#use strict;
+our $VERSION = "0.31"; # remember to update version in POD!
 
 package DynaLoader;
 
@@ -252,7 +255,7 @@ XSLoader - Dynamically load C libraries into Perl code
 
 =head1 VERSION
 
-Version 0.30
+Version 0.31
 
 =head1 SYNOPSIS
 

--- a/dist/XSLoader/t/XSLoader.t
+++ b/dist/XSLoader/t/XSLoader.t
@@ -12,8 +12,6 @@ BEGIN {
         die "Test::More not available\n";
     }
 
-    plan(skip_all => "these tests needs Perl 5.5+") if $] < 5.005;
-
     use Config;
     foreach (qw/SDBM_File GDBM_File ODBM_File NDBM_File DB_File/) {
         if ($Config{extensions} =~ /\b$_\b/) {

--- a/dist/XSLoader/t/XSLoader.t
+++ b/dist/XSLoader/t/XSLoader.t
@@ -1,6 +1,8 @@
 #!perl -T
 
 use strict;
+use warnings;
+
 use Config;
 
 my $db_file;
@@ -117,6 +119,7 @@ SKIP: {
 
   # [perl #122455]
   # die instead of falling back to DynaLoader
+  no warnings 'redefine';
   local *XSLoader::bootstrap_inherit = sub { die "Fallback to DynaLoader\n" };
   ::ok( eval <<EOS, "test correct path searched for modules")
 package Not::Devel::Peek;
@@ -135,6 +138,7 @@ SKIP: {
     ">$name/auto/Foo/Bar/Bar.$Config::Config{'dlext'}";
   close $fh;
   my $fell_back;
+  no warnings 'redefine';
   local *XSLoader::bootstrap_inherit = sub {
     $fell_back++;
     # Break out of the calling subs

--- a/ext/DynaLoader/DynaLoader_pm.PL
+++ b/ext/DynaLoader/DynaLoader_pm.PL
@@ -73,6 +73,8 @@ print OUT <<'EOT';
 
 # Generated from DynaLoader_pm.PL, this file is unique for every OS
 
+use strict;
+
 package DynaLoader;
 
 #   And Gandalf said: 'Many folk like to know beforehand what is to
@@ -88,8 +90,16 @@ package DynaLoader;
 # Tim.Bunce@ig.co.uk, August 1994
 
 BEGIN {
-    $VERSION = '1.50';
+    our $VERSION = '1.51';
 }
+
+# Note: in almost any other piece of code "our" would have been a better
+# option than "use vars", but DynaLoader's bootstrap files need the
+# side effect of the variable being declared in any scope whose current
+# package is DynaLoader, not just the current lexical one.
+use vars qw(@dl_library_path @dl_resolve_using @dl_require_symbols
+            $dl_debug @dl_librefs @dl_modules @dl_shared_objects
+            $dl_dlext $dl_so $dlsrc @args $module @dirs $file $bscode);
 
 EOT
 
@@ -141,7 +151,7 @@ print OUT expand_os_specific(<<'EOT');
 # inefficient to define on systems that don't need it.
 $Is_VMS    = $^O eq 'VMS';
 <</$^O-eq-VMS>>
-$do_expand = <<$^O-eq-VMS>>1<<|$^O-eq-VMS>>0<</$^O-eq-VMS>>;
+my $do_expand = <<$^O-eq-VMS>>1<<|$^O-eq-VMS>>0<</$^O-eq-VMS>>;
 
 @dl_require_symbols = ();       # names of symbols we need<<$^O-eq-freemint>>
 @dl_resolve_using   = ();       # names of files to link with<</$^O-eq-freemint>><<$^O-eq-hpux>>
@@ -292,6 +302,8 @@ sub croak   { require Carp; Carp::croak(@_)   }
 
 sub bootstrap_inherit {
     my $module = $_[0];
+
+    no strict qw/refs vars/;
     local *isa = *{"$module\::ISA"};
     local @isa = (@isa, 'DynaLoader');
     # Cannot goto due to delocalization.  Will report errors on a wrong line?

--- a/ext/DynaLoader/Makefile.PL
+++ b/ext/DynaLoader/Makefile.PL
@@ -1,4 +1,6 @@
 use strict;
+use warnings;
+
 use ExtUtils::MakeMaker;
 
 my $is_mswin    = $^O eq 'MSWin32';

--- a/ext/DynaLoader/t/DynaLoader.t
+++ b/ext/DynaLoader/t/DynaLoader.t
@@ -1,6 +1,8 @@
 #!/usr/bin/perl -wT
 
 use strict;
+use warnings;
+
 use Config;
 push @INC, '.';
 if (-f 't/test.pl') {


### PR DESCRIPTION
This branch is an alternative to #18221

The main difference between that branch and this is that this one will not break bootstrap files, as described [here](https://github.com/Perl/perl5/pull/18221#issuecomment-705674791).