### PR TITLE
Enable warnings on «use v5.35»

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -131,6 +131,7 @@ Artiom Morozov                 <artiom@phreaker.net>
 Artur Bergman                  <artur@contiller.se>
 Arvan                          <apritchard@zeus.com>
 Ash Berlin                     <ash@cpan.org>
+Asher Mancinelli               <asher.mancinelli@pnnl.gov>
 Ask Bjørn Hansen               <ask@develooper.com>
 Atsushi Sugawara               <peanutsjamjam@gmail.com>
 Audrey Tang                    <cpan@audreyt.org>

--- a/lib/warnings.pm
+++ b/lib/warnings.pm
@@ -5,7 +5,7 @@
 
 package warnings;
 
-our $VERSION = "1.52";
+our $VERSION = "1.53";
 
 # Verify that we're called correctly so that warnings will work.
 # Can't use Carp, since Carp uses us!
@@ -580,6 +580,9 @@ warnings - Perl pragma to control optional warnings
     use warnings;
     no warnings;
 
+    # Standard warnings are enabled by use v5.35 or above
+    use v5.35;
+
     use warnings "all";
     no warnings "uninitialized";
 
@@ -644,6 +647,9 @@ The code in the enclosing block has warnings enabled, but the inner
 block has them disabled.  In this case that means the assignment to the
 scalar C<$z> will trip the C<"Scalar value @x[0] better written as $x[0]">
 warning, but the assignment to the scalar C<$y> will not.
+
+All warnings are enabled automatically within the scope of
+a C<L<use v5.35|perlfunc/use VERSION>> (or higher) declaration.
 
 =head2 Default Warnings and Optional Warnings
 

--- a/op.c
+++ b/op.c
@@ -8864,6 +8864,9 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
                 PL_hints |= HINT_STRICT_SUBS;
             if (!(PL_hints & HINT_EXPLICIT_STRICT_VARS))
                 PL_hints |= HINT_STRICT_VARS;
+
+            if (vcmp(use_version, sv_2mortal(upg_version(newSVpvs("5.035000"), FALSE))) >= 0)
+                free_and_set_cop_warnings(&PL_compiling, pWARN_ALL);
         }
         /* otherwise they are off */
         else {

--- a/pod/perl.pod
+++ b/pod/perl.pod
@@ -393,10 +393,13 @@ see L<perlvar> for more information.
 
 Using the C<use strict> pragma ensures that all variables are properly
 declared and prevents other misuses of legacy Perl features.
+These are enabled by default within the scope of
+C<L<use v5.12|perlfunc/use VERSION>> (or higher).
 
-The C<use warnings> pragma produces some lovely diagnostics. One can
-also use the B<-w> flag, but its use is normally discouraged, because
-it gets applied to all executed Perl code, including that not under
+The C<use warnings> pragma produces some lovely diagnostics.
+It is enabled by default when you say C<use v5.35> (or higher).
+One can also use the B<-w> flag, but its use is normally discouraged,
+because it gets applied to all executed Perl code, including that not under
 your control.
 
 See L<perldiag> for explanations of all Perl's diagnostics.  The C<use

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -9638,18 +9638,19 @@ L<C<use>|/use Module VERSION LIST>ing library modules that won't work
 with older versions of Perl.
 (We try not to do this more than we have to.)
 
-C<use VERSION> also lexically enables all features available in the requested
+C<use VERSION> lexically enables all features available in the requested
 version as defined by the L<feature> pragma, disabling any features
 not in the requested version's feature bundle.  See L<feature>.
-Similarly, if the specified Perl version is greater than or equal to
+If the specified Perl version is greater than or equal to
 5.12.0, strictures are enabled lexically as
-with L<C<use strict>|strict>.  Any explicit use of
-C<use strict> or C<no strict> overrides C<use VERSION>, even if it comes
-before it.  Later use of C<use VERSION>
-will override all behavior of a previous
-C<use VERSION>, possibly removing the C<strict> and C<feature> added by
-C<use VERSION>.  C<use VERSION> does not
-load the F<feature.pm> or F<strict.pm>
+with L<C<use strict>|strict>.  
+Similarly, L<warnings> are enabled if C<VERSION> is 5.35.0 or higher.
+Any explicit use of C<use strict> or C<no strict> overrides C<use VERSION>,
+even if it comes before it.
+Later use of C<use VERSION> will override all behavior of a previous
+C<use VERSION>, possibly removing the C<strict>, C<warnings>, and C<feature>
+added by C<use VERSION>.  C<use VERSION> does not
+load the F<feature.pm>, F<strict.pm>, or F<warnings.pm>
 files.
 
 The C<BEGIN> forces the L<C<require>|/require VERSION> and

--- a/pod/perlintro.pod
+++ b/pod/perlintro.pod
@@ -93,8 +93,14 @@ problems in your code.  They check different things so you need both.  A
 potential problem caught by C<use strict;> will cause your code to stop
 immediately when it is encountered, while C<use warnings;> will merely
 give a warning (like the command-line switch B<-w>) and let your code run.
-To read more about them check their respective manual pages at L<strict>
+To read more about them, check their respective manual pages at L<strict>
 and L<warnings>.
+
+A C<L<use v5.35|perlfunc/use VERSION>> (or higher) declaration will
+enable both C<strict> and C<warnings>:
+
+  #!/usr/bin/perl
+  use v5.35;
 
 =head2 Basic syntax overview
 

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -16,7 +16,7 @@
 #
 # This script is normally invoked from regen.pl.
 
-$VERSION = '1.52';
+$VERSION = '1.53';
 
 BEGIN {
     require './regen/regen_lib.pl';
@@ -882,6 +882,9 @@ warnings - Perl pragma to control optional warnings
     use warnings;
     no warnings;
 
+    # Standard warnings are enabled by use v5.35 or above
+    use v5.35;
+
     use warnings "all";
     no warnings "uninitialized";
 
@@ -946,6 +949,9 @@ The code in the enclosing block has warnings enabled, but the inner
 block has them disabled.  In this case that means the assignment to the
 scalar C<$z> will trip the C<"Scalar value @x[0] better written as $x[0]">
 warning, but the assignment to the scalar C<$y> will not.
+
+All warnings are enabled automatically within the scope of
+a C<L<use v5.35|perlfunc/use VERSION>> (or higher) declaration.
 
 =head2 Default Warnings and Optional Warnings
 

--- a/t/op/ver.t
+++ b/t/op/ver.t
@@ -12,7 +12,7 @@ $DOWARN = 1; # enable run-time warnings now
 
 use Config;
 
-plan( tests => 52 );
+plan( tests => 54 );
 
 eval 'use v5.5.640';
 is( $@, '', "use v5.5.640; $@");
@@ -266,6 +266,23 @@ sub { $_[0] = v3;
 
 *{"\3"} = *DATA;
 is( (readline v3), "This is what we expect to see!\n", "v-strings even work in Mordor" );
+
+{
+    # disable warnings just for the following test
+    local $DOWARN = 0;
+
+    # Keep a list of all warnings issued in this test
+    my @warnings = ();
+    local $SIG{__WARN__} = sub { push @warnings, @_; };
+
+    # This should *not* result in a warning
+    eval { my $foo; "This doesn't need to be here...".$foo; };
+    is( scalar @warnings, 0, "Warnings are disabled by default pre 5.35" );
+
+    # This *should* result in a warning
+    eval { use v5.035; my $foo; "This doesn't need to be here...".$foo; };
+    is( scalar @warnings, 1, "Warnings are enabled by default post 5.35" );
+}
 
 __DATA__
 This is what we expect to see!


### PR DESCRIPTION
This is a proof of concept for enabling warnings by default in some future version of perl

~~~shell
leont@leon-desktop:~/Code/perl$ perl -e 'my $foo; print "$foo"'
leont@leon-desktop:~/Code/perl$ perl -e 'use 5.035; my $foo; print "$foo"'
Use of uninitialized value $foo in string at -e line 1.
~~~

This fixes #17162