### PR TITLE
Silence one build-time warning

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -12514,7 +12514,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                  && q == fmtstart + 1 /* plain %d, not %....d */
                  && patend >= fmtstart + sizeof(UTF8f) - 1 /* long enough */
                  && *q == '%'
-                 && strnEQ(q + 1, UTF8f + 2, sizeof(UTF8f) - 3))
+                 && strnEQ(q + 1, (UTF8f) + 2, sizeof(UTF8f) - 3))
             {
 		/* The argument has already gone through cBOOL, so the cast
 		   is safe. */


### PR DESCRIPTION
Observed in clang 9 and 10.

Partial solution for https://github.com/Perl/perl5/issues/17015