### PR TITLE
Mention "trim" as a common name for removing space

### DIFF
--- a/cpan/perlfaq/lib/perlfaq.pod
+++ b/cpan/perlfaq/lib/perlfaq.pod
@@ -455,7 +455,7 @@ How can I split a [character]-delimited string except when inside [character]?
 
 =item *
 
-How do I strip blank space from the beginning/end of a string?
+How do I trim a string to strip blank space from the beginning/end?
 
 =item *
 

--- a/cpan/perlfaq/lib/perlfaq4.pod
+++ b/cpan/perlfaq/lib/perlfaq4.pod
@@ -930,7 +930,7 @@ implementing it yourself is highly recommended; you'll save yourself odd bugs
 popping up later by just using code which has already been tried and tested in
 production for years.
 
-=head2 How do I strip blank space from the beginning/end of a string?
+=head2 How do I trim a string to strip blank space from the beginning/end?
 
 (contributed by brian d foy)
 


### PR DESCRIPTION
As discussed on perl5-porters, folks looking for this entry may not find
it if they are coming from another language where this is commonly
called "trim".