### PR TITLE
av_extend_guts: set correct ary_offset when unshifting (GH#18667)

### DIFF
--- a/av.c
+++ b/av.c
@@ -110,6 +110,7 @@ Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp,
         if (av && *allocp != *arrayp) { /* a shifted SV* array exists */
             to_null = *arrayp - *allocp;
             *maxp += to_null;
+            ary_offset = AvFILLp(av) + 1;
 
             Move(*arrayp, *allocp, AvFILLp(av)+1, SV*);
 

--- a/t/op/splice.t
+++ b/t/op/splice.t
@@ -108,4 +108,10 @@ is sprintf("%s", splice @a, 0, 1, undef), "",
         "croak when splicing into readonly array";
 }
 
+# GH#18667 - av_extend_guts must zero duplicate SV*s
+fresh_perl_is('my @data = (undef) x 4; splice @data, 1, 1;
+    splice @data, 2, 1; $data[3] = undef; splice @data, 3, 1;',
+    '', {}, 'GH#18667 - av_extend_guts must zero duplicate SV*s');
+
+
 done_testing;


### PR DESCRIPTION
The bug observed in #18667 occurred due to a failure to clear SV*s left behind
following a `Move()` operation on a shifted array. Specifically, the value of
`ary_offset`, which controls from where to begin clearing unused elements,
should have been set (to `AvFILLp(av) + 1`) to override the default value.
(The default being correct only when `Renew()`ing an _unshifted_ array.)

Heartfelt thanks to @hvds  for identifying the faulty behaviour and producing a
minimal test case, which is included in this PR as a new test.

The bug was introduced as part of a refactor in the current 5.33.x development
cycle and therefore no entry is required in perldelta.