### PR TITLE
Fixed corelist -r param processing bug for 0 and non-number values

### DIFF
--- a/dist/Module-CoreList/corelist
+++ b/dist/Module-CoreList/corelist
@@ -148,6 +148,7 @@ use Pod::Usage;
 use strict;
 use warnings;
 use List::Util qw/maxstr/;
+use Scalar::Util qw/looks_like_number/;
 
 my %Opts;
 
@@ -159,8 +160,8 @@ GetOptions(
 pod2usage(1) if $Opts{help};
 pod2usage(-verbose=>2) if $Opts{man};
 
-if(exists $Opts{r} ){
-    if ( !$Opts{r} ) {
+if ( exists $Opts{r} ) {
+    if ( $Opts{r} eq '' ) {
         print "\nModule::CoreList has release info for the following perl versions:\n";
         my $versions = { };
         my $max_ver_len = max_mod_len(\%Module::CoreList::released);
@@ -174,7 +175,7 @@ if(exists $Opts{r} ){
     my $num_r = numify_version( $Opts{r} );
     my $version_hash = Module::CoreList->find_version($num_r);
 
-    if( !$version_hash ) {
+    if ( !$version_hash ) {
         print "\nModule::CoreList has no info on perl $Opts{r}\n\n";
         exit 1;
     }
@@ -498,11 +499,11 @@ sub format_perl_version {
 sub numify_version {
     my $ver = shift;
     if ($ver =~ /\..+\./) {
-	have_version_pm()
-	    or die "You need to install version.pm to use dotted version numbers\n";
+        have_version_pm()
+          or die "You need to install version.pm to use dotted version numbers\n";
         $ver = version->new($ver)->numify;
     }
-    $ver += 0;
+    $ver = looks_like_number($ver) ? $ver : 0;
     return $ver;
 }
 

--- a/dist/Module-CoreList/t/corelist.t
+++ b/dist/Module-CoreList/t/corelist.t
@@ -5,20 +5,20 @@ use Test::More tests => 34;
 
 BEGIN { require_ok('Module::CoreList'); }
 
-ok($Module::CoreList::version{5.00503},    "5.00503");
+ok( $Module::CoreList::version{5.00503}, "5.00503" );
 
-ok(!exists $Module::CoreList::version{5.00503}{attributes},
-   "attributes weren't in 5.00503");
+ok( !exists $Module::CoreList::version{5.00503}{attributes},
+    "attributes weren't in 5.00503" );
 
-ok($Module::CoreList::version{5.006001},    "5.006001");
+ok( $Module::CoreList::version{5.006001}, "5.006001" );
 
-ok(exists $Module::CoreList::version{'5.006001'}{attributes},
-   "attributes were in 5.6.1");
+ok( exists $Module::CoreList::version{'5.006001'}{attributes},
+    "attributes were in 5.6.1" );
 
-ok($Module::CoreList::version{5.007003},    "5.007003");
+ok( $Module::CoreList::version{5.007003}, "5.007003" );
 
-ok(exists $Module::CoreList::version{5.007003}{'Attribute::Handlers'},
-   "Attribute::Handlers were bundled with 5.7.3");
+ok( exists $Module::CoreList::version{5.007003}{'Attribute::Handlers'},
+    "Attribute::Handlers were bundled with 5.7.3" );
 
 is(Module::CoreList->first_release_by_date('File::Spec'), 5.005,
    "File::Spec was first bundled in 5.005");
@@ -45,10 +45,12 @@ is_deeply([ sort keys %Module::CoreList::released ],
           [ sort keys %Module::CoreList::version ],
           "have a note of everythings release");
 
-is_deeply( [ map {
-    exists $Module::CoreList::version{ $_ }{FindExt} ? $_ : ()
-} keys %Module::CoreList::version ],
-           [], "FindExt shouldn't get included rt#6922" );
+is_deeply(
+    [ map { exists $Module::CoreList::version{$_}{FindExt} ? $_ : () }
+      keys %Module::CoreList::version ],
+    [],
+    "FindExt shouldn't get included rt#6922"
+);
 
 
 my $consistent = 1;

--- a/dist/Module-CoreList/t/script.t
+++ b/dist/Module-CoreList/t/script.t
@@ -1,0 +1,40 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 9;
+
+BEGIN { require_ok('Module::CoreList'); }
+
+my $cl = './blib/script/corelist';
+
+my $perl_5 = `$cl -r 5`;
+is($perl_5, "Perl 5 was released on 1994-10-17\n\n", 'perl 5 ok');
+
+my $perl_v5 = `$cl -r v5`;
+is($perl_v5, "\nModule::CoreList has no info on perl v5\n\n", 'perl v5 not ok');
+
+my $perl_5_10 = `$cl -r 5.10.0`;
+is($perl_5_10, "Perl v5.10.0 was released on 2007-12-18\n\n", 'perl 5.10.0 ok');
+
+my $perl_v5_10 = `$cl -r v5.10.0`;
+is($perl_v5_10, "Perl v5.10.0 was released on 2007-12-18\n\n", 'perl v5.10.0 ok');
+
+my $perl_0 = `$cl -r 0`;
+is($perl_0, "\nModule::CoreList has no info on perl 0\n\n", 'perl 0 not ok');
+
+my $perl_v0 = `$cl -r v0`;
+is($perl_v0, "\nModule::CoreList has no info on perl v0\n\n", 'perl v0 not ok');
+
+my $perl_a = `$cl -r a`;
+is($perl_a, "\nModule::CoreList has no info on perl a\n\n", 'perl a not ok');
+
+my $perl_all = `$cl -r`;
+
+my $printed_version_count = () = $perl_all =~ /\n/g;
+$printed_version_count -= 3; # 1 \n for prologue and 2 \n for epilogue
+
+my $versions_count = grep !/0[01]0$/, keys %Module::CoreList::released;
+
+is($printed_version_count, $versions_count, "perl all ok");


### PR DESCRIPTION
These cases was failed:

```
corelist -r 0 # works like corelist -r that's not right
corelist -r a # show the warning: Argument "a" isn't numeric in addition (+) at
```