### PR TITLE
Don't zero non-real arrays

### DIFF
--- a/av.c
+++ b/av.c
@@ -193,11 +193,9 @@ Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp,
              * don't get any special treatment here. */
             ary_offset = 0;
             to_null = *maxp+1;
-            goto zero;
         }
 
         if (av && AvREAL(av)) {
-          zero:
             Zero(*allocp + ary_offset,to_null,SV*);
         }
 


### PR DESCRIPTION
A minor difference in behaviour introduced by the rewrite of av_extend_guts
in 440c1856 and 399fef93 is that when the SV* array is first acquired, we
now zero its contents regardless of whether that is needed - and add an
extra label and 'goto' to do so.

This commit restores the original behaviour: for non-refcounted arrays such
as @_ and pad arrays this is not needed, and for pads in particular we may
hit this path many times during the course of a program.

@richardleach I mentioned this difference in #18667, but the focus there was on the ary_offset bug. If you think this requires further discussion I can also open a separate ticket for it.