### PR TITLE
pad.c - less avoidable, inefficient use of av_store

### DIFF
--- a/pad.c
+++ b/pad.c
@@ -220,17 +220,24 @@ Perl_pad_new(pTHX_ int flags)
 
     Newxz(padlist, 1, PADLIST);
     pad		= newAV();
+    Newxz(AvALLOC(pad), 4, SV *); /* Originally sized to
+                                     match av_extend default */
+    AvARRAY(pad) = AvALLOC(pad);
+    AvMAX(pad) = 3;
+    AvFILLp(pad) = 0; /* @_ or NULL, set below. */
 
     if (flags & padnew_CLONE) {
         AV * const a0 = newAV();			/* will be @_ */
-        av_store(pad, 0, MUTABLE_SV(a0));
+        AvARRAY(pad)[0] = MUTABLE_SV(a0);
         AvREIFY_only(a0);
 
         PadnamelistREFCNT(padname = PL_comppad_name)++;
     }
     else {
         padlist->xpadl_id = PL_padlist_generation++;
-        av_store(pad, 0, NULL);
+        /* Set implicitly through use of Newxz above
+            AvARRAY(pad)[0] = NULL;
+        */
         padname = newPADNAMELIST(0);
         padnamelist_store(padname, 0, &PL_padname_undef);
     }

--- a/pad.c
+++ b/pad.c
@@ -2396,6 +2396,10 @@ Perl_pad_push(pTHX_ PADLIST *padlist, int depth)
         PADNAME ** const names = PadnamelistARRAY((PADNAMELIST *)svp[0]);
         AV *av;
 
+        Newxz( AvALLOC(newpad), ix + 1, SV *);
+        AvARRAY(newpad) = AvALLOC(newpad);
+        AvMAX(newpad) = AvFILLp(newpad) = ix;
+
         for ( ;ix > 0; ix--) {
             SV *sv;
             if (names_fill >= ix && PadnameLEN(names[ix])) {
@@ -2424,10 +2428,10 @@ Perl_pad_push(pTHX_ PADLIST *padlist, int depth)
                 sv = newSV(0);
                 SvPADTMP_on(sv);
             }
-            av_store(newpad, ix, sv);
+            AvARRAY(newpad)[ix] = sv;
         }
         av = newAV();
-        av_store(newpad, 0, MUTABLE_SV(av));
+        AvARRAY(newpad)[0] = MUTABLE_SV(av);
         AvREIFY_only(av);
 
         padlist_store(padlist, depth, newpad);

--- a/pad.c
+++ b/pad.c
@@ -2397,6 +2397,7 @@ Perl_pad_push(pTHX_ PADLIST *padlist, int depth)
         AV *av;
 
         for ( ;ix > 0; ix--) {
+            SV *sv;
             if (names_fill >= ix && PadnameLEN(names[ix])) {
                 const char sigil = PadnamePV(names[ix])[0];
                 if (PadnameOUTER(names[ix])
@@ -2404,28 +2405,26 @@ Perl_pad_push(pTHX_ PADLIST *padlist, int depth)
                         || sigil == '&')
                 {
                     /* outer lexical or anon code */
-                    av_store(newpad, ix, SvREFCNT_inc(oldpad[ix]));
+                    sv = SvREFCNT_inc(oldpad[ix]);
                 }
                 else {		/* our own lexical */
-                    SV *sv; 
                     if (sigil == '@')
                         sv = MUTABLE_SV(newAV());
                     else if (sigil == '%')
                         sv = MUTABLE_SV(newHV());
                     else
                         sv = newSV(0);
-                    av_store(newpad, ix, sv);
                 }
             }
             else if (PadnamePV(names[ix])) {
-                av_store(newpad, ix, SvREFCNT_inc_NN(oldpad[ix]));
+                sv = SvREFCNT_inc_NN(oldpad[ix]);
             }
             else {
                 /* save temporaries on recursion? */
-                SV * const sv = newSV(0);
-                av_store(newpad, ix, sv);
+                sv = newSV(0);
                 SvPADTMP_on(sv);
             }
+            av_store(newpad, ix, sv);
         }
         av = newAV();
         av_store(newpad, 0, MUTABLE_SV(av));


### PR DESCRIPTION
In a few places in _pad.c_, particularly in _Perl_pad_push()_,  `av_store()` is used
to populate array elements very soon after creating the AV via `newAV()`.
Given that proximity, much of the code of `av_store()` can be reasoned to be 
superfluous and therefore its use is inefficient:
* `if (SvRMAGICAL(av))` - never true
* `if (key < 0)`        - never true
* `if (SvREADONLY(av)`  - never true
* `if (!AvREAL(av) && AvREIFY(av))` - never true
* `if (key > AvMAX(av))` - could be true some of the time, but it's easy to `Newx`
 or `Newxz `the SV* array shortly after the `newAV()`, so this test is then not true
* `if (AvFILLp(av) < key)` - final value can be set once, rather than incrementally
* `if (!AvREAL(av))` - never true
* `SvREFCNT_dec(ary[key])` - not necessary when the array is brand new
* `if (SvSMAGICAL(av))` - never true
* `return &ary[key];`   - return value is not used

This PR does two things to avoid such use of `av_store()`:
* Directly creates the SV* arrays for the relevant AVs
* Directly assigns the array elements

Direct array creation does make the code harder to follow, but this could be 
tidied up via macros e.g. https://github.com/Perl/perl5/issues/18695

Note: Some use of `av_store()` elsewhere in _pad.c_ might also be inefficient,
but evaluating occurrences when the AV and SV* array already exist is 
less straightforward.