### PR TITLE
Base refactoring with docs to some t/base/*.t files

### DIFF
--- a/t/base/cond.t
+++ b/t/base/cond.t
@@ -1,10 +1,20 @@
 #!./perl
 
-# make sure conditional operators work
+# t/base/cond.t - check conditional operators
+
+# Test plan
+#
+#   eq
+#   ne
+#   ==
+#   !=
+
+use strict;
+use warnings;
 
 print "1..4\n";
 
-$x = '0';
+my $x = '0';
 
 $x eq $x && (print "ok 1 - operator eq\n");
 $x ne $x && (print "not ok 1 - operator ne\n");

--- a/t/base/cond.t
+++ b/t/base/cond.t
@@ -1,7 +1,7 @@
 #!./perl
 
 # t/base/cond.t - check conditional operators
-
+#
 # Test plan
 #
 #   eq
@@ -9,12 +9,9 @@
 #   ==
 #   !=
 
-use strict;
-use warnings;
-
 print "1..4\n";
 
-my $x = '0';
+$x = '0';
 
 $x eq $x && (print "ok 1 - operator eq\n");
 $x ne $x && (print "not ok 1 - operator ne\n");

--- a/t/base/if.t
+++ b/t/base/if.t
@@ -1,9 +1,14 @@
 #!./perl
 
+# t/base/if.t - check "if"
+
+use strict;
+use warnings;
+
 print "1..2\n";
 
-# first test to see if we can run the tests.
+# First test to see if we can run the tests.
 
-$x = 'test';
-if ($x eq $x) { print "ok 1 - if eq\n"; } else { print "not ok 1 - if eq\n";}
-if ($x ne $x) { print "not ok 2 - if ne\n"; } else { print "ok 2 - if ne\n";}
+my $x = 'test';
+if ($x eq $x) { print "ok 1 - if eq\n"; } else { print "not ok 1 - if eq\n"; }
+if ($x ne $x) { print "not ok 2 - if ne\n"; } else { print "ok 2 - if ne\n"; }

--- a/t/base/if.t
+++ b/t/base/if.t
@@ -2,13 +2,10 @@
 
 # t/base/if.t - check "if"
 
-use strict;
-use warnings;
-
 print "1..2\n";
 
 # First test to see if we can run the tests.
 
-my $x = 'test';
+$x = 'test';
 if ($x eq $x) { print "ok 1 - if eq\n"; } else { print "not ok 1 - if eq\n"; }
 if ($x ne $x) { print "not ok 2 - if ne\n"; } else { print "ok 2 - if ne\n"; }

--- a/t/base/pat.t
+++ b/t/base/pat.t
@@ -1,9 +1,19 @@
 #!./perl
 
+# t/base/pat.t - check base regex for $_
+
+use strict;
+use warnings;
+
 print "1..2\n";
 
-# first test to see if we can run the tests.
+# First test to see if we can run the tests.
 
 $_ = 'test';
-if (/^test/) { print "ok 1 - match regex\n"; } else { print "not ok 1 - match regex\n";}
-if (/^foo/) { print "not ok 2 - match regex\n"; } else { print "ok 2 - match regex\n";}
+/^test/
+  ? ( print "ok 1 - match regex\n" )
+  : ( print "not ok 1 - match regex\n" );
+
+/^foo/
+  ? ( print "not ok 2 - match regex\n" )
+  : ( print "ok 2 - match regex\n" );

--- a/t/base/pat.t
+++ b/t/base/pat.t
@@ -2,9 +2,6 @@
 
 # t/base/pat.t - check base regex for $_
 
-use strict;
-use warnings;
-
 print "1..2\n";
 
 # First test to see if we can run the tests.

--- a/t/base/rs.t
+++ b/t/base/rs.t
@@ -36,9 +36,6 @@
 # Test $/ by reading file to "our" filehandle variable
 # Test $/ for files from variables like real files
 
-use strict;
-use warnings;
-
 # Test $/
 
 print "1..41\n";
@@ -47,9 +44,9 @@ print "1..41\n";
 # Preparation
 # ======================================================
 
-my $test_count = 1;
-my $teststring = "1\n12\n123\n1234\n1234\n12345\n\n123456\n1234567\n";
-my $teststring2 = "1234567890123456789012345678901234567890";
+$test_count = 1;
+$teststring = "1\n12\n123\n1234\n1234\n12345\n\n123456\n1234567\n";
+$teststring2 = "1234567890123456789012345678901234567890";
 
 # ------------------------------------------------------
 # Remove previous test files if exist
@@ -80,7 +77,7 @@ close TESTFILE or die "error $! $^E closing";
 # ---------------------------------------------
 # Check $/ for $test_string from the 'foo' file
 # ---------------------------------------------
-my $test_count_start = $test_count;  # Needed to know how many tests to skip
+$test_count_start = $test_count;  # Needed to know how many tests to skip
 open TESTFILE, "<./foo";
 binmode TESTFILE;
 test_string(*TESTFILE);
@@ -101,7 +98,7 @@ open TESTFILE, "<./foo";
 binmode TESTFILE;
 test_record(*TESTFILE);
 close TESTFILE;
-my $test_count_end = $test_count;  # Needed to know how many tests to skip
+$test_count_end = $test_count;  # Needed to know how many tests to skip
 
 # -----------------------------------
 # $/ preserved when set to bad value
@@ -137,7 +134,7 @@ if ( $^O eq 'VMS' ) {
     print CREATEFILE "\$EXIT\n";
     close CREATEFILE;
 
-    my $throwaway = `\@\[\]foo`, "\n";
+    $throwaway = `\@\[\]foo`, "\n";
 
     open( TEMPFILE, ">./foo.bar" ) or die "# open failed $! $^E\n";
     print TEMPFILE "foo\nfoobar\nbaz\n";
@@ -147,7 +144,7 @@ if ( $^O eq 'VMS' ) {
 
     $/ = \10;
 
-    my $bar = <TESTFILE>;
+    $bar = <TESTFILE>;
     $bar eq "foo\n"
       ? ( print "ok $test_count\n" )
       : ( print "not ok $test_count\n" );
@@ -180,7 +177,7 @@ if ( $^O eq 'VMS' ) {
 else {
     # Nobody else does this at the moment (well, maybe OS/390, but they can
     # put their own tests in) so we just punt
-    foreach my $test ( $test_count .. $test_count + 3 ) {
+    foreach $test ( $test_count .. $test_count + 3 ) {
         print "ok $test # skipped on non-VMS system\n";
         $test_count++;
     }
@@ -197,7 +194,7 @@ $/ = "\n";
 # For "our" variable
 {
     if ( open our $T, "./foo" ) {
-        my $line = <$T>;
+        $line = <$T>;
         print "# $line\n";
         # length of $teststring2
         length($line) == 40 or print "not ";
@@ -213,7 +210,7 @@ $/ = "\n";
 # For "my" variable
 {
     if ( open my $T, "./foo" ) {
-        my $line = <$T>;
+        $line = <$T>;
         print "# $line\n";
         length($line) == 40 or print "not ";
         close $T            or print "not ";
@@ -237,7 +234,7 @@ $/ = "\n";
         # perlio and dynaloading enabled. miniperl won't be able to run this
         # test, so skip it
 
-        for my $test ( $test_count .. $test_count +
+        for $test ( $test_count .. $test_count +
             ( $test_count_end - $test_count_start - 1 ) )
         {
             print "ok $test # skipped - Can't test in memory file "
@@ -265,7 +262,7 @@ sub test_string {
     *FH = shift;
 
     # Check the default $/ which is newline
-    my $bar = <FH>;
+    $bar = <FH>;
     if ( $bar ne "1\n" ) { print "not "; }
     print "ok $test_count # default \$/\n";
     $test_count++;
@@ -319,7 +316,7 @@ sub test_record {
 
     # Test straight number
     $/ = \2;
-    my $bar = <FH>;
+    $bar = <FH>;
     if ( $bar ne "12" ) { print "not "; }
     print "ok $test_count # \$/ = \\2\n";
     $test_count++;
@@ -332,7 +329,7 @@ sub test_record {
     $test_count++;
 
     # Integer variable
-    my $foo = 2;
+    $foo = 2;
     $/   = \$foo;
     $bar = <FH>;
     if ( $bar ne "56" ) { print "not "; }
@@ -355,7 +352,7 @@ sub test_bad_setting {
           " # \$/ = \\0; produced expected error message\n";
     }
     else {
-        my $msg = $@ || "Zombie Error";
+        $msg = $@ || "Zombie Error";
         print "ok ", $test_count++, " # \$/ = \\0; should die\n";
         if ( $msg !~ m!Setting \$\/ to a reference to zero is forbidden! ) {
             print "not ";
@@ -370,7 +367,7 @@ sub test_bad_setting {
           " # \$/ = \\-1; produced expected error message\n";
     }
     else {
-        my $msg = $@ || "Zombie Error";
+        $msg = $@ || "Zombie Error";
         print "ok ", $test_count++, " # \$/ = \\-1; should die\n";
         if ( $msg !~
             m!Setting \$\/ to a reference to a negative integer is forbidden! )
@@ -387,7 +384,7 @@ sub test_bad_setting {
           " # \$/ = []; produced expected error message\n";
     }
     else {
-        my $msg = $@ || "Zombie Error";
+        $msg = $@ || "Zombie Error";
         print "ok ", $test_count++, " # \$/ = []; should die\n";
         if ( $msg !~ m!Setting \$\/ to an ARRAY reference is forbidden! ) {
             print "not ";
@@ -402,7 +399,7 @@ sub test_bad_setting {
           " # \$/ = {}; produced expected error message\n";
     }
     else {
-        my $msg = $@ || "Zombie Error";
+        $msg = $@ || "Zombie Error";
         print "ok ", $test_count++, " # \$/ = {}; should die\n";
         if ( $msg !~ m!Setting \$\/ to a HASH reference is forbidden! ) {
             print "not ";
@@ -417,7 +414,7 @@ sub test_bad_setting {
           " # \$/ = \\\\1; produced expected error message\n";
     }
     else {
-        my $msg = $@ || "Zombie Error";
+        $msg = $@ || "Zombie Error";
         print "ok ", $test_count++, " # \$/ = \\\\1; should die\n";
         if ( $msg !~ m!Setting \$\/ to a REF reference is forbidden! ) {
             print "not ";
@@ -432,7 +429,7 @@ sub test_bad_setting {
           " # \$/ = qr/foo/; produced expected error message\n";
     }
     else {
-        my $msg = $@ || "Zombie Error";
+        $msg = $@ || "Zombie Error";
         print "ok ", $test_count++, " # \$/ = qr/foo/; should die\n";
         if ( $msg !~ m!Setting \$\/ to a REGEXP reference is forbidden! ) {
             print "not ";
@@ -447,7 +444,7 @@ sub test_bad_setting {
           " # \$/ = \\*STDOUT; produced expected error message\n";
     }
     else {
-        my $msg = $@ || "Zombie Error";
+        $msg = $@ || "Zombie Error";
         print "ok ", $test_count++, " # \$/ = \\*STDOUT; should die\n";
         if ( $msg !~ m!Setting \$\/ to a GLOB reference is forbidden! ) {
             print "not ";

--- a/t/base/rs.t
+++ b/t/base/rs.t
@@ -1,312 +1,458 @@
 #!./perl
+
+# t/base/rs.t - $/ variable testing
+#
+# Test plan
+#
+# $/ allowed values:
+# ------------------
+#
+#   By default  - "\n"
+#   "\n"        - explicit value
+#   3           - non line terminator
+#   34          - more than one symbol
+#   ''          - delimiter as a paragraph
+#   undef       - the whole file
+#   2           - integer
+#   "2"         - string delimiter
+#
+#   \2          - part symbols count of
+#   \"2"        - a delimited string
+#
+# $/ unallowed values:
+# --------------------
+#
+#   \0       - Setting $/ to a reference to zero is forbidden
+#   \-1      - Setting $/ to a reference to a negative integer is forbidden
+#   []       - Setting $/ to an ARRAY reference is forbidden
+#   {}       - Setting $/ to a HASH reference is forbidden
+#   \\1      - Setting $/ to a REF reference is forbidden
+#   qr/foo/  - Setting $/ to a REGEXP reference is forbidden
+#   \*STDOUT - Setting $/ to a GLOB reference is forbidden
+#
+# Test preserverd value after trying to set unallowed ones
+# Tests for VMS case
+# Test $/ by reading file to "my" filehandle variable
+# Test $/ by reading file to "our" filehandle variable
+# Test $/ for files from variables like real files
+
+use strict;
+use warnings;
+
 # Test $/
 
 print "1..41\n";
 
-$test_count = 1;
-$teststring = "1\n12\n123\n1234\n1234\n12345\n\n123456\n1234567\n";
-$teststring2 = "1234567890123456789012345678901234567890";
+# ======================================================
+# Preparation
+# ======================================================
 
-# Create our test datafile
-1 while unlink 'foo';                # in case junk left around
+my $test_count = 1;
+my $teststring = "1\n12\n123\n1234\n1234\n12345\n\n123456\n1234567\n";
+my $teststring2 = "1234567890123456789012345678901234567890";
+
+# ------------------------------------------------------
+# Remove previous test files if exist
+# ------------------------------------------------------
+# In case of existing files with the same 'foo' name
+# on some systems with versioning file system (e.g VMS).
+# Read more at pod/perport.pod "System Interaction"
+1 while unlink 'foo';
+
 rmdir 'foo';
+# ----------------------------
+
+# ----------------------
+# Create test 'foo' file
+# ----------------------
 open TESTFILE, ">./foo" or die "error $! $^E opening";
 binmode TESTFILE;
 print TESTFILE $teststring;
 close TESTFILE or die "error $! $^E closing";
+# ----------------------
 
-$test_count_start = $test_count;  # Needed to know how many tests to skip
+# ======================================================
+
+# ======================================================
+# Run base checks of $/ for strings from files
+# ======================================================
+
+# ---------------------------------------------
+# Check $/ for $test_string from the 'foo' file
+# ---------------------------------------------
+my $test_count_start = $test_count;  # Needed to know how many tests to skip
 open TESTFILE, "<./foo";
 binmode TESTFILE;
 test_string(*TESTFILE);
 close TESTFILE;
+
 unlink "./foo";
 
-# try the record reading tests. New file so we don't have to worry about
+# ----------------------------------------------------------------------
+# Try the record reading tests. New file so we don't have to worry about
 # the size of \n.
+# ----------------------------------------------------------------------
 open TESTFILE, ">./foo";
 print TESTFILE $teststring2;
 binmode TESTFILE;
 close TESTFILE;
+
 open TESTFILE, "<./foo";
 binmode TESTFILE;
 test_record(*TESTFILE);
 close TESTFILE;
-$test_count_end = $test_count;  # Needed to know how many tests to skip
+my $test_count_end = $test_count;  # Needed to know how many tests to skip
 
+# -----------------------------------
+# $/ preserved when set to bad value
+# -----------------------------------
 $/ = "\n";
-my $note = "\$/ preserved when set to bad value";
+
 # none of the setting of $/ to bad values should modify its value
 test_bad_setting();
+
 print +($/ ne "\n" ? "not " : "") .
   "ok $test_count # \$/ preserved when set to bad value\n";
 ++$test_count;
+# -----------------------------------
+
+# =================================
+# VMS case
+# =================================
 
 # Now for the tricky bit--full record reading
-if ($^O eq 'VMS') {
-  # Create a temp file. We jump through these hoops 'cause CREATE really
-  # doesn't like our methods for some reason.
-  open FDLFILE, "> ./foo.fdl";
-  print FDLFILE "RECORD\n FORMAT VARIABLE\n";
-  close FDLFILE;
-  open CREATEFILE, "> ./foo.com";
-  print CREATEFILE '$ DEFINE/USER SYS$INPUT NL:', "\n";
-  print CREATEFILE '$ DEFINE/USER SYS$OUTPUT NL:', "\n";
-  print CREATEFILE '$ OPEN YOW []FOO.BAR/WRITE', "\n";
-  print CREATEFILE '$ CLOSE YOW', "\n";
-  print CREATEFILE "\$EXIT\n";
-  close CREATEFILE;
-  $throwaway = `\@\[\]foo`, "\n";
-  open(TEMPFILE, ">./foo.bar") or print "# open failed $! $^E\n";
-  print TEMPFILE "foo\nfoobar\nbaz\n";
-  close TEMPFILE;
+if ( $^O eq 'VMS' ) {
 
-  open TESTFILE, "<./foo.bar";
-  $/ = \10;
-  $bar = <TESTFILE>;
-  if ($bar eq "foo\n") {print "ok $test_count\n";} else {print "not ok $test_count\n";}
-  $test_count++;
-  $bar = <TESTFILE>;
-  if ($bar eq "foobar\n") {print "ok $test_count\n";} else {print "not ok $test_count\n";}
-  $test_count++;
-  # can we do a short read?
-  $/ = \2;
-  $bar = <TESTFILE>;
-  if ($bar eq "ba") {print "ok $test_count\n";} else {print "not ok $test_count\n";}
-  $test_count++;
-  # do we get the rest of the record?
-  $bar = <TESTFILE>;
-  if ($bar eq "z\n") {print "ok $test_count\n";} else {print "not ok $test_count\n";}
-  $test_count++;
+    # Create a temp file. We jump through these hoops 'cause CREATE really
+    # doesn't like our methods for some reason.
+    open FDLFILE, "> ./foo.fdl";
+    print FDLFILE "RECORD\n FORMAT VARIABLE\n";
+    close FDLFILE;
 
-  close TESTFILE;
-  1 while unlink qw(foo.bar foo.com foo.fdl);
-} else {
-  # Nobody else does this at the moment (well, maybe OS/390, but they can
-  # put their own tests in) so we just punt
-  foreach $test ($test_count..$test_count + 3) {
-      print "ok $test # skipped on non-VMS system\n";
-      $test_count++;
-  }
+    open CREATEFILE, "> ./foo.com";
+    print CREATEFILE '$ DEFINE/USER SYS$INPUT NL:',  "\n";
+    print CREATEFILE '$ DEFINE/USER SYS$OUTPUT NL:', "\n";
+    print CREATEFILE '$ OPEN YOW []FOO.BAR/WRITE',   "\n";
+    print CREATEFILE '$ CLOSE YOW',                  "\n";
+    print CREATEFILE "\$EXIT\n";
+    close CREATEFILE;
+
+    my $throwaway = `\@\[\]foo`, "\n";
+
+    open( TEMPFILE, ">./foo.bar" ) or die "# open failed $! $^E\n";
+    print TEMPFILE "foo\nfoobar\nbaz\n";
+    close TEMPFILE;
+
+    open TESTFILE, "<./foo.bar";
+
+    $/ = \10;
+
+    my $bar = <TESTFILE>;
+    $bar eq "foo\n"
+      ? ( print "ok $test_count\n" )
+      : ( print "not ok $test_count\n" );
+
+    $test_count++;
+    $bar = <TESTFILE>;
+    $bar eq "foobar\n"
+      ? ( print "ok $test_count\n" )
+      : ( print "not ok $test_count\n" );
+    $test_count++;
+
+    # Can we do a short read?
+    $/ = \2;
+    $bar = <TESTFILE>;
+    $bar eq "ba"
+      ? ( print "ok $test_count\n" )
+      : ( print "not ok $test_count\n" );
+    $test_count++;
+
+    # Do we get the rest of the record?
+    $bar = <TESTFILE>;
+    $bar eq "z\n"
+      ? ( print "ok $test_count\n" )
+      : ( print "not ok $test_count\n" );
+    $test_count++;
+
+    close TESTFILE;
+    1 while unlink qw(foo.bar foo.com foo.fdl);
 }
+else {
+    # Nobody else does this at the moment (well, maybe OS/390, but they can
+    # put their own tests in) so we just punt
+    foreach my $test ( $test_count .. $test_count + 3 ) {
+        print "ok $test # skipped on non-VMS system\n";
+        $test_count++;
+    }
+}
+# =================================
+# /VMS case
+# =================================
 
 $/ = "\n";
 
-# see if open/readline/close work on our and my variables
+# =======================================================
+# See if open/readline/close work on our and my variables
+# =======================================================
+# For "our" variable
 {
-    if (open our $T, "./foo") {
+    if ( open our $T, "./foo" ) {
         my $line = <$T>;
-	print "# $line\n";
-	length($line) == 40 or print "not ";
-        close $T or print "not ";
+        print "# $line\n";
+        # length of $teststring2
+        length($line) == 40 or print "not ";
+        close $T            or print "not ";
     }
     else {
-	print "not ";
+        print "not ";
     }
     print "ok $test_count # open/readline/close on our variable\n";
     $test_count++;
 }
 
+# For "my" variable
 {
-    if (open my $T, "./foo") {
+    if ( open my $T, "./foo" ) {
         my $line = <$T>;
-	print "# $line\n";
-	length($line) == 40 or print "not ";
-        close $T or print "not ";
+        print "# $line\n";
+        length($line) == 40 or print "not ";
+        close $T            or print "not ";
     }
     else {
-	print "not ";
+        print "not ";
     }
     print "ok $test_count # open/readline/close on my variable\n";
     $test_count++;
 }
+# =======================================================
 
 
 {
- # If we do not include the lib directories, we may end up picking up a
- # binary-incompatible previously-installed version. The eval won’t help in
- # intercepting a SIGTRAP.
- local @INC = ("../lib", "lib", @INC);
- if (not eval q/use PerlIO::scalar; 1/) {
-  # In-memory files necessitate PerlIO::scalar, thus a perl with
-  # perlio and dynaloading enabled. miniperl won't be able to run this
-  # test, so skip it
+    # If we do not include the lib directories, we may end up picking up a
+    # binary-incompatible previously-installed version. The eval won’t help in
+    # intercepting a SIGTRAP.
+    local @INC = ("../lib", "lib", @INC);
+    if (not eval q/use PerlIO::scalar; 1/) {
+        # In-memory files necessitate PerlIO::scalar, thus a perl with
+        # perlio and dynaloading enabled. miniperl won't be able to run this
+        # test, so skip it
 
-  for $test ($test_count .. $test_count + ($test_count_end - $test_count_start - 1)) {
-    print "ok $test # skipped - Can't test in memory file with miniperl/without PerlIO::Scalar\n";
-    $test_count++;
-  }
- }
- else {
-  # Test if a file in memory behaves the same as a real file (= re-run the test with a file in memory)
-  open TESTFILE, "<", \$teststring;
-  test_string(*TESTFILE);
-  close TESTFILE;
+        for my $test ( $test_count .. $test_count +
+            ( $test_count_end - $test_count_start - 1 ) )
+        {
+            print "ok $test # skipped - Can't test in memory file "
+              . "with miniperl/without PerlIO::Scalar\n";
+            $test_count++;
+        }
+    }
+    else {
 
-  open TESTFILE, "<", \$teststring2;
-  test_record(*TESTFILE);
-  close TESTFILE;
- }
+        # Test if a file in memory behaves the same as a real file (= re-run the test with a file in memory)
+        open TESTFILE, "<", \$teststring;
+        test_string(*TESTFILE);
+        close TESTFILE;
+
+        open TESTFILE, "<", \$teststring2;
+        test_record(*TESTFILE);
+        close TESTFILE;
+    }
 }
 
 # Get rid of the temp file
 END { unlink "./foo"; }
 
 sub test_string {
-  *FH = shift;
+    *FH = shift;
 
-  # Check the default $/
-  $bar = <FH>;
-  if ($bar ne "1\n") {print "not ";}
-  print "ok $test_count # default \$/\n";
-  $test_count++;
+    # Check the default $/ which is newline
+    my $bar = <FH>;
+    if ( $bar ne "1\n" ) { print "not "; }
+    print "ok $test_count # default \$/\n";
+    $test_count++;
 
-  # explicitly set to \n
-  $/ = "\n";
-  $bar = <FH>;
-  if ($bar ne "12\n") {print "not ";}
-  print "ok $test_count # \$/ = \"\\n\"\n";
-  $test_count++;
+    # explicitly set to \n
+    $/   = "\n";
+    $bar = <FH>;
+    if ( $bar ne "12\n" ) { print "not "; }
+    print "ok $test_count # \$/ = \"\\n\"\n";
+    $test_count++;
 
-  # Try a non line terminator
-  $/ = 3;
-  $bar = <FH>;
-  if ($bar ne "123") {print "not ";}
-  print "ok $test_count # \$/ = 3\n";
-  $test_count++;
+    # Try a non line terminator
+    $/   = 3;
+    $bar = <FH>;
+    if ( $bar ne "123" ) { print "not "; }
+    print "ok $test_count # \$/ = 3\n";
+    $test_count++;
 
-  # Eat the line terminator
-  $/ = "\n";
-  $bar = <FH>;
+    # Eat the line terminator
+    $/   = "\n";
+    $bar = <FH>;
 
-  # How about a larger terminator
-  $/ = "34";
-  $bar = <FH>;
-  if ($bar ne "1234") {print "not ";}
-  print "ok $test_count # \$/ = \"34\"\n";
-  $test_count++;
+    # How about a larger terminator
+    $/   = "34";
+    $bar = <FH>;
+    if ( $bar ne "1234" ) { print "not "; }
+    print "ok $test_count # \$/ = \"34\"\n";
+    $test_count++;
 
-  # Eat the line terminator
-  $/ = "\n";
-  $bar = <FH>;
+    # Eat the line terminator
+    $/   = "\n";
+    $bar = <FH>;
 
-  # Does paragraph mode work?
-  $/ = '';
-  $bar = <FH>;
-  if ($bar ne "1234\n12345\n\n") {print "not ";}
-  print "ok $test_count # \$/ = ''\n";
-  $test_count++;
+    # Does paragraph mode work?
+    $/   = '';
+    $bar = <FH>;
+    if ( $bar ne "1234\n12345\n\n" ) { print "not "; }
+    print "ok $test_count # \$/ = ''\n";
+    $test_count++;
 
-  # Try slurping the rest of the file
-  $/ = undef;
-  $bar = <FH>;
-  if ($bar ne "123456\n1234567\n") {print "not ";}
-  print "ok $test_count # \$/ = undef\n";
-  $test_count++;
+    # Try slurping the rest of the file
+    $/   = undef;
+    $bar = <FH>;
+    if ( $bar ne "123456\n1234567\n" ) { print "not "; }
+    print "ok $test_count # \$/ = undef\n";
+    $test_count++;
 }
 
 sub test_record {
-  *FH = shift;
+    *FH = shift;
 
-  # Test straight number
-  $/ = \2;
-  $bar = <FH>;
-  if ($bar ne "12") {print "not ";}
-  print "ok $test_count # \$/ = \\2\n";
-  $test_count++;
+    # Test straight number
+    $/ = \2;
+    my $bar = <FH>;
+    if ( $bar ne "12" ) { print "not "; }
+    print "ok $test_count # \$/ = \\2\n";
+    $test_count++;
 
-  # Test stringified number
-  $/ = \"2";
-  $bar = <FH>;
-  if ($bar ne "34") {print "not ";}
-  print "ok $test_count # \$/ = \"2\"\n";
-  $test_count++;
+    # Test stringified number
+    $/   = \"2";
+    $bar = <FH>;
+    if ( $bar ne "34" ) { print "not "; }
+    print "ok $test_count # \$/ = \"2\"\n";
+    $test_count++;
 
-  # Integer variable
-  $foo = 2;
-  $/ = \$foo;
-  $bar = <FH>;
-  if ($bar ne "56") {print "not ";}
-  print "ok $test_count # \$/ = \\\$foo (\$foo = 2)\n";
-  $test_count++;
+    # Integer variable
+    my $foo = 2;
+    $/   = \$foo;
+    $bar = <FH>;
+    if ( $bar ne "56" ) { print "not "; }
+    print "ok $test_count # \$/ = \\\$foo (\$foo = 2)\n";
+    $test_count++;
 
-  # String variable
-  $foo = "2";
-  $/ = \$foo;
-  $bar = <FH>;
-  if ($bar ne "78") {print "not ";}
-  print "ok $test_count # \$/ = \\\$foo (\$foo = \"2\")\n";
-  $test_count++;
+    # String variable
+    $foo = "2";
+    $/   = \$foo;
+    $bar = <FH>;
+    if ( $bar ne "78" ) { print "not "; }
+    print "ok $test_count # \$/ = \\\$foo (\$foo = \"2\")\n";
+    $test_count++;
 }
 
 sub test_bad_setting {
-  if (eval {$/ = \0; 1}) {
-    print "not ok ",$test_count++," # \$/ = \\0; should die\n";
-    print "not ok ",$test_count++," # \$/ = \\0; produced expected error message\n";
-  } else {
-    my $msg= $@ || "Zombie Error";
-    print "ok ",$test_count++," # \$/ = \\0; should die\n";
-    if ($msg!~m!Setting \$\/ to a reference to zero is forbidden!) {
-      print "not ";
+    if ( eval { $/ = \0; 1 } ) {
+        print "not ok ", $test_count++, " # \$/ = \\0; should die\n";
+        print "not ok ", $test_count++,
+          " # \$/ = \\0; produced expected error message\n";
     }
-    print "ok ",$test_count++," # \$/ = \\0; produced expected error message\n";
-  }
-  if (eval {$/ = \-1; 1}) {
-    print "not ok ",$test_count++," # \$/ = \\-1; should die\n";
-    print "not ok ",$test_count++," # \$/ = \\-1; produced expected error message\n";
-  } else {
-    my $msg= $@ || "Zombie Error";
-    print "ok ",$test_count++," # \$/ = \\-1; should die\n";
-    if ($msg!~m!Setting \$\/ to a reference to a negative integer is forbidden!) {
-      print "not ";
+    else {
+        my $msg = $@ || "Zombie Error";
+        print "ok ", $test_count++, " # \$/ = \\0; should die\n";
+        if ( $msg !~ m!Setting \$\/ to a reference to zero is forbidden! ) {
+            print "not ";
+        }
+        print "ok ", $test_count++,
+          " # \$/ = \\0; produced expected error message\n";
     }
-    print "ok ",$test_count++," # \$/ = \\-1; produced expected error message\n";
-  }
-  if (eval {$/ = []; 1}) {
-    print "not ok ",$test_count++," # \$/ = []; should die\n";
-    print "not ok ",$test_count++," # \$/ = []; produced expected error message\n";
-  } else {
-    my $msg= $@ || "Zombie Error";
-    print "ok ",$test_count++," # \$/ = []; should die\n";
-    if ($msg!~m!Setting \$\/ to an ARRAY reference is forbidden!) {
-      print "not ";
+
+    if ( eval { $/ = \-1; 1 } ) {
+        print "not ok ", $test_count++, " # \$/ = \\-1; should die\n";
+        print "not ok ", $test_count++,
+          " # \$/ = \\-1; produced expected error message\n";
     }
-    print "ok ",$test_count++," # \$/ = []; produced expected error message\n";
-  }
-  if (eval {$/ = {}; 1}) {
-    print "not ok ",$test_count++," # \$/ = {}; should die\n";
-    print "not ok ",$test_count++," # \$/ = {}; produced expected error message\n";
-  } else {
-    my $msg= $@ || "Zombie Error";
-    print "ok ",$test_count++," # \$/ = {}; should die\n";
-    if ($msg!~m!Setting \$\/ to a HASH reference is forbidden!) {print "not ";}
-    print "ok ",$test_count++," # \$/ = {}; produced expected error message\n";
-  }
-  if (eval {$/ = \\1; 1}) {
-    print "not ok ",$test_count++," # \$/ = \\\\1; should die\n";
-    print "not ok ",$test_count++," # \$/ = \\\\1; produced expected error message\n";
-  } else {
-    my $msg= $@ || "Zombie Error";
-    print "ok ",$test_count++," # \$/ = \\\\1; should die\n";
-    if ($msg!~m!Setting \$\/ to a REF reference is forbidden!) {print "not ";}
-    print "ok ",$test_count++," # \$/ = \\\\1; produced expected error message\n";
-  }
-  if (eval {$/ = qr/foo/; 1}) {
-    print "not ok ",$test_count++," # \$/ = qr/foo/; should die\n";
-    print "not ok ",$test_count++," # \$/ = qr/foo/; produced expected error message\n";
-  } else {
-    my $msg= $@ || "Zombie Error";
-    print "ok ",$test_count++," # \$/ = qr/foo/; should die\n";
-    if ($msg!~m!Setting \$\/ to a REGEXP reference is forbidden!) {print "not ";}
-    print "ok ",$test_count++," # \$/ = qr/foo/; produced expected error message\n";
-  }
-  if (eval {$/ = \*STDOUT; 1}) {
-    print "not ok ",$test_count++," # \$/ = \\*STDOUT; should die\n";
-    print "not ok ",$test_count++," # \$/ = \\*STDOUT; produced expected error message\n";
-  } else {
-    my $msg= $@ || "Zombie Error";
-    print "ok ",$test_count++," # \$/ = \\*STDOUT; should die\n";
-    if ($msg!~m!Setting \$\/ to a GLOB reference is forbidden!) {print "not ";}
-    print "ok ",$test_count++," # \$/ = \\*STDOUT; produced expected error message\n";
-  }
+    else {
+        my $msg = $@ || "Zombie Error";
+        print "ok ", $test_count++, " # \$/ = \\-1; should die\n";
+        if ( $msg !~
+            m!Setting \$\/ to a reference to a negative integer is forbidden! )
+        {
+            print "not ";
+        }
+        print "ok ", $test_count++,
+          " # \$/ = \\-1; produced expected error message\n";
+    }
+
+    if ( eval { $/ = []; 1 } ) {
+        print "not ok ", $test_count++, " # \$/ = []; should die\n";
+        print "not ok ", $test_count++,
+          " # \$/ = []; produced expected error message\n";
+    }
+    else {
+        my $msg = $@ || "Zombie Error";
+        print "ok ", $test_count++, " # \$/ = []; should die\n";
+        if ( $msg !~ m!Setting \$\/ to an ARRAY reference is forbidden! ) {
+            print "not ";
+        }
+        print "ok ", $test_count++,
+          " # \$/ = []; produced expected error message\n";
+    }
+
+    if ( eval { $/ = {}; 1 } ) {
+        print "not ok ", $test_count++, " # \$/ = {}; should die\n";
+        print "not ok ", $test_count++,
+          " # \$/ = {}; produced expected error message\n";
+    }
+    else {
+        my $msg = $@ || "Zombie Error";
+        print "ok ", $test_count++, " # \$/ = {}; should die\n";
+        if ( $msg !~ m!Setting \$\/ to a HASH reference is forbidden! ) {
+            print "not ";
+        }
+        print "ok ", $test_count++,
+          " # \$/ = {}; produced expected error message\n";
+    }
+
+    if ( eval { $/ = \\1; 1 } ) {
+        print "not ok ", $test_count++, " # \$/ = \\\\1; should die\n";
+        print "not ok ", $test_count++,
+          " # \$/ = \\\\1; produced expected error message\n";
+    }
+    else {
+        my $msg = $@ || "Zombie Error";
+        print "ok ", $test_count++, " # \$/ = \\\\1; should die\n";
+        if ( $msg !~ m!Setting \$\/ to a REF reference is forbidden! ) {
+            print "not ";
+        }
+        print "ok ", $test_count++,
+          " # \$/ = \\\\1; produced expected error message\n";
+    }
+
+    if ( eval { $/ = qr/foo/; 1 } ) {
+        print "not ok ", $test_count++, " # \$/ = qr/foo/; should die\n";
+        print "not ok ", $test_count++,
+          " # \$/ = qr/foo/; produced expected error message\n";
+    }
+    else {
+        my $msg = $@ || "Zombie Error";
+        print "ok ", $test_count++, " # \$/ = qr/foo/; should die\n";
+        if ( $msg !~ m!Setting \$\/ to a REGEXP reference is forbidden! ) {
+            print "not ";
+        }
+        print "ok ", $test_count++,
+          " # \$/ = qr/foo/; produced expected error message\n";
+    }
+
+    if ( eval { $/ = \*STDOUT; 1 } ) {
+        print "not ok ", $test_count++, " # \$/ = \\*STDOUT; should die\n";
+        print "not ok ", $test_count++,
+          " # \$/ = \\*STDOUT; produced expected error message\n";
+    }
+    else {
+        my $msg = $@ || "Zombie Error";
+        print "ok ", $test_count++, " # \$/ = \\*STDOUT; should die\n";
+        if ( $msg !~ m!Setting \$\/ to a GLOB reference is forbidden! ) {
+            print "not ";
+        }
+        print "ok ", $test_count++,
+          " # \$/ = \\*STDOUT; produced expected error message\n";
+    }
 }

--- a/t/base/rs.t
+++ b/t/base/rs.t
@@ -5,7 +5,6 @@
 # Test plan
 #
 # $/ allowed values:
-# ------------------
 #
 #   By default  - "\n"
 #   "\n"        - explicit value
@@ -20,7 +19,6 @@
 #   \"2"        - a delimited string
 #
 # $/ unallowed values:
-# --------------------
 #
 #   \0       - Setting $/ to a reference to zero is forbidden
 #   \-1      - Setting $/ to a reference to a negative integer is forbidden
@@ -36,47 +34,30 @@
 # Test $/ by reading file to "our" filehandle variable
 # Test $/ for files from variables like real files
 
-# Test $/
-
 print "1..41\n";
 
-# ======================================================
 # Preparation
-# ======================================================
 
 $test_count = 1;
 $teststring = "1\n12\n123\n1234\n1234\n12345\n\n123456\n1234567\n";
 $teststring2 = "1234567890123456789012345678901234567890";
 
-# ------------------------------------------------------
 # Remove previous test files if exist
-# ------------------------------------------------------
+#
 # In case of existing files with the same 'foo' name
 # on some systems with versioning file system (e.g VMS).
-# Read more at pod/perport.pod "System Interaction"
+# Read more at pod/perlport.pod "System Interaction"
 1 while unlink 'foo';
 
 rmdir 'foo';
-# ----------------------------
 
-# ----------------------
 # Create test 'foo' file
-# ----------------------
 open TESTFILE, ">./foo" or die "error $! $^E opening";
 binmode TESTFILE;
 print TESTFILE $teststring;
 close TESTFILE or die "error $! $^E closing";
-# ----------------------
 
-# ======================================================
-
-# ======================================================
-# Run base checks of $/ for strings from files
-# ======================================================
-
-# ---------------------------------------------
 # Check $/ for $test_string from the 'foo' file
-# ---------------------------------------------
 $test_count_start = $test_count;  # Needed to know how many tests to skip
 open TESTFILE, "<./foo";
 binmode TESTFILE;
@@ -85,10 +66,8 @@ close TESTFILE;
 
 unlink "./foo";
 
-# ----------------------------------------------------------------------
 # Try the record reading tests. New file so we don't have to worry about
 # the size of \n.
-# ----------------------------------------------------------------------
 open TESTFILE, ">./foo";
 print TESTFILE $teststring2;
 binmode TESTFILE;
@@ -100,22 +79,17 @@ test_record(*TESTFILE);
 close TESTFILE;
 $test_count_end = $test_count;  # Needed to know how many tests to skip
 
-# -----------------------------------
 # $/ preserved when set to bad value
-# -----------------------------------
 $/ = "\n";
 
-# none of the setting of $/ to bad values should modify its value
+# None of the setting of $/ to bad values should modify its value
 test_bad_setting();
 
 print +($/ ne "\n" ? "not " : "") .
   "ok $test_count # \$/ preserved when set to bad value\n";
 ++$test_count;
-# -----------------------------------
 
-# =================================
 # VMS case
-# =================================
 
 # Now for the tricky bit--full record reading
 if ( $^O eq 'VMS' ) {
@@ -182,15 +156,11 @@ else {
         $test_count++;
     }
 }
-# =================================
-# /VMS case
-# =================================
 
 $/ = "\n";
 
-# =======================================================
 # See if open/readline/close work on our and my variables
-# =======================================================
+
 # For "our" variable
 {
     if ( open our $T, "./foo" ) {
@@ -221,8 +191,6 @@ $/ = "\n";
     print "ok $test_count # open/readline/close on my variable\n";
     $test_count++;
 }
-# =======================================================
-
 
 {
     # If we do not include the lib directories, we may end up picking up a
@@ -267,7 +235,7 @@ sub test_string {
     print "ok $test_count # default \$/\n";
     $test_count++;
 
-    # explicitly set to \n
+    # Explicitly set to \n
     $/   = "\n";
     $bar = <FH>;
     if ( $bar ne "12\n" ) { print "not "; }

--- a/t/base/while.t
+++ b/t/base/while.t
@@ -9,14 +9,11 @@
 #   next
 #   always false
 
-use strict;
-use warnings;
-
 print "1..4\n";
 
 # very basic tests of while
 
-my $x = 0;
+$x = 0;
 while ($x != 3) {
     $x = $x + 1;
 }

--- a/t/base/while.t
+++ b/t/base/while.t
@@ -1,10 +1,22 @@
 #!./perl
 
+# t/base/while.t - check base while loop
+#
+# Test plan
+#
+#   false
+#   always true
+#   next
+#   always false
+
+use strict;
+use warnings;
+
 print "1..4\n";
 
 # very basic tests of while
 
-$x = 0;
+my $x = 0;
 while ($x != 3) {
     $x = $x + 1;
 }
@@ -30,4 +42,3 @@ while (0) {
     $x = 1;
 }
 if ($x == 0) { print "ok 4\n"; } else { print "not ok 4\n";}
-


### PR DESCRIPTION
Added `use strict; use warnings` to some t/base/*.t files and comment descriptions about their test plans.