### PR TITLE
Support %#p format

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -374,6 +374,7 @@ Dmitri Tikhonov                <dmitri@cpan.org>
 Dmitry Karasik                 <dk@tetsuo.karasik.eu.org>
 Dmitry Ulanov                  <zprogd@gmail.com>
 Dominic Dunlop                 <domo@computer.org>
+Dominic Hamon                  <dma+github@stripysock.com>
 Dominic Hargreaves             <dom@earth.li>
 Dominique Dumont               <Dominique_Dumont@grenoble.hp.com>
 Dominique Quatravaux

--- a/sv.c
+++ b/sv.c
@@ -12472,7 +12472,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
 
 	    uv = PTR2UV(args ? va_arg(*args, void*) : argsv);
 	    base = 16;
-            c = 'x';
+            c = 'x';    /* in case the format string contains '#' */
 	    goto do_integer;
 
 	case 'c':

--- a/sv.c
+++ b/sv.c
@@ -12398,8 +12398,6 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
 	    /* INTEGERS */
 
 	case 'p':
-	    if (alt)
-		goto unknown;
 
             /* %p extensions:
              *
@@ -12474,6 +12472,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
 
 	    uv = PTR2UV(args ? va_arg(*args, void*) : argsv);
 	    base = 16;
+            c = 'x';
 	    goto do_integer;
 
 	case 'c':

--- a/t/op/sprintf.t
+++ b/t/op/sprintf.t
@@ -548,7 +548,9 @@ __END__
 >%#06.4o<   >18<          >  0022<        >0 flag with precision: no effect<
 >%d< >$p=sprintf('%p',$p);$p=~/^[0-9a-f]+$/< >1< >Coarse hack: hex from %p?<
 >%d< >$p=sprintf('%-8p',$p);$p=~/^[0-9a-f]+\s*$/< >1< >Coarse hack: hex from %p?<
->%#p<       >''<          >%#p INVALID<
+>%#p<       >0<           >0<
+>%#p<       >15<          >0xf<
+>%#p<       >2**32-1<     >0xffffffff<
 >%q<        >''<          >%q INVALID<
 >%r<        >''<          >%r INVALID<
 >%s<        >[]<          > MISSING<

--- a/t/op/sprintf.t
+++ b/t/op/sprintf.t
@@ -548,9 +548,7 @@ __END__
 >%#06.4o<   >18<          >  0022<        >0 flag with precision: no effect<
 >%d< >$p=sprintf('%p',$p);$p=~/^[0-9a-f]+$/< >1< >Coarse hack: hex from %p?<
 >%d< >$p=sprintf('%-8p',$p);$p=~/^[0-9a-f]+\s*$/< >1< >Coarse hack: hex from %p?<
->%#p<       >0<           >0<
->%#p<       >15<          >0xf<
->%#p<       >2**32-1<     >0xffffffff<
+>%d< >$p=sprintf('%#p',$p);$p=~/^0x[0-9a-f]+\s*$/< >1< >Coarse hack: hex from %#p<
 >%q<        >''<          >%q INVALID<
 >%r<        >''<          >%r INVALID<
 >%s<        >[]<          > MISSING<


### PR DESCRIPTION
Prior to this change, the `%#p` format was considered 'invalid'. This change adds support for it similarly to `%#x` and adds a test to confirm it works as intended.

Fixes #18289 