### PR TITLE
Replaced pod/ rt.perl.org tickets links to github.com issues links

### DIFF
--- a/pod/perl5121delta.pod
+++ b/pod/perl5121delta.pod
@@ -195,7 +195,7 @@ Filetests don't always expect an op on the stack, so we now use
 TOPs only if we're sure that we're not stat'ing the _ filehandle.
 This is indicated by OPf_KIDS (as checked in ck_ftst).
 
-See also: L<http://rt.perl.org/rt3/Public/Bug/Display.html?id=74542>
+See also: L<https://github.com/Perl/perl5/issues/10335>
 
 =item *
 
@@ -219,7 +219,7 @@ utf8::is_utf8 now respects GMAGIC (e.g. $1)
 XS code using C<fputc()> or C<fputs()>: on Windows could cause an error
 due to their arguments being swapped.
 
-See also: L<http://rt.perl.org/rt3/Public/Bug/Display.html?id=72704>
+See also: L<https://github.com/Perl/perl5/issues/10156>
 
 =item *
 
@@ -228,14 +228,14 @@ in an obscure situation.  It happened when stuffing was performed on the
 last line of a file and the line ended with a statement that lacked a
 terminating semicolon.  
 
-See also: L<http://rt.perl.org/rt3/Public/Bug/Display.html?id=74006>
+See also: L<https://github.com/Perl/perl5/issues/10273>
 
 =item *
 
 We fixed a bug that could cause \N{} constructs followed by a single . to
 be parsed incorrectly.
 
-See also: L<http://rt.perl.org/rt3/Public/Bug/Display.html?id=74978>
+See also: L<https://github.com/Perl/perl5/issues/10367>
 
 =item *
 
@@ -243,21 +243,21 @@ See also: L<http://rt.perl.org/rt3/Public/Bug/Display.html?id=74978>
 We fixed a bug that caused when(scalar) without an argument not to be
 treated as a syntax error.
 
-See also: L<http://rt.perl.org/rt3/Public/Bug/Display.html?id=74114>
+See also: L<https://github.com/Perl/perl5/issues/10287>
 
 =item *
 
 We fixed a regression in the handling of labels immediately before string
 evals that was introduced in Perl 5.12.0.
 
-See also: L<http://rt.perl.org/rt3/Public/Bug/Display.html?id=74290>
+See also: L<https://github.com/Perl/perl5/issues/10301>
 
 =item *
 
 We fixed a regression in case-insensitive matching of folded characters
 in regular expressions introduced in Perl 5.10.1.
 
-See also: L<http://rt.perl.org/rt3/Public/Bug/Display.html?id=72998>
+See also: L<https://github.com/Perl/perl5/issues/10193>
 
 =back
 
@@ -342,7 +342,7 @@ take a block as their first argument, like
 
     foo { ... $_ ...} list
 
-See also: L<http://rt.perl.org/rt3/Public/Bug/Display.html?id=67694>
+See also: L<https://github.com/Perl/perl5/issues/9798>
 
 =item *
 

--- a/pod/perl5122delta.pod
+++ b/pod/perl5122delta.pod
@@ -207,7 +207,7 @@ fixing a potential crash.  C<split()> would crash because the third item
 on the stack wasn't the regular expression it expected.  C<unpack("%2H",
 ...)> would return both the unpacked result and the checksum on the stack,
 as would C<unpack("%2u", ...)>.
-L<[perl #73814]|http://rt.perl.org/rt3/Ticket/Display.html?id=73814>
+L<[GH #10257]|https://github.com/Perl/perl5/issues/10257>
 
 =item *
 
@@ -233,7 +233,7 @@ stack for their return values in cases where no argument was passed in.
 
 When matching unicode strings under some conditions inappropriate backtracking would
 result in a C<Malformed UTF-8 character (fatal)> error. This should no longer occur.
-See  L<[perl #75680]|http://rt.perl.org/rt3/Public/Bug/Display.html?id=75680>
+See  L<[GH #10434]|https://github.com/Perl/perl5/issues/10434>
 
 =back
 

--- a/pod/perl5140delta.pod
+++ b/pod/perl5140delta.pod
@@ -723,7 +723,7 @@ The C<*$glob> on the second line returns a new immutable glob.  That new
 glob is made an alias to C<*bar>.  Then it is discarded.  So the second
 assignment has no effect.
 
-See L<http://rt.perl.org/rt3/Public/Bug/Display.html?id=77810> for
+See L<https://github.com/Perl/perl5/issues/10625> for
 more detail.
 
 =head3 Magic variables outside the main package
@@ -4441,7 +4441,7 @@ take a block as their first argument, like
 
     foo { ... $_ ...} list
 
-See also: L<http://rt.perl.org/rt3/Public/Bug/Display.html?id=67694>
+See also: L<https://github.com/Perl/perl5/issues/9798>
 
 =item *
 

--- a/pod/perl5160delta.pod
+++ b/pod/perl5160delta.pod
@@ -654,7 +654,7 @@ VM/ESA
 Swapping of $< and $>
 
 For more information about this future deprecation, see L<the relevant RT
-ticket|https://rt.perl.org/rt3/Ticket/Display.html?id=96212>.
+ticket|https://github.com/Perl/perl5/issues/11547>.
 
 =item *
 

--- a/pod/perl5184delta.pod
+++ b/pod/perl5184delta.pod
@@ -45,12 +45,12 @@ filehandle information is properly reset after a pager is run. [perl #121456]
 =item *
 
 Introduced by
-L<perl #113536|https://rt.perl.org/Public/Bug/Display.html?id=113536>, a memory
+L<[GH #12161]|https://github.com/Perl/perl5/issues/12161>, a memory
 leak on every call to C<system> and backticks (C< `` >), on most Win32 Perls
 starting from 5.18.0 has been fixed.  The memory leak only occurred if you
 enabled pseudo-fork in your build of Win32 Perl, and were running that build on
 Server 2003 R2 or newer OS.  The leak does not appear on WinXP SP3.
-[L<perl #121676|https://rt.perl.org/Public/Bug/Display.html?id=121676>]
+L<[GH #13741]|https://github.com/Perl/perl5/issues/13741>
 
 =back
 

--- a/pod/perl5200delta.pod
+++ b/pod/perl5200delta.pod
@@ -1854,7 +1854,7 @@ F<perlbug> now has a C<-p> option for attaching patches with a bug report.
 
 L<perlbug> has been modified to supply the report template with CRLF line
 endings on Windows.
-[L<perl #121277|https://rt.perl.org/Public/Bug/Display.html?id=121277>]
+L<[GH #13612]|https://github.com/Perl/perl5/issues/13612>
 
 =item *
 
@@ -1976,7 +1976,7 @@ too, but B<-fwrapv> was broken before 4.3, and the optimizations probably won't
 go away), F<Configure> now adds B<-fwrapv> unless the user requests
 B<-fno-wrapv>, which disables B<-fwrapv>, or B<-fsanitize=undefined>, which
 turns the overflows B<-fwrapv> ignores into runtime errors.
-[L<perl #121505|https://rt.perl.org/Public/Bug/Display.html?id=121505>]
+L<[GH #13690]|https://github.com/Perl/perl5/issues/13690>
 
 =back
 
@@ -2190,7 +2190,7 @@ The time taken to build perl on Windows has been reduced quite significantly
 (time savings in the region of 30-40% are typically seen) by reducing the
 number of, usually failing, I/O calls for each L<C<require()>|perlfunc/require>
 (for B<miniperl.exe> only).
-[L<perl #121119|https://rt.perl.org/Public/Bug/Display.html?id=121119>]
+L<[GH #13566]|https://github.com/Perl/perl5/issues/13566>
 
 =item *
 
@@ -2198,7 +2198,7 @@ About 15 minutes of idle sleeping was removed from running C<make test> due to
 a bug in which the timeout monitor used for tests could not be cancelled once
 the test completes, and the full timeout period elapsed before running the next
 test file.
-[L<perl #121395|https://rt.perl.org/Public/Bug/Display.html?id=121395>]
+L<[GH #13647]|https://github.com/Perl/perl5/issues/13647>
 
 =item *
 
@@ -2209,7 +2209,7 @@ C<kill()> killed 1 process tree PID then it returned 0 instead of 1, and if
 C<kill()> was passed 2 invalid PIDs then it returned 2 instead of 0.  This has
 probably been the case since the process tree kill feature was implemented on
 Win32.  It has now been corrected to follow the documented behaviour.
-[L<perl #121230|https://rt.perl.org/Public/Bug/Display.html?id=121230>]
+L<[GH #13595]|https://github.com/Perl/perl5/issues/13595>
 
 =item *
 
@@ -2217,7 +2217,7 @@ When building a 64-bit perl, an uninitialized memory read in B<miniperl.exe>,
 used during the build process, could lead to a 4GB B<wperl.exe> being created.
 This has now been fixed.  (Note that B<perl.exe> itself was unaffected, but
 obviously B<wperl.exe> would have been completely broken.)
-[L<perl #121471|https://rt.perl.org/Public/Bug/Display.html?id=121471>]
+L<[GH #13677]|https://github.com/Perl/perl5/issues/13677>
 
 =item *
 
@@ -2226,30 +2226,30 @@ This was previously broken due to an incorrect definition of DllMain() in one
 of perl's source files.  Earlier B<gcc> versions were also affected when using
 version 4 of the w32api package.  Versions of B<gcc> available from
 L<http://mingw-w64.sourceforge.net/> were not affected.
-[L<perl #121643|https://rt.perl.org/Public/Bug/Display.html?id=121643>]
+L<[GH #13733]|https://github.com/Perl/perl5/issues/13733>
 
 =item *
 
 The test harness now has no failures when perl is built on a FAT drive with the
 Windows OS on an NTFS drive.
-[L<perl #21442|https://rt.perl.org/Public/Bug/Display.html?id=21442>]
+L<[GH #6348]|https://github.com/Perl/perl5/issues/6348>
 
 =item *
 
 When cloning the context stack in fork() emulation, Perl_cx_dup()
 would crash accessing parameter information for context stack entries
 that included no parameters, as with C<&foo;>.
-[L<perl #121721|https://rt.perl.org/Public/Bug/Display.html?id=121721>]
+L<[GH #13763]|https://github.com/Perl/perl5/issues/13763>
 
 =item *
 
 Introduced by
-L<perl #113536|https://rt.perl.org/Public/Bug/Display.html?id=113536>, a memory
+L<[GH #12161]|https://github.com/Perl/perl5/issues/12161>, a memory
 leak on every call to C<system> and backticks (C< `` >), on most Win32 Perls
 starting from 5.18.0 has been fixed.  The memory leak only occurred if you
 enabled pseudo-fork in your build of Win32 Perl, and were running that build on
 Server 2003 R2 or newer OS.  The leak does not appear on WinXP SP3.
-[L<perl #121676|https://rt.perl.org/Public/Bug/Display.html?id=121676>]
+L<[GH #13741]|https://github.com/Perl/perl5/issues/13741>
 
 =back
 
@@ -3591,7 +3591,7 @@ Fixed a crash when destroying a self-referencing GLOB.  [perl #121242]
 =item *
 
 L<IO::Socket> is known to fail tests on AIX 5.3.  There is
-L<a patch|https://rt.perl.org/Ticket/Display.html?id=120835> in the request
+L<a patch|https://github.com/Perl/perl5/issues/13484> in the request
 tracker, #120835, which may be applied to future releases.
 
 =item *

--- a/pod/perl5201delta.pod
+++ b/pod/perl5201delta.pod
@@ -27,13 +27,13 @@ below.
 An optimization to avoid problems with COW and deliberately overallocated PVs
 has been disabled because it interfered with another, more important,
 optimization, causing a slowdown on some platforms.
-L<[perl #121975]|https://rt.perl.org/Ticket/Display.html?id=121975>
+L<[GH #13878]|https://github.com/Perl/perl5/issues/13878>
 
 =item *
 
 Returning a string from a lexical variable could be slow in some cases.  This
 has now been fixed.
-L<[perl #121977]|https://rt.perl.org/Ticket/Display.html?id=121977>
+L<[GH #13880]|https://github.com/Perl/perl5/issues/13880>
 
 =back
 
@@ -80,7 +80,7 @@ The PathTools module collection has been upgraded from version 3.47 to 3.48.
 
 Fallbacks are now in place when cross-compiling for Android and
 C<$Config::Config{sh}> is not yet defined.
-L<[perl #121963]|https://rt.perl.org/Ticket/Display.html?id=121963>
+L<[GH #13872]|https://github.com/Perl/perl5/issues/13872>
 
 =item *
 
@@ -108,7 +108,7 @@ External libraries and Perl may have different ideas of what the locale is.
 This is problematic when parsing version strings if the locale's numeric
 separator has been changed.  Version parsing has been patched to ensure it
 handles the locales correctly.
-L<[perl #121930]|https://rt.perl.org/Ticket/Display.html?id=121930>
+L<[GH #13863]|https://github.com/Perl/perl5/issues/13863>
 
 =back
 
@@ -124,7 +124,7 @@ L<[perl #121930]|https://rt.perl.org/Ticket/Display.html?id=121930>
 
 C<av_len> - Emphasize that this returns the highest index in the array, not the
 size of the array.
-L<[perl #120386]|https://rt.perl.org/Ticket/Display.html?id=120386>
+L<[GH #13377]|https://github.com/Perl/perl5/issues/13377>
 
 =item *
 
@@ -134,7 +134,7 @@ Note that C<SvSetSV> doesn't do set magic.
 
 C<sv_usepvn_flags> - Fix documentation to mention the use of C<NewX> instead of
 C<malloc>.
-L<[perl #121869]|https://rt.perl.org/Ticket/Display.html?id=121869>
+L<[GH #13835]|https://github.com/Perl/perl5/issues/13835>
 
 =item *
 
@@ -154,25 +154,25 @@ Clarify the meaning of C<-B> and C<-T>.
 
 C<-l> now notes that it will return false if symlinks aren't supported by the
 file system.
-L<[perl #121523]|https://rt.perl.org/Ticket/Display.html?id=121523>
+L<[GH #13695]|https://github.com/Perl/perl5/issues/13695>
 
 =item *
 
 Note that C<each>, C<keys> and C<values> may produce different orderings for
 tied hashes compared to other perl hashes.
-L<[perl #121404]|https://rt.perl.org/Ticket/Display.html?id=121404>
+L<[GH #13650]|https://github.com/Perl/perl5/issues/13650>
 
 =item *
 
 Note that C<exec LIST> and C<system LIST> may fall back to the shell on Win32.
 Only C<exec PROGRAM LIST> and C<system PROGRAM LIST> indirect object syntax
 will reliably avoid using the shell.  This has also been noted in L<perlport>.
-L<[perl #122046]|https://rt.perl.org/Ticket/Display.html?id=122046>
+L<[GH #13907]|https://github.com/Perl/perl5/issues/13907>
 
 =item *
 
 Clarify the meaning of C<our>.
-L<[perl #122132]|https://rt.perl.org/Ticket/Display.html?id=122132>
+L<[GH #13938]|https://github.com/Perl/perl5/issues/13938>
 
 =back
 
@@ -183,7 +183,7 @@ L<[perl #122132]|https://rt.perl.org/Ticket/Display.html?id=122132>
 =item *
 
 Explain various ways of modifying an existing SV's buffer.
-L<[perl #116925]|https://rt.perl.org/Ticket/Display.html?id=116925>
+L<[GH #12813]|https://github.com/Perl/perl5/issues/12813>
 
 =back
 
@@ -256,7 +256,7 @@ Information about Unicode behaviour has been added.
 
 Building Perl no longer writes to the source tree when configured with
 F<Configure>'s B<-Dmksymlinks> option.
-L<[perl #121585]|https://rt.perl.org/Ticket/Display.html?id=121585>
+L<[GH #13712]|https://github.com/Perl/perl5/issues/13712>
 
 =back
 
@@ -314,13 +314,13 @@ to do so, before returning to Perl.
 
 A bug has been fixed where zero-length assertions and code blocks inside of a
 regex could cause C<pos> to see an incorrect value.
-L<[perl #122460]|https://rt.perl.org/Ticket/Display.html?id=122460>
+L<[GH #14016]|https://github.com/Perl/perl5/issues/14016>
 
 =item *
 
 Using C<s///e> on tainted utf8 strings could issue bogus "Malformed UTF-8
 character (unexpected end of string)" warnings.  This has now been fixed.
-L<[perl #122148]|https://rt.perl.org/Ticket/Display.html?id=122148>
+L<[GH #13948]|https://github.com/Perl/perl5/issues/13948>
 
 =item *
 

--- a/pod/perl5202delta.pod
+++ b/pod/perl5202delta.pod
@@ -29,7 +29,7 @@ below.
 L<attributes> has been upgraded from version 0.22 to 0.23.
 
 The usage of C<memEQs> in the XS has been corrected.
-L<[perl #122701]|https://rt.perl.org/Ticket/Display.html?id=122701>
+L<[GH #14072]|https://github.com/Perl/perl5/issues/14072>
 
 =item *
 
@@ -58,7 +58,7 @@ documentation until now.
 L<IO::Socket> has been upgraded from version 1.37 to 1.38.
 
 Document the limitations of the connected() method.
-L<[perl #123096]|https://rt.perl.org/Ticket/Display.html?id=123096>
+L<[GH #14199]|https://github.com/Perl/perl5/issues/14199>
 
 =item *
 
@@ -78,7 +78,7 @@ L<PerlIO::scalar> has been upgraded from version 0.18 to 0.18_01.
 
 Reading from a position well past the end of the scalar now correctly returns
 end of file.
-L<[perl #123443]|https://rt.perl.org/Ticket/Display.html?id=123443>
+L<[GH #14342]|https://github.com/Perl/perl5/issues/14342>
 
 Seeking to a negative position still fails, but no longer leaves the file
 position set to a negation location.
@@ -147,7 +147,7 @@ formally documented.
 =item *
 
 An ambiguity in the documentation of the ellipsis statement has been corrected.
-L<[perl #122661]|https://rt.perl.org/Ticket/Display.html?id=122661>
+L<[GH #14054]|https://github.com/Perl/perl5/issues/14054>
 
 =back
 
@@ -180,7 +180,7 @@ documented.  This error is not new, but was not previously documented here.
 =item *
 
 The test script F<re/rt122747.t> has been added to verify that
-L<perl #122747|https://rt.perl.org/Ticket/Display.html?id=122747> remains
+L<[GH #14081]|https://github.com/Perl/perl5/issues/14081> remains
 fixed.
 
 =back
@@ -199,7 +199,7 @@ remain.)
 =item *
 
 AIX now sets the length in C<< getsockopt >> correctly.
-L<[perl #120835]|https://rt.perl.org/Ticket/Display.html?id=120835>,
+L<[GH #13484]|https://github.com/Perl/perl5/issues/13484>,
 L<[cpan #91183]|https://rt.cpan.org/Ticket/Display.html?id=91183>,
 L<[cpan #85570]|https://rt.cpan.org/Ticket/Display.html?id=85570>
 
@@ -208,7 +208,7 @@ L<[cpan #85570]|https://rt.cpan.org/Ticket/Display.html?id=85570>
 In Perl 5.20.0, C<$^N> accidentally had the internal UTF8 flag turned off if
 accessed from a code block within a regular expression, effectively
 UTF8-encoding the value.  This has been fixed.
-L<[perl #123135]|https://rt.perl.org/Ticket/Display.html?id=123135>
+L<[GH #14211]|https://github.com/Perl/perl5/issues/14211>
 
 =item *
 
@@ -219,14 +219,14 @@ messages) used to crash for lexical subs, but have been fixed.
 
 An assertion failure when parsing C<sort> with debugging enabled has been
 fixed.
-L<[perl #122771]|https://rt.perl.org/Ticket/Display.html?id=122771>
+L<[GH #14087]|https://github.com/Perl/perl5/issues/14087>
 
 =item *
 
 Loading UTF8 tables during a regular expression match could cause assertion
 failures under debugging builds if the previous match used the very same
 regular expression.
-L<[perl #122747]|https://rt.perl.org/Ticket/Display.html?id=122747>
+L<[GH #14081]|https://github.com/Perl/perl5/issues/14081>
 
 =item *
 
@@ -235,33 +235,33 @@ variable could instead steal the value and undefine the variable.  This bug,
 introduced in Perl 5.20, would happen mostly for long strings (1250 chars or
 more), but could happen for any strings under builds with copy-on-write
 disabled.
-L<[perl #123029]|https://rt.perl.org/Ticket/Display.html?id=123029>
+L<[GH #14175]|https://github.com/Perl/perl5/issues/14175>
 
 =item *
 
 Fixed a bug that could cause perl to execute an infinite loop during
 compilation.
-L<[perl #122995]|https://rt.perl.org/Ticket/Display.html?id=122995>
+L<[GH #14165]|https://github.com/Perl/perl5/issues/14165>
 
 =item *
 
 On Win32, restoring in a child pseudo-process a variable that was C<local()>ed
 in a parent pseudo-process before the C<fork> happened caused memory corruption
 and a crash in the child pseudo-process (and therefore OS process).
-L<[perl #40565]|https://rt.perl.org/Ticket/Display.html?id=40565>
+L<[GH #8641]|https://github.com/Perl/perl5/issues/8641>
 
 =item *
 
 Tainted constants evaluated at compile time no longer cause unrelated
 statements to become tainted.
-L<[perl #122669]|https://rt.perl.org/Ticket/Display.html?id=122669>
+L<[GH #14059]|https://github.com/Perl/perl5/issues/14059>
 
 =item *
 
 Calling C<write> on a format with a C<^**> field could produce a panic in
 sv_chop() if there were insufficient arguments or if the variable used to fill
 the field was empty.
-L<[perl #123245]|https://rt.perl.org/Ticket/Display.html?id=123245>
+L<[GH #14255]|https://github.com/Perl/perl5/issues/14255>
 
 =item *
 
@@ -269,7 +269,7 @@ In Perl 5.20.0, C<sort CORE::fake> where 'fake' is anything other than a
 keyword started chopping of the last 6 characters and treating the result as a
 sort sub name.  The previous behaviour of treating "CORE::fake" as a sort sub
 name has been restored.
-L<[perl #123410]|https://rt.perl.org/Ticket/Display.html?id=123410>
+L<[GH #14323]|https://github.com/Perl/perl5/issues/14323>
 
 =item *
 
@@ -278,30 +278,30 @@ crashes has been fixed.  This occurred only in patterns compiled with C<"/i">,
 while taking into account the current POSIX locale (this usually means they
 have to be compiled within the scope of C<S<"use locale">>), and there must be
 a string of at least 128 consecutive bytes to match.
-L<[perl #123539]|https://rt.perl.org/Ticket/Display.html?id=123539>
+L<[GH #14389]|https://github.com/Perl/perl5/issues/14389>
 
 =item *
 
 C<qr/@array(?{block})/> no longer dies with "Bizarre copy of ARRAY".
-L<[perl #123344]|https://rt.perl.org/Ticket/Display.html?id=123344>
+L<[GH #14292]|https://github.com/Perl/perl5/issues/14292>
 
 =item *
 
 C<gmtime> no longer crashes with not-a-number values.
-L<[perl #123495]|https://rt.perl.org/Ticket/Display.html?id=123495>
+L<[GH #14365]|https://github.com/Perl/perl5/issues/14365>
 
 =item *
 
 Certain syntax errors in substitutions, such as C<< s/${<>{})// >>, would
 crash, and had done so since Perl 5.10.  (In some cases the crash did not start
 happening until Perl 5.16.)  The crash has, of course, been fixed.
-L<[perl #123542]|https://rt.perl.org/Ticket/Display.html?id=123542>
+L<[GH #14391]|https://github.com/Perl/perl5/issues/14391>
 
 =item *
 
 A memory leak in some regular expressions, introduced in Perl 5.20.1, has been
 fixed.
-L<[perl #123198]|https://rt.perl.org/Ticket/Display.html?id=123198>
+L<[GH #14236]|https://github.com/Perl/perl5/issues/14236>
 
 =item *
 
@@ -309,14 +309,14 @@ C<< formline("@...", "a"); >> would crash.  The C<FF_CHECKNL> case in
 pp_formline() didn't set the pointer used to mark the chop position, which led
 to the C<FF_MORE> case crashing with a segmentation fault.  This has been
 fixed.
-L<[perl #123538]|https://rt.perl.org/Ticket/Display.html?id=123538>
-L<[perl #123622]|https://rt.perl.org/Ticket/Display.html?id=123622>
+L<[GH #14388]|https://github.com/Perl/perl5/issues/14388>
+L<[GH #14425]|https://github.com/Perl/perl5/issues/14425>
 
 =item *
 
 A possible buffer overrun and crash when parsing a literal pattern during
 regular expression compilation has been fixed.
-L<[perl #123604]|https://rt.perl.org/Ticket/Display.html?id=123604>
+L<[GH #14416]|https://github.com/Perl/perl5/issues/14416>
 
 =back
 
@@ -341,7 +341,7 @@ A regression has been fixed that was introduced in Perl 5.20.0 (fixed in Perl
 5.20.1 as well as here) in which a UTF-8 encoded regular expression pattern
 that contains a single ASCII lowercase letter does not match its uppercase
 counterpart.
-L<[perl #122655]|https://rt.perl.org/Ticket/Display.html?id=122655>
+L<[GH #14051]|https://github.com/Perl/perl5/issues/14051>
 
 =back
 

--- a/pod/perl5203delta.pod
+++ b/pod/perl5203delta.pod
@@ -30,7 +30,7 @@ L<Errno> has been upgraded from version 1.20_05 to 1.20_06.
 
 Add B<-P> to the pre-processor command-line on GCC 5.  GCC added extra line
 directives, breaking parsing of error code definitions.
-L<[perl #123784]|https://rt.perl.org/Ticket/Display.html?id=123784>
+L<[GH #14491]|https://github.com/Perl/perl5/issues/14491>
 
 =item *
 
@@ -43,7 +43,7 @@ Updated to cover the latest releases of Perl.
 L<perl5db.pl> has been upgraded from 1.44 to 1.44_01.
 
 The debugger would cause an assertion failure.
-L<[perl #124127]|https://rt.perl.org/Ticket/Display.html?id=124127>
+L<[GH #14605]|https://github.com/Perl/perl5/issues/14605>
 
 =back
 
@@ -106,7 +106,7 @@ ISO-8859-1 (Latin1).
 
 B<h2ph> now handles hexadecimal constants in the compiler's predefined macro
 definitions, as visible in C<$Config{cppsymbols}>.
-L<[perl #123784]|https://rt.perl.org/Ticket/Display.html?id=123784>
+L<[GH #14491]|https://github.com/Perl/perl5/issues/14491>
 
 =back
 
@@ -149,7 +149,7 @@ bitness) and 32-bit Visual C++ were not affected.
 
 B<miniperl.exe> is now built with B<-fno-strict-aliasing>, allowing 64-bit
 builds to complete with GCC 4.8.
-L<[perl #123976]|https://rt.perl.org/Ticket/Display.html?id=123976>
+L<[GH #14556]|https://github.com/Perl/perl5/issues/14556>
 
 =back
 
@@ -163,7 +163,7 @@ L<[perl #123976]|https://rt.perl.org/Ticket/Display.html?id=123976>
 
 Repeated global pattern matches in scalar context on large tainted strings were
 exponentially slow depending on the current match position in the string.
-L<[perl #123202]|https://rt.perl.org/Ticket/Display.html?id=123202>
+L<[GH #14238]|https://github.com/Perl/perl5/issues/14238>
 
 =item *
 
@@ -171,51 +171,51 @@ The original visible value of L<C<$E<sol>>|perlvar/$E<sol>> is now preserved
 when it is set to an invalid value.  Previously if you set C<$/> to a reference
 to an array, for example, perl would produce a runtime error and not set PL_rs,
 but Perl code that checked C<$/> would see the array reference.
-L<[perl #123218]|https://rt.perl.org/Ticket/Display.html?id=123218>
+L<[GH #14245]|https://github.com/Perl/perl5/issues/14245>
 
 =item *
 
 Perl 5.14.0 introduced a bug whereby C<eval { LABEL: }> would crash.  This has
 been fixed.
-L<[perl #123652]|https://rt.perl.org/Ticket/Display.html?id=123652>
+L<[GH #14438]|https://github.com/Perl/perl5/issues/14438>
 
 =item *
 
 Extending an array cloned from a parent thread could result in "Modification of
 a read-only value attempted" errors when attempting to modify the new elements.
-L<[perl #124127]|https://rt.perl.org/Ticket/Display.html?id=124127>
+L<[GH #14605]|https://github.com/Perl/perl5/issues/14605>
 
 =item *
 
 Several cases of data used to store environment variable contents in core C
 code being potentially overwritten before being used have been fixed.
-L<[perl #123748]|https://rt.perl.org/Ticket/Display.html?id=123748>
+L<[GH #14476]|https://github.com/Perl/perl5/issues/14476>
 
 =item *
 
 UTF-8 variable names used in array indexes, unquoted UTF-8 HERE-document
 terminators and UTF-8 function names all now work correctly.
-L<[perl #124113]|https://rt.perl.org/Ticket/Display.html?id=124113>
+L<[GH #14601]|https://github.com/Perl/perl5/issues/14601>
 
 =item *
 
 A subtle bug introduced in Perl 5.20.2 involving UTF-8 in regular expressions
 and sometimes causing a crash has been fixed.  A new test script has been added
 to test this fix; see under L</Testing>.
-L<[perl #124109]|https://rt.perl.org/Ticket/Display.html?id=124109>
+L<[GH #14600]|https://github.com/Perl/perl5/issues/14600>
 
 =item *
 
 Some patterns starting with C</.*..../> matched against long strings have been
 slow since Perl 5.8, and some of the form C</.*..../i> have been slow since
 Perl 5.18.  They are now all fast again.
-L<[perl #123743]|https://rt.perl.org/Ticket/Display.html?id=123743>
+L<[GH #14475]|https://github.com/Perl/perl5/issues/14475>
 
 =item *
 
 Warning fatality is now ignored when rewinding the stack.  This prevents
 infinite recursion when the now fatal error also causes rewinding of the stack.
-L<[perl #123398]|https://rt.perl.org/Ticket/Display.html?id=123398>
+L<[GH #14319]|https://github.com/Perl/perl5/issues/14319>
 
 =item *
 
@@ -225,7 +225,7 @@ to mean C<setpgrp(0)>.  This has been fixed.
 =item *
 
 A crash with C<< %::=(); J->${\"::"} >> has been fixed.
-L<[perl #125541]|https://rt.perl.org/Ticket/Display.html?id=125541>
+L<[GH #14790]|https://github.com/Perl/perl5/issues/14790>
 
 =item *
 
@@ -233,14 +233,14 @@ Regular expression possessive quantifier Perl 5.20 regression now fixed.
 C<qr/>I<PAT>C<{>I<min>,I<max>C<}+>C</> is supposed to behave identically to
 C<qr/(?E<gt>>I<PAT>C<{>I<min>,I<max>C<})/>.  Since Perl 5.20, this didn't work
 if I<min> and I<max> were equal.
-L<[perl #125825]|https://rt.perl.org/Ticket/Display.html?id=125825>
+L<[GH #14857]|https://github.com/Perl/perl5/issues/14857>
 
 =item *
 
 Code like C</$a[/> used to read the next line of input and treat it as though
 it came immediately after the opening bracket.  Some invalid code consequently
 would parse and run, but some code caused crashes, so this is now disallowed.
-L<[perl #123712]|https://rt.perl.org/Ticket/Display.html?id=123712>
+L<[GH #14462]|https://github.com/Perl/perl5/issues/14462>
 
 =back
 

--- a/pod/perl5220delta.pod
+++ b/pod/perl5220delta.pod
@@ -25,7 +25,7 @@ assignment variants (C<&= |= ^= &.= |.= ^.=>).
 To use this, enable the "bitwise" feature and disable the
 "experimental::bitwise" warnings category.  See L<perlop/Bitwise String
 Operators> for details.
-L<[perl #123466]|https://rt.perl.org/Ticket/Display.html?id=123466>.
+L<[GH #14348]|https://github.com/Perl/perl5/issues/14348>.
 
 =head2 New double-diamond operator
 
@@ -138,7 +138,7 @@ See L<perlref/Assigning to References>
 =head2 C<prototype> with no arguments
 
 C<prototype()> with no arguments now infers C<$_>.
-L<[perl #123514]|https://rt.perl.org/Ticket/Display.html?id=123514>.
+L<[GH #14376]|https://github.com/Perl/perl5/issues/14376>.
 
 =head2 New C<:const> subroutine attribute
 
@@ -258,14 +258,14 @@ list (if any).
 The C<&> prototype character now accepts only anonymous subs (C<sub
 {...}>), things beginning with C<\&>, or an explicit C<undef>.  Formerly
 it erroneously also allowed references to arrays, hashes, and lists.
-L<[perl #4539]|https://rt.perl.org/Ticket/Display.html?id=4539>.
-L<[perl #123062]|https://rt.perl.org/Ticket/Display.html?id=123062>.
-L<[perl #123062]|https://rt.perl.org/Ticket/Display.html?id=123475>.
+L<[GH #2776]|https://github.com/Perl/perl5/issues/2776>.
+L<[GH #14186]|https://github.com/Perl/perl5/issues/14186>.
+L<[GH #14353]|https://github.com/Perl/perl5/issues/14353>.
 
 In addition, the C<\&> prototype was allowing subroutine calls, whereas
 now it only allows subroutines: C<&foo> is still permitted as an argument,
 while C<&foo()> and C<foo()> no longer are.
-L<[perl #77860]|https://rt.perl.org/Ticket/Display.html?id=77860>.
+L<[GH #10633]|https://github.com/Perl/perl5/issues/10633>.
 
 =head2 C<use encoding> is now lexical
 
@@ -280,7 +280,7 @@ List slices now return an empty list only if the original list was empty
 (or if there are no indices).  Formerly, a list slice would return an empty
 list if all indices fell outside the original list; now it returns a list
 of C<undef> values in that case.
-L<[perl #114498]|https://rt.perl.org/Ticket/Display.html?id=114498>.
+L<[GH #12335]|https://github.com/Perl/perl5/issues/12335>.
 
 =head2 C<\N{}> with a sequence of multiple spaces is now a fatal error
 
@@ -365,7 +365,7 @@ scopes, no other Perl operations will
 be affected by locale; only C<$!> and C<$^E> stringification.  The
 C<bytes> pragma causes the UTF-8 flag to not be set, just as in previous
 Perl releases.  This resolves
-L<[perl #112208]|https://rt.perl.org/Ticket/Display.html?id=112208>.
+L<[GH #12035]|https://github.com/Perl/perl5/issues/12035>.
 
 =head2 Support for C<?PATTERN?> without explicit operator has been removed
 
@@ -590,14 +590,14 @@ skipped over.  The same applies to C<state> variables.
 
 Many internal functions have been refactored to improve performance and reduce
 their memory footprints.
-L<[perl #121436]|https://rt.perl.org/Ticket/Display.html?id=121436>
-L<[perl #121906]|https://rt.perl.org/Ticket/Display.html?id=121906>
-L<[perl #121969]|https://rt.perl.org/Ticket/Display.html?id=121969>
+L<[GH #13659]|https://github.com/Perl/perl5/issues/13659>
+L<[GH #13856]|https://github.com/Perl/perl5/issues/13856>
+L<[GH #13874]|https://github.com/Perl/perl5/issues/13874>
 
 =item *
 
 C<-T> and C<-B> filetests will return sooner when an empty file is detected.
-L<[perl #121489]|https://rt.perl.org/Ticket/Display.html?id=121489>
+L<[GH #13686]|https://github.com/Perl/perl5/issues/13686>
 
 =item *
 
@@ -607,7 +607,7 @@ Hash lookups where the key is a constant are faster.
 
 Subroutines with an empty prototype and a body containing just C<undef> are now
 eligible for inlining.
-L<[perl #122728]|https://rt.perl.org/Ticket/Display.html?id=122728>
+L<[GH #14077]|https://github.com/Perl/perl5/issues/14077>
 
 =item *
 
@@ -619,7 +619,7 @@ so accessing it will cause the stash entry to be upgraded to a typeglob
 This optimization does not currently apply to XSUBs or exported
 subroutines, and method calls will undo it, since they cache things in
 typeglobs.
-L<[perl #120441]|https://rt.perl.org/Ticket/Display.html?id=120441>
+L<[GH #13392]|https://github.com/Perl/perl5/issues/13392>
 
 =item *
 
@@ -662,7 +662,7 @@ Tests can now be run in parallel.
 L<attributes> has been upgraded to version 0.27.
 
 The usage of C<memEQs> in the XS has been corrected.
-L<[perl #122701]|https://rt.perl.org/Ticket/Display.html?id=122701>
+L<[GH #14072]|https://github.com/Perl/perl5/issues/14072>
 
 Avoid reading beyond the end of a buffer. [perl #122629]
 
@@ -738,7 +738,7 @@ cases where the assignment is optimized away.
 It now deparses C<our(I<LIST>)> and typed lexical (C<my Dog $spot>) correctly.
 
 Deparse C<$#_> as that instead of as C<$#{_}>.
-L<[perl #123947]|https://rt.perl.org/Ticket/Display.html?id=123947>
+L<[GH #14545]|https://github.com/Perl/perl5/issues/14545>
 
 BEGIN blocks at the end of the enclosing scope are now deparsed in the
 right place.  [perl #77452]
@@ -828,7 +828,7 @@ L<Carp> has been upgraded to version 1.36.
 C<Carp::Heavy> now ignores version mismatches with Carp if Carp is newer
 than 1.12, since C<Carp::Heavy>'s guts were merged into Carp at that
 point.
-L<[perl #121574]|https://rt.perl.org/Ticket/Display.html?id=121574>
+L<[GH #13708]|https://github.com/Perl/perl5/issues/13708>
 
 Carp now handles non-ASCII platforms better.
 
@@ -877,7 +877,7 @@ recursion when dumping deep data structures.
 Changes to resolve Coverity issues.
 XS dumps incorrectly stored the name of code references stored in a
 GLOB.
-L<[perl #122070]|https://rt.perl.org/Ticket/Display.html?id=122070>
+L<[GH #13911]|https://github.com/Perl/perl5/issues/13911>
 
 =item *
 
@@ -914,7 +914,7 @@ Hardcodes features for Perls older than 5.15.7.
 L<ExtUtils::CBuilder> has been upgraded to version 0.280221.
 
 Fixes a regression on Android.
-L<[perl #122675]|https://rt.perl.org/Ticket/Display.html?id=122675>
+L<[GH #14064]|https://github.com/Perl/perl5/issues/14064>
 
 =item *
 
@@ -922,7 +922,7 @@ L<ExtUtils::Manifest> has been upgraded to version 1.70.
 
 Fixes a bug with C<maniread()>'s handling of quoted filenames and improves
 C<manifind()> to follow symlinks.
-L<[perl #122415]|https://rt.perl.org/Ticket/Display.html?id=122415>
+L<[GH #14003]|https://github.com/Perl/perl5/issues/14003>
 
 =item *
 
@@ -1040,15 +1040,14 @@ Don't turn leading C<//> into C</> on Cygwin. [perl #122635]
 L<perl5db.pl> has been upgraded to version 1.49.
 
 The debugger would cause an assertion failure.
-L<[perl #124127]|https://rt.perl.org/Ticket/Display.html?id=124127>
+L<[GH #14605]|https://github.com/Perl/perl5/issues/14605>
 
 C<fork()> in the debugger under C<tmux> will now create a new window for
-the forked process. L<[perl
-#121333]|https://rt.perl.org/Ticket/Display.html?id=121333>
+the forked process. L<[GH #13602]|https://github.com/Perl/perl5/issues/13602>
 
 The debugger now saves the current working directory on startup and
-restores it when you restart your program with C<R> or C<rerun>. L<[perl
-#121509]|https://rt.perl.org/Ticket/Display.html?id=121509>
+restores it when you restart your program with C<R> or C<rerun>.
+L<[GH #13691]|https://github.com/Perl/perl5/issues/13691>
 
 =item *
 
@@ -1238,7 +1237,7 @@ Note that C<SvSetSV> doesn't do set magic.
 C<sv_usepvn_flags> - fix documentation to mention the use of C<Newx> instead of
 C<malloc>.
 
-L<[perl #121869]|https://rt.perl.org/Ticket/Display.html?id=121869>
+L<[GH #13835]|https://github.com/Perl/perl5/issues/13835>
 
 =item *
 
@@ -1320,7 +1319,7 @@ Improve documentation of C<< our >>.
 
 C<-l> now notes that it will return false if symlinks aren't supported by the
 file system.
-L<[perl #121523]|https://rt.perl.org/Ticket/Display.html?id=121523>
+L<[GH #13695]|https://github.com/Perl/perl5/issues/13695>
 
 =item *
 
@@ -1330,7 +1329,7 @@ C<system PROGRAM LIST> will reliably avoid using the shell.
 
 This has also been noted in L<perlport>.
 
-L<[perl #122046]|https://rt.perl.org/Ticket/Display.html?id=122046>
+L<[GH #13907]|https://github.com/Perl/perl5/issues/13907>
 
 =back
 
@@ -1390,7 +1389,7 @@ recommended.
 =item *
 
 Updated documentation for the C<test.valgrind> C<make> target.
-L<[perl #121431]|https://rt.perl.org/Ticket/Display.html?id=121431>
+L<[GH #13658]|https://github.com/Perl/perl5/issues/13658>
 
 =item *
 
@@ -1572,7 +1571,7 @@ Comments added on algorithmic complexity and tied hashes.
 =item *
 
 An ambiguity in the documentation of the C<...> statement has been corrected.
-L<[perl #122661]|https://rt.perl.org/Ticket/Display.html?id=122661>
+L<[GH #14054]|https://github.com/Perl/perl5/issues/14054>
 
 =item *
 
@@ -2055,7 +2054,7 @@ required fewer arguments than were supplied, but might be used in the
 future for I<e.g.> L<perlfunc/pack>.
 
 The warnings category C<< redundant >> is new. See also
-L<[perl #121025]|https://rt.perl.org/Ticket/Display.html?id=121025>.
+L<[GH #13534]|https://github.com/Perl/perl5/issues/13534>.
 
 =item *
 
@@ -2224,7 +2223,7 @@ L<Global symbol "%s" requires explicit package name|perldiag/"Global symbol "%s"
 
 This message has had '(did you forget to declare "my %s"?)' appended to it, to
 make it more helpful to new Perl programmers.
-L<[perl #121638]|https://rt.perl.org/Ticket/Display.html?id=121638>
+L<[GH #13732]|https://github.com/Perl/perl5/issues/13732>
 
 =item *
 
@@ -2292,8 +2291,8 @@ constants; I<e.g.>, C<-Inf>.
 
 Compile-time checking of constant dereferencing (I<e.g.>, C<< my_constant->() >>)
 has been removed, since it was not taking overloading into account.
-L<[perl #69456]|https://rt.perl.org/Ticket/Display.html?id=69456>
-L<[perl #122607]|https://rt.perl.org/Ticket/Display.html?id=122607>
+L<[GH #9891]|https://github.com/Perl/perl5/issues/9891>
+L<[GH #14044]|https://github.com/Perl/perl5/issues/14044>
 
 =back
 
@@ -2320,7 +2319,7 @@ separate distributions (C<App::find2perl>, C<App::s2p>, C<App::a2p>).
 
 F<h2ph> now handles hexadecimal constants in the compiler's predefined
 macro definitions, as visible in C<$Config{cppsymbols}>.
-L<[perl #123784]|https://rt.perl.org/Ticket/Display.html?id=123784>.
+L<[GH #14491]|https://github.com/Perl/perl5/issues/14491>.
 
 =back
 
@@ -2346,7 +2345,7 @@ C<llroundl()>.
 =item *
 
 F<Configure> with C<-Dmksymlinks> should now be faster.
-L<[perl #122002]|https://rt.perl.org/Ticket/Display.html?id=122002>.
+L<[GH #13890]|https://github.com/Perl/perl5/issues/13890>.
 
 =item *
 
@@ -2377,7 +2376,7 @@ For example:
 
 See L<perlhacktips/valgrind> for more information.
 
-L<[perl #121431]|https://rt.perl.org/Ticket/Display.html?id=121431>
+L<[GH #13658]|https://github.com/Perl/perl5/issues/13658>
 
 =item *
 
@@ -2445,9 +2444,9 @@ working correctly.  See L</Infinity and NaN (not-a-number) handling improved>.
 =item IRIX and Tru64 platforms are working again.
 
 Some C<make test> failures remain:
-L<[perl #123977]|https://rt.perl.org/Ticket/Display.html?id=123977>
-and L<[perl #125298]|https://rt.perl.org/Ticket/Display.html?id=125298>
-for IRIX; L<[perl #124212]|https://rt.perl.org/Ticket/Display.html?id=124212>,
+L<[GH #14557]|https://github.com/Perl/perl5/issues/14557>
+and L<[GH #14727]|https://github.com/Perl/perl5/issues/14727>
+for IRIX; L<[GH #14629]|https://github.com/Perl/perl5/issues/14629>,
 L<[cpan #99605]|https://rt.cpan.org/Public/Bug/Display.html?id=99605>, and
 L<[cpan #104836]|https://rt.cpan.org/Ticket/Display.html?id=104836> for Tru64.
 
@@ -2531,14 +2530,14 @@ a fix for legacy feature checking status.
 
 F<miniperl.exe> is now built with C<-fno-strict-aliasing>, allowing 64-bit
 builds to complete on GCC 4.8.
-L<[perl #123976]|https://rt.perl.org/Ticket/Display.html?id=123976>
+L<[GH #14556]|https://github.com/Perl/perl5/issues/14556>
 
 =item *
 
 C<nmake minitest> now works on Win32.  Due to dependency issues you
 need to build C<nmake test-prep> first, and a small number of the
 tests fail.
-L<[perl #123394]|https://rt.perl.org/Ticket/Display.html?id=123394>
+L<[GH #14318]|https://github.com/Perl/perl5/issues/14318>
 
 =item *
 
@@ -2549,7 +2548,7 @@ C<USE_CPLUSPLUS> to the value "define".
 
 The list form of piped open has been implemented for Win32.  Note: unlike
 C<system LIST> this does not fall back to the shell.
-L<[perl #121159]|https://rt.perl.org/Ticket/Display.html?id=121159>
+L<[GH #13574]|https://github.com/Perl/perl5/issues/13574>
 
 =item *
 
@@ -2586,7 +2585,7 @@ C<%I64d> is now being used instead of C<%lld> for MinGW.
 In the experimental C<:win32> layer, a crash in C<open> was fixed. Also
 opening F</dev/null> (which works under Win32 Perl's default C<:unix>
 layer) was implemented for C<:win32>.
-L<[perl #122224]|https://rt.perl.org/Ticket/Display.html?id=122224>
+L<[GH #13968]|https://github.com/Perl/perl5/issues/13968>
 
 =item *
 
@@ -2604,7 +2603,7 @@ since v5.14 due to performance reasons, but the OpenBSD project believes
 the tradeoff is worth it and would prefer that users who need the speed
 specifically ask for it.
 
-L<[perl #122000]|https://rt.perl.org/Ticket/Display.html?id=122000>.
+L<[GH #13888]|https://github.com/Perl/perl5/issues/13888>.
 
 =item Solaris
 
@@ -2620,7 +2619,7 @@ F</opt/solarisstudio*>.
 Builds on Solaris 10 with C<-Dusedtrace> would fail early since make
 didn't follow implied dependencies to build C<perldtrace.h>.  Added an
 explicit dependency to C<depend>.
-L<[perl #120120]|https://rt.perl.org/Ticket/Display.html?id=120120>
+L<[GH #13334]|https://github.com/Perl/perl5/issues/13334>
 
 =item *
 
@@ -2754,7 +2753,7 @@ C<op_convert_list> and added to the API.
 The C<sv_magic()> function no longer forbids "ext" magic on read-only
 values.  After all, perl can't know whether the custom magic will modify
 the SV or not.
-L<[perl #123103]|https://rt.perl.org/Ticket/Display.html?id=123103>.
+L<[GH #14202]|https://github.com/Perl/perl5/issues/14202>.
 
 =item *
 
@@ -2780,7 +2779,7 @@ get-magic that stores their values as IVs, and those IVs are used when
 testing their values in C<pp_dbstate()>.  This prevents perl from
 recursing infinitely if an overloaded object is assigned to any of those
 variables.
-L<[perl #122445]|https://rt.perl.org/Ticket/Display.html?id=122445>.
+L<[GH #14013]|https://github.com/Perl/perl5/issues/14013>.
 
 =item *
 
@@ -2827,8 +2826,8 @@ C<cv_name()> is a new API function that can be passed a CV or GV.  It
 returns an SV containing the name of the subroutine, for use in
 diagnostics.
 
-L<[perl #116735]|https://rt.perl.org/Ticket/Display.html?id=116735>
-L<[perl #120441]|https://rt.perl.org/Ticket/Display.html?id=120441>
+L<[GH #12767]|https://github.com/Perl/perl5/issues/12767>
+L<[GH #13392]|https://github.com/Perl/perl5/issues/13392>
 
 =item *
 
@@ -2839,7 +2838,7 @@ name, or whether it could be passed a CV instead.  Whatever value is
 passed will be acceptable to C<cv_name()>.  C<cv_set_call_checker()>
 guarantees there will be a GV, but it may have to create one on the fly,
 which is inefficient.
-L<[perl #116735]|https://rt.perl.org/Ticket/Display.html?id=116735>
+L<[GH #12767]|https://github.com/Perl/perl5/issues/12767>
 
 =item *
 
@@ -2848,7 +2847,7 @@ call a function and reify a GV.  For those cases where it has been used as a
 boolean, C<CvHASGV> has been added, which will return true for CVs that
 notionally have GVs, but without reifying the GV.  C<CvGV> also returns a GV
 now for lexical subs.
-L<[perl #120441]|https://rt.perl.org/Ticket/Display.html?id=120441>
+L<[GH #13392]|https://github.com/Perl/perl5/issues/13392>
 
 =item *
 
@@ -2907,7 +2906,7 @@ public API, such as C<cast_i32()>, remain unaffected.
 
 The C<PADNAME> and C<PADNAMELIST> types are now separate types, and no
 longer simply aliases for SV and AV.
-L<[perl #123223]|https://rt.perl.org/Ticket/Display.html?id=123223>.
+L<[GH #14250]|https://github.com/Perl/perl5/issues/14250>.
 
 =item *
 
@@ -2966,89 +2965,89 @@ C<pack("D", $x)> and C<pack("F", $x)> now zero the padding on x86 long
 double builds.  Under some build options on GCC 4.8 and later, they used
 to either overwrite the zero-initialized padding, or bypass the
 initialized buffer entirely.  This caused F<op/pack.t> to fail.
-L<[perl #123971]|https://rt.perl.org/Ticket/Display.html?id=123971>
+L<[GH #14554]|https://github.com/Perl/perl5/issues/14554>
 
 =item *
 
 Extending an array cloned from a parent thread could result in "Modification of
 a read-only value attempted" errors when attempting to modify the new elements.
-L<[perl #124127]|https://rt.perl.org/Ticket/Display.html?id=124127>
+L<[GH #14605]|https://github.com/Perl/perl5/issues/14605>
 
 =item *
 
 An assertion failure and subsequent crash with C<< *x=<y> >> has been fixed.
-L<[perl #123790]|https://rt.perl.org/Ticket/Display.html?id=123790>
+L<[GH #14493]|https://github.com/Perl/perl5/issues/14493>
 
 =item *
 
 A possible crashing/looping bug related to compiling lexical subs has been
 fixed.
-L<[perl #124099]|https://rt.perl.org/Ticket/Display.html?id=124099>
+L<[GH #14596]|https://github.com/Perl/perl5/issues/14596>
 
 =item *
 
 UTF-8 now works correctly in function names, in unquoted HERE-document
 terminators, and in variable names used as array indexes.
-L<[perl #124113]|https://rt.perl.org/Ticket/Display.html?id=124113>
+L<[GH #14601]|https://github.com/Perl/perl5/issues/14601>
 
 =item *
 
 Repeated global pattern matches in scalar context on large tainted strings were
 exponentially slow depending on the current match position in the string.
-L<[perl #123202]|https://rt.perl.org/Ticket/Display.html?id=123202>
+L<[GH #14238]|https://github.com/Perl/perl5/issues/14238>
 
 =item *
 
 Various crashes due to the parser getting confused by syntax errors have been
 fixed.
-L<[perl #123801]|https://rt.perl.org/Ticket/Display.html?id=123801>
-L<[perl #123802]|https://rt.perl.org/Ticket/Display.html?id=123802>
-L<[perl #123955]|https://rt.perl.org/Ticket/Display.html?id=123955>
-L<[perl #123995]|https://rt.perl.org/Ticket/Display.html?id=123995>
+L<[GH #14496]|https://github.com/Perl/perl5/issues/14496>
+L<[GH #14497]|https://github.com/Perl/perl5/issues/14497>
+L<[GH #14548]|https://github.com/Perl/perl5/issues/14548>
+L<[GH #14564]|https://github.com/Perl/perl5/issues/14564>
 
 =item *
 
 C<split> in the scope of lexical C<$_> has been fixed not to fail assertions.
-L<[perl #123763]|https://rt.perl.org/Ticket/Display.html?id=123763>
+L<[GH #14483]|https://github.com/Perl/perl5/issues/14483>
 
 =item *
 
 C<my $x : attr> syntax inside various list operators no longer fails
 assertions.
-L<[perl #123817]|https://rt.perl.org/Ticket/Display.html?id=123817>
+L<[GH #14500]|https://github.com/Perl/perl5/issues/14500>
 
 =item *
 
 An C<@> sign in quotes followed by a non-ASCII digit (which is not a valid
 identifier) would cause the parser to crash, instead of simply trying the
 C<@> as literal.  This has been fixed.
-L<[perl #123963]|https://rt.perl.org/Ticket/Display.html?id=123963>
+L<[GH #14553]|https://github.com/Perl/perl5/issues/14553>
 
 =item *
 
 C<*bar::=*foo::=*glob_with_hash> has been crashing since Perl 5.14, but no
 longer does.
-L<[perl #123847]|https://rt.perl.org/Ticket/Display.html?id=123847>
+L<[GH #14512]|https://github.com/Perl/perl5/issues/14512>
 
 =item *
 
 C<foreach> in scalar context was not pushing an item on to the stack, resulting
 in bugs.  (S<C<print 4, scalar do { foreach(@x){} } + 1>> would print 5.)
 It has been fixed to return C<undef>.
-L<[perl #124004]|https://rt.perl.org/Ticket/Display.html?id=124004>
+L<[GH #14569]|https://github.com/Perl/perl5/issues/14569>
 
 =item *
 
 Several cases of data used to store environment variable contents in core C
 code being potentially overwritten before being used have been fixed.
-L<[perl #123748]|https://rt.perl.org/Ticket/Display.html?id=123748>
+L<[GH #14476]|https://github.com/Perl/perl5/issues/14476>
 
 =item *
 
 Some patterns starting with C</.*..../> matched against long strings have
 been slow since v5.8, and some of the form C</.*..../i> have been slow
 since v5.18. They are now all fast again.
-L<[perl #123743]|https://rt.perl.org/Ticket/Display.html?id=123743>.
+L<[GH #14475]|https://github.com/Perl/perl5/issues/14475>.
 
 =item *
 
@@ -3057,7 +3056,7 @@ an invalid value.  Previously if you set C<$/> to a reference to an
 array, for example, perl would produce a runtime error and not set
 C<PL_rs>, but Perl code that checked C<$/> would see the array
 reference.
-L<[perl #123218]|https://rt.perl.org/Ticket/Display.html?id=123218>.
+L<[GH #14245]|https://github.com/Perl/perl5/issues/14245>.
 
 =item *
 
@@ -3071,16 +3070,16 @@ the POSIX class was negated: C<[:^ascii:]>.  This is now fixed.
 
 Perl 5.14.0 introduced a bug whereby S<C<eval { LABEL: }>> would crash.  This
 has been fixed.
-L<[perl #123652]|https://rt.perl.org/Ticket/Display.html?id=123652>.
+L<[GH #14438]|https://github.com/Perl/perl5/issues/14438>.
 
 =item *
 
 Various crashes due to the parser getting confused by syntax errors have
 been fixed.
-L<[perl #123617]|https://rt.perl.org/Ticket/Display.html?id=123617>.
-L<[perl #123737]|https://rt.perl.org/Ticket/Display.html?id=123737>.
-L<[perl #123753]|https://rt.perl.org/Ticket/Display.html?id=123753>.
-L<[perl #123677]|https://rt.perl.org/Ticket/Display.html?id=123677>.
+L<[GH #14421]|https://github.com/Perl/perl5/issues/14421>.
+L<[GH #14472]|https://github.com/Perl/perl5/issues/14472>.
+L<[GH #14480]|https://github.com/Perl/perl5/issues/14480>.
+L<[GH #14447]|https://github.com/Perl/perl5/issues/14447>.
 
 =item *
 
@@ -3088,12 +3087,12 @@ Code like C</$a[/> used to read the next line of input and treat it as
 though it came immediately after the opening bracket.  Some invalid code
 consequently would parse and run, but some code caused crashes, so this is
 now disallowed.
-L<[perl #123712]|https://rt.perl.org/Ticket/Display.html?id=123712>.
+L<[GH #14462]|https://github.com/Perl/perl5/issues/14462>.
 
 =item *
 
 Fix argument underflow for C<pack>.
-L<[perl #123874]|https://rt.perl.org/Ticket/Display.html?id=123874>.
+L<[GH #14525]|https://github.com/Perl/perl5/issues/14525>.
 
 =item *
 
@@ -3103,7 +3102,7 @@ instead of faulting.
 =item *
 
 C<stat -t> is now no longer treated as stackable, just like C<-t stat>.
-L<[perl #123816]|https://rt.perl.org/Ticket/Display.html?id=123816>.
+L<[GH #14499]|https://github.com/Perl/perl5/issues/14499>.
 
 =item *
 
@@ -3126,19 +3125,19 @@ other crashes has been fixed.  This occurred only in patterns compiled
 with C</i> while taking into account the current POSIX locale (which usually
 means they have to be compiled within the scope of C<S<use locale>>),
 and there must be a string of at least 128 consecutive bytes to match.
-L<[perl #123539]|https://rt.perl.org/Ticket/Display.html?id=123539>.
+L<[GH #14389]|https://github.com/Perl/perl5/issues/14389>.
 
 =item *
 
 C<s///g> now works on very long strings (where there are more than 2
 billion iterations) instead of dying with 'Substitution loop'.
-L<[perl #103260]|https://rt.perl.org/Ticket/Display.html?id=103260>.
-L<[perl #123071]|https://rt.perl.org/Ticket/Display.html?id=123071>.
+L<[GH #11742]|https://github.com/Perl/perl5/issues/11742>.
+L<[GH #14190]|https://github.com/Perl/perl5/issues/14190>.
 
 =item *
 
 C<gmtime> no longer crashes with not-a-number values.
-L<[perl #123495]|https://rt.perl.org/Ticket/Display.html?id=123495>.
+L<[GH #14365]|https://github.com/Perl/perl5/issues/14365>.
 
 =item *
 
@@ -3151,7 +3150,7 @@ both been fixed to extend the stack first.
 C<prototype()> with no arguments used to read the previous item on the
 stack, so S<C<print "foo", prototype()>> would print foo's prototype.
 It has been fixed to infer C<$_> instead.
-L<[perl #123514]|https://rt.perl.org/Ticket/Display.html?id=123514>.
+L<[GH #14376]|https://github.com/Perl/perl5/issues/14376>.
 
 =item *
 
@@ -3169,14 +3168,14 @@ Some cases of nested lexical state subs inside anonymous subs could cause
 When trying to emit warnings, perl's default debugger (F<perl5db.pl>) was
 sometimes giving 'Undefined subroutine &DB::db_warn called' instead.  This
 bug, which started to occur in Perl 5.18, has been fixed.
-L<[perl #123553]|https://rt.perl.org/Ticket/Display.html?id=123553>.
+L<[GH #14400]|https://github.com/Perl/perl5/issues/14400>.
 
 =item *
 
 Certain syntax errors in substitutions, such as C<< s/${<>{})// >>, would
 crash, and had done so since Perl 5.10.  (In some cases the crash did not
 start happening till 5.16.)  The crash has, of course, been fixed.
-L<[perl #123542]|https://rt.perl.org/Ticket/Display.html?id=123542>.
+L<[GH #14391]|https://github.com/Perl/perl5/issues/14391>.
 
 =item *
 
@@ -3185,7 +3184,7 @@ a repeat expression like S<C<33 x ~3>> could cause a large buffer
 overflow since the new output buffer size was not correctly handled by
 C<SvGROW()>.  An expression like this now properly produces a memory wrap
 panic.
-L<[perl #123554]|https://rt.perl.org/Ticket/Display.html?id=123554>.
+L<[GH #14401]|https://github.com/Perl/perl5/issues/14401>.
 
 =item *
 
@@ -3193,32 +3192,32 @@ C<< formline("@...", "a"); >> would crash.  The C<FF_CHECKNL> case in
 C<pp_formline()> didn't set the pointer used to mark the chop position,
 which led to the C<FF_MORE> case crashing with a segmentation fault.
 This has been fixed.
-L<[perl #123538]|https://rt.perl.org/Ticket/Display.html?id=123538>.
+L<[GH #14388]|https://github.com/Perl/perl5/issues/14388>.
 
 =item *
 
 A possible buffer overrun and crash when parsing a literal pattern during
 regular expression compilation has been fixed.
-L<[perl #123604]|https://rt.perl.org/Ticket/Display.html?id=123604>.
+L<[GH #14416]|https://github.com/Perl/perl5/issues/14416>.
 
 =item *
 
 C<fchmod()> and C<futimes()> now set C<$!> when they fail due to being
 passed a closed file handle.
-L<[perl #122703]|https://rt.perl.org/Ticket/Display.html?id=122703>.
+L<[GH #14073]|https://github.com/Perl/perl5/issues/14073>.
 
 =item *
 
 C<op_free()> and C<scalarvoid()> no longer crash due to a stack overflow
 when freeing a deeply recursive op tree.
-L<[perl #108276]|https://rt.perl.org/Ticket/Display.html?id=108276>.
+L<[GH #11866]|https://github.com/Perl/perl5/issues/11866>.
 
 =item *
 
 In Perl 5.20.0, C<$^N> accidentally had the internal UTF-8 flag turned off
 if accessed from a code block within a regular expression, effectively
 UTF-8-encoding the value.  This has been fixed.
-L<[perl #123135]|https://rt.perl.org/Ticket/Display.html?id=123135>.
+L<[GH #14211]|https://github.com/Perl/perl5/issues/14211>.
 
 =item *
 
@@ -3230,7 +3229,7 @@ which means that C<(semctl(-1,0,0,0))[0]> no longer gives an
 
 C<else{foo()}> with no space before C<foo> is now better at assigning the
 right line number to that statement.
-L<[perl #122695]|https://rt.perl.org/Ticket/Display.html?id=122695>.
+L<[GH #14070]|https://github.com/Perl/perl5/issues/14070>.
 
 =item *
 
@@ -3239,7 +3238,7 @@ itself writes directly to the array.  This caused a bug, preventing this
 assignment from being used in lvalue context.  So
 C<(@a=split//,"foo")=bar()> was an error.  (This bug probably goes back to
 Perl 3, when the optimisation was added.) It has now been fixed.
-L<[perl #123057]|https://rt.perl.org/Ticket/Display.html?id=123057>.
+L<[GH #14183]|https://github.com/Perl/perl5/issues/14183>.
 
 =item *
 
@@ -3247,7 +3246,7 @@ When an argument list fails the checks specified by a subroutine
 signature (which is still an experimental feature), the resulting error
 messages now give the file and line number of the caller, not of the
 called subroutine.
-L<[perl #121374]|https://rt.perl.org/Ticket/Display.html?id=121374>.
+L<[GH #13643]|https://github.com/Perl/perl5/issues/13643>.
 
 =item *
 
@@ -3255,14 +3254,14 @@ The flip-flop operators (C<..> and C<...> in scalar context) used to maintain
 a separate state for each recursion level (the number of times the
 enclosing sub was called recursively), contrary to the documentation.  Now
 each closure has one internal state for each flip-flop.
-L<[perl #122829]|https://rt.perl.org/Ticket/Display.html?id=122829>.
+L<[GH #14110]|https://github.com/Perl/perl5/issues/14110>.
 
 =item *
 
 The flip-flop operator (C<..> in scalar context) would return the same
 scalar each time, unless the containing subroutine was called recursively.
 Now it always returns a new scalar.
-L<[perl #122829]|https://rt.perl.org/Ticket/Display.html?id=122829>.
+L<[GH #14110]|https://github.com/Perl/perl5/issues/14110>.
 
 =item *
 
@@ -3270,7 +3269,7 @@ C<use>, C<no>, statement labels, special blocks (C<BEGIN>) and pod are now
 permitted as the first thing in a C<map> or C<grep> block, the block after
 C<print> or C<say> (or other functions) returning a handle, and within
 C<${...}>, C<@{...}>, etc.
-L<[perl #122782]|https://rt.perl.org/Ticket/Display.html?id=122782>.
+L<[GH #14088]|https://github.com/Perl/perl5/issues/14088>.
 
 =item *
 
@@ -3283,7 +3282,7 @@ C<$_>.
 
 C<(...) x ...> in scalar context used to corrupt the stack if one operand
 was an object with "x" overloading, causing erratic behavior.
-L<[perl #121827]|https://rt.perl.org/Ticket/Display.html?id=121827>.
+L<[GH #13811]|https://github.com/Perl/perl5/issues/13811>.
 
 =item *
 
@@ -3361,7 +3360,7 @@ started doing so in 5.18.
 
 C<index()> and C<rindex()> no longer crash when used on strings over 2GB in
 size.
-L<[perl #121562]|https://rt.perl.org/Ticket/Display.html?id=121562>.
+L<[GH #13700]|https://github.com/Perl/perl5/issues/13700>.
 
 =item *
 
@@ -3442,19 +3441,19 @@ mirror character.
 
 C<< s///e >> on tainted UTF-8 strings corrupted C<< pos() >>. This bug,
 introduced in 5.20, is now fixed.
-L<[perl #122148]|https://rt.perl.org/Ticket/Display.html?id=122148>.
+L<[GH #13948]|https://github.com/Perl/perl5/issues/13948>.
 
 =item *
 
 A non-word boundary in a regular expression (C<< \B >>) did not always
 match the end of the string; in particular C<< q{} =~ /\B/ >> did not
 match. This bug, introduced in perl 5.14, is now fixed.
-L<[perl #122090]|https://rt.perl.org/Ticket/Display.html?id=122090>.
+L<[GH #13917]|https://github.com/Perl/perl5/issues/13917>.
 
 =item *
 
 C<< " P" =~ /(?=.*P)P/ >> should match, but did not. This is now fixed.
-L<[perl #122171]|https://rt.perl.org/Ticket/Display.html?id=122171>.
+L<[GH #13954]|https://github.com/Perl/perl5/issues/13954>.
 
 =item *
 
@@ -3462,13 +3461,13 @@ Failing to compile C<use Foo> in an C<eval> could leave a spurious
 C<BEGIN> subroutine definition, which would produce a "Subroutine
 BEGIN redefined" warning on the next use of C<use>, or other C<BEGIN>
 block.
-L<[perl #122107]|https://rt.perl.org/Ticket/Display.html?id=122107>.
+L<[GH #13926]|https://github.com/Perl/perl5/issues/13926>.
 
 =item *
 
 C<method { BLOCK } ARGS> syntax now correctly parses the arguments if they
 begin with an opening brace.
-L<[perl #46947]|https://rt.perl.org/Ticket/Display.html?id=46947>.
+L<[GH #9085]|https://github.com/Perl/perl5/issues/9085>.
 
 =item *
 
@@ -3476,19 +3475,19 @@ External libraries and Perl may have different ideas of what the locale is.
 This is problematic when parsing version strings if the locale's numeric
 separator has been changed.  Version parsing has been patched to ensure
 it handles the locales correctly.
-L<[perl #121930]|https://rt.perl.org/Ticket/Display.html?id=121930>.
+L<[GH #13863]|https://github.com/Perl/perl5/issues/13863>.
 
 =item *
 
 A bug has been fixed where zero-length assertions and code blocks inside of a
 regex could cause C<pos> to see an incorrect value.
-L<[perl #122460]|https://rt.perl.org/Ticket/Display.html?id=122460>.
+L<[GH #14016]|https://github.com/Perl/perl5/issues/14016>.
 
 =item *
 
 Dereferencing of constants now works correctly for typeglob constants.  Previously
 the glob was stringified and its name looked up.  Now the glob itself is used.
-L<[perl #69456]|https://rt.perl.org/Ticket/Display.html?id=69456>
+L<[GH #9891]|https://github.com/Perl/perl5/issues/9891>
 
 =item *
 
@@ -3501,7 +3500,7 @@ syntax error when it guesses the latter), since it can only be a block.
 
 S<C<undef $reference>> now frees the referent immediately, instead of hanging on
 to it until the next statement.
-L<[perl #122556]|https://rt.perl.org/Ticket/Display.html?id=122556>
+L<[GH #14032]|https://github.com/Perl/perl5/issues/14032>
 
 =item *
 
@@ -3545,7 +3544,7 @@ first character in the sequence is used, again just as before.
 
 Tainted constants evaluated at compile time no longer cause unrelated
 statements to become tainted.
-L<[perl #122669]|https://rt.perl.org/Ticket/Display.html?id=122669>
+L<[GH #14059]|https://github.com/Perl/perl5/issues/14059>
 
 =item *
 
@@ -3563,7 +3562,7 @@ package of the C<our> sub, instead of the package of the invocant.
 
 The parser no longer gets confused by C<\U=> within a double-quoted string.  It
 used to produce a syntax error, but now compiles it correctly.
-L<[perl #80368]|https://rt.perl.org/Ticket/Display.html?id=80368>
+L<[GH #10882]|https://github.com/Perl/perl5/issues/10882>
 
 =item *
 
@@ -3584,7 +3583,7 @@ Perl 5.20.0 introduced a regression in which a UTF-8 encoded regular
 expression pattern that contains a single ASCII lowercase letter did not
 match its uppercase counterpart. That has been fixed in both 5.20.1 and
 5.22.0.
-L<[perl #122655]|https://rt.perl.org/Ticket/Display.html?id=122655>
+L<[GH #14051]|https://github.com/Perl/perl5/issues/14051>
 
 =item *
 
@@ -3597,7 +3596,7 @@ false at compile time and true at run time.
 Loading Unicode tables during a regular expression match could cause assertion
 failures under debugging builds if the previous match used the very same
 regular expression.
-L<[perl #122747]|https://rt.perl.org/Ticket/Display.html?id=122747>
+L<[GH #14081]|https://github.com/Perl/perl5/issues/14081>
 
 =item *
 
@@ -3626,7 +3625,7 @@ routine.
 Aliasing (I<e.g.>, via S<C<*x = *y>>) could confuse list assignments that mention the
 two names for the same variable on either side, causing wrong values to be
 assigned.
-L<[perl #15667]|https://rt.perl.org/Ticket/Display.html?id=15667>
+L<[GH #5788]|https://github.com/Perl/perl5/issues/5788>
 
 =item *
 
@@ -3642,7 +3641,7 @@ unfortunate side-effect of also treating S<C<split /\A/>> like S<C<split /^/m>>,
 which it should not.  This has been fixed.  (Note, however, that S<C<split /^x/>>
 does not behave like S<C<split /^x/m>>, which is also considered to be a bug and
 will be fixed in a future version.)
-L<[perl #122761]|https://rt.perl.org/Ticket/Display.html?id=122761>
+L<[GH #14086]|https://github.com/Perl/perl5/issues/14086>
 
 =item *
 
@@ -3682,7 +3681,7 @@ they produce errors.
 
 An assertion failure when parsing C<sort> with debugging enabled has been
 fixed.
-L<[perl #122771]|https://rt.perl.org/Ticket/Display.html?id=122771>.
+L<[GH #14087]|https://github.com/Perl/perl5/issues/14087>.
 
 =item *
 
@@ -3697,7 +3696,7 @@ the optimizer into assuming a limit of 1.
 =item *
 
 Fatal warnings no longer prevent the output of syntax errors.
-L<[perl #122966]|https://rt.perl.org/Ticket/Display.html?id=122966>.
+L<[GH #14155]|https://github.com/Perl/perl5/issues/14155>.
 
 =item *
 
@@ -3709,12 +3708,12 @@ produced.
 
 Fixed the issue that caused C<< make distclean >> to incorrectly leave some
 files behind.
-L<[perl #122820]|https://rt.perl.org/Ticket/Display.html?id=122820>.
+L<[GH #14108]|https://github.com/Perl/perl5/issues/14108>.
 
 =item *
 
 AIX now sets the length in C<< getsockopt >> correctly.
-L<[perl #120835]|https://rt.perl.org/Ticket/Display.html?id=120835>.
+L<[GH #13484]|https://github.com/Perl/perl5/issues/13484>.
 L<[cpan #91183]|https://rt.cpan.org/Ticket/Display.html?id=91183>.
 L<[cpan #85570]|https://rt.cpan.org/Ticket/Display.html?id=85570>.
 
@@ -3722,18 +3721,18 @@ L<[cpan #85570]|https://rt.cpan.org/Ticket/Display.html?id=85570>.
 
 The optimization phase of a regexp compilation could run "forever" and
 exhaust all memory under certain circumstances; now fixed.
-L<[perl #122283]|https://rt.perl.org/Ticket/Display.html?id=122283>.
+L<[GH #13984]|https://github.com/Perl/perl5/issues/13984>.
 
 =item *
 
 The test script F<< t/op/crypt.t >> now uses the SHA-256 algorithm if the
 default one is disabled, rather than giving failures.
-L<[perl #121591]|https://rt.perl.org/Ticket/Display.html?id=121591>.
+L<[GH #13715]|https://github.com/Perl/perl5/issues/13715>.
 
 =item *
 
 Fixed an off-by-one error when setting the size of a shared array.
-L<[perl #122950]|https://rt.perl.org/Ticket/Display.html?id=122950>.
+L<[GH #14151]|https://github.com/Perl/perl5/issues/14151>.
 
 =item *
 
@@ -3743,7 +3742,7 @@ compilation. In particular, a C<while(1)> within a sublist, I<e.g.>
     sub foo { () = ($a, my $b, ($c, do { while(1) {} })) }
 
 The bug was introduced in 5.20.0
-L<[perl #122995]|https://rt.perl.org/Ticket/Display.html?id=122995>.
+L<[GH #14165]|https://github.com/Perl/perl5/issues/14165>.
 
 =item *
 
@@ -3751,14 +3750,14 @@ On Win32, if a variable was C<local>-ized in a pseudo-process that later
 forked, restoring the original value in the child pseudo-process caused
 memory corruption and a crash in the child pseudo-process (and therefore the
 OS process).
-L<[perl #40565]|https://rt.perl.org/Ticket/Display.html?id=40565>.
+L<[GH #8641]|https://github.com/Perl/perl5/issues/8641>.
 
 =item *
 
 Calling C<write> on a format with a C<^**> field could produce a panic
 in C<sv_chop()> if there were insufficient arguments or if the variable
 used to fill the field was empty.
-L<[perl #123245]|https://rt.perl.org/Ticket/Display.html?id=123245>.
+L<[GH #14255]|https://github.com/Perl/perl5/issues/14255>.
 
 =item *
 
@@ -3770,7 +3769,7 @@ appear in error messages.
 The C<\@> subroutine prototype no longer flattens parenthesized arrays
 (taking a reference to each element), but takes a reference to the array
 itself.
-L<[perl #47363]|https://rt.perl.org/Ticket/Display.html?id=47363>.
+L<[GH #9111]|https://github.com/Perl/perl5/issues/9111>.
 
 =item *
 
@@ -3778,7 +3777,7 @@ A block containing nothing except a C-style C<for> loop could corrupt the
 stack, causing lists outside the block to lose elements or have elements
 overwritten.  This could happen with C<map { for(...){...} } ...> and with
 lists containing C<do { for(...){...} }>.
-L<[perl #123286]|https://rt.perl.org/Ticket/Display.html?id=123286>.
+L<[GH #14269]|https://github.com/Perl/perl5/issues/14269>.
 
 =item *
 
@@ -3788,7 +3787,7 @@ S<C<for(scalar($#foo)) { ... }>> can modify C<$#foo> through C<$_>.
 =item *
 
 C<qr/@array(?{block})/> no longer dies with "Bizarre copy of ARRAY".
-L<[perl #123344]|https://rt.perl.org/Ticket/Display.html?id=123344>.
+L<[GH #14292]|https://github.com/Perl/perl5/issues/14292>.
 
 =item *
 
@@ -3801,7 +3800,7 @@ In perl 5.20.0, C<sort CORE::fake> where 'fake' is anything other than a
 keyword, started chopping off the last 6 characters and treating the result
 as a sort sub name.  The previous behavior of treating C<CORE::fake> as a
 sort sub name has been restored.
-L<[perl #123410]|https://rt.perl.org/Ticket/Display.html?id=123410>.
+L<[GH #14323]|https://github.com/Perl/perl5/issues/14323>.
 
 =item *
 
@@ -3819,7 +3818,7 @@ C<${^LAST_FH}> ends up undefined.
 
 C<(...) x ...> in void context now applies scalar context to the left-hand
 argument, instead of the context the current sub was called in.
-L<[perl #123020]|https://rt.perl.org/Ticket/Display.html?id=123020>.
+L<[GH #14174]|https://github.com/Perl/perl5/issues/14174>.
 
 =back
 
@@ -3831,7 +3830,7 @@ L<[perl #123020]|https://rt.perl.org/Ticket/Display.html?id=123020>.
 
 C<pack>-ing a NaN on a perl compiled with Visual C 6 does not behave properly,
 leading to a test failure in F<t/op/infnan.t>.
-L<[perl 125203]|https://rt.perl.org/Ticket/Display.html?id=125203>
+L<[GH #14705]|https://github.com/Perl/perl5/issues/14705>
 
 =item *
 

--- a/pod/perl5221delta.pod
+++ b/pod/perl5221delta.pod
@@ -28,7 +28,7 @@ Several bugs, including a segmentation fault, have been fixed with the bounds
 checking constructs (introduced in Perl 5.22) C<\b{gcb}>, C<\b{sb}>, C<\b{wb}>,
 C<\B{gcb}>, C<\B{sb}>, and C<\B{wb}>.  All the C<\B{}> ones now match an empty
 string; none of the C<\b{}> ones do.
-L<[perl #126319]|https://rt.perl.org/Ticket/Display.html?id=126319>
+L<[GH #14976]|https://github.com/Perl/perl5/issues/14976>
 
 =head1 Modules and Pragmata
 
@@ -50,7 +50,7 @@ L<POSIX> has been upgraded from version 1.53 to 1.53_01.
 
 If C<POSIX::strerror> was passed C<$!> as its argument then it accidentally
 cleared C<$!>.  This has been fixed.
-L<[perl #126229]|https://rt.perl.org/Ticket/Display.html?id=126229>
+L<[GH #14951]|https://github.com/Perl/perl5/issues/14951>
 
 =item *
 
@@ -61,7 +61,7 @@ L<Storable> has been upgraded from version 2.53 to 2.53_01.
 L<warnings> has been upgraded from version 1.32 to 1.34.
 
 The C<warnings::enabled> example now actually uses C<warnings::enabled>.
-L<[perl #126051]|https://rt.perl.org/Ticket/Display.html?id=126051>
+L<[GH #14905]|https://github.com/Perl/perl5/issues/14905>
 
 =item *
 
@@ -111,7 +111,7 @@ diagnostic messages, see L<perldiag>.
 The C<printf> and C<sprintf> builtins are now more careful about the warnings
 they emit: argument reordering now disables the "redundant argument" warning in
 all cases.
-L<[perl #125469]|https://rt.perl.org/Ticket/Display.html?id=125469>
+L<[GH #14772]|https://github.com/Perl/perl5/issues/14772>
 
 =back
 
@@ -130,7 +130,7 @@ the interpreter, since Perl 5.17.10.  This has been fixed.
 Configuring with ccflags containing quotes (e.g.
 C<< -Accflags='-DAPPLLIB_EXP=\"/usr/libperl\"' >>) was broken in Perl 5.22.0
 but has now been fixed again.
-L<[perl #125314]|https://rt.perl.org/Ticket/Display.html?id=125314>
+L<[GH #14732]|https://github.com/Perl/perl5/issues/14732>
 
 =back
 
@@ -149,12 +149,12 @@ L<[perl #125314]|https://rt.perl.org/Ticket/Display.html?id=125314>
 Under some circumstances IRIX stdio fgetc() and fread() set the errno to
 C<ENOENT>, which made no sense according to either IRIX or POSIX docs.  Errno
 is now cleared in such cases.
-L<[perl #123977]|https://rt.perl.org/Ticket/Display.html?id=123977>
+L<[GH #14557]|https://github.com/Perl/perl5/issues/14557>
 
 =item *
 
 Problems when multiplying long doubles by infinity have been fixed.
-L<[perl #126396]|https://rt.perl.org/Ticket/Display.html?id=126396>
+L<[GH #14993]|https://github.com/Perl/perl5/issues/14993>
 
 =item *
 
@@ -171,7 +171,7 @@ All tests pass now on IRIX with the default build configuration.
 =item *
 
 C<qr/(?[ () ])/> no longer segfaults, giving a syntax error message instead.
-L<[perl #125805]|https://rt.perl.org/Ticket/Display.html?id=125805>
+L<[GH #14851]|https://github.com/Perl/perl5/issues/14851>
 
 =item *
 
@@ -179,19 +179,19 @@ Regular expression possessive quantifier Perl 5.20 regression now fixed.
 C<qr/>I<PAT>C<{>I<min>,I<max>C<}+>C</> is supposed to behave identically to
 C<qr/(?E<gt>>I<PAT>C<{>I<min>,I<max>C<})/>.  Since Perl 5.20, this didn't work
 if I<min> and I<max> were equal.
-L<[perl #125825]|https://rt.perl.org/Ticket/Display.html?id=125825>
+L<[GH #14857]|https://github.com/Perl/perl5/issues/14857>
 
 =item *
 
 Certain syntax errors in
 L<perlrecharclass/Extended Bracketed Character Classes> caused panics instead
 of the proper error message.  This has now been fixed.
-L<[perl #126481]|https://rt.perl.org/Ticket/Display.html?id=126481>
+L<[GH #15016]|https://github.com/Perl/perl5/issues/15016>
 
 =item *
 
 C<< BEGIN <> >> no longer segfaults and properly produces an error message.
-L<[perl #125341]|https://rt.perl.org/Ticket/Display.html?id=125341>
+L<[GH #13546]|https://github.com/Perl/perl5/issues/13546>
 
 =item *
 
@@ -199,39 +199,39 @@ A regression from Perl 5.20 has been fixed, in which some syntax errors in
 L<C<(?[...])>|perlrecharclass/Extended Bracketed Character Classes> constructs
 within regular expression patterns could cause a segfault instead of a proper
 error message.
-L<[perl #126180]|https://rt.perl.org/Ticket/Display.html?id=126180>
+L<[GH #14933]|https://github.com/Perl/perl5/issues/14933>
 
 =item *
 
 Another problem with
 L<C<(?[...])>|perlrecharclass/Extended Bracketed Character Classes>
 constructs has been fixed wherein things like C<\c]> could cause panics.
-L<[perl #126181]|https://rt.perl.org/Ticket/Display.html?id=126181>
+L<[GH #14934]|https://github.com/Perl/perl5/issues/14934>
 
 =item *
 
 In Perl 5.22.0, the logic changed when parsing a numeric parameter to the -C
 option, such that the successfully parsed number was not saved as the option
 value if it parsed to the end of the argument.
-L<[perl #125381]|https://rt.perl.org/Ticket/Display.html?id=125381>
+L<[GH #14748]|https://github.com/Perl/perl5/issues/14748>
 
 =item *
 
 Warning fatality is now ignored when rewinding the stack.  This prevents
 infinite recursion when the now fatal error also causes rewinding of the stack.
-L<[perl #123398]|https://rt.perl.org/Ticket/Display.html?id=123398>
+L<[GH #14319]|https://github.com/Perl/perl5/issues/14319>
 
 =item *
 
 A crash with C<< %::=(); J->${\"::"} >> has been fixed.
-L<[perl #125541]|https://rt.perl.org/Ticket/Display.html?id=125541>
+L<[GH #14790]|https://github.com/Perl/perl5/issues/14790>
 
 =item *
 
 Nested quantifiers such as C</.{1}??/> should cause perl to throw a fatal
 error, but were being silently accepted since Perl 5.20.0.  This has been
 fixed.
-L<[perl #126253]|https://rt.perl.org/Ticket/Display.html?id=126253>
+L<[GH #14960]|https://github.com/Perl/perl5/issues/14960>
 
 =item *
 
@@ -239,21 +239,21 @@ Regular expression sequences such as C</(?i/> (and similarly with other
 recognized flags or combination of flags) should cause perl to throw a fatal
 error, but were being silently accepted since Perl 5.18.0.  This has been
 fixed.
-L<[perl #126178]|https://rt.perl.org/Ticket/Display.html?id=126178>
+L<[GH #14931]|https://github.com/Perl/perl5/issues/14931>
 
 =item *
 
 A bug in hexadecimal floating point literal support meant that high-order bits
 could be lost in cases where mantissa overflow was caused by too many trailing
 zeros in the fractional part.  This has been fixed.
-L<[perl #126582]|https://rt.perl.org/Ticket/Display.html?id=126582>
+L<[GH #15032]|https://github.com/Perl/perl5/issues/15032>
 
 =item *
 
 Another hexadecimal floating point bug, causing low-order bits to be lost in
 cases where the last hexadecimal digit of the mantissa has bits straddling the
 limit of the number of bits allowed for the mantissa, has also been fixed.
-L<[perl #126586]|https://rt.perl.org/Ticket/Display.html?id=126586>
+L<[GH #15033]|https://github.com/Perl/perl5/issues/15033>
 
 =item *
 
@@ -266,7 +266,7 @@ even lose the radix point after the leftmost hexadecimal digit completely.
 
 A crash caused by incomplete expressions within C<< /(?[ ])/ >> (e.g.
 C<< /(?[[0]+()+])/ >>) has been fixed.
-L<[perl #126615]|https://rt.perl.org/Ticket/Display.html?id=126615>
+L<[GH #15045]|https://github.com/Perl/perl5/issues/15045>
 
 =back
 

--- a/pod/perl5222delta.pod
+++ b/pod/perl5222delta.pod
@@ -17,12 +17,12 @@ L<perl5221delta>, which describes differences between 5.22.0 and 5.22.1.
 =head2 Fix out of boundary access in Win32 path handling
 
 This is CVE-2015-8608.  For more information see
-L<[perl #126755]|https://rt.perl.org/Ticket/Display.html?id=126755>.
+L<[GH #15067]|https://github.com/Perl/perl5/issues/15067>.
 
 =head2 Fix loss of taint in C<canonpath()>
 
 This is CVE-2015-8607.  For more information see
-L<[perl #126862]|https://rt.perl.org/Ticket/Display.html?id=126862>.
+L<[GH #15084]|https://github.com/Perl/perl5/issues/15084>.
 
 =head2 Set proper umask before calling C<mkstemp(3)>
 
@@ -37,14 +37,14 @@ regardless of current umask.
 
 This has been fixed by using umask C<0177> instead.
 
-L<[perl #127322]|https://rt.perl.org/Ticket/Display.html?id=127322>
+L<[GH #15135]|https://github.com/Perl/perl5/issues/15135>
 
 =head2 Avoid accessing uninitialized memory in Win32 C<crypt()>
 
 Validation that will detect both a short salt and invalid characters in the
 salt has been added.
 
-L<[perl #126922]|https://rt.perl.org/Ticket/Display.html?id=126922>
+L<[GH #15091]|https://github.com/Perl/perl5/issues/15091>
 
 =head2 Remove duplicate environment variables from C<environ>
 
@@ -84,7 +84,7 @@ L<Module::CoreList> has been upgraded from version 5.20151213 to 5.20160429.
 The version number of L<Digest::SHA> listed for Perl 5.18.4 was wrong and has
 been corrected.  Likewise for the version number of L<Config> in 5.18.3 and
 5.18.4.
-L<[perl #127624]|https://rt.perl.org/Ticket/Display.html?id=127624>
+L<[GH #15202]|https://github.com/Perl/perl5/issues/15202>
 
 =back
 
@@ -126,14 +126,14 @@ require an input object file that uses the probes in the F<.d> file.
 
 Previously the probe would fail and cause a build failure.
 
-L<[perl #122287]|https://rt.perl.org/Ticket/Display.html?id=122287>
+L<[GH #13985]|https://github.com/Perl/perl5/issues/13985>
 
 =item *
 
 F<Configure> no longer probes for F<libnm> by default.  Originally this was the
 "New Math" library, but the name has been re-used by the GNOME NetworkManager.
 
-L<[perl #127131]|https://rt.perl.org/Ticket/Display.html?id=127131>
+L<[GH #15115]|https://github.com/Perl/perl5/issues/15115>
 
 =item *
 
@@ -155,7 +155,7 @@ Compiling perl with B<-DPERL_MEM_LOG> now works again.
 
 Compiling perl with B<-Dusecbacktrace> on Darwin now works again.
 
-L<[perl #127764]|https://rt.perl.org/Ticket/Display.html?id=127764>
+L<[GH #15245]|https://github.com/Perl/perl5/issues/15245>
 
 =item OS X/Darwin
 
@@ -166,7 +166,7 @@ atfork handler using the libc C<setenv()> function to update the environment.
 
 Perl now uses C<setenv()>/C<unsetenv()> to update the environment on OS X.
 
-L<[perl #126240]|https://rt.perl.org/Ticket/Display.html?id=126240>
+L<[GH #14955]|https://github.com/Perl/perl5/issues/14955>
 
 =item ppc64el
 
@@ -190,7 +190,7 @@ subroutine definition with a prototype has been seen, then any subsequent stub
 (or definition) of the same subroutine with an attribute was causing an
 assertion failure because of a null pointer.
 
-L<[perl #126845]|https://rt.perl.org/Ticket/Display.html?id=126845>
+L<[GH #15081]|https://github.com/Perl/perl5/issues/15081>
 
 =back
 
@@ -202,7 +202,7 @@ L<[perl #126845]|https://rt.perl.org/Ticket/Display.html?id=126845>
 
 Calls to the placeholder C<&PL_sv_yes> used internally when an C<import()> or
 C<unimport()> method isn't found now correctly handle scalar context.
-L<[perl #126042]|https://rt.perl.org/Ticket/Display.html?id=126042>
+L<[GH #14902]|https://github.com/Perl/perl5/issues/14902>
 
 =item *
 
@@ -210,19 +210,19 @@ The L<C<pipe()>|perlfunc/pipe> operator would assert for C<DEBUGGING> builds
 instead of producing the correct error message.  The condition asserted on is
 detected and reported on correctly without the assertions, so the assertions
 were removed.
-L<[perl #126480]|https://rt.perl.org/Ticket/Display.html?id=126480>
+L<[GH #15015]|https://github.com/Perl/perl5/issues/15015>
 
 =item *
 
 In some cases, failing to parse a here-doc would attempt to use freed memory.
 This was caused by a pointer not being restored correctly.
-L<[perl #126443]|https://rt.perl.org/Ticket/Display.html?id=126443>
+L<[GH #15009]|https://github.com/Perl/perl5/issues/15009>
 
 =item *
 
 Perl now reports more context when it sees an array where it expects to see an
 operator, and avoids an assertion failure.
-L<[perl #123737]|https://rt.perl.org/Ticket/Display.html?id=123737>
+L<[GH #14472]|https://github.com/Perl/perl5/issues/14472>
 
 =item *
 
@@ -230,19 +230,19 @@ If a here-doc was found while parsing another operator, the parser had already
 read end of file, and the here-doc was not terminated, perl could produce an
 assertion or a segmentation fault.  This now reliably complains about the
 unterminated here-doc.
-L<[perl #125540]|https://rt.perl.org/Ticket/Display.html?id=125540>
+L<[GH #14789]|https://github.com/Perl/perl5/issues/14789>
 
 =item *
 
 Parsing beyond the end of the buffer when processing a C<#line> directive with
 no filename is now avoided.
-L<[perl #127334]|https://rt.perl.org/Ticket/Display.html?id=127334>
+L<[GH #15139]|https://github.com/Perl/perl5/issues/15139>
 
 =item *
 
 Perl 5.22.0 added support for the C99 hexadecimal floating point notation, but
 sometimes misparsed hex floats.  This has been fixed.
-L<[perl #127183]|https://rt.perl.org/Ticket/Display.html?id=127183>
+L<[GH #15120]|https://github.com/Perl/perl5/issues/15120>
 
 =item *
 
@@ -250,56 +250,56 @@ Certain regex patterns involving a complemented posix class in an inverted
 bracketed character class, and matching something else optionally would
 improperly fail to match.  An example of one that could fail is
 C<qr/_?[^\Wbar]\x{100}/>.  This has been fixed.
-L<[perl #127537]|https://rt.perl.org/Ticket/Display.html?id=127537>
+L<[GH #15181]|https://github.com/Perl/perl5/issues/15181>
 
 =item *
 
 Fixed an issue with L<C<pack()>|perlfunc/pack> where C<< pack "H" >> (and
 C<< pack "h" >>) could read past the source when given a non-utf8 source and a
 utf8 target.
-L<[perl #126325]|https://rt.perl.org/Ticket/Display.html?id=126325>
+L<[GH #14977]|https://github.com/Perl/perl5/issues/14977>
 
 =item *
 
 Fixed some cases where perl would abort due to a segmentation fault, or a
 C-level assert.
-L<[perl #126193]|https://rt.perl.org/Ticket/Display.html?id=126193>
-L<[perl #126257]|https://rt.perl.org/Ticket/Display.html?id=126257>
-L<[perl #126258]|https://rt.perl.org/Ticket/Display.html?id=126258>
-L<[perl #126405]|https://rt.perl.org/Ticket/Display.html?id=126405>
-L<[perl #126602]|https://rt.perl.org/Ticket/Display.html?id=126602>
-L<[perl #127773]|https://rt.perl.org/Ticket/Display.html?id=127773>
-L<[perl #127786]|https://rt.perl.org/Ticket/Display.html?id=127786>
+L<[GH #14941]|https://github.com/Perl/perl5/issues/14941>
+L<[GH #14962]|https://github.com/Perl/perl5/issues/14962>
+L<[GH #14963]|https://github.com/Perl/perl5/issues/14963>
+L<[GH #14997]|https://github.com/Perl/perl5/issues/14997>
+L<[GH #15039]|https://github.com/Perl/perl5/issues/15039>
+L<[GH #15247]|https://github.com/Perl/perl5/issues/15247>
+L<[GH #15251]|https://github.com/Perl/perl5/issues/15251>
 
 =item *
 
 A memory leak when setting C<$ENV{foo}> on Darwin has been fixed.
-L<[perl #126240]|https://rt.perl.org/Ticket/Display.html?id=126240>
+L<[GH #14955]|https://github.com/Perl/perl5/issues/14955>
 
 =item *
 
 Perl now correctly raises an error when trying to compile patterns with
 unterminated character classes while there are trailing backslashes.
-L<[perl #126141]|https://rt.perl.org/Ticket/Display.html?id=126141>
+L<[GH #14919]|https://github.com/Perl/perl5/issues/14919>
 
 =item *
 
 C<NOTHING> regops and C<EXACTFU_SS> regops in C<make_trie()> are now handled
 properly.
-L<[perl #126206]|https://rt.perl.org/Ticket/Display.html?id=126206>
+L<[GH #14945]|https://github.com/Perl/perl5/issues/14945>
 
 =item *
 
 Perl now only tests C<semctl()> if we have everything needed to use it.  In
 FreeBSD the C<semctl()> entry point may exist, but it can be disabled by
 policy.
-L<[perl #127533]|https://rt.perl.org/Ticket/Display.html?id=127533>
+L<[GH #15180]|https://github.com/Perl/perl5/issues/15180>
 
 =item *
 
 A regression that allowed undeclared barewords as hash keys to work despite
 strictures has been fixed.
-L<[perl #126981]|https://rt.perl.org/Ticket/Display.html?id=126981>
+L<[GH #15099]|https://github.com/Perl/perl5/issues/15099>
 
 =item *
 

--- a/pod/perl5223delta.pod
+++ b/pod/perl5223delta.pod
@@ -198,7 +198,7 @@ L<Test::Harness> has been upgraded from version 3.35 to 3.35_01.
 
 L<XSLoader> has been upgraded from version 0.20 to 0.20_01, fixing a security
 hole in which binary files could be loaded from a path outside of C<@INC>.
-L<[perl #128528]|https://rt.perl.org/Public/Bug/Display.html?id=128528>
+L<[GH #15418]|https://github.com/Perl/perl5/issues/15418>
 
 =back
 

--- a/pod/perl5224delta.pod
+++ b/pod/perl5224delta.pod
@@ -55,7 +55,7 @@ L<Module::CoreList> has been upgraded from version 5.20170114_22 to 5.20170715_2
 
 Fixed a crash with C<s///l> where it thought it was dealing with UTF-8 when it
 wasn't.
-L<[perl #129038]|https://rt.perl.org/Ticket/Display.html?id=129038>
+L<[GH #15543]|https://github.com/Perl/perl5/issues/15543>
 
 =back
 

--- a/pod/perl5240delta.pod
+++ b/pod/perl5240delta.pod
@@ -117,18 +117,18 @@ This has been fixed by using umask 0177 instead. [perl #127322]
 =head2 Fix out of boundary access in Win32 path handling
 
 This is CVE-2015-8608.  For more information see
-L<[perl #126755]|https://rt.perl.org/Ticket/Display.html?id=126755>
+L<[GH #15067]|https://github.com/Perl/perl5/issues/15067>
 
 =head2 Fix loss of taint in canonpath
 
 This is CVE-2015-8607.  For more information see
-L<[perl #126862]|https://rt.perl.org/Ticket/Display.html?id=126862>
+L<[GH #15084]|https://github.com/Perl/perl5/issues/15084>
 
 =head2 Avoid accessing uninitialized memory in win32 C<crypt()>
 
 Added validation that will detect both a short salt and invalid characters
 in the salt.
-L<[perl #126922]|https://rt.perl.org/Ticket/Display.html?id=126922>
+L<[GH #15091]|https://github.com/Perl/perl5/issues/15091>
 
 =head2 Remove duplicate environment variables from C<environ>
 
@@ -201,9 +201,9 @@ For example, these are now fatal:
    my ($x, my($y));
    our (my $x);
 
-L<[perl #125587]|https://rt.perl.org/Ticket/Display.html?id=125587>
+L<[GH #14799]|https://github.com/Perl/perl5/issues/14799>
 
-L<[perl #121058]|https://rt.perl.org/Ticket/Display.html?id=121058>
+L<[GH #13548]|https://github.com/Perl/perl5/issues/13548>
 
 =head2 The C</\C/> character class has been removed.
 
@@ -858,7 +858,7 @@ The documentation of C<hex> has been revised to clarify valid inputs.
 =item *
 
 Better explain meaning of negative PIDs in C<waitpid>.
-L<[perl #127080]|https://rt.perl.org/Ticket/Display.html?id=127080>
+L<[GH #15108]|https://github.com/Perl/perl5/issues/15108>
 
 =item *
 
@@ -996,7 +996,7 @@ Discourage use of 'In' as a prefix signifying the Unicode Block property.
 
 The documentation of C<$@> was reworded to clarify that it is not just for
 syntax errors in C<eval>.
-L<[perl #124034]|https://rt.perl.org/Ticket/Display.html?id=124034>
+L<[GH #14572]|https://github.com/Perl/perl5/issues/14572>
 
 =item *
 
@@ -1101,7 +1101,7 @@ L<%s() is deprecated on :utf8 handles|perldiag/"%s() is deprecated on :utf8 hand
 Accessing the C<IO> part of a glob as C<FILEHANDLE> instead of C<IO> is no
 longer deprecated.  It is discouraged to encourage uniformity (so that, for
 example, one can grep more easily) but it will not be removed.
-L<[perl #127060]|https://rt.perl.org/Ticket/Display.html?id=127060>
+L<[GH #15105]|https://github.com/Perl/perl5/issues/15105>
 
 =item *
 
@@ -1145,7 +1145,7 @@ Bison 3.0 is now supported.
 F<Configure> no longer probes for F<libnm> by default.  Originally
 this was the "New Math" library, but the name has been re-used by the
 GNOME NetworkManager.
-L<[perl #127131]|https://rt.perl.org/Ticket/Display.html?id=127131>
+L<[GH #15115]|https://github.com/Perl/perl5/issues/15115>
 
 =item *
 
@@ -1239,7 +1239,7 @@ Perl 5.22.1.
 =item *
 
 Tests are more robust against unusual cygdrive prefixes.
-L<[perl #126834]|https://rt.perl.org/Ticket/Display.html?id=126834>
+L<[GH #15076]|https://github.com/Perl/perl5/issues/15076>
 
 =back
 
@@ -1287,7 +1287,7 @@ utf8>>, which are now fixed
 =item *
 
 Use the C<fdclose()> function from FreeBSD if it is available.
-L<[perl #126847]|https://rt.perl.org/Ticket/Display.html?id=126847>
+L<[GH #15082]|https://github.com/Perl/perl5/issues/15082>
 
 =back
 
@@ -1300,12 +1300,12 @@ L<[perl #126847]|https://rt.perl.org/Ticket/Display.html?id=126847>
 Under some circumstances IRIX stdio C<fgetc()> and C<fread()> set the errno to
 C<ENOENT>, which made no sense according to either IRIX or POSIX docs.  Errno
 is now cleared in such cases.
-L<[perl #123977]|https://rt.perl.org/Ticket/Display.html?id=123977>
+L<[GH #14557]|https://github.com/Perl/perl5/issues/14557>
 
 =item *
 
 Problems when multiplying long doubles by infinity have been fixed.
-L<[perl #126396]|https://rt.perl.org/Ticket/Display.html?id=126396>
+L<[GH #14993]|https://github.com/Perl/perl5/issues/14993>
 
 =back
 
@@ -1337,7 +1337,7 @@ environment conflicting with an atfork handler using the libc
 C<setenv()> function to update the environment.
 
 Perl now uses C<setenv()>/C<unsetenv()> to update the environment on OS X.
-L<[perl #126240]|https://rt.perl.org/Ticket/Display.html?id=126240>
+L<[GH #14955]|https://github.com/Perl/perl5/issues/14955>
 
 =back
 
@@ -1635,7 +1635,7 @@ The obscure C<PL_timesbuf> variable, effectively a vestige of Perl 1, has
 been removed. It was documented as deprecated in Perl 5.20, with a statement
 that it would be removed early in the 5.21.x series; that has now finally
 happened.
-L<[perl #121351]|https://rt.perl.org/Ticket/Display.html?id=121351>
+L<[GH #13632]|https://github.com/Perl/perl5/issues/13632>
 
 =item *
 
@@ -1644,7 +1644,7 @@ a stub subroutine
 definition with a prototype has been seen, then any subsequent stub (or
 definition) of the same subroutine with an attribute was causing an assertion
 failure because of a null pointer.
-L<[perl #126845]|https://rt.perl.org/Ticket/Display.html?id=126845>
+L<[GH #15081]|https://github.com/Perl/perl5/issues/15081>
 
 =item *
 
@@ -1852,35 +1852,35 @@ but sometimes misparses hex floats. This has been fixed.
 
 A regression that allowed undeclared barewords in hash keys to work despite
 strictures has been fixed.
-L<[perl #126981]|https://rt.perl.org/Ticket/Display.html?id=126981>
+L<[GH #15099]|https://github.com/Perl/perl5/issues/15099>
 
 =item *
 
 Calls to the placeholder C<&PL_sv_yes> used internally when an C<import()>
 or C<unimport()> method isn't found now correctly handle scalar context.
-L<[perl #126042]|https://rt.perl.org/Ticket/Display.html?id=126042>
+L<[GH #14902]|https://github.com/Perl/perl5/issues/14902>
 
 =item *
 
 Report more context when we see an array where we expect to see an
 operator and avoid an assertion failure.
-L<[perl #123737]|https://rt.perl.org/Ticket/Display.html?id=123737>
+L<[GH #14472]|https://github.com/Perl/perl5/issues/14472>
 
 =item *
 
 Modifying an array that was previously a package C<@ISA> no longer
 causes assertion failures or crashes.
-L<[perl #123788]|https://rt.perl.org/Ticket/Display.html?id=123788>
+L<[GH #14492]|https://github.com/Perl/perl5/issues/14492>
 
 =item *
 
 Retain binary compatibility across plain and DEBUGGING perl builds.
-L<[perl #127212]|https://rt.perl.org/Ticket/Display.html?id=127212>
+L<[GH #15122]|https://github.com/Perl/perl5/issues/15122>
 
 =item *
 
 Avoid leaking memory when setting C<$ENV{foo}> on darwin.
-L<[perl #126240]|https://rt.perl.org/Ticket/Display.html?id=126240>
+L<[GH #14955]|https://github.com/Perl/perl5/issues/14955>
 
 =item *
 
@@ -1894,7 +1894,7 @@ could lead to panics on utf8 strings.
 
 In some cases operators that return integers would return negative
 integers as large positive integers.
-L<[perl #126635]|https://rt.perl.org/Ticket/Display.html?id=126635>
+L<[GH #15049]|https://github.com/Perl/perl5/issues/15049>
 
 =item *
 
@@ -1902,27 +1902,27 @@ The C<pipe()> operator would assert for DEBUGGING builds instead of
 producing the correct error message.  The condition asserted on is
 detected and reported on correctly without the assertions, so the
 assertions were removed.
-L<[perl #126480]|https://rt.perl.org/Ticket/Display.html?id=126480>
+L<[GH #15015]|https://github.com/Perl/perl5/issues/15015>
 
 =item *
 
 In some cases, failing to parse a here-doc would attempt to use freed
 memory.  This was caused by a pointer not being restored correctly.
-L<[perl #126443]|https://rt.perl.org/Ticket/Display.html?id=126443>
+L<[GH #15009]|https://github.com/Perl/perl5/issues/15009>
 
 =item *
 
 C<< @x = sort { *a = 0; $a <=> $b } 0 .. 1 >> no longer frees the GP
 for *a before restoring its SV slot.
-L<[perl #124097]|https://rt.perl.org/Ticket/Display.html?id=124097>
+L<[GH #14595]|https://github.com/Perl/perl5/issues/14595>
 
 =item *
 
 Multiple problems with the new hexadecimal floating point printf
 format C<%a> were fixed:
-L<[perl #126582]|https://rt.perl.org/Ticket/Display.html?id=126582>,
-L<[perl #126586]|https://rt.perl.org/Ticket/Display.html?id=126586>,
-L<[perl #126822]|https://rt.perl.org/Ticket/Display.html?id=126822>
+L<[GH #15032]|https://github.com/Perl/perl5/issues/15032>,
+L<[GH #15033]|https://github.com/Perl/perl5/issues/15033>,
+L<[GH #15074]|https://github.com/Perl/perl5/issues/15074>
 
 =item *
 
@@ -1982,7 +1982,7 @@ or a C-level assert. [perl #126615], [perl #126602], [perl #126193].
 
 There were places in regular expression patterns where comments (C<(?#...)>)
 weren't allowed, but should have been.  This is now fixed.
-L<[perl #116639]|https://rt.perl.org/Ticket/Display.html?id=116639>
+L<[GH #12755]|https://github.com/Perl/perl5/issues/12755>
 
 =item *
 
@@ -1990,15 +1990,15 @@ Some regressions from Perl 5.20 have been fixed, in which some syntax errors in
 L<C<(?[...])>|perlrecharclass/Extended Bracketed Character Classes> constructs
 within regular expression patterns could cause a segfault instead of a proper
 error message.
-L<[perl #126180]|https://rt.perl.org/Ticket/Display.html?id=126180>
-L<[perl #126404]|https://rt.perl.org/Ticket/Display.html?id=126404>
+L<[GH #14933]|https://github.com/Perl/perl5/issues/14933>
+L<[GH #14996]|https://github.com/Perl/perl5/issues/14996>
 
 =item *
 
 Another problem with
 L<C<(?[...])>|perlrecharclass/Extended Bracketed Character Classes>
 constructs has been fixed wherein things like C<\c]> could cause panics.
-L<[perl #126181]|https://rt.perl.org/Ticket/Display.html?id=126181>
+L<[GH #14934]|https://github.com/Perl/perl5/issues/14934>
 
 =item *
 
@@ -2011,20 +2011,20 @@ operator, e.g.
 
 Formerly perl may have crashed, depending on the exact value of C<$big_number>;
 now it will typically raise an exception.
-L<[perl #125937]|https://rt.perl.org/Ticket/Display.html?id=125937>
+L<[GH #14880]|https://github.com/Perl/perl5/issues/14880>
 
 =item *
 
 In a regex conditional expression C<(?(condition)yes-pattern|no-pattern)>, if
 the condition is C<(?!)> then perl failed the match outright instead of
 matching the no-pattern.  This has been fixed.
-L<[perl #126222]|https://rt.perl.org/Ticket/Display.html?id=126222>
+L<[GH #14947]|https://github.com/Perl/perl5/issues/14947>
 
 =item *
 
 The special backtracking control verbs C<(*VERB:ARG)> now all allow an optional
 argument and set C<REGERROR>/C<REGMARK> appropriately as well.
-L<[perl #126186]|https://rt.perl.org/Ticket/Display.html?id=126186>
+L<[GH #14937]|https://github.com/Perl/perl5/issues/14937>
 
 =item *
 
@@ -2032,7 +2032,7 @@ Several bugs, including a segmentation fault, have been fixed with the boundary
 checking constructs (introduced in Perl 5.22) C<\b{gcb}>, C<\b{sb}>, C<\b{wb}>,
 C<\B{gcb}>, C<\B{sb}>, and C<\B{wb}>.  All the C<\B{}> ones now match an empty
 string; none of the C<\b{}> ones do.
-L<[perl #126319]|https://rt.perl.org/Ticket/Display.html?id=126319>
+L<[GH #14976]|https://github.com/Perl/perl5/issues/14976>
 
 =item *
 
@@ -2088,7 +2088,7 @@ incorrectly said it did.  This has been fixed.
 
 Very large code-points (beyond Unicode) in regular expressions no
 longer cause a buffer overflow in some cases when converted to UTF-8.
-L<[perl #125826]|https://rt.perl.org/Ticket/Display.html?id=125826>
+L<[GH #14858]|https://github.com/Perl/perl5/issues/14858>
 
 =item *
 
@@ -2096,12 +2096,12 @@ The integer overflow check for the range operator (...) in list
 context now correctly handles the case where the size of the range is
 larger than the address space.  This could happen on 32-bits with
 -Duse64bitint.
-L<[perl #125781]|https://rt.perl.org/Ticket/Display.html?id=125781>
+L<[GH #14843]|https://github.com/Perl/perl5/issues/14843>
 
 =item *
 
 A crash with C<< %::=(); J->${\"::"} >> has been fixed.
-L<[perl #125541]|https://rt.perl.org/Ticket/Display.html?id=125541>
+L<[GH #14790]|https://github.com/Perl/perl5/issues/14790>
 
 =item *
 

--- a/pod/perl5241delta.pod
+++ b/pod/perl5241delta.pod
@@ -194,7 +194,7 @@ L<Test::Harness> has been upgraded from version 3.36 to 3.36_01.
 
 L<XSLoader> has been upgraded from version 0.21 to 0.22, fixing a security hole
 in which binary files could be loaded from a path outside of C<@INC>.
-L<[perl #128528]|https://rt.perl.org/Public/Bug/Display.html?id=128528>
+L<[GH #15418]|https://github.com/Perl/perl5/issues/15418>
 
 =back
 

--- a/pod/perl5242delta.pod
+++ b/pod/perl5242delta.pod
@@ -55,7 +55,7 @@ L<Module::CoreList> has been upgraded from version 5.20170114_24 to 5.20170715_2
 
 Fixed a crash with C<s///l> where it thought it was dealing with UTF-8 when it
 wasn't.
-L<[perl #129038]|https://rt.perl.org/Ticket/Display.html?id=129038>
+L<[GH #15543]|https://github.com/Perl/perl5/issues/15543>
 
 =back
 

--- a/pod/perl5243delta.pod
+++ b/pod/perl5243delta.pod
@@ -19,20 +19,20 @@ L<perl5242delta>, which describes differences between 5.24.1 and 5.24.2.
 Compiling certain regular expression patterns with the case-insensitive
 modifier could cause a heap buffer overflow and crash perl.  This has now been
 fixed.
-L<[perl #131582]|https://rt.perl.org/Public/Bug/Display.html?id=131582>
+L<[GH #16021]|https://github.com/Perl/perl5/issues/16021>
 
 =head2 [CVE-2017-12883] Buffer over-read in regular expression parser
 
 For certain types of syntax error in a regular expression pattern, the error
 message could either contain the contents of a random, possibly large, chunk of
 memory, or could crash perl.  This has now been fixed.
-L<[perl #131598]|https://rt.perl.org/Public/Bug/Display.html?id=131598>
+L<[GH #16025]|https://github.com/Perl/perl5/issues/16025>
 
 =head2 [CVE-2017-12814] C<$ENV{$key}> stack buffer overflow on Windows
 
 A possible stack buffer overflow in the C<%ENV> code on Windows has been fixed
 by removing the buffer completely since it was superfluous anyway.
-L<[perl #131665]|https://rt.perl.org/Public/Bug/Display.html?id=131665>
+L<[GH #16051]|https://github.com/Perl/perl5/issues/16051>
 
 =head1 Incompatible Changes
 
@@ -59,9 +59,9 @@ L<POSIX> has been upgraded from version 1.65 to 1.65_01.
 
 L<Time::HiRes> has been upgraded from version 1.9733 to 1.9741.
 
-L<[perl #128427]|https://rt.perl.org/Public/Bug/Display.html?id=128427>
-L<[perl #128445]|https://rt.perl.org/Public/Bug/Display.html?id=128445>
-L<[perl #128972]|https://rt.perl.org/Public/Bug/Display.html?id=128972>
+L<[GH #15396]|https://github.com/Perl/perl5/issues/15396>
+L<[GH #15401]|https://github.com/Perl/perl5/issues/15401>
+L<[GH #15524]|https://github.com/Perl/perl5/issues/15524>
 L<[cpan #120032]|https://rt.cpan.org/Public/Bug/Display.html?id=120032>
 
 =back
@@ -75,19 +75,19 @@ L<[cpan #120032]|https://rt.cpan.org/Public/Bug/Display.html?id=120032>
 When building with GCC 6 and link-time optimization (the B<-flto> option to
 B<gcc>), F<Configure> was treating all probed symbols as present on the system,
 regardless of whether they actually exist.  This has been fixed.
-L<[perl #128131]|https://rt.perl.org/Public/Bug/Display.html?id=128131>
+L<[GH #15322]|https://github.com/Perl/perl5/issues/15322>
 
 =item *
 
 F<Configure> now aborts if both C<-Duselongdouble> and C<-Dusequadmath> are
 requested.
-L<[perl #126203]|https://rt.perl.org/Public/Bug/Display.html?id=126203>
+L<[GH #14944]|https://github.com/Perl/perl5/issues/14944>
 
 =item *
 
 Fixed a bug in which F<Configure> could append C<-quadmath> to the archname
 even if it was already present.
-L<[perl #128538]|https://rt.perl.org/Public/Bug/Display.html?id=128538>
+L<[GH #15423]|https://github.com/Perl/perl5/issues/15423>
 
 =item *
 
@@ -120,7 +120,7 @@ C<configure.com> now recognizes the VSI-branded C compiler.
 
 Building XS modules with GCC 6 in a 64-bit build of Perl failed due to
 incorrect mapping of C<strtoll> and C<strtoull>.  This has now been fixed.
-L<[perl #131726]|https://rt.perl.org/Public/Bug/Display.html?id=131726>
+L<[GH #16074]|https://github.com/Perl/perl5/issues/16074>
 L<[cpan #121683]|https://rt.cpan.org/Public/Bug/Display.html?id=121683>
 L<[cpan #122353]|https://rt.cpan.org/Public/Bug/Display.html?id=122353>
 
@@ -136,14 +136,14 @@ L<[cpan #122353]|https://rt.cpan.org/Public/Bug/Display.html?id=122353>
 
 C<< /@0{0*-E<gt>@*/*0 >> and similar contortions used to crash, but no longer
 do, but merely produce a syntax error.
-L<[perl #128171]|https://rt.perl.org/Public/Bug/Display.html?id=128171>
+L<[GH #15333]|https://github.com/Perl/perl5/issues/15333>
 
 =item *
 
 C<do> or C<require> with an argument which is a reference or typeglob which,
 when stringified, contains a null character, started crashing in Perl 5.20, but
 has now been fixed.
-L<[perl #128182]|https://rt.perl.org/Public/Bug/Display.html?id=128182>
+L<[GH #15337]|https://github.com/Perl/perl5/issues/15337>
 
 =item *
 
@@ -155,88 +155,88 @@ negated non-foldable expression, one of the negations was effectively ignored.
 The same was true of C<if> and C<unless> statement modifiers, though with the
 left-hand and right-hand sides swapped.  This long-standing bug has now been
 fixed.
-L<[perl #127952]|https://rt.perl.org/Public/Bug/Display.html?id=127952>
+L<[GH #15285]|https://github.com/Perl/perl5/issues/15285>
 
 =item *
 
 C<reset> with an argument no longer crashes when encountering stash entries
 other than globs.
-L<[perl #128106]|https://rt.perl.org/Public/Bug/Display.html?id=128106>
+L<[GH #15314]|https://github.com/Perl/perl5/issues/15314>
 
 =item *
 
 Assignment of hashes to, and deletion of, typeglobs named C<*::::::> no longer
 causes crashes.
-L<[perl #128086]|https://rt.perl.org/Public/Bug/Display.html?id=128086>
+L<[GH #15307]|https://github.com/Perl/perl5/issues/15307>
 
 =item *
 
 Assignment variants of any bitwise ops under the C<bitwise> feature would crash
 if the left-hand side was an array or hash.
-L<[perl #128204]|https://rt.perl.org/Public/Bug/Display.html?id=128204>
+L<[GH #15346]|https://github.com/Perl/perl5/issues/15346>
 
 =item *
 
 C<socket> now leaves the error code returned by the system in C<$!> on failure.
-L<[perl #128316]|https://rt.perl.org/Public/Bug/Display.html?id=128316>
+L<[GH #15383]|https://github.com/Perl/perl5/issues/15383>
 
 =item *
 
 Parsing bad POSIX charclasses no longer leaks memory.
-L<[perl #128313]|https://rt.perl.org/Public/Bug/Display.html?id=128313>
+L<[GH #15382]|https://github.com/Perl/perl5/issues/15382>
 
 =item *
 
 Since Perl 5.20, line numbers have been off by one when perl is invoked with
 the B<-x> switch.  This has been fixed.
-L<[perl #128508]|https://rt.perl.org/Public/Bug/Display.html?id=128508>
+L<[GH #15413]|https://github.com/Perl/perl5/issues/15413>
 
 =item *
 
 Some obscure cases of subroutines and file handles being freed at the same time
 could result in crashes, but have been fixed.  The crash was introduced in Perl
 5.22.
-L<[perl #128597]|https://rt.perl.org/Public/Bug/Display.html?id=128597>
+L<[GH #15435]|https://github.com/Perl/perl5/issues/15435>
 
 =item *
 
 Some regular expression parsing glitches could lead to assertion failures with
 regular expressions such as C</(?E<lt>=/> and C</(?E<lt>!/>.  This has now been
 fixed.
-L<[perl #128170]|https://rt.perl.org/Public/Bug/Display.html?id=128170>
+L<[GH #15332]|https://github.com/Perl/perl5/issues/15332>
 
 =item *
 
 C<gethostent> and similar functions now perform a null check internally, to
 avoid crashing with the torsocks library.  This was a regression from Perl
 5.22.
-L<[perl #128740]|https://rt.perl.org/Public/Bug/Display.html?id=128740>
+L<[GH #15478]|https://github.com/Perl/perl5/issues/15478>
 
 =item *
 
 Mentioning the same constant twice in a row (which is a syntax error) no longer
 fails an assertion under debugging builds.  This was a regression from Perl
 5.20.
-L<[perl #126482]|https://rt.perl.org/Public/Bug/Display.html?id=126482>
+L<[GH #15017]|https://github.com/Perl/perl5/issues/15017>
 
 =item *
 
 In Perl 5.24 C<fchown> was changed not to accept negative one as an argument
 because in some platforms that is an error.  However, in some other platforms
 that is an acceptable argument.  This change has been reverted.
-L<[perl #128967]|https://rt.perl.org/Public/Bug/Display.html?id=128967>.
+L<[GH #15523]|https://github.com/Perl/perl5/issues/15523>.
 
 =item *
 
 C<@{x> followed by a newline where C<"x"> represents a control or non-ASCII
 character no longer produces a garbled syntax error message or a crash.
-L<[perl #128951]|https://rt.perl.org/Public/Bug/Display.html?id=128951>
+L<[GH #15518]|https://github.com/Perl/perl5/issues/15518>
 
 =item *
 
 A regression in Perl 5.24 with C<tr/\N{U+...}/foo/> when the code point was
 between 128 and 255 has been fixed.
-L<[perl #128734]|https://rt.perl.org/Public/Bug/Display.html?id=128734>.
+L<[GH #15475]|https://github.com/Perl/perl5/issues/15475>.
 
 =item *
 
@@ -246,30 +246,30 @@ point numbers are now supported both with the plain IEEE 754 floating point
 numbers (64-bit or 128-bit) and the x86 80-bit "extended precision".  Note that
 subnormal hexadecimal floating point literals will give a warning about
 "exponent underflow".
-L<[perl #128843]|https://rt.perl.org/Public/Bug/Display.html?id=128843>
-L<[perl #128888]|https://rt.perl.org/Public/Bug/Display.html?id=128888>
-L<[perl #128889]|https://rt.perl.org/Public/Bug/Display.html?id=128889>
-L<[perl #128890]|https://rt.perl.org/Public/Bug/Display.html?id=128890>
-L<[perl #128893]|https://rt.perl.org/Public/Bug/Display.html?id=128893>
-L<[perl #128909]|https://rt.perl.org/Public/Bug/Display.html?id=128909>
-L<[perl #128919]|https://rt.perl.org/Public/Bug/Display.html?id=128919>
+L<[GH #15495]|https://github.com/Perl/perl5/issues/15495>
+L<[GH #15502]|https://github.com/Perl/perl5/issues/15502>
+L<[GH #15503]|https://github.com/Perl/perl5/issues/15503>
+L<[GH #15504]|https://github.com/Perl/perl5/issues/15504>
+L<[GH #15505]|https://github.com/Perl/perl5/issues/15505>
+L<[GH #15510]|https://github.com/Perl/perl5/issues/15510>
+L<[GH #15512]|https://github.com/Perl/perl5/issues/15512>
 
 =item *
 
 The parser could sometimes crash if a bareword came after C<evalbytes>.
-L<[perl #129196]|https://rt.perl.org/Public/Bug/Display.html?id=129196>
+L<[GH #15586]|https://github.com/Perl/perl5/issues/15586>
 
 =item *
 
 Fixed a place where the regex parser was not setting the syntax error correctly
 on a syntactically incorrect pattern.
-L<[perl #129122]|https://rt.perl.org/Public/Bug/Display.html?id=129122>
+L<[GH #15565]|https://github.com/Perl/perl5/issues/15565>
 
 =item *
 
 A vulnerability in Perl's C<sprintf> implementation has been fixed by avoiding
 a possible memory wrap.
-L<[perl #131260]|https://rt.perl.org/Public/Bug/Display.html?id=131260>
+L<[GH #15970]|https://github.com/Perl/perl5/issues/15970>
 
 =back
 

--- a/pod/perl5244delta.pod
+++ b/pod/perl5244delta.pod
@@ -18,18 +18,18 @@ L<perl5243delta>, which describes differences between 5.24.2 and 5.24.3.
 
 A crafted regular expression could cause a heap buffer write overflow, with
 control over the bytes written.
-L<[perl #132227]|https://rt.perl.org/Public/Bug/Display.html?id=132227>
+L<[GH #16185]|https://github.com/Perl/perl5/issues/16185>
 
 =head2 [CVE-2018-6798] Heap-buffer-overflow in Perl__byte_dump_string (utf8.c)
 
 Matching a crafted locale dependent regular expression could cause a heap
 buffer read overflow and potentially information disclosure.
-L<[perl #132063]|https://rt.perl.org/Public/Bug/Display.html?id=132063>
+L<[GH #16143]|https://github.com/Perl/perl5/issues/16143>
 
 =head2 [CVE-2018-6913] heap-buffer-overflow in S_pack_rec
 
 C<pack()> could cause a heap buffer write overflow with a large item count.
-L<[perl #131844]|https://rt.perl.org/Public/Bug/Display.html?id=131844>
+L<[GH #16098]|https://github.com/Perl/perl5/issues/16098>
 
 =head2 Assertion failure in Perl__core_swash_init (utf8.c)
 
@@ -66,7 +66,7 @@ L<Module::CoreList> has been upgraded from version 5.20170922_24 to 5.20180414_2
 The C<readpipe()> built-in function now checks at compile time that it has only
 one parameter expression, and puts it in scalar context, thus ensuring that it
 doesn't corrupt the stack at runtime.
-L<[perl #4574]|https://rt.perl.org/Public/Bug/Display.html?id=4574>
+L<[GH #2793]|https://github.com/Perl/perl5/issues/2793>
 
 =back
 

--- a/pod/perl5260delta.pod
+++ b/pod/perl5260delta.pod
@@ -433,7 +433,7 @@ to in list context.
 
 This makes the lvalue sub case consistent with C<(keys %hash) = ...> and
 C<(keys @_) = ...>, which are also errors.
-L<[perl #128187]|https://rt.perl.org/Public/Bug/Display.html?id=128187>
+L<[GH #15339]|https://github.com/Perl/perl5/issues/15339>
 
 =head2 The C<${^ENCODING}> facility has been removed
 
@@ -622,7 +622,7 @@ L<B::Deparse> has been upgraded from version 1.37 to 1.40.
 L<B::Xref> has been upgraded from version 1.05 to 1.06.
 
 It now uses 3-arg C<open()> instead of 2-arg C<open()>.
-L<[perl #130122]|https://rt.perl.org/Public/Bug/Display.html?id=130122>
+L<[GH #15721]|https://github.com/Perl/perl5/issues/15721>
 
 =item *
 
@@ -683,14 +683,14 @@ L<Devel::PPPort> has been upgraded from version 3.32 to 3.35.
 L<Devel::SelfStubber> has been upgraded from version 1.05 to 1.06.
 
 It now uses 3-arg C<open()> instead of 2-arg C<open()>.
-L<[perl #130122]|https://rt.perl.org/Public/Bug/Display.html?id=130122>
+L<[GH #15721]|https://github.com/Perl/perl5/issues/15721>
 
 =item *
 
 L<diagnostics> has been upgraded from version 1.34 to 1.36.
 
 It now uses 3-arg C<open()> instead of 2-arg C<open()>.
-L<[perl #130122]|https://rt.perl.org/Public/Bug/Display.html?id=130122>
+L<[GH #15721]|https://github.com/Perl/perl5/issues/15721>
 
 =item *
 
@@ -733,14 +733,14 @@ L<Errno> has been upgraded from version 1.25 to 1.28.
 It now documents that using C<%!> automatically loads Errno for you.
 
 It now uses 3-arg C<open()> instead of 2-arg C<open()>.
-L<[perl #130122]|https://rt.perl.org/Public/Bug/Display.html?id=130122>
+L<[GH #15721]|https://github.com/Perl/perl5/issues/15721>
 
 =item *
 
 L<ExtUtils::Embed> has been upgraded from version 1.33 to 1.34.
 
 It now uses 3-arg C<open()> instead of 2-arg C<open()>.
-L<[perl #130122]|https://rt.perl.org/Public/Bug/Display.html?id=130122>
+L<[GH #15721]|https://github.com/Perl/perl5/issues/15721>
 
 =item *
 
@@ -790,7 +790,7 @@ L<Filter::Simple> has been upgraded from version 0.92 to 0.93.
 
 It no longer treats C<no MyFilter> immediately following C<use MyFilter> as
 end-of-file.
-L<[perl #107726]|https://rt.perl.org/Public/Bug/Display.html?id=107726>
+L<[GH #11853]|https://github.com/Perl/perl5/issues/11853>
 
 =item *
 
@@ -815,7 +815,7 @@ Internal 599-series errors now include the redirect history.
 L<I18N::LangTags> has been upgraded from version 0.40 to 0.42.
 
 It now uses 3-arg C<open()> instead of 2-arg C<open()>.
-L<[perl #130122]|https://rt.perl.org/Public/Bug/Display.html?id=130122>
+L<[GH #15721]|https://github.com/Perl/perl5/issues/15721>
 
 =item *
 
@@ -842,7 +842,7 @@ L<JSON::PP> has been upgraded from version 2.27300 to 2.27400_02.
 L<lib> has been upgraded from version 0.63 to 0.64.
 
 It now uses 3-arg C<open()> instead of 2-arg C<open()>.
-L<[perl #130122]|https://rt.perl.org/Public/Bug/Display.html?id=130122>
+L<[GH #15721]|https://github.com/Perl/perl5/issues/15721>
 
 =item *
 
@@ -920,7 +920,7 @@ L<open> has been upgraded from version 1.10 to 1.11.
 L<OS2::Process> has been upgraded from version 1.11 to 1.12.
 
 It now uses 3-arg C<open()> instead of 2-arg C<open()>.
-L<[perl #130122]|https://rt.perl.org/Public/Bug/Display.html?id=130122>
+L<[GH #15721]|https://github.com/Perl/perl5/issues/15721>
 
 =item *
 
@@ -937,7 +937,7 @@ L<parent> has been upgraded from version 0.234 to 0.236.
 L<perl5db.pl> has been upgraded from version 1.50 to 1.51.
 
 It now ignores F</dev/tty> on non-Unix systems.
-L<[perl #113960]|https://rt.perl.org/Public/Bug/Display.html?id=113960>
+L<[GH #12244]|https://github.com/Perl/perl5/issues/12244>
 
 =item *
 
@@ -988,7 +988,7 @@ L<Pod::Usage> has been upgraded from version 1.68 to 1.69.
 L<POSIX> has been upgraded from version 1.65 to 1.76.
 
 This remedies several defects in making its symbols exportable.
-L<[perl #127821]|https://rt.perl.org/Public/Bug/Display.html?id=127821>
+L<[GH #15260]|https://github.com/Perl/perl5/issues/15260>
 
 The C<POSIX::tmpnam()> interface has been removed,
 see L</"POSIX::tmpnam() has been removed">.
@@ -1042,7 +1042,7 @@ L<Scalar::Util> has been upgraded from version 1.42_02 to 1.46_02.
 L<Storable> has been upgraded from version 2.56 to 2.62.
 
 Fixes
-L<[perl #130098]|https://rt.perl.org/Public/Bug/Display.html?id=130098>.
+L<[GH #15714]|https://github.com/Perl/perl5/issues/15714>.
 
 =item *
 
@@ -1061,14 +1061,14 @@ L<Term::ANSIColor> has been upgraded from version 4.04 to 4.06.
 L<Term::ReadLine> has been upgraded from version 1.15 to 1.16.
 
 It now uses 3-arg C<open()> instead of 2-arg C<open()>.
-L<[perl #130122]|https://rt.perl.org/Public/Bug/Display.html?id=130122>
+L<[GH #15721]|https://github.com/Perl/perl5/issues/15721>
 
 =item *
 
 L<Test> has been upgraded from version 1.28 to 1.30.
 
 It now uses 3-arg C<open()> instead of 2-arg C<open()>.
-L<[perl #130122]|https://rt.perl.org/Public/Bug/Display.html?id=130122>
+L<[GH #15721]|https://github.com/Perl/perl5/issues/15721>
 
 =item *
 
@@ -1122,7 +1122,7 @@ L<Unicode::Collate> has been upgraded from version 1.14 to 1.19.
 L<Unicode::UCD> has been upgraded from version 0.64 to 0.68.
 
 It now uses 3-arg C<open()> instead of 2-arg C<open()>.
-L<[perl #130122]|https://rt.perl.org/Public/Bug/Display.html?id=130122>
+L<[GH #15721]|https://github.com/Perl/perl5/issues/15721>
 
 =item *
 
@@ -1133,7 +1133,7 @@ L<version> has been upgraded from version 0.9916 to 0.9917.
 L<VMS::DCLsym> has been upgraded from version 1.06 to 1.08.
 
 It now uses 3-arg C<open()> instead of 2-arg C<open()>.
-L<[perl #130122]|https://rt.perl.org/Public/Bug/Display.html?id=130122>
+L<[GH #15721]|https://github.com/Perl/perl5/issues/15721>
 
 =item *
 
@@ -1151,7 +1151,7 @@ Fixed a security hole in which binary files could be loaded from a path
 outside of L<C<@INC>|perlvar/@INC>.
 
 It now uses 3-arg C<open()> instead of 2-arg C<open()>.
-L<[perl #130122]|https://rt.perl.org/Public/Bug/Display.html?id=130122>
+L<[GH #15721]|https://github.com/Perl/perl5/issues/15721>
 
 =back
 
@@ -1196,7 +1196,7 @@ and L<C<evalbytes()>|perlfunc/evalbytes>.
 Clarified documentation of L<C<seek()>|perlfunc/seek>,
 L<C<tell()>|perlfunc/tell> and L<C<sysseek()>|perlfunc/sysseek>
 emphasizing that positions are in bytes and not characters.
-L<[perl #128607]|https://rt.perl.org/Public/Bug/Display.html?id=128607>
+L<[GH #15438]|https://github.com/Perl/perl5/issues/15438>
 
 =item *
 
@@ -1631,7 +1631,7 @@ L<Experimental %s on scalar is now forbidden
 |perldiag/Experimental %s on scalar is now forbidden>
 
 This message is now followed by more helpful text.
-L<[perl #127976]|https://rt.perl.org/Public/Bug/Display.html?id=127976>
+L<[GH #15291]|https://github.com/Perl/perl5/issues/15291>
 
 =item *
 
@@ -1931,7 +1931,7 @@ C<-Ddefault_inc_excludes_dot> has added, and enabled by default.
 =item *
 
 The C<dtrace> build process has further changes
-L<[perl #130108]|https://rt.perl.org/Public/Bug/Display.html?id=130108>:
+L<[GH #15718]|https://github.com/Perl/perl5/issues/15718>:
 
 =over
 
@@ -1977,7 +1977,7 @@ C<-Accflags=-DNO_PERL_HASH_SEED_DEBUG>.
 
 F<Configure> now zeroes out the alignment bytes when calculating the bytes
 for 80-bit C<NaN> and C<Inf> to make builds more reproducible.
-L<[perl #130133]|https://rt.perl.org/Public/Bug/Display.html?id=130133>
+L<[GH #15725]|https://github.com/Perl/perl5/issues/15725>
 
 =item *
 
@@ -2015,7 +2015,7 @@ over 750 lines of unhelpful output.
 =item *
 
 Cleanup for C<clang -Weverything> support.
-L<[perl #129961]|https://rt.perl.org/Public/Bug/Display.html?id=129961>
+L<[GH #15683]|https://github.com/Perl/perl5/issues/15683>
 
 =item *
 
@@ -2046,13 +2046,13 @@ readable strings.
 
 F<Configure> now aborts if both C<-Duselongdouble> and C<-Dusequadmath> are
 requested.
-L<[perl #126203]|https://rt.perl.org/Public/Bug/Display.html?id=126203>
+L<[GH #14944]|https://github.com/Perl/perl5/issues/14944>
 
 =item *
 
 Fixed a bug in which F<Configure> could append C<-quadmath> to the
 archname even if it was already present.
-L<[perl #128538]|https://rt.perl.org/Public/Bug/Display.html?id=128538>
+L<[GH #15423]|https://github.com/Perl/perl5/issues/15423>
 
 =item *
 
@@ -2065,7 +2065,7 @@ been fixed (by disabling Thread Safety Analysis for these configurations).
 F<make_ext.pl> no longer updates a module's F<pm_to_blib> file when no
 files require updates.  This could cause dependencies, F<perlmain.c>
 in particular, to be rebuilt unnecessarily.
-L<[perl #126710]|https://rt.perl.org/Public/Bug/Display.html?id=126710>
+L<[GH #15060]|https://github.com/Perl/perl5/issues/15060>
 
 =item *
 
@@ -2079,7 +2079,7 @@ F<Configure> now builds C<miniperl> and C<generate_uudmap> if you
 invoke it with C<-Dusecrosscompiler> but not C<-Dtargethost=somehost>.
 This means you can supply your target platform C<config.sh>, generate
 the headers and proceed to build your cross-target perl.
-L<[perl #127234]|https://rt.perl.org/Public/Bug/Display.html?id=127234>
+L<[GH #15126]|https://github.com/Perl/perl5/issues/15126>
 
 =item *
 
@@ -2092,7 +2092,7 @@ non-zero integer.  This allows C<make test> to pass on such a build.
 When building with GCC 6 and link-time optimization (the C<-flto> option to
 C<gcc>), F<Configure> was treating all probed symbols as present on the
 system, regardless of whether they actually exist.  This has been fixed.
-L<[perl #128131]|https://rt.perl.org/Public/Bug/Display.html?id=128131>
+L<[GH #15322]|https://github.com/Perl/perl5/issues/15322>
 
 =item *
 
@@ -2101,7 +2101,7 @@ also copied by several CPAN modules.  Some of those modules must work on
 older versions of Perl, so F<t/test.pl> must in turn avoid newer Perl
 features.  Compatibility with Perl 5.8 was inadvertently removed some time
 ago; it has now been restored.
-L<[perl #128052]|https://rt.perl.org/Public/Bug/Display.html?id=128052>
+L<[GH #15302]|https://github.com/Perl/perl5/issues/15302>
 
 =item *
 
@@ -2175,13 +2175,13 @@ multiple test files so that they can be run in parallel.
 
 F<t/harness> now tries really hard not to run tests which are located
 outside of the Perl source tree.
-L<[perl #124050]|https://rt.perl.org/Public/Bug/Display.html?id=124050>
+L<[GH #14578]|https://github.com/Perl/perl5/issues/14578>
 
 =item *
 
 Prevent debugger tests (F<lib/perl5db.t>) from failing due to the contents
 of C<$ENV{PERLDB_OPTS}>.
-L<[perl #130445]|https://rt.perl.org/Public/Bug/Display.html?id=130445>
+L<[GH #15782]|https://github.com/Perl/perl5/issues/15782>
 
 =back
 
@@ -2327,7 +2327,7 @@ F<t/uni/overload.t>: Skip hanging test on FreeBSD.
 =item DragonFly BSD
 
 DragonFly BSD now has support for C<setproctitle()>.
-L<[perl #130068]|https://rt.perl.org/Public/Bug/Display.html?id=130068>.
+L<[GH #15703]|https://github.com/Perl/perl5/issues/15703>.
 
 =back
 
@@ -2576,67 +2576,67 @@ often get set on C<PMOP> ops, but had become meaningless over time.
 
 Perl no longer panics when switching into some locales on machines with
 buggy C<strxfrm()> implementations in their F<libc>.
-L<[perl #121734]|https://rt.perl.org/Public/Bug/Display.html?id=121734>
+L<[GH #13768]|https://github.com/Perl/perl5/issues/13768>
 
 =item *
 
 C< $-{$name} > would leak an C<AV> on each access if the regular
 expression had no named captures.  The same applies to access to any
 hash tied with L<Tie::Hash::NamedCapture> and C<< all =E<gt> 1 >>.
-L<[perl #130822]|https://rt.perl.org/Public/Bug/Display.html?id=130822>
+L<[GH #15882]|https://github.com/Perl/perl5/issues/15882>
 
 =item *
 
 Attempting to use the deprecated variable C<$#> as the object in an
 indirect object method call could cause a heap use after free or
 buffer overflow.
-L<[perl #129274]|https://rt.perl.org/Public/Bug/Display.html?id=129274>
+L<[GH #15599]|https://github.com/Perl/perl5/issues/15599>
 
 =item *
 
 When checking for an indirect object method call, in some rare cases
 the parser could reallocate the line buffer but then continue to use
 pointers to the old buffer.
-L<[perl #129190]|https://rt.perl.org/Public/Bug/Display.html?id=129190>
+L<[GH #15585]|https://github.com/Perl/perl5/issues/15585>
 
 =item *
 
 Supplying a glob as the format argument to
 L<C<formline>|perlfunc/formline> would
 cause an assertion failure.
-L<[perl #130722]|https://rt.perl.org/Public/Bug/Display.html?id=130722>
+L<[GH #15862]|https://github.com/Perl/perl5/issues/15862>
 
 =item *
 
 Code like C< $value1 =~ qr/.../ ~~ $value2 > would have the match
 converted into a C<qr//> operator, leaving extra elements on the stack to
 confuse any surrounding expression.
-L<[perl #130705]|https://rt.perl.org/Public/Bug/Display.html?id=130705>
+L<[GH #15859]|https://github.com/Perl/perl5/issues/15859>
 
 =item *
 
 Since v5.24 in some obscure cases, a regex which included code blocks
 from multiple sources (I<e.g.>, via embedded via C<qr//> objects) could end up
 with the wrong current pad and crash or give weird results.
-L<[perl #129881]|https://rt.perl.org/Public/Bug/Display.html?id=129881>
+L<[GH #15657]|https://github.com/Perl/perl5/issues/15657>
 
 =item *
 
 Occasionally C<local()>s in a code block within a patterns weren't being
 undone when the pattern matching backtracked over the code block.
-L<[perl #126697]|https://rt.perl.org/Public/Bug/Display.html?id=126697>
+L<[GH #15056]|https://github.com/Perl/perl5/issues/15056>
 
 =item *
 
 Using C<substr()> to modify a magic variable could access freed memory
 in some cases.
-L<[perl #130766]|https://rt.perl.org/Public/Bug/Display.html?id=130766>
+L<[GH #15871]|https://github.com/Perl/perl5/issues/15871>
 
 =item *
 
 Under C<use utf8>, the entire source code is now checked for being UTF-8
 well formed, not just quoted strings as before.
-L<[perl #126310]|https://rt.perl.org/Public/Bug/Display.html?id=126310>.
+L<[GH #14973]|https://github.com/Perl/perl5/issues/14973>.
 
 =item *
 
@@ -2651,7 +2651,7 @@ The C<split> operator did not ensure enough space was allocated for
 its return value in scalar context.  It could then write a single
 pointer immediately beyond the end of the memory block allocated for
 the stack.
-L<[perl #130262]|https://rt.perl.org/Public/Bug/Display.html?id=130262>
+L<[GH #15749]|https://github.com/Perl/perl5/issues/15749>
 
 =item *
 
@@ -2659,14 +2659,14 @@ Using a large code point with the C<"W"> pack template character with
 the current output position aligned at just the right point could
 cause a write of a single zero byte immediately beyond the end of an
 allocated buffer.
-L<[perl #129149]|https://rt.perl.org/Public/Bug/Display.html?id=129149>
+L<[GH #15572]|https://github.com/Perl/perl5/issues/15572>
 
 =item *
 
 Supplying a format's picture argument as part of the format argument list
 where the picture specifies modifying the argument could cause an
 access to the new freed compiled format.
-L<[perl #129125]|https://rt.perl.org/Public/Bug/Display.html?id=129125>
+L<[GH #15566]|https://github.com/Perl/perl5/issues/15566>
 
 =item *
 
@@ -2674,59 +2674,59 @@ The L<sort()|perlfunc/sort> operator's built-in numeric comparison
 function didn't handle large integers that weren't exactly
 representable by a double.  This now uses the same code used to
 implement the C<< E<lt>=E<gt> >> operator.
-L<[perl #130335]|https://rt.perl.org/Public/Bug/Display.html?id=130335>
+L<[GH #15768]|https://github.com/Perl/perl5/issues/15768>
 
 =item *
 
 Fix issues with C</(?{ ... E<lt>E<lt>EOF })/> that broke
 L<Method::Signatures>.
-L<[perl #130398]|https://rt.perl.org/Public/Bug/Display.html?id=130398>
+L<[GH #15779]|https://github.com/Perl/perl5/issues/15779>
 
 =item *
 
 Fixed an assertion failure with C<chop> and C<chomp>, which
 could be triggered by C<chop(@x =~ tr/1/1/)>.
-L<[perl #130198]|https://rt.perl.org/Public/Bug/Display.html?id=130198>.
+L<[GH #15738]|https://github.com/Perl/perl5/issues/15738>.
 
 =item *
 
 Fixed a comment skipping error in patterns under C</x>; it could stop
 skipping a byte early, which could be in the middle of a UTF-8
 character.
-L<[perl #130495]|https://rt.perl.org/Public/Bug/Display.html?id=130495>.
+L<[GH #15790]|https://github.com/Perl/perl5/issues/15790>.
 
 =item *
 
 F<perldb> now ignores F</dev/tty> on non-Unix systems.
-L<[perl #113960]|https://rt.perl.org/Public/Bug/Display.html?id=113960>;
+L<[GH #12244]|https://github.com/Perl/perl5/issues/12244>;
 
 =item *
 
 Fix assertion failure for C<{}-E<gt>$x> when C<$x> isn't defined.
-L<[perl #130496]|https://rt.perl.org/Public/Bug/Display.html?id=130496>.
+L<[GH #15791]|https://github.com/Perl/perl5/issues/15791>.
 
 =item *
 
 Fix an assertion error which could be triggered when a lookahead string
 in patterns exceeded a minimum length.
-L<[perl #130522]|https://rt.perl.org/Public/Bug/Display.html?id=130522>.
+L<[GH #15796]|https://github.com/Perl/perl5/issues/15796>.
 
 =item *
 
 Only warn once per literal number about a misplaced C<"_">.
-L<[perl #70878]|https://rt.perl.org/Public/Bug/Display.html?id=70878>.
+L<[GH #9989]|https://github.com/Perl/perl5/issues/9989>.
 
 =item *
 
 The C<tr///> parse code could be looking at uninitialized data after a
 perse error.
-L<[perl #129342]|https://rt.perl.org/Public/Bug/Display.html?id=129342>.
+L<[GH #15624]|https://github.com/Perl/perl5/issues/15624>.
 
 =item *
 
 In a pattern match, a back-reference (C<\1>) to an unmatched capture could
 read back beyond the start of the string being matched.
-L<[perl #129377]|https://rt.perl.org/Public/Bug/Display.html?id=129377>.
+L<[GH #15634]|https://github.com/Perl/perl5/issues/15634>.
 
 =item *
 
@@ -2739,19 +2739,19 @@ at C<U+1D7E>.
 
 A sub containing a "forward" declaration with the same name (I<e.g.>,
 C<sub c { sub c; }>) could sometimes crash or loop infinitely.
-L<[perl #129090]|https://rt.perl.org/Public/Bug/Display.html?id=129090>
+L<[GH #15557]|https://github.com/Perl/perl5/issues/15557>
 
 =item *
 
 A crash in executing a regex with a non-anchored UTF-8 substring against a
 target string that also used UTF-8 has been fixed.
-L<[perl #129350]|https://rt.perl.org/Public/Bug/Display.html?id=129350>
+L<[GH #15628]|https://github.com/Perl/perl5/issues/15628>
 
 =item *
 
 Previously, a shebang line like C<#!perl -i u> could be erroneously
 interpreted as requesting the C<-u> option.  This has been fixed.
-L<[perl #129336]|https://rt.perl.org/Public/Bug/Display.html?id=129336>
+L<[GH #15623]|https://github.com/Perl/perl5/issues/15623>
 
 =item *
 
@@ -2761,24 +2761,24 @@ thing; this
 showed up as capture buffers (C<$1>, C<$2>, I<etc.>) erroneously containing data
 from regex execution paths that weren't actually executed for the final
 match.
-L<[perl #129897]|https://rt.perl.org/Public/Bug/Display.html?id=129897>
+L<[GH #15666]|https://github.com/Perl/perl5/issues/15666>
 
 =item *
 
 Certain regexes making use of the experimental C<regex_sets> feature could
 trigger an assertion failure.  This has been fixed.
-L<[perl #129322]|https://rt.perl.org/Public/Bug/Display.html?id=129322>
+L<[GH #15620]|https://github.com/Perl/perl5/issues/15620>
 
 =item *
 
 Invalid assignments to a reference constructor (I<e.g.>, C<\eval=time>) could
 sometimes crash in addition to giving a syntax error.
-L<[perl #125679]|https://rt.perl.org/Public/Bug/Display.html?id=125679>
+L<[GH #14815]|https://github.com/Perl/perl5/issues/14815>
 
 =item *
 
 The parser could sometimes crash if a bareword came after C<evalbytes>.
-L<[perl #129196]|https://rt.perl.org/Public/Bug/Display.html?id=129196>
+L<[GH #15586]|https://github.com/Perl/perl5/issues/15586>
 
 =item *
 
@@ -2786,35 +2786,35 @@ Autoloading via a method call would warn erroneously ("Use of inherited
 AUTOLOAD for non-method") if there was a stub present in the package into
 which the invocant had been blessed.  The warning is no longer emitted in
 such circumstances.
-L<[perl #47047]|https://rt.perl.org/Public/Bug/Display.html?id=47047>
+L<[GH #9094]|https://github.com/Perl/perl5/issues/9094>
 
 =item *
 
 The use of C<splice> on arrays with non-existent elements could cause other
 operators to crash.
-L<[perl #129164]|https://rt.perl.org/Public/Bug/Display.html?id=129164>
+L<[GH #15577]|https://github.com/Perl/perl5/issues/15577>
 
 =item *
 
 A possible buffer overrun when a pattern contains a fixed utf8 substring.
-L<[perl #129012]|https://rt.perl.org/Public/Bug/Display.html?id=129012>
+L<[GH #15534]|https://github.com/Perl/perl5/issues/15534>
 
 =item *
 
 Fixed two possible use-after-free bugs in perl's lexer.
-L<[perl #129069]|https://rt.perl.org/Public/Bug/Display.html?id=129069>
+L<[GH #15549]|https://github.com/Perl/perl5/issues/15549>
 
 =item *
 
 Fixed a crash with C<s///l> where it thought it was dealing with UTF-8
 when it wasn't.
-L<[perl #129038]|https://rt.perl.org/Public/Bug/Display.html?id=129038>
+L<[GH #15543]|https://github.com/Perl/perl5/issues/15543>
 
 =item *
 
 Fixed a place where the regex parser was not setting the syntax error
 correctly on a syntactically incorrect pattern.
-L<[perl #129122]|https://rt.perl.org/Public/Bug/Display.html?id=129122>
+L<[GH #15565]|https://github.com/Perl/perl5/issues/15565>
 
 =item *
 
@@ -2824,18 +2824,18 @@ was marked as utf8 internally.  Many code paths (system calls, regexp
 compilation) still expect there to be a null byte in the string buffer
 just past the end of the logical string.  An assertion failure was the
 result.
-L<[perl #129287]|https://rt.perl.org/Public/Bug/Display.html?id=129287>
+L<[GH #15606]|https://github.com/Perl/perl5/issues/15606>
 
 =item *
 
 Avoid a heap-after-use error in the parser when creating an error messge
 for a syntactically invalid heredoc.
-L<[perl #128988]|https://rt.perl.org/Public/Bug/Display.html?id=128988>
+L<[GH #15527]|https://github.com/Perl/perl5/issues/15527>
 
 =item *
 
 Fix a segfault when run with C<-DC> options on DEBUGGING builds.
-L<[perl #129106]|https://rt.perl.org/Public/Bug/Display.html?id=129106>
+L<[GH #15563]|https://github.com/Perl/perl5/issues/15563>
 
 =item *
 
@@ -2846,14 +2846,14 @@ Fixed the parser error handling in subroutine attributes for an
 
 Fix the perl lexer to correctly handle a backslash as the last char in
 quoted-string context. This actually fixed two bugs,
-L<[perl #129064]|https://rt.perl.org/Public/Bug/Display.html?id=129064> and
-L<[perl #129176]|https://rt.perl.org/Public/Bug/Display.html?id=129176>.
+L<[GH #15546]|https://github.com/Perl/perl5/issues/15546> and
+L<[GH #15582]|https://github.com/Perl/perl5/issues/15582>.
 
 =item *
 
 In the API function C<gv_fetchmethod_pvn_flags>, rework separator parsing
 to prevent possible string overrun with an invalid C<len> argument.
-L<[perl #129267]|https://rt.perl.org/Public/Bug/Display.html?id=129267>
+L<[GH #15598]|https://github.com/Perl/perl5/issues/15598>
 
 =item *
 
@@ -2864,13 +2864,13 @@ were that the contents of C<@a> as seen by sort routines were
 partially sorted; and under some circumstances accessing C<@a> during the
 sort could crash the interpreter.  Both these issues have been fixed, and
 Sort functions see the original value of C<@a>.
-L<[perl #128340]|https://rt.perl.org/Public/Bug/Display.html?id=128340>
+L<[GH #15387]|https://github.com/Perl/perl5/issues/15387>
 
 =item *
 
 Non-ASCII string delimiters are now reported correctly in error messages
 for unterminated strings.
-L<[perl #128701]|https://rt.perl.org/Public/Bug/Display.html?id=128701>
+L<[GH #15469]|https://github.com/Perl/perl5/issues/15469>
 
 =item *
 
@@ -2895,7 +2895,7 @@ C<@-> and C<@+> were already exempt from the warning.)
 
 C<gethostent> and similar functions now perform a null check internally, to
 avoid crashing with the torsocks library.  This was a regression from v5.22.
-L<[perl #128740]|https://rt.perl.org/Public/Bug/Display.html?id=128740>
+L<[GH #15478]|https://github.com/Perl/perl5/issues/15478>
 
 =item *
 
@@ -2907,7 +2907,7 @@ memory if the typeglob in question has never been accessed before.
 Mentioning the same constant twice in a row (which is a syntax error) no
 longer fails an assertion under debugging builds.  This was a regression
 from v5.20.
-L<[perl #126482]|https://rt.perl.org/Public/Bug/Display.html?id=126482>
+L<[GH #15017]|https://github.com/Perl/perl5/issues/15017>
 
 =item *
 
@@ -2917,18 +2917,18 @@ floating point numbers are now supported both with the plain IEEE 754
 floating point numbers (64-bit or 128-bit) and the x86 80-bit
 "extended precision".  Note that subnormal hexadecimal floating
 point literals will give a warning about "exponent underflow".
-L<[perl #128843]|https://rt.perl.org/Public/Bug/Display.html?id=128843>
-L<[perl #128889]|https://rt.perl.org/Public/Bug/Display.html?id=128889>
-L<[perl #128890]|https://rt.perl.org/Public/Bug/Display.html?id=128890>
-L<[perl #128893]|https://rt.perl.org/Public/Bug/Display.html?id=128893>
-L<[perl #128909]|https://rt.perl.org/Public/Bug/Display.html?id=128909>
-L<[perl #128919]|https://rt.perl.org/Public/Bug/Display.html?id=128919>
+L<[GH #15495]|https://github.com/Perl/perl5/issues/15495>
+L<[GH #15503]|https://github.com/Perl/perl5/issues/15503>
+L<[GH #15504]|https://github.com/Perl/perl5/issues/15504>
+L<[GH #15505]|https://github.com/Perl/perl5/issues/15505>
+L<[GH #15510]|https://github.com/Perl/perl5/issues/15510>
+L<[GH #15512]|https://github.com/Perl/perl5/issues/15512>
 
 =item *
 
 A regression in v5.24 with C<tr/\N{U+...}/foo/> when the code point was between
 128 and 255 has been fixed.
-L<[perl #128734]|https://rt.perl.org/Public/Bug/Display.html?id=128734>.
+L<[GH #15475]|https://github.com/Perl/perl5/issues/15475>.
 
 =item *
 
@@ -2939,52 +2939,52 @@ with special meaning (such as C<"?"> in C<m?...?>), resulting
 in inconsistent behaviour.  Note that this is non-portable,
 and is based on Perl's extension to UTF-8, and is probably not
 displayable nor enterable by any editor.
-L<[perl #128738]|https://rt.perl.org/Public/Bug/Display.html?id=128738>
+L<[GH #15477]|https://github.com/Perl/perl5/issues/15477>
 
 =item *
 
 C<@{x> followed by a newline where C<"x"> represents a control or non-ASCII
 character no longer produces a garbled syntax error message or a crash.
-L<[perl #128951]|https://rt.perl.org/Public/Bug/Display.html?id=128951>
+L<[GH #15518]|https://github.com/Perl/perl5/issues/15518>
 
 =item *
 
 An assertion failure with C<%: = 0> has been fixed.
-L<[perl #128238]|https://rt.perl.org/Public/Bug/Display.html?id=128238>
+L<[GH #15358]|https://github.com/Perl/perl5/issues/15358>
 
 =item *
 
 In Perl 5.18, the parsing of C<"$foo::$bar"> was accidentally changed, such
 that it would be treated as C<$foo."::".$bar>.  The previous behavior, which
 was to parse it as C<$foo:: . $bar>, has been restored.
-L<[perl #128478]|https://rt.perl.org/Public/Bug/Display.html?id=128478>
+L<[GH #15408]|https://github.com/Perl/perl5/issues/15408>
 
 =item *
 
 Since Perl 5.20, line numbers have been off by one when perl is invoked with
 the B<-x> switch.  This has been fixed.
-L<[perl #128508]|https://rt.perl.org/Public/Bug/Display.html?id=128508>
+L<[GH #15413]|https://github.com/Perl/perl5/issues/15413>
 
 =item *
 
 Vivifying a subroutine stub in a deleted stash (I<e.g.>,
 C<delete $My::{"Foo::"}; \&My::Foo::foo>) no longer crashes.  It had begun
 crashing in Perl 5.18.
-L<[perl #128532]|https://rt.perl.org/Public/Bug/Display.html?id=128532>
+L<[GH #15420]|https://github.com/Perl/perl5/issues/15420>
 
 =item *
 
 Some obscure cases of subroutines and file handles being freed at the same time
 could result in crashes, but have been fixed.  The crash was introduced in Perl
 5.22.
-L<[perl #128597]|https://rt.perl.org/Public/Bug/Display.html?id=128597>
+L<[GH #15435]|https://github.com/Perl/perl5/issues/15435>
 
 =item *
 
 Code that looks for a variable name associated with an uninitialized value
 could cause an assertion failure in cases where magic is involved, such as
 C<$ISA[0][0]>.  This has now been fixed.
-L<[perl #128253]|https://rt.perl.org/Public/Bug/Display.html?id=128253>
+L<[GH #15364]|https://github.com/Perl/perl5/issues/15364>
 
 =item *
 
@@ -2992,7 +2992,7 @@ A crash caused by code generating the warning "Subroutine STASH::NAME
 redefined" in cases such as C<sub P::f{} undef *P::; *P::f =sub{};> has been
 fixed.  In these cases, where the STASH is missing, the warning will now appear
 as "Subroutine NAME redefined".
-L<[perl #128257]|https://rt.perl.org/Public/Bug/Display.html?id=128257>
+L<[GH #15368]|https://github.com/Perl/perl5/issues/15368>
 
 =item *
 
@@ -3003,44 +3003,44 @@ formats, I<e.g.>, in cases like this:
     @
     0"$x"
 
-L<[perl #128255]|https://rt.perl.org/Public/Bug/Display.html?id=128255>
+L<[GH #15366]|https://github.com/Perl/perl5/issues/15366>
 
 =item *
 
 A possible divide by zero in string transformation code on Windows has been
 avoided, fixing a crash when collating an empty string.
-L<[perl #128618]|https://rt.perl.org/Public/Bug/Display.html?id=128618>
+L<[GH #15439]|https://github.com/Perl/perl5/issues/15439>
 
 =item *
 
 Some regular expression parsing glitches could lead to assertion failures with
 regular expressions such as C</(?E<lt>=/> and C</(?E<lt>!/>.  This has now been fixed.
-L<[perl #128170]|https://rt.perl.org/Public/Bug/Display.html?id=128170>
+L<[GH #15332]|https://github.com/Perl/perl5/issues/15332>
 
 =item *
 
 C< until ($x = 1) { ... } > and C< ... until $x = 1 > now properly
 warn when syntax warnings are enabled.
-L<[perl #127333]|https://rt.perl.org/Public/Bug/Display.html?id=127333>
+L<[GH #15138]|https://github.com/Perl/perl5/issues/15138>
 
 =item *
 
 socket() now leaves the error code returned by the system in C<$!> on
 failure.
-L<[perl #128316]|https://rt.perl.org/Public/Bug/Display.html?id=128316>
+L<[GH #15383]|https://github.com/Perl/perl5/issues/15383>
 
 =item *
 
 Assignment variants of any bitwise ops under the C<bitwise> feature would
 crash if the left-hand side was an array or hash.
-L<[perl #128204]|https://rt.perl.org/Public/Bug/Display.html?id=128204>
+L<[GH #15346]|https://github.com/Perl/perl5/issues/15346>
 
 =item *
 
 C<require> followed by a single colon (as in C<foo() ? require : ...> is
 now parsed correctly as C<require> with implicit C<$_>, rather than
 C<require "">.
-L<[perl #128307]|https://rt.perl.org/Public/Bug/Display.html?id=128307>
+L<[GH #15380]|https://github.com/Perl/perl5/issues/15380>
 
 =item *
 
@@ -3053,7 +3053,7 @@ List assignment to C<vec> or C<substr> with an array or hash for its first
 argument used to result in crashes or "Can't coerce" error messages at run
 time, unlike scalar assignment, which would give an error at compile time.
 List assignment now gives a compile-time error, too.
-L<[perl #128260]|https://rt.perl.org/Public/Bug/Display.html?id=128260>
+L<[GH #15370]|https://github.com/Perl/perl5/issues/15370>
 
 =item *
 
@@ -3065,19 +3065,19 @@ a negated non-foldable expression, one of the negations was effectively
 ignored.  The same was true of C<if> and C<unless> statement modifiers,
 though with the left-hand and right-hand sides swapped.  This long-standing
 bug has now been fixed.
-L<[perl #127952]|https://rt.perl.org/Public/Bug/Display.html?id=127952>
+L<[GH #15285]|https://github.com/Perl/perl5/issues/15285>
 
 =item *
 
 C<reset> with an argument no longer crashes when encountering stash entries
 other than globs.
-L<[perl #128106]|https://rt.perl.org/Public/Bug/Display.html?id=128106>
+L<[GH #15314]|https://github.com/Perl/perl5/issues/15314>
 
 =item *
 
 Assignment of hashes to, and deletion of, typeglobs named C<*::::::> no
 longer causes crashes.
-L<[perl #128086]|https://rt.perl.org/Public/Bug/Display.html?id=128086>
+L<[GH #15307]|https://github.com/Perl/perl5/issues/15307>
 
 =item *
 
@@ -3090,12 +3090,12 @@ This could trigger an assertion failure in something like the following:
     }
 
 This was a regression from v5.24.
-L<[perl #129991]|https://rt.perl.org/Public/Bug/Display.html?id=129991>
+L<[GH #15690]|https://github.com/Perl/perl5/issues/15690>
 
 =item *
 
 Assertion failure with user-defined Unicode-like properties.
-L<[perl #130010]|https://rt.perl.org/Public/Bug/Display.html?id=130010>
+L<[GH #15696]|https://github.com/Perl/perl5/issues/15696>
 
 =item *
 
@@ -3124,31 +3124,31 @@ stack (not the normal perl stack) when the last successful pattern in
 scope is itself.  We avoid the segfault by simply forbidding the use of
 the empty pattern when it would resolve to the currently executing
 pattern.
-L<[perl #129903]|https://rt.perl.org/Public/Bug/Display.html?id=129903>
+L<[GH #15669]|https://github.com/Perl/perl5/issues/15669>
 
 =item *
 
 Avoid reading beyond the end of the line buffer in perl's lexer when
 there's a short UTF-8 character at the end.
-L<[perl #128997]|https://rt.perl.org/Public/Bug/Display.html?id=128997>
+L<[GH #15531]|https://github.com/Perl/perl5/issues/15531>
 
 =item *
 
 Alternations in regular expressions were sometimes failing to match
 a utf8 string against a utf8 alternate.
-L<[perl #129950]|https://rt.perl.org/Public/Bug/Display.html?id=129950>
+L<[GH #15680]|https://github.com/Perl/perl5/issues/15680>
 
 =item *
 
 Make C<do "a\0b"> fail silently (and return C<undef> and set C<$!>)
 instead of throwing an error.
-L<[perl #129928]|https://rt.perl.org/Public/Bug/Display.html?id=129928>
+L<[GH #15676]|https://github.com/Perl/perl5/issues/15676>
 
 =item *
 
 C<chdir> with no argument didn't ensure that there was stack space
 available for returning its result.
-L<[perl #129130]|https://rt.perl.org/Public/Bug/Display.html?id=129130>
+L<[GH #15569]|https://github.com/Perl/perl5/issues/15569>
 
 =item *
 
@@ -3167,7 +3167,7 @@ Code like C<$x = $x . "a"> was incorrectly failing to yield a
 L<use of uninitialized value|perldiag/"Use of uninitialized value%s">
 warning when C<$x> was a lexical variable with an undefined value. That has
 now been fixed.
-L<[perl #127877]|https://rt.perl.org/Public/Bug/Display.html?id=127877>
+L<[GH #15269]|https://github.com/Perl/perl5/issues/15269>
 
 =item *
 
@@ -3185,7 +3185,7 @@ overloaded object, bringing it into consistency with C<$$scalar>.
 
 C<< /@0{0*-E<gt>@*/*0 >> and similar contortions used to crash, but no longer
 do, but merely produce a syntax error.
-L<[perl #128171]|https://rt.perl.org/Public/Bug/Display.html?id=128171>
+L<[GH #15333]|https://github.com/Perl/perl5/issues/15333>
 
 =item *
 
@@ -3193,7 +3193,7 @@ C<do> or C<require> with an argument which is a reference or typeglob
 which, when stringified,
 contains a null character, started crashing in Perl 5.20, but has now been
 fixed.
-L<[perl #128182]|https://rt.perl.org/Public/Bug/Display.html?id=128182>
+L<[GH #15337]|https://github.com/Perl/perl5/issues/15337>
 
 =item *
 
@@ -3204,7 +3204,7 @@ calls.
 =item *
 
 Parsing bad POSIX charclasses no longer leaks memory.
-L<[perl #128313]|https://rt.perl.org/Public/Bug/Display.html?id=128313>
+L<[GH #15382]|https://github.com/Perl/perl5/issues/15382>
 
 =back
 
@@ -3218,7 +3218,7 @@ G++ 6 handles subnormal (denormal) floating point values differently
 than gcc 6 or g++ 5 resulting in "flush-to-zero". The end result is
 that if you specify very small values using the hexadecimal floating
 point format, like C<0x1.fffffffffffffp-1022>, they become zeros.
-L<[perl #131388]|https://rt.perl.org/Ticket/Display.html?id=131388>
+L<[GH #15990]|https://github.com/Perl/perl5/issues/15990>
 
 =back 
 
@@ -3229,7 +3229,7 @@ L<[perl #131388]|https://rt.perl.org/Ticket/Display.html?id=131388>
 =item *
 
 Fixed issues with recursive regexes.  The behavior was fixed in Perl 5.24.
-L<[perl #126182]|https://rt.perl.org/Public/Bug/Display.html?id=126182>
+L<[GH #14935]|https://github.com/Perl/perl5/issues/14935>
 
 =back
 

--- a/pod/perl5261delta.pod
+++ b/pod/perl5261delta.pod
@@ -19,20 +19,20 @@ L<perl5260delta>, which describes differences between 5.24.0 and 5.26.0.
 Compiling certain regular expression patterns with the case-insensitive
 modifier could cause a heap buffer overflow and crash perl.  This has now been
 fixed.
-L<[perl #131582]|https://rt.perl.org/Public/Bug/Display.html?id=131582>
+L<[GH #16021]|https://github.com/Perl/perl5/issues/16021>
 
 =head2 [CVE-2017-12883] Buffer over-read in regular expression parser
 
 For certain types of syntax error in a regular expression pattern, the error
 message could either contain the contents of a random, possibly large, chunk of
 memory, or could crash perl.  This has now been fixed.
-L<[perl #131598]|https://rt.perl.org/Public/Bug/Display.html?id=131598>
+L<[GH #16025]|https://github.com/Perl/perl5/issues/16025>
 
 =head2 [CVE-2017-12814] C<$ENV{$key}> stack buffer overflow on Windows
 
 A possible stack buffer overflow in the C<%ENV> code on Windows has been fixed
 by removing the buffer completely since it was superfluous anyway.
-L<[perl #131665]|https://rt.perl.org/Public/Bug/Display.html?id=131665>
+L<[GH #16051]|https://github.com/Perl/perl5/issues/16051>
 
 =head1 Incompatible Changes
 
@@ -77,7 +77,7 @@ L<Module::CoreList> has been upgraded from version 5.20170530 to 5.20170922_26.
 =item *
 
 Building with B<g++> on FreeBSD-11.0 has been fixed.
-L<[perl #131337]|https://rt.perl.org/Public/Bug/Display.html?id=131337>
+L<[GH #15984]|https://github.com/Perl/perl5/issues/15984>
 
 =back
 
@@ -94,7 +94,7 @@ Support for compiling perl on Windows using Microsoft Visual Studio 2017
 
 Building XS modules with GCC 6 in a 64-bit build of Perl failed due to
 incorrect mapping of C<strtoll> and C<strtoull>.  This has now been fixed.
-L<[perl #131726]|https://rt.perl.org/Public/Bug/Display.html?id=131726>
+L<[GH #16074]|https://github.com/Perl/perl5/issues/16074>
 L<[cpan #121683]|https://rt.cpan.org/Public/Bug/Display.html?id=121683>
 L<[cpan #122353]|https://rt.cpan.org/Public/Bug/Display.html?id=122353>
 
@@ -113,19 +113,19 @@ to the internal stack without allocating room for the item being written.  In
 rare situations, this could have led to a crash.  These bugs have now been
 fixed, and if any similar bugs are introduced in future, they will be detected
 automatically in debugging builds.
-L<[perl #131732]|https://rt.perl.org/Public/Bug/Display.html?id=131732>
+L<[GH #16076]|https://github.com/Perl/perl5/issues/16076>
 
 =item *
 
 Using a symbolic ref with postderef syntax as the key in a hash lookup was
 yielding an assertion failure on debugging builds.
-L<[perl #131627]|https://rt.perl.org/Public/Bug/Display.html?id=131627>
+L<[GH #16029]|https://github.com/Perl/perl5/issues/16029>
 
 =item *
 
 List assignment (C<aassign>) could in some rare cases allocate an entry on the
 mortal stack and leave the entry uninitialized.
-L<[perl #131570]|https://rt.perl.org/Public/Bug/Display.html?id=131570>
+L<[GH #16017]|https://github.com/Perl/perl5/issues/16017>
 
 =item *
 
@@ -139,41 +139,41 @@ L<[perl #131597]|https://rt.perl.org/Public/Bug/Display.html?id=131597>
 The code that vivifies a typeglob out of a code ref made some false assumptions
 that could lead to a crash in cases such as C<< $::{"A"} = sub {}; \&{"A"} >>.
 This has now been fixed.
-L<[perl #131085]|https://rt.perl.org/Public/Bug/Display.html?id=131085>
+L<[GH #15937]|https://github.com/Perl/perl5/issues/15937>
 
 =item *
 
 C<my_atof2> no longer reads beyond the terminating NUL, which previously
 occurred if the decimal point is immediately before the NUL.
-L<[perl #131526]|https://rt.perl.org/Public/Bug/Display.html?id=131526>
+L<[GH #16002]|https://github.com/Perl/perl5/issues/16002>
 
 =item *
 
 Occasional "Malformed UTF-8 character" crashes in C<s//> on utf8 strings have
 been fixed.
-L<[perl #131575]|https://rt.perl.org/Public/Bug/Display.html?id=131575>
+L<[GH #16019]|https://github.com/Perl/perl5/issues/16019>
 
 =item *
 
 C<perldoc -f s> now finds C<s///>.
-L<[perl #131371]|https://rt.perl.org/Public/Bug/Display.html?id=131371>
+L<[GH #15989]|https://github.com/Perl/perl5/issues/15989>
 
 =item *
 
 Some erroneous warnings after utf8 conversion have been fixed.
-L<[perl #131190]|https://rt.perl.org/Public/Bug/Display.html?id=131190>
+L<[GH #15958]|https://github.com/Perl/perl5/issues/15958>
 
 =item *
 
 The C<jmpenv> frame to catch Perl exceptions is set up lazily, and this used to
 be a bit too lazy.  The catcher is now set up earlier, preventing some possible
 crashes.
-L<[perl #105930]|https://rt.perl.org/Public/Bug/Display.html?id=105930>
+L<[GH #11804]|https://github.com/Perl/perl5/issues/11804>
 
 =item *
 
 Spurious "Assuming NOT a POSIX class" warnings have been removed.
-L<[perl #131522]|https://rt.perl.org/Public/Bug/Display.html?id=131522>
+L<[GH #16001]|https://github.com/Perl/perl5/issues/16001>
 
 =back
 

--- a/pod/perl5262delta.pod
+++ b/pod/perl5262delta.pod
@@ -18,18 +18,18 @@ L<perl5261delta>, which describes differences between 5.26.0 and 5.26.1.
 
 A crafted regular expression could cause a heap buffer write overflow, with
 control over the bytes written.
-L<[perl #132227]|https://rt.perl.org/Public/Bug/Display.html?id=132227>
+L<[GH #16185]|https://github.com/Perl/perl5/issues/16185>
 
 =head2 [CVE-2018-6798] Heap-buffer-overflow in Perl__byte_dump_string (utf8.c)
 
 Matching a crafted locale dependent regular expression could cause a heap
 buffer read overflow and potentially information disclosure.
-L<[perl #132063]|https://rt.perl.org/Public/Bug/Display.html?id=132063>
+L<[GH #16143]|https://github.com/Perl/perl5/issues/16143>
 
 =head2 [CVE-2018-6913] heap-buffer-overflow in S_pack_rec
 
 C<pack()> could cause a heap buffer write overflow with a large item count.
-L<[perl #131844]|https://rt.perl.org/Public/Bug/Display.html?id=131844>
+L<[GH #16098]|https://github.com/Perl/perl5/issues/16098>
 
 =head2 Assertion failure in Perl__core_swash_init (utf8.c)
 
@@ -97,11 +97,11 @@ points that match this property: U+200C (ZERO WIDTH NON-JOINER) and U+200D
 
 Visual C++ compiler version detection has been improved to work on non-English
 language systems.
-L<[perl #132421]|https://rt.perl.org/Public/Bug/Display.html?id=132421>
+L<[GH #16235]|https://github.com/Perl/perl5/issues/16235>
 
 We now set C<$Config{libpth}> correctly for 64-bit builds using Visual C++
 versions earlier than 14.1.
-L<[perl #132484]|https://rt.perl.org/Public/Bug/Display.html?id=132484>
+L<[GH #16269]|https://github.com/Perl/perl5/issues/16269>
 
 =back
 
@@ -114,18 +114,18 @@ L<[perl #132484]|https://rt.perl.org/Public/Bug/Display.html?id=132484>
 The C<readpipe()> built-in function now checks at compile time that it has only
 one parameter expression, and puts it in scalar context, thus ensuring that it
 doesn't corrupt the stack at runtime.
-L<[perl #4574]|https://rt.perl.org/Public/Bug/Display.html?id=4574>
+L<[GH #2793]|https://github.com/Perl/perl5/issues/2793>
 
 =item *
 
 Fixed a use after free bug in C<pp_list> introduced in Perl 5.27.1.
-L<[perl #131954]|https://rt.perl.org/Public/Bug/Display.html?id=131954>
+L<[GH #16124]|https://github.com/Perl/perl5/issues/16124>
 
 =item *
 
 Parsing a C<sub> definition could cause a use after free if the C<sub> keyword
 was followed by whitespace including newlines (and comments).
-L<[perl #131836]|https://rt.perl.org/Public/Bug/Display.html?id=131836>
+L<[GH #16097]|https://github.com/Perl/perl5/issues/16097>
 
 =item *
 
@@ -137,26 +137,26 @@ L<[perl #131949]|https://rt.perl.org/Public/Bug/Display.html?id=131949>
 
 Accesses to C<${^LAST_FH}> no longer assert after using any of a variety of I/O
 operations on a non-glob.
-L<[perl #128263]|https://rt.perl.org/Public/Bug/Display.html?id=128263>
+L<[GH #15372]|https://github.com/Perl/perl5/issues/15372>
 
 =item *
 
 C<sort> now performs correct reference counting when aliasing C<$a> and C<$b>,
 thus avoiding premature destruction and leakage of scalars if they are
 re-aliased during execution of the sort comparator.
-L<[perl #92264]|https://rt.perl.org/Public/Bug/Display.html?id=92264>
+L<[GH #11422]|https://github.com/Perl/perl5/issues/11422>
 
 =item *
 
 Some convoluted kinds of regexp no longer cause an arithmetic overflow when
 compiled.
-L<[perl #131893]|https://rt.perl.org/Public/Bug/Display.html?id=131893>
+L<[GH #16113]|https://github.com/Perl/perl5/issues/16113>
 
 =item *
 
 Fixed a duplicate symbol failure with B<-flto -mieee-fp> builds.  F<pp.c>
 defined C<_LIB_VERSION> which B<-lieee> already defines.
-L<[perl #131786]|https://rt.perl.org/Public/Bug/Display.html?id=131786>
+L<[GH #16086]|https://github.com/Perl/perl5/issues/16086>
 
 =item *
 
@@ -172,7 +172,7 @@ earlier.
 Previously compilation could continue in order to report other errors, but the
 failed sub-parse could leave partly parsed constructs on the parser
 shift-reduce stack, confusing the parser, leading to perl crashes.
-L<[perl #125351]|https://rt.perl.org/Public/Bug/Display.html?id=125351>
+L<[GH #14739]|https://github.com/Perl/perl5/issues/14739>
 
 =back
 

--- a/pod/perl5263delta.pod
+++ b/pod/perl5263delta.pod
@@ -20,7 +20,7 @@ By default, L<Archive::Tar> doesn't allow extracting files outside the current
 working directory.  However, this secure extraction mode could be bypassed by
 putting a symlink and a regular file with the same name into the tar file.
 
-L<[perl #133250]|https://rt.perl.org/Ticket/Display.html?id=133250>
+L<[GH #16580]|https://github.com/Perl/perl5/issues/16580>
 L<[cpan #125523]|https://rt.cpan.org/Ticket/Display.html?id=125523>
 
 =head2 [CVE-2018-18311] Integer overflow leading to buffer overflow and segmentation fault
@@ -30,28 +30,28 @@ of the environment variable name and value exceeded around 0x7fffffff.  This
 could lead to writing beyond the end of an allocated buffer with attacker
 supplied data.
 
-L<[perl #133204]|https://rt.perl.org/Ticket/Display.html?id=133204>
+L<[GH #16560]|https://github.com/Perl/perl5/issues/16560>
 
 =head2 [CVE-2018-18312] Heap-buffer-overflow write in S_regatom (regcomp.c)
 
 A crafted regular expression could cause heap-buffer-overflow write during
 compilation, potentially allowing arbitrary code execution.
 
-L<[perl #133423]|https://rt.perl.org/Ticket/Display.html?id=133423>
+L<[GH #16649]|https://github.com/Perl/perl5/issues/16649>
 
 =head2 [CVE-2018-18313] Heap-buffer-overflow read in S_grok_bslash_N (regcomp.c)
 
 A crafted regular expression could cause heap-buffer-overflow read during
 compilation, potentially leading to sensitive information being leaked.
 
-L<[perl #133192]|https://rt.perl.org/Ticket/Display.html?id=133192>
+L<[GH #16554]|https://github.com/Perl/perl5/issues/16554>
 
 =head2 [CVE-2018-18314] Heap-buffer-overflow write in S_regatom (regcomp.c)
 
 A crafted regular expression could cause heap-buffer-overflow write during
 compilation, potentially allowing arbitrary code execution.
 
-L<[perl #131649]|https://rt.perl.org/Ticket/Display.html?id=131649>
+L<[GH #16041]|https://github.com/Perl/perl5/issues/16041>
 
 =head1 Incompatible Changes
 

--- a/pod/perl5280delta.pod
+++ b/pod/perl5280delta.pod
@@ -24,7 +24,7 @@ L<http://www.unicode.org/versions/Unicode10.0.0>.
 L<C<delete>|perlfunc/delete EXPR> can now be used on
 L<keyE<sol>value hash slices|perldata/KeyE<sol>Value Hash Slices>,
 returning the keys along with the deleted values.
-L<[perl #131328]|https://rt.perl.org/Ticket/Display.html?id=131328>
+L<[GH #15982]|https://github.com/Perl/perl5/issues/15982>
 
 =head2 Experimentally, there are now alphabetic synonyms for some regular expression assertions
 
@@ -111,7 +111,7 @@ functions, the final rename step may fail.
 
 =back
 
-L<[perl #127663]|https://rt.perl.org/Public/Bug/Display.html?id=127663>
+L<[GH #15216]|https://github.com/Perl/perl5/issues/15216>
 
 =head2 Initialisation of aggregate state variables
 
@@ -205,20 +205,20 @@ operation (see previous item).
 Compiling certain regular expression patterns with the case-insensitive
 modifier could cause a heap buffer overflow and crash perl.  This has now been
 fixed.
-L<[perl #131582]|https://rt.perl.org/Public/Bug/Display.html?id=131582>
+L<[GH #16021]|https://github.com/Perl/perl5/issues/16021>
 
 =head2 [CVE-2017-12883] Buffer over-read in regular expression parser
 
 For certain types of syntax error in a regular expression pattern, the error
 message could either contain the contents of a random, possibly large, chunk of
 memory, or could crash perl.  This has now been fixed.
-L<[perl #131598]|https://rt.perl.org/Public/Bug/Display.html?id=131598>
+L<[GH #16025]|https://github.com/Perl/perl5/issues/16025>
 
 =head2 [CVE-2017-12814] C<$ENV{$key}> stack buffer overflow on Windows
 
 A possible stack buffer overflow in the C<%ENV> code on Windows has been fixed
 by removing the buffer completely since it was superfluous anyway.
-L<[perl #131665]|https://rt.perl.org/Public/Bug/Display.html?id=131665>
+L<[GH #16051]|https://github.com/Perl/perl5/issues/16051>
 
 =head2 Default Hash Function Change
 
@@ -322,7 +322,7 @@ This has been deprecated since Perl 5.22 and a no-op since Perl 5.26.
 
 Previously the C<-S> switch incorrectly treated backslash ("\") as an
 escape for colon when traversing the C<PATH> environment variable.
-L<[perl #129183]|https://rt.perl.org/Ticket/Display.html?id=129183>
+L<[GH #15584]|https://github.com/Perl/perl5/issues/15584>
 
 =head2 the -DH (DEBUG_H) misfeature has been removed
 
@@ -357,7 +357,7 @@ portable beyond Perl 5.8.  These subpragmata have now been deleted,
 and any attempt to use them is an error.  The L<sort> pragma otherwise
 remains, and the algorithm-neutral C<stable> subpragma can be used to
 control sorting behaviour.
-L<[perl #119635]|https://rt.perl.org/Ticket/Display.html?id=119635>
+L<[GH #13234]|https://github.com/Perl/perl5/issues/13234>
 
 =head2 Over-radix digits in floating point literals
 
@@ -415,7 +415,7 @@ now been scheduled for Perl 5.30.
 
 Passing arguments to C<Sys::Hostname::hostname()> was already deprecated,
 but didn't have a removal date.  This has now been scheduled for Perl
-5.32.  L<[perl #124349]|https://rt.perl.org/Ticket/Display.html?id=124349>
+5.32.  L<[GH #14662]|https://github.com/Perl/perl5/issues/14662>
 
 =head2 Module removals
 
@@ -521,12 +521,12 @@ Various integer-returning ops are now more efficient in scalar/boolean context.
 =item *
 
 Slightly improved performance when parsing stash names.
-L<[perl #129990]|https://rt.perl.org/Public/Bug/Display.html?id=129990>
+L<[GH #15689]|https://github.com/Perl/perl5/issues/15689>
 
 =item *
 
 Calls to C<require> for an already loaded module are now slightly faster.
-L<[perl #132171]|https://rt.perl.org/Public/Bug/Display.html?id=132171>
+L<[GH #16175]|https://github.com/Perl/perl5/issues/16175>
 
 =item *
 
@@ -642,13 +642,13 @@ longer throws a "Not a GLOB reference" error.
 
 L<Carp>, when generating stack traces, now attempts to work around
 longstanding bugs resulting from Perl's non-reference-counted stack.
-L<[perl #52610]|https://rt.perl.org/Ticket/Display.html?id=52610>
+L<[GH #9282]|https://github.com/Perl/perl5/issues/9282>
 
 Carp has been modified to avoid assuming that objects cannot be
 overloaded without the L<overload> module loaded (this can happen with
 objects created by XS modules).  Previously, infinite recursion would
 result if an XS-defined overload method itself called Carp.
-L<[perl #132828]|https://rt.perl.org/Ticket/Display.html?id=132828>
+L<[GH #16407]|https://github.com/Perl/perl5/issues/16407>
 
 Carp now avoids using C<overload::StrVal>, partly because older versions
 of L<overload> (included with perl 5.14 and earlier) load L<Scalar::Util>
@@ -682,11 +682,11 @@ L<CPAN> has been upgraded from version 2.18 to 2.20.
 L<Data::Dumper> has been upgraded from version 2.167 to 2.170.
 
 Quoting of glob names now obeys the Useqq option
-L<[perl #119831]|https://rt.perl.org/Ticket/Display.html?id=119831>.
+L<[GH #13274]|https://github.com/Perl/perl5/issues/13274>.
 
 Attempts to set an option to C<undef> through a combined getter/setter
 method are no longer mistaken for getter calls
-L<[perl #113090]|https://rt.perl.org/Ticket/Display.html?id=113090>.
+L<[GH #12135]|https://github.com/Perl/perl5/issues/12135>.
 
 =item *
 
@@ -717,7 +717,7 @@ L<DynaLoader> has been upgraded from version 1.42 to 1.45.
 
 Its documentation now shows the use of C<__PACKAGE__> and direct object
 syntax
-L<[perl #132247]|https://rt.perl.org/Ticket/Display.html?id=132247>.
+L<[GH #16190]|https://github.com/Perl/perl5/issues/16190>.
 
 =item *
 
@@ -789,7 +789,7 @@ L<File::Copy> has been upgraded from version 2.32 to 2.33.
 
 It will now use the sub-second precision variant of utime() supplied by
 L<Time::HiRes> where available.
-L<[perl #132401]|https://rt.perl.org/Ticket/Display.html?id=132401>.
+L<[GH #16225]|https://github.com/Perl/perl5/issues/16225>.
 
 =item *
 
@@ -829,11 +829,11 @@ L<GDBM_File> has been upgraded from version 1.15 to 1.17.
 
 Its documentation now explains that C<each> and C<delete> don't mix in
 hashes tied to this module
-L<[perl #117449]|https://rt.perl.org/Ticket/Display.html?id=117449>.
+L<[GH #12894]|https://github.com/Perl/perl5/issues/12894>.
 
 It will now retry opening with an acceptable block size if asking gdbm
 to default the block size failed
-L<[perl #119623]|https://rt.perl.org/Ticket/Display.html?id=119623>.
+L<[GH #13232]|https://github.com/Perl/perl5/issues/13232>.
 
 =item *
 
@@ -855,7 +855,7 @@ those systems, always returning C<"">.
 
 It now sets the UTF-8 flag in its returned scalar if the string contains
 legal non-ASCII UTF-8, and the locale is UTF-8
-L<[perl #127288]|https://rt.perl.org/Ticket/Display.html?id=127288>.
+L<[GH #15131]|https://github.com/Perl/perl5/issues/15131>.
 
 This update also fixes a bug in which the underlying locale was ignored
 for the C<RADIXCHAR> (always was returned as a dot) and the C<THOUSEP>
@@ -967,7 +967,7 @@ A title for the HTML document will now be automatically generated by
 default from a "NAME" section in the POD document, as it used to be
 before the module was rewritten to use L<Pod::Simple::XHTML> to do the
 core of its job
-L<[perl #110520]|https://rt.perl.org/Ticket/Display.html?id=110520>.
+L<[GH #11954]|https://github.com/Perl/perl5/issues/11954>.
 
 =item *
 
@@ -1046,7 +1046,7 @@ L<threads> has been upgraded from version 2.15 to 2.22.
 The documentation now better describes the problems that arise when
 returning values from threads, and no longer warns about creating threads
 in C<BEGIN> blocks.
-L<[perl #96538]|https://rt.perl.org/Ticket/Display.html?id=96538>
+L<[GH #11563]|https://github.com/Perl/perl5/issues/11563>
 
 =item *
 
@@ -1125,7 +1125,7 @@ L<warnings> has been upgraded from version 1.37 to 1.42.
 
 It now includes new functions with names ending in C<_at_level>, allowing
 callers to specify the exact call frame.
-L<[perl #132468]|https://rt.perl.org/Ticket/Display.html?id=132468>
+L<[GH #16257]|https://github.com/Perl/perl5/issues/16257>
 
 =item *
 
@@ -1137,7 +1137,7 @@ L<XSLoader> has been upgraded from version 0.27 to 0.30.
 
 Its documentation now shows the use of C<__PACKAGE__>, and direct object
 syntax for example C<DynaLoader> usage
-L<[perl #132247]|https://rt.perl.org/Ticket/Display.html?id=132247>.
+L<[GH #16190]|https://github.com/Perl/perl5/issues/16190>.
 
 Platforms that use C<mod2fname> to edit the names of loadable
 libraries now look for bootstrap (.bs) files under the correct,
@@ -1206,7 +1206,7 @@ L<perldata>.
 
 The description of the conditions under which C<DB::sub()> will be called
 has been clarified.
-L<[perl #131672]|https://rt.perl.org/Ticket/Display.html?id=131672>
+L<[GH #16055]|https://github.com/Perl/perl5/issues/16055>
 
 =back
 
@@ -1275,27 +1275,27 @@ or as a special case for C<ERRSV> simply:
 
 There is now a note that warnings generated by built-in functions are
 documented in L<perldiag> and L<warnings>.
-L<[perl #116080]|https://rt.perl.org/Ticket/Display.html?id=116080>
+L<[GH #12642]|https://github.com/Perl/perl5/issues/12642>
 
 =item *
 
 The documentation for the C<exists> operator no longer says that
 autovivification behaviour "may be fixed in a future release".
 We've determined that we're not going to change the default behaviour.
-L<[perl #127712]|https://rt.perl.org/Ticket/Display.html?id=127712>
+L<[GH #15231]|https://github.com/Perl/perl5/issues/15231>
 
 =item *
 
 A couple of small details in the documentation for the C<bless> operator
 have been clarified.
-L<[perl #124428]|https://rt.perl.org/Ticket/Display.html?id=124428>
+L<[GH #14684]|https://github.com/Perl/perl5/issues/14684>
 
 =item *
 
 The description of C<@INC> hooks in the documentation for C<require>
 has been corrected to say that filter subroutines receive a useless
 first argument.
-L<[perl #115754]|https://rt.perl.org/Ticket/Display.html?id=115754>
+L<[GH #12569]|https://github.com/Perl/perl5/issues/12569>
 
 =item *
 
@@ -1311,7 +1311,7 @@ as a version number for its module version checking feature.
 The documentation of C<warn> has been updated to reflect that since Perl
 5.14 it has treated complex exception objects in a manner equivalent
 to C<die>.
-L<[perl #121372]|https://rt.perl.org/Ticket/Display.html?id=121372>
+L<[GH #13641]|https://github.com/Perl/perl5/issues/13641>
 
 =item *
 
@@ -1322,7 +1322,7 @@ The documentation of C<die> and C<warn> has been revised for clarity.
 The documentation of C<each> has been improved, with a slightly more
 explicit description of the sharing of iterator state, and with
 caveats regarding the fragility of while-each loops.
-L<[perl #132644]|https://rt.perl.org/Ticket/Display.html?id=132644>
+L<[GH #16334]|https://github.com/Perl/perl5/issues/16334>
 
 =item *
 
@@ -1378,7 +1378,7 @@ now documented.
 
 The documentation about C<DESTROY> methods has been corrected, updated,
 and revised, especially in regard to how they interact with exceptions.
-L<[perl #122753]|https://rt.perl.org/Ticket/Display.html?id=122753>
+L<[GH #14083]|https://github.com/Perl/perl5/issues/14083>
 
 =back
 
@@ -1389,7 +1389,7 @@ L<[perl #122753]|https://rt.perl.org/Ticket/Display.html?id=122753>
 =item *
 
 The description of the C<x> operator in L<perlop> has been clarified.
-L<[perl #132460]|https://rt.perl.org/Ticket/Display.html?id=132460>
+L<[GH #16253]|https://github.com/Perl/perl5/issues/16253>
 
 =item *
 
@@ -1400,13 +1400,13 @@ from that of C<split>'s in that only ASCII whitespace is used.
 
 The general explanation of operator precedence and associativity has
 been corrected and clarified.
-L<[perl #127391]|https://rt.perl.org/Ticket/Display.html?id=127391>
+L<[GH #15153]|https://github.com/Perl/perl5/issues/15153>
 
 =item *
 
 The documentation for the C<\> referencing operator now explains the
 unusual context that it supplies to its operand.
-L<[perl #131061]|https://rt.perl.org/Ticket/Display.html?id=131061>
+L<[GH #15932]|https://github.com/Perl/perl5/issues/15932>
 
 =back
 
@@ -1437,7 +1437,7 @@ Clarify metacharacters.
 =item *
 
 Clarify the differences between B<< -M >> and B<< -m >>.
-L<[perl #131518]|https://rt.perl.org/Ticket/Display.html?id=131518>
+L<[GH #15998]|https://github.com/Perl/perl5/issues/15998>
 
 =back
 
@@ -1448,7 +1448,7 @@ L<[perl #131518]|https://rt.perl.org/Ticket/Display.html?id=131518>
 =item *
 
 The documentation about set-id scripts has been updated and revised.
-L<[perl #74142]|https://rt.perl.org/Ticket/Display.html?id=74142>
+L<[GH #10289]|https://github.com/Perl/perl5/issues/10289>
 
 =item *
 
@@ -1470,7 +1470,7 @@ paragraph on the same topic in L<perldata>.
 
 The means to disambiguate between code blocks and hash constructors,
 already documented in L<perlref>, are now documented in L<perlsyn> too.
-L<[perl #130958]|https://rt.perl.org/Ticket/Display.html?id=130958>
+L<[GH #15918]|https://github.com/Perl/perl5/issues/15918>
 
 =back
 
@@ -1514,7 +1514,7 @@ multiply-named capturing groups.
 In various places, improve the documentation of the special cases
 in the condition expression of a while loop, such as implicit C<defined>
 and assignment to C<$_>.
-L<[perl #132644]|https://rt.perl.org/Ticket/Display.html?id=132644>
+L<[GH #16334]|https://github.com/Perl/perl5/issues/16334>
 
 =back
 
@@ -1543,12 +1543,12 @@ L<Can't "goto" into a binary or list expression|perldiag/"Can't E<quot>gotoE<quo
 
 Use of C<goto> to jump into the parameter of a binary or list operator has
 been prohibited, to prevent crashes and stack corruption.
-L<[perl #130936]|https://rt.perl.org/Ticket/Display.html?id=130936>
+L<[GH #15914]|https://github.com/Perl/perl5/issues/15914>
 
 You may only enter the I<first> argument of an operator that takes a fixed
 number of arguments, since this is a case that will not cause stack
 corruption.
-L<[perl #132854]|https://rt.perl.org/Ticket/Display.html?id=132854>
+L<[GH #16415]|https://github.com/Perl/perl5/issues/16415>
 
 =back
 
@@ -1581,14 +1581,14 @@ meanings>
 
 A false-positive warning that was issued when using a
 numerically-quantified sub-pattern in a recursive regex has been
-silenced. L<[perl #131868]|https://rt.perl.org/Public/Bug/Display.html?id=131868>
+silenced. L<[GH #16106]|https://github.com/Perl/perl5/issues/16106>
 
 =item *
 
 The warning about useless use of a concatenation operator in void context
 is now generated for expressions with multiple concatenations, such as
 C<$a.$b.$c>, which used to mistakenly not warn.
-L<[perl #6997]|https://rt.perl.org/Ticket/Display.html?id=6997>
+L<[GH #3990]|https://github.com/Perl/perl5/issues/3990>
 
 =item *
 
@@ -1601,7 +1601,7 @@ new warnings category "shadow".  Previously they were in category "misc".
 The deprecation warning from C<Sys::Hostname::hostname()> saying that
 it doesn't accept arguments now states the Perl version in which the
 warning will be upgraded to an error.
-L<[perl #124349]|https://rt.perl.org/Ticket/Display.html?id=124349>
+L<[GH #14662]|https://github.com/Perl/perl5/issues/14662>
 
 =item *
 
@@ -1651,7 +1651,7 @@ Where an HTML version of the documentation is installed, the HTML
 documents now use relative links to refer to each other.  Links from
 the index page of L<perlipc> to the individual section documents are
 now correct.
-L<[perl #110056]|https://rt.perl.org/Ticket/Display.html?id=110056>
+L<[GH #11941]|https://github.com/Perl/perl5/issues/11941>
 
 =item *
 
@@ -1665,7 +1665,7 @@ generated files doesn't depend on how F<regen/mk_invlists.pl> is
 invoked.
 
 This lack of canonical names could cause test failures in F<t/porting/regen.t>.
-L<[perl #132925]|https://rt.perl.org/Ticket/Display.html?id=132925>
+L<[GH #16446]|https://github.com/Perl/perl5/issues/16446>
 
 =item * New probes
 
@@ -1712,7 +1712,7 @@ applicable.
 
 Perl now includes a default F<.travis.yml> file for Travis CI testing
 on github mirrors.
-L<[perl #123981]|https://rt.perl.org/Ticket/Display.html?id=123981>
+L<[GH #14558]|https://github.com/Perl/perl5/issues/14558>
 
 =item *
 
@@ -1726,8 +1726,8 @@ the time out setting is multiplied by its value.
 =item *
 
 F<harness> no longer waits for 30 seconds when running F<t/io/openpid.t>.
-L<[perl #121028]|https://rt.perl.org/Ticket/Display.html?id=121028>
-L<[perl #132867]|https://rt.perl.org/Ticket/Display.html?id=132867>
+L<[GH #13535]|https://github.com/Perl/perl5/issues/13535>
+L<[GH #16420]|https://github.com/Perl/perl5/issues/16420>
 
 =back
 
@@ -1942,7 +1942,7 @@ defelem scalar each time, as long as the element is within the array.
 
 It partially fixes the rare bug of deferred elements getting out of synch
 with their arrays when the array is shifted or unshifted.
-L<[perl #132729]|https://rt.perl.org/Ticket/Display.html?id=132729>
+L<[GH #16364]|https://github.com/Perl/perl5/issues/16364>
 
 =back
 
@@ -1955,7 +1955,7 @@ L<[perl #132729]|https://rt.perl.org/Ticket/Display.html?id=132729>
 List assignment (C<aassign>) could in some rare cases allocate an
 entry on the mortals stack and leave the entry uninitialized, leading to
 possible crashes.
-L<[perl #131570]|https://rt.perl.org/Ticket/Display.html?id=131570>
+L<[GH #16017]|https://github.com/Perl/perl5/issues/16017>
 
 =item *
 
@@ -1972,7 +1972,7 @@ scope of the L<< C<unicode_strings>|feature/"The 'unicode_strings' feature"
 representation contained characters that are whitespace by Unicode rules but
 not by ASCII rules, it treated those characters as part of fields rather
 than as field separators.
-L<[perl #130907]|https://rt.perl.org/Ticket/Display.html?id=130907>
+L<[GH #15904]|https://github.com/Perl/perl5/issues/15904>
 
 =item *
 
@@ -1985,26 +1985,26 @@ be detected automatically in debugging builds.
 These internal stack usage checks introduced are also done
 by the C<entersub> operator when calling XSUBs.  This means we can
 report which XSUB failed to allocate enough stack space.
-L<[perl #131975]|https://rt.perl.org/Public/Bug/Display.html?id=131975>
+L<[GH #16126]|https://github.com/Perl/perl5/issues/16126>
 
 =item *
 
 Using a symbolic ref with postderef syntax as the key in a hash lookup was
 yielding an assertion failure on debugging builds.
-L<[perl #131627]|https://rt.perl.org/Ticket/Display.html?id=131627>
+L<[GH #16029]|https://github.com/Perl/perl5/issues/16029>
 
 =item *
 
 Array and hash variables whose names begin with a caret now admit indexing
 inside their curlies when interpolated into strings, as in C<<
 "${^CAPTURE[0]}" >> to index C<@{^CAPTURE}>.
-L<[perl #131664]|https://rt.perl.org/Ticket/Display.html?id=131664>
+L<[GH #16050]|https://github.com/Perl/perl5/issues/16050>
 
 =item *
 
 Fetching the name of a glob that was previously UTF-8 but wasn't any
 longer would return that name flagged as UTF-8.
-L<[perl #131263]|https://rt.perl.org/Ticket/Display.html?id=131263>
+L<[GH #15971]|https://github.com/Perl/perl5/issues/15971>
 
 =item *
 
@@ -2028,13 +2028,13 @@ C<$@>. For example:
 
 Fixed a duplicate symbol failure with C<-flto -mieee-fp> builds.
 F<pp.c> defined C<_LIB_VERSION> which C<-lieee> already defines.
-L<[perl #131786]|https://rt.perl.org/Ticket/Display.html?id=131786>
+L<[GH #16086]|https://github.com/Perl/perl5/issues/16086>
 
 =item *
 
 The tokenizer no longer consumes the exponent part of a floating
 point number if it's incomplete.
-L<[perl #131725]|https://rt.perl.org/Ticket/Display.html?id=131725>
+L<[GH #16073]|https://github.com/Perl/perl5/issues/16073>
 
 =item *
 
@@ -2043,13 +2043,13 @@ string is no longer treated as if the C</o> flag was present when the
 previous matching match operator included the C</o> flag.  The
 rewriting used to implement this behavior could confuse the
 interpreter.  This matches the behaviour of threaded builds.
-L<[perl #124368]|https://rt.perl.org/Ticket/Display.html?id=124368>
+L<[GH #14668]|https://github.com/Perl/perl5/issues/14668>
 
 =item *
 
 Parsing a C<sub> definition could cause a use after free if the C<sub>
 keyword was followed by whitespace including newlines (and comments.)
-L<[perl #131836]|https://rt.perl.org/Public/Bug/Display.html?id=131836>
+L<[GH #16097]|https://github.com/Perl/perl5/issues/16097>
 
 =item *
 
@@ -2061,7 +2061,7 @@ L<[perl #131949]|https://rt.perl.org/Public/Bug/Display.html?id=131949>
 
 Accesses to C<${^LAST_FH}> no longer assert after using any of a
 variety of I/O operations on a non-glob.
-L<[perl #128263]|https://rt.perl.org/Public/Bug/Display.html?id=128263>
+L<[GH #15372]|https://github.com/Perl/perl5/issues/15372>
 
 =item *
 
@@ -2071,15 +2071,15 @@ supplying NULL pointers to the functions these macros are built upon
 as undefined behaviour even when their count parameters are zero.
 Based on these assertions and the original bug report three macro
 calls were made conditional.
-L<[perl #131746]|https://rt.perl.org/Public/Bug/Display.html?id=131746>
-L<[perl #131892]|https://rt.perl.org/Public/Bug/Display.html?id=131892>
+L<[GH #16079]|https://github.com/Perl/perl5/issues/16079>
+L<[GH #16112]|https://github.com/Perl/perl5/issues/16112>
 
 =item *
 
 Only the C<=> operator is permitted for defining defaults for
 parameters in subroutine signatures.  Previously other assignment
 operators, e.g. C<+=>, were also accidentally permitted.
-L<[perl #131777]|https://rt.perl.org/Public/Bug/Display.html?id=131777>
+L<[GH #16084]|https://github.com/Perl/perl5/issues/16084>
 
 =item *
 
@@ -2092,7 +2092,7 @@ The C<je_old_stack_hwm> field, previously only found in the C<jmpenv>
 structure on debugging builds, has been added to non-debug builds as
 well. This fixes an issue with some CPAN modules caused by the size of
 this structure varying between debugging and non-debugging builds.
-L<[perl #131942]|https://rt.perl.org/Public/Bug/Display.html?id=131942>
+L<[GH #16122]|https://github.com/Perl/perl5/issues/16122>
 
 =item *
 
@@ -2110,7 +2110,7 @@ Calling L<exec PROGRAM LIST|perlfunc/exec PROGRAM LIST> with an empty C<LIST>
 has been fixed.  This should call C<execvp()> with an empty C<argv> array
 (containing only the terminating C<NULL> pointer), but was instead just
 returning false (and not setting L<C<$!>|perlvar/$!>).
-L<[perl #131730]|https://rt.perl.org/Public/Bug/Display.html?id=131730>
+L<[GH #16075]|https://github.com/Perl/perl5/issues/16075>
 
 =item *
 
@@ -2124,7 +2124,7 @@ been corrected.
 Single-letter debugger commands followed by an argument which starts with
 punctuation  (e.g. C<p$^V> and C<x@ARGV>) now work again.  They had been
 wrongly requiring a space between the command and the argument.
-L<[perl #120174]|https://rt.perl.org/Public/Bug/Display.html?id=120174>
+L<[GH #13342]|https://github.com/Perl/perl5/issues/13342>
 
 =item *
 
@@ -2133,7 +2133,7 @@ L<splice|perlfunc/splice ARRAY,OFFSET,LENGTH,LIST> now throws an exception
 array.  Until now it had been silently modifying the array.  The new behaviour
 is consistent with the behaviour of L<push|perlfunc/push ARRAY,LIST> and
 L<unshift|perlfunc/unshift ARRAY,LIST>.
-L<[perl #131000]|https://rt.perl.org/Public/Bug/Display.html?id=131000>
+L<[GH #15923]|https://github.com/Perl/perl5/issues/15923>
 
 =item *
 
@@ -2158,37 +2158,37 @@ and yield the appropriate errors if the argument doesn't refer to a file.
 Fixed a 'read before buffer' overrun when parsing a range starting with
 C<\N{}> at the beginning of the character set for the transliteration
 operator.
-L<[perl #132245]|https://rt.perl.org/Ticket/Display.html?id=132245>
+L<[GH #16189]|https://github.com/Perl/perl5/issues/16189>
 
 =item *
 
 Fixed a leaked scalar when parsing an empty C<\N{}> at compile-time.
-L<[perl #132245]|https://rt.perl.org/Ticket/Display.html?id=132245>
+L<[GH #16189]|https://github.com/Perl/perl5/issues/16189>
 
 =item *
 
 Calling C<do $path> on a directory or block device now yields a meaningful
 error code in C<$!>.
-L<[perl #125774]|https://rt.perl.org/Ticket/Display.html?id=125774>
+L<[GH #14841]|https://github.com/Perl/perl5/issues/14841>
 
 =item *
 
 Regexp substitution using an overloaded replacement value that provides
 a tainted stringification now correctly taints the resulting string.
-L<[perl #115266]|https://rt.perl.org/Ticket/Display.html?id=115266>
+L<[GH #12495]|https://github.com/Perl/perl5/issues/12495>
 
 =item *
 
 Lexical sub declarations in C<do> blocks such as C<do { my sub lex; 123 }>
 could corrupt the stack, erasing items already on the stack in the
 enclosing statement.  This has been fixed.
-L<[perl #132442]|https://rt.perl.org/Ticket/Display.html?id=132442>
+L<[GH #16243]|https://github.com/Perl/perl5/issues/16243>
 
 =item *
 
 C<pack> and C<unpack> can now handle repeat counts and lengths that
 exceed two billion.
-L<[perl #119367]|https://rt.perl.org/Ticket/Display.html?id=119367>
+L<[GH #13179]|https://github.com/Perl/perl5/issues/13179>
 
 =item *
 
@@ -2202,84 +2202,84 @@ The canonical truth value no longer has a spurious special meaning as a
 callable subroutine.  It used to be a magic placeholder for a missing
 C<import> or C<unimport> method, but is now treated like any other string
 C<1>.
-L<[perl #126042]|https://rt.perl.org/Ticket/Display.html?id=126042>
+L<[GH #14902]|https://github.com/Perl/perl5/issues/14902>
 
 =item *
 
 C<system> now reduces its arguments to strings in the parent process, so
 any effects of stringifying them (such as overload methods being called
 or warnings being emitted) are visible in the way the program expects.
-L<[perl #121105]|https://rt.perl.org/Ticket/Display.html?id=121105>
+L<[GH #13561]|https://github.com/Perl/perl5/issues/13561>
 
 =item *
 
 The C<readpipe()> built-in function now checks at compile time that
 it has only one parameter expression, and puts it in scalar context,
 thus ensuring that it doesn't corrupt the stack at runtime.
-L<[perl #4574]|https://rt.perl.org/Ticket/Display.html?id=4574>
+L<[GH #2793]|https://github.com/Perl/perl5/issues/2793>
 
 =item *
 
 C<sort> now performs correct reference counting when aliasing C<$a> and
 C<$b>, thus avoiding premature destruction and leakage of scalars if they
 are re-aliased during execution of the sort comparator.
-L<[perl #92264]|https://rt.perl.org/Ticket/Display.html?id=92264>
+L<[GH #11422]|https://github.com/Perl/perl5/issues/11422>
 
 =item *
 
 C<reverse> with no operand, reversing C<$_> by default, is no longer in
 danger of corrupting the stack.
-L<[perl #132544]|https://rt.perl.org/Ticket/Display.html?id=132544>
+L<[GH #16291]|https://github.com/Perl/perl5/issues/16291>
 
 =item *
 
 C<exec>, C<system>, et al are no longer liable to have their argument
 lists corrupted by reentrant calls and by magic such as tied scalars.
-L<[perl #129888]|https://rt.perl.org/Ticket/Display.html?id=129888>
+L<[GH #15660]|https://github.com/Perl/perl5/issues/15660>
 
 =item *
 
 Perl's own C<malloc> no longer gets confused by attempts to allocate
 more than a gigabyte on a 64-bit platform.
-L<[perl #119829]|https://rt.perl.org/Ticket/Display.html?id=119829>
+L<[GH #13273]|https://github.com/Perl/perl5/issues/13273>
 
 =item *
 
 Stacked file test operators in a sort comparator expression no longer
 cause a crash.
-L<[perl #129347]|https://rt.perl.org/Ticket/Display.html?id=129347>
+L<[GH #15626]|https://github.com/Perl/perl5/issues/15626>
 
 =item *
 
 An identity C<tr///> transformation on a reference is no longer mistaken
 for that reference for the purposes of deciding whether it can be
 assigned to.
-L<[perl #130578]|https://rt.perl.org/Ticket/Display.html?id=130578>
+L<[GH #15812]|https://github.com/Perl/perl5/issues/15812>
 
 =item *
 
 Lengthy hexadecimal, octal, or binary floating point literals no
 longer cause undefined behaviour when parsing digits that are of such
 low significance that they can't affect the floating point value.
-L<[perl #131894]|https://rt.perl.org/Ticket/Display.html?id=131894>
+L<[GH #16114]|https://github.com/Perl/perl5/issues/16114>
 
 =item *
 
 C<open $$scalarref...> and similar invocations no longer leak the file
 handle.
-L<[perl #115814]|https://rt.perl.org/Ticket/Display.html?id=115814>
+L<[GH #12593]|https://github.com/Perl/perl5/issues/12593>
 
 =item *
 
 Some convoluted kinds of regexp no longer cause an arithmetic overflow
 when compiled.
-L<[perl #131893]|https://rt.perl.org/Ticket/Display.html?id=131893>
+L<[GH #16113]|https://github.com/Perl/perl5/issues/16113>
 
 =item *
 
 The default typemap, by avoiding C<newGVgen>, now no longer leaks when
 XSUBs return file handles (C<PerlIO *> or C<FILE *>).
-L<[perl #115814]|https://rt.perl.org/Ticket/Display.html?id=115814>
+L<[GH #12593]|https://github.com/Perl/perl5/issues/12593>
 
 =item *
 
@@ -2289,7 +2289,7 @@ crashes because of the early freeing of the subroutine.
 =item *
 
 The C<printf> format specifier C<%.0f> no longer rounds incorrectly
-L<[perl #47602]|https://rt.perl.org/Ticket/Display.html?id=47602>,
+L<[GH #9125]|https://github.com/Perl/perl5/issues/9125>,
 and now shows the correct sign for a negative zero.
 
 =item * 
@@ -2297,25 +2297,25 @@ and now shows the correct sign for a negative zero.
 Fixed an issue where the error C<< Scalar value @arrayname[0] better
 written as $arrayname >> would give an error C<< Cannot printf Inf with 'c' >>
 when arrayname starts with C<< Inf >>.
-L<[perl #132645]|https://rt.perl.org/Ticket/Display.html?id=132645>
+L<[GH #16335]|https://github.com/Perl/perl5/issues/16335>
 
 =item *
 
 The Perl implementation of C<< getcwd() >> in C<< Cwd >> in the PathTools
 distribution now behaves the same as XS implementation on errors: it
 returns an error, and sets C<< $! >>.
-L<[perl #132648]|https://rt.perl.org/Ticket/Display.html?id=132648>
+L<[GH #16338]|https://github.com/Perl/perl5/issues/16338>
 
 =item *
 
 Vivify array elements when putting them on the stack.
-Fixes L<[perl #8910]|https://rt.perl.org/Ticket/Display.html?id=8910>
+Fixes L<[GH #5310]|https://github.com/Perl/perl5/issues/5310>
 (reported in April 2002).
 
 =item *
 
 Fixed parsing of braced subscript after parens. Fixes
-L<[perl #8045]|https://rt.perl.org/Ticket/Display.html?id=8045>
+L<[GH #4688]|https://github.com/Perl/perl5/issues/4688>
 (reported in December 2001).
 
 =item *
@@ -2338,7 +2338,7 @@ Previously compilation could continue in order to report other errors,
 but the failed sub-parse could leave partly parsed constructs on the
 parser shift-reduce stack, confusing the parser, leading to perl
 crashes.
-L<[perl #125351]|https://rt.perl.org/Ticket/Display.html?id=125351>
+L<[GH #14739]|https://github.com/Perl/perl5/issues/14739>
 
 =item *
 
@@ -2352,7 +2352,7 @@ and the problem just doesn't come up on those with thread-safe locales.
 
 Errors while compiling a regex character class could sometime trigger an
 assertion failure.
-L<[perl #132163]|https://rt.perl.org/Ticket/Display.html?id=132163>
+L<[GH #16172]|https://github.com/Perl/perl5/issues/16172>
 
 =back
 

--- a/pod/perl5281delta.pod
+++ b/pod/perl5281delta.pod
@@ -21,14 +21,14 @@ of the environment variable name and value exceeded around 0x7fffffff.  This
 could lead to writing beyond the end of an allocated buffer with attacker
 supplied data.
 
-L<[perl #133204]|https://rt.perl.org/Ticket/Display.html?id=133204>
+L<[GH #16560]|https://github.com/Perl/perl5/issues/16560>
 
 =head2 [CVE-2018-18312] Heap-buffer-overflow write in S_regatom (regcomp.c)
 
 A crafted regular expression could cause heap-buffer-overflow write during
 compilation, potentially allowing arbitrary code execution.
 
-L<[perl #133423]|https://rt.perl.org/Ticket/Display.html?id=133423>
+L<[GH #16649]|https://github.com/Perl/perl5/issues/16649>
 
 =head1 Incompatible Changes
 
@@ -58,7 +58,7 @@ Perl 5.28 introduced an C<index()> optimization when comparing to -1 (or
 indirectly, e.g. >= 0).  When this optimization was triggered inside a C<when>
 clause it caused a warning ("Argument %s isn't numeric in smart match").  This
 has now been fixed.
-L<[perl #133368]|https://rt.perl.org/Ticket/Display.html?id=133368>
+L<[GH #16626]|https://github.com/Perl/perl5/issues/16626>
 
 =item *
 
@@ -69,7 +69,7 @@ not.  This has now been fixed.
 =item *
 
 The new in-place editing code no longer leaks directory handles.
-L<[perl #133314]|https://rt.perl.org/Ticket/Display.html?id=133314>
+L<[GH #16602]|https://github.com/Perl/perl5/issues/16602>
 
 =back
 

--- a/pod/perl5282delta.pod
+++ b/pod/perl5282delta.pod
@@ -27,7 +27,7 @@ so is both a bug fix and an incompatibility.
 
 All digits in a run still have to come from the same set of ten digits.
 
-L<[perl #133547]|https://rt.perl.org/Ticket/Display.html?id=133547>
+L<[GH #16704]|https://github.com/Perl/perl5/issues/16704>
 
 =head1 Modules and Pragmata
 
@@ -75,7 +75,7 @@ To work around that, the initial build of the F<perl> executable expects to
 find F<libperl.dylib> in the build directory, and the library path is then
 adjusted during installation to point to the installed library.
 
-L<[perl #126706]|https://rt.perl.org/Ticket/Display.html?id=126706>
+L<[GH #15057]|https://github.com/Perl/perl5/issues/15057>
 
 =back
 
@@ -99,7 +99,7 @@ to replace the input file, while code like:
 
 will not.  Partly resolves [perl #133659].
 
-L<[perl #133659]|https://rt.perl.org/Ticket/Display.html?id=133659>
+L<[GH #16748]|https://github.com/Perl/perl5/issues/16748>
 
 =item *
 
@@ -114,7 +114,7 @@ because the child's stdin would be closed on exec.  This has now been fixed.
 C<pack "u", "invalid uuencoding"> now properly NUL terminates the zero-length
 SV produced.
 
-L<[perl #132655]|https://rt.perl.org/Ticket/Display.html?id=132655>
+L<[GH #16343]|https://github.com/Perl/perl5/issues/16343>
 
 =item *
 
@@ -122,7 +122,7 @@ Failing to compile a format now aborts compilation.  Like other errors in
 sub-parses this could leave the parser in a strange state, possibly crashing
 perl if compilation continued.
 
-L<[perl #132158]|https://rt.perl.org/Ticket/Display.html?id=132158>
+L<[GH #16169]|https://github.com/Perl/perl5/issues/16169>
 
 =item *
 

--- a/pod/perl5300delta.pod
+++ b/pod/perl5300delta.pod
@@ -15,7 +15,7 @@ L<perl5280delta>, which describes differences between 5.26.0 and 5.28.0.
 =head1 Notice
 
 sv_utf8_(downgrade|decode) are no longer marked as experimental.
-L<[perl #133788]|https://rt.perl.org/Ticket/Display.html?id=133788>.
+L<[GH #16822]|https://github.com/Perl/perl5/issues/16822>.
 
 =head1 Core Enhancements
 
@@ -155,40 +155,40 @@ could lead to invalidly encoded perl scalars.
 
 =back
 
-L<[perl #125760]|https://rt.perl.org/Ticket/Display.html?id=125760>.
+L<[GH #14839]|https://github.com/Perl/perl5/issues/14839>.
 
 =head2 my() in false conditional prohibited
 
 Declarations such as C<my $x if 0> are no longer permitted.
 
-L<[perl #133543]|https://rt.perl.org/Ticket/Display.html?id=133543>.
+L<[GH #16702]|https://github.com/Perl/perl5/issues/16702>.
 
 =head2 Fatalize $* and $#
 
 These special variables, long deprecated, now throw exceptions when used.
 
-L<[perl #133583]|https://rt.perl.org/Ticket/Display.html?id=133583>.
+L<[GH #16718]|https://github.com/Perl/perl5/issues/16718>.
 
 =head2 Fatalize unqualified use of dump()
 
 The C<dump()> function, long discouraged, may no longer be used unless it is
 fully qualified, I<i.e.>, C<CORE::dump()>.
 
-L<[perl #133584]|https://rt.perl.org/Ticket/Display.html?id=133584>.
+L<[GH #16719]|https://github.com/Perl/perl5/issues/16719>.
 
 =head2 Remove File::Glob::glob()
 
 The C<File::Glob::glob()> function, long deprecated, has been removed and now
 throws an exception which advises use of C<File::Glob::bsd_glob()> instead.
 
-L<[perl #133586]|https://rt.perl.org/Ticket/Display.html?id=133586>.
+L<[GH #16721]|https://github.com/Perl/perl5/issues/16721>.
 
 =head2 C<pack()> no longer can return malformed UTF-8
 
 It croaks if it would otherwise return a UTF-8 string that contains
 malformed UTF-8.  This protects against potential security threats.  This
 is considered a bug fix as well.
-L<[perl #131642]|https://rt.perl.org/Ticket/Display.html?id=131642>.
+L<[GH #16035]|https://github.com/Perl/perl5/issues/16035>.
 
 =head2 Any set of digits in the Common script are legal in a script run of another script
 
@@ -200,7 +200,7 @@ Any of these sets should be able to appear in script runs of, say,
 Greek.  But the design of 5.30 overlooked all but the ASCII digits
 C<[0-9]>, so the design was flawed.  This has been fixed, so is both a
 bug fix and an incompatibility.
-L<[perl #133547]|https://rt.perl.org/Ticket/Display.html?id=133547>.
+L<[GH #16704]|https://github.com/Perl/perl5/issues/16704>.
 
 All digits in a run still have to come from the same set of ten digits.
 
@@ -233,7 +233,7 @@ improved, again by using a DFA.
 =item *
 
 Eliminate recursion from finalize_op().
-L<[perl #108276]|https://rt.perl.org/Ticket/Display.html?id=108276>.
+L<[GH #11866]|https://github.com/Perl/perl5/issues/11866>.
 
 =item *
 
@@ -243,20 +243,20 @@ and character classes in regular expressions.
 =item *
 
 Optimization of C<IV> to C<UV> conversions.
-L<[perl #133677]|https://rt.perl.org/Ticket/Display.html?id=133677>.
+L<[GH #16761]|https://github.com/Perl/perl5/issues/16761>.
 
 =item *
 
 Speed up of the integer stringification algorithm by processing
 two digits at a time instead of one.
-L<[perl #133691]|https://rt.perl.org/Ticket/Display.html?id=133691>.
+L<[GH #16769]|https://github.com/Perl/perl5/issues/16769>.
 
 =item *
 
 Improvements based on LGTM analysis and recommendation.
 (L<https://lgtm.com/projects/g/Perl/perl5/alerts/?mode=tree>). 
-L<[perl #133686]|https://rt.perl.org/Ticket/Display.html?id=133686>.
-L<[perl #133699]|https://rt.perl.org/Ticket/Display.html?id=133699>.
+L<[GH #16765]|https://github.com/Perl/perl5/issues/16765>.
+L<[GH #16773]|https://github.com/Perl/perl5/issues/16773>.
 
 =item *
 
@@ -384,7 +384,7 @@ L<ExtUtils::Miniperl> has been upgraded from version 1.08 to 1.09.
 L<ExtUtils::ParseXS> has been upgraded from version 3.39 to 3.40.
 C<OUTLIST> parameters are no longer incorrectly included in the
 automatically generated function prototype.
-L<[perl #133654]|https://rt.perl.org/Ticket/Display.html?id=133654>.
+L<[GH #16746]|https://github.com/Perl/perl5/issues/16746>.
 
 =item *
 
@@ -400,7 +400,7 @@ L<File::Find> has been upgraded from version 1.34 to 1.36.
 
 C<$File::Find::dont_use_nlink> now defaults to 1 on all
 platforms.
-L<[perl #133673]|https://rt.perl.org/Ticket/Display.html?id=133673>.
+L<[GH #16759]|https://github.com/Perl/perl5/issues/16759>.
 
 Variables C<< $Is_Win32 >> and C<< $Is_VMS >> are being initialized.
 
@@ -569,14 +569,14 @@ L<sigtrap> has been upgraded from version 1.08 to 1.09.
 L<Storable> has been upgraded from version 3.08 to 3.15.
 
 Storable no longer probes for recursion limits at build time.
-L<[perl #133708]|https://rt.perl.org/Ticket/Display.html?id=133708>
+L<[GH #16780]|https://github.com/Perl/perl5/issues/16780>
 and others.
 
 Metasploit exploit code was included to test for CVE-2015-1992
 detection, this caused anti-virus detections on at least one AV suite.
 The exploit code has been removed and replaced with a simple
 functional test.
-L<[perl #133706]|https://rt.perl.org/Ticket/Display.html?id=133706>
+L<[GH #16778]|https://github.com/Perl/perl5/issues/16778>
 
 =item *
 
@@ -627,7 +627,7 @@ L<vars> has been upgraded from version 1.04 to 1.05.
 
 C<vars.pm> no longer disables non-vars strict when checking if strict
 vars is enabled.
-L<[perl #130674]|https://rt.perl.org/Ticket/Display.html?id=130674>.
+L<[GH #15851]|https://github.com/Perl/perl5/issues/15851>.
 
 =item *
 
@@ -676,7 +676,7 @@ C<< L<B::Debug|https://metacpan.org/pod/B::Debug> >>.
 Locale::Codes has been removed at the request of its author.  It
 continues to be available on CPAN as
 C<< L<Locale::Codes|https://metacpan.org/pod/Locale::Codes> >>
-L<[perl #133458]|https://rt.perl.org/Ticket/Display.html?id=133458>.
+L<[GH #16660]|https://github.com/Perl/perl5/issues/16660>.
 
 =back
 
@@ -695,7 +695,7 @@ to L<perlbug@perl.org|mailto:perlbug@perl.org>.
 =item *
 
 C<AvFILL()> was wrongly listed as deprecated.  This has been corrected.
-L<[perl #133278]|https://rt.perl.org/Ticket/Display.html?id=133278>
+L<[GH #16586]|https://github.com/Perl/perl5/issues/16586>
 
 =back
 
@@ -712,7 +712,7 @@ L<perlop> should not refer to them.
 
 The behaviour of C<tr> when the delimiter is an apostrophe has been clarified.
 In particular, hyphens aren't special, and C<\x{}> isn't interpolated.
-L<[perl #130679]|https://rt.perl.org/Ticket/Display.html?id=130679>
+L<[GH #15853]|https://github.com/Perl/perl5/issues/15853>
 
 =back
 
@@ -743,7 +743,7 @@ Clarification of behaviour of C<reset EXPR>.
 
 Try to clarify that C<< ref(qr/xx/) >> returns C<Regexp> rather than
 C<REGEXP> and why.
-L<[perl #133751]|https://rt.perl.org/Ticket/Display.html?id=133751>.
+L<[GH #16801]|https://github.com/Perl/perl5/issues/16801>.
 
 =back
 
@@ -786,7 +786,7 @@ Added a note for the ::xdigit:: character class.
 =item *
 
 More specific documentation of paragraph mode.
-L<[perl #133722]|https://rt.perl.org/Ticket/Display.html?id=133722>.
+L<[GH #16787]|https://github.com/Perl/perl5/issues/16787>.
 
 =back
 
@@ -831,14 +831,14 @@ L<Type of arg %d to %s must be %s (not %s)|perldiag/"Type of arg %d to %s must b
 
 Attempts to push, pop, etc on a hash or glob now produce this message
 rather than complaining that they no longer work on scalars.
-L<[perl #130367]|https://rt.perl.org/Ticket/Display.html?id=130367>.
+L<[GH #15774]|https://github.com/Perl/perl5/issues/15774>.
 
 =item *
 
 L<Prototype not terminated|perldiag/"Prototype not terminated">
 
 The file and line number is now reported for this error.
-L<[perl #133524]|https://rt.perl.org/Ticket/Display.html?id=133524>
+L<[GH #16697]|https://github.com/Perl/perl5/issues/16697>
 
 =item *
 
@@ -861,7 +861,7 @@ as that spelling has been around the longest.
 The generated prototype (with C<< PROTOTYPES: ENABLE >>) would include
 C<< OUTLIST >> parameters, but these aren't arguments to the perl function.
 This has been rectified.
-L<[perl #133654]|https://rt.perl.org/Ticket/Display.html?id=133654>.
+L<[GH #16746]|https://github.com/Perl/perl5/issues/16746>.
 
 =back
 
@@ -883,7 +883,7 @@ Improve detection of memrchr, strlcat, and strlcpy
 =item *
 
 Improve Configure detection of memmem().
-L<[perl #133760]|https://rt.perl.org/Ticket/Display.html?id=133760>.
+L<[GH #16807]|https://github.com/Perl/perl5/issues/16807>.
 
 =item *
 
@@ -902,14 +902,14 @@ Fix -DPERL_GLOBAL_STRUCT_PRIVATE build option.
 =item *
 
 F<t/lib/croak/op>
-L<[perl #130367]|https://rt.perl.org/Ticket/Display.html?id=130367>.
+L<[GH #15774]|https://github.com/Perl/perl5/issues/15774>.
 
 separate error for C<push>, etc. on hash/glob.
 
 =item *
 
 F<t/op/svleak.t>
-L<[perl #133660]|https://rt.perl.org/Ticket/Display.html?id=133660>.
+L<[GH #16749]|https://github.com/Perl/perl5/issues/16749>.
 
 Add test for C<goto &sub> in overload leaking.
 
@@ -921,13 +921,13 @@ Split F<t/re/fold_grind.t> into multiple test files.
 
 Fix intermittent tests which failed due to race conditions which
 surface during parallel testing.
-L<[perl #133740]|https://rt.perl.org/Ticket/Display.html?id=133740>.
+L<[GH #16795]|https://github.com/Perl/perl5/issues/16795>.
 
 =item *
 
 Thoroughly test paragraph mode, using a new test file,
 F<t/io/paragraph_mode.t>.
-L<[perl #133722]|https://rt.perl.org/Ticket/Display.html?id=133722>.
+L<[GH #16787]|https://github.com/Perl/perl5/issues/16787>.
 
 =item *
 
@@ -964,7 +964,7 @@ expects to find F<libperl.dylib> in the build directory, and the
 library path is then adjusted during installation to point to the
 installed library.
 
-L<[perl #126706]|https://rt.perl.org/Ticket/Display.html?id=126706>.
+L<[GH #15057]|https://github.com/Perl/perl5/issues/15057>.
 
 =item Minix3
 
@@ -1004,7 +1004,7 @@ been added to the B<nmake> makefile.)
 
 C<sleep()> with warnings enabled for a C<USE_IMP_SYS> build no longer
 warns about the sleep timeout being too large.
-L<[perl #133376]|https://rt.perl.org/Ticket/Display.html?id=133376>.
+L<[GH #16631]|https://github.com/Perl/perl5/issues/16631>.
 
 =item *
 
@@ -1015,7 +1015,7 @@ Support for compiling perl on Windows using Microsoft Visual Studio 2019
 
 socket() now sets C<$!> if the protocol, address family and socket
 type combination is not found.
-L<[perl #133853]|https://rt.perl.org/Ticket/Display.html?id=133853>.
+L<[GH #16849]|https://github.com/Perl/perl5/issues/16849>.
 
 =item *
 
@@ -1049,7 +1049,7 @@ should be a dot or comma.
 
 Added C<newSVsv_nomg()> to copy a SV without processing get magic on
 the source.
-L<[perl #132964]|https://rt.perl.org/Ticket/Display.html?id=132964>.
+L<[GH #16461]|https://github.com/Perl/perl5/issues/16461>.
 
 =item *
 
@@ -1088,40 +1088,40 @@ Perl 5.28 introduced an C<index()> optimization when comparing to -1 (or
 indirectly, e.g. >= 0).  When this optimization was triggered inside a C<when>
 clause it caused a warning ("Argument %s isn't numeric in smart match").  This
 has now been fixed.
-L<[perl #133368]|https://rt.perl.org/Ticket/Display.html?id=133368>
+L<[GH #16626]|https://github.com/Perl/perl5/issues/16626>
 
 =item *
 
 The new in-place editing code no longer leaks directory handles.
-L<[perl #133314]|https://rt.perl.org/Ticket/Display.html?id=133314>.
+L<[GH #16602]|https://github.com/Perl/perl5/issues/16602>.
 
 =item *
 
 Warnings produced from constant folding operations on overloaded
 values no longer produce spurious "Use of uninitialized value"
 warnings.
-L<[perl #132683]|https://rt.perl.org/Ticket/Display.html?id=132683>.
+L<[GH #16349]|https://github.com/Perl/perl5/issues/16349>.
 
 =item *
 
 Fix for "mutator not seen in (lex = ...) .= ..."
-L<[perl #133441]|https://rt.perl.org/Ticket/Display.html?id=133441>.
+L<[GH #16655]|https://github.com/Perl/perl5/issues/16655>.
 
 =item *
 
 C<pack "u", "invalid uuencoding"> now properly NUL terminates the
 zero-length SV produced.
-L<[perl #132655]|https://rt.perl.org/Ticket/Display.html?id=132655>.
+L<[GH #16343]|https://github.com/Perl/perl5/issues/16343>.
 
 =item *
 
 Improve the debugging output for calloc() calls with C<-Dm>.
-L<[perl #133439]|https://rt.perl.org/Ticket/Display.html?id=133439>.
+L<[GH #16653]|https://github.com/Perl/perl5/issues/16653>.
 
 =item *
 
 Regexp script runs were failing to permit ASCII digits in some cases.
-L<[perl #133547]|https://rt.perl.org/Ticket/Display.html?id=133547>.
+L<[GH #16704]|https://github.com/Perl/perl5/issues/16704>.
 
 =item *
 
@@ -1129,19 +1129,19 @@ On Unix-like systems supporting a platform-specific technique for
 determining L<< C<$^X>|perlvar/$^X >>, Perl failed to fall back to the
 generic technique when the platform-specific one fails (for example, a Linux
 system with /proc not mounted).  This was a regression in Perl 5.28.0.
-L<[perl #133573]|https://rt.perl.org/Ticket/Display.html?id=133573>.
+L<[GH #16715]|https://github.com/Perl/perl5/issues/16715>.
 
 =item *
 
 L<SDBM_File> is now more robust with corrupt database files.  The
 improvements do not make SDBM files suitable as an interchange format.
-L<[perl #132147]|https://rt.perl.org/Ticket/Display.html?id=132147>.
+L<[GH #16164]|https://github.com/Perl/perl5/issues/16164>.
 
 =item *
 
 C<binmode($fh);> or C<binmode($fh, ':raw');> now properly removes the
 C<:utf8> flag from the default C<:crlf> I/O layer on Win32.
-L<[perl #133604]|https://rt.perl.org/Ticket/Display.html?id=133604>.
+L<[GH #16730]|https://github.com/Perl/perl5/issues/16730>.
 
 =item *
 
@@ -1154,13 +1154,13 @@ was being interpreted as:
 
     local \(@a[3,5,7]) = \(....);
 
-L<[perl #133538]|https://rt.perl.org/Ticket/Display.html?id=133538>.
+L<[GH #16701]|https://github.com/Perl/perl5/issues/16701>.
 
 =item *
 
 C<sort SUBNAME> within an C<eval EXPR> when C<EXPR> was UTF-8 upgraded
 could panic if the C<SUBNAME> was non-ASCII.
-L<[perl #134061]|https://rt.perl.org/Ticket/Display.html?id=134061>.
+L<[GH #16979]|https://github.com/Perl/perl5/issues/16979>.
 
 =item *
 
@@ -1168,7 +1168,7 @@ Correctly handle realloc() modifying C<errno> on success so that the
 modification isn't visible to the perl user, since realloc() is called
 implicitly by the interpreter.  This modification is permitted by the
 C standard, but has only been observed on FreeBSD 13.0-CURRENT.
-L<[perl #133958]|https://rt.perl.org/Ticket/Display.html?id=133958>.
+L<[GH #16907]|https://github.com/Perl/perl5/issues/16907>.
 
 =item *
 
@@ -1177,14 +1177,14 @@ available.  This is intended for use by C<Cwd.pm> during bootstrapping
 and may be removed or changed without notice.  This fixes some
 bootstrapping issues while building perl in a directory where some
 ancestor directory isn't readable.
-L<[perl #133951]|https://rt.perl.org/Ticket/Display.html?id=133951>.
+L<[GH #16903]|https://github.com/Perl/perl5/issues/16903>.
 
 =item *
 
 C<pack()> no longer can return malformed UTF-8.  It croaks if it would
 otherwise return a UTF-8 string that contains malformed UTF-8.  This
 protects against potential security threats.
-L<[perl #131642]|https://rt.perl.org/Ticket/Display.html?id=131642>.
+L<[GH #16035]|https://github.com/Perl/perl5/issues/16035>.
 
 =item *
 
@@ -1200,7 +1200,7 @@ an incorrect value.
 =item *
 
 Reduce recursion on ops
-L<[perl #108276]|https://rt.perl.org/Ticket/Display.html?id=108276>.
+L<[GH #11866]|https://github.com/Perl/perl5/issues/11866>.
 
 This can prevent stack overflow when processing extremely deep op
 trees.
@@ -1208,7 +1208,7 @@ trees.
 =item *
 
 Avoid leak in multiconcat with overloading.
-L<[perl #133789]|https://rt.perl.org/Ticket/Display.html?id=133789>.
+L<[GH #16823]|https://github.com/Perl/perl5/issues/16823>.
 
 =item *
 
@@ -1289,19 +1289,19 @@ string at a place which could potentially be in the middle of a
 multi-character fold, we back off one (or more) characters, leaving
 a shorter EXACTFish regnode. This backing off mechanism contained
 an off-by-one error.
-L<[perl #133756]|https://rt.perl.org/Ticket/Display.html?id=133756>.
+L<[GH #16806]|https://github.com/Perl/perl5/issues/16806>.
 
 =item *
 
 A bare C<eof> call with no previous file handle now returns true.
-L<[perl #133721]|https://rt.perl.org/Ticket/Display.html?id=133721>
+L<[GH #16786]|https://github.com/Perl/perl5/issues/16786>
 
 =item *
 
 Failing to compile a format now aborts compilation.  Like other errors
 in sub-parses this could leave the parser in a strange state, possibly
 crashing perl if compilation continued.
-L<[perl #132158]|https://rt.perl.org/Ticket/Display.html?id=132158>
+L<[GH #16169]|https://github.com/Perl/perl5/issues/16169>
 
 =item *
 
@@ -1319,7 +1319,7 @@ to replace the input file, while code like:
   perl -i -ne 'print "Foo"; die'
 
 will not.  Partly resolves
-L<[perl #133659]|https://rt.perl.org/Ticket/Display.html?id=133659>.
+L<[GH #16748]|https://github.com/Perl/perl5/issues/16748>.
 
 =item *
 
@@ -1339,12 +1339,12 @@ which is invalid syntax.
 
 Fixed build failures with C<< -DNO_LOCALE_NUMERIC >> and
 C<< -DNO_LOCALE_COLLATE >>.
-L<[perl #133696]|https://rt.perl.org/Ticket/Display.html?id=133696>.
+L<[GH #16771]|https://github.com/Perl/perl5/issues/16771>.
 
 =item *
 
 Prevent the tests in F<< ext/B/t/strict.t >> from being skipped.
-L<[perl #133713]|https://rt.perl.org/Ticket/Display.html?id=133713>.
+L<[GH #16783]|https://github.com/Perl/perl5/issues/16783>.
 
 =item *
 

--- a/pod/perl5320delta.pod
+++ b/pod/perl5320delta.pod
@@ -220,7 +220,7 @@ This error can be avoided by adding a return to the sub definition:
     $sub = sub () { return $var };
 
 This has been deprecated since Perl 5.22.
-[L<perl #134138|https://rt.perl.org/Ticket/Display.html?id=134138>]
+L<[GH #17020]|https://github.com/Perl/perl5/issues/17020>
 
 =head2 Use of L<C<vec>|perlfunc/vec EXPR,OFFSET,BITS> on strings with code points above 0xFF is forbidden
 
@@ -248,13 +248,13 @@ list of integers, where previously it would produce a list of strings.
 This was due to a special case that treated strings starting with "0"
 as strings so ranges like C<"00" .. "03"> produced C<"00", "01", "02", "03">,
 but didn't specially handle the string C<"0">.
-[L<perl #133695|https://rt.perl.org/Ticket/Display.html?id=133695>]
+L<[GH #16770]|https://github.com/Perl/perl5/issues/16770>
 
 =head2 C<\K> now disallowed in look-ahead and look-behind assertions
 
 This was disallowed because it causes unexpected behaviour, and no-one
 could define what the desired behaviour should be.
-[L<perl #124256|https://rt.perl.org/Ticket/Display.html?id=124256>]
+L<[GH #14638]|https://github.com/Perl/perl5/issues/14638>
 
 =head1 Performance Enhancements
 
@@ -441,7 +441,7 @@ that on platforms that don't implement C<SO_PROTOCOL> for a given
 socket type the protocol method may return C<undef>.
 
 The supplied I<TO> is now always honoured on calls to the C<send()>
-method. [L<perl #133936|https://rt.perl.org/Ticket/Display.html?id=133936>]
+method. L<[GH #16891]|https://github.com/Perl/perl5/issues/16891>
 
 =item *
 
@@ -567,7 +567,7 @@ Vstring magic strings over 2GB are now disallowed.
 
 Regular expressions objects weren't properly counted for object id
 purposes on retrieve. This would corrupt the resulting structure, or
-cause a runtime error in some cases. [L<perl #134179|https://rt.perl.org/Ticket/Display.html?id=134179>]
+cause a runtime error in some cases. L<[GH #17037]|https://github.com/Perl/perl5/issues/17037>
 
 =item *
 
@@ -622,7 +622,7 @@ L<Tie::StdHandle> has been upgraded from version 4.5 to 4.6.
 L<Time::HiRes> has been upgraded from version 1.9760 to 1.9764.
 
 Removed obsolete code such as support for pre-5.6 perl and classic
-MacOS. [L<perl #134288|https://rt.perl.org/Ticket/Display.html?id=134288>]
+MacOS. L<[GH #17096]|https://github.com/Perl/perl5/issues/17096>
 
 =item *
 
@@ -665,8 +665,8 @@ L<XS::APItest> has been upgraded from version 1.00 to 1.09.
 =item *
 
 Pod::Parser has been removed from the core distribution.
-It still is available for download from CPAN. This resolves [L<perl
-#119439|https://rt.perl.org/Ticket/Display.html?id=119439>].
+It still is available for download from CPAN. This resolves 
+[L<#13194|https://github.com/Perl/perl5/issues/13194>].
 
 =back
 
@@ -1200,7 +1200,7 @@ as gcc-1 and turned on C<-fpcc-struct-return>.
 Perl now no longer probes for C<d_u32align>, defaulting to C<define> on all
 platforms. This check was error-prone when it was done, which was on 32-bit
 platforms only.
-[L<perl #133495|https://rt.perl.org/Ticket/Display.html?id=133495>]
+L<[GH #16680]|https://github.com/Perl/perl5/issues/16680>
 
 =item *
 
@@ -1214,7 +1214,7 @@ A new probe for C<malloc_usable_size> has been added.
 =item *
 
 Improvements in F<Configure> to detection in C++ and clang++. Work ongoing by
-Andy Dougherty. [L<perl #134171|https://rt.perl.org/Ticket/Display.html?id=134171>]
+Andy Dougherty. L<[GH #17033]|https://github.com/Perl/perl5/issues/17033>
 
 =item *
 
@@ -1230,7 +1230,7 @@ entries in code.
 The C<ECHO> macro is now defined. This is used in a C<dtrace> rule that was
 originally changed for FreeBSD, and the FreeBSD make apparently predefines it.
 The Solaris make does not predefine C<ECHO> which broke this rule on Solaris.
-[L<perl #134218|https://rt.perl.org/Ticket/Display.html?id=134218>]
+L<[GH #17057]|https://github.com/Perl/perl5/issues/17057>
 
 =item *
 
@@ -1302,7 +1302,7 @@ Support for building perl on Windows CE has now been removed.
 =item Linux
 
 C<cc> will be used to populate C<plibpth> if C<cc> is C<clang>.
-[L<perl #134189|https://rt.perl.org/Ticket/Display.html?id=134189>]
+L<[GH #17043]|https://github.com/Perl/perl5/issues/17043>
 
 =item NetBSD 8.0
 
@@ -1329,7 +1329,7 @@ separately due to the CRT throwing an exception if the locale name
 wasn't validly encoded in the current code page.
 
 For the second we now decode the locale name ourselves, and always
-decode it as UTF-8. [L<perl #133981|https://rt.perl.org/Ticket/Display.html?id=133981>]
+decode it as UTF-8. L<[GH #16922]|https://github.com/Perl/perl5/issues/16922>
 
 =item *
 
@@ -1472,7 +1472,7 @@ contain characters whose code points are above 255. Some of the bugs
 were undocumented, one being that under some circumstances (but not all)
 with C</s>, the squeezing was done based on the source, rather than the
 replacement. A documented bug that got fixed was
-[L<perl #125493|https://rt.perl.org/Ticket/Display.html?id=125493>].
+L<[GH #14777]|https://github.com/Perl/perl5/issues/14777>.
 
 =item *
 
@@ -1503,7 +1503,7 @@ A new parser function L<parse_subsignature()|perlapi/parse_subsignature>
 allows a keyword plugin to parse a subroutine signature while C<use feature
 'signatures'> is in effect. This allows custom keywords to implement
 semantics similar to regular C<sub> declarations that include signatures.
-[L<perl #132474|https://rt.perl.org/Ticket/Display.html?id=132474>]
+L<[GH #16261]|https://github.com/Perl/perl5/issues/16261>
 
 =item *
 
@@ -1511,7 +1511,7 @@ Since on some platforms we need to hold a mutex when temporarily
 switching locales, new macros (C<STORE_LC_NUMERIC_SET_TO_NEEDED_IN>,
 C<WITH_LC_NUMERIC_SET_TO_NEEDED> and C<WITH_LC_NUMERIC_SET_TO_NEEDED_IN>)
 have been added to make it easier to do this safely and efficiently
-as part of [L<perl #134172|https://rt.perl.org/Ticket/Display.html?id=134172>].
+as part of L<[GH #17034]|https://github.com/Perl/perl5/issues/17034>.
 
 =item *
 
@@ -1521,7 +1521,7 @@ reduced by 8 bytes per OP on 64-bit systems.
 =item *
 
 L<eval_pv()|perlapi/eval_pv> no longer stringifies the exception when
-C<croak_on_error> is true. [L<perl #134175|https://rt.perl.org/Ticket/Display.html?id=134175>]
+C<[GH #17035]|https://github.com/Perl/perl5/issues/17035>]
 
 =item *
 
@@ -1536,12 +1536,12 @@ leak detection tools such as valgrind.
 The API eval_sv() now accepts a C<G_RETHROW> flag. If this flag is set and an
 exception is thrown while compiling or executing the supplied code, it will be
 rethrown, and eval_sv() will not return.
-[L<perl #134177|https://rt.perl.org/Ticket/Display.html?id=134177>]
+L<[GH #17036]|https://github.com/Perl/perl5/issues/17036>
 
 =item *
 
 As part of the fix for
-[L<perl #2754|https://rt.perl.org/Ticket/Display.html?id=2754>] perl_parse()
+L<[GH #1537]|https://github.com/Perl/perl5/issues/1537> perl_parse()
 now returns non-zero if exit(0) is called in a C<BEGIN>, C<UNITCHECK> or
 C<CHECK> block.
 
@@ -1656,76 +1656,76 @@ Perl no longer treats strings starting with "0x" or "0b" as hex or
 binary numbers respectively when converting a string to a number.
 This reverts a change in behaviour inadvertently introduced in perl
 5.30.0 intended to improve precision when converting a string to a
-floating point number. [L<perl #134230|https://rt.perl.org/Ticket/Display.html?id=134230>]
+floating point number. L<[GH #17062]|https://github.com/Perl/perl5/issues/17062>
 
 =item *
 
 Matching a non-C<SVf_UTF8> string against a regular expression
 containing unicode literals could leak a SV on each match attempt.
-[L<perl #134390|https://rt.perl.org/Ticket/Display.html?id=134390>]
+L<[GH #17140]|https://github.com/Perl/perl5/issues/17140>
 
 =item *
 
 Overloads for octal and binary floating point literals were always
 passed a string with a C<0x> prefix instead of the appropriate C<0> or
-C<0b> prefix. [L<perl #125557|https://rt.perl.org/Ticket/Display.html?id=125557>]
+C<[GH #14791]|https://github.com/Perl/perl5/issues/14791>]
 
 =item *
 
 C<< $@ = 100; die; >> now correctly propagates the 100 as an exception
-instead of ignoring it. [L<perl #134291|https://rt.perl.org/Ticket/Display.html?id=134291>]
+instead of ignoring it. L<[GH #17098]|https://github.com/Perl/perl5/issues/17098>
 
 =item *
 
-C<< 0 0x@ >> no longer asserts in S_no_op(). [L<perl #134310|https://rt.perl.org/Ticket/Display.html?id=134310>]
+C<[GH #17108]|https://github.com/Perl/perl5/issues/17108>]
 
 =item *
 
 Exceptions thrown while C<$@> is read-only could result in infinite
 recursion as perl tried to update C<$@>, which throws another
 exception, resulting in a stack overflow. Perl now replaces C<$@>
-with a copy if it's not a simple writable SV. [L<perl #134266|https://rt.perl.org/Ticket/Display.html?id=134266>]
+with a copy if it's not a simple writable SV. L<[GH #17083]|https://github.com/Perl/perl5/issues/17083>
 
 =item *
 
 Setting C<$)> now properly sets supplementary group ids if you have
-the necessary privileges. [L<perl #134169|https://rt.perl.org/Ticket/Display.html?id=134169>]
+the necessary privileges. L<[GH #17031]|https://github.com/Perl/perl5/issues/17031>
 
 =item *
 
 close() on a pipe now preemptively clears the PerlIO object from the
 IO SV. This prevents a second attempt to close the already closed
 PerlIO object if a signal handler calls die() or exit() while close()
-is waiting for the child process to complete. [L<perl #122112|https://rt.perl.org/Ticket/Display.html?id=122112>]
+is waiting for the child process to complete. L<[GH #13929]|https://github.com/Perl/perl5/issues/13929>
 
 =item *
 
 C<< sprintf("%.*a", -10000, $x) >> would cause a buffer overflow due
-to mishandling of the negative precision value. [L<perl #134008|https://rt.perl.org/Ticket/Display.html?id=134008>]
+to mishandling of the negative precision value. L<[GH #16942]|https://github.com/Perl/perl5/issues/16942>
 
 =item *
 
 scalar() on a reference could cause an erroneous assertion failure
-during compilation. [L<perl #134045|https://rt.perl.org/Ticket/Display.html?id=134045>]
+during compilation. L<[GH #16969]|https://github.com/Perl/perl5/issues/16969>
 
 =item *
 
 C<%{^CAPTURE_ALL}> is now an alias to C<%-> as documented, rather than
-incorrectly an alias for C<%+>. [L<perl #131867|https://rt.perl.org/Ticket/Display.html?id=131867>]
+incorrectly an alias for C<[GH #16105]|https://github.com/Perl/perl5/issues/16105>]
 
 =item *
 
 C<%{^CAPTURE}> didn't work if C<@{^CAPTURE}> was mentioned first.
 Similarly for C<%{^CAPTURE_ALL}> and C<@{^CAPTURE_ALL}>, though
-C<@{^CAPTURE_ALL}> currently isn't used. [L<perl #134193|https://rt.perl.org/Ticket/Display.html?id=134193>]
+C<[GH #17045]|https://github.com/Perl/perl5/issues/17045>]
 
 =item *
 
 Extraordinarily large (over 2GB) floating point format widths could
 cause an integer overflow in the underlying call to snprintf(),
 resulting in an assertion. Formatted floating point widths are now
-limited to the range of int, the return value of snprintf(). [L<perl
-#133913|https://rt.perl.org/Ticket/Display.html?id=133913>]
+limited to the range of int, the return value of snprintf(). 
+[L<#16881|https://github.com/Perl/perl5/issues/16881>]
 
 =item *
 
@@ -1752,15 +1752,15 @@ C<@x {"a"}> (with the space) in a sub-parse now properly produces a
 =item *
 
 Attributes can now be used in a sub-parse.
-[L<perl #133850|https://rt.perl.org/Ticket/Display.html?id=133850>]
+L<[GH #16847]|https://github.com/Perl/perl5/issues/16847>
 
 =back
 
 =item *
 
 Incomplete hex and binary literals like C<0x> and C<0b> are now
-treated as if the C<x> or C<b> is part of the next token. [L<perl
-#134125|https://rt.perl.org/Ticket/Display.html?id=134125>]
+treated as if the C<x> or C<b> is part of the next token. 
+[L<#17010|https://github.com/Perl/perl5/issues/17010>]
 
 =item *
 
@@ -1773,24 +1773,24 @@ normal subparse clean up, confusing the parser and possible causing an
 assertion failure.
 
 Such constructs are now surrounded by artificial tokens that can't be
-included in the source. [L<perl #130585|https://rt.perl.org/Ticket/Display.html?id=130585>]
+included in the source. L<[GH #15814]|https://github.com/Perl/perl5/issues/15814>
 
 =item *
 
 Reference assignment of a sub, such as C<\&foo = \&bar;>, silently did
-nothing in the C<main::> package. [L<perl #134072|https://rt.perl.org/Ticket/Display.html?id=134072>]
+nothing in the C<[GH #16987]|https://github.com/Perl/perl5/issues/16987>]
 
 =item *
 
 sv_gets() now recovers better if the target SV is modified by a signal
-handler. [L<perl #134035|https://rt.perl.org/Ticket/Display.html?id=134035>]
+handler. L<[GH #16960]|https://github.com/Perl/perl5/issues/16960>
 
 =item *
 
 C<readline @foo> now evaluates C<@foo> in scalar context. Previously
 it would be evaluated in list context, and since readline() pops only
 one argument from the stack, the stack could underflow, or be left
-with unexpected values on the stack. [L<perl #133989|https://rt.perl.org/Ticket/Display.html?id=133989>]
+with unexpected values on the stack. L<[GH #16929]|https://github.com/Perl/perl5/issues/16929>
 
 =item *
 
@@ -1798,31 +1798,31 @@ Parsing incomplete hex or binary literals was changed in 5.31.1 to treat such a
 literal as just the 0, leaving the following C<x> or C<b> to be parsed as part
 of the next token. This could lead to some silent changes in behaviour, so now
 incomplete hex or binary literals produce a fatal error.
-[L<perl #134125|https://rt.perl.org/Ticket/Display.html?id=134125>]
+L<[GH #17010]|https://github.com/Perl/perl5/issues/17010>
 
 =item *
 
 eval_pv()'s I<croak_on_error> flag will now throw even if the exception is a
 false overloaded value.
-[L<perl #134177|https://rt.perl.org/Ticket/Display.html?id=134177>]
+L<[GH #17036]|https://github.com/Perl/perl5/issues/17036>
 
 =item *
 
 C<INIT> blocks and the program itself are no longer run if exit(0) is called
 within a C<BEGIN>, C<UNITCHECK> or C<CHECK> block.
-[L<perl #2754|https://rt.perl.org/Ticket/Display.html?id=2754>]
+L<[GH #1537]|https://github.com/Perl/perl5/issues/1537>
 
 =item *
 
 C<< open my $fh, ">>+", undef >> now opens the temporary file in append mode:
 writes will seek to the end of file before writing.
-[L<perl #134221|https://rt.perl.org/Ticket/Display.html?id=134221>]
+L<[GH #17058]|https://github.com/Perl/perl5/issues/17058>
 
 =item *
 
 Fixed a SEGV when searching for the source of an uninitialized value warning on
 an op whose subtree includes an OP_MULTIDEREF.
-[L<perl #134275|https://rt.perl.org/Ticket/Display.html?id=134275>]
+L<[GH #17088]|https://github.com/Perl/perl5/issues/17088>
 
 =back
 

--- a/pod/perl5335delta.pod
+++ b/pod/perl5335delta.pod
@@ -169,7 +169,7 @@ while running the test suite.
 Windows now supports L<symlink()|perlfunc/symlink> and
 L<readlink()|perlfunc/readlink>, and L<lstat()|perlfunc/lstat> is no
 longer an alias for L<stat()|perlfunc/stat>.
-L<[#18005]|https://github.com/Perl/perl5/issues/18005>.
+L<[GH #18005]|https://github.com/Perl/perl5/issues/18005>.
 
 Unlike POSIX systems, creating a symbolic link on Windows requires
 either elevated privileges or Windows 10 1703 or later with Developer
@@ -188,18 +188,18 @@ information required for stat() is now retrieved in a single API call.
 The C<-r> and C<-w> operators now return true for the C<STDIN>,
 C<STDOUT> and C<STDERR> handles.  Unfortunately it still won't return
 true for duplicates of those handles.
-L<[#8502]|https://github.com/Perl/perl5/issues/8502>.
+L<[GH #8502]|https://github.com/Perl/perl5/issues/8502>.
 
 The times returned by stat() and lstat() are no longer incorrect
 across Daylight Savings Time adjustments.
-L<[#6080]|https://github.com/Perl/perl5/issues/6080>.
+L<[GH #6080]|https://github.com/Perl/perl5/issues/6080>.
 
 C<-x> on a filehandle should now match C<-x> on the corresponding
 filename on Vista or later.
-L<[#4145]|https://github.com/Perl/perl5/issues/4145>.
+L<[GH #4145]|https://github.com/Perl/perl5/issues/4145>.
 
 C<-e '"'> no longer incorrectly returns true.
-L<[#12431]|https://github.com/Perl/perl5/issues/12431>.
+L<[GH #12431]|https://github.com/Perl/perl5/issues/12431>.
 
 =back
 

--- a/pod/perl5337delta.pod
+++ b/pod/perl5337delta.pod
@@ -122,7 +122,7 @@ Additionally, the following selected changes have been made:
 L<my()|perlfunc/my> and L<state()|perlfunc/state> now explicitly warn
 the reader that lexical variables should typically not be redeclared
 within the same scope or statement.
-L<[#18389]|https://github.com/Perl/perl5/issues/18389>
+L<[GH #18389]|https://github.com/Perl/perl5/issues/18389>
 
 =back
 


### PR DESCRIPTION
For the task from the issue #17331 I replaced all rt.perl.org ticket links to their github.com issue links with issue numbers in square brackets [# 12345] (if it's not ok [# 12345] can be easily replaced to any form of issue number now).