### PR TITLE
perlgov: update core team membership

### DIFF
--- a/pod/perlgov.pod
+++ b/pod/perlgov.pod
@@ -508,6 +508,8 @@ The current members of the Perl Core Team are:
 
 =item * Max Maischein
 
+=item * Neil Bowers
+
 =item * Nicholas Clark
 
 =item * Nicolas R.
@@ -517,8 +519,6 @@ The current members of the Perl Core Team are:
 =item * Philippe "BooK" Bruhat
 
 =item * Ricardo Signes
-
-=item * Sawyer X
 
 =item * Steve Hay
 


### PR DESCRIPTION
Sawyer X has resigned.

Neil Bowers was made a member by virtue of election to PSC.