### PR TITLE
Update ExtUtils-MakeMaker to CPAN version 7.62

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -466,7 +466,7 @@ use File::Glob qw(:case);
     },
 
     'ExtUtils::MakeMaker' => {
-        'DISTRIBUTION' => 'BINGOS/ExtUtils-MakeMaker-7.60.tar.gz',
+        'DISTRIBUTION' => 'BINGOS/ExtUtils-MakeMaker-7.62.tar.gz',
         'FILES'        => q[cpan/ExtUtils-MakeMaker],
         'EXCLUDED'     => [
             qr{^t/lib/Test/},

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Command.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Command.pm
@@ -8,7 +8,7 @@ use vars qw(@ISA @EXPORT @EXPORT_OK $VERSION);
 @ISA       = qw(Exporter);
 @EXPORT    = qw(cp rm_f rm_rf mv cat eqtime mkpath touch test_f test_d chmod
                 dos2unix);
-$VERSION = '7.60';
+$VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 my $Is_VMS   = $^O eq 'VMS';

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Command/MM.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Command/MM.pm
@@ -10,7 +10,7 @@ our @ISA = qw(Exporter);
 
 our @EXPORT  = qw(test_harness pod2man perllocal_install uninstall
                   warn_if_old_packlist test_s cp_nonempty);
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 my $Is_VMS = $^O eq 'VMS';

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Liblist.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Liblist.pm
@@ -3,7 +3,7 @@ package ExtUtils::Liblist;
 use strict;
 use warnings;
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 use File::Spec;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Liblist/Kid.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Liblist/Kid.pm
@@ -11,7 +11,7 @@ use 5.006;
 
 use strict;
 use warnings;
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 use ExtUtils::MakeMaker::Config;
@@ -52,7 +52,7 @@ sub _unix_os2_ext {
     require Text::ParseWords;
 
     my ( @searchpath );    # from "-L/path" entries in $potential_libs
-    my ( @libpath ) = Text::ParseWords::quotewords( '\s+', 0, $Config{'libpth'} || '' );
+    my ( @libpath ) = Text::ParseWords::shellwords( $Config{'libpth'} || '' );
     my ( @ldloadlibs, @bsloadlibs, @extralibs, @ld_run_path, %ld_run_path_seen );
     my ( @libs,       %libs_seen );
     my ( $fullname,   @fullname );
@@ -65,7 +65,7 @@ sub _unix_os2_ext {
         $potential_libs =~ s/(^|\s)(-F)\s*(\S+)/$1-Wl,$2 -Wl,$3/g;
     }
 
-    foreach my $thislib ( Text::ParseWords::quotewords( '\s+', 0, $potential_libs) ) {
+    foreach my $thislib ( Text::ParseWords::shellwords($potential_libs) ) {
         my ( $custom_name ) = '';
 
         # Handle possible linker path arguments.

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use ExtUtils::MakeMaker::Config;
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::Liblist;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_AIX.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_AIX.pm
@@ -2,7 +2,7 @@ package ExtUtils::MM_AIX;
 
 use strict;
 use warnings;
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 use ExtUtils::MakeMaker::Config;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Any.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Any.pm
@@ -2,7 +2,7 @@ package ExtUtils::MM_Any;
 
 use strict;
 use warnings;
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 use Carp;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_BeOS.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_BeOS.pm
@@ -27,7 +27,7 @@ require ExtUtils::MM_Any;
 require ExtUtils::MM_Unix;
 
 our @ISA = qw( ExtUtils::MM_Any ExtUtils::MM_Unix );
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Cygwin.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Cygwin.pm
@@ -10,7 +10,7 @@ require ExtUtils::MM_Unix;
 require ExtUtils::MM_Win32;
 our @ISA = qw( ExtUtils::MM_Unix );
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_DOS.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_DOS.pm
@@ -3,7 +3,7 @@ package ExtUtils::MM_DOS;
 use strict;
 use warnings;
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Any;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Darwin.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Darwin.pm
@@ -8,7 +8,7 @@ BEGIN {
     our @ISA = qw( ExtUtils::MM_Unix );
 }
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_MacOS.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_MacOS.pm
@@ -3,7 +3,7 @@ package ExtUtils::MM_MacOS;
 use strict;
 use warnings;
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 sub new {

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_NW5.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_NW5.pm
@@ -23,7 +23,7 @@ use warnings;
 use ExtUtils::MakeMaker::Config;
 use File::Basename;
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Win32;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_OS2.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_OS2.pm
@@ -6,7 +6,7 @@ use warnings;
 use ExtUtils::MakeMaker qw(neatvalue);
 use File::Spec;
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Any;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_OS390.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_OS390.pm
@@ -2,7 +2,7 @@ package ExtUtils::MM_OS390;
 
 use strict;
 use warnings;
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 use ExtUtils::MakeMaker::Config;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_QNX.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_QNX.pm
@@ -2,7 +2,7 @@ package ExtUtils::MM_QNX;
 
 use strict;
 use warnings;
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Unix;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_UWIN.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_UWIN.pm
@@ -2,7 +2,7 @@ package ExtUtils::MM_UWIN;
 
 use strict;
 use warnings;
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Unix;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Unix.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Unix.pm
@@ -15,7 +15,7 @@ use ExtUtils::MakeMaker qw($Verbose neatvalue _sprintf562);
 
 # If we make $VERSION an our variable parse_version() breaks
 use vars qw($VERSION);
-$VERSION = '7.60';
+$VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Any;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_VMS.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_VMS.pm
@@ -16,7 +16,7 @@ BEGIN {
 
 use File::Basename;
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Any;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_VOS.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_VOS.pm
@@ -2,7 +2,7 @@ package ExtUtils::MM_VOS;
 
 use strict;
 use warnings;
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Unix;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Win32.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Win32.pm
@@ -27,7 +27,7 @@ use ExtUtils::MakeMaker qw(neatvalue _sprintf562);
 require ExtUtils::MM_Any;
 require ExtUtils::MM_Unix;
 our @ISA = qw( ExtUtils::MM_Any ExtUtils::MM_Unix );
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 $ENV{EMXSHELL} = 'sh'; # to run `commands`

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Win95.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Win95.pm
@@ -3,7 +3,7 @@ package ExtUtils::MM_Win95;
 use strict;
 use warnings;
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Win32;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MY.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MY.pm
@@ -3,7 +3,7 @@ package ExtUtils::MY;
 use strict;
 require ExtUtils::MM;
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 our @ISA = qw(ExtUtils::MM);
 

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker.pm
@@ -25,7 +25,7 @@ my %Recognized_Att_Keys;
 our %macro_fsentity; # whether a macro is a filesystem name
 our %macro_dep; # whether a macro is a dependency
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 # Emulate something resembling CVS $Revision$

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Config.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Config.pm
@@ -3,7 +3,7 @@ package ExtUtils::MakeMaker::Config;
 use strict;
 use warnings;
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 use Config ();

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/FAQ.pod
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/FAQ.pod
@@ -1,6 +1,6 @@
 package ExtUtils::MakeMaker::FAQ;
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 1;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Locale.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Locale.pm
@@ -2,7 +2,7 @@ package ExtUtils::MakeMaker::Locale;
 
 use strict;
 use warnings;
-our $VERSION = "7.60";
+our $VERSION = "7.62";
 $VERSION =~ tr/_//d;
 
 use base 'Exporter';

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Tutorial.pod
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Tutorial.pod
@@ -1,6 +1,6 @@
 package ExtUtils::MakeMaker::Tutorial;
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/version.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/version.pm
@@ -16,7 +16,7 @@ use warnings;
 
 use vars qw(@ISA $VERSION $CLASS $STRICT $LAX *declare *qv);
 
-$VERSION = '7.60';
+$VERSION = '7.62';
 $VERSION =~ tr/_//d;
 $CLASS = 'version';
 

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/version/regex.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/version/regex.pm
@@ -11,7 +11,7 @@ use warnings;
 
 use vars qw($VERSION $CLASS $STRICT $LAX);
 
-$VERSION = '7.60';
+$VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 #--------------------------------------------------------------------------#

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Mkbootstrap.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Mkbootstrap.pm
@@ -3,7 +3,7 @@ package ExtUtils::Mkbootstrap;
 use strict;
 use warnings;
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 require Exporter;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Mksymlists.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Mksymlists.pm
@@ -11,7 +11,7 @@ use Config;
 
 our @ISA = qw(Exporter);
 our @EXPORT = qw(&Mksymlists);
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 sub Mksymlists {

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/testlib.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/testlib.pm
@@ -3,7 +3,7 @@ package ExtUtils::testlib;
 use strict;
 use warnings;
 
-our $VERSION = '7.60';
+our $VERSION = '7.62';
 $VERSION =~ tr/_//d;
 
 use Cwd;


### PR DESCRIPTION
  [DELTA]

7.62    Tue 13 Apr 18:58:24 BST 2021

    No changes since v7.61_01

7.61_01 Sun 21 Mar 09:24:57 GMT 2021

    Bug fixes:
    - Use shellwords in ExtUtils::Liblist::Kid::_unix_os2_ext