### PR TITLE
Update secondary contact addresses for security reports.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,7 @@ membership mailing list monitored by the Perl security team.
 
 You should receive an initial response to your report within 72 hours.
 If you do not receive a response in that time, please contact
-the security team lead [John Lightsey](mailto:john@04755.net) and
-the Perl pumpking [SawyerX](mailto:xsawyerx@cpan.org).
+the [Perl steering council](mailto:steering-council@perl.org).
 
 When members of the security team reply to your messages, they will
 generally include the perl-security@perl.org address in the "To" or "CC"

--- a/pod/perlsecpolicy.pod
+++ b/pod/perlsecpolicy.pod
@@ -29,7 +29,6 @@ security team.
 
 You should receive an initial response to your report within 72 hours.
 If you do not receive a response in that time, please contact
-the security team lead L<John Lightsey|mailto:john@04755.net> and
 the L<Perl steering council|mailto:steering-council@perl.org>.
 
 When members of the security team reply to your messages, they will
@@ -296,9 +295,8 @@ open and transparent as possible about the state of your security report.
 
 New vulnerability reports will receive an initial reply within 72 hours
 from the time they arrive at the security team's mailing list. If you do
-not receive any response in that time, contact the security team lead
-L<John Lightsey|mailto:john@04755.net> and the the L<Perl steering
-council|mailto:steering-council@perl.org>.
+not receive any response in that time, contact the
+L<Perl steering council|mailto:steering-council@perl.org>.
 
 The initial response sent by the security team will confirm your message was
 received and provide an estimated time frame for the security team's


### PR DESCRIPTION
The perl steering council should now be used as a secondary
contact if the security team does not respond to a report.