### PR TITLE
toke.c: fix format warnings

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -93,8 +93,8 @@ Individual members of C<PL_parser> have their own documentation.
     (SvTYPE(sv) >= SVt_PVNV \
     && ((XPVIV*)SvANY(sv))->xiv_u.xivu_eval_seen)
 
-static const char* const ident_too_long = "Identifier too long";
-static const char* const ident_var_zero_multi_digit = "Numeric variables with more than one digit may not start with '0'";
+static const char const ident_too_long[] = "Identifier too long";
+static const char const ident_var_zero_multi_digit[] = "Numeric variables with more than one digit may not start with '0'";
 
 #  define NEXTVAL_NEXTTOKE PL_nextval[PL_nexttoke]
 
@@ -9999,7 +9999,7 @@ S_scan_ident(pTHX_ char *s, char *dest, STRLEN destlen, I32 ck_uni)
             if (d >= e)
                 Perl_croak(aTHX_ "%s", ident_too_long);
             *d++ = *s++;
-        } 
+        }
         if (is_zero && d - digit_start > 1)
             Perl_croak(aTHX_ ident_var_zero_multi_digit);
     }


### PR DESCRIPTION
```
toke.c: In function 'S_scan_ident':
toke.c:9946:13: error: format not a string literal and no format arguments [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security-Werror=format-security8;;]
 9946 |             Perl_croak(aTHX_ ident_var_zero_multi_digit);
      |             ^~~~~~~~~~
toke.c:10009:21: error: format not a string literal and no format arguments [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security-Werror=format-security8;;]
10009 |                     Perl_croak(aTHX_ ident_var_zero_multi_digit);
      |                     ^~~~~~~~~~
```