### PR TITLE
Do not cache utf8 offsets for non-canonical lengths

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3095,7 +3095,7 @@ S	|int	|sv_2iuv_non_preserve	|NN SV *const sv
 SR	|STRLEN	|expect_number	|NN const char **const pattern
 ST	|STRLEN	|sv_pos_u2b_forwards|NN const U8 *const start \
 		|NN const U8 *const send|NN STRLEN *const uoffset \
-		|NN bool *const at_end
+		|NN bool *const at_end|NN bool *canonical_position
 ST	|STRLEN	|sv_pos_u2b_midway|NN const U8 *const start \
 		|NN const U8 *send|STRLEN uoffset|const STRLEN uend
 S	|STRLEN	|sv_pos_u2b_cached|NN SV *const sv|NN MAGIC **const mgp \

--- a/proto.h
+++ b/proto.h
@@ -6382,9 +6382,9 @@ STATIC STRLEN	S_sv_pos_b2u_midway(pTHX_ const U8 *const s, const U8 *const targe
 STATIC STRLEN	S_sv_pos_u2b_cached(pTHX_ SV *const sv, MAGIC **const mgp, const U8 *const start, const U8 *const send, STRLEN uoffset, STRLEN uoffset0, STRLEN boffset0);
 #define PERL_ARGS_ASSERT_SV_POS_U2B_CACHED	\
 	assert(sv); assert(mgp); assert(start); assert(send)
-STATIC STRLEN	S_sv_pos_u2b_forwards(const U8 *const start, const U8 *const send, STRLEN *const uoffset, bool *const at_end);
+STATIC STRLEN	S_sv_pos_u2b_forwards(const U8 *const start, const U8 *const send, STRLEN *const uoffset, bool *const at_end, bool *canonical_position);
 #define PERL_ARGS_ASSERT_SV_POS_U2B_FORWARDS	\
-	assert(start); assert(send); assert(uoffset); assert(at_end)
+	assert(start); assert(send); assert(uoffset); assert(at_end); assert(canonical_position)
 STATIC STRLEN	S_sv_pos_u2b_midway(const U8 *const start, const U8 *send, STRLEN uoffset, const STRLEN uend);
 #define PERL_ARGS_ASSERT_SV_POS_U2B_MIDWAY	\
 	assert(start); assert(send)

--- a/t/op/index.t
+++ b/t/op/index.t
@@ -8,7 +8,7 @@ BEGIN {
 }
 
 use strict;
-plan( tests => 414 );
+plan( tests => 415 );
 
 run_tests() unless caller;
 
@@ -356,6 +356,14 @@ my $x;
 ($x = (index($y, $z) == -1)) =~ s/^/a/;
 $x;
 EOS
+    }
+
+    {
+        my $s = "abc";
+        my $len = length($s);
+        utf8::upgrade($s);
+        length($s);
+        is(index($s, "", $len+1), 3, 'Overlong index doesn\'t confuse utf8 cache');
     }
 
 } # end of sub run_tests


### PR DESCRIPTION
In particular, if the length is beyond the end, it should not be stored as the end.

This fixes #18588