### PR TITLE
Upgrade NEXT to 0.68 from CPAN

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -866,10 +866,9 @@ use File::Glob qw(:case);
     },
 
     'NEXT' => {
-        'DISTRIBUTION' => 'NEILB/NEXT-0.67.tar.gz',
+        'DISTRIBUTION' => 'NEILB/NEXT-0.68.tar.gz',
         'FILES'        => q[cpan/NEXT],
         'EXCLUDED'     => [qr{^demo/}],
-        'CUSTOMIZED'   => [ qw(lib/NEXT.pm t/next.t) ],
     },
 
     'Params::Check' => {

--- a/cpan/NEXT/lib/NEXT.pm
+++ b/cpan/NEXT/lib/NEXT.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use overload ();
 
-our $VERSION = '0.67_01';
+our $VERSION = '0.68';
 
 sub NEXT::ELSEWHERE::ancestors
 {

--- a/cpan/NEXT/t/actual.t
+++ b/cpan/NEXT/t/actual.t
@@ -1,25 +1,33 @@
+use strict;
+use warnings;
 use Test::More tests => 10;
 
 BEGIN { use_ok('NEXT') };
 my $order = 0;
 
 package A;
-@ISA = qw/B C D/;
+our @ISA = qw/B C D/;
+use if $] >= 5.009005, 'mro', 'dfs';
+
 
 sub test { ++$order; ::ok($order==1,"test A"); $_[0]->NEXT::ACTUAL::test;}
 
 package B;
-@ISA = qw/D C/;
+our @ISA = qw/D C/;
+use if $] >= 5.009005, 'mro', 'dfs';
 sub test { ++$order; ::ok($order==2,"test B"); $_[0]->NEXT::ACTUAL::test;}
 
 package C;
-@ISA = qw/D/;
+our @ISA = qw/D/;
+use if $] >= 5.009005, 'mro', 'dfs';
+
 sub test {
 	++$order; ::ok($order==4||$order==6,"test C");
 	$_[0]->NEXT::ACTUAL::test;
 }
 
 package D;
+use if $] >= 5.009005, 'mro', 'dfs';
 
 sub test {
 	++$order; ::ok($order==3||$order==5||$order==7||$order==8,"test D");
@@ -27,6 +35,7 @@ sub test {
 }
 
 package main;
+use if $] >= 5.009005, 'mro', 'dfs';
 
 my $foo = {};
 

--- a/cpan/NEXT/t/actuns.t
+++ b/cpan/NEXT/t/actuns.t
@@ -1,22 +1,31 @@
+use strict;
+use warnings;
 use Test::More tests => 6;
 
 BEGIN { use_ok('NEXT') };
 my $order = 0;
 
 package A;
-@ISA = qw/B C D/;
+
+our @ISA = qw/B C D/;
+use if $] >= 5.009005, 'mro', 'dfs';
+
 
 sub test { ::ok(++$order==1,"test A"); $_[0]->NEXT::UNSEEN::ACTUAL::test;}
 
 package B;
-@ISA = qw/D C/;
+our @ISA = qw/D C/;
+use if $] >= 5.009005, 'mro', 'dfs';
 sub test { ::ok(++$order==2,"test B"); $_[0]->NEXT::ACTUAL::UNSEEN::test;}
 
 package C;
-@ISA = qw/D/;
+our @ISA = qw/D/;
+use if $] >= 5.009005, 'mro', 'dfs';
+
 sub test { ::ok(++$order==4,"test C"); $_[0]->NEXT::UNSEEN::ACTUAL::test;}
 
 package D;
+use if $] >= 5.009005, 'mro', 'dfs';
 
 sub test { ::ok(++$order==3,"test D"); $_[0]->NEXT::ACTUAL::UNSEEN::test;}
 

--- a/cpan/NEXT/t/dynamically_scoped_regex_vars.t
+++ b/cpan/NEXT/t/dynamically_scoped_regex_vars.t
@@ -1,3 +1,5 @@
+use strict;
+use warnings;
 use Test::More tests => 7;
 
 BEGIN { use_ok('NEXT') };

--- a/cpan/NEXT/t/next.t
+++ b/cpan/NEXT/t/next.t
@@ -1,7 +1,9 @@
-BEGIN { print "1..27\n"; }
 
+use strict;
+use warnings;
 use NEXT;
 
+print "1..27\n";
 print "ok 1\n";
 
 package A;
@@ -11,6 +13,7 @@ sub A::evaled   { eval { $_[0]->NEXT::evaled(); return 'evaled' } }
 
 package B;
 use base qw( A );
+our $AUTOLOAD;
 sub B::AUTOLOAD { return ( 9, $_[0]->NEXT::AUTOLOAD() )
 			if $AUTOLOAD =~ /.*(missing_method|secondary)/ }
 sub B::DESTROY  { $_[0]->NEXT::DESTROY() }
@@ -19,7 +22,7 @@ package C;
 sub C::DESTROY  { print "ok 25\n"; $_[0]->NEXT::DESTROY() }
 
 package D;
-@D::ISA = qw( B C E );
+our @ISA = qw( B C E );
 sub D::method   { return ( 2, $_[0]->NEXT::method() ) }
 sub D::AUTOLOAD { return ( 8, $_[0]->NEXT::AUTOLOAD() ) }
 sub D::DESTROY  { print "ok 24\n"; $_[0]->NEXT::DESTROY() }
@@ -27,9 +30,9 @@ sub D::oops     { $_[0]->NEXT::method() }
 sub D::secondary { return ( 17, 18, map { $_+10 } $_[0]->NEXT::secondary() ) }
 
 package E;
-@E::ISA = qw( F G );
+our @ISA = qw( F G );
 sub E::method   { return ( 4,  $_[0]->NEXT::method(), $_[0]->NEXT::method() ) }
-sub E::AUTOLOAD { return ( 10, $_[0]->NEXT::AUTOLOAD() ) 
+sub E::AUTOLOAD { return ( 10, $_[0]->NEXT::AUTOLOAD() )
 			if $AUTOLOAD =~ /.*(missing_method|secondary)/ }
 sub E::DESTROY  { print "ok 26\n"; $_[0]->NEXT::DESTROY() }
 
@@ -76,7 +79,7 @@ eval {
 print "ok 13\n";
 
 # NAMED METHOD CAN'T REDISPATCH TO AUTOLOAD'ED METHOD (ok 14)
-eval { 
+eval {
 	*C::method = sub{ $_[0]->NEXT::AUTOLOAD() };
 	*C::method = *C::method;
 	eval { $obj->method(); } && print "not ";
@@ -85,11 +88,11 @@ print "ok 14\n";
 
 # BASE CLASS METHODS ONLY REDISPATCHED WITHIN HIERARCHY (ok 15..16)
 my $ob2 = bless {}, "B";
-@val = $ob2->method();         
+my @val = $ob2->method();
 print "not " unless @val==1 && $val[0]==3;
 print "ok 15\n";
 
-@val = $ob2->missing_method(); 
+@val = $ob2->missing_method();
 print "not " unless @val==1 && $val[0]==9;
 print "ok 16\n";
 
@@ -107,7 +110,7 @@ print "ok 22\n";
 # TEST WITH CONSTANTS (23)
 
 package Hay;
-@ISA = 'Bee';
+our @ISA = 'Bee';
 sub foo { return shift->NEXT::foo }
 package Bee;
 use constant foo => 3;
@@ -115,4 +118,5 @@ package main;
 print "not " unless Hay->foo eq '3';
 print "ok 23\n";
 
-# CAN REDISPATCH DESTRUCTORS (ok 24..27)
+
+# CAN REDISPATCH DESTRUCTORS (ok 23..26)

--- a/cpan/NEXT/t/unseen.t
+++ b/cpan/NEXT/t/unseen.t
@@ -1,26 +1,35 @@
+use strict;
+use warnings;
 use Test::More tests => 7;
 
 BEGIN { use_ok('NEXT') };
 my $order = 0;
 
 package A;
-@ISA = qw/B C D/;
+our @ISA = qw/B C D/;
+use if $] >= 5.009005, 'mro', 'dfs';
 
 sub test { ::ok(++$order==1,"test A"); $_[0]->NEXT::UNSEEN::test; 1}
 
 package B;
-@ISA = qw/D C/;
+
+our @ISA = qw/D C/;
+use if $] >= 5.009005, 'mro', 'dfs';
 sub test { ::ok(++$order==2,"test B"); $_[0]->NEXT::UNSEEN::test; 1}
 
 package C;
-@ISA = qw/D/;
+our @ISA = qw/D/;
+use if $] >= 5.009005, 'mro', 'dfs';
+
 sub test { ::ok(++$order==4,"test C"); $_[0]->NEXT::UNSEEN::test; 1}
 
 package D;
+use if $] >= 5.009005, 'mro', 'dfs';
 
 sub test { ::ok(++$order==3,"test D"); $_[0]->NEXT::UNSEEN::test; 1}
 
 package main;
+use if $] >= 5.009005, 'mro', 'dfs';
 
 my $foo = {};
 
@@ -31,6 +40,7 @@ eval{ $foo->test }
 	: fail("Shouldn't die on missing ancestor");
 
 package Diamond::Base;
+use if $] >= 5.009005, 'mro', 'dfs';
 my $seen;
 sub test {
 	$seen++ ? ::fail("Can't visit inherited test twice")
@@ -38,9 +48,13 @@ sub test {
 	shift->NEXT::UNSEEN::test;
 }
 
-package Diamond::Left;  @ISA = qw[Diamond::Base];
-package Diamond::Right; @ISA = qw[Diamond::Base];
-package Diamond::Top;   @ISA = qw[Diamond::Left Diamond::Right];
+package Diamond::Left;  our @ISA = qw[Diamond::Base];
+use if $] >= 5.009005, 'mro', 'dfs';
+package Diamond::Right; our @ISA = qw[Diamond::Base];
+use if $] >= 5.009005, 'mro', 'dfs';
+package Diamond::Top;   our @ISA = qw[Diamond::Left Diamond::Right];
+use if $] >= 5.009005, 'mro', 'dfs';
+
 
 package main;
 


### PR DESCRIPTION
[DELTA]

0.68 2021-04-19 NEILB
    - Fix for RT#123002, so NEXT works with proxy constants
    - Made testsuite clean under strict & warnings
    - Made testsuite pass if running under perls that are already c3.

0.67_03 2021-04-18 NEILB
    - mro was added in Perl 5.9.5, and it's not dual-life, so Reini's
      patch (in 0.67_01) failed on earlier versions of Perl.
      Have now made its use dependent on version, with "use if".

0.67_02 2021-04-18 NEILB
    - Applied patch from Father C so that NEXT works with proxy constants.
      RT#123002

0.67_01 2021-04-18 NEILB
    - Enforced strict and warnings on testsuite. Thanks to ATOOMIC.
    - Added github CI. Thanks to ATOOMIC.
    - @ISA fixes for c3, so tests will pass on perls that use c3 as default
      (for example cperl). Thanks to RURBAN.