### PR TITLE
DO NOT MERGE - Test cygwin via bisect revert.

### DIFF
--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.16';
+our $VERSION = '1.15';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -2356,18 +2356,6 @@ print_long_double()
 #endif
 
 void
-print_long_doubleL()
-        CODE:
-#ifdef HAS_LONG_DOUBLE
-        /* used to test we allow the length modifier required by the standard */
-        long double val = 7.0;
-        printf("%5.3Lf\n",val);
-#else
-        double val = 7.0;
-        printf("%5.3f\n",val);
-#endif
-
-void
 print_int(val)
         int val
         CODE:

--- a/ext/XS-APItest/t/printf.t
+++ b/ext/XS-APItest/t/printf.t
@@ -1,4 +1,12 @@
-use Test::More tests => 13;
+BEGIN {
+  require Config; import Config;
+  if ($Config{usequadmath}) {
+     print "1..0 # Skip: usequadmath\n";
+     exit(0);
+  }
+}
+
+use Test::More tests => 12;
 
 BEGIN { use_ok('XS::APItest') };
 
@@ -21,7 +29,6 @@ print_int(3);
 print_long(4);
 print_float(4);
 print_long_double() if $ldok;  # val=7 hardwired
-print_long_doubleL() if $ldok;  # val=7 hardwired
 
 print_flush();
 
@@ -40,9 +47,8 @@ is($output[2], "4", "print_long");
 is($output[3], "4.000", "print_float");
 
 SKIP: {
-   skip "No long doubles", 2 unless $ldok;
+   skip "No long doubles", 1 unless $ldok;
    is($output[4], "7.000", "print_long_double");
-   is($output[5], "7.000", "print_long_doubleL");
 }
 
 {


### PR DESCRIPTION
Revert "quadmath: handle long doubles supplied via va_args in sv_vcatpvfn_flags()"

This reverts commit 3472c1f6c5f15cb5047171d5a70ef37eccb023ab.