### PR TITLE
workaround unexpected op trees generated by Data::Alias

### DIFF
--- a/op.c
+++ b/op.c
@@ -1964,6 +1964,11 @@ Perl_scalar(pTHX_ OP *o)
         case OP_LEAVETRY:
             kid = cLISTOPo->op_first;
             scalar(kid);
+            if (!OpHAS_SIBLING(kid)) {
+                /* handle broken leave trees */
+                next_kid = kid;
+                goto do_next;
+            }
             kid = OpSIBLING(kid);
         do_kids:
             while (kid) {
@@ -2552,6 +2557,11 @@ Perl_list(pTHX_ OP *o)
         case OP_LEAVETRY:
             kid = cLISTOPo->op_first;
             list(kid);
+            if (!OpHAS_SIBLING(kid)) {
+                /* handle broken leave trees */
+                next_kid = kid;
+                goto do_next;
+            }
             kid = OpSIBLING(kid);
         do_kids:
             while (kid) {


### PR DESCRIPTION
A fix is also required to Data::Alias to fix compilation under -DDEBUGGING builds,

A more recent (apparently parser) issue means Data::Alias still won't pass its tests.