### PR TITLE
fix utime() to set $!/errno when called on a closed handle

### DIFF
--- a/doio.c
+++ b/doio.c
@@ -2766,6 +2766,7 @@ nothing in the core.
 #endif
                     }
                     else {
+                        SETERRNO(EBADF,RMS_IFI);
                         tot--;
                     }
                 }

--- a/t/io/fs.t
+++ b/t/io/fs.t
@@ -265,6 +265,7 @@ SKIP: {
     check_utime_result($ut, $accurate_timestamps, $delta);
     # [perl #122703]
     close $fh;
+    $! = 0;
     ok(!utime($ut,$ut + $delta, $fh),
        "utime fails on a closed file handle");
     isnt($!+0, 0, "and errno was set");


### PR DESCRIPTION
My 8334cae65 was intended to fix this, but the test was faulty, and
didn't correctly fail.

This started showing as a failure on cygwin, with the fixed test it
also fails on Linux, so fix doio.c as well.