### PR TITLE
Add a regex test for changes in 1d8aafa

### DIFF
--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -290,6 +290,7 @@ a[bcd]+dcdcde	adcdcde	n	-	-
 ((((((((((a))))))))))${bang}	aa	n	-	-
 ((((((((((a))))))))))${bang}	a!	y	$&	a!
 (((((((((a)))))))))	a	y	$&	a
+[89]+	1((((((7(9))))))	y	-	-
 multiple words of text	uh-uh	n	-	-
 multiple words	multiple words, yeah	y	$&	multiple words
 (.*)c(.*)	abcde	y	$&-$1-$2	abcde-ab-de


### PR DESCRIPTION
In https://groups.google.com/u/1/g/google-code/c/bn4X3d-89to, Neil
Agarwal wrote:

---

Could someone please explain to me the output of the following Perl
code in Code Jam's test run mode? The system gives "BCD" instead of
"ABCD", and I have not been able to reproduce this behavior anywhere
else.

$S1 = "1((((((7(9))))))";
$S2 = "1((((((7(9)))))";

print "A" if $S1 =~ /[89]+/;
print "B" if $S1 =~ /[9]+/;
print "C" if $S2 =~ /[89]+/;
print "D" if $S2 =~ /[9]+/;

---

I tried to bisect the problem and discovered the wrong behaviour was
introduced in 2813d4adc971fbaa124b5322d4bccaa73e9df8e2 and fixed in
1d8aafa0548097ffe407cad078f79b4d56fd7dca, which means all 5.28.* had
this problem. Google Code Jam used 5.28.1 in the 2021 contest.

This commit adds the original test case to prevent further
regressions.