### PR TITLE
docs: small but important perlexperiment updates

### DIFF
--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -417,6 +417,12 @@ bareword filehandles for older versions of perl.
 
 =head2 The 'try' feature.
 
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::try";
+
 This feature enables the C<try> and C<catch> syntax, which allows exception
 handling, where exceptions throwin from the body of the block introduced with
 C<try> are caught by executing the body of the C<catch> block.

--- a/pod/perlexperiment.pod
+++ b/pod/perlexperiment.pod
@@ -150,6 +150,19 @@ C<experimental::private_use>.
 The ticket for this experiment is
 L<[perl #18758]|https://github.com/Perl/perl5/issues/18758>.
 
+=item Unicode property wildcards
+
+Introduced in Perl 5.30.0.
+
+This feature allows regular expression matching against Unicode character
+properties to be expressed more concisely.
+
+Using this feature triggers warnings in the category
+C<experimental::uniprop_wildcards>.
+
+The ticket for this experiment is
+L<[perl #18759]|https://github.com/Perl/perl5/issues/18759>.
+
 =item isa infix operator
 
 Introduced in Perl 5.32.0.

--- a/pod/perlexperiment.pod
+++ b/pod/perlexperiment.pod
@@ -25,29 +25,29 @@ Modified in Perl 5.10.1, 5.12.0
 Using this feature triggers warnings in the category
 C<experimental::smartmatch>.
 
-The ticket for this feature is
+The ticket for this experiment is
 L<[perl #13173]|https://github.com/Perl/perl5/issues/13173>.
 
 =item Pluggable keywords
 
-The ticket for this feature is
-L<[perl #13199]|https://github.com/Perl/perl5/issues/13199>.
+Introduced in Perl 5.11.2
 
 See L<perlapi/PL_keyword_plugin> for the mechanism.
 
-Introduced in Perl 5.11.2
+The ticket for this experiment is
+L<[perl #13199]|https://github.com/Perl/perl5/issues/13199>.
 
 =item Regular Expression Set Operations
 
 Introduced in Perl 5.18
 
-The ticket for this feature is
+Using this feature triggers warnings in the category
+C<experimental::regex_sets>.
+
+The ticket for this experiment is
 L<[perl #13197]|https://github.com/Perl/perl5/issues/13197>.
 
 See also: L<perlrecharclass/Extended Bracketed Character Classes>
-
-Using this feature triggers warnings in the category
-C<experimental::regex_sets>.
 
 =item Subroutine signatures
 
@@ -56,7 +56,7 @@ Introduced in Perl 5.20.0
 Using this feature triggers warnings in the category
 C<experimental::signatures>.
 
-The ticket for this feature is
+The ticket for this experiment is
 L<[perl #13681]|https://github.com/Perl/perl5/issues/13681>.
 
 =item Aliasing via reference
@@ -66,7 +66,7 @@ Introduced in Perl 5.22.0
 Using this feature triggers warnings in the category
 C<experimental::refaliasing>.
 
-The ticket for this feature is
+The ticket for this experiment is
 L<[perl #14150]|https://github.com/Perl/perl5/issues/14150>.
 
 See also: L<perlref/Assigning to References>
@@ -78,7 +78,7 @@ Introduced in Perl 5.22.0
 Using this feature triggers warnings in the category
 C<experimental::const_attr>.
 
-The ticket for this feature is
+The ticket for this experiment is
 L<[perl #14428]|https://github.com/Perl/perl5/issues/14428>.
 
 See also: L<perlsub/Constant Functions>
@@ -90,11 +90,14 @@ Introduced in Perl 5.22.0
 Using this feature triggers warnings in the category
 C<experimental::re_strict>.
 
+The ticket for this experiment is
+L<[perl #18755]|https://github.com/Perl/perl5/issues/18755>
+
 See L<re/'strict' mode>
 
 =item The <:win32> IO pseudolayer
 
-The ticket for this feature is
+The ticket for this experiment is
 L<[perl #13198]|https://github.com/Perl/perl5/issues/13198>.
 
 See also L<perlrun/PERLIO>
@@ -106,23 +109,27 @@ Introduced in Perl 5.26.0
 Using this feature triggers warnings in the category
 C<experimental::declared_refs>.
 
-The ticket for this feature is
+The ticket for this experiment is
 L<[perl #15458]|https://github.com/Perl/perl5/issues/15458>.
 
 See also: L<perlref/Declaring a Reference to a Variable>
 
 =item There is an C<installhtml> target in the Makefile.
 
-The ticket for this feature is
+The ticket for this experiment is
 L<[perl #12726]|https://github.com/Perl/perl5/issues/12726>.
 
 =item (Limited) Variable-length look-behind
 
-Introduced in Perl 5.30.0.  Variability of up to 255 characters is
-handled.
+Introduced in Perl 5.30.0.
+
+Variability of up to 255 characters is handled.
 
 Using this feature triggers warnings in the category
 C<experimental::vlb>.
+
+The ticket for this experiment is
+L<[perl #18756]|https://github.com/Perl/perl5/issues/18756>.
 
 See also: L<perlre/(*positive_lookbehind:I<pattern>)> and
 L<perlre/(*negative_lookbehind:I<pattern>)>
@@ -134,7 +141,7 @@ Introduced in Perl 5.32.0.
 Using this feature triggers warnings in the category
 C<experimental::isa>.
 
-The ticket for this feature is
+The ticket for this experiment is
 L<[perl #18754]|https://github.com/Perl/perl5/issues/18754>
 
 =back

--- a/pod/perlexperiment.pod
+++ b/pod/perlexperiment.pod
@@ -173,6 +173,15 @@ C<experimental::isa>.
 The ticket for this experiment is
 L<[perl #18754]|https://github.com/Perl/perl5/issues/18754>
 
+=item try/catch control structure
+
+Introduced in Perl 5.34.0.
+
+Using this feature triggers warnings in the category C<experimental::try>.
+
+The ticket for this experiment is
+L<[perl #18760]|https://github.com/Perl/perl5/issues/18760>
+
 =back
 
 =head2 Accepted features

--- a/pod/perlexperiment.pod
+++ b/pod/perlexperiment.pod
@@ -135,7 +135,7 @@ Using this feature triggers warnings in the category
 C<experimental::isa>.
 
 The ticket for this feature is
-L<[perl #17200]|https://github.com/Perl/perl5/issues/17200>
+L<[perl #18754]|https://github.com/Perl/perl5/issues/18754>
 
 =back
 

--- a/pod/perlexperiment.pod
+++ b/pod/perlexperiment.pod
@@ -97,6 +97,9 @@ See L<re/'strict' mode>
 
 =item The <:win32> IO pseudolayer
 
+Using this feature triggers warnings in the category
+C<experimental::win32_perlio>.
+
 The ticket for this experiment is
 L<[perl #13198]|https://github.com/Perl/perl5/issues/13198>.
 

--- a/pod/perlexperiment.pod
+++ b/pod/perlexperiment.pod
@@ -137,6 +137,19 @@ L<[perl #18756]|https://github.com/Perl/perl5/issues/18756>.
 See also: L<perlre/(*positive_lookbehind:I<pattern>)> and
 L<perlre/(*negative_lookbehind:I<pattern>)>
 
+=item Unicode private use character hooks
+
+Introduced in Perl 5.30.0.
+
+This feature is part of an interface intended for internal and experimental
+use by the perl5 developers.  You are unlikely to encounter it in the wild.
+
+Using this feature triggers warnings in the category
+C<experimental::private_use>.
+
+The ticket for this experiment is
+L<[perl #18758]|https://github.com/Perl/perl5/issues/18758>.
+
 =item isa infix operator
 
 Introduced in Perl 5.32.0.

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -823,6 +823,12 @@ bareword filehandles for older versions of perl.
 
 =head2 The 'try' feature.
 
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::try";
+
 This feature enables the C<try> and C<catch> syntax, which allows exception
 handling, where exceptions throwin from the body of the block introduced with
 C<try> are caught by executing the body of the C<catch> block.


### PR DESCRIPTION
This updates the `perlexperiment` document to:

* add GitHub issue links for more tickets
* add a few pieces of missing data
* unify the presentation of data just a _little_ more