### PR TITLE
fix heuristics for setsockopt's OPTVAL argument

### DIFF
--- a/pp_sys.c
+++ b/pp_sys.c
@@ -2723,7 +2723,7 @@ PP(pp_ssockopt)
             const char *buf;
             int aint;
             SvGETMAGIC(sv);
-            if (SvPOKp(sv)) {
+            if (SvPOK(sv)) {    /* sv is originally a string */
                 STRLEN l;
                 buf = SvPVbyte_nomg(sv, l);
                 len = l;

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -2723,7 +2723,7 @@ PP(pp_ssockopt)
             const char *buf;
             int aint;
             SvGETMAGIC(sv);
-            if (SvPOK(sv)) {    /* sv is originally a string */
+            if (SvPOK(sv) && !SvIsBOOL(sv)) { /* sv is originally a string */
                 STRLEN l;
                 buf = SvPVbyte_nomg(sv, l);
                 len = l;

--- a/t/io/socket.t
+++ b/t/io/socket.t
@@ -335,6 +335,43 @@ SKIP: {
     is(unpack('i', $set_ttl // ''), $ttl, 'TTL set to desired value');
 }
 
+# GH #19892
+SKIP: {
+    eval { Socket::IPPROTO_TCP(); 1 } or skip 'no IPPROTO_TCP', 1;
+    eval { Socket::SOL_SOCKET(); 1 } or skip 'no SOL_SOCKET', 1;
+    eval { Socket::SO_RCVBUF(); 1 } or skip 'no SO_RCVBUF', 1;
+
+    # The value of RCVBUF_SIZE constant below is changed from #19892 testcase;
+    # original "262144" may be clamped on low-memory systems.
+    fresh_perl_is(<<'EOP', "Ok.\n", {}, 'setsockopt works for a constant that is once stringified');
+use warnings;
+use strict;
+
+use Socket qw'PF_INET SOCK_STREAM IPPROTO_TCP SOL_SOCKET SO_RCVBUF';
+
+use constant { RCVBUF_SIZE => 32768 };
+
+socket(my $sock, PF_INET, SOCK_STREAM, IPPROTO_TCP)
+  or die "Could not create socket - $!\n";
+
+setsockopt($sock,SOL_SOCKET,SO_RCVBUF,RCVBUF_SIZE)
+  or die "Could not set SO_RCVBUF on socket - $!\n";
+
+my $rcvBuf=getsockopt($sock,SOL_SOCKET,SO_RCVBUF)
+  or die "Could not get SO_RCVBUF on socket - $!\n";
+
+$rcvBuf=unpack('i',$rcvBuf);
+
+die "Unexpected SO_RCVBUF value: $rcvBuf\n"
+  unless($rcvBuf == RCVBUF_SIZE || $rcvBuf == 2*RCVBUF_SIZE);
+
+print "Ok.\n";
+exit;
+
+sub bug {RCVBUF_SIZE.''}
+EOP
+}
+
 done_testing();
 
 my @child_tests;

--- a/t/io/socket.t
+++ b/t/io/socket.t
@@ -307,6 +307,16 @@ SKIP:
        "set SO_REUSEADDR from magic");
     isnt(getsockopt($sock, SOL_SOCKET, SO_REUSEADDR), pack("i", 0),
        "check SO_REUSEADDR set correctly");
+
+    # test whether boolean value treated as a number
+    ok(setsockopt($sock, SOL_SOCKET, SO_REUSEADDR, !1),
+       "clear SO_REUSEADDR by a boolean false");
+    is(getsockopt($sock, SOL_SOCKET, SO_REUSEADDR), pack("i", 0),
+       "check SO_REUSEADDR cleared correctly");
+    ok(setsockopt($sock, SOL_SOCKET, SO_REUSEADDR, !0),
+       "set SO_REUSEADDR by a boolean true");
+    isnt(getsockopt($sock, SOL_SOCKET, SO_REUSEADDR), pack("i", 0),
+         "check SO_REUSEADDR set correctly");
 }
 
 # GH #18642 - test whether setsockopt works with a numeric OPTVAL which also


### PR DESCRIPTION
`pp_ssockopt` used to treat its last argument (`OPTVAL`) as a packed string whenever it has string slot set (SvPOKp), but this would be confused if the argument is an integer but had cached stringified value.
This PR will make it treat `OPTVAL` as a packed string only when it does not contain any valid public numeric value.

Will fix #18642.