### PR TITLE
Fix perlop.pod about isa operator's precedence

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -134,9 +134,9 @@ values only, not array values.
     left	+ - .
     left	<< >>
     nonassoc	named unary operators
+    nonassoc    isa
     chained 	< > <= >= lt gt le ge
     chain/na	== != eq ne <=> cmp ~~
-    nonassoc    isa
     left	& &.
     left	| |. ^ ^.
     left	&&


### PR DESCRIPTION
Tiny one-line docs fix - perhaps we can allow this in before 5.34?