### PR TITLE
Data::Dumper: rework Unicode-in-qr support

### DIFF
--- a/dist/Data-Dumper/Dumper.pm
+++ b/dist/Data-Dumper/Dumper.pm
@@ -29,7 +29,7 @@ our ( $Indent, $Trailingcomma, $Purity, $Pad, $Varname, $Useqq, $Terse, $Freezer
 our ( @ISA, @EXPORT, @EXPORT_OK, $VERSION );
 
 BEGIN {
-    $VERSION = '2.178'; # Don't forget to set version and release
+    $VERSION = '2.179'; # Don't forget to set version and release
                         # date in POD below!
 
     @ISA = qw(Exporter);
@@ -1478,7 +1478,7 @@ modify it under the same terms as Perl itself.
 
 =head1 VERSION
 
-Version 2.178
+Version 2.179
 
 =head1 SEE ALSO
 

--- a/dist/Data-Dumper/Dumper.pm
+++ b/dist/Data-Dumper/Dumper.pm
@@ -394,7 +394,9 @@ sub _dump {
         else {
           $pat = "$val";
         }
-        $pat =~ s <(\\.)|/> { $1 || '\\/' }ge;
+        $pat =~ s <(\\.)|(/)|([^[:ascii:]])> {
+            $1 // (defined $2 ? '\\/' : sprintf '\x{%x}', ord $3)
+        }ge;
         $out .= "qr/$pat/$flags";
     }
     elsif ($realtype eq 'SCALAR' || $realtype eq 'REF'

--- a/dist/Data-Dumper/t/dumper.t
+++ b/dist/Data-Dumper/t/dumper.t
@@ -1709,6 +1709,7 @@ EOW
 #############
 {
   # [github #18614 - handling of Unicode characters in regexes]
+  # [github #18764 - … without breaking subsequent Latin-1]
   if ($] lt '5.010') {
       SKIP_TEST "Incomplete support for UTF-8 in old perls";
       SKIP_TEST "Incomplete support for UTF-8 in old perls";
@@ -1717,15 +1718,18 @@ EOW
 $WANT = <<"EOW";
 #\$VAR1 = [
 #  "\\x{41f}",
-#  qr/\x{8b80}/,
-#  qr/\x{41f}/
+#  qr/\\x{8b80}/,
+#  qr/\\x{41f}/,
+#  qr/\\x{e4}/,
+#  '\xE4'
 #];
 EOW
   $WANT =~ s{/(,?)$}{/u$1}mg if $] gt '5.014';
-  TEST qq(Data::Dumper->Dump([ [qq/\x{41f}/, qr/\x{8b80}/, qr/\x{41f}/] ])),
+  TEST qq(Data::Dumper->Dump([ [qq/\x{41f}/, qr/\x{8b80}/, qr/\x{41f}/, qr/\x{e4}/, "\xE4"] ])),
     "string with Unicode + regexp with Unicode";
 
-  TEST qq(Data::Dumper->Dumpxs([ [qq/\x{41f}/, qr/\x{8b80}/, qr/\x{41f}/] ])),
+  $WANT =~ s/'\xE4'/"\\x{e4}"/;
+  TEST qq(Data::Dumper->Dumpxs([ [qq/\x{41f}/, qr/\x{8b80}/, qr/\x{41f}/, qr/\x{e4}/, "\xE4"] ])),
     "string with Unicode + regexp with Unicode, XS"
     if $XS;
 }


### PR DESCRIPTION
The previous approach was to upgrade the output to the internal UTF-8
encoding when dumping a regex containing supra-Latin-1 characters. That
has the disadvantage that nothing else generates wide characters in the
output, or even knows that the output might be upgraded.

A better approach, and one that's more consistent with the one taken for
string literals, is to use `\x{…}` notation where needed.

Closes #18764