### PR TITLE
Skip all if built with -DSILENT_NO_TAINT_SUPPORT

### DIFF
--- a/t/op/taint.t
+++ b/t/op/taint.t
@@ -12,6 +12,14 @@ BEGIN {
     require './test.pl';
     set_up_inc('../lib');
     require './loc_tools.pl';
+    use Config;
+    skip_all("perl built with SILENT_NO_TAINT_SUPPORT") if (
+        $Config{ccflags} =~ m/-DSILENT_NO_TAINT_SUPPORT/
+            or
+        $Config{cppflags} =~ m/-DSILENT_NO_TAINT_SUPPORT/
+            or
+        $Config{ccflags_nolargefiles} =~ m/-DSILENT_NO_TAINT_SUPPORT/
+    );
 }
 
 use strict;


### PR DESCRIPTION
What formerly was bug ticket RT # 134287 is now GH issue
https://github.com/Perl/perl5/issues/17095.

This p.r. replaces patches attached to that ticket.