### PR TITLE
Always set -fwrapv in the gcc compiler flags on Win32.

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -583,15 +583,14 @@ MINIBUILDOPT    += -D__USE_MINGW_ANSI_STDIO
 endif
 
 
-# If you are using GCC, 4.3 or later by default we add the -fwrapv option.
-# See https://github.com/Perl/perl5/issues/13690
-#
-GCCWRAPV := $(shell if "$(GCCVER1)"=="4" (if "$(GCCVER2)" geq "3" echo define) else if "$(GCCVER1)" geq "5" (echo define))
+# Previously, if you were using GCC, 4.3 or later we addeed the -fwrapv option.
+# See https://github.com/Perl/perl5/issues/13690 and 18739
+# However, as documented in README.win32 our minimum Win32 gcc version is 3.4.5.
+# As that supports -fwrapv it's both simpler and more correct to unconditionally
+# add it to the flags:
 
-ifeq ($(GCCWRAPV),define)
 BUILDOPT        += -fwrapv
 MINIBUILDOPT    += -fwrapv
-endif
 
 i = .i
 o = .o


### PR DESCRIPTION
We need this because we are unfortunately relying on the behaviour of signed
integer overflow. This is undefined behaviour in C (which gcc's optimiser
likes to take advantage of) unless we use this flag.

Previously we had used it conditionally based on gcc version, but that code
failed to consider gcc versions greater than 9. We realise that the flag is
actually present from the minimum gcc that we support, so we should simply
add it always. Fixes #18739.