### PR TITLE
set -fwrapv on by default unconditionally

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -583,10 +583,11 @@ MINIBUILDOPT    += -D__USE_MINGW_ANSI_STDIO
 endif
 
 
-# If you are using GCC, 4.3 or later by default we add the -fwrapv option.
+# By default add -fwrapv, since we depend on 2's complement behaviour
+# for signed numbers.
 # See https://github.com/Perl/perl5/issues/13690
 #
-GCCWRAPV := $(shell if "$(GCCVER1)"=="4" (if "$(GCCVER2)" geq "3" echo define) else if "$(GCCVER1)" geq "5" (echo define))
+GCCWRAPV := define
 
 ifeq ($(GCCWRAPV),define)
 BUILDOPT        += -fwrapv


### PR DESCRIPTION
This was broken on gcc 10, and we want -fwrapv for all versions of
gcc that we support.

We also want a developer to be able to disable it easily
(GCCWRAPV=undef) so it remains a flag rather than hard-coding
-frwapv below.

fixes #18739 