### PR TITLE
Make scalar assignment to undef a compile time error (Closes #18779)

### DIFF
--- a/op.c
+++ b/op.c
@@ -4291,6 +4291,8 @@ Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
 
     switch (o->op_type) {
     case OP_UNDEF:
+        if (type == OP_SASSIGN)
+            goto nomod;
 	PL_modcount++;
 	goto do_next;
 

--- a/t/run/fresh_perl.t
+++ b/t/run/fresh_perl.t
@@ -194,8 +194,8 @@ BEGIN failed--compilation aborted at - line 1.
 ########
 BEGIN { undef = 0 }
 EXPECT
-Modification of a read-only value attempted at - line 1.
-BEGIN failed--compilation aborted at - line 1.
+Can't modify undef operator in scalar assignment at - line 1, near "0 }"
+BEGIN not safe after errors--compilation aborted at - line 1.
 ########
 {
     package foo;


### PR DESCRIPTION
Scalar assignment to undef is currently a runtime error:

````
# perl -c -e 'undef = my $foo;'
-e syntax OK
# perl -e 'undef = my $foo;'
Modification of a read-only value attempted at -e line 1.
````
It would be helpful for users to learn that this is invalid
syntax as soon as possible, i.e. at compile time. This
was requested in [[GH#18779](https://github.com/Perl/perl5/issues/18779)].

This PR makes it a compile time error:
````
# ./miniperl -c -e 'undef = my $foo;'
Can't modify undef operator in scalar assignment at -e line 1, near "$foo;"
-e had compilation errors.
````
It does not break the existing list assignment behaviour (even when the
assignment is entirely useless):
````
# ./miniperl -e '(undef) = my $foo;'
# 
````
A grep of CPAN suggests that no (or minimal) breakage is likely.