### PR TITLE
use64bitint is mandatory for NetBSD.

### DIFF
--- a/hints/netbsd.sh
+++ b/hints/netbsd.sh
@@ -300,3 +300,12 @@ EOM
 ;;
 esac
 EOCBU
+
+# use64bitint is mandatory for NetBSD 4.0 and later, where ino_t is uint64_t.
+case "$osver" in
+[0-3].*)
+	;;
+*)
+	use64bitint=yes
+	;;
+esac


### PR DESCRIPTION
Forcibly enable use64bitint for NetBSD 4.0 and later, where ino_t is uint64_t.

Otherwise, miniperl cannot open files whose inode numbers are not within
32-bit integer. This results in random build failures.