### PR TITLE
fall back to getcwd() if we can't find system "pwd"

### DIFF
--- a/dist/PathTools/Cwd.pm
+++ b/dist/PathTools/Cwd.pm
@@ -3,7 +3,7 @@ use strict;
 use Exporter;
 
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 my $xs_version = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/dist/PathTools/Cwd.pm
+++ b/dist/PathTools/Cwd.pm
@@ -212,7 +212,8 @@ unless ($METHOD_MAP{$^O}{cwd} or defined &cwd) {
 	*cwd = \&_backtick_pwd;
     }
     else {
-	*cwd = \&getcwd;
+        # getcwd() might have an empty prototype
+	*cwd = sub { getcwd(); };
     }
 }
 

--- a/dist/PathTools/Cwd.pm
+++ b/dist/PathTools/Cwd.pm
@@ -213,20 +213,6 @@ sub _backtick_pwd {
 # we take care not to override an existing definition for cwd().
 
 unless ($METHOD_MAP{$^O}{cwd} or defined &cwd) {
-    # The pwd command is not available in some chroot(2)'ed environments
-    my $sep = $Config::Config{path_sep} || ':';
-    my $os = $^O;  # Protect $^O from tainting
-
-
-    # Try again to find a pwd, this time searching the whole PATH.
-    if (defined $ENV{PATH} and $os ne 'MSWin32') {  # no pwd on Windows
-	my @candidates = split($sep, $ENV{PATH});
-	while (!$found_pwd_cmd and @candidates) {
-	    my $candidate = shift @candidates;
-	    $found_pwd_cmd = 1 if -x "$candidate/pwd";
-	}
-    }
-
     if( $found_pwd_cmd )
     {
 	*cwd = \&_backtick_pwd;

--- a/dist/PathTools/Cwd.pm
+++ b/dist/PathTools/Cwd.pm
@@ -181,12 +181,6 @@ if ($^O =~ /android/) {
 }
 
 my $found_pwd_cmd = defined($pwd_cmd);
-unless ($pwd_cmd) {
-    # Isn't this wrong?  _backtick_pwd() will fail if someone has
-    # pwd in their path but it is not /bin/pwd or /usr/bin/pwd?
-    # See [perl #16774]. --jhi
-    $pwd_cmd = 'pwd';
-}
 
 # Lazy-load Carp
 sub _carp  { require Carp; Carp::carp(@_)  }

--- a/dist/PathTools/lib/File/Spec.pm
+++ b/dist/PathTools/lib/File/Spec.pm
@@ -2,7 +2,7 @@ package File::Spec;
 
 use strict;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 my %module = (

--- a/dist/PathTools/lib/File/Spec/AmigaOS.pm
+++ b/dist/PathTools/lib/File/Spec/AmigaOS.pm
@@ -3,7 +3,7 @@ package File::Spec::AmigaOS;
 use strict;
 require File::Spec::Unix;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Cygwin.pm
+++ b/dist/PathTools/lib/File/Spec/Cygwin.pm
@@ -3,7 +3,7 @@ package File::Spec::Cygwin;
 use strict;
 require File::Spec::Unix;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Epoc.pm
+++ b/dist/PathTools/lib/File/Spec/Epoc.pm
@@ -2,7 +2,7 @@ package File::Spec::Epoc;
 
 use strict;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 require File::Spec::Unix;

--- a/dist/PathTools/lib/File/Spec/Functions.pm
+++ b/dist/PathTools/lib/File/Spec/Functions.pm
@@ -3,7 +3,7 @@ package File::Spec::Functions;
 use File::Spec;
 use strict;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 require Exporter;

--- a/dist/PathTools/lib/File/Spec/Mac.pm
+++ b/dist/PathTools/lib/File/Spec/Mac.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/OS2.pm
+++ b/dist/PathTools/lib/File/Spec/OS2.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Unix.pm
+++ b/dist/PathTools/lib/File/Spec/Unix.pm
@@ -3,7 +3,7 @@ package File::Spec::Unix;
 use strict;
 use Cwd ();
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 =head1 NAME

--- a/dist/PathTools/lib/File/Spec/VMS.pm
+++ b/dist/PathTools/lib/File/Spec/VMS.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Win32.pm
+++ b/dist/PathTools/lib/File/Spec/Win32.pm
@@ -5,7 +5,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);


### PR DESCRIPTION
I'm not sure why we differentiate them, and the fallback here doesn't differentiate them.

The other changes here, if we don't find pwd in a standard place, searching PATH isn't useful since we clear that before trying to run pwd.

I also removed the fallback to plain pwd, since we clear the PATH it can't be found on the PATH, and we won't invoke a shell unless the string contains shell metacharacters, which "pwd" doesn't.

sort of fixes #18703 