### PR TITLE
Data::Dumper handles Unicode regex corner cases (GH #18614, GH #18764)

### DIFF
--- a/dist/Data-Dumper/Changes
+++ b/dist/Data-Dumper/Changes
@@ -6,6 +6,10 @@ Changes - public release history for Data::Dumper
 
 =over 8
 
+=item 2.179_50 (May 14 2021)
+
+Data::Dumper handles Unicode regex corner cases (GH #18614, GH #18764)
+
 =item 2.179 (May 13 2021)
 
 Revert the changes of 2.177 for the v5.34.0 release to avoid a regression.

--- a/dist/Data-Dumper/Changes
+++ b/dist/Data-Dumper/Changes
@@ -6,11 +6,35 @@ Changes - public release history for Data::Dumper
 
 =over 8
 
-=item 2.173
+=item 2.179 (May 13 2021)
+
+Revert the changes of 2.177 for the v5.34.0 release to avoid a regression.
+
+=item 2.178 (Apr  7 2021)
+
+Correct documentation of indent Style 2.
+
+=item 2.177 (Mar  3 2021)
+
+Make Data::Dumper mark regex output as UTF-8 if needed. (GH #18614)
+
+=item 2.176 (Sep 30 2020)
+
+Make Data::Dumper strict and warnings compliant.
+
+=item 2.175 (Aug 13 2020)
+
+Avoid some leaks if we call get magic and that throws an exception.
+
+=item 2.174 (Apr  3 2019)
+
+Avoid leaking if we croak due to excessive recursion.
+
+=item 2.173 (Nov 10 2018)
 
 perl #133624: Reinstate support for 5.8.8 and older.
 
-=item 2.172
+=item 2.172 (Sep 19 2018)
 
 Prepare recent changes for CPAN release
 

--- a/dist/Data-Dumper/Dumper.pm
+++ b/dist/Data-Dumper/Dumper.pm
@@ -29,7 +29,7 @@ our ( $Indent, $Trailingcomma, $Purity, $Pad, $Varname, $Useqq, $Terse, $Freezer
 our ( @ISA, @EXPORT, @EXPORT_OK, $VERSION );
 
 BEGIN {
-    $VERSION = '2.178'; # Don't forget to set version and release
+    $VERSION = '2.179'; # Don't forget to set version and release
                         # date in POD below!
 
     @ISA = qw(Exporter);
@@ -1476,7 +1476,7 @@ modify it under the same terms as Perl itself.
 
 =head1 VERSION
 
-Version 2.178
+Version 2.179
 
 =head1 SEE ALSO
 

--- a/dist/Data-Dumper/Dumper.pm
+++ b/dist/Data-Dumper/Dumper.pm
@@ -29,7 +29,7 @@ our ( $Indent, $Trailingcomma, $Purity, $Pad, $Varname, $Useqq, $Terse, $Freezer
 our ( @ISA, @EXPORT, @EXPORT_OK, $VERSION );
 
 BEGIN {
-    $VERSION = '2.179'; # Don't forget to set version and release
+    $VERSION = '2.179_50'; # Don't forget to set version and release
                         # date in POD below!
 
     @ISA = qw(Exporter);
@@ -1476,7 +1476,7 @@ modify it under the same terms as Perl itself.
 
 =head1 VERSION
 
-Version 2.179
+Version 2.179_50
 
 =head1 SEE ALSO
 

--- a/dist/Data-Dumper/Dumper.xs
+++ b/dist/Data-Dumper/Dumper.xs
@@ -2,9 +2,14 @@
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
+/* FIXME - we should go through the code and validate what we can remove.
+   Looks like we could elimiate much of our custom utf8_to_uvchr_buf games in
+   favour of ppport.h, and likewise if we replace my_sprintf with my_snprintf
+   some more complexity dies. */
 #ifdef USE_PPPORT_H
 #  define NEED_my_snprintf
 #  define NEED_sv_2pv_flags
+#  define NEED_utf8_to_uvchr_buf
 #  include "ppport.h"
 #endif
 

--- a/dist/Data-Dumper/Dumper.xs
+++ b/dist/Data-Dumper/Dumper.xs
@@ -651,10 +651,6 @@ dump_regexp(pTHX_ SV *retval, SV *val)
 
     assert(sv_pattern);
 
-    if (SvUTF8(sv_pattern)) {
-        sv_utf8_upgrade(retval);
-    }
-
     rval = SvPV(sv_pattern, rlen);
     rend = rval+rlen;
     slash = rval;

--- a/dist/Data-Dumper/t/dumper.t
+++ b/dist/Data-Dumper/t/dumper.t
@@ -1734,9 +1734,6 @@ EOW
   TEST qq(Data::Dumper->Dump([ [qq/\x{41f}/, qr/\x{8b80}/, qr/\x{41f}/, qr/\x{e4}/, "\xE4"] ])),
     "string with Unicode + regexp with Unicode";
 
-  SKIP_TEST "skipped, pending fix for github #18764";
-  last;
-
   $WANT =~ s/'\xE4'/"\\x{e4}"/;
   $WANT =~ s<([^\0-\177])> <sprintf '\\x{%x}', ord $1>ge;
   TEST qq(Data::Dumper->Dumpxs([ [qq/\x{41f}/, qr/\x{8b80}/, qr/\x{41f}/, qr/\x{e4}/, "\xE4"] ])),
@@ -1796,9 +1793,6 @@ EOW
   }
   TEST qq(Data::Dumper->Dump([ [ '\x{2e18}', qr! \x{203d}/ !, qr! \\\x{203d}/ !, qr! \\\x{203d}$bs:/ !, "\xa3"] ])),
       "github #18614, github #18764, perl #58608 corner cases";
-
-  SKIP_TEST "skipped, pending fix for github #18764";
-  last;
 
   $WANT =~ s/'\x{A3}'/"\\x{a3}"/;
   $WANT =~ s/\x{203D}/\\x{203d}/g;

--- a/dist/Data-Dumper/t/dumper.t
+++ b/dist/Data-Dumper/t/dumper.t
@@ -1725,6 +1725,9 @@ EOW
   TEST qq(Data::Dumper->Dump([ [qq/\x{41f}/, qr/\x{8b80}/, qr/\x{41f}/] ])),
     "string with Unicode + regexp with Unicode";
 
+  SKIP_TEST "skipped, pending fix for github #18764";
+  last;
+
   TEST qq(Data::Dumper->Dumpxs([ [qq/\x{41f}/, qr/\x{8b80}/, qr/\x{41f}/] ])),
     "string with Unicode + regexp with Unicode, XS"
     if $XS;

--- a/dist/Data-Dumper/t/dumper.t
+++ b/dist/Data-Dumper/t/dumper.t
@@ -139,7 +139,7 @@ sub SKIP_TEST {
   ++$TNUM; print "ok $TNUM # skip $reason\n";
 }
 
-$TMAX = 474;
+$TMAX = 480;
 
 # Force Data::Dumper::Dump to use perl. We test Dumpxs explicitly by calling
 # it direct. Out here it lets us knobble the next if to test that the perl
@@ -1731,6 +1731,32 @@ EOW
   TEST qq(Data::Dumper->Dumpxs([ [qq/\x{41f}/, qr/\x{8b80}/, qr/\x{41f}/] ])),
     "string with Unicode + regexp with Unicode, XS"
     if $XS;
+}
+#############
+{
+  # [more perl #58608 tests]
+  my $bs = "\\\\";
+  $WANT = <<"EOW";
+#\$VAR1 = [
+#  qr/ \\/ /,
+#  qr/ \\?\\/ /,
+#  qr/ $bs\\/ /,
+#  qr/ $bs:\\/ /,
+#  qr/ \\?$bs:\\/ /,
+#  qr/ $bs$bs\\/ /,
+#  qr/ $bs$bs:\\/ /,
+#  qr/ $bs$bs$bs\\/ /
+#];
+EOW
+  if ($] lt '5.010001') {
+      $WANT =~ s!qr/!qr/(?-xism:!g;
+      $WANT =~ s! /! )/!g;
+  }
+  TEST qq(Data::Dumper->Dump([ [qr! / !, qr! \\?/ !, qr! $bs/ !, qr! $bs:/ !, qr! \\?$bs:/ !, qr! $bs$bs/ !, qr! $bs$bs:/ !, qr! $bs$bs$bs/ !, ] ])),
+      "more perl #58608";
+  TEST qq(Data::Dumper->Dump([ [qr! / !, qr! \\?/ !, qr! $bs/ !, qr! $bs:/ !, qr! \\?$bs:/ !, qr! $bs$bs/ !, qr! $bs$bs:/ !, qr! $bs$bs$bs/ !, ] ])),
+      "more perl #58608 XS"
+      if $XS;
 }
 #############
 {

--- a/dist/Devel-PPPort/parts/inc/utf8
+++ b/dist/Devel-PPPort/parts/inc/utf8
@@ -359,7 +359,9 @@ utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
          * disabled, so this 'if' will be true, and so later on, we know that
          * 's' is dereferencible */
         if (do_warnings) {
-            *retlen = (STRLEN) -1;
+            if (retlen) {
+                *retlen = (STRLEN) -1;
+            }
         }
         else {
             ret = D_PPP_utf8_to_uvchr_buf_callee(


### PR DESCRIPTION
My suggested plan is

1. smoke this
2. merge **adb79bc** into blead before RC2 (so version **2.179**). This reverts the behaviour to how it was on v5.32.0
3. push a dev release of this branch to CPAN to see what the testers think
4. if happy, ship **2.180** to CPAN
5. v5.34.0 ships

The fix for all the bugs feels a bit too risky to put into blead at this time, but we can iterate CPAN release for Data::Dumper much faster than RCs (or v5.34.1). The plan above ensures that

1. There is never a behaviour regression for the version downloaded from CPAN
2. There is a fix immediately available to adopters of v5.34.0, for anyone that needs it

I don't think that we need to change the pure-perl output for `qr//` with Unicode, as (I believe) it wasn't buggy, hence i left it unchanged and adapted the tests.