### PR TITLE
compare inode numbers as strings in PathTools

### DIFF
--- a/dist/PathTools/Cwd.pm
+++ b/dist/PathTools/Cwd.pm
@@ -275,7 +275,7 @@ sub fastcwd_ {
 	($odev, $oino) = ($cdev, $cino);
 	CORE::chdir('..') || return undef;
 	($cdev, $cino) = stat('.');
-	last if $odev == $cdev && $oino == $cino;
+	last if $odev == $cdev && $oino eq $cino;
 	opendir(DIR, '.') || return undef;
 	for (;;) {
 	    $direntry = readdir(DIR);
@@ -284,7 +284,7 @@ sub fastcwd_ {
 	    next if $direntry eq '..';
 
 	    ($tdev, $tino) = lstat($direntry);
-	    last unless $tdev != $odev || $tino != $oino;
+	    last unless $tdev != $odev || $tino ne $oino;
 	}
 	closedir(DIR);
 	return undef unless defined $direntry; # should never happen
@@ -298,7 +298,7 @@ sub fastcwd_ {
 	&& CORE::chdir($1) or return undef;
     ($cdev, $cino) = stat('.');
     die "Unstable directory path, current directory changed unexpectedly"
-	if $cdev != $orig_cdev || $cino != $orig_cino;
+	if $cdev != $orig_cdev || $cino ne $orig_cino;
     $path;
 }
 if (not defined &fastcwd) { *fastcwd = \&fastcwd_ }
@@ -315,7 +315,7 @@ sub chdir_init {
     if ($ENV{'PWD'} and $^O ne 'os2' and $^O ne 'dos' and $^O ne 'MSWin32') {
 	my($dd,$di) = stat('.');
 	my($pd,$pi) = stat($ENV{'PWD'});
-	if (!defined $dd or !defined $pd or $di != $pi or $dd != $pd) {
+	if (!defined $dd or !defined $pd or $di ne $pi or $dd != $pd) {
 	    $ENV{'PWD'} = cwd();
 	}
     }
@@ -328,7 +328,7 @@ sub chdir_init {
     if ($^O ne 'MSWin32' and $ENV{'PWD'} =~ m|(/[^/]+(/[^/]+/[^/]+))(.*)|s) {
 	my($pd,$pi) = stat($2);
 	my($dd,$di) = stat($1);
-	if (defined $pd and defined $dd and $di == $pi and $dd == $pd) {
+	if (defined $pd and defined $dd and $di ne $pi and $dd == $pd) {
 	    $ENV{'PWD'}="$2$3";
 	}
     }
@@ -430,7 +430,7 @@ sub _perl_abs_path
 	    $! = $e;
 	    return undef;
 	}
-	if ($pst[0] == $cst[0] && $pst[1] == $cst[1])
+	if ($pst[0] == $cst[0] && $pst[1] eq $cst[1])
 	{
 	    $dir = undef;
 	}
@@ -448,7 +448,7 @@ sub _perl_abs_path
 		$tst[0] = $pst[0]+1 unless (@tst = lstat("$dotdots/$dir"))
 	    }
 	    while ($dir eq '.' || $dir eq '..' || $tst[0] != $pst[0] ||
-		   $tst[1] != $pst[1]);
+		   $tst[1] ne $pst[1]);
 	}
 	$cwd = (defined $dir ? "$dir" : "" ) . "/$cwd" ;
 	closedir(PARENT);

--- a/dist/PathTools/Cwd.pm
+++ b/dist/PathTools/Cwd.pm
@@ -3,7 +3,7 @@ use strict;
 use Exporter;
 
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 my $xs_version = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/dist/PathTools/lib/File/Spec.pm
+++ b/dist/PathTools/lib/File/Spec.pm
@@ -2,7 +2,7 @@ package File::Spec;
 
 use strict;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 my %module = (

--- a/dist/PathTools/lib/File/Spec/AmigaOS.pm
+++ b/dist/PathTools/lib/File/Spec/AmigaOS.pm
@@ -3,7 +3,7 @@ package File::Spec::AmigaOS;
 use strict;
 require File::Spec::Unix;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Cygwin.pm
+++ b/dist/PathTools/lib/File/Spec/Cygwin.pm
@@ -3,7 +3,7 @@ package File::Spec::Cygwin;
 use strict;
 require File::Spec::Unix;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Epoc.pm
+++ b/dist/PathTools/lib/File/Spec/Epoc.pm
@@ -2,7 +2,7 @@ package File::Spec::Epoc;
 
 use strict;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 require File::Spec::Unix;

--- a/dist/PathTools/lib/File/Spec/Functions.pm
+++ b/dist/PathTools/lib/File/Spec/Functions.pm
@@ -3,7 +3,7 @@ package File::Spec::Functions;
 use File::Spec;
 use strict;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 require Exporter;

--- a/dist/PathTools/lib/File/Spec/Mac.pm
+++ b/dist/PathTools/lib/File/Spec/Mac.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/OS2.pm
+++ b/dist/PathTools/lib/File/Spec/OS2.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Unix.pm
+++ b/dist/PathTools/lib/File/Spec/Unix.pm
@@ -3,7 +3,7 @@ package File::Spec::Unix;
 use strict;
 use Cwd ();
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 =head1 NAME

--- a/dist/PathTools/lib/File/Spec/VMS.pm
+++ b/dist/PathTools/lib/File/Spec/VMS.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Win32.pm
+++ b/dist/PathTools/lib/File/Spec/Win32.pm
@@ -5,7 +5,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.80';
+our $VERSION = '3.81';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);


### PR DESCRIPTION
Partly fixes #18788.

The change from https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/pull/395 is also needed.