### PR TITLE
Perl_newSVnv: inline relevant subset of sv_setnv

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -9605,10 +9605,12 @@ The reference count for the SV is set to 1.
 SV *
 Perl_newSVnv(pTHX_ const NV n)
 {
-    SV *sv;
+    SV *sv = newSV_type(SVt_NV);
+    (void)SvNOK_on(sv);
 
-    new_SV(sv);
-    sv_setnv(sv,n);
+    SvNV_set(sv, n);
+    SvTAINT(sv);
+
     return sv;
 }
 

--- a/sv.c
+++ b/sv.c
@@ -9626,20 +9626,7 @@ SV is set to 1.
 SV *
 Perl_newSViv(pTHX_ const IV i)
 {
-    SV *sv;
-
-    new_SV(sv);
-
-    /* Inlining ONLY the small relevant subset of sv_setiv here
-     * for performance. Makes a significant difference. */
-
-    /* We're starting from SVt_FIRST, so provided that's
-     * actual 0, we don't have to unset any SV type flags
-     * to promote to SVt_IV. */
-    STATIC_ASSERT_STMT(SVt_FIRST == 0);
-
-    SET_SVANY_FOR_BODYLESS_IV(sv);
-    SvFLAGS(sv) |= SVt_IV;
+    SV *sv = newSV_type(SVt_IV);
     (void)SvIOK_on(sv);
 
     SvIV_set(sv, i);


### PR DESCRIPTION
This PR takes its cue from `Perl_newSViv`, which already inlines the relevant subset of `sv_setiv`. This cuts out any function call overhead, a switch statement leading to a `sv_upgrade(sv, SVt_NV)` call, and a touch more bit-twiddling than is necessary.