### PR TITLE
Report Data::Dumper problems to Perl 5 Github issues queue

### DIFF
--- a/dist/Data-Dumper/Makefile.PL
+++ b/dist/Data-Dumper/Makefile.PL
@@ -1,10 +1,23 @@
 use strict;
 use warnings;
 use ExtUtils::MakeMaker;
+
+my @extra;
+push @extra, 'LICENSE' => 'perl_5'
+    unless $ExtUtils::MakeMaker::VERSION < 6.31;
+push @extra, 'META_MERGE' => {
+        resources => {
+            repository  => 'git://perl5.git.perl.org/perl.git',
+            bugtracker => 'https://github.com/Perl/perl5/issues',
+            homepage    => "http://dev.perl.org/",
+        },
+    } unless $ExtUtils::MakeMaker::VERSION < 6.46;
+
 WriteMakefile(
     NAME          => 'Data::Dumper',
     VERSION_FROM  => 'Dumper.pm',
     ABSTRACT_FROM => 'Dumper.pm',
     $] <= 5.011000 ? ( INSTALLDIRS => 'perl' ) : (),
     ((grep { $_ eq 'PERL_CORE=1' } @ARGV) ? () : ('DEFINE' => '-DUSE_PPPORT_H')),
+    @extra,
 );


### PR DESCRIPTION
In the commit message for 29c66c43dc9b80118284c89a37f090d4f2fada58,
Nicholas Clark wrote:

    Really we should decide *which* bugtracker is canonical for Data::Dumper
    (and will be checked and acted upon) and then record that metadata in this
    Makefile.PL so that [metacpan.org, etc., can] link to it.

Let's provide that information based on the examples of other
blead-upstream distros under `dist`, `dist/Module-CoreList/Makefile.PL`
and `dist/PathTools/Makefile.PL`.