### PR TITLE
perlcommunity - add a webchat link for Libera.Chat #perl

### DIFF
--- a/pod/perlcommunity.pod
+++ b/pod/perlcommunity.pod
@@ -44,7 +44,8 @@ own IRC network, L<irc://irc.perl.org>. General (not help-oriented) chat can be
 found at L<irc://irc.perl.org/#perl>. Many other more specific chats are also
 hosted on the network. Information about irc.perl.org is located on the
 network's website: L<https://www.irc.perl.org>. For a more help-oriented #perl,
-check out L<irc://irc.libera.chat/#perl>. Most Perl-related channels
+check out L<irc://irc.libera.chat/#perl>
+(L<webchat|https://web.libera.chat/#perl>). Most Perl-related channels
 will be kind enough to point you in the right direction if you ask nicely.
 
 Any large IRC network (Dalnet, EFnet) is also likely to have a #perl channel,


### PR DESCRIPTION
Provide easy access to the Libera.Chat channel from web perldocs, since it doesn't have a website.