### PR TITLE
Detect and use __builtin_assume for ASSUME

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -4217,6 +4217,14 @@ intrinsic function, see its documents for more details.
 
 #ifdef DEBUGGING
 #  define ASSUME(x) assert(x)
+#elif __has_builtin(__builtin_assume)
+#  if defined(__clang__) || defined(__clang)
+#    define ASSUME(x)  CLANG_DIAG_IGNORE(-Wassume)      \
+                       __builtin_assume (x)             \
+                       CLANG_DIAG_RESTORE
+#  else
+#    define ASSUME(x)  __builtin_assume(x)
+#  endif
 #elif defined(_MSC_VER)
 #  define ASSUME(x) __assume(x)
 #elif defined(__ARMCC_VERSION) /* untested */


### PR DESCRIPTION
Commit 5d5b9c460e2a06563d2b5e35a1a79991460696eb fixed the definition of
ASSUME for some purposes, but broke it on Windows.  This commit should
fix that.  It also adds support for clang's __builtin_assume()