### PR TITLE
only croak on undef = ... not on (complex... undef) = ...

### DIFF
--- a/op.c
+++ b/op.c
@@ -4291,8 +4291,6 @@ Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
 
     switch (o->op_type) {
     case OP_UNDEF:
-        if (type == OP_SASSIGN)
-            goto nomod;
         PL_modcount++;
         goto do_next;
 
@@ -13675,6 +13673,12 @@ Perl_ck_sassign(pTHX_ OP *o)
 
     if (OpHAS_SIBLING(kid)) {
         OP *kkid = OpSIBLING(kid);
+
+        if (kkid->op_type == OP_UNDEF) {
+            /* diag_listed_as: Can't modify %s in %s */
+            yyerror("Can't modify undef operator in scalar assignment");
+        }
+
         /* For state variable assignment with attributes, kkid is a list op
            whose op_last is a padsv. */
         if ((kkid->op_type == OP_PADSV ||

--- a/t/lib/croak/op
+++ b/t/lib/croak/op
@@ -251,3 +251,16 @@ Type of arg 1 to pop must be array (not private hash) at - line 4, near "%a;"
 Type of arg 1 to shift must be array (not private hash) at - line 5, near "%a;"
 Type of arg 1 to unshift must be array (not private hash) at - line 6, near "1;"
 Execution of - aborted due to compilation errors.
+########
+# NAME detect scalar assignment to undef during compilation
+BEGIN { undef = 0 }
+EXPECT
+Can't modify undef operator in scalar assignment at - line 1, near "0 }"
+BEGIN not safe after errors--compilation aborted at - line 1.
+########
+# NAME but don't trigger on a more complex left-hand expression involving undef
+my $x = 1;
+my $y;
+($x ? $y : undef) = 0;
+EXPECT
+OPTIONS nonfatal

--- a/t/run/fresh_perl.t
+++ b/t/run/fresh_perl.t
@@ -192,11 +192,6 @@ EXPECT
 Illegal division by zero at - line 1.
 BEGIN failed--compilation aborted at - line 1.
 ########
-BEGIN { undef = 0 }
-EXPECT
-Can't modify undef operator in scalar assignment at - line 1, near "0 }"
-BEGIN not safe after errors--compilation aborted at - line 1.
-########
 {
     package foo;
     sub PRINT {


### PR DESCRIPTION
@richardleach I'm not sure whether it was intended to croak on the case below

The previous check would trigger on code like:

  ($x ? $y : undef) = 1;

I also moved the test from t/run/fresh_perl.t to t/run/croak/op and
added a test for the broken case.

fixes #18834 