### PR TITLE
prevent undefined behaviour at a language level while probing getenv

### DIFF
--- a/Configure
+++ b/Configure
@@ -14249,7 +14249,7 @@ $cat >try.c <<EOCP
 void *
 thread_start(void * arg)
 {
-    (void *) getenv("HOME");
+    return (void *) getenv("HOME");
 }
 
 int main() {
@@ -14280,7 +14280,7 @@ int main() {
         exit(2);
     }
 
-    exit(! strcmp(main_buffer, save_main_buffer) == 0);
+    exit(! (strcmp(main_buffer, save_main_buffer) == 0));
 }
 EOCP
 val=


### PR DESCRIPTION
This test in Configure tries to probe for undefined behaviour in
getenv(), but provokes undefined behaviour in C/C++ by falling off
the end of a function with a non-void return type.

Without optimization clang++ generated a ud2 instruction here on
amd64 producing an illegal instruction exception.  With optimization
the test case fell off the end and started re-executing main(),
eventually producing a SIGBUS.

Simply dropping the value of getenv() here and returning NULL wasn't
useful, under -O2 the compiler optimized away the getenv() call,
voiding the whole point of the test.

fixes the Configure core dump from #18847 