### PR TITLE
Replace 'slave' with 'client'

### DIFF
--- a/lib/perl5db.pl
+++ b/lib/perl5db.pl
@@ -1225,6 +1225,16 @@ $pidprompt = '';
 our ($client_editor);
 *emacs = $client_editor if $client_editor;    # May be used in afterinit()...
 
+package RenameVariable;
+require Tie::Scalar;
+our @ISA = qw(Tie::Scalar);
+our $message = '$slave_editor deprecated; use $client_editor instead';
+sub FETCH { warn $message; }
+sub STORE { die $message; }
+
+
+package DB;
+
 =head2 READING THE RC FILE
 
 The debugger will read a file of initialization options if supplied. If

--- a/lib/perl5db.pl
+++ b/lib/perl5db.pl
@@ -1229,7 +1229,7 @@ package RenameVariable;
 require Tie::Scalar;
 our @ISA = qw(Tie::Scalar);
 our $message = '$slave_editor deprecated; use $client_editor instead';
-sub FETCH { warn $message; }
+sub FETCH { warn $message; return $client_editor; }
 sub STORE { die $message; }
 
 

--- a/pod/perldebug.pod
+++ b/pod/perldebug.pod
@@ -740,7 +740,7 @@ X<debugger option, LineInfo>
 
 File or pipe to print line number info to.  If it is a pipe (say,
 C<|visual_perl_db>), then a short message is used.  This is the
-mechanism used to interact with a slave editor or visual debugger,
+mechanism used to interact with a client editor or visual debugger,
 such as the special C<vi> or C<emacs> hooks, or the C<ddd> graphical
 debugger.
 

--- a/pod/perlipc.pod
+++ b/pod/perlipc.pod
@@ -1008,7 +1008,7 @@ or firewall machine), fill this in with your real address instead.
  }
 
 And here's a multitasking version.  It's multitasked in that
-like most typical servers, it spawns (fork()s) a slave server to
+like most typical servers, it spawns (fork()s) a client server to
 handle the client request so that the master server can quickly
 go back to service a new client.
 

--- a/pod/perlipc.pod
+++ b/pod/perlipc.pod
@@ -1008,7 +1008,7 @@ or firewall machine), fill this in with your real address instead.
  }
 
 And here's a multitasking version.  It's multitasked in that
-like most typical servers, it spawns (fork()s) a client server to
+like most typical servers, it spawns (fork()s) a child server to
 handle the client request so that the master server can quickly
 go back to service a new client.
 


### PR DESCRIPTION
This commit moves us a step forward on eliminating 'master/slave' terminology.

Its scope is limited to those files within the Perl 5 core distribution which
are not CPAN-upstream.  Within that scope, we leave untouched the use of the
term 'slave' in epigraphs and other literary quotations and its use in data
coming from outside sources (e.g., Unicode code points).

Increment $VERSION in lib/perl5db.pl.

This partially addresses https://github.com/Perl/perl5/issues/18830