### PR TITLE
Silence one "non-numeric" warning

### DIFF
--- a/ext/POSIX/t/posix.t
+++ b/ext/POSIX/t/posix.t
@@ -114,8 +114,9 @@ SKIP: {
     }
     sleep 1;
 
-    $todo = 1 if ($^O eq 'freebsd' && $Config{osvers} < 8)
-              || ($^O eq 'darwin' && $Config{osvers} < '6.6');
+    my ($major, $minor) = $Config{osvers} =~ / (\d+) \. (\d+) .* /x;
+    $todo = 1 if ($^O eq 'freebsd' && $major < 8)
+              || ($^O eq 'darwin' && "${major}.${minor}" < '6.6');
     printf "%s 11 - masked SIGINT received %s\n",
         $sigint_called ? "ok" : "not ok",
         $todo ? $why_todo : '';


### PR DESCRIPTION
As suggested by Tom Hukins.

For: https://github.com/Perl/perl5/issues/18244