### PR TITLE
perlop - Invocant only needs to be an object or class name for method calls

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -230,8 +230,9 @@ assignment.)  See L<perlreftut> and L<perlref>.
 
 Otherwise, the right side is a method name or a simple scalar
 variable containing either the method name or a subroutine reference,
-and the left side must be either an object (a blessed reference)
-or a class name (that is, a package name).  See L<perlobj>.
+and (if it is a method name) the left side must be either an object (a
+blessed reference) or a class name (that is, a package name).  See
+L<perlobj>.
 
 The dereferencing cases (as opposed to method-calling cases) are
 somewhat extended by the C<postderef> feature.  For the


### PR DESCRIPTION
The restriction on the left side mentioned here only applies when the right side is a method name, not when it is a subroutine reference.