### PR TITLE
pp_unshift: av_store is often unnecessary

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -5845,10 +5845,31 @@ PP(pp_unshift)
 
         av_unshift(ary, SP - MARK);
         PL_delaymagic = DM_DELAY;
-        while (MARK < SP) {
-            SV * const sv = newSVsv(*++MARK);
-            (void)av_store(ary, i++, sv);
+
+        if (!SvMAGICAL(ary)) {
+            /* The av_unshift above means that many of the checks inside
+             * av_store are unnecessary. If ary does not have magic attached
+             * then a simple direct assignment is possible here. */
+            while (MARK < SP) {
+                SV * const sv = newSVsv(*++MARK);
+                assert( !SvTIED_mg((const SV *)ary, PERL_MAGIC_tied) );
+                assert( i >= 0 );
+                assert( !SvREADONLY(ary) );
+                assert( AvREAL(ary) || !AvREIFY(ary) );
+                assert( i <= AvMAX(ary) );
+                assert( i <= AvFILLp(ary) );
+                if (AvREAL(ary))
+                    SvREFCNT_dec(AvARRAY(ary)[i]);
+                AvARRAY(ary)[i] = sv;
+                i++;
+            }
+        } else {
+            while (MARK < SP) {
+                SV * const sv = newSVsv(*++MARK);
+                (void)av_store(ary, i++, sv);
+            }
         }
+
         if (PL_delaymagic & DM_ARRAY_ISA)
             mg_set(MUTABLE_SV(ary));
         PL_delaymagic = old_delaymagic;


### PR DESCRIPTION
Within `pp_unshift`, use of  `av_store` seems unnecessary for non-magical
arrays, and so this PR adds a simple-assignment alternative.

Stepping through `av_store`, the logic behind is:
* `if (tied_magic)` - the call site ensures that there cannot be tied magic.
* `if (key < 0)` - `pp_unshift` ensures that key >=0 (though could it wrap ?)
* `if (SvREADONLY(av) && key >= AvFILL(av))` - the earlier call to `av_unshift`
would already have croaked on `if (SvREADONLY(av))`
* `if (!AvREAL(av) && AvREIFY(av))` - the earlier call to `av_unshift` would have 
done the same check and reified if required
* `if (key > AvMAX(av))` - the earlier call to `av_unshift` should have set
AvMAX(av) so that isn't true
* `if (AvFILLp(av) < key)`  - the earlier call to `av_unshift` should have set
AvFILLp(av) so that isn't true

That leaves two conditionals to consider:
* `if (AvREAL(av))        SvREFCNT_dec(ary[key]);` - I'm thinking that `ary[key]`
should contain NULL, so there's nothing to decrement, but haven't cogitated
enough over that yet to be sure.
* `if (SvSMAGICAL(av))` - that could be true, so the existing `av_store` logic is
preserved in a branch for such arrays.

I can add `assert()`s in for all the above if required.
