### PR TITLE
perlgov: re-alphabetize the name list

### DIFF
--- a/pod/perlgov.pod
+++ b/pod/perlgov.pod
@@ -506,9 +506,9 @@ The current members of the Perl Core Team are:
 
 =item * James E Keenan
 
-=item * Jason McIntosh
-
 =item * Jan Dubois (inactive)
+
+=item * Jason McIntosh
 
 =item * Jesse Vincent (inactive)
 


### PR DESCRIPTION
This just helps with the currently-manual process of setting up voting invites.