### PR TITLE
Fix final-expression semantics for multiple statements in `catch` (fixes #18855)

### DIFF
--- a/op.c
+++ b/op.c
@@ -2622,8 +2622,13 @@ S_voidnonfinal(pTHX_ OP *o)
         if (type == OP_LINESEQ || type == OP_SCOPE ||
             type == OP_LEAVE || type == OP_LEAVETRY)
         {
-            OP *kid, *sib;
-            for (kid = cLISTOPo->op_first; kid; kid = sib) {
+            OP *kid = cLISTOPo->op_first, *sib;
+            if(type == OP_LEAVE) {
+                /* Don't put the OP_ENTER in void context */
+                assert(kid->op_type == OP_ENTER);
+                kid = OpSIBLING(kid);
+            }
+            for (; kid; kid = sib) {
                 if ((sib = OpSIBLING(kid))
                  && (  OpHAS_SIBLING(sib) || sib->op_type != OP_NULL
                     || (  sib->op_targ != OP_NEXTSTATE

--- a/t/op/try.t
+++ b/t/op/try.t
@@ -232,6 +232,14 @@ no warnings 'experimental::try';
         catch ($e) { 4, 5, 6 }
     };
     ok(eq_array(\@list, [1, 2, 3]), 'do { try } in list context');
+
+    # Regression test related to
+    #   https://github.com/Perl/perl5/issues/18855
+    $scalar = do {
+        try { my $x = 123; 456 }
+        catch ($e) { 789 }
+    };
+    is($scalar, 456, 'do { try } with multiple statements');
 }
 
 # catch as final expression yields correct value

--- a/t/op/try.t
+++ b/t/op/try.t
@@ -247,6 +247,14 @@ no warnings 'experimental::try';
         catch ($e) { 4, 5, 6 }
     };
     ok(eq_array(\@list, [4, 5, 6]), 'do { try/catch } in list context');
+
+    # Regression test 
+    #   https://github.com/Perl/perl5/issues/18855
+    $scalar = do {
+        try { die "Oops" }
+        catch ($e) { my $x = 123; "result" }
+    };
+    is($scalar, "result", 'do { try/catch } with multiple statements');
 }
 
 # try{} blocks should be invisible to caller()


### PR DESCRIPTION
Bugfix for #18855

Amazingly enough, the fix for `voidnonfinal()` breaking context of `OP_ENTER` doesn't seem to cause any unit-test collateral damage. We might want to test a bit of CPAN as well on this.