### PR TITLE
Rename scalarseq() to a somewhat more meaningful voidnonfinal()

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1731,7 +1731,7 @@ Apd	|OP*	|op_contextualize|NN OP* o|I32 context
 p	|OP*	|scalar		|NULLOK OP* o
 #if defined(PERL_IN_OP_C)
 S	|OP*	|scalarkids	|NULLOK OP* o
-S	|OP*	|scalarseq	|NULLOK OP* o
+S	|OP*	|voidnonfinal	|NULLOK OP* o
 #endif
 : Used in pp_ctl.c
 p	|OP*	|scalarvoid	|NN OP* o

--- a/embed.h
+++ b/embed.h
@@ -1774,12 +1774,12 @@
 #define scalar_mod_type		S_scalar_mod_type
 #define scalarboolean(a)	S_scalarboolean(aTHX_ a)
 #define scalarkids(a)		S_scalarkids(aTHX_ a)
-#define scalarseq(a)		S_scalarseq(aTHX_ a)
 #define search_const(a)		S_search_const(aTHX_ a)
 #define simplify_sort(a)	S_simplify_sort(aTHX_ a)
 #define too_few_arguments_pv(a,b,c)	S_too_few_arguments_pv(aTHX_ a,b,c)
 #define too_many_arguments_pv(a,b,c)	S_too_many_arguments_pv(aTHX_ a,b,c)
 #define traverse_op_tree(a,b)	S_traverse_op_tree(aTHX_ a,b)
+#define voidnonfinal(a)		S_voidnonfinal(aTHX_ a)
 #    if defined(USE_ITHREADS)
 #define op_relocate_sv(a,b)	S_op_relocate_sv(aTHX_ a,b)
 #    endif

--- a/op.c
+++ b/op.c
@@ -2611,9 +2611,10 @@ Perl_list(pTHX_ OP *o)
     } /* while */
 }
 
+/* apply void context to non-final ops of a sequence */
 
 static OP *
-S_scalarseq(pTHX_ OP *o)
+S_voidnonfinal(pTHX_ OP *o)
 {
     if (o) {
         const OPCODE type = o->op_type;
@@ -5721,7 +5722,7 @@ OP*
 Perl_block_end(pTHX_ I32 floor, OP *seq)
 {
     const int needblockscope = PL_hints & HINT_BLOCK_SCOPE;
-    OP* retval = scalarseq(seq);
+    OP* retval = voidnonfinal(seq);
     OP *o;
 
     /* XXX Is the null PL_parser check necessary here? */
@@ -10937,8 +10938,8 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
         block = CvLVALUE(compcv)
              || (cv && CvLVALUE(cv) && !CvROOT(cv) && !CvXSUB(cv))
                    ? newUNOP(OP_LEAVESUBLV, 0,
-                             op_lvalue(scalarseq(block), OP_LEAVESUBLV))
-                   : newUNOP(OP_LEAVESUB, 0, scalarseq(block));
+                             op_lvalue(voidnonfinal(block), OP_LEAVESUBLV))
+                   : newUNOP(OP_LEAVESUB, 0, voidnonfinal(block));
         start = LINKLIST(block);
         block->op_next = 0;
         if (ps && !*ps && !attrs && !CvLVALUE(compcv))
@@ -11453,8 +11454,8 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
              || (cv && CvLVALUE(cv) && !CvROOT(cv) && !CvXSUB(cv)
                     && (!isGV(gv) || !GvASSUMECV(gv)))
                    ? newUNOP(OP_LEAVESUBLV, 0,
-                             op_lvalue(scalarseq(block), OP_LEAVESUBLV))
-                   : newUNOP(OP_LEAVESUB, 0, scalarseq(block));
+                             op_lvalue(voidnonfinal(block), OP_LEAVESUBLV))
+                   : newUNOP(OP_LEAVESUB, 0, voidnonfinal(block));
         start = LINKLIST(block);
         block->op_next = 0;
         if (ps && !*ps && !attrs && !CvLVALUE(PL_compcv))
@@ -12273,7 +12274,7 @@ Perl_newFORM(pTHX_ I32 floor, OP *o, OP *block)
     CvFILE_set_from_cop(cv, PL_curcop);
 
 
-    root = newUNOP(OP_LEAVEWRITE, 0, scalarseq(block));
+    root = newUNOP(OP_LEAVEWRITE, 0, voidnonfinal(block));
     CvROOT(cv) = root;
     start = LINKLIST(root);
     root->op_next = 0;

--- a/proto.h
+++ b/proto.h
@@ -5327,8 +5327,6 @@ STATIC OP*	S_scalarboolean(pTHX_ OP *o);
 	assert(o)
 STATIC OP*	S_scalarkids(pTHX_ OP* o);
 #define PERL_ARGS_ASSERT_SCALARKIDS
-STATIC OP*	S_scalarseq(pTHX_ OP* o);
-#define PERL_ARGS_ASSERT_SCALARSEQ
 STATIC OP*	S_search_const(pTHX_ OP *o)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SEARCH_CONST	\
@@ -5348,6 +5346,8 @@ STATIC OP*	S_too_many_arguments_pv(pTHX_ OP *o, const char* name, U32 flags);
 STATIC OP*	S_traverse_op_tree(pTHX_ OP* top, OP* o);
 #define PERL_ARGS_ASSERT_TRAVERSE_OP_TREE	\
 	assert(top); assert(o)
+STATIC OP*	S_voidnonfinal(pTHX_ OP* o);
+#define PERL_ARGS_ASSERT_VOIDNONFINAL
 #  if defined(USE_ITHREADS)
 #ifndef PERL_NO_INLINE_FUNCTIONS
 PERL_STATIC_INLINE void	S_op_relocate_sv(pTHX_ SV** svp, PADOFFSET* targp);


### PR DESCRIPTION
Renamed to better convey the operation it actually performs. Also added a oneline documentation comment.

There should be no portability/back-compat issues with this, because the function is `static` and invisible outside of this `op.c` file.