### PR TITLE
Add .gitattributes to tell github to treat perly.{act,h,tab} as generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 .git_patch export-subst
+perly.act linguist-generated
+perly.h linguist-generated
+perly.tab linguist-generated


### PR DESCRIPTION
This skips over them in diff views, for example, making code reviews simpler.