### PR TITLE
Update perlgov.pod with Steering Council Election Results

### DIFF
--- a/pod/perlgov.pod
+++ b/pod/perlgov.pod
@@ -472,7 +472,7 @@ Foundation will select a Vote Administrator.
 
 =item * Neil Bowers
 
-=item * Nicholas Clark
+=item * Paul Evans
 
 =item * Ricardo Signes
 


### PR DESCRIPTION
This commit updates the Perl Steering Council member list with the results of the June 2021 Term Election.