### PR TITLE
Makefile.SH: Fixes for z/OS

### DIFF
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -124,9 +124,8 @@ true)
 		linklibperl="-L `pwd | sed 's/\/UU$//'` -Wl,+s -Wl,+b$archlibexp/CORE -lperl"
 		;;
 	os390*)
-            shrpldflags='-W l,XPLINK,dll'
+            shrpldflags='-Wl,XPLINK,dll'
 	    linklibperl='libperl.x'
-	    DPERL_EXTERNAL_GLOB=''
 	    ;;
 	esac
 	case "$ldlibpthname" in


### PR DESCRIPTION
This removes two things that are causing problems:
    1) a space in a parameter
    2) DPERL_EXTERNAL_GLOB=''