### PR TITLE
Fix GDBM_File to compile with version 1.20 and earlier (follow-up to 18919)

### DIFF
--- a/ext/GDBM_File/GDBM_File.pm
+++ b/ext/GDBM_File/GDBM_File.pm
@@ -363,7 +363,7 @@ require XSLoader;
 );
 
 # This module isn't dual life, so no need for dev version numbers.
-$VERSION = '1.19';
+$VERSION = '1.20';
 
 XSLoader::load();
 

--- a/ext/GDBM_File/GDBM_File.xs
+++ b/ext/GDBM_File/GDBM_File.xs
@@ -145,10 +145,11 @@ output_datum(pTHX_ SV *arg, char *str, int size)
 #define gdbm_setopt(db,optflag,optval,optlen) not_here("gdbm_setopt")
 #endif
 
-#if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR < 13        
-/* Prior to 1.13, gdbm_fetch family functions set gdbm_errno to GDBM_NO_ERROR
-   if the requested key did not exist */
-# define ITEM_NOT_FOUND()  (gdbm_errno == GDBM_NO_ERROR)
+#if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR < 13
+/* Prior to 1.13, only gdbm_fetch set GDBM_ITEM_NOT_FOUND if the requested
+   key did not exist.  Other similar function wouls set GDBM_NO_ERROR instead.
+   The GDBM_ITEM_NOT_FOUND existeds as early as in 1.7.3 */
+# define ITEM_NOT_FOUND()  (gdbm_errno == GDBM_NO_ERROR || gdbm_errno == GDBM_ITEM_NOT_FOUND)
 #else
 # define ITEM_NOT_FOUND()  (gdbm_errno == GDBM_ITEM_NOT_FOUND)
 #endif

--- a/ext/GDBM_File/GDBM_File.xs
+++ b/ext/GDBM_File/GDBM_File.xs
@@ -145,14 +145,13 @@ output_datum(pTHX_ SV *arg, char *str, int size)
 #define gdbm_setopt(db,optflag,optval,optlen) not_here("gdbm_setopt")
 #endif
 
-#ifndef GDBM_ITEM_NOT_FOUND
-# define GDBM_ITEM_NOT_FOUND GDBM_NO_ERROR
-#endif
-
+#if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR < 13        
 /* Prior to 1.13, gdbm_fetch family functions set gdbm_errno to GDBM_NO_ERROR
    if the requested key did not exist */
-#define ITEM_NOT_FOUND()                                                \
-    (gdbm_errno == GDBM_ITEM_NOT_FOUND || gdbm_errno == GDBM_NO_ERROR)
+# define ITEM_NOT_FOUND()  (gdbm_errno == GDBM_NO_ERROR)
+#else
+# define ITEM_NOT_FOUND()  (gdbm_errno == GDBM_ITEM_NOT_FOUND)
+#endif
 
 #define CHECKDB(db) do {                        \
     if (!db->dbp) {                             \


### PR DESCRIPTION
This is to replace PR 18919, which was found to contain extra cruft.  

Description of changes

* ext/GDBM_File/GDBM_File.xs (ITEM_NOT_FOUND): Define conditionally,
depending on the GDBM_VERSION_MAJOR and GDBM_VERSION_MINOR.
Don't assume GDBM_ITEM_NOT_FOUND is a define (it isn't since
gdbm commit d3e27957).