### PR TITLE
fix new libperl.t 'no symbols' warning on darwin

### DIFF
--- a/t/porting/libperl.t
+++ b/t/porting/libperl.t
@@ -472,8 +472,12 @@ if (defined $nm_err_tmp) {
         while (<$nm_err_fh>) {
             # OS X has weird error where nm warns about
             # "no name list" but then outputs fine.
+            # llvm-nm may also complain about 'no symbols'. In some
+            # versions this is exactly the string "no symbols\n" but in later
+            # versions becomes a string followed by ": no symbols\n". For this
+            # test it is typically "../libperl.a:perlapi.o: no symbols\n"
             if ( $^O eq 'darwin' ) {
-                if (/nm: no name list/ || /^no symbols$/ ) {
+                if (/nm: no name list/ || /^(.*: )?no symbols$/ ) {
                     print "# $^O ignoring $nm output: $_";
                     next;
                 }


### PR DESCRIPTION
A change in October 2019 added handling for the case that 'nm' might
emit the error message 'no symbols' (apparently erroneously. Apple seems
to have included a fix to upstream LLVM to change the message to be a
file reference followed by ': no symbols'. For libperl.t, the message is
typically '../libperl.a:perlapi.o: no symbols'. This change handles both
the old and current behavior.