### PR TITLE
core-team.json: one-stop shopping for core team members

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,7 @@
 # https://www.kernel.org/pub/software/scm/git/docs/git-shortlog.html#_mapping_authors
 Aaron Crane <arc@cpan.org> <perl@aaroncrane.co.uk>
+Abhijit Menon-Sen <ams@toroid.org> <ams@toroid.org>
+Andy Dougherty <doughera@lafayette.edu> <doughera@lafayette.edu>
 Andy Dougherty <doughera@lafayette.edu> Andy Dougherty <doughera.lafayette.edu>
 Andy Dougherty <doughera@lafayette.edu> Andy Dougherty <doughera@fractal.phys.lafayette.edu>
 Andy Dougherty <doughera@lafayette.edu> Andy Dougherty <doughera@lafcol.lafayette.edu>
@@ -7,16 +9,21 @@ Andy Dougherty <doughera@lafayette.edu> Andy Dougherty <doughera@newton.phys.laf
 Audrey Tang <cpan@audreyt.org> Autrijus Tang <unknown>
 Audrey Tang <cpan@audreyt.org> autrijus@ossf.iis.sinica.edu.tw <autrijus@ossf.iis.sinica.edu.tw>
 Ævar Arnfjörð Bjarmason <avar@cpan.org> Ævar Arnfjörð Bjarmason <avarab@gmail.com>
+Chad Granum <exodist7@gmail.com> <exodist7@gmail.com>
 Chip Salzenberg <chip@atlantic.net> Chip <chip@pobox.com>
 Chip Salzenberg <chip@atlantic.net> Chip Salzenberg <chip@ci005.sv2.upperbeyond.com>
 Chip Salzenberg <chip@atlantic.net> Chip Salzenberg <chip@perl.com>
 Chip Salzenberg <chip@atlantic.net> Chip Salzenberg <chip@pobox.com>
 Chip Salzenberg <chip@atlantic.net> Chip Salzenberg <salzench@dun.nielsen.com>
 Chip Salzenberg <chip@atlantic.net> Chip Salzenberg <salzench@nielsenmedia.com>
+Chris 'BinGOs' Williams <chris@bingosnet.co.uk> <chris@bingosnet.co.uk>
 Chris 'BinGOs' Williams <chris@bingosnet.co.uk> Chris BinGOs Williams <chris@bingosnet.co.uk>
 Chris 'BinGOs' Williams <chris@bingosnet.co.uk> Chris Williams <chris@bingosnet.co.uk>
 Craig A. Berry <craigberry@mac.com> <Craig A. Berry)>
 Craig A. Berry <craigberry@mac.com> <craig.a.berry@gmail.com>
+Craig Berry <craigberry@mac.com> <craigberry@mac.com>
+Dagfinn Ilmari Mannsåker <ilmari@ilmari.org> <ilmari@ilmari.org>
+David Golden <xdg@xdg.me> <xdg@xdg.me>
 David Mitchell <davem@iabyn.com> <davem@fdisolutions.com>
 David Mitchell <davem@iabyn.com> <davem@iabyn.com>
 David Nicol <davidnicol@gmail.com> david nicol <whatever@davidnicol.com>
@@ -27,6 +34,7 @@ Father Chrysostomos <sprout@cpan.org> Father Chrysostomos <perlbug-followup@perl
 Gisle Aas <gisle@aas.no> Gisle Aas <aas@bergen.sn.no>
 Gisle Aas <gisle@aas.no> Gisle Aas <gisle@activestate.com>
 Gurusamy Sarathy <gsar@cpan.org> <gsar@engin.umich.edu>
+H. Merijn Brand <perl5@tux.freedom.nl> <perl5@tux.freedom.nl>
 Hugo van der Sanden <hv@crypt.org> <hv@crypt.compulink.co.uk>
 Hugo van der Sanden <hv@crypt.org> <hv@crypt.org>
 Hugo van der Sanden <hv@crypt.org> <hv@iii.co.uk>
@@ -34,12 +42,17 @@ James E Keenan <jkeenan@cpan.org> <jkeen@verizon.net>
 James E Keenan <jkeenan@cpan.org> James E. Keenan <jkeenan@cpan.org>
 James E Keenan <jkeenan@cpan.org> James Keenan <jkeenan@dromedary-001.ams6.corp.booking.com>
 James E Keenan <jkeenan@cpan.org> jkeenan
+Jan Dubois <jan@jandubois.com> <jan@jandubois.com>
 Jarkko Hietaniemi <jhi@iki.fi> <Jarkko.Hietaniemi@cc.hut.fi>
 Jarkko Hietaniemi <jhi@iki.fi> <jarkko.hietaniemi@booking.com>
 Jarkko Hietaniemi <jhi@iki.fi> <jhi@alpha.hut.fi>
 Jarkko Hietaniemi <jhi@iki.fi> <jhi@cc.hut.fi>
 Jarkko Hietaniemi <jhi@iki.fi> <jhi@hut.fi>
+Jason McIntosh <jmac@jmac.org> <jmac@jmac.org>
 Jesse Vincent <jesse@bestpractical.com> Jesse Vincent <jesse@fsck.com>
+Jesse Vincent <jesse@fsck.com> <jesse@fsck.com>
+Karen Etheridge <ether@cpan.org> <ether@cpan.org>
+Karl Williamson <khw@cpan.org> <khw@cpan.org>
 Karl Williamson <khw@cpan.org> <khw@karl.(none)>
 Karl Williamson <khw@cpan.org> <khw@khw-desktop.(none)>
 Karl Williamson <khw@cpan.org> <public@khwilliamson.com>
@@ -47,17 +60,29 @@ Karl Williamson <khw@cpan.org> karl williamson (via RT) <perlbug-followup@perl.o
 Kurt D. Starsinic <kstar@wolfetech.com> <kstar@www.chapin.edu>
 Kurt D. Starsinic <kstar@wolfetech.com> Kurt Starsinic <kstar@cpan.org>
 Kurt D. Starsinic <kstar@wolfetech.com> Starsinic, Kurt <Kurt_Starsinic@ml.com>
+Leon Timmermans <fawaka@gmail.com> <fawaka@gmail.com>
+Matthew Horsfall <wolfsage@gmail.com> <wolfsage@gmail.com>
+Max Maischein <cpan@corion.net> <cpan@corion.net>
+Neil Bowers <neilb@neilb.org> <neilb@neilb.org>
 Nicholas Clark <nick@ccl4.org> <Nicholas Clark (sans From field in mail header)>
 Nicholas Clark <nick@ccl4.org> <nicholas@dromedary.ams6.corp.booking.com>
+Nicholas Clark <nick@ccl4.org> <nick@ccl4.org>
 Nick Ing-Simmons <nik@tiuk.ti.com> <Nick.Ing-Simmons@tiuk.ti.com>
 Nick Ing-Simmons <nik@tiuk.ti.com> <nick@ni-s.u-net.com>
 Nicolas R <atoomic@cpan.org> <cpan@atoomic.org>
 Nicolas R <atoomic@cpan.org> <nicolas@atoomic.org>
 Nicolas R <atoomic@cpan.org> ☢ ℕicolas ℝ <nicolas@atoomic.org>
+Paul "LeoNerd" Evans <leonerd@leonerd.org.uk> <leonerd@leonerd.org.uk>
+Philippe "BooK" Bruhat <book@cpan.org> <book@cpan.org>
 Rafael Garcia-Suarez <rgarciasuarez@gmail.com> Rafael Garcia-Suarez <rgs@consttype.org>
+Ricardo Signes <rjbs@semiotic.systems> <rjbs@semiotic.systems>
 Ricardo Signes <rjbs@semiotic.systems> <rjbs@cpan.org>
 Ricardo Signes <rjbs@semiotic.systems> <rjbs@users.noreply.github.com>
 Steve Hay <steve.m.hay@googlemail.com> <SteveHay@planit.com>
+Steve Hay <steve.m.hay@googlemail.com> <steve.m.hay@googlemail.com>
+Stuart Mackintosh <stuart@perlfoundation.org> <stuart@perlfoundation.org>
+Todd Rinaldo <toddr@cpanel.net> <toddr@cpanel.net>
+Tony Cook <tony@develop-help.com> <tony@develop-help.com>
 Tony Cook <tony@develop-help.com> <tony@openbsd32.tony.develop-help.com>
 Tony Cook <tony@develop-help.com> <tony@saturn.(none)>
 Yves Orton <demerphq@gmail.com> <demerphq@camel.booking.com>

--- a/.mailmap
+++ b/.mailmap
@@ -24,9 +24,8 @@ Craig A. Berry <craigberry@mac.com> <craig.a.berry@gmail.com>
 Craig A. Berry <craigberry@mac.com> <Craig A. Berry)>
 Nick Ing-Simmons <nik@tiuk.ti.com> <nick@ni-s.u-net.com>
 Nick Ing-Simmons <nik@tiuk.ti.com> <Nick.Ing-Simmons@tiuk.ti.com>
-Ricardo Signes <rjbs@cpan.org> <rjbs@cpan.org>
-Ricardo Signes <rjbs@cpan.org> <rjbs@semiotic.systems>
-Ricardo Signes <rjbs@cpan.org> <rjbs@users.noreply.github.com>
+Ricardo Signes <rjbs@semiotic.systems> <rjbs@cpan.org>
+Ricardo Signes <rjbs@semiotic.systems> <rjbs@users.noreply.github.com>
 Yves Orton <demerphq@gmail.com> <yves.orton@booking.com>
 Yves Orton <demerphq@gmail.com> yves orton <unknown>
 Yves Orton <demerphq@gmail.com> Orton, Yves <yves.orton@de.mci.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,70 +1,70 @@
 # https://www.kernel.org/pub/software/scm/git/docs/git-shortlog.html#_mapping_authors
-Jarkko Hietaniemi <jhi@iki.fi> <jhi@alpha.hut.fi>
-Jarkko Hietaniemi <jhi@iki.fi> <Jarkko.Hietaniemi@cc.hut.fi>
-Jarkko Hietaniemi <jhi@iki.fi> <jhi@cc.hut.fi>
-Jarkko Hietaniemi <jhi@iki.fi> <jarkko.hietaniemi@booking.com>
-Jarkko Hietaniemi <jhi@iki.fi> <jhi@hut.fi>
-Karl Williamson <khw@cpan.org> <public@khwilliamson.com>
-Karl Williamson <khw@cpan.org> <khw@khw-desktop.(none)>
-Karl Williamson <khw@cpan.org> <khw@karl.(none)>
-Karl Williamson <khw@cpan.org> karl williamson (via RT) <perlbug-followup@perl.org>
-Father Chrysostomos <sprout@cpan.org> Father Chrysostomos <perlbug-followup@perl.org>
-Nicholas Clark <nick@ccl4.org> <Nicholas Clark (sans From field in mail header)>
-Nicholas Clark <nick@ccl4.org> <nicholas@dromedary.ams6.corp.booking.com>
-David Mitchell <davem@iabyn.com> <davem@fdisolutions.com>
-David Mitchell <davem@iabyn.com> <davem@iabyn.com>
-Rafael Garcia-Suarez <rgarciasuarez@gmail.com> Rafael Garcia-Suarez <rgs@consttype.org>
-Gurusamy Sarathy <gsar@cpan.org> <gsar@engin.umich.edu>
-Steve Hay <steve.m.hay@googlemail.com> <SteveHay@planit.com>
-Chris 'BinGOs' Williams <chris@bingosnet.co.uk> Chris BinGOs Williams <chris@bingosnet.co.uk>
-Chris 'BinGOs' Williams <chris@bingosnet.co.uk> Chris Williams <chris@bingosnet.co.uk>
-Tony Cook <tony@develop-help.com> <tony@openbsd32.tony.develop-help.com>
-Tony Cook <tony@develop-help.com> <tony@saturn.(none)>
-Craig A. Berry <craigberry@mac.com> <craig.a.berry@gmail.com>
-Craig A. Berry <craigberry@mac.com> <Craig A. Berry)>
-Nick Ing-Simmons <nik@tiuk.ti.com> <nick@ni-s.u-net.com>
-Nick Ing-Simmons <nik@tiuk.ti.com> <Nick.Ing-Simmons@tiuk.ti.com>
-Ricardo Signes <rjbs@semiotic.systems> <rjbs@cpan.org>
-Ricardo Signes <rjbs@semiotic.systems> <rjbs@users.noreply.github.com>
-Yves Orton <demerphq@gmail.com> <yves.orton@booking.com>
-Yves Orton <demerphq@gmail.com> yves orton <unknown>
-Yves Orton <demerphq@gmail.com> Orton, Yves <yves.orton@de.mci.com>
-Yves Orton <demerphq@gmail.com> yves orton <bugs-perl5@bugs6.perl.org>
-Yves Orton <demerphq@gmail.com> <demerphq@gmail.com>
-Yves Orton <demerphq@gmail.com> <demerphq@dromedary.booking.com>
-Yves Orton <demerphq@gmail.com> <demerphq@gemini.(none)>
-Yves Orton <demerphq@gmail.com> <demerphq@camel.booking.com>
-James E Keenan <jkeenan@cpan.org> James E. Keenan <jkeenan@cpan.org>
-James E Keenan <jkeenan@cpan.org> jkeenan
-James E Keenan <jkeenan@cpan.org> <jkeen@verizon.net>
-James E Keenan <jkeenan@cpan.org> James Keenan <jkeenan@dromedary-001.ams6.corp.booking.com>
-Jesse Vincent <jesse@bestpractical.com> Jesse Vincent <jesse@fsck.com>
+Aaron Crane <arc@cpan.org> <perl@aaroncrane.co.uk>
+Andy Dougherty <doughera@lafayette.edu> Andy Dougherty <doughera.lafayette.edu>
+Andy Dougherty <doughera@lafayette.edu> Andy Dougherty <doughera@fractal.phys.lafayette.edu>
+Andy Dougherty <doughera@lafayette.edu> Andy Dougherty <doughera@lafcol.lafayette.edu>
+Andy Dougherty <doughera@lafayette.edu> Andy Dougherty <doughera@newton.phys.lafayette.edu>
+Audrey Tang <cpan@audreyt.org> Autrijus Tang <unknown>
+Audrey Tang <cpan@audreyt.org> autrijus@ossf.iis.sinica.edu.tw <autrijus@ossf.iis.sinica.edu.tw>
+Ævar Arnfjörð Bjarmason <avar@cpan.org> Ævar Arnfjörð Bjarmason <avarab@gmail.com>
+Chip Salzenberg <chip@atlantic.net> Chip <chip@pobox.com>
+Chip Salzenberg <chip@atlantic.net> Chip Salzenberg <chip@ci005.sv2.upperbeyond.com>
 Chip Salzenberg <chip@atlantic.net> Chip Salzenberg <chip@perl.com>
 Chip Salzenberg <chip@atlantic.net> Chip Salzenberg <chip@pobox.com>
-Chip Salzenberg <chip@atlantic.net> Chip Salzenberg <salzench@nielsenmedia.com>
 Chip Salzenberg <chip@atlantic.net> Chip Salzenberg <salzench@dun.nielsen.com>
-Chip Salzenberg <chip@atlantic.net> Chip Salzenberg <chip@ci005.sv2.upperbeyond.com>
-Chip Salzenberg <chip@atlantic.net> Chip <chip@pobox.com>
-Hugo van der Sanden <hv@crypt.org> <hv@crypt.compulink.co.uk>
-Hugo van der Sanden <hv@crypt.org> <hv@iii.co.uk>
-Hugo van der Sanden <hv@crypt.org> <hv@crypt.org>
-Andy Dougherty <doughera@lafayette.edu> Andy Dougherty <doughera@lafcol.lafayette.edu>
-Andy Dougherty <doughera@lafayette.edu> Andy Dougherty <doughera@fractal.phys.lafayette.edu>
-Andy Dougherty <doughera@lafayette.edu> Andy Dougherty <doughera.lafayette.edu>
-Andy Dougherty <doughera@lafayette.edu> Andy Dougherty <doughera@newton.phys.lafayette.edu>
-Gisle Aas <gisle@aas.no> Gisle Aas <gisle@activestate.com>
-Gisle Aas <gisle@aas.no> Gisle Aas <aas@bergen.sn.no>
-Nicolas R <atoomic@cpan.org> ☢ ℕicolas ℝ <nicolas@atoomic.org>
-Nicolas R <atoomic@cpan.org> <nicolas@atoomic.org>
-Nicolas R <atoomic@cpan.org> <cpan@atoomic.org>
-Ævar Arnfjörð Bjarmason <avar@cpan.org> Ævar Arnfjörð Bjarmason <avarab@gmail.com>
-Dominic Hargreaves <dom@earth.li> <dom@semmle.com>
+Chip Salzenberg <chip@atlantic.net> Chip Salzenberg <salzench@nielsenmedia.com>
+Chris 'BinGOs' Williams <chris@bingosnet.co.uk> Chris BinGOs Williams <chris@bingosnet.co.uk>
+Chris 'BinGOs' Williams <chris@bingosnet.co.uk> Chris Williams <chris@bingosnet.co.uk>
+Craig A. Berry <craigberry@mac.com> <Craig A. Berry)>
+Craig A. Berry <craigberry@mac.com> <craig.a.berry@gmail.com>
+David Mitchell <davem@iabyn.com> <davem@fdisolutions.com>
+David Mitchell <davem@iabyn.com> <davem@iabyn.com>
+David Nicol <davidnicol@gmail.com> david nicol <whatever@davidnicol.com>
 Dominic Dunlop <domo@computer.org> <domo@slipper.ip.lu>
 Dominic Dunlop <domo@computer.org> <domo@tcp.ip.lu>
-David Nicol <davidnicol@gmail.com> david nicol <whatever@davidnicol.com>
+Dominic Hargreaves <dom@earth.li> <dom@semmle.com>
+Father Chrysostomos <sprout@cpan.org> Father Chrysostomos <perlbug-followup@perl.org>
+Gisle Aas <gisle@aas.no> Gisle Aas <aas@bergen.sn.no>
+Gisle Aas <gisle@aas.no> Gisle Aas <gisle@activestate.com>
+Gurusamy Sarathy <gsar@cpan.org> <gsar@engin.umich.edu>
+Hugo van der Sanden <hv@crypt.org> <hv@crypt.compulink.co.uk>
+Hugo van der Sanden <hv@crypt.org> <hv@crypt.org>
+Hugo van der Sanden <hv@crypt.org> <hv@iii.co.uk>
+James E Keenan <jkeenan@cpan.org> <jkeen@verizon.net>
+James E Keenan <jkeenan@cpan.org> James E. Keenan <jkeenan@cpan.org>
+James E Keenan <jkeenan@cpan.org> James Keenan <jkeenan@dromedary-001.ams6.corp.booking.com>
+James E Keenan <jkeenan@cpan.org> jkeenan
+Jarkko Hietaniemi <jhi@iki.fi> <Jarkko.Hietaniemi@cc.hut.fi>
+Jarkko Hietaniemi <jhi@iki.fi> <jarkko.hietaniemi@booking.com>
+Jarkko Hietaniemi <jhi@iki.fi> <jhi@alpha.hut.fi>
+Jarkko Hietaniemi <jhi@iki.fi> <jhi@cc.hut.fi>
+Jarkko Hietaniemi <jhi@iki.fi> <jhi@hut.fi>
+Jesse Vincent <jesse@bestpractical.com> Jesse Vincent <jesse@fsck.com>
+Karl Williamson <khw@cpan.org> <khw@karl.(none)>
+Karl Williamson <khw@cpan.org> <khw@khw-desktop.(none)>
+Karl Williamson <khw@cpan.org> <public@khwilliamson.com>
+Karl Williamson <khw@cpan.org> karl williamson (via RT) <perlbug-followup@perl.org>
 Kurt D. Starsinic <kstar@wolfetech.com> <kstar@www.chapin.edu>
 Kurt D. Starsinic <kstar@wolfetech.com> Kurt Starsinic <kstar@cpan.org>
 Kurt D. Starsinic <kstar@wolfetech.com> Starsinic, Kurt <Kurt_Starsinic@ml.com>
-Audrey Tang <cpan@audreyt.org> Autrijus Tang <unknown>
-Audrey Tang <cpan@audreyt.org> autrijus@ossf.iis.sinica.edu.tw <autrijus@ossf.iis.sinica.edu.tw>
-Aaron Crane <arc@cpan.org> <perl@aaroncrane.co.uk>
+Nicholas Clark <nick@ccl4.org> <Nicholas Clark (sans From field in mail header)>
+Nicholas Clark <nick@ccl4.org> <nicholas@dromedary.ams6.corp.booking.com>
+Nick Ing-Simmons <nik@tiuk.ti.com> <Nick.Ing-Simmons@tiuk.ti.com>
+Nick Ing-Simmons <nik@tiuk.ti.com> <nick@ni-s.u-net.com>
+Nicolas R <atoomic@cpan.org> <cpan@atoomic.org>
+Nicolas R <atoomic@cpan.org> <nicolas@atoomic.org>
+Nicolas R <atoomic@cpan.org> ☢ ℕicolas ℝ <nicolas@atoomic.org>
+Rafael Garcia-Suarez <rgarciasuarez@gmail.com> Rafael Garcia-Suarez <rgs@consttype.org>
+Ricardo Signes <rjbs@semiotic.systems> <rjbs@cpan.org>
+Ricardo Signes <rjbs@semiotic.systems> <rjbs@users.noreply.github.com>
+Steve Hay <steve.m.hay@googlemail.com> <SteveHay@planit.com>
+Tony Cook <tony@develop-help.com> <tony@openbsd32.tony.develop-help.com>
+Tony Cook <tony@develop-help.com> <tony@saturn.(none)>
+Yves Orton <demerphq@gmail.com> <demerphq@camel.booking.com>
+Yves Orton <demerphq@gmail.com> <demerphq@dromedary.booking.com>
+Yves Orton <demerphq@gmail.com> <demerphq@gemini.(none)>
+Yves Orton <demerphq@gmail.com> <demerphq@gmail.com>
+Yves Orton <demerphq@gmail.com> <yves.orton@booking.com>
+Yves Orton <demerphq@gmail.com> Orton, Yves <yves.orton@de.mci.com>
+Yves Orton <demerphq@gmail.com> yves orton <bugs-perl5@bugs6.perl.org>
+Yves Orton <demerphq@gmail.com> yves orton <unknown>

--- a/.mailmap
+++ b/.mailmap
@@ -23,6 +23,7 @@ Craig A. Berry <craigberry@mac.com> <Craig A. Berry)>
 Craig A. Berry <craigberry@mac.com> <craig.a.berry@gmail.com>
 Craig Berry <craigberry@mac.com> <craigberry@mac.com>
 Dagfinn Ilmari Mannsåker <ilmari@ilmari.org> <ilmari@ilmari.org>
+David Golden <xdg@xdg.me> <dagolden@cpan.org>
 David Golden <xdg@xdg.me> <xdg@xdg.me>
 David Mitchell <davem@iabyn.com> <davem@fdisolutions.com>
 David Mitchell <davem@iabyn.com> <davem@iabyn.com>

--- a/MANIFEST
+++ b/MANIFEST
@@ -5402,6 +5402,7 @@ Porting/config.sh		Sample config.sh
 Porting/config_H		Sample config.h
 Porting/config_h.pl		Reorder config_h.SH after metaconfig
 Porting/core-cpan-diff		Compare core distros with their CPAN equivalents
+Porting/core-team.json		Membership of the Perl Core Team
 Porting/corecpan.pl		Reports outdated dual-lived modules
 Porting/corelist.pl		Generates data for Module::CoreList
 Porting/corelist-diff		Tool to produce corelist diffs
@@ -5436,6 +5437,7 @@ Porting/mksample		Generate Porting/config_H and Porting/config.sh
 Porting/new-perldelta.pl	Generate a new perldelta
 Porting/newtests-perldelta.pl	Generate Perldelta stub for newly added tests
 Porting/perldelta_template.pod	Template for creating new perldelta.pod files
+Porting/perlgov-team-update			Tool to update perlgov from perl-core-teaml
 Porting/perlhist_calculate.pl		Perform calculations to update perlhist
 Porting/pod_lib.pl		Code for handling generated pods
 Porting/pod_rules.pl		generate lists of pod files for Makefiles

--- a/Porting/README.pod
+++ b/Porting/README.pod
@@ -132,6 +132,11 @@ F<perldelta*> files.
 
 Generates info for Module::CoreList from this perl tree.
 
+=head2 F<core-team.json>
+
+The canonical list of Perl Core Team members, used to build perlgov.pod,
+produce election mailings, and all that sort of thing.
+
 =head2 F<deparse-skips.txt>
 
 List of test files to ignore/skip for deparse tests.
@@ -272,6 +277,11 @@ This script outputs the added tests between the two versions of Perl.
 =head2 F<perldelta_template.pod>
 
 Template for F<perldelta>.
+
+=head2 F<perlgov-team-update>
+
+This produces a new team list for F<perlgov.pod>, but does not, at present,
+insert that content into the file.
 
 =head2 F<perlhist_calculate.pl>
 

--- a/Porting/core-team.json
+++ b/Porting/core-team.json
@@ -1,0 +1,35 @@
+{
+  "inactive": [
+    "ams@toroid.org",
+    "doughera@lafayette.edu",
+    "jan@jandubois.com",
+    "jesse@fsck.com"
+  ],
+  "active": [
+    "book@cpan.org",
+    "chris@bingosnet.co.uk",
+    "cpan@corion.net",
+    "craigberry@mac.com",
+    "davem@iabyn.com",
+    "ether@cpan.org",
+    "exodist7@gmail.com",
+    "fawaka@gmail.com",
+    "hv@crypt.org",
+    "ilmari@ilmari.org",
+    "jkeenan@cpan.org",
+    "jmac@jmac.org",
+    "khw@cpan.org",
+    "leonerd@leonerd.org.uk",
+    "neilb@neilb.org",
+    "nick@ccl4.org",
+    "nicolas@atoomic.org",
+    "perl5@tux.freedom.nl",
+    "rjbs@semiotic.systems",
+    "steve.m.hay@googlemail.com",
+    "stuart@perlfoundation.org",
+    "toddr@cpanel.net",
+    "tony@develop-help.com",
+    "wolfsage@gmail.com",
+    "xdg@xdg.me"
+  ]
+}

--- a/Porting/perlgov-team-update
+++ b/Porting/perlgov-team-update
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+use v5.30.0;
+use warnings;
+use JSON::PP;
+
+my $file = 'Porting/core-team.json';
+my $data = JSON::PP->new->decode(scalar `cat $file`);
+
+my $pod = q{};
+
+for my $key (qw( active inactive )) {
+  $pod .= qq{=head2 \u$key Members\n\n=over 4\n\n};
+
+  my @items = map {; "<$_>" } $data->{$key}->@*;
+
+  open(my $fh, '-|', 'git', 'check-mailmap', @items)
+    or die "error running check-mailmap: $!";
+
+  my @lines = <$fh>;
+
+  $pod .= "=item $_\n" for sort @lines;
+
+  $pod .= "=back\n\n";
+}
+
+say $pod;

--- a/Porting/perlgov-team-update
+++ b/Porting/perlgov-team-update
@@ -1,17 +1,23 @@
 #!/usr/bin/env perl
 use v5.30.0;
 use warnings;
+use Encode qw(encode);
 use JSON::PP;
 
 my $file = 'Porting/core-team.json';
-my $data = JSON::PP->new->decode(scalar `cat $file`);
+open my $fh, '<:encoding(UTF-8)', $file
+  or die "can't read $file: $!\n";
+
+my $json = do { local $/; <$fh> };
+
+my $data = JSON::PP->new->decode($json);
 
 my $pod = q{};
 
 for my $key (qw( active inactive )) {
   $pod .= qq{=head2 \u$key Members\n\n=over 4\n\n};
 
-  my @items = map {; "<$_>" } $data->{$key}->@*;
+  my @items = map {; encode('utf-8', "<$_>") } $data->{$key}->@*;
 
   open(my $fh, '-|', 'git', 'check-mailmap', @items)
     or die "error running check-mailmap: $!";

--- a/pod/perlgov.pod
+++ b/pod/perlgov.pod
@@ -482,64 +482,73 @@ Foundation will select a Vote Administrator.
 
 The current members of the Perl Core Team are:
 
-=over
+=head2 Active Members
 
-=item * Abhijit Menon-Sen (inactive)
+=over 4
 
-=item * Andy Dougherty (inactive)
+=item Chad Granum <exodist7@gmail.com>
 
-=item * Chad Granum
+=item Chris 'BinGOs' Williams <chris@bingosnet.co.uk>
 
-=item * Chris 'BinGOs' Williams
+=item Craig Berry <craigberry@mac.com>
 
-=item * Craig Berry
+=item Dagfinn Ilmari Mannsåker <ilmari@ilmari.org>
 
-=item * Dagfinn Ilmari Mannsåker
+=item David Golden <xdg@xdg.me>
 
-=item * Dave Mitchell
+=item David Mitchell <davem@iabyn.com>
 
-=item * David Golden
+=item H. Merijn Brand <perl5@tux.freedom.nl>
 
-=item * H. Merijn Brand
+=item Hugo van der Sanden <hv@crypt.org>
 
-=item * Hugo van der Sanden
+=item James E Keenan <jkeenan@cpan.org>
 
-=item * James E Keenan
+=item Jason McIntosh <jmac@jmac.org>
 
-=item * Jan Dubois (inactive)
+=item Karen Etheridge <ether@cpan.org>
 
-=item * Jason McIntosh
+=item Karl Williamson <khw@cpan.org>
 
-=item * Jesse Vincent (inactive)
+=item Leon Timmermans <fawaka@gmail.com>
 
-=item * Karen Etheridge
+=item Matthew Horsfall <wolfsage@gmail.com>
 
-=item * Karl Williamson
+=item Max Maischein <cpan@corion.net>
 
-=item * Leon Timmermans
+=item Neil Bowers <neilb@neilb.org>
 
-=item * Matthew Horsfall
+=item Nicholas Clark <nick@ccl4.org>
 
-=item * Max Maischein
+=item Nicolas R <atoomic@cpan.org>
 
-=item * Neil Bowers
+=item Paul "LeoNerd" Evans <leonerd@leonerd.org.uk>
 
-=item * Nicholas Clark
+=item Philippe "BooK" Bruhat <book@cpan.org>
 
-=item * Nicolas R.
+=item Ricardo Signes <rjbs@semiotic.systems>
 
-=item * Paul "LeoNerd" Evans
+=item Steve Hay <steve.m.hay@googlemail.com>
 
-=item * Philippe "BooK" Bruhat
+=item Stuart Mackintosh <stuart@perlfoundation.org>
 
-=item * Ricardo Signes
+=item Todd Rinaldo <toddr@cpanel.net>
 
-=item * Steve Hay
-
-=item * Stuart Mackintosh
-
-=item * Todd Rinaldo
-
-=item * Tony Cook
+=item Tony Cook <tony@develop-help.com>
 
 =back
+
+=head2 Inactive Members
+
+=over 4
+
+=item Abhijit Menon-Sen <ams@toroid.org>
+
+=item Andy Dougherty <doughera@lafayette.edu>
+
+=item Jan Dubois <jan@jandubois.com>
+
+=item Jesse Vincent <jesse@fsck.com>
+
+=back
+


### PR DESCRIPTION
I am following up on a [recent Core Team thread](https://perl.topicbox.com/groups/perl-core/T53277f85ba05d655-Mc2d4a664b16cdd474d7394ef) where I said it would be useful to have a single canonical source of machine-readable core team members, and work from that.  Here's what I did:

* started with the list of core team member emails from mailing list
* replaced emails of those who had asked me to
* put them in a JSON file (because we have no core YAML and I wanted to make this trivial)
* wrote a program to generate POD from that as proof of concept

I wanted to stick to "person == email" in the data, so I made the doc-generating program use git's mailmap to get real names.  This required making some new entries in the git mailmap.

I left the individual steps (update README, update MANIFEST) distinct because they spell out what has to happen.  If people prefer, this can be all squashed down.