### PR TITLE
Remove references to Macintosh/Mac OS in perlfunc.pod and perlintro.pod

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -8850,8 +8850,7 @@ X<O_RDONLY> X<O_RDWR> X<O_WRONLY>
 For historical reasons, some values work on almost every system
 supported by Perl: 0 means read-only, 1 means write-only, and 2
 means read/write.  We know that these values do I<not> work under
-OS/390 and on the Macintosh; you probably don't want to
-use them in new code.
+OS/390; you probably don't want to use them in new code.
 
 If the file named by FILENAME does not exist and the
 L<C<open>|/open FILEHANDLE,MODE,EXPR> call creates

--- a/pod/perlintro.pod
+++ b/pod/perlintro.pod
@@ -77,7 +77,7 @@ to be executable first, so C<chmod 755 script.pl> (under Unix).
 directly the path to your perl executable, like in C<#!/usr/bin/perl>).
 
 For more information, including instructions for other platforms such as
-Windows and Mac OS, read L<perlrun>.
+Windows, read L<perlrun>.
 
 =head2 Safety net
 


### PR DESCRIPTION
Both of these were about Classic, not Darwin.

The relevant Mac OS text in perlrun referenced from perlintro was removed
in 2009 by commit 78aea6ff0e955611:
    Remove Mac OS classic instructions from perlrun

The Fcntl constants on current MacOS are 0, 1, 2:

```
% perl -MFcntl -lwe 'print for $^O, O_RDONLY, O_WRONLY, O_RDWR'
darwin
0
1
2
```