### PR TITLE
Three small changes to perlintro.pod

### DIFF
--- a/pod/perlintro.pod
+++ b/pod/perlintro.pod
@@ -162,7 +162,7 @@ A scalar represents a single value:
 
 Scalar values can be strings, integers or floating point numbers, and Perl
 will automatically convert between them as required.  There is no need
-to pre-declare your variable types, but you have to declare them using
+to pre-declare your variable types - just declare their names using
 the C<my> keyword the first time you use them.  (This is one of the
 requirements of C<use strict;>.)
 
@@ -172,8 +172,9 @@ Scalar values can be used in various ways:
  print "The animal is $animal\n";
  print "The square of $answer is ", $answer * $answer, "\n";
 
-There are a number of "magic" scalars with names that look like
-punctuation or line noise.  These special variables are used for all
+There are a number of "magic" scalars with names that use punctuation symbols,
+and a few that are all uppercase letters.
+These special variables are used for all
 kinds of purposes, and are documented in L<perlvar>.  The only one you
 need to know about for now is C<$_> which is the "default variable".
 It's used as the default argument to a number of functions in Perl, and
@@ -326,9 +327,7 @@ running the program.  Using C<strict> is highly recommended.
 
 =head2 Conditional and looping constructs
 
-Perl has most of the usual conditional and looping constructs.  As of Perl
-5.10, it even has a case/switch statement (spelled C<given>/C<when>).  See
-L<perlsyn/"Switch Statements"> for more details.
+Perl has most of the usual conditional and looping constructs.
 
 The conditions can be any Perl expression.  See the list of operators in
 the next section for information on comparison and boolean logic operators,

--- a/pod/perlintro.pod
+++ b/pod/perlintro.pod
@@ -161,9 +161,8 @@ A scalar represents a single value:
  my $answer = 42;
 
 Scalar values can be strings, integers or floating point numbers, and Perl
-will automatically convert between them as required.  There is no need
-to pre-declare your variable types - just declare their names using
-the C<my> keyword the first time you use them.  (This is one of the
+will automatically convert between them as required.  You have to declare
+them using the C<my> keyword the first time you use them.  (This is one of the
 requirements of C<use strict;>.)
 
 Scalar values can be used in various ways:
@@ -172,9 +171,8 @@ Scalar values can be used in various ways:
  print "The animal is $animal\n";
  print "The square of $answer is ", $answer * $answer, "\n";
 
-There are a number of "magic" scalars with names that use punctuation symbols,
-and a few that are all uppercase letters.
-These special variables are used for all
+Perl defines a number of special scalars with short names, often single
+punctuation marks or digits. These variables are used for all
 kinds of purposes, and are documented in L<perlvar>.  The only one you
 need to know about for now is C<$_> which is the "default variable".
 It's used as the default argument to a number of functions in Perl, and


### PR DESCRIPTION
Simplify the text about declaring variables with my. The previous text said both that "you don't have to pre-declare" and "you have to declare them", where it wasn't clear that the former was about types, and the latter about variables. The new phrasing tries to be clearer.

Note that special variables can also be "all capitals", not just "punctuation". Remove the in joke about "line noise" because it adds little, but many people use it as a negative trope about Perl.

Remove mention of given/when. We should not be promoting something we intend to change. We should have done this years ago when we made it experimental.


I wondered about changing "owl" to "alpaca" given that owls aren't camelids, whist alpacas are and feature on another book, but left it for now. Should we do this too?