### PR TITLE
Fast determination of most and least set bits in a machine word

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1140,6 +1140,7 @@ ATidRp	|bool	|is_utf8_invariant_string_loc|NN const U8* const s	    \
 		|STRLEN len						    \
 		|NULLOK const U8 ** ep
 CTiRp	|unsigned|my_ffs|PERL_UINTMAX_T word
+CTiRp	|unsigned|my_msbit_pos|PERL_UINTMAX_T word
 CTiRp	|unsigned|single_1bit_pos|PERL_UINTMAX_T word
 #ifndef EBCDIC
 CTiRp	|unsigned int|variant_byte_number|PERL_UINTMAX_T word

--- a/embed.fnc
+++ b/embed.fnc
@@ -1139,6 +1139,7 @@ ATdmoR	|bool	|is_utf8_invariant_string|NN const U8* const s		    \
 ATidRp	|bool	|is_utf8_invariant_string_loc|NN const U8* const s	    \
 		|STRLEN len						    \
 		|NULLOK const U8 ** ep
+CTiRp	|unsigned|single_1bit_pos|PERL_UINTMAX_T word
 #ifndef EBCDIC
 CTiRp	|unsigned int|variant_byte_number|PERL_UINTMAX_T word
 #endif

--- a/embed.fnc
+++ b/embed.fnc
@@ -1139,6 +1139,7 @@ ATdmoR	|bool	|is_utf8_invariant_string|NN const U8* const s		    \
 ATidRp	|bool	|is_utf8_invariant_string_loc|NN const U8* const s	    \
 		|STRLEN len						    \
 		|NULLOK const U8 ** ep
+CTiRp	|unsigned|my_ffs|PERL_UINTMAX_T word
 CTiRp	|unsigned|single_1bit_pos|PERL_UINTMAX_T word
 #ifndef EBCDIC
 CTiRp	|unsigned int|variant_byte_number|PERL_UINTMAX_T word

--- a/embed.h
+++ b/embed.h
@@ -331,6 +331,7 @@
 #define my_fflush_all()		Perl_my_fflush_all(aTHX)
 #define my_ffs			Perl_my_ffs
 #define my_fork			Perl_my_fork
+#define my_msbit_pos		Perl_my_msbit_pos
 #define my_popen_list(a,b,c)	Perl_my_popen_list(aTHX_ a,b,c)
 #define my_setenv(a,b)		Perl_my_setenv(aTHX_ a,b)
 #define my_socketpair		Perl_my_socketpair

--- a/embed.h
+++ b/embed.h
@@ -559,6 +559,7 @@
 #define set_context		Perl_set_context
 #define setdefout(a)		Perl_setdefout(aTHX_ a)
 #define share_hek(a,b,c)	Perl_share_hek(aTHX_ a,b,c)
+#define single_1bit_pos		Perl_single_1bit_pos
 #define sortsv(a,b,c)		Perl_sortsv(aTHX_ a,b,c)
 #define sortsv_flags(a,b,c,d)	Perl_sortsv_flags(aTHX_ a,b,c,d)
 #define stack_grow(a,b,c)	Perl_stack_grow(aTHX_ a,b,c)

--- a/embed.h
+++ b/embed.h
@@ -329,6 +329,7 @@
 #define my_exit(a)		Perl_my_exit(aTHX_ a)
 #define my_failure_exit()	Perl_my_failure_exit(aTHX)
 #define my_fflush_all()		Perl_my_fflush_all(aTHX)
+#define my_ffs			Perl_my_ffs
 #define my_fork			Perl_my_fork
 #define my_popen_list(a,b,c)	Perl_my_popen_list(aTHX_ a,b,c)
 #define my_setenv(a,b)		Perl_my_setenv(aTHX_ a,b)

--- a/globvar.sym
+++ b/globvar.sym
@@ -12,6 +12,7 @@ PL_c9_utf8_dfa_tab
 PL_charclass
 PL_check
 PL_core_reg_engine
+PL_deBruijn_bitpos_tab
 PL_EXACTFish_bitmask
 PL_EXACT_REQ8_bitmask
 PL_extended_utf8_dfa_tab

--- a/inline.h
+++ b/inline.h
@@ -610,6 +610,12 @@ Perl_single_1bit_pos(PERL_UINTMAX_T word)
 
 }
 
+#if defined(WIN32) && (defined(PERL_USE_FFS) || defined(PERL_USE_CLZ))
+#  include <intrin.h>
+#  pragma intrinsic(_BitScanReverse,_BitScanReverse64)
+#  pragma intrinsic(_BitScanForward,_BitScanForward64)
+#endif
+
 PERL_STATIC_INLINE unsigned
 Perl_my_msbit_pos(PERL_UINTMAX_T word)
 {
@@ -625,8 +631,6 @@ Perl_my_msbit_pos(PERL_UINTMAX_T word)
     return (PERL_UINTMAX_SIZE * CHARBITS) - 1 - PERL_USE_CLZ(word);
 
 #  else
-#    include <intrin.h>
-#    pragma intrinsic(_BitScanReverse,_BitScanReverse64)
 
     {
         unsigned long Index;
@@ -688,8 +692,6 @@ Perl_my_ffs(PERL_UINTMAX_T word)
     return PERL_USE_FFS(word) - 1;
 
 #  else
-#    include <intrin.h>
-#    pragma intrinsic(_BitScanForward,_BitScanForward64)
 
     {
         unsigned long Index;

--- a/inline.h
+++ b/inline.h
@@ -581,6 +581,23 @@ Perl_is_utf8_invariant_string_loc(const U8* const s, STRLEN len, const U8 ** ep)
     return TRUE;
 }
 
+PERL_STATIC_INLINE unsigned
+Perl_single_1bit_pos(PERL_UINTMAX_T word)
+{
+    /* Given a word known to contain all zero bits except one 1 bit, find and
+     * return the 1's position: 0..63 */
+
+#ifdef PERL_CORE    /* macro not exported */
+    ASSUME(isPOWER_OF_2(word));
+#endif
+
+    /* The position of the only set bit in a word can be quickly calculated
+     * using deBruijn sequences.  See for example
+     * https://en.wikipedia.org/wiki/De_Bruijn_sequence */
+    return PL_deBruijn_bitpos_tab[(word * PERL_deBruijnMagic_)
+                                                    >> PERL_deBruijnShift_];
+}
+
 #ifndef EBCDIC
 
 PERL_STATIC_INLINE unsigned int

--- a/inline.h
+++ b/inline.h
@@ -619,10 +619,24 @@ Perl_my_msbit_pos(PERL_UINTMAX_T word)
     ASSUME(word != 0);
 
 #ifdef PERL_USE_CLZ
+#  ifndef WIN32
 
     /* First set bit is the complement of how many leading unset bits */
     return (PERL_UINTMAX_SIZE * CHARBITS) - 1 - PERL_USE_CLZ(word);
 
+#  else
+#    include <intrin.h>
+#    pragma intrinsic(_BitScanReverse,_BitScanReverse64)
+
+    {
+        unsigned long Index;
+
+        PERL_USE_CLZ(&Index, word);
+
+        return Index;
+    }
+
+#  endif
 #else
 
     /* Isolate the msb; http://codeforces.com/blog/entry/10330
@@ -668,10 +682,24 @@ Perl_my_ffs(PERL_UINTMAX_T word)
      * the hand-rolled code we otherwise would execute, may very well incur
      * function call overhead.  So use it only if no clz */
 #if defined(PERL_USE_FFS) && ! defined(PERL_USE_CLZ)
+#  ifndef WIN32
 
     /* ffs() returns bit position indexed from 1 */
     return PERL_USE_FFS(word) - 1;
 
+#  else
+#    include <intrin.h>
+#    pragma intrinsic(_BitScanForward,_BitScanForward64)
+
+    {
+        unsigned long Index;
+
+        PERL_USE_FFS(&Index, word);
+
+        return Index;
+    }
+
+#  endif
 #else
 
     /*  Isolate the lsb;

--- a/inline.h
+++ b/inline.h
@@ -591,11 +591,19 @@ Perl_single_1bit_pos(PERL_UINTMAX_T word)
     ASSUME(isPOWER_OF_2(word));
 #endif
 
+#ifdef PERL_USE_CLZ
+
+    return my_msbit_pos(word);
+
+#else
+
     /* The position of the only set bit in a word can be quickly calculated
      * using deBruijn sequences.  See for example
      * https://en.wikipedia.org/wiki/De_Bruijn_sequence */
     return PL_deBruijn_bitpos_tab[(word * PERL_deBruijnMagic_)
                                                     >> PERL_deBruijnShift_];
+#endif
+
 }
 
 PERL_STATIC_INLINE unsigned
@@ -605,6 +613,13 @@ Perl_my_msbit_pos(PERL_UINTMAX_T word)
      * word */
 
     ASSUME(word != 0);
+
+#ifdef PERL_USE_CLZ
+
+    /* First set bit is the complement of how many leading unset bits */
+    return (PERL_UINTMAX_SIZE * CHARBITS) - 1 - PERL_USE_CLZ(word);
+
+#else
 
     /* Isolate the msb; http://codeforces.com/blog/entry/10330
      *
@@ -630,6 +645,9 @@ Perl_my_msbit_pos(PERL_UINTMAX_T word)
 
     /* Now we have a single bit set */
     return single_1bit_pos(word);
+
+#endif
+
 }
 
 PERL_STATIC_INLINE unsigned

--- a/inline.h
+++ b/inline.h
@@ -590,10 +590,12 @@ Perl_variant_byte_number(PERL_UINTMAX_T word)
     /* This returns the position in a word (0..7) of the first variant byte in
      * it.  This is a helper function.  Note that there are no branches */
 
-    assert(word);
-
     /* Get just the msb bits of each byte */
     word &= PERL_VARIANTS_WORD_MASK;
+
+    /* This should only be called if we know there is a variant byte in the
+     * word */
+    assert(word);
 
 #  if BYTEORDER == 0x1234 || BYTEORDER == 0x12345678
 

--- a/inline.h
+++ b/inline.h
@@ -605,22 +605,18 @@ Perl_variant_byte_number(PERL_UINTMAX_T word)
      * https://stackoverflow.com/questions/757059/position-of-least-significant-bit-that-is-set
      *
      * The word will look like this, with a rightmost set bit in position 's':
-     * ('x's are don't cares)
+     * ('x's are don't cares, and 'y's are their complements)
      *      s
-     *  x..x100..0
-     *  x..xx10..0      Right shift (rightmost 0 is shifted off)
-     *  x..xx01..1      Subtract 1, turns all the trailing zeros into 1's and
-     *                  the 1 just to their left into a 0; the remainder is
-     *                  untouched
-     *  0..0011..1      The xor with the original, x..xx10..0, clears that
-     *                  remainder, sets the bottom to all 1
-     *  0..0100..0      Add 1 to clear the word except for the bit in 's'
+     *  x..x100..00
+     *  y..y011..11      Complement
+     *  y..y100..00      Add 1
+     *  0..0100..00      AND with the original
      *
-     * Another method is to do 'word &= -word'; but it generates a compiler
-     * message on some platforms about taking the negative of an unsigned */
-
-    word >>= 1;
-    word = 1 + (word ^ (word - 1));
+     *  (Yes, complementing and adding 1 is just taking the negative on 2's
+     *  complement machines, but not on 1's complement ones, and some compilers
+     *  complain about negating an unsigned.)
+     */
+    word &= (~word + 1);
 
 #  elif BYTEORDER == 0x4321 || BYTEORDER == 0x87654321
 

--- a/perl.h
+++ b/perl.h
@@ -3865,32 +3865,33 @@ hint to the compiler that this condition is likely to be false.
 #  define __has_builtin(x) 0 /* not a clang style compiler */
 #endif
 
-#if PERL_UINTMAX_SIZE == INTSIZE
+#if defined(WIN32) || defined(WIN64)
+#  if defined(_MSC_VER) && _MSC_VER >= 1400
+#    ifdef WIN64
+#      define PERL_USE_CLZ(i, x) _BitScanReverse64(i, x)
+#      define PERL_USE_FFS(i, x) _BitScanForward64(i, x)
+#    else
+#      define PERL_USE_CLZ(i, x) _BitScanReverse(i, x)
+#      define PERL_USE_FFS(i, x) _BitScanForward(i, x)
+#    endif
+#  endif
+#elif PERL_UINTMAX_SIZE == INTSIZE
 #  if  __has_builtin(__builtin_clz)                                         \
    || (defined(__GNUC__) && (   __GNUC__ > 3                                \
                              || __GNUC__ == 3 && __GNUC_MINOR__ >= 4))
 #    define PERL_USE_CLZ(x) __builtin_clz(x)
-
-#  elif defined(WIN32) && defined(_MSC_VER) && _MSC_VER >= 1400
-#    define PERL_USE_CLZ(i, x) _BitScanReverse(i, x)
 #  endif
 #  ifdef HAS_FFS
 #    define PERL_USE_FFS(x)  ffs(x)
-#  elif defined(WIN32) && defined(_MSC_VER) && _MSC_VER >= 1400
-#    define PERL_USE_FFS(i, x) _BitScanForward(i, x)
 #  endif
 #elif PERL_UINTMAX_SIZE == LONGSIZE
 #  if  __has_builtin(__builtin_clzl)                                        \
    || (defined(__GNUC__) && (   __GNUC__ > 3                                \
                              || __GNUC__ == 3 && __GNUC_MINOR__ >= 4))
 #    define PERL_USE_CLZ(x) __builtin_clzl(x)
-#  elif defined(WIN32) && defined(_MSC_VER) && _MSC_VER >= 1400
-#    define PERL_USE_CLZ(i, x) _BitScanReverse64(i, x)
 #  endif
 #  ifdef HAS_FFSL
 #    define PERL_USE_FFS(x)  ffsl(x)
-#  elif defined(WIN32) && defined(_MSC_VER) && _MSC_VER >= 1400
-#    define PERL_USE_FFS(i, x) _BitScanForward64(i, x)
 #  endif
 #endif
 

--- a/perl.h
+++ b/perl.h
@@ -3871,11 +3871,17 @@ hint to the compiler that this condition is likely to be false.
                              || __GNUC__ == 3 && __GNUC_MINOR__ >= 4))
 #    define PERL_USE_CLZ(x) __builtin_clz(x)
 #  endif
+#  ifdef HAS_FFS
+#    define PERL_USE_FFS(x)  ffs(x)
+#  endif
 #elif PERL_UINTMAX_SIZE == LONGSIZE
 #  if  __has_builtin(__builtin_clzl)                                        \
    || (defined(__GNUC__) && (   __GNUC__ > 3                                \
                              || __GNUC__ == 3 && __GNUC_MINOR__ >= 4))
 #    define PERL_USE_CLZ(x) __builtin_clzl(x)
+#  endif
+#  ifdef HAS_FFSL
+#    define PERL_USE_FFS(x)  ffsl(x)
 #  endif
 #endif
 

--- a/perl.h
+++ b/perl.h
@@ -3865,6 +3865,20 @@ hint to the compiler that this condition is likely to be false.
 #  define __has_builtin(x) 0 /* not a clang style compiler */
 #endif
 
+#if PERL_UINTMAX_SIZE == INTSIZE
+#  if  __has_builtin(__builtin_clz)                                         \
+   || (defined(__GNUC__) && (   __GNUC__ > 3                                \
+                             || __GNUC__ == 3 && __GNUC_MINOR__ >= 4))
+#    define PERL_USE_CLZ(x) __builtin_clz(x)
+#  endif
+#elif PERL_UINTMAX_SIZE == LONGSIZE
+#  if  __has_builtin(__builtin_clzl)                                        \
+   || (defined(__GNUC__) && (   __GNUC__ > 3                                \
+                             || __GNUC__ == 3 && __GNUC_MINOR__ >= 4))
+#    define PERL_USE_CLZ(x) __builtin_clzl(x)
+#  endif
+#endif
+
 /*
 =for apidoc Am||ASSUME|bool expr
 C<ASSUME> is like C<assert()>, but it has a benefit in a release build. It is a

--- a/perl.h
+++ b/perl.h
@@ -1202,6 +1202,7 @@ Use L</UV> to declare variables of the maximum usable size on this platform.
     typedef I64TYPE PERL_INTMAX_T;
     typedef U64TYPE PERL_UINTMAX_T;
 #  endif
+#  define PERL_UINTMAX_SIZE U64SIZE
 #  ifndef INTMAX_C
 #    define INTMAX_C(c) INT64_C(c)
 #  endif
@@ -1216,6 +1217,7 @@ Use L</UV> to declare variables of the maximum usable size on this platform.
     typedef I32TYPE PERL_INTMAX_T;
     typedef U32TYPE PERL_UINTMAX_T;
 #  endif
+#  define PERL_UINTMAX_SIZE U32SIZE;
 #  ifndef INTMAX_C
 #    define INTMAX_C(c) INT32_C(c)
 #  endif

--- a/perl.h
+++ b/perl.h
@@ -5838,6 +5838,26 @@ PL_valid_types_IV_set[] = { 0, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1 };
 EXTCONST bool
 PL_valid_types_NV_set[] = { 0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0 };
 
+EXTCONST U8
+PL_deBruijn_bitpos_tab[] = {
+
+#  if PERL_UINTMAX_SIZE == 4
+    /* https://graphics.stanford.edu/~seander/bithacks.html#IntegerLogDeBruijn */
+    0,   1, 28,  2, 29, 14, 24,  3, 30, 22, 20, 15, 25, 17,  4,  8,
+    31, 27, 13, 23, 21, 19, 16,  7, 26, 12, 18,  6, 11,  5, 10,  9
+
+#  else
+
+    /* https://stackoverflow.com/questions/11376288/fast-computing-of-log2-for-64-bit-integers */
+    63,  0, 58,  1, 59, 47, 53,  2, 60, 39, 48, 27, 54, 33, 42,  3,
+    61, 51, 37, 40, 49, 18, 28, 20, 55, 30, 34, 11, 43, 14, 22,  4,
+    62, 57, 46, 52, 38, 26, 32, 41, 50, 36, 17, 19, 29, 10, 13, 21,
+    56, 45, 25, 31, 35, 16,  9, 12, 44, 24, 15,  8, 23,  7,  6,  5
+
+#  endif
+
+};
+
 #else
 
 EXTCONST bool PL_valid_types_IVX[];
@@ -5846,7 +5866,17 @@ EXTCONST bool PL_valid_types_PVX[];
 EXTCONST bool PL_valid_types_RV[];
 EXTCONST bool PL_valid_types_IV_set[];
 EXTCONST bool PL_valid_types_NV_set[];
+EXTCONST U8   PL_deBruijn_bitpos_tab[];
 
+#endif
+
+/* The constants for using PL_deBruijn_bitpos_tab */
+#if PERL_UINTMAX_SIZE == 4
+#  define PERL_deBruijnMagic_  0x077CB531
+#  define PERL_deBruijnShift_  27
+#else
+#  define PERL_deBruijnMagic_  0x07EDD5E59A4E28C2
+#  define PERL_deBruijnShift_  58
 #endif
 
 /* In C99 we could use designated (named field) union initializers.

--- a/perl.h
+++ b/perl.h
@@ -3870,18 +3870,27 @@ hint to the compiler that this condition is likely to be false.
    || (defined(__GNUC__) && (   __GNUC__ > 3                                \
                              || __GNUC__ == 3 && __GNUC_MINOR__ >= 4))
 #    define PERL_USE_CLZ(x) __builtin_clz(x)
+
+#  elif defined(WIN32) && defined(_MSC_VER) && _MSC_VER >= 1400
+#    define PERL_USE_CLZ(i, x) _BitScanReverse(i, x)
 #  endif
 #  ifdef HAS_FFS
 #    define PERL_USE_FFS(x)  ffs(x)
+#  elif defined(WIN32) && defined(_MSC_VER) && _MSC_VER >= 1400
+#    define PERL_USE_FFS(i, x) _BitScanForward(i, x)
 #  endif
 #elif PERL_UINTMAX_SIZE == LONGSIZE
 #  if  __has_builtin(__builtin_clzl)                                        \
    || (defined(__GNUC__) && (   __GNUC__ > 3                                \
                              || __GNUC__ == 3 && __GNUC_MINOR__ >= 4))
 #    define PERL_USE_CLZ(x) __builtin_clzl(x)
+#  elif defined(WIN32) && defined(_MSC_VER) && _MSC_VER >= 1400
+#    define PERL_USE_CLZ(i, x) _BitScanReverse64(i, x)
 #  endif
 #  ifdef HAS_FFSL
 #    define PERL_USE_FFS(x)  ffsl(x)
+#  elif defined(WIN32) && defined(_MSC_VER) && _MSC_VER >= 1400
+#    define PERL_USE_FFS(i, x) _BitScanForward64(i, x)
 #  endif
 #endif
 

--- a/proto.h
+++ b/proto.h
@@ -2166,6 +2166,12 @@ PERL_CALLCONV_NO_RET void	Perl_my_failure_exit(pTHX)
 
 PERL_CALLCONV I32	Perl_my_fflush_all(pTHX);
 #define PERL_ARGS_ASSERT_MY_FFLUSH_ALL
+#ifndef PERL_NO_INLINE_FUNCTIONS
+PERL_STATIC_INLINE unsigned	Perl_my_ffs(PERL_UINTMAX_T word)
+			__attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_MY_FFS
+#endif
+
 PERL_CALLCONV Pid_t	Perl_my_fork(void);
 #define PERL_ARGS_ASSERT_MY_FORK
 /* PERL_CALLCONV I32	my_lstat(pTHX); */

--- a/proto.h
+++ b/proto.h
@@ -2188,6 +2188,12 @@ PERL_CALLCONV int	Perl_my_mkstemp_cloexec(char *templte)
 #define PERL_ARGS_ASSERT_MY_MKSTEMP_CLOEXEC	\
 	assert(templte)
 
+#ifndef PERL_NO_INLINE_FUNCTIONS
+PERL_STATIC_INLINE unsigned	Perl_my_msbit_pos(PERL_UINTMAX_T word)
+			__attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_MY_MSBIT_POS
+#endif
+
 PERL_CALLCONV PerlIO*	Perl_my_popen_list(pTHX_ const char* mode, int n, SV ** args);
 #define PERL_ARGS_ASSERT_MY_POPEN_LIST	\
 	assert(mode); assert(args)

--- a/proto.h
+++ b/proto.h
@@ -3234,6 +3234,12 @@ PERL_CALLCONV Signal_t	Perl_sighandler1(int sig);
 #define PERL_ARGS_ASSERT_SIGHANDLER1
 PERL_CALLCONV Signal_t	Perl_sighandler3(int sig, Siginfo_t *info, void *uap);
 #define PERL_ARGS_ASSERT_SIGHANDLER3
+#ifndef PERL_NO_INLINE_FUNCTIONS
+PERL_STATIC_INLINE unsigned	Perl_single_1bit_pos(PERL_UINTMAX_T word)
+			__attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_SINGLE_1BIT_POS
+#endif
+
 PERL_CALLCONV char*	Perl_skipspace_flags(pTHX_ char *s, U32 flags)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SKIPSPACE_FLAGS	\

--- a/regcomp.c
+++ b/regcomp.c
@@ -19398,17 +19398,8 @@ S_optimize_regclass(pTHX_
             bool already_inverted;
             bool are_equivalent;
 
-            /* Compute which bit is set, which is the same thing as, e.g.,
-             * ANYOF_CNTRL.  From
-             * https://graphics.stanford.edu/~seander/bithacks.html#IntegerLogDeBruijn
-             * */
-            static const int MultiplyDeBruijnBitPosition2[32] = {
-                0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
-                31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
-                };
 
-            namedclass = MultiplyDeBruijnBitPosition2[(posixl
-                                                      * 0x077CB531U) >> 27];
+            namedclass = single_1bit_pos(posixl);
             classnum = namedclass_to_classnum(namedclass);
 
             /* The named classes are such that the inverted number is one

--- a/regcomp.h
+++ b/regcomp.h
@@ -680,30 +680,32 @@ struct regnode_ssc {
 
 #define ANYOF_BIT(c)		(1U << ((c) & 7))
 
+#define ANYOF_POSIXL_BITMAP(p)  (((regnode_charclass_posixl*) (p))->classflags)
+
 #define POSIXL_SET(field, c)	((field) |= (1U << (c)))
-#define ANYOF_POSIXL_SET(p, c)	POSIXL_SET(((regnode_charclass_posixl*) (p))->classflags, (c))
+#define ANYOF_POSIXL_SET(p, c)	POSIXL_SET(ANYOF_POSIXL_BITMAP(p), (c))
 
 #define POSIXL_CLEAR(field, c) ((field) &= ~ (1U <<(c)))
-#define ANYOF_POSIXL_CLEAR(p, c) POSIXL_CLEAR(((regnode_charclass_posixl*) (p))->classflags, (c))
+#define ANYOF_POSIXL_CLEAR(p, c) POSIXL_CLEAR(ANYOF_POSIXL_BITMAP(p), (c))
 
 #define POSIXL_TEST(field, c)	((field) & (1U << (c)))
-#define ANYOF_POSIXL_TEST(p, c)	POSIXL_TEST(((regnode_charclass_posixl*) (p))->classflags, (c))
+#define ANYOF_POSIXL_TEST(p, c)	POSIXL_TEST(ANYOF_POSIXL_BITMAP(p), (c))
 
 #define POSIXL_ZERO(field)	STMT_START { (field) = 0; } STMT_END
-#define ANYOF_POSIXL_ZERO(ret)	POSIXL_ZERO(((regnode_charclass_posixl*) (ret))->classflags)
+#define ANYOF_POSIXL_ZERO(ret)	POSIXL_ZERO(ANYOF_POSIXL_BITMAP(ret))
 
 #define ANYOF_POSIXL_SET_TO_BITMAP(p, bits)                                 \
-     STMT_START {                                                           \
-                    ((regnode_charclass_posixl*) (p))->classflags = (bits); \
-     } STMT_END
+                STMT_START { ANYOF_POSIXL_BITMAP(p) = (bits); } STMT_END
 
 /* Shifts a bit to get, eg. 0x4000_0000, then subtracts 1 to get 0x3FFF_FFFF */
-#define ANYOF_POSIXL_SETALL(ret) STMT_START { ((regnode_charclass_posixl*) (ret))->classflags = nBIT_MASK(ANYOF_POSIXL_MAX); } STMT_END
+#define ANYOF_POSIXL_SETALL(ret)                                            \
+                STMT_START {                                                \
+                    ANYOF_POSIXL_BITMAP(ret) = nBIT_MASK(ANYOF_POSIXL_MAX); \
+                } STMT_END
 #define ANYOF_CLASS_SETALL(ret) ANYOF_POSIXL_SETALL(ret)
 
 #define ANYOF_POSIXL_TEST_ANY_SET(p)                               \
-        ((ANYOF_FLAGS(p) & ANYOF_MATCHES_POSIXL)                           \
-         && (((regnode_charclass_posixl*)(p))->classflags))
+        ((ANYOF_FLAGS(p) & ANYOF_MATCHES_POSIXL) && ANYOF_POSIXL_BITMAP(p))
 #define ANYOF_CLASS_TEST_ANY_SET(p) ANYOF_POSIXL_TEST_ANY_SET(p)
 
 /* Since an SSC always has this field, we don't have to test for that; nor do
@@ -716,8 +718,7 @@ struct regnode_ssc {
 
 #define ANYOF_POSIXL_TEST_ALL_SET(p)                                   \
         ((ANYOF_FLAGS(p) & ANYOF_MATCHES_POSIXL)                       \
-         && ((regnode_charclass_posixl*) (p))->classflags              \
-                                    == nBIT_MASK(ANYOF_POSIXL_MAX))
+         && ANYOF_POSIXL_BITMAP(p) == nBIT_MASK(ANYOF_POSIXL_MAX))
 
 #define ANYOF_POSIXL_OR(source, dest) STMT_START { (dest)->classflags |= (source)->classflags ; } STMT_END
 #define ANYOF_CLASS_OR(source, dest) ANYOF_POSIXL_OR((source), (dest))


### PR DESCRIPTION
Modern hardware tends to have machine instructions to find this information.

This series of commits creates functions that return the least and most set bits in the largest word perl thinks the hardware is capable of, and uses them in all but one of the places in core that I am aware of could benefit.  (Perhaps you know of other places.)  The final place has to do with Unicode handling, is more complex, and I'm deferring that until this P.R. is merged.

There are builtins for clang, gcc, and Windows to find the msb; a builtin for Windows for the lsb, and a POSIX function, ffs(), for the latter, but defined only for ints.  Many platforms have a ffsl() additionally, and blead already has probes for that and the other possibilities.  If a platform is lacking, fast bit twiddling, and deBruijn sequences are used instead, so the functions are completely general.

These functions are currently considered core-only, but if there is a benefit for modules to be able to use them, I could easily create public documentation for them.
