### PR TITLE
Silence build-time warning coming from scope.h

### DIFF
--- a/scope.h
+++ b/scope.h
@@ -208,9 +208,11 @@ scope has the given name. C<name> must be a literal string.
     STMT_START {							\
         DEBUG_SCOPE("LEAVE \"" name "\"")				\
         if (PL_scopestack_name)	{					\
+            GCC_DIAG_IGNORE_STMT(-Wstring-compare);			\
             assert(((char*)PL_scopestack_name[PL_scopestack_ix-1]	\
                         == (char*)name)					\
                     || strEQ(PL_scopestack_name[PL_scopestack_ix-1], name));        \
+            GCC_DIAG_RESTORE_STMT;					\
         }								\
         pop_scope();							\
     } STMT_END


### PR DESCRIPTION
In our ticket tracking build-time warnings generated during `make` when using `clang` (especially versions 9, 10 and 11) to build `perl`, https://github.com/Perl/perl5/issues/17015, the last remaining such warning looked like this:
```
{
    char   => 37,
    group  => "Wstring-compare",
    line   => 8219,
    source => "re_comp.c",
    text   => "result of comparison against a string literal is unspecified (use an explicit string comparison function instead)",
  },
  {
    char   => 2,
    group  => "Wstring-compare",
    line   => 8267,
    source => "re_comp.c",
    text   => "result of comparison against a string literal is unspecified (use an explicit string comparison function instead)",
  },
```
Analysis of the `make` output showed that the source of the problem lay in `scope.h`.  This pull request simplifies some code in that file and silences that build-time warning.

(Unfortunately, it does not mean we've achieved warnings-free building with clang9 or clang10.  Since that time a build-time warning has crept into `cpan/Scalar-List-Utils/ListUtil.xs`, for which I have filed a bug ticket upstream.)

(Also, we still have to face the problem of [many thousands of build-time warnings being generated when we configure with clang12](https://github.com/Perl/perl5/issues/18780).)

Thank you very much.
Jim Keenan