### PR TITLE
perldiag: numer -> number typo fix

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -6454,7 +6454,7 @@ C<\L> or C<\Q> preceding it.
 
 The C<"?"> and C<"+"> don't have any effect, as they modify whether to
 match more or fewer when there is a choice, and by specifying to match
-exactly a given numer, there is no room left for a choice.
+exactly a given number, there is no room left for a choice.
 
 =item Useless use of %s in void context
 


### PR DESCRIPTION
Just a small typo fix. I grepped the rest for \bnumer\b and didn't see any outright mistakes, tho i'm suspicious of https://github.com/Perl/perl5/blob/9cc5c436f846b78979eaa14aa6678db1270f7a46/cpan/Scalar-List-Utils/ListUtil.xs#L1868 (opinion, @leonerd?)