### PR TITLE
Pod html refactoring 2 of 5

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4324,7 +4324,7 @@ ext/Pod-Html/bin/pod2html	Translator to turn pod into HTML
 ext/Pod-Html/corpus/perlpodspec-copy.pod
 ext/Pod-Html/corpus/perlvar-copy.pod
 ext/Pod-Html/lib/Pod/Html.pm	Convert POD data to HTML
-ext/Pod-Html/lib/Pod/Html/Auxiliary.pm	Helper functions for Pod-Html
+ext/Pod-Html/lib/Pod/Html/Util.pm	Helper functions for Pod-Html
 ext/Pod-Html/t/anchorify.t
 ext/Pod-Html/t/cache.pod
 ext/Pod-Html/t/cache.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -4324,6 +4324,7 @@ ext/Pod-Html/bin/pod2html	Translator to turn pod into HTML
 ext/Pod-Html/corpus/perlpodspec-copy.pod
 ext/Pod-Html/corpus/perlvar-copy.pod
 ext/Pod-Html/lib/Pod/Html.pm	Convert POD data to HTML
+ext/Pod-Html/lib/Pod/Html/Auxiliary.pm	Helper functions for Pod-Html
 ext/Pod-Html/t/anchorify.t
 ext/Pod-Html/t/cache.pod
 ext/Pod-Html/t/cache.t

--- a/Makefile.SH
+++ b/Makefile.SH
@@ -1447,7 +1447,7 @@ _cleaner2:
 	-rmdir lib/TAP/Formatter/File lib/TAP/Formatter/Console
 	-rmdir lib/TAP/Formatter lib/TAP lib/Sys/Syslog lib/Sys lib/Sub
 	-rmdir lib/Search lib/Scalar lib/Pod/Text lib/Pod/Simple
-	-rmdir lib/Pod/Perldoc lib/PerlIO/via lib/PerlIO lib/Perl
+	-rmdir lib/Pod/Perldoc lib/Pod/Html lib/PerlIO/via lib/PerlIO lib/Perl
 	-rmdir lib/Parse/CPAN lib/Parse lib/Params lib/Net/FTP lib/Module/Load
 	-rmdir lib/Module/CoreList lib/Module lib/Memoize lib/Math/BigInt
 	-rmdir lib/Math/BigFloat lib/Math lib/MIME lib/Locale/Maketext

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -574,16 +574,16 @@ sub _save_page {
 sub write_file {
     my ($globals, $output) = @_;
     $globals->{Htmlfile} = "-" unless $globals->{Htmlfile}; # stdout
-    my $FHOUT;
+    my $fhout;
     if($globals->{Htmlfile} and $globals->{Htmlfile} ne '-') {
-        open $FHOUT, ">", $globals->{Htmlfile}
+        open $fhout, ">", $globals->{Htmlfile}
             or die "$0: cannot open $globals->{Htmlfile} file for output: $!\n";
     } else {
-        open $FHOUT, ">-";
+        open $fhout, ">-";
     }
-    binmode $FHOUT, ":utf8";
-    print $FHOUT $output;
-    close $FHOUT or die "Failed to close $globals->{Htmlfile}: $!";
+    binmode $fhout, ":utf8";
+    print $fhout $output;
+    close $fhout or die "Failed to close $globals->{Htmlfile}: $!";
     chmod 0644, $globals->{Htmlfile} unless $globals->{Htmlfile} eq '-';
 }
 

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -220,11 +220,11 @@ This program is distributed under the Artistic License.
 sub feed_tree_to_parser {
     my($parser, $tree) = @_;
     if(ref($tree) eq "") {
-	$parser->_handle_text($tree);
+        $parser->_handle_text($tree);
     } elsif(!($tree->[0] eq "X" && $parser->nix_X_codes)) {
-	$parser->_handle_element_start($tree->[0], $tree->[1]);
-	feed_tree_to_parser($parser, $_) foreach @{$tree}[2..$#$tree];
-	$parser->_handle_element_end($tree->[0]);
+        $parser->_handle_element_start($tree->[0], $tree->[1]);
+        feed_tree_to_parser($parser, $_) foreach @{$tree}[2..$#$tree];
+        $parser->_handle_element_end($tree->[0]);
     }
 }
 
@@ -437,19 +437,7 @@ HTMLFOOT
 
     feed_tree_to_parser($parser, $podtree);
 
-    # Write output to file
-    $globals->{Htmlfile} = "-" unless $globals->{Htmlfile}; # stdout
-    my $fhout;
-    if($globals->{Htmlfile} and $globals->{Htmlfile} ne '-') {
-        open $fhout, ">", $globals->{Htmlfile}
-            or die "$0: cannot open $globals->{Htmlfile} file for output: $!\n";
-    } else {
-        open $fhout, ">-";
-    }
-    binmode $fhout, ":utf8";
-    print $fhout $output;
-    close $fhout or die "Failed to close $globals->{Htmlfile}: $!";
-    chmod 0644, $globals->{Htmlfile} unless $globals->{Htmlfile} eq '-';
+    write_file($globals, $output);
 }
 
 sub get_cache {
@@ -544,6 +532,22 @@ sub _save_page {
 
     my ($file, $dir) = fileparse($modspec, qr/\.[^.]*/); # strip .ext
     $Pages{$modname} = $dir.$file;
+}
+
+sub write_file {
+    my ($globals, $output) = @_;
+    $globals->{Htmlfile} = "-" unless $globals->{Htmlfile}; # stdout
+    my $FHOUT;
+    if($globals->{Htmlfile} and $globals->{Htmlfile} ne '-') {
+        open $FHOUT, ">", $globals->{Htmlfile}
+            or die "$0: cannot open $globals->{Htmlfile} file for output: $!\n";
+    } else {
+        open $FHOUT, ">-";
+    }
+    binmode $FHOUT, ":utf8";
+    print $FHOUT $output;
+    close $FHOUT or die "Failed to close $globals->{Htmlfile}: $!";
+    chmod 0644, $globals->{Htmlfile} unless $globals->{Htmlfile} eq '-';
 }
 
 package Pod::Simple::XHTML::LocalPodLinks;

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -14,7 +14,7 @@ use File::Spec;
 use File::Spec::Unix;
 use Pod::Simple::Search;
 use Pod::Simple::SimpleTree ();
-use Pod::Html::Auxiliary qw(
+use Pod::Html::Util qw(
     html_escape
     htmlify
     parse_command_line
@@ -655,15 +655,15 @@ sub resolve_pod_page_link {
         $path = $self->pages->{$to};
     }
 
-    my $url = File::Spec::Unix->catfile(Pod::Html::Auxiliary::unixify($self->htmlroot),
+    my $url = File::Spec::Unix->catfile(Pod::Html::Util::unixify($self->htmlroot),
                                         $path);
 
     if ($self->htmlfileurl ne '') {
         # then $self->htmlroot eq '' (by definition of htmlfileurl) so
         # $self->htmldir needs to be prepended to link to get the absolute path
         # that will be relativized
-        $url = Pod::Html::Auxiliary::relativize_url(
-            File::Spec::Unix->catdir(Pod::Html::Auxiliary::unixify($self->htmldir), $url),
+        $url = Pod::Html::Util::relativize_url(
+            File::Spec::Unix->catdir(Pod::Html::Util::unixify($self->htmldir), $url),
             $self->htmlfileurl # already unixified
         );
     }

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -326,24 +326,7 @@ sub pod2html {
     }
 
     my $podtree = parse_input_for_podtree($globals, $input);
-
-    unless(defined $globals->{Title}) {
-        if($podtree->[0] eq "Document" && ref($podtree->[2]) eq "ARRAY" &&
-            $podtree->[2]->[0] eq "head1" && @{$podtree->[2]} == 3 &&
-            ref($podtree->[2]->[2]) eq "" && $podtree->[2]->[2] eq "NAME" &&
-            ref($podtree->[3]) eq "ARRAY" && $podtree->[3]->[0] eq "Para" &&
-            @{$podtree->[3]} >= 3 &&
-            !(grep { ref($_) ne "" }
-                @{$podtree->[3]}[2..$#{$podtree->[3]}]) &&
-            (@$podtree == 4 ||
-                (ref($podtree->[4]) eq "ARRAY" &&
-                $podtree->[4]->[0] eq "head1"))) {
-            $globals->{Title} = join("", @{$podtree->[3]}[2..$#{$podtree->[3]}]);
-        }
-    }
-
-    $globals->{Title} //= "";
-    $globals->{Title} = html_escape($globals->{Title});
+    $globals->{Title} = set_Title($globals, $podtree);
 
     # set options for the HTML generator
     my $parser = Pod::Simple::XHTML::LocalPodLinks->new();
@@ -450,6 +433,28 @@ sub parse_input_for_podtree {
     warn "Converting input file $globals->{Podfile}\n" if $globals->{Verbose};
     my $podtree = $input_parser->parse_file($input)->root;
     return $podtree;
+}
+
+sub set_Title {
+    my ($globals, $podtree) = @_;
+    unless(defined $globals->{Title}) {
+        if($podtree->[0] eq "Document" && ref($podtree->[2]) eq "ARRAY" &&
+            $podtree->[2]->[0] eq "head1" && @{$podtree->[2]} == 3 &&
+            ref($podtree->[2]->[2]) eq "" && $podtree->[2]->[2] eq "NAME" &&
+            ref($podtree->[3]) eq "ARRAY" && $podtree->[3]->[0] eq "Para" &&
+            @{$podtree->[3]} >= 3 &&
+            !(grep { ref($_) ne "" }
+                @{$podtree->[3]}[2..$#{$podtree->[3]}]) &&
+            (@$podtree == 4 ||
+                (ref($podtree->[4]) eq "ARRAY" &&
+                $podtree->[4]->[0] eq "head1"))) {
+            $globals->{Title} = join("", @{$podtree->[3]}[2..$#{$podtree->[3]}]);
+        }
+    }
+
+    $globals->{Title} //= "";
+    #$globals->{Title} = html_escape($globals->{Title});
+    return html_escape($globals->{Title});
 }
 
 sub get_cache {

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -326,7 +326,7 @@ sub pod2html {
     }
 
     my $podtree = parse_input_for_podtree($globals, $input);
-    $globals->{Title} = set_Title($globals, $podtree);
+    $globals->{Title} = set_Title_from_podtree($globals, $podtree);
 
     # set options for the HTML generator
     my $parser = Pod::Simple::XHTML::LocalPodLinks->new();
@@ -435,7 +435,7 @@ sub parse_input_for_podtree {
     return $podtree;
 }
 
-sub set_Title {
+sub set_Title_from_podtree {
     my ($globals, $podtree) = @_;
     unless(defined $globals->{Title}) {
         if($podtree->[0] eq "Document" && ref($podtree->[2]) eq "ARRAY" &&

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -3,8 +3,7 @@ use strict;
 use Exporter 'import';
 
 our $VERSION = 1.29;
-eval $VERSION;
-our @ISA = qw(Exporter);
+$VERSION = eval $VERSION;
 our @EXPORT = qw(pod2html);
 
 use Config;

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -328,7 +328,6 @@ sub pod2html {
             }
             print $cache "$key $Pages{$key}\n";
         }
-
         close $cache or die "error closing $globals->{Dircache}: $!";
     }
 
@@ -357,18 +356,18 @@ sub pod2html {
     my $podtree = $parser->parse_file($input)->root;
 
     unless(defined $globals->{Title}) {
-	if($podtree->[0] eq "Document" && ref($podtree->[2]) eq "ARRAY" &&
-		$podtree->[2]->[0] eq "head1" && @{$podtree->[2]} == 3 &&
-		ref($podtree->[2]->[2]) eq "" && $podtree->[2]->[2] eq "NAME" &&
-		ref($podtree->[3]) eq "ARRAY" && $podtree->[3]->[0] eq "Para" &&
-		@{$podtree->[3]} >= 3 &&
-		!(grep { ref($_) ne "" }
-		    @{$podtree->[3]}[2..$#{$podtree->[3]}]) &&
-		(@$podtree == 4 ||
-		    (ref($podtree->[4]) eq "ARRAY" &&
-			$podtree->[4]->[0] eq "head1"))) {
-	    $globals->{Title} = join("", @{$podtree->[3]}[2..$#{$podtree->[3]}]);
-	}
+        if($podtree->[0] eq "Document" && ref($podtree->[2]) eq "ARRAY" &&
+            $podtree->[2]->[0] eq "head1" && @{$podtree->[2]} == 3 &&
+            ref($podtree->[2]->[2]) eq "" && $podtree->[2]->[2] eq "NAME" &&
+            ref($podtree->[3]) eq "ARRAY" && $podtree->[3]->[0] eq "Para" &&
+            @{$podtree->[3]} >= 3 &&
+            !(grep { ref($_) ne "" }
+                @{$podtree->[3]}[2..$#{$podtree->[3]}]) &&
+            (@$podtree == 4 ||
+                (ref($podtree->[4]) eq "ARRAY" &&
+                $podtree->[4]->[0] eq "head1"))) {
+            $globals->{Title} = join("", @{$podtree->[3]}[2..$#{$podtree->[3]}]);
+        }
     }
 
     $globals->{Title} //= "";

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -275,25 +275,7 @@ sub pod2html {
 
     my $globals = init_globals();
     $globals = parse_command_line($globals);
-
-    # prevent '//' in urls
-    $globals->{Htmlroot} = "" if $globals->{Htmlroot} eq "/";
-    $globals->{Htmldir} =~ s#/\z##;
-
-    if (  $globals->{Htmlroot} eq ''
-       && defined( $globals->{Htmldir} )
-       && $globals->{Htmldir} ne ''
-       && substr( $globals->{Htmlfile}, 0, length( $globals->{Htmldir} ) ) eq $globals->{Htmldir}
-       ) {
-        # Set the 'base' url for this file, so that we can use it
-        # as the location from which to calculate relative links
-        # to other files. If this is '', then absolute links will
-        # be used throughout.
-        #$globals->{Htmlfileurl} = "$globals->{Htmldir}/" . substr( $globals->{Htmlfile}, length( $globals->{Htmldir} ) + 1);
-        # Is the above not just "$globals->{Htmlfileurl} = $globals->{Htmlfile}"?
-        $globals->{Htmlfileurl} = unixify($globals->{Htmlfile});
-
-    }
+    $globals = refine_globals($globals);
 
     # load or generate/cache %Pages
     unless (get_cache($globals)) {
@@ -428,6 +410,30 @@ HTMLFOOT
     feed_tree_to_parser($parser, $podtree);
 
     write_file($globals, $output);
+}
+
+sub refine_globals {
+    my $globals = shift;
+    require Data::Dumper if $globals->{verbose};
+
+    # prevent '//' in urls
+    $globals->{Htmlroot} = "" if $globals->{Htmlroot} eq "/";
+    $globals->{Htmldir} =~ s#/\z##;
+
+    if (  $globals->{Htmlroot} eq ''
+       && defined( $globals->{Htmldir} )
+       && $globals->{Htmldir} ne ''
+       && substr( $globals->{Htmlfile}, 0, length( $globals->{Htmldir} ) ) eq $globals->{Htmldir}
+       ) {
+        # Set the 'base' url for this file, so that we can use it
+        # as the location from which to calculate relative links
+        # to other files. If this is '', then absolute links will
+        # be used throughout.
+        #$globals->{Htmlfileurl} = "$globals->{Htmldir}/" . substr( $globals->{Htmlfile}, length( $globals->{Htmldir} ) + 1);
+        # Is the above not just "$globals->{Htmlfileurl} = $globals->{Htmlfile}"?
+        $globals->{Htmlfileurl} = unixify($globals->{Htmlfile});
+    }
+    return $globals;
 }
 
 sub parse_input_for_podtree {

--- a/ext/Pod-Html/lib/Pod/Html/Auxiliary.pm
+++ b/ext/Pod-Html/lib/Pod/Html/Auxiliary.pm
@@ -2,7 +2,7 @@ package Pod::Html::Auxiliary;
 use strict;
 require Exporter;
 
-our $VERSION = 1.27_001; # Please keep in synch with lib/Pod/Html.pm
+our $VERSION = 1.29; # Please keep in synch with lib/Pod/Html.pm
 $VERSION = eval $VERSION;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(

--- a/ext/Pod-Html/lib/Pod/Html/Auxiliary.pm
+++ b/ext/Pod-Html/lib/Pod/Html/Auxiliary.pm
@@ -1,0 +1,292 @@
+package Pod::Html::Auxiliary;
+use strict;
+require Exporter;
+
+our $VERSION = 1.27_001; # Please keep in synch with lib/Pod/Html.pm
+$VERSION = eval $VERSION;
+our @ISA = qw(Exporter);
+our @EXPORT_OK = qw(
+    anchorify
+    html_escape
+    htmlify
+    parse_command_line
+    relativize_url
+    trim_leading_whitespace
+    unixify
+    usage
+);
+
+use Config;
+use File::Spec;
+use File::Spec::Unix;
+use Getopt::Long;
+use Pod::Simple::XHTML;
+use Text::Tabs;
+use locale; # make \w work right in non-ASCII lands
+
+=head1 NAME
+
+Pod::Html::Auxiliary - helper functions for Pod-Html
+
+=head1 SUBROUTINES
+
+=head2 C<parse_command_line()>
+
+TK
+
+=cut
+
+sub parse_command_line {
+    my $globals = shift;
+    my ($opt_backlink,$opt_cachedir,$opt_css,$opt_flush,$opt_header,
+        $opt_help,$opt_htmldir,$opt_htmlroot,$opt_index,$opt_infile,
+        $opt_outfile,$opt_poderrors,$opt_podpath,$opt_podroot,
+        $opt_quiet,$opt_recurse,$opt_title,$opt_verbose);
+
+    unshift @ARGV, split ' ', $Config{pod2html} if $Config{pod2html};
+    my $result = GetOptions(
+                       'backlink!'  => \$opt_backlink,
+                       'cachedir=s' => \$opt_cachedir,
+                       'css=s'      => \$opt_css,
+                       'flush'      => \$opt_flush,
+                       'help'       => \$opt_help,
+                       'header!'    => \$opt_header,
+                       'htmldir=s'  => \$opt_htmldir,
+                       'htmlroot=s' => \$opt_htmlroot,
+                       'index!'     => \$opt_index,
+                       'infile=s'   => \$opt_infile,
+                       'outfile=s'  => \$opt_outfile,
+                       'poderrors!' => \$opt_poderrors,
+                       'podpath=s'  => \$opt_podpath,
+                       'podroot=s'  => \$opt_podroot,
+                       'quiet!'     => \$opt_quiet,
+                       'recurse!'   => \$opt_recurse,
+                       'title=s'    => \$opt_title,
+                       'verbose!'   => \$opt_verbose,
+    );
+    usage("-", "invalid parameters") if not $result;
+
+    usage("-") if defined $opt_help;    # see if the user asked for help
+    $opt_help = "";                     # just to make -w shut-up.
+
+    @{$globals->{Podpath}}  = split(":", $opt_podpath) if defined $opt_podpath;
+
+    $globals->{Backlink}  =          $opt_backlink   if defined $opt_backlink;
+    $globals->{Cachedir}  =  unixify($opt_cachedir)  if defined $opt_cachedir;
+    $globals->{Css}       =          $opt_css        if defined $opt_css;
+    $globals->{Header}    =          $opt_header     if defined $opt_header;
+    $globals->{Htmldir}   =  unixify($opt_htmldir)   if defined $opt_htmldir;
+    $globals->{Htmlroot}  =  unixify($opt_htmlroot)  if defined $opt_htmlroot;
+    $globals->{Doindex}   =          $opt_index      if defined $opt_index;
+    $globals->{Podfile}   =  unixify($opt_infile)    if defined $opt_infile;
+    $globals->{Htmlfile}  =  unixify($opt_outfile)   if defined $opt_outfile;
+    $globals->{Poderrors} =          $opt_poderrors  if defined $opt_poderrors;
+    $globals->{Podroot}   =  unixify($opt_podroot)   if defined $opt_podroot;
+    $globals->{Quiet}     =          $opt_quiet      if defined $opt_quiet;
+    $globals->{Recurse}   =          $opt_recurse    if defined $opt_recurse;
+    $globals->{Title}     =          $opt_title      if defined $opt_title;
+    $globals->{Verbose}   =          $opt_verbose    if defined $opt_verbose;
+
+    warn "Flushing directory caches\n"
+        if $opt_verbose && defined $opt_flush;
+    $globals->{Dircache} = "$globals->{Cachedir}/pod2htmd.tmp";
+    if (defined $opt_flush) {
+        1 while unlink($globals->{Dircache});
+    }
+    return $globals;
+}
+
+=head2 C<usage()>
+
+TK
+
+=cut
+
+sub usage {
+    my $podfile = shift;
+    warn "$0: $podfile: @_\n" if @_;
+    die <<END_OF_USAGE;
+Usage:  $0 --help --htmldir=<name> --htmlroot=<URL>
+           --infile=<name> --outfile=<name>
+           --podpath=<name>:...:<name> --podroot=<name>
+           --cachedir=<name> --flush --recurse --norecurse
+           --quiet --noquiet --verbose --noverbose
+           --index --noindex --backlink --nobacklink
+           --header --noheader --poderrors --nopoderrors
+           --css=<URL> --title=<name>
+
+  --[no]backlink  - turn =head1 directives into links pointing to the top of
+                      the page (off by default).
+  --cachedir      - directory for the directory cache files.
+  --css           - stylesheet URL
+  --flush         - flushes the directory cache.
+  --[no]header    - produce block header/footer (default is no headers).
+  --help          - prints this message.
+  --htmldir       - directory for resulting HTML files.
+  --htmlroot      - http-server base directory from which all relative paths
+                      in podpath stem (default is /).
+  --[no]index     - generate an index at the top of the resulting html
+                      (default behaviour).
+  --infile        - filename for the pod to convert (input taken from stdin
+                      by default).
+  --outfile       - filename for the resulting html file (output sent to
+                      stdout by default).
+  --[no]poderrors - include a POD ERRORS section in the output if there were 
+                      any POD errors in the input (default behavior).
+  --podpath       - colon-separated list of directories containing library
+                      pods (empty by default).
+  --podroot       - filesystem base directory from which all relative paths
+                      in podpath stem (default is .).
+  --[no]quiet     - suppress some benign warning messages (default is off).
+  --[no]recurse   - recurse on those subdirectories listed in podpath
+                      (default behaviour).
+  --title         - title that will appear in resulting html file.
+  --[no]verbose   - self-explanatory (off by default).
+
+END_OF_USAGE
+
+}
+
+=head2 C<unixify()>
+
+TK
+
+=cut
+
+sub unixify {
+    my $full_path = shift;
+    return '' unless $full_path;
+    return $full_path if $full_path eq '/';
+
+    my ($vol, $dirs, $file) = File::Spec->splitpath($full_path);
+    my @dirs = $dirs eq File::Spec->curdir()
+               ? (File::Spec::Unix->curdir())
+               : File::Spec->splitdir($dirs);
+    if (defined($vol) && $vol) {
+        $vol =~ s/:$// if $^O eq 'VMS';
+        $vol = uc $vol if $^O eq 'MSWin32';
+
+        if( $dirs[0] ) {
+            unshift @dirs, $vol;
+        }
+        else {
+            $dirs[0] = $vol;
+        }
+    }
+    unshift @dirs, '' if File::Spec->file_name_is_absolute($full_path);
+    return $file unless scalar(@dirs);
+    $full_path = File::Spec::Unix->catfile(File::Spec::Unix->catdir(@dirs),
+                                           $file);
+    $full_path =~ s|^\/|| if $^O eq 'MSWin32'; # C:/foo works, /C:/foo doesn't
+    $full_path =~ s/\^\././g if $^O eq 'VMS'; # unescape dots
+    return $full_path;
+}
+
+=head2 C<relativize_url()>
+
+Convert an absolute URL to one relative to a base URL.
+Assumes both end in a filename.
+
+=cut
+
+sub relativize_url {
+    my ($dest, $source) = @_;
+
+    # Remove each file from its path
+    my ($dest_volume, $dest_directory, $dest_file) =
+        File::Spec::Unix->splitpath( $dest );
+    $dest = File::Spec::Unix->catpath( $dest_volume, $dest_directory, '' );
+
+    my ($source_volume, $source_directory, $source_file) =
+        File::Spec::Unix->splitpath( $source );
+    $source = File::Spec::Unix->catpath( $source_volume, $source_directory, '' );
+
+    my $rel_path = '';
+    if ($dest ne '') {
+       $rel_path = File::Spec::Unix->abs2rel( $dest, $source );
+    }
+
+    if ($rel_path ne '' && substr( $rel_path, -1 ) ne '/') {
+        $rel_path .= "/$dest_file";
+    } else {
+        $rel_path .= "$dest_file";
+    }
+
+    return $rel_path;
+}
+
+=head2 C<html_escape()>
+
+Make text safe for HTML.
+
+=cut
+
+sub html_escape {
+    my $rest = $_[0];
+    $rest   =~ s/&/&amp;/g;
+    $rest   =~ s/</&lt;/g;
+    $rest   =~ s/>/&gt;/g;
+    $rest   =~ s/"/&quot;/g;
+    $rest =~ s/([[:^print:]])/sprintf("&#x%x;", ord($1))/aeg;
+    return $rest;
+}
+
+=head2 C<htmlify()>
+
+    htmlify($heading);
+
+Converts a pod section specification to a suitable section specification
+for HTML. Note that we keep spaces and special characters except
+C<", ?> (Netscape problem) and the hyphen (writer's problem...).
+
+=cut
+
+sub htmlify {
+    my( $heading) = @_;
+    return Pod::Simple::XHTML->can("idify")->(undef, $heading, 1);
+}
+
+=head2 C<anchorify()>
+
+    anchorify(@heading);
+
+Similar to C<htmlify()>, but turns non-alphanumerics into underscores.  Note
+that C<anchorify()> is not exported by default.
+
+=cut
+
+sub anchorify {
+    my ($anchor) = @_;
+    $anchor = htmlify($anchor);
+    $anchor =~ s/\W/_/g;
+    return $anchor;
+}
+
+=head2 C<trim_leading_whitespace()>
+
+Remove any level of indentation (spaces or tabs) from each code block
+consistently.  Adapted from:
+https://metacpan.org/source/HAARG/MetaCPAN-Pod-XHTML-0.002001/lib/Pod/Simple/Role/StripVerbatimIndent.pm
+
+=cut
+
+sub trim_leading_whitespace {
+    my ($para) = @_;
+
+    # Start by converting tabs to spaces
+    @$para = Text::Tabs::expand(@$para);
+
+    # Find the line with the least amount of indent, as that's our "base"
+    my @indent_levels = (sort(map { $_ =~ /^( *)./mg } @$para));
+    my $indent        = $indent_levels[0] || "";
+
+    # Remove the "base" amount of indent from each line
+    foreach (@$para) {
+        $_ =~ s/^\Q$indent//mg;
+    }
+
+    return;
+}
+
+1;
+

--- a/ext/Pod-Html/lib/Pod/Html/Util.pm
+++ b/ext/Pod-Html/lib/Pod/Html/Util.pm
@@ -1,4 +1,4 @@
-package Pod::Html::Auxiliary;
+package Pod::Html::Util;
 use strict;
 require Exporter;
 
@@ -26,7 +26,7 @@ use locale; # make \w work right in non-ASCII lands
 
 =head1 NAME
 
-Pod::Html::Auxiliary - helper functions for Pod-Html
+Pod::Html::Util - helper functions for Pod-Html
 
 =head1 SUBROUTINES
 

--- a/ext/Pod-Html/t/anchorify.t
+++ b/ext/Pod-Html/t/anchorify.t
@@ -1,6 +1,7 @@
 # -*- perl -*-
+
 use strict;
-use Pod::Html qw( anchorify );
+use Pod::Html::Auxiliary qw( anchorify );
 use Test::More tests => 1;
 
 my @filedata;
@@ -45,7 +46,7 @@ is_deeply(
 __DATA__
 =head1 NAME
 
-anchorify - Test C<Pod::Html::anchorify()>
+anchorify - Test C<Pod::Html::Auxiliary::anchorify()>
 
 =head1 DESCRIPTION
 

--- a/ext/Pod-Html/t/anchorify.t
+++ b/ext/Pod-Html/t/anchorify.t
@@ -1,7 +1,7 @@
 # -*- perl -*-
 
 use strict;
-use Pod::Html::Auxiliary qw( anchorify );
+use Pod::Html::Util qw( anchorify );
 use Test::More tests => 1;
 
 my @filedata;
@@ -46,7 +46,7 @@ is_deeply(
 __DATA__
 =head1 NAME
 
-anchorify - Test C<Pod::Html::Auxiliary::anchorify()>
+anchorify - Test C<Pod::Html::Util::anchorify()>
 
 =head1 DESCRIPTION
 

--- a/ext/Pod-Html/t/cache.t
+++ b/ext/Pod-Html/t/cache.t
@@ -11,6 +11,9 @@ use warnings;
 use Test::More tests => 10;
 use Testing qw( setup_testing_dir xconvert );
 use Cwd;
+use Pod::Html::Auxiliary qw(
+    unixify
+);
 
 my $debug = 0;
 my $startdir = cwd();
@@ -21,7 +24,7 @@ my $tdir = setup_testing_dir( {
     debug       => $debug,
 } );
 
-my $cwd = Pod::Html::_unixify(Cwd::cwd());
+my $cwd = unixify(Cwd::cwd());
 my $infile = catfile('t', 'cache.pod');
 my $outfile = "cacheout.html";
 my $cachefile = "pod2htmd.tmp";

--- a/ext/Pod-Html/t/cache.t
+++ b/ext/Pod-Html/t/cache.t
@@ -11,7 +11,7 @@ use warnings;
 use Test::More tests => 10;
 use Testing qw( setup_testing_dir xconvert );
 use Cwd;
-use Pod::Html::Auxiliary qw(
+use Pod::Html::Util qw(
     unixify
 );
 

--- a/ext/Pod-Html/t/crossref2.t
+++ b/ext/Pod-Html/t/crossref2.t
@@ -11,6 +11,9 @@ use warnings;
 use Test::More tests => 1;
 use Testing qw( setup_testing_dir xconvert );
 use Cwd;
+use Pod::Html::Auxiliary qw(
+    unixify
+);
 
 my $debug = 0;
 my $startdir = cwd();
@@ -22,7 +25,7 @@ my $tdir = setup_testing_dir( {
     debug       => $debug,
 } );
 
-my $cwd = Pod::Html::_unixify(cwd());
+my $cwd = unixify(cwd());
 
 $args = {
     podstub => "crossref",

--- a/ext/Pod-Html/t/crossref2.t
+++ b/ext/Pod-Html/t/crossref2.t
@@ -11,7 +11,7 @@ use warnings;
 use Test::More tests => 1;
 use Testing qw( setup_testing_dir xconvert );
 use Cwd;
-use Pod::Html::Auxiliary qw(
+use Pod::Html::Util qw(
     unixify
 );
 

--- a/ext/Pod-Html/t/eol.t
+++ b/ext/Pod-Html/t/eol.t
@@ -1,5 +1,6 @@
 #!./perl -w
 
+use Pod::Html;
 use Test::More tests => 3;
 
 my $podfile = "$$.pod";
@@ -33,8 +34,6 @@ crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
 =cut
 __EOF__
 close $pod or die $!;
-
-use Pod::Html;
 
 my $i = 0;
 foreach my $eol ("\r", "\n", "\r\n") {

--- a/ext/Pod-Html/t/feature2.t
+++ b/ext/Pod-Html/t/feature2.t
@@ -38,7 +38,6 @@ $args = {
         podroot     => $cwd,
         norecurse   => 1,
         verbose     => 1,
-        quiet       => 1,
     },
     debug => $debug,
 };

--- a/ext/Pod-Html/t/htmldir3.t
+++ b/ext/Pod-Html/t/htmldir3.t
@@ -8,7 +8,7 @@ BEGIN {
 
 use strict;
 use warnings;
-use Test::More tests => 2;
+use Test::More tests => 3;
 use Testing qw( setup_testing_dir xconvert );
 use Cwd;
 
@@ -27,6 +27,23 @@ my ($v, $d) = splitpath($cwd, 1);
 my @dirs = splitdir($d);
 shift @dirs if $dirs[0] eq '';
 my $relcwd = join '/', @dirs;
+
+$args = {
+    podstub => "htmldir3",
+    description => "test --htmldir and --htmlroot 3c: as expected pod file not yet locatable either under podroot or in cache: GH 12271",
+    expect => $expect_raw,
+    expect_fail => 1,
+    p2h => {
+        podpath    => catdir($relcwd, 't'),
+        podroot    => catpath($v, '/', ''),
+        htmldir    => 't',
+        outfile    => 't/htmldir3.html',
+        quiet      => 1,
+    },
+    debug => $debug,
+};
+$args->{core} = 1 if $ENV{PERL_CORE};
+xconvert($args);
 
 $args = {
     podstub => "htmldir3",

--- a/ext/Pod-Html/t/htmlview.t
+++ b/ext/Pod-Html/t/htmlview.t
@@ -27,6 +27,7 @@ $args = {
     description => "html rendering",
     expect => $expect_raw,
     p2h => {
+        podpath => 't',
         quiet  => 1,
     },
 };

--- a/ext/Pod-Html/t/lib/Testing.pm
+++ b/ext/Pod-Html/t/lib/Testing.pm
@@ -7,6 +7,7 @@ our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(
     setup_testing_dir
     xconvert
+    record_state_of_cache
 );
 use Cwd;
 use Pod::Html;
@@ -444,6 +445,7 @@ sub xconvert {
     my $podstub = $args->{podstub};
     my $description = $args->{description};
     my $debug = $args->{debug} // 0;
+    $args->{expect_fail} //= 0;
     if (defined $args->{p2h}) {
         die "Value for 'p2h' must be hashref"
             unless ref($args->{p2h}) eq 'HASH'; # TEST ME
@@ -479,6 +481,7 @@ sub xconvert {
         podstub     => $podstub,
         outfile     => $outfile,
         debug       => $debug,
+        expect_fail => $args->{expect_fail},
     } );
 
     # pod2html creates these
@@ -567,17 +570,28 @@ sub _process_diff {
     $diff = 'fc/n' if $^O =~ /^MSWin/;
     $diff = 'differences' if $^O eq 'VMS';
     if ($diff) {
-        ok($args->{expect} eq $args->{result}, $args->{description}) or do {
-            my $expectfile = $args->{podstub} . "_expected.tmp";
-            open my $tmpfile, ">", $expectfile or die $!;
-            print $tmpfile $args->{expect}, "\n";
-            close $tmpfile;
-            open my $diff_fh, "-|", "$diff $diffopt $expectfile $args->{outfile}"
-                or die("problem diffing: $!");
-            print STDERR "# $_" while <$diff_fh>;
-            close $diff_fh;
-            unlink $expectfile unless $args->{debug};
-        };
+        my $outcome = $args->{expect} eq $args->{result};
+        if ($outcome) {
+            ok($outcome, $args->{description});
+        }
+        else {
+            if ($args->{expect_fail}) {
+                ok(! $outcome, $args->{description});
+            }
+            else {
+                ok($outcome, $args->{description}) or do {
+                    my $expectfile = $args->{podstub} . "_expected.tmp";
+                    open my $tmpfile, ">", $expectfile or die $!;
+                    print $tmpfile $args->{expect}, "\n";
+                    close $tmpfile;
+                    open my $diff_fh, "-|", "$diff $diffopt $expectfile $args->{outfile}"
+                        or die("problem diffing: $!");
+                    print STDERR "# $_" while <$diff_fh>;
+                    close $diff_fh;
+                    unlink $expectfile unless $args->{debug};
+                };
+            }
+        }
     }
     else {
         # This is fairly evil, but lets us get detailed failure modes
@@ -585,6 +599,89 @@ sub _process_diff {
         is($args->{expect}, $args->{result}, $args->{description});
     }
     return 1;
+}
+
+=head2 C<record_state_of_cache()>
+
+=over 4
+
+=item * Purpose
+
+During debugging, enable developer to examine the state of the Pod-Html cache
+after each call to C<xconvert()>.
+
+=item * Arguments
+
+Single hash reference.
+
+    record_state_of_cache( {
+        outdir => "$ENV{P5P_DIR}/pod-html",
+        stub => $args->{podstub},
+        run => 1,
+    } );
+
+Hash reference has the following key-value pairs:
+
+=over 4
+
+=item * C<outdir>
+
+Any directory of your system to which you want a sorted copy of the cache to
+be printed.
+
+=item * C<stub>
+
+The same value you passed in C<$args> to C<xconvert()>.
+
+=item * C<run>
+
+Integer which you set manually to distinguish among multiple runs of this
+function within the same test file (presumably corresponding to multiple
+invocations of C<xconvert()>).
+
+=back
+
+=item * Return Value
+
+Implicitly returns Perl-true value.
+
+=item * Comment
+
+Function will print out location of cache files and other information.
+
+=back
+
+=cut
+
+sub record_state_of_cache {
+    my $args = shift;
+    die("record_state_of_cache() takes hash reference")
+        unless ref($args) eq 'HASH';
+    for my $k ( qw| outdir stub run | ) {
+        die("Argument to record_state_of_cache() lacks defined $k element")
+            unless defined $args->{$k};
+    }
+    my $cwd = cwd();
+    my $cache = catfile($cwd, 'pod2htmd.tmp');
+    die("Could not locate file $cache") unless -f $cache;
+    die("Could not locate directory $args->{outdir}") unless -d $args->{outdir};
+    die("'run' element takes integer") unless $args->{run} =~ m/^\d+$/;
+
+    my @cachelines = ();
+    open my $IN, '<', $cache or die "Unable to open $cache for reading";
+    while (my $l = <$IN>) {
+        chomp $l;
+        push @cachelines, $l;
+    }
+    close $IN  or die "Unable to close $cache after reading";
+
+    my $outfile = catfile($args->{outdir}, "$args->{run}.cache.$args->{stub}.$$.txt");
+    die("$outfile already exists; did you remember to increment the 'run' argument?")
+        if -f $outfile;
+    open my $OUT, '>', $outfile or die "Unable to open $outfile for writing";
+    print $OUT "$_\n" for (sort @cachelines);
+    close $OUT or die "Unable to close after writing";
+    print STDERR "XXX: cache (sorted): $outfile\n";
 }
 
 =head1 AUTHORS

--- a/ext/Pod-Html/t/lib/Testing.pm
+++ b/ext/Pod-Html/t/lib/Testing.pm
@@ -19,7 +19,7 @@ use File::Path ( qw| make_path | );
 use File::Spec::Functions ':ALL';
 use File::Temp ( qw| tempdir | );
 use Data::Dumper;$Data::Dumper::Sortkeys=1;
-use Pod::Html::Auxiliary qw(
+use Pod::Html::Util qw(
     unixify
 );
 

--- a/ext/Pod-Html/t/lib/Testing.pm
+++ b/ext/Pod-Html/t/lib/Testing.pm
@@ -672,19 +672,19 @@ sub record_state_of_cache {
     die("'run' element takes integer") unless $args->{run} =~ m/^\d+$/;
 
     my @cachelines = ();
-    open my $IN, '<', $cache or die "Unable to open $cache for reading";
-    while (my $l = <$IN>) {
+    open my $in, '<', $cache or die "Unable to open $cache for reading";
+    while (my $l = <$in>) {
         chomp $l;
         push @cachelines, $l;
     }
-    close $IN  or die "Unable to close $cache after reading";
+    close $in  or die "Unable to close $cache after reading";
 
     my $outfile = catfile($args->{outdir}, "$args->{run}.cache.$args->{stub}.$$.txt");
     die("$outfile already exists; did you remember to increment the 'run' argument?")
         if -f $outfile;
-    open my $OUT, '>', $outfile or die "Unable to open $outfile for writing";
-    print $OUT "$_\n" for (sort @cachelines);
-    close $OUT or die "Unable to close after writing";
+    open my $out, '>', $outfile or die "Unable to open $outfile for writing";
+    print $out "$_\n" for (sort @cachelines);
+    close $out or die "Unable to close after writing";
     print STDERR "XXX: cache (sorted): $outfile\n";
 }
 

--- a/ext/Pod-Html/t/lib/Testing.pm
+++ b/ext/Pod-Html/t/lib/Testing.pm
@@ -406,7 +406,10 @@ this key.  Required.
 
 Hash reference holding arguments passed to C<Pod::Html::pod2html()> (though
 without the leading double hyphens (C<-->).  See documentation for
-F<Pod::Html>.  Optional, but mostly necessary.
+F<Pod::Html>.  Optional, but mostly necessary.  In particular, if a F<.pod>
+file contains any C<LE<lt>E<gt>> tags, a C<podpath> element almost always
+needs to be supplied with a colon-delimited list of directories from which to
+begin a search for files containing POD.
 
 =item * C<debug>
 
@@ -496,9 +499,6 @@ sub _prepare_argstable {
     my %args_table = (
         infile      =>    $args->{infile},
         outfile     =>    $args->{outfile},
-        podpath     =>    't',
-        htmlroot    =>    '/',
-        podroot     =>    $args->{cwd},
     );
     my %no_arg_switches = map { $_ => 1 } @no_arg_switches;
     if (defined $args->{p2h}) {

--- a/ext/Pod-Html/t/lib/Testing.pm
+++ b/ext/Pod-Html/t/lib/Testing.pm
@@ -2,7 +2,8 @@ package Testing;
 use 5.10.0;
 use warnings;
 require Exporter;
-our $VERSION = 1.26; # Let's keep this same as lib/Pod/Html.pm
+our $VERSION = 1.27_001; # Let's keep this same as lib/Pod/Html.pm
+$VERSION = eval $VERSION;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(
     setup_testing_dir
@@ -18,6 +19,9 @@ use File::Path ( qw| make_path | );
 use File::Spec::Functions ':ALL';
 use File::Temp ( qw| tempdir | );
 use Data::Dumper;$Data::Dumper::Sortkeys=1;
+use Pod::Html::Auxiliary qw(
+    unixify
+);
 
 *ok = \&Test::More::ok;
 *is = \&Test::More::is;
@@ -453,7 +457,7 @@ sub xconvert {
         die "Value for 'p2h' must be hashref"
             unless ref($args->{p2h}) eq 'HASH'; # TEST ME
     }
-    my $cwd = Pod::Html::_unixify( Cwd::cwd() );
+    my $cwd = unixify( Cwd::cwd() );
     my ($vol, $dir) = splitpath($cwd, 1);
     my @dirs = splitdir($dir);
     shift @dirs if $dirs[0] eq '';

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -139,6 +139,7 @@
 /Pod/Escapes.pm
 /Pod/Functions.pm
 /Pod/Html.pm
+/Pod/Html/
 /Pod/Man.pm
 /Pod/ParseLink.pm
 /Pod/Perldoc.pm

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1851,6 +1851,7 @@ distclean: realclean
 	-if exist $(LIBDIR)\Parse rmdir /s /q $(LIBDIR)\Parse
 	-if exist $(LIBDIR)\Perl rmdir /s /q $(LIBDIR)\Perl
 	-if exist $(LIBDIR)\PerlIO rmdir /s /q $(LIBDIR)\PerlIO
+	-if exist $(LIBDIR)\Pod\Html rmdir /s /q $(LIBDIR)\Pod\Html
 	-if exist $(LIBDIR)\Pod\Perldoc rmdir /s /q $(LIBDIR)\Pod\Perldoc
 	-if exist $(LIBDIR)\Pod\Simple rmdir /s /q $(LIBDIR)\Pod\Simple
 	-if exist $(LIBDIR)\Pod\Text rmdir /s /q $(LIBDIR)\Pod\Text

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -1316,6 +1316,7 @@ distclean: realclean
 	-if exist $(LIBDIR)\Parse rmdir /s /q $(LIBDIR)\Parse
 	-if exist $(LIBDIR)\Perl rmdir /s /q $(LIBDIR)\Perl
 	-if exist $(LIBDIR)\PerlIO rmdir /s /q $(LIBDIR)\PerlIO
+	-if exist $(LIBDIR)\Pod\Html rmdir /s /q $(LIBDIR)\Pod\Html
 	-if exist $(LIBDIR)\Pod\Perldoc rmdir /s /q $(LIBDIR)\Pod\Perldoc
 	-if exist $(LIBDIR)\Pod\Simple rmdir /s /q $(LIBDIR)\Pod\Simple
 	-if exist $(LIBDIR)\Pod\Text rmdir /s /q $(LIBDIR)\Pod\Text


### PR DESCRIPTION
This is the second of ~two~ five pull requests in support of https://github.com/Perl/perl5/issues/18894.  These p.r.s are intended to make the internals of Pod-Html less messy.  Ultimately Pod::Html will hold a series of methods calls on an object.  In this commit we start to gather together most of the loose lexical variables holding state into an object.  We also move auxiliary functions into a package of their own.