### PR TITLE
Only set IOKp, not IOK on $) and $(.

### DIFF
--- a/mg.c
+++ b/mg.c
@@ -1240,7 +1240,13 @@ Perl_magic_get(pTHX_ SV *sv, MAGIC *mg)
                 Safefree(gary);
             }
         }
-        (void)SvIOK_on(sv);	/* what a wonderful hack! */
+
+        /*
+            Set this to avoid warnings when the SV is used as a number.
+            Avoid setting the public IOK flag so that serializers will
+            use the PV.
+        */
+        (void)SvIOKp_on(sv);	/* what a wonderful hack! */
 #endif
         break;
     case '0':

--- a/t/op/groups.t
+++ b/t/op/groups.t
@@ -51,8 +51,22 @@ sub Test {
     my %basegroup = basegroups( $pwgid, $pwgnam );
     my @extracted_supplementary_groups = remove_basegroup( \ %basegroup, \ @extracted_groups );
 
-    plan 3;
+    plan 4;
 
+    {
+        my @warnings = do {
+            my @w;
+            local $SIG{'__WARN__'} = sub { push @w, @_ };
+
+            use warnings;
+            my $v = $( + 1;
+            $v = $) + 1;
+
+            @w;
+        };
+
+        is ("@warnings", "", 'Neither $( nor $) trigger warnings when used as number.' );
+    }
 
     # Test: The supplementary groups in $( should match the
     # getgroups(2) kernal API call.


### PR DESCRIPTION
Issue #18955: This will prevent serializers from serializing these
variables as numbers (which loses the additional groups).

This restores behaviour from 5.16.