### PR TITLE
Fix syntax error wwhen NAN_COMPARE_BROKEN

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -9147,7 +9147,7 @@ Perl_sv_dec_nomg(pTHX_ SV *const sv)
                 UNLIKELY(was <= -NV_OVERFLOWS_INTEGERS_AT ||
                          was > NV_OVERFLOWS_INTEGERS_AT) &&
 #if defined(NAN_COMPARE_BROKEN)
-                LIKELY(!Perl_isinfnan(was)))
+                LIKELY(!Perl_isinfnan(was))
 #else
                 LIKELY(!Perl_isinf(was))
 #endif


### PR DESCRIPTION
http://nntp.perl.org/group/perl.perl5.porters/26082