### PR TITLE
Pod html refactoring 3 of 5

### DIFF
--- a/ext/Pod-Html/lib/Pod/Html/Util.pm
+++ b/ext/Pod-Html/lib/Pod/Html/Util.pm
@@ -2,7 +2,7 @@ package Pod::Html::Util;
 use strict;
 require Exporter;
 
-our $VERSION = 1.29; # Please keep in synch with lib/Pod/Html.pm
+our $VERSION = 1.30; # Please keep in synch with lib/Pod/Html.pm
 $VERSION = eval $VERSION;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(

--- a/ext/Pod-Html/t/lib/Testing.pm
+++ b/ext/Pod-Html/t/lib/Testing.pm
@@ -2,7 +2,7 @@ package Testing;
 use 5.10.0;
 use warnings;
 require Exporter;
-our $VERSION = 1.27_001; # Let's keep this same as lib/Pod/Html.pm
+our $VERSION = 1.30; # Let's keep this same as lib/Pod/Html.pm
 $VERSION = eval $VERSION;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(


### PR DESCRIPTION
This is the third five pull requests in support of #18894. These p.r.s are intended to make the internals of Pod-Html less messy. Ultimately Pod::Html will hold a series of methods calls on an object.

In this commit we rearrange the subroutine definitions in `ext/Pod-Html/lib/Pod/Html.pm` to more closely track the order in which they are called inside `Pod::Html::pod2html()`.  Here is a non-proofread guide to where the subs have moved.

| Subroutine            | blead     | branch   |
| --------------------- | ---------:| --------:|
| feed_tree_to_parser   |       219 |      562 |
| refine_globals        | 310        | 297 |
| generate_cache        | 334        | 322 |
| identify_input        | 377        | 457 |
| parse_input_for_podtree        | 393        | 473 |
| set_Title_from_podtree        | 409        | 489 |
| refine_parser        | 430        | 510 |
| get_cache        | 480        | 384 |
| cache_key        | 502        | 406 |
| load_cache        | 517        | 421 |
| _save_page        | 558        | 368 |
| write_file        | 574        | 573 |
| resolve_pod_page_link        | 607        | 606 |
