### PR TITLE
Get working directory on a non existing path returns a value and no errno on Haiku

### DIFF
--- a/dist/PathTools/Cwd.pm
+++ b/dist/PathTools/Cwd.pm
@@ -3,7 +3,7 @@ use strict;
 use Exporter;
 
 
-our $VERSION = '3.81';
+our $VERSION = '3.82';
 my $xs_version = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/dist/PathTools/t/cwd_enoent.t
+++ b/dist/PathTools/t/cwd_enoent.t
@@ -31,6 +31,9 @@ foreach my $type (qw(regular perl)) {
 	skip "getcwd() doesn't fail on non-existent directories on this platform", 4
 	    if $type eq 'regular' && $^O eq 'dragonfly';
 
+	skip "getcwd() doesn't fail on non-existent directories on this platform", 4
+	    if $type eq 'regular' && $^O eq 'haiku';
+
 	no warnings "redefine";
 	local *Cwd::abs_path = \&Cwd::_perl_abs_path if $type eq "perl";
 	local *Cwd::getcwd = \&Cwd::_perl_getcwd if $type eq "perl";


### PR DESCRIPTION
On Haiku, if you `cd` to a directory, `rm` it then `pwd` you will get the path and no error. 