### PR TITLE
skip using gcc brace groups for STMT_START/END

### DIFF
--- a/dist/Devel-PPPort/parts/inc/misc
+++ b/dist/Devel-PPPort/parts/inc/misc
@@ -248,17 +248,12 @@ __UNDEF_NOT_PROVIDED__  PERL_GCC_BRACE_GROUPS_FORBIDDEN
 
 #undef STMT_START
 #undef STMT_END
-#ifdef PERL_USE_GCC_BRACE_GROUPS
-#  define STMT_START    (void)( /* gcc supports ``({ STATEMENTS; })'' */
-#  define STMT_END      )
-#else
-#  if defined(VOIDFLAGS) && (VOIDFLAGS) && (defined(sun) || defined(__sun__)) && !defined(__GNUC__)
+#if defined(VOIDFLAGS) && (VOIDFLAGS) && (defined(sun) || defined(__sun__)) && !defined(__GNUC__)
 #    define STMT_START  if (1)
 #    define STMT_END    else (void)0
-#  else
+#else
 #    define STMT_START  do
 #    define STMT_END    while (0)
-#  endif
 #endif
 
 __UNDEFINED__  boolSV(b)    ((b) ? &PL_sv_yes : &PL_sv_no)

--- a/perl.h
+++ b/perl.h
@@ -734,13 +734,8 @@ Example usage:
  Trying to select a version that gives no warnings...
 */
 #if !(defined(STMT_START) && defined(STMT_END))
-# ifdef PERL_USE_GCC_BRACE_GROUPS
-#   define STMT_START	(void)(	/* gcc supports "({ STATEMENTS; })" */
-#   define STMT_END	)
-# else
 #   define STMT_START	do
 #   define STMT_END	while (0)
-# endif
 #endif
 
 #ifndef BYTEORDER  /* Should never happen -- byteorder is in config.h */


### PR DESCRIPTION
This warns (and warns a lot) on clang, and since these are documented
to only work to make a single statement, so there's little value to
allowing them to work in an expression.

An alternative would be to disable GCC brace groups on clang, but
these are used extensively in DEBUGGING builds to add extra checks
in sv.h.

Fixes #18780 