### PR TITLE
Generalize Unicode::Normalize to run on EBCDIC platforms

### DIFF
--- a/dist/Unicode-Normalize/Normalize.pm
+++ b/dist/Unicode-Normalize/Normalize.pm
@@ -16,7 +16,7 @@ use Carp;
 
 no warnings 'utf8';
 
-our $VERSION = '1.28';
+our $VERSION = '1.29';
 our $PACKAGE = __PACKAGE__;
 
 our @EXPORT = qw( NFC NFD NFKC NFKD );
@@ -50,6 +50,17 @@ sub unpack_U {
     # the shifted parameter into being UTF-8.  This allows this to work on
     # Perl 5.6, where there is no utf8::upgrade().
     return unpack('U*', shift(@_).pack('U*'));
+}
+
+sub ok ($$;$) {
+    my $count_ref = shift;  # Test number in caller
+    my $p = my $r = shift;
+    if (@_) {
+	my $x = shift;
+	$p = !defined $x ? !defined $r : !defined $r ? 0 : $r eq $x;
+    }
+
+    print $p ? "ok" : "not ok", ' ', ++$$count_ref, "\n";
 }
 
 require Exporter;

--- a/dist/Unicode-Normalize/mkheader
+++ b/dist/Unicode-Normalize/mkheader
@@ -24,28 +24,16 @@ use Carp;
 use File::Spec;
 use SelectSaver;
 
-BEGIN {
-    unless ('A' eq pack('U', 0x41)) {
-	die "Unicode::Normalize cannot stringify a Unicode code point\n";
-    }
-    unless (0x41 == unpack('U', 'A')) {
-	die "Unicode::Normalize cannot get Unicode code point\n";
-    }
-}
-
 our $PACKAGE = 'Unicode::Normalize, mkheader';
 
 our $prefix = "UNF_";
 our $structname = "${prefix}complist";
 
 # Starting in v5.20, the tables in lib/unicore are built using the platform's
-# native character set for code points 0-255.
-*pack_U = ($] ge 5.020)
-          ? sub { return pack('W*', @_).pack('U*'); } # The empty pack returns
-                                                      # an empty UTF-8 string,
-                                                      # so the effect is to
-                                                      # force the return into
-                                                      # being UTF-8.
+# native character set for code points 0-255.  But in v5.35, pack U stopped
+# trying to compensate
+*pack_U = ($] ge 5.020 && $] lt 5.035)
+          ? sub { return pack('U*', map { utf8::unicode_to_native($_) } @_); }
           : sub { return pack('U*', @_); };
 
 # %Canon and %Compat will be ($codepoint => $hexstring) after _U_stringify()

--- a/dist/Unicode-Normalize/t/fcdc.t
+++ b/dist/Unicode-Normalize/t/fcdc.t
@@ -23,14 +23,7 @@ use strict;
 use warnings;
 BEGIN { $| = 1; print "1..70\n"; }
 my $count = 0;
-sub ok ($;$) {
-    my $p = my $r = shift;
-    if (@_) {
-	my $x = shift;
-	$p = !defined $x ? !defined $r : !defined $r ? 0 : $r eq $x;
-    }
-    print $p ? "ok" : "not ok", ' ', ++$count, "\n";
-}
+sub ok { Unicode::Normalize::ok(\$count, @_) }
 
 use Unicode::Normalize qw(:all);
 

--- a/dist/Unicode-Normalize/t/fcdc.t
+++ b/dist/Unicode-Normalize/t/fcdc.t
@@ -1,16 +1,5 @@
 
 BEGIN {
-    unless ('A' eq pack('U', 0x41)) {
-	print "1..0 # Unicode::Normalize cannot pack a Unicode code point\n";
-	exit 0;
-    }
-    unless (0x41 == unpack('U', 'A')) {
-	print "1..0 # Unicode::Normalize cannot get a Unicode code point\n";
-	exit 0;
-    }
-}
-
-BEGIN {
     if ($ENV{PERL_CORE}) {
         chdir('t') if -d 't';
         @INC = $^O eq 'MacOS' ? qw(::lib) : qw(../lib);
@@ -29,7 +18,7 @@ use Unicode::Normalize qw(:all);
 
 ok(1);
 
-sub _pack_U { Unicode::Normalize::pack_U(@_) }
+sub _pack_U { Unicode::Normalize::dot_t_pack_U(@_) }
 sub hexU { _pack_U map hex, split ' ', shift }
 sub answer { defined $_[0] ? $_[0] ? "YES" : "NO" : "MAYBE" }
 

--- a/dist/Unicode-Normalize/t/form.t
+++ b/dist/Unicode-Normalize/t/form.t
@@ -23,14 +23,7 @@ use strict;
 use warnings;
 BEGIN { $| = 1; print "1..37\n"; }
 my $count = 0;
-sub ok ($;$) {
-    my $p = my $r = shift;
-    if (@_) {
-	my $x = shift;
-	$p = !defined $x ? !defined $r : !defined $r ? 0 : $r eq $x;
-    }
-    print $p ? "ok" : "not ok", ' ', ++$count, "\n";
-}
+sub ok { Unicode::Normalize::ok(\$count, @_) }
 
 use Unicode::Normalize qw(:all);
 

--- a/dist/Unicode-Normalize/t/form.t
+++ b/dist/Unicode-Normalize/t/form.t
@@ -1,16 +1,5 @@
 
 BEGIN {
-    unless ('A' eq pack('U', 0x41)) {
-	print "1..0 # Unicode::Normalize cannot pack a Unicode code point\n";
-	exit 0;
-    }
-    unless (0x41 == unpack('U', 'A')) {
-	print "1..0 # Unicode::Normalize cannot get a Unicode code point\n";
-	exit 0;
-    }
-}
-
-BEGIN {
     if ($ENV{PERL_CORE}) {
 	chdir('t') if -d 't';
 	@INC = $^O eq 'MacOS' ? qw(::lib) : qw(../lib);

--- a/dist/Unicode-Normalize/t/func.t
+++ b/dist/Unicode-Normalize/t/func.t
@@ -1,16 +1,5 @@
 
 BEGIN {
-    unless ('A' eq pack('U', 0x41)) {
-	print "1..0 # Unicode::Normalize cannot pack a Unicode code point\n";
-	exit 0;
-    }
-    unless (0x41 == unpack('U', 'A')) {
-	print "1..0 # Unicode::Normalize cannot get a Unicode code point\n";
-	exit 0;
-    }
-}
-
-BEGIN {
     if ($ENV{PERL_CORE}) {
         chdir('t') if -d 't';
         @INC = $^O eq 'MacOS' ? qw(::lib) : qw(../lib);
@@ -29,7 +18,7 @@ use Unicode::Normalize qw(:all);
 
 ok(1);
 
-sub _pack_U { Unicode::Normalize::pack_U(@_) }
+sub _pack_U { Unicode::Normalize::dot_t_pack_U(@_) }
 sub hexU { _pack_U map hex, split ' ', shift }
 
 # This won't work on EBCDIC platforms prior to v5.8.0, which is when this

--- a/dist/Unicode-Normalize/t/func.t
+++ b/dist/Unicode-Normalize/t/func.t
@@ -23,14 +23,7 @@ use strict;
 use warnings;
 BEGIN { $| = 1; print "1..217\n"; }
 my $count = 0;
-sub ok ($;$) {
-    my $p = my $r = shift;
-    if (@_) {
-	my $x = shift;
-	$p = !defined $x ? !defined $r : !defined $r ? 0 : $r eq $x;
-    }
-    print $p ? "ok" : "not ok", ' ', ++$count, "\n";
-}
+sub ok { Unicode::Normalize::ok(\$count, @_) }
 
 use Unicode::Normalize qw(:all);
 

--- a/dist/Unicode-Normalize/t/illegal.t
+++ b/dist/Unicode-Normalize/t/illegal.t
@@ -1,16 +1,5 @@
 
 BEGIN {
-    unless ('A' eq pack('U', 0x41)) {
-	print "1..0 # Unicode::Normalize cannot pack a Unicode code point\n";
-	exit 0;
-    }
-    unless (0x41 == unpack('U', 'A')) {
-	print "1..0 # Unicode::Normalize cannot get a Unicode code point\n";
-	exit 0;
-    }
-}
-
-BEGIN {
     if ($ENV{PERL_CORE}) {
         chdir('t') if -d 't';
         @INC = $^O eq 'MacOS' ? qw(::lib) : qw(../lib);
@@ -70,7 +59,7 @@ for my $u (0xD800, 0xDFFF, 0xFDD0, 0xFDEF, 0xFEFF, 0xFFFE, 0xFFFF,
 our $proc;    # before the last starter
 our $unproc;  # the last starter and after
 
-sub _pack_U   { Unicode::Normalize::pack_U(@_) }
+sub _pack_U   { Unicode::Normalize::dot_t_pack_U(@_) }
 
 ($proc, $unproc) = splitOnLastStarter(_pack_U(0x41, 0x300, 0x327, 0xFFFF));
 ok($proc   eq _pack_U(0x41, 0x300, 0x327));

--- a/dist/Unicode-Normalize/t/illegal.t
+++ b/dist/Unicode-Normalize/t/illegal.t
@@ -43,14 +43,7 @@ use warnings;
 
 BEGIN { $| = 1; print "1..113\n"; }
 my $count = 0;
-sub ok ($;$) {
-    my $p = my $r = shift;
-    if (@_) {
-	my $x = shift;
-	$p = !defined $x ? !defined $r : !defined $r ? 0 : $r eq $x;
-    }
-    print $p ? "ok" : "not ok", ' ', ++$count, "\n";
-}
+sub ok { Unicode::Normalize::ok(\$count, @_) }
 
 ok(1);
 

--- a/dist/Unicode-Normalize/t/norm.t
+++ b/dist/Unicode-Normalize/t/norm.t
@@ -1,16 +1,5 @@
 
 BEGIN {
-    unless ('A' eq pack('U', 0x41)) {
-	print "1..0 # Unicode::Normalize cannot pack a Unicode code point\n";
-	exit 0;
-    }
-    unless (0x41 == unpack('U', 'A')) {
-	print "1..0 # Unicode::Normalize cannot get a Unicode code point\n";
-	exit 0;
-    }
-}
-
-BEGIN {
     if ($ENV{PERL_CORE}) {
         chdir('t') if -d 't';
         @INC = $^O eq 'MacOS' ? qw(::lib) : qw(../lib);
@@ -29,8 +18,8 @@ use Unicode::Normalize qw(normalize);
 
 ok(1);
 
-sub _pack_U   { Unicode::Normalize::pack_U(@_) }
-sub _unpack_U { Unicode::Normalize::unpack_U(@_) }
+sub _pack_U   { Unicode::Normalize::dot_t_pack_U(@_) }
+sub _unpack_U { Unicode::Normalize::dot_t_unpack_U(@_) }
 
 #########################
 

--- a/dist/Unicode-Normalize/t/norm.t
+++ b/dist/Unicode-Normalize/t/norm.t
@@ -23,14 +23,7 @@ use strict;
 use warnings;
 BEGIN { $| = 1; print "1..64\n"; }
 my $count = 0;
-sub ok ($;$) {
-    my $p = my $r = shift;
-    if (@_) {
-	my $x = shift;
-	$p = !defined $x ? !defined $r : !defined $r ? 0 : $r eq $x;
-    }
-    print $p ? "ok" : "not ok", ' ', ++$count, "\n";
-}
+sub ok { Unicode::Normalize::ok(\$count, @_) }
 
 use Unicode::Normalize qw(normalize);
 

--- a/dist/Unicode-Normalize/t/null.t
+++ b/dist/Unicode-Normalize/t/null.t
@@ -1,16 +1,5 @@
 
 BEGIN {
-    unless ('A' eq pack('U', 0x41)) {
-	print "1..0 # Unicode::Normalize cannot pack a Unicode code point\n";
-	exit 0;
-    }
-    unless (0x41 == unpack('U', 'A')) {
-	print "1..0 # Unicode::Normalize cannot get a Unicode code point\n";
-	exit 0;
-    }
-}
-
-BEGIN {
     if ($ENV{PERL_CORE}) {
         chdir('t') if -d 't';
         @INC = $^O eq 'MacOS' ? qw(::lib) : qw(../lib);

--- a/dist/Unicode-Normalize/t/partial1.t
+++ b/dist/Unicode-Normalize/t/partial1.t
@@ -1,16 +1,5 @@
 
 BEGIN {
-    unless ('A' eq pack('U', 0x41)) {
-	print "1..0 # Unicode::Normalize cannot pack a Unicode code point\n";
-	exit 0;
-    }
-    unless (0x41 == unpack('U', 'A')) {
-	print "1..0 # Unicode::Normalize cannot get a Unicode code point\n";
-	exit 0;
-    }
-}
-
-BEGIN {
     if ($ENV{PERL_CORE}) {
         chdir('t') if -d 't';
         @INC = $^O eq 'MacOS' ? qw(::lib) : qw(../lib);

--- a/dist/Unicode-Normalize/t/partial1.t
+++ b/dist/Unicode-Normalize/t/partial1.t
@@ -31,14 +31,7 @@ use strict;
 use warnings;
 BEGIN { $| = 1; print "1..26\n"; }
 my $count = 0;
-sub ok ($;$) {
-    my $p = my $r = shift;
-    if (@_) {
-	my $x = shift;
-	$p = !defined $x ? !defined $r : !defined $r ? 0 : $r eq $x;
-    }
-    print $p ? "ok" : "not ok", ' ', ++$count, "\n";
-}
+sub ok { Unicode::Normalize::ok(\$count, @_) }
 
 use Unicode::Normalize qw(:all);
 

--- a/dist/Unicode-Normalize/t/partial2.t
+++ b/dist/Unicode-Normalize/t/partial2.t
@@ -31,14 +31,7 @@ use strict;
 use warnings;
 BEGIN { $| = 1; print "1..26\n"; }
 my $count = 0;
-sub ok ($;$) {
-    my $p = my $r = shift;
-    if (@_) {
-	my $x = shift;
-	$p = !defined $x ? !defined $r : !defined $r ? 0 : $r eq $x;
-    }
-    print $p ? "ok" : "not ok", ' ', ++$count, "\n";
-}
+sub ok { Unicode::Normalize::ok(\$count, @_) }
 
 use Unicode::Normalize qw(:all);
 

--- a/dist/Unicode-Normalize/t/partial2.t
+++ b/dist/Unicode-Normalize/t/partial2.t
@@ -1,16 +1,5 @@
 
 BEGIN {
-    unless ('A' eq pack('U', 0x41)) {
-	print "1..0 # Unicode::Normalize cannot pack a Unicode code point\n";
-	exit 0;
-    }
-    unless (0x41 == unpack('U', 'A')) {
-	print "1..0 # Unicode::Normalize cannot get a Unicode code point\n";
-	exit 0;
-    }
-}
-
-BEGIN {
     if ($ENV{PERL_CORE}) {
         chdir('t') if -d 't';
         @INC = $^O eq 'MacOS' ? qw(::lib) : qw(../lib);
@@ -37,8 +26,8 @@ use Unicode::Normalize qw(:all);
 
 ok(1);
 
-sub _pack_U   { Unicode::Normalize::pack_U(@_) }
-sub _unpack_U { Unicode::Normalize::unpack_U(@_) }
+sub _pack_U   { Unicode::Normalize::dot_t_pack_U(@_) }
+sub _unpack_U { Unicode::Normalize::undot_t_pack_U(@_) }
 
 #########################
 

--- a/dist/Unicode-Normalize/t/proto.t
+++ b/dist/Unicode-Normalize/t/proto.t
@@ -1,16 +1,5 @@
 
 BEGIN {
-    unless ('A' eq pack('U', 0x41)) {
-	print "1..0 # Unicode::Normalize cannot pack a Unicode code point\n";
-	exit 0;
-    }
-    unless (0x41 == unpack('U', 'A')) {
-	print "1..0 # Unicode::Normalize cannot get a Unicode code point\n";
-	exit 0;
-    }
-}
-
-BEGIN {
     if ($ENV{PERL_CORE}) {
         chdir('t') if -d 't';
         @INC = $^O eq 'MacOS' ? qw(::lib) : qw(../lib);

--- a/dist/Unicode-Normalize/t/proto.t
+++ b/dist/Unicode-Normalize/t/proto.t
@@ -23,14 +23,7 @@ use strict;
 use warnings;
 BEGIN { $| = 1; print "1..48\n"; }
 my $count = 0;
-sub ok ($;$) {
-    my $p = my $r = shift;
-    if (@_) {
-	my $x = shift;
-	$p = !defined $x ? !defined $r : !defined $r ? 0 : $r eq $x;
-    }
-    print $p ? "ok" : "not ok", ' ', ++$count, "\n";
-}
+sub ok { Unicode::Normalize::ok(\$count, @_) }
 
 use Unicode::Normalize qw(:all);
 

--- a/dist/Unicode-Normalize/t/split.t
+++ b/dist/Unicode-Normalize/t/split.t
@@ -1,16 +1,5 @@
 
 BEGIN {
-    unless ('A' eq pack('U', 0x41)) {
-	print "1..0 # Unicode::Normalize cannot pack a Unicode code point\n";
-	exit 0;
-    }
-    unless (0x41 == unpack('U', 'A')) {
-	print "1..0 # Unicode::Normalize cannot get a Unicode code point\n";
-	exit 0;
-    }
-}
-
-BEGIN {
     if ($ENV{PERL_CORE}) {
         chdir('t') if -d 't';
         @INC = $^O eq 'MacOS' ? qw(::lib) : qw(../lib);
@@ -37,8 +26,8 @@ use Unicode::Normalize qw(:all);
 
 ok(1);
 
-sub _pack_U   { Unicode::Normalize::pack_U(@_) }
-sub _unpack_U { Unicode::Normalize::unpack_U(@_) }
+sub _pack_U   { Unicode::Normalize::dot_t_pack_U(@_) }
+sub _unpack_U { Unicode::Normalize::dot_t_unpack_U(@_) }
 
 #########################
 

--- a/dist/Unicode-Normalize/t/split.t
+++ b/dist/Unicode-Normalize/t/split.t
@@ -31,14 +31,7 @@ use strict;
 use warnings;
 BEGIN { $| = 1; print "1..34\n"; }
 my $count = 0;
-sub ok ($;$) {
-    my $p = my $r = shift;
-    if (@_) {
-	my $x = shift;
-	$p = !defined $x ? !defined $r : !defined $r ? 0 : $r eq $x;
-    }
-    print $p ? "ok" : "not ok", ' ', ++$count, "\n";
-}
+sub ok { Unicode::Normalize::ok(\$count, @_) }
 
 use Unicode::Normalize qw(:all);
 

--- a/dist/Unicode-Normalize/t/test.t
+++ b/dist/Unicode-Normalize/t/test.t
@@ -1,16 +1,5 @@
 
 BEGIN {
-    unless ('A' eq pack('U', 0x41)) {
-	print "1..0 # Unicode::Normalize cannot pack a Unicode code point\n";
-	exit 0;
-    }
-    unless (0x41 == unpack('U', 'A')) {
-	print "1..0 # Unicode::Normalize cannot get a Unicode code point\n";
-	exit 0;
-    }
-}
-
-BEGIN {
     if ($ENV{PERL_CORE}) {
         chdir('t') if -d 't';
         @INC = $^O eq 'MacOS' ? qw(::lib) : qw(../lib);
@@ -29,8 +18,8 @@ use Unicode::Normalize;
 
 ok(1);
 
-sub _pack_U   { Unicode::Normalize::pack_U(@_) }
-sub _unpack_U { Unicode::Normalize::unpack_U(@_) }
+sub _pack_U   { Unicode::Normalize::dot_t_pack_U(@_) }
+sub _unpack_U { Unicode::Normalize::dot_t_unpack_U(@_) }
 
 #########################
 

--- a/dist/Unicode-Normalize/t/test.t
+++ b/dist/Unicode-Normalize/t/test.t
@@ -23,14 +23,7 @@ use strict;
 use warnings;
 BEGIN { $| = 1; print "1..72\n"; }
 my $count = 0;
-sub ok ($;$) {
-    my $p = my $r = shift;
-    if (@_) {
-	my $x = shift;
-	$p = !defined $x ? !defined $r : !defined $r ? 0 : $r eq $x;
-    }
-    print $p ? "ok" : "not ok", ' ', ++$count, "\n";
-}
+sub ok { Unicode::Normalize::ok(\$count, @_) }
 
 use Unicode::Normalize;
 

--- a/dist/Unicode-Normalize/t/tie.t
+++ b/dist/Unicode-Normalize/t/tie.t
@@ -1,16 +1,5 @@
 
 BEGIN {
-    unless ('A' eq pack('U', 0x41)) {
-	print "1..0 # Unicode::Normalize cannot pack a Unicode code point\n";
-	exit 0;
-    }
-    unless (0x41 == unpack('U', 'A')) {
-	print "1..0 # Unicode::Normalize cannot get a Unicode code point\n";
-	exit 0;
-    }
-}
-
-BEGIN {
     if ($ENV{PERL_CORE}) {
         chdir('t') if -d 't';
         @INC = $^O eq 'MacOS' ? qw(::lib) : qw(../lib);

--- a/dist/Unicode-Normalize/t/tie.t
+++ b/dist/Unicode-Normalize/t/tie.t
@@ -34,14 +34,7 @@ use strict;
 use warnings;
 BEGIN { $| = 1; print "1..17\n"; }
 my $count = 0;
-sub ok ($;$) {
-    my $p = my $r = shift;
-    if (@_) {
-	my $x = shift;
-	$p = !defined $x ? !defined $r : !defined $r ? 0 : $r eq $x;
-    }
-    print $p ? "ok" : "not ok", ' ', ++$count, "\n";
-}
+sub ok { Unicode::Normalize::ok(\$count, @_) }
 
 ok(1);
 


### PR DESCRIPTION
There's actually very little code change required to do this.

The biggest effort was various trivial changes in the .t files so that they didn't assume EBCDIC doesn't work, and their hand-rolled TAP function was moved to be in the module, and improved to give better debugging information.