### PR TITLE
Save some bitwise & instructions by casting to U8

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -1236,18 +1236,18 @@ Use L</UV> to declare variables of the maximum usable size on this platform.
 
 /* byte-swapping functions for big-/little-endian conversion */
 # define _swab_16_(x) ((U16)( \
-         (((U16)(x) & UINT16_C(0x00ff)) << 8) | \
-         (((U16)(x) & UINT16_C(0xff00)) >> 8) ))
+         (((U16)(U8) (x)                   ) << 8) |  \
+         (((U16)     (x) & UINT16_C(0xff00)) >> 8) ))
 
 # define _swab_32_(x) ((U32)( \
-         (((U32)(x) & UINT32_C(0x000000ff)) << 24) | \
+         (((U32)(U8)(x)                   ) << 24) | \
          (((U32)(x) & UINT32_C(0x0000ff00)) <<  8) | \
          (((U32)(x) & UINT32_C(0x00ff0000)) >>  8) | \
          (((U32)(x) & UINT32_C(0xff000000)) >> 24) ))
 
 # ifdef HAS_QUAD
 #  define _swab_64_(x) ((U64)( \
-          (((U64)(x) & UINT64_C(0x00000000000000ff)) << 56) | \
+          (((U64)(U8)(x)                           ) << 56) | \
           (((U64)(x) & UINT64_C(0x000000000000ff00)) << 40) | \
           (((U64)(x) & UINT64_C(0x0000000000ff0000)) << 24) | \
           (((U64)(x) & UINT64_C(0x00000000ff000000)) <<  8) | \

--- a/perl.h
+++ b/perl.h
@@ -4231,11 +4231,11 @@ my_swap16(const U16 x) {
 #  define htovl(x)      vtohl(x)
 #  define htovs(x)      vtohs(x)
 #elif BYTEORDER == 0x4321 || BYTEORDER == 0x87654321
-#  define vtohl(x)	((((x)&0xFF)<<24)	\
-                        +(((x)>>24)&0xFF)	\
+#  define vtohl(x)	((((U8) (x)) << 24)     \
+                        +((U8) ((x) >> 24))     \
                         +(((x)&0x0000FF00)<<8)	\
                         +(((x)&0x00FF0000)>>8)	)
-#  define vtohs(x)	((((x)&0xFF)<<8) + (((x)>>8)&0xFF))
+#  define vtohs(x)	((((U8) (x)) << 8) + ((U8) ((x) >> 8)))
 #  define htovl(x)	vtohl(x)
 #  define htovs(x)	vtohs(x)
 #else

--- a/perl.h
+++ b/perl.h
@@ -4189,13 +4189,13 @@ struct ptr_tbl {
 
 PERL_STATIC_INLINE U32
 my_swap32(const U32 x) {
-    return ((x & 0xFF) << 24) | ((x >> 24) & 0xFF)
+    return ((U8) (x) << 24) | ((U8) (x >> 24))
         | ((x & 0x0000FF00) << 8) | ((x & 0x00FF0000) >> 8);
 }
 
 PERL_STATIC_INLINE U16
 my_swap16(const U16 x) {
-    return ((x & 0xFF) << 8) | ((x >> 8) & 0xFF);
+    return (((U8) x) << 8) | ((U8) (x >> 8));
 }
 
 #    define htonl(x)    my_swap32(x)

--- a/win32/fcrypt.c
+++ b/win32/fcrypt.c
@@ -35,10 +35,10 @@ typedef struct des_ks_struct
                          l|=((unsigned long)(*((c)++)))<<16, \
                          l|=((unsigned long)(*((c)++)))<<24)
 
-#define l2c(l,c)	(*((c)++)=(unsigned char)(((l)    )&0xff), \
-                         *((c)++)=(unsigned char)(((l)>> 8)&0xff), \
-                         *((c)++)=(unsigned char)(((l)>>16)&0xff), \
-                         *((c)++)=(unsigned char)(((l)>>24)&0xff))
+#define l2c(l,c)	(*((c)++)=(unsigned char)((l)    ), \
+                         *((c)++)=(unsigned char)((l)>> 8), \
+                         *((c)++)=(unsigned char)((l)>>16), \
+                         *((c)++)=(unsigned char)((l)>>24))
 
 static const unsigned long SPtrans[8][64]={
 { /* nibble 0 */
@@ -357,8 +357,8 @@ des_set_key(des_cblock *key, des_key_schedule schedule)
         PERM_OP (d,c,t,1,0x55555555);
         PERM_OP (c,d,t,8,0x00ff00ff);
         PERM_OP (d,c,t,1,0x55555555);
-        d=	(((d&0x000000ff)<<16)| (d&0x0000ff00)     |
-                 ((d&0x00ff0000)>>16)|((c&0xf0000000)>>4));
+        d= ((((unsigned char) d) <<16)| (d&0x0000ff00)     |
+                  ((d&0x00ff0000)>>16)|((c&0xf0000000)>>4));
         c&=0x0fffffff;
 
         for (i=0; i<ITERATIONS; i++)


### PR DESCRIPTION
I believe that on any platform that Perl runs on, casting to U8 is the same as ANDing with 0xFF.  This wouldn't be the case if a byte were anything different than 8 bits, but Perl doesn't run on such a platform

This is a series of commits that remove the unnecessary '&'.  In many cases the result is more readable, and serves as an example for future maintainers that '& 0xFF' is unnecessary.

In some cases the code did both a cast and an AND.  This is redundant.

I did not check to see if typical compilers optimized away the instructions, but even if many do; probably not all do, and this isn't less readable