### PR TITLE
Document a way to perform `use Module VERSION LIST` on the command-line

### DIFF
--- a/pod/perlrun.pod
+++ b/pod/perlrun.pod
@@ -698,6 +698,11 @@ is that B<-MI<MODULE>=number> never does a version check,
 unless C<I<MODULE>::import()> itself is set up to do a version check, which
 could happen for example if I<MODULE> inherits from L<Exporter>.
 
+However, it should be noted that since the syntax C<'-MI<MODULE foo,bar>'>
+shown above will generate C<use MODULE ('foo', 'bar')>, it's possible
+to do a version check using C<'-MI<MODULE VERSION foo,bar>'>, which will
+generate C<use MODULE VERSION ('foo', 'bar')>.
+
 =item B<-n>
 X<-n>
 


### PR DESCRIPTION
The `split(/,/,q{foo,bar})` seems to still happen.

This is the currently documented case:

    $ perl -MO=Deparse '-MList::Util=any,all' -e1
    use List::Util (split(/,/, 'any,all', 0));
    '???';
    -e syntax OK

And these work too (and the split on comma also happens somehow):

    $ perl -MO=Deparse '-MList::Util any,all' -e1
    use List::Util ('any', 'all');
    '???';
    -e syntax OK

    $ perl -MO=Deparse '-MList::Util 1.5' -e1
    use List::Util 1.5;
    '???';
    -e syntax OK

    $ perl -MO=Deparse '-MList::Util 1.5 any,all' -e1
    use List::Util 1.5 ('any', 'all');
    '???';
    -e syntax OK