### PR TITLE
Time-HiRes: handle $Config{d_various} correctly

### DIFF
--- a/dist/Time-HiRes/Makefile.PL
+++ b/dist/Time-HiRes/Makefile.PL
@@ -562,7 +562,10 @@ EOD
     my $has_clock_gettime;
     my $has_clock_gettime_emulation;
     if (exists $Config{d_clock_gettime}) {
-        $has_clock_gettime++ if $Config{d_clock_gettime}; # Unlikely...
+        if ($Config{d_clock_gettime}) { # possibly set for cross-compilation
+            $has_clock_gettime++;
+            $DEFINE .= ' -DTIME_HIRES_CLOCK_GETTIME';
+        }
     } elsif (has_clock_xxx('gettime')) {
         $has_clock_gettime++;
         $DEFINE .= ' -DTIME_HIRES_CLOCK_GETTIME';
@@ -591,7 +594,10 @@ EOD
     my $has_clock_getres;
     my $has_clock_getres_emulation;
     if (exists $Config{d_clock_getres}) {
-        $has_clock_getres++ if $Config{d_clock_getres}; # Unlikely...
+        if ($Config{d_clock_getres}) { # possibly set for cross-compilation
+            $has_clock_getres++;
+            $DEFINE .= ' -DTIME_HIRES_CLOCK_GETRES';
+        }
     } elsif (has_clock_xxx('getres')) {
         $has_clock_getres++;
         $DEFINE .= ' -DTIME_HIRES_CLOCK_GETRES';
@@ -620,7 +626,10 @@ EOD
     my $has_clock_nanosleep;
     my $has_clock_nanosleep_emulation;
     if (exists $Config{d_clock_nanosleep}) {
-        $has_clock_nanosleep++ if $Config{d_clock_nanosleep}; # Unlikely...
+        if ($Config{d_clock_nanosleep}) { # possibly set for cross-compilation
+            $has_clock_nanosleep++;
+            $DEFINE .= ' -DTIME_HIRES_CLOCK_NANOSLEEP';
+        }
     } elsif (has_clock_nanosleep()) {
         $has_clock_nanosleep++;
         $DEFINE .= ' -DTIME_HIRES_CLOCK_NANOSLEEP';
@@ -643,7 +652,10 @@ EOD
     print "Looking for clock()... ";
     my $has_clock;
     if (exists $Config{d_clock}) {
-        $has_clock++ if $Config{d_clock}; # Unlikely...
+        if ($Config{d_clock}) { # possibly set for cross-compilation
+            $has_clock++;
+            $DEFINE .= ' -DTIME_HIRES_CLOCK';
+        }
     } elsif (has_clock()) {
         $has_clock++;
         $DEFINE .= ' -DTIME_HIRES_CLOCK';


### PR DESCRIPTION
The Time::HiRes Makefile.PL checks %Config for a variety of symbols
to attempt to probe for them without having to perform its own
compilation/run to probe for them.  This is useful for cross
compilation, since the Time::HiRes probes don't appear to handle
probing on a remote system as the Configure probes do.

A few of these probes didn't set the appropriate -DTIME_HIRES_XXX
symbol on the compilation command-line, fix that.

fixes #18953 