### PR TITLE
use CLANG_DIAG_IGNORE_STMT instead of GCC_DIAG_IGNORE_STMT

### DIFF
--- a/scope.h
+++ b/scope.h
@@ -208,11 +208,11 @@ scope has the given name. C<name> must be a literal string.
     STMT_START {							\
         DEBUG_SCOPE("LEAVE \"" name "\"")				\
         if (PL_scopestack_name)	{					\
-            GCC_DIAG_IGNORE_STMT(-Wstring-compare);			\
+            CLANG_DIAG_IGNORE_STMT(-Wstring-compare);			\
             assert(((char*)PL_scopestack_name[PL_scopestack_ix-1]	\
                         == (char*)name)					\
                     || strEQ(PL_scopestack_name[PL_scopestack_ix-1], name));        \
-            GCC_DIAG_RESTORE_STMT;					\
+            CLANG_DIAG_RESTORE_STMT;					\
         }								\
         pop_scope();							\
     } STMT_END


### PR DESCRIPTION
It turns out gcc wasn't warning on this code, but older gcc (as
included in debian buster) *does* warn on the switch which it
doesn't recognise.

Newer gcc does recognise the -Wstring-compare switch, but it controls
warning on a different construct, so there's no reason to present it
to gcc.