### PR TITLE
Only initialize threads::shared interpreter once

### DIFF
--- a/dist/threads-shared/lib/threads/shared.pm
+++ b/dist/threads-shared/lib/threads/shared.pm
@@ -8,7 +8,7 @@ use Config;
 
 use Scalar::Util qw(reftype refaddr blessed);
 
-our $VERSION = '1.62'; # Please update the pod, too.
+our $VERSION = '1.63'; # Please update the pod, too.
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -196,7 +196,7 @@ threads::shared - Perl extension for sharing data structures between threads
 
 =head1 VERSION
 
-This document describes threads::shared version 1.62
+This document describes threads::shared version 1.63
 
 =head1 SYNOPSIS
 

--- a/dist/threads-shared/shared.xs
+++ b/dist/threads-shared/shared.xs
@@ -1296,14 +1296,16 @@ static void
 Perl_sharedsv_init(pTHX)
 {
     dTHXc;
-    PL_sharedsv_space = perl_alloc();
-    perl_construct(PL_sharedsv_space);
-    /* The pair above leaves us in shared context (what dTHX would get),
-     * but aTHX still points to caller context */
-    aTHX = PL_sharedsv_space;
-    LEAVE; /* This balances the ENTER at the end of perl_construct.  */
-    PERL_SET_CONTEXT((aTHX = caller_perl));
-    recursive_lock_init(aTHX_ &PL_sharedsv_lock);
+    if (!PL_sharedsv_space) {
+        PL_sharedsv_space = perl_alloc();
+        perl_construct(PL_sharedsv_space);
+        /* The pair above leaves us in shared context (what dTHX would get),
+         * but aTHX still points to caller context */
+        aTHX = PL_sharedsv_space;
+        LEAVE; /* This balances the ENTER at the end of perl_construct.  */
+        PERL_SET_CONTEXT((aTHX = caller_perl));
+        recursive_lock_init(aTHX_ &PL_sharedsv_lock);
+    }
     PL_lockhook = &Perl_sharedsv_locksv;
     PL_sharehook = &Perl_sharedsv_share;
 #ifdef PL_destroyhook


### PR DESCRIPTION
Previously, the shared interpreter would be recreated every time the bootstrap was run, in the assumption that the bootstrap would only be run once. This assumption isn't necessarily true if multiple non-cloned interpreters exist.

Theoretically there's still a race condition around initialization, but I'm not particularly worried about that.