### PR TITLE
Enable capture variables to be used in a Net::hostent gethost call

### DIFF
--- a/lib/Net/hostent.pm
+++ b/lib/Net/hostent.pm
@@ -2,7 +2,7 @@ package Net::hostent;
 use strict;
 
 use 5.006_001;
-our $VERSION = '1.02';
+our $VERSION = '1.03';
 our (@EXPORT, @EXPORT_OK, %EXPORT_TAGS);
 our (
       $h_name, @h_aliases,
@@ -58,13 +58,14 @@ sub gethostbyaddr ($;$) {
 } 
 
 sub gethost($) {
-    if ($_[0] =~ /^\d+(?:\.\d+(?:\.\d+(?:\.\d+)?)?)?$/) {
-	require Socket;
-	&gethostbyaddr(Socket::inet_aton(shift));
+    my $addr = shift;
+    if ($addr =~ /^\d+(?:\.\d+(?:\.\d+(?:\.\d+)?)?)?$/) {
+       require Socket;
+       &gethostbyaddr(Socket::inet_aton($addr));
     } else {
-	&gethostbyname;
-    } 
-} 
+       &gethostbyname($addr);
+    }
+}
 
 1;
 __END__

--- a/lib/Net/hostent.t
+++ b/lib/Net/hostent.t
@@ -19,7 +19,7 @@ BEGIN {
     }
 }
 
-use Test::More tests => 7;
+use Test::More tests => 10;
 
 BEGIN { use_ok 'Net::hostent' }
 
@@ -47,6 +47,14 @@ ok(defined $i,  "gethostbyaddr('127.0.0.1')") ||
   DIE("Can't continue without working gethostbyaddr: $!");
 
 is( inet_ntoa($i->addr), "127.0.0.1",   'addr from gethostbyaddr' );
+
+$i = gethost("127.0.0.1");
+ok(defined $i,  "gethost('127.0.0.1')");
+is( inet_ntoa($i->addr), "127.0.0.1",   'addr from gethost' );
+
+"127.0.0.1" =~ /(.*)/;
+$i = gethost($1);
+ok(defined $i, 'gethost on capture variable');
 
 # need to skip the name comparisons on Win32 because windows will
 # return the name of the machine instead of "localhost" when resolving


### PR DESCRIPTION
Add test cases for gethost.

For: https://github.com/Perl/perl5/issues/19017