### PR TITLE
Porting/sync-with-cpan: handle weird tarball basedir names

### DIFF
--- a/Porting/sync-with-cpan
+++ b/Porting/sync-with-cpan
@@ -404,7 +404,7 @@ if ($$info {EXCLUDED}) {
 
 FILE: for my $file ( find_type_f( $new_dir )) {
     my $old_file = $file;
-    $file =~ s{^$new_dir/}{};
+    $file =~ s{^\Q$new_dir\E/}{};
 
     next if $EXCLUDED_QQ{$file};
     for my $qr (@EXCLUDED_QR) {


### PR DESCRIPTION
This was failing to map new Text::Tabs releases properly because its distname is Text-Tabs+Wrap and interpolating it into a pattern without quoting causes the `+` to be misinterpreted as a quantifier.