### PR TITLE
Porting/core-cpan-diff: Remove '--binary'

### DIFF
--- a/Porting/core-cpan-diff
+++ b/Porting/core-cpan-diff
@@ -53,7 +53,8 @@ Usage: $0 [opts] [ -d | -v | -x ] [ -a | module ... ]
 -d/--diff     Display file differences using diff(1), rather than just
               listing which files have changed.
 
---diffopts    Options to pass to the diff command. Defaults to '-u --binary'.
+--diffopts    Options to pass to the diff command. Defaults to '-u --binary'
+              (except on *BSD, where it's just '-u').
 
 -f|force      Force download from CPAN of new 02packages.details.txt file
               (with --crosscheck only).
@@ -125,7 +126,10 @@ sub run {
           if ( $reverse || $use_diff || $diff_opts );
     }
     else {
-        $diff_opts = '-u --binary' unless defined $diff_opts;
+        #$diff_opts = '-u --binary' unless defined $diff_opts;
+        if (! defined $diff_opts) {
+            $diff_opts = ($^O =~ m/bsd$/i) ? '-u' : '-u --binary';
+        };
         usage("can't use -f without --crosscheck") if $force;
     }
 


### PR DESCRIPTION
Other things being equal, this program defaults to passing '-u --binary'
to the 'diff' command.  But there is no such option to 'diff' on either
Linux or FreeBSD.  Consequently, running the program spews more than
80,000 lines of error output.  Removing that option from code and
documentation makes the program DWIM.