### PR TITLE
Add MAIN_MODULE to Porting/Maintainers.pl and use it in Porting/sync-with-cpan

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -70,6 +70,10 @@ use File::Glob qw(:case);
 # upload the corresponding cpan release, and the entry in this file should
 # only be updated when that release has been done.)
 
+# MAIN_MODULE names the top-level module by which the tarball is indexed on
+# CPAN in cases where this differs from the distribution's key in %Modules.
+# (If it is equal then MAIN_MODULE is optional and should be omitted.)
+
 # EXCLUDED is a list of files to be excluded from a CPAN tarball before
 # comparing the remaining contents with core. Each item can either be a
 # full pathname (eg 't/foo.t') or a pattern (e.g. qr{^t/}).
@@ -631,6 +635,7 @@ use File::Glob qw(:case);
 
     'IO-Compress' => {
         'DISTRIBUTION' => 'PMQS/IO-Compress-2.102.tar.gz',
+        'MAIN_MODULE'  => 'IO::Compress::Base',
         'FILES'        => q[cpan/IO-Compress],
         'EXCLUDED'     => [
             qr{^examples/},
@@ -687,6 +692,7 @@ use File::Glob qw(:case);
 
     'libnet' => {
         'DISTRIBUTION' => 'SHAY/libnet-3.13.tar.gz',
+        'MAIN_MODULE'  => 'Net::Cmd',
         'FILES'        => q[cpan/libnet],
         'EXCLUDED'     => [
             qw( Configure
@@ -888,6 +894,7 @@ use File::Glob qw(:case);
 
     'PathTools' => {
         'DISTRIBUTION' => 'XSAWYERX/PathTools-3.75.tar.gz',
+        'MAIN_MODULE'  => 'File::Spec',
         'FILES'        => q[dist/PathTools],
         'EXCLUDED'     => [
             qr{^t/lib/Test/},
@@ -966,6 +973,7 @@ use File::Glob qw(:case);
 
     'podlators' => {
         'DISTRIBUTION' => 'RRA/podlators-4.14.tar.gz',
+        'MAIN_MODULE'  => 'Pod::Man',
         'FILES'        => q[cpan/podlators pod/perlpodstyle.pod],
         'EXCLUDED'     => [
             qr{^docs/metadata/},
@@ -1123,6 +1131,7 @@ use File::Glob qw(:case);
 
     'Text-Tabs+Wrap' => {
         'DISTRIBUTION' => 'ARISTOTLE/Text-Tabs+Wrap-2021.0804.tar.gz',
+        'MAIN_MODULE'  => 'Text::Tabs',
         'FILES'        => q[cpan/Text-Tabs],
         'EXCLUDED'   => [
             qr{^xt},

--- a/Porting/sync-with-cpan
+++ b/Porting/sync-with-cpan
@@ -293,7 +293,6 @@ my  $pkg_dir      = $files[0];
 
 my ($old_version) = $distribution =~ /-([0-9.]+(?:-TRIAL[0-9]*)?)\.tar\.gz/;
 
-my  $o_module     = $module;
 if ($cpan_mod =~ /-/ && $cpan_mod !~ /::/) {
     $cpan_mod =~ s/-/::/g;
 }
@@ -672,7 +671,7 @@ print <<"EOF";
 
 =======================================================================
 
-$o_module is now at version $new_version
+$module is now at version $new_version
 Next, you should run a "make test".
 
 Hopefully that will complete successfully, but if not, you can make any

--- a/Porting/sync-with-cpan
+++ b/Porting/sync-with-cpan
@@ -179,7 +179,7 @@ my @problematic = (
 sub usage
 {
     my $err = shift and select STDERR;
-    print "Usage: $0 module [args] [cpan package]\n";
+    print "Usage: $0 <module-or-dist> [args]\n";
     exit $err;
 }
 
@@ -269,8 +269,6 @@ EOF
     print "Hit return to continue; ^C to abort "; <STDIN>;
 }
 
-my $cpan_mod = @ARGV ? shift : $module;
-
 my  $distribution = $$info {DISTRIBUTION};
 
 my @files         = glob $$info {FILES};
@@ -292,10 +290,6 @@ my  $pkg_dir      = $files[0];
     $pkg_dir      =~ s!.*/!!;
 
 my ($old_version) = $distribution =~ /-([0-9.]+(?:-TRIAL[0-9]*)?)\.tar\.gz/;
-
-if ($cpan_mod =~ /-/ && $cpan_mod !~ /::/) {
-    $cpan_mod =~ s/-/::/g;
-}
 
 sub wget {
     my ($url, $saveas) = @_;
@@ -347,8 +341,9 @@ else {
         wget $package_url, $package_file;
     }
 
+    my $cpan_mod = $info->{MAIN_MODULE} // $module;
     open my $fh, '<', $package_file;
-    (my $new_line) = grep {/^$cpan_mod/} <$fh> # Yes, this needs a lot of memory
+    (my $new_line) = grep {/^\Q$cpan_mod\E /} <$fh> # Yes, this needs a lot of memory
                      or die "Cannot find $cpan_mod on CPAN\n";
     (undef, $new_version, my $new_path) = split ' ', $new_line;
     if (defined $version) {


### PR DESCRIPTION
This also fills in this data for all the cases where it’s needed and removes the rendered-obsolete and barely-documented ability to pass this information to `sync-with-cpan` manually via a second argument.