### PR TITLE
Add PL_shutdownhook

### DIFF
--- a/dist/threads-shared/lib/threads/shared.pm
+++ b/dist/threads-shared/lib/threads/shared.pm
@@ -8,7 +8,7 @@ use Config;
 
 use Scalar::Util qw(reftype refaddr blessed);
 
-our $VERSION = '1.69'; # Please update the pod, too.
+our $VERSION = '1.70'; # Please update the pod, too.
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -196,7 +196,7 @@ threads::shared - Perl extension for sharing data structures between threads
 
 =head1 VERSION
 
-This document describes threads::shared version 1.68
+This document describes threads::shared version 1.70
 
 =head1 SYNOPSIS
 

--- a/dosish.h
+++ b/dosish.h
@@ -31,10 +31,10 @@
  * to work, but must NOT be retained in production code. */
 #ifndef PERL_SYS_TERM_BODY
 #  define PERL_SYS_TERM_BODY()                         \
-    ENV_TERM; USER_PROP_MUTEX_TERM; LOCALE_TERM;       \
-    HINTS_REFCNT_TERM; KEYWORD_PLUGIN_MUTEX_TERM;      \
-    OP_CHECK_MUTEX_TERM; OP_REFCNT_TERM;               \
-    PERLIO_TERM; MALLOC_TERM; 
+    SHUTDOWN_TERM; ENV_TERM; USER_PROP_MUTEX_TERM;      \
+    LOCALE_TERM;INTS_REFCNT_TERM;                      \
+    KEYWORD_PLUGIN_MUTEX_TERM;OP_CHECK_MUTEX_TERM;     \
+    OP_REFCNT_TERM;PERLIO_TERM; MALLOC_TERM;
 #endif
 #define dXSUB_SYS dNOOP
 

--- a/embed.fnc
+++ b/embed.fnc
@@ -2353,6 +2353,7 @@ p	|void	|no_bareword_filehandle 				\
 				|NN const char *fhname
 Tefprv	|void	|noperl_die	|NN const char *pat			\
 				|...
+CGTdp	|void	|noshutdownhook
 Adp	|int	|nothreadhook
 p	|void	|notify_parser_that_encoding_changed
 : Used in perly.y

--- a/embed.h
+++ b/embed.h
@@ -452,6 +452,7 @@
 # define new_stackinfo(a,b)                     Perl_new_stackinfo(aTHX_ a,b)
 # define new_stackinfo_flags(a,b,c)             Perl_new_stackinfo_flags(aTHX_ a,b,c)
 # define new_version(a)                         Perl_new_version(aTHX_ a)
+# define noshutdownhook                         Perl_noshutdownhook
 # define nothreadhook()                         Perl_nothreadhook(aTHX)
 # define op_append_elem(a,b,c)                  Perl_op_append_elem(aTHX_ a,b,c)
 # define op_append_list(a,b,c)                  Perl_op_append_list(aTHX_ a,b,c)

--- a/perl.c
+++ b/perl.c
@@ -480,6 +480,19 @@ Perl_nothreadhook(pTHX)
     return 0;
 }
 
+/*
+=for apidoc noshutdownhook
+
+Stub that provides shutdown hook.
+
+=cut
+*/
+
+void
+Perl_noshutdownhook()
+{
+}
+
 #ifdef DEBUG_LEAKING_SCALARS_FORK_DUMP
 void
 Perl_dump_sv_child(pTHX_ SV *sv)

--- a/perl.h
+++ b/perl.h
@@ -3606,6 +3606,8 @@ freeing any remaining Perl interpreters.
 #define PERL_SYS_INIT3(argc, argv, env)	Perl_sys_init3(argc, argv, env)
 #define PERL_SYS_TERM()			Perl_sys_term()
 
+#define SHUTDOWN_TERM PL_shutdownhook();
+
 #ifndef PERL_WRITE_MSG_TO_CONSOLE
 #  define PERL_WRITE_MSG_TO_CONSOLE(io, msg, len) PerlIO_write(io, msg, len)
 #endif

--- a/perl.h
+++ b/perl.h
@@ -5350,6 +5350,7 @@ typedef int  (*thrhook_proc_t) (pTHX);
 typedef OP* (*PPADDR_t[]) (pTHX);
 typedef bool (*destroyable_proc_t) (pTHX_ SV *sv);
 typedef void (*despatch_signals_proc_t) (pTHX);
+typedef void (*shutdown_proc_t)();
 
 #if defined(__DYNAMIC__) && defined(PERL_DARWIN) && defined(PERL_CORE)
 #  include <crt_externs.h>	/* for the env array */

--- a/perlvars.h
+++ b/perlvars.h
@@ -380,6 +380,12 @@ PERLVAR(G, user_prop_mutex, perl_mutex)    /* Mutex for manipulating
                                               PL_user_defined_properties */
 #endif
 
+/* This hook is called during system termination (PERL_SYS_TERM).
+ * This is needed for tearing down threads::shared and probably
+ * not be used for anything else.
+ */
+PERLVARI(G, shutdownhook, shutdown_proc_t, &Perl_noshutdownhook);
+
 /* these record the best way to perform certain IO operations while
  * atomically setting FD_CLOEXEC. On the first call, a probe is done
  * and the result recorded for use by subsequent calls.

--- a/proto.h
+++ b/proto.h
@@ -3155,6 +3155,9 @@ Perl_noperl_die(const char *pat, ...)
 #define PERL_ARGS_ASSERT_NOPERL_DIE             \
         assert(pat)
 
+PERL_CALLCONV void
+Perl_noshutdownhook(void);
+
 PERL_CALLCONV int
 Perl_nothreadhook(pTHX);
 #define PERL_ARGS_ASSERT_NOTHREADHOOK

--- a/unixish.h
+++ b/unixish.h
@@ -155,10 +155,10 @@ int afstat(int fd, struct stat *statb);
  * to work, but must NOT be retained in production code. */
 #ifndef PERL_SYS_TERM_BODY
 #  define PERL_SYS_TERM_BODY()                                          \
-                    ENV_TERM; USER_PROP_MUTEX_TERM; LOCALE_TERM;        \
-                    HINTS_REFCNT_TERM; KEYWORD_PLUGIN_MUTEX_TERM;       \
-                    OP_CHECK_MUTEX_TERM; OP_REFCNT_TERM;                \
-                    PERLIO_TERM; MALLOC_TERM;                           \
+                    SHUTDOWN_TERM; ENV_TERM; USER_PROP_MUTEX_TERM;      \
+                    LOCALE_TERM; HINTS_REFCNT_TERM;                     \
+                    KEYWORD_PLUGIN_MUTEX_TERM; OP_CHECK_MUTEX_TERM;     \
+                    OP_REFCNT_TERM; PERLIO_TERM; MALLOC_TERM;           \
                     PLATFORM_SYS_TERM_;
 #endif
 

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -5502,6 +5502,7 @@ Perl_win32_init(int *argcp, char ***argvp)
 void
 Perl_win32_term(void)
 {
+    SHUTDOWN_TERM;
     HINTS_REFCNT_TERM;
     OP_REFCNT_TERM;
     PERLIO_TERM;


### PR DESCRIPTION
This is a proposed solution to #19022

This adds a hook that is run early in `PERL_SYS_TERM` to terminate global resources, and uses it to destroy the shared interpreter in `threads::shared`