### PR TITLE
Pod html auxiliary functions compatibility

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4360,6 +4360,7 @@ ext/Pod-Html/corpus/perlvar-copy.pod
 ext/Pod-Html/lib/Pod/Html.pm	Convert POD data to HTML
 ext/Pod-Html/lib/Pod/Html/Util.pm	Helper functions for Pod-Html
 ext/Pod-Html/t/anchorify.t
+ext/Pod-Html/t/anchorify-536.t	Test Pod-Html utility functions during perl-5.36
 ext/Pod-Html/t/cache.pod
 ext/Pod-Html/t/cache.t
 ext/Pod-Html/t/crossref.pod

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -2,9 +2,10 @@ package Pod::Html;
 use strict;
 use Exporter 'import';
 
-our $VERSION = 1.31;
+our $VERSION = 1.32;
 $VERSION = eval $VERSION;
-our @EXPORT = qw(pod2html);
+our @EXPORT = qw(pod2html htmlify);
+our @EXPORT_OK = qw(anchorify relativize_url);
 
 use Config;
 use Cwd;
@@ -15,12 +16,13 @@ use Pod::Simple::Search;
 use Pod::Simple::SimpleTree ();
 use Pod::Html::Util qw(
     html_escape
-    htmlify
     parse_command_line
-    relativize_url
     trim_leading_whitespace
     unixify
     usage
+    htmlify
+    anchorify
+    relativize_url
 );
 use locale; # make \w work right in non-ASCII lands
 
@@ -193,6 +195,29 @@ Specify the title of the resulting HTML file.
 Display progress messages.  By default, they won't be displayed.
 
 =back
+
+=head2 Auxiliary Functions
+
+Prior to perl-5.36, the following three functions were exported by
+F<Pod::Html>, either by default or on request:
+
+=over 4
+
+=item * C<htmlify()> (by default)
+
+=item * C<anchorify()> (upon request)
+
+=item * C<relativize_url()> (upon request)
+
+=back
+
+The definition and documentation of these functions have been moved to
+F<Pod::Html::Util>, viewable via C<perldoc Pod::Html::Util>.
+
+In perl-5.36, these functions will be importable from either F<Pod::Html> or
+F<Pod::Html::Util>.  However, beginning with perl-5.38 they will only be
+importable, upon request, from F<Pod::Html::Util>.  Please modify your code as
+needed.
 
 =head1 ENVIRONMENT
 
@@ -585,6 +610,7 @@ sub write_file {
     close $fhout or die "Failed to close $globals->{Htmlfile}: $!";
     chmod 0644, $globals->{Htmlfile} unless $globals->{Htmlfile} eq '-';
 }
+
 
 package Pod::Simple::XHTML::LocalPodLinks;
 use strict;

--- a/ext/Pod-Html/lib/Pod/Html/Util.pm
+++ b/ext/Pod-Html/lib/Pod/Html/Util.pm
@@ -2,7 +2,7 @@ package Pod::Html::Util;
 use strict;
 require Exporter;
 
-our $VERSION = 1.31; # Please keep in synch with lib/Pod/Html.pm
+our $VERSION = 1.32; # Please keep in synch with lib/Pod/Html.pm
 $VERSION = eval $VERSION;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(
@@ -30,11 +30,19 @@ Pod::Html::Util - helper functions for Pod-Html
 
 =head1 SUBROUTINES
 
-=head2 C<parse_command_line()>
-
-TK
+B<Note:> While these functions are importable on request from
+F<Pod::Html::Util>, they are specifically intended for use within (a) the
+F<Pod-Html> distribution (modules and test programs) shipped as part of the
+Perl 5 core and (b) other parts of the core such as the F<installhtml>
+program.  These functions may be modified or relocated within the core
+distribution -- or removed entirely therefrom -- as the core's needs evolve.
+Hence, you should not rely on these functions in situations other than those
+just described.
 
 =cut
+
+# parse_command_line will be moved back to lib/Pod/Html.pm in a subsequent
+# p.r. and will be documented then and there
 
 sub parse_command_line {
     my $globals = shift;
@@ -98,7 +106,7 @@ sub parse_command_line {
 
 =head2 C<usage()>
 
-TK
+Display customary Pod::Html usage information.
 
 =cut
 
@@ -149,7 +157,8 @@ END_OF_USAGE
 
 =head2 C<unixify()>
 
-TK
+Ensure that F<Pod::Html>'s internals and tests handle paths consistently
+across Unix, Windows and VMS.
 
 =cut
 

--- a/ext/Pod-Html/t/anchorify-536.t
+++ b/ext/Pod-Html/t/anchorify-536.t
@@ -1,8 +1,15 @@
 # -*- perl -*-
 
 use strict;
-use Pod::Html::Util qw( anchorify relativize_url );
-use Test::More tests => 3;
+use Pod::Html qw( anchorify relativize_url );
+my ($revision,$version,$subversion) = split /\./, sprintf("%vd",$^V);
+use Test::More;
+unless ($version == 35 or $version == 36) {
+    plan skip_all => "Needed only during 5.36";
+}
+else {
+    plan tests => 3;
+}
 
 my @filedata;
 {

--- a/ext/Pod-Html/t/lib/Testing.pm
+++ b/ext/Pod-Html/t/lib/Testing.pm
@@ -2,7 +2,7 @@ package Testing;
 use 5.10.0;
 use warnings;
 require Exporter;
-our $VERSION = 1.31; # Let's keep this same as lib/Pod/Html.pm
+our $VERSION = 1.32; # Let's keep this same as lib/Pod/Html.pm
 $VERSION = eval $VERSION;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(

--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -14,6 +14,15 @@ features are available.
 The deprecated features will be grouped by the version of Perl in
 which they will be removed.
 
+=head2 Perl 5.38
+
+=head3 Pod::Html utility functions
+
+The definition and documentation of three utility functions previously
+importable from L<Pod::Html> were moved to new package L<Pod::Html::Util> in
+Perl 5.36.  While they remain importable from L<Pod::Html> in Perl 5.36, as of
+Perl 5.38 they will only be importable, on request, from L<Pod::Html::Util>.
+
 =head2 Perl 5.34
 
 There are no deprecations or fatalizations scheduled for Perl 5.34.


### PR DESCRIPTION
The rationale for this pull request is as follows:

In commit d32e5dc4f13e3a8f42c445ab32d50f7aff8d1cd7 (applied July 6), we moved
the definition of three subroutines, `htmlify()`, `anchorify()` and
`relativize_url()` from `lib/Pod/Html.pm` -- all paths herein relative to
`ext/Pod-Html/` -- to what is now called `lib/Pod/Html/Util.pm`.

The rationale for this was to limit `lib/Pod/Html.pm` to *only one exported
subroutine*, `pod2html()`, which would in turn be a wrapper around a
constructor for a `Pod::Html` object and subsequent method calls on that
object.  Helper subroutines which do not need to be `Pod::Html` method calls
should not be in package `Pod::Html`; hence package `Pod::Html::Util`.  (We
continue to export Pod::Html::pod2html() because that is invoked in executable
bin/pod2html and we don't want revisions to that program to be in scope for
this project.)

On the perl5-porters list
(https://www.nntp.perl.org/group/perl.perl5.porters/2021/07/msg260930.html),
@sisyphus on July 24 reported a problem trying out `installhtml` on Windows:

> ... [T]he installhtml script specifies:
> use Pod::Html 1.23 qw(anchorify relativize_url);
> 
> However, version 1.31 of Pod/Html.pm (which is the version of Pod::Html that
> ships with 5.35.2) exports neither "anchorify" nor "relativize_url" Am I the
> only person experiencing this issue ?
> 
> It seems to me that installhtml needs to be rewritten to accommodate the
> significant alterations that have been made to Html.pm since the perl-5.35.1
> release.

I have proposed pull request https://github.com/Perl/perl5/pull/19000 to
address this problem   It will probably need some fine tuning -- but that's
not the immediate problem.

In https://github.com/Perl/perl5/pull/19000#issuecomment-886117386 (July 24),
@haarg noted:

> This was broken by
> https://github.com/Perl/perl5/commit/d32e5dc4f13e3a8f42c445ab32d50f7aff8d1cd7.
> Previously, htmlify and anchorify were documented functions available from
> Pod::Html. relativize_url was also exportable, although it was not included in
> the documentation.

@haarg did not say how he felt this problem should be addressed, but since
there is an implication that we are violating backwards compatibility, we do
have to address it.

I believe the best way forward is to first assess the likelihood of breakage
and then act accordingly.  One step should be to ask:  **How heavily are these
functions used on CPAN?**  I grepped CPAN; you can see the results and
analysis in this [gist](https://gist.github.com/jkeenan/24992aaa4a0596142336f7315aeb2645).

**Summary of findings:**  *None* of these three helper functions are used (as
imports from `Pod::Html`) anywhere on CPAN.  They are only used in
`installhtml` and in Pod-Html's own test suite, *i.e.,* entirely within the core
distribution.

Since the likelihood of breakage is very small, I recommend the following:

1. For the version of Pod-Html shipped with Perl-5.36, move the three
auxiliary functions to `lib/Pod/Html/Util.pm` as already implemented.

2. For Perl-5.36 only, import these three subroutines into `lib/Pod/Html.pm`
from `lib/Pod/Html/Util.pm` and make them exportable from the latter on the
same terms as in Perl-5.34.  Document this move and advise any "darkpan" users
of the three functions that they should adjust their code to now import those
functions from `lib/Pod/Html/Util.pm`. 

3. For Perl-5.38 and after, cease to re-export the three auxiliary functions
from `lib/Pod/Html.pm`.

The code and documentation changes in this pull request implement this
approach.

Thank you very much.
Jim Keenan 