### PR TITLE
Stable tracking of "boolean intent" across SVs

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1977,6 +1977,8 @@ cpan/Scalar-List-Utils/multicall.h		Util extension
 cpan/Scalar-List-Utils/t/00version.t		Scalar::Util
 cpan/Scalar-List-Utils/t/any-all.t		List::Util
 cpan/Scalar-List-Utils/t/blessed.t		Scalar::Util
+cpan/Scalar-List-Utils/t/boolean.t		Scalar::Util
+cpan/Scalar-List-Utils/t/boolean-thr.t		Scalar::Util
 cpan/Scalar-List-Utils/t/dualvar.t		Scalar::Util
 cpan/Scalar-List-Utils/t/exotic_names.t
 cpan/Scalar-List-Utils/t/first.t		List::Util

--- a/MANIFEST
+++ b/MANIFEST
@@ -5830,6 +5830,7 @@ t/op/auto.t			See if autoincrement et all work
 t/op/avhv.t			See if pseudo-hashes work
 t/op/bless.t			See if bless works
 t/op/blocks.t			See if BEGIN and friends work
+t/op/bool.t			Check misc details of boolean values
 t/op/bop.t			See if bitops work
 t/op/caller.pl			Tests shared between caller.t and XS op.t
 t/op/caller.t			See if caller() works

--- a/cpan/Scalar-List-Utils/ListUtil.xs
+++ b/cpan/Scalar-List-Utils/ListUtil.xs
@@ -1666,6 +1666,19 @@ PPCODE:
 MODULE=List::Util       PACKAGE=Scalar::Util
 
 void
+isbool(sv)
+    SV *sv
+PROTOTYPE: $
+CODE:
+#ifdef SvIsBOOL
+    SvGETMAGIC(sv);
+    ST(0) = boolSV(SvIsBOOL(sv));
+    XSRETURN(1);
+#else
+    croak("stable boolean values are not implemented in this release of perl");
+#endif
+
+void
 dualvar(num,str)
     SV *num
     SV *str
@@ -2101,7 +2114,7 @@ BOOT:
     HV *lu_stash = gv_stashpvn("List::Util", 10, TRUE);
     GV *rmcgv = *(GV**)hv_fetch(lu_stash, "REAL_MULTICALL", 14, TRUE);
     SV *rmcsv;
-#if !defined(SvWEAKREF) || !defined(SvVOK)
+#if !defined(SvWEAKREF) || !defined(SvVOK) || !defined(SvIsBOOL)
     HV *su_stash = gv_stashpvn("Scalar::Util", 12, TRUE);
     GV *vargv = *(GV**)hv_fetch(su_stash, "EXPORT_FAIL", 11, TRUE);
     AV *varav;
@@ -2118,6 +2131,9 @@ BOOT:
 #endif
 #ifndef SvVOK
     av_push(varav, newSVpv("isvstring",9));
+#endif
+#ifndef SvIsBOOL
+    av_push(varav, newSVpv("isbool",6));
 #endif
 #ifdef REAL_MULTICALL
     sv_setsv(rmcsv, &PL_sv_yes);

--- a/cpan/Scalar-List-Utils/lib/List/Util.pm
+++ b/cpan/Scalar-List-Utils/lib/List/Util.pm
@@ -16,7 +16,7 @@ our @EXPORT_OK  = qw(
   sample shuffle uniq uniqint uniqnum uniqstr zip zip_longest zip_shortest mesh mesh_longest mesh_shortest
   head tail pairs unpairs pairkeys pairvalues pairmap pairgrep pairfirst
 );
-our $VERSION    = "1.56";
+our $VERSION    = "1.56_001";
 our $XS_VERSION = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/cpan/Scalar-List-Utils/lib/List/Util/XS.pm
+++ b/cpan/Scalar-List-Utils/lib/List/Util/XS.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use List::Util;
 
-our $VERSION = "1.56";       # FIXUP
+our $VERSION = "1.56_001";       # FIXUP
 $VERSION =~ tr/_//d;         # FIXUP
 
 1;

--- a/cpan/Scalar-List-Utils/lib/Scalar/Util.pm
+++ b/cpan/Scalar-List-Utils/lib/Scalar/Util.pm
@@ -14,10 +14,12 @@ our @ISA       = qw(Exporter);
 our @EXPORT_OK = qw(
   blessed refaddr reftype weaken unweaken isweak
 
+  isbool
+
   dualvar isdual isvstring looks_like_number openhandle readonly set_prototype
   tainted
 );
-our $VERSION    = "1.56";
+our $VERSION    = "1.56_001";
 $VERSION =~ tr/_//d;
 
 require List::Util; # List::Util loads the XS
@@ -38,12 +40,17 @@ unless (defined &isvstring) {
 sub export_fail {
   if (grep { /^(?:weaken|isweak)$/ } @_ ) {
     require Carp;
-    Carp::croak("Weak references are not implemented in the version of perl");
+    Carp::croak("Weak references are not implemented in this version of perl");
   }
 
   if (grep { /^isvstring$/ } @_ ) {
     require Carp;
-    Carp::croak("Vstrings are not implemented in the version of perl");
+    Carp::croak("Vstrings are not implemented in this version of perl");
+  }
+
+  if (grep { /^isbool$/ } @_ ) {
+    require Carp;
+    Carp::croak("isbool is not implemented in this version of perl");
   }
 
   @_;
@@ -217,6 +224,16 @@ B<NOTE>: Copying a weak reference creates a normal, strong, reference.
 
 =head1 OTHER FUNCTIONS
 
+=head2 isbool
+
+    my $bool = isbool( $var );
+
+I<Available only since perl 5.35.3 onwards.>
+
+Returns true if the given variable is boolean in nature - that is, it is the
+result of a boolean operator (such as C<defined>, C<exists>, or a numerical or
+string comparison), or is a variable that is copied from one.
+
 =head2 dualvar
 
     my $var = dualvar( $num, $string );
@@ -324,15 +341,20 @@ Module use may give one of the following errors during import.
 
 =over
 
-=item Weak references are not implemented in the version of perl
+=item Weak references are not implemented in this version of perl
 
 The version of perl that you are using does not implement weak references, to
 use L</isweak> or L</weaken> you will need to use a newer release of perl.
 
-=item Vstrings are not implemented in the version of perl
+=item Vstrings are not implemented in this version of perl
 
 The version of perl that you are using does not implement Vstrings, to use
 L</isvstring> you will need to use a newer release of perl.
+
+=item isbool is not implemented in this version of perl
+
+The version of perl that you are using does not implement stable boolean
+tracking, to use L</isbool> you will need to use a newer release of perl.
 
 =back
 

--- a/cpan/Scalar-List-Utils/lib/Sub/Util.pm
+++ b/cpan/Scalar-List-Utils/lib/Sub/Util.pm
@@ -15,7 +15,7 @@ our @EXPORT_OK = qw(
   subname set_subname
 );
 
-our $VERSION    = "1.56";
+our $VERSION    = "1.56_001";
 $VERSION =~ tr/_//d;
 
 require List::Util; # as it has the XS

--- a/cpan/Scalar-List-Utils/t/boolean-thr.t
+++ b/cpan/Scalar-List-Utils/t/boolean-thr.t
@@ -1,0 +1,38 @@
+#!./perl
+
+use strict;
+use warnings;
+
+use Config ();
+use Scalar::Util ();
+use Test::More
+    (grep { /isbool/ } @Scalar::Util::EXPORT_FAIL) ? (skip_all => 'isbool is not supported on this perl') :
+    (!$Config::Config{usethreads})                 ? (skip_all => 'perl does not support threads') :
+    (tests => 5);
+
+use threads;
+use threads::shared;
+
+Scalar::Util->import("isbool");
+
+ok(threads->create( sub { isbool($_[0]) }, !!0 )->join,
+    'value in to thread is bool');
+
+ok(isbool(threads->create( sub { return !!0 } )->join),
+    'value out of thread is bool');
+
+{
+    my $var = !!0;
+    ok(threads->create( sub { isbool($var) } )->join,
+        'variable captured by thread is bool');
+}
+
+{
+    my $sharedvar :shared = !!0;
+
+    ok(isbool($sharedvar),
+        ':shared variable is bool outside');
+
+    ok(threads->create( sub { isbool($sharedvar) } )->join,
+        ':shared variable is bool inside thread');
+}

--- a/cpan/Scalar-List-Utils/t/boolean.t
+++ b/cpan/Scalar-List-Utils/t/boolean.t
@@ -1,0 +1,64 @@
+#!./perl
+
+use strict;
+use warnings;
+
+use Scalar::Util ();
+use Test::More  (grep { /isbool/ } @Scalar::Util::EXPORT_FAIL)
+    ? (skip_all => 'isbool is not supported on this perl')
+    : (tests => 15);
+
+Scalar::Util->import("isbool");
+
+# basic constants
+{
+    ok(isbool(!!0), 'false is boolean');
+    ok(isbool(!!1), 'true is boolean');
+
+    ok(!isbool(0), '0 is not boolean');
+    ok(!isbool(1), '1 is not boolean');
+    ok(!isbool(""), '"" is not boolean');
+}
+
+# variables
+{
+    my $falsevar = !!0;
+    my $truevar  = !!1;
+
+    ok(isbool($falsevar), 'false var is boolean');
+    ok(isbool($truevar),  'true var is boolean');
+
+    my $str = "$truevar";
+    my $num = $truevar + 0;
+
+    ok(!isbool($str), 'stringified true is not boolean');
+    ok(!isbool($num), 'numified true is not boolean');
+
+    ok(isbool($truevar), 'true var remains boolean after stringification and numification');
+}
+
+# aggregate members
+{
+    my %hash = ( false => !!0, true => !!1 );
+
+    ok(isbool($hash{false}), 'false HELEM is boolean');
+    ok(isbool($hash{true}),  'true HELEM is boolean');
+
+    # We won't test AELEM but it's likely to be the same
+}
+
+{
+    my $var;
+    package Foo { sub TIESCALAR { bless {}, shift } sub FETCH { $var } }
+
+    tie my $tied, "Foo";
+
+    $var = 1;
+    ok(!isbool($tied), 'tied var should not yet be boolean');
+
+    $var = !!1;
+    ok(isbool($tied), 'tied var should now be boolean');
+
+    my $copy = $tied;
+    ok(isbool($copy), 'copy of tied var should also be boolean');
+}

--- a/dump.c
+++ b/dump.c
@@ -1928,6 +1928,8 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
                     PerlIO_printf(file, " [UTF8 \"%s\"]",
                                          sv_uni_display(d, sv, 6 * SvCUR(sv),
                                                         UNI_DISPLAY_QQ));
+                if (SvIsBOOL(sv))
+                    PerlIO_printf(file, " [BOOL %s]", ptr == PL_Yes ? "PL_Yes" : "PL_No");
                 PerlIO_printf(file, "\n");
             }
             Perl_dump_indent(aTHX_ level, file, "  CUR = %" IVdf "\n", (IV)SvCUR(sv));

--- a/ext/B/B.pm
+++ b/ext/B/B.pm
@@ -20,7 +20,7 @@ sub import {
 # walkoptree comes from B.xs
 
 BEGIN {
-    $B::VERSION = '1.82';
+    $B::VERSION = '1.83';
     @B::EXPORT_OK = ();
 
     # Our BOOT code needs $VERSION set, and will append to @EXPORT_OK.

--- a/ext/B/B.xs
+++ b/ext/B/B.xs
@@ -638,7 +638,7 @@ BOOT:
     cv = newXS("B::diehook", intrpvar_sv_common, file);
     ASSIGN_COMMON_ALIAS(I, diehook);
     sv = get_sv("B::OP::does_parent", GV_ADDMULTI);
-    sv_setsv(sv, &PL_sv_yes);
+    sv_setbool(sv, TRUE);
 }
 
 void

--- a/ext/Devel-Peek/t/Peek.t
+++ b/ext/Devel-Peek/t/Peek.t
@@ -240,6 +240,30 @@ do_test('reference to scalar',
     COW_REFCNT = 1
 ');
 
+do_test('immediate boolean',
+        !!0,
+'SV = PVNV\\($ADDR\\) at $ADDR
+  REFCNT = \d+
+  FLAGS = \\(.*\\)
+  IV = 0
+  NV = 0
+  PV = $ADDR "" \[BOOL PL_No\]
+  CUR = 0
+  LEN = 0
+') if $] >= 5.035004;
+
+do_test('assignment of boolean',
+        do { my $tmp = !!1 },
+'SV = PVNV\\($ADDR\\) at $ADDR
+  REFCNT = \d+
+  FLAGS = \\(.*\\)
+  IV = 1
+  NV = 1
+  PV = $ADDR "1" \[BOOL PL_Yes\]
+  CUR = 1
+  LEN = 0
+') if $] >= 5.035004;
+
 my $c_pattern;
 if ($type eq 'N') {
   $c_pattern = '

--- a/ext/attributes/attributes.pm
+++ b/ext/attributes/attributes.pm
@@ -1,6 +1,6 @@
 package attributes;
 
-our $VERSION = 0.33;
+our $VERSION = 0.34;
 
 @EXPORT_OK = qw(get reftype);
 @EXPORT = ();

--- a/ext/attributes/attributes.xs
+++ b/ext/attributes/attributes.xs
@@ -204,7 +204,7 @@ usage:
 	Perl_sv_sethek(aTHX_ TARG, HvNAME_HEK(SvSTASH(sv)));
 #if 0	/* this was probably a bad idea */
     else if (SvPADMY(sv))
-	sv_setsv(TARG, &PL_sv_no);	/* unblessed lexical */
+	sv_setbool(TARG, FALSE);	/* unblessed lexical */
 #endif
     else {
 	const HV *stash = NULL;

--- a/gv.c
+++ b/gv.c
@@ -3172,7 +3172,7 @@ Perl_try_amagic_bin(pTHX_ int method, int flags) {
            able name. */
         if (!SvOK(right)) {
             if (ckWARN(WARN_UNINITIALIZED)) report_uninit(right);
-            sv_setsv_flags(left, &PL_sv_no, 0);
+            sv_setbool(left, FALSE);
         }
         else sv_setsv_flags(left, right, 0);
         SvGETMAGIC(right);

--- a/inline.h
+++ b/inline.h
@@ -3407,6 +3407,13 @@ Perl_mortal_getenv(const char * str)
     return ret;
 }
 
+PERL_STATIC_INLINE bool
+Perl_sv_isbool(pTHX_ const SV *sv)
+{
+    return SvIOK(sv) && SvPOK(sv) && SvIsCOW_static(sv) &&
+        (SvPVX_const(sv) == PL_Yes || SvPVX_const(sv) == PL_No);
+}
+
 /*
  * ex: set ts=8 sts=4 sw=4 et:
  */

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -42,6 +42,17 @@ as other "fault"-like signals such as SIGSEGV. This means one has at
 least a chance to catch such a signal with a C<$SIG{FPE}> handler, e.g.
 so that C<die> can report the line in perl that triggered it.
 
+=head2 Stable boolean tracking
+
+The "true" and "false" boolean values, often accessed by constructions like
+C<!!0> and C<!!1>, as well as being returned from many core functions and
+operators, now remember their boolean nature even through assignment into
+variables. The new function C<isbool()> in L<Scalar::Util> can check whether
+a value has boolean nature.
+
+This is likely to be useful when interoperating with other languages or
+data-type serialisation, among other places.
+
 =head1 Security
 
 XXX Any security-related notices go here.  In particular, any security

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -1083,7 +1083,7 @@ PP(pp_multiconcat)
                     if (!SvOK(right)) {
                         if (ckWARN(WARN_UNINITIALIZED))
                             report_uninit(right);
-                        sv_setsv_flags(left, &PL_sv_no, 0);
+                        sv_setbool(left, FALSE);
                     }
                     else
                         sv_setsv_flags(left, right, 0);

--- a/sv.h
+++ b/sv.h
@@ -462,6 +462,8 @@ perform the upgrade if necessary.  See C<L</svtype>>.
 /* Some private flags. */
 
 
+/* scalar SVs with SVp_POK */
+#define SVppv_STATIC    0x40000000 /* PV is pointer to static const; must be set with SVf_IsCOW */
 /* PVAV */
 #define SVpav_REAL	0x40000000  /* free old entries */
 /* PVHV */
@@ -2008,10 +2010,11 @@ scalar.
     )								\
 )
 
-#define SvIsCOW(sv)		(SvFLAGS(sv) & SVf_IsCOW)
-#define SvIsCOW_on(sv)		(SvFLAGS(sv) |= SVf_IsCOW)
-#define SvIsCOW_off(sv)		(SvFLAGS(sv) &= ~SVf_IsCOW)
-#define SvIsCOW_shared_hash(sv)	(SvIsCOW(sv) && SvLEN(sv) == 0)
+#define SvIsCOW(sv)              (SvFLAGS(sv) & SVf_IsCOW)
+#define SvIsCOW_on(sv)           (SvFLAGS(sv) |= SVf_IsCOW)
+#define SvIsCOW_off(sv)          (SvFLAGS(sv) &= ~(SVf_IsCOW|SVppv_STATIC))
+#define SvIsCOW_shared_hash(sv)  ((SvFLAGS(sv) & (SVf_IsCOW|SVppv_STATIC)) == (SVf_IsCOW) && SvLEN(sv) == 0)
+#define SvIsCOW_static(sv)       ((SvFLAGS(sv) & (SVf_IsCOW|SVppv_STATIC)) == (SVf_IsCOW|SVppv_STATIC))
 
 #define SvSHARED_HEK_FROM_PV(pvx) \
         ((struct hek*)(pvx - STRUCT_OFFSET(struct hek, hek_key)))

--- a/sv.h
+++ b/sv.h
@@ -1052,6 +1052,17 @@ Remove any string offset.
     ((SvFLAGS(sv) & (SVf_POK|SVf_UTF8|SVf_IOK|SVf_NOK|SVf_ROK|SVpgv_GP|SVf_THINKFIRST|SVs_GMG)) == SVf_POK)
 
 /*
+=for apidoc Am|BOOL|SvIsBOOL|SV* sv
+
+Returns true if the SV is one of the special boolean constants (PL_sv_yes or
+PL_sv_no), or is a regular SV whose last assignment stored a copy of one.
+
+=cut
+*/
+
+#define SvIsBOOL(sv)            Perl_sv_isbool(aTHX_ sv)
+
+/*
 =for apidoc Am|U32|SvGAMAGIC|SV* sv
 
 Returns true if the SV has get magic or
@@ -2333,6 +2344,21 @@ See also C<L</PL_sv_yes>> and C<L</PL_sv_no>>.
 */
 
 #define boolSV(b) ((b) ? &PL_sv_yes : &PL_sv_no)
+
+/*
+=for apidoc Am|void|sv_setbool|SV *sv|bool b
+=for apidoc_item |void|sv_setbool_mg|SV *sv|bool b
+
+These set an SV to a true or false boolean value, upgrading first if necessary.
+
+They differ only in that C<sv_setbool_mg> handles 'set' magic; C<sv_setbool>
+does not.
+
+=cut
+*/
+
+#define sv_setbool(sv, b)     sv_setsv(sv, boolSV(b))
+#define sv_setbool_mg(sv, b)  sv_setsv_mg(sv, boolSV(b))
 
 #define isGV(sv) (SvTYPE(sv) == SVt_PVGV)
 /* If I give every macro argument a different name, then there won't be bugs

--- a/t/op/bool.t
+++ b/t/op/bool.t
@@ -1,0 +1,37 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+}
+
+use strict;
+use warnings;
+
+my $truevar  = (5 == 5);
+my $falsevar = (5 == 6);
+
+cmp_ok($truevar, '==', 1);
+cmp_ok($truevar, 'eq', "1");
+
+cmp_ok($falsevar, '==', 0);
+cmp_ok($falsevar, 'eq', "");
+
+{
+    # Check that boolean COW string buffer is safe to copy into new SVs and
+    # doesn't get corrupted by inplace mutations
+    my $x = $truevar;
+    $x =~ s/1/t/;
+
+    cmp_ok($x, 'eq', "t");
+    cmp_ok($truevar, 'eq', "1");
+
+    my $y = $truevar;
+    substr($y, 0, 1, "T");
+
+    cmp_ok($y, 'eq', "T");
+    cmp_ok($truevar, 'eq', "1");
+}
+
+done_testing();


### PR DESCRIPTION
It is likely this PR should be split into two parts; a low-level "implement static const COW", and a high level "use it to make booleans stable". I'll take suggestions from reviewers as to whether to leave it as one (squashed) commit, form two commits, or even split it into two PRs entirely to implement the to halves.

The overall result is that it is now possible for modules like data printers, formatters, serialisers, etc... to distinguish which Perl values are intended to be booleans, and can take special action on them to render them differently from numbers or strings.

## Low-level

The low-level part is basically this one commit:

Define a third kind of COW state; STATIC

Previously, when IsCOW flag was set there were two cases:
  * SvLEN()==0:
    >  PV is really a shared HEK
 * SvLEN()!=0:
    >  PV is a COW structure with 1..256 refcount stored in its extra final byte

This change adds a third state:

 * SvLEN()==0 && (SvFLAGS() & SVppv_STATIC):
   >  PV is a shared static const pointer and must not be modified

`sv_setsv_flags()`, `sv_setsv_cow()` and `rvpv_dup()` will preserve this state.

`sv_uncow()` will copy it out to a regular string buffer, which means that `SV_THINKFIRST` will undo this and result in a regular mutable copy before any edit operations.

The upshot here is that we can now store static strings inside PVs without having to copy the buffer of them. This can help save memory and CPU time when copying them around. It is likely to be useful independently of the higher-level change; for example when storing large static strings of message text or other data, or as a general-purpose way to pass pointers around in a way that does not get broken even by thread-cloning.

## High Level

The higher part is then everything else that builds atop it. It uses these new static strings to store the `PL_Yes` and `PL_No` buffers inside the boolean constant SVs, and because these strings are copied by pointer reference, these pointers remain stable into any SV intended to be a boolean value, even across threads. A simple pointer comparison can then be used to implement the `SvIsBOOL` macro, which is exposed via `Scalar::Util` to be useful to pureperl code.