### PR TITLE
Fix a (possible) typo in Storable.xs

### DIFF
--- a/dist/Storable/Storable.xs
+++ b/dist/Storable/Storable.xs
@@ -1247,7 +1247,7 @@ static const char byteorderstr_56[] = {BYTEORDER_BYTES_56, 0};
 #    define Sntohl(x) (x)
 #  else
 static U32 Sntohl(U32 x) {
-    return (((U8) x) << 24) + ((x * 0xFF00) << 8)
+    return (((U8) x) << 24) + ((x & 0xFF00) << 8)
 	+ ((x & 0xFF0000) >> 8) + ((x & 0xFF000000) >> 24);
 }
 #  endif


### PR DESCRIPTION
I came across this by skim-reading the code.

I think `*` in this expression obviously should be `&`, but the containing function (`Sntohl`) seems to be never compiled because <perl.h> [always defines HAS_NTOHL](https://github.com/Perl/perl5/blob/8d469d0ecbd06a993426de11b8feec551378525b/perl.h#L4173), so no visible change is expected.