### PR TITLE
Avoid passing undefined values to Text::Wrap::wrap().

### DIFF
--- a/utils/perlbug.PL
+++ b/utils/perlbug.PL
@@ -1096,7 +1096,7 @@ sub _read_report {
     local $Text::Wrap::huge = 'overflow';
     while (<REP>) {
         if ($::HaveWrap && /\S/) { # wrap() would remove empty lines
-            $content .= Text::Wrap::wrap(undef, undef, $_);
+            $content .= Text::Wrap::wrap('', '', $_);
         } else {
             $content .= $_;
         }


### PR DESCRIPTION
Following upgrade to CPAN version 2021.0804 of Text-Tabs+Wrap (9a679b43, Aug
05 2021), we began to get "use of uninitialized value $_ in split" warnings
when running lib/perlbug.t.