### PR TITLE
Pod html refactoring 5 of 5

### DIFF
--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -24,7 +24,6 @@ use Pod::Html::Util qw(
     relativize_url
 );
 use locale; # make \w work right in non-ASCII lands
-use Data::Dumper;
 
 =head1 NAME
 
@@ -239,12 +238,6 @@ This program is distributed under the Artistic License.
 
 =cut
 
-
-my $Podroot;
-
-#my %Pages = ();                 # associative array used to find the location
-                                #   of pages referenced by L<> links.
-
 sub new {
     my $class = shift;
     return bless {}, $class;
@@ -380,12 +373,10 @@ sub refine_globals {
         # Is the above not just "$self->{Htmlfileurl} = $self->{Htmlfile}"?
         $self->{Htmlfileurl} = unixify($self->{Htmlfile});
     }
-    #return $self;
     return { %{$self} };
 }
 
 sub generate_cache {
-    #my ($self, $Pagesref) = @_;
     my $self = shift;
     my $pwd = getcwd();
     chdir($self->{Podroot}) ||
@@ -427,7 +418,6 @@ sub generate_cache {
         print $cache "$key $self->{Pages}->{$key}\n";
     }
     close $cache or die "error closing $self->{Dircache}: $!";
-    #return %{$Pagesref};
 }
 
 sub _transform {

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -273,7 +273,6 @@ sub pod2html {
 
     # set options for the HTML generator
     my $parser = Pod::Simple::XHTML::LocalPodLinks->new();
-    my $output;
     $parser->codes_in_verbatim(0);
     $parser->anchor_items(1); # the old Pod::Html always did
     $parser->backlink($self->{Backlink}); # linkify =head1 directives
@@ -282,14 +281,14 @@ sub pod2html {
     $parser->htmlfileurl($self->{Htmlfileurl});
     $parser->htmlroot($self->{Htmlroot});
     $parser->index($self->{Doindex});
-    $parser->output_string(\$output); # written to file later
+    $parser->output_string(\$self->{output}); # written to file later
     $parser->pages(\%Pages);
     $parser->quiet($self->{Quiet});
     $parser->verbose($self->{Verbose});
 
     $parser = $self->refine_parser($parser);
     $self->feed_tree_to_parser($parser, $podtree);
-    $self->write_file($output);
+    $self->write_file();
 }
 
 sub init_globals {
@@ -631,7 +630,7 @@ sub feed_tree_to_parser {
 }
 
 sub write_file {
-    my ($self, $output) = @_;
+    my $self = shift;
     $self->{Htmlfile} = "-" unless $self->{Htmlfile}; # stdout
     my $fhout;
     if($self->{Htmlfile} and $self->{Htmlfile} ne '-') {
@@ -641,7 +640,7 @@ sub write_file {
         open $fhout, ">-";
     }
     binmode $fhout, ":utf8";
-    print $fhout $output;
+    print $fhout $self->{output};
     close $fhout or die "Failed to close $self->{Htmlfile}: $!";
     chmod 0644, $self->{Htmlfile} unless $self->{Htmlfile} eq '-';
 }

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -2,7 +2,7 @@ package Pod::Html;
 use strict;
 use Exporter 'import';
 
-our $VERSION = 1.32;
+our $VERSION = 1.33;
 $VERSION = eval $VERSION;
 our @EXPORT = qw(pod2html htmlify);
 our @EXPORT_OK = qw(anchorify relativize_url);

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -11,7 +11,6 @@ use Config;
 use Cwd;
 use File::Basename;
 use File::Spec;
-use File::Spec::Unix;
 use Pod::Simple::Search;
 use Pod::Simple::SimpleTree ();
 use Pod::Html::Util qw(

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -276,20 +276,20 @@ sub pod2html {
     my $output;
     $parser->codes_in_verbatim(0);
     $parser->anchor_items(1); # the old Pod::Html always did
-    $parser->backlink($globals->{Backlink}); # linkify =head1 directives
-    $parser->force_title($globals->{Title});
-    $parser->htmldir($globals->{Htmldir});
-    $parser->htmlfileurl($globals->{Htmlfileurl});
-    $parser->htmlroot($globals->{Htmlroot});
-    $parser->index($globals->{Doindex});
+    $parser->backlink($self->{Backlink}); # linkify =head1 directives
+    $parser->force_title($self->{Title});
+    $parser->htmldir($self->{Htmldir});
+    $parser->htmlfileurl($self->{Htmlfileurl});
+    $parser->htmlroot($self->{Htmlroot});
+    $parser->index($self->{Doindex});
     $parser->output_string(\$output); # written to file later
     $parser->pages(\%Pages);
-    $parser->quiet($globals->{Quiet});
-    $parser->verbose($globals->{Verbose});
+    $parser->quiet($self->{Quiet});
+    $parser->verbose($self->{Verbose});
 
-    $parser = refine_parser($globals, $parser);
-    feed_tree_to_parser($parser, $podtree);
-    write_file($globals, $output);
+    $parser = $self->refine_parser($parser);
+    $self->feed_tree_to_parser($parser, $podtree);
+    $self->write_file($output);
 }
 
 sub init_globals {
@@ -571,27 +571,27 @@ sub set_Title_from_podtree {
 }
 
 sub refine_parser {
-    my ($globals, $parser) = @_;
+    my ($self, $parser) = @_;
     # We need to add this ourselves because we use our own header, not
     # ::XHTML's header. We need to set $parser->backlink to linkify
     # the =head1 directives
-    my $bodyid = $globals->{Backlink} ? ' id="_podtop_"' : '';
+    my $bodyid = $self->{Backlink} ? ' id="_podtop_"' : '';
 
     my $csslink = '';
     my $tdstyle = ' style="background-color: #cccccc; color: #000"';
 
-    if ($globals->{Css}) {
-        $csslink = qq(\n<link rel="stylesheet" href="$globals->{Css}" type="text/css" />);
+    if ($self->{Css}) {
+        $csslink = qq(\n<link rel="stylesheet" href="$self->{Css}" type="text/css" />);
         $csslink =~ s,\\,/,g;
         $csslink =~ s,(/.):,$1|,;
         $tdstyle= '';
     }
 
     # header/footer block
-    my $block = $globals->{Header} ? <<END_OF_BLOCK : '';
+    my $block = $self->{Header} ? <<END_OF_BLOCK : '';
 <table border="0" width="100%" cellspacing="0" cellpadding="3">
 <tr><td class="_podblock_"$tdstyle valign="middle">
-<big><strong><span class="_podblock_">&nbsp;$globals->{Title}</span></strong></big>
+<big><strong><span class="_podblock_">&nbsp;$self->{Title}</span></strong></big>
 </td></tr>
 </table>
 END_OF_BLOCK
@@ -602,7 +602,7 @@ END_OF_BLOCK
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<title>$globals->{Title}</title>$csslink
+<title>$self->{Title}</title>$csslink
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <link rev="made" href="mailto:$Config{perladmin}" />
 </head>
@@ -623,30 +623,30 @@ HTMLFOOT
 # This sub duplicates the guts of Pod::Simple::FromTree.  We could have
 # used that module, except that it would have been a non-core dependency.
 sub feed_tree_to_parser {
-    my($parser, $tree) = @_;
+    my($self, $parser, $tree) = @_;
     if(ref($tree) eq "") {
         $parser->_handle_text($tree);
     } elsif(!($tree->[0] eq "X" && $parser->nix_X_codes)) {
         $parser->_handle_element_start($tree->[0], $tree->[1]);
-        feed_tree_to_parser($parser, $_) foreach @{$tree}[2..$#$tree];
+        $self->feed_tree_to_parser($parser, $_) foreach @{$tree}[2..$#$tree];
         $parser->_handle_element_end($tree->[0]);
     }
 }
 
 sub write_file {
-    my ($globals, $output) = @_;
-    $globals->{Htmlfile} = "-" unless $globals->{Htmlfile}; # stdout
+    my ($self, $output) = @_;
+    $self->{Htmlfile} = "-" unless $self->{Htmlfile}; # stdout
     my $fhout;
-    if($globals->{Htmlfile} and $globals->{Htmlfile} ne '-') {
-        open $fhout, ">", $globals->{Htmlfile}
-            or die "$0: cannot open $globals->{Htmlfile} file for output: $!\n";
+    if($self->{Htmlfile} and $self->{Htmlfile} ne '-') {
+        open $fhout, ">", $self->{Htmlfile}
+            or die "$0: cannot open $self->{Htmlfile} file for output: $!\n";
     } else {
         open $fhout, ">-";
     }
     binmode $fhout, ":utf8";
     print $fhout $output;
-    close $fhout or die "Failed to close $globals->{Htmlfile}: $!";
-    chmod 0644, $globals->{Htmlfile} unless $globals->{Htmlfile} eq '-';
+    close $fhout or die "Failed to close $self->{Htmlfile}: $!";
+    chmod 0644, $self->{Htmlfile} unless $self->{Htmlfile} eq '-';
 }
 
 

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -374,7 +374,7 @@ sub refine_globals {
         # Is the above not just "$self->{Htmlfileurl} = $self->{Htmlfile}"?
         $self->{Htmlfileurl} = unixify($self->{Htmlfile});
     }
-    return { %{$self} };
+    return $self;
 }
 
 sub generate_cache {

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -325,7 +325,9 @@ sub init_globals {
 sub process_options {
     my ($self, $opts) = @_;
 
-    @{$self->{Podpath}}  = split(":", $opts->{podpath}) if defined $opts->{podpath};
+    $self->{Podpath}   = (defined $opts->{podpath})
+                            ? [ split(":", $opts->{podpath}) ]
+                            : [];
 
     $self->{Backlink}  =          $opts->{backlink}   if defined $opts->{backlink};
     $self->{Cachedir}  =  unixify($opts->{cachedir})  if defined $opts->{cachedir};

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -356,7 +356,6 @@ sub process_options {
 
 sub refine_globals {
     my $self = shift;
-    require Data::Dumper if $self->{verbose};
 
     # prevent '//' in urls
     $self->{Htmlroot} = "" if $self->{Htmlroot} eq "/";

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -558,6 +558,7 @@ sub set_Title_from_podtree {
     }
 
     $self->{Title} //= "";
+    $self->{Title} = html_escape($self->{Title});
     return $self;
 }
 

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -384,36 +384,36 @@ sub refine_globals {
 }
 
 sub generate_cache {
-    my ($globals, $Pagesref) = @_;
+    my ($self, $Pagesref) = @_;
     my $pwd = getcwd();
-    chdir($globals->{Podroot}) ||
-        die "$0: error changing to directory $globals->{Podroot}: $!\n";
+    chdir($self->{Podroot}) ||
+        die "$0: error changing to directory $self->{Podroot}: $!\n";
 
     # find all pod modules/pages in podpath, store in %Pages
     # - inc(0): do not prepend directories in @INC to search list;
-    #     limit search to those in @{$globals->{Podpath}}
+    #     limit search to those in @{$self->{Podpath}}
     # - verbose: report (via 'warn') what search is doing
     # - laborious: to allow '.' in dirnames (e.g., /usr/share/perl/5.14.1)
     # - callback: used to remove Podroot and extension from each file
     # - recurse: go into subdirectories
     # - survey: search for POD files in PodPath
     my ($name2path, $path2name) = 
-        Pod::Simple::Search->new->inc(0)->verbose($globals->{Verbose})->laborious(1)
-        ->callback(\&_save_page)->recurse($globals->{Recurse})->survey(@{$globals->{Podpath}});
-    #print STDERR Data::Dumper::Dumper($name2path, $path2name) if ($globals->{Verbose});
+        Pod::Simple::Search->new->inc(0)->verbose($self->{Verbose})->laborious(1)
+        ->callback(\&_save_page)->recurse($self->{Recurse})->survey(@{$self->{Podpath}});
+    #print STDERR Data::Dumper::Dumper($name2path, $path2name) if ($self->{Verbose});
 
     chdir($pwd) || die "$0: error changing to directory $pwd: $!\n";
 
     # cache the directory list for later use
-    warn "caching directories for later use\n" if $globals->{Verbose};
-    open my $cache, '>', $globals->{Dircache}
-        or die "$0: error open $globals->{Dircache} for writing: $!\n";
+    warn "caching directories for later use\n" if $self->{Verbose};
+    open my $cache, '>', $self->{Dircache}
+        or die "$0: error open $self->{Dircache} for writing: $!\n";
 
-    print $cache join(":", @{$globals->{Podpath}}) . "\n$globals->{Podroot}\n";
-    my $_updirs_only = ($globals->{Podroot} =~ /\.\./) && !($globals->{Podroot} =~ /[^\.\\\/]/);
+    print $cache join(":", @{$self->{Podpath}}) . "\n$self->{Podroot}\n";
+    my $_updirs_only = ($self->{Podroot} =~ /\.\./) && !($self->{Podroot} =~ /[^\.\\\/]/);
     foreach my $key (keys %{$Pagesref}) {
         if($_updirs_only) {
-          my $_dirlevel = $globals->{Podroot};
+          my $_dirlevel = $self->{Podroot};
           while($_dirlevel =~ /\.\./) {
             $_dirlevel =~ s/\.\.//;
             # Assume $Pagesref->{$key} has '/' separators (html dir separators).
@@ -422,7 +422,7 @@ sub generate_cache {
         }
         print $cache "$key $Pagesref->{$key}\n";
     }
-    close $cache or die "error closing $globals->{Dircache}: $!";
+    close $cache or die "error closing $self->{Dircache}: $!";
     return %{$Pagesref};
 }
 

--- a/ext/Pod-Html/lib/Pod/Html/Util.pm
+++ b/ext/Pod-Html/lib/Pod/Html/Util.pm
@@ -1,10 +1,9 @@
 package Pod::Html::Util;
 use strict;
-require Exporter;
+use Exporter 'import';
 
 our $VERSION = 1.33; # Please keep in synch with lib/Pod/Html.pm
 $VERSION = eval $VERSION;
-our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(
     anchorify
     html_escape

--- a/ext/Pod-Html/lib/Pod/Html/Util.pm
+++ b/ext/Pod-Html/lib/Pod/Html/Util.pm
@@ -2,7 +2,7 @@ package Pod::Html::Util;
 use strict;
 require Exporter;
 
-our $VERSION = 1.32; # Please keep in synch with lib/Pod/Html.pm
+our $VERSION = 1.33; # Please keep in synch with lib/Pod/Html.pm
 $VERSION = eval $VERSION;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(

--- a/ext/Pod-Html/t/htmldir3.t
+++ b/ext/Pod-Html/t/htmldir3.t
@@ -61,8 +61,9 @@ xconvert($args);
 
 $args = {
     podstub => "htmldir3",
-    description => "test --htmldir and --htmlroot 3b",
+    description => "test --htmldir and --htmlroot 3b: as expected pod file not yet locatable either under podroot or in cache: GH 12271",
     expect => $expect_raw,
+    expect_fail => 1,
     p2h => {
         podpath    => catdir($relcwd, 't'),
         podroot    => catpath($v, '/', ''),

--- a/ext/Pod-Html/t/lib/Testing.pm
+++ b/ext/Pod-Html/t/lib/Testing.pm
@@ -1,10 +1,9 @@
 package Testing;
 use 5.10.0;
 use warnings;
-require Exporter;
+use Exporter 'import';
 our $VERSION = 1.33; # Let's keep this same as lib/Pod/Html.pm
 $VERSION = eval $VERSION;
-our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(
     setup_testing_dir
     xconvert

--- a/ext/Pod-Html/t/lib/Testing.pm
+++ b/ext/Pod-Html/t/lib/Testing.pm
@@ -2,7 +2,7 @@ package Testing;
 use 5.10.0;
 use warnings;
 require Exporter;
-our $VERSION = 1.32; # Let's keep this same as lib/Pod/Html.pm
+our $VERSION = 1.33; # Let's keep this same as lib/Pod/Html.pm
 $VERSION = eval $VERSION;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(


### PR DESCRIPTION
This if the fifth (and last) in a series of five pull requests submitted with respect to https://github.com/Perl/perl5/issues/18894.

In this p.r., we at long last complete the conversion of the data structures holding information needed to generate HTML files from documents containing POD.  As noted in https://github.com/Perl/perl5/issues/18894, when we started (in the version which shipped with perl-5.34.0), "the code in `ext/Pod-Html/lib/Pod/Html.pm` [was] not fully encapsulated. State [was] held in a total of 19 lexical variables declared outside the scope of the main function, `pod2html()`."  Now that state is held in a `Pod::Html` object and the exportable function `pod2html()` is simply a wrapper around method calls on that object.  The length of `pod2html()` is reduced from 182 lines to 42 lines, which should make it easier to understand what it's doing.

Once this p.r. is merged to blead, we can evaluate patches for all the small points which we're raised in review of this series of pull requests.