### PR TITLE
Add top-level Code of Conduct document

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,20 @@
+# Code of Conduct
+
+Development of the Perl 5 language is covered by the [Standards of
+Conduct](https://perldoc.perl.org/perlpolicy#STANDARDS-OF-CONDUCT) in the
+[perlpolicy](https://perldoc.perl.org/perlpolicy) document.  (See
+[pod/perlpolicy.pod](pod/perlpolicy.pod) for source version.)
+
+The overarching rule is that participants are expected to **be civil**.
+It is not enough to be factual. You must also be civil.
+
+The Standard of Conduct falls under the authority of the
+[Perl Steering Council](https://perldoc.perl.org/perlgov#The-Steering-Council)
+and covers activities on the perl5-porters mailing list, the
+GitHub repository issue/pull-request tracker, and any other venues
+directly organized on behalf the Perl Steering Council.
+
+**NOTE**: The Perl Steering Council operates independently of
+[The Perl Foundation](https://www.perlfoundation.org/) and other
+Perl community organizations.  Consult their websites for information on
+other community codes of conduct.

--- a/MANIFEST
+++ b/MANIFEST
@@ -18,6 +18,7 @@ caretx.c		C file to create $^X
 cflags.SH		A script that emits C compilation flags per file
 Changes			Describe how to peruse changes between releases
 charclass_invlists.h	Compiled-in inversion lists
+CODE_OF_CONDUCT.md	Information on where to find the Standards of Conduct
 config_h.SH		Produces config.h
 configpm		Produces lib/Config.pm
 Configure		Portability tool


### PR DESCRIPTION
This commit adds a top-level file that points readers to the actual
Standards of Conduct in perlpolicy.pod.  It also makes a point to
distinguish between what the Perl Steering Council is responsible for
and what other community groups are responsible for.