### PR TITLE
perlop: Fix indented here-doc empty line description

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -2895,15 +2895,16 @@ This will print...
 
 The line containing the delimiter that marks the end of the here-doc
 determines the indentation template for the whole thing.  Compilation
-croaks if any line inside the here-doc does not begin with the precise
-indentation of the terminating line.  For example, suppose the
-terminating line begins with a tab character followed by 4 space
-characters.  Every line in the here-doc must begin with a tab followed
-by 4 spaces.  They are stripped from each line, and any leading white
-space remaining on a line serves as the indentation for that line.
-Currently, only the TAB and SPACE characters are treated as whitespace
-for this purpose.  Tabs and spaces may be mixed, but are matched
-exactly; tabs remain tabs and are not expanded.
+croaks if any non-empty line inside the here-doc does not begin with the
+precise indentation of the terminating line.  (An empty line consists of
+the single character "\n".)  For example, suppose the terminating line
+begins with a tab character followed by 4 space characters.  Every
+non-empty line in the here-doc must begin with a tab followed by 4
+spaces.  They are stripped from each line, and any leading white space
+remaining on a line serves as the indentation for that line.  Currently,
+only the TAB and SPACE characters are treated as whitespace for this
+purpose.  Tabs and spaces may be mixed, but are matched exactly; tabs
+remain tabs and are not expanded.
 
 Additional beginning whitespace (beyond what preceded the
 delimiter) will be preserved:


### PR DESCRIPTION
This bug was introduced by c275db86a9.

Spotted by Karen Etheridge