### PR TITLE
Text-Tabs+Wrap: Sync with CPAN version 2021.0814

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -2629,6 +2629,7 @@ cpan/Text-Tabs/t/sep.t			See if Text::Tabs is working
 cpan/Text-Tabs/t/sep2.t			See if Text::Tabs is working
 cpan/Text-Tabs/t/tabs.t			See if Text::Tabs works
 cpan/Text-Tabs/t/Tabs-ElCid.t		See if Text::Tabs works
+cpan/Text-Tabs/t/undef.t
 cpan/Text-Tabs/t/wrap.t			See if Text::Wrap::wrap works
 cpan/Text-Tabs/t/Wrap-JLB.t		See if Text::Wrap::wrap works
 cpan/Text-Tabs/t/wrap_separator2.t	See if Text::Wrap::wrap works

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1130,7 +1130,7 @@ use File::Glob qw(:case);
     },
 
     'Text-Tabs+Wrap' => {
-        'DISTRIBUTION' => 'ARISTOTLE/Text-Tabs+Wrap-2021.0804.tar.gz',
+        'DISTRIBUTION' => 'ARISTOTLE/Text-Tabs+Wrap-2021.0814.tar.gz',
         'MAIN_MODULE'  => 'Text::Tabs',
         'FILES'        => q[cpan/Text-Tabs],
         'EXCLUDED'   => [

--- a/cpan/Text-Tabs/lib/Text/Tabs.pm
+++ b/cpan/Text-Tabs/lib/Text/Tabs.pm
@@ -6,7 +6,7 @@ BEGIN { require Exporter; *import = \&Exporter::import }
 
 our @EXPORT = qw( expand unexpand $tabstop );
 
-our $VERSION = '2021.0804';
+our $VERSION = '2021.0814';
 our $SUBVERSION = 'modern'; # back-compat vestige
 
 our $tabstop = 8;
@@ -15,6 +15,7 @@ sub expand {
 	my @l;
 	my $pad;
 	for ( @_ ) {
+		defined or do { push @l, ''; next };
 		my $s = '';
 		for (split(/^/m, $_, -1)) {
 			my $offs;
@@ -43,6 +44,7 @@ sub unexpand
 	my $lastbit;
 	my $ts_as_space = " " x $tabstop;
 	for $x (@l) {
+		defined $x or next;
 		@lines = split("\n", $x, -1);
 		for $line (@lines) {
 			$line = expand($line);

--- a/cpan/Text-Tabs/lib/Text/Wrap.pm
+++ b/cpan/Text-Tabs/lib/Text/Wrap.pm
@@ -9,7 +9,7 @@ BEGIN { require Exporter; *import = \&Exporter::import }
 our @EXPORT = qw( wrap fill );
 our @EXPORT_OK = qw( $columns $break $huge );
 
-our $VERSION = '2021.0804';
+our $VERSION = '2021.0814';
 our $SUBVERSION = 'modern'; # back-compat vestige
 
 our $columns = 76;  # <= screen width
@@ -26,7 +26,7 @@ use Text::Tabs qw(expand unexpand);
 
 sub wrap
 {
-	my ($ip, $xp, @t) = @_;
+	my ($ip, $xp, @t) = map +( defined $_ ? $_ : '' ), @_;
 
 	local($Text::Tabs::tabstop) = $tabstop;
 	my $r = "";
@@ -69,7 +69,7 @@ sub wrap
 		} elsif ($columns < 2) {
 			warnings::warnif "Increasing \$Text::Wrap::columns from $columns to 2";
 			$columns = 2;
-			return ($ip, $xp, @t);
+			return @_;
 		} else {
 			die "This shouldn't happen";
 		}
@@ -92,7 +92,7 @@ sub wrap
 
 sub fill 
 {
-	my ($ip, $xp, @raw) = @_;
+	my ($ip, $xp, @raw) = map +( defined $_ ? $_ : '' ), @_;
 	my @para;
 	my $pp;
 

--- a/cpan/Text-Tabs/t/Jacobson.t
+++ b/cpan/Text-Tabs/t/Jacobson.t
@@ -13,11 +13,4 @@ $a=$a=wrap('','',
 "mmmm,n,ooo,ppp.qqqq.rrrrr,sssssssssssss,ttttttttt,uu,vvv wwwwwwwww####\n");
 };
 
-if ($@) {
-	my $e = $@;
-	$e =~ s/^/# /gm;
-	print $e;
-}
-ok( !$@ );
-
-
+ok( !$@ ) or diag( $@ );

--- a/cpan/Text-Tabs/t/Jacobson2.t
+++ b/cpan/Text-Tabs/t/Jacobson2.t
@@ -13,11 +13,4 @@ $a=$a=wrap('','',
 "mmmm,n,ooo,ppp.qqqq.rrrrr.adsljasdf\nlasjdflajsdflajsdfljasdfl\nlasjdflasjdflasf,sssssssssssss,ttttttttt,uu,vvv wwwwwwwww####\n");
 };
 
-if ($@) {
-	my $e = $@;
-	$e =~ s/^/# /gm;
-	print $e;
-}
-ok( !$@ );
-
-
+ok( !$@ ) or diag( $@ );

--- a/cpan/Text-Tabs/t/belg4mit.t
+++ b/cpan/Text-Tabs/t/belg4mit.t
@@ -3,17 +3,16 @@ use strict; use warnings;
 BEGIN { require './t/lib/ok.pl' }
 use Text::Wrap;
 
-print "1..1\n";
+print "1..2\n";
+
+my $w; $SIG{'__WARN__'} = sub { $w = join '', @_ };
 
 $Text::Wrap::columns = 1;
-eval { wrap('', '', 'H4sICNoBwDoAA3NpZwA9jbsNwDAIRHumuC4NklvXTOD0KSJEnwU8fHz4Q8M9i3sGzkS7BBrm
+my $ok = eval { wrap('', '', <<''); 1 };
+H4sICNoBwDoAA3NpZwA9jbsNwDAIRHumuC4NklvXTOD0KSJEnwU8fHz4Q8M9i3sGzkS7BBrm
 OkCTwsycb4S3DloZuMIYeXpLFqw5LaMhXC2ymhreVXNWMw9YGuAYdfmAbwomoPSyFJuFn2x8
-Opr8bBBidccAAAA'); };
+Opr8bBBidccAAAA
 
-if ($@) {
-	my $e = $@;
-	$e =~ s/^/# /gm;
-	print $e;
-}
-ok( !$@ );
-
+ok( $ok, 'no exception thrown' ) or diag( $@ );
+ok( defined $w && $w =~ /^Increasing \$Text::Wrap::columns from 1 to 2 at ${\quotemeta __FILE__} line [0-9]+/,
+	'warning about increase of $columns' );

--- a/cpan/Text-Tabs/t/dandv.t
+++ b/cpan/Text-Tabs/t/dandv.t
@@ -3,9 +3,14 @@ use strict; use warnings;
 BEGIN { require './t/lib/ok.pl' }
 use Text::Wrap;
 
-print "1..2\n";
+print "1..3\n";
+
+my $w; $SIG{'__WARN__'} = sub { $w = join '', @_ };
 
 $Text::Wrap::columns = 4;
-my $x = eval { wrap('', '123', 'some text') };
-ok(!$@);
-ok($x eq "some\n123t\n123e\n123x\n123t");
+my $x;
+my $ok = eval { $x = wrap('', '123', 'some text'); 1 };
+ok( $ok, 'no exception thrown' );
+ok( defined $x && $x eq "some\n123t\n123e\n123x\n123t", 'expected wrapping returned' );
+ok( defined $w && $w =~ /^Increasing \$Text::Wrap::columns from 4 to 8 to accommodate length of subsequent tab at ${\quotemeta __FILE__} line [0-9]+/,
+	'warning about increase of $columns' );

--- a/cpan/Text-Tabs/t/lib/ok.pl
+++ b/cpan/Text-Tabs/t/lib/ok.pl
@@ -1,4 +1,5 @@
 use strict; use warnings;
 my $_t;
-sub ok { print +( $_[0] ? 'ok ' : 'not ok ' ) . ++$_t . ( $_[1] ? " - $_[1]\n" : "\n" ) }
+sub ok { print +( $_[0] ? 'ok ' : 'not ok ' ) . ++$_t . ( $_[1] ? " - $_[1]\n" : "\n" ); !!$_[0] }
+sub diag { s/^/# /gm, s/\Z.*/\n/s, print for join '', map +( defined $_ ? $_ : 'undef' ), @_ }
 1;

--- a/cpan/Text-Tabs/t/undef.t
+++ b/cpan/Text-Tabs/t/undef.t
@@ -1,0 +1,23 @@
+use strict; use warnings;
+
+BEGIN { require './t/lib/ok.pl' }
+use Text::Tabs;
+use Text::Wrap;
+
+print "1..4\n";
+
+my $w; $SIG{'__WARN__'} = sub { $w = join '', @_ };
+
+sub cleanup { diag $w; undef $w }
+
+expand( undef );
+ok( !defined $w, 'expand accepts undef silently' ) or cleanup;
+
+unexpand( undef, undef, undef );
+ok( !defined $w, 'unexpand accepts undef silently' ) or cleanup;
+
+wrap( undef, undef, undef, ( ( "abc " x 20 ) . "abc\n" ) x 5, undef );
+ok( !defined $w, 'wrap accepts undef silently' ) or cleanup;
+
+fill( undef, undef, undef, ( ( "abc " x 20 ) . "abc\n" ) x 5, undef );
+ok( !defined $w, 'fill accepts undef silently' ) or cleanup;

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -129,6 +129,14 @@ L<XXX> has been upgraded from version A.xx to B.yy.
 
 If there was something important to note about this change, include that here.
 
+=item *
+
+L<Text::Tabs> has been upgraded from version 2021.0717 to 2021.0814.
+
+=item *
+
+L<Text::Wrap> has been upgraded from version 2021.0717 to 2021.0814.
+
 =back
 
 =head2 Removed Modules and Pragmata


### PR DESCRIPTION
This fixes the breakage on undef inputs that causes the wall of warnings from the perlbug tests.