### PR TITLE
Removed a redundant SvNV_nomg call in sv_vcatpvfn_flags

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -12919,7 +12919,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
             if (Perl_isinfnan(nv)) {
                 if (c == 'c')
                     Perl_croak(aTHX_ "Cannot printf %" NVgf " with '%c'",
-                           SvNV_nomg(argsv), (int)c);
+                               nv, (int)c);
 
                 elen = S_infnan_2pv(nv, ebuf, sizeof(ebuf), plus);
                 assert(elen);


### PR DESCRIPTION
I found that `SvNV_nomg(argsv)` is redundant here because its NV is already loaded to the local variable `nv`.

I hope this change will slightly reduce the code size.