### PR TITLE
Don't call HvHASKFLAGS_on() in S_hv_delete_common().

### DIFF
--- a/hv.c
+++ b/hv.c
@@ -1183,7 +1183,6 @@ S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
             }
             k_flags |= HVhek_WASUTF8 | HVhek_FREEKEY;
         }
-        HvHASKFLAGS_on(MUTABLE_SV(hv));
     }
 
     if (keysv && (SvIsCOW_shared_hash(keysv))) {


### PR DESCRIPTION
We're not changing any keys on the hash, so if it didn't have any keys with
flags before the delete, it won't have any afterwards either.

I added this line in Nov 2003 as part of commit cd6d36ac47e47079:
    Move the negative key -> utf8 flag conversion out to hv_delete

I don't think that it was correct then, and I don't think that it's correct
now.