### PR TITLE
cmpVERSION.pl and test.pl now handle checkouts from git-worktree.

### DIFF
--- a/Porting/cmpVERSION.pl
+++ b/Porting/cmpVERSION.pl
@@ -31,8 +31,24 @@ unless (GetOptions('diffs' => \$diffs,
 
 die "$0: This does not look like a Perl directory\n"
     unless -f "perl.h" && -d "Porting";
-die "$0: 'This is a Perl directory but does not look like Git working directory\n"
-    unless (-d ".git" || (exists $ENV{GIT_DIR} && -d $ENV{GIT_DIR}));
+
+if (-d ".git" || (exists $ENV{GIT_DIR} && -d $ENV{GIT_DIR})) {
+    # Looks good
+} else {
+    # Also handle linked worktrees created by git-worktree:
+    my $found;
+    if (-f '.git') {
+	my $commit = '8d063cd8450e59ea1c611a2f4f5a21059a2804f1';
+	my $out = `git rev-parse --verify --quiet '$commit^{commit}'`;
+	chomp $out;
+	if($out eq $commit) {
+            ++$found;
+	}
+    }
+
+    die "$0: This is a Perl directory but does not look like Git working directory\n"
+        unless $found;
+}
 
 my $null = devnull();
 

--- a/t/test.pl
+++ b/t/test.pl
@@ -203,7 +203,7 @@ sub find_git_or_skip {
 	    }
 	    $source_dir = $where;
 	}
-    } elsif (exists $ENV{GIT_DIR}) {
+    } elsif (exists $ENV{GIT_DIR} || -f '.git') {
 	my $commit = '8d063cd8450e59ea1c611a2f4f5a21059a2804f1';
 	my $out = `git rev-parse --verify --quiet '$commit^{commit}'`;
 	chomp $out;


### PR DESCRIPTION
Previously, linked checkouts made with git-worktree were not recognised as git checkouts and hence t/porting/cmp_verson.t was skipped, which could hide problems.