### PR TITLE
Change FIXME to XXX in source code

### DIFF
--- a/Porting/bisect-runner.pl
+++ b/Porting/bisect-runner.pl
@@ -1046,7 +1046,7 @@ foreach my $phase (qw(early late)) {
 unless (exists $defines{cc}) {
     # If it fails, the heuristic of 63f9ec3008baf7d6 is noisy, and hence
     # confusing.
-    # FIXME - really it should be replaced with a proper test of
+    # XXX - really it should be replaced with a proper test of
     # "can we build something?" and a helpful diagnostic if we can't.
     # For now, simply move it here.
     $defines{cc} = (`ccache -V`, $?) ? 'cc' : 'ccache cc';

--- a/Porting/how_to_write_a_perldelta.pod
+++ b/Porting/how_to_write_a_perldelta.pod
@@ -196,7 +196,7 @@ for the particular file in core.)
 
 Changes which create B<new> files in F<pod/> go here.
 
-B<FIXME> - this could be automated, at least as far as generating a first
+B<XXX> - this could be automated, at least as far as generating a first
 draft.
 
 =over

--- a/Porting/security_template.pod
+++ b/Porting/security_template.pod
@@ -5,7 +5,7 @@ Delete this begin/end block before publication.
 Not every heading below is appropriate for every security issue, so
 some may be deleted.
 
-Look for FIXME to see what needs to be filled in.
+Look for XXX to see what needs to be filled in.
 
 =end editor
 
@@ -13,40 +13,40 @@ Look for FIXME to see what needs to be filled in.
 
 =head1 NAME
 
-FIXME - short description of the security issue, with an identifier of the issue as the manpage name
+XXX - short description of the security issue, with an identifier of the issue as the manpage name
 
 =head1 DESCRIPTION
 
 =for editor
-Ideally, FIXME here should be the CVE-ID as a link to cve.mitre.org
+Ideally, XXX here should be the CVE-ID as a link to cve.mitre.org
 
 This document describes the
-L<FIXME|http://cve.mitre.org/cgi-bin/cvename.cgi?name=FIXME>
+L<XXX|http://cve.mitre.org/cgi-bin/cvename.cgi?name=XXX>
 security vulnerability for perl 5.
 
 =head2 Are there any known exploits "in the wild" for this vulnerability
 
-FIXME or delete
+XXX or delete
 
 =head2 Who is particularly vulnerable because of this issue?
 
-FIXME or delete
+XXX or delete
 
 =head2 What is the nature of the vulnerability?
 
-FIXME
+XXX
 
 =head2 What potential exploits are enabled by this vulnerability?
 
-FIXME or delete
+XXX or delete
 
 =head2 Which major versions of perl 5 are affected?
 
-FIXME with a list of versions that are affected, and which were updated.
+XXX with a list of versions that are affected, and which were updated.
 
 =head2 How can users protect themselves?
 
-FIXME or use the following:
+XXX or use the following:
 
 If you are vulnerable, upgrade to the latest maintenance release for the
 version of perl you are using.
@@ -54,14 +54,14 @@ version of perl you are using.
 If your release of perl is no longer supported by the perl 5 committers you
 may need to upgrade to a new major release of perl. The versions currently
 supported by the perl 5 committers are
-FIXME 5.28.2 (until 2020-05-31)
+XXX 5.28.2 (until 2020-05-31)
 and
-FIXME 5.30.1 (until 2021-05-31).
+XXX 5.30.1 (until 2021-05-31).
 The current version of perl is available from https://www.perl.org/get.html .
 
 =head2 Who was given access to the information about the vulnerability?
 
-FIXME or use the following:
+XXX or use the following:
 
 Specifics about the vulnerability were first disclosed to
 C<perl-security>, a closed subscriber mailing list that has a
@@ -69,15 +69,15 @@ subset of the perl committers subcribed to it.
 
 =head2 When was the vulnerability discovered?
 
-FIXME
+XXX
 
 =head2 Who discovered the vulnerability?
 
-FIXME
+XXX
 
 =head2 How was the vulnerability reported?
 
-FIXME: something like "So-and-so sent email to
+XXX: something like "So-and-so sent email to
 perl-security@perl.org"
 
 =cut

--- a/Porting/todo.pod
+++ b/Porting/todo.pod
@@ -805,7 +805,7 @@ Change 25773 notes
     AvARYLEN(av) has been freed before av, and hence the SvANY() pointer
     is now part of the linked list of SV heads, rather than pointing to
     the original body.  */
- /* FIXME - audit the code for other bugs like this one.  */
+ /* XXX - audit the code for other bugs like this one.  */
 
 adding the C<SvMAGICAL> check to
 

--- a/amigaos4/amigaio.c
+++ b/amigaos4/amigaio.c
@@ -356,7 +356,7 @@ struct child_arg
 
 #undef kill
 
-/* FIXME: Is here's a chance, albeit it small of a clash between our pseudo pid */
+/* XXX: Is here's a chance, albeit it small of a clash between our pseudo pid */
 /* derived from the pthread API  and the dos.library pid that newlib kill uses? */
 /* clib2 used the Process address so there was no issue */
 

--- a/configpm
+++ b/configpm
@@ -70,7 +70,7 @@ my %Extensions = map {($_,$_)}
 # Could use a map to add ".h", but I suspect that it's easier to use literals,
 # so that anyone using grep will find them
 # This is the list from MM_VMS, plus pad.h, parser.h, utf8.h
-# which it installs. It *doesn't* install perliol.h - FIXME.
+# which it installs. It *doesn't* install perliol.h - XXX.
 my @header_files = qw(EXTERN.h INTERN.h XSUB.h av.h config.h cop.h cv.h
 		      embed.h embedvar.h form.h gv.h handy.h hv.h hv_func.h intrpvar.h
 		      iperlsys.h keywords.h mg.h nostdio.h op.h opcode.h

--- a/configure.com
+++ b/configure.com
@@ -3189,7 +3189,7 @@ $!
 $ ccdlflags=""
 $ cccdlflags=""
 $!
-$! FIXME -- This section does not really handle all the different permutations 
+$! XXX -- This section does not really handle all the different permutations
 $! of 64-bitness, and it does not provide for the /POINTER_SIZE=64 compiler
 $! option that would be necessary to support the "explicit 64-bit interfaces"
 $! promised by -Dusemorebits.
@@ -5419,7 +5419,7 @@ $  d_getgrnam_r = "define"
 $  getgrnam_r_proto = "1"
 $  if d_symlink .or. d_symlink .EQS. "define"
 $  then
-$!	 FIXME: Need to find how to activate this.
+$!	 XXX: Need to find how to activate this.
 $!       d_getpgid = "define"
 $!       d_getpgrp = "define"
 $  endif

--- a/doio.c
+++ b/doio.c
@@ -974,7 +974,7 @@ S_openn_cleanup(pTHX_ GV *gv, IO *io, PerlIO *fp, char *mode, const char *oname,
 #endif /* !PERL_MICRO */
     }
 
-    /* Eeek - FIXME !!!
+    /* Eeek - XXX !!!
      * If this is a standard handle we discard all the layer stuff
      * and just dup the fd into whatever was on the handle before !
      */

--- a/embed.fnc
+++ b/embed.fnc
@@ -622,7 +622,7 @@ Apd	|OP*	|op_append_elem	|I32 optype|NULLOK OP* first|NULLOK OP* last
 Apd	|OP*	|op_append_list	|I32 optype|NULLOK OP* first|NULLOK OP* last
 Apd	|OP*	|op_linklist	|NN OP *o
 Apd	|OP*	|op_prepend_elem|I32 optype|NULLOK OP* first|NULLOK OP* last
-: FIXME - this is only called by pp_chown. They should be merged.
+: XXX - this is only called by pp_chown. They should be merged.
 p	|I32	|apply		|I32 type|NN SV** mark|NN SV** sp
 Apx	|void	|apply_attrs_string|NN const char *stashpv|NN CV *cv|NN const char *attrstr|STRLEN len
 Apd	|void	|av_clear	|NN AV *av
@@ -745,9 +745,9 @@ Ap	|void	|filter_del	|NN filter_t funcp
 ApRhd	|I32	|filter_read	|int idx|NN SV *buf_sv|int maxlen
 ApPR	|char**	|get_op_descs
 ApPR	|char**	|get_op_names
-: FIXME discussion on p5p
+: XXX discussion on p5p
 pPR	|const char*	|get_no_modify
-: FIXME discussion on p5p
+: XXX discussion on p5p
 pPR	|U32*	|get_opargs
 ApPR	|PPADDR_t*|get_ppaddr
 : Used by CXINC, which appears to be in widespread use
@@ -775,7 +775,7 @@ Afrpd	|OP*    |die            |NULLOK const char* pat|...
 : Used in util.c
 pr	|void	|die_unwind	|NN SV* msv
 Ap	|void	|dounwind	|I32 cxix
-: FIXME
+: XXX
 pMb	|bool|do_aexec	|NULLOK SV* really|NN SV** mark|NN SV** sp
 : Used in pp_sys.c
 p	|bool|do_aexec5	|NULLOK SV* really|NN SV** mark|NN SV** sp|int fd|int do_report
@@ -924,7 +924,7 @@ i	|void	|op_relocate_sv	|NN SV** svp|NN PADOFFSET* targp
 #endif
 i	|OP*	|newMETHOP_internal	|I32 type|I32 flags|NULLOK OP* dynamic_meth \
 					|NULLOK SV* const_meth
-: FIXME
+: XXX
 S	|OP*	|fold_constants	|NN OP * const o
 Sd	|OP*	|traverse_op_tree|NN OP* top|NN OP* o
 #endif
@@ -1255,7 +1255,7 @@ Axpd	|OP*	|parse_stmtseq	|U32 flags
 Axpd	|OP*	|parse_subsignature|U32 flags
 : Used in various files
 Apd	|void	|op_null	|NN OP* o
-: FIXME. Used by Data::Alias
+: XXX. Used by Data::Alias
 EXp	|void	|op_clear	|NN OP* o
 Ap	|void	|op_refcnt_lock
 Ap	|void	|op_refcnt_unlock
@@ -1372,7 +1372,7 @@ p	|char*	|_mem_collxfrm	|NN const char* input_string	\
 Afpd	|SV*	|mess		|NN const char* pat|...
 Apd	|SV*	|mess_sv	|NN SV* basemsg|bool consume
 Apd	|SV*	|vmess		|NN const char* pat|NULLOK va_list* args
-: FIXME - either make it public, or stop exporting it. (Data::Alias uses this)
+: XXX - either make it public, or stop exporting it. (Data::Alias uses this)
 : Used in gv.c, op.c, toke.c
 EXp	|void	|qerror		|NN SV* err
 Apd	|void	|sortsv		|NULLOK SV** array|size_t num_elts|NN SVCOMPARE_t cmp
@@ -1958,7 +1958,7 @@ Apdh	|I32	|pregexec	|NN REGEXP * const prog|NN char* stringarg \
 				|SSize_t minend |NN SV* screamer|U32 nosave
 Ap	|void	|pregfree	|NULLOK REGEXP* r
 Cp	|void	|pregfree2	|NN REGEXP *rx
-: FIXME - is anything in re using this now?
+: XXX - is anything in re using this now?
 EXp	|REGEXP*|reg_temp_copy	|NULLOK REGEXP* dsv|NN REGEXP* ssv
 Cp	|void	|regfree_internal|NN REGEXP *const rx
 #if defined(USE_ITHREADS)
@@ -1997,14 +1997,14 @@ Cp	|SV*|reg_named_buff_nextkey  |NN REGEXP * const rx|const U32 flags
 Cp	|SV*|reg_named_buff_scalar   |NN REGEXP * const rx|const U32 flags
 Cp	|SV*|reg_named_buff_all      |NN REGEXP * const rx|const U32 flags
 
-: FIXME - is anything in re using this now?
+: XXX - is anything in re using this now?
 EXp	|void|reg_numbered_buff_fetch|NN REGEXP * const rx|const I32 paren|NULLOK SV * const sv
-: FIXME - is anything in re using this now?
+: XXX - is anything in re using this now?
 EXp	|void|reg_numbered_buff_store|NN REGEXP * const rx|const I32 paren|NULLOK SV const * const value
-: FIXME - is anything in re using this now?
+: XXX - is anything in re using this now?
 EXp	|I32|reg_numbered_buff_length|NN REGEXP * const rx|NN const SV * const sv|const I32 paren
 
-: FIXME - is anything in re using this now?
+: XXX - is anything in re using this now?
 EXp	|SV*|reg_qr_package|NN REGEXP * const rx
 EXpRT	|I16	|do_uniprop_match|NN const char * const key|const U16 key_len
 EXpRT	|const char * const *|get_prop_values|const int table_index
@@ -2658,7 +2658,7 @@ dm	|void	|free_c_backtrace|NN Perl_c_backtrace* bt
 Apd	|SV*	|get_c_backtrace_dump|int max_depth|int skip
 Apd	|bool	|dump_c_backtrace|NN PerlIO* fp|int max_depth|int skip
 #endif
-: FIXME
+: XXX
 p	|void	|watch		|NN char** addr
 Amd	|I32	|whichsig	|NN const char* sig
 Apd	|I32    |whichsig_sv    |NN SV* sigsv
@@ -2952,7 +2952,7 @@ pe	|void	|Slab_to_rw	|NN OPSLAB *const slab
 #    endif
 : Used in OpREFCNT_inc() in sv.c
 poex	|OP *	|op_refcnt_inc	|NULLOK OP *o
-: FIXME - can be static.
+: XXX - can be static.
 poex	|PADOFFSET	|op_refcnt_dec	|NN OP *o
 #endif
 
@@ -3551,7 +3551,7 @@ S	|bool	|ckwarn_common	|U32 w
 #endif
 CpoP	|bool	|ckwarn		|U32 w
 CpoP	|bool	|ckwarn_d	|U32 w
-: FIXME - exported for ByteLoader - public or private?
+: XXX - exported for ByteLoader - public or private?
 XEopxR	|STRLEN *|new_warnings_bitfield|NULLOK STRLEN *buffer \
 				|NN const char *const bits|STRLEN size
 

--- a/ext/B/B.pm
+++ b/ext/B/B.pm
@@ -20,7 +20,7 @@ sub import {
 # walkoptree comes from B.xs
 
 BEGIN {
-    $B::VERSION = '1.82';
+    $B::VERSION = '1.83';
     @B::EXPORT_OK = ();
 
     # Our BOOT code needs $VERSION set, and will append to @EXPORT_OK.

--- a/ext/B/B.xs
+++ b/ext/B/B.xs
@@ -1631,7 +1631,7 @@ REGEX(sv)
 	    if (ix)
 		PUSHu(RX_COMPFLAGS(sv));
 	    else
-	    /* FIXME - can we code this method more efficiently?  */
+	    /* XXX - can we code this method more efficiently?  */
 		PUSHi(PTR2IV(sv));
 	}
 

--- a/ext/Devel-Peek/Peek.pm
+++ b/ext/Devel-Peek/Peek.pm
@@ -3,7 +3,7 @@
 
 package Devel::Peek;
 
-$VERSION = '1.32';
+$VERSION = '1.33';
 $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 

--- a/ext/Devel-Peek/Peek.xs
+++ b/ext/Devel-Peek/Peek.xs
@@ -224,7 +224,7 @@ _mstats_to_hv(HV *hv, const struct mstats_buffer *b, int level)
     sv_setiv(*svp, b->buffer.nbuckets);
 
     if (_NBUCKETS < b->buffer.nbuckets) 
-	warn("FIXME: internal mstats buffer too short");
+	warn("XXX: internal mstats buffer too short");
     
     for (type = 0; type < (level ? 4 : 2); type++) {
 	UV *p = 0, *p1 = 0, i;

--- a/ext/File-DosGlob/lib/File/DosGlob.pm
+++ b/ext/File-DosGlob/lib/File/DosGlob.pm
@@ -6,7 +6,7 @@
 
 package File::DosGlob;
 
-our $VERSION = '1.12';
+our $VERSION = '1.13';
 use strict;
 use warnings;
 
@@ -155,12 +155,12 @@ sub glob {
 		}
 	    }
 	    #print "Sould have "GOT" vs "Got"!\n";
-		#FIXME: There should be checking for this.
+		#XXX: There should be checking for this.
 		#  How or what should be done about failure is beyond me.
 	}
 	if ( $#appendpat != -1
 		) {
-	    #FIXME: Max loop, no way! :")
+	    #XXX: Max loop, no way! :")
 	    for ( @appendpat ) {
 	        push @pat, $_;
 	    }

--- a/ext/PerlIO-encoding/encoding.pm
+++ b/ext/PerlIO-encoding/encoding.pm
@@ -1,7 +1,7 @@
 package PerlIO::encoding;
 
 use strict;
-our $VERSION = '0.30';
+our $VERSION = '0.31';
 our $DEBUG = 0;
 $DEBUG and warn __PACKAGE__, " called by ", join(", ", caller), "\n";
 

--- a/ext/PerlIO-encoding/encoding.xs
+++ b/ext/PerlIO-encoding/encoding.xs
@@ -462,7 +462,7 @@ PerlIOEncode_flush(pTHX_ PerlIO * f)
 	else if ((PerlIOBase(f)->flags & PERLIO_F_RDBUF)) {
 	    /* read case */
 	    /* if we have any untranslated stuff then unread that first */
-	    /* FIXME - unread is fragile is there a better way ? */
+	    /* XXX - unread is fragile is there a better way ? */
 	    if (e->dataSV && SvCUR(e->dataSV)) {
 		s = SvPV(e->dataSV, len);
 		count = PerlIO_unread(PerlIONext(f),s,len);

--- a/ext/PerlIO-via/via.pm
+++ b/ext/PerlIO-via/via.pm
@@ -1,5 +1,5 @@
 package PerlIO::via;
-our $VERSION = '0.18';
+our $VERSION = '0.19';
 require XSLoader;
 XSLoader::load();
 1;

--- a/ext/PerlIO-via/via.xs
+++ b/ext/PerlIO-via/via.xs
@@ -110,7 +110,7 @@ PerlIOVia_method(pTHX_ PerlIO * f, const char *method, CV ** save, int flags,
 	}
 	else {
 	    PerlIO_debug("No next\n");
-	    /* FIXME: How should this work for OPEN etc? */
+	    /* XXX: How should this work for OPEN etc? */
 	}
 	PUTBACK;
 	count = call_sv((SV *) cv, flags);
@@ -292,7 +292,7 @@ PerlIOVia_open(pTHX_ PerlIO_funcs * self, PerlIO_list_t * layers,
 			    f = NULL;
 			}
 		    }
-		    /* FIXME - Call an OPENED method here ? */
+		    /* XXX - Call an OPENED method here ? */
 		    return f;
 		}
 		else {

--- a/ext/XS-Typemap/Typemap.pm
+++ b/ext/XS-Typemap/Typemap.pm
@@ -34,7 +34,7 @@ to the test script.
 use parent qw/ Exporter /;
 require XSLoader;
 
-our $VERSION = '0.18';
+our $VERSION = '0.19';
 
 our @EXPORT = (qw/
 	   T_SV

--- a/ext/XS-Typemap/Typemap.xs
+++ b/ext/XS-Typemap/Typemap.xs
@@ -96,7 +96,7 @@ XS_unpack_anotherstructPtr(SV *in)
     else
         Perl_croak(aTHX_ "Argument is not a HASH reference");
 
-    /* FIXME dunno if supposed to use perl mallocs here */
+    /* XXX dunno if supposed to use perl mallocs here */
     Newxz(out, 1, anotherstruct);
 
     elem = hv_fetchs(inhash, "a", 0);
@@ -159,7 +159,7 @@ XS_unpack_anotherstructPtrPtr(SV *in)
 
     nitems = av_count(inary);
 
-    /* FIXME dunno if supposed to use perl mallocs here */
+    /* XXX dunno if supposed to use perl mallocs here */
     /* N+1 elements so we know the last one is NULL */
     Newxz(out, nitems+1, anotherstruct*);
 

--- a/ext/re/re.pm
+++ b/ext/re/re.pm
@@ -4,7 +4,7 @@ package re;
 use strict;
 use warnings;
 
-our $VERSION     = "0.41";
+our $VERSION     = "0.42";
 our @ISA         = qw(Exporter);
 our @EXPORT_OK   = qw{
 	is_regexp regexp_pattern
@@ -895,7 +895,7 @@ Ignored for anchored, so may be 0 or same as min.
 
 =item anchored end shift/floating end shift
 
-FIXME: not sure what this is, something to do with lookbehind. regcomp.c
+XXX: not sure what this is, something to do with lookbehind. regcomp.c
 says:
     When the final pattern is compiled and the data is moved from the
     scan_data_t structure into the regexp structure the information

--- a/gv.c
+++ b/gv.c
@@ -1537,7 +1537,7 @@ S_gv_stashpvn_internal(pTHX_ const char *name, U32 namelen, I32 flags)
     if (!HvNAME_get(stash)) {
         hv_name_set(stash, name, namelen, flags & SVf_UTF8 ? SVf_UTF8 : 0 );
         
-        /* FIXME: This is a repeat of logic in gv_fetchpvn_flags */
+        /* XXX: This is a repeat of logic in gv_fetchpvn_flags */
         /* If the containing stash has multiple effective
            names, see that this one gets them, too. */
         if (HvAUX(GvSTASH(tmpgv))->xhv_name_count)
@@ -2780,7 +2780,7 @@ Perl_gp_free(pTHX_ GV *gv)
 
       SvREFCNT_dec(sv);
       SvREFCNT_dec(av);
-      /* FIXME - another reference loop GV -> symtab -> GV ?
+      /* XXX - another reference loop GV -> symtab -> GV ?
          Somehow gp->gp_hv can end up pointing at freed garbage.  */
       if (hv && SvTYPE(hv) == SVt_PVHV) {
         const HEK *hvname_hek = HvNAME_HEK(hv);

--- a/hv.c
+++ b/hv.c
@@ -416,7 +416,7 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
             if (mg_find((const SV *)hv, PERL_MAGIC_tied)
                 || SvGMAGICAL((const SV *)hv))
             {
-                /* FIXME should be able to skimp on the HE/HEK here when
+                /* XXX should be able to skimp on the HE/HEK here when
                    HV_FETCH_JUST_SV is true.  */
                 if (!keysv) {
                     keysv = newSVpvn_utf8(key, klen, is_utf8);

--- a/lib/h2xs.t
+++ b/lib/h2xs.t
@@ -12,7 +12,7 @@
 BEGIN {
     chdir 't' if -d 't';
     @INC = '../lib';
-    # FIXME (or rather FIXh2xs)
+    # XXX (or rather FIXh2xs)
     require Config;
     if (($Config::Config{'extensions'} !~ m!\bDevel/PPPort\b!) ){
 	print "1..0 # Skip -- Perl configured without Devel::PPPort module\n";

--- a/mg.c
+++ b/mg.c
@@ -357,7 +357,7 @@ Perl_mg_size(pTHX_ SV *sv)
         case SVt_PVAV:
             return AvFILLp((const AV *) sv); /* Fallback to non-tied array */
         case SVt_PVHV:
-            /* FIXME */
+            /* XXX */
         default:
             Perl_croak(aTHX_ "Size magic not implemented");
 

--- a/op.c
+++ b/op.c
@@ -13401,7 +13401,7 @@ Perl_ck_fun(pTHX_ OP *o)
             prev_kid = kid;
             kid = OpSIBLING(kid);
         }
-        /* FIXME - should the numargs or-ing move after the too many
+        /* XXX - should the numargs or-ing move after the too many
          * arguments check? */
         o->op_private |= numargs;
         if (kid)

--- a/perlio.c
+++ b/perlio.c
@@ -1322,7 +1322,7 @@ PerlIO_binmode(pTHX_ PerlIO *f, int iotype, int mode, const char *names)
          */
         if (!(mode & O_BINARY)) {
             /* Text mode */
-            /* FIXME?: Looking down the layer stack seems wrong,
+            /* XXX?: Looking down the layer stack seems wrong,
                but is a way of reaching past (say) an encoding layer
                to flip CRLF-ness of the layer(s) below
              */
@@ -2695,7 +2695,7 @@ PerlIOUnix_open(pTHX_ PerlIO_funcs *self, PerlIO_list_t *layers,
         if (f) {
             NOOP;
             /*
-             * FIXME: pop layers ???
+             * XXX: pop layers ???
              */
         }
         return NULL;
@@ -3136,7 +3136,7 @@ PerlIOStdio_dup(pTHX_ PerlIO *f, PerlIO *o, CLONE_PARAMS *param, int flags)
             }
             else {
                 NOOP;
-                /* FIXME: To avoid messy error recovery if dup fails
+                /* XXX: To avoid messy error recovery if dup fails
                    re-use the existing stdio as though flag was not set
                  */
             }
@@ -3476,7 +3476,7 @@ PerlIOStdio_flush(pTHX_ PerlIO *f)
         NOOP;
 #if 0
         /*
-         * FIXME: This discards ungetc() and pre-read stuff which is not
+         * XXX: This discards ungetc() and pre-read stuff which is not
          * right if this is just a "sync" from a layer above Suspect right
          * design is to do _this_ but not have layer above flush this
          * layer read-to-read

--- a/regcomp.c
+++ b/regcomp.c
@@ -12599,7 +12599,7 @@ S_regbranch(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, I32 first, U32 depth)
             ret = latest;
         *flagp |= flags&(HASWIDTH|POSTPONED);
         if (chain != 0) {
-            /* FIXME adding one for every branch after the first is probably
+            /* XXX adding one for every branch after the first is probably
              * excessive now we have TRIE support. (hv) */
             MARK_NAUGHTY(1);
             if (! REGTAIL(pRExC_state, chain, latest)) {

--- a/regexec.c
+++ b/regexec.c
@@ -7906,7 +7906,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
              * the same position we throw an error.
              */
             if ( rex->recurse_locinput[arg] == locinput ) {
-                /* FIXME: we should show the regop that is failing as part
+                /* XXX: we should show the regop that is failing as part
                  * of the error message. */
                 Perl_croak(aTHX_ "Infinite recursion in regex");
             } else {

--- a/regexp.h
+++ b/regexp.h
@@ -511,7 +511,7 @@ and check for NULL.
                                             + ReANY(rx_sv)->pre_prefix)
 #  define RX_PRECOMP_const(rx_sv)        (RX_WRAPPED_const(rx_sv) \
                                             + ReANY(rx_sv)->pre_prefix)
-/* FIXME? Are we hardcoding too much here and constraining plugin extension
+/* XXX? Are we hardcoding too much here and constraining plugin extension
    writers? Specifically, the value 1 assumes that the wrapped version always
    has exactly one character at the end, a ')'. Will that always be true?  */
 #  define RX_PRELEN(rx_sv)                (RX_WRAPLEN(rx_sv) \
@@ -628,7 +628,7 @@ and check for NULL.
 #endif
 #define ReANY(re)		Perl_ReANY((const REGEXP *)(re))
 
-/* FIXME for plugins. */
+/* XXX for plugins. */
 
 #define FBMcf_TAIL_DOLLAR	1
 #define FBMcf_TAIL_DOLLARM	2

--- a/scope.c
+++ b/scope.c
@@ -263,7 +263,7 @@ Perl_save_scalar(pTHX_ GV *gv)
         PL_localizing = 0;
     }
     save_pushptrptr(SvREFCNT_inc_simple(gv), SvREFCNT_inc(*sptr), SAVEt_SV);
-    return save_scalar_at(sptr, SAVEf_SETMAGIC); /* XXX - FIXME - see #60360 */
+    return save_scalar_at(sptr, SAVEf_SETMAGIC); /* XXX - XXX - see #60360 */
 }
 
 /* Like save_sptr(), but also SvREFCNT_dec()s the new value.  Can be used to
@@ -741,7 +741,7 @@ Perl_save_aelem_flags(pTHX_ AV *av, SSize_t idx, SV **sptr,
        must be AvREAL. */
     if (UNLIKELY(!AvREAL(av) && AvREIFY(av)))
         av_reify(av);
-    save_scalar_at(sptr, flags); /* XXX - FIXME - see #60360 */
+    save_scalar_at(sptr, flags); /* XXX - XXX - see #60360 */
     if (flags & SAVEf_KEEPOLDELEM)
         return;
     sv = *sptr;
@@ -788,7 +788,7 @@ Perl_save_svref(pTHX_ SV **sptr)
 
     SvGETMAGIC(*sptr);
     save_pushptrptr(sptr, SvREFCNT_inc(*sptr), SAVEt_SVREF);
-    return save_scalar_at(sptr, SAVEf_SETMAGIC); /* XXX - FIXME - see #60360 */
+    return save_scalar_at(sptr, SAVEf_SETMAGIC); /* XXX - XXX - see #60360 */
 }
 
 

--- a/sv.c
+++ b/sv.c
@@ -6688,7 +6688,7 @@ Perl_sv_clear(pTHX_ SV *const orig_sv)
                 PL_statgv = NULL;
             goto freescalar;
         case SVt_REGEXP:
-            /* FIXME for plugins */
+            /* XXX for plugins */
             pregfree2((REGEXP*) sv);
             goto freescalar;
         case SVt_PVCV:
@@ -6789,7 +6789,7 @@ Perl_sv_clear(pTHX_ SV *const orig_sv)
                 if ((stash = GvSTASH(sv)))
                         sv_del_backref(MUTABLE_SV(stash), sv);
             }
-            /* FIXME. There are probably more unreferenced pointers to SVs
+            /* XXX. There are probably more unreferenced pointers to SVs
              * in the interpreter struct that we should check and tidy in
              * a similar fashion to this:  */
             /* See also S_sv_unglob, which does the same thing. */
@@ -13221,7 +13221,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                    missing Q.
                 */
                 *--ptr = 'Q';
-                /* FIXME: what to do if HAS_LONG_DOUBLE but not PERL_PRIfldbl? */
+                /* XXX: what to do if HAS_LONG_DOUBLE but not PERL_PRIfldbl? */
 #elif defined(HAS_LONG_DOUBLE) && defined(PERL_PRIfldbl)
                 /* Note that this is HAS_LONG_DOUBLE and PERL_PRIfldbl,
                  * not USE_LONG_DOUBLE and NVff.  In other words,
@@ -13868,7 +13868,7 @@ Perl_mg_dup(pTHX_ MAGIC *mg, CLONE_PARAMS *const param)
            assignment to nmg->mg_ptr.  */
         *nmg = *mg;
 
-        /* FIXME for plugins
+        /* XXX for plugins
         if (nmg->mg_type == PERL_MAGIC_qr) {
             nmg->mg_obj	= MUTABLE_SV(CALLREGDUPE((REGEXP*)nmg->mg_obj, param));
         }
@@ -14300,7 +14300,7 @@ S_sv_dup_common(pTHX_ const SV *const ssv, CLONE_PARAMS *const param)
                are now in the destination.  We can check the flags and the
                pointers in either, but it's possible that there's less cache
                missing by always going for the destination.
-               FIXME - instrument and check that assumption  */
+               XXX - instrument and check that assumption  */
             if (sv_type >= SVt_PVMG) {
                 if (SvMAGIC(dsv))
                     SvMAGIC_set(dsv, mg_dup(SvMAGIC(dsv), param));
@@ -14321,7 +14321,7 @@ S_sv_dup_common(pTHX_ const SV *const ssv, CLONE_PARAMS *const param)
                 break;
             case SVt_REGEXP:
               duprex:
-                /* FIXME for plugins */
+                /* XXX for plugins */
                 re_dup_guts((REGEXP*) ssv, (REGEXP*) dsv, param);
                 break;
             case SVt_PVLV:
@@ -15560,7 +15560,7 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
 
 
     /* Clone the regex array */
-    /* ORANGE FIXME for plugins, probably in the SV dup code.
+    /* ORANGE XXX for plugins, probably in the SV dup code.
        newSViv(PTR2IV(CALLREGDUPE(
        INT2PTR(REGEXP *, SvIVX(regex)), param))))
     */
@@ -15986,7 +15986,7 @@ Perl_clone_params_new(PerlInterpreter *const from, PerlInterpreter *const to)
 {
     /* Need to play this game, as newAV() can call safesysmalloc(), and that
        does a dTHX; to get the context from thread local storage.
-       FIXME - under PERL_CORE Newx(), Safefree() and friends should expand to
+       XXX - under PERL_CORE Newx(), Safefree() and friends should expand to
        a version that passes in my_perl.  */
     PerlInterpreter *const was = PERL_GET_THX;
     CLONE_PARAMS *param;

--- a/t/TEST
+++ b/t/TEST
@@ -30,7 +30,7 @@ my %dir_to_switch =
     (base => '',
      comp => '',
      run => '',
-     '../ext/File-Glob/t' => '-I.. -MTestInit', # FIXME - tests assume t/
+     '../ext/File-Glob/t' => '-I.. -MTestInit', # XXX - tests assume t/
      );
 
 # "not absolute" is the default, as it saves some fakery within TestInit

--- a/t/comp/utf.t
+++ b/t/comp/utf.t
@@ -64,7 +64,7 @@ for my $bom (0, 1) {
 	    }
 	    next if $enc eq 'UTF-8';
 	    # Arguably a bug that currently string literals from UTF-8 file
-	    # handles are not implicitly "use utf8", but don't FIXME that
+	    # handles are not implicitly "use utf8", but don't XXX that
 	    # right now, as here we're testing the input filter itself.
 
 	    for my $expect (

--- a/t/io/layers.t
+++ b/t/io/layers.t
@@ -7,7 +7,7 @@ BEGIN {
     require './test.pl';
     set_up_inc('../lib');
     skip_all_without_perlio();
-    # FIXME - more of these could be tested without Encode or full perl
+    # XXX - more of these could be tested without Encode or full perl
     skip_all_without_dynamic_extension('Encode');
 
     # Makes testing easier.

--- a/t/porting/diag.t
+++ b/t/porting/diag.t
@@ -511,7 +511,7 @@ sub check_message {
 # Entries after __CATEGORIES__ are those that are in perldiag but fail the
 # severity/category test.
 
-# Also FIXME this test, as the first entry in TODO *is* covered by the
+# Also XXX this test, as the first entry in TODO *is* covered by the
 # description: Malformed UTF-8 character (%s)
 __DATA__
 Malformed UTF-8 character (unexpected non-continuation byte 0x%x, immediately after start byte 0x%x)

--- a/toke.c
+++ b/toke.c
@@ -6672,7 +6672,7 @@ yyl_dblquote(pTHX_ char *s)
     if (!s)
         missingterm(NULL, 0);
     pl_yylval.ival = OP_CONST;
-    /* FIXME. I think that this can be const if char *d is replaced by
+    /* XXX. I think that this can be const if char *d is replaced by
        more localised variables.  */
     for (d = SvPV(PL_lex_stuff, len); len; len--, d++) {
         if (*d == '$' || *d == '@' || *d == '\\' || !UTF8_IS_INVARIANT((U8)*d)) {

--- a/vms/vms.c
+++ b/vms/vms.c
@@ -12310,7 +12310,7 @@ Perl_flex_lstat(pTHX_ const char *fspec, Stat_t *statbufp)
  * as part of the Perl standard distribution under the terms of the
  * GNU General Public License or the Perl Artistic License.  Copies
  * of each may be found in the Perl standard distribution.
- */ /* FIXME */
+ */ /* XXX */
 /*{{{int rmscopy(char *src, char *dst, int preserve_dates)*/
 int
 Perl_rmscopy(pTHX_ const char *spec_in, const char *spec_out, int preserve_dates)

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -4391,7 +4391,7 @@ RETRY:
     else {
         DWORD status;
         win32_msgwait(aTHX_ 1, &ProcessInformation.hProcess, INFINITE, NULL);
-        /* FIXME: if msgwait returned due to message perhaps forward the
+        /* XXX: if msgwait returned due to message perhaps forward the
            "signal" to the process
          */
         GetExitCodeProcess(ProcessInformation.hProcess, &status);


### PR DESCRIPTION
As per a discussion on #irc, XXX stands visually out more than FIXME,
and is more likely to prevent a commit from being made whose intent was
to fix the item beforehand.

It also is more visually arresting when just reading code, and hence
stands a better chance of being addressed later.

There are also TODO lines in the source.  This commit doesn't address
those, in part to see what the response is to this one.