### PR TITLE
Test that mg_copy is called only when expected.

### DIFF
--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -1922,8 +1922,6 @@ fetch(hash, key_sv)
         OUTPUT:
         RETVAL
 
-#if defined (hv_common)
-
 SV *
 common(params)
         INPUT:
@@ -1982,8 +1980,6 @@ common(params)
         OUTPUT:
         RETVAL
 
-#endif
-
 void
 test_hv_free_ent()
         PPCODE:
@@ -2014,8 +2010,6 @@ test_share_unshare_pvn(input)
         OUTPUT:
         RETVAL
 
-#if PERL_VERSION_GE(5,9,0)
-
 bool
 refcounted_he_exists(key, level=0)
         SV *key
@@ -2040,8 +2034,6 @@ refcounted_he_fetch(key, level=0)
         SvREFCNT_inc(RETVAL);
         OUTPUT:
         RETVAL
-
-#endif
 
 void
 test_force_keys(HV *hv)
@@ -4046,7 +4038,7 @@ CODE:
     exit(0);
 }
 
-#endif /* USE_ITHREDS */
+#endif /* USE_ITHREADS */
 
 SV*
 take_svref(SVREF sv)
@@ -4673,6 +4665,7 @@ CODE:
         (const char *)thingy, 0);
 
 
+MODULE = XS::APItest            PACKAGE = XS::APItest
 
 bool
 test_isBLANK_uni(UV ord)

--- a/t/op/tie.t
+++ b/t/op/tie.t
@@ -21,48 +21,6 @@ done_testing();
 
 __END__
 
-########
-# tied hash in list context
-use Tie::Hash;
-my %tied;
-tie %tied, "Tie::StdHash";
-%tied = qw(perl rules beer foamy);
-my @a = %tied;
-if ($a[0] eq 'beer') {
-    print "@a\n";
-} else {
-    # Must do this explicitly (not sort) to spot if keys and values are muddled
-    print "$a[2] $a[3] $a[0] $a[1]\n"
-}
-
-EXPECT
-beer foamy perl rules
-########
-# tied hash keys in list context
-use Tie::Hash;
-my %tied;
-tie %tied, "Tie::StdHash";
-%tied = qw(perl rules beer foamy);
-my @a = keys %tied;
-@a = sort @a;
-print "@a\n";
-
-EXPECT
-beer perl
-########
-# tied hash values in list context
-use Tie::Hash;
-my %tied;
-tie %tied, "Tie::StdHash";
-%tied = qw(perl rules beer foamy);
-my @a = values %tied;
-@a = sort @a;
-print "@a\n";
-
-EXPECT
-foamy rules
-########
-
 # standard behaviour, without any extra references
 use Tie::Hash ;
 tie %h, Tie::StdHash;

--- a/t/op/tiehash.t
+++ b/t/op/tiehash.t
@@ -150,4 +150,43 @@ package TestIterators {
     is("@have", "@want", "tie/untie resets the hash iterator");
 }
 
+{
+    require Tie::Hash;
+    my $count;
+
+    package Tie::Count {
+        use parent -norequire, 'Tie::StdHash';
+        sub FETCH {
+            ++$count;
+            return $_[0]->SUPER::FETCH($_[1]);
+        }
+    }
+
+    $count = 0;
+    my %tied;
+    tie %tied, "Tie::Count";
+    %tied = qw(perl rules beer foamy);
+    my @a = %tied;
+    if ($a[0] eq 'beer') {
+        is("@a", "beer foamy perl rules", "tied hash in list context");
+    } else {
+        is("@a", "perl rules beer foamy", "tied hash in list context");
+    }
+    is($count, 2, "two FETCHes for tied hash in list context");
+
+    $count = 0;
+
+    @a = keys %tied;
+    @a = sort @a;
+    is("@a", "beer perl", "tied hash keys in list context");
+    is($count, 0, "no FETCHes for tied hash keys in list context");
+
+    $count = 0;
+    @a = values %tied;
+    @a = sort @a;
+
+    is("@a", "foamy rules", "tied hash values in list context");
+    is($count, 2, "two FETCHes for tied hash values in list context");
+}
+
 done_testing();


### PR DESCRIPTION
mg_copy is called for most operations on tied hashes, but not for `keys`. This is externally observable behaviour, and Variable::Magic on CPAN has a regression test that expects the current behaviour.

However, until now we had no tests in core that verified that the current behaviour has not changed. Hence this new test.

Also, some other cleanup of APITest.xs and hash regression tests.