### PR TITLE
remaining_count is marked NULLOK in embed.fnc, so always check it

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -3237,7 +3237,9 @@ S_to_case_cp_list(pTHX_ const UV original,
              * should be given. */
         }
 
-        *remaining_count = 0;
+        if (remaining_count) {
+            *remaining_count = 0;
+        }
         return original;
     }
 


### PR DESCRIPTION
Coverity detected the inconsistent NULL checks.

CID 338543