### PR TITLE
Evaluate arg to FITS_IN_8_BITS just once

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -1449,8 +1449,8 @@ or casts
 #ifndef __COVERITY__
   /* The '| 0' part ensures a compiler error if c is not integer (like e.g., a
    * pointer) */
-#  define FITS_IN_8_BITS(c) (   (sizeof(c) == 1)                        \
-                 || ((WIDEST_UTYPE) ASSERT_NOT_PTR(c)) == ((U8)(c)))
+#  define FITS_IN_8_BITS(c) (   (sizeof(c) == 1)                            \
+                             || ((WIDEST_UTYPE) ASSERT_NOT_PTR(c)) <= 0xFF)
 #else
 #  define FITS_IN_8_BITS(c) (1)
 #endif


### PR DESCRIPTION
This had been changed by 9555181b32f9b30122a8ea4e779c2c9916cec9f8 to
evaluating multiple times.

(sizeof() also is called with the parameter, but that doesn't actually
evaluate the parameter.)