### PR TITLE
Evaluate arg to FITS_IN_8_BITS just once

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -1447,10 +1447,10 @@ or casts
  * of operands.  Well, they are, but that is kind of the point.
  */
 #ifndef __COVERITY__
-  /* The '| 0' part ensures a compiler error if c is not integer (like e.g., a
-   * pointer) */
-#  define FITS_IN_8_BITS(c) (   (sizeof(c) == 1)                        \
-                 || ((WIDEST_UTYPE) ASSERT_NOT_PTR(c)) == ((U8)(c)))
+  /* The '| 0' part in ASSERT_NOT_PTR ensures a compiler error if c is not
+   * integer (like e.g., a pointer) */
+#  define FITS_IN_8_BITS(c) (   (sizeof(c) == 1)                            \
+                             || (((WIDEST_UTYPE) ASSERT_NOT_PTR(c)) >> 8) == 0)
 #else
 #  define FITS_IN_8_BITS(c) (1)
 #endif


### PR DESCRIPTION
This had been changed by 9555181b32f9b30122a8ea4e779c2c9916cec9f8 to
evaluating multiple times.

(sizeof() also is called with the parameter, but that doesn't actually
evaluate the parameter.)

The previous version of this commit used a comparison with 0xFF, but gcc
is smart enough to realise that `comparison is always true due to limited
range of data type`, but not smart enough to realise that the sizeof makes
that code unreachable. Hence with -Wtype-limits we get thousands of warnings.

Using >> defeats the warnings.