### PR TITLE
Remove duplicate update of iter in Perl_hv_iternext_flags().

### DIFF
--- a/hv.c
+++ b/hv.c
@@ -2737,14 +2737,6 @@ Perl_hv_iternext_flags(pTHX_ HV *hv, I32 flags)
     if (!entry && SvRMAGICAL((const SV *)hv)
         && mg_find((const SV *)hv, PERL_MAGIC_env)) {
         prime_env_iter();
-#ifdef VMS
-        /* The prime_env_iter() on VMS just loaded up new hash values
-         * so the iteration count needs to be reset back to the beginning
-         */
-        hv_iterinit(hv);
-        iter = HvAUX(hv);
-        oldentry = entry = iter->xhv_eiter; /* HvEITER(hv) */
-#endif
     }
 #endif
 


### PR DESCRIPTION
Because`iter` points to a structure immediately after of HvARRAY(), it needs
updating if HvARRAY() has moved because it has been expanded.

Code was added for VMS in Aug 2005 to address a specific instance of this
bug with commit 03026e68943709ca:
    [patch@25334] hv.c vms environment fix.
    From: "John E. Malmberg" <wb8tyw@qsl.net>
    Message-ID: <4310F552.8050401@qsl.net>

see https://www.nntp.perl.org/group/perl.perl5.porters/2005/08/msg104261.html

However, this code was duplicated by and hence made redundant with a more
general fix added in March 2014 by commit 339441efdfcbaef5:
    make core safe against HvAUX() realloc

    Since the HvAUX structure is just tacked onto the end of the HvARRAY()
    struct, code like this can do bad things:

        aux = HvAUX();
        ... something that might split hv ...
        aux->foo = ...; /* SEGV! */

    So I've visually audited core for places where HbAUX() is saved and then
    re-used, and re-initialised the var if it looks like HvARRAY() could
    have changed in the meantime.

    I've been very conservative about what might be unsafe. For example,
    destructors or __WARN__ handlers could call perl code that modifies the
    hash.

Hence remove the redundant code.