### PR TITLE
In pp_defined assert that the SV is not a hash or array.

### DIFF
--- a/pp_hot.c
+++ b/pp_hot.c
@@ -1365,6 +1365,15 @@ PP(pp_defined)
             RETSETNO;
     }
 
+    /* Historically what followed was a switch on SvTYPE(sv), handling SVt_PVAV,
+     * SVt_PVCV, SVt_PVHV and "default". `defined &sub` is still valid syntax,
+     * hence we still need the special case PVCV code. But AVs and HVs now
+     * should never arrive here... */
+#ifdef DEBUGGING
+    assert(SvTYPE(sv) != SVt_PVAV);
+    assert(SvTYPE(sv) != SVt_PVHV);
+#endif
+
     if (UNLIKELY(SvTYPE(sv) == SVt_PVCV)) {
         if (CvROOT(sv) || CvXSUB(sv))
             defined = TRUE;


### PR DESCRIPTION
The code that handled hashes and arrays was removed by commit 2517717a8902:
    The cases for SVt_PVAV and SVt_PVHV in pp_defined are unreachable.

    Remove them, and hit to the C compiler that it's unlikely that someone used
    `defined` on a subroutine.

    These have been unreachable since `defined @array` and `defined %hash`
    became syntax errors. Whilst the same PP code is used for // and //=,
    expressions such as`@a // @b` put the left array (or hash) in scalar
    context, meaning that it always returns a define value.
    (Should we warn on these?)

However, it turns out that that the removed code was reachable by XS code
generating data structures that would be "illegal" in pure Perl (eg also
triggering "Bizarre copy of ..." errors). Hence with -DDEBUGGING, add logic
to report problematic cases, instead of silently continuing with changed
behaviour.