### PR TITLE
The different xs_handshake() failures need distinct messages

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -3420,7 +3420,7 @@ does when displayed.
   \n    line feed
   \cK   vertical tab
 
-=item %s: loadable library and perl binaries are mismatched (got handshake key %p, needed %p)
+=item %s: loadable library and perl binaries are mismatched (got %s handshake key %p, needed %p)
 
 (P) A dynamic loading library C<.so> or C<.dll> was being loaded into the
 process that was built against a different build of perl than the

--- a/util.c
+++ b/util.c
@@ -5588,6 +5588,7 @@ Perl_xs_handshake(const U32 key, void * v_my_perl, const char * file, ...)
     U32 items, ax;
     void * got;
     void * need;
+    const char *stage = "first";
 #ifdef MULTIPLICITY
     dTHX;
     tTHX xs_interp;
@@ -5624,12 +5625,13 @@ Perl_xs_handshake(const U32 key, void * v_my_perl, const char * file, ...)
     got = xs_spp;
     need = &PL_stack_sp;
 #endif
+    stage = "second";
     if(UNLIKELY(got != need)) {
         bad_handshake:/* recycle branch and string from above */
         if(got != (void *)HSf_NOCHK)
             noperl_die("%s: loadable library and perl binaries are mismatched"
-                       " (got handshake key %p, needed %p)\n",
-                file, got, need);
+                       " (got %s handshake key %p, needed %p)\n",
+                       file, stage, got, need);
     }
 
     if(key & HSf_SETXSUBFN) {     /* this might be called from a module bootstrap */


### PR DESCRIPTION
xs_handshake() makes two different comparisons that on failure are reported
as "got handshake key %p, needed %p", with opaque hexadecimal values.

The first is the "actual" key as generated by the HS_KEY() macro, which
encodes various values such as sizeof(PerlInterpreter) and the API version.
The second is the address of the current thread's PerlInterpreter struct.

Either can fail, and before this commit they would fail with identical text.
Hence it wasn't obvious what the problem was, causing "confusion and delay"
if one tried to decode the hexadecimal output as the wrong thing. (For
example when it's actually pointers mismatching, but one tries to decode the
values into API version and structure size, assuming that the values were
the packed output from HS_KEY().)