### PR TITLE
Fix a leak when copying a STATIC COW SV to a stringified SV

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -4691,6 +4691,9 @@ Perl_sv_setsv_flags(pTHX_ SV *dsv, SV* ssv, const I32 flags)
          * SV_COW_SHARED_HASH_KEYS being set or else we'll break SvIsBOOL()
          */
         else if (SvIsCOW_static(ssv)) {
+            if (SvPVX_const(dsv)) {     /* we know that dtype >= SVt_PV */
+                SvPV_free(dsv);
+            }
             SvPV_set(dsv, SvPVX(ssv));
             SvLEN_set(dsv, 0);
             SvCUR_set(dsv, cur);


### PR DESCRIPTION
This is minor a a regression introduced by commit 914bb57489325d34:
    Define a third kind of COW state; STATIC

    ...

    sv_setsv_flags() and sv_setsv_cow() will preserve this state

There was a small omission in the copy code - it didn't handle the case where
the destination SV owned a string buffer already. This is actually
relatively rare - triggering it requires a scalar in code path that is
assigned both strings and booleans. Minimal test case is:

    my $got = 1;
    $got .= "";
    $got = ref "";

cut down from &is in t/comp/parser.t