### PR TITLE
Plug PVLV REGEXP body leak

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2882,7 +2882,9 @@ po	|SV*	|hfree_next_entry	|NN HV *hv|NN STRLEN *indexp
 S	|void	|hsplit		|NN HV *hv|STRLEN const oldsize|STRLEN newsize
 S	|void	|hv_free_entries|NN HV *hv
 S	|SV*	|hv_free_ent_ret|NN HV *hv|NN HE *entry
+#if !defined(PURIFY)
 SR	|HE*	|new_he
+#endif
 SaTR	|HEK*	|save_hek_flags	|NN const char *str|I32 len|U32 hash|int flags
 ST	|void	|hv_magic_check	|NN HV *hv|NN bool *needs_copy|NN bool *needs_store
 S	|void	|unshare_hek_or_pvn|NULLOK const HEK* hek|NULLOK const char* str|I32 len|U32 hash

--- a/embed.h
+++ b/embed.h
@@ -1565,6 +1565,11 @@
 #define utf16_textfilter(a,b,c)	S_utf16_textfilter(aTHX_ a,b,c)
 #    endif
 #  endif
+#  if !defined(PURIFY)
+#    if defined(PERL_IN_HV_C)
+#define new_he()		S_new_he(aTHX)
+#    endif
+#  endif
 #  if !defined(WIN32)
 #define do_exec3(a,b,c)		Perl_do_exec3(aTHX_ a,b,c)
 #  endif
@@ -1695,7 +1700,6 @@
 #define hv_free_entries(a)	S_hv_free_entries(aTHX_ a)
 #define hv_magic_check		S_hv_magic_check
 #define hv_notallowed(a,b,c,d)	S_hv_notallowed(aTHX_ a,b,c,d)
-#define new_he()		S_new_he(aTHX)
 #define ptr_hash		S_ptr_hash
 #define refcounted_he_value(a)	S_refcounted_he_value(aTHX_ a)
 #define save_hek_flags		S_save_hek_flags

--- a/proto.h
+++ b/proto.h
@@ -4585,6 +4585,14 @@ STATIC I32	S_utf16_textfilter(pTHX_ int idx, SV *sv, int maxlen);
 	assert(sv)
 #  endif
 #endif
+#if !defined(PURIFY)
+#  if defined(PERL_IN_HV_C)
+STATIC HE*	S_new_he(pTHX)
+			__attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_NEW_HE
+
+#  endif
+#endif
 #if !defined(SETUID_SCRIPTS_ARE_SECURE_NOW)
 #  if defined(PERL_IN_PERL_C)
 STATIC void	S_validate_suid(pTHX_ PerlIO *rsfp);
@@ -5142,10 +5150,6 @@ PERL_STATIC_NO_RET void	S_hv_notallowed(pTHX_ int flags, const char *key, I32 kl
 			__attribute__noreturn__;
 #define PERL_ARGS_ASSERT_HV_NOTALLOWED	\
 	assert(key); assert(msg)
-
-STATIC HE*	S_new_he(pTHX)
-			__attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEW_HE
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
 PERL_STATIC_INLINE U32	S_ptr_hash(PTRV u);


### PR DESCRIPTION
This was leaking a body:

```
#!./perl -w

use strict;

my %h;

sub bar {
    my $r = qr/abc/;
    $_[0] = $$r;
};

bar($h{foo});
```

The leak has actually been present since 8d919b0a35f2b57a but was only exposed by tests added in 2017.

With this leak fixed, and the obscure leak in `hv.c` fixed, the testsuite is clean under `-DPURIFY`