### PR TITLE
Check for NULL locale in S_emulate_setlocale

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -553,12 +553,13 @@ S_emulate_setlocale(const int category,
     int mask;
     locale_t old_obj;
     locale_t new_obj;
+    const char * safelocale = locale ? locale : "(null)";
     dTHX;
 
 #  ifdef DEBUGGING
 
     if (DEBUG_Lv_TEST || debug_initialization) {
-        PerlIO_printf(Perl_debug_log, "%s:%d: emulate_setlocale input=%d (%s), \"%s\", %d, %d\n", __FILE__, __LINE__, category, category_name(category), locale, index, is_index_valid);
+        PerlIO_printf(Perl_debug_log, "%s:%d: emulate_setlocale input=%d (%s), \"%s\", %d, %d\n", __FILE__, __LINE__, category, category_name(category), safelocale, index, is_index_valid);
     }
 
 #  endif
@@ -586,7 +587,7 @@ S_emulate_setlocale(const int category,
          * Fallback to the early POSIX usages */
         Perl_warner(aTHX_ packWARN(WARN_LOCALE),
                             "Unknown locale category %d; can't set it to %s\n",
-                                                     category, locale);
+                                                     category, safelocale);
         return NULL;
 
       found_index: ;


### PR DESCRIPTION
gcc-11.2.0 correctly warns that it is called with NULL from Perl_switch_to_global_locale():
```
In function 'S_emulate_setlocale',
    inlined from 'Perl_switch_to_global_locale' at locale.c:5400:13:
locale.c:587:9: warning: '%s' directive argument is null [-Wformat-overflow=]
  587 |         Perl_warner(aTHX_ packWARN(WARN_LOCALE),
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  588 |                             "Unknown locale category %d; can't set it to %s\n",
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  589 |                                                      category, locale);
      |                                                      ~~~~~~~~~~~~~~~~~
```