### PR TITLE
On VMS, %ENV in scalar context must call prime_env_iter()

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -371,9 +371,18 @@ L</Modules and Pragmata> section.
 
 =over 4
 
-=item XXX-some-platform
+=item C<keys %ENV> on VMS returns consistent results
 
-XXX
+On VMS entries in the C<%ENV> hash are loaded from the OS environment on
+first access, hence the first iteration of C<%ENV> requires the entire
+environment to be scanned to find all possible keys. This initialisation had
+always been done correctly for full iteration, but previously was not
+happening for C<%ENV> in scalar context, meaning that C<scalar %ENV> would
+return 0 if called before any other C<%ENV> access, or would only return the
+count of keys accessed if there had been no iteration.
+
+These bugs are now fixed - C<%ENV> and C<keys %ENV> in scalar context now
+return the correct result - the count of all keys in the environment.
 
 =back
 

--- a/t/op/each.t
+++ b/t/op/each.t
@@ -286,6 +286,15 @@ for my $k (qw(each keys values)) {
     ok(!$warned, "no warnings 'internal' silences each() after insert warnings");
 }
 
+fresh_perl_like('$a = keys %ENV; $b = () = keys %ENV; $c = keys %ENV; print qq=$a,$b,$c=',
+                qr/^([1-9][0-9]*),\1,\1$/,
+                undef,
+                'keys %ENV in scalar context triggers prime_env_iter if needed');
+fresh_perl_like('$a = $ENV{PATH}; $a = $ENV{q=DCL$PATH=}; $a = keys %ENV; $b = () = keys %ENV; $c = keys %ENV; print qq=$a,$b,$c=',
+                qr/^([1-9][0-9]*),\1,\1$/,
+                undef,
+                '%ENV lookup, and keys %ENV in scalar context remain consistent');
+
 use feature 'refaliasing';
 no warnings 'experimental::refaliasing';
 $a = 7;


### PR DESCRIPTION
Otherwise it will return wrong results, unless other code happens to
have iterated over %ENV. This bug has probably existed forever.