### PR TITLE
Remove "skip if no PerlIO" code from tests in ext/

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4171,6 +4171,7 @@ ext/B/hints/openbsd.pl	Hints for named architecture
 ext/B/Makefile.PL	Compiler backend makefile writer
 ext/B/O.pm		Compiler front-end module (-MO=...)
 ext/B/t/b.t		See if B works
+ext/B/t/B/success.pm	Test module for ext/B/t/o.t
 ext/B/t/concise.t	See whether B::Concise works
 ext/B/t/concise-xs.t	See whether B::Concise recognizes XS functions
 ext/B/t/f_map			code from perldoc -f map

--- a/ext/B/t/B/success.pm
+++ b/ext/B/t/B/success.pm
@@ -1,0 +1,13 @@
+package B::success;
+use strict;
+
+$| = 1;
+print "Compiling!\n";
+
+sub compile {
+    return 'fail' if ($_[0] eq 'fail');
+    print "($_[0]) <$_[1]>\n";
+    return sub { print "[$O::BEGIN_output]\n" };
+}
+
+1;

--- a/ext/B/t/concise-xs.t
+++ b/ext/B/t/concise-xs.t
@@ -10,10 +10,6 @@ BEGIN {
         print "1..0 # Skip -- Perl configured without B module\n";
         exit 0;
     }
-    unless ($Config::Config{useperlio}) {
-        print "1..0 # Skip -- Perl configured without perlio\n";
-        exit 0;
-    }
 }
 
 use Carp;

--- a/ext/B/t/concise.t
+++ b/ext/B/t/concise.t
@@ -42,7 +42,6 @@ like($out, qr/print/, "'-exec' option output has print opcode");
 
 ######## API tests v.60 
 
-use Config;	# used for perlio check
 B::Concise->import(qw( set_style set_style_standard add_callback 
 		       add_style walk_output reset_sequence ));
 
@@ -70,10 +69,7 @@ eval {  walk_output($foo) };
 is ($@, '', "walk_output() accepts obj that can print");
 
 # test that walk_output accepts a HANDLE arg
-SKIP: {
-    skip("no perlio in this build", 4)
-        unless $Config::Config{useperlio};
-
+{
     foreach my $foo (\*STDOUT, \*STDERR) {
 	eval {  walk_output($foo) };
 	is ($@, '', "walk_output() accepts STD* " . ref $foo);
@@ -129,11 +125,8 @@ sub render {
     return $out;
 }
 
-SKIP: {
+{
     # tests output to GLOB, using perlio feature directly
-    skip "no perlio on this build", 127
-	unless $Config::Config{useperlio};
-    
     set_style_standard('concise');  # MUST CALL before output needed
     
     @options = qw(
@@ -413,7 +406,7 @@ $out = runperl ( switches => ["-MO=Concise,-stash=Data::Dumper,-src,-exec"],
 
 SKIP: {
     skip "Data::Dumper is statically linked", 1
-	if $Config{static_ext} =~ m|\bData/Dumper\b|;
+	if $Config::Config{static_ext} =~ m|\bData/Dumper\b|;
     like($out, qr/FUNC: \*Data::Dumper::format_refaddr/,
 	"stash rendering loads package as needed");
 }

--- a/ext/B/t/concise.t
+++ b/ext/B/t/concise.t
@@ -69,20 +69,18 @@ eval {  walk_output($foo) };
 is ($@, '', "walk_output() accepts obj that can print");
 
 # test that walk_output accepts a HANDLE arg
-{
-    foreach my $foo (\*STDOUT, \*STDERR) {
-	eval {  walk_output($foo) };
-	is ($@, '', "walk_output() accepts STD* " . ref $foo);
-    }
-
-    # now test a ref to scalar
-    eval {  walk_output(\my $junk) };
-    is ($@, '', "walk_output() accepts ref-to-sprintf target");
-
-    $junk = "non-empty";
-    eval {  walk_output(\$junk) };
-    is ($@, '', "walk_output() accepts ref-to-non-empty-scalar");
+foreach my $foo (\*STDOUT, \*STDERR) {
+    eval {  walk_output($foo) };
+    is ($@, '', "walk_output() accepts STD* " . ref $foo);
 }
+
+# now test a ref to scalar
+eval {  walk_output(\my $junk) };
+is ($@, '', "walk_output() accepts ref-to-sprintf target");
+
+$junk = "non-empty";
+eval {  walk_output(\$junk) };
+is ($@, '', "walk_output() accepts ref-to-non-empty-scalar");
 
 ## add_style
 my @stylespec;
@@ -125,226 +123,224 @@ sub render {
     return $out;
 }
 
-{
-    # tests output to GLOB, using perlio feature directly
-    set_style_standard('concise');  # MUST CALL before output needed
-    
-    @options = qw(
-		  -basic -exec -tree -compact -loose -vt -ascii
-		  -base10 -bigendian -littleendian
-		  );
-    foreach $opt (@options) {
-	($out) = render($opt, $func);
-	isnt($out, '', "got output with option $opt");
-    }
-    
-    ## test output control via walk_output
-    
-    my $treegen = B::Concise::compile('-basic', $func); # reused
-    
-    { # test output into a package global string (sprintf-ish)
-	our $thing;
-	walk_output(\$thing);
-	$treegen->();
-	ok($thing, "walk_output to our SCALAR, output seen");
-    }
-    
-    # test walkoutput acceptance of a scalar-bound IO handle
-    open (my $fh, '>', \my $buf);
-    walk_output($fh);
+# tests output to GLOB, using perlio feature directly
+set_style_standard('concise');  # MUST CALL before output needed
+
+@options = qw(
+                 -basic -exec -tree -compact -loose -vt -ascii
+                 -base10 -bigendian -littleendian
+         );
+foreach $opt (@options) {
+    ($out) = render($opt, $func);
+    isnt($out, '', "got output with option $opt");
+}
+
+## test output control via walk_output
+
+my $treegen = B::Concise::compile('-basic', $func); # reused
+
+{ # test output into a package global string (sprintf-ish)
+    our $thing;
+    walk_output(\$thing);
     $treegen->();
-    ok($buf, "walk_output to GLOB, output seen");
-    
-    ## test B::Concise::compile error checking
-    
-    # call compile on non-CODE ref items
-    if (0) {
-	# pending STASH splaying
-	
-	foreach my $ref ([], {}) {
-	    my $typ = ref $ref;
-	    walk_output(\my $out);
-	    eval { B::Concise::compile('-basic', $ref)->() };
-	    like ($@, qr/^err: not a coderef: $typ/,
-		  "compile detects $typ-ref where expecting subref");
-	    is($out,'', "no output when errd"); # announcement prints
-	}
+    ok($thing, "walk_output to our SCALAR, output seen");
+}
+
+# test walkoutput acceptance of a scalar-bound IO handle
+open (my $fh, '>', \my $buf);
+walk_output($fh);
+$treegen->();
+ok($buf, "walk_output to GLOB, output seen");
+
+## test B::Concise::compile error checking
+
+# call compile on non-CODE ref items
+if (0) {
+    # pending STASH splaying
+
+    foreach my $ref ([], {}) {
+        my $typ = ref $ref;
+        walk_output(\my $out);
+        eval { B::Concise::compile('-basic', $ref)->() };
+        like ($@, qr/^err: not a coderef: $typ/,
+              "compile detects $typ-ref where expecting subref");
+        is($out,'', "no output when errd"); # announcement prints
     }
-    
-    # test against a bogus autovivified subref.
-    # in debugger, it should look like:
-    #  1  CODE(0x84840cc)
-    #      -> &CODE(0x84840cc) in ???
+}
 
-    my ($res,$err);
-    TODO: {
-	#local $TODO = "\tdoes this handling make sense ?";
+# test against a bogus autovivified subref.
+# in debugger, it should look like:
+#  1  CODE(0x84840cc)
+#      -> &CODE(0x84840cc) in ???
 
-	sub declared_only;
-	($res,$err) = render('-basic', \&declared_only);
-	like ($res, qr/coderef CODE\(0x[0-9a-fA-F]+\) has no START/,
-	      "'sub decl_only' seen as having no START");
+my ($res,$err);
+TODO: {
+    #local $TODO = "\tdoes this handling make sense ?";
 
-	sub defd_empty {};
-	($res,$err) = render('-basic', \&defd_empty);
-	my @lines = split(/\n/, $res);
-	is(scalar @lines, 3,
-	   "'sub defd_empty {}' seen as 3 liner");
+    sub declared_only;
+    ($res,$err) = render('-basic', \&declared_only);
+    like ($res, qr/coderef CODE\(0x[0-9a-fA-F]+\) has no START/,
+          "'sub decl_only' seen as having no START");
 
-	is(1, $res =~ /leavesub/ && $res =~ /(next|db)state/,
-	   "'sub defd_empty {}' seen as 2 ops: leavesub,nextstate");
+    sub defd_empty {};
+    ($res,$err) = render('-basic', \&defd_empty);
+    my @lines = split(/\n/, $res);
+    is(scalar @lines, 3,
+       "'sub defd_empty {}' seen as 3 liner");
 
-	($res,$err) = render('-basic', \&not_even_declared);
-	like ($res, qr/coderef CODE\(0x[0-9a-fA-F]+\) has no START/,
-	      "'\&not_even_declared' seen as having no START");
+    is(1, $res =~ /leavesub/ && $res =~ /(next|db)state/,
+       "'sub defd_empty {}' seen as 2 ops: leavesub,nextstate");
 
-	{
-	    package Bar;
-	    our $AUTOLOAD = 'garbage';
-	    sub AUTOLOAD { print "# in AUTOLOAD body: $AUTOLOAD\n" }
-	}
-	($res,$err) = render('-basic', Bar::auto_func);
-	like ($res, qr/unknown function \(Bar::auto_func\)/,
-	      "Bar::auto_func seen as unknown function");
+    ($res,$err) = render('-basic', \&not_even_declared);
+    like ($res, qr/coderef CODE\(0x[0-9a-fA-F]+\) has no START/,
+          "'\&not_even_declared' seen as having no START");
 
-	($res,$err) = render('-basic', \&Bar::auto_func);
-	like ($res, qr/coderef CODE\(0x[0-9a-fA-F]+\) has no START/,
-	      "'\&Bar::auto_func' seen as having no START");
-
-	($res,$err) = render('-basic', \&Bar::AUTOLOAD);
-	like ($res, qr/in AUTOLOAD body: /, "found body of Bar::AUTOLOAD");
-
+    {
+        package Bar;
+        our $AUTOLOAD = 'garbage';
+        sub AUTOLOAD { print "# in AUTOLOAD body: $AUTOLOAD\n" }
     }
-    ($res,$err) = render('-basic', Foo::bar);
-    like ($res, qr/unknown function \(Foo::bar\)/,
-	  "BC::compile detects fn-name as unknown function");
+    ($res,$err) = render('-basic', Bar::auto_func);
+    like ($res, qr/unknown function \(Bar::auto_func\)/,
+          "Bar::auto_func seen as unknown function");
 
-    # v.62 tests
+    ($res,$err) = render('-basic', \&Bar::auto_func);
+    like ($res, qr/coderef CODE\(0x[0-9a-fA-F]+\) has no START/,
+          "'\&Bar::auto_func' seen as having no START");
 
-    pass ("TEST POST-COMPILE OPTION-HANDLING IN WALKER SUBROUTINE");
-    
-    my $sample;
+    ($res,$err) = render('-basic', \&Bar::AUTOLOAD);
+    like ($res, qr/in AUTOLOAD body: /, "found body of Bar::AUTOLOAD");
 
-    my $walker = B::Concise::compile('-basic', $func);
-    walk_output(\$sample);
-    $walker->('-exec');
-    like($sample, qr/goto/m, "post-compile -exec");
+}
+($res,$err) = render('-basic', Foo::bar);
+like ($res, qr/unknown function \(Foo::bar\)/,
+      "BC::compile detects fn-name as unknown function");
 
-    walk_output(\$sample);
-    $walker->('-basic');
-    unlike($sample, qr/goto/m, "post-compile -basic");
+# v.62 tests
+
+pass ("TEST POST-COMPILE OPTION-HANDLING IN WALKER SUBROUTINE");
+
+my $sample;
+
+my $walker = B::Concise::compile('-basic', $func);
+walk_output(\$sample);
+$walker->('-exec');
+like($sample, qr/goto/m, "post-compile -exec");
+
+walk_output(\$sample);
+$walker->('-basic');
+unlike($sample, qr/goto/m, "post-compile -basic");
 
 
-    # bang at it combinatorically
-    my %combos;
-    my @modes = qw( -basic -exec );
-    my @styles = qw( -concise -debug -linenoise -terse );
+# bang at it combinatorically
+my %combos;
+my @modes = qw( -basic -exec );
+my @styles = qw( -concise -debug -linenoise -terse );
 
-    # prep samples
+# prep samples
+for $style (@styles) {
+    for $mode (@modes) {
+        walk_output(\$sample);
+        reset_sequence();
+        $walker->($style, $mode);
+        $combos{"$style$mode"} = $sample;
+    }
+}
+# crosscheck that samples are all text-different
+@list = sort keys %combos;
+for $i (0..$#list) {
+    for $j ($i+1..$#list) {
+        isnt ($combos{$list[$i]}, $combos{$list[$j]},
+              "combos for $list[$i] and $list[$j] are different, as expected");
+    }
+}
+
+# add samples with styles in different order
+for $mode (@modes) {
     for $style (@styles) {
-	for $mode (@modes) {
-	    walk_output(\$sample);
-	    reset_sequence();
-	    $walker->($style, $mode);
-	    $combos{"$style$mode"} = $sample;
-	}
+        reset_sequence();
+        walk_output(\$sample);
+        $walker->($mode, $style);
+        $combos{"$mode$style"} = $sample;
     }
-    # crosscheck that samples are all text-different
-    @list = sort keys %combos;
-    for $i (0..$#list) {
-	for $j ($i+1..$#list) {
-	    isnt ($combos{$list[$i]}, $combos{$list[$j]},
-		  "combos for $list[$i] and $list[$j] are different, as expected");
-	}
-    }
-    
-    # add samples with styles in different order
-    for $mode (@modes) {
-	for $style (@styles) {
-	    reset_sequence();
-	    walk_output(\$sample);
-	    $walker->($mode, $style);
-	    $combos{"$mode$style"} = $sample;
-	}
-    }
-    # test commutativity of flags, ie that AB == BA
-    for $mode (@modes) {
-	for $style (@styles) {
-	    is ( $combos{"$style$mode"},
-		 $combos{"$mode$style"},
-		 "results for $style$mode vs $mode$style are the same" );
-	}
-    }
-
-    my %save = %combos;
-    %combos = ();	# outputs for $mode=any($order) and any($style)
-
-    # add more samples with switching modes & sticky styles
+}
+# test commutativity of flags, ie that AB == BA
+for $mode (@modes) {
     for $style (@styles) {
-	walk_output(\$sample);
-	reset_sequence();
-	$walker->($style);
-	for $mode (@modes) {
-	    walk_output(\$sample);
-	    reset_sequence();
-	    $walker->($mode);
-	    $combos{"$style/$mode"} = $sample;
-	}
+        is ( $combos{"$style$mode"},
+             $combos{"$mode$style"},
+             "results for $style$mode vs $mode$style are the same" );
     }
-    # crosscheck that samples are all text-different
-    @nm = sort keys %combos;
-    for $i (0..$#nm) {
-	for $j ($i+1..$#nm) {
-	    isnt ($combos{$nm[$i]}, $combos{$nm[$j]},
-		  "results for $nm[$i] and $nm[$j] are different, as expected");
-	}
-    }
-    
-    # add samples with switching styles & sticky modes
+}
+
+my %save = %combos;
+%combos = ();	# outputs for $mode=any($order) and any($style)
+
+# add more samples with switching modes & sticky styles
+for $style (@styles) {
+    walk_output(\$sample);
+    reset_sequence();
+    $walker->($style);
     for $mode (@modes) {
-	walk_output(\$sample);
-	reset_sequence();
-	$walker->($mode);
-	for $style (@styles) {
-	    walk_output(\$sample);
-	    reset_sequence();
-	    $walker->($style);
-	    $combos{"$mode/$style"} = $sample;
-	}
+        walk_output(\$sample);
+        reset_sequence();
+        $walker->($mode);
+        $combos{"$style/$mode"} = $sample;
     }
-    # test commutativity of flags, ie that AB == BA
-    for $mode (@modes) {
-	for $style (@styles) {
-	    is ( $combos{"$style/$mode"},
-		 $combos{"$mode/$style"},
-		 "results for $style/$mode vs $mode/$style are the same" );
-	}
+}
+# crosscheck that samples are all text-different
+@nm = sort keys %combos;
+for $i (0..$#nm) {
+    for $j ($i+1..$#nm) {
+        isnt ($combos{$nm[$i]}, $combos{$nm[$j]},
+              "results for $nm[$i] and $nm[$j] are different, as expected");
     }
+}
+
+# add samples with switching styles & sticky modes
+for $mode (@modes) {
+    walk_output(\$sample);
+    reset_sequence();
+    $walker->($mode);
+    for $style (@styles) {
+        walk_output(\$sample);
+        reset_sequence();
+        $walker->($style);
+        $combos{"$mode/$style"} = $sample;
+    }
+}
+# test commutativity of flags, ie that AB == BA
+for $mode (@modes) {
+    for $style (@styles) {
+        is ( $combos{"$style/$mode"},
+             $combos{"$mode/$style"},
+             "results for $style/$mode vs $mode/$style are the same" );
+    }
+}
 
 
-    #now do double crosschecks: commutativity across stick / nostick
-    %combos = (%combos, %save);
+#now do double crosschecks: commutativity across stick / nostick
+%combos = (%combos, %save);
 
-    # test commutativity of flags, ie that AB == BA
-    for $mode (@modes) {
-	for $style (@styles) {
+# test commutativity of flags, ie that AB == BA
+for $mode (@modes) {
+    for $style (@styles) {
 
-	    is ( $combos{"$style$mode"},
-		 $combos{"$style/$mode"},
-		 "$style$mode VS $style/$mode are the same" );
+        is ( $combos{"$style$mode"},
+             $combos{"$style/$mode"},
+             "$style$mode VS $style/$mode are the same" );
 
-	    is ( $combos{"$mode$style"},
-		 $combos{"$mode/$style"},
-		 "$mode$style VS $mode/$style are the same" );
+        is ( $combos{"$mode$style"},
+             $combos{"$mode/$style"},
+             "$mode$style VS $mode/$style are the same" );
 
-	    is ( $combos{"$style$mode"},
-		 $combos{"$mode/$style"},
-		 "$style$mode VS $mode/$style are the same" );
+        is ( $combos{"$style$mode"},
+             $combos{"$mode/$style"},
+             "$style$mode VS $mode/$style are the same" );
 
-	    is ( $combos{"$mode$style"},
-		 $combos{"$style/$mode"},
-		 "$mode$style VS $style/$mode are the same" );
-	}
+        is ( $combos{"$mode$style"},
+             $combos{"$style/$mode"},
+             "$mode$style VS $style/$mode are the same" );
     }
 }
 

--- a/ext/B/t/f_map.t
+++ b/ext/B/t/f_map.t
@@ -7,10 +7,6 @@ BEGIN {
         print "1..0 # Skip -- Perl configured without B module\n";
         exit 0;
     }
-    if (!$Config::Config{useperlio}) {
-        print "1..0 # Skip -- need perlio to walk the optree\n";
-        exit 0;
-    }
 }
 use OptreeCheck;
 plan tests => 18;
@@ -19,14 +15,6 @@ plan tests => 18;
 =head1 f_map.t
 
 Code test snippets here are adapted from `perldoc -f map`
-
-Due to a bleadperl optimization (Dave Mitchell, circa may 04), the
-(map|grep)(start|while) opcodes have different flags in 5.9, their
-private flags /1, /2 are gone in blead (for the cases covered)
-
-When the optree stuff was integrated into 5.8.6, these tests failed,
-and were todo'd.  They're now done, by version-specific tweaking in
-mkCheckRex(), therefore the skip is removed too.
 
 =for gentest
 

--- a/ext/B/t/f_sort.t
+++ b/ext/B/t/f_sort.t
@@ -7,10 +7,6 @@ BEGIN {
         print "1..0 # Skip -- Perl configured without B module\n";
         exit 0;
     }
-    if (!$Config::Config{useperlio}) {
-        print "1..0 # Skip -- need perlio to walk the optree\n";
-        exit 0;
-    }
 }
 use OptreeCheck;
 plan tests => 38;
@@ -18,14 +14,6 @@ plan tests => 38;
 =head1 f_sort.t
 
 Code test snippets here are adapted from `perldoc -f map`
-
-Due to a bleadperl optimization (Dave Mitchell, circa apr 04), the
-(map|grep)(start|while) opcodes have different flags in 5.9, their
-private flags /1, /2 are gone in blead (for the cases covered)
-
-When the optree stuff was integrated into 5.8.6, these tests failed,
-and were todo'd.  They're now done, by version-specific tweaking in
-mkCheckRex(), therefore the skip is removed too.
 
 =head1 Test Notes
 

--- a/ext/B/t/o.t
+++ b/ext/B/t/o.t
@@ -11,19 +11,6 @@ BEGIN {
 }
 
 use strict;
-use File::Spec;
-use File::Path;
-
-my $path = File::Spec->catdir( 'lib', 'B' );
-unless (-d $path) {
-	mkpath( $path ) or skip_all( 'Cannot create fake module path' );
-}
-
-my $file = File::Spec->catfile( $path, 'success.pm' );
-local *OUT;
-open(OUT, '>', $file) or skip_all( 'Cannot write fake backend module');
-print OUT while <DATA>;
-close *OUT;
 
 plan( 9 ); # And someone's responsible.
 
@@ -51,25 +38,6 @@ like( $lines[1], qr/fail at .eval/,
 
 sub get_lines {
     my $compile = shift;
-	split(/[\r\n]+/, runperl( switches => [ '-Ilib', $compile ],
-				  prog => 1, stderr => 1 ));
+    split(/[\r\n]+/, runperl( switches => [ '-Ilib', '-It', $compile ],
+                              prog => 1, stderr => 1 ));
 }
-
-END {
-	1 while unlink($file);
-	rmdir($path); # not "1 while" since there might be more in there
-}
-
-__END__
-package B::success;
-
-$| = 1;
-print "Compiling!\n";
-
-sub compile {
-	return 'fail' if ($_[0] eq 'fail');
-	print "($_[0]) <$_[1]>\n";
-	return sub { print "[$O::BEGIN_output]\n" };
-}
-
-1;

--- a/ext/B/t/o.t
+++ b/ext/B/t/o.t
@@ -11,7 +11,6 @@ BEGIN {
 }
 
 use strict;
-use Config;
 use File::Spec;
 use File::Path;
 
@@ -41,14 +40,10 @@ is( $lines[3], '-e syntax OK', 'O.pm should not munge perl output without -qq');
 @lines = get_lines( '-MO=-q,success,foo,bar' );
 isnt( $lines[1], 'Compiling!', 'Output should not be printed with -q switch' );
 
-SKIP: {
-	skip( '-q redirection does not work without PerlIO', 2)
-		unless $Config{useperlio};
-	is( $lines[1], "[Compiling!", '... but should be in $O::BEGIN_output' );
+is( $lines[1], "[Compiling!", '... but should be in $O::BEGIN_output' );
 
-	@lines = get_lines( '-MO=-qq,success,foo,bar' );
-	is( scalar @lines, 3, '-qq should suppress even the syntax OK message' );
-}
+@lines = get_lines( '-MO=-qq,success,foo,bar' );
+is( scalar @lines, 3, '-qq should suppress even the syntax OK message' );
 
 @lines = get_lines( '-MO=success,fail' );
 like( $lines[1], qr/fail at .eval/,

--- a/ext/B/t/optree_check.t
+++ b/ext/B/t/optree_check.t
@@ -7,10 +7,6 @@ BEGIN {
         print "1..0 # Skip -- Perl configured without B module\n";
         exit 0;
     }
-    if (!$Config::Config{useperlio}) {
-        print "1..0 # Skip -- need perlio to walk the optree\n";
-        exit 0;
-    }
 }
 
 use OptreeCheck;

--- a/ext/B/t/optree_concise.t
+++ b/ext/B/t/optree_concise.t
@@ -7,15 +7,10 @@ BEGIN {
         print "1..0 # Skip -- Perl configured without B module\n";
         exit 0;
     }
-    if (!$Config::Config{useperlio}) {
-        print "1..0 # Skip -- need perlio to walk the optree\n";
-        exit 0;
-    }
 }
 
 # import checkOptree(), and %gOpts (containing test state)
 use OptreeCheck;	# ALSO DOES @ARGV HANDLING !!!!!!
-use Config;
 
 plan tests => 41;
 

--- a/ext/B/t/optree_constants.t
+++ b/ext/B/t/optree_constants.t
@@ -7,14 +7,9 @@ BEGIN {
         print "1..0 # Skip -- Perl configured without B module\n";
         exit 0;
     }
-    if (!$Config::Config{useperlio}) {
-        print "1..0 # Skip -- need perlio to walk the optree\n";
-        exit 0;
-    }
 }
 
 use OptreeCheck;	# ALSO DOES @ARGV HANDLING !!!!!!
-use Config;
 
 plan tests => 99;
 

--- a/ext/B/t/optree_misc.t
+++ b/ext/B/t/optree_misc.t
@@ -9,11 +9,7 @@ BEGIN {
     }
 }
 use OptreeCheck;
-use Config;
 plan tests => 18;
-
-SKIP: {
-skip "no perlio in this build", 4 unless $Config::Config{useperlio};
 
 # The regression this was testing is that the first aelemfast, derived
 # from a lexical array, is supposed to be a BASEOP "<0>", while the
@@ -84,8 +80,6 @@ EOT_EOT
 # -           <1> ex-rv2sv sK/1 ->4
 # 3              <$> gvsv(*1) s ->4
 EONT_EONT
-
-} #skip
 
 my $t = <<'EOT_EOT';
 # 8  <@> leave[1 ref] vKP/REFC ->(end)

--- a/ext/B/t/optree_samples.t
+++ b/ext/B/t/optree_samples.t
@@ -7,13 +7,8 @@ BEGIN {
         print "1..0 # Skip -- Perl configured without B module\n";
         exit 0;
     }
-    if (!$Config::Config{useperlio}) {
-        print "1..0 # Skip -- need perlio to walk the optree\n";
-        exit 0;
-    }
 }
 use OptreeCheck;
-use Config;
 plan tests	=> 46;
 
 pass("GENERAL OPTREE EXAMPLES");

--- a/ext/B/t/optree_sort.t
+++ b/ext/B/t/optree_sort.t
@@ -7,13 +7,8 @@ BEGIN {
         print "1..0 # Skip -- Perl configured without B module\n";
         exit 0;
     }
-    if (!$Config::Config{useperlio}) {
-        print "1..0 # Skip -- need perlio to walk the optree\n";
-        exit 0;
-    }
 }
 use OptreeCheck;
-use Config;
 plan tests => 21;
 
 pass("SORT OPTIMIZATION");

--- a/ext/B/t/optree_specials.t
+++ b/ext/B/t/optree_specials.t
@@ -24,7 +24,6 @@ BEGIN {
 
 # import checkOptree(), and %gOpts (containing test state)
 use OptreeCheck;	# ALSO DOES @ARGV HANDLING !!!!!!
-use Config;
 
 plan tests => 15;
 

--- a/ext/B/t/optree_varinit.t
+++ b/ext/B/t/optree_varinit.t
@@ -7,13 +7,8 @@ BEGIN {
         print "1..0 # Skip -- Perl configured without B module\n";
         exit 0;
     }
-    if (!$Config::Config{useperlio}) {
-        print "1..0 # Skip -- need perlio to walk the optree\n";
-        exit 0;
-    }
 }
 use OptreeCheck;
-use Config;
 plan tests	=> 42;
 
 pass("OPTIMIZER TESTS - VAR INITIALIZATION");

--- a/ext/B/t/showlex.t
+++ b/ext/B/t/showlex.t
@@ -13,7 +13,6 @@ BEGIN {
 $| = 1;
 use warnings;
 use strict;
-use Config;
 use B::Showlex ();
 
 plan tests => 15;
@@ -48,10 +47,6 @@ for $newlex ('', '-newlex') {
     like ($out, qr/2: $nb/ms, 'found $b in "my ($a,$b)"');
 
     print $out if $verbose;
-
-SKIP: {
-    skip "no perlio in this build", 5
-    unless $Config::Config{useperlio};
 
     our $buf = 'arb startval';
     my $ak = B::Showlex::walk_output (\$buf);
@@ -101,5 +96,4 @@ SKIP: {
     $walker = B::Concise::compile($asub, '-exec');
     $walker->();
 
-}
 }

--- a/ext/PerlIO-encoding/t/encoding.t
+++ b/ext/PerlIO-encoding/t/encoding.t
@@ -1,10 +1,6 @@
 #!./perl -w
 
 BEGIN {
-    unless (find PerlIO::Layer 'perlio') {
-	print "1..0 # Skip: not perlio\n";
-	exit 0;
-    }
     unless (eval { require Encode } ) {
 	print "1..0 # Skip: not Encode\n";
 	exit 0;

--- a/ext/PerlIO-encoding/t/nolooping.t
+++ b/ext/PerlIO-encoding/t/nolooping.t
@@ -8,12 +8,9 @@ BEGIN {
     }
 }
 
-use Config;
-
-use Test::More (ord("A") == 65 && $Config{useperlio})
+use Test::More ord("A") == 65
                ? (tests => 1)
-               : (skip_all => '(No PerlIO enabled;'
-                            . ' or is EBCDIC platform which doesnt have'
+               : (skip_all => 'EBCDIC platform which doesnt have'
                             . ' "use encoding" used by open ":locale")');
 BEGIN {
     $SIG{__WARN__} = sub { $warn .= $_[0] };

--- a/ext/PerlIO-scalar/t/scalar.t
+++ b/ext/PerlIO-scalar/t/scalar.t
@@ -1,10 +1,6 @@
 #!./perl
 
 BEGIN {
-    unless (find PerlIO::Layer 'perlio') {
-	print "1..0 # Skip: not perlio\n";
-	exit 0;
-    }
     require Config;
     if (($Config::Config{'extensions'} !~ m!\bPerlIO/scalar\b!) ){
         print "1..0 # Skip -- Perl configured without PerlIO::scalar module\n";
@@ -353,7 +349,7 @@ sub has_trailing_nul(\$) {
     return $trailing eq "\0";
 }
 SKIP: {
-    if ($Config::Config{'extensions'} !~ m!\bPerlIO/scalar\b!) {
+    if ($Config::Config{'extensions'} !~ m!\bB\b!) {
 	skip "no B", 4;
     }
     require B;

--- a/ext/PerlIO-via/t/thread.t
+++ b/ext/PerlIO-via/t/thread.t
@@ -1,9 +1,5 @@
 #!perl
 BEGIN {
-    unless (find PerlIO::Layer 'perlio') {
-	print "1..0 # Skip: not perlio\n";
-	exit 0;
-    }
     require Config;
     unless ($Config::Config{'usethreads'}) {
         print "1..0 # Skip -- need threads for this test\n";

--- a/ext/PerlIO-via/t/via.t
+++ b/ext/PerlIO-via/t/via.t
@@ -1,10 +1,6 @@
 #!./perl
 
 BEGIN {
-    unless (find PerlIO::Layer 'perlio') {
-	print "1..0 # Skip: not perlio\n";
-	exit 0;
-    }
     require Config;
     if (($Config::Config{'extensions'} !~ m!\bPerlIO/via\b!) ){
         print "1..0 # Skip -- Perl configured without PerlIO::via module\n";


### PR DESCRIPTION
It's been 9 years since we disabled the ability to `Configure` without PerlIO, hence all these bits of conditional logic are dead code and should go.

I left the similar code in tests in `t/` (for now) as *micro*perl isn't configured, and builds without PerlIO (if it builds at all). I'm not sure whether microperl is supposed to attempt tests, and also what the future holds for it, so didn't want to get digressed and delay these improvements.