### PR TITLE
Use fabs/fabsl/fabsq for NVs in pp_abs

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -2261,7 +2261,7 @@ You probably want to be using L<C</INT2PTR>> instead.
 #       define Perl_cos cosl
 #       define Perl_cosh coshl
 #       define Perl_exp expl
-/* no Perl_fabs, but there's PERL_ABS */
+#       define Perl_fabs fabsl
 #       define Perl_floor floorl
 #       define Perl_fmod fmodl
 #       define Perl_log logl
@@ -2340,7 +2340,7 @@ extern long double Perl_my_frexpl(long double x, int *e);
 #   define Perl_cos cosq
 #   define Perl_cosh coshq
 #   define Perl_exp expq
-/* no Perl_fabs, but there's PERL_ABS */
+#   define Perl_fabs fabsq
 #   define Perl_floor floorq
 #   define Perl_fmod fmodq
 #   define Perl_log logq
@@ -2386,7 +2386,7 @@ extern long double Perl_my_frexpl(long double x, int *e);
 #   define Perl_cos cos
 #   define Perl_cosh cosh
 #   define Perl_exp exp
-/* no Perl_fabs, but there's PERL_ABS */
+#   define Perl_fabs fabs
 #   define Perl_floor floor
 #   define Perl_fmod fmod
 #   define Perl_log log

--- a/pp.c
+++ b/pp.c
@@ -3057,10 +3057,7 @@ PP(pp_abs)
         }
       } else{
         const NV value = SvNV_nomg(sv);
-        if (value < 0.0)
-          SETn(-value);
-        else
-          SETn(value);
+        SETn(Perl_fabs(value));
       }
     }
     return NORMAL;


### PR DESCRIPTION
In many floating point formats, `fabs*()` are rather simple operations such as just clearing the sign bit, and will be slightly faster and compacter than a conditional negation (especially with optimizing compilers).