### PR TITLE
Test SvIsBOOL using XS::APItest

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4512,6 +4512,8 @@ ext/XS-APItest/t/Block.pm	Helper for ./blockhooks.t
 ext/XS-APItest/t/blockasexpr.t	test recursive descent block parsing
 ext/XS-APItest/t/blockhooks.t	XS::APItest: tests for PL_blockhooks
 ext/XS-APItest/t/blockhooks-csc.t	XS::APItest: more tests for PL_blockhooks
+ext/XS-APItest/t/boolean.t	test SvIsBOOL
+ext/XS-APItest/t/boolean-thr.t	test SvIsBOOL on threads
 ext/XS-APItest/t/bootstrap.t	XS::APItest: test APItest.bs
 ext/XS-APItest/t/call.t		Test calling perl from C
 ext/XS-APItest/t/call_checker.t	test call checker plugin API

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -4304,6 +4304,13 @@ CODE:
 OUTPUT:
     RETVAL
 
+bool
+SvIsBOOL(SV *sv)
+CODE:
+    RETVAL = SvIsBOOL(sv);
+OUTPUT:
+    RETVAL
+
 void
 setup_addissub()
 CODE:

--- a/ext/XS-APItest/t/boolean-thr.t
+++ b/ext/XS-APItest/t/boolean-thr.t
@@ -1,0 +1,38 @@
+#!./perl
+
+use strict;
+use warnings;
+
+use Config ();
+use if !$Config::Config{usethreads}, 'Test::More',
+    skip_all => "This perl does not support threads";
+
+use Test::More;
+use XS::APItest;
+
+use threads;
+use threads::shared;
+
+ok(threads->create( sub { SvIsBOOL($_[0]) }, !!0 )->join,
+    'value in to thread is bool');
+
+ok(SvIsBOOL(threads->create( sub { return !!0 } )->join),
+    'value out of thread is bool');
+
+{
+    my $var = !!0;
+    ok(threads->create( sub { SvIsBOOL($var) } )->join,
+        'variable captured by thread is bool');
+}
+
+{
+    my $sharedvar :shared = !!0;
+
+    ok(SvIsBOOL($sharedvar),
+        ':shared variable is bool outside');
+
+    ok(threads->create( sub { SvIsBOOL($sharedvar) } )->join,
+        ':shared variable is bool inside thread');
+}
+
+done_testing;

--- a/ext/XS-APItest/t/boolean.t
+++ b/ext/XS-APItest/t/boolean.t
@@ -1,0 +1,46 @@
+#!./perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use XS::APItest;
+
+# basic constants
+{
+    ok(SvIsBOOL(!!0), 'false is boolean');
+    ok(SvIsBOOL(!!1), 'true is boolean');
+
+    ok(!SvIsBOOL(0), '0 is not boolean');
+    ok(!SvIsBOOL(1), '1 is not boolean');
+    ok(!SvIsBOOL(""), '"" is not boolean');
+}
+
+# variables
+{
+    my $falsevar = !!0;
+    my $truevar  = !!1;
+
+    ok(SvIsBOOL($falsevar), 'false var is boolean');
+    ok(SvIsBOOL($truevar),  'true var is boolean');
+
+    my $str = "$truevar";
+    my $num = $truevar + 0;
+
+    ok(!SvIsBOOL($str), 'stringified true is not boolean');
+    ok(!SvIsBOOL($num), 'numified true is not boolean');
+
+    ok(SvIsBOOL($truevar), 'true var remains boolean after stringification and numification');
+}
+
+# aggregate members
+{
+    my %hash = ( false => !!0, true => !!1 );
+
+    ok(SvIsBOOL($hash{false}), 'false HELEM is boolean');
+    ok(SvIsBOOL($hash{true}),  'true HELEM is boolean');
+
+    # We won't test AELEM but it's likely to be the same
+}
+
+done_testing;


### PR DESCRIPTION
I recently added SvIsBOOL and tested it via Scalar::Util, but really I should have tested it directly in core.

This PR copies most of the unit tests out of `cpan/Scalar-List-Util` into the XS APItest area, so it's more core-ish. I can then delete most of them from the CPAN side later.

The tests about tied variables aren't copied, because those test a specific part of the Scalar::Util XS wrapping function, rather than the actual core macro.