### PR TITLE
untie should release the tie'd hashes iterator state

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -418,7 +418,39 @@ files in F<ext/> and F<lib/> are best summarized in L</Modules and Pragmata>.
 
 =item *
 
-XXX
+Calling C<untie> on a tied hash that is partway through iteration now frees the
+iteration state immediately.
+
+Iterating a tied hash causes perl to store a copy of the current hash key to
+track the iteration state, with this stored copy passed as the second parameter
+to C<NEXTKEY>. This internal state is freed immediately when tie hash iteration
+completes, or if the hash is destroyed, but due to an implementation oversight,
+it was not freed if the hash was untied. In that case, the internal copy of the
+key would persist until the earliest of
+
+=over 4
+
+=item 1
+
+C<tie> was called again on the same hash
+
+=item 2
+
+The (now untied) hash was iterated (ie passed to any of C<keys>, C<values> or
+C<each>)
+
+=item 3
+
+The hash was destroyed.
+
+=back
+
+This inconsistency is now fixed - the internal state is now freed immediately by
+C<untie>.
+
+As the precise timing of this behaviour can be observed with pure Perl code
+(the timing of C<DESTROY> on objects returned from C<FIRSTKEY> and C<NEXTKEY>)
+it's just possible that some code is sensitive to it.
 
 =back
 

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -1033,6 +1033,18 @@ PP(pp_untie)
         }
     }
     sv_unmagic(sv, how) ;
+
+    if (SvTYPE(sv) == SVt_PVHV) {
+        /* If the tied hash was partway through iteration, free the iterator and
+         * any key that it is pointing to. */
+        HE *entry;
+        if (HvLAZYDEL(sv) && (entry = HvEITER_get((HV *)sv))) {
+            HvLAZYDEL_off(sv);
+            hv_free_ent((HV *)sv, entry);
+            HvEITER_set(MUTABLE_HV(sv), 0);
+        }
+    }
+
     RETPUSHYES;
 }
 

--- a/t/op/tie.t
+++ b/t/op/tie.t
@@ -1622,3 +1622,82 @@ EXPECT
 leaving
 destroy
 left
+########
+# This is not intended as a test of *correctness*. The precise ordering of all
+# the events here is observable by code on CPAN, so potentially some of it will
+# inadvertently be relying on it (and likely not in any regression test)
+# Hence this "test" here is intended as a way to alert us if any core code
+# change has the side effect of alerting this observable behaviour, so that we
+# can document it in the perldelta.
+package Note {
+    sub new {
+        my ($class, $note) = @_;
+        bless \$note, $class;
+    }
+
+    sub DESTROY {
+        my $self = shift;
+        print "Destroying $$self\n";
+    }
+};
+
+package Infinity {
+    sub TIEHASH {
+        my $zero = 0;
+        bless \$zero, shift;
+    }
+
+    sub FIRSTKEY {
+        my $self = shift;
+        Note->new($$self);
+    }
+
+    sub NEXTKEY {
+        my $self = shift;
+        Note->new(++$$self);
+    }
+};
+
+# Iteration on tied hashes is implemented by storing a copy of the last reported
+# key within the hash, passing it to NEXTKEY, and then freeing it (in order to
+# store the SV for the newly returned key)
+
+# Here FIRSTKEY/NEXTKEY return keys that are references to objects...
+
+my %h;
+tie %h, 'Infinity';
+
+my $k;
+print "Start\n";
+$k = each %h;
+printf "FIRSTKEY is %s %s\n", ref $k, $$k;
+
+# each calls iternext_flags, hence this is where the previous key is freed
+
+$k = each %h;
+printf "NEXTKEY is %s %s\n", ref $k, $$k;
+undef $k;
+# Our reference to the object is gone, but a reference remains within %h, so
+# DESTROY isn't triggered.
+
+print "Before untie\n";
+untie %h;
+print "After untie\n";
+
+# Currently if tied hash iteration is incomplete at the untie, the SV recording
+# the last returned key is only freed if regular hash iteration is attempted.
+
+print "Before regular iteration\n";
+$k = each %h;
+print "After regular iteration\n";
+
+EXPECT
+Start
+FIRSTKEY is Note 0
+Destroying 0
+NEXTKEY is Note 1
+Before untie
+After untie
+Before regular iteration
+Destroying 1
+After regular iteration

--- a/t/op/tie.t
+++ b/t/op/tie.t
@@ -1697,7 +1697,7 @@ FIRSTKEY is Note 0
 Destroying 0
 NEXTKEY is Note 1
 Before untie
+Destroying 1
 After untie
 Before regular iteration
-Destroying 1
 After regular iteration


### PR DESCRIPTION
Iterating a tied hash causes perl to store a copy of the current hash key to track the iteration state, with this stored copy passed as the second parameter to `NEXTKEY`. This internal state is freed immediately when tie hash iteration completes, or if the hash is destroyed, but due to an implementation oversight, it was not freed if the hash was untied. In that case, the internal copy of the key would persist until the earliest of

1. `tie` was called again on the same hash
2. The (now untied) hash was iterated (ie passed to any of `keys`, `values` or `each`)
3. The hash was destroyed.

This inconsistency is now fixed - the internal state is now freed immediately by `untie`.