### PR TITLE
gh19100: avoid buggy "maybe used uninitialized" warning

### DIFF
--- a/perl.c
+++ b/perl.c
@@ -195,6 +195,12 @@ perl_alloc(void)
     /* Newx() needs interpreter, so call malloc() instead */
     my_perl = (PerlInterpreter*)PerlMem_malloc(sizeof(PerlInterpreter));
 
+#if defined(MULTIPLICITY) && PERL_IS_GCC
+    /* Write to any element to avoid buggy "maybe used uninitialized" warning
+     * (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102329) */
+    my_perl->Istack_sp = 0;
+#endif
+
     S_init_tls_and_interp(my_perl);
 #ifndef PERL_TRACK_MEMPOOL
     return (PerlInterpreter *) ZeroD(my_perl, 1, PerlInterpreter);


### PR DESCRIPTION
New warnings introduced around gcc-10 or -11 assume that the call to
pthread_getspecific() in S_init_tls_and_interp may read through the
my_perl pointer provided; writing to any element of the structure
is enough to shut it up.