### PR TITLE
perl_alloc() wants zeroed memory so should use calloc()

### DIFF
--- a/perl.c
+++ b/perl.c
@@ -159,9 +159,8 @@ perl_alloc_using(struct IPerlMem* ipM, struct IPerlMem* ipMS,
     PERL_ARGS_ASSERT_PERL_ALLOC_USING;
 
     /* Newx() needs interpreter, so call malloc() instead */
-    my_perl = (PerlInterpreter*)(*ipM->pMalloc)(ipM, sizeof(PerlInterpreter));
+    my_perl = (PerlInterpreter*)(*ipM->pCalloc)(ipM, 1, sizeof(PerlInterpreter));
     S_init_tls_and_interp(my_perl);
-    Zero(my_perl, 1, PerlInterpreter);
     PL_Mem = ipM;
     PL_MemShared = ipMS;
     PL_MemParse = ipMP;

--- a/perl.c
+++ b/perl.c
@@ -193,9 +193,7 @@ perl_alloc(void)
     PerlInterpreter *my_perl = (PerlInterpreter*)PerlMem_calloc(1, sizeof(PerlInterpreter));
 
     S_init_tls_and_interp(my_perl);
-#ifdef PERL_TRACK_MEMPOOL
     INIT_TRACK_MEMPOOL(PL_memory_debug_header, my_perl);
-#endif
     return my_perl;
 }
 #endif /* PERL_IMPLICIT_SYS */

--- a/perl.c
+++ b/perl.c
@@ -190,19 +190,13 @@ Allocates a new Perl interpreter.  See L<perlembed>.
 PerlInterpreter *
 perl_alloc(void)
 {
-    PerlInterpreter *my_perl;
-
-    /* Newx() needs interpreter, so call malloc() instead */
-    my_perl = (PerlInterpreter*)PerlMem_malloc(sizeof(PerlInterpreter));
+    PerlInterpreter *my_perl = (PerlInterpreter*)PerlMem_calloc(1, sizeof(PerlInterpreter));
 
     S_init_tls_and_interp(my_perl);
-#ifndef PERL_TRACK_MEMPOOL
-    return (PerlInterpreter *) ZeroD(my_perl, 1, PerlInterpreter);
-#else
-    Zero(my_perl, 1, PerlInterpreter);
+#ifdef PERL_TRACK_MEMPOOL
     INIT_TRACK_MEMPOOL(PL_memory_debug_header, my_perl);
-    return my_perl;
 #endif
+    return my_perl;
 }
 #endif /* PERL_IMPLICIT_SYS */
 


### PR DESCRIPTION
The previous code

1) allocated memory with PerlMem_malloc()
2) passed the pointer to S_init_tls_and_interp()
3) called Zero() or ZeroD()
4) optionally invoked INIT_TRACK_MEMPOOL()
5) returned the pointer

ZeroD() and Zero() are equivalent, apart from the return value of the
expression.

The layers of functions and macros obscured what what was actually
happening, and what the ordering dependencies are:

* S_init_tls_and_interp() uses only the address of the pointer
* Zero() zeros the memory
* Only INIT_TRACK_MEMPOOL() touches the contents
* all the "memory wrap" macros inside the other macros can't "trigger"

Hence the order of Zero() and S_init_tls_and_interp() can be swapped,
at which point Zero() immediately follows malloc(), meaning that the two
should be be replaced with calloc().

This simplifies the function considerably.