### PR TITLE
Update comment in POSIX::import()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -970,6 +970,7 @@ Norman Koch                    <kochnorman@rocketmail.com>
 Norton T. Allen                <allen@huarp.harvard.edu>
 Nuno Carvalho                  <mestre.smash@gmail.com>
 Offer Kaye                     <offer.kaye@gmail.com>
+Olaf Alders                    <olaf@wundersolutions.com>
 Olaf Flebbe                    <o.flebbe@science-computing.de>
 Olaf Titz                      <olaf@bigred.inka.de>
 Oleg Nesterov                  <oleg@redhat.com>

--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our ($AUTOLOAD, %SIGRT);
 
-our $VERSION = '1.99';
+our $VERSION = '2.00';
 
 require XSLoader;
 
@@ -176,7 +176,7 @@ sub import {
 
     load_imports() unless $loaded++;
 
-    # Grandfather old foo_h form to new :foo_h form
+    # Rewrite legacy foo_h form to new :foo_h form
     s/^(?=\w+_h$)/:/ for my @list = @_;
 
     my @unimpl = sort grep { exists $replacement{$_} } @list;


### PR DESCRIPTION
This removes the use of grandfather as a verb. See #18830 for initial
discussion.