### PR TITLE
Nothing changed in SIGINFO for OpenBSD 7.0

### DIFF
--- a/ext/POSIX/t/sigaction.t
+++ b/ext/POSIX/t/sigaction.t
@@ -202,7 +202,7 @@ SKIP: {
     $skip{pid}{$^O} = $skip{uid}{$^O} = "not set for kill()"
         if (($^O.$Config{osvers}) =~ /^darwin[0-8]\./
             ||
-            ($^O.$Config{osvers}) =~ /^openbsd[0-6]\./
+            ($^O.$Config{osvers}) =~ /^openbsd[0-7]\./
             ||
             ($^O eq 'gnu')
             ||


### PR DESCRIPTION
We'll check back in five years for OpenBSD 8.0 unless someone notices a fix before then.

Thanks to xenu on IRC in #p5p for pointing that out.