### PR TITLE
Move the HvAUX struct into the end of the hash's body

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1015,6 +1015,7 @@ i	|GV*	|gv_fetchmeth_internal	|NULLOK HV* stash|NULLOK SV* meth|NULLOK const cha
 					|STRLEN len|I32 level|U32 flags
 #endif
 Apd	|HV*	|gv_stashsv	|NN SV* sv|I32 flags
+po	|struct xpvhv_aux*|hv_auxalloc|NN HV *hv
 Apd	|void	|hv_clear	|NULLOK HV *hv
 : used in SAVEHINTS() and op.c
 ApdR	|HV *	|hv_copy_hints_hv|NULLOK HV *const ohv

--- a/embed.fnc
+++ b/embed.fnc
@@ -2892,7 +2892,6 @@ SR	|HEK*	|share_hek_flags|NN const char *str|STRLEN len|U32 hash|int flags
 rS	|void	|hv_notallowed	|int flags|NN const char *key|I32 klen|NN const char *msg
 iT	|U32|ptr_hash|PTRV u
 S	|struct xpvhv_aux*|hv_auxinit|NN HV *hv
-ST	|struct xpvhv_aux*|hv_auxinit_internal|NN struct xpvhv_aux *iter
 Sx	|SV*	|hv_delete_common|NULLOK HV *hv|NULLOK SV *keysv \
 		|NULLOK const char *key|STRLEN klen|int k_flags|I32 d_flags \
 		|U32 hash

--- a/embed.h
+++ b/embed.h
@@ -1694,7 +1694,6 @@
 #define clear_placeholders(a,b)	S_clear_placeholders(aTHX_ a,b)
 #define hsplit(a,b,c)		S_hsplit(aTHX_ a,b,c)
 #define hv_auxinit(a)		S_hv_auxinit(aTHX_ a)
-#define hv_auxinit_internal	S_hv_auxinit_internal
 #define hv_delete_common(a,b,c,d,e,f,g)	S_hv_delete_common(aTHX_ a,b,c,d,e,f,g)
 #define hv_free_ent_ret(a,b)	S_hv_free_ent_ret(aTHX_ a,b)
 #define hv_free_entries(a)	S_hv_free_entries(aTHX_ a)

--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.19';
+our $VERSION = '1.20';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -202,10 +202,10 @@ test_freeent(freeent_function *f) {
 
     /* We need to "inline" new_he here as it's static, and the functions we
        test expect to be able to call del_HE on the HE  */
-    if (!PL_body_roots[HE_SVSLOT])
+    if (!PL_body_roots[HE_ARENA_ROOT_IX])
         croak("PL_he_root is 0");
-    victim = (HE*) PL_body_roots[HE_SVSLOT];
-    PL_body_roots[HE_SVSLOT] = HeNEXT(victim);
+    victim = (HE*) PL_body_roots[HE_ARENA_ROOT_IX];
+    PL_body_roots[HE_ARENA_ROOT_IX] = HeNEXT(victim);
 #endif
 
     victim->hent_hek = Perl_share_hek(aTHX_ "", 0, 0);

--- a/hv.c
+++ b/hv.c
@@ -2208,8 +2208,7 @@ S_hv_auxinit(pTHX_ HV *hv) {
             Renew(array, PERL_HV_ARRAY_ALLOC_BYTES(HvMAX(hv) + 1), char);
         }
         HvARRAY(hv) = (HE**)array;
-        SvOOK_on(hv);
-        iter = HvAUX(hv);
+        iter = Perl_hv_auxalloc(aTHX_ hv);
 #ifdef PERL_HASH_RANDOMIZE_KEYS
         if (PL_HASH_RAND_BITS_ENABLED) {
             /* mix in some new state to PL_hash_rand_bits to "randomize" the traversal order*/

--- a/hv.c
+++ b/hv.c
@@ -1954,7 +1954,6 @@ Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
                 /* warning: at this point HvARRAY may have been
                  * re-allocated, HvMAX changed etc */
             }
-            iter = HvAUX(hv); /* may have been realloced */
             iter->xhv_riter = -1; 	/* HvRITER(hv) = -1 */
             iter->xhv_eiter = NULL;	/* HvEITER(hv) = NULL */
 #ifdef PERL_HASH_RANDOMIZE_KEYS
@@ -2262,7 +2261,6 @@ Perl_hv_iterinit(pTHX_ HV *hv)
             HvLAZYDEL_off(hv);
             hv_free_ent(hv, entry);
         }
-        iter = HvAUX(hv); /* may have been reallocated */
         iter->xhv_riter = -1; 	/* HvRITER(hv) = -1 */
         iter->xhv_eiter = NULL; /* HvEITER(hv) = NULL */
 #ifdef PERL_HASH_RANDOMIZE_KEYS
@@ -2378,7 +2376,6 @@ Perl_hv_name_set(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
                 /* The first elem may be null. */
                 if(*this_name) unshare_hek_or_pvn(*this_name, 0, 0, 0);
                 Safefree(this_name);
-                iter = HvAUX(hv); /* may been realloced */
                 spot = &iter->xhv_name_u.xhvnameu_name;
                 iter->xhv_name_count = 0;
               }
@@ -2400,7 +2397,6 @@ Perl_hv_name_set(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
             }
             else if (flags & HV_NAME_SETALL) {
                 unshare_hek_or_pvn(iter->xhv_name_u.xhvnameu_name, 0, 0, 0);
-                iter = HvAUX(hv); /* may been realloced */
                 spot = &iter->xhv_name_u.xhvnameu_name;
             }
             else {
@@ -2546,7 +2542,6 @@ Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
                 : (HEK_LEN(*victim) == (I32)len && memEQ(HEK_KEY(*victim), name, len))
             ) {
                 unshare_hek_or_pvn(*victim, 0, 0, 0);
-                aux = HvAUX(hv); /* may been realloced */
                 if (count < 0) ++aux->xhv_name_count;
                 else --aux->xhv_name_count;
                 if (
@@ -2696,7 +2691,6 @@ Perl_hv_iternext_flags(pTHX_ HV *hv, I32 flags)
             SvREFCNT_dec(HeVAL(entry));
             Safefree(HeKEY_hek(entry));
             del_HE(entry);
-            iter = HvAUX(hv); /* may been realloced */
             iter->xhv_eiter = NULL; /* HvEITER(hv) = NULL */
             HvLAZYDEL_off(hv);
             return NULL;
@@ -2706,10 +2700,6 @@ Perl_hv_iternext_flags(pTHX_ HV *hv, I32 flags)
     if (!entry && SvRMAGICAL((const SV *)hv)
         && mg_find((const SV *)hv, PERL_MAGIC_env)) {
         prime_env_iter();
-        /* The prime_env_iter() on VMS just loaded up new hash values
-         * so HvARRAY() liked has been reallocated
-         */
-        iter = HvAUX(hv);
     }
 #endif
 
@@ -2739,7 +2729,6 @@ Perl_hv_iternext_flags(pTHX_ HV *hv, I32 flags)
                              pTHX__FORMAT
                              pTHX__VALUE);
         }
-        iter = HvAUX(hv); /* may been realloced */
         iter->xhv_last_rand = iter->xhv_rand;
     }
 #endif
@@ -2785,7 +2774,6 @@ Perl_hv_iternext_flags(pTHX_ HV *hv, I32 flags)
         hv_free_ent(hv, oldentry);
     }
 
-    iter = HvAUX(hv); /* may been realloced */
     iter->xhv_eiter = entry; /* HvEITER(hv) = entry */
     return entry;
 }

--- a/hv.c
+++ b/hv.c
@@ -2194,23 +2194,6 @@ PERL_STATIC_INLINE U32 S_ptr_hash(PTRV u) {
 }
 
 static struct xpvhv_aux*
-S_hv_auxinit_internal(struct xpvhv_aux *iter) {
-    PERL_ARGS_ASSERT_HV_AUXINIT_INTERNAL;
-    iter->xhv_riter = -1; 	/* HvRITER(hv) = -1 */
-    iter->xhv_eiter = NULL;	/* HvEITER(hv) = NULL */
-#ifdef PERL_HASH_RANDOMIZE_KEYS
-    iter->xhv_last_rand = iter->xhv_rand;
-#endif
-    iter->xhv_name_u.xhvnameu_name = 0;
-    iter->xhv_name_count = 0;
-    iter->xhv_backreferences = 0;
-    iter->xhv_mro_meta = NULL;
-    iter->xhv_aux_flags = 0;
-    return iter;
-}
-
-
-static struct xpvhv_aux*
 S_hv_auxinit(pTHX_ HV *hv) {
     struct xpvhv_aux *iter;
     char *array;
@@ -2240,7 +2223,17 @@ S_hv_auxinit(pTHX_ HV *hv) {
         iter = HvAUX(hv);
     }
 
-    return hv_auxinit_internal(iter);
+    iter->xhv_riter = -1;       /* HvRITER(hv) = -1 */
+    iter->xhv_eiter = NULL;     /* HvEITER(hv) = NULL */
+#ifdef PERL_HASH_RANDOMIZE_KEYS
+    iter->xhv_last_rand = iter->xhv_rand;
+#endif
+    iter->xhv_name_u.xhvnameu_name = 0;
+    iter->xhv_name_count = 0;
+    iter->xhv_backreferences = 0;
+    iter->xhv_mro_meta = NULL;
+    iter->xhv_aux_flags = 0;
+    return iter;
 }
 
 /*

--- a/hv.c
+++ b/hv.c
@@ -1444,8 +1444,7 @@ S_hsplit(pTHX_ HV *hv, STRLEN const oldsize, STRLEN newsize)
             return;
 
     PL_nomemok = TRUE;
-    Renew(a, PERL_HV_ARRAY_ALLOC_BYTES(newsize)
-          + (do_aux ? sizeof(struct xpvhv_aux) : 0), char);
+    Renew(a, PERL_HV_ARRAY_ALLOC_BYTES(newsize), char);
     PL_nomemok = FALSE;
     if (!a) {
       return;
@@ -1469,11 +1468,8 @@ S_hsplit(pTHX_ HV *hv, STRLEN const oldsize, STRLEN newsize)
      * need to deal with the aux struct that may be there
      * or have been allocated by us*/
     if (do_aux) {
-        struct xpvhv_aux *const dest
-            = (struct xpvhv_aux*) &a[newsize * sizeof(HE*)];
+        struct xpvhv_aux *const dest = HvAUX(hv);
         if (SvOOK(hv)) {
-            /* alread have an aux, copy the old one in place. */
-            Move(&a[oldsize * sizeof(HE*)], dest, 1, struct xpvhv_aux);
             /* we reset the iterator's xhv_rand as well, so they get a totally new ordering */
 #ifdef PERL_HASH_RANDOMIZE_KEYS
             dest->xhv_rand = (U32)PL_hash_rand_bits;
@@ -2248,12 +2244,10 @@ S_hv_auxinit(pTHX_ HV *hv) {
 
     if (!SvOOK(hv)) {
         if (!HvARRAY(hv)) {
-            Newxz(array, PERL_HV_ARRAY_ALLOC_BYTES(HvMAX(hv) + 1)
-                + sizeof(struct xpvhv_aux), char);
+            Newxz(array, PERL_HV_ARRAY_ALLOC_BYTES(HvMAX(hv) + 1), char);
         } else {
             array = (char *) HvARRAY(hv);
-            Renew(array, PERL_HV_ARRAY_ALLOC_BYTES(HvMAX(hv) + 1)
-                  + sizeof(struct xpvhv_aux), char);
+            Renew(array, PERL_HV_ARRAY_ALLOC_BYTES(HvMAX(hv) + 1), char);
         }
         HvARRAY(hv) = (HE**)array;
         SvOOK_on(hv);

--- a/hv.c
+++ b/hv.c
@@ -60,10 +60,10 @@ STATIC HE*
 S_new_he(pTHX)
 {
     HE* he;
-    void ** const root = &PL_body_roots[HE_SVSLOT];
+    void ** const root = &PL_body_roots[HE_ARENA_ROOT_IX];
 
     if (!*root)
-        Perl_more_bodies(aTHX_ HE_SVSLOT, sizeof(HE), PERL_ARENA_SIZE);
+        Perl_more_bodies(aTHX_ HE_ARENA_ROOT_IX, sizeof(HE), PERL_ARENA_SIZE);
     he = (HE*) *root;
     assert(he);
     *root = HeNEXT(he);
@@ -73,8 +73,8 @@ S_new_he(pTHX)
 #define new_HE() new_he()
 #define del_HE(p) \
     STMT_START { \
-        HeNEXT(p) = (HE*)(PL_body_roots[HE_SVSLOT]);	\
-        PL_body_roots[HE_SVSLOT] = p; \
+        HeNEXT(p) = (HE*)(PL_body_roots[HE_ARENA_ROOT_IX]);	\
+        PL_body_roots[HE_ARENA_ROOT_IX] = p; \
     } STMT_END
 
 

--- a/hv.h
+++ b/hv.h
@@ -243,18 +243,6 @@ C<SV*>.
 
 #define PERL_HASH_DEFAULT_HvMAX 7
 
-/* During hsplit(), if HvMAX(hv)+1 (the new bucket count) is >= this value,
- * we preallocate the HvAUX() struct.
- * The assumption being that we are using so much space anyway we might
- * as well allocate the extra bytes and speed up later keys()
- * or each() operations. We don't do this to small hashes as we assume
- * that a) it will be easy/fast to resize them to add the iterator, and b) that
- * many of them will be objects which won't be traversed. Larger hashes however
- * will take longer to extend, and the size of the aux struct is swamped by the
- * overall length of the bucket array.
- * */
-#define PERL_HV_ALLOC_AUX_SIZE (1 << 9)
-
 /* these hash entry flags ride on hent_klen (for use only in magic/tied HVs) */
 #define HEf_SVKEY	-2	/* hent_key is an SV* */
 

--- a/hv.h
+++ b/hv.h
@@ -137,6 +137,13 @@ struct xpvhv {
     union _xmgu	xmg_u;
     STRLEN      xhv_keys;       /* total keys, including placeholders */
     STRLEN      xhv_max;        /* subscript of last element of xhv_array */
+};
+
+struct xpvhv_with_aux {
+    HV         *xmg_stash;      /* class package */
+    union _xmgu xmg_u;
+    STRLEN      xhv_keys;       /* total keys, including placeholders */
+    STRLEN      xhv_max;        /* subscript of last element of xhv_array */
     struct xpvhv_aux xhv_aux;
 };
 
@@ -264,7 +271,7 @@ See L</hv_fill>.
 #define HvMAX(hv)	((XPVHV*)  SvANY(hv))->xhv_max
 /* This quite intentionally does no flag checking first. That's your
    responsibility.  */
-#define HvAUX(hv)       (&(((XPVHV*) SvANY(hv))->xhv_aux))
+#define HvAUX(hv)       (&(((struct xpvhv_with_aux*)  SvANY(hv))->xhv_aux))
 #define HvRITER(hv)	(*Perl_hv_riter_p(aTHX_ MUTABLE_HV(hv)))
 #define HvEITER(hv)	(*Perl_hv_eiter_p(aTHX_ MUTABLE_HV(hv)))
 #define HvRITER_set(hv,r)	Perl_hv_riter_set(aTHX_ MUTABLE_HV(hv), r)

--- a/hv.h
+++ b/hv.h
@@ -137,6 +137,7 @@ struct xpvhv {
     union _xmgu	xmg_u;
     STRLEN      xhv_keys;       /* total keys, including placeholders */
     STRLEN      xhv_max;        /* subscript of last element of xhv_array */
+    struct xpvhv_aux xhv_aux;
 };
 
 /*
@@ -275,7 +276,7 @@ See L</hv_fill>.
 #define HvMAX(hv)	((XPVHV*)  SvANY(hv))->xhv_max
 /* This quite intentionally does no flag checking first. That's your
    responsibility.  */
-#define HvAUX(hv)	((struct xpvhv_aux*)&(HvARRAY(hv)[HvMAX(hv)+1]))
+#define HvAUX(hv)       (&(((XPVHV*) SvANY(hv))->xhv_aux))
 #define HvRITER(hv)	(*Perl_hv_riter_p(aTHX_ MUTABLE_HV(hv)))
 #define HvEITER(hv)	(*Perl_hv_eiter_p(aTHX_ MUTABLE_HV(hv)))
 #define HvRITER_set(hv,r)	Perl_hv_riter_set(aTHX_ MUTABLE_HV(hv), r)

--- a/proto.h
+++ b/proto.h
@@ -1412,6 +1412,9 @@ PERL_CALLCONV HV*	Perl_gv_stashsv(pTHX_ SV* sv, I32 flags);
 PERL_CALLCONV void	Perl_gv_try_downgrade(pTHX_ GV* gv);
 #define PERL_ARGS_ASSERT_GV_TRY_DOWNGRADE	\
 	assert(gv)
+PERL_CALLCONV struct xpvhv_aux*	Perl_hv_auxalloc(pTHX_ HV *hv);
+#define PERL_ARGS_ASSERT_HV_AUXALLOC	\
+	assert(hv)
 PERL_CALLCONV AV**	Perl_hv_backreferences_p(pTHX_ HV *hv);
 #define PERL_ARGS_ASSERT_HV_BACKREFERENCES_P	\
 	assert(hv)

--- a/proto.h
+++ b/proto.h
@@ -5132,9 +5132,6 @@ STATIC void	S_hsplit(pTHX_ HV *hv, STRLEN const oldsize, STRLEN newsize);
 STATIC struct xpvhv_aux*	S_hv_auxinit(pTHX_ HV *hv);
 #define PERL_ARGS_ASSERT_HV_AUXINIT	\
 	assert(hv)
-STATIC struct xpvhv_aux*	S_hv_auxinit_internal(struct xpvhv_aux *iter);
-#define PERL_ARGS_ASSERT_HV_AUXINIT_INTERNAL	\
-	assert(iter)
 STATIC SV*	S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen, int k_flags, I32 d_flags, U32 hash);
 #define PERL_ARGS_ASSERT_HV_DELETE_COMMON
 STATIC SV*	S_hv_free_ent_ret(pTHX_ HV *hv, HE *entry);

--- a/sv.c
+++ b/sv.c
@@ -6631,9 +6631,6 @@ instead.
 void
 Perl_sv_clear(pTHX_ SV *const orig_sv)
 {
-    HV *stash;
-    U32 type;
-    const struct body_details *sv_type_details;
     SV* iter_sv = NULL;
     SV* next_sv = NULL;
     SV *sv = orig_sv;
@@ -6647,8 +6644,9 @@ Perl_sv_clear(pTHX_ SV *const orig_sv)
      * over to provide more SVs */
 
     while (sv) {
-
-        type = SvTYPE(sv);
+        U32 type = SvTYPE(sv);
+        const struct body_details *sv_type_details;
+        HV *stash;
 
         assert(SvREFCNT(sv) == 0);
         assert(SvTYPE(sv) != (svtype)SVTYPEMASK);

--- a/sv.c
+++ b/sv.c
@@ -14462,8 +14462,7 @@ S_sv_dup_common(pTHX_ const SV *const ssv, CLONE_PARAMS *const param)
                     XPVHV * const dxhv = (XPVHV*)SvANY(dsv);
                     XPVHV * const sxhv = (XPVHV*)SvANY(ssv);
                     char *darray;
-                    Newx(darray, PERL_HV_ARRAY_ALLOC_BYTES(dxhv->xhv_max+1)
-                        + (SvOOK(ssv) ? sizeof(struct xpvhv_aux) : 0),
+                    Newx(darray, PERL_HV_ARRAY_ALLOC_BYTES(dxhv->xhv_max+1),
                         char);
                     HvARRAY(dsv) = (HE**)darray;
                     while (i <= sxhv->xhv_max) {

--- a/sv.h
+++ b/sv.h
@@ -174,9 +174,13 @@ typedef enum {
 #endif
 
 /* The array of arena roots for SV bodies is indexed by SvTYPE. SVt_NULL doesn't
- * use a body, so that arena root is re-used for HEs. */
+ * use a body, so that arena root is re-used for HEs. SVt_IV also doesn't, so
+ * that arena root is used for HVs with struct xpvhv_aux. */
 #if defined(PERL_IN_HV_C) || defined(PERL_IN_XS_APITEST)
 #  define HE_ARENA_ROOT_IX      SVt_NULL
+#endif
+#if defined(PERL_IN_HV_C) || defined(PERL_IN_SV_C)
+#  define HVAUX_ARENA_ROOT_IX   SVt_IV
 #endif
 #ifdef PERL_IN_SV_C
 #  define SVt_FIRST SVt_NULL	/* the type of SV that new_SV() in sv.c returns */

--- a/sv.h
+++ b/sv.h
@@ -173,12 +173,10 @@ typedef enum {
 #  define SVt_RV	SVt_IV
 #endif
 
-/* There is collusion here with sv_clear - sv_clear exits early for SVt_NULL
-   so never reaches the clause at the end that uses sv_type_details->body_size
-   to determine whether to call safefree(). Hence body_size can be set
-   non-zero to record the size of HEs, without fear of bogus frees.  */
+/* The array of arena roots for SV bodies is indexed by SvTYPE. SVt_NULL doesn't
+ * use a body, so that arena root is re-used for HEs. */
 #if defined(PERL_IN_HV_C) || defined(PERL_IN_XS_APITEST)
-#define HE_SVSLOT	SVt_NULL
+#  define HE_ARENA_ROOT_IX      SVt_NULL
 #endif
 #ifdef PERL_IN_SV_C
 #  define SVt_FIRST SVt_NULL	/* the type of SV that new_SV() in sv.c returns */


### PR DESCRIPTION
Memory for hash iterators *etc* is only allocated on demand, as most hashes are used as objects and so are never iterated.

The iterator state (and other extra data) is stored in a `struct xpvhv_aux`. In blead this is allocated as part of the block of memory used to hold the linked lists of `HE *` pointers - the hash's main array. As a consequence, the address of this struct can move if the hash grows, which adds complexity in quite a few places.

Instead, allocate the memory as part of the hash body - this way, the memory doesn't move once it is allocated.

Memory is still only allocated on demand - "upgrade" the body as needed, changing the existing code paths that (re)allocated `HvARRAY()` to instead swap the body.

Larger bodies can still be allocated from arenas - we can use the arena for `SVt_IV`. At one point this arena was used to allocate memory for pointer table hashes, until that allocation was moved into the pointer table code.

ASAN does not find this branch interesting (no regressions, threaded or unthreaded, with `-DPURIFY`)