### PR TITLE
Remove grandfather as a verb in Tie::Handle, Tie::Hash and Tie::Scalar

### DIFF
--- a/lib/Tie/Handle.pm
+++ b/lib/Tie/Handle.pm
@@ -1,7 +1,7 @@
 package Tie::Handle;
 
 use 5.006_001;
-our $VERSION = '4.2';
+our $VERSION = '4.3';
 
 # Tie::StdHandle used to be inside Tie::Handle.  For backwards compatibility
 # loading Tie::Handle has to make Tie::StdHandle available.
@@ -128,7 +128,7 @@ sub new {
     $pkg->TIEHANDLE(@_);
 }
 
-# "Grandfather" the new, a la Tie::Hash
+# Legacy support for new(), a la Tie::Hash
 
 sub TIEHANDLE {
     my $pkg = shift;

--- a/lib/Tie/Hash.pm
+++ b/lib/Tie/Hash.pm
@@ -1,6 +1,6 @@
 package Tie::Hash;
 
-our $VERSION = '1.05';
+our $VERSION = '1.06';
 
 =head1 NAME
 
@@ -60,7 +60,7 @@ as methods C<TIEHASH>, C<EXISTS> and C<CLEAR>. The B<Tie::StdHash> and
 B<Tie::ExtraHash> packages
 provide most methods for hashes described in L<perltie> (the exceptions
 are C<UNTIE> and C<DESTROY>).  They cause tied hashes to behave exactly like standard hashes,
-and allow for selective overwriting of methods.  B<Tie::Hash> grandfathers the
+and allow for selective overwriting of methods.  B<Tie::Hash> has legacy support for the
 C<new> method: it is used if C<TIEHASH> is not defined
 in the case a class forgets to include a C<TIEHASH> method.
 
@@ -195,7 +195,7 @@ sub new {
     $pkg->TIEHASH(@_);
 }
 
-# Grandfather "new"
+# Legacy support for new()
 
 sub TIEHASH {
     my $pkg = shift;

--- a/lib/Tie/Scalar.pm
+++ b/lib/Tie/Scalar.pm
@@ -1,6 +1,6 @@
 package Tie::Scalar;
 
-our $VERSION = '1.05';
+our $VERSION = '1.06';
 
 =head1 NAME
 
@@ -41,7 +41,7 @@ as methods C<TIESCALAR>, C<FETCH> and C<STORE>. The B<Tie::StdScalar>
 package provides all the methods specified in  L<perltie>. It inherits from
 B<Tie::Scalar> and causes scalars tied to it to behave exactly like the
 built-in scalars, allowing for selective overloading of methods. The C<new>
-method is provided as a means of grandfathering, for classes that forget to
+method is provided as a means of legacy support for classes that forget to
 provide their own C<TIESCALAR> method.
 
 For developers wishing to write their own tied-scalar classes, the methods
@@ -101,7 +101,7 @@ sub new {
     $pkg->TIESCALAR(@_);
 }
 
-# "Grandfather" the new, a la Tie::Hash
+# Legacy support for new(), a la Tie::Hash
 
 sub TIESCALAR {
     my $pkg = shift;


### PR DESCRIPTION
It's not clear to me that legacy is actually the correct word here as the docs
seem to be expressing that what is provided is actually a fallback for classes
which don't implement their own new() methods. Would fallback be a better way
to describe this? I didn't go with this to start with because the wording
also seemed to imply that the new() methods were in place to support an older
API.

See https://github.com/Perl/perl5/issues/18830 for initial discussion.