### PR TITLE
Add exit code test (GH #19020):

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5916,6 +5916,7 @@ t/op/isa.t			See if isa works
 t/op/join.t			See if join works
 t/op/kill0.t			See if kill works
 t/op/kill0_child		Process tree script that is kill()ed
+t/op/kill9_shell_exit.t	Check that we get the right exit code on shell execution kill signal
 t/op/kvaslice.t			See if index/value array slices work
 t/op/kvhslice.t			See if key/value hash slices work
 t/op/lc.t			See if lc, uc, lcfirst, ucfirst, quotemeta work

--- a/t/op/kill9_shell_exit.t
+++ b/t/op/kill9_shell_exit.t
@@ -1,0 +1,20 @@
+#!./perl -w
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+}
+
+use strict;
+use warnings;
+
+plan( 'tests' => 4 );
+
+my $res  = system qq($^X -e'\''kill "KILL", \$\$; sleep 100'\'');
+my $exit = $?;
+
+is( $res, $exit, "system() result ($res) and \$? ($exit) are the same" );
+is( $exit, 9, "\$? ($exit) from a KILL signal is 9" );
+is( $exit >> 8, 0, 'OS exit code (shifted) is 0' );
+is( $exit & 127, 9, 'KILL signal (bitwise ANDed exit) is 9' );


### PR DESCRIPTION
This tests that when we kill a process through a shell, we get the correct exit code and signal.

Unfortunately, this fails on some versions of Ubuntu and `dash`, which I believe shows a bug somewhere. This PR **cannot be merged** until that is resolved one way (like fixing it in the core) or another (like turning this into a `TODO` or something). I'm hoping to get some smoke tests from this to provide more information.

There's a `sleep()` included because some systems might delay the signal until the `-e''` execution would already finish.