### PR TITLE
pp_match: is_utf8_string check was used by removed (v5.24) \C char class

### DIFF
--- a/pp_hot.c
+++ b/pp_hot.c
@@ -3135,7 +3135,7 @@ PP(pp_match)
                         (long) i, (long) RXp_OFFS(prog)[i].start,
                         (long)RXp_OFFS(prog)[i].end, s, strend, (UV) len);
                 sv_setpvn(*SP, s, len);
-                if (DO_UTF8(TARG) && is_utf8_string((U8*)s, len))
+                if (DO_UTF8(TARG))
                     SvUTF8_on(*SP);
             }
         }


### PR DESCRIPTION
@tonycoz pointed out in #18820 that the `is_utf8_string()` check is redundant. The /\C/ regular 
expression character class was deprecated in v5.20.0 and removed in v5.24.0.