### PR TITLE
The Makefile must run makedef.pl with -Ilib on the command line

### DIFF
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -847,7 +847,7 @@ PERLEXPORT		= perl.exp
 	esac
 	$spitshell >>$Makefile <<'!NO!SUBS!'
 perl.exp: $(MINIPERLEXP) makedef.pl $(CONFIGPM) $(SYM) $(SYMH)
-	$(MINIPERL) makedef.pl --sort-fold PLATFORM=aix CC_FLAGS="$(OPTIMIZE)" > perl.exp
+	./$(MINIPERLEXP) -Ilib makedef.pl --sort-fold PLATFORM=aix CC_FLAGS="$(OPTIMIZE)" > perl.exp
 
 !NO!SUBS!
 	;;
@@ -856,7 +856,7 @@ os2)
 MINIPERLEXP		= miniperl
 
 perl5.def: $(MINIPERLEXP) makedef.pl $(CONFIGPM) $(SYM) $(SYMH) miniperl.map
-	$(MINIPERL) makedef.pl PLATFORM=os2 -DPERL_DLL=$(PERL_DLL) CC_FLAGS="$(OPTIMIZE)" > perl5.def
+	./$(MINIPERLEXP) -Ilib makedef.pl PLATFORM=os2 -DPERL_DLL=$(PERL_DLL) CC_FLAGS="$(OPTIMIZE)" > perl5.def
 
 !NO!SUBS!
 	;;

--- a/makedef.pl
+++ b/makedef.pl
@@ -32,14 +32,14 @@
 #    perl.imp    NetWare
 #    makedef.lis VMS
 
+use strict;
+use Config;
+
 my $fold;
 my %ARGS;
 my %define;
 
 BEGIN {
-    use Config;
-    use strict;
-
     %ARGS = (CCTYPE => 'MSVC', TARG_DIR => '');
 
     sub process_cc_flags {

--- a/makedef.pl
+++ b/makedef.pl
@@ -37,7 +37,6 @@ my %ARGS;
 my %define;
 
 BEGIN {
-    BEGIN { unshift @INC, "lib" }
     use Config;
     use strict;
 


### PR DESCRIPTION
It can't rely on adding 'lib' to `@INC` in a BEGIN block because during the build not all modules *are* in lib yet. For miniperl the two are not equivalent - adding -Ilib means that lib/buildcustomize.pl is run, and this sets up `@INC` properly to include all the toolchain modules in dist and cpan.

In particular, constant is dual life and hence not available as lib/constant.pm until it has been copied from dist/constant/lib as part of the build process. Hence with a parallel build on AIX, before this commit there was a race condition between the job that builds dist/constant and the job that builds perl.exp. Sometimes the race was lost, resulting in a mysterious failed build.

All other users of makedef.pl already invoke it with the appropriate -Ilib or -I..\lib, so this change won't affect them.
