### PR TITLE
Add option '-?' as a synonym to -h

### DIFF
--- a/perl.c
+++ b/perl.c
@@ -2108,6 +2108,7 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
         case 'c':
         case 'd':
         case 'D':
+        case '?':
         case 'h':
         case 'i':
         case 'l':
@@ -3565,6 +3566,9 @@ Perl_moreswitches(pTHX_ const char *s)
         return s;
         NOT_REACHED; /* NOTREACHED */
     }
+
+    case '?':
+        /* FALLTHROUGH */
     case 'h':
         usage();
         NOT_REACHED; /* NOTREACHED */


### PR DESCRIPTION
-? is a common paradigm for finding the usage of a program.  Prior to
this commit, doing so on perl would tell you it is illegal and suggest
-h.  This commit allows someone using this paradigm  to skip the second
step