### PR TITLE
Remove the last traces of the no longer existing cmd_l command

### DIFF
--- a/lib/perl5db.pl
+++ b/lib/perl5db.pl
@@ -531,7 +531,7 @@ BEGIN {
 use vars qw($VERSION $header);
 
 # bump to X.XX in blead, only use X.XX_XX in maint
-$VERSION = '1.61';
+$VERSION = '1.62';
 
 $header = "perl5db.pl version $VERSION";
 
@@ -2544,7 +2544,7 @@ sub _DB__handle_i_command {
     next CMD;
 }
 
-=head3 C<cmd_l> - list lines (command)
+=head3 C<_cmd_l_main> - list lines (command)
 
 Most of the command is taken up with transforming all the different line
 specification syntaxes into 'start-stop'. After that is done, the command
@@ -6001,7 +6001,7 @@ sub cmd_O {
 =head3 C<cmd_v> - view window (command)
 
 Uses the C<$preview> variable set in the second C<BEGIN> block (q.v.) to
-move back a few lines to list the selected line in context. Uses C<cmd_l>
+move back a few lines to list the selected line in context. Uses C<_cmd_l_main>
 to do the actual listing after figuring out the range of line to request.
 
 =cut
@@ -6027,7 +6027,7 @@ sub cmd_v {
         # Back up by the context amount.
         $start -= $preview;
 
-        # Put together a linespec that cmd_l will like.
+        # Put together a linespec that _cmd_l_main will like.
         $line = $start . '-' . ( $start + $incr );
 
         # List the lines.


### PR DESCRIPTION
cmd_l was still mentioned in the documentation and comments. Also,
there was no test for the "v" command which would test #18900.
