### PR TITLE
Send bugs to GitHub

### DIFF
--- a/Configure
+++ b/Configure
@@ -9391,9 +9391,7 @@ $cat <<EOM
 
 If you or somebody else will be maintaining perl at your site, please
 fill in the correct e-mail address here so that they may be contacted
-if necessary. Currently, the "perlbug" program included with perl
-will send mail to this address in addition to perlbug@perl.org. You may
-enter "none" for no administrator.
+if necessary. You may enter "none" for no administrator.
 
 EOM
 case "$perladmin" in

--- a/configure.com
+++ b/configure.com
@@ -1870,9 +1870,7 @@ $   DECK
 
 If you or somebody else will be maintaining perl at your site, please
 fill in the correct e-mail address here so that they may be contacted
-if necessary. Currently, the "perlbug" program included with perl
-will send mail to this address in addition to perlbug@perl.org. You may
-enter "none" for no administrator.
+if necessary. You may enter "none" for no administrator.
 $   EOD
 $ ENDIF
 $ dflt = "''cf_email'"

--- a/dist/XSLoader/Makefile.PL
+++ b/dist/XSLoader/Makefile.PL
@@ -76,8 +76,7 @@ WriteMakefile(
             x_IRC       => 'irc://irc.perl.org/#p5p',
             x_MailingList => 'http://lists.perl.org/list/perl5-porters.html',
             bugtracker => {
-                mailto      => 'perlbug@perl.org',
-                web         => "https://rt.perl.org/rt3/Search/Results.html?Query=Queue='perl5' AND Content LIKE 'module=XSLoader' AND (Status='open' OR Status='new' OR Status='stalled')",
+                web         => 'https://github.com/Perl/perl5/issues',
             },
         },
         provides    => {


### PR DESCRIPTION
Do not advise sending mail to 'perlbug@perl.org', as that now simply
triggers a response redirecting sender to GitHub.