### PR TITLE
GDBM_File: Implement crash-tolerance and export/import functions.

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -76,6 +76,10 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
+      - name: Install System dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -139,6 +143,10 @@ jobs:
           - "-Dcc='clang'"
 
     steps:
+      - name: Install System dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -186,9 +194,8 @@ jobs:
     steps:
       - name: Install System dependencies
         run: |
-          apt-get update ||:
-          apt-get -y install build-essential git-core
-
+          apt-get update
+          apt-get install -y build-essential git-core libgdbm-dev libdb-dev
       # actions/checkout@v2 doesn't work in a container, so we use v1.
       - uses: actions/checkout@v1
       - name: fix git remote credential
@@ -227,6 +234,10 @@ jobs:
     if: needs.sanity_check.outputs.run_all_jobs == 'true'
 
     steps:
+      - name: Install System dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -423,7 +434,8 @@ jobs:
         run: |
           choco install cygwin --params="/InstallDir:%GITHUB_WORKSPACE%\cygwin"
           choco install cyg-get
-          cyg-get cygwin-devel gcc-core gcc gcc-g++ make cygwin64-w32api-headers binutils libtool git ccache
+          cyg-get cygwin-devel gcc-core gcc gcc-g++ make cygwin64-w32api-headers ^
+                  binutils libtool git ccache lib libgdbm-devel libdb-devel
       - name: Check out using Cygwin git, to ensure correct file permissions
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -485,6 +497,10 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
+      - name: Install System dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -532,6 +548,10 @@ jobs:
           - "-Dusethreads"
 
     steps:
+      - name: Install System dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -578,6 +598,10 @@ jobs:
           - "-Dusethreads -Accflags=-DPURIFY -Dcc='gcc -fsanitize=address' -Dld='gcc -fsanitize=address'"
 
     steps:
+      - name: Install System dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/MANIFEST
+++ b/MANIFEST
@@ -4272,9 +4272,11 @@ ext/GDBM_File/GDBM_File.xs	GDBM extension external subroutines
 ext/GDBM_File/hints/sco.pl	Hint for GDBM_File for named architecture
 ext/GDBM_File/Makefile.PL	GDBM extension makefile writer
 ext/GDBM_File/t/count.t		Test if the count method works
+ext/GDBM_File/t/dump.t		Test if export/import methods work
 ext/GDBM_File/t/fatal.t		Test the fatal_func argument to gdbm_open
 ext/GDBM_File/t/gdbm.t		See if GDBM_File works
 ext/GDBM_File/t/opt.t		Test if gdbm_setopt and derived methods work
+ext/GDBM_File/t/snapshot.t	Test if the latest_snapshot method works
 ext/GDBM_File/typemap		GDBM extension interface types
 ext/Hash-Util/Changes		Change history of Hash::Util
 ext/Hash-Util/lib/Hash/Util.pm	Hash::Util

--- a/ext/GDBM_File/GDBM_File.xs
+++ b/ext/GDBM_File/GDBM_File.xs
@@ -217,7 +217,7 @@ rcvr_errfun(void *cv, char const *fmt, ...)
 
 #if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 11
 static int
-is_true(SV *val)
+is_true(pTHX_ SV *val)
 {
     unsigned t = 0;
 
@@ -650,7 +650,7 @@ gdbm_count(db)
    OUTPUT:
         RETVAL
 
-int
+void
 gdbm_dump(db, filename, ...)
 	GDBM_File	db
         char *          filename
@@ -679,11 +679,11 @@ gdbm_dump(db, filename, ...)
                         mode = SvUV(val) & 0777;
                     }
                 } else if (strcmp(kw, "binary") == 0) {
-                    if (is_true(val)) {
+                    if (is_true(aTHX_ val)) {
                         format = GDBM_DUMP_FMT_BINARY;
                     }
                 } else if (strcmp(kw, "overwrite") == 0) {
-                    if (is_true(val)) {
+                    if (is_true(aTHX_ val)) {
                         flags = GDBM_NEWDB;
                     }
                 } else {
@@ -723,16 +723,16 @@ gdbm_load(db, filename, ...)
                 kw = SvPV_nolen(sv);
 
                 if (strcmp(kw, "restore_mode") == 0) {
-                    if (!is_true(val))
+                    if (!is_true(aTHX_ val))
                         meta_mask |= GDBM_META_MASK_MODE;
                 } else if (strcmp(kw, "restore_owner") == 0) {
-                    if (!is_true(val))
+                    if (!is_true(aTHX_ val))
                         meta_mask |= GDBM_META_MASK_OWNER;
                 } else if (strcmp(kw, "replace") == 0) {
-                    if (is_true(val))
+                    if (is_true(aTHX_ val))
                         flag = GDBM_REPLACE;
                 } else if (strcmp(kw, "strict_errors") == 0) {
-                    strict_errors = is_true(val);
+                    strict_errors = is_true(aTHX_ val);
                 } else {
                     croak("unrecognized keyword: %s", kw);
                 }

--- a/ext/GDBM_File/GDBM_File.xs
+++ b/ext/GDBM_File/GDBM_File.xs
@@ -509,10 +509,9 @@ gdbm_recover(db, ...)
                 SV *sv = ST(i);
                 SV *val = ST(i+1);
 
-                if (!SvPOK(sv))
-                    croak("bad arguments near #%d", i);
                 kw = SvPV_nolen(sv);
                 if (strcmp(kw, "err") == 0) {
+                    SvGETMAGIC(val);
                     if (SvROK(val) && SvTYPE(SvRV(val)) == SVt_PVCV) {
                         rcvr.data = SvRV(val);
                     } else {
@@ -530,17 +529,19 @@ gdbm_recover(db, ...)
                     rcvr.max_failures = SvUV(val);
                     flags |= GDBM_RCVR_MAX_FAILURES;
                 } else if (strcmp(kw, "backup") == 0) {
+                    SvGETMAGIC(val);
                     if (SvROK(val) && SvTYPE(SvRV(val)) < SVt_PVAV) {
                         backup_ref = val;
                     } else {
-                        croak("backup must be a scalar reference");
+                        croak("%s must be a scalar reference", kw);
                     } 
                     flags |= GDBM_RCVR_BACKUP;
                 } else if (strcmp(kw, "stat") == 0) {
+                    SvGETMAGIC(val);
                     if (SvROK(val) && SvTYPE(SvRV(val)) == SVt_PVHV) {
                         stat_ref = val;
                     } else {
-                        croak("backup must be a scalar reference");
+                        croak("%s must be a scalar reference", kw);
                     } 
                 } else {
                     croak("%s: unrecognized argument", kw);
@@ -636,8 +637,6 @@ gdbm_dump(db, filename, ...)
                 SV *sv = ST(i);
                 SV *val = ST(i+1);
 
-                if (!SvPOK(sv))
-                    croak("bad arguments near #%d", i);
                 kw = SvPV_nolen(sv);
                 if (strcmp(kw, "mode") == 0) {
                     mode = SvUV(val) & 0777;
@@ -681,8 +680,6 @@ gdbm_load(db, filename, ...)
                 SV *sv = ST(i);
                 SV *val = ST(i+1);
 
-                if (!SvPOK(sv))
-                    croak("bad arguments near #%d", i);
                 kw = SvPV_nolen(sv);
 
                 if (strcmp(kw, "restore_mode") == 0) {
@@ -732,11 +729,7 @@ gdbm_load(db, filename, ...)
                 opcode = OPTNAME(GDBM_GET, opt);                   \
             } else {                                               \
                 opcode = OPTNAME(GDBM_SET, opt);                   \
-                sv = ST(1);                                        \
-                if (!SvIOK(sv)) {                                  \
-                    croak("%s: bad argument type", opt_names[ix]); \
-                }                                                  \
-                c_iv = SvIV(sv);                                   \
+                c_iv = SvIV(ST(1));                                \
             }                                                      \
         } while (0)
 
@@ -878,11 +871,7 @@ gdbm_flags(db, ...)
                 opcode = GDBM_GETMAXMAPSIZE;
             } else {                                      
                 opcode = GDBM_SETMAXMAPSIZE;
-                sv = ST(1);                               
-                if (!SvUOK(sv)) {                         
-                    croak("%s: bad argument type", opt_names[ix]);           
-                }                                         
-                c_uv = SvUV(sv);                          
+                c_uv = SvUV(ST(1));
             }                                             
             break;
         }

--- a/ext/GDBM_File/GDBM_File.xs
+++ b/ext/GDBM_File/GDBM_File.xs
@@ -817,7 +817,6 @@ gdbm_flags(db, ...)
         char *c_cv;
         OPTVALPTR vptr = (OPTVALPTR) &c_iv;
         size_t vsiz = sizeof(c_iv);
-        SV *sv;
     INIT:
         CHECKDB(db);
     CODE:

--- a/ext/GDBM_File/GDBM_File.xs
+++ b/ext/GDBM_File/GDBM_File.xs
@@ -215,29 +215,6 @@ rcvr_errfun(void *cv, char const *fmt, ...)
 }
 #endif
 
-#if GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 11
-static int
-is_true(pTHX_ SV *val)
-{
-    unsigned t = 0;
-
-    if (!SvOK(val)) {
-        t = 0;
-    } else if (SvIOK(val)) {
-        t = SvUV(val);
-    } else if (SvROK(val)) {
-        char *s = SvPV_nolen(val);
-        if (s[0] == 0 || s[0] == '0')
-            t = 0;
-        else
-            t = 1;
-    } else {
-        t = 1;
-    }
-    return t != 0;
-}
-#endif
-
 #include "const-c.inc"
 
 MODULE = GDBM_File	PACKAGE = GDBM_File	PREFIX = gdbm_
@@ -544,25 +521,13 @@ gdbm_recover(db, ...)
                     rcvr.errfun = rcvr_errfun;
                     flags |= GDBM_RCVR_ERRFUN;
                 } else if (strcmp(kw, "max_failed_keys") == 0) {
-                    if (SvIOK(val)) {
-                        rcvr.max_failed_keys = SvUV(val);
-                    } else {
-                        croak("max_failed_keys must be numeric");
-                    }
+                    rcvr.max_failed_keys = SvUV(val);
                     flags |= GDBM_RCVR_MAX_FAILED_KEYS;
                 } else if (strcmp(kw, "max_failed_buckets") == 0) {
-                    if (SvIOK(val)) {
-                        rcvr.max_failed_buckets = SvUV(val);
-                    } else {
-                        croak("max_failed_buckets must be numeric");
-                    }
+                    rcvr.max_failed_buckets = SvUV(val);
                     flags |= GDBM_RCVR_MAX_FAILED_BUCKETS;
                 } else if (strcmp(kw, "max_failures") == 0) {
-                    if (SvIOK(val)) {
-                        rcvr.max_failures = SvUV(val);
-                    } else {
-                        croak("max_failures must be numeric");
-                    }
+                    rcvr.max_failures = SvUV(val);
                     flags |= GDBM_RCVR_MAX_FAILURES;
                 } else if (strcmp(kw, "backup") == 0) {
                     if (SvROK(val) && SvTYPE(SvRV(val)) < SVt_PVAV) {
@@ -675,15 +640,13 @@ gdbm_dump(db, filename, ...)
                     croak("bad arguments near #%d", i);
                 kw = SvPV_nolen(sv);
                 if (strcmp(kw, "mode") == 0) {
-                    if (SvIOK(val)) {
-                        mode = SvUV(val) & 0777;
-                    }
+                    mode = SvUV(val) & 0777;
                 } else if (strcmp(kw, "binary") == 0) {
-                    if (is_true(aTHX_ val)) {
+                    if (SvTRUE(val)) {
                         format = GDBM_DUMP_FMT_BINARY;
                     }
                 } else if (strcmp(kw, "overwrite") == 0) {
-                    if (is_true(aTHX_ val)) {
+                    if (SvTRUE(val)) {
                         flags = GDBM_NEWDB;
                     }
                 } else {
@@ -723,16 +686,16 @@ gdbm_load(db, filename, ...)
                 kw = SvPV_nolen(sv);
 
                 if (strcmp(kw, "restore_mode") == 0) {
-                    if (!is_true(aTHX_ val))
+                    if (!SvTRUE(val))
                         meta_mask |= GDBM_META_MASK_MODE;
                 } else if (strcmp(kw, "restore_owner") == 0) {
-                    if (!is_true(aTHX_ val))
+                    if (!SvTRUE(val))
                         meta_mask |= GDBM_META_MASK_OWNER;
                 } else if (strcmp(kw, "replace") == 0) {
-                    if (is_true(aTHX_ val))
+                    if (SvTRUE(val))
                         flag = GDBM_REPLACE;
                 } else if (strcmp(kw, "strict_errors") == 0) {
-                    strict_errors = is_true(aTHX_ val);
+                    strict_errors = SvTRUE(val);
                 } else {
                     croak("unrecognized keyword: %s", kw);
                 }

--- a/ext/GDBM_File/Makefile.PL
+++ b/ext/GDBM_File/Makefile.PL
@@ -8,13 +8,26 @@ WriteMakefile(
     realclean => {FILES=> 'const-c.inc const-xs.inc'},
     XS_VERSION => eval MM->parse_version('GDBM_File.pm'), #silence warnings if we are a dev release
 );
+
+my @names = qw(GDBM_CACHESIZE GDBM_CENTFREE GDBM_COALESCEBLKS
+	       GDBM_FAST GDBM_FASTMODE GDBM_INSERT GDBM_NEWDB GDBM_NOLOCK
+	       GDBM_OPENMASK GDBM_READER GDBM_REPLACE GDBM_SYNC GDBM_SYNCMODE
+	       GDBM_WRCREAT GDBM_WRITER GDBM_NOMMAP GDBM_CLOEXEC GDBM_BSEXACT
+               GDBM_XVERIFY GDBM_PREREAD GDBM_NUMSYNC);
+
+push @names, {
+    name  => $_,
+    type  => "IV",
+    macro => [ "#if  GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 21\n",
+               "#endif\n" ],
+    value => "$_",
+} foreach qw(GDBM_SNAPSHOT_OK GDBM_SNAPSHOT_BAD GDBM_SNAPSHOT_ERR
+             GDBM_SNAPSHOT_SAME GDBM_SNAPSHOT_SUSPICIOUS);
+
 WriteConstants(
     NAME => 'GDBM_File',
     DEFAULT_TYPE => 'IV',
     BREAKOUT_AT => 8,
     PROXYSUBS => {autoload => 1},
-    NAMES => [qw(GDBM_CACHESIZE GDBM_CENTFREE GDBM_COALESCEBLKS
-		 GDBM_FAST GDBM_FASTMODE GDBM_INSERT GDBM_NEWDB GDBM_NOLOCK
-		 GDBM_OPENMASK GDBM_READER GDBM_REPLACE GDBM_SYNC GDBM_SYNCMODE
-		 GDBM_WRCREAT GDBM_WRITER)],
+    NAMES => \@names
 );

--- a/ext/GDBM_File/t/dump.t
+++ b/ext/GDBM_File/t/dump.t
@@ -1,0 +1,101 @@
+#!./perl -w
+use strict;
+
+use Test::More;
+use Config;
+use File::Temp 'tempdir';
+use File::Spec;
+use Fcntl qw( :mode );
+
+BEGIN {
+    plan(skip_all => "GDBM_File was not built")
+	unless $Config{extensions} =~ /\bGDBM_File\b/;
+
+    plan(tests => 18);
+    use_ok('GDBM_File');
+}
+
+use constant {
+    DUMP_ASCII => 0,
+    DUMP_BIN => 1,
+    DUMP_UNKNOWN => -1
+};
+
+sub dump_format {
+    my $file = shift;
+    if (open(my $fd, '<', $file)) {
+        $_ = <$fd>;
+        if (/^# GDBM dump file created by GDBM version/) {
+            return DUMP_ASCII;
+        }
+        if (/^!\r$/) {
+            $_ = <$fd>;
+            if (/^! GDBM FLAT FILE DUMP -- THIS IS NOT A TEXT FILE/) {
+                return DUMP_BIN;
+            }
+        }
+    }
+    return DUMP_UNKNOWN;
+}
+
+my $wd = tempdir(CLEANUP => 1);
+my $dbname = File::Spec->catfile($wd, 'Op_dbmx');
+my %h;
+my $db = tie(%h, 'GDBM_File', $dbname, GDBM_WRCREAT, 0640);
+isa_ok($db, 'GDBM_File');
+SKIP: {
+     skip 'GDBM_File::dump not available', 16
+        unless $db->can('dump');
+
+     $h{one} = '1';
+     $h{two} = '2';
+     $h{three} = '3';
+
+     my $dumpname = "$dbname.dump";
+     is(eval { $db->dump($dumpname); 1 }, 1, "Create ASCII dump");
+     is(dump_format($dumpname), DUMP_ASCII, "ASCII dump created");
+     is(eval { $db->dump($dumpname); 1 }, undef, "Refuse to overwrite existing dump");
+     is(eval { $db->dump($dumpname, overwrite => 1); 1 }, 1, "Working overwrite option");
+
+     my $binname = "$dbname.bin";
+     is(eval { $db->dump($binname, binary => 1); 1 }, 1, "Create binary dump");
+     is(dump_format($binname), DUMP_BIN, "Binary dump created");
+     is(eval { $db->dump($binname, binary => 1); 1 }, undef, "Refuse to overwrite existing binary dump");
+     is(eval { $db->dump($binname, binary => 1, overwrite => 1); 1 }, 1, "Working overwrite option (binary format)");
+
+     untie %h;
+     $db->close;
+
+     #
+     # Test loading the database
+     #
+     
+     $db = tie(%h, 'GDBM_File', $dbname, GDBM_NEWDB, 0640);
+     isa_ok($db, 'GDBM_File');
+
+     is(eval { $db->load($dumpname); 1 }, 1, "Loading from ascii dump");
+     is_deeply({map { $_ => $h{$_} } sort keys %h},
+	       { one => 1, two => 2, three => 3 },
+	       "Restored database content");
+     
+     is(eval { $db->load($dumpname); 1 }, undef, "Refuse to replace existing keys");
+
+     is(eval { $db->load($dumpname, replace => 1); 1 }, 1, "Replace existing keys");
+
+     untie %h;
+     $db->close;
+
+     #
+     # Test loading the database from binary dump
+     #
+     $db = tie(%h, 'GDBM_File', $dbname, GDBM_NEWDB, 0640);
+     isa_ok($db, 'GDBM_File');
+
+     is(eval { $db->load($binname); 1 }, 1, "Loading from binary dump");
+     is_deeply({map { $_ => $h{$_} } sort keys %h},
+	       { one => 1, two => 2, three => 3 },
+	       "Restored database content");
+     
+}
+
+     

--- a/ext/GDBM_File/t/snapshot.t
+++ b/ext/GDBM_File/t/snapshot.t
@@ -1,0 +1,89 @@
+#!./perl -w
+use strict;
+
+use Test::More;
+use Config;
+use File::Temp 'tempdir';
+use File::Spec;
+use Fcntl qw( :mode );
+
+BEGIN {
+    plan(skip_all => "GDBM_File was not built")
+	unless $Config{extensions} =~ /\bGDBM_File\b/;
+
+    plan(tests => 7);
+    use_ok('GDBM_File');
+}
+
+SKIP: {
+    skip "GDBM_File crash tolerance not available", 6,
+        unless GDBM_File->crash_tolerance_status;
+
+    my $wd = tempdir(CLEANUP => 1);
+    chdir $wd;
+
+    sub createdb {
+        my ($name, $type, $code) = @_;
+        my %h;
+        $type //= 0;
+        my $dbh = tie(%h, 'GDBM_File', $name, GDBM_NEWDB|$type, 0640);
+        if ($code) {
+            &{$code}($dbh, \%h);
+        }
+        untie %h
+    }
+    my $even = 'a.db';
+    my $odd = 'b.db';
+    my $time = time;
+
+    # Valid cases
+
+    createdb($even);
+    createdb($odd);
+    chmod S_IRUSR, $even;
+    chmod S_IWUSR, $odd;
+    is_deeply([GDBM_File->latest_snapshot($even, $odd)],
+  	      [ 'a.db', GDBM_SNAPSHOT_OK ], "different acess modes");
+
+    chmod S_IRUSR, $odd;
+    utime($time, $time, $even);
+    utime($time, $time-5, $odd);
+    is_deeply([GDBM_File->latest_snapshot($even, $odd)],
+ 	      [ 'a.db', GDBM_SNAPSHOT_OK ], "different mtimes");
+    unlink $even, $odd;
+
+    createdb($even, GDBM_NUMSYNC);
+    createdb($odd, GDBM_NUMSYNC, sub { shift->sync });
+    chmod S_IRUSR, $even, $odd;
+    utime($time, $time, $even, $odd);
+    is_deeply([GDBM_File->latest_snapshot($even, $odd)],
+	      [ 'b.db', GDBM_SNAPSHOT_OK ], "different numsync value");
+
+    # Erroneous cases
+    unlink $even, $odd;
+
+    createdb($even);
+    createdb($odd);
+    chmod S_IRUSR, $even, $odd;
+    utime($time, $time, $even, $odd);
+    is_deeply([GDBM_File->latest_snapshot($even, $odd)],
+	      [ undef, GDBM_SNAPSHOT_SAME ], "GDBM_SNAPSHOT_SAME");
+
+    chmod S_IWUSR, $even, $odd;
+    is_deeply([GDBM_File->latest_snapshot($even, $odd)],
+	      [ undef, GDBM_SNAPSHOT_BAD ], "GDBM_SNAPSHOT_BAD");
+
+    unlink $even, $odd;
+
+    createdb($even, GDBM_NUMSYNC);
+    createdb($odd, GDBM_NUMSYNC,
+	 sub {
+	     my $dbh = shift;
+             $dbh->sync;
+	     $dbh->sync;
+	 });
+    chmod S_IRUSR, $even, $odd;
+    utime($time, $time, $even, $odd);
+    is_deeply([GDBM_File->latest_snapshot($even, $odd)],
+	      [ undef, GDBM_SNAPSHOT_SUSPICIOUS ], "GDBM_SNAPSHOT_SUSPICIOUS");
+}

--- a/ext/GDBM_File/t/snapshot.t
+++ b/ext/GDBM_File/t/snapshot.t
@@ -35,44 +35,55 @@ SKIP: {
     my $even = 'a.db';
     my $odd = 'b.db';
     my $time = time;
-
-    # Valid cases
 
+    #
+    # Valid cases
+    #
+
+    # access modes
     createdb($even);
     createdb($odd);
     chmod S_IRUSR, $even;
     chmod S_IWUSR, $odd;
     is_deeply([GDBM_File->latest_snapshot($even, $odd)],
   	      [ 'a.db', GDBM_SNAPSHOT_OK ], "different acess modes");
-
+
+    # mtimes
     chmod S_IRUSR, $odd;
     utime($time, $time, $even);
     utime($time, $time-5, $odd);
     is_deeply([GDBM_File->latest_snapshot($even, $odd)],
  	      [ 'a.db', GDBM_SNAPSHOT_OK ], "different mtimes");
     unlink $even, $odd;
-
+
+    # numsync
     createdb($even, GDBM_NUMSYNC);
     createdb($odd, GDBM_NUMSYNC, sub { shift->sync });
     chmod S_IRUSR, $even, $odd;
     utime($time, $time, $even, $odd);
     is_deeply([GDBM_File->latest_snapshot($even, $odd)],
 	      [ 'b.db', GDBM_SNAPSHOT_OK ], "different numsync value");
-
+
+    #
     # Erroneous cases
+    #
+    
     unlink $even, $odd;
 
+    # Same snapshots
     createdb($even);
     createdb($odd);
     chmod S_IRUSR, $even, $odd;
     utime($time, $time, $even, $odd);
     is_deeply([GDBM_File->latest_snapshot($even, $odd)],
 	      [ undef, GDBM_SNAPSHOT_SAME ], "GDBM_SNAPSHOT_SAME");
-
+
+    # Both writable
     chmod S_IWUSR, $even, $odd;
     is_deeply([GDBM_File->latest_snapshot($even, $odd)],
 	      [ undef, GDBM_SNAPSHOT_BAD ], "GDBM_SNAPSHOT_BAD");
-
+
+    # numsync difference > 1
     unlink $even, $odd;
 
     createdb($even, GDBM_NUMSYNC);


### PR DESCRIPTION
* ext/GDBM_File/Makefile.PL: Register new constants: gdbm_open
flags and return values for gdbm_latest_snapshot.
* ext/GDBM_File/GDBM_File.pm: Update documentation.
Export new constants.
Raise version to 1.21.
* ext/GDBM_File/GDBM_File.xs (dbcroak): Include system error
infomation, when appropriate.
(gdbm_syserrno): Return a meaningful value if not_here.
(gdbm_dump, gdbm_load, gdbm_convert)
(gdbm_failure_atomic, gdbm_latest_snapshot)
(gdbm_crash_tolerance_status): New functions.
* ext/GDBM_File/t/dump.t: New testcase.
* ext/GDBM_File/t/snapshot.t: New testcase.
* MANIFEST: List new files.