### PR TITLE
Change INSTALL to note that "changes in the Perl language" are usually minor

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -854,7 +854,7 @@ separated list of directories, like this
 
        sh Configure -Accflags='-DAPPLLIB_EXP=\"/usr/libperl\"'
 
-The directories defined by APPLLIB_EXP get added to @INC I<first>,
+The directories defined by APPLLIB_EXP get added to @INC B<first>,
 ahead of any others, and so provide a way to override the standard perl
 modules should you, for example, want to distribute fixes without
 touching the perl distribution proper.  And, like otherlib dirs,
@@ -2791,7 +2791,6 @@ by perl itself; for source compatibility reasons, though, they weren't
 completely removed.
 
 =head2 C<-DNO_PERL_INTERNAL_RAND_SEED>
-X<PERL_INTERNAL_RAND_SEED>
 
 If you configure perl with C<-Accflags=-DNO_PERL_INTERNAL_RAND_SEED>,
 perl will ignore the C<PERL_INTERNAL_RAND_SEED> environment variable.

--- a/INSTALL
+++ b/INSTALL
@@ -103,11 +103,18 @@ L<"Coexistence with earlier versions of perl 5"> for more details.
 
 The standard extensions supplied with Perl will be handled automatically.
 
-On a related issue, old modules may possibly be affected by the changes
-in the Perl language in the current release.  Please see
-F<pod/perldelta.pod> for a description of what's changed.  See your
-installed copy of the perllocal.pod file for a (possibly incomplete)
-list of locally installed modules.  Also see the L<CPAN> module's
+On a related issue, old modules may possibly be affected by the changes in the
+Perl language in the current release.  We try hard to make new features
+"opt-in", such that existing code will work unchanged, and attempt to identify
+where bug fixes might expose code which was relying on incorrect interpreter
+behaviour.  Please see F<pod/perldelta.pod> for a description of what's
+changed between this and the previous release.  If you are upgrading from an
+earlier release, please also check the perldeltas describing changes for the
+intermediate releases, to get a full picture of what changes might affect your
+installation.
+
+See your installed copy of the perllocal.pod file for a (possibly
+incomplete) list of locally installed modules. Also see the L<CPAN> module's
 C<autobundle> function for one way to make a "bundle" of your currently
 installed modules.
 


### PR DESCRIPTION
The paragraph starts:

> On a related issue, old modules may possibly be affected by the changes in the Perl language in the current release.

Previously it made no indication about whether these changes were frequent or rare, small or large. The reality is that we are careful to keep them small and backwards compatible, whenever possible. So add the text:

> We try hard to make new features "opt-in", such that existing code will work unchanged, and attempt to identify where bug fixes might expose code which was relying on incorrect interpreter behaviour.
