### PR TITLE
Make pp_abs a bit compact

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -3034,27 +3034,31 @@ PP(pp_abs)
       SV * const sv = TOPs;
       /* This will cache the NV value if string isn't actually integer  */
       const IV iv = SvIV_nomg(sv);
+      UV uv;
 
       if (!SvOK(sv)) {
-        SETu(0);
+        uv = 0;
+        goto set_uv;
       }
       else if (SvIOK(sv)) {
         /* IVX is precise  */
         if (SvIsUV(sv)) {
-          SETu(SvUVX(sv));	/* force it to be numeric only */
+          uv = SvUVX(sv);       /* force it to be numeric only */
         } else {
           if (iv >= 0) {
-            SETi(iv);
+            uv = (UV)iv;
           } else {
             if (iv != IV_MIN) {
-              SETi(-iv);
+              uv = (UV)-iv;
             } else {
               /* 2s complement assumption. Also, not really needed as
                  IV_MIN and -IV_MIN should both be %100...00 and NV-able  */
-              SETu((UV)IV_MIN);
+              uv = (UV)IV_MIN;
             }
           }
         }
+      set_uv:
+        SETu(uv);
       } else{
         const NV value = SvNV_nomg(sv);
         SETn(Perl_fabs(value));

--- a/pp.c
+++ b/pp.c
@@ -3048,13 +3048,12 @@ PP(pp_abs)
           if (iv >= 0) {
             uv = (UV)iv;
           } else {
-            if (iv != IV_MIN) {
-              uv = (UV)-iv;
-            } else {
-              /* 2s complement assumption. Also, not really needed as
-                 IV_MIN and -IV_MIN should both be %100...00 and NV-able  */
-              uv = (UV)IV_MIN;
-            }
+              /* "(UV)-(iv + 1) + 1" below is mathematically "-iv", but
+                 transformed so that every subexpression will never trigger
+                 overflows even on 2's complement representation (note that
+                 iv is always < 0 here), and modern compilers could optimize
+                 this to a single negation.  */
+              uv = (UV)-(iv + 1) + 1;
           }
         }
       set_uv:

--- a/pp.c
+++ b/pp.c
@@ -3041,7 +3041,7 @@ PP(pp_abs)
       else if (SvIOK(sv)) {
         /* IVX is precise  */
         if (SvIsUV(sv)) {
-          SETu(SvUV_nomg(sv));	/* force it to be numeric only */
+          SETu(SvUVX(sv));	/* force it to be numeric only */
         } else {
           if (iv >= 0) {
             SETi(iv);


### PR DESCRIPTION
While creating #19127 patch, I have noticed that `pp_abs` is somewhat code-bloating in its IV handling.
This patch will hopefully reduce the code size of `pp_abs` while no behavioral changes are expected.