### PR TITLE
gdbm: Define error codes; provide the global $gdbm_errno variable.

### DIFF
--- a/ext/GDBM_File/GDBM_File.pm
+++ b/ext/GDBM_File/GDBM_File.pm
@@ -108,8 +108,8 @@ below for more information.
 
 The I<$mode> parameter is the file mode for creating new database
 file.  Use an octal constant or a combination of C<S_I*> constants
-from the B<Fcntl> module (see L<chmod>).  This parameter is used 
-if I<$flags> is B<GDBM_NEWDB> or B<GDBM_WRCREAT>.
+from the B<Fcntl> module.  This parameter is used if I<$flags> is
+B<GDBM_NEWDB> or B<GDBM_WRCREAT>.
 
 On success, B<tie> returns an object of class B<GDBM_File>.  On failure,
 it returns B<undef>.  It is recommended to always check the return value,

--- a/ext/GDBM_File/GDBM_File.pm
+++ b/ext/GDBM_File/GDBM_File.pm
@@ -65,6 +65,57 @@ Unlike Perl's built-in hashes, it is not safe to C<delete> the current
 item from a GDBM_File tied hash while iterating over it with C<each>.
 This is a limitation of the gdbm library.
 
+=head2 Tie
+
+Use the Perl buil-in B<tie> to associate a B<GDBM> database with a Perl
+hash:
+
+   tie %hash, 'GDBM_File', $filename, $flags, $mode;
+
+Here, I<$filename> is the name of the database file to open or create.
+I<$flags> is a bitwise OR of I<access mode> and optional I<modifiers>.
+Access mode is one of:
+
+=over 4
+
+=item B<GDBM_READER>
+
+Open existing database file in read-only mode.
+
+=item B<GDBM_WRITER>
+
+Open existing database file in read-write mode.
+
+=item B<GDBM_WRCREAT>
+
+If the database file exists, open it in read-write mode.  If it doesn't,
+create it first and open read-write.
+
+=item B<GDBM_NEWDB>
+
+Create new database and open it read-write.  If the database already exists,
+truncate it first.
+
+=back
+
+A number of modifiers can be OR'd to the access mode.  Most of them are
+rarely needed (see L<https://www.gnu.org.ua/software/gdbm/manual/Open.html>
+for a complete list), but one is worth mentioning.  The B<GDBM_NUMSYNC>
+modifier, when used with B<GDBM_NEWDB>, instructs B<GDBM> to create the
+database in I<extended> (so called I<numsync>) format.  This format is
+best suited for crash-tolerant implementations.  See B<CRASH TOLERANCE>
+below for more information.
+
+The I<$mode> parameter is the file mode for creating new database
+file.  Use an octal constant or a combination of C<S_I*> constants
+from the B<Fcntl> module (see L<chmod>).  This parameter is used 
+if I<$flags> is B<GDBM_NEWDB> or B<GDBM_WRCREAT>.
+
+On success, B<tie> returns an object of class B<GDBM_File>.  On failure,
+it returns B<undef>.  It is recommended to always check the return value,
+to make sure your hash is successfully associated with the database file.
+See B<ERROR HANDLING> below for examples.
+
 =head1 STATIC METHODS
 
 =head2 GDBM_version

--- a/ext/GDBM_File/GDBM_File.xs
+++ b/ext/GDBM_File/GDBM_File.xs
@@ -466,14 +466,7 @@ gdbm_errno(db)
     {
         int ec = gdbm_last_errno(db->dbp);
         RETVAL = newSViv(ec);
-        sv_setpv(RETVAL, gdbm_strerror(ec));
-        if (gdbm_check_syserr(ec)) {
-            SV *sv = get_sv("!", 0);
-            if (sv) {
-                sv_catpv(RETVAL, ": ");
-                sv_catsv(RETVAL, sv);
-            }
-        }
+        sv_setpv(RETVAL, gdbm_db_strerror (db->dbp);
         SvIOK_on(RETVAL);
     }
 #else

--- a/ext/GDBM_File/GDBM_File.xs
+++ b/ext/GDBM_File/GDBM_File.xs
@@ -466,7 +466,7 @@ gdbm_errno(db)
     {
         int ec = gdbm_last_errno(db->dbp);
         RETVAL = newSViv(ec);
-        sv_setpv(RETVAL, gdbm_db_strerror (db->dbp);
+        sv_setpv(RETVAL, gdbm_db_strerror (db->dbp));
         SvIOK_on(RETVAL);
     }
 #else

--- a/ext/GDBM_File/Makefile.PL
+++ b/ext/GDBM_File/Makefile.PL
@@ -18,11 +18,69 @@ my @names = qw(GDBM_CACHESIZE GDBM_CENTFREE GDBM_COALESCEBLKS
 push @names, {
     name  => $_,
     type  => "IV",
-    macro => [ "#if  GDBM_VERSION_MAJOR == 1 && GDBM_VERSION_MINOR >= 21\n",
+    macro => [ "#if  GDBM_VERSION_MAJOR > 1 || GDBM_VERSION_MINOR >= 21\n",
                "#endif\n" ],
     value => "$_",
 } foreach qw(GDBM_SNAPSHOT_OK GDBM_SNAPSHOT_BAD GDBM_SNAPSHOT_ERR
              GDBM_SNAPSHOT_SAME GDBM_SNAPSHOT_SUSPICIOUS);
+
+# Basic error codes - these are supported by all versions of gdbm
+push @names, qw(
+    GDBM_NO_ERROR
+    GDBM_MALLOC_ERROR
+    GDBM_BLOCK_SIZE_ERROR
+    GDBM_FILE_OPEN_ERROR
+    GDBM_FILE_WRITE_ERROR
+    GDBM_FILE_SEEK_ERROR
+    GDBM_FILE_READ_ERROR
+    GDBM_BAD_MAGIC_NUMBER
+    GDBM_EMPTY_DATABASE
+    GDBM_CANT_BE_READER
+    GDBM_CANT_BE_WRITER
+    GDBM_READER_CANT_DELETE
+    GDBM_READER_CANT_STORE
+    GDBM_READER_CANT_REORGANIZE
+    GDBM_UNKNOWN_UPDATE
+    GDBM_ITEM_NOT_FOUND
+    GDBM_REORGANIZE_FAILED
+    GDBM_CANNOT_REPLACE
+    GDBM_ILLEGAL_DATA
+    GDBM_OPT_ALREADY_SET
+    GDBM_OPT_ILLEGAL);
+
+# Error codes added in various versions of gdbm
+push @names, {
+    name  => $_->[0],
+    value => "$_->[0]",
+    type  => "IV",
+    macro => [ "#if GDBM_VERSION_MAJOR > 1 || $_->[1]\n",
+               "#endif\n" ],
+} foreach map {
+    my @vref = @{$_}[1..$#{$_}];
+    my $cond;
+    if ($_->[2]) {
+        $cond = "GDBM_VERSION_MINOR > $_->[1] || ( GDBM_VERSION_MINOR == $_->[1] && GDBM_VERSION_PATCH >= $_->[2] )";
+    } else {
+        $cond = "GDBM_VERSION_MINOR >= $_->[1]";
+    }
+    map { [$_, $cond ] } @{$_->[0]}
+} ( # [ [ ERROR_CODE_NAMES ], MAJ [, MIN [, PAT]] ]
+    # where MAJ,MIN,PAT are major, minor and patchlevel numbers of the gdbm
+    # version which introduced ERROR_CODE_NAMES.
+    [[qw(GDBM_BYTE_SWAPPED GDBM_BAD_FILE_OFFSET GDBM_BAD_OPEN_FLAGS)], 9],
+    [[qw(GDBM_FILE_STAT_ERROR GDBM_FILE_EOF)], 10],
+    [[qw(GDBM_NO_DBNAME GDBM_ERR_FILE_OWNER GDBM_ERR_FILE_MODE)], 11],
+    [[qw(GDBM_UNKNOWN_ERROR GDBM_NEED_RECOVERY GDBM_BACKUP_FAILED
+         GDBM_DIR_OVERFLOW)], 13],
+    [[qw(GDBM_BAD_BUCKET GDBM_BAD_HEADER GDBM_BAD_AVAIL GDBM_BAD_HASH_TABLE
+         GDBM_BAD_DIR_ENTRY)], 15],
+    [[qw(GDBM_FILE_CLOSE_ERROR GDBM_FILE_SYNC_ERROR)], 17],
+    [[qw(GDBM_FILE_TRUNCATE_ERROR)], 18, 1],
+    [[qw(GDBM_BUCKET_CACHE_CORRUPTED GDBM_BAD_HASH_ENTRY)], 20],
+    [[qw(GDBM_MALFORMED_DATA GDBM_OPT_BADVAL GDBM_ERR_SNAPSHOT_CLONE
+         GDBM_ERR_REALPATH GDBM_ERR_USAGE)], 21]
+   );
+
 
 WriteConstants(
     NAME => 'GDBM_File',


### PR DESCRIPTION
* ext/GDBM_File/GDBM_File.pm: Export gdbm error codes.
Improve documentation.
* ext/GDBM_File/GDBM_File.xs (BOOT): Define the GDBM_File::gdbm_errno
variable.
(gdbm_errno): Return a value usable both in numeric and string
contexts.
* ext/GDBM_File/Makefile.PL: Define gdbm error codes.