### PR TITLE
Fix Memoize tests, where GDBM_File is involved

### DIFF
--- a/cpan/Memoize/t/errors.t
+++ b/cpan/Memoize/t/errors.t
@@ -21,7 +21,7 @@ $n = 4;
 my $dummyfile = './dummydb';
 use Fcntl;
 my %args = ( DB_File => [],
-             GDBM_File => [$dummyfile, 2, 0666],
+             GDBM_File => [$dummyfile, \&GDBM_File::GDBM_NEWDB, 0666],
              ODBM_File => [$dummyfile, O_RDWR|O_CREAT, 0666],
              NDBM_File => [$dummyfile, O_RDWR|O_CREAT, 0666],
              SDBM_File => [$dummyfile, O_RDWR|O_CREAT, 0666],
@@ -29,7 +29,7 @@ my %args = ( DB_File => [],
 for $mod (qw(DB_File GDBM_File SDBM_File ODBM_File NDBM_File)) {
   eval {
     require "$mod.pm";
-    tie my %cache => $mod, @{$args{$mod}};
+    tie my %cache => $mod, map { (ref($_) eq 'CODE') ? &$_ : $_ } @{$args{$mod}};
     memoize(sub {}, LIST_CACHE => [HASH => \%cache ]);
   };
   print $@ =~ /can only store scalars/

--- a/cpan/Memoize/t/tie_gdbm.t
+++ b/cpan/Memoize/t/tie_gdbm.t
@@ -35,7 +35,7 @@ sub tryout {
   require GDBM_File;
   my ($tiepack, $file, $testno) = @_;
 
-  tie my %cache => $tiepack, $file, O_RDWR | O_CREAT, 0666
+  tie my %cache => $tiepack, $file, &GDBM_File::GDBM_NEWDB, 0666
     or die $!;
 
   memoize 'c5', 


### PR DESCRIPTION
The tie_gdbm.t test uses O_RDWR | O_CREAT as the flags argument
when tying to GDBM_File.  However, GDBM_File requires this argument
to be a valid combination of GDBM_* constants.  Incidentally,
O_RDWR|O_CREAT = 0x42 = GDBM_NOLOCK|GDBM_WRCREAT, so the test passes,
albeit the use of 0x40 (GDBM_NOLOCK) bit is risky.  Change this to
GDBM_NEWDB, which suits this case best.

In errors.t, tests 4--8, constant value 2 (GDBM_WRCREAT) is used
instead.  Change it to use symbolic value, instead of
a hardcoded constant (again, GDBM_NEWDB).
