### PR TITLE
Remove old MSVC++ (pre-VC12) support from Windows Makefiles

### DIFF
--- a/README.win32
+++ b/README.win32
@@ -63,9 +63,8 @@ that are also supported by perl's makefile.
 =back
 
 The Microsoft Visual C++ compilers are also now being given away free. They
-are available as "Visual C++ 2013-2019 Community Edition" (and also as part of
-the ".NET Framework SDK") and are the same compilers that ship with "Visual
-C++ 2013-2019 Professional".
+are available as "Visual C++ 2013-2019 Community Edition" and are the same
+compilers that ship with "Visual C++ 2013-2019 Professional".
 
 Visual C++ 2013 is capable of B<targeting> XP and Windows Server 2003 but the
 build host requirement is Windows 7/Windows Server 2012. For more details see
@@ -73,7 +72,6 @@ https://docs.microsoft.com/en-us/visualstudio/productinfo/vs2013-compatibility-v
 and
 https://docs.microsoft.com/en-us/visualstudio/productinfo/vs2013-sysrequirements-vs
 
-The Windows SDK can be downloaded from L<https://developer.microsoft.com/windows/downloads/sdk-archive>.
 The MinGW64 compiler is available at L<http://mingw-w64.org>.
 The latter is actually a cross-compiler targeting Win64. There's also a trimmed
 down compiler (no java, or gfortran) suitable for building perl available at:
@@ -96,8 +94,8 @@ See L</Usage Hints for Perl on Windows> below for general hints about this.
 =item Make
 
 You need a "make" program to build the sources.  If you are using
-Visual C++ or the Windows SDK tools, you can use nmake supplied with Visual C++
-or Windows SDK. You may also use gmake instead of nmake.  Builds using gcc need
+Visual C++, you can use nmake supplied with Visual C++.
+You may also use gmake instead of nmake.  Builds using gcc need
 gmake. nmake is not supported for gcc builds.  Parallel building is only
 supported with gmake, not nmake.
 
@@ -133,8 +131,7 @@ so.
 
 These free versions of Visual C++ 2013-2019 Professional contain the same
 compilers and linkers that ship with the full versions, and also contain
-everything necessary to build Perl, rather than requiring a separate download
-of the Windows SDK like previous versions did.
+everything necessary to build Perl.
 
 These packages can be downloaded by searching in the Download Center at
 L<https://www.microsoft.com/downloads/search.aspx?displaylang=en>.  (Providing exact
@@ -149,13 +146,7 @@ using, e.g.
 (assuming the default installation location was chosen).
 
 Perl should now build using the win32/Makefile.  You will need to edit that
-file to set CCTYPE to one of MSVC90-MSVC142 first.
-
-=item Microsoft Platform SDK 64-bit Compiler
-
-The nmake that comes with the Platform SDK will suffice for building
-Perl.  Make sure you are building within one of the "Build Environment"
-shells available after you install the Platform SDK from the Start Menu.
+file to set CCTYPE to one of MSVC120-MSVC142 first.
 
 =item GCC
 
@@ -198,7 +189,7 @@ unlike GCC.
 
 Make sure you are in the "win32" subdirectory under the perl toplevel.
 This directory contains a "Makefile" that will work with
-versions of nmake that come with Visual C++ or the Windows SDK, and
+versions of nmake that come with Visual C++, and
 a GNU make "GNUmakefile" that will work for all supported compilers.
 The defaults in the gmake makefile are setup to build using MinGW/gcc.
 

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1,10 +1,9 @@
 #
 # Makefile to build perl on Windows using GMAKE.
 # Supported compilers:
-#	Microsoft Visual C++ 7.0 or later
+#	Microsoft Visual C++ 12.0 or later
 #	MinGW with gcc-3.4.5-5.3.0
 #	MinGW64 with gcc-4.4.3 or later
-#	Windows SDK 64-bit compiler and tools
 #
 # This is set up to build a perl.exe that runs off a shared library
 # (perl535.dll).  Also makes individual DLLs for the XS extensions.
@@ -161,20 +160,6 @@ DEFAULT_INC_EXCLUDES_DOT := define
 #
 # uncomment exactly one of the following
 #
-# Visual C++ .NET 2002/2003 (aka Visual C++ 7.0/7.1) (full version)
-#CCTYPE		:= MSVC70
-# Visual C++ Toolkit 2003 (aka Visual C++ 7.1) (free command-line tools)
-#CCTYPE		:= MSVC70FREE
-# Windows Server 2003 SP1 Platform SDK (April 2005) (64-bit compiler and tools)
-#CCTYPE		:= SDK2003SP1
-# Visual C++ 2005 (aka Visual C++ 8.0) (full version or Express Edition)
-#CCTYPE		:= MSVC80
-# Visual C++ 2008 (aka Visual C++ 9.0) (full version or Express Edition)
-#CCTYPE		:= MSVC90
-# Visual C++ 2010 (aka Visual C++ 10.0) (full version or Express Edition)
-#CCTYPE		:= MSVC100
-# Visual C++ 2012 (aka Visual C++ 11.0) (full version or Express Edition)
-#CCTYPE		:= MSVC110
 # Visual C++ 2013 (aka Visual C++ 12.0) (full version or Express Edition)
 #CCTYPE		:= MSVC120
 # Visual C++ 2015 (aka Visual C++ 14.0) (full version or Express Edition)
@@ -389,22 +374,17 @@ endif
 endif
 endif
 
-# Versions of Visual C++ up to VC++ 7.1 define $(MSVCDir); versions since then
-# define $(VCINSTALLDIR) instead, but for VC++ 14.1 we need the subfolder given
-# by $(VCToolsInstallDir).
+# Versions of Visual C++ up to VC++ 14.0 define $(VCINSTALLDIR), but for
+# VC++ 14.1 we need the subfolder given by $(VCToolsInstallDir).
 ifeq ($(CCHOME),)
 ifeq ($(CCTYPE),GCC)
 CCHOME		:= C:\MinGW
-else ifeq ($(CCTYPE),MSVC70)
-CCHOME		:= $(MSVCDir)
-else ifeq ($(CCTYPE),MSVC70FREE)
-CCHOME		:= $(MSVCDir)
-else ifeq ($(CCTYPE),MSVC141)
-CCHOME		:= $(VCToolsInstallDir)
-else ifeq ($(CCTYPE),MSVC142)
-CCHOME		:= $(VCToolsInstallDir)
-else
+else ifeq ($(CCTYPE),MSVC120)
 CCHOME		:= $(VCINSTALLDIR)
+else ifeq ($(CCTYPE),MSVC140)
+CCHOME		:= $(VCINSTALLDIR)
+else
+CCHOME		:= $(VCToolsInstallDir)
 endif
 endif
 
@@ -516,23 +496,23 @@ CCLIBDIR := $(CCHOME)\lib;$(CCHOME)\$(GCCTARGET)\lib;$(CCHOME)\lib\gcc\$(GCCTARG
 ARCHPREFIX :=
 else
 CCINCDIR := $(CCHOME)\include
-ifeq ($(CCTYPE),MSVC141)
-ifeq ($(WIN64),define)
-CCLIBDIR := $(CCHOME)\lib\x64
-else
-CCLIBDIR := $(CCHOME)\lib\x86
-endif
-else ifeq ($(CCTYPE),MSVC142)
-ifeq ($(WIN64),define)
-CCLIBDIR := $(CCHOME)\lib\x64
-else
-CCLIBDIR := $(CCHOME)\lib\x86
-endif
-else
+ifeq ($(CCTYPE),MSVC120)
 ifeq ($(WIN64),define)
 CCLIBDIR := $(CCHOME)\lib\amd64
 else
 CCLIBDIR := $(CCHOME)\lib
+endif
+else ifeq ($(CCTYPE),MSVC140)
+ifeq ($(WIN64),define)
+CCLIBDIR := $(CCHOME)\lib\amd64
+else
+CCLIBDIR := $(CCHOME)\lib
+endif
+else
+ifeq ($(WIN64),define)
+CCLIBDIR := $(CCHOME)\lib\x64
+else
+CCLIBDIR := $(CCHOME)\lib\x86
 endif
 endif
 ARCHPREFIX :=
@@ -651,9 +631,7 @@ else
 
 o = .obj
 
-# All but the free version of VC++ 7.1 can load DLLs on demand.  Makes the test
-# suite run in about 10% less time.
-ifneq ($(CCTYPE),MSVC70FREE)
+# Loading DLLs on demand makes the test suite run in about 10% less time.
 # If no registry, advapi32 is only used for Perl_pp_getlogin/getlogin/GetUserNameA
 # which is rare to execute
 ifneq ($(USE_NO_REGISTRY),undef)
@@ -663,31 +641,6 @@ else
 DELAYLOAD	= -DELAYLOAD:ws2_32.dll delayimp.lib
 #miniperl never does any registry lookups
 MINIDELAYLOAD	= -DELAYLOAD:advapi32.dll
-endif
-endif
-
-# Visual C++ 2005 and 2008 (VC++ 8.0 and 9.0) create manifest files for EXEs and
-# DLLs. These either need copying everywhere with the binaries, or else need
-# embedding in them otherwise MSVCR80.dll or MSVCR90.dll won't be found. For
-# simplicity, embed them if they exist (and delete them afterwards so that they
-# don't get installed too).
-EMBED_EXE_MANI	= if exist $@.manifest mt -nologo -manifest $@.manifest -outputresource:$@;1 && \
-		  if exist $@.manifest del $@.manifest
-EMBED_DLL_MANI	= if exist $@.manifest mt -nologo -manifest $@.manifest -outputresource:$@;2 && \
-		  if exist $@.manifest del $@.manifest
-# This one is for perl.exe which already has an embedded manifest, so we want to
-# append to it, not replace it.
-APPEND_EXE_MANI	= if exist $@.manifest mt -nologo -manifest $@.manifest -updateresource:$@;1 && \
-		  if exist $@.manifest del $@.manifest
-
-# Most relevant compiler-specific options fall into two groups:
-# either pre-MSVC80 or MSVC80 onwards, so define a macro for this.
-ifeq ($(CCTYPE),MSVC70)
-PREMSVC80	= define
-else ifeq ($(CCTYPE),MSVC70FREE)
-PREMSVC80	= define
-else
-PREMSVC80	= undef
 endif
 
 ifneq ($(__ICC),define)
@@ -711,14 +664,10 @@ LOCDEFS		= -DPERLDLL -DPERL_CORE
 CXX_FLAG	= -TP -EHsc
 EXTRACFLAGS	= -nologo -GF -W3
 
-ifeq ($(CCTYPE),MSVC140)
-LIBC		= ucrt.lib
-else ifeq ($(CCTYPE),MSVC141)
-LIBC		= ucrt.lib
-else ifeq ($(CCTYPE),MSVC142)
-LIBC		= ucrt.lib
-else
+ifeq ($(CCTYPE),MSVC120)
 LIBC		= msvcrt.lib
+else
+LIBC		= ucrt.lib
 endif
 
 ifeq ($(CFG),Debug)
@@ -731,14 +680,10 @@ OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
 EXTRACFLAGS	+= -MD
 else ifeq ($(CFG),DebugFull)
-ifeq ($(CCTYPE),MSVC140)
-LIBC		= ucrtd.lib
-else ifeq ($(CCTYPE),MSVC141)
-LIBC		= ucrtd.lib
-else ifeq ($(CCTYPE),MSVC142)
-LIBC		= ucrtd.lib
-else
+ifeq ($(CCTYPE),MSVC120)
 LIBC		= msvcrtd.lib
+else
+LIBC		= ucrtd.lib
 endif
 OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
@@ -766,42 +711,13 @@ DEFINES		+= -DWIN64
 OPTIMIZE	+= -fp:precise
 endif
 
-# For now, silence warnings from VC++ 8.0 onwards about "unsafe" CRT functions
+# For now, silence warnings about "unsafe" CRT functions
 # and POSIX CRT function names being deprecated.
-ifeq ($(PREMSVC80),undef)
 DEFINES		+= -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE
-endif
 
 # Likewise for deprecated Winsock APIs in VC++ 14.0 onwards for now.
-ifeq ($(CCTYPE),MSVC140)
+ifneq ($(CCTYPE),MSVC120)
 DEFINES		+= -D_WINSOCK_DEPRECATED_NO_WARNINGS
-else ifeq ($(CCTYPE),MSVC141)
-DEFINES		+= -D_WINSOCK_DEPRECATED_NO_WARNINGS
-else ifeq ($(CCTYPE),MSVC142)
-DEFINES		+= -D_WINSOCK_DEPRECATED_NO_WARNINGS
-endif
-
-# The Windows Server 2003 SP1 SDK compiler only defines _configthreadlocale() if
-# _MT is defined, i.e. when using /MT (the LIBCMT.lib version of the CRT), which
-# the perl build doesn't use. We therefore specify NO_THREAD_SAFE_LOCALE so that
-# perl.h doesn't set USE_THREAD_SAFE_LOCALE, which it otherwise would do since
-# _MSC_VER is 1400 for this compiler (as per MSVC80).
-ifeq ($(CCTYPE),SDK2003SP1)
-DEFINES		+= -DNO_THREAD_SAFE_LOCALE
-endif
-
-# In VS 2005 (VC++ 8.0) Microsoft changes time_t from 32-bit to
-# 64-bit, even in 32-bit mode.  It also provides the _USE_32BIT_TIME_T
-# preprocessor option to revert back to the old functionality for
-# backward compatibility.  We define this symbol here for older 32-bit
-# compilers only (which aren't using it at all) for the sole purpose
-# of getting it into $Config{ccflags}.  That way if someone builds
-# Perl itself with e.g. VC7 but later installs an XS module using VC8
-# the time_t types will still be compatible.
-ifeq ($(WIN64),undef)
-ifeq ($(PREMSVC80),define)
-BUILDOPT	+= -D_USE_32BIT_TIME_T
-endif
 endif
 
 LIBBASEFILES	= oldnames.lib kernel32.lib user32.lib gdi32.lib winspool.lib \
@@ -809,19 +725,7 @@ LIBBASEFILES	= oldnames.lib kernel32.lib user32.lib gdi32.lib winspool.lib \
 	netapi32.lib uuid.lib ws2_32.lib mpr.lib winmm.lib version.lib \
 	odbc32.lib odbccp32.lib comctl32.lib
 
-ifeq ($(CCTYPE),MSVC140)
-ifeq ($(CFG),DebugFull)
-LIBBASEFILES	+= msvcrtd.lib vcruntimed.lib
-else
-LIBBASEFILES	+= msvcrt.lib vcruntime.lib
-endif
-else ifeq ($(CCTYPE),MSVC141)
-ifeq ($(CFG),DebugFull)
-LIBBASEFILES	+= msvcrtd.lib vcruntimed.lib
-else
-LIBBASEFILES	+= msvcrt.lib vcruntime.lib
-endif
-else ifeq ($(CCTYPE),MSVC142)
+ifneq ($(CCTYPE),MSVC120)
 ifeq ($(CFG),DebugFull)
 LIBBASEFILES	+= msvcrtd.lib vcruntimed.lib
 else
@@ -835,14 +739,6 @@ endif
 # and optimized C89 funcs
 ifeq ($(__ICC),define)
 LIBBASEFILES	+= libircmt.lib libmmd.lib
-endif
-
-# The Windows Server 2003 SP1 SDK compiler links against MSVCRT.dll, which
-# doesn't include the buffer overrun verification code used by the /GS switch.
-# Since the code links against libraries that are compiled with /GS, this
-# "security cookie verification" code must be included via bufferoverflow.lib.
-ifeq ($(CCTYPE),SDK2003SP1)
-LIBBASEFILES    += bufferoverflowU.lib
 endif
 
 LIBFILES	= $(LIBBASEFILES) $(LIBC)
@@ -874,40 +770,14 @@ RSC_FLAGS	=
 # VS 2017 (VC++ 14.1) requires at minimum Windows 7 SP1 (with latest Windows Updates)
 
 # For XP support in >= VS 2013 (VC++ 12.0), subsystem is always in Config.pm
-# LINK_FLAGS else subsystem is only needed for EXE building, not XS DLL building
-# Console vs GUI makes no difference for DLLs, so use default for cleaner
-# building cmd lines
+# LINK_FLAGS.
 
-ifeq ($(CCTYPE),MSVC120)
+ifneq ($(CCTYPE),GCC)
 ifeq ($(WIN64),define)
 LINK_FLAGS	+= -subsystem:console,"5.02"
 else
 LINK_FLAGS	+= -subsystem:console,"5.01"
 endif
-
-else ifeq ($(CCTYPE),MSVC140)
-ifeq ($(WIN64),define)
-LINK_FLAGS	+= -subsystem:console,"5.02"
-else
-LINK_FLAGS	+= -subsystem:console,"5.01"
-endif
-
-else ifeq ($(CCTYPE),MSVC141)
-ifeq ($(WIN64),define)
-LINK_FLAGS	+= -subsystem:console,"5.02"
-else
-LINK_FLAGS	+= -subsystem:console,"5.01"
-endif
-
-else ifeq ($(CCTYPE),MSVC142)
-ifeq ($(WIN64),define)
-LINK_FLAGS	+= -subsystem:console,"5.02"
-else
-LINK_FLAGS	+= -subsystem:console,"5.01"
-endif
-
-else ifneq ($(CCTYPE),GCC)
-PRIV_LINK_FLAGS	+= -subsystem:console
 endif
 
 BLINK_FLAGS	= $(PRIV_LINK_FLAGS) $(LINK_FLAGS)
@@ -1288,7 +1158,7 @@ ifeq ($(CCTYPE),GCC)
 	$(LINK32) $(EXTRACFLAGS) $(OPTIMIZE) $(BLINK_FLAGS) -mconsole -o $@ perlglob.c $(LIBFILES)
 else
 	$(CC) $(EXTRACFLAGS) $(OPTIMIZE) $(PDBOUT) -Fe$@ perlglob.c -link $(BLINK_FLAGS) \
-	setargv$(o) $(LIBFILES) && $(EMBED_EXE_MANI)
+	setargv$(o) $(LIBFILES)
 endif
 
 ..\git_version.h : $(HAVEMINIPERL) ..\make_patchnum.pl
@@ -1324,7 +1194,6 @@ ifeq ($(CCTYPE),GCC)
 else
 	$(LINK32) -out:$(MINIPERL) $(BLINK_FLAGS) \
 	    $(DELAYLOAD) $(MINIDELAYLOAD) $(LIBFILES) $(MINI_OBJ)
-	$(subst $@,$(MINIPERL),$(EMBED_EXE_MANI))
 
 endif
 	$(MINIPERL) -I..\lib -f ..\write_buildcustomize.pl ..
@@ -1389,27 +1258,7 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #undef I_QUADMATH&& \
 	echo #undef USE_QUADMATH&& \
 	echo #undef USE_CPLUSPLUS)>> config.h
-ifeq ($(CCTYPE),MSVC140)
-	@(echo #undef FILE_ptr&& \
-	echo #undef FILE_cnt&& \
-	echo #undef FILE_base&& \
-	echo #undef FILE_bufsiz&& \
-	echo #define FILE_ptr^(fp^) PERLIO_FILE_ptr^(fp^)&& \
-	echo #define FILE_cnt^(fp^) PERLIO_FILE_cnt^(fp^)&& \
-	echo #define FILE_base^(fp^) PERLIO_FILE_base^(fp^)&& \
-	echo #define FILE_bufsiz^(fp^) ^(PERLIO_FILE_cnt^(fp^) + PERLIO_FILE_ptr^(fp^) - PERLIO_FILE_base^(fp^)^)&& \
-	echo #define I_STDBOOL)>> config.h
-else ifeq ($(CCTYPE),MSVC141)
-	@(echo #undef FILE_ptr&& \
-	echo #undef FILE_cnt&& \
-	echo #undef FILE_base&& \
-	echo #undef FILE_bufsiz&& \
-	echo #define FILE_ptr^(fp^) PERLIO_FILE_ptr^(fp^)&& \
-	echo #define FILE_cnt^(fp^) PERLIO_FILE_cnt^(fp^)&& \
-	echo #define FILE_base^(fp^) PERLIO_FILE_base^(fp^)&& \
-	echo #define FILE_bufsiz^(fp^) ^(PERLIO_FILE_cnt^(fp^) + PERLIO_FILE_ptr^(fp^) - PERLIO_FILE_base^(fp^)^)&& \
-	echo #define I_STDBOOL)>> config.h
-else ifeq ($(CCTYPE),MSVC142)
+ifneq ($(CCTYPE),MSVC120)
 	@(echo #undef FILE_ptr&& \
 	echo #undef FILE_cnt&& \
 	echo #undef FILE_base&& \
@@ -1609,7 +1458,6 @@ else
 	    @Extensions_static \
 	    $(DELAYLOAD) $(LIBFILES) \
 	    $(PERLDLL_RES) $(PERLDLL_OBJ) $(PERLEXPLIB)
-	$(EMBED_DLL_MANI)
 endif
 
 $(PERLSTATICLIB): $(PERLDLL_OBJ) Extensions_static
@@ -1642,7 +1490,6 @@ ifeq ($(CCTYPE),GCC)
 	$(BLINK_FLAGS) $(LIBFILES)
 else
 	$(CC) $(CFLAGS_O) $(PDBOUT) -Fe..\generate_uudmap.exe ..\generate_uudmap.c -link $(LIBFILES) $(BLINK_FLAGS)
-	$(EMBED_EXE_MANI)
 endif
 
 .PHONY: MakePPPort
@@ -1670,7 +1517,6 @@ ifeq ($(CCTYPE),GCC)
 else
 	$(LINK32) -out:$@ $(BLINK_FLAGS) \
 	    $(PERLEXE_OBJ) $(PERLEXE_RES) $(PERLIMPLIB) $(LIBFILES) $(SETARGV_OBJ)
-	$(APPEND_EXE_MANI)
 endif
 	copy $(PERLEXE) $(WPERLEXE)
 	$(MINIPERL) -I..\lib bin\exetype.pl $(WPERLEXE) WINDOWS
@@ -1682,7 +1528,6 @@ ifeq ($(CCTYPE),GCC)
 else
 	$(LINK32) -out:$@ $(BLINK_FLAGS) \
 	    $(PERLEXEST_OBJ) $(PERLEXE_RES) $(PERLSTATICLIB) $(LIBFILES) $(SETARGV_OBJ)
-	$(APPEND_EXE_MANI)
 endif
 
 #-------------------------------------------------------------------------------

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -1,8 +1,7 @@
 #
 # Makefile to build perl on Windows using Microsoft NMAKE.
 # Supported compilers:
-#	Microsoft Visual C++ 7.0 or later
-#	Windows SDK 64-bit compiler and tools
+#	Microsoft Visual C++ 12.0 or later
 #
 # This is set up to build a perl.exe that runs off a shared library
 # (perl535.dll).  Also makes individual DLLs for the XS extensions.
@@ -103,20 +102,6 @@ DEFAULT_INC_EXCLUDES_DOT = define
 #
 # uncomment exactly one of the following
 #
-# Visual C++ .NET 2002/2003 (aka Visual C++ 7.0/7.1) (full version)
-#CCTYPE		= MSVC70
-# Visual C++ Toolkit 2003 (aka Visual C++ 7.1) (free command-line tools)
-#CCTYPE		= MSVC70FREE
-# Windows Server 2003 SP1 Platform SDK (April 2005) (64-bit compiler and tools)
-#CCTYPE		= SDK2003SP1
-# Visual C++ 2005 (aka Visual C++ 8.0) (full version or Express Edition)
-#CCTYPE		= MSVC80
-# Visual C++ 2008 (aka Visual C++ 9.0) (full version or Express Edition)
-#CCTYPE		= MSVC90
-# Visual C++ 2010 (aka Visual C++ 10.0) (full version or Express Edition)
-#CCTYPE		= MSVC100
-# Visual C++ 2012 (aka Visual C++ 11.0) (full version or Express Edition)
-#CCTYPE		= MSVC110
 # Visual C++ 2013 (aka Visual C++ 12.0) (full version or Express Edition)
 #CCTYPE		= MSVC120
 # Visual C++ 2015 (aka Visual C++ 14.0) (full version or Express Edition)
@@ -202,16 +187,13 @@ DEFAULT_INC_EXCLUDES_DOT = define
 # set the install location of the compiler
 # Running VCVARS32.BAT, VCVARSALL.BAT or similar is *required* when using
 # Visual C++.
-# Versions of Visual C++ up to VC++ 7.1 define $(MSVCDir); versions since then
-# define $(VCINSTALLDIR) instead, but from VC++ 14.1 we need the subfolder given
-# by $(VCToolsInstallDir).
+# Versions of Visual C++ up to VC++ 14.0 define $(VCINSTALLDIR), but from
+# VC++ 14.1 we need the subfolder given by $(VCToolsInstallDir).
 #
-!IF "$(CCTYPE)" == "MSVC70" || "$(CCTYPE)" == "MSVC70FREE"
-CCHOME		= $(MSVCDIR)
-!ELSEIF "$(CCTYPE)" == "MSVC141" || "$(CCTYPE)" == "MSVC142"
-CCHOME		= $(VCTOOLSINSTALLDIR)
-!ELSE
+!IF "$(CCTYPE)" == "MSVC120" || "$(CCTYPE)" == "MSVC140"
 CCHOME		= $(VCINSTALLDIR)
+!ELSE
+CCHOME		= $(VCTOOLSINSTALLDIR)
 !ENDIF
 
 #
@@ -347,14 +329,6 @@ WIN64			= undef
 USE_64_BIT_INT	= define
 !ENDIF
 
-# Most relevant compiler-specific options fall into two groups:
-# either pre-MSVC80 or MSVC80 onwards, so define a macro for this.
-!IF "$(CCTYPE)" == "MSVC70" || "$(CCTYPE)" == "MSVC70FREE"
-PREMSVC80	= define
-!ELSE
-PREMSVC80	= undef
-!ENDIF
-
 ARCHITECTURE = $(PROCESSOR_ARCHITECTURE)
 !IF "$(ARCHITECTURE)" == "AMD64"
 ARCHITECTURE	= x64
@@ -376,50 +350,32 @@ ARCHNAME	= $(ARCHNAME)-thread
 ARCHNAME	= $(ARCHNAME)-64int
 !ENDIF
 
-# All but the free version of VC++ 7.1 can load DLLs on demand.  Makes the test
-# suite run in about 10% less time.
-!IF "$(CCTYPE)" != "MSVC70FREE"
+# Loading DLLs on demand makes the test suite run in about 10% less time.
 # If no registry, advapi32 is only used for Perl_pp_getlogin/getlogin/GetUserNameA
 # which is rare to execute
-!  IF "$(USE_NO_REGISTRY)" != "undef"
+!IF "$(USE_NO_REGISTRY)" != "undef"
 DELAYLOAD	= -DELAYLOAD:ws2_32.dll -DELAYLOAD:advapi32.dll delayimp.lib
 MINIDELAYLOAD	=
-!  ELSE
+!ELSE
 DELAYLOAD	= -DELAYLOAD:ws2_32.dll delayimp.lib
 #miniperl never does any registry lookups
 MINIDELAYLOAD	= -DELAYLOAD:advapi32.dll
-!  ENDIF
 !ENDIF
-
-# Visual C++ 2005 and 2008 (VC++ 8.0 and 9.0) create manifest files for EXEs and
-# DLLs. These either need copying everywhere with the binaries, or else need
-# embedding in them otherwise MSVCR80.dll or MSVCR90.dll won't be found. For
-# simplicity, embed them if they exist (and delete them afterwards so that they
-# don't get installed too).
-EMBED_EXE_MANI	= if exist $@.manifest mt -nologo -manifest $@.manifest -outputresource:$@;1 && \
-		  if exist $@.manifest del $@.manifest
-EMBED_DLL_MANI	= if exist $@.manifest mt -nologo -manifest $@.manifest -outputresource:$@;2 && \
-		  if exist $@.manifest del $@.manifest
-# This one is for perl.exe which already has an embedded manifest, so we want to
-# append to it, not replace it.
-APPEND_EXE_MANI	= if exist $@.manifest mt -nologo -manifest $@.manifest -updateresource:$@;1 && \
-		  if exist $@.manifest del $@.manifest
-
 
 # Set the install location of the compiler headers/libraries.
 # These are saved into $Config{incpath} and $Config{libpth}.
 CCINCDIR	= $(CCHOME)\include
-!IF "$(CCTYPE)" == "MSVC141" || "$(CCTYPE)" == "MSVC142"
-!  IF "$(WIN64)" == "define"
-CCLIBDIR	= $(CCHOME)\lib\x64
-!  ELSE
-CCLIBDIR	= $(CCHOME)\lib\x86
-!  ENDIF
-!ELSE
+!IF "$(CCTYPE)" == "MSVC120" || "$(CCTYPE)" == "MSVC140"
 !  IF "$(WIN64)" == "define"
 CCLIBDIR	= $(CCHOME)\lib\amd64
 !  ELSE
 CCLIBDIR	= $(CCHOME)\lib
+!  ENDIF
+!ELSE
+!  IF "$(WIN64)" == "define"
+CCLIBDIR	= $(CCHOME)\lib\x64
+!  ELSE
+CCLIBDIR	= $(CCHOME)\lib\x86
 !  ENDIF
 !ENDIF
 
@@ -471,10 +427,10 @@ LOCDEFS		= -DPERLDLL -DPERL_CORE
 CXX_FLAG	= -TP -EHsc
 EXTRACFLAGS	= -nologo -GF -W3
 
-!IF "$(CCTYPE)" == "MSVC140" || "$(CCTYPE)" == "MSVC141" || "$(CCTYPE)" == "MSVC142"
-LIBC		= ucrt.lib
-!ELSE
+!IF "$(CCTYPE)" == "MSVC120"
 LIBC		= msvcrt.lib
+!ELSE
+LIBC		= ucrt.lib
 !ENDIF
 
 !IF  "$(CFG)" == "Debug"
@@ -487,10 +443,10 @@ OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
 EXTRACFLAGS	= $(EXTRACFLAGS) -MD
 !ELSEIF  "$(CFG)" == "DebugFull"
-!  IF "$(CCTYPE)" == "MSVC140" || "$(CCTYPE)" == "MSVC141" || "$(CCTYPE)" == "MSVC142"
-LIBC		= ucrtd.lib
-!  ELSE
+!  IF "$(CCTYPE)" == "MSVC120"
 LIBC		= msvcrtd.lib
+!  ELSE
+LIBC		= ucrtd.lib
 !  ENDIF
 OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
@@ -517,36 +473,13 @@ DEFINES		= $(DEFINES) -DWIN64
 OPTIMIZE	= $(OPTIMIZE) -fp:precise
 !ENDIF
 
-# For now, silence warnings from VC++ 8.0 onwards about "unsafe" CRT functions
+# For now, silence warnings about "unsafe" CRT functions
 # and POSIX CRT function names being deprecated.
-!IF "$(PREMSVC80)" == "undef"
 DEFINES		= $(DEFINES) -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE
-!ENDIF
 
 # Likewise for deprecated Winsock APIs in VC++ 14.0 onwards for now.
-!IF "$(CCTYPE)" == "MSVC140" || "$(CCTYPE)" == "MSVC141" || "$(CCTYPE)" == "MSVC142"
+!IF "$(CCTYPE)" != "MSVC120"
 DEFINES		= $(DEFINES) -D_WINSOCK_DEPRECATED_NO_WARNINGS
-!ENDIF
-
-# The Windows Server 2003 SP1 SDK compiler only defines _configthreadlocale() if
-# _MT is defined, i.e. when using /MT (the LIBCMT.lib version of the CRT), which
-# the perl build doesn't use. We therefore specify NO_THREAD_SAFE_LOCALE so that
-# perl.h doesn't set USE_THREAD_SAFE_LOCALE, which it otherwise would do since
-# _MSC_VER is 1400 for this compiler (as per MSVC80).
-!IF "$(CCTYPE)" == "SDK2003SP1"
-DEFINES		= $(DEFINES) -DNO_THREAD_SAFE_LOCALE
-!ENDIF
-
-# In VS 2005 (VC++ 8.0) Microsoft changes time_t from 32-bit to
-# 64-bit, even in 32-bit mode.  It also provides the _USE_32BIT_TIME_T
-# preprocessor option to revert back to the old functionality for
-# backward compatibility.  We define this symbol here for older 32-bit
-# compilers only (which aren't using it at all) for the sole purpose
-# of getting it into $Config{ccflags}.  That way if someone builds
-# Perl itself with e.g. VC7 but later installs an XS module using VC8
-# the time_t types will still be compatible.
-!IF "$(WIN64)" == "undef" && "$(PREMSVC80)" == "define"
-BUILDOPT	= $(BUILDOPT) -D_USE_32BIT_TIME_T
 !ENDIF
 
 LIBBASEFILES	= \
@@ -555,7 +488,7 @@ LIBBASEFILES	= \
 		netapi32.lib uuid.lib ws2_32.lib mpr.lib winmm.lib \
 		version.lib odbc32.lib odbccp32.lib comctl32.lib
 
-!IF "$(CCTYPE)" == "MSVC140" || "$(CCTYPE)" == "MSVC141" || "$(CCTYPE)" == "MSVC142"
+!IF "$(CCTYPE)" != "MSVC120"
 !  IF  "$(CFG)" == "DebugFull"
 LIBBASEFILES	= $(LIBBASEFILES) msvcrtd.lib vcruntimed.lib
 !  ELSE
@@ -569,14 +502,6 @@ LIBBASEFILES	= $(LIBBASEFILES) msvcrt.lib vcruntime.lib
 # and optimized C89 funcs
 !IF "$(__ICC)" == "define"
 LIBBASEFILES	= $(LIBBASEFILES) libircmt.lib libmmd.lib
-!ENDIF
-
-# The Windows Server 2003 SP1 SDK compiler links against MSVCRT.dll, which
-# doesn't include the buffer overrun verification code used by the /GS switch.
-# Since the code links against libraries that are compiled with /GS, this
-# "security cookie verification" code must be included via bufferoverflow.lib.
-!IF "$(CCTYPE)" == "SDK2003SP1"
-LIBBASEFILES    = $(LIBBASEFILES) bufferoverflowU.lib
 !ENDIF
 
 LIBFILES	= $(LIBBASEFILES) $(LIBC)
@@ -603,18 +528,11 @@ RSC_FLAGS	=
 # VS 2017 (VC++ 14.1) requires at minimum Windows 7 SP1 (with latest Windows Updates)
 
 # For XP support in >= VS 2013 (VC++ 12.0), subsystem is always in Config.pm
-# LINK_FLAGS else subsystem is only needed for EXE building, not XS DLL building
-# Console vs GUI makes no difference for DLLs, so use default for cleaner
-# building cmd lines
-!IF "$(CCTYPE)" == "MSVC120" || "$(CCTYPE)" == "MSVC140" || "$(CCTYPE)" == "MSVC141" || "$(CCTYPE)" == "MSVC142"
-!  IF "$(WIN64)" == "define"
+# LINK_FLAGS.
+!IF "$(WIN64)" == "define"
 LINK_FLAGS	= $(LINK_FLAGS) -subsystem:console,"5.02"
-!  ELSE
-LINK_FLAGS	= $(LINK_FLAGS) -subsystem:console,"5.01"
-!  ENDIF
-
 !ELSE
-PRIV_LINK_FLAGS	= $(PRIV_LINK_FLAGS) -subsystem:console
+LINK_FLAGS	= $(LINK_FLAGS) -subsystem:console,"5.01"
 !ENDIF
 
 BLINK_FLAGS	= $(PRIV_LINK_FLAGS) $(LINK_FLAGS)
@@ -645,7 +563,6 @@ o = .obj
 $(o).dll:
 	$(LINK32) -dll -implib:$(*B).lib -def:$(*B).def \
 	    -out:$@ $(BLINK_FLAGS) $(LIBFILES) $< $(LIBPERL)
-	$(EMBED_DLL_MANI)
 
 .rc.res:
 	$(RSC) -i.. $(RSC_FLAGS) $<
@@ -935,7 +852,6 @@ static: $(PERLEXESTATIC)
 $(GLOBEXE) : perlglob$(o)
 	$(LINK32) $(BLINK_FLAGS) $(LIBFILES) -out:$@ \
 	    perlglob$(o) setargv$(o)
-	$(EMBED_EXE_MANI)
 
 perlglob$(o)  : perlglob.c
 
@@ -976,7 +892,6 @@ $(MINIPERL) : ..\lib\buildcustomize.pl
 	$(LINK32) -out:$(MINIPERL) @<<
 	$(BLINK_FLAGS) $(DELAYLOAD) $(MINIDELAYLOAD) $(LIBFILES) $(MINI_OBJ)
 <<
-	$(EMBED_EXE_MANI:..\lib\buildcustomize.pl=..\miniperl.exe)
 	$(MINIPERL) -I..\lib -f ..\write_buildcustomize.pl ..
 
 $(MINIDIR)\.exists : $(CFGH_TMPL)
@@ -1014,7 +929,7 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #undef USE_64_BIT_INT&& \
 	echo #undef USE_LONG_DOUBLE&& \
 	echo #undef USE_CPLUSPLUS)>> config.h
-!IF "$(CCTYPE)" == "MSVC140" || "$(CCTYPE)" == "MSVC141" || "$(CCTYPE)" == "MSVC142"
+!IF "$(CCTYPE)" != "MSVC120"
 	@(echo #undef FILE_ptr&& \
 	echo #undef FILE_cnt&& \
 	echo #undef FILE_base&& \
@@ -1108,7 +1023,6 @@ $(PERLDLL): perldll.def $(PERLDLL_OBJ) $(PERLDLL_RES) Extensions_static
 	$(LINK32) -dll -def:perldll.def -out:$@ @Extensions_static @<<
 		$(BLINK_FLAGS) $(DELAYLOAD) $(LIBFILES) $(PERLDLL_OBJ) $(PERLDLL_RES)
 <<
-	$(EMBED_DLL_MANI)
 	$(XCOPY) $(PERLIMPLIB) $(COREDIR)
 
 $(PERLSTATICLIB): Extensions_static
@@ -1132,7 +1046,6 @@ $(GENUUDMAP) : $(GENUUDMAP_OBJ)
 	$(LINK32) -out:$@ @<<
 		$(BLINK_FLAGS) $(LIBFILES) $(GENUUDMAP_OBJ)
 <<
-	$(EMBED_EXE_MANI)
 
 perlmain.c : runperl.c
 	copy runperl.c perlmain.c
@@ -1149,14 +1062,12 @@ perlmainst$(o) : perlmainst.c
 $(PERLEXE): $(PERLDLL) $(CONFIGPM) $(PERLEXE_OBJ) $(PERLEXE_RES)
 	$(LINK32) -out:$@ $(BLINK_FLAGS) \
 	    $(PERLEXE_OBJ) $(PERLEXE_RES) $(PERLIMPLIB) $(LIBFILES) $(SETARGV_OBJ)
-	$(APPEND_EXE_MANI)
 	copy $(PERLEXE) $(WPERLEXE)
 	$(MINIPERL) -I..\lib bin\exetype.pl $(WPERLEXE) WINDOWS
 
 $(PERLEXESTATIC): $(PERLSTATICLIB) $(CONFIGPM) $(PERLEXEST_OBJ) $(PERLEXE_RES)
 	$(LINK32) -out:$@ $(BLINK_FLAGS) \
 	    $(PERLEXEST_OBJ) $(PERLEXE_RES) $(PERLSTATICLIB) $(LIBFILES) $(SETARGV_OBJ)
-	$(APPEND_EXE_MANI)
 
 MakePPPort: $(MINIPERL) $(CONFIGPM) Extensions_nonxs
 	$(MINIPERL) -I..\lib ..\mkppport


### PR DESCRIPTION
Also remove the Platform SDK 2003 SP1/R2 64-bit compiler since (having just
tried it) it no longer builds perl because it doesn't allow mixed code and
declarations.

Also remove mention of the Windows SDK since it doesn't appear to contain
the compiler or linker any more. This page says that the VC++ 2010 compiler
and linker were included in the Windows 7 SDK but then makes no mention of
it for the Windows 8 SDK:
https://docs.microsoft.com/en-us/previous-versions/visualstudio/windows-sdk/ff660763(v=vs.110)
The page notes that it is no longer being updated, but the whole of the
C:\Program Files (x86)\Windows Kits folder on my system (which contains
8.0, 8.10 and 10) does not contain any cl.exe or link.exe.

I've re-worded some of the if/else conditions in the makefiles to pick out
earlier versions rather than later versions. Thus, the current versions
become the "else" case, which means that the next version of Visual C++ is
more likely to work without requiring any changes.