### PR TITLE
`for my($k, $v) (%hash)` should not be a syntax error

### DIFF
--- a/t/comp/parser_run.t
+++ b/t/comp/parser_run.t
@@ -15,13 +15,11 @@ plan(7);
 # [perl #130814] can reallocate lineptr while looking ahead for
 # "Missing $ on loop variable" diagnostic.
 my $result = fresh_perl(
-    " foreach m0\n\$" . ("v" x 0x2000),
+    " foreach my\n\$" . ("v" x 0x2000),
     { stderr => 1 },
 );
 is($result . "\n", <<EXPECT);
-syntax error at - line 3, near "foreach m0
-"
-Identifier too long at - line 3.
+Identifier too long at - line 2.
 EXPECT
 
 fresh_perl_is(<<'EOS', <<'EXPECT', {}, "check zero vars");

--- a/t/op/for-many.t
+++ b/t/op/for-many.t
@@ -500,4 +500,39 @@ is($continue, 'xx', 'continue reached twice');
     is("@have", 'alpaca;guanaco llama;vicuña', 'comma test 42');
 }
 
+# Spaces shouldn't trigger parsing errors:
+{
+    my @correct = ('Pointy', 'Up', 'Flamey', 'Down');
+
+    @have = ();
+
+    for my                                          ($one) (@correct) {
+        push @have, $one;
+    }
+    is("@have", "@correct", 'for my ($one)');
+
+    @have = ();
+
+    for my($one) (@correct) {
+        push @have, $one;
+    }
+    is("@have", "@correct", 'for my($one)');
+
+    @have = ();
+
+    # This is lots of lovely whitespace:
+    for my
+        ($end, $orientation) (@correct) {
+        push @have, "$end end $orientation";
+    }
+    is("@have", "Pointy end Up Flamey end Down", 'for my ($one, $two)');
+
+    @have = ();
+
+    for my($end, $orientation) (@correct) {
+        push @have, "$end end $orientation";
+    }
+    is("@have", "Pointy end Up Flamey end Down", 'for my ($one, $two)');
+}
+
 done_testing();


### PR DESCRIPTION
No-one had thought to test for this explicitly. After all, both
`for my $foo ...` and `for my$foo ...` are valid syntax, so tweaking the
C lexer code to add an optional '(' should work, surely?

The problem was that, *as was*, the lexer code didn't "accept" those two
syntax variants the way the comments would suggest.

`for my $foo ...` was treated as

1) we saw 'my '
2) we saw the dollar sign
3) success!

but `for my$foo ...` was treated as

0) we didn't see 'my ' or 'our '
1) we saw the literal string 'my' which is valid as a package name
2) we saw the dollar sign
3) success!

ie some sort of mangled variant of `for my Dog $spot ...` without 'my'

*but* as the lexer was happy with what it saw, it returned that the input
stream was valid for a "for" token, and control continues to the grammar.
The grammar, of course, didn't make these mistakes, so parsed everything
properly and built the correct optree.

(And, if presented with `for Dog $spot (...)` the grammar wouldn't match,
so all invalid code was correctly rejected)

However, all this came unstuck with `for my($k` because that didn't
mis-tokenise as some crazy package name 'my(', so it reported a syntax error.

Hence rewrite yyl_foreach() to actually tokenise everything correctly.

"Correctly", apart from how scan_word() needs to be called even when we
know we saw neither "my" nor "our', so that "Identifier too long" is reported
instead of "syntax error".

Fixes #19192