### PR TITLE
don't overwrite the faked up type details for hv-with-aux

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -6987,8 +6987,8 @@ Perl_sv_clear(pTHX_ SV *const orig_sv)
         }
         else {
             arena_index = type;
+            sv_type_details = bodies_by_type + arena_index;
         }
-        sv_type_details = bodies_by_type + arena_index;
         if (sv_type_details->arena) {
             del_body(((char *)SvANY(sv) + sv_type_details->offset),
                      &PL_body_roots[type]);


### PR DESCRIPTION
Detected by coverity as:

340472 Unused value

An assigned value that is never used may represent unnecessary computation, an incorrect algorithm, or possibly the need for cleanup or refactoring.

In Perl_sv_clear: A value assigned to a variable is never used. (CWE-563)