### PR TITLE
_BitScanForward64 is available only on 64-bit architectures

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -730,7 +730,7 @@ Perl_is_utf8_invariant_string_loc(const U8* const s, STRLEN len, const U8 ** ep)
 #  endif
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER >= 1400
+#if defined(_MSC_VER)
 #  include <intrin.h>
 #  pragma intrinsic(_BitScanForward)
 #  pragma intrinsic(_BitScanReverse)
@@ -772,7 +772,7 @@ Perl_lsbit_pos64(U64 word)
 
     return (unsigned) PERL_CTZ_64(word);
 
-#  elif U64SIZE == 8 && defined(_MSC_VER) && _MSC_VER >= 1400
+#  elif U64SIZE == 8 && defined(_MSC_VER)
 #    define PERL_HAS_FAST_GET_LSB_POS64
 
     {
@@ -826,7 +826,7 @@ Perl_lsbit_pos32(U32 word)
 
     return (unsigned) PERL_CTZ_32(word);
 
-#elif U32SIZE == 4 && defined(_MSC_VER) && _MSC_VER >= 1400
+#elif U32SIZE == 4 && defined(_MSC_VER)
 #  define PERL_HAS_FAST_GET_LSB_POS32
 
     {
@@ -872,7 +872,7 @@ Perl_msbit_pos64(U64 word)
 
     return (unsigned) LZC_TO_MSBIT_POS_(U64, PERL_CLZ_64(word));
 
-#  elif U64SIZE == 8 && defined(_WIN64) && defined(_MSC_VER) && _MSC_VER >= 1400
+#  elif U64SIZE == 8 && defined(_WIN64) && defined(_MSC_VER)
 #    define PERL_HAS_FAST_GET_MSB_POS64
 
     {
@@ -929,7 +929,7 @@ Perl_msbit_pos32(U32 word)
 
     return (unsigned) LZC_TO_MSBIT_POS_(U32, PERL_CLZ_32(word));
 
-#elif U32SIZE == 4 && defined(_MSC_VER) && _MSC_VER >= 1400
+#elif U32SIZE == 4 && defined(_MSC_VER)
 #  define PERL_HAS_FAST_GET_MSB_POS32
 
     {

--- a/inline.h
+++ b/inline.h
@@ -772,7 +772,7 @@ Perl_lsbit_pos64(U64 word)
 
     return (unsigned) PERL_CTZ_64(word);
 
-#  elif U64SIZE == 8 && defined(_MSC_VER)
+#  elif U64SIZE == 8 && defined(_WIN64) && defined(_MSC_VER)
 #    define PERL_HAS_FAST_GET_LSB_POS64
 
     {


### PR DESCRIPTION
Fixes #19205