### PR TITLE
Remove the usage of "whole nuther"

### DIFF
--- a/lib/diagnostics.pm
+++ b/lib/diagnostics.pm
@@ -72,7 +72,7 @@ trace.
 
 =head2 The I<splain> Program
 
-While apparently a whole nuther program, I<splain> is actually nothing
+Another program, I<splain> is actually nothing
 more than a link to the (executable) F<diagnostics.pm> module, as well as
 a link to the F<diagnostics.pod> documentation.  The B<-v> flag is like
 the C<use diagnostics -verbose> directive.


### PR DESCRIPTION
The text "While apparently a whole nuther program" is too informal
and too obscure for non-Native English speakers.

It is also a misspelling of "whole nother".

See https://www.merriam-webster.com/dictionary/whole%20nother