### PR TITLE
Fixed possible syntax error in Configure's test program for Inf/NaN bytes

### DIFF
--- a/Configure
+++ b/Configure
@@ -20777,10 +20777,12 @@ int main(int argc, char *argv[]) {
     memset((char *)&ldinf + 10, '\0', LONG_DOUBLESIZE - 10);
     memset((char *)&ldnan + 10, '\0', LONG_DOUBLESIZE - 10);
 # endif
+#endif
   if (argc == 2) {
     switch (argv[1][0]) {
     case '1': bytes(&dinf, sizeof(dinf)); break;
     case '2': bytes(&dnan, sizeof(dnan)); break;
+#ifdef HAS_LONG_DOUBLE
     case '3': bytes(&ldinf, sizeof(ldinf)); break;
     case '4': bytes(&ldnan, sizeof(ldnan)); break;
 #endif


### PR DESCRIPTION
In `Configure` script, test program (`try.c`) for probing `(double|longdbl)(inf|nan)bytes` seems to lack some preprocessor directives (probably accidentally removed) and caused syntax error if `HAS_LONG_DOUBLE` is not defined.

I'm not sure whether any supported build environment that leave `HAS_LONG_DOUBLE` undefined might exist today.  I have tested this change with `./Configure -Ud_longdbl`.