### PR TITLE
porting/bidi-control.t: add a porting test for bidi control chars

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6015,6 +6015,7 @@ t/porting/bench/oddentry	a test file for t/porting/bench.t
 t/porting/bench/ret0		a test file for t/porting/bench.t
 t/porting/bench/synerr		a test file for t/porting/bench.t
 t/porting/bench_selftest.t	run Porting/bench.pl's selftest facility
+t/porting/bidi-control.t	Check that source does not contain bidi controls
 t/porting/bincompat.t		Check that {non_,}bincompat_options are ordered
 t/porting/checkcase.t		Check whether we are case-insensitive-fs-friendly
 t/porting/checkcfgvar.t		Check that all config.sh-like files are good

--- a/t/porting/bidi-control.t
+++ b/t/porting/bidi-control.t
@@ -2,12 +2,16 @@
 use v5.20.0;
 use warnings;
 
-use utf8 ();
+use PerlIO::encoding ();
 
 BEGIN {
   @INC = '..' if -f '../TestInit.pm';
   require './test.pl';
 }
+
+my %SKIP_FILE = (
+  'cpan/Encode/t/big5-hkscs.enc' => 1, # weird data file and not really source
+);
 
 use TestInit qw(T); # T is chdir to the top level
 
@@ -42,11 +46,13 @@ unless (@files) {
 }
 
 FILE: for my $file (@files) {
-  open my $fh, '<', "$file"
+  next if $SKIP_FILE{$file};
+
+  open my $fh, '<:encoding(UTF-8)', "$file"
     or die "can't open $file: $!";
 
+  no warnings 'utf8';
   while (defined (my $line = <$fh>)) {
-    utf8::decode($line);
     push @errors, "$file at line $." if $line =~ /\p{Bidi_Control}/;
   }
 }

--- a/t/porting/bidi-control.t
+++ b/t/porting/bidi-control.t
@@ -1,0 +1,61 @@
+#!/usr/bin/perl
+use v5.20.0;
+use warnings;
+
+use utf8 ();
+
+BEGIN {
+  @INC = '..' if -f '../TestInit.pm';
+  require './test.pl';
+}
+
+use TestInit qw(T); # T is chdir to the top level
+
+find_git_or_skip();
+
+my $cdup = `git rev-parse --show-cdup`;
+die "couldn't git-rev-parse --show-cdup\n" if $?;
+chomp $cdup;
+
+if (length $cdup) {
+  chdir $cdup or die "can't chdir to git root: $!";
+}
+
+my @files = `git ls-files`;
+die "couldn't git-ls-files\n" if $?;
+
+chomp @files;
+
+if (0) {
+  # Is this a useful filter?  Should we test every file?  Do we contain binary
+  # files, etc? -- rjbs, 2021-11-02
+  my %is_interesting = map {; $_ => 1 } qw( bat c h pl pm sh t xs );
+  @files = grep {; /\.([a-z]+)\z/ && $is_interesting{$1} } @files;
+}
+
+my @errors;
+
+unless (@files) {
+  fail("Something's wrong: no files to check?!");
+  done_testing;
+  exit;
+}
+
+FILE: for my $file (@files) {
+  open my $fh, '<', "$file"
+    or die "can't open $file: $!";
+
+  while (defined (my $line = <$fh>)) {
+    utf8::decode($line);
+    push @errors, "$file at line $." if $line =~ /\p{Bidi_Control}/;
+  }
+}
+
+if (@errors) {
+  fail("Bidi control characters found in source");
+  diag("Bidi control characters in $_") for @errors;
+} else {
+  pass("No bidi control characters found in source");
+}
+
+done_testing;


### PR DESCRIPTION
This is a simple but, I believe, effective test for bidi control characters entering the p5 source.

Obviously, this file needs to be considered specially. :-)