### PR TITLE
Unencrypted git protocol no longer supported by github.com

### DIFF
--- a/pod/perlgit.pod
+++ b/pod/perlgit.pod
@@ -22,12 +22,9 @@ I<github.com>.
 
 You can make a read-only clone of the repository by running:
 
-  % git clone git://github.com/Perl/perl5.git perl
+  % git clone git@github.com:Perl/perl5.git perl
 
-This uses the git protocol (port 9418).
-
-If you cannot use the git protocol for firewall reasons, you can also
-clone via http:
+If you cannot use that for firewall reasons, you can also clone via http:
 
   % git clone https://github.com/Perl/perl5.git perl
 

--- a/pod/perlhack.pod
+++ b/pod/perlhack.pod
@@ -175,7 +175,7 @@ L<perlgit>.
 You will need a copy of Git for your computer.  You can fetch a copy of
 the repository using the git protocol:
 
-  % git clone git://github.com/Perl/perl5.git perl
+  % git clone git@github.com:Perl/perl5.git perl
 
 This clones the repository and makes a local copy in the F<perl>
 directory.


### PR DESCRIPTION
Reference: https://github.blog/2021-09-01-improving-git-protocol-security-github/