### PR TITLE
Return the "hv with aux" PVHV bodies to the correct arena

### DIFF
--- a/hv.c
+++ b/hv.c
@@ -2231,18 +2231,15 @@ PERL_STATIC_INLINE U32 S_ptr_hash(PTRV u) {
 static struct xpvhv_aux*
 S_hv_auxinit(pTHX_ HV *hv) {
     struct xpvhv_aux *iter;
-    char *array;
 
     PERL_ARGS_ASSERT_HV_AUXINIT;
 
     if (!SvOOK(hv)) {
-        if (!HvARRAY(hv)) {
+        char *array = (char *) HvARRAY(hv);
+        if (!array) {
             Newxz(array, PERL_HV_ARRAY_ALLOC_BYTES(HvMAX(hv) + 1), char);
-        } else {
-            array = (char *) HvARRAY(hv);
-            Renew(array, PERL_HV_ARRAY_ALLOC_BYTES(HvMAX(hv) + 1), char);
+            HvARRAY(hv) = (HE**)array;
         }
-        HvARRAY(hv) = (HE**)array;
         iter = Perl_hv_auxalloc(aTHX_ hv);
 #ifdef PERL_HASH_RANDOMIZE_KEYS
         if (PL_HASH_RAND_BITS_ENABLED) {


### PR DESCRIPTION
PVHV body handling was changed recently by commit 94ee6ed79dbca73d:

```
Split the XPVHV body into two variants "normal" and "with aux"

Default to the smaller body, and switch to the larger body if we need to
allocate a C<struct xpvhv_aux> (eg need an iterator).

This restores the previous small size optimisation for hashes used as
objects.
```

as part of changing where memory for `struct xpvhv_aux` is allocated.

The new implementation uses two sizes of "bodies" for PVHVs - the default body is unchanged, but when a hash needs a `struct xpvhv_aux`, it now swaps out the default body for a larger body with space for the struct.

(Previously it would reallocate the memory used for HvARRAY() to make space for the struct there - an approach which requires more tracking of changed pointers.)

That commit was subtly buggy in that on hash deallocation it didn't *return* hash bodies to the correct arena. As-was, it would return both sizes of hash body to the arena for the default (smaller) body. This was due to a combination of two subtle bugs

1) the explicit reset of all SvFLAGS to SVf_BREAK would implicitly clear SVf_OOK. That flag bit set is needed to signal the different body size

2) The code must call del_body() with &PL_body_roots[arena_index], not &PL_body_roots[type] type is SVt_PVHV for both body sizes. arena_index is SVt_PVHV for the smaller (default) bodies, and HVAUX_ARENA_ROOT_IX for the larger bodies.

There were no memory errors or leaks (that would have been detectable by tools such as ASAN or valgrind), but the bug meant that larger hash bodies would never get re-used. So for code that was steady-state creating and destroying hashes with iterators (or similar), instead of those bodies being recycled via their correct arena, the interpreter would need to continuously allocate new memory for that arena, whilst accumulating ever more unused "smaller" bodies in the other arena.

I didn't spot this bug whilst reviewing commit 8461dd8ad90b2bce:

```
don't overwrite the faked up type details for hv-with-aux

CID 340472
```

which is in the same area of the code, but fixes a related problem.
