### PR TITLE
Document `local *STDOUT` as an alternative to `select ... select`

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -7130,6 +7130,31 @@ methods, preferring to write the last example as:
 (Prior to Perl version 5.14, you have to C<use IO::Handle;> explicitly
 first.)
 
+Whilst you can use C<select> to temporarily "capture" the output of
+C<print> like this:
+
+    {
+        my $old_handle = select $new_handle;
+        
+        # This goes to $new_handle:
+        print "ok 1\n";
+        ...
+        
+        select $old_handle;
+    }
+
+you might find it easier to localize the typeglob instead:
+
+    {
+        local *STDOUT = $new_handle;
+        
+        print "ok 1\n";
+        ...
+    }
+
+The two are not exactly equivalent, but the latter might be clearer, and will
+restore STDOUT if the wrapped code dies.
+
 Portability issues: L<perlport/select>.
 
 =item select RBITS,WBITS,EBITS,TIMEOUT

--- a/t/porting/known_pod_issues.dat
+++ b/t/porting/known_pod_issues.dat
@@ -389,6 +389,7 @@ pod/perlbook.pod	Verbatim line length including indents exceeds 78 by	1
 pod/perldebguts.pod	Verbatim line length including indents exceeds 78 by	24
 pod/perldebtut.pod	Verbatim line length including indents exceeds 78 by	2
 pod/perldtrace.pod	Verbatim line length including indents exceeds 78 by	7
+pod/perlfunc.pod	line containing nothing but whitespace in paragraph	3
 pod/perlgit.pod	? Should you be using F<...> or maybe L<...> instead of	3
 pod/perlgit.pod	Verbatim line length including indents exceeds 78 by	1
 pod/perlguts.pod	? Should you be using L<...> instead of	1


### PR DESCRIPTION
If one needs to temporarily "capture" the output of `print`, for example as part of a unit test, the classic "obvious" approach has been to use `select` before and afterwards, to set a different default output handle and the restore the previous handle.

If one is already in the mindset of `select`, it might not be obvious that `local *STDOUT` is alternative way to achieve the underlying goal, and might be clearer and more robust. Hence add it as a suggestion in the `select` documentation.