### PR TITLE
POD breakage in warnings.pm

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1016,6 +1016,7 @@ Pedro Felipe Horrillo Guerra   <pancho@pancho.name>
 Per Einar Ellefsen             <per.einar@skynet.be>
 Perlover                       <perlover@perlover.com>
 Petar-Kaleychev                <87611976+Petar-Kaleychev@users.noreply.github.com>
+Pete Houston                   <githubdevteam@openstrike.co.uk>
 Pete Peterson                  <petersonp@genrad.com>
 Peter Avalos                   <peter@theshell.com>
 Peter BARABAS

--- a/lib/warnings.pm
+++ b/lib/warnings.pm
@@ -1141,7 +1141,7 @@ use:
    use warnings 'FATAL';  # short form of "use warnings FATAL => 'all';"
 
 However, you should still heed the guidance earlier in this section against
-using C<use warnings FATAL =E<gt> 'all';>.
+using C<< use warnings FATAL => 'all'; >>.
 
 If you want your program to be compatible with versions of Perl before
 5.20, you must use C<< use warnings FATAL => 'all'; >> instead.  (In

--- a/lib/warnings.pm
+++ b/lib/warnings.pm
@@ -5,7 +5,7 @@
 
 package warnings;
 
-our $VERSION = "1.55";
+our $VERSION = "1.56";
 
 # Verify that we're called correctly so that warnings will work.
 # Can't use Carp, since Carp uses us!

--- a/lib/warnings.pm
+++ b/lib/warnings.pm
@@ -1141,7 +1141,7 @@ use:
    use warnings 'FATAL';  # short form of "use warnings FATAL => 'all';"
 
 However, you should still heed the guidance earlier in this section against
-using C<use warnings FATAL => 'all';>.
+using C<use warnings FATAL =E<gt> 'all';>.
 
 If you want your program to be compatible with versions of Perl before
 5.20, you must use C<< use warnings FATAL => 'all'; >> instead.  (In

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -1289,7 +1289,7 @@ use:
    use warnings 'FATAL';  # short form of "use warnings FATAL => 'all';"
 
 However, you should still heed the guidance earlier in this section against
-using C<use warnings FATAL => 'all';>.
+using C<<use warnings FATAL => 'all';>>.
 
 If you want your program to be compatible with versions of Perl before
 5.20, you must use C<< use warnings FATAL => 'all'; >> instead.  (In

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -1289,7 +1289,7 @@ use:
    use warnings 'FATAL';  # short form of "use warnings FATAL => 'all';"
 
 However, you should still heed the guidance earlier in this section against
-using C<<use warnings FATAL => 'all';>>.
+using C<< use warnings FATAL => 'all'; >>.
 
 If you want your program to be compatible with versions of Perl before
 5.20, you must use C<< use warnings FATAL => 'all'; >> instead.  (In

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -16,7 +16,7 @@
 #
 # This script is normally invoked from regen.pl.
 
-$VERSION = '1.55';
+$VERSION = '1.56';
 
 BEGIN {
     require './regen/regen_lib.pl';


### PR DESCRIPTION
An unescaped right angle bracket was resulting in a malformed code snippet in warnings.pm

This tiny PR escapes that character and thus fixes the rendering.