### PR TITLE
update perldsc examples to be strict compliant

### DIFF
--- a/pod/perldsc.pod
+++ b/pod/perldsc.pod
@@ -603,6 +603,7 @@ X<hash of hashes> X<HoH>
          ($key, $value) = split /=/, $field;
          $HoH{$who}{$key} = $value;
      }
+ }
 
 
  # reading from file; more temps

--- a/pod/perldsc.pod
+++ b/pod/perldsc.pod
@@ -348,7 +348,7 @@ X<array of arrays> X<AoA>
 
 =head2 Declaration of an ARRAY OF ARRAYS
 
- @AoA = (
+ my @AoA = (
         [ "fred", "barney" ],
         [ "george", "jane", "elroy" ],
         [ "homer", "marge", "bart" ],
@@ -362,13 +362,13 @@ X<array of arrays> X<AoA>
  }
 
  # calling a function
- for $i ( 1 .. 10 ) {
+ for my $i ( 1 .. 10 ) {
      $AoA[$i] = [ somefunc($i) ];
  }
 
  # using temp vars
- for $i ( 1 .. 10 ) {
-     @tmp = somefunc($i);
+ for my $i ( 1 .. 10 ) {
+     my @tmp = somefunc($i);
      $AoA[$i] = [ @tmp ];
  }
 
@@ -384,18 +384,18 @@ X<array of arrays> X<AoA>
  $AoA[1][1] =~ s/(\w)/\u$1/;
 
  # print the whole thing with refs
- for $aref ( @AoA ) {
+ for my $aref ( @AoA ) {
      print "\t [ @$aref ],\n";
  }
 
  # print the whole thing with indices
- for $i ( 0 .. $#AoA ) {
+ for my $i ( 0 .. $#AoA ) {
      print "\t [ $AoA[$i]->@* ],\n";
  }
 
  # print the whole thing one at a time
- for $i ( 0 .. $#AoA ) {
-     for $j ( 0 .. $AoA[$i]->$#* ) {
+ for my $i ( 0 .. $#AoA ) {
+     for my $j ( 0 .. $AoA[$i]->$#* ) {
          print "elem at ($i, $j) is $AoA[$i][$j]\n";
      }
  }
@@ -405,7 +405,7 @@ X<hash of arrays> X<HoA>
 
 =head2 Declaration of a HASH OF ARRAYS
 
- %HoA = (
+ my %HoA = (
         flintstones        => [ "fred", "barney" ],
         jetsons            => [ "george", "jane", "elroy" ],
         simpsons           => [ "homer", "marge", "bart" ],
@@ -422,20 +422,20 @@ X<hash of arrays> X<HoA>
 
  # reading from file; more temps
  # flintstones: fred barney wilma dino
- while ( $line = <> ) {
-     ($who, $rest) = split /:\s*/, $line, 2;
-     @fields = split ' ', $rest;
+ while ( my $line = <> ) {
+     my ($who, $rest) = split /:\s*/, $line, 2;
+     my @fields = split ' ', $rest;
      $HoA{$who} = [ @fields ];
  }
 
  # calling a function that returns a list
- for $group ( "simpsons", "jetsons", "flintstones" ) {
+ for my $group ( "simpsons", "jetsons", "flintstones" ) {
      $HoA{$group} = [ get_family($group) ];
  }
 
  # likewise, but using temps
- for $group ( "simpsons", "jetsons", "flintstones" ) {
-     @members = get_family($group);
+ for my $group ( "simpsons", "jetsons", "flintstones" ) {
+     my @members = get_family($group);
      $HoA{$group} = [ @members ];
  }
 
@@ -451,26 +451,26 @@ X<hash of arrays> X<HoA>
  $HoA{simpsons}[1] =~ s/(\w)/\u$1/;
 
  # print the whole thing
- foreach $family ( keys %HoA ) {
+ foreach my $family ( keys %HoA ) {
      print "$family: $HoA{$family}->@* \n"
  }
 
  # print the whole thing with indices
- foreach $family ( keys %HoA ) {
+ foreach my $family ( keys %HoA ) {
      print "family: ";
-     foreach $i ( 0 .. $HoA{$family}->$#* ) {
+     foreach my $i ( 0 .. $HoA{$family}->$#* ) {
          print " $i = $HoA{$family}[$i]";
      }
      print "\n";
  }
 
  # print the whole thing sorted by number of members
- foreach $family ( sort { $HoA{$b}->@* <=> $HoA{$a}->@* } keys %HoA ) {
+ foreach my $family ( sort { $HoA{$b}->@* <=> $HoA{$a}->@* } keys %HoA ) {
      print "$family: $HoA{$family}->@* \n"
  }
 
  # print the whole thing sorted by number of members and name
- foreach $family ( sort {
+ foreach my $family ( sort {
                             $HoA{$b}->@* <=> $HoA{$a}->@*
                                           ||
                                       $a cmp $b
@@ -484,7 +484,7 @@ X<array of hashes> X<AoH>
 
 =head2 Declaration of an ARRAY OF HASHES
 
- @AoH = (
+ my @AoH = (
         {
             Lead     => "fred",
             Friend   => "barney",
@@ -506,9 +506,9 @@ X<array of hashes> X<AoH>
  # reading from file
  # format: LEAD=fred FRIEND=barney
  while ( <> ) {
-     $rec = {};
-     for $field ( split ) {
-         ($key, $value) = split /=/, $field;
+     my $rec = {};
+     for my $field ( split ) {
+         my ($key, $value) = split /=/, $field;
          $rec->{$key} = $value;
      }
      push @AoH, $rec;
@@ -524,7 +524,7 @@ X<array of hashes> X<AoH>
 
  # calling a function  that returns a key/value pair list, like
  # "lead","fred","daughter","pebbles"
- while ( %fields = getnextpairset() ) {
+ while ( my %fields = getnextpairset() ) {
      push @AoH, { %fields };
  }
 
@@ -546,26 +546,26 @@ X<array of hashes> X<AoH>
  $AoH[1]{lead} =~ s/(\w)/\u$1/;
 
  # print the whole thing with refs
- for $href ( @AoH ) {
+ for my $href ( @AoH ) {
      print "{ ";
-     for $role ( keys %$href ) {
+     for my $role ( keys %$href ) {
          print "$role=$href->{$role} ";
      }
      print "}\n";
  }
 
  # print the whole thing with indices
- for $i ( 0 .. $#AoH ) {
+ for my $i ( 0 .. $#AoH ) {
      print "$i is { ";
-     for $role ( keys $AoH[$i]->%* ) {
+     for my $role ( keys $AoH[$i]->%* ) {
          print "$role=$AoH[$i]{$role} ";
      }
      print "}\n";
  }
 
  # print the whole thing one at a time
- for $i ( 0 .. $#AoH ) {
-     for $role ( keys $AoH[$i]->%* ) {
+ for my $i ( 0 .. $#AoH ) {
+     for my $role ( keys $AoH[$i]->%* ) {
          print "elem at ($i, $role) is $AoH[$i]{$role}\n";
      }
  }
@@ -575,7 +575,7 @@ X<hash of hashes> X<HoH>
 
 =head2 Declaration of a HASH OF HASHES
 
- %HoH = (
+ my %HoH = (
         flintstones => {
                 lead      => "fred",
                 pal       => "barney",
@@ -598,9 +598,9 @@ X<hash of hashes> X<HoH>
  # flintstones: lead=fred pal=barney wife=wilma pet=dino
  while ( <> ) {
      next unless s/^(.*?):\s*//;
-     $who = $1;
-     for $field ( split ) {
-         ($key, $value) = split /=/, $field;
+     my $who = $1;
+     for my $field ( split ) {
+         my ($key, $value) = split /=/, $field;
          $HoH{$who}{$key} = $value;
      }
  }
@@ -609,33 +609,33 @@ X<hash of hashes> X<HoH>
  # reading from file; more temps
  while ( <> ) {
      next unless s/^(.*?):\s*//;
-     $who = $1;
-     $rec = {};
+     my $who = $1;
+     my $rec = {};
      $HoH{$who} = $rec;
-     for $field ( split ) {
-         ($key, $value) = split /=/, $field;
+     for my $field ( split ) {
+         my ($key, $value) = split /=/, $field;
          $rec->{$key} = $value;
      }
  }
 
  # calling a function  that returns a key,value hash
- for $group ( "simpsons", "jetsons", "flintstones" ) {
+ for my $group ( "simpsons", "jetsons", "flintstones" ) {
      $HoH{$group} = { get_family($group) };
  }
 
  # likewise, but using temps
- for $group ( "simpsons", "jetsons", "flintstones" ) {
-     %members = get_family($group);
+ for my $group ( "simpsons", "jetsons", "flintstones" ) {
+     my %members = get_family($group);
      $HoH{$group} = { %members };
  }
 
  # append new members to an existing family
- %new_folks = (
+ my %new_folks = (
      wife => "wilma",
      pet  => "dino",
  );
 
- for $what (keys %new_folks) {
+ for my $what (keys %new_folks) {
      $HoH{flintstones}{$what} = $new_folks{$what};
  }
 
@@ -648,18 +648,18 @@ X<hash of hashes> X<HoH>
  $HoH{simpsons}{lead} =~ s/(\w)/\u$1/;
 
  # print the whole thing
- foreach $family ( keys %HoH ) {
+ foreach my $family ( keys %HoH ) {
      print "$family: { ";
-     for $role ( keys $HoH{$family}->%* ) {
+     for my $role ( keys $HoH{$family}->%* ) {
          print "$role=$HoH{$family}{$role} ";
      }
      print "}\n";
  }
 
  # print the whole thing  somewhat sorted
- foreach $family ( sort keys %HoH ) {
+ foreach my $family ( sort keys %HoH ) {
      print "$family: { ";
-     for $role ( sort keys $HoH{$family}->%* ) {
+     for my $role ( sort keys $HoH{$family}->%* ) {
          print "$role=$HoH{$family}{$role} ";
      }
      print "}\n";
@@ -667,23 +667,24 @@ X<hash of hashes> X<HoH>
 
 
  # print the whole thing sorted by number of members
- foreach $family ( sort { $HoH{$b}->%* <=> $HoH{$a}->%* } keys %HoH ) {
+ foreach my $family ( sort { $HoH{$b}->%* <=> $HoH{$a}->%* } keys %HoH ) {
      print "$family: { ";
-     for $role ( sort keys $HoH{$family}->%* ) {
+     for my $role ( sort keys $HoH{$family}->%* ) {
          print "$role=$HoH{$family}{$role} ";
      }
      print "}\n";
  }
 
  # establish a sort order (rank) for each role
- $i = 0;
+ my $i = 0;
+ my %rank;
  for ( qw(lead wife son daughter pal pet) ) { $rank{$_} = ++$i }
 
  # now print the whole thing sorted by number of members
- foreach $family ( sort { $HoH{$b}->%* <=> $HoH{$a}->%* } keys %HoH ) {
+ foreach my $family ( sort { $HoH{$b}->%* <=> $HoH{$a}->%* } keys %HoH ) {
      print "$family: { ";
      # and print these according to rank order
-     for $role ( sort { $rank{$a} <=> $rank{$b} }
+     for my $role ( sort { $rank{$a} <=> $rank{$b} }
                                                keys $HoH{$family}->%* )
      {
          print "$role=$HoH{$family}{$role} ";
@@ -700,7 +701,7 @@ X<record> X<structure> X<struct>
 Here's a sample showing how to create and use a record whose fields are of
 many different sorts:
 
-     $rec = {
+     my $rec = {
          TEXT      => $string,
          SEQUENCE  => [ @old_values ],
          LOOKUP    => { %some_table },
@@ -712,12 +713,12 @@ many different sorts:
      print $rec->{TEXT};
 
      print $rec->{SEQUENCE}[0];
-     $last = pop $rec->{SEQUENCE}->@*;
+     my $last = pop $rec->{SEQUENCE}->@*;
 
      print $rec->{LOOKUP}{"key"};
-     ($first_k, $first_v) = each $rec->{LOOKUP}->%*;
+     my ($first_k, $first_v) = each $rec->{LOOKUP}->%*;
 
-     $answer = $rec->{THATCODE}->($arg);
+     my $answer = $rec->{THATCODE}->($arg);
      $answer = $rec->{THISCODE}->($arg1, $arg2);
 
      # careful of extra block braces on fh ref
@@ -729,7 +730,7 @@ many different sorts:
 
 =head2 Declaration of a HASH OF COMPLEX RECORDS
 
-     %TV = (
+     my %TV = (
         flintstones => {
             series   => "flintstones",
             nights   => [ qw(monday thursday friday) ],
@@ -770,14 +771,14 @@ many different sorts:
      # sometimes it's easiest to do that
 
      # here's a piece by piece build up
-     $rec = {};
+     my $rec = {};
      $rec->{series} = "flintstones";
      $rec->{nights} = [ find_days() ];
 
-     @members = ();
+     my @members = ();
      # assume this file in field=value syntax
      while (<>) {
-         %fields = split /[\s=]+/;
+         my %fields = split /[\s=]+/;
          push @members, { %fields };
      }
      $rec->{members} = [ @members ];
@@ -793,10 +794,10 @@ many different sorts:
      # to an array of the kids' records without having duplicate
      # records and thus update problems.
      ###########################################################
-     foreach $family (keys %TV) {
-         $rec = $TV{$family}; # temp pointer
-         @kids = ();
-         for $person ( $rec->{members}->@* ) {
+     foreach my $family (keys %TV) {
+         my $rec = $TV{$family}; # temp pointer
+         my @kids = ();
+         for my $person ( $rec->{members}->@* ) {
              if ($person->{role} =~ /kid|son|daughter/) {
                  push @kids, $person;
              }
@@ -818,11 +819,11 @@ many different sorts:
      # both point to the same underlying anonymous hash table
 
      # print the whole thing
-     foreach $family ( keys %TV ) {
+     foreach my $family ( keys %TV ) {
          print "the $family";
          print " is on during $TV{$family}{nights}->@*\n";
          print "its members are:\n";
-         for $who ( $TV{$family}{members}->@* ) {
+         for my $who ( $TV{$family}{members}->@* ) {
              print " $who->{name} ($who->{role}), age $who->{age}\n";
          }
          print "it turns out that $TV{$family}{lead} has ";


### PR DESCRIPTION
Where possible, update perldsc examples to use lexical variables, to be
strict compliant. Earlier code in this document specifically discusses
differences with strict, but the examples aren't really related to
anything about non-lexical variables, so they should be updated to work
with modern standards.

Some parts of the examples have not been updated because they are using
variables that are implicitly meant to come from some an outside source.