### PR TITLE
Forbid using 'goto' to jump into a 'defer' block

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -1042,6 +1042,11 @@ error occurs in cases such as these:
     goto G;
     $x + do { G: $y }; # How is + supposed to get its first operand?
 
+=item Can't "goto" into a defer block
+
+(F) A "goto" statement was executed to jump into the scope of a defer
+block.  This is not permitted.
+
 =item Can't "goto" into a "given" block
 
 (F) A "goto" statement was executed to jump into the middle of a C<given>

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -2794,8 +2794,11 @@ S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstac
                 first_kid_of_binary = TRUE;
                 ops--;
             }
-            if ((o = dofindlabel(kid, label, len, flags, ops, oplimit)))
+            if ((o = dofindlabel(kid, label, len, flags, ops, oplimit))) {
+                if (kid->op_type == OP_PUSHDEFER)
+                    Perl_croak(aTHX_ "Can't \"goto\" into a defer block");
                 return o;
+            }
             if (first_kid_of_binary)
                 *ops++ = UNENTERABLE;
         }

--- a/t/op/defer.t
+++ b/t/op/defer.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan 29;
+plan 30;
 
 use feature 'defer';
 no warnings 'experimental::defer';
@@ -276,6 +276,19 @@ no warnings 'experimental::defer';
     my $e = defined eval { $sub->(); 1 } ? undef : $@;
     like($e, qr/^Can't "goto" out of a defer block /,
         'Cannot goto out of defer block');
+}
+
+{
+    my $sub = sub {
+        while(1) {
+            goto HERE;
+            defer { HERE: 1; }
+        }
+    };
+
+    my $e = defined eval { $sub->(); 1 } ? undef : $@;
+    like($e, qr/^Can't "goto" into a defer block /,
+        'Cannot goto into defer block');
 }
 
 {


### PR DESCRIPTION
Otherwise, once the `defer` block is done the main body of the program will abruptly end, because the `defer`'s optree ends in a NULL `->op_next` pointer.