### PR TITLE
Quote the word "defer" in exception messages about control flow

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -749,9 +749,9 @@ of C<SV*> scalars containing the arguments.
 integer format can only be used with positive integers, and you attempted
 to compress something else.  See L<perlfunc/pack>.
 
-=item Can't "%s" out of a defer block
+=item Can't "%s" out of a "defer" block
 
-(F) An attempt was made to jump out of the scope of a defer block by using
+(F) An attempt was made to jump out of the scope of a C<defer> block by using
 a control-flow statement such as C<return>, C<goto> or a loop control. This is
 not permitted.
 
@@ -1042,7 +1042,7 @@ error occurs in cases such as these:
     goto G;
     $x + do { G: $y }; # How is + supposed to get its first operand?
 
-=item Can't "goto" into a defer block
+=item Can't "goto" into a "defer" block
 
 (F) A "goto" statement was executed to jump into the scope of a defer
 block.  This is not permitted.

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -1044,7 +1044,7 @@ error occurs in cases such as these:
 
 =item Can't "goto" into a "defer" block
 
-(F) A "goto" statement was executed to jump into the scope of a defer
+(F) A C<goto> statement was executed to jump into the scope of a C<defer>
 block.  This is not permitted.
 
 =item Can't "goto" into a "given" block

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -2494,7 +2494,7 @@ PP(pp_return)
         /* Check for  defer { return; } */
         for(i = cxstack_ix; i > cxix; i--) {
             if(CxTYPE(&cxstack[i]) == CXt_DEFER)
-                Perl_croak(aTHX_ "Can't \"%s\" out of a defer block", "return");
+                Perl_croak(aTHX_ "Can't \"%s\" out of a \"defer\" block", "return");
         }
         if (cxix < 0) {
             if (!(       PL_curstackinfo->si_type == PERLSI_SORT
@@ -2640,7 +2640,7 @@ S_unwind_loop(pTHX)
         /* Check for  defer { last ... } etc */
         for(i = cxstack_ix; i > cxix; i--) {
             if(CxTYPE(&cxstack[i]) == CXt_DEFER)
-                Perl_croak(aTHX_ "Can't \"%s\" out of a defer block", OP_NAME(PL_op));
+                Perl_croak(aTHX_ "Can't \"%s\" out of a \"defer\" block", OP_NAME(PL_op));
         }
         dounwind(cxix);
     }
@@ -2796,7 +2796,7 @@ S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstac
             }
             if ((o = dofindlabel(kid, label, len, flags, ops, oplimit))) {
                 if (kid->op_type == OP_PUSHDEFER)
-                    Perl_croak(aTHX_ "Can't \"goto\" into a defer block");
+                    Perl_croak(aTHX_ "Can't \"goto\" into a \"defer\" block");
                 return o;
             }
             if (first_kid_of_binary)
@@ -2893,7 +2893,7 @@ PP(pp_goto)
             /* Check for  defer { goto &...; } */
             for(ix = cxstack_ix; ix > cxix; ix--) {
                 if(CxTYPE(&cxstack[ix]) == CXt_DEFER)
-                    Perl_croak(aTHX_ "Can't \"%s\" out of a defer block", "goto");
+                    Perl_croak(aTHX_ "Can't \"%s\" out of a \"defer\" block", "goto");
             }
 
             /* First do some returnish stuff. */
@@ -3135,7 +3135,7 @@ PP(pp_goto)
             case CXt_NULL:
                 DIE(aTHX_ "Can't \"goto\" out of a pseudo block");
             case CXt_DEFER:
-                DIE(aTHX_ "Can't \"%s\" out of a defer block", "goto");
+                DIE(aTHX_ "Can't \"%s\" out of a \"defer\" block", "goto");
             default:
                 if (ix)
                     DIE(aTHX_ "panic: goto, type=%u, ix=%ld",

--- a/t/op/defer.t
+++ b/t/op/defer.t
@@ -261,7 +261,7 @@ no warnings 'experimental::defer';
     };
 
     my $e = defined eval { $sub->(); 1 } ? undef : $@;
-    like($e, qr/^Can't "return" out of a defer block /,
+    like($e, qr/^Can't "return" out of a "defer" block /,
         'Cannot return out of defer block');
 }
 
@@ -274,7 +274,7 @@ no warnings 'experimental::defer';
     };
 
     my $e = defined eval { $sub->(); 1 } ? undef : $@;
-    like($e, qr/^Can't "goto" out of a defer block /,
+    like($e, qr/^Can't "goto" out of a "defer" block /,
         'Cannot goto out of defer block');
 }
 
@@ -287,7 +287,7 @@ no warnings 'experimental::defer';
     };
 
     my $e = defined eval { $sub->(); 1 } ? undef : $@;
-    like($e, qr/^Can't "goto" into a defer block /,
+    like($e, qr/^Can't "goto" into a "defer" block /,
         'Cannot goto into defer block');
 }
 
@@ -300,8 +300,8 @@ no warnings 'experimental::defer';
     };
 
     my $e = defined eval { $subA->(); 1 } ? undef : $@;
-    like($e, qr/^Can't "goto" out of a defer block at /,
-        'Cannot goto &SUB out of a defer block');
+    like($e, qr/^Can't "goto" out of a "defer" block at /,
+        'Cannot goto &SUB out of a "defer" block');
 }
 
 {
@@ -312,7 +312,7 @@ no warnings 'experimental::defer';
     };
 
     my $e = defined eval { $sub->(); 1 } ? undef : $@;
-    like($e, qr/^Can't "last" out of a defer block /,
+    like($e, qr/^Can't "last" out of a "defer" block /,
         'Cannot last out of defer block');
 }
 


### PR DESCRIPTION
These messages are all new in the 5.35.x development cycle anyway, so there's no risk of code out in the wild relying on the exact spelling from any stable version.