### PR TITLE
Replace sv_2mortal(newSVpv(x,0)) with newSVpvn_flags(x,... ,SVs_TEMP)

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -3407,7 +3407,7 @@ Perl_mortal_getenv(const char * str)
     ret = getenv(str);
 
     if (ret != NULL) {
-        ret = SvPVX(sv_2mortal(newSVpv(ret, 0)));
+        ret = SvPVX( newSVpvn_flags(ret, strlen(ret) ,SVs_TEMP) );
     }
 
     GETENV_UNLOCK;

--- a/perl.c
+++ b/perl.c
@@ -2017,7 +2017,8 @@ S_Internals_V(pTHX_ CV *cv)
 
     EXTEND(SP, entries);
 
-    PUSHs(sv_2mortal(newSVpv(PL_bincompat_options, 0)));
+    PUSHs(newSVpvn_flags(PL_bincompat_options, strlen(PL_bincompat_options),
+                              SVs_TEMP));
     PUSHs(Perl_newSVpvn_flags(aTHX_ non_bincompat_options,
                               sizeof(non_bincompat_options) - 1, SVs_TEMP));
 
@@ -2041,7 +2042,9 @@ S_Internals_V(pTHX_ CV *cv)
 
     for (i = 1; i <= local_patch_count; i++) {
         /* This will be an undef, if PL_localpatches[i] is NULL.  */
-        PUSHs(sv_2mortal(newSVpv(PL_localpatches[i], 0)));
+        PUSHs(newSVpvn_flags(PL_localpatches[i],
+            PL_localpatches[i] == NULL ? 0 : strlen(PL_localpatches[i]),
+            SVs_TEMP));
     }
 
     XSRETURN(entries);
@@ -2280,7 +2283,7 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
                 while (++s && *s) {
                     if (isSPACE(*s)) {
                         if (!popt_copy) {
-                            popt_copy = SvPVX(sv_2mortal(newSVpv(d,0)));
+                            popt_copy = SvPVX(newSVpvn_flags(d, strlen(d), SVs_TEMP));
                             s = popt_copy + (s - d);
                             d = popt_copy;
                         }

--- a/perlio.c
+++ b/perlio.c
@@ -4899,7 +4899,7 @@ PerlIO *
 PerlIO_open(const char *path, const char *mode)
 {
     dTHX;
-    SV *name = sv_2mortal(newSVpv(path, 0));
+    SV *name = newSVpvn_flags(path, path == NULL ? 0 : strlen(path), SVs_TEMP);
     return PerlIO_openn(aTHX_ NULL, mode, -1, 0, 0, NULL, 1, &name);
 }
 
@@ -4908,7 +4908,7 @@ PerlIO *
 PerlIO_reopen(const char *path, const char *mode, PerlIO *f)
 {
     dTHX;
-    SV *name = sv_2mortal(newSVpv(path,0));
+    SV *name = newSVpvn_flags(path, path == NULL ? 0 : strlen(path), SVs_TEMP);
     return PerlIO_openn(aTHX_ NULL, mode, -1, 0, 0, f, 1, &name);
 }
 

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -5598,7 +5598,9 @@ PP(pp_gpwent)
 #   endif
 
 #   ifdef PWGECOS
-        PUSHs(sv = sv_2mortal(newSVpv(pwent->pw_gecos, 0)));
+        PUSHs(sv = newSVpvn_flags(pwent->pw_gecos,
+            pwent->pw_gecos == NULL ? 0 : strlen(pwent->pw_gecos),
+            SVs_TEMP));
 #   else
         PUSHs(sv = sv_mortalcopy(&PL_sv_no));
 #   endif
@@ -5607,7 +5609,9 @@ PP(pp_gpwent)
 
         mPUSHs(newSVpv(pwent->pw_dir, 0));
 
-        PUSHs(sv = sv_2mortal(newSVpv(pwent->pw_shell, 0)));
+        PUSHs(sv = newSVpvn_flags(pwent->pw_shell,
+            pwent->pw_shell == NULL ? 0 : strlen(pwent->pw_shell),
+            SVs_TEMP));
         /* pw_shell is tainted because user himself can diddle with it. */
         SvTAINTED_on(sv);
 


### PR DESCRIPTION
This should be more efficient.

(I'm not sure whether there's any further scope to simplifying any of the ternaries because it's safe to assume that the first argument pointer won't be NULL.)