### PR TITLE
Do not count tests, instead use done_testing()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -910,6 +910,7 @@ Michael Stevens                <mstevens@etla.org>
 Michael van Elst               <mlelstv@serpens.de>
 Michael Witten                 <mfwitten@gmail.com>
 Michele Sardo
+Michiel Beijen                 <mb@x14.nl>
 Mik Firestone                  <fireston@lexmark.com>
 Mike Doherty                   <mike@mikedoherty.ca>
 Mike Fletcher                  <fletch@phydeaux.org>

--- a/lib/B/Deparse-core.t
+++ b/lib/B/Deparse-core.t
@@ -36,7 +36,6 @@ BEGIN {
 
 use strict;
 use Test::More;
-plan tests => 3904;
 
 use feature (sprintf(":%vd", $^V)); # to avoid relying on the feature
                                     # logic to add CORE::
@@ -434,6 +433,8 @@ SKIP:
     }
     ok($pass, "sanity checks");
 }
+
+done_testing();
 
 __DATA__
 #

--- a/lib/B/Deparse-subclass.t
+++ b/lib/B/Deparse-subclass.t
@@ -4,7 +4,7 @@
 # publicise an API for subclassing B::Deparse they can prevent us from
 # gratuitously breaking conventions that CPAN modules already use.
 
-use Test::More tests => 2;
+use Test::More;
 
 use B::Deparse;
 
@@ -22,3 +22,5 @@ like  $nm->coderef2text(sub { my($a, $b, $c) }),
 like  $nm->coderef2text(sub { my $c; /(??{ $c })/; }),
       qr/\Q(??{\E \$c_groovy/,
      'overriding padname works for renaming lexicals in regexp blocks';
+
+done_testing();

--- a/lib/Benchmark.t
+++ b/lib/Benchmark.t
@@ -8,7 +8,7 @@ BEGIN {
 use warnings;
 use strict;
 our ($foo, $bar, $baz, $ballast);
-use Test::More tests => 213;
+use Test::More;
 
 use Benchmark qw(:all);
 
@@ -634,6 +634,7 @@ is_deeply ([keys %Benchmark::Cache], \@before_keys,
     }
 }
 
+done_testing();
 
 package TieOut;
 

--- a/lib/Config/Extensions.t
+++ b/lib/Config/Extensions.t
@@ -6,7 +6,7 @@ BEGIN {
     }
 }
 use strict;
-use Test::More 'no_plan';
+use Test::More;
 
 BEGIN {use_ok 'Config::Extensions', '%Extensions'};
 
@@ -31,3 +31,5 @@ while (my ($key, $val) = each %Extensions) {
     my $type = $val . '_ext';
     like($Config{$type}, $re, "$key is $type");
 }
+
+done_testing();

--- a/lib/DB.t
+++ b/lib/DB.t
@@ -18,7 +18,7 @@ use Scalar::Util qw( dualvar );
 my $dualfalse = dualvar(0, 'false');
 my $dualtrue = dualvar(1, 'true');
 
-use Test::More tests => 106;
+use Test::More;
 
 # must happen at compile time for DB:: package variable localizations to work
 BEGIN {
@@ -497,6 +497,8 @@ is( $FakeDB::output, '123123123',
 for my $method (qw( cprestop cpoststop awaken init stop idle cleanup output )) {
         ok( defined &{ "DB::$method" }, "DB::$method() should be defined" );
 }
+
+done_testing();
 
 # DB::skippkg() uses lexical
 # DB::ready() uses lexical

--- a/lib/DBM_Filter/t/01error.t
+++ b/lib/DBM_Filter/t/01error.t
@@ -45,7 +45,7 @@ print "# runFilter $name\n" ;
     return $@;
 }
 
-use Test::More tests => 21;
+use Test::More;
 
 BEGIN { use_ok('DBM_Filter') };
 my $db_file;
@@ -249,3 +249,4 @@ undef $db;
     is $@, '', "untie without inner references" ;
 }
 
+done_testing();

--- a/lib/DBM_Filter/t/02core.t
+++ b/lib/DBM_Filter/t/02core.t
@@ -30,7 +30,7 @@ sub writeFile
 
 END { unlink keys %files if keys %files }
 
-use Test::More tests => 189;
+use Test::More;
 
 BEGIN { use_ok('DBM_Filter') };
 my $db_file;
@@ -728,3 +728,4 @@ sub checkRaw
 
 }
 
+done_testing();

--- a/lib/DBM_Filter/t/compress.t
+++ b/lib/DBM_Filter/t/compress.t
@@ -14,7 +14,7 @@ print "# $@\n";
 }
 require "dbm_filter_util.pl";
 
-use Test::More tests => 23;
+use Test::More;
 
 BEGIN { use_ok('DBM_Filter') };
 my $db_file;
@@ -119,3 +119,4 @@ undef $db2;
     is $@, '', "untie without inner references" ;
 }
 
+done_testing();

--- a/lib/DBM_Filter/t/encode.t
+++ b/lib/DBM_Filter/t/encode.t
@@ -19,7 +19,7 @@ BEGIN
 
 require "dbm_filter_util.pl";
 
-use Test::More tests => 26;
+use Test::More;
 
 BEGIN { use_ok('DBM_Filter') };
 my $db_file;
@@ -122,3 +122,5 @@ undef $db2;
 }
 
 }
+
+done_testing();

--- a/lib/DBM_Filter/t/int32.t
+++ b/lib/DBM_Filter/t/int32.t
@@ -5,7 +5,7 @@ use Carp;
 
 require "dbm_filter_util.pl";
 
-use Test::More tests => 22;
+use Test::More;
 
 BEGIN { use_ok('DBM_Filter') };
 my $db_file;
@@ -97,3 +97,4 @@ undef $db2;
     is $@, '', "untie without inner references" ;
 }
 
+done_testing();

--- a/lib/DBM_Filter/t/null.t
+++ b/lib/DBM_Filter/t/null.t
@@ -5,7 +5,7 @@ use Carp;
 
 require "dbm_filter_util.pl";
 
-use Test::More tests => 26;
+use Test::More;
 
 BEGIN { use_ok('DBM_Filter') };
 my $db_file;
@@ -94,3 +94,4 @@ undef $db2;
     is $@, '', "untie without inner references" ;
 }
 
+done_testing();

--- a/lib/DBM_Filter/t/utf8.t
+++ b/lib/DBM_Filter/t/utf8.t
@@ -18,7 +18,7 @@ BEGIN
 
 require "dbm_filter_util.pl";
 
-use Test::More tests => 20;
+use Test::More;
 
 BEGIN { use_ok('DBM_Filter') };
 my $db_file;
@@ -96,3 +96,4 @@ undef $db2;
     is $@, '', "untie without inner references" ;
 }
 
+done_testing();

--- a/lib/DirHandle.t
+++ b/lib/DirHandle.t
@@ -11,7 +11,7 @@ BEGIN {
 }
 
 use DirHandle;
-use Test::More tests => 31;
+use Test::More;
 
 # Fetching the list of files in two different ways and expecting them 
 # to be the same is a race condition when tests are running in parallel.
@@ -133,3 +133,5 @@ ok(! $bbdot->close(),
 if ($chdir) {
   chdir "..";
 }
+
+done_testing();

--- a/lib/English.t
+++ b/lib/English.t
@@ -6,7 +6,7 @@ BEGIN {
     @INC = '../lib';
 }
 
-use Test::More tests => 58;
+use Test::More;
 
 use English qw( -no_match_vars ) ;
 use Config;
@@ -163,6 +163,9 @@ main::ok( !$POSTMATCH, '$POSTMATCH disabled' );
     local $" = 'frooble';
     ::is $LIST_SEPARATOR, 'frooble';
 }
+
+# because of the 'package' statements above, we have to prefix Test::More::
+Test::More::done_testing();
 
 __END__
 This is a line.

--- a/lib/File/Basename.t
+++ b/lib/File/Basename.t
@@ -5,7 +5,7 @@ BEGIN {
     @INC = '../lib';
 }
 
-use Test::More tests => 65;
+use Test::More;
 
 BEGIN { use_ok 'File::Basename' }
 
@@ -184,3 +184,5 @@ SKIP: {
     ok tainted(dirname($TAINT.'/perl/lib//'));
     ok all_tainted(fileparse($TAINT.'/dir/draft.book7','\.book\d+'));
 }
+
+done_testing();

--- a/lib/File/Compare.t
+++ b/lib/File/Compare.t
@@ -17,7 +17,7 @@ BEGIN {
   }
 }
 
-use Test::More ( tests => 16 );
+use Test::More;
 use File::Compare qw(compare compare_text);
 
 # Upon success, compare() and compare_text() return a Unix-ish 0
@@ -131,6 +131,8 @@ SKIP: {
     like($@, qr/to\s+undefined/,
         "compare() fails: second argument undefined");
 }
+
+done_testing();
 
 sub get_valid_whitespace {
     return ' ' unless $^O eq 'VMS';

--- a/lib/File/Copy.t
+++ b/lib/File/Copy.t
@@ -14,8 +14,6 @@ use Test::More;
 
 my $TB = Test::More->builder;
 
-plan tests => 466;
-
 # We are going to override rename() later on but Perl has to see an override
 # at compile time to honor it.
 BEGIN { *CORE::GLOBAL::rename = sub { CORE::rename($_[0], $_[1]) }; }
@@ -521,6 +519,7 @@ SKIP: {
     "copy with buffer above normal size";
 }
 
+done_testing();
 
 END {
     1 while unlink "copy-$$";

--- a/lib/FileHandle.t
+++ b/lib/FileHandle.t
@@ -13,7 +13,7 @@ BEGIN {
 use strict;
 use FileHandle;
 autoflush STDOUT 1;
-use Test::More (tests => 12);
+use Test::More;
 my $TB = Test::More->builder;
 
 my $mystdout = new_from_fd FileHandle 1,"w";
@@ -91,3 +91,5 @@ ok($|, "handle auto-flushing current output channel");
 }
 
 ok(!FileHandle->new('', 'r'), "Can't open empty filename");
+
+done_testing();

--- a/lib/Getopt/Std.t
+++ b/lib/Getopt/Std.t
@@ -8,7 +8,7 @@ BEGIN {
 use strict;
 use warnings;
 
-use Test::More tests => 22;
+use Test::More;
 use Getopt::Std;
 
 our ($warning, $opt_f, $opt_i, $opt_o, $opt_x, $opt_y, %opt);
@@ -92,3 +92,5 @@ my $expected;
         "getopt: single switch; switch expected argument, none provided; value undef");
     undef %opt;
 }
+
+done_testing();

--- a/lib/Internals.t
+++ b/lib/Internals.t
@@ -7,7 +7,7 @@ BEGIN {
     }
 }
 
-use Test::More tests => 82;
+use Test::More;
 
 my $ro_err = qr/^Modification of a read-only value attempted/;
 
@@ -188,3 +188,5 @@ is( Internals::SvREFCNT($foo), $big_count, "reference count unsigned");
     eval { &Internals::SvREFCNT($foo, 0..3);};
     like($@, qr/\Q$usage\E/);
 }
+
+done_testing();

--- a/lib/Net/hostent.t
+++ b/lib/Net/hostent.t
@@ -19,7 +19,7 @@ BEGIN {
     }
 }
 
-use Test::More tests => 10;
+use Test::More;
 
 BEGIN { use_ok 'Net::hostent' }
 
@@ -102,3 +102,5 @@ SKIP: {
     }
 }
 }
+
+done_testing();

--- a/lib/Pod/t/Usage.t
+++ b/lib/Pod/t/Usage.t
@@ -8,7 +8,6 @@ BEGIN {
 use File::Basename;
 use File::Spec;
 use Test::More;
-plan tests => 8;
 
 use_ok( 'Pod::Usage' );
 
@@ -97,6 +96,7 @@ my $pod2usage = $$fake_out;
 
 is( $pod2usage, $pod2text, 'Verbose level >= 2 eq pod2text' );
 
+done_testing();
 
 package CatchOut;
 sub TIEHANDLE { bless \( my $self ), shift }

--- a/lib/Symbol.t
+++ b/lib/Symbol.t
@@ -8,7 +8,7 @@ BEGIN {
     @INC = '../lib';
 }
 
-use Test::More tests => 31;
+use Test::More;
 
 BEGIN { $_ = 'foo'; }  # because Symbol used to clobber $_
 
@@ -111,3 +111,5 @@ ok( exists $::{'Bar::'}, 'third transient stash exists' );
 ok( defined $Bar::{variable}, 'third transient variable in stash' );
 ok( ! defined(Symbol::delete_package('Bar::Bar::')),
     'delete_package() returns undef due to undefined leaf');
+
+done_testing();

--- a/lib/Thread.t
+++ b/lib/Thread.t
@@ -14,7 +14,7 @@ BEGIN {
 
 use Thread qw(:DEFAULT async yield);
 
-use Test::More tests => 13;
+use Test::More;
 
 my $lock;
 {
@@ -93,4 +93,4 @@ COND_:
     is($thr->join(), 3, "->join returned thread's tid");
 }
 
-# EOF
+done_testing();

--- a/lib/Tie/ExtraHash.t
+++ b/lib/Tie/ExtraHash.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 11;
+use Test::More;
 use_ok('Tie::Hash');
 
 tie my %tied, 'Tie::ExtraHash';
@@ -39,3 +39,4 @@ is_deeply(\%tied, \%hash, "CLEAR");
 # SCALAR
 is(scalar(%tied), scalar(%hash), "SCALAR");
 
+done_testing();

--- a/lib/Tie/Handle/stdhandle.t
+++ b/lib/Tie/Handle/stdhandle.t
@@ -5,7 +5,7 @@ BEGIN {
     @INC = '../lib';
 }
 
-use Test::More tests => 29;
+use Test::More;
 
 use_ok('Tie::StdHandle');
 
@@ -87,3 +87,5 @@ ok(eof($f), "eof");
 ok(close($f), "close");
 
 unlink("afile");
+
+done_testing();

--- a/lib/Tie/Handle/stdhandle_from_handle.t
+++ b/lib/Tie/Handle/stdhandle_from_handle.t
@@ -5,7 +5,7 @@ BEGIN {
     @INC = '../lib';
 }
 
-use Test::More tests => 1;
+use Test::More;
 
 use Tie::Handle;
 
@@ -16,3 +16,5 @@ use Tie::Handle;
 
 # For backwards compatibility with 5.8.x
 ok( Foo->can("TIEHANDLE"), "loading Tie::Handle loads TieStdHandle" );
+
+done_testing();

--- a/lib/Tie/Hash.t
+++ b/lib/Tie/Hash.t
@@ -2,7 +2,7 @@
 
 # These tests are not complete. Patches welcome.
 
-use Test::More tests => 3;
+use Test::More;
 
 BEGIN {use_ok( 'Tie::Hash' )};
 
@@ -11,3 +11,5 @@ for my $method (qw( TIEHASH EXISTS )) {
 	eval { Tie::Hash->$method() };
 	like( $@, qr/doesn't define an? $method/, "croaks on inherited $method()" );
 }
+
+done_testing();

--- a/lib/Tie/Scalar.t
+++ b/lib/Tie/Scalar.t
@@ -16,7 +16,7 @@ sub new { 'Fooled you.' }
 package main;
 
 our $flag;
-use Test::More tests => 16;
+use Test::More;
 
 use_ok( 'Tie::Scalar' );
 
@@ -118,3 +118,5 @@ my $r2 = eval {tie my $foo => "InheritHasMethod2"; 1};
 
 ok $r1 && $called1, "inheriting new() does not croak";
 ok $r2 && $called2, "inheriting TIESCALAR() does not croak";
+
+done_testing();

--- a/lib/Time/gmtime.t
+++ b/lib/Time/gmtime.t
@@ -7,8 +7,6 @@ BEGIN {
     @times   = (-2**55, -2**50, -2**33, -2**31-1, -1, 0, 1, 2**31-1, 2**33, 2**50, 2**55, time);
     @methods = qw(sec min hour mday mon year wday yday isdst);
 
-    plan tests => (@times * (@methods + 1)) + 1;
-
     use_ok Time::gmtime;
 }
 
@@ -21,3 +19,5 @@ for my $time (@times) {
         is $gmtime->$method, shift @gmtime, "gmtime($time)->$method";
     }
 }
+
+done_testing();

--- a/lib/Time/localtime.t
+++ b/lib/Time/localtime.t
@@ -7,8 +7,6 @@ BEGIN {
     @times   = (-2**55, -2**50, -2**33, -2**31-1, -1, 0, 1, 2**31-1, 2**33, 2**50, 2**55, time);
     @methods = qw(sec min hour mday mon year wday yday isdst);
 
-    plan tests => (@times * (@methods + 1)) + 1;
-
     use_ok Time::localtime;
 }
 
@@ -21,3 +19,5 @@ for my $time (@times) {
         is $localtime->$method, shift @localtime, "localtime($time)->$method";
     }
 }
+
+done_testing();

--- a/lib/User/grent.t
+++ b/lib/User/grent.t
@@ -24,7 +24,6 @@ BEGIN {
 }
 
 BEGIN {
-    plan tests => 5;
     use_ok('User::grent');
 }
 
@@ -41,3 +40,4 @@ is( $grent->gid, $grent[2],     '   gid' );
 
 # Testing pretty much anything else is unportable.
 
+done_testing();

--- a/lib/blib.t
+++ b/lib/blib.t
@@ -48,7 +48,7 @@ BEGIN {
     _cleanup( @blib_dirs );
 }
 
-use Test::More tests => 7;
+use Test::More;
 
 eval 'use blib;';
 ok( $@ =~ /Cannot find blib/, 'Fails if blib directory not found' );
@@ -80,5 +80,7 @@ else
 
 ok( grep(m|\Q$blib_lib\E$|, @INC[0,1])  == 1,     "  $blib_lib in \@INC");
 ok( grep(m|\Q$blib_arch\E$|, @INC[0,1]) == 1,     "  $blib_arch in \@INC");
+
+done_testing();
 
 END { _cleanup( @blib_dirs ); }

--- a/lib/dumpvar.t
+++ b/lib/dumpvar.t
@@ -23,8 +23,6 @@ my @prgs;
 
 use Test::More;
 
-plan tests => scalar @prgs;
-
 require "dumpvar.pl";
 
 sub unctrl    { print dumpvar::unctrl($_[0]), "\n" }
@@ -83,6 +81,8 @@ for (@prgs) {
 	}
     }
 }
+
+done_testing();
 
 package TieOut;
 

--- a/lib/filetest.t
+++ b/lib/filetest.t
@@ -6,7 +6,7 @@ BEGIN {
 }
 
 use Config;
-use Test::More tests => 15;
+use Test::More;
 
 # these two should be kept in sync with the pragma itself
 # if hint bits are changed there, other things *will* break
@@ -98,3 +98,5 @@ SKIP: {
     unlink $tstfile;
     warn "Can't remove $tstfile: $!" if -e $tstfile;
 }
+
+done_testing();

--- a/lib/h2xs.t
+++ b/lib/h2xs.t
@@ -154,19 +154,6 @@ Writing $name/MANIFEST
 EOXSFILES
 );
 
-my $total_tests = 3; # opening, closing and deleting the header file.
-for (my $i = $#tests; $i > 0; $i-=3) {
-  # 1 test for running it, 1 test for the expected result, and 1 for each file
-  # plus 1 to open and 1 to check for the use in lib/$name.pm and Makefile.PL
-  # And 1 more for our check for "bonus" files, 2 more for ExtUtil::Manifest.
-  # And 1 more to examine const-c.inc contents in tests that use $header.
-  # use the () to force list context and hence count the number of matches.
-  $total_tests += 9 + (() = $tests[$i] =~ /(Writing)/sg);
-  $total_tests++ if $tests[$i-2] =~ / \Q$header\E$/;
-}
-
-plan tests => $total_tests;
-
 ok (open (HEADER, '>', $header), "open '$header'");
 print HEADER <<HEADER or die $!;
 #define Camel 2
@@ -253,3 +240,5 @@ while (my ($args, $version, $expectation) = splice @tests, 0, 3) {
 }
 
 cmp_ok (unlink ($header), "==", 1, "unlink '$header'") or die "\$! is $!";
+
+done_testing();

--- a/lib/integer.t
+++ b/lib/integer.t
@@ -7,7 +7,7 @@ BEGIN {
 
 use integer;
 
-use Test::More tests => 15;
+use Test::More;
 use Config;
 
 my $x = 4.5;
@@ -67,3 +67,5 @@ SKIP: {
     is($@, '', 'IV_MIN % -1 succeeds');
     is($biff, 0, 'IV_MIN % -1 == 0');
 }
+
+done_testing();

--- a/lib/less.t
+++ b/lib/less.t
@@ -5,7 +5,7 @@ BEGIN {
     push @INC, '../lib';
 }
 
-use Test::More tests => 12;
+use Test::More;
 
 BEGIN {
     use_ok( 'less' );
@@ -34,3 +34,5 @@ use less 'random acts';
 is_deeply([sort less->of],[sort qw(random acts)],'less random acts');
 
 is(scalar less->of('random'),1,'less random');
+
+done_testing();

--- a/lib/overload64.t
+++ b/lib/overload64.t
@@ -11,7 +11,7 @@ BEGIN {
 }
 
 $| = 1;
-use Test::More 'tests' => 140;
+use Test::More;
 
 
 my $ii = 36028797018963971;  # 2^55 + 3
@@ -273,4 +273,4 @@ is($$oo, $cnt++, 'overload called once');
     }
 }
 
-# EOF
+done_testing();

--- a/lib/overloading.t
+++ b/lib/overloading.t
@@ -1,6 +1,6 @@
 #./perl
 
-use Test::More tests => 50;
+use Test::More;
 
 use Scalar::Util qw(refaddr);
 
@@ -114,3 +114,5 @@ is( cos($x), "far side of overload table", "cosinusfies" );
 
     BEGIN { ok(!exists($^H{overloading}), "overloading hint removed") }
 }
+
+done_testing();

--- a/lib/sort.t
+++ b/lib/sort.t
@@ -25,9 +25,7 @@ BEGIN {
 use strict;
 use warnings;
 
-use Test::More tests => @TestSizes * 2	# sort() tests
-			* 3		# number of pragmas to test
-			+ 10;		# tests for sort::current
+use Test::More;
 
 # Generate array of specified size for testing sort.
 #
@@ -213,3 +211,5 @@ main(sub { sort {&{$_[0]}} @{$_[1]} }, 0);
     }
     is($sort_current, 'stable', 'sort::current for stable');
 }
+
+done_testing();

--- a/lib/vmsish.t
+++ b/lib/vmsish.t
@@ -10,7 +10,7 @@ $perl = VMS::Filespec::vmsify($perl) if $^O eq 'VMS';
 
 my $Invoke_Perl = qq(MCR $perl "-I[-.lib]");
 
-use Test::More tests => 29;
+use Test::More;
 
 SKIP: {
     skip("tests for non-VMS only", 1) if $^O eq 'VMS';
@@ -182,6 +182,8 @@ is($?,0,"outer lex scope of vmsish [POSIX status]");
   ok(abs($utcmtime - $vmsmtime + $offset) <= 10,"(stat) UTC: $utcmtime  VMS: $vmsmtime");
 }
 }
+
+done_testing();
 
 #====== need this to make sure error messages come out, even if
 #       they were turned off in invoking procedure


### PR DESCRIPTION
this is my first contribution to perl5

Having to count tests is annoying for maintainers.

Also, manually updating count tests is problematic when multiple people
are working on the same code; it causes merge conflicts and recounts.

Sometimes creative workarounds involving BEGIN blocks were used to make
counting the tests a little more bearable. But these tricks are no
longer required.

done_testing() is available since Test::More 0.88 which was released in
2009.

While updating this I've also removed shebang lines if possible - there
were many different shebangs in use, and the files do not have an
execute bit. I've also added 'use strict; use warnings;' if possible.

Some of the tests use 'test.pl' and this is most often not super easy to
change because they use features of 'test.pl' not available in
Test::More; such as fresh_perl_*(); luckily also `test.pl` has
done_testing()!

This PR covers all tests in lib/ that were using Test::More and a plan.

(updated: previously I also made minor other cleanups, which increased the complexity of the PR, probably a bit too much)