### PR TITLE
Misc microoptimizations when dealing with new SVs

### DIFF
--- a/hv.c
+++ b/hv.c
@@ -204,8 +204,10 @@ S_hv_notallowed(pTHX_ int flags, const char *key, I32 klen,
 
     PERL_ARGS_ASSERT_HV_NOTALLOWED;
 
+    sv_upgrade(sv, SVt_PV); /* Needed by sv_setpvn_fresh and
+                             * sv_usepvn would otherwise call it */
     if (!(flags & HVhek_FREEKEY)) {
-        sv_setpvn(sv, key, klen);
+        sv_setpvn_fresh(sv, key, klen);
     }
     else {
         /* Need to free saved eventually assign to mortal SV */

--- a/pp.c
+++ b/pp.c
@@ -180,8 +180,7 @@ S_rv2gv(pTHX_ SV *sv, const bool vivify_sv, const bool strict,
         }
     }
     if (SvFAKE(sv) && !(PL_op->op_private & OPpALLOW_FAKE)) {
-        SV *newsv = sv_newmortal();
-        sv_setsv_flags(newsv, sv, 0);
+        SV *newsv = sv_mortalcopy_flags(sv, 0);
         SvFAKE_off(newsv);
         sv = newsv;
     }
@@ -7006,9 +7005,7 @@ PP(pp_argelem)
              */
             for (i = 0; i < argc; i++) {
                 SV **svp = av_fetch(defav, ix + i, FALSE);
-                SV *newsv = newSV(0);
-                sv_setsv_flags(newsv,
-                                svp ? *svp : &PL_sv_undef,
+                SV *newsv = newSVsv_flags(svp ? *svp : &PL_sv_undef,
                                 (SV_DO_COW_SVSETSV|SV_NOSTEAL));
                 if (!av_store(defav, ix + i, newsv))
                     SvREFCNT_dec_NN(newsv);
@@ -7130,7 +7127,7 @@ S_find_runcv_name(void)
     if (!gv)
         return &PL_sv_no;
 
-    sv = sv_2mortal(newSV(0));
+    sv = sv_newmortal();
     gv_fullname4(sv, gv, NULL, TRUE);
     return sv;
 }

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -3284,7 +3284,7 @@ S_save_lines(pTHX_ AV *array, SV *sv)
         else
             t = send;
 
-        sv_setpvn(tmpstr, s, t - s);
+        sv_setpvn_fresh(tmpstr, s, t - s);
         av_store(array, line++, tmpstr);
         s = t;
     }

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -1077,16 +1077,15 @@ PP(pp_multiconcat)
 
                 /* if both args are the same magical value, make one a copy */
                 if (left == right && SvGMAGICAL(left)) {
-                    left = sv_newmortal();
+                    SV * targetsv = right;
                     /* Print the uninitialized warning now, so it includes the
                      * variable name. */
                     if (!SvOK(right)) {
                         if (ckWARN(WARN_UNINITIALIZED))
                             report_uninit(right);
-                        sv_setbool(left, FALSE);
+                        targetsv = &PL_sv_no;
                     }
-                    else
-                        sv_setsv_flags(left, right, 0);
+                    left = sv_mortalcopy_flags(targetsv, 0);
                     SvGETMAGIC(right);
                 }
             }
@@ -2407,13 +2406,10 @@ PP(pp_aassign)
                     }
                     else {
                         SV *nsv;
-                        /* do get before newSV, in case it dies and leaks */
-                        SvGETMAGIC(rsv);
-                        nsv = newSV(0);
                         /* see comment in S_aassign_copy_common about
                          * SV_NOSTEAL */
-                        sv_setsv_flags(nsv, rsv,
-                                (SV_DO_COW_SVSETSV|SV_NOSTEAL));
+                        nsv = newSVsv_flags(rsv,
+                                (SV_DO_COW_SVSETSV|SV_NOSTEAL|SV_GMAGIC));
                         rsv = *svp = nsv;
                     }
 
@@ -2531,13 +2527,10 @@ PP(pp_aassign)
                 }
                 else {
                     SV *nsv;
-                    /* do get before newSV, in case it dies and leaks */
-                    SvGETMAGIC(rsv);
-                    nsv = newSV(0);
                     /* see comment in S_aassign_copy_common about
                      * SV_NOSTEAL */
-                    sv_setsv_flags(nsv, rsv,
-                            (SV_DO_COW_SVSETSV|SV_NOSTEAL));
+                    nsv = newSVsv_flags(rsv,
+                            (SV_DO_COW_SVSETSV|SV_NOSTEAL|SV_GMAGIC));
                     rsv = *svp = nsv;
                 }
 

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -938,7 +938,7 @@ PP(pp_tie)
                /* If the glob doesn't name an existing package, using
                 * SVfARG(*MARK) would yield "*Foo::Bar" or *main::Foo. So
                 * generate the name for the error message explicitly. */
-               SV *stashname = sv_2mortal(newSV(0));
+               SV *stashname = sv_newmortal();
                gv_fullname4(stashname, (GV *) *MARK, NULL, FALSE);
                DIE(aTHX_ "Can't locate object method \"%s\" via package \"%" SVf "\"",
                    methname, SVfARG(stashname));
@@ -2697,7 +2697,8 @@ PP(pp_ssockopt)
         goto nuts;
     switch (optype) {
     case OP_GSOCKOPT:
-        SvGROW(sv, 257);
+        /* Note: there used to be an explicit SvGROW(sv,257) here, but
+         * this is redundant given the sv initialization ternary above */
         (void)SvPOK_only(sv);
         SvCUR_set(sv,256);
         *SvEND(sv) ='\0';
@@ -5063,7 +5064,8 @@ PP(pp_ghostent)
         if (hent) {
             if (which == OP_GHBYNAME) {
                 if (hent->h_addr)
-                    sv_setpvn(sv, hent->h_addr, hent->h_length);
+                    sv_upgrade(sv, SVt_PV);
+                    sv_setpvn_fresh(sv, hent->h_addr, hent->h_length);
             }
             else
                 sv_setpv(sv, (char*)hent->h_name);


### PR DESCRIPTION
In a few places, SVs can be created more efficiently or new SVs
can be assigned to more efficiently. Small changes included:
* Use sv_setpvn_fresh instead of sv_setpvn
* Use sv_mortalcopy_flags instead of sv_newmortal + sv_setsv_flags
* newSVsv_flags instead of newSV + sv_setsv_flags
* sv_newmortal instead of sv_2mortal(newSV(0))
* Remove a SvGROW(sv, 257) following a newSV(257)