### PR TITLE
Modernise File::Compare a little

### DIFF
--- a/lib/File/Compare.pm
+++ b/lib/File/Compare.pm
@@ -1,18 +1,14 @@
-package File::Compare;
+package File::Compare 1.1007;
 
-use 5.006;
-use strict;
+use v5.12;
 use warnings;
-our($VERSION, @ISA, @EXPORT, @EXPORT_OK, $Too_Big);
 
-require Exporter;
+use Exporter 'import';
 
-$VERSION = '1.1006';
-@ISA = qw(Exporter);
-@EXPORT = qw(compare);
-@EXPORT_OK = qw(cmp compare_text);
+our @EXPORT = qw(compare);
+our @EXPORT_OK = qw(cmp compare_text);
 
-$Too_Big = 1024 * 1024 * 2;
+our $Too_Big = 1024 * 1024 * 2;
 
 sub croak {
     require Carp;
@@ -127,8 +123,7 @@ sub compare_text {
 	if @_ == 3 && ref($cmp) ne 'CODE';
 
     # Using a negative buffer size puts compare into text_mode too
-    $cmp = -1 unless defined $cmp;
-    compare($from, $to, $cmp);
+    compare($from, $to, $cmp // -1);
 }
 
 1;
@@ -177,6 +172,3 @@ are equal, 1 if the files are unequal, or -1 if an error was encountered.
 
 File::Compare was written by Nick Ing-Simmons.
 Its original documentation was written by Chip Salzenberg.
-
-=cut
-


### PR DESCRIPTION
Based on @leonerd 's recent email about "dogfooding" newer features in core I've attempted to modernise File::Compare to the dizzying heights of Perl 5.12. I wasn't sure if one should always bump the version of a lib when changing it but figured since the ISA change is technically user visible we ought to.

The file could definitely be improved more, specially the use of bareword filehandles. But I believe this to be a fairly uncontroversial improvement that removes more lines than it adds which is always good.

 - Move the version to the package line and bump it.
 - Drop superfluous use version.
 - Switch to non-inheritance based Exporter usage.
 - Use defined-or operator.