### PR TITLE
Use the new `builtin::` functions in core unit tests

### DIFF
--- a/ext/Hash-Util-FieldHash/t/02_function.t
+++ b/ext/Hash-Util-FieldHash/t/02_function.t
@@ -1,5 +1,9 @@
 #!perl
-use strict; use warnings;
+
+use strict;
+use warnings;
+use builtin qw(refaddr);
+
 use Test::More;
 my $n_tests = 0;
 
@@ -104,7 +108,6 @@ BEGIN { $n_tests += 6 }
 
 ### id-action (stringification independent of bless)
 BEGIN { $n_tests += 5 }
-# use Scalar::Util qw( refaddr);
 {
     my( %f, %g, %h, %i);
     Hash::Util::FieldHash::_fieldhash \ %f, $fieldhash_mode;
@@ -304,14 +307,6 @@ BEGIN { $n_tests += 4 }
 BEGIN { plan tests => $n_tests }
 
 #######################################################################
-
-sub refaddr {
-    # silence possible warnings from hex() on 64bit systems
-    no warnings 'portable';
-
-    my $ref = shift;
-    hex +($ref =~ /\(0x([[:xdigit:]]+)\)$/)[ 0];
-}
 
 use Symbol qw( gensym);
 

--- a/ext/Hash-Util-FieldHash/t/05_perlhook.t
+++ b/ext/Hash-Util-FieldHash/t/05_perlhook.t
@@ -4,7 +4,7 @@ use Test::More;
 my $n_tests;
 
 use Hash::Util::FieldHash;
-use Scalar::Util qw( weaken);
+use builtin qw(weaken);
 
 sub numbers_first { # Sort helper: All digit entries sort in front of others
                     # Makes sorting portable across ASCII/EBCDIC

--- a/ext/XS-APItest/t/caller.t
+++ b/ext/XS-APItest/t/caller.t
@@ -2,10 +2,10 @@
 
 use warnings;
 use strict;
+use builtin qw(reftype);
 
 use Test::More;
 use XS::APItest;
-use Scalar::Util qw/reftype/;
 
 BEGIN { *my_caller = \&XS::APItest::my_caller }
 

--- a/ext/XS-APItest/t/hash.t
+++ b/ext/XS-APItest/t/hash.t
@@ -191,7 +191,7 @@ sub test_precomputed_hashes {
 }
 
 {
-    use Scalar::Util 'weaken';
+    use builtin 'weaken';
     my %h;
     fill_hash_with_nulls(\%h);
     my @objs;

--- a/ext/XS-APItest/t/magic.t
+++ b/ext/XS-APItest/t/magic.t
@@ -29,7 +29,6 @@ ok !mg_find_bar($sv), '... and bar magic is removed too';
 
 is(test_get_vtbl(), 0, 'get_vtbl(-1) returns NULL');
 
-use Scalar::Util 'weaken';
 eval { sv_magic(\!0, $foo) };
 is $@, "", 'PERL_MAGIC_ext is permitted on read-only things';
 

--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -413,9 +413,8 @@ like runperl(stderr => 1, switches => [ '-MO=-qq,Deparse', $path ],
      qr/sub f\s*\(\$\)\s*\{\s*\}/,
     'predeclared prototyped subs';
 like runperl(stderr => 1, switches => [ '-MO=-qq,Deparse', $path ],
-           prog => 'use Scalar::Util q-weaken-;
-                    sub f($);
-                    BEGIN { weaken($_=\$::{f}) }'),
+           prog => 'sub f($);
+                    BEGIN { use builtin q-weaken-; weaken($_=\$::{f}) }'),
      qr/sub f\s*\(\$\)\s*;/,
     'prototyped stub with weak reference to the stash entry';
 like runperl(stderr => 1, switches => [ '-MO=-qq,Deparse', $path ],

--- a/lib/overload.t
+++ b/lib/overload.t
@@ -1390,7 +1390,7 @@ foreach my $op (qw(<=> == != < <= > >=)) {
 }
 
 {
-    use Scalar::Util 'weaken';
+    use builtin 'weaken';
 
     package Shklitza;
     use overload '""' => sub {"CLiK KLAK"};

--- a/lib/overloading.t
+++ b/lib/overloading.t
@@ -2,7 +2,7 @@
 
 use Test::More;
 
-use Scalar::Util qw(refaddr);
+use builtin qw(refaddr);
 
 {
     package Stringifies;

--- a/t/op/array.t
+++ b/t/op/array.t
@@ -440,14 +440,13 @@ $::ra = [ bless [], 'A' ];
 pass 'no crash when freeing array that is being cleared';
 
 # [perl #85670] Copying magic to elements
-SKIP: {
-    skip "no Scalar::Util::weaken on miniperl", 1, if is_miniperl;
-    require Scalar::Util;
+{
     package glelp {
-	Scalar::Util::weaken ($a = \@ISA);
-	@ISA = qw(Foo);
-	Scalar::Util::weaken ($a = \$ISA[0]);
-	::is @ISA, 1, 'backref magic is not copied to elements';
+        use builtin 'weaken';
+        weaken ($a = \@ISA);
+        @ISA = qw(Foo);
+        weaken ($a = \$ISA[0]);
+        ::is @ISA, 1, 'backref magic is not copied to elements';
     }
 }
 package peen {

--- a/t/op/array.t
+++ b/t/op/array.t
@@ -440,14 +440,12 @@ $::ra = [ bless [], 'A' ];
 pass 'no crash when freeing array that is being cleared';
 
 # [perl #85670] Copying magic to elements
-{
-    package glelp {
-        use builtin 'weaken';
-        weaken ($a = \@ISA);
-        @ISA = qw(Foo);
-        weaken ($a = \$ISA[0]);
-        ::is @ISA, 1, 'backref magic is not copied to elements';
-    }
+package glelp {
+    use builtin 'weaken';
+    weaken ($a = \@ISA);
+    @ISA = qw(Foo);
+    weaken ($a = \$ISA[0]);
+    ::is @ISA, 1, 'backref magic is not copied to elements';
 }
 package peen {
     $#ISA = -1;

--- a/t/op/hash.t
+++ b/t/op/hash.t
@@ -100,13 +100,12 @@ sub guard::DESTROY {
 }
 
 # Weak references to pad hashes
-SKIP: {
-    skip_if_miniperl("No Scalar::Util::weaken under miniperl", 1);
+{
     my $ref;
-    require Scalar::Util;
+    use builtin 'weaken';
     {
         my %hash;
-        Scalar::Util::weaken($ref = \%hash);
+        weaken($ref = \%hash);
         1;  # the previous statement must not be the last
     }
     is $ref, undef, 'weak refs to pad hashes go stale on scope exit';

--- a/t/op/hashassign.t
+++ b/t/op/hashassign.t
@@ -310,15 +310,14 @@ foreach my $chr (60, 200, 600, 6000, 60000) {
 }
 
 # [perl #76716] Hash assignment should not zap weak refs.
-SKIP: {
- skip_if_miniperl("no dynamic loading on miniperl, no Scalar::Util", 2);
- my %tb;
- require Scalar::Util;
- Scalar::Util::weaken(my $p = \%tb);
- %tb = ();
- is $p, \%tb, "hash assignment should not zap weak refs";
- undef %tb;
- is $p, \%tb, "hash undef should not zap weak refs";
+{
+    my %tb;
+    use builtin 'weaken';
+    weaken(my $p = \%tb);
+    %tb = ();
+    is $p, \%tb, "hash assignment should not zap weak refs";
+    undef %tb;
+    is $p, \%tb, "hash undef should not zap weak refs";
 }
 
 # test odd hash assignment warnings

--- a/t/op/lvref.t
+++ b/t/op/lvref.t
@@ -538,11 +538,9 @@ like $@,
   is s(3), 1, 'padstale alias should not reset state'
 }
 
-SKIP: {
-    skip_without_dynamic_extension('List/Util');
-    require Scalar::Util;
+{
     my $a;
-    Scalar::Util::weaken($r = \$a);
+    builtin::weaken($r = \$a);
     \$a = $r;
     pass 'no crash when assigning \$lex = $weakref_to_lex'
 }

--- a/t/op/ref.t
+++ b/t/op/ref.t
@@ -724,16 +724,14 @@ is (runperl(
 # it doesn't trigger a panic with multiple rounds of global cleanup
 # (Perl_sv_clean_all).
 
-SKIP: {
-    skip_if_miniperl('no Scalar::Util under miniperl', 4);
-
+{
     local $ENV{PERL_DESTRUCT_LEVEL} = 2;
 
     # we do all permutations of array/hash, 1ref/2ref, to account
     # for the different way backref magic is stored
 
     fresh_perl_is(<<'EOF', 'ok', { stderr => 1 }, 'array with 1 weak ref');
-use Scalar::Util qw(weaken);
+use builtin qw(weaken);
 my $r = [];
 Internals::SvREFCNT(@$r, 9);
 my $r1 = $r;
@@ -742,7 +740,7 @@ print "ok";
 EOF
 
     fresh_perl_is(<<'EOF', 'ok', { stderr => 1 }, 'array with 2 weak refs');
-use Scalar::Util qw(weaken);
+use builtin qw(weaken);
 my $r = [];
 Internals::SvREFCNT(@$r, 9);
 my $r1 = $r;
@@ -753,7 +751,7 @@ print "ok";
 EOF
 
     fresh_perl_is(<<'EOF', 'ok', { stderr => 1 }, 'hash with 1 weak ref');
-use Scalar::Util qw(weaken);
+use builtin qw(weaken);
 my $r = {};
 Internals::SvREFCNT(%$r, 9);
 my $r1 = $r;
@@ -762,7 +760,7 @@ print "ok";
 EOF
 
     fresh_perl_is(<<'EOF', 'ok', { stderr => 1 }, 'hash with 2 weak refs');
-use Scalar::Util qw(weaken);
+use builtin qw(weaken);
 my $r = {};
 Internals::SvREFCNT(%$r, 9);
 my $r1 = $r;
@@ -774,12 +772,11 @@ EOF
 
 }
 
-SKIP:{
-    skip_if_miniperl "no Scalar::Util on miniperl", 1;
+{
     my $error;
     *hassgropper::DESTROY = sub {
-        require Scalar::Util;
-        eval { Scalar::Util::weaken($_[0]) };
+        use builtin qw(weaken);
+        eval { weaken($_[0]) };
         $error = $@;
         # This line caused a crash before weaken refused to weaken a
         # read-only reference:

--- a/t/op/svleak.t
+++ b/t/op/svleak.t
@@ -222,12 +222,10 @@ leak_expr(5, 0, q{"YYYYYa" =~ /.+?(a(.+?)|b)/ }, "trie leak");
      'map reading from sparse array');
 }
 
-SKIP:
 { # broken by 304474c3, fixed by cefd5c7c, but didn't seem to cause
   # any other test failures
   # base test case from ribasushi (Peter Rabbitson)
-  eval { require Scalar::Util; Scalar::Util->import("weaken"); 1; }
-    or skip "no weaken", 1;
+  use builtin 'weaken';
   my $weak;
   {
     $weak = my $in = {};

--- a/t/op/threads.t
+++ b/t/op/threads.t
@@ -29,11 +29,11 @@ EOI
 # Attempt to free unreferenced scalar: SV 0x814e0dc.
 fresh_perl_is(<<'EOI', 'ok', { }, 'weaken ref under threads');
 use threads;
-use Scalar::Util;
+use builtin 'weaken';
 my $data = "a";
 my $obj = \$data;
 my $copy = $obj;
-Scalar::Util::weaken($copy);
+weaken($copy);
 threads->create(sub { 1 })->join for (1..1);
 print "ok";
 EOI
@@ -47,7 +47,7 @@ package Foo;
 sub new { bless {},shift }
 package main;
 use threads;
-use Scalar::Util qw(weaken);
+use builtin 'weaken';
 my $object = Foo->new;
 my $ref = $object;
 weaken $ref;
@@ -217,8 +217,8 @@ EOJ
 # The weak reference $a, however, is visible from the symbol table.
 fresh_perl_is(<<'EOI', 'ok', { }, 'Test for 34394ecd06e704e9');
     use threads;
+    use builtin 'weaken';
     %h = (1, 2);
-    use Scalar::Util 'weaken';
     $a = \$h{1};
     weaken($a);
     delete $h{1} && threads->create(sub {}, shift)->join();
@@ -243,8 +243,8 @@ EOI
 
 fresh_perl_is(<<'EOI', 'ok', { }, '0 refcnt neither on tmps stack nor in @_');
     use threads;
+    use builtin 'weaken';
     my %h = (1, []);
-    use Scalar::Util 'weaken';
     my $a = $h{1};
     weaken($a);
     delete $h{1} && threads->create(sub {}, shift)->join();
@@ -295,7 +295,7 @@ use threads;
 
 {
     package My::Obj;
-    use Scalar::Util 'weaken';
+    use builtin 'weaken';
 
     my %reg;
 

--- a/t/op/tie.t
+++ b/t/op/tie.t
@@ -996,7 +996,7 @@ EXPECT
 #
 # [perl #86328] Crash when freeing tie magic that can increment the refcnt
 
-eval { require Scalar::Util } or print("ok\n"), exit;
+use builtin 'weaken';
 
 sub TIEHASH {
     return $_[1];
@@ -1010,12 +1010,12 @@ sub DESTROY {
 
 my $a = {};
 my $o = bless [];
-Scalar::Util::weaken($o->[0] = $a);
+weaken($o->[0] = $a);
 tie %$a, "main", $o;
 
 my $b = [];
 my $p = bless [];
-Scalar::Util::weaken($p->[0] = $b);
+weaken($p->[0] = $b);
 tie @$b, "main", $p;
 
 # Done setting up the evil data structures
@@ -1189,9 +1189,9 @@ EXPECT
 BEGIN { unless (defined &DynaLoader::boot_DynaLoader) {
     print "HASH\nHASH\nARRAY\nARRAY\n"; exit;
 }}
-use Scalar::Util 'weaken';
+use builtin 'weaken';
 { package xoufghd;
-  sub TIEHASH { Scalar::Util::weaken($_[1]); bless \$_[1], xoufghd:: }
+  sub TIEHASH { weaken($_[1]); bless \$_[1], xoufghd:: }
   *TIEARRAY = *TIEHASH;
   DESTROY {
      bless ${$_[0]} || return, 0;

--- a/t/op/write.t
+++ b/t/op/write.t
@@ -1972,13 +1972,13 @@ write STRICT;
 close STRICT or die "Could not close: $!";
 is cat('Op_write.tmp'), "oof:\n", 'pragmata on format line';
 
-SKIP: {
-   skip "no weak refs" unless eval { require Scalar::Util };
+{
+   use builtin 'weaken';
    sub Potshriggley {
 format Potshriggley =
 .
    }
-   Scalar::Util::weaken(my $x = *Potshriggley{FORMAT});
+   weaken(my $x = *Potshriggley{FORMAT});
    undef *Potshriggley;
    is $x, undef, 'formats in subs do not leak';
 }

--- a/t/porting/podcheck.t
+++ b/t/porting/podcheck.t
@@ -11,13 +11,13 @@ BEGIN {
 use strict;
 use warnings;
 use feature 'unicode_strings';
+use builtin 'refaddr';
 
 use Carp;
 use Config;
 use Digest;
 use File::Find;
 use File::Spec;
-use Scalar::Util;
 use Text::Tabs;
 
 BEGIN {
@@ -687,7 +687,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
                             # currently being worked on
 
     sub DESTROY {
-        my $addr = Scalar::Util::refaddr $_[0];
+        my $addr = refaddr $_[0];
         delete $CFL_text{$addr};
         delete $C_text{$addr};
         delete $command_count{$addr};
@@ -715,7 +715,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
 
         my $self = $class->SUPER::new(-quiet => 1,
                                      -warnings => $Warnings_Level);
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
         $command_count{$addr} = 0;
         $current_indent{$addr} = 0;
         $filename{$addr} = $filename;
@@ -747,7 +747,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         my $self = shift;
         my $opts = shift;
 
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
         return if $skip{$addr};
 
         # Input can be a string or hash.  If a string, parse it to separate
@@ -843,7 +843,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         # specially.
 
         my $self = shift;
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         my $return = $self->SUPER::handle_text(@_);
 
@@ -890,7 +890,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         my $self = shift;
         check_see_but_not_link($self);
 
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
         $start_line{$addr} = $_[0]->{start_line};
         $running_CFL_text{$addr} = "";
         $running_simple_text{$addr} = "";
@@ -901,7 +901,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         my $self = shift;
         check_see_but_not_link($self);
 
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
         $start_line{$addr} = $_[0]->{start_line};
         $running_CFL_text{$addr} = "";
         $running_simple_text{$addr} = "";
@@ -911,7 +911,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
     sub start_item_text {
         my $self = shift;
         start_item($self);
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         # This is the only =item that is linkable
         $linkable_item{$addr} = 1;
@@ -943,7 +943,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         my $self = shift;
         check_see_but_not_link($self);
 
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
         $start_line{$addr} = $_[0]->{start_line};
         $running_CFL_text{$addr} = "";
         $running_simple_text{$addr} = "";
@@ -965,7 +965,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         my $self = shift;
         check_see_but_not_link($self);
 
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         # Pop current indent
         if (@{$indents{$addr}}) {
@@ -985,7 +985,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         # C<link> instead of L<link>.
 
         my $self = shift;
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         return unless defined $running_CFL_text{$addr};
 
@@ -1048,7 +1048,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         my $self = shift;
         check_see_but_not_link($self);
 
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
         if ($in_NAME{$addr}) {
             if ($running_simple_text{$addr} =~ /^\s*(\S+?)\s*$/) {
                 $self->poderror({ -line => $start_line{$addr},
@@ -1064,7 +1064,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         my $self = shift;
         check_see_but_not_link($self);
 
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
         $start_line{$addr} = $_[0]->{start_line};
         $running_CFL_text{$addr} = "";
         $running_simple_text{$addr} = "";
@@ -1076,7 +1076,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         my $self = shift;
         check_see_but_not_link($self);
 
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         $in_NAME{$addr} = 1 if $running_simple_text{$addr} eq 'NAME';
         return $self->SUPER::end_head(@_);
@@ -1086,7 +1086,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         my $self = shift;
         check_see_but_not_link($self);
 
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
         $running_simple_text{$addr} = "";
         $start_line{$addr} = $_[0]->{start_line};
         return $self->SUPER::start_Verbatim(@_);
@@ -1094,7 +1094,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
 
     sub end_Verbatim {
         my $self = shift;
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         # Pick up the name if it looks like one, since the parent class
         # doesn't handle verbatim NAMEs
@@ -1128,7 +1128,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
 
     sub start_C {
         my $self = shift;
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         $C_text{$addr} = "";
 
@@ -1142,7 +1142,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
 
     sub start_F {
         my $self = shift;
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         $CFL_text{$addr} = "" if ! $in_CFL{$addr};
         $in_CFL{$addr}++;
@@ -1151,7 +1151,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
 
     sub start_L {
         my $self = shift;
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         $CFL_text{$addr} = "" if ! $in_CFL{$addr};
         $in_CFL{$addr}++;
@@ -1160,7 +1160,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
 
     sub end_C {
         my $self = shift;
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         # Warn if looks like a file or link enclosed instead by this C<>
         if ($C_text{$addr} =~ qr/^ $C_path_re $/x) {
@@ -1220,7 +1220,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
 
     sub end_F {
         my $self = shift;
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         $CFL_text{$addr} = "F<$CFL_text{$addr}>";
         $in_CFL{$addr}--;
@@ -1230,7 +1230,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
 
     sub end_L {
         my $self = shift;
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         $CFL_text{$addr} = "L<$CFL_text{$addr}>";
         $in_CFL{$addr}--;
@@ -1240,7 +1240,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
 
     sub start_X {
         my $self = shift;
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         $in_X{$addr} = 1;
         return $self->SUPER::start_X(@_);
@@ -1248,7 +1248,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
 
     sub end_X {
         my $self = shift;
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         $in_X{$addr} = 0;
         return $self->SUPER::end_X(@_);
@@ -1256,7 +1256,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
 
     sub start_for {
         my $self = shift;
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         $in_for{$addr} = 1;
         return $self->SUPER::start_for(@_);
@@ -1264,7 +1264,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
 
     sub end_for {
         my $self = shift;
-        my $addr = Scalar::Util::refaddr $self;
+        my $addr = refaddr $self;
 
         $in_for{$addr} = 0;
         return $self->SUPER::end_for(@_);
@@ -1301,7 +1301,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         if($text) {
             $text =~ s/\s+$//s; # strip trailing whitespace
             $text =~ s/\s+/ /gs; # collapse whitespace
-            my $addr = Scalar::Util::refaddr $self;
+            my $addr = refaddr $self;
             push(@{$linkable_nodes{$addr}}, $text) if
                                     ! $current_indent{$addr}
                                     || $linkable_item{$addr};
@@ -1310,26 +1310,26 @@ package My::Pod::Checker {      # Extend Pod::Checker
     }
 
     sub get_current_indent {
-        return $INDENT + $current_indent{Scalar::Util::refaddr $_[0]};
+        return $INDENT + $current_indent{refaddr $_[0]};
     }
 
     sub get_filename {
-        return $filename{Scalar::Util::refaddr $_[0]};
+        return $filename{refaddr $_[0]};
     }
 
     sub linkable_nodes {
-        my $linkables = $linkable_nodes{Scalar::Util::refaddr $_[0]};
+        my $linkables = $linkable_nodes{refaddr $_[0]};
         return undef unless $linkables;
         return @$linkables;
     }
 
     sub get_skip {
-        return $skip{Scalar::Util::refaddr $_[0]} // 0;
+        return $skip{refaddr $_[0]} // 0;
     }
 
     sub set_skip {
         my $self = shift;
-        $skip{Scalar::Util::refaddr $self} = shift;
+        $skip{refaddr $self} = shift;
 
         # If skipping, no need to keep the problems for it
         delete $problems{$self->get_filename};

--- a/t/re/qr-72922.t
+++ b/t/re/qr-72922.t
@@ -4,8 +4,9 @@ use strict;
 BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
-    skip_all_if_miniperl("no dynamic loading on miniperl, no Scalar::Util");
 }
+
+use builtin 'weaken';
 
 plan(tests => 14);
 
@@ -13,7 +14,6 @@ plan(tests => 14);
 # When a Regex object was copied and the copy weaken then the original regex object
 # could no longer be 'copied' with qr//
 
-use Scalar::Util 'weaken';
 sub s1 {
     my $re = qr/abcdef/;
     my $re_copy1 = $re;


### PR DESCRIPTION
Avoids loading `Scalar::Util`.

In several places this tidies up logic as now it no longer has to be conditional on not running on miniperl, since the `builtin::` functions are even available there.