### PR TITLE
Use `builtin` in core libs

### DIFF
--- a/ext/Hash-Util-FieldHash/lib/Hash/Util/FieldHash.pm
+++ b/ext/Hash-Util-FieldHash/lib/Hash/Util/FieldHash.pm
@@ -2,9 +2,9 @@ package Hash::Util::FieldHash;
 
 use strict;
 use warnings;
-use Scalar::Util qw( reftype);
+use builtin qw(reftype);
 
-our $VERSION = '1.23';
+our $VERSION = '1.24';
 
 use Exporter 'import';
 our %EXPORT_TAGS = (

--- a/ext/Hash-Util/lib/Hash/Util.pm
+++ b/ext/Hash-Util/lib/Hash/Util.pm
@@ -6,7 +6,7 @@ use Carp;
 use warnings;
 no warnings 'uninitialized';
 use warnings::register;
-use Scalar::Util qw(reftype);
+use builtin qw(reftype);
 
 require Exporter;
 our @EXPORT_OK  = qw(
@@ -41,7 +41,7 @@ our @EXPORT_OK  = qw(
 BEGIN {
     # make sure all our XS routines are available early so their prototypes
     # are correctly applied in the following code.
-    our $VERSION = '0.26';
+    our $VERSION = '0.27';
     require XSLoader;
     XSLoader::load();
 }

--- a/lib/File/Copy.pm
+++ b/lib/File/Copy.pm
@@ -44,8 +44,8 @@ sub carp {
 sub _catname {
     my($from, $to) = @_;
     if (not defined &basename) {
-	require File::Basename;
-	import  File::Basename 'basename';
+        require File::Basename;
+        File::Basename->import( 'basename' );
     }
 
     return File::Spec->catfile($to, basename($from));

--- a/lib/File/Copy.pm
+++ b/lib/File/Copy.pm
@@ -7,15 +7,13 @@
 
 package File::Copy;
 
-use 5.006;
+use 5.035007;
 use strict;
 use warnings; no warnings 'newline';
+use builtin 'blessed';
+use overload;
 use File::Spec;
 use Config;
-# During perl build, we need File::Copy but Scalar::Util might not be built yet
-# And then we need these games to avoid loading overload, as that will
-# confuse miniperl during the bootstrap of perl.
-my $Scalar_Util_loaded = eval q{ require Scalar::Util; require overload; 1 };
 # We want HiRes stat and utime if available
 BEGIN { eval q{ use Time::HiRes qw( stat utime ) } };
 our(@ISA, @EXPORT, @EXPORT_OK, $VERSION, $Too_Big, $Syscopy_is_copy);
@@ -24,7 +22,7 @@ sub syscopy;
 sub cp;
 sub mv;
 
-$VERSION = '2.37';
+$VERSION = '2.38';
 
 require Exporter;
 @ISA = qw(Exporter);
@@ -56,8 +54,7 @@ sub _catname {
 # _eq($from, $to) tells whether $from and $to are identical
 sub _eq {
     my ($from, $to) = map {
-        $Scalar_Util_loaded && Scalar::Util::blessed($_)
-	    && overload::Method($_, q{""})
+        blessed($_) && overload::Method($_, q{""})
             ? "$_"
             : $_
     } (@_);

--- a/lib/overload.pm
+++ b/lib/overload.pm
@@ -3,7 +3,7 @@ package overload;
 use strict;
 no strict 'refs';
 
-our $VERSION = '1.33';
+our $VERSION = '1.34';
 
 our %ops = (
     with_assign         => "+ - * / % ** << >> x .",
@@ -101,8 +101,7 @@ sub Method {
   if(ref $package) {
     local $@;
     local $!;
-    require Scalar::Util;
-    $package = Scalar::Util::blessed($package);
+    $package = builtin::blessed($package);
     return undef if !defined $package;
   }
   #my $meth = $package->can('(' . shift);
@@ -972,7 +971,7 @@ Gives the string value of C<arg> as in the
 absence of stringify overloading.  If you
 are using this to get the address of a reference (useful for checking if two
 references point to the same thing) then you may be better off using
-C<Scalar::Util::refaddr()>, which is faster.
+C<builtin::refaddr()> or C<Scalar::Util::refaddr()>, which are faster.
 
 =item overload::Overloaded(arg)
 

--- a/t/op/switch.t
+++ b/t/op/switch.t
@@ -715,8 +715,7 @@ sub contains_x {
     is($ok2, 1, "Calling sub indirectly (false)");
 }
 
-SKIP: {
-    skip_if_miniperl("no dynamic loading on miniperl, no Scalar::Util", 14);
+{
     # Test overloading
     { package OverloadTest;
 
@@ -745,7 +744,7 @@ SKIP: {
 		 retval => $retval,
 		}, $pkg;
       }
-  }
+    }
 
     {
 	my $test = "Overloaded obj in given (true)";


### PR DESCRIPTION
Various files in `lib/` and `ext/` that aren't dual-life, might as well use the new `builtin` functions, especially if it avoids needing to load the `Scalar::Util` XS module.

This now makes it possible to `use overload` in miniperl.