### PR TITLE
sv_upgrade: minor AV/HV new_body refactoring

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -1371,13 +1371,6 @@ Perl_sv_upgrade(pTHX_ SV *const sv, svtype new_type)
             AvMAX(sv)	= -1;
             AvFILLp(sv)	= -1;
             AvREAL_only(sv);
-            if (old_type_details->body_size) {
-                AvALLOC(sv) = 0;
-            } else {
-                /* It will have been zeroed when the new body was allocated.
-                   Lets not write to it, in case it confuses a write-back
-                   cache.  */
-            }
         } else {
             assert(!SvOK(sv));
             SvOK_off(sv);


### PR DESCRIPTION
This PR includes 2 commits:
- Removal of a branch that appears to be a no-op. 
- Changing xpvav & xpvhv initialization from Zero() followed by struct member overwrites, to using compound literals.