### PR TITLE
Fix function calls being misinterpreted as bareword filehandles

### DIFF
--- a/t/lib/feature/bareword_filehandles
+++ b/t/lib/feature/bareword_filehandles
@@ -484,3 +484,12 @@ OPTIONS fatal
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 4.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 5.
 Execution of - aborted due to compilation errors.
+########
+# NAME subroutine calls
+use feature "say";
+no feature "bareword_filehandles";
+sub foo {}
+print foo();
+say foo();
+-x foo();
+EXPECT

--- a/t/lib/feature/bareword_filehandles
+++ b/t/lib/feature/bareword_filehandles
@@ -490,6 +490,9 @@ use feature "say";
 no feature "bareword_filehandles";
 sub foo {}
 print foo();
+print foo;
 say foo();
+say foo;
 -x foo();
+-x foo;
 EXPECT

--- a/toke.c
+++ b/toke.c
@@ -7620,7 +7620,7 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 orig_keyword, struct code c)
         s = SvPVX(PL_linestr) + s_off;
 
         if (((PL_opargs[PL_last_lop_op] >> OASHIFT) & 7) == OA_FILEREF
-            && !immediate_paren
+            && !immediate_paren && !c.cv
             && !FEATURE_BAREWORD_FILEHANDLES_IS_ENABLED) {
             no_bareword_filehandle(PL_tokenbuf);
         }

--- a/toke.c
+++ b/toke.c
@@ -7620,6 +7620,7 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 orig_keyword, struct code c)
         s = SvPVX(PL_linestr) + s_off;
 
         if (((PL_opargs[PL_last_lop_op] >> OASHIFT) & 7) == OA_FILEREF
+            && !immediate_paren
             && !FEATURE_BAREWORD_FILEHANDLES_IS_ENABLED) {
             no_bareword_filehandle(PL_tokenbuf);
         }


### PR DESCRIPTION
When bareword filehandles are disabled, the parser was interpreting
any bareword as a filehandle, even when immediatey followed by parens:

    $ perl -M-feature=bareword_filehandles -le 'print foo()'
    Bareword filehandle "foo" not allowed under 'no feature "bareword_filehandles"' at -e line 1.

While with the feature enabled, it works and prints the value returned
by the function:

    $ perl  -le 'sub foo { @_ } print foo("bar")'
    bar

As for filehandles versus functions, a space before the parens makes
the difference:

    $ perl -le 'print STDOUT ("bar")'
    bar
    $ perl -le 'print STDOUT("bar")'
    Undefined subroutine &main::STDOUT called at -e line 1.

This fixes the bug by using the already-existing "immediate_paren"
variable to make it consistent when the feature is disabled.

Fixes #19271