### PR TITLE
dist/IO/IO.xs: Rmv defns that ppport.h supplies

### DIFF
--- a/dist/IO/IO.pm
+++ b/dist/IO/IO.pm
@@ -7,7 +7,7 @@ use Carp;
 use strict;
 use warnings;
 
-our $VERSION = "1.48";
+our $VERSION = "1.49";
 XSLoader::load 'IO', $VERSION;
 
 sub import {

--- a/dist/IO/IO.xs
+++ b/dist/IO/IO.xs
@@ -49,20 +49,12 @@ typedef FILE * OutputStream;
 
 #define MY_start_subparse(fmt,flags) start_subparse(fmt,flags)
 
-#ifndef gv_stashpvn
-#define gv_stashpvn(str,len,flags) gv_stashpv(str,flags)
-#endif
-
 #ifndef __attribute__noreturn__
 #  define __attribute__noreturn__
 #endif
 
 #ifndef NORETURN_FUNCTION_END
 # define NORETURN_FUNCTION_END /* NOT REACHED */ return 0
-#endif
-
-#ifndef dVAR
-#  define dVAR dNOOP
 #endif
 
 #ifndef OpSIBLING
@@ -76,32 +68,6 @@ not_here(const char *s)
     croak("%s not implemented on this architecture", s);
     NORETURN_FUNCTION_END;
 }
-
-#ifndef UVCHR_IS_INVARIANT   /* For use with Perls without this macro */
-#   if ('A' == 65)
-#       define UVCHR_IS_INVARIANT(cp) ((cp) < 128)
-#   elif (defined(NATIVE_IS_INVARIANT)) /* EBCDIC on old Perl */
-#       define UVCHR_IS_INVARIANT(cp) ((cp) < 256 && NATIVE_IS_INVARIANT(cp))
-#   elif defined(isASCII)    /* EBCDIC on very old Perl */
-        /* In EBCDIC, the invariants are the code points corresponding to ASCII,
-         * plus all the controls.  All but one EBCDIC control is below SPACE; it
-         * varies depending on the code page, determined by the ord of '^' */
-#       define UVCHR_IS_INVARIANT(cp) (isASCII(cp)                            \
-                                       || (cp) < ' '                          \
-                                       || (('^' == 106)    /* POSIX-BC */     \
-                                          ? (cp) == 95                        \
-                                          : (cp) == 0xFF)) /* 1047 or 037 */
-#   else    /* EBCDIC on very very old Perl */
-        /* This assumes isascii() is available, but that could be fixed by
-         * having the macro test for each printable ASCII char */
-#       define UVCHR_IS_INVARIANT(cp) (isascii(cp)                            \
-                                       || (cp) < ' '                          \
-                                       || (('^' == 106)    /* POSIX-BC */     \
-                                          ? (cp) == 95                        \
-                                          : (cp) == 0xFF)) /* 1047 or 037 */
-#   endif
-#endif
-
 
 #ifndef PerlIO
 #define PerlIO_fileno(f) fileno(f)


### PR DESCRIPTION
No sense trying to derive them ourselves.