### PR TITLE
POSIX::FLT_ROUNDS should not be an NV constant

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4438,6 +4438,7 @@ ext/POSIX/lib/POSIX.pod		POSIX extension documentation
 ext/POSIX/Makefile.PL		POSIX extension makefile writer
 ext/POSIX/POSIX.xs		POSIX extension external subroutines
 ext/POSIX/t/export.t		Test @EXPORT and @EXPORT_OK
+ext/POSIX/t/fenv.t		Floating-point rounding mode tests for POSIX
 ext/POSIX/t/iscrash		See if POSIX isxxx() crashes with threads on Win32
 ext/POSIX/t/iv_const.t		See if integer constants of POSIX are IV
 ext/POSIX/t/math.t		Basic math tests for POSIX

--- a/ext/POSIX/Makefile.PL
+++ b/ext/POSIX/Makefile.PL
@@ -82,7 +82,6 @@ my @names =
    {name=>"NULL", value=>"0"},
    {name=>"_POSIX_JOB_CONTROL", type=>"YES", default=>["IV", "0"]},
    {name=>"_POSIX_SAVED_IDS", type=>"YES", default=>["IV", "0"]},
-   {name=>'FLT_ROUNDS', type=>"NV", not_constant=>1},
    {name=>"HUGE_VAL", type=>"NV", not_constant=>1,
     macro=>[<<'END', "#endif\n"],
 #if (defined(USE_LONG_DOUBLE) && defined(HUGE_VALL)) || defined(HUGE_VAL)

--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -2501,13 +2501,29 @@ acos(x)
 
 IV
 fegetround()
+    PROTOTYPE:
+    ALIAS:
+        FLT_ROUNDS = 1
     CODE:
+        switch (ix) {
+        case 0:
+        default:
 #ifdef HAS_FEGETROUND
-	RETVAL = my_fegetround();
+            RETVAL = my_fegetround();
 #else
-	RETVAL = -1;
-	not_here("fegetround");
+            RETVAL = -1;
+            not_here("fegetround");
 #endif
+            break;
+        case 1:
+#ifdef FLT_ROUNDS
+            RETVAL = FLT_ROUNDS;
+#else
+            RETVAL = -1;
+            not_here("FLT_ROUNDS");
+#endif
+            break;
+        }
     OUTPUT:
 	RETVAL
 

--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -1017,6 +1017,11 @@ static NV my_log2(NV x)
 
 /* XXX nexttoward */
 
+/* GCC's FLT_ROUNDS is (wrongly) hardcoded to 1 (at least up to 11.x) */
+#if defined(PERL_IS_GCC) /* && __GNUC__ < XXX */
+#  define BROKEN_FLT_ROUNDS
+#endif
+
 static int my_fegetround()
 {
 #ifdef HAS_FEGETROUND
@@ -2516,8 +2521,26 @@ fegetround()
 #endif
             break;
         case 1:
-#ifdef FLT_ROUNDS
+#if defined(FLT_ROUNDS) && !defined(BROKEN_FLT_ROUNDS)
             RETVAL = FLT_ROUNDS;
+#elif defined(HAS_FEGETROUND) || defined(HAS_FPGETROUND) || defined(__osf__)
+            switch (my_fegetround()) {
+                /* C standard seems to say that each of the FE_* macros is
+                   defined if and only if the implementation supports it. */
+#  ifdef FE_TOWARDZERO
+            case FE_TOWARDZERO: RETVAL = 0;  break;
+#  endif
+#  ifdef FE_TONEAREST
+            case FE_TONEAREST:  RETVAL = 1;  break;
+#  endif
+#  ifdef FE_UPWARD
+            case FE_UPWARD:     RETVAL = 2;  break;
+#  endif
+#  ifdef FE_DOWNWARD
+            case FE_DOWNWARD:   RETVAL = 3;  break;
+#  endif
+            default:            RETVAL = -1; break;
+            }
 #else
             RETVAL = -1;
             not_here("FLT_ROUNDS");

--- a/ext/POSIX/t/fenv.t
+++ b/ext/POSIX/t/fenv.t
@@ -1,0 +1,48 @@
+#! ./perl -w
+
+# These tests are in a separate .t file, because they may change
+# execution environment of the perl process.
+
+use strict;
+use warnings;
+
+use Test::More;
+use POSIX qw/:fenv_h :float_h/;
+
+my $defmode;
+plan skip_all => 'fegetround is unavailable'
+    unless eval { $defmode = fegetround(); 1 };
+
+ok(defined $defmode, 'fegetround');
+
+SKIP: {
+    skip 'default rounding mode is not FE_TONEAREST', 1
+        unless eval { $defmode == FE_TONEAREST() };
+    my $flt_rounds;
+    skip 'FLT_ROUNDS is unavailable', 1
+        unless eval { $flt_rounds = FLT_ROUNDS(); 1 };
+    cmp_ok($flt_rounds, '==', 1, 'FLT_ROUNDS');
+}
+
+cmp_ok(fesetround($defmode), '==', 0, 'fesetround');
+cmp_ok(fegetround(), '==', $defmode, 'fesetround/fegetround round-trip');
+
+my @rounding = qw/TOWARDZERO TONEAREST UPWARD DOWNWARD/;
+
+for (my $i = 0; $i < @rounding; $i++) {
+  SKIP: {
+      my $macro = "FE_$rounding[$i]";
+      my $femode = eval "$macro()";
+      skip "no support for FE_$rounding[$i]", 3
+          unless defined $femode;
+
+      cmp_ok(fesetround($femode), '==', 0, "fesetround($macro)");
+      cmp_ok(fegetround(), '==', $femode, "fegetround() under $macro");
+      cmp_ok(FLT_ROUNDS, '==', $i, "FLT_ROUNDS under $macro");
+    }
+}
+
+# Revert to default rounding mode
+fesetround($defmode);
+
+done_testing();

--- a/ext/POSIX/t/iv_const.t
+++ b/ext/POSIX/t/iv_const.t
@@ -66,4 +66,10 @@ push @tests, qw(FE_TONEAREST FE_TOWARDZERO FE_UPWARD FE_DOWNWARD)
 
 is_iv(eval "POSIX::$_", "$_ is an integer") foreach @tests;
 
+SKIP: {
+    my $x;
+    skip $@, 1 unless eval '$x = FLT_ROUNDS; 1';
+    is_iv($x, 'FLT_ROUNDS is an integer');
+}
+
 done_testing();


### PR DESCRIPTION
Perl's `POSIX::FLT_ROUNDS` used to be an NV constant, but `FLT_ROUNDS` in C <float.h> is actually an integer and not a constant (C99 seems to say that it reflects the current rounding mode set by `fesetround()`).

This PR will fix this by turning `POSIX::FLT_ROUNDS` into an XS function (actually an alias of existing function for `POSIX::fesetround()`).