### PR TITLE
Version tags for `use builtin :ver`

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -18,7 +18,7 @@
 
 struct BuiltinFuncDescriptor {
     const char *name;
-    int since_ver;
+    int since_ver;  /* if nonzero, included in every version bundle since this */
     XSUBADDR_t xsub;
     OP *(*checker)(pTHX_ OP *, GV *, SV *);
     IV ckval;
@@ -273,7 +273,9 @@ XS(XS_builtin_import)
             Perl_croak(aTHX_ "Builtin version bundle %s is not supported by this Perl", sympv);
 
         for(int j = 0; builtins[j].name; j++) {
-            if(want_ver >= builtins[i].since_ver)
+            int since_ver = builtins[j].since_ver;
+
+            if(since_ver && want_ver >= since_ver)
                 S_import_sym(aTHX_ newSVpvn_flags(builtins[j].name, strlen(builtins[j].name), SVs_TEMP));
         }
     }

--- a/builtin.c
+++ b/builtin.c
@@ -171,17 +171,17 @@ static const char builtin_not_recognised[] = "'%" SVf "' is not recognised as a 
 
 static const struct BuiltinFuncDescriptor builtins[] = {
     /* constants */
-    { "builtin::true",   &XS_builtin_true,   &ck_builtin_const, BUILTIN_CONST_TRUE  },
-    { "builtin::false",  &XS_builtin_false,  &ck_builtin_const, BUILTIN_CONST_FALSE },
+    { "true",   &XS_builtin_true,   &ck_builtin_const, BUILTIN_CONST_TRUE  },
+    { "false",  &XS_builtin_false,  &ck_builtin_const, BUILTIN_CONST_FALSE },
 
     /* unary functions */
-    { "builtin::isbool",   &XS_builtin_func1_scalar, &ck_builtin_func1, OP_ISBOOL   },
-    { "builtin::weaken",   &XS_builtin_func1_void,   &ck_builtin_func1, OP_WEAKEN   },
-    { "builtin::unweaken", &XS_builtin_func1_void,   &ck_builtin_func1, OP_UNWEAKEN },
-    { "builtin::isweak",   &XS_builtin_func1_scalar, &ck_builtin_func1, OP_ISWEAK   },
-    { "builtin::blessed",  &XS_builtin_func1_scalar, &ck_builtin_func1, OP_BLESSED  },
-    { "builtin::refaddr",  &XS_builtin_func1_scalar, &ck_builtin_func1, OP_REFADDR  },
-    { "builtin::reftype",  &XS_builtin_func1_scalar, &ck_builtin_func1, OP_REFTYPE  },
+    { "isbool",   &XS_builtin_func1_scalar, &ck_builtin_func1, OP_ISBOOL   },
+    { "weaken",   &XS_builtin_func1_void,   &ck_builtin_func1, OP_WEAKEN   },
+    { "unweaken", &XS_builtin_func1_void,   &ck_builtin_func1, OP_UNWEAKEN },
+    { "isweak",   &XS_builtin_func1_scalar, &ck_builtin_func1, OP_ISWEAK   },
+    { "blessed",  &XS_builtin_func1_scalar, &ck_builtin_func1, OP_BLESSED  },
+    { "refaddr",  &XS_builtin_func1_scalar, &ck_builtin_func1, OP_REFADDR  },
+    { "reftype",  &XS_builtin_func1_scalar, &ck_builtin_func1, OP_REFTYPE  },
     { 0 }
 };
 
@@ -240,7 +240,9 @@ Perl_boot_core_builtin(pTHX)
         else if(builtin->checker == &ck_builtin_func1)
             proto = "$";
 
-        CV *cv = newXS_flags(builtin->name, builtin->xsub, __FILE__, proto, 0);
+        SV *fqname = sv_2mortal(Perl_newSVpvf(aTHX_ "builtin::%s", builtin->name));
+
+        CV *cv = newXS_flags(SvPVX(fqname), builtin->xsub, __FILE__, proto, 0);
         XSANY.any_i32 = builtin->ckval;
 
         if(builtin->checker) {

--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -22,6 +22,8 @@ builtin - Perl pragma to import built-in utility functions
         blessed refaddr reftype
     );
 
+    use builtin ':5.35';  # all of the above
+
 =head1 DESCRIPTION
 
 Perl provides several utility functions in the C<builtin> package. These are
@@ -65,6 +67,15 @@ don't accidentally appear as object methods from a class.
 
     # Can't locate object method "true" via package "An::Object::Class"
     #   at ...
+
+=head2 Version Bundles
+
+The entire set of builtin functions defined by a version of perl can be
+imported all at once, by requesting a version bundle. This is done by giving
+the perl release version (without its subversion suffix) after a colon
+character:
+
+    use builtin ':5.36';
 
 =head1 FUNCTIONS
 

--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -83,6 +83,8 @@ character:
 
     $val = true;
 
+I<Available since perl version 5.36.>
+
 Returns the boolean truth value. While any scalar value can be tested for
 truth and most defined, non-empty and non-zero values are considered "true"
 by perl, this one is special in that L</isbool> considers it to be a
@@ -94,6 +96,8 @@ This gives an equivalent value to expressions like C<!!1> or C<!0>.
 
     $val = false;
 
+I<Available since perl version 5.36.>
+
 Returns the boolean fiction value. While any non-true scalar value is
 considered "false" by perl, this one is special in that L</isbool> considers
 it to be a distinguished boolean value.
@@ -103,6 +107,8 @@ This gives an equivalent value to expressions like C<!!0> or C<!1>.
 =head2 isbool
 
     $bool = isbool($val);
+
+I<Available since perl version 5.36.>
 
 Returns true when given a distinguished boolean value, or false if not. A
 distinguished boolean value is the result of any boolean-returning builtin
@@ -114,6 +120,8 @@ or any variable containing one of these results.
 
     weaken($ref);
 
+I<Available since perl version 5.36.>
+
 Weakens a reference. A weakened reference does not contribute to the reference
 count of its referent. If only weakened references to a referent remain, it
 will be disposed of, and all remaining weak references to it will have their
@@ -123,11 +131,15 @@ value set to C<undef>.
 
     unweaken($ref);
 
+I<Available since perl version 5.36.>
+
 Strengthens a reference, undoing the effects of a previous call to L</weaken>.
 
 =head2 isweak
 
     $bool = isweak($ref);
+
+I<Available since perl version 5.36.>
 
 Returns true when given a weakened reference, or false if not a reference or
 not weak.
@@ -136,12 +148,16 @@ not weak.
 
     $str = blessed($ref);
 
+I<Available since perl version 5.36.>
+
 Returns the package name for an object reference, or C<undef> for a
 non-reference or reference that is not an object.
 
 =head2 refaddr
 
     $num = refaddr($ref);
+
+I<Available since perl version 5.36.>
 
 Returns the memory address for a reference, or C<undef> for a non-reference.
 This value is not likely to be very useful for pure Perl code, but is handy as
@@ -150,6 +166,8 @@ a means to test for referential identity or uniqueness.
 =head2 reftype
 
     $str = reftype($ref);
+
+I<Available since perl version 5.36.>
 
 Returns the basic container type of the referent of a reference, or C<undef>
 for a non-reference. This is returned as a string in all-capitals, such as

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -152,6 +152,12 @@ package FetchStoreCounter {
 {
     use builtin ':5.36';
     ok(true, 'true() is available from :5.36 bundle');
+
+    # parse errors
+    foreach my $bundle (qw( :x :5.x :5.36x :5.36.1000 :5.1000 :5.36.1.2 )) {
+        ok(!defined eval "use builtin '$bundle';", $bundle.' is invalid bundle');
+        like($@, qr/^Invalid version bundle \Q$bundle\E at /);
+    }
 }
 
 done_testing();

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -148,4 +148,10 @@ package FetchStoreCounter {
     cmp_ok($val, $_,  !1, "false is equivalent to  !1 by $_") for qw( eq == );
 }
 
+# version bundles
+{
+    use builtin ':5.36';
+    ok(true, 'true() is available from :5.36 bundle');
+}
+
 done_testing();


### PR DESCRIPTION
Supports the same syntax/semantics as `use feature`, in that

* `:major.minor` accepted
* `:major.minor.patch` accepted but patch number is ignored - anything goes

Not (yet) integrated into the main `use VERSION` syntax; but we can consider that in future.