### PR TITLE
Revert "_MSC_VER is now always >= 1800 (Visual C++ 2013 / Visual C++ 12.0)"

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -543,6 +543,11 @@ __typeof__ and nothing else.
 #  endif
 #endif
 
+#if defined(_MSC_VER) && _MSC_VER < 1400
+/* XXX older MSVC versions have a smallish macro buffer */
+#  define PERL_SMALL_MACRO_BUFFER
+#endif
+
 /* on gcc (and clang), specify that a warning should be temporarily
  * ignored; e.g.
  *
@@ -595,7 +600,7 @@ __typeof__ and nothing else.
 #define CLANG_DIAG_IGNORE_STMT(x) CLANG_DIAG_IGNORE(x) NOOP
 #define CLANG_DIAG_RESTORE_STMT CLANG_DIAG_RESTORE NOOP
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (_MSC_VER >= 1300)
 #  define MSVC_DIAG_IGNORE(x) __pragma(warning(push)) \
                               __pragma(warning(disable : x))
 #  define MSVC_DIAG_RESTORE   __pragma(warning(pop))
@@ -1006,7 +1011,7 @@ Example usage:
                                     * on unthreaded builds */
 #  elif   (defined(USE_ITHREADS) || defined(USE_THREAD_SAFE_LOCALE))         \
        && (    defined(HAS_POSIX_2008_LOCALE)                                \
-           || (defined(WIN32) && defined(_MSC_VER)))                         \
+           || (defined(WIN32) && defined(_MSC_VER) && _MSC_VER >= 1400))     \
        && ! defined(NO_THREAD_SAFE_LOCALE)
 #    ifndef USE_THREAD_SAFE_LOCALE
 #      define USE_THREAD_SAFE_LOCALE

--- a/util.c
+++ b/util.c
@@ -5775,6 +5775,12 @@ Perl_my_strlcpy(char *dst, const char *src, Size_t size)
 }
 #endif
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1300) && (_MSC_VER < 1400) && (WINVER < 0x0500)
+/* VC7 or 7.1, building with pre-VC7 runtime libraries. */
+long _ftol( double ); /* Defined by VC6 C libs. */
+long _ftol2( double dblSource ) { return _ftol( dblSource ); }
+#endif
+
 PERL_STATIC_INLINE bool
 S_gv_has_usable_name(pTHX_ GV *gv)
 {

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -92,7 +92,18 @@ END_EXTERN_C
 #  define getlogin g_getlogin
 #endif
 
-#ifdef _MSC_VER
+/* VS2005 (MSC version 14) provides a mechanism to set an invalid
+ * parameter handler.  This functionality is not available in the
+ * 64-bit compiler from the Platform SDK, which unfortunately also
+ * believes itself to be MSC version 14.
+ *
+ * There is no #define related to _set_invalid_parameter_handler(),
+ * but we can check for one of the constants defined for
+ * _set_abort_behavior(), which was introduced into stdlib.h at
+ * the same time.
+ */
+
+#if _MSC_VER >= 1400 && defined(_WRITE_ABORT_MSG)
 #  define SET_INVALID_PARAMETER_HANDLER
 #endif
 

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -260,8 +260,16 @@ typedef long		uid_t;
 typedef long		gid_t;
 typedef unsigned short	mode_t;
 
+#if _MSC_VER < 1800
+#define isnan		_isnan	/* Defined already in VC++ 12.0 */
+#endif
 #define snprintf	_snprintf
 #define vsnprintf	_vsnprintf
+
+/* on VS2003, msvcrt.lib is missing these symbols */
+#if _MSC_VER >= 1300 && _MSC_VER < 1400
+#  pragma intrinsic(_rotl64,_rotr64)
+#endif
 
 MSVC_DIAG_IGNORE(4756 4056)
 PERL_STATIC_INLINE
@@ -612,7 +620,17 @@ void win32_wait_for_children(pTHX);
 #  define _CRTIMP __declspec(dllimport)
 #endif
 
-#ifndef __MINGW32__
+
+/* VS2005 has multiple ioinfo struct definitions through VS2005's release life
+ * VS2008-2012 have been stable but do not assume future VSs will have the
+ * same ioinfo struct, just because past struct stability. If research is done
+ * on the CRTs of future VSs, the version check can be bumped up so the newer
+ * VS uses a fixed ioinfo size. (Actually, only VS2013 (_MSC_VER 1800) hasn't
+ * been looked at; after that we cannot use the ioinfo struct anyway (see the
+ * #if above).)
+ */
+#if ! (_MSC_VER < 1400 || (_MSC_VER >= 1500 && _MSC_VER <= 1700) \
+  || defined(__MINGW32__))
 /* size of ioinfo struct is determined at runtime */
 #  define WIN32_DYN_IOINFO_SIZE
 #endif
@@ -629,6 +647,12 @@ typedef struct {
     CRITICAL_SECTION lock;
 /* this struct definition breaks ABI compatibility with
  * not using, cl.exe's native VS version specitfic CRT. */
+#  if _MSC_VER >= 1400 && _MSC_VER < 1500
+#    error "This ioinfo struct is incomplete for Visual C 2005"
+#  endif
+/* VS2005 CRT has at least 3 different definitions of this struct based on the
+ * CRT DLL's build number. */
+#  if _MSC_VER >= 1500
 #    ifndef _SAFECRT_IMPL
     /* Not used in the safecrt downlevel. We do not define them, so we cannot
      * use them accidentally */
@@ -640,6 +664,7 @@ typedef struct {
     char dbcsBuffer;       /* Buffer for the lead byte of dbcs when converting from dbcs to unicode */
     BOOL dbcsBufferUsed;   /* Bool for the lead byte buffer is used or not */
 #    endif
+#  endif
 } ioinfo;
 #else
 typedef intptr_t ioinfo;


### PR DESCRIPTION
Reverts Perl/perl5#19226

The author said it should not have been merged yet