### PR TITLE
ExtUtils-ParseXS: fix plan/skip in 002-more.t

### DIFF
--- a/dist/ExtUtils-ParseXS/t/002-more.t
+++ b/dist/ExtUtils-ParseXS/t/002-more.t
@@ -47,7 +47,7 @@ SKIP: {
 }
 
 SKIP: {
-  skip "no dynamic loading", 26
+  skip "no dynamic loading", 28
     if !$b->have_compiler || !$Config{usedl};
   my $module = 'XSMore';
   $lib_file = $b->link( objects => $obj_file, module_name => $module );


### PR DESCRIPTION
The commit https://github.com/Perl/perl5/commit/2647863031762b1897841364c638c3727bc043f1 has added 2 tests in 002-more.t, the plan was updated from 30 to 32.
But the corresponding skip counter was missing.