### PR TITLE
z/OS ASCII Enablement: Manage untagged header errno.h by copy & tag

### DIFF
--- a/ext/Errno/Errno_pm.PL
+++ b/ext/Errno/Errno_pm.PL
@@ -2,7 +2,7 @@ use ExtUtils::MakeMaker;
 use Config;
 use strict;
 
-our $VERSION = "1.35";
+our $VERSION = "1.36";
 
 my %err = ();
 
@@ -131,7 +131,11 @@ sub get_files {
 	$file{'Sys$Library:DECC$RTLDEF.TLB'} = 1;
     } elsif ($^O eq 'os390') {
 	# OS/390 C compiler doesn't generate #file or #line directives
-	$file{'/usr/include/errno.h'} = 1;
+        # and it does not tag the header as 1047 (EBCDIC), so make a local
+        # copy and tag it
+        my $cp = `cp /usr/include/errno.h ./errno.h`;
+        my $chtag = `chtag -t -cIBM-1047 ./errno.h`;
+	$file{'./errno.h'} = 1;
     } elsif ($Config{archname} eq 'arm-riscos') {
 	# Watch out for cross compiling for RISC OS
 	my $dep = `echo "#include <errno.h>" | gcc -E -M -`;


### PR DESCRIPTION
   The system headers on z/OS are in EBCDIC, but are untagged. The bi-modal build requires that files be tagged correctly
   so this patch copies the errno.h file (which may be mounted on a read-only file system) to a local file and then tags
   it as IBM-1047 (EBCDIC) so that it can be processed properly. The longer-term fix for this may be to have z/OS tag
   header files as EBCDIC, although this would not be something Perl could rely on for several years.