### PR TITLE
Specify PERL_USE_SAFE_PUTENV when configuring ASCII z/OS builds

### DIFF
--- a/hints/os390.sh
+++ b/hints/os390.sh
@@ -60,6 +60,8 @@ myfirstchar=$(od -A n -N 1 -t x $me | xargs | tr [:lower:] [:upper:] | tr -d 0)
 if [ "${myfirstchar}" = "23" ]; then # 23 is '#' in ASCII
   unset ebcdic
   def_os390_cflags="$def_os390_cflags -qascii"
+  # ensure that 'safe' putenv is used and avoid direct environ manipulation
+  def_os390_defs="$def_os390_defs -DPERL_USE_SAFE_PUTENV";
 else
   ebcdic=true
 fi
@@ -78,7 +80,7 @@ def_os390_cccdlflags="$def_os390_cccdlflags -qexportall"
 #       We do not care about this warning - the bit field is 1 bit and is being specified on something smaller than an int
 def_os390_cflags="$def_os390_cflags -qhaltonmsg=3296:4108 -qsuppress=CCN3159 -qfloat=ieee"
 
-def_os390_defs='-DMAXSIG=39 -DNSIG=39';     # maximum signal number; not furnished by IBM
+def_os390_defs="$def_os390_defs -DMAXSIG=39 -DNSIG=39";     # maximum signal number; not furnished by IBM
 def_os390_defs="$def_os390_defs -DOEMVS";   # is used in place of #ifdef __MVS__
 
 # ensure that the OS/390 yacc generated parser is reentrant.


### PR DESCRIPTION
   The Perl code expects that the ``environ`` global variable can be re-allocated to new storage and then have
   entries added and removed from it. This isn't supported by z/OS when in Bi-Modal mode and so    
    _PERL_USE_SAFE_PUTENV_ macro is defined to use the _env_ services to manipulate ``environ`` 
   instead of doing so directly.  It is not clear
   if it is valid to re-allocate storage for the ``environ`` global variable or not, although
   it is worth pursuing with the z/OS development team as a longer-term potential fix.