### PR TITLE
Provide asciiopen and asciiopen3 for z/OS ASCII I/O

### DIFF
--- a/doio.c
+++ b/doio.c
@@ -218,6 +218,57 @@ Perl_PerlLIO_dup2_cloexec(pTHX_ int oldfd, int newfd)
 #endif
 }
 
+#if defined(OEMVS)
+  #if (__CHARSET_LIB == 1)
+#   include <stdio.h>
+#   include <stdlib.h>
+
+    static int setccsid(int fd, int ccsid) 
+    {
+      attrib_t attr;
+      int rc;
+
+      memset(&attr, 0, sizeof(attr));
+      attr.att_filetagchg = 1;
+      attr.att_filetag.ft_ccsid = ccsid;
+      attr.att_filetag.ft_txtflag = 1;
+
+      rc = __fchattr(fd, &attr, sizeof(attr));
+      return rc;
+    }
+
+    static void updateccsid(int fd, const char* path, int oflag, int perm) 
+    { 
+      int rc;
+      if (oflag & O_CREAT) {
+        rc = setccsid(fd, 819);
+      }
+    }
+
+    int asciiopen(const char* path, int oflag) 
+    {
+      int rc;
+      int fd = open(path, oflag);
+      if (fd == -1) { 
+        return fd;
+      }
+      updateccsid(fd, path, oflag, -1);
+      return fd; 
+    }
+
+    int asciiopen3(const char* path, int oflag, int perm) 
+    {
+      int rc;
+      int fd = open(path, oflag, perm);
+      if (fd == -1) { 
+        return fd;
+      }
+      updateccsid(fd, path, oflag, perm);
+      return fd;
+    } 
+  #endif
+#endif
+
 int
 Perl_PerlLIO_open_cloexec(pTHX_ const char *file, int flag)
 {
@@ -246,8 +297,34 @@ Perl_PerlLIO_open3_cloexec(pTHX_ const char *file, int flag, int perm)
 #endif
 }
 
+#if defined(OEMVS)
+  #if (__CHARSET_LIB == 1)
+    #define TEMP_CCSID 819
+  #endif
+static int Internal_Perl_my_mkstemp_cloexec(char *templte)
+{     
+    PERL_ARGS_ASSERT_MY_MKSTEMP_CLOEXEC;
+#if defined(O_CLOEXEC)
+    DO_ONEOPEN_EXPERIMENTING_CLOEXEC(
+	PL_strategy_mkstemp,
+   	Perl_my_mkostemp(templte, O_CLOEXEC),
+        Perl_my_mkstemp(templte));
+#else
+    DO_ONEOPEN_THEN_CLOEXEC(Perl_my_mkstemp(templte));
+#endif
+}
 int
-Perl_my_mkstemp_cloexec(char *templte)
+Perl_my_mkstemp_cloexec(char *templte) 
+{
+    int tempfd = Internal_Perl_my_mkstemp_cloexec(templte);
+#if defined(TEMP_CCSID)
+    setccsid(tempfd, TEMP_CCSID);
+#endif
+    return tempfd;
+}
+
+#else /* OEMVS */
+Perl_my_mkstemp_cloexec(char *templte) 
 {
     PERL_ARGS_ASSERT_MY_MKSTEMP_CLOEXEC;
 #if defined(O_CLOEXEC)
@@ -259,6 +336,7 @@ Perl_my_mkstemp_cloexec(char *templte)
     DO_ONEOPEN_THEN_CLOEXEC(Perl_my_mkstemp(templte));
 #endif
 }
+#endif
 
 int
 Perl_my_mkostemp_cloexec(char *templte, int flags)

--- a/iperlsys.h
+++ b/iperlsys.h
@@ -49,6 +49,7 @@
 */
 #include "perlio.h"
 
+
 typedef Signal_t (*Sighandler1_t) (int);
 typedef Signal_t (*Sighandler3_t) (int, Siginfo_t*, void*);
 
@@ -776,8 +777,21 @@ struct IPerlLIOInfo
 #  define PerlLIO_lstat(name, buf)	PerlLIO_stat((name), (buf))
 #endif
 #define PerlLIO_mktemp(file)		mktemp((file))
-#define PerlLIO_open(file, flag)	open((file), (flag))
-#define PerlLIO_open3(file, flag, perm)	open((file), (flag), (perm))
+#if defined(OEMVS)
+  #if (__CHARSET_LIB == 1)
+    int asciiopen(const char* path, int oflag);
+    int asciiopen3(const char* path, int oflag, int perm);
+
+    #define PerlLIO_open(file, flag)		asciiopen((file), (flag))
+    #define PerlLIO_open3(file, flag, perm)	asciiopen3((file), (flag), (perm))
+  #else
+    #define PerlLIO_open(file, flag)		open((file), (flag))
+    #define PerlLIO_open3(file, flag, perm)	open((file), (flag), (perm))
+  #endif
+#else
+#  define PerlLIO_open(file, flag)		open((file), (flag))
+#  define PerlLIO_open3(file, flag, perm)	open((file), (flag), (perm))
+#endif
 #define PerlLIO_read(fd, buf, count)	read((fd), (buf), (count))
 #define PerlLIO_rename(old, new)	rename((old), (new))
 #define PerlLIO_setmode(fd, mode)	setmode((fd), (mode))


### PR DESCRIPTION
 Rewrite of the readme file to bring it up to date and to document the various ways
 Perl can now be built and used on z/OS.