### PR TITLE
nostdio should test for z/OS (i.e. OEMVS) not EBCDIC

### DIFF
--- a/nostdio.h
+++ b/nostdio.h
@@ -25,7 +25,7 @@ struct _FILE;
 #define FILE struct _FILE
 #endif
 
-#ifndef EBCDIC
+#if !defined(OEMVS)
 
 #define _CANNOT "CANNOT"
 


### PR DESCRIPTION
@khwilliamson please review