### PR TITLE
Enable z/OS to run with '-e' option for runtests

### DIFF
--- a/runtests.SH
+++ b/runtests.SH
@@ -40,8 +40,9 @@ export PATH || (echo "OOPS, this isn't sh.  Desperation time.  I will feed mysel
 # descendents of this script run cpan/ExtUtils-Constant/t/Constant.t
 # which itelf invokes make, the warnings ensue.
 
-unset MAKEFLAGS
-
+if [ "x$MAKEFLAGS" != "x" ]; then
+    unset MAKEFLAGS
+fi
 
 case $# in
     0)


### PR DESCRIPTION
 Change this code so that the unset of MAKEFLAGS is protected because, on z/OS,
 unset will return non-zero if the variable is not set and this then causes the
 shell to fail because it is being run with _-e_. This change is only required
 for z/OS but is harmless to have on all platforms.