### PR TITLE
Fix problem in makefile for z/OS 64-bit builds

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -915,7 +915,7 @@ Michiel Beijen                 <mb@x14.nl>
 Mik Firestone                  <fireston@lexmark.com>
 Mike Doherty                   <mike@mikedoherty.ca>
 Mike Fletcher                  <fletch@phydeaux.org>
-Mike Fulton                    <mikefultonpersonal@gmail.com>
+Mike Fulton                    <61100689+mikefultondev@users.noreply.github.com>
 Mike Giroux                    <rmgiroux@acm.org>
 Mike Guy                       <mjtg@cam.ac.uk>
 Mike Heins                     <mike@bill.iac.net>

--- a/Makefile.SH
+++ b/Makefile.SH
@@ -118,11 +118,11 @@ true)
 		linklibperl="-L `pwd | sed 's/\/UU$//'` -Wl,+s -Wl,+b$archlibexp/CORE -lperl"
 		;;
 	os390*)
-            case "$use64bitall" in
-            '')    shrpldflags='-Wl,XPLINK,dll'
-	           linklibperl='libperl.x'
-	           ;;
-            *)    shrpldflags='-Wl,LP64,dll'
+            case "$use64bitall" in 
+            define|true|[yY]*) shrpldflags='-Wl,LP64,dll'
+                   linklibperl='libperl.x'
+                   ;;
+            *)     shrpldflags='-Wl,XPLINK,dll'
 	           linklibperl='libperl.x'
 	           ;;
             esac

--- a/Porting/checkAUTHORS.pl
+++ b/Porting/checkAUTHORS.pl
@@ -1035,6 +1035,7 @@ mgjv\100comdyn.com.au                   mgjv\100tradingpost.com.au
 mlh\100swl.msd.ray.com                  webtools\100uewrhp03.msd.ray.com
 michael.schroeder\100informatik.uni-erlangen.de mls\100suse.de
 mike\100stok.co.uk                      mike\100exegenix.com
+61100689+mikefultondev\100users.noreply.github.com mikefultonpersonal\100gmail.com
 miyagawa\100bulknews.net                    miyagawa\100edge.co.jp
 mjtg\100cam.ac.uk                       mjtg\100cus.cam.ac.uk
 mikedlr\100tardis.ed.ac.uk              mikedlr\100it.com.pl


### PR DESCRIPTION
  This change fixes a bug where the value of _use64bitall_ was
  expected to be nothing or something, but in fact, the proper
  test is for ``define|true|[yY]*``.