### PR TITLE
For C++ extensions, use the pthreads definition of PERL_GET_CONTEXT

### DIFF
--- a/thread.h
+++ b/thread.h
@@ -372,8 +372,16 @@
 #    define PTHREAD_GETSPECIFIC(key) pthread_getspecific(key)
 #endif
 
-#if defined(PERL_THREAD_LOCAL) && !defined(PERL_GET_CONTEXT) && !defined(PERL_SET_CONTEXT)
-/* Use C11 thread-local storage, where possible: */
+#if defined(PERL_THREAD_LOCAL) && !defined(PERL_GET_CONTEXT) && !defined(PERL_SET_CONTEXT) && !defined(__cplusplus)
+/* Use C11 thread-local storage, where possible.
+ * Frustratingly we can't use it for C++ extensions, C++ and C disagree on the
+ * syntax used for thread local storage, meaning that the working token that
+ * Configure probed for C turns out to be a compiler error on C++. Great.
+ * (Well, unless one or both is supporting non-standard syntax as an extension)
+ * As Configure doesn't have a way to probe for C++ dialects, we just take the
+ * safe option and do the same as 5.34.0 and earlier - use pthreads on C++.
+ * Of course, if C++ XS extensions really want to avoid *all* this overhead,
+ * they should #define PERL_NO_GET_CONTEXT and pass aTHX/aTHX_ explicitly) */
 #  define PERL_USE_THREAD_LOCAL
 extern PERL_THREAD_LOCAL void *PL_current_context;
 

--- a/util.c
+++ b/util.c
@@ -3762,13 +3762,18 @@ Perl_get_context(void)
 void
 Perl_set_context(void *t)
 {
-#if defined(USE_ITHREADS)
-#endif
     PERL_ARGS_ASSERT_SET_CONTEXT;
 #if defined(USE_ITHREADS)
+#  ifdef PERL_USE_THREAD_LOCAL
+    PL_current_context = t;
+#  endif
 #  ifdef I_MACH_CTHREADS
     cthread_set_data(cthread_self(), t);
 #  else
+    /* We set thread-specific value always, as C++ code has to read it with
+     * pthreads, beacuse the declaration syntax for thread local storage for C11
+     * is incompatible with C++, meaning that we can't expose the thread local
+     * variable to C++ code. */
     {
         const int error = pthread_setspecific(PL_thr_key, t);
         if (error)


### PR DESCRIPTION
Configure probes the C compiler to find out whether it supports C11 thread local storage, and if found uses this for PERL_SET_CONTEXT/PERL_GET_CONTEXT, in preference to the pthread_setspecific()/pthread_getspecific() approach.

However, we can come unstuck with XS extensions written in C++, as C++ and C disagree on the syntax used for thread local storage, meaning that the working token that Configure probed for C turns out to be a compiler error on C++.

As Configure doesn't have a way to probe for C++ dialects, we just take the safe option and do the same as 5.34.0 and earlier - use pthreads on C++.

This commit is minimal because the implementation of PERL_SET_CONTEXT for C11 thread local storage was already defensively written to *also* call pthread_setspecific().

Fixes #19310