### PR TITLE
backport #31 from https://github.com/perl-libwin32/win32

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1303,6 +1303,10 @@ use File::Glob qw(:case);
     'Win32' => {
         'DISTRIBUTION' => "JDB/Win32-0.57.tar.gz",
         'FILES'        => q[cpan/Win32],
+        'CUSTOMIZED'   => [
+            # backport #31, this can be removed if a new Win32 is merged
+            "t/Unicode.t"
+            ],
     },
 
     'Win32API::File' => {

--- a/cpan/Win32/t/Unicode.t
+++ b/cpan/Win32/t/Unicode.t
@@ -90,7 +90,8 @@ if ($^O eq "cygwin") {
     $subdir = Cygwin::posix_to_win_path($subdir, 1);
 }
 $subdir =~ s,/,\\,g;
-ok(Win32::GetLongPathName($subdir), $long);
+# Cygwin64 no longer returns an ANSI name
+skip($^O eq "cygwin", Win32::GetLongPathName($subdir), $long);
 
 # We can chdir() into the Unicode directory if we use the ANSI name
 ok(chdir(Win32::GetANSIPathName($dir)));

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -21,5 +21,6 @@ Net::Ping dist/Net-Ping/t/500_ping_icmp.t 3eeb60181c01b85f876bd6658644548fdf2e24
 Net::Ping dist/Net-Ping/t/501_ping_icmpv6.t cd719bca662b054b676dd2ee6e0c73c7a5e50cf9
 Pod::Perldoc cpan/Pod-Perldoc/lib/Pod/Perldoc.pm 582be34c077c9ff44d99914724a0cc2140bcd48c
 Test::Harness cpan/Test-Harness/t/source.t aaa3939591114c0c52ecd44159218336d1f762b9
+Win32 cpan/Win32/t/Unicode.t 1cd9c990b7751f9f4f3da1a8ead80acaf33253a9
 Win32API::File cpan/Win32API-File/File.pm 8fd212857f821cb26648878b96e57f13bf21b99e
 Win32API::File cpan/Win32API-File/File.xs beb870fed4490d2faa547b4a8576b8d64d1d27c5


### PR DESCRIPTION
fixes #19239

Ideally a new release of Win32 will be released, but it's hard to tell
when that will happen, since it may be waiting on #30.

So fix this in core for now to clean up CI results.