### PR TITLE
magic.t: fix test on systems with busybox ps

### DIFF
--- a/t/op/magic.t
+++ b/t/op/magic.t
@@ -822,7 +822,7 @@ SKIP: {
             $0 = $arg if defined $arg;
             # In FreeBSD the ps -o command= will cause
             # an empty header line, grab only the last line.
-            my $ps = (`ps -o command= -p $$`)[-1];
+            my $ps = (`ps -o command= -p $$ 2>&1`)[-1];
             return if $?;
             chomp $ps;
             $ps;


### PR DESCRIPTION
I found that this test is failing on Alpine Linux, a rather popular
linux for creating Docker containers out of.

Alpine Linux uses busybox and the `ps` command it provides does not
handle the `-p` option used by this test, or any option, really.

But also yocto (used for building embedded linuxes) uses busybox

Alpine currently has a patch for this test in their perl package:
https://git.alpinelinux.org/aports/tree/main/perl/skip-test-due-to-busybox-ps.patch

The fix in this commit is as proposed by @bingos in
https://github.com/Perl/perl5/issues/17542#issuecomment-583586365

I tested it on alpine, debian and macOS

Closes https://github.com/Perl/perl5/issues/17542