### PR TITLE
POSIX.pod: fix in the description of "isnan"

### DIFF
--- a/ext/POSIX/lib/POSIX.pod
+++ b/ext/POSIX/lib/POSIX.pod
@@ -830,7 +830,7 @@ L<equality operators|perlop/"Equality Operators"> (C<==> or C<!=>), as in
 
     print "x is not a NaN\n" if $x == $x;
 
-since the C<NaN> is not equivalent to anything, B<including itself>.
+since the C<NaN> is not equal to anything, B<including itself>.
 
 See also L</nan>, L</NaN>, L</isinf>, and L</fpclassify>.
 

--- a/ext/POSIX/lib/POSIX.pod
+++ b/ext/POSIX/lib/POSIX.pod
@@ -825,9 +825,10 @@ to use instead.  See L<perlrecharclass/POSIX Character Classes>.
 Returns true if the argument is C<NaN> (not-a-number) [C99].  Added in
 Perl v5.22.
 
-Note that you can test for "C<NaN>-ness" with
+Note that you can also test for "C<NaN>-ness" with
+L<equality operators|perlop/"Equality Operators"> (C<==> or C<!=>), as in
 
-   $x == $x
+    print "x is not a NaN\n" if $x == $x;
 
 since the C<NaN> is not equivalent to anything, B<including itself>.
 

--- a/ext/POSIX/lib/POSIX.pod
+++ b/ext/POSIX/lib/POSIX.pod
@@ -825,7 +825,7 @@ to use instead.  See L<perlrecharclass/POSIX Character Classes>.
 Returns true if the argument is C<NaN> (not-a-number) [C99].  Added in
 Perl v5.22.
 
-Note that you cannot test for "C<NaN>-ness" with
+Note that you can test for "C<NaN>-ness" with
 
    $x == $x
 


### PR DESCRIPTION
"Note" on the description of "isnan" in POSIX.pod used to say
> Note that you cannot test for "`NaN`-ness" with
> ```
>                  $x == $x
> ```
but actually we _can_ test for `NaN`-ness with equality operators.
("Equality Operators" section in `perlop` already mentions this.)

I also added a small example for this.
I hope this addition will improve clarity.