### PR TITLE
Stop setting console to "con" on non-MSWin systems

### DIFF
--- a/lib/perl5db.pl
+++ b/lib/perl5db.pl
@@ -532,7 +532,7 @@ BEGIN {
 use vars qw($VERSION $header);
 
 # bump to X.XX in blead, only use X.XX_XX in maint
-$VERSION = '1.68';
+$VERSION = '1.69';
 
 $header = "perl5db.pl version $VERSION";
 
@@ -1538,11 +1538,11 @@ We then determine what the console should be on various systems:
         undef $console;
     }
 
-=item * Windows or MSDOS - use C<con>.
+=item * Windows - use C<con>.
 
 =cut
 
-    elsif ( -e "con" or $^O eq 'MSWin32' ) {
+    elsif ( $^O eq 'MSWin32' and -e "con" ) {
         $console = "con";
     }
 


### PR DESCRIPTION
The condition has existed since eternity but it never made sense.
Only use "con" if $^O eq 'MSWin32'.

Also, remove MSDOS from the comment: it's the last forgotten mention
of the OS in the whole file.