### PR TITLE
t/porting/authors.t: Windows fixes

### DIFF
--- a/t/porting/authors.t
+++ b/t/porting/authors.t
@@ -9,6 +9,7 @@ BEGIN {
 
 use TestInit qw(T);    # T is chdir to the top level
 use strict;
+use File::Spec;
 
 find_git_or_skip('all');
 skip_all(
@@ -29,12 +30,13 @@ elsif( $ENV{GITHUB_ACTIONS} && length $ENV{GITHUB_BASE_REF} ) {
     # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables
 
     # we should be on a merge commit, but double check
-    my $branch_head = `git rev-parse "HEAD^2" 2>/dev/null`;
+    my $null = File::Spec->devnull;
+    my $branch_head = `git rev-parse "HEAD^2" 2>$null`;
     chomp $branch_head;
 
     # gives the history of the branch being merged, excluding what it is
     # merged into
-    $revision_range = 'HEAD^1..HEAD^2'
+    $revision_range = '"HEAD^1..HEAD^2"'
         if $branch_head;
 }
 


### PR DESCRIPTION
^ is a shell metacharacter in cmd.exe, so it needs to be quoted.

Also, /dev/null doesn't exist on Windows.