### PR TITLE
Adjust Win32/t/Unicode.t for Cygwin

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1303,6 +1303,9 @@ use File::Glob qw(:case);
     'Win32' => {
         'DISTRIBUTION' => "JDB/Win32-0.58.tar.gz",
         'FILES'        => q[cpan/Win32],
+        'CUSTOMIZED'   => [
+            't/Unicode.t', # https://github.com/perl-libwin32/win32/pull/33/files
+        ]
     },
 
     'Win32API::File' => {

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -21,5 +21,6 @@ Net::Ping dist/Net-Ping/t/500_ping_icmp.t 3eeb60181c01b85f876bd6658644548fdf2e24
 Net::Ping dist/Net-Ping/t/501_ping_icmpv6.t cd719bca662b054b676dd2ee6e0c73c7a5e50cf9
 Pod::Perldoc cpan/Pod-Perldoc/lib/Pod/Perldoc.pm 582be34c077c9ff44d99914724a0cc2140bcd48c
 Test::Harness cpan/Test-Harness/t/source.t aaa3939591114c0c52ecd44159218336d1f762b9
+Win32 cpan/Win32/t/Unicode.t f3898f12f102d0ff2738b039fb08aeeacf92e05a
 Win32API::File cpan/Win32API-File/File.pm 8fd212857f821cb26648878b96e57f13bf21b99e
 Win32API::File cpan/Win32API-File/File.xs beb870fed4490d2faa547b4a8576b8d64d1d27c5


### PR DESCRIPTION
Attempt to fix the Cygwin issue

We need to postpone the function call 

Error reported upstream:
https://github.com/perl-libwin32/win32/pull/33/files