### PR TITLE
Update ReadLine.pm to deal with existence of "con" file or dir in current dir

### DIFF
--- a/dist/Term-ReadLine/lib/Term/ReadLine.pm
+++ b/dist/Term-ReadLine/lib/Term/ReadLine.pm
@@ -242,7 +242,7 @@ sub findConsole {
 
     if ($^O ne 'MSWin32' and -e $devtty) {
 	$console = $devtty;
-    } elsif ($^O eq 'MSWin32' or $^O eq 'msys' or -e "con") {
+    } elsif ( ($^O eq 'MSWin32' or $^O eq 'msys') and -e "con") {
        $console = 'CONIN$';
        $consoleOUT = 'CONOUT$';
     } elsif ($^O eq 'VMS') {

--- a/dist/Term-ReadLine/lib/Term/ReadLine.pm
+++ b/dist/Term-ReadLine/lib/Term/ReadLine.pm
@@ -326,7 +326,7 @@ sub Features { \%features }
 
 package Term::ReadLine;		# So late to allow the above code be defined?
 
-our $VERSION = '1.17';
+our $VERSION = '1.18';
 
 my ($which) = exists $ENV{PERL_RL} ? split /\s+/, $ENV{PERL_RL} : undef;
 if ($which) {


### PR DESCRIPTION
The original line:
elsif ($^O eq 'MSWin32' or $^O eq 'msys' or -e "con") {

can succeed if a file or dir named "con" exists in current dir and OS is other than MSWin32 or msys.
The way the conditional cases are structured, leaves a tiny window for succeeding when OS is VMS or os2, AFAICS.

I am not aware of what "msys" is, so my proposed change may not be entirely correct.