### PR TITLE
toke.c: Fix potential C sign error

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -11473,9 +11473,9 @@ Perl_scan_str(pTHX_ char *start, int keep_bracketed_quoted, int keep_delims, int
                         *to++ = *s++;
                 }
                 /* allow nested opens and closes */
-                else if ((UV)*s == PL_multi_close && --brackets <= 0)
+                else if (*(U8 *) s == PL_multi_close && --brackets <= 0)
                     break;
-                else if ((UV)*s == PL_multi_open)
+                else if (*(U8 *) s == PL_multi_open)
                     brackets++;
                 else if (!d_is_utf8 && !UTF8_IS_INVARIANT((U8)*s) && UTF)
                     d_is_utf8 = TRUE;


### PR DESCRIPTION
Taking (UV)(* char) isn't what was meant.  Instead it should be
       (UV) * (U8 *)(char).
(and the UV cast becomes irrelevant in this case).

If the C compiler defaults char to unsigned, it doesn't matter.  Nor
does it matter if the char value is positive.  But it gives the wrong
result when 'char' means 'signed char' and the value is negative.

Experimentally adding non-ASCII brackets to this code showed up this
error.