### PR TITLE
Detect short name clashes in 'use charnames'

### DIFF
--- a/lib/_charnames.pm
+++ b/lib/_charnames.pm
@@ -6,7 +6,7 @@
 package _charnames;
 use strict;
 use warnings;
-our $VERSION = '1.49';
+our $VERSION = '1.50';
 use unicore::Name;    # mktables-generated algorithmically-defined names
 
 use bytes ();          # for $bytes::hint_bits

--- a/lib/charnames.pm
+++ b/lib/charnames.pm
@@ -1,7 +1,7 @@
 package charnames;
 use strict;
 use warnings;
-our $VERSION = '1.49';
+our $VERSION = '1.50';
 use unicore::Name;    # mktables-generated algorithmically-defined names
 use _charnames ();    # The submodule for this where most of the work gets done
 

--- a/lib/charnames.t
+++ b/lib/charnames.t
@@ -217,9 +217,21 @@ sub test_vianame ($$$) {
     like(
       $caught_error,
       qr/charnames: some short character names may clash in \[ARABIC, HEBREW\], for example ALEF/,
-      "warned about potential character name clashes"
+      "warned about potential character name clashes when asking for 'hebrew' and 'arabic'"
     );
-    ok("\N{bet}"   eq "\N{HEBREW LETTER BET}",   'despite that, \N{bet} gives HEBREW LETTER BET');
+    ok("\N{alef}"  eq "\N{HEBREW LETTER ALEF}",  '\N{alef} gives HEBREW LETTER ALEF because we asked for Hebrew first');
+    ok("\N{bet}"   eq "\N{HEBREW LETTER BET}",   '\N{bet} gives HEBREW LETTER BET');
+    ok("\N{sheen}" eq "\N{ARABIC LETTER SHEEN}", 'and \N{sheen} gives ARABIC LETTER SHEEN');
+  };
+  eval q{
+    use charnames qw(arabic hebrew :full);
+    like(
+      $caught_error,
+      qr/charnames: some short character names may clash in \[ARABIC, HEBREW\], for example ALEF/,
+      "warned about potential character name clashes when asking for 'arabic' and 'hebrew'"
+    );
+    ok("\N{alef}"  eq "\N{ARABIC LETTER ALEF}",  '\N{alef} gives ARABIC LETTER ALEF because we asked for Arabic first');
+    ok("\N{bet}"   eq "\N{HEBREW LETTER BET}",   '\N{bet} gives HEBREW LETTER BET');
     ok("\N{sheen}" eq "\N{ARABIC LETTER SHEEN}", 'and \N{sheen} gives ARABIC LETTER SHEEN');
   };
 }

--- a/lib/charnames.t
+++ b/lib/charnames.t
@@ -201,6 +201,30 @@ sub test_vianame ($$$) {
 }
 
 {
+  my $caught_error;
+  local $SIG{__WARN__} = sub { $caught_error = shift; };
+  eval q{
+    use charnames qw(runic greek);
+    is($caught_error, undef, "no letter name clashes between runic and greek");
+  };
+}
+
+{
+  my $caught_error;
+  local $SIG{__WARN__} = sub { $caught_error = shift; };
+  eval q{
+    use charnames qw(hebrew arabic :full);
+    like(
+      $caught_error,
+      qr/charnames: some short character names may clash in \[ARABIC, HEBREW\], for example ALEF/,
+      "warned about potential character name clashes"
+    );
+    ok("\N{bet}"   eq "\N{HEBREW LETTER BET}",   'despite that, \N{bet} gives HEBREW LETTER BET');
+    ok("\N{sheen}" eq "\N{ARABIC LETTER SHEEN}", 'and \N{sheen} gives ARABIC LETTER SHEEN');
+  };
+}
+
+{
     use charnames ':full';
     is("\x{263a}", "\N{WHITE SMILING FACE}", 'Verify "\x{263a}" eq "\N{WHITE SMILING FACE}"');
     cmp_ok(length("\x{263a}"), '==', 1, 'Verify length of \x{263a} is 1');


### PR DESCRIPTION
When the user asks for short names for multiple scripts there is a potential for name clashes and confusion. For example, both Arabic and Hebrew have a letter called "alef" - in shouty Unicode terms they are HEBREW LETTER ALEF and ARABIC LETTER ALEF. So what happens when the user asks for short names for both scripts?

```perl
use charnames qw(arabic hebrew);

say "\N{alef}";    # Argh, confusing
```

In this particular example you always get the Hebrew alef, because that has a lower codepoint - 0x5d0 vs Arabic alef's 0x627.

This patch makes charnames.pm emit a warning (at use-time) when this happens.

Questions:

1. Is this an appropriate thing to do? It may be a bit noisier than you expect, as there are some surprising clashes - did you know that there's a LATIN (SMALL|CAPITAL) LETTER GAMMA? I didn't either.
2. To do this we need to load the character database in `import`. Is this acceptable? I assume so, as you're obviously calling `import` so you can use the feature, so you're going to get the memory consumption at some point.
3. The algorithm for finding duplicates in this first draft is naive and inefficient, but it's also _clear_, and in normal circumstances won't be called that often;
4. The text of the warning definitely needs work. It currently warns about all the scripts asked for, even those that _don't_ have clashes, and while it lists one clashing name, it might be useful to list all clashes if there are more of 'em.
5. Even though the issue is about character _naming_ and not character _encoding_, should it only warn if the 'utf8' warnings category is enabled like much of the rest of charnames.pm does?