### PR TITLE
subroutine redefinitions made with local() shouldn't warn

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -218,7 +218,9 @@ XXX Changes (i.e. rewording) of diagnostic messages go here
 
 =item *
 
-XXX Describe change here
+L<Subroutine %s redefined|perldiag/"Subroutine %s redefined">
+
+Localized subroutine redefinitions no longer trigger this warning.
 
 =back
 

--- a/sv.c
+++ b/sv.c
@@ -4187,7 +4187,7 @@ Perl_gv_setref(pTHX_ SV *const dsv, SV *const ssv)
                     (CvROOT(cv) || CvXSUB(cv)) &&
                     /* redundant check that avoids creating the extra SV
                        most of the time: */
-                    (CvCONST(cv) || ckWARN(WARN_REDEFINE)))
+                    (CvCONST(cv) || (ckWARN(WARN_REDEFINE) && !intro)))
                     {
                         SV * const new_const_sv =
                             CvCONST((const CV *)sref)

--- a/t/lib/warnings/sv
+++ b/t/lib/warnings/sv
@@ -437,3 +437,18 @@ undef *Foo::;
 *Foo::f =sub {};
 EXPECT
 Subroutine f redefined at - line 5.
+########
+# sv.c
+use warnings 'redefine';
+sub fred { 1 }
+sub barney() { 2 }
+sub wilma() { 3 }
+# local redefines of subs shouldn't warn...
+local *fred = sub {};
+local(*fred) = sub {};
+# ...unless they're constant
+local *barney = \&fred;
+local(*wilma) = \&fred;
+EXPECT
+Constant subroutine main::barney redefined at - line 10.
+Constant subroutine main::wilma redefined at - line 11.


### PR DESCRIPTION
The following code will no longer warn:

```
  use warnings 'redefine';
  sub foo {}
  local *foo = sub{};
```

The main purpose of local() is to temporarily redefine stuff, so it
doesn't make sense to warn about it.