### PR TITLE
Use sha256 instead of sha1 in release announcement

### DIFF
--- a/Porting/release_announcement_template.txt
+++ b/Porting/release_announcement_template.txt
@@ -10,10 +10,10 @@ favorite CPAN mirror or find it at:
 
 https://metacpan.org/release/[AUTHOR]/perl-5.[VERSION.SUBVERSION]/
 
-SHA1 digests for this release are:
+SHA256 digests for this release are:
 
- [TAR.GZ SHA1]   perl-5.[VERSION.SUBVERSION].tar.gz
- [TAR.XZ SHA1]   perl-5.[VERSION.SUBVERSION].tar.xz
+ [TAR.GZ SHA256]   perl-5.[VERSION.SUBVERSION].tar.gz
+ [TAR.XZ SHA256]   perl-5.[VERSION.SUBVERSION].tar.xz
 
 You can find a full list of changes in the file "perldelta.pod" located in
 the "pod" directory inside the release and on the web at

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -1218,7 +1218,7 @@ Be sure to commit your change:
 =head3 announce to p5p
 
 Mail perl5-porters@perl.org to announce your new release, with a quote you prepared earlier.
-Get the SHA1 digests from the PAUSE email responses.
+Get the SHA256 digests from the PAUSE email responses.
 
 Use the template at Porting/release_announcement_template.txt
 


### PR DESCRIPTION
The last time perl got released, there was this comment:

https://www.nntp.perl.org/group/perl.perl5.porters/2022/01/msg262480.html

> Why use the old ( and somewhat broken ) SHA1 for message digests?

I decided to look into using SHA256;
I notice that the release managers guide gets the SHA1s from the PAUSE
email. So I've made a PR from PAUSE so that they no longer send SHA1s
(or MD5SUMS for that matter) but just SHA256. That change is live
already, see https://github.com/andk/pause/pull/379

So now the next step is to update the perl release documentation to deal
with the new reality that PAUSE mails no longer incluse sha1s!