### PR TITLE
Deprecate downgrading use VERSION below v5.11

### DIFF
--- a/embedvar.h
+++ b/embedvar.h
@@ -233,6 +233,7 @@
 #define PL_phase		(vTHX->Iphase)
 #define PL_pidstatus		(vTHX->Ipidstatus)
 #define PL_preambleav		(vTHX->Ipreambleav)
+#define PL_prevailing_version	(vTHX->Iprevailing_version)
 #define PL_profiledata		(vTHX->Iprofiledata)
 #define PL_psig_name		(vTHX->Ipsig_name)
 #define PL_psig_pend		(vTHX->Ipsig_pend)

--- a/handy.h
+++ b/handy.h
@@ -2858,10 +2858,10 @@ last-inclusive range.
                                             "Use of " s " is deprecated")
 #  define deprecate_disappears_in(when,message) \
               Perl_ck_warner_d(aTHX_ packWARN(WARN_DEPRECATED),    \
-                               message ", and will disappear in Perl " when)
+                               message " is deprecated, and will disappear in Perl " when)
 #  define deprecate_fatal_in(when,message) \
               Perl_ck_warner_d(aTHX_ packWARN(WARN_DEPRECATED),    \
-                               message ". Its use will be fatal in Perl " when)
+                               message " is deprecated, and will become fatal in Perl " when)
 #endif
 
 /* Internal macros to deal with gids and uids */

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -1029,6 +1029,12 @@ PERLVAR(I, wcrtomb_ps, mbstate_t)
 PERLVARA(I, mem_log, 1 + 1 + TYPE_DIGITS(UV) + 1 + 3 + 1, char)
 #endif
 
+/* The most recently seen `use VERSION` declaration, encoded in a single
+ * U16 as (major << 8) | minor. We do this rather than store an entire SV
+ * version object so we can fit the U16 into the uv of a SAVEHINTS and not
+ * have to worry about SV refcounts during scope enter/exit. */
+PERLVAR(I, prevailing_version, U16)
+
 /* If you are adding a U8 or U16, check to see if there are 'Space' comments
  * above on where there are gaps which currently will be structure padding.  */
 

--- a/op.c
+++ b/op.c
@@ -8960,8 +8960,7 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
         U16 shortver = S_extract_shortver(aTHX_ use_version);
 
         /* If a version >= 5.11.0 is requested, strictures are on by default! */
-        if (vcmp(use_version,
-                 sv_2mortal(upg_version(newSVnv(5.011000), FALSE))) >= 0) {
+        if (shortver >= SHORTVER(5, 11)) {
             if (!(PL_hints & HINT_EXPLICIT_STRICT_REFS))
                 PL_hints |= HINT_STRICT_REFS;
             if (!(PL_hints & HINT_EXPLICIT_STRICT_SUBS))
@@ -8969,7 +8968,7 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
             if (!(PL_hints & HINT_EXPLICIT_STRICT_VARS))
                 PL_hints |= HINT_STRICT_VARS;
 
-            if (vcmp(use_version, sv_2mortal(upg_version(newSVpvs("5.035000"), FALSE))) >= 0)
+            if (shortver >= SHORTVER(5, 35))
                 free_and_set_cop_warnings(&PL_compiling, pWARN_ALL);
         }
         /* otherwise they are off */

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -77,6 +77,39 @@ XXX For a release on a stable branch, this section aspires to be:
 
 XXX Any deprecated features, syntax, modules etc. should be listed here.
 
+=head2 Downgrading a C<use VERSION> statement to below v5.11
+
+Attempting to issue a second C<use VERSION> statement that requests a version
+lower than C<v5.11> when an earlier statement that requested a version at
+least C<v5.11> has already been seen, will now print a deprecation warning.
+
+For example:
+
+    use v5.14;
+    say "The say statement is permitted";
+    use v5.8;                               # This will print a warning
+    print "We must use print\n";
+
+This is because of an intended related change to the interaction between
+C<use VERSION> and C<use strict>. If you specify a version >= 5.11, strict is
+enabled implicitly. If you request a version < 5.11, strict will become
+disabled I<even if you had previously written> C<use strict>. This was not
+the previous behaviour of C<use VERSION>, which at present will track
+explicitly-enabled strictness flags independently.
+
+Code which wishes to mix versions in this manner should use lexical scoping
+with block syntax to ensure that the differently versioned regions remain
+lexically isolated.
+
+    {
+        use v5.14;
+        say "The say statement is permitted";
+    }
+    {
+        use v5.8;                           # No warning is emitted
+        print "We must use print\n";
+    }
+
 =head2 Module removals
 
 XXX Remove this section if not applicable.

--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -14,6 +14,29 @@ features are available.
 The deprecated features will be grouped by the version of Perl in
 which they will be removed.
 
+=head2 Perl 5.40
+
+=head3 Downgrading a C<use VERSION> to below v5.11
+
+Once Perl has seen a C<use VERSION> declaration that requests a version
+C<v5.11> or above, a subsequent second declaration that requests an earlier
+version will print a deprecation warning. For example,
+
+    use v5.14;
+    say "We can use v5.14's features here";
+
+    use v5.10;        # This prints a warning
+
+This behaviour will be removed in Perl 5.40; such a subsequent request will
+become a compile-time error.
+
+This is because of an intended related change to the interaction between
+C<use VERSION> and C<use strict>. If you specify a version >= 5.11, strict is
+enabled implicitly. If you request a version < 5.11, strict will become
+disabled I<even if you had previously written> C<use strict>. This was not
+the previous behaviour of C<use VERSION>, which at present will track
+explicitly-enabled strictness flags independently.
+
 =head2 Perl 5.38
 
 =head3 Pod::Html utility functions

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2083,6 +2083,15 @@ somehow called on another platform.  This should not happen.
 
 (P) The internal handling of magical variables has been cursed.
 
+=item Downgrading a use VERSION declaration to below v5.11 is deprecated
+
+(S deprecated) This warning is emitted on a C<use VERSION> statement that
+requests a version below v5.11 (when the effects of C<use strict> would be
+disabled), after a previous declaration of one having a larger number (which
+would have enabled these effects). Because of a change to the way that
+C<use VERSION> interacts with the strictness flags, this is no longer
+supported.
+
 =item (Do you need to predeclare %s?)
 
 (S syntax) This is an educated guess made in conjunction with the message

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -3539,6 +3539,7 @@ S_doeval_compile(pTHX_ U8 gimme, CV* outside, U32 seq, HV *hh)
     SAVEHINTS();
     if (clear_hints) {
         PL_hints = HINTS_DEFAULT;
+        PL_prevailing_version = 0;
         hv_clear(GvHV(PL_hintgv));
         CLEARFEATUREBITS();
     }

--- a/scope.c
+++ b/scope.c
@@ -699,14 +699,14 @@ Perl_save_hints(pTHX)
             SS_ADD_INT(PL_hints);
             SS_ADD_PTR(save_cophh);
             SS_ADD_PTR(oldhh);
-            SS_ADD_UV(SAVEt_HINTS_HH);
+            SS_ADD_UV(SAVEt_HINTS_HH | (PL_prevailing_version << 8));
             SS_ADD_END(4);
         }
         GvHV(PL_hintgv) = NULL; /* in case copying dies */
         GvHV(PL_hintgv) = hv_copy_hints_hv(oldhh);
         SAVEFEATUREBITS();
     } else {
-        save_pushi32ptr(PL_hints, save_cophh, SAVEt_HINTS);
+        save_pushi32ptr(PL_hints, save_cophh, SAVEt_HINTS | (PL_prevailing_version << 8));
     }
 }
 
@@ -1380,6 +1380,7 @@ Perl_leave_scope(pTHX_ I32 base)
             cophh_free(CopHINTHASH_get(&PL_compiling));
             CopHINTHASH_set(&PL_compiling, (COPHH*)a1.any_ptr);
             *(I32*)&PL_hints = a0.any_i32;
+            PL_prevailing_version = (U16)(uv >> 8);
             if (type == SAVEt_HINTS_HH) {
                 SvREFCNT_dec(MUTABLE_SV(GvHV(PL_hintgv)));
                 GvHV(PL_hintgv) = MUTABLE_HV(a2.any_ptr);

--- a/t/comp/use.t
+++ b/t/comp/use.t
@@ -6,7 +6,7 @@ BEGIN {
     $INC{"feature.pm"} = 1; # so we don't attempt to load feature.pm
 }
 
-print "1..84\n";
+print "1..85\n";
 
 # Can't require test.pl, as we're testing the use/require mechanism here.
 
@@ -149,8 +149,14 @@ like $@, qr/^Can't use string/,
 eval 'use strict "subs"; use 5.012; ${"foo"} = "bar"';
 like $@, qr/^Can't use string/,
     'explicit use strict "subs" does not stop ver decl from enabling refs';
-eval 'use 5.012; use 5.01; ${"foo"} = "bar"';
-is $@, "", 'use 5.01 overrides implicit strict from prev ver decl';
+{
+    my $warnings = "";
+    local $SIG{__WARN__} = sub { $warnings .= $_[0] };
+    eval 'use 5.012; use 5.01; ${"foo"} = "bar"';
+    is $@, "", 'use 5.01 overrides implicit strict from prev ver decl';
+    like $warnings, qr/^Downgrading a use VERSION declaration to below v5.11 is deprecated, and will become fatal in Perl 5.40 at /,
+        'use 5.01 after use 5.012 provokes deprecation warning';
+}
 eval 'no strict "subs"; use 5.012; ${"foo"} = "bar"';
 ok $@, 'no strict subs allows ver decl to enable refs';
 eval 'no strict "subs"; use 5.012; $nonexistent_pack_var';

--- a/t/lib/feature/implicit
+++ b/t/lib/feature/implicit
@@ -69,6 +69,7 @@ evalbytes;
 use 5;
 say "no"
 EXPECT
+Downgrading a use VERSION declaration to below v5.11 is deprecated, and will become fatal in Perl 5.40 at - line 8.
 yes
 evalbytes sub
 say sub
@@ -80,6 +81,7 @@ print 'ss' =~ /$sharp_s/i ? "ok\n" : "nok\n";
 use v5.8.8;
 print 'ss' =~ /$sharp_s/i ? "ok\n" : "nok\n";
 EXPECT
+Downgrading a use VERSION declaration to below v5.11 is deprecated, and will become fatal in Perl 5.40 at - line 5.
 ok
 nok
 ########
@@ -91,5 +93,6 @@ print eval "use utf8; q|$long_s|" eq $long_s ? "ok\n" : "nok\n";
 use v5.8.8;
 print eval "use utf8; q|$long_s|" eq "\x{17f}" ? "ok\n" : "nok\n";
 EXPECT
+Downgrading a use VERSION declaration to below v5.11 is deprecated, and will become fatal in Perl 5.40 at - line 6.
 ok
 ok


### PR DESCRIPTION
Print a deprecation warning if a `use VERSION` requesting a version below v5.11 is encountered, after a `use VERSION` of a higher version is already in scope.

This is because versions v5.11 or higher will enable the strictness hints as if loaded by `use strict`, and earlier versions will clear them. The model for this is complicated by the second set of HINT_EXPLICIT_STRICT_* bits, which have now been decided are a bad design and we'd like to remove them.

Once merged, I will follow this up with another change which actually removes the HINT_EXPLICIT_STRICT bits, freeing up three more hints bits for useful work. Removing the hints bits would slightly change the behaviour in this scenario, therefore we should print a deprecation warning on situations that might be affected.