### PR TITLE
Update perldiag and perldeprecation for features removed in 5.30

### DIFF
--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -180,8 +180,8 @@ C<< File::Glob >> has a function called C<< glob >>, which just calls
 C<< bsd_glob >>.
 
 C<< File::Glob::glob() >> was deprecated in Perl 5.8. A deprecation
-message was issued from Perl 5.26 onwards, and the function has now
-disappeared in Perl 5.30.
+message was issued from Perl 5.26 onwards, the function became fatal
+in Perl 5.30, and was removed entirely in Perl 5.32.
 
 Code using C<< File::Glob::glob() >> should call
 C<< File::Glob::bsd_glob() >> instead.
@@ -192,7 +192,7 @@ C<< File::Glob::bsd_glob() >> instead.
 
 Before Perl 5.10, setting C<< $* >> to a true value globally enabled
 multi-line matching within a string. This relique from the past lost
-its special meaning in 5.10. Use of this variable will be a fatal error
+its special meaning in 5.10. Use of this variable became a fatal error
 in Perl 5.30, freeing the variable up for a future special meaning.
 
 To enable multiline matching one should use the C<< /m >> regexp
@@ -205,7 +205,7 @@ a whole file) with C<< use re '/m' >>.
 This variable used to have a special meaning -- it could be used
 to control how numbers were formatted when printed. This seldom
 used functionality was removed in Perl 5.10. In order to free up
-the variable for a future special meaning, its use will be a fatal
+the variable for a future special meaning, its use became a fatal
 error in Perl 5.30.
 
 To specify how numbers are formatted when printed, one is advised
@@ -228,8 +228,8 @@ of C<< CORE::glob >>, and hence, C<< File::Glob::glob >> should not
 be used.
 
 C<< File::Glob::glob() >> was deprecated in Perl 5.8. A deprecation
-message was issued from Perl 5.26 onwards, and the function will
-disappear in Perl 5.30.
+message was issued from Perl 5.26 onwards, and in Perl 5.30 this was
+turned into a fatal error.
 
 Code using C<< File::Glob::glob() >> should call
 C<< File::Glob::bsd_glob() >> instead.
@@ -241,7 +241,7 @@ See L</Unescaped left braces in regular expressions> above.
 =head3 Unqualified C<dump()>
 
 Use of C<dump()> instead of C<CORE::dump()> was deprecated in Perl 5.8,
-and an unqualified C<dump()> will no longer be available in Perl 5.30.
+and an unqualified C<dump()> is no longer available as of Perl 5.30.
 
 See L<perlfunc/dump>.
 
@@ -297,7 +297,7 @@ code.  To avoid this a future version of perl will throw an exception when
 any of sysread(), recv(), syswrite() or send() are called on handle with the
 C<:utf8> layer.
 
-In Perl 5.30, it will no longer be possible to use sysread(), recv(),
+As of Perl 5.30, it is no longer be possible to use sysread(), recv(),
 syswrite() or send() to read or send bytes from/to :utf8 handles.
 
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2013,30 +2013,6 @@ or a hash key/value or array index/value slice, such as:
 long for Perl to handle.  You have to be seriously twisted to write code
 that triggers this error.
 
-=item Deprecated use of my() in false conditional. This will be a fatal error in Perl 5.30
-
-(D deprecated) You used a declaration similar to C<my $x if 0>.  There
-has been a long-standing bug in Perl that causes a lexical variable
-not to be cleared at scope exit when its declaration includes a false
-conditional.  Some people have exploited this bug to achieve a kind of
-static variable.  Since we intend to fix this bug, we don't want people
-relying on this behavior.  You can achieve a similar static effect by
-declaring the variable in a separate block outside the function, eg
-
-    sub f { my $x if 0; return $x++ }
-
-becomes
-
-    { my $x; sub f { return $x++ } }
-
-Beginning with perl 5.10.0, you can also use C<state> variables to have
-lexicals that are initialized only once (see L<feature>):
-
-    sub f { state $x; return $x++ }
-
-This use of C<my()> in a false conditional has been deprecated since
-Perl 5.10, and it will become a fatal error in Perl 5.30.
-
 =item DESTROY created new reference to dead object '%s'
 
 (F) A DESTROY() method created a new reference to the object which is


### PR DESCRIPTION
Remove the perldiag entry for `my` in false conditional, and change
the perldiag entries to past tense.

Also correct the description of what actually happened to
`File::Glob::glob()`.