### PR TITLE
Make map and grep preserve their args lists.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6166,6 +6166,7 @@ t/re/uniprops09.t		Test unicode \p{} regex constructs
 t/re/uniprops10.t		Test unicode \p{} regex constructs
 t/re/user_prop_race_thr.t	Test races in user-defined \p{} under threads
 t/README			Instructions for regression tests
+t/run/argv_free.t		Ensure no conflicts between @ARGV and <>.
 t/run/cloexec.t			Test close-on-exec.
 t/run/dtrace.pl			For dtrace.t
 t/run/dtrace.t			Test for DTrace probes

--- a/t/op/grep.t
+++ b/t/op/grep.t
@@ -10,7 +10,7 @@ BEGIN {
     set_up_inc( qw(. ../lib) );
 }
 
-plan( tests => 67 );
+plan( tests => 68 );
 
 {
     my @lol = ([qw(a b c)], [], [qw(1 2 3)]);
@@ -237,4 +237,11 @@ pass 'no double frees with grep/map { undef *_ }';
 {
     my @a = map { 1; "$_" } 1,2;
     is("@a", "1 2", "PADTMP");
+}
+
+{
+    # Ensure that the map args list doesn't disappear midstream:
+    my @foo = qw(1 2 3 4 5 6 7);
+    my @foo2 = map { @foo = (); $_ } @foo;
+    is("@foo2", "1 2 3 4 5 6 7", 'map preserves args list');
 }

--- a/t/run/argv_free.t
+++ b/t/run/argv_free.t
@@ -1,0 +1,13 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    @INC = '../lib';
+    require './test.pl';
+    skip_all_without_config('d_fcntl');
+}
+
+system $^X, '-e', 'close STDIN; map <>, @ARGV', 1, 2;
+is($?, 0, '@ARGV does not conflict with <>');
+
+done_testing;


### PR DESCRIPTION
Issue #19340: This prevents an obscure segfault.