### PR TITLE
String "Inf" should be consistently converted to IV/UV

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -2294,6 +2294,7 @@ S_sv_2iuv_common(pTHX_ SV *const sv)
         if (SvTYPE(sv) == SVt_NV)
             sv_upgrade(sv, SVt_PVNV);
 
+    got_nv:
         (void)SvIOKp_on(sv);	/* Must do this first, to clear any SvOOK */
         /* < not <= as for NV doesn't preserve UV, ((NV)IV_MAX+1) will almost
            certainly cast into the IV range at IV_MAX, whereas the correct
@@ -2418,7 +2419,7 @@ S_sv_2iuv_common(pTHX_ SV *const sv)
             if (ckWARN(WARN_NUMERIC) && ((numtype & IS_NUMBER_TRAILING)))
                 not_a_number(sv);
             S_sv_setnv(aTHX_ sv, numtype);
-            return FALSE;
+            goto got_nv;        /* Fill IV/UV slot and set IOKp */
         }
 
         /* If NVs preserve UVs then we only use the UV value if we know that

--- a/t/op/infnan.t
+++ b/t/op/infnan.t
@@ -578,9 +578,6 @@ cmp_ok('-1e-9999', '==', 0,     "underflow to 0 (runtime) from neg");
 
 # "-Inf" should be converted to IV consistently
 {
-    # Enclosed in a string eval so that majority of infnan.t are run
-    # before loading integer.pm, just in case.
-    eval <<'EOC';
     use integer;
     my $x = '-Inf';
     my $y = $NInf;      # $NInf and $y shall be NV -Inf
@@ -589,7 +586,6 @@ cmp_ok('-1e-9999', '==', 0,     "underflow to 0 (runtime) from neg");
     # $z shall be IV_MIN here, but as the actual value of IV_MIN is not
     # (easily) available in Perl so check its negative-ness as the next best.
     cmp_ok($z, '<', 0, "'-Inf' should be converted to a negative IV");
-EOC
 }
 
 done_testing();

--- a/t/op/infnan.t
+++ b/t/op/infnan.t
@@ -576,4 +576,20 @@ cmp_ok('-1e-9999', '==', 0,     "underflow to 0 (runtime) from neg");
     is($x, ' Inf ', "string shall be ' Inf ' after UV/NV conversion");
 }
 
+# "-Inf" should be converted to IV consistently
+{
+    # Enclosed in a string eval so that majority of infnan.t are run
+    # before loading integer.pm, just in case.
+    eval <<'EOC';
+    use integer;
+    my $x = '-Inf';
+    my $y = $NInf;      # $NInf and $y shall be NV -Inf
+    my $z = $x | 0;     # "|" under "use integer;" requires IV operands
+    is($z, $y | 0, "'-Inf' should be converted to IV consistently");
+    # $z shall be IV_MIN here, but as the actual value of IV_MIN is not
+    # (easily) available in Perl so check its negative-ness as the next best.
+    cmp_ok($z, '<', 0, "'-Inf' should be converted to a negative IV");
+EOC
+}
+
 done_testing();

--- a/t/op/infnan.t
+++ b/t/op/infnan.t
@@ -562,4 +562,18 @@ cmp_ok('-1e-9999', '==', 0,     "underflow to 0 (runtime) from neg");
     }
 }
 
+# "+Inf" should be converted to UV consistently
+{
+    my $uv_max = ~0;
+    my $x = 42;     # Some arbitrary integer.
+    $x = ' Inf ';   # Spaces will detect unwanted string/NV round-trip
+    is($x << 0, $uv_max, "' Inf ' converted to UV");
+    # Test twice just in case if SvUV is tricked by cached NV
+    is($x << 0, $uv_max, "second conversion of ' Inf ' to UV");
+    # Cached NV should be Inf even after conversion to UV returned UV_MAX
+    cmp_ok($x, '==', $PInf, "NV value of ' Inf ' after UV conversion");
+    # String value should not be changed
+    is($x, ' Inf ', "string shall be ' Inf ' after UV/NV conversion");
+}
+
 done_testing();


### PR DESCRIPTION
I found that using string `"Inf"` in contexts that requires IV/UV is converted to wrong results for the first time:
```
$ perl -wle 'my $x = "Inf"; print $x << 0; print $x << 0; print $x << 0'
0
18446744073709551615
18446744073709551615
```
To make matters worse, `"Inf"` seems to "leak" the previous value of the variable:
```
$ perl -wle 'my $x = 42; $x = "Inf"; print $x << 0; print $x << 0'
42
18446744073709551615
```
This PR will fix this problem (and add testcases).