### PR TITLE
Sort tests in t/porting/dual-life.t

### DIFF
--- a/t/porting/dual-life.t
+++ b/t/porting/dual-life.t
@@ -61,7 +61,7 @@ find(
 );
 
 
-for my $f ( @programs ) {
+for my $f ( sort @programs ) {
   $f =~ s/\.\z// if $^O eq 'VMS';
   next if $f =~ $not_installed;
   my $bn = basename($f);


### PR DESCRIPTION
I notice a couple of openSUSE smokes are giving fails on this test (eg https://perl5.test-smoke.org/report/5015678), but since the order of the tests is determined by `File::Find::find` I don't know which utils it is actually complaining about.

This simple change gives a consistent but non-obvious order: we're sorting on eg
```
../cpan/Pod-Checker/scripts/podchecker.PL
../cpan/podlators/scripts/pod2text
../cpan/IO-Compress/bin/streamzip
../ext/Pod-Html/bin/pod2html 
...
```
rather than what appears in the test legends:
```
Verify -f '../cpan/Pod-Checker/podchecker'
Verify -f '../cpan/podlators/scripts/pod2text'
Verify -f '../utils/streamzip'
Verify -f '../utils/pod2html'
...
```

Since the list changes only rarely, for smoke failures after this is committed that should be enough to work out which file is being complained about by comparing a local verbose run.