### PR TITLE
Yves/revert reverted caller fixes

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5682,6 +5682,10 @@ t/lib/feature/nonesuch		Tests for enabling/disabling nonexistent feature
 t/lib/feature/removed		Tests for enabling/disabling removed feature
 t/lib/feature/say		Tests for enabling/disabling say feature
 t/lib/feature/switch		Tests for enabling/disabling switch feature
+t/lib/GH_15109/Apack.pm		test Module for caller.t
+t/lib/GH_15109/Bpack.pm		test Module for caller.t
+t/lib/GH_15109/Cpack.pm		test Module for caller.t
+t/lib/GH_15109/Foo.pm		test Module for caller.t
 t/lib/h2ph.h			Test header file for h2ph
 t/lib/h2ph.pht			Generated output from h2ph.h by h2ph, for comparison
 t/lib/locale/latin1		Part of locale.t in Latin 1

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -1872,6 +1872,10 @@ It has the same scoping as the C<$^H> and C<%^H> variables.  The exact
 values are considered internal to the L<warnings> pragma and may change
 between versions of Perl.
 
+Each time a statement completes being compiled, the current value of
+C<${^WARNING_BITS}> is stored with that statement, and can later be
+retrieved via C<(caller($level))[9]>.
+
 This variable was added in Perl v5.6.0.
 
 =item $OS_ERROR
@@ -2138,6 +2142,10 @@ This variable contains compile-time hints for the Perl interpreter.  At the
 end of compilation of a BLOCK the value of this variable is restored to the
 value when the interpreter started to compile the BLOCK.
 
+Each time a statement completes being compiled, the current value of
+C<$^H> is stored with that statement, and can later be retrieved via
+C<(caller($level))[8]>.
+
 When perl begins to parse any block construct that provides a lexical scope
 (e.g., eval body, required file, subroutine body, loop body, or conditional
 block), the existing value of C<$^H> is saved, but its value is left unchanged.
@@ -2185,6 +2193,10 @@ it useful for implementation of lexically scoped pragmas.  See
 L<perlpragma>.   All the entries are stringified when accessed at
 runtime, so only simple values can be accommodated.  This means no
 pointers to objects, for example.
+
+Each time a statement completes being compiled, the current value of
+C<%^H> is stored with that statement, and can later be retrieved via
+C<(caller($level))[10]>.
 
 When putting items into C<%^H>, in order to avoid conflicting with other
 users of the hash there is a convention regarding which keys to use.

--- a/t/lib/GH_15109/Apack.pm
+++ b/t/lib/GH_15109/Apack.pm
@@ -1,0 +1,4 @@
+# for use by caller.t for GH #15109
+package Apack;
+use Bpack;
+1;

--- a/t/lib/GH_15109/Bpack.pm
+++ b/t/lib/GH_15109/Bpack.pm
@@ -1,0 +1,4 @@
+# for use by caller.t for GH #15109
+package Bpack;
+use Cpack;
+1;

--- a/t/lib/GH_15109/Cpack.pm
+++ b/t/lib/GH_15109/Cpack.pm
@@ -1,0 +1,11 @@
+# for use by caller.t for GH #15109
+package Cpack;
+
+
+my $i = 0;
+
+while (my ($package, $file, $line) = caller($i++)) {
+    push @Cpack::callers, "$file:$line";
+}
+
+1;

--- a/t/lib/GH_15109/Foo.pm
+++ b/t/lib/GH_15109/Foo.pm
@@ -1,0 +1,9 @@
+# for use by caller.t for GH #15109
+
+package Foo;
+
+sub import {
+    use warnings; # restore default warnings
+    () = caller(1); # this used to cause valgrind errors
+}
+1;

--- a/t/op/caller.t
+++ b/t/op/caller.t
@@ -5,7 +5,7 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib');
-    plan( tests => 97 ); # some tests are run in a BEGIN block
+    plan( tests => 111 ); # some tests are run in a BEGIN block
 }
 
 my @c;
@@ -335,16 +335,44 @@ $::testing_caller = 1;
 
 do './op/caller.pl' or die $@;
 
+# GH #15109
+# See that callers within a nested series of 'use's gets the right
+# filenames.
+{
+    local @INC = 'lib/GH_15109/';
+    # Apack use's Bpack which use's Cpack which populates @Cpack::caller
+    # with the file:N of all the callers
+    eval 'use Apack; 1';
+    is($@, "", "GH #15109 - eval");
+    is (scalar(@Cpack::callers), 10, "GH #15109 - callers count");
+    like($Cpack::callers[$_], qr{GH_15109/Bpack.pm:3}, "GH #15109 level $_") for 0..2;
+    like($Cpack::callers[$_], qr{GH_15109/Apack.pm:3}, "GH #15109 level $_") for 3..5;
+    like($Cpack::callers[$_], qr{\(eval \d+\):1}, "GH #15109 level $_") for 6..8;
+    like($Cpack::callers[$_], qr{caller\.t}, "GH #15109 level $_") for 9;
+
+    # GH #15109 followup - the original fix wasn't saving cop_warnings
+    # correctly and this code used to crash or fail valgrind
+
+    my $w = 0;
+    local $SIG{__WARN__} = sub { $w++ };
+    eval q{
+        use warnings;
+        no warnings 'numeric'; # ensure custom cop_warnings
+        use Foo;      # this used to mess up warnings flags
+        BEGIN { my $x = "foo" + 1; } # potential "numeric" warning
+    };
+    is ($@, "", "GH #15109 - eval okay");
+    is ($w, 0, "GH #15109 - warnings restored");
+}
+
 {
     package RT129239;
     BEGIN {
         my ($pkg, $file, $line) = caller;
         ::is $file, 'virtually/op/caller.t', "BEGIN block sees correct caller filename";
         ::is $line, 12345,                   "BEGIN block sees correct caller line";
-        TODO: {
-            local $::TODO = "BEGIN blocks have wrong caller package [perl #129239]";
-            ::is $pkg, 'RT129239',               "BEGIN block sees correct caller package";
-        }
+        ::is $pkg, 'RT129239',               "BEGIN block sees correct caller package";
 #line 12345 "virtually/op/caller.t"
     }
+
 }


### PR DESCRIPTION
Revert: commit c0d05305c156c83e4f9f3a207451b3175fbb7f24
Merge: c6b2e294d8 79f75eaa71
Author: David Mitchell <davem@iabyn.com>
Date:   Mon Apr 27 22:04:23 2020 +0100

    [MERGE] Revert BEGIN { caller() } fixups
    
    These commits were intended to fix a problem with stack backtraces
    reporting wrong file and line numbers in nested use's.
    
    A side-effect of the commits was to fix the package name returned by
    caller() too; but quite a few distributions were relying on the old
    behaviour.
    
    So for now, revert to the old behaviour and re-address after 5.32.0 is
    released.
    
    The reverted commits are:
    
    v5.31.6-141-gf2f32cd638 avoid identical stack traces
    v5.31.9-122-gee428a211d docs: clarify effect of $^H, %^H, ${^WARNING_BITS}
    v5.31.9-162-gad89278aa2 fixup to "avoid identical stack traces" - try 2
