### PR TITLE
Porting/GitUtils.pm: add missing package declaration

### DIFF
--- a/Porting/GitUtils.pm
+++ b/Porting/GitUtils.pm
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+package GitUtils;
 use strict;
 use warnings;
 use POSIX qw(strftime);


### PR DESCRIPTION
I missed this in 2009. Working on https://github.com/Perl/perl5/pull/19419 revealed that I missed the package declaration meaning the code only accidentally works because it installs the subs in the same namespace they are used from "main".