### PR TITLE
Add trim() to builtin::

### DIFF
--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -21,6 +21,7 @@ builtin - Perl pragma to import built-in utility functions
         weaken unweaken is_weak
         blessed refaddr reftype
         ceil floor
+        trim
     );
 
 =head1 DESCRIPTION
@@ -195,6 +196,36 @@ C<foreach> loop syntax; as
 
 In scalar context this function returns the size of the list that it would
 otherwise have returned, and provokes a warning in the C<scalar> category.
+
+=head2 trim
+
+    $stripped = trim($string);
+
+Returns the input string with whitespace stripped from the beginning
+and end. trim() will remove these characters:
+
+" ", an ordinary space.
+
+"\t", a tab.
+
+"\n", a new line (line feed).
+
+"\r", a carriage return.
+
+and all other Unicode characters that are flagged as whitespace.
+A complete list is in L<perlrecharclass/Whitespace>.
+
+    $var = "  Hello world   ";            # "Hello world"
+    $var = "\t\t\tHello world";           # "Hello world"
+    $var = "Hello world\n";               # "Hello world"
+    $var = "\x{2028}Hello world\x{3000}"; # "Hello world"
+
+C<trim> is equivalent to:
+
+    $str =~ s/\A\s+|\s+\z//urg;
+
+For Perl versions where this feature is not available look at the
+L<String::Util> module for a comparable implementation.
 
 =head1 SEE ALSO
 

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -219,4 +219,62 @@ package FetchStoreCounter {
     }
 }
 
+# Vanilla trim tests
+{
+    use builtin qw( trim );
+
+    is(trim("    Hello world!   ")      , "Hello world!"  , 'Trim spaces');
+    is(trim("\tHello world!\t")         , "Hello world!"  , 'Trim tabs');
+    is(trim("\n\n\nHello\nworld!\n")    , "Hello\nworld!" , 'Trim \n');
+    is(trim("\t\n\n\nHello world!\n \t"), "Hello world!"  , 'Trim all three');
+    is(trim("Perl")                     , "Perl"          , 'Trim nothing');
+    is(trim('')                         , ""              , 'Trim empty string');
+}
+
+TODO: {
+    my $warn = '';
+    local $SIG{__WARN__} = sub { $warn .= join "", @_; };
+
+    is(builtin::trim(undef), "", 'Trim undef');
+    like($warn    , qr/^Use of uninitialized value in subroutine entry at/,
+         'Trim undef triggers warning');
+    local $main::TODO = "Currently uses generic value for the name of non-opcode builtins";
+    like($warn    , qr/^Use of uninitialized value in trim at/,
+         'Trim undef triggers warning using actual name of builtin');
+}
+
+# Fancier trim tests against a regexp and unicode
+{
+    use builtin qw( trim );
+    my $nbsp = chr utf8::unicode_to_native(0xA0);
+
+    is(trim("   \N{U+2603}       "), "\N{U+2603}", 'Trim with unicode content');
+    is(trim("\N{U+2029}foobar\x{2028} "), "foobar",
+            'Trim with unicode whitespace');
+    is(trim("$nbsp foobar$nbsp    "), "foobar", 'Trim with latin1 whitespace');
+}
+
+# Test on a magical fetching variable
+{
+    use builtin qw( trim );
+
+    my $str3 = "   Hello world!\t";
+    $str3 =~ m/(.+Hello)/;
+    is(trim($1), "Hello", "Trim on a magical variable");
+}
+
+# Inplace edit, my, our variables
+{
+    use builtin qw( trim );
+
+    my $str4 = "\t\tHello world!\n\n";
+    $str4 = trim($str4);
+    is($str4, "Hello world!", "Trim on an inplace variable");
+
+    our $str2 = "\t\nHello world!\t  ";
+    is(trim($str2), "Hello world!", "Trim on an our \$var");
+}
+
+# vim: tabstop=4 shiftwidth=4 expandtab autoindent softtabstop=4
+
 done_testing();

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -25,7 +25,11 @@ XXX New core language features go here.  Summarize user-visible core language
 enhancements.  Particularly prominent performance optimisations could go
 here, but most should go in the L</Performance Enhancements> section.
 
-[ List each enhancement as a =head2 entry ]
+=head2 New function C<builtin::trim>
+
+This function treats its argument as a string, returning the result of
+removing all white space at its beginning and ending.  See
+L<builtin/trim>
 
 =head2 Variable length lookbehind is mostly no longer considered experimental.
 

--- a/regcharclass.h
+++ b/regcharclass.h
@@ -156,6 +156,35 @@
 ( 0x205F == cp || 0x3000 == cp ) ) ) ) ) ) ) ) )
 
 /*
+	SPACE: Backwards \p{XPerlSpace}
+
+	\p{XPerlSpace}
+*/
+/*** GENERATED CODE ***/
+#define is_SPACE_utf8_safe_backwards(s,e)                                   \
+( ((s) - (e) > 2) ?                                                         \
+    ( ( inRANGE_helper_(U8, *((const U8*)s - 1), '\t', '\r') || ' ' == *((const U8*)s - 1) ) ? 1\
+    : ( 0x80 == *((const U8*)s - 1) ) ?                                     \
+	( ( 0x80 == *((const U8*)s - 2) ) ?                                 \
+	    ( ( inRANGE_helper_(U8, *((const U8*)s - 3), 0xE2, 0xE3) ) ? 3 : 0 )\
+	: ( ( 0x9A == *((const U8*)s - 2) ) && ( 0xE1 == *((const U8*)s - 3) ) ) ? 3 : 0 )\
+    : ( inRANGE_helper_(U8, *((const U8*)s - 1), 0x81, 0x84) || inRANGE_helper_(U8, *((const U8*)s - 1), 0x86, 0x8A) || inRANGE_helper_(U8, *((const U8*)s - 1), 0xA8, 0xA9) || 0xAF == *((const U8*)s - 1) ) ?\
+	( ( ( 0x80 == *((const U8*)s - 2) ) && ( 0xE2 == *((const U8*)s - 3) ) ) ? 3 : 0 )\
+    : ( 0x85 == *((const U8*)s - 1) ) ?                                     \
+	( ( 0x80 == *((const U8*)s - 2) ) ?                                 \
+	    ( ( 0xE2 == *((const U8*)s - 3) ) ? 3 : 0 )                     \
+	: ( 0xC2 == *((const U8*)s - 2) ) ? 2 : 0 )                         \
+    : ( 0x9F == *((const U8*)s - 1) ) ?                                     \
+	( ( ( 0x81 == *((const U8*)s - 2) ) && ( 0xE2 == *((const U8*)s - 3) ) ) ? 3 : 0 )\
+    : ( ( 0xA0 == *((const U8*)s - 1) ) && ( 0xC2 == *((const U8*)s - 2) ) ) ? 2 : 0 )\
+: ((s) - (e) > 1) ?                                                         \
+    ( ( inRANGE_helper_(U8, *((const U8*)s - 1), '\t', '\r') || ' ' == *((const U8*)s - 1) ) ? 1\
+    : ( ( 0x85 == *((const U8*)s - 1) || 0xA0 == *((const U8*)s - 1) ) && ( 0xC2 == *((const U8*)s - 2) ) ) ? 2 : 0 )\
+: ((s) - (e) > 0) ?                                                         \
+    ( inRANGE_helper_(U8, *((const U8*)s - 1), '\t', '\r') || ' ' == *((const U8*)s - 1) )\
+: 0 )
+
+/*
 	NONCHAR: Non character code points
 
 	\p{_Perl_Nchar}
@@ -1383,6 +1412,35 @@
 ( inRANGE_helper_(UV, cp, 0x2028, 0x2029) || ( 0x2029 < cp &&               \
 ( 0x202F == cp || ( 0x202F < cp &&                                          \
 ( 0x205F == cp || 0x3000 == cp ) ) ) ) ) ) ) ) )
+
+/*
+	SPACE: Backwards \p{XPerlSpace}
+
+	\p{XPerlSpace}
+*/
+/*** GENERATED CODE ***/
+#define is_SPACE_utf8_safe_backwards(s,e)                                   \
+( ((s) - (e) > 2) ?                                                         \
+    ( ( '\t' == *((const U8*)s - 1) || inRANGE_helper_(U8, *((const U8*)s - 1), '\v', '\r') || '\n' == *((const U8*)s - 1) || 0x25 == *((const U8*)s - 1) || ' ' == *((const U8*)s - 1) ) ? 1\
+    : ( 0x41 == *((const U8*)s - 1) ) ?                                     \
+	( ( 0x41 == *((const U8*)s - 2) ) ?                                 \
+	    ( ( ( *((const U8*)s - 3) & 0xFB ) == 0xCA ) ? 3 : 0 )          \
+	: ( 0x63 == *((const U8*)s - 2) ) ?                                 \
+	    ( ( 0xBC == *((const U8*)s - 3) ) ? 3 : 0 )                     \
+	: ( 0x80 == *((const U8*)s - 2) ) ? 2 : 0 )                         \
+    : ( inRANGE_helper_(U8, *((const U8*)s - 1), 0x42, 0x48) || 0x51 == *((const U8*)s - 1) ) ?\
+	( ( ( 0x41 == *((const U8*)s - 2) ) && ( 0xCA == *((const U8*)s - 3) ) ) ? 3 : 0 )\
+    : ( inRANGE_helper_(U8, *((const U8*)s - 1), 0x49, 0x4A) ) ?            \
+	( ( ( inRANGE_helper_(U8, *((const U8*)s - 2), 0x41, 0x42) ) && ( 0xCA == *((const U8*)s - 3) ) ) ? 3 : 0 )\
+    : ( 0x56 == *((const U8*)s - 1) ) ?                                     \
+	( ( ( 0x42 == *((const U8*)s - 2) ) && ( 0xCA == *((const U8*)s - 3) ) ) ? 3 : 0 )\
+    : ( ( ( 0x73 == *((const U8*)s - 1) ) && ( 0x43 == *((const U8*)s - 2) ) ) && ( 0xCA == *((const U8*)s - 3) ) ) ? 3 : 0 )\
+: ((s) - (e) > 1) ?                                                         \
+    ( ( '\t' == *((const U8*)s - 1) || inRANGE_helper_(U8, *((const U8*)s - 1), '\v', '\r') || '\n' == *((const U8*)s - 1) || 0x25 == *((const U8*)s - 1) || ' ' == *((const U8*)s - 1) ) ? 1\
+    : ( ( 0x41 == *((const U8*)s - 1) ) && ( 0x80 == *((const U8*)s - 2) ) ) ? 2 : 0 )\
+: ((s) - (e) > 0) ?                                                         \
+    ( '\t' == *((const U8*)s - 1) || inRANGE_helper_(U8, *((const U8*)s - 1), '\v', '\r') || '\n' == *((const U8*)s - 1) || 0x25 == *((const U8*)s - 1) || ' ' == *((const U8*)s - 1) )\
+: 0 )
 
 /*
 	NONCHAR: Non character code points
@@ -2614,6 +2672,35 @@
 ( 0x205F == cp || 0x3000 == cp ) ) ) ) ) ) ) ) )
 
 /*
+	SPACE: Backwards \p{XPerlSpace}
+
+	\p{XPerlSpace}
+*/
+/*** GENERATED CODE ***/
+#define is_SPACE_utf8_safe_backwards(s,e)                                   \
+( ((s) - (e) > 2) ?                                                         \
+    ( ( '\t' == *((const U8*)s - 1) || inRANGE_helper_(U8, *((const U8*)s - 1), '\v', '\r') || 0x15 == *((const U8*)s - 1) || '\n' == *((const U8*)s - 1) || ' ' == *((const U8*)s - 1) ) ? 1\
+    : ( 0x41 == *((const U8*)s - 1) ) ?                                     \
+	( ( 0x41 == *((const U8*)s - 2) ) ?                                 \
+	    ( ( ( *((const U8*)s - 3) & 0xFB ) == 0xCA ) ? 3 : 0 )          \
+	: ( 0x62 == *((const U8*)s - 2) ) ?                                 \
+	    ( ( 0xBD == *((const U8*)s - 3) ) ? 3 : 0 )                     \
+	: ( 0x78 == *((const U8*)s - 2) ) ? 2 : 0 )                         \
+    : ( inRANGE_helper_(U8, *((const U8*)s - 1), 0x42, 0x48) || 0x51 == *((const U8*)s - 1) ) ?\
+	( ( ( 0x41 == *((const U8*)s - 2) ) && ( 0xCA == *((const U8*)s - 3) ) ) ? 3 : 0 )\
+    : ( inRANGE_helper_(U8, *((const U8*)s - 1), 0x49, 0x4A) ) ?            \
+	( ( ( inRANGE_helper_(U8, *((const U8*)s - 2), 0x41, 0x42) ) && ( 0xCA == *((const U8*)s - 3) ) ) ? 3 : 0 )\
+    : ( 0x56 == *((const U8*)s - 1) ) ?                                     \
+	( ( ( 0x42 == *((const U8*)s - 2) ) && ( 0xCA == *((const U8*)s - 3) ) ) ? 3 : 0 )\
+    : ( ( ( 0x72 == *((const U8*)s - 1) ) && ( 0x43 == *((const U8*)s - 2) ) ) && ( 0xCA == *((const U8*)s - 3) ) ) ? 3 : 0 )\
+: ((s) - (e) > 1) ?                                                         \
+    ( ( '\t' == *((const U8*)s - 1) || inRANGE_helper_(U8, *((const U8*)s - 1), '\v', '\r') || 0x15 == *((const U8*)s - 1) || '\n' == *((const U8*)s - 1) || ' ' == *((const U8*)s - 1) ) ? 1\
+    : ( ( 0x41 == *((const U8*)s - 1) ) && ( 0x78 == *((const U8*)s - 2) ) ) ? 2 : 0 )\
+: ((s) - (e) > 0) ?                                                         \
+    ( '\t' == *((const U8*)s - 1) || inRANGE_helper_(U8, *((const U8*)s - 1), '\v', '\r') || 0x15 == *((const U8*)s - 1) || '\n' == *((const U8*)s - 1) || ' ' == *((const U8*)s - 1) )\
+: 0 )
+
+/*
 	NONCHAR: Non character code points
 
 	\p{_Perl_Nchar}
@@ -3765,6 +3852,6 @@
  * a5032876704eb2ed2872ea296f8b1543ad2b9029b9d4ec011ad81c05644b0bfa lib/unicore/mktables
  * c72bbdeda99714db1c8024d3311da4aef3c0db3b9b9f11455a7cfe10d5e9aba3 lib/unicore/version
  * 0a6b5ab33bb1026531f816efe81aea1a8ffcd34a27cbea37dd6a70a63d73c844 regen/charset_translations.pl
- * 1aa94679c695efd507b7e4491629dba1021b74c21a5324dfd3a582a5d654bd32 regen/regcharclass.pl
+ * acc94e4afc339fe2cf2ae74d6e1cbcf2c396328d78e56236ad314eadbfc84125 regen/regcharclass.pl
  * b2f896452d2b30da3e04800f478c60c1fd0b03d6b668689b020f1e3cf1f1cdd9 regen/regcharclass_multi_char_folds.pl
  * ex: set ro: */

--- a/regen/regcharclass.pl
+++ b/regen/regcharclass.pl
@@ -355,8 +355,9 @@ sub val_fmt
 #
 # Each string is then stored in the 'strs' subhash as a hash record
 # made up of the results of __uni_latin1, using the keynames
-# 'low','latin1','utf8', as well as the synthesized 'LATIN1', 'high', and
-# 'UTF8' which hold a merge of 'low' and their lowercase equivalents.
+# 'low', 'latin1', 'utf8', as well as the synthesized 'LATIN1', 'high',
+# 'UTF8', and 'backwards_UTF8' which hold a merge of 'low' and their lowercase
+# equivalents.
 #
 # Size data is tracked per type in the 'size' subhash.
 #
@@ -503,7 +504,7 @@ sub new {
 #
 
 sub make_trie {
-    my ( $self, $type, $maxlen )= @_;
+    my ( $self, $type, $maxlen, $backwards )= @_;
 
     my $strs= $self->{strs};
     my %trie;
@@ -514,7 +515,8 @@ sub make_trie {
         next unless $dat;
         next if $maxlen && @$dat > $maxlen;
         my $node= \%trie;
-        foreach my $elem ( @$dat ) {
+        my @ordered_dat = ($backwards) ? reverse @$dat : @$dat;
+        foreach my $elem ( @ordered_dat ) {
             $node->{$elem} ||= {};
             $node= $node->{$elem};
         }
@@ -547,7 +549,7 @@ sub pop_count ($) {
 #
 
 sub _optree {
-    my ( $self, $trie, $test_type, $ret_type, $else, $depth )= @_;
+    my ( $self, $trie, $test_type, $ret_type, $else, $depth, $backwards )= @_;
     return unless defined $trie;
     $ret_type ||= 'len';
     $else= 0  unless defined $else;
@@ -581,7 +583,16 @@ sub _optree {
     # can return the "else" value.
     return $else if !@conds;
 
-    my $test = $test_type =~ /^cp/ ? "cp" : "((const U8*)s)[$depth]";
+    my $test;
+    if ($test_type =~ /^cp/) {
+        $test = "cp";
+    }
+    elsif ($backwards) {
+        $test = "*((const U8*)s - " . ($depth + 1) . ")";
+    }
+    else {
+        $test = "((const U8*)s)[$depth]";
+    }
 
     # First we loop over the possible keys/conditions and find out what they
     # look like; we group conditions with the same optree together.
@@ -592,7 +603,7 @@ sub _optree {
 
         # get the optree for this child/condition
         my $res= $self->_optree( $trie->{$cond}, $test_type, $ret_type,
-                                                            $else, $depth + 1 );
+                                                $else, $depth + 1, $backwards );
         # convert it to a string with Dumper
         my $res_code= Dumper( $res );
 
@@ -632,10 +643,11 @@ sub _optree {
 sub optree {
     my $self= shift;
     my %opt= @_;
-    my $trie= $self->make_trie( $opt{type}, $opt{max_depth} );
+    my $trie= $self->make_trie( $opt{type}, $opt{max_depth}, $opt{backwards} );
     $opt{ret_type} ||= 'len';
     my $test_type= $opt{type} =~ /^cp/ ? 'cp' : 'depth';
-    return $self->_optree( $trie, $test_type, $opt{ret_type}, $opt{else}, 0 );
+    return $self->_optree( $trie, $test_type, $opt{ret_type}, $opt{else}, 0,
+                                                                    $opt{backwards} );
 }
 
 # my $optree= generic_optree(%opts);
@@ -652,10 +664,10 @@ sub generic_optree {
     my $test_type= 'depth';
     my $else= $opt{else} || 0;
 
-    my $latin1= $self->make_trie( 'latin1', $opt{max_depth} );
-    my $utf8= $self->make_trie( 'utf8',     $opt{max_depth} );
+    my $latin1= $self->make_trie( 'latin1', $opt{max_depth}, $opt{backwards} );
+    my $utf8= $self->make_trie( 'utf8',     $opt{max_depth}, $opt{backwards} );
 
-    $_= $self->_optree( $_, $test_type, $opt{ret_type}, $else, 0 )
+    $_= $self->_optree( $_, $test_type, $opt{ret_type}, $else, 0, $opt{backwards} )
       for $latin1, $utf8;
 
     if ( $utf8 ) {
@@ -664,9 +676,10 @@ sub generic_optree {
         $else= __cond_join( "!( is_utf8 )", $latin1, $else );
     }
     if ($opt{type} eq 'generic') {
-        my $low= $self->make_trie( 'low', $opt{max_depth} );
+        my $low= $self->make_trie( 'low', $opt{max_depth}, $opt{backwards} );
         if ( $low ) {
-            $else= $self->_optree( $low, $test_type, $opt{ret_type}, $else, 0 );
+            $else= $self->_optree( $low, $test_type, $opt{ret_type}, $else, 0,
+                                                                    $opt{backwards} );
         }
     }
 
@@ -724,6 +737,14 @@ sub length_optree {
             $else= __cond_join( $cond, $optree, $else );
         }
     }
+    elsif ($opt{backwards}) {
+        my @size= sort { $a <=> $b } keys %{ $self->{size}{$type} };
+        for my $size ( @size ) {
+            my $optree= $self->$method(%opt, type => $type, max_depth => $size);
+            my $cond= "((s) - (e) > " . ( $size - 1 ).")";
+            $else= __cond_join( $cond, $optree, $else );
+        }
+    }
     else {
         my $utf8;
 
@@ -739,11 +760,12 @@ sub length_optree {
         # If we do want more than the 0-255 range, find those, and if they
         # exist...
         if (   $opt{type} !~ /latin1/i
-            && ($utf8 = $self->make_trie($trie_type, 0)))
+            && ($utf8 = $self->make_trie($trie_type, 0, $opt{backwards})))
         {
 
             # ... get them into an optree, and set them up as the 'else' clause
-            $utf8 = $self->_optree( $utf8, 'depth', $opt{ret_type}, 0, 0 );
+            $utf8 = $self->_optree( $utf8, 'depth', $opt{ret_type}, 0, 0,
+                                                                    $opt{backwards} );
 
             # We could make this
             #   UTF8_IS_START(*s) && ((e) - (s)) >= UTF8SKIP(s))";
@@ -761,16 +783,18 @@ sub length_optree {
             # the case where the input isn't UTF-8.
             my $latin1;
             if ($method eq 'generic_optree') {
-                $latin1 = $self->make_trie( 'latin1', 1);
-                $latin1= $self->_optree($latin1, 'depth', $opt{ret_type}, 0, 0);
+                $latin1 = $self->make_trie( 'latin1', 1, $opt{backwards});
+                $latin1= $self->_optree($latin1, 'depth', $opt{ret_type}, 0, 0,
+                                                                    $opt{backwards});
             }
 
             # If we want the UTF-8 invariants, get those.
             my $low;
             if ($opt{type} !~ /non_low|high/
-                && ($low= $self->make_trie( 'low', 1)))
+                && ($low= $self->make_trie( 'low', 1, 0)))
             {
-                $low= $self->_optree( $low, 'depth', $opt{ret_type}, 0, 0 );
+                $low= $self->_optree( $low, 'depth', $opt{ret_type}, 0, 0,
+                                                                    $opt{backwards} );
 
                 # Expand out the UTF-8 invariants as a string so that we
                 # can use them as the conditional
@@ -1408,7 +1432,8 @@ sub render {
 # make a macro of a given type.
 # calls into make_trie and (generic_|length_)optree as needed
 # Opts are:
-# type             : 'cp','cp_high', 'generic','high','low','latin1','utf8','LATIN1','UTF8'
+# type             : 'cp', 'cp_high', 'generic', 'high', 'low', 'latin1',
+#                    'utf8', 'LATIN1', 'UTF8' 'backwards_UTF8'
 # ret_type         : 'cp' or 'len'
 # safe             : don't assume is well-formed UTF-8, so don't skip any range
 #                    checks, and add length guards to macro
@@ -1462,6 +1487,7 @@ sub make_macro {
     $ext .= '_non_low' if $type eq 'generic_non_low';
     $ext .= "_safe" if $opts{safe};
     $ext .= "_no_length_checks" if $opts{no_length_checks};
+    $ext .= "_backwards" if $opts{backwards};
     my $argstr= join ",", @args;
     my $def_fmt="$pfx$self->{op}$ext%s($argstr)";
     my $optree= $self->$method( %opts, type => $type, ret_type => $ret_type );
@@ -1523,6 +1549,13 @@ EOF
         foreach my $type_spec ( @types ) {
             my ( $type, $ret )= split /-/, $type_spec;
             $ret ||= 'len';
+
+            my $backwards = 0;
+            if ($type eq 'backwards_UTF8') {
+                $type = 'UTF8';
+                $backwards = 1;
+            }
+
             foreach my $mod ( @mods ) {
 
                 # 'safe' is irrelevant with code point macros, so skip if
@@ -1540,6 +1573,7 @@ EOF
                     charset  => $charset,
                     no_length_checks => $mod eq 'no_length_checks'
                                      && $type !~ /^cp/,
+                    backwards => $backwards,
                 );
                 print $out_fh $macro, "\n";
             }
@@ -1667,6 +1701,9 @@ EOF
 #               class that can include any code point, adding the 'low' ones
 #               to what 'utf8' works on.  It is designed to take only an input
 #               UTF-8 parameter.
+#   backwards_UTF8  like 'UTF8', but designed to match backwards, so that the
+#               second parameter to the function is earlier in the string than
+#               the first.
 #   generic     generate a macro whose name is 'is_BASE".  It has a 2nd,
 #               boolean, parameter which indicates if the first one points to
 #               a UTF-8 string or not.  Thus it works in all circumstances.

--- a/regen/regcharclass.pl
+++ b/regen/regcharclass.pl
@@ -1790,6 +1790,10 @@ XPERLSPACE: \p{XPerlSpace}
 => high cp_high : fast
 \p{XPerlSpace}
 
+SPACE: Backwards \p{XPerlSpace}
+=> backwards_UTF8 : safe
+\p{XPerlSpace}
+
 NONCHAR: Non character code points
 => UTF8 :safe
 \p{_Perl_Nchar}


### PR DESCRIPTION
This is an attempt to finally get the trimmed() work into perl.

I mostly took the work of @leonerd and @scottchiefbaker and converted to builtin:: from the original 'use feature'.

Since I don't know what I'm doing around XS code and builtin::, I just mashed things together; as a result, some porting tests fail.  Suggestions for doing it right are welcome on #p5p irc