### PR TITLE
Document Hash::Util::hash_value($string, $seed)

### DIFF
--- a/ext/Hash-Util/lib/Hash/Util.pm
+++ b/ext/Hash-Util/lib/Hash/Util.pm
@@ -510,13 +510,22 @@ Perl has been built with. Possible sizes may be but are not limited to
 =item B<hash_value>
 
     my $hash_value = hash_value($string);
+    my $hash_value = hash_value($string, $seed);
 
-hash_value() returns the current perl's internal hash value for a given
-string.
+C<hash_value($string)>
+returns
+the current perl's internal hash value for a given string.
+C<hash_value($string, $seed)>
+returns the hash value as if computed with a different seed.
+If the custom seed is too short, the function errors out.
+The minimum length of the seed is implementation-dependent.
 
-Returns a 32 bit integer representing the hash value of the string passed
-in. This value is only reliable for the lifetime of the process. It may
-be different depending on invocation, environment variables,  perl version,
+Returns a 32-bit integer
+representing the hash value of the string passed in.
+The 1-parameter value is only reliable
+for the lifetime of the process.
+It may be different
+depending on invocation, environment variables, perl version,
 architectures, and build options.
 
 B<Note that the hash value of a given string is sensitive information>:
@@ -832,6 +841,9 @@ Ing-Simmons and Jeffrey Friedl.
 hv_store() is from Array::RefElem, Copyright 2000 Gisle Aas.
 
 Additional code by Yves Orton.
+
+Description of C<hash_value($string, $seed)>
+by Christopher Yeleighton <ne01026@shark.2a.pl>
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
Returns the hash value as if computed with a different seed.