### PR TITLE
enable x64 -Duselongdouble build for all mingw-runtime versions.

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -2188,7 +2188,7 @@ You probably want to be using L<C</INT2PTR>> instead.
    here, so no allowance is being made for mingw.org
    compilers at this stage. -- sisyphus January 2021
 */
-#if defined(USE_QUADMATH) && defined(__MINGW64__)
+#if (defined(USE_LONG_DOUBLE) || defined(USE_QUADMATH)) && defined(__MINGW64__)
    /* 64-bit build, mingw-w64 compiler only */
    typedef NVTYPE NV __attribute__ ((aligned(8)));
 #else


### PR DESCRIPTION
See https://github.com/Perl/perl5/issues/18363

Reading through that ticket, I'm no longer sure if the problem with x64 -Duselongdouble builds begins with runtime v7, or runtime v8 or runtime v9.

I could check if need be - but I'm hopeful that the blanket inclusion of all x64 -Duselongdouble builds (irrespective of runtime version) will be quite acceptable.
In saying that, I'm assuming that the directive:
```
typedef NVTYPE NV __attribute__ ((aligned(8)));
```
comes at zero cost if it's not actually needed.
To be clear, it *is* needed for all runtime versions wrt x64 -Dusequadmath builds.
For x64 -Duselongdouble builds, the directive is apparently unnecessary until (somewhere) later than v6.