### PR TITLE
regcomp.c: remove experimental status from variable length lookbehind

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -857,7 +857,6 @@ sub parse_config_h {
                 }
 
                 # Enclose what we think are symbols with C<...>.
-                no warnings 'experimental::vlb';
                 s/ (*nlb:<)
                    (
                         # Any word followed immediately with parens or

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -27,6 +27,15 @@ here, but most should go in the L</Performance Enhancements> section.
 
 [ List each enhancement as a =head2 entry ]
 
+=head2 Variable length lookbehind is no longer experimental.
+
+From perl version 5.30 variable length lookbehind was allowed but
+marked as experimental and would generate warnings when used. In
+perl version 5.35.10 various bugs in the feature were fixed and the
+experimental flag was removed. Note that prior to this release there
+were bugs relating to alternations that may cause the construct to
+match when it should not or vice versa. These bugs have been fixed.
+
 =head1 Security
 
 XXX Any security-related notices go here.  In particular, any security

--- a/pod/perlexperiment.pod
+++ b/pod/perlexperiment.pod
@@ -102,21 +102,6 @@ See also: L<perlref/Declaring a Reference to a Variable>
 The ticket for this experiment is
 L<[perl #12726]|https://github.com/Perl/perl5/issues/12726>.
 
-=item (Limited) Variable-length look-behind
-
-Introduced in Perl 5.30.0.
-
-Variability of up to 255 characters is handled.
-
-Using this feature triggers warnings in the category
-C<experimental::vlb>.
-
-The ticket for this experiment is
-L<[perl #18756]|https://github.com/Perl/perl5/issues/18756>.
-
-See also: L<perlre/(*positive_lookbehind:I<pattern>)> and
-L<perlre/(*negative_lookbehind:I<pattern>)>
-
 =item Unicode private use character hooks
 
 Introduced in Perl 5.30.0.
@@ -307,6 +292,12 @@ Accepted in Perl 5.36.0
 =item Subroutine signatures
 
 Introduced in Perl 5.20.0
+
+Accepted in Perl 5.36.0
+
+=item (Limited) Variable-length look-behind
+
+Introduced in Perl 5.30.0.
 
 Accepted in Perl 5.36.0
 

--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -1651,20 +1651,15 @@ matches a word that follows a tab, without including the tab in C<$&>.
 
 Prior to Perl 5.30, it worked only for fixed-width lookbehind, but
 starting in that release, it can handle variable lengths from 1 to 255
-characters as an experimental feature.  The feature is enabled
-automatically if you use a variable length lookbehind assertion, but
-will raise a warning at pattern compilation time, unless turned off, in
-the C<experimental::vlb> category.  This is to warn you that the exact
-behavior is subject to change should feedback from actual use in the
-field indicate to do so; or even complete removal if the problems found
-are not practically surmountable.  You can achieve close to pre-5.30
-behavior by fatalizing warnings in this category.
+characters as an experimental feature, in Perl 5.35.10 the feature was
+changed to no longer be experimental. Note that prior to this release
+the feature was buggy and would match (or not) when it shouldn't.
 
 There is a special form of this construct, called C<\K>
 (available since Perl 5.10.0), which causes the
 regex engine to "keep" everything it had matched prior to the C<\K> and
-not include it in C<$&>. This effectively provides non-experimental
-variable-length lookbehind of any length.
+not include it in C<$&>. This effectively provides variable-length
+lookbehind of any length.
 
 And, there is a technique that can be used to handle variable length
 lookbehinds on earlier releases, and longer than 255 characters.  It is
@@ -1711,14 +1706,9 @@ matches any occurrence of "foo" that does not follow "bar".
 
 Prior to Perl 5.30, it worked only for fixed-width lookbehind, but
 starting in that release, it can handle variable lengths from 1 to 255
-characters as an experimental feature.  The feature is enabled
-automatically if you use a variable length lookbehind assertion, but
-will raise a warning at pattern compilation time, unless turned off, in
-the C<experimental::vlb> category.  This is to warn you that the exact
-behavior is subject to change should feedback from actual use in the
-field indicate to do so; or even complete removal if the problems found
-are not practically surmountable.  You can achieve close to pre-5.30
-behavior by fatalizing warnings in this category.
+characters as an experimental feature, in Perl 5.35.10 the feature was
+changed to no longer be experimental. Note that prior to this release
+the feature was buggy and would match (or not) when it shouldn't.
 
 There is a technique that can be used to handle variable length
 lookbehinds on earlier releases, and longer than 255 characters.  It is

--- a/regcomp.c
+++ b/regcomp.c
@@ -6084,9 +6084,6 @@ S_study_chunk(pTHX_ RExC_state_t *pRExC_state, regnode **scanp,
                      * extension) */
                     if (deltanext) {
                         scan->next_off = deltanext;
-                        ckWARNexperimental(RExC_parse,
-                            WARN_EXPERIMENTAL__VLB,
-                            "Variable length lookbehind is experimental");
                     }
                     scan->flags = (U8)minnext + deltanext;
                 }

--- a/t/re/alpha_assertions.t
+++ b/t/re/alpha_assertions.t
@@ -3,7 +3,6 @@
 use strict;
 use warnings;
 no warnings 'once';
-no warnings 'experimental::vlb';
 
 # This tests that the alphabetic assertions, like '(*atomic:...) work
 # It just sets a flag and calls regexp.t which will run through its test

--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -6,7 +6,6 @@
 
 use strict;
 use warnings;
-no warnings 'experimental::vlb';
 use 5.010;
 
 sub run_tests;
@@ -2089,8 +2088,7 @@ EOP
         fresh_perl_is('m m0*0+\Rm', "",{},"Undefined behavior in address sanitizer");
     }
     {   # [perl #133642]
-        fresh_perl_is('no warnings "experimental::vlb";
-                      m/((?<=(0?)))/', "",{},"Was getting 'Double free'");
+        fresh_perl_is('m/((?<=(0?)))/', "",{},"Was getting 'Double free'");
     }
     {   # [perl #133782]
         # this would panic on DEBUGGING builds

--- a/t/re/regexp.t
+++ b/t/re/regexp.t
@@ -87,7 +87,6 @@ sub _comment {
 
 use strict;
 use warnings FATAL=>"all";
-no warnings 'experimental::vlb';
 our ($bang, $ffff, $nulnul); # used by the tests
 our ($qr, $skip_amp, $qr_embed, $qr_embed_thr, $regex_sets, $alpha_assertions, $no_null); # set by our callers
 


### PR DESCRIPTION
Remove experimental status for lookbehind. This patch should not be applied until https://github.com/Perl/perl5/pull/19442 is merged.