### PR TITLE
Reduce scope of experimental warnings with lookbehind

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -27,6 +27,20 @@ here, but most should go in the L</Performance Enhancements> section.
 
 [ List each enhancement as a =head2 entry ]
 
+=head2 Variable length lookbehind is mostly no longer considered experimental.
+
+Prior to this release any form of variable length lookbehind was
+considered experimental. With this release the experimental status has
+been reduced to cover only lookbehind that contains capturing parenthesis.
+This is because it is not clear if
+
+    "aaz"=~/(?=z)(?<=(a|aa))/
+
+should match and leave $1 equaling "a" or "aa". Currently it will match
+the longest possible alternative, "aa". We are confident that the overall
+construct will now match only when it should, we are not confident that we
+will keep the current "longest match" behavior.
+
 =head1 Security
 
 XXX Any security-related notices go here.  In particular, any security

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -7628,6 +7628,26 @@ You can also say
 to apply C</aa> to all regular expressions compiled within its scope.
 See L<re>.
 
+=item Variable length positive lookbehind with capturing is experimental in regex m/%s/
+
+(W) Variable length positive lookbehind with capturing is not well defined. This
+warning alerts you to the fact that you are using a construct which may
+change in a future version of perl. See the
+L<< documentation of Positive Lookbehind in perlre|perlre/"C<(?<=I<pattern>)>" >>
+for details. You may silence this warning with the following:
+
+    no warnings 'experimental::vlb';
+
+=item Variable length negative lookbehind with capturing is experimental in regex m/%s/
+
+(W) Variable length negative lookbehind with capturing is not well defined. This
+warning alerts you to the fact that you are using a construct which may
+change in a future version of perl. See the
+L<< documentation of Negative Lookbehind in perlre|perlre/"C<(?<!I<pattern>)>" >>
+for details. You may silence this warning with the following:
+
+    no warnings 'experimental::vlb';
+
 =item "%s" variable %s masks earlier declaration in same %s
 
 (W shadow) A "my", "our" or "state" variable has been redeclared in the

--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -1652,13 +1652,27 @@ matches a word that follows a tab, without including the tab in C<$&>.
 Prior to Perl 5.30, it worked only for fixed-width lookbehind, but
 starting in that release, it can handle variable lengths from 1 to 255
 characters as an experimental feature.  The feature is enabled
-automatically if you use a variable length lookbehind assertion, but
-will raise a warning at pattern compilation time, unless turned off, in
-the C<experimental::vlb> category.  This is to warn you that the exact
-behavior is subject to change should feedback from actual use in the
-field indicate to do so; or even complete removal if the problems found
-are not practically surmountable.  You can achieve close to pre-5.30
-behavior by fatalizing warnings in this category.
+automatically if you use a variable length positive lookbehind assertion.
+
+In Perl 5.35.10 the scope of the experimental nature of this construct
+has been reduced, and experimental warnings will only be produced when
+the construct contains capturing parenthesis. The warnings will be
+raised at pattern compilation time, unless turned off, in the
+C<experimental::vlb> category.  This is to warn you that the exact
+contents of capturing buffers in a variable length positive lookbehind
+is not well defined and is subject to change in a future release of perl.
+
+Currently if you use capture buffers inside of a positive variable length
+lookbehind the result will be the longest and thus leftmost match possible.
+This means that
+
+    "aax" =~ /(?=x)(?<=(a|aa))/
+    "aax" =~ /(?=x)(?<=(aa|a))/
+    "aax" =~ /(?=x)(?<=(a{1,2}?)/
+    "aax" =~ /(?=x)(?<=(a{1,2})/
+
+will all result in C<$1> containing C<"aa">. It is possible in a future
+release of perl we will change this behavior.
 
 There is a special form of this construct, called C<\K>
 (available since Perl 5.10.0), which causes the
@@ -1712,16 +1726,44 @@ matches any occurrence of "foo" that does not follow "bar".
 Prior to Perl 5.30, it worked only for fixed-width lookbehind, but
 starting in that release, it can handle variable lengths from 1 to 255
 characters as an experimental feature.  The feature is enabled
-automatically if you use a variable length lookbehind assertion, but
-will raise a warning at pattern compilation time, unless turned off, in
-the C<experimental::vlb> category.  This is to warn you that the exact
-behavior is subject to change should feedback from actual use in the
-field indicate to do so; or even complete removal if the problems found
-are not practically surmountable.  You can achieve close to pre-5.30
-behavior by fatalizing warnings in this category.
+automatically if you use a variable length negative lookbehind assertion.
+
+In Perl 5.35.10 the scope of the experimental nature of this construct
+has been reduced, and experimental warnings will only be produced when
+the construct contains capturing parentheses. The warnings will be
+raised at pattern compilation time, unless turned off, in the
+C<experimental::vlb> category.  This is to warn you that the exact
+contents of capturing buffers in a variable length negative lookbehind
+is not well defined and is subject to change in a future release of perl.
+
+Currently if you use capture buffers inside of a negative variable length
+lookbehind the result may not be what you expect, for instance:
+
+    say "axfoo"=~/(?=foo)(?<!(a|ax)(?{ say $1 }))/ ? "y" : "n";
+
+will output the following:
+
+    a
+    no
+
+which does not make sense as this should print out "ax" as the "a" does
+not line up at the correct place. Another example would be:
+
+    say "yes: '$1-$2'" if "aayfoo"=~/(?=foo)(?<!(a|aa)(a|aa)x)/;
+
+will output the following:
+
+    yes: 'aa-a'
+
+It is possible in a future release of perl we will change this behavior
+so both of these examples produced more reasonable output.
+
+Note that we are confident that the construct will match and reject
+patterns appropriately, the undefined behavior strictly relates to the
+value of the capture buffer during or after matching.
 
 There is a technique that can be used to handle variable length
-lookbehinds on earlier releases, and longer than 255 characters.  It is
+lookbehind on earlier releases, and longer than 255 characters.  It is
 described in
 L<http://www.drregex.com/2019/02/variable-length-lookbehinds-actually.html>.
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -4444,21 +4444,23 @@ S_rck_elide_nothing(pTHX_ regnode *node)
 
 /* the return from this sub is the minimum length that could possibly match */
 STATIC SSize_t
-S_study_chunk(pTHX_ RExC_state_t *pRExC_state, regnode **scanp,
-                        SSize_t *minlenp, SSize_t *deltap,
-                        regnode *last,
-                        scan_data_t *data,
-                        I32 stopparen,
-                        U32 recursed_depth,
-                        regnode_ssc *and_withp,
-                        U32 flags, U32 depth, bool was_mutate_ok)
-                        /* scanp: Start here (read-write). */
-                        /* deltap: Write maxlen-minlen here. */
-                        /* last: Stop before this one. */
-                        /* data: string data about the pattern */
-                        /* stopparen: treat close N as END */
-                        /* recursed: which subroutines have we recursed into */
-                        /* and_withp: Valid if flags & SCF_DO_STCLASS_OR */
+S_study_chunk(pTHX_
+    RExC_state_t *pRExC_state,
+    regnode **scanp,        /* Start here (read-write). */
+    SSize_t *minlenp,
+    SSize_t *deltap,        /* Write maxlen-minlen here. */
+    regnode *last,          /* Stop before this one. */
+    scan_data_t *data,      /* string data about the pattern */
+    I32 stopparen,          /* treat CLOSE-N as END, see GOSUB */
+    U32 recursed_depth,     /* how deep have we recursed via GOSUB */
+    regnode_ssc *and_withp, /* Valid if flags & SCF_DO_STCLASS_OR */
+    U32 flags,              /* flags controlling this call, see SCF_ flags */
+    U32 depth,              /* how deep have we recursed period */
+    bool was_mutate_ok      /* TRUE if in-place optimizations are allowed.
+                               FALSE only if the caller (recursively) was
+                               prohibited from modifying the regops, because
+                               a higher caller is holding a ptr to them. */
+)
 {
     SSize_t final_minlen;
     /* There must be at least this number of characters to match */

--- a/regcomp.c
+++ b/regcomp.c
@@ -4611,7 +4611,7 @@ S_study_chunk(pTHX_
                     ssc_init_zero(pRExC_state, &accum);
 
                 while (OP(scan) == code) {
-                    SSize_t deltanext, minnext, fake;
+                    SSize_t deltanext, minnext, fake_last_close = 0;
                     I32 f = 0;
                     regnode_ssc this_class;
 
@@ -4624,7 +4624,7 @@ S_study_chunk(pTHX_
                         data_fake.last_closep = data->last_closep;
                     }
                     else
-                        data_fake.last_closep = &fake;
+                        data_fake.last_closep = &fake_last_close;
 
                     data_fake.pos_delta = delta;
                     next = regnext(scan);
@@ -6040,7 +6040,8 @@ S_study_chunk(pTHX_
                    In this case we can't do fixed string optimisation.
                 */
 
-                SSize_t deltanext, minnext, fake = 0;
+                SSize_t deltanext, minnext;
+                SSize_t fake_last_close = 0;
                 regnode *nscan;
                 regnode_ssc intrnl;
                 int f = 0;
@@ -6051,7 +6052,7 @@ S_study_chunk(pTHX_
                     data_fake.last_closep = data->last_closep;
                 }
                 else
-                    data_fake.last_closep = &fake;
+                    data_fake.last_closep = &fake_last_close;
                 data_fake.pos_delta = delta;
                 if ( flags & SCF_DO_STCLASS && !scan->flags
                      && OP(scan) == IFMATCH ) { /* Lookahead */
@@ -6127,7 +6128,7 @@ S_study_chunk(pTHX_
                    length of the pattern, something we won't know about
                    until after the recurse.
                 */
-                SSize_t deltanext, fake = 0;
+                SSize_t deltanext, fake_last_close = 0;
                 regnode *nscan;
                 regnode_ssc intrnl;
                 int f = 0;
@@ -6151,7 +6152,7 @@ S_study_chunk(pTHX_
                     }
                 }
                 else
-                    data_fake.last_closep = &fake;
+                    data_fake.last_closep = &fake_last_close;
                 data_fake.flags = 0;
                 data_fake.substrs[0].flags = 0;
                 data_fake.substrs[1].flags = 0;
@@ -6325,7 +6326,8 @@ S_study_chunk(pTHX_
 
                 for ( word=1 ; word <= trie->wordcount ; word++)
                 {
-                    SSize_t deltanext=0, minnext=0, f = 0, fake;
+                    SSize_t deltanext = 0, minnext = 0, f = 0;
+                    SSize_t fake_last_close = 0;
                     regnode_ssc this_class;
 
                     StructCopy(&zero_scan_data, &data_fake, scan_data_t);
@@ -6334,7 +6336,7 @@ S_study_chunk(pTHX_
                         data_fake.last_closep = data->last_closep;
                     }
                     else
-                        data_fake.last_closep = &fake;
+                        data_fake.last_closep = &fake_last_close;
                     data_fake.pos_delta = delta;
                     if (flags & SCF_DO_STCLASS) {
                         ssc_init(pRExC_state, &this_class);

--- a/regcomp.c
+++ b/regcomp.c
@@ -7987,7 +7987,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
        data in the pattern. If there is then we can use it for optimisations */
     if (!(RExC_seen & REG_TOP_LEVEL_BRANCHES_SEEN)) { /*  Only one top-level choice.
                                                   */
-        SSize_t fake;
+        SSize_t fake_deltap;
         STRLEN longest_length[2];
         regnode_ssc ch_class; /* pointed to by data */
         int stclass_flag;
@@ -8141,7 +8141,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
          * MAIN ENTRY FOR study_chunk() FOR m/PATTERN/
          * (NO top level branches)
          */
-        minlen = study_chunk(pRExC_state, &first, &minlen, &fake,
+        minlen = study_chunk(pRExC_state, &first, &minlen, &fake_deltap,
                              scan + RExC_size, /* Up to end */
             &data, -1, 0, NULL,
             SCF_DO_SUBSTR | SCF_WHILEM_VISITED_POS | stclass_flag
@@ -8254,7 +8254,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
     }
     else {
         /* Several toplevels. Best we can is to set minlen. */
-        SSize_t fake;
+        SSize_t fake_deltap;
         regnode_ssc ch_class;
         SSize_t last_close = 0;
 
@@ -8271,7 +8271,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
          * (patterns WITH top level branches)
          */
         minlen = study_chunk(pRExC_state,
-            &scan, &minlen, &fake, scan + RExC_size, &data, -1, 0, NULL,
+            &scan, &minlen, &fake_deltap, scan + RExC_size, &data, -1, 0, NULL,
             SCF_DO_STCLASS_AND|SCF_WHILEM_VISITED_POS|(restudied
                                                       ? SCF_TRIE_DOING_RESTUDY
                                                       : 0),

--- a/t/re/reg_mesg.t
+++ b/t/re/reg_mesg.t
@@ -142,6 +142,7 @@ my @death =
  '/(?<= a{200}b{55})/' =>  'Lookbehind longer than 255 not implemented in regex m/(?<= a{200}b{55})/',
 
  '/(?<= x{1000})/' => 'Lookbehind longer than 255 not implemented in regex m/(?<= x{1000})/',
+ '/(?<= (?&x))(?<x>x+)/' => 'Lookbehind longer than 255 not implemented in regex m/(?<= (?&x))(?<x>x+)/',
 
  '/(?@)/' => 'Sequence (?@...) not implemented {#} m/(?@{#})/',
 
@@ -733,6 +734,25 @@ my @experimental_regex_sets = (
     '/noutf8 ネ (?[ [\tネ] ])/' => 'The regex_sets feature is experimental {#} m/noutf8 ネ (?[{#} [\tネ] ])/',
 );
 
+my @experimental_vlb = (
+    '/(?<=(p|qq|rrr))/' => 'Variable length positive lookbehind with capturing' .
+                           ' is experimental {#} m/(?<=(p|qq|rrr)){#}/',
+    '/(?<!(p|qq|rrr))/' => 'Variable length negative lookbehind with capturing' .
+                           ' is experimental {#} m/(?<!(p|qq|rrr)){#}/',
+    '/(?| (?=(foo)) | (?<=(foo)|p) )/'
+            => 'Variable length positive lookbehind with capturing' .
+               ' is experimental {#} m/(?| (?=(foo)) | (?<=(foo)|p) ){#}/',
+    '/(?| (?=(foo)) | (?<=(foo)|p) )/x'
+            => 'Variable length positive lookbehind with capturing' .
+               ' is experimental {#} m/(?| (?=(foo)) | (?<=(foo)|p) ){#}/',
+    '/(?| (?=(foo)) | (?<!(foo)|p) )/'
+            => 'Variable length negative lookbehind with capturing' .
+               ' is experimental {#} m/(?| (?=(foo)) | (?<!(foo)|p) ){#}/',
+    '/(?| (?=(foo)) | (?<!(foo)|p) )/x'
+            => 'Variable length negative lookbehind with capturing' .
+               ' is experimental {#} m/(?| (?=(foo)) | (?<!(foo)|p) ){#}/',
+);
+
 my @wildcard = (
     'm!(?[\p{name=/KATAKANA/}])$!' =>
     [
@@ -829,11 +849,13 @@ for my $strict ("",  "no warnings 'experimental::re_strict'; use re 'strict';") 
         }
     }
 
-    foreach my $ref (\@warning_tests,
-                     \@experimental_regex_sets,
-                     \@wildcard,
-                     \@deprecated)
-    {
+    foreach my $ref (
+        \@warning_tests,
+        \@experimental_regex_sets,
+        \@wildcard,
+        \@deprecated,
+        \@experimental_vlb,
+    ){
         my $warning_type;
         my $turn_off_warnings = "";
         my $default_on;
@@ -852,6 +874,10 @@ for my $strict ("",  "no warnings 'experimental::re_strict'; use re 'strict';") 
         }
         elsif ($ref == \@wildcard) {
             $warning_type = 'experimental::regex_sets, experimental::uniprop_wildcards';
+            $default_on = 1;
+        }
+        elsif ($ref == \@experimental_vlb) {
+            $warning_type = 'experimental::vlb';
             $default_on = 1;
         }
         else {


### PR DESCRIPTION
The only case where we need to warn about variable length lookbehind is
when we are doing postive lookbehind and capturing buffers are involved.