### PR TITLE
Update perldebug.pod to explain detection of running under the debugger

### DIFF
--- a/pod/perldebug.pod
+++ b/pod/perldebug.pod
@@ -92,7 +92,7 @@ debugger:
         # running under the debugger
     }
 
-See C<perldoc -v '$^P'> for more information on the variable.
+See L<perlvar/$^P> for more information on the variable.
 
 =head2 Debugger Commands
 

--- a/pod/perldebug.pod
+++ b/pod/perldebug.pod
@@ -84,6 +84,16 @@ Debug a given program using threads (experimental).
 
 =back
 
+If Perl is called with the C<-d> switch, the variable C<$^P> will hold a true
+value. This is useful if you need to know if your code is running under the
+debugger:
+
+    if ( $^P ) {
+        # running under the debugger
+    }
+
+See C<perldoc -v '$^P'> for more information on the variable.
+
 =head2 Debugger Commands
 
 The interactive debugger understands the following commands:


### PR DESCRIPTION
Perl discussion on P5P, this updates`pod/perldebug.pod` to explain using the `$^P` variable to detect if you're running under the debugger.