### PR TITLE
fix __CALLER__ handling in Attribute::Handlers

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3019,6 +3019,7 @@ dist/Attribute-Handlers/demo/demo_rawdata.pl		Attribute::Handlers demo
 dist/Attribute-Handlers/demo/Descriptions.pm		Attribute::Handlers demo
 dist/Attribute-Handlers/demo/MyClass.pm			Attribute::Handlers demo
 dist/Attribute-Handlers/lib/Attribute/Handlers.pm	Attribute::Handlers
+dist/Attribute-Handlers/t/caller.t			See if Attribute::Handlers works
 dist/Attribute-Handlers/t/constants.t			Test constants and Attribute::Handlers
 dist/Attribute-Handlers/t/data_convert.t		Test attribute data conversion
 dist/Attribute-Handlers/t/linerep.t			See if Attribute::Handlers works

--- a/dist/Attribute-Handlers/lib/Attribute/Handlers.pm
+++ b/dist/Attribute-Handlers/lib/Attribute/Handlers.pm
@@ -687,13 +687,13 @@ and need to export their attributes to any module that calls them. To
 facilitate this, Attribute::Handlers recognizes a special "pseudo-class" --
 C<__CALLER__>, which may be specified as the qualifier of an attribute:
 
-    package Tie::Me::Kangaroo:Down::Sport;
+    package Tie::Me::Kangaroo::Down::Sport;
 
     use Attribute::Handlers autotie =>
 	 { '__CALLER__::Roo' => __PACKAGE__ };
 
 This causes Attribute::Handlers to define the C<Roo> attribute in the package
-that imports the Tie::Me::Kangaroo:Down::Sport module.
+that imports the Tie::Me::Kangaroo::Down::Sport module.
 
 Note that it is important to quote the __CALLER__::Roo identifier because
 a bug in perl 5.8 will refuse to parse it and cause an unknown error.

--- a/dist/Attribute-Handlers/t/caller.t
+++ b/dist/Attribute-Handlers/t/caller.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+BEGIN {
+    package MyTie;
+    BEGIN { $INC{'MyTie.pm'} = 1 }
+
+    use Attribute::Handlers autotie => { '__CALLER__::Mine' => __PACKAGE__ };
+
+    sub TIESCALAR {
+        my ($class, $data) = @_;
+        bless \$data, $class;
+    }
+
+    sub FETCH { ${$_[0]} }
+    sub STORE { ${$_[0]} = $_[1] }
+}
+
+use MyTie;
+
+eval q{
+    my $var :Mine;
+    1;
+};
+::is $@, '',
+    'attribute available in caller';
+
+{
+    package Pack2;
+    use MyTie;
+
+    eval q{
+        my $var :Mine;
+        1;
+    };
+    ::is $@, '',
+        'attribute available in caller of second package';
+}


### PR DESCRIPTION
Attribute::Handlers supports a __CALLER__ token when declaring autotie
attributes. This is meant to create the attribute in the caller of the
class it is used in. The only reliable way for this to work requires
creating an import method in the calling class. Instead,
Attribute::Handlers was trying to walk up the call stack from when its
own import would be called. This used to partially work, at least enough
to be deceptive. Checking the caller deeper in the call stack of
Attribute::Handlers would allow the __CALLER__ attribute to work only
for the first time the module using it was called. Any future users
would not re-compile the module, so they would not re-invoke
Attribute::Handlers' import method, and would not get the autotie
attribute defined.

This attempt to find the caller's caller also started failing as of
f6387cff9cb31db4cf18c8641917ea4639ac2b65.

Fix the handling of __CALLER__ by creating an import method in the
caller if it is used, so that users of the calling module will reliably
get the attribute defined.