### PR TITLE
utf8.h: fixup signed/unsigned warning from UTF8_IS_REPLACEMENT

### DIFF
--- a/utf8.h
+++ b/utf8.h
@@ -917,9 +917,10 @@ representation.
  */
 #define UNICODE_REPLACEMENT		0xFFFD
 #define UNICODE_IS_REPLACEMENT(uv)  UNLIKELY((UV) (uv) == UNICODE_REPLACEMENT)
-#define UTF8_IS_REPLACEMENT(s, send)                                        \
-    UNLIKELY(   ((send) - (s)) >= (sizeof(REPLACEMENT_CHARACTER_UTF8) - 1)  \
-             && memEQ((s), REPLACEMENT_CHARACTER_UTF8,                      \
+#define UTF8_IS_REPLACEMENT(s, send)                                         \
+    UNLIKELY(                                                                \
+        ((send) - (s)) >= ((SSize_t)(sizeof(REPLACEMENT_CHARACTER_UTF8) - 1))\
+             && memEQ((s), REPLACEMENT_CHARACTER_UTF8,                       \
                       sizeof(REPLACEMENT_CHARACTER_UTF8) - 1))
 
 /* Max legal code point according to Unicode */


### PR DESCRIPTION
Added a SSize_t cast to the sizeof() call.