### PR TITLE
Fix GH Issue #19472: read warnings from open($fh,">",\(my $x))

### DIFF
--- a/doio.c
+++ b/doio.c
@@ -639,6 +639,16 @@ Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len,
                 goto say_false;
             }
 #endif /* USE_STDIO */
+            if (SvROK(*svp) && !sv_isobject(*svp)) {
+                /* if they pass in a reference and its not an object
+                 * and the reference is to undef, "autovivify" it to
+                 * the empty string. See GH Issue #19472
+                 */
+                SV *sv= SvRV(*svp);
+                if (!SvOK(sv) && !SvREADONLY(sv))
+                    sv_setpvs(MUTABLE_SV(sv),"");
+            }
+
             p = (SvOK(*svp) || SvGMAGICAL(*svp)) ? SvPV(*svp, nlen) : NULL;
 
             if (p && !IS_SAFE_PATHNAME(p, nlen, "open")) {

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4657,8 +4657,8 @@ L<C<seek>|/seek FILEHANDLE,POSITION,WHENCE> to do the reading.
 =item Opening a filehandle into an in-memory scalar
 
 You can open filehandles directly to Perl scalars instead of a file or
-other resource external to the program. To do so, provide a reference to
-that scalar as the third argument to C<open>, like so:
+other resource external to the program. To do so, provide an unblessed
+reference to that scalar as the third argument to C<open>, like so:
 
  open(my $memory, ">", \$var)
      or die "Can't open memory file: $!";
@@ -4673,6 +4673,14 @@ To (re)open C<STDOUT> or C<STDERR> as an in-memory file, close it first:
 The scalars for in-memory files are treated as octet strings: unless
 the file is being opened with truncation the scalar may not contain
 any code points over 0xFF.
+
+Be aware that attempting to open a reference to a readonly scalar will
+cause a warning and the open to fail.
+
+Prior to Perl version 5.36.0, passing in a reference to an undef scalar
+could cause strange warnings. As of Perl version 5.36.0, provided the
+reference is unblessed, the scalar will be "autovivified" to be an empty
+string, even for read mode open operations.
 
 Opening in-memory files I<can> fail for a variety of reasons.  As with
 any other C<open>, check the return value for success.


### PR DESCRIPTION
We produce all kinds of warnings if someone opens a scalar reference
that is undef. Prior to this we handled write operations ok, at
least in blead, but read operations would produce a plethora of
warnings. To me this analagous to treating an undef var as hash
and trying to read from it, we autovivify the undef var to be
a hash. So in this case we should just "autovivify" the referenced
scalar to be an empty string.

Eg before this patch:

./perl -Ilib -wle'open my $fh,"+>", \(my $v); my @x=<$fh>; print 0+@x'
Use of uninitialized value $fh in <HANDLE> at -e line 1.
Use of uninitialized value $fh in <HANDLE> at -e line 1.
Use of uninitialized value $fh in <HANDLE> at -e line 1.
Use of uninitialized value $fh in <HANDLE> at -e line 1.
Use of uninitialized value $fh in <HANDLE> at -e line 1.
Use of uninitialized value $fh in <HANDLE> at -e line 1.
Use of uninitialized value $fh in <HANDLE> at -e line 1.
0

After it:
./perl -Ilib -wle'open my $fh,"+>", \(my $v); my @x=<$fh>; print 0+@x'
0