### PR TITLE
Fix possible null pointer dereferences in Perl_my_strtod()

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4633,6 +4633,7 @@ ext/XS-APItest/t/mro.t		Test mro plugin api
 ext/XS-APItest/t/multicall.t	XS::APItest: test MULTICALL macros
 ext/XS-APItest/t/my_cxt.t	XS::APItest: test MY_CXT interface
 ext/XS-APItest/t/my_exit.t	XS::APItest: test my_exit
+ext/XS-APItest/t/my_strtod.t	XS::APItest: test my_strtod
 ext/XS-APItest/t/newCONSTSUB.t	XS::APItest: test newCONSTSUB(_flags)
 ext/XS-APItest/t/newDEFSVOP.t	XS::APItest: test newDEFSVOP
 ext/XS-APItest/t/Null.pm	Helper for ./blockhooks.t

--- a/ext/XS-APItest/numeric.xs
+++ b/ext/XS-APItest/numeric.xs
@@ -59,3 +59,18 @@ grok_atoUV(number, endsv)
 	    PUSHs(sv_2mortal(newSViv(0)));
 	  }
 	}
+
+void
+my_strtod(s)
+        SV *s
+    PREINIT:
+        SV *sv = newSVsv(s);
+        char *endptr = NULL;
+        NV nv;
+    PPCODE:
+        nv = my_strtod(SvPV_force_nolen(sv), &endptr);
+        PUSHs(sv_2mortal(newSVnv(nv)));
+        if (endptr) {
+            sv_chop(sv, endptr);
+            PUSHs(sv_2mortal(sv));
+        }

--- a/ext/XS-APItest/t/my_strtod.t
+++ b/ext/XS-APItest/t/my_strtod.t
@@ -1,0 +1,16 @@
+#!perl -w
+use strict;
+
+use Test::More;
+use Config;
+use XS::APItest;
+
+my ($nv, $rest);
+
+# GH 19492 - d_strtod=undef build segfaults here
+($nv, $rest) = my_strtod('17.265625x');
+# Note that .265625 is 17/64 so it can be represented exactly
+is($nv, 17.265625, 'my_strtod("17.265625x", &e) returns 17.265625');
+is($rest, 'x', 'my_strtod("17.265625x", &e) sets e to "x"');
+
+done_testing();

--- a/numeric.c
+++ b/numeric.c
@@ -108,14 +108,14 @@ Perl_my_strtod(const char * const s, char **e)
 
     {
         NV result;
-        char ** end_ptr = NULL;
+        char * end_ptr;
 
-        *end_ptr = my_atof2(s, &result);
+        end_ptr = my_atof2(s, &result);
         if (e) {
-            *e = *end_ptr;
+            *e = end_ptr;
         }
 
-        if (! *end_ptr) {
+        if (! end_ptr) {
             result = 0.0;
         }
 


### PR DESCRIPTION
I found that `Perl_my_strtod()` apparently dereferences null pointer when `Perl_strtod` macro is not defined.

I couldn't test this, because I couldn't find when this code is actually used (even if configured with `-Ud_strtod`).