### PR TITLE
hv.c: ALWAYS perform in_collision check

### DIFF
--- a/hv.c
+++ b/hv.c
@@ -849,6 +849,7 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
         HeKEY_hek(entry) = save_hek_flags(key, klen, hash, flags);
     }
     HeVAL(entry) = val;
+    in_collision = cBOOL(*oentry != NULL);
 
 #ifdef PERL_HASH_RANDOMIZE_KEYS
     /* This logic semi-randomizes the insert order in a bucket.
@@ -856,7 +857,6 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
      * making it harder to see if there is a collision. We also
      * reset the iterator randomizer if there is one.
      */
-    in_collision = *oentry != NULL;
     if ( *oentry && PL_HASH_RAND_BITS_ENABLED) {
         PL_hash_rand_bits++;
         PL_hash_rand_bits= ROTL_UV(PL_hash_rand_bits,1);


### PR DESCRIPTION
This is a critical patch. Any perl built with the previous code
without PERL_HASH_RANDOMIZE_KEYS would never perform a key split!