### PR TITLE
perl.c: Remove run time docs and redundant support for -DH

### DIFF
--- a/perl.c
+++ b/perl.c
@@ -3360,7 +3360,6 @@ Perl_get_debug_opts(pTHX_ const char **s, bool givehelp)
       "  r  Regular expression parsing and execution\n"
       "  x  Syntax tree dump\n",
       "  u  Tainting checks\n"
-      "  H  Hash dump -- usurps values()\n"
       "  X  Scratchpad allocation\n"
       "  D  Cleaning up\n"
       "  S  Op slab allocation\n"
@@ -3384,7 +3383,13 @@ Perl_get_debug_opts(pTHX_ const char **s, bool givehelp)
 
     if (isALPHA(**s)) {
         /* if adding extra options, remember to update DEBUG_MASK */
-        static const char debopts[] = "psltocPmfrxuUHXDSTRJvCAqMBLiy";
+        /* Note that the ? indicates an unused slot. As the code below
+         * indicates the position in this list is important. You cannot
+         * change the order or delete a character from the list without
+         * impacting the definitions of all the other flags in perl.h
+         * However because the logic is guarded by isWORDCHAR we can
+         * fill in holes with non-wordchar characters instead. */
+        static const char debopts[] = "psltocPmfrxuU?XDSTRJvCAqMBLiy";
 
         for (; isWORDCHAR(**s); (*s)++) {
             const char * const d = strchr(debopts,**s);


### PR DESCRIPTION
In 2017 in fcd573e77ec68fbe3936ac1381654581fba8a64f Dave Mitchell
removed support for the -DH flag but missed this.

Part of the -D options parsing is positionally sensitive, so in order to
be able to remove the 'H' option entirely I had to use a placeholder
character, and I chose '?'. This is because it is not isWORDCHAR(),
which means the preceding logic prevents it from being chosen anyway,
and thus it should be safe.