### PR TITLE
improve test and debug hash randomization, and related improvements

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -512,7 +512,7 @@ See L<perlrun/PERL_HASH_SEED> and L<perlrun/PERL_PERTURB_KEYS> for
 details on the environment variables, and L<perlsec/Algorithmic
 Complexity Attacks> for further security details.
 
-The C<PERL_HASH_SEED> and PERL_PERTURB_KEYS> environment variables can
+The C<PERL_HASH_SEED> and C<PERL_PERTURB_KEYS> environment variables can
 be disabled by building configuring perl with
 C<-Accflags=-DNO_PERL_HASH_ENV>.
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -6202,6 +6202,7 @@ t/run/fresh_perl.t		Tests that require a fresh perl.
 t/run/locale.t		Tests related to locale handling
 t/run/noswitch.t		Test aliasing ARGV for other switch tests
 t/run/runenv.t			Test if perl honors its environment variables.
+t/run/runenv_hashseed.t	Test if perl honors PERL_HASH_SEED.
 t/run/script.t			See if script invocation works
 t/run/switch0.t			Test the -0 switch
 t/run/switcha.t			Test the -a switch

--- a/embed.fnc
+++ b/embed.fnc
@@ -2649,7 +2649,8 @@ Ap	|U32	|seed
 XpTo	|double	|drand48_r	|NN perl_drand48_t *random_state
 XpTo	|void	|drand48_init_r |NN perl_drand48_t *random_state|U32 seed
 : Only used in perl.c
-p	|void	|get_hash_seed        |NN unsigned char * const seed_buffer
+p	|void	|get_hash_seed  |NN unsigned char * const seed_buffer
+p	|void	|debug_hash_seed|bool via_debug_h
 : Used in doio.c, pp_hot.c, pp_sys.c
 p	|void	|report_evil_fh	|NULLOK const GV *gv
 : Used in doio.c, pp_hot.c, pp_sys.c

--- a/embed.h
+++ b/embed.h
@@ -1322,6 +1322,7 @@
 #define cvgv_set(a,b)		Perl_cvgv_set(aTHX_ a,b)
 #define cvstash_set(a,b)	Perl_cvstash_set(aTHX_ a,b)
 #define deb_stack_all()		Perl_deb_stack_all(aTHX)
+#define debug_hash_seed(a)	Perl_debug_hash_seed(aTHX_ a)
 #define defelem_target(a,b)	Perl_defelem_target(aTHX_ a,b)
 #define delete_eval_scope()	Perl_delete_eval_scope(aTHX)
 #define die_unwind(a)		Perl_die_unwind(aTHX_ a)

--- a/hv_func.h
+++ b/hv_func.h
@@ -91,15 +91,15 @@
 #else
 
 #define _PERL_HASH_FUNC         "SBOX32_WITH_" __PERL_HASH_FUNC
-/* note the 3 in the below code comes from the fact the seed to initialize the SBOX is 96 bits */
-#define _PERL_HASH_SEED_BYTES   ( __PERL_HASH_SEED_BYTES + (int)( 3 * sizeof(U32)) )
+/* note the 4 in the below code comes from the fact the seed to initialize the SBOX is 128 bits */
+#define _PERL_HASH_SEED_BYTES   ( __PERL_HASH_SEED_BYTES + (int)( 4 * sizeof(U32)) )
 
 #define _PERL_HASH_STATE_BYTES  \
     ( __PERL_HASH_STATE_BYTES + ( ( 1 + ( 256 * SBOX32_MAX_LEN ) ) * sizeof(U32) ) )
 
 #define _PERL_HASH_SEED_STATE(seed,state) STMT_START {                                      \
     __PERL_HASH_SEED_STATE(seed,state);                                                     \
-    sbox32_seed_state96(seed + __PERL_HASH_SEED_BYTES, state + __PERL_HASH_STATE_BYTES);    \
+    sbox32_seed_state128(seed + __PERL_HASH_SEED_BYTES, state + __PERL_HASH_STATE_BYTES);    \
 } STMT_END
 
 #define _PERL_HASH_WITH_STATE(state,str,len)                                            \

--- a/perl.h
+++ b/perl.h
@@ -4362,7 +4362,7 @@ Gid_t getegid (void);
 #define DEBUG_u_FLAG		0x00000800 /*   2048 */
 /* U is reserved for Unofficial, exploratory hacking */
 #define DEBUG_U_FLAG		0x00001000 /*   4096 */
-/* spare                                        8192 */
+#define DEBUG_h_FLAG            0x00002000 /*   8192 */
 #define DEBUG_X_FLAG		0x00004000 /*  16384 */
 #define DEBUG_D_FLAG		0x00008000 /*  32768 */
 #define DEBUG_S_FLAG		0x00010000 /*  65536 */
@@ -4401,6 +4401,7 @@ Gid_t getegid (void);
 #  define DEBUG_x_TEST_ UNLIKELY(PL_debug & DEBUG_x_FLAG)
 #  define DEBUG_u_TEST_ UNLIKELY(PL_debug & DEBUG_u_FLAG)
 #  define DEBUG_U_TEST_ UNLIKELY(PL_debug & DEBUG_U_FLAG)
+#  define DEBUG_h_TEST_ UNLIKELY(PL_debug & DEBUG_h_FLAG)
 #  define DEBUG_X_TEST_ UNLIKELY(PL_debug & DEBUG_X_FLAG)
 #  define DEBUG_D_TEST_ UNLIKELY(PL_debug & DEBUG_D_FLAG)
 #  define DEBUG_S_TEST_ UNLIKELY(PL_debug & DEBUG_S_FLAG)
@@ -4437,6 +4438,7 @@ Gid_t getegid (void);
 #  define DEBUG_x_TEST DEBUG_x_TEST_
 #  define DEBUG_u_TEST DEBUG_u_TEST_
 #  define DEBUG_U_TEST DEBUG_U_TEST_
+#  define DEBUG_h_TEST DEBUG_h_TEST_
 #  define DEBUG_X_TEST DEBUG_X_TEST_
 #  define DEBUG_D_TEST DEBUG_D_TEST_
 #  define DEBUG_S_TEST DEBUG_S_TEST_
@@ -4567,6 +4569,7 @@ Gid_t getegid (void);
 #  define DEBUG_x_TEST (0)
 #  define DEBUG_u_TEST (0)
 #  define DEBUG_U_TEST (0)
+#  define DEBUG_h_TEST (0)
 #  define DEBUG_X_TEST (0)
 #  define DEBUG_D_TEST (0)
 #  define DEBUG_S_TEST (0)

--- a/pod/perlrun.pod
+++ b/pod/perlrun.pod
@@ -411,6 +411,8 @@ B<-D14> is equivalent to B<-Dtls>):
       2048  u  Tainting checks
       4096  U  Unofficial, User hacking (reserved for private,
                unreleased use)
+      8192  h  Show hash randomization debug output (changes to
+               PL_hash_rand_bits and their origin)
      16384  X  Scratchpad allocation
      32768  D  Cleaning up
      65536  S  Op slab allocation

--- a/proto.h
+++ b/proto.h
@@ -871,6 +871,8 @@ PERL_CALLCONV I32	Perl_debstack(pTHX);
 #define PERL_ARGS_ASSERT_DEBSTACK
 PERL_CALLCONV I32	Perl_debstackptrs(pTHX);
 #define PERL_ARGS_ASSERT_DEBSTACKPTRS
+PERL_CALLCONV void	Perl_debug_hash_seed(pTHX_ bool via_debug_h);
+#define PERL_ARGS_ASSERT_DEBUG_HASH_SEED
 PERL_CALLCONV SV *	Perl_defelem_target(pTHX_ SV *sv, MAGIC *mg)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_DEFELEM_TARGET	\

--- a/sbox32_hash.h
+++ b/sbox32_hash.h
@@ -1390,71 +1390,20 @@
 #define case_1_SBOX32(hash,state,key) /**/
 #endif
 
-#define XORSHIFT96_set(r,x,y,z,t) STMT_START {          \
-    t = (x ^ ( x << 10 ) );                             \
-    x = y; y = z;                                       \
-    r = z = (z ^ ( z >> 26 ) ) ^ ( t ^ ( t >> 5 ) );    \
-} STMT_END
-
 #define XORSHIFT128_set(r,x,y,z,w,t) STMT_START {       \
     t = ( x ^ ( x << 5 ) );                             \
     x = y; y = z; z = w;                                \
     r = w = ( w ^ ( w >> 29 ) ) ^ ( t ^ ( t >> 12 ) );  \
 } STMT_END
 
-#define SBOX32_SCRAMBLE32(v,prime) STMT_START {  \
-    v ^= (v>>9);                        \
-    v ^= (v<<21);                       \
-    v ^= (v>>16);                       \
-    v *= prime;                         \
-    v ^= (v>>17);                       \
-    v ^= (v<<15);                       \
-    v ^= (v>>23);                       \
-} STMT_END
-
 #ifndef SBOX32_CHURN_ROUNDS 
-#define SBOX32_CHURN_ROUNDS 5
-#endif
-#ifndef SBOX32_SKIP_MASK
-#define SBOX32_SKIP_MASK 0x3
+#define SBOX32_CHURN_ROUNDS 128
 #endif
 
 #define _SBOX32_CASE(len,hash,state,key) \
     /* FALLTHROUGH */ \
     case len: hash ^= state[ 1 + ( 256 * ( len - 1 ) ) + key[ len - 1 ] ];
 
-
-SBOX32_STATIC_INLINE void sbox32_seed_state96 (
-    const U8 *seed_ch,
-    U8 *state_ch
-) {
-    const U32 *seed= (const U32 *)seed_ch;
-    U32 *state= (U32 *)state_ch;
-    U32 *state_cursor = state + 1;
-    U32 *sbox32_end = state + 1 + (256 * SBOX32_MAX_LEN);
-    U32 s0 = seed[0] ^ 0x68736168; /* sbox */
-    U32 s1 = seed[1] ^ 0x786f6273; /* hash */
-    U32 s2 = seed[2] ^ 0x646f6f67; /* good */
-    U32 t1,t2,i;
-
-    /* make sure we have all non-zero state elements */
-    if (!s0) s0 = 1;
-    if (!s1) s1 = 2;
-    if (!s2) s2 = 4;
-
-    /* Do a bunch of mix rounds to avalanche the seedbits
-     * before we use them for the XORSHIFT rng. */
-    for ( i = 0; i < SBOX32_CHURN_ROUNDS; i++ )
-        SBOX32_MIX3(s0,s1,s2,"SEED STATE");
-
-    while ( state_cursor < sbox32_end ) {
-        U32 *row_end = state_cursor + 256; 
-        for ( ; state_cursor < row_end; state_cursor++ ) {
-            XORSHIFT96_set(*state_cursor,s0,s1,s2,t1);
-        }
-    }
-    XORSHIFT96_set(*state,s0,s1,s2,t2);
-}
 
 SBOX32_STATIC_INLINE void sbox32_seed_state128 (
     const U8 *seed_ch,
@@ -1464,8 +1413,8 @@ SBOX32_STATIC_INLINE void sbox32_seed_state128 (
     U32 *state= (U32 *)state_ch;
     U32 *state_cursor = state + 1;
     U32 *sbox32_end = state + 1 + (256 * SBOX32_MAX_LEN);
-    U32 s0 = seed[0] ^ 0x68736168; /* sbox */
-    U32 s1 = seed[1] ^ 0x786f6273; /* hash */
+    U32 s0 = seed[1] ^ 0x786f6273; /* sbox */
+    U32 s1 = seed[0] ^ 0x68736168; /* hash */
     U32 s2 = seed[2] ^ 0x646f6f67; /* good */
     U32 s3 = seed[3] ^ 0x74736166; /* fast */
     U32 t1,t2,i;
@@ -1475,9 +1424,23 @@ SBOX32_STATIC_INLINE void sbox32_seed_state128 (
     if (!s1) s1 = 2;
     if (!s2) s2 = 4;
     if (!s3) s3 = 8;
-    
+
     /* Do a bunch of mix rounds to avalanche the seedbits
      * before we use them for the XORSHIFT rng. */
+    for ( i = 0; i < SBOX32_CHURN_ROUNDS; i++ )
+        SBOX32_MIX4(s0,s1,s2,s3,"SEED STATE");
+
+    s0 ^= ~seed[3];
+    s1 ^= ~seed[2];
+    s2 ^= ~seed[1];
+    s3 ^= ~seed[0];
+
+    /* make sure we have all non-zero state elements, again */
+    if (!s0) s0 = 8;
+    if (!s1) s1 = 4;
+    if (!s2) s2 = 2;
+    if (!s3) s3 = 1;
+    
     for ( i = 0; i < SBOX32_CHURN_ROUNDS; i++ )
         SBOX32_MIX4(s0,s1,s2,s3,"SEED STATE");
 
@@ -1758,16 +1721,6 @@ SBOX32_STATIC_INLINE U32 sbox32_hash_with_state(
         case 0: break;
     }
     return hash;
-}
-
-SBOX32_STATIC_INLINE U32 sbox32_hash96(
-    const U8 *seed_ch,
-    const U8 *key,
-    const STRLEN key_len
-) {
-    U32 state[SBOX32_STATE_WORDS];
-    sbox32_seed_state96(seed_ch,(U8*)state);
-    return sbox32_hash_with_state((U8*)state,key,key_len);
 }
 
 SBOX32_STATIC_INLINE U32 sbox32_hash128(

--- a/t/run/runenv.t
+++ b/t/run/runenv.t
@@ -24,43 +24,6 @@ delete $ENV{PERL5LIB};
 delete $ENV{PERL5OPT};
 delete $ENV{PERL_USE_UNSAFE_INC};
 
-
-# Run perl with specified environment and arguments, return (STDOUT, STDERR)
-sub runperl_and_capture {
-  local *F;
-  my ($env, $args) = @_;
-
-  local %ENV = %ENV;
-  delete $ENV{PERLLIB};
-  delete $ENV{PERL5LIB};
-  delete $ENV{PERL5OPT};
-  delete $ENV{PERL_USE_UNSAFE_INC};
-  my $pid = fork;
-  return (0, "Couldn't fork: $!") unless defined $pid;   # failure
-  if ($pid) {                   # parent
-    wait;
-    return (0, "Failure in child.\n") if ($?>>8) == $FAILURE_CODE;
-
-    open my $stdout, '<', $STDOUT
-	or return (0, "Couldn't read $STDOUT file: $!");
-    open my $stderr, '<', $STDERR
-	or return (0, "Couldn't read $STDERR file: $!");
-    local $/;
-    # Empty file with <$stderr> returns nothing in list context
-    # (because there are no lines) Use scalar to force it to ''
-    return (scalar <$stdout>, scalar <$stderr>);
-  } else {                      # child
-    for my $k (keys %$env) {
-      $ENV{$k} = $env->{$k};
-    }
-    open STDOUT, '>', $STDOUT or exit $FAILURE_CODE;
-    open STDERR, '>', $STDERR and do { exec $PERL, @$args };
-    # it did not work:
-    print STDOUT "IWHCWJIHCI\cNHJWCJQWKJQJWCQW\n";
-    exit $FAILURE_CODE;
-  }
-}
-
 sub try {
   my ($env, $args, $stdout, $stderr) = @_;
   my ($actual_stdout, $actual_stderr) = runperl_and_capture($env, $args);

--- a/t/run/runenv_hashseed.t
+++ b/t/run/runenv_hashseed.t
@@ -1,0 +1,136 @@
+#!./perl
+#
+# Tests for Perl run-time environment variable settings
+#
+# $PERL5OPT, $PERL5LIB, etc.
+
+BEGIN {
+    chdir 't' if -d 't';
+    @INC = '../lib';
+    require './test.pl';
+    require Config;
+    Config->import;
+}
+
+skip_all_without_config('d_fork');
+skip_all("NO_PERL_HASH_ENV or NO_PERL_HASH_SEED_DEBUG set")
+    if $Config{ccflags} =~ /-DNO_PERL_HASH_ENV\b/
+    || $Config{ccflags} =~ /-DNO_PERL_HASH_SEED_DEBUG\b/;
+
+my @modes = (
+        'NO',
+        'RANDOM',
+        'DETERMINISTIC'
+    ); # 0, 1 and 2 respectively
+my $repeat = 50;
+plan tests => @modes * 7 * $repeat;
+use strict;
+our $TODO;
+
+sub my_runperl_and_capture {
+    my ($opts_hash, $cmd_array)= @_;
+    my ( $out, $err )
+        = runperl_and_capture( $opts_hash, $cmd_array );
+    my $err_got_data = "";
+    while ($err=~s/^(Got.*\n)//) {
+        $err_got_data .= $1;
+    }
+    my @rand_bits_data;
+    while ($err=~s/^(PL_hash_rand_bits=.*)\n//m) {
+        push @rand_bits_data, $1;
+    }
+    return ($out, $err, $err_got_data, \@rand_bits_data);
+}
+
+# Test that PERL_PERTURB_KEYS works as expected.  We check that we get the same
+# results if we use PERL_PERTURB_KEYS = 0 or 2 and we reuse the seed from previous run.
+my $print_keys = [
+    '-Dh', '-I../lib',
+    (is_miniperl() ? () : '-MHash::Util=hash_traversal_mask,num_buckets'),
+    '-e',
+    'my %h; @h{"A".."Z", "a".."z"}=(); @k=keys %h;'.
+      ' print join ":", 0+@k, ' .
+      (is_miniperl() ? '' : 'num_buckets(%h),hash_traversal_mask(%h),') .
+      ' join "", @k;'
+];
+for my $mode (@modes) {
+    my $base_opts = {
+        PERL_PERTURB_KEYS => $mode,
+        PERL_HASH_SEED_DEBUG => 1,  # needed for non DEBUGGING builds
+    };
+    for my $try (1 .. $repeat) {
+        my $descr = sprintf "PERL_PERTURB_KEYS = %s, try %2d:", $mode, $try;
+        my ( $out, $err )
+            = my_runperl_and_capture( $base_opts, $print_keys );
+        $err =~ /HASH_SEED = (0x[a-f0-9]+)/
+            or die "Failed to extract hash seed from runperl_and_capture";
+        my $seed = $1;
+        my $run_opts = { %$base_opts, PERL_HASH_SEED => $seed };
+
+        # now we have to run it again.
+        my ( $out1, $err1, $err_got_data1, $rand_bits_data1 )
+            = my_runperl_and_capture( $run_opts, $print_keys );
+
+        # and once more, these two should be the same
+        my ( $out2, $err2, $err_got_data2, $rand_bits_data2 )
+            = my_runperl_and_capture( $run_opts, $print_keys );
+
+        if ( $mode eq 'RANDOM' ) {
+            isnt( $out1, $out2,
+                "$descr results in different key order with the same keys"
+            );
+        }
+        else {
+            is( $out1, $out2,
+                "$descr results in the same key order each time"
+            );
+        }
+        SKIP: {
+            skip "$descr not testing rand bits", 3
+                if $mode eq "RANDOM";
+            is ( 0+@$rand_bits_data1, 0+@$rand_bits_data2,
+                "$descr same count of rand_bits_data entries each time");
+            my $max_i = $#$rand_bits_data1 > $#$rand_bits_data2
+                      ? $#$rand_bits_data1 : $#$rand_bits_data2;
+            my $bad_idx;
+            for my $i (0..$max_i) {
+                if (($rand_bits_data2->[$i] // "") ne
+                    ($rand_bits_data1->[$i] // "")) {
+                    $bad_idx = $i;
+                    last;
+                }
+            }
+            is($bad_idx, undef,
+                "$descr bad rand bits data index should be undef");
+            if (defined $bad_idx) {
+                # we use is() to see the differing data, but this test is
+                # expected will fail - the description seems a little odd here,
+                # but since it will always fail it makes sense in context.
+                is($rand_bits_data2->[$bad_idx],$rand_bits_data1->[$bad_idx],
+                    "$descr rand bits data is same at idx $bad_idx");
+            } else {
+                pass("$descr rand bits data does not differ");
+            }
+        }
+        is( $err, $err2,
+            "$descr debug output was consistent between runs"
+        );
+        ################################################################################
+        # Using a different HASH_SEED
+        $seed=~s/^0x//;
+        my @chars = split //, $seed;
+        $seed = "0x" . $seed;
+
+        # increase by 1 the last digit (only)
+        $chars[-1] = sprintf( "%x", ( hex( $chars[-1] ) + 1 ) % 16 );
+        my $new_seed = "0x" . join '', @chars;
+        isnt $new_seed, $seed, "$descr got a different seed";
+        $run_opts->{PERL_HASH_SEED}= $new_seed;
+        my ( $out2, $err2 )
+            = my_runperl_and_capture( $run_opts, $print_keys );
+        isnt( $out, $out2,
+            "$descr results in different order with a different key"
+        );
+    }
+    unlink_tempfiles();
+}

--- a/t/test.pl
+++ b/t/test.pl
@@ -876,8 +876,8 @@ sub runperl_and_capture {
             print "Failed to dup STDERR to '$STDERR': $!";
             exit $FAILURE_CODE;
         };
-    exec $PERL, @$args;
-    print STDERR "Failed to exec: ",
+    exec $PERL, @$args
+        or print STDERR "Failed to exec: ",
                   join(" ",map { "'$_'" } $^X, @$args),
                   ": $!\n";
     exit $FAILURE_CODE;

--- a/t/test.pl
+++ b/t/test.pl
@@ -920,7 +920,12 @@ sub _num_to_alpha {
 }
 
 my %tmpfiles;
-END { unlink_all keys %tmpfiles }
+sub unlink_tempfiles {
+    unlink_all keys %tmpfiles;
+    %tempfiles = ();
+}
+
+END { unlink_tempfiles(); }
 
 
 # NOTE: tempfile() may be used as a module names in our tests

--- a/t/test.pl
+++ b/t/test.pl
@@ -817,6 +817,43 @@ sub runperl {
 # Nice alias
 *run_perl = *run_perl = \&runperl; # shut up "used only once" warning
 
+-# Run perl with specified environment and arguments, return (STDOUT, STDERR)
+sub runperl_and_capture {
+  local *F;
+  my ($env, $args) = @_;
+
+  local %ENV = %ENV;
+  delete $ENV{PERLLIB};
+  delete $ENV{PERL5LIB};
+  delete $ENV{PERL5OPT};
+  delete $ENV{PERL_USE_UNSAFE_INC};
+  my $pid = fork;
+  return (0, "Couldn't fork: $!") unless defined $pid;   # failure
+  if ($pid) {                   # parent
+    wait;
+    return (0, "Failure in child.\n") if ($?>>8) == $FAILURE_CODE;
+
+    open my $stdout, '<', $STDOUT
+        or return (0, "Couldn't read $STDOUT file: $!");
+    open my $stderr, '<', $STDERR
+        or return (0, "Couldn't read $STDERR file: $!");
+    local $/;
+    # Empty file with <$stderr> returns nothing in list context
+    # (because there are no lines) Use scalar to force it to ''
+    return (scalar <$stdout>, scalar <$stderr>);
+  } else {                      # child
+    for my $k (keys %$env) {
+      $ENV{$k} = $env->{$k};
+    }
+    open STDOUT, '>', $STDOUT or exit $FAILURE_CODE;
+    open STDERR, '>', $STDERR and do { exec $PERL, @$args };
+    # it did not work:
+    print STDOUT "IWHCWJIHCI\cNHJWCJQWKJQJWCQW\n";
+    exit $FAILURE_CODE;
+  }
+}
+
+
 sub DIE {
     _print_stderr "# @_\n";
     exit 1;


### PR DESCRIPTION
This replaces PR #18095, please review that PR for related discussion that lead to this PR.

This PR includes the following:

1. Updates to test.pl used by the PR.
2. Updates to our SBOX32 hash initialization to be more robust as revealed by the original PR from @atoomic 
3. A reworking of the PL_hash_rand_bits update logic so it is wrapped in consistent macros which include the capability to produce debug output
4. Add a new -Dh debug switch to enabled the diagnostics introduced in point 3.
5. Add a new test which fairly thoroughly tests the hash randomization logic and seed initialization, including verifying that a bit change to the seed actually results in a significant change in hash behavior. The depends on all of the changes mentioned above.

The test is based on work by @atoomic which was apparently the result of observations by @jkeenan. Thanks to both for bringing this to my attention.