### PR TITLE
Document demarcated variable form better

### DIFF
--- a/pod/perldata.pod
+++ b/pod/perldata.pod
@@ -503,12 +503,14 @@ and POSIX::setlocale() has been called, the character used for the
 decimal separator is affected by the LC_NUMERIC locale.
 See L<perllocale> and L<POSIX>.
 
-As in some shells, you can enclose the variable name in braces to
-disambiguate it from following alphanumerics (and underscores).
-You must also do
-this when interpolating a variable into a string to separate the
-variable name from a following double-colon or an apostrophe, since
-these would be otherwise treated as a package separator:
+=head3 Demarcated variable names using braces
+
+As in some shells, you can enclose the variable name in braces as a
+demarcator to disambiguate it from following alphanumerics and
+underscores or other text. You must also do this when interpolating a
+variable into a string to separate the variable name from a following
+double-colon or an apostrophe since these would be otherwise treated as
+a package separator:
 X<interpolation>
 
     $who = "Larry";
@@ -520,13 +522,95 @@ C<$who::0>, and a C<$who's> variable.  The last two would be the
 $0 and the $s variables in the (presumably) non-existent package
 C<who>.
 
-In fact, a simple identifier within such curlies is forced to be
-a string, and likewise within a hash subscript.  Neither need
-quoting.  Our earlier example, C<$days{'Feb'}> can be written as
-C<$days{Feb}> and the quotes will be assumed automatically.  But
-anything more complicated in the subscript will be interpreted as an
-expression.  This means for example that C<$version{2.0}++> is
-equivalent to C<$version{2}++>, not to C<$version{'2.0'}++>.
+In fact, a simple identifier within such curly braces is forced to be a
+string, and likewise within a hash subscript. Neither need quoting. Our
+earlier example, C<$days{'Feb'}> can be written as C<$days{Feb}> and the
+quotes will be assumed automatically. But anything more complicated in
+the subscript will be interpreted as an expression. This means for
+example that C<$version{2.0}++> is equivalent to C<$version{2}++>, not
+to C<$version{'2.0'}++>.
+
+There is a similar problem with interpolation with text that looks like
+array or hash access notation. Placing a simple variable like C<$who>
+immediately in front of text like C<"[1]"> or C<"{foo}"> would cause the
+variable to be interpolated as accessing an element of C<@who> or a
+value stored in C<%who>:
+
+    $who = "Larry Wall";
+    print "$who[1] is the father of Perl.\n";
+
+would attempt to access index 1 of an array named C<@who>. Again, using
+braces will prevent this from happening:
+
+    $who = "Larry Wall";
+    print "${who}[1] is the father of Perl.\n";
+
+will be treated the same as
+
+    $who = "Larry Wall";
+    print $who . "[1] is the father of Perl.\n";
+
+This notation also applies to more complex variable descriptions,
+such as array or hash access with subscripts. For instance
+
+    @name = qw(Larry Curly Moe);
+    print "Also ${name[0]}[1] was a member\n";
+
+Without the braces the above example would be parsed as a two level
+array subscript in the C<@name> array, and under C<use strict> would
+likely produce a fatal exception, as it would be parsed like this:
+
+    print "Also " . $name[0][1] . " was a member\n";
+
+and not as the intended:
+
+    print "Also " . $name[0] . "[1] was a member\n";
+
+A similar result may be derived by using a backslash on the first
+character of the subscript or package notation that is not part of
+the variable you want to access. Thus the above example could also
+be written:
+
+    @name = qw(Larry Curly Moe);
+    print "Also $name[0]\[1] was a member\n";
+
+however for some special variables (multi character caret variables) the
+demarcated form using curly braces is the B<only> way you can reference
+the variable at all, and the only way you can access a subscript of the
+variable via interpolation.
+
+Consider the magic array C<@{^CAPTURE}> which is populated by the
+regex engine with the contents of all of the capture buffers in a
+pattern (see L<perlvar> and L<perlre>). The B<only> way you can
+access one of these members inside of a string is via the braced
+(demarcated) form:
+
+    "abc"=~/(.)(.)(.)/
+        and print "Second buffer is ${^CAPTURE[1]}";
+
+is equivalent to
+
+    "abc"=~/(.)(.)(.)/
+        and print "Second buffer is " . ${^CAPTURE}[1];
+
+Saying C<@^CAPTURE> is a syntax error, so it B<must> be referenced as
+C<@{^CAPTURE}>, and to access one of its elements in normal code you
+would write C< ${^CAPTURE}[1] >. However when interpolating in a string
+C<"${^CAPTURE}[1]"> would be equivalent to C<${^CAPTURE} . "[1]">,
+which does not even refer to the same variable! Thus the subscripts must
+B<also> be placed B<inside> of the braces: C<"${^CAPTURE[1]}">.
+
+The demarcated form using curly braces can be used with all the
+different types of variable access, including array and hash slices. For
+instance code like the following:
+
+    @name = qw(Larry Curly Moe);
+    local $" = " and ";
+    print "My favorites were @{name[1,2]}.\n";
+
+would output
+
+    My favorites were Curly and Moe.
 
 =head3 Special floating point: infinity (Inf) and not-a-number (NaN)
 

--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -1279,6 +1279,23 @@ until the end of the enclosing block or until the next successful
 match, whichever comes first.  (See L<perlsyn/"Compound Statements">.)
 X<$+> X<$^N> X<$&> X<$`> X<$'>
 X<$1> X<$2> X<$3> X<$4> X<$5> X<$6> X<$7> X<$8> X<$9>
+X<@{^CAPTURE}>
+
+The C<@{^CAPTURE}> array may be used to access ALL of the capture buffers
+as an array without needing to know how many there are. For instance
+
+    $string=~/$pattern/ and @captured = @{^CAPTURE};
+
+will place a copy of each capture variable, C<$1>, C<$2> etc, into the
+C<@captured> array.
+
+Be aware that when interpolating a subscript of the C<@{^CAPTURE}>
+array you must use demarcated curly brace notation:
+
+    print "@{^CAPTURE[0]}";
+
+See L<perldata/"Demarcated variable names using braces"> for more on
+this notation.
 
 B<NOTE>: Failed matches in Perl do not reset the match variables,
 which makes it easier to write code that tests for a series of more

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -25,15 +25,27 @@ to hold data captured by backreferences after a regular expression
 match.
 
 Since Perl v5.6.0, Perl variable names may also be alphanumeric strings
-preceded by a caret.  These must all be written in the form C<${^Foo}>;
-the braces are not optional.  C<${^Foo}> denotes the scalar variable
+preceded by a caret.  These must all be written using the demarcated
+variable form using curly braces such as C<${^Foo}>;
+the braces are B<not> optional.  C<${^Foo}> denotes the scalar variable
 whose name is considered to be a control-C<F> followed by two C<o>'s.
+(See L<perldata/"Demarcated variable names using braces"> for more
+information on this form of spelling a variable name or specifying
+access to an element of an array or a hash).
 These variables are
 reserved for future special uses by Perl, except for the ones that
 begin with C<^_> (caret-underscore).  No
 name that begins with C<^_> will acquire a special
 meaning in any future version of Perl; such names may therefore be
 used safely in programs.  C<$^_> itself, however, I<is> reserved.
+
+Note that you also B<must> use the demarcated form to access subscripts
+of variables of this type when interpolating, for instance to access the
+first element of the C<@{^CAPTURE}> variable inside of a double quoted
+string you would write C<"${^CAPTURE[0]}"> and NOT C<"${^CAPTURE}[0]">
+which would mean to reference a scalar variable named C<${^CAPTURE}> and
+not index 0 of the magic C<@{^CAPTURE}> array which is populated by the
+regex engine.
 
 Perl identifiers that begin with digits or
 punctuation characters are exempt from the effects of the C<package>
@@ -937,7 +949,14 @@ See also L<<< /$<I<digits>> ($1, $2, ...) >>>, L</%{^CAPTURE}> and
 L</%{^CAPTURE_ALL}>.
 
 Note that unlike most other regex magic variables there is no single
-letter equivalent to C<@{^CAPTURE}>.
+letter equivalent to C<@{^CAPTURE}>. Also be aware that when
+interpolating subscripts of this array you B<must> use the demarcated
+variable form, for instance
+
+    print "${^CAPTURE[0]}"
+
+see L<perldata/"Demarcated variable names using braces"> for more
+information on this form and its uses.
 
 This variable was added in 5.25.7
 


### PR DESCRIPTION
This updated pod/perldata.pod to explain the demarcated variable form better and more completely. We have always documented it but did not specify it included array subscripts or hash subscripts and we did not document that it is the *required* form for mutli-character caret variables, and that it is the required form when doing lookups into such a variable. 

It also updated pod/perlre.pod to include references to @{^CAPTURE}, one of the notable examples of a non scalar multi-character caret variable. Previously it was only documented in perlvar.pod.

It also updates pod/perlvar.pod to include links back to pod/perldata.pod on the demarcated variable form. And a few minor enhancements to the docs on @{^CAPTURE} spelling out the necessity of using that form in interpolation. 

See GH Issue #19497 and GH Issue #18800 for examples of people being confused by this notation.

