### PR TITLE
assert() PL_parser before trying to dereference it

### DIFF
--- a/op.c
+++ b/op.c
@@ -9523,6 +9523,7 @@ Perl_newSTATEOP(pTHX_ I32 flags, char *label, OP *o)
     const U32 utf8 = flags & SVf_UTF8;
     COP *cop;
 
+    assert(PL_parser);
     PL_parser->parsed_sub = 0;
 
     flags &= ~SVf_UTF8;


### PR DESCRIPTION
Doesn't entirely solve, but partially addresses #19506. At least the failure message is now more obvious:

Was:

```
Segmentation fault
```

Now:

```
perl: op.c:9526: Perl_newSTATEOP: Assertion `PL_parser' failed.
Aborted
```

Not hugely helpful to end-users but at least more developer-friendly