### PR TITLE
Increase NV precision in sv_dump and Devel::Peek::Dump

### DIFF
--- a/ext/Devel-Peek/t/Peek.t
+++ b/ext/Devel-Peek/t/Peek.t
@@ -1569,4 +1569,27 @@ EODUMP
     $out =~ s/\(0x[0-9a-f]{3,}\)/(0xNNN)/g;
     is $out, $e, "DumpProg() has no 'Attempt to free X prematurely' warning";
 }
+
+{
+    my $one = 1.0;
+    my $epsilon_p = 1.0;
+    $epsilon_p /= 2 while $one != $one + $epsilon_p / 2;
+    my $epsilon_n = 1.0;
+    $epsilon_n /= 2 while $one != $one - $epsilon_n / 2;
+
+    my $head = 'SV = NV\($ADDR\) at $ADDR
+(?:.+
+)*  ';
+    my $tail = '
+(?:.+
+)*';
+
+    do_test('NV 1.0', $one,
+            $head . 'NV = 1' . $tail);
+    do_test('NV 1.0 + epsilon', $one + $epsilon_p,
+            $head . 'NV = 1\.00000000\d+' . $tail);
+    do_test('NV 1.0 - epsilon', $one - $epsilon_p,
+            $head . 'NV = 0\.99999999\d+' . $tail);
+}
+
 done_testing();


### PR DESCRIPTION
I think it will be better that `Devel::Peek::Dump` dump NVs to enough precision to distinguish any adjacent floating point numbers.

Previously, some LSBs in floating point numbers were lost in `Dump` output, so very close (but numerically not equal) floating point numbers (e.g. 1.0 and 1.0000000000000003 if NV is "double") might produce indistinguishable dumps.