### PR TITLE
Add MANIFEST.SKIP file

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5132,6 +5132,7 @@ Makefile.SH			A script that generates Makefile
 malloc.c			A version of malloc you might not want
 malloc_ctl.h			A version of malloc you might not want
 MANIFEST			This list of files
+MANIFEST.SKIP			Patterns for files not included in this file
 mathoms.c			A home for binary-compatible code artifacts
 META.json			Distribution meta-data in JSON
 META.yml			Distribution meta-data in YAML

--- a/MANIFEST
+++ b/MANIFEST
@@ -71,6 +71,7 @@ Makefile.SH				A script that generates Makefile
 malloc.c				A version of malloc you might not want
 malloc_ctl.h				A version of malloc you might not want
 MANIFEST				This list of files
+MANIFEST.SKIP				Patterns for files not included in this file
 mathoms.c				A home for binary-compatible code artifacts
 META.json				Distribution meta-data in JSON
 META.yml				Distribution meta-data in YAML

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,6 @@
+\.mailmap
+\.gitignore
+\.gitattributes
+\.git_patch
+^\.git\b
+^\.github/

--- a/Porting/manicheck
+++ b/Porting/manicheck
@@ -8,6 +8,7 @@ use v5.14;
 use warnings;
 use File::Find;
 use Getopt::Long;
+use ExtUtils::Manifest 'maniskip';
 use constant SKIP => 125;
 
 my $exitstatus;
@@ -17,6 +18,7 @@ GetOptions('exitstatus!', \$exitstatus)
 my %files;
 my $missing = 0;
 my $bonus = 0;
+my $skip = maniskip;
 
 open my $fh, '<', 'MANIFEST' or die "Can't read MANIFEST: $!\n";
 for my $line (<$fh>) {
@@ -31,17 +33,11 @@ close $fh;
 find {
     wanted => sub {
         return if -d;
-        return if $_ eq '.mailmap';
-        return if $_ eq '.gitignore';
-        return if $_ eq '.gitattributes';
-        return if $_ eq '.git_patch';
-
-        my $x = $File::Find::name =~ s!^\./!!r;
-        return if $x =~ /^\.git\b/;
-        return if $x =~ m{^\.github/};
-        return if $files{$x};
+        my $path = $File::Find::name =~ s!^\./!!r;
+        return if $skip->($path);
+        return if $files{$path};
         ++$bonus;
-        print "$x\t\tnot in MANIFEST\n";
+        print "$path\t\tnot in MANIFEST\n";
     },
 }, ".";
 

--- a/t/porting/manifest.t
+++ b/t/porting/manifest.t
@@ -25,6 +25,7 @@
 # correct the problem.
 
 use Config;
+use ExtUtils::Manifest 'maniskip';
 BEGIN {
     @INC = '..' if -f '../TestInit.pm';
 }
@@ -85,14 +86,11 @@ SKIP: {
 
 SKIP: {
     find_git_or_skip(6);
+    my $skip = maniskip;
     my %seen; # De-dup ls-files output (can appear more than once)
     my @repo= grep {
         chomp();
-        !m{\.git_patch$} &&
-        !m{\.gitattributes$} &&
-        !m{\.gitignore$} &&
-        !m{\.mailmap$} &&
-        !m{^\.github/} &&
+        !$skip->($_) &&
         -e $_ &&
         !$seen{$_}++
     } `git ls-files`;


### PR DESCRIPTION
This replaces the lists of files to skip in `Porting/manicheck`, `t/porting/manifest.t` and `Porting/makerel` with a centralized and standardized `MANIFEST.SKIP` file.
    
This would also allow us to add a make manifest target, but I left that for a follow-up PR.