### PR TITLE
Revert "Fix GH Issue #19472: read warnings from open($fh,">",\(my $x))"

### DIFF
--- a/doio.c
+++ b/doio.c
@@ -639,16 +639,6 @@ Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len,
                 goto say_false;
             }
 #endif /* USE_STDIO */
-            if (SvROK(*svp) && !sv_isobject(*svp)) {
-                /* if they pass in a reference and its not an object
-                 * and the reference is to undef, "autovivify" it to
-                 * the empty string. See GH Issue #19472
-                 */
-                SV *sv= SvRV(*svp);
-                if (!SvOK(sv) && !SvREADONLY(sv))
-                    sv_setpvs(MUTABLE_SV(sv),"");
-            }
-
             p = (SvOK(*svp) || SvGMAGICAL(*svp)) ? SvPV(*svp, nlen) : NULL;
 
             if (p && !IS_SAFE_PATHNAME(p, nlen, "open")) {

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4657,8 +4657,8 @@ L<C<seek>|/seek FILEHANDLE,POSITION,WHENCE> to do the reading.
 =item Opening a filehandle into an in-memory scalar
 
 You can open filehandles directly to Perl scalars instead of a file or
-other resource external to the program. To do so, provide an unblessed
-reference to that scalar as the third argument to C<open>, like so:
+other resource external to the program. To do so, provide a reference to
+that scalar as the third argument to C<open>, like so:
 
  open(my $memory, ">", \$var)
      or die "Can't open memory file: $!";
@@ -4673,14 +4673,6 @@ To (re)open C<STDOUT> or C<STDERR> as an in-memory file, close it first:
 The scalars for in-memory files are treated as octet strings: unless
 the file is being opened with truncation the scalar may not contain
 any code points over 0xFF.
-
-Be aware that attempting to open a reference to a readonly scalar will
-cause a warning and the open to fail.
-
-Prior to Perl version 5.36.0, passing in a reference to an undef scalar
-could cause strange warnings. As of Perl version 5.36.0, provided the
-reference is unblessed, the scalar will be "autovivified" to be an empty
-string, even for read mode open operations.
 
 Opening in-memory files I<can> fail for a variety of reasons.  As with
 any other C<open>, check the return value for success.

--- a/t/io/open.t
+++ b/t/io/open.t
@@ -10,7 +10,7 @@ $|  = 1;
 use warnings;
 use Config;
 
-plan tests => 193;
+plan tests => 188;
 
 sub ok_cloexec {
     SKIP: {
@@ -408,28 +408,6 @@ SKIP: {
     is $var, "hello", '[perl #77684]: open $fh, ">", \$glob_copy'
         # when this fails, it leaves an extra file:
         or unlink \*STDOUT;
-}
-
-# [GH Issue #19472] Opening a reference to an undef scalar
-SKIP: {
-    skip_if_miniperl("no dynamic loading on miniperl, so can't load PerlIO::scalar", 5);
-    use strict;
-    my $var;
-    open my $fh, "+>", \$var;
-    is defined($var) ? "defined" : "undef", "defined",
-        '[GH Issue #19472]: open $fh, ">", \$undef_var leaves var defined';
-    is $var, "",
-        '[GH Issue #19472]: open $fh, ">", \$undef_var leaves var empty string';
-    my $warn_count= 0;
-    my $warn_text= "";
-    local $SIG{__WARN__}= sub { $warn_count++; $warn_text .= shift; };
-    my @x= <$fh>;
-    is $warn_count, 0, '[GH Issue #19472]: read after open $fh, ">", ' .
-                       '\$undef_var produces 0 warnings';
-    is $warn_text, "", '[GH Issue #19472]: read after open $fh, ">", ' .
-                       '\$undef_var produces no warning text';
-    is 0+@x, 0,        '[GH Issue #19472]: <$fh> after open $fh, ">", ' .
-                       '\$undef_var returns nothing';
 }
 
 # check that we can call methods on filehandles auto-magically


### PR DESCRIPTION
This reverts commit 8b03aeb95ab72abdb2fa40f2d1196ce42f34708d.

This is causing BBC breakage, and its unimport and grey zone enough that
we can pick it up in 5.37 when we have more time to deal with it.