### PR TITLE
hv_macro.h: only use direct memory loads on little endian machines

### DIFF
--- a/hv_macro.h
+++ b/hv_macro.h
@@ -31,7 +31,7 @@
 
 #ifndef U8TO16_LE
   #define _shifted_octet(type,ptr,idx,shift) (((type)(((U8*)(ptr))[(idx)]))<<(shift))
-    #ifdef USE_UNALIGNED_PTR_DEREF
+    #if defined(USE_UNALIGNED_PTR_DEREF) && (BYTEORDER == 0x1234 || BYTEORDER == 0x12345678)
         #define U8TO16_LE(ptr)   (*((const U16*)(ptr)))
         #define U8TO32_LE(ptr)   (*((const U32*)(ptr)))
         #define U8TO64_LE(ptr)   (*((const U64*)(ptr)))


### PR DESCRIPTION
Using the shift logic should work correctly anywhere, using direct
memory loads will only work correctly on little endian machines.