### PR TITLE
perl.c: www.perl.org uses https

### DIFF
--- a/perl.c
+++ b/perl.c
@@ -3841,7 +3841,7 @@ Perl may be copied only under the terms of either the Artistic License or the\n\
 GNU General Public License, which may be found in the Perl 5 source kit.\n\n\
 Complete documentation for Perl, including FAQ lists, should be found on\n\
 this system using \"man perl\" or \"perldoc perl\".  If you have access to the\n\
-Internet, point your browser at http://www.perl.org/, the Perl Home Page.\n\n");
+Internet, point your browser at https://www.perl.org/, the Perl Home Page.\n\n");
         my_exit(0);
 }
 


### PR DESCRIPTION
As pointed out in #19522, www.perl.org is available over HTTPS.