### PR TITLE
perldelta for removal of empty sort

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -59,6 +59,13 @@ XXX For a release on a stable branch, this section aspires to be:
 
 [ List each incompatible change as a =head2 entry ]
 
+=head2 sort with no arguments is now a compile-time error
+
+C<@a = sort;> used to be equivalent to C<@a = ();>, which wasn't very
+useful; it is now a compile-time error. The old behaviour has been
+removed to make room for future features. Sorting an empty array (ie
+C<@empty = (); @a = sort @empty;>) continues to be valid syntax.
+
 =head1 Deprecations
 
 XXX Any deprecated features, syntax, modules etc. should be listed here.


### PR DESCRIPTION
This reflects the change in 78cc98885f, "make a sort with zero args
a compile-time err".

(Should this commit also remove the preceding "XXX" boilerplate?)