### PR TITLE
always prevent setting POK flag when NV values are used as strings

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -3005,7 +3005,7 @@ Perl_sv_2pv_flags(pTHX_ SV *const sv, STRLEN *const lp, const U32 flags)
             len = S_infnan_2pv(SvNVX(sv), s, size, 0);
             if (len > 0) {
                 s += len;
-                SvPOK_on(sv);
+                SvPOKp_on(sv);
             }
             else {
                 /* some Xenix systems wipe out errno here */
@@ -3025,7 +3025,7 @@ Perl_sv_2pv_flags(pTHX_ SV *const sv, STRLEN *const lp, const U32 flags)
 #ifndef USE_LOCALE_NUMERIC
                 SNPRINTF_G(SvNVX(sv), s, SvLEN(sv), NV_DIG);
 
-                SvPOK_on(sv);
+                SvPOKp_on(sv);
 #else
                 {
                     bool local_radix;

--- a/t/op/svflags.t
+++ b/t/op/svflags.t
@@ -10,7 +10,7 @@ BEGIN {
 # Tests the new documented mechanism for determining the original type
 # of an SV.
 
-plan tests => 4;
+plan tests => 12;
 use strict;
 use B qw(svref_2object SVf_IOK SVf_NOK SVf_POK);
 
@@ -21,6 +21,41 @@ is($xobj->FLAGS & (SVf_IOK | SVf_POK), SVf_IOK, "correct base flags on IV");
 my $y = $x . "";
 
 is($xobj->FLAGS & (SVf_IOK | SVf_POK), SVf_IOK, "POK not set on IV used as string");
+
+$x = 1.0;
+
+is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "correct base flags on NV");
+
+$y = $x . "";
+
+is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "POK not set on NV used as string");
+
+$x = "Inf" + 0;
+
+is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "correct base flags on Inf NV");
+
+$y = $x . "";
+
+is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "POK not set on Inf NV used as string");
+
+$x = "-Inf" + 0;
+
+is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "correct base flags on -Inf NV");
+
+$y = $x . "";
+
+is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "POK not set on -Inf NV used as string");
+
+{
+    local $^W = 0;
+    $x  = "NaN" + 0;
+}
+
+is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "correct base flags on NaN NV");
+
+$y = $x . "";
+
+is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "POK not set on NaN NV used as string");
 
 $x = "10";
 is($xobj->FLAGS & (SVf_IOK | SVf_POK), SVf_POK, "correct base flags on PV");


### PR DESCRIPTION
Since PR #18958, values that start as IVs will not get their POK flags
set when they are used as strings. This is meant to aid in
serialization, allowing the "original" type of a value to be preserved.

For NV values, the POK flag was already usually not being set, because
the string form of a float could change based on the locale changing.
However, for Inf and NaN values, the POK flag would still be enabled.
Also, POK would be set for all floats if USE_LOCALE_NUMERIC was not
defined.

Update Perl_sv_2pv_flags to only enable the POKp flag when storing the
PV for Inf or NaN values, or all NVs when USE_LOCALE_NUMERIC is not
defined.