### PR TITLE
Fix windows compilation

### DIFF
--- a/win32/Makefile
+++ b/win32/Makefile
@@ -823,6 +823,7 @@ CFG_VARS	=					\
 		"usemultiplicity=$(USE_MULTI)"		\
 		"use64bitint=$(USE_64_BIT_INT)"		\
 		"uselongdouble=undef"			\
+		"usequadmath=undef"			    \
 		"usesitecustomize=$(USE_SITECUST)"	\
 		"default_inc_excludes_dot=$(DEFAULT_INC_EXCLUDES_DOT)"	\
 		"LINK_FLAGS=$(LINK_FLAGS:"=\")"		\


### PR DESCRIPTION
I'm compiling perl on Windows with the following command line:
`cd win32 & nmake CCTYPE=MSVC141 -ck "CFG=DebugFull" "PROCESSOR_ARCHITECTURE=AMD64" "PROCESSOR_ARCHITEW6432=AMD64" "NO_THREAD_SAFE_LOCALE=define"`

I've the following warnings:
`Use of uninitialized value $opt{"usequadmath"} in string eq at config_sh.PL line 148.`
`Use of uninitialized value $opt{"usequadmath"} in string eq at config_sh.PL line 231.`

I changed the makefile to pass usequadmath like uselongdouble to config_sh.PL.
