### PR TITLE
Perl_reg_named_buff_fetch: simplify newSVsv(&PL_sv_undef)

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -8770,7 +8770,7 @@ Perl_reg_named_buff_fetch(pTHX_ REGEXP * const r, SV * const namesv,
                         return ret;
                 } else {
                     if (retarray)
-                        ret = newSVsv(&PL_sv_undef);
+                        ret = newSV_type(SVt_NULL);
                 }
                 if (retarray)
                     av_push(retarray, ret);


### PR DESCRIPTION
Specifically, `newSVsv(&PL_sv_undef)` reduces to just `newSV_type(SVt_NULL)`.

This seems to be the only instance of `newSVsv(&PL_<some constant>)` in core.