### PR TITLE
inline.h: add av_push_simple, move in av_new_alloc

### DIFF
--- a/av.c
+++ b/av.c
@@ -393,48 +393,6 @@ Perl_av_store(pTHX_ AV *av, SSize_t key, SV *val)
 }
 
 /*
-=for apidoc av_new_alloc
-
-This implements L<perlapi/C<newAV_alloc_x>>
-and L<perlapi/C<newAV_alloc_xz>>, which are the public API for this
-functionality.
-
-Creates a new AV and allocates its SV* array.
-
-This is similar to, but more efficient than doing:
-
-    AV *av = newAV();
-    av_extend(av, key);
-
-The size parameter is used to pre-allocate a SV* array large enough to
-hold at least elements C<0..(size-1)>.  C<size> must be at least 1.
-
-The C<zeroflag> parameter controls whether or not the array is NULL
-initialized.
-
-=cut
-*/
-
-AV *
-Perl_av_new_alloc(pTHX_ SSize_t size, bool zeroflag)
-{
-    AV * const av = newAV();
-    SV** ary;
-    PERL_ARGS_ASSERT_AV_NEW_ALLOC;
-    assert(size > 0);
-
-    Newx(ary, size, SV*); /* Newx performs the memwrap check */
-    AvALLOC(av) = ary;
-    AvARRAY(av) = ary;
-    AvMAX(av) = size - 1;
-
-    if (zeroflag)
-        Zero(ary, size, SV*);
-
-    return av;
-}
-
-/*
 =for apidoc av_make
 
 Creates a new AV and populates it with a list (C<**strp>, length C<size>) of

--- a/embed.fnc
+++ b/embed.fnc
@@ -640,7 +640,7 @@ CipdR	|SV**	|av_fetch_simple|NN AV *av|SSize_t key|I32 lval
 Apd	|void	|av_fill	|NN AV *av|SSize_t fill
 ApdR	|SSize_t|av_len		|NN AV *av
 ApdR	|AV*	|av_make	|SSize_t size|NN SV **strp
-CpdR	|AV*	|av_new_alloc	|SSize_t size|bool zeroflag
+CipdR	|AV*	|av_new_alloc	|SSize_t size|bool zeroflag
 p	|SV*	|av_nonelem	|NN AV *av|SSize_t ix
 Apd	|SV*	|av_pop		|NN AV *av
 Apdoe	|void	|av_create_and_push|NN AV **const avp|NN SV *const val

--- a/embed.fnc
+++ b/embed.fnc
@@ -645,6 +645,7 @@ p	|SV*	|av_nonelem	|NN AV *av|SSize_t ix
 Apd	|SV*	|av_pop		|NN AV *av
 Apdoe	|void	|av_create_and_push|NN AV **const avp|NN SV *const val
 Apd	|void	|av_push	|NN AV *av|NN SV *val
+Aipd	|void	|av_push_simple	|NN AV *av|NN SV *val
 : Used in scope.c, and by Data::Alias
 EXp	|void	|av_reify	|NN AV *av
 ApdR	|SV*	|av_shift	|NN AV *av

--- a/embed.h
+++ b/embed.h
@@ -74,6 +74,7 @@
 #define av_new_alloc(a,b)	Perl_av_new_alloc(aTHX_ a,b)
 #define av_pop(a)		Perl_av_pop(aTHX_ a)
 #define av_push(a,b)		Perl_av_push(aTHX_ a,b)
+#define av_push_simple(a,b)	Perl_av_push_simple(aTHX_ a,b)
 #define av_shift(a)		Perl_av_shift(aTHX_ a)
 #define av_store(a,b,c)		Perl_av_store(aTHX_ a,b,c)
 #define av_store_simple(a,b,c)	Perl_av_store_simple(aTHX_ a,b,c)

--- a/inline.h
+++ b/inline.h
@@ -140,6 +140,35 @@ Perl_av_fetch_simple(pTHX_ AV *av, SSize_t key, I32 lval)
     }
 }
 
+/*
+=for apidoc av_push_simple
+
+This is a cut-down version of av_push that assumes that the array is very
+straightforward - no magic, not readonly, and AvREAL - and that C<key> is
+not less than -1. This function MUST NOT be used in situations where any
+of those assumptions may not hold.
+
+Pushes an SV (transferring control of one reference count) onto the end of the
+array.  The array will grow automatically to accommodate the addition.
+
+Perl equivalent: C<push @myarray, $val;>.
+
+=cut
+*/
+
+PERL_STATIC_INLINE void
+Perl_av_push_simple(pTHX_ AV *av, SV *val)
+{
+    PERL_ARGS_ASSERT_AV_PUSH_SIMPLE;
+    assert(SvTYPE(av) == SVt_PVAV);
+    assert(!SvMAGICAL(av));
+    assert(!SvREADONLY(av));
+    assert(AvREAL(av));
+    assert(AvFILLp(av) > -2);
+
+    (void)av_store_simple(av,AvFILLp(av)+1,val);
+}
+
 /* ------------------------------- cv.h ------------------------------- */
 
 /*

--- a/inline.h
+++ b/inline.h
@@ -169,6 +169,49 @@ Perl_av_push_simple(pTHX_ AV *av, SV *val)
     (void)av_store_simple(av,AvFILLp(av)+1,val);
 }
 
+/*
+=for apidoc av_new_alloc
+
+This implements L<perlapi/C<newAV_alloc_x>>
+and L<perlapi/C<newAV_alloc_xz>>, which are the public API for this
+functionality.
+
+Creates a new AV and allocates its SV* array.
+
+This is similar to, but more efficient than doing:
+
+    AV *av = newAV();
+    av_extend(av, key);
+
+The size parameter is used to pre-allocate a SV* array large enough to
+hold at least elements C<0..(size-1)>.  C<size> must be at least 1.
+
+The C<zeroflag> parameter controls whether or not the array is NULL
+initialized.
+
+=cut
+*/
+
+PERL_STATIC_INLINE AV *
+Perl_av_new_alloc(pTHX_ SSize_t size, bool zeroflag)
+{
+    AV * const av = newAV();
+    SV** ary;
+    PERL_ARGS_ASSERT_AV_NEW_ALLOC;
+    assert(size > 0);
+
+    Newx(ary, size, SV*); /* Newx performs the memwrap check */
+    AvALLOC(av) = ary;
+    AvARRAY(av) = ary;
+    AvMAX(av) = size - 1;
+
+    if (zeroflag)
+        Zero(ary, size, SV*);
+
+    return av;
+}
+
+
 /* ------------------------------- cv.h ------------------------------- */
 
 /*

--- a/mro_core.c
+++ b/mro_core.c
@@ -268,7 +268,7 @@ S_mro_get_linear_isa_dfs(pTHX_ HV *stash, U32 level)
     /* We use this later in this function, but don't need a reference to it
        beyond the end of this function, so reference count is fine.  */
     our_name = newSVhek(stashhek);
-    av_push(retval, our_name); /* add ourselves at the top */
+    av_push_simple(retval, our_name); /* add ourselves at the top */
 
     /* fetch our @ISA */
     gvp = (GV**)hv_fetchs(stash, "ISA", FALSE);
@@ -326,7 +326,7 @@ S_mro_get_linear_isa_dfs(pTHX_ HV *stash, U32 level)
 
                         HeVAL(he) = &PL_sv_undef;
                         sv_sethek(val, key);
-                        av_push(retval, val);
+                        av_push_simple(retval, val);
                     }
                 }
             } else {
@@ -358,7 +358,7 @@ S_mro_get_linear_isa_dfs(pTHX_ HV *stash, U32 level)
                        as if we'd copied it from what theirs should be.  */
                     stored = MUTABLE_HV(newSV_type_mortal(SVt_PVHV));
                     (void) hv_stores(stored, "UNIVERSAL", &PL_sv_undef);
-                    av_push(retval,
+                    av_push_simple(retval,
                             newSVhek(HeKEY_hek(hv_store_ent(stored, sv,
                                                             &PL_sv_undef, 0))));
                 }
@@ -846,7 +846,7 @@ Perl_mro_package_moved(pTHX_ HV * const stash, HV * const oldstash,
                     GvNAMEUTF8(gv) ? SV_CATUTF8 : SV_CATBYTES
                 );
             }
-            av_push((AV *)namesv, aname);
+            av_push_simple((AV *)namesv, aname);
         }
     }
 
@@ -1186,7 +1186,7 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes,
                                            ? SV_CATUTF8 : SV_CATBYTES
                                     );
                                 }
-                                av_push((AV *)subname, aname);
+                                av_push_simple((AV *)subname, aname);
                             }
                         }
                         else {
@@ -1269,7 +1269,7 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes,
                                            ? SV_CATUTF8 : SV_CATBYTES
                                     );
                                 }
-                                av_push((AV *)subname, aname);
+                                av_push_simple((AV *)subname, aname);
                             }
                         }
                         else {

--- a/perlio.c
+++ b/perlio.c
@@ -690,9 +690,9 @@ PerlIO_get_layers(pTHX_ PerlIO *f)
             newSVpv(l->tab->name, 0) : &PL_sv_undef;
             SV * const arg = l->tab && l->tab->Getarg ?
             (*l->tab->Getarg)(aTHX_ &l, 0, 0) : &PL_sv_undef;
-            av_push(av, name);
-            av_push(av, arg);
-            av_push(av, newSViv((IV)l->flags));
+            av_push_simple(av, name);
+            av_push_simple(av, arg);
+            av_push_simple(av, newSViv((IV)l->flags));
             l = l->next;
         }
     }
@@ -818,7 +818,7 @@ XS(XS_io_MODIFY_SCALAR_ATTRIBUTES)
         const char * const name = SvPV_const(ST(i), len);
         SV * const layer = PerlIO_find_layer(aTHX_ name, len, 1);
         if (layer) {
-            av_push(av, SvREFCNT_inc_simple_NN(layer));
+            av_push_simple(av, SvREFCNT_inc_simple_NN(layer));
         }
         else {
             ST(count) = ST(i);

--- a/proto.h
+++ b/proto.h
@@ -326,6 +326,11 @@ PERL_CALLCONV SV*	Perl_av_pop(pTHX_ AV *av);
 PERL_CALLCONV void	Perl_av_push(pTHX_ AV *av, SV *val);
 #define PERL_ARGS_ASSERT_AV_PUSH	\
 	assert(av); assert(val)
+#ifndef PERL_NO_INLINE_FUNCTIONS
+PERL_STATIC_INLINE void	Perl_av_push_simple(pTHX_ AV *av, SV *val);
+#define PERL_ARGS_ASSERT_AV_PUSH_SIMPLE	\
+	assert(av); assert(val)
+#endif
 PERL_CALLCONV void	Perl_av_reify(pTHX_ AV *av);
 #define PERL_ARGS_ASSERT_AV_REIFY	\
 	assert(av)

--- a/proto.h
+++ b/proto.h
@@ -313,9 +313,11 @@ PERL_CALLCONV AV*	Perl_av_make(pTHX_ SSize_t size, SV **strp)
 #define PERL_ARGS_ASSERT_AV_MAKE	\
 	assert(strp)
 
-PERL_CALLCONV AV*	Perl_av_new_alloc(pTHX_ SSize_t size, bool zeroflag)
+#ifndef PERL_NO_INLINE_FUNCTIONS
+PERL_STATIC_INLINE AV*	Perl_av_new_alloc(pTHX_ SSize_t size, bool zeroflag)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_NEW_ALLOC
+#endif
 
 PERL_CALLCONV SV*	Perl_av_nonelem(pTHX_ AV *av, SSize_t ix);
 #define PERL_ARGS_ASSERT_AV_NONELEM	\

--- a/sv.c
+++ b/sv.c
@@ -3775,11 +3775,13 @@ S_glob_assign_glob(pTHX_ SV *const dsv, SV *const ssv, const int dtype)
         SV * const sref = (SV *)GvAV((const GV *)dsv);
         if (SvSMAGICAL(sref) && (mg = mg_find(sref, PERL_MAGIC_isa))) {
             if (SvTYPE(mg->mg_obj) != SVt_PVAV) {
-                AV * const ary = newAV();
-                av_push(ary, mg->mg_obj); /* takes the refcount */
+                AV * const ary = newAV_alloc_x(2);
+                av_push_simple(ary, mg->mg_obj); /* takes the refcount */
+                av_push_simple(ary, SvREFCNT_inc_simple_NN(dsv));
                 mg->mg_obj = (SV *)ary;
+            } else {
+                av_push((AV *)mg->mg_obj, SvREFCNT_inc_simple_NN(dsv));
             }
-            av_push((AV *)mg->mg_obj, SvREFCNT_inc_simple_NN(dsv));
         }
         else sv_magic(sref, dsv, PERL_MAGIC_isa, NULL, 0);
       }
@@ -3958,8 +3960,8 @@ Perl_gv_setref(pTHX_ SV *const dsv, SV *const ssv)
                                  : NULL;
             if (SvSMAGICAL(sref) && (mg = mg_find(sref, PERL_MAGIC_isa))) {
                 if (SvTYPE(mg->mg_obj) != SVt_PVAV) {
-                    AV * const ary = newAV();
-                    av_push(ary, mg->mg_obj); /* takes the refcount */
+                    AV * const ary = newAV_alloc_xz(4);
+                    av_push_simple(ary, mg->mg_obj); /* takes the refcount */
                     mg->mg_obj = (SV *)ary;
                 }
                 if (omg) {


### PR DESCRIPTION
As per the individual commit messages:
* Adding av_push_simple allows for cleaner code
* Moving in av_new_alloc can help the compiler optimize away redundant assignments and branches.