### PR TITLE
gh19557: restore match_end on early bailout

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -9484,6 +9484,7 @@ NULL
 
                 /* If the lookbehind doesn't start in the actual string, is a
                  * trivial match failure */
+                match_end = ST.prev_match_end;
                 if (logical) {
                     logical = 0;
                     sw = 1 - cBOOL(ST.wanted);

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -2073,8 +2073,10 @@ AB\s+\x{100}	AB \x{100}X	y	-	-
 /(?=(\w))(?<!^)/	1234	y	$1	2	-	# Lookahead with zero width negative lookbehind
 /(\w)(?<!^)/	1234	y	$1	1	-	# Negative lookbehind with zero width assertion
 /(?=foo)(?<=(a??))/	afoo	y	$1	a	-	# Postive lookbehind with minmod (leftmost longest)
-/(?=foo)(?<=(a{0,2}))/	aafoo	y	$1	aa	-	# Postive lookbehind with min/max (leftmost longest)
-/(?=foo)(?<=(|a|aa))/	aafoo	y	$1	aa	-	# Postive lookbehind with alternation (leftmost longest)
+/(?=foo)(?<=(a{0,2}))/	aafoo	y	$1	aa	-	# Positive lookbehind with min/max (leftmost longest)
+/(?=foo)(?<=(|a|aa))/	aafoo	y	$1	aa	-	# Positive lookbehind with alternation (leftmost longest)
+(?<=(?<!yz)b)c	aabcdef	y	$&	c	-	# Nested lookbehind without early bailout
+(?<=(?<!yz)b)c	abcdef	y	$&	c	-	# Nested lookbehind with early bailout
 
 # Keep these lines at the end of the file
 # pat	string	y/n/etc	expr	expected-expr	skip-reason	comment


### PR DESCRIPTION
After 271c3af797, early bailout from the inner one of a pair of nested
lookbehinds would leave the desired match_end pointing at the wrong
place, so the outer lookbehind could give the wrong answer.