### PR TITLE
Test::More::note() needs version 0.82

### DIFF
--- a/dist/Storable/Makefile.PL
+++ b/dist/Storable/Makefile.PL
@@ -29,7 +29,7 @@ WriteMakefile(
                 'ExtUtils::MakeMaker' => '6.31',
             },
             TEST_REQUIRES => {
-                'Test::More' => '0.41',
+                'Test::More' => '0.82',
             },
            )
         : () ),


### PR DESCRIPTION
For: https://github.com/Perl/perl5/issues/19569, as reported by
kbulgrien.