### PR TITLE
Make IPC-Open3 work as expected with localized or open-for-memory-io STDIN/STDOUT

### DIFF
--- a/ext/IPC-Open3/lib/IPC/Open3.pm
+++ b/ext/IPC-Open3/lib/IPC/Open3.pm
@@ -257,6 +257,16 @@ sub _open3 {
 		untie *STDOUT;
 		untie *STDERR;
 
+		if ((fileno(STDIN)//-1) != 0) {
+                        eval { close(STDIN); };
+                        open(STDIN, '<&=', '0');
+		}
+
+		if ((fileno(STDOUT)//-1) != 1) {
+                        eval { close(STDOUT); };
+                        open(STDOUT, '>&=', '1');
+		}
+
 		close $stat_r;
 		require Fcntl;
 		my $flags = fcntl $stat_w, &Fcntl::F_GETFD, 0;

--- a/ext/IPC-Open3/t/IPC-Open3.t
+++ b/ext/IPC-Open3/t/IPC-Open3.t
@@ -256,7 +256,7 @@ SKIP: {
     }
 }
 
-# Test that STDOUT open for in-memory I/O does not caus trouble.
+# Test that STDOUT open for in-memory I/O does not cause trouble.
 # Github issue https://github.com/Perl/perl5/issues/19573
 {
         my $buffer;

--- a/ext/IPC-Open3/t/IPC-Open3.t
+++ b/ext/IPC-Open3/t/IPC-Open3.t
@@ -14,7 +14,7 @@ BEGIN {
 }
 
 use strict;
-use Test::More tests => 47;
+use Test::More tests => 48;
 
 use IO::Handle;
 use IPC::Open3;
@@ -262,6 +262,7 @@ SKIP: {
         my $buffer;
         close(STDOUT);
         open(STDOUT, '>', \$buffer);
+        print STDOUT "huff";
         my ($in, $out);
 	my $pid = eval {
 	    open3 $in, $out, undef, $perl, '-ne', 'print';
@@ -272,5 +273,8 @@ SKIP: {
 	my $japh = <$out>;
 	waitpid $pid, 0;
 	is($japh, "Yeppers!\n", "read input correctly");
+
+        print STDOUT "buff!";
+        is ($buffer, "huffbuff!", "STDOUT still open for in-memory I/O");
 
 }


### PR DESCRIPTION
This makes Open3 work as expected (at least, as **I** expected) even with a localized STDOUT or a STDOUT open for in-memory I/O.

See https://github.com/Perl/perl5/issues/19573