### PR TITLE
Generalize thread.pm stack tests to work on boxes with larger min sizes

### DIFF
--- a/dist/threads/t/stack.t
+++ b/dist/threads/t/stack.t
@@ -25,6 +25,18 @@ sub ok {
     return ($ok);
 }
 
+sub is {
+    my ($id, $got, $expected, $name) = @_;
+
+    my $ok = ok($id, $got == $expected, $name);
+    if (! $ok) {
+        print("     GOT: $got\n");
+        print("EXPECTED: $expected\n");
+    }
+
+    return ($ok);
+}
+
 BEGIN {
     $| = 1;
     print("1..18\n");   ### Number of tests that will be run ###
@@ -35,37 +47,37 @@ ok(1, 1, 'Loaded');
 
 ### Start of Testing ###
 
-ok(2, threads->get_stack_size() == 128*4096,
+is(2, threads->get_stack_size(), 128*4096,
         'Stack size set in import');
-ok(3, threads->set_stack_size(160*4096) == 128*4096,
+is(3, threads->set_stack_size(160*4096), 128*4096,
         'Set returns previous value');
-ok(4, threads->get_stack_size() == 160*4096,
+is(4, threads->get_stack_size(), 160*4096,
         'Get stack size');
 
 threads->create(
     sub {
-        ok(5, threads->get_stack_size() == 160*4096,
+        is(5, threads->get_stack_size(), 160*4096,
                 'Get stack size in thread');
-        ok(6, threads->self()->get_stack_size() == 160*4096,
+        is(6, threads->self()->get_stack_size(), 160*4096,
                 'Thread gets own stack size');
-        ok(7, threads->set_stack_size(128*4096) == 160*4096,
+        is(7, threads->set_stack_size(128*4096), 160*4096,
                 'Thread changes stack size');
-        ok(8, threads->get_stack_size() == 128*4096,
+        is(8, threads->get_stack_size(), 128*4096,
                 'Get stack size in thread');
-        ok(9, threads->self()->get_stack_size() == 160*4096,
+        is(9, threads->self()->get_stack_size(), 160*4096,
                 'Thread stack size unchanged');
     }
 )->join();
 
-ok(10, threads->get_stack_size() == 128*4096,
+is(10, threads->get_stack_size(), 128*4096,
         'Default thread sized changed in thread');
 
 threads->create(
     { 'stack' => 160*4096 },
     sub {
-        ok(11, threads->get_stack_size() == 128*4096,
+        is(11, threads->get_stack_size(), 128*4096,
                 'Get stack size in thread');
-        ok(12, threads->self()->get_stack_size() == 160*4096,
+        is(12, threads->self()->get_stack_size(), 160*4096,
                 'Thread gets own stack size');
     }
 )->join();
@@ -74,9 +86,9 @@ my $thr = threads->create( { 'stack' => 160*4096 }, sub { } );
 
 $thr->create(
     sub {
-        ok(13, threads->get_stack_size() == 128*4096,
+        is(13, threads->get_stack_size(), 128*4096,
                 'Get stack size in thread');
-        ok(14, threads->self()->get_stack_size() == 160*4096,
+        is(14, threads->self()->get_stack_size(), 160*4096,
                 'Thread gets own stack size');
     }
 )->join();
@@ -84,18 +96,18 @@ $thr->create(
 $thr->create(
     { 'stack' => 144*4096 },
     sub {
-        ok(15, threads->get_stack_size() == 128*4096,
+        is(15, threads->get_stack_size(), 128*4096,
                 'Get stack size in thread');
-        ok(16, threads->self()->get_stack_size() == 144*4096,
+        is(16, threads->self()->get_stack_size(), 144*4096,
                 'Thread gets own stack size');
-        ok(17, threads->set_stack_size(160*4096) == 128*4096,
+        is(17, threads->set_stack_size(160*4096), 128*4096,
                 'Thread changes stack size');
     }
 )->join();
 
 $thr->join();
 
-ok(18, threads->get_stack_size() == 160*4096,
+is(18, threads->get_stack_size(), 160*4096,
         'Default thread sized changed in thread');
 
 exit(0);

--- a/dist/threads/t/stack.t
+++ b/dist/threads/t/stack.t
@@ -12,6 +12,11 @@ BEGIN {
         exit(0);
     }
 
+    # XXX Note that if the default stack size happens to be the same as these
+    # numbers, that test 2 would return success just out of happenstance.
+    # This possibility could be lessened by choosing $frames to be something
+    # less likely than a power of 2
+
     $frame_size = 4096;
     $frames     = 128;
     $size       = $frames * $frame_size;

--- a/dist/threads/t/stack.t
+++ b/dist/threads/t/stack.t
@@ -55,8 +55,17 @@ ok(1, 1, 'Loaded');
 
 ### Start of Testing ###
 
-is(2, threads->get_stack_size(), $size,
-        'Stack size set in import');
+my $actual_size = threads->get_stack_size();
+
+{
+    if ($actual_size > $size) {
+        print("ok 2 # skip because system needs larger minimum stack size\n");
+        $size = $actual_size;
+    }
+    else {
+        is(2, $actual_size, $size, 'Stack size set in import');
+    }
+}
 
 my $size_plus_quarter = $size * 1.25;   # 128 frames map to 160
 is(3, threads->set_stack_size($size_plus_quarter), $size,

--- a/dist/threads/t/stack_env.t
+++ b/dist/threads/t/stack_env.t
@@ -57,8 +57,17 @@ ok(1, 1, 'Loaded');
 
 ### Start of Testing ###
 
-is(2, threads->get_stack_size(), $size,
-        '$ENV{PERL5_ITHREADS_STACK_SIZE}');
+my $actual_size = threads->get_stack_size();
+
+{
+    if ($actual_size > $size) {
+        print("ok 2 # skip because system needs larger minimum stack size\n");
+        $size = $actual_size;
+    }
+    else {
+        is(2, $actual_size, $size, '$ENV{PERL5_ITHREADS_STACK_SIZE}');
+    }
+}
 
 my $size_plus_eighth = $size * 1.125;   # 128 frames map to 144
 is(3, threads->set_stack_size($size_plus_eighth), $size,

--- a/dist/threads/t/stack_env.t
+++ b/dist/threads/t/stack_env.t
@@ -37,11 +37,19 @@ sub is {
     return ($ok);
 }
 
+my $frame_size;
+my $frames;
+my $size;
+
 BEGIN {
     $| = 1;
     print("1..4\n");   ### Number of tests that will be run ###
 
-    $ENV{'PERL5_ITHREADS_STACK_SIZE'} = 128*4096;
+    $frame_size = 4096;
+    $frames     = 128;
+    $size       = $frames * $frame_size;
+
+    $ENV{'PERL5_ITHREADS_STACK_SIZE'} = $size;
 };
 
 use threads;
@@ -49,11 +57,13 @@ ok(1, 1, 'Loaded');
 
 ### Start of Testing ###
 
-is(2, threads->get_stack_size(), 128*4096,
+is(2, threads->get_stack_size(), $size,
         '$ENV{PERL5_ITHREADS_STACK_SIZE}');
-is(3, threads->set_stack_size(144*4096), 128*4096,
+
+my $size_plus_eighth = $size * 1.125;   # 128 frames map to 144
+is(3, threads->set_stack_size($size_plus_eighth), $size,
         'Set returns previous value');
-is(4, threads->get_stack_size(), 144*4096,
+is(4, threads->get_stack_size(), $size_plus_eighth,
         'Get stack size');
 
 exit(0);

--- a/dist/threads/t/stack_env.t
+++ b/dist/threads/t/stack_env.t
@@ -25,6 +25,18 @@ sub ok {
     return ($ok);
 }
 
+sub is {
+    my ($id, $got, $expected, $name) = @_;
+
+    my $ok = ok($id, $got == $expected, $name);
+    if (! $ok) {
+        print("     GOT: $got\n");
+        print("EXPECTED: $expected\n");
+    }
+
+    return ($ok);
+}
+
 BEGIN {
     $| = 1;
     print("1..4\n");   ### Number of tests that will be run ###
@@ -37,11 +49,11 @@ ok(1, 1, 'Loaded');
 
 ### Start of Testing ###
 
-ok(2, threads->get_stack_size() == 128*4096,
+is(2, threads->get_stack_size(), 128*4096,
         '$ENV{PERL5_ITHREADS_STACK_SIZE}');
-ok(3, threads->set_stack_size(144*4096) == 128*4096,
+is(3, threads->set_stack_size(144*4096), 128*4096,
         'Set returns previous value');
-ok(4, threads->get_stack_size() == 144*4096,
+is(4, threads->get_stack_size(), 144*4096,
         'Get stack size');
 
 exit(0);

--- a/dist/threads/t/stack_env.t
+++ b/dist/threads/t/stack_env.t
@@ -45,6 +45,11 @@ BEGIN {
     $| = 1;
     print("1..4\n");   ### Number of tests that will be run ###
 
+    # XXX Note that if the default stack size happens to be the same as these
+    # numbers, that test 2 would return success just out of happenstance.
+    # This possibility could be lessened by choosing $frames to be something
+    # less likely than a power of 2
+
     $frame_size = 4096;
     $frames     = 128;
     $size       = $frames * $frame_size;


### PR DESCRIPTION
Before these commits, these tests would fail if run on a platform whose minimum stack size is larger than they expect.  This series of commits changes that so they skip that test, but adjust the expected values to that larger minimum so that the other tests can work.

The tests use their own ok() function.  I found it useful to wrap that with a new is() function.

I realized the first real test of each file can succeed by happenstance, and put in comments about that, including an idea I had about minimizing that possibility.  But I did this mostly to invite other people to think about this, ad what to do.