### PR TITLE
Accept \p{nv=-0}

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -24679,6 +24679,15 @@ S_parse_uniprop_string(pTHX_
                     break;
                 }
             }
+
+            /* Turn nv=-0 into nv=0.  These should be equivalent, but vary by
+             * underling libc implementation. */
+            if (   i == name_len - 1
+                && name[name_len-1] == '0'
+                && lookup_name[j-1] == '-')
+            {
+                j--;
+            }
         }
     }
     else {  /* No '=' */

--- a/t/lib/croak/regcomp
+++ b/t/lib/croak/regcomp
@@ -179,8 +179,3 @@ qr/(?<=(?<!x)x)\K/;
 qr/(?<!(?<!x)x)\K/;
 EXPECT
 OPTIONS nonfatal
-########
-# NAME numeric parsing buffer overflow in numeric.c
-0=~/\p{nV:-0}/
-EXPECT
-Can't find Unicode property definition "nV:-0" in regex; marked by <-- HERE in m/\p{nV:-0} <-- HERE / at - line 1.

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -2107,6 +2107,9 @@ AB\s+\x{100}	AB \x{100}X	y	-	-
 /a?(*ACCEPT)b/	a	y	>$&<	>a<	-	# Test minlen for ACCEPT
 /a?(*ACCEPT)b/	b	y	>$&<	><	-	# Test minlen for ACCEPT
 / (A (*ACCEPT) | BC){2} D{0,4}/x	A	y	$1	A	-	# ACCEPT optimizer check
+
+\p{nv=-0}	\x{660}	y	$&	\x{660}
+
 # Keep these lines at the end of the file
 # pat	string	y/n/etc	expr	expected-expr	skip-reason	comment
 # vim: softtabstop=0 noexpandtab


### PR DESCRIPTION
Some platforms already ignore the minus sign.  The Unicode standard says
the minus sign should be ignored always.

(But always doing so would cause it to not properly get the only
negative numeric value character in Unicode; I have submitted a ticket
to Unicode about this.  Nevertheless, it is in keeping with the letter
and spirit of the standard for the leading minus to be ignored for -0)

Note that -0 not being treated as legal was being tested for.  This was the result of a fuzzing operation trying this out and getting assertion failures (#16867), and not because the old behavior was desired.  When this P.R is merged, I'll open a ticket to create a new test for that failure.  It's not immediately obvious to me, since it was generated by fuzzing.