### PR TITLE
fix SVf_POK getting set on NVs when copying

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -4547,6 +4547,16 @@ Perl_sv_setsv_flags(pTHX_ SV *dsv, SV* ssv, const I32 flags)
         }
         if (sflags & SVp_NOK) {
             SvNV_set(dsv, SvNVX(ssv));
+            if ((sflags & SVf_NOK) && !(sflags & SVf_POK)) {
+                /* Source was SVf_NOK|SVp_NOK|SVp_POK but not SVf_POK, meaning
+                   a value set as floating point and later stringified, where
+                  the value happens to be one of the few that we know aren't
+                  affected by the numeric locale, hence we can cache the
+                  stringification. Currently that's  +Inf, -Inf and NaN, but
+                  conceivably we might extend this to -9 .. +9 (excluding -0).
+                  So mark destination the same: */
+                SvFLAGS(dsv) &= ~SVf_POK;
+            }
         }
         if (sflags & SVp_IOK) {
             SvIV_set(dsv, SvIVX(ssv));

--- a/t/op/svflags.t
+++ b/t/op/svflags.t
@@ -10,7 +10,7 @@ BEGIN {
 # Tests the new documented mechanism for determining the original type
 # of an SV.
 
-plan tests => 12;
+plan tests => 16;
 use strict;
 use B qw(svref_2object SVf_IOK SVf_NOK SVf_POK);
 
@@ -30,6 +30,11 @@ $y = $x . "";
 
 is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "POK not set on NV used as string");
 
+my $z = $x;
+$x = $z;
+
+is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "POK not set on copy of NV used as string");
+
 $x = "Inf" + 0;
 
 is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "correct base flags on Inf NV");
@@ -38,6 +43,11 @@ $y = $x . "";
 
 is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "POK not set on Inf NV used as string");
 
+$z = $x;
+$x = $z;
+
+is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "POK not set on copy of Inf NV used as string");
+
 $x = "-Inf" + 0;
 
 is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "correct base flags on -Inf NV");
@@ -45,6 +55,11 @@ is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "correct base flags on -Inf NV")
 $y = $x . "";
 
 is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "POK not set on -Inf NV used as string");
+
+$z = $x;
+$x = $z;
+
+is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "POK not set on copy of -Inf NV used as string");
 
 {
     local $^W = 0;
@@ -56,6 +71,11 @@ is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "correct base flags on NaN NV");
 $y = $x . "";
 
 is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "POK not set on NaN NV used as string");
+
+$z = $x;
+$x = $z;
+
+is($xobj->FLAGS & (SVf_NOK | SVf_POK), SVf_NOK, "POK not set on copy of NaN NV used as string");
 
 $x = "10";
 is($xobj->FLAGS & (SVf_IOK | SVf_POK), SVf_POK, "correct base flags on PV");


### PR DESCRIPTION
When copying an SV with SVp_POK set, the SVf_POK flag gets enabled on
the destination SV in all cases, to allow some of the COW logic to work
properly. The flag is then meant to be disabled later in the routine, if
the original SV was not SVp_POK. This was happening for IOK values, but
not NOK values. This would only impact a few values (Inf, -Inf, NaN) as
the string form of other floats is sensitive to locale so would not be
stored. In the past, values like this would also always have SVf_POK
set, but this has recently been changed to allow tracking the origin
type of a value, exposing this bug.

Fix this by checking for this case and unsetting the flag as
appropriate for SVf_NOK values, the same as was previously being done
for SVf_IOK values.