### PR TITLE
Ipc open3 localized filehandles

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -552,6 +552,7 @@ Dennis Marsa <dennism@cyrix.com> Dennis Marsa <dennism@cyrix.com>
 Devin Heitmueller <devin.heitmueller@gmail.com> Devin Heitmueller <devin.heitmueller@gmail.com>
 DH <crazyinsomniac@yahoo.com> DH <crazyinsomniac@yahoo.com>
 Diab Jerius <dj@head-cfa.harvard.edu> Diab Jerius <dj@head-cfa.harvard.edu>
+Dianne Skoll <dianne@skoll.ca> Dianne Skoll <dianne@skoll.ca>
 dLux <dlux@spam.sch.bme.hu> dLux <dlux@spam.sch.bme.hu>
 Dmitri Tikhonov <dmitri@cpan.org> Dmitri Tikhonov <dmitri@cpan.org>
 Dmitry Karasik <dk@tetsuo.karasik.eu.org> <dmitry@karasik.eu.org>

--- a/AUTHORS
+++ b/AUTHORS
@@ -398,6 +398,7 @@ Dennis Marsa                   <dennism@cyrix.com>
 Devin Heitmueller              <devin.heitmueller@gmail.com>
 DH                             <crazyinsomniac@yahoo.com>
 Diab Jerius                    <dj@head-cfa.harvard.edu>
+Dianne Skoll                   <dianne@skoll.ca>
 dLux                           <dlux@spam.sch.bme.hu>
 Dmitri Tikhonov                <dmitri@cpan.org>
 Dmitry Karasik                 <dk@tetsuo.karasik.eu.org>

--- a/ext/IPC-Open3/lib/IPC/Open3.pm
+++ b/ext/IPC-Open3/lib/IPC/Open3.pm
@@ -8,7 +8,7 @@ use Exporter 'import';
 use Carp;
 use Symbol qw(gensym qualify);
 
-our $VERSION	= '1.22';
+our $VERSION	= '1.23';
 our @EXPORT		= qw(open3);
 
 =head1 NAME


### PR DESCRIPTION
Rather than using `STDIN` and `STDOUT`, open our own private file handles that refer to POSIX file descriptors 0 and 1.

This makes `open3` work even if STDIN/STDOUT don't refer to file descriptors 0/1 (such as if one of them has been opened for in-memory I/O, for example.)

This replaces https://github.com/Perl/perl5/pull/19575 which should be closed.