### PR TITLE
makedepend_file.SH - add -DPERL_CORE so we pick up all deps

### DIFF
--- a/makedepend_file.SH
+++ b/makedepend_file.SH
@@ -132,7 +132,7 @@ esac
     #fi
 
     if [ "$osname" = os390 ]; then
-        $cppstdin $finc -I. $cppflags $cppminus <UU/$file.c |
+        $cppstdin -DPERL_CORE $finc -I. $cppflags $cppminus <UU/$file.c |
         $sed \
     	    -e '/^#.*<stdin>/d' \
 	    -e '/^#.*"-"/d' \
@@ -146,7 +146,7 @@ esac
 	    -e 's|\.c\.c|.c|' $uwinfix | \
         $uniq | $sort | $uniq >>$outfile
     else
-        $cppstdin $finc -I. $cppflags $cppminus <UU/$file.c >$$.cout 2>$$.cerr
+        $cppstdin -DPERL_CORE $finc -I. $cppflags $cppminus <UU/$file.c >$$.cout 2>$$.cerr
         $sed \
 	    -e '1d' \
 	    -e '/^#.*<stdin>/d' \


### PR DESCRIPTION
makedepend_file does not find all deps for our code because in many
cases the dependencies are hidden behind a guard clause which checks
if PERL_CORE is defined. This is annoying when working on the regex
engine as after `make regen` is executed `make` does not notice that
files like regnodes.h have been updated. No doubt it is annoying in
other contexts too.

This adds the -DPERL_CORE so that we pick up these guarded dependencies.
With this patch things updating regnodes.h is noticed and regcomp.o,
regexec.o and miniperl will be appropriately rebuilt.

Thanks to Dagfinn Ilmari Mannsåker for figuring this out.