### PR TITLE
`use VERSION` in docs

### DIFF
--- a/pod/perldbmfilter.pod
+++ b/pod/perldbmfilter.pod
@@ -84,8 +84,7 @@ the database and have them removed when you read from the database. As I'm
 sure you have already guessed, this is a problem that DBM Filters can
 fix very easily.
 
-    use strict;
-    use warnings;
+    use v5.36;
     use SDBM_File;
     use Fcntl;
 
@@ -132,8 +131,7 @@ when reading.
 
 Here is a DBM Filter that does it:
 
-    use strict;
-    use warnings;
+    use v5.36;
     use DB_File;
     my %hash;
     my $filename = "filt";

--- a/pod/perldebtut.pod
+++ b/pod/perldebtut.pod
@@ -421,8 +421,8 @@ For more on references see L<perlref> and L<perlreftut>
 Here's a simple program which converts between Celsius and Fahrenheit, it too
 has a problem:
 
- #!/usr/bin/perl -w
- use strict;
+ #!/usr/bin/perl
+ use v5.36;
 
  my $arg = $ARGV[0] || '-c20';
 

--- a/pod/perldsc.pod
+++ b/pod/perldsc.pod
@@ -284,11 +284,11 @@ of the array pointed to by $AoA. If you wanted the C notion, you could
 write C<< $AoA[$i]->$* >> to explicitly dereference the I<i'th> item,
 reading left to right.
 
-=head1 WHY YOU SHOULD ALWAYS C<use strict>
+=head1 WHY YOU SHOULD ALWAYS C<use VERSION>
 
 If this is starting to sound scarier than it's worth, relax.  Perl has
-some features to help you avoid its most common pitfalls.  The best
-way to avoid getting confused is to start every program with:
+some features to help you avoid its most common pitfalls.  One way to avoid
+getting confused is to start every program with:
 
     use strict;
 
@@ -309,6 +309,19 @@ because you were accidentally accessing C<@aref>, an undeclared
 variable, and it would thereby remind you to write instead:
 
     print $aref->[2][2]
+
+Since Perl version 5.12, a C<use VERSION> declaration will also enable the
+C<strict> pragma.  In addition, it will also enable a feature bundle,
+giving more useful features.  Since version 5.36 it will also enable the
+C<warnings> pragma.  Often the best way to activate all these things at
+once is to start a file with:
+
+    use v5.36;
+
+In this way, every file will start with C<strict>, C<warnings>, and many
+useful named features all switched on, as well as several older features
+being switched off (such as L<C<indirect>|feature/The 'indirect' feature>).
+For more information, see L<perlfunc/use VERSION>.
 
 =head1 DEBUGGING
 X<data structure, debugging> X<complex data structure, debugging>

--- a/pod/perlfilter.pod
+++ b/pod/perlfilter.pod
@@ -410,8 +410,7 @@ Here is the complete Debug filter:
 
     package Debug;
 
-    use strict;
-    use warnings;
+    use v5.36;
     use Filter::Util::Call;
 
     use constant TRUE => 1;

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -703,7 +703,7 @@ Portability issues: L<perlport/-X>.
 To avoid confusing would-be users of your code with mysterious
 syntax errors, put something like this at the top of your script:
 
-    use 5.010;  # so filetest ops can stack
+    use v5.10;  # so filetest ops can stack
 
 =item abs VALUE
 X<abs> X<absolute>
@@ -2082,8 +2082,8 @@ versions of Perl with mysterious syntax errors, put this sort of thing at
 the top of your file to signal that your code will work I<only> on Perls of
 a recent vintage:
 
-    use 5.012;	# so keys/values/each work on arrays
-    use 5.018;	# so each assigns to $_ in a lone while test
+    use v5.12;	# so keys/values/each work on arrays
+    use v5.18;	# so each assigns to $_ in a lone while test
 
 See also L<C<keys>|/keys HASH>, L<C<values>|/values HASH>, and
 L<C<sort>|/sort SUBNAME LIST>.
@@ -3821,7 +3821,7 @@ versions of Perl with mysterious syntax errors, put this sort of thing at
 the top of your file to signal that your code will work I<only> on Perls of
 a recent vintage:
 
-    use 5.012;	# so keys/values/each work on arrays
+    use v5.12;	# so keys/values/each work on arrays
 
 See also L<C<each>|/each HASH>, L<C<values>|/values HASH>, and
 L<C<sort>|/sort SUBNAME LIST>.
@@ -6406,7 +6406,7 @@ versions of Perl with mysterious failures, put this sort of thing at the
 top of your file to signal that your code will work I<only> on Perls of a
 recent vintage:
 
-    use 5.012; # so readdir assigns to $_ in a lone while test
+    use v5.12; # so readdir assigns to $_ in a lone while test
 
 =item readline EXPR
 
@@ -8343,7 +8343,7 @@ conversion flag.  Should you instead prefer an exception, do this:
 If you would like to know about a version dependency before you
 start running the program, put something like this at its top:
 
-    use 5.014;  # for hh/j/t/z/ printf modifiers
+    use v5.14;  # for hh/j/t/z/ printf modifiers
 
 You can find out whether your Perl supports quads via L<Config>:
 
@@ -8454,7 +8454,7 @@ L<C<srand>|/srand EXPR> uses that for the seed; otherwise it
 it returns the seed.  To signal that your code will work I<only> on Perls
 of a recent vintage:
 
-    use 5.014;	# so srand returns the seed
+    use v5.14;	# so srand returns the seed
 
 If L<C<srand>|/srand EXPR> is not called explicitly, it is called
 implicitly without a parameter at the first use of the
@@ -9924,7 +9924,7 @@ versions of Perl with mysterious syntax errors, put this sort of thing at
 the top of your file to signal that your code will work I<only> on Perls of
 a recent vintage:
 
-    use 5.012;	# so keys/values/each work on arrays
+    use v5.12;	# so keys/values/each work on arrays
 
 See also L<C<keys>|/keys HASH>, L<C<each>|/each HASH>, and
 L<C<sort>|/sort SUBNAME LIST>.

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -5119,7 +5119,7 @@ L<C<our>|/our VARLIST> declaration.  This applies immediately--even
 within the same statement.
 
     package Foo;
-    use strict;
+    use v5.36;  # which implies "use strict;"
 
     $Foo::foo = 23;
 
@@ -5136,7 +5136,7 @@ This works even if the package variable has not been used before, as
 package variables spring into existence when first used.
 
     package Foo;
-    use strict;
+    use v5.36;
 
     our $foo = 23;   # just like $Foo::foo = 23
 
@@ -5147,7 +5147,7 @@ long as there is no variable with that name is already in scope, you can then
 reference the package variable again even within the same statement.
 
     package Foo;
-    use strict;
+    use v5.36;
 
     my  $foo = $foo; # error, undeclared $foo on right-hand side
     our $foo = $foo; # no errors

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -9820,6 +9820,11 @@ different implementations, file naming conventions, and other
 infrastructure, this feature is now little used in practice and should be
 avoided in newly-written code.
 
+Care should be taken when using the C<no VERSION> form, as it is I<only>
+meant to be used to assert that the running Perl is of a earlier version
+than its argument and I<not> to undo the feature-enabling side effects
+of C<use VERSION>.
+
 =item utime LIST
 X<utime>
 

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -9653,8 +9653,6 @@ X<use> X<module> X<import>
 
 =item use Module
 
-=item use VERSION
-
 =for Pod::Functions load in a module at compile time and import its namespace
 
 Imports some semantics into the current package from the named module,
@@ -9665,45 +9663,6 @@ package.  It is exactly equivalent to
 
 except that Module I<must> be a bareword.
 The importation can be made conditional by using the L<if> module.
-
-In the C<use VERSION> form, VERSION may be either a v-string such as
-v5.24.1, which will be compared to L<C<$^V>|perlvar/$^V> (aka
-$PERL_VERSION), or a numeric argument of the form 5.024001, which will
-be compared to L<C<$]>|perlvar/$]>.  An exception is raised if VERSION
-is greater than the version of the current Perl interpreter; Perl will
-not attempt to parse the rest of the file.  Compare with
-L<C<require>|/require VERSION>, which can do a similar check at run
-time.  Symmetrically, C<no VERSION> allows you to specify that you
-want a version of Perl older than the specified one.
-
-Specifying VERSION as a numeric argument of the form 5.024001 should
-generally be avoided as older less readable syntax compared to
-v5.24.1. Before perl 5.8.0 released in 2002 the more verbose numeric
-form was the only supported syntax, which is why you might see it in
-
-    use v5.24.1;    # compile time version check
-    use 5.24.1;     # ditto
-    use 5.024_001;  # ditto; older syntax compatible with perl 5.6
-
-This is often useful if you need to check the current Perl version before
-L<C<use>|/use Module VERSION LIST>ing library modules that won't work
-with older versions of Perl.
-(We try not to do this more than we have to.)
-
-C<use VERSION> lexically enables all features available in the requested
-version as defined by the L<feature> pragma, disabling any features
-not in the requested version's feature bundle.  See L<feature>.
-If the specified Perl version is greater than or equal to
-5.12.0, strictures are enabled lexically as
-with L<C<use strict>|strict>.  
-Similarly, L<warnings> are enabled if C<VERSION> is 5.35.0 or higher.
-Any explicit use of C<use strict> or C<no strict> overrides C<use VERSION>,
-even if it comes before it.
-Later use of C<use VERSION> will override all behavior of a previous
-C<use VERSION>, possibly removing the C<strict>, C<warnings>, and C<feature>
-added by C<use VERSION>.  C<use VERSION> does not
-load the F<feature.pm>, F<strict.pm>, or F<warnings.pm>
-files.
 
 The C<BEGIN> forces the L<C<require>|/require VERSION> and
 L<C<import>|/import LIST> to happen at compile time.  The
@@ -9796,16 +9755,70 @@ or no unimport method being found.
     no strict 'refs';
     no warnings;
 
-Care should be taken when using the C<no VERSION> form of L<C<no>|/no
-MODULE VERSION LIST>.  It is
-I<only> meant to be used to assert that the running Perl is of a earlier
-version than its argument and I<not> to undo the feature-enabling side effects
-of C<use VERSION>.
-
 See L<perlmodlib> for a list of standard modules and pragmas.  See
 L<perlrun|perlrun/-m[-]module> for the C<-M> and C<-m> command-line
 options to Perl that give L<C<use>|/use Module VERSION LIST>
 functionality from the command-line.
+
+=item use VERSION
+
+=for Pod::Functions enable Perl language features and declare required version
+
+Lexically enables all features available in the requested version as
+defined by the L<feature> pragma, disabling any features not in the
+requested version's feature bundle.  See L<feature>.
+
+VERSION may be either a v-string such as v5.24.1, which will be compared
+to L<C<$^V>|perlvar/$^V> (aka $PERL_VERSION), or a numeric argument of the
+form 5.024001, which will be compared to L<C<$]>|perlvar/$]>.  An
+exception is raised if VERSION is greater than the version of the current
+Perl interpreter; Perl will not attempt to parse the rest of the file.
+Compare with L<C<require>|/require VERSION>, which can do a similar check
+at run time.
+
+If the specified Perl version is 5.12 or higher, strictures are enabled
+lexically as with L<C<use strict>|strict>.  Similarly, if the specified
+Perl version is 5.35.0 or higher, L<warnings> are enabled.  Later use of
+C<use VERSION> will override all behavior of a previous C<use VERSION>,
+possibly removing the C<strict>, C<warnings>, and C<feature> added by it.
+C<use VERSION> does not load the F<feature.pm>, F<strict.pm>, or
+F<warnings.pm> files.
+
+In the current implementation, any explicit use of C<use strict> or
+C<no strict> overrides C<use VERSION>, even if it comes before it.
+However, this may be subject to change in a future release of Perl, so new
+code should not rely on this fact.  It is recommended that a
+C<use VERSION> declaration be the first significant statement within a
+file (possibly after a C<package> statement or any amount of whitespace or
+comment), so that its effects happen first, and other pragmata are applied
+after it.
+
+Specifying VERSION as a numeric argument of the form 5.024001 should
+generally be avoided as older less readable syntax compared to
+v5.24.1. Before perl 5.8.0 released in 2002 the more verbose numeric
+form was the only supported syntax, which is why you might see it in
+older code.
+
+    use v5.24.1;    # compile time version check
+    use 5.24.1;     # ditto
+    use 5.024_001;  # ditto; older syntax compatible with perl 5.6
+
+This is often useful if you need to check the current Perl version before
+L<C<use>|/use Module VERSION LIST>ing library modules that won't work
+with older versions of Perl.
+(We try not to do this more than we have to.)
+
+Symmetrically, C<no VERSION> allows you to specify that you want a version
+of Perl older than the specified one.  Historically this was added during
+early designs of the Raku language (formerly "Perl 6"), so that a Perl 5
+program could begin
+
+    no 6;
+
+to declare that it is not a Perl 6 program.  As the two languages have
+different implementations, file naming conventions, and other
+infrastructure, this feature is now little used in practice and should be
+avoided in newly-written code.
 
 =item utime LIST
 X<utime>

--- a/pod/perlintro.pod
+++ b/pod/perlintro.pod
@@ -102,6 +102,13 @@ enable both C<strict> and C<warnings>:
   #!/usr/bin/perl
   use v5.35;
 
+In addition to enabling the C<strict> and C<warnings> pragmata, this
+declaration will also activate a
+L<"feature bundle"|feature/FEATURE BUNDLES>; a collection of named
+features that enable many of the more recent additions and changes to the
+language, as well as occasionally removing older features found to have
+been mistakes in design and discouraged.
+
 =head2 Basic syntax overview
 
 A Perl script or program consists of one or more statements.  These

--- a/pod/perlipc.pod
+++ b/pod/perlipc.pod
@@ -190,8 +190,7 @@ info to show that it works; it should be replaced with the real code.
 
   #!/usr/bin/perl
 
-  use strict;
-  use warnings;
+  use v5.36;
 
   use POSIX ();
   use FindBin ();
@@ -834,8 +833,7 @@ reopen the appropriate handles to STDIN and STDOUT and call other processes.
  #!/usr/bin/perl
  # pipe1 - bidirectional communication using two pipe pairs
  #         designed for the socketpair-challenged
- use strict;
- use warnings;
+ use v5.36;
  use IO::Handle;  # enable autoflush method before Perl 5.14
  pipe(my $parent_rdr, my $child_wtr);  # XXX: check failure?
  pipe(my $child_rdr,  my $parent_wtr); # XXX: check failure?
@@ -869,8 +867,7 @@ have the socketpair() system call, it will do this all for you.
  # pipe2 - bidirectional communication using socketpair
  #   "the best ones always go both ways"
 
- use strict;
- use warnings;
+ use v5.36;
  use Socket;
  use IO::Handle;  # enable autoflush method before Perl 5.14
 
@@ -950,8 +947,7 @@ communication that might extend to machines outside of your own system.
 Here's a sample TCP client using Internet-domain sockets:
 
     #!/usr/bin/perl
-    use strict;
-    use warnings;
+    use v5.36;
     use Socket;
 
     my $remote  = shift || "localhost";
@@ -978,8 +974,7 @@ on a particular interface (like the external side of a gateway
 or firewall machine), fill this in with your real address instead.
 
  #!/usr/bin/perl -T
- use strict;
- use warnings;
+ use v5.36;
  BEGIN { $ENV{PATH} = "/usr/bin:/bin" }
  use Socket;
  use Carp;
@@ -1018,8 +1013,7 @@ handle the client request so that the master server can quickly
 go back to service a new client.
 
  #!/usr/bin/perl -T
- use strict;
- use warnings;
+ use v5.36;
  BEGIN { $ENV{PATH} = "/usr/bin:/bin" }
  use Socket;
  use Carp;
@@ -1147,8 +1141,7 @@ service on a number of different machines and shows how far their clocks
 differ from the system on which it's being run:
 
     #!/usr/bin/perl
-    use strict;
-    use warnings;
+    use v5.36;
     use Socket;
 
     my $SECS_OF_70_YEARS = 2208988800;
@@ -1196,9 +1189,8 @@ You can test for these with Perl's B<-S> file test:
 Here's a sample Unix-domain client:
 
     #!/usr/bin/perl
+    use v5.36;
     use Socket;
-    use strict;
-    use warnings;
 
     my $rendezvous = shift || "catsock";
     socket(my $sock, PF_UNIX, SOCK_STREAM, 0) || die "socket: $!";
@@ -1213,8 +1205,7 @@ network terminators here because Unix domain sockets are guaranteed
 to be on the localhost, and thus everything works right.
 
     #!/usr/bin/perl -T
-    use strict;
-    use warnings;
+    use v5.36;
     use Socket;
     use Carp;
 
@@ -1321,8 +1312,7 @@ service at port 13 of the host name "localhost" and prints out everything
 that the server there cares to provide.
 
     #!/usr/bin/perl
-    use strict;
-    use warnings;
+    use v5.36;
     use IO::Socket;
     my $remote = IO::Socket::INET->new(
                         Proto    => "tcp",
@@ -1377,8 +1367,7 @@ more interesting client than the previous one because it first sends
 something to the server before fetching the server's response.
 
     #!/usr/bin/perl
-    use strict;
-    use warnings;
+    use v5.36;
     use IO::Socket;
     unless (@ARGV > 1) { die "usage: $0 host url ..." }
     my $host = shift(@ARGV);
@@ -1458,8 +1447,7 @@ well, which is probably why it's spread to other systems.)
 Here's the code:
 
     #!/usr/bin/perl
-    use strict;
-    use warnings;
+    use v5.36;
     use IO::Socket;
 
     unless (@ARGV == 2) { die "usage: $0 host port" }
@@ -1573,8 +1561,7 @@ Chapter 16 of the Camel.
 Here's the code.
 
  #!/usr/bin/perl
- use strict;
- use warnings;
+ use v5.36;
  use IO::Socket;
  use Net::hostent;      # for OOish version of gethostbyaddr
 
@@ -1635,8 +1622,7 @@ using select() to do a timed-out wait for I/O.  To do something similar
 with TCP, you'd have to use a different socket handle for each host.
 
  #!/usr/bin/perl
- use strict;
- use warnings;
+ use v5.36;
  use Socket;
  use Sys::Hostname;
 
@@ -1804,8 +1790,7 @@ programs this way for optimal success, and don't forget to add the B<-T>
 taint-checking flag to the C<#!> line for servers:
 
     #!/usr/bin/perl -T
-    use strict;
-    use warnings;
+    use v5.36;
     use sigtrap;
     use Socket;
 

--- a/pod/perllol.pod
+++ b/pod/perllol.pod
@@ -15,7 +15,7 @@ An array of an array is just a regular old array @AoA that you can
 get at with two subscripts, like C<$AoA[3][2]>.  Here's a declaration
 of the array:
 
-    use 5.010;  # so we can use say()
+    use v5.10;  # so we can use say()
 
     # assign to our array, an array of array references
     @AoA = (

--- a/pod/perlmod.pod
+++ b/pod/perlmod.pod
@@ -448,8 +448,7 @@ create a file called F<Some/Module.pm> and start with this template:
 
     package Some::Module;  # assumes Some/Module.pm
 
-    use strict;
-    use warnings;
+    use v5.36;
 
     # Get the import method from Exporter to export functions and
     # variables

--- a/pod/perlmodstyle.pod
+++ b/pod/perlmodstyle.pod
@@ -706,8 +706,8 @@ Specify version requirements for other Perl modules in the
 pre-requisites in your Makefile.PL or Build.PL.
 
 Be sure to specify Perl version requirements both in Makefile.PL or
-Build.PL and with C<require 5.6.1> or similar.  See the section on
-C<use VERSION> of L<perlfunc/require> for details.
+Build.PL and with C<require 5.6.1> or similar.  See the documentation on
+L<C<use VERSION>|perlfunc/use VERSION> for details.
 
 =head2 Testing
 

--- a/pod/perlobj.pod
+++ b/pod/perlobj.pod
@@ -751,6 +751,16 @@ appending "::" to it, like we saw earlier:
 
   my $file = new File:: $path, $data;
 
+Indirect object syntax is only available when the 
+L<C<"indirect">|feature/The 'indirect' feature> named feature is enabled.
+This is enabled by default, but can be disabled if requested.  This
+feature is present in older feature version bundles, but was removed
+from the C<:5.36> bundle; so a L<C<use VERSION>|perlfunc/use VERSION>
+declaration of C<v5.36> or above will also disable the feature.
+
+    use v5.36;
+    # indirect object syntax is no longer available
+
 =head2 C<bless>, C<blessed>, and C<ref>
 
 As we saw earlier, an object is simply a data structure that has been

--- a/pod/perlobj.pod
+++ b/pod/perlobj.pod
@@ -1011,8 +1011,7 @@ Here's an example of a module as a blessed scalar:
 
   package Time;
 
-  use strict;
-  use warnings;
+  use v5.36;
 
   sub new {
       my $class = shift;
@@ -1050,8 +1049,7 @@ to support inside-out object implementations.
 
   package Time;
 
-  use strict;
-  use warnings;
+  use v5.36;
 
   use Hash::Util::FieldHash 'fieldhash';
 

--- a/pod/perlperf.pod
+++ b/pod/perlperf.pod
@@ -126,8 +126,7 @@ comparative code in a file and running a C<Benchmark> test.
 
  #!/usr/bin/perl
 
- use strict;
- use warnings;
+ use v5.36;
 
  use Benchmark;
 
@@ -193,8 +192,7 @@ noticing it's assigned only the once.
 
  #!/usr/bin/perl
 
- use strict;
- use warnings;
+ use v5.36;
 
  use Benchmark;
 
@@ -229,8 +227,7 @@ report on the contents.
 
  #!/usr/bin/perl
 
- use strict;
- use warnings;
+ use v5.36;
 
  =head1 NAME
 
@@ -815,8 +812,7 @@ command-line.
 
  #!/usr/bin/perl -n
 
- use strict;
- use warnings;
+ use v5.36;
 
  my @data;
 
@@ -910,8 +906,7 @@ input directly as it arrives too.  Otherwise, the code looks fairly similar:
 
  #!/usr/bin/perl -n
 
- use strict;
- use warnings;
+ use v5.36;
 
  print
 
@@ -998,8 +993,7 @@ including a C<debug()> subroutine to emulate typical C<logger()> functionality.
 
  #!/usr/bin/perl
 
- use strict;
- use warnings;
+ use v5.36;
 
  use Benchmark;
  use Data::Dumper;
@@ -1045,8 +1039,7 @@ time C<DEBUG> constant.
 
  #!/usr/bin/perl
 
- use strict;
- use warnings;
+ use v5.36;
 
  use Benchmark;
  use Data::Dumper;

--- a/pod/perlpragma.pod
+++ b/pod/perlpragma.pod
@@ -51,8 +51,7 @@ The minimal implementation of the package C<MyMaths> would be something like
 this:
 
     package MyMaths;
-    use warnings;
-    use strict;
+    use v5.36;
     use myint();
     use overload '+' => sub {
         my ($l, $r) = @_;
@@ -78,8 +77,7 @@ The interaction with the Perl compilation happens inside package C<myint>:
 
     package myint;
 
-    use strict;
-    use warnings;
+    use v5.36;
 
     sub import {
         $^H{"myint/in_effect"} = 1;

--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -672,7 +672,7 @@ security issues.
 
 This modifier may be specified to be the default by C<use feature
 'unicode_strings>, C<use locale ':not_characters'>, or
-C<L<use 5.012|perlfunc/use VERSION>> (or higher),
+C<L<use v5.12|perlfunc/use VERSION>> (or higher),
 but see L</Which character set modifier is in effect?>.
 X</u>
 
@@ -836,7 +836,7 @@ listed below that also change the defaults.
 
 Otherwise, C<L<use locale|perllocale>> sets the default modifier to C</l>;
 and C<L<use feature 'unicode_strings|feature>>, or
-C<L<use 5.012|perlfunc/use VERSION>> (or higher) set the default to
+C<L<use v5.12|perlfunc/use VERSION>> (or higher) set the default to
 C</u> when not in the same scope as either C<L<use locale|perllocale>>
 or C<L<use bytes|bytes>>.
 (C<L<use locale ':not_characters'|perllocale/Unicode and UTF-8>> also

--- a/pod/perlref.pod
+++ b/pod/perlref.pod
@@ -232,6 +232,11 @@ better to use the direct method invocation approach:
     $menubar = $main->Frame(-relief              => "raised",
                             -borderwidth         => 2)
 
+This indirect object syntax is only available when
+L<C<use feature "indirect">|feature/The 'indirect' feature> is in effect,
+and that is not the case when L<C<use v5.36>|perlfunc/use VERSION> (or
+higher) is requested, it is best to avoid indirect object syntax entirely.
+
 =head3 Autovivification
 X<autovivification>
 

--- a/pod/perlretut.pod
+++ b/pod/perlretut.pod
@@ -2048,7 +2048,7 @@ The answer to requirement 2) is that a regexp (mostly)
 uses Unicode characters.  The "mostly" is for messy backward
 compatibility reasons, but starting in Perl 5.14, any regexp compiled in
 the scope of a C<use feature 'unicode_strings'> (which is automatically
-turned on within the scope of a C<use 5.012> or higher) will turn that
+turned on within the scope of a C<use v5.12> or higher) will turn that
 "mostly" into "always".  If you want to handle Unicode properly, you
 should ensure that C<'unicode_strings'> is turned on.
 Internally, this is encoded to bytes using either UTF-8 or a native 8

--- a/pod/perlrun.pod
+++ b/pod/perlrun.pod
@@ -212,7 +212,7 @@ advised to use a specific path if you care about a specific version.
 or if you just want to be running at least version, place a statement
 like this at the top of your program:
 
-    use 5.014;
+    use v5.14;
 
 =head2 Command Switches
 X<perl, command switches> X<command switches>

--- a/pod/perlstyle.pod
+++ b/pod/perlstyle.pod
@@ -16,6 +16,13 @@ disable.  The B<-w> flag and C<$^W> variable should not be used for this
 purpose since they can affect code you use but did not write, such as
 modules from core or CPAN.
 
+A concise way to arrange for this is to use the
+L<C<use VERSION>|perlfunc/use VERSION> syntax, requesting a version 5.36
+or above, which will enable both the C<strict> and C<warnings> pragmata (as
+well as several other useful L<named features|feature/AVAILABLE FEATURES>).
+
+    use v5.36;
+
 Regarding aesthetics of code lay out, about the only thing Larry
 cares strongly about is that the closing curly bracket of
 a multi-line BLOCK should line up with the keyword that started the construct.

--- a/pod/perlsub.pod
+++ b/pod/perlsub.pod
@@ -241,11 +241,11 @@ to cheat if you know what you're doing.  See L</Prototypes> below.
 X<&>
 
 Since Perl 5.16.0, the C<__SUB__> token is available under C<use feature
-'current_sub'> and C<use 5.16.0>.  It will evaluate to a reference to the
+'current_sub'> and C<use v5.16>.  It will evaluate to a reference to the
 currently-running sub, which allows for recursive calls without knowing
 your subroutine's name.
 
-    use 5.16.0;
+    use v5.16;
     my $factorial = sub {
       my ($x) = @_;
       return 1 if $x == 1;
@@ -1105,7 +1105,7 @@ X<my sub> X<state sub> X<our sub> X<subroutine, lexical>
 
 Beginning with Perl 5.18, you can declare a private subroutine with C<my>
 or C<state>.  As with state variables, the C<state> keyword is only
-available under C<use feature 'state'> or C<use 5.010> or higher.
+available under C<use feature 'state'> or C<use v5.10> or higher.
 
 Prior to Perl 5.26, lexical subroutines were deemed experimental and were
 available only under the C<use feature 'lexical_subs'> pragma.  They also

--- a/pod/perlthrtut.pod
+++ b/pod/perlthrtut.pod
@@ -852,37 +852,36 @@ things we've covered.  This program finds prime numbers using threads.
    1 #!/usr/bin/perl
    2 # prime-pthread, courtesy of Tom Christiansen
    3
-   4 use strict;
-   5 use warnings;
-   6
-   7 use threads;
-   8 use Thread::Queue;
-   9
-  10 sub check_num {
-  11     my ($upstream, $cur_prime) = @_;
-  12     my $kid;
-  13     my $downstream = Thread::Queue->new();
-  14     while (my $num = $upstream->dequeue()) {
-  15         next unless ($num % $cur_prime);
-  16         if ($kid) {
-  17             $downstream->enqueue($num);
-  18         } else {
-  19             print("Found prime: $num\n");
-  20             $kid = threads->create(\&check_num, $downstream, $num);
-  21             if (! $kid) {
-  22                 warn("Sorry.  Ran out of threads.\n");
-  23                 last;
-  24             }
-  25         }
-  26     }
-  27     if ($kid) {
-  28         $downstream->enqueue(undef);
-  29         $kid->join();
-  30     }
-  31 }
-  32
-  33 my $stream = Thread::Queue->new(3..1000, undef);
-  34 check_num($stream, 2);
+   4 use v5.36;
+   5
+   6 use threads;
+   7 use Thread::Queue;
+   8
+   9 sub check_num {
+  10     my ($upstream, $cur_prime) = @_;
+  11     my $kid;
+  12     my $downstream = Thread::Queue->new();
+  13     while (my $num = $upstream->dequeue()) {
+  14         next unless ($num % $cur_prime);
+  15         if ($kid) {
+  16             $downstream->enqueue($num);
+  17         } else {
+  18             print("Found prime: $num\n");
+  19             $kid = threads->create(\&check_num, $downstream, $num);
+  20             if (! $kid) {
+  21                 warn("Sorry.  Ran out of threads.\n");
+  22                 last;
+  23             }
+  24         }
+  25     }
+  26     if ($kid) {
+  27         $downstream->enqueue(undef);
+  28         $kid->join();
+  29     }
+  30 }
+  31
+  32 my $stream = Thread::Queue->new(3..1000, undef);
+  33 check_num($stream, 2);
 
 This program uses the pipeline model to generate prime numbers.  Each
 thread in the pipeline has an input queue that feeds numbers to be
@@ -901,32 +900,32 @@ number is, it's a number that's only evenly divisible by itself and 1.)
 The bulk of the work is done by the C<check_num()> subroutine, which
 takes a reference to its input queue and a prime number that it's
 responsible for.  After pulling in the input queue and the prime that
-the subroutine is checking (line 11), we create a new queue (line 13)
+the subroutine is checking (line 10), we create a new queue (line 12)
 and reserve a scalar for the thread that we're likely to create later
-(line 12).
+(line 11).
 
-The while loop from line 14 to line 26 grabs a scalar off the input
+The while loop from line 13 to line 25 grabs a scalar off the input
 queue and checks against the prime this thread is responsible
-for.  Line 15 checks to see if there's a remainder when we divide the
+for.  Line 14 checks to see if there's a remainder when we divide the
 number to be checked by our prime.  If there is one, the number
 must not be evenly divisible by our prime, so we need to either pass
-it on to the next thread if we've created one (line 17) or create a
+it on to the next thread if we've created one (line 16) or create a
 new thread if we haven't.
 
-The new thread creation is line 20.  We pass on to it a reference to
-the queue we've created, and the prime number we've found.  In lines 21
-through 24, we check to make sure that our new thread got created, and
+The new thread creation is line 19.  We pass on to it a reference to
+the queue we've created, and the prime number we've found.  In lines 20
+through 23, we check to make sure that our new thread got created, and
 if not, we stop checking any remaining numbers in the queue.
 
 Finally, once the loop terminates (because we got a 0 or C<undef> in the
 queue, which serves as a note to terminate), we pass on the notice to our
-child, and wait for it to exit if we've created a child (lines 27 and
-30).
+child, and wait for it to exit if we've created a child (lines 26 and
+29).
 
-Meanwhile, back in the main thread, we first create a queue (line 33) and
+Meanwhile, back in the main thread, we first create a queue (line 32) and
 queue up all the numbers from 3 to 1000 for checking, plus a termination
 notice.  Then all we have to do to get the ball rolling is pass the queue
-and the first prime to the C<check_num()> subroutine (line 34).
+and the first prime to the C<check_num()> subroutine (line 33).
 
 That's how it works.  It's pretty simple; as with many Perl programs,
 the explanation is much longer than the program.

--- a/pod/perlthrtut.pod
+++ b/pod/perlthrtut.pod
@@ -857,31 +857,30 @@ things we've covered.  This program finds prime numbers using threads.
    6 use threads;
    7 use Thread::Queue;
    8
-   9 sub check_num {
-  10     my ($upstream, $cur_prime) = @_;
-  11     my $kid;
-  12     my $downstream = Thread::Queue->new();
-  13     while (my $num = $upstream->dequeue()) {
-  14         next unless ($num % $cur_prime);
-  15         if ($kid) {
-  16             $downstream->enqueue($num);
-  17         } else {
-  18             print("Found prime: $num\n");
-  19             $kid = threads->create(\&check_num, $downstream, $num);
-  20             if (! $kid) {
-  21                 warn("Sorry.  Ran out of threads.\n");
-  22                 last;
-  23             }
-  24         }
-  25     }
-  26     if ($kid) {
-  27         $downstream->enqueue(undef);
-  28         $kid->join();
-  29     }
-  30 }
-  31
-  32 my $stream = Thread::Queue->new(3..1000, undef);
-  33 check_num($stream, 2);
+   9 sub check_num ($upstream, $cur_prime) {
+  10     my $kid;
+  11     my $downstream = Thread::Queue->new();
+  12     while (my $num = $upstream->dequeue()) {
+  13         next unless ($num % $cur_prime);
+  14         if ($kid) {
+  15             $downstream->enqueue($num);
+  16         } else {
+  17             print("Found prime: $num\n");
+  18             $kid = threads->create(\&check_num, $downstream, $num);
+  19             if (! $kid) {
+  20                 warn("Sorry.  Ran out of threads.\n");
+  21                 last;
+  22             }
+  23         }
+  24     }
+  25     if ($kid) {
+  26         $downstream->enqueue(undef);
+  27         $kid->join();
+  28     }
+  29 }
+  30
+  31 my $stream = Thread::Queue->new(3..1000, undef);
+  32 check_num($stream, 2);
 
 This program uses the pipeline model to generate prime numbers.  Each
 thread in the pipeline has an input queue that feeds numbers to be
@@ -899,33 +898,31 @@ number is, it's a number that's only evenly divisible by itself and 1.)
 
 The bulk of the work is done by the C<check_num()> subroutine, which
 takes a reference to its input queue and a prime number that it's
-responsible for.  After pulling in the input queue and the prime that
-the subroutine is checking (line 10), we create a new queue (line 12)
-and reserve a scalar for the thread that we're likely to create later
-(line 11).
+responsible for.  We create a new queue (line 11) and reserve a scalar
+for the thread that we're likely to create later (line 10).
 
-The while loop from line 13 to line 25 grabs a scalar off the input
+The while loop from line 12 to line 24 grabs a scalar off the input
 queue and checks against the prime this thread is responsible
-for.  Line 14 checks to see if there's a remainder when we divide the
+for.  Line 13 checks to see if there's a remainder when we divide the
 number to be checked by our prime.  If there is one, the number
 must not be evenly divisible by our prime, so we need to either pass
-it on to the next thread if we've created one (line 16) or create a
+it on to the next thread if we've created one (line 15) or create a
 new thread if we haven't.
 
-The new thread creation is line 19.  We pass on to it a reference to
-the queue we've created, and the prime number we've found.  In lines 20
-through 23, we check to make sure that our new thread got created, and
+The new thread creation is line 18.  We pass on to it a reference to
+the queue we've created, and the prime number we've found.  In lines 19
+through 22, we check to make sure that our new thread got created, and
 if not, we stop checking any remaining numbers in the queue.
 
 Finally, once the loop terminates (because we got a 0 or C<undef> in the
 queue, which serves as a note to terminate), we pass on the notice to our
-child, and wait for it to exit if we've created a child (lines 26 and
-29).
+child, and wait for it to exit if we've created a child (lines 25 and
+28).
 
-Meanwhile, back in the main thread, we first create a queue (line 32) and
+Meanwhile, back in the main thread, we first create a queue (line 31) and
 queue up all the numbers from 3 to 1000 for checking, plus a termination
 notice.  Then all we have to do to get the ball rolling is pass the queue
-and the first prime to the C<check_num()> subroutine (line 33).
+and the first prime to the C<check_num()> subroutine (line 32).
 
 That's how it works.  It's pretty simple; as with many Perl programs,
 the explanation is much longer than the program.

--- a/pod/perltie.pod
+++ b/pod/perltie.pod
@@ -1070,8 +1070,7 @@ a scalar.
 
     package Remember;
 
-    use strict;
-    use warnings;
+    use v5.36;
     use IO::File;
 
     sub TIESCALAR {

--- a/pod/perlunicode.pod
+++ b/pod/perlunicode.pod
@@ -47,7 +47,7 @@ In order to preserve backward compatibility, Perl does not turn
 on full internal Unicode support unless the pragma
 L<S<C<use feature 'unicode_strings'>>|feature/The 'unicode_strings' feature>
 is specified.  (This is automatically
-selected if you S<C<use 5.012>> or higher.)  Failure to do this can
+selected if you S<C<use v5.12>> or higher.)  Failure to do this can
 trigger unexpected surprises.  See L</The "Unicode Bug"> below.
 
 This pragma doesn't affect I/O.  Nor does it change the internal
@@ -248,7 +248,7 @@ affected with newer perls.  See L</The "Unicode Bug">.
 
 =item *
 
-Within the scope of S<C<use 5.012>> or higher
+Within the scope of S<C<use v5.12>> or higher
 
 This implicitly turns on S<C<use feature 'unicode_strings'>>.
 
@@ -2044,7 +2044,7 @@ You can see from the above that the effect of C<unicode_strings>
 increased over several Perl releases.  (And Perl's support for Unicode
 continues to improve; it's best to use the latest available release in
 order to get the most complete and accurate results possible.)  Note that
-C<unicode_strings> is automatically chosen if you S<C<use 5.012>> or
+C<unicode_strings> is automatically chosen if you S<C<use v5.12>> or
 higher.
 
 For Perls earlier than those described above, or when a string is passed

--- a/pod/perlunicook.pod
+++ b/pod/perlunicook.pod
@@ -21,10 +21,9 @@ to work correctly, with the C<#!> adjusted to work on your system:
 
  #!/usr/bin/env perl
 
+ use v5.36;     # or later to get "unicode_strings" feature,
+                #   plus strict, warnings
  use utf8;      # so literals and identifiers can be in UTF-8
- use v5.12;     # or later to get "unicode_strings" feature
- use strict;    # quote strings, declare variables
- use warnings;  # on by default
  use warnings  qw(FATAL utf8);    # fatalize encoding glitches
  use open      qw(:std :encoding(UTF-8)); # undeclared streams in UTF-8
  use charnames qw(:full :short);  # unneeded in v5.16
@@ -696,17 +695,15 @@ When run, the following program produces this nicely aligned output:
     寿司............... €9.99
     包子............... €7.50
 
-Here's that program; tested on v5.14.
+Here's that program.
 
  #!/usr/bin/env perl
  # umenu - demo sorting and printing of Unicode food
  #
  # (obligatory and increasingly long preamble)
  #
+ use v5.36;
  use utf8;
- use v5.14;                       # for locale sorting
- use strict;
- use warnings;
  use warnings  qw(FATAL utf8);    # fatalize encoding faults
  use open      qw(:std :encoding(UTF-8)); # undeclared streams in UTF-8
  use charnames qw(:full :short);  # unneeded in v5.16
@@ -718,11 +715,6 @@ Here's that program; tested on v5.14.
 
  # cpan modules
  use Unicode::GCString;           # from CPAN
-
- # forward defs
- sub pad($$$);
- sub colwidth(_);
- sub entitle(_);
 
  my %price = (
      "γύρος"             => 6.50, # gyros
@@ -747,7 +739,7 @@ Here's that program; tested on v5.14.
      "お好み焼き"        => 8.00, # okonomiyaki, Japanese
  );
 
- my $width = 5 + max map { colwidth } keys %price;
+ my $width = 5 + max map { colwidth($_) } keys %price;
 
  # So the Asian stuff comes out in an order that someone
  # who reads those scripts won't freak out over; the
@@ -759,17 +751,17 @@ Here's that program; tested on v5.14.
      printf " €%.2f\n", $price{$item};
  }
 
- sub pad($$$) {
+ sub pad {
      my($str, $width, $padchar) = @_;
      return $str . ($padchar x ($width - colwidth($str)));
  }
 
- sub colwidth(_) {
+ sub colwidth {
      my($str) = @_;
      return Unicode::GCString->new($str)->columns;
  }
 
- sub entitle(_) {
+ sub entitle {
      my($str) = @_;
      $str =~ s{ (?=\pL)(\S)     (\S*) }
               { ucfirst($1) . lc($2)  }xge;

--- a/pod/perlunicook.pod
+++ b/pod/perlunicook.pod
@@ -751,18 +751,15 @@ Here's that program.
      printf " €%.2f\n", $price{$item};
  }
 
- sub pad {
-     my($str, $width, $padchar) = @_;
+ sub pad ($str, $width, $padchar) {
      return $str . ($padchar x ($width - colwidth($str)));
  }
 
- sub colwidth {
-     my($str) = @_;
+ sub colwidth ($str) {
      return Unicode::GCString->new($str)->columns;
  }
 
- sub entitle {
-     my($str) = @_;
+ sub entitle ($str) {
      $str =~ s{ (?=\pL)(\S)     (\S*) }
               { ucfirst($1) . lc($2)  }xge;
      return $str;

--- a/pod/perluniintro.pod
+++ b/pod/perluniintro.pod
@@ -160,7 +160,7 @@ started in Perl 5.28.0.)
 
 To enable this
 seamless support, you should C<use feature 'unicode_strings'> (which is
-automatically selected if you C<use 5.012> or higher).  See L<feature>.
+automatically selected if you C<use v5.12> or higher).  See L<feature>.
 (5.14 also fixes a number of bugs and departures from the Unicode
 standard.)
 
@@ -184,7 +184,7 @@ as Unicodeness cannot be avoided, the data is transparently upgraded
 to Unicode.  Prior to Perl v5.14.0, the upgrade was not completely
 transparent (see L<perlunicode/The "Unicode Bug">), and for backwards
 compatibility, full transparency is not gained unless C<use feature
-'unicode_strings'> (see L<feature>) or C<use 5.012> (or higher) is
+'unicode_strings'> (see L<feature>) or C<use v5.12> (or higher) is
 selected.
 
 Internally, Perl currently uses either whatever the native eight-bit
@@ -701,7 +701,7 @@ Very little work should be needed since nothing changes until you
 generate Unicode data.  The most important thing is getting input as
 Unicode; for that, see the earlier I/O discussion.
 To get full seamless Unicode support, add
-C<use feature 'unicode_strings'> (or C<use 5.012> or higher) to your
+C<use feature 'unicode_strings'> (or C<use v5.12> or higher) to your
 script.
 
 =item *

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -459,8 +459,9 @@ When comparing C<$]>, numeric comparison operators should be used, but the
 variable should be stringified first to avoid issues where its original
 numeric value is inaccurate.
 
-See also the documentation of C<use VERSION> and C<require VERSION>
-for a convenient way to fail if the running Perl interpreter is too old.
+See also the documentation of L<C<use VERSION>|perlfunc/use VERSION> and
+C<require VERSION> for a convenient way to fail if the running Perl
+interpreter is too old.
 
 See L</$^V> for a representation of the Perl version as a L<version>
 object, which allows more flexible string comparisons.

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -3,7 +3,7 @@
 #     ./perl -I../lib porting/customized.t --regen
 ExtUtils::Constant cpan/ExtUtils-Constant/lib/ExtUtils/Constant/Base.pm 7560e1018f806db5689dee78728ccb8374aea741
 ExtUtils::Constant cpan/ExtUtils-Constant/t/Constant.t 165e9c7132b003fd192d32a737b0f51f9ba4999e
-Filter::Util::Call pod/perlfilter.pod 2d98239c4f4a930ad165444c3879629bb91f4cef
+Filter::Util::Call pod/perlfilter.pod 545265af2f45741a0e59eecdd0cfc0c9e490c1e8
 Locale::Maketext::Simple cpan/Locale-Maketext-Simple/lib/Locale/Maketext/Simple.pm 57ed38905791a17c150210cd6f42ead22a7707b6
 Math::Complex cpan/Math-Complex/lib/Math/Complex.pm 66f28a17647e2de166909ca66e4ced26f8a0a62e
 Math::Complex cpan/Math-Complex/t/Complex.t 17039e03ee798539e770ea9a0d19a99364278306


### PR DESCRIPTION
A sweep of all the `pod/*.pod` files, looking for places to update to mention `use VERSION`.

 * Split out the main docs in `perlfunc.pod` into its own section dedicated to the `use VERSION` syntax
 * Link to that from more places in the docs
 * Change code examples that used to start `use strict; use warnings;` into `use v5.36`
 * Updated v-less mentions of `use 5.0dd` into `use v5.dd`