### PR TITLE
Update Encode to 3.17

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -657,6 +657,7 @@ cpan/Encode/t/unibench.pl		benchmark script
 cpan/Encode/t/Unicode.t			test script
 cpan/Encode/t/Unicode_trailing_nul.t
 cpan/Encode/t/use-Encode-Alias.t
+cpan/Encode/t/utf32warnings.t
 cpan/Encode/t/utf8ref.t			test script
 cpan/Encode/t/utf8strict.t		test script
 cpan/Encode/t/utf8warnings.t

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -387,7 +387,7 @@ use File::Glob qw(:case);
     },
 
     'Encode' => {
-        'DISTRIBUTION' => 'DANKOGAI/Encode-3.16.tar.gz',
+        'DISTRIBUTION' => 'DANKOGAI/Encode-3.17.tar.gz',
         'FILES'        => q[cpan/Encode],
         'EXCLUDED'     => [
             qw( t/whatwg-aliases.json

--- a/cpan/Encode/Encode.pm
+++ b/cpan/Encode/Encode.pm
@@ -1,5 +1,5 @@
 #
-# $Id: Encode.pm,v 3.16 2021/10/13 08:29:04 dankogai Exp $
+# $Id: Encode.pm,v 3.17 2022/04/07 03:05:51 dankogai Exp $
 #
 package Encode;
 use strict;
@@ -7,7 +7,7 @@ use warnings;
 use constant DEBUG => !!$ENV{PERL_ENCODE_DEBUG};
 our $VERSION;
 BEGIN {
-    $VERSION = sprintf "%d.%02d", q$Revision: 3.16 $ =~ /(\d+)/g;
+    $VERSION = sprintf "%d.%02d", q$Revision: 3.17 $ =~ /(\d+)/g;
     require XSLoader;
     XSLoader::load( __PACKAGE__, $VERSION );
 }

--- a/cpan/Encode/Makefile.PL
+++ b/cpan/Encode/Makefile.PL
@@ -1,5 +1,5 @@
 #
-# $Id: Makefile.PL,v 2.24 2021/10/13 08:29:13 dankogai Exp dankogai $
+# $Id: Makefile.PL,v 2.24 2021/10/13 08:29:13 dankogai Exp $
 #
 use 5.007003;
 use strict;

--- a/cpan/Encode/Unicode/Unicode.pm
+++ b/cpan/Encode/Unicode/Unicode.pm
@@ -3,7 +3,7 @@ package Encode::Unicode;
 use strict;
 use warnings;
 
-our $VERSION = do { my @r = ( q$Revision: 2.19 $ =~ /\d+/g ); sprintf "%d." . "%02d" x $#r, @r };
+our $VERSION = do { my @r = ( q$Revision: 2.20 $ =~ /\d+/g ); sprintf "%d." . "%02d" x $#r, @r };
 
 use XSLoader;
 XSLoader::load( __PACKAGE__, $VERSION );
@@ -170,7 +170,7 @@ simply treated as a normal character (ZERO WIDTH NO-BREAK SPACE).
 
 When BE or LE is omitted during decode(), it checks if BOM is at the
 beginning of the string; if one is found, the endianness is set to
-what the BOM says.  
+what the BOM says.
 
 =item *
 
@@ -258,15 +258,15 @@ Consider that "division by zero" of Encode :)
 
 =head1 SEE ALSO
 
-L<Encode>, L<Encode::Unicode::UTF7>, L<http://www.unicode.org/glossary/>,
-L<http://www.unicode.org/faq/utf_bom.html>,
+L<Encode>, L<Encode::Unicode::UTF7>, L<https://www.unicode.org/glossary/>,
+L<https://www.unicode.org/faq/utf_bom.html>,
 
 RFC 2781 L<http://www.ietf.org/rfc/rfc2781.txt>,
 
-The whole Unicode standard L<http://www.unicode.org/unicode/uni2book/u2.html>
+The whole Unicode standard L<https://www.unicode.org/standard/standard.html>
 
-Ch. 15, pp. 403 of C<Programming Perl (3rd Edition)>
-by Larry Wall, Tom Christiansen, Jon Orwant;
-O'Reilly & Associates; ISBN 0-596-00027-8
+Ch. 6 pp. 275 of C<Programming Perl (3rd Edition)>
+by Tom Christiansen, brian d foy & Larry Wall;
+O'Reilly & Associates; ISBN 978-0-596-00492-7
 
 =cut

--- a/cpan/Encode/bin/enc2xs
+++ b/cpan/Encode/bin/enc2xs
@@ -11,7 +11,7 @@ use warnings;
 use Getopt::Std;
 use Config;
 my @orig_ARGV = @ARGV;
-our $VERSION  = do { my @r = (q$Revision: 2.23 $ =~ /\d+/g); sprintf "%d."."%02d" x $#r, @r };
+our $VERSION  = do { my @r = (q$Revision: 2.24 $ =~ /\d+/g); sprintf "%d."."%02d" x $#r, @r };
 
 # These may get re-ordered.
 # RAW is a do_now as inserted by &enter
@@ -249,7 +249,12 @@ if ($cname =~ /\.(c|xs)$/i) # VMS may have upcased filenames with DECC$ARGV_PARS
 END
   }
 
-  if ($cname =~ /(\w+)\.xs$/)
+  if ($cname =~ /\.c$/i && $Config{ccname} eq "gcc")
+   {
+    print C qq(#pragma GCC diagnostic ignored "-Wc++-compat"\n);
+   }
+
+  if ($cname =~ /\.xs$/i)
    {
     print C "#define PERL_NO_GET_CONTEXT\n";
     print C "#include <EXTERN.h>\n";
@@ -259,15 +264,15 @@ END
   print C "#include \"encode.h\"\n\n";
 
  }
-elsif ($cname =~ /\.enc$/)
+elsif ($cname =~ /\.enc$/i)
  {
   $doEnc = 1;
  }
-elsif ($cname =~ /\.ucm$/)
+elsif ($cname =~ /\.ucm$/i)
  {
   $doUcm = 1;
  }
-elsif ($cname =~ /\.pet$/)
+elsif ($cname =~ /\.pet$/i)
  {
   $doPet = 1;
  }

--- a/cpan/Encode/t/Unicode_trailing_nul.t
+++ b/cpan/Encode/t/Unicode_trailing_nul.t
@@ -12,7 +12,7 @@ my $foo = Encode::decode("UTF-16LE", "/\0v\0a\0r\0/\0f\0f\0f\0f\0f\0f\0/\0u\0s\0
 
 my ($fh, $path) = File::Temp::tempfile( CLEANUP => 1 );
 
-diag "temp file: $path";
+note "temp file: $path";
 
 # Perl gives the internal PV to exec .. which is buggy/wrong but
 # useful here:

--- a/cpan/Encode/t/enc_data.t
+++ b/cpan/Encode/t/enc_data.t
@@ -1,4 +1,4 @@
-# $Id: enc_data.t,v 2.5 2016/11/29 23:29:23 dankogai Exp $
+# $Id: enc_data.t,v 2.6 2022/04/07 03:06:40 dankogai Exp dankogai $
 
 BEGIN {
     require Config; import Config;
@@ -15,7 +15,7 @@ BEGIN {
     exit(0);
     }
     if ($] >= 5.025 and !$Config{usecperl}) {
-    print "1..0 # Skip: encoding pragma not supported in Perl 5.26\n";
+    print "1..0 # Skip: encoding pragma not supported in Perl 5.25 or later\n";
     exit(0);
     }
     if ($] <= 5.008 and !$Config{perl_patchlevel}){

--- a/cpan/Encode/t/enc_module.t
+++ b/cpan/Encode/t/enc_module.t
@@ -1,4 +1,4 @@
-# $Id: enc_module.t,v 2.5 2016/11/29 23:29:23 dankogai Exp $
+# $Id: enc_module.t,v 2.6 2022/04/07 03:06:40 dankogai Exp dankogai $
 # This file is in euc-jp
 BEGIN {
     require Config; import Config;
@@ -19,7 +19,7 @@ BEGIN {
     exit(0);
     }
     if ($] >= 5.025 and !$Config{usecperl}) {
-    print "1..0 # Skip: encoding pragma not supported in Perl 5.26\n";
+    print "1..0 # Skip: encoding pragma not supported in Perl 5.25 or later\n";
     exit(0);
     }
 }

--- a/cpan/Encode/t/encoding.t
+++ b/cpan/Encode/t/encoding.t
@@ -13,7 +13,7 @@ BEGIN {
     exit(0);
     }
     if ($] >= 5.025 and !$Config{usecperl}) {
-    print "1..0 # Skip: encoding pragma not supported in Perl 5.26\n";
+    print "1..0 # Skip: encoding pragma not supported in Perl 5.25 or later\n";
     exit(0);
     }
 }

--- a/cpan/Encode/t/jperl.t
+++ b/cpan/Encode/t/jperl.t
@@ -1,5 +1,5 @@
 #
-# $Id: jperl.t,v 2.5 2016/11/29 23:29:23 dankogai Exp $
+# $Id: jperl.t,v 2.6 2022/04/07 03:06:40 dankogai Exp dankogai $
 #
 # This script is written in euc-jp
 
@@ -18,7 +18,7 @@ BEGIN {
     exit 0;
     }
     if ($] >= 5.025 and !$Config{usecperl}) {
-    print "1..0 # Skip: encoding pragma not supported in Perl 5.26\n";
+    print "1..0 # Skip: encoding pragma not supported in Perl 5.25 or later\n";
     exit(0);
     }
     $| = 1;

--- a/cpan/Encode/t/taint.t
+++ b/cpan/Encode/t/taint.t
@@ -4,6 +4,7 @@ use Encode qw(encode decode);
 local %Encode::ExtModule = %Encode::Config::ExtModule;
 use Scalar::Util qw(tainted);
 use Test::More;
+use Config;
 my $taint = substr($ENV{PATH},0,0);
 my $str = "dan\x{5f3e}" . $taint;                 # tainted string to encode
 my $bin = encode('UTF-8', $str);                  # tainted binary to decode
@@ -11,7 +12,12 @@ my $notaint = "";
 my $notaint_str = "dan\x{5f3e}" . $notaint;
 my $notaint_bin = encode('UTF-8', $notaint_str);
 my @names = Encode->encodings(':all');
-plan tests => 4 * @names + 2;
+if (exists($Config{taint_support}) && not $Config{taint_support}) {
+    plan skip_all => "your perl was built without taint support";
+}
+else {
+    plan tests => 4 * @names + 2;
+}
 for my $name (@names) {
     my ($d, $e, $s);
     eval {

--- a/cpan/Encode/t/utf32warnings.t
+++ b/cpan/Encode/t/utf32warnings.t
@@ -1,0 +1,277 @@
+use strict;
+use warnings;
+
+my $script = quotemeta $0;
+
+use Encode;
+use Test::More tests => 38;
+
+my $valid   = "\x61\x00\x00\x00";
+my $invalid = "\x78\x56\x34\x12";
+
+our $warn;
+$SIG{__WARN__} = sub { $warn = $_[0] };
+
+my $enc = find_encoding("UTF32-LE");
+
+{
+    local $warn;
+    my $ret = $enc->encode( "a", Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    is($warn, undef, "Calling encode on UTF32-LE encode object with valid string produces no warnings");
+    is($ret, $valid, "Calling encode on UTF32-LE encode object with valid string returns correct output");
+}
+
+
+{
+    local $warn;
+    $enc->encode( "\x{D800}", Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    like($warn, qr/UTF-16 surrogate.* at $script line /, "Calling encode on UTF32-LE encode object with invalid string warns");
+}
+
+{
+    local $warn;
+    no warnings 'utf8';
+    $enc->encode( "\x{D800}", Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    is($warn, undef, "Warning from encode method of UTF32-LE encode object can be silenced via no warnings 'utf8'");
+}
+
+{
+    local $warn;
+    no warnings;
+    $enc->encode( "\x{D800}", Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    is($warn, undef, "Warning from encode method of UTF32-LE encode object can be silenced via no warnings");
+}
+
+{
+    local $warn;
+    no warnings 'utf8';
+    $enc->encode( "\x{D800}", Encode::WARN_ON_ERR | Encode::LEAVE_SRC );
+    like($warn, qr/UTF-16 surrogate.* at $script line /, "Warning from encode method of UTF32-LE encode object cannot be silenced via no warnings 'utf8' when ONLY_PRAGMA_WARNINGS is not used");
+}
+
+{
+    local $warn;
+    no warnings;
+    $enc->encode( "\x{D800}", Encode::WARN_ON_ERR | Encode::LEAVE_SRC );
+    like($warn, qr/UTF-16 surrogate.* at $script line /, "Warning from encode method of UTF32-LE encode object cannot be silenced via no warnings when ONLY_PRAGMA_WARNINGS is not used");
+}
+
+
+{
+    local $warn;
+    my $ret = Encode::encode( $enc, "a", Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    is($warn, undef, "Calling Encode::encode for UTF32-LE with valid string produces no warnings");
+    is($ret, $valid, "Calling Encode::encode for UTF32-LE with valid string returns correct output");
+}
+
+
+{
+    local $warn;
+    Encode::encode( $enc, "\x{D800}", Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    like($warn, qr/UTF-16 surrogate.* at $script line /, "Calling Encode::encode for UTF32-LE with invalid string warns");
+}
+
+
+{
+    local $warn;
+    no warnings 'utf8';
+    Encode::encode( $enc, "\x{D800}", Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    is($warn, undef, "Warning from Encode::encode for UTF32-LE can be silenced via no warnings 'utf8'");
+}
+
+{
+    local $warn;
+    no warnings;
+    Encode::encode( $enc, "\x{D800}", Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    is($warn, undef, "Warning from Encode::encode for UTF32-LE can be silenced via no warnings");
+}
+
+{
+    local $warn;
+    no warnings 'utf8';
+    Encode::encode( $enc, "\x{D800}", Encode::WARN_ON_ERR | Encode::LEAVE_SRC );
+    like($warn, qr/UTF-16 surrogate.* at $script line /, "Warning from Encode::encode for UTF32-LE cannot be silenced via no warnings 'utf8' when ONLY_PRAGMA_WARNINGS is not used");
+}
+
+{
+    local $warn;
+    no warnings;
+    Encode::encode( $enc, "\x{D800}", Encode::WARN_ON_ERR | Encode::LEAVE_SRC );
+    like($warn, qr/UTF-16 surrogate.* at $script line /, "Warning from Encode::encode for UTF32-LE cannot be silenced via no warnings when ONLY_PRAGMA_WARNINGS is not used");
+}
+
+
+{
+    local $warn;
+    my $ret = $enc->decode( $valid, Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    is($warn, undef, "Calling decode on UTF32-LE encode object with valid string produces no warnings");
+    is($ret, "a", "Calling decode on UTF32-LE encode object with valid string returns correct output");
+}
+
+
+{
+    local $warn;
+    $enc->decode( $invalid, Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    like($warn, qr/may not be portable.* at $script line /, "Calling decode on UTF32-LE encode object with invalid string warns");
+}
+
+{
+    local $warn;
+    no warnings 'utf8';
+    $enc->decode( $invalid, Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    is($warn, undef, "Warning from decode method of UTF32-LE encode object can be silenced via no warnings 'utf8'");
+}
+
+{
+    local $warn;
+    no warnings;
+    $enc->decode( $invalid, Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    is($warn, undef, "Warning from decode method of UTF32-LE encode object can be silenced via no warnings");
+}
+
+{
+    local $warn;
+    no warnings 'utf8';
+    $enc->decode( $invalid, Encode::WARN_ON_ERR | Encode::LEAVE_SRC );
+    like($warn, qr/may not be portable.* at $script line /, "Warning from decode method of UTF32-LE encode object cannot be silenced via no warnings 'utf8' when ONLY_PRAGMA_WARNINGS is not used");
+}
+
+{
+    local $warn;
+    no warnings;
+    $enc->decode( $invalid, Encode::WARN_ON_ERR | Encode::LEAVE_SRC );
+    like($warn, qr/may not be portable.* at $script line /, "Warning from decode method of UTF32-LE encode object cannot be silenced via no warnings when ONLY_PRAGMA_WARNINGS is not used");
+}
+
+
+{
+    local $warn;
+    my $ret = Encode::decode( $enc, $valid, Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    is($warn, undef, "Calling Encode::decode for UTF32-LE with valid string produces no warnings");
+    is($ret, "a", "Calling Encode::decode for UTF32-LE with valid string returns correct output");
+}
+
+
+{
+    local $warn;
+    Encode::decode( $enc, $invalid, Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    like($warn, qr/may not be portable.* at $script line /, "Calling Encode::decode for UTF32-LE with invalid string warns");
+}
+
+{
+    local $warn;
+    no warnings 'utf8';
+    Encode::decode( $enc, $invalid, Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    is($warn, undef, "Warning from Encode::decode for UTF32-LE can be silenced via no warnings 'utf8'");
+}
+
+{
+    local $warn;
+    no warnings;
+    Encode::decode( $enc, $invalid, Encode::WARN_ON_ERR | Encode::ONLY_PRAGMA_WARNINGS | Encode::LEAVE_SRC );
+    is($warn, undef, "Warning from Encode::decode for UTF32-LE can be silenced via no warnings");
+}
+
+{
+    local $warn;
+    no warnings 'utf8';
+    Encode::decode( $enc, $invalid, Encode::WARN_ON_ERR | Encode::LEAVE_SRC );
+    like($warn, qr/may not be portable.* at $script line /, "Warning from Encode::decode for UTF32-LE cannot be silenced via no warnings 'utf8' when ONLY_PRAGMA_WARNINGS is not used");
+}
+
+{
+    local $warn;
+    no warnings;
+    Encode::decode( $enc, $invalid, Encode::WARN_ON_ERR | Encode::LEAVE_SRC );
+    like($warn, qr/may not be portable.* at $script line /, "Warning from Encode::decode for UTF32-LE cannot be silenced via no warnings when ONLY_PRAGMA_WARNINGS is not used");
+}
+
+
+use PerlIO::encoding;
+$PerlIO::encoding::fallback |= Encode::ONLY_PRAGMA_WARNINGS;
+
+{
+    local $warn;
+    my $tmp = $valid;
+    $tmp .= ''; # de-COW
+    open my $fh, '<:encoding(UTF32-LE)', \$tmp or die;
+    my $str = <$fh>;
+    close $fh;
+    is($warn, undef, "Calling PerlIO :encoding on valid string produces no warnings");
+    is($str, "a", "PerlIO decodes string correctly");
+}
+
+
+{
+    local $warn;
+    my $tmp = $invalid;
+    use Devel::Peek;
+    $tmp .= ''; # de-COW
+    open my $fh, '<:encoding(UTF32-LE)', \$tmp or die;
+    my $str = <$fh>;
+    close $fh;
+    like($warn, qr/may not be portable.* at $script line /, "Calling PerlIO :encoding on invalid string warns");
+}
+
+{
+    local $warn;
+    my $tmp = $invalid;
+    $tmp .= ''; # de-COW
+    no warnings 'utf8';
+    open my $fh, '<:encoding(UTF32-LE)', \$tmp or die;
+    my $str = <$fh>;
+    close $fh;
+    is($warn, undef, "Warning from PerlIO :encoding can be silenced via no warnings 'utf8'");
+}
+
+{
+    local $warn;
+    my $tmp = $invalid;
+    $tmp .= ''; # de-COW
+    no warnings;
+    open my $fh, '<:encoding(UTF32-LE)', \$tmp or die;
+    my $str = <$fh>;
+    close $fh;
+    is($warn, undef, "Warning from PerlIO :encoding can be silenced via no warnings");
+}
+
+
+{
+    local $warn;
+    my $str;
+    open my $fh, '>:encoding(UTF32-LE)', \$str or die;
+    print $fh "a";
+    close $fh;
+    is($warn, undef, "Calling PerlIO :encoding on valid string produces no warnings");
+    is($str, $valid, "PerlIO encodes string correctly");
+}
+
+
+{
+    local $warn;
+    my $str;
+    open my $fh, '>:encoding(UTF32-LE)', \$str or die;
+    print $fh "\x{D800}";
+    close $fh;
+    like($warn, qr/UTF-16 surrogate.* at $script line /, "Calling PerlIO :encoding on invalid string warns");
+}
+
+{
+    local $warn;
+    my $str;
+    no warnings 'utf8';
+    open my $fh, '>:encoding(UTF32-LE)', \$str or die;
+    print $fh "\x{D800}";
+    close $fh;
+    is($warn, undef, "Warning from PerlIO :encoding can be silenced via no warnings 'utf8'");
+}
+
+{
+    local $warn;
+    my $str;
+    no warnings;
+    open my $fh, '>:encoding(UTF32-LE)', \$str or die;
+    print $fh "\x{D800}";
+    close $fh;
+    is($warn, undef, "Warning from PerlIO :encoding can be silenced via no warnings");
+}


### PR DESCRIPTION
This silences the build warnings reported in https://github.com/Perl/perl5/issues/19588
and in https://github.com/Perl/perl5/issues/17014.

It includes some test updates, but no functionality changes.