### PR TITLE
pod/.gitignore - remove delete perlmacos.pod entry

### DIFF
--- a/pod/.gitignore
+++ b/pod/.gitignore
@@ -14,7 +14,6 @@
 /perljp.pod
 /perlko.pod
 /perllinux.pod
-/perlmacos.pod
 /perlmacosx.pod
 /perlnetware.pod
 /perlopenbsd.pod


### PR DESCRIPTION
perlmacos related materials were deleted in 21c79b49e2f6f7,
this pod/.gitignore entry was overlooked.