### PR TITLE
Extra B::PADNAME helpers: GEN and IsUndef

### DIFF
--- a/ext/B/B.pm
+++ b/ext/B/B.pm
@@ -20,7 +20,7 @@ sub import {
 # walkoptree comes from B.xs
 
 BEGIN {
-    $B::VERSION = '1.83';
+    $B::VERSION = '1.84';
     @B::EXPORT_OK = ();
 
     # Our BOOT code needs $VERSION set, and will append to @EXPORT_OK.
@@ -1313,6 +1313,8 @@ pointers and B::PADNAME objects otherwise.
 
 =item REFCNT
 
+=item GEN
+
 =item FLAGS
 
 For backward-compatibility, if the PADNAMEt_OUTER flag is set, the FLAGS
@@ -1348,6 +1350,10 @@ Only meaningful if PADNAMEt_OUTER is set.
 =item PARENT_FAKELEX_FLAGS
 
 Only meaningful if PADNAMEt_OUTER is set.
+
+=item IsUndef
+
+Returns a boolean value to check if the padname is PL_padname_undef.
 
 =back
 

--- a/ext/B/B.xs
+++ b/ext/B/B.xs
@@ -2252,13 +2252,14 @@ MODULE = B	PACKAGE = B::PADNAME	PREFIX = Padname
 	sv_U32p | STRUCT_OFFSET(struct padname, xpadn_low)
 #define PN_cop_seq_range_high_ix \
 	sv_U32p | STRUCT_OFFSET(struct padname, xpadn_high)
+#define PN_xpadn_gen_ix \
+	sv_I32p | STRUCT_OFFSET(struct padname, xpadn_gen)
 #define PNL_refcnt_ix \
 	sv_U32p | STRUCT_OFFSET(struct padnamelist, xpadnl_refcnt)
 #define PL_id_ix \
 	sv_U32p | STRUCT_OFFSET(struct padlist, xpadl_id)
 #define PL_outid_ix \
 	sv_U32p | STRUCT_OFFSET(struct padlist, xpadl_outid)
-
 
 void
 PadnameTYPE(pn)
@@ -2270,6 +2271,7 @@ PadnameTYPE(pn)
 	B::PADNAME::REFCNT	= PN_refcnt_ix
 	B::PADNAME::COP_SEQ_RANGE_LOW	 = PN_cop_seq_range_low_ix
 	B::PADNAME::COP_SEQ_RANGE_HIGH	 = PN_cop_seq_range_high_ix
+	B::PADNAME::GEN		= PN_xpadn_gen_ix
 	B::PADNAMELIST::REFCNT	= PNL_refcnt_ix
 	B::PADLIST::id		= PL_id_ix
 	B::PADLIST::outid	= PL_outid_ix
@@ -2304,6 +2306,14 @@ PadnamePV(pn)
 	sv_setpvn(TARG, PadnamePV(pn), PadnameLEN(pn));
 	SvUTF8_on(TARG);
 	XPUSHTARG;
+
+bool
+PadnameIsUndef(padn)
+       B::PADNAME      padn
+    CODE:
+        RETVAL = padn == &PL_padname_undef;
+    OUTPUT:
+       RETVAL
 
 BOOT:
 {


### PR DESCRIPTION
This commit adds two new helpers to B::PADNAME.
- IsUndef to check if the PADNAME is PL_padname_undef
- GEN to access to the xpadn_gen slot of the pad.