### PR TITLE
re.pm - add notes that the debug output is NOT a "supported API".

### DIFF
--- a/ext/re/re.pm
+++ b/ext/re/re.pm
@@ -4,7 +4,7 @@ package re;
 use strict;
 use warnings;
 
-our $VERSION     = "0.42";
+our $VERSION     = "0.43";
 our @ISA         = qw(Exporter);
 our @EXPORT_OK   = qw{
 	is_regexp regexp_pattern
@@ -513,6 +513,12 @@ comma-separated list of C<termcap> properties to use for highlighting
 strings on/off, pre-point part on/off.
 See L<perldebug/"Debugging Regular Expressions"> for additional info.
 
+B<NOTE> that the exact format of the C<debug> mode is B<NOT> considered
+to be an officially supported API of Perl. It is intended for debugging
+only and may change as the core development team deems appropriate
+without notice or deprecation in any release of Perl, major or minor.
+Any documentation of the output is purely advisory.
+
 As of 5.9.5 the directive C<use re 'debug'> and its equivalents are
 lexically scoped, as the other directives are.  However they have both
 compile-time and run-time effects.
@@ -525,7 +531,17 @@ Similarly C<use re 'Debug'> produces debugging output, the difference
 being that it allows the fine tuning of what debugging output will be
 emitted. Options are divided into three groups, those related to
 compilation, those related to execution and those related to special
-purposes. The options are as follows:
+purposes.
+
+B<NOTE> that the options provided under the C<Debug> mode and the exact
+format of the output they create is B<NOT> considered to be an
+officially supported API of Perl. It is intended for debugging only and
+may change as the core development team deems appropriate without notice
+or deprecation in any release of Perl, major or minor. Any documentation
+of the format or options available is advisory only and is subject to
+change without notice.
+
+The options are as follows:
 
 =over 4
 


### PR DESCRIPTION
The debug output leaks a large amount of information about the
implementation details of the regex engine and as such is highly likely
to change based on almost any change to the regex engine. Also from time
to time we make changes to the output to improve legibility, etc. While
the output of C<use re 'debug'> is intended for user consumption as well
as for debugging the regex engine itself I believe that we should not
provide any backcompat guarantees about its specific contents or format.
Similarly the list of options we provide for C<use re 'Debug'> may be
affected by changes in the internals of the engine, rending old
categories irrelevant, or requiring new categories to be added.

This patch adds language to the C<re.pm> docs that stipulate that the
debug options we provide under C<use re 'Debug'> and the output we
provide from C<use re 'debug'> and C<use re 'Debug'> are subject to
change without notice at any major or minor release.

While I do not anticipate changes to the output in a minor release I
believe it is wise to specify that we do not commit ourselves to
consistency in this regard in any way. For instance were the situation
to arise that we had a security issue or serious performance issues or
some other strong justification to make a change in a minor release then
this could very well change the output we provide or the options we
support.