### PR TITLE
gdbm: make sure basic error codes are always defined

### DIFF
--- a/ext/GDBM_File/Makefile.PL
+++ b/ext/GDBM_File/Makefile.PL
@@ -25,7 +25,12 @@ push @names, {
              GDBM_SNAPSHOT_SAME GDBM_SNAPSHOT_SUSPICIOUS);
 
 # Basic error codes - these are supported by all versions of gdbm
-push @names, qw(
+push @names, {
+    name  => $_,
+    value => "$_",
+    type  => "IV",
+    macro => 1
+} foreach qw(
     GDBM_NO_ERROR
     GDBM_MALLOC_ERROR
     GDBM_BLOCK_SIZE_ERROR


### PR DESCRIPTION
* ext/GDBM_File/Makefile.PL: Don't protect basic error codes by
ifdefs: they are not macros in recent versions of GDBM. Besides,
they are known to exist in any GDBM version.