### PR TITLE
fix printf format warning in regexp debug output

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -4412,7 +4412,7 @@ S_dump_exec_pos(pTHX_ const char *locinput,
 
         const STRLEN tlen=len0+len1+len2;
         Perl_re_printf( aTHX_
-                    "%4" IVdf " <%.*s%.*s%s%.*s>%*s|%4u| ",
+                    "%4" IVdf " <%.*s%.*s%s%.*s>%*s|%4" UVuf "| ",
                     (IV)(locinput - loc_bostr),
                     len0, s0,
                     len1, s1,

--- a/regexec.c
+++ b/regexec.c
@@ -4420,7 +4420,7 @@ S_dump_exec_pos(pTHX_ const char *locinput,
                     len2, s2,
                     (int)(tlen > 19 ? 0 :  19 - tlen),
                     "",
-                    depth);
+                    (UV)depth);
     }
 }
 


### PR DESCRIPTION
After configuring a 32-bit unoptimized debugging perl with:
```
./Configure -des -Dcc=gcc -Dprefix=/opt/scratch -Doptimize='-g -O0' -DDEBUGGING -Accflags='-ggdb3 -m32' -Aldflags='-ggdb3 -m32' -Alddlflags='-shared -ggdb3 -m32' -Dusedevel -Uversiononly
```

I see this warning when building:
```
gcc -c -DPERL_CORE -ggdb3 -m32 -fwrapv -DDEBUGGING -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2 -std=c99 -g -O0 -Wall -Werror=pointer-arith -Werror=vla -Wextra -Wno-long-long -Wno-declaration-after-statement -Wc++-compat -Wwrite-strings taint.c
regexec.c: In function 'S_dump_exec_pos':
regexec.c:4415:21: warning: format '%u' expects argument of type 'unsigned int', but argument 12 has type 'U32 {aka const long unsigned int}' [-Wformat=]
                     "%4" IVdf " <%.*s%.*s%s%.*s>%*s|%4u| ",
                     ^~~~
regexec.c:4415:55: note: format string is defined here
                     "%4" IVdf " <%.*s%.*s%s%.*s>%*s|%4u| ",
                                                     ~~^
                                                     %4lu
```

I think the final `"%4u"` needs to be `"%4" UVuf`, to handle the `U32 depth`.