### PR TITLE
toke.c: S_intuit_more: Cleanup

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -4464,7 +4464,7 @@ S_scan_const(pTHX_ char *start)
  *   {4,5} (any digits around the comma) returns FALSE
  * if we're in a pattern and the first char is a [
  *   [] returns FALSE
- *   [SOMETHING] has a funky algorithm to decide whether it's a
+ *   [SOMETHING] has a funky heuristic to decide whether it's a
  *      character class or not.  It has to deal with things like
  *      /$foo[-3]/ and /$foo[$bar]/ as well as /$foo[$\d]+/
  * anything else returns TRUE
@@ -4477,22 +4477,37 @@ S_intuit_more(pTHX_ char *s, char *e)
 {
     PERL_ARGS_ASSERT_INTUIT_MORE;
 
+    /* If recursed within brackets, there is more to the expression */
     if (PL_lex_brackets)
         return TRUE;
-    if (*s == '-' && s[1] == '>' && (s[2] == '[' || s[2] == '{'))
+
+    if (    *s == '-'
+        &&  s[1] == '>'
+        && (s[2] == '[' || s[2] == '{'))
+    {
         return TRUE;
-    if (*s == '-' && s[1] == '>'
-     && FEATURE_POSTDEREF_QQ_IS_ENABLED
-     && ( (s[2] == '$' && (s[3] == '*' || (s[3] == '#' && s[4] == '*')))
-        ||(s[2] == '@' && memCHRs("*[{",s[3])) ))
+    }
+
+    if (   *s == '-'
+        && s[1] == '>'
+        && FEATURE_POSTDEREF_QQ_IS_ENABLED
+        && (   (s[2] == '$' && (    s[3] == '*'
+                                || (s[3] == '#' && s[4] == '*')))
+            || (s[2] == '@' && memCHRs("*[{", s[3])) ))
         return TRUE;
+
     if (*s != '{' && *s != '[')
         return FALSE;
+
+    /* quit immediately from any errors from now on */
     PL_parser->sub_no_recover = TRUE;
+
+    /* Here is '{' or '['.  Outside patterns, they're always subscripts */
     if (!PL_lex_inpat)
         return TRUE;
 
-    /* In a pattern, so maybe we have {n,m}. */
+    /* In a pattern, so maybe we have {n,m}, in which case, there isn't more to
+     * the expression. */
     if (*s == '{') {
         if (regcurly(s, e, NULL)) {
             return FALSE;
@@ -4500,14 +4515,17 @@ S_intuit_more(pTHX_ char *s, char *e)
         return TRUE;
     }
 
-    /* On the other hand, maybe we have a character class */
-
+    /* Here is '[': maybe we have a character class.  Examine the guts */
     s++;
+
+    /* '^' implies a character class; An empty '[]' isn't legal, but it does
+     * mean there isn't more to come */
     if (*s == ']' || *s == '^')
         return FALSE;
 
+    /* Find matching ']' */
     const char * const send = (char *) memchr(s, ']', e - s);
-    if (!send)		/* has to be an expression */
+    if (! send)		/* has to be an expression */
         return TRUE;
 
     /* If the construct consists entirely of one or two digits, call it a
@@ -4516,7 +4534,7 @@ S_intuit_more(pTHX_ char *s, char *e)
         return TRUE;
     }
 
-    /* this is terrifying, and it works */
+    /* this is terrifying, and it mostly works.  See GH #16478 */
 
     int weight;
 
@@ -4529,10 +4547,15 @@ S_intuit_more(pTHX_ char *s, char *e)
         weight = 2;
     }
 
+    /* Unsigned version of current character */
     unsigned char un_char = 255;
-    char seen[256];
-    Zero(seen,256,char);
 
+    /* Keep track of how many multiple occurrences of the same character there
+     * are */
+    char seen[256];
+    Zero(seen, 256, char);
+
+    /* Examine each character in the construct */
     for (; s < send; s++) {
         unsigned char last_un_char = un_char;
         un_char = (unsigned char)*s;
@@ -4540,56 +4563,90 @@ S_intuit_more(pTHX_ char *s, char *e)
           case '@':
           case '&':
           case '$':
+
+            /* Each additional occurrence of one of these three strongly
+             * indicates it is a subscript */
             weight -= seen[un_char] * 10;
+
+            /* Following one of these characters, we look to see if there is an
+             * identifier already found in the program by that name.  If so,
+             * strongly suspect this isn't a character class */
             if (isWORDCHAR_lazy_if_safe(s+1, PL_bufend, UTF)) {
                 int len;
                 char tmpbuf[sizeof PL_tokenbuf * 4];
                 scan_ident(s, tmpbuf, sizeof tmpbuf, FALSE);
                 len = (int)strlen(tmpbuf);
-                if (len > 1 && gv_fetchpvn_flags(tmpbuf, len,
-                                                UTF ? SVf_UTF8 : 0, SVt_PV))
+                if (   len > 1
+                    && gv_fetchpvn_flags(tmpbuf,
+                                         len,
+                                         UTF ? SVf_UTF8 : 0,
+                                         SVt_PV))
                     weight -= 100;
-                else
+                else    /* Not a multi-char identifier already known in the
+                           program; is somewhat likely to be a subscript */
                     weight -= 10;
             }
-            else if (*s == '$'
+            else if (   *s == '$'
                      && s[1]
-                     && memCHRs("[#!%*<>()-=",s[1]))
+                     && memCHRs("[#!%*<>()-=", s[1]))
             {
-                if (/*{*/ memCHRs("])} =",s[2]))
+                /* Here we have what could be a punctuation variable.  If the
+                 * next character after it is a closing bracket, it makes it
+                 * quite likely to be that, and hence a subscript.  If it is
+                 * something else, more mildly a subscript */
+                if (/*{*/ memCHRs("])} =", s[2]))
                     weight -= 10;
                 else
                     weight -= 1;
             }
             break;
+
           case '\\':
             un_char = 254;
             if (s[1]) {
-                if (memCHRs("wds]",s[1]))
-                    weight += 100;
+                if (memCHRs("wds]", s[1]))
+                    weight += 100;  /* \w \d \s => strongly charclass */
                 else if (seen[(U8)'\''] || seen[(U8)'"'])
-                    weight += 1;
-                else if (memCHRs("rnftbxcav",s[1]))
-                    weight += 40;
+                    weight += 1;    /* \' => mildly charclass */
+                else if (memCHRs("rnftbxcav", s[1]))
+                    weight += 40;   /* \n, etc => charclass */
                 else if (isDIGIT(s[1])) {
-                    weight += 40;
+                    weight += 40;   /* \123 => charclass */
                     while (s[1] && isDIGIT(s[1]))
                         s++;
                 }
             }
-            else
+            else /* \ followed by NUL strongly indicates character class */
                 weight += 100;
             break;
+
           case '-':
+            /* If it is something like '-\', it is more likely to be a
+             * character class */
             if (s[1] == '\\')
                 weight += 50;
-            if (memCHRs("aA01! ",last_un_char))
+
+            /* If it is something like 'a-' or '0-', it is more likely to
+             * be a character class. '!' is the first ASCII graphic, so '!-'
+             * would be the start of a range of graphics. */
+            if (memCHRs("aA01! ", last_un_char))
                 weight += 30;
-            if (memCHRs("zZ79~",s[1]))
+
+            /* If it is something like '-Z' or '-7' (for octal) or '-9' it
+             * is more likely to be a character class. '~' is the final ASCII
+             * graphic, so '-~' would be the end of a range of graphics. */
+            if (memCHRs("zZ79~", s[1]))
                 weight += 30;
-            if (last_un_char == 255 && (isDIGIT(s[1]) || s[1] == '$'))
+
+            /* If it is something like -1 or -$foo, it is more likely to be a
+             * subscript.  */
+            if (   last_un_char == 255
+                && (isDIGIT(s[1]) || s[1] == '$'))
+            {
                 weight -= 5;	/* cope with negative subscript */
+            }
             break;
+
           default:
             if (   ! isWORDCHAR(last_un_char)
                 &&   last_un_char != '$'
@@ -4598,19 +4655,34 @@ S_intuit_more(pTHX_ char *s, char *e)
                 &&   isALPHA(*s)
                 &&   isALPHA(s[1]))
             {
+                /* Here it's \W (that isn't [$@&] ) followed immediately by two
+                 * alphas in a row.  Accumulate all the consecutive alphas */
                 char *d = s;
                 while (isALPHA(*s))
                     s++;
+
+                /* If those alphas spell a keyword, it's almost certainly not a
+                 * character class */
                 if (keyword(d, s - d, 0))
                     weight -= 150;
             }
+
+            /* Consecutive chars like [...12...] and [...ab...] are presumed
+             * more likely to be character classes */
             if (un_char == last_un_char + 1)
                 weight += 5;
+
+            /* But repeating a character inside a character class does nothing,
+             * like [aba], so less likely that someone makes such a class, more
+             * likely that it is a subscript; the more repeats, the less
+             * likely. */
             weight -= seen[un_char];
             break;
-        }
+        }   /* End of switch */
+
         seen[un_char]++;
-    }
+    }   /* End of loop through each character of the construct */
+
     if (weight >= 0)	/* probably a character class */
         return FALSE;
 

--- a/toke.c
+++ b/toke.c
@@ -4608,7 +4608,7 @@ S_intuit_more(pTHX_ char *s, char *e)
                     weight += 100;  /* \w \d \s => strongly charclass */
                 else if (seen[(U8)'\''] || seen[(U8)'"'])
                     weight += 1;    /* \' => mildly charclass */
-                else if (memCHRs("rnftbxcav", s[1]))
+                else if (memCHRs("abcfnrtvx", s[1]))
                     weight += 40;   /* \n, etc => charclass */
                 else if (isDIGIT(s[1])) {
                     weight += 40;   /* \123 => charclass */

--- a/toke.c
+++ b/toke.c
@@ -4506,13 +4506,7 @@ S_intuit_more(pTHX_ char *s, char *e)
     if (*s == ']' || *s == '^')
         return FALSE;
 
-    /* this is terrifying, and it works */
-    int weight;
-    char seen[256];
     const char * const send = (char *) memchr(s, ']', e - s);
-    unsigned char un_char, last_un_char;
-    char tmpbuf[sizeof PL_tokenbuf * 4];
-
     if (!send)		/* has to be an expression */
         return TRUE;
 
@@ -4521,6 +4515,10 @@ S_intuit_more(pTHX_ char *s, char *e)
     if (isDIGIT(*s) && send - s <= 2 && (send - s == 1 || (isDIGIT(s[1])))) {
         return TRUE;
     }
+
+    /* this is terrifying, and it works */
+
+    int weight;
 
     if (*s == '$') {    /* First char is dollar; lean very slightly to it being
                            a subscript */
@@ -4531,10 +4529,12 @@ S_intuit_more(pTHX_ char *s, char *e)
         weight = 2;
     }
 
+    unsigned char un_char = 255;
+    char seen[256];
     Zero(seen,256,char);
-    un_char = 255;
+
     for (; s < send; s++) {
-        last_un_char = un_char;
+        unsigned char last_un_char = un_char;
         un_char = (unsigned char)*s;
         switch (*s) {
           case '@':
@@ -4543,6 +4543,7 @@ S_intuit_more(pTHX_ char *s, char *e)
             weight -= seen[un_char] * 10;
             if (isWORDCHAR_lazy_if_safe(s+1, PL_bufend, UTF)) {
                 int len;
+                char tmpbuf[sizeof PL_tokenbuf * 4];
                 scan_ident(s, tmpbuf, sizeof tmpbuf, FALSE);
                 len = (int)strlen(tmpbuf);
                 if (len > 1 && gv_fetchpvn_flags(tmpbuf, len,

--- a/toke.c
+++ b/toke.c
@@ -4591,10 +4591,13 @@ S_intuit_more(pTHX_ char *s, char *e)
                 weight -= 5;	/* cope with negative subscript */
             break;
           default:
-            if (!isWORDCHAR(last_un_char)
-                && !(last_un_char == '$' || last_un_char == '@'
-                     || last_un_char == '&')
-                && isALPHA(*s) && s[1] && isALPHA(s[1])) {
+            if (   ! isWORDCHAR(last_un_char)
+                &&   last_un_char != '$'
+                &&   last_un_char != '@'
+                &&   last_un_char != '&'
+                &&   isALPHA(*s)
+                &&   isALPHA(s[1]))
+            {
                 char *d = s;
                 while (isALPHA(*s))
                     s++;

--- a/toke.c
+++ b/toke.c
@@ -4522,10 +4522,15 @@ S_intuit_more(pTHX_ char *s, char *e)
         return TRUE;
     }
 
-    weight = 2;		/* let's weigh the evidence */
+    if (*s == '$') {    /* First char is dollar; lean very slightly to it being
+                           a subscript */
+        weight = -1;
+    }
+    else {              /* Otherwise, lean a little more towards it being a
+                           character class. */
+        weight = 2;
+    }
 
-    if (*s == '$')
-        weight -= 3;
     Zero(seen,256,char);
     un_char = 255;
     for (; s < send; s++) {

--- a/toke.c
+++ b/toke.c
@@ -4558,7 +4558,7 @@ S_intuit_more(pTHX_ char *s, char *e)
     /* Examine each character in the construct */
     bool first_time = true;
     for (; s < send; s++, first_time = false) {
-        unsigned char last_un_char = un_char;
+        unsigned char prev_un_char = un_char;
         un_char = (unsigned char) s[0];
         switch (s[0]) {
           case '@':
@@ -4629,7 +4629,7 @@ S_intuit_more(pTHX_ char *s, char *e)
             /* If it is something like 'a-' or '0-', it is more likely to
              * be a character class. '!' is the first ASCII graphic, so '!-'
              * would be the start of a range of graphics. */
-            if (! first_time && memCHRs("aA01! ", last_un_char))
+            if (! first_time && memCHRs("aA01! ", prev_un_char))
                 weight += 30;
 
             /* If it is something like '-Z' or '-7' (for octal) or '-9' it
@@ -4646,10 +4646,10 @@ S_intuit_more(pTHX_ char *s, char *e)
             break;
 
           default:
-            if (  (first_time || (  ! isWORDCHAR(last_un_char)
-                                  &&  last_un_char != '$'
-                                  &&  last_un_char != '@'
-                                  &&  last_un_char != '&'))
+            if (  (first_time || (  ! isWORDCHAR(prev_un_char)
+                                  &&  prev_un_char != '$'
+                                  &&  prev_un_char != '@'
+                                  &&  prev_un_char != '&'))
                 && isALPHA(s[0])
                 && isALPHA(s[1]))
             {
@@ -4667,7 +4667,7 @@ S_intuit_more(pTHX_ char *s, char *e)
 
             /* Consecutive chars like [...12...] and [...ab...] are presumed
              * more likely to be character classes */
-            if (! first_time && un_char == last_un_char + 1)
+            if (! first_time && un_char == prev_un_char + 1)
                 weight += 5;
 
             /* But repeating a character inside a character class does nothing,

--- a/toke.c
+++ b/toke.c
@@ -4670,8 +4670,12 @@ S_intuit_more(pTHX_ char *s, char *e)
 
             /* Consecutive chars like [...12...] and [...ab...] are presumed
              * more likely to be character classes */
-            if (! first_time && un_char == prev_un_char + 1)
+            if (    ! first_time
+                && (   NATIVE_TO_LATIN1(un_char)
+                    == NATIVE_TO_LATIN1(prev_un_char) + 1))
+            {
                 weight += 5;
+            }
 
             /* But repeating a character inside a character class does nothing,
              * like [aba], so less likely that someone makes such a class, more

--- a/toke.c
+++ b/toke.c
@@ -4481,14 +4481,14 @@ S_intuit_more(pTHX_ char *s, char *e)
     if (PL_lex_brackets)
         return TRUE;
 
-    if (    *s == '-'
+    if (    s[0] == '-'
         &&  s[1] == '>'
         && (s[2] == '[' || s[2] == '{'))
     {
         return TRUE;
     }
 
-    if (   *s == '-'
+    if (   s[0] == '-'
         && s[1] == '>'
         && FEATURE_POSTDEREF_QQ_IS_ENABLED
         && (   (s[2] == '$' && (    s[3] == '*'
@@ -4496,7 +4496,7 @@ S_intuit_more(pTHX_ char *s, char *e)
             || (s[2] == '@' && memCHRs("*[{", s[3])) ))
         return TRUE;
 
-    if (*s != '{' && *s != '[')
+    if (s[0] != '{' && s[0] != '[')
         return FALSE;
 
     /* quit immediately from any errors from now on */
@@ -4508,7 +4508,7 @@ S_intuit_more(pTHX_ char *s, char *e)
 
     /* In a pattern, so maybe we have {n,m}, in which case, there isn't more to
      * the expression. */
-    if (*s == '{') {
+    if (s[0] == '{') {
         if (regcurly(s, e, NULL)) {
             return FALSE;
         }
@@ -4520,7 +4520,7 @@ S_intuit_more(pTHX_ char *s, char *e)
 
     /* '^' implies a character class; An empty '[]' isn't legal, but it does
      * mean there isn't more to come */
-    if (*s == ']' || *s == '^')
+    if (s[0] == ']' || s[0] == '^')
         return FALSE;
 
     /* Find matching ']' */
@@ -4530,7 +4530,7 @@ S_intuit_more(pTHX_ char *s, char *e)
 
     /* If the construct consists entirely of one or two digits, call it a
      * subscript. */
-    if (isDIGIT(*s) && send - s <= 2 && (send - s == 1 || (isDIGIT(s[1])))) {
+    if (isDIGIT(s[0]) && send - s <= 2 && (send - s == 1 || (isDIGIT(s[1])))) {
         return TRUE;
     }
 
@@ -4538,8 +4538,8 @@ S_intuit_more(pTHX_ char *s, char *e)
 
     int weight;
 
-    if (*s == '$') {    /* First char is dollar; lean very slightly to it being
-                           a subscript */
+    if (s[0] == '$') {  /* First char is dollar; lean very slightly to it
+                           being a subscript */
         weight = -1;
     }
     else {              /* Otherwise, lean a little more towards it being a
@@ -4559,8 +4559,8 @@ S_intuit_more(pTHX_ char *s, char *e)
     bool first_time = true;
     for (; s < send; s++, first_time = false) {
         unsigned char last_un_char = un_char;
-        un_char = (unsigned char)*s;
-        switch (*s) {
+        un_char = (unsigned char) s[0];
+        switch (s[0]) {
           case '@':
           case '&':
           case '$':
@@ -4587,7 +4587,7 @@ S_intuit_more(pTHX_ char *s, char *e)
                            program; is somewhat likely to be a subscript */
                     weight -= 10;
             }
-            else if (   *s == '$'
+            else if (   s[0] == '$'
                      && s[1]
                      && memCHRs("[#!%*<>()-=", s[1]))
             {
@@ -4650,13 +4650,13 @@ S_intuit_more(pTHX_ char *s, char *e)
                                   &&  last_un_char != '$'
                                   &&  last_un_char != '@'
                                   &&  last_un_char != '&'))
-                && isALPHA(*s)
+                && isALPHA(s[0])
                 && isALPHA(s[1]))
             {
                 /* Here it's \W (that isn't [$@&] ) followed immediately by two
                  * alphas in a row.  Accumulate all the consecutive alphas */
                 char *d = s;
-                while (isALPHA(*s))
+                while (isALPHA(s[0]))
                     s++;
 
                 /* If those alphas spell a keyword, it's almost certainly not a

--- a/toke.c
+++ b/toke.c
@@ -4481,20 +4481,23 @@ S_intuit_more(pTHX_ char *s, char *e)
     if (PL_lex_brackets)
         return TRUE;
 
-    if (    s[0] == '-'
-        &&  s[1] == '>'
-        && (s[2] == '[' || s[2] == '{'))
-    {
-        return TRUE;
-    }
+    /* If begins with '->' ... */
+    if (s[0] == '-' && s[1] == '>') {
 
-    if (   s[0] == '-'
-        && s[1] == '>'
-        && FEATURE_POSTDEREF_QQ_IS_ENABLED
-        && (   (s[2] == '$' && (    s[3] == '*'
-                                || (s[3] == '#' && s[4] == '*')))
-            || (s[2] == '@' && memCHRs("*[{", s[3])) ))
-        return TRUE;
+        /* '->[' and '->{' imply more to the expression */
+        if (s[2] == '[' || s[2] == '{') {
+            return TRUE;
+        }
+
+        /* Any post deref construct implies more to the expression */
+        if (   FEATURE_POSTDEREF_QQ_IS_ENABLED
+            && (   (s[2] == '$' && (    s[3] == '*'
+                                    || (s[3] == '#' && s[4] == '*')))
+                || (s[2] == '@' && memCHRs("*[{", s[3])) ))
+        {
+            return TRUE;
+        }
+    }
 
     if (s[0] != '{' && s[0] != '[')
         return FALSE;

--- a/toke.c
+++ b/toke.c
@@ -4515,18 +4515,17 @@ S_intuit_more(pTHX_ char *s, char *e)
 
     if (!send)		/* has to be an expression */
         return TRUE;
+
+    /* If the construct consists entirely of one or two digits, call it a
+     * subscript. */
+    if (isDIGIT(*s) && send - s <= 2 && (send - s == 1 || (isDIGIT(s[1])))) {
+        return TRUE;
+    }
+
     weight = 2;		/* let's weigh the evidence */
 
     if (*s == '$')
         weight -= 3;
-    else if (isDIGIT(*s)) {
-        if (s[1] != ']') {
-            if (isDIGIT(s[1]) && s[2] == ']')
-                weight -= 10;
-        }
-        else
-            weight -= 100;
-    }
     Zero(seen,256,char);
     un_char = 255;
     for (; s < send; s++) {


### PR DESCRIPTION
"This is terrifying code"

At $work there was a story about hardware that collectively handled perhaps billions of phone calls a day.  The interrupt handler was long  spaghetti code which had a single comment /* Subtle */.  Everyone was afraid to touch it, instead creating workarounds for its bugs.  Eventually Management decided to spend the money to rewrite it.

I think this is similar to a portion of S_intuit_more in toke.c, as expressed in #16478.  I have spent some hours going through the code, commenting it and adding white space to make it more legible.  In the process, I discovered some wasted effort, and some missing things.  This PR should make it less terrifying for people to work on