### PR TITLE
Update IO-Compress to 2.106 and add a way to skip utils/ files that need 64 bit ints 

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -211,7 +211,9 @@ jobs:
       # actions/checkout@v2 doesn't work in a container, so we use v1.
       - uses: actions/checkout@v1
       - name: fix git remote credential
-        run: git remote set-url origin "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
+        run: |
+          git config --global --add safe.directory /__w/perl5/perl5
+          git remote set-url origin "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
       - name: git cfg + fetch tags
         run: |
           git config diff.renameLimit 999999

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -634,7 +634,7 @@ use File::Glob qw(:case);
     },
 
     'IO-Compress' => {
-        'DISTRIBUTION' => 'PMQS/IO-Compress-2.105.tar.gz',
+        'DISTRIBUTION' => 'PMQS/IO-Compress-2.106.tar.gz',
         'MAIN_MODULE'  => 'IO::Compress::Base',
         'FILES'        => q[cpan/IO-Compress],
         'EXCLUDED'     => [

--- a/cpan/IO-Compress/Makefile.PL
+++ b/cpan/IO-Compress/Makefile.PL
@@ -3,7 +3,7 @@
 use strict ;
 require 5.006 ;
 
-$::VERSION = '2.105' ;
+$::VERSION = '2.106' ;
 $::DEP_VERSION = '2.103';
 
 use lib '.';

--- a/cpan/IO-Compress/bin/zipdetails
+++ b/cpan/IO-Compress/bin/zipdetails
@@ -7,6 +7,15 @@
 
 use 5.010; # for unpack "Q<"
 
+BEGIN {
+    # Check for a 32-bit Perl
+    if (!eval { pack "Q", 1 }) {
+        warn "zipdetails requires 64 bit integers, ",
+                "this Perl has 32 bit integers.\n";
+        exit(1);
+    }
+}
+
 BEGIN { pop @INC if $INC[-1] eq '.' }
 use strict;
 use warnings ;
@@ -16,6 +25,8 @@ use feature 'state';
 use IO::File;
 use Encode;
 use Getopt::Long;
+
+my $VERSION = "2.104" ;
 
 use constant MAX32 => 0xFFFFFFFF ;
 
@@ -194,7 +205,6 @@ my %Extras = (
 
        );
 
-my $VERSION = "2.100" ;
 
 my $FH;
 
@@ -2281,7 +2291,7 @@ sub nibbles
                        duplicates   => [],
                        detail       => [],
                        duplicate_count  => 0,
-                       operlap_count    => 0,
+                       overlap_count    => 0,
                      ) ;
 
         bless \%object, $class;

--- a/cpan/IO-Compress/lib/Compress/Zlib.pm
+++ b/cpan/IO-Compress/lib/Compress/Zlib.pm
@@ -7,17 +7,17 @@ use Carp ;
 use IO::Handle ;
 use Scalar::Util qw(dualvar);
 
-use IO::Compress::Base::Common 2.104 ;
+use IO::Compress::Base::Common 2.106 ;
 use Compress::Raw::Zlib 2.103 ;
-use IO::Compress::Gzip 2.104 ;
-use IO::Uncompress::Gunzip 2.104 ;
+use IO::Compress::Gzip 2.106 ;
+use IO::Uncompress::Gunzip 2.106 ;
 
 use strict ;
 use warnings ;
 use bytes ;
 our ($VERSION, $XS_VERSION, @ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -461,7 +461,7 @@ sub inflate
 
 package Compress::Zlib ;
 
-use IO::Compress::Gzip::Constants 2.104 ;
+use IO::Compress::Gzip::Constants 2.106 ;
 
 sub memGzip($)
 {

--- a/cpan/IO-Compress/lib/IO/Compress/Adapter/Bzip2.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Adapter/Bzip2.pm
@@ -4,12 +4,12 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.104 qw(:Status);
+use IO::Compress::Base::Common  2.106 qw(:Status);
 
 use Compress::Raw::Bzip2  2.103 ;
 
 our ($VERSION);
-$VERSION = '2.104';
+$VERSION = '2.106';
 
 sub mkCompObject
 {

--- a/cpan/IO-Compress/lib/IO/Compress/Adapter/Deflate.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Adapter/Deflate.pm
@@ -4,13 +4,13 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common 2.104 qw(:Status);
+use IO::Compress::Base::Common 2.106 qw(:Status);
 use Compress::Raw::Zlib  2.103 qw( !crc32 !adler32 ) ;
 
 require Exporter;
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, @EXPORT, %DEFLATE_CONSTANTS);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 @ISA = qw(Exporter);
 @EXPORT_OK = @Compress::Raw::Zlib::DEFLATE_CONSTANTS;
 %EXPORT_TAGS = %Compress::Raw::Zlib::DEFLATE_CONSTANTS;

--- a/cpan/IO-Compress/lib/IO/Compress/Adapter/Identity.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Adapter/Identity.pm
@@ -4,10 +4,10 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.104 qw(:Status);
+use IO::Compress::Base::Common  2.106 qw(:Status);
 our ($VERSION);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 
 sub mkCompObject
 {

--- a/cpan/IO-Compress/lib/IO/Compress/Base.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Base.pm
@@ -6,7 +6,7 @@ require 5.006 ;
 use strict ;
 use warnings;
 
-use IO::Compress::Base::Common 2.104 ;
+use IO::Compress::Base::Common 2.106 ;
 
 use IO::File (); ;
 use Scalar::Util ();
@@ -20,7 +20,7 @@ use Symbol();
 our (@ISA, $VERSION);
 @ISA    = qw(IO::File Exporter);
 
-$VERSION = '2.105';
+$VERSION = '2.106';
 
 #Can't locate object method "SWASHNEW" via package "utf8" (perhaps you forgot to load "utf8"?) at .../ext/Compress-Zlib/Gzip/blib/lib/Compress/Zlib/Common.pm line 16.
 

--- a/cpan/IO-Compress/lib/IO/Compress/Base/Common.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Base/Common.pm
@@ -11,7 +11,7 @@ use File::GlobMapper;
 require Exporter;
 our ($VERSION, @ISA, @EXPORT, %EXPORT_TAGS, $HAS_ENCODE);
 @ISA = qw(Exporter);
-$VERSION = '2.104';
+$VERSION = '2.106';
 
 @EXPORT = qw( isaFilehandle isaFilename isaScalar
               whatIsInput whatIsOutput

--- a/cpan/IO-Compress/lib/IO/Compress/Bzip2.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Bzip2.pm
@@ -5,16 +5,16 @@ use warnings;
 use bytes;
 require Exporter ;
 
-use IO::Compress::Base 2.104 ;
+use IO::Compress::Base 2.106 ;
 
-use IO::Compress::Base::Common  2.104 qw();
-use IO::Compress::Adapter::Bzip2 2.104 ;
+use IO::Compress::Base::Common  2.106 qw();
+use IO::Compress::Adapter::Bzip2 2.106 ;
 
 
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $Bzip2Error);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 $Bzip2Error = '';
 
 @ISA    = qw(IO::Compress::Base Exporter);
@@ -51,7 +51,7 @@ sub getExtraParams
 {
     my $self = shift ;
 
-    use IO::Compress::Base::Common  2.104 qw(:Parse);
+    use IO::Compress::Base::Common  2.106 qw(:Parse);
 
     return (
             'blocksize100k' => [IO::Compress::Base::Common::Parse_unsigned,  1],

--- a/cpan/IO-Compress/lib/IO/Compress/Deflate.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Deflate.pm
@@ -8,16 +8,16 @@ use bytes;
 
 require Exporter ;
 
-use IO::Compress::RawDeflate 2.104 ();
-use IO::Compress::Adapter::Deflate 2.104 ;
+use IO::Compress::RawDeflate 2.106 ();
+use IO::Compress::Adapter::Deflate 2.106 ;
 
-use IO::Compress::Zlib::Constants 2.104 ;
-use IO::Compress::Base::Common  2.104 qw();
+use IO::Compress::Zlib::Constants 2.106 ;
+use IO::Compress::Base::Common  2.106 qw();
 
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, %DEFLATE_CONSTANTS, $DeflateError);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 $DeflateError = '';
 
 @ISA    = qw(IO::Compress::RawDeflate Exporter);

--- a/cpan/IO-Compress/lib/IO/Compress/Gzip.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Gzip.pm
@@ -8,12 +8,12 @@ use bytes;
 
 require Exporter ;
 
-use IO::Compress::RawDeflate 2.104 () ;
-use IO::Compress::Adapter::Deflate 2.104 ;
+use IO::Compress::RawDeflate 2.106 () ;
+use IO::Compress::Adapter::Deflate 2.106 ;
 
-use IO::Compress::Base::Common  2.104 qw(:Status );
-use IO::Compress::Gzip::Constants 2.104 ;
-use IO::Compress::Zlib::Extra 2.104 ;
+use IO::Compress::Base::Common  2.106 qw(:Status );
+use IO::Compress::Gzip::Constants 2.106 ;
+use IO::Compress::Zlib::Extra 2.106 ;
 
 BEGIN
 {
@@ -25,7 +25,7 @@ BEGIN
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, %DEFLATE_CONSTANTS, $GzipError);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 $GzipError = '' ;
 
 @ISA    = qw(IO::Compress::RawDeflate Exporter);

--- a/cpan/IO-Compress/lib/IO/Compress/Gzip/Constants.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Gzip/Constants.pm
@@ -9,7 +9,7 @@ require Exporter;
 our ($VERSION, @ISA, @EXPORT, %GZIP_OS_Names);
 our ($GZIP_FNAME_INVALID_CHAR_RE, $GZIP_FCOMMENT_INVALID_CHAR_RE);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 
 @ISA = qw(Exporter);
 

--- a/cpan/IO-Compress/lib/IO/Compress/RawDeflate.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/RawDeflate.pm
@@ -6,16 +6,16 @@ use strict ;
 use warnings;
 use bytes;
 
-use IO::Compress::Base 2.104 ;
-use IO::Compress::Base::Common  2.104 qw(:Status :Parse);
-use IO::Compress::Adapter::Deflate 2.104 ;
+use IO::Compress::Base 2.106 ;
+use IO::Compress::Base::Common  2.106 qw(:Status :Parse);
+use IO::Compress::Adapter::Deflate 2.106 ;
 use Compress::Raw::Zlib  2.103 qw(Z_DEFLATED Z_DEFAULT_COMPRESSION Z_DEFAULT_STRATEGY);
 
 require Exporter ;
 
 our ($VERSION, @ISA, @EXPORT_OK, %DEFLATE_CONSTANTS, %EXPORT_TAGS, $RawDeflateError);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 $RawDeflateError = '';
 
 @ISA = qw(IO::Compress::Base Exporter);

--- a/cpan/IO-Compress/lib/IO/Compress/Zip.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Zip.pm
@@ -4,12 +4,12 @@ use strict ;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.104 qw(:Status );
-use IO::Compress::RawDeflate 2.104 ();
-use IO::Compress::Adapter::Deflate 2.104 ;
-use IO::Compress::Adapter::Identity 2.104 ;
-use IO::Compress::Zlib::Extra 2.104 ;
-use IO::Compress::Zip::Constants 2.104 ;
+use IO::Compress::Base::Common  2.106 qw(:Status );
+use IO::Compress::RawDeflate 2.106 ();
+use IO::Compress::Adapter::Deflate 2.106 ;
+use IO::Compress::Adapter::Identity 2.106 ;
+use IO::Compress::Zlib::Extra 2.106 ;
+use IO::Compress::Zip::Constants 2.106 ;
 
 use File::Spec();
 use Config;
@@ -47,7 +47,7 @@ require Exporter ;
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, %DEFLATE_CONSTANTS, $ZipError);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 $ZipError = '';
 
 @ISA = qw(IO::Compress::RawDeflate Exporter);

--- a/cpan/IO-Compress/lib/IO/Compress/Zip/Constants.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Zip/Constants.pm
@@ -7,7 +7,7 @@ require Exporter;
 
 our ($VERSION, @ISA, @EXPORT, %ZIP_CM_MIN_VERSIONS);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 
 @ISA = qw(Exporter);
 

--- a/cpan/IO-Compress/lib/IO/Compress/Zlib/Constants.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Zlib/Constants.pm
@@ -9,7 +9,7 @@ require Exporter;
 
 our ($VERSION, @ISA, @EXPORT);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 
 @ISA = qw(Exporter);
 

--- a/cpan/IO-Compress/lib/IO/Compress/Zlib/Extra.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Zlib/Extra.pm
@@ -8,9 +8,9 @@ use bytes;
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 
-use IO::Compress::Gzip::Constants 2.104 ;
+use IO::Compress::Gzip::Constants 2.106 ;
 
 sub ExtraFieldError
 {

--- a/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Bunzip2.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Bunzip2.pm
@@ -4,12 +4,12 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common 2.104 qw(:Status);
+use IO::Compress::Base::Common 2.106 qw(:Status);
 
 use Compress::Raw::Bzip2 2.103 ;
 
 our ($VERSION, @ISA);
-$VERSION = '2.104';
+$VERSION = '2.106';
 
 sub mkUncompObject
 {

--- a/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Identity.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Identity.pm
@@ -4,12 +4,12 @@ use warnings;
 use strict;
 use bytes;
 
-use IO::Compress::Base::Common  2.104 qw(:Status);
+use IO::Compress::Base::Common  2.106 qw(:Status);
 use IO::Compress::Zip::Constants ;
 
 our ($VERSION);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 
 use Compress::Raw::Zlib  2.103 ();
 

--- a/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Inflate.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Inflate.pm
@@ -4,11 +4,11 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.104 qw(:Status);
+use IO::Compress::Base::Common  2.106 qw(:Status);
 use Compress::Raw::Zlib  2.103 qw(Z_OK Z_BUF_ERROR Z_STREAM_END Z_FINISH MAX_WBITS);
 
 our ($VERSION);
-$VERSION = '2.104';
+$VERSION = '2.106';
 
 
 

--- a/cpan/IO-Compress/lib/IO/Uncompress/AnyInflate.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/AnyInflate.pm
@@ -6,22 +6,22 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.104 qw(:Parse);
+use IO::Compress::Base::Common  2.106 qw(:Parse);
 
-use IO::Uncompress::Adapter::Inflate  2.104 ();
+use IO::Uncompress::Adapter::Inflate  2.106 ();
 
 
-use IO::Uncompress::Base  2.104 ;
-use IO::Uncompress::Gunzip  2.104 ;
-use IO::Uncompress::Inflate  2.104 ;
-use IO::Uncompress::RawInflate  2.104 ;
-use IO::Uncompress::Unzip  2.104 ;
+use IO::Uncompress::Base  2.106 ;
+use IO::Uncompress::Gunzip  2.106 ;
+use IO::Uncompress::Inflate  2.106 ;
+use IO::Uncompress::RawInflate  2.106 ;
+use IO::Uncompress::Unzip  2.106 ;
 
 require Exporter ;
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $AnyInflateError);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 $AnyInflateError = '';
 
 @ISA = qw(IO::Uncompress::Base Exporter);

--- a/cpan/IO-Compress/lib/IO/Uncompress/AnyUncompress.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/AnyUncompress.pm
@@ -4,16 +4,16 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common 2.104 ();
+use IO::Compress::Base::Common 2.106 ();
 
-use IO::Uncompress::Base 2.104 ;
+use IO::Uncompress::Base 2.106 ;
 
 
 require Exporter ;
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $AnyUncompressError);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 $AnyUncompressError = '';
 
 @ISA = qw(IO::Uncompress::Base Exporter);

--- a/cpan/IO-Compress/lib/IO/Uncompress/Base.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Base.pm
@@ -9,12 +9,12 @@ our (@ISA, $VERSION, @EXPORT_OK, %EXPORT_TAGS);
 @ISA    = qw(IO::File Exporter);
 
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 
 use constant G_EOF => 0 ;
 use constant G_ERR => -1 ;
 
-use IO::Compress::Base::Common 2.104 ;
+use IO::Compress::Base::Common 2.106 ;
 
 use IO::File ;
 use Symbol;

--- a/cpan/IO-Compress/lib/IO/Uncompress/Bunzip2.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Bunzip2.pm
@@ -4,15 +4,15 @@ use strict ;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common 2.104 qw(:Status );
+use IO::Compress::Base::Common 2.106 qw(:Status );
 
-use IO::Uncompress::Base 2.104 ;
-use IO::Uncompress::Adapter::Bunzip2 2.104 ;
+use IO::Uncompress::Base 2.106 ;
+use IO::Uncompress::Adapter::Bunzip2 2.106 ;
 
 require Exporter ;
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $Bunzip2Error);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 $Bunzip2Error = '';
 
 @ISA    = qw(IO::Uncompress::Base Exporter);

--- a/cpan/IO-Compress/lib/IO/Uncompress/Gunzip.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Gunzip.pm
@@ -9,12 +9,12 @@ use strict ;
 use warnings;
 use bytes;
 
-use IO::Uncompress::RawInflate 2.104 ;
+use IO::Uncompress::RawInflate 2.106 ;
 
 use Compress::Raw::Zlib 2.103 () ;
-use IO::Compress::Base::Common 2.104 qw(:Status );
-use IO::Compress::Gzip::Constants 2.104 ;
-use IO::Compress::Zlib::Extra 2.104 ;
+use IO::Compress::Base::Common 2.106 qw(:Status );
+use IO::Compress::Gzip::Constants 2.106 ;
+use IO::Compress::Zlib::Extra 2.106 ;
 
 require Exporter ;
 
@@ -28,7 +28,7 @@ Exporter::export_ok_tags('all');
 
 $GunzipError = '';
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 
 sub new
 {

--- a/cpan/IO-Compress/lib/IO/Uncompress/Inflate.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Inflate.pm
@@ -5,15 +5,15 @@ use strict ;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.104 qw(:Status );
-use IO::Compress::Zlib::Constants 2.104 ;
+use IO::Compress::Base::Common  2.106 qw(:Status );
+use IO::Compress::Zlib::Constants 2.106 ;
 
-use IO::Uncompress::RawInflate  2.104 ;
+use IO::Uncompress::RawInflate  2.106 ;
 
 require Exporter ;
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $InflateError);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 $InflateError = '';
 
 @ISA    = qw(IO::Uncompress::RawInflate Exporter);

--- a/cpan/IO-Compress/lib/IO/Uncompress/RawInflate.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/RawInflate.pm
@@ -6,15 +6,15 @@ use warnings;
 use bytes;
 
 use Compress::Raw::Zlib  2.103 ;
-use IO::Compress::Base::Common  2.104 qw(:Status );
+use IO::Compress::Base::Common  2.106 qw(:Status );
 
-use IO::Uncompress::Base  2.104 ;
-use IO::Uncompress::Adapter::Inflate  2.104 ;
+use IO::Uncompress::Base  2.106 ;
+use IO::Uncompress::Adapter::Inflate  2.106 ;
 
 require Exporter ;
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, %DEFLATE_CONSTANTS, $RawInflateError);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 $RawInflateError = '';
 
 @ISA    = qw(IO::Uncompress::Base Exporter);

--- a/cpan/IO-Compress/lib/IO/Uncompress/Unzip.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Unzip.pm
@@ -9,12 +9,12 @@ use warnings;
 use bytes;
 
 use IO::File;
-use IO::Uncompress::RawInflate  2.104 ;
-use IO::Compress::Base::Common  2.104 qw(:Status );
-use IO::Uncompress::Adapter::Inflate  2.104 ;
-use IO::Uncompress::Adapter::Identity 2.104 ;
-use IO::Compress::Zlib::Extra 2.104 ;
-use IO::Compress::Zip::Constants 2.104 ;
+use IO::Uncompress::RawInflate  2.106 ;
+use IO::Compress::Base::Common  2.106 qw(:Status );
+use IO::Uncompress::Adapter::Inflate  2.106 ;
+use IO::Uncompress::Adapter::Identity 2.106 ;
+use IO::Compress::Zlib::Extra 2.106 ;
+use IO::Compress::Zip::Constants 2.106 ;
 
 use Compress::Raw::Zlib  2.103 () ;
 
@@ -38,7 +38,7 @@ require Exporter ;
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $UnzipError, %headerLookup);
 
-$VERSION = '2.104';
+$VERSION = '2.106';
 $UnzipError = '';
 
 @ISA    = qw(IO::Uncompress::RawInflate Exporter);

--- a/t/porting/utils.t
+++ b/t/porting/utils.t
@@ -76,12 +76,21 @@ foreach (@maybe) {
 
 printf "1..%d\n", scalar @victims;
 
+# Does this perl have 64 bit integers?
+my $has_64bit_ints = eval { pack "Q", 1 };
+
 foreach my $victim (@victims) {
  SKIP: {
         skip ("$victim uses $excuses{$victim}, so can't test with just core modules")
             if $excuses{$victim};
 
         my $got = runperl(switches => ['-c'], progfile => $victim, stderr => 1, nolib => 1);
+
+        # check to see if this script needs 64 bit integers.
+        if (!$has_64bit_ints and $got =~ /requires 64 bit integers/) {
+            skip("$victim requires 64 bit integers and this is a 32 bit Perl", 1);
+        }
+
         is($got, "$victim syntax OK\n", "$victim compiles")
             or diag("when executing perl with '-c $victim'");
     }


### PR DESCRIPTION
On 32 bit perls IO-Compress/bin/zipdetails fails t/porting/utils.t via its copy into the utils directory. This patch adds a way for scripts that end up in utils to advise they require 64 bit perls.

```
 # Failed test 83 - utils/zipdetails compiles at porting/utils.t line 85
 #      got "Integer overflow in hexadecimal number at utils/zipdetails line 1432.
 Integer overflow in hexadecimal number at utils/zipdetails line 2247.
 Integer overflow in hexadecimal number at utils/zipdetails line 2248.
 Integer overflow in hexadecimal number at utils/zipdetails line 2249.
 Integer overflow in hexadecimal number at utils/zipdetails line 2250.
 Integer overflow in hexadecimal number at utils/zipdetails line 2251.
 Integer overflow in hexadecimal number at utils/zipdetails line 2252.
 Integer overflow in hexadecimal number at utils/zipdetails line 2253.
 Integer overflow in hexadecimal number at utils/zipdetails line 2254.
 utils/zipdetails syntax OK
 "
 # expected "utils/zipdetails syntax OK
 "
 t/porting/utils .................................................. FAILED at test 83
```

This patch adds a way that utils of this form can exit early with a
warning containing the magic phrase "requires 64 bit integers", in
which case the compile test will be skipped.

I will push a corresponding patch to https://github.com/pmqs/zipdetails
which is the upstream repository for cpan/IO-Compress/bin/zipdetails
which is hosted at https://github.com/pmqs/IO-Compress

This problem seems to have started when IO-Compress 2.105 was merged
in 131aabd8eb09322f5fc1ad33ed607d45390ee16d.

This includes the fix to IO-Compress 2.106, and should now pass tests on 32 bit perls (it does on my local test builds).

This also includes a fix for our github pipelines that was caused by the fix for the git CVE-2022-24765.