### PR TITLE
expand wildcards in t/harness and use it for test_porting and test_reonly make targets

### DIFF
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -1664,7 +1664,7 @@ test_reonly test-reonly: test_prep_reonly
 # Porting tests (well-formedness of pod, manifest, etc)
 
 test_porting test-porting: test_prep
-	cd t && $(RUN_PERL) harness porting/*.t ../lib/diagnostics.t
+	TEST_ARGS='porting/*.t lib/diagnostics.t' TESTFILE=harness $(RUN_TESTS) choose
 
 !NO!SUBS!
 

--- a/Makefile.SH
+++ b/Makefile.SH
@@ -1658,7 +1658,7 @@ test_harness_notty: test_prep
 	HARNESS_NOTTY=1 TESTFILE=harness $(RUN_TESTS) choose
 
 test_reonly test-reonly: test_prep_reonly
-	TEST_ARGS='-re \bre\/' TESTFILE=harness $(RUN_TESTS) choose
+	TEST_ARGS='re/*.t ext/re/t/*.t' TESTFILE=harness $(RUN_TESTS) choose
 
 
 # Porting tests (well-formedness of pod, manifest, etc)

--- a/t/harness
+++ b/t/harness
@@ -93,7 +93,7 @@ if ($ENV{HARNESS_OPTIONS}) {
 if (@ARGV) {
     # If you want these run in speed order, just use prove
 
-    # Note: we use glob on even on *nix and not just on Windows
+    # Note: we use glob even on *nix and not just on Windows
     # because arguments might be passed in via the TEST_ARGS
     # env var where they wont be expanded by the shell.
     @tests = map(glob($_),@ARGV);

--- a/t/harness
+++ b/t/harness
@@ -92,12 +92,11 @@ if ($ENV{HARNESS_OPTIONS}) {
 
 if (@ARGV) {
     # If you want these run in speed order, just use prove
-    if ($^O eq 'MSWin32') {
-	@tests = map(glob($_),@ARGV);
-    }
-    else {
-	@tests = @ARGV;
-    }
+
+    # Note: we use glob on even on *nix and not just on Windows
+    # because arguments might be passed in via the TEST_ARGS
+    # env var where they wont be expanded by the shell.
+    @tests = map(glob($_),@ARGV);
     # This is a hack to force config_heavy.pl to be loaded, before the
     # prep work for running a test changes directory.
     1 if $Config{d_fork};


### PR DESCRIPTION
Historically we only expanded wildcards passed into t/harness on windows. But this meant that you cant use wildcards in TEST_ARGS inside of make targets. This then meant that people would roll-their-own `runtests` which sort of defeats the purpose of having it. We actually do have another mechanism to avoid this need, the -re option, but globs are simpler and easier to understand, and whomever created 'test_porting' either didn't know about it (although this is hard to believe it is used only a few lines above in the Makefile.SH/Makefile/makefile for the `test_reonly` target) or found it too tricky to use (backslash issues I imagine, which I definitely do understand).

This PR and patch sequence makes harness glob all non -re arguments, it also adds a patch to switch the `test_porting` make target to use `runtests` like every other test target and do its thing via the TEST_ARGS env var like `test_porting` does, and it changes the `test_reonly` target to use globs instead of -re. This should hopefully make it much easier and more clear to add new partial test make targets sanely.

This means that this:

```
   make test_harness TEST_ARGS='-v porting/*.t lib/diagnostics.t' 
```

will build perl, use `runtests` to set up for t/harness to run, and then verbosely run the tests that the `test_porting` target runs.

IMO a target like `test_porting` really aught to be a role model for such targets, and not roll its own `runtests` compatibility logic. If you check `runtests` you will see that not using it does actually have various issues, even if they are likely to very uncommon.   It also seems like a plain old Good Thing, that all our make test targets run exactly the same way.
