### PR TITLE
Make argument to S_is_invlist pointer to const

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2356,7 +2356,7 @@ EiT	|const char *|get_regex_charset_name|const U32 flags|NN STRLEN* const lenp
  || defined(PERL_IN_TOKE_C) || defined(PERL_IN_UTF8_C)		\
  || defined(PERL_IN_DOOP_C)
 EiRT	|UV*	|invlist_array	|NN SV* const invlist
-EiRT	|bool	|is_invlist	|NULLOK SV* const invlist
+EiRT	|bool	|is_invlist	|NULLOK const SV* const invlist
 EiRT	|bool*	|get_invlist_offset_addr|NN SV* invlist
 EiRT	|UV	|_invlist_len	|NN SV* const invlist
 EiRT	|bool	|_invlist_contains_cp|NN SV* const invlist|const UV cp

--- a/invlist_inline.h
+++ b/invlist_inline.h
@@ -27,7 +27,7 @@
 #define FROM_INTERNAL_SIZE(x) ((x)/ sizeof(UV))
 
 PERL_STATIC_INLINE bool
-S_is_invlist(SV* const invlist)
+S_is_invlist(const SV* const invlist)
 {
     return invlist != NULL && SvTYPE(invlist) == SVt_INVLIST;
 }

--- a/proto.h
+++ b/proto.h
@@ -6250,7 +6250,7 @@ PERL_STATIC_INLINE UV*	S_invlist_array(SV* const invlist)
 #endif
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_INLINE bool	S_is_invlist(SV* const invlist)
+PERL_STATIC_INLINE bool	S_is_invlist(const SV* const invlist)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_INVLIST
 #endif

--- a/regcomp.c
+++ b/regcomp.c
@@ -9507,7 +9507,7 @@ S_invlist_max(const SV* const invlist)
 
     PERL_ARGS_ASSERT_INVLIST_MAX;
 
-    assert(is_invlist((SV *) invlist));
+    assert(is_invlist(invlist));
 
     /* Assumes worst case, in which the 0 element is not counted in the
      * inversion list, so subtracts 1 for that */


### PR DESCRIPTION
This lets us avoid casting away the const in S_invlist_max()