### PR TITLE
regexec.c: Rmv obsolete recursion checks: GH #8369

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -1803,18 +1803,6 @@ Perl yourself.  The #! line at the top of your file could look like
 Perl uses this generic message when none of the errors that it
 encountered were severe enough to halt compilation immediately.
 
-=item Complex regular subexpression recursion limit (%d) exceeded
-
-(W regexp) The regular expression engine uses recursion in complex
-situations where back-tracking is required.  Recursion depth is limited
-to 32766, or perhaps less in architectures where the stack cannot grow
-arbitrarily.  ("Simple" and "medium" situations are handled without
-recursion and are not subject to a limit.)  Try shortening the string
-under examination; looping in Perl code (e.g. with C<while>) rather than
-in the regular expression engine; or rewriting the regular expression so
-that it is simpler or backtracks less.  (See L<perlfaq2> for information
-on I<Mastering Regular Expressions>.)
-
 =item connect() on closed socket %s
 
 (W closed) You tried to do a connect on a closed socket.  Did you forget

--- a/regexec.c
+++ b/regexec.c
@@ -8782,18 +8782,8 @@ NULL
             DEBUG_EXECUTE_r(Perl_re_exec_indentf( aTHX_  "WHILEM: failed, trying continuation...\n",
                 depth)
             );
-          do_whilem_B_max:
-            if (cur_curlyx->u.curlyx.count >= REG_INFTY
-                && ckWARN(WARN_REGEXP)
-                && !reginfo->warned)
-            {
-                reginfo->warned	= TRUE;
-                Perl_warner(aTHX_ packWARN(WARN_REGEXP),
-                     "Complex regular subexpression recursion limit (%d) "
-                     "exceeded",
-                     REG_INFTY - 1);
-            }
 
+          do_whilem_B_max:
             /* now try B */
             ST.save_curlyx = cur_curlyx;
             cur_curlyx = cur_curlyx->u.curlyx.prev_curlyx;
@@ -8803,22 +8793,6 @@ NULL
 
         case WHILEM_B_min_fail: /* just failed to match B in a minimal match */
             cur_curlyx = ST.save_curlyx;
-
-            if (cur_curlyx->u.curlyx.count >= /*max*/ARG2(cur_curlyx->u.curlyx.me)) {
-                /* Maximum greed exceeded */
-                if (cur_curlyx->u.curlyx.count >= REG_INFTY
-                    && ckWARN(WARN_REGEXP)
-                    && !reginfo->warned)
-                {
-                    reginfo->warned	= TRUE;
-                    Perl_warner(aTHX_ packWARN(WARN_REGEXP),
-                        "Complex regular subexpression recursion "
-                        "limit (%d) exceeded",
-                        REG_INFTY - 1);
-                }
-                cur_curlyx->u.curlyx.count--;
-                CACHEsayNO;
-            }
 
             DEBUG_EXECUTE_r(Perl_re_exec_indentf( aTHX_  "WHILEM: B min fail: trying longer...\n", depth)
             );


### PR DESCRIPTION
There is no recursion to exceed limits of.

This fixes #8369