### PR TITLE
mkppport.lst - add dist/ packages that contain XS

### DIFF
--- a/mkppport.lst
+++ b/mkppport.lst
@@ -8,4 +8,13 @@
 cpan/DB_File
 cpan/IPC-SysV
 cpan/Win32API-File
+dist/Data-Dumper
+dist/Devel-PPPort
+dist/ExtUtils-ParseXS
 dist/IO
+dist/PathTools
+dist/Storable
+dist/threads
+dist/threads-shared
+dist/Time-HiRes
+dist/Unicode-Normalize


### PR DESCRIPTION
note this patch does not actually change those modules to use ppport.h,
that should come in a different patch.