### PR TITLE
Customize a few modules to work with z/OS

### DIFF
--- a/cpan/Socket/Socket.pm
+++ b/cpan/Socket/Socket.pm
@@ -3,7 +3,7 @@ package Socket;
 use strict;
 { use v5.6.1; }
 
-our $VERSION = '2.032';
+our $VERSION = '2.033';
 
 =head1 NAME
 

--- a/cpan/Socket/Socket.xs
+++ b/cpan/Socket/Socket.xs
@@ -733,8 +733,13 @@ static void xs_getnameinfo(pTHX_ CV *cv)
 #endif
 
 	err = getnameinfo((struct sockaddr *)sa, addr_len,
-			want_host ? host : NULL, want_host ? sizeof(host) : 0,
-			want_serv ? serv : NULL, want_serv ? sizeof(serv) : 0,
+#ifdef OS390    /* This OS requires both parameters to be non-NULL */
+			host, sizeof(host),
+			serv, sizeof(serv),
+#else
+                        want_host ? host : NULL, want_host ? sizeof(host) : 0,
+                        want_serv ? serv : NULL, want_serv ? sizeof(serv) : 0,
+#endif
 			flags);
 
 	Safefree(sa);

--- a/cpan/libnet/lib/Net/Cmd.pm
+++ b/cpan/libnet/lib/Net/Cmd.pm
@@ -19,14 +19,14 @@ use Symbol 'gensym';
 use Errno 'EINTR';
 
 BEGIN {
-  if ($^O eq 'os390') {
+  if (ord "A" == 193) {
     require Convert::EBCDIC;
 
     #    Convert::EBCDIC->import;
   }
 }
 
-our $VERSION = "3.13";
+our $VERSION = "3.14";
 our @ISA     = qw(Exporter);
 our @EXPORT  = qw(CMD_INFO CMD_OK CMD_MORE CMD_REJECT CMD_ERROR CMD_PENDING);
 
@@ -41,7 +41,7 @@ use constant DEF_REPLY_CODE => 421;
 
 my %debug = ();
 
-my $tr = $^O eq 'os390' ? Convert::EBCDIC->new() : undef;
+my $tr = ord "A" == 193 ? Convert::EBCDIC->new() : undef;
 
 sub toebcdic {
   my $cmd = shift;
@@ -897,7 +897,7 @@ License or the Artistic License, as specified in the F<LICENCE> file.
 
 =head1 VERSION
 
-Version 3.13
+Version 3.14
 
 =head1 DATE
 

--- a/cpan/libnet/lib/Net/Config.pm
+++ b/cpan/libnet/lib/Net/Config.pm
@@ -18,7 +18,7 @@ use Socket qw(inet_aton inet_ntoa);
 
 our @EXPORT  = qw(%NetConfig);
 our @ISA     = qw(Net::LocalCfg Exporter);
-our $VERSION = "3.13";
+our $VERSION = "3.14";
 
 our($CONFIGURE, $LIBNET_CFG);
 
@@ -368,7 +368,7 @@ License or the Artistic License, as specified in the F<LICENCE> file.
 
 =head1 VERSION
 
-Version 3.13
+Version 3.14
 
 =head1 DATE
 

--- a/cpan/libnet/lib/Net/Domain.pm
+++ b/cpan/libnet/lib/Net/Domain.pm
@@ -19,7 +19,7 @@ use Net::Config;
 
 our @ISA       = qw(Exporter);
 our @EXPORT_OK = qw(hostname hostdomain hostfqdn domainname);
-our $VERSION = "3.13";
+our $VERSION = "3.14";
 
 my ($host, $domain, $fqdn) = (undef, undef, undef);
 
@@ -395,7 +395,7 @@ License or the Artistic License, as specified in the F<LICENCE> file.
 
 =head1 VERSION
 
-Version 3.13
+Version 3.14
 
 =head1 DATE
 

--- a/cpan/libnet/lib/Net/FTP.pm
+++ b/cpan/libnet/lib/Net/FTP.pm
@@ -23,7 +23,7 @@ use Net::Config;
 use Socket;
 use Time::Local;
 
-our $VERSION = '3.13';
+our $VERSION = '3.14';
 
 our $IOCLASS;
 my $family_key;
@@ -66,7 +66,7 @@ use constant TELNET_IAC => 255;
 use constant TELNET_IP  => 244;
 use constant TELNET_DM  => 242;
 
-use constant EBCDIC => $^O eq 'os390';
+use constant EBCDIC => ord 'A' == 193;
 
 sub new {
   my $pkg = shift;
@@ -2044,7 +2044,7 @@ License or the Artistic License, as specified in the F<LICENCE> file.
 
 =head1 VERSION
 
-Version 3.13
+Version 3.14
 
 =head1 DATE
 

--- a/cpan/libnet/lib/Net/FTP/A.pm
+++ b/cpan/libnet/lib/Net/FTP/A.pm
@@ -13,7 +13,7 @@ use Carp;
 use Net::FTP::dataconn;
 
 our @ISA     = qw(Net::FTP::dataconn);
-our $VERSION = "3.13";
+our $VERSION = "3.14";
 
 our $buf;
 

--- a/cpan/libnet/lib/Net/FTP/E.pm
+++ b/cpan/libnet/lib/Net/FTP/E.pm
@@ -8,6 +8,6 @@ use warnings;
 use Net::FTP::I;
 
 our @ISA = qw(Net::FTP::I);
-our $VERSION = "3.13";
+our $VERSION = "3.14";
 
 1;

--- a/cpan/libnet/lib/Net/FTP/I.pm
+++ b/cpan/libnet/lib/Net/FTP/I.pm
@@ -13,7 +13,7 @@ use Carp;
 use Net::FTP::dataconn;
 
 our @ISA     = qw(Net::FTP::dataconn);
-our $VERSION = "3.13";
+our $VERSION = "3.14";
 
 our $buf;
 

--- a/cpan/libnet/lib/Net/FTP/L.pm
+++ b/cpan/libnet/lib/Net/FTP/L.pm
@@ -8,6 +8,6 @@ use warnings;
 use Net::FTP::I;
 
 our @ISA = qw(Net::FTP::I);
-our $VERSION = "3.13";
+our $VERSION = "3.14";
 
 1;

--- a/cpan/libnet/lib/Net/FTP/dataconn.pm
+++ b/cpan/libnet/lib/Net/FTP/dataconn.pm
@@ -13,7 +13,7 @@ use Carp;
 use Errno;
 use Net::Cmd;
 
-our $VERSION = '3.13';
+our $VERSION = '3.14';
 
 $Net::FTP::IOCLASS or die "please load Net::FTP before Net::FTP::dataconn";
 our @ISA = $Net::FTP::IOCLASS;
@@ -224,7 +224,7 @@ License or the Artistic License, as specified in the F<LICENCE> file.
 
 =head1 VERSION
 
-Version 3.13
+Version 3.14
 
 =head1 DATE
 

--- a/cpan/libnet/lib/Net/NNTP.pm
+++ b/cpan/libnet/lib/Net/NNTP.pm
@@ -19,7 +19,7 @@ use Net::Cmd;
 use Net::Config;
 use Time::Local;
 
-our $VERSION = "3.13";
+our $VERSION = "3.14";
 
 # Code for detecting if we can use SSL
 my $ssl_class = eval {
@@ -1308,7 +1308,7 @@ License or the Artistic License, as specified in the F<LICENCE> file.
 
 =head1 VERSION
 
-Version 3.13
+Version 3.14
 
 =head1 DATE
 

--- a/cpan/libnet/lib/Net/Netrc.pm
+++ b/cpan/libnet/lib/Net/Netrc.pm
@@ -16,7 +16,7 @@ use warnings;
 use Carp;
 use FileHandle;
 
-our $VERSION = "3.13";
+our $VERSION = "3.14";
 
 our $TESTING;
 
@@ -353,7 +353,7 @@ License or the Artistic License, as specified in the F<LICENCE> file.
 
 =head1 VERSION
 
-Version 3.13
+Version 3.14
 
 =head1 DATE
 

--- a/cpan/libnet/lib/Net/POP3.pm
+++ b/cpan/libnet/lib/Net/POP3.pm
@@ -18,7 +18,7 @@ use IO::Socket;
 use Net::Cmd;
 use Net::Config;
 
-our $VERSION = "3.13";
+our $VERSION = "3.14";
 
 # Code for detecting if we can use SSL
 my $ssl_class = eval {
@@ -869,7 +869,7 @@ License or the Artistic License, as specified in the F<LICENCE> file.
 
 =head1 VERSION
 
-Version 3.13
+Version 3.14
 
 =head1 DATE
 

--- a/cpan/libnet/lib/Net/SMTP.pm
+++ b/cpan/libnet/lib/Net/SMTP.pm
@@ -19,7 +19,7 @@ use Net::Cmd;
 use Net::Config;
 use Socket;
 
-our $VERSION = "3.13";
+our $VERSION = "3.14";
 
 # Code for detecting if we can use SSL
 my $ssl_class = eval {
@@ -1052,7 +1052,7 @@ License or the Artistic License, as specified in the F<LICENCE> file.
 
 =head1 VERSION
 
-Version 3.13
+Version 3.14
 
 =head1 DATE
 

--- a/cpan/libnet/lib/Net/Time.pm
+++ b/cpan/libnet/lib/Net/Time.pm
@@ -22,7 +22,7 @@ use Net::Config;
 our @ISA       = qw(Exporter);
 our @EXPORT_OK = qw(inet_time inet_daytime);
 
-our $VERSION = "3.13";
+our $VERSION = "3.14";
 
 our $TIMEOUT = 120;
 
@@ -190,7 +190,7 @@ License or the Artistic License, as specified in the F<LICENCE> file.
 
 =head1 VERSION
 
-Version 3.13
+Version 3.14
 
 =head1 DATE
 

--- a/cpan/podlators/t/general/basic.t
+++ b/cpan/podlators/t/general/basic.t
@@ -80,9 +80,8 @@ for my $module (sort keys %OUTPUT) {
         $got =~ s{ \A .* \n [.]nh \n }{}xms;
     }
 
-    # OS/390 is EBCDIC, which apparently uses a different character for ESC.
-    # Try to convert so that the test still works.
-    if ($^O eq 'os390' && $module eq 'Pod::Text::Termcap') {
+    # Try to convert on EBCDIC boxes so that the test still works.
+    if (ord "A" == 193 && $module eq 'Pod::Text::Termcap') {
         $got =~ tr{\033}{\047};
     }
 

--- a/cpan/podlators/t/man/empty.t
+++ b/cpan/podlators/t/man/empty.t
@@ -32,7 +32,8 @@ local $SIG{__WARN__} = sub { croak($_[0]) };
 # Try a POD document where the only command is invalid.  Make sure it succeeds
 # and doesn't throw an exception.
 ## no critic (ValuesAndExpressions::ProhibitEscapedCharacters)
-ok(eval { $parser->parse_string_document("=\xa0") },
+my $invalid_char = chr utf8::unicode_to_native(0xa0);
+ok(eval { $parser->parse_string_document("=$invalid_char") },
     'Parsed invalid document');
 is($@, q{}, '...with no errors');
 ## use critic

--- a/cpan/podlators/t/man/no-encode.t
+++ b/cpan/podlators/t/man/no-encode.t
@@ -38,14 +38,18 @@ BEGIN {
 
 # Ensure we don't get warnings by throwing an exception if we see any.  This
 # is overridden below when we enable utf8 and do expect a warning.
-local $SIG{__WARN__} = sub { die "No warnings expected\n" };
-
+local $SIG{__WARN__} = sub { die join("\n",
+                                      "No warnings expected; instead got:",
+                                      @_);
+                           };
 # First, check that everything works properly when utf8 isn't set.  We expect
 # to get accent-mangled ASCII output.  Don't use Test::Podlators, since it
 # wants to import Encode.
 #
 ## no critic (ValuesAndExpressions::ProhibitEscapedCharacters)
-my $pod = "=encoding latin1\n\n=head1 NAME\n\nBeyonc\xE9!";
+my $pod = "=encoding latin1\n\n=head1 NAME\n\nBeyonc"
+        . chr(utf8::unicode_to_native(0xE9))
+        . "!";
 my $parser = Pod::Man->new(utf8 => 0, name => 'test');
 my $output;
 $parser->output_string(\$output);

--- a/cpan/podlators/t/text/invalid.t
+++ b/cpan/podlators/t/text/invalid.t
@@ -55,7 +55,8 @@ sub check_document {
 
 # Document whose only content is an invalid command.
 ## no critic (ValuesAndExpressions::ProhibitEscapedCharacters)
-check_document("=\xa0", 'invalid command');
+my $invalid_char = chr utf8::unicode_to_native(0xa0);
+check_document("=$invalid_char", 'invalid command');
 
 # Document containing only a =cut.
 check_document('=cut', 'document with only =cut');

--- a/handy.h
+++ b/handy.h
@@ -2016,7 +2016,12 @@ END_EXTERN_C
 #  define isALPHANUMERIC_LC(c)  _generic_LC(c, _CC_ALPHANUMERIC, isalnum)
 #  define isCNTRL_LC(c)    _generic_LC(c, _CC_CNTRL, iscntrl)
 #  define isDIGIT_LC(c)    _generic_LC(c, _CC_DIGIT, isdigit)
-#  define isGRAPH_LC(c)    _generic_LC(c, _CC_GRAPH, isgraph)
+#  ifdef OS390  /* This system considers NBSP to be a graph */
+#    define isGRAPH_LC(c)    _generic_LC(c, _CC_GRAPH, isgraph)             \
+                        && ! isSPACE_LC(c)
+#  else
+#    define isGRAPH_LC(c)    _generic_LC(c, _CC_GRAPH, isgraph)
+#  endif
 #  define isIDFIRST_LC(c)  _generic_LC_underscore(c, _CC_IDFIRST, isalpha)
 #  define isLOWER_LC(c)    _generic_LC(c, _CC_LOWER, islower)
 #  define isPRINT_LC(c)    _generic_LC(c, _CC_PRINT, isprint)

--- a/hints/os390.sh
+++ b/hints/os390.sh
@@ -35,6 +35,9 @@ esac
 # "unicode literals" to be enabled
 def_os390_cflags='-qlanglvl=extc1x';
 
+# For #ifdefs in code
+def_os390_defs="-DOS390 -DZOS";
+
 # Turn on POSIX compatibility modes
 #  https://www.ibm.com/support/knowledgecenter/SSLTBW_2.4.0/com.ibm.zos.v2r4.bpxbd00/ftms.htm
 def_os390_defs="$def_os390_defs -D_ALL_SOURCE";


### PR DESCRIPTION
z/OS works with both ASCII and EBCDIC character sets; that it works with ASCII was unknown to many people (including me).  We've had contributions this release cycle to get the ASCII mode to work.  There are still several failures in the test suite on it.  due to some peculiarities in the OS.  This commit makes minor corrections to a few /cpan modules to bring the failures down to just a few.

Some modules assumed EBCDIC for z/OS.  This commit series changes them to test for the character set, not the OS.

Some locales on z/OS improperly make some space characters into also being graphic.  A commit changes this so graphic characters can't be spaces.  We already do something similar for Windows.

getnameinfo() on z/OS requires both its return buffers to be non-NULL.  POSIX allows one to be.  A commit in this branch causes it to be called with both non-NULL.

podlators, in spite of testing for EBCDIC, includes some ASCII-isms.  Since I already had to customize the module, I included a commit to remove these.

If I were the maintainer of any of these modules, I would think it not worth it to release a new version just to accommodate a new platform.  So I have not yet issued pull requests for the modules here.  But, as Perl core, it makes sense to accommodate a new platform.