### PR TITLE
No taint debugging

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -329,7 +329,7 @@ L</Platform Support> section, instead.
 =item *
 
 A new question has been added to Configure, to ask if you want to build
-perl without taint support. If you say "no", then all taint features,
+perl with taint support. If you say "no", then all taint features,
 such as the B<-T> and B<-t> switches, will silently do nothing.
 It defaults to "yes", so if you run Configure accepting all defaults,
 you'll get a perl which supports taint just like before.

--- a/t/run/switchDx.t
+++ b/t/run/switchDx.t
@@ -32,10 +32,15 @@ END {
     ok(-e $perlio_log, "... perlio debugging file found with -Di and PERLIO_DEBUG");
 
     unlink $perlio_log;
-    fresh_perl_like("print qq(hello\n)", qr/define raw/,
-                  { stderr => 1, switches => [ "-TDi" ] },
-                  "Perlio debug output to stderr with -TDi (with PERLIO_DEBUG)...");
-    ok(!-e $perlio_log, "...no perlio debugging file found");
+    SKIP: {
+        if (not $Config{taint_support}) {
+            skip("Your perl was built without taint support", 2);
+        }
+        fresh_perl_like("print qq(hello\n)", qr/define raw/,
+                      { stderr => 1, switches => [ "-TDi" ] },
+                      "Perlio debug output to stderr with -TDi (with PERLIO_DEBUG)...");
+        ok(!-e $perlio_log, "...no perlio debugging file found");
+    }
 }
 
 {


### PR DESCRIPTION
Nicholas Clark discovered that the following configuration would fail two tests:

    ./Configure -Dusedevel -des -Utaint_support -DDEBUGGING

This skips the two tests if built without taint support.

Karl also noticed a typo in the perldelta entry, which the other commit here fixes.