### PR TITLE
regen/mph.pl - make sure the author of _squeeze() has a commit in the log

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -772,6 +772,7 @@ Ilya Martynov <ilya@martynov.org> Ilya Martynov <ilya@martynov.org>
 Ilya Martynov <ilya@martynov.org> ilya@juil.nonet <ilya@juil.nonet>
 Ilya N. Golubev <gin@mo.msk.ru> Ilya N. Golubev <gin@mo.msk.ru>
 Ilya Sandler <ilya.sandler@etak.com> Ilya Sandler <ilya.sandler@etak.com>
+Ilya Sashcheka <sas4eka@gmail.com> Ilya Sashcheka <sas4eka@gmail.com>
 Ilya Zakharevich <ilya@math.berkeley.edu> <[9]ilya@math.ohio-state.edu>
 Ilya Zakharevich <ilya@math.berkeley.edu> <nospam-abuse@ilyaz.org>
 Ilya Zakharevich <ilya@math.berkeley.edu> Ilya Zakharevich <ilya@math.berkeley.edu>

--- a/AUTHORS
+++ b/AUTHORS
@@ -574,7 +574,7 @@ Ilmari Karonen                 <iltzu@sci.fi>
 Ilya Martynov                  <ilya@martynov.org>
 Ilya N. Golubev                <gin@mo.msk.ru>
 Ilya Sandler                   <Ilya.Sandler@etak.com>
-Ilya Sashcheka
+Ilya Sashcheka                 <sas4eka@gmail.com>
 Ilya Zakharevich               <ilya@math.berkeley.edu>
 Inaba Hiroto                   <inaba@st.rim.or.jp>
 Indy Singh                     <indy@nusphere.com>

--- a/regen/mph.pl
+++ b/regen/mph.pl
@@ -792,6 +792,7 @@ sub _initial_covering_buf {
 
 sub build_split_words_squeeze {
     my ($self)= @_;
+    # Thanks to Ilya Sashcheka for this algorithm
 
     my $hash= $self->{source_hash};
     my $length_all_keys= $self->{length_all_keys};

--- a/uni_keywords.h
+++ b/uni_keywords.h
@@ -7681,5 +7681,5 @@ match_uniprop( const unsigned char * const key, const U16 key_len ) {
  * 0a6b5ab33bb1026531f816efe81aea1a8ffcd34a27cbea37dd6a70a63d73c844 regen/charset_translations.pl
  * 5f8520d3a17ade6317fc0c423f5091470924b1ef425bca0c41ce8e4a9f8460fe regen/mk_PL_charclass.pl
  * 1c73795f9150bd556573e7ae982789377289e22b6a7f3db0a05c36852e8d749f regen/mk_invlists.pl
- * 6e843ca664e002c0d05693c02281ee61f8e7900edba54981dfba549027de37b0 regen/mph.pl
+ * d6987e01ad538d1567394851cf199f99815f7701bebd6092be4bc7a6d8f147c6 regen/mph.pl
  * ex: set ro: */


### PR DESCRIPTION
This commit is actually by the committer, and is intended to ensure that someone looking for what the author wrote can find it and that his name ends up in the 5.36 authors list, etc. It took me a while to get a email address for him or I would have done this in eda35008b17e739922 which is where his work on the _squeeze() split key algorithm was added. Credit where credit is due and all of that. Thanks Ilya.