### PR TITLE
regcomp.c - silence build warning under NO_TAINT_SUPPORT

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -9390,7 +9390,9 @@ S_invlist_replace_list_destroys_src(pTHX_ SV * dest, SV * src)
     const STRLEN src_byte_len = SvLEN(src);
     char * array              = SvPVX(src);
 
+#ifndef NO_TAINT_SUPPORT
     const int oldtainted = TAINT_get;
+#endif
 
     PERL_ARGS_ASSERT_INVLIST_REPLACE_LIST_DESTROYS_SRC;
 


### PR DESCRIPTION
The variable 'oldtainted' is unused when NO_TAINT_SUPPORT is defined.
This patch ifdefs it out of the compiled code.

This should resolve GH Issue #19654
See: https://github.com/Perl/perl5/issues/19654