### PR TITLE
perlop: Clarify parts of tr///

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -2611,7 +2611,7 @@ of those; in other words, an lvalue.
 The characters delimitting I<SEARCHLIST> and I<REPLACEMENTLIST>
 can be any printable character, not just forward slashes.  If they
 are single quotes (C<tr'I<SEARCHLIST>'I<REPLACEMENTLIST>'>), the only
-interpolation is removal of C<\> from pairs of C<\\>, and hyphens are
+interpolation is removal of C<\> from pairs of C<\\>; so hyphens are
 interpreted literally rather than specifying a character range.
 
 Otherwise, a character range may be specified with a hyphen, so
@@ -2620,25 +2620,37 @@ C<tr/ACEGIBDFHJ/0246813579/>.
 
 If the I<SEARCHLIST> is delimited by bracketing quotes, the
 I<REPLACEMENTLIST> must have its own pair of quotes, which may or may
-not be bracketing quotes; for example, C<tr[aeiouy][yuoiea]> or
-C<tr(+\-*/)/ABCD/>.
+not be bracketing quotes; for example, C<tr(aeiouy)(yuoiea)> or
+C<tr[+\-*/]"ABCD">.  This final example shows a way to visually clarify
+what is going on for people who are more familiar with regular
+expression patterns than with C<tr>, and who may think forward slash
+delimiters imply that C<tr> is more like a regular expression pattern
+than it actually is.  (Another option might be to use C<tr[...][...]>.)
 
-Characters may be literals, or (if the delimiters aren't single quotes)
-any of the escape sequences accepted in double-quoted strings.  But
-there is never any variable interpolation, so C<"$"> and C<"@"> are
-always treated as literals.  A hyphen at the beginning or end, or
-preceded by a backslash is also always considered a literal.  Escape
-sequence details are in L<the table near the beginning of this
-section|/Quote and Quote-like Operators>.
+C<tr> isn't fully like bracketed character classes, just
+(significantly) more like them than it is to full patterns.  For
+example, characters appearing more than once in either list behave
+differently here than in patterns, and C<tr> lists do not allow
+backslashed character classes such as C<\d> or C<\pL>, nor variable
+interpolation, so C<"$"> and C<"@"> are always treated as literals.
 
-Note that C<tr> does B<not> do regular expression character classes such as
-C<\d> or C<\pL>.  The C<tr> operator is not equivalent to the C<L<tr(1)>>
-utility.  C<tr[a-z][A-Z]> will uppercase the 26 letters "a" through "z",
-but for case changing not confined to ASCII, use
-L<C<lc>|perlfunc/lc>, L<C<uc>|perlfunc/uc>,
-L<C<lcfirst>|perlfunc/lcfirst>, L<C<ucfirst>|perlfunc/ucfirst>
-(all documented in L<perlfunc>), or the
-L<substitution operator C<sE<sol>I<PATTERN>E<sol>I<REPLACEMENT>E<sol>>|/sE<sol>PATTERNE<sol>REPLACEMENTE<sol>msixpodualngcer>
+The allowed elements are literals plus C<\'> (meaning a single quote).
+If the delimiters aren't single quotes, also allowed are any of the
+escape sequences accepted in double-quoted strings.  Escape sequence
+details are in L<the table near the beginning of this section|/Quote and
+Quote-like Operators>.
+
+A hyphen at the beginning or end, or preceded by a backslash is also
+always considered a literal.  Precede a delimiter character with a
+backslash to allow it.
+
+The C<tr> operator is not equivalent to the C<L<tr(1)>> utility.
+C<tr[a-z][A-Z]> will uppercase the 26 letters "a" through "z", but for
+case changing not confined to ASCII, use L<C<lc>|perlfunc/lc>,
+L<C<uc>|perlfunc/uc>, L<C<lcfirst>|perlfunc/lcfirst>,
+L<C<ucfirst>|perlfunc/ucfirst> (all documented in L<perlfunc>), or the
+L<substitution operator
+C<sE<sol>I<PATTERN>E<sol>I<REPLACEMENT>E<sol>>|/sE<sol>PATTERNE<sol>REPLACEMENTE<sol>msixpodualngcer>
 (with C<\U>, C<\u>, C<\L>, and C<\l> string-interpolation escapes in the
 I<REPLACEMENT> portion).
 


### PR DESCRIPTION
I think I had a similar pull request earlier, and had to close it for some reason, and that @Grinnz had comments on it.  But I can't find the PR in github.