### PR TITLE
Evaluate SvPVXtrue's argument just once

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2797,6 +2797,7 @@ AiMdp	|void	|SvREFCNT_dec	|NULLOK SV *sv
 AiMdp	|void	|SvREFCNT_dec_NN|NN SV *sv
 AiTpd	|void	|SvAMAGIC_on	|NN SV *sv
 AiTpd	|void	|SvAMAGIC_off	|NN SV *sv
+AIpd	|bool	|SvPVXtrue	|NN SV *sv
 Aipd	|bool	|SvTRUE		|NULLOK SV *sv
 Aipd	|bool	|SvTRUE_nomg	|NULLOK SV *sv
 Aipd	|bool	|SvTRUE_NN	|NN SV *sv

--- a/embed.h
+++ b/embed.h
@@ -31,6 +31,7 @@
 #define Gv_AMupdate(a,b)	Perl_Gv_AMupdate(aTHX_ a,b)
 #define SvAMAGIC_off		Perl_SvAMAGIC_off
 #define SvAMAGIC_on		Perl_SvAMAGIC_on
+#define SvPVXtrue(a)		Perl_SvPVXtrue(aTHX_ a)
 #define SvTRUE(a)		Perl_SvTRUE(aTHX_ a)
 #define SvTRUE_NN(a)		Perl_SvTRUE_NN(aTHX_ a)
 #define SvTRUE_common(a,b)	Perl_SvTRUE_common(aTHX_ a,b)

--- a/inline.h
+++ b/inline.h
@@ -316,6 +316,41 @@ Perl_ReANY(const REGEXP * const re)
 
 /* ------------------------------- sv.h ------------------------------- */
 
+/*
+=for apidoc_section $SV
+=for apidoc Am|bool|SvPVXtrue|SV * sv
+
+Returns a boolean as to whether or not C<sv> contains a PV that is considered
+TRUE.  FALSE is returned if C<sv> doesn't contain a PV, or if the PV it does
+contain is zero length, or consists of just the single character '0'.  Every
+other PV value is considered TRUE.
+
+As of Perl v5.37.1, C<sv> is evaluated exactly once; in earlier releases, it
+could be evaluated more than once.
+
+=cut
+*/
+
+PERL_STATIC_INLINE bool
+Perl_SvPVXtrue(pTHX_ SV *sv)
+{
+    PERL_ARGS_ASSERT_SVPVXTRUE;
+
+    if (! (XPV *) SvANY(sv)) {
+        return false;
+    }
+
+    if ( ((XPV *) SvANY(sv))->xpv_cur > 1) { /* length > 1 */
+        return true;
+    }
+
+    if (( (XPV *) SvANY(sv))->xpv_cur == 0) {
+        return false;
+    }
+
+    return *sv->sv_u.svu_pv != '0';
+}
+
 PERL_STATIC_INLINE bool
 Perl_SvTRUE(pTHX_ SV *sv)
 {

--- a/proto.h
+++ b/proto.h
@@ -95,6 +95,13 @@ PERL_STATIC_INLINE void	Perl_SvAMAGIC_on(SV *sv);
 	assert(sv)
 #endif
 #ifndef PERL_NO_INLINE_FUNCTIONS
+PERL_STATIC_FORCE_INLINE bool	Perl_SvPVXtrue(pTHX_ SV *sv)
+			__attribute__always_inline__;
+#define PERL_ARGS_ASSERT_SVPVXTRUE	\
+	assert(sv)
+#endif
+
+#ifndef PERL_NO_INLINE_FUNCTIONS
 PERL_STATIC_INLINE void	Perl_SvREFCNT_dec(pTHX_ SV *sv);
 #define PERL_ARGS_ASSERT_SVREFCNT_DEC
 #endif

--- a/sv.h
+++ b/sv.h
@@ -2072,30 +2072,6 @@ scalar.
 #  define SvPVbytex_nolen(sv) ((PL_Sv = (sv)), SvPVbyte_nolen(PL_Sv))
 #endif /* __GNU__ */
 
-/*
-=for apidoc Am|bool|SvPVXtrue|SV * sv
-
-Note: This macro may evaluate C<sv> more than once.
-
-Returns a boolean as to whether or not C<sv> contains a PV that is considered
-TRUE.  FALSE is returned if C<sv> doesn't contain a PV, or if the PV it does
-contain is zero length, or consists of just the single character '0'.  Every
-other PV value is considered TRUE.
-
-=cut
-*/
-
-#define SvPVXtrue(sv)	(					\
-    ((XPV*)SvANY((sv))) 					\
-     && (							\
-        ((XPV*)SvANY((sv)))->xpv_cur > 1			\
-        || (							\
-            ((XPV*)SvANY((sv)))->xpv_cur			\
-            && *(sv)->sv_u.svu_pv != '0'                        \
-        )							\
-    )								\
-)
-
 #define SvIsCOW(sv)              (SvFLAGS(sv) & SVf_IsCOW)
 #define SvIsCOW_on(sv)           (SvFLAGS(sv) |= SVf_IsCOW)
 #define SvIsCOW_off(sv)          (SvFLAGS(sv) &= ~(SVf_IsCOW|SVppv_STATIC))


### PR DESCRIPTION
by making the macro instead an inline function