### PR TITLE
Davem/refactor warnings pl

### DIFF
--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -165,12 +165,10 @@ my %NAME_TO_VALUE; # ('NAME'       => index_number,       ....);
 sub valueWalk
 {
     my ($tre, $v_list) = @_;
-    my @list = () ;
     my ($k, $v) ;
 
     foreach $k (sort keys %$tre) {
         $v = $tre->{$k};
-        die "duplicate key $k\n" if defined $CATEGORIES{$k} ;
         die "Value associated with key '$k' is not an ARRAY reference"
             if !ref $v || ref $v ne 'ARRAY' ;
 

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -328,8 +328,6 @@ my ($index, $warn_size);
 
   print $warn warnings_h_boilerplate_1();
 
-  my $offset = 0 ;
-
   valueWalk ($tree) ;
   $index = orderValues();
 

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -209,7 +209,12 @@ sub orderValues
     return $index ;
 }
 
+
 ###########################################################################
+
+# Recurse the tree and populate
+#  %CATEGORIES
+#  %DEFAULTS
 
 sub walk
 {
@@ -238,7 +243,10 @@ sub walk
    return @list ;
 }
 
+
 ###########################################################################
+
+# convert a list like (1,2,3,7,8) into a string like '1..3,7,8'
 
 sub mkRange
 {
@@ -258,7 +266,12 @@ sub mkRange
     return $out;
 }
 
+
 ###########################################################################
+
+# return a string containing a visual representation of the warnings tree
+# structure.
+
 sub warningsTree
 {
     my $tre = shift ;
@@ -300,7 +313,10 @@ sub warningsTree
     return $rv;
 }
 
+
 ###########################################################################
+
+# common backend for mkHex() and mkOct()
 
 sub mkHexOct
 {
@@ -323,17 +339,23 @@ sub mkHexOct
     return $string ;
 }
 
+# Convert a list of bit offsets (0...) into a string containing $max bytes
+# of the form "\xMM\xNN...."
+
 sub mkHex
 {
     my($max, @bits) = @_;
     return mkHexOct("x", $max, @bits);
 }
 
+# Like mkHex(), but outputs "\o..." instead
+
 sub mkOct
 {
     my($max, @bits) = @_;
     return mkHexOct("o", $max, @bits);
 }
+
 
 ###########################################################################
 

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -148,8 +148,6 @@ my @DEFAULTS;      # List of category numbers which are DEFAULT_ON
                    # it enables; e.g.
 my %CATEGORIES;    # { 'name' => [ 1,2,5], ... }
 
-my %Value ;
-
 my %VALUE_TO_NAME; # (index_number => [ 'NAME', version ], ...);
 
 my %NAME_TO_VALUE; # ('NAME'       => index_number,       ....);

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -181,11 +181,11 @@ my %NAME_TO_VALUE; # ('NAME'       => index_number,       ....);
 
 sub valueWalk
 {
-    my ($tre, $v_list) = @_;
+    my ($tree, $v_list) = @_;
     my ($k, $v) ;
 
-    foreach $k (sort keys %$tre) {
-        $v = $tre->{$k};
+    foreach $k (sort keys %$tree) {
+        $v = $tree->{$k};
         die "Value associated with key '$k' is not an ARRAY reference"
             if !ref $v || ref $v ne 'ARRAY' ;
 
@@ -210,10 +210,10 @@ sub valueWalk
 
 sub orderValues
 {
-    my ($tre) = @_;
+    my ($tree) = @_;
 
     my %v_list;
-    valueWalk($tre, \%v_list);
+    valueWalk($tree, \%v_list);
 
     my $index = 0;
     foreach my $ver ( sort { $a <=> $b } keys %v_list ) {
@@ -235,12 +235,12 @@ sub orderValues
 
 sub walk
 {
-    my $tre = shift ;
+    my $tree = shift ;
     my @list = () ;
     my ($k, $v) ;
 
-    foreach $k (sort keys %$tre) {
-        $v = $tre->{$k};
+    foreach $k (sort keys %$tree) {
+        $v = $tree->{$k};
         die "duplicate key $k\n" if defined $CATEGORIES{$k} ;
         die "Can't find key '$k'"
             if ! defined $NAME_TO_VALUE{uc $k} ;
@@ -291,22 +291,22 @@ sub mkRange
 
 sub warningsTree
 {
-    my $tre = shift ;
+    my $tree = shift ;
     my $prefix = shift ;
     my ($k, $v) ;
 
-    my $max = (sort {$a <=> $b} map { length $_ } keys %$tre)[-1] ;
-    my @keys = sort keys %$tre ;
+    my $max = (sort {$a <=> $b} map { length $_ } keys %$tree)[-1] ;
+    my @keys = sort keys %$tree ;
 
     my $rv = '';
 
     while ($k = shift @keys) {
-        $v = $tre->{$k};
+        $v = $tree->{$k};
         die "Value associated with key '$k' is not an ARRAY reference"
             if !ref $v || ref $v ne 'ARRAY' ;
 
         my $offset ;
-        if ($tre ne $TREE) {
+        if ($tree ne $TREE) {
             $rv .= $prefix . "|\n" ;
             $rv .= $prefix . "+- $k" ;
             $offset = ' ' x ($max + 4) ;

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -323,54 +323,52 @@ my ($warn, $pm) = map {
 
 my ($index, $warn_size);
 
-{
-  # generate warnings.h
+# generate warnings.h
 
-  print $warn warnings_h_boilerplate_1();
+print $warn warnings_h_boilerplate_1();
 
-  valueWalk ($tree) ;
-  $index = orderValues();
+valueWalk ($tree) ;
+$index = orderValues();
 
-  die <<EOM if $index > 255 ;
+die <<EOM if $index > 255 ;
 Too many warnings categories -- max is 255
-    rewrite packWARN* & unpackWARN* macros
+rewrite packWARN* & unpackWARN* macros
 EOM
 
-  walk ($tree) ;
-  for (my $i = $index; $i & 3; $i++) {
-      push @{$list{all}}, $i;
-  }
-
-  $index *= 2 ;
-  $warn_size = int($index / 8) + ($index % 8 != 0) ;
-
-  my $k ;
-  my $last_ver = 0;
-  my @names;
-  foreach $k (sort { $a <=> $b } keys %ValueToName) {
-      my ($name, $version) = @{ $ValueToName{$k} };
-      print $warn "\n/* Warnings Categories added in Perl $version */\n\n"
-          if $last_ver != $version ;
-      $name =~ y/:/_/;
-      $name = "WARN_$name";
-      print $warn tab(6, "#define $name"), " $k\n" ;
-      push @names, $name;
-      $last_ver = $version ;
-  }
-
-  print $warn tab(6, '#define WARNsize'),	" $warn_size\n" ;
-  print $warn tab(6, '#define WARN_ALLstring'), ' "', ('\125' x $warn_size) , "\"\n" ;
-  print $warn tab(6, '#define WARN_NONEstring'), ' "', ('\0' x $warn_size) , "\"\n" ;
-
-  print $warn warnings_h_boilerplate_2();
-
-  print $warn "\n\n/*\n" ;
-  print $warn map { "=for apidoc Amnh||$_\n" } @names;
-  print $warn "\n=cut\n*/\n\n" ;
-  print $warn "/* end of file warnings.h */\n";
-
-  read_only_bottom_close_and_rename($warn);
+walk ($tree) ;
+for (my $i = $index; $i & 3; $i++) {
+    push @{$list{all}}, $i;
 }
+
+$index *= 2 ;
+$warn_size = int($index / 8) + ($index % 8 != 0) ;
+
+my $k ;
+my $last_ver = 0;
+my @names;
+foreach $k (sort { $a <=> $b } keys %ValueToName) {
+    my ($name, $version) = @{ $ValueToName{$k} };
+    print $warn "\n/* Warnings Categories added in Perl $version */\n\n"
+        if $last_ver != $version ;
+    $name =~ y/:/_/;
+    $name = "WARN_$name";
+    print $warn tab(6, "#define $name"), " $k\n" ;
+    push @names, $name;
+    $last_ver = $version ;
+}
+
+print $warn tab(6, '#define WARNsize'),	" $warn_size\n" ;
+print $warn tab(6, '#define WARN_ALLstring'), ' "', ('\125' x $warn_size) , "\"\n" ;
+print $warn tab(6, '#define WARN_NONEstring'), ' "', ('\0' x $warn_size) , "\"\n" ;
+
+print $warn warnings_h_boilerplate_2();
+
+print $warn "\n\n/*\n" ;
+print $warn map { "=for apidoc Amnh||$_\n" } @names;
+print $warn "\n=cut\n*/\n\n" ;
+print $warn "/* end of file warnings.h */\n";
+
+read_only_bottom_close_and_rename($warn);
 
 while (<DATA>) {
     last if /^VERSION$/ ;

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -27,6 +27,23 @@ use strict ;
 sub DEFAULT_ON  () { 1 }
 sub DEFAULT_OFF () { 2 }
 
+
+# Define the hierarchy of warnings.
+#
+# Each level in the tree is a hash which lists the names of all the
+# children below that level. Each child is an array consisting of the
+# version when that warnings category was introduced and, if a terminal
+# category, whether that warning is on by default; otherwise a ref to
+# another hash of children.
+#
+# Note that the version numbers are currently only used to sort and to
+# generate code comments in the output files.
+#
+# Note that warning names aren't hierarchical; by having 'pipe' as a child
+# of 'io', a warnings category called 'io::pipe' is NOT automatically
+# created. But the warnings category 'io' WILL include all the mask bits
+# necessary to turn on 'pipe', 'unopened' etc.
+
 my $TREE = {
 'all' => [ 5.008, {
         'io'            => [ 5.008, {


### PR DESCRIPTION
Refactor regen/warnings.pl. The src for this tool was a mess: it started out 20 years ago as a small utility, then grew. Lots of badly-named global variables, no comments about what subs do etc. This series of commits cleans things up, refactors, adds comments etc. In theory it makes no functional changes, and indeed as run currently it generates exactly the same warnings.h and lib/warning.pm files as before.

I think this can be safely merged before 5.36.0. It's a tool that's only used when developing the perl interpreter (and then only when adding a new warnings category), so even if were broken, it would make no different to an end user of 5.36.0.