### PR TITLE
re_op_compile: Coverity ASSIGN_WHERE_COMPARE_MEANT fix

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -1833,7 +1833,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
          * properly currently.
          *
          */
-        while ((OP(first) == OPEN && (sawopen = 1)) ||
+        while ((OP(first) == OPEN && ((sawopen = 1)) ) ||
                /* An OR of *one* alternative - should not happen now. */
             (OP(first) == BRANCH && OP(first_next) != BRANCH) ||
             /* for now we can't handle lookbehind IFMATCH*/


### PR DESCRIPTION
Coverity CID 316368 raises the concern that in the following comparison:
    `(OP(first) == OPEN && (sawopen = 1)`
the intention might have been to compare sawopen, not assign to it.

The intention genuinely is to assign to sawopen, but since there are two
assignments in this fashion followed by two assignments in the subsequent
block, we can do a small refactor to consolidate the assignments in a way
that will hopefully keep Coverity happy.