### PR TITLE
embed.fnc: Mark taint_env, taint_proper as Core only

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2494,8 +2494,8 @@ EFp	|int	|re_exec_indentf|NN const char *fmt|U32 depth|...
 ESR	|bool	|isFOO_lc	|const U8 classnum|const U8 character
 #endif
 
-Ap	|void	|taint_env
-Ap	|void	|taint_proper	|NULLOK const char* f|NN const char *const s
+Cp	|void	|taint_env
+Cp	|void	|taint_proper	|NULLOK const char* f|NN const char *const s
 EXp	|char *	|_byte_dump_string					\
 				|NN const U8 * const start		\
 				|const STRLEN len			\

--- a/taint.c
+++ b/taint.c
@@ -23,6 +23,14 @@
 #define PERL_IN_TAINT_C
 #include "perl.h"
 
+/*
+=forapidoc taint_proper
+
+Implements the L</TAINT_PROPER> macro, which you should generally use instead.
+
+=cut
+*/
+
 void
 Perl_taint_proper(pTHX_ const char *f, const char *const s)
 {
@@ -78,7 +86,8 @@ Perl_taint_proper(pTHX_ const char *f, const char *const s)
 }
 
 void
-Perl_taint_env(pTHX)
+Perl_taint_env(pTHX)     /* Generally, don't use directly; instead use
+                            TAINT_ENV */
 {
     SV** svp;
     const char* const *e;


### PR DESCRIPTION
One is supposed to access this functionality only through the documented
uppercase-named macros.