### PR TITLE
Fix a typo in a comment in Carp.pm

### DIFF
--- a/dist/Carp/lib/Carp.pm
+++ b/dist/Carp/lib/Carp.pm
@@ -179,7 +179,7 @@ BEGIN {
             ? do { require "overload.pm"; _fetch_sub overload => 'mycan' }
             : \&UNIVERSAL::can;
 
-        # _blessed is either UNIVERAL::isa(...), or, in the presence of an
+        # _blessed is either UNIVERSAL::isa(...), or, in the presence of an
         # override, a hideous, but fairly reliable, workaround.
         *_blessed = $isa
             ? sub { &$isa($_[0], "UNIVERSAL") }
@@ -211,7 +211,7 @@ BEGIN {
 }
 
 
-our $VERSION = '1.52';
+our $VERSION = '1.53';
 $VERSION =~ tr/_//d;
 
 our $MaxEvalLen = 0;

--- a/dist/Carp/lib/Carp/Heavy.pm
+++ b/dist/Carp/lib/Carp/Heavy.pm
@@ -2,7 +2,7 @@ package Carp::Heavy;
 
 use Carp ();
 
-our $VERSION = '1.52';
+our $VERSION = '1.53';
 $VERSION =~ tr/_//d;
 
 # Carp::Heavy was merged into Carp in version 1.12.  Any mismatched versions


### PR DESCRIPTION
Bump $CARP::VERSION and $Carp::Heavy::VERSION

Probably not worth "merging" this until 5.37.1 (ie cherry-pick it then)