### PR TITLE
ExtUtils::CBuilder - print out commands being run in usable form

### DIFF
--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder.pm
@@ -7,7 +7,7 @@ use Perl::OSType qw/os_type/;
 
 use warnings;
 use strict;
-our $VERSION = '0.280236'; # VERSION
+our $VERSION = '0.280237'; # VERSION
 our @ISA;
 
 # We only use this once - don't waste a symbol table entry on it.

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
@@ -335,10 +335,24 @@ sub _do_link {
   return wantarray ? ($out, @temp_files) : $out;
 }
 
+sub quote_literal {
+  my ($self, $string) = @_;
+
+  if (length $string && $string !~ /[^a-zA-Z0-9,._+@%\/-]/) {
+    return $string;
+  }
+
+  $string =~ s{'}{'\\''}g;
+
+  return "'$string'";
+}
 
 sub do_system {
   my ($self, @cmd) = @_;
-  print "@cmd\n" if !$self->{quiet};
+  if (!$self->{quiet}) {
+    my $full = join ' ', map $self->quote_literal($_), @cmd;
+    print $full . "\n";
+  }
   return !system(@cmd);
 }
 

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
@@ -9,7 +9,7 @@ use Text::ParseWords;
 use IPC::Cmd qw(can_run);
 use File::Temp qw(tempfile);
 
-our $VERSION = '0.280236'; # VERSION
+our $VERSION = '0.280237'; # VERSION
 
 # More details about C/C++ compilers:
 # http://developers.sun.com/sunstudio/documentation/product/compiler.jsp

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Unix.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Unix.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Base;
 
-our $VERSION = '0.280236'; # VERSION
+our $VERSION = '0.280237'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Base);
 
 sub link_executable {

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/VMS.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/VMS.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Base;
 
-our $VERSION = '0.280236'; # VERSION
+our $VERSION = '0.280237'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Base);
 
 use File::Spec::Functions qw(catfile catdir);

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows.pm
@@ -8,7 +8,7 @@ use File::Spec;
 use ExtUtils::CBuilder::Base;
 use IO::File;
 
-our $VERSION = '0.280236'; # VERSION
+our $VERSION = '0.280237'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Base);
 
 =begin comment

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows.pm
@@ -51,6 +51,22 @@ sub _compiler_type {
 	  : 'GCC');
 }
 
+# native quoting, not shell quoting
+sub quote_literal {
+  my ($self, $string) = @_;
+
+  # some of these characters don't need to be quoted for "native" quoting, but
+  # quote them anyway so they are more likely to make it through cmd.exe
+  if (length $string && $string !~ /[ \t\n\x0b"|<>%]/) {
+    return $string;
+  }
+
+  $string =~ s{(\\*)(?="|\z)}{$1$1}g;
+  $string =~ s{"}{\\"}g;
+
+  return qq{"$string"};
+}
+
 sub split_like_shell {
   # Since Windows will pass the whole command string (not an argument
   # array) to the target program and make the program parse it itself,
@@ -65,10 +81,15 @@ sub split_like_shell {
 sub do_system {
   # See above
   my $self = shift;
-  my $cmd = join(" ",
-		 grep length,
-		 map {$a=$_;$a=~s/\t/ /g;$a=~s/^\s+|\s+$//;$a}
-		 grep defined, @_);
+  my $cmd = join ' ',
+    grep length,
+    map {$a=$_;$a=~s/\t/ /g;$a=~s/^\s+|\s+$//;$a}
+    grep defined, @_;
+
+  if (!$self->{quiet}) {
+    print $cmd . "\n";
+  }
+  local $self->{quiet} = 1;
   return $self->SUPER::do_system($cmd);
 }
 

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/BCC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/BCC.pm
@@ -1,6 +1,6 @@
 package ExtUtils::CBuilder::Platform::Windows::BCC;
 
-our $VERSION = '0.280236'; # VERSION
+our $VERSION = '0.280237'; # VERSION
 
 use strict;
 use warnings;

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/GCC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/GCC.pm
@@ -1,6 +1,6 @@
 package ExtUtils::CBuilder::Platform::Windows::GCC;
 
-our $VERSION = '0.280236'; # VERSION
+our $VERSION = '0.280237'; # VERSION
 
 use warnings;
 use strict;

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/MSVC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/MSVC.pm
@@ -1,6 +1,6 @@
 package ExtUtils::CBuilder::Platform::Windows::MSVC;
 
-our $VERSION = '0.280236'; # VERSION
+our $VERSION = '0.280237'; # VERSION
 
 use warnings;
 use strict;

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/aix.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/aix.pm
@@ -5,7 +5,7 @@ use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 use File::Spec;
 
-our $VERSION = '0.280236'; # VERSION
+our $VERSION = '0.280237'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub need_prelink { 1 }

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/android.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/android.pm
@@ -6,7 +6,7 @@ use File::Spec;
 use ExtUtils::CBuilder::Platform::Unix;
 use Config;
 
-our $VERSION = '0.280236'; # VERSION
+our $VERSION = '0.280237'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 # The Android linker will not recognize symbols from

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/cygwin.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/cygwin.pm
@@ -5,7 +5,7 @@ use strict;
 use File::Spec;
 use ExtUtils::CBuilder::Platform::Unix;
 
-our $VERSION = '0.280236'; # VERSION
+our $VERSION = '0.280237'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 # TODO: If a specific exe_file name is requested, if the exe created

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/darwin.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/darwin.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 
-our $VERSION = '0.280236'; # VERSION
+our $VERSION = '0.280237'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub compile {

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/dec_osf.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/dec_osf.pm
@@ -5,7 +5,7 @@ use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 use File::Spec;
 
-our $VERSION = '0.280236'; # VERSION
+our $VERSION = '0.280237'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub link_executable {

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/os2.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/os2.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 
-our $VERSION = '0.280236'; # VERSION
+our $VERSION = '0.280237'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub need_prelink { 1 }


### PR DESCRIPTION
When not set to be quiet, the system commands being run are printed out
before running them. This can assist with diagnosing issues. It is
implied that this is a command that could be run by a user.

Since the command is internally run with system using list form, it does not
involve the shell, and does not need any extra quoting. The printed out
command however, would be run by a user through a shell. Just joining
the arguments with spaces will not quote them correctly for use through
a shell.

Add a new method for quoting a string for the shell. And use this method
when printing out the command line that we are running.