### PR TITLE
Module::CoreList - change github clone URL to https

### DIFF
--- a/dist/Module-CoreList/Makefile.PL
+++ b/dist/Module-CoreList/Makefile.PL
@@ -8,7 +8,7 @@ push @extra, 'INSTALLDIRS' => 'perl' if $] >= 5.008009 and $] < 5.012;
 
 push @extra, 'META_MERGE' => {
         resources => {
-            repository => 'git://github.com/Perl/perl5.git',
+            repository => 'https://github.com/Perl/perl5.git',
             bugtracker => 'https://github.com/Perl/perl5/issues',
             homepage   => "http://dev.perl.org/",
         },


### PR DESCRIPTION
GitHub no longer supports git:// cloning because it is not encrypted.