### PR TITLE
doio.c: Rename formal parameters for clarity

### DIFF
--- a/doio.c
+++ b/doio.c
@@ -1632,7 +1632,7 @@ S_dir_unchanged(pTHX_ const char *orig_pv, MAGIC *mg) {
     S_dir_unchanged(aTHX_ (orig_psv), (mg))
 
 STATIC bool
-S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool not_implicit) {
+S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explict) {
     bool retval;
 
     /* ensure args are checked before we start using them */
@@ -1679,7 +1679,7 @@ S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool not_implicit) {
 #endif
         }
 
-        retval = io_close(io, NULL, not_implicit, FALSE);
+        retval = io_close(io, NULL, is_explict, FALSE);
 
         if (SvIV(*pid_psv) != (IV)PerlProc_getpid()) {
             /* this is a child process, don't duplicate our rename() etc
@@ -1724,7 +1724,7 @@ S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool not_implicit) {
                         PerlLIO_rename(orig_pv, SvPVX(*back_psv)) < 0
 #  endif
                         ) {
-                        if (!not_implicit) {
+                        if (!is_explict) {
 #  ifdef ARGV_USE_ATFUNCTIONS
                             if (unlinkat(dfd, SvPVX_const(*temp_psv), 0) < 0 &&
                                 UNLIKELY(NotSupported(errno)) &&
@@ -1742,7 +1742,7 @@ S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool not_implicit) {
 #else
                     (void)UNLINK(SvPVX(*back_psv));
                     if (link(orig_pv, SvPVX(*back_psv))) {
-                        if (!not_implicit) {
+                        if (!is_explict) {
                             Perl_croak(aTHX_ "Can't rename %s to %s: %s, skipping file",
                                        SvPVX(*orig_psv), SvPVX(*back_psv), Strerror(errno));
                         }
@@ -1771,7 +1771,7 @@ S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool not_implicit) {
                 PerlLIO_rename(SvPVX(*temp_psv), orig_pv) < 0
 #endif
                 ) {
-                if (!not_implicit) {
+                if (!is_explict) {
 #ifdef ARGV_USE_ATFUNCTIONS
                     if (unlinkat(dfd, SvPVX_const(*temp_psv), 0) < 0 &&
                         NotSupported(errno))
@@ -1800,7 +1800,7 @@ S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool not_implicit) {
 #else
             UNLINK(SvPVX_const(*temp_psv));
 #endif
-            if (!not_implicit) {
+            if (!is_explict) {
                 Perl_croak(aTHX_ "Failed to close in-place work file %s: %s",
                            SvPVX(*temp_psv), Strerror(errno));
             }
@@ -1813,7 +1813,7 @@ S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool not_implicit) {
 
 /* explicit renamed to avoid C++ conflict    -- kja */
 bool
-Perl_do_close(pTHX_ GV *gv, bool not_implicit)
+Perl_do_close(pTHX_ GV *gv, bool is_explict)
 {
     bool retval;
     IO *io;
@@ -1822,13 +1822,13 @@ Perl_do_close(pTHX_ GV *gv, bool not_implicit)
     if (!gv)
         gv = PL_argvgv;
     if (!gv || !isGV_with_GP(gv)) {
-        if (not_implicit)
+        if (is_explict)
             SETERRNO(EBADF,SS_IVCHAN);
         return FALSE;
     }
     io = GvIO(gv);
     if (!io) {		/* never opened */
-        if (not_implicit) {
+        if (is_explict) {
             report_evil_fh(gv);
             SETERRNO(EBADF,SS_IVCHAN);
         }
@@ -1836,13 +1836,13 @@ Perl_do_close(pTHX_ GV *gv, bool not_implicit)
     }
     if ((mg = mg_findext((SV*)io, PERL_MAGIC_uvar, &argvout_vtbl))
         && mg->mg_obj) {
-        retval = argvout_final(mg, io, not_implicit);
+        retval = argvout_final(mg, io, is_explict);
         mg_freeext((SV*)io, PERL_MAGIC_uvar, &argvout_vtbl);
     }
     else {
-        retval = io_close(io, NULL, not_implicit, FALSE);
+        retval = io_close(io, NULL, is_explict, FALSE);
     }
-    if (not_implicit) {
+    if (is_explict) {
         IoLINES(io) = 0;
         IoPAGE(io) = 0;
         IoLINES_LEFT(io) = IoPAGE_LEN(io);
@@ -1852,7 +1852,7 @@ Perl_do_close(pTHX_ GV *gv, bool not_implicit)
 }
 
 bool
-Perl_io_close(pTHX_ IO *io, GV *gv, bool not_implicit, bool warn_on_fail)
+Perl_io_close(pTHX_ IO *io, GV *gv, bool is_explict, bool warn_on_fail)
 {
     bool retval = FALSE;
 
@@ -1871,7 +1871,7 @@ Perl_io_close(pTHX_ IO *io, GV *gv, bool not_implicit, bool warn_on_fail)
             */
             IoOFP(io) = IoIFP(io) = NULL;
             status = PerlProc_pclose(fh);
-            if (not_implicit) {
+            if (is_explict) {
                 STATUS_NATIVE_CHILD_SET(status);
                 retval = (STATUS_UNIX == 0);
             }
@@ -1916,7 +1916,7 @@ Perl_io_close(pTHX_ IO *io, GV *gv, bool not_implicit, bool warn_on_fail)
                                  SVfARG(get_sv("!",GV_ADD)));
         }
     }
-    else if (not_implicit) {
+    else if (is_explict) {
         SETERRNO(EBADF,SS_IVCHAN);
     }
 

--- a/embed.fnc
+++ b/embed.fnc
@@ -783,7 +783,7 @@ pMb	|bool|do_aexec	|NULLOK SV* really|NN SV** mark|NN SV** sp
 p	|bool|do_aexec5	|NULLOK SV* really|NN SV** mark|NN SV** sp|int fd|int do_report
 AbpD	|int	|do_binmode	|NN PerlIO *fp|int iotype|int mode
 : Used in pp.c
-Ap	|bool	|do_close	|NULLOK GV* gv|bool not_implicit
+Apd	|bool	|do_close	|NULLOK GV* gv|bool is_explicit
 : Defined in doio.c, used only in pp_sys.c
 p	|bool	|do_eof		|NN GV* gv
 
@@ -803,7 +803,7 @@ p	|bool|do_exec3	|NN const char *incmd|int fd|int do_report
 #endif
 #if defined(PERL_IN_DOIO_C)
 S	|void	|exec_failed	|NN const char *cmd|int fd|int do_report
-S	|bool	|argvout_final	|NN MAGIC *mg|NN IO *io|bool not_implicit
+S	|bool	|argvout_final	|NN MAGIC *mg|NN IO *io|bool is_explicit
 #endif
 #if defined(HAS_MSG) || defined(HAS_SEM) || defined(HAS_SHM)
 : Defined in doio.c, used only in pp_sys.c
@@ -1108,7 +1108,7 @@ Cp	|void	|init_tm	|NN struct tm *ptm
 AbMTpPRd|char*	|instr		|NN const char* big|NN const char* little
 : Used in sv.c
 p	|bool	|io_close	|NN IO* io|NULLOK GV *gv \
-				|bool not_implicit|bool warn_on_fail
+				|bool is_explicit|bool warn_on_fail
 : Used in perly.y
 pR	|OP*	|invert		|NULLOK OP* cmd
 pR	|OP*	|cmpchain_start	|I32 type|NULLOK OP* left \

--- a/proto.h
+++ b/proto.h
@@ -918,7 +918,7 @@ PERL_CALLCONV int	Perl_do_binmode(pTHX_ PerlIO *fp, int iotype, int mode)
 	assert(fp)
 #endif
 
-PERL_CALLCONV bool	Perl_do_close(pTHX_ GV* gv, bool not_implicit);
+PERL_CALLCONV bool	Perl_do_close(pTHX_ GV* gv, bool is_explicit);
 #define PERL_ARGS_ASSERT_DO_CLOSE
 PERL_CALLCONV void	Perl_do_dump_pad(pTHX_ I32 level, PerlIO *file, PADLIST *padlist, int full);
 #define PERL_ARGS_ASSERT_DO_DUMP_PAD	\
@@ -1646,7 +1646,7 @@ PERL_CALLCONV OP*	Perl_invert(pTHX_ OP* cmd)
 PERL_CALLCONV void	Perl_invmap_dump(pTHX_ SV* invlist, UV * map);
 #define PERL_ARGS_ASSERT_INVMAP_DUMP	\
 	assert(invlist); assert(map)
-PERL_CALLCONV bool	Perl_io_close(pTHX_ IO* io, GV *gv, bool not_implicit, bool warn_on_fail);
+PERL_CALLCONV bool	Perl_io_close(pTHX_ IO* io, GV *gv, bool is_explicit, bool warn_on_fail);
 #define PERL_ARGS_ASSERT_IO_CLOSE	\
 	assert(io)
 #ifndef PERL_NO_INLINE_FUNCTIONS
@@ -5056,7 +5056,7 @@ STATIC void	S_deb_stack_n(pTHX_ SV** stack_base, I32 stack_min, I32 stack_max, I
 	assert(stack_base)
 #endif
 #if defined(PERL_IN_DOIO_C)
-STATIC bool	S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool not_implicit);
+STATIC bool	S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explicit);
 #define PERL_ARGS_ASSERT_ARGVOUT_FINAL	\
 	assert(mg); assert(io)
 STATIC void	S_exec_failed(pTHX_ const char *cmd, int fd, int do_report);


### PR DESCRIPTION
This was named 'not_implicit' instead of 'explicit' because the latter
is a C++ keyword.

But a negative name increases the cognitive load of understanding, and
in this case resulted in some double negatives, which is worse.

'is_explicit' isn't a keyword and is a clearer name for this concept.