### PR TITLE
Some cleanups for encoding-warnings

### DIFF
--- a/dist/encoding-warnings/lib/encoding/warnings.pm
+++ b/dist/encoding-warnings/lib/encoding/warnings.pm
@@ -1,5 +1,5 @@
 package encoding::warnings;
-$encoding::warnings::VERSION = '0.13';
+$encoding::warnings::VERSION = '0.14';
 
 use strict;
 use 5.007;

--- a/dist/encoding-warnings/lib/encoding/warnings.pm
+++ b/dist/encoding-warnings/lib/encoding/warnings.pm
@@ -32,7 +32,7 @@ thereafter.
     use encoding::warnings; # or 'FATAL' to raise fatal exceptions
 
     utf8::encode($a = chr(20000));  # a byte-string (raw bytes)
-    $b = chr(20000);		    # a unicode-string (wide characters)
+    $b = chr(20000);                # a unicode-string (wide characters)
 
     # "Bytes implicitly upgraded into wide characters as iso-8859-1"
     $c = $a . $b;
@@ -133,9 +133,9 @@ some people:
     use encoding 'big5';
 
     my $byte_string = pack("C*", 0xA4, 0x40);
-    print length $a;	# 2 here.
-    $a .= "";		# concatenating with a unicode string...
-    print length $a;	# 1 here!
+    print length $a;    # 2 here.
+    $a .= "";           # concatenating with a unicode string...
+    print length $a;    # 1 here!
 
 In other words, do not C<use encoding> unless you are certain that the
 program will not deal with any raw, 8-bit binary data at all.
@@ -162,11 +162,11 @@ sub FATAL  () { 2 }
 
 sub import {
     if ($] >= 5.025003) {
-	require Carp;
-	Carp::cluck(
-	    "encoding::warnings is not supported on Perl 5.26.0 and later"
-	);
-	return;
+        require Carp;
+        Carp::cluck(
+            "encoding::warnings is not supported on Perl 5.26.0 and later"
+        );
+        return;
     }
 
     # Install a ${^ENCODING} handler if no other one are already in place.
@@ -185,11 +185,11 @@ sub import {
 
     # Install a warning handler for decode()
     my $decoder = bless(
-	[
-	    $ascii,
-	    $latin1,
-	    (($fatal eq 'FATAL') ? 'Carp::croak' : 'Carp::carp'),
-	], $class,
+        [
+            $ascii,
+            $latin1,
+            (($fatal eq 'FATAL') ? 'Carp::croak' : 'Carp::carp'),
+        ], $class,
     );
 
     no warnings 'deprecated';

--- a/dist/encoding-warnings/t/1-warning.t
+++ b/dist/encoding-warnings/t/1-warning.t
@@ -4,12 +4,12 @@
 
 BEGIN {
     if (ord("A") != 65) {
-      print "1..0 # Skip: Encode not working on EBCDIC\n";
-      exit 0;
+        print "1..0 # Skip: Encode not working on EBCDIC\n";
+        exit 0;
     }
     unless (eval { require Encode } ) {
-	print "1..0 # Skip: no Encode\n";
-	exit 0;
+        print "1..0 # Skip: no Encode\n";
+        exit 0;
     }
 }
 
@@ -18,16 +18,16 @@ use strict;
 
 BEGIN {
     if ("$]" >= 5.025) {
-	# Test the new almost-noop behaviour in new perls.
-	plan tests => 3;
-	my $w;
-	$SIG{__WARN__} = sub { $w .= shift };
-	require encoding::warnings;
-	ok $w, undef, 'no warning from requiring encoding::warnings';
-	ok(encoding::warnings->VERSION);
-	encoding::warnings->import;
-	ok $w, qr/^encoding::warnings is not supported /, 'import warning';
-	exit;
+        # Test the new almost-noop behaviour in new perls.
+        plan tests => 3;
+        my $w;
+        $SIG{__WARN__} = sub { $w .= shift };
+        require encoding::warnings;
+        ok $w, undef, 'no warning from requiring encoding::warnings';
+        ok(encoding::warnings->VERSION);
+        encoding::warnings->import;
+        ok $w, qr/^encoding::warnings is not supported /, 'import warning';
+        exit;
     }
     # else continue with your usual scheduled testing...
     plan tests => 2;

--- a/dist/encoding-warnings/t/1-warning.t
+++ b/dist/encoding-warnings/t/1-warning.t
@@ -13,8 +13,9 @@ BEGIN {
     }
 }
 
-use Test;
 use strict;
+use warnings;
+use Test::More;
 
 BEGIN {
     if ("$]" >= 5.025) {
@@ -23,10 +24,10 @@ BEGIN {
         my $w;
         $SIG{__WARN__} = sub { $w .= shift };
         require encoding::warnings;
-        ok $w, undef, 'no warning from requiring encoding::warnings';
+        is $w, undef, 'no warning from requiring encoding::warnings';
         ok(encoding::warnings->VERSION);
         encoding::warnings->import;
-        ok $w, qr/^encoding::warnings is not supported /, 'import warning';
+        like $w, qr/^encoding::warnings is not supported /, 'import warning';
         exit;
     }
     # else continue with your usual scheduled testing...

--- a/dist/encoding-warnings/t/2-fatal.t
+++ b/dist/encoding-warnings/t/2-fatal.t
@@ -4,16 +4,16 @@
 
 BEGIN {
     if ("$]" >= 5.025) {
-      print "1..0 # Skip: encoding::warnings not supported on perl 5.26\n";
-      exit 0;
+        print "1..0 # Skip: encoding::warnings not supported on perl 5.26\n";
+        exit 0;
     }
     if (ord("A") != 65) {
-      print "1..0 # Skip: Encode not working on EBCDIC\n";
-      exit 0;
+        print "1..0 # Skip: Encode not working on EBCDIC\n";
+        exit 0;
     }
     unless (eval { require Encode } ) {
-	print "1..0 # Skip: no Encode\n";
-	exit 0;
+        print "1..0 # Skip: no Encode\n";
+        exit 0;
     }
 }
 

--- a/dist/encoding-warnings/t/2-fatal.t
+++ b/dist/encoding-warnings/t/2-fatal.t
@@ -17,10 +17,10 @@ BEGIN {
     }
 }
 
-use Test;
-BEGIN { plan tests => 2 }
+use Test::More tests => 2;
 
 use strict;
+use warnings;
 use encoding::warnings 'FATAL';
 ok(encoding::warnings->VERSION);
 

--- a/dist/encoding-warnings/t/3-normal.t
+++ b/dist/encoding-warnings/t/3-normal.t
@@ -1,7 +1,7 @@
 BEGIN {
     if ("$]" >= 5.025) {
-      print "1..0 # Skip: encoding::warnings not supported on perl 5.26\n";
-      exit 0;
+        print "1..0 # Skip: encoding::warnings not supported on perl 5.26\n";
+        exit 0;
     }
 }
 

--- a/dist/encoding-warnings/t/3-normal.t
+++ b/dist/encoding-warnings/t/3-normal.t
@@ -5,10 +5,10 @@ BEGIN {
     }
 }
 
-use Test;
-BEGIN { plan tests => 2 }
+use Test::More tests => 2;
 
 use strict;
+use warnings;
 use encoding::warnings 'FATAL';
 ok(encoding::warnings->VERSION);
 

--- a/dist/encoding-warnings/t/4-lexical.t
+++ b/dist/encoding-warnings/t/4-lexical.t
@@ -1,5 +1,5 @@
 use strict;
-use Test;
+use warnings;
 BEGIN {
     if ("$]" >= 5.025) {
         print "1..0 # Skip: encoding::warnings not supported on perl 5.26\n";
@@ -15,8 +15,9 @@ BEGIN {
         exit 0;
     }
 
-    plan tests => 3;
 }
+
+use Test::More tests => 3;
 
 {
     use encoding::warnings;

--- a/dist/encoding-warnings/t/4-lexical.t
+++ b/dist/encoding-warnings/t/4-lexical.t
@@ -2,17 +2,17 @@ use strict;
 use Test;
 BEGIN {
     if ("$]" >= 5.025) {
-      print "1..0 # Skip: encoding::warnings not supported on perl 5.26\n";
-      exit 0;
+        print "1..0 # Skip: encoding::warnings not supported on perl 5.26\n";
+        exit 0;
     }
     if (ord("A") != 65) {
-      print "1..0 # Skip: Encode not working on EBCDIC\n";
-      exit 0;
+        print "1..0 # Skip: Encode not working on EBCDIC\n";
+        exit 0;
     }
     use Config;
     if ($Config::Config{'extensions'} !~ /\bEncode\b/) {
-      print "1..0 # Skip: Encode was not built\n";
-      exit 0;
+        print "1..0 # Skip: Encode was not built\n";
+        exit 0;
     }
 
     plan tests => 3;


### PR DESCRIPTION
Although the module no longer functions, as long as it is included in core it is worth keeping clean and modernizing. Normalize the whitespace to be 4 space indents everywhere, and convert the tests to use Test::More.