### PR TITLE
Loosen regex in tests which validate process name.

### DIFF
--- a/t/op/magic.t
+++ b/t/op/magic.t
@@ -476,13 +476,14 @@ EOP
     # A selection of kernels/distros tested:
     #
     #   4.18.0-348.20.1.el8_5.x86_64 (AlmaLinux 8.5): NUL then spaces
+    #   4.18.0-348.23.1.el8_5.x86_64 (AlmaLinux 8.5): NUL, spaces, then NUL
     #   3.10.0-1160.62.1.el7.x86_64 (CentOS 7.9.2009): no NUL nor spaces
     #   2.6.32-954.3.5.lve1.4.87.el6.x86_64 (CloudLinux 6.10): ^^ ditto
     #
     #   5.13.0-1025-raspi (Ubuntu 21.10): NUL only
     #   5.10.103-v7+ (RaspiOS 10): NUL only
     #
-    $got=~s/\0\s*\z//;
+    $got =~ s/\0[\s\0]*\z//;
 
     return $got;
   };


### PR DESCRIPTION
This addresses some kernel inconsistencies on how the
process name can be represented in the /proc file. This
specifically addresses a failure on AlmaLinux 8.