### PR TITLE
perlapi: Consolidate all the sv_catpv* entries into one

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -354,20 +354,12 @@ a string/length pair.
 Like C<newSVpvn_share>, but takes a literal string instead of
 a string/length pair and omits the hash parameter.
 
-=for apidoc Am|void|sv_catpvs_flags|SV* sv|"literal string"|I32 flags
-Like C<sv_catpvn_flags>, but takes a literal string instead
-of a string/length pair.
-
-=for apidoc Am|void|sv_catpvs_nomg|SV* sv|"literal string"
-Like C<sv_catpvn_nomg>, but takes a literal string instead of
-a string/length pair.
-
-=for apidoc Am|void|sv_catpvs|SV* sv|"literal string"
-Like C<sv_catpvn>, but takes a literal string instead of a
+=for apidoc Am|void|sv_setpvs|SV* sv|"literal string"
+Like C<sv_setpvn>, but takes a literal string instead of a
 string/length pair.
 
-=for apidoc Am|void|sv_catpvs_mg|SV* sv|"literal string"
-Like C<sv_catpvn_mg>, but takes a literal string instead of a
+=for apidoc Am|void|sv_setpvs_mg|SV* sv|"literal string"
+Like C<sv_setpvn_mg>, but takes a literal string instead of a
 string/length pair.
 
 =for apidoc Am|SV *|sv_setref_pvs|SV *const rv|const char *const classname|"literal string"

--- a/sv.c
+++ b/sv.c
@@ -5374,35 +5374,53 @@ Perl_sv_chop(pTHX_ SV *const sv, const char *const ptr)
 }
 
 /*
-=for apidoc sv_catpvn
-=for apidoc_item sv_catpvn_flags
-=for apidoc_item sv_catpvn_mg
-=for apidoc_item sv_catpvn_nomg
+=for apidoc           sv_catpv
+=for apidoc_item      sv_catpv_flags
+=for apidoc_item      sv_catpv_mg
+=for apidoc_item      sv_catpv_nomg
+=for apidoc_item      sv_catpvn
+=for apidoc_item      sv_catpvn_flags
+=for apidoc_item      sv_catpvn_mg
+=for apidoc_item      sv_catpvn_nomg
+=for apidoc_item|void|sv_catpvn_nomg_maybeutf8|SV *const dsv|const char *sstr|const STRLEN slen|const bool is_utf8
+=for apidoc_item|void|sv_catpvs      |SV* dsv|"literal string"
+=for apidoc_item|void|sv_catpvs_flags|SV* dsv|"literal string"|I32 flags
+=for apidoc_item|void|sv_catpvs_nomg |SV* dsv|"literal string"
+=for apidoc_item|void|sv_catpvs_mg   |SV* dsv|"literal string"
 
-These concatenate the C<len> bytes of the string beginning at C<ptr> onto the
-end of the string which is in C<dsv>.  The caller must make sure C<ptr>
-contains at least C<len> bytes.
+These each concatenate a string onto the end of the string which is in C<dsv>.
+They differ in how the catenated string is specified and in the handling of
+magic and UTF-8ness.
 
-For all but C<sv_catpvn_flags>, the string appended is assumed to be valid
-UTF-8 if the SV has the UTF-8 status set, and a string of bytes otherwise.
+In the plain C<pv> forms, the source string is a C language NUL-terminated
+string.
+In the C<pvs> forms, the source string is a C language string literal, enclosed
+in double quotes.
+In the C<pvn> forms, C<sstr> points to the first byte of the string to
+concatenate, and an additional parameter, C<len>, specifies the number of
+bytes to copy.  Hence, C<sstr> may contain embedded-NUL characters.
 
-They differ in that:
+The C<_mg> forms perform both 'get' and 'set' magic on C<dsv>.
 
-C<sv_catpvn_mg> performs both 'get' and 'set' magic on C<dsv>.
+The C<_nomg> forms skip all magic.
 
-C<sv_catpvn> performs only 'get' magic.
+The C<_flags> forms have an extra C<flags> parameter which allows you to
+specify any combination of magic handling (using C<SV_GMAGIC> and/or
+C<SV_SMAGIC>).
 
-C<sv_catpvn_nomg> skips all magic.
+The other forms perform only 'get' magic.
 
-C<sv_catpvn_flags> has an extra C<flags> parameter which allows you to specify
-any combination of magic handling (using C<SV_GMAGIC> and/or C<SV_SMAGIC>) and
-to also override the UTF-8 handling.  By supplying the C<SV_CATBYTES> flag, the
-appended string is interpreted as plain bytes; by supplying instead the
-C<SV_CATUTF8> flag, it will be interpreted as UTF-8, and the C<dsv> will be
-upgraded to UTF-8 if necessary.
+C<sv_catpvn_nomg_maybeutf8> has an extra boolean parameter, C<is_utf8>, which
+if C<true> indicates that C<sstr> is encoded in UTF-8; otherwise not.
 
-C<sv_catpvn>, C<sv_catpvn_mg>, and C<sv_catpvn_nomg> are implemented
-in terms of C<sv_catpvn_flags>.
+The C<_flags> forms C<flags> parameter allows you to also override the UTF-8
+handling.  By supplying the C<SV_CATBYTES> flag, the appended string is
+interpreted as plain bytes; by supplying instead the C<SV_CATUTF8> flag, it
+will be interpreted as UTF-8, and the C<dsv> will be upgraded to UTF-8 if
+necessary.
+
+For all other forms, the string appended is assumed to be valid UTF-8
+if and only if the C<dsv> has the UTF-8 status set.
 
 =for apidoc Amnh||SV_CATUTF8
 =for apidoc Amnh||SV_CATBYTES
@@ -5500,35 +5518,6 @@ Perl_sv_catsv_flags(pTHX_ SV *const dsv, SV *const sstr, const I32 flags)
                 SvSETMAGIC(dsv);
     }
 }
-
-/*
-=for apidoc sv_catpv
-=for apidoc_item sv_catpv_flags
-=for apidoc_item sv_catpv_mg
-=for apidoc_item sv_catpv_nomg
-
-These concatenate the C<NUL>-terminated string C<sstr> onto the end of the
-string which is in the SV.
-If the SV has the UTF-8 status set, then the bytes appended should be
-valid UTF-8.
-
-They differ only in how they handle magic:
-
-C<sv_catpv_mg> performs both 'get' and 'set' magic.
-
-C<sv_catpv> performs only 'get' magic.
-
-C<sv_catpv_nomg> skips all magic.
-
-C<sv_catpv_flags> has an extra C<flags> parameter which allows you to specify
-any combination of magic handling (using C<SV_GMAGIC> and/or C<SV_SMAGIC>), and
-to also override the UTF-8 handling.  By supplying the C<SV_CATUTF8> flag, the
-appended string is forced to be interpreted as UTF-8; by supplying instead the
-C<SV_CATBYTES> flag, it will be interpreted as just bytes.  Either the SV or
-the string appended will be upgraded to UTF-8 if necessary.
-
-=cut
-*/
 
 void
 Perl_sv_catpv(pTHX_ SV *const dsv, const char *sstr)


### PR DESCRIPTION
I decided not to document sv_catpvn_nomg_utf8_upgrade(), as it is
extremely specialized