### PR TITLE
perlapi: Mark hv_free_ent as internal

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1039,7 +1039,7 @@ Cp	|void*	|hv_common_key_len|NULLOK HV *hv|NN const char *key \
 				|I32 klen_i32|const int action|NULLOK SV *val \
 				|const U32 hash
 Cpod	|STRLEN	|hv_fill	|NN HV *const hv
-Ap	|void	|hv_free_ent	|NULLOK HV *notused|NULLOK HE *entry
+Cp	|void	|hv_free_ent	|NULLOK HV *notused|NULLOK HE *entry
 Apd	|I32	|hv_iterinit	|NN HV *hv
 ApdR	|char*	|hv_iterkey	|NN HE* entry|NN I32* retlen
 ApdR	|SV*	|hv_iterkeysv	|NN HE* entry


### PR DESCRIPTION
There are no CPAN uses of this, and looking at the code and how it is
used, it appears to be a helper function for various operations.