### PR TITLE
perldiag: drop documentation of extinct warning

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2391,20 +2391,6 @@ which can't encode values above 63.  So there is no point in asking for
 a line length bigger than that.  Perl will behave as if you specified
 C<u63> as the format.
 
-=item File::Glob::glob() will disappear in perl 5.30. Use File::Glob::bsd_glob() instead.
-
-(D deprecated) C<< File::Glob >> has a function called C<< glob >>, which
-just calls C<< bsd_glob >>. However, its prototype is different from the
-prototype of C<< CORE::glob >>, and hence, C<< File::Glob::glob >> should
-not be used.
-
-C<< File::Glob::glob() >> was deprecated in perl 5.8.0. A deprecation
-message was issued from perl 5.26.0 onwards, and the function will
-disappear in perl 5.30.0.
-
-Code using C<< File::Glob::glob() >> should call
-C<< File::Glob::bsd_glob() >> instead.
-
 =item Filehandle %s opened only for input
 
 (W io) You tried to write on a read-only filehandle.  If you intended


### PR DESCRIPTION
We had a "will be removed in 5.30" warning still documented.  The new release is 5.36.  This warning is long gone.