### PR TITLE
perl5360delta - pod syntax fix

### DIFF
--- a/pod/perl5360delta.pod
+++ b/pod/perl5360delta.pod
@@ -1050,7 +1050,7 @@ that are strict in rejecting certain C99 features, particularly mixed
 declarations and code, and hence it makes sense for XS module authors to audit
 that their code does not violate this. However, doing this is now only
 possible on these earlier versions of Perl, hence these modules need to be
-changed to only add this flag for C<<$] < 5.035005>>.
+changed to only add this flag for C<< $] < 5.035005 >>.
 
 =item *
 


### PR DESCRIPTION
whitespace must surround the contents of a `C<< >>` tag.