### PR TITLE
perlapi: Deprecate 5 functions

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -747,13 +747,11 @@ AdiMTp	|I32 *	|CvDEPTH	|NN const CV * const sv
 Aphd	|SV*	|filter_add	|NULLOK filter_t funcp|NULLOK SV* datasv
 Apd	|void	|filter_del	|NN filter_t funcp
 ApRhd	|I32	|filter_read	|int idx|NN SV *buf_sv|int maxlen
-ApPRx	|char**	|get_op_descs
-ApPRx	|char**	|get_op_names
-: FIXME discussion on p5p
-pPR	|const char*	|get_no_modify
-: FIXME discussion on p5p
-pPRx	|U32*	|get_opargs
-CpPRx	|PPADDR_t*|get_ppaddr
+ApdPRD	|char**	|get_op_descs
+ApdPRD	|char**	|get_op_names
+pPRD	|const char*	|get_no_modify
+pPRD	|U32*	|get_opargs
+CpPRD	|PPADDR_t*|get_ppaddr
 : Used by CXINC, which appears to be in widespread use
 CpR	|I32	|cxinc
 Afpd	|void	|deb		|NN const char* pat|...

--- a/proto.h
+++ b/proto.h
@@ -1213,26 +1213,31 @@ PERL_CALLCONV HV*	Perl_get_hv(pTHX_ const char *name, I32 flags);
 #define PERL_ARGS_ASSERT_GET_HV	\
 	assert(name)
 PERL_CALLCONV const char*	Perl_get_no_modify(pTHX)
+			__attribute__deprecated__
 			__attribute__warn_unused_result__
 			__attribute__pure__;
 #define PERL_ARGS_ASSERT_GET_NO_MODIFY
 
 PERL_CALLCONV char**	Perl_get_op_descs(pTHX)
+			__attribute__deprecated__
 			__attribute__warn_unused_result__
 			__attribute__pure__;
 #define PERL_ARGS_ASSERT_GET_OP_DESCS
 
 PERL_CALLCONV char**	Perl_get_op_names(pTHX)
+			__attribute__deprecated__
 			__attribute__warn_unused_result__
 			__attribute__pure__;
 #define PERL_ARGS_ASSERT_GET_OP_NAMES
 
 PERL_CALLCONV U32*	Perl_get_opargs(pTHX)
+			__attribute__deprecated__
 			__attribute__warn_unused_result__
 			__attribute__pure__;
 #define PERL_ARGS_ASSERT_GET_OPARGS
 
 PERL_CALLCONV PPADDR_t*	Perl_get_ppaddr(pTHX)
+			__attribute__deprecated__
 			__attribute__warn_unused_result__
 			__attribute__pure__;
 #define PERL_ARGS_ASSERT_GET_PPADDR

--- a/util.c
+++ b/util.c
@@ -3869,12 +3869,32 @@ Perl_set_context(void *t)
 
 #endif /* !PERL_GET_CONTEXT_DEFINED */
 
+/*
+=for apidoc get_op_names
+
+Return a pointer to the array of all the names of the various OPs
+Given an opcode from the enum in F<opcodes.h>, C<PL_op_name[opcode]> returns a
+pointer to a C language string giving its name.
+
+=cut
+*/
+
 char **
 Perl_get_op_names(pTHX)
 {
     PERL_UNUSED_CONTEXT;
     return (char **)PL_op_name;
 }
+
+/*
+=for apidoc get_op_descs
+
+Return a pointer to the array of all the descriptions of the various OPs
+Given an opcode from the enum in F<opcodes.h>, C<PL_op_desc[opcode]> returns a
+pointer to a C language string giving its description.
+
+=cut
+*/
 
 char **
 Perl_get_op_descs(pTHX)


### PR DESCRIPTION
and document two of them, which I had done before I realized they were
to be deprecated.

These functions are obsolete, and stemmed from a long-solved problem in
Windows.  There are a couple of uses on cpan of a couple of them.  But
people should just use PL_opnames[], for example, instead of the
function here that returns the address of that array.