### PR TITLE
Remove deprecated functions

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -720,8 +720,6 @@ AdfTp	|void	|sv_catpvf_nocontext|NN SV *const sv|NN const char *const pat|...
 AdfTp	|void	|sv_setpvf_nocontext|NN SV *const sv|NN const char *const pat|...
 AdfTp	|void	|sv_catpvf_mg_nocontext|NN SV *const sv|NN const char *const pat|...
 AdfTp	|void	|sv_setpvf_mg_nocontext|NN SV *const sv|NN const char *const pat|...
-AbfTpD	|int	|fprintf_nocontext|NN PerlIO *stream|NN const char *format|...
-AbfTpD	|int	|printf_nocontext|NN const char *format|...
 #endif
 : Used in pp.c
 pd	|SV *	|core_prototype	|NULLOK SV *sv|NN const char *name \
@@ -783,7 +781,6 @@ Cpdh	|void	|dounwind	|I32 cxix
 pMb	|bool|do_aexec	|NULLOK SV* really|NN SV** mark|NN SV** sp
 : Used in pp_sys.c
 p	|bool|do_aexec5	|NULLOK SV* really|NN SV** mark|NN SV** sp|int fd|int do_report
-AbpD	|int	|do_binmode	|NN PerlIO *fp|int iotype|int mode
 : Used in pp.c
 Apd	|bool	|do_close	|NULLOK GV* gv|bool is_explicit
 : Defined in doio.c, used only in pp_sys.c
@@ -828,9 +825,6 @@ Apd	|void	|do_join	|NN SV *sv|NN SV *delim|NN SV **mark|NN SV **sp
 pR	|I32	|do_ncmp	|NN SV *const left|NN SV *const right
 ApMb	|bool	|do_open	|NN GV* gv|NN const char* name|I32 len|int as_raw \
 				|int rawmode|int rawperm|NULLOK PerlIO* supplied_fp
-AbpD	|bool	|do_open9	|NN GV *gv|NN const char *name|I32 len|int as_raw \
-				|int rawmode|int rawperm|NULLOK PerlIO *supplied_fp \
-				|NN SV *svs|I32 num
 pT	|void	|setfd_cloexec|int fd
 pT	|void	|setfd_inhexec|int fd
 p	|void	|setfd_cloexec_for_nonsysfd|int fd
@@ -958,7 +952,6 @@ ApR	|GV*	|gv_autoload_pv	|NULLOK HV* stash|NN const char* namepv \
 ApR	|GV*	|gv_autoload_pvn	|NULLOK HV* stash|NN const char* name \
                                         |STRLEN len|U32 flags
 Cp	|void	|gv_check	|NN HV* stash
-AbpD	|void	|gv_efullname	|NN SV* sv|NN const GV* gv
 ApdMb	|void	|gv_efullname3	|NN SV* sv|NN const GV* gv|NULLOK const char* prefix
 Apd	|void	|gv_efullname4	|NN SV* sv|NN const GV* gv|NULLOK const char* prefix|bool keepmain
 Adp	|GV*	|gv_fetchfile	|NN const char* name
@@ -988,7 +981,6 @@ Apx	|GV*	|gv_fetchmethod_pv_flags|NN HV* stash|NN const char* name \
 Apx	|GV*	|gv_fetchmethod_pvn_flags|NN HV* stash|NN const char* name \
 				|const STRLEN len|U32 flags
 Adp	|GV*	|gv_fetchpv	|NN const char *nambeg|I32 flags|const svtype sv_type
-AbpD	|void	|gv_fullname	|NN SV* sv|NN const GV* gv
 ApdMb	|void	|gv_fullname3	|NN SV* sv|NN const GV* gv|NULLOK const char* prefix
 Apd	|void	|gv_fullname4	|NN SV* sv|NN const GV* gv|NULLOK const char* prefix|bool keepmain
 : Used in scope.c
@@ -1165,7 +1157,6 @@ AmTdRP	|bool	|is_invariant_string|NN const U8* const s|STRLEN len
 EXTidRp	|bool	|is_utf8_non_invariant_string|NN const U8* const s	    \
 		|STRLEN len
 #endif
-AbTpdD	|STRLEN	|is_utf8_char	|NN const U8 *s
 AbMTpd	|STRLEN	|is_utf8_char_buf|NN const U8 *buf|NN const U8 *buf_end
 ATidRp	|Size_t	|isUTF8_CHAR|NN const U8 * const s0			    \
 			    |NN const U8 * const e
@@ -1365,7 +1356,6 @@ Cp	|I32 *	|markstack_grow
 #if defined(USE_LOCALE_COLLATE)
 p	|int	|magic_setcollxfrm|NN SV* sv|NN MAGIC* mg
 p	|int	|magic_freecollxfrm|NN SV* sv|NN MAGIC* mg
-pbD	|char*	|mem_collxfrm	|NN const char* input_string|STRLEN len|NN STRLEN* xlen
 : Defined in locale.c, used only in sv.c
 #   if defined(PERL_IN_LOCALE_C) || defined(PERL_IN_SV_C) || defined(PERL_IN_MATHOMS_C)
 p	|char*	|_mem_collxfrm	|NN const char* input_string	\
@@ -1396,7 +1386,6 @@ Apd	|int	|mg_free	|NN SV* sv
 Apd	|void	|mg_free_type	|NN SV* sv|int how
 Apd	|void	|mg_freeext	|NN SV* sv|int how|NULLOK const MGVTBL *vtbl
 Apd	|int	|mg_get		|NN SV* sv
-ApdD	|U32	|mg_length	|NN SV* sv
 ApdT	|void	|mg_magical	|NN SV* sv
 Apd	|int	|mg_set		|NN SV* sv
 Cp	|I32	|mg_size	|NN SV* sv
@@ -1438,8 +1427,6 @@ pX	|I32	|my_stat_flags	|NULLOK const U32 flags
 Adfp	|char *	|my_strftime	|NN const char *fmt|int sec|int min|int hour|int mday|int mon|int year|int wday|int yday|int isdst
 : Used in pp_ctl.c
 p	|void	|my_unexec
-CbDTPR	|UV	|NATIVE_TO_NEED	|const UV enc|const UV ch
-CbDTPR	|UV	|ASCII_TO_NEED	|const UV enc|const UV ch
 ApR	|OP*	|newANONLIST	|NULLOK OP* o
 ApR	|OP*	|newANONHASH	|NULLOK OP* o
 Ap	|OP*	|newANONSUB	|I32 floor|NULLOK OP* proto|NULLOK OP* block
@@ -1624,7 +1611,6 @@ ATdo	|const char*|Perl_langinfo|const nl_item item
 ATdo	|const char*|Perl_langinfo|const int item
 #endif
 CpO	|int	|init_i18nl10n	|int printwarn
-CbpOD	|int	|init_i18nl14n	|int printwarn
 p	|char*	|my_strerror	|const int errnum
 XpT	|void	|_warn_problematic_locale
 Xp	|void	|set_numeric_underlying
@@ -1635,8 +1621,6 @@ ApdT	|bool	|sync_locale
 ApxT	|void	|thread_locale_init
 ApxT	|void	|thread_locale_term
 ApdO	|void	|require_pv	|NN const char* pv
-AbpdD	|void	|pack_cat	|NN SV *cat|NN const char *pat|NN const char *patend \
-				|NN SV **beglist|NN SV **endlist|NN SV ***next_in_list|U32 flags
 Apd	|void	|packlist	|NN SV *cat|NN const char *pat|NN const char *patend|NN SV **beglist|NN SV **endlist
 #if defined(PERL_USES_PL_PIDSTATUS) && defined(PERL_IN_UTIL_C)
 S	|void	|pidgone	|Pid_t pid|int status
@@ -1719,10 +1703,7 @@ Cp	|void	|save_I8	|NN I8* bytep
 Cp	|void	|save_int	|NN int* intp
 Apdh	|void	|save_item	|NN SV* item
 Cp	|void	|save_iv	|NN IV *ivp
-AbpDdh	|void	|save_list	|NN SV** sarg|I32 maxsarg
-CbpD	|void	|save_long	|NN long* longp
 CpMb	|void	|save_mortalizesv|NN SV* sv
-AbpD	|void	|save_nogv	|NN GV* gv
 : Used in SAVEFREOP(), used in gv.c, op.c, perl.c, pp_ctl.c, pp_sort.c
 CpMbd	|void	|save_op
 Apdh	|SV*	|save_scalar	|NN GV* gv
@@ -1804,15 +1785,8 @@ ApdMb	|char*	|sv_2pvutf8	|NN SV *sv|NULLOK STRLEN *const lp
 Apd	|char*	|sv_2pvutf8_flags	|NN SV *sv|NULLOK STRLEN *const lp|const U32 flags
 ApdMb	|char*	|sv_2pvbyte	|NN SV *sv|NULLOK STRLEN *const lp
 Apd	|char*	|sv_2pvbyte_flags	|NN SV *sv|NULLOK STRLEN *const lp|const U32 flags
-AbpD	|char*	|sv_pvn_nomg	|NN SV* sv|NULLOK STRLEN* lp
 CpMb	|UV	|sv_2uv		|NN SV *sv
 Apd	|UV	|sv_2uv_flags	|NN SV *const sv|const I32 flags
-CbpdD	|IV	|sv_iv		|NN SV* sv
-CbpdD	|UV	|sv_uv		|NN SV* sv
-CbpdD	|NV	|sv_nv		|NN SV* sv
-CbpdD	|char*	|sv_pvn		|NN SV *sv|NN STRLEN *lp
-CbpdD	|char*	|sv_pvutf8n	|NN SV *sv|NN STRLEN *lp
-CbpdD	|char*	|sv_pvbyten	|NN SV *sv|NN STRLEN *lp
 Cpd	|I32	|sv_true	|NULLOK SV *const sv
 #if defined(PERL_IN_SV_C)
 Sd	|void	|sv_add_arena	|NN char *const ptr|const U32 size \
@@ -1924,7 +1898,6 @@ p	|void	|sv_resetpvn	|NULLOK const char* s|STRLEN len \
 Afpd	|void	|sv_setpvf	|NN SV *const sv|NN const char *const pat|...
 Apd	|void	|sv_vsetpvf	|NN SV *const sv|NN const char *const pat|NULLOK va_list *const args
 Apd	|void	|sv_setiv	|NN SV *const sv|const IV num
-ApdbD	|void	|sv_setpviv	|NN SV *const sv|const IV num
 Apd	|void	|sv_setuv	|NN SV *const sv|const UV num
 Apd	|void	|sv_setnv	|NN SV *const sv|const NV num
 Apd	|SV*	|sv_setref_iv	|NN SV *const rv|NULLOK const char *const classname|const IV iv
@@ -2564,9 +2537,6 @@ pT	|bool	|translate_substr_offsets|STRLEN curlen|IV pos1_iv \
 #if defined(UNLINK_ALL_VERSIONS)
 Cp	|I32	|unlnk		|NN const char* f
 #endif
-AbpdD	|SSize_t|unpack_str	|NN const char *pat|NN const char *patend|NN const char *s \
-				|NULLOK const char *strbeg|NN const char *strend|NULLOK char **new_s \
-				|I32 ocnt|U32 flags
 Apd	|SSize_t|unpackstring	|NN const char *pat|NN const char *patend|NN const char *s \
 				|NN const char *strend|U32 flags
 Cpd	|void	|unsharepvn	|NULLOK const char* sv|I32 len|U32 hash
@@ -2598,12 +2568,8 @@ CxTdp	|U8*	|bytes_from_utf8_loc|NN const U8 *s			    \
 				    |NN bool *is_utf8p			    \
 				    |NULLOK const U8 ** first_unconverted
 Apxd	|U8*	|bytes_to_utf8	|NN const U8 *s|NN STRLEN *lenp
-ApdDb	|UV	|utf8_to_uvchr	|NN const U8 *s|NULLOK STRLEN *retlen
-CbpdD	|UV	|utf8_to_uvuni	|NN const U8 *s|NULLOK STRLEN *retlen
-CbpD	|UV	|valid_utf8_to_uvuni	|NN const U8 *s|NULLOK STRLEN *retlen
 AMpd	|UV	|utf8_to_uvchr_buf	|NN const U8 *s|NN const U8 *send|NULLOK STRLEN *retlen
 Cip	|UV	|utf8_to_uvchr_buf_helper|NN const U8 *s|NN const U8 *send|NULLOK STRLEN *retlen
-CpdD	|UV	|utf8_to_uvuni_buf	|NN const U8 *s|NN const U8 *send|NULLOK STRLEN *retlen
 p	|bool	|check_utf8_print	|NN const U8 *s|const STRLEN len
 
 AdMTp	|UV	|utf8n_to_uvchr	|NN const U8 *s				    \
@@ -2629,7 +2595,6 @@ CTp	|UV	|_utf8n_to_uvchr_msgs_helper				    \
 				|NULLOK U32 * errors			    \
 				|NULLOK AV ** msgs
 CipTRd	|UV	|valid_utf8_to_uvchr	|NN const U8 *s|NULLOK STRLEN *retlen
-CdbDp	|UV	|utf8n_to_uvuni|NN const U8 *s|STRLEN curlen|NULLOK STRLEN *retlen|U32 flags
 
 Adm	|U8*	|uvchr_to_utf8	|NN U8 *d|UV uv
 Cp	|U8*	|uvuni_to_utf8	|NN U8 *d|UV uv
@@ -2637,7 +2602,6 @@ Adm	|U8*	|uvchr_to_utf8_flags	|NN U8 *d|UV uv|UV flags
 Adm	|U8*	|uvchr_to_utf8_flags_msgs|NN U8 *d|UV uv|UV flags|NULLOK HV ** msgs
 CMpd	|U8*	|uvoffuni_to_utf8_flags	|NN U8 *d|UV uv|UV flags
 Cp	|U8*	|uvoffuni_to_utf8_flags_msgs|NN U8 *d|UV input_uv|const UV flags|NULLOK HV** msgs
-CdpbD	|U8*	|uvuni_to_utf8_flags	|NN U8 *d|UV uv|UV flags
 Apd	|char*	|pv_uni_display	|NN SV *dsv|NN const U8 *spv|STRLEN len|STRLEN pvlim|UV flags
 ApdR	|char*	|sv_uni_display	|NN SV *dsv|NN SV *ssv|STRLEN pvlim|UV flags
 EXpR	|Size_t	|_inverse_folds	|const UV cp				    \
@@ -2735,7 +2699,6 @@ Afpd	|void	|sv_setpvf_mg	|NN SV *const sv|NN const char *const pat|...
 Apd	|void	|sv_vsetpvf_mg	|NN SV *const sv|NN const char *const pat \
 				|NULLOK va_list *const args
 Apd	|void	|sv_setiv_mg	|NN SV *const sv|const IV i
-ApdbD	|void	|sv_setpviv_mg	|NN SV *const sv|const IV iv
 Apd	|void	|sv_setuv_mg	|NN SV *const sv|const UV u
 Apd	|void	|sv_setnv_mg	|NN SV *const sv|const NV num
 Apd	|void	|sv_setpv_mg	|NN SV *const sv|NULLOK const char *const ptr
@@ -2856,8 +2819,6 @@ Cp	|void	|sys_intern_dup	|NN struct interp_intern* src|NN struct interp_intern* 
 : The reason for the 'u' flag is that this passes "aTHX_ x" to its callee: not
 : a legal C parameter
 Admu	|const XOP *	|Perl_custom_op_xop	|NN const OP *o
-AbpRdD	|const char *	|custom_op_name	|NN const OP *o
-AbpRdD	|const char *	|custom_op_desc	|NN const OP *o
 pRX	|XOPRETANY	|custom_op_get_field	|NN const OP *o|const xop_flags_enum field
 Adop	|void	|custom_op_register	|NN Perl_ppaddr_t ppaddr \
 			|NN const XOP *xop
@@ -3464,7 +3425,6 @@ Sd	|void	|pad_check_dup	|NN PADNAME *name|U32 flags \
 Apd	|PADOFFSET|pad_findmy_pvn|NN const char* namepv|STRLEN namelen|U32 flags
 Apd	|PADOFFSET|pad_findmy_pv|NN const char* name|U32 flags
 Apd	|PADOFFSET|pad_findmy_sv|NN SV* name|U32 flags
-ApdD	|PADOFFSET|find_rundefsvoffset	|
 Apd	|SV*	|find_rundefsv	|
 #if defined(PERL_IN_PAD_C)
 Sd	|PADOFFSET|pad_findlex	|NN const char *namepv|STRLEN namelen|U32 flags \
@@ -3498,7 +3458,6 @@ Apd	|CV*	|cv_clone	|NN CV* proto
 p	|CV*	|cv_clone_into	|NN CV* proto|NN CV *target
 pd	|void	|pad_fixup_inner_anons|NN PADLIST *padlist|NN CV *old_cv|NN CV *new_cv
 pdX	|void	|pad_push	|NN PADLIST *padlist|int depth
-ApbdDR	|HV*	|pad_compname_type|const PADOFFSET po
 AxpdRT	|PADNAME *|padnamelist_fetch|NN PADNAMELIST *pnl|SSize_t key
 Xop	|void	|padnamelist_free|NN PADNAMELIST *pnl
 Axpd	|PADNAME **|padnamelist_store|NN PADNAMELIST *pnl|SSize_t key \

--- a/embed.h
+++ b/embed.h
@@ -109,12 +109,6 @@
 #define croak_xs_usage		Perl_croak_xs_usage
 #define csighandler1		Perl_csighandler1
 #define csighandler3		Perl_csighandler3
-#ifndef NO_MATHOMS
-#define custom_op_desc(a)	Perl_custom_op_desc(aTHX_ a)
-#endif
-#ifndef NO_MATHOMS
-#define custom_op_name(a)	Perl_custom_op_name(aTHX_ a)
-#endif
 #define cv_clone(a)		Perl_cv_clone(aTHX_ a)
 #define cv_const_sv		Perl_cv_const_sv
 #define cv_get_call_checker(a,b,c)	Perl_cv_get_call_checker(aTHX_ a,b,c)
@@ -138,9 +132,6 @@
 #define die			Perl_die
 #endif
 #define die_sv(a)		Perl_die_sv(aTHX_ a)
-#ifndef NO_MATHOMS
-#define do_binmode(a,b,c)	Perl_do_binmode(aTHX_ a,b,c)
-#endif
 #define do_close(a,b)		Perl_do_close(aTHX_ a,b)
 #define do_gv_dump(a,b,c,d)	Perl_do_gv_dump(aTHX_ a,b,c,d)
 #define do_gvgv_dump(a,b,c,d)	Perl_do_gvgv_dump(aTHX_ a,b,c,d)
@@ -148,9 +139,6 @@
 #define do_join(a,b,c,d)	Perl_do_join(aTHX_ a,b,c,d)
 #define do_magic_dump(a,b,c,d,e,f,g)	Perl_do_magic_dump(aTHX_ a,b,c,d,e,f,g)
 #define do_op_dump(a,b,c)	Perl_do_op_dump(aTHX_ a,b,c)
-#ifndef NO_MATHOMS
-#define do_open9(a,b,c,d,e,f,g,h,i)	Perl_do_open9(aTHX_ a,b,c,d,e,f,g,h,i)
-#endif
 #define do_openn(a,b,c,d,e,f,g,h,i)	Perl_do_openn(aTHX_ a,b,c,d,e,f,g,h,i)
 #define do_pmop_dump(a,b,c)	Perl_do_pmop_dump(aTHX_ a,b,c)
 #define do_sprintf(a,b,c)	Perl_do_sprintf(aTHX_ a,b,c)
@@ -177,7 +165,6 @@
 #define filter_read(a,b,c)	Perl_filter_read(aTHX_ a,b,c)
 #define find_runcv(a)		Perl_find_runcv(aTHX_ a)
 #define find_rundefsv()		Perl_find_rundefsv(aTHX)
-#define find_rundefsvoffset()	Perl_find_rundefsvoffset(aTHX)
 #define foldEQ			Perl_foldEQ
 #define foldEQ_latin1		Perl_foldEQ_latin1
 #define foldEQ_locale		Perl_foldEQ_locale
@@ -212,9 +199,6 @@
 #define gv_check(a)		Perl_gv_check(aTHX_ a)
 #define gv_const_sv(a)		Perl_gv_const_sv(aTHX_ a)
 #define gv_dump(a)		Perl_gv_dump(aTHX_ a)
-#ifndef NO_MATHOMS
-#define gv_efullname(a,b)	Perl_gv_efullname(aTHX_ a,b)
-#endif
 #define gv_efullname4(a,b,c,d)	Perl_gv_efullname4(aTHX_ a,b,c,d)
 #define gv_fetchfile(a)		Perl_gv_fetchfile(aTHX_ a)
 #define gv_fetchfile_flags(a,b,c)	Perl_gv_fetchfile_flags(aTHX_ a,b,c)
@@ -231,9 +215,6 @@
 #define gv_fetchpv(a,b,c)	Perl_gv_fetchpv(aTHX_ a,b,c)
 #define gv_fetchpvn_flags(a,b,c,d)	Perl_gv_fetchpvn_flags(aTHX_ a,b,c,d)
 #define gv_fetchsv(a,b,c)	Perl_gv_fetchsv(aTHX_ a,b,c)
-#ifndef NO_MATHOMS
-#define gv_fullname(a,b)	Perl_gv_fullname(aTHX_ a,b)
-#endif
 #define gv_fullname4(a,b,c,d)	Perl_gv_fullname4(aTHX_ a,b,c,d)
 #define gv_handler(a,b)		Perl_gv_handler(aTHX_ a,b)
 #define gv_init_pv(a,b,c,d)	Perl_gv_init_pv(aTHX_ a,b,c,d)
@@ -262,9 +243,6 @@
 #define hv_rand_set(a,b)	Perl_hv_rand_set(aTHX_ a,b)
 #define hv_scalar(a)		Perl_hv_scalar(aTHX_ a)
 #define init_i18nl10n(a)	Perl_init_i18nl10n(aTHX_ a)
-#ifndef NO_MATHOMS
-#define init_i18nl14n(a)	Perl_init_i18nl14n(aTHX_ a)
-#endif
 #define init_stacks()		Perl_init_stacks(aTHX)
 #define init_tm(a)		Perl_init_tm(aTHX_ a)
 #define intro_my()		Perl_intro_my(aTHX)
@@ -277,9 +255,6 @@
 #define is_safe_syscall(a,b,c,d)	Perl_is_safe_syscall(aTHX_ a,b,c,d)
 #define is_strict_utf8_string_loclen	Perl_is_strict_utf8_string_loclen
 #define is_utf8_FF_helper_	Perl_is_utf8_FF_helper_
-#ifndef NO_MATHOMS
-#define is_utf8_char		Perl_is_utf8_char
-#endif
 #define is_utf8_char_helper_	Perl_is_utf8_char_helper_
 #define is_utf8_fixed_width_buf_loclen_flags	Perl_is_utf8_fixed_width_buf_loclen_flags
 #define is_utf8_invariant_string_loc	Perl_is_utf8_invariant_string_loc
@@ -322,7 +297,6 @@
 #define mg_free_type(a,b)	Perl_mg_free_type(aTHX_ a,b)
 #define mg_freeext(a,b,c)	Perl_mg_freeext(aTHX_ a,b,c)
 #define mg_get(a)		Perl_mg_get(aTHX_ a)
-#define mg_length(a)		Perl_mg_length(aTHX_ a)
 #define mg_magical		Perl_mg_magical
 #define mg_set(a)		Perl_mg_set(aTHX_ a)
 #define mg_size(a)		Perl_mg_size(aTHX_ a)
@@ -433,18 +407,12 @@
 #define op_scope(a)		Perl_op_scope(aTHX_ a)
 #define op_sibling_splice	Perl_op_sibling_splice
 #define op_wrap_finally(a,b)	Perl_op_wrap_finally(aTHX_ a,b)
-#ifndef NO_MATHOMS
-#define pack_cat(a,b,c,d,e,f,g)	Perl_pack_cat(aTHX_ a,b,c,d,e,f,g)
-#endif
 #define packlist(a,b,c,d,e)	Perl_packlist(aTHX_ a,b,c,d,e)
 #define pad_add_anon(a,b)	Perl_pad_add_anon(aTHX_ a,b)
 #define pad_add_name_pv(a,b,c,d)	Perl_pad_add_name_pv(aTHX_ a,b,c,d)
 #define pad_add_name_pvn(a,b,c,d,e)	Perl_pad_add_name_pvn(aTHX_ a,b,c,d,e)
 #define pad_add_name_sv(a,b,c,d)	Perl_pad_add_name_sv(aTHX_ a,b,c,d)
 #define pad_alloc(a,b)		Perl_pad_alloc(aTHX_ a,b)
-#ifndef NO_MATHOMS
-#define pad_compname_type(a)	Perl_pad_compname_type(aTHX_ a)
-#endif
 #define pad_findmy_pv(a,b)	Perl_pad_findmy_pv(aTHX_ a,b)
 #define pad_findmy_pvn(a,b,c)	Perl_pad_findmy_pvn(aTHX_ a,b,c)
 #define pad_findmy_sv(a,b)	Perl_pad_findmy_sv(aTHX_ a,b)
@@ -534,15 +502,6 @@
 #define save_int(a)		Perl_save_int(aTHX_ a)
 #define save_item(a)		Perl_save_item(aTHX_ a)
 #define save_iv(a)		Perl_save_iv(aTHX_ a)
-#ifndef NO_MATHOMS
-#define save_list(a,b)		Perl_save_list(aTHX_ a,b)
-#endif
-#ifndef NO_MATHOMS
-#define save_long(a)		Perl_save_long(aTHX_ a)
-#endif
-#ifndef NO_MATHOMS
-#define save_nogv(a)		Perl_save_nogv(aTHX_ a)
-#endif
 #define save_padsv_and_mortalize(a)	Perl_save_padsv_and_mortalize(aTHX_ a)
 #define save_pptr(a)		Perl_save_pptr(aTHX_ a)
 #define save_pushi32ptr(a,b,c)	Perl_save_pushi32ptr(aTHX_ a,b,c)
@@ -631,9 +590,6 @@
 #define sv_isa(a,b)		Perl_sv_isa(aTHX_ a,b)
 #define sv_isa_sv(a,b)		Perl_sv_isa_sv(aTHX_ a,b)
 #define sv_isobject(a)		Perl_sv_isobject(aTHX_ a)
-#ifndef NO_MATHOMS
-#define sv_iv(a)		Perl_sv_iv(aTHX_ a)
-#endif
 #define sv_len(a)		Perl_sv_len(aTHX_ a)
 #define sv_len_utf8(a)		Perl_sv_len_utf8(aTHX_ a)
 #define sv_len_utf8_nomg(a)	Perl_sv_len_utf8_nomg(aTHX_ a)
@@ -650,28 +606,13 @@
 #define sv_nounlocking(a)	Perl_sv_nounlocking(aTHX_ a)
 #endif
 #define sv_numeq_flags(a,b,c)	Perl_sv_numeq_flags(aTHX_ a,b,c)
-#ifndef NO_MATHOMS
-#define sv_nv(a)		Perl_sv_nv(aTHX_ a)
-#endif
 #define sv_peek(a)		Perl_sv_peek(aTHX_ a)
 #define sv_pos_b2u(a,b)		Perl_sv_pos_b2u(aTHX_ a,b)
 #define sv_pos_b2u_flags(a,b,c)	Perl_sv_pos_b2u_flags(aTHX_ a,b,c)
 #define sv_pos_u2b(a,b,c)	Perl_sv_pos_u2b(aTHX_ a,b,c)
 #define sv_pos_u2b_flags(a,b,c,d)	Perl_sv_pos_u2b_flags(aTHX_ a,b,c,d)
-#ifndef NO_MATHOMS
-#define sv_pvbyten(a,b)		Perl_sv_pvbyten(aTHX_ a,b)
-#endif
 #define sv_pvbyten_force(a,b)	Perl_sv_pvbyten_force(aTHX_ a,b)
-#ifndef NO_MATHOMS
-#define sv_pvn(a,b)		Perl_sv_pvn(aTHX_ a,b)
-#endif
 #define sv_pvn_force_flags(a,b,c)	Perl_sv_pvn_force_flags(aTHX_ a,b,c)
-#ifndef NO_MATHOMS
-#define sv_pvn_nomg(a,b)	Perl_sv_pvn_nomg(aTHX_ a,b)
-#endif
-#ifndef NO_MATHOMS
-#define sv_pvutf8n(a,b)		Perl_sv_pvutf8n(aTHX_ a,b)
-#endif
 #define sv_pvutf8n_force(a,b)	Perl_sv_pvutf8n_force(aTHX_ a,b)
 #define sv_recode_to_utf8(a,b)	Perl_sv_recode_to_utf8(aTHX_ a,b)
 #define sv_ref(a,b,c)		Perl_sv_ref(aTHX_ a,b,c)
@@ -695,12 +636,6 @@
 #ifndef MULTIPLICITY
 #define sv_setpvf		Perl_sv_setpvf
 #define sv_setpvf_mg		Perl_sv_setpvf_mg
-#endif
-#ifndef NO_MATHOMS
-#define sv_setpviv(a,b)		Perl_sv_setpviv(aTHX_ a,b)
-#endif
-#ifndef NO_MATHOMS
-#define sv_setpviv_mg(a,b)	Perl_sv_setpviv_mg(aTHX_ a,b)
 #endif
 #define sv_setpvn(a,b,c)	Perl_sv_setpvn(aTHX_ a,b,c)
 #define sv_setpvn_fresh(a,b,c)	Perl_sv_setpvn_fresh(aTHX_ a,b,c)
@@ -733,9 +668,6 @@
 #define sv_utf8_downgrade_flags(a,b,c)	Perl_sv_utf8_downgrade_flags(aTHX_ a,b,c)
 #define sv_utf8_encode(a)	Perl_sv_utf8_encode(aTHX_ a)
 #define sv_utf8_upgrade_flags_grow(a,b,c)	Perl_sv_utf8_upgrade_flags_grow(aTHX_ a,b,c)
-#ifndef NO_MATHOMS
-#define sv_uv(a)		Perl_sv_uv(aTHX_ a)
-#endif
 #define sv_vcatpvf(a,b,c)	Perl_sv_vcatpvf(aTHX_ a,b,c)
 #define sv_vcatpvf_mg(a,b,c)	Perl_sv_vcatpvf_mg(aTHX_ a,b,c)
 #define sv_vcatpvfn(a,b,c,d,e,f,g)	Perl_sv_vcatpvfn(aTHX_ a,b,c,d,e,f,g)
@@ -752,9 +684,6 @@
 #define to_uni_lower(a,b,c)	Perl_to_uni_lower(aTHX_ a,b,c)
 #define to_uni_title(a,b,c)	Perl_to_uni_title(aTHX_ a,b,c)
 #define to_uni_upper(a,b,c)	Perl_to_uni_upper(aTHX_ a,b,c)
-#ifndef NO_MATHOMS
-#define unpack_str(a,b,c,d,e,f,g,h)	Perl_unpack_str(aTHX_ a,b,c,d,e,f,g,h)
-#endif
 #define unpackstring(a,b,c,d,e)	Perl_unpackstring(aTHX_ a,b,c,d,e)
 #define unshare_hek(a)		Perl_unshare_hek(aTHX_ a)
 #define unsharepvn(a,b,c)	Perl_unsharepvn(aTHX_ a,b,c)
@@ -766,27 +695,11 @@
 #define utf8_hop_safe		Perl_utf8_hop_safe
 #define utf8_length(a,b)	Perl_utf8_length(aTHX_ a,b)
 #define utf8_to_bytes(a,b)	Perl_utf8_to_bytes(aTHX_ a,b)
-#ifndef NO_MATHOMS
-#define utf8_to_uvchr(a,b)	Perl_utf8_to_uvchr(aTHX_ a,b)
-#endif
 #define utf8_to_uvchr_buf_helper(a,b,c)	Perl_utf8_to_uvchr_buf_helper(aTHX_ a,b,c)
-#ifndef NO_MATHOMS
-#define utf8_to_uvuni(a,b)	Perl_utf8_to_uvuni(aTHX_ a,b)
-#endif
-#define utf8_to_uvuni_buf(a,b,c)	Perl_utf8_to_uvuni_buf(aTHX_ a,b,c)
 #define utf8n_to_uvchr_msgs	Perl_utf8n_to_uvchr_msgs
-#ifndef NO_MATHOMS
-#define utf8n_to_uvuni(a,b,c,d)	Perl_utf8n_to_uvuni(aTHX_ a,b,c,d)
-#endif
 #define uvoffuni_to_utf8_flags_msgs(a,b,c,d)	Perl_uvoffuni_to_utf8_flags_msgs(aTHX_ a,b,c,d)
 #define uvuni_to_utf8(a,b)	Perl_uvuni_to_utf8(aTHX_ a,b)
-#ifndef NO_MATHOMS
-#define uvuni_to_utf8_flags(a,b,c)	Perl_uvuni_to_utf8_flags(aTHX_ a,b,c)
-#endif
 #define valid_utf8_to_uvchr	Perl_valid_utf8_to_uvchr
-#ifndef NO_MATHOMS
-#define valid_utf8_to_uvuni(a,b)	Perl_valid_utf8_to_uvuni(aTHX_ a,b)
-#endif
 #define vcmp(a,b)		Perl_vcmp(aTHX_ a,b)
 #define vcroak(a,b)		Perl_vcroak(aTHX_ a,b)
 #define vdeb(a,b)		Perl_vdeb(aTHX_ a,b)
@@ -872,15 +785,9 @@
 #define deb_nocontext		Perl_deb_nocontext
 #define die_nocontext		Perl_die_nocontext
 #define form_nocontext		Perl_form_nocontext
-#ifndef NO_MATHOMS
-#define fprintf_nocontext	Perl_fprintf_nocontext
-#endif
 #define load_module_nocontext	Perl_load_module_nocontext
 #define mess_nocontext		Perl_mess_nocontext
 #define newSVpvf_nocontext	Perl_newSVpvf_nocontext
-#ifndef NO_MATHOMS
-#define printf_nocontext	Perl_printf_nocontext
-#endif
 #define sv_catpvf_mg_nocontext	Perl_sv_catpvf_mg_nocontext
 #define sv_catpvf_nocontext	Perl_sv_catpvf_nocontext
 #define sv_setpvf_mg_nocontext	Perl_sv_setpvf_mg_nocontext
@@ -2059,9 +1966,6 @@
 #  if defined(USE_LOCALE_COLLATE)
 #define magic_freecollxfrm(a,b)	Perl_magic_freecollxfrm(aTHX_ a,b)
 #define magic_setcollxfrm(a,b)	Perl_magic_setcollxfrm(aTHX_ a,b)
-#ifndef NO_MATHOMS
-#define mem_collxfrm(a,b,c)	Perl_mem_collxfrm(aTHX_ a,b,c)
-#endif
 #  endif
 #  if defined(USE_PERLIO)
 #define PerlIO_restore_errno(a)	Perl_PerlIO_restore_errno(aTHX_ a)
@@ -2107,7 +2011,6 @@
 #  define perl_get_hv(a,b)		get_hv(a,b)
 #  define perl_get_sv(a,b)		get_sv(a,b)
 #  define perl_init_i18nl10n(a)		init_i18nl10n(a)
-#  define perl_init_i18nl14n(a)		init_i18nl14n(a)
 #  define perl_require_pv(a)		require_pv(a)
 
 /* varargs functions can't be handled with CPP macros. :-(

--- a/mathoms.c
+++ b/mathoms.c
@@ -301,109 +301,12 @@ Perl_sv_catsv_mg(pTHX_ SV *dsv, SV *sstr)
 
 /*
 =for apidoc_section $SV
-=for apidoc sv_iv
-
-A private implementation of the C<SvIVx> macro for compilers which can't
-cope with complex macro expressions.  Always use the macro instead.
-
-=cut
-*/
-
-IV
-Perl_sv_iv(pTHX_ SV *sv)
-{
-    PERL_ARGS_ASSERT_SV_IV;
-
-    if (SvIOK(sv)) {
-        if (SvIsUV(sv))
-            return (IV)SvUVX(sv);
-        return SvIVX(sv);
-    }
-    return sv_2iv(sv);
-}
-
-/*
-=for apidoc_section $SV
-=for apidoc sv_uv
-
-A private implementation of the C<SvUVx> macro for compilers which can't
-cope with complex macro expressions.  Always use the macro instead.
-
-=cut
-*/
-
-UV
-Perl_sv_uv(pTHX_ SV *sv)
-{
-    PERL_ARGS_ASSERT_SV_UV;
-
-    if (SvIOK(sv)) {
-        if (SvIsUV(sv))
-            return SvUVX(sv);
-        return (UV)SvIVX(sv);
-    }
-    return sv_2uv(sv);
-}
-
-/*
-=for apidoc_section $SV
-=for apidoc sv_nv
-
-A private implementation of the C<SvNVx> macro for compilers which can't
-cope with complex macro expressions.  Always use the macro instead.
-
-=cut
-*/
-
-NV
-Perl_sv_nv(pTHX_ SV *sv)
-{
-    PERL_ARGS_ASSERT_SV_NV;
-
-    if (SvNOK(sv))
-        return SvNVX(sv);
-    return sv_2nv(sv);
-}
-
-/*
-=for apidoc_section $SV
 =for apidoc sv_pv
 
 Use the C<SvPV_nolen> macro instead
 
-=for apidoc_section $SV
-=for apidoc sv_pvn
-
-A private implementation of the C<SvPV> macro for compilers which can't
-cope with complex macro expressions.  Always use the macro instead.
-
 =cut
 */
-
-char *
-Perl_sv_pvn(pTHX_ SV *sv, STRLEN *lp)
-{
-    PERL_ARGS_ASSERT_SV_PVN;
-
-    if (SvPOK(sv)) {
-        *lp = SvCUR(sv);
-        return SvPVX(sv);
-    }
-    return sv_2pv(sv, lp);
-}
-
-
-char *
-Perl_sv_pvn_nomg(pTHX_ SV *sv, STRLEN *lp)
-{
-    PERL_ARGS_ASSERT_SV_PVN_NOMG;
-
-    if (SvPOK(sv)) {
-        *lp = SvCUR(sv);
-        return SvPVX(sv);
-    }
-    return sv_2pv_flags(sv, lp, 0);
-}
 
 /* sv_pv() is now a macro using SvPV_nolen();
  * this function provided for binary compatibility only
@@ -451,23 +354,8 @@ Perl_sv_pvbyte(pTHX_ SV *sv)
 
 Use C<SvPVbyte_nolen> instead.
 
-=for apidoc sv_pvbyten
-
-A private implementation of the C<SvPVbyte> macro for compilers
-which can't cope with complex macro expressions.  Always use the macro
-instead.
-
 =cut
 */
-
-char *
-Perl_sv_pvbyten(pTHX_ SV *sv, STRLEN *lp)
-{
-    PERL_ARGS_ASSERT_SV_PVBYTEN;
-
-    sv_utf8_downgrade(sv, FALSE);
-    return sv_pvn(sv,lp);
-}
 
 /* sv_pvutf8 () is now a macro using Perl_sv_2pv_flags();
  * this function provided for binary compatibility only
@@ -482,30 +370,6 @@ Perl_sv_pvutf8(pTHX_ SV *sv)
     return sv_pv(sv);
 }
 
-/*
-=for apidoc_section $SV
-=for apidoc sv_pvutf8
-
-Use the C<SvPVutf8_nolen> macro instead
-
-=for apidoc sv_pvutf8n
-
-A private implementation of the C<SvPVutf8> macro for compilers
-which can't cope with complex macro expressions.  Always use the macro
-instead.
-
-=cut
-*/
-
-char *
-Perl_sv_pvutf8n(pTHX_ SV *sv, STRLEN *lp)
-{
-    PERL_ARGS_ASSERT_SV_PVUTF8N;
-
-    sv_utf8_upgrade(sv);
-    return sv_pvn(sv,lp);
-}
-
 /* sv_utf8_upgrade() is now a macro using sv_utf8_upgrade_flags();
  * this function provided for binary compatibility only
  */
@@ -516,41 +380,6 @@ Perl_sv_utf8_upgrade(pTHX_ SV *sv)
     PERL_ARGS_ASSERT_SV_UTF8_UPGRADE;
 
     return sv_utf8_upgrade_flags(sv, SV_GMAGIC);
-}
-
-int
-Perl_fprintf_nocontext(PerlIO *stream, const char *format, ...)
-{
-    int ret = 0;
-    va_list arglist;
-
-    /* Easier to special case this here than in embed.pl. (Look at what it
-       generates for proto.h) */
-#ifdef MULTIPLICITY
-    PERL_ARGS_ASSERT_FPRINTF_NOCONTEXT;
-#endif
-
-    va_start(arglist, format);
-    ret = PerlIO_vprintf(stream, format, arglist);
-    va_end(arglist);
-    return ret;
-}
-
-int
-Perl_printf_nocontext(const char *format, ...)
-{
-    dTHX;
-    va_list arglist;
-    int ret = 0;
-
-#ifdef MULTIPLICITY
-    PERL_ARGS_ASSERT_PRINTF_NOCONTEXT;
-#endif
-
-    va_start(arglist, format);
-    ret = PerlIO_vprintf(PerlIO_stdout(), format, arglist);
-    va_end(arglist);
-    return ret;
 }
 
 #if defined(HUGE_VAL) || (defined(USE_LONG_DOUBLE) && defined(HUGE_VALL))
@@ -569,24 +398,6 @@ Perl_huge(void)
 #  endif
 }
 #endif
-
-/* compatibility with versions <= 5.003. */
-void
-Perl_gv_fullname(pTHX_ SV *sv, const GV *gv)
-{
-    PERL_ARGS_ASSERT_GV_FULLNAME;
-
-    gv_fullname3(sv, gv, sv == (const SV*)gv ? "*" : "");
-}
-
-/* compatibility with versions <= 5.003. */
-void
-Perl_gv_efullname(pTHX_ SV *sv, const GV *gv)
-{
-    PERL_ARGS_ASSERT_GV_EFULLNAME;
-
-    gv_efullname3(sv, gv, sv == (const SV*)gv ? "*" : "");
-}
 
 void
 Perl_gv_fullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)
@@ -647,36 +458,6 @@ Perl_do_open(pTHX_ GV *gv, const char *name, I32 len, int as_raw,
                     supplied_fp, (SV **) NULL, 0);
 }
 
-bool
-Perl_do_open9(pTHX_ GV *gv, const char *name, I32 len, int
-as_raw,
-              int rawmode, int rawperm, PerlIO *supplied_fp, SV *svs,
-              I32 num_svs)
-{
-    PERL_ARGS_ASSERT_DO_OPEN9;
-
-    PERL_UNUSED_ARG(num_svs);
-    return do_openn(gv, name, len, as_raw, rawmode, rawperm,
-                    supplied_fp, &svs, 1);
-}
-
-int
-Perl_do_binmode(pTHX_ PerlIO *fp, int iotype, int mode)
-{
- /* The old body of this is now in non-LAYER part of perlio.c
-  * This is a stub for any XS code which might have been calling it.
-  */
- const char *name = ":raw";
-
- PERL_ARGS_ASSERT_DO_BINMODE;
-
-#ifdef PERLIO_USING_CRLF
- if (!(mode & O_BINARY))
-     name = ":crlf";
-#endif
- return PerlIO_binmode(aTHX_ fp, iotype, mode, name);
-}
-
 #ifndef OS2
 bool
 Perl_do_aexec(pTHX_ SV *really, SV **mark, SV **sp)
@@ -686,13 +467,6 @@ Perl_do_aexec(pTHX_ SV *really, SV **mark, SV **sp)
     return do_aexec5(really, mark, sp, 0, 0);
 }
 #endif
-
-/* Backwards compatibility. */
-int
-Perl_init_i18nl14n(pTHX_ int printwarn)
-{
-    return init_i18nl10n(printwarn);
-}
 
 bool
 Perl_is_utf8_string_loc(const U8 *s, const STRLEN len, const U8 **ep)
@@ -748,46 +522,6 @@ Perl_sv_nounlocking(pTHX_ SV *sv)
 }
 
 void
-Perl_save_long(pTHX_ long int *longp)
-{
-    PERL_ARGS_ASSERT_SAVE_LONG;
-
-    SSCHECK(3);
-    SSPUSHLONG(*longp);
-    SSPUSHPTR(longp);
-    SSPUSHUV(SAVEt_LONG);
-}
-
-void
-Perl_save_nogv(pTHX_ GV *gv)
-{
-    PERL_ARGS_ASSERT_SAVE_NOGV;
-
-    SSCHECK(2);
-    SSPUSHPTR(gv);
-    SSPUSHUV(SAVEt_NSTAB);
-}
-
-void
-Perl_save_list(pTHX_ SV **sarg, I32 maxsarg)
-{
-    I32 i;
-
-    PERL_ARGS_ASSERT_SAVE_LIST;
-
-    for (i = 1; i <= maxsarg; i++) {
-        SV *sv;
-        SvGETMAGIC(sarg[i]);
-        sv = newSV(0);
-        sv_setsv_nomg(sv,sarg[i]);
-        SSCHECK(3);
-        SSPUSHPTR(sarg[i]);		/* remember the pointer */
-        SSPUSHPTR(sv);			/* remember the value */
-        SSPUSHUV(SAVEt_ITEM);
-    }
-}
-
-void
 Perl_sv_usepvn_mg(pTHX_ SV *sv, char *ptr, STRLEN len)
 {
     PERL_ARGS_ASSERT_SV_USEPVN_MG;
@@ -802,52 +536,6 @@ Perl_sv_usepvn(pTHX_ SV *sv, char *ptr, STRLEN len)
     PERL_ARGS_ASSERT_SV_USEPVN;
 
     sv_usepvn_flags(sv,ptr,len, 0);
-}
-
-/*
-=for apidoc_section $pack
-=for apidoc unpack_str
-
-The engine implementing C<unpack()> Perl function.  Note: parameters C<strbeg>,
-C<new_s> and C<ocnt> are not used.  This call should not be used, use
-C<unpackstring> instead.
-
-=cut */
-
-SSize_t
-Perl_unpack_str(pTHX_ const char *pat, const char *patend, const char *s,
-                const char *strbeg, const char *strend, char **new_s, I32 ocnt,
-                U32 flags)
-{
-    PERL_ARGS_ASSERT_UNPACK_STR;
-
-    PERL_UNUSED_ARG(strbeg);
-    PERL_UNUSED_ARG(new_s);
-    PERL_UNUSED_ARG(ocnt);
-
-    return unpackstring(pat, patend, s, strend, flags);
-}
-
-/*
-=for apidoc_section $pack
-=for apidoc pack_cat
-
-The engine implementing C<pack()> Perl function.  Note: parameters
-C<next_in_list> and C<flags> are not used.  This call should not be used; use
-C<L</packlist>> instead.
-
-=cut
-*/
-
-void
-Perl_pack_cat(pTHX_ SV *cat, const char *pat, const char *patend, SV **beglist, SV **endlist, SV ***next_in_list, U32 flags)
-{
-    PERL_ARGS_ASSERT_PACK_CAT;
-
-    PERL_UNUSED_ARG(next_in_list);
-    PERL_UNUSED_ARG(flags);
-
-    packlist(cat, pat, patend, beglist, endlist);
 }
 
 HE *
@@ -1081,17 +769,6 @@ Perl_sv_collxfrm(pTHX_ SV *const sv, STRLEN *const nxp)
     return sv_collxfrm_flags(sv, nxp, SV_GMAGIC);
 }
 
-char *
-Perl_mem_collxfrm(pTHX_ const char *input_string, STRLEN len, STRLEN *xlen)
-{
-    /* This function is retained for compatibility in case someone outside core
-     * is using this (but it is undocumented) */
-
-    PERL_ARGS_ASSERT_MEM_COLLXFRM;
-
-    return _mem_collxfrm(input_string, len, xlen, FALSE);
-}
-
 #endif
 
 bool
@@ -1099,36 +776,6 @@ Perl_sv_2bool(pTHX_ SV *const sv)
 {
     PERL_ARGS_ASSERT_SV_2BOOL;
     return sv_2bool_flags(sv, SV_GMAGIC);
-}
-
-
-/*
-=for apidoc_section $custom
-=for apidoc custom_op_name
-Return the name for a given custom op.  This was once used by the C<OP_NAME>
-macro, but is no longer: it has only been kept for compatibility, and
-should not be used.
-
-=for apidoc custom_op_desc
-Return the description of a given custom op.  This was once used by the
-C<OP_DESC> macro, but is no longer: it has only been kept for
-compatibility, and should not be used.
-
-=cut
-*/
-
-const char*
-Perl_custom_op_name(pTHX_ const OP* o)
-{
-    PERL_ARGS_ASSERT_CUSTOM_OP_NAME;
-    return XopENTRYCUSTOM(o, xop_name);
-}
-
-const char*
-Perl_custom_op_desc(pTHX_ const OP* o)
-{
-    PERL_ARGS_ASSERT_CUSTOM_OP_DESC;
-    return XopENTRYCUSTOM(o, xop_desc);
 }
 
 CV *
@@ -1151,46 +798,6 @@ Perl_sv_copypv(pTHX_ SV *const dsv, SV *const ssv)
     sv_copypv_flags(dsv, ssv, SV_GMAGIC);
 }
 
-UV      /* Made into a function, so can be deprecated */
-NATIVE_TO_NEED(const UV enc, const UV ch)
-{
-    PERL_UNUSED_ARG(enc);
-    return ch;
-}
-
-UV      /* Made into a function, so can be deprecated */
-ASCII_TO_NEED(const UV enc, const UV ch)
-{
-    PERL_UNUSED_ARG(enc);
-    return ch;
-}
-
-/*
-=for apidoc_section $unicode
-=for apidoc is_utf8_char
-
-Tests if some arbitrary number of bytes begins in a valid UTF-8
-character.  Note that an INVARIANT (i.e. ASCII on non-EBCDIC machines)
-character is a valid UTF-8 character.  The actual number of bytes in the UTF-8
-character will be returned if it is valid, otherwise 0.
-
-This function is deprecated due to the possibility that malformed input could
-cause reading beyond the end of the input buffer.  Use L</isUTF8_CHAR>
-instead.
-
-=cut */
-
-STRLEN
-Perl_is_utf8_char(const U8 *s)
-{
-    PERL_ARGS_ASSERT_IS_UTF8_CHAR;
-
-    /* Assumes we have enough space, which is why this is deprecated.  But the
-     * UTF8_CHK_SKIP(s)) makes it safe for the common case of NUL-terminated
-     * strings */
-    return isUTF8_CHAR(s, s + UTF8_CHK_SKIP(s));
-}
-
 /*
 =for apidoc_section $unicode
 =for apidoc is_utf8_char_buf
@@ -1206,54 +813,6 @@ Perl_is_utf8_char_buf(const U8 *buf, const U8* buf_end)
     PERL_ARGS_ASSERT_IS_UTF8_CHAR_BUF;
 
     return isUTF8_CHAR(buf, buf_end);
-}
-
-/* DEPRECATED!
- * Like L</utf8_to_uvuni_buf>(), but should only be called when it is known that
- * there are no malformations in the input UTF-8 string C<s>.  Surrogates,
- * non-character code points, and non-Unicode code points are allowed */
-
-UV
-Perl_valid_utf8_to_uvuni(pTHX_ const U8 *s, STRLEN *retlen)
-{
-    PERL_UNUSED_CONTEXT;
-    PERL_ARGS_ASSERT_VALID_UTF8_TO_UVUNI;
-
-    return NATIVE_TO_UNI(valid_utf8_to_uvchr(s, retlen));
-}
-
-/*
-=for apidoc_section $unicode
-=for apidoc utf8_to_uvuni
-
-Returns the Unicode code point of the first character in the string C<s>
-which is assumed to be in UTF-8 encoding; C<retlen> will be set to the
-length, in bytes, of that character.
-
-Some, but not all, UTF-8 malformations are detected, and in fact, some
-malformed input could cause reading beyond the end of the input buffer, which
-is one reason why this function is deprecated.  The other is that only in
-extremely limited circumstances should the Unicode versus native code point be
-of any interest to you.  See L</utf8_to_uvuni_buf> for alternatives.
-
-If C<s> points to one of the detected malformations, and UTF8 warnings are
-enabled, zero is returned and C<*retlen> is set (if C<retlen> doesn't point to
-NULL) to -1.  If those warnings are off, the computed value if well-defined (or
-the Unicode REPLACEMENT CHARACTER, if not) is silently returned, and C<*retlen>
-is set (if C<retlen> isn't NULL) so that (S<C<s> + C<*retlen>>) is the
-next possible position in C<s> that could begin a non-malformed character.
-See L<perlapi/utf8n_to_uvchr> for details on when the REPLACEMENT CHARACTER is returned.
-
-=cut
-*/
-
-UV
-Perl_utf8_to_uvuni(pTHX_ const U8 *s, STRLEN *retlen)
-{
-    PERL_UNUSED_CONTEXT;
-    PERL_ARGS_ASSERT_UTF8_TO_UVUNI;
-
-    return NATIVE_TO_UNI(valid_utf8_to_uvchr(s, retlen));
 }
 
 /*
@@ -1322,97 +881,6 @@ Perl_uvuni_to_utf8(pTHX_ U8 *d, UV uv)
     PERL_ARGS_ASSERT_UVUNI_TO_UTF8;
 
     return uvoffuni_to_utf8_flags(d, uv, 0);
-}
-
-/*
-=for apidoc_section $unicode
-=for apidoc utf8n_to_uvuni
-
-Instead use L<perlapi/utf8_to_uvchr_buf>, or rarely, L<perlapi/utf8n_to_uvchr>.
-
-This function was useful for code that wanted to handle both EBCDIC and
-ASCII platforms with Unicode properties, but starting in Perl v5.20, the
-distinctions between the platforms have mostly been made invisible to most
-code, so this function is quite unlikely to be what you want.  If you do need
-this precise functionality, use instead
-C<L<NATIVE_TO_UNI(utf8_to_uvchr_buf(...))|perlapi/utf8_to_uvchr_buf>>
-or C<L<NATIVE_TO_UNI(utf8n_to_uvchr(...))|perlapi/utf8n_to_uvchr>>.
-
-=cut
-*/
-
-UV
-Perl_utf8n_to_uvuni(pTHX_ const U8 *s, STRLEN curlen, STRLEN *retlen, U32 flags)
-{
-    PERL_ARGS_ASSERT_UTF8N_TO_UVUNI;
-
-    return NATIVE_TO_UNI(utf8n_to_uvchr(s, curlen, retlen, flags));
-}
-
-/*
-=for apidoc_section $unicode
-=for apidoc uvuni_to_utf8_flags
-
-Instead you almost certainly want to use L<perlapi/uvchr_to_utf8> or
-L<perlapi/uvchr_to_utf8_flags>.
-
-This function is a deprecated synonym for L</uvoffuni_to_utf8_flags>,
-which itself, while not deprecated, should be used only in isolated
-circumstances.  These functions were useful for code that wanted to handle
-both EBCDIC and ASCII platforms with Unicode properties, but starting in Perl
-v5.20, the distinctions between the platforms have mostly been made invisible
-to most code, so this function is quite unlikely to be what you want.
-
-=cut
-*/
-
-U8 *
-Perl_uvuni_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
-{
-    PERL_ARGS_ASSERT_UVUNI_TO_UTF8_FLAGS;
-
-    return uvoffuni_to_utf8_flags(d, uv, flags);
-}
-
-/*
-=for apidoc_section $unicode
-=for apidoc utf8_to_uvchr
-
-Returns the native code point of the first character in the string C<s>
-which is assumed to be in UTF-8 encoding; C<retlen> will be set to the
-length, in bytes, of that character.
-
-Some, but not all, UTF-8 malformations are detected, and in fact, some
-malformed input could cause reading beyond the end of the input buffer, which
-is why this function is deprecated.  Use L</utf8_to_uvchr_buf> instead.
-
-If C<s> points to one of the detected malformations, and UTF8 warnings are
-enabled, zero is returned and C<*retlen> is set (if C<retlen> isn't
-C<NULL>) to -1.  If those warnings are off, the computed value if well-defined (or
-the Unicode REPLACEMENT CHARACTER, if not) is silently returned, and C<*retlen>
-is set (if C<retlen> isn't NULL) so that (S<C<s> + C<*retlen>>) is the
-next possible position in C<s> that could begin a non-malformed character.
-See L</utf8n_to_uvchr> for details on when the REPLACEMENT CHARACTER is returned.
-
-=cut
-*/
-
-UV
-Perl_utf8_to_uvchr(pTHX_ const U8 *s, STRLEN *retlen)
-{
-    PERL_ARGS_ASSERT_UTF8_TO_UVCHR;
-
-    /* This function is unsafe if malformed UTF-8 input is given it, which is
-     * why the function is deprecated.  If the first byte of the input
-     * indicates that there are more bytes remaining in the sequence that forms
-     * the character than there are in the input buffer, it can read past the
-     * end.  But we can make it safe if the input string happens to be
-     * NUL-terminated, as many strings in Perl are, by refusing to read past a
-     * NUL, which is what UTF8_CHK_SKIP() does.  A NUL indicates the start of
-     * the next character anyway.  If the input isn't NUL-terminated, the
-     * function remains unsafe, as it always has been. */
-
-    return utf8_to_uvchr_buf(s, s + UTF8_CHK_SKIP(s), retlen);
 }
 
 GCC_DIAG_RESTORE

--- a/mg.c
+++ b/mg.c
@@ -297,42 +297,6 @@ Perl_mg_set(pTHX_ SV *sv)
     return 0;
 }
 
-/*
-=for apidoc mg_length
-
-Reports on the SV's length in bytes, calling length magic if available,
-but does not set the UTF8 flag on C<sv>.  It will fall back to 'get'
-magic if there is no 'length' magic, but with no indication as to
-whether it called 'get' magic.  It assumes C<sv> is a C<PVMG> or
-higher.  Use C<sv_len()> instead.
-
-=cut
-*/
-
-U32
-Perl_mg_length(pTHX_ SV *sv)
-{
-    MAGIC* mg;
-    STRLEN len;
-
-    PERL_ARGS_ASSERT_MG_LENGTH;
-
-    for (mg = SvMAGIC(sv); mg; mg = mg->mg_moremagic) {
-        const MGVTBL * const vtbl = mg->mg_virtual;
-        if (vtbl && vtbl->svt_len) {
-            const I32 mgs_ix = SSNEW(sizeof(MGS));
-            save_magic(mgs_ix, sv);
-            /* omit MGf_GSKIP -- not changed here */
-            len = vtbl->svt_len(aTHX_ sv, mg);
-            restore_magic(INT2PTR(void*, (IV)mgs_ix));
-            return len;
-        }
-    }
-
-    (void)SvPV_const(sv, len);
-    return len;
-}
-
 I32
 Perl_mg_size(pTHX_ SV *sv)
 {

--- a/proto.h
+++ b/proto.h
@@ -17,14 +17,6 @@
  */
 
 START_EXTERN_C
-#ifndef NO_MATHOMS
-PERL_CALLCONV UV	ASCII_TO_NEED(const UV enc, const UV ch)
-			__attribute__deprecated__
-			__attribute__warn_unused_result__
-			__attribute__pure__;
-#define PERL_ARGS_ASSERT_ASCII_TO_NEED
-#endif
-
 #ifndef PERL_NO_INLINE_FUNCTIONS
 PERL_STATIC_INLINE I32 *	Perl_CvDEPTH(const CV * const sv);
 #define PERL_ARGS_ASSERT_CVDEPTH	\
@@ -38,14 +30,6 @@ PERL_STATIC_INLINE GV *	Perl_CvGV(pTHX_ CV *sv);
 PERL_CALLCONV int	Perl_Gv_AMupdate(pTHX_ HV* stash, bool destructing);
 #define PERL_ARGS_ASSERT_GV_AMUPDATE	\
 	assert(stash)
-#ifndef NO_MATHOMS
-PERL_CALLCONV UV	NATIVE_TO_NEED(const UV enc, const UV ch)
-			__attribute__deprecated__
-			__attribute__warn_unused_result__
-			__attribute__pure__;
-#define PERL_ARGS_ASSERT_NATIVE_TO_NEED
-#endif
-
 #ifndef PERL_NO_INLINE_FUNCTIONS
 PERL_STATIC_INLINE I32	Perl_POPMARK(pTHX);
 #define PERL_ARGS_ASSERT_POPMARK
@@ -782,26 +766,10 @@ PERL_CALLCONV Signal_t	Perl_csighandler3(int sig, Siginfo_t *info, void *uap);
 #define PERL_ARGS_ASSERT_CSIGHANDLER3
 PERL_CALLCONV regexp_engine const *	Perl_current_re_engine(pTHX);
 #define PERL_ARGS_ASSERT_CURRENT_RE_ENGINE
-#ifndef NO_MATHOMS
-PERL_CALLCONV const char *	Perl_custom_op_desc(pTHX_ const OP *o)
-			__attribute__deprecated__
-			__attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_CUSTOM_OP_DESC	\
-	assert(o)
-#endif
-
 PERL_CALLCONV XOPRETANY	Perl_custom_op_get_field(pTHX_ const OP *o, const xop_flags_enum field)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_CUSTOM_OP_GET_FIELD	\
 	assert(o)
-
-#ifndef NO_MATHOMS
-PERL_CALLCONV const char *	Perl_custom_op_name(pTHX_ const OP *o)
-			__attribute__deprecated__
-			__attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_CUSTOM_OP_NAME	\
-	assert(o)
-#endif
 
 PERL_CALLCONV void	Perl_custom_op_register(pTHX_ Perl_ppaddr_t ppaddr, const XOP *xop);
 #define PERL_ARGS_ASSERT_CUSTOM_OP_REGISTER	\
@@ -918,13 +886,6 @@ PERL_CALLCONV bool	Perl_do_aexec(pTHX_ SV* really, SV** mark, SV** sp);
 PERL_CALLCONV bool	Perl_do_aexec5(pTHX_ SV* really, SV** mark, SV** sp, int fd, int do_report);
 #define PERL_ARGS_ASSERT_DO_AEXEC5	\
 	assert(mark); assert(sp)
-#ifndef NO_MATHOMS
-PERL_CALLCONV int	Perl_do_binmode(pTHX_ PerlIO *fp, int iotype, int mode)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_DO_BINMODE	\
-	assert(fp)
-#endif
-
 PERL_CALLCONV bool	Perl_do_close(pTHX_ GV* gv, bool is_explicit);
 #define PERL_ARGS_ASSERT_DO_CLOSE
 PERL_CALLCONV void	Perl_do_dump_pad(pTHX_ I32 level, PerlIO *file, PADLIST *padlist, int full);
@@ -964,13 +925,6 @@ PERL_CALLCONV bool	Perl_do_open(pTHX_ GV* gv, const char* name, I32 len, int as_
 PERL_CALLCONV bool	Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len, PerlIO *supplied_fp, SV **svp, U32 num);
 #define PERL_ARGS_ASSERT_DO_OPEN6	\
 	assert(gv); assert(oname)
-#ifndef NO_MATHOMS
-PERL_CALLCONV bool	Perl_do_open9(pTHX_ GV *gv, const char *name, I32 len, int as_raw, int rawmode, int rawperm, PerlIO *supplied_fp, SV *svs, I32 num)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_DO_OPEN9	\
-	assert(gv); assert(name); assert(svs)
-#endif
-
 PERL_CALLCONV bool	Perl_do_open_raw(pTHX_ GV *gv, const char *oname, STRLEN len, int rawmode, int rawperm, Stat_t *statbufp);
 #define PERL_ARGS_ASSERT_DO_OPEN_RAW	\
 	assert(gv); assert(oname)
@@ -1115,10 +1069,6 @@ PERL_CALLCONV CV*	Perl_find_runcv_where(pTHX_ U8 cond, IV arg, U32 *db_seqp)
 
 PERL_CALLCONV SV*	Perl_find_rundefsv(pTHX);
 #define PERL_ARGS_ASSERT_FIND_RUNDEFSV
-PERL_CALLCONV PADOFFSET	Perl_find_rundefsvoffset(pTHX)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_FIND_RUNDEFSVOFFSET
-
 PERL_CALLCONV char*	Perl_find_script(pTHX_ const char *scriptname, bool dosearch, const char *const *const search_ext, I32 flags);
 #define PERL_ARGS_ASSERT_FIND_SCRIPT	\
 	assert(scriptname)
@@ -1304,13 +1254,6 @@ PERL_CALLCONV SV*	Perl_gv_const_sv(pTHX_ GV* gv)
 PERL_CALLCONV void	Perl_gv_dump(pTHX_ GV* gv);
 #define PERL_ARGS_ASSERT_GV_DUMP
 #ifndef NO_MATHOMS
-PERL_CALLCONV void	Perl_gv_efullname(pTHX_ SV* sv, const GV* gv)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_GV_EFULLNAME	\
-	assert(sv); assert(gv)
-#endif
-
-#ifndef NO_MATHOMS
 PERL_CALLCONV void	Perl_gv_efullname3(pTHX_ SV* sv, const GV* gv, const char* prefix);
 #define PERL_ARGS_ASSERT_GV_EFULLNAME3	\
 	assert(sv); assert(gv)
@@ -1372,13 +1315,6 @@ PERL_CALLCONV GV*	Perl_gv_fetchpvn_flags(pTHX_ const char* name, STRLEN len, I32
 PERL_CALLCONV GV*	Perl_gv_fetchsv(pTHX_ SV *name, I32 flags, const svtype sv_type);
 #define PERL_ARGS_ASSERT_GV_FETCHSV	\
 	assert(name)
-#ifndef NO_MATHOMS
-PERL_CALLCONV void	Perl_gv_fullname(pTHX_ SV* sv, const GV* gv)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_GV_FULLNAME	\
-	assert(sv); assert(gv)
-#endif
-
 #ifndef NO_MATHOMS
 PERL_CALLCONV void	Perl_gv_fullname3(pTHX_ SV* sv, const GV* gv, const char* prefix);
 #define PERL_ARGS_ASSERT_GV_FULLNAME3	\
@@ -1620,12 +1556,6 @@ PERL_CALLCONV void	Perl_init_debugger(pTHX);
 #define PERL_ARGS_ASSERT_INIT_DEBUGGER
 PERL_CALLCONV int	Perl_init_i18nl10n(pTHX_ int printwarn);
 #define PERL_ARGS_ASSERT_INIT_I18NL10N
-#ifndef NO_MATHOMS
-PERL_CALLCONV int	Perl_init_i18nl14n(pTHX_ int printwarn)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_INIT_I18NL14N
-#endif
-
 PERL_CALLCONV void	Perl_init_named_cv(pTHX_ CV *cv, OP *nameop);
 #define PERL_ARGS_ASSERT_INIT_NAMED_CV	\
 	assert(cv); assert(nameop)
@@ -1732,13 +1662,6 @@ PERL_CALLCONV Size_t	Perl_is_utf8_FF_helper_(const U8 * const s0, const U8 * con
 			__attribute__pure__;
 #define PERL_ARGS_ASSERT_IS_UTF8_FF_HELPER_	\
 	assert(s0); assert(e)
-
-#ifndef NO_MATHOMS
-PERL_CALLCONV STRLEN	Perl_is_utf8_char(const U8 *s)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_IS_UTF8_CHAR	\
-	assert(s)
-#endif
 
 #ifndef NO_MATHOMS
 PERL_CALLCONV STRLEN	Perl_is_utf8_char_buf(const U8 *buf, const U8 *buf_end);
@@ -2113,11 +2036,6 @@ PERL_CALLCONV void	Perl_mg_freeext(pTHX_ SV* sv, int how, const MGVTBL *vtbl);
 PERL_CALLCONV int	Perl_mg_get(pTHX_ SV* sv);
 #define PERL_ARGS_ASSERT_MG_GET	\
 	assert(sv)
-PERL_CALLCONV U32	Perl_mg_length(pTHX_ SV* sv)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_MG_LENGTH	\
-	assert(sv)
-
 PERL_CALLCONV void	Perl_mg_localize(pTHX_ SV* sv, SV* nsv, bool setmagic);
 #define PERL_ARGS_ASSERT_MG_LOCALIZE	\
 	assert(sv); assert(nsv)
@@ -2710,13 +2628,6 @@ PERL_CALLCONV OP*	Perl_op_wrap_finally(pTHX_ OP *block, OP *finally)
 PERL_CALLCONV void	Perl_optimize_optree(pTHX_ OP* o);
 #define PERL_ARGS_ASSERT_OPTIMIZE_OPTREE	\
 	assert(o)
-#ifndef NO_MATHOMS
-PERL_CALLCONV void	Perl_pack_cat(pTHX_ SV *cat, const char *pat, const char *patend, SV **beglist, SV **endlist, SV ***next_in_list, U32 flags)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_PACK_CAT	\
-	assert(cat); assert(pat); assert(patend); assert(beglist); assert(endlist); assert(next_in_list)
-#endif
-
 PERL_CALLCONV void	Perl_package(pTHX_ OP* o);
 #define PERL_ARGS_ASSERT_PACKAGE	\
 	assert(o)
@@ -2745,13 +2656,6 @@ PERL_CALLCONV PADOFFSET	Perl_pad_alloc(pTHX_ I32 optype, U32 tmptype);
 #define PERL_ARGS_ASSERT_PAD_ALLOC
 PERL_CALLCONV void	Perl_pad_block_start(pTHX_ int full);
 #define PERL_ARGS_ASSERT_PAD_BLOCK_START
-#ifndef NO_MATHOMS
-PERL_CALLCONV HV*	Perl_pad_compname_type(pTHX_ const PADOFFSET po)
-			__attribute__deprecated__
-			__attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_PAD_COMPNAME_TYPE
-#endif
-
 PERL_CALLCONV PADOFFSET	Perl_pad_findmy_pv(pTHX_ const char* name, U32 flags);
 #define PERL_ARGS_ASSERT_PAD_FINDMY_PV	\
 	assert(name)
@@ -3147,31 +3051,10 @@ PERL_CALLCONV void	Perl_save_iv(pTHX_ IV *ivp);
 #define PERL_ARGS_ASSERT_SAVE_IV	\
 	assert(ivp)
 #ifndef NO_MATHOMS
-PERL_CALLCONV void	Perl_save_list(pTHX_ SV** sarg, I32 maxsarg)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_SAVE_LIST	\
-	assert(sarg)
-#endif
-
-#ifndef NO_MATHOMS
-PERL_CALLCONV void	Perl_save_long(pTHX_ long* longp)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_SAVE_LONG	\
-	assert(longp)
-#endif
-
-#ifndef NO_MATHOMS
 PERL_CALLCONV void	Perl_save_mortalizesv(pTHX_ SV* sv);
 #define PERL_ARGS_ASSERT_SAVE_MORTALIZESV	\
 	assert(sv)
 #endif
-#ifndef NO_MATHOMS
-PERL_CALLCONV void	Perl_save_nogv(pTHX_ GV* gv)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_SAVE_NOGV	\
-	assert(gv)
-#endif
-
 #ifndef NO_MATHOMS
 PERL_CALLCONV void	Perl_save_op(pTHX);
 #define PERL_ARGS_ASSERT_SAVE_OP
@@ -3616,13 +3499,6 @@ PERL_CALLCONV bool	Perl_sv_isa_sv(pTHX_ SV* sv, SV* namesv)
 
 PERL_CALLCONV int	Perl_sv_isobject(pTHX_ SV* sv);
 #define PERL_ARGS_ASSERT_SV_ISOBJECT
-#ifndef NO_MATHOMS
-PERL_CALLCONV IV	Perl_sv_iv(pTHX_ SV* sv)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_SV_IV	\
-	assert(sv)
-#endif
-
 PERL_CALLCONV STRLEN	Perl_sv_len(pTHX_ SV *const sv);
 #define PERL_ARGS_ASSERT_SV_LEN
 PERL_CALLCONV STRLEN	Perl_sv_len_utf8(pTHX_ SV *const sv);
@@ -3673,13 +3549,6 @@ PERL_CALLCONV void	Perl_sv_nounlocking(pTHX_ SV *sv)
 #define PERL_ARGS_ASSERT_SV_NUMEQ
 PERL_CALLCONV bool	Perl_sv_numeq_flags(pTHX_ SV* sv1, SV* sv2, const U32 flags);
 #define PERL_ARGS_ASSERT_SV_NUMEQ_FLAGS
-#ifndef NO_MATHOMS
-PERL_CALLCONV NV	Perl_sv_nv(pTHX_ SV* sv)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_SV_NV	\
-	assert(sv)
-#endif
-
 #ifndef PERL_NO_INLINE_FUNCTIONS
 PERL_STATIC_INLINE bool	Perl_sv_only_taint_gmagic(SV *sv);
 #define PERL_ARGS_ASSERT_SV_ONLY_TAINT_GMAGIC	\
@@ -3713,23 +3582,9 @@ PERL_CALLCONV char*	Perl_sv_pvbyte(pTHX_ SV *sv)
 	assert(sv)
 #endif
 
-#ifndef NO_MATHOMS
-PERL_CALLCONV char*	Perl_sv_pvbyten(pTHX_ SV *sv, STRLEN *lp)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_SV_PVBYTEN	\
-	assert(sv); assert(lp)
-#endif
-
 PERL_CALLCONV char*	Perl_sv_pvbyten_force(pTHX_ SV *const sv, STRLEN *const lp);
 #define PERL_ARGS_ASSERT_SV_PVBYTEN_FORCE	\
 	assert(sv)
-#ifndef NO_MATHOMS
-PERL_CALLCONV char*	Perl_sv_pvn(pTHX_ SV *sv, STRLEN *lp)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_SV_PVN	\
-	assert(sv); assert(lp)
-#endif
-
 #ifndef NO_MATHOMS
 PERL_CALLCONV char*	Perl_sv_pvn_force(pTHX_ SV* sv, STRLEN* lp);
 #define PERL_ARGS_ASSERT_SV_PVN_FORCE	\
@@ -3739,24 +3594,10 @@ PERL_CALLCONV char*	Perl_sv_pvn_force_flags(pTHX_ SV *const sv, STRLEN *const lp
 #define PERL_ARGS_ASSERT_SV_PVN_FORCE_FLAGS	\
 	assert(sv)
 #ifndef NO_MATHOMS
-PERL_CALLCONV char*	Perl_sv_pvn_nomg(pTHX_ SV* sv, STRLEN* lp)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_SV_PVN_NOMG	\
-	assert(sv)
-#endif
-
-#ifndef NO_MATHOMS
 PERL_CALLCONV char*	Perl_sv_pvutf8(pTHX_ SV *sv)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_PVUTF8	\
 	assert(sv)
-#endif
-
-#ifndef NO_MATHOMS
-PERL_CALLCONV char*	Perl_sv_pvutf8n(pTHX_ SV *sv, STRLEN *lp)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_SV_PVUTF8N	\
-	assert(sv); assert(lp)
 #endif
 
 PERL_CALLCONV char*	Perl_sv_pvutf8n_force(pTHX_ SV *const sv, STRLEN *const lp);
@@ -3834,20 +3675,6 @@ PERL_CALLCONV void	Perl_sv_setpvf_mg(pTHX_ SV *const sv, const char *const pat, 
 			__attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_SV_SETPVF_MG	\
 	assert(sv); assert(pat)
-
-#ifndef NO_MATHOMS
-PERL_CALLCONV void	Perl_sv_setpviv(pTHX_ SV *const sv, const IV num)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_SV_SETPVIV	\
-	assert(sv)
-#endif
-
-#ifndef NO_MATHOMS
-PERL_CALLCONV void	Perl_sv_setpviv_mg(pTHX_ SV *const sv, const IV iv)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_SV_SETPVIV_MG	\
-	assert(sv)
-#endif
 
 PERL_CALLCONV void	Perl_sv_setpvn(pTHX_ SV *const sv, const char *const ptr, const STRLEN len);
 #define PERL_ARGS_ASSERT_SV_SETPVN	\
@@ -3986,13 +3813,6 @@ PERL_CALLCONV STRLEN	Perl_sv_utf8_upgrade_flags_grow(pTHX_ SV *const sv, const I
 	assert(sv)
 /* PERL_CALLCONV STRLEN	sv_utf8_upgrade_nomg(pTHX_ SV *sv); */
 #define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE_NOMG
-#ifndef NO_MATHOMS
-PERL_CALLCONV UV	Perl_sv_uv(pTHX_ SV* sv)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_SV_UV	\
-	assert(sv)
-#endif
-
 PERL_CALLCONV void	Perl_sv_vcatpvf(pTHX_ SV *const sv, const char *const pat, va_list *const args);
 #define PERL_ARGS_ASSERT_SV_VCATPVF	\
 	assert(sv); assert(pat)
@@ -4055,13 +3875,6 @@ PERL_CALLCONV bool	Perl_try_amagic_bin(pTHX_ int method, int flags);
 #define PERL_ARGS_ASSERT_TRY_AMAGIC_BIN
 PERL_CALLCONV bool	Perl_try_amagic_un(pTHX_ int method, int flags);
 #define PERL_ARGS_ASSERT_TRY_AMAGIC_UN
-#ifndef NO_MATHOMS
-PERL_CALLCONV SSize_t	Perl_unpack_str(pTHX_ const char *pat, const char *patend, const char *s, const char *strbeg, const char *strend, char **new_s, I32 ocnt, U32 flags)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_UNPACK_STR	\
-	assert(pat); assert(patend); assert(s); assert(strend)
-#endif
-
 PERL_CALLCONV SSize_t	Perl_unpackstring(pTHX_ const char *pat, const char *patend, const char *s, const char *strend, U32 flags);
 #define PERL_ARGS_ASSERT_UNPACKSTRING	\
 	assert(pat); assert(patend); assert(s); assert(strend)
@@ -4127,13 +3940,6 @@ PERL_CALLCONV U8*	Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp);
 PERL_CALLCONV U8*	Perl_utf8_to_utf16_base(pTHX_ U8* s, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low);
 #define PERL_ARGS_ASSERT_UTF8_TO_UTF16_BASE	\
 	assert(s); assert(d); assert(newlen)
-#ifndef NO_MATHOMS
-PERL_CALLCONV UV	Perl_utf8_to_uvchr(pTHX_ const U8 *s, STRLEN *retlen)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_UTF8_TO_UVCHR	\
-	assert(s)
-#endif
-
 PERL_CALLCONV UV	Perl_utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen);
 #define PERL_ARGS_ASSERT_UTF8_TO_UVCHR_BUF	\
 	assert(s); assert(send)
@@ -4142,18 +3948,6 @@ PERL_STATIC_INLINE UV	Perl_utf8_to_uvchr_buf_helper(pTHX_ const U8 *s, const U8 
 #define PERL_ARGS_ASSERT_UTF8_TO_UVCHR_BUF_HELPER	\
 	assert(s); assert(send)
 #endif
-#ifndef NO_MATHOMS
-PERL_CALLCONV UV	Perl_utf8_to_uvuni(pTHX_ const U8 *s, STRLEN *retlen)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_UTF8_TO_UVUNI	\
-	assert(s)
-#endif
-
-PERL_CALLCONV UV	Perl_utf8_to_uvuni_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_UTF8_TO_UVUNI_BUF	\
-	assert(s); assert(send)
-
 PERL_CALLCONV UV	Perl_utf8n_to_uvchr(const U8 *s, STRLEN curlen, STRLEN *retlen, const U32 flags);
 #define PERL_ARGS_ASSERT_UTF8N_TO_UVCHR	\
 	assert(s)
@@ -4165,13 +3959,6 @@ PERL_STATIC_INLINE UV	Perl_utf8n_to_uvchr_msgs(const U8 *s, STRLEN curlen, STRLE
 #define PERL_ARGS_ASSERT_UTF8N_TO_UVCHR_MSGS	\
 	assert(s)
 #endif
-#ifndef NO_MATHOMS
-PERL_CALLCONV UV	Perl_utf8n_to_uvuni(pTHX_ const U8 *s, STRLEN curlen, STRLEN *retlen, U32 flags)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_UTF8N_TO_UVUNI	\
-	assert(s)
-#endif
-
 PERL_CALLCONV void	Perl_utilize(pTHX_ int aver, I32 floor, OP* version, OP* idop, OP* arg);
 #define PERL_ARGS_ASSERT_UTILIZE	\
 	assert(idop)
@@ -4190,24 +3977,10 @@ PERL_CALLCONV U8*	Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, con
 PERL_CALLCONV U8*	Perl_uvuni_to_utf8(pTHX_ U8 *d, UV uv);
 #define PERL_ARGS_ASSERT_UVUNI_TO_UTF8	\
 	assert(d)
-#ifndef NO_MATHOMS
-PERL_CALLCONV U8*	Perl_uvuni_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_UVUNI_TO_UTF8_FLAGS	\
-	assert(d)
-#endif
-
 #ifndef PERL_NO_INLINE_FUNCTIONS
 PERL_STATIC_INLINE UV	Perl_valid_utf8_to_uvchr(const U8 *s, STRLEN *retlen)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_VALID_UTF8_TO_UVCHR	\
-	assert(s)
-#endif
-
-#ifndef NO_MATHOMS
-PERL_CALLCONV UV	Perl_valid_utf8_to_uvuni(pTHX_ const U8 *s, STRLEN *retlen)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_VALID_UTF8_TO_UVUNI	\
 	assert(s)
 #endif
 
@@ -4884,14 +4657,6 @@ PERL_CALLCONV char*	Perl_form_nocontext(const char* pat, ...)
 #define PERL_ARGS_ASSERT_FORM_NOCONTEXT	\
 	assert(pat)
 
-#ifndef NO_MATHOMS
-PERL_CALLCONV int	Perl_fprintf_nocontext(PerlIO *stream, const char *format, ...)
-			__attribute__deprecated__
-			__attribute__format__(__printf__,2,3);
-#define PERL_ARGS_ASSERT_FPRINTF_NOCONTEXT	\
-	assert(stream); assert(format)
-#endif
-
 PERL_CALLCONV void	Perl_load_module_nocontext(U32 flags, SV* name, SV* ver, ...);
 #define PERL_ARGS_ASSERT_LOAD_MODULE_NOCONTEXT	\
 	assert(name)
@@ -4907,14 +4672,6 @@ PERL_CALLCONV SV*	Perl_newSVpvf_nocontext(const char *const pat, ...)
 			__attribute__format__(__printf__,1,2);
 #define PERL_ARGS_ASSERT_NEWSVPVF_NOCONTEXT	\
 	assert(pat)
-
-#ifndef NO_MATHOMS
-PERL_CALLCONV int	Perl_printf_nocontext(const char *format, ...)
-			__attribute__deprecated__
-			__attribute__format__(__printf__,1,2);
-#define PERL_ARGS_ASSERT_PRINTF_NOCONTEXT	\
-	assert(format)
-#endif
 
 PERL_CALLCONV void	Perl_sv_catpvf_mg_nocontext(SV *const sv, const char *const pat, ...)
 			__attribute__format__(__printf__,2,3);
@@ -6991,13 +6748,6 @@ PERL_CALLCONV int	Perl_magic_freecollxfrm(pTHX_ SV* sv, MAGIC* mg);
 PERL_CALLCONV int	Perl_magic_setcollxfrm(pTHX_ SV* sv, MAGIC* mg);
 #define PERL_ARGS_ASSERT_MAGIC_SETCOLLXFRM	\
 	assert(sv); assert(mg)
-#ifndef NO_MATHOMS
-PERL_CALLCONV char*	Perl_mem_collxfrm(pTHX_ const char* input_string, STRLEN len, STRLEN* xlen)
-			__attribute__deprecated__;
-#define PERL_ARGS_ASSERT_MEM_COLLXFRM	\
-	assert(input_string); assert(xlen)
-#endif
-
 #ifndef NO_MATHOMS
 PERL_CALLCONV char*	Perl_sv_collxfrm(pTHX_ SV *const sv, STRLEN *const nxp);
 #define PERL_ARGS_ASSERT_SV_COLLXFRM	\

--- a/sv.c
+++ b/sv.c
@@ -10860,54 +10860,6 @@ Perl_sv_tainted(pTHX_ SV *const sv)
     return FALSE;
 }
 
-#ifndef NO_MATHOMS  /* Can't move these to mathoms.c because call uiv_2buf(),
-                       private to this file */
-
-/*
-=for apidoc sv_setpviv
-=for apidoc_item sv_setpviv_mg
-
-These copy an integer into the given SV, also updating its string value.
-
-They differ only in that C<sv_setpviv_mg> performs 'set' magic; C<sv_setpviv>
-skips any magic.
-
-=cut
-*/
-
-void
-Perl_sv_setpviv(pTHX_ SV *const sv, const IV iv)
-{
-    /* The purpose of this union is to ensure that arr is aligned on
-       a 2 byte boundary, because that is what uiv_2buf() requires */
-    union {
-        char arr[TYPE_CHARS(UV)];
-        U16 dummy;
-    } buf;
-    char *ebuf;
-    char * const ptr = uiv_2buf(buf.arr, iv, 0, 0, &ebuf);
-
-    PERL_ARGS_ASSERT_SV_SETPVIV;
-
-    sv_setpvn(sv, ptr, ebuf - ptr);
-}
-
-void
-Perl_sv_setpviv_mg(pTHX_ SV *const sv, const IV iv)
-{
-    PERL_ARGS_ASSERT_SV_SETPVIV_MG;
-
-    GCC_DIAG_IGNORE_STMT(-Wdeprecated-declarations);
-
-    sv_setpviv(sv, iv);
-
-    GCC_DIAG_RESTORE_STMT;
-
-    SvSETMAGIC(sv);
-}
-
-#endif  /* NO_MATHOMS */
-
 #if defined(MULTIPLICITY)
 
 /* pTHX_ magic can't cope with varargs, so this is a no-context

--- a/utf8.c
+++ b/utf8.c
@@ -2169,43 +2169,6 @@ Perl_utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
     return utf8_to_uvchr_buf_helper(s, send, retlen);
 }
 
-/* This is marked as deprecated
- *
-=for apidoc utf8_to_uvuni_buf
-
-Only in very rare circumstances should code need to be dealing in Unicode
-(as opposed to native) code points.  In those few cases, use
-C<L<NATIVE_TO_UNI(utf8_to_uvchr_buf(...))|perlapi/utf8_to_uvchr_buf>> instead.
-If you are not absolutely sure this is one of those cases, then assume it isn't
-and use plain C<utf8_to_uvchr_buf> instead.
-
-Returns the Unicode (not-native) code point of the first character in the
-string C<s> which
-is assumed to be in UTF-8 encoding; C<send> points to 1 beyond the end of C<s>.
-C<retlen> will be set to the length, in bytes, of that character.
-
-If C<s> does not point to a well-formed UTF-8 character and UTF8 warnings are
-enabled, zero is returned and C<*retlen> is set (if C<retlen> isn't
-NULL) to -1.  If those warnings are off, the computed value if well-defined (or
-the Unicode REPLACEMENT CHARACTER, if not) is silently returned, and C<*retlen>
-is set (if C<retlen> isn't NULL) so that (S<C<s> + C<*retlen>>) is the
-next possible position in C<s> that could begin a non-malformed character.
-See L<perlapi/utf8n_to_uvchr> for details on when the REPLACEMENT CHARACTER is
-returned.
-
-=cut
-*/
-
-UV
-Perl_utf8_to_uvuni_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
-{
-    PERL_ARGS_ASSERT_UTF8_TO_UVUNI_BUF;
-
-    assert(send > s);
-
-    return NATIVE_TO_UNI(utf8_to_uvchr_buf(s, send, retlen));
-}
-
 /*
 =for apidoc utf8_length
 


### PR DESCRIPTION
Most of these have been deprecated for a long time; and we've never
bothered to follow through in removing them.  This commit does that.