### PR TITLE
Fix building with clang-cl

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -408,6 +408,7 @@ Claes Jacobsson <claes@surfar.nu> Claes Jacobsson <claes@surfar.nu>
 Claes Jacobsson <claes@surfar.nu> Claes Jakobsson <claes@surfar.nu>
 Claes Jacobsson <claes@surfar.nu> Claes Jakobsson <claes@versed.se>
 Claudio Ramirez <nxadm@cpan.org> Claudio Ramirez <nxadm@cpan.org>
+Clemens Wasser <clemens.wasser@gmail.com> Clemens Wasser <clemens.wasser@gmail.com>
 Clinton A. Pierce <clintp@geeksalad.org> Clinton A. Pierce <clintp@geeksalad.org>
 Clinton A. Pierce <clintp@geeksalad.org> Clinton Pierce <cpierce1@ford.com>
 Clinton Gormley <unknown> Clinton Gormley <unknown>

--- a/AUTHORS
+++ b/AUTHORS
@@ -283,6 +283,7 @@ Chunhui Teng                   <cteng@nortel.ca>
 Claes Jacobsson                <claes@surfar.nu>
 Clark Cooper                   <coopercc@netheaven.com>
 Claudio Ramirez                <nxadm@cpan.org>
+Clemens Wasser                 <clemens.wasser@gmail.com>
 Clinton A. Pierce              <clintp@geeksalad.org>
 Clinton Gormley
 Colin Kuskie                   <ckuskie@cadence.com>

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -284,8 +284,8 @@ MSVC_DIAG_RESTORE
    importing __PL_nan_u across DLL boundaries in size in the importing DLL
    will be more than the 8 bytes it will take up being in each XS DLL if
    that DLL actually uses __PL_nan_u */
-extern const __declspec(selectany) union { unsigned __int64 __q; double __d; }
-__PL_nan_u = { 0x7FF8000000000000UI64 };
+union PerlNan { unsigned __int64 __q; double __d; };
+extern const __declspec(selectany) union PerlNan __PL_nan_u = { 0x7FF8000000000000UI64 };
 #define NV_NAN ((NV)__PL_nan_u.__d)
 
 /* The CRT was rewritten in VS2015. */


### PR DESCRIPTION
As mentioned in https://lists.llvm.org/pipermail/llvm-dev/2015-July/088122.html
and https://github.com/llvm/llvm-project/issues/24625 building with clang-cl currently fails due to the declaration of __PL_nan_u.
By declaring it like this, cl and clang-cl are happy to parse it.