### PR TITLE
ci: add build for Windows on Arm

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -375,6 +375,40 @@ jobs:
           cd win32
           nmake CCTYPE=MSVC142 test
 
+  #
+  #          _           _                                               __   _  _
+  # __      _(_)_ __   __| | _____      _____        __ _ _ __ _ __ ___  / /_ | || |
+  # \ \ /\ / / | '_ \ / _` |/ _ \ \ /\ / / __|_____ / _` | '__| '_ ` _ \| '_ \| || |_
+  #  \ V  V /| | | | | (_| | (_) \ V  V /\__ \_____| (_| | |  | | | | | | (_) |__   _|
+  #   \_/\_/ |_|_| |_|\__,_|\___/ \_/\_/ |___/      \__,_|_|  |_| |_| |_|\___/   |_|
+  #
+
+  windows-arm64-msvc142:
+    name: "Windows on Arm msvc142"
+    runs-on: windows-2019
+    timeout-minutes: 120
+    needs: sanity_check
+    if: needs.sanity_check.outputs.run_all_jobs == 'true'
+
+    steps:
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@v2
+      - name: Build
+        shell: cmd
+        run: |
+          cd win32
+          :: first, we need some x64 binaries
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          nmake CCTYPE=MSVC142 ../generate_uudmap.exe ../miniperl.exe ../perlglob.exe
+          :: then switch to arm64
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64_arm64
+          :: override PROCESSOR_ARCHITECTURE to define target
+          set PROCESSOR_ARCHITECTURE=ARM64
+          nmake CCTYPE=MSVC142 ../perl.exe
+          :: show architecture for perl binary
+          cd ..
+          dumpbin /headers perl.exe
+
   #            _                       __   _  _
   #  _ __ ___ (_)_ __   __ ___      __/ /_ | || |
   # | '_ ` _ \| | '_ \ / _` \ \ /\ / / '_ \| || |_

--- a/AUTHORS
+++ b/AUTHORS
@@ -1102,6 +1102,7 @@ Philip Newton                  <pne@cpan.org>
 Philippe Bruhat (BooK)         <book@cpan.org>
 Philippe M. Chiasson           <gozer@ActiveState.com>
 Pierre Bogossian               <bogossian@mail.com>
+Pierrick Bouvier               <pierrick.bouvier@linaro.org>
 Piers Cawley                   <pdcawley@bofh.org.uk>
 Pino Toscano                   <pino@debian.org>
 Piotr Fusik                    <pfusik@op.pl>


### PR DESCRIPTION
Since Github Actions does not offer environment for Windows on Arm, we
can only compile this target, and not run any tests.

Since perl build uses some binaries, we must build in two steps.
First, create those binaries (x64), and then compile perl itself for arm64.