### PR TITLE
GDBM_File: fix fetching mmapsize

### DIFF
--- a/ext/GDBM_File/GDBM_File.pm
+++ b/ext/GDBM_File/GDBM_File.pm
@@ -733,7 +733,7 @@ require XSLoader;
 );
 
 # This module isn't dual life, so no need for dev version numbers.
-$VERSION = '1.23';
+$VERSION = '1.24';
 
 our $gdbm_errno;
 

--- a/ext/GDBM_File/GDBM_File.xs
+++ b/ext/GDBM_File/GDBM_File.xs
@@ -878,7 +878,7 @@ gdbm_flags(db, ...)
     PREINIT:
         int opcode = -1;
         int c_iv;
-        unsigned c_uv;
+        size_t c_uv;
         char *c_cv;
         OPTVALPTR vptr = (OPTVALPTR) &c_iv;
         size_t vsiz = sizeof(c_iv);

--- a/ext/GDBM_File/t/opt.t
+++ b/ext/GDBM_File/t/opt.t
@@ -14,7 +14,7 @@ BEGIN {
     plan(skip_all => "GDBM_File is flaky in $^O")
         if $^O =~ /darwin/;
 
-    plan(tests => 8);
+    plan(tests => 9);
     use_ok('GDBM_File');
 }
 
@@ -34,4 +34,9 @@ SKIP: {
      is($db->sync_mode, 0, 'get sync_mode');
      is($db->sync_mode(1), 1, 'set sync_mode');
      is($db->sync_mode, 1, 'get sync_mode');
+   SKIP: {
+         my ($maj, $min) = GDBM_File->GDBM_version;
+         skip "gdbm too old", 1 if $maj != 1 || $maj == 1 && $min < 9;
+         isnt($db->mmapsize, 0, "get mmapsize");
+     }
 }


### PR DESCRIPTION
Originally this came up from a Coverity complaint.

GDBM_SETMAXMAPSIZE accepts any of unsigned, unsigned long or size_t,
but GDBM_GETMAXMAPSIZE only accepts size_t.  Since this is the only
case that uses unsigned values we can safely switch it to size_t.

Unfortunately Coverity's analysis was pretty broken, it complained
about c_uv being uninitialised at the call to newSVuv, but its example
code flow went through the opt_dbname case, which sets vptr to != &c_uv
so the newSVuv() wouldn't execute anyway.

Before looking closely at the Coverity analysis and after finding the
bug fixed here I thought for a moment that Coverity had been tracing
into libgdbm, which could have caught the actual problem, but alas
that was not the case.

I expect this fix will not close CID 351943, and if it remains after
this is applied I'll close it as a false positive.

CID 351943.