### PR TITLE
proto.h: Fix build with gcc-12

### DIFF
--- a/proto.h
+++ b/proto.h
@@ -5769,50 +5769,43 @@ STATIC SSize_t	S_unpack_rec(pTHX_ struct tempsym* symptr, const char *s, const c
 #endif
 #if defined(PERL_IN_PP_SORT_C)
 #ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_FORCE_INLINE I32	S_amagic_cmp(pTHX_ SV *const str1, SV *const str2)
-			__attribute__always_inline__;
+PERL_STATIC_FORCE_INLINE I32	S_amagic_cmp(pTHX_ SV *const str1, SV *const str2);
 #define PERL_ARGS_ASSERT_AMAGIC_CMP	\
 	assert(str1); assert(str2)
 #endif
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_FORCE_INLINE I32	S_amagic_cmp_desc(pTHX_ SV *const str1, SV *const str2)
-			__attribute__always_inline__;
+PERL_STATIC_FORCE_INLINE I32	S_amagic_cmp_desc(pTHX_ SV *const str1, SV *const str2);
 #define PERL_ARGS_ASSERT_AMAGIC_CMP_DESC	\
 	assert(str1); assert(str2)
 #endif
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_FORCE_INLINE I32	S_amagic_i_ncmp(pTHX_ SV *const a, SV *const b)
-			__attribute__always_inline__;
+PERL_STATIC_FORCE_INLINE I32	S_amagic_i_ncmp(pTHX_ SV *const a, SV *const b);
 #define PERL_ARGS_ASSERT_AMAGIC_I_NCMP	\
 	assert(a); assert(b)
 #endif
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_FORCE_INLINE I32	S_amagic_i_ncmp_desc(pTHX_ SV *const a, SV *const b)
-			__attribute__always_inline__;
+PERL_STATIC_FORCE_INLINE I32	S_amagic_i_ncmp_desc(pTHX_ SV *const a, SV *const b);
 #define PERL_ARGS_ASSERT_AMAGIC_I_NCMP_DESC	\
 	assert(a); assert(b)
 #endif
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_FORCE_INLINE I32	S_amagic_ncmp(pTHX_ SV *const a, SV *const b)
-			__attribute__always_inline__;
+PERL_STATIC_FORCE_INLINE I32	S_amagic_ncmp(pTHX_ SV *const a, SV *const b);
 #define PERL_ARGS_ASSERT_AMAGIC_NCMP	\
 	assert(a); assert(b)
 #endif
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_FORCE_INLINE I32	S_amagic_ncmp_desc(pTHX_ SV *const a, SV *const b)
-			__attribute__always_inline__;
+PERL_STATIC_FORCE_INLINE I32	S_amagic_ncmp_desc(pTHX_ SV *const a, SV *const b);
 #define PERL_ARGS_ASSERT_AMAGIC_NCMP_DESC	\
 	assert(a); assert(b)
 #endif
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_FORCE_INLINE I32	S_cmp_desc(pTHX_ SV *const str1, SV *const str2)
-			__attribute__always_inline__;
+PERL_STATIC_FORCE_INLINE I32	S_cmp_desc(pTHX_ SV *const str1, SV *const str2);
 #define PERL_ARGS_ASSERT_CMP_DESC	\
 	assert(str1); assert(str2)
 #endif
@@ -5834,51 +5827,44 @@ PERL_STATIC_FORCE_INLINE void	S_sortsv_flags_impl(pTHX_ SV** array, size_t num_e
 #endif
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_FORCE_INLINE I32	S_sv_i_ncmp(pTHX_ SV *const a, SV *const b)
-			__attribute__always_inline__;
+PERL_STATIC_FORCE_INLINE I32	S_sv_i_ncmp(pTHX_ SV *const a, SV *const b);
 #define PERL_ARGS_ASSERT_SV_I_NCMP	\
 	assert(a); assert(b)
 #endif
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_FORCE_INLINE I32	S_sv_i_ncmp_desc(pTHX_ SV *const a, SV *const b)
-			__attribute__always_inline__;
+PERL_STATIC_FORCE_INLINE I32	S_sv_i_ncmp_desc(pTHX_ SV *const a, SV *const b);
 #define PERL_ARGS_ASSERT_SV_I_NCMP_DESC	\
 	assert(a); assert(b)
 #endif
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_FORCE_INLINE I32	S_sv_ncmp(pTHX_ SV *const a, SV *const b)
-			__attribute__always_inline__;
+PERL_STATIC_FORCE_INLINE I32	S_sv_ncmp(pTHX_ SV *const a, SV *const b);
 #define PERL_ARGS_ASSERT_SV_NCMP	\
 	assert(a); assert(b)
 #endif
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_FORCE_INLINE I32	S_sv_ncmp_desc(pTHX_ SV *const a, SV *const b)
-			__attribute__always_inline__;
+PERL_STATIC_FORCE_INLINE I32	S_sv_ncmp_desc(pTHX_ SV *const a, SV *const b);
 #define PERL_ARGS_ASSERT_SV_NCMP_DESC	\
 	assert(a); assert(b)
 #endif
 
 #  if defined(USE_LOCALE_COLLATE)
 #ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_FORCE_INLINE I32	S_amagic_cmp_locale(pTHX_ SV *const str1, SV *const str2)
-			__attribute__always_inline__;
+PERL_STATIC_FORCE_INLINE I32	S_amagic_cmp_locale(pTHX_ SV *const str1, SV *const str2);
 #define PERL_ARGS_ASSERT_AMAGIC_CMP_LOCALE	\
 	assert(str1); assert(str2)
 #endif
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_FORCE_INLINE I32	S_amagic_cmp_locale_desc(pTHX_ SV *const str1, SV *const str2)
-			__attribute__always_inline__;
+PERL_STATIC_FORCE_INLINE I32	S_amagic_cmp_locale_desc(pTHX_ SV *const str1, SV *const str2);
 #define PERL_ARGS_ASSERT_AMAGIC_CMP_LOCALE_DESC	\
 	assert(str1); assert(str2)
 #endif
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_FORCE_INLINE I32	S_cmp_locale_desc(pTHX_ SV *const str1, SV *const str2)
-			__attribute__always_inline__;
+PERL_STATIC_FORCE_INLINE I32	S_cmp_locale_desc(pTHX_ SV *const str1, SV *const str2);
 #define PERL_ARGS_ASSERT_CMP_LOCALE_DESC	\
 	assert(str1); assert(str2)
 #endif


### PR DESCRIPTION
Fixes:
  In function 'dynprep',
    inlined from 'S_sortsv_flags_impl' at pp_sort.c:358:20,
    inlined from 'sortsv_amagic_i_ncmp' at pp_sort.c:572:5:
    pp_sort.c:1232:1: error: inlining failed in call to 'always_inline' 'S_amagic_i_ncmp': function not considered for inlining
  1232 | S_amagic_i_ncmp(pTHX_ SV *const a, SV *const b)

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>