### PR TITLE
RMG: Add step for deprecation/experimental resolution

### DIFF
--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -1604,6 +1604,18 @@ Go over your notes from the release (you did take some, right?) and update
 F<Porting/release_managers_guide.pod> with any fixes or information that
 will make life easier for the next release manager.
 
+=head3 For a BLEAD-POINT .0 release
+
+This is the time for the project to decide the fate and begin to
+implement the required changes for experimental/deprecated features and
+API elements for the next BLEAD-FINAL, a year away.
+
+Fortunately your job is not to do this yourself, but merely to remind
+people that this needs to get done.  Send email to
+L<p5p|mailto:perl5-porters@perl.org>.  All of L<perlexperiment>,
+L<perldeprecation>, F<mathoms.c>, L<perlapi>, and L<perlintern> need to
+be considered.
+
 =for checklist end
 
 =head1 SOURCE


### PR DESCRIPTION
At the beginning of the development cycle, the project should look ahead at what to do about experimental/deprecated features.  Some are coming due this cycle, so email should be sent to p5p to lower the possibility of their falling through the cracks