### PR TITLE
GH19478: applying taint is no reason to mess with pos

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -5825,16 +5825,6 @@ Perl_sv_magic(pTHX_ SV *const sv, SV *const obj, const int how,
         }
     }
 
-    /* Force pos to be stored as characters, not bytes. */
-    if (SvMAGICAL(sv) && DO_UTF8(sv)
-      && (mg = mg_find(sv, PERL_MAGIC_regex_global))
-      && mg->mg_len != -1
-      && mg->mg_flags & MGf_BYTES) {
-        mg->mg_len = (SSize_t)sv_pos_b2u_flags(sv, (STRLEN)mg->mg_len,
-                                               SV_CONST_RETURN);
-        mg->mg_flags &= ~MGf_BYTES;
-    }
-
     /* Rest of work is done else where */
     mg = sv_magicext(sv,obj,how,vtable,name,namlen);
 

--- a/t/op/taint.t
+++ b/t/op/taint.t
@@ -25,7 +25,7 @@ if ($NoTaintSupport) {
     exit 0;
 }
 
-plan tests => 1061;
+plan tests => 1065;
 
 $| = 1;
 
@@ -2968,6 +2968,18 @@ is_tainted("$ovtaint", "overload preserves taint");
     taint_sig3($TAINT);
 }
 
+{
+	# GH 19478: panic on s///gre with tainted utf8 strings
+	my $u = "\x{10469}";
+	my $r1 = ("foo$TAINT" =~ s/./"$u"/gre);
+	is($r1, "$u$u$u", 'tainted string with utf8 s/.//gre');
+	my $r2 = ("foo$TAINT" =~ s/.*/"${u}"/gre);
+	is($r2, "$u$u", 'tainted string with utf8 s/.*//gre');
+	my $r3 = ("foo$TAINT" =~ s/.+/"${u}"/gre);
+	is($r3, $u, 'tainted string with utf8 s/.+//gre');
+	my $r4 = ("$u$TAINT" =~ s/./""/gre);
+	is($r4, '', 'tainted utf8 string with s///gre');
+}
 
 # This may bomb out with the alarm signal so keep it last
 SKIP: {


### PR DESCRIPTION
25fdce4a16 introduced a chunk in sv_magic() to "force pos to be stored
as characters, not bytes" whenever any magic was applied to a string
marked UTF8.

It is not clear why a random call to sv_magic(), eg to mark a string as
tainted, needs to do this - it would seem more logical for the check to
happen either earlier (when the string first qualifies as SvMAGICAL(sv)
&& DO_UTF8(sv)) or later (eg on mg_find).

Experimentally remove this block - it appears to cause no test failures,
and allows the new test cases to pass.