### PR TITLE
opt.t: Fix count of tests to be skipped

### DIFF
--- a/ext/GDBM_File/t/opt.t
+++ b/ext/GDBM_File/t/opt.t
@@ -25,7 +25,7 @@ my $db = tie(%h, 'GDBM_File', $dbname, GDBM_WRCREAT, 0640);
 isa_ok($db, 'GDBM_File');
 SKIP: {
      my $name = eval { $db->dbname } or do {
-         skip "gdbm_setopt GET calls not implemented", 6
+         skip "gdbm_setopt GET calls not implemented", 7
              if $@ =~ /GDBM_File::dbname not implemented/;
      };
      is($db->dbname, $dbname, 'get dbname');


### PR DESCRIPTION
In https://perl5.test-smoke.org/report/5019104 I am observing a test failure not previously seen in `ext/GDBM_File/t/opt.t`.  This failure appears in all configurations:
```
$ uname -mrs
Linux 5.10.13-x86_64-linode141 x86_64
$ git describe
v5.37.0-112-gaecef8c
$ cd t;./perl harness -v ../ext/GDBM_File/t/opt.t; cd -

ok 1 - use GDBM_File;
ok 2 - An object of class 'GDBM_File' isa 'GDBM_File'
ok 3 # skip gdbm_setopt GET calls not implemented
ok 4 # skip gdbm_setopt GET calls not implemented
ok 5 # skip gdbm_setopt GET calls not implemented
ok 6 # skip gdbm_setopt GET calls not implemented
ok 7 # skip gdbm_setopt GET calls not implemented
ok 8 # skip gdbm_setopt GET calls not implemented
# Looks like you planned 9 tests but ran 8.
Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 1/9 subtests 
	(less 6 skipped subtests: 2 okay)

Test Summary Report
-------------------
../ext/GDBM_File/t/opt.t (Wstat: 65280 (exited 255) Tests: 8 Failed: 0)
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 9 tests but ran 8.
Files=1, Tests=8,  0 wallclock secs ( 0.01 usr  0.01 sys +  0.09 cusr  0.01 csys =  0.12 CPU)
Result: FAIL
```
This failure was probably introduced in 34e6e2fba776f00fec86643349436bb01ce33e85.
```
commit 34e6e2fba776f00fec86643349436bb01ce33e85
Author:     Tony Cook <tony@develop-help.com>
AuthorDate: Thu Jun 2 11:01:44 2022 +1000
Commit:     Tony Cook <tony@develop-help.com>
CommitDate: Fri Jun 3 10:31:56 2022 +1000

    GDBM_File: fix fetching mmapsize
```
The problem is the `SKIP` count within nested `SKIP` blocks.  This pull request fixes the test on the machine where the failure was observed.

@tonycoz, can you take a look?