### PR TITLE
Fix indentation in op.c to not be misleading

### DIFF
--- a/op.c
+++ b/op.c
@@ -16278,9 +16278,8 @@ S_aassign_scan(pTHX_ OP* o, bool rhs, int *scalars_p)
             if (o == effective_top_op)
                 effective_top_op = next_kid;
         }
-        else
-            if (o == effective_top_op)
-                effective_top_op = o->op_sibparent;
+        else if (o == effective_top_op)
+            effective_top_op = o->op_sibparent;
         o = o->op_sibparent; /* try parent's next sibling */
     }
     o = next_kid;

--- a/op.c
+++ b/op.c
@@ -16281,8 +16281,7 @@ S_aassign_scan(pTHX_ OP* o, bool rhs, int *scalars_p)
         else
             if (o == effective_top_op)
                 effective_top_op = o->op_sibparent;
-            o = o->op_sibparent; /* try parent's next sibling */
-
+        o = o->op_sibparent; /* try parent's next sibling */
     }
     o = next_kid;
     } /* while */


### PR DESCRIPTION
gcc did not previously warn about this code, but in my branch where I split the giant `op.c` file into some smaller parts, it started warning:

```
peep.c: In function ‘S_aassign_scan’:
peep.c:1292:9: warning: this ‘else’ clause does not guard... [-Wmisleading-indentation]
 1292 |         else
      |         ^~~~
peep.c:1295:13: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘else’
 1295 |             o = o->op_sibparent; /* try parent's next sibling */
      |             ^
```

I suspect it just gave up when it was in `op.c` because the file was so long, but in the smaller `peep.c` it noticed the problem.

I've also generally reïndented the body of the file so it now matches the code.

This is a **whitespace-only** change and should not cause any changes in behaviour.