### PR TITLE
fix no bareword_filehandles for method calls as first argument of LSTOPs

### DIFF
--- a/t/lib/feature/bareword_filehandles
+++ b/t/lib/feature/bareword_filehandles
@@ -362,6 +362,26 @@ no feature "bareword_filehandles";
 accept(FOO, CHILD);
 accept($fh, CHILD);
 accept(FOO, $fh);
+accept(*FOO, *CHILD);
+EXPECT
+OPTIONS fatal
+Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 5.
+Bareword filehandle "CHILD" not allowed under 'no feature "bareword_filehandles"' at - line 5.
+Bareword filehandle "CHILD" not allowed under 'no feature "bareword_filehandles"' at - line 6.
+Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 7.
+Execution of - aborted due to compilation errors.
+########
+# NAME accept some more
+accept FOO, CHILD ;
+accept $fh, CHILD ;
+accept FOO, $fh ;
+no feature "bareword_filehandles";
+accept FOO, CHILD ;
+accept $fh, CHILD ;
+accept FOO, $fh;
+package BAR {}
+accept QUUX BAR, $fh;
+sub BAR::QUUX { $fh }
 EXPECT
 OPTIONS fatal
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 5.
@@ -495,4 +515,17 @@ say foo();
 say foo;
 -x foo();
 -x foo;
+EXPECT
+########
+# NAME method calls
+# https://github.com/Perl/perl5/issues/19704
+use feature "say";
+no feature "bareword_filehandles";
+sub foo {}
+print main->foo();
+print main->foo;
+say main->foo();
+say main->foo;
+-x main->foo();
+-x main->foo;
 EXPECT

--- a/toke.c
+++ b/toke.c
@@ -7622,12 +7622,6 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 orig_keyword, struct code c)
         }
         s = SvPVX(PL_linestr) + s_off;
 
-        if (((PL_opargs[PL_last_lop_op] >> OASHIFT) & 7) == OA_FILEREF
-            && !immediate_paren && !c.cv
-            && !FEATURE_BAREWORD_FILEHANDLES_IS_ENABLED) {
-            no_bareword_filehandle(PL_tokenbuf);
-        }
-
         /* If not a declared subroutine, it's an indirect object. */
         /* (But it's an indir obj regardless for sort.) */
         /* Also, if "_" follows a filetest operator, it's a bareword */


### PR DESCRIPTION
The original code in toke.c tried to detect a bareword as a
file handle during tokenization rather than once the expression
following the LSTOP has been parsed.

I've moved the checking for a bareword filehandle to the ck functions
for each OP in most cases, which covers most OPs except for LSTOPs
like print.

To handle that I've added a check in newGVREF().

This means in most cases that the error is produced just as the
bareword would normally be wrapped in an OP_RV2GV.

The special case for that is readline(), which does it's own
rv2gv() at runtime, but it does have a ck function which can check
for the bareword handle.

fixes #19704 