### PR TITLE
minitest_prep conflict on building $(MINIPERL_EXE)

### DIFF
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -1633,7 +1633,7 @@ $spitshell >>$Makefile <<'!NO!SUBS!'
 
 # minitest can't depend on lib/Config.pm because that might be where miniperl
 # is crashing.
-minitest_prep:
+minitest_prep: $(MINIPERL_EXE)
 	-@test -f lib/Config.pm || $(MAKE) lib/Config.pm $(unidatafiles)
 	@echo " "
 	@echo "You may see some irrelevant test failures if you have been unable"
@@ -1643,10 +1643,10 @@ minitest_prep:
 
 MINITEST_TESTS = base/*.t comp/*.t cmd/*.t run/*.t io/*.t re/*.t opbasic/*.t op/*.t uni/*.t perf/*.t
 
-minitest: $(MINIPERL_EXE) minitest_prep
+minitest: minitest_prep
 	cd t && $(RUN_PERL) TEST $(MINITEST_TESTS) <$(devtty)
 
-minitest-notty minitest_notty: $(MINIPERL_EXE) minitest_prep
+minitest-notty minitest_notty: minitest_prep
 	cd t && PERL_SKIP_TTY_TEST=1 $(RUN_PERL) TEST $(MINITEST_TESTS)
 
 # Test via harness


### PR DESCRIPTION
minitest depends on $(MINIPERL_EXE) and minitest_prep, but
minitest_prep calls back into make to build lib/Config.pm which
indirectly depends on $(MINIPERL_EXE).

This can result in a race between the parallel work of the parent
make and the work of the child make, as they both try to build
$(MINIPERL_EXE) and its dependencies, causing some of the errors
described in the ticket.

Note that trying to `make -j6 minitest all` could lead to
similar conflicts, but I think that's an unlikely and not worth
supporting anyway.

Fixes #19829 (I think)