### PR TITLE
Add perlstatic.h

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5232,6 +5232,7 @@ perlio.h			PerlIO abstraction
 perlio.sym			Symbols for PerlIO abstraction
 perliol.h			PerlIO Layer definition
 perlsdio.h			Fake stdio using perlio
+perlstatic.h			Like inline.h, but functions not declared inline
 perlvars.h			Global variables
 perly.act			parser actions; derived from perly.y
 perly.c				parser code (NOT derived from perly.y)

--- a/XSUB.h
+++ b/XSUB.h
@@ -74,28 +74,28 @@ Macro to declare an XSUB and its C parameter list explicitly exporting the symbo
 Macro used by C<L</XS_INTERNAL>> and C<L</XS_EXTERNAL>> to declare a function
 prototype.  You probably shouldn't be using this directly yourself.
 
-=for apidoc Amns||dAX
+=for apidoc Amn;||dAX
 Sets up the C<ax> variable.
 This is usually handled automatically by C<xsubpp> by calling C<dXSARGS>.
 
-=for apidoc Amns||dAXMARK
+=for apidoc Amn;||dAXMARK
 Sets up the C<ax> variable and stack marker variable C<mark>.
 This is usually handled automatically by C<xsubpp> by calling C<dXSARGS>.
 
-=for apidoc Amns||dITEMS
+=for apidoc Amn;||dITEMS
 Sets up the C<items> variable.
 This is usually handled automatically by C<xsubpp> by calling C<dXSARGS>.
 
-=for apidoc Amns||dXSARGS
+=for apidoc Amn;||dXSARGS
 Sets up stack and mark pointers for an XSUB, calling C<dSP> and C<dMARK>.
 Sets up the C<ax> and C<items> variables by calling C<dAX> and C<dITEMS>.
 This is usually handled automatically by C<xsubpp>.
 
-=for apidoc Amns||dXSI32
+=for apidoc Amn;||dXSI32
 Sets up the C<ix> variable for an XSUB which has aliases.  This is usually
 handled automatically by C<xsubpp>.
 
-=for apidoc Amns||dUNDERBAR
+=for apidoc Amn;||dUNDERBAR
 Sets up any variable needed by the C<UNDERBAR> macro.  It used to define
 C<padoff_du>, but it is currently a noop.  However, it is strongly advised
 to still use it for ensuring past and future compatibility.
@@ -261,16 +261,16 @@ Return a double from an XSUB immediately.  Uses C<XST_mNV>.
 =for apidoc Am|void|XSRETURN_PV|char* str
 Return a copy of a string from an XSUB immediately.  Uses C<XST_mPV>.
 
-=for apidoc Amns||XSRETURN_NO
+=for apidoc Amn;||XSRETURN_NO
 Return C<&PL_sv_no> from an XSUB immediately.  Uses C<XST_mNO>.
 
-=for apidoc Amns||XSRETURN_YES
+=for apidoc Amn;||XSRETURN_YES
 Return C<&PL_sv_yes> from an XSUB immediately.  Uses C<XST_mYES>.
 
-=for apidoc Amns||XSRETURN_UNDEF
+=for apidoc Amn;||XSRETURN_UNDEF
 Return C<&PL_sv_undef> from an XSUB immediately.  Uses C<XST_mUNDEF>.
 
-=for apidoc Amns||XSRETURN_EMPTY
+=for apidoc Amn;||XSRETURN_EMPTY
 Return an empty list from an XSUB immediately.
 
 =for apidoc AmU||newXSproto|char* name|XSUBADDR_t f|char* filename|const char *proto
@@ -282,18 +282,18 @@ The version identifier for an XS module.  This is usually
 handled automatically by C<ExtUtils::MakeMaker>.  See
 C<L</XS_VERSION_BOOTCHECK>>.
 
-=for apidoc Amns||XS_VERSION_BOOTCHECK
+=for apidoc Amn;||XS_VERSION_BOOTCHECK
 Macro to verify that a PM module's C<$VERSION> variable matches the XS
 module's C<XS_VERSION> variable.  This is usually handled automatically by
 C<xsubpp>.  See L<perlxs/"The VERSIONCHECK: Keyword">.
 
-=for apidoc Amns||XS_APIVERSION_BOOTCHECK
+=for apidoc Amn;||XS_APIVERSION_BOOTCHECK
 Macro to verify that the perl api version an XS module has been compiled against
 matches the api version of the perl interpreter it's being loaded into.
 
 =for apidoc_section $exceptions
 
-=for apidoc Amns||dXCPT
+=for apidoc Amn;||dXCPT
 Set up necessary local variables for exception handling.
 See L<perlguts/"Exception Handling">.
 
@@ -306,7 +306,7 @@ Ends a try block.  See L<perlguts/"Exception Handling">.
 =for apidoc AmnU||XCPT_CATCH
 Introduces a catch block.  See L<perlguts/"Exception Handling">.
 
-=for apidoc Amns||XCPT_RETHROW
+=for apidoc Amn;||XCPT_RETHROW
 Rethrows a previously caught exception.  See L<perlguts/"Exception Handling">.
 
 =cut

--- a/autodoc.pl
+++ b/autodoc.pl
@@ -369,7 +369,7 @@ my $apidoc_re = qr/ ^ (\s*)            # $1
                       (.*?)            # $7
                       \s* \n /x;
 # Only certain flags, dealing with display, are acceptable for apidoc_item
-my $display_flags = "fFnDopsTx";
+my $display_flags = "fFnDopTx;";
 
 sub check_api_doc_line ($$) {
     my ($file, $in) = @_;
@@ -529,7 +529,7 @@ sub autodoc ($$) { # parse a file and extract documentation info
             }
 
             die "flag '$1' is not legal (for function $element_name (from $file))"
-                        if $flags =~ / ( [^AabCDdEeFfGhiIMmNnTOoPpRrSsUuWXxy] ) /x;
+                        if $flags =~ / ( [^AabCDdEeFfGhiIMmNnTOoPpRrSUuWXxy;] ) /x;
 
             die "'u' flag must also have 'm' or 'y' flags' for $element_name"
                                             if $flags =~ /u/ && $flags !~ /[my]/;
@@ -664,7 +664,7 @@ sub autodoc ($$) { # parse a file and extract documentation info
                 # Don't output a usage example for linked to documentation if
                 # it is trivial (has no arguments) and we aren't to add a
                 # semicolon
-                $flags .= 'U' if $flags =~ /n/ && $flags !~ /[Us]/;
+                $flags .= 'U' if $flags =~ /n/ && $flags !~ /[U;]/;
 
                 # Keep track of all the pod files that we refer to.
                 push $described_elsewhere{$podname}->@*, $podname;
@@ -1328,8 +1328,8 @@ sub docout ($$$) { # output the docs for one function group
 
     if ($flags =~ /[Uy]/) { # no usage; typedefs are considered simple enough
                             # to never warrant a usage line
-        warn("U and s flags are incompatible")
-                                            if $flags =~ /U/ && $flags =~ /s/;
+        warn("U and ; flags are incompatible")
+                                            if $flags =~ /U/ && $flags =~ /;/;
         # nothing
     } else {
 
@@ -1492,7 +1492,7 @@ sub docout ($$$) { # output the docs for one function group
                     print $fh ")";
                 }
 
-                print $fh ";" if $item_flags =~ /s/; # semicolon: "dTHR;"
+                print $fh ";" if $item_flags =~ /;/; # semicolon: "dTHR;"
                 print $fh "\n";
 
                 # Only the first entry is normally displayed

--- a/cop.h
+++ b/cop.h
@@ -1217,17 +1217,17 @@ program; otherwise 0;
 /*
 =for apidoc_section $multicall
 
-=for apidoc Amns||dMULTICALL
+=for apidoc Amn;||dMULTICALL
 Declare local variables for a multicall.  See L<perlcall/LIGHTWEIGHT CALLBACKS>.
 
-=for apidoc Ams||PUSH_MULTICALL|CV* the_cv
+=for apidoc Am;||PUSH_MULTICALL|CV* the_cv
 Opening bracket for a lightweight callback.
 See L<perlcall/LIGHTWEIGHT CALLBACKS>.
 
-=for apidoc Amns||MULTICALL
+=for apidoc Amn;||MULTICALL
 Make a lightweight callback.  See L<perlcall/LIGHTWEIGHT CALLBACKS>.
 
-=for apidoc Amns||POP_MULTICALL
+=for apidoc Amn;||POP_MULTICALL
 Closing bracket for a lightweight callback.
 See L<perlcall/LIGHTWEIGHT CALLBACKS>.
 

--- a/embed.fnc
+++ b/embed.fnc
@@ -500,8 +500,6 @@
 :                STATIC is added to declaration;
 :         embed.h: "#define foo S_foo" entries added
 :
-:   s  autodoc.pl adds a terminating semi-colon to the usage example in the
-:      documentation.
 :
 :   T  Has no implicit interpreter/thread context argument:
 :
@@ -548,6 +546,9 @@
 :         even if it is allegedly API.
 :
 :   y  Typedef.  The element names a type rather than being a macro
+:
+:   ;  autodoc.pl adds a terminating semi-colon to the usage example in the
+:      documentation.
 :
 : In this file, pointer parameters that must not be passed NULLs should be
 : prefixed with NN.

--- a/embed.fnc
+++ b/embed.fnc
@@ -500,6 +500,14 @@
 :                STATIC is added to declaration;
 :         embed.h: "#define foo S_foo" entries added
 :
+:   s  Static function, but function in source code has a Perl_ prefix:
+:
+:	This is used for functions that have always had a Perl_ prefix, but
+:	have been moved to a header file and declared static.
+:
+:         proto.h: function is declared as Perl_foo rather than foo
+:                STATIC is added to declaration;
+:         embed.h: "#define foo Perl_foo" entries added
 :
 :   T  Has no implicit interpreter/thread context argument:
 :

--- a/embed.fnc
+++ b/embed.fnc
@@ -2696,7 +2696,7 @@ ATdpa	|Malloc_t|safesysmalloc	|MEM_SIZE nbytes
 ATdpa	|Malloc_t|safesyscalloc	|MEM_SIZE elements|MEM_SIZE size
 ATdpR	|Malloc_t|safesysrealloc|Malloc_t where|MEM_SIZE nbytes
 AdTp	|Free_t	|safesysfree	|Malloc_t where
-CrTp	|void	|croak_memory_wrap
+CsrT	|void	|croak_memory_wrap
 Cpdh	|int	|runops_standard
 Cpdh	|int	|runops_debug
 Afpd	|void	|sv_catpvf_mg	|NN SV *const sv|NN const char *const pat|...

--- a/makedef.pl
+++ b/makedef.pl
@@ -696,7 +696,7 @@ unless ($Config{d_wcrtomb}) {
 {
     my %seen;
     my ($embed) = setup_embed($ARGS{TARG_DIR});
-    my $excludedre = $define{'NO_MATHOMS'} ? qr/[emiIb]/ : qr/[emiI]/;
+    my $excludedre = $define{'NO_MATHOMS'} ? qr/[emiIsb]/ : qr/[emiIs]/;
 
     foreach (@$embed) {
 	my ($flags, $retval, $func, @args) = @$_;
@@ -712,7 +712,7 @@ unless ($Config{d_wcrtomb}) {
 	    # mean "don't export"
 	    next if $seen{$func}++;
 	    # Should we also skip adding the Perl_ prefix if $flags =~ /o/ ?
-	    $func = "Perl_$func" if ($flags =~ /[pX]/ && $func !~ /^Perl_/);
+	    $func = "Perl_$func" if ($flags =~ /[psX]/ && $func !~ /^Perl_/);
 	    ++$export{$func} unless exists $skip{$func};
 	}
     }

--- a/perl.h
+++ b/perl.h
@@ -473,18 +473,18 @@ Example usage:
  * but we cannot quite get rid of, such as "ax" in PPCODE+noargs xsubs,
  * or variables/arguments that are used only in certain configurations.
 
-=for apidoc Ams||PERL_UNUSED_ARG|void x
+=for apidoc Am;||PERL_UNUSED_ARG|void x
 This is used to suppress compiler warnings that a parameter to a function is
 not used.  This situation can arise, for example, when a parameter is needed
 under some configuration conditions, but not others, so that C preprocessor
 conditional compilation causes it be used just some times.
 
-=for apidoc Amns||PERL_UNUSED_CONTEXT
+=for apidoc Amn;||PERL_UNUSED_CONTEXT
 This is used to suppress compiler warnings that the thread context parameter to
 a function is not used.  This situation can arise, for example, when a
 C preprocessor conditional compilation causes it be used just some times.
 
-=for apidoc Ams||PERL_UNUSED_VAR|void x
+=for apidoc Am;||PERL_UNUSED_VAR|void x
 This is used to suppress compiler warnings that the variable I<x> is not used.
 This situation can arise, for example, when a C preprocessor conditional
 compilation causes it be used just some times.
@@ -625,11 +625,11 @@ __typeof__ and nothing else.
 #define MSVC_DIAG_RESTORE_STMT MSVC_DIAG_RESTORE NOOP
 
 /*
-=for apidoc Amns||NOOP
+=for apidoc Amn;||NOOP
 Do nothing; typically used as a placeholder to replace something that used to
 do something.
 
-=for apidoc Amns||dNOOP
+=for apidoc Amn;||dNOOP
 Declare nothing; typically used as a placeholder to replace something that used
 to declare something.  Works on compilers that require declarations before any
 code.
@@ -668,7 +668,7 @@ code.
 This is now a synonym for dNOOP: declare nothing
 
 =for apidoc_section $XS
-=for apidoc Amns||dMY_CXT_SV
+=for apidoc Amn;||dMY_CXT_SV
 Now a placeholder that declares nothing
 
 =cut

--- a/perl.h
+++ b/perl.h
@@ -7246,6 +7246,7 @@ cannot have changed since the precalculation.
 
 START_EXTERN_C
 
+#  include "perlstatic.h"
 #  include "inline.h"
 #  include "sv_inline.h"
 

--- a/perlstatic.h
+++ b/perlstatic.h
@@ -1,0 +1,33 @@
+/*    perlstatic.h
+ *
+ *    'I don't know half of you half as well as I should like; and I like less
+ *    than half of you half as well as you deserve.'
+ *
+ *    Copyright (C) 2020 by Larry Wall and others
+ *
+ *    You may distribute under the terms of either the GNU General Public
+ *    License or the Artistic License, as specified in the README file.
+ *
+ * This file is a home for static functions that we don't consider suitable for
+ * inlining, but for which giving the compiler full knowledge of may be
+ * advantageous.  Functions that have potential tail call optimizations are a
+ * likely component.
+
+ */
+
+/* saves machine code for a common noreturn idiom typically used in Newx*() */
+GCC_DIAG_IGNORE_DECL(-Wunused-function);
+
+STATIC void
+Perl_croak_memory_wrap(void)
+{
+    Perl_croak_nocontext("%s",PL_memory_wrap);
+}
+
+GCC_DIAG_RESTORE_DECL;
+
+
+/*
+ * ex: set ts=8 sts=4 sw=4 et:
+ */
+

--- a/pp.h
+++ b/pp.h
@@ -24,28 +24,28 @@ Stack marker variable for the XSUB.  See C<L</dMARK>>.
 Opening bracket for arguments on a callback.  See C<L</PUTBACK>> and
 L<perlcall>.
 
-=for apidoc Amns||dSP
+=for apidoc Amn;||dSP
 Declares a local copy of perl's stack pointer for the XSUB, available via
 the C<SP> macro.  See C<L</SP>>.
 
-=for apidoc ms||djSP
+=for apidoc m;||djSP
 
 Declare Just C<SP>.  This is actually identical to C<dSP>, and declares
 a local copy of perl's stack pointer, available via the C<SP> macro.
 See C<L<perlapi/SP>>.  (Available for backward source code compatibility with
 the old (Perl 5.005) thread model.)
 
-=for apidoc Amns||dMARK
+=for apidoc Amn;||dMARK
 Declare a stack marker variable, C<mark>, for the XSUB.  See C<L</MARK>> and
 C<L</dORIGMARK>>.
 
-=for apidoc Amns||dORIGMARK
+=for apidoc Amn;||dORIGMARK
 Saves the original stack mark for the XSUB.  See C<L</ORIGMARK>>.
 
 =for apidoc AmnU||ORIGMARK
 The original stack mark for the XSUB.  See C<L</dORIGMARK>>.
 
-=for apidoc Amns||SPAGAIN
+=for apidoc Amn;||SPAGAIN
 Refetch the stack pointer.  Used after a callback.  See L<perlcall>.
 
 =cut */
@@ -55,7 +55,7 @@ Refetch the stack pointer.  Used after a callback.  See L<perlcall>.
 #define MARK mark
 
 /*
-=for apidoc Amns||TARG
+=for apidoc Amn;||TARG
 
 C<TARG> is short for "target".  It is an entry in the pad that an OPs
 C<op_targ> refers to.  It is scratchpad space, often used as a return
@@ -103,7 +103,7 @@ value for the OP, but some use it for other purposes.
 #define GETTARGET targ = PAD_SV(PL_op->op_targ)
 
 /*
-=for apidoc Amns||dTARGET
+=for apidoc Amn;||dTARGET
 Declare that this function uses C<TARG>
 
 =cut
@@ -119,7 +119,7 @@ Declare that this function uses C<TARG>
 #define DIE return Perl_die
 
 /*
-=for apidoc Amns||PUTBACK
+=for apidoc Amn;||PUTBACK
 Closing bracket for XSUB arguments.  This is usually handled by C<xsubpp>.
 See C<L</PUSHMARK>> and L<perlcall> for other uses.
 

--- a/proto.h
+++ b/proto.h
@@ -764,7 +764,7 @@ PERL_CALLCONV_NO_RET void	Perl_croak_caller(const char* pat, ...)
 			__attribute__format__null_ok__(__printf__,1,2);
 #define PERL_ARGS_ASSERT_CROAK_CALLER
 
-PERL_CALLCONV_NO_RET void	Perl_croak_memory_wrap(void)
+PERL_STATIC_NO_RET void	Perl_croak_memory_wrap(void)
 			__attribute__noreturn__;
 #define PERL_ARGS_ASSERT_CROAK_MEMORY_WRAP
 

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -140,15 +140,17 @@ my ($embed, $core, $ext, $api) = setup_embed();
 
         die_at_end "For '$plain_func', M flag requires p flag"
                                             if $flags =~ /M/ && $flags !~ /p/;
-        die_at_end "For '$plain_func', C flag requires one of [pIimb] flags"
-						   if $flags =~ /C/
-						   && ($flags !~ /[Iibmp]/
+	my $C_required_flags = '[pIimb]';
+        die_at_end
+	    "For '$plain_func', C flag requires one of $C_required_flags] flags"
+						if $flags =~ /C/
+						&& ($flags !~ /$C_required_flags/
 
-						      # Notwithstanding the
-						      # above, if the name
-						      # won't clash with a
-						      # user name, it's ok.
-						   && $plain_func !~ /^[Pp]erl/);
+						   # Notwithstanding the
+						   # above, if the name won't
+						   # clash with a user name,
+						   # it's ok.
+						&& $plain_func !~ /^[Pp]erl/);
 
         die_at_end "For '$plain_func', X flag requires one of [Iip] flags"
                                             if $flags =~ /X/ && $flags !~ /[Iip]/;

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -48,7 +48,7 @@ sub full_name ($$) { # Returns the function name with potentially the
                      # prefixes 'S_' or 'Perl_'
     my ($func, $flags) = @_;
 
-    return "Perl_$func" if $flags =~ /p/;
+    return "Perl_$func" if $flags =~ /[ps]/;
     return "S_$func" if $flags =~ /[SIi]/;
     return $func;
 }
@@ -79,7 +79,7 @@ my ($embed, $core, $ext, $api) = setup_embed();
         }
 
         my ($flags,$retval,$plain_func,@args) = @$_;
-        if ($flags =~ / ( [^AabCDdEefFGhIiMmNnOoPpRrSTUuWXx;] ) /x) {
+        if ($flags =~ / ( [^AabCDdEefFGhIiMmNnOoPpRrSsTUuWXx;] ) /x) {
             die_at_end "flag $1 is not legal (for function $plain_func)";
         }
         my @nonnull;
@@ -107,11 +107,12 @@ my ($embed, $core, $ext, $api) = setup_embed();
                                                             && $flags !~ /m/;
 
         my $static_inline = 0;
-        if ($flags =~ /([SIi])/) {
+        if ($flags =~ /([SsIi])/) {
             my $type;
             if ($never_returns) {
                 $type = {
                     'S' => 'PERL_STATIC_NO_RET',
+                    's' => 'PERL_STATIC_NO_RET',
                     'i' => 'PERL_STATIC_INLINE_NO_RET',
                     'I' => 'PERL_STATIC_FORCE_INLINE_NO_RET'
                 }->{$1};
@@ -119,6 +120,7 @@ my ($embed, $core, $ext, $api) = setup_embed();
             else {
                 $type = {
                     'S' => 'STATIC',
+                    's' => 'STATIC',
                     'i' => 'PERL_STATIC_INLINE',
                     'I' => 'PERL_STATIC_FORCE_INLINE'
                 }->{$1};
@@ -140,7 +142,7 @@ my ($embed, $core, $ext, $api) = setup_embed();
 
         die_at_end "For '$plain_func', M flag requires p flag"
                                             if $flags =~ /M/ && $flags !~ /p/;
-	my $C_required_flags = '[pIimb]';
+	my $C_required_flags = '[pIimbs]';
         die_at_end
 	    "For '$plain_func', C flag requires one of $C_required_flags] flags"
 						if $flags =~ /C/

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -79,7 +79,7 @@ my ($embed, $core, $ext, $api) = setup_embed();
         }
 
         my ($flags,$retval,$plain_func,@args) = @$_;
-        if ($flags =~ / ( [^AabCDdEefFGhIiMmNnOoPpRrSsTUuWXx] ) /x) {
+        if ($flags =~ / ( [^AabCDdEefFGhIiMmNnOoPpRrSTUuWXx;] ) /x) {
             die_at_end "flag $1 is not legal (for function $plain_func)";
         }
         my @nonnull;

--- a/scope.h
+++ b/scope.h
@@ -155,26 +155,26 @@
 /*
 =for apidoc_section $callback
 
-=for apidoc Amns||SAVETMPS
+=for apidoc Amn;||SAVETMPS
 Opening bracket for temporaries on a callback.  See C<L</FREETMPS>> and
 L<perlcall>.
 
-=for apidoc Amns||FREETMPS
+=for apidoc Amn;||FREETMPS
 Closing bracket for temporaries on a callback.  See C<L</SAVETMPS>> and
 L<perlcall>.
 
-=for apidoc Amns||ENTER
+=for apidoc Amn;||ENTER
 Opening bracket on a callback.  See C<L</LEAVE>> and L<perlcall>.
 
-=for apidoc Amns||LEAVE
+=for apidoc Amn;||LEAVE
 Closing bracket on a callback.  See C<L</ENTER>> and L<perlcall>.
 
-=for apidoc Ams||ENTER_with_name|"name"
+=for apidoc Am;||ENTER_with_name|"name"
 
 Same as C<L</ENTER>>, but when debugging is enabled it also associates the
 given literal string with the new scope.
 
-=for apidoc Ams||LEAVE_with_name|"name"
+=for apidoc Am;||LEAVE_with_name|"name"
 
 Same as C<L</LEAVE>>, but when debugging is enabled it first checks that the
 scope has the given name. C<name> must be a literal string.

--- a/util.c
+++ b/util.c
@@ -2054,15 +2054,6 @@ Perl_croak_nocontext(const char *pat, ...)
 }
 #endif /* MULTIPLICITY */
 
-/* saves machine code for a common noreturn idiom typically used in Newx*() */
-GCC_DIAG_IGNORE_DECL(-Wunused-function);
-void
-Perl_croak_memory_wrap(void)
-{
-    Perl_croak_nocontext("%s",PL_memory_wrap);
-}
-GCC_DIAG_RESTORE_DECL;
-
 void
 Perl_croak(pTHX_ const char *pat, ...)
 {


### PR DESCRIPTION
This is used for functions that we don't suggest should be inlined, but  we think the compiler will generate better code if it has full knowledge about them.
     
At the moment, it only contains a single function which can be tail-call optimized.
