### PR TITLE
Convert '!!' to cBOOL()

### DIFF
--- a/gv.c
+++ b/gv.c
@@ -310,7 +310,7 @@ Perl_cvgv_from_hek(pTHX_ CV *cv)
     if (!isGV(gv))
         gv_init_pvn(gv, CvSTASH(cv), HEK_KEY(CvNAME_HEK(cv)),
                 HEK_LEN(CvNAME_HEK(cv)),
-                SVf_UTF8 * !!HEK_UTF8(CvNAME_HEK(cv)));
+                SVf_UTF8 * cBOOL(HEK_UTF8(CvNAME_HEK(cv))));
     if (!CvNAMED(cv)) { /* gv_init took care of it */
         assert (SvANY(cv)->xcv_gv_u.xcv_gv == gv);
         return gv;
@@ -4148,7 +4148,7 @@ Perl_gv_try_downgrade(pTHX_ GV *gv)
             (gvp = hv_fetchhek(stash, namehek, 0)) &&
             *gvp == (SV*)gv) {
         SV *value = SvREFCNT_inc(CvXSUBANY(cv).any_ptr);
-        const bool imported = !!GvIMPORTED_CV(gv);
+        const bool imported = cBOOL(GvIMPORTED_CV(gv));
         SvREFCNT(gv) = 0;
         sv_clear((SV*)gv);
         SvREFCNT(gv) = 1;

--- a/gv.h
+++ b/gv.h
@@ -269,7 +269,7 @@ Return the CV from the GV.
 #define gv_fetchmethod(stash, name) gv_fetchmethod_autoload(stash, name, TRUE)
 #define gv_fetchsv_nomg(n,f,t) gv_fetchsv(n,(f)|GV_NO_SVGMAGIC,t)
 #define gv_init(gv,stash,name,len,multi) \
-        gv_init_pvn(gv,stash,name,len,GV_ADDMULTI*!!(multi))
+        gv_init_pvn(gv,stash,name,len,GV_ADDMULTI*cBOOL(multi))
 #define gv_fetchmeth(stash,name,len,level) gv_fetchmeth_pvn(stash, name, len, level, 0)
 #define gv_fetchmeth_autoload(stash,name,len,level) gv_fetchmeth_pvn_autoload(stash, name, len, level, 0)
 #define gv_fetchmethod_flags(stash,name,flags) gv_fetchmethod_pv_flags(stash, name, flags)
@@ -281,7 +281,7 @@ Equivalent to C<L</gv_autoload_pvn>>.
 =cut
 */
 #define gv_autoload4(stash, name, len, autoload) \
-        gv_autoload_pvn(stash, name, len, !!(autoload))
+        gv_autoload_pvn(stash, name, len, cBOOL(autoload))
 #define newGVgen(pack)  newGVgen_flags(pack, 0)
 #define gv_method_changed(gv)		    \
     (					     \

--- a/hv.c
+++ b/hv.c
@@ -2289,7 +2289,10 @@ Perl_hv_undef_flags(pTHX_ HV *hv, U32 flags)
       /* If this call originated from sv_clear, then we must check for
        * effective names that need freeing, as well as the usual name. */
       name = HvNAME(hv);
-      if (flags & HV_NAME_SETALL ? !!HvAUX(hv)->xhv_name_u.xhvnameu_name : !!name) {
+      if (flags & HV_NAME_SETALL
+          ? cBOOL(HvAUX(hv)->xhv_name_u.xhvnameu_name)
+          : cBOOL(name))
+      {
         if (name && PL_stashcache) {
             DEBUG_o(Perl_deb(aTHX_ "hv_undef_flags clearing PL_stashcache for name '%"
                              HEKf "'\n", HEKfARG(HvNAME_HEK(hv))));
@@ -3537,8 +3540,8 @@ Perl_refcounted_he_chain_2hv(pTHX_ const struct refcounted_he *chain, U32 flags)
                 const STRLEN klen = HeKLEN(entry);
                 const char *const key = HeKEY(entry);
                 if (klen == chain->refcounted_he_keylen
-                    && (!!HeKUTF8(entry)
-                        == !!(chain->refcounted_he_data[0] & HVhek_UTF8))
+                    && (cBOOL(HeKUTF8(entry))
+                        == cBOOL((chain->refcounted_he_data[0] & HVhek_UTF8)))
                     && memEQ(key, REF_HE_KEY(chain), klen))
                     goto next_please;
 #else

--- a/op.c
+++ b/op.c
@@ -512,7 +512,7 @@ Perl_Slab_Free(pTHX_ void *op)
 void
 Perl_opslab_free_nopad(pTHX_ OPSLAB *slab)
 {
-    const bool havepad = !!PL_comppad;
+    const bool havepad = cBOOL(PL_comppad);
     PERL_ARGS_ASSERT_OPSLAB_FREE_NOPAD;
     if (havepad) {
         ENTER;
@@ -18868,7 +18868,7 @@ Perl_report_redefined_cv(pTHX_ const SV *name, const CV *old_cv,
                                SV * const *new_const_svp)
 {
     const char *hvname;
-    bool is_const = !!CvCONST(old_cv);
+    bool is_const = cBOOL(CvCONST(old_cv));
     SV *old_const_sv = is_const ? cv_const_sv(old_cv) : NULL;
 
     PERL_ARGS_ASSERT_REPORT_REDEFINED_CV;

--- a/pad.c
+++ b/pad.c
@@ -1110,7 +1110,7 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV* cv,
     SV *new_capture;
     SV **new_capturep;
     const PADLIST * const padlist = CvPADLIST(cv);
-    const bool staleok = !!(flags & padadd_STALEOK);
+    const bool staleok = cBOOL(flags & padadd_STALEOK);
 
     PERL_ARGS_ASSERT_PAD_FINDLEX;
 

--- a/pad.h
+++ b/pad.h
@@ -315,7 +315,7 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PadnameSV(pn) \
         newSVpvn_flags(PadnamePV(pn), PadnameLEN(pn), SVs_TEMP|SVf_UTF8)
 #define PadnameFLAGS(pn)	(pn)->xpadn_flags
-#define PadnameIsOUR(pn)	(!!(pn)->xpadn_ourstash)
+#define PadnameIsOUR(pn)	cBOOL((pn)->xpadn_ourstash)
 #define PadnameOURSTASH(pn)	(pn)->xpadn_ourstash
 #define PadnameTYPE(pn)		(pn)->xpadn_type_u.xpadn_typestash
 #define PadnamePROTOCV(pn)	(pn)->xpadn_type_u.xpadn_protocv
@@ -338,8 +338,8 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 
 /* backward compatibility */
 #define SvPAD_STATE		PadnameIsSTATE
-#define SvPAD_TYPED(pn)		(!!PadnameTYPE(pn))
-#define SvPAD_OUR(pn)		(!!PadnameOURSTASH(pn))
+#define SvPAD_TYPED(pn)	        cBOOL(PadnameTYPE(pn))
+#define SvPAD_OUR(pn)	        cBOOL(PadnameOURSTASH(pn))
 #define SvPAD_STATE_on		PadnameIsSTATE_on
 #define SvPAD_TYPED_on(pn)	(PadnameFLAGS(pn) |= PADNAMEt_TYPED)
 #define SvPAD_OUR_on(pn)	(PadnameFLAGS(pn) |= PADNAMEt_OUR)

--- a/pp.c
+++ b/pp.c
@@ -5118,7 +5118,7 @@ S_do_delete_local(pTHX)
     const U8 gimme = GIMME_V;
     const MAGIC *mg;
     HV *stash;
-    const bool sliced = !!(PL_op->op_private & OPpSLICE);
+    const bool sliced = cBOOL(PL_op->op_private & OPpSLICE);
     SV **unsliced_keysv = sliced ? NULL : sp--;
     SV * const osv = POPs;
     SV **mark = sliced ? PL_stack_base + POPMARK : unsliced_keysv-1;

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -574,7 +574,9 @@ PP(pp_formline)
             source = (U8 *)f;
             f += to_copy;
             trans = '~';
-            item_is_utf8 = targ_is_utf8 ? !!DO_UTF8(formsv) : !!SvUTF8(formsv);
+            item_is_utf8 = (targ_is_utf8)
+                           ? cBOOL(DO_UTF8(formsv))
+                           : cBOOL(SvUTF8(formsv));
             goto append;
 
         case FF_SKIP: /* skip <arg> chars in format */
@@ -1954,7 +1956,7 @@ PP(pp_caller)
       else (void)POPs;
     }
 
-    cx = caller_cx(count + !!(PL_op->op_private & OPpOFFBYONE), &dbcx);
+    cx = caller_cx(count + cBOOL(PL_op->op_private & OPpOFFBYONE), &dbcx);
     if (!cx) {
         if (gimme != G_LIST) {
             EXTEND(SP, 1);
@@ -5582,9 +5584,9 @@ S_doparseform(pTHX_ SV *sv)
     if (mg) {
         /* still the same as previously-compiled string? */
         SV *old = mg->mg_obj;
-        if ( !(!!SvUTF8(old) ^ !!SvUTF8(sv))
-              && len == SvCUR(old)
-              && strnEQ(SvPVX(old), s, len)
+        if ( ! (cBOOL(SvUTF8(old)) ^ cBOOL(SvUTF8(sv)))
+            && len == SvCUR(old)
+            && strnEQ(SvPVX(old), s, len)
         ) {
             DEBUG_f(PerlIO_printf(Perl_debug_log,"Re-using compiled format\n"));
             return mg;

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -2272,7 +2272,8 @@ PP(pp_truncate)
 
         if (PL_op->op_flags & OPf_SPECIAL
                        ? (tmpgv = gv_fetchsv(sv, 0, SVt_PVIO), 1)
-                       : !!(tmpgv = MAYBE_DEREF_GV(sv)) ) {
+                       : cBOOL(tmpgv = MAYBE_DEREF_GV(sv)) )
+        {
             io = GvIO(tmpgv);
             if (!io)
                 result = 0;
@@ -2827,7 +2828,8 @@ PP(pp_stat)
     SV* sv;
 
     if (PL_op->op_flags & OPf_REF ? (gv = cGVOP_gv, 1)
-                                  : !!(sv=POPs, gv = MAYBE_DEREF_GV(sv))) {
+                                  : cBOOL((sv=POPs, gv = MAYBE_DEREF_GV(sv))))
+    {
         if (PL_op->op_type == OP_LSTAT) {
             if (gv != PL_defgv) {
             do_fstat_warning_check:

--- a/regcomp.c
+++ b/regcomp.c
@@ -7968,7 +7968,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
 
     if (   old_re
         && !recompile
-        && !!RX_UTF8(old_re) == !!RExC_utf8
+        && cBOOL(RX_UTF8(old_re)) == cBOOL(RExC_utf8)
         && ( RX_COMPFLAGS(old_re) == ( orig_rx_flags & RXf_PMf_FLAGCOPYMASK ) )
         && RX_PRECOMP(old_re)
         && RX_PRELEN(old_re) == plen

--- a/regexec.c
+++ b/regexec.c
@@ -1111,7 +1111,7 @@ Perl_re_intuit_start(pTHX_
             && prog->intflags & PREGf_ANCH
             && prog->check_offset_max != SSize_t_MAX)
         {
-            SSize_t check_len = SvCUR(check) - !!SvTAIL(check);
+            SSize_t check_len = SvCUR(check) - cBOOL(SvTAIL(check));
             const char * const anchor =
                         (prog->intflags & PREGf_ANCH_GPOS ? strpos : strbeg);
             SSize_t targ_len = (char*)end_point - anchor;

--- a/scope.c
+++ b/scope.c
@@ -1310,7 +1310,7 @@ Perl_leave_scope(pTHX_ I32 base)
 
             a0 = ap[0]; a1 = ap[1];
             /* possibly taking a method out of circulation */	
-            had_method = !!GvCVu(a0.any_gv);
+            had_method = cBOOL(GvCVu(a0.any_gv));
             gp_free(a0.any_gv);
             GvGP_set(a0.any_gv, (GP*)a1.any_ptr);
             if ((hv=GvSTASH(a0.any_gv)) && HvENAME_get(hv)) {


### PR DESCRIPTION
I believe the '!!' is somewhat obscure; I for one didn't know about it
for years of programming C, and it was buggy in one compiler, which is why
cBOOL was created, I believe.

This commit dates from before we moved to C99 where we can simply cast
to (bool), and cBOOL() has been rewritten to do that.  But the vast
majority of code uses cBOOL(), and this commit brings the remainder of
the core .[ch] files into uniformity.