### PR TITLE
[doc] perlsub.pod: Link function and modules

### DIFF
--- a/pod/perlsub.pod
+++ b/pod/perlsub.pod
@@ -1852,7 +1852,7 @@ built-in name with the special package qualifier C<CORE::>.  For example,
 saying C<CORE::open()> always refers to the built-in L<C<open()>|perlfunc/open>, even
 if the current package has imported some other subroutine called
 C<&open()> from elsewhere.  Even though it looks like a regular
-function call, it isn't: the CORE:: prefix in that case is part of Perl's
+function call, it isn't: the C<CORE::> prefix in that case is part of Perl's
 syntax, and works for any keyword, regardless of what is in the CORE
 package.  Taking a reference to it, that is, C<\&CORE::open>, only works
 for some keywords.  See L<CORE>.

--- a/pod/perlsub.pod
+++ b/pod/perlsub.pod
@@ -52,8 +52,8 @@ X<subroutine, call> X<call>
 
 Like many languages, Perl provides for user-defined subroutines.
 These may be located anywhere in the main program, loaded in from
-other files via the C<do>, C<require>, or C<use> keywords, or
-generated on the fly using C<eval> or anonymous subroutines.
+other files via the L<C<do>|perlfunc/do>, L<C<require>|perlfunc/require>, or L<C<use>|perlfunc/use> keywords, or
+generated on the fly using L<C<eval>|perlfunc/eval> or anonymous subroutines.
 You can even call a function indirectly using a variable containing
 its name or a CODE reference.
 
@@ -71,7 +71,7 @@ X<subroutine, parameter> X<parameter>
 In a subroutine that uses signatures (see L</Signatures> below),
 arguments are assigned into lexical variables introduced by the
 signature.  In the current implementation of perl they are also
-accessible in the C<@_> array in the same way as for non-signature
+accessible in the L<C<@_>|perlvar/General Variables> array in the same way as for non-signature
 subroutines, but accessing them in this manner is now discouraged inside
 such a signature-using subroutine.
 
@@ -97,7 +97,7 @@ L</"Private Variables via my()"> and L</"Temporary Values via local()">.
 To create protected environments for a set of functions in a separate
 package (and probably a separate file), see L<perlmod/"Packages">.
 
-A C<return> statement may be used to exit a subroutine, optionally
+A L<C<return>|perlfunc/return> statement may be used to exit a subroutine, optionally
 specifying the returned value, which will be evaluated in the
 appropriate context (list, scalar, or void) depending on the context of
 the subroutine call.  If you specify no return value, the subroutine
@@ -108,7 +108,7 @@ one large indistinguishable list.
 
 If no C<return> is found and if the last statement is an expression, its
 value is returned.  If the last statement is a loop control structure
-like a C<foreach> or a C<while>, the returned value is unspecified.  The
+like a L<C<foreach>|perlfunc/foreach> or a L<C<while>|perlfunc/while>, the returned value is unspecified.  The
 empty sub returns the empty list.
 X<subroutine, return value> X<return value> X<return>
 
@@ -333,7 +333,7 @@ subroutine is simply a braced block of code, but when using a signature,
 the signature is a parenthesised list that goes immediately before the
 block, after any name or attributes.
 
-For example,
+For example:
 
     sub foo :lvalue ($a, $b = 1, @c) { .... }
 
@@ -476,7 +476,7 @@ that the caller passed no arguments:
     }
 
 Prior to Perl 5.36 these were considered experimental, and emitted a
-warning in the C<experimental::signatures> category. From Perl 5.36
+warning in the L<C<experimental::signatures>|warnings/Category-Hierarchy> category. From Perl 5.36
 onwards this no longer happens, though the warning category still exists
 for back-compatibility with code that attempts to disable it with a
 statement such as:
@@ -747,8 +747,8 @@ if you want to stay compatible with releases older than 5.10.
 
 =head3 Persistent variables via state()
 
-Beginning with Perl 5.10.0, you can declare variables with the C<state>
-keyword in place of C<my>.  For that to work, though, you must have
+Beginning with Perl 5.10.0, you can declare variables with the L<C<state>|perlfunc/state>
+keyword in place of L<C<my>|perlfunc/my>.  For that to work, though, you must have
 enabled that feature beforehand, either by using the C<feature> pragma, or
 by using C<-E> on one-liners (see L<feature>).  Beginning with Perl 5.16,
 the C<CORE::state> form does not require the
@@ -1849,7 +1849,7 @@ via the import syntax, and these names may then override built-in ones:
 
 To unambiguously refer to the built-in form, precede the
 built-in name with the special package qualifier C<CORE::>.  For example,
-saying C<CORE::open()> always refers to the built-in C<open()>, even
+saying C<CORE::open()> always refers to the built-in L<C<open()>|perlfunc/open>, even
 if the current package has imported some other subroutine called
 C<&open()> from elsewhere.  Even though it looks like a regular
 function call, it isn't: the CORE:: prefix in that case is part of Perl's
@@ -1857,10 +1857,10 @@ syntax, and works for any keyword, regardless of what is in the CORE
 package.  Taking a reference to it, that is, C<\&CORE::open>, only works
 for some keywords.  See L<CORE>.
 
-Library modules should not in general export built-in names like C<open>
-or C<chdir> as part of their default C<@EXPORT> list, because these may
+Library modules should not in general export built-in names like L<C<open>|perlfunc/open>
+or L<C<chdir>|perlfunc/chdir> as part of their default L<C<@EXPORT>|Exporter/How-to-Export> list, because these may
 sneak into someone else's namespace and change the semantics unexpectedly.
-Instead, if the module adds that name to C<@EXPORT_OK>, then it's
+Instead, if the module adds that name to L<C<@EXPORT_OK>|Exporter/How-to-Export>, then it's
 possible for a user to import the name explicitly, but not implicitly.
 That is, they could say
 
@@ -1877,7 +1877,7 @@ deliberately, to the package that requests the import.  There is a second
 method that is sometimes applicable when you wish to override a built-in
 everywhere, without regard to namespace boundaries.  This is achieved by
 importing a sub into the special namespace C<CORE::GLOBAL::>.  Here is an
-example that quite brazenly replaces the C<glob> operator with something
+example that quite brazenly replaces the L<C<glob>|perlfunc/glob> operator with something
 that understands regular expressions.
 
     package REGlob;
@@ -1919,12 +1919,12 @@ those namespaces.  Naturally, this should be done with extreme caution--if
 it must be done at all.
 
 The C<REGlob> example above does not implement all the support needed to
-cleanly override perl's C<glob> operator.  The built-in C<glob> has
+cleanly override perl's L<C<glob>|perlfunc/glob> operator.  The built-in C<glob> has
 different behaviors depending on whether it appears in a scalar or list
 context, but our C<REGlob> doesn't.  Indeed, many perl built-in have such
 context sensitive behaviors, and these must be adequately supported by
 a properly written override.  For a fully functional example of overriding
-C<glob>, study the implementation of C<File::DosGlob> in the standard
+C<glob>, study the implementation of L<C<File::DosGlob>|File::DosGlob> in the standard
 library.
 
 When you override a built-in, your replacement should be consistent (if
@@ -1949,9 +1949,9 @@ the argument C<"Foo/Bar.pm"> in @_.  See L<perlfunc/require>.
 And, as you'll have noticed from the previous example, if you override
 C<glob>, the C<< <*> >> glob operator is overridden as well.
 
-In a similar fashion, overriding the C<readline> function also overrides
+In a similar fashion, overriding the L<C<readline>|perlfunc/readline> function also overrides
 the equivalent I/O operator C<< <FILEHANDLE> >>.  Also, overriding
-C<readpipe> also overrides the operators C<``> and C<qx//>.
+L<C<readpipe>|perlfunc/readpipe> also overrides the operators C<``> and C<qx//>.
 
 Finally, some built-ins (e.g. C<exists> or C<grep>) can't be overridden.
 


### PR DESCRIPTION
Link some function and modules (keeping code formatting) in Description and other places while at it,
so it's clearer to the reader what's being referred to in the document.
