### PR TITLE
on freebsd replace the first part of archname with `uname -p`

### DIFF
--- a/hints/freebsd.sh
+++ b/hints/freebsd.sh
@@ -352,3 +352,18 @@ arm|mips)
   test "$optimize" || optimize='-O2'
   ;;
 esac
+
+# don't modify a supplied -Darchname
+case "$archname" in
+'')
+  cat > UU/archname.cbu <<'EOCBU'
+unamem=`uname -m`
+case "$archname" in
+"$unamem"-*)
+  arch=`uname -p`
+  archname=`echo "$archname" | sed -e "s/^$unamem-/$arch-/"`
+  ;;
+esac
+EOCBU
+  ;;
+esac


### PR DESCRIPTION
I haven't done a full make test on this, my ppc machine is qemu, so it would finish some time next week, but Configure is producing an archname like those discussed in the ticket.

The substitution is a NOP on amd64, there both `uname -m` and `uname -p` are "amd64".

Fixes #19791