### PR TITLE
Add a PERL_MEM_LOG=c option that prints more levels of C backtrace

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -3339,7 +3339,7 @@ Perl_mortal_getenv(const char * str)
             }
         }
 
-        /* Then each of the three significant characters */
+        /* Then each of the four significant characters */
         if (strchr(ret, 'm')) {
             *mem_log_meat++ = 'm';
         }
@@ -3348,6 +3348,9 @@ Perl_mortal_getenv(const char * str)
         }
         if (strchr(ret, 't')) {
             *mem_log_meat++ = 't';
+        }
+        if (strchr(ret, 'c')) {
+            *mem_log_meat++ = 'c';
         }
         *mem_log_meat = '\0';
 

--- a/pod/perlhacktips.pod
+++ b/pod/perlhacktips.pod
@@ -1699,6 +1699,8 @@ determine whether to log the event, and if so how:
 
     $ENV{PERL_MEM_LOG} =~ /m/           Log all memory ops
     $ENV{PERL_MEM_LOG} =~ /s/           Log all SV ops
+    $ENV{PERL_MEM_LOG} =~ /c/           Additionally log C backtrace for
+                                        new_SV events
     $ENV{PERL_MEM_LOG} =~ /t/           include timestamp in Log
     $ENV{PERL_MEM_LOG} =~ /^(\d+)/      write to FD given (default is 2)
 
@@ -1713,6 +1715,10 @@ Since the logging doesn't use PerlIO, all SV allocations are logged and
 no extra SV allocations are introduced by enabling the logging.  If
 compiled with C<-DDEBUG_LEAKING_SCALARS>, the serial number for each SV
 allocation is also logged.
+
+The C<c> option uses the C<Perl_c_backtrace> facility, and therefore
+additionally requires the Configure C<-Dusecbacktrace> compile flag in
+order to access it.
 
 =head2 DDD over gdb
 

--- a/util.c
+++ b/util.c
@@ -5218,9 +5218,10 @@ S_mem_log_common(enum mem_log_type mlt, const UV n,
             PERL_UNUSED_RESULT(PerlLIO_write(fd, buf, len));
 #ifdef USE_C_BACKTRACE
             if(strchr(pmlenv,'c') && (mlt == MLT_NEW_SV)) {
-                /* TODO: get caller package in here when we work out how */
                 len = my_snprintf(buf, sizeof(buf),
-                        "  caller at %s line %d\n",
+                        "  caller %s at %s line %d\n",
+                        /* CopSTASHPV can crash early on startup; use CopFILE to check */
+                        CopFILE(PL_curcop) ? CopSTASHPV(PL_curcop) : "<unknown>",
                         CopFILE(PL_curcop), CopLINE(PL_curcop));
                 PERL_UNUSED_RESULT(PerlLIO_write(fd, buf, len));
 

--- a/util.c
+++ b/util.c
@@ -5107,7 +5107,7 @@ Perl_debug_hash_seed(pTHX_ bool via_debug_h)
 /* -DPERL_MEM_LOG_SPRINTF_BUF_SIZE=X: size of a (stack-allocated) buffer
  * the Perl_mem_log_...() will use (either via sprintf or snprintf).
  */
-#define PERL_MEM_LOG_SPRINTF_BUF_SIZE 128
+#define PERL_MEM_LOG_SPRINTF_BUF_SIZE 256
 
 /* -DPERL_MEM_LOG_FD=N: the file descriptor the Perl_mem_log_...()
  * writes to.  In the default logger, this is settable at runtime.
@@ -5216,6 +5216,32 @@ S_mem_log_common(enum mem_log_type mlt, const UV n,
                 len = 0;
             }
             PERL_UNUSED_RESULT(PerlLIO_write(fd, buf, len));
+#ifdef USE_C_BACKTRACE
+            if(strchr(pmlenv,'c') && (mlt == MLT_NEW_SV)) {
+                /* TODO: get caller package in here when we work out how */
+                len = my_snprintf(buf, sizeof(buf),
+                        "  caller at %s line %d\n",
+                        CopFILE(PL_curcop), CopLINE(PL_curcop));
+                PERL_UNUSED_RESULT(PerlLIO_write(fd, buf, len));
+
+                Perl_c_backtrace *bt = Perl_get_c_backtrace(aTHX_ 3, 3);
+                Perl_c_backtrace_frame *frame;
+                UV i;
+                for (i = 0, frame = bt->frame_info;
+                        i < bt->header.frame_count;
+                        i++, frame++) {
+                    len = my_snprintf(buf, sizeof(buf),
+                            "  frame[%" UVuf "]: %p %s at %s +0x%lx\n",
+                            i,
+                            frame->addr,
+                            frame->symbol_name_size && frame->symbol_name_offset ? (char *)bt + frame->symbol_name_offset : "-",
+                            frame->object_name_size && frame->object_name_offset ? (char *)bt + frame->object_name_offset : "?",
+                            (char *)frame->addr - (char *)frame->object_base_addr);
+                    PERL_UNUSED_RESULT(PerlLIO_write(fd, buf, len));
+                }
+                Perl_free_c_backtrace(bt);
+            }
+#endif /* USE_C_BACKTRACE */
         }
     }
 }


### PR DESCRIPTION
Setting just `PERL_MEM_LOG=s` is almost useless, because basically every SV appears to be allocated by calls to `Perl_newSV_type()` from `inline.h` line 369 (or whatever).

This new flag requests that the `Perl_c_backtrace` facility is used to obtain more information about the C-level caller context of the SV allocation operation, which will likely be of more help when reading the debug log.