### PR TITLE
pp_aelemfast: include fast return for non-lvals

### DIFF
--- a/pp_hot.c
+++ b/pp_hot.c
@@ -1637,6 +1637,9 @@ PP(pp_aelemfast)
         if (sv) {
             PUSHs(sv);
             RETURN;
+        } else if (!lval) {
+            PUSHs(&PL_sv_undef);
+            RETURN;
         }
     }
 


### PR DESCRIPTION
Within the "inlined av_fetch() for simple cases" fast path, we already
operate within the bounding conditions of the if() statement. Once
AvARRAY(av)[key] is found to be null, a call of av_fetch(av,key,lval)
here just boils down to a single line:

    return lval ? av_store(av,key,newSV_type(SVt_NULL)) : NULL;

Checking the rest of pp_aelemfast, it's clear that within the fast
path, if (!sv) and (!lval), the function must eventually
PUSHs(&PL_sv_undef). So the fast path might as well do that directly.