### PR TITLE
allow building with -DPERL_MEM_LOG on Win32

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3327,9 +3327,11 @@ ST	|void	|mem_log_common	|enum mem_log_type mlt|const UV n|const UV typesize \
 #endif
 
 #if defined(PERL_MEM_LOG)
-pT	|Malloc_t	|mem_log_alloc	|const UV nconst|UV typesize|NN const char *type_name|Malloc_t newalloc|NN const char *filename|const int linenumber|NN const char *funcname
-pT	|Malloc_t	|mem_log_realloc	|const UV n|const UV typesize|NN const char *type_name|Malloc_t oldalloc|Malloc_t newalloc|NN const char *filename|const int linenumber|NN const char *funcname
-pT	|Malloc_t	|mem_log_free	|Malloc_t oldalloc|NN const char *filename|const int linenumber|NN const char *funcname
+CpT	|Malloc_t	|mem_log_alloc	|const UV nconst|UV typesize|NN const char *type_name|Malloc_t newalloc|NN const char *filename|const int linenumber|NN const char *funcname
+CpT	|Malloc_t	|mem_log_realloc	|const UV n|const UV typesize|NN const char *type_name|Malloc_t oldalloc|Malloc_t newalloc|NN const char *filename|const int linenumber|NN const char *funcname
+CpT	|Malloc_t	|mem_log_free	|Malloc_t oldalloc|NN const char *filename|const int linenumber|NN const char *funcname
+CpT	|void		|mem_log_new_sv|NN const SV *sv|NN const char *filename|int linenumber|NN const char *funcname
+CpT	|void		|mem_log_del_sv|NN const SV *sv|NN const char *filename|int linenumber|NN const char *funcname
 #endif
 
 #if defined(PERL_IN_UTF8_C)

--- a/embed.h
+++ b/embed.h
@@ -810,6 +810,13 @@
 #if defined(PERL_IN_SV_C)
 #define more_sv()		Perl_more_sv(aTHX)
 #endif
+#if defined(PERL_MEM_LOG)
+#define mem_log_alloc		Perl_mem_log_alloc
+#define mem_log_del_sv		Perl_mem_log_del_sv
+#define mem_log_free		Perl_mem_log_free
+#define mem_log_new_sv		Perl_mem_log_new_sv
+#define mem_log_realloc		Perl_mem_log_realloc
+#endif
 #if defined(PERL_USE_3ARG_SIGHANDLER)
 #define csighandler		Perl_csighandler
 #endif
@@ -1950,11 +1957,6 @@
 #    if defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL)
 #define mem_log_common		S_mem_log_common
 #    endif
-#  endif
-#  if defined(PERL_MEM_LOG)
-#define mem_log_alloc		Perl_mem_log_alloc
-#define mem_log_free		Perl_mem_log_free
-#define mem_log_realloc		Perl_mem_log_realloc
 #  endif
 #  if defined(PERL_USES_PL_PIDSTATUS) && defined(PERL_IN_UTIL_C)
 #define pidgone(a,b)		S_pidgone(aTHX_ a,b)

--- a/handy.h
+++ b/handy.h
@@ -2783,10 +2783,6 @@ enum mem_log_type {
   MLT_DEL_SV
 };
 #  endif
-#  if defined(PERL_IN_SV_C)  /* those are only used in sv.c */
-void Perl_mem_log_new_sv(const SV *sv, const char *filename, const int linenumber, const char *funcname);
-void Perl_mem_log_del_sv(const SV *sv, const char *filename, const int linenumber, const char *funcname);
-#  endif
 # endif
 
 #endif

--- a/makedef.pl
+++ b/makedef.pl
@@ -485,7 +485,14 @@ unless ($define{'PERL_TRACK_MEMPOOL'}) {
 }
 
 unless ($define{'PERL_MEM_LOG'}) {
-    ++$skip{PL_mem_log};
+    ++$skip{$_} foreach qw(
+                    PL_mem_log
+                    Perl_mem_log_alloc
+                    Perl_mem_log_realloc
+                    Perl_mem_log_free
+                    Perl_mem_log_new_sv
+                    Perl_mem_log_del_sv
+                );
 }
 
 unless ($define{'MULTIPLICITY'}) {

--- a/proto.h
+++ b/proto.h
@@ -6606,9 +6606,15 @@ STATIC void	S_mem_log_common(enum mem_log_type mlt, const UV n, const UV typesiz
 PERL_CALLCONV Malloc_t	Perl_mem_log_alloc(const UV nconst, UV typesize, const char *type_name, Malloc_t newalloc, const char *filename, const int linenumber, const char *funcname);
 #define PERL_ARGS_ASSERT_MEM_LOG_ALLOC	\
 	assert(type_name); assert(filename); assert(funcname)
+PERL_CALLCONV void	Perl_mem_log_del_sv(const SV *sv, const char *filename, int linenumber, const char *funcname);
+#define PERL_ARGS_ASSERT_MEM_LOG_DEL_SV	\
+	assert(sv); assert(filename); assert(funcname)
 PERL_CALLCONV Malloc_t	Perl_mem_log_free(Malloc_t oldalloc, const char *filename, const int linenumber, const char *funcname);
 #define PERL_ARGS_ASSERT_MEM_LOG_FREE	\
 	assert(filename); assert(funcname)
+PERL_CALLCONV void	Perl_mem_log_new_sv(const SV *sv, const char *filename, int linenumber, const char *funcname);
+#define PERL_ARGS_ASSERT_MEM_LOG_NEW_SV	\
+	assert(sv); assert(filename); assert(funcname)
 PERL_CALLCONV Malloc_t	Perl_mem_log_realloc(const UV n, const UV typesize, const char *type_name, Malloc_t oldalloc, Malloc_t newalloc, const char *filename, const int linenumber, const char *funcname);
 #define PERL_ARGS_ASSERT_MEM_LOG_REALLOC	\
 	assert(type_name); assert(filename); assert(funcname)

--- a/util.c
+++ b/util.c
@@ -5153,7 +5153,7 @@ S_mem_log_common(enum mem_log_type mlt, const UV n,
 #     define MEM_LOG_TIME_FMT	"%10d.%06d: "
 #     define MEM_LOG_TIME_ARG	(int)tv.tv_sec, (int)tv.tv_usec
         struct timeval tv;
-        gettimeofday(&tv, 0);
+        PerlProc_gettimeofday(&tv, 0);
 #   else
 #     define MEM_LOG_TIME_FMT	"%10d: "
 #     define MEM_LOG_TIME_ARG	(int)when
@@ -5279,6 +5279,8 @@ Perl_mem_log_new_sv(const SV *sv,
                     const char *filename, const int linenumber,
                     const char *funcname)
 {
+    PERL_ARGS_ASSERT_MEM_LOG_NEW_SV;
+
     mem_log_common_if(MLT_NEW_SV, 0, 0, "", sv, NULL, NULL,
                       filename, linenumber, funcname);
 }
@@ -5288,6 +5290,8 @@ Perl_mem_log_del_sv(const SV *sv,
                     const char *filename, const int linenumber, 
                     const char *funcname)
 {
+    PERL_ARGS_ASSERT_MEM_LOG_DEL_SV;
+
     mem_log_common_if(MLT_DEL_SV, 0, 0, "", sv, NULL, NULL, 
                       filename, linenumber, funcname);
 }


### PR DESCRIPTION
This appears to have been broken for a while, and became more broken
with 75acd14e, which made newSV_type() inline.

This will also prevent warnings about calls to undeclared functions
on systems that don't need symbols to be exported.