### PR TITLE
define POSIX:: constants from limits.h when building with mingw

### DIFF
--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -1,6 +1,9 @@
 #define PERL_EXT_POSIX
 #define PERL_EXT
 
+#if defined(_WIN32) && defined(__GNUC__) /* mingw compiler */
+#define _POSIX_
+#endif
 #define PERL_NO_GET_CONTEXT
 
 #include "EXTERN.h"


### PR DESCRIPTION
mingw builds do not define POSIX::PIPE_BUF because limits.h only defines it when _POSIX_PIPE_BUF is defined, which only is done when \_POSIX\_ has been defined before limits.h is included.  This can be seen in Strawberry Perl:

$ perl -v
This is perl 5, version 32, subversion 1 (v5.32.1) built for MSWin32-x64-multi-thread

$ perl -MPOSIX=PIPE_BUF -e "print PIPE_BUF;"
Your vendor has not defined POSIX macro PIPE_BUF, used at -e line 1

This patch defines \_POSIX\_ in POSIX.xs before include perl.h because perl.h has include limits.h
I have confirmed that using -D_POSIX_ as build option for everything gets compile errors, but limiting it to POSIX.xs seems to only use it for building POSIX module and that works. 