### PR TITLE
Storable - support boolean values via special case hack

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3985,6 +3985,7 @@ dist/Storable/t/attach.t		Check STORABLE_attach doesn't create objects unnecessa
 dist/Storable/t/attach_errors.t		Trigger and test STORABLE_attach errors
 dist/Storable/t/attach_singleton.t	Test STORABLE_attach for the Singleton pattern
 dist/Storable/t/blessed.t		See if Storable works
+dist/Storable/t/boolean.t		See if Storable works
 dist/Storable/t/canonical.t		See if Storable works
 dist/Storable/t/circular_hook.t		Test thaw hook called depth-first for circular refs
 dist/Storable/t/code.t			See if Storable works

--- a/dist/Storable/Makefile.PL
+++ b/dist/Storable/Makefile.PL
@@ -11,11 +11,14 @@ use warnings;
 use ExtUtils::MakeMaker 6.31;
 use Config;
 
+my $defines = $ENV{PERL_CORE} ? q[] : q[-DUSE_PPPORT_H];
+
 WriteMakefile(
     NAME                => 'Storable',
     AUTHOR              => 'Perl 5 Porters',
     LICENSE             => 'perl',
     DISTNAME            => "Storable",
+    DEFINE              => $defines,
     PREREQ_PM           =>
       {
           XSLoader => 0,

--- a/dist/Storable/Storable.pm
+++ b/dist/Storable/Storable.pm
@@ -28,7 +28,7 @@ our @EXPORT_OK = qw(
 our ($canonical, $forgive_me);
 
 BEGIN {
-  our $VERSION = '3.26';
+  our $VERSION = '3.27';
 }
 
 our $recursion_limit;

--- a/dist/Storable/Storable.xs
+++ b/dist/Storable/Storable.xs
@@ -16,8 +16,7 @@
 #include <perl.h>
 #include <XSUB.h>
 
-#ifndef PERL_VERSION_LT
-# if !defined(PERL_VERSION) || !defined(PERL_REVISION) || ( PERL_REVISION == 5 && ( PERL_VERSION < 10 || (PERL_VERSION == 10 && PERL_SUBVERSION < 1) ) )
+#ifdef USE_PPPORT_H
 #   define NEED_PL_parser
 #   define NEED_sv_2pv_flags
 #   define NEED_load_module
@@ -25,7 +24,6 @@
 #   define NEED_newCONSTSUB
 #   define NEED_newSVpvn_flags
 #   define NEED_newRV_noinc
-# endif
 #include "ppport.h"             /* handle old perls */
 #endif
 

--- a/dist/Storable/t/boolean.t
+++ b/dist/Storable/t/boolean.t
@@ -1,0 +1,84 @@
+use strict;
+use warnings;
+
+my $true_ref;
+my $false_ref;
+BEGIN {
+    $true_ref = \!!1;
+    $false_ref = \!!0;
+}
+
+BEGIN {
+    unshift @INC, 't';
+    unshift @INC, 't/compat' if $] < 5.006002;
+    require Config;
+    if ($ENV{PERL_CORE} and $Config::Config{'extensions'} !~ /\bStorable\b/) {
+        print "1..0 # Skip: Storable was not built\n";
+        exit 0;
+    }
+}
+
+use Test::More tests => 12;
+use Storable qw(thaw freeze);
+
+use constant CORE_BOOLS => defined &builtin::is_bool;
+
+{
+  my $x = $true_ref;
+  my $y = ${thaw freeze \$x};
+  is($y, $x);
+  eval {
+    $$y = 2;
+  };
+  isnt $@, '',
+    'immortal true maintained as immortal';
+}
+
+{
+  my $x = $false_ref;
+  my $y = ${thaw freeze \$x};
+  is($y, $x);
+  eval {
+    $$y = 2;
+  };
+  isnt $@, '',
+    'immortal false maintained as immortal';
+}
+
+{
+  my $true = $$true_ref;
+  my $x = \$true;
+  my $y = ${thaw freeze \$x};
+  is($$y, $$x);
+  is($$y, '1');
+  SKIP: {
+    skip "perl $] does not support tracking boolean values", 1
+      unless CORE_BOOLS;
+    BEGIN { CORE_BOOLS and warnings->unimport('experimental::builtin') }
+    ok builtin::is_bool($$y);
+  }
+  eval {
+    $$y = 2;
+  };
+  is $@, '',
+    'mortal true maintained as mortal';
+}
+
+{
+  my $false = $$false_ref;
+  my $x = \$false;
+  my $y = ${thaw freeze \$x};
+  is($$y, $$x);
+  is($$y, '');
+  SKIP: {
+    skip "perl $] does not support tracking boolean values", 1
+      unless CORE_BOOLS;
+    BEGIN { CORE_BOOLS and warnings->unimport('experimental::builtin') }
+    ok builtin::is_bool($$y);
+  }
+  eval {
+    $$y = 2;
+  };
+  is $@, '',
+    'mortal true maintained as mortal';
+}


### PR DESCRIPTION
Add a special case to Storable to always encode boolean values as 'long'
format. This should never normally happen for strings of length 0 or 1.
This is a valid encoding of these values, even on old versions of
Storable. On older versions, they will decode as "1" and "", the same as
they would have without this change.

When decoding 'long' strings, recognise these abnormally encoded
strings, and decode them as boolean values.

This allows round tripping booleans through Storable without changing
anything about the format.

It would be possible for an existing stored blob to have these abnormal
encodings, but they would have to be manually constructed. And even in
that case, the decoded values would still have the same string value.
They would just additionally be flagged as booleans.