### PR TITLE
Remove usage of old package separator from cmd/subval.t

### DIFF
--- a/t/cmd/subval.t
+++ b/t/cmd/subval.t
@@ -106,7 +106,7 @@ sub somesub {
 &somesub(27, 'main', __FILE__, __LINE__);
 
 package foo;
-&main'somesub(28, 'foo', __FILE__, __LINE__);
+&main::somesub(28, 'foo', __FILE__, __LINE__);
 
 package main;
 $i = 28;
@@ -151,28 +151,28 @@ sub iseof {
 
 {package foo;
 
- sub main'file_package {
+ sub main::file_package {
         local(*F) = @_;
 
         open(F, 'Cmd_subval.tmp') || die "can't open: $!\n";
-	$main'i++;
-        eof F ? print "not ok $main'i\n" : print "ok $main'i\n";
+	$main::i++;
+        eof F ? print "not ok $main::i\n" : print "ok $main::i\n";
  }
 
- sub main'info_package {
+ sub main::info_package {
         local(*F);
 
         open(F, 'Cmd_subval.tmp') || die "can't open: $!\n";
-	$main'i++;
-        eof F ? print "not ok $main'i\n" : print "ok $main'i\n";
+	$main::i++;
+        eof F ? print "not ok $main::i\n" : print "ok $main::i\n";
         &iseof(*F);
  }
 
  sub iseof {
         local(*UNIQ) = @_;
 
-	$main'i++;
-        eof UNIQ ? print "not ok $main'i\n" : print "ok $main'i\n";
+	$main::i++;
+        eof UNIQ ? print "not ok $main::i\n" : print "ok $main::i\n";
  }
 }
 


### PR DESCRIPTION
The old separator is being tested in various other places:

lib/overload.t
t/comp/package.t
t/comp/parser.t
t/lib/croak/toke
t/lib/warnings/toke
t/op/method.t
t/op/ref.t
t/op/sort.t
t/op/stash.t
t/op/stash_parse_gv.t
t/re/pat_re_eval.t
t/uni/package.t
t/uni/parser.t
t/uni/stash.t
t/uni/variables.t

In this test it seems to be an actual leftover from old times.