### PR TITLE
Adjust PSC with 2022 members

### DIFF
--- a/Porting/vote_admin_guide.pod
+++ b/Porting/vote_admin_guide.pod
@@ -172,11 +172,11 @@ edit the Perl Core mailing list admins to match the incoming Steering Council
 
 =item *
 
-update the GitHub "steering" team to match incoming Steering Council
+update the L<GitHub "steering" team|https://github.com/orgs/Perl/teams/perl-steering-council/members> to match incoming Steering Council
 
 =item *
 
-request that the Perl NOC update the perl-security list to include all incoming
+request that the L<Perl NOC|https://noc.perl.org> update the perl-security list to include all incoming
 Steering Council members (without removing outgoing members; the incoming Steering
 Council will decide whether this is needed)
 


### PR DESCRIPTION
After nomination period for Perl Steering
Committee members. New members were elected
without the need for a vote.

Adjust the list of PSC memmbers.
Also mark as requested @xdg as an inactive
member.