### PR TITLE
Eval param to SvPV-foo exactly once

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1909,7 +1909,9 @@ Apd	|STRLEN	|sv_pos_b2u_flags|NN SV *const sv|STRLEN const offset \
 				 |U32 flags
 CpMdb	|char*	|sv_pvn_force	|NN SV* sv|NULLOK STRLEN* lp
 Cpd	|char*	|sv_pvutf8n_force|NN SV *const sv|NULLOK STRLEN *const lp
+Ip	|char*	|sv_pvutf8n_force_wrapper|NN SV *const sv|NULLOK STRLEN *const lp|const U32 dummy
 Cpd	|char*	|sv_pvbyten_force|NN SV *const sv|NULLOK STRLEN *const lp
+Ip	|char*	|sv_pvbyten_force_wrapper|NN SV *const sv|NULLOK STRLEN *const lp|const U32 dummy
 Apd	|char*	|sv_recode_to_utf8	|NN SV* sv|NN SV *encoding
 Apd	|bool	|sv_cat_decode	|NN SV* dsv|NN SV *encoding|NN SV *ssv|NN int *offset \
 				|NN char* tstr|int tlen

--- a/embed.h
+++ b/embed.h
@@ -1430,6 +1430,8 @@
 #define sv_clean_objs()		Perl_sv_clean_objs(aTHX)
 #define sv_del_backref(a,b)	Perl_sv_del_backref(aTHX_ a,b)
 #define sv_free_arenas()	Perl_sv_free_arenas(aTHX)
+#define sv_pvbyten_force_wrapper(a,b,c)	Perl_sv_pvbyten_force_wrapper(aTHX_ a,b,c)
+#define sv_pvutf8n_force_wrapper(a,b,c)	Perl_sv_pvutf8n_force_wrapper(aTHX_ a,b,c)
 #define sv_resetpvn(a,b,c)	Perl_sv_resetpvn(aTHX_ a,b,c)
 #define sv_sethek(a,b)		Perl_sv_sethek(aTHX_ a,b)
 #ifndef MULTIPLICITY

--- a/proto.h
+++ b/proto.h
@@ -4042,6 +4042,13 @@ PERL_CALLCONV char*	Perl_sv_pvbyte(pTHX_ SV *sv)
 PERL_CALLCONV char*	Perl_sv_pvbyten_force(pTHX_ SV *const sv, STRLEN *const lp);
 #define PERL_ARGS_ASSERT_SV_PVBYTEN_FORCE	\
 	assert(sv)
+#ifndef PERL_NO_INLINE_FUNCTIONS
+PERL_STATIC_FORCE_INLINE char*	Perl_sv_pvbyten_force_wrapper(pTHX_ SV *const sv, STRLEN *const lp, const U32 dummy)
+			__attribute__always_inline__;
+#define PERL_ARGS_ASSERT_SV_PVBYTEN_FORCE_WRAPPER	\
+	assert(sv)
+#endif
+
 #ifndef NO_MATHOMS
 PERL_CALLCONV char*	Perl_sv_pvn_force(pTHX_ SV* sv, STRLEN* lp);
 #define PERL_ARGS_ASSERT_SV_PVN_FORCE	\
@@ -4060,6 +4067,13 @@ PERL_CALLCONV char*	Perl_sv_pvutf8(pTHX_ SV *sv)
 PERL_CALLCONV char*	Perl_sv_pvutf8n_force(pTHX_ SV *const sv, STRLEN *const lp);
 #define PERL_ARGS_ASSERT_SV_PVUTF8N_FORCE	\
 	assert(sv)
+#ifndef PERL_NO_INLINE_FUNCTIONS
+PERL_STATIC_FORCE_INLINE char*	Perl_sv_pvutf8n_force_wrapper(pTHX_ SV *const sv, STRLEN *const lp, const U32 dummy)
+			__attribute__always_inline__;
+#define PERL_ARGS_ASSERT_SV_PVUTF8N_FORCE_WRAPPER	\
+	assert(sv)
+#endif
+
 PERL_CALLCONV char*	Perl_sv_recode_to_utf8(pTHX_ SV* sv, SV *encoding);
 #define PERL_ARGS_ASSERT_SV_RECODE_TO_UTF8	\
 	assert(sv); assert(encoding)


### PR DESCRIPTION
This changes all the API macros that retrieve a PV into a call to an
inline function so as to evaluate the parameter just once.