### PR TITLE
Don't use ppport.h when building dist/ modules in core

### DIFF
--- a/dist/IO/IO.pm
+++ b/dist/IO/IO.pm
@@ -7,7 +7,7 @@ use Carp;
 use strict;
 use warnings;
 
-our $VERSION = "1.50";
+our $VERSION = "1.51";
 XSLoader::load 'IO', $VERSION;
 
 sub import {

--- a/dist/IO/IO.xs
+++ b/dist/IO/IO.xs
@@ -11,9 +11,13 @@
 #define PERLIO_NOT_STDIO 1
 #include "perl.h"
 #include "XSUB.h"
-#define NEED_newCONSTSUB
-#define NEED_newSVpvn_flags
-#include "ppport.h"
+
+#ifdef USE_PPPORT_H
+#   define NEED_newCONSTSUB
+#   define NEED_newSVpvn_flags
+#   include "ppport.h"
+#endif
+
 #include "poll.h"
 #ifdef I_UNISTD
 #  include <unistd.h>

--- a/dist/IO/Makefile.PL
+++ b/dist/IO/Makefile.PL
@@ -19,6 +19,10 @@ unless ( $PERL_CORE or exists $Config{'i_poll'} ) {
     }
 }
 
+if (!$PERL_CORE) {
+    $define .= '-DUSE_PPPORT_H ';
+}
+
 #--- Write the Makefile
 
 WriteMakefile(

--- a/dist/IO/lib/IO/Dir.pm
+++ b/dist/IO/lib/IO/Dir.pm
@@ -18,7 +18,7 @@ use File::stat;
 use File::Spec;
 
 our @ISA = qw(Tie::Hash Exporter);
-our $VERSION = "1.49";
+our $VERSION = "1.51";
 
 our @EXPORT_OK = qw(DIR_UNLINK);
 

--- a/dist/IO/lib/IO/File.pm
+++ b/dist/IO/lib/IO/File.pm
@@ -135,7 +135,7 @@ require Exporter;
 
 our @ISA = qw(IO::Handle IO::Seekable Exporter);
 
-our $VERSION = "1.48";
+our $VERSION = "1.51";
 
 our @EXPORT = @IO::Seekable::EXPORT;
 

--- a/dist/IO/lib/IO/Handle.pm
+++ b/dist/IO/lib/IO/Handle.pm
@@ -270,7 +270,7 @@ use IO ();	# Load the XS module
 require Exporter;
 our @ISA = qw(Exporter);
 
-our $VERSION = "1.49";
+our $VERSION = "1.51";
 
 our @EXPORT_OK = qw(
     autoflush

--- a/dist/IO/lib/IO/Poll.pm
+++ b/dist/IO/lib/IO/Poll.pm
@@ -12,7 +12,7 @@ use IO::Handle;
 use Exporter ();
 
 our @ISA = qw(Exporter);
-our $VERSION = "1.49";
+our $VERSION = "1.51";
 
 our @EXPORT = qw( POLLIN
 	      POLLOUT

--- a/dist/IO/lib/IO/Seekable.pm
+++ b/dist/IO/lib/IO/Seekable.pm
@@ -106,7 +106,7 @@ require Exporter;
 our @EXPORT = qw(SEEK_SET SEEK_CUR SEEK_END);
 our @ISA = qw(Exporter);
 
-our $VERSION = "1.48";
+our $VERSION = "1.51";
 
 sub seek {
     @_ == 3 or croak 'usage: $io->seek(POS, WHENCE)';

--- a/dist/IO/lib/IO/Select.pm
+++ b/dist/IO/lib/IO/Select.pm
@@ -10,7 +10,7 @@ use     strict;
 use warnings::register;
 require Exporter;
 
-our $VERSION = "1.49";
+our $VERSION = "1.51";
 
 our @ISA = qw(Exporter); # This is only so we can do version checking
 

--- a/dist/IO/lib/IO/Socket.pm
+++ b/dist/IO/lib/IO/Socket.pm
@@ -23,7 +23,7 @@ require IO::Socket::UNIX if ($^O ne 'epoc' && $^O ne 'symbian');
 
 our @ISA = qw(IO::Handle);
 
-our $VERSION = "1.49";
+our $VERSION = "1.51";
 
 our @EXPORT_OK = qw(sockatmark);
 

--- a/dist/IO/lib/IO/Socket/UNIX.pm
+++ b/dist/IO/lib/IO/Socket/UNIX.pm
@@ -11,7 +11,7 @@ use IO::Socket;
 use Carp;
 
 our @ISA = qw(IO::Socket);
-our $VERSION = "1.50";
+our $VERSION = "1.51";
 
 IO::Socket::UNIX->register_domain( AF_UNIX );
 

--- a/dist/Unicode-Normalize/Makefile.PL
+++ b/dist/Unicode-Normalize/Makefile.PL
@@ -3,6 +3,8 @@ use warnings;
 
 use ExtUtils::MakeMaker;
 
+my $PERL_CORE = grep { $_ eq 'PERL_CORE=1' } @ARGV;
+
 my $clean = {};
 
 my $mm_ver = ExtUtils::MakeMaker->VERSION;
@@ -15,6 +17,8 @@ if (-f "Normalize.xs") {
     $clean = { FILES => 'unfcan.h unfcmb.h unfcmp.h unfcpt.h unfexc.h' };
 }
 
+my $defines = $PERL_CORE ? '' : '-DUSE_PPPORT_H';
+
 WriteMakefile(
     ($mm_ver < 6.58)
     ? ('AUTHOR' => 'SADAHIRO Tomoyuki <SADAHIRO@cpan.org>, Karl Williamson <khw@cpan.org>')
@@ -25,6 +29,7 @@ WriteMakefile(
     'ABSTRACT'          => 'Unicode Normalization Forms',
     'INSTALLDIRS'       => ($] >= 5.007002 && $] < 5.011) ? 'perl' : 'site',
                             # see perl5110delta, @INC reorganization
+    'DEFINE'            => $defines,
     'LICENSE'           => 'perl',
     'NAME'              => 'Unicode::Normalize',
     'VERSION_FROM'      => 'Normalize.pm', # finds $VERSION

--- a/dist/Unicode-Normalize/Normalize.pm
+++ b/dist/Unicode-Normalize/Normalize.pm
@@ -7,7 +7,7 @@ use Carp;
 
 no warnings 'utf8';
 
-our $VERSION = '1.32';
+our $VERSION = '1.33';
 our $PACKAGE = __PACKAGE__;
 
 our @EXPORT = qw( NFC NFD NFKC NFKD );

--- a/dist/Unicode-Normalize/Normalize.xs
+++ b/dist/Unicode-Normalize/Normalize.xs
@@ -13,8 +13,10 @@
 #include "perl.h"
 #include "XSUB.h"
 
-#define NEED_utf8_to_uvchr_buf
-#include "ppport.h"
+#ifdef USE_PPPORT_H
+#   define NEED_utf8_to_uvchr_buf
+#   include "ppport.h"
+#endif
 
 /* These 5 files are prepared by mkheader */
 #include "unfcmb.h"


### PR DESCRIPTION
When building extensions in core, ppport.h should not be needed. Update IO and Unicode-Normalize to avoid it when built in core.