### PR TITLE
Add builtin::export_lexically

### DIFF
--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -25,6 +25,7 @@ builtin - Perl pragma to import built-in utility functions
         indexed
         trim
         is_tainted
+        export_lexically
     );
 
 =head1 DESCRIPTION
@@ -287,6 +288,35 @@ L<String::Util> module for a comparable implementation.
     $bool = is_tainted($var);
 
 Returns true when given a tainted variable.
+
+=head2 export_lexically
+
+    export_lexically($name1, $ref1, $name2, $ref2, ...)
+
+Exports new lexical names into the scope currently being compiled. Names given
+by the first of each pair of values will refer to the corresponding item whose
+reference is given by the second. Types of item that are permitted are
+subroutines, and scalar, array, and hash variables. If the item is a
+subroutine, the name may optionally be prefixed with the C<&> sigil, but for
+convenience it doesn't have to. For items that are variables the sigil is
+required, and must match the type of the variable.
+
+    export_lexically func    => \&func,
+                     '&func' => \&func;  # same as above
+
+    export_lexically '$scalar' => \my $var;
+
+Z<>
+
+    # The following are not permitted
+    export_lexically '$var' => \@arr;   # sigil does not match
+    export_lexically name => \$scalar;  # implied '&' sigil does not match
+
+    export_lexically '*name' => \*globref;  # globrefs are not supported
+
+This must be called at compile time; which typically means during a C<BEGIN>
+block. Usually this would be used as part of an C<import> method of a module,
+when invoked as part of a C<use ...> statement.
 
 =head1 SEE ALSO
 

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -358,6 +358,41 @@ TODO: {
     is($storecount, 1, 'is_tainted() invokes STORE magic');
 }
 
+# Lexical export
+{
+    my $name;
+    BEGIN {
+        use builtin qw( export_lexically );
+
+        $name = "message";
+        export_lexically $name => sub { "Hello, world" };
+    }
+
+    is(message(), "Hello, world", 'Lexically exported sub is callable');
+    ok(!__PACKAGE__->can("message"), 'Exported sub is not visible via ->can');
+
+    is($name, "message", '$name argument was not modified by export_lexically');
+
+    our ( $scalar, @array, %hash );
+    BEGIN {
+        use builtin qw( export_lexically );
+
+        export_lexically
+            '$SCALAR' => \$scalar,
+            '@ARRAY'  => \@array,
+            '%HASH'   => \%hash;
+    }
+
+    $::scalar = "value";
+    is($SCALAR, "value", 'Lexically exported scalar is accessible');
+
+    @::array = ('a' .. 'e');
+    is(scalar @ARRAY, 5, 'Lexically exported array is accessible');
+
+    %::hash = (key => "val");
+    is($HASH{key}, "val", 'Lexically exported hash is accessible');
+}
+
 # vim: tabstop=4 shiftwidth=4 expandtab autoindent softtabstop=4
 
 done_testing();

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -129,6 +129,8 @@ L<builtin> has been upgraded from version 0.007 to 0.008.
 
 Added the is_tainted() builtin function. [github #19854]
 
+Added the C<export_lexically()> function. [github #19895]
+
 =item *
 
 L<feature> has been upgraded from version 1.74 to 1.75.

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2275,6 +2275,12 @@ as a goto, or a loop control statement.
 (W exiting) You are exiting a substitution by unconventional means, such
 as a return, a goto, or a loop control statement.
 
+=item Expected %s reference in export_lexically
+
+(F) The type of a reference given to L<builtin/export_lexically> did not
+match the sigil of the preceding name, or the value was not a reference at
+all. 
+
 =item Expecting close bracket in regex; marked by S<<-- HERE> in m/%s/
 
 (F) You wrote something like
@@ -2326,6 +2332,12 @@ has been removed.  The C<postderef> feature may meet your needs better.
 the effect of blessing the reference into the package main.  This is
 usually not what you want.  Consider providing a default target package,
 e.g. bless($ref, $p || 'MyPackage');
+
+=item export_lexically can only be called at compile time
+
+(F) L<builtin/export_lexically> was called at runtime.  Because it creates
+new names in the lexical scope currently being compiled, it can only be
+called from code inside C<BEGIN> block in that scope.
 
 =item %s: Expression syntax
 
@@ -4449,6 +4461,12 @@ arguments.  The arguments should come in pairs.
 
 (W misc) You specified an odd number of elements to initialize a hash,
 which is odd, because hashes come in key/value pairs.
+
+=item Odd number of elements in export_lexically
+
+(F) A call to L<builtin/export_lexically> contained an odd number of
+arguments.  This is not permitted, because each name must be paired with a
+valid reference value.
 
 =item Odd number of elements in hash assignment
 


### PR DESCRIPTION
Adds a `builtin::` function for performing the lexical-export behaviour, so that new code can do the same trickery that core `builtin::` itself achieves.