### PR TITLE
Rename some grammar rules/tokens to avoid 'method'

### DIFF
--- a/perly.act
+++ b/perly.act
@@ -2083,6 +2083,6 @@ case 2:
     
 
 /* Generated from:
- * f6f4ca1df1f28e285f644b160b176887b111ca03c1fd20e3b4868c27a2c93623 perly.y
+ * a24382f2699548896a26e257b6f72e255658ef63e4dd5820a5cbe07d690b6f05 perly.y
  * acf1cbfd2545faeaaa58b1cf0cf9d7f98b5be0752eb7a54528ef904a9e2e1ca7 regen_perly.pl
  * ex: set ro: */

--- a/perly.h
+++ b/perly.h
@@ -80,8 +80,8 @@ extern int yydebug;
     PERLY_SNAIL = 279,
     PERLY_STAR = 280,
     BAREWORD = 281,
-    METHOD = 282,
-    FUNCMETH = 283,
+    METHCALL0 = 282,
+    METHCALL = 283,
     THING = 284,
     PMFUNC = 285,
     PRIVATEREF = 286,
@@ -179,10 +179,10 @@ S_is_opval_token(int type) {
     case BAREWORD:
     case FUNC0OP:
     case FUNC0SUB:
-    case FUNCMETH:
     case LABEL:
     case LSTOPSUB:
-    case METHOD:
+    case METHCALL:
+    case METHCALL0:
     case PLUGEXPR:
     case PLUGSTMT:
     case PMFUNC:
@@ -220,6 +220,6 @@ int yyparse (void);
 
 
 /* Generated from:
- * f6f4ca1df1f28e285f644b160b176887b111ca03c1fd20e3b4868c27a2c93623 perly.y
+ * a24382f2699548896a26e257b6f72e255658ef63e4dd5820a5cbe07d690b6f05 perly.y
  * acf1cbfd2545faeaaa58b1cf0cf9d7f98b5be0752eb7a54528ef904a9e2e1ca7 regen_perly.pl
  * ex: set ro: */

--- a/perly.tab
+++ b/perly.tab
@@ -117,14 +117,14 @@ static const char *const yytname[] =
   "PERLY_BRACKET_OPEN", "PERLY_BRACKET_CLOSE", "PERLY_COMMA",
   "PERLY_DOLLAR", "PERLY_DOT", "PERLY_EQUAL_SIGN", "PERLY_MINUS",
   "PERLY_PERCENT_SIGN", "PERLY_PLUS", "PERLY_SEMICOLON", "PERLY_SLASH",
-  "PERLY_SNAIL", "PERLY_STAR", "BAREWORD", "METHOD", "FUNCMETH", "THING",
-  "PMFUNC", "PRIVATEREF", "QWLIST", "FUNC0OP", "FUNC0SUB", "UNIOPSUB",
-  "LSTOPSUB", "PLUGEXPR", "PLUGSTMT", "LABEL", "FORMAT", "SUB", "SIGSUB",
-  "ANONSUB", "ANON_SIGSUB", "PACKAGE", "USE", "WHILE", "UNTIL", "IF",
-  "UNLESS", "ELSE", "ELSIF", "CONTINUE", "FOR", "GIVEN", "WHEN", "DEFAULT",
-  "TRY", "CATCH", "FINALLY", "LOOPEX", "DOTDOT", "YADAYADA", "FUNC0",
-  "FUNC1", "FUNC", "UNIOP", "LSTOP", "MULOP", "ADDOP", "DOLSHARP", "DO",
-  "HASHBRACK", "NOAMP", "LOCAL", "MY", "REQUIRE", "COLONATTR",
+  "PERLY_SNAIL", "PERLY_STAR", "BAREWORD", "METHCALL0", "METHCALL",
+  "THING", "PMFUNC", "PRIVATEREF", "QWLIST", "FUNC0OP", "FUNC0SUB",
+  "UNIOPSUB", "LSTOPSUB", "PLUGEXPR", "PLUGSTMT", "LABEL", "FORMAT", "SUB",
+  "SIGSUB", "ANONSUB", "ANON_SIGSUB", "PACKAGE", "USE", "WHILE", "UNTIL",
+  "IF", "UNLESS", "ELSE", "ELSIF", "CONTINUE", "FOR", "GIVEN", "WHEN",
+  "DEFAULT", "TRY", "CATCH", "FINALLY", "LOOPEX", "DOTDOT", "YADAYADA",
+  "FUNC0", "FUNC1", "FUNC", "UNIOP", "LSTOP", "MULOP", "ADDOP", "DOLSHARP",
+  "DO", "HASHBRACK", "NOAMP", "LOCAL", "MY", "REQUIRE", "COLONATTR",
   "FORMLBRACK", "FORMRBRACK", "SUBLEXSTART", "SUBLEXEND", "DEFER",
   "PREC_LOW", "OROP", "ANDOP", "NOTOP", "ASSIGNOP", "PERLY_QUESTION_MARK",
   "PERLY_COLON", "OROR", "DORDOR", "ANDAND", "BITOROP", "BITANDOP",
@@ -143,12 +143,12 @@ static const char *const yytname[] =
   "sigdefault", "sigscalarelem", "sigelem", "siglist", "optsiglist",
   "optsubsignature", "subsignature", "subsigguts", "$@18", "optsubbody",
   "subbody", "optsigsubbody", "sigsubbody", "expr", "listexpr", "listop",
-  "@19", "method", "subscripted", "termbinop", "termrelop", "relopchain",
-  "termeqop", "eqopchain", "termunop", "anonymous", "termdo", "term",
-  "@20", "myattrterm", "myterm", "optlistexpr", "optexpr", "optrepl",
-  "my_scalar", "list_of_scalars", "my_list_of_scalars", "my_var",
-  "refgen_topic", "my_refgen", "amper", "scalar", "ary", "hsh", "arylen",
-  "star", "sliceme", "kvslice", "gelem", "indirob", YY_NULLPTR
+  "@19", "methodname", "subscripted", "termbinop", "termrelop",
+  "relopchain", "termeqop", "eqopchain", "termunop", "anonymous", "termdo",
+  "term", "@20", "myattrterm", "myterm", "optlistexpr", "optexpr",
+  "optrepl", "my_scalar", "list_of_scalars", "my_list_of_scalars",
+  "my_var", "refgen_topic", "my_refgen", "amper", "scalar", "ary", "hsh",
+  "arylen", "star", "sliceme", "kvslice", "gelem", "indirob", YY_NULLPTR
 };
 #endif
 
@@ -1169,14 +1169,14 @@ static const toketypes yy_type_tab[] =
   toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival,
-  toketype_ival, toketype_ival, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
+  toketype_ival, toketype_ival, toketype_opval, toketype_opval, toketype_opval,
   toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
-  toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_ival, toketype_ival, toketype_ival,
+  toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
-  toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
+  toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
@@ -1195,15 +1195,15 @@ static const toketypes yy_type_tab[] =
   toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
   toketype_opval, toketype_opval, toketype_opval, toketype_ival, toketype_opval,
   toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
-  toketype_ival, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
+  toketype_ival, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
   toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
-  toketype_ival, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
+  toketype_opval, toketype_ival, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
   toketype_opval, toketype_opval, toketype_opval, toketype_opval,
-  toketype_opval, toketype_ival, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
-  toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval
+  toketype_opval, toketype_opval, toketype_ival, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
+  toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval
 };
 
 /* Generated from:
- * f6f4ca1df1f28e285f644b160b176887b111ca03c1fd20e3b4868c27a2c93623 perly.y
+ * a24382f2699548896a26e257b6f72e255658ef63e4dd5820a5cbe07d690b6f05 perly.y
  * acf1cbfd2545faeaaa58b1cf0cf9d7f98b5be0752eb7a54528ef904a9e2e1ca7 regen_perly.pl
  * ex: set ro: */


### PR DESCRIPTION
These token names are shared between `perl.y` and `toke.c`, to communicate on the nature of various tokens parsed from perl source. The name `FUNCMETH` used to refer to a method call with possible arguments

    ->NAME(...)

whereas `METHOD` referred to one without even the parens

    ->NAME

These names are a little confusing, and most importantly, `METHOD` was in the way of my adding a new `method` keyword as part of the upcoming work on 'use feature "class"'.

As such, this simple rename moves them out of the way and makes them slightly more consistent and easier to read/remember, by calling them `METHCALL` and `METHCALL0`.

This commit also renames the `method` grammar rule to `methodname`, for similar reasons.

As all of these names are entirely internal to the tokenizer/parser, there is not expected to be any upstream CPAN incompatibility, or other issues, caused by these renames.