### PR TITLE
PathTools/Cwd.xs: define SYSNAME/SYSNAME_LEN for OS390 only

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1147,6 +1147,7 @@ Marcel Grünauer <marcel@codewerk.com> Marcel Gruenauer <hanekomu@gmail.com>
 Marcel Grünauer <marcel@codewerk.com> Marcel Grunauer <marcel@codewerk.com>
 Marcel Grünauer <marcel@codewerk.com> Marcel Grünauer <gr@univie.ac.at>
 Marcel Grünauer <marcel@codewerk.com> Marcel Grünauer <marcel@codewerk.com>
+Marcel Telka <marcel@telka.sk> Marcel Telka <marcel@telka.sk>
 Marco Fontani <mfontani@cpan.org> Marco Fontani <mfontani@cpan.org>
 Marco Peereboom <marco@conformal.com> Marco Peereboom <marco@conformal.com>
 Marcus Holland-Moritz <mhx-perl@gmx.net> Marcus Holland-Moritz <mhx-perl@gmx.net>

--- a/AUTHORS
+++ b/AUTHORS
@@ -852,6 +852,7 @@ Marc Reisner                   <reisner.marc@gmail.com>
 Marc Simpson                   <marc@0branch.com>
 Marc-Philip Werner             <marc-philip.werner@sap.com>
 Marcel Grünauer                <marcel@codewerk.com>
+Marcel Telka                   <marcel@telka.sk>
 Marco Fontani                  <MFONTANI@cpan.org>
 Marco Peereboom                <marco@conformal.com>
 Marcus Holland-Moritz          <mhx-perl@gmx.net>

--- a/dist/PathTools/Changes
+++ b/dist/PathTools/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl distribution PathTools.
 
+3.86
+
+- Fix compilation warning on illumos based platforms
+
 3.85
 
 - Fix issue related to tainting empty PATH

--- a/dist/PathTools/Cwd.pm
+++ b/dist/PathTools/Cwd.pm
@@ -3,7 +3,7 @@ use strict;
 use Exporter;
 
 
-our $VERSION = '3.85';
+our $VERSION = '3.86';
 my $xs_version = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/dist/PathTools/Cwd.xs
+++ b/dist/PathTools/Cwd.xs
@@ -24,8 +24,10 @@
 #endif
 
 /* For special handling of os390 sysplexed systems */
+#ifdef OS390
 #define SYSNAME "$SYSNAME"
 #define SYSNAME_LEN (sizeof(SYSNAME) - 1)
+#endif
 
 /* The realpath() implementation from OpenBSD 3.9 to 4.2 (realpath.c 1.13)
  * Renamed here to bsd_realpath() to avoid library conflicts.
@@ -202,7 +204,7 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
                     if (slen < 0)
                         return (NULL);
                     symlink[slen] = '\0';
-#  ifdef EBCDIC /* XXX Probably this should be only os390 */
+#  ifdef OS390
                     /* Replace all instances of $SYSNAME/foo simply by /foo */
                     if (slen > SYSNAME_LEN + strlen(next_token)
                         && strnEQ(symlink, SYSNAME, SYSNAME_LEN)
@@ -245,7 +247,7 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
                     }
                     remaining_len = my_strlcpy(remaining, symlink, sizeof(remaining));
                 }
-#  ifdef EBCDIC
+#  ifdef OS390
               not_symlink: ;
 #  endif
             }

--- a/dist/PathTools/lib/File/Spec.pm
+++ b/dist/PathTools/lib/File/Spec.pm
@@ -2,7 +2,7 @@ package File::Spec;
 
 use strict;
 
-our $VERSION = '3.85';
+our $VERSION = '3.86';
 $VERSION =~ tr/_//d;
 
 my %module = (

--- a/dist/PathTools/lib/File/Spec/AmigaOS.pm
+++ b/dist/PathTools/lib/File/Spec/AmigaOS.pm
@@ -3,7 +3,7 @@ package File::Spec::AmigaOS;
 use strict;
 require File::Spec::Unix;
 
-our $VERSION = '3.85';
+our $VERSION = '3.86';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Cygwin.pm
+++ b/dist/PathTools/lib/File/Spec/Cygwin.pm
@@ -3,7 +3,7 @@ package File::Spec::Cygwin;
 use strict;
 require File::Spec::Unix;
 
-our $VERSION = '3.85';
+our $VERSION = '3.86';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Epoc.pm
+++ b/dist/PathTools/lib/File/Spec/Epoc.pm
@@ -2,7 +2,7 @@ package File::Spec::Epoc;
 
 use strict;
 
-our $VERSION = '3.85';
+our $VERSION = '3.86';
 $VERSION =~ tr/_//d;
 
 require File::Spec::Unix;

--- a/dist/PathTools/lib/File/Spec/Functions.pm
+++ b/dist/PathTools/lib/File/Spec/Functions.pm
@@ -3,7 +3,7 @@ package File::Spec::Functions;
 use File::Spec;
 use strict;
 
-our $VERSION = '3.85';
+our $VERSION = '3.86';
 $VERSION =~ tr/_//d;
 
 require Exporter;

--- a/dist/PathTools/lib/File/Spec/Mac.pm
+++ b/dist/PathTools/lib/File/Spec/Mac.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.85';
+our $VERSION = '3.86';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/OS2.pm
+++ b/dist/PathTools/lib/File/Spec/OS2.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.85';
+our $VERSION = '3.86';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Unix.pm
+++ b/dist/PathTools/lib/File/Spec/Unix.pm
@@ -3,7 +3,7 @@ package File::Spec::Unix;
 use strict;
 use Cwd ();
 
-our $VERSION = '3.85';
+our $VERSION = '3.86';
 $VERSION =~ tr/_//d;
 
 =head1 NAME

--- a/dist/PathTools/lib/File/Spec/VMS.pm
+++ b/dist/PathTools/lib/File/Spec/VMS.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.85';
+our $VERSION = '3.86';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Win32.pm
+++ b/dist/PathTools/lib/File/Spec/Win32.pm
@@ -5,7 +5,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.85';
+our $VERSION = '3.86';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);


### PR DESCRIPTION
This fixes the following warning on illumos based platforms:

    Cwd.xs:27:0: warning: "SYSNAME" redefined
     #define SYSNAME "$SYSNAME"

    In file included from ../../perl.h:1111:0,
                     from Cwd.xs:8:
    /usr/include/sys/param.h:184:0: note: this is the location of the previous definition
     #define SYSNAME 9  /* # chars in system name */

Also, both SYSNAME and SYSNAME_LEN are used later in the code only in a case
the EBCDIC is defined so it is safe to have defined them for EBCDIC only.