### PR TITLE
win32/vmem.h - memory alignment needed for gcc-12

### DIFF
--- a/win32/vmem.h
+++ b/win32/vmem.h
@@ -69,12 +69,24 @@ inline void MEMODSlx(char *str, long x)
 
 #ifdef _USE_LINKED_LIST
 class VMem;
+
+#if defined(__MINGW64__) && __GNUC__ > 11
+typedef struct _MemoryBlockHeader* PMEMORY_BLOCK_HEADER __attribute__ ((aligned(16)));
+#else
 typedef struct _MemoryBlockHeader* PMEMORY_BLOCK_HEADER;
+#endif
+
 typedef struct _MemoryBlockHeader {
     PMEMORY_BLOCK_HEADER    pNext;
     PMEMORY_BLOCK_HEADER    pPrev;
     VMem *owner;
+
+#if defined(__MINGW64__) && __GNUC__ > 11
+} MEMORY_BLOCK_HEADER __attribute__ ((aligned(16))), *PMEMORY_BLOCK_HEADER;
+#else
 } MEMORY_BLOCK_HEADER, *PMEMORY_BLOCK_HEADER;
+#endif
+
 #endif
 
 class VMem

--- a/win32/vmem.h
+++ b/win32/vmem.h
@@ -70,6 +70,12 @@ inline void MEMODSlx(char *str, long x)
 #ifdef _USE_LINKED_LIST
 class VMem;
 
+/*
+ * Address an alignment issue with x64 mingw-w64 ports of gcc-12 and
+ * (presumably) later. We do the same thing again 16 lines further down.
+ * See https://github.com/Perl/perl5/issues/19824
+ */
+
 #if defined(__MINGW64__) && __GNUC__ > 11
 typedef struct _MemoryBlockHeader* PMEMORY_BLOCK_HEADER __attribute__ ((aligned(16)));
 #else


### PR DESCRIPTION
64-bit mingw-w64 ports of gcc version 12 currently build a perl.exe that crashes immediately upon execution.
This PR addresses and resolves that issue.
See discussion at https://github.com/Perl/perl5/issues/19824.

Note that the additional issue (of some crashes during 'make test')  mentioned there is not addressed by this PR.
It's something that should be fixed ... but I don't have the solution to it.
For now, we can work around that issue by choosing favorable options regarding optimization level and/or threading.
The selection of those options can be made without any need to make further changes to the perl source.

Cheers,
Rob
