### PR TITLE
Neaten Padname flag contants

### DIFF
--- a/ext/B/B.pm
+++ b/ext/B/B.pm
@@ -20,7 +20,7 @@ sub import {
 # walkoptree comes from B.xs
 
 BEGIN {
-    $B::VERSION = '1.84';
+    $B::VERSION = '1.85';
     @B::EXPORT_OK = ();
 
     # Our BOOT code needs $VERSION set, and will append to @EXPORT_OK.

--- a/ext/B/B.xs
+++ b/ext/B/B.xs
@@ -2351,7 +2351,7 @@ PadnameFLAGS(pn)
 	RETVAL = PadnameFLAGS(pn);
 	/* backward-compatibility hack, which should be removed if the
 	   flags field becomes large enough to hold SVf_FAKE (and
-	   PADNAMEt_OUTER should be renumbered to match SVf_FAKE) */
+	   PADNAMEf_OUTER should be renumbered to match SVf_FAKE) */
 	STATIC_ASSERT_STMT(SVf_FAKE >= 1<<(sizeof(PadnameFLAGS((B__PADNAME)NULL)) * 8));
 	if (PadnameOUTER(pn))
 	    RETVAL |= SVf_FAKE;

--- a/ext/B/Makefile.PL
+++ b/ext/B/Makefile.PL
@@ -30,7 +30,7 @@ foreach my $tuple (['cop.h'],
                    ['op.h'],
                    ['opcode.h', 'OPp'],
                    ['op_reg_common.h','(?:(?:RXf_)?PMf_)'],
-                   ['pad.h','PADNAMEt_'],
+                   ['pad.h','PADNAMEf_'],
                    ['regexp.h','RXf_'],
                    ['sv.h', 'SV(?:[fps]|pad)_'],
                   ) {

--- a/op.c
+++ b/op.c
@@ -9683,7 +9683,7 @@ S_op_const_sv(pTHX_ const OP *o, CV *cv, bool allow_lex)
             SAVEFREESV(sv);
         }
         else if (allow_lex && type == OP_PADSV) {
-                if (PAD_COMPNAME_FLAGS(o->op_targ) & PADNAMEt_OUTER)
+                if (PAD_COMPNAME_FLAGS(o->op_targ) & PADNAMEf_OUTER)
                 {
                     sv = &PL_sv_undef; /* an arbitrary non-null value */
                     padsv = TRUE;

--- a/op.c
+++ b/op.c
@@ -2672,7 +2672,7 @@ Perl_check_hash_fields_and_hekify(pTHX_ UNOP *rop, SVOP *key_op, int real)
     check_fields =
             rop
          && (lexname = padnamelist_fetch(PL_comppad_name, rop->op_targ),
-             SvPAD_TYPED(lexname))
+             PadnameHasTYPE(lexname))
          && (fields = (GV**)hv_fetchs(PadnameTYPE(lexname), "FIELDS", FALSE))
          && isGV(*fields) && GvHV(*fields);
 

--- a/pad.c
+++ b/pad.c
@@ -2753,9 +2753,9 @@ Perl_newPADNAMEpvn(const char *s, STRLEN len)
 Constructs and returns a new pad name.  Only use this function for names
 that refer to outer lexicals.  (See also L</newPADNAMEpvn>.)  C<outer> is
 the outer pad name that this one mirrors.  The returned pad name has the
-C<PADNAMEt_OUTER> flag already set.
+C<PADNAMEf_OUTER> flag already set.
 
-=for apidoc Amnh||PADNAMEt_OUTER
+=for apidoc Amnh||PADNAMEf_OUTER
 
 =cut
 */
@@ -2771,7 +2771,7 @@ Perl_newPADNAMEouter(PADNAME *outer)
     /* Not PadnameREFCNT(outer), because ‘outer’ may itself close over
        another entry.  The original pad name owns the buffer.  */
     PadnameREFCNT(PADNAME_FROM_PV(PadnamePV(outer)))++;
-    PadnameFLAGS(pn) = PADNAMEt_OUTER;
+    PadnameFLAGS(pn) = PADNAMEf_OUTER;
     PadnameLEN(pn) = PadnameLEN(outer);
     return pn;
 }

--- a/pad.h
+++ b/pad.h
@@ -318,6 +318,7 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PadnameIsOUR(pn)	cBOOL((pn)->xpadn_ourstash)
 #define PadnameOURSTASH(pn)	(pn)->xpadn_ourstash
 #define PadnameTYPE(pn)		(pn)->xpadn_type_u.xpadn_typestash
+#define PadnameHasTYPE(pn)      cBOOL(PadnameTYPE(pn))
 #define PadnamePROTOCV(pn)	(pn)->xpadn_type_u.xpadn_protocv
 #define PadnameREFCNT(pn)	(pn)->xpadn_refcnt
 #define PadnameREFCNT_dec(pn)	Perl_padname_free(aTHX_ pn)
@@ -337,18 +338,18 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PADNAMEf_OUR	0x10	/* for B; unused by core */
 
 /* backward compatibility */
-#define SvPAD_STATE		PadnameIsSTATE
-#define SvPAD_TYPED(pn)	        cBOOL(PadnameTYPE(pn))
-#define SvPAD_OUR(pn)	        cBOOL(PadnameOURSTASH(pn))
-#define SvPAD_STATE_on		PadnameIsSTATE_on
-#define SvPAD_TYPED_on(pn)	(PadnameFLAGS(pn) |= PADNAMEf_TYPED)
-#define SvPAD_OUR_on(pn)	(PadnameFLAGS(pn) |= PADNAMEf_OUR)
-#define SvOURSTASH		PadnameOURSTASH
-#define SvOURSTASH_set		PadnameOURSTASH_set
-#define SVpad_STATE		PADNAMEf_STATE
-#define SVpad_TYPED		PADNAMEf_TYPED
-#define SVpad_OUR		PADNAMEf_OUR
 #ifndef PERL_CORE
+#  define SvPAD_STATE           PadnameIsSTATE
+#  define SvPAD_TYPED           PadnameHasTYPE
+#  define SvPAD_OUR(pn)         cBOOL(PadnameOURSTASH(pn))
+#  define SvPAD_STATE_on        PadnameIsSTATE_on
+#  define SvPAD_TYPED_on(pn)    (PadnameFLAGS(pn) |= PADNAMEf_TYPED)
+#  define SvPAD_OUR_on(pn)      (PadnameFLAGS(pn) |= PADNAMEf_OUR)
+#  define SvOURSTASH            PadnameOURSTASH
+#  define SvOURSTASH_set        PadnameOURSTASH_set
+#  define SVpad_STATE           PADNAMEf_STATE
+#  define SVpad_TYPED           PADNAMEf_TYPED
+#  define SVpad_OUR             PADNAMEf_OUR
 #  define PADNAMEt_OUTER        PADNAMEf_OUTER
 #  define PADNAMEt_STATE        PADNAMEf_STATE
 #  define PADNAMEt_LVALUE       PADNAMEf_LVALUE
@@ -452,13 +453,12 @@ ling pad (lvalue) to C<gen>.
 #define PAD_COMPNAME(po)	PAD_COMPNAME_SV(po)
 #define PAD_COMPNAME_SV(po)	(PadnamelistARRAY(PL_comppad_name)[(po)])
 #define PAD_COMPNAME_FLAGS(po)	PadnameFLAGS(PAD_COMPNAME(po))
-#define PAD_COMPNAME_FLAGS_isOUR(po) SvPAD_OUR(PAD_COMPNAME_SV(po))
+#define PAD_COMPNAME_FLAGS_isOUR(po) PadnameIsOUR(PAD_COMPNAME_SV(po))
 #define PAD_COMPNAME_PV(po)	PadnamePV(PAD_COMPNAME(po))
 
 #define PAD_COMPNAME_TYPE(po)	PadnameTYPE(PAD_COMPNAME(po))
 
-#define PAD_COMPNAME_OURSTASH(po) \
-    (SvOURSTASH(PAD_COMPNAME_SV(po)))
+#define PAD_COMPNAME_OURSTASH(po)  (PadnameOURSTASH(PAD_COMPNAME_SV(po)))
 
 #define PAD_COMPNAME_GEN(po) \
     ((STRLEN)PadnamelistARRAY(PL_comppad_name)[po]->xpadn_gen)

--- a/pad.h
+++ b/pad.h
@@ -323,31 +323,38 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PadnameREFCNT_dec(pn)	Perl_padname_free(aTHX_ pn)
 #define PadnameOURSTASH_set(pn,s) (PadnameOURSTASH(pn) = (s))
 #define PadnameTYPE_set(pn,s)	  (PadnameTYPE(pn) = (s))
-#define PadnameOUTER(pn)	(PadnameFLAGS(pn) & PADNAMEt_OUTER)
-#define PadnameIsSTATE(pn)	(PadnameFLAGS(pn) & PADNAMEt_STATE)
-#define PadnameLVALUE(pn)	(PadnameFLAGS(pn) & PADNAMEt_LVALUE)
+#define PadnameOUTER(pn)	(PadnameFLAGS(pn) & PADNAMEf_OUTER)
+#define PadnameIsSTATE(pn)	(PadnameFLAGS(pn) & PADNAMEf_STATE)
+#define PadnameLVALUE(pn)	(PadnameFLAGS(pn) & PADNAMEf_LVALUE)
 
-#define PadnameLVALUE_on(pn)	(PadnameFLAGS(pn) |= PADNAMEt_LVALUE)
-#define PadnameIsSTATE_on(pn)	(PadnameFLAGS(pn) |= PADNAMEt_STATE)
+#define PadnameLVALUE_on(pn)	(PadnameFLAGS(pn) |= PADNAMEf_LVALUE)
+#define PadnameIsSTATE_on(pn)	(PadnameFLAGS(pn) |= PADNAMEf_STATE)
 
-#define PADNAMEt_OUTER	1	/* outer lexical var */
-#define PADNAMEt_STATE	2	/* state var */
-#define PADNAMEt_LVALUE	4	/* used as lvalue */
-#define PADNAMEt_TYPED	8	/* for B; unused by core */
-#define PADNAMEt_OUR	16	/* for B; unused by core */
+#define PADNAMEf_OUTER	0x01	/* outer lexical var */
+#define PADNAMEf_STATE	0x02	/* state var */
+#define PADNAMEf_LVALUE	0x04	/* used as lvalue */
+#define PADNAMEf_TYPED	0x08	/* for B; unused by core */
+#define PADNAMEf_OUR	0x10	/* for B; unused by core */
 
 /* backward compatibility */
 #define SvPAD_STATE		PadnameIsSTATE
 #define SvPAD_TYPED(pn)	        cBOOL(PadnameTYPE(pn))
 #define SvPAD_OUR(pn)	        cBOOL(PadnameOURSTASH(pn))
 #define SvPAD_STATE_on		PadnameIsSTATE_on
-#define SvPAD_TYPED_on(pn)	(PadnameFLAGS(pn) |= PADNAMEt_TYPED)
-#define SvPAD_OUR_on(pn)	(PadnameFLAGS(pn) |= PADNAMEt_OUR)
+#define SvPAD_TYPED_on(pn)	(PadnameFLAGS(pn) |= PADNAMEf_TYPED)
+#define SvPAD_OUR_on(pn)	(PadnameFLAGS(pn) |= PADNAMEf_OUR)
 #define SvOURSTASH		PadnameOURSTASH
 #define SvOURSTASH_set		PadnameOURSTASH_set
-#define SVpad_STATE		PADNAMEt_STATE
-#define SVpad_TYPED		PADNAMEt_TYPED
-#define SVpad_OUR		PADNAMEt_OUR
+#define SVpad_STATE		PADNAMEf_STATE
+#define SVpad_TYPED		PADNAMEf_TYPED
+#define SVpad_OUR		PADNAMEf_OUR
+#ifndef PERL_CORE
+#  define PADNAMEt_OUTER        PADNAMEf_OUTER
+#  define PADNAMEt_STATE        PADNAMEf_STATE
+#  define PADNAMEt_LVALUE       PADNAMEf_LVALUE
+#  define PADNAMEt_TYPED        PADNAMEf_TYPED
+#  define PADNAMEt_OUR          PADNAMEf_OUR
+#endif
 
 #ifdef DEBUGGING
 #  define PAD_SV(po)	   pad_sv(po)


### PR DESCRIPTION
The constants were named `PADNAMEt_*` suggesting their purpose is a type enumeration. They're not. They're bitflags, so the name `PADNAMEf_*` would be more appropriate.

Also updated the `B` and `B::Deparse` modules to make use of the new modern names (and avoid the old `SVpad_*` flags).