### PR TITLE
Share duplicated aux data in regex patterns

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -20575,18 +20575,19 @@ S_set_ANYOF_arg(pTHX_ RExC_state_t* const pRExC_state,
             /* There are two such cases:
              *  1)  there is no list of code points matched outside the bitmap
              */
-        if (! cp_list) {
-            ARG_SET(node, ANYOF_MATCHES_NONE_OUTSIDE_BITMAP_VALUE);
-            return;
-        }
+            if (! cp_list) {
+                ARG_SET(node, ANYOF_MATCHES_NONE_OUTSIDE_BITMAP_VALUE);
+                return;
+            }
 
             /*  2)  the list indicates everything outside the bitmap matches */
-        if (   invlist_highest(cp_list) == UV_MAX
-            && invlist_highest_range_start(cp_list) <= NUM_ANYOF_CODE_POINTS)
-        {
-            ARG_SET(node, ANYOF_MATCHES_ALL_OUTSIDE_BITMAP_VALUE);
-            return;
-        }
+            if (   invlist_highest(cp_list) == UV_MAX
+                && invlist_highest_range_start(cp_list)
+                                                       <= NUM_ANYOF_CODE_POINTS)
+            {
+                ARG_SET(node, ANYOF_MATCHES_ALL_OUTSIDE_BITMAP_VALUE);
+                return;
+            }
 
             /* In all other cases there are things outside the bitmap that we
              * may need to check at runtime. */


### PR DESCRIPTION
Bracketed character classes may contain auxiliary data consisting of
inversion lists.  Some of these lists can be quite large, a couple
thousand UV-sized words; the worst case is much larger, but these are
the more likely worst case numbers.  If the same class is used a second
time or more in a pattern, the savings from sharing are considerable.
And it's not uncommon for such repeated classes to occur.

The official Unicode/Posix character classes are already in shared data,
so prior to this commit if you had a bunch of \w's in a pattern the only
duplication would be the array containing pointers to the bulk of the
data.  This commit eliminates even that.  But if someone said [\w,] for
example, that custom character class would have a copy of the \w
inversion list (plus the neglible comma) in each case.  That copy as of
Unicode 14.0 is about 1500 UV words.  Now any extra [\w,] classes would
share the same data as the first one in the pattern.