### PR TITLE
Unixish.h, doshish.h: Reorder terminations; simplify

### DIFF
--- a/dosish.h
+++ b/dosish.h
@@ -24,12 +24,17 @@
 #  define BIT_BUCKET "\\dev\\nul" /* "wanna be like, umm, Newlined, or somethin?" */
 #endif
 
+/* Generally add things last-in first-terminated.  IO and memory terminations
+ * need to be generally last
+ *
+ * BEWARE that using PerlIO in these will be using freed memory, so may appear
+ * to work, but must NOT be retained in production code. */
 #ifndef PERL_SYS_TERM_BODY
 #  define PERL_SYS_TERM_BODY()                         \
+    ENV_TERM; USER_PROP_MUTEX_TERM; LOCALE_TERM;       \
     HINTS_REFCNT_TERM; KEYWORD_PLUGIN_MUTEX_TERM;      \
-    OP_CHECK_MUTEX_TERM; OP_REFCNT_TERM; PERLIO_TERM;  \
-    MALLOC_TERM; LOCALE_TERM; USER_PROP_MUTEX_TERM;    \
-    ENV_TERM;
+    OP_CHECK_MUTEX_TERM; OP_REFCNT_TERM;               \
+    PERLIO_TERM; MALLOC_TERM; 
 #endif
 #define dXSUB_SYS dNOOP
 

--- a/unixish.h
+++ b/unixish.h
@@ -136,28 +136,34 @@ int afstat(int fd, struct stat *statb);
 #define Mkdir(path,mode)   mkdir((path),(mode))
 
 #if defined(__amigaos4__)
-#  define PERL_SYS_INIT_BODY(c,v)					\
-        MALLOC_CHECK_TAINT2(*c,*v) PERL_FPU_INIT; PERLIO_INIT; MALLOC_INIT; amigaos4_init_fork_array(); amigaos4_init_environ_sema();
-#  define PERL_SYS_TERM_BODY()                         \
-    HINTS_REFCNT_TERM; KEYWORD_PLUGIN_MUTEX_TERM;      \
-    OP_CHECK_MUTEX_TERM; OP_REFCNT_TERM; PERLIO_TERM;  \
-    MALLOC_TERM; LOCALE_TERM; USER_PROP_MUTEX_TERM;    \
-    ENV_TERM;                                          \
-    amigaos4_dispose_fork_array();
+#  define PLATFORM_SYS_TERM_  amigaos4_dispose_fork_array()
+#  define PLATFORM_SYS_INIT_ STMT_START {                       \
+                                amigaos4_init_fork_array();     \
+                                amigaos4_init_environ_sema();   \
+                             } STMT_END
+#else 
+#  define PLATFORM_SYS_TERM_  NOOP
+#  define PLATFORM_SYS_INIT_  NOOP
 #endif
 
 #ifndef PERL_SYS_INIT_BODY
-#  define PERL_SYS_INIT_BODY(c,v)					\
-        MALLOC_CHECK_TAINT2(*c,*v) PERL_FPU_INIT; PERLIO_INIT; MALLOC_INIT
+#define PERL_SYS_INIT_BODY(c,v)					\
+	MALLOC_CHECK_TAINT2(*c,*v) PERL_FPU_INIT; PERLIO_INIT;  \
+        MALLOC_INIT; PLATFORM_SYS_INIT_;
 #endif
 
+/* Generally add things last-in first-terminated.  IO and memory terminations
+ * need to be generally last
+ *
+ * BEWARE that using PerlIO in these will be using freed memory, so may appear
+ * to work, but must NOT be retained in production code. */
 #ifndef PERL_SYS_TERM_BODY
-#  define PERL_SYS_TERM_BODY()                         \
-    HINTS_REFCNT_TERM; KEYWORD_PLUGIN_MUTEX_TERM;      \
-    OP_CHECK_MUTEX_TERM; OP_REFCNT_TERM; PERLIO_TERM;  \
-    MALLOC_TERM; LOCALE_TERM; USER_PROP_MUTEX_TERM;    \
-    ENV_TERM;
-
+#  define PERL_SYS_TERM_BODY()                                          \
+                    ENV_TERM; USER_PROP_MUTEX_TERM; LOCALE_TERM;        \
+                    HINTS_REFCNT_TERM; KEYWORD_PLUGIN_MUTEX_TERM;       \
+                    OP_CHECK_MUTEX_TERM; OP_REFCNT_TERM;                \
+                    PERLIO_TERM; MALLOC_TERM;                           \
+                    PLATFORM_SYS_TERM_;
 #endif
 
 #define BIT_BUCKET "/dev/null"

--- a/vms/vmsish.h
+++ b/vms/vmsish.h
@@ -309,9 +309,8 @@ struct interp_intern {
 
 #define BIT_BUCKET "/dev/null"
 #define PERL_SYS_INIT_BODY(c,v)	MALLOC_CHECK_TAINT2(*c,*v) vms_image_init((c),(v)); PERLIO_INIT; MALLOC_INIT
-#define PERL_SYS_TERM_BODY()    HINTS_REFCNT_TERM; OP_REFCNT_TERM;      \
-                                PERLIO_TERM; MALLOC_TERM; LOCALE_TERM;  \
-                                ENV_TERM;
+/* Use standard PERL_SYS_TERM_BODY */
+
 #define dXSUB_SYS dNOOP
 #define HAS_KILL
 #define HAS_WAIT


### PR DESCRIPTION
The IO and memory terminations need to be after other things.  Add a
comment so that future maintainers won't make the mistakes I did.

Also refactor to that amiga os doesn't have a separate list to get out
of sync

I suspect that the amiga termination should be moved to earlier in
the sequence, but absent any evidence; I'm leaving it unchanged.

vms destruction was missing a bunch of things and I didn't see any
reason to have special handling, so I changed it to just use the
standard.