### PR TITLE
Revert "study_chunk: temporary underflow guard for scan_commit"

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -1607,8 +1607,6 @@ S_scan_commit(pTHX_ const RExC_state_t *pRExC_state, scan_data_t *data,
                        ? OPTIMIZE_INFTY
                        : (l
                           ? data->last_start_max
-                          /* temporary underflow guard for 5.32 */
-                          : data->pos_delta < 0 ? OPTIMIZE_INFTY
                           : (data->pos_delta > OPTIMIZE_INFTY - data->pos_min
                                          ? OPTIMIZE_INFTY
                                          : data->pos_min + data->pos_delta));


### PR DESCRIPTION
This reverts commit d23733db32b12b784b2bf07cae6d645569636f6d.
As it says in its message it should be reverted so as to surface
more underlying issues, early in the development cycle.