### PR TITLE
qr/\K*/ now works without hanging; rmv check

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -3212,14 +3212,6 @@ neither as a system call nor an ioctl call (SIOCATMARK).
 Perl.  The current valid ones are given in
 L<perlrebackslash/\b{}, \b, \B{}, \B>.
 
-=item %s is forbidden - matches null string many times in regex; marked by S<<-- HERE> in
-m/%s/
-
-(F) The pattern you've specified might cause the regular expression to
-infinite loop so it is forbidden.  The S<<-- HERE>
-shows whereabouts in the regular expression the problem was discovered.
-See L<perlre>.
-
 =item %s() isn't allowed on :utf8 handles
 
 (F) The sysread(), recv(), syswrite() and send() operators are

--- a/regcomp.c
+++ b/regcomp.c
@@ -13237,22 +13237,12 @@ S_regpiece(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
      * Check and possibly adjust a zero width operand */
     if (! (flags & (HASWIDTH|POSTPONED))) {
         if (max > REG_INFTY/3) {
-            if (origparse[0] == '\\' && origparse[1] == 'K') {
-                vFAIL2utf8f(
-                           "%" UTF8f " is forbidden - matches null string"
-                           " many times",
-                           UTF8fARG(UTF, (RExC_parse >= origparse
-                                         ? RExC_parse - origparse
-                                         : 0),
-                           origparse));
-            } else {
-                ckWARN2reg(RExC_parse,
-                           "%" UTF8f " matches null string many times",
-                           UTF8fARG(UTF, (RExC_parse >= origparse
-                                         ? RExC_parse - origparse
-                                         : 0),
-                           origparse));
-            }
+            ckWARN2reg(RExC_parse,
+                       "%" UTF8f " matches null string many times",
+                       UTF8fARG(UTF, (RExC_parse >= origparse
+                                     ? RExC_parse - origparse
+                                     : 0),
+                       origparse));
         }
 
         /* There's no point in trying to match something 0 length more than

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -2043,9 +2043,9 @@ AB\s+\x{100}	AB \x{100}X	y	-	-
 /(?:0)|(?:)(?:[1-9])/	q0	y	$&	0	# [https://github.com/Perl/perl5/issues/17372]
 /\x{_1_0000}/	\x{10000}	y	$&	\x{10000}		# khw doesn't like leading underscores, but don't rmv them accidentally
 /\o{_1_0000}/	\o{10000}	y	$&	\o{10000}
-/(?iaax:A? \K +)/	African_Feh	c	-	\\K + is forbidden - matches null string many times in regex
-/(?iaa:A?\K+)/	African_Feh	c	-	\\K+ is forbidden - matches null string many times in regex
-/(?iaa:A?\K*)/	African_Feh	c	-	\\K* is forbidden - matches null string many times in regex
+/(?iaax:A? \K +)/	African_Feh	y	$&	
+/(?iaa:A?\K+)/	African_Feh	y	$&	
+/(?iaa:A?\K*)/	African_Feh	y	$&	
 ^((\w|<(\s)*(?1)(?3)*>)(?:(?3)*\+(?3)*(?2))*)(?3)*\+	a + b + <c + d>	y	$1	a + b		# [GH #18096]
 ^((\w|<(\s)*(?1)(?3)*>)(?:(?3)*\+(?3)*(?2))*)(?3)*\+	a + <b> + c	y	$1	a + <b>		# [GH #18096]
 /0?\xdf\xdf\xdf\xdfs\o{500}|/i	\o{600}	y	$&				# [GH #18451]


### PR DESCRIPTION
This removes the diagnostic that was put into place to forbid saying
\K*, and similar, as the code now handles the case reasonably.