### PR TITLE
Rename `CVf_METHOD` to `CVf_NOWARN_AMBIGUOUS`

### DIFF
--- a/cv.h
+++ b/cv.h
@@ -107,7 +107,10 @@ See L<perlguts/Autoloading with XSUBs>.
           : 0                                           \
         )
 
-#define CVf_METHOD	0x0001	/* CV is explicitly marked as a method */
+/* CV has the `:method` attribute. This used to be called CVf_METHOD but is
+ * renamed to avoid collision with an upcoming feature */
+#define CVf_NOWARN_AMBIGUOUS	0x0001
+
 #define CVf_LVALUE	0x0002  /* CV return value can be used as lvalue */
 #define CVf_CONST	0x0004  /* inlinable sub */
 #define CVf_ISXSUB	0x0008	/* CV is an XSUB, not pure perl.  */
@@ -133,7 +136,7 @@ See L<perlguts/Autoloading with XSUBs>.
 #define CVf_SIGNATURE   0x40000 /* CV uses a signature */
 
 /* This symbol for optimised communication between toke.c and op.c: */
-#define CVf_BUILTIN_ATTRS	(CVf_METHOD|CVf_LVALUE|CVf_ANONCONST)
+#define CVf_BUILTIN_ATTRS	(CVf_NOWARN_AMBIGUOUS|CVf_LVALUE|CVf_ANONCONST)
 
 #define CvCLONE(cv)		(CvFLAGS(cv) & CVf_CLONE)
 #define CvCLONE_on(cv)		(CvFLAGS(cv) |= CVf_CLONE)
@@ -156,9 +159,9 @@ See L<perlguts/Autoloading with XSUBs>.
 #define CvNODEBUG_on(cv)	(CvFLAGS(cv) |= CVf_NODEBUG)
 #define CvNODEBUG_off(cv)	(CvFLAGS(cv) &= ~CVf_NODEBUG)
 
-#define CvMETHOD(cv)		(CvFLAGS(cv) & CVf_METHOD)
-#define CvMETHOD_on(cv)		(CvFLAGS(cv) |= CVf_METHOD)
-#define CvMETHOD_off(cv)	(CvFLAGS(cv) &= ~CVf_METHOD)
+#define CvNOWARN_AMBIGUOUS(cv)		(CvFLAGS(cv) & CVf_NOWARN_AMBIGUOUS)
+#define CvNOWARN_AMBIGUOUS_on(cv)	(CvFLAGS(cv) |= CVf_NOWARN_AMBIGUOUS)
+#define CvNOWARN_AMBIGUOUS_off(cv)	(CvFLAGS(cv) &= ~CVf_NOWARN_AMBIGUOUS)
 
 #define CvLVALUE(cv)		(CvFLAGS(cv) & CVf_LVALUE)
 #define CvLVALUE_on(cv)		(CvFLAGS(cv) |= CVf_LVALUE)

--- a/cv.h
+++ b/cv.h
@@ -227,6 +227,14 @@ See L<perlguts/Autoloading with XSUBs>.
 #define CvSIGNATURE_on(cv)	(CvFLAGS(cv) |= CVf_SIGNATURE)
 #define CvSIGNATURE_off(cv)	(CvFLAGS(cv) &= ~CVf_SIGNATURE)
 
+/* Back-compat */
+#ifndef PERL_CORE
+#  define CVf_METHOD            CVf_NOWARN_AMBIGUOUS
+#  define CvMETHOD(cv)          CvNOWARN_AMBIGUOUS(cv)
+#  define CvMETHOD_on(cv)       CvNOWARN_AMBIGUOUS_on(cv)
+#  define CvMETHOD_off(cv)      CvNOWARN_AMBIGUOUS_off(off)
+#endif
+
 /* Flags for newXS_flags  */
 #define XS_DYNAMIC_FILENAME	0x01	/* The filename isn't static  */
 

--- a/dump.c
+++ b/dump.c
@@ -1710,7 +1710,7 @@ const struct flag_to_name cv_flags_names[] = {
     {CVf_CONST, "CONST,"},
     {CVf_NODEBUG, "NODEBUG,"},
     {CVf_LVALUE, "LVALUE,"},
-    {CVf_METHOD, "METHOD,"},
+    {CVf_NOWARN_AMBIGUOUS, "NOWARN_AMBIGUOUS,"},
     {CVf_WEAKOUTSIDE, "WEAKOUTSIDE,"},
     {CVf_CVGV_RC, "CVGV_RC,"},
     {CVf_DYNFILE, "DYNFILE,"},

--- a/ext/B/B.pm
+++ b/ext/B/B.pm
@@ -88,6 +88,12 @@ our @specialsv_name = qw(Nullsv &PL_sv_undef &PL_sv_yes &PL_sv_no
 			(SV*)pWARN_ALL (SV*)pWARN_NONE (SV*)pWARN_STD
                         &PL_sv_zero);
 
+# Back-compat
+{
+    no warnings 'once';
+    *CVf_METHOD = \&CVf_NOWARN_AMBIGUOUS;
+}
+
 {
     # Stop "-w" from complaining about the lack of a real B::OBJECT class
     package B::OBJECT;

--- a/ext/attributes/attributes.pm
+++ b/ext/attributes/attributes.pm
@@ -1,6 +1,6 @@
 package attributes;
 
-our $VERSION = 0.34;
+our $VERSION = 0.35;
 
 @EXPORT_OK = qw(get reftype);
 @EXPORT = ();

--- a/ext/attributes/attributes.xs
+++ b/ext/attributes/attributes.xs
@@ -78,9 +78,9 @@ modify_SV_attributes(pTHX_ SV *sv, SV **retlist, SV **attrlist, int numattrs)
 		case 'h':
 		    if (memEQs(name, 6, "method")) {
 			if (negated)
-			    CvFLAGS(MUTABLE_CV(sv)) &= ~CVf_METHOD;
+			    CvFLAGS(MUTABLE_CV(sv)) &= ~CVf_NOWARN_AMBIGUOUS;
 			else
-			    CvFLAGS(MUTABLE_CV(sv)) |= CVf_METHOD;
+			    CvFLAGS(MUTABLE_CV(sv)) |= CVf_NOWARN_AMBIGUOUS;
 			continue;
 		    }
 		    break;
@@ -173,7 +173,7 @@ usage:
 	cvflags = CvFLAGS((const CV *)sv);
 	if (cvflags & CVf_LVALUE)
 	    XPUSHs(newSVpvs_flags("lvalue", SVs_TEMP));
-	if (cvflags & CVf_METHOD)
+	if (cvflags & CVf_NOWARN_AMBIGUOUS)
 	    XPUSHs(newSVpvs_flags("method", SVs_TEMP));
 	break;
     default:

--- a/gv.c
+++ b/gv.c
@@ -4143,7 +4143,7 @@ Perl_gv_try_downgrade(pTHX_ GV *gv)
     } else if (GvMULTI(gv) && cv && SvREFCNT(cv) == 1 &&
             !SvOBJECT(cv) && !SvMAGICAL(cv) && !SvREADONLY(cv) &&
             CvSTASH(cv) == stash && !CvNAMED(cv) && CvGV(cv) == gv &&
-            CvCONST(cv) && !CvMETHOD(cv) && !CvLVALUE(cv) && !CvUNIQUE(cv) &&
+            CvCONST(cv) && !CvNOWARN_AMBIGUOUS(cv) && !CvLVALUE(cv) && !CvUNIQUE(cv) &&
             !CvNODEBUG(cv) && !CvCLONE(cv) && !CvCLONED(cv) && !CvANON(cv) &&
             (namehek = GvNAME_HEK(gv)) &&
             (gvp = hv_fetchhek(stash, namehek, 0)) &&

--- a/lib/B/Deparse.pm
+++ b/lib/B/Deparse.pm
@@ -7,7 +7,7 @@
 # This is based on the module of the same name by Malcolm Beattie,
 # but essentially none of his code remains.
 
-package B::Deparse 1.65;
+package B::Deparse 1.66;
 use strict;
 use Carp;
 use B qw(class main_root main_start main_cv svref_2object opnumber perlstring
@@ -25,7 +25,7 @@ use B qw(class main_root main_start main_cv svref_2object opnumber perlstring
          OPpTRUEBOOL OPpINDEX_BOOLNEG OPpDEFER_FINALLY
 	 SVf_IOK SVf_NOK SVf_ROK SVf_POK SVf_FAKE SVs_RMG SVs_SMG
 	 SVs_PADTMP
-         CVf_METHOD CVf_LVALUE
+         CVf_NOWARN_AMBIGUOUS CVf_LVALUE
 	 PMf_KEEP PMf_GLOBAL PMf_CONTINUE PMf_EVAL PMf_ONCE
 	 PMf_MULTILINE PMf_SINGLELINE PMf_FOLD PMf_EXTENDED PMf_EXTENDED_MORE
 	 PADNAMEf_OUTER PADNAMEf_OUR PADNAMEf_TYPED
@@ -1322,9 +1322,9 @@ Carp::confess("SPECIAL in deparse_sub") if $cv->isa("B::SPECIAL");
             $proto = $myproto;
         }
     }
-    if ($cv->CvFLAGS & (CVf_METHOD|CVf_LOCKED|CVf_LVALUE|CVf_ANONCONST)) {
+    if ($cv->CvFLAGS & (CVf_NOWARN_AMBIGUOUS|CVf_LOCKED|CVf_LVALUE|CVf_ANONCONST)) {
         push @attrs, "lvalue" if $cv->CvFLAGS & CVf_LVALUE;
-        push @attrs, "method" if $cv->CvFLAGS & CVf_METHOD;
+        push @attrs, "method" if $cv->CvFLAGS & CVf_NOWARN_AMBIGUOUS;
         push @attrs, "const"  if $cv->CvFLAGS & CVf_ANONCONST;
     }
 

--- a/op.c
+++ b/op.c
@@ -9916,7 +9916,7 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
         CvCONST_on(cv);
         CvISXSUB_on(cv);
         PoisonPADLIST(cv);
-        CvFLAGS(cv) |= CvMETHOD(compcv);
+        CvFLAGS(cv) |= CvNOWARN_AMBIGUOUS(compcv);
         op_free(block);
         SvREFCNT_dec(compcv);
         PL_compcv = NULL;
@@ -10454,10 +10454,10 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
             CvCONST_on(cv);
             CvISXSUB_on(cv);
             PoisonPADLIST(cv);
-            CvFLAGS(cv) |= CvMETHOD(PL_compcv);
+            CvFLAGS(cv) |= CvNOWARN_AMBIGUOUS(PL_compcv);
         }
         else {
-            if (isGV(gv) || CvMETHOD(PL_compcv)) {
+            if (isGV(gv) || CvNOWARN_AMBIGUOUS(PL_compcv)) {
                 if (name && isGV(gv))
                     GvCV_set(gv, NULL);
                 cv = newCONSTSUB_flags(
@@ -10466,7 +10466,7 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
                 );
                 assert(cv);
                 assert(SvREFCNT((SV*)cv) != 0);
-                CvFLAGS(cv) |= CvMETHOD(PL_compcv);
+                CvFLAGS(cv) |= CvNOWARN_AMBIGUOUS(PL_compcv);
             }
             else {
                 if (!SvROK(gv)) {

--- a/pad.c
+++ b/pad.c
@@ -2118,7 +2118,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
         /* the candidate should have 1 ref from this pad and 1 ref
          * from the parent */
         if (const_sv && SvREFCNT(const_sv) == 2) {
-            const bool was_method = cBOOL(CvMETHOD(cv));
+            const bool was_method = cBOOL(CvNOWARN_AMBIGUOUS(cv));
             if (outside) {
                 PADNAME * const pn =
                     PadlistNAMESARRAY(CvPADLIST(outside))
@@ -2164,7 +2164,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
             SvREFCNT_dec_NN(cv);
             cv = newCONSTSUB(CvSTASH(proto), NULL, const_sv);
             if (was_method)
-                CvMETHOD_on(cv);
+                CvNOWARN_AMBIGUOUS_on(cv);
         }
         else {
           constoff:

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -377,6 +377,14 @@ I32:
 These are used in the same way already existing similar symbols, such as
 C<IVdf>, are used.  See L<perlapi/I/O Formats>.
 
+=item *
+
+The C<CVf_METHOD> CV flag and associated C<CvMETHOD> macro has been renamed to
+C<CVf_NOWARN_AMBIGUOUS> and C<CvNOWARN_AMBIGUOUS>. This closer reflects its
+actual behaviour (it suppresses a warning that would otherwise be generated
+about ambiguous names), in order to be less confusing with a possible upcoming
+feature.
+
 =back
 
 =head1 Selected Bug Fixes

--- a/toke.c
+++ b/toke.c
@@ -5547,7 +5547,7 @@ yyl_secondclass_keyword(pTHX_ char *s, STRLEN len, int key, I32 *orig_keyword,
         {
             if (GvIMPORTED_CV(gv))
                 ogv = gv;
-            else if (! CvMETHOD(cv))
+            else if (! CvNOWARN_AMBIGUOUS(cv))
                 hgv = gv;
         }
         if (!ogv
@@ -5964,7 +5964,7 @@ yyl_colon(pTHX_ char *s)
                 else if (!PL_in_my && memEQs(SvPVX(sv), len, "method")) {
                     sv_free(sv);
                     if (!sig)
-                        CvMETHOD_on(PL_compcv);
+                        CvNOWARN_AMBIGUOUS_on(PL_compcv);
                 }
                 else if (!PL_in_my && memEQs(SvPVX(sv), len, "const")) {
                     sv_free(sv);


### PR DESCRIPTION
Renaming as suggested in https://www.nntp.perl.org/group/perl.perl5.porters/2022/07/msg264282.html

I decided on `NOWARN_AMBIGUOUS` rather than `NOWARN_RESOLVE` because it feels a bit closer related to the actual warning it causes not to happen.