### PR TITLE
Fix various ubsan revealed issues in the build process and regex engine.

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3309,20 +3309,21 @@ iTR	|const char *|save_to_buffer|NULLOK const char * string	\
 				    |const Size_t offset
 #  if defined(USE_LOCALE)
 S	|char*	|stdize_locale	|NN char* locs
-#    ifdef USE_QUERYLOCALE
-S	|const char *|calculate_LC_ALL|const locale_t cur_obj
-#    else
-S	|const char *|calculate_LC_ALL|NN const char ** individ_locales
-#    endif
 S	|void	|new_collate	|NULLOK const char* newcoll
 S	|void	|new_ctype	|NN const char* newctype
-#    ifndef USE_POSIX_2008_LOCALE
+#    if defined(USE_POSIX_2008_LOCALE)
+#      if defined(USE_QUERYLOCALE)
+S	|const char *|calculate_LC_ALL|const locale_t cur_obj
+#      else
+S	|const char *|calculate_LC_ALL|NN const char ** individ_locales
+#      endif
+#    else /* !defined(USE_POSIX_2008_LOCALE) */
 Sr	|void	|setlocale_failure_panic_i|const unsigned int cat_index	\
 				|NULLOK const char * current		\
 				|NN const char * failed			\
 				|const line_t caller_0_line		\
 				|const line_t caller_1_line
-#    endif
+#    endif /* !defined(USE_POSIX_2008_LOCALE) */
 S	|void	|set_numeric_radix|const bool use_locale
 S	|void	|new_numeric	|NULLOK const char* newnum
 S	|void	|new_LC_ALL	|NULLOK const char* unused

--- a/embed.h
+++ b/embed.h
@@ -1483,10 +1483,19 @@
 #  if !(defined(PERL_USE_3ARG_SIGHANDLER))
 #define sighandler		Perl_sighandler
 #  endif
+#  if !(defined(USE_POSIX_2008_LOCALE))
+#    if defined(PERL_IN_LOCALE_C)
+#      if defined(USE_LOCALE)
+#define setlocale_failure_panic_i(a,b,c,d,e)	S_setlocale_failure_panic_i(aTHX_ a,b,c,d,e)
+#      endif
+#    endif
+#  endif
 #  if !(defined(USE_QUERYLOCALE))
 #    if defined(PERL_IN_LOCALE_C)
 #      if defined(USE_LOCALE)
+#        if defined(USE_POSIX_2008_LOCALE)
 #define calculate_LC_ALL(a)	S_calculate_LC_ALL(aTHX_ a)
+#        endif
 #      endif
 #    endif
 #  endif
@@ -1535,13 +1544,6 @@
 #  if !defined(PURIFY)
 #    if defined(PERL_IN_HV_C)
 #define new_he()		S_new_he(aTHX)
-#    endif
-#  endif
-#  if !defined(USE_POSIX_2008_LOCALE)
-#    if defined(PERL_IN_LOCALE_C)
-#      if defined(USE_LOCALE)
-#define setlocale_failure_panic_i(a,b,c,d,e)	S_setlocale_failure_panic_i(aTHX_ a,b,c,d,e)
-#      endif
 #    endif
 #  endif
 #  if !defined(WIN32)
@@ -1694,9 +1696,9 @@
 #      if defined(USE_POSIX_2008_LOCALE)
 #define emulate_setlocale_i(a,b)	S_emulate_setlocale_i(aTHX_ a,b)
 #define my_querylocale_i(a)	S_my_querylocale_i(aTHX_ a)
-#      endif
-#      if defined(USE_QUERYLOCALE)
+#        if defined(USE_QUERYLOCALE)
 #define calculate_LC_ALL(a)	S_calculate_LC_ALL(aTHX_ a)
+#        endif
 #      endif
 #      if defined(WIN32)
 #define win32_setlocale(a,b)	S_win32_setlocale(aTHX_ a,b)

--- a/locale.c
+++ b/locale.c
@@ -1105,6 +1105,7 @@ S_stdize_locale(pTHX_ char *locs)
     return locs;
 }
 
+#if defined(USE_POSIX_2008_LOCALE)
 STATIC
 const char *
 
@@ -1228,6 +1229,7 @@ S_calculate_LC_ALL(pTHX_ const char ** individ_locales)
 
     return aggregate_locale;
 }
+#endif /*defined(USE_POSIX_2008_LOCALE)*/
 
 #ifndef USE_POSIX_2008_LOCALE
 

--- a/proto.h
+++ b/proto.h
@@ -4672,12 +4672,25 @@ PERL_CALLCONV Signal_t	Perl_sighandler(int sig)
 #define PERL_ARGS_ASSERT_SIGHANDLER
 
 #endif
+#if !(defined(USE_POSIX_2008_LOCALE))
+#  if defined(PERL_IN_LOCALE_C)
+#    if defined(USE_LOCALE)
+PERL_STATIC_NO_RET void	S_setlocale_failure_panic_i(pTHX_ const unsigned int cat_index, const char * current, const char * failed, const line_t caller_0_line, const line_t caller_1_line)
+			__attribute__noreturn__;
+#define PERL_ARGS_ASSERT_SETLOCALE_FAILURE_PANIC_I	\
+	assert(failed)
+
+#    endif
+#  endif
+#endif
 #if !(defined(USE_QUERYLOCALE))
 #  if defined(PERL_IN_LOCALE_C)
 #    if defined(USE_LOCALE)
+#      if defined(USE_POSIX_2008_LOCALE)
 STATIC const char *	S_calculate_LC_ALL(pTHX_ const char ** individ_locales);
 #define PERL_ARGS_ASSERT_CALCULATE_LC_ALL	\
 	assert(individ_locales)
+#      endif
 #    endif
 #  endif
 #endif
@@ -4986,17 +4999,6 @@ STATIC void	S_validate_suid(pTHX_ PerlIO *rsfp);
 #if !defined(USE_ITHREADS)
 /* PERL_CALLCONV void	CopFILEGV_set(pTHX_ COP * c, GV * gv); */
 #define PERL_ARGS_ASSERT_COPFILEGV_SET
-#endif
-#if !defined(USE_POSIX_2008_LOCALE)
-#  if defined(PERL_IN_LOCALE_C)
-#    if defined(USE_LOCALE)
-PERL_STATIC_NO_RET void	S_setlocale_failure_panic_i(pTHX_ const unsigned int cat_index, const char * current, const char * failed, const line_t caller_0_line, const line_t caller_1_line)
-			__attribute__noreturn__;
-#define PERL_ARGS_ASSERT_SETLOCALE_FAILURE_PANIC_I	\
-	assert(failed)
-
-#    endif
-#  endif
 #endif
 #if !defined(WIN32)
 PERL_CALLCONV bool	Perl_do_exec3(pTHX_ const char *incmd, int fd, int do_report)
@@ -5641,10 +5643,10 @@ STATIC const char*	S_emulate_setlocale_i(pTHX_ const unsigned int index, const c
 #define PERL_ARGS_ASSERT_EMULATE_SETLOCALE_I
 STATIC const char*	S_my_querylocale_i(pTHX_ const unsigned int index);
 #define PERL_ARGS_ASSERT_MY_QUERYLOCALE_I
-#    endif
-#    if defined(USE_QUERYLOCALE)
+#      if defined(USE_QUERYLOCALE)
 STATIC const char *	S_calculate_LC_ALL(pTHX_ const locale_t cur_obj);
 #define PERL_ARGS_ASSERT_CALCULATE_LC_ALL
+#      endif
 #    endif
 #    if defined(WIN32)
 STATIC char*	S_win32_setlocale(pTHX_ int category, const char* locale);

--- a/regcomp.c
+++ b/regcomp.c
@@ -6820,18 +6820,88 @@ S_study_chunk(pTHX_
     assert(!frame);
     DEBUG_STUDYDATA("pre-fin", data, depth, is_inf, min, stopmin, delta);
 
+    /* is this pattern infinite? Eg, consider /(a|b+)/ */
+    if (is_inf_internal)
+        delta = OPTIMIZE_INFTY;
+
+    /* deal with (*ACCEPT), Eg, consider /(foo(*ACCEPT)|bop)bar/ */
     if (min > stopmin) {
-        /* stopmin might be shorter than min if we saw an (*ACCEPT). If
-        this is the case then it means this pattern is variable length
-        and we need to ensure that the delta accounts for it. delta
-        represents the difference between min length and max length for
-        this part of the pattern. */
-        delta += min - stopmin;
+        /*
+        At this point 'min' represents the minimum length string we can
+        match while *ignoring* the implication of ACCEPT, and 'delta'
+        represents the difference between the minimum length and maximum
+        length, and if the pattern matches an infinitely long string
+        (consider the + and * quantifiers) then we use the special delta
+        value of OPTIMIZE_INFTY to represent it. 'stopmin' is the
+        minimum length that can be matched *and* accepted.
+
+        A pattern is accepted when matching was successful *and*
+        complete, and thus there is no further matching needing to be
+        done, no backtracking to occur, etc. Prior to the introduction
+        of ACCEPT the only opcode that signaled acceptance was the END
+        opcode, which is always the very last opcode in a regex program.
+        ACCEPT is thus conceptually an early successful return out of
+        the matching process. stopmin starts out as OPTIMIZE_INFTY to
+        represent "the entire pattern", and is ratched down to the
+        "current min" if necessary when an ACCEPT opcode is encountered.
+
+        Thus stopmin might be smaller than min if we saw an (*ACCEPT),
+        and we now need to account for it in both min and delta.
+        Consider that in a pattern /AB/ normally the min length it can
+        match can be computed as min(A)+min(B). But (*ACCEPT) means
+        that it might be something else, not even neccesarily min(A) at
+        all. Consider
+
+             A  = /(foo(*ACCEPT)|x+)/
+             B  = /whop/
+             AB = /(foo(*ACCEPT)|x+)whop/
+
+        The min for A is 1 for "x" and the delta for A is OPTIMIZE_INFTY
+        for "xxxxx...", its stopmin is 3 for "foo". The min for B is 4 for
+        "whop", and the delta of 0 as the pattern is of fixed length, the
+        stopmin would be OPTIMIZE_INFTY as it does not contain an ACCEPT.
+        When handling AB we expect to see a min of 5 for "xwhop", and a
+        delta of OPTIMIZE_INFTY for "xxxxx...whop", and a stopmin of 3
+        for "foo". This should result in a final min of 3 for "foo", and
+        a final delta of OPTIMIZE_INFTY for "xxxxx...whop".
+
+        In something like /(dude(*ACCEPT)|irk)x{3,7}/ we would have a
+        min of 6 for "irkxxx" and a delta of 4 for "irkxxxxxxx", and the
+        stop min would be 4 for "dude". This should result in a final
+        min of 4 for "dude", and a final delta of 6, for "irkxxxxxxx".
+
+        When min is smaller than stopmin then we can ignore it. In the
+        fragment /(x{10,20}(*ACCEPT)|a)b+/, we would have a min of 2,
+        and a delta of OPTIMIZE_INFTY, and a stopmin of 10. Obviously
+        the ACCEPT doesn't reduce the minimum length of the string that
+        might be matched, nor affect the maximum length.
+
+        In something like /foo(*ACCEPT)ba?r/ we would have a min of 5
+        for "foobr", a delta of 1 for "foobar", and a stopmin of 3 for
+        "foo". We currently turn this into a min of 3 for "foo" and a
+        delta of 3 for "foobar" even though technically "foobar" isn't
+        possible. ACCEPT affects some aspects of the optimizer, like
+        length computations and mandatory substring optimizations, but
+        there are other optimzations this routine perfoms that are not
+        affected and this compromise simplifies implementation.
+
+        It might be helpful to consider that this C function is called
+        recursively on the pattern in a bottom up fashion, and that the
+        min returned by a nested call may be marked as coming from an
+        ACCEPT, causing its callers to treat the returned min as a
+        stopmin as the recursion unwinds. Thus a single ACCEPT can affect
+        multiple calls into this function in different ways.
+        */
+
+        if (OPTIMIZE_INFTY - delta >= min - stopmin)
+            delta += min - stopmin;
+        else
+            delta = OPTIMIZE_INFTY;
         min = stopmin;
     }
 
     *scanp = scan;
-    *deltap = is_inf_internal ? OPTIMIZE_INFTY : delta;
+    *deltap = delta;
 
     if (flags & SCF_DO_SUBSTR && is_inf)
         data->pos_delta = OPTIMIZE_INFTY - data->pos_min;
@@ -6862,7 +6932,9 @@ S_study_chunk(pTHX_
 }
 
 /* add a data member to the struct reg_data attached to this regex, it should
- * always return a non-zero return */
+ * always return a non-zero return. the 's' argument is the type of the items
+ * being added and the n is the number of items. The length of 's' should match
+ * the number of items. */
 STATIC U32
 S_add_data(RExC_state_t* const pRExC_state, const char* const s, const U32 n)
 {

--- a/regcomp.h
+++ b/regcomp.h
@@ -112,6 +112,45 @@ typedef struct regexp_internal {
 
 /* this is where the old regcomp.h started */
 
+
+/* Define the various regnode structures. These all should be a multiple
+ * of 32 bits large, and they should by and large correspond with each other
+ * in terms of naming, etc. Things can and will break in subtle ways if you
+ * change things without care. If you look at regexp.h you will see it
+ * contains this:
+ *
+ * struct regnode {
+ *   U8  flags;
+ *   U8  type;
+ *   U16 next_off;
+ * };
+ *
+ * This structure is the base unit of elements in the regexp program. When
+ * we increment our way through the program we increment by the size of this
+ * structure, and in all cases where regnode sizing is considered it is in
+ * units of this structure.
+ *
+ * This implies that no regnode style structure should contain 64 bit
+ * aligned members. Since the base regnode is 32 bits any member might
+ * not be 64 bit aligned no matter how you might try to pad out the
+ * struct itself (the regnode_ssc is special in this regard as it is
+ * never used in a program directly). If you want to store 64 bit
+ * members you need to store them specially. The struct regnode_p and the
+ * ARGp() and ARGp_SET() macros and related inline functions provide an example
+ * solution. Note they deal with a slightly more complicated problem than simple
+ * alignment, as pointers may be 32 bits or 64 bits depending on platform,
+ * but they illustrate the pattern to follow if you want to put a 64 bit value
+ * into a regnode.
+
+ * NOTE: Ideally we do not put pointers into the regnodes in a program. Instead
+ * we put them in the "data" part of the regexp structure and store the index into
+ * the data in the pointers in the regnode. This allows the pointer to be handled
+ * properly during clone/free operations (eg refcount bookkeeping). See S_add_data(),
+ * Perl_regdupe_internal(), Perl_regfree_internal() in regcomp.c for how the data
+ * array can be used, the letters 'arsSu' all refer to different types of SV that
+ * we already have support for in the data array.
+ */
+
 struct regnode_string {
     U8	str_len;
     U8  type;
@@ -145,12 +184,25 @@ struct regnode_1 {
 };
 
 /* Node whose argument is 'SV *'.  This needs to be used very carefully in
- * situations where pointers won't become invalid because of, say re-mallocs */
+ * situations where pointers won't become invalid because of, say re-mallocs.
+ *
+ * Note that this regnode type is problematic and should not be used or copied
+ * and will be removed in the future. Pointers should be stored in the data[]
+ * array and an index into the data array stored in the regnode, which allows the
+ * pointers to be handled properly during clone/free operations on the regexp
+ * data structure. As a byproduct it also saves space, often we use a 16 bit
+ * member to store indexes into the data[] array.
+ *
+ * Also note that the weird storage here is because regnodes are 32 bit aligned,
+ * which means we cannot have a 64 bit aligned member. To make things more annoying
+ * the size of a pointer may vary by platform. Thus we use a character array, and
+ * then use inline functions to copy the data in or out.
+ * */
 struct regnode_p {
     U8	flags;
     U8  type;
     U16 next_off;
-    SV * arg1;
+    char arg1_sv_ptr_bytes[sizeof(SV *)];
 };
 
 /* Similar to a regnode_1 but with an extra signed argument */
@@ -218,14 +270,18 @@ struct regnode_charclass_posixl {
 };
 
 /* A synthetic start class (SSC); is a regnode_charclass_posixl_fold, plus an
- * extra SV*, used only during its construction and which is not used by
- * regexec.c.  Note that the 'next_off' field is unused, as the SSC stands
- * alone, so there is never a next node.  Also, there is no alignment issue,
- * because these are declared or allocated as a complete unit so the compiler
- * takes care of alignment.  This is unlike the other regnodes which are
- * allocated in terms of multiples of a single-argument regnode.  SSC nodes can
- * have a pointer field because there is no alignment issue, and because it is
- * set to NULL after construction, before any cloning of the pattern */
+ * extra SV*, used only during regex construction and which is not used by the
+ * main machinery in regexec.c and which does not get embedded in the final compiled
+ * regex program.
+ *
+ * Because it does not get embedded it does not have to comply with the alignment
+ * and sizing constraints required for a normal regnode structure: it MAY contain
+ * pointers or members of whatever size needed and the compiler will do the right
+ * thing. (Every other regnode type is 32 bit aligned.)
+ *
+ * Note that the 'next_off' field is unused, as the SSC stands alone, so there is
+ * never a next node.
+ */
 struct regnode_ssc {
     U8	flags;                      /* ANYOF_MATCHES_POSIXL bit must go here */
     U8  type;
@@ -282,16 +338,16 @@ struct regnode_ssc {
 #undef ARG2
 
 #define ARG(p) ARG_VALUE(ARG_LOC(p))
-#define ARGp(p) ARG_VALUE(ARGp_LOC(p))
+#define ARGp(p) ARGp_VALUE_inline(p)
 #define ARG1(p) ARG_VALUE(ARG1_LOC(p))
 #define ARG2(p) ARG_VALUE(ARG2_LOC(p))
 #define ARG2L(p) ARG_VALUE(ARG2L_LOC(p))
 
 #define ARG_SET(p, val) ARG__SET(ARG_LOC(p), (val))
-#define ARGp_SET(p, val) ARG__SET(ARGp_LOC(p), (val))
 #define ARG1_SET(p, val) ARG__SET(ARG1_LOC(p), (val))
 #define ARG2_SET(p, val) ARG__SET(ARG2_LOC(p), (val))
 #define ARG2L_SET(p, val) ARG__SET(ARG2L_LOC(p), (val))
+#define ARGp_SET(p, val) ARGp_SET_inline((p),(val))
 
 #undef NEXT_OFF
 #undef NODE_ALIGN
@@ -377,7 +433,7 @@ struct regnode_ssc {
 
 #define	NODE_ALIGN(node)
 #define	ARG_LOC(p)	(((struct regnode_1 *)p)->arg1)
-#define ARGp_LOC(p)	(((struct regnode_p *)p)->arg1)
+#define ARGp_BYTES_LOC(p)  (((struct regnode_p *)p)->arg1_sv_ptr_bytes)
 #define	ARG1_LOC(p)	(((struct regnode_2 *)p)->arg1)
 #define	ARG2_LOC(p)	(((struct regnode_2 *)p)->arg2)
 #define ARG2L_LOC(p)	(((struct regnode_2L *)p)->arg2)
@@ -419,6 +475,22 @@ struct regnode_ssc {
                     FILL_ADVANCE_NODE(offset, op);                      \
                     (offset) += 2;                                      \
     } STMT_END
+
+/* define these after we define the normal macros, so we can use
+ * ARGp_BYTES_LOC(n) */
+
+static inline SV *
+ARGp_VALUE_inline(struct regnode *node) {
+    SV *ptr;
+    memcpy(&ptr, ARGp_BYTES_LOC(node), sizeof(ptr));
+
+    return ptr;
+}
+
+static inline void
+ARGp_SET_inline(struct regnode *node, SV *ptr) {
+    memcpy(ARGp_BYTES_LOC(node), &ptr, sizeof(ptr));
+}
 
 #define REG_MAGIC 0234
 

--- a/regen/embed_lib.pl
+++ b/regen/embed_lib.pl
@@ -143,10 +143,10 @@ sub setup_embed {
         $_->[0] =~ s/^#ifndef\s+(\S+)/#if !defined($1)/;
         if ($_->[0] =~ /^#if\s*(.*)/) {
             push @state, $1;
-        } elsif ($_->[0] =~ /^#else\s*$/) {
+        } elsif ($_->[0] =~ m!^#else\s*(?:/\*.*?\*/)?$!) {
             die "Unmatched #else in embed.fnc" unless @state;
             $state[-1] = "!($state[-1])";
-        } elsif ($_->[0] =~ m!^#endif\s*(?:/\*.*\*/)?$!) {
+        } elsif ($_->[0] =~ m!^#endif\s*(?:/\*.*?\*/)?$!) {
             die "Unmatched #endif in embed.fnc" unless @state;
             pop @state;
         } else {


### PR DESCRIPTION
See #19874 for related discussion. I only addressed build warnings and the regex engine.

locale.c - silence warnings about unused S_calculate_LC_ALL() under non USE_POSIX_2008_LOCALE builds
regexec.c - avoid (bogus) compiler warnings about possibly uninitialized pointer dereference and make code clearer
regcomp.h - fix non aligned pointer value stored in the regex opcode directly.
regcomp.c - deal with overflow of delta during stopmin logic related to (*ACCEPT)
regen/embed_lib.pl - deal with comments in `#else` statements better and fix handling for `#endif`

Also for the regex engine stuff I added a bunch of comments.

