### PR TITLE
Mark S_setlocale_failure_panic_i() as currently unused

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -1231,6 +1231,7 @@ S_calculate_LC_ALL(pTHX_ const char ** individ_locales)
 
 #ifndef USE_POSIX_2008_LOCALE
 
+PERL_UNUSED_DECL /* this function is currently unused but reserved for possible future use */
 STATIC void
 S_setlocale_failure_panic_i(pTHX_
                             const unsigned int cat_index,


### PR DESCRIPTION
It otherwise provokes a compiler warning because the function isn't actually called anywhere. This warning becomes fatal on Windows compilers.