### PR TITLE
getcwd() is fixed from dragonfly bsd 6.2

### DIFF
--- a/Configure
+++ b/Configure
@@ -3494,7 +3494,10 @@ EOM
 			osvers="$3"
 			;;
 		dragonfly) osname=dragonfly
-			osvers="$3"
+                        case "$3" in
+                            [0-9]*) osvers="$3" ;;
+                            *) osvers="$2" ;;
+                        esac
 			;;
 		dynixptx*) osname=dynixptx
 			osvers=`echo "$4"|sed 's/^v//'`

--- a/dist/PathTools/t/cwd_enoent.t
+++ b/dist/PathTools/t/cwd_enoent.t
@@ -28,8 +28,9 @@ foreach my $type (qw(regular perl)) {
 
         # https://github.com/Perl/perl5/issues/16525
         # https://bugs.dragonflybsd.org/issues/3250
+        my $osver = sprintf("%d%03d", ($Config{osvers} =~ /(\d+)/g));
 	skip "getcwd() doesn't fail on non-existent directories on this platform", 4
-	    if $type eq 'regular' && $^O eq 'dragonfly';
+	    if $type eq 'regular' && $^O eq 'dragonfly' && $osver < 6002;
 
 	skip "getcwd() doesn't fail on non-existent directories on this platform", 4
 	    if $type eq 'regular' && $^O eq 'haiku';


### PR DESCRIPTION
While working on this I found a problem where osvers wasn't being populated properly on both default 5.8 and 6.2 installs, so a fix to Configure is included for that.

@Tux is the Configure change sane?

Fixes #16525