### PR TITLE
Fix slowness in unicode regex-subst

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1110,6 +1110,7 @@ Lincoln D. Stein <lstein@cshl.org> Lincoln Stein <lstein@formaggio.cshl.org>
 Lincoln D. Stein <lstein@cshl.org> Lincoln Stein <lstein@genome.wi.mit.edu>
 Linda Walsh <unknown> Linda Walsh <unknown>
 Lionel Cons <lionel.cons@cern.ch> Lionel Cons <lionel.cons@cern.ch>
+Loren Merritt <pengvado@videolan.org> Loren Merritt <pengvado@videolan.org>
 Louis Strous <louis.strous@gmail.com> Louis Strous <louis.strous@gmail.com>
 Lubomir Rintel <lkundrak@v3.sk> Lubomir Rintel (GoodData) <lubo.rintel@gooddata.com>
 Lubomir Rintel <lkundrak@v3.sk> Lubomir Rintel <lkundrak@v3.sk>

--- a/AUTHORS
+++ b/AUTHORS
@@ -827,6 +827,7 @@ Lesley Binks                   <lesley.binks@gmail.com>
 Lincoln D. Stein               <lstein@cshl.org>
 Linda Walsh
 Lionel Cons                    <lionel.cons@cern.ch>
+Loren Merritt                  <pengvado@videolan.org>
 Louis Strous                   <louis.strous@gmail.com>
 Lubomir Rintel                 <lkundrak@v3.sk>
 Luc St-Louis                   <luc.st-louis@ca.transport.bombardier.com>

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -4250,7 +4250,6 @@ PP(pp_subst)
     STRLEN len;
     int force_on_match = 0;
     const I32 oldsave = PL_savestack_ix;
-    STRLEN slen;
     bool doutf8 = FALSE; /* whether replacement is in utf8 */
 #ifdef PERL_ANY_COW
     bool was_cow;
@@ -4316,10 +4315,12 @@ PP(pp_subst)
         DIE(aTHX_ "panic: pp_subst, pm=%p, orig=%p", pm, orig);
 
     strend = orig + len;
-    slen = DO_UTF8(TARG) ? utf8_length((U8*)orig, (U8*)strend) : len;
-    maxiters = 2 * slen + 10;	/* We can match twice at each
-                                   position, once with zero-length,
-                                   second time with non-zero. */
+    /* We can match twice at each position, once with zero-length,
+     * second time with non-zero.
+     * Don't handle utf8 specially; we can use length-in-bytes as an
+     * upper bound on length-in-characters, and avoid the cpu-cost of
+     * computing a tighter bound. */
+    maxiters = 2 * len + 10;
 
     /* handle the empty pattern */
     if (!RX_PRELEN(rx) && PL_curpm && !prog->mother_re) {

--- a/t/re/pat_rt_report.t
+++ b/t/re/pat_rt_report.t
@@ -1076,10 +1076,11 @@ SKIP: {
 	unless $Config{extensions} =~ / Encode /;
 
     # Test case cut down by jhi
-    fresh_perl_like(<<'EOP', qr!Malformed UTF-8 character \(unexpected end of string\) in substitution \(s///\) at!, {}, 'Segfault using HTML::Entities');
+    fresh_perl_like(<<'EOP', qr!Malformed UTF-8 character \(unexpected end of string\)!, {}, 'Segfault using HTML::Entities');
 use Encode;
 my $t = ord('A') == 193 ? "\xEA" : "\xE9";
 Encode::_utf8_on($t);
+substr($t,0);
 $t =~ s/([^a])//ge;
 EOP
     }


### PR DESCRIPTION
Applying a regex-substitution to a unicode string is much slower than it should be.
`perf` says that the vast majority of the cpu-time is in Perl_utf8_length, called from Perl_pp_subst. (That's 98% of cpu-time in this isolated benchmark, and I have some real-world scripts where it's as high as 40%.)
This is not a bug in utf8 length caching, rather it's a case that hasn't implemented caching.

The solution isn't to add caching, because pp_subst doesn't really need to know utf8 length at all. It was only using that info to compute an upper bound on number of matches so that perl can die instead of hang if a bug in perl core leads to the regex engine getting stuck in an infinite loop. But that bound doesn't need to be tight, so we can use length-in-bytes as an upper bound on length-in-characters.

I had to change one regression test, which expected Perl_utf8_length to print a warning about a malformed string. Of course it doesn't print if Perl_utf8_length isn't called. The test was associated with a (very old) commit making it safe to regex-process malformed strings, it doesn't reject them, so this doesn't change the functionality of the test. Also, Perl_utf8_length only checks for a very limited subset of the ways that a utf8 string can be malformed, so anything that actually needs validity can't depend on this warning.

```
use Benchmark qw(:all);
my $str = "a" x 10000;
timethis(-5, sub { $str =~ s/a/b/r; }, "ascii s///");
utf8::upgrade($str);
timethis(-5, sub { $str =~ s/a/b/r; }, "utf s///");
```
before patch, on a Sandybridge cpu:
ascii s///:  5 wallclock secs ( 5.25 usr +  0.00 sys =  5.25 CPU) @ 2205538.29/s (n=11579076)
  utf s///:  5 wallclock secs ( 5.21 usr +  0.00 sys =  5.21 CPU) @ 37167.95/s (n=193645)
after patch:
ascii s///:  5 wallclock secs ( 5.31 usr +  0.00 sys =  5.31 CPU) @ 2208935.22/s (n=11729446)
  utf s///:  5 wallclock secs ( 5.12 usr +  0.00 sys =  5.12 CPU) @ 1664148.83/s (n=8520442)
