### PR TITLE
Add LINE_Tf format for line_t variables

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -2519,6 +2519,7 @@ The typedef to use to declare variables that are to hold line numbers.
   Line numbers are unsigned, 32 bits.
 */
 typedef U32 line_t;
+#define LINE_Tf  U32uf
 #define NOLINE ((line_t) 4294967295UL)  /* = FFFFFFFF */
 
 /* Helpful alias for version prescan */

--- a/locale.c
+++ b/locale.c
@@ -1256,7 +1256,8 @@ S_setlocale_failure_panic_i(pTHX_
     }
 
     RESTORE_ERRNO;
-    Perl_croak(aTHX_ "panic: %s: %d:(%d): Can't change locale for %s(%d)"
+    Perl_croak(aTHX_ "panic: %s: %" LINE_Tf "d:(%" LINE_Tf
+                     "): Can't change locale for" " %s(%d)"
                      " from '%s' to '%s'; errno=%d\n",
                      __FILE__, caller_0_line, caller_1_line, name, cat,
                      current, failed, errno);


### PR DESCRIPTION
This is so you can print them without having to know their length.