### PR TITLE
newAVav/newAVhv - use recent inline AV functions

### DIFF
--- a/av.c
+++ b/av.c
@@ -523,7 +523,7 @@ Perl_newAVhv(pTHX_ HV *ohv)
 
     bool tied = SvRMAGICAL(ohv) && mg_find(MUTABLE_SV(ohv), PERL_MAGIC_tied);
 
-    U32 nkeys = hv_iterinit(ohv);
+    Size_t nkeys = hv_iterinit(ohv);
     /* This number isn't perfect but it doesn't matter; it only has to be
      * close to make the initial allocation about the right size
      */
@@ -538,12 +538,12 @@ Perl_newAVhv(pTHX_ HV *ohv)
     HE *he;
     while((he = hv_iternext(ohv))) {
         if(tied) {
-            av_push(ret, newSVsv(hv_iterkeysv(he)));
-            av_push(ret, newSVsv(hv_iterval(ohv, he)));
+            av_push_simple(ret, newSVsv(hv_iterkeysv(he)));
+            av_push_simple(ret, newSVsv(hv_iterval(ohv, he)));
         }
         else {
-            av_push(ret, newSVhek(HeKEY_hek(he)));
-            av_push(ret, HeVAL(he) ? newSVsv(HeVAL(he)) : &PL_sv_undef);
+            av_push_simple(ret, newSVhek(HeKEY_hek(he)));
+            av_push_simple(ret, HeVAL(he) ? newSVsv(HeVAL(he)) : &PL_sv_undef);
         }
     }
 


### PR DESCRIPTION
Apologies to @leonerd for not commenting on #19935 in time. The new _av.c_ functions can be made more efficient by using new-ish inline functions and/or doing array assignments directly.

The commits are:
1. The `newAV_alloc_x(z)` macros are more efficient here than calling `av_extend()`, especially in newAVav, where there's no need to `Zero()` the allocation.
2. Since `ret` is a new, simple AV, we could use `av_push_simple` in place of `av_push`. I made the assignments and `AvFILLp` management explicit instead, but wouldn't be too surprised if a good compiler did similar with `av_push_simple`. Also, since most of the guts of `av_make` seemed to be in `newAVav`, seemed like we may as well do the simple case inline.
3. Again, since `ret` is a new, simple AV, we could use `av_push_simple` in place of `av_push`, but I went with doing things explicitly for clarity.

Wasn't sure whether it would be useful to hoist the `if (tied)` check outside of the loop in `newAVhv`, creating two separate loops instead, but perhaps that's something to leave the compiler to decide?