### PR TITLE
handy.h: 'porcelain" => "base"

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -1920,27 +1920,27 @@ END_EXTERN_C
  * The first two aren't in C89, so the fallback is to use the non-locale
  * sensitive versions; these are the same for all platforms */
 #if defined(HAS_ISASCII)
-#   define is_porcelain_ASCII(c) isascii((U8) (c))
+#   define is_base_ASCII(c) isascii((U8) (c))
 #else
-#   define is_porcelain_ASCII(c) isASCII(c)
+#   define is_base_ASCII(c) isASCII(c)
 #endif
 
 #if defined(HAS_ISBLANK)
-#   define is_porcelain_BLANK(c) isblank((U8) (c))
+#   define is_base_BLANK(c) isblank((U8) (c))
 #else
-#   define is_porcelain_BLANK(c) isBLANK(c)
+#   define is_base_BLANK(c) isBLANK(c)
 #endif
 
 /* The next few are the same in all platforms. */
-#define is_porcelain_CNTRL(c)     iscntrl((U8) (c))
-#define is_porcelain_IDFIRST(c)  (UNLIKELY((c) == '_') || is_porcelain_ALPHA(c))
-#define is_porcelain_SPACE(c)     isspace((U8) (c))
-#define is_porcelain_WORDCHAR(c) (UNLIKELY((c) == '_') || is_porcelain_ALPHANUMERIC(c))
+#define is_base_CNTRL(c)     iscntrl((U8) (c))
+#define is_base_IDFIRST(c)  (UNLIKELY((c) == '_') || is_base_ALPHA(c))
+#define is_base_SPACE(c)     isspace((U8) (c))
+#define is_base_WORDCHAR(c) (UNLIKELY((c) == '_') || is_base_ALPHANUMERIC(c))
 
 /* The base-level case changing macros are also the same in all platforms */
-#define to_porcelain_LOWER(c)     tolower((U8) (c))
-#define to_porcelain_UPPER(c)     toupper((U8) (c))
-#define to_porcelain_FOLD(c)      to_porcelain_LOWER(c)
+#define to_base_LOWER(c)     tolower((U8) (c))
+#define to_base_UPPER(c)     toupper((U8) (c))
+#define to_base_FOLD(c)      to_base_LOWER(c)
 
 #ifdef WIN32
 
@@ -1954,48 +1954,48 @@ END_EXTERN_C
  * ispunct(), and things that are \W, like ispunct(), arent't controls.  Not
  * all possible weirdnesses are checked for, just ones that were detected on
  * actual Microsoft code pages */
-#  define is_porcelain_ALPHA(c)                                          \
-                          (isalpha((U8) (c)) && ! is_porcelain_PUNCT(c))
-#  define is_porcelain_ALPHANUMERIC(c)                                   \
-                          (isalnum((U8) (c)) && ! is_porcelain_PUNCT(c))
-#  define is_porcelain_CASED(c)                                          \
-   ((isupper((U8) (c)) || islower((U8) (c))) && ! is_porcelain_PUNCT(c))
-#  define is_porcelain_DIGIT(c)                                          \
-                          (isdigit((U8) (c)) && ! is_porcelain_PUNCT(c))
-#  define is_porcelain_GRAPH(c)                                          \
-                          (isgraph((U8) (c)) && ! is_porcelain_CNTRL(c))
-#  define is_porcelain_LOWER(c)                                          \
-                          (islower((U8) (c)) && ! is_porcelain_PUNCT(c))
-#  define is_porcelain_PRINT(c)                                          \
-                          (isprint((U8) (c)) && ! is_porcelain_CNTRL(c))
-#  define is_porcelain_PUNCT(c)                                          \
-                          (ispunct((U8) (c)) && ! is_porcelain_CNTRL(c))
-#  define is_porcelain_UPPER(c)                                          \
-                          (isupper((U8) (c)) && ! is_porcelain_PUNCT(c))
-#  define is_porcelain_XDIGIT(c)                                         \
-                         (isxdigit((U8) (c)) && ! is_porcelain_PUNCT(c))
+#  define is_base_ALPHA(c)                                          \
+                          (isalpha((U8) (c)) && ! is_base_PUNCT(c))
+#  define is_base_ALPHANUMERIC(c)                                   \
+                          (isalnum((U8) (c)) && ! is_base_PUNCT(c))
+#  define is_base_CASED(c)                                          \
+   ((isupper((U8) (c)) || islower((U8) (c))) && ! is_base_PUNCT(c))
+#  define is_base_DIGIT(c)                                          \
+                          (isdigit((U8) (c)) && ! is_base_PUNCT(c))
+#  define is_base_GRAPH(c)                                          \
+                          (isgraph((U8) (c)) && ! is_base_CNTRL(c))
+#  define is_base_LOWER(c)                                          \
+                          (islower((U8) (c)) && ! is_base_PUNCT(c))
+#  define is_base_PRINT(c)                                          \
+                          (isprint((U8) (c)) && ! is_base_CNTRL(c))
+#  define is_base_PUNCT(c)                                          \
+                          (ispunct((U8) (c)) && ! is_base_CNTRL(c))
+#  define is_base_UPPER(c)                                          \
+                          (isupper((U8) (c)) && ! is_base_PUNCT(c))
+#  define is_base_XDIGIT(c)                                         \
+                         (isxdigit((U8) (c)) && ! is_base_PUNCT(c))
 #else
 
 /* For all other platforms, as far as we know, isdigit(), etc. work sanely
  * enough */
-#  define is_porcelain_ALPHA(c)         isalpha((U8) (c))
-#  define is_porcelain_ALPHANUMERIC(c)  isalnum((U8) (c))
-#  define is_porcelain_CASED(c)        (islower((U8) (c)) || isupper((U8) (c)))
-#  define is_porcelain_DIGIT(c)         isdigit((U8) (c))
+#  define is_base_ALPHA(c)         isalpha((U8) (c))
+#  define is_base_ALPHANUMERIC(c)  isalnum((U8) (c))
+#  define is_base_CASED(c)        (islower((U8) (c)) || isupper((U8) (c)))
+#  define is_base_DIGIT(c)         isdigit((U8) (c))
 
      /* ... But it seems that IBM products treat NBSP as both a space and a
       * graphic; these are the two platforms that we have active test beds for.
       */
 #  if defined(OS390) || defined(_AIX)
-#    define is_porcelain_GRAPH(c)      (isgraph((U8) (c)) && ! isspace((U8) (c)))
+#    define is_base_GRAPH(c)      (isgraph((U8) (c)) && ! isspace((U8) (c)))
 #  else
-#    define is_porcelain_GRAPH(c)       isgraph((U8) (c))
+#    define is_base_GRAPH(c)       isgraph((U8) (c))
 #  endif
-#  define is_porcelain_LOWER(c)         islower((U8) (c))
-#  define is_porcelain_PRINT(c)         isprint((U8) (c))
-#  define is_porcelain_PUNCT(c)         ispunct((U8) (c))
-#  define is_porcelain_UPPER(c)         isupper((U8) (c))
-#  define is_porcelain_XDIGIT(c)        isxdigit((U8) (c))
+#  define is_base_LOWER(c)         islower((U8) (c))
+#  define is_base_PRINT(c)         isprint((U8) (c))
+#  define is_base_PUNCT(c)         ispunct((U8) (c))
+#  define is_base_UPPER(c)         isupper((U8) (c))
+#  define is_base_XDIGIT(c)        isxdigit((U8) (c))
 #endif
 
 /* Below is the next level up, which currently expands to nothing more
@@ -2010,28 +2010,28 @@ END_EXTERN_C
  * (Note, proper general operation of the bare libc functons requires you to
  * cast to U8.  These do that for you automatically.) */
 
-#  define WRAP_U8_LC_(c, classnum, porcelain)  porcelain(c)
+#  define WRAP_U8_LC_(c, classnum, base)  base(c)
 
 #define isU8_ALPHANUMERIC_LC(c)                                                \
-              WRAP_U8_LC_((c), CC_ALPHANUMERIC_, is_porcelain_ALPHANUMERIC)
-#define isU8_ALPHA_LC(c)    WRAP_U8_LC_((c), CC_ALPHA_, is_porcelain_ALPHA)
-#define isU8_ASCII_LC(c)    WRAP_U8_LC_((c), CC_ASCII_, is_porcelain_ASCII)
-#define isU8_BLANK_LC(c)    WRAP_U8_LC_((c), CC_BLANK_, is_porcelain_BLANK)
-#define isU8_CASED_LC(c)    WRAP_U8_LC_((c), CC_CASED_, is_porcelain_CASED)
-#define isU8_CNTRL_LC(c)    WRAP_U8_LC_((c), CC_CNTRL_, is_porcelain_CNTRL)
-#define isU8_DIGIT_LC(c)    WRAP_U8_LC_((c), CC_DIGIT_, is_porcelain_DIGIT)
-#define isU8_GRAPH_LC(c)    WRAP_U8_LC_((c), CC_GRAPH_, is_porcelain_GRAPH)
-#define isU8_IDFIRST_LC(c)  WRAP_U8_LC_((c), CC_IDFIRST_, is_porcelain_IDFIRST)
-#define isU8_LOWER_LC(c)    WRAP_U8_LC_((c), CC_LOWER_, is_porcelain_LOWER)
-#define isU8_PRINT_LC(c)    WRAP_U8_LC_((c), CC_PRINT_, is_porcelain_PRINT)
-#define isU8_PUNCT_LC(c)    WRAP_U8_LC_((c), CC_PUNCT_, is_porcelain_PUNCT)
-#define isU8_SPACE_LC(c)    WRAP_U8_LC_((c), CC_SPACE_, is_porcelain_SPACE)
-#define isU8_UPPER_LC(c)    WRAP_U8_LC_((c), CC_UPPER_, is_porcelain_UPPER)
-#define isU8_WORDCHAR_LC(c) WRAP_U8_LC_((c), CC_WORDCHAR_, is_porcelain_WORDCHAR)
-#define isU8_XDIGIT_LC(c)   WRAP_U8_LC_((c), CC_XDIGIT_, is_porcelain_XDIGIT)
+              WRAP_U8_LC_((c), CC_ALPHANUMERIC_, is_base_ALPHANUMERIC)
+#define isU8_ALPHA_LC(c)    WRAP_U8_LC_((c), CC_ALPHA_, is_base_ALPHA)
+#define isU8_ASCII_LC(c)    WRAP_U8_LC_((c), CC_ASCII_, is_base_ASCII)
+#define isU8_BLANK_LC(c)    WRAP_U8_LC_((c), CC_BLANK_, is_base_BLANK)
+#define isU8_CASED_LC(c)    WRAP_U8_LC_((c), CC_CASED_, is_base_CASED)
+#define isU8_CNTRL_LC(c)    WRAP_U8_LC_((c), CC_CNTRL_, is_base_CNTRL)
+#define isU8_DIGIT_LC(c)    WRAP_U8_LC_((c), CC_DIGIT_, is_base_DIGIT)
+#define isU8_GRAPH_LC(c)    WRAP_U8_LC_((c), CC_GRAPH_, is_base_GRAPH)
+#define isU8_IDFIRST_LC(c)  WRAP_U8_LC_((c), CC_IDFIRST_, is_base_IDFIRST)
+#define isU8_LOWER_LC(c)    WRAP_U8_LC_((c), CC_LOWER_, is_base_LOWER)
+#define isU8_PRINT_LC(c)    WRAP_U8_LC_((c), CC_PRINT_, is_base_PRINT)
+#define isU8_PUNCT_LC(c)    WRAP_U8_LC_((c), CC_PUNCT_, is_base_PUNCT)
+#define isU8_SPACE_LC(c)    WRAP_U8_LC_((c), CC_SPACE_, is_base_SPACE)
+#define isU8_UPPER_LC(c)    WRAP_U8_LC_((c), CC_UPPER_, is_base_UPPER)
+#define isU8_WORDCHAR_LC(c) WRAP_U8_LC_((c), CC_WORDCHAR_, is_base_WORDCHAR)
+#define isU8_XDIGIT_LC(c)   WRAP_U8_LC_((c), CC_XDIGIT_, is_base_XDIGIT)
 
-#define toU8_LOWER_LC(c)    WRAP_U8_LC_((c), CC_TOLOWER_, to_porcelain_LOWER)
-#define toU8_UPPER_LC(c)    WRAP_U8_LC_((c), CC_TOUPPER_, to_porcelain_UPPER)
+#define toU8_LOWER_LC(c)    WRAP_U8_LC_((c), CC_TOLOWER_, to_base_LOWER)
+#define toU8_UPPER_LC(c)    WRAP_U8_LC_((c), CC_TOUPPER_, to_base_UPPER)
 #define toU8_FOLD_LC(c)     toU8_LOWER_LC(c)
 
 /* The definitions below use the ones above to create versions in which the


### PR DESCRIPTION
I intended to convery in the names of these macros that they exist to
present a uniform api to the layers above, minimally processing the
layer below to achieve that.  So for example, is_porcelain_BLANK hides
the fact that isblank() doesn't exist on all platforms, or
is_porcelain_DIGIT matches the same set of 0..9 on all platforms, fixing
the non-standard definition Windows has.

I thought this is what git had meant when it used 'porcelain', but Tony
Cook informed me that it actually means something else.  So to avoid
confusing people who might be aware of the real git meaning, this commit
changes 'porcelain' to 'base', which, while not entirely satisfactory,
is the best short name I have been able to think of.