### PR TITLE
Fix build error when UV is uint64_t

### DIFF
--- a/Configure
+++ b/Configure
@@ -17026,6 +17026,10 @@ $cat <<EOP >try.c
 #ifdef I_STDLIB
 #include <stdlib.h>
 #endif
+#$i_inttypes I_INTTYPES
+#ifdef I_INTTYPES
+#include <inttypes.h>
+#endif
 #include <sys/types.h>
 #include <signal.h>
 #ifdef SIGFPE
@@ -20123,6 +20127,10 @@ EOM
 #$i_stdlib I_STDLIB
 #ifdef I_STDLIB
 #include <stdlib.h>
+#endif
+#$i_inttypes I_INTTYPES
+#ifdef I_INTTYPES
+#include <inttypes.h>
 #endif
 #include <sys/types.h>
 typedef $uvtype UV;

--- a/Configure
+++ b/Configure
@@ -21632,7 +21632,7 @@ EOCP
 		case "$yyy" in
 		12345678901)
 			sPRId64=PRId64; sPRIi64=PRIi64; sPRIu64=PRIu64;
-			sPRIo64=PRIo64; sPRIx64=PRIx64; sPRIXU64=PRIXU64;
+			sPRIo64=PRIo64; sPRIx64=PRIx64; sPRIXU64=PRIX64;
 			echo "We will use the C9X style."
 			;;
 		esac


### PR DESCRIPTION
With `-Duse64bitint` on 32-bit machines, UV might be configured as `uint64_t`.
But this had several problems that cause building perl to fail:
1. Referring nonexistent macro `PRIXU64` for `UVXf`
2. Some Configure tests fail to compile (by referring `$uvtype` without necessary include file) and leave erroneous values

This PR will fix these.
I don't know whether there are actual situations where `uint64_t` is supported but `long long` is not, but I've tested the patch with `-Ud_longlong` Configure option.