### PR TITLE
buildtoc - fix inner links when generating perltoc.pod

### DIFF
--- a/pod/buildtoc
+++ b/pod/buildtoc
@@ -237,6 +237,8 @@ sub podset {
 	    s/^\s*\*\s*//;
 	    s/\n/ /g;
 	    s/\s+$//;
+	    # make sure inner links include the target page
+	    s{L<(?:[^|>]+\|)?\K/}{$pod/}g;
 	    next if /^[\d.]+$/;
 	    next if $pod eq 'perlmodlib' && /^ftp:/;
 	    $OUT .= ", " if $initem;


### PR DESCRIPTION
When generating perltoc.pod, the headings taken from all of the various
pod documents included in core. These headings can have arbitrary
content, including links. A link with a second but without a name won't
work once it's moved into the perltoc.pod file, so convert any links
like this to include the name of the pod document they are being taken
from.