### PR TITLE
Add Haarg to the Core Team

### DIFF
--- a/Porting/core-team.json
+++ b/Porting/core-team.json
@@ -18,6 +18,7 @@
     "hv@crypt.org",
     "ilmari@ilmari.org",
     "jkeenan@cpan.org",
+    "haarg@haarg.org",
     "jmac@jmac.org",
     "khw@cpan.org",
     "leonerd@leonerd.org.uk",

--- a/pod/perlgov.pod
+++ b/pod/perlgov.pod
@@ -518,6 +518,8 @@ The current members of the Perl Core Team are:
 
 =item David Mitchell <davem@iabyn.com>
 
+=item Graham Knop <haarg@haarg.org>
+
 =item H. Merijn Brand <perl5@tux.freedom.nl>
 
 =item Hugo van der Sanden <hv@crypt.org>


### PR DESCRIPTION
After a one week election, haarg is now elected
as a new member of the Perl Core Team.

URL: https://civs1.civs.us/cgi-bin/results.pl?id=E_452873954bf5383a