### PR TITLE
Sync CPAN with CPAN 2.34

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -250,7 +250,7 @@ use File::Glob qw(:case);
     },
 
     'CPAN' => {
-        'DISTRIBUTION' => 'ANDK/CPAN-2.33-TRIAL.tar.gz',
+        'DISTRIBUTION' => 'ANDK/CPAN-2.34.tar.gz',
         'FILES'        => q[cpan/CPAN],
         'EXCLUDED'     => [
             qr{^distroprefs/},

--- a/cpan/CPAN/lib/CPAN.pm
+++ b/cpan/CPAN/lib/CPAN.pm
@@ -2,7 +2,7 @@
 # vim: ts=4 sts=4 sw=4:
 use strict;
 package CPAN;
-$CPAN::VERSION = '2.33';
+$CPAN::VERSION = '2.34';
 $CPAN::VERSION =~ s/_//;
 
 # we need to run chdir all over and we would get at wrong libraries

--- a/cpan/CPAN/lib/CPAN/Distribution.pm
+++ b/cpan/CPAN/lib/CPAN/Distribution.pm
@@ -9,7 +9,7 @@ use File::Path ();
 use POSIX ":sys_wait_h"; 
 @CPAN::Distribution::ISA = qw(CPAN::InfoObj);
 use vars qw($VERSION);
-$VERSION = "2.33";
+$VERSION = "2.34";
 
 my $run_allow_installing_within_test = 1; # boolean; either in test or in install, there is no third option
 
@@ -2950,7 +2950,7 @@ sub prereqs_for_slot {
         }
         if (-f "Build.PL"
             && ! -f File::Spec->catfile($self->{build_dir},"Makefile.PL")
-            && ! $merged->requirements_for_module("Module::Build")
+            && ! @{[ $merged->required_modules ]}
             && ! $CPAN::META->has_inst("Module::Build")
            ) {
             $CPAN::Frontend->mywarn(


### PR DESCRIPTION
From ChangeLog

* Consider Module::Build as undeclared prerequisite only if
  there are no configure phase prereqs declared (Dan Book)

* tiny distroprefs maintenance