### PR TITLE
Sync PerlIO::via::QuotedPrint with CPAN 0.10

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -939,7 +939,7 @@ use File::Glob qw(:case);
     },
 
     'PerlIO::via::QuotedPrint' => {
-        'DISTRIBUTION' => 'SHAY/PerlIO-via-QuotedPrint-0.09.tar.gz',
+        'DISTRIBUTION' => 'SHAY/PerlIO-via-QuotedPrint-0.10.tar.gz',
         'FILES'        => q[cpan/PerlIO-via-QuotedPrint],
     },
 

--- a/cpan/PerlIO-via-QuotedPrint/lib/PerlIO/via/QuotedPrint.pm
+++ b/cpan/PerlIO-via-QuotedPrint/lib/PerlIO/via/QuotedPrint.pm
@@ -12,7 +12,7 @@ use 5.008001;
 # be as strict as possible
 use strict;
 
-our $VERSION = '0.09';
+our $VERSION = '0.10';
 
 # modules that we need
 use MIME::QuotedPrint (); # no need to pollute this namespace
@@ -163,11 +163,11 @@ Public License or the Artistic License, as specified in the F<LICENCE> file.
 
 =head1 VERSION
 
-Version 0.09
+Version 0.10
 
 =head1 DATE
 
-08 Dec 2020
+22 May 2022
 
 =head1 HISTORY
 

--- a/cpan/PerlIO-via-QuotedPrint/t/QuotedPrint.t
+++ b/cpan/PerlIO-via-QuotedPrint/t/QuotedPrint.t
@@ -10,6 +10,7 @@ BEGIN {                         # Magic Perl CORE pragma
     }
     if (ord("A") == 193) {
         print "1..0 # Skip: EBCDIC\n";
+        exit 0;
     }
 }
 


### PR DESCRIPTION
Add missing exit() to t/QuotedPrint.t