### PR TITLE
Sync Test::Simple with CPAN 1.302191

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1124,7 +1124,7 @@ use File::Glob qw(:case);
     },
 
     'Test::Simple' => {
-        'DISTRIBUTION' => 'EXODIST/Test-Simple-1.302190.tar.gz',
+        'DISTRIBUTION' => 'EXODIST/Test-Simple-1.302191.tar.gz',
         'FILES'        => q[cpan/Test-Simple],
         'EXCLUDED'     => [
             qr{^examples/},

--- a/cpan/Test-Simple/lib/Test/Builder.pm
+++ b/cpan/Test-Simple/lib/Test/Builder.pm
@@ -4,7 +4,7 @@ use 5.006;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN {
     if( $] < 5.008 ) {
@@ -1002,15 +1002,7 @@ END
             $self->_is_diag( $got, $type, $expect );
         }
         elsif( $type =~ /^(ne|!=)$/ ) {
-            no warnings;
-            my $eq = ($got eq $expect || $got == $expect)
-                && (
-                    (defined($got) xor defined($expect))
-                 || (length($got)  !=  length($expect))
-                );
-            use warnings;
-
-            if ($eq) {
+            if (defined($got) xor defined($expect)) {
                 $self->_cmp_diag( $got, $type, $expect );
             }
             else {

--- a/cpan/Test-Simple/lib/Test/Builder/Formatter.pm
+++ b/cpan/Test-Simple/lib/Test/Builder/Formatter.pm
@@ -2,7 +2,7 @@ package Test::Builder::Formatter;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN { require Test2::Formatter::TAP; our @ISA = qw(Test2::Formatter::TAP) }
 

--- a/cpan/Test-Simple/lib/Test/Builder/Module.pm
+++ b/cpan/Test-Simple/lib/Test/Builder/Module.pm
@@ -7,7 +7,7 @@ use Test::Builder;
 require Exporter;
 our @ISA = qw(Exporter);
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 =head1 NAME

--- a/cpan/Test-Simple/lib/Test/Builder/Tester.pm
+++ b/cpan/Test-Simple/lib/Test/Builder/Tester.pm
@@ -1,7 +1,7 @@
 package Test::Builder::Tester;
 
 use strict;
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Test::Builder;
 use Symbol;

--- a/cpan/Test-Simple/lib/Test/Builder/Tester/Color.pm
+++ b/cpan/Test-Simple/lib/Test/Builder/Tester/Color.pm
@@ -1,7 +1,7 @@
 package Test::Builder::Tester::Color;
 
 use strict;
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 require Test::Builder::Tester;
 

--- a/cpan/Test-Simple/lib/Test/Builder/TodoDiag.pm
+++ b/cpan/Test-Simple/lib/Test/Builder/TodoDiag.pm
@@ -2,7 +2,7 @@ package Test::Builder::TodoDiag;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN { require Test2::Event::Diag; our @ISA = qw(Test2::Event::Diag) }
 

--- a/cpan/Test-Simple/lib/Test/More.pm
+++ b/cpan/Test-Simple/lib/Test/More.pm
@@ -17,7 +17,7 @@ sub _carp {
     return warn @_, " at $file line $line\n";
 }
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Test::Builder::Module;
 our @ISA    = qw(Test::Builder::Module);
@@ -1770,8 +1770,8 @@ sub eq_set {
 Sometimes the Test::More interface isn't quite enough.  Fortunately,
 Test::More is built on top of L<Test::Builder> which provides a single,
 unified backend for any test library to use.  This means two test
-libraries which both use <Test::Builder> B<can> be used together in the
-same program>.
+libraries which both use L<Test::Builder> B<can> be used together in the
+same program.
 
 If you simply want to do a little tweaking of how the tests behave,
 you can access the underlying L<Test::Builder> object like so:

--- a/cpan/Test-Simple/lib/Test/Simple.pm
+++ b/cpan/Test-Simple/lib/Test/Simple.pm
@@ -4,7 +4,7 @@ use 5.006;
 
 use strict;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Test::Builder::Module;
 our @ISA    = qw(Test::Builder::Module);

--- a/cpan/Test-Simple/lib/Test/Tester.pm
+++ b/cpan/Test-Simple/lib/Test/Tester.pm
@@ -18,7 +18,7 @@ require Exporter;
 
 use vars qw( @ISA @EXPORT );
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 @EXPORT = qw( run_tests check_tests check_test cmp_results show_space );
 @ISA = qw( Exporter );

--- a/cpan/Test-Simple/lib/Test/Tester/Capture.pm
+++ b/cpan/Test-Simple/lib/Test/Tester/Capture.pm
@@ -2,7 +2,7 @@ use strict;
 
 package Test::Tester::Capture;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 use Test::Builder;

--- a/cpan/Test-Simple/lib/Test/Tester/CaptureRunner.pm
+++ b/cpan/Test-Simple/lib/Test/Tester/CaptureRunner.pm
@@ -3,7 +3,7 @@ use strict;
 
 package Test::Tester::CaptureRunner;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 use Test::Tester::Capture;

--- a/cpan/Test-Simple/lib/Test/Tester/Delegate.pm
+++ b/cpan/Test-Simple/lib/Test/Tester/Delegate.pm
@@ -3,7 +3,7 @@ use warnings;
 
 package Test::Tester::Delegate;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Scalar::Util();
 

--- a/cpan/Test-Simple/lib/Test/use/ok.pm
+++ b/cpan/Test-Simple/lib/Test/use/ok.pm
@@ -1,7 +1,7 @@
 package Test::use::ok;
 use 5.005;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 __END__

--- a/cpan/Test-Simple/lib/Test2.pm
+++ b/cpan/Test-Simple/lib/Test2.pm
@@ -2,7 +2,7 @@ package Test2;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 1;

--- a/cpan/Test-Simple/lib/Test2/API.pm
+++ b/cpan/Test-Simple/lib/Test2/API.pm
@@ -10,7 +10,7 @@ BEGIN {
     $ENV{TEST2_ACTIVE} = 1;
 }
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 my $INST;

--- a/cpan/Test-Simple/lib/Test2/API/Breakage.pm
+++ b/cpan/Test-Simple/lib/Test2/API/Breakage.pm
@@ -2,7 +2,7 @@ package Test2::API::Breakage;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 use Test2::Util qw/pkg_to_file/;

--- a/cpan/Test-Simple/lib/Test2/API/Context.pm
+++ b/cpan/Test-Simple/lib/Test2/API/Context.pm
@@ -2,7 +2,7 @@ package Test2::API::Context;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 use Carp qw/confess croak/;

--- a/cpan/Test-Simple/lib/Test2/API/Instance.pm
+++ b/cpan/Test-Simple/lib/Test2/API/Instance.pm
@@ -2,7 +2,7 @@ package Test2::API::Instance;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 our @CARP_NOT = qw/Test2::API Test2::API::Instance Test2::IPC::Driver Test2::Formatter/;
 use Carp qw/confess carp/;

--- a/cpan/Test-Simple/lib/Test2/API/InterceptResult.pm
+++ b/cpan/Test-Simple/lib/Test2/API/InterceptResult.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Scalar::Util qw/blessed/;
 use Test2::Util  qw/pkg_to_file/;

--- a/cpan/Test-Simple/lib/Test2/API/InterceptResult/Event.pm
+++ b/cpan/Test-Simple/lib/Test2/API/InterceptResult/Event.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use List::Util   qw/first/;
 use Test2::Util  qw/pkg_to_file/;

--- a/cpan/Test-Simple/lib/Test2/API/InterceptResult/Facet.pm
+++ b/cpan/Test-Simple/lib/Test2/API/InterceptResult/Facet.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Facet;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN {
     require Test2::EventFacet;

--- a/cpan/Test-Simple/lib/Test2/API/InterceptResult/Hub.pm
+++ b/cpan/Test-Simple/lib/Test2/API/InterceptResult/Hub.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN { require Test2::Hub; our @ISA = qw(Test2::Hub) }
 use Test2::Util::HashBase;

--- a/cpan/Test-Simple/lib/Test2/API/InterceptResult/Squasher.pm
+++ b/cpan/Test-Simple/lib/Test2/API/InterceptResult/Squasher.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Squasher;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Carp qw/croak/;
 use List::Util qw/first/;

--- a/cpan/Test-Simple/lib/Test2/API/Stack.pm
+++ b/cpan/Test-Simple/lib/Test2/API/Stack.pm
@@ -2,7 +2,7 @@ package Test2::API::Stack;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 use Test2::Hub();

--- a/cpan/Test-Simple/lib/Test2/Event.pm
+++ b/cpan/Test-Simple/lib/Test2/Event.pm
@@ -2,7 +2,7 @@ package Test2::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Scalar::Util qw/blessed reftype/;
 use Carp qw/croak/;

--- a/cpan/Test-Simple/lib/Test2/Event/Bail.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Bail.pm
@@ -2,7 +2,7 @@ package Test2::Event::Bail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Diag.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Diag.pm
@@ -2,7 +2,7 @@ package Test2::Event::Diag;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Encoding.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Encoding.pm
@@ -2,7 +2,7 @@ package Test2::Event::Encoding;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Carp qw/croak/;
 

--- a/cpan/Test-Simple/lib/Test2/Event/Exception.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Exception.pm
@@ -2,7 +2,7 @@ package Test2::Event::Exception;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Fail.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Fail.pm
@@ -2,7 +2,7 @@ package Test2::Event::Fail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Test2::EventFacet::Info;
 

--- a/cpan/Test-Simple/lib/Test2/Event/Generic.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Generic.pm
@@ -5,7 +5,7 @@ use warnings;
 use Carp qw/croak/;
 use Scalar::Util qw/reftype/;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }
 use Test2::Util::HashBase;

--- a/cpan/Test-Simple/lib/Test2/Event/Note.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Note.pm
@@ -2,7 +2,7 @@ package Test2::Event::Note;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Ok.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Ok.pm
@@ -2,7 +2,7 @@ package Test2::Event::Ok;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Pass.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Pass.pm
@@ -2,7 +2,7 @@ package Test2::Event::Pass;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Test2::EventFacet::Info;
 

--- a/cpan/Test-Simple/lib/Test2/Event/Plan.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Plan.pm
@@ -2,7 +2,7 @@ package Test2::Event::Plan;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Skip.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Skip.pm
@@ -2,7 +2,7 @@ package Test2::Event::Skip;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 BEGIN { require Test2::Event::Ok; our @ISA = qw(Test2::Event::Ok) }

--- a/cpan/Test-Simple/lib/Test2/Event/Subtest.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Event::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN { require Test2::Event::Ok; our @ISA = qw(Test2::Event::Ok) }
 use Test2::Util::HashBase qw{subevents buffered subtest_id subtest_uuid start_stamp stop_stamp};

--- a/cpan/Test-Simple/lib/Test2/Event/TAP/Version.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/TAP/Version.pm
@@ -2,7 +2,7 @@ package Test2::Event::TAP::Version;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Carp qw/croak/;
 

--- a/cpan/Test-Simple/lib/Test2/Event/V2.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/V2.pm
@@ -2,7 +2,7 @@ package Test2::Event::V2;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Scalar::Util qw/reftype/;
 use Carp qw/croak/;

--- a/cpan/Test-Simple/lib/Test2/Event/Waiting.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Waiting.pm
@@ -2,7 +2,7 @@ package Test2::Event::Waiting;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/EventFacet.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Test2::Util::HashBase qw/-details/;
 use Carp qw/croak/;

--- a/cpan/Test-Simple/lib/Test2/EventFacet/About.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/About.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::About;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -package -no_display -uuid -eid };

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Amnesty.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Amnesty.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Amnesty;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 sub is_list { 1 }
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Assert.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Assert.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Assert;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -pass -no_debug -number };

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Control.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Control.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Control;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -global -terminate -halt -has_callback -encoding -phase };

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Error.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Error.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Error;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 sub facet_key { 'errors' }
 sub is_list { 1 }

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Hub.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Hub.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 sub is_list { 1 }
 sub facet_key { 'hubs' }

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Info.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Info.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Info;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 sub is_list { 1 }
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Info/Table.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Info/Table.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Info::Table;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Carp qw/confess/;
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Meta.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Meta.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Meta;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use vars qw/$AUTOLOAD/;

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Parent.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Parent.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Parent;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Carp qw/confess/;
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Plan.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Plan.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Plan;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -count -skip -none };

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Render.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Render.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Render;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 sub is_list { 1 }
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Trace.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Trace.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Trace;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 

--- a/cpan/Test-Simple/lib/Test2/Formatter.pm
+++ b/cpan/Test-Simple/lib/Test2/Formatter.pm
@@ -2,7 +2,7 @@ package Test2::Formatter;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 my %ADDED;

--- a/cpan/Test-Simple/lib/Test2/Formatter/TAP.pm
+++ b/cpan/Test-Simple/lib/Test2/Formatter/TAP.pm
@@ -2,7 +2,7 @@ package Test2::Formatter::TAP;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Test2::Util qw/clone_io/;
 

--- a/cpan/Test-Simple/lib/Test2/Hub.pm
+++ b/cpan/Test-Simple/lib/Test2/Hub.pm
@@ -2,7 +2,7 @@ package Test2::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 use Carp qw/carp croak confess/;

--- a/cpan/Test-Simple/lib/Test2/Hub/Interceptor.pm
+++ b/cpan/Test-Simple/lib/Test2/Hub/Interceptor.pm
@@ -2,7 +2,7 @@ package Test2::Hub::Interceptor;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 use Test2::Hub::Interceptor::Terminator();

--- a/cpan/Test-Simple/lib/Test2/Hub/Interceptor/Terminator.pm
+++ b/cpan/Test-Simple/lib/Test2/Hub/Interceptor/Terminator.pm
@@ -2,7 +2,7 @@ package Test2::Hub::Interceptor::Terminator;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 1;

--- a/cpan/Test-Simple/lib/Test2/Hub/Subtest.pm
+++ b/cpan/Test-Simple/lib/Test2/Hub/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Hub::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN { require Test2::Hub; our @ISA = qw(Test2::Hub) }
 use Test2::Util::HashBase qw/nested exit_code manual_skip_all/;

--- a/cpan/Test-Simple/lib/Test2/IPC.pm
+++ b/cpan/Test-Simple/lib/Test2/IPC.pm
@@ -2,7 +2,7 @@ package Test2::IPC;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 use Test2::API::Instance;

--- a/cpan/Test-Simple/lib/Test2/IPC/Driver.pm
+++ b/cpan/Test-Simple/lib/Test2/IPC/Driver.pm
@@ -2,7 +2,7 @@ package Test2::IPC::Driver;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 use Carp qw/confess/;

--- a/cpan/Test-Simple/lib/Test2/IPC/Driver/Files.pm
+++ b/cpan/Test-Simple/lib/Test2/IPC/Driver/Files.pm
@@ -2,7 +2,7 @@ package Test2::IPC::Driver::Files;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN { require Test2::IPC::Driver; our @ISA = qw(Test2::IPC::Driver) }
 

--- a/cpan/Test-Simple/lib/Test2/Tools/Tiny.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Tiny.pm
@@ -16,7 +16,7 @@ use Test2::API qw/context run_subtest test2_stack/;
 use Test2::Hub::Interceptor();
 use Test2::Hub::Interceptor::Terminator();
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 BEGIN { require Exporter; our @ISA = qw(Exporter) }
 our @EXPORT = qw{

--- a/cpan/Test-Simple/lib/Test2/Util.pm
+++ b/cpan/Test-Simple/lib/Test2/Util.pm
@@ -2,7 +2,7 @@ package Test2::Util;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use POSIX();
 use Config qw/%Config/;

--- a/cpan/Test-Simple/lib/Test2/Util/ExternalMeta.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/ExternalMeta.pm
@@ -2,7 +2,7 @@ package Test2::Util::ExternalMeta;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 
 use Carp qw/croak/;

--- a/cpan/Test-Simple/lib/Test2/Util/Facets2Legacy.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Facets2Legacy.pm
@@ -2,7 +2,7 @@ package Test2::Util::Facets2Legacy;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use Carp qw/croak confess/;
 use Scalar::Util qw/blessed/;

--- a/cpan/Test-Simple/lib/Test2/Util/HashBase.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/HashBase.pm
@@ -2,7 +2,7 @@ package Test2::Util::HashBase;
 use strict;
 use warnings;
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 #################################################################
 #                                                               #

--- a/cpan/Test-Simple/lib/Test2/Util/Trace.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Trace.pm
@@ -6,7 +6,7 @@ use strict;
 
 our @ISA = ('Test2::EventFacet::Trace');
 
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 1;
 

--- a/cpan/Test-Simple/lib/ok.pm
+++ b/cpan/Test-Simple/lib/ok.pm
@@ -1,5 +1,5 @@
 package ok;
-our $VERSION = '1.302190';
+our $VERSION = '1.302191';
 
 use strict;
 use Test::More ();

--- a/cpan/Test-Simple/t/Legacy/cmp_ok.t
+++ b/cpan/Test-Simple/t/Legacy/cmp_ok.t
@@ -60,6 +60,7 @@ Test::More->builder->no_ending(1);
 require MyOverload;
 my $cmp = Overloaded::Compare->new("foo", 42);
 my $ify = Overloaded::Ify->new("bar", 23);
+my $part = Overloaded::Partial->new('baz', 0);
 
 my @Tests = (
     [1, '==', 1],
@@ -73,6 +74,8 @@ my @Tests = (
     [$cmp, 'eq', "foo"],
     [$ify, 'eq', "bar"],
     [$ify, "==", 23],
+
+    [$part, '!=', 0, 'expected: anything else'],
 
     [1, "=", 0,  "= is not a valid comparison operator in cmp_ok()"],
     [1, "+=", 0, "+= is not a valid comparison operator in cmp_ok()"],

--- a/cpan/Test-Simple/t/lib/MyOverload.pm
+++ b/cpan/Test-Simple/t/lib/MyOverload.pm
@@ -33,4 +33,11 @@ use overload
     $_[0]->{num};
   };
 
+package Overloaded::Partial;
+
+our @ISA = qw(Overloaded);
+use overload
+  q{""} => sub { $_[0]->{string} },
+  q{!=} => sub { $_[0]->{num} != $_[1] };
+
 1;


### PR DESCRIPTION
From ChangeLog:

- avoid failing when printing diagnostic info comparing
partial overload objects