### PR TITLE
my_strerror(): Avoid leak

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -5137,11 +5137,16 @@ Perl__is_in_locale_category(pTHX_ const bool compiling, const int category)
 char *
 Perl_my_strerror(pTHX_ const int errnum)
 {
-    /* Returns a mortalized copy of the text of the error message associated
-     * with 'errnum'.  It uses the current locale's text unless the platform
-     * doesn't have the LC_MESSAGES category or we are not being called from
-     * within the scope of 'use locale'.  In the former case, it uses whatever
-     * strerror returns; in the latter case it uses the text from the C locale.
+    /* Returns a newly malloc'd copy of the text of the error message
+     * associated with 'errnum'.
+     *
+     * The caller must arrange for the return value to be freed after it is no
+     * longer needed.
+     *
+     * If not called from within the scope of 'use locale', it uses the text from
+     * the C locale.  If Perl is compiled to not pay attention to LC_MESSAGES,
+     * it uses whatever strerror() returns.  Otherwise the text is
+     * derived from the locale LC_MESSAGES is in.
      *
      * The function just calls strerror(), but temporarily switches, if needed,
      * to the C locale */
@@ -5298,7 +5303,6 @@ Perl_my_strerror(pTHX_ const int errnum)
 
 #endif   /* End of does have locale messages */
 
-    SAVEFREEPV(errstr);
     return errstr;
 }
 

--- a/mg.c
+++ b/mg.c
@@ -846,6 +846,7 @@ Perl_sv_string_from_errnum(pTHX_ int errnum, SV *tgtsv)
     errstr = my_strerror(errnum);
     if(errstr) {
         sv_setpv(tgtsv, errstr);
+        Safefree(errstr);
         fixup_errno_string(tgtsv);
     } else {
         SvPVCLEAR(tgtsv);
@@ -925,7 +926,14 @@ Perl_magic_get(pTHX_ SV *sv, MAGIC *mg)
 #elif defined(OS2)
         if (!(_emx_env & 0x200)) {	/* Under DOS */
             sv_setnv(sv, (NV)errno);
-            sv_setpv(sv, errno ? my_strerror(errno) : "");
+            if (errno) {
+                errstr = my_strerror(errno);
+                sv_setpv(sv, errstr);
+                Safefree(errstr);
+            }
+            else {
+                SvPVCLEAR(sv);
+            }
         } else {
             if (errno != errno_isOS2) {
                 const int tmp = _syserrno();


### PR DESCRIPTION
This code does a savepv(), and then before returning, a SAVEFREEPV() of
that already saved PV.  The result is a leak.

Remove the SAVEFREEPV() and fix up its only two callers to free its
return when done, and update the comments.