### PR TITLE
Add whitespace in 'Setting locale failed' error

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -3575,11 +3575,11 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 #  else /* !LC_ALL */
 
                 PerlIO_printf(Perl_error_log,
-                "perl: warning: Setting locale failed for the categories:\n\t");
+                "perl: warning: Setting locale failed for the categories:\n");
 
                 for (j = 0; j < NOMINAL_LC_ALL_INDEX; j++) {
                     if (! curlocales[j]) {
-                        PerlIO_printf(Perl_error_log, category_names[j]);
+                        PerlIO_printf(Perl_error_log, "\t%s\n", category_names[j]);
                     }
                     else {
                         Safefree(curlocales[j]);


### PR DESCRIPTION
When LC_ALL doesn't exist(*) then the error message printed wasn't readable.

Before:

    $ LC_ALL= LC_NUMERIC='aa_BB' LC_PAPER='cc_DD'  ./perl -e1
    perl: warning: Setting locale failed for the categories:
        LC_NUMERICLC_PAPERperl: warning: Please check that your locale settings:
        LANGUAGE = "en_US:en",
        ...

After:

    $ LC_ALL= LC_NUMERIC='aa_BB' LC_PAPER='cc_DD'  ./perl -e1
    perl: warning: Setting locale failed for the categories:
        LC_NUMERIC
        LC_PAPER
    perl: warning: Please check that your locale settings:
        ...

(The output got mangled in commit e5f10d4955)

(*) I faked this by adding '#undef LC_ALL' inside locale.c. This does
    cause some test failure since some tests assume 'LC_ALL' is present.