### PR TITLE
perlop: clarify \U, \L, \F behaviour

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -1790,9 +1790,9 @@ X<\l> X<\u> X<\L> X<\U> X<\E> X<\Q> X<\F>
 
     \l		lowercase next character only
     \u		titlecase (not uppercase!) next character only
-    \L		lowercase all characters till \E or end of string
-    \U		uppercase all characters till \E or end of string
-    \F		foldcase all characters till \E or end of string
+    \L		lowercase all characters till \U, \F, \E or end of string
+    \U		uppercase all characters till \L, \F, \E or end of string
+    \F		foldcase all characters till \U, \L, \E or end of string
     \Q          quote (disable) pattern metacharacters till \E or
                 end of string
     \E		end either case modification or quoted section

--- a/t/op/lc.t
+++ b/t/op/lc.t
@@ -17,7 +17,7 @@ BEGIN {
 
 use feature qw( fc );
 
-plan tests => 139 + 2 * (5 * 256) + 17;
+plan tests => 139 + 2 + 2 * (5 * 256) + 17;
 
 is(lc(undef),	   "", "lc(undef) is ''");
 is(lcfirst(undef), "", "lcfirst(undef) is ''");
@@ -71,6 +71,9 @@ is(lcfirst($b)    , "hello\.\* WORLD",      'lcfirst');
 is(uc($b)         , "HELLO\.\* WORLD",      'uc');
 is(lc($b)         , "hello\.\* world",      'lc');
 is(fc($b)         , "hello\.\* world",      'fc');
+
+is("\L$a\U$b",    'hello.* worldHELLO.* WORLD', '\L$a\U$b');
+is("\U$a\L$b",    'HELLO.* WORLDhello.* world', '\U$a\L$b');
 
 # \x{100} is LATIN CAPITAL LETTER A WITH MACRON; its bijective lowercase is
 # \x{101}, LATIN SMALL LETTER A WITH MACRON.


### PR DESCRIPTION
... as they do not stop "at \E or end of string" but are also
stopped by another \U, \L or \F.

See also:
    https://www.nntp.perl.org/group/perl.perl5.porters/2022/07/msg264490.html