### PR TITLE
Remove OPf_SPECIAL flag from OP_ENTERSUB

### DIFF
--- a/ext/B/t/optree_specials.t
+++ b/ext/B/t/optree_specials.t
@@ -53,7 +53,7 @@ checkOptree ( name	=> 'BEGIN',
 # -        <;> ex-nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$ ->4
 # -        <@> lineseq K ->-
 # 4           <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) :*,&,{,x*,x&,x$,$ ->5
-# 9           <1> entersub[t1] KRS*/TARG,STRICT ->a
+# 9           <1> entersub[t1] KRS/TARG,STRICT ->a
 # 5              <0> pushmark s ->6
 # 6              <$> const[PV "strict"] sM ->7
 # 7              <$> const[PV "refs"] sM ->8
@@ -67,7 +67,7 @@ checkOptree ( name	=> 'BEGIN',
 # -        <;> ex-nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$ ->e
 # -        <@> lineseq K ->-
 # e           <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) :*,&,{,x*,x&,x$ ->f
-# j           <1> entersub[t1] KRS*/TARG ->k
+# j           <1> entersub[t1] KRS/TARG ->k
 # f              <0> pushmark s ->g
 # g              <$> const[PV "warnings"] sM ->h
 # h              <$> const[PV "once"] sM ->i
@@ -92,7 +92,7 @@ checkOptree ( name	=> 'BEGIN',
 # -        <;> ex-nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$ ->v
 # -        <@> lineseq K ->-
 # v           <;> nextstate(B::Concise -1134 Concise.pm:183) :*,&,x*,x&,x$,$ ->w
-# 10          <1> entersub[t1] KRS*/TARG,STRICT ->11
+# 10          <1> entersub[t1] KRS/TARG,STRICT ->11
 # w              <0> pushmark s ->x
 # x              <$> const[PV "strict"] sM ->y
 # y              <$> const[PV "refs"] sM ->z
@@ -106,7 +106,7 @@ checkOptree ( name	=> 'BEGIN',
 # -        <;> ex-nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$ ->15
 # -        <@> lineseq K ->-
 # 15          <;> nextstate(B::Concise -1031 Concise.pm:305) :*,&,x*,x&,x$,$ ->16
-# 1a          <1> entersub[t1] KRS*/TARG,STRICT ->1b
+# 1a          <1> entersub[t1] KRS/TARG,STRICT ->1b
 # 16             <0> pushmark s ->17
 # 17             <$> const[PV "strict"] sM ->18
 # 18             <$> const[PV "refs"] sM ->19
@@ -120,7 +120,7 @@ checkOptree ( name	=> 'BEGIN',
 # -        <;> ex-nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$ ->1f
 # -        <@> lineseq K ->-
 # 1f          <;> nextstate(B::Concise -984 Concise.pm:370) :*,&,{,x*,x&,x$,$ ->1g
-# 1k          <1> entersub[t1] KRS*/TARG,STRICT ->1l
+# 1k          <1> entersub[t1] KRS/TARG,STRICT ->1l
 # 1g             <0> pushmark s ->1h
 # 1h             <$> const[PV "strict"] sM ->1i
 # 1i             <$> const[PV "refs"] sM ->1j
@@ -134,7 +134,7 @@ checkOptree ( name	=> 'BEGIN',
 # -        <;> ex-nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$ ->1p
 # -        <@> lineseq K ->-
 # 1p          <;> nextstate(B::Concise -959 Concise.pm:390) :*,&,x*,x&,x$,$ ->1q
-# 1u          <1> entersub[t1] KRS*/TARG,STRICT ->1v
+# 1u          <1> entersub[t1] KRS/TARG,STRICT ->1v
 # 1q             <0> pushmark s ->1r
 # 1r             <$> const[PV "strict"] sM ->1s
 # 1s             <$> const[PV "refs"] sM ->1t
@@ -148,7 +148,7 @@ checkOptree ( name	=> 'BEGIN',
 # -        <;> ex-nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$ ->1z
 # -        <@> lineseq K ->-
 # 1z          <;> nextstate(B::Concise -945 Concise.pm:410) :*,&,{,x*,x&,x$,$ ->20
-# 24          <1> entersub[t1] KRS*/TARG,STRICT ->25
+# 24          <1> entersub[t1] KRS/TARG,STRICT ->25
 # 20             <0> pushmark s ->21
 # 21             <$> const[PV "warnings"] sM ->22
 # 22             <$> const[PV "qw"] sM ->23
@@ -170,7 +170,7 @@ EOT_EOT
 # -        <;> ex-nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$ ->4
 # -        <@> lineseq K ->-
 # 4           <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) :*,&,{,x*,x&,x$,$ ->5
-# 9           <1> entersub[t1] KRS*/TARG,STRICT ->a
+# 9           <1> entersub[t1] KRS/TARG,STRICT ->a
 # 5              <0> pushmark s ->6
 # 6              <$> const(PV "strict") sM ->7
 # 7              <$> const(PV "refs") sM ->8
@@ -184,7 +184,7 @@ EOT_EOT
 # -        <;> ex-nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$ ->e
 # -        <@> lineseq K ->-
 # e           <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) :*,&,{,x*,x&,x$ ->f
-# j           <1> entersub[t1] KRS*/TARG ->k
+# j           <1> entersub[t1] KRS/TARG ->k
 # f              <0> pushmark s ->g
 # g              <$> const(PV "warnings") sM ->h
 # h              <$> const(PV "once") sM ->i
@@ -209,7 +209,7 @@ EOT_EOT
 # -        <;> ex-nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$ ->v
 # -        <@> lineseq K ->-
 # v           <;> nextstate(B::Concise -1134 Concise.pm:183) :*,&,x*,x&,x$,$ ->w
-# 10          <1> entersub[t1] KRS*/TARG,STRICT ->11
+# 10          <1> entersub[t1] KRS/TARG,STRICT ->11
 # w              <0> pushmark s ->x
 # x              <$> const(PV "strict") sM ->y
 # y              <$> const(PV "refs") sM ->z
@@ -223,7 +223,7 @@ EOT_EOT
 # -        <;> ex-nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$ ->15
 # -        <@> lineseq K ->-
 # 15          <;> nextstate(B::Concise -1031 Concise.pm:305) :*,&,x*,x&,x$,$ ->16
-# 1a          <1> entersub[t1] KRS*/TARG,STRICT ->1b
+# 1a          <1> entersub[t1] KRS/TARG,STRICT ->1b
 # 16             <0> pushmark s ->17
 # 17             <$> const(PV "strict") sM ->18
 # 18             <$> const(PV "refs") sM ->19
@@ -237,7 +237,7 @@ EOT_EOT
 # -        <;> ex-nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$ ->1f
 # -        <@> lineseq K ->-
 # 1f          <;> nextstate(B::Concise -984 Concise.pm:370) :*,&,{,x*,x&,x$,$ ->1g
-# 1k          <1> entersub[t1] KRS*/TARG,STRICT ->1l
+# 1k          <1> entersub[t1] KRS/TARG,STRICT ->1l
 # 1g             <0> pushmark s ->1h
 # 1h             <$> const(PV "strict") sM ->1i
 # 1i             <$> const(PV "refs") sM ->1j
@@ -251,7 +251,7 @@ EOT_EOT
 # -        <;> ex-nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$ ->1p
 # -        <@> lineseq K ->-
 # 1p          <;> nextstate(B::Concise -959 Concise.pm:390) :*,&,x*,x&,x$,$ ->1q
-# 1u          <1> entersub[t1] KRS*/TARG,STRICT ->1v
+# 1u          <1> entersub[t1] KRS/TARG,STRICT ->1v
 # 1q             <0> pushmark s ->1r
 # 1r             <$> const(PV "strict") sM ->1s
 # 1s             <$> const(PV "refs") sM ->1t
@@ -265,7 +265,7 @@ EOT_EOT
 # -        <;> ex-nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$ ->1z
 # -        <@> lineseq K ->-
 # 1z          <;> nextstate(B::Concise -945 Concise.pm:410) :*,&,{,x*,x&,x$,$ ->20
-# 24          <1> entersub[t1] KRS*/TARG,STRICT ->25
+# 24          <1> entersub[t1] KRS/TARG,STRICT ->25
 # 20             <0> pushmark s ->21
 # 21             <$> const(PV "warnings") sM ->22
 # 22             <$> const(PV "qw") sM ->23
@@ -382,7 +382,7 @@ checkOptree ( name	=> 'all of BEGIN END INIT CHECK UNITCHECK -exec',
 # 6  <$> const[PV "strict"] sM
 # 7  <$> const[PV "refs"] sM
 # 8  <.> method_named[PV "unimport"] 
-# 9  <1> entersub[t1] KRS*/TARG,STRICT
+# 9  <1> entersub[t1] KRS/TARG,STRICT
 # a  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 2:
 # b  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$
@@ -393,7 +393,7 @@ checkOptree ( name	=> 'all of BEGIN END INIT CHECK UNITCHECK -exec',
 # g  <$> const[PV "warnings"] sM
 # h  <$> const[PV "once"] sM
 # i  <.> method_named[PV "unimport"] 
-# j  <1> entersub[t1] KRS*/TARG
+# j  <1> entersub[t1] KRS/TARG
 # k  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 3:
 # l  <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$
@@ -412,7 +412,7 @@ checkOptree ( name	=> 'all of BEGIN END INIT CHECK UNITCHECK -exec',
 # x  <$> const[PV "strict"] sM
 # y  <$> const[PV "refs"] sM
 # z  <.> method_named[PV "unimport"] 
-# 10 <1> entersub[t1] KRS*/TARG,STRICT
+# 10 <1> entersub[t1] KRS/TARG,STRICT
 # 11 <1> leavesub[1 ref] K/REFC,1
 # BEGIN 5:
 # 12 <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$
@@ -423,7 +423,7 @@ checkOptree ( name	=> 'all of BEGIN END INIT CHECK UNITCHECK -exec',
 # 17 <$> const[PV "strict"] sM
 # 18 <$> const[PV "refs"] sM
 # 19 <.> method_named[PV "unimport"] 
-# 1a <1> entersub[t1] KRS*/TARG,STRICT
+# 1a <1> entersub[t1] KRS/TARG,STRICT
 # 1b <1> leavesub[1 ref] K/REFC,1
 # BEGIN 6:
 # 1c <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$
@@ -434,7 +434,7 @@ checkOptree ( name	=> 'all of BEGIN END INIT CHECK UNITCHECK -exec',
 # 1h <$> const[PV "strict"] sM
 # 1i <$> const[PV "refs"] sM
 # 1j <.> method_named[PV "unimport"] 
-# 1k <1> entersub[t1] KRS*/TARG,STRICT
+# 1k <1> entersub[t1] KRS/TARG,STRICT
 # 1l <1> leavesub[1 ref] K/REFC,1
 # BEGIN 7:
 # 1m <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$
@@ -445,7 +445,7 @@ checkOptree ( name	=> 'all of BEGIN END INIT CHECK UNITCHECK -exec',
 # 1r <$> const[PV "strict"] sM
 # 1s <$> const[PV "refs"] sM
 # 1t <.> method_named[PV "unimport"] 
-# 1u <1> entersub[t1] KRS*/TARG,STRICT
+# 1u <1> entersub[t1] KRS/TARG,STRICT
 # 1v <1> leavesub[1 ref] K/REFC,1
 # BEGIN 8:
 # 1w <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$
@@ -456,7 +456,7 @@ checkOptree ( name	=> 'all of BEGIN END INIT CHECK UNITCHECK -exec',
 # 21 <$> const[PV "warnings"] sM
 # 22 <$> const[PV "qw"] sM
 # 23 <.> method_named[PV "unimport"] 
-# 24 <1> entersub[t1] KRS*/TARG,STRICT
+# 24 <1> entersub[t1] KRS/TARG,STRICT
 # 25 <1> leavesub[1 ref] K/REFC,1
 # BEGIN 9:
 # 26 <;> nextstate(main 3 -e:1) v:{
@@ -493,7 +493,7 @@ EOT_EOT
 # 6  <$> const(PV "strict") sM
 # 7  <$> const(PV "refs") sM
 # 8  <.> method_named(PV "unimport") 
-# 9  <1> entersub[t1] KRS*/TARG,STRICT
+# 9  <1> entersub[t1] KRS/TARG,STRICT
 # a  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 2:
 # b  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$
@@ -504,7 +504,7 @@ EOT_EOT
 # g  <$> const(PV "warnings") sM
 # h  <$> const(PV "once") sM
 # i  <.> method_named(PV "unimport") 
-# j  <1> entersub[t1] KRS*/TARG
+# j  <1> entersub[t1] KRS/TARG
 # k  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 3:
 # l  <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$
@@ -523,7 +523,7 @@ EOT_EOT
 # x  <$> const(PV "strict") sM
 # y  <$> const(PV "refs") sM
 # z  <.> method_named(PV "unimport") 
-# 10 <1> entersub[t1] KRS*/TARG,STRICT
+# 10 <1> entersub[t1] KRS/TARG,STRICT
 # 11 <1> leavesub[1 ref] K/REFC,1
 # BEGIN 5:
 # 12 <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$
@@ -534,7 +534,7 @@ EOT_EOT
 # 17 <$> const(PV "strict") sM
 # 18 <$> const(PV "refs") sM
 # 19 <.> method_named(PV "unimport") 
-# 1a <1> entersub[t1] KRS*/TARG,STRICT
+# 1a <1> entersub[t1] KRS/TARG,STRICT
 # 1b <1> leavesub[1 ref] K/REFC,1
 # BEGIN 6:
 # 1c <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$
@@ -545,7 +545,7 @@ EOT_EOT
 # 1h <$> const(PV "strict") sM
 # 1i <$> const(PV "refs") sM
 # 1j <.> method_named(PV "unimport") 
-# 1k <1> entersub[t1] KRS*/TARG,STRICT
+# 1k <1> entersub[t1] KRS/TARG,STRICT
 # 1l <1> leavesub[1 ref] K/REFC,1
 # BEGIN 7:
 # 1m <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$
@@ -556,7 +556,7 @@ EOT_EOT
 # 1r <$> const(PV "strict") sM
 # 1s <$> const(PV "refs") sM
 # 1t <.> method_named(PV "unimport") 
-# 1u <1> entersub[t1] KRS*/TARG,STRICT
+# 1u <1> entersub[t1] KRS/TARG,STRICT
 # 1v <1> leavesub[1 ref] K/REFC,1
 # BEGIN 8:
 # 1w <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$
@@ -567,7 +567,7 @@ EOT_EOT
 # 21 <$> const(PV "warnings") sM
 # 22 <$> const(PV "qw") sM
 # 23 <.> method_named(PV "unimport") 
-# 24 <1> entersub[t1] KRS*/TARG,STRICT
+# 24 <1> entersub[t1] KRS/TARG,STRICT
 # 25 <1> leavesub[1 ref] K/REFC,1
 # BEGIN 9:
 # 26 <;> nextstate(main 3 -e:1) v:{
@@ -611,7 +611,7 @@ checkOptree ( name	=> 'regression test for patch 25352',
 # 6  <$> const[PV "strict"] sM
 # 7  <$> const[PV "refs"] sM
 # 8  <.> method_named[PV "unimport"] 
-# 9  <1> entersub[t1] KRS*/TARG,STRICT
+# 9  <1> entersub[t1] KRS/TARG,STRICT
 # a  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 2:
 # b  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$
@@ -622,7 +622,7 @@ checkOptree ( name	=> 'regression test for patch 25352',
 # g  <$> const[PV "warnings"] sM
 # h  <$> const[PV "once"] sM
 # i  <.> method_named[PV "unimport"] 
-# j  <1> entersub[t1] KRS*/TARG
+# j  <1> entersub[t1] KRS/TARG
 # k  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 3:
 # l  <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$
@@ -641,7 +641,7 @@ checkOptree ( name	=> 'regression test for patch 25352',
 # x  <$> const[PV "strict"] sM
 # y  <$> const[PV "refs"] sM
 # z  <.> method_named[PV "unimport"] 
-# 10 <1> entersub[t1] KRS*/TARG,STRICT
+# 10 <1> entersub[t1] KRS/TARG,STRICT
 # 11 <1> leavesub[1 ref] K/REFC,1
 # BEGIN 5:
 # 12 <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$
@@ -652,7 +652,7 @@ checkOptree ( name	=> 'regression test for patch 25352',
 # 17 <$> const[PV "strict"] sM
 # 18 <$> const[PV "refs"] sM
 # 19 <.> method_named[PV "unimport"] 
-# 1a <1> entersub[t1] KRS*/TARG,STRICT
+# 1a <1> entersub[t1] KRS/TARG,STRICT
 # 1b <1> leavesub[1 ref] K/REFC,1
 # BEGIN 6:
 # 1c <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$
@@ -663,7 +663,7 @@ checkOptree ( name	=> 'regression test for patch 25352',
 # 1h <$> const[PV "strict"] sM
 # 1i <$> const[PV "refs"] sM
 # 1j <.> method_named[PV "unimport"] 
-# 1k <1> entersub[t1] KRS*/TARG,STRICT
+# 1k <1> entersub[t1] KRS/TARG,STRICT
 # 1l <1> leavesub[1 ref] K/REFC,1
 # BEGIN 7:
 # 1m <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$
@@ -674,7 +674,7 @@ checkOptree ( name	=> 'regression test for patch 25352',
 # 1r <$> const[PV "strict"] sM
 # 1s <$> const[PV "refs"] sM
 # 1t <.> method_named[PV "unimport"] 
-# 1u <1> entersub[t1] KRS*/TARG,STRICT
+# 1u <1> entersub[t1] KRS/TARG,STRICT
 # 1v <1> leavesub[1 ref] K/REFC,1
 # BEGIN 8:
 # 1w <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$
@@ -685,7 +685,7 @@ checkOptree ( name	=> 'regression test for patch 25352',
 # 21 <$> const[PV "warnings"] sM
 # 22 <$> const[PV "qw"] sM
 # 23 <.> method_named[PV "unimport"] 
-# 24 <1> entersub[t1] KRS*/TARG,STRICT
+# 24 <1> entersub[t1] KRS/TARG,STRICT
 # 25 <1> leavesub[1 ref] K/REFC,1
 EOT_EOT
 # BEGIN 1:
@@ -697,7 +697,7 @@ EOT_EOT
 # 6  <$> const(PV "strict") sM
 # 7  <$> const(PV "refs") sM
 # 8  <.> method_named(PV "unimport") 
-# 9  <1> entersub[t1] KRS*/TARG,STRICT
+# 9  <1> entersub[t1] KRS/TARG,STRICT
 # a  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 2:
 # b  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$
@@ -708,7 +708,7 @@ EOT_EOT
 # g  <$> const(PV "warnings") sM
 # h  <$> const(PV "once") sM
 # i  <.> method_named(PV "unimport") 
-# j  <1> entersub[t1] KRS*/TARG
+# j  <1> entersub[t1] KRS/TARG
 # k  <1> leavesub[1 ref] K/REFC,1
 # BEGIN 3:
 # l  <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$
@@ -727,7 +727,7 @@ EOT_EOT
 # x  <$> const(PV "strict") sM
 # y  <$> const(PV "refs") sM
 # z  <.> method_named(PV "unimport") 
-# 10 <1> entersub[t1] KRS*/TARG,STRICT
+# 10 <1> entersub[t1] KRS/TARG,STRICT
 # 11 <1> leavesub[1 ref] K/REFC,1
 # BEGIN 5:
 # 12 <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$
@@ -738,7 +738,7 @@ EOT_EOT
 # 17 <$> const(PV "strict") sM
 # 18 <$> const(PV "refs") sM
 # 19 <.> method_named(PV "unimport") 
-# 1a <1> entersub[t1] KRS*/TARG,STRICT
+# 1a <1> entersub[t1] KRS/TARG,STRICT
 # 1b <1> leavesub[1 ref] K/REFC,1
 # BEGIN 6:
 # 1c <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$
@@ -749,7 +749,7 @@ EOT_EOT
 # 1h <$> const(PV "strict") sM
 # 1i <$> const(PV "refs") sM
 # 1j <.> method_named(PV "unimport") 
-# 1k <1> entersub[t1] KRS*/TARG,STRICT
+# 1k <1> entersub[t1] KRS/TARG,STRICT
 # 1l <1> leavesub[1 ref] K/REFC,1
 # BEGIN 7:
 # 1m <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$
@@ -760,7 +760,7 @@ EOT_EOT
 # 1r <$> const(PV "strict") sM
 # 1s <$> const(PV "refs") sM
 # 1t <.> method_named(PV "unimport") 
-# 1u <1> entersub[t1] KRS*/TARG,STRICT
+# 1u <1> entersub[t1] KRS/TARG,STRICT
 # 1v <1> leavesub[1 ref] K/REFC,1
 # BEGIN 8:
 # 1w <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$
@@ -771,6 +771,6 @@ EOT_EOT
 # 21 <$> const(PV "warnings") sM
 # 22 <$> const(PV "qw") sM
 # 23 <.> method_named(PV "unimport") 
-# 24 <1> entersub[t1] KRS*/TARG,STRICT
+# 24 <1> entersub[t1] KRS/TARG,STRICT
 # 25 <1> leavesub[1 ref] K/REFC,1
 EONT_EONT

--- a/lib/B/Deparse.pm
+++ b/lib/B/Deparse.pm
@@ -7,7 +7,7 @@
 # This is based on the module of the same name by Malcolm Beattie,
 # but essentially none of his code remains.
 
-package B::Deparse 1.66;
+package B::Deparse 1.67;
 use strict;
 use Carp;
 use B qw(class main_root main_start main_cv svref_2object opnumber perlstring
@@ -5103,9 +5103,7 @@ sub pp_entersub {
     my $prefix = "";
     my $amper = "";
     my($kid, @exprs);
-    if ($op->flags & OPf_SPECIAL && !($op->flags & OPf_MOD)) {
-	$prefix = "do ";
-    } elsif ($op->private & OPpENTERSUB_AMPER) {
+    if ($op->private & OPpENTERSUB_AMPER) {
 	$amper = "&";
     }
     $kid = $op->first;

--- a/op.c
+++ b/op.c
@@ -3824,7 +3824,7 @@ S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **imopsp)
 
     /* Fake up a method call to import */
     meth = newSVpvs_share("import");
-    imop = op_convert_list(OP_ENTERSUB, OPf_STACKED|OPf_SPECIAL|OPf_WANT_VOID,
+    imop = op_convert_list(OP_ENTERSUB, OPf_STACKED|OPf_WANT_VOID,
                    op_append_elem(OP_LIST,
                                op_prepend_elem(OP_LIST, pack, arg),
                                newMETHOP_named(OP_METHOD_NAMED, 0, meth)));

--- a/op.c
+++ b/op.c
@@ -7571,7 +7571,7 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
 
             /* Fake up a method call to VERSION */
             meth = newSVpvs_share("VERSION");
-            veop = op_convert_list(OP_ENTERSUB, OPf_STACKED|OPf_SPECIAL,
+            veop = op_convert_list(OP_ENTERSUB, OPf_STACKED,
                             op_append_elem(OP_LIST,
                                         op_prepend_elem(OP_LIST, pack, version),
                                         newMETHOP_named(OP_METHOD_NAMED, 0, meth)));
@@ -7598,7 +7598,7 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
         /* Fake up a method call to import/unimport */
         meth = aver
             ? newSVpvs_share("import") : newSVpvs_share("unimport");
-        imop = op_convert_list(OP_ENTERSUB, OPf_STACKED|OPf_SPECIAL,
+        imop = op_convert_list(OP_ENTERSUB, OPf_STACKED,
                        op_append_elem(OP_LIST,
                                    op_prepend_elem(OP_LIST, pack, arg),
                                    newMETHOP_named(OP_METHOD_NAMED, 0, meth)

--- a/op.c
+++ b/op.c
@@ -3450,8 +3450,7 @@ Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
         o->op_flags |= OPf_MOD;
 
     if (type == OP_AASSIGN || type == OP_SASSIGN)
-        o->op_flags |= OPf_SPECIAL
-                      |(o->op_type == OP_ENTERSUB ? 0 : OPf_REF);
+        o->op_flags |= o->op_type == OP_ENTERSUB ? 0 : OPf_SPECIAL|OPf_REF;
     else if (!type) { /* local() */
         switch (localize) {
         case 1:

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -358,6 +358,13 @@ actual behaviour (it suppresses a warning that would otherwise be generated
 about ambiguous names), in order to be less confusing with a possible upcoming
 feature.
 
+=item *
+
+The C<OPf_SPECIAL> flag is no longer set on the C<OP_ENTERSUB> op
+constructed to call the C<VERSION>, C<import> and C<unimport> methods
+as part of a C<use> statement and attribute application, nor when
+assigning to an C<:lvalue> subroutine.
+
 =back
 
 =head1 Selected Bug Fixes


### PR DESCRIPTION
It was being set for lvalue sub assignments and method calls implied by `use` and attributes on lexical variables, but nothing appears to ever have used that flag for anything.

The last thing that actually used it was `do SUBNAME(LIST)` notation, which signalled that `B::Deparse` had to emit a `do ` before the subname. That functionality was removed in 5.20 (commit 8c74b41425572faeb638f1269025b59d0785794f), but `B::Deparse` missed the memo.

This frees up the `OPf_SPECIAL` flag for some other purpose, see https://github.com/Perl/perl5/issues/19997#issuecomment-1196987459.