### PR TITLE
vutil.c: Simplify locale handling

### DIFF
--- a/vutil.c
+++ b/vutil.c
@@ -582,7 +582,8 @@ Perl_upg_version(pTHX_ SV *ver, bool qv)
     PERL_ARGS_ASSERT_UPG_VERSION;
 
     if ( (SvUOK(ver) && SvUVX(ver) > VERSION_MAX)
-	   || (SvIOK(ver) && SvIVX(ver) > VERSION_MAX) ) {
+        || (SvIOK(ver) && SvIVX(ver) > VERSION_MAX) )
+    {
 	/* out of bounds [unsigned] integer */
 	STRLEN len;
 	char tbuf[64];
@@ -690,12 +691,9 @@ VER_NV:
             }
 
 # endif
-
             /* Prevent recursed calls from trying to change back */
             LOCK_LC_NUMERIC_STANDARD();
-
 #endif
-
 	if (sv) {
                 Perl_sv_setpvf(aTHX_ sv, "%.9" NVff, SvNVX(ver));
 	    len = SvCUR(sv);
@@ -718,7 +716,6 @@ VER_NV:
             }
 
             LC_NUMERIC_UNLOCK;  /* End critical section */
-
 #  else
 
             if (locale_name_on_entry) {

--- a/vutil.c
+++ b/vutil.c
@@ -626,11 +626,15 @@ VER_NV:
              * locales without letting perl know, therefore we have to find it
              * from first principals.  See [perl #121930]. */
 
+#  ifdef USE_POSIX_2008_LOCALE
+
+            /* Its easiest with POSIX 2008: Just save the initial locale and
+             * toggle to C */
+            const locale_t locale_obj_on_entry
+                                        = uselocale((locale_t) PL_C_locale_obj);
+# else
             /* In windows, or not threaded, or not thread-safe, if it isn't C,
              * set it to C. */
-
-#  ifndef USE_POSIX_2008_LOCALE
-
             const char * locale_name_on_entry;
 
             LC_NUMERIC_LOCK(0);    /* Start critical section */
@@ -647,49 +651,6 @@ VER_NV:
                        change the locale */
                 locale_name_on_entry = NULL;
             }
-
-# else
-
-            const locale_t locale_obj_on_entry = uselocale((locale_t) 0);
-            const char * locale_name_on_entry = NULL;
-            DECLARATION_FOR_LC_NUMERIC_MANIPULATION;
-
-            if (locale_obj_on_entry == LC_GLOBAL_LOCALE) {
-
-                /* in the global locale, we can call system setlocale and if it
-                 * isn't C, set it to C. */
-                LC_NUMERIC_LOCK(0);
-
-                locale_name_on_entry = setlocale(LC_NUMERIC, NULL);
-                if (   strNE(locale_name_on_entry, "C")
-                    && strNE(locale_name_on_entry, "POSIX"))
-                {
-                    /* the setlocale() call might free or overwrite the name */
-                    locale_name_on_entry = savepv(locale_name_on_entry);
-                    setlocale(LC_NUMERIC, "C");
-                }
-                else {  /* This value indicates to the restore code that we
-                           didn't change the locale */
-                    locale_name_on_entry = NULL;
-	    }
-	}
-            else if (locale_obj_on_entry == PL_underlying_numeric_obj) {
-                /* Here, the locale appears to have been changed to use the
-                 * program's underlying locale.  Just use our mechanisms to
-                 * switch back to C.   It might be possible for this pointer to
-                 * actually refer to something else if it got released and
-                 * reused somehow.  But it doesn't matter, our mechanisms will
-                 * work even so */
-                STORE_LC_NUMERIC_SET_STANDARD();
-            }
-            else if (locale_obj_on_entry != PL_C_locale_obj) {
-                /* The C object should be unchanged during a program's
-                 * execution, so it should be safe to assume it means what it
-                 * says, so if we are in it, no locale change is required.
-                 * Otherwise, simply use the thread-safe operation. */
-                uselocale(PL_C_locale_obj);
-            }
-
 # endif
             /* Prevent recursed calls from trying to change back */
             LOCK_LC_NUMERIC_STANDARD();
@@ -717,19 +678,7 @@ VER_NV:
 
             LC_NUMERIC_UNLOCK;  /* End critical section */
 #  else
-
-            if (locale_name_on_entry) {
-                setlocale(LC_NUMERIC, locale_name_on_entry);
-                Safefree(locale_name_on_entry);
-                LC_NUMERIC_UNLOCK;
-            }
-            else if (locale_obj_on_entry == PL_underlying_numeric_obj) {
-                RESTORE_LC_NUMERIC();
-            }
-            else if (locale_obj_on_entry != PL_C_locale_obj) {
                 uselocale(locale_obj_on_entry);
-        }
-
 #  endif
 
         }


### PR DESCRIPTION
I read the code over and realized that there was a much simpler way to do things.
