### PR TITLE
Use ppport.h when building dist/ modules in core

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4097,6 +4097,7 @@ dist/threads/t/stress_string.t	Test with multiple threads, string cv argument.
 dist/threads/t/thread.t		General ithread tests from thr5005
 dist/threads/t/unique.t		Test unique attribute with threads
 dist/threads/t/version.t	Test that pod version matches code version.
+dist/threads/threads.h		threads compatibility helper
 dist/threads/threads.xs		ithreads
 dist/threads-shared/hints/linux.pl	thread shared variables
 dist/threads-shared/lib/threads/shared.pm	thread shared variables

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1182,7 +1182,6 @@ use File::Glob qw(:case);
             qr{^examples/},
             qw( t/pod.t
                 t/test.pl
-                threads.h
                 ),
         ],
     },
@@ -1192,7 +1191,6 @@ use File::Glob qw(:case);
         'FILES'        => q[dist/threads-shared],
         'EXCLUDED'     => [
             qw( examples/class.pl
-                shared.h
                 t/pod.t
                 t/test.pl
                 ),

--- a/dist/Data-Dumper/Dumper.pm
+++ b/dist/Data-Dumper/Dumper.pm
@@ -30,7 +30,8 @@ our ( $Indent, $Trailingcomma, $Purity, $Pad, $Varname, $Useqq, $Terse, $Freezer
 our ( @ISA, @EXPORT, @EXPORT_OK, $VERSION );
 
 BEGIN {
-    $VERSION = '2.187'; # Don't forget to set version in POD below!
+    $VERSION = '2.188'; # Don't forget to set version and release
+                        # date in POD below!
 
     @ISA = qw(Exporter);
     @EXPORT = qw(Dumper);
@@ -1454,7 +1455,7 @@ modify it under the same terms as Perl itself.
 
 =head1 VERSION
 
-Version 2.187
+Version 2.188
 
 =head1 SEE ALSO
 

--- a/dist/Data-Dumper/Dumper.xs
+++ b/dist/Data-Dumper/Dumper.xs
@@ -2,13 +2,11 @@
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
-#ifdef USE_PPPORT_H
-#  define NEED_my_snprintf
-#  define NEED_my_sprintf
-#  define NEED_sv_2pv_flags
-#  define NEED_utf8_to_uvchr_buf
-#  include "ppport.h"
-#endif
+#define NEED_my_snprintf
+#define NEED_my_sprintf
+#define NEED_sv_2pv_flags
+#define NEED_utf8_to_uvchr_buf
+#include "ppport.h"
 
 #ifndef strlcpy
 #  ifdef my_strlcpy

--- a/dist/Data-Dumper/Makefile.PL
+++ b/dist/Data-Dumper/Makefile.PL
@@ -18,6 +18,5 @@ WriteMakefile(
     VERSION_FROM  => 'Dumper.pm',
     ABSTRACT_FROM => 'Dumper.pm',
     $] <= 5.011000 ? ( INSTALLDIRS => 'perl' ) : (),
-    ((grep { $_ eq 'PERL_CORE=1' } @ARGV) ? () : ('DEFINE' => '-DUSE_PPPORT_H')),
     @extra,
 );

--- a/dist/PathTools/Cwd.pm
+++ b/dist/PathTools/Cwd.pm
@@ -3,7 +3,7 @@ use strict;
 use Exporter;
 
 
-our $VERSION = '3.88';
+our $VERSION = '3.89';
 my $xs_version = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/dist/PathTools/Cwd.xs
+++ b/dist/PathTools/Cwd.xs
@@ -7,13 +7,11 @@
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
-#ifndef NO_PPPORT_H
-#  define NEED_croak_xs_usage
-#  define NEED_sv_2pv_flags
-#  define NEED_my_strlcpy
-#  define NEED_my_strlcat
-#  include "ppport.h"
-#endif
+#define NEED_croak_xs_usage
+#define NEED_sv_2pv_flags
+#define NEED_my_strlcpy
+#define NEED_my_strlcat
+#include "ppport.h"
 
 #if defined(HAS_READLINK) && !defined(PerlLIO_readlink)
 #define PerlLIO_readlink readlink

--- a/dist/PathTools/Makefile.PL
+++ b/dist/PathTools/Makefile.PL
@@ -29,10 +29,7 @@ WriteMakefile
           'VERSION_FROM' => 'Cwd.pm',
           'ABSTRACT' => 'Tools for working with directory and file names',
           'AUTHOR' => 'Perl 5 Porters',
-          'DEFINE' => join(" ",
-                "-DDOUBLE_SLASHES_SPECIAL=@{[$^O eq q(qnx) || $^O eq q(nto) ? 1 : 0]}",
-                ((grep { $_ eq 'PERL_CORE=1' } @ARGV) ? '-DNO_PPPORT_H' : ()),
-          ),
+          'DEFINE' => "-DDOUBLE_SLASHES_SPECIAL=@{[$^O eq q(qnx) || $^O eq q(nto) ? 1 : 0]}",
           'PREREQ_PM' => {
                            'Carp' => '0',
                            'File::Basename' => '0',

--- a/dist/Storable/Makefile.PL
+++ b/dist/Storable/Makefile.PL
@@ -11,14 +11,11 @@ use warnings;
 use ExtUtils::MakeMaker 6.31;
 use Config;
 
-my $defines = $ENV{PERL_CORE} ? q[] : q[-DUSE_PPPORT_H];
-
 WriteMakefile(
     NAME                => 'Storable',
     AUTHOR              => 'Perl 5 Porters',
     LICENSE             => 'perl',
     DISTNAME            => "Storable",
-    DEFINE              => $defines,
     PREREQ_PM           =>
       {
           XSLoader => 0,

--- a/dist/Storable/Storable.pm
+++ b/dist/Storable/Storable.pm
@@ -28,7 +28,7 @@ our @EXPORT_OK = qw(
 our ($canonical, $forgive_me);
 
 BEGIN {
-  our $VERSION = '3.29';
+  our $VERSION = '3.30';
 }
 
 our $recursion_limit;

--- a/dist/Storable/Storable.xs
+++ b/dist/Storable/Storable.xs
@@ -16,16 +16,14 @@
 #include <perl.h>
 #include <XSUB.h>
 
-#ifdef USE_PPPORT_H
-#   define NEED_PL_parser
-#   define NEED_sv_2pv_flags
-#   define NEED_load_module
-#   define NEED_vload_module
-#   define NEED_newCONSTSUB
-#   define NEED_newSVpvn_flags
-#   define NEED_newRV_noinc
+#define NEED_PL_parser
+#define NEED_sv_2pv_flags
+#define NEED_load_module
+#define NEED_vload_module
+#define NEED_newCONSTSUB
+#define NEED_newSVpvn_flags
+#define NEED_newRV_noinc
 #include "ppport.h"             /* handle old perls */
-#endif
 
 #ifdef DEBUGGING
 #define DEBUGME /* Debug mode, turns assertions on as well */

--- a/dist/Time-HiRes/HiRes.pm
+++ b/dist/Time-HiRes/HiRes.pm
@@ -50,7 +50,7 @@ our @EXPORT_OK = qw (usleep sleep ualarm alarm gettimeofday time tv_interval
                  stat lstat utime
                 );
 
-our $VERSION = '1.9772';
+our $VERSION = '1.9773';
 our $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 

--- a/dist/Time-HiRes/HiRes.xs
+++ b/dist/Time-HiRes/HiRes.xs
@@ -19,10 +19,8 @@ extern "C" {
 #include "perl.h"
 #include "XSUB.h"
 #include "reentr.h"
-#ifdef USE_PPPORT_H
 #define NEED_ck_warner
-#  include "ppport.h"
-#endif
+#include "ppport.h"
 #if defined(__CYGWIN__) && defined(HAS_W32API_WINDOWS_H)
 #  include <w32api/windows.h>
 #  define CYGWIN_WITH_W32API

--- a/dist/Time-HiRes/Makefile.PL
+++ b/dist/Time-HiRes/Makefile.PL
@@ -868,8 +868,6 @@ EOM
 sub doMakefile {
     my @makefileopts = ();
 
-    DEFINE('USE_PPPORT_H') unless $ENV{PERL_CORE};
-
     push (@makefileopts,
         'NAME'  => 'Time::HiRes',
         'AUTHOR'    => 'Jarkko Hietaniemi <jhi@iki.fi>',

--- a/dist/threads-shared/lib/threads/shared.pm
+++ b/dist/threads-shared/lib/threads/shared.pm
@@ -8,7 +8,7 @@ use Config;
 
 use Scalar::Util qw(reftype refaddr blessed);
 
-our $VERSION = '1.65'; # Please update the pod, too.
+our $VERSION = '1.66'; # Please update the pod, too.
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -196,7 +196,7 @@ threads::shared - Perl extension for sharing data structures between threads
 
 =head1 VERSION
 
-This document describes threads::shared version 1.64
+This document describes threads::shared version 1.66
 
 =head1 SYNOPSIS
 

--- a/dist/threads-shared/shared.xs
+++ b/dist/threads-shared/shared.xs
@@ -130,14 +130,11 @@
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
-#ifdef HAS_PPPORT_H
-#  define NEED_sv_2pv_flags
-#  define NEED_vnewSVpvf
-#  define NEED_warner
-#  define NEED_newSVpvn_flags
-#  include "ppport.h"
-#  include "shared.h"
-#endif
+#define NEED_sv_2pv_flags
+#define NEED_vnewSVpvf
+#define NEED_warner
+#define NEED_newSVpvn_flags
+#include "ppport.h"
 
 #ifndef CLANG_DIAG_IGNORE
 # define CLANG_DIAG_IGNORE(x)

--- a/dist/threads/threads.xs
+++ b/dist/threads/threads.xs
@@ -19,12 +19,10 @@
 #    define setjmp(x) _setjmpex((x), mingw_getsp())
 #  endif
 #endif
-#ifdef HAS_PPPORT_H
-#  define NEED_PL_signals
-#  define NEED_sv_2pv_flags
-#  include "ppport.h"
-#  include "threads.h"
-#endif
+#define NEED_PL_signals
+#define NEED_sv_2pv_flags
+#include "ppport.h"
+#include "threads.h"
 #ifndef sv_dup_inc
 #  define sv_dup_inc(s,t) SvREFCNT_inc(sv_dup(s,t))
 #endif


### PR DESCRIPTION
By always including `ppport.h`, this simplifies both XS code and tooling around it.

This is an alternative to #19888 (and as such we probably should finish the discussion there).

Something similar to this should probably be done to some of the modules in `cpan/` (IPC-SysV, Scalar-List-Util, Compress-Raw-ZLib, Compress-Raw-Bzip2, Sys-Syslog), and threads.pm needs a bit of refactoring to simplify further.