### PR TITLE
Add (to sv.c) and use new Perl_newSVhek_mortal function

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1531,6 +1531,7 @@ ApdR	|SV*	|newSVpv	|NULLOK const char *const s|const STRLEN len
 ApdR	|SV*	|newSVpvn	|NULLOK const char *const buffer|const STRLEN len
 ApdR	|SV*	|newSVpvn_flags	|NULLOK const char *const s|const STRLEN len|const U32 flags
 ApdR	|SV*	|newSVhek	|NULLOK const HEK *const hek
+ApdR	|SV*	|newSVhek_mortal|NULLOK const HEK *const hek
 ApdR	|SV*	|newSVpvn_share	|NULLOK const char* s|I32 len|U32 hash
 ApdR	|SV*	|newSVpv_share	|NULLOK const char* s|U32 hash
 AfpdR	|SV*	|newSVpvf	|NN const char *const pat|...

--- a/embed.h
+++ b/embed.h
@@ -378,6 +378,7 @@
 #define newSV_type_mortal(a)	Perl_newSV_type_mortal(aTHX_ a)
 #define newSVbool(a)		Perl_newSVbool(aTHX_ a)
 #define newSVhek(a)		Perl_newSVhek(aTHX_ a)
+#define newSVhek_mortal(a)	Perl_newSVhek_mortal(aTHX_ a)
 #define newSViv(a)		Perl_newSViv(aTHX_ a)
 #define newSVnv(a)		Perl_newSVnv(aTHX_ a)
 #define newSVpv(a,b)		Perl_newSVpv(aTHX_ a,b)

--- a/gv.c
+++ b/gv.c
@@ -1367,7 +1367,7 @@ Perl_gv_autoload_pvn(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags)
             stash = NULL;
         }
         else
-            packname = sv_2mortal(newSVhek(HvNAME_HEK(stash)));
+            packname = newSVhek_mortal(HvNAME_HEK(stash));
         if (flags & GV_SUPER) sv_catpvs(packname, "::SUPER");
     }
     if (!(gv = gv_fetchmeth_pvn(stash, S_autoload, S_autolen, FALSE,
@@ -2744,7 +2744,7 @@ Perl_gv_fullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
       }
     }
     else sv_catpvs(sv,"__ANON__::");
-    sv_catsv(sv,sv_2mortal(newSVhek(GvNAME_HEK(gv))));
+    sv_catsv(sv,newSVhek_mortal(GvNAME_HEK(gv)));
 }
 
 void
@@ -3788,7 +3788,7 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int flags)
                         "in overloaded package ":
                         "has no overloaded magic",
                       SvAMAGIC(left)?
-                        SVfARG(sv_2mortal(newSVhek(HvNAME_HEK(SvSTASH(SvRV(left)))))):
+                        SVfARG(newSVhek_mortal(HvNAME_HEK(SvSTASH(SvRV(left))))):
                         SVfARG(&PL_sv_no),
                       SvAMAGIC(right)?
                         ",\n\tright argument in overloaded package ":
@@ -3796,7 +3796,7 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int flags)
                          ? ""
                          : ",\n\tright argument has no overloaded magic"),
                       SvAMAGIC(right)?
-                        SVfARG(sv_2mortal(newSVhek(HvNAME_HEK(SvSTASH(SvRV(right)))))):
+                        SVfARG(newSVhek_mortal(HvNAME_HEK(SvSTASH(SvRV(right))))):
                         SVfARG(&PL_sv_no)));
         if (use_default_op) {
           DEBUG_o( Perl_deb(aTHX_ "%" SVf, SVfARG(msg)) );
@@ -3882,7 +3882,7 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int flags)
                      flags & AMGf_unary? "" :
                      lr==1 ? " for right argument": " for left argument",
                      flags & AMGf_unary? " for argument" : "",
-                     stash ? SVfARG(sv_2mortal(newSVhek(HvNAME_HEK(stash)))) : SVfARG(newSVpvs_flags("null", SVs_TEMP)),
+                     stash ? SVfARG(newSVhek_mortal(HvNAME_HEK(stash))) : SVfARG(newSVpvs_flags("null", SVs_TEMP)),
                      fl? ",\n\tassignment variant used": "") );
   }
 #endif

--- a/hv.c
+++ b/hv.c
@@ -3127,7 +3127,7 @@ Perl_hv_iterkeysv(pTHX_ HE *entry)
 {
     PERL_ARGS_ASSERT_HV_ITERKEYSV;
 
-    return sv_2mortal(newSVhek(HeKEY_hek(entry)));
+    return newSVhek_mortal(HeKEY_hek(entry));
 }
 
 /*

--- a/mro_core.c
+++ b/mro_core.c
@@ -812,7 +812,7 @@ Perl_mro_package_moved(pTHX_ HV * const stash, HV * const oldstash,
                 : newSVpvs_flags("",  SVs_TEMP);
         }
         else {
-            namesv = sv_2mortal(newSVhek(*namep));
+            namesv = newSVhek_mortal(*namep);
             if (GvNAMELEN(gv) == 1) sv_catpvs(namesv, ":");
             else                    sv_catpvs(namesv, "::");
         }

--- a/op.c
+++ b/op.c
@@ -9571,7 +9571,7 @@ Perl_cv_ckproto_len_flags(pTHX_ const CV *cv, const GV *gv, const char *p,
         else if (SvPOK(gv) && *SvPVX((SV *)gv) == '&')
             name = newSVpvn_flags(SvPVX((SV *)gv)+1, SvCUR(gv)-1, SvUTF8(gv)|SVs_TEMP);
         else if (flags & CV_CKPROTO_CURSTASH || SvROK(gv)) {
-            name = sv_2mortal(newSVhek(HvNAME_HEK(PL_curstash)));
+            name = newSVhek_mortal(HvNAME_HEK(PL_curstash));
             sv_catpvs(name, "::");
             if (SvROK(gv)) {
                 assert (SvTYPE(SvRV_const(gv)) == SVt_PVCV);
@@ -12826,7 +12826,7 @@ Perl_ck_refassign(pTHX_ OP *o)
                 /* a CVREF here confuses pp_refassign, so make sure
                    it gets a GV */
                 CV *const cv = (CV*)SvRV(sv);
-                SV *name_sv = sv_2mortal(newSVhek(CvNAME_HEK(cv)));
+                SV *name_sv = newSVhek_mortal(CvNAME_HEK(cv));
                 (void)gv_init_sv((GV*)sv, CvSTASH(cv), name_sv, 0);
                 assert(SvTYPE(sv) == SVt_PVGV);
             }

--- a/pp.c
+++ b/pp.c
@@ -904,11 +904,11 @@ PP(pp_undef)
                           "Constant subroutine %" SVf " undefined",
                            SVfARG(CvANON((const CV *)sv)
                              ? newSVpvs_flags("(anonymous)", SVs_TEMP)
-                             : sv_2mortal(newSVhek(
+                             : newSVhek_mortal(
                                 CvNAMED(sv)
                                  ? CvNAME_HEK((CV *)sv)
                                  : GvENAME_HEK(CvGV((const CV *)sv))
-                               ))
+                               )
                            ));
         /* FALLTHROUGH */
     case SVt_PVFM:

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -2844,7 +2844,7 @@ PP(pp_stat)
                                "lstat() on filehandle%s%" SVf,
                                 gv ? " " : "",
                                 SVfARG(gv
-                                        ? sv_2mortal(newSVhek(GvENAME_HEK(gv)))
+                                        ? newSVhek_mortal(GvENAME_HEK(gv))
                                         : &PL_sv_no));
             } else if (PL_laststype != OP_LSTAT)
                 /* diag_listed_as: The stat preceding %s wasn't an lstat */

--- a/proto.h
+++ b/proto.h
@@ -2823,6 +2823,10 @@ PERL_CALLCONV SV*	Perl_newSVhek(pTHX_ const HEK *const hek)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVHEK
 
+PERL_CALLCONV SV*	Perl_newSVhek_mortal(pTHX_ const HEK *const hek)
+			__attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_NEWSVHEK_MORTAL
+
 PERL_CALLCONV SV*	Perl_newSViv(pTHX_ const IV i)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVIV

--- a/sv.c
+++ b/sv.c
@@ -9554,6 +9554,30 @@ Perl_newSVpvn(pTHX_ const char *const buffer, const STRLEN len)
 }
 
 /*
+=for apidoc newSVhek_mortal
+
+Creates a new mortal SV from the hash key structure.  It will generate
+scalars that point to the shared string table where possible.  Returns
+a new (undefined) SV if C<hek> is NULL.
+
+This is more efficient than using sv_2mortal(newSVhek( ... ))
+
+=cut
+*/
+
+SV *
+Perl_newSVhek_mortal(pTHX_ const HEK *const hek)
+{
+    SV * const sv = newSVhek(hek);
+    assert(sv);
+    assert(!SvIMMORTAL(sv));
+
+    PUSH_EXTEND_MORTAL__SV_C(sv);
+    SvTEMP_on(sv);
+    return sv;
+}
+
+/*
 =for apidoc newSVhek
 
 Creates a new SV from the hash key structure.  It will generate scalars that

--- a/sv.c
+++ b/sv.c
@@ -16410,7 +16410,7 @@ S_find_hash_subscript(pTHX_ const HV *const hv, const SV *const val)
         HE *entry;
         for (entry = array[i]; entry; entry = HeNEXT(entry)) {
             if (HeVAL(entry) == val)
-                return sv_2mortal(newSVhek(HeKEY_hek(entry)));
+                return newSVhek_mortal(HeKEY_hek(entry));
         }
     }
     return NULL;

--- a/toke.c
+++ b/toke.c
@@ -11201,7 +11201,7 @@ S_scan_inputsymbol(pTHX_ char *start)
                 if (PAD_COMPNAME_FLAGS_isOUR(tmp)) {
                     HV * const stash = PAD_COMPNAME_OURSTASH(tmp);
                     HEK * const stashname = HvNAME_HEK(stash);
-                    SV * const sym = sv_2mortal(newSVhek(stashname));
+                    SV * const sym = newSVhek_mortal(stashname);
                     sv_catpvs(sym, "::");
                     sv_catpv(sym, d+1);
                     d = SvPVX(sym);

--- a/util.c
+++ b/util.c
@@ -1756,7 +1756,7 @@ Perl_mess_sv(pTHX_ SV *basemsg, bool consume)
             Perl_sv_catpvf(aTHX_ sv, ", <%" SVf "> %s %" IVdf,
                            SVfARG(PL_last_in_gv == PL_argvgv
                                  ? &PL_sv_no
-                                 : sv_2mortal(newSVhek(GvNAME_HEK(PL_last_in_gv)))),
+                                 : newSVhek_mortal(GvNAME_HEK(PL_last_in_gv))),
                            line_mode ? "line" : "chunk",
                            (IV)IoLINES(GvIOp(PL_last_in_gv)));
         }
@@ -3916,7 +3916,7 @@ Perl_report_evil_fh(pTHX_ const GV *gv)
     if (ckWARN(warn_type)) {
         SV * const name
             = gv && isGV_with_GP(gv) && GvENAMELEN(gv) ?
-                                     sv_2mortal(newSVhek(GvENAME_HEK(gv))) : NULL;
+                                     newSVhek_mortal(GvENAME_HEK(gv)) : NULL;
         const char * const pars =
             (const char *)(OP_IS_FILETEST(op) ? "" : "()");
         const char * const func =


### PR DESCRIPTION
This is a small wrapper function intended to replace use of
    `sv_2mortal(newSVhek(...))`

This provides some small optimization, since `sv_2mortal` performs
a number of checks for conditions that we know cannot be true.
