### PR TITLE
Allow ${0x10}, ${0b10000} and ${0o20} to be used as aliases for $16 under use strict.

### DIFF
--- a/t/comp/parser_run.t
+++ b/t/comp/parser_run.t
@@ -10,7 +10,7 @@ BEGIN {
     set_up_inc( qw(. ../lib ) );
 }
 
-plan(70);
+plan(82);
 
 # [perl #130814] can reallocate lineptr while looking ahead for
 # "Missing $ on loop variable" diagnostic.
@@ -38,7 +38,10 @@ for my $var ('$00','${00}','$001','${001}','$01','${01}','$09324', '${09324}') {
     }
 }
 
-for my $var ('$0', '${0}', '$1', '${1}', '$10', '${10}', '$9324', '${9324}') {
+for my $var (
+    '$0', '${0}', '$1', '${1}', '$10', '${10}', '$9324', '${9324}',
+    '${0x10}', '${0b10000}', '${0xA}',
+) {
     for my $utf8 ("","use utf8;") {
         for my $strict ("","use strict;") {
             fresh_perl_is(

--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -51,7 +51,6 @@ sub run_tests {
             $ok= eval sprintf 'is ${0%d}, "%s", q(${0%d} = %s); 1', ($n, substr($string,$n-1,1))x2;
             ok(!$ok, "eval failed as expected for \${0$n} test");
 
-            no strict 'refs';
             $ok= eval sprintf 'is ${0b%b}, "%s", q(${0b%b} = %s); 1', ($n, substr($string,$n-1,1))x2;
             ok($ok, sprintf "eval for \${0b%b} test", $n);
             $ok= eval sprintf 'is ${0x%x}, "%s", q(${0x%x} = %s); 1', ($n, substr($string,$n-1,1))x2;


### PR DESCRIPTION
This PR assumes that the commit in #20000 will be merged and includes it for now. 

Treat `${0x10}` as `$16` and allowed under strict, similarly `${0b10000}` and `${0o20}`. Without strict they would resolve to `$16` as well, but would be treated as symbolic references. Since they are constants and since "all digits vars always exist", it doesn't seem necessary to treat them as symbolic references and forbid this usage under use strict.
