### PR TITLE
newSvsv_flags - support SVs_TEMP flag, then make use of it

### DIFF
--- a/hv.c
+++ b/hv.c
@@ -692,7 +692,7 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
                     }
                     if (TAINTING_get)
                         TAINT_set(SvTAINTED(keysv));
-                    keysv = sv_2mortal(newSVsv(keysv));
+                    keysv = newSVsv_flags(keysv, SV_GMAGIC|SV_NOSTEAL|SVs_TEMP);
                     mg_copy(MUTABLE_SV(hv), val, (char*)keysv, HEf_SVKEY);
                 } else {
                     mg_copy(MUTABLE_SV(hv), val, key, klen);

--- a/mro_core.c
+++ b/mro_core.c
@@ -1190,7 +1190,7 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes,
                             }
                         }
                         else {
-                            subname = sv_2mortal(newSVsv(namesv));
+                            subname = newSVsv_flags(namesv, SV_GMAGIC|SV_NOSTEAL|SVs_TEMP);
                             if (len == 1) sv_catpvs(subname, ":");
                             else {
                                 sv_catpvs(subname, "::");
@@ -1273,7 +1273,7 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes,
                             }
                         }
                         else {
-                            subname = sv_2mortal(newSVsv(namesv));
+                            subname = newSVsv_flags(namesv, SV_GMAGIC|SV_NOSTEAL|SVs_TEMP);
                             if (len == 1) sv_catpvs(subname, ":");
                             else {
                                 sv_catpvs(subname, "::");

--- a/op.c
+++ b/op.c
@@ -3968,7 +3968,7 @@ S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV * name,
 
             if (curstash && svname == (SV *)name
              && !memchr(SvPVX(svname), ':', SvCUR(svname))) {
-                svname = sv_2mortal(newSVsv(PL_curstname));
+                svname = newSVsv_flags(PL_curstname, SV_GMAGIC|SV_NOSTEAL|SVs_TEMP);
                 sv_catpvs(svname, "::");
                 sv_catsv(svname, (SV *)name);
             }

--- a/pp.c
+++ b/pp.c
@@ -3096,7 +3096,7 @@ PP(pp_oct)
     if (DO_UTF8(sv)) {
          /* If Unicode, try to downgrade
           * If not possible, croak. */
-         SV* const tsv = sv_2mortal(newSVsv(sv));
+         SV* const tsv = newSVsv_flags(sv, SV_GMAGIC|SV_NOSTEAL|SVs_TEMP);
 
          SvUTF8_on(tsv);
          sv_utf8_downgrade(tsv, FALSE);
@@ -6855,7 +6855,7 @@ PP(pp_refassign)
         (void)hv_store_ent((HV *)left, key, SvREFCNT_inc_simple_NN(SvRV(sv)), 0);
     }
     if (PL_op->op_flags & OPf_MOD)
-        SETs(sv_2mortal(newSVsv(sv)));
+        SETs(newSVsv_flags(sv, SV_GMAGIC|SV_NOSTEAL|SVs_TEMP));
     /* XXX else can weak references go stale before they are read, e.g.,
        in leavesub?  */
     RETURN;

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -1274,7 +1274,7 @@ PP(pp_flop)
                 XPUSHs(sv);
                 if (strEQ(SvPVX_const(sv),tmps))
                     break;
-                sv = sv_2mortal(newSVsv(sv));
+                sv = newSVsv_flags(sv, SV_GMAGIC|SV_NOSTEAL|SVs_TEMP);
                 sv_inc(sv);
             }
         }
@@ -2026,7 +2026,7 @@ PP(pp_caller)
             }
             else {
                 /* I think this is will always be "", but be sure */
-                PUSHs(sv_2mortal(newSVsv(cur_text)));
+                PUSHs(newSVsv_flags(cur_text, SV_GMAGIC|SV_NOSTEAL|SVs_TEMP));
             }
 
             PUSHs(&PL_sv_no);

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -4499,7 +4499,7 @@ PP(pp_subst)
                    However, I suspect it isn't worth the complexity of
                    unravelling the C<goto force_it> for the small number of
                    cases where it would be viable to drop into the copy code. */
-                TARG = sv_2mortal(newSVsv(TARG));
+                TARG = newSVsv_flags(TARG, SV_GMAGIC|SV_NOSTEAL|SVs_TEMP);
             }
             orig = SvPV_force_nomg(TARG, len);
             goto force_it;

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -345,7 +345,7 @@ PP(pp_glob)
 
     /* make a copy of the pattern if it is gmagical, to ensure that magic
      * is called once and only once */
-    if (SvGMAGICAL(TOPs)) TOPs = sv_2mortal(newSVsv(TOPs));
+    if (SvGMAGICAL(TOPs)) TOPs = newSVsv_flags(TOPs, SV_GMAGIC|SV_NOSTEAL|SVs_TEMP);
 
     tryAMAGICunTARGETlist(iter_amg, (PL_op->op_flags & OPf_SPECIAL));
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -7394,7 +7394,7 @@ S_concat_pat(pTHX_ RExC_state_t * const pRExC_state,
                 } else {
                     /* a string with no trailing null, we need to copy it
                      * so it has a trailing null */
-                    pat = sv_2mortal(newSVsv(msv));
+                    pat = newSVsv_flags(msv, SV_GMAGIC|SV_NOSTEAL|SVs_TEMP);
                 }
             }
 
@@ -25973,7 +25973,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
     must_sv = re_intuit_string(subpattern_re);
     if (must_sv) {
         /* regexec.c can free the re_intuit_string() return. GH #17734 */
-        must_sv = sv_2mortal(newSVsv(must_sv));
+        must_sv = newSVsv_flags(must_sv, SV_GMAGIC|SV_NOSTEAL|SVs_TEMP);
         must = SvPV(must_sv, must_len);
     }
     else {

--- a/sv.c
+++ b/sv.c
@@ -9954,6 +9954,11 @@ Perl_newSVsv_flags(pTHX_ SV *const old, I32 flags)
         SvGETMAGIC(old);
     new_SV(sv);
     sv_setsv_flags(sv, old, flags & ~SV_GMAGIC);
+
+    if(flags & SVs_TEMP){
+        PUSH_EXTEND_MORTAL__SV_C(sv);
+    }
+
     return sv;
 }
 

--- a/toke.c
+++ b/toke.c
@@ -1794,7 +1794,7 @@ Perl_validate_proto(pTHX_ SV *name, SV *proto, bool warn, bool curstash)
             : pv_pretty(tmpsv, p, origlen, 60, NULL, NULL, PERL_PV_ESCAPE_NONASCII);
 
         if (curstash && !memchr(SvPVX(name), ':', SvCUR(name))) {
-            SV *name2 = sv_2mortal(newSVsv(PL_curstname));
+            SV *name2 = newSVsv_flags(PL_curstname, SV_GMAGIC|SV_NOSTEAL|SVs_TEMP);
             sv_catpvs(name2, "::");
             sv_catsv(name2, (SV *)name);
             name = name2;

--- a/universal.c
+++ b/universal.c
@@ -1038,7 +1038,7 @@ XS(XS_re_regexp_pattern)
         } else {
             /* Scalar, so use the string that Perl would return */
             /* return the pattern in (?msixn:..) format */
-            pattern = sv_2mortal(newSVsv(MUTABLE_SV(re)));
+            pattern = newSVsv_flags(MUTABLE_SV(re), SV_GMAGIC|SV_NOSTEAL|SVs_TEMP);
             PUSHs(pattern);
             XSRETURN(1);
         }


### PR DESCRIPTION
Prior to this commit, a new mortal SV couldn't be created in one
call, instead the following would be necessary:
`    sv_2mortal(newSVsv(...))`

Between the two function calls and unnecessary checks performed by
`sv_2mortal`, it is more efficient for `newSVsv_flags` to be able to
directly add the SV it has just created to the temp stack. This mirrors
the `SVs_TEMP` flag handling from `newSVpvn_flags`.

A number of instances of the old pattern have then been updated to
use the new functionality.
