### PR TITLE
pod/perlsub.pod -  Make three links working after pod2html conversion

### DIFF
--- a/pod/perlsub.pod
+++ b/pod/perlsub.pod
@@ -294,8 +294,8 @@ C<SETLINEBUF>, C<SYSOPEN>, C<TELL>, C<UNREAD>, C<UTF8>, C<WRITE>
 
 =item documented in L<perlfunc>
 
-L<< C<import> | perlfunc/use >>, L<< C<unimport> | perlfunc/use >>,
-L<< C<INC> | perlfunc/require >>
+L<< C<import>|perlfunc/use >>, L<< C<unimport>|perlfunc/use >>,
+L<< C<INC>|perlfunc/require >>
 
 =item documented in L<UNIVERSAL>
 


### PR DESCRIPTION
Severity: minor

A space after the separator between text and name as in L<< text | name >>
is retained in the href element created by pod2html: href="base/ name".
Three of these occur in perlsub.pod, the links are broken in the
perlsub presentations on metacpan, perldoc.pl and github.

This patch removes a set of such spaces.

I guess this could also (or instead) be fixed in pod2html and maybe
other POD converters by making them eliminate leading spaces after
the separator?