### PR TITLE
pod/perlsub.pod -  Make three links working after pod2html conversion

### DIFF
--- a/Porting/checkAUTHORS.pl
+++ b/Porting/checkAUTHORS.pl
@@ -940,6 +940,7 @@ hansmu\100xs4all.nl                     hansm\100icgroup.nl
 +                                       hans\100icgroup.nl
 +                                       hansm\100euronet.nl
 +                                       hansm\100euro.net
+harald.joerg\100arcor.de                haj\100posteo.de
 hio\100ymir.co.jp                       hio\100hio.jp
 hops\100sco.com                         hops\100scoot.pdev.sco.com
 

--- a/pod/perlsub.pod
+++ b/pod/perlsub.pod
@@ -294,8 +294,8 @@ C<SETLINEBUF>, C<SYSOPEN>, C<TELL>, C<UNREAD>, C<UTF8>, C<WRITE>
 
 =item documented in L<perlfunc>
 
-L<< C<import> | perlfunc/use >>, L<< C<unimport> | perlfunc/use >>,
-L<< C<INC> | perlfunc/require >>
+L<< C<import>|perlfunc/use >>, L<< C<unimport>|perlfunc/use >>,
+L<< C<INC>|perlfunc/require >>
 
 =item documented in L<UNIVERSAL>
 


### PR DESCRIPTION
A space after the separator between text and name as in L<< text | name >>
is retained in the href element created by pod2html: href="base/ name".
Three of these occur in perlsub.pod, the links are broken in the
perlsub presentations on metacpan, perldoc.pl and github.

This patch removes a set of such spaces.

I guess this could also (or instead) be fixed in pod2html and maybe
other POD converters by making them eliminate leading spaces after
the separator?

Committer: add 2nd email address for submitter. Keep porting tests happy.

For: https://github.com/Perl/perl5/pull/20023