### PR TITLE
Configure should avoid looping infinitely repeating the same question

### DIFF
--- a/Configure
+++ b/Configure
@@ -2215,6 +2215,7 @@ $startsh
 xxxm=\$dflt
 $myecho
 ans='!'
+counter=42
 case "\$fastread" in
 yes) case "\$dflt" in
 	'') ;;
@@ -2289,6 +2290,12 @@ while expr "X\$ans" : "X!" >/dev/null; do
 		$myecho
 		;;
 	esac
+	counter=\`echo \$counter | awk '{ print --\$0 }'\`
+	if [ \$counter = 0 ]; then
+		echo >&4
+		echo >&4 Too many attempts asking the same question.  Giving up.
+		exit 1
+	fi
 done
 case "\$ans" in
 '') ans="\$xxxm";;


### PR DESCRIPTION
Configure's helper function ./myread is intended to loop until it gets an
acceptable answer. For a couple of cases, an empty string is not acceptable
(eg 'Where is your C library?', if all automated attempts at answering this
have failed). In these cases, if Configure's standard input is /dev/null (or
closed), the shell read returns an empty string, and ./myread repeats the
question.

Before this commit, it would loop infinitely (generating continuous terminal
output). With this commit, we add a retry counter - if it asks the same
question to many times, it aborts Configure. This means that unattended
./Configure runs should now always terminate, as termination with an error is
better than spinning forever.