### PR TITLE
Create and use a `refcount_is()` unit-test helper function

### DIFF
--- a/t/op/eval.t
+++ b/t/op/eval.t
@@ -514,7 +514,7 @@ END_EVAL_TEST
     my $t;
     my $s = "a";
     $s =~ s/a/$t = \%^H;  qq( qq() );/ee;
-    is(Internals::SvREFCNT(%$t), $count_expected, 'RT 63110');
+    refcount_is $t, $count_expected, 'RT 63110';
 }
 
 # make sure default arg eval only adds a hints hash once to entereval
@@ -531,9 +531,9 @@ END_EVAL_TEST
     # test that the CV compiled for the eval is freed by checking that no additional 
     # reference to outside lexicals are made.
     my $x;
-    is(Internals::SvREFCNT($x), 1, "originally only 1 reference");
+    refcount_is \$x, 1+1, "originally only 1 reference"; # + 1 to account for the ref here
     eval '$x';
-    is(Internals::SvREFCNT($x), 1, "execution eval doesn't create new references");
+    refcount_is \$x, 1+1, "execution eval doesn't create new references"; # + 1 the same
 }
 
 fresh_perl_is(<<'EOP', "ok\n", undef, 'RT #70862');

--- a/t/op/inccode.t
+++ b/t/op/inccode.t
@@ -247,16 +247,17 @@ shift @INC;
     my $data = [];
     unshift @INC, sub { $die, $data };
 
-    my $initial_sub_refcnt = &Internals::SvREFCNT($die);
-    my $initial_data_refcnt = &Internals::SvREFCNT($data);
+    # + 1 to account for prototype-defeating &... calling convention
+    my $initial_sub_refcnt = &Internals::SvREFCNT($die) + 1;
+    my $initial_data_refcnt = &Internals::SvREFCNT($data) + 1;
 
     do "foo";
-    is(&Internals::SvREFCNT($die), $initial_sub_refcnt, "no leaks");
-    is(&Internals::SvREFCNT($data), $initial_data_refcnt, "no leaks");
+    refcount_is $die, $initial_sub_refcnt, "no leaks";
+    refcount_is $data, $initial_data_refcnt, "no leaks";
 
     do "bar";
-    is(&Internals::SvREFCNT($die), $initial_sub_refcnt, "no leaks");
-    is(&Internals::SvREFCNT($data), $initial_data_refcnt, "no leaks");
+    refcount_is $die, $initial_sub_refcnt, "no leaks";
+    refcount_is $data, $initial_data_refcnt, "no leaks";
 
     shift @INC;
 }

--- a/t/op/sort.t
+++ b/t/op/sort.t
@@ -900,12 +900,13 @@ cmp_ok($answer,'eq','good','sort subr called from other package');
 # Sorting shouldn't increase the refcount of a sub
 {
     sub sportello {(1+$a) <=> (1+$b)}
-    my $refcnt = &Internals::SvREFCNT(\&sportello);
+    # + 1 to account for prototype-defeating &... calling convention
+    my $refcnt = &Internals::SvREFCNT(\&sportello) + 1;
     @output = sort sportello 3,7,9;
 
     {
         package Doc;
-        ::is($refcnt, &Internals::SvREFCNT(\&::sportello), "sort sub refcnt");
+        ::refcount_is \&::sportello, $refcnt, "sort sub refcnt";
         $fail_msg = q(Modification of a read-only value attempted);
         # Sorting a read-only array in-place shouldn't be allowed
         my @readonly = (1..10);

--- a/t/re/qr-72922.t
+++ b/t/re/qr-72922.t
@@ -30,11 +30,11 @@ sub s1 {
     my $refcnt_start = Internals::SvREFCNT($$re_weak_copy);
 
     undef $re;
-    is(Internals::SvREFCNT($$re_weak_copy), $refcnt_start - 1, "refcnt decreased");
+    refcount_is $re_weak_copy, $refcnt_start - 1, "refcnt decreased";
     is("$re_weak_copy", $str_re, "weak copy still equals original");
 
     undef $re_copy2;
-    is(Internals::SvREFCNT($$re_weak_copy), $refcnt_start - 1, "refcnt not decreased");
+    refcount_is $re_weak_copy, $refcnt_start - 1, "refcnt not decreased";
     is("$re_weak_copy", $str_re, "weak copy still equals original");
 }
 s1();

--- a/t/re/subst.t
+++ b/t/re/subst.t
@@ -87,9 +87,9 @@ $b = $m =~ s/xxx/yyy/r;
 ok( ! defined tied($b), 's///r magic isn\'t contagious' );
 
 my $ref = \("aaa" =~ s/aaa/bbb/r);
-is (Internals::SvREFCNT($$ref), 1, 's///r does not leak');
+refcount_is $ref, 1, 's///r does not leak';
 $ref = \("aaa" =~ s/aaa/bbb/rg);
-is (Internals::SvREFCNT($$ref), 1, 's///rg does not leak');
+refcount_is $ref, 1, 's///rg does not leak';
 
 $x = 'foo';
 $_ = "x";

--- a/t/test.pl
+++ b/t/test.pl
@@ -476,6 +476,19 @@ sub like_yn ($$$@) {
     _ok($pass, _where(), $name, @mess);
 }
 
+sub refcount_is {
+    # Don't unpack first arg; access it directly via $_[0] to avoid creating
+    # another reference and upsetting the refcount
+    my (undef, $expected, $name, @mess) = @_;
+    my $got = &Internals::SvREFCNT($_[0]) + 1; # +1 to account for the & calling style
+    my $pass = $got == $expected;
+    unless ($pass) {
+        unshift @mess, "#      got $got references\n" .
+                       "# expected $expected\n";
+    }
+    _ok($pass, _where(), $name, @mess);
+}
+
 sub pass {
     _ok(1, '', @_);
 }


### PR DESCRIPTION
Extracts some common behaviour from unit tests into one standard place.

The use of `Internals::SvREFCNT` isn't great here, but at least it's now in fewer places where we can fix them all up later.