### PR TITLE
Perl_newRV_noinc - explicitly simplify, convert to inline func

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1515,7 +1515,7 @@ ApdR	|OP*	|newPADOP	|I32 type|I32 flags|NN SV* sv
 ApdR	|OP*	|newPMOP	|I32 type|I32 flags
 ApdR	|OP*	|newPVOP	|I32 type|I32 flags|NULLOK char* pv
 ApdR	|SV*	|newRV		|NN SV *const sv
-ApdR	|SV*	|newRV_noinc	|NN SV *const tmpRef
+ApdiR	|SV*	|newRV_noinc	|NN SV *const tmpRef
 ApdR	|SV*	|newSV		|const STRLEN len
 ApR	|OP*	|newSVREF	|NN OP* o
 ApdR	|OP*	|newSVOP	|I32 type|I32 flags|NN SV* sv

--- a/proto.h
+++ b/proto.h
@@ -2752,10 +2752,12 @@ PERL_CALLCONV SV*	Perl_newRV(pTHX_ SV *const sv)
 #define PERL_ARGS_ASSERT_NEWRV	\
 	assert(sv)
 
-PERL_CALLCONV SV*	Perl_newRV_noinc(pTHX_ SV *const tmpRef)
+#ifndef PERL_NO_INLINE_FUNCTIONS
+PERL_STATIC_INLINE SV*	Perl_newRV_noinc(pTHX_ SV *const tmpRef)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWRV_NOINC	\
 	assert(tmpRef)
+#endif
 
 PERL_CALLCONV OP*	Perl_newSLICEOP(pTHX_ I32 flags, OP* subscript, OP* listop)
 			__attribute__warn_unused_result__;

--- a/sv.c
+++ b/sv.c
@@ -9878,39 +9878,6 @@ Perl_newSV_false(pTHX)
     return sv;
 }
 
-/*
-=for apidoc newRV_noinc
-
-Creates an RV wrapper for an SV.  The reference count for the original
-SV is B<not> incremented.
-
-=cut
-*/
-
-SV *
-Perl_newRV_noinc(pTHX_ SV *const tmpRef)
-{
-    SV *sv;
-
-    PERL_ARGS_ASSERT_NEWRV_NOINC;
-
-    new_SV(sv);
-
-    /* We're starting from SVt_FIRST, so provided that's
-     * actual 0, we don't have to unset any SV type flags
-     * to promote to SVt_IV. */
-    STATIC_ASSERT_STMT(SVt_FIRST == 0);
-
-    SET_SVANY_FOR_BODYLESS_IV(sv);
-    SvFLAGS(sv) |= SVt_IV;
-
-    SvTEMP_off(tmpRef);
-
-    sv_setrv_noinc(sv, tmpRef);
-
-    return sv;
-}
-
 /* newRV_inc is the official function name to use now.
  * newRV_inc is in fact #defined to newRV in sv.h
  */

--- a/sv_inline.h
+++ b/sv_inline.h
@@ -929,5 +929,30 @@ Perl_SvPV_helper(pTHX_
 }
 
 /*
+=for apidoc newRV_noinc
+
+Creates an RV wrapper for an SV.  The reference count for the original
+SV is B<not> incremented.
+
+=cut
+*/
+
+PERL_STATIC_INLINE SV *
+Perl_newRV_noinc(pTHX_ SV *const tmpRef)
+{
+    SV *sv = newSV_type(SVt_IV);
+
+    PERL_ARGS_ASSERT_NEWRV_NOINC;
+
+    SvTEMP_off(tmpRef);
+
+    /* inlined, simplified sv_setrv_noinc(sv, tmpRef); */
+    SvRV_set(sv, tmpRef);
+    SvROK_on(sv);
+
+    return sv;
+}
+
+/*
  * ex: set ts=8 sts=4 sw=4 et:
  */


### PR DESCRIPTION
`Perl_newRV_noinc` creates a new `SVt_IV`, then calls `sv_setrv_noinc`,
which will check if the `SVt_IV` is `SvTHINKFIRST` (it won't be) and
if it is types other than `SVt_IV` (it won't be). If those checks
and associated branches are removed, all that remains is some flag
twiddling and setting the `sv_u.svu_rv` pointer.

A decent compiler *might* figure that all out and simplify
`Perl_newRV_noinc` right down to the essentials, but if we do that
directly, the entire function is small enough to move to _sv_inline.h_.