### PR TITLE
Handle intrin files on win32 with gcc

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -495,6 +495,7 @@ Keith Thompson <keith.s.thompson@gmail.com> Keith Thompson <kst@mib.org>
 Ken Neighbors <unknown> Ken Neighbors <perlbug@perl.org>
 Ken Williams <ken@mathforum.org> <kenahoo@gmail.com>
 Ken Williams <ken@mathforum.org> Ken Williams <ken.williams@thomsonreuters.com>
+Kenneth Ölwing <knth@cpan.org> Kenneth Olwing <knth@cpan.org>
 Kent Fredric <kentfredric@gmail.com> Kent Fredric <kentnl@cpan.org>
 Kevin Brintnall <kbrint@rufus.net> kevin brintnall <kbrint@rufus.net>
 Kevin Ryde <user42@zip.com.au> Kevin Ryde <perlbug-followup@perl.org>

--- a/AUTHORS
+++ b/AUTHORS
@@ -783,6 +783,7 @@ Ken Williams                   <ken@mathforum.org>
 Kenichi Ishigaki               <ishigaki@cpan.org>
 Kenneth Albanowski             <kjahds@kjahds.com>
 Kenneth Duda                   <kjd@cisco.com>
+Kenneth Ölwing                 <knth@cpan.org>
 Kent Fredric                   <kentfredric@gmail.com>
 Keong Lim                      <Keong.Lim@sr.com.au>
 Kevin Brintnall                <kbrint@rufus.net>

--- a/ext/Errno/Errno_pm.PL
+++ b/ext/Errno/Errno_pm.PL
@@ -2,7 +2,7 @@ use ExtUtils::MakeMaker;
 use Config;
 use strict;
 
-our $VERSION = "1.36";
+our $VERSION = "1.37";
 
 my %err = ();
 
@@ -18,18 +18,11 @@ if ($Config{gccversion} ne '' && $^O eq 'MSWin32') {
     # MinGW complains "warning: #pragma system_header ignored outside include
     # file" if the header files are processed individually, so include them
     # all in .c file and process that instead.
-    my %seen;
     open INCS, '>', 'includes.c' or
 	die "Cannot open includes.c";
     foreach $file (@files) {
 	next if $file eq 'errno.c';
 	next unless -f $file;
-	if ( $file eq 'avx512vpopcntdqvlintrin.h' || $file eq 'avx512bwintrin.h' ) {
-		# "Never use <avx512bwintrin.h> directly; include <immintrin.h> instead."
-		# "Never use <avx512vpopcntdqvlintrin.h> directly; include <immintrin.h> instead."
-		$file = 'immintrin.h';
-	}
-	next if ++$seen{$file} > 1;
 	print INCS qq[#include "$file"\n];
     }
     close INCS;
@@ -114,7 +107,7 @@ sub default_cpp {
 }
 
 sub get_files {
-    my %file = ();
+    my @file;
     # When cross-compiling we may store a path for gcc's "sysroot" option:
     my $sysroot = $Config{sysroot} || '';
     my $linux_errno_h;
@@ -128,19 +121,19 @@ sub get_files {
 
     # VMS keeps its include files in system libraries
     if ($^O eq 'VMS') {
-	$file{'Sys$Library:DECC$RTLDEF.TLB'} = 1;
+	push(@file, 'Sys$Library:DECC$RTLDEF.TLB');
     } elsif ($^O eq 'os390') {
 	# OS/390 C compiler doesn't generate #file or #line directives
         # and it does not tag the header as 1047 (EBCDIC), so make a local
         # copy and tag it
         my $cp = `cp /usr/include/errno.h ./errno.h`;
         my $chtag = `chtag -t -cIBM-1047 ./errno.h`;
-	$file{'./errno.h'} = 1;
+	push(@file, './errno.h');
     } elsif ($Config{archname} eq 'arm-riscos') {
 	# Watch out for cross compiling for RISC OS
 	my $dep = `echo "#include <errno.h>" | gcc -E -M -`;
 	if ($dep =~ /(\S+errno\.h)/) {
-	     $file{$1} = 1;
+	     push(@file, $1);
 	}
     } elsif ($^O eq 'linux' &&
 	      $Config{gccversion} ne '' && 
@@ -148,14 +141,14 @@ sub get_files {
 	      # might be using, say, Intel's icc
 	      $linux_errno_h
 	     ) {
-	$file{$linux_errno_h} = 1;
+	push(@file, $linux_errno_h);
     } elsif ($^O eq 'haiku') {
 	# hidden in a special place
-	$file{'/boot/system/develop/headers/posix/errno.h'} = 1;
+	push(@file, '/boot/system/develop/headers/posix/errno.h');
 
     } elsif ($^O eq 'vos') {
 	# avoid problem where cpp returns non-POSIX pathnames
-	$file{'/system/include_library/errno.h'} = 1;
+	push(@file, '/system/include_library/errno.h');
     } else {
 	open(CPPI, '>', 'errno.c') or
 	    die "Cannot open errno.c";
@@ -183,16 +176,28 @@ sub get_files {
 		if (/$pat/o) {
 		   my $f = $1;
 		   $f =~ s,\\\\,/,g;
-		   $file{$f} = 1;
+		   push(@file, $f);
 		}
 	    }
 	    else {
-		$file{$1} = 1 if /$pat/o;
+		push(@file, $1) if /$pat/o;
 	    }
 	}
 	close(CPPO);
     }
-    return keys %file;
+    return uniq(@file);
+}
+
+# 
+#
+sub uniq
+{
+	# At this point List::Util::uniq appears not to be usable so
+	# roll our own.
+	#
+	# Returns a list with unique values, while keeping the order
+	#
+	return do { my %seen; grep { !$seen{$_}++ } @_ };
 }
 
 sub write_errno_pm {
@@ -364,7 +369,7 @@ ESQ
 
     if ($IsMSWin32) {
 	print "    WINSOCK => [qw(\n";
-	$k = join(" ", grep { /^WSAE/ } keys %err);
+	$k = join(" ", grep { /^WSAE/ } sort keys %err);
 	$k =~ s/(.{50,70})\s/$1\n\t/g;
 	print "\t",$k,"\n    )],\n";
     }


### PR DESCRIPTION
Hi all,

This is effectively a new fix for the issue #18025, merged in [https://github.com/Perl/perl5/pull/18026](url).

As it happens, that fix can't ever have worked as I understand it as tests are made against a file basename only, but the variable contains full pathnames. Further, it only addresses two possibilities, but there are more headers that exhibit the behavior that it tries to fix.

It may not have been noticed since it depends on the order of the files, coming as keys from a hash in a non-determinate fashion, and since in many such cases the 'right' files happens to have been #include'd first, and then there simply is no error.  Other reasons are that the error is only noticeable if you eyeball the build log, since the code doesn't report back the fact that the gcc run has failed - nor even if it does, the build system doesn't stop.

No need to actually build, just running the Errno_pm.PL script is enough to eventually hit it. In my experience at least once per 10 tries, but typically more; here are some sample runs (using a portable Strawberry 5.32.1 on a Win11 machine):

```
C:\ws\git\perl5\ext\Errno>perl Errno_pm.PL

C:\ws\git\perl5\ext\Errno>perl Errno_pm.PL

C:\ws\git\perl5\ext\Errno>perl Errno_pm.PL

C:\ws\git\perl5\ext\Errno>perl Errno_pm.PL

C:\ws\git\perl5\ext\Errno>perl Errno_pm.PL

C:\ws\git\perl5\ext\Errno>perl Errno_pm.PL

C:\ws\git\perl5\ext\Errno>perl Errno_pm.PL

C:\ws\git\perl5\ext\Errno>perl Errno_pm.PL
In file included from includes.c:1:
c:/ken1/slask/straw/SP-5.32.1.1/c/lib/gcc/x86_64-w64-mingw32/8.3.0/include/clwbintrin.h:25:3: error: #error "Never use <clwbintrin.h> directly; include <x86intrin.h> instead."
 # error "Never use <clwbintrin.h> directly; include <x86intrin.h> instead."
   ^~~~~

C:\ws\git\perl5\ext\Errno>perl Errno_pm.PL

C:\ws\git\perl5\ext\Errno>perl Errno_pm.PL
In file included from includes.c:1:
c:/ken1/slask/straw/SP-5.32.1.1/c/lib/gcc/x86_64-w64-mingw32/8.3.0/include/adxintrin.h:25:3: error: #error "Never use <adxintrin.h> directly; include <x86intrin.h> instead."
 # error "Never use <adxintrin.h> directly; include <x86intrin.h> instead."
   ^~~~~
In file included from includes.c:2:
c:/ken1/slask/straw/SP-5.32.1.1/c/lib/gcc/x86_64-w64-mingw32/8.3.0/include/avx512vnniintrin.h:25:2: error:
 #error "Never use <avx512vnniintrin.h> directly; include <immintrin.h> instead."
 #error "Never use <avx512vnniintrin.h> directly; include <immintrin.h> instead."
  ^~~~~

C:\ws\git\perl5\ext\Errno>perl Errno_pm.PL

C:\ws\git\perl5\ext\Errno>perl Errno_pm.PL
In file included from includes.c:3:
c:/ken1/slask/straw/SP-5.32.1.1/c/lib/gcc/x86_64-w64-mingw32/8.3.0/include/fmaintrin.h:25:3: error: #error "Never use <fmaintrin.h> directly; include <immintrin.h> instead."
 # error "Never use <fmaintrin.h> directly; include <immintrin.h> instead."
   ^~~~~
```

Unfortunately there is obviously no way to know if future headers in a mingw64 will change the assumption here, but after checking the headers it appears that it is the immintrin.h/x86intrin.h that are required to be 'first' so the code simply ensures that they come in that order (and also that both they and the rest are ordered by sorting the two categories - helps when troubleshooting so the results are always the same...).

Hope this helps,

ken1