### PR TITLE
regex engine - replace many attribute arrays with one     

### DIFF
--- a/globvar.sym
+++ b/globvar.sym
@@ -57,11 +57,8 @@ PL_phase_names
 PL_ppaddr
 PL_reg_extflags_name
 PL_reg_intflags_name
-PL_regnode_arg_len
-PL_regnode_arg_len_varies
-PL_regnode_kind
+PL_regnode_info
 PL_regnode_name
-PL_regnode_off_by_arg
 PL_revision
 PL_runops_dbg
 PL_runops_std

--- a/regcomp.c
+++ b/regcomp.c
@@ -2950,7 +2950,7 @@ S_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         case EXACTFU:
         case EXACTFLU8: folder = PL_fold_latin1; break;
         case EXACTF:  folder = PL_fold; break;
-        default: Perl_croak( aTHX_ "panic! In trie construction, unknown node type %u %s", (unsigned) flags, PL_regnode_name[flags] );
+        default: Perl_croak( aTHX_ "panic! In trie construction, unknown node type %u %s", (unsigned) flags, REGNODE_NAME(flags) );
     }
 
     trie = (reg_trie_data *) PerlMemShared_calloc( 1, sizeof(reg_trie_data) );
@@ -5168,7 +5168,7 @@ S_study_chunk(pTHX_
                                 }
                                 Perl_re_printf( aTHX_  "(First==%d,Last==%d,Cur==%d,tt==%s,ntt==%s,nntt==%s)\n",
                                    REG_NODE_NUM(first), REG_NODE_NUM(prev), REG_NODE_NUM(cur),
-                                   PL_regnode_name[trietype], PL_regnode_name[noper_trietype], PL_regnode_name[noper_next_trietype]
+                                   REGNODE_NAME(trietype), REGNODE_NAME(noper_trietype), REGNODE_NAME(noper_next_trietype)
                                 );
                             });
 
@@ -5266,7 +5266,7 @@ S_study_chunk(pTHX_
                               depth+1, SvPV_nolen_const( RExC_mysv ), REG_NODE_NUM(cur));
                             Perl_re_printf( aTHX_  "(First==%d, Last==%d, Cur==%d, tt==%s)\n",
                                REG_NODE_NUM(first), REG_NODE_NUM(prev), REG_NODE_NUM(cur),
-                               PL_regnode_name[trietype]
+                               REGNODE_NAME(trietype)
                             );
 
                         });
@@ -6788,7 +6788,7 @@ S_study_chunk(pTHX_
 
         else if (OP(scan) == REGEX_SET) {
             Perl_croak(aTHX_ "panic: %s regnode should be resolved"
-                             " before optimization", PL_regnode_name[REGEX_SET]);
+                             " before optimization", REGNODE_NAME(REGEX_SET));
         }
 
         /* Else: zero-length, ignore. */
@@ -21390,7 +21390,7 @@ S_reginsert(pTHX_ RExC_state_t *pRExC_state, const U8 op,
     PERL_UNUSED_CONTEXT;
     PERL_UNUSED_ARG(depth);
 /* (REGNODE_TYPE((U8)op) == CURLY ? EXTRA_STEP_2ARGS : 0); */
-    DEBUG_PARSE_FMT("inst"," - %s", PL_regnode_name[op]);
+    DEBUG_PARSE_FMT("inst"," - %s", REGNODE_NAME(op));
     assert(!RExC_study_started); /* I believe we should never use reginsert once we have started
                                     studying. If this is wrong then we need to adjust RExC_recurse
                                     below like we do with RExC_open_parens/RExC_close_parens. */
@@ -21474,7 +21474,7 @@ S_regtail(pTHX_ RExC_state_t * pRExC_state,
             Perl_re_printf( aTHX_  "~ %s (%zu) %s %s\n",
                 SvPV_nolen_const(RExC_mysv), scan,
                     (temp == NULL ? "->" : ""),
-                    (temp == NULL ? PL_regnode_name[OP(REGNODE_p(val))] : "")
+                    (temp == NULL ? REGNODE_NAME(OP(REGNODE_p(val))) : "")
             );
         });
         if (temp == NULL)
@@ -21567,7 +21567,7 @@ S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p,
             Perl_re_printf( aTHX_  "~ %s (%zu) -> %s\n",
                 SvPV_nolen_const(RExC_mysv),
                 scan,
-                PL_regnode_name[exact]);
+                REGNODE_NAME(exact));
         });
         if (temp == NULL)
             break;
@@ -21895,7 +21895,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
                              (int)op, (int)REGNODE_MAX);
         }
     }
-    sv_catpv(sv, PL_regnode_name[op]); /* Take off const! */
+    sv_catpv(sv, REGNODE_NAME(op)); /* Take off const! */
 
     k = REGNODE_TYPE(op);
 
@@ -21923,7 +21923,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         const reg_trie_data * const trie
             = (reg_trie_data*)progi->data->data[!IS_TRIE_AC(op) ? n : ac->trie];
 
-        Perl_sv_catpvf(aTHX_ sv, "-%s", PL_regnode_name[o->flags]);
+        Perl_sv_catpvf(aTHX_ sv, "-%s", REGNODE_NAME(o->flags));
         DEBUG_TRIE_COMPILE_r({
           if (trie->jump)
             sv_catpvs(sv, "(JUMP)");

--- a/regcomp.c
+++ b/regcomp.c
@@ -1823,7 +1823,7 @@ S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state,
     SV* invlist = NULL;
     SV* only_utf8_locale_invlist = NULL;
     bool new_node_has_latin1 = FALSE;
-    const U8 flags = (PL_regnode_kind[OP(node)] == ANYOF)
+    const U8 flags = (REGNODE_TYPE(OP(node)) == ANYOF)
                       ? ANYOF_FLAGS(node)
                       : 0;
 
@@ -1882,7 +1882,7 @@ S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state,
     }
 
     /* Add in the points from the bit map */
-    if (PL_regnode_kind[OP(node)] == ANYOF){
+    if (REGNODE_TYPE(OP(node)) == ANYOF){
         for (unsigned i = 0; i < NUM_ANYOF_CODE_POINTS; i++) {
             if (ANYOF_BITMAP_TEST(node, i)) {
                 unsigned int start = i++;
@@ -1976,7 +1976,7 @@ S_ssc_and(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc,
      * another SSC or a regular ANYOF class.  Can create false positives. */
 
     SV* anded_cp_list;
-    U8  and_with_flags = (PL_regnode_kind[OP(and_with)] == ANYOF)
+    U8  and_with_flags = (REGNODE_TYPE(OP(and_with)) == ANYOF)
                           ? ANYOF_FLAGS(and_with)
                           : 0;
     U8  anded_flags;
@@ -2161,7 +2161,7 @@ S_ssc_or(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc,
 
     SV* ored_cp_list;
     U8 ored_flags;
-    U8  or_with_flags = (PL_regnode_kind[OP(or_with)] == ANYOF)
+    U8  or_with_flags = (REGNODE_TYPE(OP(or_with)) == ANYOF)
                          ? ANYOF_FLAGS(or_with)
                          : 0;
 
@@ -4244,20 +4244,20 @@ S_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan,
 #endif
     DEBUG_PEEP("join", scan, depth, 0);
 
-    assert(PL_regnode_kind[OP(scan)] == EXACT);
+    assert(REGNODE_TYPE(OP(scan)) == EXACT);
 
     /* Look through the subsequent nodes in the chain.  Skip NOTHING, merge
      * EXACT ones that are mergeable to the current one. */
     while (    n
-           && (    PL_regnode_kind[OP(n)] == NOTHING
-               || (stringok && PL_regnode_kind[OP(n)] == EXACT))
+           && (    REGNODE_TYPE(OP(n)) == NOTHING
+               || (stringok && REGNODE_TYPE(OP(n)) == EXACT))
            && NEXT_OFF(n)
            && NEXT_OFF(scan) + NEXT_OFF(n) < I16_MAX)
     {
 
         if (OP(n) == TAIL || n > next)
             stringok = 0;
-        if (PL_regnode_kind[OP(n)] == NOTHING) {
+        if (REGNODE_TYPE(OP(n)) == NOTHING) {
             DEBUG_PEEP("skip:", n, depth, 0);
             NEXT_OFF(scan) += NEXT_OFF(n);
             next = n + NODE_STEP_REGNODE;
@@ -4668,7 +4668,7 @@ S_rck_elide_nothing(pTHX_ regnode *node)
         while (
             (n = regnext(n))
             && (
-                (PL_regnode_kind[OP(n)] == NOTHING && (noff = NEXT_OFF(n)))
+                (REGNODE_TYPE(OP(n)) == NOTHING && (noff = NEXT_OFF(n)))
                 || ((OP(n) == LONGJMP) && (noff = ARG(n)))
             )
             && off + noff < max
@@ -4799,7 +4799,7 @@ S_study_chunk(pTHX_
          * parsing code, as each (?:..) is handled by a different invocation of
          * reg() -- Yves
          */
-        if (PL_regnode_kind[OP(scan)] == EXACT
+        if (REGNODE_TYPE(OP(scan)) == EXACT
             && OP(scan) != LEXACT
             && OP(scan) != LEXACT_REQ8
             && mutate_ok
@@ -5456,7 +5456,7 @@ S_study_chunk(pTHX_
                 continue;
             }
         }
-        else if (PL_regnode_kind[OP(scan)] == EXACT && ! isEXACTFish(OP(scan))) {
+        else if (REGNODE_TYPE(OP(scan)) == EXACT && ! isEXACTFish(OP(scan))) {
             SSize_t bytelen = STR_LEN(scan), charlen;
             UV uc;
             assert(bytelen);
@@ -5511,7 +5511,7 @@ S_study_chunk(pTHX_
             flags &= ~SCF_DO_STCLASS;
             DEBUG_STUDYDATA("end EXACT", data, depth, is_inf, min, stopmin, delta);
         }
-        else if (PL_regnode_kind[OP(scan)] == EXACT) {
+        else if (REGNODE_TYPE(OP(scan)) == EXACT) {
             /* But OP != EXACT!, so is EXACTFish */
             SSize_t bytelen = STR_LEN(scan), charlen;
             const U8 * s = (U8*)STRING(scan);
@@ -5605,14 +5605,14 @@ S_study_chunk(pTHX_
             regnode_ssc *oclass = NULL;
             I32 next_is_eval = 0;
 
-            switch (PL_regnode_kind[OP(scan)]) {
+            switch (REGNODE_TYPE(OP(scan))) {
             case WHILEM:		/* End of (?:...)* . */
                 scan = REGNODE_AFTER(scan);
                 goto finish;
             case PLUS:
                 if (flags & (SCF_DO_SUBSTR | SCF_DO_STCLASS)) {
                     next = REGNODE_AFTER(scan);
-                    if (   (     PL_regnode_kind[OP(next)] == EXACT
+                    if (   (     REGNODE_TYPE(OP(next)) == EXACT
                             && ! isEXACTFish(OP(next)))
                         || (flags & SCF_DO_STCLASS))
                     {
@@ -5826,7 +5826,7 @@ S_study_chunk(pTHX_
                     /* Skip open. */
                     nxt = regnext(nxt);
                     if (!REGNODE_SIMPLE(OP(nxt))
-                        && !(PL_regnode_kind[OP(nxt)] == EXACT
+                        && !(REGNODE_TYPE(OP(nxt)) == EXACT
                              && STR_LEN(nxt) == 1))
                         goto nogo;
 #ifdef DEBUGGING
@@ -6322,14 +6322,14 @@ S_study_chunk(pTHX_
                 flags &= ~SCF_DO_STCLASS;
             }
         }
-        else if (PL_regnode_kind[OP(scan)] == EOL && flags & SCF_DO_SUBSTR) {
+        else if (REGNODE_TYPE(OP(scan)) == EOL && flags & SCF_DO_SUBSTR) {
             data->flags |= (OP(scan) == MEOL
                             ? SF_BEFORE_MEOL
                             : SF_BEFORE_SEOL);
             scan_commit(pRExC_state, data, minlenp, is_inf);
 
         }
-        else if (  PL_regnode_kind[OP(scan)] == BRANCHJ
+        else if (  REGNODE_TYPE(OP(scan)) == BRANCHJ
                  /* Lookbehind, or need to calculate parens/evals/stclass: */
                    && (scan->flags || data || (flags & SCF_DO_STCLASS))
                    && (OP(scan) == IFMATCH || OP(scan) == UNLESSM))
@@ -6580,7 +6580,7 @@ S_study_chunk(pTHX_
             if (data)
                 data->flags |= SF_HAS_EVAL;
         }
-        else if ( PL_regnode_kind[OP(scan)] == ENDLIKE ) {
+        else if ( REGNODE_TYPE(OP(scan)) == ENDLIKE ) {
             if (flags & SCF_DO_SUBSTR) {
                 scan_commit(pRExC_state, data, minlenp, is_inf);
                 flags &= ~SCF_DO_SUBSTR;
@@ -6630,7 +6630,7 @@ S_study_chunk(pTHX_
         }
 #ifdef TRIE_STUDY_OPT
 #ifdef FULL_TRIE_STUDY
-        else if (PL_regnode_kind[OP(scan)] == TRIE) {
+        else if (REGNODE_TYPE(OP(scan)) == TRIE) {
             /* NOTE - There is similar code to this block above for handling
                BRANCH nodes on the initial study.  If you change stuff here
                check there too. */
@@ -6694,7 +6694,7 @@ S_study_chunk(pTHX_
                             stopparen, recursed_depth, NULL, f, depth+1,
                             mutate_ok);
                     }
-                    if (nextbranch && PL_regnode_kind[OP(nextbranch)]==BRANCH)
+                    if (nextbranch && REGNODE_TYPE(OP(nextbranch))==BRANCH)
                         nextbranch= regnext((regnode*)nextbranch);
 
                     if (min1 > (SSize_t)(minnext + trie->minlen))
@@ -6764,7 +6764,7 @@ S_study_chunk(pTHX_
             continue;
         }
 #else
-        else if (PL_regnode_kind[OP(scan)] == TRIE) {
+        else if (REGNODE_TYPE(OP(scan)) == TRIE) {
             reg_trie_data *trie = (reg_trie_data*)RExC_rxi->data->data[ ARG(scan) ];
             U8*bang=NULL;
 
@@ -8458,8 +8458,8 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
             (OP(first) == PLUS) ||
             (OP(first) == MINMOD) ||
                /* An {n,m} with n>0 */
-            (PL_regnode_kind[OP(first)] == CURLY && ARG1(first) > 0) ||
-            (OP(first) == NOTHING && PL_regnode_kind[OP(first_next)] != END ))
+            (REGNODE_TYPE(OP(first)) == CURLY && ARG1(first) > 0) ||
+            (OP(first) == NOTHING && REGNODE_TYPE(OP(first_next)) != END ))
         {
                 /*
                  * the only op that could be a regnode is PLUS, all the rest
@@ -8481,7 +8481,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
       again:
         DEBUG_PEEP("first:", first, 0, 0);
         /* Ignore EXACT as we deal with it later. */
-        if (PL_regnode_kind[OP(first)] == EXACT) {
+        if (REGNODE_TYPE(OP(first)) == EXACT) {
             if (! isEXACTFish(OP(first))) {
                 NOOP;	/* Empty, get anchored substr later. */
             }
@@ -8489,7 +8489,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
                 RExC_rxi->regstclass = first;
         }
 #ifdef TRIE_STCLASS
-        else if (PL_regnode_kind[OP(first)] == TRIE &&
+        else if (REGNODE_TYPE(OP(first)) == TRIE &&
                 ((reg_trie_data *)RExC_rxi->data->data[ ARG(first) ])->minlen>0)
         {
             /* this can happen only on restudy
@@ -8500,10 +8500,10 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
 #endif
         else if (REGNODE_SIMPLE(OP(first)))
             RExC_rxi->regstclass = first;
-        else if (PL_regnode_kind[OP(first)] == BOUND ||
-                 PL_regnode_kind[OP(first)] == NBOUND)
+        else if (REGNODE_TYPE(OP(first)) == BOUND ||
+                 REGNODE_TYPE(OP(first)) == NBOUND)
             RExC_rxi->regstclass = first;
-        else if (PL_regnode_kind[OP(first)] == BOL) {
+        else if (REGNODE_TYPE(OP(first)) == BOL) {
             RExC_rx->intflags |= (OP(first) == MBOL
                            ? PREGf_ANCH_MBOL
                            : PREGf_ANCH_SBOL);
@@ -8518,7 +8518,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
         else if ((!sawopen || !RExC_sawback) &&
             !sawlookahead &&
             (OP(first) == STAR &&
-            PL_regnode_kind[OP(REGNODE_AFTER(first))] == REG_ANY) &&
+            REGNODE_TYPE(OP(REGNODE_AFTER(first))) == REG_ANY) &&
             !(RExC_rx->intflags & PREGf_ANCH) && !pRExC_state->code_blocks)
         {
             /* turn .* into ^.* with an implied $*=1 */
@@ -8828,7 +8828,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
         /* It's safe to read through *next only if OP(first) is a regop of
          * the right type (not EXACT, for example).
          */
-        if (PL_regnode_kind[fop] == NOTHING && nop == END)
+        if (REGNODE_TYPE(fop) == NOTHING && nop == END)
             RExC_rx->extflags |= RXf_NULL;
         else if ((fop == MBOL || (fop == SBOL && !first->flags)) && nop == END)
             /* when fop is SBOL first->flags will be true only when it was
@@ -8838,11 +8838,11 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
              * See rt #122761 for more details. -- Yves */
             RExC_rx->extflags |= RXf_START_ONLY;
         else if (fop == PLUS
-                 && PL_regnode_kind[nop] == POSIXD && FLAGS(next) == CC_SPACE_
+                 && REGNODE_TYPE(nop) == POSIXD && FLAGS(next) == CC_SPACE_
                  && OP(regnext(first)) == END)
             RExC_rx->extflags |= RXf_WHITE;
         else if ( RExC_rx->extflags & RXf_SPLIT
-                  && (PL_regnode_kind[fop] == EXACT && ! isEXACTFish(fop))
+                  && (REGNODE_TYPE(fop) == EXACT && ! isEXACTFish(fop))
                   && STR_LEN(first) == 1
                   && *(STRING(first)) == ' '
                   && OP(regnext(first)) == END )
@@ -12898,7 +12898,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
 
             /* Hook the tails of the branches to the closing node. */
             for (br = REGNODE_p(ret); br; br = regnext(br)) {
-                const U8 op = PL_regnode_kind[OP(br)];
+                const U8 op = REGNODE_TYPE(OP(br));
                 regnode *nextoper = REGNODE_AFTER(br);
                 if (op == BRANCH) {
                     if (! REGTAIL_STUDY(pRExC_state,
@@ -12926,7 +12926,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
             }
             if (is_nothing) {
                 regnode * ret_as_regnode = REGNODE_p(ret);
-                br= PL_regnode_kind[OP(ret_as_regnode)] != BRANCH
+                br= REGNODE_TYPE(OP(ret_as_regnode)) != BRANCH
                                ? regnext(ret_as_regnode)
                                : ret_as_regnode;
                 DEBUG_PARSE_r({
@@ -16052,7 +16052,7 @@ S_populate_anyof_bitmap_from_invlist(pTHX_ regnode *node, SV** invlist_ptr)
     PERL_ARGS_ASSERT_POPULATE_ANYOF_BITMAP_FROM_INVLIST;
 
     /* There is no bitmap for this node type */
-    if (PL_regnode_kind[OP(node)]  != ANYOF) {
+    if (REGNODE_TYPE(OP(node))  != ANYOF) {
         return;
     }
 
@@ -20741,7 +20741,7 @@ S_set_ANYOF_arg(pTHX_ RExC_state_t* const pRExC_state,
         /* On plain ANYOF nodes without the possibility of a runtime locale
          * making a difference, maybe there's no information to be gleaned
          * except for what's in the bitmap */
-        if (PL_regnode_kind[OP(node)] == ANYOF && ! only_utf8_locale_list) {
+        if (REGNODE_TYPE(OP(node)) == ANYOF && ! only_utf8_locale_list) {
 
             /* There are two such cases:
              *  1)  there is no list of code points matched outside the bitmap
@@ -21283,7 +21283,7 @@ S_regnode_guts(pTHX_ RExC_state_t *pRExC_state, const STRLEN extra_size)
 STATIC regnode_offset
 S_regnode_guts_debug(pTHX_ RExC_state_t *pRExC_state, const U8 op, const STRLEN extra_size) {
     PERL_ARGS_ASSERT_REGNODE_GUTS_DEBUG;
-    assert(extra_size >= PL_regnode_arg_len[op] || PL_regnode_kind[op] == ANYOF);
+    assert(extra_size >= PL_regnode_arg_len[op] || REGNODE_TYPE(op) == ANYOF);
     return S_regnode_guts(aTHX_ pRExC_state, extra_size);
 }
 
@@ -21389,7 +21389,7 @@ S_reginsert(pTHX_ RExC_state_t *pRExC_state, const U8 op,
     PERL_ARGS_ASSERT_REGINSERT;
     PERL_UNUSED_CONTEXT;
     PERL_UNUSED_ARG(depth);
-/* (PL_regnode_kind[(U8)op] == CURLY ? EXTRA_STEP_2ARGS : 0); */
+/* (REGNODE_TYPE((U8)op) == CURLY ? EXTRA_STEP_2ARGS : 0); */
     DEBUG_PARSE_FMT("inst"," - %s", PL_regnode_name[op]);
     assert(!RExC_study_started); /* I believe we should never use reginsert once we have started
                                     studying. If this is wrong then we need to adjust RExC_recurse
@@ -21543,7 +21543,7 @@ S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p,
     for (;;) {
         regnode * const temp = regnext(REGNODE_p(scan));
 #ifdef EXPERIMENTAL_INPLACESCAN
-        if (PL_regnode_kind[OP(REGNODE_p(scan))] == EXACT) {
+        if (REGNODE_TYPE(OP(REGNODE_p(scan))) == EXACT) {
             bool unfolded_multi_char;	/* Unexamined in this routine */
             if (join_exact(pRExC_state, scan, &min,
                            &unfolded_multi_char, 1, REGNODE_p(val), depth+1))
@@ -21551,7 +21551,7 @@ S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p,
         }
 #endif
         if ( exact ) {
-            if (PL_regnode_kind[OP(REGNODE_p(scan))] == EXACT) {
+            if (REGNODE_TYPE(OP(REGNODE_p(scan))) == EXACT) {
                 if (exact == PSEUDO )
                     exact= OP(REGNODE_p(scan));
                 else if (exact != OP(REGNODE_p(scan)) )
@@ -21897,7 +21897,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
     }
     sv_catpv(sv, PL_regnode_name[op]); /* Take off const! */
 
-    k = PL_regnode_kind[op];
+    k = REGNODE_TYPE(op);
 
     if (k == EXACT) {
         sv_catpvs(sv, " ");
@@ -22252,7 +22252,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         if (op == ANYOFHs) {
             Perl_sv_catpvf(aTHX_ sv, " (Leading UTF-8 bytes=%s", _byte_dump_string((U8 *) ((struct regnode_anyofhs *) o)->string, FLAGS(o), 1));
         }
-        else if (PL_regnode_kind[op] != ANYOF) {
+        else if (REGNODE_TYPE(op) != ANYOF) {
             U8 lowest = (op != ANYOFHr)
                          ? FLAGS(o)
                          : LOWEST_ANYOF_HRx_BYTE(FLAGS(o));
@@ -23675,8 +23675,8 @@ S_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
         if (op != OPTIMIZED) {
             if (next == NULL)		/* Next ptr. */
                 Perl_re_printf( aTHX_  " (0)");
-            else if (PL_regnode_kind[op] == BRANCH
-                     && PL_regnode_kind[OP(next)] != BRANCH )
+            else if (REGNODE_TYPE(op) == BRANCH
+                     && REGNODE_TYPE(OP(next)) != BRANCH )
                 Perl_re_printf( aTHX_  " (FAIL)");
             else
                 Perl_re_printf( aTHX_  " (%" IVdf ")", (IV)(next - start));
@@ -23684,7 +23684,7 @@ S_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
         }
 
       after_print:
-        if (PL_regnode_kind[op] == BRANCHJ) {
+        if (REGNODE_TYPE(op) == BRANCHJ) {
             assert(next);
             const regnode *nnode = (OP(next) == LONGJMP
                                    ? regnext((regnode *)next)
@@ -23693,11 +23693,11 @@ S_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
                 nnode = last;
             DUMPUNTIL(after, nnode);
         }
-        else if (PL_regnode_kind[op] == BRANCH) {
+        else if (REGNODE_TYPE(op) == BRANCH) {
             assert(next);
             DUMPUNTIL(after, next);
         }
-        else if ( PL_regnode_kind[op]  == TRIE ) {
+        else if ( REGNODE_TYPE(op)  == TRIE ) {
             const regnode *this_trie = node;
             const U32 n = ARG(node);
             const reg_ac_data * const ac = op>=AHOCORASICK ?
@@ -23738,7 +23738,7 @@ S_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
                             nextbranch= this_trie + trie->jump[0];
                         DUMPUNTIL(this_trie + dist, nextbranch);
                     }
-                    if (nextbranch && PL_regnode_kind[OP(nextbranch)]==BRANCH)
+                    if (nextbranch && REGNODE_TYPE(OP(nextbranch))==BRANCH)
                         nextbranch= regnext((regnode *)nextbranch);
                 } else {
                     Perl_re_printf( aTHX_  "\n");
@@ -23752,14 +23752,14 @@ S_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
         else if ( op == CURLY ) {   /* "next" might be very big: optimizer */
             DUMPUNTIL(after, after + 1); /* +1 is NOT a REGNODE_AFTER */
         }
-        else if (PL_regnode_kind[op] == CURLY && op != CURLYX) {
+        else if (REGNODE_TYPE(op) == CURLY && op != CURLYX) {
             assert(next);
             DUMPUNTIL(after, next);
         }
         else if ( op == PLUS || op == STAR) {
             DUMPUNTIL(after, after + 1); /* +1 NOT a REGNODE_AFTER */
         }
-        else if (PL_regnode_kind[op] == EXACT || op == ANYOFHs) {
+        else if (REGNODE_TYPE(op) == EXACT || op == ANYOFHs) {
             /* Literal string, where present. */
             node = (const regnode *)REGNODE_AFTER_varies(node);
         }
@@ -23768,7 +23768,7 @@ S_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
         }
         if (op == CURLYX || op == OPEN || op == SROPEN)
             indent++;
-        if (PL_regnode_kind[op] == END)
+        if (REGNODE_TYPE(op) == END)
             break;
     }
     CLEAR_OPTSTART;

--- a/regcomp.c
+++ b/regcomp.c
@@ -3876,7 +3876,7 @@ S_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
             DEBUG_r({
             optimize = convert
                       + NODE_STEP_REGNODE
-                      + PL_regnode_arg_len[ OP( convert ) ];
+                      + REGNODE_ARG_LEN( OP( convert ) );
             });
             /* XXX We really should free up the resource in trie now,
                    as we won't use them - (which resources?) dmq */
@@ -13348,7 +13348,7 @@ S_regpiece(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                 reginsert(pRExC_state, OPFAIL, orig_emit, depth+1);
                 ckWARNreg(RExC_parse, "Quantifier {n,m} with n > m can't match");
                 NEXT_OFF(REGNODE_p(orig_emit)) =
-                                    PL_regnode_arg_len[OPFAIL] + NODE_STEP_REGNODE;
+                                    REGNODE_ARG_LEN(OPFAIL) + NODE_STEP_REGNODE;
                 return ret;
             }
             else if (min == max && *RExC_parse == '?') {
@@ -15415,7 +15415,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
              * eventually we'll have to artificially chunk the pattern into
              * multiple nodes. */
             if (! LOC && (node_type == EXACT || node_type == LEXACT)) {
-                Size_t overhead = 1 + PL_regnode_arg_len[OP(REGNODE_p(ret))];
+                Size_t overhead = 1 + REGNODE_ARG_LEN(OP(REGNODE_p(ret)));
                 Size_t overhead_expansion = 0;
                 char temp[256];
                 Size_t max_nodes_for_string;
@@ -15434,7 +15434,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                  * to save the string in the EXACT case before growing, and
                  * then copy it afterwards to its new location */
                 if (node_type == EXACT) {
-                    overhead_expansion = PL_regnode_arg_len[LEXACT] - PL_regnode_arg_len[EXACT];
+                    overhead_expansion = REGNODE_ARG_LEN(LEXACT) - REGNODE_ARG_LEN(EXACT);
                     RExC_emit += overhead_expansion;
                     Copy(s0, temp, len, char);
                 }
@@ -17141,7 +17141,7 @@ redo_curchar:
                             * which isn't legal */
                         || RExC_emit != orig_emit
                                       + NODE_STEP_REGNODE
-                                      + PL_regnode_arg_len[REGEX_SET])
+                                      + REGNODE_ARG_LEN(REGEX_SET))
                     {
                         vFAIL("Expecting interpolated extended charclass");
                     }
@@ -19716,9 +19716,9 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
         }
     }
 
-    ret = REGNODE_GUTS(pRExC_state, op, PL_regnode_arg_len[op]);
+    ret = REGNODE_GUTS(pRExC_state, op, REGNODE_ARG_LEN(op));
     FILL_NODE(ret, op);        /* We set the argument later */
-    RExC_emit += NODE_STEP_REGNODE + PL_regnode_arg_len[op];
+    RExC_emit += NODE_STEP_REGNODE + REGNODE_ARG_LEN(op);
     ANYOF_FLAGS(REGNODE_p(ret)) = anyof_flags;
 
     /* Here, <cp_list> contains all the code points we can determine at
@@ -20623,7 +20623,7 @@ S_optimize_regclass(pTHX_
                          * non-UTF8 targets.  The internal bitmap would serve
                          * both cases; with some extra code in regexec.c) */
                         op = ANYOFHbbm;
-                        *ret = REGNODE_GUTS(pRExC_state, op, PL_regnode_arg_len[op]);
+                        *ret = REGNODE_GUTS(pRExC_state, op, REGNODE_ARG_LEN(op));
                         FILL_NODE(*ret, op);
                         ((struct regnode_bbm *) REGNODE_p(*ret))->first_byte = low_utf8[0],
 
@@ -20639,7 +20639,7 @@ S_optimize_regclass(pTHX_
 
                             ((struct regnode_bbm *) REGNODE_p(*ret))->bitmap,
                             REGNODE_BBM_BITMAP_LEN);
-                        RExC_emit += NODE_STEP_REGNODE + PL_regnode_arg_len[op];
+                        RExC_emit += NODE_STEP_REGNODE + REGNODE_ARG_LEN(op);
                         return op;
                     }
                     else {
@@ -20649,7 +20649,7 @@ S_optimize_regclass(pTHX_
                 else {
                     op = ANYOFHs;
                     *ret = REGNODE_GUTS(pRExC_state, op,
-                                       PL_regnode_arg_len[op] + STR_SZ(len));
+                                       REGNODE_ARG_LEN(op) + STR_SZ(len));
                     FILL_NODE(*ret, op);
                     ((struct regnode_anyofhs *) REGNODE_p(*ret))->str_len
                                                                     = len;
@@ -21283,7 +21283,7 @@ S_regnode_guts(pTHX_ RExC_state_t *pRExC_state, const STRLEN extra_size)
 STATIC regnode_offset
 S_regnode_guts_debug(pTHX_ RExC_state_t *pRExC_state, const U8 op, const STRLEN extra_size) {
     PERL_ARGS_ASSERT_REGNODE_GUTS_DEBUG;
-    assert(extra_size >= PL_regnode_arg_len[op] || REGNODE_TYPE(op) == ANYOF);
+    assert(extra_size >= REGNODE_ARG_LEN(op) || REGNODE_TYPE(op) == ANYOF);
     return S_regnode_guts(aTHX_ pRExC_state, extra_size);
 }
 
@@ -21297,12 +21297,12 @@ S_regnode_guts_debug(pTHX_ RExC_state_t *pRExC_state, const U8 op, const STRLEN 
 STATIC regnode_offset /* Location. */
 S_reg_node(pTHX_ RExC_state_t *pRExC_state, U8 op)
 {
-    const regnode_offset ret = REGNODE_GUTS(pRExC_state, op, PL_regnode_arg_len[op]);
+    const regnode_offset ret = REGNODE_GUTS(pRExC_state, op, REGNODE_ARG_LEN(op));
     regnode_offset ptr = ret;
 
     PERL_ARGS_ASSERT_REG_NODE;
 
-    assert(PL_regnode_arg_len[op] == 0);
+    assert(REGNODE_ARG_LEN(op) == 0);
 
     FILL_ADVANCE_NODE(ptr, op);
     RExC_emit = ptr;
@@ -21315,13 +21315,13 @@ S_reg_node(pTHX_ RExC_state_t *pRExC_state, U8 op)
 STATIC regnode_offset /* Location. */
 S_reganode(pTHX_ RExC_state_t *pRExC_state, U8 op, U32 arg)
 {
-    const regnode_offset ret = REGNODE_GUTS(pRExC_state, op, PL_regnode_arg_len[op]);
+    const regnode_offset ret = REGNODE_GUTS(pRExC_state, op, REGNODE_ARG_LEN(op));
     regnode_offset ptr = ret;
 
     PERL_ARGS_ASSERT_REGANODE;
 
     /* ANYOF are special cased to allow non-length 1 args */
-    assert(PL_regnode_arg_len[op] == 1);
+    assert(REGNODE_ARG_LEN(op) == 1);
 
     FILL_ADVANCE_NODE_ARG(ptr, op, arg);
     RExC_emit = ptr;
@@ -21334,7 +21334,7 @@ S_reganode(pTHX_ RExC_state_t *pRExC_state, U8 op, U32 arg)
 STATIC regnode_offset /* Location. */
 S_regpnode(pTHX_ RExC_state_t *pRExC_state, U8 op, SV * arg)
 {
-    const regnode_offset ret = REGNODE_GUTS(pRExC_state, op, PL_regnode_arg_len[op]);
+    const regnode_offset ret = REGNODE_GUTS(pRExC_state, op, REGNODE_ARG_LEN(op));
     regnode_offset ptr = ret;
 
     PERL_ARGS_ASSERT_REGPNODE;
@@ -21349,12 +21349,12 @@ S_reg2Lanode(pTHX_ RExC_state_t *pRExC_state, const U8 op, const U32 arg1, const
 {
     /* emit a node with U32 and I32 arguments */
 
-    const regnode_offset ret = REGNODE_GUTS(pRExC_state, op, PL_regnode_arg_len[op]);
+    const regnode_offset ret = REGNODE_GUTS(pRExC_state, op, REGNODE_ARG_LEN(op));
     regnode_offset ptr = ret;
 
     PERL_ARGS_ASSERT_REG2LANODE;
 
-    assert(PL_regnode_arg_len[op] == 2);
+    assert(REGNODE_ARG_LEN(op) == 2);
 
     FILL_ADVANCE_NODE_2L_ARG(ptr, op, arg1, arg2);
     RExC_emit = ptr;
@@ -21371,7 +21371,7 @@ S_reg2Lanode(pTHX_ RExC_state_t *pRExC_state, const U8 op, const U32 arg1, const
 * set up NEXT_OFF() of the inserted node if needed. Something like this:
 *
 *   reginsert(pRExC, OPFAIL, orig_emit, depth+1);
-*   NEXT_OFF(REGNODE_p(orig_emit)) = PL_regnode_arg_len[OPFAIL] + NODE_STEP_REGNODE;
+*   NEXT_OFF(REGNODE_p(orig_emit)) = REGNODE_ARG_LEN(OPFAIL) + NODE_STEP_REGNODE;
 *
 * ALSO NOTE - FLAGS(newly-inserted-operator) will be set to 0 as well.
 */
@@ -21382,7 +21382,7 @@ S_reginsert(pTHX_ RExC_state_t *pRExC_state, const U8 op,
     regnode *src;
     regnode *dst;
     regnode *place;
-    const int offset = PL_regnode_arg_len[(U8)op];
+    const int offset = REGNODE_ARG_LEN((U8)op);
     const int size = NODE_STEP_REGNODE + offset;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -4396,7 +4396,7 @@ S_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan,
 #ifdef EXPERIMENTAL_INPLACESCAN
         if (flags && !NEXT_OFF(n)) {
             DEBUG_PEEP("atch", val, depth, 0);
-            if (PL_regnode_off_by_arg[OP(n)]) {
+            if (REGNODE_OFF_BY_ARG(OP(n))) {
                 ARG_SET(n, val - n);
             }
             else {
@@ -4656,11 +4656,11 @@ S_rck_elide_nothing(pTHX_ regnode *node)
     PERL_ARGS_ASSERT_RCK_ELIDE_NOTHING;
 
     if (OP(node) != CURLYX) {
-        const int max = (PL_regnode_off_by_arg[OP(node)]
+        const int max = (REGNODE_OFF_BY_ARG(OP(node))
                         ? I32_MAX
                           /* I32 may be smaller than U16 on CRAYs! */
                         : (I32_MAX < U16_MAX ? I32_MAX : U16_MAX));
-        int off = (PL_regnode_off_by_arg[OP(node)] ? ARG(node) : NEXT_OFF(node));
+        int off = (REGNODE_OFF_BY_ARG(OP(node)) ? ARG(node) : NEXT_OFF(node));
         int noff;
         regnode *n = node;
 
@@ -4675,7 +4675,7 @@ S_rck_elide_nothing(pTHX_ regnode *node)
         ) {
             off += noff;
         }
-        if (PL_regnode_off_by_arg[OP(node)])
+        if (REGNODE_OFF_BY_ARG(OP(node)))
             ARG(node) = off;
         else
             NEXT_OFF(node) = off;
@@ -5908,7 +5908,7 @@ S_study_chunk(pTHX_
                         while ( nxt1 && (OP(nxt1) != WHILEM)) {
                             regnode *nnxt = regnext(nxt1);
                             if (nnxt == nxt) {
-                                if (PL_regnode_off_by_arg[OP(nxt1)])
+                                if (REGNODE_OFF_BY_ARG(OP(nxt1)))
                                     ARG_SET(nxt1, nxt2 - nxt1);
                                 else if (nxt2 - nxt1 < U16_MAX)
                                     NEXT_OFF(nxt1) = nxt2 - nxt1;
@@ -21484,7 +21484,7 @@ S_regtail(pTHX_ RExC_state_t * pRExC_state,
 
     /* Populate this node's next pointer */
     assert(val >= scan);
-    if (PL_regnode_off_by_arg[OP(REGNODE_p(scan))]) {
+    if (REGNODE_OFF_BY_ARG(OP(REGNODE_p(scan)))) {
         assert((UV) (val - scan) <= U32_MAX);
         ARG_SET(REGNODE_p(scan), val - scan);
     }
@@ -21583,7 +21583,7 @@ S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p,
                       (IV)(val - scan)
         );
     });
-    if (PL_regnode_off_by_arg[OP(REGNODE_p(scan))]) {
+    if (REGNODE_OFF_BY_ARG(OP(REGNODE_p(scan)))) {
         assert((UV) (val - scan) <= U32_MAX);
         ARG_SET(REGNODE_p(scan), val - scan);
     }

--- a/regcomp.h
+++ b/regcomp.h
@@ -515,7 +515,7 @@ struct regnode_ssc {
 
 /* find the regnode after this p by using the opcode we previously extracted
  * with OP(p) */
-#define REGNODE_AFTER_opcode(p,op)          REGNODE_AFTER_PLUS_DEBUG((p),PL_regnode_arg_len[op])
+#define REGNODE_AFTER_opcode(p,op)          REGNODE_AFTER_PLUS_DEBUG((p),REGNODE_ARG_LEN(op))
 
 /* find the regnode after this p by using the size of the struct associated with
  * the opcode for p. use this when you *know* that p is pointer to a given type*/
@@ -555,13 +555,13 @@ struct regnode_ssc {
                     FILL_ADVANCE_NODE(offset, op);                      \
                     /* This is used generically for other operations    \
                      * that have a longer argument */                   \
-                    (offset) += PL_regnode_arg_len[op];                          \
+                    (offset) += REGNODE_ARG_LEN(op);                          \
     } STMT_END
 #define FILL_ADVANCE_NODE_ARGp(offset, op, arg)                          \
     STMT_START {                                                        \
                     ARGp_SET(REGNODE_p(offset), arg);                    \
                     FILL_ADVANCE_NODE(offset, op);                      \
-                    (offset) += PL_regnode_arg_len[op];                          \
+                    (offset) += REGNODE_ARG_LEN(op);                          \
     } STMT_END
 #define FILL_ADVANCE_NODE_2L_ARG(offset, op, arg1, arg2)                \
     STMT_START {                                                        \
@@ -1411,6 +1411,7 @@ typedef enum {
 
 #define REGNODE_TYPE(arg) PL_regnode_kind[(arg)]
 #define REGNODE_OFF_BY_ARG(node) PL_regnode_of_by_arg[(node)]
+#define REGNODE_ARG_LEN(node) PL_regnode_arg_len[(node)]
 
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C)
 #include "reginline.h"

--- a/regcomp.h
+++ b/regcomp.h
@@ -1413,6 +1413,7 @@ typedef enum {
 #define REGNODE_OFF_BY_ARG(node) PL_regnode_of_by_arg[(node)]
 #define REGNODE_ARG_LEN(node) PL_regnode_arg_len[(node)]
 #define REGNODE_ARG_LEN_VARIES(node) PL_regnode_arg_len_varies[(node)]
+#define REGNODE_NAME(node) PL_regnode_name[(node)]
 
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C)
 #include "reginline.h"

--- a/regcomp.h
+++ b/regcomp.h
@@ -1412,6 +1412,7 @@ typedef enum {
 #define REGNODE_TYPE(arg) PL_regnode_kind[(arg)]
 #define REGNODE_OFF_BY_ARG(node) PL_regnode_of_by_arg[(node)]
 #define REGNODE_ARG_LEN(node) PL_regnode_arg_len[(node)]
+#define REGNODE_ARG_LEN_VARIES(node) PL_regnode_arg_len_varies[(node)]
 
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C)
 #include "reginline.h"

--- a/regcomp.h
+++ b/regcomp.h
@@ -1410,6 +1410,7 @@ typedef enum {
 #endif
 
 #define REGNODE_TYPE(arg) PL_regnode_kind[(arg)]
+#define REGNODE_OFF_BY_ARG(node) PL_regnode_of_by_arg[(node)]
 
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C)
 #include "reginline.h"

--- a/regcomp.h
+++ b/regcomp.h
@@ -306,7 +306,7 @@ struct regnode_ssc {
 #define set_ANYOF_SYNTHETIC(n) STMT_START{ OP(n) = ANYOF;              \
                                            NEXT_OFF(n) = 1;            \
                                } STMT_END
-#define is_ANYOF_SYNTHETIC(n) (PL_regnode_kind[OP(n)] == ANYOF && NEXT_OFF(n) == 1)
+#define is_ANYOF_SYNTHETIC(n) (REGNODE_TYPE(OP(n)) == ANYOF && NEXT_OFF(n) == 1)
 
 /* XXX fix this description.
    Impose a limit of REG_INFTY on various pattern matching operations
@@ -1408,6 +1408,8 @@ typedef enum {
 #else
 #  define GET_REGCLASS_AUX_DATA(a,b,c,d,e,f)  get_re_gclass_aux_data(a,b,c,d,e,f)
 #endif
+
+#define REGNODE_TYPE(arg) PL_regnode_kind[(arg)]
 
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C)
 #include "reginline.h"

--- a/regcomp.h
+++ b/regcomp.h
@@ -10,6 +10,7 @@
 
 #if ! defined(PERL_REGCOMP_H_) && (   defined(PERL_CORE)            \
                                    || defined(PERL_EXT_RE_BUILD))
+
 #define PERL_REGCOMP_H_
 
 #include "regcharclass.h"
@@ -1409,11 +1410,11 @@ typedef enum {
 #  define GET_REGCLASS_AUX_DATA(a,b,c,d,e,f)  get_re_gclass_aux_data(a,b,c,d,e,f)
 #endif
 
-#define REGNODE_TYPE(arg) PL_regnode_kind[(arg)]
-#define REGNODE_OFF_BY_ARG(node) PL_regnode_of_by_arg[(node)]
-#define REGNODE_ARG_LEN(node) PL_regnode_arg_len[(node)]
-#define REGNODE_ARG_LEN_VARIES(node) PL_regnode_arg_len_varies[(node)]
-#define REGNODE_NAME(node) PL_regnode_name[(node)]
+#define REGNODE_TYPE(node)              (PL_regnode_info[(node)].type)
+#define REGNODE_OFF_BY_ARG(node)        (PL_regnode_info[(node)].off_by_arg)
+#define REGNODE_ARG_LEN(node)           (PL_regnode_info[(node)].arg_len)
+#define REGNODE_ARG_LEN_VARIES(node)    (PL_regnode_info[(node)].arg_len_varies)
+#define REGNODE_NAME(node)              (PL_regnode_name[(node)])
 
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C)
 #include "reginline.h"

--- a/regexec.c
+++ b/regexec.c
@@ -6183,7 +6183,7 @@ S_backup_one_WB(pTHX_ WB_enum * previous, const U8 * const strbeg, U8 ** curpos,
         Perl_re_printf( aTHX_                               \
             "%*s" pp " %s%s%s%s%s\n",                       \
             INDENT_CHARS(depth), "",                        \
-            PL_regnode_name[st->resume_state],                  \
+            REGNODE_NAME(st->resume_state),                  \
             ((st==yes_state||st==mark_state) ? "[" : ""),   \
             ((st==yes_state) ? "Y" : ""),                   \
             ((st==mark_state) ? "M" : ""),                  \
@@ -9816,7 +9816,7 @@ NULL
                     Perl_re_exec_indentf( aTHX_ "%4s #%-3d %-10s %s\n",
                         depth,
                         i ? "    " : "push",
-                        depth - i, PL_regnode_name[cur->resume_state],
+                        depth - i, REGNODE_NAME(cur->resume_state),
                         (curyes == cur) ? "yes" : ""
                     );
                     if (curyes == cur)
@@ -10643,7 +10643,7 @@ S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
 
     default:
         Perl_croak(aTHX_ "panic: regrepeat() called with unrecognized"
-                         " node type %d='%s'", OP(p), PL_regnode_name[OP(p)]);
+                         " node type %d='%s'", OP(p), REGNODE_NAME(OP(p)));
         NOT_REACHED; /* NOTREACHED */
 
     }

--- a/regexec.c
+++ b/regexec.c
@@ -188,11 +188,11 @@ static const char non_utf8_target_but_utf8_required[]
     OP(rn) == SUSPEND || OP(rn) == IFMATCH ||                                      \
     OP(rn) == PLUS || OP(rn) == MINMOD ||                                          \
     OP(rn) == KEEPS ||                                                             \
-    (PL_regnode_kind[OP(rn)] == CURLY && ARG1(rn) > 0)                                  \
+    (REGNODE_TYPE(OP(rn)) == CURLY && ARG1(rn) > 0)                                  \
 )
-#define IS_EXACT(rn) (PL_regnode_kind[OP(rn)] == EXACT)
+#define IS_EXACT(rn) (REGNODE_TYPE(OP(rn)) == EXACT)
 
-#define HAS_TEXT(rn) ( IS_EXACT(rn) || PL_regnode_kind[OP(rn)] == REF )
+#define HAS_TEXT(rn) ( IS_EXACT(rn) || REGNODE_TYPE(OP(rn)) == REF )
 
 /*
   Search for mandatory following text node; for lookahead, the text must
@@ -201,7 +201,7 @@ static const char non_utf8_target_but_utf8_required[]
 #define FIND_NEXT_IMPT(rn) STMT_START {                                   \
     while (JUMPABLE(rn)) { \
         const OPCODE type = OP(rn); \
-        if (type == SUSPEND || PL_regnode_kind[type] == CURLY) \
+        if (type == SUSPEND || REGNODE_TYPE(type) == CURLY) \
             rn = REGNODE_AFTER_opcode(rn,type); \
         else if (type == PLUS) \
             rn = REGNODE_AFTER_type(rn,tregnode_PLUS); \
@@ -1485,11 +1485,11 @@ Perl_re_intuit_start(pTHX_
      * (trie stclasses are too expensive to use here, we are better off to
      * leave it to regmatch itself) */
 
-    if (progi->regstclass && PL_regnode_kind[OP(progi->regstclass)]!=TRIE) {
+    if (progi->regstclass && REGNODE_TYPE(OP(progi->regstclass))!=TRIE) {
         const U8* const str = (U8*)STRING(progi->regstclass);
 
         /* XXX this value could be pre-computed */
-        const SSize_t cl_l = (PL_regnode_kind[OP(progi->regstclass)] == EXACT
+        const SSize_t cl_l = (REGNODE_TYPE(OP(progi->regstclass)) == EXACT
                     ?  (reginfo->is_utf8_pat
                         ? (SSize_t)utf8_distance(str + STR_LEN(progi->regstclass), str)
                         : (SSize_t)STR_LEN(progi->regstclass))
@@ -4050,7 +4050,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
         if (minlen) {
             const OPCODE op = OP(progi->regstclass);
             /* don't bother with what can't match */
-            if (PL_regnode_kind[op] != EXACT && PL_regnode_kind[op] != TRIE)
+            if (REGNODE_TYPE(op) != EXACT && REGNODE_TYPE(op) != TRIE)
                 strend = HOPc(strend, -(minlen - 1));
         }
         DEBUG_EXECUTE_r({
@@ -6465,7 +6465,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                     INDENT_CHARS(depth), "",
                     (IV)(scan - rexi->program),
                     SvPVX_const(prop),
-                    (PL_regnode_kind[OP(scan)] == END || !rnext) ?
+                    (REGNODE_TYPE(OP(scan)) == END || !rnext) ?
                         0 : (IV)(rnext - rexi->program));
             }
         );
@@ -8488,7 +8488,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 for (
                     cursor = scan;
                     cursor && ( OP(cursor) != END );
-                    cursor = ( PL_regnode_kind[ OP(cursor) ] == END )
+                    cursor = ( REGNODE_TYPE( OP(cursor) ) == END )
                              ? REGNODE_AFTER(cursor)
                              : regnext(cursor)
                 ){
@@ -9061,7 +9061,7 @@ NULL
                     regnode *text_node = ST.B;
                     if (! HAS_TEXT(text_node))
                         FIND_NEXT_IMPT(text_node);
-                    if (PL_regnode_kind[OP(text_node)] == EXACT) {
+                    if (REGNODE_TYPE(OP(text_node)) == EXACT) {
                         if (! S_setup_EXACTISH_ST(aTHX_ text_node,
                                                         &ST.Binfo, reginfo))
                         {
@@ -9218,7 +9218,7 @@ NULL
                 if (! HAS_TEXT(text_node))
                     ST.Binfo.count = 0;
                 else {
-                    if ( PL_regnode_kind[OP(text_node)] != EXACT ) {
+                    if ( REGNODE_TYPE(OP(text_node)) != EXACT ) {
                         ST.Binfo.count = 0;
                     }
                     else {
@@ -9281,7 +9281,7 @@ NULL
                     sayNO;
                 SET_locinput(li);
                 if ((ST.count > ST.min)
-                    && (PL_regnode_kind[OP(ST.B)] == EOL) && (OP(ST.B) != MEOL))
+                    && (REGNODE_TYPE(OP(ST.B)) == EOL) && (OP(ST.B) != MEOL))
                 {
                     /* A{m,n} must come at the end of the string, there's
                      * no point in backing off ... */

--- a/regexp.h
+++ b/regexp.h
@@ -22,6 +22,13 @@
 
 typedef SSize_t regnode_offset;
 
+struct regnode_meta {
+    U8 type;
+    U8 arg_len;
+    U8 arg_len_varies;
+    U8 off_by_arg;
+};
+
 struct regnode {
     U8	flags;
     U8  type;

--- a/reginline.h
+++ b/reginline.h
@@ -38,7 +38,7 @@ Perl_regnode_after(pTHX_ const regnode *p, const bool varies)
     const U8 op = OP(p);
     assert(op < REGNODE_MAX);
     const regnode *ret = p + NODE_STEP_REGNODE + REGNODE_ARG_LEN(op);
-    if (varies || PL_regnode_arg_len_varies[op])
+    if (varies || REGNODE_ARG_LEN_VARIES(op))
         ret += STR_SZ(STR_LEN(p));
     return (regnode *)ret;
 }

--- a/reginline.h
+++ b/reginline.h
@@ -18,7 +18,7 @@ Perl_regnext(pTHX_ const regnode *p)
                                                 (int)OP(p), (int)REGNODE_MAX);
     }
 
-    offset = (PL_regnode_off_by_arg[OP(p)] ? ARG(p) : NEXT_OFF(p));
+    offset = (REGNODE_OFF_BY_ARG(OP(p)) ? ARG(p) : NEXT_OFF(p));
     if (offset == 0)
         return(NULL);
 

--- a/reginline.h
+++ b/reginline.h
@@ -37,7 +37,7 @@ Perl_regnode_after(pTHX_ const regnode *p, const bool varies)
     assert(p);
     const U8 op = OP(p);
     assert(op < REGNODE_MAX);
-    const regnode *ret = p + NODE_STEP_REGNODE + PL_regnode_arg_len[op];
+    const regnode *ret = p + NODE_STEP_REGNODE + REGNODE_ARG_LEN(op);
     if (varies || PL_regnode_arg_len_varies[op])
         ret += STR_SZ(STR_LEN(p));
     return (regnode *)ret;

--- a/regnodes.h
+++ b/regnodes.h
@@ -2383,10 +2383,10 @@ EXTCONST U8 PL_simple_bitmask[] = {
 #endif /* DOINIT */
 
 /* Is 'op', known to be of type EXACT, folding? */
-#define isEXACTFish(op) (__ASSERT_(PL_regnode_kind[op] == EXACT) (PL_EXACTFish_bitmask & (1U << (op - EXACT))))
+#define isEXACTFish(op) (__ASSERT_(REGNODE_TYPE(op) == EXACT) (PL_EXACTFish_bitmask & (1U << (op - EXACT))))
 
 /* Do only UTF-8 target strings match 'op', known to be of type EXACT? */
-#define isEXACT_REQ8(op) (__ASSERT_(PL_regnode_kind[op] == EXACT) (PL_EXACT_REQ8_bitmask & (1U << (op - EXACT))))
+#define isEXACT_REQ8(op) (__ASSERT_(REGNODE_TYPE(op) == EXACT) (PL_EXACT_REQ8_bitmask & (1U << (op - EXACT))))
 
 #ifndef DOINIT
 EXTCONST U32 PL_EXACTFish_bitmask;

--- a/regnodes.h
+++ b/regnodes.h
@@ -1573,536 +1573,6 @@ typedef struct regnode                           tregnode_WHILEM;
 #define KEEPS_next_fail_t8_p8             607  /*      0x25f */
 
 
-/* PL_regnode_kind[] What type of regop or state is this. */
-
-#ifndef DOINIT
-EXTCONST U8 PL_regnode_kind[];
-#else
-EXTCONST U8 PL_regnode_kind[] = {
-	END,      	/* END                    */
-	END,      	/* SUCCEED                */
-	BOL,      	/* SBOL                   */
-	BOL,      	/* MBOL                   */
-	EOL,      	/* SEOL                   */
-	EOL,      	/* MEOL                   */
-	EOL,      	/* EOS                    */
-	GPOS,     	/* GPOS                   */
-	BOUND,    	/* BOUND                  */
-	BOUND,    	/* BOUNDL                 */
-	BOUND,    	/* BOUNDU                 */
-	BOUND,    	/* BOUNDA                 */
-	NBOUND,   	/* NBOUND                 */
-	NBOUND,   	/* NBOUNDL                */
-	NBOUND,   	/* NBOUNDU                */
-	NBOUND,   	/* NBOUNDA                */
-	REG_ANY,  	/* REG_ANY                */
-	REG_ANY,  	/* SANY                   */
-	ANYOF,    	/* ANYOF                  */
-	ANYOF,    	/* ANYOFD                 */
-	ANYOF,    	/* ANYOFL                 */
-	ANYOF,    	/* ANYOFPOSIXL            */
-	ANYOFH,   	/* ANYOFH                 */
-	ANYOFH,   	/* ANYOFHb                */
-	ANYOFH,   	/* ANYOFHr                */
-	ANYOFH,   	/* ANYOFHs                */
-	ANYOFR,   	/* ANYOFR                 */
-	ANYOFR,   	/* ANYOFRb                */
-	ANYOFHbbm,	/* ANYOFHbbm              */
-	ANYOFM,   	/* ANYOFM                 */
-	ANYOFM,   	/* NANYOFM                */
-	POSIXD,   	/* POSIXD                 */
-	POSIXD,   	/* POSIXL                 */
-	POSIXD,   	/* POSIXU                 */
-	POSIXD,   	/* POSIXA                 */
-	NPOSIXD,  	/* NPOSIXD                */
-	NPOSIXD,  	/* NPOSIXL                */
-	NPOSIXD,  	/* NPOSIXU                */
-	NPOSIXD,  	/* NPOSIXA                */
-	CLUMP,    	/* CLUMP                  */
-	BRANCH,   	/* BRANCH                 */
-	EXACT,    	/* EXACT                  */
-	EXACT,    	/* LEXACT                 */
-	EXACT,    	/* EXACTL                 */
-	EXACT,    	/* EXACTF                 */
-	EXACT,    	/* EXACTFL                */
-	EXACT,    	/* EXACTFU                */
-	EXACT,    	/* EXACTFAA               */
-	EXACT,    	/* EXACTFAA_NO_TRIE       */
-	EXACT,    	/* EXACTFUP               */
-	EXACT,    	/* EXACTFLU8              */
-	EXACT,    	/* EXACT_REQ8             */
-	EXACT,    	/* LEXACT_REQ8            */
-	EXACT,    	/* EXACTFU_REQ8           */
-	EXACT,    	/* EXACTFU_S_EDGE         */
-	LNBREAK,  	/* LNBREAK                */
-	TRIE,     	/* TRIE                   */
-	TRIE,     	/* TRIEC                  */
-	TRIE,     	/* AHOCORASICK            */
-	TRIE,     	/* AHOCORASICKC           */
-	NOTHING,  	/* NOTHING                */
-	NOTHING,  	/* TAIL                   */
-	STAR,     	/* STAR                   */
-	PLUS,     	/* PLUS                   */
-	CURLY,    	/* CURLY                  */
-	CURLY,    	/* CURLYN                 */
-	CURLY,    	/* CURLYM                 */
-	CURLY,    	/* CURLYX                 */
-	WHILEM,   	/* WHILEM                 */
-	OPEN,     	/* OPEN                   */
-	CLOSE,    	/* CLOSE                  */
-	SROPEN,   	/* SROPEN                 */
-	SRCLOSE,  	/* SRCLOSE                */
-	REF,      	/* REF                    */
-	REF,      	/* REFF                   */
-	REF,      	/* REFFL                  */
-	REF,      	/* REFFU                  */
-	REF,      	/* REFFA                  */
-	REF,      	/* REFN                   */
-	REF,      	/* REFFN                  */
-	REF,      	/* REFFLN                 */
-	REF,      	/* REFFUN                 */
-	REF,      	/* REFFAN                 */
-	LONGJMP,  	/* LONGJMP                */
-	BRANCHJ,  	/* BRANCHJ                */
-	BRANCHJ,  	/* IFMATCH                */
-	BRANCHJ,  	/* UNLESSM                */
-	BRANCHJ,  	/* SUSPEND                */
-	BRANCHJ,  	/* IFTHEN                 */
-	GROUPP,   	/* GROUPP                 */
-	EVAL,     	/* EVAL                   */
-	MINMOD,   	/* MINMOD                 */
-	LOGICAL,  	/* LOGICAL                */
-	BRANCHJ,  	/* RENUM                  */
-	GOSUB,    	/* GOSUB                  */
-	GROUPPN,  	/* GROUPPN                */
-	INSUBP,   	/* INSUBP                 */
-	DEFINEP,  	/* DEFINEP                */
-	ENDLIKE,  	/* ENDLIKE                */
-	ENDLIKE,  	/* OPFAIL                 */
-	ENDLIKE,  	/* ACCEPT                 */
-	VERB,     	/* VERB                   */
-	VERB,     	/* PRUNE                  */
-	VERB,     	/* MARKPOINT              */
-	VERB,     	/* SKIP                   */
-	VERB,     	/* COMMIT                 */
-	VERB,     	/* CUTGROUP               */
-	KEEPS,    	/* KEEPS                  */
-	END,      	/* LOOKBEHIND_END         */
-	NOTHING,  	/* OPTIMIZED              */
-	PSEUDO,   	/* PSEUDO                 */
-	REGEX_SET,	/* REGEX_SET              */
-	/* ------------ States ------------- */
-	TRIE,     	/* TRIE_next              */
-	TRIE,     	/* TRIE_next_fail         */
-	EVAL,     	/* EVAL_B                 */
-	EVAL,     	/* EVAL_B_fail            */
-	EVAL,     	/* EVAL_postponed_AB      */
-	EVAL,     	/* EVAL_postponed_AB_fail */
-	CURLYX,   	/* CURLYX_end             */
-	CURLYX,   	/* CURLYX_end_fail        */
-	WHILEM,   	/* WHILEM_A_pre           */
-	WHILEM,   	/* WHILEM_A_pre_fail      */
-	WHILEM,   	/* WHILEM_A_min           */
-	WHILEM,   	/* WHILEM_A_min_fail      */
-	WHILEM,   	/* WHILEM_A_max           */
-	WHILEM,   	/* WHILEM_A_max_fail      */
-	WHILEM,   	/* WHILEM_B_min           */
-	WHILEM,   	/* WHILEM_B_min_fail      */
-	WHILEM,   	/* WHILEM_B_max           */
-	WHILEM,   	/* WHILEM_B_max_fail      */
-	BRANCH,   	/* BRANCH_next            */
-	BRANCH,   	/* BRANCH_next_fail       */
-	CURLYM,   	/* CURLYM_A               */
-	CURLYM,   	/* CURLYM_A_fail          */
-	CURLYM,   	/* CURLYM_B               */
-	CURLYM,   	/* CURLYM_B_fail          */
-	IFMATCH,  	/* IFMATCH_A              */
-	IFMATCH,  	/* IFMATCH_A_fail         */
-	CURLY,    	/* CURLY_B_min            */
-	CURLY,    	/* CURLY_B_min_fail       */
-	CURLY,    	/* CURLY_B_max            */
-	CURLY,    	/* CURLY_B_max_fail       */
-	COMMIT,   	/* COMMIT_next            */
-	COMMIT,   	/* COMMIT_next_fail       */
-	MARKPOINT,	/* MARKPOINT_next         */
-	MARKPOINT,	/* MARKPOINT_next_fail    */
-	SKIP,     	/* SKIP_next              */
-	SKIP,     	/* SKIP_next_fail         */
-	CUTGROUP, 	/* CUTGROUP_next          */
-	CUTGROUP, 	/* CUTGROUP_next_fail     */
-	KEEPS,    	/* KEEPS_next             */
-	KEEPS,    	/* KEEPS_next_fail        */
-};
-#endif
-
-/* PL_regnode_arg_len[] - How large is the argument part of the node (in regnodes) */
-
-#ifndef DOINIT
-EXTCONST U8 PL_regnode_arg_len[];
-#else
-EXTCONST U8 PL_regnode_arg_len[] = {
-	0,                                   	/* END          */
-	0,                                   	/* SUCCEED      */
-	0,                                   	/* SBOL         */
-	0,                                   	/* MBOL         */
-	0,                                   	/* SEOL         */
-	0,                                   	/* MEOL         */
-	0,                                   	/* EOS          */
-	0,                                   	/* GPOS         */
-	0,                                   	/* BOUND        */
-	0,                                   	/* BOUNDL       */
-	0,                                   	/* BOUNDU       */
-	0,                                   	/* BOUNDA       */
-	0,                                   	/* NBOUND       */
-	0,                                   	/* NBOUNDL      */
-	0,                                   	/* NBOUNDU      */
-	0,                                   	/* NBOUNDA      */
-	0,                                   	/* REG_ANY      */
-	0,                                   	/* SANY         */
-	EXTRA_SIZE(tregnode_ANYOF),          	/* ANYOF        */
-	EXTRA_SIZE(tregnode_ANYOFD),         	/* ANYOFD       */
-	EXTRA_SIZE(tregnode_ANYOFL),         	/* ANYOFL       */
-	EXTRA_SIZE(tregnode_ANYOFPOSIXL),    	/* ANYOFPOSIXL  */
-	EXTRA_SIZE(tregnode_ANYOFH),         	/* ANYOFH       */
-	EXTRA_SIZE(tregnode_ANYOFHb),        	/* ANYOFHb      */
-	EXTRA_SIZE(tregnode_ANYOFHr),        	/* ANYOFHr      */
-	EXTRA_SIZE(tregnode_ANYOFHs),        	/* ANYOFHs      */
-	EXTRA_SIZE(tregnode_ANYOFR),         	/* ANYOFR       */
-	EXTRA_SIZE(tregnode_ANYOFRb),        	/* ANYOFRb      */
-	EXTRA_SIZE(tregnode_ANYOFHbbm),      	/* ANYOFHbbm    */
-	EXTRA_SIZE(tregnode_ANYOFM),         	/* ANYOFM       */
-	EXTRA_SIZE(tregnode_NANYOFM),        	/* NANYOFM      */
-	0,                                   	/* POSIXD       */
-	0,                                   	/* POSIXL       */
-	0,                                   	/* POSIXU       */
-	0,                                   	/* POSIXA       */
-	0,                                   	/* NPOSIXD      */
-	0,                                   	/* NPOSIXL      */
-	0,                                   	/* NPOSIXU      */
-	0,                                   	/* NPOSIXA      */
-	0,                                   	/* CLUMP        */
-	0,                                   	/* BRANCH       */
-	0,                                   	/* EXACT        */
-	EXTRA_SIZE(tregnode_LEXACT),         	/* LEXACT       */
-	0,                                   	/* EXACTL       */
-	0,                                   	/* EXACTF       */
-	0,                                   	/* EXACTFL      */
-	0,                                   	/* EXACTFU      */
-	0,                                   	/* EXACTFAA     */
-	0,                                   	/* EXACTFAA_NO_TRIE */
-	0,                                   	/* EXACTFUP     */
-	0,                                   	/* EXACTFLU8    */
-	0,                                   	/* EXACT_REQ8   */
-	EXTRA_SIZE(tregnode_LEXACT_REQ8),    	/* LEXACT_REQ8  */
-	0,                                   	/* EXACTFU_REQ8 */
-	0,                                   	/* EXACTFU_S_EDGE */
-	0,                                   	/* LNBREAK      */
-	EXTRA_SIZE(tregnode_TRIE),           	/* TRIE         */
-	EXTRA_SIZE(tregnode_TRIEC),          	/* TRIEC        */
-	EXTRA_SIZE(tregnode_AHOCORASICK),    	/* AHOCORASICK  */
-	EXTRA_SIZE(tregnode_AHOCORASICKC),   	/* AHOCORASICKC */
-	0,                                   	/* NOTHING      */
-	0,                                   	/* TAIL         */
-	0,                                   	/* STAR         */
-	0,                                   	/* PLUS         */
-	EXTRA_SIZE(tregnode_CURLY),          	/* CURLY        */
-	EXTRA_SIZE(tregnode_CURLYN),         	/* CURLYN       */
-	EXTRA_SIZE(tregnode_CURLYM),         	/* CURLYM       */
-	EXTRA_SIZE(tregnode_CURLYX),         	/* CURLYX       */
-	0,                                   	/* WHILEM       */
-	EXTRA_SIZE(tregnode_OPEN),           	/* OPEN         */
-	EXTRA_SIZE(tregnode_CLOSE),          	/* CLOSE        */
-	0,                                   	/* SROPEN       */
-	0,                                   	/* SRCLOSE      */
-	EXTRA_SIZE(tregnode_REF),            	/* REF          */
-	EXTRA_SIZE(tregnode_REFF),           	/* REFF         */
-	EXTRA_SIZE(tregnode_REFFL),          	/* REFFL        */
-	EXTRA_SIZE(tregnode_REFFU),          	/* REFFU        */
-	EXTRA_SIZE(tregnode_REFFA),          	/* REFFA        */
-	EXTRA_SIZE(tregnode_REFN),           	/* REFN         */
-	EXTRA_SIZE(tregnode_REFFN),          	/* REFFN        */
-	EXTRA_SIZE(tregnode_REFFLN),         	/* REFFLN       */
-	EXTRA_SIZE(tregnode_REFFUN),         	/* REFFUN       */
-	EXTRA_SIZE(tregnode_REFFAN),         	/* REFFAN       */
-	EXTRA_SIZE(tregnode_LONGJMP),        	/* LONGJMP      */
-	EXTRA_SIZE(tregnode_BRANCHJ),        	/* BRANCHJ      */
-	EXTRA_SIZE(tregnode_IFMATCH),        	/* IFMATCH      */
-	EXTRA_SIZE(tregnode_UNLESSM),        	/* UNLESSM      */
-	EXTRA_SIZE(tregnode_SUSPEND),        	/* SUSPEND      */
-	EXTRA_SIZE(tregnode_IFTHEN),         	/* IFTHEN       */
-	EXTRA_SIZE(tregnode_GROUPP),         	/* GROUPP       */
-	EXTRA_SIZE(tregnode_EVAL),           	/* EVAL         */
-	0,                                   	/* MINMOD       */
-	0,                                   	/* LOGICAL      */
-	EXTRA_SIZE(tregnode_RENUM),          	/* RENUM        */
-	EXTRA_SIZE(tregnode_GOSUB),          	/* GOSUB        */
-	EXTRA_SIZE(tregnode_GROUPPN),        	/* GROUPPN      */
-	EXTRA_SIZE(tregnode_INSUBP),         	/* INSUBP       */
-	EXTRA_SIZE(tregnode_DEFINEP),        	/* DEFINEP      */
-	0,                                   	/* ENDLIKE      */
-	EXTRA_SIZE(tregnode_OPFAIL),         	/* OPFAIL       */
-	EXTRA_SIZE(tregnode_ACCEPT),         	/* ACCEPT       */
-	EXTRA_SIZE(tregnode_VERB),           	/* VERB         */
-	EXTRA_SIZE(tregnode_PRUNE),          	/* PRUNE        */
-	EXTRA_SIZE(tregnode_MARKPOINT),      	/* MARKPOINT    */
-	EXTRA_SIZE(tregnode_SKIP),           	/* SKIP         */
-	EXTRA_SIZE(tregnode_COMMIT),         	/* COMMIT       */
-	EXTRA_SIZE(tregnode_CUTGROUP),       	/* CUTGROUP     */
-	0,                                   	/* KEEPS        */
-	0,                                   	/* LOOKBEHIND_END */
-	0,                                   	/* OPTIMIZED    */
-	0,                                   	/* PSEUDO       */
-	EXTRA_SIZE(tregnode_REGEX_SET),      	/* REGEX_SET    */
-};
-#endif /* DOINIT */
-
-
-/* PL_regnode_arg_len_varies[] - Is the size of the node determined by STR_SZ() macros?
-   Currently this is a boolean, but in the future it might turn into something
-   that uses more bits of the value to indicate that a different macro would be
-   used. */
-
-#ifndef DOINIT
-EXTCONST U8 PL_regnode_arg_len_varies[];
-#else
-EXTCONST U8 PL_regnode_arg_len_varies[] = {
-	0,                                   	/* END          */
-	0,                                   	/* SUCCEED      */
-	0,                                   	/* SBOL         */
-	0,                                   	/* MBOL         */
-	0,                                   	/* SEOL         */
-	0,                                   	/* MEOL         */
-	0,                                   	/* EOS          */
-	0,                                   	/* GPOS         */
-	0,                                   	/* BOUND        */
-	0,                                   	/* BOUNDL       */
-	0,                                   	/* BOUNDU       */
-	0,                                   	/* BOUNDA       */
-	0,                                   	/* NBOUND       */
-	0,                                   	/* NBOUNDL      */
-	0,                                   	/* NBOUNDU      */
-	0,                                   	/* NBOUNDA      */
-	0,                                   	/* REG_ANY      */
-	0,                                   	/* SANY         */
-	0,                                   	/* ANYOF        */
-	0,                                   	/* ANYOFD       */
-	0,                                   	/* ANYOFL       */
-	0,                                   	/* ANYOFPOSIXL  */
-	0,                                   	/* ANYOFH       */
-	0,                                   	/* ANYOFHb      */
-	0,                                   	/* ANYOFHr      */
-	1,                                   	/* ANYOFHs      */
-	0,                                   	/* ANYOFR       */
-	0,                                   	/* ANYOFRb      */
-	0,                                   	/* ANYOFHbbm    */
-	0,                                   	/* ANYOFM       */
-	0,                                   	/* NANYOFM      */
-	0,                                   	/* POSIXD       */
-	0,                                   	/* POSIXL       */
-	0,                                   	/* POSIXU       */
-	0,                                   	/* POSIXA       */
-	0,                                   	/* NPOSIXD      */
-	0,                                   	/* NPOSIXL      */
-	0,                                   	/* NPOSIXU      */
-	0,                                   	/* NPOSIXA      */
-	0,                                   	/* CLUMP        */
-	0,                                   	/* BRANCH       */
-	1,                                   	/* EXACT        */
-	1,                                   	/* LEXACT       */
-	1,                                   	/* EXACTL       */
-	1,                                   	/* EXACTF       */
-	1,                                   	/* EXACTFL      */
-	1,                                   	/* EXACTFU      */
-	1,                                   	/* EXACTFAA     */
-	1,                                   	/* EXACTFAA_NO_TRIE */
-	1,                                   	/* EXACTFUP     */
-	1,                                   	/* EXACTFLU8    */
-	1,                                   	/* EXACT_REQ8   */
-	1,                                   	/* LEXACT_REQ8  */
-	1,                                   	/* EXACTFU_REQ8 */
-	1,                                   	/* EXACTFU_S_EDGE */
-	0,                                   	/* LNBREAK      */
-	0,                                   	/* TRIE         */
-	0,                                   	/* TRIEC        */
-	0,                                   	/* AHOCORASICK  */
-	0,                                   	/* AHOCORASICKC */
-	0,                                   	/* NOTHING      */
-	0,                                   	/* TAIL         */
-	0,                                   	/* STAR         */
-	0,                                   	/* PLUS         */
-	0,                                   	/* CURLY        */
-	0,                                   	/* CURLYN       */
-	0,                                   	/* CURLYM       */
-	0,                                   	/* CURLYX       */
-	0,                                   	/* WHILEM       */
-	0,                                   	/* OPEN         */
-	0,                                   	/* CLOSE        */
-	0,                                   	/* SROPEN       */
-	0,                                   	/* SRCLOSE      */
-	0,                                   	/* REF          */
-	0,                                   	/* REFF         */
-	0,                                   	/* REFFL        */
-	0,                                   	/* REFFU        */
-	0,                                   	/* REFFA        */
-	0,                                   	/* REFN         */
-	0,                                   	/* REFFN        */
-	0,                                   	/* REFFLN       */
-	0,                                   	/* REFFUN       */
-	0,                                   	/* REFFAN       */
-	0,                                   	/* LONGJMP      */
-	0,                                   	/* BRANCHJ      */
-	0,                                   	/* IFMATCH      */
-	0,                                   	/* UNLESSM      */
-	0,                                   	/* SUSPEND      */
-	0,                                   	/* IFTHEN       */
-	0,                                   	/* GROUPP       */
-	0,                                   	/* EVAL         */
-	0,                                   	/* MINMOD       */
-	0,                                   	/* LOGICAL      */
-	0,                                   	/* RENUM        */
-	0,                                   	/* GOSUB        */
-	0,                                   	/* GROUPPN      */
-	0,                                   	/* INSUBP       */
-	0,                                   	/* DEFINEP      */
-	0,                                   	/* ENDLIKE      */
-	0,                                   	/* OPFAIL       */
-	0,                                   	/* ACCEPT       */
-	0,                                   	/* VERB         */
-	0,                                   	/* PRUNE        */
-	0,                                   	/* MARKPOINT    */
-	0,                                   	/* SKIP         */
-	0,                                   	/* COMMIT       */
-	0,                                   	/* CUTGROUP     */
-	0,                                   	/* KEEPS        */
-	0,                                   	/* LOOKBEHIND_END */
-	0,                                   	/* OPTIMIZED    */
-	0,                                   	/* PSEUDO       */
-	0,                                   	/* REGEX_SET    */
-};
-#endif /* DOINIT */
-
-
-/* PL_regnode_off_by_arg[] - Which argument holds the offset to the next node */
-
-#ifndef DOINIT
-EXTCONST U8 PL_regnode_off_by_arg[];
-#else
-EXTCONST U8 PL_regnode_off_by_arg[] = {
-	0,	/* END          */
-	0,	/* SUCCEED      */
-	0,	/* SBOL         */
-	0,	/* MBOL         */
-	0,	/* SEOL         */
-	0,	/* MEOL         */
-	0,	/* EOS          */
-	0,	/* GPOS         */
-	0,	/* BOUND        */
-	0,	/* BOUNDL       */
-	0,	/* BOUNDU       */
-	0,	/* BOUNDA       */
-	0,	/* NBOUND       */
-	0,	/* NBOUNDL      */
-	0,	/* NBOUNDU      */
-	0,	/* NBOUNDA      */
-	0,	/* REG_ANY      */
-	0,	/* SANY         */
-	0,	/* ANYOF        */
-	0,	/* ANYOFD       */
-	0,	/* ANYOFL       */
-	0,	/* ANYOFPOSIXL  */
-	0,	/* ANYOFH       */
-	0,	/* ANYOFHb      */
-	0,	/* ANYOFHr      */
-	0,	/* ANYOFHs      */
-	0,	/* ANYOFR       */
-	0,	/* ANYOFRb      */
-	0,	/* ANYOFHbbm    */
-	0,	/* ANYOFM       */
-	0,	/* NANYOFM      */
-	0,	/* POSIXD       */
-	0,	/* POSIXL       */
-	0,	/* POSIXU       */
-	0,	/* POSIXA       */
-	0,	/* NPOSIXD      */
-	0,	/* NPOSIXL      */
-	0,	/* NPOSIXU      */
-	0,	/* NPOSIXA      */
-	0,	/* CLUMP        */
-	0,	/* BRANCH       */
-	0,	/* EXACT        */
-	0,	/* LEXACT       */
-	0,	/* EXACTL       */
-	0,	/* EXACTF       */
-	0,	/* EXACTFL      */
-	0,	/* EXACTFU      */
-	0,	/* EXACTFAA     */
-	0,	/* EXACTFAA_NO_TRIE */
-	0,	/* EXACTFUP     */
-	0,	/* EXACTFLU8    */
-	0,	/* EXACT_REQ8   */
-	0,	/* LEXACT_REQ8  */
-	0,	/* EXACTFU_REQ8 */
-	0,	/* EXACTFU_S_EDGE */
-	0,	/* LNBREAK      */
-	0,	/* TRIE         */
-	0,	/* TRIEC        */
-	0,	/* AHOCORASICK  */
-	0,	/* AHOCORASICKC */
-	0,	/* NOTHING      */
-	0,	/* TAIL         */
-	0,	/* STAR         */
-	0,	/* PLUS         */
-	0,	/* CURLY        */
-	0,	/* CURLYN       */
-	0,	/* CURLYM       */
-	0,	/* CURLYX       */
-	0,	/* WHILEM       */
-	0,	/* OPEN         */
-	0,	/* CLOSE        */
-	0,	/* SROPEN       */
-	0,	/* SRCLOSE      */
-	0,	/* REF          */
-	0,	/* REFF         */
-	0,	/* REFFL        */
-	0,	/* REFFU        */
-	0,	/* REFFA        */
-	0,	/* REFN         */
-	0,	/* REFFN        */
-	0,	/* REFFLN       */
-	0,	/* REFFUN       */
-	0,	/* REFFAN       */
-	1,	/* LONGJMP      */
-	1,	/* BRANCHJ      */
-	1,	/* IFMATCH      */
-	1,	/* UNLESSM      */
-	1,	/* SUSPEND      */
-	1,	/* IFTHEN       */
-	0,	/* GROUPP       */
-	0,	/* EVAL         */
-	0,	/* MINMOD       */
-	0,	/* LOGICAL      */
-	1,	/* RENUM        */
-	0,	/* GOSUB        */
-	0,	/* GROUPPN      */
-	0,	/* INSUBP       */
-	0,	/* DEFINEP      */
-	0,	/* ENDLIKE      */
-	0,	/* OPFAIL       */
-	0,	/* ACCEPT       */
-	0,	/* VERB         */
-	0,	/* PRUNE        */
-	0,	/* MARKPOINT    */
-	0,	/* SKIP         */
-	0,	/* COMMIT       */
-	0,	/* CUTGROUP     */
-	0,	/* KEEPS        */
-	0,	/* LOOKBEHIND_END */
-	0,	/* OPTIMIZED    */
-	0,	/* PSEUDO       */
-	0,	/* REGEX_SET    */
-};
-#endif
-
 /* PL_regnode_name[] - Opcode/state names in string form, for debugging */
 
 #ifndef DOINIT
@@ -2262,6 +1732,1080 @@ EXTCONST char * const PL_regnode_name[] = {
 	"CUTGROUP_next_fail",    	/* REGNODE_MAX +0x26 */
 	"KEEPS_next",            	/* REGNODE_MAX +0x27 */
 	"KEEPS_next_fail",       	/* REGNODE_MAX +0x28 */
+};
+#endif /* DOINIT */
+
+
+/* PL_regnode_info[] - Opcode/state names in string form, for debugging */
+
+#ifndef DOINIT
+EXTCONST struct regnode_meta PL_regnode_info[];
+#else
+EXTCONST struct regnode_meta const PL_regnode_info[] = {
+    {
+        /* #0 op END */
+        .type = END,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #1 op SUCCEED */
+        .type = END,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #2 op SBOL */
+        .type = BOL,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #3 op MBOL */
+        .type = BOL,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #4 op SEOL */
+        .type = EOL,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #5 op MEOL */
+        .type = EOL,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #6 op EOS */
+        .type = EOL,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #7 op GPOS */
+        .type = GPOS,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #8 op BOUND */
+        .type = BOUND,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #9 op BOUNDL */
+        .type = BOUND,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #10 op BOUNDU */
+        .type = BOUND,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #11 op BOUNDA */
+        .type = BOUND,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #12 op NBOUND */
+        .type = NBOUND,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #13 op NBOUNDL */
+        .type = NBOUND,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #14 op NBOUNDU */
+        .type = NBOUND,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #15 op NBOUNDA */
+        .type = NBOUND,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #16 op REG_ANY */
+        .type = REG_ANY,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #17 op SANY */
+        .type = REG_ANY,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #18 op ANYOF */
+        .type = ANYOF,
+        .arg_len = EXTRA_SIZE(tregnode_ANYOF),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #19 op ANYOFD */
+        .type = ANYOF,
+        .arg_len = EXTRA_SIZE(tregnode_ANYOFD),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #20 op ANYOFL */
+        .type = ANYOF,
+        .arg_len = EXTRA_SIZE(tregnode_ANYOFL),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #21 op ANYOFPOSIXL */
+        .type = ANYOF,
+        .arg_len = EXTRA_SIZE(tregnode_ANYOFPOSIXL),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #22 op ANYOFH */
+        .type = ANYOFH,
+        .arg_len = EXTRA_SIZE(tregnode_ANYOFH),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #23 op ANYOFHb */
+        .type = ANYOFH,
+        .arg_len = EXTRA_SIZE(tregnode_ANYOFHb),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #24 op ANYOFHr */
+        .type = ANYOFH,
+        .arg_len = EXTRA_SIZE(tregnode_ANYOFHr),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #25 op ANYOFHs */
+        .type = ANYOFH,
+        .arg_len = EXTRA_SIZE(tregnode_ANYOFHs),
+        .arg_len_varies = 1,
+        .off_by_arg = 0
+    },
+    {
+        /* #26 op ANYOFR */
+        .type = ANYOFR,
+        .arg_len = EXTRA_SIZE(tregnode_ANYOFR),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #27 op ANYOFRb */
+        .type = ANYOFR,
+        .arg_len = EXTRA_SIZE(tregnode_ANYOFRb),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #28 op ANYOFHbbm */
+        .type = ANYOFHbbm,
+        .arg_len = EXTRA_SIZE(tregnode_ANYOFHbbm),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #29 op ANYOFM */
+        .type = ANYOFM,
+        .arg_len = EXTRA_SIZE(tregnode_ANYOFM),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #30 op NANYOFM */
+        .type = ANYOFM,
+        .arg_len = EXTRA_SIZE(tregnode_NANYOFM),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #31 op POSIXD */
+        .type = POSIXD,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #32 op POSIXL */
+        .type = POSIXD,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #33 op POSIXU */
+        .type = POSIXD,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #34 op POSIXA */
+        .type = POSIXD,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #35 op NPOSIXD */
+        .type = NPOSIXD,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #36 op NPOSIXL */
+        .type = NPOSIXD,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #37 op NPOSIXU */
+        .type = NPOSIXD,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #38 op NPOSIXA */
+        .type = NPOSIXD,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #39 op CLUMP */
+        .type = CLUMP,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #40 op BRANCH */
+        .type = BRANCH,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #41 op EXACT */
+        .type = EXACT,
+        .arg_len = 0,
+        .arg_len_varies = 1,
+        .off_by_arg = 0
+    },
+    {
+        /* #42 op LEXACT */
+        .type = EXACT,
+        .arg_len = EXTRA_SIZE(tregnode_LEXACT),
+        .arg_len_varies = 1,
+        .off_by_arg = 0
+    },
+    {
+        /* #43 op EXACTL */
+        .type = EXACT,
+        .arg_len = 0,
+        .arg_len_varies = 1,
+        .off_by_arg = 0
+    },
+    {
+        /* #44 op EXACTF */
+        .type = EXACT,
+        .arg_len = 0,
+        .arg_len_varies = 1,
+        .off_by_arg = 0
+    },
+    {
+        /* #45 op EXACTFL */
+        .type = EXACT,
+        .arg_len = 0,
+        .arg_len_varies = 1,
+        .off_by_arg = 0
+    },
+    {
+        /* #46 op EXACTFU */
+        .type = EXACT,
+        .arg_len = 0,
+        .arg_len_varies = 1,
+        .off_by_arg = 0
+    },
+    {
+        /* #47 op EXACTFAA */
+        .type = EXACT,
+        .arg_len = 0,
+        .arg_len_varies = 1,
+        .off_by_arg = 0
+    },
+    {
+        /* #48 op EXACTFAA_NO_TRIE */
+        .type = EXACT,
+        .arg_len = 0,
+        .arg_len_varies = 1,
+        .off_by_arg = 0
+    },
+    {
+        /* #49 op EXACTFUP */
+        .type = EXACT,
+        .arg_len = 0,
+        .arg_len_varies = 1,
+        .off_by_arg = 0
+    },
+    {
+        /* #50 op EXACTFLU8 */
+        .type = EXACT,
+        .arg_len = 0,
+        .arg_len_varies = 1,
+        .off_by_arg = 0
+    },
+    {
+        /* #51 op EXACT_REQ8 */
+        .type = EXACT,
+        .arg_len = 0,
+        .arg_len_varies = 1,
+        .off_by_arg = 0
+    },
+    {
+        /* #52 op LEXACT_REQ8 */
+        .type = EXACT,
+        .arg_len = EXTRA_SIZE(tregnode_LEXACT_REQ8),
+        .arg_len_varies = 1,
+        .off_by_arg = 0
+    },
+    {
+        /* #53 op EXACTFU_REQ8 */
+        .type = EXACT,
+        .arg_len = 0,
+        .arg_len_varies = 1,
+        .off_by_arg = 0
+    },
+    {
+        /* #54 op EXACTFU_S_EDGE */
+        .type = EXACT,
+        .arg_len = 0,
+        .arg_len_varies = 1,
+        .off_by_arg = 0
+    },
+    {
+        /* #55 op LNBREAK */
+        .type = LNBREAK,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #56 op TRIE */
+        .type = TRIE,
+        .arg_len = EXTRA_SIZE(tregnode_TRIE),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #57 op TRIEC */
+        .type = TRIE,
+        .arg_len = EXTRA_SIZE(tregnode_TRIEC),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #58 op AHOCORASICK */
+        .type = TRIE,
+        .arg_len = EXTRA_SIZE(tregnode_AHOCORASICK),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #59 op AHOCORASICKC */
+        .type = TRIE,
+        .arg_len = EXTRA_SIZE(tregnode_AHOCORASICKC),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #60 op NOTHING */
+        .type = NOTHING,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #61 op TAIL */
+        .type = NOTHING,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #62 op STAR */
+        .type = STAR,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #63 op PLUS */
+        .type = PLUS,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #64 op CURLY */
+        .type = CURLY,
+        .arg_len = EXTRA_SIZE(tregnode_CURLY),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #65 op CURLYN */
+        .type = CURLY,
+        .arg_len = EXTRA_SIZE(tregnode_CURLYN),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #66 op CURLYM */
+        .type = CURLY,
+        .arg_len = EXTRA_SIZE(tregnode_CURLYM),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #67 op CURLYX */
+        .type = CURLY,
+        .arg_len = EXTRA_SIZE(tregnode_CURLYX),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #68 op WHILEM */
+        .type = WHILEM,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #69 op OPEN */
+        .type = OPEN,
+        .arg_len = EXTRA_SIZE(tregnode_OPEN),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #70 op CLOSE */
+        .type = CLOSE,
+        .arg_len = EXTRA_SIZE(tregnode_CLOSE),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #71 op SROPEN */
+        .type = SROPEN,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #72 op SRCLOSE */
+        .type = SRCLOSE,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #73 op REF */
+        .type = REF,
+        .arg_len = EXTRA_SIZE(tregnode_REF),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #74 op REFF */
+        .type = REF,
+        .arg_len = EXTRA_SIZE(tregnode_REFF),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #75 op REFFL */
+        .type = REF,
+        .arg_len = EXTRA_SIZE(tregnode_REFFL),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #76 op REFFU */
+        .type = REF,
+        .arg_len = EXTRA_SIZE(tregnode_REFFU),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #77 op REFFA */
+        .type = REF,
+        .arg_len = EXTRA_SIZE(tregnode_REFFA),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #78 op REFN */
+        .type = REF,
+        .arg_len = EXTRA_SIZE(tregnode_REFN),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #79 op REFFN */
+        .type = REF,
+        .arg_len = EXTRA_SIZE(tregnode_REFFN),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #80 op REFFLN */
+        .type = REF,
+        .arg_len = EXTRA_SIZE(tregnode_REFFLN),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #81 op REFFUN */
+        .type = REF,
+        .arg_len = EXTRA_SIZE(tregnode_REFFUN),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #82 op REFFAN */
+        .type = REF,
+        .arg_len = EXTRA_SIZE(tregnode_REFFAN),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #83 op LONGJMP */
+        .type = LONGJMP,
+        .arg_len = EXTRA_SIZE(tregnode_LONGJMP),
+        .arg_len_varies = 0,
+        .off_by_arg = 1
+    },
+    {
+        /* #84 op BRANCHJ */
+        .type = BRANCHJ,
+        .arg_len = EXTRA_SIZE(tregnode_BRANCHJ),
+        .arg_len_varies = 0,
+        .off_by_arg = 1
+    },
+    {
+        /* #85 op IFMATCH */
+        .type = BRANCHJ,
+        .arg_len = EXTRA_SIZE(tregnode_IFMATCH),
+        .arg_len_varies = 0,
+        .off_by_arg = 1
+    },
+    {
+        /* #86 op UNLESSM */
+        .type = BRANCHJ,
+        .arg_len = EXTRA_SIZE(tregnode_UNLESSM),
+        .arg_len_varies = 0,
+        .off_by_arg = 1
+    },
+    {
+        /* #87 op SUSPEND */
+        .type = BRANCHJ,
+        .arg_len = EXTRA_SIZE(tregnode_SUSPEND),
+        .arg_len_varies = 0,
+        .off_by_arg = 1
+    },
+    {
+        /* #88 op IFTHEN */
+        .type = BRANCHJ,
+        .arg_len = EXTRA_SIZE(tregnode_IFTHEN),
+        .arg_len_varies = 0,
+        .off_by_arg = 1
+    },
+    {
+        /* #89 op GROUPP */
+        .type = GROUPP,
+        .arg_len = EXTRA_SIZE(tregnode_GROUPP),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #90 op EVAL */
+        .type = EVAL,
+        .arg_len = EXTRA_SIZE(tregnode_EVAL),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #91 op MINMOD */
+        .type = MINMOD,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #92 op LOGICAL */
+        .type = LOGICAL,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #93 op RENUM */
+        .type = BRANCHJ,
+        .arg_len = EXTRA_SIZE(tregnode_RENUM),
+        .arg_len_varies = 0,
+        .off_by_arg = 1
+    },
+    {
+        /* #94 op GOSUB */
+        .type = GOSUB,
+        .arg_len = EXTRA_SIZE(tregnode_GOSUB),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #95 op GROUPPN */
+        .type = GROUPPN,
+        .arg_len = EXTRA_SIZE(tregnode_GROUPPN),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #96 op INSUBP */
+        .type = INSUBP,
+        .arg_len = EXTRA_SIZE(tregnode_INSUBP),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #97 op DEFINEP */
+        .type = DEFINEP,
+        .arg_len = EXTRA_SIZE(tregnode_DEFINEP),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #98 op ENDLIKE */
+        .type = ENDLIKE,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #99 op OPFAIL */
+        .type = ENDLIKE,
+        .arg_len = EXTRA_SIZE(tregnode_OPFAIL),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #100 op ACCEPT */
+        .type = ENDLIKE,
+        .arg_len = EXTRA_SIZE(tregnode_ACCEPT),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #101 op VERB */
+        .type = VERB,
+        .arg_len = EXTRA_SIZE(tregnode_VERB),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #102 op PRUNE */
+        .type = VERB,
+        .arg_len = EXTRA_SIZE(tregnode_PRUNE),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #103 op MARKPOINT */
+        .type = VERB,
+        .arg_len = EXTRA_SIZE(tregnode_MARKPOINT),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #104 op SKIP */
+        .type = VERB,
+        .arg_len = EXTRA_SIZE(tregnode_SKIP),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #105 op COMMIT */
+        .type = VERB,
+        .arg_len = EXTRA_SIZE(tregnode_COMMIT),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #106 op CUTGROUP */
+        .type = VERB,
+        .arg_len = EXTRA_SIZE(tregnode_CUTGROUP),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #107 op KEEPS */
+        .type = KEEPS,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #108 op LOOKBEHIND_END */
+        .type = END,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #109 op OPTIMIZED */
+        .type = NOTHING,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #110 op PSEUDO */
+        .type = PSEUDO,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #111 op REGEX_SET */
+        .type = REGEX_SET,
+        .arg_len = EXTRA_SIZE(tregnode_REGEX_SET),
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #112 state TRIE_next */
+        .type = TRIE,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #113 state TRIE_next_fail */
+        .type = TRIE,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #114 state EVAL_B */
+        .type = EVAL,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #115 state EVAL_B_fail */
+        .type = EVAL,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #116 state EVAL_postponed_AB */
+        .type = EVAL,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #117 state EVAL_postponed_AB_fail */
+        .type = EVAL,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #118 state CURLYX_end */
+        .type = CURLYX,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #119 state CURLYX_end_fail */
+        .type = CURLYX,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #120 state WHILEM_A_pre */
+        .type = WHILEM,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #121 state WHILEM_A_pre_fail */
+        .type = WHILEM,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #122 state WHILEM_A_min */
+        .type = WHILEM,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #123 state WHILEM_A_min_fail */
+        .type = WHILEM,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #124 state WHILEM_A_max */
+        .type = WHILEM,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #125 state WHILEM_A_max_fail */
+        .type = WHILEM,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #126 state WHILEM_B_min */
+        .type = WHILEM,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #127 state WHILEM_B_min_fail */
+        .type = WHILEM,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #128 state WHILEM_B_max */
+        .type = WHILEM,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #129 state WHILEM_B_max_fail */
+        .type = WHILEM,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #130 state BRANCH_next */
+        .type = BRANCH,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #131 state BRANCH_next_fail */
+        .type = BRANCH,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #132 state CURLYM_A */
+        .type = CURLYM,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #133 state CURLYM_A_fail */
+        .type = CURLYM,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #134 state CURLYM_B */
+        .type = CURLYM,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #135 state CURLYM_B_fail */
+        .type = CURLYM,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #136 state IFMATCH_A */
+        .type = IFMATCH,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #137 state IFMATCH_A_fail */
+        .type = IFMATCH,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #138 state CURLY_B_min */
+        .type = CURLY,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #139 state CURLY_B_min_fail */
+        .type = CURLY,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #140 state CURLY_B_max */
+        .type = CURLY,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #141 state CURLY_B_max_fail */
+        .type = CURLY,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #142 state COMMIT_next */
+        .type = COMMIT,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #143 state COMMIT_next_fail */
+        .type = COMMIT,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #144 state MARKPOINT_next */
+        .type = MARKPOINT,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #145 state MARKPOINT_next_fail */
+        .type = MARKPOINT,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #146 state SKIP_next */
+        .type = SKIP,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #147 state SKIP_next_fail */
+        .type = SKIP,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #148 state CUTGROUP_next */
+        .type = CUTGROUP,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #149 state CUTGROUP_next_fail */
+        .type = CUTGROUP,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #150 state KEEPS_next */
+        .type = KEEPS,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    },
+    {
+        /* #151 state KEEPS_next_fail */
+        .type = KEEPS,
+        .arg_len = 0,
+        .arg_len_varies = 0,
+        .off_by_arg = 0
+    }
 };
 #endif /* DOINIT */
 


### PR DESCRIPTION
This replaces `PL_regnode_arg_len`, `PL_regnode_arg_len_varies`,
`PL_regnode_off_by_arg` and `PL_regnode_kind` with a single `PL_regnode_info`
array, which is an array of `struct regnode_meta`, which contains the same
data but as a struct. Since `PL_regnode_name` is only used in debugging
builds of the regex engine we keep it separate. If we add more debug
properties it might be good to create a `PL_regnode_debug_info[]` to hold
that data instead.

This means when we add new properties we do not need to modify any
secondary sources to add new properites, just the struct definition
and `regen/regcomp.pl`
