### PR TITLE
Add tests for `do { ... } while 0;` and `do { ... } until 1;`

### DIFF
--- a/t/cmd/mod.t
+++ b/t/cmd/mod.t
@@ -1,6 +1,6 @@
 #!./perl
 
-print "1..13\n";
+print "1..15\n";
 
 print "ok 1\n" if 1;
 print "not ok 1\n" unless 1;
@@ -54,3 +54,19 @@ print "not ok 12\n" if $x > 0;
 # This used to cause a segfault
 $x = "".("".do{"foo" for (1)});
 print "ok 13\n";
+
+$x = 0;
+do { ++$x } while 0;
+if ($x == 1) {
+    print "ok 14\n";
+} else {
+    print "not ok 14 # $x\n";
+}
+
+$x = 0;
+do { ++$x } until 1;
+if ($x == 1) {
+    print "ok 15\n";
+} else {
+    print "not ok 15 # $x\n";
+}


### PR DESCRIPTION
Astoundingly, even though we had the perl code as a comment in the C code
which handles this special case in Perl_newLOOPOP(), we didn't actually have
a regression test for it. Father C added a test case for a variant in commit
fc39925ca702f4c8 in Dec 2013, where the value for until is a constant, but
constant folding fails, but the "simple" version never actually had a test
case.

This commit adds the missing test cases.