### PR TITLE
t/op/sselect.t: skip 4 tests under miniperl

### DIFF
--- a/t/op/sselect.t
+++ b/t/op/sselect.t
@@ -106,6 +106,7 @@ select ($tie, undef, undef, $tie);
 ok("no crash from select $numeric_tie, undef, undef, $numeric_tie");
 
 SKIP: {
+    skip "Can't load modules under miniperl", 4 if is_miniperl;
     my $SKIP_CR = sub {
         skip shift, 4;
     };


### PR DESCRIPTION
Commit 85907e6fd46 (July 22 2022) added unit tests to t/op/sselect.t but
failed to take into consideration that this file is run as part of 'make
minitest'.  When we run that command, we get this result:

    t/op/sselect .... FAILED--unexpected output at test 17

... which is due in part to a quirk in t/TEST.  To avoid this problem we
should SKIP the block of tests in question if we're running with
miniperl.