### PR TITLE
dl_dyld.xs should not create a `mode` variable only to ignore it

### DIFF
--- a/ext/DynaLoader/DynaLoader_pm.PL
+++ b/ext/DynaLoader/DynaLoader_pm.PL
@@ -90,7 +90,7 @@ package DynaLoader;
 # Tim.Bunce@ig.co.uk, August 1994
 
 BEGIN {
-    our $VERSION = '1.52';
+    our $VERSION = '1.53';
 }
 
 # Note: in almost any other piece of code "our" would have been a better

--- a/ext/DynaLoader/dl_dyld.xs
+++ b/ext/DynaLoader/dl_dyld.xs
@@ -104,7 +104,7 @@ static void TranslateError
     sv_setpv(MY_CXT.x_dl_last_error, error);
 }
 
-static char *dlopen(char *path, int mode /* mode is ignored */)
+static char *dlopen(char *path)
 {
     int dyld_result;
     NSObjectFileImage ofile;
@@ -159,13 +159,11 @@ void *
 dl_load_file(filename, flags=0)
     char *	filename
     int		flags
-    PREINIT:
-    int mode = 1;
     CODE:
     DLDEBUG(1,PerlIO_printf(Perl_debug_log, "dl_load_file(%s,%x):\n", filename,flags));
     if (flags & 0x01)
 	Perl_warn(aTHX_ "Can't make loaded symbols global on this platform while loading %s",filename);
-    RETVAL = dlopen(filename, mode) ;
+    RETVAL = dlopen(filename);
     DLDEBUG(2,PerlIO_printf(Perl_debug_log, " libref=%x\n", RETVAL));
     ST(0) = sv_newmortal() ;
     if (RETVAL == NULL)


### PR DESCRIPTION
This unused variable dates back to when the file was first added. The code
was structured as a static C wrapper emulating the dlopen() API with the
native APIs, and then a copy of the existing XS code that called dlopen().
However, there is (and was) no need to keep it exactly this way, as the
wrapper is only visible inside this file, meaning that it does not need to
conform to any externally defined prototype.