### PR TITLE
Document postderef_qq support for ->$#* interpolation

### DIFF
--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -272,9 +272,10 @@ regardless of what feature declarations are in scope.
 =head2 The 'postderef' and 'postderef_qq' features
 
 The 'postderef_qq' feature extends the applicability of L<postfix
-dereference syntax|perlref/Postfix Dereference Syntax> so that postfix array
-and scalar dereference are available in double-quotish interpolations. For
-example, it makes the following two statements equivalent:
+dereference syntax|perlref/Postfix Dereference Syntax> so that
+postfix array dereference, postfix scalar dereference, and
+postfix array highest index access are available in double-quotish interpolations.
+For example, it makes the following two statements equivalent:
 
   my $s = "[@{ $h->{a} }]";
   my $s = "[$h->{a}->@*]";

--- a/pod/perlref.pod
+++ b/pod/perlref.pod
@@ -757,7 +757,9 @@ Glob elements can be extracted through the postfix dereferencing feature:
 
 Postfix array and scalar dereferencing I<can> be used in interpolating
 strings (double quotes or the C<qq> operator), but only if the
-C<postderef_qq> feature is enabled.
+C<postderef_qq> feature is enabled. Interpolation of postfix array highest index
+access (C<< ->$#* >>) is also supported when the C<postderef_qq> feature is
+enabled.
 
 =head2 Postfix Reference Slicing
 

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -687,9 +687,10 @@ regardless of what feature declarations are in scope.
 =head2 The 'postderef' and 'postderef_qq' features
 
 The 'postderef_qq' feature extends the applicability of L<postfix
-dereference syntax|perlref/Postfix Dereference Syntax> so that postfix array
-and scalar dereference are available in double-quotish interpolations. For
-example, it makes the following two statements equivalent:
+dereference syntax|perlref/Postfix Dereference Syntax> so that
+postfix array dereference, postfix scalar dereference, and
+postfix array highest index access are available in double-quotish interpolations.
+For example, it makes the following two statements equivalent:
 
   my $s = "[@{ $h->{a} }]";
   my $s = "[$h->{a}->@*]";


### PR DESCRIPTION
This was added in commit <https://github.com/Perl/perl5/commit/ff25e5dbbad6ccf83f2e2a874a3c90294ea8cb47>.
