### PR TITLE
Add support for PERL_RAND_SEED env var

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -2755,6 +2755,12 @@ X<PERL_INTERNAL_RAND_SEED>
 If you configure perl with C<-Accflags=-DNO_PERL_INTERNAL_RAND_SEED>,
 perl will ignore the C<PERL_INTERNAL_RAND_SEED> environment variable.
 
+=head2 C<-DNO_PERL_RAND_SEED>
+X<PERL_RAND_SEED>
+
+If you configure perl with C<-Accflags=-DNO_PERL_RAND_SEED>,
+perl will ignore the C<PERL_RAND_SEED> environment variable.
+
 =head1 DOCUMENTATION
 
 Read the manual entries before running perl.  The main documentation

--- a/MANIFEST
+++ b/MANIFEST
@@ -4046,7 +4046,8 @@ dist/threads/t/stress_cv.t	Test with multiple threads, coderef cv argument.
 dist/threads/t/stress_re.t	Test with multiple threads, string cv argument and regexes.
 dist/threads/t/stress_string.t	Test with multiple threads, string cv argument.
 dist/threads/t/thread.t		General ithread tests from thr5005
-dist/threads/t/unique.t			Test unique attribute with threads
+dist/threads/t/unique.t		Test unique attribute with threads
+dist/threads/t/version.t	Test that pod version matches code version.
 dist/threads/threads.xs		ithreads
 dist/threads-shared/hints/linux.pl	thread shared variables
 dist/threads-shared/lib/threads/shared.pm	thread shared variables

--- a/MANIFEST
+++ b/MANIFEST
@@ -6175,7 +6175,8 @@ t/run/fresh_perl.t		Tests that require a fresh perl.
 t/run/locale.t		Tests related to locale handling
 t/run/noswitch.t		Test aliasing ARGV for other switch tests
 t/run/runenv.t			Test if perl honors its environment variables.
-t/run/runenv_hashseed.t	Test if perl honors PERL_HASH_SEED.
+t/run/runenv_hashseed.t		Test if perl honors PERL_HASH_SEED.
+t/run/runenv_randseed.t		Test if perl honors PERL_RAND_SEED.
 t/run/script.t			See if script invocation works
 t/run/switch0.t			Test the -0 switch
 t/run/switcha.t			Test the -a switch

--- a/dist/threads/lib/threads.pm
+++ b/dist/threads/lib/threads.pm
@@ -5,7 +5,7 @@ use 5.008;
 use strict;
 use warnings;
 
-our $VERSION = '2.28';      # remember to update version in POD!
+our $VERSION = '2.29';      # remember to update version in POD!
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -134,7 +134,7 @@ threads - Perl interpreter-based threads
 
 =head1 VERSION
 
-This document describes threads version 2.27
+This document describes threads version 2.29
 
 =head1 WARNING
 

--- a/dist/threads/t/thread.t
+++ b/dist/threads/t/thread.t
@@ -11,6 +11,7 @@ BEGIN {
 }
 
 use ExtUtils::testlib;
+use Data::Dumper;
 
 use threads;
 
@@ -156,7 +157,8 @@ package main;
     rand(10);
     threads->create( sub { $rand{int(rand(10000000000))}++ } ) foreach 1..25;
     $_->join foreach threads->list;
-    ok((keys %rand >= 23), "Check that rand() is randomized in new threads");
+    ok((keys %rand >= 23), "Check that rand() is randomized in new threads")
+        or diag Dumper(\%rand);
 }
 
 # bugid #24165

--- a/dist/threads/t/version.t
+++ b/dist/threads/t/version.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use threads;
+use Test::More;
+
+# test that the version documented in threads.pm pod matches
+# that of the code.
+
+open my $fh, "<", $INC{"threads.pm"}
+    or die qq(Failed to open '$INC{"threads.pm"}': $!);
+my $file= do { local $/; <$fh> };
+close $fh;
+my $pod_version = 0; 
+if ($file=~/This document describes threads version (\d.\d+)/) {
+    $pod_version = $1;
+}
+is($pod_version, $threads::VERSION, 
+   "Check that pod and \$threads::VERSION match");
+done_testing();
+
+
+    

--- a/dist/threads/t/version.t
+++ b/dist/threads/t/version.t
@@ -1,7 +1,16 @@
 use strict;
 use warnings;
-use threads;
 use Test::More;
+
+BEGIN {
+    use Config;
+    if (! $Config{'useithreads'}) {
+        print("1..0 # SKIP Perl not compiled with 'useithreads'\n");
+        exit(0);
+    }
+}
+
+use threads;
 
 # test that the version documented in threads.pm pod matches
 # that of the code.

--- a/dist/threads/threads.xs
+++ b/dist/threads/threads.xs
@@ -807,6 +807,7 @@ S_ithread_create(
     thread->gimme = gimme;
     thread->state = exit_opt;
 
+
     /* "Clone" our interpreter into the thread's interpreter.
      * This gives thread access to "static data" and code.
      */
@@ -1171,6 +1172,7 @@ ithread_create(...)
         if (! thread) {
             XSRETURN_UNDEF;     /* Mutex already unlocked */
         }
+        PERL_SRAND_OVERRIDE_NEXT_PARENT();
         ST(0) = sv_2mortal(S_ithread_to_SV(aTHX_ Nullsv, thread, classname, FALSE));
 
         /* Let thread run. */
@@ -1179,7 +1181,6 @@ ithread_create(...)
         /* warning: releasing mutex 'thread->mutex' that was not held [-Wthread-safety-analysis] */
         MUTEX_UNLOCK(&thread->mutex);
         CLANG_DIAG_RESTORE_STMT;
-
         /* XSRETURN(1); - implied */
 
 

--- a/embedvar.h
+++ b/embedvar.h
@@ -280,6 +280,8 @@
 #define PL_sortstash		(vTHX->Isortstash)
 #define PL_splitstr		(vTHX->Isplitstr)
 #define PL_srand_called		(vTHX->Isrand_called)
+#define PL_srand_override	(vTHX->Isrand_override)
+#define PL_srand_override_next	(vTHX->Isrand_override_next)
 #define PL_stack_base		(vTHX->Istack_base)
 #define PL_stack_max		(vTHX->Istack_max)
 #define PL_stack_sp		(vTHX->Istack_sp)

--- a/handy.h
+++ b/handy.h
@@ -2960,6 +2960,31 @@ last-inclusive range.
 
 #endif
 
+/* These are simple Marsaglia XOR-SHIFT RNG's for 64 and 32 bits. These
+ * RNG's are of reasonable quality, very fast, and have the interesting
+ * property that provided 'x' is non-zero they create a cycle of 2^32-1
+ * or 2^64-1 "random" like numbers, with the exception of 0. Thus they
+ * are very useful when you want an integer to "dance" in a random way,
+ * but you also never want it to become 0 and thus false.
+ *
+ * Obviously they leave x unchanged if it starts out as 0. */
+
+#define PERL_XORSHIFT64(x)      \
+STMT_START {                    \
+    (x) ^= (x) << 13;           \
+    (x) ^= (x) >> 17;           \
+    (x) ^= (x) << 5;            \
+} STMT_END
+
+/* 32 bit version */
+#define PERL_XORSHIFT32(x)           \
+STMT_START {                    \
+    (x) ^= (x) << 13;           \
+    (x) ^= (x) >> 7;            \
+    (x) ^= (x) << 17;           \
+} STMT_END
+
+
 #endif  /* PERL_HANDY_H_ */
 
 /*

--- a/handy.h
+++ b/handy.h
@@ -2967,21 +2967,75 @@ last-inclusive range.
  * are very useful when you want an integer to "dance" in a random way,
  * but you also never want it to become 0 and thus false.
  *
- * Obviously they leave x unchanged if it starts out as 0. */
+ * Obviously they leave x unchanged if it starts out as 0.
+ *
+ * We have two variants just because that can be helpful in certain
+ * places. There is no advantage to either, they are equally bad as each
+ * other as far RNG's go. Sufficiently random for many purposes, but
+ * insufficiently random for serious use as they fail important tests in
+ * the Test01 BigCrush RNG test suite by L’Ecuyer and Simard. (Note
+ * that Drand48 also fails BigCrush). The main point is they produce
+ * different sequences and in places where we want some randomlike
+ * behavior they are cheap and easy.
+ *
+ * Marsaglia was one of the early researchers into RNG testing and wrote
+ * the Diehard RNG test suite, which after his death become the
+ * Dieharder RNG suite, and was generally supplanted by the Test01 suite
+ * by L'Ecruyer and associates.
+ *
+ * There are dozens of shift parameters that create a pseudo random ring
+ * of integers 1..2^N-1, if you need a different sequence just read the
+ * paper and select a set of parameters. In fact, simply reversing the
+ * shift order from L/R/L to R/L/R should result in another valid
+ * example, but read the paper before you do that.
+ *
+ * PDF of the original paper:
+ *  https://www.jstatsoft.org/article/download/v008i14/916
+ * Wikipedia:
+ *  https://en.wikipedia.org/wiki/Xorshift
+ * Criticism:
+ *  https://www.iro.umontreal.ca/~lecuyer/myftp/papers/xorshift.pdf
+ * Test01:
+ *  http://simul.iro.umontreal.ca/testu01/tu01.html
+ * Diehard:
+ *  https://en.wikipedia.org/wiki/Diehard_tests
+ * Dieharder:
+ *  https://webhome.phy.duke.edu/~rgb/General/rand_rate/rand_rate.abs
+ *
+ */
 
-#define PERL_XORSHIFT64(x)      \
+/* 32 bit version */
+#define PERL_XORSHIFT32_A(x)    \
 STMT_START {                    \
-    (x) ^= (x) << 13;           \
-    (x) ^= (x) >> 17;           \
-    (x) ^= (x) << 5;            \
+    (x) ^= ((x) << 13);         \
+    (x) ^= ((x) >> 17);         \
+    (x) ^= ((x) << 5);          \
+} STMT_END
+
+/* 64 bit version */
+#define PERL_XORSHIFT64_A(x)    \
+STMT_START {                    \
+    (x) ^= ((x) << 13);         \
+    (x) ^= ((x) >> 7);          \
+    (x) ^= ((x) << 17);         \
 } STMT_END
 
 /* 32 bit version */
-#define PERL_XORSHIFT32(x)           \
+#define PERL_XORSHIFT32_B(x)    \
 STMT_START {                    \
-    (x) ^= (x) << 13;           \
-    (x) ^= (x) >> 7;            \
-    (x) ^= (x) << 17;           \
+    (x) ^= ((x) << 5);          \
+    (x) ^= ((x) >> 27);         \
+    (x) ^= ((x) << 8);          \
+} STMT_END
+
+/* 64 bit version - currently this is unused,
+ * it is provided here to complement the 32 bit _B
+ * variant which IS used. */
+#define PERL_XORSHIFT64_B(x)    \
+STMT_START {                    \
+    (x) ^= ((x) << 15);         \
+    (x) ^= ((x) >> 49);         \
+    (x) ^= ((x) << 26);         \
 } STMT_END
 
 

--- a/hv.c
+++ b/hv.c
@@ -56,20 +56,10 @@ static const char S_strtab_error[]
  */
 #if IVSIZE == 8
 /* 64 bit version */
-#define XORSHIFT_RAND_BITS(x)   \
-STMT_START {                    \
-    (x) ^= (x) << 13;           \
-    (x) ^= (x) >> 17;           \
-    (x) ^= (x) << 5;            \
-} STMT_END
+#define XORSHIFT_RAND_BITS(x)   PERL_XORSHIFT64(x)
 #else
 /* 32 bit version */
-#define XORSHIFT_RAND_BITS(x)   \
-STMT_START {                    \
-    (x) ^= (x) << 13;           \
-    (x) ^= (x) >> 7;            \
-    (x) ^= (x) << 17;           \
-} STMT_END
+#define XORSHIFT_RAND_BITS(x)   PERL_XORSHIFT32(x)
 #endif
 
 #define UPDATE_HASH_RAND_BITS_KEY(key,klen)                             \

--- a/hv.c
+++ b/hv.c
@@ -56,10 +56,10 @@ static const char S_strtab_error[]
  */
 #if IVSIZE == 8
 /* 64 bit version */
-#define XORSHIFT_RAND_BITS(x)   PERL_XORSHIFT64(x)
+#define XORSHIFT_RAND_BITS(x)   PERL_XORSHIFT64_A(x)
 #else
 /* 32 bit version */
-#define XORSHIFT_RAND_BITS(x)   PERL_XORSHIFT32(x)
+#define XORSHIFT_RAND_BITS(x)   PERL_XORSHIFT32_A(x)
 #endif
 
 #define UPDATE_HASH_RAND_BITS_KEY(key,klen)                             \

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -810,7 +810,9 @@ PERLVARI(I, perl_destruct_level, signed char,	0)
 
 PERLVAR(I, pad_reset_pending, bool)	/* reset pad on next attempted alloc */
 
-PERLVAR(I, srand_called, bool)
+PERLVARI(I, srand_called, bool, false)      /* has random_state been initialized yet? */
+PERLVARI(I, srand_override, U32, 0)         /* Should we use a deterministic sequence? */
+PERLVARI(I, srand_override_next, U32, 0)    /* Next item in the sequence */
 
 PERLVARI(I, numeric_underlying, bool, TRUE)
                                         /* Assume underlying locale numerics */

--- a/perl.h
+++ b/perl.h
@@ -8806,8 +8806,31 @@ END_EXTERN_C
 #  endif
 #endif
 
-#endif /* DOUBLE_HAS_NAN */
+/* these are used to faciliate the env var PERL_RAND_SEED,
+ * which allows consistent behavior from code that calls
+ * srand() with no arguments, either explicitly or implicitly.
+ */
+#define PERL_SRAND_OVERRIDE_NEXT() PERL_XORSHIFT32_A(PL_srand_override_next);
 
+#define PERL_SRAND_OVERRIDE_NEXT_INIT() STMT_START {    \
+    PL_srand_override = PL_srand_override_next;         \
+    PERL_SRAND_OVERRIDE_NEXT();                         \
+} STMT_END
+
+#define PERL_SRAND_OVERRIDE_GET(into) STMT_START {      \
+    into= PL_srand_override;                            \
+    PERL_SRAND_OVERRIDE_NEXT_INIT();                    \
+} STMT_END
+
+#define PERL_SRAND_OVERRIDE_NEXT_CHILD() STMT_START {   \
+    PERL_XORSHIFT32_B(PL_srand_override_next);          \
+    PERL_SRAND_OVERRIDE_NEXT_INIT();                    \
+} STMT_END
+
+#define PERL_SRAND_OVERRIDE_NEXT_PARENT() \
+    PERL_SRAND_OVERRIDE_NEXT()
+
+#endif /* DOUBLE_HAS_NAN */
 
 /*
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -27,6 +27,17 @@ here, but most should go in the L</Performance Enhancements> section.
 
 [ List each enhancement as a =head2 entry ]
 
+=head2 PERL_RAND_SEED
+
+Added a new environment variable C<PERL_RAND_SEED> which can be used to
+cause a perl program which uses C<rand> without using C<srand()>
+explicitly or which uses C<srand()> with no arguments to be repeatable.
+See L<perlrun>. This feature can be disabled at compile time by passing
+
+    -Accflags=-DNO_PERL_RAND_SEED
+
+to F<Configure> during the build process.
+
 =head1 Security
 
 XXX Any security-related notices go here.  In particular, any security

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -8480,7 +8480,7 @@ The point of the function is to "seed" the L<C<rand>|/rand EXPR>
 function so that L<C<rand>|/rand EXPR> can produce a different sequence
 each time you run your program.  When called with a parameter,
 L<C<srand>|/srand EXPR> uses that for the seed; otherwise it
-(semi-)randomly chooses a seed.  In either case, starting with Perl 5.14,
+(semi-)randomly chooses a seed (see below).  In either case, starting with Perl 5.14,
 it returns the seed.  To signal that your code will work I<only> on Perls
 of a recent vintage:
 
@@ -8511,6 +8511,20 @@ A typical use of the returned seed is for a test program which has too many
 combinations to test comprehensively in the time available to it each run.  It
 can test a random subset each time, and should there be a failure, log the seed
 used for that run so that it can later be used to reproduce the same results.
+
+If the C<PERL_RAND_SEED> environment variable is set to a non-negative
+integer during process startup then calls to C<srand()> with no
+arguments will initialize the perl random number generator with a
+consistent seed each time it is called, whether called explicitly with
+no arguments or implicitly via use of C<rand()>. The exact seeding that
+a given C<PERL_RAND_SEED> will produce is deliberately unspecified, but
+using different values for C<PERL_RAND_SEED> should produce different
+results. This is intended for debugging and performance analysis and is
+only guaranteed to produce consistent results between invocations of the
+same perl executable running the same code when all other factors are
+equal. The environment variable is read only once during process
+startup, and changing it during the program flow will not affect the
+currently running process. See L<perlrun> for more details.
 
 B<L<C<rand>|/rand EXPR> is not cryptographically secure.  You should not rely
 on it in security-sensitive situations.>  As of this writing, a

--- a/pod/perlrun.pod
+++ b/pod/perlrun.pod
@@ -1405,6 +1405,32 @@ with tainting enabled.
 
 Perl may be built to ignore this variable.
 
+=item PERL_RAND_SEED
+X<PERL_RAND_SEED>
+
+When set to an integer value this value will be used to seed the perl
+internal random number generator used for C<rand()> when it is used
+without an explicit C<srand()> call or for when an explicit no-argument
+C<srand()> call is made.
+
+Normally calling C<rand()> prior to calling C<srand()> or calling
+C<srand()> explicitly with no arguments should result in the random
+number generator using "best efforts" to seed the generator state with a
+relatively high quality random seed. When this environment variable is
+set then the seeds used will be deterministically computed from the
+value provided in the env var in such a way that the application process
+and any forks or threads should continue to have their own unique seed but
+that the program may be run twice with identical results as far as
+C<rand()> goes (assuming all else is equal).
+
+PERL_RAND_SEED is intended for performance measurements and debugging
+and is explicitly NOT intended for stable testing. The only guarantee is
+that a specific perl executable will produce the same results twice in a
+row, there is no guarantee that the results will be the same between
+perl releases or on different architectures.
+
+Ignored if perl is run setuid or setgid.
+
 =back
 
 Perl also has environment variables that control how Perl handles data

--- a/pp.c
+++ b/pp.c
@@ -2920,7 +2920,17 @@ PP(pp_sin)
 PP(pp_rand)
 {
     if (!PL_srand_called) {
-        (void)seedDrand01((Rand_seed_t)seed());
+        Rand_seed_t s;
+        if (PL_srand_override) {
+            /* env var PERL_RAND_SEED has been set so the user wants
+             * consistent srand() initialization. */
+            PERL_SRAND_OVERRIDE_GET(s);
+        } else {
+            /* Pseudo random initialization from context state and possible
+             * random devices */
+            s= (Rand_seed_t)seed();
+        }
+        (void)seedDrand01(s);
         PL_srand_called = TRUE;
     }
     {
@@ -2979,7 +2989,13 @@ PP(pp_srand)
         }
     }
     else {
-        anum = seed();
+        if (PL_srand_override) {
+            /* env var PERL_RAND_SEED has been set so the user wants
+             * consistent srand() initialization. */
+            PERL_SRAND_OVERRIDE_GET(anum);
+        } else {
+            anum = seed();
+        }
     }
 
     (void)seedDrand01((Rand_seed_t)anum);

--- a/sv.c
+++ b/sv.c
@@ -15544,6 +15544,8 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
 
     PL_srand_called	= proto_perl->Isrand_called;
     Copy(&(proto_perl->Irandom_state), &PL_random_state, 1, PL_RANDOM_STATE_TYPE);
+    PL_srand_override   = proto_perl->Isrand_override;
+    PL_srand_override_next = proto_perl->Isrand_override_next;
 
     if (flags & CLONEf_COPY_STACKS) {
         /* next allocation will be PL_tmps_stack[PL_tmps_ix+1] */

--- a/t/op/srand.t
+++ b/t/op/srand.t
@@ -52,9 +52,12 @@ ok( !eq_array(\@first_run, \@second_run),
 }
 
 # This test checks whether Perl called srand for you.
-@first_run  = `$^X -le "print int rand 100 for 1..100"`;
-sleep(1); # in case our srand() is too time-dependent
-@second_run = `$^X -le "print int rand 100 for 1..100"`;
+{
+    local $ENV{PERL_RAND_SEED};
+    @first_run  = `$^X -le "print int rand 100 for 1..100"`;
+    sleep(1); # in case our srand() is too time-dependent
+    @second_run = `$^X -le "print int rand 100 for 1..100"`;
+}
 
 ok( !eq_array(\@first_run, \@second_run), 'srand() called automatically');
 

--- a/t/run/runenv_randseed.t
+++ b/t/run/runenv_randseed.t
@@ -1,0 +1,68 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    @INC = '../lib';
+    require './test.pl';
+    require Config;
+    Config->import;
+}
+
+skip_all_without_config('d_fork');
+skip_all("This perl is built with NO_PERL_RAND_SEED")
+    if $Config{ccflags} =~ /-DNO_PERL_RAND_SEED\b/;
+use strict;
+use warnings;
+
+for (1..2) {
+    local $ENV{PERL_RAND_SEED} = 1;
+    fresh_perl_is("print map { chr(rand(26)+65) } 1..10",
+                  "BLVIOAEZTJ", undef, "Test randomness with PERL_RAND_SEED=1");
+}
+
+for (1..2) {
+    local $ENV{PERL_RAND_SEED} = 2;
+    fresh_perl_is("print map { chr(rand(26)+65) } 1..10",
+                  "XEOUOFRPQZ", undef, "Test randomness with PERL_RAND_SEED=2");
+}
+
+my %got;
+for my $try (1..10) {
+    local $ENV{PERL_RAND_SEED};
+    my ($out,$err)= runperl_and_capture({}, ['-e',"print map { chr(rand(26)+65) } 1..10;"]);
+    if ($err) { diag $err }
+    $got{$out}++;
+}
+ok(8 <= keys %got, "Got at least 8 different strings");
+for (1..2) {
+    local $ENV{PERL_RAND_SEED} = 1;
+    my ($out,$err)= runperl_and_capture({}, ['-le',
+            <<'EOF_TEST_CODE'
+            for my $l ("A".."E") {
+                my $pid= fork;
+                if ($pid) {
+                    push @pids, $pid;
+                }
+                elsif (!defined $pid) {
+                    print "$l:failed fork";
+                } elsif (!$pid) {
+                    print "$l:", map { chr(rand(26)+65) } 1..10;
+                    exit;
+                }
+            }
+            waitpid $_,0 for @pids;
+EOF_TEST_CODE
+        ]);
+    is($err, "", "No exceptions forking.");
+    my @parts= sort { $a cmp $b } split /\n/, $out;
+    my @want= (
+            "A:KNXDITWWJZ",
+            "B:WDQJGTBJQS",
+            "C:ZGYCCINIHE",
+            "D:UGLGAEXFBP",
+            "E:MQLTNZGZQB"
+    );
+    is("@parts","@want","Works as expected with forks.");
+}
+
+done_testing();


### PR DESCRIPTION
The idea of this env var is to provide consistent behavior to scripts that call `srand()` with no arguments, either implicitly or explicitly. This is implemented in such a way that each process in the process tree should get unique but repeatable initialization.

Eg

```
$ PERL_RAND_SEED=123 ./perl -Ilib -le'print map { chr(65+rand 26) } 1..10'
HKYDDJQVSD
$ PERL_RAND_SEED=123 ./perl -Ilib -le'print map { chr(65+rand 26) } 1..10'
HKYDDJQVSD
```

Should produce the same results in each time. Similarly if the program forks() or starts subthreads the Nth forked child should get the same initialization each time, and each child should be seeded differently from the parent similarly to how the seed would normally be randomly initialized. In the below example the `| sort -n` sorts the results by which fork they come from so that it is more obvious they are producing the same results 

```
$ PERL_RAND_SEED=123 ./perl -Ilib -le'for my $n (1..5) { my $pid= fork(); if (!$pid) { print $n,map { chr(65+rand 26) } 1..10; exit} }' | sort -n
1ZFKXOTACST
2IXQXRCLXGV
3YZSNSMOBHX
4BNSLRHINMT
5SFCPDTHIRV

$ PERL_RAND_SEED=123 ./perl -Ilib -le'for my $n (1..5) { my $pid= fork(); if (!$pid) { print $n,map { chr(65+rand 26) } 1..10; exit} }' | sort -n
1ZFKXOTACST
2IXQXRCLXGV
3YZSNSMOBHX
4BNSLRHINMT
5SFCPDTHIRV
```
The exact seeding is deliberately unspecified, although in practice when no sub processes are involved it should be equivalent to calling `srand($ENV{PERL_RAND_SEED})` at the top of the script, however each fork() or thread->create() call could change the exact value the mother process uses if the use of `rand()` or `srand()` occurs post fork. The main point is that if the program is executed twice it should produce the exact same results from `rand()` and `srand()` assuming all other factors are equal:

```
PERL_RAND_SEED=1 ./perl -Ilib -le'for my $n (1..5) { my $pid= fork(); if ($pid) { push @pids, $pid} else { print join ", ",$n,map { sprintf "%08x", srand() } 1..10; exit} } waitpid $_,0 for @pids; printf "%08x\n", srand() for 1..5'
1, 80a42501, 8484e763, 1579e1b7, 00adb710, 7fb26ad7, 6ffae7c3, 53515602, 4bb4738a, 7d6f7c68, cea49639
2, 8dcef731, 36372a05, bd8b947e, 2f824c7c, a7b2103a, 53117ee0, e5655046, a2db49f0, b740ac42, fbdf19e6
3, 7de9d161, bf7f82e3, ab5b6b32, 01944dac, 8c10be3c, e1390937, c3eeae38, d31d00ac, 121f9c28, d2c77045
4, be5614a4, e497f265, 41b0be08, 98433330, 3a8cc862, d39bede2, 6ad8a4d1, b615c5f0, dbd39605, 8b7f330c
5, 8a3616fb, 55c3036f, 8071ceb8, 8d74df0b, c4233c61, d646fb76, 2c2fc3a2, 5f26d86f, 0144353a, 7b85efab
00000001
2c6f5bd0
25b2331a
19f91cb2
77877125
```

The new env var does NOT change behavior of scripts using srand() with an argument.

This can be combined with `PERL_HASH_SEED` and `PERL_INTERNAL_RAND_SEED` to produce a repeatable test run of of code that does not hard initialize the random number generator. We document that users cannot expect consistency except in the most constrained circumstance of a given perl executable, but in practice the results should be stable (all other things considered) which we porters can exploit to test the feature in the perl test suite.

This includes a few patches for issues that came up while I testing this with our test suite along with PERL_HASH_SEED=0 and PERL_INTERNAL_RAND_SEED=123.
