### PR TITLE
Reduce tech debt in define related logic in perl.c and hv_func.h

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -450,30 +450,39 @@ storage with 256 32-bit random values as well. In practice the RNG we use
 for seeding the SBOX32 storage is very efficient, and populating the table
 required for hashing even fairly long keys is negligible as we only do it
 during startup. By default we build with SBOX32 enabled, but you can change
-that by setting
+that by setting the C<PERL_HASH_USE_SBOX32_ALSO> in the Configure process,
+with something like this
 
-   PERL_HASH_USE_SBOX32_ALSO
+   -Accflags='-DPERL_HASH_USE_SBOX32_ALSO=0'
 
-to zero in configure. By default Perl will use SBOX32 to hash strings 24 bytes
-or shorter, you can change this length by setting
+or alternatively you can use the simple define C<PERL_HASH_NO_SBOX32> like this:
 
-    SBOX32_MAX_LEN
+    -Accflags='-DPERL_HASH_NO_SBOX32'
 
-to the desired length, with the maximum length being 256.
+By default Perl will use SBOX32 to hash strings 24 bytes
+or shorter, you can change this length by setting C<SBOX32_MAX_LEN>
+to the desired length, with the maximum length being 256. For example with
+this:
+
+    -Accflags='-DSBOX_MAX_LEN=128'
 
 As of Perl 5.18 the order returned by keys(), values(), and each() is
 non-deterministic and distinct per hash, and the insert order for
 colliding keys is randomized as well, and perl allows for controlling this
 by the PERL_PERTURB_KEYS environment setting. You can disable this behavior
-entirely with the define
+entirely with the define C<PERL_PERTURB_KEYS_DISABLED> with
 
-    PERL_PERTURB_KEYS_DISABLED
+    -Accflags='-DPERL_PERTURB_KEYS_DISABLED'
 
 You can disable the environment variable checks and compile time specify
-the type of key traversal randomization to be used by defining one of these:
+the type of key traversal randomization to be used by defining either
+C<PERL_PERTURB_KEYS_RANDOM> or C<PERL_PERTURB_KEYS_DETERMINISTIC> with
 
-    PERL_PERTURB_KEYS_RANDOM
-    PERL_PERTURB_KEYS_DETERMINISTIC
+    -Accflags='-DPERL_PERTURB_KEYS_RANDOM'
+
+or
+
+    -Accflags='-DPERL_PERTURB_KEYS_DETERMINISTIC'
 
 Since Perl 5.18 the seed used for the hash function is randomly selected
 at process start, which can be overridden by specifying a seed by setting
@@ -489,9 +498,9 @@ DETERMINISTIC in this context means "if everything else is kept the same
 the same results should be observed".
 
 You can change this behavior so that your perl is built with a hard coded
-seed with the define
+seed with the define C<NO_HASH_SEED> by providing to Configure
 
-    NO_HASH_SEED
+    -Accflags='-DNO_HASH_SEED'
 
 Note that if you do this you should modify the code in hv_func.h to specify
 your own key. In the future this define may be renamed and replaced with one

--- a/hv_func.h
+++ b/hv_func.h
@@ -34,40 +34,40 @@
 #include "sbox32_hash.h"
 
 #if defined(PERL_HASH_FUNC_SIPHASH)
-# define __PERL_HASH_FUNC "SIPHASH_2_4"
-# define __PERL_HASH_WORD_TYPE U64
-# define __PERL_HASH_WORD_SIZE sizeof(__PERL_HASH_WORD_TYPE)
-# define __PERL_HASH_SEED_BYTES (__PERL_HASH_WORD_SIZE * 2)
-# define __PERL_HASH_STATE_BYTES (__PERL_HASH_WORD_SIZE * 4)
-# define __PERL_HASH_SEED_STATE(seed,state) S_perl_siphash_seed_state(seed,state)
-# define __PERL_HASH_WITH_STATE(state,str,len) S_perl_hash_siphash_2_4_with_state((state),(U8*)(str),(len))
+# define PVT__PERL_HASH_FUNC "SIPHASH_2_4"
+# define PVT__PERL_HASH_WORD_TYPE U64
+# define PVT__PERL_HASH_WORD_SIZE sizeof(PVT__PERL_HASH_WORD_TYPE)
+# define PVT__PERL_HASH_SEED_BYTES (PVT__PERL_HASH_WORD_SIZE * 2)
+# define PVT__PERL_HASH_STATE_BYTES (PVT__PERL_HASH_WORD_SIZE * 4)
+# define PVT__PERL_HASH_SEED_STATE(seed,state) S_perl_siphash_seed_state(seed,state)
+# define PVT__PERL_HASH_WITH_STATE(state,str,len) S_perl_hash_siphash_2_4_with_state((state),(U8*)(str),(len))
 #elif defined(PERL_HASH_FUNC_SIPHASH13)
-# define __PERL_HASH_FUNC "SIPHASH_1_3"
-# define __PERL_HASH_WORD_TYPE U64
-# define __PERL_HASH_WORD_SIZE sizeof(__PERL_HASH_WORD_TYPE)
-# define __PERL_HASH_SEED_BYTES (__PERL_HASH_WORD_SIZE * 2)
-# define __PERL_HASH_STATE_BYTES (__PERL_HASH_WORD_SIZE * 4)
-# define __PERL_HASH_SEED_STATE(seed,state) S_perl_siphash_seed_state(seed,state)
-# define __PERL_HASH_WITH_STATE(state,str,len) S_perl_hash_siphash_1_3_with_state((state),(U8*)(str),(len))
+# define PVT__PERL_HASH_FUNC "SIPHASH_1_3"
+# define PVT__PERL_HASH_WORD_TYPE U64
+# define PVT__PERL_HASH_WORD_SIZE sizeof(PVT__PERL_HASH_WORD_TYPE)
+# define PVT__PERL_HASH_SEED_BYTES (PVT__PERL_HASH_WORD_SIZE * 2)
+# define PVT__PERL_HASH_STATE_BYTES (PVT__PERL_HASH_WORD_SIZE * 4)
+# define PVT__PERL_HASH_SEED_STATE(seed,state) S_perl_siphash_seed_state(seed,state)
+# define PVT__PERL_HASH_WITH_STATE(state,str,len) S_perl_hash_siphash_1_3_with_state((state),(U8*)(str),(len))
 #elif defined(PERL_HASH_FUNC_ZAPHOD32)
-# define __PERL_HASH_FUNC "ZAPHOD32"
-# define __PERL_HASH_WORD_TYPE U32
-# define __PERL_HASH_WORD_SIZE sizeof(__PERL_HASH_WORD_TYPE)
-# define __PERL_HASH_SEED_BYTES (__PERL_HASH_WORD_SIZE * 3)
-# define __PERL_HASH_STATE_BYTES (__PERL_HASH_WORD_SIZE * 3)
-# define __PERL_HASH_SEED_STATE(seed,state) zaphod32_seed_state(seed,state)
-# define __PERL_HASH_WITH_STATE(state,str,len) (U32)zaphod32_hash_with_state((state),(U8*)(str),(len))
+# define PVT__PERL_HASH_FUNC "ZAPHOD32"
+# define PVT__PERL_HASH_WORD_TYPE U32
+# define PVT__PERL_HASH_WORD_SIZE sizeof(PVT__PERL_HASH_WORD_TYPE)
+# define PVT__PERL_HASH_SEED_BYTES (PVT__PERL_HASH_WORD_SIZE * 3)
+# define PVT__PERL_HASH_STATE_BYTES (PVT__PERL_HASH_WORD_SIZE * 3)
+# define PVT__PERL_HASH_SEED_STATE(seed,state) zaphod32_seed_state(seed,state)
+# define PVT__PERL_HASH_WITH_STATE(state,str,len) (U32)zaphod32_hash_with_state((state),(U8*)(str),(len))
 # include "zaphod32_hash.h"
 #endif
 
-#ifndef __PERL_HASH_WITH_STATE
+#ifndef PVT__PERL_HASH_WITH_STATE
 #error "No hash function defined!"
 #endif
-#ifndef __PERL_HASH_SEED_BYTES
-#error "__PERL_HASH_SEED_BYTES not defined"
+#ifndef PVT__PERL_HASH_SEED_BYTES
+#error "PVT__PERL_HASH_SEED_BYTES not defined"
 #endif
-#ifndef __PERL_HASH_FUNC
-#error "__PERL_HASH_FUNC not defined"
+#ifndef PVT__PERL_HASH_FUNC
+#error "PVT__PERL_HASH_FUNC not defined"
 #endif
 
 /* Some siphash static functions are needed by XS::APItest even when
@@ -76,56 +76,56 @@
 */
 #include "perl_siphash.h"
 
-#define __PERL_HASH_SEED_roundup(x, y)   ( ( ( (x) + ( (y) - 1 ) ) / (y) ) * (y) )
-#define _PERL_HASH_SEED_roundup(x) __PERL_HASH_SEED_roundup(x,__PERL_HASH_WORD_SIZE)
+#define PVT__PERL_HASH_SEED_roundup(x, y)   ( ( ( (x) + ( (y) - 1 ) ) / (y) ) * (y) )
+#define PVT_PERL_HASH_SEED_roundup(x) PVT__PERL_HASH_SEED_roundup(x,PVT__PERL_HASH_WORD_SIZE)
 
 #define PL_hash_seed ((U8 *)PL_hash_seed_w)
 #define PL_hash_state ((U8 *)PL_hash_state_w)
 
 #if PERL_HASH_USE_SBOX32_ALSO != 1
-# define _PERL_HASH_FUNC                        __PERL_HASH_FUNC
-# define _PERL_HASH_SEED_BYTES                  __PERL_HASH_SEED_BYTES
-# define _PERL_HASH_STATE_BYTES                 __PERL_HASH_STATE_BYTES
-# define _PERL_HASH_SEED_STATE(seed,state)      __PERL_HASH_SEED_STATE(seed,state)
-# define _PERL_HASH_WITH_STATE(state,str,len)   __PERL_HASH_WITH_STATE(state,str,len)
+# define PVT_PERL_HASH_FUNC                        PVT__PERL_HASH_FUNC
+# define PVT_PERL_HASH_SEED_BYTES                  PVT__PERL_HASH_SEED_BYTES
+# define PVT_PERL_HASH_STATE_BYTES                 PVT__PERL_HASH_STATE_BYTES
+# define PVT_PERL_HASH_SEED_STATE(seed,state)      PVT__PERL_HASH_SEED_STATE(seed,state)
+# define PVT_PERL_HASH_WITH_STATE(state,str,len)   PVT__PERL_HASH_WITH_STATE(state,str,len)
 #else
 
-#define _PERL_HASH_FUNC         "SBOX32_WITH_" __PERL_HASH_FUNC
+#define PVT_PERL_HASH_FUNC         "SBOX32_WITH_" PVT__PERL_HASH_FUNC
 /* note the 4 in the below code comes from the fact the seed to initialize the SBOX is 128 bits */
-#define _PERL_HASH_SEED_BYTES   ( __PERL_HASH_SEED_BYTES + (int)( 4 * sizeof(U32)) )
+#define PVT_PERL_HASH_SEED_BYTES   ( PVT__PERL_HASH_SEED_BYTES + (int)( 4 * sizeof(U32)) )
 
-#define _PERL_HASH_STATE_BYTES  \
-    ( __PERL_HASH_STATE_BYTES + ( ( 1 + ( 256 * SBOX32_MAX_LEN ) ) * sizeof(U32) ) )
+#define PVT_PERL_HASH_STATE_BYTES  \
+    ( PVT__PERL_HASH_STATE_BYTES + ( ( 1 + ( 256 * SBOX32_MAX_LEN ) ) * sizeof(U32) ) )
 
-#define _PERL_HASH_SEED_STATE(seed,state) STMT_START {                                      \
-    __PERL_HASH_SEED_STATE(seed,state);                                                     \
-    sbox32_seed_state128(seed + __PERL_HASH_SEED_BYTES, state + __PERL_HASH_STATE_BYTES);    \
+#define PVT_PERL_HASH_SEED_STATE(seed,state) STMT_START {                                      \
+    PVT__PERL_HASH_SEED_STATE(seed,state);                                                     \
+    sbox32_seed_state128(seed + PVT__PERL_HASH_SEED_BYTES, state + PVT__PERL_HASH_STATE_BYTES);    \
 } STMT_END
 
-#define _PERL_HASH_WITH_STATE(state,str,len)                                            \
+#define PVT_PERL_HASH_WITH_STATE(state,str,len)                                            \
     (LIKELY(len <= SBOX32_MAX_LEN)                                                      \
-        ? sbox32_hash_with_state((state + __PERL_HASH_STATE_BYTES),(U8*)(str),(len))    \
-        : __PERL_HASH_WITH_STATE((state),(str),(len)))
+        ? sbox32_hash_with_state((state + PVT__PERL_HASH_STATE_BYTES),(U8*)(str),(len))    \
+        : PVT__PERL_HASH_WITH_STATE((state),(str),(len)))
 
 #endif
 
 #define PERL_HASH_WITH_SEED(seed,hash,str,len) \
     (hash) = S_perl_hash_with_seed((const U8 *) seed, (const U8 *) str,len)
 #define PERL_HASH_WITH_STATE(state,hash,str,len) \
-    (hash) = _PERL_HASH_WITH_STATE((state),(U8*)(str),(len))
+    (hash) = PVT_PERL_HASH_WITH_STATE((state),(U8*)(str),(len))
 
-#define PERL_HASH_SEED_STATE(seed,state) _PERL_HASH_SEED_STATE(seed,state)
-#define PERL_HASH_SEED_BYTES _PERL_HASH_SEED_roundup(_PERL_HASH_SEED_BYTES)
-#define PERL_HASH_STATE_BYTES _PERL_HASH_SEED_roundup(_PERL_HASH_STATE_BYTES)
-#define PERL_HASH_FUNC        _PERL_HASH_FUNC
+#define PERL_HASH_SEED_STATE(seed,state) PVT_PERL_HASH_SEED_STATE(seed,state)
+#define PERL_HASH_SEED_BYTES PVT_PERL_HASH_SEED_roundup(PVT_PERL_HASH_SEED_BYTES)
+#define PERL_HASH_STATE_BYTES PVT_PERL_HASH_SEED_roundup(PVT_PERL_HASH_STATE_BYTES)
+#define PERL_HASH_FUNC        PVT_PERL_HASH_FUNC
 
-#define PERL_HASH_SEED_WORDS (PERL_HASH_SEED_BYTES/__PERL_HASH_WORD_SIZE)
-#define PERL_HASH_STATE_WORDS (PERL_HASH_STATE_BYTES/__PERL_HASH_WORD_SIZE)
+#define PERL_HASH_SEED_WORDS (PERL_HASH_SEED_BYTES/PVT__PERL_HASH_WORD_SIZE)
+#define PERL_HASH_STATE_WORDS (PERL_HASH_STATE_BYTES/PVT__PERL_HASH_WORD_SIZE)
 
 #ifdef PERL_USE_SINGLE_CHAR_HASH_CACHE
 #define PERL_HASH(state,str,len) \
     (hash) = ((len) < 2 ? ( (len) == 0 ? PL_hash_chars[256] : PL_hash_chars[(U8)(str)[0]] ) \
-                       : _PERL_HASH_WITH_STATE(PL_hash_state,(U8*)(str),(len)))
+                       : PVT_PERL_HASH_WITH_STATE(PL_hash_state,(U8*)(str),(len)))
 #else
 #define PERL_HASH(hash,str,len) \
     PERL_HASH_WITH_STATE(PL_hash_state,hash,(U8*)(str),(len))
@@ -162,9 +162,9 @@
 
 PERL_STATIC_INLINE U32
 S_perl_hash_with_seed(const U8 * seed, const U8 *str, STRLEN len) {
-    __PERL_HASH_WORD_TYPE state[PERL_HASH_STATE_WORDS];
-    _PERL_HASH_SEED_STATE(seed,(U8*)state);
-    return _PERL_HASH_WITH_STATE((U8*)state,str,len);
+    PVT__PERL_HASH_WORD_TYPE state[PERL_HASH_STATE_WORDS];
+    PVT_PERL_HASH_SEED_STATE(seed,(U8*)state);
+    return PVT_PERL_HASH_WITH_STATE((U8*)state,str,len);
 }
 
 #endif /*compile once*/

--- a/hv_func.h
+++ b/hv_func.h
@@ -23,7 +23,19 @@
 #endif
 
 #ifndef PERL_HASH_USE_SBOX32_ALSO
-#define PERL_HASH_USE_SBOX32_ALSO 1
+#  if defined(PERL_HASH_USE_SBOX32) || !defined(PERL_HASH_NO_SBOX32)
+#    define PERL_HASH_USE_SBOX32_ALSO 1
+#  else
+#    define PERL_HASH_USE_SBOX32_ALSO 0
+#  endif
+#endif
+
+#undef PERL_HASH_USE_SBOX32
+#undef PERL_HASH_NO_SBOX32
+#if PERL_HASH_USE_SBOX32_ALSO != 0
+#  define PERL_HASH_USE_SBOX32
+#else
+#  define PERL_HASH_NO_SBOX32
 #endif
 
 #ifndef SBOX32_MAX_LEN
@@ -34,6 +46,7 @@
 #include "sbox32_hash.h"
 
 #if defined(PERL_HASH_FUNC_SIPHASH)
+# define PERL_HASH_FUNC_DEFINE "PERL_HASH_FUNC_SIPHASH"
 # define PVT__PERL_HASH_FUNC "SIPHASH_2_4"
 # define PVT__PERL_HASH_WORD_TYPE U64
 # define PVT__PERL_HASH_WORD_SIZE sizeof(PVT__PERL_HASH_WORD_TYPE)
@@ -42,6 +55,7 @@
 # define PVT__PERL_HASH_SEED_STATE(seed,state) S_perl_siphash_seed_state(seed,state)
 # define PVT__PERL_HASH_WITH_STATE(state,str,len) S_perl_hash_siphash_2_4_with_state((state),(U8*)(str),(len))
 #elif defined(PERL_HASH_FUNC_SIPHASH13)
+# define PERL_HASH_FUNC_DEFINE "PERL_HASH_FUNC_SIPHASH13"
 # define PVT__PERL_HASH_FUNC "SIPHASH_1_3"
 # define PVT__PERL_HASH_WORD_TYPE U64
 # define PVT__PERL_HASH_WORD_SIZE sizeof(PVT__PERL_HASH_WORD_TYPE)
@@ -50,6 +64,7 @@
 # define PVT__PERL_HASH_SEED_STATE(seed,state) S_perl_siphash_seed_state(seed,state)
 # define PVT__PERL_HASH_WITH_STATE(state,str,len) S_perl_hash_siphash_1_3_with_state((state),(U8*)(str),(len))
 #elif defined(PERL_HASH_FUNC_ZAPHOD32)
+# define PERL_HASH_FUNC_DEFINE "PERL_HASH_FUNC_ZAPHOD32"
 # define PVT__PERL_HASH_FUNC "ZAPHOD32"
 # define PVT__PERL_HASH_WORD_TYPE U32
 # define PVT__PERL_HASH_WORD_SIZE sizeof(PVT__PERL_HASH_WORD_TYPE)
@@ -82,7 +97,7 @@
 #define PL_hash_seed ((U8 *)PL_hash_seed_w)
 #define PL_hash_state ((U8 *)PL_hash_state_w)
 
-#if PERL_HASH_USE_SBOX32_ALSO != 1
+#if PERL_HASH_USE_SBOX32_ALSO == 0
 # define PVT_PERL_HASH_FUNC                        PVT__PERL_HASH_FUNC
 # define PVT_PERL_HASH_SEED_BYTES                  PVT__PERL_HASH_SEED_BYTES
 # define PVT_PERL_HASH_STATE_BYTES                 PVT__PERL_HASH_STATE_BYTES

--- a/perl.c
+++ b/perl.c
@@ -1935,15 +1935,14 @@ S_Internals_V(pTHX_ CV *cv)
 #endif
     const int entries = 3 + local_patch_count;
     int i;
+    /* NOTE - This list must remain sorted. Do not put any settings here
+     * which affect binary compatibility */
     static const char non_bincompat_options[] =
 #  ifdef DEBUGGING
                              " DEBUGGING"
 #  endif
 #  ifdef NO_MATHOMS
                              " NO_MATHOMS"
-#  endif
-#  ifdef NO_HASH_SEED
-                             " NO_HASH_SEED"
 #  endif
 #  ifdef NO_TAINT_SUPPORT
                              " NO_TAINT_SUPPORT"
@@ -1959,16 +1958,6 @@ S_Internals_V(pTHX_ CV *cv)
 #  endif
 #  ifdef PERL_EXTERNAL_GLOB
                              " PERL_EXTERNAL_GLOB"
-#  endif
-#  ifdef PERL_HASH_FUNC_DEFINE
-/* note that this is different from the others, PERL_HASH_FUNC_DEFINE
- * is a string which says which define was defined. */
-                             " " PERL_HASH_FUNC_DEFINE
-#  endif
-#  ifdef PERL_HASH_USE_SBOX32
-                             " PERL_HASH_USE_SBOX32"
-#  else
-                             " PERL_HASH_NO_SBOX32"
 #  endif
 #  ifdef PERL_IS_MINIPERL
                              " PERL_IS_MINIPERL"

--- a/perl.c
+++ b/perl.c
@@ -1923,6 +1923,7 @@ perl_parse(pTHXx_ XSINIT_t xsinit, int argc, char **argv, char **env)
 
 /* What this returns is subject to change.  Use the public interface in Config.
  */
+
 static void
 S_Internals_V(pTHX_ CV *cv)
 {
@@ -1959,29 +1960,15 @@ S_Internals_V(pTHX_ CV *cv)
 #  ifdef PERL_EXTERNAL_GLOB
                              " PERL_EXTERNAL_GLOB"
 #  endif
-#  ifdef PERL_HASH_FUNC_SIPHASH
-                             " PERL_HASH_FUNC_SIPHASH"
+#  ifdef PERL_HASH_FUNC_DEFINE
+/* note that this is different from the others, PERL_HASH_FUNC_DEFINE
+ * is a string which says which define was defined. */
+                             " " PERL_HASH_FUNC_DEFINE
 #  endif
-#  ifdef PERL_HASH_FUNC_SDBM
-                             " PERL_HASH_FUNC_SDBM"
-#  endif
-#  ifdef PERL_HASH_FUNC_DJB2
-                             " PERL_HASH_FUNC_DJB2"
-#  endif
-#  ifdef PERL_HASH_FUNC_SUPERFAST
-                             " PERL_HASH_FUNC_SUPERFAST"
-#  endif
-#  ifdef PERL_HASH_FUNC_MURMUR3
-                             " PERL_HASH_FUNC_MURMUR3"
-#  endif
-#  ifdef PERL_HASH_FUNC_ONE_AT_A_TIME
-                             " PERL_HASH_FUNC_ONE_AT_A_TIME"
-#  endif
-#  ifdef PERL_HASH_FUNC_ONE_AT_A_TIME_HARD
-                             " PERL_HASH_FUNC_ONE_AT_A_TIME_HARD"
-#  endif
-#  ifdef PERL_HASH_FUNC_ONE_AT_A_TIME_OLD
-                             " PERL_HASH_FUNC_ONE_AT_A_TIME_OLD"
+#  ifdef PERL_HASH_USE_SBOX32
+                             " PERL_HASH_USE_SBOX32"
+#  else
+                             " PERL_HASH_NO_SBOX32"
 #  endif
 #  ifdef PERL_IS_MINIPERL
                              " PERL_IS_MINIPERL"
@@ -2019,6 +2006,7 @@ S_Internals_V(pTHX_ CV *cv)
 #  ifdef PERL_USE_SAFE_PUTENV
                              " PERL_USE_SAFE_PUTENV"
 #  endif
+
 #  ifdef PERL_USE_UNSHARED_KEYS_IN_LARGE_HASHES
                              " PERL_USE_UNSHARED_KEYS_IN_LARGE_HASHES"
 #  endif

--- a/perl.h
+++ b/perl.h
@@ -5682,6 +5682,9 @@ EXTCONST char PL_bincompat_options[] =
 #  ifdef MYMALLOC
                              " MYMALLOC"
 #  endif
+#  ifdef NO_HASH_SEED
+                             " NO_HASH_SEED"
+#  endif
 #  ifdef PERLIO_LAYERS
                              " PERLIO_LAYERS"
 #  endif
@@ -5690,6 +5693,16 @@ EXTCONST char PL_bincompat_options[] =
 #  endif
 #  ifdef PERL_DEBUG_READONLY_OPS
                              " PERL_DEBUG_READONLY_OPS"
+#  endif
+#  ifdef PERL_HASH_FUNC_DEFINE
+/* note that this is different from the others, PERL_HASH_FUNC_DEFINE
+ * is a string which says which define was defined. */
+                             " " PERL_HASH_FUNC_DEFINE
+#  endif
+#  ifdef PERL_HASH_USE_SBOX32
+                             " PERL_HASH_USE_SBOX32"
+#  else
+                             " PERL_HASH_NO_SBOX32"
 #  endif
 #  ifdef PERL_IMPLICIT_SYS
                              " PERL_IMPLICIT_SYS"

--- a/perlvars.h
+++ b/perlvars.h
@@ -260,9 +260,9 @@ PERLVAR(G, malloc_mutex, perl_mutex)	/* Mutex for malloc */
 #endif
 
 PERLVARI(G, hash_seed_set, bool, FALSE)	/* perl.c */
-PERLVARA(G, hash_seed_w, PERL_HASH_SEED_WORDS, __PERL_HASH_WORD_TYPE) /* perl.c and hv.h */
+PERLVARA(G, hash_seed_w, PERL_HASH_SEED_WORDS, PVT__PERL_HASH_WORD_TYPE) /* perl.c and hv.h */
 #if defined(PERL_HASH_STATE_BYTES)
-PERLVARA(G, hash_state_w, PERL_HASH_STATE_WORDS, __PERL_HASH_WORD_TYPE) /* perl.c and hv.h */
+PERLVARA(G, hash_state_w, PERL_HASH_STATE_WORDS, PVT__PERL_HASH_WORD_TYPE) /* perl.c and hv.h */
 #endif
 #if defined(PERL_USE_SINGLE_CHAR_HASH_CACHE)
 PERLVARA(G, hash_chars, (1+256) * sizeof(U32), unsigned char) /* perl.c and hv.h */


### PR DESCRIPTION
hv_func.h is chocker full of reserved identifiers, this renames them so they start with PVT and not underbars.

perl.c is chocker full of define checks for non-existent defines related to the hash function. This removes them. At the same time it replaces the fragile mechanism used currently with something a little more likely to be future proof.
