### PR TITLE
Sync JSON::PP with CPAN 4.11

### DIFF
--- a/META.json
+++ b/META.json
@@ -119,5 +119,5 @@
       }
    },
    "version" : "5.037003",
-   "x_serialization_backend" : "JSON::PP version 4.10"
+   "x_serialization_backend" : "JSON::PP version 4.11"
 }

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -683,7 +683,7 @@ use File::Glob qw(:case);
     },
 
     'JSON::PP' => {
-        'DISTRIBUTION' => 'ISHIGAKI/JSON-PP-4.10.tar.gz',
+        'DISTRIBUTION' => 'ISHIGAKI/JSON-PP-4.11.tar.gz',
         'FILES'        => q[cpan/JSON-PP],
     },
 

--- a/cpan/JSON-PP/lib/JSON/PP/Boolean.pm
+++ b/cpan/JSON-PP/lib/JSON/PP/Boolean.pm
@@ -10,7 +10,7 @@ overload::import('overload',
     fallback => 1,
 );
 
-$JSON::PP::Boolean::VERSION = '4.10';
+$JSON::PP::Boolean::VERSION = '4.11';
 
 1;
 

--- a/cpan/JSON-PP/t/003_types.t
+++ b/cpan/JSON-PP/t/003_types.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
-BEGIN { plan tests => 76 + 2 };
+BEGIN { plan tests => 78 + 2 };
 
 BEGIN { $ENV{PERL_JSON_BACKEND} = 0; }
 
@@ -46,6 +46,14 @@ ok ('[false]' eq encode_json [\0]);
 ok ('[null]'  eq encode_json [undef]);
 ok ('[true]'  eq encode_json [JSON::PP::true]);
 ok ('[false]' eq encode_json [JSON::PP::false]);
+
+SKIP: {
+  skip "core booleans not supported", 2
+    unless JSON::PP->can("CORE_BOOL") && JSON::PP::CORE_BOOL();
+
+  ok ('[true]'  eq encode_json [!!1]);
+  ok ('[false]' eq encode_json [!!0]);
+}
 
 for my $v (1, 2, 3, 5, -1, -2, -3, -4, 100, 1000, 10000, -999, -88, -7, 7, 88, 999, -1e5, 1e6, 1e7, 1e8) {
    ok ($v == ((decode_json "[$v]")->[0]));


### PR DESCRIPTION
From Changes:

  - restored core boolean support

This changes how boolean values are serialized to use true or false for
values that perl thinks are booleans. This is likely to have some impact
on code that is expecting a specific encoding of structures including
these values.