### PR TITLE
Make PerlIO::get_layers accept IO references #20058

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -381,6 +381,15 @@ assigning to an C<:lvalue> subroutine.
 XXX Important bug fixes in the core language are summarized here.  Bug fixes in
 files in F<ext/> and F<lib/> are best summarized in L</Modules and Pragmata>.
 
+=over 4
+
+=item * PerlIO::get_layers will now accept IO references too
+
+Previously it would only take glob references or names of globs. Now it will
+also accept IO references.
+
+=back
+
 [ List each fix as an =item entry ]
 
 =over 4

--- a/t/io/layers.t
+++ b/t/io/layers.t
@@ -34,7 +34,7 @@ if (${^UNICODE} & 1) {
 } else {
     $UTF8_STDIN = 0;
 }
-my $NTEST = 60 - (($DOSISH || !$FASTSTDIO) ? 7 : 0) - ($DOSISH ? 7 : 0)
+my $NTEST = 62 - (($DOSISH || !$FASTSTDIO) ? 7 : 0) - ($DOSISH ? 7 : 0)
     + $UTF8_STDIN;
 
 sub PerlIO::F_UTF8 () { 0x00008000 } # from perliol.h
@@ -190,6 +190,10 @@ __EOH__
     binmode(F);
 
     check([ PerlIO::get_layers(F) ],
+	  [ "stdio" ],
+	  "binmode");
+
+    check([ PerlIO::get_layers(*F{IO}) ],
 	  [ "stdio" ],
 	  "binmode");
 


### PR DESCRIPTION
`PerlIO::get_layers` used to not work with IO references, now it does.

```
perl -MPerlIO -E 'my @ls = PerlIO::get_layers(*STDOUT{IO}); say("[@ls]")'
```

This fixes #20058