### PR TITLE
Ensure cmd.exe is used in pl2bat tests

### DIFF
--- a/cpan/ExtUtils-PL2Bat/t/make_executable.t
+++ b/cpan/ExtUtils-PL2Bat/t/make_executable.t
@@ -13,6 +13,11 @@ my @test_vals = ( 0, 1, 2, 3, -1, -2, 65535, 65536, 65537, 47, 100, 200, 255, 25
 
 plan($OSNAME eq 'MSWin32' ? ( tests => (($#test_vals+1)*5)+2 ) : ( skip_all => 'Only usable on Windows' ));
 
+# the method of execution of the test script is geared to cmd.exe so ensure
+# this is used in case the user have some non-standard shell.
+# E.g. TCC/4NT doesn't quite handle the invocation correctly producing errors.
+$ENV{COMSPEC} = "$ENV{SystemRoot}\\System32\\cmd.exe";
+
 my $perl_in_fname = 'test_perl_source';
 
 open my $out, '>', $perl_in_fname or die qq{Couldn't create source file ("$perl_in_fname"): $!};


### PR DESCRIPTION
Tests done in cpan/ExtUtils-PL2Bat/t/make_executable.t are geared to work with cmd.exe; a user having something else as the COMSPEC (e.g. in my case, TCC (see [jpsoft.com](jpsoft.com)) may well get confusing errors. Hence, ensure that COMSPEC is set to cmd.exe.