### PR TITLE
Use optype casting macros

### DIFF
--- a/op.c
+++ b/op.c
@@ -1386,7 +1386,7 @@ S_find_and_forget_pmops(pTHX_ OP *o)
         case OP_SPLIT:
         case OP_MATCH:
         case OP_QR:
-            forget_pmop((PMOP*)o);
+            forget_pmop(cPMOPo);
         }
 
         if (o->op_flags & OPf_KIDS) {
@@ -7061,7 +7061,7 @@ Perl_pmruntime(pTHX_ OP *o, OP *expr, OP *repl, UV flags, I32 floor)
     }
 
     PL_hints |= HINT_BLOCK_SCOPE;
-    pm = (PMOP*)o;
+    pm = cPMOPo;
     assert(floor==0 || (pm->op_pmflags & PMf_HAS_CV));
 
     if (is_compiletime) {
@@ -7147,7 +7147,7 @@ Perl_pmruntime(pTHX_ OP *o, OP *expr, OP *repl, UV flags, I32 floor)
                  * squirrel away expr in op_code_list without the peephole
                  * optimiser etc processing it for a second time */
                 OP *qr = newPMOP(OP_QR, 0);
-                ((PMOP*)qr)->op_code_list = expr;
+                cPMOPx(qr)->op_code_list = expr;
 
                 /* handle the implicit sub{} wrapped round the qr/(?{..})/ */
                 SvREFCNT_inc_simple_void(PL_compcv);
@@ -8076,11 +8076,11 @@ Perl_newASSIGNOP(pTHX_ I32 flags, OP *left, I32 optype, OP *right)
                 OP *tmpop;
                 if (gvop) {
 #ifdef USE_ITHREADS
-                    ((PMOP*)right)->op_pmreplrootu.op_pmtargetoff
+                    cPMOPx(right)->op_pmreplrootu.op_pmtargetoff
                         = cPADOPx(gvop)->op_padix;
                     cPADOPx(gvop)->op_padix = 0;	/* steal it */
 #else
-                    ((PMOP*)right)->op_pmreplrootu.op_pmtargetgv
+                    cPMOPx(right)->op_pmreplrootu.op_pmtargetgv
                         = MUTABLE_GV(cSVOPx(gvop)->op_sv);
                     cSVOPx(gvop)->op_sv = NULL;	/* steal it */
 #endif
@@ -8088,7 +8088,7 @@ Perl_newASSIGNOP(pTHX_ I32 flags, OP *left, I32 optype, OP *right)
                         left->op_private & OPpOUR_INTRO;
                 }
                 else {
-                    ((PMOP*)right)->op_pmreplrootu.op_pmtargetoff = left->op_targ;
+                    cPMOPx(right)->op_pmreplrootu.op_pmtargetoff = left->op_targ;
                     left->op_targ = 0;	/* steal it */
                     right->op_private |= OPpSPLIT_LEX;
                 }
@@ -13264,7 +13264,7 @@ Perl_ck_split(pTHX_ OP *o)
 
     assert(kid->op_type == OP_MATCH || kid->op_type == OP_SPLIT);
 
-    if (((PMOP *)kid)->op_pmflags & PMf_GLOBAL) {
+    if (kPMOP->op_pmflags & PMf_GLOBAL) {
       Perl_ck_warner(aTHX_ packWARN(WARN_REGEXP),
                      "Use of /g modifier is meaningless in split");
     }

--- a/op.c
+++ b/op.c
@@ -8818,7 +8818,7 @@ Perl_newLOOPOP(pTHX_ I32 flags, I32 debuggable, OP *expr, OP *block)
     {
         assert(cUNOPo->op_first->op_type == OP_AND
             || cUNOPo->op_first->op_type == OP_OR);
-        o->op_next = ((LOGOP*)cUNOPo->op_first)->op_other;
+        o->op_next = cLOGOPx(cUNOPo->op_first)->op_other;
     }
 
     if (o == listop)
@@ -9107,7 +9107,7 @@ Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
          * treated as min/max values by 'pp_enteriter'.
          */
         const UNOP* const flip = (UNOP*)((UNOP*)cBINOPx(expr)->op_first)->op_first;
-        LOGOP* const range = (LOGOP*) flip->op_first;
+        LOGOP* const range = cLOGOPx(flip->op_first);
         OP* const left  = range->op_first;
         OP* const right = OpSIBLING(left);
         LISTOP* listop;

--- a/op.c
+++ b/op.c
@@ -2287,11 +2287,11 @@ Perl_scalarvoid(pTHX_ OP *arg)
             if ((o->op_private & ~OPpASSIGN_BACKWARDS) != 2)
                 break;
 
-            rv2gv = ((BINOP *)o)->op_last;
+            rv2gv = cBINOPo->op_last;
             if (!rv2gv || rv2gv->op_type != OP_RV2GV)
                 break;
 
-            refgen = (UNOP *)((BINOP *)o)->op_first;
+            refgen = (UNOP *)cBINOPo->op_first;
 
             if (!refgen || (refgen->op_type != OP_REFGEN
                             && refgen->op_type != OP_SREFGEN))
@@ -5607,7 +5607,7 @@ Perl_newBINOP(pTHX_ I32 type, I32 flags, OP *first, OP *last)
     if (binop->op_last)
         OpLASTSIB_set(binop->op_last, (OP*)binop);
 
-    binop = (BINOP*)CHECKOP(type, binop);
+    binop = (BINOP*) CHECKOP(type, binop);
     if (binop->op_next || binop->op_type != (OPCODE)type)
         return (OP*)binop;
 
@@ -9100,13 +9100,13 @@ Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
     }
     else if (expr->op_type == OP_NULL &&
              (expr->op_flags & OPf_KIDS) &&
-             ((BINOP*)expr)->op_first->op_type == OP_FLOP)
+             cBINOPx(expr)->op_first->op_type == OP_FLOP)
     {
         /* Basically turn for($x..$y) into the same as for($x,$y), but we
          * set the STACKED flag to indicate that these values are to be
          * treated as min/max values by 'pp_enteriter'.
          */
-        const UNOP* const flip = (UNOP*)((UNOP*)((BINOP*)expr)->op_first)->op_first;
+        const UNOP* const flip = (UNOP*)((UNOP*)cBINOPx(expr)->op_first)->op_first;
         LOGOP* const range = (LOGOP*) flip->op_first;
         OP* const left  = range->op_first;
         OP* const right = OpSIBLING(left);
@@ -12230,7 +12230,7 @@ Perl_ck_fun(pTHX_ OP *o)
                                      || kid->op_type == OP_HELEM)
                             {
                                  OP *firstop;
-                                 OP *op = ((BINOP*)kid)->op_first;
+                                 OP *op = kBINOP->op_first;
                                  name = NULL;
                                  if (op) {
                                       SV *tmpstr = NULL;

--- a/peep.c
+++ b/peep.c
@@ -3560,7 +3560,7 @@ Perl_rpeep(pTHX_ OP *o)
                 )
                 && (o->op_next->op_flags & OPf_WANT) == OPf_WANT_VOID
             ) {
-                o->op_next = ((LOGOP*)o->op_next)->op_other;
+                o->op_next = cLOGOPx(o->op_next)->op_other;
             }
             DEFER(cLOGOP->op_other);
             o->op_opt = 1;

--- a/peep.c
+++ b/peep.c
@@ -1317,7 +1317,7 @@ S_finalize_op(pTHX_ OP* o)
                              ? kid
                              : OpSIBLING(kLISTOP->op_first));
 
-            rop = (UNOP*)((LISTOP*)o)->op_last;
+            rop = (UNOP*)(cLISTOPo->op_last);
 
         check_keys:
             if (o->op_private & OPpLVAL_INTRO || rop->op_type != OP_RV2HV)
@@ -3687,11 +3687,11 @@ Perl_rpeep(pTHX_ OP *o)
             if (o->op_private & OPpSORT_INPLACE)
                 break;
 
-            enter = (LISTOP *) o->op_next;
+            enter = cLISTOPx(o->op_next);
             if (!enter)
                 break;
             if (enter->op_type == OP_NULL) {
-                enter = (LISTOP *) enter->op_next;
+                enter = cLISTOPx(enter->op_next);
                 if (!enter)
                     break;
             }
@@ -3699,11 +3699,11 @@ Perl_rpeep(pTHX_ OP *o)
                for (...) just has an OP_GV.  */
             if (enter->op_type == OP_GV) {
                 gvop = (OP *) enter;
-                enter = (LISTOP *) enter->op_next;
+                enter = cLISTOPx(enter->op_next);
                 if (!enter)
                     break;
                 if (enter->op_type == OP_RV2GV) {
-                  enter = (LISTOP *) enter->op_next;
+                  enter = cLISTOPx(enter->op_next);
                   if (!enter)
                     break;
                 }
@@ -3721,7 +3721,7 @@ Perl_rpeep(pTHX_ OP *o)
                 || expushmark->op_targ != OP_PUSHMARK)
                 break;
 
-            exlist = (LISTOP *) OpSIBLING(expushmark);
+            exlist = cLISTOPx(OpSIBLING(expushmark));
             if (!exlist || exlist->op_type != OP_NULL
                 || exlist->op_targ != OP_LIST)
                 break;
@@ -3741,11 +3741,11 @@ Perl_rpeep(pTHX_ OP *o)
                 break;
             }
 
-            ourmark = ((LISTOP *)o)->op_first;
+            ourmark = cLISTOPo->op_first;
             if (!ourmark || ourmark->op_type != OP_PUSHMARK)
                 break;
 
-            ourlast = ((LISTOP *)o)->op_last;
+            ourlast = cLISTOPo->op_last;
             if (!ourlast || ourlast->op_next != o)
                 break;
 

--- a/peep.c
+++ b/peep.c
@@ -1296,7 +1296,7 @@ S_finalize_op(pTHX_ OP* o)
             if ((key_op = cSVOPx(cBINOPo->op_last))->op_type != OP_CONST)
                 break;
 
-            rop = (UNOP*)cBINOPo->op_first;
+            rop = cUNOPx(cBINOPo->op_first);
 
             goto check_keys;
 
@@ -1317,7 +1317,7 @@ S_finalize_op(pTHX_ OP* o)
                              ? kid
                              : OpSIBLING(kLISTOP->op_first));
 
-            rop = (UNOP*)(cLISTOPo->op_last);
+            rop = cUNOPx(cLISTOPo->op_last);
 
         check_keys:
             if (o->op_private & OPpLVAL_INTRO || rop->op_type != OP_RV2HV)
@@ -2072,7 +2072,7 @@ S_maybe_multideref(pTHX_ OP *start, OP *orig_o, UV orig_action, U8 hints)
                                    || helem_op->op_type == OP_NULL
                                    || pass == 0);
                             if (helem_op->op_type == OP_HELEM) {
-                                rop = (UNOP*)(cBINOPx(helem_op)->op_first);
+                                rop = cUNOPx(cBINOPx(helem_op)->op_first);
                                 if (   helem_op->op_private & OPpLVAL_INTRO
                                     || rop->op_type != OP_RV2HV
                                 )

--- a/peep.c
+++ b/peep.c
@@ -1293,10 +1293,10 @@ S_finalize_op(pTHX_ OP* o)
             SVOP *key_op;
             OP *kid;
 
-            if ((key_op = cSVOPx(((BINOP*)o)->op_last))->op_type != OP_CONST)
+            if ((key_op = cSVOPx(cBINOPo->op_last))->op_type != OP_CONST)
                 break;
 
-            rop = (UNOP*)((BINOP*)o)->op_first;
+            rop = (UNOP*)cBINOPo->op_first;
 
             goto check_keys;
 
@@ -2072,7 +2072,7 @@ S_maybe_multideref(pTHX_ OP *start, OP *orig_o, UV orig_action, U8 hints)
                                    || helem_op->op_type == OP_NULL
                                    || pass == 0);
                             if (helem_op->op_type == OP_HELEM) {
-                                rop = (UNOP*)(((BINOP*)helem_op)->op_first);
+                                rop = (UNOP*)(cBINOPx(helem_op)->op_first);
                                 if (   helem_op->op_private & OPpLVAL_INTRO
                                     || rop->op_type != OP_RV2HV
                                 )

--- a/peep.c
+++ b/peep.c
@@ -1313,7 +1313,7 @@ S_finalize_op(pTHX_ OP* o)
                 break;
             }
 
-            key_op = (SVOP*)(kid->op_type == OP_CONST
+            key_op = cSVOPx(kid->op_type == OP_CONST
                              ? kid
                              : OpSIBLING(kLISTOP->op_first));
 
@@ -3465,7 +3465,7 @@ Perl_rpeep(pTHX_ OP *o)
                     pop->op_next->op_type == OP_AELEM &&
                     !(pop->op_next->op_private &
                       (OPpLVAL_INTRO|OPpLVAL_DEFER|OPpDEREF|OPpMAYBE_LVSUB)) &&
-                    (i = SvIV(((SVOP*)pop)->op_sv)) >= -128 && i <= 127)
+                    (i = SvIV(cSVOPx(pop)->op_sv)) >= -128 && i <= 127)
                 {
                     GV *gv;
                     if (cSVOPx(pop)->op_private & OPpCONST_STRICT)

--- a/pp.c
+++ b/pp.c
@@ -6059,7 +6059,7 @@ PP(pp_split)
     const bool do_utf8 = DO_UTF8(sv);
     const bool in_uni_8_bit = IN_UNI_8_BIT;
     const char *strend = s + len;
-    PMOP *pm = cPMOPx(PL_op);
+    PMOP *pm = cPMOP;
     REGEXP *rx;
     SV *dstr;
     const char *m;

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -78,7 +78,7 @@ PP(pp_regcreset)
 PP(pp_regcomp)
 {
     dSP;
-    PMOP *pm = (PMOP*)cLOGOP->op_other;
+    PMOP *pm = cPMOPx(cLOGOP->op_other);
     SV **args;
     int nargs;
     REGEXP *re = NULL;
@@ -189,7 +189,7 @@ PP(pp_substcont)
 {
     dSP;
     PERL_CONTEXT *cx = CX_CUR();
-    PMOP * const pm = (PMOP*) cLOGOP->op_other;
+    PMOP * const pm = cPMOPx(cLOGOP->op_other);
     SV * const dstr = cx->sb_dstr;
     char *s = cx->sb_s;
     char *m = cx->sb_m;
@@ -4957,7 +4957,7 @@ PP(pp_leavegiven)
 STATIC PMOP *
 S_make_matcher(pTHX_ REGEXP *re)
 {
-    PMOP *matcher = (PMOP *) newPMOP(OP_MATCH, OPf_WANT_SCALAR | OPf_STACKED);
+    PMOP *matcher = cPMOPx(newPMOP(OP_MATCH, OPf_WANT_SCALAR | OPf_STACKED));
 
     PERL_ARGS_ASSERT_MAKE_MATCHER;
 

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -998,7 +998,7 @@ PP(pp_grepstart)
     PUTBACK;
     if (PL_op->op_type == OP_MAPSTART)
         Perl_pp_pushmark(aTHX);			/* push top */
-    return ((LOGOP*)PL_op->op_next)->op_other;
+    return cLOGOPx(PL_op->op_next)->op_other;
 }
 
 /* pp_grepwhile() lives in pp_hot.c */
@@ -1161,7 +1161,7 @@ PP(pp_flip)
     dSP;
 
     if (GIMME_V == G_LIST) {
-        RETURNOP(((LOGOP*)cUNOP->op_first)->op_other);
+        RETURNOP(cLOGOPx(cUNOP->op_first)->op_other);
     }
     else {
         dTOPss;
@@ -1190,7 +1190,7 @@ PP(pp_flip)
             else {
                 sv_setiv(targ, 0);
                 SP--;
-                RETURNOP(((LOGOP*)cUNOP->op_first)->op_other);
+                RETURNOP(cLOGOPx(cUNOP->op_first)->op_other);
             }
         }
         SvPVCLEAR(TARG);

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4072,7 +4072,7 @@ S_require_file(pTHX_ SV *sv)
 
         /*XXX OPf_KIDS should always be true? -dapm 4/2017 */
         if (PL_op->op_flags & OPf_KIDS) {
-            SVOP * const kid = (SVOP*)cUNOP->op_first;
+            SVOP * const kid = cSVOPx(cUNOP->op_first);
 
             if (kid->op_type == OP_CONST && (kid->op_private & OPpCONST_BARE)) {
                 /* Make sure that a bareword module name (e.g. ::Foo::Bar)

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -1299,7 +1299,7 @@ PP(pp_flop)
         }
 
         if (flop) {
-            sv_setiv(PAD_SV(((UNOP*)cUNOP->op_first)->op_first->op_targ), 0);
+            sv_setiv(PAD_SV(cUNOPx(cUNOP->op_first)->op_first->op_targ), 0);
             sv_catpvs(targ, "E0");
         }
         SETs(targ);


### PR DESCRIPTION
Use these macros where appropriate for consistency and ease of searching. Also some cases can be made less verbose (when the argument is `o`, `kid` or `PL_op`).

Should have no CPAN-visible change