### PR TITLE
win32: Remove trailing backslash from `INST_TOP`

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -539,6 +539,9 @@ CPANDIR		= ..\cpan
 PODDIR		= ..\pod
 HTMLDIR		= .\html
 
+# Strip trailing backslash from INST_TOP
+override INST_TOP := $(INST_TOP:\=)
+
 INST_SCRIPT	= $(INST_TOP)$(INST_VER)\bin
 INST_BIN	= $(INST_SCRIPT)$(INST_ARCH)
 INST_LIB	= $(INST_TOP)$(INST_VER)\lib


### PR DESCRIPTION
When `INST_TOP` contains a trailing backslash then things go horribly wrong.

Example (output slightly altered for readability):

	C:\...> gmake INST_TOP=C:\Perl\blead\perl\
	...
	..\miniperl.exe -I..\lib config_sh.PL
		"INST_TOP=C:\Perl\blead\perl\"
		"INST_VER="
		"INST_ARCH="
		"archname=MSWin32-x64-multi-thread"
		"cc=gcc"
		"ld=g++"
		"ccflags= -DWIN32 -DWIN64 ...."
		...
	Use of uninitialized value $opt{"static_ext"} in split at config_sh.PL line 57.
	...
	Can't open -DWIN32: No such file or directory at config_sh.PL line 335.
	...

	..\miniperl.exe -I..\lib ..\configpm --chdir=..
	Use of uninitialized value $t in string eq at ..\configpm line 345.
	...
	written lib/Config.pod
	syntax error at lib/Config_heavy.pl line 165, near "x;"
	Compilation failed in require at ..\configpm line 1144.
	gmake: *** [GNUmakefile:1195: ..\lib\Config.pm] Error 255

-> The trailing backslash in 'INST_TOP' caused the double quote (in
   `miniperl.exe config_sh.PL`) to be escaped which messes up the
   rest of the arguments/the argument parsing leading to the errors.

Avoid the errors by removing the trailing backslash.

(Tested on Windows 10 with GNU Make v4.2.1)