### PR TITLE
Fix sporadic test failure in t/io/eintr.t (+ cleanup)

### DIFF
--- a/t/io/eintr.t
+++ b/t/io/eintr.t
@@ -19,16 +19,16 @@ use Config;
 
 my $piped;
 eval {
-	pipe my $in, my $out;
-	$piped = 1;
+    pipe my $in, my $out;
+    $piped = 1;
 };
 if (!$piped) {
-	skip_all('pipe not implemented');
-	exit 0;
+    skip_all('pipe not implemented');
+    exit 0;
 }
 unless (exists  $Config{'d_alarm'}) {
-	skip_all('alarm not implemented');
-	exit 0;
+    skip_all('alarm not implemented');
+    exit 0;
 }
 
 # XXX for some reason the stdio layer doesn't seem to interrupt
@@ -36,8 +36,8 @@ unless (exists  $Config{'d_alarm'}) {
 # hang.
 
 if (exists $ENV{PERLIO} && $ENV{PERLIO} =~ /stdio/  ) {
-	skip_all('stdio not supported for this script');
-	exit 0;
+    skip_all('stdio not supported for this script');
+    exit 0;
 }
 
 # on Win32, alarm() won't interrupt the read/write call.
@@ -55,8 +55,8 @@ if ($^O eq 'VMS' || $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O =~ /freebsd/ || $
      ($^O eq 'darwin' && $osmajmin < 9) ||
     ((int($]*1000) & 1) == 0)
 ) {
-	skip_all('various portability issues');
-	exit 0;
+    skip_all('various portability issues');
+    exit 0;
 }
 
 
@@ -69,10 +69,10 @@ plan(tests => 10);
 # make two handles that will always block
 
 sub fresh_io {
-	close $in if $in; close $out if $out;
-	undef $in; undef $out; # use fresh handles each time
-	pipe $in, $out;
-	$sigst = "";
+    close $in if $in; close $out if $out;
+    undef $in; undef $out; # use fresh handles each time
+    pipe $in, $out;
+    $sigst = "";
 }
 
 $SIG{PIPE} = 'IGNORE';

--- a/t/io/eintr.t
+++ b/t/io/eintr.t
@@ -61,7 +61,7 @@ if ($^O eq 'VMS' || $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O =~ /freebsd/ || $
 
 
 
-my ($in, $out, $st, $sigst, $buf, $pipe_buf_size);
+my ($in, $out, $st, $sigst, $buf, $pipe_buf_size, $pipe_buf_err);
 
 plan(tests => 10);
 
@@ -73,6 +73,7 @@ sub fresh_io {
     undef $in; undef $out; # use fresh handles each time
     pipe $in, $out;
     $sigst = "";
+    $pipe_buf_err = "";
 
     # This used to be 1_000_000, but on Linux/ppc64 (POWER7) this kept
     # consistently failing. At exactly 0x100000 it started passing
@@ -80,11 +81,19 @@ sub fresh_io {
     # that fails, hoping this number is bigger than any pipe buffer.
     $pipe_buf_size = eval {
         use Fcntl qw(F_GETPIPE_SZ);
-        fcntl($out, F_GETPIPE_SZ, 0);
+        # When F_GETPIPE_SZ isn't implemented then fcntl() raises an exception:
+        #   "Your vendor has not defined Fcntl macro F_GETPIPE_SZ ..."
+        # When F_GETPIPE_SZ is implemented then errors are still possible
+        # (EINVAL, EBADF, ...). These are not exceptions (i.e. these don't die)
+        # but instead these set $! and make fcntl() return undef.
+        fcntl($out, F_GETPIPE_SZ, 0) or die "$!\n";
     };
     if ($@ or not $pipe_buf_size) {
+        my $err = $@;;
+        chomp $err;
         $pipe_buf_size = 0xfffff;
-        diag("fcntl F_GETPIPE_SZ failed, falling back to $pipe_buf_size");
+        $pipe_buf_err = "fcntl F_GETPIPE_SZ failed" . ($err ? " ($err)" : "") .
+                        ", falling back to $pipe_buf_size";
     };
     $pipe_buf_size++; # goal is to completely fill the buffer so write one
                       # byte more then the buffer size
@@ -99,9 +108,10 @@ $SIG{ALRM} = sub { $sigst = close($in) ? "ok" : "nok" };
 alarm(1);
 $st = read($in, $buf, 1);
 alarm(0);
-is($sigst, 'ok', 'read/close: sig handler close status');
-ok(!$st, 'read/close: read status');
-ok(!close($in), 'read/close: close status');
+my $result = is($sigst, 'ok', 'read/close: sig handler close status');
+$result &= ok(!$st, 'read/close: read status');
+$result &= ok(!close($in), 'read/close: close status');
+diag($pipe_buf_err) if (not $result and $pipe_buf_err);
 
 # die during read
 
@@ -110,8 +120,9 @@ $SIG{ALRM} = sub { die };
 alarm(1);
 $st = eval { read($in, $buf, 1) };
 alarm(0);
-ok(!$st, 'read/die: read status');
-ok(close($in), 'read/die: close status');
+$result = ok(!$st, 'read/die: read status');
+$result &= ok(close($in), 'read/die: close status');
+diag($pipe_buf_err) if (not $result and $pipe_buf_err);
 
 SKIP: {
     skip "Tests hang on older versions of Darwin", 5
@@ -126,9 +137,10 @@ SKIP: {
     alarm(1);
     $st = print $out $buf;
     alarm(0);
-    is($sigst, 'nok', 'print/close: sig handler close status');
-    ok(!$st, 'print/close: print status');
-    ok(!close($out), 'print/close: close status');
+    $result = is($sigst, 'nok', 'print/close: sig handler close status');
+    $result &= ok(!$st, 'print/close: print status');
+    $result &= ok(!close($out), 'print/close: close status');
+    diag($pipe_buf_err) if (not $result and $pipe_buf_err);
 
     # die during print
 
@@ -139,11 +151,12 @@ SKIP: {
     alarm(1);
     $st = eval { print $out $buf };
     alarm(0);
-    ok(!$st, 'print/die: print status');
+    $result = ok(!$st, 'print/die: print status');
     # the close will hang since there's data to flush, so use alarm
     alarm(1);
-    ok(!eval {close($out)}, 'print/die: close status');
+    $result &= ok(!eval {close($out)}, 'print/die: close status');
     alarm(0);
+    diag($pipe_buf_err) if (not $result and $pipe_buf_err);
 
     # close during close
 

--- a/t/io/eintr.t
+++ b/t/io/eintr.t
@@ -106,7 +106,7 @@ SKIP: {
     # consistently failing. At exactly 0x100000 it started passing
     # again. Now we're asking the kernel what the pipe buffer is, and if
     # that fails, hoping this number is bigger than any pipe buffer.
-    my $surely_this_arbitrary_number_is_fine = (eval {
+    my $pipe_buf_size = (eval {
         use Fcntl qw(F_GETPIPE_SZ);
         fcntl($out, F_GETPIPE_SZ, 0);
     } || 0xfffff) + 1;
@@ -115,7 +115,7 @@ SKIP: {
 
     fresh_io;
     $SIG{ALRM} = sub { $sigst = close($out) ? "ok" : "nok" };
-    $buf = "a" x $surely_this_arbitrary_number_is_fine . "\n";
+    $buf = "a" x $pipe_buf_size . "\n";
     select $out; $| = 1; select STDOUT;
     alarm(1);
     $st = print $out $buf;
@@ -128,7 +128,7 @@ SKIP: {
 
     fresh_io;
     $SIG{ALRM} = sub { die };
-    $buf = "a" x $surely_this_arbitrary_number_is_fine . "\n";
+    $buf = "a" x $pipe_buf_size . "\n";
     select $out; $| = 1; select STDOUT;
     alarm(1);
     $st = eval { print $out $buf };


### PR DESCRIPTION
The test would sporadically fail; troubleshooting this revealed that
the size of the pipe buffer could vary between pipes which this code
didn't take into account.

What the code did:

1. Create two pipes ($in, $out)
2. Get buffer size of '$out' pipe
3. Do something that should block (using the buffer size)
4. Create two new pipes ($in, $out)
5. Do something that should block (using the buffer size)

The problem: the pipe created in 4. does not always have the same buffer size as the pipe created in 1.

Adding some debug info in the test:

	# pipe buf size: 8193
	ok 4 - read/die: read status
	ok 5 - read/die: close status
	# pipe buf size: 65537
	not ok 6 - print/close: sig handler close status

During test 6 it reused the smaller buffer size and wrote data
to the new pipe. It expected this to block but the buffer of the pipe
used for test 6 is 65536 bytes. End result: the pipe buffer is not
full (only 8194 bytes were written) so the test does not block which
causes the alarm not to trigger which causes the test failure.

Fix all this by reinitialising `$pipe_buf_size` when creating new pipes.

(Observed by @khwilliamson , diagnosed with help of @wolfsage )

+

Apply some small cleanup to t/io/eintr.t
