### PR TITLE
Fix #20085 locale failure on certain threaded locale configurations

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3334,7 +3334,7 @@ Sr	|void	|setlocale_failure_panic_i|const unsigned int cat_index	\
 #    if defined(USE_POSIX_2008_LOCALE)
 S	|const char*|emulate_setlocale_i|const unsigned int index	\
 				    |NULLOK const char* new_locale	\
-				    |const int recalc_LC_ALL		\
+				    |const recalc_lc_all_t recalc_LC_ALL\
 				    |const line_t line
 S	|const char*|my_querylocale_i|const unsigned int index
 S	|locale_t   |use_curlocale_scratch
@@ -3347,7 +3347,7 @@ S	|const char *|calculate_LC_ALL|const locale_t cur_obj
 S	|const char *|calculate_LC_ALL|NN const char ** individ_locales
 S	|const char*|update_PL_curlocales_i|const unsigned int index	\
 				    |NN const char * new_locale		\
-				    |int recalc_LC_ALL
+				    |recalc_lc_all_t recalc_LC_ALL
 S	|const char *|find_locale_from_environment|const unsigned int index
 #      endif
 #    endif

--- a/locale.c
+++ b/locale.c
@@ -1178,9 +1178,9 @@ S_emulate_setlocale_i(pTHX_
                  * code would have then set them up, but since it didn't, do so
                  * here.  khw isn't sure if this prevents some issues or not,
                  * but tis is defensive coding.  The system setlocale() returns
-                 * the desired information.  Calculate LC_ALL's entry on the
-                 * final iteration */
-                for (PERL_UINT_FAST8_T i = 0; i <= NOMINAL_LC_ALL_INDEX; i++) {
+                 * the desired information.  This will calculate LC_ALL's entry
+                 * on the final iteration */
+                for (PERL_UINT_FAST8_T i = 0; i < NOMINAL_LC_ALL_INDEX; i++) {
                     update_PL_curlocales_i(i,
                                        porcelain_setlocale(categories[i], NULL),
                                        LOOPING);

--- a/locale.c
+++ b/locale.c
@@ -1057,6 +1057,23 @@ S_emulate_setlocale_i(pTHX_
                  "(%" LINE_Tf "): emulate_setlocale_i"
                  " no-op to change to what it already was\n",
                  line));
+
+#  ifdef USE_PL_CURLOCALES
+
+       /* On the final iteration of a loop that needs to recalculate LC_ALL, do
+        * so.  If no iteration changed anything, LC_ALL also doesn't change,
+        * but khw believes the complexity needed to keep track of that isn't
+        * worth it. */
+        if (UNLIKELY(   recalc_LC_ALL == RECALCULATE_LC_ALL_ON_FINAL_INTERATION
+                     && index == NOMINAL_LC_ALL_INDEX - 1))
+        {
+            Safefree(PL_curlocales[LC_ALL_INDEX_]);
+            PL_curlocales[LC_ALL_INDEX_] =
+                                        savepv(calculate_LC_ALL(PL_curlocales));
+        }
+
+#  endif
+
         return locale_on_entry;
     }
 

--- a/perl.h
+++ b/perl.h
@@ -1348,6 +1348,23 @@ violations are fatal.
 #  endif
 #endif
 
+#ifdef PERL_CORE
+
+/* Used in locale.c only, but defined here so that embed.fnc can generate
+ * the proper prototypes. */
+
+typedef enum {
+    DONT_RECALC_LC_ALL,
+    YES_RECALC_LC_ALL,
+
+    /* Used in tight loops through all sub-categories, where LC_ALL won't be
+     * fully known until all subcategories are handled. */
+    RECALCULATE_LC_ALL_ON_FINAL_INTERATION
+} recalc_lc_all_t;
+
+#endif
+
+
 #include <setjmp.h>
 
 #ifdef I_SYS_PARAM

--- a/proto.h
+++ b/proto.h
@@ -4692,7 +4692,7 @@ STATIC const char *	S_calculate_LC_ALL(pTHX_ const char ** individ_locales);
 	assert(individ_locales)
 STATIC const char *	S_find_locale_from_environment(pTHX_ const unsigned int index);
 #define PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT
-STATIC const char*	S_update_PL_curlocales_i(pTHX_ const unsigned int index, const char * new_locale, int recalc_LC_ALL);
+STATIC const char*	S_update_PL_curlocales_i(pTHX_ const unsigned int index, const char * new_locale, recalc_lc_all_t recalc_LC_ALL);
 #define PERL_ARGS_ASSERT_UPDATE_PL_CURLOCALES_I	\
 	assert(new_locale)
 #      endif
@@ -5648,7 +5648,7 @@ STATIC const char*	S_stdize_locale(pTHX_ const int category, const char* input_l
 STATIC const char*	S_switch_category_locale_to_template(pTHX_ const int switch_category, const int template_category, const char * template_locale);
 #define PERL_ARGS_ASSERT_SWITCH_CATEGORY_LOCALE_TO_TEMPLATE
 #    if defined(USE_POSIX_2008_LOCALE)
-STATIC const char*	S_emulate_setlocale_i(pTHX_ const unsigned int index, const char* new_locale, const int recalc_LC_ALL, const line_t line);
+STATIC const char*	S_emulate_setlocale_i(pTHX_ const unsigned int index, const char* new_locale, const recalc_lc_all_t recalc_LC_ALL, const line_t line);
 #define PERL_ARGS_ASSERT_EMULATE_SETLOCALE_I
 STATIC const char*	S_my_querylocale_i(pTHX_ const unsigned int index);
 #define PERL_ARGS_ASSERT_MY_QUERYLOCALE_I


### PR DESCRIPTION
Locale initialization was failing on threaded perls on systems without the ability to query the current locale (mainly linux) and with an initialization where some categories had a different locale than others