### PR TITLE
prevent calling recursing into S_concat_pat() for an empty array

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -7287,10 +7287,15 @@ S_concat_pat(pTHX_ RExC_state_t * const pRExC_state,
             else
                 array = AvARRAY(av);
 
-            pat = S_concat_pat(aTHX_ pRExC_state, pat,
-                                array, maxarg, NULL, recompile_p,
-                                /* $" */
-                                GvSV((gv_fetchpvs("\"", GV_ADDMULTI, SVt_PV))));
+            if (maxarg > 0) {
+                pat = S_concat_pat(aTHX_ pRExC_state, pat,
+                                   array, maxarg, NULL, recompile_p,
+                                   /* $" */
+                                   GvSV((gv_fetchpvs("\"", GV_ADDMULTI, SVt_PV))));
+            }
+            else if (!pat) {
+                pat = newSVpvs_flags("", SVs_TEMP);
+            }
 
             continue;
         }


### PR DESCRIPTION
If AvARRAY() was NULL (and it is in one test) this would cause
undefined behaviour in the S_concat_pat() outer for loop.

This is the last ASAN error I could see from building/testing with `-fsanitize=undefined`

Fixes #19851 