### PR TITLE
Pathtools: updated version info in meta.json and meta.xml

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1972,3 +1972,4 @@ Zsbán Ambrus <ambrus@math.bme.hu> Zsbán Ambrus <ambrus@math.bme.hu>
 Ævar Arnfjörð Bjarmason <avar@cpan.org> Ævar Arnfjörð Bjarmason <avarab@gmail.com>
 Ævar Arnfjörð Bjarmason <avar@cpan.org> Ævar Arnfjörð Bjarmason) (via RT <perlbug-followup@perl.org>
 Михаил Козачков <mchlkzch@gmail.com> Михаил Козачков <mchlkzch@gmail.com>
+小鸡 <345865759@163.com> 小鸡 <345865759@163.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1445,3 +1445,4 @@ Zefram                         <zefram@fysh.org>
 Zsbán Ambrus                   <ambrus@math.bme.hu>
 Ævar Arnfjörð Bjarmason        <avar@cpan.org>
 Михаил Козачков                <mchlkzch@gmail.com>
+小鸡                             <345865759@163.com>

--- a/dist/PathTools/META.json
+++ b/dist/PathTools/META.json
@@ -50,6 +50,6 @@
          "url" : "git://perl5.git.perl.org/perl.git"
       }
    },
-   "version" : "3.73",
+   "version" : "3.86",
    "x_serialization_backend" : "JSON::PP version 2.27400_02"
 }

--- a/dist/PathTools/META.yml
+++ b/dist/PathTools/META.yml
@@ -26,5 +26,5 @@ resources:
   bugtracker: https://rt.perl.org/rt3/
   homepage: http://dev.perl.org/
   repository: git://perl5.git.perl.org/perl.git
-version: '3.73'
+version: '3.86'
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'


### PR DESCRIPTION
the version info in meta.json and meta.xml of perl module "Pathtools" is mistake, so we should fix this bug.