### PR TITLE
Fix g++ builds (/ locale.c: Fix trial_locales declaration)

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -3530,13 +3530,13 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
     const char * const setlocale_init = (PerlEnv_getenv("PERL_SKIP_LOCALE_INIT"))
                                         ? NULL
                                         : "";
-    typedef struct trial_locales_struct {
+    typedef struct trial_locales_struct_s {
         const char* trial_locale;
         const char* fallback_desc;
         const char* fallback_name;
     } trial_locales_struct;
     /* 5 = 1 each for "", LC_ALL, LANG, (Win32) system default locale, C */
-    struct trial_locales_struct trial_locales[5];
+    trial_locales_struct trial_locales[5];
     unsigned int trial_locales_count;
     const char * const lc_all     = PerlEnv_getenv("LC_ALL");
     const char * const lang       = PerlEnv_getenv("LANG");


### PR DESCRIPTION
Commit e57aaf750b3d2461053eff690d0954bc8fb9d7f3 broke builds with g++
because the declaration of `trial_locales` was incorrect. It contained
an extra 'struct' keyword which is wrong.

Errors on g++:

	locale.c:3539:12: error: using typedef-name 'trial_locales_struct' after 'struct'
	     struct trial_locales_struct trial_locales[5];
            ^
	locale.c:3537:7: note: 'trial_locales_struct' has a previous declaration here
	     } trial_locales_struct;

(Build tested with gcc-12, g++-12, gcc-4.9, g++-4.9)