### PR TITLE
Add 'g++' build in the GitHub workflow

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -149,6 +149,7 @@ jobs:
           - "-Duseshrplib -Dusequadmath -Dusecbacktrace -Dusethreads"
           - "-Duserelocatableinc"
           - "-Dcc='clang'"
+          - "-Dcc='g++'"
 
     steps:
       - name: Install System dependencies


### PR DESCRIPTION
Also do a build with 'g++' since it can catch more errors.

(I accidentally broke builds with g++ and that commit got merged
 on blead; smokers then reported build failures with g++ but it would
 have been nicer if I knew this before it got merged.)