### PR TITLE
t/porting/authors.t - respect .mailmap in test

### DIFF
--- a/t/porting/authors.t
+++ b/t/porting/authors.t
@@ -41,6 +41,6 @@ elsif( $ENV{GITHUB_ACTIONS} && length $ENV{GITHUB_BASE_REF} ) {
 }
 
 # This is the subset of "pretty=fuller" that checkAUTHORS.pl actually needs:
-print qx{git log --pretty=format:"Author: %an <%ae>" $revision_range | $^X Porting/checkAUTHORS.pl --tap -};
+print qx{git log --pretty=format:"Author: %aN <%aE>" $revision_range | $^X Porting/checkAUTHORS.pl --tap -};
 
 # EOF


### PR DESCRIPTION
The logic in checkAUTHORS.pl internally uses the "Author:" data from

    git log --pretty=fuller

which respects .mailmap entries, thus it is actually equivalent to

    git log --pretty='format:%aN %aE'

whereas "%an %ae" will show the raw uncorrected values, this can then
make authors.t think there are more and different authors than there
actually are.