### PR TITLE
Fix make_patchnum.pl when run from subdir

### DIFF
--- a/make_patchnum.pl
+++ b/make_patchnum.pl
@@ -51,14 +51,6 @@ our $opt_v = scalar grep $_ eq '-v', @ARGV;
 
 BEGIN {
     my $root=".";
-    # test 1st to see if we're a -Dmksymlinks target dir
-    $subcd = '';
-    $srcdir = $root;
-    if (-l "./Configure") {
-	$srcdir = readlink("./Configure");
-	$srcdir =~ s/Configure//;
-	$subcd = "cd $srcdir &&"; # activate backtick fragment
-    }
     while (!-e "$root/perl.c" and length($root)<100) {
         if ($root eq '.') {
             $root="..";
@@ -68,6 +60,15 @@ BEGIN {
     }
     die "Can't find toplevel" if !-e "$root/perl.c";
     sub path_to { "$root/$_[0]" } # use $_[0] if this'd be placed in toplevel.
+
+    # test to see if we're a -Dmksymlinks target dir
+    $subcd = '';
+    $srcdir = $root;
+    if (-l "$root/Configure") {
+        $srcdir = readlink("$root/Configure");
+        $srcdir =~ s/Configure//;
+        $subcd = "cd $srcdir &&"; # activate backtick fragment
+    }
 }
 
 sub read_file {


### PR DESCRIPTION
When running 'make_patchnum.pl' from a subdir then 'make_patchnum.pl'
failed to write a proper lib/Config_git.pl. That is: all values in it
were set to the empty string instead to the actual values.

Example:

	$ cd perl5
	$ mkdir foo && cd $foo
	$ ../miniperl -I../lib ../make_patchnum.pl
	Updating 'git_version.h' and 'lib/Config_git.pl'
	$ cat ../lib/Config_git.pl
	######################################################################
	# WARNING: 'lib/Config_git.pl' is generated by make_patchnum.pl
	#          DO NOT EDIT DIRECTLY - edit make_patchnum.pl instead
	######################################################################
	$Config::Git_Data=<<'ENDOFGIT';
	git_commit_id=''
	git_describe=''
	git_branch=''
	git_uncommitted_changes=''
	git_commit_id_title=''

This got broken in commit 3f1788e11f2685299067ac0f8d3e4fd141a5b5cd which
added support for -Dmksymlink.

That commit basically assumed that the stating point was always '.' and
that the './.git' directory exist. Neither are true when the command is
run from inside a subdir.

The proper thing to do is to first find the `$root` directory and then
check if it's in -Dmksymlinks target dir. (Luckily all that code already
exists, we just need to move the -Dmksymlinks logic a bit down.)

With this change applied:

	$ ../miniperl -I../lib ../make_patchnum.pl
	Updating 'git_version.h' and 'lib/Config_git.pl'
	$ cat lib/Config_git.pl
	######################################################################
	# WARNING: 'lib/Config_git.pl' is generated by make_patchnum.pl
	#          DO NOT EDIT DIRECTLY - edit make_patchnum.pl instead
	######################################################################
	$Config::Git_Data=<<'ENDOFGIT';
	git_commit_id='c589bf60082d119a14e11ef05a77fed6d36aba4b'
	git_describe='v5.37.2-170-gc589bf6'
	git_branch='bram/fix-make_patchnum-in-subdir'
	git_uncommitted_changes='0'
	git_commit_id_title='Commit id:'
	git_commit_date='2022-08-16 15:49:38 +0200'
	ENDOFGIT

Note:
- to build on Windows one must do a `cd win32` before building. This is how
  I noticed the file was incorrect.
- I've tested running make_patchnum from:
  * the root
  * a subdir
  * a '-Dmksymlinks' target dir
  * a subdir inside a '-Dmksymlinks' target

(PS: I also fixed the indentation from tabs to 4 spaces)