### PR TITLE
win32/GNUmakefile: correct $(CONFIGPM) deps

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1185,7 +1185,7 @@ regen_config_h:
 	-$(MINIPERL) -I..\lib config_h.PL "ARCHPREFIX=$(ARCHPREFIX)"
 	rename config.h $(CFGH_TMPL)
 
-$(CONFIGPM): ..\config.sh config_h.PL
+$(CONFIGPM): ..\config.sh config_h.PL ..\git_version.h
 	$(MINIPERL) -I..\lib ..\configpm --chdir=..
 	-$(MINIPERL) -I..\lib config_h.PL "ARCHPREFIX=$(ARCHPREFIX)"
 


### PR DESCRIPTION
The `$(CONFIGPM}` target depends on the 'lib/Config_git.pl' file which
is created by the '..\git_version.h' target (this runs `make_patchnum.pl`
which creates both files).

Build log when dependency is missing:

	..\miniperl.exe -I..\lib ..\configpm --chdir=..
	written lib/Config.pod
	updated lib/Config.pm
	updated lib/Config_heavy.pl
	Warning: failed to load Config_git.pl, something strange about this perl...
	..\miniperl.exe -I..\lib config_h.PL "ARCHPREFIX="
	Running config_h.PL
	Writing config.h
	Warning: failed to load Config_git.pl, something strange about this perl...
	config.h has changed
	(....)
	..\miniperl.exe -I..\lib ..\make_patchnum.pl
	Updating 'git_version.h' and 'lib/Config_git.pl'

-> It first ran `configpm` and only later it ran `make_patchnum.pl`

Build log with the dependency:

	..\miniperl.exe -I..\lib ..\make_patchnum.pl
	Updating 'git_version.h' and 'lib/Config_git.pl'
	(...)
	..\miniperl.exe -I..\lib ..\configpm --chdir=..
	written lib/Config.pod
	updated lib/Config.pm
	updated lib/Config_heavy.pl
	..\miniperl.exe -I..\lib config_h.PL "ARCHPREFIX="
	Running config_h.PL
	Writing config.h
	config.h has changed

Notes:
- in ./Makefile.SH the same dependency was added in
  commit 744ac0eac539aead596d9fa09cc15a20b09a5884 (and later updated in
  commit 0f13ebd5d71f81771c1044e2c89aff29b408bfec)
- in ./win32/Makefile the same dependency was added in
  commit 680b2c5ee3b53c627074192b3cf14416a24da6ea (the dependency fix
  however was not mentioned in the commit message)