### PR TITLE
only clear the stream error state in readline() for a good nextargv()

### DIFF
--- a/pp_hot.c
+++ b/pp_hot.c
@@ -3334,14 +3334,19 @@ Perl_do_readline(pTHX)
                 || SNARF_EOF(gimme, PL_rs, io, sv)
                 || PerlIO_error(fp)))
         {
-            PerlIO_clearerr(fp);
             if (IoFLAGS(io) & IOf_ARGV) {
                 fp = nextargv(PL_last_in_gv, PL_op->op_flags & OPf_SPECIAL);
-                if (fp)
+                if (fp) {
                     continue;
+                }
                 (void)do_close(PL_last_in_gv, FALSE);
             }
             else if (type == OP_GLOB) {
+                /* clear any errors here so we only fail on the pclose()
+                   failing, which should only happen on the child
+                   failing
+                */
+                PerlIO_clearerr(fp);
                 if (!do_close(PL_last_in_gv, FALSE)) {
                     Perl_ck_warner(aTHX_ packWARN(WARN_GLOB),
                                    "glob failed (child exited with status %d%s)",

--- a/t/lib/warnings/pp_hot
+++ b/t/lib/warnings/pp_hot
@@ -237,8 +237,8 @@ $a = <FOO> ;
 use warnings 'io' ;
 $a = <FOO> ;
 $a = <FH> ;
-close (FH) or die $! ;
-close (FOO) or die $! ;
+close (FH);
+close (FOO);
 unlink $file ;
 EXPECT
 Filehandle FH opened only for output at - line 5.

--- a/t/op/readline.t
+++ b/t/op/readline.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan tests => 32;
+plan tests => 36;
 
 # [perl #19566]: sv_gets writes directly to its argument via
 # TARG. Test that we respect SvREADONLY.
@@ -287,6 +287,18 @@ is ${^LAST_FH}, undef, '${^LAST_FH} after readline undef';
     like $w, qr/^readline\(\) on unopened filehandle y at .*\n(?x:
                 )Undefined value assigned to typeglob at .*\n\z/,
         '[perl #123790] *x=<y> used to fail an assertion';
+}
+
+SKIP:
+{
+    skip_without_dynamic_extension("IO", 4);
+    my $tmpfile = tempfile();
+    open my $fh, ">", $tmpfile
+        or die "Cannot open $tmpfile: $!";
+    ok(!$fh->error, "no error before we try to read");
+    ok(!<$fh>, "fail to readline file opened for write");
+    ok($fh->error, "error after trying to readline file opened for write");
+    ok(!close($fh), "closing the file should fail");
 }
 
 __DATA__


### PR DESCRIPTION
This would previously clear the stream error state in any case
where sv_gets() failed and the error state was set.

Since this now leaves the error state on the stream, the close()
calls in the test updated by this commit would fail, changing its
output.  Since the result of those closes didn't seem related
to the purpose of the test, I changed it not throw an error on
either close() failing.

Fixes #20060 