### PR TITLE
Add a PadnameREFCNT_inc() macro

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -3430,6 +3430,13 @@ Perl_cop_file_avn(pTHX_ const COP *cop) {
 
 #endif
 
+PERL_STATIC_INLINE PADNAME *
+Perl_padname_refcnt_inc(PADNAME *pn)
+{
+    PadnameREFCNT(pn)++;
+    return pn;
+}
+
 /*
  * ex: set ts=8 sts=4 sw=4 et:
  */

--- a/pad.c
+++ b/pad.c
@@ -613,7 +613,7 @@ Perl_pad_add_name_pvn(pTHX_ const char *namepv, STRLEN namelen,
         SAVEFREEPADNAME(name); /* in case of fatal warnings */
         /* check for duplicate declaration */
         pad_check_dup(name, flags & padadd_OUR, ourstash);
-        PadnameREFCNT(name)++;
+        PadnameREFCNT_inc(name);
         LEAVE;
     }
 
@@ -2714,7 +2714,7 @@ Perl_padnamelist_dup(pTHX_ PADNAMELIST *srcpad, CLONE_PARAMS *param)
       if (PadnamelistARRAY(srcpad)[max]) {
         PadnamelistARRAY(dstpad)[max] =
             padname_dup(PadnamelistARRAY(srcpad)[max], param);
-        PadnameREFCNT(PadnamelistARRAY(dstpad)[max])++;
+        PadnameREFCNT_inc(PadnamelistARRAY(dstpad)[max]);
       }
 
     return dstpad;
@@ -2775,7 +2775,7 @@ Perl_newPADNAMEouter(PADNAME *outer)
     PadnamePV(pn) = PadnamePV(outer);
     /* Not PadnameREFCNT(outer), because ‘outer’ may itself close over
        another entry.  The original pad name owns the buffer.  */
-    PadnameREFCNT(PADNAME_FROM_PV(PadnamePV(outer)))++;
+    PadnameREFCNT_inc(PADNAME_FROM_PV(PadnamePV(outer)));
     PadnameFLAGS(pn) = PADNAMEf_OUTER;
     PadnameLEN(pn) = PadnameLEN(outer);
     return pn;

--- a/pad.h
+++ b/pad.h
@@ -249,6 +249,9 @@ for C<my Foo $bar>.
 =for apidoc Amx|SSize_t|PadnameREFCNT|PADNAME * pn
 The reference count of the pad name.
 
+=for apidoc Amx|PADNAME *|PadnameREFCNT_inc|PADNAME * pn
+Increases the reference count of the pad name.  Returns the pad name itself.
+
 =for apidoc Amx|void|PadnameREFCNT_dec|PADNAME * pn
 Lowers the reference count of the pad name.
 
@@ -321,6 +324,7 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PadnameHasTYPE(pn)      cBOOL(PadnameTYPE(pn))
 #define PadnamePROTOCV(pn)	(pn)->xpadn_type_u.xpadn_protocv
 #define PadnameREFCNT(pn)	(pn)->xpadn_refcnt
+#define PadnameREFCNT_inc(pn)   Perl_padname_refcnt_inc(pn)
 #define PadnameREFCNT_dec(pn)	Perl_padname_free(aTHX_ pn)
 #define PadnameOURSTASH_set(pn,s) (PadnameOURSTASH(pn) = (s))
 #define PadnameTYPE_set(pn,s)	  (PadnameTYPE(pn) = (s))


### PR DESCRIPTION
Implemented as a static inline function call, so that it can return the padname pointer itself.  This would allow use in expressions such as

```c
ptr->field = PadnameREFCNT_inc(pn);
```

That makes it similar to the familiar `SvREFCNT_inc()` macro.