### PR TITLE
Fix g++ build (Add extra scope block for switch case)

### DIFF
--- a/peep.c
+++ b/peep.c
@@ -3799,7 +3799,7 @@ Perl_rpeep(pTHX_ OP *o)
             }
             break;
 
-        case OP_SASSIGN:
+        case OP_SASSIGN: {
             if (OP_GIMME(o,0) == G_VOID
              || (  o->op_next->op_type == OP_LINESEQ
                 && (  o->op_next->op_next->op_type == OP_LEAVESUB
@@ -3893,6 +3893,7 @@ Perl_rpeep(pTHX_ OP *o)
                 oldoldop = NULL; oldop = NULL;
             }
             break;
+        }
 
         case OP_AASSIGN: {
             int l, r, lr, lscalars, rscalars;


### PR DESCRIPTION
Code in 9fdd7fc4796d89d16dceea42f2af91e4fde296ed broke the g++ builds,

Basically after the commit the code looked like:

         switch (o->op_type) {
         ...
         case OP_SASSIGN:
             ...
             OP* rhs = cBINOPx(o)->op_first;
             OP* lval = cBINOPx(o)->op_last;
             ...
             break;

         case OP_AASSIGN: {

g++ does not allow this and errors with:

	peep.c:3897:14: error: jump to case label
	 3897 |         case OP_AASSIGN: {
	      |              ^~~~~~~~~~
	peep.c:3844:17: note:   crosses initialization of 'OP* lval'
	 3844 |             OP* lval = cBINOPx(o)->op_last;
	      |                 ^~~~
	peep.c:3843:17: note:   crosses initialization of 'OP* rhs'
	 3843 |             OP* rhs = cBINOPx(o)->op_first;
	      |                 ^~~

This happens because `rhs` and `lval` are not scoped in the case statement
so it could fall through to the next case.

The solution is to scope them which this commit now does by adding a
separate scope for `OP_SASSIGN` (similar to `OP_AASSIGN`).

Fixes #20108