### PR TITLE
win32: use tmp file when creating config.sh

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1181,7 +1181,8 @@ endif
 ..\perl$(o) : ..\git_version.h
 
 ..\config.sh : $(CFGSH_TMPL) config_sh.PL FindExt.pm $(HAVEMINIPERL)
-	$(MINIPERL) -I..\lib config_sh.PL $(CFG_VARS) $(CFGSH_TMPL) > ..\config.sh
+	$(MINIPERL) -I..\lib config_sh.PL $(CFG_VARS) $(CFGSH_TMPL) > ..\config.sh.tmp
+	rename ..\config.sh.tmp config.sh
 
 # This target is for when changes to the main config.sh happen.
 # Edit config.gc, then make perl using GCC in a minimal configuration (i.e.

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -873,7 +873,8 @@ perlglob$(o)  : perlglob.c
 ..\perl$(o) : ..\git_version.h
 
 ..\config.sh : $(CFGSH_TMPL) config_sh.PL FindExt.pm $(MINIPERL)
-	$(MINIPERL) -I..\lib config_sh.PL $(CFG_VARS) $(CFGSH_TMPL) > ..\config.sh
+	$(MINIPERL) -I..\lib config_sh.PL $(CFG_VARS) $(CFGSH_TMPL) > ..\config.sh.tmp
+	rename ..\config.sh.tmp config.sh
 
 # This target is for when changes to the main config.sh happen.
 # Edit config.vc, then make perl in a minimal configuration (i.e. with MULTI,


### PR DESCRIPTION
When `config_sh.PL` failed then it created an empty '..\config.sh' file.
This is unwanted since if make is then re-run it detects a '..\config.sh'
file and skips the target which leads to completely different errors.

After adding a `die "Foobar";` in win32/config_sh.PL:

	$ gmake INST_TOP=... CCHOME=...
	...
	..\miniperl.exe -I..\lib config_sh.PL ... > ..\config.sh
	Foobar at config_sh.PL line 5.
	gmake: *** [GNUmakefile:1175: ..\config.sh] Error 255

Re-running the make command:

	$ gmake INST_TOP=... CCHOME=...
	..\miniperl.exe -I..\lib ..\configpm --chdir=..
	Use of uninitialized value $t in string eq at ..\configpm line 345.
	...
	written lib/Config.pod
	updated lib/Config.pm
	updated lib/Config_heavy.pl
	syntax error at lib/Config_heavy.pl line 165, near "x;"
	Compilation failed in require at ..\configpm line 1144.
	gmake: *** [GNUmakefile:1190: ..\lib\Config.pm] Error 255

When `gmake` was re-run it started with the '$(CONFIGPM)' target instead
of the '..\config.sh' target.

The fix: instead of creating '..\config.sh' it now first creates '..\config.sh.tmp' and then renames[^1] it to '..\config.sh'

Tested the GNUmakefile on Windows 10 using GNU Make v4.2.1,
I did *not* test the Makefile (no nmake installed).

[^1]: `rename` on windows only takes a path in the first argument.
      That is: `rename ..\config.sh.tmp config.sh` can be considered
      the same as `move ..\config.sh.tmp ..\config.sh`.