### PR TITLE
win32: check if CCHOME is correctly set

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1111,7 +1111,8 @@ CFG_VARS	=					\
 		"LINK_FLAGS=$(subst ",\",$(LINK_FLAGS))"\
 		"optimize=$(subst ",\",$(OPTIMIZE))"	\
 		"ARCHPREFIX=$(ARCHPREFIX)"		\
-		"WIN64=$(WIN64)"
+		"WIN64=$(WIN64)"                        \
+		"SKIP_CCHOME_CHECK=$(SKIP_CCHOME_CHECK)"
 
 #
 # Top targets

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -834,7 +834,8 @@ CFG_VARS	=					\
 		"default_inc_excludes_dot=$(DEFAULT_INC_EXCLUDES_DOT)"	\
 		"LINK_FLAGS=$(LINK_FLAGS:"=\")"		\
 		"optimize=$(OPTIMIZE:"=\")"		\
-		"WIN64=$(WIN64)"
+		"WIN64=$(WIN64)"                        \
+		"SKIP_CCHOME_CHECK=$(SKIP_CCHOME_CHECK)"
 
 #
 # Top targets

--- a/win32/config_sh.PL
+++ b/win32/config_sh.PL
@@ -11,7 +11,32 @@ sub mungepath {
     $p =~ s/[ ;]+$//;
     $p =~ s/'/"/g;
     my @p = map { $_ = "\"$_\"" if /\s/ and !/^".*"$/; $_ } split /;/, $p;
-    return join(' ', @p);
+    return wantarray ? @p : join(' ', @p);
+}
+
+# check that the directories in the provided var exist
+sub check_path {
+    my $opt = shift;
+    my $p = shift;
+    my @paths = mungepath($p);
+    my $header_seen = 0;
+    foreach my $path (@paths) {
+        $path =~ s/^"(.*)"$/$1/;
+        next, if -d $path;
+
+        if (not $header_seen++) {
+            print STDERR "'$opt' contains the following non-existing paths:\n";
+        }
+        print STDERR "\t$path\n";
+    }
+    if ($header_seen) {
+        print STDERR <<EOF;
+Did you provide a correct value for the 'CCHOME' option?
+
+(This check can be skipped by using the SKIP_CCHOME_CHECK=1 option)
+EOF
+        exit 1;
+    }
 }
 
 # generate an array of option strings from command-line args
@@ -111,6 +136,11 @@ if (!$opt{cf_email}) {
     $opt{cf_email} = $opt{cf_by} . '@' . $computername;
 }
 $opt{usemymalloc} = 'y' if $opt{d_mymalloc} eq 'define';
+
+unless ($opt{SKIP_CCHOME_CHECK}) {
+    check_path('CCLIBDIR', $opt{libpth});
+    check_path('CCINCDIR', $opt{incpath});
+}
 
 $opt{libpth} = mungepath($opt{libpth}) if exists $opt{libpth};
 $opt{incpath} = mungepath($opt{incpath}) if exists $opt{incpath};


### PR DESCRIPTION
When building on Windows one must provide a value for 'CCHOME'.
The value of 'CCHOME' is used to set the value of 'CCLIBDIR' and 'CCINCDIR'.
(These eventually become `$Config{libpth}` and `$Config{incpath}`.)

When 'CCHOME' is incorrectly set the build mostly works; what fails
is building cpan/Win32 and this then fails with non-obvious errors such as:

	Warning (mostly harmless): No library found for -luserenv
	Warning (mostly harmless): No library found for -lwinhttp
	...
	g++ Win32.def -o ....
	C:/.../ld.exe: ... undefined reference to `WinHttpCrackUrl'
	...
	collect2.exe: error: ld returned 1 exit status
	gmake[1]: *** [Makefile:472: ..\..\lib\auto\Win32\Win32.dll] Error 1
	gmake[1]: Leaving directory 'C:/Perl/perl5/cpan/Win32'
	Unsuccessful make(cpan/Win32): code=512 at ..\make_ext.pl line 584.

Make this a bit more obvious by checking if the path(s) specified in 'CCLIBDIR' and 'CCINCDIR' actually exist.

If these do not exist then stop the build process at an early stage with a clear(er) error.

Example error:

	..\miniperl.exe -I..\lib config_sh.PL ...
	'CCLIBDIR' contains the following non-existing paths:
	        C:\MinGW\lib
	        C:\MinGW\x86_64-w64-mingw32\lib
	        C:\MinGW\lib\gcc\x86_64-w64-mingw32\8.3.0
	Did you provide a correct value for the 'CCHOME' option?

	(This check can be skipped by using the SKIP_CCHOME_CHECK=1 option)
	gmake: *** [GNUmakefile:1176: ..\config.sh] Error 1

Some notes:
- This check can be skipped/overridden by adding 'SKIP_CCHOME_CHECK=1'
  on the make cmd line. (I added this because I don't know if there are
  valid use cases for having a non-existing path in 'libpth'/'incpath')
- My first idea was to do this in the Makefile/GNUmakefile at a very early
  stage but that is more complex to do and the resulting code is messy/ugly.
  So instead I opted to do it in 'config_sh.PL' since this is the
  first(/only) place that uses these vars.
- I (only) tested on Windows 10 using GNU Make and gcc