### PR TITLE
Clean up cygwin.c some

### DIFF
--- a/cygwin/cygwin.c
+++ b/cygwin/cygwin.c
@@ -337,6 +337,9 @@ XS(XS_Cygwin_win_to_posix_path)
         posix_path = (char *) safemalloc(wlen+1);
         wcsrtombs(posix_path, (const wchar_t **)&wbuf, wlen, NULL);
         */
+
+        safefree(wpath);
+        safefree(wbuf);
     } else {
         int what = absolute_flag ? CCP_WIN_A_TO_POSIX : CCP_WIN_A_TO_POSIX | CCP_RELATIVE;
         posix_path = (char *) safemalloc (len + PATH_LEN_GUESS);
@@ -425,6 +428,9 @@ XS(XS_Cygwin_posix_to_win_path)
         else setlocale(LC_CTYPE, "C");
 
         SETLOCALE_UNLOCK;
+
+        safefree(wpath);
+        safefree(wbuf);
     } else {
         int what = absolute_flag ? CCP_POSIX_TO_WIN_A : CCP_POSIX_TO_WIN_A | CCP_RELATIVE;
         win_path = (char *) safemalloc(len + PATH_LEN_GUESS);

--- a/cygwin/cygwin.c
+++ b/cygwin/cygwin.c
@@ -313,10 +313,10 @@ S_convert_path_common(pTHX_ const direction_t direction)
                      ? CCP_WIN_W_TO_POSIX
                      : CCP_POSIX_TO_WIN_W);
         STRLEN wlen;
-        wchar_t *wsrc = NULL;
-        wchar_t *wconverted = NULL;
+        wchar_t *wsrc = NULL;       /* The source, as a wchar_t */
+        wchar_t *wconverted = NULL; /* wsrc, converted to the destination */
 
-        if (!IN_BYTES) {
+        if (LIKELY(! IN_BYTES)) {    /* Normal case, convert UTF-8 to UTF-16 */
             wlen = PATH_LEN_GUESS;
             wconverted = utf8_to_wide_extra_len(src_path, &wlen);
 

--- a/cygwin/cygwin.c
+++ b/cygwin/cygwin.c
@@ -289,7 +289,7 @@ XS(XS_Cygwin_win_to_posix_path)
        Size calculation: On overflow let cygwin_conv_path calculate the final size.
      */
     if (isutf8) {
-        int what = absolute_flag ? CCP_WIN_W_TO_POSIX : CCP_WIN_W_TO_POSIX | CCP_RELATIVE;
+        int what = CCP_WIN_W_TO_POSIX | ((absolute_flag) ? 0 : CCP_RELATIVE);
         STRLEN wlen = sizeof(wchar_t)*(len + PATH_LEN_GUESS);
         wchar_t *wconverted = (wchar_t *) safemalloc(sizeof(wchar_t)*len);
         wchar_t *wsrc = (wchar_t *) safemalloc(wlen);
@@ -323,7 +323,7 @@ XS(XS_Cygwin_win_to_posix_path)
         safefree(wconverted);
         safefree(wsrc);
     } else {
-        int what = absolute_flag ? CCP_WIN_A_TO_POSIX : CCP_WIN_A_TO_POSIX | CCP_RELATIVE;
+        int what = CCP_WIN_A_TO_POSIX | ((absolute_flag) ? 0 : CCP_RELATIVE);
         converted_path = (char *) safemalloc (len + PATH_LEN_GUESS);
         err = cygwin_conv_path(what, src_path, converted_path, len + PATH_LEN_GUESS);
         if (err == ENOSPC) { /* our space assumption was wrong, not enough space */
@@ -378,7 +378,7 @@ XS(XS_Cygwin_posix_to_win_path)
        Size calculation: On overflow let cygwin_conv_path calculate the final size.
      */
     if (isutf8) {
-        int what = absolute_flag ? CCP_POSIX_TO_WIN_W : CCP_POSIX_TO_WIN_W | CCP_RELATIVE;
+        int what = CCP_POSIX_TO_WIN_W | ((absolute_flag) ? 0 : CCP_RELATIVE);
         int wlen = sizeof(wchar_t)*(len + PATH_LEN_GUESS);
         wchar_t *wconverted = (wchar_t *) safemalloc(sizeof(wchar_t)*len);
         wchar_t *wsrc = (wchar_t *) safemalloc(wlen);
@@ -415,7 +415,7 @@ XS(XS_Cygwin_posix_to_win_path)
         safefree(wconverted);
         safefree(wsrc);
     } else {
-        int what = absolute_flag ? CCP_POSIX_TO_WIN_A : CCP_POSIX_TO_WIN_A | CCP_RELATIVE;
+        int what = CCP_POSIX_TO_WIN_A | ((absolute_flag) ? 0 : CCP_RELATIVE);
         converted_path = (char *) safemalloc(len + PATH_LEN_GUESS);
         err = cygwin_conv_path(what, src_path, converted_path, len + PATH_LEN_GUESS);
         if (err == ENOSPC) { /* our space assumption was wrong, not enough space */

--- a/cygwin/cygwin.c
+++ b/cygwin/cygwin.c
@@ -179,23 +179,18 @@ wchar_t*
 utf8_to_wide(const char *buf)
 {
     dTHX;
-    wchar_t *wsrc;
-    mbstate_t mbs;
-    char *oldlocale;
-    int wlen = sizeof(wchar_t)*strlen(buf);
+    Size_t len = strlen(buf) + 1;
 
-    SETLOCALE_LOCK;
+    /* Max expansion factor is sizeof(wchar_t) */
+    Size_t wlen = sizeof(wchar_t) * len;
 
-    oldlocale = setlocale(LC_CTYPE, NULL);
+    wchar_t* wsrc = (wchar_t *) safemalloc(wlen);
 
-    setlocale(LC_CTYPE, "utf-8");
-    wsrc = (wchar_t *) safemalloc(wlen);
-    wlen = mbsrtowcs(wsrc, (const char**)&buf, wlen, &mbs);
+    utf8_to_utf16(buf, (U8 *) wsrc, len, &wlen);
 
-    if (oldlocale) setlocale(LC_CTYPE, oldlocale);
-    else setlocale(LC_CTYPE, "C");
+    return wsrc;
+}
 
-    SETLOCALE_UNLOCK;
 
     return wsrc;
 }

--- a/cygwin/cygwin.c
+++ b/cygwin/cygwin.c
@@ -317,14 +317,8 @@ XS(XS_Cygwin_win_to_posix_path)
             err = cygwin_conv_path(what, wpath, wbuf, newlen);
             wlen = newlen;
         }
-        /* utf16_to_utf8(*p, *d, bytlen, *newlen) */
-        posix_path = (char *) safemalloc(wlen*3);
-        Perl_utf16_to_utf8(aTHX_ (U8*)&wpath, (U8*)posix_path, wlen*2, &len);
-        /*
-        wlen = wcsrtombs(NULL, (const wchar_t **)&wbuf, wlen, NULL);
-        posix_path = (char *) safemalloc(wlen+1);
-        wcsrtombs(posix_path, (const wchar_t **)&wbuf, wlen, NULL);
-        */
+
+        posix_path = wide_to_utf8(wpath);
 
         safefree(wpath);
         safefree(wbuf);
@@ -408,10 +402,9 @@ XS(XS_Cygwin_posix_to_win_path)
             err = cygwin_conv_path(what, wpath, wbuf, newlen);
             wlen = newlen;
         }
-        /* also see utf8.c: Perl_utf16_to_utf8() or Encoding::_bytes_to_utf8(sv, "UCS-2BE"); */
-        wlen = wcsrtombs(NULL, (const wchar_t **)&wbuf, wlen, NULL);
-        win_path = (char *) safemalloc(wlen+1);
-        wcsrtombs(win_path, (const wchar_t **)&wbuf, wlen, NULL);
+
+        win_path = wide_to_utf8(wpath);
+
         if (oldlocale) setlocale(LC_CTYPE, oldlocale);
         else setlocale(LC_CTYPE, "C");
 

--- a/cygwin/cygwin.c
+++ b/cygwin/cygwin.c
@@ -19,6 +19,8 @@
 #include <wchar.h>
 #endif
 
+#define PATH_LEN_GUESS (260 + 1001)
+
 /*
  * pp_system() implemented via spawn()
  * - more efficient and useful when embedding Perl in non-Cygwin apps
@@ -302,7 +304,7 @@ XS(XS_Cygwin_win_to_posix_path)
      */
     if (isutf8) {
         int what = absolute_flag ? CCP_WIN_W_TO_POSIX : CCP_WIN_W_TO_POSIX | CCP_RELATIVE;
-        STRLEN wlen = sizeof(wchar_t)*(len + 260 + 1001);
+        STRLEN wlen = sizeof(wchar_t)*(len + PATH_LEN_GUESS);
         wchar_t *wpath = (wchar_t *) safemalloc(sizeof(wchar_t)*len);
         wchar_t *wbuf = (wchar_t *) safemalloc(wlen);
         if (!IN_BYTES) {
@@ -340,8 +342,8 @@ XS(XS_Cygwin_win_to_posix_path)
         */
     } else {
         int what = absolute_flag ? CCP_WIN_A_TO_POSIX : CCP_WIN_A_TO_POSIX | CCP_RELATIVE;
-        posix_path = (char *) safemalloc (len + 260 + 1001);
-        err = cygwin_conv_path(what, src_path, posix_path, len + 260 + 1001);
+        posix_path = (char *) safemalloc (len + PATH_LEN_GUESS);
+        err = cygwin_conv_path(what, src_path, posix_path, len + PATH_LEN_GUESS);
         if (err == ENOSPC) { /* our space assumption was wrong, not enough space */
             int newlen = cygwin_conv_path(what, src_path, posix_path, 0);
             posix_path = (char *) realloc(&posix_path, newlen);
@@ -349,7 +351,7 @@ XS(XS_Cygwin_win_to_posix_path)
         }
     }
 #else
-    posix_path = (char *) safemalloc (len + 260 + 1001);
+    posix_path = (char *) safemalloc (len + PATH_LEN_GUESS);
     if (absolute_flag)
         err = cygwin_conv_to_full_posix_path(src_path, posix_path);
     else
@@ -395,7 +397,7 @@ XS(XS_Cygwin_posix_to_win_path)
      */
     if (isutf8) {
         int what = absolute_flag ? CCP_POSIX_TO_WIN_W : CCP_POSIX_TO_WIN_W | CCP_RELATIVE;
-        int wlen = sizeof(wchar_t)*(len + 260 + 1001);
+        int wlen = sizeof(wchar_t)*(len + PATH_LEN_GUESS);
         wchar_t *wpath = (wchar_t *) safemalloc(sizeof(wchar_t)*len);
         wchar_t *wbuf = (wchar_t *) safemalloc(wlen);
         char *oldlocale;
@@ -429,8 +431,8 @@ XS(XS_Cygwin_posix_to_win_path)
         SETLOCALE_UNLOCK;
     } else {
         int what = absolute_flag ? CCP_POSIX_TO_WIN_A : CCP_POSIX_TO_WIN_A | CCP_RELATIVE;
-        win_path = (char *) safemalloc(len + 260 + 1001);
-        err = cygwin_conv_path(what, src_path, win_path, len + 260 + 1001);
+        win_path = (char *) safemalloc(len + PATH_LEN_GUESS);
+        err = cygwin_conv_path(what, src_path, win_path, len + PATH_LEN_GUESS);
         if (err == ENOSPC) { /* our space assumption was wrong, not enough space */
             int newlen = cygwin_conv_path(what, src_path, win_path, 0);
             win_path = (char *) realloc(&win_path, newlen);
@@ -440,7 +442,7 @@ XS(XS_Cygwin_posix_to_win_path)
 #else
     if (isutf8)
         Perl_warn(aTHX_ "can't convert utf8 path");
-    win_path = (char *) safemalloc(len + 260 + 1001);
+    win_path = (char *) safemalloc(len + PATH_LEN_GUESS);
     if (absolute_flag)
         err = cygwin_conv_to_full_win32_path(src_path, win_path);
     else

--- a/cygwin/cygwin.c
+++ b/cygwin/cygwin.c
@@ -175,7 +175,6 @@ wide_to_utf8(const wchar_t *wbuf)
     oldlocale = setlocale(LC_CTYPE, NULL);
     setlocale(LC_CTYPE, "utf-8");
 
-    /* uvchr_to_utf8(buf, chr) or Encoding::_bytes_to_utf8(sv, "UCS-2BE"); */
     wlen = wcsrtombs(NULL, (const wchar_t **)&wbuf, wlen, NULL);
     buf = (char *) safemalloc(wlen+1);
     wcsrtombs(buf, (const wchar_t **)&wbuf, wlen, NULL);
@@ -203,7 +202,6 @@ utf8_to_wide(const char *buf)
 
     setlocale(LC_CTYPE, "utf-8");
     wbuf = (wchar_t *) safemalloc(wlen);
-    /* utf8_to_uvchr_buf(pathname, pathname + wlen, wpath) or Encoding::_utf8_to_bytes(sv, "UCS-2BE"); */
     wlen = mbsrtowcs(wbuf, (const char**)&buf, wlen, &mbs);
 
     if (oldlocale) setlocale(LC_CTYPE, oldlocale);
@@ -315,7 +313,6 @@ XS(XS_Cygwin_win_to_posix_path)
 
             oldlocale = setlocale(LC_CTYPE, NULL);
             setlocale(LC_CTYPE, "utf-8");
-            /* utf8_to_uvchr_buf(src_path, src_path + wlen, wpath) or Encoding::_utf8_to_bytes(sv, "UCS-2BE"); */
             wlen = mbsrtowcs(wpath, (const char**)&src_path, wlen, &mbs);
             if (wlen > 0)
                 err = cygwin_conv_path(what, wpath, wbuf, wlen);
@@ -323,7 +320,7 @@ XS(XS_Cygwin_win_to_posix_path)
             else setlocale(LC_CTYPE, "C");
 
             SETLOCALE_UNLOCK;
-        } else { /* use bytes; assume already ucs-2 encoded bytestream */
+        } else { /* use bytes; assume already UTF-16 encoded bytestream */
             err = cygwin_conv_path(what, src_path, wbuf, wlen);
         }
         if (err == ENOSPC) { /* our space assumption was wrong, not enough space */
@@ -408,11 +405,10 @@ XS(XS_Cygwin_posix_to_win_path)
         setlocale(LC_CTYPE, "utf-8");
         if (!IN_BYTES) {
             mbstate_t mbs;
-            /* utf8_to_uvchr_buf(src_path, src_path + wlen, wpath) or Encoding::_utf8_to_bytes(sv, "UCS-2BE"); */
             wlen = mbsrtowcs(wpath, (const char**)&src_path, wlen, &mbs);
             if (wlen > 0)
                 err = cygwin_conv_path(what, wpath, wbuf, wlen);
-        } else { /* use bytes; assume already ucs-2 encoded bytestream */
+        } else { /* use bytes; assume already UTF-16 encoded bytestream */
             err = cygwin_conv_path(what, src_path, wbuf, wlen);
         }
         if (err == ENOSPC) { /* our space assumption was wrong, not enough space */

--- a/cygwin/cygwin.c
+++ b/cygwin/cygwin.c
@@ -379,7 +379,7 @@ XS(XS_Cygwin_posix_to_win_path)
      */
     if (isutf8) {
         int what = CCP_POSIX_TO_WIN_W | ((absolute_flag) ? 0 : CCP_RELATIVE);
-        int wlen = sizeof(wchar_t)*(len + PATH_LEN_GUESS);
+        STRLEN wlen = sizeof(wchar_t)*(len + PATH_LEN_GUESS);
         wchar_t *wconverted = (wchar_t *) safemalloc(sizeof(wchar_t)*len);
         wchar_t *wsrc = (wchar_t *) safemalloc(wlen);
 

--- a/cygwin/cygwin.c
+++ b/cygwin/cygwin.c
@@ -160,17 +160,17 @@ leave:
 
 #if (CYGWIN_VERSION_API_MINOR >= 181)
 char*
-wide_to_utf8(const wchar_t *wbuf)
+wide_to_utf8(const wchar_t *wsrc)
 {
     dTHX;
-    const Size_t wlen = (wcslen(wbuf) + 1) * sizeof(wchar_t);
+    const Size_t wlen = (wcslen(wsrc) + 1) * sizeof(wchar_t);
 
     /* Max expansion factor is 3/2 */
     Size_t blen = wlen * 3 / 2;
 
     char *buf = (char *) safemalloc(blen);
 
-    utf16_to_utf8((U8 *) wbuf, buf, wlen, &blen);
+    utf16_to_utf8((U8 *) wsrc, buf, wlen, &blen);
 
     return buf;
 }
@@ -179,7 +179,7 @@ wchar_t*
 utf8_to_wide(const char *buf)
 {
     dTHX;
-    wchar_t *wbuf;
+    wchar_t *wsrc;
     mbstate_t mbs;
     char *oldlocale;
     int wlen = sizeof(wchar_t)*strlen(buf);
@@ -189,15 +189,15 @@ utf8_to_wide(const char *buf)
     oldlocale = setlocale(LC_CTYPE, NULL);
 
     setlocale(LC_CTYPE, "utf-8");
-    wbuf = (wchar_t *) safemalloc(wlen);
-    wlen = mbsrtowcs(wbuf, (const char**)&buf, wlen, &mbs);
+    wsrc = (wchar_t *) safemalloc(wlen);
+    wlen = mbsrtowcs(wsrc, (const char**)&buf, wlen, &mbs);
 
     if (oldlocale) setlocale(LC_CTYPE, oldlocale);
     else setlocale(LC_CTYPE, "C");
 
     SETLOCALE_UNLOCK;
 
-    return wbuf;
+    return wsrc;
 }
 #endif /* cygwin 1.7 */
 
@@ -270,7 +270,7 @@ XS(XS_Cygwin_win_to_posix_path)
     STRLEN len;
     int err = 0;
     char *src_path;
-    char *posix_path;
+    char *converted_path;
     int isutf8 = 0;
 
     if (items < 1 || items > 2)
@@ -291,8 +291,8 @@ XS(XS_Cygwin_win_to_posix_path)
     if (isutf8) {
         int what = absolute_flag ? CCP_WIN_W_TO_POSIX : CCP_WIN_W_TO_POSIX | CCP_RELATIVE;
         STRLEN wlen = sizeof(wchar_t)*(len + PATH_LEN_GUESS);
-        wchar_t *wpath = (wchar_t *) safemalloc(sizeof(wchar_t)*len);
-        wchar_t *wbuf = (wchar_t *) safemalloc(wlen);
+        wchar_t *wconverted = (wchar_t *) safemalloc(sizeof(wchar_t)*len);
+        wchar_t *wsrc = (wchar_t *) safemalloc(wlen);
         if (!IN_BYTES) {
             mbstate_t mbs;
             char *oldlocale;
@@ -301,55 +301,55 @@ XS(XS_Cygwin_win_to_posix_path)
 
             oldlocale = setlocale(LC_CTYPE, NULL);
             setlocale(LC_CTYPE, "utf-8");
-            wlen = mbsrtowcs(wpath, (const char**)&src_path, wlen, &mbs);
+            wlen = mbsrtowcs(wconverted, (const char**)&src_path, wlen, &mbs);
             if (wlen > 0)
-                err = cygwin_conv_path(what, wpath, wbuf, wlen);
+                err = cygwin_conv_path(what, wconverted, wsrc, wlen);
             if (oldlocale) setlocale(LC_CTYPE, oldlocale);
             else setlocale(LC_CTYPE, "C");
 
             SETLOCALE_UNLOCK;
         } else { /* use bytes; assume already UTF-16 encoded bytestream */
-            err = cygwin_conv_path(what, src_path, wbuf, wlen);
+            err = cygwin_conv_path(what, src_path, wsrc, wlen);
         }
         if (err == ENOSPC) { /* our space assumption was wrong, not enough space */
-            int newlen = cygwin_conv_path(what, wpath, wbuf, 0);
-            wbuf = (wchar_t *) realloc(&wbuf, newlen);
-            err = cygwin_conv_path(what, wpath, wbuf, newlen);
+            int newlen = cygwin_conv_path(what, wconverted, wsrc, 0);
+            wsrc = (wchar_t *) realloc(&wsrc, newlen);
+            err = cygwin_conv_path(what, wconverted, wsrc, newlen);
             wlen = newlen;
         }
 
-        posix_path = wide_to_utf8(wpath);
+        converted_path = wide_to_utf8(wconverted);
 
-        safefree(wpath);
-        safefree(wbuf);
+        safefree(wconverted);
+        safefree(wsrc);
     } else {
         int what = absolute_flag ? CCP_WIN_A_TO_POSIX : CCP_WIN_A_TO_POSIX | CCP_RELATIVE;
-        posix_path = (char *) safemalloc (len + PATH_LEN_GUESS);
-        err = cygwin_conv_path(what, src_path, posix_path, len + PATH_LEN_GUESS);
+        converted_path = (char *) safemalloc (len + PATH_LEN_GUESS);
+        err = cygwin_conv_path(what, src_path, converted_path, len + PATH_LEN_GUESS);
         if (err == ENOSPC) { /* our space assumption was wrong, not enough space */
-            int newlen = cygwin_conv_path(what, src_path, posix_path, 0);
-            posix_path = (char *) realloc(&posix_path, newlen);
-            err = cygwin_conv_path(what, src_path, posix_path, newlen);
+            int newlen = cygwin_conv_path(what, src_path, converted_path, 0);
+            converted_path = (char *) realloc(&converted_path, newlen);
+            err = cygwin_conv_path(what, src_path, converted_path, newlen);
         }
     }
 #else
-    posix_path = (char *) safemalloc (len + PATH_LEN_GUESS);
+    converted_path = (char *) safemalloc (len + PATH_LEN_GUESS);
     if (absolute_flag)
-        err = cygwin_conv_to_full_posix_path(src_path, posix_path);
+        err = cygwin_conv_to_full_posix_path(src_path, converted_path);
     else
-        err = cygwin_conv_to_posix_path(src_path, posix_path);
+        err = cygwin_conv_to_posix_path(src_path, converted_path);
 #endif
     if (!err) {
         EXTEND(SP, 1);
-        ST(0) = sv_2mortal(newSVpv(posix_path, 0));
+        ST(0) = sv_2mortal(newSVpv(converted_path, 0));
         if (isutf8) { /* src was utf-8, so result should also */
             /* TODO: convert ANSI (local windows encoding) to utf-8 on cygwin-1.5 */
             SvUTF8_on(ST(0));
         }
-        safefree(posix_path);
+        safefree(converted_path);
         XSRETURN(1);
     } else {
-        safefree(posix_path);
+        safefree(converted_path);
         XSRETURN_UNDEF;
     }
 }
@@ -360,7 +360,7 @@ XS(XS_Cygwin_posix_to_win_path)
     int absolute_flag = 0;
     STRLEN len;
     int err = 0;
-    char *src_path, *win_path;
+    char *src_path, *converted_path;
     int isutf8 = 0;
 
     if (items < 1 || items > 2)
@@ -380,8 +380,8 @@ XS(XS_Cygwin_posix_to_win_path)
     if (isutf8) {
         int what = absolute_flag ? CCP_POSIX_TO_WIN_W : CCP_POSIX_TO_WIN_W | CCP_RELATIVE;
         int wlen = sizeof(wchar_t)*(len + PATH_LEN_GUESS);
-        wchar_t *wpath = (wchar_t *) safemalloc(sizeof(wchar_t)*len);
-        wchar_t *wbuf = (wchar_t *) safemalloc(wlen);
+        wchar_t *wconverted = (wchar_t *) safemalloc(sizeof(wchar_t)*len);
+        wchar_t *wsrc = (wchar_t *) safemalloc(wlen);
 
         if (!IN_BYTES) {
             mbstate_t mbs;
@@ -392,57 +392,57 @@ XS(XS_Cygwin_posix_to_win_path)
             oldlocale = setlocale(LC_CTYPE, NULL);
             setlocale(LC_CTYPE, "utf-8");
 
-            wlen = mbsrtowcs(wpath, (const char**)&src_path, wlen, &mbs);
+            wlen = mbsrtowcs(wconverted, (const char**)&src_path, wlen, &mbs);
             if (wlen > 0)
-                err = cygwin_conv_path(what, wpath, wbuf, wlen);
+                err = cygwin_conv_path(what, wconverted, wsrc, wlen);
 
             if (oldlocale) setlocale(LC_CTYPE, oldlocale);
             else setlocale(LC_CTYPE, "C");
 
             SETLOCALE_UNLOCK;
         } else { /* use bytes; assume already UTF-16 encoded bytestream */
-            err = cygwin_conv_path(what, src_path, wbuf, wlen);
+            err = cygwin_conv_path(what, src_path, wsrc, wlen);
         }
         if (err == ENOSPC) { /* our space assumption was wrong, not enough space */
-            int newlen = cygwin_conv_path(what, wpath, wbuf, 0);
-            wbuf = (wchar_t *) realloc(&wbuf, newlen);
-            err = cygwin_conv_path(what, wpath, wbuf, newlen);
+            int newlen = cygwin_conv_path(what, wconverted, wsrc, 0);
+            wsrc = (wchar_t *) realloc(&wsrc, newlen);
+            err = cygwin_conv_path(what, wconverted, wsrc, newlen);
             wlen = newlen;
         }
 
-        win_path = wide_to_utf8(wpath);
+        converted_path = wide_to_utf8(wconverted);
 
-        safefree(wpath);
-        safefree(wbuf);
+        safefree(wconverted);
+        safefree(wsrc);
     } else {
         int what = absolute_flag ? CCP_POSIX_TO_WIN_A : CCP_POSIX_TO_WIN_A | CCP_RELATIVE;
-        win_path = (char *) safemalloc(len + PATH_LEN_GUESS);
-        err = cygwin_conv_path(what, src_path, win_path, len + PATH_LEN_GUESS);
+        converted_path = (char *) safemalloc(len + PATH_LEN_GUESS);
+        err = cygwin_conv_path(what, src_path, converted_path, len + PATH_LEN_GUESS);
         if (err == ENOSPC) { /* our space assumption was wrong, not enough space */
-            int newlen = cygwin_conv_path(what, src_path, win_path, 0);
-            win_path = (char *) realloc(&win_path, newlen);
-            err = cygwin_conv_path(what, src_path, win_path, newlen);
+            int newlen = cygwin_conv_path(what, src_path, converted_path, 0);
+            converted_path = (char *) realloc(&converted_path, newlen);
+            err = cygwin_conv_path(what, src_path, converted_path, newlen);
         }
     }
 #else
     if (isutf8)
         Perl_warn(aTHX_ "can't convert utf8 path");
-    win_path = (char *) safemalloc(len + PATH_LEN_GUESS);
+    converted_path = (char *) safemalloc(len + PATH_LEN_GUESS);
     if (absolute_flag)
-        err = cygwin_conv_to_full_win32_path(src_path, win_path);
+        err = cygwin_conv_to_full_win32_path(src_path, converted_path);
     else
-        err = cygwin_conv_to_win32_path(src_path, win_path);
+        err = cygwin_conv_to_win32_path(src_path, converted_path);
 #endif
     if (!err) {
         EXTEND(SP, 1);
-        ST(0) = sv_2mortal(newSVpv(win_path, 0));
+        ST(0) = sv_2mortal(newSVpv(converted_path, 0));
         if (isutf8) {
             SvUTF8_on(ST(0));
         }
-        safefree(win_path);
+        safefree(converted_path);
         XSRETURN(1);
     } else {
-        safefree(win_path);
+        safefree(converted_path);
         XSRETURN_UNDEF;
     }
 }

--- a/cygwin/cygwin.c
+++ b/cygwin/cygwin.c
@@ -276,7 +276,7 @@ XS(XS_Cygwin_win_to_posix_path)
     if (items < 1 || items > 2)
         Perl_croak(aTHX_ "Usage: Cygwin::win_to_posix_path(pathname, [absolute])");
 
-    src_path = SvPV(ST(0), len);
+    src_path = SvPVx(ST(0), len);
     if (items == 2)
         absolute_flag = SvTRUE(ST(1));
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -836,6 +836,11 @@ but then $foo no longer contains a glob.
 (F) You called C<continue>, but you're not inside a C<when>
 or C<default> block.
 
+=item can't convert empty path
+
+(F) On Cygwin, you called a path conversion function with an empty path.
+Only non-empty paths are legal.
+
 =item Can't create pipe mailbox
 
 (P) An error peculiar to VMS.  The process is suffering from exhausted


### PR DESCRIPTION
This series of commits simplifies cygwin.c by, for example, folding nearly identical functions into a single one.  The use of locales to convert between UTF 8/16 is eliminated; instead using the core functions that do that explicitly.

However **The changes are not executed in our test suite**.  Are they actually used by cygwin?  @sisyphus