### PR TITLE
Math-Complex: list all imported constants in POD

### DIFF
--- a/cpan/Math-Complex/lib/Math/Complex.pm
+++ b/cpan/Math-Complex/lib/Math/Complex.pm
@@ -10,7 +10,7 @@ package Math::Complex;
 { use 5.006; }
 use strict;
 
-our $VERSION = 1.59_02;
+our $VERSION = 1.59_03;
 
 use Config;
 

--- a/cpan/Math-Complex/lib/Math/Trig.pm
+++ b/cpan/Math-Complex/lib/Math/Trig.pm
@@ -247,7 +247,7 @@ Math::Trig - trigonometric functions
 
     $rad = deg2rad(120);
 
-    # Import constants pi2, pip2, pip4 (2*pi, pi/2, pi/4).
+    # Import constants pi2, pi4, pip2, pip4 (2*pi, 4*pi, pi/2, pi/4).
     use Math::Trig ':pi';
 
     # Import the conversions between cartesian/spherical/cylindrical.


### PR DESCRIPTION
The constant 'pi4' (= 4*pi) is imported, but is missing from the list of
imported constants in the SYNOPSIS.

This fixes CPAN RT #102544