### PR TITLE
CI: Fix t/porting/authors.t in testsuite

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -93,10 +93,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: git cfg + fetch tags
+      - name: git cfg
         run: |
           git config diff.renameLimit 999999
-          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Configure
         run: |
           ./Configure -des -Dusedevel ${CONFIGURE_ARGS} -Dprefix="$HOME/perl-blead"

--- a/t/porting/authors.t
+++ b/t/porting/authors.t
@@ -10,10 +10,14 @@ BEGIN {
 use TestInit qw(T);    # T is chdir to the top level
 use strict;
 
-find_git_or_skip('all');
+my $source_dir = find_git_or_skip('all');
 skip_all(
     "This distro may have modified some files in cpan/. Skipping validation.")
   if $ENV{'PERL_BUILD_PACKAGING'};
+
+skip_all(
+    "This is a shallow clone, this test requires history.")
+  if (-e "$source_dir/.git/shallow");
 
 my $revision_range = ''; # could use 'v5.22.0..' as default, no reason to recheck all previous commits...
 if ( $ENV{TRAVIS} && defined $ENV{TRAVIS_COMMIT_RANGE} ) {


### PR DESCRIPTION
Starting with commit 16dd3f70cc16005d5af7146385733a7c945fb67e:
- t/porting/authors.t was passing in the sanity check
- t/porting/authors.t was failing in the other tests configurations [when github actions added a merge]

This PR should fix that by: skipping t/porting/authors.t when it's run from a shallow clone. [This is the same behavior as before except now it's explicit and no longer accidental]
