### PR TITLE
Use Windows system default locale

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -3938,8 +3938,18 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
              * fallback possibility). */
             {
                 /* Note that this may change the locale, but we are going to do
-                 * that anyway */
-                const char *system_default_locale = stdized_setlocale(LC_ALL, "");
+                 * that anyway.
+                 *
+                 * Our normal Windows setlocale() implementation ignores the
+                 * system default locale to make things work like POSIX.  This
+                 * is the only place where we want to consider it, so have to
+                 * use wrap_wsetlocale(). */
+                const char *system_default_locale =
+                                    stdize_locale(LC_ALL,
+                                                  S_wrap_wsetlocale(aTHX_ LC_ALL, ""),
+                                                  &PL_stdize_locale_buf,
+                                                  &PL_stdize_locale_bufsize,
+                                                  __LINE__);
                 DEBUG_LOCALE_INIT(LC_ALL_INDEX_, "", system_default_locale);
 
                 /* Skip if invalid or if it's already on the list of locales to

--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -569,4 +569,19 @@ SKIP: {   # GH #20085
     EOF
 }
 
+SKIP: {   # GH #20054
+    my @lc_all_locales = find_locales('LC_ALL');
+    my $locale = $lc_all_locales[0];
+    skip "LC_ALL not enabled on this platform", 1 unless $locale;
+
+    local $ENV{LC_ALL} = "This is not a legal locale name";
+    local $ENV{LANG} = "Nor this neither";
+
+    my $fallback = ($^O eq "MSWin32")
+                    ? "system default"
+                    : "standard";
+    fresh_perl_like("", qr/Falling back to the $fallback locale/,
+                    {}, "check that illegal startup environment falls back");
+}
+
 done_testing();


### PR DESCRIPTION
This fixes #20054

In order to make Perl programs more portable, the perl locale system on
Windows emulates POSIX behavior.  But Windows has a default system
locale, missing from other platforms.  This really should be considered
as a fallback when the POSIX behavior doesn't work.

And it was, for a few releases, as noted in the ticket.  But
inadvertently broken in 5.28; and this commit now restores it.