### PR TITLE
The idea of this PR is to give the dev a little bit more control over our CI testing

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -203,6 +203,11 @@ jobs:
       matrix:
         CONFIGURE_ARGS:
           - "-Dusedevel"
+        TEST_TARGET:
+          - "test"
+          - "test_harness"
+          - "test_porting"
+          - "test_reonly"
 
     steps:
       - name: Install System dependencies
@@ -234,7 +239,7 @@ jobs:
       # linux-i386 is just one job (not a matrix)
       - name: Run Tests
         run: |
-          MALLOC_PERTURB_=254 MALLOC_CHECK_=3 make -j2 test
+          MALLOC_PERTURB_=254 MALLOC_CHECK_=3 make -j2 ${{ matrix.TEST_TARGET }}
 
   #                  _          _           _        _ _
   #  _ __ ___   __ _| | _____  (_)_ __  ___| |_ __ _| | |

--- a/Porting/manicheck
+++ b/Porting/manicheck
@@ -15,12 +15,18 @@ GetOptions('exitstatus!', \$exitstatus)
     or die "$0 [--exitstatus]";
 
 my %files;
+my $forbidden = 0;
 my $missing = 0;
 my $bonus = 0;
 
 open my $fh, '<', 'MANIFEST' or die "Can't read MANIFEST: $!\n";
 for my $line (<$fh>) {
     my ($file) = $line =~ /^(\S+)/;
+    if ($file =~ m/RUNTESTS_([A-Z]+)_ARGS/) {
+        print "$file should never be listed in MANIFEST, please remove it.\n";
+        $forbidden++;
+        next;
+    }
     ++$files{$file};
     next if -f $file;
     ++$missing;
@@ -39,20 +45,21 @@ find {
         my $x = $File::Find::name =~ s!^\./!!r;
         return if $x =~ /^\.git\b/;
         return if $x =~ m{^\.github/};
+        return if $x =~ m/RUNTESTS_([A-Z]+)_ARGS/;
         return if $files{$x};
         ++$bonus;
         print "$x\t\tnot in MANIFEST\n";
     },
 }, ".";
 
-my $exitcode = $exitstatus ? $missing + $bonus : 0;
+my $exitcode = $exitstatus ? $missing + $bonus + $forbidden : 0;
 
 # We can't (meaningfully) exit with codes above 255, so we're going to have to
 # clamp them to some range whatever we do. So as we need the code anyway, use
 # 124 as our maximum instead, and then we can run as a useful git bisect run
 # script if needed...
 
-$exitcode = SKIP - 1
+$exitcode = SKIP
     if $exitcode > SKIP;
 
 exit $exitcode;

--- a/runtests.SH
+++ b/runtests.SH
@@ -71,8 +71,12 @@ case $1 in
 	;;
 esac
 
-if test X"$TESTFILE" = X; then
-    TESTFILE=TEST
+if [ "x$TESTFILE" = "x" ]; then
+    if [ -e "./RUNTESTS_HARNESS_ARGS" ]; then
+        TESTFILE=harness
+    else
+        TESTFILE=TEST
+    fi
 fi
 
 cd t

--- a/t/TEST
+++ b/t/TEST
@@ -464,7 +464,18 @@ sub _tests_from_manifest {
     return @results;
 }
 
-unless (@ARGV) {
+my $test_manifest= "./RUNTESTS_TEST_ARGS";
+if (-e $test_manifest and !@ARGV) {
+    print STDERR "# using '$test_manifest' for t/TEST arguments!\n";
+    open my $fh, "<", $test_manifest
+	or die "Failed to read '$test_manifest': $!";
+    while (defined(my $arg= <$fh>)) {
+	chomp($arg);
+	push @ARGV, $arg;
+    }
+    close $fh;
+}
+elsif (!@ARGV) {
     # base first, as TEST bails out if that can't run
     # then comp, to validate that require works
     # then run, to validate that -M works

--- a/t/harness
+++ b/t/harness
@@ -14,6 +14,18 @@ use TAP::Harness 3.13;
 use strict;
 use Config;
 
+my $test_manifest= "./RUNTESTS_HARNESS_ARGS";
+if (-e $test_manifest and !@ARGV) {
+    print STDERR "# using $test_manifest for t/harness arguments!\n";
+    open my $fh, "<", $test_manifest
+	or die "Failed to read '$test_manifest': $!";
+    while (defined(my $arg= <$fh>)) {
+	chomp($arg);
+	push @ARGV, $arg;
+    }
+    close $fh;
+}
+
 $::do_nothing = $::do_nothing = 1;
 require './TEST';
 our $Valgrind_Log;

--- a/t/porting/manifest.t
+++ b/t/porting/manifest.t
@@ -55,6 +55,14 @@ while (<$m>) {
 
     isnt($file, undef, "Line $. doesn't start with a blank") or next;
     ok(-f $file, "File $file exists");
+    if ($file=~/RUNTESTS_([A-Z]+)_ARGS/) {
+        # files of the form RUNTESTS_([A-Z]+)_ARGS should never be listed in
+        # the manifest, and their presence on disk should ALWAYS cause a manifest
+        # failure if the manifest test is run. They are strictly meant for use
+        # during development to control our testing CI.
+        fail("Forbidden file '$file' should not be listed in MANIFEST at line $.");
+        next;
+    }
     if ($separator !~ tr/\t//c) {
 	# It's all tabs
 	next;


### PR DESCRIPTION
Karl asked for a way to run CI with a restricted set of targets, which is pretty easy to do on the command line. This PR is intended to allow some magic files to be included in the root directory, RUNTESTS_TEST_ARGS and RUNTESTS_HARNESS_ARGS, which is intended to be a way to make runtests use the desired harness target with the desired arguments.

Files of the form RUNTESTS_[A-Z]_ARGS are forbidden from being listed in the manifest, and if the manifest checks run they will get unhappy if the files are either present on disk or listed explicitly. Eg, unless somone is extremely careless we should never merge these files to blead.