### PR TITLE
Make it possible to turn off (or lengthen time for) the watchdog in the t\win32\popen.t test

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -495,6 +495,7 @@ Keith Thompson <keith.s.thompson@gmail.com> Keith Thompson <kst@mib.org>
 Ken Neighbors <unknown> Ken Neighbors <perlbug@perl.org>
 Ken Williams <ken@mathforum.org> <kenahoo@gmail.com>
 Ken Williams <ken@mathforum.org> Ken Williams <ken.williams@thomsonreuters.com>
+Kenneth Ölwing <knth@cpan.org>
 Kent Fredric <kentfredric@gmail.com> Kent Fredric <kentnl@cpan.org>
 Kevin Brintnall <kbrint@rufus.net> kevin brintnall <kbrint@rufus.net>
 Kevin Ryde <user42@zip.com.au> Kevin Ryde <perlbug-followup@perl.org>

--- a/AUTHORS
+++ b/AUTHORS
@@ -783,7 +783,6 @@ Ken Williams                   <ken@mathforum.org>
 Kenichi Ishigaki               <ishigaki@cpan.org>
 Kenneth Albanowski             <kjahds@kjahds.com>
 Kenneth Duda                   <kjd@cisco.com>
-Kenneth Olwing                 <knth@cpan.org>
 Kenneth Ölwing                 <knth@cpan.org>
 Kent Fredric                   <kentfredric@gmail.com>
 Keong Lim                      <Keong.Lim@sr.com.au>

--- a/AUTHORS
+++ b/AUTHORS
@@ -783,6 +783,8 @@ Ken Williams                   <ken@mathforum.org>
 Kenichi Ishigaki               <ishigaki@cpan.org>
 Kenneth Albanowski             <kjahds@kjahds.com>
 Kenneth Duda                   <kjd@cisco.com>
+Kenneth Olwing                 <knth@cpan.org>
+Kenneth Ölwing                 <knth@cpan.org>
 Kent Fredric                   <kentfredric@gmail.com>
 Keong Lim                      <Keong.Lim@sr.com.au>
 Kevin Brintnall                <kbrint@rufus.net>

--- a/t/win32/popen.t
+++ b/t/win32/popen.t
@@ -13,7 +13,15 @@ BEGIN {
 
 # [perl #77672] backticks capture text printed to stdout when working
 # with multiple threads on windows
-watchdog(20); # before the fix this would often lock up
+# As documented in https://github.com/Perl/perl5/issues/20081 (but as
+# what seems to a problem not related to that issue per se) it appears
+# that the use of the watchdog actually introduces a problem by itself
+# when building on Win11. Running the test without a watchdogs succeeds.
+# As the real cause is as yet unclear, for anyone experiencing the problem,
+# the watchdog can be set to a longer time by setting PERL_TEST_TIME_OUT_FACTOR
+my $time_out_factor = $ENV{PERL_TEST_TIME_OUT_FACTOR} || 1;
+$time_out_factor = 1 if $time_out_factor < 1;
+watchdog(20 * $time_out_factor); # before the fix this would often lock up
 
 fresh_perl_like(<<'PERL', qr/\A[z\n]+\z/, {}, "popen and threads");
 if (!defined fork) { die "can't fork" }


### PR DESCRIPTION
In my case when building on Win11, the t\win32\popen.t test often fails due to a watchdog timing out. Turning off (or really lengthening) the timer, it completes successfully. So far, this seems prevalent on Win11, have not been able to replicate on Win10.
As the root cause for why it takes a longer time to succeed is unknown, I suspect that the watchdog code itself is causing a problem. Hence, I require the possibility to turn it off which this change enables.

For further discussion on when this was identified, see #20081 (this problem seems not to be directly coupled with the issue discussed there).