### PR TITLE
Consolidate PERL_TEST_TIME_OUT_FACTOR to watchdog()

### DIFF
--- a/dist/threads/t/libc.t
+++ b/dist/threads/t/libc.t
@@ -9,11 +9,8 @@ BEGIN {
         skip_all(q/Perl not compiled with 'useithreads'/);
     }
 
-    my $time_out_factor = $ENV{PERL_TEST_TIME_OUT_FACTOR} || 1;
-    $time_out_factor = 1 if $time_out_factor < 1;
-
     # Guard against bugs that result in deadlock
-    watchdog(1 * 60 * $time_out_factor);
+    watchdog(1 * 60);
 
     plan(11);
 }

--- a/t/re/fold_grind.pl
+++ b/t/re/fold_grind.pl
@@ -17,10 +17,8 @@ BEGIN {
     if ($^O eq 'dec_osf') {
       skip_all("$^O cannot handle this test");
     }
-    my $time_out_factor = $ENV{PERL_TEST_TIME_OUT_FACTOR} || 1;
-    $time_out_factor = 1 if $time_out_factor < 1;
 
-    watchdog(5 * 60 * $time_out_factor);
+    watchdog(5 * 60);
     require './loc_tools.pl';
 }
 

--- a/t/re/pat_advanced.t
+++ b/t/re/pat_advanced.t
@@ -2382,7 +2382,7 @@ EOF
     TODO: {   # Was looping
         todo_skip('Triggers thread clone SEGV. See #86550')
 	  if $::running_as_thread && $::running_as_thread;
-        watchdog(10 * ($ENV{PERL_TEST_TIME_OUT_FACTOR} || 1));
+        watchdog(10);
         like("\x{00DF}", qr/[\x{1E9E}_]*/i, "\"\\x{00DF}\" =~ /[\\x{1E9E}_]*/i was looping");
     }
 

--- a/t/re/pat_psycho.t
+++ b/t/re/pat_psycho.t
@@ -24,10 +24,8 @@ BEGIN {
     if ($^O eq 'dec_osf') {
         skip_all("$^O cannot handle this test");
     }
-    my $time_out_factor = $ENV{PERL_TEST_TIME_OUT_FACTOR} || 1;
-    $time_out_factor = 1 if $time_out_factor < 1;
 
-    watchdog(5 * 60 * $time_out_factor);
+    watchdog(5 * 60);
 }
 
 

--- a/t/re/speed.t
+++ b/t/re/speed.t
@@ -42,9 +42,7 @@ run_tests() unless caller;
 sub run_tests {
 
 
-    watchdog(($ENV{PERL_TEST_TIME_OUT_FACTOR} || 1)
-             * (($::running_as_thread && $::running_as_thread)
-                ? 150 : 225));
+    watchdog((($::running_as_thread && $::running_as_thread) ? 150 : 225));
 
     {
         # [perl #120446]


### PR DESCRIPTION
This changes test.pl watchdog() to always consider this potential
setting of an environment variable, and removes the distributed uses.

This means that no code needs to change when tests start failing on a
slow platform due to timing out; or when you need to temporarily
increase the timeout of a test for debugging.  This will correspondingly
increase the timeout of all tests, but who cares for debugging purposes.