### PR TITLE
Bump Locale::Maketext version to 1.32 to match CPAN

### DIFF
--- a/dist/Locale-Maketext/ChangeLog
+++ b/dist/Locale-Maketext/ChangeLog
@@ -1,5 +1,9 @@
 Revision history for Perl suite Locale::Maketext
 
+2022-08-22
+   * Release 1.32 to CPAN
+   * Fix Makefile.PL logic for default install destination on 5.008 up to 5.011
+
 2022-04-14
    * Release 1.31 to CPAN
    * White space cleanup.

--- a/dist/Locale-Maketext/lib/Locale/Maketext.pm
+++ b/dist/Locale-Maketext/lib/Locale/Maketext.pm
@@ -25,7 +25,7 @@ BEGIN {
 }
 
 
-our $VERSION = '1.31';
+our $VERSION = '1.32';
 our @ISA = ();
 
 our $MATCH_SUPERS = 1;


### PR DESCRIPTION
This corrected a Makefile.PL bug specific only to the dual life version
related to where libraries were installed

See #20087 for more information.