### PR TITLE
Change optimization level for Win32 builds

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -608,11 +608,16 @@ LIBFILES	+= -lquadmath
 endif
 
 ifeq ($(CFG),Debug)
-OPTIMIZE	= -g -O2
+# According to https://gcc.gnu.org/onlinedocs/gcc-8.3.0/gcc/Optimize-Options.html
+# -Og should provide some optimizations while still giving convenient debugging
+OPTIMIZE	= -g -Og
 LINK_DBG	= -g
 DEFINES		+= -DDEBUGGING
 else
-OPTIMIZE	= -O2
+# In https://github.com/Perl/perl5/issues/20081 it is found that the previous
+# optimization level -O2 causes generated code that fails in mysterious ways
+# when run on Win11 (*even* if it was built and successfully tested on Win10!).
+OPTIMIZE	= -Os
 LINK_DBG	= -s
 endif
 


### PR DESCRIPTION
As described in #20081, building with the toolchain in Strawberry 5.32.1 (gcc 8.3.0), something in -O2 optimization stably causes fatal errors (i.e. process dying hard) when building (on either Windows 10/11) and running the resulting perl on Windows 11. For safety until the cause can be found,, this PR shifts to -Os instead which, again stably, makes the problems disappear.

As an aside, I think it's odd to have a debug build do -O2 optimizations; instead suggesting -Og which is documented to provide a good debugging experience.