### PR TITLE
Time-HiRes: use GIMME_V instead of the deprecated GIMME

### DIFF
--- a/dist/Time-HiRes/Changes
+++ b/dist/Time-HiRes/Changes
@@ -4,6 +4,7 @@ Revision history for the Perl extension Time::HiRes.
 
  - Remove obsolete vms code
  - Use core version compare
+ - Use GIMME_V instead of the deprecated GIMME
 
 1.9764 [2020-08-10]
  - Fix a bunch of repeated-word typos

--- a/dist/Time-HiRes/HiRes.pm
+++ b/dist/Time-HiRes/HiRes.pm
@@ -50,7 +50,7 @@ our @EXPORT_OK = qw (usleep sleep ualarm alarm gettimeofday time tv_interval
                  stat lstat utime
                 );
 
-our $VERSION = '1.9770';
+our $VERSION = '1.9771';
 our $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 

--- a/dist/Time-HiRes/HiRes.xs
+++ b/dist/Time-HiRes/HiRes.xs
@@ -1193,7 +1193,7 @@ gettimeofday()
         int status;
         status = gettimeofday (&Tp, NULL);
         if (status == 0) {
-            if (GIMME == G_LIST) {
+            if (GIMME_V == G_LIST) {
                 EXTEND(sp, 2);
                 PUSHs(sv_2mortal(newSViv(Tp.tv_sec)));
                 PUSHs(sv_2mortal(newSViv(Tp.tv_usec)));
@@ -1250,7 +1250,7 @@ setitimer(which, seconds, interval = 0)
         if (setitimer(which, &newit, &oldit) == 0) {
             EXTEND(sp, 1);
             PUSHs(sv_2mortal(newSVnv(TV2NV(oldit.it_value))));
-            if (GIMME == G_LIST) {
+            if (GIMME_V == G_LIST) {
                 EXTEND(sp, 1);
                 PUSHs(sv_2mortal(newSVnv(TV2NV(oldit.it_interval))));
             }
@@ -1270,7 +1270,7 @@ getitimer(which)
         if (getitimer(which, &nowit) == 0) {
             EXTEND(sp, 1);
             PUSHs(sv_2mortal(newSVnv(TV2NV(nowit.it_value))));
-            if (GIMME == G_LIST) {
+            if (GIMME_V == G_LIST) {
                 EXTEND(sp, 1);
                 PUSHs(sv_2mortal(newSVnv(TV2NV(nowit.it_interval))));
             }


### PR DESCRIPTION
GIMME_V has been around since 5.003_96.  It was already used in some
places, this just makes it consistent.