### PR TITLE
Mark dowantarray() as deprecated

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -977,7 +977,7 @@ p	|void	|do_vop 	|I32 optype				\
 : Used in perly.y
 p	|OP *	|dofile 	|NN OP *term				\
 				|I32 force_builtin
-CdpR	|U8	|dowantarray
+CdpRD	|U8	|dowantarray
 Adp	|void	|dump_all
 p	|void	|dump_all_perl	|bool justperl
 Apdh	|void	|dump_eval

--- a/proto.h
+++ b/proto.h
@@ -1017,6 +1017,7 @@ Perl_dounwind(pTHX_ I32 cxix);
 
 PERL_CALLCONV U8
 Perl_dowantarray(pTHX)
+        __attribute__deprecated__
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_DOWANTARRAY
 


### PR DESCRIPTION
This will make uses of the also-deprecated `GIMME` macro emit a compile-time warning.

Note that there are 3 modules still using `GIMME` in core, so this should not be merged until these are merged:

 * #20138 
 * pmqs/Compress-Raw-Zlib#19
 * pmqs/Compress-Raw-Bzip2#8