### PR TITLE
updateAUTHORS.pm: quote the commit range

### DIFF
--- a/Porting/updateAUTHORS.pm
+++ b/Porting/updateAUTHORS.pm
@@ -205,7 +205,7 @@ sub read_commit_log {
     my $author_info= $self->{author_info}   ||= {};
     my $mailmap_info= $self->{mailmap_info} ||= {};
 
-    my $commit_range= $self->{commit_range};
+    my $commit_range= $self->{commit_range} ? qq#'$self->{commit_range}'# : "";
     my $commits_read= 0;
 
     my $numstat= $self->{numstat} ? "--numstat" : "";


### PR DESCRIPTION
Several of the tests in t/porting/update_authors.t include
the '^' symbol in the commit range to refer to the parent of the
commit (or '^^^' to refer to grand-grand-parent).

On Windows '^' is a meta-character in cmd.exe which causes the
next character to be escaped (i.e. it's Windows variant of '\').

=> When running commands the commit range must be quoted (since
   it might contain '^' characters). (An alternative fix: do
   `s/\^/^^/g;` when running on Windows)