### PR TITLE
Improve switching to a new LC_CTYPE locale

### DIFF
--- a/embedvar.h
+++ b/embedvar.h
@@ -85,6 +85,7 @@
 #define PL_comppad_name_floor	(vTHX->Icomppad_name_floor)
 #define PL_constpadix		(vTHX->Iconstpadix)
 #define PL_cop_seqmax		(vTHX->Icop_seqmax)
+#define PL_ctype_name		(vTHX->Ictype_name)
 #define PL_curcop		(vTHX->Icurcop)
 #define PL_curcopdb		(vTHX->Icurcopdb)
 #define PL_curlocales		(vTHX->Icurlocales)

--- a/inline.h
+++ b/inline.h
@@ -3133,8 +3133,14 @@ Perl_foldEQ_locale(pTHX_ const char *s1, const char *s2, I32 len)
     assert(len >= 0);
 
     while (len--) {
-        if (*a != *b && *a != PL_fold_locale[*b])
+        if (*a != *b && *a != PL_fold_locale[*b]) {
+            DEBUG_Lv(PerlIO_printf(Perl_debug_log,
+                     "%s:%d: Our records indicate %02x is not a fold of %02x"
+                     " or its mate %02x\n",
+                     __FILE__, __LINE__, *a, *b, PL_fold_locale[*b]));
+
             return 0;
+        }
         a++,b++;
     }
     return 1;

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -839,6 +839,12 @@ PERLVARI(I, underlying_numeric_obj, locale_t, NULL)
 PERLVARI(I, scratch_locale_obj, locale_t, 0)
 #endif
 
+#ifdef USE_LOCALE_CTYPE
+
+PERLVARI(I, ctype_name, const char *, NULL)   /* Name of current ctype locale */
+
+#  endif
+
 /* Array of signal handlers, indexed by signal number, through which the C
    signal handler dispatches.  */
 PERLVAR(I, psig_ptr,	SV **)

--- a/makedef.pl
+++ b/makedef.pl
@@ -553,6 +553,12 @@ unless ($define{USE_LOCALE_NUMERIC}) {
 			 );
 }
 
+unless ($define{USE_LOCALE_CTYPE}) {
+    ++$skip{$_} foreach qw(
+		    PL_ctype_name
+			 );
+}
+
 unless ($define{'USE_C_BACKTRACE'}) {
     ++$skip{Perl_get_c_backtrace_dump};
     ++$skip{Perl_dump_c_backtrace};

--- a/perl.c
+++ b/perl.c
@@ -1161,6 +1161,10 @@ perl_destruct(pTHXx)
     SvREFCNT_dec(PL_numeric_radix_sv);
     PL_numeric_radix_sv = NULL;
 #endif
+#ifdef USE_LOCALE_CTYPE
+    Safefree(PL_ctype_name);
+    PL_ctype_name = NULL;
+#endif
 
     if (PL_setlocale_buf) {
         Safefree(PL_setlocale_buf);

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -207,7 +207,7 @@ and New Warnings
 
 =item *
 
-XXX L<message|perldiag/"message">
+L<Locale '%s' is unsupported, and may crash the interpreter.message|perldiag/"Locale '%s' is unsupported, and may crash the interpreter.">
 
 =back
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -3436,6 +3436,16 @@ the first approach, not using C<ispunct()> at all (see L<Note [5] in
 perlrecharclass|perlrecharclass/[5]>), and this message is raised to notify you that you
 are getting Perl's approach, not the locale's.
 
+=item Locale '%s' is unsupported, and may crash the interpreter.
+
+(S locale) The named locale is not supported by Perl, and using it leads
+to undefined behavior, including potentially crashing the computer.
+
+Currently the only locales that generate this severe warning are
+non-UTF-8 ones which have characters that require more than one byte to
+represent (common in older East Asian language locales).  See
+L<perllocale>.
+
 =item Locale '%s' may not work well.%s
 
 (W locale) You are using the named locale, which is a non-UTF-8 one, and

--- a/sv.c
+++ b/sv.c
@@ -15831,6 +15831,7 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
 #ifdef USE_LOCALE_CTYPE
     Copy(proto_perl->Ifold_locale, PL_fold_locale, 256, U8);
     /* Should we warn if uses locale? */
+    PL_ctype_name	= SAVEPV(proto_perl->Ictype_name);
     PL_warn_locale      = sv_dup_inc(proto_perl->Iwarn_locale, param);
     PL_utf8locale             = proto_perl->Iutf8locale;
     PL_in_utf8_CTYPE_locale   = proto_perl->Iin_utf8_CTYPE_locale;


### PR DESCRIPTION
This series of commits caches the LC_CTYPE value so it doesn't need to be recalculated

And uses our built-in fold tables for the C and UTF-8 locales.  This saves work and avoids bugs in vendors' locale definitions

A new diagnostic is raised when someone switches to, say an ISO 2022, multibyte locale that is not UTF-8.  These are unsupported, and can crash the interpreter.  The message is thus marked as S

And new verbose debugging info is added.