### PR TITLE
Perl_sv_setsv_flags: return after invlist_clone case

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -4156,7 +4156,9 @@ Perl_sv_setsv_flags(pTHX_ SV *dsv, SV* ssv, const I32 flags)
     SV_CHECK_THINKFIRST_COW_DROP(dsv);
     dtype = SvTYPE(dsv); /* THINKFIRST may have changed type */
 
-    /* There's a lot of redundancy below but we're going for speed here */
+    /* There's a lot of redundancy below but we're going for speed here
+     * Note: some of the cases below do return; rather than break; so the
+     * if-elseif-else logic below this switch does not see all cases. */
 
     switch (stype) {
     case SVt_NULL:
@@ -4244,7 +4246,7 @@ Perl_sv_setsv_flags(pTHX_ SV *dsv, SV* ssv, const I32 flags)
 
     case SVt_INVLIST:
         invlist_clone(ssv, dsv);
-        break;
+        return;
     default:
         {
         const char * const type = sv_reftype(ssv,0);


### PR DESCRIPTION
In the "first_ switch" statement in **Perl_sv_setsv_flags**, there's this case:
```
    case SVt_INVLIST:
        invlist_clone(ssv, dsv);
        break;
```
It's not obvious clear that there's any point in this case continuing rather than returning from the function. This was briefly discussed on IRC earlier this year,  but no-one pointed out anything wrong with it or any reason for it, and it seemed a case of "if it ain't broke, don't fix it".

But looking at it again, it definitely seems inefficient. **S_initialize_invlist_guts** (called from **Perl_invlist_clone**, both in _regcomp.c_), does `SvPOK_on(invlist)`.

**Perl_invlist_clone** does some stuff and then copies the PV buffer from the old invlist to the new one:
`    Copy(SvPVX(invlist), SvPVX(new_invlist), physical_length, char);`
and then returns to **Perl_sv_setsv_flags**.

There, since `(sflags & SVp_POK)` is presumably true from the original inversion list, the function is going to try to (swipe or COW or) copy the PV buffer again!

Changing the `break;` to a `return;` doesn't seem to break any existing tests.