### PR TITLE
run/locale.t: skip illegal locale test when all are legal

### DIFF
--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -571,6 +571,10 @@ SKIP: {   # GH #20085
 }
 
 SKIP: {   # GH #20054
+    skip "Even illegal locale names are accepted", 1
+                    if $Config{d_setlocale_accepts_any_locale_name}
+                    && $Config{d_setlocale_accepts_any_locale_name} eq 'define';
+	
     my @lc_all_locales = find_locales('LC_ALL');
     my $locale = $lc_all_locales[0];
     skip "LC_ALL not enabled on this platform", 1 unless $locale;


### PR DESCRIPTION
OpenBSD believes that locales are so inherently insecure that it only
internally has two locales: C and C.UTF-8, which it knows how to treat
securely.

However, to preserve at least the illusion of portability, the locale
setting operations do not fail whatever garbage is passed as the locale
name.  (There may be unacceptable strings, but any reasonable locale
name and a lot of unreasonable ones are accepted.)  If the input name
looks like it was meant to have "UTF-8" in its name, the locale is set
to C.UTF-8.  Otherwise, it is set to C.  Early releases had bugs in
switching between the two.

I wrote a Configure probe some years ago to detect this situation.

I forgot about this fact in adapting Bram's test case.  It should be
skipped on such platforms.

This fixes #20149