### PR TITLE
dist/threads/shared.pm - use attributes.pm explicitly

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4079,6 +4079,7 @@ dist/threads-shared/t/stress.t		Stress test
 dist/threads-shared/t/sv_refs.t		thread shared variables
 dist/threads-shared/t/sv_simple.t	thread shared variables
 dist/threads-shared/t/utf8.t		Test UTF-8 keys in shared hashes
+dist/threads-shared/t/version.t		Test that pod version matches code version.
 dist/threads-shared/t/wait.t		Test cond_wait and cond_timedwait
 dist/threads-shared/t/waithires.t	Test sub-second cond_timedwait
 dist/Tie-File/ChangeLog			Tie::File

--- a/dist/threads-shared/lib/threads/shared.pm
+++ b/dist/threads-shared/lib/threads/shared.pm
@@ -4,11 +4,11 @@ use 5.008;
 
 use strict;
 use warnings;
+use attributes;
 use Config;
-
 use Scalar::Util qw(reftype refaddr blessed);
 
-our $VERSION = '1.65'; # Please update the pod, too.
+our $VERSION = '1.66'; # Please update the pod, too.
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -196,7 +196,7 @@ threads::shared - Perl extension for sharing data structures between threads
 
 =head1 VERSION
 
-This document describes threads::shared version 1.64
+This document describes threads::shared version 1.66
 
 =head1 SYNOPSIS
 

--- a/dist/threads-shared/t/version.t
+++ b/dist/threads-shared/t/version.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use Test::More;
+
+BEGIN {
+    use Config;
+    if (! $Config{'useithreads'}) {
+        print("1..0 # SKIP Perl not compiled with 'useithreads'\n");
+        exit(0);
+    }
+}
+
+use threads::shared;
+
+# test that the version documented in threads.pm pod matches
+# that of the code.
+
+open my $fh, "<", $INC{"threads/shared.pm"}
+    or die qq(Failed to open '$INC{"threads/shared.pm"}': $!);
+my $file= do { local $/; <$fh> };
+close $fh;
+my $pod_version = 0; 
+if ($file=~/This document describes threads::shared version (\d.\d+)/) {
+    $pod_version = $1;
+}
+is($pod_version, $threads::shared::VERSION,
+   "Check that pod and \$threads::shared::VERSION match");
+done_testing();


### PR DESCRIPTION
It seems it is possible that we load the attributes XS code
without loading the .pm code first. This causes threads/t/kill.t to
die with an error about XS version mismatch. Explicitly loading
the attributes module from threads::shared seems to fix the problem.

This resolves #20155.