### PR TITLE
locale.c: Improve newnumeric()

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3328,7 +3328,6 @@ S	|utf8ness_t|get_locale_string_utf8ness_i				\
 				|const locale_utf8ness_t known_utf8
 S	|void	|new_collate	|NULLOK const char* newcoll
 S	|void	|new_ctype	|NN const char* newctype
-S	|void	|set_numeric_radix|const bool use_locale
 S	|void	|new_numeric	|NN const char* newnum
 S	|void	|new_LC_ALL	|NULLOK const char* unused
 S	|const char*|stdize_locale|const int category			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -3329,7 +3329,7 @@ S	|utf8ness_t|get_locale_string_utf8ness_i				\
 S	|void	|new_collate	|NULLOK const char* newcoll
 S	|void	|new_ctype	|NN const char* newctype
 S	|void	|set_numeric_radix|const bool use_locale
-S	|void	|new_numeric	|NULLOK const char* newnum
+S	|void	|new_numeric	|NN const char* newnum
 S	|void	|new_LC_ALL	|NULLOK const char* unused
 S	|const char*|stdize_locale|const int category			\
 				|NULLOK const char* input_locale	\

--- a/embed.h
+++ b/embed.h
@@ -1732,7 +1732,6 @@
 #define new_numeric(a)		S_new_numeric(aTHX_ a)
 #define restore_switched_locale(a,b)	S_restore_switched_locale(aTHX_ a,b)
 #define save_to_buffer		S_save_to_buffer
-#define set_numeric_radix(a)	S_set_numeric_radix(aTHX_ a)
 #define setlocale_failure_panic_i(a,b,c,d,e)	S_setlocale_failure_panic_i(aTHX_ a,b,c,d,e)
 #define stdize_locale(a,b,c,d,e)	S_stdize_locale(aTHX_ a,b,c,d,e)
 #define switch_category_locale_to_template(a,b,c)	S_switch_category_locale_to_template(aTHX_ a,b,c)

--- a/embedvar.h
+++ b/embedvar.h
@@ -329,6 +329,7 @@
 #define PL_top_env		(vTHX->Itop_env)
 #define PL_toptarget		(vTHX->Itoptarget)
 #define PL_underlying_numeric_obj	(vTHX->Iunderlying_numeric_obj)
+#define PL_underlying_radix_sv	(vTHX->Iunderlying_radix_sv)
 #define PL_unicode		(vTHX->Iunicode)
 #define PL_unitcheckav		(vTHX->Iunitcheckav)
 #define PL_unitcheckav_save	(vTHX->Iunitcheckav_save)

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -828,7 +828,8 @@ PERLVARI(I, numeric_underlying_is_standard, bool, TRUE)
 
 PERLVARI(I, numeric_standard, int, TRUE)    /* Assume C locale numerics */
 PERLVAR(I, numeric_name, char *)     /* Name of current numeric locale */
-PERLVAR(I, numeric_radix_sv, SV *)	/* The radix separator if not '.' */
+PERLVAR(I, numeric_radix_sv, SV *)	/* The radix separator */
+PERLVAR(I, underlying_radix_sv, SV *)	/* The radix in the program's current underlying locale */
 
 #if defined(USE_LOCALE_NUMERIC) && defined(USE_POSIX_2008_LOCALE)
 

--- a/locale.c
+++ b/locale.c
@@ -1703,6 +1703,15 @@ S_new_numeric(pTHX_ const char *newnum)
     Safefree(PL_numeric_name);
     PL_numeric_name = savepv(newnum);
 
+    /* Handle the trivial case */
+    if (isNAME_C_OR_POSIX(PL_numeric_name)) {
+        PL_numeric_standard = TRUE;
+        PL_numeric_underlying_is_standard = TRUE;
+        PL_numeric_underlying = TRUE;
+        sv_setpv(PL_numeric_radix_sv, C_decimal_point);
+        return;
+    }
+
     /* We are in the underlying locale until changed at the end of this
      * function */
     PL_numeric_underlying = TRUE;
@@ -1716,11 +1725,8 @@ S_new_numeric(pTHX_ const char *newnum)
 
 #    endif
 
-    if (isNAME_C_OR_POSIX(PL_numeric_name)) {
-        PL_numeric_standard = TRUE;
-    }
-    else { /* If its name isn't C nor POSIX, it could still be
-              indistinguishable from them. */
+     { /* If its name isn't C nor POSIX, it could still be indistinguishable
+          from them. */
         const char * scratch_buffer = NULL;
 
         PL_numeric_standard  = strEQ(C_decimal_point,

--- a/locale.c
+++ b/locale.c
@@ -1696,13 +1696,16 @@ S_new_numeric(pTHX_ const char *newnum)
      *                  such platforms.
      */
 
-    PL_numeric_underlying = TRUE;
 
     /* Save the new name if it isn't the same as the previous one, if any */
     if (strNE(PL_numeric_name, newnum)) {
         Safefree(PL_numeric_name);
         PL_numeric_name = savepv(newnum);
     }
+
+    /* We are in the underlying locale until changed at the end of this
+     * function */
+    PL_numeric_underlying = TRUE;
 
 #  ifdef USE_POSIX_2008_LOCALE
 

--- a/locale.c
+++ b/locale.c
@@ -1609,7 +1609,11 @@ S_set_numeric_radix(pTHX_ const bool use_locale)
     /* If 'use_locale' is FALSE, set to use a dot for the radix character.  If
      * TRUE, use the radix character derived from the current locale */
 
-#  ifdef CAN_CALCULATE_RADIX
+#  ifndef CAN_CALCULATE_RADIX
+
+    PERL_UNUSED_ARG(use_locale);
+
+#  else
 
     utf8ness_t utf8ness = UTF8NESS_IMMATERIAL;
     const char * radix;
@@ -1634,11 +1638,8 @@ S_set_numeric_radix(pTHX_ const bool use_locale)
     DEBUG_L(PerlIO_printf(Perl_debug_log, "Locale radix is '%s', ?UTF-8=%d\n",
                                            SvPVX(PL_numeric_radix_sv),
                                            cBOOL(SvUTF8(PL_numeric_radix_sv))));
-#  else
 
-    PERL_UNUSED_ARG(use_locale);
-
-#  endif /* USE_LOCALE_NUMERIC and can find the radix char */
+#  endif /* USE_LOCALE_NUMERIC */
 
 }
 

--- a/locale.c
+++ b/locale.c
@@ -1735,13 +1735,13 @@ S_new_numeric(pTHX_ const char *newnum)
 #    endif
 
     /* Save the new name if it isn't the same as the previous one, if any */
-    if (strNE(PL_numeric_name, save_newnum)) {
+    if (strEQ(PL_numeric_name, save_newnum)) {
+        Safefree(save_newnum);
+    }
+    else {
     /* Save the locale name for future use */
         Safefree(PL_numeric_name);
         PL_numeric_name = save_newnum;
-    }
-    else {
-        Safefree(save_newnum);
     }
 
     PL_numeric_underlying_is_standard = PL_numeric_standard;

--- a/locale.c
+++ b/locale.c
@@ -1696,12 +1696,12 @@ S_new_numeric(pTHX_ const char *newnum)
      *                  such platforms.
      */
 
-
-    /* Save the new name if it isn't the same as the previous one, if any */
-    if (strNE(PL_numeric_name, newnum)) {
-        Safefree(PL_numeric_name);
-        PL_numeric_name = savepv(newnum);
+    if (strEQ(PL_numeric_name, newnum)) {
+        return;
     }
+
+    Safefree(PL_numeric_name);
+    PL_numeric_name = savepv(newnum);
 
     /* We are in the underlying locale until changed at the end of this
      * function */

--- a/locale.c
+++ b/locale.c
@@ -1729,10 +1729,12 @@ S_new_numeric(pTHX_ const char *newnum)
           from them. */
         const char * scratch_buffer = NULL;
 
-        PL_numeric_standard  = strEQ(C_decimal_point,
-                                     my_langinfo_c(RADIXCHAR, LC_NUMERIC,
-                                                   PL_numeric_name,
-                                                   &scratch_buffer, NULL, NULL));
+        PL_numeric_underlying_is_standard  = strEQ(C_decimal_point,
+                                                   my_langinfo_c(RADIXCHAR,
+                                                                 LC_NUMERIC,
+                                                                 PL_numeric_name,
+                                                                 &scratch_buffer,
+                                                                 NULL, NULL));
         Safefree(scratch_buffer);
 
 #    ifndef TS_W32_BROKEN_LOCALECONV
@@ -1756,17 +1758,19 @@ S_new_numeric(pTHX_ const char *newnum)
          * doesn't appear to be used in any of the Micrsoft library routines
          * anyway. */
 
-        PL_numeric_standard &= strEQ(C_thousands_sep,
-                                     my_langinfo_c(THOUSEP, LC_NUMERIC,
-                                                   PL_numeric_name,
-                                                   &scratch_buffer, NULL, NULL));
+        PL_numeric_underlying_is_standard &= strEQ(C_thousands_sep,
+                                                   my_langinfo_c(THOUSEP,
+                                                                 LC_NUMERIC,
+                                                                 PL_numeric_name,
+                                                                 &scratch_buffer,
+                                                                 NULL, NULL));
         Safefree(scratch_buffer);
 
 #    endif
 
     }
 
-    PL_numeric_underlying_is_standard = PL_numeric_standard;
+    PL_numeric_standard = PL_numeric_underlying_is_standard;
 
     DEBUG_L( PerlIO_printf(Perl_debug_log,
                             "Called new_numeric with %s, PL_numeric_name=%s\n",

--- a/locale.c
+++ b/locale.c
@@ -1646,6 +1646,7 @@ S_set_numeric_radix(pTHX_ const bool use_locale)
 STATIC void
 S_new_numeric(pTHX_ const char *newnum)
 {
+    PERL_ARGS_ASSERT_NEW_NUMERIC;
 
 #  ifndef USE_LOCALE_NUMERIC
 
@@ -1694,15 +1695,6 @@ S_new_numeric(pTHX_ const char *newnum)
      *                  with everything set up properly so as to avoid work on
      *                  such platforms.
      */
-
-    if (! newnum) {
-        Safefree(PL_numeric_name);
-        PL_numeric_name = savepv("C");
-        PL_numeric_standard = TRUE;
-        PL_numeric_underlying = TRUE;
-        PL_numeric_underlying_is_standard = TRUE;
-        return;
-    }
 
     PL_numeric_underlying = TRUE;
 

--- a/locale.c
+++ b/locale.c
@@ -1691,6 +1691,11 @@ S_new_numeric(pTHX_ const char *newnum)
     const char * radix = C_decimal_point;
     utf8ness_t utf8ness = UTF8NESS_IMMATERIAL;
 
+    DEBUG_L( PerlIO_printf(Perl_debug_log,
+                           "Called new_numeric with %s, PL_numeric_name=%s\n",
+                           newnum, PL_numeric_name));
+
+    /* If this isn't actually a change, do nothing */
     if (strEQ(PL_numeric_name, newnum)) {
         return;
     }
@@ -1765,10 +1770,6 @@ S_new_numeric(pTHX_ const char *newnum)
 #    endif
 
     PL_numeric_standard = PL_numeric_underlying_is_standard;
-
-    DEBUG_L( PerlIO_printf(Perl_debug_log,
-                           "Called new_numeric with %s, PL_numeric_name=%s\n",
-                           newnum, PL_numeric_name));
 
     /* Keep LC_NUMERIC so that it has the C locale radix and thousands
      * separator.  This is for XS modules, so they don't have to worry about

--- a/locale.c
+++ b/locale.c
@@ -1615,24 +1615,11 @@ S_set_numeric_radix(pTHX_ const bool use_locale)
 
 #  else
 
-    utf8ness_t utf8ness = UTF8NESS_IMMATERIAL;
-    const char * radix;
-    const char * scratch_buffer = NULL;
-
     if (! use_locale) {
-        radix = C_decimal_point;
+        sv_setpv(PL_numeric_radix_sv, C_decimal_point);
     }
     else {
-        radix = my_langinfo_c(RADIXCHAR, LC_NUMERIC,
-                              PL_numeric_name,
-                              &scratch_buffer, NULL, &utf8ness);
-    }
-
-        sv_setpv(PL_numeric_radix_sv, radix);
-    Safefree(scratch_buffer);
-
-    if (utf8ness == UTF8NESS_YES) {
-        SvUTF8_on(PL_numeric_radix_sv);
+        sv_setsv_nomg(PL_numeric_radix_sv, PL_underlying_radix_sv);
     }
 
     DEBUG_L(PerlIO_printf(Perl_debug_log, "Locale radix is '%s', ?UTF-8=%d\n",
@@ -1650,6 +1637,7 @@ S_new_numeric(pTHX_ const char *newnum)
 
 #  ifndef USE_LOCALE_NUMERIC
 
+    PERL_ARGS_ASSERT_NEW_NUMERIC;
     PERL_UNUSED_ARG(newnum);
 
 #  else
@@ -1691,10 +1679,17 @@ S_new_numeric(pTHX_ const char *newnum)
      *                  decimal point.  It is set to either a dot or the
      *                  program's underlying locale's radix character string,
      *                  depending on the situation.
+     * PL_underlying_radix_sv  Contains the program's underlying locale's radix
+     *                  character string.  This is copied into
+     *                  PL_numeric_radix_sv when the situation warrants.  It
+     *                  exists to avoid having to recalculate it when toggling.
      * PL_underlying_numeric_obj = (only on POSIX 2008 platforms)  An object
      *                  with everything set up properly so as to avoid work on
      *                  such platforms.
      */
+
+    const char * radix = C_decimal_point;
+    utf8ness_t utf8ness = UTF8NESS_IMMATERIAL;
 
     if (strEQ(PL_numeric_name, newnum)) {
         return;
@@ -1709,6 +1704,7 @@ S_new_numeric(pTHX_ const char *newnum)
         PL_numeric_underlying_is_standard = TRUE;
         PL_numeric_underlying = TRUE;
         sv_setpv(PL_numeric_radix_sv, C_decimal_point);
+        sv_setpv(PL_underlying_radix_sv, C_decimal_point);
         return;
     }
 
@@ -1725,56 +1721,54 @@ S_new_numeric(pTHX_ const char *newnum)
 
 #    endif
 
-     { /* If its name isn't C nor POSIX, it could still be indistinguishable
-          from them. */
-        const char * scratch_buffer = NULL;
+    /* Find and save this locale's radix character. */
+    my_langinfo_c(RADIXCHAR, LC_NUMERIC, PL_numeric_name,
+                  &radix, NULL, &utf8ness);
+    sv_setpv(PL_underlying_radix_sv, radix);
 
-        PL_numeric_underlying_is_standard  = strEQ(C_decimal_point,
-                                                   my_langinfo_c(RADIXCHAR,
-                                                                 LC_NUMERIC,
-                                                                 PL_numeric_name,
-                                                                 &scratch_buffer,
-                                                                 NULL, NULL));
-        Safefree(scratch_buffer);
+    if (utf8ness == UTF8NESS_YES) {
+        SvUTF8_on(PL_underlying_radix_sv);
+    }
+
+    /* This locale is indistinguishable from C (for numeric purposes) if both
+     * the radix character and the thousands separator are the same as C's.
+     * Start with the radix. */
+    PL_numeric_underlying_is_standard = strEQ(C_decimal_point, radix);
+    Safefree(radix);
 
 #    ifndef TS_W32_BROKEN_LOCALECONV
 
-        scratch_buffer = NULL;
+    /* If the radix isn't the same as C's, we know it is distinguishable from
+     * C; otherwise check the thousands separator too.  Only if both are the
+     * same as C's is the locale indistinguishable from C.
+     *
+     * But on earlier Windows versions, there is a potential race.  This code
+     * knows that localeconv() (elsewhere in this file) will be used to extract
+     * the needed value, and localeconv() was buggy for quite a while, and that
+     * code in this file hence uses a workaround.  And that workaround may have
+     * an (unlikely) race.  Gathering the radix uses a different workaround on
+     * Windows that doesn't involve a race.  It might be possible to do the
+     * same for this (patches welcome).
+     *
+     * Until then khw doesn't think it's worth even the small risk of a race to
+     * get this value, which in almost all locales is empty, and doesn't appear
+     * to be used in any of the Micrsoft library routines anyway. */
 
-        /* If the radix isn't the same as C's, we know it is distinguishable
-         * from C; otherwise check the thousands separator too.  Only if both
-         * are the same as C's is the locale indistinguishable from C.
-         *
-         * But on earlier Windows versions, there is a potential race.  This
-         * code knows that localeconv() (elsewhere in this file) will be used
-         * to extract the needed value, and localeconv() was buggy for quite a
-         * while, and that code in this file hence uses a workaround.  And that
-         * workaround may have an (unlikely) race.  Gathering the radix uses a
-         * different workaround on Windows that doesn't involve a race.  It
-         * might be possible to do the same for this (patches welcome).
-         *
-         * Until then khw doesn't think it's worth even the small risk of a
-         * race to get this value, which in almost all locales is empty, and
-         * doesn't appear to be used in any of the Micrsoft library routines
-         * anyway. */
-
-        PL_numeric_underlying_is_standard &= strEQ(C_thousands_sep,
-                                                   my_langinfo_c(THOUSEP,
-                                                                 LC_NUMERIC,
-                                                                 PL_numeric_name,
-                                                                 &scratch_buffer,
-                                                                 NULL, NULL));
-        Safefree(scratch_buffer);
+    const char * scratch_buffer = NULL;
+    PL_numeric_underlying_is_standard &= strEQ(C_thousands_sep,
+                                               my_langinfo_c(THOUSEP, LC_NUMERIC,
+                                                             PL_numeric_name,
+                                                             &scratch_buffer,
+                                                             NULL, NULL));
+    Safefree(scratch_buffer);
 
 #    endif
-
-    }
 
     PL_numeric_standard = PL_numeric_underlying_is_standard;
 
     DEBUG_L( PerlIO_printf(Perl_debug_log,
-                            "Called new_numeric with %s, PL_numeric_name=%s\n",
-                            newnum, PL_numeric_name));
+                           "Called new_numeric with %s, PL_numeric_name=%s\n",
+                           newnum, PL_numeric_name));
 
     /* Keep LC_NUMERIC so that it has the C locale radix and thousands
      * separator.  This is for XS modules, so they don't have to worry about
@@ -4752,6 +4746,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 #  ifdef USE_LOCALE_NUMERIC
 
     PL_numeric_radix_sv    = newSVpvn(C_decimal_point, strlen(C_decimal_point));
+    PL_underlying_radix_sv = newSVpvn(C_decimal_point, strlen(C_decimal_point));
     Newx(PL_numeric_name, 2, char);
     Copy("C", PL_numeric_name, 2, char);
 

--- a/numeric.c
+++ b/numeric.c
@@ -1492,7 +1492,7 @@ N.B. C<s> must be NUL terminated.
     {
         DECLARATION_FOR_LC_NUMERIC_MANIPULATION;
         STORE_LC_NUMERIC_SET_TO_NEEDED();
-        if (! (PL_numeric_radix_sv && IN_LC(LC_NUMERIC))) {
+        if (! IN_LC(LC_NUMERIC)) {
             ATOF(s,x);
         }
         else {

--- a/perl.c
+++ b/perl.c
@@ -1160,6 +1160,8 @@ perl_destruct(pTHXx)
     PL_numeric_name = NULL;
     SvREFCNT_dec(PL_numeric_radix_sv);
     PL_numeric_radix_sv = NULL;
+    SvREFCNT_dec(PL_underlying_radix_sv);
+    PL_underlying_radix_sv  = NULL;
 #endif
 
     if (PL_setlocale_buf) {

--- a/proto.h
+++ b/proto.h
@@ -5689,8 +5689,6 @@ STATIC void	S_restore_toggled_locale_i(pTHX_ const unsigned cat_index, const cha
 #define PERL_ARGS_ASSERT_RESTORE_TOGGLED_LOCALE_I
 STATIC const char *	S_save_to_buffer(const char * string, const char **buf, Size_t *buf_size);
 #define PERL_ARGS_ASSERT_SAVE_TO_BUFFER
-STATIC void	S_set_numeric_radix(pTHX_ const bool use_locale);
-#define PERL_ARGS_ASSERT_SET_NUMERIC_RADIX
 PERL_STATIC_NO_RET void	S_setlocale_failure_panic_i(pTHX_ const unsigned int cat_index, const char * current, const char * failed, const line_t caller_0_line, const line_t caller_1_line)
 			__attribute__noreturn__;
 #define PERL_ARGS_ASSERT_SETLOCALE_FAILURE_PANIC_I	\

--- a/proto.h
+++ b/proto.h
@@ -5681,7 +5681,8 @@ STATIC void	S_new_ctype(pTHX_ const char* newctype);
 #define PERL_ARGS_ASSERT_NEW_CTYPE	\
 	assert(newctype)
 STATIC void	S_new_numeric(pTHX_ const char* newnum);
-#define PERL_ARGS_ASSERT_NEW_NUMERIC
+#define PERL_ARGS_ASSERT_NEW_NUMERIC	\
+	assert(newnum)
 STATIC void	S_restore_switched_locale(pTHX_ const int category, const char * const original_locale);
 #define PERL_ARGS_ASSERT_RESTORE_SWITCHED_LOCALE
 STATIC void	S_restore_toggled_locale_i(pTHX_ const unsigned cat_index, const char * original_locale, const line_t caller_line);

--- a/sv.c
+++ b/sv.c
@@ -15845,6 +15845,7 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
 #ifdef USE_LOCALE_NUMERIC
     PL_numeric_name	= SAVEPV(proto_perl->Inumeric_name);
     PL_numeric_radix_sv	= sv_dup_inc(proto_perl->Inumeric_radix_sv, param);
+    PL_underlying_radix_sv = sv_dup_inc(proto_perl->Iunderlying_radix_sv, param);
 
 #  if defined(USE_POSIX_2008_LOCALE)
     PL_underlying_numeric_obj = NULL;


### PR DESCRIPTION
This function is called when LC_NUMERIC is changed.  This series of commits reorders things so as to perform less work by performing things earlier that later things depend on.