### PR TITLE
error messages - do not repeat class names twice in our error messages

### DIFF
--- a/gv.c
+++ b/gv.c
@@ -961,12 +961,11 @@ S_gv_fetchmeth_internal(pTHX_ HV* stash, SV* meth, const char* name, STRLEN len,
                     Perl_ck_warner(aTHX_ packWARN(WARN_SYNTAX),
                         "While trying to resolve method call %.*s->%.*s()"
                         " can not locate package %" SVf_QUOTEDPREFIX " yet it is mentioned in @%.*s::ISA"
-                        " (perhaps you forgot to load %" SVf_QUOTEDPREFIX "?)",
+                        " (perhaps you forgot to load it?)",
                          (int) hvnamelen, hvname,
                          (int) len, name,
                         SVfARG(linear_sv),
-                         (int) hvnamelen, hvname,
-                         SVfARG(linear_sv));
+                         (int) hvnamelen, hvname);
                 }
             }
             continue;
@@ -1265,9 +1264,9 @@ Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN le
                 Perl_croak(aTHX_
                            "Can't locate object method %" UTF8f_QUOTEDPREFIX ""
                            " via package %" SVf_QUOTEDPREFIX ""
-                           " (perhaps you forgot to load %" SVf_QUOTEDPREFIX "?)",
+                           " (perhaps you forgot to load it?)",
                            UTF8fARG(is_utf8, name_end - name, name),
-                           SVfARG(packnamesv), SVfARG(packnamesv));
+                           SVfARG(packnamesv));
             }
         }
     }

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -1279,8 +1279,7 @@ unable to locate this library.  See L<DynaLoader>.
 functioning as a class, but that package doesn't define that particular
 method, nor does any of its base classes.  See L<perlobj>.
 
-=item Can't locate object method "%s" via package "%s" (perhaps you forgot
-to load "%s"?)
+=item Can't locate object method "%s" via package "%s" (perhaps you forgot to load it?)
 
 (F) You called a method on a class that did not exist, and the method
 could not be found in UNIVERSAL.  This often means that a method
@@ -8213,7 +8212,7 @@ can be determined from the template alone.  This is not possible if
 it contains any of the codes @, /, U, u, w or a *-length.  Redesign
 the template.
 
-=item While trying to resolve method call %s->%s() can not locate package "%s" yet it is mentioned in @%s::ISA (perhaps you forgot to load "%s"?)
+=item While trying to resolve method call %s->%s() can not locate package "%s" yet it is mentioned in @%s::ISA (perhaps you forgot to load it?)
 
 (W syntax) It is possible that the C<@ISA> contains a misspelled or never loaded
 package name, which can result in perl choosing an unexpected parent

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -1169,8 +1169,8 @@ PP_wrapped(pp_tie, 0, 1)
                              :                 newSVpvs_flags("main", SVs_TEMP);
                DIE(aTHX_ "Can't locate object method %" PVf_QUOTEDPREFIX
                          " via package %" SVf_QUOTEDPREFIX
-                   " (perhaps you forgot to load %" SVf_QUOTEDPREFIX "?)",
-                   methname, SVfARG(stashname), SVfARG(stashname));
+                   " (perhaps you forgot to load it?)",
+                   methname, SVfARG(stashname));
            }
        }
        else if (!(gv = gv_fetchmethod(stash, methname))) {

--- a/t/lib/warnings/gv
+++ b/t/lib/warnings/gv
@@ -28,7 +28,7 @@ Undefined subroutine &main::joe called at - line 3.
 use warnings 'syntax' ;
 @ISA = qw(Fred); __PACKAGE__->joe()
 EXPECT
-While trying to resolve method call main->joe() can not locate package "Fred" yet it is mentioned in @main::ISA (perhaps you forgot to load "Fred"?) at - line 3.
+While trying to resolve method call main->joe() can not locate package "Fred" yet it is mentioned in @main::ISA (perhaps you forgot to load it?) at - line 3.
 Can't locate object method "joe" via package "main" at - line 3.
 ########
 # gv.c
@@ -57,7 +57,7 @@ $a = bless [], 'C';
 $a->foo();
 __END__
 EXPECT
-While trying to resolve method call C->foo() can not locate package "A" yet it is mentioned in @C::ISA (perhaps you forgot to load "A"?) at - line 18.
+While trying to resolve method call C->foo() can not locate package "A" yet it is mentioned in @C::ISA (perhaps you forgot to load it?) at - line 18.
 I'm in B's foo
 ########
 # gv.c

--- a/t/op/tie.t
+++ b/t/op/tie.t
@@ -930,7 +930,7 @@ sub IO::File::TIEARRAY {
 }
 fileno FOO; tie @a, "FOO"
 EXPECT
-Can't locate object method "TIEARRAY" via package "FOO" (perhaps you forgot to load "FOO"?) at - line 5.
+Can't locate object method "TIEARRAY" via package "FOO" (perhaps you forgot to load it?) at - line 5.
 ########
 # tie into empty package name
 tie $foo, "";

--- a/t/run/fresh_perl.t
+++ b/t/run/fresh_perl.t
@@ -81,7 +81,7 @@ $array[128]=1
 ########
 $x=0x0eabcd; print $x->ref;
 EXPECT
-Can't locate object method "ref" via package "961485" (perhaps you forgot to load "961485"?) at - line 1.
+Can't locate object method "ref" via package "961485" (perhaps you forgot to load it?) at - line 1.
 ########
 chop ($str .= <DATA>);
 ########


### PR DESCRIPTION
Showing the classname twice in the error message just increases
cognitive load understanding the message when the class/package name
is more than a few components long, and can easily make what should be
a simple one line error message wrap and be unreadable.

We can simply replace the second invocation of the class name by saying
"it" instead, and that is what this patch does. It is still friendly,
but not repetitive.

Thus:
$ perl -le'("x" x 50)->new()'
Can't locate object method "new" via package "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 (perhaps you forgot to load "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"?) at -e line 1.

Turns into:
$ ./perl -le'("x" x 50)->new()'
Can't locate object method "new" via package "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 (perhaps you forgot to load it?) at -e line 1.