### PR TITLE
Tests for Issue #20161

### DIFF
--- a/t/comp/retainedlines.t
+++ b/t/comp/retainedlines.t
@@ -108,7 +108,8 @@ foreach my $flags (0x0, 0x800, 0x1000, 0x1800) {
     # This is easier if we accept that the guts eval will add a trailing \n
     # for us
     my $prog = "1 + 1 + 1\n";
-    my $fail = "1 + \n";
+    my $syntax_errors_to_stop_after= 10;
+    my $fail = "1 +; \n" x ($syntax_errors_to_stop_after + 1);
 
     is (eval $prog, 3, 'String eval works');
     if ($flags & 0x800) {


### PR DESCRIPTION
This is to demonstrate the issue reported in GH Issue #20161,
that we leak debug data from eval statements that croak during
compilation.

We fail test when the parser croaks during compilation, but the old code
did not trigger a croak. With this change the test fails in a large
number of ways, many of which are false positives. A follow up patch
will remove the false positives, but still leave failing tests.