### PR TITLE
deb.c - when PL_copline is NOLINE show 0 not 2^32-1.

### DIFF
--- a/deb.c
+++ b/deb.c
@@ -87,7 +87,9 @@ Perl_vdeb(pTHX_ const char *pat, va_list *args)
 #ifdef DEBUGGING
     const char* const file = PL_curcop ? OutCopFILE(PL_curcop) : "<null>";
     const char* const display_file = file ? file : "<free>";
-    const long line = PL_curcop ? (long)CopLINE(PL_curcop) : 0;
+    long line = PL_curcop ? (long)CopLINE(PL_curcop) : NOLINE;
+    if (line == NOLINE)
+        line = 0;
 
     PERL_ARGS_ASSERT_VDEB;
 


### PR DESCRIPTION
deb.c - when PL_copline is NOLINE show 0 not 2^32-1.
NOLINE is defined to be U32_MAX (not sure why it is not 0,
as lines in files by convention are numbered from 1 so 0 should
be an illegal line number), some parts of our code explicitly
set the cop_line to be NOLINE. When we debug we should show this
as line 0, the U32_MAX value is somewhat confusing. We could also
just not show a line at all, but for now this makes more sense,
especially as the deb.c logic was using 0 when there is no curcop.

Without this patch:
```
    $ ./perl -Dl -e'eval "1+;"x10'
    (-e:0)	ENTER scope 2 (savestack=38) at op.c:10897
    (-e:4294967295)	LEAVE scope 2 (savestack=46) at op.c:10937
    (-e:4294967295)	savestack: releasing items 46 -> 38
    (-e:0)	ENTER scope 2 (savestack=40) at perly.c:289
    (-e:1)	ENTER scope 3 (savestack=78) at toke.c:4868
```

With this patch:

```
    $ ./perl -Dl -e'eval "1+;"x10'
    (-e:0)	ENTER scope 2 (savestack=38) at op.c:10897
    (-e:0)	LEAVE scope 2 (savestack=46) at op.c:10937
    (-e:0)	savestack: releasing items 46 -> 38
    (-e:0)	ENTER scope 2 (savestack=40) at perly.c:289
    (-e:1)	ENTER scope 3 (savestack=78) at toke.c:4868
```

This fixes GH Issue https://github.com/Perl/perl5/issues/20175