### PR TITLE
Custom timeout in watchdog in -T tests fails

### DIFF
--- a/t/test.pl
+++ b/t/test.pl
@@ -1742,6 +1742,7 @@ sub watchdog ($;$)
                       || $ENV{PERL_TEST_TIMEOUT_FACTOR}
                       || 1;
     $timeout_factor = 1 if $timeout_factor < 1;
+	$timeout_factor = $1 if $timeout_factor =~ /^(\d+)$/;
 
     # Valgrind slows perl way down so give it more time before dying.
     $timeout_factor = 10 if $timeout_factor < 10 && $ENV{PERL_VALGRIND};


### PR DESCRIPTION

The recent change in the test.pl/watchdog() in #20134 causes

re/substT.t .......................................................... ok

and

perf/taint.t ......................................................... ok

This occurs when setting the PERL_TEST_TIME_OUT_FACTOR environment value in the build
which causes the $timeout_factor to become tainted.

Untainting it fixes the problem.