### PR TITLE
Don't end up in global locale upon thread destruction

### DIFF
--- a/dist/threads/lib/threads.pm
+++ b/dist/threads/lib/threads.pm
@@ -5,7 +5,7 @@ use 5.008;
 use strict;
 use warnings;
 
-our $VERSION = '2.29';      # remember to update version in POD!
+our $VERSION = '2.30';      # remember to update version in POD!
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 

--- a/embed.fnc
+++ b/embed.fnc
@@ -1663,8 +1663,8 @@ Xp	|void	|set_numeric_standard
 Cp	|bool	|_is_in_locale_category|const bool compiling|const int category
 Apd	|void	|switch_to_global_locale
 Apd	|bool	|sync_locale
-ApxT	|void	|thread_locale_init
-ApxT	|void	|thread_locale_term
+Apx	|void	|thread_locale_init
+Apx	|void	|thread_locale_term
 ApdO	|void	|require_pv	|NN const char* pv
 Apd	|void	|packlist	|NN SV *cat|NN const char *pat|NN const char *patend|NN SV **beglist|NN SV **endlist
 #if defined(PERL_USES_PL_PIDSTATUS) && defined(PERL_IN_UTIL_C)

--- a/embed.fnc
+++ b/embed.fnc
@@ -3442,12 +3442,15 @@ S	|const char*|my_langinfo_i|const int item			\
 				|NULLOK utf8ness_t * utf8ness
 #    endif
 #    ifdef DEBUGGING
-S	|const char *|get_LC_ALL_display
 SR	|char *	|my_setlocale_debug_string_i			\
 			    |const unsigned cat_index		\
 			    |NULLOK const char* locale		\
 			    |NULLOK const char* retval		\
 			    |const line_t line
+#    endif
+#    if  defined(DEBUGGING)						    \
+     || (defined(USE_THREAD_SAFE_LOCALE) && defined(USE_POSIX_2008_LOCALE))
+S	|const char *|get_LC_ALL_display
 #    endif
 #  endif
 S	|const char *|get_displayable_string|NN const char * const s	\

--- a/embed.fnc
+++ b/embed.fnc
@@ -3426,6 +3426,9 @@ S	|char*	|win32_setlocale|int category|NULLOK const char* locale
 pTC	|wchar_t *|Win_utf8_string_to_wstring|NULLOK const char * utf8_string
 pTC	|char *	|Win_wstring_to_utf8_string|NULLOK const wchar_t * wstring
 #    endif
+#    ifdef USE_PL_CUR_LC_ALL
+CpT	|void	|switch_locale_context
+#    endif
 #    if defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L)
 S	|const char*|my_langinfo_i|const nl_item item			\
 				|const unsigned int cat_index		\

--- a/embed.h
+++ b/embed.h
@@ -697,8 +697,8 @@
 #define sync_locale()		Perl_sync_locale(aTHX)
 #define taint_env()		Perl_taint_env(aTHX)
 #define taint_proper(a,b)	Perl_taint_proper(aTHX_ a,b)
-#define thread_locale_init	Perl_thread_locale_init
-#define thread_locale_term	Perl_thread_locale_term
+#define thread_locale_init()	Perl_thread_locale_init(aTHX)
+#define thread_locale_term()	Perl_thread_locale_term(aTHX)
 #define to_uni_lower(a,b,c)	Perl_to_uni_lower(aTHX_ a,b,c)
 #define to_uni_title(a,b,c)	Perl_to_uni_title(aTHX_ a,b,c)
 #define to_uni_upper(a,b,c)	Perl_to_uni_upper(aTHX_ a,b,c)

--- a/embed.h
+++ b/embed.h
@@ -1628,7 +1628,6 @@
 #define set_padlist		Perl_set_padlist
 #    if defined(PERL_IN_LOCALE_C)
 #      if defined(USE_LOCALE)
-#define get_LC_ALL_display()	S_get_LC_ALL_display(aTHX)
 #define my_setlocale_debug_string_i(a,b,c,d)	S_my_setlocale_debug_string_i(aTHX_ a,b,c,d)
 #        if defined(USE_LOCALE_COLLATE)
 #define print_collxfrm_input_and_return(a,b,c,d,e)	S_print_collxfrm_input_and_return(aTHX_ a,b,c,d,e)
@@ -1644,6 +1643,13 @@
 #    if defined(PERL_IN_TOKE_C)
 #define printbuf(a,b)		S_printbuf(aTHX_ a,b)
 #define tokereport(a,b)		S_tokereport(aTHX_ a,b)
+#    endif
+#  endif
+#  if defined(DEBUGGING)						         || (defined(USE_THREAD_SAFE_LOCALE) && defined(USE_POSIX_2008_LOCALE))
+#    if defined(PERL_IN_LOCALE_C)
+#      if defined(USE_LOCALE)
+#define get_LC_ALL_display()	S_get_LC_ALL_display(aTHX)
+#      endif
 #    endif
 #  endif
 #  if defined(DEBUG_LEAKING_SCALARS_FORK_DUMP)

--- a/embed.h
+++ b/embed.h
@@ -828,6 +828,9 @@
 #endif
 #if defined(PERL_IN_LOCALE_C)
 #  if defined(USE_LOCALE)
+#    if defined(USE_PL_CUR_LC_ALL)
+#define switch_locale_context	Perl_switch_locale_context
+#    endif
 #    if defined(WIN32)
 #define Win_utf8_string_to_wstring	Perl_Win_utf8_string_to_wstring
 #define Win_wstring_to_utf8_string	Perl_Win_wstring_to_utf8_string

--- a/embedvar.h
+++ b/embedvar.h
@@ -86,6 +86,7 @@
 #define PL_constpadix		(vTHX->Iconstpadix)
 #define PL_cop_seqmax		(vTHX->Icop_seqmax)
 #define PL_ctype_name		(vTHX->Ictype_name)
+#define PL_cur_LC_ALL		(vTHX->Icur_LC_ALL)
 #define PL_curcop		(vTHX->Icurcop)
 #define PL_curcopdb		(vTHX->Icurcopdb)
 #define PL_curlocales		(vTHX->Icurlocales)

--- a/embedvar.h
+++ b/embedvar.h
@@ -87,6 +87,7 @@
 #define PL_cop_seqmax		(vTHX->Icop_seqmax)
 #define PL_ctype_name		(vTHX->Ictype_name)
 #define PL_cur_LC_ALL		(vTHX->Icur_LC_ALL)
+#define PL_cur_locale_obj	(vTHX->Icur_locale_obj)
 #define PL_curcop		(vTHX->Icurcop)
 #define PL_curcopdb		(vTHX->Icurcopdb)
 #define PL_curlocales		(vTHX->Icurlocales)

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -741,8 +741,13 @@ PERLVAR(I, padix_floor,	PADOFFSET)	/* how low may inner block reset padix */
 #ifdef USE_PL_CURLOCALES
 
 /* This is the most number of categories we've encountered so far on any
- * platform */
-PERLVARA(I, curlocales, 12, const char *)
+ * platform, doesn't include LC_ALL */
+PERLVARA(I, curlocales, 11, const char *)
+
+#endif
+#ifdef USE_PL_CUR_LC_ALL
+
+PERLVARI(I, cur_LC_ALL, const char *, NULL)
 
 #endif
 #ifdef USE_LOCALE_COLLATE

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -738,6 +738,9 @@ PERLVAR(I, constpadix,	PADOFFSET)	/* lowest unused for constants */
 
 PERLVAR(I, padix_floor,	PADOFFSET)	/* how low may inner block reset padix */
 
+#if defined(USE_POSIX_2008_LOCALE) && defined(MULTIPLICITY)
+PERLVARI(I, cur_locale_obj, locale_t, NULL)
+#endif
 #ifdef USE_PL_CURLOCALES
 
 /* This is the most number of categories we've encountered so far on any

--- a/locale.c
+++ b/locale.c
@@ -5173,15 +5173,6 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
     /* Done with finding the locales; update the auxiliary records */
     new_LC_ALL(NULL);
 
-#  if defined(USE_POSIX_2008_LOCALE) && defined(USE_LOCALE_NUMERIC)
-
-    /* This is a temporary workaround for #20155, to avoid issues where the
-     * global locale wants a radix different from the per-thread one.  This
-     * restores behavior for LC_NUMERIC to what it was before a7ff7ac. */
-    posix_setlocale(LC_NUMERIC, "C");
-
-#  endif
-
     for (i = 0; i < NOMINAL_LC_ALL_INDEX; i++) {
         Safefree(curlocales[i]);
     }

--- a/locale.c
+++ b/locale.c
@@ -1372,6 +1372,10 @@ S_emulate_setlocale_i(pTHX_
     DEBUG_Lv(PerlIO_printf(Perl_debug_log,
              "(%" LINE_Tf "): emulate_setlocale_i now using %p\n", line, new_obj));
 
+#ifdef MULTIPLICITY
+    PL_cur_locale_obj = new_obj;
+#endif
+
     /* We are done, except for updating our records (if the system doesn't keep
      * them) and in the case of locale "", we don't actually know what the
      * locale that got switched to is, as it came from the environment.  So
@@ -6732,31 +6736,28 @@ S_my_setlocale_debug_string_i(pTHX_
 void
 Perl_thread_locale_init(pTHX)
 {
-    /* Called from a thread on startup*/
 
 #ifdef USE_THREAD_SAFE_LOCALE
+#  ifdef USE_POSIX_2008_LOCALE
+
+    /* Called from a thread on startup.
+     *
+     * The operations here have to be done from within the calling thread, as
+     * they affect libc's knowledge of the thread; libc has no knowledge of
+     * aTHX */
 
      DEBUG_L(PerlIO_printf(Perl_debug_log,
                            "new thread, initial locale is %s;"
                            " calling setlocale(LC_ALL, \"C\")\n",
                            get_LC_ALL_display()));
-#  ifdef WIN32
+
+    uselocale(PL_C_locale_obj);
+
+#  elif defined(WIN32)
 
     /* On Windows, make sure new thread has per-thread locales enabled */
     _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
-
-#  endif
-#  if defined(LC_ALL)
-
-    /* This thread starts off in the C locale.  Use the full Perl_setlocale()
-     * to make sure no ill-advised shortcuts get taken on this new thread, */
-    Perl_setlocale(LC_ALL, "C");
-
-#  else
-
-    for (unsigned i = 0; i < NOMINAL_LC_ALL_INDEX; i++) {
-        Perl_setlocale(categories[i], "C");
-    }
+    void_setlocale("C");
 
 #  endif
 #endif
@@ -6766,19 +6767,33 @@ Perl_thread_locale_init(pTHX)
 void
 Perl_thread_locale_term(pTHX)
 {
-    /* Called from a thread as it gets ready to terminate */
+    /* Called from a thread as it gets ready to terminate.
+     *
+     * The operations here have to be done from within the calling thread, as
+     * they affect libc's knowledge of the thread; libc has no knowledge of
+     * aTHX */
 
 #ifdef USE_POSIX_2008_LOCALE
 
     /* C starts the new thread in the global C locale.  If we are thread-safe,
      * we want to not be in the global locale */
 
-    {   /* Free up */
-        locale_t cur_obj = uselocale(LC_GLOBAL_LOCALE);
-        if (cur_obj != LC_GLOBAL_LOCALE && cur_obj != PL_C_locale_obj) {
-            freelocale(cur_obj);
-        }
+    /* Free up */
+    locale_t actual_obj   = uselocale(LC_GLOBAL_LOCALE);
+    if (actual_obj != LC_GLOBAL_LOCALE && actual_obj != PL_C_locale_obj) {
+        freelocale(actual_obj);
     }
+
+    /* Prevent leaks even if something has gone wrong */
+    locale_t expected_obj = PL_cur_locale_obj;
+    if (UNLIKELY(   expected_obj != actual_obj
+                 && expected_obj != LC_GLOBAL_LOCALE
+                 && expected_obj != PL_C_locale_obj))
+    {
+        freelocale(expected_obj);
+    }
+
+    PL_cur_locale_obj = LC_GLOBAL_LOCALE;
 
 #endif
 

--- a/locale.c
+++ b/locale.c
@@ -1670,8 +1670,7 @@ S_calculate_LC_ALL(pTHX_ const char ** individ_locales)
 }
 
 #endif
-
-#if defined(USE_LOCALE) && defined(DEBUGGING)
+#ifdef USE_LOCALE
 
 STATIC const char *
 S_get_LC_ALL_display(pTHX)

--- a/locale.c
+++ b/locale.c
@@ -6726,13 +6726,11 @@ S_my_setlocale_debug_string_i(pTHX_
 #endif
 
 void
-Perl_thread_locale_init()
+Perl_thread_locale_init(pTHX)
 {
     /* Called from a thread on startup*/
 
 #ifdef USE_THREAD_SAFE_LOCALE
-
-    dTHX_DEBUGGING;
 
      DEBUG_L(PerlIO_printf(Perl_debug_log,
                            "new thread, initial locale is %s;"
@@ -6762,7 +6760,7 @@ Perl_thread_locale_init()
 }
 
 void
-Perl_thread_locale_term()
+Perl_thread_locale_term(pTHX)
 {
     /* Called from a thread as it gets ready to terminate */
 

--- a/locale.c
+++ b/locale.c
@@ -2586,6 +2586,22 @@ S_win32_setlocale(pTHX_ int category, const char* locale)
                           setlocale_debug_string_r(category, locale, result)));
 
     if (! override_LC_ALL)  {
+
+#  ifdef USE_PL_CUR_LC_ALL
+
+        /* If we need to keep this variable updated, and it potentially
+         * changed, update it */
+        if (locale != NULL) {
+            if (category == LC_ALL) {
+                PL_cur_LC_ALL = result;
+            }
+            else {
+                PL_cur_LC_ALL = S_wrap_wsetlocale(aTHX_ LC_ALL, NULL);
+            };
+        }
+
+#  endif
+
         return result;
     }
 
@@ -2611,6 +2627,11 @@ S_win32_setlocale(pTHX_ int category, const char* locale)
     result = setlocale(LC_ALL, NULL);
     DEBUG_L(PerlIO_printf(Perl_debug_log, "%s\n",
                           setlocale_debug_string_c(LC_ALL, NULL, result)));
+
+
+#  ifdef USE_PL_CUR_LC_ALL
+    PL_cur_LC_ALL = result;
+#  endif
 
     return result;
 }

--- a/locale.c
+++ b/locale.c
@@ -4792,6 +4792,11 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
     DEBUG_Lv(PerlIO_printf(Perl_debug_log, "created C object %p\n",
                            PL_C_locale_obj));
 
+    /* Switch to using the POSIX 2008 interface now.  This would happen below
+     * anyway, but deferring it can lead to leaks of memory that would also get
+     * malloc'd in the interim */
+    uselocale(PL_C_locale_obj);
+
 #    ifdef USE_LOCALE_NUMERIC
 
     PL_underlying_numeric_obj = duplocale(PL_C_locale_obj);

--- a/makedef.pl
+++ b/makedef.pl
@@ -386,6 +386,7 @@ unless ($define{'USE_ITHREADS'}) {
 		    PL_stashpad
 		    PL_stashpadix
 		    PL_stashpadmax
+                    PL_veto_switch_non_tTHX_context
 		    Perl_alloccopstash
 		    Perl_allocfilegv
 		    Perl_clone_params_del

--- a/makedef.pl
+++ b/makedef.pl
@@ -372,6 +372,7 @@ unless ($define{'USE_ITHREADS'}) {
     ++$skip{$_} foreach qw(
                     PL_keyword_plugin_mutex
 		    PL_check_mutex
+                    PL_cur_locale_obj
 		    PL_op_mutex
 		    PL_regex_pad
 		    PL_regex_padav

--- a/makedef.pl
+++ b/makedef.pl
@@ -428,6 +428,13 @@ unless ($define{USE_PL_CURLOCALES})
     );
 }
 
+unless ($define{USE_PL_CUR_LC_ALL})
+{
+    ++$skip{$_} foreach qw(
+        PL_cur_LC_ALL
+    );
+}
+
 unless ($define{'MULTIPLICITY'}) {
     ++$skip{$_} foreach qw(
 		    PL_my_cxt_index

--- a/perl.c
+++ b/perl.c
@@ -1140,6 +1140,17 @@ perl_destruct(pTHXx)
             freelocale(old_locale);
         }
     }
+
+#  ifdef USE_PL_CUR_LC_ALL
+
+    if (PL_cur_LC_ALL) {
+        DEBUG_L( PerlIO_printf(Perl_debug_log, "PL_cur_LC_ALL=%p\n", PL_cur_LC_ALL));
+        Safefree(PL_cur_LC_ALL);
+        PL_cur_LC_ALL = NULL;
+    }
+
+#  endif
+
     if (PL_scratch_locale_obj) {
         freelocale(PL_scratch_locale_obj);
         PL_scratch_locale_obj = NULL;

--- a/perl.c
+++ b/perl.c
@@ -1129,15 +1129,12 @@ perl_destruct(pTHXx)
     {
         /* This also makes sure we aren't using a locale object that gets freed
          * below */
-        const locale_t old_locale = uselocale(LC_GLOBAL_LOCALE);
-        if (   old_locale != LC_GLOBAL_LOCALE
-#  ifdef USE_POSIX_2008_LOCALE
-            && old_locale != PL_C_locale_obj
-#  endif
+        if (   PL_cur_locale_obj != NULL
+            && PL_cur_locale_obj != LC_GLOBAL_LOCALE
+            && PL_cur_locale_obj != PL_C_locale_obj
         ) {
-            DEBUG_Lv(PerlIO_printf(Perl_debug_log,
-                     "%s:%d: Freeing %p\n", __FILE__, __LINE__, old_locale));
-            freelocale(old_locale);
+            freelocale(PL_cur_locale_obj);
+            PL_cur_locale_obj = NULL;
         }
     }
 

--- a/perl.h
+++ b/perl.h
@@ -1275,6 +1275,7 @@ violations are fatal.
 
 #  if (defined(USE_POSIX_2008_LOCALE) && ! defined(USE_QUERYLOCALE))
 #    define USE_PL_CURLOCALES
+#    define USE_PL_CUR_LC_ALL
 #  endif
 
 /*  Microsoft documentation reads in the change log for VS 2015:
@@ -1283,8 +1284,11 @@ violations are fatal.
  *     function would return the lconv data for the global locale, not the
  *     thread's locale."
  */
-#  if defined(WIN32) && defined(USE_THREAD_SAFE_LOCALE) && _MSC_VER < 1900
-#  define TS_W32_BROKEN_LOCALECONV
+#  if defined(WIN32) && defined(USE_THREAD_SAFE_LOCALE)
+#    define USE_PL_CUR_LC_ALL
+#    if _MSC_VER < 1900
+#      define TS_W32_BROKEN_LOCALECONV
+#    endif
 #  endif
 #endif
 

--- a/perl.h
+++ b/perl.h
@@ -155,6 +155,17 @@ Otherwise ends a section of code already begun by a C<L</START_EXTERN_C>>.
 #  endif
 #endif
 
+#ifndef PERL_CALLCONV
+#  ifdef __cplusplus
+#    define PERL_CALLCONV  EXTERN_C
+#  else
+#    define PERL_CALLCONV
+#  endif
+#endif
+#ifndef PERL_CALLCONV_NO_RET
+#    define PERL_CALLCONV_NO_RET PERL_CALLCONV
+#endif
+
 /*
 =for apidoc_section $concurrency
 =for apidoc AmU|void|dTHXa|PerlInterpreter * a
@@ -4377,17 +4388,6 @@ typedef        struct crypt_data {     /* straight from /usr/include/crypt.h */
 } CRYPTD;
 #endif /* threading */
 #endif /* AIX */
-
-#ifndef PERL_CALLCONV
-#  ifdef __cplusplus
-#    define PERL_CALLCONV  EXTERN_C
-#  else
-#    define PERL_CALLCONV
-#  endif
-#endif
-#ifndef PERL_CALLCONV_NO_RET
-#    define PERL_CALLCONV_NO_RET PERL_CALLCONV
-#endif
 
 /* PERL_STATIC_NO_RET is supposed to be equivalent to STATIC on builds that
    dont have a noreturn as a declaration specifier

--- a/perlvars.h
+++ b/perlvars.h
@@ -169,6 +169,7 @@ PERLVAR(G, check_mutex,	perl_mutex)	/* Mutex for PL_check */
 #ifdef MULTIPLICITY
 # ifdef USE_ITHREADS
 PERLVAR(G, my_ctx_mutex, perl_mutex)
+PERLVARI(G, veto_switch_non_tTHX_context, int, FALSE)
 # endif
 PERLVARI(G, my_cxt_index, int,	0)
 #endif

--- a/proto.h
+++ b/proto.h
@@ -4355,9 +4355,9 @@ PERL_CALLCONV void	Perl_taint_env(pTHX);
 PERL_CALLCONV void	Perl_taint_proper(pTHX_ const char* f, const char *const s);
 #define PERL_ARGS_ASSERT_TAINT_PROPER	\
 	assert(s)
-PERL_CALLCONV void	Perl_thread_locale_init(void);
+PERL_CALLCONV void	Perl_thread_locale_init(pTHX);
 #define PERL_ARGS_ASSERT_THREAD_LOCALE_INIT
-PERL_CALLCONV void	Perl_thread_locale_term(void);
+PERL_CALLCONV void	Perl_thread_locale_term(pTHX);
 #define PERL_ARGS_ASSERT_THREAD_LOCALE_TERM
 PERL_CALLCONV OP *	Perl_tied_method(pTHX_ SV *methname, SV **sp, SV *const sv, const MAGIC *const mg, const U32 flags, U32 argc, ...)
 			__attribute__visibility__("hidden");

--- a/proto.h
+++ b/proto.h
@@ -5122,8 +5122,6 @@ PERL_CALLCONV void	Perl_set_padlist(CV * cv, PADLIST * padlist);
 	assert(cv)
 #  if defined(PERL_IN_LOCALE_C)
 #    if defined(USE_LOCALE)
-STATIC const char *	S_get_LC_ALL_display(pTHX);
-#define PERL_ARGS_ASSERT_GET_LC_ALL_DISPLAY
 STATIC char *	S_my_setlocale_debug_string_i(pTHX_ const unsigned cat_index, const char* locale, const char* retval, const line_t line)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_MY_SETLOCALE_DEBUG_STRING_I
@@ -5213,6 +5211,14 @@ STATIC void	S_printbuf(pTHX_ const char *const fmt, const char *const s)
 STATIC int	S_tokereport(pTHX_ I32 rv, const YYSTYPE* lvalp);
 #define PERL_ARGS_ASSERT_TOKEREPORT	\
 	assert(lvalp)
+#  endif
+#endif
+#if defined(DEBUGGING)						         || (defined(USE_THREAD_SAFE_LOCALE) && defined(USE_POSIX_2008_LOCALE))
+#  if defined(PERL_IN_LOCALE_C)
+#    if defined(USE_LOCALE)
+STATIC const char *	S_get_LC_ALL_display(pTHX);
+#define PERL_ARGS_ASSERT_GET_LC_ALL_DISPLAY
+#    endif
 #  endif
 #endif
 #if defined(DEBUGGING) && defined(ENABLE_REGEX_SETS_DEBUGGING)

--- a/proto.h
+++ b/proto.h
@@ -5751,6 +5751,10 @@ STATIC void	S_new_numeric(pTHX_ const char* newnum);
 #define PERL_ARGS_ASSERT_NEW_NUMERIC	\
 	assert(newnum)
 #    endif
+#    if defined(USE_PL_CUR_LC_ALL)
+PERL_CALLCONV void	Perl_switch_locale_context(void);
+#define PERL_ARGS_ASSERT_SWITCH_LOCALE_CONTEXT
+#    endif
 #    if defined(USE_POSIX_2008_LOCALE)
 STATIC const char*	S_emulate_setlocale_i(pTHX_ const unsigned int index, const char* new_locale, const recalc_lc_all_t recalc_LC_ALL, const line_t line);
 #define PERL_ARGS_ASSERT_EMULATE_SETLOCALE_I

--- a/sv.c
+++ b/sv.c
@@ -15888,31 +15888,32 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
 
 #ifdef USE_PL_CURLOCALES
     for (i = 0; i < (int) C_ARRAY_LENGTH(PL_curlocales); i++) {
-        PL_curlocales[i] = SAVEPV(proto_perl->Icurlocales[i]);
+        PL_curlocales[i] = SAVEPV("C");
     }
 #endif
 #ifdef USE_LOCALE_CTYPE
-    Copy(proto_perl->Ifold_locale, PL_fold_locale, 256, U8);
+    Copy(PL_fold, PL_fold_locale, 256, U8);
+
     /* Should we warn if uses locale? */
-    PL_ctype_name	= SAVEPV(proto_perl->Ictype_name);
+    PL_ctype_name	= SAVEPV("C");
     PL_warn_locale      = sv_dup_inc(proto_perl->Iwarn_locale, param);
-    PL_in_utf8_CTYPE_locale   = proto_perl->Iin_utf8_CTYPE_locale;
-    PL_in_utf8_turkic_locale  = proto_perl->Iin_utf8_turkic_locale;
+    PL_in_utf8_CTYPE_locale   = false;
+    PL_in_utf8_turkic_locale  = false;
 #endif
 
     /* Did the locale setup indicate UTF-8? */
-    PL_utf8locale	= proto_perl->Iutf8locale;
+    PL_utf8locale	= false;
 
 #ifdef USE_LOCALE_COLLATE
-    PL_in_utf8_COLLATE_locale = proto_perl->Iin_utf8_COLLATE_locale;
-    PL_collation_name	= SAVEPV(proto_perl->Icollation_name);
+    PL_in_utf8_COLLATE_locale = false;
+    PL_collation_name	= SAVEPV("C");
     PL_collation_ix	= proto_perl->Icollation_ix;
-    PL_collation_standard = proto_perl->Icollation_standard;
-    PL_collxfrm_base	= proto_perl->Icollxfrm_base;
-    PL_collxfrm_mult	= proto_perl->Icollxfrm_mult;
-    PL_strxfrm_max_cp   = proto_perl->Istrxfrm_max_cp;
+    PL_collation_standard = true;
+    PL_collxfrm_base	= 0;
+    PL_collxfrm_mult	= 0;
+    PL_strxfrm_max_cp   = 0;
     PL_strxfrm_is_behaved = proto_perl->Istrxfrm_is_behaved;
-    PL_strxfrm_NUL_replacement = proto_perl->Istrxfrm_NUL_replacement;
+    PL_strxfrm_NUL_replacement = '\0';
 #endif /* USE_LOCALE_COLLATE */
 
 #ifdef USE_LOCALE_THREADS
@@ -15921,12 +15922,12 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
 #endif
 
 #ifdef USE_LOCALE_NUMERIC
-    PL_numeric_name	= SAVEPV(proto_perl->Inumeric_name);
-    PL_numeric_radix_sv	= sv_dup_inc(proto_perl->Inumeric_radix_sv, param);
-    PL_underlying_radix_sv = sv_dup_inc(proto_perl->Iunderlying_radix_sv, param);
-    PL_numeric_standard	= proto_perl->Inumeric_standard;
-    PL_numeric_underlying	= proto_perl->Inumeric_underlying;
-    PL_numeric_underlying_is_standard	= proto_perl->Inumeric_underlying_is_standard;
+    PL_numeric_name	= SAVEPV("C");
+    PL_numeric_radix_sv	= newSVpvs(".");
+    PL_underlying_radix_sv = newSVpvs(".");
+    PL_numeric_standard	= true;
+    PL_numeric_underlying = true;
+    PL_numeric_underlying_is_standard = true;
 
 #  if defined(USE_POSIX_2008_LOCALE)
     PL_underlying_numeric_obj = NULL;

--- a/sv.c
+++ b/sv.c
@@ -15939,6 +15939,7 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
 #endif /* !USE_LOCALE_NUMERIC */
 #if defined(USE_POSIX_2008_LOCALE)
     PL_scratch_locale_obj = NULL;
+    PL_cur_locale_obj = PL_C_locale_obj;
 #endif
 
 #ifdef HAS_MBRLEN

--- a/sv.c
+++ b/sv.c
@@ -15423,6 +15423,7 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
 
     /* for each stash, determine whether its objects should be cloned */
     S_visit(proto_perl, do_mark_cloneable_stash, SVt_PVHV, SVTYPEMASK);
+    my_perl->Iphase = PERL_PHASE_CONSTRUCT;
     PERL_SET_THX(my_perl);
 
 #ifdef DEBUGGING

--- a/sv.c
+++ b/sv.c
@@ -15584,30 +15584,6 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
     PL_subline		= proto_perl->Isubline;
 
     PL_cv_has_eval	= proto_perl->Icv_has_eval;
-
-#ifdef USE_LOCALE_COLLATE
-    PL_collation_ix	= proto_perl->Icollation_ix;
-    PL_collation_standard = proto_perl->Icollation_standard;
-    PL_collxfrm_base	= proto_perl->Icollxfrm_base;
-    PL_collxfrm_mult	= proto_perl->Icollxfrm_mult;
-    PL_strxfrm_max_cp   = proto_perl->Istrxfrm_max_cp;
-    PL_strxfrm_is_behaved = proto_perl->Istrxfrm_is_behaved;
-    PL_strxfrm_NUL_replacement = proto_perl->Istrxfrm_NUL_replacement;
-#endif /* USE_LOCALE_COLLATE */
-
-#ifdef USE_LOCALE_NUMERIC
-    PL_numeric_standard	= proto_perl->Inumeric_standard;
-    PL_numeric_underlying	= proto_perl->Inumeric_underlying;
-    PL_numeric_underlying_is_standard	= proto_perl->Inumeric_underlying_is_standard;
-#endif /* !USE_LOCALE_NUMERIC */
-
-    /* Did the locale setup indicate UTF-8? */
-    PL_utf8locale	= proto_perl->Iutf8locale;
-
-#ifdef USE_LOCALE_THREADS
-    assert(PL_locale_mutex_depth <= 0);
-    PL_locale_mutex_depth = 0;
-#endif
     /* Unicode features (see perlrun/-C) */
     PL_unicode		= proto_perl->Iunicode;
 
@@ -15920,20 +15896,37 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
     /* Should we warn if uses locale? */
     PL_ctype_name	= SAVEPV(proto_perl->Ictype_name);
     PL_warn_locale      = sv_dup_inc(proto_perl->Iwarn_locale, param);
-    PL_utf8locale             = proto_perl->Iutf8locale;
     PL_in_utf8_CTYPE_locale   = proto_perl->Iin_utf8_CTYPE_locale;
     PL_in_utf8_turkic_locale  = proto_perl->Iin_utf8_turkic_locale;
 #endif
 
+    /* Did the locale setup indicate UTF-8? */
+    PL_utf8locale	= proto_perl->Iutf8locale;
+
 #ifdef USE_LOCALE_COLLATE
     PL_in_utf8_COLLATE_locale = proto_perl->Iin_utf8_COLLATE_locale;
     PL_collation_name	= SAVEPV(proto_perl->Icollation_name);
+    PL_collation_ix	= proto_perl->Icollation_ix;
+    PL_collation_standard = proto_perl->Icollation_standard;
+    PL_collxfrm_base	= proto_perl->Icollxfrm_base;
+    PL_collxfrm_mult	= proto_perl->Icollxfrm_mult;
+    PL_strxfrm_max_cp   = proto_perl->Istrxfrm_max_cp;
+    PL_strxfrm_is_behaved = proto_perl->Istrxfrm_is_behaved;
+    PL_strxfrm_NUL_replacement = proto_perl->Istrxfrm_NUL_replacement;
 #endif /* USE_LOCALE_COLLATE */
+
+#ifdef USE_LOCALE_THREADS
+    assert(PL_locale_mutex_depth <= 0);
+    PL_locale_mutex_depth = 0;
+#endif
 
 #ifdef USE_LOCALE_NUMERIC
     PL_numeric_name	= SAVEPV(proto_perl->Inumeric_name);
     PL_numeric_radix_sv	= sv_dup_inc(proto_perl->Inumeric_radix_sv, param);
     PL_underlying_radix_sv = sv_dup_inc(proto_perl->Iunderlying_radix_sv, param);
+    PL_numeric_standard	= proto_perl->Inumeric_standard;
+    PL_numeric_underlying	= proto_perl->Inumeric_underlying;
+    PL_numeric_underlying_is_standard	= proto_perl->Inumeric_underlying_is_standard;
 
 #  if defined(USE_POSIX_2008_LOCALE)
     PL_underlying_numeric_obj = NULL;

--- a/sv.c
+++ b/sv.c
@@ -15891,6 +15891,9 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
         PL_curlocales[i] = SAVEPV("C");
     }
 #endif
+#ifdef USE_PL_CUR_LC_ALL
+    PL_cur_LC_ALL = SAVEPV(proto_perl->Icur_LC_ALL);
+#endif
 #ifdef USE_LOCALE_CTYPE
     Copy(PL_fold, PL_fold_locale, 256, U8);
 

--- a/thread.h
+++ b/thread.h
@@ -404,6 +404,7 @@ extern PERL_THREAD_LOCAL void *PL_current_context;
                                         PL_current_context = (void *)(t)))) \
             Perl_croak_nocontext("panic: pthread_setspecific (%d) [%s:%d]", \
                                  _eC_, __FILE__, __LINE__);                 \
+        PERL_SET_NON_tTHX_CONTEXT(t);                                       \
     } STMT_END
 
 #else

--- a/thread.h
+++ b/thread.h
@@ -397,12 +397,13 @@ extern PERL_THREAD_LOCAL void *PL_current_context;
 /* We must also call pthread_setspecific() always, as C++ code has to read it
  * with pthreads (the #else side just below) */
 
-#  define PERL_SET_CONTEXT(t)                                           \
-    STMT_START {                                                        \
-        int _eC_;                                                       \
-        if ((_eC_ = pthread_setspecific(PL_thr_key, PL_current_context = (void *)(t)))) \
+#  define PERL_SET_CONTEXT(t)                                               \
+    STMT_START {                                                            \
+        int _eC_;                                                           \
+        if ((_eC_ = pthread_setspecific(PL_thr_key,                         \
+                                        PL_current_context = (void *)(t)))) \
             Perl_croak_nocontext("panic: pthread_setspecific (%d) [%s:%d]", \
-                                 _eC_, __FILE__, __LINE__);             \
+                                 _eC_, __FILE__, __LINE__);                 \
     } STMT_END
 
 #else

--- a/util.c
+++ b/util.c
@@ -3740,6 +3740,9 @@ Perl_set_context(void *t)
             Perl_croak_nocontext("panic: pthread_setspecific, error=%d", error);
     }
 #  endif
+
+    PERL_SET_NON_tTHX_CONTEXT(t);
+
 #else
     PERL_UNUSED_ARG(t);
 #endif


### PR DESCRIPTION
The POSIX 2008 locale API introduces per-thread locales.  But the
previous global locale system is retained, probably for backward
compatibility.

Prior to this commit, there was a bug in which, when a thread
terminates, the master thread was switched into the global locale.  That
meant that that thread was no longer thread-safe with regards to
locales.

This bug stems from the fact that perl assumes that all you need to do
to switch between threads (or embedded interpreters) is to change out
aTHX.  Indeed much effort was expended in crafting perl to make this the
case.  But it breaks down in the case of some alien library that keeps
per-thread information.  That library needs to be informed of the
switch.  In this case it is libc keeping per-thread locale information.
We change the thread context, but the library still retains the old
thread's locale.

One cannot be using a given locale object and successfully free it.
Therefore the code switches to the global locale (which isn't
deletable) before freeing.  There was no apparent need to do more
switching, as the thread is in the process of dying.  What I was unaware
of is that it is the parent thread pretending to be the dying one for the
purposes of destruction.  So switching to the global locale affected the
parent, leaving it there.

The parent thread called the locale.c thread locale termination
function, and then called the perl.c perl_destruct() on the thread.  This
commit moves all the code for thread destruction from perl.c into the
locale.c code, and calls it.  Thus the thread initiation and termination
is moved into locale.c

The thread termination is also called from thread.c.  This cleans up a
dying thread.  The perl.c call is needed for thread0 and
non-multiplicity builds.  A check is done to prevent duplicate work.

This commit adds a new per-interpreter variable which maps aTHX to its
locale.  This is used to get the terminating thread's locale instead of
the master.  And the master locale is switched back to at the end.

This commit is incomplete.  Something similar needs to be done for
Windows where the libc knows the per-thread locale.

I'm unsure of if this is the full correct approach.  It only works for
thread termination.  Perhaps a better solution would be to change the
locale every time aTHX is changed.  PERL_SET_INTERP, PERL_SET_CONTEXT,
and PERL_SET_THX all seem to do the aTHX change, and I can't figure out
when you would prefer one over the other.  But maybe one of them should
then arrange also to change the locale when aTHX is changed.

Perhaps you can think of other libraries and functions that have a
similar problem that also would need something like this.

This commit causes https://github.com/Perl/perl5/issues/20155 to go away.  The triggering failure is merely
a symptom of the deeper problem.  A proper test will need to be done in
XS.