### PR TITLE
io_unix test leaves stray tmp file

### DIFF
--- a/dist/IO/t/io_unix.t
+++ b/dist/IO/t/io_unix.t
@@ -71,6 +71,7 @@ my $listen = IO::Socket::UNIX->new(Local => $PATH, Listen => 0);
 # local sockets.  Therefore we will retry with a File::Temp
 # generated filename from a temp directory.
 unless (defined $listen) {
+print STDERR "KEN1 TEMP\n";
     eval { require File::Temp };
     unless ($@) {
 	File::Temp->import( 'mktemp' );
@@ -100,7 +101,7 @@ if (my $pid = fork()) {
 	$sock->close;
 
 	waitpid($pid,0);
-	unlink($PATH) || $^O eq 'os2' || warn "Can't unlink $PATH: $!";
+	unlink($PATH) || $^O =~ /^(?:os2|MSWin32)$/ || warn "Can't unlink $PATH: $!";
 
 	print "ok 5\n";
     } else {
@@ -123,3 +124,4 @@ if (my $pid = fork()) {
 } else {
  die;
 }
+system('cmd.exe', '/c', 'del', $PATH) if $^O eq 'MSWin32';

--- a/dist/IO/t/io_unix.t
+++ b/dist/IO/t/io_unix.t
@@ -71,7 +71,6 @@ my $listen = IO::Socket::UNIX->new(Local => $PATH, Listen => 0);
 # local sockets.  Therefore we will retry with a File::Temp
 # generated filename from a temp directory.
 unless (defined $listen) {
-print STDERR "KEN1 TEMP\n";
     eval { require File::Temp };
     unless ($@) {
 	File::Temp->import( 'mktemp' );


### PR DESCRIPTION
On Windows, the dist/IO/t/io_unix.t test leaves a temporary file 'dist/IO/t/sock-*' like:

`../dist/IO/t/io_unix.t .. 1/5 Can't unlink sock-27804: Invalid argument at t/io_unix.t line 103.`

The code uses fork() and considering the fork() emulation on Windows and how Windows dislikes removing files that are in use, this causes problems during the attempted unlink() call. I can't figure out exactly why perl can't unlink it later, but doing at the end of the script with an external shell does the trick.

Obviously not a biggie but nice to get the test output cleaner if nothing else...

Better commented commit forthcoming asap.