### PR TITLE
Resolve #2754 and #16300 - introduce a workaround for Module::Install::DSL and fixup return code for perl_parser()

### DIFF
--- a/op.c
+++ b/op.c
@@ -10711,14 +10711,17 @@ S_process_special_blocks(pTHX_ I32 floor, const char *const fullname,
 {
     const char *const colon = strrchr(fullname,':');
     const char *const name = colon ? colon + 1 : fullname;
+    int is_module_install_hack = 0;
 
     PERL_ARGS_ASSERT_PROCESS_SPECIAL_BLOCKS;
 
     if (*name == 'B') {
-        if (strEQ(name, "BEGIN")) {
+        module_install_hack:
+        if (strEQ(name, "BEGIN") || is_module_install_hack) {
             const I32 oldscope = PL_scopestack_ix;
             dSP;
             (void)CvGV(cv);
+            is_module_install_hack = 0;
             if (floor) LEAVE_SCOPE(floor);
             ENTER;
 
@@ -10784,6 +10787,30 @@ S_process_special_blocks(pTHX_ I32 floor, const char *const fullname,
                 return FALSE;
         } else if (*name == 'I') {
             if (strEQ(name, "INIT")) {
+#ifdef MI_INIT_WORKAROUND_PACK
+                {
+                    HV *hv= CvSTASH(cv);
+                    STRLEN len = hv ? HvNAMELEN(hv) : 0;
+                    char *pv= (len == sizeof(MI_INIT_WORKAROUND_PACK)-1)
+                            ? HvNAME_get(hv) : NULL;
+                    if ( pv && strEQ(pv,MI_INIT_WORKAROUND_PACK) )
+                    {
+                        /* old versions of Module::Install::DSL contain code
+                         * that creates an INIT in eval, which expect to run
+                         * after an exit(0) in BEGIN. This unfortunately
+                         * breaks a lot of code in the CPAN river. So we magically
+                         * convert INIT blocks from Module::Install::DSL to
+                         * be BEGIN blocks. Which works out, since the INIT
+                         * blocks it creates are eval'ed so are late.
+                         */
+                        Perl_warn(aTHX_ "Treating %s::INIT block as BEGIN block as workaround",
+                                MI_INIT_WORKAROUND_PACK);
+                        is_module_install_hack = 1;
+                        goto module_install_hack;
+                    }
+
+                }
+#endif
                 if (PL_main_start)
                     /* diag_listed_as: Too late to run %s block */
                     Perl_ck_warner(aTHX_ packWARN(WARN_VOID),

--- a/op.h
+++ b/op.h
@@ -1166,6 +1166,7 @@ struct op_argcheck_aux {
     char slurpy;     /* presence of slurpy: may be '\0', '@' or '%' */
 };
 
+#define MI_INIT_WORKAROUND_PACK "Module::Install::DSL"
 
 /*
  * ex: set ts=8 sts=4 sw=4 et:

--- a/os2/perlrexx.c
+++ b/os2/perlrexx.c
@@ -74,6 +74,7 @@ init_perl(int doparse)
         if (!my_perl)
             return 0;
         perl_construct(my_perl);
+        PL_exit_flags |= PERL_EXIT_DESTRUCT_END;
         PL_perl_destruct_level = 1;
     }
     if (!doparse)

--- a/perl.c
+++ b/perl.c
@@ -631,9 +631,6 @@ perl_destruct(pTHXx)
 
     assert(PL_scopestack_ix == 1);
 
-    /* wait for all pseudo-forked children to finish */
-    PERL_WAIT_FOR_CHILDREN;
-
     destruct_level = PL_perl_destruct_level;
     {
         const char * const s = PerlEnv_getenv("PERL_DESTRUCT_LEVEL");
@@ -671,6 +668,10 @@ perl_destruct(pTHXx)
     LEAVE;
     FREETMPS;
     assert(PL_scopestack_ix == 0);
+
+    /* wait for all pseudo-forked children to finish */
+    PERL_WAIT_FOR_CHILDREN;
+
 
     /* normally when we get here, PL_parser should be null due to having
      * its original (null) value restored by SAVEt_PARSER during leaving

--- a/perl.c
+++ b/perl.c
@@ -1727,16 +1727,13 @@ For historical reasons, the non-zero return value also attempts to
 be a suitable value to pass to the C library function C<exit> (or to
 return from C<main>), to serve as an exit code indicating the nature
 of the way initialisation terminated.  However, this isn't portable,
-due to differing exit code conventions.  A historical bug is preserved
-for the time being: if the Perl built-in C<exit> is called during this
-function's execution, with a type of exit entailing a zero exit code
-under the host operating system's conventions, then this function
-returns zero rather than a non-zero value.  This bug, [perl #2754],
-leads to C<perl_run> being called (and therefore C<INIT> blocks and the
-main program running) despite a call to C<exit>.  It has been preserved
-because a popular module-installing module has come to rely on it and
-needs time to be fixed.  This issue is [perl #132577], and the original
-bug is due to be fixed in Perl 5.30.
+due to differing exit code conventions.  An attempt is made to return
+an exit code of the type required by the host operating system, but
+because it is constrained to be non-zero, it is not necessarily possible
+to indicate every type of exit.  It is only reliable on Unix, where a
+zero exit code can be augmented with a set bit that will be ignored.
+In any case, this function is not the correct place to acquire an exit
+code: one should get that from L</perl_destruct>.
 
 =cut
 */
@@ -1929,12 +1926,11 @@ perl_parse(pTHXx_ XSINIT_t xsinit, int argc, char **argv, char **env)
         ret = STATUS_EXIT;
         if (ret == 0) {
             /*
-             * At this point we should do
-             *     ret = 0x100;
-             * to avoid [perl #2754], but that bugfix has been postponed
-             * because of the Module::Install breakage it causes
-             * [perl #132577].
+             * We do this here to avoid [perl #2754].
+             * Note this may cause trouble with Module::Install.
+             * See: [perl #132577].
              */
+            ret = 0x100;
         }
         break;
     case 3:

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -6391,6 +6391,15 @@ C<$tr> or C<$y> may cause this error.
 (F) The lexer couldn't find the final delimiter of a tr///, tr[][],
 y/// or y[][] construct.
 
+=item Treating %s::INIT block as BEGIN block as workaround
+
+(S) A package is using an old version of C<Module::Install::DSL> to
+install, which makes unsafe assumptions about when INIT blocks will be
+called. Because C<Module::Install::DSL> is used to install other modules
+and is difficult to upgrade we have a special workaround in place to
+deal with this. Unless you are a maintainer of an affected module you
+can ignore this warning. We emit it only as a sanity check.
+
 =item '%s' trapped by operation mask
 
 (F) You tried to use an operator from a Safe compartment in which it's

--- a/t/op/blocks.t
+++ b/t/op/blocks.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan tests => 22;
+plan tests => 23;
 
 my @expect = qw(
 b1
@@ -265,3 +265,7 @@ TODO: {
 
 fresh_perl_is('eval "BEGIN {goto end}"; end:', '', {}, 'RT #113934: goto out of BEGIN causes assertion failure');
 
+fresh_perl_is('package Module::Install::DSL; BEGIN { eval "INIT { print q(INIT fired in eval) }" }',
+    "Treating Module::Install::DSL::INIT block as BEGIN block as workaround at (eval 1) line 1.\n"
+    ."INIT fired in eval", {},
+   'GH Issue #16300: Module::Install::DSL workaround');

--- a/t/op/blocks.t
+++ b/t/op/blocks.t
@@ -188,10 +188,6 @@ SKIP: {
 
 
 SKIP: {
-    if ($^O =~ /^(MSWin32|os2)$/) {
-        skip "non_UNIX plafforms and PERL_EXIT_DESTRUCT_END (RT #132863)", 6;
-    }
-
     fresh_perl_is(
         "$testblocks BEGIN { exit 1; }",
         "begin\nunitcheck\ncheck\nend",

--- a/t/op/blocks.t
+++ b/t/op/blocks.t
@@ -147,7 +147,6 @@ fresh_perl_is('END { print "ok\n" } INIT { bless {} and exit }', "ok\n",
 	       {}, 'null PL_curcop in newGP');
 
 # [perl #2754] exit(0) didn't exit from inside a UNITCHECK or CHECK block
-
 my $testblocks =
     join(" ",
         "BEGIN { \$| = 1; }",
@@ -167,21 +166,21 @@ SKIP: {
     skip "VMS doesn't have the perl #2754 bug", 3 if $^O eq 'VMS';
     fresh_perl_is(
         "$testblocks BEGIN { exit 0; }",
-        "begin\nunitcheck\ncheck\ninit\nend",
+        "begin\nunitcheck\ncheck\nend",
         {},
         "BEGIN{exit 0} doesn't exit yet"
     );
 
     fresh_perl_is(
         "$testblocks UNITCHECK { exit 0; }",
-        "begin\nunitcheck\ncheck\ninit\nmain\nend",
+        "begin\nunitcheck\ncheck\nend",
         {},
         "UNITCHECK{exit 0} doesn't exit yet"
     );
 
     fresh_perl_is(
         "$testblocks CHECK { exit 0; }",
-        "begin\nunitcheck\ncheck\ninit\nmain\nend",
+        "begin\nunitcheck\ncheck\nend",
         {},
         "CHECK{exit 0} doesn't exit yet"
     );
@@ -257,6 +256,7 @@ fresh_perl_like(
     {},
     "INIT{die} should exit"
 );
+
 
 TODO: {
     local $TODO = 'RT #2917: INIT{} in eval is wrongly considered too late';

--- a/win32/perllib.c
+++ b/win32/perllib.c
@@ -180,6 +180,7 @@ RunPerl(int argc, char **argv, char **env)
     if (!(my_perl = perl_alloc()))
         return (1);
     perl_construct(my_perl);
+    PL_exit_flags |= PERL_EXIT_DESTRUCT_END;
     PL_perl_destruct_level = 0;
 
     /* PERL_SYS_INIT() may update the environment, e.g. via ansify_path().


### PR DESCRIPTION
In 0301e899536a22752f40481d8a1d141b7a7dda82 Zefram fixed a long standing bug #2754, and properly defined the exit code from perl_parse(). This however broke Module::Install::DSL as can be seen in issue #16300. The patch was reverted in 857320cbf85e762add18885ae8a197b5e0c21b69.  Module::Install is not easily upgradable due to its design, and there are still a lot of modules out there with the buggy use of INIT. 

However, it turns out that the bugfix from #2754 allows us to fix other issues which we want to address. 

So this PR reverts Zeframs revert and creates a simple workaround for the Module::Install::DSL issue. INIT blocks in the Module::Install::DSL namespace will magically be treated as BEGIN blocks. This means that they will be executed inside of the eval that Module::Install::DSL creates, and executed as expected, at the same time a warning is produced to show the workaround has been triggered.

The check for this is quite efficient so it should not be noticeable outside of the special case it is meant to work around.

This will enable us to fix Issue: #20161 and potentially also apply PR #20168  