### PR TITLE
Resolve issue #20161: Evals that die under the debugger may or may not leak eval data

### DIFF
--- a/cop.h
+++ b/cop.h
@@ -116,8 +116,8 @@ typedef struct jmpenv JMPENV;
             int i = 0;                                                  \
             JMPENV *p = PL_top_env;                                     \
             while (p) { i++; p = p->je_prev; }				\
-            Perl_deb(aTHX_ "JMPENV_PUSH pre level=%d at %s:%d\n",       \
-                         i,  __FILE__, __LINE__);                       \
+            Perl_deb(aTHX_ "JMPENV_PUSH pre level=%d in %s at %s:%d\n", \
+                         i,  SAFE_FUNCTION__, __FILE__, __LINE__);      \
         });                                                             \
         cur_env.je_prev = PL_top_env;					\
         JE_OLD_STACK_HWM_save(cur_env);                                 \
@@ -130,8 +130,8 @@ typedef struct jmpenv JMPENV;
             int i = 0;                                                  \
             JMPENV *p = PL_top_env;                                     \
             while (p) { i++; p = p->je_prev; }				\
-            Perl_deb(aTHX_ "JMPENV_PUSH level=%d ret=%d at %s:%d\n",    \
-                         i, cur_env.je_ret,  __FILE__, __LINE__);       \
+            Perl_deb(aTHX_ "JMPENV_PUSH level=%d ret=%d in %s at %s:%d\n",    \
+                         i, cur_env.je_ret, SAFE_FUNCTION__,  __FILE__, __LINE__); \
         });                                                             \
         (v) = cur_env.je_ret;						\
     } STMT_END
@@ -141,8 +141,8 @@ typedef struct jmpenv JMPENV;
         DEBUG_l({                                                       \
             int i = -1; JMPENV *p = PL_top_env;				\
             while (p) { i++; p = p->je_prev; }				\
-            Perl_deb(aTHX_ "JMPENV_POP level=%d at %s:%d\n",		\
-                         i, __FILE__, __LINE__);})			\
+            Perl_deb(aTHX_ "JMPENV_POP level=%d in %s at %s:%d\n",        \
+                         i, SAFE_FUNCTION__, __FILE__, __LINE__);})        \
         assert(PL_top_env == &cur_env);					\
         PL_delaymagic = cur_env.je_old_delaymagic;			\
         PL_top_env = cur_env.je_prev;					\
@@ -153,8 +153,8 @@ typedef struct jmpenv JMPENV;
         DEBUG_l({                                               \
             int i = -1; JMPENV *p = PL_top_env;			\
             while (p) { i++; p = p->je_prev; }			\
-            Perl_deb(aTHX_ "JMPENV_JUMP(%d) level=%d at %s:%d\n", \
-                         (int)(v), i, __FILE__, __LINE__);})    \
+            Perl_deb(aTHX_ "JMPENV_JUMP(%d) level=%d in %s at %s:%d\n",         \
+                         (int)(v), i, SAFE_FUNCTION__, __FILE__, __LINE__);})   \
         if (PL_top_env->je_prev)				\
             PerlProc_longjmp(PL_top_env->je_buf, (v));		\
         if ((v) == 2)						\
@@ -168,9 +168,9 @@ typedef struct jmpenv JMPENV;
     STMT_START {							\
         DEBUG_l(                                                        \
             Perl_deb(aTHX_						\
-                "JUMPLEVEL set catch %d => %d (for %p) at %s:%d\n",	\
+                "JUMPLEVEL set catch %d => %d (for %p) in %s at %s:%d\n",   \
                  PL_top_env->je_mustcatch, (v), (void*)PL_top_env,      \
-                 __FILE__, __LINE__);)					\
+                 SAFE_FUNCTION__, __FILE__, __LINE__);)			\
         PL_top_env->je_mustcatch = (v);					\
     } STMT_END
 
@@ -889,7 +889,7 @@ struct block {
 
 #define CX_DEBUG(cx, action)						\
     DEBUG_l(								\
-        Perl_deb(aTHX_ "CX %ld %s %s (scope %ld,%ld) (save %ld,%ld) at %s:%d\n",\
+        Perl_deb(aTHX_ "CX %ld %s %s (scope %ld,%ld) (save %ld,%ld) in %s at %s:%d\n",\
                     (long)cxstack_ix,					\
                     action,						\
                     PL_block_type[CxTYPE(cx)],	                        \
@@ -897,7 +897,7 @@ struct block {
                     (long)(cx->blk_oldscopesp),		                \
                     (long)PL_savestack_ix,				\
                     (long)(cx->blk_oldsaveix),                          \
-                    __FILE__, __LINE__));
+                    SAFE_FUNCTION__, __FILE__, __LINE__));
 
 
 
@@ -1162,8 +1162,8 @@ typedef struct stackinfo PERL_SI;
         DEBUG_l({							\
             int i = 0; PERL_SI *p = PL_curstackinfo;			\
             while (p) { i++; p = p->si_prev; }				\
-            Perl_deb(aTHX_ "push STACKINFO %d at %s:%d\n",		\
-                         i, __FILE__, __LINE__);})			\
+            Perl_deb(aTHX_ "push STACKINFO %d in %s at %s:%d\n",        \
+                         i, SAFE_FUNCTION__, __FILE__, __LINE__);})        \
         if (!next) {							\
             next = new_stackinfo(32, 2048/sizeof(PERL_CONTEXT) - 1);	\
             next->si_prev = PL_curstackinfo;				\
@@ -1190,8 +1190,8 @@ typedef struct stackinfo PERL_SI;
         DEBUG_l({							\
             int i = -1; PERL_SI *p = PL_curstackinfo;			\
             while (p) { i++; p = p->si_prev; }				\
-            Perl_deb(aTHX_ "pop  STACKINFO %d at %s:%d\n",		\
-                         i, __FILE__, __LINE__);})			\
+            Perl_deb(aTHX_ "pop  STACKINFO %d in %s at %s:%d\n",        \
+                         i, SAFE_FUNCTION__, __FILE__, __LINE__);})        \
         if (!prev) {							\
             Perl_croak_popstack();					\
         }								\

--- a/cop.h
+++ b/cop.h
@@ -112,10 +112,12 @@ typedef struct jmpenv JMPENV;
 
 #define JMPENV_PUSH(v)                                                  \
     STMT_START {							\
-        PERL_DEB(int i=0);                                              \
         DEBUG_l({                                                       \
+            int i = 0;                                                  \
             JMPENV *p = PL_top_env;                                     \
             while (p) { i++; p = p->je_prev; }				\
+            Perl_deb(aTHX_ "JMPENV_PUSH pre level=%d at %s:%d\n",       \
+                         i,  __FILE__, __LINE__);                       \
         });                                                             \
         cur_env.je_prev = PL_top_env;					\
         JE_OLD_STACK_HWM_save(cur_env);                                 \
@@ -124,11 +126,14 @@ typedef struct jmpenv JMPENV;
         PL_top_env = &cur_env;						\
         cur_env.je_mustcatch = FALSE;					\
         cur_env.je_old_delaymagic = PL_delaymagic;			\
-        (v) = cur_env.je_ret;						\
         DEBUG_l({                                                       \
+            int i = 0;                                                  \
+            JMPENV *p = PL_top_env;                                     \
+            while (p) { i++; p = p->je_prev; }				\
             Perl_deb(aTHX_ "JMPENV_PUSH level=%d ret=%d at %s:%d\n",    \
                          i, cur_env.je_ret,  __FILE__, __LINE__);       \
         });                                                             \
+        (v) = cur_env.je_ret;						\
     } STMT_END
 
 #define JMPENV_POP \

--- a/handy.h
+++ b/handy.h
@@ -132,10 +132,13 @@ required, but is kept for backwards compatibility.
  * XXX Similarly, a Configure probe for __FILE__ and __LINE__ is needed. */
 #if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || (defined(__SUNPRO_C)) /* C99 or close enough. */
 #  define FUNCTION__ __func__
+#  define SAFE_FUNCTION__ __func__
 #elif (defined(__DECC_VER)) /* Tru64 or VMS, and strict C89 being used, but not modern enough cc (in Tur64, -c99 not known, only -std1). */
-#  define FUNCTION__ ""
+#  define FUNCTION__ ("")
+#  define SAFE_FUNCTION__ ("UNKNOWN")
 #else
 #  define FUNCTION__ __FUNCTION__ /* Common extension. */
+#  define SAFE_FUNCTION__ __FUNCTION__ /* Common extension. */
 #endif
 
 /* XXX A note on the perl source internal type system.  The

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -3686,12 +3686,13 @@ S_doeval_compile(pTHX_ U8 gimme, CV* outside, U32 seq, HV *hh)
 
     CALL_BLOCK_HOOKS(bhk_eval, saveop);
 
-    /* note that yyparse() may raise an exception, e.g. C<BEGIN{die}>,
-     * so honour CATCH_GET and trap it here if necessary */
-
-
+    /* we should never be CATCH_GET true here, as our immediate callers should
+     * always handle that case. */
+    assert(!CATCH_GET);
     /* compile the code */
-    yystatus = (!in_require && CATCH_GET) ? S_try_yyparse(aTHX_ GRAMPROG) : yyparse(GRAMPROG);
+    yystatus = (!in_require)
+               ? S_try_yyparse(aTHX_ GRAMPROG)
+               : yyparse(GRAMPROG);
 
     if (yystatus || PL_parser->error_count || !PL_eval_root) {
         PERL_CONTEXT *cx;
@@ -4577,6 +4578,8 @@ PP(pp_entereval)
      */
     if (CATCH_GET)
         return docatch(Perl_pp_entereval);
+
+    assert(!CATCH_GET);
 
     gimme = GIMME_V;
     was = PL_breakable_sub_gen;

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -3750,7 +3750,7 @@ S_doeval_compile(pTHX_ U8 gimme, CV* outside, U32 seq, HV *hh)
         }
     }
 
-    if (PL_unitcheckav) {
+    if (PL_unitcheckav && av_count(PL_unitcheckav)>0) {
         OP *es = PL_eval_start;
         if (in_require) {
             call_list(PL_scopestack_ix, PL_unitcheckav);

--- a/t/comp/retainedlines.t
+++ b/t/comp/retainedlines.t
@@ -6,7 +6,7 @@
 # we've not yet verified that use works.
 # use strict;
 
-print "1..98\n";
+print "1..109\n";
 my $test = 0;
 
 sub failed {
@@ -164,6 +164,26 @@ for (0xA, 0) {
        "evals with BEGIN{die} are correctly cleaned up");
   }
 }
+
+for (0xA, 0) {
+  local $^P = $_;
+
+  eval (my $prog = "UNITCHECK{die}\n");
+  is (!!$@, 1, "Is \$@ true?");
+  is ($@=~/UNITCHECK failed--call queue aborted/, 1,
+      "Error is expected value?");
+
+  if ($_) {
+    check_retained_lines($prog, 'eval that defines UNITCHECK that dies');
+  }
+  else {
+    my @after = grep { /eval/ } keys %::;
+
+    is (scalar @after, 0 + keys %seen,
+       "evals with UNITCHECK{die} are correctly cleaned up");
+  }
+}
+
 
 # [perl #79442] A #line "foo" directive in a string eval was not updating
 # *{"_<foo"} in threaded perls, and was not putting the right lines into

--- a/t/comp/retainedlines.t
+++ b/t/comp/retainedlines.t
@@ -6,7 +6,7 @@
 # we've not yet verified that use works.
 # use strict;
 
-print "1..75\n";
+print "1..98\n";
 my $test = 0;
 
 sub failed {
@@ -101,7 +101,10 @@ for my $sep (' ', "\0") {
   my $prog = "sub $name {
     'This is $name'
   }
-1 +
+# 10 errors to triger a croak during compilation.
+1 +; 1 +; 1 +; 1 +; 1 +;
+1 +; 1 +; 1 +; 1 +; 1 +;
+1 +; # and one more for good measure.
 ";
 
   eval $prog and die;
@@ -119,7 +122,9 @@ foreach my $flags (0x0, 0x800, 0x1000, 0x1800) {
     # This is easier if we accept that the guts eval will add a trailing \n
     # for us
     my $prog = "1 + 1 + 1\n";
-    my $fail = "1 + \n";
+    my $fail = "1 +;\n" x 11; # we need 10 errors to trigger a croak during
+                              # compile, we add an extra one just for good
+                              # measure.
 
     is (eval $prog, 3, 'String eval works');
     if ($flags & 0x800) {

--- a/t/op/eval.t
+++ b/t/op/eval.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan(tests => 146);
+plan(tests => 149);
 
 eval 'pass();';
 
@@ -715,4 +715,15 @@ pass("eval in freed package does not crash");
         'Blocked BEGIN results in expected error');
     ::is($x,2,'BEGIN really did nothing');
 
+}
+
+{
+    # make sure that none of these segfault.
+    foreach my $line (
+        'eval "UNITCHECK { eval q(UNITCHECK { die; }); print q(A-) }";',
+        'eval "UNITCHECK { eval q(BEGIN     { die; }); print q(A-) }";',
+        'eval "BEGIN     { eval q(UNITCHECK { die; }); print q(A-) }";',
+    ) {
+        fresh_perl_is($line . ' print "ok";', "A-ok", {}, "No segfault: $line");
+    }
 }


### PR DESCRIPTION
We were leaking debug data, and not testing if we did. Assuming #20181 is applied, then we can apply this and fix #20161 which will enable use to merge #20168 if we want. This is rebased on top of #20181. Once that is applied only the most recent patch in this sequence will be relevant to this PR. 

This patch changes the code to use try_yyparse() when compiling evals, while preserving the existing behavior for require.  