### PR TITLE
patchlevel.h: Adjust embedded script for detabify

### DIFF
--- a/patchlevel.h
+++ b/patchlevel.h
@@ -118,11 +118,12 @@ open PLIN, "<", "patchlevel.h" or die "Couldn't open patchlevel.h : $!";
 open PLOUT, ">", "patchlevel.new" or die "Couldn't write on patchlevel.new : $!";
 my $seen=0;
 while (<PLIN>) {
-    if (/\t,NULL/ and $seen) {
+    if (/^(\s+),NULL/ and $seen) {
+       my $pre = $1;
        while (my $c = shift @ARGV){
             $c =~ s|\\|\\\\|g;
             $c =~ s|"|\\"|g;
-            print PLOUT qq{\t,"$c"\n};
+            print PLOUT qq{$pre,"$c"\n};
        }
     }
     $seen++ if /local_patches\[\]/;


### PR DESCRIPTION
patchlevel.h was detabified[^1] and tabs replaced with spaces.

It however contains an embedded perl script for updating the
`local_patches` list (in patchlevel.h).

This no longer worked because it used:

	/\t,NULL/

(which no longer matches after the detabify)

Fix it by using `\s+` (and by capturing it and using it
as leading space in the added text).

Example of how to run it:

	$ perl -x patchlevel.h patch_foo patch_bar patch_baz

[^1]: in commit 1604cfb0273418ed479719f39def5ee559bffda2