### PR TITLE
handle intermediate scopes not including the name in find_lexical_cv()

### DIFF
--- a/op.c
+++ b/op.c
@@ -13532,13 +13532,40 @@ subroutine.
 CV *
 Perl_find_lexical_cv(pTHX_ PADOFFSET off)
 {
-    PADNAME *name = PAD_COMPNAME(off);
+    const PADNAME *name = PAD_COMPNAME(off);
     CV *compcv = PL_compcv;
     while (PadnameOUTER(name)) {
-        assert(PARENT_PAD_INDEX(name));
         compcv = CvOUTSIDE(compcv);
-        name = PadlistNAMESARRAY(CvPADLIST(compcv))
+        if (LIKELY(PARENT_PAD_INDEX(name))) {
+            name = PadlistNAMESARRAY(CvPADLIST(compcv))
                 [off = PARENT_PAD_INDEX(name)];
+        }
+        else {
+            /* In an eval() in an inner scope like a function, the
+               intermediate pad in the sub might not be populated with the
+               sub.  So search harder.
+
+               It is possible we won't find the name in this
+               particular scope, but that's fine, if we don't we'll
+               find it in some outer scope.  Finding it here will let us
+               go back to following the PARENT_PAD_INDEX() chain.
+            */
+            const PADNAMELIST * const names = PadlistNAMES(CvPADLIST(compcv));
+            PADNAME * const * const name_p = PadnamelistARRAY(names);
+            int offset;
+            for (offset = PadnamelistMAXNAMED(names); offset > 0; offset--) {
+                const PADNAME * const thisname = name_p[offset];
+                /* The pv is copied from the outer PADNAME to the
+                   inner PADNAMEs so we don't need to compare the
+                   string contents
+                */
+                if (thisname && PadnameLEN(thisname) == PadnameLEN(name)
+                    && PadnamePV(thisname) == PadnamePV(name)) {
+                    name = thisname;
+                    break;
+                }
+            }
+        }
     }
     assert(!PadnameIsOUR(name));
     if (!PadnameIsSTATE(name) && PadnamePROTOCV(name)) {

--- a/t/op/lexsub.t
+++ b/t/op/lexsub.t
@@ -7,7 +7,7 @@ BEGIN {
     *bar::is = *is;
     *bar::like = *like;
 }
-plan 150;
+plan 151;
 
 # -------------------- our -------------------- #
 
@@ -960,3 +960,14 @@ like runperl(
 
 is join("-", qw(aa bb), do { my sub lleexx; 123 }, qw(cc dd)),
   "aa-bb-123-cc-dd", 'do { my sub...} in a list [perl #132442]';
+
+{
+    # this would crash because find_lexical_cv() couldn't handle an
+    # intermediate scope which didn't include the sub
+    no warnings 'experimental::builtin';
+    use builtin 'ceil';
+    sub nested {
+        ok(eval 'ceil(1.5)', "no assertion failure calling a lexical sub from nested eval");
+    }
+    nested();
+}


### PR DESCRIPTION
In non-eval cases a use of a lexical symbol in an inner scope
also adds that name to the intermediate scope:
```
  [&foo] [$bar]  # defining scope
  [&foo] [$bar]  # intermediate scope
  [&foo] [$bar]  # using scope
```
but names can only be added to the PAD at compile-time, so for an
eval the intermediate scope is closed to further modifications,
and the intermediate scope doesn't get a definition for the name:
```
  [&foo] [$bar]  # defining scope
                 # intermediate scope
  [&foo] [$bar]  # eval 'foo($bar)' scope
```
but find_lexical_cv() assumed that the names would always exist
in the intermediate scopes, and failed an assertion.

find_lexical_cv() now falls back to searching for the cv by name
up the chain of nested scopes.

This doesn't fix a slightly related problem:
```
  my sub foo { }
  BEGIN {
    foo(); # Undefined subroutine &foo
  }
```
The fix for that may make find_lexical_cv() unnecessary, but is a
more complex fix.

Fixes #19857