### PR TITLE
Bump IO.pm version to 1.51, due to PR 19663

### DIFF
--- a/dist/IO/IO.pm
+++ b/dist/IO/IO.pm
@@ -7,7 +7,7 @@ use Carp;
 use strict;
 use warnings;
 
-our $VERSION = "1.50";
+our $VERSION = "1.51";
 XSLoader::load 'IO', $VERSION;
 
 sub import {

--- a/dist/IO/lib/IO/Dir.pm
+++ b/dist/IO/lib/IO/Dir.pm
@@ -18,7 +18,7 @@ use File::stat;
 use File::Spec;
 
 our @ISA = qw(Tie::Hash Exporter);
-our $VERSION = "1.50";
+our $VERSION = "1.51";
 
 our @EXPORT_OK = qw(DIR_UNLINK);
 

--- a/dist/IO/lib/IO/File.pm
+++ b/dist/IO/lib/IO/File.pm
@@ -135,7 +135,7 @@ require Exporter;
 
 our @ISA = qw(IO::Handle IO::Seekable Exporter);
 
-our $VERSION = "1.49";
+our $VERSION = "1.51";
 
 our @EXPORT = @IO::Seekable::EXPORT;
 

--- a/dist/IO/lib/IO/Handle.pm
+++ b/dist/IO/lib/IO/Handle.pm
@@ -270,7 +270,7 @@ use IO ();	# Load the XS module
 require Exporter;
 our @ISA = qw(Exporter);
 
-our $VERSION = "1.50";
+our $VERSION = "1.51";
 
 our @EXPORT_OK = qw(
     autoflush

--- a/dist/IO/lib/IO/Pipe.pm
+++ b/dist/IO/lib/IO/Pipe.pm
@@ -13,7 +13,7 @@ use strict;
 use Carp;
 use Symbol;
 
-our $VERSION = "1.50";
+our $VERSION = "1.51";
 
 sub new {
     my $type = shift;

--- a/dist/IO/lib/IO/Poll.pm
+++ b/dist/IO/lib/IO/Poll.pm
@@ -12,7 +12,7 @@ use IO::Handle;
 use Exporter ();
 
 our @ISA = qw(Exporter);
-our $VERSION = "1.49";
+our $VERSION = "1.51";
 
 our @EXPORT = qw( POLLIN
 	      POLLOUT

--- a/dist/IO/lib/IO/Seekable.pm
+++ b/dist/IO/lib/IO/Seekable.pm
@@ -106,7 +106,7 @@ require Exporter;
 our @EXPORT = qw(SEEK_SET SEEK_CUR SEEK_END);
 our @ISA = qw(Exporter);
 
-our $VERSION = "1.48";
+our $VERSION = "1.51";
 
 sub seek {
     @_ == 3 or croak 'usage: $io->seek(POS, WHENCE)';

--- a/dist/IO/lib/IO/Select.pm
+++ b/dist/IO/lib/IO/Select.pm
@@ -10,7 +10,7 @@ use     strict;
 use warnings::register;
 require Exporter;
 
-our $VERSION = "1.49";
+our $VERSION = "1.51";
 
 our @ISA = qw(Exporter); # This is only so we can do version checking
 

--- a/dist/IO/lib/IO/Socket.pm
+++ b/dist/IO/lib/IO/Socket.pm
@@ -23,7 +23,7 @@ require IO::Socket::UNIX if ($^O ne 'epoc' && $^O ne 'symbian');
 
 our @ISA = qw(IO::Handle);
 
-our $VERSION = "1.49";
+our $VERSION = "1.51";
 
 our @EXPORT_OK = qw(sockatmark);
 

--- a/dist/IO/lib/IO/Socket/INET.pm
+++ b/dist/IO/lib/IO/Socket/INET.pm
@@ -14,7 +14,7 @@ use Exporter;
 use Errno;
 
 our @ISA = qw(IO::Socket);
-our $VERSION = "1.50";
+our $VERSION = "1.51";
 
 my $EINVAL = exists(&Errno::EINVAL) ? Errno::EINVAL() : 1;
 

--- a/dist/IO/lib/IO/Socket/UNIX.pm
+++ b/dist/IO/lib/IO/Socket/UNIX.pm
@@ -11,7 +11,7 @@ use IO::Socket;
 use Carp;
 
 our @ISA = qw(IO::Socket);
-our $VERSION = "1.50";
+our $VERSION = "1.51";
 
 IO::Socket::UNIX->register_domain( AF_UNIX );
 


### PR DESCRIPTION
IIUC, https://github.com/Perl/perl5/pull/19663 should have bumped IO.pm to version 1.51, because of the alteration it made to dist/IO/poll.h.
But this was overlooked.
Consequently, blead has IO at version 1.50 and CPAN has IO at version 1.50, but they contain different IO/poll.h files.

This PR is intended to correct the earlier oversight.

Cheers,
Rob