### PR TITLE
Math-Complex: update URLs

### DIFF
--- a/cpan/Math-Complex/lib/Math/Trig.pm
+++ b/cpan/Math-Complex/lib/Math/Trig.pm
@@ -15,7 +15,7 @@ require Exporter;
 
 our @ISA = qw(Exporter);
 
-our $VERSION = 1.23;
+our $VERSION = 1.23_01;
 
 my @angcnv = qw(rad2deg rad2grad
 		deg2rad deg2grad
@@ -47,8 +47,9 @@ my @pi = qw(pi pi2 pi4 pip2 pip4);
 our @EXPORT_OK = (@rdlcnv, @greatcircle, @pi, 'Inf');
 
 # See e.g. the following pages:
-# http://www.movable-type.co.uk/scripts/LatLong.html
-# http://williams.best.vwh.net/avform.htm
+# https://www.movable-type.co.uk/scripts/latlong.html
+# https://edwilliams.org/avform.htm
+# https://en.wikipedia.org/wiki/Great-circle_distance
 
 our %EXPORT_TAGS = ('radial' => [ @rdlcnv ],
 	        'great_circle' => [ @greatcircle ],


### PR DESCRIPTION
Update the URLs with formulas for computing distance, bearing,
waypoints, destination etc. on a sphere. One of the URLs was dead.

This fixes CPAN RT #144195