### PR TITLE
Net-Ping: No longer need to TODO some tests when on FreeBSD

### DIFF
--- a/dist/Net-Ping/t/010_pingecho.t
+++ b/dist/Net-Ping/t/010_pingecho.t
@@ -19,7 +19,6 @@ BEGIN {use_ok('Net::Ping')};
 TODO: {
     local $TODO = "Not working on os390 smoker; may be a permissions problem"
       if $^O eq 'os390';
-    $TODO = "Not working on freebsd" if $^O eq 'freebsd';
     my $result = pingecho("127.0.0.1");
     is($result, 1, "pingecho 127.0.0.1 works");
 }

--- a/dist/Net-Ping/t/450_service.t
+++ b/dist/Net-Ping/t/450_service.t
@@ -78,7 +78,7 @@ is($p->ping("127.0.0.1"), 1, 'first port is reachable');
 $p->{port_num} = $port2;
 
 {
-    local $TODO = "Believed not to work on $^O" if $^O =~ /^(?:hpux|MSWin32|os390|freebsd)$/;
+    local $TODO = "Believed not to work on $^O" if $^O =~ /^(?:hpux|MSWin32|os390)$/;
     is($p->ping("127.0.0.1"), 1, 'second port is reachable');
 }
 
@@ -133,7 +133,7 @@ SKIP: {
 
   {
     local $TODO = "Believed not to work on $^O"
-      if $^O =~ /^(?:hpux|MSWin32|os390|freebsd)$/;
+      if $^O =~ /^(?:hpux|MSWin32|os390)$/;
     is($p->ack(), '127.0.0.1', 'IP should be reachable');
   }
 }

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -12,8 +12,8 @@ Math::Complex cpan/Math-Complex/t/Trig.t 508f8e27373c08228be13ca5d42b28812ab0e02
 Math::Complex cpan/Math-Complex/t/underbar.t 97e7b9615658eefc67a710d4b258349cc5bace63
 Net::Ping dist/Net-Ping/t/000_load.t deff5dc2ca54dae28cb19d3631427db127279ac2
 Net::Ping dist/Net-Ping/t/001_new.t 7b24e05672e22edfe3e6b5cc0277f815efe557e5
-Net::Ping dist/Net-Ping/t/010_pingecho.t 218d7a9ee5b6d03ba2544210acaf6585f8dc5503
-Net::Ping dist/Net-Ping/t/450_service.t f6578680f2872d7fc9f24dd75388d55654761875
+Net::Ping dist/Net-Ping/t/010_pingecho.t 74437379673c8ba82f81574fd7e652f41a65c993
+Net::Ping dist/Net-Ping/t/450_service.t 4963cd2240f1e583aa950f2bbe8c478ceba3b949
 Net::Ping dist/Net-Ping/t/500_ping_icmp.t 3eeb60181c01b85f876bd6658644548fdf2e24d4
 Net::Ping dist/Net-Ping/t/501_ping_icmpv6.t cd719bca662b054b676dd2ee6e0c73c7a5e50cf9
 Pod::Perldoc cpan/Pod-Perldoc/lib/Pod/Perldoc.pm 582be34c077c9ff44d99914724a0cc2140bcd48c


### PR DESCRIPTION
See Net-Ping maintainer's comment:
https://github.com/rurban/Net-Ping/pull/18#issuecomment-1234223370