### PR TITLE
Configure: remove nsl from libswanted

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -335,6 +335,7 @@ Daniel P. Berrange             <dan@berrange.com>
 Daniel Perrett                 <perrettdl@googlemail.com>
 Daniel S. Lewart               <lewart@uiuc.edu>
 Daniel Yacob                   <perl@geez.org>
+danielnachun                   <daniel.nachun@gmail.com>
 Danny R. Faught                <faught@mailhost.rsn.hp.com>
 Danny Rathjens
 Danny Sadinoff                 <danny-cpan@sadinoff.com>

--- a/Configure
+++ b/Configure
@@ -1505,7 +1505,7 @@ archname=''
 usereentrant='undef'
 : List of libraries we want.
 : If anyone needs extra -lxxx, put those in a hint file.
-libswanted="cl pthread socket bind inet nsl ndbm gdbm dbm db malloc dl ld"
+libswanted="cl pthread socket bind inet ndbm gdbm dbm db malloc dl ld"
 libswanted="$libswanted sun m crypt sec util c cposix posix ucb bsd BSD"
 : We probably want to search /usr/shlib before most other libraries.
 : This is only used by the lib/ExtUtils/MakeMaker.pm routine extliblist.


### PR DESCRIPTION
`libnsl` has been deprecated in `glibc` since at least `glibc` 2.27 and has been superseded by `libnsl2`.  In Homebrew we have been migrating packages that were previously using `libnsl` from `glibc` to `libnsl2`. In doing so we've found that while Configure checks for `libnsl`, there is no dynamic linkage we can find in any binaries to `libnsl` whether it is provided by `glibc` or `libnsl`.

It does not make sense to try to link to a library while configuring that will not actually be linked to in the final binary, which makes me think this is an oversight.  Perhaps `libnsl` was at one point linked to by an XS module that is no longer installed by default?