### PR TITLE
Start cleaning up mutexes for locale and functions that access global memory 

### DIFF
--- a/embedvar.h
+++ b/embedvar.h
@@ -170,6 +170,7 @@
 #define PL_laststatval		(vTHX->Ilaststatval)
 #define PL_laststype		(vTHX->Ilaststype)
 #define PL_lc_numeric_mutex_depth	(vTHX->Ilc_numeric_mutex_depth)
+#define PL_locale_mutex_depth	(vTHX->Ilocale_mutex_depth)
 #define PL_localizing		(vTHX->Ilocalizing)
 #define PL_localpatches		(vTHX->Ilocalpatches)
 #define PL_lockhook		(vTHX->Ilockhook)

--- a/embedvar.h
+++ b/embedvar.h
@@ -169,7 +169,6 @@
 #define PL_lastgotoprobe	(vTHX->Ilastgotoprobe)
 #define PL_laststatval		(vTHX->Ilaststatval)
 #define PL_laststype		(vTHX->Ilaststype)
-#define PL_lc_numeric_mutex_depth	(vTHX->Ilc_numeric_mutex_depth)
 #define PL_locale_mutex_depth	(vTHX->Ilocale_mutex_depth)
 #define PL_localizing		(vTHX->Ilocalizing)
 #define PL_localpatches		(vTHX->Ilocalpatches)

--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -3187,9 +3187,9 @@ mblen(s, n = ~0)
             memzero(&PL_mbrlen_ps, sizeof(PL_mbrlen_ps));
             RETVAL = 0;
 #else
-            MBLEN_LOCK;
+            MBLEN_LOCK_;
             RETVAL = mblen(NULL, 0);
-            MBLEN_UNLOCK;
+            MBLEN_UNLOCK_;
 #endif
         }
         else {  /* Not resetting state */
@@ -3209,9 +3209,9 @@ mblen(s, n = ~0)
 #else
                 /* Locking prevents races, but locales can be switched out
                  * without locking, so this isn't a cure all */
-                MBLEN_LOCK;
+                MBLEN_LOCK_;
                 RETVAL = mblen(string, len);
-                MBLEN_UNLOCK;
+                MBLEN_UNLOCK_;
 #endif
             }
         }
@@ -3278,9 +3278,9 @@ wctomb(s, wchar)
              * But probably memzero would too */
             RETVAL = wcrtomb(NULL, L'\0', &PL_wcrtomb_ps);
 #else
-            WCTOMB_LOCK;
+            WCTOMB_LOCK_;
             RETVAL = wctomb(NULL, L'\0');
-            WCTOMB_UNLOCK;
+            WCTOMB_UNLOCK_;
 #endif
         }
         else {  /* Not resetting state */
@@ -3290,9 +3290,9 @@ wctomb(s, wchar)
 #else
             /* Locking prevents races, but locales can be switched out without
              * locking, so this isn't a cure all */
-            WCTOMB_LOCK;
+            WCTOMB_LOCK_;
             RETVAL = wctomb(buffer, wchar);
-            WCTOMB_UNLOCK;
+            WCTOMB_UNLOCK_;
 #endif
             if (RETVAL >= 0) {
                 sv_setpvn_mg(s, buffer, RETVAL);

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -738,8 +738,7 @@ PERLVAR(I, constpadix,	PADOFFSET)	/* lowest unused for constants */
 
 PERLVAR(I, padix_floor,	PADOFFSET)	/* how low may inner block reset padix */
 
-#if defined(USE_POSIX_2008_LOCALE)          \
- && ! defined(USE_QUERYLOCALE)
+#ifdef USE_PL_CURLOCALES
 
 /* This is the most number of categories we've encountered so far on any
  * platform */

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -390,9 +390,6 @@ PERLVAR(I, in_utf8_turkic_locale, bool)
 #if defined(USE_LOCALE) && defined(USE_LOCALE_THREADS)
 PERLVARI(I, locale_mutex_depth, int, 0)     /* Emulate general semaphore */
 #endif
-#if defined(USE_ITHREADS) && ! defined(USE_THREAD_SAFE_LOCALE)
-PERLVARI(I, lc_numeric_mutex_depth, int, 0)   /* Emulate general semaphore */
-#endif
 
 #ifdef USE_LOCALE_CTYPE
     PERLVAR(I, warn_locale, SV *)

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -740,7 +740,7 @@ PERLVAR(I, padix_floor,	PADOFFSET)	/* how low may inner block reset padix */
 
 #if defined(USE_POSIX_2008_LOCALE)          \
  && defined(USE_THREAD_SAFE_LOCALE)         \
- && ! defined(HAS_QUERYLOCALE)
+ && ! defined(USE_QUERYLOCALE)
 
 /* This is the most number of categories we've encountered so far on any
  * platform */

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -739,7 +739,6 @@ PERLVAR(I, constpadix,	PADOFFSET)	/* lowest unused for constants */
 PERLVAR(I, padix_floor,	PADOFFSET)	/* how low may inner block reset padix */
 
 #if defined(USE_POSIX_2008_LOCALE)          \
- && defined(USE_THREAD_SAFE_LOCALE)         \
  && ! defined(USE_QUERYLOCALE)
 
 /* This is the most number of categories we've encountered so far on any

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -387,6 +387,9 @@ PERLVAR(I, utf8locale,	bool)		/* utf8 locale detected */
 PERLVAR(I, in_utf8_CTYPE_locale, bool)
 PERLVAR(I, in_utf8_COLLATE_locale, bool)
 PERLVAR(I, in_utf8_turkic_locale, bool)
+#if defined(USE_LOCALE) && defined(USE_LOCALE_THREADS)
+PERLVARI(I, locale_mutex_depth, int, 0)     /* Emulate general semaphore */
+#endif
 #if defined(USE_ITHREADS) && ! defined(USE_THREAD_SAFE_LOCALE)
 PERLVARI(I, lc_numeric_mutex_depth, int, 0)   /* Emulate general semaphore */
 #endif

--- a/locale.c
+++ b/locale.c
@@ -430,9 +430,15 @@ Perl_force_locale_unlock()
 #if defined(USE_LOCALE_THREADS)
 
     dTHX;
-#  ifdef LOCALE_UNLOCK_
-    LOCALE_UNLOCK_;
-#  endif
+
+    /* If recursively locked, clear all at once */
+    if (PL_locale_mutex_depth > 1) {
+        PL_locale_mutex_depth = 1;
+    }
+
+    if (PL_locale_mutex_depth > 0) {
+        LOCALE_UNLOCK_;
+    }
 
 #endif
 

--- a/locale.c
+++ b/locale.c
@@ -585,9 +585,7 @@ Perl_locale_panic(const char * msg,
 #  define querylocale_c(cat)    querylocale_i(cat##_INDEX_)
 #  define querylocale_r(cat)    querylocale_i(get_category_index(cat,NULL))
 
-#  ifndef USE_QUERYLOCALE
-#    define USE_PL_CURLOCALES
-#  else
+#  ifdef USE_QUERYLOCALE
 #    define isSINGLE_BIT_SET(mask) isPOWER_OF_2(mask)
 
      /* This code used to think querylocale() was valid on LC_ALL.  Make sure

--- a/locale.c
+++ b/locale.c
@@ -710,8 +710,16 @@ S_my_querylocale_i(pTHX_ const unsigned int index)
 
 #  else
 
-        /* But we do have up-to-date values when we keep our own records */
-        retval = PL_curlocales[index];
+        /* But we do have up-to-date values when we keep our own records
+         * (except some times in initialization, where we get the value from
+         * the system. */
+        if (PL_curlocales[index] == NULL) {
+            retval = stdized_setlocale(category, NULL);
+            PL_curlocales[index] = savepv(retval);
+        }
+        else {
+            retval = PL_curlocales[index];
+        }
 
 #  endif
 

--- a/locale.c
+++ b/locale.c
@@ -728,6 +728,7 @@ S_my_querylocale_i(pTHX_ const unsigned int index)
                 DEBUG_Lv(PerlIO_printf(Perl_debug_log,
                            "my_querylocale_i(%s) returning '%s'\n",
                            category_names[index], retval));
+    assert(strNE(retval, ""));
     return retval;
 }
 
@@ -2640,12 +2641,14 @@ Perl_setlocale(const int category, const char * locale)
 
     /* Here, an actual change is being requested.  Do it */
     retval = setlocale_i(cat_index, locale);
+
     if (! retval) {
         DEBUG_L(PerlIO_printf(Perl_debug_log, "%s\n",
                           setlocale_debug_string_i(cat_index, locale, "NULL")));
         return NULL;
     }
 
+    assert(strNE(retval, ""));
     retval = save_to_buffer(retval, &PL_setlocale_buf, &PL_setlocale_bufsize);
 
     /* Now that have changed locales, we have to update our records to
@@ -3836,6 +3839,7 @@ S_my_langinfo_i(pTHX_
 
     switch (item) {
       default:
+        assert(item < 0);   /* Make sure using perl_langinfo.h */
         retval = "";
         break;
 

--- a/locale.c
+++ b/locale.c
@@ -3091,12 +3091,12 @@ S_my_localeconv(pTHX_ const int item, const locale_utf8ness_t locale_is_utf8)
 
 #    endif
 
-    LOCALECONV_LOCK;
+    gwLOCALE_LOCK;
     retval = copy_localeconv(aTHX_ localeconv(),
                                    item,
                                    numeric_locale_is_utf8,
                                    monetary_locale_is_utf8);
-    LOCALECONV_UNLOCK;
+    gwLOCALE_UNLOCK;
 
 #    ifdef USE_LOCALE_NUMERIC
 
@@ -3160,12 +3160,12 @@ S_my_localeconv(pTHX_ const int item, const locale_utf8ness_t locale_is_utf8)
     void_setlocale_c(LC_ALL, save_thread);
 
     /* Safely stash the desired data */
-    LOCALECONV_LOCK;
+    gwLOCALE_LOCK;
     retval = copy_localeconv(aTHX_ localeconv(),
                                    item,
                                    numeric_locale_is_utf8,
                                    monetary_locale_is_utf8);
-    LOCALECONV_UNLOCK;
+    gwLOCALE_UNLOCK;
 
     /* Restore the global locale's prior state */
     void_setlocale_c(LC_ALL, save_global);

--- a/locale.c
+++ b/locale.c
@@ -2873,10 +2873,10 @@ Perl_mbtowc_(pTHX_ const wchar_t * pwc, const char * s, const Size_t len)
 
 #  else
 
-        MBTOWC_LOCK;
+        MBTOWC_LOCK_;
         SETERRNO(0, 0);
         retval = mbtowc(NULL, NULL, 0);
-        MBTOWC_UNLOCK;
+        MBTOWC_UNLOCK_;
         return retval;
 
 #  endif
@@ -2892,10 +2892,10 @@ Perl_mbtowc_(pTHX_ const wchar_t * pwc, const char * s, const Size_t len)
 
     /* Locking prevents races, but locales can be switched out without locking,
      * so this isn't a cure all */
-    MBTOWC_LOCK;
+    MBTOWC_LOCK_;
     SETERRNO(0, 0);
     retval = mbtowc((wchar_t *) pwc, s, len);
-    MBTOWC_UNLOCK;
+    MBTOWC_UNLOCK_;
 
 #  endif
 

--- a/locale.c
+++ b/locale.c
@@ -3804,9 +3804,9 @@ S_my_langinfo_i(pTHX_
 
     const char * orig_switched_locale = toggle_locale_i(cat_index, locale);
 
-    NL_LANGINFO_LOCK;
+    gwLOCALE_LOCK;
     retval = save_to_buffer(nl_langinfo(item), retbufp, retbuf_sizep);
-    NL_LANGINFO_UNLOCK;
+    gwLOCALE_UNLOCK;
 
     if (utf8ness) {
         *utf8ness = get_locale_string_utf8ness_i(locale, cat_index,

--- a/makedef.pl
+++ b/makedef.pl
@@ -157,6 +157,11 @@ elsif (   ($define{USE_LOCALE_THREADS} || $define{USE_THREAD_SAFE_LOCALE})
     $define{USE_POSIX_2008_LOCALE} = 1 if $define{HAS_POSIX_2008_LOCALE};
 }
 
+if (   ($define{USE_POSIX_2008_LOCALE} && ! $define{HAS_QUERYLOCALE}))
+{
+    $define{USE_PL_CURLOCALES} = 1;
+}
+
 if (   $ARGS{PLATFORM} eq 'win32'
     && $define{USE_THREAD_SAFE_LOCALE}
     && $cctype < 140)
@@ -416,7 +421,7 @@ unless ($define{USE_POSIX_2008_LOCALE})
         PL_underlying_numeric_obj
     );
 }
-unless ($define{USE_POSIX_2008_LOCALE} && ! $define{USE_QUERY_LOCALE})
+unless ($define{USE_PL_CURLOCALES})
 {
     ++$skip{$_} foreach qw(
         PL_curlocales

--- a/makedef.pl
+++ b/makedef.pl
@@ -378,6 +378,7 @@ unless ($define{'USE_ITHREADS'}) {
 		    PL_env_mutex
 		    PL_hints_mutex
 		    PL_locale_mutex
+		    PL_locale_mutex_depth
 		    PL_lc_numeric_mutex
 		    PL_lc_numeric_mutex_depth
 		    PL_my_ctx_mutex

--- a/makedef.pl
+++ b/makedef.pl
@@ -416,7 +416,7 @@ unless ($define{USE_POSIX_2008_LOCALE})
         PL_underlying_numeric_obj
     );
 }
-unless ($define{USE_POSIX_2008_LOCALE} && ! $define{HAS_QUERY_LOCALE})
+unless ($define{USE_POSIX_2008_LOCALE} && ! $define{USE_QUERY_LOCALE})
 {
     ++$skip{$_} foreach qw(
         PL_curlocales

--- a/makedef.pl
+++ b/makedef.pl
@@ -379,8 +379,6 @@ unless ($define{'USE_ITHREADS'}) {
 		    PL_hints_mutex
 		    PL_locale_mutex
 		    PL_locale_mutex_depth
-		    PL_lc_numeric_mutex
-		    PL_lc_numeric_mutex_depth
 		    PL_my_ctx_mutex
 		    PL_perlio_mutex
 		    PL_stashpad
@@ -452,11 +450,6 @@ unless ($define{'MULTIPLICITY'}) {
 		    Perl_my_cxt_init
 		    Perl_my_cxt_index
 			 );
-}
-
-if ($define{USE_THREAD_SAFE_LOCALE}) {
-    ++$skip{PL_lc_numeric_mutex};
-    ++$skip{PL_lc_numeric_mutex_depth};
 }
 
 unless ($define{'USE_DTRACE'}) {

--- a/perl.c
+++ b/perl.c
@@ -1119,9 +1119,7 @@ perl_destruct(pTHXx)
     Safefree(PL_collation_name);
     PL_collation_name = NULL;
 #endif
-#if   defined(USE_POSIX_2008_LOCALE)      \
- &&   defined(USE_THREAD_SAFE_LOCALE)     \
- && ! defined(HAS_QUERYLOCALE)
+#if defined(USE_POSIX_2008_LOCALE) && ! defined(USE_QUERYLOCALE)
     for (i = 0; i < (int) C_ARRAY_LENGTH(PL_curlocales); i++) {
         Safefree(PL_curlocales[i]);
         PL_curlocales[i] = NULL;

--- a/perl.c
+++ b/perl.c
@@ -1119,7 +1119,7 @@ perl_destruct(pTHXx)
     Safefree(PL_collation_name);
     PL_collation_name = NULL;
 #endif
-#if defined(USE_POSIX_2008_LOCALE) && ! defined(USE_QUERYLOCALE)
+#if defined(USE_PL_CURLOCALES)
     for (i = 0; i < (int) C_ARRAY_LENGTH(PL_curlocales); i++) {
         Safefree(PL_curlocales[i]);
         PL_curlocales[i] = NULL;

--- a/perl.h
+++ b/perl.h
@@ -1145,6 +1145,8 @@ violations are fatal.
 #   include <xlocale.h>
 #endif
 
+#include "perl_langinfo.h"    /* Needed for _NL_LOCALE_NAME */
+
 /* If not forbidden, we enable locale handling if either 1) the POSIX 2008
  * functions are available, or 2) just the setlocale() function.  This logic is
  * repeated in t/loc_tools.pl and makedef.pl;  The three should be kept in

--- a/perl.h
+++ b/perl.h
@@ -1343,6 +1343,10 @@ violations are fatal.
 #    endif
 #  endif
 
+#  if (defined(USE_POSIX_2008_LOCALE) && ! defined(USE_QUERYLOCALE))
+#    define USE_PL_CURLOCALES
+#  endif
+
 /*  Microsoft documentation reads in the change log for VS 2015:
  *     "The localeconv function declared in locale.h now works correctly when
  *     per-thread locale is enabled. In previous versions of the library, this

--- a/perl.h
+++ b/perl.h
@@ -7052,7 +7052,9 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
            || (defined(HAS_MBTOWC) && ! defined(HAS_MBRTOWC))               \
            || (defined(HAS_WCTOMB) && ! defined(HAS_WCRTOMB))))
 
-#  ifdef USE_POSIX_2008_LOCALE
+#  ifndef USE_POSIX_2008_LOCALE
+#    define LOCALE_TERM_POSIX_2008_  NOOP
+#  else
      /* We have a locale object holding the 'C' locale for Posix 2008 */
 #    define LOCALE_TERM_POSIX_2008_                                         \
                     STMT_START {                                            \
@@ -7064,8 +7066,6 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
                             PL_C_locale_obj = (locale_t) NULL;              \
                         }                                                   \
                     } STMT_END
-#  else
-#    define LOCALE_TERM_POSIX_2008_  NOOP
 #  endif
 
 #  define LOCALE_INIT           STMT_START {                                \

--- a/perl.h
+++ b/perl.h
@@ -7145,16 +7145,11 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #endif
 #if ! (   defined(USE_LOCALE)                                               \
        &&    defined(USE_LOCALE_THREADS)                                    \
-       && (  ! defined(USE_THREAD_SAFE_LOCALE)                              \
-           || (   defined(HAS_LOCALECONV)                                   \
-               && (  ! defined(HAS_LOCALECONV_L)                            \
-                   ||  defined(TS_W32_BROKEN_LOCALECONV)))))
+       && (  ! defined(USE_THREAD_SAFE_LOCALE)))
 
 /* The whole expression just above was complemented, so here we have no need
  * for thread synchronization, most likely it would be that this isn't a
  * threaded build. */
-#  define LOCALECONV_LOCK           NOOP
-#  define LOCALECONV_UNLOCK         NOOP
 #  define LOCALE_READ_LOCK          NOOP
 #  define LOCALE_READ_UNLOCK        NOOP
 #  define SETLOCALE_LOCK            NOOP
@@ -7190,16 +7185,6 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
     * modern platforms will have reentrant versions (which don't lock) for
     * almost all of them, so khw thinks a single mutex should suffice. */
 
-   /* We do define a different macro for each case; then if we want to have
-    * separate mutexes for some of them, the only changes needed are here.
-    * Define just the necessary macros.  The compiler should then croak if the
-    * #ifdef's in the code are incorrect */
-#  if defined(HAS_LOCALECONV) && (  ! defined(USE_POSIX_2008_LOCALE)        \
-                                 || ! defined(HAS_LOCALECONV_L)             \
-                                 ||   defined(TS_W32_BROKEN_LOCALECONV))
-#    define LOCALECONV_LOCK   LOCALE_LOCK_(0)
-#    define LOCALECONV_UNLOCK LOCALE_UNLOCK_
-#  endif
 #  if defined(USE_THREAD_SAFE_LOCALE)
 
      /* There may be instance core where we this is invoked yet should do

--- a/perl.h
+++ b/perl.h
@@ -7242,6 +7242,33 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  endif
 #endif
 
+#ifndef LOCALE_LOCK_
+#  define LOCALE_LOCK_(cond)  NOOP
+#  define LOCALE_UNLOCK_      NOOP
+#endif
+
+/* There are some locale-related functions which may need locking only because
+ * they share some common memory across threads, and hence there is the
+ * potential for a race in accessing that space.  Most are because their return
+ * points to a global static buffer, but some just use some common space
+ * internally.  All functions accessing a given space need to have a critical
+ * section to prevent any other thread from accessing it at the same time.
+ * Ideally, there would be a separate mutex for each such space, so that
+ * another thread isn't unnecessarily blocked.  But, most of them need to be
+ * locked against the locale changing while accessing that space, and it is not
+ * expected that any will be called frequently, and the locked interval should
+ * be short, and modern platforms will have reentrant versions (which don't
+ * lock) for almost all of them, so khw thinks a single mutex should suffice.
+ * Having a single mutex facilitates that, avoiding potential deadlock
+ * situations.
+ *
+ * This will be a no-op iff the perl is unthreaded. 'gw' stands for 'global
+ * write', to indicate the caller wants to be able to access memory that isn't
+ * thread specific, either to write to itself, or to prevent anyone else from
+ * writing. */
+#define gwLOCALE_LOCK    LOCALE_LOCK_(0)
+#define gwLOCALE_UNLOCK  LOCALE_UNLOCK_
+
 #ifndef LC_NUMERIC_LOCK
 #  define LC_NUMERIC_LOCK(cond)   NOOP
 #  define LC_NUMERIC_UNLOCK       NOOP

--- a/perl.h
+++ b/perl.h
@@ -7057,16 +7057,16 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  define LOCALECONV_UNLOCK         NOOP
 #  define LOCALE_READ_LOCK          NOOP
 #  define LOCALE_READ_UNLOCK        NOOP
-#  define MBLEN_LOCK                NOOP
-#  define MBLEN_UNLOCK              NOOP
-#  define MBTOWC_LOCK               NOOP
-#  define MBTOWC_UNLOCK             NOOP
+#  define MBLEN_LOCK_               NOOP
+#  define MBLEN_UNLOCK_             NOOP
+#  define MBTOWC_LOCK_              NOOP
+#  define MBTOWC_UNLOCK_            NOOP
 #  define NL_LANGINFO_LOCK          NOOP
 #  define NL_LANGINFO_UNLOCK        NOOP
 #  define SETLOCALE_LOCK            NOOP
 #  define SETLOCALE_UNLOCK          NOOP
-#  define WCTOMB_LOCK               NOOP
-#  define WCTOMB_UNLOCK             NOOP
+#  define WCTOMB_LOCK_              NOOP
+#  define WCTOMB_UNLOCK_            NOOP
 #else
 
    /* Here, we will need critical sections in locale handling, because one or
@@ -7126,16 +7126,16 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #    define NL_LANGINFO_UNLOCK LOCALE_UNLOCK_
 #  endif
 #  if defined(HAS_MBLEN) && ! defined(HAS_MBRLEN)
-#    define MBLEN_LOCK   LOCALE_LOCK_
-#    define MBLEN_UNLOCK LOCALE_UNLOCK_
+#    define MBLEN_LOCK_   LOCALE_LOCK_
+#    define MBLEN_UNLOCK_ LOCALE_UNLOCK_
 #  endif
 #  if defined(HAS_MBTOWC) && ! defined(HAS_MBRTOWC)
-#    define MBTOWC_LOCK   LOCALE_LOCK_
-#    define MBTOWC_UNLOCK LOCALE_UNLOCK_
+#    define MBTOWC_LOCK_   LOCALE_LOCK_
+#    define MBTOWC_UNLOCK_ LOCALE_UNLOCK_
 #  endif
 #  if defined(HAS_WCTOMB) && ! defined(HAS_WCRTOMB)
-#    define WCTOMB_LOCK   LOCALE_LOCK_
-#    define WCTOMB_UNLOCK LOCALE_UNLOCK_
+#    define WCTOMB_LOCK_   LOCALE_LOCK_
+#    define WCTOMB_UNLOCK_ LOCALE_UNLOCK_
 #  endif
 #  if defined(USE_THREAD_SAFE_LOCALE)
      /* On locale thread-safe systems, we don't need these workarounds */

--- a/perl.h
+++ b/perl.h
@@ -7040,17 +7040,74 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #define locale_panic_(m)  Perl_locale_panic((m), __FILE__, __LINE__, errno)
 
 /* Locale/thread synchronization macros. */
-#if   (   defined(USE_LOCALE)                                               \
-       &&    defined(USE_LOCALE_THREADS)                                    \
-       && (  ! defined(USE_THREAD_SAFE_LOCALE)                              \
-           || (   defined(HAS_LOCALECONV)                                   \
-               && (  ! defined(HAS_LOCALECONV_L)                            \
-                   ||  defined(TS_W32_BROKEN_LOCALECONV)))                  \
-           || (   defined(HAS_NL_LANGINFO)                                  \
-               && ! defined(HAS_THREAD_SAFE_NL_LANGINFO_L))                 \
-           || (defined(HAS_MBLEN)  && ! defined(HAS_MBRLEN))                \
-           || (defined(HAS_MBTOWC) && ! defined(HAS_MBRTOWC))               \
-           || (defined(HAS_WCTOMB) && ! defined(HAS_WCRTOMB))))
+#if ! defined(USE_LOCALE) || ! defined(USE_LOCALE_THREADS)
+#  define LOCALE_LOCK_(cond)  NOOP
+#  define LOCALE_UNLOCK_      NOOP
+#  define LOCALE_INIT
+#  define LOCALE_TERM
+
+#else   /* Below: Threaded, and locales are supported */
+
+    /* A locale mutex is required on all such threaded builds.
+     *
+     * This mutex simulates a general (or recursive) semaphore.  The current
+     * thread will lock the mutex if the per-thread variable is zero, and then
+     * increments that variable.  Each corresponding UNLOCK decrements the
+     * variable until it is 0, at which point it actually unlocks the mutex.
+     * Since the variable is per-thread, initialized to 0, there is no race
+     * with other threads.
+     *
+     * The single argument is a condition to test for, and if true, to panic.
+     * Call it with the constant 0 to suppress the check.
+     *
+     * Clang improperly gives warnings for this, if not silenced:
+     * https://clang.llvm.org/docs/ThreadSafetyAnalysis.html#conditional-locks
+     */
+#  define LOCALE_LOCK_(cond_to_panic_if_already_locked)                     \
+        STMT_START {                                                        \
+            CLANG_DIAG_IGNORE(-Wthread-safety)	     	                    \
+            if (LIKELY(PL_locale_mutex_depth <= 0)) {                       \
+                DEBUG_Lv(PerlIO_printf(Perl_debug_log,                      \
+                         "%s: %d: locking locale; depth=1\n",               \
+                         __FILE__, __LINE__));                              \
+                MUTEX_LOCK(&PL_locale_mutex);                               \
+                PL_locale_mutex_depth = 1;                                  \
+            }                                                               \
+            else {                                                          \
+                PL_locale_mutex_depth++;                                    \
+                DEBUG_Lv(PerlIO_printf(Perl_debug_log,                      \
+                        "%s: %d: avoided locking locale; new depth=%d\n",   \
+                        __FILE__, __LINE__, PL_locale_mutex_depth));        \
+                if (cond_to_panic_if_already_locked) {                      \
+                    locale_panic_("Trying to lock locale incompatibly: "    \
+                         STRINGIFY(cond_to_panic_if_already_locked));       \
+                }                                                           \
+            }                                                               \
+            CLANG_DIAG_RESTORE                                              \
+        } STMT_END
+
+#  define LOCALE_UNLOCK_                                                    \
+        STMT_START {                                                        \
+            if (LIKELY(PL_locale_mutex_depth == 1)) {                       \
+                DEBUG_Lv(PerlIO_printf(Perl_debug_log,                      \
+                         "%s: %d: unlocking locale; new depth=0\n",         \
+                         __FILE__, __LINE__));                              \
+                PL_locale_mutex_depth = 0;                                  \
+                MUTEX_UNLOCK(&PL_locale_mutex);                             \
+            }                                                               \
+            else if (PL_locale_mutex_depth <= 0) {                          \
+                DEBUG_L(PerlIO_printf(Perl_debug_log,                       \
+                        "%s: %d: ignored attempt to unlock already"         \
+                        " unlocked locale; depth unchanged at %d\n",        \
+                       __FILE__, __LINE__, PL_locale_mutex_depth));         \
+            }                                                               \
+            else {                                                          \
+                PL_locale_mutex_depth--;                                    \
+                DEBUG_Lv(PerlIO_printf(Perl_debug_log,                      \
+                        "%s: %d: avoided unlocking locale; new depth=%d\n", \
+                        __FILE__, __LINE__, PL_locale_mutex_depth));        \
+            }                                                               \
+        } STMT_END
 
 #  ifndef USE_POSIX_2008_LOCALE
 #    define LOCALE_TERM_POSIX_2008_  NOOP
@@ -7094,8 +7151,6 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 /* The whole expression just above was complemented, so here we have no need
  * for thread synchronization, most likely it would be that this isn't a
  * threaded build. */
-#  define LOCALE_INIT
-#  define LOCALE_TERM
 #  define LC_NUMERIC_LOCK(cond)     NOOP
 #  define LC_NUMERIC_UNLOCK         NOOP
 #  define LOCALECONV_LOCK           NOOP
@@ -7142,18 +7197,6 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
     * will be called frequently, and the locked interval should be short, and
     * modern platforms will have reentrant versions (which don't lock) for
     * almost all of them, so khw thinks a single mutex should suffice. */
-#  define LOCALE_LOCK_                                                      \
-        STMT_START {                                                        \
-            DEBUG_Lv(PerlIO_printf(Perl_debug_log,                          \
-                    "%s: %d: locking locale\n", __FILE__, __LINE__));       \
-            MUTEX_LOCK(&PL_locale_mutex);                                   \
-        } STMT_END
-#  define LOCALE_UNLOCK_                                                    \
-        STMT_START {                                                        \
-            DEBUG_Lv(PerlIO_printf(Perl_debug_log,                          \
-                   "%s: %d: unlocking locale\n", __FILE__, __LINE__));      \
-            MUTEX_UNLOCK(&PL_locale_mutex);                                 \
-        } STMT_END
 
    /* We do define a different macro for each case; then if we want to have
     * separate mutexes for some of them, the only changes needed are here.
@@ -7162,24 +7205,24 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  if defined(HAS_LOCALECONV) && (  ! defined(USE_POSIX_2008_LOCALE)        \
                                  || ! defined(HAS_LOCALECONV_L)             \
                                  ||   defined(TS_W32_BROKEN_LOCALECONV))
-#    define LOCALECONV_LOCK   LOCALE_LOCK_
+#    define LOCALECONV_LOCK   LOCALE_LOCK_(0)
 #    define LOCALECONV_UNLOCK LOCALE_UNLOCK_
 #  endif
 #  if defined(HAS_NL_LANGINFO) && (   ! defined(HAS_THREAD_SAFE_NL_LANGINFO_L) \
                                    || ! defined(USE_POSIX_2008_LOCALE))
-#    define NL_LANGINFO_LOCK   LOCALE_LOCK_
+#    define NL_LANGINFO_LOCK   LOCALE_LOCK_(0)
 #    define NL_LANGINFO_UNLOCK LOCALE_UNLOCK_
 #  endif
 #  if defined(HAS_MBLEN) && ! defined(HAS_MBRLEN)
-#    define MBLEN_LOCK_   LOCALE_LOCK_
+#    define MBLEN_LOCK_   LOCALE_LOCK_(0)
 #    define MBLEN_UNLOCK_ LOCALE_UNLOCK_
 #  endif
 #  if defined(HAS_MBTOWC) && ! defined(HAS_MBRTOWC)
-#    define MBTOWC_LOCK_   LOCALE_LOCK_
+#    define MBTOWC_LOCK_   LOCALE_LOCK_(0)
 #    define MBTOWC_UNLOCK_ LOCALE_UNLOCK_
 #  endif
 #  if defined(HAS_WCTOMB) && ! defined(HAS_WCRTOMB)
-#    define WCTOMB_LOCK_   LOCALE_LOCK_
+#    define WCTOMB_LOCK_   LOCALE_LOCK_(0)
 #    define WCTOMB_UNLOCK_ LOCALE_UNLOCK_
 #  endif
 #  if defined(USE_THREAD_SAFE_LOCALE)
@@ -7196,7 +7239,7 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #    define SETLOCALE_LOCK    NOOP
 #    define SETLOCALE_UNLOCK  NOOP
 #  else
-#    define SETLOCALE_LOCK   LOCALE_LOCK_
+#    define SETLOCALE_LOCK   LOCALE_LOCK_(0)
 #    define SETLOCALE_UNLOCK LOCALE_UNLOCK_
 
     /* On platforms without per-thread locales, when another thread can switch

--- a/perl.h
+++ b/perl.h
@@ -7109,6 +7109,18 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
             }                                                               \
         } STMT_END
 
+#  ifndef USE_THREAD_SAFE_LOCALE
+
+     /* By definition, a thread-unsafe locale means we need a critical
+      * section. */
+
+#    ifdef USE_LOCALE_NUMERIC
+#      define LC_NUMERIC_LOCK(cond_to_panic_if_already_locked)              \
+                 LOCALE_LOCK_(cond_to_panic_if_already_locked)
+#      define LC_NUMERIC_UNLOCK  LOCALE_UNLOCK_
+#    endif
+#  endif
+
 #  ifndef USE_POSIX_2008_LOCALE
 #    define LOCALE_TERM_POSIX_2008_  NOOP
 #  else
@@ -7125,14 +7137,9 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
                     } STMT_END
 #  endif
 
-#  define LOCALE_INIT           STMT_START {                                \
-                                    MUTEX_INIT(&PL_locale_mutex);           \
-                                    LOCALE_INIT_LC_NUMERIC_;                \
-                                } STMT_END
-
+#  define LOCALE_INIT           MUTEX_INIT(&PL_locale_mutex)
 #  define LOCALE_TERM           STMT_START {                                \
                                     LOCALE_TERM_POSIX_2008_;                \
-                                    LOCALE_TERM_LC_NUMERIC_;                \
                                     MUTEX_DESTROY(&PL_locale_mutex);        \
                                 } STMT_END
 #endif
@@ -7151,8 +7158,6 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 /* The whole expression just above was complemented, so here we have no need
  * for thread synchronization, most likely it would be that this isn't a
  * threaded build. */
-#  define LC_NUMERIC_LOCK(cond)     NOOP
-#  define LC_NUMERIC_UNLOCK         NOOP
 #  define LOCALECONV_LOCK           NOOP
 #  define LOCALECONV_UNLOCK         NOOP
 #  define LOCALE_READ_LOCK          NOOP
@@ -7226,13 +7231,6 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #    define WCTOMB_UNLOCK_ LOCALE_UNLOCK_
 #  endif
 #  if defined(USE_THREAD_SAFE_LOCALE)
-     /* On locale thread-safe systems, we don't need these workarounds */
-#    define LOCALE_TERM_LC_NUMERIC_   NOOP
-#    define LOCALE_INIT_LC_NUMERIC_   NOOP
-#    define LC_NUMERIC_LOCK(cond)   NOOP
-#    define LC_NUMERIC_UNLOCK       NOOP
-#    define LOCALE_INIT_LC_NUMERIC_ NOOP
-#    define LOCALE_TERM_LC_NUMERIC_ NOOP
 
      /* There may be instance core where we this is invoked yet should do
       * nothing.  Rather than have #ifdef's around them, define it here */
@@ -7241,77 +7239,12 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  else
 #    define SETLOCALE_LOCK   LOCALE_LOCK_(0)
 #    define SETLOCALE_UNLOCK LOCALE_UNLOCK_
-
-    /* On platforms without per-thread locales, when another thread can switch
-     * our locale, we need another mutex to create critical sections where we
-     * want the LC_NUMERIC locale to be locked into either the C (standard)
-     * locale, or the underlying locale, so that other threads interrupting
-     * this one don't change it to the wrong state before we've had a chance to
-     * complete our operation.  It can stay locked over an entire printf
-     * operation, for example.  And so is made distinct from the LOCALE_LOCK
-     * mutex.
-     *
-     * This simulates kind of a general semaphore.  The current thread will
-     * lock the mutex if the per-thread variable is zero, and then increments
-     * that variable.  Each corresponding UNLOCK decrements the variable until
-     * it is 0, at which point it actually unlocks the mutex.  Since the
-     * variable is per-thread, there is no race with other threads.
-     *
-     * The single argument is a condition to test for, and if true, to panic,
-     * as this would be an attempt to complement the LC_NUMERIC state, and
-     * we're not supposed to because it's locked.
-     *
-     * Clang improperly gives warnings for this, if not silenced:
-     * https://clang.llvm.org/docs/ThreadSafetyAnalysis.html#conditional-locks
-     *
-     * If LC_NUMERIC_LOCK is combined with one of the LOCKs above, calls to
-     * that and its corresponding unlock should be contained entirely within
-     * the locked portion of LC_NUMERIC.  Those mutexes should be used only in
-     * very short sections of code, while LC_NUMERIC_LOCK may span more
-     * operations.  By always following this convention, deadlock should be
-     * impossible.  But if necessary, the two mutexes could be combined. */
-#    define LC_NUMERIC_LOCK(cond_to_panic_if_already_locked)                \
-        CLANG_DIAG_IGNORE(-Wthread-safety)	     	                    \
-        STMT_START {                                                        \
-            if (PL_lc_numeric_mutex_depth <= 0) {                           \
-                MUTEX_LOCK(&PL_lc_numeric_mutex);                           \
-                PL_lc_numeric_mutex_depth = 1;                              \
-                DEBUG_Lv(PerlIO_printf(Perl_debug_log,                      \
-                         "%s: %d: locking lc_numeric; depth=1\n",           \
-                         __FILE__, __LINE__));                              \
-            }                                                               \
-            else {                                                          \
-                PL_lc_numeric_mutex_depth++;                                \
-                DEBUG_Lv(PerlIO_printf(Perl_debug_log,                      \
-                        "%s: %d: avoided lc_numeric_lock; new depth=%d\n",  \
-                        __FILE__, __LINE__, PL_lc_numeric_mutex_depth));    \
-                if (cond_to_panic_if_already_locked) {                      \
-                  locale_panic_("Trying to change LC_NUMERIC incompatibly");\
-                }                                                           \
-            }                                                               \
-        } STMT_END
-
-#    define LC_NUMERIC_UNLOCK                                               \
-        STMT_START {                                                        \
-            if (PL_lc_numeric_mutex_depth <= 1) {                           \
-                MUTEX_UNLOCK(&PL_lc_numeric_mutex);                         \
-                PL_lc_numeric_mutex_depth = 0;                              \
-                DEBUG_Lv(PerlIO_printf(Perl_debug_log,                      \
-                         "%s: %d: unlocking lc_numeric; depth=0\n",         \
-                         __FILE__, __LINE__));                              \
-            }                                                               \
-            else {                                                          \
-                PL_lc_numeric_mutex_depth--;                                \
-                DEBUG_Lv(PerlIO_printf(Perl_debug_log,                      \
-                        "%s: %d: avoided lc_numeric_unlock; new depth=%d\n",\
-                        __FILE__, __LINE__, PL_lc_numeric_mutex_depth));    \
-            }                                                               \
-        } STMT_END                                                          \
-        CLANG_DIAG_RESTORE
-
-#    define LOCALE_INIT_LC_NUMERIC_   MUTEX_INIT(&PL_lc_numeric_mutex)
-#    define LOCALE_TERM_LC_NUMERIC_   MUTEX_DESTROY(&PL_lc_numeric_mutex)
 #  endif
+#endif
+
+#ifndef LC_NUMERIC_LOCK
+#  define LC_NUMERIC_LOCK(cond)   NOOP
+#  define LC_NUMERIC_UNLOCK       NOOP
 #endif
 
 #ifdef USE_LOCALE_NUMERIC

--- a/perl.h
+++ b/perl.h
@@ -7150,10 +7150,7 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
                && (  ! defined(HAS_LOCALECONV_L)                            \
                    ||  defined(TS_W32_BROKEN_LOCALECONV)))                  \
            || (   defined(HAS_NL_LANGINFO)                                  \
-               && ! defined(HAS_THREAD_SAFE_NL_LANGINFO_L))                 \
-           || (defined(HAS_MBLEN)  && ! defined(HAS_MBRLEN))                \
-           || (defined(HAS_MBTOWC) && ! defined(HAS_MBRTOWC))               \
-           || (defined(HAS_WCTOMB) && ! defined(HAS_WCRTOMB))))
+               && ! defined(HAS_THREAD_SAFE_NL_LANGINFO_L))))
 
 /* The whole expression just above was complemented, so here we have no need
  * for thread synchronization, most likely it would be that this isn't a
@@ -7162,16 +7159,10 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  define LOCALECONV_UNLOCK         NOOP
 #  define LOCALE_READ_LOCK          NOOP
 #  define LOCALE_READ_UNLOCK        NOOP
-#  define MBLEN_LOCK_               NOOP
-#  define MBLEN_UNLOCK_             NOOP
-#  define MBTOWC_LOCK_              NOOP
-#  define MBTOWC_UNLOCK_            NOOP
 #  define NL_LANGINFO_LOCK          NOOP
 #  define NL_LANGINFO_UNLOCK        NOOP
 #  define SETLOCALE_LOCK            NOOP
 #  define SETLOCALE_UNLOCK          NOOP
-#  define WCTOMB_LOCK_              NOOP
-#  define WCTOMB_UNLOCK_            NOOP
 #else
 
    /* Here, we will need critical sections in locale handling, because one or
@@ -7218,18 +7209,6 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #    define NL_LANGINFO_LOCK   LOCALE_LOCK_(0)
 #    define NL_LANGINFO_UNLOCK LOCALE_UNLOCK_
 #  endif
-#  if defined(HAS_MBLEN) && ! defined(HAS_MBRLEN)
-#    define MBLEN_LOCK_   LOCALE_LOCK_(0)
-#    define MBLEN_UNLOCK_ LOCALE_UNLOCK_
-#  endif
-#  if defined(HAS_MBTOWC) && ! defined(HAS_MBRTOWC)
-#    define MBTOWC_LOCK_   LOCALE_LOCK_(0)
-#    define MBTOWC_UNLOCK_ LOCALE_UNLOCK_
-#  endif
-#  if defined(HAS_WCTOMB) && ! defined(HAS_WCRTOMB)
-#    define WCTOMB_LOCK_   LOCALE_LOCK_(0)
-#    define WCTOMB_UNLOCK_ LOCALE_UNLOCK_
-#  endif
 #  if defined(USE_THREAD_SAFE_LOCALE)
 
      /* There may be instance core where we this is invoked yet should do
@@ -7273,6 +7252,15 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  define LC_NUMERIC_LOCK(cond)   NOOP
 #  define LC_NUMERIC_UNLOCK       NOOP
 #endif
+
+#  define MBLEN_LOCK_                gwLOCALE_LOCK
+#  define MBLEN_UNLOCK_              gwLOCALE_UNLOCK
+
+#  define MBTOWC_LOCK_               gwLOCALE_LOCK
+#  define MBTOWC_UNLOCK_             gwLOCALE_UNLOCK
+
+#  define WCTOMB_LOCK_               gwLOCALE_LOCK
+#  define WCTOMB_UNLOCK_             gwLOCALE_UNLOCK
 
 #ifdef USE_LOCALE_NUMERIC
 

--- a/perl.h
+++ b/perl.h
@@ -7148,9 +7148,7 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
        && (  ! defined(USE_THREAD_SAFE_LOCALE)                              \
            || (   defined(HAS_LOCALECONV)                                   \
                && (  ! defined(HAS_LOCALECONV_L)                            \
-                   ||  defined(TS_W32_BROKEN_LOCALECONV)))                  \
-           || (   defined(HAS_NL_LANGINFO)                                  \
-               && ! defined(HAS_THREAD_SAFE_NL_LANGINFO_L))))
+                   ||  defined(TS_W32_BROKEN_LOCALECONV)))))
 
 /* The whole expression just above was complemented, so here we have no need
  * for thread synchronization, most likely it would be that this isn't a
@@ -7159,8 +7157,6 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  define LOCALECONV_UNLOCK         NOOP
 #  define LOCALE_READ_LOCK          NOOP
 #  define LOCALE_READ_UNLOCK        NOOP
-#  define NL_LANGINFO_LOCK          NOOP
-#  define NL_LANGINFO_UNLOCK        NOOP
 #  define SETLOCALE_LOCK            NOOP
 #  define SETLOCALE_UNLOCK          NOOP
 #else
@@ -7203,11 +7199,6 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
                                  ||   defined(TS_W32_BROKEN_LOCALECONV))
 #    define LOCALECONV_LOCK   LOCALE_LOCK_(0)
 #    define LOCALECONV_UNLOCK LOCALE_UNLOCK_
-#  endif
-#  if defined(HAS_NL_LANGINFO) && (   ! defined(HAS_THREAD_SAFE_NL_LANGINFO_L) \
-                                   || ! defined(USE_POSIX_2008_LOCALE))
-#    define NL_LANGINFO_LOCK   LOCALE_LOCK_(0)
-#    define NL_LANGINFO_UNLOCK LOCALE_UNLOCK_
 #  endif
 #  if defined(USE_THREAD_SAFE_LOCALE)
 

--- a/perl.h
+++ b/perl.h
@@ -7040,6 +7040,45 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #define locale_panic_(m)  Perl_locale_panic((m), __FILE__, __LINE__, errno)
 
 /* Locale/thread synchronization macros. */
+#if   (   defined(USE_LOCALE)                                               \
+       &&    defined(USE_LOCALE_THREADS)                                    \
+       && (  ! defined(USE_THREAD_SAFE_LOCALE)                              \
+           || (   defined(HAS_LOCALECONV)                                   \
+               && (  ! defined(HAS_LOCALECONV_L)                            \
+                   ||  defined(TS_W32_BROKEN_LOCALECONV)))                  \
+           || (   defined(HAS_NL_LANGINFO)                                  \
+               && ! defined(HAS_THREAD_SAFE_NL_LANGINFO_L))                 \
+           || (defined(HAS_MBLEN)  && ! defined(HAS_MBRLEN))                \
+           || (defined(HAS_MBTOWC) && ! defined(HAS_MBRTOWC))               \
+           || (defined(HAS_WCTOMB) && ! defined(HAS_WCRTOMB))))
+
+#  ifdef USE_POSIX_2008_LOCALE
+     /* We have a locale object holding the 'C' locale for Posix 2008 */
+#    define LOCALE_TERM_POSIX_2008_                                         \
+                    STMT_START {                                            \
+                        if (PL_C_locale_obj) {                              \
+                            /* Make sure we aren't using the locale         \
+                             * space we are about to free */                \
+                            uselocale(LC_GLOBAL_LOCALE);                    \
+                            freelocale(PL_C_locale_obj);                    \
+                            PL_C_locale_obj = (locale_t) NULL;              \
+                        }                                                   \
+                    } STMT_END
+#  else
+#    define LOCALE_TERM_POSIX_2008_  NOOP
+#  endif
+
+#  define LOCALE_INIT           STMT_START {                                \
+                                    MUTEX_INIT(&PL_locale_mutex);           \
+                                    LOCALE_INIT_LC_NUMERIC_;                \
+                                } STMT_END
+
+#  define LOCALE_TERM           STMT_START {                                \
+                                    LOCALE_TERM_POSIX_2008_;                \
+                                    LOCALE_TERM_LC_NUMERIC_;                \
+                                    MUTEX_DESTROY(&PL_locale_mutex);        \
+                                } STMT_END
+#endif
 #if ! (   defined(USE_LOCALE)                                               \
        &&    defined(USE_LOCALE_THREADS)                                    \
        && (  ! defined(USE_THREAD_SAFE_LOCALE)                              \
@@ -7230,33 +7269,6 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #    define LOCALE_INIT_LC_NUMERIC_   MUTEX_INIT(&PL_lc_numeric_mutex)
 #    define LOCALE_TERM_LC_NUMERIC_   MUTEX_DESTROY(&PL_lc_numeric_mutex)
 #  endif
-
-#  ifdef USE_POSIX_2008_LOCALE
-     /* We have a locale object holding the 'C' locale for Posix 2008 */
-#    define LOCALE_TERM_POSIX_2008_                                         \
-                    STMT_START {                                            \
-                        if (PL_C_locale_obj) {                              \
-                            /* Make sure we aren't using the locale         \
-                             * space we are about to free */                \
-                            uselocale(LC_GLOBAL_LOCALE);                    \
-                            freelocale(PL_C_locale_obj);                    \
-                            PL_C_locale_obj = (locale_t) NULL;              \
-                        }                                                   \
-                    } STMT_END
-#  else
-#    define LOCALE_TERM_POSIX_2008_  NOOP
-#  endif
-
-#  define LOCALE_INIT           STMT_START {                                \
-                                    MUTEX_INIT(&PL_locale_mutex);           \
-                                    LOCALE_INIT_LC_NUMERIC_;                \
-                                } STMT_END
-
-#  define LOCALE_TERM           STMT_START {                                \
-                                    LOCALE_TERM_POSIX_2008_;                \
-                                    LOCALE_TERM_LC_NUMERIC_;                \
-                                    MUTEX_DESTROY(&PL_locale_mutex);        \
-                                } STMT_END
 #endif
 
 #ifdef USE_LOCALE_NUMERIC

--- a/perlvars.h
+++ b/perlvars.h
@@ -102,9 +102,6 @@ PERLVARI(G, mmap_page_size, IV, 0)
 PERLVAR(G, hints_mutex, perl_mutex)    /* Mutex for refcounted he refcounting */
 PERLVAR(G, env_mutex, perl_RnW1_mutex_t)      /* Mutex for accessing ENV */
 PERLVAR(G, locale_mutex, perl_mutex)   /* Mutex related to locale handling */
-#  ifndef USE_THREAD_SAFE_LOCALE
-PERLVAR(G, lc_numeric_mutex, perl_mutex)   /* Mutex for switching LC_NUMERIC */
-#  endif
 #endif
 
 #ifdef USE_POSIX_2008_LOCALE

--- a/sv.c
+++ b/sv.c
@@ -15905,9 +15905,7 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
 
     PL_subname		= sv_dup_inc(proto_perl->Isubname, param);
 
-#if   defined(USE_POSIX_2008_LOCALE)      \
- &&   defined(USE_THREAD_SAFE_LOCALE)     \
- && ! defined(HAS_QUERYLOCALE)
+#if defined(USE_POSIX_2008_LOCALE) && ! defined(USE_QUERYLOCALE)
     for (i = 0; i < (int) C_ARRAY_LENGTH(PL_curlocales); i++) {
         PL_curlocales[i] = SAVEPV(proto_perl->Icurlocales[i]);
     }

--- a/sv.c
+++ b/sv.c
@@ -15905,7 +15905,7 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
 
     PL_subname		= sv_dup_inc(proto_perl->Isubname, param);
 
-#if defined(USE_POSIX_2008_LOCALE) && ! defined(USE_QUERYLOCALE)
+#ifdef USE_PL_CURLOCALES
     for (i = 0; i < (int) C_ARRAY_LENGTH(PL_curlocales); i++) {
         PL_curlocales[i] = SAVEPV(proto_perl->Icurlocales[i]);
     }

--- a/sv.c
+++ b/sv.c
@@ -15600,6 +15600,11 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
 
     /* Did the locale setup indicate UTF-8? */
     PL_utf8locale	= proto_perl->Iutf8locale;
+
+#ifdef USE_LOCALE_THREADS
+    assert(PL_locale_mutex_depth <= 0);
+    PL_locale_mutex_depth = 0;
+#endif
 #if defined(USE_ITHREADS) && ! defined(USE_THREAD_SAFE_LOCALE)
     PL_lc_numeric_mutex_depth = 0;
 #endif

--- a/sv.c
+++ b/sv.c
@@ -15605,9 +15605,6 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
     assert(PL_locale_mutex_depth <= 0);
     PL_locale_mutex_depth = 0;
 #endif
-#if defined(USE_ITHREADS) && ! defined(USE_THREAD_SAFE_LOCALE)
-    PL_lc_numeric_mutex_depth = 0;
-#endif
     /* Unicode features (see perlrun/-C) */
     PL_unicode		= proto_perl->Iunicode;
 


### PR DESCRIPTION
This series of commit first cleans up some locale initialization gotchas, and adds asserts.

And it cleans up where a few locale-related definitions are done

It converts the locale mutex to a general semaphore from a binary one, which allows for simplification in switching the LC_NUMERIC locale.

And certain mutex macros now use the newly-general one