### PR TITLE
io/socket.t: Use SO_SNDBUF instead of SO_RCVBUF

### DIFF
--- a/t/io/socket.t
+++ b/t/io/socket.t
@@ -349,36 +349,36 @@ SKIP: {
 SKIP: {
     eval { Socket::IPPROTO_TCP(); 1 } or skip 'no IPPROTO_TCP', 1;
     eval { Socket::SOL_SOCKET(); 1 } or skip 'no SOL_SOCKET', 1;
-    eval { Socket::SO_RCVBUF(); 1 } or skip 'no SO_RCVBUF', 1;
+    eval { Socket::SO_SNDBUF(); 1 } or skip 'no SO_SNDBUF', 1;
 
-    # The value of RCVBUF_SIZE constant below is changed from #19892 testcase;
+    # The value of SNDBUF_SIZE constant below is changed from #19892 testcase;
     # original "262144" may be clamped on low-memory systems.
     fresh_perl_is(<<'EOP', "Ok.\n", {}, 'setsockopt works for a constant that is once stringified');
 use warnings;
 use strict;
 
-use Socket qw'PF_INET SOCK_STREAM IPPROTO_TCP SOL_SOCKET SO_RCVBUF';
+use Socket qw'PF_INET SOCK_STREAM IPPROTO_TCP SOL_SOCKET SO_SNDBUF';
 
-use constant { RCVBUF_SIZE => 32768 };
+use constant { SNDBUF_SIZE => 32768 };
 
 socket(my $sock, PF_INET, SOCK_STREAM, IPPROTO_TCP)
   or die "Could not create socket - $!\n";
 
-setsockopt($sock,SOL_SOCKET,SO_RCVBUF,RCVBUF_SIZE)
-  or die "Could not set SO_RCVBUF on socket - $!\n";
+setsockopt($sock,SOL_SOCKET,SO_SNDBUF,SNDBUF_SIZE)
+  or die "Could not set SO_SNDBUF on socket - $!\n";
 
-my $rcvBuf=getsockopt($sock,SOL_SOCKET,SO_RCVBUF)
-  or die "Could not get SO_RCVBUF on socket - $!\n";
+my $sndBuf=getsockopt($sock,SOL_SOCKET,SO_SNDBUF)
+  or die "Could not get SO_SNDBUF on socket - $!\n";
 
-$rcvBuf=unpack('i',$rcvBuf);
+$sndBuf=unpack('i',$sndBuf);
 
-die "Unexpected SO_RCVBUF value: $rcvBuf\n"
-  unless($rcvBuf == RCVBUF_SIZE || $rcvBuf == 2*RCVBUF_SIZE);
+die "Unexpected SO_SNDBUF value: $sndBuf\n"
+  unless($sndBuf == SNDBUF_SIZE || $sndBuf == 2*SNDBUF_SIZE);
 
 print "Ok.\n";
 exit;
 
-sub bug {RCVBUF_SIZE.''}
+sub bug {SNDBUF_SIZE.''}
 EOP
 }
 


### PR DESCRIPTION
The test was checking the return value of `getsockopt(..., SO_RCVBUF)`
after setting it with `setsockopt(..., SO_RCVBUF, $i)`.

The values the test accepted:
- '$i'
- '2 * $i'

The '2 * $i' is because Linux doubles the size of the buffer.[^1]

On OmniOS(/SmartOS/Solaris?) it also treats the SO_RCVBUF special..
Apparently:
- when using g++: it returns '$i'
- when using gcc: the value depends on the 'tcp_mss_def_ipv4' setting.[^2].
  By default this is 536 so the value it returns is: '536 * ceil($i / 536)'
  (with a minimum of 'tcp_recv_hiwat_minmss' (=4) * 'tcp_mss_def_ipv4' (=536)

It doesn't seem to do anything special for `SO_SNDBUF` so let's use that
in the test instead.

(Tested on: Linux (gcc), Windows 10 (gcc), OmniOS (gcc,g++), FreeBSD (gcc).)

Fixes #20188

[^1]: https://www.cs.helsinki.fi/linux/linux-kernel/2001-30/0880.html
[^2]: https://github.com/TritonDataCenter/illumos-joyent/blob/master/usr/src/stand/lib/tcp/tcp.c#L7034
    ```
        case SOL_SOCKET: {
            switch (option) {
                case SO_RCVBUF:
                    ...
                    val = MSS_ROUNDUP(val, tcp->tcp_mss);
    ```
    (with thanks to @wolfsage for that link)