### PR TITLE
Add a .github/README.md

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,128 @@
+```
+Perl is Copyright (C) 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2000,
+2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012,
+2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
+by Larry Wall and others.
+All rights reserved.
+```
+
+# ABOUT PERL
+
+Perl is a general-purpose programming language originally developed for
+text manipulation and now used for a wide range of tasks including
+system administration, web development, network programming, GUI
+development, and more.
+
+The language is intended to be practical (easy to use, efficient,
+complete) rather than beautiful (tiny, elegant, minimal).  Its major
+features are that it's easy to use, supports both procedural and
+object-oriented (OO) programming, has powerful built-in support for text
+processing, and has one of the world's most impressive collections of
+third-party modules.
+
+For an introduction to the language's features, see pod/perlintro.pod.
+
+For a discussion of the important changes in this release, see
+pod/perldelta.pod.
+
+There are also many Perl books available, covering a wide variety of topics,
+from various publishers.  See pod/perlbook.pod for more information.
+
+
+# INSTALLATION
+
+If you're using a relatively modern operating system and want to
+install this version of Perl locally, run the following commands:
+
+    ./Configure -des -Dprefix=$HOME/localperl
+    make test
+    make install
+
+This will configure and compile perl for your platform, run the regression
+tests, and install perl in a subdirectory "localperl" of your home directory.
+
+If you run into any trouble whatsoever or you need to install a customized
+version of Perl, you should read the detailed instructions in the "INSTALL"
+file that came with this distribution.  Additionally, there are a number of
+"README" files with hints and tips about building and using Perl on a wide
+variety of platforms, some more common than others.
+
+Once you have Perl installed, a wealth of documentation is available to you
+through the 'perldoc' tool.  To get started, run this command:
+
+    perldoc perl
+
+
+# IF YOU RUN INTO TROUBLE
+
+Perl is a large and complex system that's used for everything from
+knitting to rocket science.  If you run into trouble, it's quite
+likely that someone else has already solved the problem you're
+facing. Once you've exhausted the documentation, please report bugs to us
+at the GitHub issue tracker at https://github.com/Perl/perl5/issues
+
+While it was current when we made it available, Perl is constantly evolving
+and there may be a more recent version that fixes bugs you've run into or
+adds new features that you might find useful.
+
+You can always find the latest version of perl on a CPAN (Comprehensive Perl
+Archive Network) site near you at https://www.cpan.org/src/
+
+If you want to submit a simple patch to the perl source, see the "SUPER
+QUICK PATCH GUIDE" in pod/perlhack.pod.
+
+Just a personal note:  I want you to know that I create nice things like this
+because it pleases the Author of my story.  If this bothers you, then your
+notion of Authorship needs some revision.  But you can use perl anyway. :-)
+
+The author.
+
+
+# LICENSING
+
+```
+This program is free software; you can redistribute it and/or modify
+it under the terms of either:
+
+	a) the GNU General Public License as published by the Free
+	Software Foundation; either version 1, or (at your option) any
+	later version, or
+
+	b) the "Artistic License" which comes with this Kit.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See either
+the GNU General Public License or the Artistic License for more details.
+
+You should have received a copy of the Artistic License with this
+Kit, in the file named "Artistic".  If not, I'll be glad to provide one.
+
+You should also have received a copy of the GNU General Public License
+along with this program in the file named "Copying". If not, write to the
+Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+Boston, MA 02110-1301, USA or visit their web page on the internet at
+https://www.gnu.org/copyleft/gpl.html.
+
+For those of you that choose to use the GNU General Public License,
+my interpretation of the GNU General Public License is that no Perl
+script falls under the terms of the GPL unless you explicitly put
+said script under the terms of the GPL yourself.  Furthermore, any
+object code linked with perl does not automatically fall under the
+terms of the GPL, provided such object code only adds definitions
+of subroutines and variables, and does not otherwise impair the
+resulting interpreter from executing any standard Perl script.  I
+consider linking in C subroutines in this manner to be the moral
+equivalent of defining subroutines in the Perl language itself.  You
+may sell such an object file as proprietary provided that you provide
+or offer to provide the Perl source, as specified by the GNU General
+Public License.  (This is merely an alternate way of specifying input
+to the program.)  You may also sell a binary produced by the dumping of
+a running Perl script that belongs to you, provided that you provide or
+offer to provide the Perl source as specified by the GPL.  (The
+fact that a Perl interpreter and your code are in the same binary file
+is, in this case, a form of mere aggregation.)  This is my interpretation
+of the GPL.  If you still have concerns or difficulties understanding
+my intent, feel free to contact me.  Of course, the Artistic License
+spells all this out for your protection, so you may prefer to use that.
+```

--- a/t/porting/copyright.t
+++ b/t/porting/copyright.t
@@ -30,6 +30,12 @@ my ($opt) = @ARGV;
 
 my $readme_year = readme_year();
 my $v_year = v_year();
+my $gh_readme_year;
+if (-e "../.github/README.md")
+{
+  $gh_readme_year = readme_year(".github/README.md");
+}
+
 
 # Check that both copyright dates are up-to-date, but only if requested, so
 # that tests still pass for people intentionally working on older versions:
@@ -38,12 +44,22 @@ if ($opt eq '--now')
   my $current_year = (gmtime)[5] + 1900;
   is $v_year, $current_year, 'perl -v copyright includes current year';
   is $readme_year, $current_year, 'README copyright includes current year';
+  if ($gh_readme_year)
+  {
+    is ($gh_readme_year, $current_year,
+        '.github/README.md copyright includes current year');
+  }
 }
 
 # Otherwise simply check that the two copyright dates match each other:
 else
 {
   is $readme_year, $v_year, 'README and perl -v copyright dates match';
+  if ($gh_readme_year)
+  {
+    is ($gh_readme_year, $v_year,
+        '.github/README.md and perl -v copyright dates match');
+  }
 }
 
 done_testing;
@@ -52,15 +68,16 @@ done_testing;
 sub readme_year
 # returns the latest copyright year from the top-level README file
 {
+  my $file = shift || "README";
 
-  open my $readme, '<', '../README' or die "Opening README failed: $!";
+  open my $readme, '<', "../$file" or die "Opening $file failed: $!";
 
   # The copyright message is the first paragraph:
   local $/ = '';
   my $copyright_msg = <$readme>;
 
   my ($year) = $copyright_msg =~ /.*\b(\d{4,})/s
-      or die "Year not found in README copyright message '$copyright_msg'";
+      or die "Year not found in $file copyright message '$copyright_msg'";
 
   $year;
 }


### PR DESCRIPTION
This is based on the existing README and is an almost exact copy.
Some minor formatting changes to improve the rendering but the text
remains the same.

t/porting/copyright.t was also adjusted to check the copyright in
.github/README.md

Note: this can be considered a (very) minor first step in adding a more
      informative README for Github. This first step is needed because
      not having a formatted README is blocking some other changes (rendering
      the platform specific READMEs as POD in GitHub).