### PR TITLE
DRAFT: Revert "op.c - work around Module::Install::DSL issue"

### DIFF
--- a/op.c
+++ b/op.c
@@ -10965,19 +10965,16 @@ S_process_special_blocks(pTHX_ I32 floor, const char *const fullname,
 {
     const char *const colon = strrchr(fullname,':');
     const char *const name = colon ? colon + 1 : fullname;
-    int is_module_install_hack = 0;
 
     PERL_ARGS_ASSERT_PROCESS_SPECIAL_BLOCKS;
 
     if (*name == 'B') {
-        module_install_hack:
-        if (strEQ(name, "BEGIN") || is_module_install_hack) {
+        if (strEQ(name, "BEGIN")) {
             const I32 oldscope = PL_scopestack_ix;
             SV *max_nest_sv = NULL;
             IV max_nest_iv;
             dSP;
             (void)CvGV(cv);
-            is_module_install_hack = 0;
             if (floor) LEAVE_SCOPE(floor);
             ENTER;
 
@@ -11106,30 +11103,6 @@ S_process_special_blocks(pTHX_ I32 floor, const char *const fullname,
                 return FALSE;
         } else if (*name == 'I') {
             if (strEQ(name, "INIT")) {
-#ifdef MI_INIT_WORKAROUND_PACK
-                {
-                    HV *hv= CvSTASH(cv);
-                    STRLEN len = hv ? HvNAMELEN(hv) : 0;
-                    char *pv= (len == sizeof(MI_INIT_WORKAROUND_PACK)-1)
-                            ? HvNAME_get(hv) : NULL;
-                    if ( pv && strEQ(pv,MI_INIT_WORKAROUND_PACK) )
-                    {
-                        /* old versions of Module::Install::DSL contain code
-                         * that creates an INIT in eval, which expect to run
-                         * after an exit(0) in BEGIN. This unfortunately
-                         * breaks a lot of code in the CPAN river. So we magically
-                         * convert INIT blocks from Module::Install::DSL to
-                         * be BEGIN blocks. Which works out, since the INIT
-                         * blocks it creates are eval'ed so are late.
-                         */
-                        Perl_warn(aTHX_ "Treating %s::INIT block as BEGIN block as workaround",
-                                MI_INIT_WORKAROUND_PACK);
-                        is_module_install_hack = 1;
-                        goto module_install_hack;
-                    }
-
-                }
-#endif
                 if (PL_main_start)
                     /* diag_listed_as: Too late to run %s block */
                     Perl_ck_warner(aTHX_ packWARN(WARN_VOID),

--- a/op.h
+++ b/op.h
@@ -1170,7 +1170,6 @@ struct op_argcheck_aux {
     char slurpy;     /* presence of slurpy: may be '\0', '@' or '%' */
 };
 
-#define MI_INIT_WORKAROUND_PACK "Module::Install::DSL"
 
 
 /*

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -6453,15 +6453,6 @@ C<$tr> or C<$y> may cause this error.
 (F) The lexer couldn't find the final delimiter of a tr///, tr[][],
 y/// or y[][] construct.
 
-=item Treating %s::INIT block as BEGIN block as workaround
-
-(S) A package is using an old version of C<Module::Install::DSL> to
-install, which makes unsafe assumptions about when INIT blocks will be
-called. Because C<Module::Install::DSL> is used to install other modules
-and is difficult to upgrade we have a special workaround in place to
-deal with this. Unless you are a maintainer of an affected module you
-can ignore this warning. We emit it only as a sanity check.
-
 =item '%s' trapped by operation mask
 
 (F) You tried to use an operator from a Safe compartment in which it's

--- a/t/op/blocks.t
+++ b/t/op/blocks.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan tests => 26;
+plan tests => 25;
 
 my @expect = qw(
 b1
@@ -288,7 +288,3 @@ TODO: {
 
 fresh_perl_is('eval "BEGIN {goto end}"; end:', '', {}, 'RT #113934: goto out of BEGIN causes assertion failure');
 
-fresh_perl_is('package Module::Install::DSL; BEGIN { eval "INIT { print q(INIT fired in eval) }" }',
-    "Treating Module::Install::DSL::INIT block as BEGIN block as workaround at (eval 1) line 1.\n"
-    ."INIT fired in eval", {},
-   'GH Issue #16300: Module::Install::DSL workaround');


### PR DESCRIPTION
This reverts commit 451a9a1260f66bc37e4e7187d4368bca92540a8e which added a workaround for `Module::Install::DSL`.

When we no longer need the Module::Install::DSL workaround we should merge this P and resolve Issue #20233.

