### PR TITLE
perlfilter.pod: Retain entry in customized database

### DIFF
--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -10,11 +10,6 @@ Math::Complex cpan/Math-Complex/lib/Math/Complex.pm 66f28a17647e2de166909ca66e4c
 Math::Complex cpan/Math-Complex/t/Complex.t 17039e03ee798539e770ea9a0d19a99364278306
 Math::Complex cpan/Math-Complex/t/Trig.t 508f8e27373c08228be13ca5d42b28812ab0e020
 Math::Complex cpan/Math-Complex/t/underbar.t 97e7b9615658eefc67a710d4b258349cc5bace63
-Memoize cpan/Memoize/Memoize.pm 902092ff91cdec9c7b4bd06202eb179e1ce26ca2
-Memoize cpan/Memoize/t/errors.t bcd0c02a4bc47dfda07a97d265d7210849871659
-Memoize cpan/Memoize/t/expmod_t.t a1c3d03fd3ec2e7c6c835f02316475756e1b16b7
-Memoize cpan/Memoize/t/speed.t 89fe8c8928f0164c9ed898b5a427dbbc814e9976
-Memoize cpan/Memoize/t/tie_gdbm.t d81c4f6208f6c925539b3878bff9a8ff1b73a37e
 Net::Ping dist/Net-Ping/t/000_load.t deff5dc2ca54dae28cb19d3631427db127279ac2
 Net::Ping dist/Net-Ping/t/001_new.t 7b24e05672e22edfe3e6b5cc0277f815efe557e5
 Net::Ping dist/Net-Ping/t/010_pingecho.t 218d7a9ee5b6d03ba2544210acaf6585f8dc5503

--- a/t/porting/customized.t
+++ b/t/porting/customized.t
@@ -28,9 +28,12 @@ sub filter_customized {
     return @files
         unless my $customized = $Modules{$m}{CUSTOMIZED};
 
-    my ($pat) = map { qr/$_/ } join '|' => map {
-        ref $_ ? $_ : qr/\b\Q$_\E$/
-    } @{ $customized };
+    my ($pat) = map { qr/$_/ }
+        join ( '|' =>
+            map { ref $_ ? $_ : qr/\b\Q$_\E$/ } @{ $customized },
+            # https://github.com/Perl/perl5/issues/20228
+            qr/pod\/perlfilter\.pod/
+        );
 
     return grep { $_ =~ $pat } @files;
 }


### PR DESCRIPTION
`pod/perlfilter.pod` is (for historical reasons, apparently) maintained
upstream on CPAN as part of the Filter distribution.  As such, (i) it
should, generally speaking, only be edited upstream and synched into
core; (ii) needs to be referenced in several places in the
`Filter::Util::Call` element in `%Maintainers::Modules`
(`Porting/Maintainers.pl`); (iii) needs to have an entry in
`t/porting/customized.dat` (the "customized database") to protect it from
being "overwritten" or accidentally removed.

For all of the above conditions to work together, the
`filter_customized()` subroutine in `t/porting/customized.t` needs to be
able to construct a regex which recognizes `pod/perlfilter.pod`'s
weirdness.  Prior to this patch it was failing to do so.  Thus when
`pod/perlfilter.pod` was accidentally edited in commit d84bd0bd47, the
need to regenerate the customized database was not recognized.  Later,
review of a different pull request which required regeneration of the
customized database spotted the unintentional deletion of the entry for
`pod/perlfilter.pod` from `t/porting/customized.dat`.

Addressing this problem is inevitably going to be kludgy, but it will be
less kludgy if done in `t/porting/customized.t` than in
`Porting/Maintainers.pl`.  This patch modifies the former file to
guarantee that the string 'pod/perlfilter.pod' is matched.  After that
modification, `cd t; ./perl -I../lib porting/customized.t --regen; cd -`
was run.  This accomplished the (previously overlooked) removal of
certain entries for `Memoize` in the customized database while leaving the
entry for `pod/perlfilter.pod` in that database intact.

If at some point in the future we decide that `pod/perlfilter.pod` should
be maintained directly in core, we can remove this kludge and simplify
the `Filter::Util::Call` element in `%Maintainers::Modules` in
`Porting/Maintainers.pl`.

For: https://github.com/Perl/perl5/issues/20228.

Should (partially) unblock https://github.com/Perl/perl5/pull/20216.