### PR TITLE
Syntax highlighting for README.* files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,4 @@ warnings.h linguist-generated
 *.pl linguist-language=Perl
 *.pm linguist-language=Perl
 *.t linguist-language=Perl
+README.* linguist-language=Pod


### PR DESCRIPTION
Make known to GitHub Linguist for syntax highlighting and counting as well.

The README files are platform-specific documentation in POD that are published as `perl<PLATFORM>` eg. [perlaix](https://perldoc.perl.org/perlaix)