### PR TITLE
todo.pod: Remove version number from todo item

### DIFF
--- a/Porting/todo.pod
+++ b/Porting/todo.pod
@@ -486,7 +486,7 @@ Natively 64-bit systems need neither -Duse64bitint nor -Duse64bitall.
 On these systems, it might be the default compilation mode, and there
 is currently no guarantee that passing no use64bitall option to the
 Configure process will build a 32bit perl. Implementing -Duse32bit*
-options would be nice for perl 5.37.4.
+options would be nice for a future version.
 
 =head2 Profile Perl - am I hot or not?
 


### PR DESCRIPTION
Porting/todo.pod contains one todo item that mentions a version number.
That particular version number has already been bumped 90 times on blead...

I think it's time to stop bumping it and replace it with a generic text.
(It started as v5.14.0, then got bumped to v5.18.0 and then got bumped
 with every release...)