### PR TITLE
Add note in RMG about using your own fork

### DIFF
--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -67,6 +67,14 @@ of these release types.  If a step does not apply to a given
 type of release, you will see a notation to that effect at
 the beginning of the step.
 
+This guide assumes you are working on the Perl master repository (i.e.
+L<https://github.com/Perl/perl5>) and B<not> on your own fork of the perl5
+repository. While it is possible to prepare a release on your own fork
+this guide is not written with that in mind and as a result several
+key steps are missing. If you do use your own fork then extra care
+needs to be taken when setting/pushing the tag and doing the merge
+(do B<not> use a PR).
+
 =head2 Release types
 
 =over 4


### PR DESCRIPTION
Add a small section in the release manager guide about using your own
fork of the perl5 repo when making the release. The current guide is
not written with that in mind and as a result is missing some steps.

Some context: when @neilb created the 5.37.3 release he used his own fork and then ran into several issues.
While it is possible to amend the RMG to cover the use-your-own-fork use case I opted not to do that (at least for now).
(If you know what you're doing then using your own fork shouldn't be a big problem)

I'm also not sure if 'Details' is the best section to put that note in (feel free to recommend a better place.)
