### PR TITLE
locale.c: Silence some compiler warnings

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3314,8 +3314,8 @@ SG   |bool   |sv_derived_from_svpvn  |NULLOK SV *sv			\
 #endif
 
 #if defined(PERL_IN_LOCALE_C)
-iR	|const char *|mortalized_pv_copy|NULLOK const char * const pv
 #  ifdef USE_LOCALE
+iR	|const char *|mortalized_pv_copy|NULLOK const char * const pv
 ST	|const char *|save_to_buffer|NULLOK const char * string	\
 				    |NULLOK const char **buf	\
 				    |NULLOK Size_t *buf_size

--- a/embed.fnc
+++ b/embed.fnc
@@ -3320,14 +3320,16 @@ ST	|const char *|save_to_buffer|NULLOK const char * string	\
 				    |NULLOK const char **buf	\
 				    |NULLOK Size_t *buf_size
 ST	|unsigned int|get_category_index|const int category|NULLOK const char * locale
-ST	|bool	    |is_codeset_name_UTF8|NN const char * name
 S	|utf8ness_t|get_locale_string_utf8ness_i				\
 				|NULLOK const char * locale		\
 				|const unsigned cat_index		\
 				|NULLOK const char * string		\
 				|const locale_utf8ness_t known_utf8
 S	|void	|new_collate	|NN const char* newcoll
+#    ifdef USE_LOCALE_CTYPE
 S	|void	|new_ctype	|NN const char* newctype
+ST	|bool	|is_codeset_name_UTF8|NN const char * name
+#    endif
 #    ifdef USE_LOCALE_NUMERIC
 S	|void	|new_numeric	|NN const char* newnum
 #    endif

--- a/embed.fnc
+++ b/embed.fnc
@@ -3325,7 +3325,6 @@ S	|utf8ness_t|get_locale_string_utf8ness_i				\
 				|const unsigned cat_index		\
 				|NULLOK const char * string		\
 				|const locale_utf8ness_t known_utf8
-S	|void	|new_collate	|NN const char* newcoll
 #    ifdef USE_LOCALE_CTYPE
 S	|void	|new_ctype	|NN const char* newctype
 ST	|bool	|is_codeset_name_UTF8|NN const char * name
@@ -3392,6 +3391,17 @@ S	|const char *|calculate_LC_ALL|const locale_t cur_obj
 S	|const char *|calculate_LC_ALL|NN const char ** individ_locales
 #      endif
 #    endif
+#    ifdef USE_LOCALE_COLLATE
+S	|void	|new_collate	|NN const char* newcoll
+#      ifdef DEBUGGING
+S	|void	|print_collxfrm_input_and_return		\
+			    |NN const char * s			\
+			    |NN const char * e			\
+			    |NULLOK const char * xbuf		\
+			    |const STRLEN xlen			\
+			    |const bool is_utf8
+#      endif
+#    endif
 #    ifdef WIN32
 S	|char*	|win32_setlocale|int category|NULLOK const char* locale
 pTC	|wchar_t *|Win_utf8_string_to_wstring|NULLOK const char * utf8_string
@@ -3413,12 +3423,6 @@ S	|const char*|my_langinfo_i|const int item			\
 				|NULLOK utf8ness_t * utf8ness
 #    endif
 #    ifdef DEBUGGING
-S	|void	|print_collxfrm_input_and_return		\
-			    |NN const char * s			\
-			    |NN const char * e			\
-			    |NULLOK const char * xbuf		\
-			    |const STRLEN xlen			\
-			    |const bool is_utf8
 STR	|char *	|setlocale_debug_string_i|const unsigned cat_index	    \
 					|NULLOK const char* const locale    \
 					|NULLOK const char* const retval

--- a/embed.fnc
+++ b/embed.fnc
@@ -3328,7 +3328,9 @@ S	|utf8ness_t|get_locale_string_utf8ness_i				\
 				|const locale_utf8ness_t known_utf8
 S	|void	|new_collate	|NN const char* newcoll
 S	|void	|new_ctype	|NN const char* newctype
+#    ifdef USE_LOCALE_NUMERIC
 S	|void	|new_numeric	|NN const char* newnum
+#    endif
 S	|void	|new_LC_ALL	|NULLOK const char* unused
 S	|const char*|stdize_locale|const int category			\
 				|NULLOK const char* input_locale	\

--- a/embed.h
+++ b/embed.h
@@ -1739,10 +1739,12 @@
 #define new_LC_ALL(a)		S_new_LC_ALL(aTHX_ a)
 #define new_collate(a)		S_new_collate(aTHX_ a)
 #define new_ctype(a)		S_new_ctype(aTHX_ a)
-#define new_numeric(a)		S_new_numeric(aTHX_ a)
 #define save_to_buffer		S_save_to_buffer
 #define setlocale_failure_panic_i(a,b,c,d,e)	S_setlocale_failure_panic_i(aTHX_ a,b,c,d,e)
 #define stdize_locale(a,b,c,d,e)	S_stdize_locale(aTHX_ a,b,c,d,e)
+#      if defined(USE_LOCALE_NUMERIC)
+#define new_numeric(a)		S_new_numeric(aTHX_ a)
+#      endif
 #      if defined(USE_POSIX_2008_LOCALE)
 #define emulate_setlocale_i(a,b,c,d)	S_emulate_setlocale_i(aTHX_ a,b,c,d)
 #define my_querylocale_i(a)	S_my_querylocale_i(aTHX_ a)

--- a/embed.h
+++ b/embed.h
@@ -1733,15 +1733,17 @@
 #    if defined(USE_LOCALE)
 #define get_category_index	S_get_category_index
 #define get_locale_string_utf8ness_i(a,b,c,d)	S_get_locale_string_utf8ness_i(aTHX_ a,b,c,d)
-#define is_codeset_name_UTF8	S_is_codeset_name_UTF8
 #define is_locale_utf8(a)	S_is_locale_utf8(aTHX_ a)
 #define mortalized_pv_copy(a)	S_mortalized_pv_copy(aTHX_ a)
 #define new_LC_ALL(a)		S_new_LC_ALL(aTHX_ a)
 #define new_collate(a)		S_new_collate(aTHX_ a)
-#define new_ctype(a)		S_new_ctype(aTHX_ a)
 #define save_to_buffer		S_save_to_buffer
 #define setlocale_failure_panic_i(a,b,c,d,e)	S_setlocale_failure_panic_i(aTHX_ a,b,c,d,e)
 #define stdize_locale(a,b,c,d,e)	S_stdize_locale(aTHX_ a,b,c,d,e)
+#      if defined(USE_LOCALE_CTYPE)
+#define is_codeset_name_UTF8	S_is_codeset_name_UTF8
+#define new_ctype(a)		S_new_ctype(aTHX_ a)
+#      endif
 #      if defined(USE_LOCALE_NUMERIC)
 #define new_numeric(a)		S_new_numeric(aTHX_ a)
 #      endif

--- a/embed.h
+++ b/embed.h
@@ -1730,12 +1730,12 @@
 #define unshare_hek_or_pvn(a,b,c,d)	S_unshare_hek_or_pvn(aTHX_ a,b,c,d)
 #  endif
 #  if defined(PERL_IN_LOCALE_C)
-#define mortalized_pv_copy(a)	S_mortalized_pv_copy(aTHX_ a)
 #    if defined(USE_LOCALE)
 #define get_category_index	S_get_category_index
 #define get_locale_string_utf8ness_i(a,b,c,d)	S_get_locale_string_utf8ness_i(aTHX_ a,b,c,d)
 #define is_codeset_name_UTF8	S_is_codeset_name_UTF8
 #define is_locale_utf8(a)	S_is_locale_utf8(aTHX_ a)
+#define mortalized_pv_copy(a)	S_mortalized_pv_copy(aTHX_ a)
 #define new_LC_ALL(a)		S_new_LC_ALL(aTHX_ a)
 #define new_collate(a)		S_new_collate(aTHX_ a)
 #define new_ctype(a)		S_new_ctype(aTHX_ a)

--- a/embed.h
+++ b/embed.h
@@ -1610,8 +1610,10 @@
 #define print_bytes_for_locale(a,b,c)	S_print_bytes_for_locale(aTHX_ a,b,c)
 #      if defined(USE_LOCALE)
 #define get_LC_ALL_display()	S_get_LC_ALL_display(aTHX)
-#define print_collxfrm_input_and_return(a,b,c,d,e)	S_print_collxfrm_input_and_return(aTHX_ a,b,c,d,e)
 #define setlocale_debug_string_i	S_setlocale_debug_string_i
+#        if defined(USE_LOCALE_COLLATE)
+#define print_collxfrm_input_and_return(a,b,c,d,e)	S_print_collxfrm_input_and_return(aTHX_ a,b,c,d,e)
+#        endif
 #      endif
 #    endif
 #    if defined(PERL_IN_PAD_C)
@@ -1736,10 +1738,12 @@
 #define is_locale_utf8(a)	S_is_locale_utf8(aTHX_ a)
 #define mortalized_pv_copy(a)	S_mortalized_pv_copy(aTHX_ a)
 #define new_LC_ALL(a)		S_new_LC_ALL(aTHX_ a)
-#define new_collate(a)		S_new_collate(aTHX_ a)
 #define save_to_buffer		S_save_to_buffer
 #define setlocale_failure_panic_i(a,b,c,d,e)	S_setlocale_failure_panic_i(aTHX_ a,b,c,d,e)
 #define stdize_locale(a,b,c,d,e)	S_stdize_locale(aTHX_ a,b,c,d,e)
+#      if defined(USE_LOCALE_COLLATE)
+#define new_collate(a)		S_new_collate(aTHX_ a)
+#      endif
 #      if defined(USE_LOCALE_CTYPE)
 #define is_codeset_name_UTF8	S_is_codeset_name_UTF8
 #define new_ctype(a)		S_new_ctype(aTHX_ a)

--- a/locale.c
+++ b/locale.c
@@ -143,7 +143,8 @@ S_mortalized_pv_copy(pTHX_ const char * const pv)
 #define GET_ERRNO   saved_errno
 
 /* Default values come from the C locale */
-static const char C_codeset[] = "ANSI_X3.4-1968";
+#define C_codeset "ANSI_X3.4-1968" /* Only in some Configurations, and usually
+                                      a single instance, so is a #define */
 static const char C_decimal_point[] = ".";
 static const char C_thousands_sep[] = "";
 

--- a/locale.c
+++ b/locale.c
@@ -119,6 +119,8 @@ static int debug_initialization = 0;
 #  include <wctype.h>
 #endif
 
+#ifdef USE_LOCALE
+
 PERL_STATIC_INLINE const char *
 S_mortalized_pv_copy(pTHX_ const char * const pv)
 {
@@ -136,6 +138,7 @@ S_mortalized_pv_copy(pTHX_ const char * const pv)
     return copy;
 }
 
+#endif
 
 /* Returns the Unix errno portion; ignoring any others.  This is a macro here
  * instead of putting it into perl.h, because unclear to khw what should be

--- a/locale.c
+++ b/locale.c
@@ -1606,18 +1606,12 @@ S_setlocale_failure_panic_i(pTHX_
                                       || defined(HAS_SNPRINTF))
 #    define CAN_CALCULATE_RADIX
 #  endif
+#  ifdef USE_LOCALE_NUMERIC
 
 STATIC void
 S_new_numeric(pTHX_ const char *newnum)
 {
     PERL_ARGS_ASSERT_NEW_NUMERIC;
-
-#  ifndef USE_LOCALE_NUMERIC
-
-    PERL_ARGS_ASSERT_NEW_NUMERIC;
-    PERL_UNUSED_ARG(newnum);
-
-#  else
 
     /* Called after each libc setlocale() call affecting LC_NUMERIC, to tell
      * core Perl this and that 'newnum' is the name of the new locale, and we
@@ -1761,9 +1755,9 @@ S_new_numeric(pTHX_ const char *newnum)
         set_numeric_standard();
     }
 
-#  endif
-
 }
+
+#  endif
 
 void
 Perl_set_numeric_standard(pTHX)

--- a/locale.c
+++ b/locale.c
@@ -1816,19 +1816,11 @@ Perl_set_numeric_underlying(pTHX)
 
 }
 
-/*
- * Set up for a new ctype locale.
- */
+#  ifdef USE_LOCALE_CTYPE
+
 STATIC void
 S_new_ctype(pTHX_ const char *newctype)
 {
-
-#  ifndef USE_LOCALE_CTYPE
-
-    PERL_UNUSED_ARG(newctype);
-    PERL_UNUSED_CONTEXT;
-
-#  else
 
     /* Called after each libc setlocale() call affecting LC_CTYPE, to tell
      * core Perl this and that 'newctype' is the name of the new locale.
@@ -2224,10 +2216,9 @@ S_new_ctype(pTHX_ const char *newctype)
             }
         }
     }
+}
 
 #  endif /* USE_LOCALE_CTYPE */
-
-}
 
 void
 Perl__warn_problematic_locale()
@@ -5253,7 +5244,10 @@ Perl_mem_collxfrm_(pTHX_ const char *input_string,
     STRLEN xAlloc;          /* xalloc is a reserved word in VC */
     STRLEN length_in_chars;
     bool first_time = TRUE; /* Cleared after first loop iteration */
-    const char * orig_CTYPE_locale = NULL;
+
+#  ifdef USE_LOCALE_CTYPE
+        const char * orig_CTYPE_locale = NULL;
+#  endif
 
 #  if defined(USE_POSIX_2008_LOCALE) && defined HAS_STRXFRM_L
     locale_t constructed_locale = (locale_t) 0;
@@ -5949,6 +5943,8 @@ S_restore_toggled_locale_i(pTHX_ const unsigned int cat_index,
 
 }
 
+#ifdef USE_LOCALE_CTYPE
+
 STATIC bool
 S_is_codeset_name_UTF8(const char * name)
 {
@@ -5973,6 +5969,8 @@ S_is_codeset_name_UTF8(const char * name)
                 || memBEGINs(name, len, "utf"))
             && (len == 4 || name[3] == '-'));
 }
+
+#endif
 
 STATIC bool
 S_is_locale_utf8(pTHX_ const char * locale)

--- a/locale.c
+++ b/locale.c
@@ -2261,17 +2261,13 @@ S_new_LC_ALL(pTHX_ const char *unused)
     }
 }
 
+#  ifdef USE_LOCALE_COLLATE
+
 STATIC void
 S_new_collate(pTHX_ const char *newcoll)
 {
     PERL_ARGS_ASSERT_NEW_COLLATE;
 
-#  ifndef USE_LOCALE_COLLATE
-
-    PERL_UNUSED_ARG(newcoll);
-    PERL_UNUSED_CONTEXT;
-
-#  else
 
     /* Called after each libc setlocale() call affecting LC_COLLATE, to tell
      * core Perl this and that 'newcoll' is the name of the new locale.
@@ -2317,10 +2313,9 @@ S_new_collate(pTHX_ const char *newcoll)
     PL_collxfrm_mult = 0;
     PL_collxfrm_base = 0;
 
-#  endif /* USE_LOCALE_COLLATE */
-
 }
 
+#  endif /* USE_LOCALE_COLLATE */
 #endif  /* USE_LOCALE */
 
 #ifdef WIN32

--- a/proto.h
+++ b/proto.h
@@ -5097,13 +5097,15 @@ STATIC void	S_print_bytes_for_locale(pTHX_ const char * const s, const char * co
 #    if defined(USE_LOCALE)
 STATIC const char *	S_get_LC_ALL_display(pTHX);
 #define PERL_ARGS_ASSERT_GET_LC_ALL_DISPLAY
-STATIC void	S_print_collxfrm_input_and_return(pTHX_ const char * s, const char * e, const char * xbuf, const STRLEN xlen, const bool is_utf8);
-#define PERL_ARGS_ASSERT_PRINT_COLLXFRM_INPUT_AND_RETURN	\
-	assert(s); assert(e)
 STATIC char *	S_setlocale_debug_string_i(const unsigned cat_index, const char* const locale, const char* const retval)
 			__attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SETLOCALE_DEBUG_STRING_I
 
+#      if defined(USE_LOCALE_COLLATE)
+STATIC void	S_print_collxfrm_input_and_return(pTHX_ const char * s, const char * e, const char * xbuf, const STRLEN xlen, const bool is_utf8);
+#define PERL_ARGS_ASSERT_PRINT_COLLXFRM_INPUT_AND_RETURN	\
+	assert(s); assert(e)
+#      endif
 #    endif
 #  endif
 #  if defined(PERL_IN_PAD_C)
@@ -5681,9 +5683,6 @@ PERL_STATIC_INLINE const char *	S_mortalized_pv_copy(pTHX_ const char * const pv
 
 STATIC void	S_new_LC_ALL(pTHX_ const char* unused);
 #define PERL_ARGS_ASSERT_NEW_LC_ALL
-STATIC void	S_new_collate(pTHX_ const char* newcoll);
-#define PERL_ARGS_ASSERT_NEW_COLLATE	\
-	assert(newcoll)
 STATIC void	S_restore_toggled_locale_i(pTHX_ const unsigned cat_index, const char * original_locale, const line_t caller_line);
 #define PERL_ARGS_ASSERT_RESTORE_TOGGLED_LOCALE_I
 STATIC const char *	S_save_to_buffer(const char * string, const char **buf, Size_t *buf_size);
@@ -5698,6 +5697,11 @@ STATIC const char*	S_stdize_locale(pTHX_ const int category, const char* input_l
 STATIC const char *	S_toggle_locale_i(pTHX_ const unsigned switch_cat_index, const char * new_locale, const line_t caller_line);
 #define PERL_ARGS_ASSERT_TOGGLE_LOCALE_I	\
 	assert(new_locale)
+#    if defined(USE_LOCALE_COLLATE)
+STATIC void	S_new_collate(pTHX_ const char* newcoll);
+#define PERL_ARGS_ASSERT_NEW_COLLATE	\
+	assert(newcoll)
+#    endif
 #    if defined(USE_LOCALE_CTYPE)
 STATIC bool	S_is_codeset_name_UTF8(const char * name);
 #define PERL_ARGS_ASSERT_IS_CODESET_NAME_UTF8	\

--- a/proto.h
+++ b/proto.h
@@ -5690,9 +5690,6 @@ STATIC void	S_new_collate(pTHX_ const char* newcoll);
 STATIC void	S_new_ctype(pTHX_ const char* newctype);
 #define PERL_ARGS_ASSERT_NEW_CTYPE	\
 	assert(newctype)
-STATIC void	S_new_numeric(pTHX_ const char* newnum);
-#define PERL_ARGS_ASSERT_NEW_NUMERIC	\
-	assert(newnum)
 STATIC void	S_restore_toggled_locale_i(pTHX_ const unsigned cat_index, const char * original_locale, const line_t caller_line);
 #define PERL_ARGS_ASSERT_RESTORE_TOGGLED_LOCALE_I
 STATIC const char *	S_save_to_buffer(const char * string, const char **buf, Size_t *buf_size);
@@ -5707,6 +5704,11 @@ STATIC const char*	S_stdize_locale(pTHX_ const int category, const char* input_l
 STATIC const char *	S_toggle_locale_i(pTHX_ const unsigned switch_cat_index, const char * new_locale, const line_t caller_line);
 #define PERL_ARGS_ASSERT_TOGGLE_LOCALE_I	\
 	assert(new_locale)
+#    if defined(USE_LOCALE_NUMERIC)
+STATIC void	S_new_numeric(pTHX_ const char* newnum);
+#define PERL_ARGS_ASSERT_NEW_NUMERIC	\
+	assert(newnum)
+#    endif
 #    if defined(USE_POSIX_2008_LOCALE)
 STATIC const char*	S_emulate_setlocale_i(pTHX_ const unsigned int index, const char* new_locale, const recalc_lc_all_t recalc_LC_ALL, const line_t line);
 #define PERL_ARGS_ASSERT_EMULATE_SETLOCALE_I

--- a/proto.h
+++ b/proto.h
@@ -5665,12 +5665,6 @@ PERL_CALLCONV SV*	Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
 
 #endif
 #if defined(PERL_IN_LOCALE_C)
-#ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_INLINE const char *	S_mortalized_pv_copy(pTHX_ const char * const pv)
-			__attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_MORTALIZED_PV_COPY
-#endif
-
 #  if defined(USE_LOCALE)
 STATIC unsigned int	S_get_category_index(const int category, const char * locale);
 #define PERL_ARGS_ASSERT_GET_CATEGORY_INDEX
@@ -5682,6 +5676,12 @@ STATIC bool	S_is_codeset_name_UTF8(const char * name);
 STATIC bool	S_is_locale_utf8(pTHX_ const char * locale);
 #define PERL_ARGS_ASSERT_IS_LOCALE_UTF8	\
 	assert(locale)
+#ifndef PERL_NO_INLINE_FUNCTIONS
+PERL_STATIC_INLINE const char *	S_mortalized_pv_copy(pTHX_ const char * const pv)
+			__attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_MORTALIZED_PV_COPY
+#endif
+
 STATIC void	S_new_LC_ALL(pTHX_ const char* unused);
 #define PERL_ARGS_ASSERT_NEW_LC_ALL
 STATIC void	S_new_collate(pTHX_ const char* newcoll);

--- a/proto.h
+++ b/proto.h
@@ -5670,9 +5670,6 @@ STATIC unsigned int	S_get_category_index(const int category, const char * locale
 #define PERL_ARGS_ASSERT_GET_CATEGORY_INDEX
 STATIC utf8ness_t	S_get_locale_string_utf8ness_i(pTHX_ const char * locale, const unsigned cat_index, const char * string, const locale_utf8ness_t known_utf8);
 #define PERL_ARGS_ASSERT_GET_LOCALE_STRING_UTF8NESS_I
-STATIC bool	S_is_codeset_name_UTF8(const char * name);
-#define PERL_ARGS_ASSERT_IS_CODESET_NAME_UTF8	\
-	assert(name)
 STATIC bool	S_is_locale_utf8(pTHX_ const char * locale);
 #define PERL_ARGS_ASSERT_IS_LOCALE_UTF8	\
 	assert(locale)
@@ -5687,9 +5684,6 @@ STATIC void	S_new_LC_ALL(pTHX_ const char* unused);
 STATIC void	S_new_collate(pTHX_ const char* newcoll);
 #define PERL_ARGS_ASSERT_NEW_COLLATE	\
 	assert(newcoll)
-STATIC void	S_new_ctype(pTHX_ const char* newctype);
-#define PERL_ARGS_ASSERT_NEW_CTYPE	\
-	assert(newctype)
 STATIC void	S_restore_toggled_locale_i(pTHX_ const unsigned cat_index, const char * original_locale, const line_t caller_line);
 #define PERL_ARGS_ASSERT_RESTORE_TOGGLED_LOCALE_I
 STATIC const char *	S_save_to_buffer(const char * string, const char **buf, Size_t *buf_size);
@@ -5704,6 +5698,14 @@ STATIC const char*	S_stdize_locale(pTHX_ const int category, const char* input_l
 STATIC const char *	S_toggle_locale_i(pTHX_ const unsigned switch_cat_index, const char * new_locale, const line_t caller_line);
 #define PERL_ARGS_ASSERT_TOGGLE_LOCALE_I	\
 	assert(new_locale)
+#    if defined(USE_LOCALE_CTYPE)
+STATIC bool	S_is_codeset_name_UTF8(const char * name);
+#define PERL_ARGS_ASSERT_IS_CODESET_NAME_UTF8	\
+	assert(name)
+STATIC void	S_new_ctype(pTHX_ const char* newctype);
+#define PERL_ARGS_ASSERT_NEW_CTYPE	\
+	assert(newctype)
+#    endif
 #    if defined(USE_LOCALE_NUMERIC)
 STATIC void	S_new_numeric(pTHX_ const char* newnum);
 #define PERL_ARGS_ASSERT_NEW_NUMERIC	\


### PR DESCRIPTION
These commits silence some locale-related compiler warnings.

One fixes #20140

