### PR TITLE
Tidy output of `perlbug` for pasting on GitHub

### DIFF
--- a/utils/perlbug.PL
+++ b/utils/perlbug.PL
@@ -86,7 +86,7 @@ BEGIN {
     $::HaveWrap = ($@ eq "");
 };
 
-our $VERSION = "1.42";
+our $VERSION = "1.43";
 
 #TODO:
 #       make sure failure (transmission-wise) of Mail::Send is accounted for.
@@ -620,6 +620,10 @@ generated with the help of perlbug $VERSION running under perl $perl_version.
 
 EOF
 
+    if ($report_about_module) {
+	print REP "Module: $report_about_module\n\n";
+    }
+
     if ($body) {
 	print REP $body;
     } elsif ($usefile) {
@@ -646,12 +650,25 @@ EOF
 	    print REP <<'EOF';
 
 -----------------------------------------------------------------
-[Please describe your issue here]
+<!--[Please describe your issue here]-->
+
+**Description**
+<!-- A clear and concise description of what the bug is. -->
 
 
 
-[Please do not change anything below this line]
------------------------------------------------------------------
+**Steps to Reproduce**
+<!-- A one-liner or script to reproduce the issue. -->
+
+
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+
+
+<!--[Please do not change anything below this line]-->
+<!------------------------------------------------------------------- -->
 EOF
 	}
     }
@@ -671,26 +688,30 @@ sub Dump {
     $severity ||= 'low';
 
     print OUT <<EFF;
+
+
 ---
-Flags:
-    category=$category
-    severity=$severity
+**Flags**
+- category=$category
+- severity=$severity
 EFF
 
     if ($has_patch) {
         print OUT <<EFF;
-    Type=Patch
-    PatchStatus=HasPatch
+- Type=Patch
+- PatchStatus=HasPatch
 EFF
     }
 
     if ($report_about_module ) { 
         print OUT <<EFF;
-    module=$report_about_module
+- module=$report_about_module
 EFF
     }
     print OUT <<EFF;
 ---
+**Perl configuration**
+```
 EFF
     print OUT "This perlbug was built using Perl $config_tag1\n",
 	    "It is being executed now by  Perl $config_tag2.\n\n"
@@ -745,6 +766,7 @@ EOF
 	    print OUT "$_='$value'\n";
 	}
     }
+    print OUT "```\n";
 } # sub Dump
 
 sub Edit {


### PR DESCRIPTION
Clean up the report created by `perlbug` so that it looks better
when pasted in a GitHub issue:
- Put the 'perl configuration' in a code-block
- Hide some sentences
- Clean up 'Flags' section (it was shown as a very big header and
  taking up quite a lot of space)
- Add `**Description**`, `**Steps to Reproduce**` and `**Expected behaviour**`
  in the body of the report (similar to the GitHub issue template)
- If this is a report about a core module then also put the name of the Module
  at the top (it's still included in 'Flags' as well)
- ...

(There are two newlines added before 'Flags', this is to deal with someone
 using `perlbug -b foo`, without the newlines GitHub would make turn the
 'foo' into a title)