### PR TITLE
locale.c: Initialize variable to avoid runtime check; also PL_underlying_numeric_ob

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -4632,6 +4632,12 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 
     DEBUG_Lv(PerlIO_printf(Perl_debug_log, "created C object %p\n",
                            PL_C_locale_obj));
+
+#    ifdef USE_LOCALE_NUMERIC
+
+    PL_underlying_numeric_obj = duplocale(PL_C_locale_obj);
+
+#    endif
 #  endif
 #  ifdef USE_LOCALE_NUMERIC
 


### PR DESCRIPTION
Initializing the first means we no longer have to tess that it is non-NULL
each time it is accessed; the second is just better form.