### PR TITLE
peep.c:OP_PADSV_STORE - skip SASSIGN created by Memoize::Once

### DIFF
--- a/peep.c
+++ b/peep.c
@@ -3908,8 +3908,12 @@ Perl_rpeep(pTHX_ OP *o)
                 !(lval->op_private & OPpDEREF)
                  /* skip if padrange has already gazumped the padsv */
                  && (lval == oldop)
+                 /* Memoize::Once produces a non-standard SASSIGN that
+                  * doesn't actually point to pp_sassign, has only one
+                  * child (PADSV), and gets to it via op_other rather
+                  * than op_next. Don't try to optimize this. */
+                 && (lval != rhs)
                ) {
-
                 /* SASSIGN's bitfield flags, such as op_moresib and
                  * op_slabbed, will be carried over unchanged. */
                 OpTYPE_set(o, OP_PADSV_STORE);


### PR DESCRIPTION
Memoize::Once produces a non-standard SASSIGN which should not and
need not be optimized. Because this SASSIGN has only one child,
something that hasn't been seen elsewhere, that can be used as a
heuristic for skipping this type of SASSIGN in rpeep().