### PR TITLE
porting/diag.t - improved parsing a bit

### DIFF
--- a/dquote.c
+++ b/dquote.c
@@ -46,7 +46,7 @@ Perl_grok_bslash_c(pTHX_ const char   source,
         const char control = toCTRL('{');
         if (isPRINT_A(control)) {
             /* diag_listed_as: Use "%s" instead of "%s" */
-            *message = Perl_form(aTHX_ "Use \"%c\" instead of \"\\c{\"", control);
+            *message = Perl_form(aTHX_ PERL_DIAG_DIE_SYNTAX("Use \"%c\" instead of \"\\c{\""), control);
         }
         else {
             *message = "Sequence \"\\c{\" invalid";
@@ -58,7 +58,7 @@ Perl_grok_bslash_c(pTHX_ const char   source,
     if (isPRINT_A(*result) && ckWARN(WARN_SYNTAX)) {
         U8 clearer[3];
         U8 i = 0;
-        char format[] = "\"\\c%c\" is more clearly written simply as \"%s\"";
+        char format[] = PERL_DIAG_WARN_SYNTAX("\"\\c%c\" is more clearly written simply as \"%s\"");
 
         if (! isWORDCHAR(*result)) {
             clearer[i++] = '\\';

--- a/op.c
+++ b/op.c
@@ -1877,20 +1877,26 @@ Perl_warn_elem_scalar_context(pTHX_ const OP *o, SV *name, bool is_hash, bool is
 
     if (keypv) {
         msg = is_slice ?
-            "Scalar value @%" SVf "%c%s%c better written as $%" SVf "%c%s%c" :
-            "%%%" SVf "%c%s%c in scalar context better written as $%" SVf "%c%s%c";
-        /* diag_listed_as: %%s[%s] in scalar context better written as $%s[%s] */
-        /* diag_listed_as: Scalar value @%s[%s] better written as $%s[%s] */
+            /* diag_listed_as: Scalar value @%s[%s] better written as $%s[%s] */
+            PERL_DIAG_WARN_SYNTAX(
+                "Scalar value @%" SVf "%c%s%c better written as $%" SVf "%c%s%c") :
+            /* diag_listed_as: %%s[%s] in scalar context better written as $%s[%s] */
+            PERL_DIAG_WARN_SYNTAX(
+                "%%%" SVf "%c%s%c in scalar context better written as $%" SVf "%c%s%c");
+
         Perl_warner(aTHX_ packWARN(WARN_SYNTAX), msg,
                 SVfARG(name), lbrack, keypv, rbrack,
                 SVfARG(name), lbrack, keypv, rbrack);
     }
     else {
         msg = is_slice ?
-            "Scalar value @%" SVf "%c%" SVf "%c better written as $%" SVf "%c%" SVf "%c" :
-            "%%%" SVf "%c%" SVf "%c in scalar context better written as $%" SVf "%c%" SVf "%c";
-        /* diag_listed_as: %%s[%s] in scalar context better written as $%s[%s] */
-        /* diag_listed_as: Scalar value @%s[%s] better written as $%s[%s] */
+            /* diag_listed_as: Scalar value @%s[%s] better written as $%s[%s] */
+            PERL_DIAG_WARN_SYNTAX(
+                "Scalar value @%" SVf "%c%" SVf "%c better written as $%" SVf "%c%" SVf "%c") :
+            /* diag_listed_as: %%s[%s] in scalar context better written as $%s[%s] */
+            PERL_DIAG_WARN_SYNTAX(
+                "%%%" SVf "%c%" SVf "%c in scalar context better written as $%" SVf "%c%" SVf "%c");
+
         Perl_warner(aTHX_ packWARN(WARN_SYNTAX), msg,
                 SVfARG(name), lbrack, SVfARG(keysv), rbrack,
                 SVfARG(name), lbrack, SVfARG(keysv), rbrack);

--- a/os2/os2ish.h
+++ b/os2/os2ish.h
@@ -192,7 +192,7 @@ extern int rc;
 #  define pthread_setspecific(k,v)	(*(k)=(v),0)
 #  define pthread_key_create(keyp,flag)			\
         ( DosAllocThreadLocalMemory(1,(unsigned long**)keyp)	\
-          ? Perl_croak_nocontext("LocalMemory"),1	\
+          ? Perl_croak_nocontext("Out of memory!"), 1        \
           : 0						\
         )
 #endif /* USE_SLOW_THREAD_SPECIFIC */
@@ -1239,4 +1239,3 @@ typedef struct {
 PQTOPLEVEL get_sysinfo(ULONG pid, ULONG flags);
 
 #endif /* _OS2_H */
-

--- a/perl.h
+++ b/perl.h
@@ -8916,6 +8916,24 @@ END_EXTERN_C
 /* ${^MAX_NESTED_EVAL_BEGIN_BLOCKS} */
 #define PERL_VAR_MAX_NESTED_EVAL_BEGIN_BLOCKS "\015AX_NESTED_EVAL_BEGIN_BLOCKS"
 
+/* Defines like this make it easier to do porting/diag.t. They are no-
+ * ops that return their argument which can be used to hint to diag.t
+ * that a string is actually an error message. By putting the category
+ * information into the macro name it considerably simplifies extended
+ * diag.t to support these cases. Feel free to add more.
+ *
+ * While it seems tempting to try to convert all of our diagnostics to
+ * this format, it would miss part of the point of diag.t in that it
+ * detects NEW diagnostics, which would not necessarily use these
+ * macros. The macros instead exist where we know we have an error
+ * message that isnt being picked up by diag.t because it is declared
+ * as a string independently of the function it is fed to, something
+ * diag.t can never handle right without help.
+ */
+#define PERL_DIAG_STR_(x)           ("" x "")
+#define PERL_DIAG_WARN_SYNTAX(x)    PERL_DIAG_STR_(x)
+#define PERL_DIAG_DIE_SYNTAX(x)     PERL_DIAG_STR_(x)
+
 /*
 
    (KEEP THIS LAST IN perl.h!)

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2415,6 +2415,11 @@ previously.
 (W io) You opened for writing a filehandle that got the same filehandle id
 as STDIN.  This occurred because you closed STDIN previously.
 
+=item Filehandle STD%s reopened as %s only for input
+
+(W io) You opened for reading a filehandle that got the same filehandle id
+as STDOUT or STDERR.  This occurred because you closed the handle previously.
+
 =item Final $ should be \$ or $name
 
 (F) You must now decide whether the final $ in a string was meant to be

--- a/t/porting/diag.t
+++ b/t/porting/diag.t
@@ -601,7 +601,6 @@ Error reading "%s": %s
 EVAL without pos change exceeded limit in regex
 Filehandle opened only for %sput
 Filehandle %s opened only for %sput
-Filehandle STD%s reopened as %s only for input
 file_type not implemented on DOS
 filter_del can only delete in reverse order (currently)
 fork() not available


### PR DESCRIPTION
The "multiline" logic of diag.t was getting confused by define
statements that would define a symbol to call an error function but not
end in ";", this would then slurp potentially many lines errorenously,
potentially absorbing more than one message. The multi-line logic also
would undef $listed_as and lose the diag_listed_as data in some
circumstances.

Fixing those issues revealed some interesting cases. To fix one of them
I defined a new noop macro in perl.h to help: PERL_DIAG_WARN_SYNTAX(),
which helps the diag.t parser identify messages without needing to be
actually part of a specific message line. These macros are noops, they
just return their argument, but they help hint to diag.t what is going
on. Maybe in the future this can be reworked to be more generic, there
are other similar cases that are not covered.

Interestingly fixing this bug meant that at least one message that used
to be erroneously picked up was no longer identified or tested. This was
replaced with a PERL_DIAG_DIE_SYNTAX() wrapper.