### PR TITLE
Fix t/porting/update_authors.t when diff algorithm is set in config

### DIFF
--- a/Porting/updateAUTHORS.pm
+++ b/Porting/updateAUTHORS.pm
@@ -211,7 +211,7 @@ sub read_commit_log {
     push @args, "'$self->{commit_range}'" if $self->{commit_range};
 
     my $last_commit_info;
-    my $cmd= qq(git log @args);
+    my $cmd= qq(git -c diff.algorithm=myers log @args);
     $cmd =~ s/'/"/g if $^O =~ /Win/;
     open my $fh, "-|", $cmd
         or die "Failed to open git log pipe: $!";

--- a/Porting/updateAUTHORS.pm
+++ b/Porting/updateAUTHORS.pm
@@ -205,13 +205,13 @@ sub read_commit_log {
     my $author_info= $self->{author_info}   ||= {};
     my $mailmap_info= $self->{mailmap_info} ||= {};
 
-    my $commit_range= $self->{commit_range} ? qq#'$self->{commit_range}'# : "";
     my $commits_read= 0;
-
-    my $numstat= $self->{numstat} ? "--numstat" : "";
+    my @args= ("--pretty='format:$tformat'");
+    push @args, "--numstat" if $self->{numstat};
+    push @args, "'$self->{commit_range}'" if $self->{commit_range};
 
     my $last_commit_info;
-    my $cmd= qq(git log --pretty='format:$tformat' $numstat $commit_range);
+    my $cmd= qq(git log @args);
     $cmd =~ s/'/"/g if $^O =~ /Win/;
     open my $fh, "-|", $cmd
         or die "Failed to open git log pipe: $!";


### PR DESCRIPTION
When the 'diff.algorithm' in git config is set to 'patience'
(i.e. `git config diff.algorithm patience`) then t/porting/update_authors.t
failed because it can renders a slightly different diff which results in
different line counts which caused the test failed.

An example of such a commit f7e7b4d5e7c86d3d5df8a744581a7f7390fc64ce:

	$ git show --oneline --numstat --diff-algorithm=myers f7e7b4d5e7
	f7e7b4d win32.c: use _mkgmtime() instead of mktime() in stat()
	11      2       pod/perldelta.pod
	10      13      win32/win32.c

	$ git show --oneline --numstat --diff-algorithm=patience f7e7b4d5e7
	f7e7b4d win32.c: use _mkgmtime() instead of mktime() in stat()
	11      2       pod/perldelta.pod
	9       12      win32/win32.c


Note: I opted to use `git -c diff.algorithm` since that will also
      work on old git versions that don't support `git log --diff-algorithm`