### PR TITLE
t/op/eval.t - Test for eval string inside of sort

### DIFF
--- a/t/op/eval.t
+++ b/t/op/eval.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan(tests => 149);
+plan(tests => 152);
 
 eval 'pass();';
 
@@ -724,6 +724,8 @@ pass("eval in freed package does not crash");
         'eval "UNITCHECK { eval q(BEGIN     { die; }); print q(A-) }";',
         'eval "BEGIN     { eval q(UNITCHECK { die; }); print q(A-) }";',
     ) {
+        fresh_perl_is($line . ' print "ok";', "A-ok", {}, "No segfault: $line");
+        my $sort_line= 'my @x= sort { ' . $line . ' } 1,2;';
         fresh_perl_is($line . ' print "ok";', "A-ok", {}, "No segfault: $line");
     }
 }


### PR DESCRIPTION
Things that die in eval in sort have from time to time caused trouble.
This tests that dieing inside of a BEGIN or UNITCHECK inside of an eval
inside of sort does not segfault.

See discussion in GH Issue #20261.