### PR TITLE
Fix GNU/{Hurd,kFreeBSD,kNetBSD} hint files in several modules

### DIFF
--- a/dist/Storable/hints/gnukfreebsd.pl
+++ b/dist/Storable/hints/gnukfreebsd.pl
@@ -1,1 +1,1 @@
-do './hints/linux.pl' or die $@;
+eval `cat hints/linux.pl` or die $@;

--- a/dist/Storable/hints/gnuknetbsd.pl
+++ b/dist/Storable/hints/gnuknetbsd.pl
@@ -1,1 +1,1 @@
-do './hints/linux.pl' or die $@;
+eval `cat hints/linux.pl` or die $@;

--- a/ext/DynaLoader/hints/gnukfreebsd.pl
+++ b/ext/DynaLoader/hints/gnukfreebsd.pl
@@ -1,1 +1,1 @@
-do './hints/linux.pl' or die $@;
+eval `cat hints/linux.pl` or die $@;

--- a/ext/DynaLoader/hints/gnuknetbsd.pl
+++ b/ext/DynaLoader/hints/gnuknetbsd.pl
@@ -1,1 +1,1 @@
-do './hints/linux.pl' or die $@;
+eval `cat hints/linux.pl` or die $@;

--- a/ext/NDBM_File/hints/gnu.pl
+++ b/ext/NDBM_File/hints/gnu.pl
@@ -1,1 +1,1 @@
-do './hints/linux.pl' or die $@;
+eval `cat hints/linux.pl` or die $@;

--- a/ext/NDBM_File/hints/gnukfreebsd.pl
+++ b/ext/NDBM_File/hints/gnukfreebsd.pl
@@ -1,1 +1,1 @@
-do './hints/linux.pl' or die $@;
+eval `cat hints/linux.pl` or die $@;

--- a/ext/NDBM_File/hints/gnuknetbsd.pl
+++ b/ext/NDBM_File/hints/gnuknetbsd.pl
@@ -1,1 +1,1 @@
-do './hints/linux.pl' or die $@;
+eval `cat hints/linux.pl` or die $@;

--- a/ext/ODBM_File/hints/gnu.pl
+++ b/ext/ODBM_File/hints/gnu.pl
@@ -1,1 +1,1 @@
-do './hints/linux.pl' or die $@;
+eval `cat hints/linux.pl` or die $@;

--- a/ext/ODBM_File/hints/gnukfreebsd.pl
+++ b/ext/ODBM_File/hints/gnukfreebsd.pl
@@ -1,1 +1,1 @@
-do './hints/linux.pl' or die $@;
+eval `cat hints/linux.pl` or die $@;

--- a/ext/ODBM_File/hints/gnuknetbsd.pl
+++ b/ext/ODBM_File/hints/gnuknetbsd.pl
@@ -1,1 +1,1 @@
-do './hints/linux.pl' or die $@;
+eval `cat hints/linux.pl` or die $@;

--- a/ext/POSIX/hints/gnukfreebsd.pl
+++ b/ext/POSIX/hints/gnukfreebsd.pl
@@ -1,1 +1,1 @@
-do './hints/linux.pl' or die $@;
+eval `cat hints/linux.pl` or die $@;

--- a/ext/POSIX/hints/gnuknetbsd.pl
+++ b/ext/POSIX/hints/gnuknetbsd.pl
@@ -1,1 +1,1 @@
-do './hints/linux.pl' or die $@;
+eval `cat hints/linux.pl` or die $@;


### PR DESCRIPTION
The idiom of

  do './hints/linux.pl' or die $@;

broke with https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/pull/367 which made $self a lexical variable so it is no longer visible in a file loaded with 'do'.

This silently makes the loaded Linux hints a no-op, leading to missing symbols, broken modules and test failures in at least NDBM_File and ODBM_File on GNU/Hurd, as reported by Samuel Thibault in https://bugs.debian.org/1018289 .

The replacement of eval `cat hints/linux.pl` is not very sophisticated but should be enough for this, and alternatives seem overly verbose.

Bug-Debian: https://bugs.debian.org/1018289