### PR TITLE
locale.c Use functions to initialize certain locale categories; save some conditionals

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -1800,7 +1800,7 @@ S_new_ctype(pTHX_ const char *newctype)
     DEBUG_L(PerlIO_printf(Perl_debug_log, "Entering new_ctype(%s)\n", newctype));
 
     /* No change means no-op */
-    if (PL_ctype_name && strEQ(PL_ctype_name, newctype)) {
+    if (strEQ(PL_ctype_name, newctype)) {
         return;
     }
 
@@ -5949,7 +5949,7 @@ S_is_locale_utf8(pTHX_ const char * locale)
 
     PERL_ARGS_ASSERT_IS_LOCALE_UTF8;
 
-    if (PL_ctype_name && strEQ(locale, PL_ctype_name)) {
+    if (strEQ(locale, PL_ctype_name)) {
         return PL_in_utf8_CTYPE_locale;
     }
 

--- a/locale.c
+++ b/locale.c
@@ -1784,32 +1784,16 @@ Perl_set_numeric_underlying(pTHX)
 STATIC void
 S_new_ctype(pTHX_ const char *newctype)
 {
+    PERL_ARGS_ASSERT_NEW_CTYPE;
 
-#  ifndef USE_LOCALE_CTYPE
-
-    PERL_UNUSED_ARG(newctype);
-    PERL_UNUSED_CONTEXT;
-
-#  else
+#  ifdef USE_LOCALE_CTYPE
 
     /* Called after each libc setlocale() call affecting LC_CTYPE, to tell
      * core Perl this and that 'newctype' is the name of the new locale.
      *
      * This function sets up the folding arrays for all 256 bytes, assuming
      * that tofold() is tolc() since fold case is not a concept in POSIX,
-     *
-     * Any code changing the locale (outside this file) should use
-     * Perl_setlocale or POSIX::setlocale, which call this function.  Therefore
-     * this function should be called directly only from this file and from
-     * POSIX::setlocale() */
-
-    unsigned int i;
-
-    /* Don't check for problems if we are suppressing the warnings */
-    bool check_for_problems = ckWARN_d(WARN_LOCALE) || UNLIKELY(DEBUG_L_TEST);
-    bool maybe_utf8_turkic = FALSE;
-
-    PERL_ARGS_ASSERT_NEW_CTYPE;
+     */
 
     DEBUG_L(PerlIO_printf(Perl_debug_log, "Entering new_ctype(%s)\n", newctype));
 
@@ -1829,23 +1813,27 @@ S_new_ctype(pTHX_ const char *newctype)
     Safefree(PL_ctype_name);
     PL_ctype_name = "";
 
-    /* Guard against the is_locale_utf8() call potentially zapping newctype.
-     * This is not extra work as the cache is set to this a few lines down, and
-     * that needs to be copied anyway */
-    newctype = savepv(newctype);
-
-    /* With cache cleared, this will know to compute a new value */
-    PL_in_utf8_CTYPE_locale = is_locale_utf8(newctype);
-
-    /* Cache new name */
-    PL_ctype_name = newctype;
-
     PL_in_utf8_turkic_locale = FALSE;
 
-    if (isNAME_C_OR_POSIX(PL_ctype_name)) {
+    /* For the C locale, just use the standard folds, and we know there are no
+     * glitches possible, so return early */
+    if (isNAME_C_OR_POSIX(newctype)) {
         Copy(PL_fold, PL_fold_locale, 256, U8);
+        PL_ctype_name = savepv(newctype);
+        PL_in_utf8_CTYPE_locale = FALSE;
+        return;
     }
-    else if (PL_in_utf8_CTYPE_locale) {
+
+    /* The cache being cleared signals this to compute a new value */
+    PL_in_utf8_CTYPE_locale = is_locale_utf8(newctype);
+
+    PL_ctype_name = savepv(newctype);
+    bool maybe_utf8_turkic = FALSE;
+
+    /* Don't check for problems if we are suppressing the warnings */
+    bool check_for_problems = ckWARN_d(WARN_LOCALE) || UNLIKELY(DEBUG_L_TEST);
+
+    if (PL_in_utf8_CTYPE_locale) {
 
         /* A UTF-8 locale gets standard rules.  But note that code still has to
          * handle this specially because of the three problematic code points
@@ -1880,7 +1868,7 @@ S_new_ctype(pTHX_ const char *newctype)
         bool found_unexpected = FALSE;
 
         if (DEBUG_Lv_TEST) {
-            for (i = 128; i < 256; i++) {
+            for (unsigned i = 128; i < 256; i++) {
                 int j = LATIN1_TO_NATIVE(i);
                 if (toU8_LOWER_LC(j) != j || toU8_UPPER_LC(j) != j) {
                     has_non_ascii_fold = TRUE;
@@ -1891,7 +1879,7 @@ S_new_ctype(pTHX_ const char *newctype)
 
 #    endif
 
-        for (i = 0; i < 256; i++) {
+        for (unsigned i = 0; i < 256; i++) {
             if (isU8_UPPER_LC(i))
                 PL_fold_locale[i] = (U8) toU8_LOWER_LC(i);
             else if (isU8_LOWER_LC(i))
@@ -2003,7 +1991,7 @@ S_new_ctype(pTHX_ const char *newctype)
         char bad_chars_list[ (94 * 4) + (3 * 5) + 1 ] = { '\0' };
         unsigned int bad_count = 0;         /* Count of bad characters */
 
-        for (i = 0; i < 256; i++) {
+        for (unsigned i = 0; i < 256; i++) {
 
             /* If checking for locale problems, see if the native ASCII-range
              * printables plus \n and \t are in their expected categories in

--- a/locale.c
+++ b/locale.c
@@ -4620,6 +4620,12 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 
     DEBUG_Lv(PerlIO_printf(Perl_debug_log, "created C object %p\n",
                            PL_C_locale_obj));
+
+#    ifdef USE_LOCALE_NUMERIC
+
+    PL_underlying_numeric_obj = duplocale(PL_C_locale_obj);
+
+#    endif
 #  endif
 #  ifdef USE_LOCALE_NUMERIC
 

--- a/locale.c
+++ b/locale.c
@@ -1636,7 +1636,9 @@ S_new_numeric(pTHX_ const char *newnum)
     Safefree(PL_numeric_name);
     PL_numeric_name = savepv(newnum);
 
-    /* Handle the trivial case */
+    /* Handle the trivial case.  Since this is called at process
+     * initialization, be aware that this bit can't rely on much being
+     * available. */
     if (isNAME_C_OR_POSIX(PL_numeric_name)) {
         PL_numeric_standard = TRUE;
         PL_numeric_underlying_is_standard = TRUE;
@@ -1816,7 +1818,9 @@ S_new_ctype(pTHX_ const char *newctype)
     PL_in_utf8_turkic_locale = FALSE;
 
     /* For the C locale, just use the standard folds, and we know there are no
-     * glitches possible, so return early */
+     * glitches possible, so return early.  Since this is called at process
+     * initialization, be aware that this bit can't rely on much being
+     * available. */
     if (isNAME_C_OR_POSIX(newctype)) {
         Copy(PL_fold, PL_fold_locale, 256, U8);
         PL_ctype_name = savepv(newctype);
@@ -2258,11 +2262,11 @@ S_new_collate(pTHX_ const char *newcoll)
     PL_collation_name = savepv(newcoll);
     ++PL_collation_ix;
 
-    /* Set the new one up if trivial */
+    /* Set the new one up if trivial.  Since this is called at process
+     * initialization, be aware that this bit can't rely on much being
+     * available. */
     PL_collation_standard = isNAME_C_OR_POSIX(newcoll);
     if (PL_collation_standard) {
-
-    /* Do minimal set up now */
         DEBUG_Lv(PerlIO_printf(Perl_debug_log, "Setting PL_collation name='%s'\n", PL_collation_name));
         PL_collxfrm_base = 0;
         PL_collxfrm_mult = 2;
@@ -4629,16 +4633,22 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 #  endif
 #  ifdef USE_LOCALE_NUMERIC
 
-    PL_numeric_radix_sv    = newSVpvn(C_decimal_point, strlen(C_decimal_point));
-    PL_underlying_radix_sv = newSVpvn(C_decimal_point, strlen(C_decimal_point));
-    Newx(PL_numeric_name, 2, char);
-    Copy("C", PL_numeric_name, 2, char);
+    PL_numeric_radix_sv    = newSV(1);
+    PL_underlying_radix_sv = newSV(1);
+    Newxz(PL_numeric_name, 1, char);    /* Single NUL character */
+    new_numeric("C");
 
 #  endif
 #  ifdef USE_LOCALE_COLLATE
 
-    Newx(PL_collation_name, 2, char);
-    Copy("C", PL_collation_name, 2, char);
+    Newxz(PL_collation_name, 1, char);
+    new_collate("C");
+
+#  endif
+#  ifdef USE_LOCALE_CTYPE
+
+    Newxz(PL_ctype_name, 1, char);
+    new_ctype("C");
 
 #  endif
 #  ifdef USE_PL_CURLOCALES


### PR DESCRIPTION
This series of commits includes #20256 as its requirement

The rest of the series initializes an object, and changes the initialization process to call the specialty functions for all the locale categories that them to do the initialization, instead of duplicating the logic in the initialization section.  This allows for the removal of a couple of conditionals that otherwise would need to be executed each time the locale changes.