### PR TITLE
sv_setsv_cow - directly create desired SVt_COW SV

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -4781,10 +4781,10 @@ Perl_sv_setsv_cow(pTHX_ SV *dsv, SV *ssv)
             sv_force_normal_flags(dsv, SV_COW_DROP_PV);
         else if (SvPVX_const(dsv))
             Safefree(SvPVX_mutable(dsv));
+        SvUPGRADE(dsv, SVt_COW);
     }
     else
-        new_SV(dsv);
-    SvUPGRADE(dsv, SVt_COW);
+        dsv = newSV_type(SVt_COW);
 
     assert (SvPOK(ssv));
     assert (SvPOKp(ssv));


### PR DESCRIPTION
It's more efficient to directly create the desired SV type than create a SVt_NULL and then call sv_upgrade to get the desired type.