### PR TITLE
vnewSVpvf - inline & reduce call to sv_vsetpvfn

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -9765,8 +9765,14 @@ Perl_vnewSVpvf(pTHX_ const char *const pat, va_list *const args)
 
     PERL_ARGS_ASSERT_VNEWSVPVF;
 
-    new_SV(sv);
-    sv_vsetpvfn(sv, pat, strlen(pat), args, NULL, 0, NULL);
+    /* More efficient than new_SV(sv) and SvPVCLEAR(sv) */
+    sv = newSV(1);
+    *(SvEND(sv))= '\0';
+    (void)SvPOK_only_UTF8(sv); /* validate pointer */
+    SvTAINT(sv);
+
+    sv_vcatpvfn_flags(sv, pat, strlen(pat), args, NULL, 0, NULL, 0);
+
     return sv;
 }
 


### PR DESCRIPTION
sv_vsetpvfn essentially contains two function calls that act on the SV passed in:
* SvPVCLEAR
* sv_vcatpvfn_flags

Since the SV passed in by vnewSVpvf is a brand new SVt_NULL, the net results of the call to SvPVCLEAR can be done much more efficiently inline.

Note: The `(void)SvPOK_only_UTF8(sv);` is probably not strictly necessary, as it looks like it will be set during SV normalization in sv_vcatpvfn_flags. It's left here in case it simplifies any later refactoring of the normalization code in sv_vcatpvfn_flags.