### PR TITLE
toke.c/regcomp.c: Simplified handling of new SVs

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -18444,8 +18444,8 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                                 * points. */
                                 AV * this_string = (AV *) av_shift( strings);
                                 STRLEN cp_count = av_count(this_string);
-                                SV * final = newSV(cp_count * 4);
-                                SvPVCLEAR(final);
+                                SV * final = newSV(cp_count ? cp_count * 4 : 1);
+                                SvPVCLEAR_FRESH(final);
 
                                 /* Create another string of sequences of \x{...} */
                                 while (av_count(this_string) > 0) {

--- a/sv.c
+++ b/sv.c
@@ -9765,8 +9765,9 @@ Perl_vnewSVpvf(pTHX_ const char *const pat, va_list *const args)
 
     PERL_ARGS_ASSERT_VNEWSVPVF;
 
-    new_SV(sv);
-    sv_vsetpvfn(sv, pat, strlen(pat), args, NULL, 0, NULL);
+    sv = newSV(1);
+    SvPVCLEAR_FRESH(sv);
+    sv_vcatpvfn_flags(sv, pat, strlen(pat), args, NULL, 0, NULL, 0);
     return sv;
 }
 

--- a/sv.h
+++ b/sv.h
@@ -2292,10 +2292,28 @@ existing size, but instead it is the total size C<sv> should be.
 Ensures that sv is a SVt_PV and that its SvCUR is 0, and that it is
 properly null terminated. Equivalent to sv_setpvs(""), but more efficient.
 
+=for apidoc Am|char *|SvPVCLEAR_FRESH|SV* sv
+
+Like SvPVCLEAR, but optimized for newly-minted SVt_PV/PVIV/PVNV/PVMG
+that already have a PV buffer allocated, but no SvTHINKFIRST.
+
 =cut
 */
 
 #define SvPVCLEAR(sv) sv_setpv_bufsize(sv,0,0)
+#define SvPVCLEAR_FRESH(sv)                             \
+        STMT_START {                                    \
+            assert(SvTYPE(sv) >= SVt_PV);               \
+            assert(SvTYPE(sv) <= SVt_PVMG);             \
+            assert(!SvTHINKFIRST(sv));                  \
+            assert(SvPVX(sv));                          \
+            SvCUR_set(sv, 0  );                         \
+            *(SvEND(sv))= '\0';                         \
+            (void)SvPOK_only_UTF8(sv);                  \
+            SvTAINT(sv);                                \
+            SvPVX(sv);                                  \
+        } STMT_END
+
 #define SvSHARE(sv) PL_sharehook(aTHX_ sv)
 #define SvLOCK(sv) PL_lockhook(aTHX_ sv)
 #define SvUNLOCK(sv) PL_unlockhook(aTHX_ sv)

--- a/toke.c
+++ b/toke.c
@@ -10777,7 +10777,6 @@ S_scan_heredoc(pTHX_ char *s)
 #endif
 
     tmpstr = newSV_type(SVt_PVIV);
-    SvGROW(tmpstr, 80);
     if (term == '\'') {
         op_type = OP_CONST;
         SvIV_set(tmpstr, -1);
@@ -10888,7 +10887,7 @@ S_scan_heredoc(pTHX_ char *s)
             goto interminable;
         }
 
-        sv_setpvn(tmpstr,d+1,s-d);
+        sv_setpvn_fresh(tmpstr,d+1,s-d);
         s += len - 1;
         /* the preceding stmt passes a newline */
         PL_parser->herelines++;
@@ -10935,6 +10934,7 @@ S_scan_heredoc(pTHX_ char *s)
         char *oldbufptr_save;
         char *oldoldbufptr_save;
       streaming:
+        sv_grow_fresh(tmpstr, 80);
         SvPVCLEAR(tmpstr);   /* avoid "uninitialized" warning */
         term = PL_tokenbuf[1];
         len--;

--- a/toke.c
+++ b/toke.c
@@ -10935,7 +10935,7 @@ S_scan_heredoc(pTHX_ char *s)
         char *oldoldbufptr_save;
       streaming:
         sv_grow_fresh(tmpstr, 80);
-        SvPVCLEAR(tmpstr);   /* avoid "uninitialized" warning */
+        SvPVCLEAR_FRESH(tmpstr);   /* avoid "uninitialized" warning */
         term = PL_tokenbuf[1];
         len--;
         linestr_save = PL_linestr; /* must restore this afterwards */


### PR DESCRIPTION
The 3 commits in this PR reflect the fact that calling generic function/macros on new SVs is often inefficient. 
* In `S_scan_heredoc`, `SvGROW` is replaced by `sv_grow_fresh` and `sv_setpvn` by `sv_setpvn_fresh`, depending upon the if/else branch.
* Also in `S_scan_heredoc`, `SvPVCLEAR` is inlined and simplified.
* In `S_regclass`, another `SvPVCLEAR` is inlined and simplified.