### PR TITLE
Mitigate unsafe threaded locales

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3382,6 +3382,21 @@ S	|const char*|update_PL_curlocales_i|const unsigned int index	\
 				    |recalc_lc_all_t recalc_LC_ALL
 S	|const char *|find_locale_from_environment|const unsigned int index
 #      endif
+#    else
+#      if   defined(USE_LOCALE_THREADS)					\
+       && ! defined(USE_THREAD_SAFE_LOCALE)				\
+       && ! defined(USE_THREAD_SAFE_LOCALE_EMULATION)
+S	|const char *|less_dicey_setlocale_r				\
+				|const int category			\
+				|NULLOK const char * locale
+S	|bool	|less_dicey_bool_setlocale_r				\
+				|const int cat				\
+				|NN const char * locale
+S	|void	|less_dicey_void_setlocale_i				\
+				|const unsigned cat_index		\
+				|NN const char * locale			\
+				|const line_t line
+#      endif
 #    endif
 #    if defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE)
 S	|const char *|calculate_LC_ALL|const locale_t cur_obj

--- a/embed.h
+++ b/embed.h
@@ -1527,6 +1527,17 @@
 #      endif
 #    endif
 #  endif
+#  if !(defined(USE_POSIX_2008_LOCALE))
+#    if defined(PERL_IN_LOCALE_C)
+#      if defined(USE_LOCALE)
+#        if defined(USE_LOCALE_THREADS)					       && ! defined(USE_THREAD_SAFE_LOCALE)				       && ! defined(USE_THREAD_SAFE_LOCALE_EMULATION)
+#define less_dicey_bool_setlocale_r(a,b)	S_less_dicey_bool_setlocale_r(aTHX_ a,b)
+#define less_dicey_setlocale_r(a,b)	S_less_dicey_setlocale_r(aTHX_ a,b)
+#define less_dicey_void_setlocale_i(a,b,c)	S_less_dicey_void_setlocale_i(aTHX_ a,b,c)
+#        endif
+#      endif
+#    endif
+#  endif
 #  if !(defined(_MSC_VER))
 #define magic_regdatum_set(a,b)	Perl_magic_regdatum_set(aTHX_ a,b)
 #  endif

--- a/locale.c
+++ b/locale.c
@@ -700,9 +700,11 @@ S_my_querylocale_i(pTHX_ const unsigned int index)
 
     DEBUG_Lv(PerlIO_printf(Perl_debug_log, "my_querylocale_i(%s) on %p\n",
                                            category_names[index], cur_obj));
-        if (cur_obj == LC_GLOBAL_LOCALE) {
+    if (cur_obj == LC_GLOBAL_LOCALE) {
+        POSIX_SETLOCALE_LOCK;
         retval = posix_setlocale(category, NULL);
-        }
+        POSIX_SETLOCALE_UNLOCK;
+    }
     else {
 
 #  ifdef USE_QUERYLOCALE
@@ -1212,6 +1214,7 @@ S_emulate_setlocale_i(pTHX_
 #    ifdef USE_PL_CURLOCALES
 
             if (entry_obj == LC_GLOBAL_LOCALE) {
+
                 /* Here, we are back in the global locale.  We may never have
                  * set PL_curlocales.  If the locale change had succeeded, the
                  * code would have then set them up, but since it didn't, do so
@@ -1219,11 +1222,13 @@ S_emulate_setlocale_i(pTHX_
                  * but tis is defensive coding.  The system setlocale() returns
                  * the desired information.  This will calculate LC_ALL's entry
                  * only on the final iteration */
+                POSIX_SETLOCALE_LOCK;
                 for (PERL_UINT_FAST8_T i = 0; i < NOMINAL_LC_ALL_INDEX; i++) {
                     update_PL_curlocales_i(i,
                                        posix_setlocale(categories[i], NULL),
                                        RECALCULATE_LC_ALL_ON_FINAL_INTERATION);
                 }
+                POSIX_SETLOCALE_UNLOCK;
             }
 #    endif
 

--- a/perl.h
+++ b/perl.h
@@ -7223,6 +7223,24 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #define gwLOCALE_LOCK    LOCALE_LOCK_(0)
 #define gwLOCALE_UNLOCK  LOCALE_UNLOCK_
 
+/* setlocale() generally returns in a global static buffer, but not on Windows
+ * when operating in thread-safe mode */
+#if defined(WIN32) && defined(USE_THREAD_SAFE_LOCALE)
+#  define POSIX_SETLOCALE_LOCK                                              \
+            STMT_START {                                                    \
+                if (_configthreadlocale(0) == _DISABLE_PER_THREAD_LOCALE)   \
+                    gwLOCALE_LOCK;                                          \
+            } STMT_END
+#  define POSIX_SETLOCALE_UNLOCK                                            \
+            STMT_START {                                                    \
+                if (_configthreadlocale(0) == _DISABLE_PER_THREAD_LOCALE)   \
+                    gwLOCALE_UNLOCK;                                        \
+            } STMT_END
+#else
+#  define POSIX_SETLOCALE_LOCK      gwLOCALE_LOCK
+#  define POSIX_SETLOCALE_UNLOCK    gwLOCALE_UNLOCK
+#endif
+
 #ifndef LC_NUMERIC_LOCK
 #  define LC_NUMERIC_LOCK(cond)   NOOP
 #  define LC_NUMERIC_UNLOCK       NOOP

--- a/perl.h
+++ b/perl.h
@@ -7148,15 +7148,9 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
                                     MUTEX_DESTROY(&PL_locale_mutex);        \
                                 } STMT_END
 #endif
-#if ! (   defined(USE_LOCALE)                                               \
+#if ! (   defined(USE_LOCALE)                                                 \
        &&    defined(USE_LOCALE_THREADS)                                    \
        && (  ! defined(USE_THREAD_SAFE_LOCALE)))
-
-/* The whole expression just above was complemented, so here we have no need
- * for thread synchronization, most likely it would be that this isn't a
- * threaded build. */
-#  define LOCALE_READ_LOCK          NOOP
-#  define LOCALE_READ_UNLOCK        NOOP
 #else
 
    /* Here, we will need critical sections in locale handling, because one or
@@ -7235,6 +7229,11 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  define SETLOCALE_LOCK                NOOP
 #  define SETLOCALE_UNLOCK              NOOP
 #endif
+
+/* Currently, the read lock is an exclusive lock */
+#define LOCALE_READ_LOCK                SETLOCALE_LOCK
+#define LOCALE_READ_UNLOCK              SETLOCALE_UNLOCK
+
 
 #ifndef LC_NUMERIC_LOCK
 #  define LC_NUMERIC_LOCK(cond)   NOOP

--- a/perl.h
+++ b/perl.h
@@ -7117,7 +7117,8 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 
      /* By definition, a thread-unsafe locale means we need a critical
       * section. */
-
+#    define SETLOCALE_LOCK   LOCALE_LOCK_(0)
+#    define SETLOCALE_UNLOCK LOCALE_UNLOCK_
 #    ifdef USE_LOCALE_NUMERIC
 #      define LC_NUMERIC_LOCK(cond_to_panic_if_already_locked)              \
                  LOCALE_LOCK_(cond_to_panic_if_already_locked)
@@ -7156,8 +7157,6 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
  * threaded build. */
 #  define LOCALE_READ_LOCK          NOOP
 #  define LOCALE_READ_UNLOCK        NOOP
-#  define SETLOCALE_LOCK            NOOP
-#  define SETLOCALE_UNLOCK          NOOP
 #else
 
    /* Here, we will need critical sections in locale handling, because one or
@@ -7189,16 +7188,6 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
     * modern platforms will have reentrant versions (which don't lock) for
     * almost all of them, so khw thinks a single mutex should suffice. */
 
-#  if defined(USE_THREAD_SAFE_LOCALE)
-
-     /* There may be instance core where we this is invoked yet should do
-      * nothing.  Rather than have #ifdef's around them, define it here */
-#    define SETLOCALE_LOCK    NOOP
-#    define SETLOCALE_UNLOCK  NOOP
-#  else
-#    define SETLOCALE_LOCK   LOCALE_LOCK_(0)
-#    define SETLOCALE_UNLOCK LOCALE_UNLOCK_
-#  endif
 #endif
 
 /* There are some locale-related functions which may need locking only because
@@ -7239,6 +7228,12 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #else
 #  define POSIX_SETLOCALE_LOCK      gwLOCALE_LOCK
 #  define POSIX_SETLOCALE_UNLOCK    gwLOCALE_UNLOCK
+#endif
+
+/* This was defined above for the case where locales aren't thread safe. */
+#ifndef SETLOCALE_LOCK
+#  define SETLOCALE_LOCK                NOOP
+#  define SETLOCALE_UNLOCK              NOOP
 #endif
 
 #ifndef LC_NUMERIC_LOCK

--- a/proto.h
+++ b/proto.h
@@ -4721,6 +4721,22 @@ STATIC const char *	S_calculate_LC_ALL(pTHX_ const char ** individ_locales);
 #    endif
 #  endif
 #endif
+#if !(defined(USE_POSIX_2008_LOCALE))
+#  if defined(PERL_IN_LOCALE_C)
+#    if defined(USE_LOCALE)
+#      if defined(USE_LOCALE_THREADS)					       && ! defined(USE_THREAD_SAFE_LOCALE)				       && ! defined(USE_THREAD_SAFE_LOCALE_EMULATION)
+STATIC bool	S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char * locale);
+#define PERL_ARGS_ASSERT_LESS_DICEY_BOOL_SETLOCALE_R	\
+	assert(locale)
+STATIC const char *	S_less_dicey_setlocale_r(pTHX_ const int category, const char * locale);
+#define PERL_ARGS_ASSERT_LESS_DICEY_SETLOCALE_R
+STATIC void	S_less_dicey_void_setlocale_i(pTHX_ const unsigned cat_index, const char * locale, const line_t line);
+#define PERL_ARGS_ASSERT_LESS_DICEY_VOID_SETLOCALE_I	\
+	assert(locale)
+#      endif
+#    endif
+#  endif
+#endif
 #if !(defined(_MSC_VER))
 PERL_CALLCONV_NO_RET int	Perl_magic_regdatum_set(pTHX_ SV* sv, MAGIC* mg)
 			__attribute__noreturn__


### PR DESCRIPTION
This series of commits lays the groundwork for, and then implements a new set of macros and functions to do locale changing and querying for platforms where perl is compiled with threads, but the platform doesn't have thread-safe locale handling.  These add a modicum of thread-safety to such platforms