### PR TITLE
locale.c: Refactor internal debugging function

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3423,10 +3423,12 @@ S	|const char*|my_langinfo_i|const int item			\
 				|NULLOK utf8ness_t * utf8ness
 #    endif
 #    ifdef DEBUGGING
-STR	|char *	|setlocale_debug_string_i|const unsigned cat_index	    \
-					|NULLOK const char* const locale    \
-					|NULLOK const char* const retval
 S	|const char *|get_LC_ALL_display
+SR	|char *	|my_setlocale_debug_string_i			\
+			    |const unsigned cat_index		\
+			    |NULLOK const char* locale		\
+			    |NULLOK const char* retval		\
+			    |const line_t line
 #    endif
 #  endif
 #  ifdef DEBUGGING

--- a/embed.h
+++ b/embed.h
@@ -1610,7 +1610,7 @@
 #define print_bytes_for_locale(a,b,c)	S_print_bytes_for_locale(aTHX_ a,b,c)
 #      if defined(USE_LOCALE)
 #define get_LC_ALL_display()	S_get_LC_ALL_display(aTHX)
-#define setlocale_debug_string_i	S_setlocale_debug_string_i
+#define my_setlocale_debug_string_i(a,b,c,d)	S_my_setlocale_debug_string_i(aTHX_ a,b,c,d)
 #        if defined(USE_LOCALE_COLLATE)
 #define print_collxfrm_input_and_return(a,b,c,d,e)	S_print_collxfrm_input_and_return(aTHX_ a,b,c,d,e)
 #        endif

--- a/locale.c
+++ b/locale.c
@@ -179,6 +179,8 @@ static const char C_thousands_sep[] = "";
 #ifdef USE_LOCALE
 
 #  ifdef DEBUGGING
+#    define setlocale_debug_string_i(index, locale, result)                 \
+            my_setlocale_debug_string_i(index, locale, result, __LINE__)
 #    define setlocale_debug_string_c(category, locale, result)              \
                 setlocale_debug_string_i(category##_INDEX_, locale, result)
 #    define setlocale_debug_string_r(category, locale, result)              \
@@ -6480,48 +6482,58 @@ Perl_sync_locale()
 #if defined(DEBUGGING) && defined(USE_LOCALE)
 
 STATIC char *
-S_setlocale_debug_string_i(const unsigned cat_index,
-                           const char* const locale, /* Optional locale name */
+S_my_setlocale_debug_string_i(pTHX_
+                              const unsigned cat_index,
+                              const char* locale, /* Optional locale name */
 
-                            /* return value from setlocale() when attempting to
-                             * set 'category' to 'locale' */
-                            const char* const retval)
+                              /* return value from setlocale() when attempting
+                               * to set 'category' to 'locale' */
+                              const char* retval,
+
+                              const line_t line)
 {
     /* Returns a pointer to a NUL-terminated string in static storage with
      * added text about the info passed in.  This is not thread safe and will
      * be overwritten by the next call, so this should be used just to
      * formulate a string to immediately print or savepv() on. */
 
-    static char ret[1024];
+    const char * locale_quote;
+    const char * retval_quote;
+
     assert(cat_index <= NOMINAL_LC_ALL_INDEX);
 
-    my_strlcpy(ret, "setlocale(", sizeof(ret));
-    my_strlcat(ret, category_names[cat_index], sizeof(ret));
-    my_strlcat(ret, ", ", sizeof(ret));
-
-    if (locale) {
-        my_strlcat(ret, "\"", sizeof(ret));
-        my_strlcat(ret, locale, sizeof(ret));
-        my_strlcat(ret, "\"", sizeof(ret));
+    if (locale == NULL) {
+        locale_quote = "";
+        locale = "NULL";
     }
     else {
-        my_strlcat(ret, "NULL", sizeof(ret));
+        locale_quote = "\"";
     }
 
-    my_strlcat(ret, ") returned ", sizeof(ret));
-
-    if (retval) {
-        my_strlcat(ret, "\"", sizeof(ret));
-        my_strlcat(ret, retval, sizeof(ret));
-        my_strlcat(ret, "\"", sizeof(ret));
+    if (retval == NULL) {
+        retval_quote = "";
+        retval = "NULL";
     }
     else {
-        my_strlcat(ret, "NULL", sizeof(ret));
+        retval_quote = "\"";
     }
 
-    assert(strlen(ret) < sizeof(ret));
+#  ifdef USE_LOCALE_THREADS
+#    define THREAD_FORMAT "%p:"
+#    define THREAD_ARGUMENT aTHX_
+#  else
+#    define THREAD_FORMAT
+#    define THREAD_ARGUMENT
+#  endif
 
-    return ret;
+    return Perl_form(aTHX_
+                     "%s:%" LINE_Tf ":" THREAD_FORMAT
+                     " setlocale(%s[%d], %s%s%s) returned %s%s%s\n",
+
+                     __FILE__, line, THREAD_ARGUMENT
+                     category_names[cat_index], categories[cat_index],
+                     locale_quote, locale, locale_quote,
+                     retval_quote, retval, retval_quote);
 }
 
 #endif

--- a/makedef.pl
+++ b/makedef.pl
@@ -294,7 +294,6 @@ unless ($define{'DEBUGGING'}) {
 		    Perl_debstackptrs
 		    Perl_pad_sv
 		    Perl_pad_setsv
-                    Perl__setlocale_debug_string
 		    Perl_set_padlist
 		    Perl_hv_assert
 		    PL_watchaddr

--- a/proto.h
+++ b/proto.h
@@ -5098,9 +5098,9 @@ STATIC void	S_print_bytes_for_locale(pTHX_ const char * const s, const char * co
 #    if defined(USE_LOCALE)
 STATIC const char *	S_get_LC_ALL_display(pTHX);
 #define PERL_ARGS_ASSERT_GET_LC_ALL_DISPLAY
-STATIC char *	S_setlocale_debug_string_i(const unsigned cat_index, const char* const locale, const char* const retval)
+STATIC char *	S_my_setlocale_debug_string_i(pTHX_ const unsigned cat_index, const char* locale, const char* retval, const line_t line)
 			__attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_SETLOCALE_DEBUG_STRING_I
+#define PERL_ARGS_ASSERT_MY_SETLOCALE_DEBUG_STRING_I
 
 #      if defined(USE_LOCALE_COLLATE)
 STATIC void	S_print_collxfrm_input_and_return(pTHX_ const char * s, const char * e, const char * xbuf, const STRLEN xlen, const bool is_utf8);


### PR DESCRIPTION
setlocale_debug_string() variants  now use Perl_form, a function I
didn't know existed when I originally wrote this code.