### PR TITLE
re/pat_advanced.t: remove `todo_skip` from test

### DIFF
--- a/t/re/pat_advanced.t
+++ b/t/re/pat_advanced.t
@@ -2379,9 +2379,7 @@ EOF
         ok(1, $message);  # If it didn't crash, it worked.
     }
 
-    TODO: {   # Was looping
-        todo_skip('Triggers thread clone SEGV. See #86550')
-	  if $::running_as_thread && $::running_as_thread;
+    {   # Was looping
         watchdog(10);
         like("\x{00DF}", qr/[\x{1E9E}_]*/i, "\"\\x{00DF}\" =~ /[\\x{1E9E}_]*/i was looping");
     }


### PR DESCRIPTION
This test is skipped when running as threads (i.e. via t/re/pat_advanced_thr.t) since 20 Mar 2011 (commit 2feceb76bc07c8978188ab67f91851845258b0e1) because of a bug.

That bug `[perl #86550]` is GH #7533 and that was fixed in Oct 2015 with commit 0ee3fa26f660ac426e3e082f77d806c9d1471f93.

So I think it's safe to remove the `todo_skip` since the bug for why it was skipped looks resolved. (A smoke-me branch also revealed no unexpected problems)