### PR TITLE
Compile anonymous subs as anoncode without srefgen.

### DIFF
--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -877,6 +877,13 @@ my $f = sub {
     +{[]};
 } ;
 ####
+# anonconst
+# CONTEXT no warnings 'experimental::const_attr';
+my $f = sub : const {
+    123;
+}
+;
+####
 # bug #43010
 '!@$%'->();
 ####


### PR DESCRIPTION
Heretofore the compiler represented an anonymous subroutine as an anoncode op then an srefgen op; the latter’s only purpose was to return a reference to the anoncode’s returned CV.

This changeset slightly optimizes that by making pp_anoncode return a reference if so bidden. The same optimization is applied to pp_anonconst as well.

Hat-tip to @leonerd for the suggestion and guidance.