### PR TITLE
CI improvements (testsuite.yaml)

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -520,7 +520,7 @@ jobs:
         # complete all CI runs.
         run: |
           cd ~/work
-          PATH=`pwd`:.:$PATH ./perl.exe t/TEST
+          PATH=`pwd`:.:$PATH TEST_JOBS=2 ./perl.exe t/harness
 
   #            _       _ _            _
   #  _ __ ___ (_)_ __ (_) |_ ___  ___| |_

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -215,7 +215,13 @@ jobs:
         run: |
           apt-get update
           apt-get install -y build-essential git-core libgdbm-dev libdb-dev
-      # actions/checkout@v2 doesn't work in a container, so we use v1.
+      # actions/checkout@v2 doesn't work in a i386 container: the GitHub runner
+      # uses `node` that is installed on the host inside the container. The host
+      # is (likely) running x86_64 and using a binary build for x86_64 inside a
+      # i386 container just doesn't work.
+      # Upstream reports:
+      # - https://github.com/actions/checkout/issues/334#issuecomment-1241306390
+      # - https://github.com/actions/runner/issues/2115
       - uses: actions/checkout@v1
       - name: fix git remote credential
         run: |

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -469,13 +469,12 @@ jobs:
           git config --global core.autocrlf false
           mkdir -p ~
           cd ~
-          git clone -qn "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" work
+          git init work
           cd work
-          if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
-              git fetch origin "$GITHUB_REF" && git checkout FETCH_HEAD
-          else
-              git checkout "$GITHUB_SHA"
-          fi
+          git remote add origin "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY"
+          git config --local gc.auto 0
+          git fetch origin --depth=1 "$GITHUB_SHA"
+          git checkout "$GITHUB_SHA"
       - name: Configure
         shell: sh
         env:

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -462,28 +462,51 @@ jobs:
       - name: Check out using Cygwin git, to ensure correct file permissions
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: cmd
+          PATH: /usr/bin:/bin
+          SHELLOPTS: igncr
+        shell: sh
         run: |
-          path %GITHUB_WORKSPACE%\cygwin\bin;%GITHUB_WORKSPACE%\cygwin\usr\bin
-          sh -c "git config --global core.autocrlf false"
-          sh -c "mkdir -p ~; cd ~; git clone -qn \"https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY\" work ; cd work ; if [ \"$GITHUB_EVENT_NAME\" = pull_request ] ; then git fetch origin \"$GITHUB_REF\" && git checkout FETCH_HEAD ; else  git checkout \"$GITHUB_SHA\" ; fi"
+          git config --global core.autocrlf false
+          mkdir -p ~
+          cd ~
+          git clone -qn "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" work
+          cd work
+          if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
+              git fetch origin "$GITHUB_REF" && git checkout FETCH_HEAD
+          else
+              git checkout "$GITHUB_SHA"
+          fi
       - name: Configure
-        shell: cmd
+        shell: sh
+        env:
+          PATH: /usr/bin:/bin
+          SHELLOPTS: igncr
         run: |
-          path %GITHUB_WORKSPACE%\cygwin\bin;%GITHUB_WORKSPACE%\cygwin\usr\bin
-          sh -c "cd ~/work; ./Configure -des -Dusedevel -Doptimize=-g -DDEBUGGING"
+          cd ~/work
+          set +e
+          ./Configure -des -Dusedevel -Doptimize=-g -DDEBUGGING || exit 1
       - name: Build
-        shell: cmd
+        shell: sh
+        env:
+          PATH: /usr/bin:/bin
+          SHELLOPTS: igncr
         run: |
-          path %GITHUB_WORKSPACE%\cygwin\bin;%GITHUB_WORKSPACE%\cygwin\usr\bin
-          sh -c "cd ~/work; make -j2 test_prep"
+          cd ~/work
+          make -j2 test_prep
       - name: Show Config
-        shell: cmd
+        shell: sh
+        env:
+          PATH: /usr/bin:/bin
+          SHELLOPTS: igncr
         run: |
-          path %GITHUB_WORKSPACE%\cygwin\bin;%GITHUB_WORKSPACE%\cygwin\usr\bin
-          sh -c "cd ~/work; ./perl -Ilib -V; ./perl -Ilib -e 'use Config; print Config::config_sh'"
+          cd ~/work
+          ./perl -Ilib -V
+          ./perl -Ilib -e 'use Config; print Config::config_sh'
       - name: Run Tests
-        shell: cmd
+        shell: sh
+        env:
+          PATH: /usr/bin:/bin
+          SHELLOPTS: igncr
         # Descend far enough down the cygwin yak warren, and one discovers that
         # hints/cygwin.sh sets ldlibpthname=PATH
         # Meaning that the Makefile variable LDLIBPTH is "PATH=..."
@@ -496,8 +519,8 @@ jobs:
         # about 40 seconds, which is nearly 1% of the total wallclock time for
         # complete all CI runs.
         run: |
-          path %GITHUB_WORKSPACE%\cygwin\bin;%GITHUB_WORKSPACE%\cygwin\usr\bin
-          sh -c "cd ~/work; PATH=`pwd`:.:$PATH ./perl.exe t/TEST"
+          cd ~/work
+          PATH=`pwd`:.:$PATH ./perl.exe t/TEST
 
   #            _       _ _            _
   #  _ __ ___ (_)_ __ (_) |_ ___  ___| |_

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -223,14 +223,10 @@ jobs:
       # - https://github.com/actions/checkout/issues/334#issuecomment-1241306390
       # - https://github.com/actions/runner/issues/2115
       - uses: actions/checkout@v1
-      - name: fix git remote credential
+      - name: git cfg
         run: |
           git config --global --add safe.directory /__w/perl5/perl5
-          git remote set-url origin "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
-      - name: git cfg + fetch tags
-        run: |
           git config diff.renameLimit 999999
-          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Configure
         run: |
           ./Configure -des -Dusedevel ${{ matrix.CONFIGURE_ARGS }} -Dprefix="$HOME/perl-blead"

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -223,6 +223,8 @@ jobs:
       # - https://github.com/actions/checkout/issues/334#issuecomment-1241306390
       # - https://github.com/actions/runner/issues/2115
       - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
       - name: git cfg
         run: |
           git config --global --add safe.directory /__w/perl5/perl5

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -164,10 +164,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v2
-      - name: git cfg + fetch tags
+      - name: git cfg
         run: |
           git config diff.renameLimit 999999
-          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Configure
         run: |
           ./Configure -des -Dusedevel ${{ matrix.CONFIGURE_ARGS }} -Dprefix="$HOME/perl-blead" -DDEBUGGING
@@ -261,10 +260,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v2
-      - name: git cfg + fetch tags
+      - name: git cfg
         run: |
           git config diff.renameLimit 999999
-          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Configure
         run: |
           ./Configure -des -Dusedevel -Duseshrplib -Dusesitecustomize -Duselongdouble -Dprefix="$HOME/perl-blead" -DDEBUGGING
@@ -523,10 +521,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v2
-      - name: git cfg + fetch tags
+      - name: git cfg
         run: |
           git config diff.renameLimit 999999
-          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: manicheck
         run: |
           perl Porting/manicheck --exitstatus
@@ -575,10 +572,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v2
-      - name: git cfg + fetch tags
+      - name: git cfg
         run: |
           git config diff.renameLimit 999999
-          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Configure
         run: |
           ./Configure -des -Dusedevel -Dcc="clang -fsanitize=address" -Dld="clang -fsanitize=address" ${{ matrix.CONFIGURE_ARGS }} -Dprefix="$HOME/perl-blead"
@@ -624,10 +620,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v2
-      - name: git cfg + fetch tags
+      - name: git cfg
         run: |
           git config diff.renameLimit 999999
-          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Show Locales
         run: locale -a
       - name: Configure


### PR DESCRIPTION
For details see the commit messages,

The highlights:
- remove `git fetch --tags` [it didn't work]
- cygwin: cleanup `run`-blocks
- cygwin: use t/harness with 2 jobs (instead of t/TEST)
- cygwin+linux-I386; use shallow clone like the other CI configs
