### PR TITLE
Fix t/porting/authors.t breakgage for people with non-ASCII names

### DIFF
--- a/Porting/updateAUTHORS.pl
+++ b/Porting/updateAUTHORS.pl
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(GetOptions);
 use Pod::Usage qw(pod2usage);
 use Data::Dumper;
-use Encode qw(encode_utf8 decode_utf8 decode);
+use Encode qw(encode_utf8 decode_utf8);
 use lib "./";
 use Porting::updateAUTHORS;
 use Test::More;
@@ -292,7 +292,7 @@ sub error_advice_for_uncommitted_changes {
     }
 
     my $quote= $^O =~ /Win/ ? '"' : "'";
-    my @config=
+    my @config= map decode_utf8($_),
         `git config --get-regexp $quote^(user|author|committer).(name|email)$quote`;
     if (@config) {
 
@@ -337,7 +337,7 @@ EOF_EXTRA
 EOF_PROPS
     }
 
-    return <<"EOF_MESAGE";
+    return encode_utf8 <<"EOF_MESAGE";
 
 There are uncommitted changes in the working directory
 $uncommitted_files

--- a/Porting/updateAUTHORS.pm
+++ b/Porting/updateAUTHORS.pm
@@ -111,7 +111,7 @@ sub _register_author {
 sub git_conf_get {
     my ($self, $setting)= @_;
     chomp(my $value= `git config --get $setting`);
-    return $value;
+    return decode_utf8 $value;
 }
 
 sub current_git_user_name {


### PR DESCRIPTION
The lack of decoding of git config values in Porting/updateAUTHORS.pm would make it erroneously claim that anyone with a non-ASCII character in their name was an unknown author.

The decoding and encoding in updateAUTHORS.pl is not strictly necessary, since that's just passing things through to the terminal, but let's be consistent.