### PR TITLE
Revert "Don't use POSIX 2008 locales on cygwin"

### DIFF
--- a/cygwin/cygwin.c
+++ b/cygwin/cygwin.c
@@ -160,7 +160,6 @@ leave:
 char*
 wide_to_utf8(const wchar_t *wbuf)
 {
-    dTHX;
     char *buf;
     int wlen = 0;
     char *oldlocale;
@@ -189,7 +188,6 @@ wide_to_utf8(const wchar_t *wbuf)
 wchar_t*
 utf8_to_wide(const char *buf)
 {
-    dTHX;
     wchar_t *wbuf;
     mbstate_t mbs;
     char *oldlocale;

--- a/hints/cygwin.sh
+++ b/hints/cygwin.sh
@@ -95,6 +95,3 @@ lddlflags="$lddlflags $ldflags"
 # it still doesn't work, despite our probes looking good:
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64697
 d_thread_local=undef
-
-# Broken: https://sourceware.org/pipermail/cygwin/2022-August/252043.html */
-d_newlocale=undef


### PR DESCRIPTION
This reverts commit 5ee7770b70fd48652f905014e47b07eb031ed5bc.

Claimed to be and apparently fixed:
 https://cygwin.com/pipermail/cygwin/2022-September/252178.html