### PR TITLE
Small docs clarification on MRO resolve function

### DIFF
--- a/ext/mro/mro.pm
+++ b/ext/mro/mro.pm
@@ -12,7 +12,7 @@ use warnings;
 
 # mro.pm versions < 1.00 reserved for MRO::Compat
 #  for partial back-compat to 5.[68].x
-our $VERSION = '1.26';
+our $VERSION = '1.27';
 
 require XSLoader;
 XSLoader::load('mro');

--- a/ext/mro/mro.xs
+++ b/ext/mro/mro.xs
@@ -14,7 +14,8 @@ static const struct mro_alg c3_alg =
 =for apidoc mro_get_linear_isa_c3
 
 Returns the C3 linearization of C<@ISA>
-the given stash.  The return value is a read-only AV*.
+the given stash.  The return value is a read-only AV*
+whose values are string SVs giving class names.
 C<level> should be 0 (it is used internally in this
 function's recursion).
 

--- a/mro_core.c
+++ b/mro_core.c
@@ -216,7 +216,8 @@ Perl_mro_meta_dup(pTHX_ struct mro_meta* smeta, CLONE_PARAMS* param)
 =for apidoc mro_get_linear_isa_dfs
 
 Returns the Depth-First Search linearization of C<@ISA>
-the given stash.  The return value is a read-only AV*.
+the given stash.  The return value is a read-only AV*
+whose elements are string SVs giving class names.
 C<level> should be 0 (it is used internally in this
 function's recursion).
 
@@ -399,7 +400,7 @@ S_mro_get_linear_isa_dfs(pTHX_ HV *stash, U32 level)
 Returns the mro linearisation for the given stash.  By default, this
 will be whatever C<mro_get_linear_isa_dfs> returns unless some
 other MRO is in effect for the stash.  The return value is a
-read-only AV*.
+read-only AV* whose values are string SVs giving class names.
 
 You are responsible for C<SvREFCNT_inc()> on the
 return value if you plan to store it anywhere

--- a/pod/perlmroapi.pod
+++ b/pod/perlmroapi.pod
@@ -57,10 +57,10 @@ a I<level> of 0. The core always sets I<level> to 0 when it calls your
 function - the parameter is provided to allow your implementation to track
 depth if it needs to recurse.
 
-The function should return a reference to an array containing the parent
-classes in order. The names of the classes should be the result of calling
-C<HvENAME()> on the stash. In those cases where C<HvENAME()> returns null,
-C<HvNAME()> should be used instead.
+The function should return a reference to an array containing string SVs
+giving the names of parent classes in order. The names of the classes should
+be the result of calling C<HvENAME()> on the stash. In those cases where
+C<HvENAME()> returns null, C<HvNAME()> should be used instead.
 
 The caller is responsible for incrementing the reference count of the array
 returned if it wants to keep the structure. Hence, if you have created a


### PR DESCRIPTION
Points out that the linear MRO function returns a list of strings.

Before this it wasn't clear to me whether it's a list of string names, or actual HV pointers to stashes.