### PR TITLE
Add option to select which CI jobs to run (in a fork)

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -1,3 +1,19 @@
+#
+# Run the tests on various build configurations and various operating systems.
+#
+# In the Perl/perl5 repository all jobs are run by default.
+#
+# To enable the testing on a fork of the perl5 repository you first need to
+# enable GitHub Actions in 'Settings' -> 'Actions' -> 'General'.
+#
+# When actions are enabled then it will - by default - run the 'Sanity Check' job.
+#
+# Testing other build configurations is controlled by the 'Secrets' configured
+# in 'Settings' -> 'Secrets' -> 'Actions' -> 'Repository Secrets':
+#   - EXTENDED_TESTING: when this secret exists (value is irrelevant) then all
+#     build configurations are tested;
+#
+
 name: testsuite
 
 on:

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -10,8 +10,23 @@
 #
 # Testing other build configurations is controlled by the 'Secrets' configured
 # in 'Settings' -> 'Secrets' -> 'Actions' -> 'Repository Secrets':
-#   - EXTENDED_TESTING: when this secret exists (value is irrelevant) then all
-#     build configurations are tested;
+#   - EXTENDED_TESTING: when this secret exists and is set to a true value then
+#     all build configurations are tested;
+#
+# For the purpose of this workflow:
+#   - 'true value': any value that is not false
+#   - 'false value':
+#      * empty string
+#      * string containing only spaces (i.e. '    ')
+#      * string containing only zeroes (i.e. '0', '0000')
+#      * string containing only spaces and zeroes (i.e. '0  0 0 0')
+#
+# When setting a value it's best to set a long and complex value
+# since GitHub will mask the secrets in the output. Which means if you
+# set (for example) EXTENDED_TESTING to 1 then all occurrences of '1'
+# are replaced with '*'. (e.g. `s/1/*/g;`). So it's recommended to set
+# something that is unlikely to occur in the job(/build/test) output
+# (for example: '111111111111111111', 'Rumpelstiltskin', ...).
 #
 
 name: testsuite
@@ -139,7 +154,7 @@ jobs:
           if [[ "${CURRENT_REPOSITORY}" = 'Perl/perl5' ]]; then
             echo "Running all test jobs"
             echo "::set-output name=run_all_jobs::true"
-          elif [[ -n "${EXTENDED_TESTING}" ]]; then
+          elif [[ -n "${EXTENDED_TESTING}" ]] && [[ "${EXTENDED_TESTING%[!0 ]*}" != "${EXTENDED_TESTING}" ]]; then
             echo "Running all test jobs"
             echo "::set-output name=run_all_jobs::true"
           else

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -129,7 +129,7 @@ jobs:
           fi
 
       - name: Run Porting Tests (t/porting)
-        if: always() && steps.build.outcome == 'success'
+        if: (! cancelled() && steps.build.outcome == 'success')
         run: |
           TEST_JOBS=2 ./perl t/harness -re='^porting/'
 
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs: sanity_check
-    if: always() && needs.sanity_check.outputs.run_all_jobs == 'true'
+    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
 
     strategy:
       fail-fast: false
@@ -198,7 +198,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs: sanity_check
-    if: always() && needs.sanity_check.outputs.run_all_jobs == 'true'
+    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
 
     # https://hub.docker.com/r/i386/ubuntu/
     container:
@@ -256,7 +256,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs: sanity_check
-    if: always() && needs.sanity_check.outputs.run_all_jobs == 'true'
+    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
 
     steps:
       - name: Install System dependencies
@@ -305,7 +305,7 @@ jobs:
     runs-on: macos-10.15
     timeout-minutes: 120
     needs: sanity_check
-    if: always() && needs.sanity_check.outputs.run_all_jobs == 'true'
+    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
 
     strategy:
       fail-fast: false
@@ -341,7 +341,7 @@ jobs:
     runs-on: windows-2019
     timeout-minutes: 120
     needs: sanity_check
-    if: always() && needs.sanity_check.outputs.run_all_jobs == 'true'
+    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
 
     steps:
       - run: git config --global core.autocrlf false
@@ -397,7 +397,7 @@ jobs:
     runs-on: windows-2019
     timeout-minutes: 120
     needs: sanity_check
-    if: always() && needs.sanity_check.outputs.run_all_jobs == 'true'
+    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
 
     steps:
       - run: git config --global core.autocrlf false
@@ -447,7 +447,7 @@ jobs:
     runs-on: windows-2019
     timeout-minutes: 120
     needs: sanity_check
-    if: always() && needs.sanity_check.outputs.run_all_jobs == 'true'
+    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
 
     steps:
       # we use Cygwin git, so no need to configure git here.
@@ -532,7 +532,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs: sanity_check
-    if: always() && needs.sanity_check.outputs.run_all_jobs == 'true'
+    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
 
     outputs:
       run_all_jobs: ${{ steps.check_extended_testing.outputs.run_all_jobs }}
@@ -580,7 +580,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs: sanity_check
-    if: always() && needs.sanity_check.outputs.run_all_jobs == 'true'
+    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
 
     strategy:
       matrix:
@@ -630,7 +630,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs: sanity_check
-    if: always() && needs.sanity_check.outputs.run_all_jobs == 'true'
+    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
 
     strategy:
       matrix:
@@ -676,7 +676,7 @@ jobs:
     name: dist-modules
     needs: sanity_check
     runs-on: ubuntu-latest
-    if: always() && needs.sanity_check.outputs.run_all_jobs == 'true'
+    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
 
     env:
       # some plugins still needs this to run their tests...

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -676,7 +676,7 @@ jobs:
     name: dist-modules
     needs: sanity_check
     runs-on: ubuntu-latest
-    if: needs.sanity_check.outputs.run_all_jobs == 'true'
+    if: always() && needs.sanity_check.outputs.run_all_jobs == 'true'
 
     env:
       # some plugins still needs this to run their tests...

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -12,6 +12,18 @@
 # in 'Settings' -> 'Secrets' -> 'Actions' -> 'Repository Secrets':
 #   - EXTENDED_TESTING: when this secret exists and is set to a true value then
 #     all build configurations are tested;
+#   - CI_SKIP_SANITY: if set to a true value then most of the 'Sanity Check' job is skipped;
+#   - CI_FORCE_LINUX: if set to a true value: run the 'linux' job;
+#   - CI_FORCE_LINUX_I386: if set to a true value: run the 'linux-i386' job;
+#   - CI_FORCE_INSTALL: if set to a true value: run the 'install' job;
+#   - CI_FORCE_MACOS: if set to a true value: run the 'smoke-macos-catalina-xcode12' job;
+#   - CI_FORCE_MSVC142: if set to a true value: run the 'windows-msvc142' job;
+#   - CI_FORCE_MINGW64: if set to a true value: run the 'mingw64' job;
+#   - CI_FORCE_CYGWIN: if set to a true value: run the 'cygwin' job;
+#   - CI_FORCE_MINITEST: if set to a true value: run the 'miniperl' job;
+#   - CI_FORCE_ASAN: if set to a true value: run the 'ASAN' job;
+#   - CI_FORCE_PERL_UNICODE: if set to a true value: run the 'PERL_UNICODE' job;
+#   - CI_FORCE_DIST_MODULES: if set to a true value: run the 'dist-modules' job;
 #
 # For the purpose of this workflow:
 #   - 'true value': any value that is not false
@@ -27,6 +39,12 @@
 # are replaced with '*'. (e.g. `s/1/*/g;`). So it's recommended to set
 # something that is unlikely to occur in the job(/build/test) output
 # (for example: '111111111111111111', 'Rumpelstiltskin', ...).
+#
+# Example: if you only want to run tests on cygwin then you can set:
+#   - EXTENDED_TESTING=00000000000000000000000000000000000000
+#   - CI_SKIP_SANITY=1111111111111111111111111111111111111111
+#   - CI_FORCE_CYGWIN=111111111111111111111111111111111111111
+#   - (and all other CI_FORCE_... secrets to 0000000000000000)
 #
 
 name: testsuite
@@ -111,36 +129,84 @@ jobs:
 
     outputs:
       run_all_jobs: ${{ steps.check_extended_testing.outputs.run_all_jobs }}
+      ci_force_linux: ${{ steps.ci_config.outputs.ci_force_linux }}
+      ci_force_linux_i386: ${{ steps.ci_config.outputs.ci_force_linux_i386 }}
+      ci_force_install: ${{ steps.ci_config.outputs.ci_force_install }}
+      ci_force_macos: ${{ steps.ci_config.outputs.ci_force_macos }}
+      ci_force_msvc142: ${{ steps.ci_config.outputs.ci_force_msvc142 }}
+      ci_force_mingw64: ${{ steps.ci_config.outputs.ci_force_mingw64 }}
+      ci_force_cygwin: ${{ steps.ci_config.outputs.ci_force_cygwin }}
+      ci_force_minitest: ${{ steps.ci_config.outputs.ci_force_minitest }}
+      ci_force_asan: ${{ steps.ci_config.outputs.ci_force_asan }}
+      ci_force_perl_unicode: ${{ steps.ci_config.outputs.ci_force_perl_unicode }}
+      ci_force_dist_modules: ${{ steps.ci_config.outputs.ci_force_dist_modules }}
 
     steps:
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
+      - name: Check what-to-do
+        id: ci_config
+        env:
+          CI_SKIP_SANITY: ${{ secrets.CI_SKIP_SANITY }}
+          CI_FORCE_LINUX: ${{ secrets.CI_FORCE_LINUX }}
+          CI_FORCE_LINUX_I386: ${{ secrets.CI_FORCE_LINUX_I386 }}
+          CI_FORCE_INSTALL: ${{ secrets.CI_FORCE_INSTALL }}
+          CI_FORCE_MACOS: ${{ secrets.CI_FORCE_MACOS }}
+          CI_FORCE_MSVC142: ${{ secrets.CI_FORCE_MSVC142 }}
+          CI_FORCE_MINGW64: ${{ secrets.CI_FORCE_MINGW64 }}
+          CI_FORCE_CYGWIN: ${{ secrets.CI_FORCE_CYGWIN }}
+          CI_FORCE_MINITEST: ${{ secrets.CI_FORCE_MINITEST }}
+          CI_FORCE_ASAN: ${{ secrets.CI_FORCE_ASAN }}
+          CI_FORCE_PERL_UNICODE: ${{ secrets.CI_FORCE_PERL_UNICODE }}
+          CI_FORCE_DIST_MODULES: ${{ secrets.CI_FORCE_DIST_MODULES }}
+        run: |
+          echo '::echo::on'
+          [[ -n "${CI_SKIP_SANITY}"        ]] && [[ "${CI_SKIP_SANITY%[!0 ]*}"        != "${CI_SKIP_SANITY}"        ]] && echo "::set-output name=ci_skip_sanity::true"
+          [[ -n "${CI_FORCE_LINUX}"        ]] && [[ "${CI_FORCE_LINUX%[!0 ]*}"        != "${CI_FORCE_LINUX}"        ]] && echo "::set-output name=ci_force_linux::true"
+          [[ -n "${CI_FORCE_LINUX_I386}"   ]] && [[ "${CI_FORCE_LINUX_I386%[!0 ]*}"   != "${CI_FORCE_LINUX_I386}"   ]] && echo "::set-output name=ci_force_linux_i386::true"
+          [[ -n "${CI_FORCE_INSTALL}"      ]] && [[ "${CI_FORCE_INSTALL%[!0 ]*}"      != "${CI_FORCE_INSTALL}"      ]] && echo "::set-output name=ci_force_install::true"
+          [[ -n "${CI_FORCE_MACOS}"        ]] && [[ "${CI_FORCE_MACOS%[!0 ]*}"        != "${CI_FORCE_MACOS}"        ]] && echo "::set-output name=ci_force_macos::true"
+          [[ -n "${CI_FORCE_MSVC142}"      ]] && [[ "${CI_FORCE_MSVC142%[!0 ]*}"      != "${CI_FORCE_MSVC142}"      ]] && echo "::set-output name=ci_force_msvc142::true"
+          [[ -n "${CI_FORCE_MINGW64}"      ]] && [[ "${CI_FORCE_MINGW64%[!0 ]*}"      != "${CI_FORCE_MINGW64}"      ]] && echo "::set-output name=ci_force_mingw64::true"
+          [[ -n "${CI_FORCE_CYGWIN}"       ]] && [[ "${CI_FORCE_CYGWIN%[!0 ]*}"       != "${CI_FORCE_CYGWIN}"       ]] && echo "::set-output name=ci_force_cygwin::true"
+          [[ -n "${CI_FORCE_MINITEST}"     ]] && [[ "${CI_FORCE_MINITEST%[!0 ]*}"     != "${CI_FORCE_MINITEST}"     ]] && echo "::set-output name=ci_force_minitest::true"
+          [[ -n "${CI_FORCE_ASAN}"         ]] && [[ "${CI_FORCE_ASAN%[!0 ]*}"         != "${CI_FORCE_ASAN}"         ]] && echo "::set-output name=ci_force_asan::true"
+          [[ -n "${CI_FORCE_PERL_UNICODE}" ]] && [[ "${CI_FORCE_PERL_UNICODE%[!0 ]*}" != "${CI_FORCE_PERL_UNICODE}" ]] && echo "::set-output name=ci_force_perl_unicode::true"
+          [[ -n "${CI_FORCE_DIST_MODULES}" ]] && [[ "${CI_FORCE_DIST_MODULES%[!0 ]*}" != "${CI_FORCE_DIST_MODULES}" ]] && echo "::set-output name=ci_force_dist_modules::true"
+          echo '::echo::off'
       - name: Install System dependencies
+        if: steps.ci_config.outputs.ci_skip_sanity != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+        if: steps.ci_config.outputs.ci_skip_sanity != 'true'
       - name: git cfg
+        if: steps.ci_config.outputs.ci_skip_sanity != 'true'
         run: |
           git config diff.renameLimit 999999
       - name: Configure
+        if: steps.ci_config.outputs.ci_skip_sanity != 'true'
         run: |
           ./Configure -des -Dusedevel ${CONFIGURE_ARGS} -Dprefix="$HOME/perl-blead"
         env:
           CONFIGURE_ARGS: "-Dusethreads"
       - name: Build
+        if: steps.ci_config.outputs.ci_skip_sanity != 'true'
         id: build
         run: |
           make -j2 test_prep
       - name: Show Config
+        if: steps.ci_config.outputs.ci_skip_sanity != 'true'
         run: |
           ./perl -Ilib -V
           ./perl -Ilib -e 'use Config; print Config::config_sh'
       - name: Run Tests (excluding t/porting)
+        if: steps.ci_config.outputs.ci_skip_sanity != 'true'
         run: |
           TEST_JOBS=2 ./perl t/harness -nre='^porting/'
 
@@ -163,7 +229,7 @@ jobs:
           fi
 
       - name: Run Porting Tests (t/porting)
-        if: (! cancelled() && steps.build.outcome == 'success')
+        if: (! cancelled() && steps.ci_config.outputs.ci_skip_sanity != 'true' && steps.build.outcome == 'success')
         run: |
           TEST_JOBS=2 ./perl t/harness -re='^porting/'
 
@@ -176,7 +242,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs: sanity_check
-    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
+    if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_linux == 'true'))
 
     strategy:
       fail-fast: false
@@ -232,7 +298,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs: sanity_check
-    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
+    if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_linux_i386 == 'true'))
 
     # https://hub.docker.com/r/i386/ubuntu/
     container:
@@ -290,7 +356,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs: sanity_check
-    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
+    if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_install == 'true'))
 
     steps:
       - name: Install System dependencies
@@ -339,7 +405,7 @@ jobs:
     runs-on: macos-10.15
     timeout-minutes: 120
     needs: sanity_check
-    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
+    if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_macos == 'true'))
 
     strategy:
       fail-fast: false
@@ -375,7 +441,7 @@ jobs:
     runs-on: windows-2019
     timeout-minutes: 120
     needs: sanity_check
-    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
+    if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_msvc142 == 'true'))
 
     steps:
       - run: git config --global core.autocrlf false
@@ -431,7 +497,7 @@ jobs:
     runs-on: windows-2019
     timeout-minutes: 120
     needs: sanity_check
-    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
+    if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_mingw64 == 'true'))
 
     steps:
       - run: git config --global core.autocrlf false
@@ -481,7 +547,7 @@ jobs:
     runs-on: windows-2019
     timeout-minutes: 120
     needs: sanity_check
-    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
+    if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_cygwin == 'true'))
 
     steps:
       # we use Cygwin git, so no need to configure git here.
@@ -566,7 +632,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs: sanity_check
-    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
+    if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_minitest == 'true'))
 
     outputs:
       run_all_jobs: ${{ steps.check_extended_testing.outputs.run_all_jobs }}
@@ -614,7 +680,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs: sanity_check
-    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
+    if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_asan == 'true'))
 
     strategy:
       matrix:
@@ -664,7 +730,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs: sanity_check
-    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
+    if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_perl_unicode == 'true'))
 
     strategy:
       matrix:
@@ -710,7 +776,7 @@ jobs:
     name: dist-modules
     needs: sanity_check
     runs-on: ubuntu-latest
-    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
+    if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_dist_modules == 'true'))
 
     env:
       # some plugins still needs this to run their tests...

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -136,12 +136,15 @@ jobs:
           EXTENDED_TESTING: ${{ secrets.EXTENDED_TESTING }}
           CURRENT_REPOSITORY: ${{ github.repository }}
         run: |
-          if [[ -z "${EXTENDED_TESTING}" && "${CURRENT_REPOSITORY}" != 'Perl/perl5' ]]; then
-            echo "Skipping extended test jobs."
-            echo "::set-output name=run_all_jobs::false"
-          else
+          if [[ "${CURRENT_REPOSITORY}" = 'Perl/perl5' ]]; then
             echo "Running all test jobs"
             echo "::set-output name=run_all_jobs::true"
+          elif [[ -n "${EXTENDED_TESTING}" ]]; then
+            echo "Running all test jobs"
+            echo "::set-output name=run_all_jobs::true"
+          else
+            echo "Skipping extended test jobs."
+            echo "::set-output name=run_all_jobs::false"
           fi
 
       - name: Run Porting Tests (t/porting)


### PR DESCRIPTION
For the Perl/perl5 repository nothing changes, it still runs all jobs by default.

For forks of the perl5 repository: it is now possible to 'select' which CI jobs to run. This is done by adding the 'proper' Secrets in the settings of the forked repo. The how/what/... is documented in the workflow.yaml file.


Note: the PR also fixes two small bugs:
- make it possible to cancel a workflow (that is the `s/always/! cancelled/;` change)
- also run 'dist_modules' job when (only) the porting test failed in the sanity check

___
(This is a feature that was requested a while back by @khwilliamson)
