### PR TITLE
perldebug: clarify the readline support

### DIFF
--- a/pod/perldebug.pod
+++ b/pod/perldebug.pod
@@ -1145,7 +1145,7 @@ use only, and as such are subject to change without notice.
 
 As shipped, the only command-line history supplied is a simplistic one
 that checks for leading exclamation points.  However, if you install
-the L<Term::ReadKey> and L<Term::ReadLine> modules from CPAN (such as
+the L<Term::ReadKey> and one of the L<Term::ReadLine::*> modules from CPAN (such as
 L<Term::ReadLine::Gnu>, L<Term::ReadLine::Perl>, ...) you will
 have full editing capabilities much like those GNU I<readline>(3) provides.
 Look for these in the F<modules/by-module/Term> directory on CPAN.


### PR DESCRIPTION
Also I don't see any traces that [`Term::ReadKey`][a] is used (`rg ReadKey /usr/share/perl5 /usr/lib/perl5`). I'm running `perl-5.36.0` under Linux. And it doesn't seem like installing it makes any difference. Is it needed only under Windows and for it to get used you need [`Term::ReadLine::Perl5`][b]? But the former is a dependency of the latter, so that should be handled automatically. Which means under Windows `Term::ReadLine::Perl5` is preferred over `Term::ReadLine::Gnu`?

In other words a couple of corrections might be needed. Another one: Perl -> Perl5.

[a]: https://metacpan.org/pod/Term::ReadKey
[b]: https://metacpan.org/pod/Term::ReadLine::Perl5