### PR TITLE
CI: Improve dist-modules (group output + continue on error)

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -699,7 +699,7 @@ jobs:
       image: perldocker/perl-tester:${{ matrix.perl-version }}
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: perl -V
         run: perl -V
       - name: Build and test dist modules

--- a/Porting/test-dist-modules.pl
+++ b/Porting/test-dist-modules.pl
@@ -7,8 +7,12 @@ use File::Temp "tempdir";
 use ExtUtils::Manifest "maniread";
 use Cwd "getcwd";
 
+$|++;
+
 -f "Configure"
   or die "Expected to be run from a perl checkout";
+
+my $github_ci = $ENV{'GITHUB_SHA'} ? 1 : 0;
 
 my $manifest = maniread();
 
@@ -47,6 +51,7 @@ for my $dist (@dists) {
 sub test_dist {
     my ($name) = @_;
 
+    print "::group::Testing $name\n" if $github_ci;
     print "*** Testing $name ***\n";
     my $dir = tempdir( CLEANUP => 1);
     system "cp", "-a", "dist/$name/.", "$dir/."
@@ -139,6 +144,8 @@ EOM
 
     chdir $start
       or die "Cannot return to $start: $!\n";
+
+    print "::endgroup::\n" if $github_ci;
 
     $dir;
 }

--- a/Porting/test-dist-modules.pl
+++ b/Porting/test-dist-modules.pl
@@ -135,7 +135,7 @@ EOM
     system $^X, "Makefile.PL"
       and die "$name: Makefile.PL failed\n";
 
-    my $verbose = 0;
+    my $verbose = $github_ci && $ENV{'RUNNER_DEBUG'} ? 1 : 0;
     system "make", "test", "TEST_VERBOSE=$verbose"
       and die "$name: make test failed\n";
 


### PR DESCRIPTION
Highlights:

- Group the output per dist (before there was no grouping so all output was in one big block)
- Continue when one dist fails (before it would stop after the first failure)

(Details: see commit message)

Example runs:
- no failure: https://github.com/bram-perl/perl5/actions/runs/3070729590/jobs/4960754562
- 1 failure: https://github.com/bram-perl/perl5/actions/runs/3070682723/jobs/4960655118
- 2 failures: https://github.com/bram-perl/perl5/actions/runs/3070645332/jobs/4960579443
