### PR TITLE
Fix assigning stack variable to function parameter.

### DIFF
--- a/pp_pack.c
+++ b/pp_pack.c
@@ -939,7 +939,8 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
             const U32 group_modifiers = TYPE_MODIFIERS(datumtype & ~symptr->flags);
             symptr->flags |= group_modifiers;
             symptr->patend = savsym.grpend;
-            symptr->previous = &savsym;
+            Newx(symptr->previous, 1, tempsym_t);
+            *symptr->previous = savsym;
             symptr->level++;
             PUTBACK;
             if (len && unpack_only_one) len = 1;
@@ -953,6 +954,7 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
             }
             SPAGAIN;
             savsym.flags = symptr->flags & ~group_modifiers;
+            Safefree(symptr->previous);
             *symptr = savsym;
             break;
         }
@@ -2249,7 +2251,8 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
             symptr->flags |= group_modifiers;
             symptr->patend = savsym.grpend;
             symptr->level++;
-            symptr->previous = &lookahead;
+            Newx(symptr->previous, 1, tempsym_t);
+            *symptr->previous = lookahead;
             while (len--) {
                 U32 was_utf8;
                 if (utf8) symptr->flags |=  FLAG_PARSE_UTF8;
@@ -2266,6 +2269,7 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
             }
             items = endlist - beglist;
             lookahead.flags  = symptr->flags & ~group_modifiers;
+            Safefree(symptr->previous);
             goto no_change;
         }
         case 'X' | TYPE_IS_SHRIEKING:


### PR DESCRIPTION
Fixes #20180 by 1. allocating extra memory for another tempsym_t before the loop with the recursive call to (un)pack_rec, 2. assigning lookahead or savsym to `*symptr->previous`, which copies the members of that tempsym_t to the tempsym_t pointed to by symptr->previous 3. and finally frees the extra memory after the loop ends but before copying `savsym` or `lookahead` to `symptr`.

This might leak memory if the recursive call to (un)pack_rec croaks, but I'm not sure how to fix that. I suppose I could add a boolean flag to S_unpack_rec and S_pack_rec (or alternatively in tempsym_t) which would be set to false when called from another function and set to true on recursive calls (inside parentheses) and then call Safefree right before every croak in both these functions when isrecursive is true.