### PR TITLE
Use `git symbolic-ref` instead of `git branch`

### DIFF
--- a/make_patchnum.pl
+++ b/make_patchnum.pl
@@ -162,8 +162,7 @@ elsif ($git_patch_file = read_file(".git_patch") and $git_patch_file !~ /\A\$For
     $commit_title = "Snapshot of:";
 }
 elsif (-d "$srcdir/.git") {
-    # git branch | awk 'BEGIN{ORS=""} /\*/ { print $2 }'
-    ($branch) = map { /\* ([^(]\S*)/ ? $1 : () } backtick("git branch");
+    ($branch) = backtick("git symbolic-ref -q HEAD") =~ m#^refs/heads/(.+)$#;
     $branch //= "";
     my ($remote,$merge);
     if (length $branch) {


### PR DESCRIPTION
`git branch` is a porcelain command and should not be used in scripts.[^1]

It can also cause failures when:
- color.ui in git config is set to 'always'
- HEAD is detached (i.e. `git checkout blead^0`)

In that case the current branch is colored and (partially) ends up in the `$branch` var. (The code did check that the branch name didn't start with `(` but that check doesn't really work when it's colored. In that case the 'branch name' starts with an escape sequence for the color)

Example (without the patch):

	$ git config color.ui always
	$ git checkout blead^0
	$ ./miniperl -Ilib make_patchnum.pl
	sh: -c: line 0: syntax error near unexpected token `('
	sh: -c: line 0: `git config branch.(detached.merge'
	sh: -c: line 0: syntax error near unexpected token `('
	sh: -c: line 0: `git config branch.(detached.remote'
	$ grep git_branch lib/Config_git.pl
	git_branch='(detached'
	$ grep git_branch lib/Config_git.pl | cat -A
	git_branch='^[[32m(detached'$

With the patch applied:

	$ ./miniperl -Ilib make_patchnum.pl
	Updating 'git_version.h' and 'lib/Config_git.pl'
	$ grep git_branch lib/Config_git.pl
	git_branch=''
	$ grep git_branch lib/Config_git.pl | cat -A
	git_branch=''$

[^1]: See https://git-blame.blogspot.com/2013/06/checking-current-branch-programatically.html
      which is a blog post from the git maintainer.