### PR TITLE
CI/macos: Swtich to macos-11

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -318,7 +318,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Configure
         run: |
-          export SDK=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk
           sh ./Configure -des -Dusedevel ${{ matrix.CONFIGURE_ARGS }}
       - name: Build
         run: |

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -300,9 +300,9 @@ jobs:
   # | '  \/ _` / _| (_) \__ \
   # |_|_|_\__,_\__|\___/|___/
 
-  smoke-macos-catalina-xcode12:
-    name: "macOS (catalina) xcode 12"
-    runs-on: macos-10.15
+  smoke-macos-big-sur-xcode13:
+    name: "macOS (big sur) xcode 13"
+    runs-on: macos-11
     timeout-minutes: 120
     needs: sanity_check
     if: always() && needs.sanity_check.outputs.run_all_jobs == 'true'


### PR DESCRIPTION
macos-10 is deprecated in GitHub CI and is planned to be removed on 1 December 2022.

For the removal of `export SDK`: as far as I can tell there is nothing using it. (See the commit message for more details).

(Fixes #20167)
