### PR TITLE
pp_pack: Suppress Cppcheck warning.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -989,6 +989,7 @@ Mr. Nobody                     <mrnobo1024@yahoo.com>
 Murray Nesbitt                 <murray@nesbitt.ca>
 Nathan Glenn                   <garfieldnate@gmail.com>
 Nathan Kurz                    <nate@valleytel.net>
+Nathan Mills                   <38995150+quipyowert2@users.noreply.github.com>
 Nathan Torkington              <gnat@frii.com>
 Nathan Trapuzzano              <nbtrap@nbtrap.com>
 Neale Ferguson                 <neale@VMA.TABNSW.COM.AU>

--- a/pp_pack.c
+++ b/pp_pack.c
@@ -939,6 +939,7 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
             const U32 group_modifiers = TYPE_MODIFIERS(datumtype & ~symptr->flags);
             symptr->flags |= group_modifiers;
             symptr->patend = savsym.grpend;
+            /* cppcheck-suppress autoVariables */
             symptr->previous = &savsym;
             symptr->level++;
             PUTBACK;
@@ -2249,6 +2250,7 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
             symptr->flags |= group_modifiers;
             symptr->patend = savsym.grpend;
             symptr->level++;
+            /* cppcheck-suppress autoVariables */
             symptr->previous = &lookahead;
             while (len--) {
                 U32 was_utf8;


### PR DESCRIPTION
Cppcheck warns about assigning the address of a stack variable to a function parameter. This is harmless because symptr->previous is reassigned after the recursive call to (un)pack_rec by the copying of savsym/lookahead to the struct pointed to by symptr.

Fixes #20180.