### PR TITLE
builtin::trim() - Only warn about being experimental once

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -174,8 +174,6 @@ XS(XS_builtin_trim)
 {
     dXSARGS;
 
-    warn_experimental_builtin("trim", true);
-
     if (items != 1) {
         croak_xs_usage(cv, "arg");
     }

--- a/t/lib/warnings/builtin
+++ b/t/lib/warnings/builtin
@@ -121,3 +121,12 @@ Built-in function 'builtin::indexed' is experimental at - line 6.
 Built-in function 'builtin::indexed' is experimental at - line 7.
 Useless use of builtin::indexed in scalar context at - line 6.
 Useless use of builtin::indexed in void context at - line 7.
+########
+# builtin.c - trim
+use strict;
+use warnings qw(all);
+use builtin qw(trim);
+my $str = "cat";
+trim $str;
+EXPECT
+Built-in function 'builtin::trim' is experimental at - line 6.


### PR DESCRIPTION
ck_builtin_func1() already handles the warning for us, so we don't need to repeat it in our function.