### PR TITLE
eliminate an unused call to SvPVX() at the end of SvPVCLEAR_FRESH()

### DIFF
--- a/sv.h
+++ b/sv.h
@@ -2311,7 +2311,6 @@ that already have a PV buffer allocated, but no SvTHINKFIRST.
             *(SvEND(sv))= '\0';                         \
             (void)SvPOK_only_UTF8(sv);                  \
             SvTAINT(sv);                                \
-            SvPVX(sv);                                  \
         } STMT_END
 
 #define SvSHARE(sv) PL_sharehook(aTHX_ sv)


### PR DESCRIPTION
The value was simply being discarded, which caused build warnings.

@richardleach 