### PR TITLE
SvPVCLEAR_FRESH - change from macro to inline function

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1958,6 +1958,7 @@ Apd	|void	|sv_setpv	|NN SV *const sv|NULLOK const char *const ptr
 Apd	|void	|sv_setpvn	|NN SV *const sv|NULLOK const char *const ptr|const STRLEN len
 Apd	|void	|sv_setpvn_fresh|NN SV *const sv|NULLOK const char *const ptr|const STRLEN len
 Apd	|char  *|sv_setpv_bufsize|NN SV *const sv|const STRLEN cur|const STRLEN len
+Cipx	|char  *|sv_setpv_freshbuf|NN SV *const sv
 Xp	|void	|sv_sethek	|NN SV *const sv|NULLOK const HEK *const hek
 Apd	|void	|sv_setrv_noinc	|NN SV *const sv|NN SV *const ref
 Apd	|void	|sv_setrv_inc	|NN SV *const sv|NN SV *const ref

--- a/embed.h
+++ b/embed.h
@@ -647,6 +647,7 @@
 #define sv_setnv_mg(a,b)	Perl_sv_setnv_mg(aTHX_ a,b)
 #define sv_setpv(a,b)		Perl_sv_setpv(aTHX_ a,b)
 #define sv_setpv_bufsize(a,b,c)	Perl_sv_setpv_bufsize(aTHX_ a,b,c)
+#define sv_setpv_freshbuf(a)	Perl_sv_setpv_freshbuf(aTHX_ a)
 #define sv_setpv_mg(a,b)	Perl_sv_setpv_mg(aTHX_ a,b)
 #if !defined(MULTIPLICITY) || defined(PERL_CORE)
 #define sv_setpvf(a,...)	Perl_sv_setpvf(aTHX_ a,__VA_ARGS__)

--- a/proto.h
+++ b/proto.h
@@ -4161,6 +4161,11 @@ PERL_CALLCONV void	Perl_sv_setpv(pTHX_ SV *const sv, const char *const ptr);
 PERL_CALLCONV char  *	Perl_sv_setpv_bufsize(pTHX_ SV *const sv, const STRLEN cur, const STRLEN len);
 #define PERL_ARGS_ASSERT_SV_SETPV_BUFSIZE	\
 	assert(sv)
+#ifndef PERL_NO_INLINE_FUNCTIONS
+PERL_STATIC_INLINE char  *	Perl_sv_setpv_freshbuf(pTHX_ SV *const sv);
+#define PERL_ARGS_ASSERT_SV_SETPV_FRESHBUF	\
+	assert(sv)
+#endif
 PERL_CALLCONV void	Perl_sv_setpv_mg(pTHX_ SV *const sv, const char *const ptr);
 #define PERL_ARGS_ASSERT_SV_SETPV_MG	\
 	assert(sv)

--- a/sv.h
+++ b/sv.h
@@ -2301,19 +2301,7 @@ that already have a PV buffer allocated, but no SvTHINKFIRST.
 */
 
 #define SvPVCLEAR(sv) sv_setpv_bufsize(sv,0,0)
-#define SvPVCLEAR_FRESH(sv)                             \
-        STMT_START {                                    \
-            assert(SvTYPE(sv) >= SVt_PV);               \
-            assert(SvTYPE(sv) <= SVt_PVMG);             \
-            assert(!SvTHINKFIRST(sv));                  \
-            assert(SvPVX(sv));                          \
-            SvCUR_set(sv, 0  );                         \
-            *(SvEND(sv))= '\0';                         \
-            (void)SvPOK_only_UTF8(sv);                  \
-            SvTAINT(sv);                                \
-            SvPVX(sv);                                  \
-        } STMT_END
-
+#define SvPVCLEAR_FRESH(sv) sv_setpv_freshbuf(sv)
 #define SvSHARE(sv) PL_sharehook(aTHX_ sv)
 #define SvLOCK(sv) PL_lockhook(aTHX_ sv)
 #define SvUNLOCK(sv) PL_unlockhook(aTHX_ sv)

--- a/sv_inline.h
+++ b/sv_inline.h
@@ -953,6 +953,21 @@ Perl_newRV_noinc(pTHX_ SV *const tmpRef)
     return sv;
 }
 
+PERL_STATIC_INLINE char *
+Perl_sv_setpv_freshbuf(pTHX_ SV *const sv)
+{
+    PERL_ARGS_ASSERT_SV_SETPV_FRESHBUF;
+    assert(SvTYPE(sv) >= SVt_PV);
+    assert(SvTYPE(sv) <= SVt_PVMG);
+    assert(!SvTHINKFIRST(sv));
+    assert(SvPVX(sv));
+    SvCUR_set(sv, 0);
+    *(SvEND(sv))= '\0';
+    (void)SvPOK_only_UTF8(sv);
+    SvTAINT(sv);
+    return SvPVX(sv);
+}
+
 /*
  * ex: set ts=8 sts=4 sw=4 et:
  */


### PR DESCRIPTION
This is to prevent warnings due to the char * frequently being unused.