### PR TITLE
make expr parameter to newLOOPOP() NN, it was required anyway

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1472,7 +1472,7 @@ ApdR	|OP*	|newGIVENOP	|NN OP* cond|NN OP* block|PADOFFSET defsv_off
 ApdR	|OP*	|newLOGOP	|I32 optype|I32 flags|NN OP *first|NN OP *other
 px	|LOGOP*	|alloc_LOGOP	|I32 type|NULLOK OP *first|NULLOK OP *other
 ApdR	|OP*	|newLOOPEX	|I32 type|NN OP* label
-ApdR	|OP*	|newLOOPOP	|I32 flags|I32 debuggable|NULLOK OP* expr|NULLOK OP* block
+ApdR	|OP*	|newLOOPOP	|I32 flags|I32 debuggable|NN OP* expr|NULLOK OP* block
 ApdR	|OP*	|newNULLLIST
 ApdR	|OP*	|newOP		|I32 optype|I32 flags
 Cp	|void	|newPROG	|NN OP* o

--- a/proto.h
+++ b/proto.h
@@ -2713,7 +2713,8 @@ PERL_CALLCONV OP*	Perl_newLOOPEX(pTHX_ I32 type, OP* label)
 
 PERL_CALLCONV OP*	Perl_newLOOPOP(pTHX_ I32 flags, I32 debuggable, OP* expr, OP* block)
 			__attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWLOOPOP
+#define PERL_ARGS_ASSERT_NEWLOOPOP	\
+	assert(expr)
 
 PERL_CALLCONV OP*	Perl_newMETHOP(pTHX_ I32 type, I32 flags, OP* dynamic_meth)
 			__attribute__warn_unused_result__;


### PR DESCRIPTION
Coverity picked up that while we checked that expr was non-NULL in newLOOPOP(), the call to new_logop() dereferenced it anyway, the address of expr is passed to new_logop(), which sees it as firstp (so firstp == &expr), that is then derefed to first (first == expr) and then switches on first->op_type, hence dereferencing expr.

Since both callers always pass in an expr value, and the code would have crashed anyway with a NULL expr, make it required.