### PR TITLE
locale.c: Workaround for attributes.pm breakage

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -5011,6 +5011,15 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
     /* Done with finding the locales; update the auxiliary records */
     new_LC_ALL(NULL);
 
+#  if defined(USE_POSIX_2008_LOCALE) && defined(USE_LOCALE_NUMERIC)
+
+    /* This is a temporary workaround for #20155, to avoid issues where the
+     * global locale wants a radix different from the per-thread one.  This
+     * restores behavior for LC_NUMERIC to what it was before a7ff7ac. */
+    posix_setlocale(LC_NUMERIC, "C");
+
+#  endif
+
     for (i = 0; i < NOMINAL_LC_ALL_INDEX; i++) {
         Safefree(curlocales[i]);
     }


### PR DESCRIPTION
See https://github.com/Perl/perl5/issues/20155

The root cause of that problem is that under POSIX 2008, when a thread terminates, it causes thread 0 (the controller) to change to the global locale.  Commit a7ff7ac caused perl to pay attention to the environment variables in effect at startup for setting the global locale when using the POSIX 2008 locale API.  (Previously only the initial per-thread locale was affected.)

This causes problems when the initial setting was for a locale that uses a comma as the radix character, but the thread 0 is set to a locale that is expecting a dot as a radix character.  Whenever another thread terminates, thread 0 was silently changed to using the global locake, and hence a comma.  This caused parse errors.

The real solution is to fix thread 0 to remain in its chosen locale. But that fix is not ready in time for 5.37.4, and it is deemed important to get something working for this monthly development release.

This commit changes the initial global LC_NUMERIC locale to always be C, hence uses a dot radix.  The vast majority of code is expecting a dot. This is not the ultimate fix, but it works around the immediate problem at hand.

The test case is courtesy @bram-perl