### PR TITLE
Fix links in perldelta

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -546,9 +546,9 @@ platform specific bugs also go here.
 
 =item *
 
-I<Variable::Magic>
+L<Variable::Magic>
 L<[RT #144052]|https://rt.cpan.org/Ticket/Display.html?id=144052>,
-and I<Devel::Caller>
+and L<Devel::Caller>
 L<[RT #144051]|https://rt.cpan.org/Ticket/Display.html?id=144051>
 have not yet been updated to add awareness of new OPs introduced in
 this development cycle.
@@ -556,7 +556,7 @@ L<[GH #20114]|https://github.com/Perl/perl5/issues/20114>. Patches have
 been submitted upstream but these have not been incorporated into new
 releases yet.
 
-I<Test::Vars>
+L<Test::Vars>
 L<[Test-Vars/GH #47]|https://github.com/houseabsolute/p5-Test-Vars/issues/47>
 also requires updating, but since this module's own tests are not failing,
 it is harder to determine how the new OPs should be accounted for.

--- a/t/porting/known_pod_issues.dat
+++ b/t/porting/known_pod_issues.dat
@@ -93,6 +93,7 @@ DBIx::Profile
 dbm(3)
 dbm_open(3)
 Devel::Apache::Profiler
+Devel::Caller
 Devel::CallParser
 Devel::Callsite
 Devel::Cover
@@ -344,6 +345,7 @@ Test::Harness::TAP
 Test::Inline
 Test::MockObject
 Test::Unit
+Test::Vars
 Text::Autoformat
 Text::Diff
 Text::Soundex
@@ -369,6 +371,7 @@ Unicode::Tussle
 Unicode::Unihan
 unzip(1)
 utime(2)
+Variable::Magic
 Version::Requirements
 vsprintf(3)
 wait(2)


### PR DESCRIPTION
This is a correction for f1cc674150b9408466f484c1bd08faaa989000de

The `I<...>` formatting code is to be used generally for descriptive text that is to be replaced by the user with whatever is appropriate.

`C<...>` is for text that is to be typed as-is.  That would be more appropriate for these module names, which are as-is.

But in this case, these are links to modules.  perl doesn't currently know if those are valid or not, so podcheck.t fails them.  It has to be told that the spellings indeed are real modules.  So instead of changing the `L<...>` to something else, a better solution that will allow hyperlinks to be followed (when formatted by e.g., a browser), is to inform podcheck.t that these are valid links.  This is trivially done by

 `perl t/porting/podcheck.t --add-link Test::Vars`

for example.  This revises its knowledge database, which will need to be committed.