### PR TITLE
AELEMFASTLEX_STORE - support negative keys, skip unnecessary check

### DIFF
--- a/peep.c
+++ b/peep.c
@@ -3958,8 +3958,7 @@ Perl_rpeep(pTHX_ OP *o)
 
             if (!(o->op_private & (OPpASSIGN_BACKWARDS|OPpASSIGN_CV_TO_GV))
                 && (lval->op_type == OP_NULL) && (lval->op_private == 2) &&
-                (cBINOPx(lval)->op_first->op_type == OP_AELEMFAST_LEX) &&
-                ((I8)(cBINOPx(lval)->op_first->op_private) >= 0)
+                (cBINOPx(lval)->op_first->op_type == OP_AELEMFAST_LEX)
             ) {
                 OP * lex = cBINOPx(lval)->op_first;
                 /* SASSIGN's bitfield flags, such as op_moresib and

--- a/t/perf/opcount.t
+++ b/t/perf/opcount.t
@@ -898,13 +898,13 @@ test_opcount(0, "simple aelemfast_lex + sassign replacement",
 
 # aelemfast_lex + sassign are not replaced by a combined OP
 # when key <0 (not handled, to keep the pp_ function simple
-test_opcount(0, "no aelemfast_lex + sassign replacement with neg key",
+test_opcount(0, "aelemfast_lex + sassign replacement with neg key",
                 sub { my @x = (1,2); $x[-1] = 7 },
                 {
-                    aelemfast_lex      => 1,
-                    aelemfastlex_store => 0,
+                    aelemfast_lex      => 0,
+                    aelemfastlex_store => 1,
                     padav              => 1,
-                    sassign            => 1,
+                    sassign            => 0,
                 });
 
 # aelemfast_lex + sassign optimization does not disrupt multideref


### PR DESCRIPTION
This commit:
* Adds support for negative keys, as per the original `AELEMFAST_LEX`
* Changes an `if()` check for a "_useless assignment to a temporary_" 
into an assert, since this condition should never be true when the
LHS is the result of an array fetch.

Both changes address feedback from @iabyn in #20063.