### PR TITLE
pp_undef w/ TARGMY: push sv, not &PL_sv_undef, onto the stack

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -981,7 +981,11 @@ PP(pp_undef)
         SvSETMAGIC(sv);
     }
 
-    SETs(&PL_sv_undef);
+
+    if (PL_op->op_private & OPpTARGET_MY)
+        SETs(sv);
+    else
+        SETs(&PL_sv_undef);
     return NORMAL;
 }
 

--- a/t/op/undef.t
+++ b/t/op/undef.t
@@ -10,7 +10,7 @@ use strict;
 
 my (@ary, %ary, %hash);
 
-plan 87;
+plan 88;
 
 ok !defined($a);
 
@@ -204,3 +204,7 @@ EOS
     is( scalar @x, 1, 'assignment of one element to array');
     is( defined($x[0]->$*), "", 'assignment of undef element to array');
 }
+
+# GH#20336 - "my $x = undef" pushed &PL_sv_undef onto the stack, but
+#            should be pushing $x (i.e. a mutable copy of &PL_sv_undef)
+is( ++(my $x = undef), 1, '"my $x = undef" pushes $x onto the stack' );


### PR DESCRIPTION
Since https://github.com/Perl/perl5/commit/c74a928a43322c574522f122a3f3a29262f90613, `(my $x = undef)` pushed `&PL_sv_undef` onto the stack, but should be pushing `$x` instead. 

Closes #20336.