### PR TITLE
locale.c: Stop compiler warning

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3389,9 +3389,12 @@ S	|const char *|find_locale_from_environment|const unsigned int index
 S	|const char *|less_dicey_setlocale_r				\
 				|const int category			\
 				|NULLOK const char * locale
+: Not currently used
+#      if 0
 S	|bool	|less_dicey_bool_setlocale_r				\
 				|const int cat				\
 				|NN const char * locale
+#      endif
 S	|void	|less_dicey_void_setlocale_i				\
 				|const unsigned cat_index		\
 				|NN const char * locale			\

--- a/embed.h
+++ b/embed.h
@@ -1528,10 +1528,18 @@
 #    endif
 #  endif
 #  if !(defined(USE_POSIX_2008_LOCALE))
+#    if 0
+#      if defined(PERL_IN_LOCALE_C)
+#        if defined(USE_LOCALE)
+#          if defined(USE_LOCALE_THREADS)					       && ! defined(USE_THREAD_SAFE_LOCALE)				       && ! defined(USE_THREAD_SAFE_LOCALE_EMULATION)
+#define less_dicey_bool_setlocale_r(a,b)	S_less_dicey_bool_setlocale_r(aTHX_ a,b)
+#          endif
+#        endif
+#      endif
+#    endif
 #    if defined(PERL_IN_LOCALE_C)
 #      if defined(USE_LOCALE)
 #        if defined(USE_LOCALE_THREADS)					       && ! defined(USE_THREAD_SAFE_LOCALE)				       && ! defined(USE_THREAD_SAFE_LOCALE_EMULATION)
-#define less_dicey_bool_setlocale_r(a,b)	S_less_dicey_bool_setlocale_r(aTHX_ a,b)
 #define less_dicey_setlocale_r(a,b)	S_less_dicey_setlocale_r(aTHX_ a,b)
 #define less_dicey_void_setlocale_i(a,b,c)	S_less_dicey_void_setlocale_i(aTHX_ a,b,c)
 #        endif

--- a/locale.c
+++ b/locale.c
@@ -646,6 +646,8 @@ S_less_dicey_void_setlocale_i(pTHX_ const unsigned cat_index,
 #  define void_setlocale_r(cat, locale)                                     \
        void_setlocale_i(get_category_index(cat, locale), locale)
 
+#  if 0     /* Not currently used */
+
 STATIC bool
 S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char * locale)
 {
@@ -660,6 +662,7 @@ S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char * locale)
     return retval;
 }
 
+#  endif
 #  define bool_setlocale_r(cat, locale)                                 \
                                less_dicey_bool_setlocale_r(cat, locale)
 #  define bool_setlocale_i(i, locale)                                   \

--- a/proto.h
+++ b/proto.h
@@ -4722,12 +4722,20 @@ STATIC const char *	S_calculate_LC_ALL(pTHX_ const char ** individ_locales);
 #  endif
 #endif
 #if !(defined(USE_POSIX_2008_LOCALE))
-#  if defined(PERL_IN_LOCALE_C)
-#    if defined(USE_LOCALE)
-#      if defined(USE_LOCALE_THREADS)					       && ! defined(USE_THREAD_SAFE_LOCALE)				       && ! defined(USE_THREAD_SAFE_LOCALE_EMULATION)
+#  if 0
+#    if defined(PERL_IN_LOCALE_C)
+#      if defined(USE_LOCALE)
+#        if defined(USE_LOCALE_THREADS)					       && ! defined(USE_THREAD_SAFE_LOCALE)				       && ! defined(USE_THREAD_SAFE_LOCALE_EMULATION)
 STATIC bool	S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char * locale);
 #define PERL_ARGS_ASSERT_LESS_DICEY_BOOL_SETLOCALE_R	\
 	assert(locale)
+#        endif
+#      endif
+#    endif
+#  endif
+#  if defined(PERL_IN_LOCALE_C)
+#    if defined(USE_LOCALE)
+#      if defined(USE_LOCALE_THREADS)					       && ! defined(USE_THREAD_SAFE_LOCALE)				       && ! defined(USE_THREAD_SAFE_LOCALE_EMULATION)
 STATIC const char *	S_less_dicey_setlocale_r(pTHX_ const int category, const char * locale);
 #define PERL_ARGS_ASSERT_LESS_DICEY_SETLOCALE_R
 STATIC void	S_less_dicey_void_setlocale_i(pTHX_ const unsigned cat_index, const char * locale, const line_t line);


### PR DESCRIPTION
S_less_dicey_bool_setlocale_r() is a short function that makes a complete set of similar functions, but there is no current use of it. So just #ifdef it out.

This resolves #20338