### PR TITLE
Add mutexes to protect various libc calls

### DIFF
--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our ($AUTOLOAD, %SIGRT);
 
-our $VERSION = '2.06';
+our $VERSION = '2.07';
 
 require XSLoader;
 

--- a/os2/os2.c
+++ b/os2/os2.c
@@ -5047,14 +5047,14 @@ my_tmpnam (char *str)
     char *p = PerlEnv_getenv("TMP"), *tpath;
 
     if (!p) p = PerlEnv_getenv("TEMP");
-    ENV_LOCK;
+    ENV_READ_LOCK;
     tpath = tempnam(p, "pltmp");
     if (str && tpath) {
         strcpy(str, tpath);
-        ENV_UNLOCK;
+        ENV_READ_UNLOCK;
         return str;
     }
-    ENV_UNLOCK;
+    ENV_READ_UNLOCK;
     return tpath;
 }
 

--- a/perl.h
+++ b/perl.h
@@ -7576,6 +7576,12 @@ cannot have changed since the precalculation.
 #  define GETENV_UNLOCK   NOOP
 #endif
 
+/* Some critical sections care only that no one else is writing either the
+ * locale nor the environment.  XXX This is for the future; in the meantime
+ * just use an exclusive lock */
+#define ENVr_LOCALEr_LOCK     gwENVr_LOCALEr_LOCK
+#define ENVr_LOCALEr_UNLOCK   gwENVr_LOCALEr_UNLOCK
+
 #ifndef PERL_NO_INLINE_FUNCTIONS
 /* Static inline funcs that depend on includes and declarations above.
    Some of these reference functions in the perl object files, and some
@@ -7598,12 +7604,6 @@ START_EXTERN_C
 END_EXTERN_C
 
 #endif
-
-/* Some critical sections care only that no one else is writing either the
- * locale nor the environment.  XXX This is for the future; in the meantime
- * just use an exclusive lock */
-#define ENVr_LOCALEr_LOCK     gwENVr_LOCALEr_LOCK
-#define ENVr_LOCALEr_UNLOCK   gwENVr_LOCALEr_UNLOCK
 
 /*
 

--- a/perl.h
+++ b/perl.h
@@ -7235,6 +7235,7 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  define LC_NUMERIC_UNLOCK       NOOP
 #endif
 
+   /* These non-reentrant versions use global space */
 #  define MBLEN_LOCK_                gwLOCALE_LOCK
 #  define MBLEN_UNLOCK_              gwLOCALE_UNLOCK
 
@@ -7243,6 +7244,22 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 
 #  define WCTOMB_LOCK_               gwLOCALE_LOCK
 #  define WCTOMB_UNLOCK_             gwLOCALE_UNLOCK
+
+   /* Whereas the reentrant versions don't (assuming they are called with a
+    * per-thread buffer; some have the capability of being called with a NULL
+    * parameter, which defeats the reentrancy) */
+#  define MBRLEN_LOCK_                  NOOP
+#  define MBRLEN_UNLOCK_                NOOP
+#  define MBRTOWC_LOCK_                 NOOP
+#  define MBRTOWC_UNLOCK_               NOOP
+#  define WCRTOMB_LOCK_                 NOOP
+#  define WCRTOMB_UNLOCK_               NOOP
+
+#  define LC_COLLATE_LOCK               SETLOCALE_LOCK
+#  define LC_COLLATE_UNLOCK             SETLOCALE_UNLOCK
+
+#  define STRFTIME_LOCK                 ENV_LOCK
+#  define STRFTIME_UNLOCK               ENV_UNLOCK
 
 #ifdef USE_LOCALE_NUMERIC
 

--- a/perl.h
+++ b/perl.h
@@ -7602,8 +7602,8 @@ END_EXTERN_C
 /* Some critical sections care only that no one else is writing either the
  * locale nor the environment.  XXX This is for the future; in the meantime
  * just use an exclusive lock */
-#define ENV_LOCALE_READ_LOCK     gwENVr_LOCALEr_LOCK
-#define ENV_LOCALE_READ_UNLOCK   gwENVr_LOCALEr_UNLOCK
+#define ENVr_LOCALEr_LOCK     gwENVr_LOCALEr_LOCK
+#define ENVr_LOCALEr_UNLOCK   gwENVr_LOCALEr_UNLOCK
 
 /*
 

--- a/perl.h
+++ b/perl.h
@@ -7219,6 +7219,12 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  define SETLOCALE_UNLOCK              NOOP
 #endif
 
+
+      /* On systems that don't have per-thread locales, even though we don't
+       * think we are changing the locale ourselves, behind the scenes it does
+       * get changed to whatever the thread's should be, so it has to be an
+       * exclusive lock.  By defining it here with this name, we can, for the
+       * most part, hide this detail from the rest of the code */
 /* Currently, the read lock is an exclusive lock */
 #define LOCALE_READ_LOCK                SETLOCALE_LOCK
 #define LOCALE_READ_UNLOCK              SETLOCALE_UNLOCK
@@ -7576,11 +7582,161 @@ cannot have changed since the precalculation.
 #  define GETENV_UNLOCK   NOOP
 #endif
 
-/* Some critical sections care only that no one else is writing either the
- * locale nor the environment.  XXX This is for the future; in the meantime
- * just use an exclusive lock */
-#define ENVr_LOCALEr_LOCK     gwENVr_LOCALEr_LOCK
-#define ENVr_LOCALEr_UNLOCK   gwENVr_LOCALEr_UNLOCK
+/* Some critical sections need to lock both the locale and the environment from
+ * changing, while allowing for any number of readers.  To avoid deadlock, this
+ * is always done in the same order.  These should always be invoked, like all
+ * locks really, at such a low level that its just a libc call that is wrapped,
+ * so as to prevent recursive calls which could deadlock. */
+#define ENVr_LOCALEr_LOCK                                               \
+            STMT_START { LOCALE_READ_LOCK; ENV_READ_LOCK; } STMT_END
+#define ENVr_LOCALEr_UNLOCK                                             \
+        STMT_START { ENV_READ_UNLOCK; LOCALE_READ_UNLOCK; } STMT_END
+
+/* These time-related functions all requre that the environment and locale
+ * don't change while they are executing (at least in glibc; this appears to be
+ * contrary to the POSIX standard).  tzset() writes global variables, so
+ * always needs to have write locking.  ctime, localtime, mktime, and strftime
+ * effectively call it, so they too need exclusive access.  The rest need to
+ * have exclusive locking as well so that they can copy the contents of the
+ * returned static buffer before releasing the lock.  That leaves asctime and
+ * gmtime.  There may be reentrant versions of these available on the platform
+ * which don't require write locking.
+ */
+#ifdef PERL_REENTR_USING_ASCTIME_R
+#  define ASCTIME_LOCK     ENVr_LOCALEr_LOCK
+#  define ASCTIME_UNLOCK   ENVr_LOCALEr_UNLOCK
+#else
+#  define ASCTIME_LOCK     gwENVr_LOCALEr_LOCK
+#  define ASCTIME_UNLOCK   gwENVr_LOCALEr_UNLOCK
+#endif
+
+#define CTIME_LOCK         gwENVr_LOCALEr_LOCK
+#define CTIME_UNLOCK       gwENVr_LOCALEr_UNLOCK
+
+#ifdef PERL_REENTR_USING_GMTIME_R
+#  define GMTIME_LOCK      ENVr_LOCALEr_LOCK
+#  define GMTIME_UNLOCK    ENVr_LOCALEr_UNLOCK
+#else
+#  define GMTIME_LOCK      gwENVr_LOCALEr_LOCK
+#  define GMTIME_UNLOCK    gwENVr_LOCALEr_UNLOCK
+#endif
+
+#define LOCALTIME_LOCK     gwENVr_LOCALEr_LOCK
+#define LOCALTIME_UNLOCK   gwENVr_LOCALEr_UNLOCK
+#define MKTIME_LOCK        gwENVr_LOCALEr_LOCK
+#define MKTIME_UNLOCK      gwENVr_LOCALEr_UNLOCK
+#define TZSET_LOCK         gwENVr_LOCALEr_LOCK
+#define TZSET_UNLOCK       gwENVr_LOCALEr_UNLOCK
+
+/* Similiarly, these functions need a constant environment and/or locale.  And
+ * some have a buffer that is shared with another thread executing the same or
+ * a related call.  A mutex could be created for each class, but for now, share
+ * the ENV mutex with everything, as none probably gets called so much that
+ * performance would suffer by a thread being locked out by another thread that
+ * could have used a different mutex.
+ *
+ * But, create a different macro name just to indicate the ones that don't
+ * actually depend on the environment, but are using its mutex for want of a
+ * better one */
+#define gwLOCALEr_LOCK              gwENVr_LOCALEr_LOCK
+#define gwLOCALEr_UNLOCK            gwENVr_LOCALEr_UNLOCK
+
+#ifdef PERL_REENTR_USING_GETHOSTBYADDR_R
+#  define GETHOSTBYADDR_LOCK        ENVr_LOCALEr_LOCK
+#  define GETHOSTBYADDR_UNLOCK      ENVr_LOCALEr_UNLOCK
+#else
+#  define GETHOSTBYADDR_LOCK        gwENVr_LOCALEr_LOCK
+#  define GETHOSTBYADDR_UNLOCK      gwENVr_LOCALEr_UNLOCK
+#endif
+#ifdef PERL_REENTR_USING_GETHOSTBYNAME_R
+#  define GETHOSTBYNAME_LOCK        ENVr_LOCALEr_LOCK
+#  define GETHOSTBYNAME_UNLOCK      ENVr_LOCALEr_UNLOCK
+#else
+#  define GETHOSTBYNAME_LOCK        gwENVr_LOCALEr_LOCK
+#  define GETHOSTBYNAME_UNLOCK      gwENVr_LOCALEr_UNLOCK
+#endif
+#ifdef PERL_REENTR_USING_GETNETBYADDR_R
+#  define GETNETBYADDR_LOCK         LOCALE_READ_LOCK
+#  define GETNETBYADDR_UNLOCK       LOCALE_READ_UNLOCK
+#else
+#  define GETNETBYADDR_LOCK         gwLOCALEr_LOCK
+#  define GETNETBYADDR_UNLOCK       gwLOCALEr_UNLOCK
+#endif
+#ifdef PERL_REENTR_USING_GETNETBYNAME_R
+#  define GETNETBYNAME_LOCK         LOCALE_READ_LOCK
+#  define GETNETBYNAME_UNLOCK       LOCALE_READ_UNLOCK
+#else
+#  define GETNETBYNAME_LOCK         gwLOCALEr_LOCK
+#  define GETNETBYNAME_UNLOCK       gwLOCALEr_UNLOCK
+#endif
+#ifdef PERL_REENTR_USING_GETPROTOBYNAME_R
+#  define GETPROTOBYNAME_LOCK       LOCALE_READ_LOCK
+#  define GETPROTOBYNAME_UNLOCK     LOCALE_READ_UNLOCK
+#else
+#  define GETPROTOBYNAME_LOCK       gwLOCALEr_LOCK
+#  define GETPROTOBYNAME_UNLOCK     gwLOCALEr_UNLOCK
+#endif
+#ifdef PERL_REENTR_USING_GETPROTOBYNUMBER_R
+#  define GETPROTOBYNUMBER_LOCK     LOCALE_READ_LOCK
+#  define GETPROTOBYNUMBER_UNLOCK   LOCALE_READ_UNLOCK
+#else
+#  define GETPROTOBYNUMBER_LOCK     gwLOCALEr_LOCK
+#  define GETPROTOBYNUMBER_UNLOCK   gwLOCALEr_UNLOCK
+#endif
+#ifdef PERL_REENTR_USING_GETPROTOENT_R
+#  define GETPROTOENT_LOCK          LOCALE_READ_LOCK
+#  define GETPROTOENT_UNLOCK        LOCALE_READ_UNLOCK
+#else
+#  define GETPROTOENT_LOCK          gwLOCALEr_LOCK
+#  define GETPROTOENT_UNLOCK        gwLOCALEr_UNLOCK
+#endif
+#ifdef PERL_REENTR_USING_GETPWNAM_R
+#  define GETPWNAM_LOCK             LOCALE_READ_LOCK
+#  define GETPWNAM_UNLOCK           LOCALE_READ_UNLOCK
+#else
+#  define GETPWNAM_LOCK             gwLOCALEr_LOCK
+#  define GETPWNAM_UNLOCK           gwLOCALEr_UNLOCK
+#endif
+#ifdef PERL_REENTR_USING_GETPWUID_R
+#  define GETPWUID_LOCK             LOCALE_READ_LOCK
+#  define GETPWUID_UNLOCK           LOCALE_READ_UNLOCK
+#else
+#  define GETPWUID_LOCK             gwLOCALEr_LOCK
+#  define GETPWUID_UNLOCK           gwLOCALEr_UNLOCK
+#endif
+#ifdef PERL_REENTR_USING_GETSERVBYNAME_R
+#  define GETSERVBYNAME_LOCK        LOCALE_READ_LOCK
+#  define GETSERVBYNAME_UNLOCK      LOCALE_READ_UNLOCK
+#else
+#  define GETSERVBYNAME_LOCK        gwLOCALEr_LOCK
+#  define GETSERVBYNAME_UNLOCK      gwLOCALEr_UNLOCK
+#endif
+#ifdef PERL_REENTR_USING_GETSERVBYPORT_R
+#  define GETSERVBYPORT_LOCK        LOCALE_READ_LOCK
+#  define GETSERVBYPORT_UNLOCK      LOCALE_READ_UNLOCK
+#else
+#  define GETSERVBYPORT_LOCK        gwLOCALEr_LOCK
+#  define GETSERVBYPORT_UNLOCK      gwLOCALEr_UNLOCK
+#endif
+#ifdef PERL_REENTR_USING_GETSERVENT_R
+#  define GETSERVENT_LOCK           LOCALE_READ_LOCK
+#  define GETSERVENT_UNLOCK         LOCALE_READ_UNLOCK
+#else
+#  define GETSERVENT_LOCK           gwLOCALEr_LOCK
+#  define GETSERVENT_UNLOCK         gwLOCALEr_UNLOCK
+#endif
+#ifdef PERL_REENTR_USING_GETSPNAM_R
+#  define GETSPNAM_LOCK             LOCALE_READ_LOCK
+#  define GETSPNAM_UNLOCK           LOCALE_READ_UNLOCK
+#else
+#  define GETSPNAM_LOCK             gwLOCALEr_LOCK
+#  define GETSPNAM_UNLOCK           gwLOCALEr_UNLOCK
+#endif
+
+#define STRFMON_LOCK        LC_MONETARY_LOCK
+#define STRFMON_UNLOCK      LC_MONETARY_UNLOCK
+
+/* End of locale/env synchronization */
 
 #ifndef PERL_NO_INLINE_FUNCTIONS
 /* Static inline funcs that depend on includes and declarations above.

--- a/perl.h
+++ b/perl.h
@@ -7189,7 +7189,31 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  define POSIX_SETLOCALE_UNLOCK    gwLOCALE_UNLOCK
 #endif
 
-/* This was defined above for the case where locales aren't thread safe. */
+/* Similar to gwLOCALE_LOCK, there are functions that require both the locale
+ * and environment to be constant during their execution, and don't change
+ * either of those things, but do write to some sort of shared global space.
+ * They require some sort of exclusive lock against similar functions, and a
+ * read lock on both the locale and environment.  However, on systems which
+ * have per-thread locales, the locale is constant during the execution of
+ * these functions, and so no locale lock is necssary.  For such systems, an
+ * exclusive ENV lock is necessary and sufficient.  On systems where the locale
+ * could change out from under us, we use an exclusive LOCALE lock to prevent
+ * that, and a read ENV lock to prevent other threads that have nothing to do
+ * with locales here from changing the environment. */
+#ifdef SETLOCALE_LOCK
+#  define gwENVr_LOCALEr_LOCK                                               \
+                    STMT_START { SETLOCALE_LOCK; ENV_READ_LOCK; } STMT_END
+#  define gwENVr_LOCALEr_UNLOCK                                             \
+                STMT_START { ENV_READ_UNLOCK; SETLOCALE_UNLOCK; } STMT_END
+#else
+#  define gwENVr_LOCALEr_LOCK           ENV_LOCK
+#  define gwENVr_LOCALEr_UNLOCK         ENV_UNLOCK
+#endif
+
+/* Now that we have defined gwENVr_LOCALEr_LOCK, we can finish defining
+ * SETLOCALE_LOCK, which we kept undefined until here on a thread-safe system
+ * so that we could use that fact to calculate what gwENVr_LOCALEr_LOCK should
+ * be */
 #ifndef SETLOCALE_LOCK
 #  define SETLOCALE_LOCK                NOOP
 #  define SETLOCALE_UNLOCK              NOOP

--- a/perl.h
+++ b/perl.h
@@ -7599,20 +7599,11 @@ END_EXTERN_C
 
 #endif
 
-/* Some critical sections need to lock both the locale and the environment.
- * XXX khw intends to change this to lock both mutexes, but that brings up
- * issues of potential deadlock, so should be done at the beginning of a
- * development cycle.  So for now, it just locks the environment.  Note that
- * many modern platforms are locale-thread-safe anyway, so locking the locale
- * mutex is a no-op anyway */
-#define ENV_LOCALE_LOCK     ENV_LOCK
-#define ENV_LOCALE_UNLOCK   ENV_UNLOCK
-
-/* And some critical sections care only that no one else is writing either the
- * locale nor the environment.  XXX Again this is for the future.  This can be
- * simulated with using COND_WAIT in thread.h */
-#define ENV_LOCALE_READ_LOCK     ENV_LOCALE_LOCK
-#define ENV_LOCALE_READ_UNLOCK   ENV_LOCALE_UNLOCK
+/* Some critical sections care only that no one else is writing either the
+ * locale nor the environment.  XXX This is for the future; in the meantime
+ * just use an exclusive lock */
+#define ENV_LOCALE_READ_LOCK     gwENVr_LOCALEr_LOCK
+#define ENV_LOCALE_READ_UNLOCK   gwENVr_LOCALEr_UNLOCK
 
 /*
 

--- a/pp.c
+++ b/pp.c
@@ -2899,10 +2899,16 @@ PP(pp_sin)
 #if defined(NAN_COMPARE_BROKEN) && defined(Perl_isnan)
               ! Perl_isnan(value) &&
 #endif
-              (op_type == OP_LOG ? (value <= 0.0) : (value < 0.0))) {
+              (op_type == OP_LOG ? (value <= 0.0) : (value < 0.0)))
+          {
+              char * mesg;
+              SETLOCALE_LOCK;
               SET_NUMERIC_STANDARD();
+              mesg = Perl_form(aTHX_ "Can't take %s of %" NVgf, neg_report, value);
+              SETLOCALE_UNLOCK;
+
               /* diag_listed_as: Can't take log of %g */
-              DIE(aTHX_ "Can't take %s of %" NVgf, neg_report, value);
+              DIE(aTHX_ "%s", mesg);
           }
       }
       switch (op_type) {

--- a/time64.c
+++ b/time64.c
@@ -156,15 +156,15 @@ static const short safe_years[SOLAR_CYCLE_LENGTH] = {
 #ifdef USE_REENTRANT_API  /* This indicates a platform where we need reentrant
                              versions if have them */
 #  ifdef PERL_REENTR_USING_LOCALTIME_R
-#    define LOCALTIME_LOCK    ENV_LOCALE_READ_LOCK
-#    define LOCALTIME_UNLOCK  ENV_LOCALE_READ_UNLOCK
+#    define LOCALTIME_LOCK    ENVr_LOCALEr_LOCK
+#    define LOCALTIME_UNLOCK  ENVr_LOCALEr_UNLOCK
 #  else
 #    define LOCALTIME_LOCK    gwENVr_LOCALEr_LOCK
 #    define LOCALTIME_UNLOCK  gwENVr_LOCALEr_UNLOCK
 #  endif
 #  ifdef PERL_REENTR_USING_GMTIME_R
-#    define GMTIME_LOCK    ENV_LOCALE_READ_LOCK
-#    define GMTIME_UNLOCK  ENV_LOCALE_READ_UNLOCK
+#    define GMTIME_LOCK    ENVr_LOCALEr_LOCK
+#    define GMTIME_UNLOCK  ENVr_LOCALEr_UNLOCK
 #  else
 #    define GMTIME_LOCK    gwENVr_LOCALEr_LOCK
 #    define GMTIME_UNLOCK  gwENVr_LOCALEr_UNLOCK

--- a/time64.c
+++ b/time64.c
@@ -142,40 +142,6 @@ static const short safe_years[SOLAR_CYCLE_LENGTH] = {
 #    define TIME64_TRACE3(format, var1, var2, var3) ((void)0)
 #endif
 
-/* Set up the mutexes for this file.  There are no races possible on
- * non-threaded perls, nor platforms that naturally don't have them.
- * Otherwise, we need to have mutexes.  If we have reentrant versions of the
- * functions below, they automatically will be substituted for the
- * non-reentrant ones.  That solves the problem of the buffers being trashed by
- * another thread, but not of the environment or locale changing during their
- * execution.  To do that, we only need a read lock (which prevents writing by
- * others).  However, if we don't have re-entrant functions, we can gain some
- * measure of thread-safety by using an exclusive lock during their execution.
- * That will protect against any other use of the functions that use the
- * mutexes, which all of core should be using. */
-#ifdef USE_REENTRANT_API  /* This indicates a platform where we need reentrant
-                             versions if have them */
-#  ifdef PERL_REENTR_USING_LOCALTIME_R
-#    define LOCALTIME_LOCK    ENVr_LOCALEr_LOCK
-#    define LOCALTIME_UNLOCK  ENVr_LOCALEr_UNLOCK
-#  else
-#    define LOCALTIME_LOCK    gwENVr_LOCALEr_LOCK
-#    define LOCALTIME_UNLOCK  gwENVr_LOCALEr_UNLOCK
-#  endif
-#  ifdef PERL_REENTR_USING_GMTIME_R
-#    define GMTIME_LOCK    ENVr_LOCALEr_LOCK
-#    define GMTIME_UNLOCK  ENVr_LOCALEr_UNLOCK
-#  else
-#    define GMTIME_LOCK    gwENVr_LOCALEr_LOCK
-#    define GMTIME_UNLOCK  gwENVr_LOCALEr_UNLOCK
-#  endif
-#else   /* Reentrant not needed, so races not possible */
-#  define LOCALTIME_LOCK    NOOP
-#  define LOCALTIME_UNLOCK  NOOP
-#  define GMTIME_LOCK       NOOP
-#  define GMTIME_UNLOCK     NOOP
-#endif
-
 static int S_is_exception_century(Year year)
 {
     const int is_exception = ((year % 100 == 0) && !(year % 400 == 0));

--- a/time64.c
+++ b/time64.c
@@ -159,15 +159,15 @@ static const short safe_years[SOLAR_CYCLE_LENGTH] = {
 #    define LOCALTIME_LOCK    ENV_LOCALE_READ_LOCK
 #    define LOCALTIME_UNLOCK  ENV_LOCALE_READ_UNLOCK
 #  else
-#    define LOCALTIME_LOCK    ENV_LOCALE_LOCK
-#    define LOCALTIME_UNLOCK  ENV_LOCALE_UNLOCK
+#    define LOCALTIME_LOCK    gwENVr_LOCALEr_LOCK
+#    define LOCALTIME_UNLOCK  gwENVr_LOCALEr_UNLOCK
 #  endif
 #  ifdef PERL_REENTR_USING_GMTIME_R
 #    define GMTIME_LOCK    ENV_LOCALE_READ_LOCK
 #    define GMTIME_UNLOCK  ENV_LOCALE_READ_UNLOCK
 #  else
-#    define GMTIME_LOCK    ENV_LOCALE_LOCK
-#    define GMTIME_UNLOCK  ENV_LOCALE_UNLOCK
+#    define GMTIME_LOCK    gwENVr_LOCALEr_LOCK
+#    define GMTIME_UNLOCK  gwENVr_LOCALEr_UNLOCK
 #  endif
 #else   /* Reentrant not needed, so races not possible */
 #  define LOCALTIME_LOCK    NOOP

--- a/util.c
+++ b/util.c
@@ -3975,11 +3975,12 @@ Perl_init_tm(pTHX_ struct tm *ptm)	/* see mktime, strftime and asctime */
     PERL_UNUSED_CONTEXT;
     PERL_ARGS_ASSERT_INIT_TM;
     (void)time(&now);
-    ENVr_LOCALEr_LOCK;
+
+    LOCALTIME_LOCK;
     my_tm = localtime(&now);
     if (my_tm)
         Copy(my_tm, ptm, 1, struct tm);
-    ENVr_LOCALEr_UNLOCK;
+    LOCALTIME_UNLOCK;
 #else
     PERL_UNUSED_CONTEXT;
     PERL_ARGS_ASSERT_INIT_TM;

--- a/util.c
+++ b/util.c
@@ -4235,7 +4235,9 @@ giving localized results.
   STMT_START {
     struct tm mytm2;
     mytm2 = mytm;
+    MKTIME_LOCK;
     mktime(&mytm2);
+    MKTIME_UNLOCK;
 #ifdef HAS_TM_TM_GMTOFF
     mytm.tm_gmtoff = mytm2.tm_gmtoff;
 #endif

--- a/util.c
+++ b/util.c
@@ -4251,7 +4251,9 @@ giving localized results.
 
   GCC_DIAG_IGNORE_STMT(-Wformat-nonliteral); /* fmt checked by caller */
 
+  STRFTIME_LOCK;
   len = strftime(buf, buflen, fmt, &mytm);
+  STRFTIME_UNLOCK;
 
   GCC_DIAG_RESTORE_STMT;
 
@@ -4280,7 +4282,9 @@ giving localized results.
     while (buf) {
 
       GCC_DIAG_IGNORE_STMT(-Wformat-nonliteral); /* fmt checked by caller */
+      STRFTIME_LOCK;
       buflen = strftime(buf, bufsize, fmt, &mytm);
+      STRFTIME_UNLOCK;
       GCC_DIAG_RESTORE_STMT;
 
       if (inRANGE(buflen, 1, bufsize - 1))

--- a/util.c
+++ b/util.c
@@ -3975,11 +3975,11 @@ Perl_init_tm(pTHX_ struct tm *ptm)	/* see mktime, strftime and asctime */
     PERL_UNUSED_CONTEXT;
     PERL_ARGS_ASSERT_INIT_TM;
     (void)time(&now);
-    ENV_LOCALE_READ_LOCK;
+    ENVr_LOCALEr_LOCK;
     my_tm = localtime(&now);
     if (my_tm)
         Copy(my_tm, ptm, 1, struct tm);
-    ENV_LOCALE_READ_UNLOCK;
+    ENVr_LOCALEr_UNLOCK;
 #else
     PERL_UNUSED_CONTEXT;
     PERL_ARGS_ASSERT_INIT_TM;


### PR DESCRIPTION
The vast majority of libc calls are thread-safe, but a substantial number aren't, even ones claimed to be re-entrant.  `mbrlen(),` for example, may require both the locale and environment to remain unchanged by other threads during its execution, or undefined behavior (like segfaults)  ensues.  I went through the POSIX specification looking for such calls, and also looked at likely suspects in my Ubuntu man pages.  It turns out that glibc violates POSIX in a few cases, allowing thread-unsafe behavior even when the Standard prohibits it.  A future commit will change perlxs to include my findings.  This series of commits implements them by defining mutexes to prohibit concurrent execution of multiple collaborating threads during critical sections.  Like all mutexes, code can simply not opt-in to using it, but this at least causes all the perl core to conform.  And the future perlxs changes will document what XS code should do.

Another example is most time functions.  `tzset()` is called behind the scenes in many of them.  It sets `tzname[],` which in many implementations is a global variable.  Thus, `tzset()` needs to be executed under control of a mutex until `tzname` is safely copied to a per-interpreter variable.  And hence, `asctime_r` isn't really thread safe without a mutex surrounding it.

On unthreaded perls, all these mutexes resolve to no-ops.

I certainly may have missed, in my search, items that should have mutexes.  Those can be added whenever any surfaces