### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/detect-conflicts.yml
+++ b/.github/workflows/detect-conflicts.yml
@@ -2,8 +2,12 @@ on:
   push:
     branches:
       - blead
+permissions: {}
 jobs:
   conflicts:
+    permissions:
+      pull-requests: write # to add labels to pull requests
+
     runs-on: ubuntu-latest
     if: ( github.event.pull_request.head.repo.full_name == 'Perl/perl5' || github.repository == 'Perl/perl5' )
     steps:

--- a/.github/workflows/irc-notifications.yaml
+++ b/.github/workflows/irc-notifications.yaml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 # IRC colors: https://modern.ircdocs.horse/formatting.html
 # yaml formating: https://www.yaml.info/learn/quote.html
 
+permissions: {}
 jobs:
   notify-irc:
     runs-on: ubuntu-latest

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -18,6 +18,9 @@ env:
   PERL_SKIP_TTY_TEST: 1
   CONTINUOUS_INTEGRATION: 1
 
+permissions:
+  contents: read # to fetch code
+
 jobs:
   #  ___           _         ___       __                    _   _
   # / __|_ __  ___| |_____  |_ _|_ _  / _|___ _ _ _ __  __ _| |_(_)___ _ _  ___

--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Albert Chin-A-Young            <china@thewrittenword.com>
 Albert Dvornik                 <bert@alum.mit.edu>
 Alberto Simões                 <ambs@cpan.org>
 Alessandro Forghieri           <alf@orion.it>
+Alex                           <aleksandrosansan@gmail.com>
 Alex Davies                    <adavies@ptc.com>
 Alex Gough                     <alex@rcon.org>
 Alex Solovey                   <a.solovey@gmail.com>


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.