### PR TITLE
end of file (^D on POSIX-likes) now behaves like q as documented

### DIFF
--- a/lib/perl5db.pl
+++ b/lib/perl5db.pl
@@ -532,7 +532,7 @@ BEGIN {
 use vars qw($VERSION $header);
 
 # bump to X.XX in blead, only use X.XX_XX in maint
-$VERSION = '1.76';
+$VERSION = '1.77';
 
 $header = "perl5db.pl version $VERSION";
 
@@ -3490,7 +3490,9 @@ again.
 =cut
 
         # No more commands? Quit.
-        $fall_off_end = 1 unless defined $cmd;    # Emulate 'q' on EOF
+        unless (defined $cmd) {
+            DB::Obj::_do_quit();
+        }
 
         # Evaluate post-prompt commands.
         foreach $evalarg (@$post) {
@@ -4294,13 +4296,17 @@ sub _handle_x_command {
     return;
 }
 
+sub _do_quit {
+    $fall_off_end = 1;
+    DB::clean_ENV();
+    exit $?;
+}
+
 sub _handle_q_command {
     my $self = shift;
 
     if ($self->_is_full('q')) {
-        $fall_off_end = 1;
-        DB::clean_ENV();
-        exit $?;
+        _do_quit();
     }
 
     return;


### PR DESCRIPTION
This was originally reported againt 5.36.0 where ^D would act more like 'n' than 'q':

$ ~/perl/v5.36.0-clang14/bin/perl -lde 'print 1; print 2; print 3;'

Loading DB routines from perl5db.pl version 1.73
Editor support available.

Enter h or 'h h' for help, or 'man perldebug' for more help.

main::(-e:1):   print 1; print 2; print 3;
  DB<1> 1
main::(-e:1):   print 1; print 2; print 3;
  DB<1> 2
main::(-e:1):   print 1; print 2; print 3;
  DB<1> 3

(^D at each prompt)

Post 80c1f1e4 this behaved a little differently, since reading ^D from the stream now sets the eof() flag readline() would return immediately after each attempt, instead of reading a command.

This produced the same output as above, but only required a single ^D.

But neither of these is correct, both 'q' and ^D are documented to exit the debugger, and 'q' does that, this changes eof to also exit the debugger.

Unfortunately the perl5db test infrastructure doesn't support testing this, and due to the way the debugger interacts with the terminal, I don't think this is easily tested in core.  I think a module like Expect or IPC::Run that can interact with a terminal would be needed.

Fixes #20307 