### PR TITLE
Free PL_splitstr properly with threads and duplicate flags

### DIFF
--- a/intrpvar.h
+++ b/intrpvar.h
@@ -496,7 +496,7 @@ PERLVAR(I, warnhook,	SV *)
 /* switches */
 PERLVAR(I, patchlevel,	SV *)
 PERLVAR(I, localpatches, const char * const *)
-PERLVARI(I, splitstr,	const char *, " ")
+PERLVARI(I, splitstr,	char *, NULL)
 
 PERLVAR(I, minus_c,	bool)
 PERLVAR(I, minus_n,	bool)

--- a/perl.c
+++ b/perl.c
@@ -3554,9 +3554,11 @@ Perl_moreswitches(pTHX_ const char *s)
         PL_minus_a = TRUE;
         PL_minus_F = TRUE;
         PL_minus_n = TRUE;
-        PL_splitstr = ++s;
-        while (*s && !isSPACE(*s)) ++s;
-        PL_splitstr = savepvn(PL_splitstr, s - PL_splitstr);
+        {
+            const char *start = ++s;
+            while (*s && !isSPACE(*s)) ++s;
+            PL_splitstr = savepvn(start, s - start);
+        }
         return s;
     case 'a':
         PL_minus_a = TRUE;

--- a/perl.c
+++ b/perl.c
@@ -3557,6 +3557,7 @@ Perl_moreswitches(pTHX_ const char *s)
         {
             const char *start = ++s;
             while (*s && !isSPACE(*s)) ++s;
+            Safefree(PL_splitstr);
             PL_splitstr = savepvn(start, s - start);
         }
         return s;

--- a/sv.c
+++ b/sv.c
@@ -15508,7 +15508,7 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
     PL_minus_c		= proto_perl->Iminus_c;
 
     PL_localpatches	= proto_perl->Ilocalpatches;
-    PL_splitstr		= proto_perl->Isplitstr;
+    PL_splitstr		= SAVEPV(proto_perl->Isplitstr);
     PL_minus_n		= proto_perl->Iminus_n;
     PL_minus_p		= proto_perl->Iminus_p;
     PL_minus_l		= proto_perl->Iminus_l;

--- a/t/run/switchF2.t
+++ b/t/run/switchF2.t
@@ -38,4 +38,14 @@ SKIP:
                 }, "PL_splitstr freed in each thread");
 }
 
+{
+  # old value of PL_splitstr wasn't freed with multiple switches (it wasn't safe to before)
+  # this would only fail under valgrind/LSAN
+  fresh_perl_is('print $F[1]', "b",
+                {
+                    switches => [ "-F:", "-F," ],
+                    stdin => "a,b,c",
+                }, "PL_splitstr freed on extra -F switch");
+}
+
 done_testing();


### PR DESCRIPTION
Fixes a problem found while looking at #16856.

An alternative for the threads case might be to just set splitstr to NULL in child threads.