### PR TITLE
ensure curlocales[] is initialized

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -4829,6 +4829,10 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
     };
     trial_locales_count = 1;
 
+    for (i = 0; i < NOMINAL_LC_ALL_INDEX; i++) {
+        curlocales[i] = NULL;
+    }
+
     for (i= 0; i < trial_locales_count; i++) {
         const char * trial_locale = trial_locales[i].trial_locale;
         setlocale_failure = FALSE;


### PR DESCRIPTION
Coverity complains that the call to Safefree() now at line 5098 could be called with an uninitialized value for curlocales[i], which appears to be possible if the trial_locales loop just below this change fails to find a locale.

Fixes CID 184451