### PR TITLE
Allow non-ASCII locale names

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -964,11 +964,12 @@ S_setlocale_from_aggregate_LC_ALL(pTHX_ const char * locale, const line_t line)
         /* Parse through the locale name */
         const char * name_start = p;
         while (p < e && *p != ';') {
-            if (! isGRAPH(*p)) {
-                locale_panic_(Perl_form(aTHX_
-                              "Unexpected character in locale name '%02X", *p));
-            }
             p++;
+        }
+        if (UNLIKELY( p < e && *p != ';')) {
+            locale_panic_(Perl_form(aTHX_
+                          "Unexpected character in locale name '%s<-- HERE",
+                          get_displayable_string(s, p, 0)));
         }
 
         const char * name_end = p;


### PR DESCRIPTION
Locale names are supposed to be opaque to the calling program.  The only requirement is that any name output by libc means the same as input to that libc.  And it makes sense, you might very well want to have a locale name in your native language.  This commit changes locale.c to not impose any restrictions on the name proper.  (It should be noted, however, other Standards have come along that specify a particular syntax using only ASCII.  Perl needn't, and shouldn't, impose those further restrictions.)