### PR TITLE
Fix return type of CopLINE() in perlapi

### DIFF
--- a/cop.h
+++ b/cop.h
@@ -463,7 +463,7 @@ struct cop {
 =for apidoc Am|const char *|CopFILE|const COP * c
 Returns the name of the file associated with the C<COP> C<c>
 
-=for apidoc Am|STRLEN|CopLINE|const COP * c
+=for apidoc Am|line_t|CopLINE|const COP * c
 Returns the line number in the source code associated with the C<COP> C<c>
 
 =for apidoc Am|AV *|CopFILEAV|const COP * c


### PR DESCRIPTION
In perlapi.pod, `CopLINE()` had been described as it returns `STRLEN`, but actual code returned `line_t` since a long time ago.

I've tried to fix this discrepancy by modifying its apidoc entry in `cop.h`.