### PR TITLE
Enable `use feature 'module_true'`

### DIFF
--- a/feature.h
+++ b/feature.h
@@ -22,16 +22,17 @@
 #define FEATURE_FC_BIT                      0x0080
 #define FEATURE_INDIRECT_BIT                0x0100
 #define FEATURE_ISA_BIT                     0x0200
-#define FEATURE_MULTIDIMENSIONAL_BIT        0x0400
-#define FEATURE_POSTDEREF_QQ_BIT            0x0800
-#define FEATURE_REFALIASING_BIT             0x1000
-#define FEATURE_SAY_BIT                     0x2000
-#define FEATURE_SIGNATURES_BIT              0x4000
-#define FEATURE_STATE_BIT                   0x8000
-#define FEATURE_SWITCH_BIT                  0x10000
-#define FEATURE_TRY_BIT                     0x20000
-#define FEATURE_UNIEVAL_BIT                 0x40000
-#define FEATURE_UNICODE_BIT                 0x80000
+#define FEATURE_MODULE_TRUE_BIT             0x0400
+#define FEATURE_MULTIDIMENSIONAL_BIT        0x0800
+#define FEATURE_POSTDEREF_QQ_BIT            0x1000
+#define FEATURE_REFALIASING_BIT             0x2000
+#define FEATURE_SAY_BIT                     0x4000
+#define FEATURE_SIGNATURES_BIT              0x8000
+#define FEATURE_STATE_BIT                   0x10000
+#define FEATURE_SWITCH_BIT                  0x20000
+#define FEATURE_TRY_BIT                     0x40000
+#define FEATURE_UNIEVAL_BIT                 0x80000
+#define FEATURE_UNICODE_BIT                 0x100000
 
 #define FEATURE_BUNDLE_DEFAULT	0
 #define FEATURE_BUNDLE_510	1
@@ -144,6 +145,13 @@
 	 CURRENT_FEATURE_BUNDLE <= FEATURE_BUNDLE_537) \
      || (CURRENT_FEATURE_BUNDLE == FEATURE_BUNDLE_CUSTOM && \
 	 FEATURE_IS_ENABLED_MASK(FEATURE___SUB___BIT)) \
+    )
+
+#define FEATURE_MODULE_TRUE_IS_ENABLED \
+    ( \
+	CURRENT_FEATURE_BUNDLE == FEATURE_BUNDLE_537 \
+     || (CURRENT_FEATURE_BUNDLE == FEATURE_BUNDLE_CUSTOM && \
+	 FEATURE_IS_ENABLED_MASK(FEATURE_MODULE_TRUE_BIT)) \
     )
 
 #define FEATURE_REFALIASING_IS_ENABLED \
@@ -328,7 +336,12 @@ S_magic_sethint_feature(pTHX_ SV *keysv, const char *keypv, STRLEN keylen,
             return;
 
         case 'm':
-            if (keylen == sizeof("feature_more_delims")-1
+            if (keylen == sizeof("feature_module_true")-1
+                 && memcmp(subf+1, "odule_true", keylen - sizeof("feature_")) == 0) {
+                mask = FEATURE_MODULE_TRUE_BIT;
+                break;
+            }
+            else if (keylen == sizeof("feature_more_delims")-1
                  && memcmp(subf+1, "ore_delims", keylen - sizeof("feature_")) == 0) {
                 mask = FEATURE_MORE_DELIMS_BIT;
                 break;

--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -4,8 +4,7 @@
 # Any changes made here will be lost!
 
 package feature;
-
-our $VERSION = '1.76';
+our $VERSION = '1.77';
 
 our %feature = (
     fc                      => 'feature_fc',
@@ -20,6 +19,7 @@ our %feature = (
     evalbytes               => 'feature_evalbytes',
     signatures              => 'feature_signatures',
     current_sub             => 'feature___SUB__',
+    module_true             => 'feature_module_true',
     refaliasing             => 'feature_refaliasing',
     postderef_qq            => 'feature_postderef_qq',
     unicode_eval            => 'feature_unieval',
@@ -37,8 +37,8 @@ our %feature_bundle = (
     "5.23"    => [qw(bareword_filehandles current_sub evalbytes fc indirect multidimensional postderef_qq say state switch unicode_eval unicode_strings)],
     "5.27"    => [qw(bareword_filehandles bitwise current_sub evalbytes fc indirect multidimensional postderef_qq say state switch unicode_eval unicode_strings)],
     "5.35"    => [qw(bareword_filehandles bitwise current_sub evalbytes fc isa postderef_qq say signatures state unicode_eval unicode_strings)],
-    "5.37"    => [qw(bitwise current_sub evalbytes fc isa postderef_qq say signatures state unicode_eval unicode_strings)],
-    "all"     => [qw(bareword_filehandles bitwise current_sub declared_refs defer evalbytes extra_paired_delimiters fc indirect isa multidimensional postderef_qq refaliasing say signatures state switch try unicode_eval unicode_strings)],
+    "5.37"    => [qw(bitwise current_sub evalbytes fc isa module_true postderef_qq say signatures state unicode_eval unicode_strings)],
+    "all"     => [qw(bareword_filehandles bitwise current_sub declared_refs defer evalbytes extra_paired_delimiters fc indirect isa module_true multidimensional postderef_qq refaliasing say signatures state switch try unicode_eval unicode_strings)],
     "default" => [qw(bareword_filehandles indirect multidimensional)],
 );
 
@@ -867,6 +867,14 @@ The complete list of accepted paired delimiters as of Unicode 14.0 is:
  🢫  🢪    U+1F8AB, U+1F8AA RIGHT/LEFTWARDS FRONT-TILTED SHADOWED WHITE
                           ARROW
 
+=head2 The 'module_true' feature
+
+This feature removes the need to return a true value at the end of a module
+loaded with C<require> or C<use>. Any errors during compilation will cause
+failures, but reaching the end of the module when this feature is in effect
+will prevent C<perl> from throwing an exception that the module "did not return
+a true value".
+
 =head1 FEATURE BUNDLES
 
 It's possible to load multiple features together, using
@@ -944,8 +952,8 @@ The following feature bundles are available:
             state unicode_eval unicode_strings
 
   :5.38     bitwise current_sub evalbytes fc isa
-            postderef_qq say signatures state
-            unicode_eval unicode_strings
+            module_true postderef_qq say signatures
+            state unicode_eval unicode_strings
 
 The C<:default> bundle represents the feature set that is enabled before
 any C<use feature> or C<no feature> declaration.

--- a/op.c
+++ b/op.c
@@ -4462,6 +4462,10 @@ Perl_block_end(pTHX_ I32 floor, OP *seq)
     if (PL_parser && PL_parser->parsed_sub) {
         o = newSTATEOP(0, NULL, NULL);
         op_null(o);
+
+        /* propagate features if this is the only COP in the block */
+        cCOPx(o)->cop_features = PL_curcop->cop_features;
+
         retval = op_append_elem(OP_LINESEQ, retval, o);
     }
 

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4761,6 +4761,7 @@ PP(pp_entereval)
 
 PP(pp_leaveeval)
 {
+    dSP;
     SV **oldsp;
     U8 gimme;
     PERL_CONTEXT *cx;
@@ -4804,9 +4805,16 @@ PP(pp_leaveeval)
         }
         PL_curcop = old_pl_curcop;
 
-        failed = !(gimme == G_SCALAR
-                        ? (module_true || SvTRUE_NN(*PL_stack_sp))
-                        : PL_stack_sp > oldsp);
+        /* failed stays false */
+        if (module_true) {
+            POPs;
+            PUSHs(&PL_sv_yes);
+        }
+        else {
+            failed = !(gimme == G_SCALAR
+                            ? SvTRUE_NN(*PL_stack_sp)
+                            : PL_stack_sp > oldsp);
+        }
     }
 
     /* the cx_popeval does a leavescope, which frees the optree associated

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4807,7 +4807,7 @@ PP(pp_leaveeval)
         PL_curcop = old_pl_curcop;
 
         if (module_true) {
-            POPs;
+            (void)POPs;
             PUSHs(&PL_sv_yes);
             failed = false;
         }

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4788,7 +4788,7 @@ PP(pp_leaveeval)
     /* did require return a false value?
        check if use feature 'module_true' is enabled where it matters
      */
-    bool failed = false;
+    int failed = 0;
 
     if (CxOLD_OP_TYPE(cx) == OP_REQUIRE) {
         bool module_true = false;
@@ -4809,7 +4809,7 @@ PP(pp_leaveeval)
         if (module_true) {
             (void)POPs;
             PUSHs(&PL_sv_yes);
-            failed = false;
+            failed = 0;
         }
         else {
             failed = !(gimme == G_SCALAR

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -43,6 +43,7 @@ my %feature = (
     try             => 'try',
     defer           => 'defer',
     extra_paired_delimiters => 'more_delims',
+    module_true => 'module_true',
 );
 
 # NOTE: If a feature is ever enabled in a non-contiguous range of Perl
@@ -62,7 +63,7 @@ use constant V5_35  => sort grep {; $_ ne 'switch'
                                  && $_ ne 'indirect'
                                  && $_ ne 'multidimensional' } +V5_27, qw{isa signatures};
 
-use constant V5_37  => sort grep {; $_ ne 'bareword_filehandles' } +V5_35;
+use constant V5_37  => sort grep {; $_ ne 'bareword_filehandles' } +V5_35, qw{module_true};
 
 #
 # when updating features please also update the Pod entry for L</"FEATURES CHEAT SHEET">
@@ -492,8 +493,7 @@ read_only_bottom_close_and_rename($h);
 
 __END__
 package feature;
-
-our $VERSION = '1.76';
+our $VERSION = '1.77';
 
 FEATURES
 
@@ -1281,6 +1281,14 @@ The complete list of accepted paired delimiters as of Unicode 14.0 is:
  🢩  🢨    U+1F8A9, U+1F8A8 RIGHT/LEFTWARDS BACK-TILTED SHADOWED WHITE ARROW
  🢫  🢪    U+1F8AB, U+1F8AA RIGHT/LEFTWARDS FRONT-TILTED SHADOWED WHITE
                           ARROW
+
+=head2 The 'module_true' feature
+
+This feature removes the need to return a true value at the end of a module
+loaded with C<require> or C<use>. Any errors during compilation will cause
+failures, but reaching the end of the module when this feature is in effect
+will prevent C<perl> from throwing an exception that the module "did not return
+a true value".
 
 =head1 FEATURE BUNDLES
 

--- a/t/comp/require.t
+++ b/t/comp/require.t
@@ -33,7 +33,7 @@ if (grep -e, @files_to_delete) {
 
 
 my $Is_UTF8   = (${^OPEN} || "") =~ /:utf8/;
-my $total_tests = 62;
+my $total_tests = 64;
 if ($Is_UTF8) { $total_tests -= 3; }
 print "1..$total_tests\n";
 
@@ -381,6 +381,19 @@ if (defined &DynaLoader::boot_DynaLoader) {
     my $not = eval 'use bleah; 1' ? "" : "not ";
     $i++;
     print "${not}ok $i - use feature 'module_true' removes the need for an explicit true return value from a module ($@)\n";
+}
+
+{
+    BEGIN { ${^OPEN} = ":utf8\0"; }
+    %INC = ();
+    write_file('bleah.pm',"package bleah;\nuse feature 'module_true';\nsub bar{}; return 'some_true_value';\n");
+    my ($return_val, $rv2);
+    my $not = eval "\$return_val = require 'bleah.pm'; 1" ? "" : "not ";
+    $i++;
+    print "${not}ok $i - use feature 'module_true' works even if module has an explicit true return value ($@)\n";
+    $not = ($return_val && $return_val ne 'some_true_value') ? "" : "not ";
+    $i++;
+    print "${not}ok $i - use feature 'module_true' replaces any explicit return value with a true value ($@) <$return_val>\n";
 }
 
 ##########################################

--- a/t/comp/require.t
+++ b/t/comp/require.t
@@ -16,7 +16,7 @@ sub do_require {
 # don't make this lexical
 $i = 1;
 
-my @files_to_delete = qw (bleah.pm bleah.do bleah.flg urkkk.pm urkkk.pmc
+my @files_to_delete = qw (bleah.pm bleah.do bleah.flg bleahp.pm urkkk.pm urkkk.pmc
 krunch.pm krunch.pmc whap.pm whap.pmc);
 
 # there may be another copy of this test script running, or the files may
@@ -386,7 +386,7 @@ if (defined &DynaLoader::boot_DynaLoader) {
 {
     BEGIN { ${^OPEN} = ":utf8\0"; }
     %INC = ();
-    write_file('bleah.pm',"package bleah;\nuse feature 'module_true';\nsub bar{}; return 'some_true_value';\n");
+    write_file('bleahp.pm',"package bleahp;\nuse feature 'module_true';\nsub foop{}; return 'some_true_value';\n");
     my ($return_val, $rv2);
     my $not = eval "\$return_val = require 'bleah.pm'; 1" ? "" : "not ";
     $i++;

--- a/t/comp/require.t
+++ b/t/comp/require.t
@@ -33,7 +33,7 @@ if (grep -e, @files_to_delete) {
 
 
 my $Is_UTF8   = (${^OPEN} || "") =~ /:utf8/;
-my $total_tests = 58;
+my $total_tests = 62;
 if ($Is_UTF8) { $total_tests -= 3; }
 print "1..$total_tests\n";
 
@@ -348,6 +348,41 @@ if (defined &DynaLoader::boot_DynaLoader) {
     print "${not}ok $i - require does not localise %^H at run time\n";
 }
 
+{
+    BEGIN { ${^OPEN} = ":utf8\0"; }
+    %INC = ();
+    write_file('bleah.pm',"package bleah;\nuse v5.37;\nsub foo {};\n");
+    my $not = eval 'use bleah; 1' ? "" : "not ";
+    $i++;
+    print "${not}ok $i - use v5.37 removes the need for an explicit true return value from a module ($@)\n";
+}
+{
+    BEGIN { ${^OPEN} = ":utf8\0"; }
+    %INC = ();
+    write_file('bleah.pm',"package bleah;\nuse feature ':5.38';\n");
+    my $not = eval 'use bleah; 1' ? "" : "not ";
+    $i++;
+    print "${not}ok $i - use feature :5.38 removes the need for an explicit true return value from a module ($@)\n";
+}
+
+{
+    BEGIN { ${^OPEN} = ":utf8\0"; }
+    %INC = ();
+    write_file('bleah.pm',"package bleah;\nuse feature ':all';\nsub foo {};\n");
+    my $not = eval 'use bleah; 1' ? "" : "not ";
+    $i++;
+    print "${not}ok $i - use feature :all removes the need for an explicit true return value from a module ($@)\n";
+}
+
+{
+    BEGIN { ${^OPEN} = ":utf8\0"; }
+    %INC = ();
+    write_file('bleah.pm',"package bleah;\nuse feature 'module_true';\nsub bar{};\n");
+    my $not = eval 'use bleah; 1' ? "" : "not ";
+    $i++;
+    print "${not}ok $i - use feature 'module_true' removes the need for an explicit true return value from a module ($@)\n";
+}
+
 ##########################################
 # What follows are UTF-8 specific tests. #
 # Add generic tests before this point.   #
@@ -379,7 +414,7 @@ foreach (sort keys %templates) {
 
 END {
     foreach my $file (@files_to_delete) {
-	1 while unlink $file;
+        1 while unlink $file;
     }
 }
 


### PR DESCRIPTION
Per RFC 18, whenever `use feature 'module_true';` is enabled in a scope, any file required with `require` has an implicit return value of true and will not trigger the "did not return a true value" error condition.

Note that this implementation also propagates all features of the previous COP into the ex-nextstate COP created when leaving a block. This makes it possible to find and examine the last COP of a block (even when nulled) to discover any hints or features in effect at the end of the block.