### PR TITLE
Use `LINE_Tf` consistently for formatting `line_t` values

### DIFF
--- a/deb.c
+++ b/deb.c
@@ -87,17 +87,18 @@ Perl_vdeb(pTHX_ const char *pat, va_list *args)
 #ifdef DEBUGGING
     const char* const file = PL_curcop ? OutCopFILE(PL_curcop) : "<null>";
     const char* const display_file = file ? file : "<free>";
-    long line = PL_curcop ? (long)CopLINE(PL_curcop) : NOLINE;
+    line_t line = PL_curcop ? CopLINE(PL_curcop) : NOLINE;
     if (line == NOLINE)
         line = 0;
 
     PERL_ARGS_ASSERT_VDEB;
 
     if (DEBUG_v_TEST)
-        PerlIO_printf(Perl_debug_log, "(%ld:%s:%ld)\t",
+        PerlIO_printf(Perl_debug_log, "(%ld:%s:%" LINE_Tf ")\t",
                       (long)PerlProc_getpid(), display_file, line);
     else
-        PerlIO_printf(Perl_debug_log, "(%s:%ld)\t", display_file, line);
+        PerlIO_printf(Perl_debug_log, "(%s:%" LINE_Tf ")\t",
+                      display_file, line);
     (void) PerlIO_vprintf(Perl_debug_log, pat, *args);
 #else
     PERL_UNUSED_CONTEXT;

--- a/dump.c
+++ b/dump.c
@@ -1318,8 +1318,8 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
     case OP_NEXTSTATE:
     case OP_DBSTATE:
         if (CopLINE(cCOPo))
-            S_opdump_indent(aTHX_ o, level, bar, file, "LINE = %" UVuf "\n",
-                             (UV)CopLINE(cCOPo));
+            S_opdump_indent(aTHX_ o, level, bar, file, "LINE = %" LINE_Tf "\n",
+                            CopLINE(cCOPo));
 
         if (CopSTASHPV(cCOPo)) {
             SV* tmpsv = newSVpvs_flags("", SVs_TEMP);

--- a/dump.c
+++ b/dump.c
@@ -2523,7 +2523,7 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
                                             " (%s)\n",
                                (UV)GvGPFLAGS(sv),
                                "");
-        Perl_dump_indent(aTHX_ level, file, "    LINE = %" IVdf "\n", (IV)GvLINE(sv));
+        Perl_dump_indent(aTHX_ level, file, "    LINE = %" LINE_Tf "\n", (line_t)GvLINE(sv));
         Perl_dump_indent(aTHX_ level, file, "    FILE = \"%s\"\n", GvFILE(sv));
         do_gv_dump (level, file, "    EGV", GvEGV(sv));
         break;

--- a/locale.c
+++ b/locale.c
@@ -531,7 +531,7 @@ Perl_locale_panic(const char * msg,
 #endif
 
     /* diag_listed_as: panic: %s */
-    Perl_croak(aTHX_ "%s: %d: panic: %s; errno=%d\n",
+    Perl_croak(aTHX_ "%s: %" LINE_Tf ": panic: %s; errno=%d\n",
                      file_name, line, msg, errnum);
 }
 
@@ -6037,7 +6037,7 @@ S_toggle_locale_i(pTHX_ const unsigned cat_index,
     /* If the locales are the same, there's nothing to do */
     if (strEQ(locale_to_restore_to, new_locale)) {
         DEBUG_Lv(PerlIO_printf(Perl_debug_log,
-                               "(%d): %s locale unchanged as %s\n",
+                               "(%" LINE_Tf "): %s locale unchanged as %s\n",
                                caller_line, category_names[cat_index],
                                new_locale));
 

--- a/locale.c
+++ b/locale.c
@@ -121,14 +121,19 @@
 static int debug_initialization = 0;
 #  define DEBUG_INITIALIZATION_set(v) (debug_initialization = v)
 #  define DEBUG_LOCALE_INITIALIZATION_  debug_initialization
+/* C standards seem to say that __LINE__ is merely "an integer constant",
+ * which means it might be either int, long (with L suffix), or long long
+ * (or their corresponding unsigned type).  So, we have to explicitly cast
+ * __LINE__ to a particular integer type to pass it reliably to variadic
+ * functions like (PerlIO_)printf, as below: */
 #  ifdef USE_LOCALE_THREADS
 #    define DEBUG_PRE_STMTS                                                     \
      dSAVE_ERRNO; dTHX; PerlIO_printf(Perl_debug_log,"\n%s: %" LINE_Tf ": %p: ",\
-                                                     __FILE__, __LINE__, aTHX);
+                                      __FILE__, (line_t)__LINE__, aTHX);
 #  else
 #    define DEBUG_PRE_STMTS                                                     \
      dSAVE_ERRNO; dTHX; PerlIO_printf(Perl_debug_log, "\n%s: %" LINE_Tf ": ",   \
-                                                     __FILE__, __LINE__);
+                                      __FILE__, (line_t)__LINE__);
 #  endif
 #  define DEBUG_POST_STMTS  RESTORE_ERRNO;
 #else

--- a/op.c
+++ b/op.c
@@ -10048,9 +10048,9 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
             GV * const db_postponed = gv_fetchpvs("DB::postponed",
                                                   GV_ADDMULTI, SVt_PVHV);
             HV *hv;
-            SV * const sv = Perl_newSVpvf(aTHX_ "%s:%ld-%" LINE_Tf,
+            SV * const sv = Perl_newSVpvf(aTHX_ "%s:%" LINE_Tf "-%" LINE_Tf,
                                           CopFILE(PL_curcop),
-                                          (long)PL_subline,
+                                          (line_t)PL_subline,
                                           CopLINE(PL_curcop));
             if (HvNAME_HEK(PL_curstash)) {
                 sv_sethek(tmpstr, HvNAME_HEK(PL_curstash));
@@ -10656,9 +10656,9 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
             GV * const db_postponed = gv_fetchpvs("DB::postponed",
                                                   GV_ADDMULTI, SVt_PVHV);
             HV *hv;
-            SV * const sv = Perl_newSVpvf(aTHX_ "%s:%ld-%" LINE_Tf,
+            SV * const sv = Perl_newSVpvf(aTHX_ "%s:%" LINE_Tf "-%" LINE_Tf,
                                           CopFILE(PL_curcop),
-                                          (long)PL_subline,
+                                          (line_t)PL_subline,
                                           CopLINE(PL_curcop));
             (void)hv_store_ent(GvHV(PL_DBsub), tmpstr, sv, 0);
             hv = GvHVn(db_postponed);

--- a/op.c
+++ b/op.c
@@ -10048,10 +10048,10 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
             GV * const db_postponed = gv_fetchpvs("DB::postponed",
                                                   GV_ADDMULTI, SVt_PVHV);
             HV *hv;
-            SV * const sv = Perl_newSVpvf(aTHX_ "%s:%ld-%ld",
+            SV * const sv = Perl_newSVpvf(aTHX_ "%s:%ld-%" LINE_Tf,
                                           CopFILE(PL_curcop),
                                           (long)PL_subline,
-                                          (long)CopLINE(PL_curcop));
+                                          CopLINE(PL_curcop));
             if (HvNAME_HEK(PL_curstash)) {
                 sv_sethek(tmpstr, HvNAME_HEK(PL_curstash));
                 sv_catpvs(tmpstr, "::");
@@ -10260,9 +10260,9 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
         has_name = TRUE;
     } else if (PERLDB_NAMEANON && CopLINE(PL_curcop)) {
         SV * const sv = sv_newmortal();
-        Perl_sv_setpvf(aTHX_ sv, "%s[%s:%" IVdf "]",
+        Perl_sv_setpvf(aTHX_ sv, "%s[%s:%" LINE_Tf "]",
                        PL_curstash ? "__ANON__" : "__ANON__::__ANON__",
-                       CopFILE(PL_curcop), (IV)CopLINE(PL_curcop));
+                       CopFILE(PL_curcop), CopLINE(PL_curcop));
         gv = gv_fetchsv(sv, gv_fetch_flags, SVt_PVCV);
         has_name = TRUE;
     } else if (PL_curstash) {
@@ -10656,10 +10656,10 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
             GV * const db_postponed = gv_fetchpvs("DB::postponed",
                                                   GV_ADDMULTI, SVt_PVHV);
             HV *hv;
-            SV * const sv = Perl_newSVpvf(aTHX_ "%s:%ld-%ld",
+            SV * const sv = Perl_newSVpvf(aTHX_ "%s:%ld-%" LINE_Tf,
                                           CopFILE(PL_curcop),
                                           (long)PL_subline,
-                                          (long)CopLINE(PL_curcop));
+                                          CopLINE(PL_curcop));
             (void)hv_store_ent(GvHV(PL_DBsub), tmpstr, sv, 0);
             hv = GvHVn(db_postponed);
             if (HvTOTALKEYS(hv) > 0 && hv_exists_ent(hv, tmpstr, 0)) {
@@ -13973,7 +13973,7 @@ Perl_ck_entersub_args_core(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
         case 'L': return newSVOP(
                            OP_CONST, 0,
                            Perl_newSVpvf(aTHX_
-                             "%" IVdf, (IV)CopLINE(PL_curcop)
+                             "%" LINE_Tf, CopLINE(PL_curcop)
                            )
                          );
         case 'P': return newSVOP(OP_CONST, 0,

--- a/perlio.c
+++ b/perlio.c
@@ -362,7 +362,7 @@ PerlIO_debug(const char *fmt, ...)
         const char * const s = CopFILE(PL_curcop);
         /* Use fixed buffer as sv_catpvf etc. needs SVs */
         char buffer[1024];
-        const STRLEN len1 = my_snprintf(buffer, sizeof(buffer), "%.40s:%" IVdf " ", s ? s : "(none)", (IV) CopLINE(PL_curcop));
+        const STRLEN len1 = my_snprintf(buffer, sizeof(buffer), "%.40s:%" LINE_Tf " ", s ? s : "(none)", CopLINE(PL_curcop));
 #  ifdef USE_QUADMATH
 #    ifdef HAS_VSNPRINTF
         /* my_vsnprintf() isn't available with quadmath, but the native vsnprintf()
@@ -380,8 +380,8 @@ PerlIO_debug(const char *fmt, ...)
 #else
         const char *s = CopFILE(PL_curcop);
         STRLEN len;
-        SV * const sv = Perl_newSVpvf(aTHX_ "%s:%" IVdf " ", s ? s : "(none)",
-                                      (IV) CopLINE(PL_curcop));
+        SV * const sv = Perl_newSVpvf(aTHX_ "%s:%" LINE_Tf " ",
+                                      s ? s : "(none)", CopLINE(PL_curcop));
         Perl_sv_vcatpvf(aTHX_ sv, fmt, &ap);
 
         s = SvPV_const(sv, len);

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4693,9 +4693,9 @@ PP(pp_entereval)
 
     if (PERLDB_NAMEEVAL && CopLINE(PL_curcop)) {
         SV * const temp_sv = sv_newmortal();
-        Perl_sv_setpvf(aTHX_ temp_sv, "_<(eval %lu)[%s:%" IVdf "]",
+        Perl_sv_setpvf(aTHX_ temp_sv, "_<(eval %lu)[%s:%" LINE_Tf "]",
                        (unsigned long)++PL_evalseq,
-                       CopFILE(PL_curcop), (IV)CopLINE(PL_curcop));
+                       CopFILE(PL_curcop), CopLINE(PL_curcop));
         tmpbuf = SvPVX(temp_sv);
         len = SvCUR(temp_sv);
     }

--- a/toke.c
+++ b/toke.c
@@ -10096,7 +10096,7 @@ S_scan_ident(pTHX_ char *s, char *dest, STRLEN destlen, I32 ck_uni)
     char *d = dest;
     char * const e = d + destlen - 3;    /* two-character token, ending NUL */
     bool is_utf8 = cBOOL(UTF);
-    I32 orig_copline = 0, tmp_copline = 0;
+    line_t orig_copline = 0, tmp_copline = 0;
 
     PERL_ARGS_ASSERT_SCAN_IDENT;
 

--- a/toke.c
+++ b/toke.c
@@ -9385,8 +9385,8 @@ Perl_yylex(pTHX)
     }
     DEBUG_T( {
         SV* tmp = newSVpvs("");
-        PerlIO_printf(Perl_debug_log, "### %" IVdf ":LEX_%s/X%s %s\n",
-            (IV)CopLINE(PL_curcop),
+        PerlIO_printf(Perl_debug_log, "### %" LINE_Tf ":LEX_%s/X%s %s\n",
+            CopLINE(PL_curcop),
             lex_state_names[PL_lex_state],
             exp_name[PL_expect],
             pv_display(tmp, s, strlen(s), 0, 60));
@@ -12641,8 +12641,8 @@ Perl_yyerror_pvn(pTHX_ const char *const s, STRLEN len, U32 flags)
         {
             Perl_sv_catpvf(aTHX_ msg,
             "  (Might be a runaway multi-line %c%c string starting on"
-            " line %" IVdf ")\n",
-                    (int)PL_multi_open,(int)PL_multi_close,(IV)PL_multi_start);
+            " line %" LINE_Tf ")\n",
+                    (int)PL_multi_open,(int)PL_multi_close,(line_t)PL_multi_start);
             PL_multi_end = 0;
         }
         if (PL_in_eval & EVAL_WARNONLY) {

--- a/toke.c
+++ b/toke.c
@@ -7755,7 +7755,7 @@ yyl_word_or_keyword(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword, struct
     case KEY___LINE__:
         FUN0OP(
             newSVOP(OP_CONST, 0,
-                Perl_newSVpvf(aTHX_ "%" IVdf, (IV)CopLINE(PL_curcop)))
+                Perl_newSVpvf(aTHX_ "%" LINE_Tf, CopLINE(PL_curcop)))
         );
 
     case KEY___PACKAGE__:
@@ -12626,9 +12626,9 @@ Perl_yyerror_pvn(pTHX_ const char *const s, STRLEN len, U32 flags)
                 Perl_sv_catpvf(aTHX_ where_sv, "\\%03o", yychar & 255);
         }
         msg = newSVpvn_flags(s, len, (flags & SVf_UTF8) | SVs_TEMP);
-        Perl_sv_catpvf(aTHX_ msg, " at %s line %" IVdf ", ",
+        Perl_sv_catpvf(aTHX_ msg, " at %s line %" LINE_Tf ", ",
             OutCopFILE(PL_curcop),
-            (IV)(PL_parser->preambling == NOLINE
+            (PL_parser->preambling == NOLINE
                    ? CopLINE(PL_curcop)
                    : PL_parser->preambling));
         if (context)

--- a/util.c
+++ b/util.c
@@ -1742,8 +1742,8 @@ Perl_mess_sv(pTHX_ SV *basemsg, bool consume)
                 cop = PL_curcop;
 
             if (CopLINE(cop))
-                Perl_sv_catpvf(aTHX_ sv, " at %s line %" IVdf,
-                                OutCopFILE(cop), (IV)CopLINE(cop));
+                Perl_sv_catpvf(aTHX_ sv, " at %s line %" LINE_Tf,
+                                OutCopFILE(cop), CopLINE(cop));
         }
 
         /* Seems that GvIO() can be untrustworthy during global destruction. */
@@ -5233,7 +5233,7 @@ S_mem_log_common(enum mem_log_type mlt, const UV n,
 #ifdef USE_C_BACKTRACE
             if(strchr(pmlenv,'c') && (mlt == MLT_NEW_SV)) {
                 len = my_snprintf(buf, sizeof(buf),
-                        "  caller %s at %s line %d\n",
+                        "  caller %s at %s line %" LINE_Tf "\n",
                         /* CopSTASHPV can crash early on startup; use CopFILE to check */
                         CopFILE(PL_curcop) ? CopSTASHPV(PL_curcop) : "<unknown>",
                         CopFILE(PL_curcop), CopLINE(PL_curcop));


### PR DESCRIPTION
Before this change, formatting `line_t` values used to be done with various specifiers, such as `%ld` (with `(long)` cast), `UVuf` (with `(UV)` cast), or plain `%d` (without cast).
I think this inconsistent so that I will suggest to use `LINE_Tf` thoroughly.

This will also silence build warnings (on 32-bit DEBUGGING build) around `line_t`, like these:
```
locale.c:527:28: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘line_t’ {aka ‘const long unsigned int’} [-Wformat=]
deb.c:91:14: warning: comparison of integer expressions of different signedness: ‘long int’ and ‘long unsigned int’ [-Wsign-compare]
```

No functional changes are intended.