### PR TITLE
Meld Windows and non-Windows setlocale(..., "") into a single function, and tidy

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3381,7 +3381,6 @@ S	|const char *|setlocale_from_aggregate_LC_ALL			\
 S	|const char*|update_PL_curlocales_i|const unsigned int index	\
 				    |NN const char * new_locale		\
 				    |recalc_lc_all_t recalc_LC_ALL
-S	|const char *|find_locale_from_environment|const unsigned int index
 #      endif
 #    else
 #      if   defined(USE_LOCALE_THREADS)					\
@@ -3401,6 +3400,9 @@ S	|void	|less_dicey_void_setlocale_i				\
 				|NN const char * locale			\
 				|const line_t line
 #      endif
+#    endif
+#    if defined(USE_POSIX_2008_LOCALE) && ! defined(USE_QUERYLOCALE)
+S	|const char *|find_locale_from_environment|const unsigned int index
 #    endif
 #    if defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE)
 S	|const char *|calculate_LC_ALL|const locale_t cur_obj

--- a/embed.fnc
+++ b/embed.fnc
@@ -3425,7 +3425,7 @@ S	|void	|print_collxfrm_input_and_return		\
 #      endif
 #    endif
 #    ifdef WIN32
-S	|char*	|win32_setlocale|int category|NULLOK const char* locale
+S	|const char*|win32_setlocale|int category|NULLOK const char* locale
 ST	|wchar_t *|Win_byte_string_to_wstring|const UINT code_page	\
 				|NULLOK const char * byte_string
 ST	|char *	|Win_wstring_to_byte_string|const UINT code_page	\

--- a/embed.fnc
+++ b/embed.fnc
@@ -3430,7 +3430,8 @@ ST	|wchar_t *|Win_byte_string_to_wstring|const UINT code_page	\
 				|NULLOK const char * byte_string
 ST	|char *	|Win_wstring_to_byte_string|const UINT code_page	\
 				|NULLOK const wchar_t * wstring
-S	|char *|wrap_wsetlocale |const int category			\
+S	|const char *|wrap_wsetlocale					\
+				|const int category			\
 				|NULLOK const char *locale
 #    endif
 #    if defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L)

--- a/embed.fnc
+++ b/embed.fnc
@@ -3426,8 +3426,8 @@ S	|void	|print_collxfrm_input_and_return		\
 #    endif
 #    ifdef WIN32
 S	|char*	|win32_setlocale|int category|NULLOK const char* locale
-pTC	|wchar_t *|Win_utf8_string_to_wstring|NULLOK const char * utf8_string
-pTC	|char *	|Win_wstring_to_utf8_string|NULLOK const wchar_t * wstring
+ST	|wchar_t *|Win_utf8_string_to_wstring|NULLOK const char * utf8_string
+ST	|char *	|Win_wstring_to_utf8_string|NULLOK const wchar_t * wstring
 S	|char *|wrap_wsetlocale |const int category			\
 				|NULLOK const char *locale
 #    endif

--- a/embed.fnc
+++ b/embed.fnc
@@ -3401,14 +3401,15 @@ S	|void	|less_dicey_void_setlocale_i				\
 				|const line_t line
 #      endif
 #    endif
-#    if defined(USE_POSIX_2008_LOCALE) && ! defined(USE_QUERYLOCALE)
+#    if defined(WIN32) || (     defined(USE_POSIX_2008_LOCALE)   \
+                           && ! defined(USE_QUERYLOCALE))
 S	|const char *|find_locale_from_environment|const unsigned int index
 #    endif
 #    if defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE)
 S	|const char *|calculate_LC_ALL|const locale_t cur_obj
 #    else
 :	    regen/embed.pl can't currently cope with 'elif'
-#      if defined(USE_POSIX_2008_LOCALE) || ! defined(LC_ALL)
+#      if defined(WIN32) || defined(USE_POSIX_2008_LOCALE) || ! defined(LC_ALL)
 S	|const char *|calculate_LC_ALL|NN const char ** individ_locales
 #      endif
 #    endif

--- a/embed.fnc
+++ b/embed.fnc
@@ -3425,6 +3425,8 @@ S	|void	|print_collxfrm_input_and_return		\
 S	|char*	|win32_setlocale|int category|NULLOK const char* locale
 pTC	|wchar_t *|Win_utf8_string_to_wstring|NULLOK const char * utf8_string
 pTC	|char *	|Win_wstring_to_utf8_string|NULLOK const wchar_t * wstring
+S	|char *|wrap_wsetlocale |const int category			\
+				|NULLOK const char *locale
 #    endif
 #    if defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L)
 S	|const char*|my_langinfo_i|const nl_item item			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -3426,8 +3426,10 @@ S	|void	|print_collxfrm_input_and_return		\
 #    endif
 #    ifdef WIN32
 S	|char*	|win32_setlocale|int category|NULLOK const char* locale
-ST	|wchar_t *|Win_utf8_string_to_wstring|NULLOK const char * utf8_string
-ST	|char *	|Win_wstring_to_utf8_string|NULLOK const wchar_t * wstring
+ST	|wchar_t *|Win_byte_string_to_wstring|const UINT code_page	\
+				|NULLOK const char * byte_string
+ST	|char *	|Win_wstring_to_byte_string|const UINT code_page	\
+				|NULLOK const wchar_t * wstring
 S	|char *|wrap_wsetlocale |const int category			\
 				|NULLOK const char *locale
 #    endif

--- a/embed.h
+++ b/embed.h
@@ -1772,8 +1772,8 @@
 #define calculate_LC_ALL(a)	S_calculate_LC_ALL(aTHX_ a)
 #      endif
 #      if defined(WIN32)
-#define Win_utf8_string_to_wstring	S_Win_utf8_string_to_wstring
-#define Win_wstring_to_utf8_string	S_Win_wstring_to_utf8_string
+#define Win_byte_string_to_wstring	S_Win_byte_string_to_wstring
+#define Win_wstring_to_byte_string	S_Win_wstring_to_byte_string
 #define win32_setlocale(a,b)	S_win32_setlocale(aTHX_ a,b)
 #define wrap_wsetlocale(a,b)	S_wrap_wsetlocale(aTHX_ a,b)
 #      endif

--- a/embed.h
+++ b/embed.h
@@ -1598,7 +1598,6 @@
 #    if defined(PERL_IN_LOCALE_C)
 #      if defined(USE_LOCALE)
 #        if defined(USE_POSIX_2008_LOCALE)
-#define find_locale_from_environment(a)	S_find_locale_from_environment(aTHX_ a)
 #define update_PL_curlocales_i(a,b,c)	S_update_PL_curlocales_i(aTHX_ a,b,c)
 #        endif
 #      endif
@@ -1776,6 +1775,9 @@
 #define my_querylocale_i(a)	S_my_querylocale_i(aTHX_ a)
 #define setlocale_from_aggregate_LC_ALL(a,b)	S_setlocale_from_aggregate_LC_ALL(aTHX_ a,b)
 #define use_curlocale_scratch()	S_use_curlocale_scratch(aTHX)
+#      endif
+#      if defined(USE_POSIX_2008_LOCALE) && ! defined(USE_QUERYLOCALE)
+#define find_locale_from_environment(a)	S_find_locale_from_environment(aTHX_ a)
 #      endif
 #      if defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE)
 #define calculate_LC_ALL(a)	S_calculate_LC_ALL(aTHX_ a)

--- a/embed.h
+++ b/embed.h
@@ -1522,7 +1522,7 @@
 #  if !(defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE))
 #    if defined(PERL_IN_LOCALE_C)
 #      if defined(USE_LOCALE)
-#        if defined(USE_POSIX_2008_LOCALE) || ! defined(LC_ALL)
+#        if defined(WIN32) || defined(USE_POSIX_2008_LOCALE) || ! defined(LC_ALL)
 #define calculate_LC_ALL(a)	S_calculate_LC_ALL(aTHX_ a)
 #        endif
 #      endif
@@ -1776,15 +1776,15 @@
 #define setlocale_from_aggregate_LC_ALL(a,b)	S_setlocale_from_aggregate_LC_ALL(aTHX_ a,b)
 #define use_curlocale_scratch()	S_use_curlocale_scratch(aTHX)
 #      endif
-#      if defined(USE_POSIX_2008_LOCALE) && ! defined(USE_QUERYLOCALE)
-#define find_locale_from_environment(a)	S_find_locale_from_environment(aTHX_ a)
-#      endif
 #      if defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE)
 #define calculate_LC_ALL(a)	S_calculate_LC_ALL(aTHX_ a)
 #      endif
 #      if defined(WIN32)
 #define win32_setlocale(a,b)	S_win32_setlocale(aTHX_ a,b)
 #define wrap_wsetlocale(a,b)	S_wrap_wsetlocale(aTHX_ a,b)
+#      endif
+#      if defined(WIN32) || (     defined(USE_POSIX_2008_LOCALE)                              && ! defined(USE_QUERYLOCALE))
+#define find_locale_from_environment(a)	S_find_locale_from_environment(aTHX_ a)
 #      endif
 #    endif
 #  endif

--- a/embed.h
+++ b/embed.h
@@ -826,14 +826,6 @@
 #define dump_mstats(a)		Perl_dump_mstats(aTHX_ a)
 #define get_mstats(a,b,c)	Perl_get_mstats(aTHX_ a,b,c)
 #endif
-#if defined(PERL_IN_LOCALE_C)
-#  if defined(USE_LOCALE)
-#    if defined(WIN32)
-#define Win_utf8_string_to_wstring	Perl_Win_utf8_string_to_wstring
-#define Win_wstring_to_utf8_string	Perl_Win_wstring_to_utf8_string
-#    endif
-#  endif
-#endif
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C)
 #define check_regnode_after(a,b)	Perl_check_regnode_after(aTHX_ a,b)
 #define regnext(a)		Perl_regnext(aTHX_ a)
@@ -1780,6 +1772,8 @@
 #define calculate_LC_ALL(a)	S_calculate_LC_ALL(aTHX_ a)
 #      endif
 #      if defined(WIN32)
+#define Win_utf8_string_to_wstring	S_Win_utf8_string_to_wstring
+#define Win_wstring_to_utf8_string	S_Win_wstring_to_utf8_string
 #define win32_setlocale(a,b)	S_win32_setlocale(aTHX_ a,b)
 #define wrap_wsetlocale(a,b)	S_wrap_wsetlocale(aTHX_ a,b)
 #      endif

--- a/embed.h
+++ b/embed.h
@@ -1782,6 +1782,7 @@
 #      endif
 #      if defined(WIN32)
 #define win32_setlocale(a,b)	S_win32_setlocale(aTHX_ a,b)
+#define wrap_wsetlocale(a,b)	S_wrap_wsetlocale(aTHX_ a,b)
 #      endif
 #    endif
 #  endif

--- a/locale.c
+++ b/locale.c
@@ -2500,6 +2500,8 @@ Perl_Win_wstring_to_utf8_string(const wchar_t * wstring)
 
 STATIC char *
 S_wrap_wsetlocale(pTHX_ int category, const char *locale) {
+    PERL_ARGS_ASSERT_WRAP_WSETLOCALE;
+
     wchar_t *wlocale = NULL;
     wchar_t *wresult;
     char *result;
@@ -2587,7 +2589,7 @@ S_win32_setlocale(pTHX_ int category, const char* locale)
     }
 
 #ifdef USE_WSETLOCALE
-    result = S_wrap_wsetlocale(aTHX_ category, locale);
+    result = wrap_wsetlocale(category, locale);
 #else
     result = setlocale(category, locale);
 #endif
@@ -2608,7 +2610,7 @@ S_win32_setlocale(pTHX_ int category, const char* locale)
         result = PerlEnv_getenv(category_names[i]);
         if (result && strNE(result, "")) {
 #ifdef USE_WSETLOCALE
-            S_wrap_wsetlocale(aTHX_ categories[i], result);
+            wrap_wsetlocale(categories[i], result);
 #else
             setlocale(categories[i], result);
 #endif
@@ -5050,7 +5052,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
                  * use wrap_wsetlocale(). */
                 const char *system_default_locale =
                                     stdize_locale(LC_ALL,
-                                                  S_wrap_wsetlocale(aTHX_ LC_ALL, ""),
+                                                  wrap_wsetlocale(LC_ALL, ""),
                                                   &PL_stdize_locale_buf,
                                                   &PL_stdize_locale_bufsize,
                                                   __LINE__);

--- a/locale.c
+++ b/locale.c
@@ -2542,13 +2542,12 @@ S_Win_wstring_to_byte_string(const UINT code_page, const wchar_t * wstring)
 
 #define Win_wstring_to_utf8_string(ws) Win_wstring_to_byte_string(CP_UTF8, (ws))
 
-STATIC char *
-S_wrap_wsetlocale(pTHX_ int category, const char *locale) {
+STATIC const char *
+S_wrap_wsetlocale(pTHX_ const int category, const char *locale)
+{
     PERL_ARGS_ASSERT_WRAP_WSETLOCALE;
 
-    wchar_t *wlocale = NULL;
-    wchar_t *wresult;
-    char *result;
+    const wchar_t * wlocale = NULL;
 
     if (locale) {
         wlocale = Win_utf8_string_to_wstring(locale);
@@ -2560,14 +2559,14 @@ S_wrap_wsetlocale(pTHX_ int category, const char *locale) {
         wlocale = NULL;
     }
 
-    wresult = _wsetlocale(category, wlocale);
+    const wchar_t * wresult = _wsetlocale(category, wlocale);
     Safefree(wlocale);
 
     if (! wresult) {
             return NULL;
         }
 
-    result = Win_wstring_to_utf8_string(wresult);
+    const char * result = Win_wstring_to_utf8_string(wresult);
     SAVEFREEPV(result); /* is there something better we can do here? */
 
     return result;
@@ -2601,10 +2600,10 @@ S_win32_setlocale(pTHX_ int category, const char* locale)
         locale = find_locale_from_environment(get_category_index(category, ""));
     }
 
-    char * result = wrap_wsetlocale(category, locale);
+    const char * result = wrap_wsetlocale(category, locale);
     DEBUG_L(PerlIO_printf(Perl_debug_log, "%s\n",
                           setlocale_debug_string_r(category, locale, result)));
-    return result;
+    return (char *) result;
 }
 
 #endif

--- a/locale.c
+++ b/locale.c
@@ -2572,7 +2572,7 @@ S_wrap_wsetlocale(pTHX_ const int category, const char *locale)
     return result;
 }
 
-STATIC char *
+STATIC const char *
 S_win32_setlocale(pTHX_ int category, const char* locale)
 {
     /* This, for Windows, emulates POSIX setlocale() behavior.  There is no
@@ -2603,7 +2603,7 @@ S_win32_setlocale(pTHX_ int category, const char* locale)
     const char * result = wrap_wsetlocale(category, locale);
     DEBUG_L(PerlIO_printf(Perl_debug_log, "%s\n",
                           setlocale_debug_string_r(category, locale, result)));
-    return (char *) result;
+    return result;
 }
 
 #endif

--- a/locale.c
+++ b/locale.c
@@ -2538,10 +2538,6 @@ Perl_Win_wstring_to_utf8_string(const wchar_t * wstring)
     return utf8_string;
 }
 
-#define USE_WSETLOCALE
-
-#ifdef USE_WSETLOCALE
-
 STATIC char *
 S_wrap_wsetlocale(pTHX_ int category, const char *locale) {
     PERL_ARGS_ASSERT_WRAP_WSETLOCALE;
@@ -2573,8 +2569,6 @@ S_wrap_wsetlocale(pTHX_ int category, const char *locale) {
     return result;
 }
 
-#endif
-
 STATIC char *
 S_win32_setlocale(pTHX_ int category, const char* locale)
 {
@@ -2603,11 +2597,7 @@ S_win32_setlocale(pTHX_ int category, const char* locale)
         locale = find_locale_from_environment(get_category_index(category, ""));
     }
 
-#ifdef USE_WSETLOCALE
     char * result = wrap_wsetlocale(category, locale);
-#else
-    char * result = setlocale(category, locale);
-#endif
     DEBUG_L(PerlIO_printf(Perl_debug_log, "%s\n",
                           setlocale_debug_string_r(category, locale, result)));
     return result;

--- a/locale.c
+++ b/locale.c
@@ -2593,7 +2593,11 @@ S_win32_setlocale(pTHX_ int category, const char* locale)
      * variable. */
 
 
-    if (locale && strEQ(locale, "")) {
+    if (locale == NULL) {
+        return wrap_wsetlocale(category, NULL);
+    }
+
+    if (strEQ(locale, "")) {
         /* Note this function may change the locale, but that's ok because we
          * are about to change it anyway */
         locale = find_locale_from_environment(get_category_index(category, ""));

--- a/locale.c
+++ b/locale.c
@@ -2495,7 +2495,7 @@ S_new_collate(pTHX_ const char *newcoll)
 #ifdef WIN32
 
 wchar_t *
-Perl_Win_utf8_string_to_wstring(const char * utf8_string)
+S_Win_utf8_string_to_wstring(const char * utf8_string)
 {
     wchar_t *wstring;
 
@@ -2518,7 +2518,7 @@ Perl_Win_utf8_string_to_wstring(const char * utf8_string)
 }
 
 char *
-Perl_Win_wstring_to_utf8_string(const wchar_t * wstring)
+S_Win_wstring_to_utf8_string(const wchar_t * wstring)
 {
     char *utf8_string;
 

--- a/locale.c
+++ b/locale.c
@@ -2495,11 +2495,11 @@ S_new_collate(pTHX_ const char *newcoll)
 #ifdef WIN32
 
 wchar_t *
-S_Win_utf8_string_to_wstring(const char * utf8_string)
+S_Win_byte_string_to_wstring(const UINT code_page, const char * byte_string)
 {
     wchar_t *wstring;
 
-    int req_size = MultiByteToWideChar(CP_UTF8, 0, utf8_string, -1, NULL, 0);
+    int req_size = MultiByteToWideChar(code_page, 0, byte_string, -1, NULL, 0);
     if (! req_size) {
         errno = EINVAL;
         return NULL;
@@ -2507,7 +2507,7 @@ S_Win_utf8_string_to_wstring(const char * utf8_string)
 
     Newx(wstring, req_size, wchar_t);
 
-    if (! MultiByteToWideChar(CP_UTF8, 0, utf8_string, -1, wstring, req_size))
+    if (! MultiByteToWideChar(code_page, 0, byte_string, -1, wstring, req_size))
     {
         Safefree(wstring);
         errno = EINVAL;
@@ -2517,26 +2517,30 @@ S_Win_utf8_string_to_wstring(const char * utf8_string)
     return wstring;
 }
 
+#define Win_utf8_string_to_wstring(s)  Win_byte_string_to_wstring(CP_UTF8, (s))
+
 char *
-S_Win_wstring_to_utf8_string(const wchar_t * wstring)
+S_Win_wstring_to_byte_string(const UINT code_page, const wchar_t * wstring)
 {
-    char *utf8_string;
 
     int req_size =
-              WideCharToMultiByte(CP_UTF8, 0, wstring, -1, NULL, 0, NULL, NULL);
+            WideCharToMultiByte(code_page, 0, wstring, -1, NULL, 0, NULL, NULL);
 
-    Newx(utf8_string, req_size, char);
+    char *byte_string;
+    Newx(byte_string, req_size, char);
 
-    if (! WideCharToMultiByte(CP_UTF8, 0, wstring, -1, utf8_string,
+    if (! WideCharToMultiByte(code_page, 0, wstring, -1, byte_string,
                                                          req_size, NULL, NULL))
     {
-        Safefree(utf8_string);
+        Safefree(byte_string);
         errno = EINVAL;
         return NULL;
     }
 
-    return utf8_string;
+    return byte_string;
 }
+
+#define Win_wstring_to_utf8_string(ws) Win_wstring_to_byte_string(CP_UTF8, (ws))
 
 STATIC char *
 S_wrap_wsetlocale(pTHX_ int category, const char *locale) {

--- a/proto.h
+++ b/proto.h
@@ -5765,7 +5765,7 @@ STATIC char *	S_Win_wstring_to_byte_string(const UINT code_page, const wchar_t *
 #define PERL_ARGS_ASSERT_WIN_WSTRING_TO_BYTE_STRING
 STATIC char*	S_win32_setlocale(pTHX_ int category, const char* locale);
 #define PERL_ARGS_ASSERT_WIN32_SETLOCALE
-STATIC char *	S_wrap_wsetlocale(pTHX_ const int category, const char *locale);
+STATIC const char *	S_wrap_wsetlocale(pTHX_ const int category, const char *locale);
 #define PERL_ARGS_ASSERT_WRAP_WSETLOCALE
 #    endif
 #    if defined(WIN32) || (     defined(USE_POSIX_2008_LOCALE)                              && ! defined(USE_QUERYLOCALE))

--- a/proto.h
+++ b/proto.h
@@ -4718,7 +4718,7 @@ PERL_CALLCONV Signal_t	Perl_sighandler(int sig)
 #if !(defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE))
 #  if defined(PERL_IN_LOCALE_C)
 #    if defined(USE_LOCALE)
-#      if defined(USE_POSIX_2008_LOCALE) || ! defined(LC_ALL)
+#      if defined(WIN32) || defined(USE_POSIX_2008_LOCALE) || ! defined(LC_ALL)
 STATIC const char *	S_calculate_LC_ALL(pTHX_ const char ** individ_locales);
 #define PERL_ARGS_ASSERT_CALCULATE_LC_ALL	\
 	assert(individ_locales)
@@ -5754,10 +5754,6 @@ STATIC const char *	S_setlocale_from_aggregate_LC_ALL(pTHX_ const char * locale,
 STATIC locale_t	S_use_curlocale_scratch(pTHX);
 #define PERL_ARGS_ASSERT_USE_CURLOCALE_SCRATCH
 #    endif
-#    if defined(USE_POSIX_2008_LOCALE) && ! defined(USE_QUERYLOCALE)
-STATIC const char *	S_find_locale_from_environment(pTHX_ const unsigned int index);
-#define PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT
-#    endif
 #    if defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE)
 STATIC const char *	S_calculate_LC_ALL(pTHX_ const locale_t cur_obj);
 #define PERL_ARGS_ASSERT_CALCULATE_LC_ALL
@@ -5771,6 +5767,10 @@ STATIC char*	S_win32_setlocale(pTHX_ int category, const char* locale);
 #define PERL_ARGS_ASSERT_WIN32_SETLOCALE
 STATIC char *	S_wrap_wsetlocale(pTHX_ const int category, const char *locale);
 #define PERL_ARGS_ASSERT_WRAP_WSETLOCALE
+#    endif
+#    if defined(WIN32) || (     defined(USE_POSIX_2008_LOCALE)                              && ! defined(USE_QUERYLOCALE))
+STATIC const char *	S_find_locale_from_environment(pTHX_ const unsigned int index);
+#define PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT
 #    endif
 #  endif
 #endif

--- a/proto.h
+++ b/proto.h
@@ -5767,6 +5767,8 @@ PERL_CALLCONV char *	Perl_Win_wstring_to_utf8_string(const wchar_t * wstring);
 #define PERL_ARGS_ASSERT_WIN_WSTRING_TO_UTF8_STRING
 STATIC char*	S_win32_setlocale(pTHX_ int category, const char* locale);
 #define PERL_ARGS_ASSERT_WIN32_SETLOCALE
+STATIC char *	S_wrap_wsetlocale(pTHX_ const int category, const char *locale);
+#define PERL_ARGS_ASSERT_WRAP_WSETLOCALE
 #    endif
 #  endif
 #endif

--- a/proto.h
+++ b/proto.h
@@ -5763,7 +5763,7 @@ STATIC wchar_t *	S_Win_byte_string_to_wstring(const UINT code_page, const char *
 #define PERL_ARGS_ASSERT_WIN_BYTE_STRING_TO_WSTRING
 STATIC char *	S_Win_wstring_to_byte_string(const UINT code_page, const wchar_t * wstring);
 #define PERL_ARGS_ASSERT_WIN_WSTRING_TO_BYTE_STRING
-STATIC char*	S_win32_setlocale(pTHX_ int category, const char* locale);
+STATIC const char*	S_win32_setlocale(pTHX_ int category, const char* locale);
 #define PERL_ARGS_ASSERT_WIN32_SETLOCALE
 STATIC const char *	S_wrap_wsetlocale(pTHX_ const int category, const char *locale);
 #define PERL_ARGS_ASSERT_WRAP_WSETLOCALE

--- a/proto.h
+++ b/proto.h
@@ -5759,10 +5759,10 @@ STATIC const char *	S_calculate_LC_ALL(pTHX_ const locale_t cur_obj);
 #define PERL_ARGS_ASSERT_CALCULATE_LC_ALL
 #    endif
 #    if defined(WIN32)
-STATIC wchar_t *	S_Win_utf8_string_to_wstring(const char * utf8_string);
-#define PERL_ARGS_ASSERT_WIN_UTF8_STRING_TO_WSTRING
-STATIC char *	S_Win_wstring_to_utf8_string(const wchar_t * wstring);
-#define PERL_ARGS_ASSERT_WIN_WSTRING_TO_UTF8_STRING
+STATIC wchar_t *	S_Win_byte_string_to_wstring(const UINT code_page, const char * byte_string);
+#define PERL_ARGS_ASSERT_WIN_BYTE_STRING_TO_WSTRING
+STATIC char *	S_Win_wstring_to_byte_string(const UINT code_page, const wchar_t * wstring);
+#define PERL_ARGS_ASSERT_WIN_WSTRING_TO_BYTE_STRING
 STATIC char*	S_win32_setlocale(pTHX_ int category, const char* locale);
 #define PERL_ARGS_ASSERT_WIN32_SETLOCALE
 STATIC char *	S_wrap_wsetlocale(pTHX_ const int category, const char *locale);

--- a/proto.h
+++ b/proto.h
@@ -5060,8 +5060,6 @@ STATIC void	S_validate_suid(pTHX_ PerlIO *rsfp);
 #  if defined(PERL_IN_LOCALE_C)
 #    if defined(USE_LOCALE)
 #      if defined(USE_POSIX_2008_LOCALE)
-STATIC const char *	S_find_locale_from_environment(pTHX_ const unsigned int index);
-#define PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT
 STATIC const char*	S_update_PL_curlocales_i(pTHX_ const unsigned int index, const char * new_locale, recalc_lc_all_t recalc_LC_ALL);
 #define PERL_ARGS_ASSERT_UPDATE_PL_CURLOCALES_I	\
 	assert(new_locale)
@@ -5755,6 +5753,10 @@ STATIC const char *	S_setlocale_from_aggregate_LC_ALL(pTHX_ const char * locale,
 	assert(locale)
 STATIC locale_t	S_use_curlocale_scratch(pTHX);
 #define PERL_ARGS_ASSERT_USE_CURLOCALE_SCRATCH
+#    endif
+#    if defined(USE_POSIX_2008_LOCALE) && ! defined(USE_QUERYLOCALE)
+STATIC const char *	S_find_locale_from_environment(pTHX_ const unsigned int index);
+#define PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT
 #    endif
 #    if defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE)
 STATIC const char *	S_calculate_LC_ALL(pTHX_ const locale_t cur_obj);

--- a/proto.h
+++ b/proto.h
@@ -5759,9 +5759,9 @@ STATIC const char *	S_calculate_LC_ALL(pTHX_ const locale_t cur_obj);
 #define PERL_ARGS_ASSERT_CALCULATE_LC_ALL
 #    endif
 #    if defined(WIN32)
-PERL_CALLCONV wchar_t *	Perl_Win_utf8_string_to_wstring(const char * utf8_string);
+STATIC wchar_t *	S_Win_utf8_string_to_wstring(const char * utf8_string);
 #define PERL_ARGS_ASSERT_WIN_UTF8_STRING_TO_WSTRING
-PERL_CALLCONV char *	Perl_Win_wstring_to_utf8_string(const wchar_t * wstring);
+STATIC char *	S_Win_wstring_to_utf8_string(const wchar_t * wstring);
 #define PERL_ARGS_ASSERT_WIN_WSTRING_TO_UTF8_STRING
 STATIC char*	S_win32_setlocale(pTHX_ int category, const char* locale);
 #define PERL_ARGS_ASSERT_WIN32_SETLOCALE


### PR DESCRIPTION
This series of commits collapses duplicate functionality into one, and tidies up the Windows-specific locale functions, with regard to constness, and returning temp scalars.  A particular buffer now is always used, which is freed on destruction