### PR TITLE
handy.h: Set macro to false if can't ever be true

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -1880,7 +1880,13 @@ END_EXTERN_C
 #define toUPPER_LATIN1_MOD(c) ((! FITS_IN_8_BITS(c))                       \
                                ? (c)                                       \
                                : PL_mod_latin1_uc[ (U8) (c) ])
-#define IN_UTF8_CTYPE_LOCALE PL_in_utf8_CTYPE_locale
+#ifdef USE_LOCALE_CTYPE
+#  define IN_UTF8_CTYPE_LOCALE   PL_in_utf8_CTYPE_locale
+#  define IN_UTF8_TURKIC_LOCALE  PL_in_utf8_turkic_locale
+#else
+#  define IN_UTF8_CTYPE_LOCALE   false
+#  define IN_UTF8_TURKIC_LOCALE  false
+#endif
 
 /* Use foo_LC_uvchr() instead  of these for beyond the Latin1 range */
 

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -391,10 +391,9 @@ PERLVARI(I, locale_mutex_depth, int, 0)     /* Emulate general semaphore */
 
 #ifdef USE_LOCALE_CTYPE
 PERLVAR(I, warn_locale, SV *)
-#endif
-
 PERLVAR(I, in_utf8_CTYPE_locale, bool)
 PERLVAR(I, in_utf8_turkic_locale, bool)
+#endif
 
 PERLVARA(I, colors,6,	char *)		/* values from PERL_RE_COLORS env var */
 

--- a/makedef.pl
+++ b/makedef.pl
@@ -556,6 +556,8 @@ unless ($define{USE_LOCALE_NUMERIC}) {
 unless ($define{USE_LOCALE_CTYPE}) {
     ++$skip{$_} foreach qw(
 		    PL_ctype_name
+                    PL_in_utf8_CTYPE_locale
+                    PL_in_utf8_turkic_locale
 			 );
 }
 

--- a/perl.h
+++ b/perl.h
@@ -6918,7 +6918,7 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
       * string, and an end position which it won't try to read past */
 #    define _CHECK_AND_OUTPUT_WIDE_LOCALE_CP_MSG(cp)                        \
         STMT_START {                                                        \
-            if (! PL_in_utf8_CTYPE_locale && ckWARN(WARN_LOCALE)) {         \
+            if (! IN_UTF8_CTYPE_LOCALE && ckWARN(WARN_LOCALE)) {            \
                 Perl_warner(aTHX_ packWARN(WARN_LOCALE),                    \
                                        "Wide character (U+%" UVXf ") in %s",\
                                        (UV) cp, OP_DESC(PL_op));            \
@@ -6927,7 +6927,7 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 
 #    define _CHECK_AND_OUTPUT_WIDE_LOCALE_UTF8_MSG(s, send)                 \
         STMT_START { /* Check if to warn before doing the conversion work */\
-            if (! PL_in_utf8_CTYPE_locale && ckWARN(WARN_LOCALE)) {         \
+            if (! IN_UTF8_CTYPE_LOCALE && ckWARN(WARN_LOCALE)) {            \
                 UV cp = utf8_to_uvchr_buf((U8 *) (s), (U8 *) (send), NULL); \
                 Perl_warner(aTHX_ packWARN(WARN_LOCALE),                    \
                     "Wide character (U+%" UVXf ") in %s",                   \

--- a/pp.c
+++ b/pp.c
@@ -3838,7 +3838,7 @@ PP(pp_ucfirst)
              * call to lowercase above has handled this.  But SpecialCasing.txt
              * says we are supposed to remove the COMBINING DOT ABOVE.  We can
              * tell if we have this situation if I ==> i in a turkic locale. */
-            if (   UNLIKELY(PL_in_utf8_turkic_locale)
+            if (   UNLIKELY(IN_UTF8_TURKIC_LOCALE)
                 && IN_LC_RUNTIME(LC_CTYPE)
                 && (UNLIKELY(*s == 'I' && tmpbuf[0] == 'i')))
             {
@@ -3882,7 +3882,7 @@ PP(pp_ucfirst)
 #ifdef USE_LOCALE_CTYPE
 
         if (IN_LC_RUNTIME(LC_CTYPE)) {
-            if (    UNLIKELY(PL_in_utf8_turkic_locale)
+            if (    UNLIKELY(IN_UTF8_TURKIC_LOCALE)
                 && (   (op_type == OP_LCFIRST && UNLIKELY(*s == 'I'))
                     || (op_type == OP_UCFIRST && UNLIKELY(*s == 'i'))))
             {
@@ -4284,7 +4284,7 @@ PP(pp_uc)
 
 #ifdef USE_LOCALE_CTYPE
 
-                        && (LIKELY(   ! PL_in_utf8_turkic_locale
+                        && (LIKELY(   ! IN_UTF8_TURKIC_LOCALE
                                    || ! IN_LC_RUNTIME(LC_CTYPE))
                                    || *s != 'i')
 #endif
@@ -4390,7 +4390,7 @@ PP(pp_uc)
                      * its own loop */
 
 #ifdef USE_LOCALE_CTYPE
-                    if (   UNLIKELY(PL_in_utf8_turkic_locale)
+                    if (   UNLIKELY(IN_UTF8_TURKIC_LOCALE)
                         && UNLIKELY(IN_LC_RUNTIME(LC_CTYPE)))
                     {
                         for (; s < send; s++) {
@@ -4456,7 +4456,7 @@ PP(pp_lc)
 #ifdef USE_LOCALE_CTYPE
 
         && (   LIKELY(! IN_LC_RUNTIME(LC_CTYPE))
-            || LIKELY(! PL_in_utf8_turkic_locale))
+            || LIKELY(! IN_UTF8_TURKIC_LOCALE))
 
 #endif
 
@@ -4492,7 +4492,7 @@ PP(pp_lc)
 
         /* Lowercasing in a Turkic locale can cause non-UTF-8 to need to become
          * UTF-8 for the single case of the character 'I' */
-        if (     UNLIKELY(PL_in_utf8_turkic_locale)
+        if (     UNLIKELY(IN_UTF8_TURKIC_LOCALE)
             && ! DO_UTF8(source)
             &&   (next_I = (U8 *) memchr(s, 'I', len)))
         {
@@ -4549,7 +4549,7 @@ PP(pp_lc)
              * and if so, do it.  We know that there is a DOT because
              * _toLOWER_utf8_flags() wouldn't have returned 'i' unless there
              * was one in a proper position. */
-            if (   UNLIKELY(PL_in_utf8_turkic_locale)
+            if (   UNLIKELY(IN_UTF8_TURKIC_LOCALE)
                 && IN_LC_RUNTIME(LC_CTYPE))
             {
                 if (   UNLIKELY(remove_dot_above)
@@ -4841,7 +4841,7 @@ PP(pp_fc)
             for (; s < send; d++, s++) {
                 if (    UNLIKELY(*s == MICRO_SIGN)
 #ifdef USE_LOCALE_CTYPE
-                    || (   UNLIKELY(PL_in_utf8_turkic_locale)
+                    || (   UNLIKELY(IN_UTF8_TURKIC_LOCALE)
                         && UNLIKELY(IN_LC_RUNTIME(LC_CTYPE))
                         && UNLIKELY(*s == 'I'))
 #endif

--- a/regexec.c
+++ b/regexec.c
@@ -4623,7 +4623,7 @@ S_setup_EXACTISH_ST(pTHX_ const regnode * const text_node,
     if (   (op == EXACTF && utf8_target)
         || (op == EXACTFL && IN_UTF8_CTYPE_LOCALE))
     {
-        if (op == EXACTFL && PL_in_utf8_turkic_locale) {
+        if (op == EXACTFL && IN_UTF8_TURKIC_LOCALE) {
             op = TURKISH;
         }
         else {
@@ -10823,7 +10823,7 @@ S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const
                     }
                     else /* Failing that, hardcode the two tests for a Turkic
                             locale */
-                         if (   UNLIKELY(PL_in_utf8_turkic_locale)
+                         if (   UNLIKELY(IN_UTF8_TURKIC_LOCALE)
                              && isALPHA_FOLD_EQ(*p, 'i'))
                     {
                         /* Turkish locales have these hard-coded rules
@@ -10854,7 +10854,7 @@ S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const
             /* In a Turkic locale under folding, hard-code the I i case pair
              * matches; these wouldn't have the ANYOF_HAS_EXTRA_RUNTIME_MATCHES
              * flag set unless [Ii] were match possibilities */
-            if (UNLIKELY(PL_in_utf8_turkic_locale) && ! match) {
+            if (UNLIKELY(IN_UTF8_TURKIC_LOCALE) && ! match) {
                 if (utf8_target) {
                     if (c == LATIN_CAPITAL_LETTER_I_WITH_DOT_ABOVE) {
                         if (ANYOF_BITMAP_TEST(n, 'i')) {

--- a/utf8.c
+++ b/utf8.c
@@ -3167,7 +3167,7 @@ Perl__to_uni_fold_flags(pTHX_ UV c, U8* p, STRLEN *lenp, U8 flags)
         /* Treat a non-Turkic UTF-8 locale as not being in locale at all,
          * except for potentially warning */
         CHECK_AND_WARN_PROBLEMATIC_LOCALE_;
-        if (IN_UTF8_CTYPE_LOCALE && ! PL_in_utf8_turkic_locale) {
+        if (IN_UTF8_CTYPE_LOCALE && ! IN_UTF8_TURKIC_LOCALE) {
             flags &= ~FOLD_FLAGS_LOCALE;
         }
         else {
@@ -3720,7 +3720,7 @@ S_turkic_uc(pTHX_ const U8 * const p, const U8 * const e,
     if (flags & (locale_flags)) {                                            \
         CHECK_AND_WARN_PROBLEMATIC_LOCALE_;                                  \
         if (IN_UTF8_CTYPE_LOCALE) {                                          \
-            if (UNLIKELY(PL_in_utf8_turkic_locale)) {                        \
+            if (UNLIKELY(IN_UTF8_TURKIC_LOCALE)) {                           \
                 UV ret = turkic(p, e, ustrp, lenp);                          \
                 if (ret) return ret;                                         \
             }                                                                \
@@ -4299,7 +4299,7 @@ Perl_foldEQ_utf8_flags(pTHX_ const char *s1, char **pe1, UV l1, bool u1,
 
     if (flags & FOLDEQ_LOCALE) {
         if (IN_UTF8_CTYPE_LOCALE) {
-            if (UNLIKELY(PL_in_utf8_turkic_locale)) {
+            if (UNLIKELY(IN_UTF8_TURKIC_LOCALE)) {
                 flags_for_folder |= FOLD_FLAGS_LOCALE;
             }
             else {


### PR DESCRIPTION
It's unlikely that perl will be compiled with out the LC_CTYPE locale category being enabled.  But if it isn't, there is no sense in having per-interpreter variables for various conditions in it, and no sense having code that tests those variables.

This commit changes a macro to always yield 'false' when this is disabled, adds a new similar macro, and changes some occurrences that test for a variable to use the macros instead of the variables.  That way the compiler knows these to conditions can never be true.