### PR TITLE
fix clockid_t compilation failure on macos system perl (and some other things)

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -801,7 +801,7 @@ jobs:
       image: perldocker/perl-tester:${{ matrix.perl-version }}
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: perl -V
         run: perl -V
       - name: Build and test dist modules

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -807,3 +807,29 @@ jobs:
       - name: Build and test dist modules
         run:
           perl Porting/test-dist-modules.pl -continue
+
+  dist-modules-sys-macos:
+    name: "Test dist/ modules on MacOS system perl"
+    needs: sanity_check
+    runs-on: macos-11
+    if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_dist_modules == 'true'))
+
+    env:
+      # some plugins still needs this to run their tests...
+      # these don't really matter, but might later
+      PERL_USE_UNSAFE_INC: 0
+      AUTHOR_TESTING: 1
+      AUTOMATED_TESTING: 1
+      RELEASE_TESTING: 1
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: perl -V
+        run: /usr/bin/perl -V
+      - name: Build and test dist modules
+        run:
+          /usr/bin/perl Porting/test-dist-modules.pl -continue -separate
+

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -806,4 +806,4 @@ jobs:
         run: perl -V
       - name: Build and test dist modules
         run:
-          perl Porting/test-dist-modules.pl
+          perl Porting/test-dist-modules.pl -continue

--- a/Porting/test-dist-modules.pl
+++ b/Porting/test-dist-modules.pl
@@ -38,6 +38,13 @@ if ($separate) {
       "$install_base/lib/perl5";
 }
 
+my %dist_config = (
+    # these are defined by the modules as distributed on CPAN
+    # I don't know why their Makefile.PLs aren't in core
+    "threads"        => [ "DEFINE=-DHAS_PPPORT_H" ],
+    "threads-shared" => [ "DEFINE=-DHAS_PPPORT_H" ],
+   );
+
 my $start = getcwd()
   or die "Cannot fetch current directory: $!\n";
 
@@ -178,7 +185,11 @@ EOM
 
     my $verbose = $github_ci && $ENV{'RUNNER_DEBUG'} ? 1 : 0;
     my $failed = "";
-    if (system($^X, "Makefile.PL", @config)) {
+    my @my_config = @config;
+    if (my $cfg = $dist_config{$name}) {
+        push @my_config, @$cfg;
+    }
+    if (system($^X, "Makefile.PL", @my_config)) {
         $failed = "Makefile.PL";
         die "$name: Makefile.PL failed\n" unless $continue;
     }

--- a/Porting/test-dist-modules.pl
+++ b/Porting/test-dist-modules.pl
@@ -1288,6 +1288,11 @@ sub watchdog ($)
 #  define CLANG_DIAG_RESTORE
 #endif
 
+/* Added in 5.38 */
+#ifndef PERL_SRAND_OVERRIDE_NEXT_PARENT
+#  define PERL_SRAND_OVERRIDE_NEXT_PARENT()
+#endif
+
 #endif
 -- shared.h --
 #ifndef _SHARED_H_

--- a/Porting/test-dist-modules.pl
+++ b/Porting/test-dist-modules.pl
@@ -118,6 +118,9 @@ sub test_dist {
     if ($name eq "threads" || $name eq "threads-shared") {
         write_threads_h();
     }
+    if ($name eq "threads-shared") {
+        write_shared_h();
+    }
     unless (-f "Makefile.PL") {
         print "  Creating Makefile.PL for $name\n";
         my $key = "ABSTRACT_FROM";
@@ -230,6 +233,11 @@ sub write_testpl {
 # threads and threads-shared bundle this file, which isn't needed in core
 sub write_threads_h {
     _write_from_data("threads.h");
+}
+
+# threads-shared bundles this file, which isn't needed in core
+sub write_shared_h {
+    _write_from_data("shared.h");
 }
 
 # file data read from <DATA>
@@ -1257,6 +1265,17 @@ sub watchdog ($)
 #endif
 #ifndef CLANG_DIAG_RESTORE
 #  define CLANG_DIAG_RESTORE
+#endif
+
+#endif
+-- shared.h --
+#ifndef _SHARED_H_
+#define _SHARED_H_
+
+#include "ppport.h"
+
+#ifndef HvNAME_get
+#  define HvNAME_get(hv)        (0 + ((XPVHV*)SvANY(hv))->xhv_name)
 #endif
 
 #endif

--- a/Porting/test-dist-modules.pl
+++ b/Porting/test-dist-modules.pl
@@ -7,8 +7,12 @@ use File::Temp "tempdir";
 use ExtUtils::Manifest "maniread";
 use Cwd "getcwd";
 
+$|++;
+
 -f "Configure"
   or die "Expected to be run from a perl checkout";
+
+my $github_ci = $ENV{'GITHUB_SHA'} ? 1 : 0;
 
 my $manifest = maniread();
 
@@ -47,6 +51,7 @@ for my $dist (@dists) {
 sub test_dist {
     my ($name) = @_;
 
+    print "::group::Testing $name\n" if $github_ci;
     print "*** Testing $name ***\n";
     my $dir = tempdir( CLEANUP => 1);
     system "cp", "-a", "dist/$name/.", "$dir/."
@@ -139,6 +144,8 @@ EOM
 
     chdir $start
       or die "Cannot return to $start: $!\n";
+
+    print "::endgroup::\n" if $github_ci;
 
     $dir;
 }

--- a/Porting/test-dist-modules.pl
+++ b/Porting/test-dist-modules.pl
@@ -9,7 +9,8 @@ use Cwd "getcwd";
 use Getopt::Long;
 
 my $continue;
-GetOptions("c|continue" => \$continue)
+GetOptions("c|continue" => \$continue,
+           "h|help"     => \&usage)
   or die "Unknown options\n";
 
 $|++;
@@ -1142,4 +1143,15 @@ sub watchdog ($)
 1;
 EOS
     close $fh;
+}
+
+sub usage {
+    print <<EOS;
+Usage: $^X $0 [options]
+ -c | -continue
+     Continue processing after failures
+     Devel::PPPort must successfully build to continue.
+ -h | -help
+     Display this message.
+EOS
 }

--- a/Porting/test-dist-modules.pl
+++ b/Porting/test-dist-modules.pl
@@ -292,7 +292,7 @@ sub run {
 
 sub usage {
     print <<EOS;
-Usage: $^X $0 [options]
+Usage: $^X $0 [options] [distnames]
  -c | -continue
      Continue processing after failures
      Devel::PPPort must successfully build to continue.
@@ -300,6 +300,18 @@ Usage: $^X $0 [options]
      Install to a work path, not to perl's site_perl.
  -h | -help
      Display this message.
+
+Optional distnames should be names of the distributions under dist/ to
+test.  If omitted all of the distributions under dist/ are tested.
+Devel-PPPort is always tested.
+
+Test all of the distributions, stop on the first failure:
+
+   $^X $0 -s
+
+Test the various threads distributions, continue on failure:
+
+   $^X $0 -s -c threads threads-shared Thread-Queue Thread-Semaphore
 EOS
 }
 

--- a/Porting/test-dist-modules.pl
+++ b/Porting/test-dist-modules.pl
@@ -135,7 +135,7 @@ EOM
     system $^X, "Makefile.PL"
       and die "$name: Makefile.PL failed\n";
 
-    my $verbose = 0;
+    my $verbose = $github_ci && $ENV{'RUNNER_DEBUG'} ? 1 : 0;
     system "make", "test", "TEST_VERBOSE=$verbose"
       and die "$name: make test failed\n";
 

--- a/Porting/test-dist-modules.pl
+++ b/Porting/test-dist-modules.pl
@@ -126,6 +126,7 @@ sub test_dist {
         my $key = "ABSTRACT_FROM";
         my @parts = split /-/, $name;
         my $last = $parts[-1];
+        my $module = join "::", @parts;
         my $fromname;
         for my $check ("$last.pm", join("/", "lib", @parts) . ".pm") {
             if (-f $check) {
@@ -139,7 +140,7 @@ sub test_dist {
         open my $fh, ">", "Makefile.PL"
           or die "Cannot create Makefile.PL: $!\n";
         # adapted from make_ext.pl
-        printf $fh <<'EOM', $name, $fromname, $key, $value;
+        printf $fh <<'EOM', $module, $fromname, $key, $value;
 use strict;
 use ExtUtils::MakeMaker;
 

--- a/Porting/test-dist-modules.pl
+++ b/Porting/test-dist-modules.pl
@@ -68,10 +68,18 @@ my $pppfile = "$pppdir/ppport.h";
 
 # Devel-PPPort is manually processed before anything else to ensure we
 # have an up to date ppport.h
-opendir my $distdir, "dist"
-  or die "Cannot opendir 'dist': $!\n";
-my @dists = sort { lc $a cmp lc $b } grep { /^\w/ && $_ ne "Devel-PPPort" } readdir $distdir;
-closedir $distdir;
+my @dists = @ARGV;
+if (@dists) {
+    for my $dist (@dists) {
+        -d "dist/$dist" or die "dist/$dist not a directory\n";
+    }
+}
+else {
+    opendir my $distdir, "dist"
+      or die "Cannot opendir 'dist': $!\n";
+    @dists = sort { lc $a cmp lc $b } grep { /^\w/ && $_ ne "Devel-PPPort" } readdir $distdir;
+    closedir $distdir;
+}
 
 # These may end up being included if their problems are resolved
 {

--- a/dist/ExtUtils-CBuilder/Changes
+++ b/dist/ExtUtils-CBuilder/Changes
@@ -1,5 +1,19 @@
 Revision history for Perl extension ExtUtils::CBuilder.
 
+0.280238
+
+  Fix:
+
+  - use -isyswithroot option for the CORE directory for the system perl on darwin.
+    The compiler would fail to find EXTERN.h with -I.
+    Came up while working on a fix for the similar issue in
+    https://github.com/Perl/perl5/issues/20362
+
+0.280237 - 2022-05-09
+
+  - when not set to quiet, print commands being run in a usable form.
+    https://github.com/Perl/perl5/pull/19701
+
 0.280236 - 2021-02-12
 
   Fix:

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder.pm
@@ -7,7 +7,7 @@ use Perl::OSType qw/os_type/;
 
 use warnings;
 use strict;
-our $VERSION = '0.280237'; # VERSION
+our $VERSION = '0.280238'; # VERSION
 our @ISA;
 
 # We only use this once - don't waste a symbol table entry on it.

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
@@ -9,7 +9,7 @@ use Text::ParseWords;
 use IPC::Cmd qw(can_run);
 use File::Temp qw(tempfile);
 
-our $VERSION = '0.280237'; # VERSION
+our $VERSION = '0.280238'; # VERSION
 
 # More details about C/C++ compilers:
 # http://developers.sun.com/sunstudio/documentation/product/compiler.jsp

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Unix.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Unix.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Base;
 
-our $VERSION = '0.280237'; # VERSION
+our $VERSION = '0.280238'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Base);
 
 sub link_executable {

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/VMS.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/VMS.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Base;
 
-our $VERSION = '0.280237'; # VERSION
+our $VERSION = '0.280238'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Base);
 
 use File::Spec::Functions qw(catfile catdir);

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows.pm
@@ -8,7 +8,7 @@ use File::Spec;
 use ExtUtils::CBuilder::Base;
 use IO::File;
 
-our $VERSION = '0.280237'; # VERSION
+our $VERSION = '0.280238'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Base);
 
 =begin comment

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/BCC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/BCC.pm
@@ -1,6 +1,6 @@
 package ExtUtils::CBuilder::Platform::Windows::BCC;
 
-our $VERSION = '0.280237'; # VERSION
+our $VERSION = '0.280238'; # VERSION
 
 use strict;
 use warnings;

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/GCC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/GCC.pm
@@ -1,6 +1,6 @@
 package ExtUtils::CBuilder::Platform::Windows::GCC;
 
-our $VERSION = '0.280237'; # VERSION
+our $VERSION = '0.280238'; # VERSION
 
 use warnings;
 use strict;

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/MSVC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/MSVC.pm
@@ -1,6 +1,6 @@
 package ExtUtils::CBuilder::Platform::Windows::MSVC;
 
-our $VERSION = '0.280237'; # VERSION
+our $VERSION = '0.280238'; # VERSION
 
 use warnings;
 use strict;

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/aix.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/aix.pm
@@ -5,7 +5,7 @@ use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 use File::Spec;
 
-our $VERSION = '0.280237'; # VERSION
+our $VERSION = '0.280238'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub need_prelink { 1 }

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/android.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/android.pm
@@ -6,7 +6,7 @@ use File::Spec;
 use ExtUtils::CBuilder::Platform::Unix;
 use Config;
 
-our $VERSION = '0.280237'; # VERSION
+our $VERSION = '0.280238'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 # The Android linker will not recognize symbols from

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/cygwin.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/cygwin.pm
@@ -5,7 +5,7 @@ use strict;
 use File::Spec;
 use ExtUtils::CBuilder::Platform::Unix;
 
-our $VERSION = '0.280237'; # VERSION
+our $VERSION = '0.280238'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 # TODO: If a specific exe_file name is requested, if the exe created

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/darwin.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/darwin.pm
@@ -3,9 +3,13 @@ package ExtUtils::CBuilder::Platform::darwin;
 use warnings;
 use strict;
 use ExtUtils::CBuilder::Platform::Unix;
+use Config;
 
 our $VERSION = '0.280237'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
+
+my ($osver) = split /\./, $Config{osvers};
+my $apple_cor = $^X eq "/usr/bin/perl" && $osver >= 18;
 
 sub compile {
   my $self = shift;
@@ -22,5 +26,18 @@ sub compile {
   $self->SUPER::compile(@_);
 }
 
+sub arg_include_dirs {
+    my $self = shift;
+
+    if ($apple_cor) {
+        my $perl_inc = $self->perl_inc;
+        return map {
+           $_ eq $perl_inc ? ("-iwithsysroot", $_ ) : "-I$_"
+        } @_;
+    }
+    else {
+        return $self->SUPER::arg_include_dirs(@_);
+    }
+}
 
 1;

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/darwin.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/darwin.pm
@@ -5,7 +5,7 @@ use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 use Config;
 
-our $VERSION = '0.280237'; # VERSION
+our $VERSION = '0.280238'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 my ($osver) = split /\./, $Config{osvers};

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/dec_osf.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/dec_osf.pm
@@ -5,7 +5,7 @@ use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 use File::Spec;
 
-our $VERSION = '0.280237'; # VERSION
+our $VERSION = '0.280238'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub link_executable {

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/os2.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/os2.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 
-our $VERSION = '0.280237'; # VERSION
+our $VERSION = '0.280238'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub need_prelink { 1 }

--- a/dist/Time-HiRes/Changes
+++ b/dist/Time-HiRes/Changes
@@ -5,6 +5,13 @@ Revision history for the Perl extension Time::HiRes.
  - Remove obsolete vms code
  - Use core version compare
  - Use GIMME_V instead of the deprecated GIMME
+ - t/utime.t: dragonflybsd has only microsecond precision
+ - t/utime.t: dragonflybsd is noatime by default
+ - t/stat.t: skip testing access times on HaikuOS, it doesn't support
+   atime
+ - darwin: make sure the compiler can find the system perl headers
+   https://github.com/Perl/perl5/issues/20362
+ - darwin: make sure PERL_DARWIN is defined on darwin.
 
 1.9764 [2020-08-10]
  - Fix a bunch of repeated-word typos

--- a/dist/Time-HiRes/HiRes.pm
+++ b/dist/Time-HiRes/HiRes.pm
@@ -50,7 +50,7 @@ our @EXPORT_OK = qw (usleep sleep ualarm alarm gettimeofday time tv_interval
                  stat lstat utime
                 );
 
-our $VERSION = '1.9771';
+our $VERSION = '1.9772';
 our $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 

--- a/dist/Time-HiRes/Makefile.PL
+++ b/dist/Time-HiRes/Makefile.PL
@@ -850,6 +850,11 @@ EOM
             print "NOT found.\n";
         }
     }
+    if ($^O eq "darwin") {
+        # the system perl on darwin doesn't seem to include -DPERL_DARWIN
+        # which breaks setting up emulation
+        DEFINE("PERL_DARWIN");
+    }
 
     if ($DEFINE) {
         $DEFINE =~ s/^\s+//;

--- a/dist/Time-HiRes/Makefile.PL
+++ b/dist/Time-HiRes/Makefile.PL
@@ -68,8 +68,17 @@ __EOD__
             }
         }
 
-        my $ccflags = $Config{'ccflags'} . ' ' . "-I$COREincdir"
-         . ' -DPERL_NO_INLINE_FUNCTIONS';
+        my $ccflags = $Config{'ccflags'} . ' ';
+        my @osvers = split /\./, $Config{osvers};
+        if ($^O eq "darwin"
+            && $^X eq "/usr/bin/perl"
+            && $osvers[0] >= 18) {
+            $ccflags .= qq(-iwithsysroot "$COREincdir");
+        }
+        else {
+            $ccflags .= "-I$COREincdir"
+        }
+        $ccflags .= ' -DPERL_NO_INLINE_FUNCTIONS';
 
         if ($^O eq 'VMS') {
             $cccmd = "$Config{'cc'} /include=($COREincdir) $tmp.c";


### PR DESCRIPTION
Fixes #20362 

This is built on top of @bram-perl's PR #20309 and extends it in a few ways, fixing some of the limitations of the dist-modules work that I ran out of energy for the first time around:

- continuing on error now depends on a command-line flag
- added a help option to test-dist-modules.pl
- added an option to install to a temp directory instead of to perl, so it can be used for system perls
- test dist/ modules against the macos system perl (to reproduce #20362)
- allow the dist-modules tests to run when test_porting fails, to match other tests
- threads and threads-shared (which weren't properly tested with the non-threaded perls used by dist-modules) are now passed the flag needed to make them use ppport.h
- added headers bundled by the threads and threads-shared CPAN distributions (in test-dist-modules.pl, as with test.pl)
- log system calls for builds, and better report failures
- supply the module name, not the dist name as NAME in the generated Makefile.PL
- optionally accept list of distributions to test on the test-dist-modules.pl command-line

And fixes that came about from being able to test on macos, and to test the threads code:
- fix building threads (a recent change broke it)
- fix the clockid_t probe problem, which was caused by the compiler not finding the system perl's CORE headers, and fix another problem when building against the darwin system perl
- make ExtUtils::CBuilder also properly tell the compiler where to find the system perl's CORE headers, which allows ExtUtils::ParseXS to test successfully.