### PR TITLE
locale.c: Fix Debug statement on netbsd

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -3894,8 +3894,8 @@ S_my_langinfo_i(pTHX_
     assert(cat_index <= NOMINAL_LC_ALL_INDEX);
 
     DEBUG_Lv(PerlIO_printf(Perl_debug_log,
-                           "Entering my_langinfo item=%d, using locale %s\n",
-                           item, locale));
+                           "Entering my_langinfo item=%ld, using locale %s\n",
+                           (long) item, locale));
 /*--------------------------------------------------------------------------*/
 /* Above is the common beginning to all the implementations of my_langinfo().
  * Below are the various completions.


### PR DESCRIPTION
Other platforms declare the nl_item typedef an int, but this one makes it a long.  To portably output its value, cast it to a long and use the %ld format.