### PR TITLE
t/test.pl: Add ability to cancel an 'alarm' watchdog

### DIFF
--- a/t/re/pat_advanced.t
+++ b/t/re/pat_advanced.t
@@ -2382,6 +2382,7 @@ EOF
     {   # Was looping
         watchdog(10);
         like("\x{00DF}", qr/[\x{1E9E}_]*/i, "\"\\x{00DF}\" =~ /[\\x{1E9E}_]*/i was looping");
+        watchdog(0);
     }
 
     {   # Bug #90536, caused failed assertion

--- a/t/test.pl
+++ b/t/test.pl
@@ -1731,10 +1731,12 @@ sub warning_like {
 #
 # NOTE:  If the test file uses 'threads', then call the watchdog() function
 #        _AFTER_ the 'threads' module is loaded.
+{ # Closure
+    my $watchdog;
+    my $watchdog_thread;
+
 sub watchdog ($;$)
 {
-    CORE::state $watchdog;
-    CORE::state $watchdog_thread;
     my $timeout = shift;
 
     # If cancelling, use the state variables to know which method was used to
@@ -1768,7 +1770,7 @@ sub watchdog ($;$)
                       || $ENV{PERL_TEST_TIMEOUT_FACTOR}
                       || 1;
     $timeout_factor = 1 if $timeout_factor < 1;
-	$timeout_factor = $1 if $timeout_factor =~ /^(\d+)$/;
+    $timeout_factor = $1 if $timeout_factor =~ /^(\d+)$/;
 
     # Valgrind slows perl way down so give it more time before dying.
     $timeout_factor = 10 if $timeout_factor < 10 && $ENV{PERL_VALGRIND};
@@ -1937,6 +1939,7 @@ WATCHDOG_VIA_ALARM:
         };
     }
 }
+} # End closure
 
 # Orphaned Docker or Linux containers do not necessarily attach to PID 1. They might attach to 0 instead.
 sub is_linux_container {


### PR DESCRIPTION
A watchdog affects the entire rest of the file.  As more tests get added
to a test file, they could end up triggering the watchdog.  It's trivial
to cancel a watchdog that uses SIGALRM.  This commit adds the capability
to do so; checking that what gets cancelled actually was set via this
method.

The other watchdog methods remain uncancellable.  Patches welcome.
These were created so that one could set a watchdog for cases where we
are testing timers and alarms.  Those situations aren't as common.
Hence this commit allows cancellation in most cases, but not all.