### PR TITLE
POC - eliminate C preprocessor complexity

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -9148,6 +9148,8 @@ END_EXTERN_C
 
 */
 
+#include "platform/platforms.h"
+
 #endif /* Include guard */
 
 /*

--- a/platform/defaults/platform-defaults.h
+++ b/platform/defaults/platform-defaults.h
@@ -1,0 +1,13 @@
+
+#ifndef PERL__platform_defaults__H
+#	define PERL__platform_defaults__H
+
+#	ifndef PERL_PLATFORM_HAS_DIR_HANDLE_FUNCTIONS
+#		if defined(Direntry_t) && defined(HAS_READDIR)
+#			define PERL_PLATFORM_HAS_DIR_HANDLE_FUNCTIONS 1
+#		else
+#			define PERL_PLATFORM_HAS_DIR_HANDLE_FUNCTIONS 0
+#		endif
+#	endif
+
+#endif

--- a/platform/defaults/platform-defaults.h
+++ b/platform/defaults/platform-defaults.h
@@ -10,4 +10,23 @@
 #		endif
 #	endif
 
+#	define PERL_PLATFORM_closedir_default     "pp/closedir_default.inc"
+#	define PERL_PLATFORM_open_dir_default     "pp/open_dir_default.inc"
+#	define PERL_PLATFORM_readdir_default      "pp/readdir_default.inc"
+
+#	define PERL_PLATFORM_closedir_unavailable "pp/closedir_unavailable.inc"
+#	define PERL_PLATFORM_open_dir_unavailable "pp/open_dir_unavailable.inc"
+#	define PERL_PLATFORM_readdir_unavailable  "pp/readdir_unavailable.inc"
+
+/* dir handle functions */
+#	if PERL_PLATFORM_HAS_DIR_HANDLE_FUNCTIONS
+#		define PERL_PLATFORM_closedir PERL_PLATFORM_closedir_default
+#		define PERL_PLATFORM_open_dir PERL_PLATFORM_open_dir_default
+#		define PERL_PLATFORM_readdir  PERL_PLATFORM_readdir_default
+#	else
+#		define PERL_PLATFORM_closedir PERL_PLATFORM_closedir_unavailable
+#		define PERL_PLATFORM_open_dir PERL_PLATFORM_open_dir_unavailable
+#		define PERL_PLATFORM_readdir  PERL_PLATFORM_readdir_unavailable
+#	endif
+
 #endif

--- a/platform/platforms.h
+++ b/platform/platforms.h
@@ -1,0 +1,24 @@
+
+#ifndef PERL__platforms__H
+#	define PERL__platforms__H
+
+/* Intended usage:
+ * - all platform specific includes will be included here
+ * - platform specific include is responsible for detecting it's platform
+ *
+ * Example:
+ * #include "platform/amigaos4/platform-amigaos4.h"
+ * #include "platform/amigaos4/platform-defaults.h"
+ *
+ * where platform-amigaos4.h will contain:
+ * #if defined(__amigaos4__) && ! defined(__guard__)
+ *
+ * Platform specific include will define platform specific implementations
+ * of certain steps.
+ *
+ * platform-defaults.h will define default behaviour of platform specific steps
+ */
+
+#include "../platform/defaults/platform-defaults.h"
+
+#endif

--- a/pp/closedir_default.inc
+++ b/pp/closedir_default.inc
@@ -1,0 +1,27 @@
+{
+    dSP;
+    GV * const gv = MUTABLE_GV(POPs);
+    IO * const io = GvIOn(gv);
+
+    if (!IoDIRP(io)) {
+        Perl_ck_warner(aTHX_ packWARN(WARN_IO),
+                       "closedir() attempted on invalid dirhandle %" HEKf,
+                                HEKfARG(GvENAME_HEK(gv)));
+        goto nope;
+    }
+#ifdef VOID_CLOSEDIR
+    PerlDir_close(IoDIRP(io));
+#else
+    if (PerlDir_close(IoDIRP(io)) < 0) {
+        IoDIRP(io) = 0; /* Don't try to close again--coredumps on SysV */
+        goto nope;
+    }
+#endif
+    IoDIRP(io) = 0;
+
+    RETPUSHYES;
+  nope:
+    if (!errno)
+        SETERRNO(EBADF,RMS_IFI);
+    RETPUSHUNDEF;
+}

--- a/pp/closedir_unavailable.inc
+++ b/pp/closedir_unavailable.inc
@@ -1,0 +1,3 @@
+{
+    DIE(aTHX_ PL_no_dir_func, "closedir");
+}

--- a/pp/open_dir_default.inc
+++ b/pp/open_dir_default.inc
@@ -1,0 +1,20 @@
+{
+    dSP;
+    const char * const dirname = POPpconstx;
+    GV * const gv = MUTABLE_GV(POPs);
+    IO * const io = GvIOn(gv);
+
+    if ((IoIFP(io) || IoOFP(io)))
+        Perl_croak(aTHX_ "Cannot open %" HEKf " as a dirhandle: it is already open as a filehandle",
+                         HEKfARG(GvENAME_HEK(gv)));
+    if (IoDIRP(io))
+        PerlDir_close(IoDIRP(io));
+    if (!(IoDIRP(io) = PerlDir_open(dirname)))
+        goto nope;
+
+    RETPUSHYES;
+  nope:
+    if (!errno)
+        SETERRNO(EBADF,RMS_DIR);
+    RETPUSHUNDEF;
+}

--- a/pp/open_dir_unavailable.inc
+++ b/pp/open_dir_unavailable.inc
@@ -1,0 +1,3 @@
+{
+    DIE(aTHX_ PL_no_dir_func, "opendir");
+}

--- a/pp/readdir_default.inc
+++ b/pp/readdir_default.inc
@@ -1,0 +1,46 @@
+{
+#if !defined(I_DIRENT) && !defined(VMS)
+    Direntry_t *readdir (DIR *);
+#endif
+    dSP;
+
+    SV *sv;
+    const U8 gimme = GIMME_V;
+    GV * const gv = MUTABLE_GV(POPs);
+    const Direntry_t *dp;
+    IO * const io = GvIOn(gv);
+
+    if (!IoDIRP(io)) {
+        Perl_ck_warner(aTHX_ packWARN(WARN_IO),
+                       "readdir() attempted on invalid dirhandle %" HEKf,
+                            HEKfARG(GvENAME_HEK(gv)));
+        goto nope;
+    }
+
+    do {
+        dp = (Direntry_t *)PerlDir_read(IoDIRP(io));
+        if (!dp)
+            break;
+#ifdef DIRNAMLEN
+        sv = newSVpvn(dp->d_name, dp->d_namlen);
+#else
+        sv = newSVpv(dp->d_name, 0);
+#endif
+        if (!(IoFLAGS(io) & IOf_UNTAINT))
+            SvTAINTED_on(sv);
+        mXPUSHs(sv);
+    } while (gimme == G_LIST);
+
+    if (!dp && gimme != G_LIST)
+        RETPUSHUNDEF;
+
+    RETURN;
+
+  nope:
+    if (!errno)
+        SETERRNO(EBADF,RMS_ISI);
+    if (gimme == G_LIST)
+        RETURN;
+    else
+        RETPUSHUNDEF;
+}

--- a/pp/readdir_unavailable.inc
+++ b/pp/readdir_unavailable.inc
@@ -1,0 +1,3 @@
+{
+    DIE(aTHX_ PL_no_dir_func, "readdir");
+}

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -4043,52 +4043,9 @@ PP(pp_open_dir)
 PP(pp_readdir)
 {
 #if !defined(Direntry_t) || !defined(HAS_READDIR)
-    DIE(aTHX_ PL_no_dir_func, "readdir");
+#	include "pp/readddir_unavailable.inc"
 #else
-#if !defined(I_DIRENT) && !defined(VMS)
-    Direntry_t *readdir (DIR *);
-#endif
-    dSP;
-
-    SV *sv;
-    const U8 gimme = GIMME_V;
-    GV * const gv = MUTABLE_GV(POPs);
-    const Direntry_t *dp;
-    IO * const io = GvIOn(gv);
-
-    if (!IoDIRP(io)) {
-        Perl_ck_warner(aTHX_ packWARN(WARN_IO),
-                       "readdir() attempted on invalid dirhandle %" HEKf,
-                            HEKfARG(GvENAME_HEK(gv)));
-        goto nope;
-    }
-
-    do {
-        dp = (Direntry_t *)PerlDir_read(IoDIRP(io));
-        if (!dp)
-            break;
-#ifdef DIRNAMLEN
-        sv = newSVpvn(dp->d_name, dp->d_namlen);
-#else
-        sv = newSVpv(dp->d_name, 0);
-#endif
-        if (!(IoFLAGS(io) & IOf_UNTAINT))
-            SvTAINTED_on(sv);
-        mXPUSHs(sv);
-    } while (gimme == G_LIST);
-
-    if (!dp && gimme != G_LIST)
-        RETPUSHUNDEF;
-
-    RETURN;
-
-  nope:
-    if (!errno)
-        SETERRNO(EBADF,RMS_ISI);
-    if (gimme == G_LIST)
-        RETURN;
-    else
-        RETPUSHUNDEF;
+#	include "pp/readdir_default.inc"
 #endif
 }
 

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -4042,10 +4042,10 @@ PP(pp_open_dir)
 
 PP(pp_readdir)
 {
-#if !defined(Direntry_t) || !defined(HAS_READDIR)
-#	include "pp/readddir_unavailable.inc"
-#else
+#if defined(Direntry_t) && defined(HAS_READDIR)
 #	include "pp/readdir_default.inc"
+#else
+#	include "pp/readddir_unavailable.inc"
 #endif
 }
 

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -4033,7 +4033,7 @@ PP(pp_rmdir)
 
 PP(pp_open_dir)
 {
-#if defined(Direntry_t) && defined(HAS_READDIR)
+#if PERL_PLATFORM_HAS_DIR_HANDLE_FUNCTIONS
 #	include "pp/open_dir_default.inc"
 #else
 #	include "pp/open_dir_unavailable.inc"
@@ -4042,7 +4042,7 @@ PP(pp_open_dir)
 
 PP(pp_readdir)
 {
-#if defined(Direntry_t) && defined(HAS_READDIR)
+#if PERL_PLATFORM_HAS_DIR_HANDLE_FUNCTIONS
 #	include "pp/readdir_default.inc"
 #else
 #	include "pp/readddir_unavailable.inc"
@@ -4133,7 +4133,7 @@ PP(pp_rewinddir)
 
 PP(pp_closedir)
 {
-#if defined(Direntry_t) && defined(HAS_READDIR)
+#if PERL_PLATFORM_HAS_DIR_HANDLE_FUNCTIONS
 #	include "pp/closedir_default.inc"
 #else
 #	include "pp/closedir_unavailable.inc"

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -4033,20 +4033,12 @@ PP(pp_rmdir)
 
 PP(pp_open_dir)
 {
-#if PERL_PLATFORM_HAS_DIR_HANDLE_FUNCTIONS
-#	include "pp/open_dir_default.inc"
-#else
-#	include "pp/open_dir_unavailable.inc"
-#endif
+#	include PERL_PLATFORM_open_dir
 }
 
 PP(pp_readdir)
 {
-#if PERL_PLATFORM_HAS_DIR_HANDLE_FUNCTIONS
-#	include "pp/readdir_default.inc"
-#else
-#	include "pp/readddir_unavailable.inc"
-#endif
+#	include PERL_PLATFORM_readdir
 }
 
 PP(pp_telldir)
@@ -4133,11 +4125,7 @@ PP(pp_rewinddir)
 
 PP(pp_closedir)
 {
-#if PERL_PLATFORM_HAS_DIR_HANDLE_FUNCTIONS
-#	include "pp/closedir_default.inc"
-#else
-#	include "pp/closedir_unavailable.inc"
-#endif
+#	include PERL_PLATFORM_closedir
 }
 
 /* Process control. */

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -4134,33 +4134,9 @@ PP(pp_rewinddir)
 PP(pp_closedir)
 {
 #if defined(Direntry_t) && defined(HAS_READDIR)
-    dSP;
-    GV * const gv = MUTABLE_GV(POPs);
-    IO * const io = GvIOn(gv);
-
-    if (!IoDIRP(io)) {
-        Perl_ck_warner(aTHX_ packWARN(WARN_IO),
-                       "closedir() attempted on invalid dirhandle %" HEKf,
-                                HEKfARG(GvENAME_HEK(gv)));
-        goto nope;
-    }
-#ifdef VOID_CLOSEDIR
-    PerlDir_close(IoDIRP(io));
+#	include "pp/closedir_default.inc"
 #else
-    if (PerlDir_close(IoDIRP(io)) < 0) {
-        IoDIRP(io) = 0; /* Don't try to close again--coredumps on SysV */
-        goto nope;
-    }
-#endif
-    IoDIRP(io) = 0;
-
-    RETPUSHYES;
-  nope:
-    if (!errno)
-        SETERRNO(EBADF,RMS_IFI);
-    RETPUSHUNDEF;
-#else
-    DIE(aTHX_ PL_no_dir_func, "closedir");
+#	include "pp/closedir_unavailable.inc"
 #endif
 }
 

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -4034,26 +4034,9 @@ PP(pp_rmdir)
 PP(pp_open_dir)
 {
 #if defined(Direntry_t) && defined(HAS_READDIR)
-    dSP;
-    const char * const dirname = POPpconstx;
-    GV * const gv = MUTABLE_GV(POPs);
-    IO * const io = GvIOn(gv);
-
-    if ((IoIFP(io) || IoOFP(io)))
-        Perl_croak(aTHX_ "Cannot open %" HEKf " as a dirhandle: it is already open as a filehandle",
-                         HEKfARG(GvENAME_HEK(gv)));
-    if (IoDIRP(io))
-        PerlDir_close(IoDIRP(io));
-    if (!(IoDIRP(io) = PerlDir_open(dirname)))
-        goto nope;
-
-    RETPUSHYES;
-  nope:
-    if (!errno)
-        SETERRNO(EBADF,RMS_DIR);
-    RETPUSHUNDEF;
+#	include "pp/open_dir_default.inc"
 #else
-    DIE(aTHX_ PL_no_dir_func, "opendir");
+#	include "pp/open_dir_unavailable.inc"
 #endif
 }
 


### PR DESCRIPTION
This is an example how to eliminate C preprocessor complexity on example of one function.

This PR is made to support discussion on mailing list.

Complexity of PP functions:

| pp             | lines | paths | variables | file      |
|-|-|-|-|-|
| pp_system      | 213   | 20    |  9        | pp_sys.c  |
| pp_gpwent      | 223   | 14    | 15        | pp_sys.c  |
| pp_aassign     | 649   | 13    | 10        | pp_hot.c  |
| pp_ftrread     | 120   | 12    |  5        | pp_sys.c  |
| pp_sselect     | 177   | 12    | 12        | pp_sys.c  |
| pp_uc          | 323   | 11    |  3        | pp.c      |
| pp_stat        | 233   | 10    | 10        | pp_sys.c  |
| pp_ghostent    |  91   | 10    |  8        | pp_sys.c  |
| pp_subst       | 396   |  9    |  2        | pp_hot.c  |
| pp_ehostent    |  64   |  9    | 10        | pp_sys.c  |
| pp_gnetent     |  72   |  9    |  7        | pp_sys.c  |
| pp_fc          | 207   |  8    |  3        | pp.c      |
| pp_ucfirst     | 347   |  7    |  1        | pp.c      |
| pp_ggrent      |  71   |  7    |  7        | pp_sys.c  |
| pp_fork        |  71   |  7    |  6        | pp_sys.c  |
| pp_lc          | 216   |  6    |  1        | pp.c      |
| pp_pow         | 180   |  6    |  6        | pp.c      |
| pp_truncate    | 106   |  6    |  6        | pp_sys.c  |
| pp_sysread     | 260   |  6    |  7        | pp_sys.c  |
| pp_gservent    |  64   |  6    |  4        | pp_sys.c  |
| pp_gprotoent   |  59   |  6    |  4        | pp_sys.c  |
| pp_crypt       |  44   |  5    |  5        | pp.c      |
| pp_divide      | 116   |  5    |  6        | pp.c      |
| pp_match       | 216   |  5    |  2        | pp_hot.c  |
| pp_chdir       |  88   |  5    |  2        | pp_sys.c  |
| pp_shostent    |  36   |  5    |  4        | pp_sys.c  |
| pp_ioctl       |  72   |  5    |  4        | pp_sys.c  |
| pp_syswrite    | 153   |  5    |  4        | pp_sys.c  |
| pp_multiply    | 192   |  4    |  7        | pp.c      |
| pp_regcomp     | 108   |  4    |  2        | pp_ctl.c  |
| pp_accept      |  60   |  4    |  5        | pp_sys.c  |
| pp_glob        |  58   |  4    |  3        | pp_sys.c  |
| pp_sysseek     |  46   |  4    |  2        | pp_sys.c  |
| pp_getpeername |  63   |  4    |  4        | pp_sys.c  |
| pp_fileno      |  47   |  4    |  4        | pp_sys.c  |
| pp_waitpid     |  36   |  4    |  7        | pp_sys.c  |
| pp_readdir     |  51   |  4    |  5        | pp_sys.c  |
| pp_ftrowned    |  82   |  4    |  3        | pp_sys.c  |
| pp_sin         |  55   |  3    |  3        | pp.c      |
| pp_wait        |  27   |  3    |  6        | pp_sys.c  |
| pp_fttext      | 197   |  3    |  3        | pp_sys.c  |
| pp_telldir     |  31   |  3    |  4        | pp_sys.c  |
| pp_rename      |  27   |  3    |  1        | pp_sys.c  |
| pp_exec        |  38   |  3    |  1        | pp_sys.c  |
| pp_tms         |  30   |  3    |  2        | pp_sys.c  |
| pp_closedir    |  32   |  3    |  3        | pp_sys.c  |
| pp_getpgrp     |  21   |  3    |  2        | pp_sys.c  |
| pp_setpgrp     |  30   |  3    |  2        | pp_sys.c  |
| pp_undef       | 119   |  2    |  1        | pp.c      |
| pp_negate      |  43   |  2    |  1        | pp.c      |
| pp_scmp        |  17   |  2    |  1        | pp.c      |
| pp_substr      | 139   |  2    |  1        | pp.c      |
| pp_argelem     | 135   |  2    |  2        | pp.c      |
| pp_sle         |  41   |  2    |  1        | pp.c      |
| pp_vec         |  53   |  2    |  2        | pp.c      |
| pp_argdefelem  |  20   |  2    |  2        | pp.c      |
| pp_subtract    | 165   |  2    |  1        | pp.c      |
| pp_rand        |  49   |  2    |  2        | pp.c      |
| pp_quotemeta   |  77   |  2    |  1        | pp.c      |
| pp_split       | 450   |  2    |  1        | pp.c      |
| pp_flop        |  93   |  2    |  2        | pp_ctl.c  |
| pp_exit        |  25   |  2    |  1        | pp_ctl.c  |
| pp_goto        | 435   |  2    |  1        | pp_ctl.c  |
| pp_formline    | 487   |  2    |  1        | pp_ctl.c  |
| pp_leaveeval   |  57   |  2    |  1        | pp_ctl.c  |
| pp_sort        | 349   |  2    |  1        | pp_sort.c |
| pp_aelem       |  81   |  2    |  1        | pp_hot.c  |
| pp_entersub    | 323   |  2    |  2        | pp_hot.c  |
| pp_add         | 215   |  2    |  1        | pp_hot.c  |
| pp_defined     |  53   |  2    |  1        | pp_hot.c  |
| pp_ftis        |  50   |  2    |  2        | pp_sys.c  |
| pp_getlogin    |  15   |  2    |  1        | pp_sys.c  |
| pp_chroot      |  12   |  2    |  1        | pp_sys.c  |
| pp_flock       |  26   |  2    |  1        | pp_sys.c  |
| pp_ssockopt    |  66   |  2    |  1        | pp_sys.c  |
| pp_semctl      |  19   |  2    |  3        | pp_sys.c  |
| pp_tell        |  33   |  2    |  2        | pp_sys.c  |
| pp_pipe_op     |  48   |  2    |  1        | pp_sys.c  |
| pp_shmwrite    |  29   |  2    |  3        | pp_sys.c  |
| pp_getppid     |  10   |  2    |  1        | pp_sys.c  |
| pp_die         |  57   |  2    |  1        | pp_sys.c  |
| pp_umask       |  29   |  2    |  1        | pp_sys.c  |
| pp_rewinddir   |  23   |  2    |  2        | pp_sys.c  |
| pp_syscall     |  71   |  2    |  1        | pp_sys.c  |
| pp_seekdir     |  25   |  2    |  2        | pp_sys.c  |
| pp_time        |  10   |  2    |  1        | pp_sys.c  |
| pp_semget      |  14   |  2    |  3        | pp_sys.c  |
| pp_alarm       |  32   |  2    |  1        | pp_sys.c  |
| pp_sockpair    |  43   |  2    |  5        | pp_sys.c  |
| pp_open_dir    |  25   |  2    |  2        | pp_sys.c  |
| pp_setpriority |  14   |  2    |  1        | pp_sys.c  |
| pp_rmdir       |  18   |  2    |  1        | pp_sys.c  |
| pp_mkdir       |  26   |  2    |  1        | pp_sys.c  |
| pp_readlink    |  24   |  2    |  1        | pp_sys.c  |
| pp_getpriority |  12   |  2    |  1        | pp_sys.c  |
