### PR TITLE
Ensure 'ok #' test output includes a location

### DIFF
--- a/t/test.pl
+++ b/t/test.pl
@@ -246,7 +246,7 @@ sub _ok {
         $name =~ s/#/\\#/g;
 	$out = $pass ? "ok $test - $name" : "not ok $test - $name";
     } else {
-	$out = $pass ? "ok $test" : "not ok $test";
+	$out = $pass ? "ok $test - [$where]" : "not ok $test - [$where]";
     }
 
     if ($TODO) {


### PR DESCRIPTION
If no test name is supplied it can be hard to work out where the failure was, if the output is something like

    ...
    ok 100
    ok 101
    ok 102
    Segmentation fault

There's no easy correlation with the lines in the .t file, short of counting all the calls.

By adding the caller file/line number, at least we can get a rough idea of where the test script got to when it failed

    ...
    ok 102 - [at foo.t line 1234]
    Segmentation fault