### PR TITLE
pp_ctl.c - make sure we dont leak PL_restartop from failed compile

### DIFF
--- a/perl.c
+++ b/perl.c
@@ -2701,6 +2701,11 @@ perl_run(pTHXx)
 #ifndef MULTIPLICITY
     PERL_UNUSED_ARG(my_perl);
 #endif
+    /* perl_parse() may end up starting its own run loops, which might end
+     * up "leaking" PL_restartop from the parse phase into the run phase
+     * which then ends up confusing run_body(). This leakage shouldn't
+     * happen and if it does its a bug. */
+    assert(!PL_restartop);
 
     oldscope = PL_scopestack_ix;
 #ifdef VMS

--- a/perl.c
+++ b/perl.c
@@ -2783,6 +2783,14 @@ S_run_body(pTHX_ I32 oldscope)
     PERL_SET_PHASE(PERL_PHASE_RUN);
 
     if (PL_restartop) {
+#ifdef DEBUGGING
+        /* this complements the "EXECUTING..." debug we emit above.
+         * it will show up when an eval fails in the main program level
+         * and the code continues after the error.
+         */
+        if (!DEBUG_q_TEST)
+          PERL_DEBUG(PerlIO_printf(Perl_debug_log, "\nCONTINUING...\n\n"));
+#endif
         PL_restartjmpenv = NULL;
         PL_op = PL_restartop;
         PL_restartop = 0;

--- a/scope.c
+++ b/scope.c
@@ -725,6 +725,7 @@ Perl_save_clearsv(pTHX_ SV **svp)
     PERL_ARGS_ASSERT_SAVE_CLEARSV;
 
     ASSERT_CURPAD_ACTIVE("save_clearsv");
+    assert(*svp);
     SvPADSTALE_off(*svp); /* mark lexical as active */
     if (UNLIKELY((offset_shifted >> SAVE_TIGHT_SHIFT) != offset)) {
         Perl_croak(aTHX_ "panic: pad offset %" UVuf " out of range (%p-%p)",

--- a/t/op/eval.t
+++ b/t/op/eval.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan(tests => 160);
+plan(tests => 162);
 
 eval 'pass();';
 
@@ -727,6 +727,7 @@ pass("eval in freed package does not crash");
         'INIT      { eval "]" } print q"A-";',
         'UNITCHECK { eval "]" } print q"A-";',
         'BEGIN     { eval "]" } print q"A-";',
+        'INIT      { eval q(UNITCHECK { die; } print 0;); print q(A-); }',
     ) {
         fresh_perl_is($line . ' print "ok";', "A-ok", {}, "No segfault: $line");
 

--- a/t/op/eval.t
+++ b/t/op/eval.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan(tests => 152);
+plan(tests => 160);
 
 eval 'pass();';
 
@@ -723,10 +723,17 @@ pass("eval in freed package does not crash");
         'eval "UNITCHECK { eval q(UNITCHECK { die; }); print q(A-) }";',
         'eval "UNITCHECK { eval q(BEGIN     { die; }); print q(A-) }";',
         'eval "BEGIN     { eval q(UNITCHECK { die; }); print q(A-) }";',
+        'CHECK     { eval "]" } print q"A-";',
+        'INIT      { eval "]" } print q"A-";',
+        'UNITCHECK { eval "]" } print q"A-";',
+        'BEGIN     { eval "]" } print q"A-";',
     ) {
         fresh_perl_is($line . ' print "ok";', "A-ok", {}, "No segfault: $line");
-        my $sort_line= 'my @x= sort { ' . $line . ' } 1,2;';
-        fresh_perl_is($line . ' print "ok";', "A-ok", {}, "No segfault: $line");
 
+        # sort blocks are somewhat special and things that work in normal blocks
+        # can blow up in sort blocks, so test these constructs specially.
+        my $sort_line= 'my @x= sort { ' . $line . ' } 1,2;';
+        fresh_perl_is($sort_line . ' print "ok";', "A-ok", {},
+            "No segfault inside sort: $sort_line");
     }
 }


### PR DESCRIPTION
Fix GH Issue #20396, try_yyparse() breaks Attribute::Handlers.

Reduced test case is:

```
    perl -e'CHECK { eval "]" }'
```

which should not assert or segfault.

In c304acb49 we made it so that when doeval_compile() is executed and it calls yyparse() inside of an eval any exceptions that occur during the parse process are trapped by try_yyparse() so that exection would return to doeval_compile(). This was done so that post eval compilation cleanup logic could be handled similarly regardless of whether Perl_croak() was called or not. However the logic to setup PL_restartop was not adjusted accordingly.

The opcode that calls doeval_compile() setups an eval context data before it calls doeval_compile().  This data includes the "retop" which is used to return control to after the eval should it die and is set to the be the evaling opcodes op_next. When Perl_die_unwind() is called it sets PL_restartop to be the "retop" of the of the current eval frame, and then does a longjmp, on the assumption it will end up inside of a "run loop enabled jump enviornment", where it restarts the run loop based on the value of PL_restartop, zeroing it aftewards.

After c304acb49 however, a die inside of try_yyparse the die_unwind returns control back to the try_yyparse, which ignores PL_restartop, and leaves it set. Code then goes through the "compilation failed" branch and execution returns to PL_restartop /anyway/, as PL_op hasn't changed and pp_entereval returns control to PL_op->op_next, which is what we pushed into the eval context anyway for the PL_restartop.

The end result of this however is that PL_restartop remains set when we enter perl_run() for the first time. perl_run() is a "run loop enabled jump enviornment" which uses run_body() to do its business, such that when PL_restartop is NULL it executes the just compiled body of the program, and when PL_restartop is not null it assumes it must be in the eval handler from an eval from the main body and it should recontinue. The leaked PL_restartop is thus executed instead of the main program body and things go horribly wrong.

This patch changes it so that when try_yyparse traps an exception we restore PL_restartop back to its old value. Same for its partner PL_restartjmpenv. This is fine as they have been set to the values from the beginning of the eval frame which we are part of, which is now over.