### PR TITLE
locale.c: Don't compile get_displayable_string if unused

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3463,9 +3463,11 @@ SR	|char *	|my_setlocale_debug_string_i			\
 S	|const char *|get_LC_ALL_display
 #    endif
 #  endif
+#  if  defined(DEBUGGING) || defined(USE_POSIX_2008_LOCALE)
 S	|const char *|get_displayable_string|NN const char * const s	\
 					|NN const char * const e	\
 					|const bool is_utf8
+#  endif
 #endif
 
 #if defined(PERL_IN_UTIL_C)

--- a/embed.h
+++ b/embed.h
@@ -1643,6 +1643,11 @@
 #      endif
 #    endif
 #  endif
+#  if defined(DEBUGGING) || defined(USE_POSIX_2008_LOCALE)
+#    if defined(PERL_IN_LOCALE_C)
+#define get_displayable_string(a,b,c)	S_get_displayable_string(aTHX_ a,b,c)
+#    endif
+#  endif
 #  if defined(DEBUG_LEAKING_SCALARS_FORK_DUMP)
 #define dump_sv_child(a)	Perl_dump_sv_child(aTHX_ a)
 #  endif
@@ -1748,7 +1753,6 @@
 #define unshare_hek_or_pvn(a,b,c,d)	S_unshare_hek_or_pvn(aTHX_ a,b,c,d)
 #  endif
 #  if defined(PERL_IN_LOCALE_C)
-#define get_displayable_string(a,b,c)	S_get_displayable_string(aTHX_ a,b,c)
 #    if defined(USE_LOCALE)
 #define get_category_index	S_get_category_index
 #define get_locale_string_utf8ness_i(a,b,c,d)	S_get_locale_string_utf8ness_i(aTHX_ a,b,c,d)

--- a/locale.c
+++ b/locale.c
@@ -5954,6 +5954,7 @@ S_print_collxfrm_input_and_return(pTHX_
 
 #  endif    /* DEBUGGING */
 #endif /* USE_LOCALE_COLLATE */
+#if  defined(DEBUGGING) || defined(USE_POSIX_2008_LOCALE)
 
 STATIC const char *
 S_get_displayable_string(pTHX_
@@ -6007,6 +6008,7 @@ S_get_displayable_string(pTHX_
     return ret;
 }
 
+#endif
 #ifdef USE_LOCALE
 
 STATIC const char *

--- a/proto.h
+++ b/proto.h
@@ -5226,6 +5226,13 @@ STATIC const char *	S_get_LC_ALL_display(pTHX);
 #    endif
 #  endif
 #endif
+#if defined(DEBUGGING) || defined(USE_POSIX_2008_LOCALE)
+#  if defined(PERL_IN_LOCALE_C)
+STATIC const char *	S_get_displayable_string(pTHX_ const char * const s, const char * const e, const bool is_utf8);
+#define PERL_ARGS_ASSERT_GET_DISPLAYABLE_STRING	\
+	assert(s); assert(e)
+#  endif
+#endif
 #if defined(DEBUG_LEAKING_SCALARS_FORK_DUMP)
 PERL_CALLCONV void	Perl_dump_sv_child(pTHX_ SV *sv)
 			__attribute__visibility__("hidden");
@@ -5698,9 +5705,6 @@ PERL_CALLCONV SV*	Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
 
 #endif
 #if defined(PERL_IN_LOCALE_C)
-STATIC const char *	S_get_displayable_string(pTHX_ const char * const s, const char * const e, const bool is_utf8);
-#define PERL_ARGS_ASSERT_GET_DISPLAYABLE_STRING	\
-	assert(s); assert(e)
 #  if defined(USE_LOCALE)
 STATIC unsigned int	S_get_category_index(const int category, const char * locale);
 #define PERL_ARGS_ASSERT_GET_CATEGORY_INDEX


### PR DESCRIPTION
This was generating warnings on several different platforms