### PR TITLE
Add `PL_throwing`, true during exceptional stack unwind

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4708,6 +4708,7 @@ ext/XS-APItest/t/swaptwostmts.t	test recursive descent statement parsing
 ext/XS-APItest/t/sym-hook.t	Test rv2cv hooks for bareword lookup
 ext/XS-APItest/t/synthetic_scope.t	Test block_start/block_end/intro_my
 ext/XS-APItest/t/temp_lv_sub.t	XS::APItest: tests for lvalue subs returning temps
+ext/XS-APItest/t/throwing.t	XS::APItest: tests the behaviour of PL_throwing
 ext/XS-APItest/t/underscore_length.t	Test find_rundefsv()
 ext/XS-APItest/t/utf16_to_utf8.t	Test behaviour of utf16_to_utf8{,reversed}
 ext/XS-APItest/t/utf8.t		Tests for code in utf8.c

--- a/embedvar.h
+++ b/embedvar.h
@@ -320,6 +320,7 @@
 # define PL_tainted                             (vTHX->Itainted)
 # define PL_tainting                            (vTHX->Itainting)
 # define PL_threadhook                          (vTHX->Ithreadhook)
+# define PL_throwing                            (vTHX->Ithrowing)
 # define PL_tmps_floor                          (vTHX->Itmps_floor)
 # define PL_tmps_ix                             (vTHX->Itmps_ix)
 # define PL_tmps_max                            (vTHX->Itmps_max)

--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.30';
+our $VERSION = '1.31';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -4736,6 +4736,13 @@ sv_streq_flags(SV *sv1, SV *sv2, U32 flags)
     OUTPUT:
         RETVAL
 
+bool
+PL_throwing()
+    CODE:
+        RETVAL = PL_throwing;
+    OUTPUT:
+        RETVAL
+
 MODULE = XS::APItest PACKAGE = XS::APItest::AUTOLOADtest
 
 int

--- a/ext/XS-APItest/t/throwing.t
+++ b/ext/XS-APItest/t/throwing.t
@@ -2,7 +2,12 @@
 
 use v5.36;
 
-use Test::More;
+# Test::More doesn't have fresh_perl_is() yet
+
+BEGIN {
+    require '../../t/test.pl';
+};
+
 use XS::APItest;
 
 package RunOnDestruct {
@@ -49,6 +54,30 @@ sub run_on_destruct :prototype(&) {
     ok(!XS::APItest::PL_throwing, 'PL_throwing false after eval returned');
 }
 
+# PL_throwing during string-eval()
+{
+    my $var;
+    eval q(
+        my $guard = run_on_destruct { $var = 0 + XS::APItest::PL_throwing };
+        die "Oopsie";
+    ); # ignore the error
+    is($var, 1, 'var is true after die in string-eval');
+    ok(!XS::APItest::PL_throwing, 'PL_throwing false after string-eval returned');
+}
+
+# It's (probably) not possible to observe PL_throwing=true during a BEGIN,
+# CHECK or INIT phaser, but we can test END
+fresh_perl_is(
+    <<'EOF',
+use strict;
+use XS::APItest;
+END { printf "PL_throwing=%s\n", XS::APItest::PL_throwing ? "true" : "false" }
+die "Oopsie\n";
+EOF
+    "Oopsie\nPL_throwing=true",
+    { stderr => 1 },
+    'PL_throwing during END block');
+
 # PL_throwing during normal defer
 {
     use experimental 'defer';
@@ -73,6 +102,19 @@ sub run_on_destruct :prototype(&) {
     is($var, 1, 'var is true during exceptional defer');
     ok(!XS::APItest::PL_throwing, 'PL_throwing false after eval');
 }
+
+# PL_throwing at top-level defer
+fresh_perl_is(
+    <<'EOF',
+use strict;
+use experimental 'defer';
+use XS::APItest;
+defer { printf "PL_throwing=%s\n", XS::APItest::PL_throwing ? "true" : "false" }
+die "Oopsie\n";
+EOF
+    "Oopsie\nPL_throwing=true",
+    { stderr => 1 },
+    'PL_throwing during toplevel defer {}');
 
 # PL_throwing during caught finally
 {

--- a/ext/XS-APItest/t/throwing.t
+++ b/ext/XS-APItest/t/throwing.t
@@ -1,0 +1,117 @@
+#!perl
+
+use v5.36;
+
+use Test::More;
+use XS::APItest;
+
+package RunOnDestruct {
+    sub DESTROY { $_[0]->[0]->() }
+}
+sub run_on_destruct :prototype(&) {
+    return bless [@_], "RunOnDestruct";
+}
+
+# PL_throwing quiescently
+{
+    my $throwing = XS::APItest::PL_throwing;
+    ok(defined $throwing, 'PL_throwing is defined initially');
+    ok(!$throwing,        'PL_throwing is false initially');
+}
+
+# PL_throwing during normal leave
+{
+    my $var;
+    {
+        my $guard = run_on_destruct { $var = 0 + XS::APItest::PL_throwing };
+    }
+    is($var, 0, 'var is false after normal scope leave');
+}
+
+# PL_throwing during normal eval leave
+{
+    my $var;
+    eval {
+        my $guard = run_on_destruct { $var = 0 + XS::APItest::PL_throwing };
+    };
+    is($var, 0, 'var is false after normal eval leave');
+    ok(!XS::APItest::PL_throwing, 'PL_throwing false after eval returned');
+}
+
+# PL_throwing during exceptional eval leave
+{
+    my $var;
+    eval {
+        my $guard = run_on_destruct { $var = 0 + XS::APItest::PL_throwing };
+        die "Oopsie";
+    }; # ignore the error
+    is($var, 1, 'var is true after die in eval');
+    ok(!XS::APItest::PL_throwing, 'PL_throwing false after eval returned');
+}
+
+# PL_throwing during normal defer
+{
+    use experimental 'defer';
+
+    my $var;
+    eval {
+        defer { $var = 0 + XS::APItest::PL_throwing; }
+    };
+    is($var, 0, 'var is true during normal defer');
+    ok(!XS::APItest::PL_throwing, 'PL_throwing false after eval');
+}
+
+# PL_throwing during exceptional defer
+{
+    use experimental 'defer';
+
+    my $var;
+    eval {
+        defer { $var = 0 + XS::APItest::PL_throwing; }
+        die "Oopsie";
+    }; # ignore the error
+    is($var, 1, 'var is true during exceptional defer');
+    ok(!XS::APItest::PL_throwing, 'PL_throwing false after eval');
+}
+
+# PL_throwing during caught finally
+{
+    use experimental 'try';
+
+    my $var;
+    eval {
+        try {
+            die "Oopsie";
+        }
+        catch ($e) {
+            # ignore it
+        }
+        finally {
+            $var = 0 + XS::APItest::PL_throwing;
+        }
+    };
+    is($var, 0, 'var is caught during caught finally');
+    ok(!XS::APItest::PL_throwing, 'PL_throwing false after eval');
+}
+
+# PL_throwing during throwing finally
+{
+    use experimental 'try';
+
+    my $var;
+    eval {
+        try {
+            die "Oopsie";
+        }
+        catch ($e) {
+            die $e; # rethrow
+        }
+        finally {
+            $var = 0 + XS::APItest::PL_throwing;
+        }
+    }; # ignore the error
+    is($var, 1, 'var is true during throwing finally');
+    ok(!XS::APItest::PL_throwing, 'PL_throwing false after eval');
+}
+
+done_testing;

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -1086,6 +1086,8 @@ PERLVARA(I, mem_log, PERL_MEM_LOG_ARYLEN,  char)
  * have to worry about SV refcounts during scope enter/exit. */
 PERLVAR(I, prevailing_version, U16)
 
+PERLVARI(I, throwing, bool, false)  /* true only during stack-unwind due to an exception being thrown */
+
 /* If you are adding a U8 or U16, check to see if there are 'Space' comments
  * above on where there are gaps which currently will be structure padding.  */
 

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -1086,7 +1086,17 @@ PERLVARA(I, mem_log, PERL_MEM_LOG_ARYLEN,  char)
  * have to worry about SV refcounts during scope enter/exit. */
 PERLVAR(I, prevailing_version, U16)
 
-PERLVARI(I, throwing, bool, false)  /* true only during stack-unwind due to an exception being thrown */
+/*
+=for apidoc_section $warning
+=for apidoc Amnx|BOOL|PL_throwing
+
+In most normal circumstances remains false. Becomes true during a stack unwind
+due to an exception being thrown. Code pushed to the save stack by
+SAVEDESTRUCTOR or similar can use this variable to distinguish the reason for
+stack unwind.
+=cut
+ */
+PERLVARI(I, throwing, bool, false)
 
 /* If you are adding a U8 or U16, check to see if there are 'Space' comments
  * above on where there are gaps which currently will be structure padding.  */

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -27,6 +27,13 @@ here, but most should go in the L</Performance Enhancements> section.
 
 [ List each enhancement as a =head2 entry ]
 
+=head2 Added `PL_throwing` interpreter variable
+
+A new interpreter variable named C<PL_throwing> allows code to inspect the
+reason for the current stack unwind in progress. This should be a more
+reliable method of detection than existing techniques such as
+C<SvTRUE(ERRSV)>.
+
 =head1 Security
 
 XXX Any security-related notices go here.  In particular, any security

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -1744,14 +1744,15 @@ Perl_die_unwind(pTHX_ SV *msv)
     U8 in_eval = PL_in_eval;
     PERL_ARGS_ASSERT_DIE_UNWIND;
 
+    bool was_throwing = PL_throwing;
+    PL_throwing = true;
+
     if (in_eval) {
         I32 cxix;
         /* We can't use the regular SAVEBOOL() mechanism for this because we
          *   are currently unwinding the save stack. We will have to do it the
          *   old-fashioned way
          */
-        bool was_throwing = PL_throwing;
-        PL_throwing = true;
 
         /* We need to keep this SV alive through all the stack unwinding
          * and FREETMPSing below, while ensuing that it doesn't leak

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -1746,6 +1746,12 @@ Perl_die_unwind(pTHX_ SV *msv)
 
     if (in_eval) {
         I32 cxix;
+        /* We can't use the regular SAVEBOOL() mechanism for this because we
+         *   are currently unwinding the save stack. We will have to do it the
+         *   old-fashioned way
+         */
+        bool was_throwing = PL_throwing;
+        PL_throwing = true;
 
         /* We need to keep this SV alive through all the stack unwinding
          * and FREETMPSing below, while ensuing that it doesn't leak
@@ -1862,6 +1868,7 @@ Perl_die_unwind(pTHX_ SV *msv)
             }
             PL_restartjmpenv = restartjmpenv;
             PL_restartop = restartop;
+            PL_throwing = was_throwing;
             JMPENV_JUMP(3);
             NOT_REACHED; /* NOTREACHED */
         }


### PR DESCRIPTION
This PR adds a mechanism by which code that runs during stack unwind (`finally` and `defer` blocks at the Perl layer, `SAVEDESTRUCTOR*` at the XS layer) can inspect whether that stack unwind is happening because of a thrown exception. Or, at least, whether *a* stack unwind because of a thrown exception is happening - not necessarily "this" one.

Such a mechanism is a prerequisite to solving #20389, and also hinted at by the comment https://github.com/Perl/perl5/blob/1932805f63d6181a90fe36fabbdc3755a78b072f/pp_ctl.c#L1776-L1782

Still undecided:

 * How it should behave during nested (normal) unwinds invoked as part of an exceptional one
 * Whether a pure-perl wrapping should be added; perhaps by a interpreter-global variable `${^THROWING}`