### PR TITLE
t/op/require_errors.t: Fix Windows warning

### DIFF
--- a/t/op/require_errors.t
+++ b/t/op/require_errors.t
@@ -21,7 +21,7 @@ for my $file ($nonfile, ' ') {
 	require $file;
     };
 
-    like $@, qr/^Can't locate $file in \@INC \(\@INC contains: @INC\) at/,
+    like $@, qr/^Can't locate $file in \@INC \(\@INC contains: \Q@INC\E\) at/,
 	"correct error message for require '$file'";
 }
 


### PR DESCRIPTION
A regular expression pattern was failing to \Q an expansion of @INC, leading to a perl warning due to it's thinking a \ in a path was an escape.  This doesn't arise on systems where the path separator is a forward slash.