### PR TITLE
Update Net-Ping to CPAN version 2.75

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -858,7 +858,7 @@ use File::Glob qw(:case);
     },
 
     'Net::Ping' => {
-        'DISTRIBUTION' => 'RURBAN/Net-Ping-2.74.tar.gz',
+        'DISTRIBUTION' => 'RURBAN/Net-Ping-2.75.tar.gz',
         'FILES'        => q[dist/Net-Ping],
         'EXCLUDED'     => [
             qr{^\.[awc]},

--- a/dist/Net-Ping/Changes
+++ b/dist/Net-Ping/Changes
@@ -1,5 +1,14 @@
 CHANGES
 -------
+2.75  2022-09-01 12:44:03 rurban
+      Minor
+      - Modernized the synopsis (PR #31)
+      - Fixed a link in a comment (PR #25)
+      META Changes
+      - Remove some TEST_REQUIRES (PR #23)
+      Test fixes
+      - Support NO_NETWORK_TESTING=1 (PR #24)
+      - Fix non-routable addresses for negative tests (PR #24)
 2.74  2020-09-09 09:21:39 rurban
       Features
       - Add ICMPv6_NI_REPLY support.

--- a/dist/Net-Ping/lib/Net/Ping.pm
+++ b/dist/Net-Ping/lib/Net/Ping.pm
@@ -22,7 +22,7 @@ use Time::HiRes;
 @ISA = qw(Exporter);
 @EXPORT = qw(pingecho);
 @EXPORT_OK = qw(wakeonlan);
-$VERSION = "2.74";
+$VERSION = "2.75";
 
 # Globals
 
@@ -1081,8 +1081,7 @@ sub tcp_connect
 
 sub DESTROY {
   my $self = shift;
-  if ($self->{'proto'} eq 'tcp' &&
-      $self->{'tcp_chld'}) {
+  if ($self->{'proto'} && ($self->{'proto'} eq 'tcp') && $self->{'tcp_chld'}) {
     # Put that choking client out of its misery
     kill "KILL", $self->{'tcp_chld'};
     # Clean off the zombie
@@ -2004,13 +2003,13 @@ Net::Ping - check a remote host for reachability
 
     use Net::Ping;
 
-    $p = Net::Ping->new();
+    my $p = Net::Ping->new();
     print "$host is alive.\n" if $p->ping($host);
     $p->close();
 
-    $p = Net::Ping->new("icmp");
+    my $p = Net::Ping->new("icmp");
     $p->bind($my_addr); # Specify source interface of pings
-    foreach $host (@host_array)
+    foreach my $host (@host_array)
     {
         print "$host is ";
         print "NOT " unless $p->ping($host, 2);
@@ -2019,11 +2018,11 @@ Net::Ping - check a remote host for reachability
     }
     $p->close();
 
-    $p = Net::Ping->new("icmpv6");
-    $ip = "[fd00:dead:beef::4e]";
+    my $p = Net::Ping->new("icmpv6");
+    my $ip = "[fd00:dead:beef::4e]";
     print "$ip is alive.\n" if $p->ping($ip);
 
-    $p = Net::Ping->new("tcp", 2);
+    my $p = Net::Ping->new("tcp", 2);
     # Try connecting to the www port instead of the echo port
     $p->port_number(scalar(getservbyname("http", "tcp")));
     while ($stop_time > time())
@@ -2035,19 +2034,19 @@ Net::Ping - check a remote host for reachability
     undef($p);
 
     # Like tcp protocol, but with many hosts
-    $p = Net::Ping->new("syn");
+    my $p = Net::Ping->new("syn");
     $p->port_number(getservbyname("http", "tcp"));
-    foreach $host (@host_array) {
+    foreach my $host (@host_array) {
       $p->ping($host);
     }
-    while (($host,$rtt,$ip) = $p->ack) {
+    while (my ($host, $rtt, $ip) = $p->ack) {
       print "HOST: $host [$ip] ACKed in $rtt seconds.\n";
     }
 
     # High precision syntax (requires Time::HiRes)
-    $p = Net::Ping->new();
+    my $p = Net::Ping->new();
     $p->hires();
-    ($ret, $duration, $ip) = $p->ping($host, 5.5);
+    my ($ret, $duration, $ip) = $p->ping($host, 5.5);
     printf("$host [ip: $ip] is alive (packet return time: %.2f ms)\n",
             1000 * $duration)
       if $ret;

--- a/dist/Net-Ping/t/190_alarm.t
+++ b/dist/Net-Ping/t/190_alarm.t
@@ -4,11 +4,10 @@
 # Based on code written by radu@netsoft.ro (Radu Greab).
 
 BEGIN {
-  if ($ENV{PERL_CORE}) {
-    unless ($ENV{PERL_TEST_Net_Ping}) {
-      print "1..0 \# Skip: network dependent test\n";
-        exit;
-    }
+  if ($ENV{NO_NETWORK_TESTING} ||
+      ($ENV{PERL_CORE}) && !$ENV{PERL_TEST_Net_Ping}) {
+    print "1..0 \# Skip: network dependent test\n";
+    exit;
   } 
   unless (eval "require Socket") {
     print "1..0 \# Skip: no Socket\n";
@@ -29,7 +28,7 @@ use Test::More tests => 6;
 BEGIN {use_ok 'Net::Ping'};
 
 # Hopefully this is never a routeable host
-my $fail_ip = $ENV{NET_PING_FAIL_IP} || "172.29.249.249";
+my $fail_ip = $ENV{NET_PING_FAIL_IP} || "192.0.2.0";
 
 eval {
   my $timeout = 11;

--- a/dist/Net-Ping/t/200_ping_tcp.t
+++ b/dist/Net-Ping/t/200_ping_tcp.t
@@ -1,11 +1,10 @@
 use strict;
 
 BEGIN {
-  if ($ENV{PERL_CORE}) {
-    unless ($ENV{PERL_TEST_Net_Ping}) {
-      print "1..0 # Skip: network dependent test\n";
-        exit;
-    }
+  if ($ENV{NO_NETWORK_TESTING} ||
+      ($ENV{PERL_CORE}) && !$ENV{PERL_TEST_Net_Ping}) {
+    print "1..0 # Skip: network dependent test\n";
+    exit;
   }
   unless (eval "require Socket") {
     print "1..0 \# Skip: no Socket\n";
@@ -18,7 +17,7 @@ BEGIN {
 }
 
 # Hopefully this is never a routeable host
-my $fail_ip = $ENV{NET_PING_FAIL_IP} || "172.29.249.249";
+my $fail_ip = $ENV{NET_PING_FAIL_IP} || "192.0.2.0";
 
 # Remote network test using tcp protocol.
 #

--- a/dist/Net-Ping/t/250_ping_hires.t
+++ b/dist/Net-Ping/t/250_ping_hires.t
@@ -3,12 +3,11 @@
 use strict;
 
 BEGIN {
-  if ($ENV{PERL_CORE}) {
-    unless ($ENV{PERL_TEST_Net_Ping}) {
-      print "1..0 # Skip: network dependent test\n";
-        exit;
-    }
-  }
+  if ($ENV{NO_NETWORK_TESTING} ||
+      ($ENV{PERL_CORE}) && !$ENV{PERL_TEST_Net_Ping}) {
+    print "1..0 \# Skip: network dependent test\n";
+    exit;
+  } 
   unless (eval "require Socket") {
     print "1..0 \# Skip: no Socket\n";
     exit;

--- a/dist/Net-Ping/t/300_ping_stream.t
+++ b/dist/Net-Ping/t/300_ping_stream.t
@@ -1,11 +1,10 @@
 use strict; 
 BEGIN {
-  if ($ENV{PERL_CORE}) {
-    unless ($ENV{PERL_TEST_Net_Ping}) {
-      print "1..0 # Skip: network dependent test\n";
-        exit;
-    }
-  }
+  if ($ENV{NO_NETWORK_TESTING} ||
+      ($ENV{PERL_CORE}) && !$ENV{PERL_TEST_Net_Ping}) {
+    print "1..0 \# Skip: network dependent test\n";
+    exit;
+  } 
   if ($^O eq 'freebsd') {
     print "1..0 \# Skip: unreliable localhost resolver on $^O\n";
     exit;

--- a/dist/Net-Ping/t/400_ping_syn.t
+++ b/dist/Net-Ping/t/400_ping_syn.t
@@ -1,11 +1,10 @@
 use strict;
 
 BEGIN {
-  if ($ENV{PERL_CORE}) {
-    unless ($ENV{PERL_TEST_Net_Ping}) {
-      print "1..0 # Skip: network dependent test\n";
-      exit;
-    }
+  if ($ENV{NO_NETWORK_TESTING} ||
+      ($ENV{PERL_CORE} && !$ENV{PERL_TEST_Net_Ping})) {
+    print "1..0 # Skip: network dependent test\n";
+    exit;
   }
   unless (eval "require Socket") {
     print "1..0 \# Skip: no Socket\n";
@@ -30,10 +29,10 @@ BEGIN {
 #   connection to remote networks, but you still want the tests
 #   to pass, use the following:
 #
-# $ PERL_CORE=1 make test
+# $ NO_NETWORK_TESTING=1 make test
 
 # Hopefully this is never a routeable host
-my $fail_ip = $ENV{NET_PING_FAIL_IP} || "172.29.249.249";
+my $fail_ip = $ENV{NET_PING_FAIL_IP} || "192.0.2.0";
 
 # Try a few remote servers
 my %webs = (

--- a/dist/Net-Ping/t/410_syn_host.t
+++ b/dist/Net-Ping/t/410_syn_host.t
@@ -2,11 +2,10 @@
 use strict;
 
 BEGIN {
-  if ($ENV{PERL_CORE}) {
-    unless ($ENV{PERL_TEST_Net_Ping}) {
-      print "1..0 # Skip: network dependent test\n";
-        exit;
-    }
+  if ($ENV{NO_NETWORK_TESTING} ||
+      ($ENV{PERL_CORE} && !$ENV{PERL_TEST_Net_Ping})) {
+    print "1..0 # Skip: network dependent test\n";
+    exit;
   }
   unless (eval "require Socket") {
     print "1..0 \# Skip: no Socket\n";
@@ -31,13 +30,13 @@ BEGIN {
 #   connection to remote networks, but you still want the tests
 #   to pass, use the following:
 #
-# $ PERL_CORE=1 make test
+# $ NO_NETWORK_TESTING=1 make test
 
 # Try a few remote servers
 my %webs;
 BEGIN {
   # Hopefully this is never a routeable host
-  my $fail_ip = $ENV{NET_PING_FAIL_IP} || "172.29.249.249";
+  my $fail_ip = $ENV{NET_PING_FAIL_IP} || "192.0.2.0";
 
   %webs = (
   $fail_ip => 0,

--- a/dist/Net-Ping/t/420_ping_syn_port.t
+++ b/dist/Net-Ping/t/420_ping_syn_port.t
@@ -2,11 +2,10 @@
 use strict;
 
 BEGIN {
-  if ($ENV{PERL_CORE}) {
-    unless ($ENV{PERL_TEST_Net_Ping}) {
-      print "1..0 # Skip: network dependent test\n";
-        exit;
-    }
+  if ($ENV{NO_NETWORK_TESTING} ||
+      ($ENV{PERL_CORE} && !$ENV{PERL_TEST_Net_Ping})) {
+    print "1..0 # Skip: network dependent test\n";
+    exit;
   }
   unless (eval "require Socket") {
     print "1..0 \# Skip: no Socket\n";
@@ -31,10 +30,10 @@ BEGIN {
 #   connection to remote networks, but you still want the tests
 #   to pass, use the following:
 #
-# $ PERL_CORE=1 make test
+# $ NO_NETWORK_TESTING=1 make test
 
 # Hopefully this is never a routeable host
-my $fail_ip = $ENV{NET_PING_FAIL_IP} || "172.29.249.249";
+my $fail_ip = $ENV{NET_PING_FAIL_IP} || "192.0.2.0";
 
 # Try a few remote servers
 my %webs;


### PR DESCRIPTION
[DELTA]

2.75  2022-09-01 12:44:03 rurban                                                                                                                                                    
      Minor                                                                                                                                                                         
      - Modernized the synopsis (https://github.com/rurban/Net-Ping/pull/31)                                                                                                        
      - Fixed a link in a comment (https://github.com/rurban/Net-Ping/pull/25)                                                                                                      
      META Changes                                                                                                                                                                  
      - Remove some TEST_REQUIRES (https://github.com/rurban/Net-Ping/pull/23)                                                                                                      
      Test fixes                                                                                                                                                                    
      - Support NO_NETWORK_TESTING=1 (https://github.com/rurban/Net-Ping/pull/24)                                                                                                   
      - Fix non-routable addresses for negative tests (https://github.com/rurban/Net-Ping/pull/24)