### PR TITLE
t/test.pl: Fix threads signalling watchdog cancellation

### DIFF
--- a/t/test.pl
+++ b/t/test.pl
@@ -1932,7 +1932,7 @@ sub watchdog ($;$)
         while (     $watchdog_thread->is_running()
                && ! $watchdog_thread->is_detached())
         {
-            sleep 0;    # Relinquishes control, with minimal delay
+            'threads'->yield();
         }
 
         return;

--- a/t/test.pl
+++ b/t/test.pl
@@ -1907,6 +1907,10 @@ sub watchdog ($;$)
 
                 $SIG{'KILL'} = sub { threads->exit(); };
 
+                # Detach after the signal handler is set up; the parent knows
+                # not to signal until detached.
+                'threads'->detach();
+
                 # Execute the timeout
                 my $time_left = $timeout;
                 do {
@@ -1919,7 +1923,18 @@ sub watchdog ($;$)
                 POSIX::_exit(1) if (defined(&POSIX::_exit));
                 my $sig = $is_vms ? 'TERM' : 'KILL';
                 kill($sig, $pid_to_kill);
-            })->detach();
+        });
+
+        # Don't proceed until the watchdog has set up its signal handler.
+        # (Otherwise there is a possibility that we will exit with threads
+        # running.)  The watchdog tells us the handler is set by detaching
+        # itself.  (The 'is_running()' is a fail-safe.)
+        while (     $watchdog_thread->is_running()
+               && ! $watchdog_thread->is_detached())
+        {
+            sleep 0;    # Relinquishes control, with minimal delay
+        }
+
         return;
     }
 


### PR DESCRIPTION
Commit 4712a4c94e5974bba8ef97d68aadf2b99c0b4ff4 added the ability to cancel a watchdog timer.  Unfortunately it doesn't work properly when the timer method was using the thread signalling cancellation method. This problem only shows up on slow systems under load, so the flaw wasn't immediately discovered.  That commit lowered the incidence level significantly.

This commit solves the problem by having the child thread detach itself, after it sets up the needed code to handle a signal from the parent. The parent thread signals the child, as currently when it is done processing, but waits for the child being detached.  That is a cue to the parent that it is safe to signal the child.