### PR TITLE
Fix fegetround on s390x with clang

### DIFF
--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -1021,7 +1021,7 @@ static NV my_log2(NV x)
 /* XXX nexttoward */
 
 /* GCC's FLT_ROUNDS is (wrongly) hardcoded to 1 (at least up to 11.x) */
-#if defined(PERL_IS_GCC) /* && __GNUC__ < XXX */
+#if defined(PERL_IS_GCC) /* && __GNUC__ < XXX */ || (defined(__clang__) && defined(__s390x__))
 #  define BROKEN_FLT_ROUNDS
 #endif
 

--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our ($AUTOLOAD, %SIGRT);
 
-our $VERSION = '2.07';
+our $VERSION = '2.08';
 
 require XSLoader;
 


### PR DESCRIPTION
Clang's s390x backend hard codes FLT_ROUNDS to one.  This fixes fenv.t test failures with building with clang on s390x.