### PR TITLE
19207: Document ellipsis statement error

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -433,6 +433,7 @@ Jody Belka <dev-perl@pimb.org> Jody Belka <lists-p5p@pimb.org>
 Jody Belka <dev-perl@pimb.org> knew-p5p@pimb.org <knew-p5p@pimb.org>
 Joe Buehler <jbuehler@hekimian.com> <jhpb@hekimian.com>
 Joe McMahon <mcmahon@ibiblio.org> <mcmahon@metalab.unc.edu>
+Joe McMahon <mcmahon@ibiblio.org> Joe McMahon <joe.mcmahon@gmail.com>
 John Heidemann <johnh@isi.edu> johnh@isi.edu <johnh@isi.edu>
 John Hughes <john@atlantech.com> John Hughes <john@titanic.atlantech.com>
 John L. Allen <allen@grumman.com> John L. Allen <allen@gateway.grumman.com>

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -6781,6 +6781,21 @@ problems when being input or output, which is likely where this message
 came from.  If you really really know what you are doing you can turn
 off this warning by C<no warnings 'surrogate';>.
 
+=item Unimplemented
+
+(F) In Perl 5.12 and above, you have executed an
+L<ellipsis statement|perlsyn/"The Ellipsis Statement">.  This is a
+bare C<...;>, meant to be used to allow you to outline code that
+is to be written, but is not complete, similar to the following:
+
+    sub not_done_yet {
+      my($self, $arg1, $arg2) = @_;
+      ...
+    }
+
+If C<not_done_yet()> is called, Perl will die with an C<Unimplemented> error
+at the line containing C<...>.
+
 =item Unknown charname '%s'
 
 (F) The name you used inside C<\N{}> is unknown to Perl.  Check the


### PR DESCRIPTION
Adds a section to `perldiag` that details what the `Unimplemented` error is, caused by executing an ellipsis ("...;") statement.