### PR TITLE
Update Module::CoreList for 5.37.6

### DIFF
--- a/dist/Module-CoreList/Changes
+++ b/dist/Module-CoreList/Changes
@@ -1,3 +1,6 @@
+5.20221024
+  - Updated for v5.37.6
+
 5.20221020
   - Updated for v5.37.5
 

--- a/dist/Module-CoreList/lib/Module/CoreList.pm
+++ b/dist/Module-CoreList/lib/Module/CoreList.pm
@@ -398,6 +398,7 @@ sub changes_between {
     5.037003 => '2022-08-20',
     5.037004 => '2022-09-20',
     5.037005 => '2022-10-20',
+    5.037006 => '2022-10-24',
   );
 
 for my $version ( sort { $a <=> $b } keys %released ) {
@@ -19789,6 +19790,30 @@ for my $version ( sort { $a <=> $b } keys %released ) {
         removed => {
         }
     },
+    5.037006 => {
+        delta_from => 5.037005,
+        changed => {
+            'B::Op_private'         => '5.037006',
+            'Config'                => '5.037006',
+            'ExtUtils::CBuilder'    => '0.280238',
+            'ExtUtils::CBuilder::Base'=> '0.280238',
+            'ExtUtils::CBuilder::Platform::Unix'=> '0.280238',
+            'ExtUtils::CBuilder::Platform::VMS'=> '0.280238',
+            'ExtUtils::CBuilder::Platform::Windows'=> '0.280238',
+            'ExtUtils::CBuilder::Platform::Windows::BCC'=> '0.280238',
+            'ExtUtils::CBuilder::Platform::Windows::GCC'=> '0.280238',
+            'ExtUtils::CBuilder::Platform::Windows::MSVC'=> '0.280238',
+            'ExtUtils::CBuilder::Platform::aix'=> '0.280238',
+            'ExtUtils::CBuilder::Platform::android'=> '0.280238',
+            'ExtUtils::CBuilder::Platform::cygwin'=> '0.280238',
+            'ExtUtils::CBuilder::Platform::darwin'=> '0.280238',
+            'ExtUtils::CBuilder::Platform::dec_osf'=> '0.280238',
+            'ExtUtils::CBuilder::Platform::os2'=> '0.280238',
+            'Time::HiRes'           => '1.9772',
+        },
+        removed => {
+        }
+    },
 );
 
 sub is_core
@@ -21129,6 +21154,13 @@ sub is_core
     },
     5.037005 => {
         delta_from => 5.037004,
+        changed => {
+        },
+        removed => {
+        }
+    },
+    5.037006 => {
+        delta_from => 5.037005,
         changed => {
         },
         removed => {

--- a/dist/Module-CoreList/lib/Module/CoreList/Utils.pm
+++ b/dist/Module-CoreList/lib/Module/CoreList/Utils.pm
@@ -1846,6 +1846,13 @@ my %delta = (
         removed => {
         }
     },
+    5.037006 => {
+        delta_from => 5.037005,
+        changed => {
+        },
+        removed => {
+        }
+    },
 );
 
 %utilities = Module::CoreList::_undelta(\%delta);


### PR DESCRIPTION
In 4ab96809c99e944e70c21779641e4b1c9a00df41 the perl version data was bumped, without doing any Module-CoreList changes and now related tests are failing. Release managers guide said to do:

    ./perl -Ilib Porting/corelist.pl cpan

to update the corelist data, which is this commit. Not sure if this is 100% the right thing to do, but it makes the test fails stop for now. Someone who knows this better can do any mop-up.