### PR TITLE
dist/threads: Only veto switching locale on new perls

### DIFF
--- a/dist/threads/lib/threads.pm
+++ b/dist/threads/lib/threads.pm
@@ -5,7 +5,7 @@ use 5.008;
 use strict;
 use warnings;
 
-our $VERSION = '2.31';      # remember to update version in POD!
+our $VERSION = '2.32';      # remember to update version in POD!
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -134,7 +134,7 @@ threads - Perl interpreter-based threads
 
 =head1 VERSION
 
-This document describes threads version 2.31
+This document describes threads version 2.32
 
 =head1 WARNING
 

--- a/dist/threads/threads.xs
+++ b/dist/threads/threads.xs
@@ -241,7 +241,9 @@ S_ithread_clear(pTHX_ ithread *thread)
     S_block_most_signals(&origmask);
 #endif
 
+#if PERL_VERSION_GE(5, 37, 5)
     int save_veto = PL_veto_switch_non_tTHX_context;
+#endif
 
     interp = thread->interp;
     if (interp) {
@@ -251,7 +253,9 @@ S_ithread_clear(pTHX_ ithread *thread)
          * which doesn't work with things that don't rely on tTHX during
          * tear-down, as they will tend to rely on a mapping from the tTHX
          * structure, and that structure is being destroyed. */
+#if PERL_VERSION_GE(5, 37, 5)
         PL_veto_switch_non_tTHX_context = true;
+#endif
 
         PERL_SET_CONTEXT(interp);
 
@@ -271,7 +275,9 @@ S_ithread_clear(pTHX_ ithread *thread)
     }
 
     PERL_SET_CONTEXT(aTHX);
+#if PERL_VERSION_GE(5, 37, 5)
     PL_veto_switch_non_tTHX_context = save_veto;
+#endif
 
 #ifdef THREAD_SIGNAL_BLOCKING
     S_set_sigmask(&origmask);


### PR DESCRIPTION
Older perls don't define these variables.