### PR TITLE
allow porting/corelist.t to be run from root

### DIFF
--- a/t/porting/corelist.t
+++ b/t/porting/corelist.t
@@ -1,7 +1,9 @@
 #!perl -w
 
 # Check that the current version of perl exists in Module-CoreList data
-
+BEGIN {
+    push @INC, "." if -e "TestInit.pm";
+}
 use TestInit qw(T);
 use strict;
 use Config;


### PR DESCRIPTION
Currently it errors out in the root dir.