### PR TITLE
Default the COP's cop_features to the bitmask of the default-on featu…

### DIFF
--- a/cop.h
+++ b/cop.h
@@ -558,6 +558,8 @@ string C<p>, creating the package if necessary.
 #define CopHINTHASH_get(c)	((COPHH*)((c)->cop_hints_hash))
 #define CopHINTHASH_set(c,h)	((c)->cop_hints_hash = (h))
 
+#define CopFEATURES_setfrom(dst, src) ((dst)->cop_features = (src)->cop_features)
+
 /*
 =for apidoc   Am|SV *|cop_hints_fetch_pv |const COP *cop|const char *key              |U32 hash|U32 flags
 =for apidoc_item|SV *|cop_hints_fetch_pvn|const COP *cop|const char *key|STRLEN keylen|U32 hash|U32 flags

--- a/feature.h
+++ b/feature.h
@@ -43,8 +43,13 @@
 #define FEATURE_BUNDLE_537	7
 #define FEATURE_BUNDLE_CUSTOM	(HINT_FEATURE_MASK >> HINT_FEATURE_SHIFT)
 
-#define CURRENT_HINTS \
+/* this is preserved for testing and asserts */
+#define OLD_CURRENT_HINTS \
     (PL_curcop == &PL_compiling ? PL_hints : PL_curcop->cop_hints)
+/* this is the same thing, but simpler (no if) as PL_hints expands
+   to PL_compiling.cop_hints */
+#define CURRENT_HINTS \
+    PL_curcop->cop_hints
 #define CURRENT_FEATURE_BUNDLE \
     ((CURRENT_HINTS & HINT_FEATURE_MASK) >> HINT_FEATURE_SHIFT)
 

--- a/op.c
+++ b/op.c
@@ -8225,6 +8225,7 @@ Perl_newSTATEOP(pTHX_ I32 flags, char *label, OP *o)
     cop->cop_seq = seq;
     cop->cop_warnings = DUP_WARNINGS(PL_curcop->cop_warnings);
     CopHINTHASH_set(cop, cophh_copy(CopHINTHASH_get(PL_curcop)));
+    CopFEATURES_setfrom(cop, PL_curcop);
     if (label) {
         Perl_cop_store_label(aTHX_ cop, label, strlen(label), utf8);
 

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -305,8 +305,13 @@ for (@HintedBundles) {
 print $h <<'EOH';
 #define FEATURE_BUNDLE_CUSTOM	(HINT_FEATURE_MASK >> HINT_FEATURE_SHIFT)
 
-#define CURRENT_HINTS \
+/* this is preserved for testing and asserts */
+#define OLD_CURRENT_HINTS \
     (PL_curcop == &PL_compiling ? PL_hints : PL_curcop->cop_hints)
+/* this is the same thing, but simpler (no if) as PL_hints expands
+   to PL_compiling.cop_hints */
+#define CURRENT_HINTS \
+    PL_curcop->cop_hints
 #define CURRENT_FEATURE_BUNDLE \
     ((CURRENT_HINTS & HINT_FEATURE_MASK) >> HINT_FEATURE_SHIFT)
 


### PR DESCRIPTION
…res.

The assumption is that cop_features holds the bitmask of the currently enabled feature set, and hence that S_magic_sethint_feature() can incrementally update it as keys for features are set in/cleared from %^H.

However, this overlooks one problem - the default set of features enabled (keys) is not empty, the default for %^H *is* empty, but as long as %^H is empty the internals knows that it is *not* running with a custom feature set, so avoids the complexity of setting up %^H.

There's a C test for features that knows about this, but it was only correctly handling (Perl) compile-time tests for features. That hasn't been noticed before, because all the "default on" features are compile-time only.

This commit fixes things so that run-time default-on features also work properly, by setting each COP's cop_features to the value of the bits set at the COP's compile time - ie the same approach as cop_hints.