### PR TITLE
Assorted manual whitespace cleanups and related changes

### DIFF
--- a/EXTERN.h
+++ b/EXTERN.h
@@ -9,10 +9,11 @@
  */
 
 /*
- * EXT  designates a global var which is defined in perl.h
- * dEXT designates a global var which is defined in another
- *      file, so we can't count on finding it in perl.h
- *      (this practice should be avoided).
+ * EXT:  designates a global var which is defined in perl.h
+ *
+ * dEXT: designates a global var which is defined in another
+ *       file, so we can't count on finding it in perl.h
+ *       (this practice should be avoided).
  */
 #undef EXT
 #undef dEXT

--- a/XSUB.h
+++ b/XSUB.h
@@ -329,15 +329,15 @@ Rethrows a previously caught exception.  See L<perlguts/"Exception Handling">.
         return;						\
     } STMT_END
 
-#define XSRETURN_IV(v) STMT_START { XST_mIV(0,v);  XSRETURN(1); } STMT_END
-#define XSRETURN_UV(v) STMT_START { XST_mUV(0,v);  XSRETURN(1); } STMT_END
-#define XSRETURN_NV(v) STMT_START { XST_mNV(0,v);  XSRETURN(1); } STMT_END
-#define XSRETURN_PV(v) STMT_START { XST_mPV(0,v);  XSRETURN(1); } STMT_END
-#define XSRETURN_PVN(v,n) STMT_START { XST_mPVN(0,v,n);  XSRETURN(1); } STMT_END
-#define XSRETURN_NO    STMT_START { XST_mNO(0);    XSRETURN(1); } STMT_END
-#define XSRETURN_YES   STMT_START { XST_mYES(0);   XSRETURN(1); } STMT_END
-#define XSRETURN_UNDEF STMT_START { XST_mUNDEF(0); XSRETURN(1); } STMT_END
-#define XSRETURN_EMPTY STMT_START {                XSRETURN(0); } STMT_END
+#define XSRETURN_IV(v)    STMT_START { XST_mIV(0,v);    XSRETURN(1); } STMT_END
+#define XSRETURN_UV(v)    STMT_START { XST_mUV(0,v);    XSRETURN(1); } STMT_END
+#define XSRETURN_NV(v)    STMT_START { XST_mNV(0,v);    XSRETURN(1); } STMT_END
+#define XSRETURN_PV(v)    STMT_START { XST_mPV(0,v);    XSRETURN(1); } STMT_END
+#define XSRETURN_PVN(v,n) STMT_START { XST_mPVN(0,v,n); XSRETURN(1); } STMT_END
+#define XSRETURN_NO       STMT_START { XST_mNO(0);      XSRETURN(1); } STMT_END
+#define XSRETURN_YES      STMT_START { XST_mYES(0);     XSRETURN(1); } STMT_END
+#define XSRETURN_UNDEF    STMT_START { XST_mUNDEF(0);   XSRETURN(1); } STMT_END
+#define XSRETURN_EMPTY    STMT_START {                  XSRETURN(0); } STMT_END
 
 #define newXSproto(a,b,c,d)	newXS_flags(a,b,c,d,0)
 

--- a/cop.h
+++ b/cop.h
@@ -887,7 +887,7 @@ struct block_eval {
 
 /* blk_u16 bit usage for eval contexts: */
 
-#define CxOLD_IN_EVAL(cx)	(((cx)->blk_u16) & 0x3F) /* saved PL in_eval */
+#define CxOLD_IN_EVAL(cx)	(((cx)->blk_u16) & 0x3F) /* saved PL_in_eval */
 #define CxEVAL_TXT_REFCNTED(cx)	(((cx)->blk_u16) & 0x40) /* cur_text rc++ */
 #define CxOLD_OP_TYPE(cx)	(((cx)->blk_u16) >> 7)   /* type of eval op */
 

--- a/cv.h
+++ b/cv.h
@@ -120,7 +120,7 @@ See L<perlguts/Autoloading with XSUBs>.
 #define CVf_CLONED	0x0040	/* a clone of one of those */
 #define CVf_ANON	0x0080	/* CV is not pointed to by a GV */
 #define CVf_UNIQUE	0x0100	/* sub is only called once (eg PL_main_cv,
-                                 * require, eval). */
+                                   require, eval). */
 #define CVf_NODEBUG	0x0200	/* no DB::sub indirection for this CV
                                    (esp. useful for special XSUBs) */
 #define CVf_CVGV_RC	0x0400	/* CvGV is reference counted */

--- a/ext/XS-APItest/t/locale.t
+++ b/ext/XS-APItest/t/locale.t
@@ -152,7 +152,7 @@ SKIP: {
         chomp;
         next unless / - \d+ $ /x;
         s/ ^ \# \s* define \s*//x;
-        m/ (.*) \  (.*) /x;
+        m/ (\S+) \s+ (.*) /x;
         $items{$1} = ($has_nl_langinfo)
                      ? $1       # Yields 'YESSTR'
                      : $2;      # Yields -54

--- a/gv.h
+++ b/gv.h
@@ -162,7 +162,7 @@ Return the CV from the GV.
 #define GVf_INTRO	0x01
 #define GVf_MULTI	0x02
 #define GVf_ASSUMECV	0x04
-/*	UNUSED		0x08 */
+#define GVf_RESERVED    0x08   /* unused */
 #define GVf_IMPORTED	0xF0
 #define GVf_IMPORTED_SV	  0x10
 #define GVf_IMPORTED_AV	  0x20

--- a/handy.h
+++ b/handy.h
@@ -1659,8 +1659,7 @@ END_EXTERN_C
 #   define isPUNCT_A(c)  generic_isCC_A_(c, CC_PUNCT_)
 #   define isSPACE_A(c)  generic_isCC_A_(c, CC_SPACE_)
 #   define isWORDCHAR_A(c) generic_isCC_A_(c, CC_WORDCHAR_)
-#   define isXDIGIT_A(c)  generic_isCC_(c, CC_XDIGIT_) /* No non-ASCII xdigits
-                                                        */
+#   define isXDIGIT_A(c)  generic_isCC_(c, CC_XDIGIT_) /* No non-ASCII xdigits */
 #   define isIDFIRST_A(c) generic_isCC_A_(c, CC_IDFIRST_)
 #   define isALPHA_L1(c)  generic_isCC_(c, CC_ALPHA_)
 #   define isALPHANUMERIC_L1(c) generic_isCC_(c, CC_ALPHANUMERIC_)

--- a/handy.h
+++ b/handy.h
@@ -161,7 +161,7 @@ required, but is kept for backwards compatibility.
 #if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || (defined(__SUNPRO_C)) /* C99 or close enough. */
 #  define FUNCTION__ __func__
 #  define SAFE_FUNCTION__ __func__
-#elif (defined(__DECC_VER)) /* Tru64 or VMS, and strict C89 being used, but not modern enough cc (in Tur64, -c99 not known, only -std1). */
+#elif (defined(__DECC_VER)) /* Tru64 or VMS, and strict C89 being used, but not modern enough cc (in Tru64, -c99 not known, only -std1). */
 #  define FUNCTION__ ("")
 #  define SAFE_FUNCTION__ ("UNKNOWN")
 #else

--- a/handy.h
+++ b/handy.h
@@ -1831,13 +1831,6 @@ END_EXTERN_C
      * don't think it's necessary to be so for the purposes where this gets
      * compiled */
 #   define isQUOTEMETA_(c)      (FITS_IN_8_BITS(c) && ! isWORDCHAR_L1(c))
-#   define _IS_IN_SOME_FOLD_ONLY_FOR_USE_BY_REGCOMP_DOT_C(c) isALPHA_L1(c)
-
-    /*  And these aren't accurate at all.  They are useful only for above
-     *  Latin1, which utilities and bootstrapping don't deal with */
-#   define _IS_NON_FINAL_FOLD_ONLY_FOR_USE_BY_REGCOMP_DOT_C(c) 0
-#   define _HAS_NONLATIN1_SIMPLE_FOLD_CLOSURE_ONLY_FOR_USE_BY_REGCOMP_DOT_C_AND_REGEXEC_DOT_C(c) 0
-#   define _HAS_NONLATIN1_FOLD_CLOSURE_ONLY_FOR_USE_BY_REGCOMP_DOT_C_AND_REGEXEC_DOT_C(c) 0
 
     /* Many of the macros later in this file are defined in terms of these.  By
      * implementing them with a function, which converts the class number into

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -1004,9 +1004,8 @@ PERLVARA(I, sv_consts, SV_CONSTS_COUNT, SV*)	/* constant SVs with precomputed ha
 PERLVARA(I, op_exec_cnt, OP_max+2, UV)  /* Counts of executed OPs of the given type.
                                            If PERL_TRACE_OPS is enabled, we'll dump
                                            a summary count of all ops executed in the
-                                           program at perl_destruct time. For
-                                           profiling/debugging only. Works only if
-                                           DEBUGGING is enabled, too. */
+                                           program at perl_destruct time. Used only
+                                           for profiling in DEBUGGING mode. */
 #endif
 
 PERLVAR(I, random_state, PL_RANDOM_STATE_TYPE)

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -58,7 +58,10 @@ PERLVARI(I, sub_generation, U32, 1)	/* incr to invalidate method cache */
 
 #ifdef PERL_HASH_RANDOMIZE_KEYS
 #ifdef USE_PERL_PERTURB_KEYS
-PERLVARI(I, hash_rand_bits_enabled, U8, 1) /* used to randomize hash stuff 0 == no-random, 1 == random, 2 == deterministic */
+PERLVARI(I, hash_rand_bits_enabled, U8, 1) /* used to randomize hash stuff
+                                              0. no-random
+                                              1. random
+                                              2. determinsitic */
 #endif
 PERLVARI(I, hash_rand_bits, UV, 0)      /* used to randomize hash stuff */
 #endif
@@ -998,7 +1001,7 @@ PERLVARI(I, sv_serial,	U32,	0)	/* SV serial number, used in sv.c */
 PERLVARA(I, sv_consts, SV_CONSTS_COUNT, SV*)	/* constant SVs with precomputed hash value */
 
 #ifdef PERL_TRACE_OPS
-PERLVARA(I, op_exec_cnt, OP_max+2, UV)	/* Counts of executed OPs of the given type.
+PERLVARA(I, op_exec_cnt, OP_max+2, UV)  /* Counts of executed OPs of the given type.
                                            If PERL_TRACE_OPS is enabled, we'll dump
                                            a summary count of all ops executed in the
                                            program at perl_destruct time. For

--- a/op_reg_common.h
+++ b/op_reg_common.h
@@ -101,8 +101,20 @@ get_regex_charset(const U32 flags)
 
 /* Mask of the above bits.  These need to be transferred from op_pmflags to
  * re->extflags during compilation */
-#define RXf_PMf_COMPILETIME    (RXf_PMf_MULTILINE|RXf_PMf_SINGLELINE|RXf_PMf_FOLD|RXf_PMf_EXTENDED|RXf_PMf_EXTENDED_MORE|RXf_PMf_KEEPCOPY|RXf_PMf_NOCAPTURE|RXf_PMf_CHARSET|RXf_PMf_STRICT)
-#define RXf_PMf_FLAGCOPYMASK   (RXf_PMf_COMPILETIME|RXf_PMf_SPLIT)
+#define RXf_PMf_COMPILETIME \
+    ( RXf_PMf_MULTILINE     \
+    | RXf_PMf_SINGLELINE    \
+    | RXf_PMf_FOLD          \
+    | RXf_PMf_EXTENDED      \
+    | RXf_PMf_EXTENDED_MORE \
+    | RXf_PMf_KEEPCOPY      \
+    | RXf_PMf_NOCAPTURE     \
+    | RXf_PMf_CHARSET       \
+    | RXf_PMf_STRICT )
+
+#define RXf_PMf_FLAGCOPYMASK    \
+    ( RXf_PMf_COMPILETIME       \
+    | RXf_PMf_SPLIT )
 
 /* Temporary to get Jenkins happy again
  * See thread starting at http://nntp.perl.org/group/perl.perl5.porters/220710

--- a/pad.h
+++ b/pad.h
@@ -23,8 +23,9 @@ typedef SSize_t PADOFFSET; /* signed so that -1 is a valid value */
 struct padlist {
     SSize_t	xpadl_max;	/* max index for which array has space */
     union {
-        PAD **	xpadlarr_alloc; /* Pointer to beginning of array of AVs.
-                                   index 0 is a padnamelist *          */
+        PAD **  xpadlarr_alloc; /* Pointer to beginning of array of AVs.
+                                   Note that a 'padnamelist *' is stored
+                                   in the 0 index of the AV. */
         struct {
             PADNAMELIST * padnl;
             PAD * pad_1;        /* this slice of PAD * array always alloced */

--- a/perlio.h
+++ b/perlio.h
@@ -32,7 +32,7 @@
 #  error "stdio is no longer supported as the default base layer -- use perlio."
 #endif
 
-/* --------------------  End of Configure controls ---------------------------- */
+/*--------------------  End of Configure controls ---------------------------*/
 
 /*
  * Although we may not want stdio to be used including <stdio.h> here

--- a/utfebcdic.h
+++ b/utfebcdic.h
@@ -73,7 +73,7 @@
  * macro NATIVE_TO_I8().  However, one "shadow", or parallel table,
  * PL_utf8skip, has been constructed that doesn't require undoing things.  It
  * is such that for each byte, it says how long the sequence is if that
-* (UTF-EBCDIC) byte were to begin it
+ * (UTF-EBCDIC) byte were to begin it.
  *
  * There are actually 3 slightly different UTF-EBCDIC encodings in
  * ebcdic_tables.h, one for each of the code pages recognized by Perl.  That

--- a/util.h
+++ b/util.h
@@ -184,7 +184,7 @@ typedef struct {
 /* uses var file to set default filename for newXS_deffile to use for CvFILE */
 #define HSf_SETXSUBFN 0x00000020
 #define HSf_POPMARK 0x00000040 /* popmark mode or you must supply ax and items */
-#define HSf_IMP_CXT 0x00000080 /* ABI, threaded/MULTIPLICITY, pTHX_ present */
+#define HSf_IMP_CXT 0x00000080 /* ABI, threaded, MULTIPLICITY, pTHX_ present */
 #define HSm_INTRPSIZE 0xFFFF0000 /* ABI, interp struct size */
 /* A mask of bits in the key which must always match between a XS mod and interp.
    Also if all ABI bits in a key are true, skip all ABI checks, it is very

--- a/zaphod32_hash.h
+++ b/zaphod32_hash.h
@@ -133,12 +133,17 @@ void zaphod32_seed_state (
     const U32 *seed= (const U32 *)seed_ch;
     U32 *state= (U32 *)state_ch;
   
-    /* hex expansion of pi, skipping first two digits. pi= 3.2[43f6...]*/
-    /* pi value in hex from here:
-     * http://turner.faculty.swau.edu/mathematics/materialslibrary/pi/pibases.html*/
-    /* Ensure that the three state vectors are nonzero regardless of the seed. */
-    /* The idea of these two steps is to ensure that the 0 state comes from a seed
-     * utterly unlike that of the value we replace it with.*/
+    /* hex expansion of PI, skipping first two digits. PI= 3.2[43f6...]
+     *
+     * PI value in hex from here:
+     *
+     * http://turner.faculty.swau.edu/mathematics/materialslibrary/pi/pibases.html
+     *
+     * Ensure that the three state vectors are nonzero regardless of
+     * the seed. The idea of these two steps is to ensure that the 0
+     * state comes from a seed utterly unlike that of the value we
+     * replace it with.
+     */
     state[0]= seed[0] ^ 0x43f6a888;
     state[1]= seed[1] ^ 0x5a308d31;
     state[2]= seed[2] ^ 0x3198a2e0;


### PR DESCRIPTION
This is a set of manual adjustments to WS in our headers and in a few cases to our code which parses headers to harden them against whitespace change.  It consists primarily of WS changes to the headers, or minor adjustments to how we handle certain cases in our headers.