### PR TITLE
Add `xV_FROM_REF` macros

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -804,8 +804,7 @@ Perl_dump_sub_perl(pTHX_ const GV *gv, bool justperl)
 
     PERL_ARGS_ASSERT_DUMP_SUB_PERL;
 
-    cv = isGV_with_GP(gv) ? GvCV(gv) :
-            (assert(SvROK((SV*)gv)), (CV*)SvRV((SV*)gv));
+    cv = isGV_with_GP(gv) ? GvCV(gv) : CV_FROM_REF((SV*)gv);
     if (justperl && (CvISXSUB(cv) || !CvROOT(cv)))
         return;
 
@@ -877,10 +876,8 @@ S_gv_display(pTHX_ GV *gv)
         if (isGV_with_GP(gv))
             gv_fullname3(raw, gv, NULL);
         else {
-            assert(SvROK(gv));
-            assert(SvTYPE(SvRV(gv)) == SVt_PVCV);
             Perl_sv_catpvf(aTHX_ raw, "cv ref: %s",
-                    SvPV_nolen_const(cv_name((CV *)SvRV(gv), name, 0)));
+                    SvPV_nolen_const(cv_name(CV_FROM_REF(gv), name, 0)));
         }
         rawpv = SvPV_const(raw, len);
         generic_pv_escape(name, rawpv, len, SvUTF8(raw));

--- a/handy.h
+++ b/handy.h
@@ -108,6 +108,34 @@ blindly casts away const.
 #define MUTABLE_IO(p)	((IO *)MUTABLE_PTR(p))
 #define MUTABLE_SV(p)	((SV *)MUTABLE_PTR(p))
 
+/*
+=for apidoc_section $SV
+=for apidoc   Am |AV *|AV_FROM_REF|SV * ref
+=for apidoc_item |CV *|CV_FROM_REF|SV * ref
+=for apidoc_item |HV *|HV_FROM_REF|SV * ref
+
+The C<I<*>V_FROM_REF> macros extract the C<SvRV()> from a given reference SV
+and return a suitably-cast to pointer to the referenced SV. When running
+under C<-DDEBUGGING>, assertions are also applied that check that I<ref> is
+definitely a reference SV that refers to an SV of the right type.
+
+=cut
+*/
+
+#if defined(DEBUGGING) && defined(PERL_USE_GCC_BRACE_GROUPS)
+#  define xV_FROM_REF(XV, ref)  \
+    ({ SV *_ref = ref; \
+       assert(SvROK(_ref)); \
+       assert(SvTYPE(SvRV(_ref)) == SVt_PV ## XV); \
+       (XV *)(SvRV(_ref)); })
+#else
+#  define xV_FROM_REF(XV, ref)  ((XV *)(SvRV(ref)))
+#endif
+
+#define AV_FROM_REF(ref)  xV_FROM_REF(AV, ref)
+#define CV_FROM_REF(ref)  xV_FROM_REF(CV, ref)
+#define HV_FROM_REF(ref)  xV_FROM_REF(HV, ref)
+
 #ifndef __cplusplus
 #  include <stdbool.h>
 #endif


### PR DESCRIPTION
These macros do the moral equivalent of `(AV *)SvRV(ref)` or similar for other types, while also `assert()`ing that it's correct to do so. Not much used in core but very handy in lots of XS modules and similar.