### PR TITLE
re/fold_grind.pl - rework so we don't double compile patterns

### DIFF
--- a/t/re/pat_advanced.t
+++ b/t/re/pat_advanced.t
@@ -2138,8 +2138,8 @@ EOP
 
     {   # This was failing unless an explicit /d was added
         my $E0 = uni_to_native("\xE0");
+        utf8::upgrade($E0);
         my $p = qr/[_$E0]/i;
-        utf8::upgrade($p);
         like(uni_to_native("\xC0"), qr/$p/, "Verify \"\\xC0\" =~ /[\\xE0_]/i; pattern in utf8");
     }
 


### PR DESCRIPTION
We were calling utf8::upgrade() on qr// objects, which works, in that it stringifies the pattern, and then upgrades the string, and the string can be used to match against. But it double compiles the pattern, which is a bit unnecessary. For example

```
    $pat= qr/\x{DF}/;
    utf8::upgrade($pat); # $pat is now a string!
    "ss"=~/$pat/;        # and now $pat gets compiled again
```

works, but it does twice the work needed.

This was found by making utf8::upgrade() ignore refs.