### PR TITLE
dump.c - add missing cast

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -877,7 +877,7 @@ S_gv_display(pTHX_ GV *gv)
             gv_fullname3(raw, gv, NULL);
         else {
             Perl_sv_catpvf(aTHX_ raw, "cv ref: %s",
-                    SvPV_nolen_const(cv_name(CV_FROM_REF(gv), name, 0)));
+                    SvPV_nolen_const(cv_name(CV_FROM_REF((SV*)gv), name, 0)));
         }
         rawpv = SvPV_const(raw, len);
         generic_pv_escape(name, rawpv, len, SvUTF8(raw));


### PR DESCRIPTION
In 06d92f00e810ad2f12b8fb9c1adf0d22765d6ccc we added the CV_FROM_REF() macros, these macros assume the argument is an SV, so the gv prequires a cast. The argument was cast to SV* in another case, so I am adding the same fix here.

Silences the following warning:

    dump.c: In function ‘S_gv_display’:
    dump.c:880:58: warning: initialization of ‘SV *’ {aka ‘struct sv *’} from
    incompatible pointer type ‘GV *’ {aka ‘struct gv *’} [-Wincompatible-pointer-types]
      880 |                     SvPV_nolen_const(cv_name(CV_FROM_REF(gv), name, 0)));
          |                                                          ^~
    sv.h:1912:42: note: in definition of macro ‘SvPV_flags_const_nolen’
     1912 |    ((const char*) Perl_SvPV_helper(aTHX_ sv, NULL, flags, SvPVnormal_type_, \
          |                                          ^~
    dump.c:880:21: note: in expansion of macro ‘SvPV_nolen_const’
      880 |                     SvPV_nolen_const(cv_name(CV_FROM_REF(gv), name, 0)));
          |                     ^~~~~~~~~~~~~~~~
    dump.c:880:38: note: in expansion of macro ‘cv_name’
      880 |                     SvPV_nolen_const(cv_name(CV_FROM_REF(gv), name, 0)));
          |                                      ^~~~~~~
    handy.h:136:27: note: in expansion of macro ‘xV_FROM_REF’
      136 | #define CV_FROM_REF(ref)  xV_FROM_REF(CV, ref)
          |                           ^~~~~~~~~~~
    dump.c:880:46: note: in expansion of macro ‘CV_FROM_REF’
      880 |                     SvPV_nolen_const(cv_name(CV_FROM_REF(gv), name, 0)));