### PR TITLE
gv.c - add ${^FORCE_UPGRADE} for triggering upgrade by concatenation

### DIFF
--- a/gv.c
+++ b/gv.c
@@ -2211,6 +2211,16 @@ S_gv_magicalize(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len,
                 if (memEQs(name, len, "\005NCODING"))
                     goto magicalize;
                 break;
+            case '\006':
+                if (memEQs(name, len, "\006ORCE_UPGRADE")) { /* ${^FORCE_UPGRADE} */
+                    /* empty string which is marked as UTF8 on */
+                    SV *sv= GvSVn(gv);
+                    sv_setpvs(sv,"");
+                    SvUTF8_on(sv);
+                    SvREADONLY_on(sv);
+                }
+                break;
+
             case '\007':	/* $^GLOBAL_PHASE */
                 if (memEQs(name, len, "\007LOBAL_PHASE"))
                     goto ro_magicalize;

--- a/lib/utf8.pm
+++ b/lib/utf8.pm
@@ -5,7 +5,7 @@ use warnings;
 
 our $hint_bits = 0x00800000;
 
-our $VERSION = '1.24';
+our $VERSION = '1.25';
 our $AUTOLOAD;
 
 sub import {
@@ -132,6 +132,13 @@ For example:
   utf8::upgrade($x);
   $x =~ /ss/i;       # matches
   my $z = uc($x);    # converts to "SS"
+
+As of 5.37.6 there is also the global variable C<${^FORCE_UPGRADE}>
+which contains an empty string which when concatenated with any other
+string causes the result to be an upgraded string. This can be helpful
+in some contexts where explicitly calling this function might be
+awkward. A similar effect can also be produced by using a C<\N{U+...}>
+style escape for one of the characters in the string.
 
 B<Note that this function does not handle arbitrary encodings>;
 use L<Encode> instead.

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -27,6 +27,11 @@ here, but most should go in the L</Performance Enhancements> section.
 
 [ List each enhancement as a =head2 entry ]
 
+=head2 New global variable C<${^FORCE_UPGRADE}>
+
+This variable contains the empty string, and can be used to force a string
+or pattern to be upgraded via concatenation.
+
 =head1 Security
 
 XXX Any security-related notices go here.  In particular, any security

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -504,6 +504,19 @@ mode is turned on.  See L<perlrun|perlrun/-a> for the B<-a> switch.  This
 array is package-specific, and must be declared or given a full package
 name if not in package main when running under C<strict 'vars'>.
 
+=item ${^FORCE_UPGRADE}
+
+This contains an empty string which when concatenated with any other
+string will cause the result to be an upgraded string. Eg:
+
+    print "ss"=~/\xDF/i ? "yes" : "no";
+    no
+
+but
+
+    print "ss"=~/\xDF${^FORCE_UPGRADE}/i ? "yes" : "no";
+    yes
+
 =item @INC
 X<@INC>
 


### PR DESCRIPTION
This is a readonly global variable which contains an upgraded empty string (eg UTF8-on). When concatenated into a string it (like any other upgraded string) causes the resulting string to also be upgraded. Similar to calling utf8::upgrade() on the string, but suitable for use in double quoted strings or regex patterns or other places where adding a utf8::upgrade() call might be awkward.

Assuming this gets merged I can think of some test code that could be cleaned up by using this, and I definitely would use it in one-liners and what not as well.