### PR TITLE
Add `Size_t` and `SSize_t` fields to `ANY` union

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -4356,7 +4356,7 @@ void init_os_extras(void);
 UNION_ANY_DEFINITION;
 #else
 union any {
-    void*	any_ptr;
+    void*       any_ptr;
     SV*         any_sv;
     SV**        any_svp;
     GV*         any_gv;
@@ -4365,14 +4365,14 @@ union any {
     OP*         any_op;
     char*       any_pv;
     char**      any_pvp;
-    I32		any_i32;
-    U32		any_u32;
-    IV		any_iv;
-    UV		any_uv;
-    long	any_long;
-    bool	any_bool;
-    void	(*any_dptr) (void*);
-    void	(*any_dxptr) (pTHX_ void*);
+    I32         any_i32;
+    U32         any_u32;
+    IV          any_iv;
+    UV          any_uv;
+    long        any_long;
+    bool        any_bool;
+    void        (*any_dptr) (void*);
+    void        (*any_dxptr) (pTHX_ void*);
 };
 #endif
 

--- a/perl.h
+++ b/perl.h
@@ -4373,6 +4373,7 @@ union any {
     bool        any_bool;
     Size_t      any_size;
     SSize_t     any_ssize;
+    STRLEN      any_strlen;
     void        (*any_dptr) (void*);
     void        (*any_dxptr) (pTHX_ void*);
 };

--- a/perl.h
+++ b/perl.h
@@ -4371,6 +4371,8 @@ union any {
     UV          any_uv;
     long        any_long;
     bool        any_bool;
+    Size_t      any_size;
+    SSize_t     any_ssize;
     void        (*any_dptr) (void*);
     void        (*any_dxptr) (pTHX_ void*);
 };


### PR DESCRIPTION
Size_t might be U32 or UV, depending on size configurations. This makes it uniformly handled nicely. Ditto for SSize_t.

STRLEN is just a fancy name for Size_t but it's used distinctly enough in our code anyway we might as well keep it distinct here too.

I would add a `PADOFFSET any_padix` member, but I can't because PADOFFSET is a macro(!) defined in pad.h which isn't visible here. But it's typedef'ed to be SSize_t anyway so probably folk can use that.

I could maybe make it `SSize_t any_ssize, any_padix;` to make that, and have it visible to all, if that might help.

(also includes some whitespace changes to turn tabs into spaces)