### PR TITLE
Devel-PPPort: fix STMT_START and STMT_END to not warn on clang

### DIFF
--- a/dist/Devel-PPPort/PPPort_pm.PL
+++ b/dist/Devel-PPPort/PPPort_pm.PL
@@ -756,7 +756,7 @@ package Devel::PPPort;
 use strict;
 use vars qw($VERSION $data);
 
-$VERSION = '3.68';
+$VERSION = '3.69';
 
 sub _init_data
 {

--- a/dist/Devel-PPPort/parts/inc/mess
+++ b/dist/Devel-PPPort/parts/inc/mess
@@ -58,17 +58,18 @@ NEED_vmess
 #  else
 #    define D_PPP_FIX_UTF8_ERRSV_FOR_SV(sv) STMT_START {} STMT_END
 #  endif
-#  define croak_sv(sv)                         \
-    STMT_START {                               \
-        SV *_sv = (sv);                        \
-        if (SvROK(_sv)) {                      \
-            sv_setsv(ERRSV, _sv);              \
-            croak(NULL);                       \
-        } else {                               \
-            D_PPP_FIX_UTF8_ERRSV_FOR_SV(_sv);  \
-            croak("%" SVf, SVfARG(_sv));       \
-        }                                      \
-    } STMT_END
+PERL_STATIC_INLINE void D_PPP_croak_sv(SV *sv) {
+    dTHX;
+    SV *_sv = (sv);
+    if (SvROK(_sv)) {
+        sv_setsv(ERRSV, _sv);
+        croak(NULL);
+    } else {
+        D_PPP_FIX_UTF8_ERRSV_FOR_SV(_sv);
+        croak("%" SVf, SVfARG(_sv));
+    }
+}
+#  define croak_sv(sv) D_PPP_croak_sv(sv)
 #elif { VERSION >= 5.4.0 }
 #  define croak_sv(sv) croak("%" SVf, SVfARG(sv))
 #else

--- a/dist/Devel-PPPort/parts/inc/misc
+++ b/dist/Devel-PPPort/parts/inc/misc
@@ -299,17 +299,12 @@ __UNDEF_NOT_PROVIDED__  PERL_GCC_BRACE_GROUPS_FORBIDDEN
 
 #undef STMT_START
 #undef STMT_END
-#if defined(VOIDFLAGS) && defined(PERL_USE_GCC_BRACE_GROUPS)
-#  define STMT_START    (void)( /* gcc supports ``({ STATEMENTS; })'' */
-#  define STMT_END      )
-#else
-#  if defined(VOIDFLAGS) && (VOIDFLAGS) && (defined(sun) || defined(__sun__)) && !defined(__GNUC__)
+#if defined(VOIDFLAGS) && (VOIDFLAGS) && (defined(sun) || defined(__sun__)) && !defined(__GNUC__)
 #    define STMT_START  if (1)
 #    define STMT_END    else (void)0
-#  else
+#else
 #    define STMT_START  do
 #    define STMT_END    while (0)
-#  endif
 #endif
 
 __UNDEFINED__  boolSV(b)    ((b) ? &PL_sv_yes : &PL_sv_no)


### PR DESCRIPTION
Since 7169efc77525df70484a824bff4ceebd1fafc760, perl's core STMT_START and STMT_END macros no longer try to use brace groups, due to the warnings they can generate and their very limited usefulness.

That commit also changed Devel::PPPort to remove the use of brace groups in STMT_START/STMT_END. That led to errors in older perls, so it was partly reverted in e08ee3cb66f362c4901846a46014cfdfcd60326c. Since then, various other macros have been improved to properly work with brace groups enabled or disabled.

We can now remove the brace group using variant of STMT_START/STMT_END, which will silence the warnings from clang.