### PR TITLE
Add a `any_padix` member to the ANY union

### DIFF
--- a/pad.h
+++ b/pad.h
@@ -13,9 +13,6 @@
 
 /* offsets within a pad */
 
-typedef SSize_t PADOFFSET; /* signed so that -1 is a valid value */
-#define NOT_IN_PAD ((PADOFFSET) -1)
-
 /* B.xs expects the first members of these two structs to line up
    (xpadl_max with xpadnl_fill).
  */

--- a/perl.h
+++ b/perl.h
@@ -4377,6 +4377,7 @@ union any {
     Size_t      any_size;
     SSize_t     any_ssize;
     STRLEN      any_strlen;
+    PADOFFSET   any_padix;
     void        (*any_dptr) (void*);
     void        (*any_dxptr) (pTHX_ void*);
 };

--- a/perl.h
+++ b/perl.h
@@ -3267,6 +3267,9 @@ typedef AV PAD;
 typedef struct padnamelist PADNAMELIST;
 typedef struct padname PADNAME;
 
+typedef SSize_t PADOFFSET; /* signed so that -1 is a valid value */
+#define NOT_IN_PAD ((PADOFFSET) -1)
+
 /* always enable PERL_OP_PARENT  */
 #if !defined(PERL_OP_PARENT)
 #  define PERL_OP_PARENT


### PR DESCRIPTION
Needed the `PADOFFSET` typedef to be moved first.