### PR TITLE
pp_ctl.c - teach module_true how to deal with blocked requires

### DIFF
--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4867,24 +4867,26 @@ PP(pp_leaveeval)
              * feature state out of the COP data it contains.
              */
             if (check) {
-                const OP *kid = cLISTOPx(check)->op_first;
-                const OP *last_state = NULL;
+                if (!OP_TYPE_IS(check,OP_STUB)) {
+                    const OP *kid = cLISTOPx(check)->op_first;
+                    const OP *last_state = NULL;
 
-                for (; kid; kid = OpSIBLING(kid)) {
-                    if (
-                           OP_TYPE_IS_OR_WAS(kid, OP_NEXTSTATE)
-                        || OP_TYPE_IS_OR_WAS(kid, OP_DBSTATE)
-                    ){
-                        last_state = kid;
+                    for (; kid; kid = OpSIBLING(kid)) {
+                        if (
+                               OP_TYPE_IS_OR_WAS(kid, OP_NEXTSTATE)
+                            || OP_TYPE_IS_OR_WAS(kid, OP_DBSTATE)
+                        ){
+                            last_state = kid;
+                        }
                     }
-                }
-                if (last_state) {
-                    PL_curcop = cCOPx(last_state);
-                    if (FEATURE_MODULE_TRUE_IS_ENABLED) {
-                        override_return = TRUE;
+                    if (last_state) {
+                        PL_curcop = cCOPx(last_state);
+                        if (FEATURE_MODULE_TRUE_IS_ENABLED) {
+                            override_return = TRUE;
+                        }
+                    } else {
+                        NOT_REACHED; /* NOTREACHED */
                     }
-                } else {
-                    NOT_REACHED; /* NOTREACHED */
                 }
             } else {
                 NOT_REACHED; /* NOTREACHED */

--- a/t/comp/require.t
+++ b/t/comp/require.t
@@ -34,7 +34,7 @@ push @files_to_delete, "$_->[0].pm" for @module_true_tests;
 # to why there might be multiple execution of this test file, I don't
 # know; but this is an experiment to see if random smoke failures go away.
 
-if (grep -e, @files_to_delete) {
+if (!$ENV{NO_SLEEP} and grep -e, @files_to_delete) {
     print "# Sleeping for 20 secs waiting for other process to finish\n";
     sleep 20;
 }

--- a/t/comp/require.t
+++ b/t/comp/require.t
@@ -371,6 +371,7 @@ BEGIN {
             'feature "module_true"',
         );
     my @module_code = (
+            undef,
             '',
             'sub foo {};',
             'sub foo {}; 0;',
@@ -425,7 +426,10 @@ BEGIN {
     foreach my $tuple (@module_true_tests) {
         my ($pack_name, $param_str, $mod_code, $eval_code)= @$tuple;
 
-        write_file("$pack_name.pm","package $pack_name;\nuse $param_str;\n$mod_code\n");
+        write_file("$pack_name.pm",
+            defined($mod_code)
+            ? "package $pack_name;\nuse $param_str;\n$mod_code\n"
+            : "");
         %INC = ();
         # these might be assigned to in the $eval_code
         my $return_val;
@@ -434,7 +438,7 @@ BEGIN {
         $^P = 0; # turn the debugger off after the eval.
         $i++;
         print "${not}ok $i - use $param_str did not blow up for `",
-            $mod_code || "#no body", "` via `$eval_code`\n";
+            ($mod_code // "# empty file") || "#no body", "` via `$eval_code`\n";
         if ($not) {
             # we died, show the error:
             print "# $_\n" for split /\n/, $@;

--- a/t/op/require_errors.t
+++ b/t/op/require_errors.t
@@ -9,7 +9,7 @@ BEGIN {
 use strict;
 use warnings;
 
-plan(tests => 57);
+plan(tests => 58);
 
 my $nonfile = tempfile();
 
@@ -282,4 +282,11 @@ like $@, qr/^Can't locate \Q$nonsearch\E at/,
     ok(!eval { require CannotParse; },
        "check the second attempt also fails");
     like $@, qr/Attempt to reload/, "check we failed for the right reason";
+}
+
+{
+    fresh_perl_like(
+        'unshift @INC, sub { sub { 0 } }; require "asdasd";',
+        qr/asdasd did not return a true value/,
+        { }, '@INC hook blocks do not cause segfault');
 }


### PR DESCRIPTION
If require encounters an @INC hook that blocks the require it ends up with a STUB node as the optree for the LEAVEEVAL. This was causing the module_true logic to segfault. Guarding against the OP_STUB node fixes the problem.

This affected the tests for IO::Socket::SSL. Thanks to Graham Knopp for the reduced case, and James Keenan for reporting it in https://github.com/Perl/perl5/issues/20468.

This should fix the problem.