### PR TITLE
See if we can reduce our CI jobs in half by not running on push and pull_request

### DIFF
--- a/.github/workflows/irc-notifications.yaml
+++ b/.github/workflows/irc-notifications.yaml
@@ -1,5 +1,5 @@
 name: "Push Notification"
-on: [push, pull_request]
+on: [pull_request]
 # add create for tracking tags
 
 # IRC colors: https://modern.ircdocs.horse/formatting.html

--- a/.github/workflows/irc-notifications.yaml
+++ b/.github/workflows/irc-notifications.yaml
@@ -1,5 +1,5 @@
 name: "Push Notification"
-on: [pull_request]
+on: [push, pull_request]
 # add create for tracking tags
 
 # IRC colors: https://modern.ircdocs.horse/formatting.html

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -52,11 +52,11 @@ name: testsuite
 on:
   push:
     branches:
-      - "blead"
-      - "maint-*"
+      - "**"
     tags-ignore:
       - "*"
   pull_request:
+      - "*:*"
 
 # I don't think that we can (safely) set TEST_JOBS=2 in the global environment,
 # because on Win32 the various Makefile's `test` target is actually ./harness,

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -52,7 +52,8 @@ name: testsuite
 on:
   push:
     branches:
-      - "**"
+      - "blead"
+      - "maint-*"
     tags-ignore:
       - "*"
   pull_request:


### PR DESCRIPTION
This is a test, trying to stop the tests running twice for PR's against branches hosted in the repo.  The patch makes it so we only run CI on pull_request, or on pushes to blead or maint. 