### PR TITLE
FindBin.pm - Handle FIFOs / Named Pipes

### DIFF
--- a/dist/FindBin/lib/FindBin.pm
+++ b/dist/FindBin/lib/FindBin.pm
@@ -90,7 +90,7 @@ our @EXPORT_OK = qw($Bin $Script $RealBin $RealScript $Dir $RealDir);
 our %EXPORT_TAGS = (ALL => [qw($Bin $Script $RealBin $RealScript $Dir $RealDir)]);
 our @ISA = qw(Exporter);
 
-our $VERSION = "1.53";
+our $VERSION = "1.54";
 
 # needed for VMS-specific filename translation
 if( $^O eq 'VMS' ) {

--- a/dist/FindBin/lib/FindBin.pm
+++ b/dist/FindBin/lib/FindBin.pm
@@ -111,9 +111,9 @@ sub init
  *Dir = \$Bin;
  *RealDir = \$RealBin;
 
- if($0 eq '-e' || $0 eq '-')
+ if($0 eq '-e' || $0 eq '-' || -p $0)
   {
-   # perl invoked with -e or script is on C<STDIN>
+   # perl invoked with -e or script is on C<STDIN> or a fifo (named pipe)
    $Script = $RealScript = $0;
    $Bin    = $RealBin    = cwd2();
    $Bin = VMS::Filespec::unixify($Bin) if $^O eq 'VMS';


### PR DESCRIPTION
Before:  (Dies)

     bash% perl -MFindBin <( echo 'print "$FindBin::Bin\n"' )
     Cannot find current script '/dev/fd/63' at FindBin.pm line 167.
     BEGIN failed--compilation aborted at FindBin.pm line 167.

After:   (Behaves like '-e' and '-')

     bash% perl -MFindBin <( echo 'print "$FindBin::Bin\n"' )
     /path/to/current/directory