### PR TITLE
improve storable hook error reporting and allow hooks to work with blessed regexps

### DIFF
--- a/dist/Storable/Storable.pm
+++ b/dist/Storable/Storable.pm
@@ -28,7 +28,7 @@ our @EXPORT_OK = qw(
 our ($canonical, $forgive_me);
 
 BEGIN {
-  our $VERSION = '3.27';
+  our $VERSION = '3.28';
 }
 
 our $recursion_limit;

--- a/dist/Storable/Storable.xs
+++ b/dist/Storable/Storable.xs
@@ -3595,6 +3595,7 @@ static int store_hook(
     switch (type) {
     case svis_REF:
     case svis_SCALAR:
+    case svis_REGEXP:
         obj_type = SHT_SCALAR;
         break;
     case svis_ARRAY:

--- a/dist/Storable/t/blessed.t
+++ b/dist/Storable/t/blessed.t
@@ -44,7 +44,7 @@ use Storable qw(freeze thaw store retrieve fd_retrieve);
    'long VSTRING' => \(my $lvstring = eval "v" . 0 x 300),
    LVALUE         => \(my $substr  = substr((my $str = "foo"), 0, 3)));
 
-my $test = 14;
+my $test = 18;
 my $tests = $test + 41 + (2 * 6 * keys %::immortals) + (3 * keys %::weird_refs);
 plan(tests => $tests);
 
@@ -435,4 +435,33 @@ is(ref $t, 'STRESS_THE_STACK');
     my $msg = $@;
     like($msg, qr/Unexpected object type \(GLOB\) of class 'GlobHooked' in store_hook\(\) calling GlobHookedBase::STORABLE_freeze/,
          "check we get the verbose message");
+}
+
+SKIP:
+{
+    $] < 5.012
+      and skip "Can't assign regexps directly before 5.12", 4;
+    my $hook_called;
+    # store regexp via hook
+    {
+        package RegexpHooked;
+        sub STORABLE_freeze {
+            ++$hook_called;
+            "$_[0]";
+        }
+        sub STORABLE_thaw {
+            my ($obj, $cloning, $serialized) = @_;
+            ++$hook_called;
+            $$obj = ${ qr/$serialized/ };
+        }
+    }
+
+    my $obj = bless qr/abc/, "RegexpHooked";
+    my $data = freeze($obj);
+    ok($data, "froze regexp blessed into hooked class");
+    ok($hook_called, "and the hook was actually called");
+    $hook_called = 0;
+    my $obj_thawed = thaw($data);
+    ok($hook_called, "hook called for thaw");
+    like("abc", $obj_thawed, "check the regexp");
 }


### PR DESCRIPTION
Fixes #19964 

This does not attempt to fix the feature request to add support for globs in hooks as suggested in #19964.