### PR TITLE
<> to readline documentation updates

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4584,7 +4584,7 @@ Reading from a file:
         or die "Can't open < input.txt: $!";
 
     # Process every line in input.txt
-    while (my $line = <$fh>) {
+    while (my $line = readline($fh)) {
         #
         # ... do something interesting with $line here ...
         #


### PR DESCRIPTION
I believe using `readline()` is considered best practice now, so this is a simple doc fix to update from `<>` to `readline()`