### PR TITLE
pod/perlhacks.pod - document TEST_ARGS and make win32 perl use it too

### DIFF
--- a/pod/perlhack.pod
+++ b/pod/perlhack.pod
@@ -880,12 +880,28 @@ it doesn't redirect stderr to stdout.
 Note that under Win32 F<t/harness> is always used instead of F<t/TEST>,
 so there is no special "test_harness" target.
 
+Under the Unix build process you may use the TEST_ARGS and TEST_FILES
+parameters to pass arguments through to the underlying harness call.
+This means that for instance you could do
+
+    make test_harness TEST_ARGS="-v -re pat"
+
+which would make, and then run the test harness in verbose mode over
+files which contain "pat". Or you could do
+
+    make test_harness TEST_ARGS="-torture" TEST_FILES="op/*.t"
+
+and run torture tests on files matching the glob "op/*.t".
+
 Under Win32's "test" target you may use the TEST_SWITCHES and
 TEST_FILES environment variables to control the behaviour of
 F<t/harness>.  This means you can say
 
     nmake test TEST_FILES="op/*.t"
     nmake test TEST_SWITCHES="-torture" TEST_FILES="op/*.t"
+
+Note that for compatibility with the unix build process TEST_ARGS
+may also be used instead of the traditional TEST_SWITCHES argument.
 
 =item * test-notty test_notty
 

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1819,11 +1819,11 @@ endif
 
 test : test-prep
 	set PERL_STATIC_EXT=$(STATIC_EXT) && \
-	    cd ..\t && perl.exe harness $(TEST_SWITCHES) $(TEST_FILES)
+	    cd ..\t && perl.exe harness $(TEST_ARGS) $(TEST_SWITCHES) $(TEST_FILES)
 
 test_porting : test-prep
 	set PERL_STATIC_EXT=$(STATIC_EXT) && \
-	    cd ..\t && perl.exe harness $(TEST_SWITCHES) porting\*.t ..\lib\diagnostics.t
+	    cd ..\t && perl.exe harness $(TEST_ARGS) $(TEST_SWITCHES) porting\*.t ..\lib\diagnostics.t
 
 test-reonly : reonly utils
 	$(XCOPY) $(PERLEXE) ..\t\$(NULL)
@@ -1837,14 +1837,14 @@ regen :
 test-notty : test-prep
 	set PERL_STATIC_EXT=$(STATIC_EXT) && \
 	    set PERL_SKIP_TTY_TEST=1 && \
-	    cd ..\t && perl.exe harness $(TEST_SWITCHES) $(TEST_FILES)
+	    cd ..\t && perl.exe harness $(TEST_ARGS) $(TEST_SWITCHES) $(TEST_FILES)
 
 _test :
 	$(XCOPY) $(PERLEXE) ..\t\$(NULL)
 	$(XCOPY) $(PERLDLL) ..\t\$(NULL)
 	$(XCOPY) $(GLOBEXE) ..\t\$(NULL)
 	set PERL_STATIC_EXT=$(STATIC_EXT) && \
-	    cd ..\t && perl.exe harness $(TEST_SWITCHES) $(TEST_FILES)
+	    cd ..\t && perl.exe harness $(TEST_ARGS) $(TEST_SWITCHES) $(TEST_FILES)
 
 _clean :
 	-@erase miniperlmain$(o)

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -1325,12 +1325,12 @@ test-prep : all utils ../pod/perltoc.pod
 
 test : test-prep
 	cd ..\t
-	perl.exe harness $(TEST_SWITCHES) $(TEST_FILES)
+	perl.exe harness $(TEST_ARGS) $(TEST_SWITCHES) $(TEST_FILES)
 	cd ..\win32
 
 test_porting : test-prep
 	cd ..\t
-	perl.exe harness $(TEST_SWITCHES) porting\*.t ..\lib\diagnostics.t
+	perl.exe harness $(TEST_ARGS) $(TEST_SWITCHES) porting\*.t ..\lib\diagnostics.t
 	cd ..\win32
 
 test-reonly : reonly utils
@@ -1349,7 +1349,7 @@ regen :
 test-notty : test-prep
 	set PERL_SKIP_TTY_TEST=1
 	cd ..\t
-	perl.exe harness $(TEST_SWITCHES) $(TEST_FILES)
+	perl.exe harness $(TEST_ARGS) $(TEST_SWITCHES) $(TEST_FILES)
 	cd ..\win32
 
 _test : 
@@ -1357,7 +1357,7 @@ _test :
        $(XCOPY) $(PERLDLL) ..\t\$(NULL)
        $(XCOPY) $(GLOBEXE) ..\t\$(NULL)
        cd ..\t
-       perl.exe harness $(TEST_SWITCHES) $(TEST_FILES)
+       perl.exe harness $(TEST_ARGS) $(TEST_SWITCHES) $(TEST_FILES)
        cd ..\win32
 
 _clean :


### PR DESCRIPTION
Win32 has had TEST_SWITCHES and TEST_FILES for ages. Unix has TEST_ARGS. This extends Win32 to support TEST_ARGS as well. I havent made the contrary change to the unix code, anyone using TEST_SWITCHES is already using it on Win32.