### PR TITLE
regcomp.c - remove always true condition

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -8109,7 +8109,6 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
         && !recompile
         && cBOOL(RX_UTF8(old_re)) == cBOOL(RExC_utf8)
         && ( RX_COMPFLAGS(old_re) == ( orig_rx_flags & RXf_PMf_FLAGCOPYMASK ) )
-        && RX_PRECOMP(old_re)
         && RX_PRELEN(old_re) == plen
         && memEQ(RX_PRECOMP(old_re), exp, plen)
         && !runtime_code /* with runtime code, always recompile */ )


### PR DESCRIPTION
RX_PRECOMP() has for some time been an expression that will always be true, thus there is not need to test it.

See https://github.com/Perl/perl5/issues/20479 and more importantly https://github.com/Perl/perl5/issues/20410#issuecomment-1302836626

