### PR TITLE
DEMO: This patch demonstrates a bizarre callstack bug.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3717,6 +3717,7 @@ dist/ExtUtils-ParseXS/t/lib/TypemapTest/Foo.pm			ExtUtils::Typemaps tests
 dist/ExtUtils-ParseXS/t/pseudotypemap1				A test-typemap
 dist/ExtUtils-ParseXS/t/typemap					Standard typemap for controlled testing
 dist/ExtUtils-ParseXS/t/XSBroken.xs				Test file for ExtUtils::ParseXS tests
+dist/ExtUtils-ParseXS/t/XSFalsePositive.xs			Test file for ExtUtils::ParseXS tests
 dist/ExtUtils-ParseXS/t/XSInclude.xsh				Test file for ExtUtils::ParseXS tests
 dist/ExtUtils-ParseXS/t/XSMore.xs				Test file for ExtUtils::ParseXS tests
 dist/ExtUtils-ParseXS/t/XSTest.pm				Test file for ExtUtils::ParseXS tests

--- a/MANIFEST
+++ b/MANIFEST
@@ -3718,6 +3718,7 @@ dist/ExtUtils-ParseXS/t/pseudotypemap1				A test-typemap
 dist/ExtUtils-ParseXS/t/typemap					Standard typemap for controlled testing
 dist/ExtUtils-ParseXS/t/XSBroken.xs				Test file for ExtUtils::ParseXS tests
 dist/ExtUtils-ParseXS/t/XSFalsePositive.xs			Test file for ExtUtils::ParseXS tests
+dist/ExtUtils-ParseXS/t/XSFalsePositive2.xs			Test file for ExtUtils::ParseXS tests
 dist/ExtUtils-ParseXS/t/XSInclude.xsh				Test file for ExtUtils::ParseXS tests
 dist/ExtUtils-ParseXS/t/XSMore.xs				Test file for ExtUtils::ParseXS tests
 dist/ExtUtils-ParseXS/t/XSTest.pm				Test file for ExtUtils::ParseXS tests

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
@@ -705,6 +705,8 @@ sub blurt {
 sub death {
   my $self = shift;
   $self->Warn(@_);
+  use Carp qw(confess);
+  confess("in death do we part");
   exit 1;
 }
 

--- a/dist/ExtUtils-ParseXS/t/001-basic.t
+++ b/dist/ExtUtils-ParseXS/t/001-basic.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 18;
+use Test::More tests => 19;
 use Config;
 use DynaLoader;
 use ExtUtils::CBuilder;
@@ -188,6 +188,22 @@ my $stderr = PrimitiveCapture::capture_stderr(sub {
 });
 like $stderr, '/No INPUT definition/', "Exercise typemap error";
 }
+#####################################################################
+
+{ # fourth block: https://github.com/Perl/perl5/issues/19661
+my $pxs = ExtUtils::ParseXS->new;
+tie *FH, 'Foo';
+my $stderr = PrimitiveCapture::capture_stderr(sub {
+  $pxs->process_file(filename => 'XSFalsePositive.xs', output => \*FH, prototypes => 1);
+});
+TODO: {
+    local $TODO = 'GH 19661';
+    unlike $stderr,
+        qr/Warning: duplicate function definition 'do' detected in XSFalsePositive\.xs/,
+        "No 'duplicate function definition' warning observed";
+    }
+}
+
 #####################################################################
 
 sub Foo::TIEHANDLE { bless {}, 'Foo' }

--- a/dist/ExtUtils-ParseXS/t/001-basic.t
+++ b/dist/ExtUtils-ParseXS/t/001-basic.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 19;
+use Test::More tests => 20;
 use Config;
 use DynaLoader;
 use ExtUtils::CBuilder;
@@ -191,17 +191,33 @@ like $stderr, '/No INPUT definition/', "Exercise typemap error";
 #####################################################################
 
 { # fourth block: https://github.com/Perl/perl5/issues/19661
-my $pxs = ExtUtils::ParseXS->new;
-tie *FH, 'Foo';
-my $stderr = PrimitiveCapture::capture_stderr(sub {
-  $pxs->process_file(filename => 'XSFalsePositive.xs', output => \*FH, prototypes => 1);
-});
-TODO: {
-    local $TODO = 'GH 19661';
-    unlike $stderr,
-        qr/Warning: duplicate function definition 'do' detected in XSFalsePositive\.xs/,
-        "No 'duplicate function definition' warning observed";
-    }
+  my $pxs = ExtUtils::ParseXS->new;
+  tie *FH, 'Foo';
+  my ($stderr, $filename);
+  {
+    $filename = 'XSFalsePositive.xs';
+    $stderr = PrimitiveCapture::capture_stderr(sub {
+      $pxs->process_file(filename => $filename, output => \*FH, prototypes => 1);
+    });
+    TODO: {
+      local $TODO = 'GH 19661';
+      unlike $stderr,
+        qr/Warning: duplicate function definition 'do' detected in $filename\.xs/,
+        "No 'duplicate function definition' warning observed in $filename";
+      }
+  }
+  {
+    $filename = 'XSFalsePositive2.xs';
+    $stderr = PrimitiveCapture::capture_stderr(sub {
+      $pxs->process_file(filename => $filename, output => \*FH, prototypes => 1);
+    });
+    TODO: {
+      local $TODO = 'GH 19661';
+      unlike $stderr,
+        qr/Warning: duplicate function definition 'do' detected in $filename\.xs/,
+        "No 'duplicate function definition' warning observed in $filename";
+      }
+  }
 }
 
 #####################################################################

--- a/dist/ExtUtils-ParseXS/t/001-basic.t
+++ b/dist/ExtUtils-ParseXS/t/001-basic.t
@@ -192,24 +192,28 @@ like $stderr, '/No INPUT definition/', "Exercise typemap error";
 
 { # fourth block: https://github.com/Perl/perl5/issues/19661
   my $pxs = ExtUtils::ParseXS->new;
-  tie *FH, 'Foo';
+  my $buf = "";
+  open my $fh,">", \$buf
+    or die "Failed to open scalar buffer:$!";
   my ($stderr, $filename);
   {
     $filename = 'XSFalsePositive.xs';
-    $stderr = PrimitiveCapture::capture_stderr(sub {
-      $pxs->process_file(filename => $filename, output => \*FH, prototypes => 1);
-    });
+    #$stderr = PrimitiveCapture::capture_stderr(sub {
+      $pxs->process_file(filename => $filename, output => $fh, prototypes => 1);
+    #});
+    diag "stderr: $stderr\n";
     TODO: {
       local $TODO = 'GH 19661';
       unlike $stderr,
         qr/Warning: duplicate function definition 'do' detected in $filename\.xs/,
         "No 'duplicate function definition' warning observed in $filename";
-      }
+    }
   }
+
   {
     $filename = 'XSFalsePositive2.xs';
     $stderr = PrimitiveCapture::capture_stderr(sub {
-      $pxs->process_file(filename => $filename, output => \*FH, prototypes => 1);
+      $pxs->process_file(filename => $filename, output => $fh, prototypes => 1);
     });
     TODO: {
       local $TODO = 'GH 19661';

--- a/dist/ExtUtils-ParseXS/t/XSFalsePositive.xs
+++ b/dist/ExtUtils-ParseXS/t/XSFalsePositive.xs
@@ -1,0 +1,23 @@
+MODULE = My PACKAGE = My
+
+#ifdef MYDEF123
+
+void
+do(dbh)
+   SV *dbh
+CODE:
+{
+   int x;
+   ++x;
+}
+
+#endif
+
+void
+do(dbh)
+   SV *dbh
+CODE:
+{
+   int x;
+   ++x;
+}

--- a/dist/ExtUtils-ParseXS/t/XSFalsePositive.xs
+++ b/dist/ExtUtils-ParseXS/t/XSFalsePositive.xs
@@ -11,7 +11,7 @@ CODE:
    ++x;
 }
 
-#endif
+#else
 
 void
 do(dbh)
@@ -21,3 +21,4 @@ CODE:
    int x;
    ++x;
 }
+#endif

--- a/dist/ExtUtils-ParseXS/t/XSFalsePositive2.xs
+++ b/dist/ExtUtils-ParseXS/t/XSFalsePositive2.xs
@@ -1,0 +1,23 @@
+MODULE = My PACKAGE = My
+
+#ifdef MYDEF123
+
+void
+do(xdbh)
+   SV *xdbh
+CODE:
+{
+   int x;
+   ++x;
+}
+
+#endif
+
+void
+do(dbh)
+   SV *dbh
+CODE:
+{
+   int x;
+   ++x;
+}


### PR DESCRIPTION
This is a draft PR prepared to demonstrate a bug. See #20493. If you build this code and then run:

```
 make -j8 test_harness TEST_ARGS="-v -re ParseXS/t/001-basic"
```

you will see (paths slightly munged with "..." for the root directory of the repo)

```
ok 18 - Exercise typemap error
Error: Unterminated '#if/#ifdef/#ifndef' in XSFalsePositive.xs, line 24
in death do we part at .../dist/ExtUtils-ParseXS/../../lib/ExtUtils/ParseXS/Utilities.pm line 709, <__ANONIO__> line 24.
	ExtUtils::ParseXS::Utilities::death(ExtUtils::ParseXS=HASH(0x55b07fed9f28), "Error: Unterminated '#if/#ifdef/#ifndef'") called at .../dist/ExtUtils-ParseXS/../../lib/ExtUtils/ParseXS.pm line 1792
	ExtUtils::ParseXS::fetch_para(ExtUtils::ParseXS=HASH(0x55b07fed9f28)) called at .../dist/ExtUtils-ParseXS/../../lib/ExtUtils/ParseXS.pm line 876
	ExtUtils::ParseXS::process_file(ExtUtils::ParseXS=HASH(0x55b07fed9f28), "filename", "XSFalsePositive.xs", "output", GLOB(0x55b07fedac00), "prototypes", 1) called at t/001-basic.t line 202
# Looks like your test exited with 255 just after 18.
```

This patch deliberately breaks one of our tests so that I can debug why it breaks (if you look at the test file there is no blank line before the final `#endif`), that *isn't* the point. The point here is that the callstack above is all wrong.

If you look at the line where 'fetch_para' is called, it says it was called at line 876 of ParseXS.pm, but that line is this:

```
for my $operator (keys %{ $self->{OverloadsThisXSUB} }) {
```

and in fact the *only* place that fetch_para() is called in the entire git repo is here: 

```
~/git_tree/perl$ git grep -n fetch_para
dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm:259:  while ($self->fetch_para()) {
dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm:1787:sub fetch_para {
```

So how did the line number for the for() loop end up as the line number for the while() loop? This suggests something really off in our line number handling.
