### PR TITLE
ParseXS - fix todo tests to match the correct filename

### DIFF
--- a/dist/ExtUtils-ParseXS/t/001-basic.t
+++ b/dist/ExtUtils-ParseXS/t/001-basic.t
@@ -202,9 +202,9 @@ like $stderr, '/No INPUT definition/', "Exercise typemap error";
     TODO: {
       local $TODO = 'GH 19661';
       unlike $stderr,
-        qr/Warning: duplicate function definition 'do' detected in $filename\.xs/,
+        qr/Warning: duplicate function definition 'do' detected in \Q$filename\E/,
         "No 'duplicate function definition' warning observed in $filename";
-      }
+    }
   }
   {
     $filename = 'XSFalsePositive2.xs';
@@ -214,7 +214,7 @@ like $stderr, '/No INPUT definition/', "Exercise typemap error";
     TODO: {
       local $TODO = 'GH 19661';
       unlike $stderr,
-        qr/Warning: duplicate function definition 'do' detected in $filename\.xs/,
+        qr/Warning: duplicate function definition 'do' detected in \Q$filename\E/,
         "No 'duplicate function definition' warning observed in $filename";
       }
   }


### PR DESCRIPTION
The original regex was off and showed this test as passing when it was actually failing, which is what we expect and why the test is marked as TODO. The test accidentally doubled the extension expected in the filename, and this patch corrects that mistake.