### PR TITLE
ParseXS improvements

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3710,6 +3710,7 @@ dist/ExtUtils-ParseXS/t/XSInclude.xsh				Test file for ExtUtils::ParseXS tests
 dist/ExtUtils-ParseXS/t/XSMore.xs				Test file for ExtUtils::ParseXS tests
 dist/ExtUtils-ParseXS/t/XSTest.pm				Test file for ExtUtils::ParseXS tests
 dist/ExtUtils-ParseXS/t/XSTest.xs				Test file for ExtUtils::ParseXS tests
+dist/ExtUtils-ParseXS/t/XSTightDirectives.xs			Test file for ExtUtils::ParseXS tests
 dist/ExtUtils-ParseXS/t/XSUsage.pm				ExtUtils::ParseXS tests
 dist/ExtUtils-ParseXS/t/XSUsage.xs				ExtUtils::ParseXS tests
 dist/ExtUtils-ParseXS/t/XSWarn.xs				ExtUtils::ParseXS tests

--- a/MANIFEST
+++ b/MANIFEST
@@ -3703,6 +3703,7 @@ dist/ExtUtils-ParseXS/t/lib/PrimitiveCapture.pm			Primitive STDOUT/ERR capturing
 dist/ExtUtils-ParseXS/t/lib/TypemapTest/Foo.pm			ExtUtils::Typemaps tests
 dist/ExtUtils-ParseXS/t/pseudotypemap1				A test-typemap
 dist/ExtUtils-ParseXS/t/typemap					Standard typemap for controlled testing
+dist/ExtUtils-ParseXS/t/XSAlias.xs				Test file for ExtUtils::ParseXS ALIAS tests
 dist/ExtUtils-ParseXS/t/XSBroken.xs				Test file for ExtUtils::ParseXS tests
 dist/ExtUtils-ParseXS/t/XSFalsePositive.xs			Test file for ExtUtils::ParseXS tests
 dist/ExtUtils-ParseXS/t/XSFalsePositive2.xs			Test file for ExtUtils::ParseXS tests

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -1881,7 +1881,7 @@ sub fetch_para {
         #   others:    ident (gcc notes that some cpps have this one)
         || $self->{lastline} =~ /^\#[ \t]*
                                   (?:
-                                        (?:if|ifn?def|elif|else|endif|
+                                        (?:if|ifn?def|elif|else|endif|elifn?def|
                                            define|undef|pragma|error|
                                            warning|line\s+\d+|ident)
                                         \b
@@ -1892,7 +1892,7 @@ sub fetch_para {
     )
     {
       last if $self->{lastline} =~ /^\S/ && @{ $self->{line} } && $self->{line}->[-1] eq "";
-      if ($self->{lastline}=~/^#[ \t]*(if|ifn?def|elif|else|endif)\b/) {
+      if ($self->{lastline}=~/^#[ \t]*(if|ifn?def|elif|else|endif|elifn?def)\b/) {
         my $type = $1; # highest defined capture buffer, "if" for any if like condition
         if ($type =~ /^if/) {
           if (@{$self->{line}}) {

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -48,7 +48,7 @@ our @EXPORT_OK = qw(
 
 ##############################
 # A number of "constants"
-
+our $DIE_ON_ERROR;
 our ($C_group_rex, $C_arg);
 # Group in C (no support for comments or literals)
 $C_group_rex = qr/ [({\[]
@@ -104,6 +104,7 @@ sub process_file {
     typemap         => [],
     versioncheck    => 1,
     FH              => Symbol::gensym(),
+    die_on_error    => $DIE_ON_ERROR, # if true we die() and not exit() after errors
     %options,
   );
   $args{except} = $args{except} ? ' TRY' : '';
@@ -133,6 +134,8 @@ sub process_file {
   $self->{WantVersionChk} = $args{versioncheck};
   $self->{WantLineNumbers} = $args{linenumbers};
   $self->{IncludedFiles} = {};
+
+  $self->{die_on_error} = $args{die_on_error};
 
   die "Missing required parameter 'filename'" unless $args{filename};
   $self->{filepathname} = $args{filename};

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -11,7 +11,7 @@ use Symbol;
 
 our $VERSION;
 BEGIN {
-  $VERSION = '3.47';
+  $VERSION = '3.48';
   require ExtUtils::ParseXS::Constants; ExtUtils::ParseXS::Constants->VERSION($VERSION);
   require ExtUtils::ParseXS::CountLines; ExtUtils::ParseXS::CountLines->VERSION($VERSION);
   require ExtUtils::ParseXS::Utilities; ExtUtils::ParseXS::Utilities->VERSION($VERSION);

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -873,7 +873,7 @@ EOF
        "        (void)$self->{newXS}(\"$self->{pname}\", XS_$self->{Full_func_name}$self->{file}$self->{proto});\n");
     }
 
-    for my $operator (keys %{ $self->{OverloadsThisXSUB} }) {
+    for my $operator (sort keys %{ $self->{OverloadsThisXSUB} }) {
       $self->{Overloaded}->{$self->{Package}} = $self->{Packid};
       my $overload = "$self->{Package}\::($operator";
       push(@{ $self->{InitFileCode} },
@@ -881,7 +881,7 @@ EOF
     }
   } # END 'PARAGRAPH' 'while' loop
 
-  for my $package (keys %{ $self->{Overloaded} }) { # make them findable with fetchmethod
+  for my $package (sort keys %{ $self->{Overloaded} }) { # make them findable with fetchmethod
     my $packid = $self->{Overloaded}->{$package};
     print Q(<<"EOF");
 #XS_EUPXS(XS_${packid}_nil); /* prototype to pass -Wmissing-prototypes */
@@ -968,7 +968,7 @@ EOF
 #
 EOF
 
-  if (%{ $self->{Overloaded} }) {
+  if (keys %{ $self->{Overloaded} }) {
     # once if any overloads
     print Q(<<"EOF");
 #    /* register the overloading (type 'A') magic */
@@ -976,7 +976,7 @@ EOF
 #    PL_amagic_generation++;
 ##endif
 EOF
-    for my $package (keys %{ $self->{Overloaded} }) {
+    for my $package (sort keys %{ $self->{Overloaded} }) {
       # once for each package with overloads
       my $fallback = $self->{Fallback}->{$package} || "&PL_sv_undef";
       print Q(<<"EOF");

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pod
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pod
@@ -19,6 +19,7 @@ ExtUtils::ParseXS - converts Perl XS code into C code
                       linenumbers => 1,
                       optimize => 1,
                       prototypes => 1,
+                      die_on_error => 0,
                     );
 
   # Legacy non-OO interface using a singleton:
@@ -118,6 +119,15 @@ Default is true.
 =item B<s>
 
 I<Maintainer note:> I have no clue what this does.  Strips function prefixes?
+
+=item B<die_on_error>
+
+Normally ExtUtils::ParseXS will terminate the program with an C<exit(1)> after
+printing the details of the exception to STDERR via (warn). This can be awkward
+when it is used programmatically and not via xsubpp, so this option can be used
+to cause it to die instead by providing a true value. When not provided this
+defaults to the value of C<$ExtUtils::ParseXS::DIE_ON_ERROR> which in turn
+defaults to false.
 
 =back
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Symbol;
 
-our $VERSION = '3.47';
+our $VERSION = '3.48';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
@@ -1,7 +1,7 @@
 package ExtUtils::ParseXS::CountLines;
 use strict;
 
-our $VERSION = '3.47';
+our $VERSION = '3.48';
 
 our $SECTION_END_MARKER;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
@@ -2,7 +2,7 @@ package ExtUtils::ParseXS::Eval;
 use strict;
 use warnings;
 
-our $VERSION = '3.47';
+our $VERSION = '3.48';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
@@ -698,13 +698,42 @@ None.
 =cut
 
 sub WarnHint {
+  warn _MsgHint(@_);
+}
+
+=head2 C<_MsgHint()>
+
+=over 4
+
+=item * Purpose
+
+Constructs an exception message with line number details. The last argument is
+assumed to be a hint string.
+
+=item * Arguments
+
+List of strings to warn, followed by one argument representing a hint.
+If that argument is defined then it will be split on newlines and concatenated
+line by line (parenthesized) after the main message.
+
+=item * Return Value
+
+The constructed string.
+
+=back
+
+=cut
+
+
+sub _MsgHint {
   my $self = shift;
   my $hint = pop;
   my $warn_line_number = $self->current_line_number();
-  print STDERR join("",@_), " in $self->{filename}, line $warn_line_number\n";
+  my $ret = join("",@_) . " in $self->{filename}, line $warn_line_number\n";
   if ($hint) {
-    print STDERR "    ($_)\n" for split /\n/, $hint;
+    $ret .= "    ($_)\n" for split /\n/, $hint;
   }
+  return $ret;
 }
 
 =head2 C<blurt()>
@@ -742,8 +771,13 @@ sub blurt {
 =cut
 
 sub death {
-  my $self = shift;
-  $self->Warn(@_);
+  my $self = (@_);
+  my $message = _MsgHint(@_,"");
+  if ($self->{die_on_error}) {
+    die $message;
+  } else {
+    warn $message;
+  }
   exit 1;
 }
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
@@ -5,7 +5,7 @@ use Exporter;
 use File::Spec;
 use ExtUtils::ParseXS::Constants ();
 
-our $VERSION = '3.47';
+our $VERSION = '3.48';
 
 our (@ISA, @EXPORT_OK);
 @ISA = qw(Exporter);

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
@@ -21,6 +21,7 @@ our (@ISA, @EXPORT_OK);
   analyze_preprocessor_statements
   set_cond
   Warn
+  WarnHint
   current_line_number
   blurt
   death
@@ -654,18 +655,56 @@ sub current_line_number {
 
 =item * Purpose
 
+Print warnings with line number details at the end.
+
 =item * Arguments
 
+List of text to output.
+
 =item * Return Value
+
+None.
 
 =back
 
 =cut
 
 sub Warn {
+  my ($self)=shift;
+  $self->WarnHint(@_,undef);
+}
+
+=head2 C<WarnHint()>
+
+=over 4
+
+=item * Purpose
+
+Prints warning with line number details. The last argument is assumed
+to be a hint string.
+
+=item * Arguments
+
+List of strings to warn, followed by one argument representing a hint.
+If that argument is defined then it will be split on newlines and output
+line by line after the main warning.
+
+=item * Return Value
+
+None.
+
+=back
+
+=cut
+
+sub WarnHint {
   my $self = shift;
+  my $hint = pop;
   my $warn_line_number = $self->current_line_number();
-  print STDERR "@_ in $self->{filename}, line $warn_line_number\n";
+  print STDERR join("",@_), " in $self->{filename}, line $warn_line_number\n";
+  if ($hint) {
+    print STDERR "    ($_)\n" for split /\n/, $hint;
+  }
 }
 
 =head2 C<blurt()>

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.47';
+our $VERSION = '3.48';
 
 require ExtUtils::ParseXS;
 require ExtUtils::ParseXS::Constants;

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Cmd.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Cmd.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::Cmd;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.47';
+our $VERSION = '3.48';
 
 use ExtUtils::Typemaps;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/InputMap.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/InputMap.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::InputMap;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.47';
+our $VERSION = '3.48';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/OutputMap.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/OutputMap.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::OutputMap;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.47';
+our $VERSION = '3.48';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Type.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Type.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 require ExtUtils::Typemaps;
 
-our $VERSION = '3.47';
+our $VERSION = '3.48';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/perlxs.pod
+++ b/dist/ExtUtils-ParseXS/lib/perlxs.pod
@@ -2409,7 +2409,7 @@ or use the methods given in L<perlcall>.
 =head1 XS VERSION
 
 This document covers features supported by C<ExtUtils::ParseXS>
-(also known as C<xsubpp>) 3.13_01.
+(also known as C<xsubpp>) 3.48
 
 =head1 AUTHOR
 

--- a/dist/ExtUtils-ParseXS/lib/perlxs.pod
+++ b/dist/ExtUtils-ParseXS/lib/perlxs.pod
@@ -1332,6 +1332,46 @@ C<BAR::getit()> for this function.
         OUTPUT:
           timep
 
+A warning will be produced when you create more than one alias to the same
+value. This may be worked around in a backwards compatible way by creating
+multiple defines which resolve to the same value, or with a modern version
+of ExtUtils::ParseXS you can use a symbolic alias, which are denoted with
+a C<< => >> instead of a C<< = >>. For instance you could change the above
+so that the alias section looked like this:
+
+	ALIAS:
+	    FOO::gettime = 1
+	    BAR::getit = 2
+            BAZ::gettime => FOO::gettime
+
+this would have the same effect as this:
+
+	ALIAS:
+	    FOO::gettime = 1
+	    BAR::getit = 2
+            BAZ::gettime = 1
+
+except that the latter will produce warnings during the build process. A
+mechanism that would work in a backwards compatible way with older
+versions of our tool chain would be to do this:
+
+    #define FOO_GETTIME 1
+    #define BAR_GETIT 2
+    #define BAZ_GETTIME 1
+
+    bool_t
+    rpcb_gettime(host,timep)
+          char *host
+          time_t &timep
+	ALIAS:
+	    FOO::gettime = FOO_GETTIME
+	    BAR::getit = BAR_GETIT
+            BAZ::gettime = BAZ_GETTIME
+	INIT:
+	  printf("# ix = %d\n", ix );
+        OUTPUT:
+          timep
+
 =head2 The OVERLOAD: Keyword
 
 Instead of writing an overloaded interface using pure Perl, you

--- a/dist/ExtUtils-ParseXS/t/001-basic.t
+++ b/dist/ExtUtils-ParseXS/t/001-basic.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 20;
+use Test::More tests => 22;
 use Config;
 use DynaLoader;
 use ExtUtils::CBuilder;
@@ -218,6 +218,24 @@ like $stderr, '/No INPUT definition/', "Exercise typemap error";
         "No 'duplicate function definition' warning observed in $filename";
       }
   }
+}
+
+#####################################################################
+
+{ # tight cpp directives
+  my $pxs = ExtUtils::ParseXS->new;
+  tie *FH, 'Foo';
+  my $stderr = PrimitiveCapture::capture_stderr(sub {
+    $pxs->process_file(
+      filename => 'XSTightDirectives.xs',
+      output => \*FH,
+      prototypes => 1);
+  });
+  my $content = tied(*FH)->{buf};
+  my $count = 0;
+  $count++ while $content=~/^XS_EUPXS\(XS_My_do\)\n\{/mg;
+  is $stderr, undef, "No error expected from TightDirectives.xs";
+  is $count, 2, "Saw XS_MY_do definition the expected number of times";
 }
 
 #####################################################################

--- a/dist/ExtUtils-ParseXS/t/001-basic.t
+++ b/dist/ExtUtils-ParseXS/t/001-basic.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 24;
+use Test::More tests => 26;
 use Config;
 use DynaLoader;
 use ExtUtils::CBuilder;
@@ -288,6 +288,24 @@ EOF_CONTENT
 
   #diag $content;
 }
+{
+    my $file = $INC{"ExtUtils/ParseXS.pm"};
+    $file=~s!ExtUtils/ParseXS\.pm\z!perlxs.pod!;
+    open my $fh, "<", $file
+        or die "Failed to open '$file' for read:$!";
+    my $pod_version = "";
+    while (defined(my $line= readline($fh))) {
+        if ($line=~/\(also known as C<xsubpp>\)\s+(\d+\.\d+)/) {
+            $pod_version = $1;
+            last;
+        }
+    }
+    close $fh;
+    ok($pod_version, "Found the version from perlxs.pod");
+    is($pod_version, $ExtUtils::ParseXS::VERSION,
+        "The version in perlxs.pod should match the version of ExtUtils::ParseXS");
+}
+
 #####################################################################
 
 sub Foo::TIEHANDLE { bless {}, 'Foo' }

--- a/dist/ExtUtils-ParseXS/t/001-basic.t
+++ b/dist/ExtUtils-ParseXS/t/001-basic.t
@@ -15,7 +15,9 @@ require_ok( 'ExtUtils::ParseXS' );
 chdir('t') if -d 't';
 push @INC, '.';
 
-use Carp; $SIG{__WARN__} = \&Carp::cluck;
+$ExtUtils::ParseXS::DIE_ON_ERROR = 1;
+
+use Carp; #$SIG{__WARN__} = \&Carp::cluck;
 
 # The linker on some platforms doesn't like loading libraries using relative
 # paths. Android won't find relative paths, and system perl on macOS will
@@ -225,12 +227,12 @@ like $stderr, '/No INPUT definition/', "Exercise typemap error";
 { # tight cpp directives
   my $pxs = ExtUtils::ParseXS->new;
   tie *FH, 'Foo';
-  my $stderr = PrimitiveCapture::capture_stderr(sub {
+  my $stderr = PrimitiveCapture::capture_stderr(sub { eval {
     $pxs->process_file(
       filename => 'XSTightDirectives.xs',
       output => \*FH,
       prototypes => 1);
-  });
+  } or warn $@ });
   my $content = tied(*FH)->{buf};
   my $count = 0;
   $count++ while $content=~/^XS_EUPXS\(XS_My_do\)\n\{/mg;

--- a/dist/ExtUtils-ParseXS/t/001-basic.t
+++ b/dist/ExtUtils-ParseXS/t/001-basic.t
@@ -252,12 +252,14 @@ like $stderr, '/No INPUT definition/', "Exercise typemap error";
   $count++ while $content=~/^XS_EUPXS\(XS_My_do\)\n\{/mg;
   is $stderr,
     "Warning: Aliases 'pox' and 'dox', 'lox' have"
-    . " identical values in XSAlias.xs, line 9\n"
+    . " identical values of 1 in XSAlias.xs, line 9\n"
     . "    (If this is deliberate use a symbolic alias instead.)\n"
     . "Warning: Conflicting duplicate alias 'pox' changes"
     . " definition from '1' to '2' in XSAlias.xs, line 10\n"
     . "Warning: Aliases 'docks' and 'dox', 'lox' have"
-    . " identical values in XSAlias.xs, line 11\n",
+    . " identical values of 1 in XSAlias.xs, line 11\n"
+    . "Warning: Aliases 'xunx' and 'do' have identical values"
+    . " of 0 - the base function in XSAlias.xs, line 13\n",
     "Saw expected warnings from XSAlias.xs";
 
   my $expect = quotemeta(<<'EOF_CONTENT');
@@ -273,6 +275,10 @@ like $stderr, '/No INPUT definition/', "Exercise typemap error";
          XSANY.any_i32 = 1;
          cv = newXSproto_portable("My::pox", XS_My_do, file, "$");
          XSANY.any_i32 = 2;
+         cv = newXSproto_portable("My::xukes", XS_My_do, file, "$");
+         XSANY.any_i32 = 0;
+         cv = newXSproto_portable("My::xunx", XS_My_do, file, "$");
+         XSANY.any_i32 = 0;
 EOF_CONTENT
   $expect=~s/(?:\\[ ])+/\\s+/g;
   $expect=qr/$expect/;

--- a/dist/ExtUtils-ParseXS/t/002-more.t
+++ b/dist/ExtUtils-ParseXS/t/002-more.t
@@ -19,7 +19,7 @@ ExtUtils::ParseXS->import('process_file');
 chdir 't' if -d 't';
 push @INC, '.';
 
-use Carp; $SIG{__WARN__} = \&Carp::cluck;
+use Carp; #$SIG{__WARN__} = \&Carp::cluck;
 
 # See the comments about this in 001-basics.t
 @INC = map { File::Spec->rel2abs($_) } @INC;

--- a/dist/ExtUtils-ParseXS/t/003-usage.t
+++ b/dist/ExtUtils-ParseXS/t/003-usage.t
@@ -20,7 +20,7 @@ require_ok( 'ExtUtils::ParseXS' );
 chdir('t') if -d 't';
 push @INC, '.';
 
-use Carp; $SIG{__WARN__} = \&Carp::cluck;
+use Carp; #$SIG{__WARN__} = \&Carp::cluck;
 
 # See the comments about this in 001-basics.t
 @INC = map { File::Spec->rel2abs($_) } @INC;

--- a/dist/ExtUtils-ParseXS/t/XSAlias.xs
+++ b/dist/ExtUtils-ParseXS/t/XSAlias.xs
@@ -1,0 +1,17 @@
+MODULE = My PACKAGE = My
+
+void
+do(dbh)
+   SV *dbh
+ALIAS:
+    dox = 1
+    lox => dox
+    pox = 1
+    pox = 2
+    docks = 1
+    dachs => lox
+CODE:
+{
+   int x;
+   ++x;
+}

--- a/dist/ExtUtils-ParseXS/t/XSAlias.xs
+++ b/dist/ExtUtils-ParseXS/t/XSAlias.xs
@@ -10,6 +10,8 @@ ALIAS:
     pox = 2
     docks = 1
     dachs => lox
+    xunx = 0
+    xukes => do
 CODE:
 {
    int x;

--- a/dist/ExtUtils-ParseXS/t/XSTightDirectives.xs
+++ b/dist/ExtUtils-ParseXS/t/XSTightDirectives.xs
@@ -1,0 +1,21 @@
+MODULE = My PACKAGE = My
+
+#ifdef MYDEF123
+void
+do(dbh)
+   SV *dbh
+CODE:
+{
+   int x;
+   ++x;
+}
+#else
+void
+do(dbh)
+   SV *dbh
+CODE:
+{
+   int x;
+   ++x;
+}
+#endif


### PR DESCRIPTION
This includes a number of ParseXS changes. A version bump, tests that perlxs.pod has the correct version, improvements to parsing cpp processor directives so XS files will be less whitespace sensitive, and enhanced support for aliases. 