### PR TITLE
regcomp.c - add a PARNO() macro to wrap the ARG() macro

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -12180,14 +12180,15 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                             SvIV_set(sv_dat, 1);
                         }
 #ifdef DEBUGGING
-                        /* Yes this does cause a memory leak in debugging Perls
-                         * */
+                        /* No, this does not cause a memory leak under
+                         * debugging. RExC_paren_name_list is freed later
+                         * on in the dump process. - Yves
+                         */
                         if (!av_store(RExC_paren_name_list,
                                       RExC_npar, SvREFCNT_inc_NN(svname)))
                             SvREFCNT_dec_NN(svname);
 #endif
 
-                        /*sv_dump(sv_dat);*/
                     }
                     nextchar(pRExC_state);
                     paren = 1;

--- a/regcomp.h
+++ b/regcomp.h
@@ -386,6 +386,8 @@ struct regnode_ssc {
                                     ((struct regnode_string *)p)->string)
 #define	OPERANDs(p)	STRINGs(p)
 
+#define PARNO(p)        ARG(p)          /* APPLIES for OPEN and CLOSE only */
+
 /* Long strings.  Currently limited to length 18 bits, which handles a 262000
  * byte string.  The limiting factor is the 16 bit 'next_off' field, which
  * points to the next regnode, so the furthest away it can be is 2**16.  On
@@ -435,6 +437,7 @@ struct regnode_ssc {
 #define	ARG1_LOC(p)	(((struct regnode_2 *)p)->arg1)
 #define	ARG2_LOC(p)	(((struct regnode_2 *)p)->arg2)
 #define ARG2L_LOC(p)	(((struct regnode_2L *)p)->arg2)
+
 
 /* These should no longer be used directly in most cases. Please use
  * the REGNODE_AFTER() macros instead. */

--- a/regexec.c
+++ b/regexec.c
@@ -183,7 +183,7 @@ static const char non_utf8_target_but_utf8_required[]
 #define JUMPABLE(rn) (                                                             \
     OP(rn) == OPEN ||                                                              \
     (OP(rn) == CLOSE &&                                                            \
-     !EVAL_CLOSE_PAREN_IS(cur_eval,ARG(rn)) ) ||                                   \
+     !EVAL_CLOSE_PAREN_IS(cur_eval,PARNO(rn)) ) ||                                 \
     OP(rn) == EVAL ||                                                              \
     OP(rn) == SUSPEND || OP(rn) == IFMATCH ||                                      \
     OP(rn) == PLUS || OP(rn) == MINMOD ||                                          \
@@ -8455,7 +8455,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 #undef ST
 
         case OPEN: /*  (  */
-            n = ARG(scan);  /* which paren pair */
+            n = PARNO(scan);  /* which paren pair */
             rex->offs[n].start_tmp = locinput - reginfo->strbeg;
             if (n > maxopenparen)
                 maxopenparen = n;
@@ -8477,7 +8477,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
 
         case CLOSE:  /*  )  */
-            n = ARG(scan);  /* which paren pair */
+            n = PARNO(scan);  /* which paren pair */
             CLOSE_CAPTURE(n, rex->offs[n].start_tmp,
                              locinput - reginfo->strbeg);
             if ( EVAL_CLOSE_PAREN_IS( cur_eval, n ) )
@@ -8513,7 +8513,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                     if ( OP(cursor) != CLOSE )
                         continue;
 
-                    n = ARG(cursor);
+                    n = PARNO(cursor);
 
                     if ( n > lastopen ) /* might be OPEN/CLOSE in the way */
                         continue;       /* so skip this one */


### PR DESCRIPTION
We used the ARG() macro to access the parno data for the OPEN and CLOSE regops. This made it difficult to change the type and size or location of this data in the node. Replacing this access with a specific macro makes the code more legible and future proof.
    
This was actually backported from finding everything that broke by changing the regnode type for OPEN and CLOSE to 2L and moving the paren parameter to the 2L slot. We might do something like this in the future and separating the PARNO() macros from their implementation will make it easier.

Includes a comment patch to regcomp.c: we do not leak with named capture in debug mode. (I checked.)
