### PR TITLE
skip testing .github/README.md if doesn't appear to be a README

### DIFF
--- a/t/porting/copyright.t
+++ b/t/porting/copyright.t
@@ -31,7 +31,9 @@ my ($opt) = @ARGV;
 my $readme_year = readme_year();
 my $v_year = v_year();
 my $gh_readme_year;
-if (-e "../.github/README.md")
+# git on windows renders symbolic links as a file containing
+# the file linked to
+if (-e "../.github/README.md" && -s "../.github/README.md" > 80)
 {
   $gh_readme_year = readme_year(".github/README.md");
 }


### PR DESCRIPTION
git on windows at least of 2.37.1 does not checkout symbolic links as symbolic links, leaving them as files containing the filename linked to.

This meant this test against .github/README.md failed, since it only contained "../README": nothing that appears to be a copyright message

I considered testing that .github/README.md was a symbolic link but 8975221916 suggests that it may eventually become more distinct from the root README file, so instead check its size.