### PR TITLE
Perl doesn't appear to be included in the ibb any more

### DIFF
--- a/pod/perlsecpolicy.pod
+++ b/pod/perlsecpolicy.pod
@@ -488,10 +488,4 @@ omitted from announcements.
 The Perl project is a non-profit volunteer effort. We do not provide
 any monetary rewards for reporting security issues in Perl.
 
-The L<Internet Bug Bounty|https://internetbugbounty.org/> offers monetary
-rewards for some Perl security issues after they are fully resolved. The
-terms of this program are available at L<HackerOne|https://hackerone.com/ibb-perl>.
-
-This program is not run by the Perl project or the Perl security team.
-
 =cut


### PR DESCRIPTION
The "ibb-perl" link prompts for a login, though other links like "https://hackerone.com/perl" load without a login.

Perl also isn't listed under the ibb project itself at "https://hackerone.com/ibb?type=team"