### PR TITLE
configure.gnu forwards extra arguments to Configure

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1286,6 +1286,13 @@ options.  Try
 
 for a listing.
 
+Unrecognized arguments with a double dash prefix produce an error.
+
+Any other arguments are passed through to C<Configure>, so you could
+build a threaded perl with:
+
+        CC=gcc ./configure.gnu -Dusethreads
+
 (The file is called configure.gnu to avoid problems on systems
 that would not distinguish the files "Configure" and "configure".)
 


### PR DESCRIPTION
except when it doesn't (the -- arguments)

This came up during discussion of #20502, but is not a fix for it.