### PR TITLE
test SvPVbyte*() and SvPVutf8*() variants set len

### DIFF
--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -4340,30 +4340,44 @@ OUTPUT:
     RETVAL
 
 char *
-SvPVbyte(SV *sv)
+SvPVbyte(SV *sv, OUT STRLEN len)
+CODE:
+    RETVAL = SvPVbyte(sv, len);
+OUTPUT:
+    RETVAL
+
+char *
+SvPVbyte_nolen(SV *sv)
 CODE:
     RETVAL = SvPVbyte_nolen(sv);
 OUTPUT:
     RETVAL
 
 char *
-SvPVbyte_nomg(SV *sv)
+SvPVbyte_nomg(SV *sv, OUT STRLEN len)
 CODE:
-    RETVAL = SvPVbyte_nomg(sv, PL_na);
+    RETVAL = SvPVbyte_nomg(sv, len);
 OUTPUT:
     RETVAL
 
 char *
-SvPVutf8(SV *sv)
+SvPVutf8(SV *sv, OUT STRLEN len)
+CODE:
+    RETVAL = SvPVutf8(sv, len);
+OUTPUT:
+    RETVAL
+
+char *
+SvPVutf8_nolen(SV *sv)
 CODE:
     RETVAL = SvPVutf8_nolen(sv);
 OUTPUT:
     RETVAL
 
 char *
-SvPVutf8_nomg(SV *sv)
+SvPVutf8_nomg(SV *sv, OUT STRLEN len)
 CODE:
-    RETVAL = SvPVutf8_nomg(sv, PL_na);
+    RETVAL = SvPVutf8_nomg(sv, len);
 OUTPUT:
     RETVAL
 

--- a/ext/XS-APItest/t/svpv_magic.t
+++ b/ext/XS-APItest/t/svpv_magic.t
@@ -33,7 +33,7 @@ is(eval { XS::APItest::first_byte($1) } || $@, 0303,
 sub TIESCALAR { bless [], shift }
 sub FETCH { ++$f; *{chr utf8::unicode_to_native(255)} }
 tie $t, "main";
-is SvPVutf8($t), "*main::" . byte_utf8a_to_utf8n("\xc3\xbf"),
+is SvPVutf8_nolen($t), "*main::" . byte_utf8a_to_utf8n("\xc3\xbf"),
   'SvPVutf8 works with get-magic changing the SV type';
 is $f, 1, 'SvPVutf8 calls get-magic once';
 
@@ -44,7 +44,7 @@ package t {
 }
 tie $t, "t";
 undef $f;
-is SvPVutf8($t), byte_utf8a_to_utf8n("\xc3\xbf"),
+is SvPVutf8_nolen($t), byte_utf8a_to_utf8n("\xc3\xbf"),
   'SvPVutf8 works with get-magic downgrading the SV';
 is $f, 1, 'SvPVutf8 calls get-magic once';
 ()="$t";


### PR DESCRIPTION
These macros have limited use in core:

- only Socket uses SvPVbyte_nomg()
- nothing uses SvPVutf8_nomg()

Update the existing tests to ensure len is set properly.

Related to #20507