### PR TITLE
New PERL_STRLEN_NEW_MIN & PERL_ARRAY_NEW_MIN_KEY definitions

### DIFF
--- a/av.c
+++ b/av.c
@@ -177,7 +177,8 @@ Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp,
                 PL_stack_max = PL_stack_base + newmax;
             }
         } else { /* there is no SV* array yet */
-            *maxp = key < 3 ? 3 : key;
+            *maxp = key < PERL_ARRAY_NEW_MIN_KEY ?
+                          PERL_ARRAY_NEW_MIN_KEY : key;
             {
                 /* see comment above about newmax+1*/
                 MEM_WRAP_CHECK_s(*maxp, SV*,

--- a/perl.h
+++ b/perl.h
@@ -1603,11 +1603,20 @@ Use L</UV> to declare variables of the maximum usable size on this platform.
 
 /* Functions like Perl_sv_grow mandate a minimum string size.
  * This was 10 bytes for a long time, the rationale for which seems lost
- * to the mists of time. However, since this does not correlate to what
- * modern malloc implementations will actually return, it can be revised
- * to be more appropriate. */
+ * to the mists of time. However, this does not correlate to what modern
+ * malloc implementations will actually return, in particular the fact
+ * that chunks are almost certainly some multiple of pointer size. The
+ * default has therefore been revised to a more useful approximation.
+ * Notes: The following is specifically conservative for 64 bit, since
+ * most dlmalloc derivatives seem to serve a 3xPTRSIZE minimum chunk,
+ * so the below perhaps should be:
+ *     ((PTRSIZE == 4) ? 12 : 24)
+ * Configure probes for malloc_good_size, malloc_actual_size etc.
+ * could be revised to record the actual minimum chunk size, to which
+ * PERL_STRLEN_NEW_MIN could then be set.
+ */
 #ifndef PERL_STRLEN_NEW_MIN
-#define PERL_STRLEN_NEW_MIN 10
+#define PERL_STRLEN_NEW_MIN ((PTRSIZE == 4) ? 12 : 16)
 #endif
 
 /* Round all values passed to malloc up, by default to a multiple of

--- a/perl.h
+++ b/perl.h
@@ -1593,6 +1593,23 @@ Use L</UV> to declare variables of the maximum usable size on this platform.
 
 #define MEM_SIZE Size_t
 
+/* av_extend and analogues enforce a minimum number of array elements.
+ * This has been 4 elements (so a minimum key size of 3) for a long
+ * time, but the rationale behind this seems to have been lost to the
+ * mists of time. */
+#ifndef PERL_ARRAY_NEW_MIN_KEY
+#define PERL_ARRAY_NEW_MIN_KEY 3
+#endif
+
+/* Functions like Perl_sv_grow mandate a minimum string size.
+ * This was 10 bytes for a long time, the rationale for which seems lost
+ * to the mists of time. However, since this does not correlate to what
+ * modern malloc implementations will actually return, it can be revised
+ * to be more appropriate. */
+#ifndef PERL_STRLEN_NEW_MIN
+#define PERL_STRLEN_NEW_MIN 10
+#endif
+
 /* Round all values passed to malloc up, by default to a multiple of
    sizeof(size_t)
 */

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -5152,7 +5152,8 @@ Perl_clear_defarray(pTHX_ AV* av, bool abandon)
     else {
         const SSize_t size = AvFILLp(av) + 1;
         /* The ternary gives consistency with av_extend() */
-        AV *newav = newAV_alloc_x(size < 4 ? 4 : size);
+        AV *newav = newAV_alloc_x(size < PERL_ARRAY_NEW_MIN_KEY ?
+                                         PERL_ARRAY_NEW_MIN_KEY : size);
         AvREIFY_only(newav);
         PAD_SVl(0) = MUTABLE_SV(newav);
         SvREFCNT_dec_NN(av);

--- a/sv.c
+++ b/sv.c
@@ -1328,7 +1328,7 @@ Perl_sv_grow(pTHX_ SV *const sv, STRLEN newlen)
 
     if (newlen > SvLEN(sv)) {		/* need more room? */
         STRLEN minlen = SvCUR(sv);
-        minlen += (minlen >> PERL_STRLEN_EXPAND_SHIFT) + 10;
+        minlen += (minlen >> PERL_STRLEN_EXPAND_SHIFT) + PERL_STRLEN_NEW_MIN;
         if (newlen < minlen)
             newlen = minlen;
 #ifndef PERL_UNWARANTED_CHUMMINESS_WITH_MALLOC
@@ -1402,10 +1402,8 @@ Perl_sv_grow_fresh(pTHX_ SV *const sv, STRLEN newlen)
         newlen++;
 #endif
 
-    /* 10 is a longstanding, hardcoded minimum length in sv_grow. */
-    /* Just doing the same here for consistency. */
-    if (newlen < 10)
-        newlen = 10;
+    if (newlen < PERL_STRLEN_NEW_MIN)
+        newlen = PERL_STRLEN_NEW_MIN;
 
     s = (char*)safemalloc(newlen);
     SvPV_set(sv, s);


### PR DESCRIPTION
This PR consists of two commits, both concerned with the
hardcoded default minimum length for PV buffers and AV arrays.

1. Extracts the hardcoded numbers into two new definitions:
```
        PERL_ARRAY_NEW_MIN_KEY
        PERL_STRLEN_NEW_MIN
```
2. Increases the value of `PERL_STRLEN_NEW_MIN` to be
closer to the likely actual allocation returned by `malloc()`.

The intention is to reduce the potential for unnecessary
calls to `sv_grow`, such as when building a string through
concatenation, when the PV buffer is actually big enough
for the operation and perl just does not know it.

The minimum value chosen for 64-bit is very likely too
small, but I am unfamiliar with memory-constrained
systems and wanted to play it safe. (Happy to raise it to
the very common 3*8 bytes if people are comfortable
with that.)

Actually measuring the minimum allocation size at
Configure time, for `malloc()` implementations that support
it, would be more accurate and I might try that in the next
development cycle.

The PERL_UNWARANTED_CHUMMINESS_WITH_MALLOC
stuff would also help with this problem, but I've previously been
told that it was disabled due to problems with COW that have
not been ironed out yet.