### PR TITLE
Replaced SSGROW with SSCHECK inside regcppush (Win32 slowdown, recursive patterns)

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -261,7 +261,7 @@ S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen _pDEPTH)
             );
     );
 
-    SSGROW(total_elems + REGCP_FRAME_ELEMS);
+    SSCHECK(total_elems + REGCP_FRAME_ELEMS);
 
     /* memcpy the offs inside the stack - it's faster than for loop */
     memcpy(&PL_savestack[PL_savestack_ix], rex->offs + parenfloor + 1, paren_bytes_to_push);


### PR DESCRIPTION
Which drastically improves performance on large matches.

[donuts.zip](https://github.com/Perl/perl5/files/10048106/donuts.zip)

For the following file for example:

(On https://github.com/AnFunctionArray/cperllexer/commit/5980b216792cd79f88eaa289ef314295a0ebc4d8)

With the following env vars:

MINQUEUECOUNT=50
SILENT=1

```
Z:\cllvmbackend\lexer>powershell -Command "Measure-Command {perl ./parse.pl ./donuts.pp}"
joinning 30, 834632 for real


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 471
Ticks             : 4713919
TotalDays         : 5.45592476851852E-06
TotalHours        : 0.000130942194444444
TotalMinutes      : 0.00785653166666667
TotalSeconds      : 0.4713919
TotalMilliseconds : 471.3919




Z:\cllvmbackend\lexer>powershell -Command "Measure-Command {Z:\perl5orig\perl.exe ./parse.pl ./donuts.pp}"
joinning 30, 834632 for real


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 25
Milliseconds      : 489
Ticks             : 254896534
TotalDays         : 0.000295019136574074
TotalHours        : 0.00708045927777778
TotalMinutes      : 0.424827556666667
TotalSeconds      : 25.4896534
TotalMilliseconds : 25489.6534




Z:\cllvmbackend\lexer>
```

Where the second run is without the patch.