### PR TITLE
t/op/readline.t: skip error handling checks on solaris with PERLIO=stdio

### DIFF
--- a/t/op/readline.t
+++ b/t/op/readline.t
@@ -295,6 +295,9 @@ SKIP:
     my $tmpfile = tempfile();
     open my $fh, ">", $tmpfile
         or die "Cannot open $tmpfile: $!";
+    my @layers = PerlIO::get_layers($fh);
+    skip "fgetc doesn't set error flag on failure on solaris likes", 4
+        if $^O eq 'solaris' && $layers[-1] eq 'stdio';
     ok(!$fh->error, "no error before we try to read");
     ok(!<$fh>, "fail to readline file opened for write");
     ok($fh->error, "error after trying to readline file opened for write");


### PR DESCRIPTION
In this test, readline() calls down into PerlIOStdio_read(), which uses fgetc() for a single character read, which fails as expected.

But fgetc() doesn't set the error flag on the stream, so the error flag test and the close() test fail.

So skip the tests.

Fixes #20528

Confirmed with the following code:
```
#include <stdio.h>
#include <stdlib.h>

int main() {
  FILE *f = fopen("test.txt", "w");
  if (!f) {
    perror("fopen");
    exit(1);
  }
  int c = fgetc(f);
  if (c != EOF) { /* should fail */
    printf("Expected fgetc() failure didn't occur\n");
    exit(1);
  }
  perror("fgetc");
  if (!ferror(f)) {
    printf("error flag not set\n");
    exit(1);
  }
  return 0;
}
```
Run:
```
tony@openindiana:~/dev/perl/git$ gcc -ostdio-error stdio-error.c
tony@openindiana:~/dev/perl/git$ ./stdio-error 
fgetc: Bad file number
error flag not set
```
On linux:
```
tony@venus:.../perl/git$ gcc -ostdio-error stdio-error.c
tony@venus:.../perl/git$ ./stdio-error 
fgetc: Bad file descriptor
tony@venus:.../perl/git$
```