### PR TITLE
Prevent empty cop_file shared string as a byproduct of @INC hook/source filter issues

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5676,6 +5676,7 @@ t/lib/Devel/nodb.pm		Module for t/run/switchd.t
 t/lib/Devel/switchd.pm		Module for t/run/switchd.t
 t/lib/Devel/switchd_empty.pm	Module for t/run/switchd.t
 t/lib/Devel/switchd_goto.pm	Module for t/run/switchd.t
+t/lib/Dies.pm			For test case in op/require_errors.t
 t/lib/feature/api		Test API for checking features enabled/disabled
 t/lib/feature/bareword_filehandles	Tests for enabling/disabling bareword_filehandles feature
 t/lib/feature/bits		Tests for feature bit handling

--- a/cop.h
+++ b/cop.h
@@ -534,7 +534,10 @@ string pv created with C<rcpv_new()>.
 Returns the refcount for a pv created with C<rcpv_new()>. 
 
 =for apidoc Am|RCPV *|RCPV_LEN|char *pv
-Returns the length of a pv created with C<rcpv_new()>. 
+Returns the length of a pv created with C<rcpv_new()>.
+Note that this reflects the length of the string from the callers
+point of view, it does not include the mandatory null which is
+always injected at the end of the string by rcpv_new().
 
 =cut
 */
@@ -542,16 +545,19 @@ Returns the length of a pv created with C<rcpv_new()>.
 struct rcpv {
     STRLEN  refcount;  /* UV would mean a 64 refcnt on
                           32 bit builds with -Duse64bitint */
-    STRLEN  len;
+    STRLEN  len;       /* length of string including mandatory
+                          null byte at end */
     char    pv[1];
 };
 typedef struct rcpv RCPV;
 
-#define RCPVf_USE_STRLEN 1
-#define RCPVf_NO_COPY 2
+#define RCPVf_USE_STRLEN    (1 << 0)
+#define RCPVf_NO_COPY       (1 << 1)
+#define RCPVf_ALLOW_EMPTY   (1 << 2)
+
 #define RCPVx(pv_arg)       ((RCPV *)((pv_arg) - STRUCT_OFFSET(struct rcpv, pv)))
 #define RCPV_REFCOUNT(pv)   (RCPVx(pv)->refcount)
-#define RCPV_LEN(pv)        (RCPVx(pv)->len)
+#define RCPV_LEN(pv)        (RCPVx(pv)->len-1) /* len always includes space for a null */
 
 #ifdef USE_ITHREADS
 

--- a/op.c
+++ b/op.c
@@ -15246,16 +15246,32 @@ Perl_dup_warnings(pTHX_ char* warnings)
 /*
 =for apidoc rcpv_new
 
-Create a new shared memory refcounted string from the argument. If flags is set 
-to RCPVf_USE_STRLEN then the len argument is ignored and set using strlen(pv). 
-If the pv is NULL returns NULL. The newly created string will have a refcount 
-of 1, and is suitable for passing into rcpv_copy() and rcpv_free(). To access
-the RCPV * from the returned value use the RCPVx() macro.
+Create a new shared memory refcounted string with the requested size, and
+with the requested initialization and a refcount of 1. The actual space
+allocated will be 1 byte more than requested and rcpv_new() will ensure that
+the extra byte is a null regardless of any flags settings.
 
-Note that rcpv_new() does NOT use a hash table or anything like that to dedupe
-inputs given the same text content. Each call with a non-null pv parameter
-will produce a distinct pointer with its own refcount regardless of the input
-content.
+If the RCPVf_NO_COPY flag is set then the pv argument will be
+ignored, otherwise the contents of the pv pointer will be copied into
+the new buffer or if it is NULL the function will do nothing and return NULL.
+
+If the RCPVf_USE_STRLEN flag is set then the len argument is ignored and
+recomputed using C<strlen(pv)>. It is an error to combine RCPVf_USE_STRLEN
+and RCPVf_NO_COPY at the same time.
+
+Under DEBUGGING rcpv_new() will assert() if it is asked to create a 0 length
+shared string unless the RCPVf_ALLOW_EMPTY flag is set.
+
+The return value from the function is suitable for passing into rcpv_copy() and
+rcpv_free(). To access the RCPV * from the returned value use the RCPVx() macro.
+The 'len' member of the RCPV struct stores the allocated length (including the
+extra byte), but the RCPV_LEN() macro returns the requested length (not
+including the extra byte).
+
+Note that rcpv_new() does NOT use a hash table or anything like that to
+dedupe inputs given the same text content. Each call with a non-null pv
+parameter will produce a distinct pointer with its own refcount regardless of
+the input content.
 
 =cut
 */
@@ -15268,23 +15284,32 @@ Perl_rcpv_new(pTHX_ const char *pv, STRLEN len, U32 flags) {
 
     PERL_UNUSED_CONTEXT;
 
+    /* Musn't use both at the same time */
+    assert((flags & (RCPVf_NO_COPY|RCPVf_USE_STRLEN))!=
+                    (RCPVf_NO_COPY|RCPVf_USE_STRLEN));
+
     if (!pv && (flags & RCPVf_NO_COPY) == 0)
         return NULL;
 
     if (flags & RCPVf_USE_STRLEN)
         len = strlen(pv);
 
-    rcpv = (RCPV *)PerlMemShared_malloc(sizeof(struct rcpv) + len + 1);
+    assert(len || (flags & RCPVf_ALLOW_EMPTY));
+
+    len++; /* add one for the null we will add to the end */
+
+    rcpv = (RCPV *)PerlMemShared_malloc(sizeof(struct rcpv) + len);
     if (!rcpv)
         croak_no_mem();
 
-    rcpv->len = len;
+    rcpv->len = len;    /* store length including null,
+                           RCPV_LEN() subtracts 1 to account for this */
     rcpv->refcount = 1;
 
     if ((flags & RCPVf_NO_COPY) == 0) {
-        (void)memcpy(rcpv->pv, pv, len);
-        rcpv->pv[len]= '\0';
+        (void)memcpy(rcpv->pv, pv, len-1);
     }
+    rcpv->pv[len-1]= '\0'; /* the last byte should always be null */
     return rcpv->pv;
 }
 
@@ -15315,6 +15340,7 @@ Perl_rcpv_free(pTHX_ char *pv) {
         return NULL;
     RCPV *rcpv = RCPVx(pv);
 
+    assert(rcpv->refcount);
     assert(rcpv->len);
 
     OP_REFCNT_LOCK;

--- a/t/lib/Dies.pm
+++ b/t/lib/Dies.pm
@@ -1,0 +1,1 @@
+die "error";

--- a/util.c
+++ b/util.c
@@ -2389,7 +2389,9 @@ Perl_new_warnings_bitfield(pTHX_ char *buffer, const char *const bits,
     PERL_UNUSED_CONTEXT;
     PERL_ARGS_ASSERT_NEW_WARNINGS_BITFIELD;
 
-    buffer = rcpv_new(buffer, len_wanted, RCPVf_NO_COPY);
+    /* pass in null as the source string as we will do the
+     * copy ourselves. */
+    buffer = rcpv_new(NULL, len_wanted, RCPVf_NO_COPY);
     Copy(bits, buffer, size, char);
     if (size < WARNsize)
         Zero(buffer + size, WARNsize - size, char);


### PR DESCRIPTION
In short the following code should produce the following: 

```
perl -It/lib -le'BEGIN{ unshift @INC, sub { if ($_[1] eq "CannotParse.pm" and !$seen++) { eval q(require $_[1]); warn $@;  my $code= qq[die qq(error)]; open my $fh,"<", \$code; return $fh } } } require CannotParse;'
```

Should output the following:
```
syntax error at t/lib/CannotParse.pm line 2, at EOF
Compilation failed in require at (eval 1) line 1.
error at /loader/0x564c1906a850/CannotParse.pm line 1.
Compilation failed in require at -e line 1.
```

Before this PR it output the following:
```
syntax error at t/lib/CannotParse.pm line 2, at EOF
Compilation failed in require at (eval 1) line 1.
error at  line 1.
Compilation failed in require at -e line 1.
```

Note the missing content in the line starting with "error".

This is because the underlying code was using the value in %INC, which was undef due to the innermost require failing.

This was revealed by an assert fail in the rcpv logic. This PR includes some changes to that logic so that it will more reasonably accommodate length 0 strings, and so we can use the length to validate that the structure is sane. It also improves the documentation. 

Note the reason this PR contains both was that at first this looked like a bug in the rcpv logic, but the more i dug into it the more convinced I because that we still should not support empty strings for the /existing/ uses of rcpv. However if someone were to use the infra for a new task it would be reasonable they have a way to support empty strings. Given the way these issues are a bit entangled I think its reasonable to include changes regarding both in this PR. (No need for PR churn.)

This fixes https://github.com/Perl/perl5/issues/20535