### PR TITLE
locale.c: Fix memory leak

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -4827,7 +4827,9 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 #  endif
 #  ifdef USE_POSIX_2008_LOCALE
 
-    PL_C_locale_obj = newlocale(LC_ALL_MASK, "C", (locale_t) 0);
+    if (! PL_C_locale_obj) {
+        PL_C_locale_obj = newlocale(LC_ALL_MASK, "C", (locale_t) 0);
+    }
     if (! PL_C_locale_obj) {
         locale_panic_(Perl_form(aTHX_
                                 "Cannot create POSIX 2008 C locale object"));

--- a/perlvars.h
+++ b/perlvars.h
@@ -105,7 +105,7 @@ PERLVAR(G, locale_mutex, perl_mutex)   /* Mutex related to locale handling */
 #endif
 
 #ifdef USE_POSIX_2008_LOCALE
-PERLVAR(G, C_locale_obj, locale_t)
+PERLVARI(G, C_locale_obj, locale_t, NULL)
 #endif
 
 PERLVARI(G, watch_pvx,	char *, NULL)


### PR DESCRIPTION
PL_C_locale_obj is a global variable, and should be allocated just once per program.  Prior to this commit it could leak under MULTIPLICITY.  I was unable to get LSAN to notice this leak.