### PR TITLE
Harden @INC handling

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -232,6 +232,37 @@ XXX Changes (i.e. rewording) of diagnostic messages go here
 
 =item *
 
+The error message that is produced when a C<require> or C<use> statement
+fails has been changed. It used to contain the words C<@INC contains:>,
+and it used to show the state of C<@INC> *after* the require had
+completed and failed. The error message has been changed to say C<@INC
+entries checked:> and to reflect the actual directories or hooks that
+were executed during the require statement. For example:
+
+    perl -e'push @INC, sub {@INC=()}; eval "require Frobnitz"
+        or die $@'
+    Can't locate Frobnitz.pm in @INC (you may need to install the
+    Frobnitz module) (@INC contains:) at (eval 1) line 1.
+
+Will change to (with some output elided for clarity):
+
+    perl -e'push @INC, sub {@INC=()}; eval "require Frobnitz"
+        or die $@'
+    Can't locate Frobnitz.pm in @INC (you may need to install the
+    Frobnitz module) (@INC entries checked:
+    .../site_perl/5.37.7/x86_64-linux .../site_perl/5.37.7
+    .../5.37.7/x86_64-linux .../5.37.7 CODE(0x562745e684b8))
+    at (eval 1) line 1.
+
+thus showing the actual directories checked. Code that checks for
+C<@INC contains:> in error messages should be hardened against any future
+wording changes between the C<@INC> and C<:>, for instance use
+C<qr/\@INC[ \w]+:/> instead of using C<qr/\@INC contains:/> or
+C<qr/\@INC entries checked:/> in tests as this will ensure both forward
+and backward compatibility.
+
+=item *
+
 XXX Describe change here
 
 =back

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -35,6 +35,37 @@ the caller provided an undefined or false value (respectively), rather than
 simply when the parameter is missing entirely.  For more detail see the
 documentation in L<perlsub>.
 
+=head2 @INC Hook Enhancements and $INC and INCDIR
+
+The internals for C<@INC> hooks have been hardened to handle various
+edge cases and should no longer segfault or throw assert failures when
+hooks modify C<@INC> during a require operation.  As part of this we
+now ensure that any given hook is executed at most once during a require
+call, and that any duplicate directories do not trigger additional
+directories probes.
+
+To provide developers more control over dynamic module lookup a new hook
+method C<INCDIR> is now supported. An object supporting this method may be
+injected into the C<@INC> array, and when it is encountered in the module
+search process it will be executed, just like how INC hooks are executed,
+and its return value used as a list of directories to search for the
+module. Returning an empty list acts as a no-op. Note that any references
+returned by this hook will be stringified and used as strings, you may not
+return a hook to be executed later via this API.
+
+When an C<@INC> hook (either C<INC> or C<INCDIR>) is called during
+require the C<$INC> variable will be localized to be the value of the
+index of C<@INC> that the hook came from. If the hook wishes to override
+what the "next" index in C<@INC> should be it may update C<$INC> to be one
+less than the desired index (C<undef> is equivalent to C<-1>). This
+allows an C<@INC> hook to completely rewrite the C<@INC> array and have
+perl restart its directory probes from the beginning of C<@INC>.
+
+Blessed CODE references in C<@INC> that do not support the C<INC> or
+C<INCDIR> methods will no longer trigger an exception, and instead will
+be treated the same as unblessed coderefs are, and executed as though
+they were an C<INC> hook.
+
 =head1 Security
 
 XXX Any security-related notices go here.  In particular, any security

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -210,6 +210,11 @@ and New Warnings
 
 =item *
 
+L<Object with arguments in @INC does not support a hook method
+ |perldiag/"Object with arguments in @INC does not support a hook method">
+
+=item *
+
 XXX L<message|perldiag/"message">
 
 =back

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -4461,6 +4461,14 @@ and you mentioned a variable that starts with 0 that has more than one
 digit. You probably want to remove the leading 0, or if the intent was
 to express a variable name in octal you should convert to decimal.
 
+=item Object with arguments in @INC does not support a hook method
+
+(F) You pushed an array reference hook into C<@INC> which has an object
+as the first argument, but the object doesn't support any known hooks.
+Since you used the array form of creating a hook, you should have supplied
+an object that supports either the C<INC> or C<INCDIR> methods. You
+could also use a coderef instead of an object.
+
 =item Octal number > 037777777777 non-portable
 
 (W portable) The octal number you specified is larger than 2**32-1

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -6716,8 +6716,14 @@ would have semantics similar to the following:
             croak "Compilation failed in require";
         }
 
-        foreach $prefix (@INC) {
-            if (ref($prefix)) {
+        local $INC;
+        # this type of loop lets a hook overwrite $INC if they wish
+        for($INC = 0; $INC < @INC; $INC++) {
+            my $prefix = $INC[$INC];
+            if (!defined $prefix) {
+                next;
+            }
+            if (ref $prefix) {
                 #... do other stuff - see text below ....
             }
             # (see text below about possible appending of .pmc
@@ -6800,16 +6806,20 @@ F<.pmc> extension.  If this file is found, it will be loaded in place of
 any file ending in a F<.pm> extension. This applies to both the explicit
 C<require "Foo/Bar.pm";> form and the C<require Foo::Bar;> form.
 
-You can also insert hooks into the import facility by putting Perl code
-directly into the L<C<@INC>|perlvar/@INC> array.  There are three forms
-of hooks: subroutine references, array references, and blessed objects.
+You can also insert hooks into the import facility by putting Perl
+coderefs or objects directly into the L<C<@INC>|perlvar/@INC> array.
+There are two types of hooks, INC filters, and INCDIR hooks, and there
+are three forms of representing a hook: subroutine references, array
+references, and blessed objects.
 
 Subroutine references are the simplest case.  When the inclusion system
-walks through L<C<@INC>|perlvar/@INC> and encounters a subroutine, this
-subroutine gets called with two parameters, the first a reference to
-itself, and the second the name of the file to be included (e.g.,
-F<Foo/Bar.pm>).  The subroutine should return either nothing or else a
-list of up to four values in the following order:
+walks through L<C<@INC>|perlvar/@INC> and encounters a subroutine, unless
+this subroutine is blessed and supports an INCDIR hook this
+subroutine will be assumed to be an INC hook will be called with two
+parameters, the first a reference to itself, and the second the name of
+the file to be included (e.g., F<Foo/Bar.pm>).  The subroutine should
+return either nothing or else a list of up to four values in the
+following order:
 
 =over
 
@@ -6848,10 +6858,37 @@ Note that this filehandle must be a real filehandle (strictly a typeglob
 or reference to a typeglob, whether blessed or unblessed); tied filehandles
 will be ignored and processing will stop there.
 
-If the hook is an array reference, its first element must be a subroutine
-reference.  This subroutine is called as above, but the first parameter is
-the array reference.  This lets you indirectly pass arguments to
-the subroutine.
+If the hook is an object, it should provide an C<INC> or C<INCDIR>
+method that will be called as above, the first parameter being the
+object itself. If it does not provide either method, and the object is
+not CODE ref then an exception will be thrown, otherwise it will simply
+be executed like an unblessed CODE ref would. Note that you must fully
+qualify the method name when you declare an C<INC> sub (unlike the
+C<INCDIR> sub), as the unqualified symbol C<INC> is always forced into
+package C<main>.  Here is a typical code layout for an C<INC> hook:
+
+    # In Foo.pm
+    package Foo;
+    sub new { ... }
+    sub Foo::INC {
+        my ($self, $filename) = @_;
+        ...
+    }
+
+    # In the main program
+    push @INC, Foo->new(...);
+
+If the hook is an array reference, its first element must be a
+subroutine reference or an object as described above. When the first
+element is an object that supports an C<INC> or C<INCDIR> method then
+the method will be called with the object as the first argument, the
+filename requested as the second, and the hook array reference as the
+the third. When the first element is a subroutine then it will be
+called with the array as the first argument, and the filename as the
+second, no third parameter will be passed in. In both forms you can
+modify the contents of the array to provide state between calls, or
+whatever you like.
+
 
 In other words, you can write:
 
@@ -6871,24 +6908,66 @@ or:
         ...
     }
 
-If the hook is an object, it must provide an C<INC> method that will be
-called as above, the first parameter being the object itself.  (Note that
-you must fully qualify the sub's name, as unqualified C<INC> is always forced
-into package C<main>.)  Here is a typical code layout:
+or:
 
-    # In Foo.pm
-    package Foo;
-    sub new { ... }
-    sub Foo::INC {
-        my ($self, $filename) = @_;
+    push @INC, [ HookObj->new(), $x, $y, ... ];
+    sub HookObj::INC {
+        my ($self, $filename, $arrayref)= @_;
+        my (undef, @parameters) = @$arrayref;
         ...
     }
 
-    # In the main program
-    push @INC, Foo->new(...);
-
 These hooks are also permitted to set the L<C<%INC>|perlvar/%INC> entry
 corresponding to the files they have loaded.  See L<perlvar/%INC>.
+Should an C<INC> hook not do this then perl will set the C<%INC> entry
+to be the hook reference itself.
+
+A hook may also be used to rewrite the C<@INC> array. While this might
+sound strange, there are situations where it can be very useful to do
+this. Such hooks usually just return undef and do not mix filtering and
+C<@INC> modifications. While in older versions of perl having a hook
+modify C<@INC> was fraught with issues and could even result in
+segfaults or assert failures, as of 5.37.7 the logic has been made much
+more robust and the hook now has control over the loop iteration if it
+wishes to do so.
+
+There is a now a facility to control the iterator for the C<@INC> array
+traversal that is performed during require. The C<$INC> variable will be
+initialized with the index of the currently executing hook. Once the
+hook returns the next slot in C<@INC> that will be checked will be the
+integer successor of value in C<$INC> (or -1 if it is undef). For example
+the following code
+
+    push @INC, sub {
+        splice @INC, $INC, 1; # remove this hook from @INC
+        unshift @INC, sub { warn "A" };
+        undef $INC; # reset the $INC iterator so we
+                    # execute the newly installed sub
+                    # immediately.
+    };
+
+would install a sub into C<@INC> that when executed as a hook (by for
+instance a require of a file that does not exist), the hook will splice
+itself out of C<@INC>, and add a new sub to the front that will warn
+whenever someone does a require operation that requires an C<@INC>
+search, and then immediately execute that hook.
+
+Prior to 5.37.7, there was no way to cause perl to use the newly
+installed hook immediately, or to inspect any changed items in C<@INC> to
+the left of the iterator, and so the warning would only be generated on
+the second call to require. In more recent perl the presence of the last
+statement which undefines C<$INC> will cause perl to restart the
+traversal of the C<@INC> array at the beginning and execute the newly
+installed sub immediately.
+
+Whatever value C<$INC> held, if any, will be restored at the end of the
+require. Any changes made to C<$INC> during the lifetime of the hook
+will be unrolled after the hook exits, and its value only has meaning
+immediately after execution of the hook, thus setting C<$INC> to some
+value prior to executing a C<require> will have no effect on how the
+require executes at all.
+
+As of 5.37.7 C<@INC> values of undef will be silently ignored.
 
 For a yet-more-powerful import facility, see
 L<C<use>|/use Module VERSION LIST> and L<perlmod>.

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -542,6 +542,23 @@ by default inserted into C<%INC> in place of a filename.  Note, however,
 that the hook may have set the C<%INC> entry by itself to provide some more
 specific info.
 
+=item $INC
+X<$INC>
+
+As of 5.37.7 when an C<@INC> hook is executed the index of the C<@INC>
+array that holds the hook will be localized into the C<$INC> variable.
+When the hook returns the integer successor of its value will be used to
+determine the next index in C<@INC> that will be checked, thus if it is
+set to -1 (or C<undef>) the traversal over the C<@INC> array will be
+restarted from its beginning.
+
+Normally traversal through the C<@INC> array is from beginning to end
+(C<0 .. $#INC>), and if the C<@INC> array is modified by the hook the
+iterator may be left in a state where newly added entries are skipped.
+Changing this value allows an C<@INC> hook to rewrite the C<@INC> array
+and tell Perl where to continue afterwards. See L<perlfunc/require> for
+details on C<@INC> hooks.
+
 =item $INPLACE_EDIT
 
 =item $^I

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4294,7 +4294,7 @@ S_require_file(pTHX_ SV *sv)
                         SvSetSV_nosteal(nsv,sv);
                     }
 
-                    ENTER_with_name("call_INC");
+                    ENTER_with_name("call_INC_hook");
                     SAVETMPS;
                     EXTEND(SP, 2);
 
@@ -4374,7 +4374,7 @@ S_require_file(pTHX_ SV *sv)
 
                     PUTBACK;
                     FREETMPS;
-                    LEAVE_with_name("call_INC");
+                    LEAVE_with_name("call_INC_hook");
 
                     /* Now re-mortalize it. */
                     sv_2mortal(filter_cache);

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4260,16 +4260,16 @@ S_require_file(pTHX_ SV *sv)
      * For searchable paths, just search @INC normally
      */
     if (!tryrsfp && !(errno == EACCES && !path_searchable)) {
-        AV * const ar = GvAVn(PL_incgv);
-        SSize_t i;
+        AV * const inc_ar = GvAVn(PL_incgv);
+        SSize_t inc_idx;
 #ifdef VMS
         if (vms_unixname)
 #endif
         {
             SV *nsv = sv;
             namesv = newSV_type(SVt_PV);
-            for (i = 0; i <= AvFILL(ar); i++) {
-                SV * const dirsv = *av_fetch(ar, i, TRUE);
+            for (inc_idx = 0; inc_idx <= AvFILL(inc_ar); inc_idx++) {
+                SV * const dirsv = *av_fetch(inc_ar, inc_idx, TRUE);
 
                 SvGETMAGIC(dirsv);
                 if (SvROK(dirsv)) {

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4259,6 +4259,7 @@ S_require_file(pTHX_ SV *sv)
      *
      * For searchable paths, just search @INC normally
      */
+    AV *inc_checked = (AV*)sv_2mortal((SV*)newAV());
     if (!tryrsfp && !(errno == EACCES && !path_searchable)) {
         SSize_t inc_idx;
 #ifdef VMS
@@ -4269,9 +4270,21 @@ S_require_file(pTHX_ SV *sv)
             namesv = newSV_type(SVt_PV);
             AV *inc_ar = GvAVn(PL_incgv);
             for (inc_idx = 0; inc_idx <= AvFILL(inc_ar); inc_idx++) {
-                SV * const dirsv = *av_fetch(inc_ar, inc_idx, TRUE);
+                SV *dirsv = *av_fetch(inc_ar, inc_idx, TRUE);
 
-                SvGETMAGIC(dirsv);
+                if (SvGMAGICAL(dirsv)) {
+                    SvGETMAGIC(dirsv);
+                    dirsv = newSVsv_nomg(dirsv);
+                } else {
+                    /* on the other hand, since we aren't copying we do need
+                     * to increment */
+                    SvREFCNT_inc(dirsv);
+                }
+                if (!SvOK(dirsv))
+                    continue;
+
+                av_push(inc_checked, dirsv);
+
                 if (SvROK(dirsv)) {
                     int count;
                     SV **svp;
@@ -4536,14 +4549,15 @@ S_require_file(pTHX_ SV *sv)
                 DIE(aTHX_ "Can't locate %s:   %s: %s",
                     name, tryname, Strerror(saved_errno));
             } else {
-                if (path_searchable) {		/* did we lookup @INC? */
-                    AV * const ar = GvAVn(PL_incgv);
+                if (path_searchable) {          /* did we lookup @INC? */
                     SSize_t i;
                     SV *const msg = newSVpvs_flags("", SVs_TEMP);
                     SV *const inc = newSVpvs_flags("", SVs_TEMP);
-                    for (i = 0; i <= AvFILL(ar); i++) {
+                    for (i = 0; i <= AvFILL(inc_checked); i++) {
+                        SV **svp= av_fetch(inc_checked, i, TRUE);
+                        if (!svp || !*svp) continue;
                         sv_catpvs(inc, " ");
-                        sv_catsv(inc, *av_fetch(ar, i, TRUE));
+                        sv_catsv(inc, *svp);
                     }
                     if (memENDPs(name, len, ".pm")) {
                         const char *e = name + len - (sizeof(".pm") - 1);
@@ -4597,7 +4611,7 @@ S_require_file(pTHX_ SV *sv)
 
                     /* diag_listed_as: Can't locate %s */
                     DIE(aTHX_
-                        "Can't locate %s in @INC%" SVf " (@INC contains:%" SVf ")",
+                        "Can't locate %s in @INC%" SVf " (@INC entries checked:%" SVf ")",
                         name, msg, inc);
                 }
             }

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4319,11 +4319,6 @@ S_require_file(pTHX_ SV *sv)
                         SvGETMAGIC(loader);
                     }
 
-                    Perl_sv_setpvf(aTHX_ namesv, "/loader/0x%" UVxf "/%s",
-                                   diruv, name);
-                    tryname = SvPVX_const(namesv);
-                    tryrsfp = NULL;
-
                     if (SvPADTMP(nsv)) {
                         nsv = sv_newmortal();
                         SvSetSV_nosteal(nsv,sv);
@@ -4369,6 +4364,11 @@ S_require_file(pTHX_ SV *sv)
                             }
                         }
                     }
+
+                    Perl_sv_setpvf(aTHX_ namesv, "/loader/0x%" UVxf "/%s",
+                                   diruv, name);
+                    tryname = SvPVX_const(namesv);
+                    tryrsfp = NULL;
 
                     ENTER_with_name("call_INC_hook");
                     SAVETMPS;

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4266,11 +4266,32 @@ S_require_file(pTHX_ SV *sv)
         if (vms_unixname)
 #endif
         {
-            SV *nsv = sv;
+            AV *incdir_av = (AV*)sv_2mortal((SV*)newAV());
+            SV *nsv = sv; /* non const copy we can change if necessary */
             namesv = newSV_type(SVt_PV);
             AV *inc_ar = GvAVn(PL_incgv);
-            for (inc_idx = 0; inc_idx <= AvFILL(inc_ar); inc_idx++) {
-                SV *dirsv = *av_fetch(inc_ar, inc_idx, TRUE);
+            SSize_t incdir_continue_inc_idx = -1;
+
+            for (
+                inc_idx = 0;
+                (AvFILL(incdir_av)>=0 /* we have INCDIR items pending */
+                    || inc_idx <= AvFILL(inc_ar));  /* @INC entries remain */
+                inc_idx++
+            ) {
+                SV *dirsv;
+
+                /* do we have any pending INCDIR items? */
+                if (AvFILL(incdir_av)>=0) {
+                    /* yep, shift it out */
+                    dirsv = av_shift(incdir_av);
+                    if (AvFILL(incdir_av)<0) {
+                        /* incdir is now empty, continue from where
+                         * we left off after we process this entry  */
+                        inc_idx = incdir_continue_inc_idx;
+                    }
+                } else {
+                    dirsv = *av_fetch(inc_ar, inc_idx, TRUE);
+                }
 
                 if (SvGMAGICAL(dirsv)) {
                     SvGETMAGIC(dirsv);
@@ -4289,6 +4310,7 @@ S_require_file(pTHX_ SV *sv)
                     int count;
                     SV **svp;
                     SV *loader = dirsv;
+                    UV diruv = PTR2UV(SvRV(dirsv));
 
                     if (SvTYPE(SvRV(loader)) == SVt_PVAV
                         && !SvOBJECT(SvRV(loader)))
@@ -4298,7 +4320,7 @@ S_require_file(pTHX_ SV *sv)
                     }
 
                     Perl_sv_setpvf(aTHX_ namesv, "/loader/0x%" UVxf "/%s",
-                                   PTR2UV(SvRV(dirsv)), name);
+                                   diruv, name);
                     tryname = SvPVX_const(namesv);
                     tryrsfp = NULL;
 
@@ -4308,6 +4330,7 @@ S_require_file(pTHX_ SV *sv)
                     }
 
                     const char *method = NULL;
+                    bool is_incdir = FALSE;
                     SV * inc_idx_sv = save_scalar(PL_incgv);
                     sv_setiv(inc_idx_sv,inc_idx);
                     if (sv_isobject(loader)) {
@@ -4318,6 +4341,12 @@ S_require_file(pTHX_ SV *sv)
                         GV * gv = gv_fetchmethod_pvn_flags(pkg, "INC", 3, 0);
                         if (gv && isGV(gv)) {
                             method = "INC";
+                        } else {
+                            gv = gv_fetchmethod_pvn_flags(pkg, "INCDIR", 6, 0);
+                            if (gv && isGV(gv)) {
+                                method = "INCDIR";
+                                is_incdir = TRUE;
+                            }
                         }
                         /* But if we have no method, check if this is a
                          * coderef, if it is then we treat it as an
@@ -4367,6 +4396,48 @@ S_require_file(pTHX_ SV *sv)
                         SV *arg;
 
                         SP -= count - 1;
+
+                        if (is_incdir) {
+                            /* push the stringified returned items into the
+                             * incdir_av array for processing immediately
+                             * afterwards. we deliberately stringify or copy
+                             * "special" arguments, so that overload logic for
+                             * instance applies, but so that the end result is
+                             * stable. We speficially do *not* support returning
+                             * coderefs from an INCDIR call. */
+                            while (count-->0) {
+                                arg = SP[i++];
+                                SvGETMAGIC(arg);
+                                if (!SvOK(arg))
+                                    continue;
+                                if (SvROK(arg)) {
+                                    STRLEN l;
+                                    char *pv = SvPV(arg,l);
+                                    arg = newSVpvn(pv,l);
+                                }
+                                else if (SvGMAGICAL(arg)) {
+                                    arg = newSVsv_nomg(arg);
+                                }
+                                else {
+                                    SvREFCNT_inc(arg);
+                                }
+                                av_push(incdir_av, arg);
+                            }
+                            /* We copy $INC into incdir_continue_inc_idx
+                             * so that when we finish processing the items
+                             * we just inserted into incdir_av we can continue
+                             * as though we had just finished executing the INCDIR
+                             * hook. We honour $INC here just like we would for
+                             * an INC hook, the hook might have rewritten @INC
+                             * at the same time as returning something to us.
+                             */
+                            inc_idx_sv = GvSVn(PL_incgv);
+                            incdir_continue_inc_idx = SvOK(inc_idx_sv)
+                                                      ? SvIV(inc_idx_sv) : -1;
+
+                            goto done_hook;
+                        }
+
                         arg = SP[i++];
 
                         if (SvROK(arg) && (SvTYPE(SvRV(arg)) <= SVt_PVLV)
@@ -4415,6 +4486,7 @@ S_require_file(pTHX_ SV *sv)
                             tryrsfp = PerlIO_open(BIT_BUCKET,
                                                   PERL_SCRIPT_MODE);
                         }
+                        done_hook:
                         SP--;
                     } else {
                         SV *errsv= ERRSV;

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4307,25 +4307,55 @@ S_require_file(pTHX_ SV *sv)
                         SvSetSV_nosteal(nsv,sv);
                     }
 
+                    const char *method = NULL;
                     SV * inc_idx_sv = save_scalar(PL_incgv);
                     sv_setiv(inc_idx_sv,inc_idx);
+                    if (sv_isobject(loader)) {
+                        /* if it is an object and it has an INC method, then
+                         * call the method.
+                         */
+                        HV *pkg = SvSTASH(SvRV(loader));
+                        GV * gv = gv_fetchmethod_pvn_flags(pkg, "INC", 3, 0);
+                        if (gv && isGV(gv)) {
+                            method = "INC";
+                        }
+                        /* But if we have no method, check if this is a
+                         * coderef, if it is then we treat it as an
+                         * unblessed coderef would be treated: we
+                         * execute it. If it is some other and it is in
+                         * an array ref wrapper, then really we don't
+                         * know what to do with it, (why use the
+                         * wrapper?) and we throw an exception to help
+                         * debug. If it is not in a wrapper assume it
+                         * has an overload and treat it as a string.
+                         * Maybe in the future we can detect if it does
+                         * have overloading and throw an error if not.
+                         */
+                        if (!method) {
+                            if (SvTYPE(SvRV(loader)) != SVt_PVCV) {
+                                if (dirsv != loader)
+                                    croak("Object with arguments in @INC does not support a hook method");
+                                else
+                                    goto treat_as_string;
+                            }
+                        }
+                    }
 
                     ENTER_with_name("call_INC_hook");
                     SAVETMPS;
-                    EXTEND(SP, 2);
-
+                    EXTEND(SP, 2 + ((method && (loader != dirsv)) ? 1 : 0));
                     PUSHMARK(SP);
-                    PUSHs(dirsv);
+                    PUSHs(method ? loader : dirsv); /* always use the object for method calls */
                     PUSHs(nsv);
+                    if (method && (loader != dirsv)) /* add the args array for method calls */
+                        PUSHs(dirsv);
                     PUTBACK;
                     if (SvGMAGICAL(loader)) {
                         SV *l = sv_newmortal();
                         sv_setsv_nomg(l, loader);
                         loader = l;
                     }
-                    const char *method = NULL;
-                    if (sv_isobject(loader)) {
-                        method = "INC";
+                    if (method) {
                         count = call_method(method, G_LIST|G_EVAL);
                     } else {
                         count = call_sv(loader, G_LIST|G_EVAL);
@@ -4482,12 +4512,13 @@ S_require_file(pTHX_ SV *sv)
                         filter_sub = NULL;
                     }
                 }
-                else if (path_searchable) {
+                else
+                    treat_as_string:
+                    if (path_searchable) {
                     /* match against a plain @INC element (non-searchable
                      * paths are only matched against refs in @INC) */
                     const char *dir;
                     STRLEN dirlen;
-
                     if (SvOK(dirsv)) {
                         dir = SvPV_nomg_const(dirsv, dirlen);
                     } else {

--- a/t/op/inccode.t
+++ b/t/op/inccode.t
@@ -399,7 +399,6 @@ if ($can_fork) {
 }
 SKIP:{
     skip "need fork",1 unless $can_fork;
-    local $::TODO = "Pending";
     fresh_perl_like('@INC=("A",bless({},"Hook"),"D"); '
                  .'sub Hook::INCDIR { return "B","C"} '
                  .'eval "require Frobnitz" or print $@;',

--- a/t/op/inccode.t
+++ b/t/op/inccode.t
@@ -294,18 +294,14 @@ SKIP: {
     $$t = sub { $called ++; !1 };
     delete $INC{'foo.pm'}; # in case another test uses foo
     eval { require foo };
-    { local $::TODO = "Will be fixed in a follow up patch";
     is $INCtie::count, 1,
         'FETCH is called once on undef scalar-tied @INC elem';
-    }
     is $called, 1, 'sub in scalar-tied @INC elem is called';
     () = "$INC[0]"; # force a fetch, so the SV is ROK
     $INCtie::count = 0;
     eval { require foo };
-    { local $::TODO = "Will be fixed in a follow up patch";
     is $INCtie::count, 1,
         'FETCH is called once on scalar-tied @INC elem holding ref';
-    }
     is $called, 2, 'sub in scalar-tied @INC elem holding ref is called';
     $$t = [];
     $INCtie::count = 0;
@@ -315,10 +311,8 @@ SKIP: {
     $$t = "string";
     $INCtie::count = 0;
     eval { require foo };
-    { local $::TODO = "Will be fixed in a follow up patch";
     is $INCtie::count, 1,
        'FETCH called once on scalar-tied @INC elem returning string';
-    }
 }
 
 
@@ -409,7 +403,7 @@ SKIP:{
     fresh_perl_like('@INC=("A",bless({},"Hook"),"D"); '
                  .'sub Hook::INCDIR { return "B","C"} '
                  .'eval "require Frobnitz" or print $@;',
-                  qr/\(\@INC contains: A Hook=HASH\(0x[A-Fa-f0-9]+\) B C D\)/,
+                  qr/\(\@INC[\w ]+: A Hook=HASH\(0x[A-Fa-f0-9]+\) B C D\)/,
                   {},
                   "Check if INCDIR hook works as expected");
 }

--- a/t/op/require_errors.t
+++ b/t/op/require_errors.t
@@ -330,7 +330,6 @@ like $@, qr/^Can't locate \Q$nonsearch\E at/,
         { }, 'INC hooks that overwrite @INC continue as expected (skips a and z)');
 }
 {
-    local $::TODO = "Pending new feature \$INC";
     # as of 5.37.7
     fresh_perl_like(
         '@INC = (sub { @INC=qw(a b); undef $INC }, "z"); '

--- a/t/op/require_errors.t
+++ b/t/op/require_errors.t
@@ -338,7 +338,6 @@ like $@, qr/^Can't locate \Q$nonsearch\E at/,
         { }, 'INC hooks that overwrite @INC and undef $INC continue at start');
 }
 {
-    local $::TODO = "Pending new feature: INCDIR";
     # as of 5.37.7
     fresh_perl_like(
         'sub CB::INCDIR { return "b", "c","d" }; '
@@ -398,7 +397,6 @@ like $@, qr/^Can't locate \Q$nonsearch\E at/,
         { }, 'Blessed objects with no hook methods in array form produce expected exception');
 }
 {
-    local $::TODO = "Pending new feature: INCDIR";
     # as of 5.37.7
     fresh_perl_like(
         'sub CB::INCDIR { "i" } sub CB2::INCDIR { }'
@@ -408,7 +406,6 @@ like $@, qr/^Can't locate \Q$nonsearch\E at/,
         { }, 'Blessed subs with INCDIR methods call INCDIR');
 }
 {
-    local $::TODO = "Pending new feature: INCDIR";
     # as of 5.37.7
     fresh_perl_like(
         'sub CB::INCDIR { return @{$_[2]} }'

--- a/t/op/require_errors.t
+++ b/t/op/require_errors.t
@@ -348,7 +348,6 @@ like $@, qr/^Can't locate \Q$nonsearch\E at/,
         { }, 'INCDIR works as expected');
 }
 {
-    local $::TODO = "Pending object handling improvements";
     # as of 5.37.7
     fresh_perl_like(
         '@INC = ("a",bless({},"CB"),"e");'
@@ -357,7 +356,6 @@ like $@, qr/^Can't locate \Q$nonsearch\E at/,
         { }, 'Objects with no INC or INCDIR method are stringified');
 }
 {
-    local $::TODO = "Pending object handling improvements";
     # as of 5.37.7
     fresh_perl_like(
         '{package CB; use overload qw("")=>sub { "blorg"};} '
@@ -367,7 +365,6 @@ like $@, qr/^Can't locate \Q$nonsearch\E at/,
         { }, 'Objects with overload and no INC or INCDIR method are stringified');
 }
 {
-    local $::TODO = "Pending object handling improvments";
     # as of 5.37.7
     fresh_perl_like(
         '@INC = ("a",bless(sub { warn "blessed sub called" },"CB"),"e");'
@@ -376,7 +373,6 @@ like $@, qr/^Can't locate \Q$nonsearch\E at/,
         { }, 'Blessed subs with no hook methods are executed');
 }
 {
-    local $::TODO = "Pending better error messages (eval)";
     # as of 5.37.7
     fresh_perl_like(
         '@INC = ("a",bless(sub { die "blessed sub called" },"CB"),"e");'
@@ -394,7 +390,6 @@ like $@, qr/^Can't locate \Q$nonsearch\E at/,
         { }, 'Blessed subs with methods call method and produce expected message');
 }
 {
-    local $::TODO = "Pending object handling improvments";
     # as of 5.37.7
     fresh_perl_like(
         '@INC = ("a",[bless([],"CB"),1],"e");'

--- a/t/op/require_errors.t
+++ b/t/op/require_errors.t
@@ -388,7 +388,6 @@ like $@, qr/^Can't locate \Q$nonsearch\E at/,
         { }, 'Blessed subs that die produce expected extra message');
 }
 {
-    local $::TODO = "Pending better error messages (eval)";
     # as of 5.37.7
     fresh_perl_like(
         'sub CB::INC { die "bad mojo" } '

--- a/t/porting/podcheck.t
+++ b/t/porting/podcheck.t
@@ -1135,7 +1135,8 @@ package My::Pod::Checker {      # Extend Pod::Checker
 
             $self->poderror({ -line => $start_line{$addr} + $i,
                 -msg => $line_length,
-                parameter => "+$exceeds (including " . ($indent - $INDENT) . " from =over's)",
+                parameter => "+$exceeds (including " . ($indent - $INDENT) .
+                             " from =over's and $INDENT as base indent)",
             });
         }
 


### PR DESCRIPTION
This hardens `@INC` hook handling in a bunch of ways. It ensures error message show the truth, and it fixes segfaults, and other bugs, and it adds new facilities to INC hooks, ($SKIP and INCDIR)

Features (not bugfixes) in this PR:

- Add support for `$SKIP` this variable is set to the index of @INC that a hook exists in before the hook is executed. The hook may alter the value to set it to the integer predecessor of the index they want perl to look at next. Thus a hook that rewrites `@INC` can set `$SKIP` to -1 and have perl process the replaced contents. undef is supported to represent -1.
- Ensure that errors show the `@INC` entries inspected or called, and not the latest state of `@INC` which may not match at all.
- Add an INCDIR method, which is called just like an INC hook would be, but which can return a list of directories that perl will search. Returning zero directories is allowed.
- Add support for providing an object as the first argument of array style hook definitions. In this case we will pass the array in as the third argument so we can execute the call_method() with the object as the first argument.

Bugfixes:
- Fixes a segfault when an INC hook does something like this: `*INC=[ "foo", "bar", "baz"];`
- Error message being incorrect about what directories were inspected. For instance `push @INC, sub { @INC=() }`, will trigger right at the end of the @INC search, and the error message will say that we searched no directories, when in fact we searched the normal list.
- Allow blessed subrefs with no INC or INCDIR methods defined to be treated as unblessed coderefs.
- Allow blessed refs with no INC or INCDIR methods to be used in `@INC` so their overloads are triggered.

This should resolve all the conceptual issues raised in https://github.com/Perl/perl5/issues/20538

Edited: removed dedupe logic discussed below.