### PR TITLE
POSIX::localeconv: Return empty values

### DIFF
--- a/ext/POSIX/t/posix.t
+++ b/ext/POSIX/t/posix.t
@@ -373,10 +373,9 @@ SKIP: {
 		currency_symbol mon_decimal_point mon_thousands_sep
 		mon_grouping positive_sign negative_sign)) {
     SKIP: {
-	    skip("localeconv has no result for $_", 1)
-		unless exists $conv->{$_};
-	    unlike(delete $conv->{$_}, qr/\A\z/,
-		   "localeconv returned a non-empty string for $_");
+	    my $value = delete $conv->{$_};
+	    skip("localeconv '$_' may be empty", 1) if $_ ne 'decimal_point';
+	    isnt($value, "", "localeconv returned a non-empty string for $_");
 	}
     }
 
@@ -399,8 +398,6 @@ SKIP: {
 
     foreach (@lconv) {
     SKIP: {
-	    skip("localeconv has no result for $_", 1)
-		unless exists $conv->{$_};
 	    like(delete $conv->{$_}, qr/\A-?\d+\z/,
 		 "localeconv returned an integer for $_");
 	}

--- a/locale.c
+++ b/locale.c
@@ -3496,7 +3496,7 @@ S_populate_localeconv(pTHX_ const struct lconv *lcbuf,
 
         while (strings->name) {
             const char *value = *((const char **)(ptr + strings->offset));
-            if (value && *value) {
+            if (value) {
                 bool is_utf8 =  /* Only make UTF-8 if required to */
                     (UTF8NESS_YES == (get_locale_string_utf8ness_i(locale,
                                                               cat_index,
@@ -3516,8 +3516,7 @@ S_populate_localeconv(pTHX_ const struct lconv *lcbuf,
     while (integers->name) {
         const char value = *((const char *)(ptr + integers->offset));
 
-        if (value != CHAR_MAX)
-            (void) hv_store(retval, integers->name,
+        (void) hv_store(retval, integers->name,
                             strlen(integers->name), newSViv(value), 0);
         integers++;
     }


### PR DESCRIPTION
This function returns a hash allowing Perl access to the localeconv() data structure, with the keys being the structure's field names, and the values being their corresponding value in the current locale.

Prior to this commit, it did not populate the hash with any keys whose values are the empty string.  But this is wrong.  Those fields exist, and are explicitly allowed to be empty, except for the decimal point. For example, the symbol indicating a number is positive is empty in many locales.  Someone might want to look up that value, and discover it is undefined.  Or they might want to iterate over all the keys in the hash.

I couldn't find a reason in the history why these are omitted, and it seems to me to be wrong to omit them.