### PR TITLE
loc_tools.pl: Add ability to skip known bad locales

### DIFF
--- a/t/loc_tools.pl
+++ b/t/loc_tools.pl
@@ -17,7 +17,8 @@ use feature 'state';
 
 my %known_bad_locales = (   # XXX eventually will need version info if and
                             # when these get fixed.
-                        );
+    solaris => [ 'vi_VN.UTF-8', ],  # Use of U+A8 segfaults: GH #20578
+);
 
 eval { require POSIX; import POSIX 'locale_h'; };
 my $has_locale_h = ! $@;

--- a/t/loc_tools.pl
+++ b/t/loc_tools.pl
@@ -15,6 +15,10 @@ use strict;
 use warnings;
 use feature 'state';
 
+my %known_bad_locales = (   # XXX eventually will need version info if and
+                            # when these get fixed.
+                        );
+
 eval { require POSIX; import POSIX 'locale_h'; };
 my $has_locale_h = ! $@;
 
@@ -156,6 +160,11 @@ sub _trylocale ($$$$) { # For use only by other functions in this file!
     # locales, as it may work out for them (or not).
     return if    defined $Config{d_setlocale_accepts_any_locale_name}
               && $locale !~ / ^ (?: C | POSIX | C\.UTF-8 ) $/ix;
+
+    if (exists $known_bad_locales{$^O}) {
+        my @bad_locales = $known_bad_locales{$^O}->@*;
+        return if grep { $locale eq $_ } @bad_locales;
+    }
 
     $categories = [ $categories ] unless ref $categories;
 


### PR DESCRIPTION
Some platforms have locales that shouldn't be used.  This adds code to
avoid using such when looking at all the locales on a platform.

The next commit will add the first use.