### PR TITLE
Replace SvGROW with sv_grow_fresh in perl.c, pp_sys.c, toke.c

### DIFF
--- a/perl.c
+++ b/perl.c
@@ -3554,8 +3554,8 @@ Perl_moreswitches(pTHX_ const char *s)
                    numlen = 0;
                    s--;
               }
-              PL_rs = newSVpvs("");
-              tmps = (U8*) SvGROW(PL_rs, (STRLEN)(UVCHR_SKIP(rschar) + 1));
+              PL_rs = newSV((STRLEN)(UVCHR_SKIP(rschar) + 1));
+              tmps = (U8*)SvPVCLEAR_FRESH(PL_rs);
               uvchr_to_utf8(tmps, rschar);
               SvCUR_set(PL_rs, UVCHR_SKIP(rschar));
               SvUTF8_on(PL_rs);

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -1854,9 +1854,8 @@ PP(pp_sysread)
            reading to:  */
         SvCUR_set(bufsv, offset);
 
-        read_target = sv_newmortal();
-        SvUPGRADE(read_target, SVt_PV);
-        buffer = SvGROW(read_target, (STRLEN)(length + 1));
+        read_target = newSV_type_mortal(SVt_PV);
+        buffer = sv_grow_fresh(read_target, (STRLEN)(length + 1));
     }
 
     if (PL_op->op_type == OP_SYSREAD) {

--- a/toke.c
+++ b/toke.c
@@ -11472,7 +11472,7 @@ Perl_scan_str(pTHX_ char *start, int keep_bracketed_quoted, int keep_delims, int
     /* create a new SV to hold the contents.  79 is the SV's initial length.
        What a random number. */
     sv = newSV_type(SVt_PVIV);
-    SvGROW(sv, 79);
+    sv_grow_fresh(sv, 79);
     SvIV_set(sv, close_delim_code);
     (void)SvPOK_only(sv);		/* validate pointer */
 


### PR DESCRIPTION
Changed:
 * _perl.c_ - `Perl_moreswitches`
 * _pp_sys.c_ - `pp_sysread`
 * _toke.c_ - `Perl_scan_str`

In each of the above functions, one instance of `SvGROW` on a new `SVt_PV` can be swapped for the more efficient `sv_grow_fresh`. In two of the instances, the calls used to create the the `SVt_PV` have also been streamlined.

There should not be any functional change as a result of this commit.