### PR TITLE
Move assert from perl.c to perlmain.c and miniperlmain.c

### DIFF
--- a/ext/ExtUtils-Miniperl/lib/ExtUtils/Miniperl.pm
+++ b/ext/ExtUtils-Miniperl/lib/ExtUtils/Miniperl.pm
@@ -5,7 +5,7 @@ use Exporter 'import';
 use ExtUtils::Embed 1.31, qw(xsi_header xsi_protos xsi_body);
 
 our @EXPORT = qw(writemain);
-our $VERSION = '1.12';
+our $VERSION = '1.13';
 
 # blead will run this with miniperl, hence we can't use autodie or File::Temp
 my $temp;
@@ -135,8 +135,29 @@ main(int argc, char **argv, char **env)
 	PL_perl_destruct_level = 0;
     }
     PL_exit_flags |= PERL_EXIT_DESTRUCT_END;
-    if (!perl_parse(my_perl, xs_init, argc, argv, (char **)NULL))
+    if (!perl_parse(my_perl, xs_init, argc, argv, (char **)NULL)) {
+
+        /* perl_parse() may end up starting its own run loops, which
+         * might end up "leaking" PL_restartop from the parse phase into
+         * the run phase which then ends up confusing run_body(). This
+         * leakage shouldn't happen and if it does its a bug.
+         *
+         * Note we do not do this assert in perl_run() or perl_parse()
+         * as there are modules out there which explicitly set
+         * PL_restartop before calling perl_run() directly from XS code
+         * (Coro), and it is conceivable PL_restartop could be set prior
+         * to calling perl_parse() by XS code as well.
+         *
+         * What we want to check is that the top level perl_parse(),
+         * perl_run() pairing does not allow a leaking PL_restartop, as
+         * that indicates a bug in perl. By putting the assert here we
+         * can validate that Perl itself is operating correctly without
+         * risking breakage to XS code under DEBUGGING. - Yves
+         */
+        assert(!PL_restartop);
+
         perl_run(my_perl);
+    }
 
 #ifndef PERL_MICRO
     /* Unregister our signal handler before destroying my_perl */

--- a/perl.c
+++ b/perl.c
@@ -2706,11 +2706,6 @@ perl_run(pTHXx)
 #ifndef MULTIPLICITY
     PERL_UNUSED_ARG(my_perl);
 #endif
-    /* perl_parse() may end up starting its own run loops, which might end
-     * up "leaking" PL_restartop from the parse phase into the run phase
-     * which then ends up confusing run_body(). This leakage shouldn't
-     * happen and if it does its a bug. */
-    assert(!PL_restartop);
 
     oldscope = PL_scopestack_ix;
 #ifdef VMS

--- a/regen.pl
+++ b/regen.pl
@@ -25,6 +25,7 @@ __END__
 embed.pl
 feature.pl
 mg_vtable.pl
+miniperlmain.pl
 opcode.pl
 overload.pl
 reentr.pl

--- a/regen.pl
+++ b/regen.pl
@@ -22,12 +22,12 @@ foreach my $pl (map {chomp; "regen/$_"} <DATA>) {
 }
 
 __END__
+embed.pl
+feature.pl
 mg_vtable.pl
 opcode.pl
 overload.pl
 reentr.pl
 regcomp.pl
-warnings.pl
-embed.pl
-feature.pl
 scope_types.pl
+warnings.pl

--- a/t/porting/regen.t
+++ b/t/porting/regen.t
@@ -26,7 +26,7 @@ if ( $Config{usecrosscompile} ) {
   skip_all( "Not all files are available during cross-compilation" );
 }
 
-my $tests = 25; # I can't see a clean way to calculate this automatically.
+my $tests = 26; # I can't see a clean way to calculate this automatically.
 
 my %skip = ("regen_perly.pl"    => [qw(perly.act perly.h perly.tab)],
             "regen/keywords.pl" => [qw(keywords.c keywords.h)],


### PR DESCRIPTION
The assert breaks Coro. Whether Coro is doing something dodgy is up to its author and future investigation, the assert was placed with an assumption that perl_run() would get called once after perl_parse(), and PL_restartop shouldnt leak, and Coro shows that isnt true, so moving the assert makes sense. 

Also adds miniperlmain.pl to regen.pl so that it gets run by make regen, it is fast so there is no point in it being manual.

This should fix #20557

