### PR TITLE
locale.c: Save to proper buffer

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -4071,9 +4071,7 @@ S_my_langinfo_i(pTHX_
             /* Everything in between is the radix string */
             if (LIKELY(s < e)) {
                 *s = '\0';
-                retval = save_to_buffer(item_start,
-                                        (const char **) &PL_langinfo_buf,
-                                        &PL_langinfo_bufsize);
+                retval = save_to_buffer(item_start, retbufp, retbuf_sizep);
                 Safefree(floatbuf);
 
                 if (utf8ness) {


### PR DESCRIPTION
This was using a particular buffer to save to, rather than the one it was supposed to, passed into the function.

This bug only manifests itself in Windows Visual Studio prior to 2015, and to platforms (unlikely to exist) without the localeconv() system call.