### PR TITLE
locale.c: Use wrap_wsetlocale on Windows

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -2652,7 +2652,7 @@ S_win32_setlocale(pTHX_ int category, const char* locale)
         PL_cur_LC_ALL = savepv(result);
     }
     else {
-        PL_cur_LC_ALL = savepv(setlocale(LC_ALL, NULL));
+        PL_cur_LC_ALL = savepv(wrap_wsetlocale(LC_ALL, NULL));
     }
 
 #  endif


### PR DESCRIPTION
This was the final remaining use of plain setlocale() on Windows.  All others have been converted to wrap_wsetlocale, introduced in 6c3320363f6cd734c66a25852aac87e4f2538215.

There is no issue with the input name in this instance, since it is NULL and not a character string, but it occurred to me that the locale name returned by the function could be problematic.  _wsetlocale() should be safe in all cases.