### PR TITLE
locale.c: Add mutex lock around _wsetlocale() call

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -2600,14 +2600,18 @@ S_wrap_wsetlocale(pTHX_ const int category, const char *locale)
         }
     }
 
+    WSETLOCALE_LOCK;
     const wchar_t * wresult = _wsetlocale(category, wlocale);
     Safefree(wlocale);
 
     if (! wresult) {
+        WSETLOCALE_UNLOCK;
         return NULL;
     }
 
     const char * result = Win_wstring_to_utf8_string(wresult);
+    WSETLOCALE_UNLOCK;
+
     SAVEFREEPV(result); /* is there something better we can do here? */
 
     return result;

--- a/perl.h
+++ b/perl.h
@@ -7128,6 +7128,10 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  define POSIX_SETLOCALE_UNLOCK    gwLOCALE_UNLOCK
 #endif
 
+/* It handles _wsetlocale() as well */
+#define WSETLOCALE_LOCK      POSIX_SETLOCALE_LOCK
+#define WSETLOCALE_UNLOCK    POSIX_SETLOCALE_UNLOCK
+
 /* Similar to gwLOCALE_LOCK, there are functions that require both the locale
  * and environment to be constant during their execution, and don't change
  * either of those things, but do write to some sort of shared global space.


### PR DESCRIPTION
The lock expands to nothing if unthreaded, or thread-local storage is in effect.  But otherwise protects a global value from being clobbered by another thread.