### PR TITLE
Fix double FETCH from tied overloaded scalar

### DIFF
--- a/lib/overload.t
+++ b/lib/overload.t
@@ -1906,7 +1906,7 @@ foreach my $op (qw(<=> == != < <= > >=)) {
 
 	# eval should do tie, overload on its arg before checking taint */
 	push @tests, [ '1;', 'eval q(eval %s); $@ =~ /Insecure/',
-		'("")', '("")', [ 1, 2, 0 ], 0 ];
+		'("")', '("")', [ 1, 1, 0 ], 0 ];
 
 
 	for my $sub (keys %subs) {

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -395,6 +395,12 @@ Also, embedded C<NUL> characters are now allowed in the input.
 If locale collation is not enabled on the platform (C<LC_COLLATE>), the
 input is returned unchanged.
 
+=item *
+
+Double FETCH during stringification of tied scalars returning an
+overloaded object have been fixed. The FETCH method should only be
+called once, but prior to this release was actually called twice.
+
 =back
 
 =head1 Known Problems


### PR DESCRIPTION
Use a copy of the tied sv in the case where the result is an overloaded object.

This likely breaks assignment to $_[0] in overloaded methods. Whether that is a bad thing is debatable. 

See: https://github.com/Perl/perl5/issues/20574