### PR TITLE
pod2html:  Group '*' and 'no*' switches in documentation

### DIFF
--- a/ext/Pod-Html/bin/pod2html
+++ b/ext/Pod-Html/bin/pod2html
@@ -28,15 +28,10 @@ pod2html takes the following arguments:
 =item backlink
 
   --backlink
-
-Turn =head1 directives into links pointing to the top of the HTML file.
-
-=item nobacklink
-
   --nobacklink
 
-Do not turn =head1 directives into links pointing to the top of the HTML file
-(default behaviour).
+Turn =head1 directives into links pointing to the top of the HTML file.
+--nobacklink (which is the default behavior) does not create these backlinks.
 
 =item cachedir
 
@@ -61,15 +56,11 @@ Flush the cache.
 =item header
 
   --header
-
-Create header and footer blocks containing the text of the "NAME" section.
-
-=item noheader
-
   --noheader
 
-Do not create header and footer blocks containing the text of the "NAME"
-section (default behaviour).
+Create header and footer blocks containing the text of the "NAME" section.
+--noheader -- which is the default behavior -- does not create header or footer
+blocks.
 
 =item help
 
@@ -105,11 +96,15 @@ Do not pass both this and --htmldir to pod2html; they are mutually exclusive.
 
 Generate an index at the top of the HTML file (default behaviour).
 
+=over 4
+
 =item noindex
 
   --noindex
 
 Do not generate an index at the top of the HTML file.
+
+=back
 
 =item infile
 
@@ -128,16 +123,11 @@ is specified.
 =item poderrors
 
   --poderrors
-
-Include a "POD ERRORS" section in the outfile if there were any POD errors in
-the infile (default behaviour).
-
-=item nopoderrors
-
   --nopoderrors
 
-Do not include a "POD ERRORS" section in the outfile if there were any POD
-errors in the infile.
+Include a "POD ERRORS" section in the outfile if there were any POD errors in
+the infile (default behaviour).  --nopoderrors does not create this "POD
+ERRORS" section.
 
 =item podpath
 
@@ -155,27 +145,19 @@ Specify the base directory for finding library pods.
 =item quiet
 
   --quiet
-
-Don't display mostly harmless warning messages.
-
-=item noquiet
-
   --noquiet
 
-Display mostly harmless warning messages (default behaviour). But this is not
-the same as "verbose" mode.
+Don't display mostly harmless warning messages.  --noquiet -- which is the
+default behavior -- I<does> display these mostly harmless warning messages (but
+this is not the same as "verbose" mode).
 
 =item recurse
 
   --recurse
-
-Recurse into subdirectories specified in podpath (default behaviour).
-
-=item norecurse
-
   --norecurse
 
-Do not recurse into subdirectories specified in podpath.
+Recurse into subdirectories specified in podpath (default behaviour).
+--norecurse does not recurse into these subdirectories.
 
 =item title
 
@@ -186,14 +168,10 @@ Specify the title of the resulting HTML file.
 =item verbose
 
   --verbose
-
-Display progress messages.
-
-=item noverbose
-
   --noverbose
 
-Do not display progress messages (default behaviour).
+Display progress messages. --noverbose -- which is the default behavior --
+does not display these progress messages.
 
 =back
 


### PR DESCRIPTION
As the next step toward unifying the documentation in bin/pod2html and lib/Pod/Html.pm, group the '*' and 'no*' command-line switches to the pod2html utility and then adjust the descriptions of the switches accordingly.  There are 5 such instances (example: 'poderrors' and 'nopoderrors') already grouped in this manner in lib/Pod/Html.pm.  This commit brings this grouping into bin/pod2html as well.

No changes in functionality.