### PR TITLE
pp_ctl.c - dedupe @INC entries, especially hooks.

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -6963,6 +6963,20 @@ or:
         ...
     }
 
+Note, that a given hook will be executed only once, no matter how many
+times it is pushed into C<@INC>. This is a precaution to make it harder
+to create infinite loops in the require machinery. For anyone deliberately
+wanting to do this, you can use the ARRAY hook representation to pass in
+the same object or sub more than once, or you use currying with a sub:
+
+    my $callback = sub { warn "In \@INC position $INC" };
+    @INC = map { sub{ $callback->() }, $_ } @INC; # curry callback
+    #or
+    @INC = map { [ $callback ], $_ } @INC;    # wrap in ARRAY
+
+would set up inc so the same callback was called before every existing
+lookup the C<@INC> array.
+
 These hooks are also permitted to set the L<C<%INC>|perlvar/%INC> entry
 corresponding to the files they have loaded.  See L<perlvar/%INC>.
 Should an C<INC> hook not do this then perl will set the C<%INC> entry
@@ -7012,6 +7026,15 @@ will be unrolled after the hook exits, and its value only has meaning
 immediately after execution of the hook, thus setting C<$INC> to some
 value prior to executing a C<require> will have no effect on how the
 require executes at all.
+
+As of 5.37.7 any given hook in the C<@INC> array no matter how it got
+there will be executed at most once, the deduping is done using the
+refaddr of the hook and cannot be bypassed with overloads (although the
+array interface makes it easy to create multiple distinct copies if you
+really really want to do this). Likewise any given textually distinct
+directory will be inspected only once. Eg, "foo/../bar/" and "bar/"
+would be treated as distinct, but inserting "foo/" twice would not result
+in us checking the filesystem twice.
 
 As of 5.37.7 C<@INC> values of undef will be silently ignored.
 

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4271,6 +4271,7 @@ S_require_file(pTHX_ SV *sv)
             namesv = newSV_type(SVt_PV);
             AV *inc_ar = GvAVn(PL_incgv);
             SSize_t incdir_continue_inc_idx = -1;
+            HV *inc_seen_hv = (HV*)sv_2mortal((SV*)newHV());
 
             for (
                 inc_idx = 0;
@@ -4303,14 +4304,31 @@ S_require_file(pTHX_ SV *sv)
                 }
                 if (!SvOK(dirsv))
                     continue;
+                
+                /* use the refaddr of the RV for the key for refs */
+                UV diruv = 0;
+                SV **seen_svp = NULL;
+                if (SvROK(dirsv)) {
+                    diruv = PTR2UV(SvRV(dirsv));
+                    seen_svp = hv_fetch(inc_seen_hv, (char*)&diruv, sizeof(UV), 1);
+                    if (!seen_svp)
+                        croak_no_mem();
+                }
+
+                /* is this a new path or callback? */
+                if (seen_svp) {
+                    if (SvOK(*seen_svp))
+                        continue; /* we have executed this hook already */
+                    else
+                        sv_setiv(*seen_svp,1); /* mark this hook as seen */
+                }
 
                 av_push(inc_checked, dirsv);
 
-                if (SvROK(dirsv)) {
+                if (diruv) {
                     int count;
                     SV **svp;
                     SV *loader = dirsv;
-                    UV diruv = PTR2UV(SvRV(dirsv));
 
                     if (SvTYPE(SvRV(loader)) == SVt_PVAV
                         && !SvOBJECT(SvRV(loader)))

--- a/t/op/inccode.t
+++ b/t/op/inccode.t
@@ -21,7 +21,7 @@ unless (is_miniperl()) {
 
 use strict;
 
-plan(tests => 71 + !is_miniperl() * (4 + 14 * $can_fork));
+plan(tests => 71 + !is_miniperl() * (5 + 14 * $can_fork));
 
 sub get_temp_fh {
     my $f = tempfile();
@@ -418,11 +418,16 @@ if ($can_fork) {
     is ("@::bbblplast", "0 1 2 3 4 5", "All ran with a filter");
 }
 SKIP:{
-    skip "need fork",1 unless $can_fork;
+    skip "need fork",2 unless $can_fork;
     fresh_perl_like('@INC=("A",bless({},"Hook"),"D"); '
-                 .'sub Hook::INCDIR { return "B","C"} '
-                 .'eval "require Frobnitz" or print $@;',
-                  qr/\(\@INC[\w ]+: A Hook=HASH\(0x[A-Fa-f0-9]+\) B C D\)/,
-                  {},
-                  "Check if INCDIR hook works as expected");
+                   .'sub Hook::INCDIR { return "B","C"} '
+                   .'eval "require Frobnitz" or print $@;',
+                    qr/\(\@INC[\w ]+: A Hook=HASH\(0x[A-Fa-f0-9]+\) B C D\)/,
+                    {},
+                    "Check if INCDIR hook works as expected");
+    fresh_perl_is('unshift @INC, my $sub= sub { @INC = reverse @INC; }; '
+                   .'eval "require Frobnitz"; print $INC[-1] eq $sub ? "ok" : "not ok"',
+                    "ok",
+                    {},
+                    "Make sure \@INC hooks are called at most once");
 }


### PR DESCRIPTION
It is all too easy to write code that will OOM with the current `@INC` hook mechanism. Consider this:

```
unshift @INC, sub { push @INC, "." };
```

this will run until it OOM's, which i believe is an untrappable and difficult error to deal with.

I think it should be harder to do this accidentally, and that a simple solution is to ensure that a given hook executes only once. I do not think this is much of a burden, as the array hook api offers a simple way to wrap hooks so that they get called an arbitrary number of times. (But not infinitely many times.)

Yes it is true that someone can write `1 while 1`; in a hook, but they are likely to do so accidentally whereas creating an OOM inducing infinite loop with an @INC hook is. 

In my experimentation with this in place, I have it makes writing `@INC` hooks which rewrite `@INC` easier, as you do not have to defend against the double call inside of the `@INC` hook. On the other hand it is still possible to intentionally cause a hook to be called more than once, by wrapping or currying.

See discussion in https://github.com/Perl/perl5/pull/20547 where @haarg and @ap have expressed some disagreement about whether this is a good thing, this patch was originally part of that PR and has been separated out. This patch is intended to be applied on top it as well. 
