### PR TITLE
libnet: remove CUSTOMIZED entries and properly sync with CPAN

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -711,23 +711,6 @@ use File::Glob qw(:case);
             qr(^demos/),
             qr(^t/external/),
         ],
-         # https://github.com/steve-m-hay/perl-libnet/pull/45
-        'CUSTOMIZED' => [
-            'lib/Net/Cmd.pm',
-            'lib/Net/Config.pm',
-            'lib/Net/Domain.pm',
-            'lib/Net/FTP.pm',
-            'lib/Net/FTP/A.pm',
-            'lib/Net/FTP/E.pm',
-            'lib/Net/FTP/I.pm',
-            'lib/Net/FTP/L.pm',
-            'lib/Net/FTP/dataconn.pm',
-            'lib/Net/NNTP.pm',
-            'lib/Net/Netrc.pm',
-            'lib/Net/POP3.pm',
-            'lib/Net/SMTP.pm',
-            'lib/Net/Time.pm',
-        ],
     },
 
     'Locale::Maketext' => {

--- a/cpan/libnet/lib/Net/Cmd.pm
+++ b/cpan/libnet/lib/Net/Cmd.pm
@@ -1,7 +1,7 @@
 # Net::Cmd.pm
 #
 # Copyright (C) 1995-2006 Graham Barr.  All rights reserved.
-# Copyright (C) 2013-2016, 2020 Steve Hay.  All rights reserved.
+# Copyright (C) 2013-2016, 2020, 2022 Steve Hay.  All rights reserved.
 # This module is free software; you can redistribute it and/or modify it under
 # the same terms as Perl itself, i.e. under the terms of either the GNU General
 # Public License or the Artistic License, as specified in the F<LICENCE> file.
@@ -887,7 +887,7 @@ libnet as of version 1.22_02.
 
 Copyright (C) 1995-2006 Graham Barr.  All rights reserved.
 
-Copyright (C) 2013-2016, 2020 Steve Hay.  All rights reserved.
+Copyright (C) 2013-2016, 2020, 2022 Steve Hay.  All rights reserved.
 
 =head1 LICENCE
 
@@ -901,7 +901,7 @@ Version 3.14
 
 =head1 DATE
 
-23 Dec 2020
+22 May 2022
 
 =head1 HISTORY
 

--- a/cpan/libnet/lib/Net/Config.pm
+++ b/cpan/libnet/lib/Net/Config.pm
@@ -372,7 +372,7 @@ Version 3.14
 
 =head1 DATE
 
-23 Dec 2020
+22 May 2022
 
 =head1 HISTORY
 

--- a/cpan/libnet/lib/Net/Domain.pm
+++ b/cpan/libnet/lib/Net/Domain.pm
@@ -399,7 +399,7 @@ Version 3.14
 
 =head1 DATE
 
-23 Dec 2020
+22 May 2022
 
 =head1 HISTORY
 

--- a/cpan/libnet/lib/Net/FTP.pm
+++ b/cpan/libnet/lib/Net/FTP.pm
@@ -1,7 +1,7 @@
 # Net::FTP.pm
 #
 # Copyright (C) 1995-2004 Graham Barr.  All rights reserved.
-# Copyright (C) 2013-2017, 2020 Steve Hay.  All rights reserved.
+# Copyright (C) 2013-2017, 2020, 2022 Steve Hay.  All rights reserved.
 # This module is free software; you can redistribute it and/or modify it under
 # the same terms as Perl itself, i.e. under the terms of either the GNU General
 # Public License or the Artistic License, as specified in the F<LICENCE> file.
@@ -1052,14 +1052,7 @@ sub _dataconn {
       Timeout   => $ftp->timeout,
       can_ssl() ? (
         SSL_startHandshake => 0,
-        $ftp->is_SSL ? (
-          SSL_reuse_ctx => $ftp,
-          SSL_verifycn_name => ${*$ftp}{net_ftp_tlsargs}{SSL_verifycn_name},
-          # This will cause the use of SNI if supported by IO::Socket::SSL.
-          $ftp->can_client_sni ? (
-            SSL_hostname  => ${*$ftp}{net_ftp_tlsargs}{SSL_hostname}
-          ):(),
-        ) :( %{${*$ftp}{net_ftp_tlsargs}} ),
+        %{${*$ftp}{net_ftp_tlsargs}},
       ):(),
     ) or return;
   } elsif (my $listen =  delete ${*$ftp}{net_ftp_listen}) {
@@ -1966,19 +1959,6 @@ Reinitialize the connection, flushing all I/O and account information.
 
 =back
 
-=head1 EXAMPLES
-
-For an example of the use of Net::FTP see
-
-=over 4
-
-=item L<https://www.csh.rit.edu/~adam/Progs/>
-
-C<autoftp> is a program that can retrieve, send, or list files via
-the FTP protocol in a non-interactive manner.
-
-=back
-
 =head1 EXPORTS
 
 I<None>.
@@ -2034,7 +2014,7 @@ libnet as of version 1.22_02.
 
 Copyright (C) 1995-2004 Graham Barr.  All rights reserved.
 
-Copyright (C) 2013-2017, 2020 Steve Hay.  All rights reserved.
+Copyright (C) 2013-2017, 2020, 2022 Steve Hay.  All rights reserved.
 
 =head1 LICENCE
 
@@ -2048,7 +2028,7 @@ Version 3.14
 
 =head1 DATE
 
-23 Dec 2020
+22 May 2022
 
 =head1 HISTORY
 

--- a/cpan/libnet/lib/Net/FTP/dataconn.pm
+++ b/cpan/libnet/lib/Net/FTP/dataconn.pm
@@ -228,7 +228,7 @@ Version 3.14
 
 =head1 DATE
 
-23 Dec 2020
+22 May 2022
 
 =head1 HISTORY
 

--- a/cpan/libnet/lib/Net/NNTP.pm
+++ b/cpan/libnet/lib/Net/NNTP.pm
@@ -1312,7 +1312,7 @@ Version 3.14
 
 =head1 DATE
 
-23 Dec 2020
+22 May 2022
 
 =head1 HISTORY
 

--- a/cpan/libnet/lib/Net/Netrc.pm
+++ b/cpan/libnet/lib/Net/Netrc.pm
@@ -357,7 +357,7 @@ Version 3.14
 
 =head1 DATE
 
-23 Dec 2020
+22 May 2022
 
 =head1 HISTORY
 

--- a/cpan/libnet/lib/Net/POP3.pm
+++ b/cpan/libnet/lib/Net/POP3.pm
@@ -873,7 +873,7 @@ Version 3.14
 
 =head1 DATE
 
-23 Dec 2020
+22 May 2022
 
 =head1 HISTORY
 

--- a/cpan/libnet/lib/Net/SMTP.pm
+++ b/cpan/libnet/lib/Net/SMTP.pm
@@ -1056,7 +1056,7 @@ Version 3.14
 
 =head1 DATE
 
-23 Dec 2020
+22 May 2022
 
 =head1 HISTORY
 

--- a/cpan/libnet/lib/Net/Time.pm
+++ b/cpan/libnet/lib/Net/Time.pm
@@ -194,7 +194,7 @@ Version 3.14
 
 =head1 DATE
 
-23 Dec 2020
+22 May 2022
 
 =head1 HISTORY
 


### PR DESCRIPTION
The customization in core was included in libnet 3.14, so the CUSTOMIZED entries aren't needed. However, they weren't removed before 3.14 was synced to core.

Remove the CUSTOMIZED entries and properly sync the changes from 3.14.