### PR TITLE
Token type `pval` should be a void * pointer

### DIFF
--- a/perly.act
+++ b/perly.act
@@ -2127,6 +2127,6 @@ case 2:
     
 
 /* Generated from:
- * 21f50be92bd623859b76b35d4165bcd0fbe33785929bfc0a6a522d266e86de40 perly.y
+ * d159cbbb0bfd3916708be07894588433a9434f9ade8adce98532533a9ea86747 perly.y
  * acf1cbfd2545faeaaa58b1cf0cf9d7f98b5be0752eb7a54528ef904a9e2e1ca7 regen_perly.pl
  * ex: set ro: */

--- a/perly.h
+++ b/perly.h
@@ -209,7 +209,7 @@ union YYSTYPE
 
     I32	ival; /* __DEFAULT__ (marker for regen_perly.pl;
 				must always be 1st union member) */
-    char *pval;
+    void *pval;
     OP *opval;
     GV *gvval;
 
@@ -226,6 +226,6 @@ int yyparse (void);
 
 
 /* Generated from:
- * 21f50be92bd623859b76b35d4165bcd0fbe33785929bfc0a6a522d266e86de40 perly.y
+ * d159cbbb0bfd3916708be07894588433a9434f9ade8adce98532533a9ea86747 perly.y
  * acf1cbfd2545faeaaa58b1cf0cf9d7f98b5be0752eb7a54528ef904a9e2e1ca7 regen_perly.pl
  * ex: set ro: */

--- a/perly.tab
+++ b/perly.tab
@@ -1222,6 +1222,6 @@ static const toketypes yy_type_tab[] =
 };
 
 /* Generated from:
- * 21f50be92bd623859b76b35d4165bcd0fbe33785929bfc0a6a522d266e86de40 perly.y
+ * d159cbbb0bfd3916708be07894588433a9434f9ade8adce98532533a9ea86747 perly.y
  * acf1cbfd2545faeaaa58b1cf0cf9d7f98b5be0752eb7a54528ef904a9e2e1ca7 regen_perly.pl
  * ex: set ro: */

--- a/perly.y
+++ b/perly.y
@@ -38,7 +38,7 @@
 %union {
     I32	ival; /* __DEFAULT__ (marker for regen_perly.pl;
 				must always be 1st union member) */
-    char *pval;
+    void *pval;
     OP *opval;
     GV *gvval;
 }

--- a/toke.c
+++ b/toke.c
@@ -573,7 +573,7 @@ S_tokereport(pTHX_ I32 rv, const YYSTYPE* lvalp)
                                     PL_op_name[lvalp->ival]);
             break;
         case TOKENTYPE_PVAL:
-            Perl_sv_catpvf(aTHX_ report, "(pval=\"%s\")", lvalp->pval);
+            Perl_sv_catpvf(aTHX_ report, "(pval=%p)", lvalp->pval);
             break;
         case TOKENTYPE_OPVAL:
             if (lvalp->opval) {
@@ -8831,7 +8831,7 @@ yyl_keylookup(pTHX_ char *s, GV *gv)
                 (*def->parse)(aTHX_ &result->parsedata, def);
                 s = PL_bufptr; /* restore local s variable */
             }
-            pl_yylval.pval = (char *)result;
+            pl_yylval.pval = result;
             CLINE;
             OPERATOR(tokentype_for_plugop(def));
         }
@@ -8937,7 +8937,7 @@ yyl_try(pTHX_ char *s)
                 (*def->parse)(aTHX_ &result->parsedata, def);
                 s = PL_bufptr; /* restore local s variable */
             }
-            pl_yylval.pval = (char *)result;
+            pl_yylval.pval = result;
             CLINE;
             OPERATOR(tokentype_for_plugop(def));
         }


### PR DESCRIPTION
The `pval` field of the token type union is currently only used in one place; storing the result of the infix operator plugin. Its use here stores a structure pointer, not a string. The union should define this field as a `void *` and not a `char *`.

In addition we should not attempt to debug print it as a string because its value is not valid as one.