### PR TITLE
Do not cast away constness

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -153,6 +153,7 @@ Bah                            <bah@longitude.com>
 Barrie Slaymaker               <barries@slaysys.com>
 Barry Friedman
 Bart Kedryna                   <bkedryna@home.com>
+Bart Van Assche                <bvanassche@acm.org>
 Bas van Sisseren               <bas@quarantainenet.nl>
 Beau Cox
 Ben Carter                     <bcarter@gumdrop.flyinganvil.org>

--- a/hv_func.h
+++ b/hv_func.h
@@ -62,7 +62,7 @@
 # define PVT__PERL_HASH_SEED_BYTES (PVT__PERL_HASH_WORD_SIZE * 2)
 # define PVT__PERL_HASH_STATE_BYTES (PVT__PERL_HASH_WORD_SIZE * 4)
 # define PVT__PERL_HASH_SEED_STATE(seed,state) S_perl_siphash_seed_state(seed,state)
-# define PVT__PERL_HASH_WITH_STATE(state,str,len) S_perl_hash_siphash_1_3_with_state((state),(U8*)(str),(len))
+# define PVT__PERL_HASH_WITH_STATE(state,str,len) S_perl_hash_siphash_1_3_with_state((state),(const U8*)(str),(len))
 #elif defined(PERL_HASH_FUNC_ZAPHOD32)
 # define PERL_HASH_FUNC_DEFINE "PERL_HASH_FUNC_ZAPHOD32"
 # define PVT__PERL_HASH_FUNC "ZAPHOD32"
@@ -119,7 +119,7 @@
 
 #define PVT_PERL_HASH_WITH_STATE(state,str,len)                                            \
     (LIKELY(len <= SBOX32_MAX_LEN)                                                      \
-        ? sbox32_hash_with_state((state + PVT__PERL_HASH_STATE_BYTES),(U8*)(str),(len))    \
+        ? sbox32_hash_with_state((state + PVT__PERL_HASH_STATE_BYTES),(const U8*)(str),(len))    \
         : PVT__PERL_HASH_WITH_STATE((state),(str),(len)))
 
 #endif
@@ -127,7 +127,7 @@
 #define PERL_HASH_WITH_SEED(seed,hash,str,len) \
     (hash) = S_perl_hash_with_seed((const U8 *) seed, (const U8 *) str,len)
 #define PERL_HASH_WITH_STATE(state,hash,str,len) \
-    (hash) = PVT_PERL_HASH_WITH_STATE((state),(U8*)(str),(len))
+    (hash) = PVT_PERL_HASH_WITH_STATE((state),(const U8*)(str),(len))
 
 #define PERL_HASH_SEED_STATE(seed,state) PVT_PERL_HASH_SEED_STATE(seed,state)
 #define PERL_HASH_SEED_BYTES PVT_PERL_HASH_SEED_roundup(PVT_PERL_HASH_SEED_BYTES)

--- a/hv_macro.h
+++ b/hv_macro.h
@@ -30,7 +30,7 @@
  */
 
 #ifndef U8TO16_LE
-  #define _shifted_octet(type,ptr,idx,shift) (((type)(((U8*)(ptr))[(idx)]))<<(shift))
+  #define _shifted_octet(type,ptr,idx,shift) (((type)(((const U8*)(ptr))[(idx)]))<<(shift))
     #if defined(USE_UNALIGNED_PTR_DEREF) && (BYTEORDER == 0x1234 || BYTEORDER == 0x12345678)
         #define U8TO16_LE(ptr)   (*((const U16*)(ptr)))
         #define U8TO32_LE(ptr)   (*((const U32*)(ptr)))

--- a/inline.h
+++ b/inline.h
@@ -568,7 +568,7 @@ Perl_is_utf8_invariant_string_loc(const U8* const s, STRLEN len, const U8 ** ep)
         /* Here, we know we have at least one full word to process.  Process
          * per-word as long as we have at least a full word left */
         do {
-            if ((* (PERL_UINTMAX_T *) x) & PERL_VARIANTS_WORD_MASK)  {
+            if ((* (const PERL_UINTMAX_T *) x) & PERL_VARIANTS_WORD_MASK)  {
 
                 /* Found a variant.  Just return if caller doesn't want its
                  * exact position */
@@ -579,7 +579,7 @@ Perl_is_utf8_invariant_string_loc(const U8* const s, STRLEN len, const U8 ** ep)
 #  if   BYTEORDER == 0x1234 || BYTEORDER == 0x12345678    \
      || BYTEORDER == 0x4321 || BYTEORDER == 0x87654321
 
-                *ep = x + variant_byte_number(* (PERL_UINTMAX_T *) x);
+                *ep = x + variant_byte_number(* (const PERL_UINTMAX_T *) x);
                 assert(*ep >= s && *ep < send);
 
                 return FALSE;

--- a/sbox32_hash.h
+++ b/sbox32_hash.h
@@ -1409,7 +1409,7 @@ SBOX32_STATIC_INLINE void sbox32_seed_state128 (
     const U8 *seed_ch,
     U8 *state_ch
 ) {
-    U32 *seed= (U32 *)seed_ch;
+    const U32 *seed= (const U32 *)seed_ch;
     U32 *state= (U32 *)state_ch;
     U32 *state_cursor = state + 1;
     U32 *sbox32_end = state + 1 + (256 * SBOX32_MAX_LEN);
@@ -1458,7 +1458,7 @@ SBOX32_STATIC_INLINE U32 sbox32_hash_with_state(
     const U8 *key,
     const STRLEN key_len
 ) {
-    U32 *state= (U32 *)state_ch;
+    const U32 *state= (const U32 *)state_ch;
     U32 hash = *state;
     switch (key_len) {
         default: return zaphod32_hash_with_state(state_ch, key, key_len);

--- a/zaphod32_hash.h
+++ b/zaphod32_hash.h
@@ -178,7 +178,7 @@ U32 zaphod32_hash_with_state(
     const U8 *key,
     const STRLEN key_len
 ) {
-    U32 *state= (U32 *)state_ch;
+    const U32 *state= (const U32 *)state_ch;
     const U8 *end;
     STRLEN len = key_len;
     U32 v0= state[0];


### PR DESCRIPTION
Prevent that building Perl extensions with -Wcast-qual triggers compiler warnings about the Perl headers. This is realized by changing the type of multiple T * arguments into const T * and by changing a few (T *) casts into (const T *). The only nontrivial change is in Perl_SvPV_helper(). In that function, the warning about casting away constness is suppressed by casting a pointer into size_t and back into a pointer type.