### PR TITLE
Add function amagic_find(sv, method, flags)

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -635,6 +635,7 @@ XEop	|bool	|try_amagic_bin	|int method|int flags
 XEop	|bool	|try_amagic_un	|int method|int flags
 Apd	|SV*	|amagic_call	|NN SV* left|NN SV* right|int method|int dir
 Apd	|SV *	|amagic_deref_call|NN SV *ref|int method
+Apd	|CV *	|amagic_find	|NN SV *sv|int method|int flags
 p	|bool	|amagic_is_enabled|int method
 Apd	|int	|Gv_AMupdate	|NN HV* stash|bool destructing
 CpdR	|CV*	|gv_handler	|NULLOK HV* stash|I32 id

--- a/embed.h
+++ b/embed.h
@@ -59,6 +59,7 @@
 #define _utf8n_to_uvchr_msgs_helper	Perl__utf8n_to_uvchr_msgs_helper
 #define amagic_call(a,b,c,d)	Perl_amagic_call(aTHX_ a,b,c,d)
 #define amagic_deref_call(a,b)	Perl_amagic_deref_call(aTHX_ a,b)
+#define amagic_find(a,b,c)	Perl_amagic_find(aTHX_ a,b,c)
 #define apply_attrs_string(a,b,c,d)	Perl_apply_attrs_string(aTHX_ a,b,c,d)
 #define apply_builtin_cv_attributes(a,b)	Perl_apply_builtin_cv_attributes(aTHX_ a,b)
 #define atfork_lock		Perl_atfork_lock

--- a/proto.h
+++ b/proto.h
@@ -252,6 +252,9 @@ PERL_CALLCONV SV*	Perl_amagic_call(pTHX_ SV* left, SV* right, int method, int di
 PERL_CALLCONV SV *	Perl_amagic_deref_call(pTHX_ SV *ref, int method);
 #define PERL_ARGS_ASSERT_AMAGIC_DEREF_CALL	\
 	assert(ref)
+PERL_CALLCONV CV *	Perl_amagic_find(pTHX_ SV *sv, int method, int flags);
+#define PERL_ARGS_ASSERT_AMAGIC_FIND	\
+	assert(sv)
 PERL_CALLCONV bool	Perl_amagic_is_enabled(pTHX_ int method)
 			__attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AMAGIC_IS_ENABLED


### PR DESCRIPTION
Returns the CV pointer to the overloaded method, which will be needed by join to detect concat magic.

Co-authored-by: @book 