### PR TITLE
Optimise bare 'redo' and 'last', same as 'next' from cd97dc8d499

### DIFF
--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -2724,8 +2724,15 @@ PP(pp_next)
 
 PP(pp_redo)
 {
-    PERL_CONTEXT *cx = S_unwind_loop(aTHX);
-    OP* redo_op = cx->blk_loop.my_op->op_redoop;
+    PERL_CONTEXT *cx;
+    OP* redo_op;
+
+    /* if not a bare 'redo' in the main scope, search for it */
+    cx = CX_CUR();
+    if (!((PL_op->op_flags & OPf_SPECIAL) && CxTYPE_is_LOOP(cx)))
+        cx = S_unwind_loop(aTHX);
+
+    redo_op = cx->blk_loop.my_op->op_redoop;
 
     if (redo_op->op_type == OP_ENTER) {
         /* pop one less context to avoid $x being freed in while (my $x..) */

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -2686,7 +2686,10 @@ PP(pp_last)
     PERL_CONTEXT *cx;
     OP* nextop;
 
-    cx = S_unwind_loop(aTHX);
+    /* if not a bare 'last' in the main scope, search for it */
+    cx = CX_CUR();
+    if (!((PL_op->op_flags & OPf_SPECIAL) && CxTYPE_is_LOOP(cx)))
+        cx = S_unwind_loop(aTHX);
 
     assert(CxTYPE_is_LOOP(cx));
     PL_stack_sp = PL_stack_base

--- a/t/perf/benchmarks
+++ b/t/perf/benchmarks
@@ -2191,6 +2191,12 @@
         code    => '$y = 0; $x = 2; out: $x--; while ($x) { goto out if $y++ > 4; redo; }',
     },
 
+    'loop::for::last4' => {
+        desc    => 'for loop containing for loop with a last',
+        setup   => '',
+        code    => 'for (1..4) { for (1..2) { last; } }',
+    },
+
     'loop::grep::expr_3int' => {
         desc    => 'grep $_ > 0, 1,2,3',
         setup   => 'my @a',

--- a/t/perf/benchmarks
+++ b/t/perf/benchmarks
@@ -2185,6 +2185,12 @@
         code    => 'for my $x (@a) {next}',
     },
 
+    'loop::for::redo4' => {
+        desc    => 'loop hitting redo a bunch of times',
+        setup   => 'my ($y, $x);',
+        code    => '$y = 0; $x = 2; out: $x--; while ($x) { goto out if $y++ > 4; redo; }',
+    },
+
     'loop::grep::expr_3int' => {
         desc    => 'grep $_ > 0, 1,2,3',
         setup   => 'my @a',


### PR DESCRIPTION
**For redo:**

```
mhorsfall@tworivers:~/p5/perl$ ./perl -Ilib  Porting/bench.pl --tests=loop::for::redo4 ~/perl ./perl
Key:
    Ir   Instruction read
    Dr   Data read
    Dw   Data write
    COND conditional branches
    IND  indirect branches
    _m   branch predict miss
    _m1  level 1 cache miss
    _mm  last cache (e.g. L3) miss
    -    indeterminate percentage (e.g. 1/0)

The numbers represent relative counts per loop iteration, compared to
/home/mhorsfall/perl at 100.0%.
Higher is better: for example, using half as many instructions gives 200%,
while using twice as many gives 50%.

loop::for::redo4
loop hitting redo a bunch of times

       /home/mhorsfall/perl ./perl
       -------------------- ------
    Ir               100.00 104.00
    Dr               100.00 102.97
    Dw               100.00 104.40
  COND               100.00 102.59
   IND               100.00 100.00

COND_m               100.00 100.13
 IND_m               100.00 100.00

 Ir_m1               100.00      -
 Dr_m1               100.00 100.00
 Dw_m1               100.00 100.00

 Ir_mm               100.00 100.00
 Dr_mm               100.00 100.00
 Dw_mm               100.00 100.00

```

**For last:**

```
mhorsfall@tworivers:~/p5/perl$ ./perl -Ilib  Porting/bench.pl --tests=loop::for::last4 ~/perl ./perl
Key:
    Ir   Instruction read
    Dr   Data read
    Dw   Data write
    COND conditional branches
    IND  indirect branches
    _m   branch predict miss
    _m1  level 1 cache miss
    _mm  last cache (e.g. L3) miss
    -    indeterminate percentage (e.g. 1/0)

The numbers represent relative counts per loop iteration, compared to
/home/mhorsfall/perl at 100.0%.
Higher is better: for example, using half as many instructions gives 200%,
while using twice as many gives 50%.

loop::for::last4
for loop containing for loop with a last

       /home/mhorsfall/perl ./perl
       -------------------- ------
    Ir               100.00 105.94
    Dr               100.00 103.88
    Dw               100.00 105.45
  COND               100.00 104.24
   IND               100.00 100.00

COND_m               100.00  99.17
 IND_m               100.00 100.00

 Ir_m1               100.00 100.00
 Dr_m1               100.00 100.00
 Dw_m1               100.00 100.00

 Ir_mm               100.00 100.00
 Dr_mm               100.00 100.00
 Dw_mm               100.00 100.00

```

The number seem good, but I'm not sure why we lost some on COND_m...

@iabyn As this was originally your optimisation for `next`, can you give this a look? I'm curious why you didn't extend this to these two when you wrote that...

Thanks.