### PR TITLE
Fix broken API: sync_locale()

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3388,13 +3388,13 @@ ST	|const char *|save_to_buffer|NULLOK const char * string	\
 				    |NULLOK Size_t *buf_size
 ST	|unsigned int|get_category_index|const int category|NULLOK const char * locale
 #    ifdef USE_LOCALE_CTYPE
-S	|void	|new_ctype	|NN const char* newctype
+S	|void	|new_ctype	|NN const char* newctype|bool force
 ST	|bool	|is_codeset_name_UTF8|NN const char * name
 #    endif
 #    ifdef USE_LOCALE_NUMERIC
-S	|void	|new_numeric	|NN const char* newnum
+S	|void	|new_numeric	|NN const char* newnum|bool force
 #    endif
-S	|void	|new_LC_ALL	|NULLOK const char* unused
+S	|void	|new_LC_ALL	|NULLOK const char* unused|bool force
 S	|const char*|stdize_locale|const int category			\
 				|NULLOK const char* input_locale	\
 				|NULLOK const char **buf		\
@@ -3458,7 +3458,7 @@ S	|const char *|calculate_LC_ALL|NN const char ** individ_locales
 #      endif
 #    endif
 #    ifdef USE_LOCALE_COLLATE
-S	|void	|new_collate	|NN const char* newcoll
+S	|void	|new_collate	|NN const char* newcoll|bool force
 #      ifdef DEBUGGING
 S	|void	|print_collxfrm_input_and_return		\
 			    |NN const char * s			\

--- a/embed.h
+++ b/embed.h
@@ -1776,19 +1776,19 @@
 #    if defined(USE_LOCALE)
 #define get_category_index	S_get_category_index
 #define mortalized_pv_copy(a)	S_mortalized_pv_copy(aTHX_ a)
-#define new_LC_ALL(a)		S_new_LC_ALL(aTHX_ a)
+#define new_LC_ALL(a,b)		S_new_LC_ALL(aTHX_ a,b)
 #define save_to_buffer		S_save_to_buffer
 #define setlocale_failure_panic_i(a,b,c,d,e)	S_setlocale_failure_panic_i(aTHX_ a,b,c,d,e)
 #define stdize_locale(a,b,c,d,e)	S_stdize_locale(aTHX_ a,b,c,d,e)
 #      if defined(USE_LOCALE_COLLATE)
-#define new_collate(a)		S_new_collate(aTHX_ a)
+#define new_collate(a,b)	S_new_collate(aTHX_ a,b)
 #      endif
 #      if defined(USE_LOCALE_CTYPE)
 #define is_codeset_name_UTF8	S_is_codeset_name_UTF8
-#define new_ctype(a)		S_new_ctype(aTHX_ a)
+#define new_ctype(a,b)		S_new_ctype(aTHX_ a,b)
 #      endif
 #      if defined(USE_LOCALE_NUMERIC)
-#define new_numeric(a)		S_new_numeric(aTHX_ a)
+#define new_numeric(a,b)	S_new_numeric(aTHX_ a,b)
 #      endif
 #      if defined(USE_POSIX_2008_LOCALE)
 #define emulate_setlocale_i(a,b,c,d)	S_emulate_setlocale_i(aTHX_ a,b,c,d)

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -7837,3 +7837,27 @@ test_CvREFCOUNTED_ANYSV()
     }
     OUTPUT:
         RETVAL
+
+MODULE = XS::APItest            PACKAGE = XS::APItest::global_locale
+
+char *
+switch_to_global_and_setlocale(int category, const char * locale)
+    CODE:
+        switch_to_global_locale();
+        RETVAL = setlocale(category, locale);
+    OUTPUT:
+        RETVAL
+
+bool
+sync_locale()
+    CODE:
+        RETVAL = sync_locale();
+    OUTPUT:
+        RETVAL
+
+NV
+newSvNV(const char * string)
+    CODE:
+        RETVAL = SvNV(newSVpv(string, 0));
+    OUTPUT:
+        RETVAL

--- a/ext/XS-APItest/t/locale.t
+++ b/ext/XS-APItest/t/locale.t
@@ -62,12 +62,8 @@ SKIP: {
        "comma recognized in global comma locale for SvNV");
     isnt(sync_locale, 0, "sync_locale() returns that was in the global locale");
 
-    TODO: {
-        local $TODO = "GH #20565";
-
-        is(check_in_bounds(newSvNV("4.888"), 4.88, 4.89), 1,
-        "dot recognized in perl-controlled comma locale for SvNV");
-    }
+    is(check_in_bounds(newSvNV("4.888"), 4.88, 4.89), 1,
+    "dot recognized in perl-controlled comma locale for SvNV");
 }
 
 my %correct_C_responses = (

--- a/ext/XS-APItest/t/locale.t
+++ b/ext/XS-APItest/t/locale.t
@@ -11,13 +11,15 @@ skip_all("locales not available") unless locales_enabled('LC_NUMERIC');
 my @locales = eval { find_locales( &LC_NUMERIC ) };
 skip_all("no LC_NUMERIC locales available") unless @locales;
 
-my $non_dot_locale;
-for (@locales) {
+my $comma_locale;
+for my $locale (@locales) {
+    use POSIX;
     use locale;
-    setlocale(LC_NUMERIC, $_) or next;
+    setlocale(LC_NUMERIC, $locale) or next;
     my $in = 4.2; # avoid any constant folding bugs
-    if (sprintf("%g", $in) ne "4.2") {
-        $non_dot_locale = $_;
+    my $s = sprintf("%g", $in);
+    if ($s eq "4,2")  {
+        $comma_locale = $locale;
         last;
     }
 }

--- a/ext/XS-APItest/t/locale.t
+++ b/ext/XS-APItest/t/locale.t
@@ -34,6 +34,42 @@ SKIP: {
       is(test_Gconvert(4.179, 2), "4.2", "Gconvert doesn't recognize underlying locale inside 'use locale'");
 }
 
+sub check_in_bounds($$$) {
+    my ($value, $lower, $upper) = @_;
+
+    $value >= $lower && $value <= $upper
+}
+
+SKIP: {
+    # This checks that when switching to the global locale, the service that
+    # Perl provides of transparently dealing with locales that have a non-dot
+    # radix is turned off, but gets turned on again after a sync_locale();
+
+    skip "no locale with a comma radix available", 5 unless $comma_locale;
+
+    my $global_locale = switch_to_global_and_setlocale(LC_NUMERIC,
+                                                       $comma_locale);
+    # Can't do a compare of $global_locale and $comma_locale because what the
+    # system returns may be an alias.  ALl we can do is test for
+    # success/failure
+    ok($global_locale, "Successfully switched to $comma_locale");
+    is(newSvNV("4.888"), 4, "dot not recognized in global comma locale for SvNV");
+
+    no warnings 'numeric';  # Otherwise get "Argument isn't numeric in
+                            # subroutine entry"
+
+    is(check_in_bounds(newSvNV("4,888"), 4.88, 4.89), 1,
+       "comma recognized in global comma locale for SvNV");
+    isnt(sync_locale, 0, "sync_locale() returns that was in the global locale");
+
+    TODO: {
+        local $TODO = "GH #20565";
+
+        is(check_in_bounds(newSvNV("4.888"), 4.88, 4.89), 1,
+        "dot recognized in perl-controlled comma locale for SvNV");
+    }
+}
+
 my %correct_C_responses = (
         # Entries that are undef could have varying returns
                             ABDAY_1 => 'Sun',

--- a/locale.c
+++ b/locale.c
@@ -355,7 +355,7 @@ STATIC const char * const category_names[] = {
 
 /* A few categories require additional setup when they are changed.  This table
  * points to the functions that do that setup */
-STATIC void (*update_functions[]) (pTHX_ const char *) = {
+STATIC void (*update_functions[]) (pTHX_ const char *, bool force) = {
 #  ifdef USE_LOCALE_CTYPE
                                 S_new_ctype,
 #  endif
@@ -1826,7 +1826,7 @@ S_setlocale_failure_panic_i(pTHX_
 #  ifdef USE_LOCALE_NUMERIC
 
 STATIC void
-S_new_numeric(pTHX_ const char *newnum)
+S_new_numeric(pTHX_ const char *newnum, bool force)
 {
     PERL_ARGS_ASSERT_NEW_NUMERIC;
 
@@ -1880,8 +1880,10 @@ S_new_numeric(pTHX_ const char *newnum)
                            "Called new_numeric with %s, PL_numeric_name=%s\n",
                            newnum, PL_numeric_name));
 
-    /* If this isn't actually a change, do nothing */
-    if (strEQ(PL_numeric_name, newnum)) {
+    /* If not forcing this procedure, and there isn't actually a change from
+     * our records, do nothing.  (Our records can be wrong when sync'ing to the
+     * locale set up by an external library, hence the 'force' parameter) */
+    if (! force && strEQ(PL_numeric_name, newnum)) {
         return;
     }
 
@@ -2040,9 +2042,10 @@ Perl_set_numeric_underlying(pTHX)
 #  ifdef USE_LOCALE_CTYPE
 
 STATIC void
-S_new_ctype(pTHX_ const char *newctype)
+S_new_ctype(pTHX_ const char *newctype, bool force)
 {
     PERL_ARGS_ASSERT_NEW_CTYPE;
+    PERL_UNUSED_ARG(force);
 
     /* Called after each libc setlocale() call affecting LC_CTYPE, to tell
      * core Perl this and that 'newctype' is the name of the new locale.
@@ -2473,18 +2476,17 @@ Perl__warn_problematic_locale()
 }
 
 STATIC void
-S_new_LC_ALL(pTHX_ const char *unused)
+S_new_LC_ALL(pTHX_ const char *unused, bool force)
 {
-    unsigned int i;
+    PERL_ARGS_ASSERT_NEW_LC_ALL;
+    PERL_UNUSED_ARG(unused);
 
     /* LC_ALL updates all the things we care about. */
 
-    PERL_UNUSED_ARG(unused);
-
-    for (i = 0; i < NOMINAL_LC_ALL_INDEX; i++) {
+    for (unsigned int i = 0; i < NOMINAL_LC_ALL_INDEX; i++) {
         if (update_functions[i]) {
             const char * this_locale = querylocale_i(i);
-            update_functions[i](aTHX_ this_locale);
+            update_functions[i](aTHX_ this_locale, force);
         }
     }
 }
@@ -2492,9 +2494,10 @@ S_new_LC_ALL(pTHX_ const char *unused)
 #  ifdef USE_LOCALE_COLLATE
 
 STATIC void
-S_new_collate(pTHX_ const char *newcoll)
+S_new_collate(pTHX_ const char *newcoll, bool force)
 {
     PERL_ARGS_ASSERT_NEW_COLLATE;
+    PERL_UNUSED_ARG(force);
 
     /* Called after each libc setlocale() call affecting LC_COLLATE, to tell
      * core Perl this and that 'newcoll' is the name of the new locale.
@@ -2855,7 +2858,7 @@ Perl_setlocale(const int category, const char * locale)
     /* Now that have changed locales, we have to update our records to
      * correspond.  Only certain categories have extra work to update. */
     if (update_functions[cat_index]) {
-        update_functions[cat_index](aTHX_ retval);
+        update_functions[cat_index](aTHX_ retval, false);
     }
 
     DEBUG_L(PerlIO_printf(Perl_debug_log, "returning '%s'\n", retval));
@@ -5109,19 +5112,19 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
     PL_numeric_radix_sv    = newSV(1);
     PL_underlying_radix_sv = newSV(1);
     Newxz(PL_numeric_name, 1, char);    /* Single NUL character */
-    new_numeric("C");
+    new_numeric("C", false);
 
 #  endif
 #  ifdef USE_LOCALE_COLLATE
 
     Newxz(PL_collation_name, 1, char);
-    new_collate("C");
+    new_collate("C", false);
 
 #  endif
 #  ifdef USE_LOCALE_CTYPE
 
     Newxz(PL_ctype_name, 1, char);
-    new_ctype("C");
+    new_ctype("C", false);
 
 #  endif
 #  ifdef USE_PL_CURLOCALES
@@ -5440,7 +5443,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 #  endif
 
     /* Done with finding the locales; update the auxiliary records */
-    new_LC_ALL(NULL);
+    new_LC_ALL(NULL, false);
 
     for (i = 0; i < NOMINAL_LC_ALL_INDEX; i++) {
         Safefree(curlocales[i]);
@@ -6815,9 +6818,11 @@ Perl_switch_to_global_locale(pTHX)
 #  ifdef USE_THREAD_SAFE_LOCALE
 #    if defined(WIN32)
 
+    const char * thread_locale = posix_setlocale(LC_ALL, NULL);
     _configthreadlocale(_DISABLE_PER_THREAD_LOCALE);
+    posix_setlocale(LC_ALL, thread_locale);
 
-#    elif defined(USE_POSIX_2008_LOCALE)
+#    else   /* Must be USE_POSIX_2008_LOCALE) */
 
     const char * cur_thread_locales[NOMINAL_LC_ALL_INDEX + 1];
 
@@ -6827,6 +6832,7 @@ Perl_switch_to_global_locale(pTHX)
     }
 
     /* Now switch to global */
+    DEBUG_Lv(PerlIO_printf(Perl_debug_log, "Switching to global locale\n"));
 
     locale_t old_locale = uselocale(LC_GLOBAL_LOCALE);
     if (! old_locale) {
@@ -6845,8 +6851,6 @@ Perl_switch_to_global_locale(pTHX)
     }
     POSIX_SETLOCALE_UNLOCK;
 
-#    else
-#      error Unexpected Configuration
 #    endif
 #  endif
 #  ifdef USE_LOCALE_NUMERIC
@@ -6918,30 +6922,45 @@ Perl_sync_locale(pTHX)
 #  ifdef USE_THREAD_SAFE_LOCALE
 #    if defined(WIN32)
 
-    was_in_global = _configthreadlocale(_ENABLE_PER_THREAD_LOCALE)
-                                    == _DISABLE_PER_THREAD_LOCALE;
+    was_in_global = _configthreadlocale(_DISABLE_PER_THREAD_LOCALE)
+                                     == _DISABLE_PER_THREAD_LOCALE;
 
 #    elif defined(USE_POSIX_2008_LOCALE)
 
-    was_in_global = LC_GLOBAL_LOCALE == uselocale((locale_t) 0);
+    was_in_global = (LC_GLOBAL_LOCALE == uselocale((locale_t) 0));
 
 #    else
 #      error Unexpected Configuration
 #    endif
 #  endif    /* USE_THREAD_SAFE_LOCALE */
-#  ifdef LC_ALL
 
-    /* Use the external interface Perl_setlocale() to make sure all setup gets
-     * done */
-    Perl_setlocale(LC_ALL, stdized_setlocale(LC_ALL, NULL));
-
-#  else
-
+    /* Here, we are in the global locale.  Get and save the values for each
+     * category. */
+    const char * current_globals[NOMINAL_LC_ALL_INDEX];
     for (unsigned i = 0; i < NOMINAL_LC_ALL_INDEX; i++) {
-        Perl_setlocale(categories[i], stdized_setlocale(categories[i], NULL));
+        POSIX_SETLOCALE_LOCK;
+        current_globals[i] = savepv(stdized_setlocale(categories[i], NULL));
+        POSIX_SETLOCALE_UNLOCK;
     }
 
+    /* Now we have to convert the current thread to use them */
+
+#  if defined(WIN32)
+
+    /* On Windows, convert to per-thread behavior.  This isn't necessary in
+     * POSIX 2008, as the conversion gets done automatically in the loop below.
+     * */
+    _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+
 #  endif
+
+    for (unsigned i = 0; i < NOMINAL_LC_ALL_INDEX; i++) {
+        setlocale_i(i, current_globals[i]);
+        Safefree(current_globals[i]);
+    }
+
+    /* And update our remaining records.  'true' => force recalculation */
+    new_LC_ALL(NULL, true);
 
     return was_in_global;
 

--- a/locale.c
+++ b/locale.c
@@ -6785,10 +6785,9 @@ Perl_switch_to_global_locale(pTHX)
 
 #ifdef USE_LOCALE
 
-    bool perl_controls = false;
-
     DEBUG_L(PerlIO_printf(Perl_debug_log, "Entering switch_to_global; %s\n",
                                           get_LC_ALL_display()));
+    bool perl_controls = false;
 
 #  ifdef USE_THREAD_SAFE_LOCALE
 
@@ -6797,11 +6796,11 @@ Perl_switch_to_global_locale(pTHX)
 
 #    ifdef USE_POSIX_2008_LOCALE
 
-    perl_controls = LC_GLOBAL_LOCALE != uselocale((locale_t) 0);
+    perl_controls = (LC_GLOBAL_LOCALE != uselocale((locale_t) 0));
 
 #    elif defined(WIN32)
 
-    perl_controls = _configthreadlocale(0) == _ENABLE_PER_THREAD_LOCALE;
+    perl_controls = (_configthreadlocale(0) == _ENABLE_PER_THREAD_LOCALE);
 
 #    else
 #      error Unexpected Configuration
@@ -6820,19 +6819,21 @@ Perl_switch_to_global_locale(pTHX)
 
 #    elif defined(USE_POSIX_2008_LOCALE)
 
-    const char * curlocales[NOMINAL_LC_ALL_INDEX + 1];
+    const char * cur_thread_locales[NOMINAL_LC_ALL_INDEX + 1];
 
-    /* Save each category's current state */
+    /* Save each category's current per-thread state */
     for (unsigned i = 0; i < NOMINAL_LC_ALL_INDEX; i++) {
-        curlocales[i] = querylocale_i(i);
+        cur_thread_locales[i] = querylocale_i(i);
     }
 
-    /* Switch to global */
+    /* Now switch to global */
+
     locale_t old_locale = uselocale(LC_GLOBAL_LOCALE);
     if (! old_locale) {
         locale_panic_(Perl_form(aTHX_ "Could not change to global locale"));
     }
 
+    /* Free the per-thread memory */
     if (old_locale != LC_GLOBAL_LOCALE && old_locale != PL_C_locale_obj) {
         freelocale(old_locale);
     }
@@ -6840,7 +6841,7 @@ Perl_switch_to_global_locale(pTHX)
     /* Set the global to what was our per-thread state */
     POSIX_SETLOCALE_LOCK;
     for (unsigned int i = 0; i < NOMINAL_LC_ALL_INDEX; i++) {
-        posix_setlocale(categories[i], curlocales[i]);
+        posix_setlocale(categories[i], cur_thread_locales[i]);
     }
     POSIX_SETLOCALE_UNLOCK;
 

--- a/proto.h
+++ b/proto.h
@@ -5724,7 +5724,7 @@ PERL_STATIC_INLINE const char *	S_mortalized_pv_copy(pTHX_ const char * const pv
 #define PERL_ARGS_ASSERT_MORTALIZED_PV_COPY
 #endif
 
-STATIC void	S_new_LC_ALL(pTHX_ const char* unused);
+STATIC void	S_new_LC_ALL(pTHX_ const char* unused, bool force);
 #define PERL_ARGS_ASSERT_NEW_LC_ALL
 STATIC void	S_restore_toggled_locale_i(pTHX_ const unsigned cat_index, const char * original_locale, const line_t caller_line);
 #define PERL_ARGS_ASSERT_RESTORE_TOGGLED_LOCALE_I
@@ -5741,7 +5741,7 @@ STATIC const char *	S_toggle_locale_i(pTHX_ const unsigned switch_cat_index, con
 #define PERL_ARGS_ASSERT_TOGGLE_LOCALE_I	\
 	assert(new_locale)
 #    if defined(USE_LOCALE_COLLATE)
-STATIC void	S_new_collate(pTHX_ const char* newcoll);
+STATIC void	S_new_collate(pTHX_ const char* newcoll, bool force);
 #define PERL_ARGS_ASSERT_NEW_COLLATE	\
 	assert(newcoll)
 #    endif
@@ -5749,12 +5749,12 @@ STATIC void	S_new_collate(pTHX_ const char* newcoll);
 STATIC bool	S_is_codeset_name_UTF8(const char * name);
 #define PERL_ARGS_ASSERT_IS_CODESET_NAME_UTF8	\
 	assert(name)
-STATIC void	S_new_ctype(pTHX_ const char* newctype);
+STATIC void	S_new_ctype(pTHX_ const char* newctype, bool force);
 #define PERL_ARGS_ASSERT_NEW_CTYPE	\
 	assert(newctype)
 #    endif
 #    if defined(USE_LOCALE_NUMERIC)
-STATIC void	S_new_numeric(pTHX_ const char* newnum);
+STATIC void	S_new_numeric(pTHX_ const char* newnum, bool force);
 #define PERL_ARGS_ASSERT_NEW_NUMERIC	\
 	assert(newnum)
 #    endif


### PR DESCRIPTION
This series of commits fixes GH https://github.com/Perl/perl5/issues/20565.

Lack of tests allowed sync_locale() to get broken until CPAN testing
showed it so.

Basically, I blew it in https://github.com/Perl/perl5/commit/9f5a615be674d7663d3b4719849baa1ba3027f5b.  
Most egregiously, I forgot to turn back on when a sync_locale() is executed,
the toggling for locales whose radix character isn't a dot.  And this
needs a way to tell the other code that it needs to recompute things at
this time, since our records don't reflect what happened before the
sync.