### PR TITLE
Fix PerlEnv_putenv threaded compilation on Windows

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3934,6 +3934,9 @@ CTo	|PerlInterpreter *|perl_clone_using				\
 Adp	|I32	|my_pclose	|NULLOK PerlIO *ptr
 Adp	|PerlIO *|my_popen	|NN const char *cmd			\
 				|NN const char *mode
+# if defined(USE_ITHREADS)
+si	|bool	|PerlEnv_putenv |NN char *str
+# endif /* defined(USE_ITHREADS) */
 #endif /* !defined(PERL_IMPLICIT_SYS) */
 #if defined(PERL_IN_AV_C)
 S	|MAGIC *|get_aux_mg	|NN AV *av

--- a/embed.h
+++ b/embed.h
@@ -1645,6 +1645,9 @@
 #     define padlist_dup(a,b)                   Perl_padlist_dup(aTHX_ a,b)
 #     define padname_dup(a,b)                   Perl_padname_dup(aTHX_ a,b)
 #     define padnamelist_dup(a,b)               Perl_padnamelist_dup(aTHX_ a,b)
+#     if !defined(PERL_IMPLICIT_SYS)
+#       define PerlEnv_putenv(a)                Perl_PerlEnv_putenv(aTHX_ a)
+#     endif /* !defined(PERL_IMPLICIT_SYS) */
 #   endif /* defined(USE_ITHREADS) */
 #   if defined(USE_LOCALE_COLLATE)
 #     define magic_freecollxfrm(a,b)            Perl_magic_freecollxfrm(aTHX_ a,b)

--- a/inline.h
+++ b/inline.h
@@ -281,6 +281,25 @@ S_strip_spaces(pTHX_ const char * orig, STRLEN * const len)
 }
 #endif
 
+/* ------------------------------- iperlsys.h ------------------------------- */
+#if ! defined(PERL_IMPLICIT_SYS) && defined(USE_ITHREADS)
+
+/* Otherwise this function is implemented as macros in iperlsys.h */
+
+PERL_STATIC_INLINE bool
+Perl_PerlEnv_putenv(pTHX_ char * str)
+{
+    PERL_ARGS_ASSERT_PERLENV_PUTENV;
+
+    ENV_LOCK;
+    bool retval = putenv(str);
+    ENV_UNLOCK;
+
+    return retval;
+}
+
+#endif
+
 /* ------------------------------- mg.h ------------------------------- */
 
 #if defined(PERL_CORE) || defined(PERL_EXT)

--- a/iperlsys.h
+++ b/iperlsys.h
@@ -559,14 +559,7 @@ struct IPerlEnvInfo
 #  endif
 
 #else   /* below is ! PERL_IMPLICIT_SYS */
-#  ifdef USE_ITHREADS
-
-     /* Use the comma operator to return 0/non-zero, while avoiding putting
-      * this in an inline function */
-#    define PerlEnv_putenv(str) (ENV_LOCK, (putenv(str)         \
-                                            ? (ENV_UNLOCK, 1)   \
-                                            : (ENV_UNLOCK, 0)))
-#  else
+#  ifndef USE_ITHREADS  /* Threaded is an inline function in inline.h */
 #    define PerlEnv_putenv(str)         putenv(str)
 #  endif
 #  define PerlEnv_getenv(str)           mortal_getenv(str)

--- a/proto.h
+++ b/proto.h
@@ -6190,6 +6190,13 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode);
 # define PERL_ARGS_ASSERT_MY_POPEN              \
         assert(cmd); assert(mode)
 
+# if defined(USE_ITHREADS)
+STATIC bool
+Perl_PerlEnv_putenv(pTHX_ char *str);
+#   define PERL_ARGS_ASSERT_PERLENV_PUTENV      \
+        assert(str)
+
+# endif /* defined(USE_ITHREADS) */
 #endif /* !defined(PERL_IMPLICIT_SYS) */
 #if defined(PERL_IN_AV_C)
 STATIC MAGIC *


### PR DESCRIPTION
A second compilation of a workspace would fail.  The first one would succeed because miniperl was being used, which isn't threaded.

This was updated from an earlier version to use the prefix `Perl_` instead of `S_`.