### PR TITLE
loc_tools.pl: Accept dashless UTF8 besides to 'UTF-8'

### DIFF
--- a/t/loc_tools.pl
+++ b/t/loc_tools.pl
@@ -160,7 +160,7 @@ sub _trylocale ($$$$) { # For use only by other functions in this file!
     # such systems fully, but we shouldn't disable the user from using
     # locales, as it may work out for them (or not).
     return if    defined $Config{d_setlocale_accepts_any_locale_name}
-              && $locale !~ / ^ (?: C | POSIX | C\.UTF-8 ) $/ix;
+              && $locale !~ / ^ (?: C | POSIX | C\.UTF-?8 ) $/ix;
 
     if (exists $known_bad_locales{$^O}) {
         my @bad_locales = $known_bad_locales{$^O}->@*;


### PR DESCRIPTION
The dash is sometimes omitted