### PR TITLE
Speed up test suite execution on a many core system

### DIFF
--- a/t/harness
+++ b/t/harness
@@ -194,9 +194,10 @@ if (@ARGV) {
                     \z !x)
             {
                 my $path = $1;
+                my $name = $2;
 
                 $all_dirs{$path} = 1;
-                $serials{$path} = 1 if $2 =~ / \A 0 /x;
+                $serials{$path} = 1 if $name =~ / \A 0 /x;
             }
         }
 

--- a/t/harness
+++ b/t/harness
@@ -8,6 +8,9 @@ BEGIN {
     @INC = '../lib';              # pick up only this build's lib
 }
 
+my %must_be_executed_serially = map { $_ => 1 }
+                                    qw(../cpan/IO-Zlib/t ../ext/File-Find/t);
+
 my $torture; # torture testing?
 
 use TAP::Harness 3.13;
@@ -200,25 +203,21 @@ if (@ARGV) {
                 my $name = $2;
 
                 $all_dirs{$path} = 1;
-                $serials{$path} = 1 if $name =~ / \A 0 /x;
                 $map_file_to_dir{$file} = $path;
+
+                if ($name =~ / \A 0 /x) {
+                    $serials{$path} = 1;
+                }
+                elsif (defined $must_be_executed_serially{$path}) {
+                    $serials{$path} = 1;
+                    delete $must_be_executed_serially{$path};
+                }
             }
         }
 
         # We assume that the reason a test file's name begins with a 0 is to
         # order its execution among the tests in its directory.  Hence, a
         # directory containing such files should be tested in serial order.
-        #
-        # Add exceptions to the above rule
-        for (qw(../cpan/IO-Zlib/t ../ext/File-Find/t)) {
-            $serials{$_} = 1;
-        }
-
-        my @nonexistent_serials = grep { not exists $all_dirs{$_} } keys %serials;
-        if (@nonexistent_serials) {
-            die "These directories to be run serially don't exist."
-              . "  Check your spelling:\n" . join "\n", @nonexistent_serials;
-        }
 
         for my $file (@last) {
             my $file_dir = $map_file_to_dir{$file};
@@ -249,6 +248,12 @@ if (@ARGV) {
                                                                      keys %dir
                             ]
                    };
+
+        if (%must_be_executed_serially) {
+            die "These directories to be run serially don't exist.  Check your"
+            . " spelling:\n"
+            . join "\n", sort keys %must_be_executed_serially;
+        }
 
         $rules = { seq => \@seq };
     }

--- a/t/harness
+++ b/t/harness
@@ -178,6 +178,7 @@ if (@ARGV) {
         my %dir;
         my %serials;
         my %all_dirs;
+        my %map_file_to_dir;
 
         # Preprocess the list of tests
         for my $file (@last) {
@@ -199,6 +200,7 @@ if (@ARGV) {
 
                 $all_dirs{$path} = 1;
                 $serials{$path} = 1 if $name =~ / \A 0 /x;
+                $map_file_to_dir{$file} = $path;
             }
         }
 
@@ -217,34 +219,33 @@ if (@ARGV) {
               . "  Check your spelling:\n" . join "\n", @nonexistent_serials;
         }
 
-        # Remove the serial testing directories from the list of all
-        # directories.  The remaining ones are testable in parallel.  Make the
-        # parallel list a scalar with names separated by '|' so that below
-        # they will be added to a regular expression.
-        my $non_serials = join "|", grep { not exists $serials{$_} } keys %all_dirs;
+        for my $file (@last) {
+            my $file_dir = $map_file_to_dir{$file};
+
+            # Treat every file in each non-serial directory as its own
+            # "directory", so that it can be executed in parallel
+            if (! defined $serials{$file_dir}) {
+                $dir{$file} = { seq => $file };
+                $total_time{$file} = $times{$file} || 0;
+            }
+            else {  # Serial.  This file contributes time to the total needed
+                    # for its directory as a whole
+                $dir{$file_dir} = { seq => "$file_dir/*" };
+                $total_time{$file_dir} += $times{$file} || 0;
+            }
+        }
+
         undef %all_dirs;
         undef %serials;
 
-        for my $file (@last) {
-            # Treat every file in each non-serial directory as its own
-            # "directory", so that it can be executed in parallel
-            $file =~ m! \A ( (?: \.\. / )? (?: $non_serials )
-                         / [^/]+ \.t \z | .* [/] ) !x
-                or die "'$file'";
-            push @{$dir{$1}}, $file;
-
-            # This file contributes time to the total needed for the directory
-            # as a whole
-            $total_time{$1} += $times{$file} || 0;
-        }
         #print STDERR __LINE__, join "\n", sort sort_by_execution_order keys %dir
 
         push @tests, @last;
 
         # Generate T::H schedule rules that run the contents of each directory
         # sequentially.
-        push @seq, { par => [ map { s!/$!/*!; { seq => $_ } } sort
-                                                sort_by_execution_order keys %dir
+        push @seq, { par => [ map { $dir{$_} } sort sort_by_execution_order
+                                                                     keys %dir
                             ]
                    };
 

--- a/t/harness
+++ b/t/harness
@@ -180,18 +180,18 @@ if (@ARGV) {
         my %all_dirs;
 
         # Preprocess the list of tests
-	for (@last) {
+	for my $file (@last) {
 	    if ($^O eq 'MSWin32') {
-		s,\\,/,g; # canonicalize path
+		$file =~ s,\\,/,g; # canonicalize path
 	    };
 
             # Keep a list of the distinct directory names, and another list of
             # those which contain a file whose name begins with a 0
-            if ( m! \A (?: \.\. / )?
+            if ($file =~ m! \A (?: \.\. / )?
                                 ( .*? )         # $1 is the directory path name
-                            /
+                               /
                                ( [^/]* \. (?: t | pl ) ) # $2 is the test name
-                    \z !x)
+                         \z !x)
             {
                 my $path = $1;
                 my $name = $2;
@@ -224,17 +224,17 @@ if (@ARGV) {
         undef %all_dirs;
         undef %serials;
 
-	for (@last) {
+	for my $file (@last) {
             # Treat every file in each non-serial directory as its own
             # "directory", so that it can be executed in parallel
-            m! \A ( (?: \.\. / )? (?: $non_serials )
+            $file =~ m! \A ( (?: \.\. / )? (?: $non_serials )
                          / [^/]+ \.t \z | .* [/] ) !x
-                or die "'$_'";
-	    push @{$dir{$1}}, $_;
+                or die "'$file'";
+	    push @{$dir{$1}}, $file;
 
             # This file contributes time to the total needed for the directory
             # as a whole
-	    $total_time{$1} += $times{$_} || 0;
+	    $total_time{$1} += $times{$file} || 0;
 	}
         #print STDERR __LINE__, join "\n", sort sort_by_execution_order keys %dir
 

--- a/t/harness
+++ b/t/harness
@@ -96,6 +96,101 @@ sub _extract_tests {
 
 my %total_time;
 
+sub _compute_tests_and_ordering($) {
+    my @tests = $_[0]->@*;
+
+    my %dir;
+    my %serials;
+    my %all_dirs;
+    my %map_file_to_dir;
+
+    if ($jobs) {
+        require App::Prove::State;
+        $state = App::Prove::State->new({ store => 'test_state' });
+        $state->apply_switch('slow', 'save');
+        # For some reason get_tests returns *all* the tests previously run,
+        # (in the right order), not simply the selection in @tests
+        # (in the right order). Not sure if this is a bug or a feature.
+        # Whatever, *we* are only interested in the ones that are in @tests
+        my %seen;
+        @seen{@tests} = ();
+        @tests = grep {exists $seen{$_} } $state->get_tests(0, @tests);
+    }
+
+    my %times;
+    if ($state) {
+        # Where known, collate the elapsed times by test name
+        foreach ($state->results->tests()) {
+            $times{$_->name} = $_->elapsed();
+        }
+    }
+
+    # Preprocess the list of tests
+    for my $file (@tests) {
+        if ($^O eq 'MSWin32') {
+            $file =~ s,\\,/,g; # canonicalize path
+        };
+
+        # Keep a list of the distinct directory names, and another list of
+        # those which contain a file whose name begins with a 0
+        if ($file =~ m! \A ( (?: \.\. / )?
+                                .*?
+                            )             # $1 is the directory path name
+                            /
+                            ( [^/]* \. (?: t | pl ) ) # $2 is the test name
+                        \z !x)
+        {
+            my $path = $1;
+            my $name = $2;
+
+            $all_dirs{$path} = 1;
+            $map_file_to_dir{$file} = $path;
+
+            # We assume that the reason a test file's name begins with a 0
+            # is to order its execution among the tests in its directory.
+            # Hence, a directory containing such files should be tested in
+            # serial order, with some exceptions hard-coded in.
+            if ($name =~ / \A 0 /x) {
+                $serials{$path} = 1;
+            }
+            elsif (defined $must_be_executed_serially{$path}) {
+                $serials{$path} = 1;
+                delete $must_be_executed_serially{$path};
+            }
+        }
+    }
+
+    for my $file (@tests) {
+        my $file_dir = $map_file_to_dir{$file};
+
+        # Treat every file in each non-serial directory as its own
+        # "directory", so that it can be executed in parallel
+        if (! defined $serials{$file_dir}) {
+            $dir{$file} = { seq => $file };
+            $total_time{$file} = $times{$file} || 0;
+        }
+        else {  # Serial.  This file contributes time to the total needed
+                # for its directory as a whole
+            $dir{$file_dir} = { seq => "$file_dir/*" };
+            $total_time{$file_dir} += $times{$file} || 0;
+        }
+    }
+
+    undef %all_dirs;
+    undef %serials;
+
+    #print STDERR __LINE__, join "\n", sort sort_by_execution_order keys %dir
+
+    # Generate T::H schedule rules that run the contents of each directory
+    # sequentially.
+    my @seq = { par => [ map { $dir{$_} } sort sort_by_execution_order
+                                                                    keys %dir
+                        ]
+               };
+
+    return \@seq;
+}
+
 sub sort_by_execution_order {
     # Directories, ordered by total time descending then name ascending
     return $total_time{$b} <=> $total_time{$a} || lc $a cmp lc $b;
@@ -154,100 +249,13 @@ if (@ARGV) {
         # This is a bit of a game, because we only want to sort these tests in
         # speed order. base/*.t wants to run first, and ext,lib etc last and in
         # MANIFEST order
-        if ($jobs) {
-            require App::Prove::State;
-            $state = App::Prove::State->new({ store => 'test_state' });
-            $state->apply_switch('slow', 'save');
-            # For some reason get_tests returns *all* the tests previously run,
-            # (in the right order), not simply the selection in @tests
-            # (in the right order). Not sure if this is a bug or a feature.
-            # Whatever, *we* are only interested in the ones that are in @tests
-            my %seen;
-            @seen{@tests} = ();
-            @tests = grep {exists $seen{$_} } $state->get_tests(0, @tests);
-        }
         @tests = (@seq, @tests);
         push @seq, $next;
 
         push @last,
           _tests_from_manifest($Config{extensions}, $Config{known_extensions});
-        my %times;
-        if ($state) {
-            # Where known, collate the elapsed times by test name
-            foreach ($state->results->tests()) {
-                $times{$_->name} = $_->elapsed();
-            }
-        }
 
-        my %dir;
-        my %serials;
-        my %all_dirs;
-        my %map_file_to_dir;
-
-        # Preprocess the list of tests
-        for my $file (@last) {
-            if ($^O eq 'MSWin32') {
-                $file =~ s,\\,/,g; # canonicalize path
-            };
-
-            # Keep a list of the distinct directory names, and another list of
-            # those which contain a file whose name begins with a 0
-            if ($file =~ m! \A ( (?: \.\. / )?
-                                 .*?
-                               )             # $1 is the directory path name
-                               /
-                               ( [^/]* \. (?: t | pl ) ) # $2 is the test name
-                         \z !x)
-            {
-                my $path = $1;
-                my $name = $2;
-
-                $all_dirs{$path} = 1;
-                $map_file_to_dir{$file} = $path;
-
-                # We assume that the reason a test file's name begins with a 0
-                # is to order its execution among the tests in its directory.
-                # Hence, a directory containing such files should be tested in
-                # serial order, with some exceptions hard-coded in.
-                if ($name =~ / \A 0 /x) {
-                    $serials{$path} = 1;
-                }
-                elsif (defined $must_be_executed_serially{$path}) {
-                    $serials{$path} = 1;
-                    delete $must_be_executed_serially{$path};
-                }
-            }
-        }
-
-        for my $file (@last) {
-            my $file_dir = $map_file_to_dir{$file};
-
-            # Treat every file in each non-serial directory as its own
-            # "directory", so that it can be executed in parallel
-            if (! defined $serials{$file_dir}) {
-                $dir{$file} = { seq => $file };
-                $total_time{$file} = $times{$file} || 0;
-            }
-            else {  # Serial.  This file contributes time to the total needed
-                    # for its directory as a whole
-                $dir{$file_dir} = { seq => "$file_dir/*" };
-                $total_time{$file_dir} += $times{$file} || 0;
-            }
-        }
-
-        undef %all_dirs;
-        undef %serials;
-
-        #print STDERR __LINE__, join "\n", sort sort_by_execution_order keys %dir
-
-        push @tests, @last;
-
-        # Generate T::H schedule rules that run the contents of each directory
-        # sequentially.
-        push @seq, { par => [ map { $dir{$_} } sort sort_by_execution_order
-                                                                     keys %dir
-                            ]
-                   };
+        push @seq, _compute_tests_and_ordering(\@last)->@*;
 
         if (%must_be_executed_serially) {
             die "These directories to be run serially don't exist.  Check your"

--- a/t/harness
+++ b/t/harness
@@ -190,7 +190,7 @@ if (@ARGV) {
             if ( m! \A (?: \.\. / )?
                                 ( .*? )         # $1 is the directory path name
                             /
-                                ( [^/]* \.t )   # $2 is the .t name
+                               ( [^/]* \. (?: t | pl ) ) # $2 is the test name
                     \z !x)
             {
                 my $path = $1;

--- a/t/harness
+++ b/t/harness
@@ -45,18 +45,18 @@ sub _extract_tests {
     # would be as clear
     my @results;
     foreach (@_) {
-	my $ref = ref $_;
-	if ($ref) {
-	    if ($ref eq 'ARRAY') {
-		push @results, _extract_tests @$_;
-	    } elsif ($ref eq 'HASH') {
-		push @results, _extract_tests values %$_;
-	    } else {
-		die "Unknown reference type $ref";
-	    }
-	} else {
-	    push @results, glob $_;
-	}
+        my $ref = ref $_;
+        if ($ref) {
+            if ($ref eq 'ARRAY') {
+                push @results, _extract_tests @$_;
+            } elsif ($ref eq 'HASH') {
+                push @results, _extract_tests values %$_;
+            } else {
+                die "Unknown reference type $ref";
+            }
+        } else {
+            push @results, glob $_;
+        }
     }
     @results;
 }
@@ -121,10 +121,10 @@ if (@ARGV) {
     # but for now, run all directories in sequence.
 
     unless (@tests) {
-	my @seq = <base/*.t>;
+        my @seq = <base/*.t>;
 
         my @last;
-	my @next = qw(comp run cmd);
+        my @next = qw(comp run cmd);
 
         # The remaining core tests are either intermixed with the non-core for
         # more parallelism (if PERL_TEST_HARNESS_ASAP is set non-zero) or done
@@ -132,58 +132,58 @@ if (@ARGV) {
         my $which = $ENV{PERL_TEST_HARNESS_ASAP} ? \@last : \@next;
 
         push @$which, qw(io re opbasic op uni mro lib porting perf);
-	push @$which, 'japh' if $torture;
-	push @$which, 'win32' if $^O eq 'MSWin32';
-	push @$which, 'benchmark' if $ENV{PERL_BENCHMARK};
-	push @$which, 'bigmem' if $ENV{PERL_TEST_MEMORY};
+        push @$which, 'japh' if $torture;
+        push @$which, 'win32' if $^O eq 'MSWin32';
+        push @$which, 'benchmark' if $ENV{PERL_BENCHMARK};
+        push @$which, 'bigmem' if $ENV{PERL_TEST_MEMORY};
 
-	# Hopefully TAP::Parser::Scheduler will support this syntax soon.
-	# my $next = { par => '{' . join (',', @next) . '}/*.t' };
-	my $next = { par => [
-			     map { "$_/*.t" } @next
-			    ] };
-	@tests = _extract_tests ($next);
+        # Hopefully TAP::Parser::Scheduler will support this syntax soon.
+        # my $next = { par => '{' . join (',', @next) . '}/*.t' };
+        my $next = { par => [
+                             map { "$_/*.t" } @next
+                            ] };
+        @tests = _extract_tests ($next);
 
-	my $last = { par => '{' . join (',', @last) . '}/*.t' };
-	@last = _extract_tests ($last);
+        my $last = { par => '{' . join (',', @last) . '}/*.t' };
+        @last = _extract_tests ($last);
 
-	# This is a bit of a game, because we only want to sort these tests in
-	# speed order. base/*.t wants to run first, and ext,lib etc last and in
-	# MANIFEST order
-	if ($jobs) {
-	    require App::Prove::State;
-	    $state = App::Prove::State->new({ store => 'test_state' });
-	    $state->apply_switch('slow', 'save');
-	    # For some reason get_tests returns *all* the tests previously run,
-	    # (in the right order), not simply the selection in @tests
-	    # (in the right order). Not sure if this is a bug or a feature.
-	    # Whatever, *we* are only interested in the ones that are in @tests
-	    my %seen;
-	    @seen{@tests} = ();
-	    @tests = grep {exists $seen{$_} } $state->get_tests(0, @tests);
-	}
-	@tests = (@seq, @tests);
-	push @seq, $next;
+        # This is a bit of a game, because we only want to sort these tests in
+        # speed order. base/*.t wants to run first, and ext,lib etc last and in
+        # MANIFEST order
+        if ($jobs) {
+            require App::Prove::State;
+            $state = App::Prove::State->new({ store => 'test_state' });
+            $state->apply_switch('slow', 'save');
+            # For some reason get_tests returns *all* the tests previously run,
+            # (in the right order), not simply the selection in @tests
+            # (in the right order). Not sure if this is a bug or a feature.
+            # Whatever, *we* are only interested in the ones that are in @tests
+            my %seen;
+            @seen{@tests} = ();
+            @tests = grep {exists $seen{$_} } $state->get_tests(0, @tests);
+        }
+        @tests = (@seq, @tests);
+        push @seq, $next;
 
-	push @last,
-	    _tests_from_manifest($Config{extensions}, $Config{known_extensions});
-	my %times;
-	if ($state) {
-	    # Where known, collate the elapsed times by test name
-	    foreach ($state->results->tests()) {
-		$times{$_->name} = $_->elapsed();
-	    }
-	}
+        push @last,
+          _tests_from_manifest($Config{extensions}, $Config{known_extensions});
+        my %times;
+        if ($state) {
+            # Where known, collate the elapsed times by test name
+            foreach ($state->results->tests()) {
+                $times{$_->name} = $_->elapsed();
+            }
+        }
 
-	my %dir;
+        my %dir;
         my %serials;
         my %all_dirs;
 
         # Preprocess the list of tests
-	for my $file (@last) {
-	    if ($^O eq 'MSWin32') {
-		$file =~ s,\\,/,g; # canonicalize path
-	    };
+        for my $file (@last) {
+            if ($^O eq 'MSWin32') {
+                $file =~ s,\\,/,g; # canonicalize path
+            };
 
             # Keep a list of the distinct directory names, and another list of
             # those which contain a file whose name begins with a 0
@@ -225,30 +225,30 @@ if (@ARGV) {
         undef %all_dirs;
         undef %serials;
 
-	for my $file (@last) {
+        for my $file (@last) {
             # Treat every file in each non-serial directory as its own
             # "directory", so that it can be executed in parallel
             $file =~ m! \A ( (?: \.\. / )? (?: $non_serials )
                          / [^/]+ \.t \z | .* [/] ) !x
                 or die "'$file'";
-	    push @{$dir{$1}}, $file;
+            push @{$dir{$1}}, $file;
 
             # This file contributes time to the total needed for the directory
             # as a whole
-	    $total_time{$1} += $times{$file} || 0;
-	}
+            $total_time{$1} += $times{$file} || 0;
+        }
         #print STDERR __LINE__, join "\n", sort sort_by_execution_order keys %dir
 
-	push @tests, @last;
+        push @tests, @last;
 
-	# Generate T::H schedule rules that run the contents of each directory
-	# sequentially.
-	push @seq, { par => [ map { s!/$!/*!; { seq => $_ } } sort
+        # Generate T::H schedule rules that run the contents of each directory
+        # sequentially.
+        push @seq, { par => [ map { s!/$!/*!; { seq => $_ } } sort
                                                 sort_by_execution_order keys %dir
                             ]
                    };
 
-	$rules = { seq => \@seq };
+        $rules = { seq => \@seq };
     }
 }
 if ($^O eq 'MSWin32') {
@@ -300,71 +300,71 @@ my $h = TAP::Harness->new({
     verbosity   => $Verbose,
     timer       => $ENV{HARNESS_TIMER},
     exec        => sub {
-	my ($harness, $test) = @_;
+        my ($harness, $test) = @_;
 
-	my $options = $options{$test};
-	if (!defined $options) {
-	    $options = $options{$test} = _scan_test($test, $type);
-	}
+        my $options = $options{$test};
+        if (!defined $options) {
+            $options = $options{$test} = _scan_test($test, $type);
+        }
 
-	(local $Valgrind_Log = "$test.valgrind-current") =~ s/^.*\///;
+        (local $Valgrind_Log = "$test.valgrind-current") =~ s/^.*\///;
 
-	return [ split ' ', _cmd($options, $type) ];
+        return [ split ' ', _cmd($options, $type) ];
     },
 });
 
 # Print valgrind output after test completes
 if ($ENV{PERL_VALGRIND}) {
     $h->callback(
-		 after_test => sub {
-		     my ($job) = @_;
-		     my $test = $job->[0];
-		     my $vfile = "$test.valgrind-current";
-	             $vfile =~ s/^.*\///;
+                 after_test => sub {
+                     my ($job) = @_;
+                     my $test = $job->[0];
+                     my $vfile = "$test.valgrind-current";
+                     $vfile =~ s/^.*\///;
 
-		     if ( (! -z $vfile) && open(my $voutput, '<', $vfile)) {
-			print "$test: Valgrind output:\n";
-			print "$test: $_" for <$voutput>;
-			close($voutput);
-		     }
+                     if ( (! -z $vfile) && open(my $voutput, '<', $vfile)) {
+                        print "$test: Valgrind output:\n";
+                        print "$test: $_" for <$voutput>;
+                        close($voutput);
+                     }
 
-		     (local $Valgrind_Log = "$test.valgrind-current") =~ s/^.*\///;
+                     (local $Valgrind_Log = "$test.valgrind-current") =~ s/^.*\///;
 
-		     _check_valgrind(\$htoolnm, \$hgrind_ct, \$test);
-		 }
-		 );
+                     _check_valgrind(\$htoolnm, \$hgrind_ct, \$test);
+                 }
+                 );
 }
 
 if ($state) {
     $h->callback(
-		 after_test => sub {
-		     $state->observe_test(@_);
-		 }
-		 );
+                 after_test => sub {
+                     $state->observe_test(@_);
+                 }
+                 );
     $h->callback(
-		 after_runtests => sub {
-		     $state->commit(@_);
-		 }
-		 );
+                 after_runtests => sub {
+                     $state->commit(@_);
+                 }
+                 );
 }
 
 $h->callback(
-	     parser_args => sub {
-		 my ($args, $job) = @_;
-		 my $test = $job->[0];
-		 _before_fork($options{$test});
-		 push @{ $args->{switches} }, "-I../../lib";
-	     }
-	     );
+             parser_args => sub {
+                 my ($args, $job) = @_;
+                 my $test = $job->[0];
+                 _before_fork($options{$test});
+                 push @{ $args->{switches} }, "-I../../lib";
+             }
+             );
 
 $h->callback(
-	     made_parser => sub {
-		 my ($parser, $job) = @_;
-		 my $test = $job->[0];
-		 my $options = delete $options{$test};
-		 _after_fork($options);
-	     }
-	     );
+             made_parser => sub {
+                 my ($parser, $job) = @_;
+                 my $test = $job->[0];
+                 my $options = delete $options{$test};
+                 _after_fork($options);
+             }
+             );
 
 my $agg = $h->runtests(@tests);
 _cleanup_valgrind(\$htoolnm, \$hgrind_ct);

--- a/t/harness
+++ b/t/harness
@@ -39,6 +39,36 @@ my (@tests, @re, @anti_re);
 # [.VMS]TEST.COM calls harness with empty arguments, so clean-up @ARGV
 @ARGV = grep $_ && length( $_ ) => @ARGV;
 
+while ($ARGV[0] && $ARGV[0]=~/^-(n?)re/) {
+    my $ary= $1 ? \@anti_re : \@re;
+
+    if ( $ARGV[0] !~ /=/ ) {
+        shift @ARGV;
+        while (@ARGV and $ARGV[0] !~ /^-/) {
+            push @$ary, shift @ARGV;
+        }
+    } else {
+        push @$ary, (split/=/,shift @ARGV)[1];
+    }
+}
+
+my $jobs = $ENV{TEST_JOBS};
+my ($rules, $state, $color);
+
+if ($ENV{HARNESS_OPTIONS}) {
+    for my $opt ( split /:/, $ENV{HARNESS_OPTIONS} ) {
+        if ( $opt =~ /^j(\d*)$/ ) {
+            $jobs ||= $1 || 9;
+        }
+        elsif ( $opt eq 'c' ) {
+            $color = 1;
+        }
+        else {
+            die "Unknown HARNESS_OPTIONS item: $opt\n";
+        }
+    }
+}
+
 sub _extract_tests;
 sub _extract_tests {
     # This can probably be done more tersely with a map, but I doubt that it
@@ -59,35 +89,6 @@ sub _extract_tests {
         }
     }
     @results;
-}
-
-while ($ARGV[0] && $ARGV[0]=~/^-(n?)re/) {
-    my $ary= $1 ? \@anti_re : \@re;
-
-    if ( $ARGV[0] !~ /=/ ) {
-        shift @ARGV;
-        while (@ARGV and $ARGV[0] !~ /^-/) {
-            push @$ary, shift @ARGV;
-        }
-    } else {
-        push @$ary, (split/=/,shift @ARGV)[1];
-    }
-}
-
-my $jobs = $ENV{TEST_JOBS};
-my ($rules, $state, $color);
-if ($ENV{HARNESS_OPTIONS}) {
-    for my $opt ( split /:/, $ENV{HARNESS_OPTIONS} ) {
-        if ( $opt =~ /^j(\d*)$/ ) {
-            $jobs ||= $1 || 9;
-        }
-        elsif ( $opt eq 'c' ) {
-            $color = 1;
-        }
-        else {
-            die "Unknown HARNESS_OPTIONS item: $opt\n";
-        }
-    }
 }
 
 my %total_time;

--- a/t/harness
+++ b/t/harness
@@ -90,6 +90,13 @@ if ($ENV{HARNESS_OPTIONS}) {
     }
 }
 
+my %total_time;
+
+sub sort_by_execution_order {
+    # Directories, ordered by total time descending then name ascending
+    return $total_time{$b} <=> $total_time{$a} || lc $a cmp lc $b;
+}
+
 if (@ARGV) {
     # If you want these run in speed order, just use prove
 
@@ -169,7 +176,6 @@ if (@ARGV) {
 	}
 
 	my %dir;
-	my %total_time;
         my %serials;
         my %all_dirs;
 
@@ -229,16 +235,16 @@ if (@ARGV) {
             # as a whole
 	    $total_time{$1} += $times{$_} || 0;
 	}
-        #print STDERR __LINE__, join "\n", sort { $total_time{$b} <=> $total_time{$a} } keys %dir, "  ";
+        #print STDERR __LINE__, join "\n", sort sort_by_execution_order keys %dir
 
 	push @tests, @last;
 
 	# Generate T::H schedule rules that run the contents of each directory
 	# sequentially.
-	push @seq, { par => [ map { s!/$!/*!; { seq => $_ } } sort {
-	    # Directories, ordered by total time descending then name ascending
-	    $total_time{$b} <=> $total_time{$a} || lc $a cmp lc $b
-	} keys %dir ] };
+	push @seq, { par => [ map { s!/$!/*!; { seq => $_ } } sort
+                                                sort_by_execution_order keys %dir
+                            ]
+                   };
 
 	$rules = { seq => \@seq };
     }

--- a/t/harness
+++ b/t/harness
@@ -236,25 +236,16 @@ if (@ARGV) {
         push @$which, 'benchmark' if $ENV{PERL_BENCHMARK};
         push @$which, 'bigmem' if $ENV{PERL_TEST_MEMORY};
 
-        # Hopefully TAP::Parser::Scheduler will support this syntax soon.
-        # my $next = { par => '{' . join (',', @next) . '}/*.t' };
-        my $next = { par => [
-                             map { "$_/*.t" } @next
-                            ] };
+        my $next = { par => '{' . join (',', @next) . '}/*.t' };
         @tests = _extract_tests ($next);
+        push @seq, _compute_tests_and_ordering(\@tests)->@*;
 
         my $last = { par => '{' . join (',', @last) . '}/*.t' };
         @last = _extract_tests ($last);
-
-        # This is a bit of a game, because we only want to sort these tests in
-        # speed order. base/*.t wants to run first, and ext,lib etc last and in
-        # MANIFEST order
-        @tests = (@seq, @tests);
-        push @seq, $next;
-
         push @last,
           _tests_from_manifest($Config{extensions}, $Config{known_extensions});
 
+        push @tests, @last;
         push @seq, _compute_tests_and_ordering(\@last)->@*;
 
         if (%must_be_executed_serially) {

--- a/t/harness
+++ b/t/harness
@@ -187,8 +187,9 @@ if (@ARGV) {
 
             # Keep a list of the distinct directory names, and another list of
             # those which contain a file whose name begins with a 0
-            if ($file =~ m! \A (?: \.\. / )?
-                                ( .*? )         # $1 is the directory path name
+            if ($file =~ m! \A ( (?: \.\. / )?
+                                 .*?
+                               )             # $1 is the directory path name
                                /
                                ( [^/]* \. (?: t | pl ) ) # $2 is the test name
                          \z !x)
@@ -206,7 +207,7 @@ if (@ARGV) {
         # directory containing such files should be tested in serial order.
         #
         # Add exceptions to the above rule
-        for (qw(cpan/IO-Zlib/t ext/File-Find/t)) {
+        for (qw(../cpan/IO-Zlib/t ../ext/File-Find/t)) {
             $serials{$_} = 1;
         }
 

--- a/t/harness
+++ b/t/harness
@@ -205,6 +205,10 @@ if (@ARGV) {
                 $all_dirs{$path} = 1;
                 $map_file_to_dir{$file} = $path;
 
+                # We assume that the reason a test file's name begins with a 0
+                # is to order its execution among the tests in its directory.
+                # Hence, a directory containing such files should be tested in
+                # serial order, with some exceptions hard-coded in.
                 if ($name =~ / \A 0 /x) {
                     $serials{$path} = 1;
                 }
@@ -214,10 +218,6 @@ if (@ARGV) {
                 }
             }
         }
-
-        # We assume that the reason a test file's name begins with a 0 is to
-        # order its execution among the tests in its directory.  Hence, a
-        # directory containing such files should be tested in serial order.
 
         for my $file (@last) {
             my $file_dir = $map_file_to_dir{$file};

--- a/t/harness
+++ b/t/harness
@@ -221,24 +221,28 @@ if (@ARGV) {
 
     unless (@tests) {
         my @seq = <base/*.t>;
+        push @tests, @seq;
 
-        my @last;
-        my @next = qw(comp run cmd);
+        my (@next, @last);
 
         # The remaining core tests are either intermixed with the non-core for
         # more parallelism (if PERL_TEST_HARNESS_ASAP is set non-zero) or done
         # after the above basic sanity tests, before any non-core ones.
         my $which = $ENV{PERL_TEST_HARNESS_ASAP} ? \@last : \@next;
 
+        push @$which, qw(comp run cmd);
         push @$which, qw(io re opbasic op uni mro lib porting perf);
         push @$which, 'japh' if $torture;
         push @$which, 'win32' if $^O eq 'MSWin32';
         push @$which, 'benchmark' if $ENV{PERL_BENCHMARK};
         push @$which, 'bigmem' if $ENV{PERL_TEST_MEMORY};
 
-        my $next = { par => '{' . join (',', @next) . '}/*.t' };
-        @tests = _extract_tests ($next);
-        push @seq, _compute_tests_and_ordering(\@tests)->@*;
+        if (@next) {
+            my $next = { par => '{' . join (',', @next) . '}/*.t' };
+            @next = _extract_tests ($next);
+            push @tests, @next;
+            push @seq, _compute_tests_and_ordering(\@next)->@*;
+        }
 
         my $last = { par => '{' . join (',', @last) . '}/*.t' };
         @last = _extract_tests ($last);


### PR DESCRIPTION
This series of commits does better parallelization of the test suite, especially when PERL_TEST_HARNESS_ASAP is set.  That leads to an improvement on my box of 30-40% in elapsed time for executing the suite