### PR TITLE
More graceful and helpful handling of overloaded objects in @INC.

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -1183,6 +1183,14 @@ to load "%s"?)
 could not be found in UNIVERSAL.  This often means that a method
 requires a package that has not been loaded.
 
+=item Can't locate object method "INC", nor "INCDIR" nor string overload via package %s %s in @INC
+
+(F) You pushed an object, either directly or via an array reference hook,
+into C<@INC>, but the object doesn't support any known hook methods, nor
+a string overload and is also not a blessed CODE reference. In short the
+C<require> function does not know what to do with the object.
+See also L<perlfunc/require>.
+
 =item Can't locate package %s for @%s::ISA
 
 (W syntax) The @ISA array contained the name of another package that
@@ -4460,14 +4468,6 @@ report.  This limit is typically 2GB.
 and you mentioned a variable that starts with 0 that has more than one
 digit. You probably want to remove the leading 0, or if the intent was
 to express a variable name in octal you should convert to decimal.
-
-=item Object with arguments in @INC does not support a hook method
-
-(F) You pushed an array reference hook into C<@INC> which has an object
-as the first argument, but the object doesn't support any known hooks.
-Since you used the array form of creating a hook, you should have supplied
-an object that supports either the C<INC> or C<INCDIR> methods. You
-could also use a coderef instead of an object.
 
 =item Octal number > 037777777777 non-portable
 

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4316,7 +4316,12 @@ S_require_file(pTHX_ SV *sv)
                         && !SvOBJECT(SvRV(loader)))
                     {
                         loader = *av_fetch(MUTABLE_AV(SvRV(loader)), 0, TRUE);
-                        SvGETMAGIC(loader);
+                        if (SvGMAGICAL(loader)) {
+                            SvGETMAGIC(loader);
+                            SV *l = sv_newmortal();
+                            sv_setsv_nomg(l, loader);
+                            loader = l;
+                        }
                     }
 
                     if (SvPADTMP(nsv)) {
@@ -4357,10 +4362,18 @@ S_require_file(pTHX_ SV *sv)
                          */
                         if (!method) {
                             if (SvTYPE(SvRV(loader)) != SVt_PVCV) {
-                                if (dirsv != loader)
-                                    croak("Object with arguments in @INC does not support a hook method");
-                                else
+                                if (amagic_applies(loader,string_amg,AMGf_unary))
                                     goto treat_as_string;
+                                else {
+                                    croak("Can't locate object method \"INC\", nor"
+                                          " \"INCDIR\" nor string overload via"
+                                          " package %" HvNAMEf_QUOTEDPREFIX " %s"
+                                          " in @INC", pkg,
+                                          dirsv == loader
+                                          ? "in object hook"
+                                          : "in object in ARRAY hook"
+                                    );
+                                }
                             }
                         }
                     }
@@ -4379,11 +4392,6 @@ S_require_file(pTHX_ SV *sv)
                     if (method && (loader != dirsv)) /* add the args array for method calls */
                         PUSHs(dirsv);
                     PUTBACK;
-                    if (SvGMAGICAL(loader)) {
-                        SV *l = sv_newmortal();
-                        sv_setsv_nomg(l, loader);
-                        loader = l;
-                    }
                     if (method) {
                         count = call_method(method, G_LIST|G_EVAL);
                     } else {


### PR DESCRIPTION
This PR adds logic to detect if objects in @INC have a string overload if they are not blessed CODE refs, and do not support a valid INC hook method (INC or INCDIR). If they do have an overload then we call it to stringify the hook. Otherwise we throw an exception. It does not make sense to actually look on disk for ARRAY(0x....) and in theory it could be a security issue if we do. (The practical likelyhood of this being a real issue is very low, but still.)

In older versions of perl we would throw an exception about not finding the INC method. This is more informative. 