### PR TITLE
Change function signature to allow for fallback

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -635,7 +635,7 @@ XEop	|bool	|try_amagic_bin	|int method|int flags
 XEop	|bool	|try_amagic_un	|int method|int flags
 Apd	|SV*	|amagic_call	|NN SV* left|NN SV* right|int method|int dir
 Apd	|SV *	|amagic_deref_call|NN SV *ref|int method
-Apd	|CV *	|amagic_find	|NN SV *sv|int method|int flags
+Epd	|CV *	|amagic_find	|NN SV *sv|NN int *method|int flags
 p	|bool	|amagic_is_enabled|int method
 Apd	|int	|Gv_AMupdate	|NN HV* stash|bool destructing
 CpdR	|CV*	|gv_handler	|NULLOK HV* stash|I32 id

--- a/embed.h
+++ b/embed.h
@@ -59,7 +59,6 @@
 #define _utf8n_to_uvchr_msgs_helper	Perl__utf8n_to_uvchr_msgs_helper
 #define amagic_call(a,b,c,d)	Perl_amagic_call(aTHX_ a,b,c,d)
 #define amagic_deref_call(a,b)	Perl_amagic_deref_call(aTHX_ a,b)
-#define amagic_find(a,b,c)	Perl_amagic_find(aTHX_ a,b,c)
 #define apply_attrs_string(a,b,c,d)	Perl_apply_attrs_string(aTHX_ a,b,c,d)
 #define apply_builtin_cv_attributes(a,b)	Perl_apply_builtin_cv_attributes(aTHX_ a,b)
 #define atfork_lock		Perl_atfork_lock
@@ -926,6 +925,7 @@
 #if defined(PERL_CORE) || defined(PERL_EXT)
 #define _byte_dump_string(a,b,c)	Perl__byte_dump_string(aTHX_ a,b,c)
 #define _inverse_folds(a,b,c)	Perl__inverse_folds(aTHX_ a,b,c)
+#define amagic_find(a,b,c)	Perl_amagic_find(aTHX_ a,b,c)
 #define append_utf8_from_native_byte	Perl_append_utf8_from_native_byte
 #define av_reify(a)		Perl_av_reify(aTHX_ a)
 #define cntrl_to_mnemonic	Perl_cntrl_to_mnemonic

--- a/gv.c
+++ b/gv.c
@@ -3380,7 +3380,7 @@ Perl_try_amagic_un(pTHX_ int method, int flags) {
 /*
 =for apidoc amagic_find
 
-Check C<sv> for the overloaded (active magic) operation C<method>, and
+Check C<sv> for the overloaded (active magic) operation C<*method>, and
 return the C<CV *> or C<NULL>.
 
 C<method> is one of the values found in F<overload.h>.
@@ -3390,12 +3390,12 @@ C<flags> are available for future use.
 =cut
 */
 CV *
-Perl_amagic_find(pTHX_ SV *sv, int method, int flags)
+Perl_amagic_find(pTHX_ SV *sv, int *method, int flags)
 {
     PERL_ARGS_ASSERT_AMAGIC_FIND;
     PERL_UNUSED_VAR(flags);
 
-    assert(method >= 0 && method < NofAMmeth);
+    assert(*method >= 0 && *method < NofAMmeth);
 
     if (!SvAMAGIC(sv))
         return NULL;
@@ -3414,7 +3414,7 @@ Perl_amagic_find(pTHX_ SV *sv, int method, int flags)
     if (!cvp)
         return NULL;
 
-    CV *cv = cvp[method];
+    CV *cv = cvp[*method];
     return cv;
 }
 

--- a/proto.h
+++ b/proto.h
@@ -252,9 +252,11 @@ PERL_CALLCONV SV*	Perl_amagic_call(pTHX_ SV* left, SV* right, int method, int di
 PERL_CALLCONV SV *	Perl_amagic_deref_call(pTHX_ SV *ref, int method);
 #define PERL_ARGS_ASSERT_AMAGIC_DEREF_CALL	\
 	assert(ref)
-PERL_CALLCONV CV *	Perl_amagic_find(pTHX_ SV *sv, int method, int flags);
+PERL_CALLCONV CV *	Perl_amagic_find(pTHX_ SV *sv, int *method, int flags)
+			__attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AMAGIC_FIND	\
-	assert(sv)
+	assert(sv); assert(method)
+
 PERL_CALLCONV bool	Perl_amagic_is_enabled(pTHX_ int method)
 			__attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AMAGIC_IS_ENABLED


### PR DESCRIPTION
By changing `int method` to `int *method`, this opens the door for the function to honor fall-back, and inform the caller of which method the CV * is for.

By changing the embed from API to PERL_EXT, this signals that uses are internal, so far. When the fallback issues are resolved it can become an API function again.

Partially addresses #20627

This patch follows the guidance from @demerphq who wrote "This is something we should iterate on, not throw away because it's not perfect."