### PR TITLE
Split notifications between the two channels

### DIFF
--- a/.github/workflows/irc-notifications.yaml
+++ b/.github/workflows/irc-notifications.yaml
@@ -16,7 +16,8 @@ jobs:
     env:
       server: ssl.irc.perl.org
       port: 7062
-      channel: "#p5p-commits"
+      channel_p5p: "#p5p"
+      channel_noise: "#p5p-commits"
 
     steps:
       - name: Dump GitHub context
@@ -89,7 +90,7 @@ jobs:
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
-          channel: ${{ env.channel }}
+          channel: ${{ env.channel_noise }}
           nickname: Commit
           message:
             "\x037${{ github.actor }}\x0F pushed to branch \x033${{ env.ref }}\x0F\n\
@@ -102,7 +103,7 @@ jobs:
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
-          channel: ${{ env.channel }}
+          channel: ${{ env.channel_noise }}
           nickname: inBlead
           message:
             "\x0313[blead]\x0F \x037${{ github.actor }}\x0F pushed to blead\n\
@@ -151,12 +152,24 @@ jobs:
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
-          channel: ${{ env.channel }}
+          channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
           message:
             "\x037${{ github.actor }}\x0F opened PR #${{ github.event.pull_request.number }}\n\
             ${{ env.TITLE }}\n\
-            ${{ env.BODY }}\n\
+            ${{ github.event.pull_request.html_url }}"
+
+      - name: irc closed pull request
+        uses: rectalogic/notify-irc@v2
+        if: github.event_name == 'pull_request' && github.event.action == 'closed'
+        with:
+          server: ${{ env.server }}
+          port: ${{ env.port }}
+          channel: ${{ env.channel_p5p }}
+          nickname: Pull-Request
+          message:
+            "\x037${{ github.actor }}\x0F close PR #${{ github.event.pull_request.number }}\n\
+            ${{ env.TITLE }}\n\
             ${{ github.event.pull_request.html_url }}"
 
       - name: irc synchronize pull request
@@ -165,7 +178,7 @@ jobs:
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
-          channel: ${{ env.channel }}
+          channel: ${{ env.channel_noise }}
           nickname: Pull-Request
           message:
             "\x037${{ github.actor }}\x0F updated PR #${{ github.event.pull_request.number }}\n\

--- a/.github/workflows/irc-notifications.yaml
+++ b/.github/workflows/irc-notifications.yaml
@@ -18,6 +18,8 @@ jobs:
       port: 7062
       channel_p5p: "#p5p"
       channel_noise: "#p5p-commits"
+      color_orange: "\x037"
+      color_clear: "\x0F"
 
     steps:
       - name: Dump GitHub context
@@ -154,10 +156,10 @@ jobs:
           port: ${{ env.port }}
           channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
-          message:
-            "\x037${{ github.actor }}\x0F opened PR #${{ github.event.pull_request.number }}\n\
-            ${{ env.TITLE }}\n\
-            ${{ github.event.pull_request.html_url }}"
+          message: |
+            ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} opened PR #${{ github.event.pull_request.number }}
+            ${{ env.TITLE }}
+            ${{ github.event.pull_request.html_url }}
 
       - name: irc merged pull request
         uses: rectalogic/notify-irc@v2
@@ -167,10 +169,10 @@ jobs:
           port: ${{ env.port }}
           channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
-          message:
-            "\x037${{ github.actor }}\x0F merged PR #${{ github.event.pull_request.number }}\n\
-            ${{ env.TITLE }}\n\
-            ${{ github.event.pull_request.html_url }}"
+          message: |
+            ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} merged PR #${{ github.event.pull_request.number }}
+            ${{ env.TITLE }}
+            ${{ github.event.pull_request.html_url }}
 
       - name: irc closed pull request
         uses: rectalogic/notify-irc@v2
@@ -180,10 +182,10 @@ jobs:
           port: ${{ env.port }}
           channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
-          message:
-            "\x037${{ github.actor }}\x0F closed PR #${{ github.event.pull_request.number }}\n\
-            ${{ env.TITLE }}\n\
-            ${{ github.event.pull_request.html_url }}"
+          message: |
+            ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} closed PR #${{ github.event.pull_request.number }}
+            ${{ env.TITLE }}
+            ${{ github.event.pull_request.html_url }}
 
       - name: irc synchronize pull request
         uses: rectalogic/notify-irc@v2
@@ -193,7 +195,7 @@ jobs:
           port: ${{ env.port }}
           channel: ${{ env.channel_noise }}
           nickname: Pull-Request
-          message:
-            "\x037${{ github.actor }}\x0F updated PR #${{ github.event.pull_request.number }}\n\
-            ${{ env.TITLE }}\n\
-            ${{ github.event.pull_request.html_url }}"
+          message: |
+            ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} updated PR #${{ github.event.pull_request.number }}
+            ${{ env.TITLE }}
+            ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/irc-notifications.yaml
+++ b/.github/workflows/irc-notifications.yaml
@@ -159,16 +159,29 @@ jobs:
             ${{ env.TITLE }}\n\
             ${{ github.event.pull_request.html_url }}"
 
-      - name: irc closed pull request
+      - name: irc merged pull request
         uses: rectalogic/notify-irc@v2
-        if: github.event_name == 'pull_request' && github.event.action == 'closed'
+        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
           channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
           message:
-            "\x037${{ github.actor }}\x0F close PR #${{ github.event.pull_request.number }}\n\
+            "\x037${{ github.actor }}\x0F merged PR #${{ github.event.pull_request.number }}\n\
+            ${{ env.TITLE }}\n\
+            ${{ github.event.pull_request.html_url }}"
+
+      - name: irc closed pull request
+        uses: rectalogic/notify-irc@v2
+        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == false
+        with:
+          server: ${{ env.server }}
+          port: ${{ env.port }}
+          channel: ${{ env.channel_p5p }}
+          nickname: Pull-Request
+          message:
+            "\x037${{ github.actor }}\x0F closed PR #${{ github.event.pull_request.number }}\n\
             ${{ env.TITLE }}\n\
             ${{ github.event.pull_request.html_url }}"
 

--- a/.github/workflows/irc-notifications.yaml
+++ b/.github/workflows/irc-notifications.yaml
@@ -84,7 +84,7 @@ jobs:
           echo "SUMUP: $SUMUP"
 
       - name: irc push
-        uses: rectalogic/notify-irc@v1
+        uses: rectalogic/notify-irc@v2
         if: github.event_name == 'push' && github.ref != 'refs/heads/blead'
         with:
           server: ${{ env.server }}
@@ -97,7 +97,7 @@ jobs:
             ${{ github.event.compare }}"
 
       - name: irc push to blead
-        uses: rectalogic/notify-irc@v1
+        uses: rectalogic/notify-irc@v2
         if: github.event_name == 'push' && github.ref == 'refs/heads/blead'
         with:
           server: ${{ env.server }}
@@ -146,7 +146,7 @@ jobs:
           echo "TITLE: $TITLE"
 
       - name: irc opened pull request
-        uses: rectalogic/notify-irc@v1
+        uses: rectalogic/notify-irc@v2
         if: github.event_name == 'pull_request' && github.event.action == 'opened'
         with:
           server: ${{ env.server }}
@@ -160,7 +160,7 @@ jobs:
             ${{ github.event.pull_request.html_url }}"
 
       - name: irc synchronize pull request
-        uses: rectalogic/notify-irc@v1
+        uses: rectalogic/notify-irc@v2
         if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
         with:
           server: ${{ env.server }}


### PR DESCRIPTION
    The idea is the following.

    Advertise opened and closed Pull Requests to #p5p
    and use #p5p-commits for any extra notifications
    so we reduce noise to #p5p to its minimum.

    Remove body from opened PR and only use title.

previously submitted as  #20633