### PR TITLE
gv.c - rename amagic_find() to amagic_applies()

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -635,7 +635,7 @@ XEop	|bool	|try_amagic_bin	|int method|int flags
 XEop	|bool	|try_amagic_un	|int method|int flags
 Apd	|SV*	|amagic_call	|NN SV* left|NN SV* right|int method|int dir
 Apd	|SV *	|amagic_deref_call|NN SV *ref|int method
-Apd	|CV *	|amagic_find	|NN SV *sv|int method|int flags
+Xpd	|bool	|amagic_applies	|NN SV *sv|int method|int flags
 p	|bool	|amagic_is_enabled|int method
 Apd	|int	|Gv_AMupdate	|NN HV* stash|bool destructing
 CpdR	|CV*	|gv_handler	|NULLOK HV* stash|I32 id

--- a/embed.h
+++ b/embed.h
@@ -59,7 +59,6 @@
 #define _utf8n_to_uvchr_msgs_helper	Perl__utf8n_to_uvchr_msgs_helper
 #define amagic_call(a,b,c,d)	Perl_amagic_call(aTHX_ a,b,c,d)
 #define amagic_deref_call(a,b)	Perl_amagic_deref_call(aTHX_ a,b)
-#define amagic_find(a,b,c)	Perl_amagic_find(aTHX_ a,b,c)
 #define apply_attrs_string(a,b,c,d)	Perl_apply_attrs_string(aTHX_ a,b,c,d)
 #define apply_builtin_cv_attributes(a,b)	Perl_apply_builtin_cv_attributes(aTHX_ a,b)
 #define atfork_lock		Perl_atfork_lock
@@ -1234,6 +1233,7 @@
 #define abort_execution(a,b)	Perl_abort_execution(aTHX_ a,b)
 #define alloc_LOGOP(a,b,c)	Perl_alloc_LOGOP(aTHX_ a,b,c)
 #define allocmy(a,b,c)		Perl_allocmy(aTHX_ a,b,c)
+#define amagic_applies(a,b,c)	Perl_amagic_applies(aTHX_ a,b,c)
 #define amagic_is_enabled(a)	Perl_amagic_is_enabled(aTHX_ a)
 #define apply(a,b,c)		Perl_apply(aTHX_ a,b,c)
 #define av_extend_guts(a,b,c,d,e)	Perl_av_extend_guts(aTHX_ a,b,c,d,e)

--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.28';
+our $VERSION = '1.29';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -1717,6 +1717,18 @@ test_uvchr_to_utf8_flags_msgs(uv, flags)
 MODULE = XS::APItest:Overload   PACKAGE = XS::APItest::Overload
 
 void
+does_amagic_apply(sv, method, flags)
+    SV *sv
+    int method
+    int flags
+    PPCODE:
+        if(Perl_amagic_applies(aTHX_ sv, method, flags))
+            XSRETURN_YES;
+        else
+            XSRETURN_NO;
+
+
+void
 amagic_deref_call(sv, what)
         SV *sv
         int what

--- a/proto.h
+++ b/proto.h
@@ -246,15 +246,15 @@ PERL_CALLCONV PADOFFSET	Perl_allocmy(pTHX_ const char *const name, const STRLEN 
 #define PERL_ARGS_ASSERT_ALLOCMY	\
 	assert(name)
 
+PERL_CALLCONV bool	Perl_amagic_applies(pTHX_ SV *sv, int method, int flags);
+#define PERL_ARGS_ASSERT_AMAGIC_APPLIES	\
+	assert(sv)
 PERL_CALLCONV SV*	Perl_amagic_call(pTHX_ SV* left, SV* right, int method, int dir);
 #define PERL_ARGS_ASSERT_AMAGIC_CALL	\
 	assert(left); assert(right)
 PERL_CALLCONV SV *	Perl_amagic_deref_call(pTHX_ SV *ref, int method);
 #define PERL_ARGS_ASSERT_AMAGIC_DEREF_CALL	\
 	assert(ref)
-PERL_CALLCONV CV *	Perl_amagic_find(pTHX_ SV *sv, int method, int flags);
-#define PERL_ARGS_ASSERT_AMAGIC_FIND	\
-	assert(sv)
 PERL_CALLCONV bool	Perl_amagic_is_enabled(pTHX_ int method)
 			__attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AMAGIC_IS_ENABLED


### PR DESCRIPTION
The api for amagic_find() didnt make as much as sense as we thought at first. Most people will be using this as a predicate, and don't care about the returned CV, so to simplify things until we can really think this through the required API this switches it to return a bool and renames it to amagic_applies(), as in "which amagic_applies to this sv".

See https://github.com/Perl/perl5/pull/20626 for example usage with tests.