### PR TITLE
sv.c - add support for HvNAMEf and HvNAMEf_QUOTEDPREFIX formats

### DIFF
--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.29';
+our $VERSION = '1.30';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -4676,6 +4676,27 @@ test_MAX_types()
     OUTPUT:
         RETVAL
 
+SV *
+test_HvNAMEf(sv)
+    SV *sv
+    CODE:
+        if (!sv_isobject(sv)) XSRETURN_UNDEF;
+        HV *pkg = SvSTASH(SvRV(sv));
+        RETVAL = newSVpvf("class='%" HvNAMEf "'", pkg);
+    OUTPUT:
+        RETVAL
+
+SV *
+test_HvNAMEf_QUOTEDPREFIX(sv)
+    SV *sv
+    CODE:
+        if (!sv_isobject(sv)) XSRETURN_UNDEF;
+        HV *pkg = SvSTASH(SvRV(sv));
+        RETVAL = newSVpvf("class=%" HvNAMEf_QUOTEDPREFIX, pkg);
+    OUTPUT:
+        RETVAL
+
+
 bool
 sv_numeq(SV *sv1, SV *sv2)
     CODE:

--- a/ext/XS-APItest/t/svcatpvf.t
+++ b/ext/XS-APItest/t/svcatpvf.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 4;
+use Test::More tests => 6;
 
 use XS::APItest;
 
@@ -19,3 +19,13 @@ for my $case (@cases) {
     like($exn, qr/\b\QCannot yet reorder sv_vcatpvfn() arguments from va_list\E\b/,
          "explicit $what index forbidden in va_list arguments");
 }
+
+# these actually test newSVpvf() but it is the same underlying logic.
+is(test_HvNAMEf(bless {}, "Whatever::You::Like"),
+    "class='Whatever::You::Like'");
+is(test_HvNAMEf_QUOTEDPREFIX(bless {}, "x" x 1000),
+    'class="xxxxxxxxxxxxxxxxxxxxxxxxxx'.
+    'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'.
+    'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"..."xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'.
+    'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'.
+    'xxxxxxxxxxxxxxxxxxxxx"');

--- a/perl.h
+++ b/perl.h
@@ -4147,6 +4147,8 @@ out there, Solaris being the most prominent.
 #define PNf UTF8f
 #define PNfARG(pn) (int)1, (UV)PadnameLEN(pn), (void *)PadnamePV(pn)
 
+#define HvNAMEf "6p"
+#define HvNAMEf_QUOTEDPREFIX "10p"
 
 #ifdef PERL_CORE
 /* not used; but needed for backward compatibility with XS code? - RMB

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -350,6 +350,12 @@ well.
 
 XXX
 
+=item *
+
+Added HvNAMEf and HvNAMEf_QUOTEDPREFIX special formats. They take an HV *
+as an argument and use C<HvNAME()> and related macros to determine the string,
+its length, and whether it is utf8.
+
 =back
 
 =head1 Selected Bug Fixes

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -3091,6 +3091,14 @@ escaping rules. If the string is longer than this then ellipses "..."
 will be appended after the trailing quote. This is intended for error
 messages where the string is assumed to be a class name.
 
+=for apidoc Amnh||HvNAMEf
+=for apidoc Amnh||HvNAMEf_QUOTEDPREFIX
+
+C<HvNAMEf> and C<HvNAMEf_QUOTEDPREFIX> are similar to C<SVf> except they
+extract the string, length and utf8 flags from the argument using the
+C<HvNAME()>, C<HvNAMELEN()>, C<HvNAMEUTF8()> macros. This is intended
+for stringifying a class name directly from an stash HV.
+
 =head2 Formatted Printing of Strings
 
 If you just want the bytes printed in a 7bit NUL-terminated string, you can

--- a/sv.c
+++ b/sv.c
@@ -12651,6 +12651,8 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
              *                   rather than here.
              * %d%lu%9p  (UTF8f_QUOTEDPREFIX) .. but escaped and quoted.
              *
+             * %6p       (HvNAMEf) Like %s, but using the HvNAME() and HvNAMELEN()
+             * %10p      (HvNAMEf_QUOTEDPREFIX) ... but escaped and quoted
              *
              * %<num>p   where num is > 9: reserved for future
              *           extensions. Warns, but then is treated as a
@@ -12706,6 +12708,17 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                     eptr = va_arg(*args,char *);
                     elen = strlen(eptr);
                     escape_it = TRUE;
+                    width = 0;
+                    goto string;
+                }
+                else if (width == 6 || width == 10) {
+                    HV *hv = va_arg(*args, HV *);
+                    eptr = HvNAME(hv);
+                    elen = HvNAMELEN(hv);
+                    if (HvNAMEUTF8(hv))
+                        is_utf8 = TRUE;
+                    if (width == 10)
+                        escape_it = TRUE;
                     width = 0;
                     goto string;
                 }

--- a/t/porting/diag.t
+++ b/t/porting/diag.t
@@ -220,7 +220,10 @@ my %specialformats = (IVdf => 'd',
 		      SVf  => 's',
 		      SVf_QUOTEDPREFIX  => 'S',
                       PVf_QUOTEDPREFIX  => 'S',
-		      PNf  => 's');
+		      PNf  => 's',
+                      HvNAMEf => 's',
+                      HvNAMEf_QUOTEDPREFIX => 's',
+                  );
 
 my $format_modifiers = qr/ [#0\ +-]*              # optional flags
 			  (?: [1-9][0-9]* | \* )? # optional field width


### PR DESCRIPTION
They are similar to SVf and SVf_QUOTEDPREFIX but take an HV * argument and use HvNAME() and related macros to extract the string. This is helpful as it makes constructing error messages from a stash (HV *) easier.

See https://github.com/Perl/perl5/pull/20626 where this is used.