### PR TITLE
t/harness - show the time finished and how long the test run took

### DIFF
--- a/t/harness
+++ b/t/harness
@@ -378,4 +378,5 @@ $h->callback(
 
 my $agg = $h->runtests(@tests);
 _cleanup_valgrind(\$htoolnm, \$hgrind_ct);
+printf "Finished test run at %s.\n", scalar(localtime);
 exit $agg->has_errors ? 1 : 0;


### PR DESCRIPTION
I often have multiple tabs open, and have stale make test output in them, showing the time at the end of the test run will make it easier to find the "latest" test output.