### PR TITLE
t/harness - remove dependency on leading 0 for serial tests

### DIFF
--- a/t/harness
+++ b/t/harness
@@ -158,18 +158,21 @@ sub _compute_tests_and_ordering($) {
                 delete $must_be_executed_serially{$path};
             }
             elsif ($name =~ / \A \d /x) {
-                # We assume that the reason a test file's name begins with a 0
-                # is to order its execution among the tests in its directory.
+                # We assume that the reason a test file's name begins with a digit
+                # is to order its execution among the tests in its directory. This
+                # has a few false positives, but we used to check for 0 and it also
+                # had false-negatives. Performing tests early in series is better
+                # than not recognizing they need to be in series.
                 # Hence, a directory containing such files should be tested in
                 # serial order, with some exceptions hard-coded in.
                 $numbered_tests{$path}++;
-                $serials{$path} = 1 if $name =~ / \A 0 /x;
+                $serials{$path} = 1;
             }
         }
     }
 
     # Some test directories that have an execution order (by virtue of at
-    # least one file having a name with a leading 0) also have files that
+    # least one file having a name with a leading digit) also have files that
     # aren't numbered.  We assume that those can be executed in parallel,
     # after all the numbered ones are done.
     my %partial_serials;


### PR DESCRIPTION
We have a CPAN module where the tests are clearly meant to be run in order, yet we do not detect them as serial because none of them start with 0. Eg, encoding-warnings has files marked 1 through 4, but no 0.

I think this sensitivity on 0 is fragile and error prone. We should just run numbered stuff in series and first, and then the rest.

There are few place where this pessimizes and treat things as serial that really should be parallel, but that is better than treating tests as parallel that should be serial.