### PR TITLE
Re-enable full blown parallel tests without using heuristics to detect special cases.

### DIFF
--- a/t/harness
+++ b/t/harness
@@ -8,14 +8,39 @@ BEGIN {
     @INC = '../lib';              # pick up only this build's lib
 }
 
-my %must_be_executed_serially =
-    map { $_ => 1 } (
-                     '../cpan/IO-Zlib/t',
-                     '../ext/File-Find/t',
-                     '../lib/DBM_Filter/t',  # Multiple test files in this
-                                             # directory use the same
-                                             # hard-coded temp file name
-                    );
+##############################################################################
+# Test files which cannot be executed at the same time.
+#
+# List all files which might fail when executed at the same time as another
+# test file from the same test directory. Being listed here does not mean
+# the test will be run by itself, it just means it won't be run at the same
+# time as any other file in the same test directory, it might be run at the
+# same time as a file from a different test directory.
+#
+# Ideally this is always empty.
+#
+# Example: ../cpan/IO-Zlib/t/basic.t
+#
+my @_must_be_executed_serially = qw(
+);
+my %must_be_executed_serially = map { $_ => 1 } @_must_be_executed_serially;
+##############################################################################
+
+##############################################################################
+# Test files which must be executed alone.
+#
+# List files which cannot be run at the same time as any other test. Typically
+# this is used to handle tests which are senstivie to load and which might
+# fail if they were run at the same time as something load intensive.
+#
+# Example: ../dist/threads-shared/t/waithires.t
+#
+my @_must_be_executed_alone = qw();
+my %must_be_executed_alone = map { $_ => 1 } @_must_be_executed_alone;
+if ($^O ne "linux") {
+    $must_be_executed_alone{"../dist/threads-shared/t/waithires.t"} = 1;
+}
+##############################################################################
 
 my $torture; # torture testing?
 
@@ -108,10 +133,8 @@ sub _compute_tests_and_ordering($) {
     my @tests = $_[0]->@*;
 
     my %dir;
-    my %serials;
     my %all_dirs;
     my %map_file_to_dir;
-    my %numbered_tests;
 
     if ($jobs > 1) {
         require App::Prove::State;
@@ -134,6 +157,7 @@ sub _compute_tests_and_ordering($) {
         }
     }
 
+    my %partial_serials;
     # Preprocess the list of tests
     for my $file (@tests) {
         if ($^O eq 'MSWin32') {
@@ -141,7 +165,6 @@ sub _compute_tests_and_ordering($) {
         };
 
         # Keep a list of the distinct directory names, and another list of
-        # those which contain a file whose name begins with a 0
         if ($file =~ m! \A ( (?: \.\. / )?
                                 .*?
                             )             # $1 is the directory path name
@@ -152,58 +175,34 @@ sub _compute_tests_and_ordering($) {
             my $path = $1;
             my $name = $2;
 
-            $all_dirs{$path}++;
+            $all_dirs{$path} = 1;
             $map_file_to_dir{$file} = $path;
-
-            if (defined $must_be_executed_serially{$path}) {
-                $serials{$path} = 1;
-                delete $must_be_executed_serially{$path};
-            }
-            elsif ($name =~ / \A \d /x) {
-                # We assume that the reason a test file's name begins with a 0
-                # is to order its execution among the tests in its directory.
-                # Hence, a directory containing such files should be tested in
-                # serial order, with some exceptions hard-coded in.
-                $numbered_tests{$path}++;
-                $serials{$path} = 1 if $name =~ / \A 0 /x;
+            # is this is a file that requires we do special processing
+            # on the directory as a whole?
+            if ($must_be_executed_serially{$file}) {
+                $partial_serials{$path} = 1;
             }
         }
     }
 
-    # Some test directories that have an execution order (by virtue of at
-    # least one file having a name with a leading 0) also have files that
-    # aren't numbered.  We assume that those can be executed in parallel,
-    # after all the numbered ones are done.
-    my %partial_serials;
-    for my $serial_dir (keys %serials) {
-
-        # Don't touch serially executed directories that don't have a numbered
-        # ordering.
-        next unless defined $numbered_tests{$serial_dir};
-
-        # $all_dirs{$serial_dir} contains the count of test files in it.
-        # Subtracting the count of numbered tests yields the number of
-        # non-numbered tests.  These may be executed in parallel, but no gain
-        # if there's only one to execute.
-        next if $all_dirs{$serial_dir} - $numbered_tests{$serial_dir} < 2;
-
-        $partial_serials{$serial_dir} = 1;
-    }
-
     my %split_partial_serials;
 
+    my @alone_files;
     # Ready to figure out the timings.
     for my $file (@tests) {
         my $file_dir = $map_file_to_dir{$file};
+
+        # if this is a file which must be processed alone
+        if ($must_be_executed_alone{$file}) {
+            push @alone_files, $file;
+            next;
+        }
 
         # Special handling is needed for a directory that has some test files
         # to execute serially, and some to execute in parallel.  This loop
         # gathers information that a later loop will process.
         if (defined $partial_serials{$file_dir}) {
-            if ($file =~ m! ^ (*atomic: .* / )  # Ignore the directory path
-                              ( \d+ )           # Grab the sequence number
-                          !x
-            ) {
+            if ($must_be_executed_serially{$file}) {
                 # This is a file to execute serially.  Its time contributes
                 # directly to the total time for this directory.
                 $total_time{$file_dir} += $times{$file} || 0;
@@ -220,23 +219,15 @@ sub _compute_tests_and_ordering($) {
                 $total_time{$file} = $times{$file} || 0;
             }
         }
-        elsif (! defined $serials{$file_dir}) {
-
+        else {
             # Treat every file in each non-serial directory as its own
             # "directory", so that it can be executed in parallel
             $dir{$file} = { seq => $file };
             $total_time{$file} = $times{$file} || 0;
         }
-        else {  # Serial.  This file contributes time to the total needed
-                # for its directory as a whole
-            $dir{$file_dir} = { seq => "$file_dir/*" };
-            $total_time{$file_dir} += $times{$file} || 0;
-        }
     }
 
     undef %all_dirs;
-    undef %serials;
-
 
     # Here, everything is complete except for the directories that have both
     # serial components and parallel components.  The loop just above gathered
@@ -282,9 +273,10 @@ sub _compute_tests_and_ordering($) {
 
         # Then the directory is ordered to have the sequential tests executed
         # first (serially), then the parallel tests (in parallel)
+
         $dir{$partial_serial_dir} =
-                                { 'seq' => [ { seq => [ @sorted_seq_list ] },
-                                             { par => [ @par_list        ] },
+                                { 'seq' => [ { seq => \@sorted_seq_list },
+                                             { par => \@par_list        },
                                            ],
                                 };
     }
@@ -298,6 +290,10 @@ sub _compute_tests_and_ordering($) {
                         ]
                };
 
+    # and lastly add in the files which must be run by themselves without
+    # any other tests /at all/ running at the same time.
+    push @seq, map { +{ seq => $_ } } sort @alone_files if @alone_files;
+    
     return \@seq;
 }
 
@@ -361,12 +357,6 @@ if (@ARGV) {
 
         push @tests, @last;
         push @seq, _compute_tests_and_ordering(\@last)->@*;
-
-        if (%must_be_executed_serially) {
-            die "These directories to be run serially don't exist.  Check your"
-            . " spelling:\n"
-            . join "\n", sort keys %must_be_executed_serially;
-        }
 
         $rules = { seq => \@seq };
     }

--- a/t/harness
+++ b/t/harness
@@ -8,8 +8,14 @@ BEGIN {
     @INC = '../lib';              # pick up only this build's lib
 }
 
-my %must_be_executed_serially = map { $_ => 1 }
-                                    qw(../cpan/IO-Zlib/t ../ext/File-Find/t);
+my %must_be_executed_serially =
+    map { $_ => 1 } (
+                     '../cpan/IO-Zlib/t',
+                     '../ext/File-Find/t',
+                     '../lib/DBM_Filter/t',  # Multiple test files in this
+                                             # directory use the same
+                                             # hard-coded temp file name
+                    );
 
 my $torture; # torture testing?
 
@@ -105,6 +111,7 @@ sub _compute_tests_and_ordering($) {
     my %serials;
     my %all_dirs;
     my %map_file_to_dir;
+    my %numbered_tests;
 
     if ($jobs > 1) {
         require App::Prove::State;
@@ -145,29 +152,78 @@ sub _compute_tests_and_ordering($) {
             my $path = $1;
             my $name = $2;
 
-            $all_dirs{$path} = 1;
+            $all_dirs{$path}++;
             $map_file_to_dir{$file} = $path;
 
-            # We assume that the reason a test file's name begins with a 0
-            # is to order its execution among the tests in its directory.
-            # Hence, a directory containing such files should be tested in
-            # serial order, with some exceptions hard-coded in.
-            if ($name =~ / \A 0 /x) {
-                $serials{$path} = 1;
-            }
-            elsif (defined $must_be_executed_serially{$path}) {
+            if (defined $must_be_executed_serially{$path}) {
                 $serials{$path} = 1;
                 delete $must_be_executed_serially{$path};
+            }
+            elsif ($name =~ / \A \d /x) {
+                # We assume that the reason a test file's name begins with a 0
+                # is to order its execution among the tests in its directory.
+                # Hence, a directory containing such files should be tested in
+                # serial order, with some exceptions hard-coded in.
+                $numbered_tests{$path}++;
+                $serials{$path} = 1 if $name =~ / \A 0 /x;
             }
         }
     }
 
+    # Some test directories that have an execution order (by virtue of at
+    # least one file having a name with a leading 0) also have files that
+    # aren't numbered.  We assume that those can be executed in parallel,
+    # after all the numbered ones are done.
+    my %partial_serials;
+    for my $serial_dir (keys %serials) {
+
+        # Don't touch serially executed directories that don't have a numbered
+        # ordering.
+        next unless defined $numbered_tests{$serial_dir};
+
+        # $all_dirs{$serial_dir} contains the count of test files in it.
+        # Subtracting the count of numbered tests yields the number of
+        # non-numbered tests.  These may be executed in parallel, but no gain
+        # if there's only one to execute.
+        next if $all_dirs{$serial_dir} - $numbered_tests{$serial_dir} < 2;
+
+        $partial_serials{$serial_dir} = 1;
+    }
+
+    my %split_partial_serials;
+
+    # Ready to figure out the timings.
     for my $file (@tests) {
         my $file_dir = $map_file_to_dir{$file};
 
-        # Treat every file in each non-serial directory as its own
-        # "directory", so that it can be executed in parallel
-        if (! defined $serials{$file_dir}) {
+        # Special handling is needed for a directory that has some test files
+        # to execute serially, and some to execute in parallel.  This loop
+        # gathers information that a later loop will process.
+        if (defined $partial_serials{$file_dir}) {
+            if ($file =~ m! ^ (*atomic: .* / )  # Ignore the directory path
+                              ( \d+ )           # Grab the sequence number
+                          !x
+            ) {
+                # This is a file to execute serially.  Its time contributes
+                # directly to the total time for this directory.
+                $total_time{$file_dir} += $times{$file} || 0;
+
+                # Save the sequence number with the file for now; below we
+                # will come back to it.
+                push $split_partial_serials{$file_dir}{seq}->@*, [ $1, $file ];
+            }
+            else {
+                # This is a file to execute in parallel after all the
+                # sequential ones are done.  Save its time in the hash to
+                # later calculate its time contribution.
+                push $split_partial_serials{$file_dir}{par}->@*, $file;
+                $total_time{$file} = $times{$file} || 0;
+            }
+        }
+        elsif (! defined $serials{$file_dir}) {
+
+            # Treat every file in each non-serial directory as its own
+            # "directory", so that it can be executed in parallel
             $dir{$file} = { seq => $file };
             $total_time{$file} = $times{$file} || 0;
         }
@@ -180,6 +236,58 @@ sub _compute_tests_and_ordering($) {
 
     undef %all_dirs;
     undef %serials;
+
+
+    # Here, everything is complete except for the directories that have both
+    # serial components and parallel components.  The loop just above gathered
+    # the information required to finish setting those up, which we now do.
+    for my $partial_serial_dir (keys %split_partial_serials) {
+
+        # Look at just the serial portion for now.
+        my @seq_list = $split_partial_serials{$partial_serial_dir}{seq}->@*;
+
+        # The 0th element contains the sequence number; the 1th element the
+        # file name.  Get the name, sorted first by the number, then by the
+        # name.  Doing it this way allows sequence numbers to be varying
+        # length, and still get a numeric sort
+        my @sorted_seq_list = map { $_->[1] }
+                                sort {    $a->[0] <=>    $b->[0]
+                                    or lc $a->[1] cmp lc $b->[1] } @seq_list;
+
+        # Now look at the tests to run in parallel.  Sort in descending order
+        # of execution time.
+        my @par_list = sort sort_by_execution_order
+                        $split_partial_serials{$partial_serial_dir}{par}->@*;
+
+        # The total time to execute this directory is the serial time (already
+        # calculated in the previous loop) plus the parallel time.  To
+        # calculate an approximate parallel time, note that the minimum
+        # parallel time is the maximum of each of the test files run in
+        # parallel.  If the number of parallel jobs J is more than the number
+        # of such files, N, it could be that all N get executed in parallel,
+        # so that maximum is the actual value.  But if N > J, a second, or
+        # third, ...  round will be required.  The code below just takes the
+        # longest-running time for each round and adds that to the previous
+        # total.  It is an imperfect estimate, but not unreasonable.
+        my $par_time = 0;
+        for (my $i = 0; $i < @par_list; $i += $jobs) {
+            $par_time += $times{$par_list[$i]} || 0;
+        }
+        $total_time{$partial_serial_dir} += $par_time;
+
+        # Now construct the rules.  Each of the parallel tests is made into a
+        # single element 'seq' structure, like is done for all the other
+        # parallel tests.
+        @par_list = map { { seq => $_ } } @par_list;
+
+        # Then the directory is ordered to have the sequential tests executed
+        # first (serially), then the parallel tests (in parallel)
+        $dir{$partial_serial_dir} =
+                                { 'seq' => [ { seq => [ @sorted_seq_list ] },
+                                             { par => [ @par_list        ] },
+                                           ],
+                                };
+    }
 
     #print STDERR __LINE__, join "\n", sort sort_by_execution_order keys %dir
 


### PR DESCRIPTION
Unrevert @khwilliamson's parallelism patch, and then modify it to not use heuristics to decide what should be run in series, and at the same time introduce a new class of tests which must be run as singletons. This seems to make `dist/threads-shared/t/waithires.t` run successfully on Win32, when it can hang and die in the middle when it is run alongside other tests.

This also changes the model of listing special cases, instead of listing directories we list test files. Except for cases like waithires.t I think the list should eventually be empty, and the tests patched. The IO-Zlib exceptions hopefully can be removed in the near future.  See: https://github.com/tomhughes/IO-Zlib/pull/4