### PR TITLE
HvNAMEf fixes

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -4150,6 +4150,8 @@ out there, Solaris being the most prominent.
 #define HvNAMEf "6p"
 #define HvNAMEf_QUOTEDPREFIX "10p"
 
+#define HvNAMEfARG(hv) ((void*)(hv))
+
 #ifdef PERL_CORE
 /* not used; but needed for backward compatibility with XS code? - RMB
 =for apidoc_section $io_formats

--- a/t/porting/diag.t
+++ b/t/porting/diag.t
@@ -223,7 +223,7 @@ my %specialformats = (IVdf => 'd',
                       PVf_QUOTEDPREFIX  => 'S',
 		      PNf  => 's',
                       HvNAMEf => 's',
-                      HvNAMEf_QUOTEDPREFIX => 's',
+                      HvNAMEf_QUOTEDPREFIX => 'S',
                   );
 
 my $format_modifiers = qr/ [#0\ +-]*              # optional flags


### PR DESCRIPTION
A couple of tiny fixes for the recently-added `HvNAMEf` printf format:

* Adds the missing `HvNAMEfARG()` macro
* Fixes t/porting/diag.t to expect quotes around HvNAMEf_QUOTEDPREFIX messages