### PR TITLE
This fixes the parallel tests issues in DBM_Filter and in FileCache

### DIFF
--- a/ext/FileCache/t/01open.t
+++ b/ext/FileCache/t/01open.t
@@ -3,7 +3,7 @@
 use FileCache;
 
 our @files;
-BEGIN { @files = qw(foo bar baz quux Foo_Bar) }
+BEGIN { @files = map { "open_$_" } qw(foo bar baz quux Foo_Bar) }
 END   { 1 while unlink @files }
 
 use Test::More tests => 1;

--- a/ext/FileCache/t/02maxopen.t
+++ b/ext/FileCache/t/02maxopen.t
@@ -2,7 +2,7 @@
 
 use FileCache maxopen => 2;
 our @files;
-BEGIN { @files = qw(foo bar baz quux) }
+BEGIN { @files = map { "max_$_" } qw(foo bar baz quux) }
 END { 1 while unlink @files }
 
 use Test::More tests => 5;
@@ -15,7 +15,7 @@ use Test::More tests => 5;
   
   my @cat;
   for my $path ( @files ){
-    ok(fileno($path) || $path =~ /^(?:foo|bar)$/);
+    ok(fileno($path) || $path =~ /^max_(?:foo|bar)$/);
     next unless fileno($path);
     print $path "$path 2\n";
     close($path);
@@ -24,5 +24,5 @@ use Test::More tests => 5;
     push @cat, <$path>;
     close($path);
   }
-  ok( grep(/^(?:baz|quux) 2$/, @cat) == 2 );
+  ok( grep(/^max_(?:baz|quux) 2$/, @cat) == 2 );
 }

--- a/ext/FileCache/t/03append.t
+++ b/ext/FileCache/t/03append.t
@@ -2,7 +2,7 @@
 
 use FileCache maxopen => 2;
 our @files;
-BEGIN { @files = qw(foo bar baz quux Foo_Bar) }
+BEGIN { @files = map { "append_$_" } qw(foo bar baz quux Foo_Bar) }
 END   { 1 while unlink @files }
 
 use Test::More tests => 2;

--- a/ext/FileCache/t/04twoarg.t
+++ b/ext/FileCache/t/04twoarg.t
@@ -2,16 +2,16 @@
 
 use FileCache;
 
-END { unlink('foo') }
+END { unlink('foo_2arg') }
 
 use Test::More tests => 1;
 
 {# Test 4: that 2 arg format works, and that we cycle on mode change
-     cacheout '>', "foo";
-     print foo "foo 4\n";
-     cacheout '+>', "foo";
-     print foo "foo 44\n";
-     seek(foo, 0, 0);
-     ok(<foo> eq "foo 44\n");
-     close foo;
+     cacheout '>', "foo_2arg";
+     print foo_2arg "foo 4\n";
+     cacheout '+>', "foo_2arg";
+     print foo_2arg "foo 44\n";
+     seek(foo_2arg, 0, 0);
+     ok(<foo_2arg> eq "foo 44\n");
+     close foo_2arg;
 }

--- a/ext/FileCache/t/05override.t
+++ b/ext/FileCache/t/05override.t
@@ -2,12 +2,12 @@
 
 use FileCache;
 
-END { unlink("Foo_Bar") }
+END { unlink("Foo_Bar_ov") }
 
 use Test::More tests => 1;
 
 {# Test 5: that close is overridden properly within the caller
-     cacheout local $_ = "Foo_Bar";
+     cacheout local $_ = "Foo_Bar_ov";
      print $_ "Hello World\n";
      close($_);
      ok(!fileno($_));

--- a/ext/FileCache/t/07noimport.t
+++ b/ext/FileCache/t/07noimport.t
@@ -8,7 +8,7 @@ use Test::More tests => 1;
     package Y;
     use FileCache ();
 
-    my $file = 'foo';
+    my $file = 'foo_noimp';
     END { unlink $file }
     FileCache::cacheout($file);
     print $file "bar";

--- a/lib/DBM_Filter/t/01error.t
+++ b/lib/DBM_Filter/t/01error.t
@@ -61,12 +61,12 @@ BEGIN {
 };
 BEGIN { use_ok('Fcntl') };
 
-unlink <Op_dbmx*>;
-END { unlink <Op_dbmx*>; }
+unlink <errOp_dbmx*>;
+END { unlink <errOp_dbmx*>; }
 
 my %h1 = () ;
 my %h2 = () ;
-$db = tie(%h1, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+$db = tie(%h1, $db_file,'errOp_dbmx', O_RDWR|O_CREAT, 0640) ;
 
 ok $db, "tied to $db_file ok";
 

--- a/lib/DBM_Filter/t/02core.t
+++ b/lib/DBM_Filter/t/02core.t
@@ -46,8 +46,8 @@ BEGIN {
 };
 BEGIN { use_ok('Fcntl') };
 
-unlink <Op_dbmx*>;
-END { unlink <Op_dbmx*>; }
+unlink <coreOp_dbmx*>;
+END { unlink <coreOp_dbmx*>; }
 
 writeFile('times_ten', <<'EOM');
     package DBM_Filter::times_ten;
@@ -161,7 +161,7 @@ sub checkRaw
     my %h;
 
     # read the dbm file without the filter
-    ok tie(%h, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640), "tied to $db_file";
+    ok tie(%h, $db_file,'coreOp_dbmx', O_RDWR|O_CREAT, 0640), "tied to $db_file";
 
     my %bad = ();
     while (my ($k, $v) = each %h) {
@@ -191,14 +191,14 @@ sub checkRaw
         eval { untie %h };
         is $@, '', "untie without inner references" ;
     }
-    unlink <Op_dbmx*>;
+    unlink <coreOp_dbmx*>;
 }
 
 {
     #diag "Test Set: Key and Value Filter, no stacking, no closure";
 
     my %h = () ;
-    my $db = tie(%h, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+    my $db = tie(%h, $db_file,'coreOp_dbmx', O_RDWR|O_CREAT, 0640) ;
     ok $db, "tied to $db_file";
     
     doPreData(\%h);
@@ -215,7 +215,7 @@ sub checkRaw
         is $@, '', "untie without inner references" ;
     }
 
-    checkRaw 'Op_dbmx', 
+    checkRaw 'coreOp_dbmx',
 	    'abc'	=> 'def',
 	    '123'	=> '456',
 	    'A'	=> 'A',
@@ -228,7 +228,7 @@ sub checkRaw
     #diag "Test Set: Key Only Filter, no stacking, no closure";
 
     my %h = () ;
-    my $db = tie(%h, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+    my $db = tie(%h, $db_file,'coreOp_dbmx', O_RDWR|O_CREAT, 0640) ;
     ok $db, "tied to $db_file";
     
     doPreData(\%h);
@@ -245,7 +245,7 @@ sub checkRaw
         is $@, '', "untie without inner references" ;
     }
 
-    checkRaw 'Op_dbmx', 
+    checkRaw 'coreOp_dbmx',
 	    'abc'	=> 'def',
 	    '123'	=> '456',
 	    'A'	=> '',
@@ -258,7 +258,7 @@ sub checkRaw
     #diag "Test Set: Value Only Filter, no stacking, no closure";
 
     my %h = () ;
-    my $db = tie(%h, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+    my $db = tie(%h, $db_file,'coreOp_dbmx', O_RDWR|O_CREAT, 0640) ;
     ok $db, "tied to $db_file";
     
     doPreData(\%h);
@@ -275,7 +275,7 @@ sub checkRaw
         is $@, '', "untie without inner references" ;
     }
 
-    checkRaw 'Op_dbmx', 
+    checkRaw 'coreOp_dbmx',
 	    'abc'	=> 'def',
 	    '123'	=> '456',
 	    ''	=> 'A',
@@ -288,7 +288,7 @@ sub checkRaw
     #diag "Test Set: Key and Value Filter, with stacking, no closure";
 
     my %h = () ;
-    my $db = tie(%h, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+    my $db = tie(%h, $db_file,'coreOp_dbmx', O_RDWR|O_CREAT, 0640) ;
     ok $db, "tied to $db_file";
     
     doPreData(\%h);
@@ -308,7 +308,7 @@ sub checkRaw
         is $@, '', "untie without inner references" ;
     }
 
-    checkRaw 'Op_dbmx', 
+    checkRaw 'coreOp_dbmx',
 	    'abc'	=> 'def',
 	    '123'	=> '456',
 	    'AB'	=> 'AB',
@@ -321,7 +321,7 @@ sub checkRaw
     #diag "Test Set: Key Filter != Value Filter, with stacking, no closure";
 
     my %h = () ;
-    my $db = tie(%h, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+    my $db = tie(%h, $db_file,'coreOp_dbmx', O_RDWR|O_CREAT, 0640) ;
     ok $db, "tied to $db_file";
     
     doPreData(\%h);
@@ -347,7 +347,7 @@ sub checkRaw
         is $@, '', "untie without inner references" ;
     }
 
-    checkRaw 'Op_dbmx', 
+    checkRaw 'coreOp_dbmx',
 	    'abc'	=> 'def',
 	    '123'	=> '456',
 	    'BD'	=> 'AC',
@@ -360,7 +360,7 @@ sub checkRaw
     #diag "Test Set: Key only Filter, with stacking, no closure";
 
     my %h = () ;
-    my $db = tie(%h, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+    my $db = tie(%h, $db_file,'coreOp_dbmx', O_RDWR|O_CREAT, 0640) ;
     ok $db, "tied to $db_file";
     
     doPreData(\%h);
@@ -380,7 +380,7 @@ sub checkRaw
         is $@, '', "untie without inner references" ;
     }
 
-    checkRaw 'Op_dbmx', 
+    checkRaw 'coreOp_dbmx',
 	    'abc'	=> 'def',
 	    '123'	=> '456',
 	    'BD'	=> '',
@@ -393,7 +393,7 @@ sub checkRaw
     #diag "Test Set: Value only Filter, with stacking, no closure";
 
     my %h = () ;
-    my $db = tie(%h, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+    my $db = tie(%h, $db_file,'coreOp_dbmx', O_RDWR|O_CREAT, 0640) ;
     ok $db, "tied to $db_file";
     
     doPreData(\%h);
@@ -413,7 +413,7 @@ sub checkRaw
         is $@, '', "untie without inner references" ;
     }
 
-    checkRaw 'Op_dbmx', 
+    checkRaw 'coreOp_dbmx',
 	    'abc'	=> 'def',
 	    '123'	=> '456',
 	    ''	=> 'AC',
@@ -426,7 +426,7 @@ sub checkRaw
     #diag "Test Set: Combination Key/Value + Key Filter != Value Filter, with stacking, no closure";
 
     my %h = () ;
-    my $db = tie(%h, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+    my $db = tie(%h, $db_file,'coreOp_dbmx', O_RDWR|O_CREAT, 0640) ;
     ok $db, "tied to $db_file";
     
     doPreData(\%h);
@@ -449,7 +449,7 @@ sub checkRaw
         is $@, '', "untie without inner references" ;
     }
 
-    checkRaw 'Op_dbmx', 
+    checkRaw 'coreOp_dbmx',
 	    'abc'	=> 'def',
 	    '123'	=> '456',
 	    'AD'	=> 'AC',
@@ -462,7 +462,7 @@ sub checkRaw
     #diag "Test Set: Combination Key/Value + Key + Key/Value, no closure";
 
     my %h = () ;
-    my $db = tie(%h, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+    my $db = tie(%h, $db_file,'coreOp_dbmx', O_RDWR|O_CREAT, 0640) ;
     ok $db, "tied to $db_file";
     
     doPreData(\%h);
@@ -485,7 +485,7 @@ sub checkRaw
         is $@, '', "untie without inner references" ;
     }
 
-    checkRaw 'Op_dbmx', 
+    checkRaw 'coreOp_dbmx',
 	    'abc'	=> 'def',
 	    '123'	=> '456',
 	    'ABC'	=> 'AC',
@@ -498,7 +498,7 @@ sub checkRaw
     #diag "Test Set: Combination Key/Value + Key + Key/Value, with closure";
 
     my %h = () ;
-    my $db = tie(%h, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+    my $db = tie(%h, $db_file,'coreOp_dbmx', O_RDWR|O_CREAT, 0640) ;
     ok $db, "tied to $db_file";
     
     doPreData(\%h);
@@ -521,7 +521,7 @@ sub checkRaw
         is $@, '', "untie without inner references" ;
     }
 
-    checkRaw 'Op_dbmx', 
+    checkRaw 'coreOp_dbmx',
 	    'abc'	=> 'def',
 	    '123'	=> '456',
 	    'ABC'	=> 'AC',
@@ -534,7 +534,7 @@ sub checkRaw
     #diag "Test Set: Combination Key/Value + Key + Key/Value, immediate";
 
     my %h = () ;
-    my $db = tie(%h, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+    my $db = tie(%h, $db_file,'coreOp_dbmx', O_RDWR|O_CREAT, 0640) ;
     ok $db, "tied to $db_file";
     
     doPreData(\%h);
@@ -566,7 +566,7 @@ sub checkRaw
         is $@, '', "untie without inner references" ;
     }
 
-    checkRaw 'Op_dbmx', 
+    checkRaw 'coreOp_dbmx',
 	    'abc'	=> 'def',
 	    '123'	=> '456',
 	    'ABC'	=> 'AC',
@@ -579,7 +579,7 @@ sub checkRaw
     #diag "Test Set: Combination Key/Value + Key + Key/Value, immediate, closure";
 
     my %h = () ;
-    my $db = tie(%h, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+    my $db = tie(%h, $db_file,'coreOp_dbmx', O_RDWR|O_CREAT, 0640) ;
     ok $db, "tied to $db_file";
     
     doPreData(\%h);
@@ -605,7 +605,7 @@ sub checkRaw
         is $@, '', "untie without inner references" ;
     }
 
-    checkRaw 'Op_dbmx', 
+    checkRaw 'coreOp_dbmx',
 	    'abc'	=> 'def',
 	    '123'	=> '456',
 	    'ABC'	=> 'AC',
@@ -618,7 +618,7 @@ sub checkRaw
     #diag "Test Set: Filtered & Filter_Pop";
 
     my %h = () ;
-    my $db = tie(%h, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+    my $db = tie(%h, $db_file,'coreOp_dbmx', O_RDWR|O_CREAT, 0640) ;
     ok $db, "tied to $db_file";
     
     doPreData(\%h);
@@ -679,7 +679,7 @@ sub checkRaw
         is $@, '', "untie without inner references" ;
     }
 
-    checkRaw 'Op_dbmx', 
+    checkRaw 'coreOp_dbmx',
 	    'abc'	=> 'def',
 	    '123'	=> '456',
 	    'ABC'	=> 'AC',
@@ -702,7 +702,7 @@ sub checkRaw
     }
     
     my %h = () ;
-    my $db = tie(%h, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+    my $db = tie(%h, $db_file,'coreOp_dbmx', O_RDWR|O_CREAT, 0640) ;
     ok $db, "tied to $db_file";
     
     doPreData(\%h);
@@ -719,7 +719,7 @@ sub checkRaw
         is $@, '', "untie without inner references" ;
     }
 
-    checkRaw 'Op_dbmx', 
+    checkRaw 'coreOp_dbmx',
 	    'abc'	=> 'def',
 	    '123'	=> '456',
 	    'X'  	=> 'X',

--- a/lib/DBM_Filter/t/compress.t
+++ b/lib/DBM_Filter/t/compress.t
@@ -31,11 +31,11 @@ BEGIN {
 BEGIN { use_ok('Fcntl') };
 BEGIN { use_ok('Compress::Zlib') };
 
-unlink <Op_dbmx*>;
-END { unlink <Op_dbmx*>; }
+unlink <cmpOp_dbmx*>;
+END { unlink <cmpOp_dbmx*>; }
 
 my %h1 = () ;
-my $db1 = tie(%h1, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+my $db1 = tie(%h1, $db_file,'cmpOp_dbmx', O_RDWR|O_CREAT, 0640) ;
 
 ok $db1, "tied to $db_file";
 
@@ -90,7 +90,7 @@ undef $db1;
 
 # read the dbm file without the filter
 my %h2 = () ;
-my $db2 = tie(%h2, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+my $db2 = tie(%h2, $db_file,'cmpOp_dbmx', O_RDWR|O_CREAT, 0640) ;
 
 ok $db2, "tied to $db_file";
 

--- a/lib/DBM_Filter/t/encode.t
+++ b/lib/DBM_Filter/t/encode.t
@@ -38,11 +38,11 @@ BEGIN { use_ok('charnames', qw{greek})};
 
 use charnames qw{greek};
 
-unlink <Op_dbmx*>;
-END { unlink <Op_dbmx*>; }
+unlink <encOp_dbmx*>;
+END { unlink <encOp_dbmx*>; }
 
 my %h1 = () ;
-my $db1 = tie(%h1, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+my $db1 = tie(%h1, $db_file,'encOp_dbmx', O_RDWR|O_CREAT, 0640) ;
 
 ok $db1, "tied to $db_file";
 
@@ -101,7 +101,7 @@ undef $db1;
 
 # read the dbm file without the filter
 my %h2 = () ;
-my $db2 = tie(%h2, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+my $db2 = tie(%h2, $db_file,'encOp_dbmx', O_RDWR|O_CREAT, 0640) ;
 
 ok $db2, "tied to $db_file";
 

--- a/lib/DBM_Filter/t/int32.t
+++ b/lib/DBM_Filter/t/int32.t
@@ -21,11 +21,11 @@ BEGIN {
 };
 BEGIN { use_ok('Fcntl') };
 
-unlink <Op_dbmx*>;
-END { unlink <Op_dbmx*>; }
+unlink <intOp_dbmx*>;
+END { unlink <intOp_dbmx*>; }
 
 my %h1 = () ;
-my $db1 = tie(%h1, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+my $db1 = tie(%h1, $db_file,'intOp_dbmx', O_RDWR|O_CREAT, 0640) ;
 
 ok $db1, "tied to $db_file";
 
@@ -72,7 +72,7 @@ undef $db1;
 
 # read the dbm file without the filter
 my %h2 = () ;
-my $db2 = tie(%h2, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+my $db2 = tie(%h2, $db_file,'intOp_dbmx', O_RDWR|O_CREAT, 0640) ;
 
 ok $db2, "tied to $db_file";
 

--- a/lib/DBM_Filter/t/null.t
+++ b/lib/DBM_Filter/t/null.t
@@ -21,11 +21,11 @@ BEGIN {
 };
 BEGIN { use_ok('Fcntl') };
 
-unlink <Op_dbmx*>;
-END { unlink <Op_dbmx*>; }
+unlink <nullOp_dbmx*>;
+END { unlink <nullOp_dbmx*>; }
 
 my %h1 = () ;
-my $db1 = tie(%h1, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+my $db1 = tie(%h1, $db_file,'nullOp_dbmx', O_RDWR|O_CREAT, 0640) ;
 
 ok $db1, "tied to $db_file";
 
@@ -76,7 +76,7 @@ undef $db1;
 
 # read the dbm file without the filter, check for null termination
 my %h2 = () ;
-my $db2 = tie(%h2, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+my $db2 = tie(%h2, $db_file,'nullOp_dbmx', O_RDWR|O_CREAT, 0640) ;
 
 ok $db2, "tied to $db_file";
 

--- a/lib/DBM_Filter/t/utf8.t
+++ b/lib/DBM_Filter/t/utf8.t
@@ -37,11 +37,11 @@ BEGIN { use_ok('charnames', qw{greek})};
 
 use charnames qw{greek};
 
-unlink <Op_dbmx*>;
-END { unlink <Op_dbmx*>; }
+unlink <utf8Op_dbmx*>;
+END { unlink <utf8Op_dbmx*>; }
 
 my %h1 = () ;
-my $db1 = tie(%h1, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+my $db1 = tie(%h1, $db_file,'utf8Op_dbmx', O_RDWR|O_CREAT, 0640) ;
 
 ok $db1, "tied to $db_file";
 
@@ -77,7 +77,7 @@ undef $db1;
 
 # read the dbm file without the filter
 my %h2 = () ;
-my $db2 = tie(%h2, $db_file,'Op_dbmx', O_RDWR|O_CREAT, 0640) ;
+my $db2 = tie(%h2, $db_file,'utf8Op_dbmx', O_RDWR|O_CREAT, 0640) ;
 
 ok $db2, "tied to $db_file";
 


### PR DESCRIPTION
Both tests were using the filenames for their tests, so if they ran at the same time, or one started just the right amount of time after the other, then one of them would fail.