### PR TITLE
Cast isdigit argument as unsigned char

### DIFF
--- a/cpan/Compress-Raw-Bzip2/bzip2-src/bzlib.c
+++ b/cpan/Compress-Raw-Bzip2/bzip2-src/bzlib.c
@@ -1415,7 +1415,7 @@ BZFILE * bzopen_or_bzdopen
       case 's':
          smallMode = 1; break;
       default:
-         if (isdigit((int)(*mode))) {
+         if (isdigit((unsigned char)(*mode))) {
             blockSize100k = *mode-BZ_HDR_0;
          }
       }

--- a/cpan/Time-Piece/Piece.xs
+++ b/cpan/Time-Piece/Piece.xs
@@ -843,7 +843,7 @@ label:
 			buf++;
 			i = 0;
 			for (len = 4; len > 0; len--) {
-				if (isdigit((int)*buf)) {
+				if (isdigit((unsigned char)*buf)) {
 					i *= 10;
 					i += *buf - '0';
 					buf++;


### PR DESCRIPTION
Theo noticed that these isdigit calls were not obviously correct.  He suggested reporting this upstream.   The only portable safe way is to always cast to (unsigned char). 

http://man.openbsd.org/isdigit#CAVEATS
> The argument c must be EOF or representable as an unsigned char;
> otherwise, the result is undefined.

I can push separately to what I think are the correct [Time-Piece](https://github.com/Dual-Life/Time-Piece) and [Compress-Raw-Bzip2](https://github.com/pmqs/Compress-Raw-Bzip2) repos if that would be preferred.