### PR TITLE
POSIX::fmax - Correct the variable used in example

### DIFF
--- a/ext/POSIX/lib/POSIX.pod
+++ b/ext/POSIX/lib/POSIX.pod
@@ -501,7 +501,7 @@ than the explicit two operations [C99].  Added in Perl v5.22.
 Maximum of C<x> and C<y>, except when either is C<NaN>, returns the other [C99].
 Added in Perl v5.22.
 
- my $min = POSIX::fmax($x, $y);
+ my $max = POSIX::fmax($x, $y);
 
 =item C<fmin>
 


### PR DESCRIPTION
The variable in the example should be $max, not $min as we're finding the maximum value.