### PR TITLE
regcomp.c etc - rework branch reset (?|: ... ) so it interoperates properly with named capture and recursion

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2811,8 +2811,14 @@ Cp	|SV *	|reg_named_buff_all					\
 				|const U32 flags
 
 : FIXME - is anything in re using this now?
+EXp	|void	|reg_numbered_buff_fetch_flags				\
+				|NN REGEXP * const re			\
+				|const I32 paren			\
+				|NULLOK SV * const sv			\
+				|U32 flags
+: FIXME - is anything in re using this now?
 EXp	|void	|reg_numbered_buff_fetch				\
-				|NN REGEXP * const rx			\
+				|NN REGEXP * const re			\
 				|const I32 paren			\
 				|NULLOK SV * const sv
 : FIXME - is anything in re using this now?

--- a/embed.h
+++ b/embed.h
@@ -1688,6 +1688,7 @@
 #   define reg_named_buff(a,b,c,d)              Perl_reg_named_buff(aTHX_ a,b,c,d)
 #   define reg_named_buff_iter(a,b,c)           Perl_reg_named_buff_iter(aTHX_ a,b,c)
 #   define reg_numbered_buff_fetch(a,b,c)       Perl_reg_numbered_buff_fetch(aTHX_ a,b,c)
+#   define reg_numbered_buff_fetch_flags(a,b,c,d) Perl_reg_numbered_buff_fetch_flags(aTHX_ a,b,c,d)
 #   define reg_numbered_buff_length(a,b,c)      Perl_reg_numbered_buff_length(aTHX_ a,b,c)
 #   define reg_numbered_buff_store(a,b,c)       Perl_reg_numbered_buff_store(aTHX_ a,b,c)
 #   define reg_qr_package(a)                    Perl_reg_qr_package(aTHX_ a)

--- a/handy.h
+++ b/handy.h
@@ -2674,6 +2674,10 @@ C<CopyD> is like C<Copy> but returns C<dest>.  Useful
 for encouraging compilers to tail-call
 optimise.
 
+=for apidoc    Am|void  |NewCopy |void* src|void* dest|int nitems|type
+Combines Newx() and Copy() into a single macro. Dest will be allocated
+using Newx() and then src will be copied into it.
+
 =for apidoc    Am|void  |Zero |void* dest|int nitems|type
 =for apidoc_item |void *|ZeroD|void* dest|int nitems|type
 
@@ -2880,6 +2884,11 @@ enum mem_log_type {
 #define MoveD(s,d,n,t)	(MEM_WRAP_CHECK_(n,t) perl_assert_ptr(d), perl_assert_ptr(s), memmove((char*)(d),(const char*)(s), (n) * sizeof(t)))
 #define CopyD(s,d,n,t)	(MEM_WRAP_CHECK_(n,t) perl_assert_ptr(d), perl_assert_ptr(s), memcpy((char*)(d),(const char*)(s), (n) * sizeof(t)))
 #define ZeroD(d,n,t)	(MEM_WRAP_CHECK_(n,t) perl_assert_ptr(d), memzero((char*)(d), (n) * sizeof(t)))
+
+#define NewCopy(s,d,n,t) STMT_START {   \
+    Newx(d,n,t);                        \
+    Copy(s,d,n,t);                      \
+} STMT_END
 
 #define PoisonWith(d,n,t,b)	(MEM_WRAP_CHECK_(n,t) (void)memset((char*)(d), (U8)(b), (n) * sizeof(t)))
 #define PoisonNew(d,n,t)	PoisonWith(d,n,t,0xAB)

--- a/proto.h
+++ b/proto.h
@@ -3722,9 +3722,14 @@ Perl_reg_named_buff_scalar(pTHX_ REGEXP * const rx, const U32 flags);
         assert(rx)
 
 PERL_CALLCONV void
-Perl_reg_numbered_buff_fetch(pTHX_ REGEXP * const rx, const I32 paren, SV * const sv);
+Perl_reg_numbered_buff_fetch(pTHX_ REGEXP * const re, const I32 paren, SV * const sv);
 #define PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_FETCH \
-        assert(rx)
+        assert(re)
+
+PERL_CALLCONV void
+Perl_reg_numbered_buff_fetch_flags(pTHX_ REGEXP * const re, const I32 paren, SV * const sv, U32 flags);
+#define PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_FETCH_FLAGS \
+        assert(re)
 
 PERL_CALLCONV I32
 Perl_reg_numbered_buff_length(pTHX_ REGEXP * const rx, const SV * const sv, const I32 paren);

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -478,7 +478,6 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         U32 parno= (op == ACCEPT)              ? (U32)ARG2L(o) :
                    (op == OPEN || op == CLOSE) ? (U32)PARNO(o) :
                                                  (U32)ARG(o);
-        Perl_sv_catpvf(aTHX_ sv, "%" UVuf, (UV)parno);        /* Parenth number */
         if ( RXp_PAREN_NAMES(prog) ) {
             name_list= MUTABLE_AV(progi->data->data[progi->name_list_idx]);
         } else if ( pRExC_state ) {
@@ -486,6 +485,14 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         }
         if ( name_list ) {
             if ( k != REF || (op < REFN)) {
+                UV logical_parno = parno;
+                if (prog->parno_to_logical)
+                    logical_parno = prog->parno_to_logical[parno];
+
+                Perl_sv_catpvf(aTHX_ sv, "%" UVuf, (UV)logical_parno);     /* Parenth number */
+                if (parno != logical_parno)
+                    Perl_sv_catpvf(aTHX_ sv, "/%" UVuf, (UV)parno);        /* Parenth number */
+
                 SV **name= av_fetch_simple(name_list, parno, 0 );
                 if (name)
                     Perl_sv_catpvf(aTHX_ sv, " '%" SVf "'", SVfARG(*name));
@@ -511,6 +518,15 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
                     Perl_sv_catpvf(aTHX_ sv, " '%" SVf "'", SVfARG(*name));
                 }
             }
+        } else if (parno>0) {
+            UV logical_parno = parno;
+            if (prog->parno_to_logical)
+                logical_parno = prog->parno_to_logical[parno];
+
+            Perl_sv_catpvf(aTHX_ sv, "%" UVuf, (UV)logical_parno);     /* Parenth number */
+            if (logical_parno != parno)
+                Perl_sv_catpvf(aTHX_ sv, "/%" UVuf, (UV)parno);     /* Parenth number */
+
         }
         if ( k == REF && reginfo) {
             U32 n = ARG(o);  /* which paren pair */
@@ -528,6 +544,10 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         }
     } else if (k == GOSUB) {
         AV *name_list= NULL;
+        IV parno = ARG(o);
+        IV logical_parno = (parno && prog->parno_to_logical)
+                         ? prog->parno_to_logical[parno]
+                         : parno;
         if ( RXp_PAREN_NAMES(prog) ) {
             name_list= MUTABLE_AV(progi->data->data[progi->name_list_idx]);
         } else if ( pRExC_state ) {
@@ -535,7 +555,11 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         }
 
         /* Paren and offset */
-        Perl_sv_catpvf(aTHX_ sv, "%d[%+d:%d]", (int)ARG(o),(int)ARG2L(o),
+        Perl_sv_catpvf(aTHX_ sv, "%" IVdf, logical_parno);
+        if (logical_parno != parno)
+            Perl_sv_catpvf(aTHX_ sv, "/%" IVdf, parno);
+
+        Perl_sv_catpvf(aTHX_ sv, "[%+d:%d]", (int)ARG2L(o),
                 (int)((o + (int)ARG2L(o)) - progi->program) );
         if (name_list) {
             SV **name= av_fetch_simple(name_list, ARG(o), 0 );

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -2112,7 +2112,20 @@ AB\s+\x{100}	AB \x{100}X	y	-	-
 
 \p{nv=-0}	\x{660}	y	$&	\x{660}
 (?:a|xx){0,4}?b	aaaaab 	y	$&	aaaab		# Bug is GH #8369; test is GH #19781
-
+(?|(?<a>a)|(?<b>b))\1(?&a)(?&b)	bbab 	y	$&	bbab		# GH 20653
+(?|(?<a>a)|(?<b>b))(?(<a>)x|y)\1	byb 	y	$&	byb		# GH 20653
+(?|(?<a>a)|(?<b>b))(?(<a>)x|y)\1	bxb 	n	-	-		# GH 20653
+(?|(?<a>a)|(?<b>b))(?(<a>)x|y)\1	axa 	y	$&	axa		# GH 20653
+(?|(?<a>a)|(?<b>b))(?(<a>)x|y)\1	aya 	n	-	-		# GH 20653
+(?|(?<a>a)|(?<b>b))	a 	y	$1-$+{a}-$+{b}	a-a-		# GH 20653
+(?|(?<a>a)|(?<b>b))	b 	y	$1-$+{a}-$+{b}	b--b		# GH 20653
+(?<pre>pre)(?|(?<a>a)(?<b>b)(?<c>c)|(?<d>d)(?<e>e)|(?<f>f))(?<post>post)	preabcpost 	y	$2-$3-$4	a-b-c		# GH 20653
+(?<pre>pre)(?|(?<a>a)(?<b>b)(?<c>c)|(?<d>d)(?<e>e)|(?<f>f))(?<post>post)	predepost 	y	$2-$3-$4	d-e-		# GH 20653
+(?<pre>pre)(?|(?<a>a)(?<b>b)(?<c>c)|(?<d>d)(?<e>e)|(?<f>f))(?<post>post)	prefpost 	y	$2-$3-$4	f--		# GH 20653
+(?<pre>pre)(?|(?<a>a)(?<b>b)(?<c>c)|(?<d>d)(?<e>e)|(?<f>f))(?<post>post)	preabcpost 	y	$+{a}-$+{b}-$+{c}	a-b-c		# GH 20653
+((?|(?<a>a)(?-1)|(?<b>b)(?-1)|(?<c>c)(?-1)))	aa 	y	$1	aa		# GH 20653
+((?|(?<a>a)(?-1)|(?<b>b)(?-1)|(?<c>c)(?-1)))	bb 	y	$1	bb		# GH 20653
+((?|(?<a>a)(?-1)|(?<b>b)(?-1)|(?<c>c)(?-1)))	cc 	y	$1	cc		# GH 20653
 # Keep these lines at the end of the file
 # pat	string	y/n/etc	expr	expected-expr	skip-reason	comment
 # vim: softtabstop=0 noexpandtab


### PR DESCRIPTION
Branch reset was hacked in without much thought about how it might interact with other features. Over time we added named capture and recursive patterns with GOSUB, but I guess because branch reset is somewhat esoteric we didnt notice the accumulating issues related to it.

The main problem was my original hack used a fairly simple device to give multiple OPEN/CLOSE opcodes the same target buffer id. When it was introduced this was fine. When GOSUB was added later however, we overlooked at that this broke a key part of the book-keeping for GOSUB.

A GOSUB regop needs to know where to jump to, and which close paren to stop at. However the structure of the regexp program can change from the time the regop is created. This means we keep track of every OPEN/CLOSE regop we encounter during parsing, and when something is inserted into the middle of the program we make sure to move the offsets we store for the OPEN/CLOSE data. This is essentially keyed and scaled to the number of parens we have seen. When branch reset is used however the number of OPEN/CLOSE regops is more than the number of logical buffers we have seen, and we only move one of the OPEN/CLOSE buffers that is in the branch reset. Which of course breaks things.

Another issues with branch reset is that it creates weird artifacts like this: `/(?|(?<a>a)|(?<b>b))(?&a)(?&b)/` where the `(?&b)` actually maps to the `(?<a>a)` capture buffer because they both have the same id. Another case is that you cannot check if `$+{b}` matched and `$+{a}` did not, because conceptually they were the same buffer under the hood.

These bugs are now fixed. The "aliasing" of capture buffers to each other is now done virtually, and under the hood each capture buffer is distinct. We introduce the concept of a "logical parno" which is the user visible capture buffer id, and keep it distinct from the true capture buffer id. Most of the internal logic uses the "true parno" for its business, so a bunch of problems go away, and we keep maps from logical to physical parnos, and vice versa, along with a map that gives use the "next physical parno with the same logical parno". Thus we can quickly skip through the physical capture buffers to find the one that matched. This means we also have to introduce a logical_total_parens as well, to complement the already existing total_parens. The latter refers to the true number of capture buffers. The former represents the logical number visible to the user.

It is helpful to consider the following table:

```
  Logical:    $1      $2     $3       $2     $3     $4     $2     $5
  Physical:    1       2      3        4      5      6      7      8
  Next:        0       4      5        7      0      0      0      0
  Pattern:   /(pre)(?|(?<a>a)(?<b>b)|(?<c>c)(?<d>d)(?<e>e)|(?<f>))(post)/
```

The names are mapped to physical buffers. So $+{b} will show what is in physical buffer 3. But $3 will show whichever of buffer 3 or 5 matched. Similarly @{^CAPTURE} will contain 5 elements, not 8. But %+ will contain all 6 named buffers.

Since the need to map these values is rare, we only store these maps when they are needed and branch reset has been used, when they are NULL it is assumed that physical and logical buffers are identical.

Currently the way this change is implemented will likely break plug in regexp engines because they will be missing the new logical_total_parens field at the very least. Given that the perl internals code is somewhat poorly abstracted from the regexp engine, with parts of the abstraction leaking out, I think this is acceptable. If we want to make plug in regexp engines work properly IMO we need to add some more hooks that they need to implement than we currently do. For instance mg.c does more work than it should. Given there are only a few plug in regexp engines and that it is specialized work, I think this is acceptable. We can work with the authors to refine the API properly.