### PR TITLE
regcomp.c - make sure conditional match (GROUPP) is not broken by CURLYM

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -9050,6 +9050,14 @@ NULL
                           depth, (IV) ST.count, (IV)ST.alen)
             );
 
+            if (ST.me->flags) {
+                /* emulate CLOSE: mark current A as captured */
+                U32 paren = (U32)ST.me->flags;
+                CLOSE_CAPTURE(paren,
+                    HOPc(locinput, -ST.alen) - reginfo->strbeg,
+                    locinput - reginfo->strbeg);
+            }
+
             if (EVAL_CLOSE_PAREN_IS_TRUE(cur_eval,(U32)ST.me->flags))
                 goto fake_end;
 

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -496,6 +496,8 @@ a(?:b|(c|e){1,2}?|d)+?(.)	ace	y	$1$2	ce
 ^(a(?(1)\1)){4}$	aaaaaaaaaa	y	$1	aaaa
 ^(a(?(1)\1)){4}$	aaaaaaaaa	n	-	-
 ^(a(?(1)\1)){4}$	aaaaaaaaaaa	n	-	-
+((?(1)a|b))+	baaa	y	$&	baaa		# GH 7754
+((?(1)aa|b))+	baaaa	y	$&	baaaa		# GH 7754
 ((a{4})+)	aaaaaaaaa	y	$1	aaaaaaaa
 (((aa){2})+)	aaaaaaaaaa	y	$1	aaaaaaaa
 (((a{2}){2})+)	aaaaaaaaaa	y	$1	aaaaaaaa


### PR DESCRIPTION
This disables the CURLY->CURLYM optimization when the contents contains a GROUPP. 

This PR also includes a prior commit which fixes this a different, less efficient way, and then corrects that to a better way afterwards.

See https://github.com/Perl/perl5/issues/7754