### PR TITLE
Update IO-Zlib to v1.12 - fixed tests for parallelism

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -663,7 +663,7 @@ use File::Glob qw(:case);
     },
 
     'IO::Zlib' => {
-        'DISTRIBUTION' => 'TOMHUGHES/IO-Zlib-1.11.tar.gz',
+        'DISTRIBUTION' => 'TOMHUGHES/IO-Zlib-1.12.tar.gz',
         'FILES'        => q[cpan/IO-Zlib],
     },
 

--- a/cpan/IO-Zlib/Zlib.pm
+++ b/cpan/IO-Zlib/Zlib.pm
@@ -291,7 +291,7 @@ use Fcntl qw(SEEK_SET);
 use Symbol;
 use Tie::Handle;
 
-our $VERSION = "1.11";
+our $VERSION = "1.12";
 our $AUTOLOAD;
 our @ISA = qw(Tie::Handle);
 

--- a/cpan/IO-Zlib/t/basic.t
+++ b/cpan/IO-Zlib/t/basic.t
@@ -10,7 +10,7 @@ sub ok
     print "not ok $no\n" unless $ok ;
 }
 
-my $name = "test.gz";
+my $name = "test_basic_$$.gz";
 
 print "1..17\n";
 

--- a/cpan/IO-Zlib/t/external.t
+++ b/cpan/IO-Zlib/t/external.t
@@ -70,7 +70,7 @@ ok(14, $@ =~ /^IO::Zlib::gzopen_external: mode 'xyz' is illegal /);
 # The following is a copy of the basic.t, shifted up by 14 tests,
 # the difference being that now we should be using the external gzip.
 
-my $name="test.gz";
+my $name="test_external_$$.gz";
 
 my $hello = <<EOM ;
 hello world

--- a/cpan/IO-Zlib/t/getc.t
+++ b/cpan/IO-Zlib/t/getc.t
@@ -10,7 +10,7 @@ sub ok
     print "not ok $no\n" unless $ok ;
 }
 
-my $name = "test.gz";
+my $name = "test_getc_$$.gz";
 
 print "1..10\n";
 

--- a/cpan/IO-Zlib/t/getline.t
+++ b/cpan/IO-Zlib/t/getline.t
@@ -10,7 +10,7 @@ sub ok
     print "not ok $no\n" unless $ok ;
 }
 
-my $name = "test.gz";
+my $name = "test_getline_$$.gz";
 
 print "1..23\n";
 

--- a/cpan/IO-Zlib/t/large.t
+++ b/cpan/IO-Zlib/t/large.t
@@ -10,7 +10,7 @@ sub ok
     print "not ok $no\n" unless $ok ;
 }
 
-my $name = "test.gz";
+my $name = "test_large_$$.gz";
 
 print "1..7\n";
 

--- a/cpan/IO-Zlib/t/tied.t
+++ b/cpan/IO-Zlib/t/tied.t
@@ -10,7 +10,7 @@ sub ok
     print "not ok $no\n" unless $ok ;
 }
 
-my $name = "test.gz";
+my $name = "test_tied_$$.gz";
 
 print "1..11\n";
 

--- a/cpan/IO-Zlib/t/uncomp1.t
+++ b/cpan/IO-Zlib/t/uncomp1.t
@@ -17,7 +17,7 @@ hello world
 this is a test
 EOM
 
-my $name = "test$$";
+my $name = "test_uncomp1_$$";
 
 if (open(FH, ">$name"))
 {

--- a/cpan/IO-Zlib/t/uncomp2.t
+++ b/cpan/IO-Zlib/t/uncomp2.t
@@ -17,7 +17,7 @@ hello world
 this is a test
 EOM
 
-my $name = "test$$";
+my $name = "test_uncomp2_$$";
 
 if (open(FH, ">$name"))
 {


### PR DESCRIPTION
Old tests used the same file names which prevented them being run simultaneously.