### PR TITLE
Math-Complex: Standardize $VERSION at 1.60

### DIFF
--- a/dist/Math-Complex/lib/Math/Complex.pm
+++ b/dist/Math-Complex/lib/Math/Complex.pm
@@ -10,7 +10,7 @@ package Math::Complex;
 { use 5.006; }
 use strict;
 
-our $VERSION = 1.59_03;
+our $VERSION = 1.60;
 
 use Config;
 

--- a/dist/Math-Complex/lib/Math/Trig.pm
+++ b/dist/Math-Complex/lib/Math/Trig.pm
@@ -15,7 +15,7 @@ require Exporter;
 
 our @ISA = qw(Exporter);
 
-our $VERSION = 1.24;
+our $VERSION = 1.60;
 
 my @angcnv = qw(rad2deg rad2grad
 		deg2rad deg2grad


### PR DESCRIPTION
Dual-life distribution Math-Complex is now maintained by Perl 5 Porters in blead and subsequently released to CPAN.  The two modules in this distribution, Math::Complex and Math::Trig, previously incremented their version numbers independently of each other.  However, in blead we generally try to keep all .pm files at the same $VERSION.  So let's standardize these modules at one number and keep them in sync going forward.

Once we've done this, we can manually resolve the version conflicts in https://github.com/Perl/perl5/pull/20212 and merge that p.r. into blead.