### PR TITLE
DBM_Filter/t - Use a private temporary directory for tests

### DIFF
--- a/lib/DBM_Filter/t/01error.t
+++ b/lib/DBM_Filter/t/01error.t
@@ -1,16 +1,20 @@
 use strict;
 use warnings;
-use Carp;
 
 BEGIN {
     chdir 't' if -d 't';
     @INC = qw(. ../lib);
 }
 
-our $db ;
+use Carp;
+use File::Temp qw(tempdir);
 
+my $tempdir;
 {
-    chdir 't' if -d 't';
+    $tempdir = tempdir( "./DBMFXXXXXXXX", CLEANUP => 1);
+    push @INC, $tempdir;
+    chdir $tempdir or die "Failed to chdir to '$tempdir': $!";
+    @INC[-1] = "../../lib";
     if ( ! -d 'DBM_Filter')
     {
         mkdir 'DBM_Filter', 0777 
@@ -18,7 +22,9 @@ our $db ;
     }
 }
 
-END { rmdir 'DBM_Filter' }
+##### Keep above code identical to 02core.t #####
+
+our $db;
 
 sub writeFile
 {
@@ -34,7 +40,7 @@ sub runFilter
     my $name = shift ;
     my $filter = shift ;
 
-print "# runFilter $name\n" ;
+    #print "# runFilter $name\n" ;
     my $filename = "DBM_Filter/$name.pm";
     $filter = "package DBM_Filter::$name ;\n$filter"
         unless $filter =~ /^\s*package/ ;

--- a/lib/DBM_Filter/t/02core.t
+++ b/lib/DBM_Filter/t/02core.t
@@ -1,14 +1,20 @@
-
 use strict;
 use warnings;
-use Carp;
 
-my %files = ();
-
-use lib '.';
-
-{
+BEGIN {
     chdir 't' if -d 't';
+    @INC = qw(. ../lib);
+}
+
+use Carp;
+use File::Temp qw(tempdir);
+
+my $tempdir;
+{
+    $tempdir = tempdir( "./DBMFXXXXXXXX", CLEANUP => 1);
+    push @INC, $tempdir;
+    chdir $tempdir or die "Failed to chdir to '$tempdir': $!";
+    @INC[-1] = "../../lib";
     if ( ! -d 'DBM_Filter')
     {
         mkdir 'DBM_Filter', 0777 
@@ -16,7 +22,10 @@ use lib '.';
     }
 }
 
-END { rmdir 'DBM_Filter' }
+##### Keep above code identical to 01error.t #####
+
+our $db;
+my %files = ();
 
 sub writeFile
 {
@@ -27,8 +36,6 @@ sub writeFile
     close F;
     $files{"DBM_Filter/$filename.pm"} ++;
 }
-
-END { unlink keys %files if keys %files }
 
 use Test::More;
 


### PR DESCRIPTION
I missed a parallelism issue in the DBM_Filter tests. This patch makes 01error.t and 02core.t use temporary directories for their tests so they don't collide.