### PR TITLE
ext/File-Find - use tempdir() for file and dir creation tests

### DIFF
--- a/ext/File-Find/lib/File/Find.pm
+++ b/ext/File-Find/lib/File/Find.pm
@@ -3,7 +3,7 @@ use 5.006;
 use strict;
 use warnings;
 use warnings::register;
-our $VERSION = '1.41';
+our $VERSION = '1.42';
 use Exporter 'import';
 require Cwd;
 

--- a/ext/File-Find/t/find.t
+++ b/ext/File-Find/t/find.t
@@ -35,6 +35,7 @@ use Testing qw(
     file_path
 );
 use Errno ();
+use File::Temp qw(tempdir);
 
 my %Expect_File = (); # what we expect for $_
 my %Expect_Name = (); # what we expect for $File::Find::name/fullname
@@ -235,6 +236,9 @@ sub my_postprocess {
 *file_path_name = \&file_path;
 
 ##### Create directories, files and symlinks used in testing #####
+my $root_dir = cwd();
+my $test_dir = tempdir("FF_find_t_XXXXXX",CLEANUP=>1);
+chdir $test_dir;
 
 mkdir_ok( dir_path('for_find'), 0770 );
 ok( chdir( dir_path('for_find')), "Able to chdir to 'for_find'")
@@ -1111,5 +1115,5 @@ if ($^O eq 'MSWin32') {
     like($@, qr/invalid top directory/,
         "find() correctly died due to undefined top directory");
 }
-
+chdir $root_dir; # let File::Temp cleanup - Switch to `defer {}` one day
 done_testing();

--- a/ext/File-Find/t/taint.t
+++ b/ext/File-Find/t/taint.t
@@ -1,5 +1,6 @@
 #!./perl -T
 use strict;
+use lib qw( ./t/lib );
 
 BEGIN {
     require File::Spec;
@@ -18,16 +19,10 @@ BEGIN {
     require File::Find;
     import File::Find;
 }
-
 use Test::More;
-BEGIN {
-    plan(
-        ${^TAINT}
-        ? (tests => 45)
-        : (skip_all => "A perl without taint support") 
-    );
-}
-use lib qw( ./t/lib );
+use File::Find;
+use File::Spec;
+use Cwd;
 use Testing qw(
     create_file_ok
     mkdir_ok
@@ -36,21 +31,21 @@ use Testing qw(
     file_path
 );
 use Errno ();
+use Config;
+
+BEGIN {
+    plan(
+        ${^TAINT}
+        ? (tests => 45)
+        : (skip_all => "A perl without taint support")
+    );
+}
 
 my %Expect_File = (); # what we expect for $_
 my %Expect_Name = (); # what we expect for $File::Find::name/fullname
 my %Expect_Dir  = (); # what we expect for $File::Find::dir
 my ($cwd, $cwd_untainted);
 
-BEGIN {
-    require File::Spec;
-    if ($ENV{PERL_CORE}) {
-        # May be doing dynamic loading while @INC is all relative
-        @INC = map { $_ = File::Spec->rel2abs($_); /(.*)/; $1 } @INC;
-    }
-}
-
-use Config;
 
 BEGIN {
     if ($^O ne 'VMS') {
@@ -77,10 +72,6 @@ BEGIN {
 }
 
 my $symlink_exists = eval { symlink("",""); 1 };
-
-use File::Find;
-use File::Spec;
-use Cwd;
 
 my $orig_dir = cwd();
 ( my $orig_dir_untainted ) = $orig_dir =~ m|^(.+)$|; # untaint it


### PR DESCRIPTION
I thought this distribution was safe since all the tests seem to be run inside of dedicated per test file root dirs. But Karl has seen test failures. Using File::Temp::tempdir() to create a private root dir should harden us to any issues that are hidden in the code, even if I have as yet been unable to replicate the test fails that Karl has experienced.