### PR TITLE
regen/embed_lib.pl - don't add integer to reference and fixup source …

### DIFF
--- a/regen/HeaderParser.pm
+++ b/regen/HeaderParser.pm
@@ -502,6 +502,7 @@ sub _normalize_if_elif {
 # calls parse_fh()
 sub parse_text {
     my ($self, $text)= @_;
+    local $self->{parse_source} = "(buffer)";
     open my $fh, "<", \$text
         or die "Failed to open buffer for read: $!";
     return $self->parse_fh($fh);
@@ -516,6 +517,7 @@ sub parse_fh {
     my @cond;
     my @cond_line;
     my $last_cond;
+    local $self->{parse_source} = $self->{parse_source} || "(unknown)";
     my $cb= $self->{pre_process_content};
     $self->{orig_content}= "";
     my $line_num= 1;
@@ -644,6 +646,7 @@ sub parse_fh {
             flat           => $flat,
             line           => $line,
             level          => $level,
+            source         => $self->{parse_source},
             start_line_num => $start_line_num,
             n_lines        => $line_num - $start_line_num,
         );
@@ -1223,7 +1226,7 @@ sub group_content {
 sub read_file {
     my ($self, $file_name, $callback)= @_;
     $self= $self->new() unless ref $self;
-    $self->{last_file_name}= $file_name;
+    local $self->{parse_source}= $file_name;
     open my $fh, "<", $file_name
         or confess "Failed to open '$file_name' for read: $!";
     my $lines= $self->parse_fh($fh);
@@ -1337,6 +1340,9 @@ based object which contains the following fields:
         raw      => $raw_content_of_line,
         line     => $normalized_content_of_line,
         level    => $level,
+        source         => $filename_or_string,
+        start_line_num => $line_num_for_first_line,
+        n_lines        => $line_num - $line_num_for_first_line,
     }, "HeaderLine"
 
 A "line" in this context is a logical line, and because of line continuations

--- a/regen/embed_lib.pl
+++ b/regen/embed_lib.pl
@@ -60,7 +60,8 @@ sub setup_embed {
                 line => "pR|OP *|$check|NN OP *o",
                 type => "content",
                 level => 1,
-                start_line_num => $lines + $line_num,
+                source => 'regen/opcodes',
+                start_line_num => $line_num,
             );
             $parser->tidy_embed_fnc_entry($new);
             push @$lines, $new;

--- a/t/porting/header_parser.t
+++ b/t/porting/header_parser.t
@@ -57,6 +57,7 @@ is($lines_as_str,<<~'DUMP_EOF', "Simple data structure as expected") or show_tex
             "line" => "#if defined(A)\n",
             "n_lines" => 1,
             "raw" => "#ifdef A\n",
+            "source" => "(buffer)",
             "start_line_num" => 1,
             "sub_type" => "#if",
             "type" => "cond"
@@ -75,6 +76,7 @@ is($lines_as_str,<<~'DUMP_EOF', "Simple data structure as expected") or show_tex
             "line" => "# if defined(B)\n",
             "n_lines" => 1,
             "raw" => "#ifdef B\n",
+            "source" => "(buffer)",
             "start_line_num" => 2,
             "sub_type" => "#if",
             "type" => "cond"
@@ -93,6 +95,7 @@ is($lines_as_str,<<~'DUMP_EOF', "Simple data structure as expected") or show_tex
             "line" => "#   define AB\n",
             "n_lines" => 1,
             "raw" => "#define AB\n",
+            "source" => "(buffer)",
             "start_line_num" => 3,
             "sub_type" => "#define",
             "type" => "content"
@@ -111,6 +114,7 @@ is($lines_as_str,<<~'DUMP_EOF', "Simple data structure as expected") or show_tex
             "line" => "content 1\n",
             "n_lines" => 1,
             "raw" => "content 1\n",
+            "source" => "(buffer)",
             "start_line_num" => 4,
             "sub_type" => "text",
             "type" => "content"
@@ -129,6 +133,7 @@ is($lines_as_str,<<~'DUMP_EOF', "Simple data structure as expected") or show_tex
             "line" => "# endif /* defined(B) */\n",
             "n_lines" => 1,
             "raw" => "#endif\n",
+            "source" => "(buffer)",
             "start_line_num" => 5,
             "sub_type" => "#endif",
             "type" => "cond"
@@ -144,6 +149,7 @@ is($lines_as_str,<<~'DUMP_EOF', "Simple data structure as expected") or show_tex
             "line" => "content 2\n",
             "n_lines" => 1,
             "raw" => "content 2\n",
+            "source" => "(buffer)",
             "start_line_num" => 6,
             "sub_type" => "text",
             "type" => "content"
@@ -159,6 +165,7 @@ is($lines_as_str,<<~'DUMP_EOF', "Simple data structure as expected") or show_tex
             "line" => "# define A\n",
             "n_lines" => 1,
             "raw" => "#define A\n",
+            "source" => "(buffer)",
             "start_line_num" => 7,
             "sub_type" => "#define",
             "type" => "content"
@@ -174,6 +181,7 @@ is($lines_as_str,<<~'DUMP_EOF', "Simple data structure as expected") or show_tex
             "line" => "#endif /* defined(A) */\n",
             "n_lines" => 1,
             "raw" => "#endif\n",
+            "source" => "(buffer)",
             "start_line_num" => 8,
             "sub_type" => "#endif",
             "type" => "cond"
@@ -185,6 +193,7 @@ is($lines_as_str,<<~'DUMP_EOF', "Simple data structure as expected") or show_tex
             "line" => "/*comment\n  line */\n",
             "n_lines" => 2,
             "raw" => "/*comment\n  line */\n",
+            "source" => "(buffer)",
             "start_line_num" => 9,
             "sub_type" => "text",
             "type" => "content"
@@ -196,6 +205,7 @@ is($lines_as_str,<<~'DUMP_EOF', "Simple data structure as expected") or show_tex
             "line" => "#define C /* this is\n             a hidden line continuation */ D\n",
             "n_lines" => 2,
             "raw" => "#define C /* this is\n             a hidden line continuation */ D\n",
+            "source" => "(buffer)",
             "start_line_num" => 11,
             "sub_type" => "#define",
             "type" => "content"


### PR DESCRIPTION
…data

Dave noticed there was a bug where I was adding a reference to an integer. That did not make any sense. This patch fixes up the data so the source of the line is more clear. I will do a further follow up to improve this more, this is just to get the bug out of the way.