### PR TITLE
pv_escape(): Fix compiler warning

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3159,7 +3159,7 @@ Apd	|char * |pv_escape	|NULLOK SV *dsv 			\
 				|const STRLEN count			\
 				|const STRLEN max			\
 				|NULLOK STRLEN * const escaped		\
-				|const U32 flags
+				|U32 flags
 Apd	|char * |pv_pretty	|NN SV *dsv				\
 				|NN char const * const str		\
 				|const STRLEN count			\

--- a/locale.c
+++ b/locale.c
@@ -1969,6 +1969,8 @@ S_new_numeric(pTHX_ const char *newnum, bool force)
                                                              NULL, NULL));
     Safefree(scratch_buffer);
 
+#    else
+    PERL_UNUSED_VAR(C_thousands_sep);
 #    endif
 
     PL_numeric_standard = PL_numeric_underlying_is_standard;

--- a/proto.h
+++ b/proto.h
@@ -3563,7 +3563,7 @@ Perl_pv_display(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pv
         assert(dsv); assert(pv)
 
 PERL_CALLCONV char *
-Perl_pv_escape(pTHX_ SV *dsv, char const * const str, const STRLEN count, const STRLEN max, STRLEN * const escaped, const U32 flags);
+Perl_pv_escape(pTHX_ SV *dsv, char const * const str, const STRLEN count, const STRLEN max, STRLEN * const escaped, U32 flags);
 #define PERL_ARGS_ASSERT_PV_ESCAPE              \
         assert(str)
 


### PR DESCRIPTION
A parameter to this function was declared const in embed.fnc, but it
isn't const