### PR TITLE
fixup many regexp bugs - not to be merged yet

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -45,6 +45,51 @@ XXX For a release on a stable branch, this section aspires to be:
 
 [ List each incompatible change as a =head2 entry ]
 
+=head2 Fixed regex engine capture buffer reset bugs and inconsistencies.
+
+Historically the exact rules of what should happen with quantified expressions
+that contain capture buffers were not clear, and the regex engine has been
+somewhat inconsistent in how it reset capture buffers inside of quantified
+groups. This meant that the state of the capture buffer variables $1, $2 could
+change when making supposedly minor and inconsequential changes to a pattern.
+
+After this release the capture buffers in the different branches of a match
+will be consistently mutually exclusive with each other, with the sole exception
+of the case of branch reset C</(?|...)/> which has its own special rules. In
+addition the final state of the capture buffers defined within a quantified
+group will consistently reflect the last successful iteration of the quantifier.
+
+For instance, after executing
+
+    "abcaba" =~ / ( (a) (b) (c) | (a) (b) | (a) )+ /x
+
+the pattern will match and leave C<$1> and C<$7> set to C<"a">, and C<$2>
+through C<$6> will be C<undef>. C<$&> will be the expected C<"abcaba">.
+
+In older perls this expression would result in C<$1> through C<$7> being
+set, with values from the first, second and third iterations of the quantifier
+set at the same time.
+
+An example of the discrepancy in behavior in older perls would be this:
+
+ "ababab" =~ /(?:(?:(ab))?\1)+/      and print "$&";
+ # output 'abab'
+ "ababab" =~ /(?:(?:((?{})ab))?\1)+/ and print "$&";
+ # outputs 'ababab'
+
+Another is this:
+
+ "A" =~ /(((?:A))?)+/;
+ my $first = $2;
+
+ "A" =~ /(((A))?)+/;
+ my $second = $2;
+
+in older perls $first and $second would not be the same. In newer perls they
+will.
+
+This may break code that was depending on the older inconsistent behaviour.
+
 =head1 Deprecations
 
 XXX Any deprecated features, syntax, modules etc. should be listed here.

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -382,9 +382,9 @@ Perl_rxres_save(pTHX_ void **rsp, REGEXP *rx)
     /* deal with regexp_paren_pair items */
     if (!p || p[1] < RX_NPARENS(rx)) {
 #ifdef PERL_ANY_COW
-        i = 7 + (RX_NPARENS(rx)+1) * 2;
+        i = 7 + (RX_NPARENS(rx)+1) * 4;
 #else
-        i = 6 + (RX_NPARENS(rx)+1) * 2;
+        i = 6 + (RX_NPARENS(rx)+1) * 4;
 #endif
         if (!p)
             Newx(p, i, UV);
@@ -410,6 +410,8 @@ Perl_rxres_save(pTHX_ void **rsp, REGEXP *rx)
     for (i = 0; i <= RX_NPARENS(rx); ++i) {
         *p++ = (UV)RX_OFFSp(rx)[i].start;
         *p++ = (UV)RX_OFFSp(rx)[i].end;
+        *p++ = (UV)RX_OFFSp(rx)[i].start_new;
+        *p++ = (UV)RX_OFFSp(rx)[i].end_new;
     }
 }
 
@@ -441,6 +443,8 @@ S_rxres_restore(pTHX_ void **rsp, REGEXP *rx)
     for (i = 0; i <= RX_NPARENS(rx); ++i) {
         RX_OFFSp(rx)[i].start = (I32)(*p++);
         RX_OFFSp(rx)[i].end = (I32)(*p++);
+        RX_OFFSp(rx)[i].start_new = (I32)(*p++);
+        RX_OFFSp(rx)[i].end_new = (I32)(*p++);
     }
 }
 

--- a/regexp.h
+++ b/regexp.h
@@ -82,6 +82,9 @@ typedef struct regexp_paren_pair {
     SSize_t start;
     SSize_t end;
 
+    SSize_t start_new;
+    SSize_t end_new;
+
     /* 'start_tmp' records a new opening position before the matching end
      * has been found, so that the old start and end values are still
      * valid, e.g.
@@ -202,13 +205,19 @@ typedef struct regexp {
 #define RXp_PAREN_NAMES(rx) ((rx)->paren_names)
 
 #define RXp_OFFS_START(rx,n) \
-     RXp_OFFSp(rx)[(n)].start 
+    ((RXp_OFFSp(rx)[(n)].end_new < 0 || RXp_OFFSp(rx)[(n)].start_new < 0 ) \
+     ? RXp_OFFSp(rx)[(n)].start \
+     : RXp_OFFSp(rx)[(n)].start_new )
 
 #define RXp_OFFS_END(rx,n) \
-     RXp_OFFSp(rx)[(n)].end 
+    ((RXp_OFFSp(rx)[(n)].end_new < 0 || RXp_OFFSp(rx)[(n)].start_new < 0 ) \
+     ? RXp_OFFSp(rx)[(n)].end \
+     : RXp_OFFSp(rx)[(n)].end_new )
 
 #define RXp_OFFS_VALID(rx,n) \
-     (RXp_OFFSp(rx)[(n)].end != -1 && RXp_OFFSp(rx)[(n)].start != -1 )
+    ((RXp_OFFSp(rx)[(n)].end_new >= 0 && RXp_OFFSp(rx)[(n)].start_new >= 0 )  \
+      ||                                                              \
+     (RXp_OFFSp(rx)[(n)].end >= 0 && RXp_OFFSp(rx)[(n)].start >= 0 ))
 
 #define RX_OFFS_START(rx_sv,n)  RXp_OFFS_START(ReANY(rx_sv),n)
 #define RX_OFFS_END(rx_sv,n)    RXp_OFFS_END(ReANY(rx_sv),n)

--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -1308,8 +1308,6 @@ sub run_tests {
     }
 
     {
-        local $::TODO = "[perl #38133]";
-
         "A" =~ /(((?:A))?)+/;
         my $first = $2;
 
@@ -2434,33 +2432,26 @@ SKIP:
         ok( "aaa" =~ /(?:((?{})a)?\1)+/,
             "GH Issue #18865 'aaa' - deoptimized pattern matches");
         $y = "($-[0],$+[0])";
-        {
-            local $::TODO = "Not Yet Implemented";
-            is( $y, $x,
-                "GH Issue #18865 'aaa' - test optimization");
-        }
+        is( $y, $x,
+            "GH Issue #18865 'aaa' - test optimization");
+
         ok( "ababab" =~ /(?:(?:(ab))?\1)+/,
             "GH Issue #18865 'ababab' - pattern matches");
         $x = "($-[0],$+[0])";
         ok( "ababab" =~ /(?:(?:((?{})ab))?\1)+/,
             "GH Issue #18865 'ababab' - deoptimized pattern matches");
         $y = "($-[0],$+[0])";
-        {
-            local $::TODO = "Not Yet Implemented";
-            is( $y, $x,
-                "GH Issue #18865 'ababab' - test optimization");
-        }
+        is( $y, $x,
+            "GH Issue #18865 'ababab' - test optimization");
+
         ok( "XaaXbbXb" =~ /(?:X([ab])?\1)+/,
             "GH Issue #18865 'XaaXbbXb' - pattern matches");
         $x = "($-[0],$+[0])";
         ok( "XaaXbbXb" =~ /(?:X((?{})[ab])?\1)+/,
             "GH Issue #18865 'XaaXbbXb' - deoptimized pattern matches");
         $y = "($-[0],$+[0])";
-        {
-            local $::TODO = "Not Yet Implemented";
-            is( $y, $x,
-                "GH Issue #18865 'XaaXbbXb' - test optimization");
-        }
+        is( $y, $x,
+            "GH Issue #18865 'XaaXbbXb' - test optimization");
     }
     {
         # Test that ${^LAST_SUCCESSFUL_PATTERN} works as expected.

--- a/t/re/pat_rt_report.t
+++ b/t/re/pat_rt_report.t
@@ -997,8 +997,6 @@ sub run_tests {
     }
 
     {
-        local $::TODO = "[perl #38133]";
-
         "A" =~ /(((?:A))?)+/;
         my $first = $2;
 

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -2137,8 +2137,8 @@ AB\s+\x{100}	AB \x{100}X	y	-	-
 (?|(a)(?{$::caret_n_got=$^N})|(b)(?{$::caret_n_got=$^N}))	a	y	$::caret_n_got	a		# GH 20912
 
 /(([ab]+)|([cd]+)|([ef]+))+/	ace	y	$1-$2-$3-$4=$&	e---e=ace
-/(([ab]+)|([cd]+)|([ef]+))+/	aceb	Ty	$1-$2-$3-$4=$&	b-b--=aceb
-/(([ab]+)|([cd]+)|([ef]+))+/	acebd	Ty	$1-$2-$3-$4=$&	d--d-=acebd
+/(([ab]+)|([cd]+)|([ef]+))+/	aceb	y	$1-$2-$3-$4=$&	b-b--=aceb
+/(([ab]+)|([cd]+)|([ef]+))+/	acebd	y	$1-$2-$3-$4=$&	d--d-=acebd
 /(([ab]+)|([cd]+)|([ef]+))+/	acebdf	y	$1-$2-$3-$4=$&	f---f=acebdf
 /((a)(b)(c)|(a)(b)|(a))+/	abcaba	y	$1+$2-$3-$4+$5-$6+$7=$&	a+--+-+a=abcaba
 


### PR DESCRIPTION
This fixes a number of longstanding regexp bugs and issues. It includes debugging changes and other stuff i will rebase away.

The main point is that we use a two layer model to represent capture buffers, and implement a concept of "commiting" the changes, and we store additional data in the CURLY nodes so we can manage the parens they contain properly. This is likely not the most efficient way to do this. The idea was to be correct first, then optimize.

The intended semantics are that: when we have a quantified group we keep track of the parens that it contains, and we ensure that all capture buffers it does contain come from a single iteration of the quantifier.

Consider 

```
./perl -le'"barfoobar"=~/((foo)|(bar))+/ and print "$1-$2-$3=$&";'
bar--bar=barfoobar
```

In older perls:
```
perl -le'"barfoobar"=~/((foo)|(bar))+/ and print "$1-$2-$3=$&";'
bar-foo-bar=barfoobar
```
You can see that in older perls that $2 is from the second iteration, and $3 is from the third.

This patch currently doesn't entirely fix this (yet):
```
./perl -le'"abcaba"=~/((a)(b)(c)|(a)(b)|(a))+/ and print "$1|$2-$3-$4|$5-$6|$7=$&";'
a|a--|a-|a=abcaba
```
where arguably $2 and $5 should be empty, as they werent part of the last succesful match. Currently I have only fixed CURLYX -> CURLYM. And what should happen here is a bit controversial, you could argue this is correct.

However even for this case we have a change from older perls:

```
perl -le'"abcaba"=~/((a)(b)(c)|(a)(b)|(a))+/ and print "$1|$2-$3-$4|$5-$6|$7=$&";'
a|a-b-c|a-b|a=abcaba
```

which really highlights the underlying bug, we have capture buffers here from the first, second and third iteration of the +. IMO that doesn't make sense, and it is inconsistent with the behavior of capture buffers in other contexts.

This PR patch also fixes some other related issues, for instance the min and max have been changed and REG_INFINITY is now I32_MAX, as opposed to U16_MAX. This means that CURLYM and CURLYX now behave the same.

This is intended to fix https://github.com/Perl/perl5/issues/20661 and related bugs. 

Fixes #20661
Fixes #8267 
Fixes #19615
Fixes #18865
Fixes #14848
Fixes #13619
Fixes #10073

