### PR TITLE
Makefile.SH - fix 'reonly' Makefile target to test ext/re/t/*.t properly

### DIFF
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -1667,7 +1667,7 @@ test_harness_notty: test_prep
 	HARNESS_NOTTY=1 TESTFILE=harness $(RUN_TESTS) choose
 
 test_reonly test-reonly: test_prep_reonly
-	TEST_ARGS='re/*.t ext/re/t/*.t' TESTFILE=harness $(RUN_TESTS) choose
+	TEST_ARGS='re/*.t ../ext/re/t/*.t' PERL_TEST_HARNESS_ASAP=1 TESTFILE=harness $(RUN_TESTS) choose
 
 
 # Porting tests (well-formedness of pod, manifest, etc)


### PR DESCRIPTION
The .. in front of the ext/ required as the list is constructed relative to the t/ directory of the repo.

This also enables "full steam ahead" mode when parallel jobs are enabled. This target only tests a subset of our functionality, running in normal mode and separating core tests from ext/ tests just slows things down for no value.