### PR TITLE
Provide '-Ilib' to @INC in programs called by regen.pl

### DIFF
--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -4,7 +4,7 @@
 # Any changes made here will be lost!
 
 package feature;
-our $VERSION = '1.78';
+our $VERSION = '1.79';
 
 our %feature = (
     fc                      => 'feature_fc',
@@ -366,7 +366,7 @@ warn when you use the feature, unless you have explicitly disabled the warning:
     no warnings "experimental::declared_refs";
 
 This allows a reference to a variable to be declared with C<my>, C<state>,
-our C<our>, or localized with C<local>.  It is intended mainly for use in
+or C<our>, or localized with C<local>.  It is intended mainly for use in
 conjunction with the "refaliasing" feature.  See L<perlref/Declaring a
 Reference to a Variable> for examples.
 

--- a/regen.pl
+++ b/regen.pl
@@ -15,7 +15,7 @@ use strict;
 
 my $tap = $ARGV[0] && $ARGV[0] eq '--tap' ? '# ' : '';
 foreach my $pl (map {chomp; "regen/$_"} <DATA>) {
-  my @command =  ($^X, '-I.', $pl, @ARGV);
+  my @command =  ($^X, '-I.', '-Ilib', $pl, @ARGV);
   print "$tap@command\n";
   system @command
     and die "@command failed: $?" 

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -500,7 +500,7 @@ read_only_bottom_close_and_rename($h);
 
 __END__
 package feature;
-our $VERSION = '1.78';
+our $VERSION = '1.79';
 
 FEATURES
 
@@ -788,7 +788,7 @@ warn when you use the feature, unless you have explicitly disabled the warning:
     no warnings "experimental::declared_refs";
 
 This allows a reference to a variable to be declared with C<my>, C<state>,
-our C<our>, or localized with C<local>.  It is intended mainly for use in
+or C<our>, or localized with C<local>.  It is intended mainly for use in
 conjunction with the "refaliasing" feature.  See L<perlref/Declaring a
 Reference to a Variable> for examples.
 


### PR DESCRIPTION
In the course of attempting correction of a one-character typo in documentation in lib/feature.pm (a generated file), an inadequacy in regen.pl was discovered.  The programs which regen.pl invokes need to be provided with '-Ilib' in their invocations to be able to locate, e.g., strict.pm.

Modification of lib/feature.pm's docs also required increment to its $VERSION inside regen/feature.pl.