### PR TITLE
regexec engine - wrap and replace RX_OFFS() with better abstractions

### DIFF
--- a/mg.c
+++ b/mg.c
@@ -643,9 +643,7 @@ Perl_magic_regdata_cnt(pTHX_ SV *sv, MAGIC *mg)
                 I32 paren = RX_LASTPAREN(rx);
 
                 /* return the last filled */
-                while ( paren >= 0
-                        && (RX_OFFS(rx)[paren].start == -1
-                            || RX_OFFS(rx)[paren].end == -1) )
+                while ( paren >= 0 && !RX_OFFS_VALID(rx,paren) )
                     paren--;
                 if (n == '-') {
                     /* @- */
@@ -680,8 +678,8 @@ Perl_magic_regdatum_get(pTHX_ SV *sv, MAGIC *mg)
             if (paren < 0)
                 return 0;
             if (paren <= (I32)RX_NPARENS(rx) &&
-                (s = RX_OFFS(rx)[paren].start) != -1 &&
-                (t = RX_OFFS(rx)[paren].end) != -1)
+                ((s = RX_OFFS_START(rx,paren)) != -1) &&
+                ((t = RX_OFFS_END(rx,paren))   != -1))
                 {
                     SSize_t i;
 

--- a/pp.c
+++ b/pp.c
@@ -6503,7 +6503,7 @@ PP(pp_split)
             /* we never pass the REXEC_COPY_STR flag, so it should
              * never get copied */
             assert(!RX_MATCH_COPIED(rx));
-            m = RX_OFFS(rx)[0].start + orig;
+            m = RX_OFFS_START(rx,0) + orig;
 
             if (gimme_scalar) {
                 iters++;
@@ -6518,8 +6518,8 @@ PP(pp_split)
             if (RX_NPARENS(rx)) {
                 I32 i;
                 for (i = 1; i <= (I32)RX_NPARENS(rx); i++) {
-                    s = RX_OFFS(rx)[i].start + orig;
-                    m = RX_OFFS(rx)[i].end + orig;
+                    s = orig + RX_OFFS_START(rx,i);
+                    m = orig + RX_OFFS_END(rx,i);
 
                     /* japhy (07/27/01) -- the (m && s) test doesn't catch
                        parens that didn't match -- they should be set to
@@ -6541,7 +6541,7 @@ PP(pp_split)
 
                 }
             }
-            s = RX_OFFS(rx)[0].end + orig;
+            s = RX_OFFS_END(rx,0) + orig;
         }
     }
 

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -320,14 +320,14 @@ PP(pp_substcont)
         s = orig + (m - s);
         cx->sb_strend = s + (cx->sb_strend - m);
     }
-    cx->sb_m = m = RX_OFFS(rx)[0].start + orig;
+    cx->sb_m = m = RX_OFFS_START(rx,0) + orig;
     if (m > s) {
         if (DO_UTF8(dstr) && !SvUTF8(cx->sb_targ))
             sv_catpvn_nomg_utf8_upgrade(dstr, s, m - s, nsv);
         else
             sv_catpvn_nomg(dstr, s, m-s);
     }
-    cx->sb_s = RX_OFFS(rx)[0].end + orig;
+    cx->sb_s = RX_OFFS_END(rx,0) + orig;
     { /* Update the pos() information. */
         SV * const sv
             = (pm->op_pmflags & PMf_NONDESTRUCT) ? cx->sb_dstr : cx->sb_targ;
@@ -407,8 +407,8 @@ Perl_rxres_save(pTHX_ void **rsp, REGEXP *rx)
     *p++ = (UV)RX_SUBOFFSET(rx);
     *p++ = (UV)RX_SUBCOFFSET(rx);
     for (i = 0; i <= RX_NPARENS(rx); ++i) {
-        *p++ = (UV)RX_OFFS(rx)[i].start;
-        *p++ = (UV)RX_OFFS(rx)[i].end;
+        *p++ = (UV)RX_OFFSp(rx)[i].start;
+        *p++ = (UV)RX_OFFSp(rx)[i].end;
     }
 }
 
@@ -438,8 +438,8 @@ S_rxres_restore(pTHX_ void **rsp, REGEXP *rx)
     RX_SUBOFFSET(rx) = (I32)*p++;
     RX_SUBCOFFSET(rx) = (I32)*p++;
     for (i = 0; i <= RX_NPARENS(rx); ++i) {
-        RX_OFFS(rx)[i].start = (I32)(*p++);
-        RX_OFFS(rx)[i].end = (I32)(*p++);
+        RX_OFFSp(rx)[i].start = (I32)(*p++);
+        RX_OFFSp(rx)[i].end = (I32)(*p++);
     }
 }
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -15718,9 +15718,9 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
              * so we could match anywhere in that string.  We have to rule out
              * matching a code point line */
             char * this_name_start = all_names_start
-                                                + RX_OFFS(subpattern_re)->start;
+                                                + RX_OFFS_START(subpattern_re,0);
             char * this_name_end   = all_names_start
-                                                + RX_OFFS(subpattern_re)->end;
+                                                + RX_OFFS_END(subpattern_re,0);
             char * cp_start;
             char * cp_end;
             UV cp = 0;      /* Silences some compilers */

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -514,15 +514,15 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         }
         if ( k == REF && reginfo) {
             U32 n = ARG(o);  /* which paren pair */
-            I32 ln = prog->offs[n].start;
-            if (prog->lastparen < n || ln == -1 || prog->offs[n].end == -1)
+            I32 ln = RXp_OFFS_START(prog,n);
+            if (prog->lastparen < n || ln == -1 || RXp_OFFS_END(prog,n) == -1)
                 Perl_sv_catpvf(aTHX_ sv, ": FAIL");
-            else if (ln == prog->offs[n].end)
+            else if (ln == RXp_OFFS_END(prog,n))
                 Perl_sv_catpvf(aTHX_ sv, ": ACCEPT - EMPTY STRING");
             else {
                 const char *s = reginfo->strbeg + ln;
                 Perl_sv_catpvf(aTHX_ sv, ": ");
-                Perl_pv_pretty( aTHX_ sv, s, prog->offs[n].end - prog->offs[n].start, 32, 0, 0,
+                Perl_pv_pretty( aTHX_ sv, s, RXp_OFFS_END(prog,n) - RXp_OFFS_START(prog,n), 32, 0, 0,
                     PERL_PV_ESCAPE_UNI_DETECT|PERL_PV_PRETTY_NOCLEAR|PERL_PV_PRETTY_ELLIPSES|PERL_PV_PRETTY_QUOTE );
             }
         }

--- a/regexp.h
+++ b/regexp.h
@@ -174,7 +174,18 @@ typedef struct regexp {
 } regexp;
 
 
-#  define RXp_PAREN_NAMES(rx)	((rx)->paren_names)
+#define RXp_PAREN_NAMES(rx)    ((rx)->paren_names)
+
+#define RXp_OFFS_START(rx,n)   ((rx)->offs[(n)].start)
+
+#define RXp_OFFS_END(rx,n)     ((rx)->offs[(n)].end)
+
+#define RXp_OFFS_VALID(rx,n) \
+    ( (rx)->offs[(n)].end != -1 && (rx)->offs[(n)].start != -1 )
+
+#define RX_OFFS_START(rx_sv,n)  RXp_OFFS_START(ReANY(rx_sv),n)
+#define RX_OFFS_END(rx_sv,n)    RXp_OFFS_END(ReANY(rx_sv),n)
+#define RX_OFFS_VALID(rx_sv,n)  RXp_OFFS_VALID(ReANY(rx_sv),n)
 
 /* used for high speed searches */
 typedef struct re_scream_pos_data_s
@@ -538,8 +549,8 @@ and check for NULL.
 #  define RXp_SUBOFFSET(prog)             (prog->suboffset)
 #  define RX_SUBOFFSET(rx_sv)             (RXp_SUBOFFSET(ReANY(rx_sv)))
 #  define RX_SUBCOFFSET(rx_sv)            (ReANY(rx_sv)->subcoffset)
-#  define RXp_OFFS(prog)                  (prog->offs)
-#  define RX_OFFS(rx_sv)                  (RXp_OFFS(ReANY(rx_sv)))
+#  define RXp_OFFSp(prog)                 (prog->offs)
+#  define RX_OFFSp(rx_sv)                 (RXp_OFFSp(ReANY(rx_sv)))
 #  define RXp_NPARENS(prog)               (prog->nparens)
 #  define RX_NPARENS(rx_sv)               (RXp_NPARENS(ReANY(rx_sv)))
 #  define RX_SUBLEN(rx_sv)                (ReANY(rx_sv)->sublen)
@@ -555,8 +566,8 @@ and check for NULL.
 #  define RX_SAVED_COPY(rx_sv)            (RXp_SAVED_COPY(ReANY(rx_sv)))
 /* last match was zero-length */
 #  define RXp_ZERO_LEN(prog) \
-        (RXp_OFFS(prog)[0].start + (SSize_t)RXp_GOFS(prog) \
-          == RXp_OFFS(prog)[0].end)
+        (RXp_OFFS_START(prog,0) + (SSize_t)RXp_GOFS(prog) \
+          == RXp_OFFS_END(prog,0))
 #  define RX_ZERO_LEN(rx_sv)              (RXp_ZERO_LEN(ReANY(rx_sv)))
 
 #endif /* PLUGGABLE_RE_EXTENSION */


### PR DESCRIPTION
RX_OFFS() exposes a bit too much about how capture buffers are represented. This adds RX_OFFS_START() and RX_OFFS_END() and RX_OFFS_VALID() to replace most of the uses of the RX_OFFS() macro or direct access to the rx->off[] array. (We add RX_OFFSp() for those rare cases that should have direct access to the array.) This allows us to replace this logic with more complicated macros in the future. Pretty much anything using RX_OFFS() is going to be broken by future changes, so changing the define allows us to track it down easily.

Not all use of the rx->offs[] array are converted; some uses are required for the regex engine internals, but anything outside of the regex engine should be using the replacement macros, and most things in the regex internals should use it also.