### PR TITLE
pp_multiconcat: don't set svpv_p to an invalid pointer

### DIFF
--- a/pp_hot.c
+++ b/pp_hot.c
@@ -957,7 +957,7 @@ PP(pp_multiconcat)
         /* Note that we iterate the loop nargs+1 times: to append nargs
          * arguments and nargs+1 constant strings. For example, "-$a-$b-"
          */
-        svpv_p = svpv_base - 1;
+        svpv_p = svpv_base;
 
         for (;;) {
             SSize_t len = (const_lens++)->ssize;
@@ -969,7 +969,7 @@ PP(pp_multiconcat)
                 const_pv += len;
             }
 
-            if (++svpv_p == svpv_end)
+            if (svpv_p == svpv_end)
                 break;
 
             /* append next arg */
@@ -997,6 +997,7 @@ PP(pp_multiconcat)
                     targ_pv += len;
             }
 
+            ++svpv_p;
         }
     }
 


### PR DESCRIPTION
When svpv_base == svpv_buf, svpv_p would be set to point before the buffer, which is undefined.

This appears to be what gcc 13 is complaining about in #20678, despite that report including what appears to be a completely valid address, on a line where the value of svpv_p is now within the range of svpv_buf.

An intermediate approach to this used:

   temp = svpv_p;
   if (svpv_p++ == svpv_end)
       break

but this is also incorrect, since svpv_p would end up as an invalid pointer, though gcc UBSAN didn't pick that up.

Fixes #20678.