### PR TITLE
t/test.pl - assign caller() to separate vars in _where()

### DIFF
--- a/t/test.pl
+++ b/t/test.pl
@@ -274,8 +274,8 @@ sub _ok {
 }
 
 sub _where {
-    my @caller = caller($Level);
-    return "at $caller[1] line $caller[2]";
+    my (undef, $filename, $lineno) = caller($Level);
+    return "at $filename line $lineno";
 }
 
 # DON'T use this for matches. Use like() instead.


### PR DESCRIPTION
`_where()` is a heavily used, small subroutine within _test.pl_. It currently assigns all eleven of `caller()`'s return values to array elements, then uses only the second and third of these to construct a return string.

This commit changes the assignment to use separate variables, which ends up being more efficient.

Benchmarking suggests that `_where()` is about 30% faster as a result. 

Blead:
```
            527.40 msec task-clock                #    0.942 CPUs utilized          
                 0      context-switches          #    0.000 K/sec                  
                 0      cpu-migrations            #    0.000 K/sec                  
               207      page-faults               #    0.392 K/sec                  
     2,294,819,979      cycles                    #    4.351 GHz                    
        17,962,377      stalled-cycles-frontend   #    0.78% frontend cycles idle   
            33,295      stalled-cycles-backend    #    0.00% backend cycles idle    
     7,764,685,025      instructions              #    3.38  insn per cycle         
                                                  #    0.00  stalled cycles per insn
     1,573,726,040      branches                  # 2983.944 M/sec               
```
Patched:
```
            395.68 msec task-clock                #    0.908 CPUs utilized          
                 1      context-switches          #    0.003 K/sec                  
                 0      cpu-migrations            #    0.000 K/sec                  
               211      page-faults               #    0.533 K/sec                  
     1,704,653,454      cycles                    #    4.308 GHz                    
         5,622,621      stalled-cycles-frontend   #    0.33% frontend cycles idle   
            33,201      stalled-cycles-backend    #    0.00% backend cycles idle    
     5,561,622,486      instructions              #    3.26  insn per cycle         
                                                  #    0.00  stalled cycles per insn
     1,134,712,918      branches                  # 2867.759 M/sec                  
```

The overhead of `ok( ... )` calls is reduced by about 10%. 
`for (1..10_000_000) { ok(1); }`
Blead:
```
         14,441.89 msec task-clock                #    0.998 CPUs utilized          
                29      context-switches          #    0.002 K/sec                  
                 0      cpu-migrations            #    0.000 K/sec                  
               484      page-faults               #    0.034 K/sec                  
    68,565,887,899      cycles                    #    4.748 GHz                    
       203,984,388      stalled-cycles-frontend   #    0.30% frontend cycles idle   
         7,440,867      stalled-cycles-backend    #    0.01% backend cycles idle    
   179,798,036,376      instructions              #    2.62  insn per cycle         
                                                  #    0.00  stalled cycles per insn
    37,787,325,446      branches                  # 2616.508 M/sec                  
```
Patched:
```
         12,847.09 msec task-clock                #    0.997 CPUs utilized          
                70      context-switches          #    0.005 K/sec                  
                 0      cpu-migrations            #    0.000 K/sec                  
               478      page-faults               #    0.037 K/sec                  
    60,646,402,759      cycles                    #    4.721 GHz                    
       187,471,796      stalled-cycles-frontend   #    0.31% frontend cycles idle   
       444,120,894      stalled-cycles-backend    #    0.73% backend cycles idle    
   161,046,642,446      instructions              #    2.66  insn per cycle         
                                                  #    0.00  stalled cycles per insn
    33,917,069,772      branches                  # 2640.059 M/sec                  
```