### PR TITLE
embed.pl - add a way to declare a parameter should be non-zero

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -600,6 +600,9 @@
 : know "I have defined whether NULL is OK or not" rather than having neither
 : NULL or NULLOK, which is ambiguous.
 :
+: Numeric arguments may also be prefixed with NZ, which will cause the
+: appropriate asserts to be generated to validate that this is the case.
+:
 : Flags should be sorted asciibetically.
 :
 : Please keep the next line *BLANK*
@@ -5319,7 +5322,7 @@ WERS	|I32	|regrepeat	|NN regexp *prog			\
 				|NN const regnode *p			\
 				|NN char *loceol			\
 				|NN regmatch_info * const reginfo	\
-				|I32 max
+				|NZ I32 max
 ERS	|bool	|regtry 	|NN regmatch_info *reginfo		\
 				|NN char **startposp
 ERS	|bool	|reginclass	|NULLOK regexp * const prog		\

--- a/proto.h
+++ b/proto.h
@@ -8815,7 +8815,8 @@ STATIC I32
 S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p, char *loceol, regmatch_info * const reginfo, I32 max _pDEPTH)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_REGREPEAT             \
-        assert(prog); assert(startposp); assert(p); assert(loceol); assert(reginfo)
+        assert(prog); assert(startposp); assert(p); assert(loceol); assert(reginfo); \
+        assert(max)
 
 STATIC bool
 S_regtry(pTHX_ regmatch_info *reginfo, char **startposp)

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -222,6 +222,7 @@ sub generate_proto_h {
                 }
                 my $nn = ( $arg =~ s/\s*\bNN\b\s+// );
                 push( @nonnull, $n ) if $nn;
+                my $nz = ( $arg =~ s/\s*\bNZ\b\s+// );
 
                 my $nullok = ( $arg =~ s/\s*\bNULLOK\b\s+// ); # strip NULLOK with no effect
 
@@ -234,7 +235,7 @@ sub generate_proto_h {
                      && ($temp_arg !~ /\w+\s+(\w+)(?:\[\d+\])?\s*$/) ) {
                     die_at_end "$func: $arg ($n) doesn't have a name\n";
                 }
-                if (defined $1 && $nn && !($commented_out && !$binarycompat)) {
+                if (defined $1 && ($nn||$nz) && !($commented_out && !$binarycompat)) {
                     push @names_of_nn, $1;
                 }
             }

--- a/regexec.c
+++ b/regexec.c
@@ -10061,8 +10061,6 @@ S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
     unsigned int to_complement = 0;  /* Invert the result? */
     char_class_number_ classnum;
 
-    assert(max);
-
     PERL_ARGS_ASSERT_REGREPEAT;
 
     /* This routine is structured so that we switch on the input OP.  Each OP


### PR DESCRIPTION
This autogenerates the required asserts to validate a parameter is non-zero. It uses it to replace the check in regrepeat() as a first example.