### PR TITLE
get_{av,hv} should ignore SVf_UTF8 when testing if flags == 0

### DIFF
--- a/perl.c
+++ b/perl.c
@@ -2845,7 +2845,8 @@ Returns the AV of the specified Perl global or package array with the given
 name (so it won't work on lexical variables).  C<flags> are passed
 to C<gv_fetchpv>.  If C<GV_ADD> is set and the
 Perl variable does not exist then it will be created.  If C<flags> is zero
-and the variable does not exist then NULL is returned.
+(ignoring C<SVf_UTF8>) and the variable does not exist then C<NULL> is
+returned.
 
 Perl equivalent: C<@{"$name"}>.
 
@@ -2859,7 +2860,7 @@ Perl_get_av(pTHX_ const char *name, I32 flags)
 
     PERL_ARGS_ASSERT_GET_AV;
 
-    if (flags)
+    if (flags & ~SVf_UTF8)
         return GvAVn(gv);
     if (gv)
         return GvAV(gv);
@@ -2874,7 +2875,8 @@ Perl_get_av(pTHX_ const char *name, I32 flags)
 Returns the HV of the specified Perl hash.  C<flags> are passed to
 C<gv_fetchpv>.  If C<GV_ADD> is set and the
 Perl variable does not exist then it will be created.  If C<flags> is zero
-and the variable does not exist then C<NULL> is returned.
+(ignoring C<SVf_UTF8>) and the variable does not exist then C<NULL> is
+returned.
 
 =cut
 */
@@ -2886,7 +2888,7 @@ Perl_get_hv(pTHX_ const char *name, I32 flags)
 
     PERL_ARGS_ASSERT_GET_HV;
 
-    if (flags)
+    if (flags & ~SVf_UTF8)
         return GvHVn(gv);
     if (gv)
         return GvHV(gv);


### PR DESCRIPTION
Otherwise, if you call with simply `SVf_UTF8` on a name that does not exist, it will try to call `GvAVn()` or `GvHVn()` on a NULL value and segfault.

(See also https://github.com/Perl/perl5/pull/20647#issuecomment-1381252416)