### PR TITLE
Override *.h files as C with Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,3 +21,4 @@ warnings.h linguist-generated
 *.pl linguist-language=Perl
 *.pm linguist-language=Perl
 *.t linguist-language=Perl
+*.h linguist-language=C


### PR DESCRIPTION
GitHub classifies 23 files as C++ for some reason.

https://github.com/Perl/perl5/search?q=language%3AC%2B%2B&type=code

I believe Perl doesn't contain C++ code, and C++ header files can have distinguishable `.hh`, `.hpp`, `.hxx`, and `.h++` [extensions](https://en.wikipedia.org/wiki/C%2B%2B) in addition.

![image](https://user-images.githubusercontent.com/68062695/212474842-f4068d73-6463-4d70-9757-dddc47cdc39f.png)

![image](https://user-images.githubusercontent.com/68062695/212474374-1ada91b5-f50c-440f-92a4-4eca96973fa1.png)
