### PR TITLE
Minor cleanups and tweaks to the regex engine (part 1 or a multipart PR sequence).

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -12712,7 +12712,6 @@ S_reginsert(pTHX_ RExC_state_t *pRExC_state, const U8 op,
     PERL_ARGS_ASSERT_REGINSERT;
     PERL_UNUSED_CONTEXT;
     PERL_UNUSED_ARG(depth);
-/* (REGNODE_TYPE((U8)op) == CURLY ? EXTRA_STEP_2ARGS : 0); */
     DEBUG_PARSE_FMT("inst"," - %s", REGNODE_NAME(op));
     assert(!RExC_study_started); /* I believe we should never use reginsert once we have started
                                     studying. If this is wrong then we need to adjust RExC_recurse

--- a/regcomp.c
+++ b/regcomp.c
@@ -4386,9 +4386,8 @@ S_regbranch(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, I32 first, U32 depth)
             ret = chain;
     }
     if (c == 1) {
-        *flagp |= flags&SIMPLE;
+        *flagp |= flags & SIMPLE;
     }
-
     return ret;
 }
 

--- a/regcomp.h
+++ b/regcomp.h
@@ -442,7 +442,6 @@ struct regnode_ssc {
 /* These should no longer be used directly in most cases. Please use
  * the REGNODE_AFTER() macros instead. */
 #define NODE_STEP_REGNODE	1	/* sizeof(regnode)/sizeof(regnode) */
-#define EXTRA_STEP_2ARGS	EXTRA_SIZE(struct regnode_2)
 
 /* Core macros for computing "the regnode after this one". See also
  * Perl_regnode_after() in reginline.h

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -3,6 +3,12 @@
 #ifndef STATIC
 #define STATIC  static
 #endif
+#ifndef RE_OPTIMIZE_CURLYX_TO_CURLYM
+#define RE_OPTIMIZE_CURLYX_TO_CURLYM 1
+#endif
+#ifndef RE_OPTIMIZE_CURLYX_TO_CURLYN
+#define RE_OPTIMIZE_CURLYX_TO_CURLYN 1
+#endif
 
 /* this is a chain of data about sub patterns we are processing that
    need to be handled separately/specially in study_chunk. Its so

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -2689,11 +2689,14 @@ Perl_study_chunk(pTHX_
                     DEBUG_STUDYDATA("after-whilem accept", data, depth, is_inf, min, stopmin, delta);
                 }
                 /* Try powerful optimization CURLYX => CURLYN. */
-                if (  OP(oscan) == CURLYX && data
-                      && data->flags & SF_IN_PAR
-                      && !(data->flags & SF_HAS_EVAL)
-                      && !deltanext && minnext == 1
-                      && mutate_ok
+                if ( RE_OPTIMIZE_CURLYX_TO_CURLYN
+                     && OP(oscan) == CURLYX
+                     && data
+                     && data->flags & SF_IN_PAR
+                     && !(data->flags & SF_HAS_EVAL)
+                     && !deltanext
+                     && minnext == 1
+                     && mutate_ok
                 ) {
                     /* Try to optimize to CURLYN.  */
                     regnode *nxt = REGNODE_AFTER_type(oscan, tregnode_CURLYX);
@@ -2739,15 +2742,16 @@ Perl_study_chunk(pTHX_
               nogo:
 
                 /* Try optimization CURLYX => CURLYM. */
-                if (  OP(oscan) == CURLYX && data
-                      && !(data->flags & SF_HAS_PAR)
-                      && !(data->flags & SF_HAS_EVAL)
-                      && !deltanext     /* atom is fixed width */
-                      && minnext != 0   /* CURLYM can't handle zero width */
+                if ( RE_OPTIMIZE_CURLYX_TO_CURLYM
+                     && OP(oscan) == CURLYX
+                     && data
+                     && !(data->flags & (SF_HAS_PAR|SF_HAS_EVAL))
+                     && !deltanext     /* atom is fixed width */
+                     && minnext != 0  /* CURLYM can't handle zero width */
                          /* Nor characters whose fold at run-time may be
                           * multi-character */
-                      && ! (RExC_seen & REG_UNFOLDED_MULTI_SEEN)
-                      && mutate_ok
+                     && !(RExC_seen & REG_UNFOLDED_MULTI_SEEN)
+                     && mutate_ok
                 ) {
                     /* XXXX How to optimize if data == 0? */
                     /* Optimize to a simpler form.  */

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -1951,7 +1951,7 @@ A+(*PRUNE)BC(?{})	AAABC	y	$&	AAABC
 /^(.\2?)(.)(?1)$/	abcb	y	$2	b
 /^(.\1?)(?1)$/	aba	y	$1	a
 /^ (\3(?2)\3)? ((.)) (?1) $/x	aaba	y	$2	a
-/^ (a|\3(?1)\2|(?2)) ((b|c)(?4)?) (?1) (d(?1)) $/x	abbcdcabbda	y	$2	b
+/^ (a|\3(?1)\2|(?2)) ((b|c)(?4)?) (?1) (d(?1)) $/x	abbcdcabbda	y	$1-$2-$3-$4	a-b-b-da
 
 # RT #121321 - perl 5.19.10 infinite loops on backrefs > number of capture buffers (npar) where npar>9
 /(a)\2/	a\2	c	-	Reference to nonexistent group in regex


### PR DESCRIPTION
These are various cleanup or preparation patches for a series of bug fixes patches that are intended to be applied on top of this PR. They do not change functionality really, just some cleanup, and some added flags to help debug the regex engine. (Eg there are new defines which can be used to disable the two optimized version of the CURLYX regop for testing purposes.)

These were originally from https://github.com/Perl/perl5/pull/20677.