### PR TITLE
regexec.c - fix accept in CURLYX/WHILEM construct.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6206,6 +6206,7 @@ t/re/regex_sets_compat.t	Test (?[ ]) is compatible with old [ ]
 t/re/regexp.t			See if regular expressions work
 t/re/regexp_noamp.t		See if regular expressions work with optimizations
 t/re/regexp_nonull.t		See if regexps work without trailing nulls
+t/re/regexp_normal.t		See if regexps work when expressions are normalized in various ways
 t/re/regexp_notrie.t		See if regular expressions work without trie optimisation
 t/re/regexp_qr.t		See if regular expressions work as qr//
 t/re/regexp_qr_embed.t		See if regular expressions work with embedded qr//

--- a/regexec.c
+++ b/regexec.c
@@ -8520,7 +8520,10 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 for (
                     cursor = scan;
                     cursor && ( OP(cursor) != END );
-                    cursor = ( REGNODE_TYPE( OP(cursor) ) == END )
+                    cursor = (
+                               REGNODE_TYPE( OP(cursor) ) == END
+                               || REGNODE_TYPE( OP(cursor) ) == WHILEM
+                             )
                              ? REGNODE_AFTER(cursor)
                              : regnext(cursor)
                 ){
@@ -8734,7 +8737,6 @@ NULL
             );
 
             /* First just match a string of min A's. */
-
             if (n < min) {
                 ST.cp = regcppush(rex, cur_curlyx->u.curlyx.parenfloor, maxopenparen);
                 cur_curlyx->u.curlyx.lastloc = locinput;

--- a/t/re/pat_re_eval.t
+++ b/t/re/pat_re_eval.t
@@ -24,7 +24,7 @@ BEGIN {
 
 our @global;
 
-plan tests => 508;  # Update this when adding/deleting tests.
+plan tests => 510;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -126,7 +126,13 @@ sub run_tests {
                "Postponed UTF-8 string in non-UTF-8 re doesn't match non-UTF-8";
         }
     }
-
+    {
+        our $this_counter;
+        ok( "ABDE" =~ /(A(A|B(*ACCEPT)|C)+D)(E)(?{ $this_counter++ })/,
+            "ACCEPT/CURLYX/EVAL - pattern should match");
+        is( "$1-$2", "AB-B",
+            "Make sure that ACCEPT works in CURLYX by using EVAL");
+    }
 
     {
         # Test if $^N and $+ work in (?{})

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -964,8 +964,8 @@ tt+$	xxxtt	y	-	-
 (?i)		y	-	-
 (?a:((?u)\w)\W)	\xC0\xC0	y	$&	\xC0\xC0
 '(?!\A)x'm	a\nxb\n	y	-	-
-^(a(b)?)+$	aba	y	-$1-$2-	-a--
-^(aa(bb)?)+$	aabbaa	y	-$1-$2-	-aa--
+^(a(b)?)+$	aba	y	-$1-$2-	-a--		# !normal
+^(aa(bb)?)+$	aabbaa	y	-$1-$2-	-aa--		# !normal
 '^.{9}abc.*\n'm	123\nabcabcabcabc\n	y	-	-
 ^(a)?a$	a	y	-$1-	--
 ^(a)?(?(1)a|b)+$	a	n	-	-

--- a/t/re/regexp.t
+++ b/t/re/regexp.t
@@ -144,7 +144,7 @@ $nulnul = "\0" x 2;
 my $OP = $qr ? 'qr' : 'm';
 
 $| = 1;
-
+$::normalize_pat = $::normalize_pat; # silence warning
 TEST:
 foreach (@tests) {
     $test_num++;
@@ -186,6 +186,22 @@ foreach (@tests) {
     my $todo_qr = $qr_embed_thr && ($result =~ s/t//);
     my $skip = ($skip_amp ? ($result =~ s/B//i) : ($result =~ s/B//));
     ++$skip if $result =~ s/M// && !defined &DynaLoader::boot_DynaLoader;
+    
+    if ($::normalize_pat) {
+        my $opat= $pat;
+        # Convert (x)? to (?:(x)|) and (x)+ to (?:(x))+ and (x)* to (?:(x))*
+        $pat =~ s/\(([\w|.]+)\)\?(?![+*?])/(?:($1)|)/g;
+        $pat =~ s/\(([\w|.]+)\)([+*])(?![+*?])/(?:($1))$2/g;
+        if ($opat eq $pat) {
+            # we didn't change anything, no point in testing it again.
+            $skip++;
+            $reason = "Test not valid for $0";
+        } elsif ($comment=~/!\s*normal/) {
+            $result .= "T";
+            $comment = "# Known to be broken under $0";
+        }
+    }
+
     if ($result =~ s/ ( [Ss] ) //x) {
         if (($1 eq 'S' && $regex_sets) || ($1 eq 's' && ! $regex_sets)) {
             $skip++;
@@ -421,9 +437,28 @@ foreach (@tests) {
             $pat = $modified;
         }
     }
+    if ($::normalize_pat){
+        if (!$skip && ($result eq "y" or $result eq "n")) {
+            my $opat= $pat;
+            # Convert (x)? to (?:(x)|) and (x)+ to (?:(x))+ and (x)* to (?:(x))*
+            $pat =~ s/\(([\w|.]+)\)\?(?![+*?])/(?:($1)|)/g;
+            $pat =~ s/\(([\w|.]+)\)([+*])(?![+*?])/(?:($1))$2/g;
+            # inject an EVAL into the front of the pattern.
+            # this should disable all optimizations.
+            $pat =~ s/\A(.)/$1(?{ \$the_counter++ })/
+                or die $pat;
+        } elsif (!$skip) {
+            $skip = $reason = "Test not applicable to $0";
+        }
+    }
 
     for my $study ('', 'study $subject;', 'utf8::upgrade($subject);',
 		   'utf8::upgrade($subject); study $subject;') {
+        if ( $skip ) {
+            print "ok $testname # skipped", length($reason) ? ".  $reason" : '', "\n";
+            next TEST;
+        }
+        our $the_counter = 0; # used in normalization tests
 	# Need to make a copy, else the utf8::upgrade of an already studied
 	# scalar confuses things.
 	my $subject = $subject;
@@ -486,11 +521,7 @@ EOFCODE
 	    eval $code;
 	}
 	chomp( my $err = $@ );
-	if ( $skip ) {
-	    print "ok $testname # skipped", length($reason) ? ".  $reason" : '', "\n";
-	    next TEST;
-	}
-	elsif ($result eq 'c') {
+	if ($result eq 'c') {
 	    if ($err !~ m!^\Q$expect!) { print "not ok $testname$todo (compile) $input => '$err'\n"; next TEST }
 	    last;  # no need to study a syntax error
 	}

--- a/t/re/regexp_normal.t
+++ b/t/re/regexp_normal.t
@@ -1,0 +1,10 @@
+#!./perl
+
+$::normalize_pat = 1;
+for $file ('./re/regexp.t', './t/re/regexp.t', ':re:regexp.t') {
+    if (-r $file) {
+	do $file or die $@;
+	exit;
+    }
+}
+die "Cannot find ./re/regexp.t or ./t/re/regexp.t\n";


### PR DESCRIPTION
The ACCEPT logic didnt know how to handle WHILEM, which for some reason does not have a next_off defined. I am not sure why.

This was revealed by forcing CURLYX optimisations off. This includes a patch to test what happens if we embed an eval group in the tests run by regexp.t when run via regexp_normal.t, which disabled CURLYX -> CURLYN and CURLYM optimisations and revealed this issue.