### PR TITLE
regcomp.c - increase size of CURLY nodes so the min/max is a I32

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -4739,13 +4739,13 @@ S_regpiece(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
         if (RExC_use_BRANCHJ) {
             reginsert(pRExC_state, LONGJMP, ret, depth+1);
             reginsert(pRExC_state, NOTHING, ret, depth+1);
-            NEXT_OFF(REGNODE_p(ret)) = 3;        /* Go over LONGJMP. */
+            REGNODE_STEP_OVER(ret,tregnode_NOTHING,tregnode_LONGJMP);
         }
         reginsert(pRExC_state, CURLYX, ret, depth+1);
-
         if (RExC_use_BRANCHJ)
-            NEXT_OFF(REGNODE_p(ret)) = 3;   /* Go over NOTHING to
-                                               LONGJMP. */
+            /* Go over NOTHING to LONGJMP. */
+            REGNODE_STEP_OVER(ret,tregnode_CURLYX,tregnode_NOTHING);
+
         if (! REGTAIL(pRExC_state, ret, reg_node(pRExC_state,
                                                   NOTHING)))
         {
@@ -4758,8 +4758,8 @@ S_regpiece(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
     /* Finish up the CURLY/CURLYX case */
     FLAGS(REGNODE_p(ret)) = 0;
 
-    ARG1_SET(REGNODE_p(ret), (U16)min);
-    ARG2_SET(REGNODE_p(ret), (U16)max);
+    ARG1_SET(REGNODE_p(ret), min);
+    ARG2_SET(REGNODE_p(ret), max);
 
   done_main_op:
 

--- a/regcomp.h
+++ b/regcomp.h
@@ -216,13 +216,13 @@ struct regnode_2L {
     I32 arg2;
 };
 
-/* 'Two field' -- Two 16 bit unsigned args */
+/* 'Two field' -- Two 32 bit signed args */
 struct regnode_2 {
     U8	flags;
     U8  type;
     U16 next_off;
-    U16 arg1;
-    U16 arg2;
+    I32 arg1;
+    I32 arg2;
 };
 
 #define REGNODE_BBM_BITMAP_LEN                                                  \
@@ -317,22 +317,22 @@ struct regnode_ssc {
    Impose a limit of REG_INFTY on various pattern matching operations
    to limit stack growth and to avoid "infinite" recursions.
 */
-/* The default size for REG_INFTY is U16_MAX, which is the same as
-   USHORT_MAX (see perl.h).  Unfortunately U16 isn't necessarily 16 bits
-   (see handy.h).  On the Cray C90, sizeof(short)==4 and hence U16_MAX is
-   ((1<<32)-1), while on the Cray T90, sizeof(short)==8 and U16_MAX is
-   ((1<<64)-1).  To limit stack growth to reasonable sizes, supply a
+/* The default size for REG_INFTY is I32_MAX, which is the same as UINT_MAX
+   (see perl.h). Unfortunately I32 isn't necessarily 32 bits (see handy.h).
+   On the Cray C90, or Cray T90, I32_MAX is considerably larger than it
+   might be elsewhere. To limit stack growth to reasonable sizes, supply a
    smaller default.
         --Andy Dougherty  11 June 1998
+        --Amended by Yves Orton 15 Jan 2023
 */
-#if SHORTSIZE > 2
+#if INTSIZE > 4
 #  ifndef REG_INFTY
-#    define REG_INFTY  nBIT_UMAX(16)
+#    define REG_INFTY  nBIT_IMAX(32)
 #  endif
 #endif
 
 #ifndef REG_INFTY
-#  define REG_INFTY U16_MAX
+#  define REG_INFTY I32_MAX
 #endif
 
 #define ARG_VALUE(arg) (arg)

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -1245,5 +1245,7 @@ static const scan_data_t zero_scan_data = {
     CLEAR_OPTSTART;                                             \
     node = dumpuntil(r,start,(b),(e),last,sv,indent+1,depth+1);
 
+#define REGNODE_STEP_OVER(ret,t1,t2) \
+    NEXT_OFF(REGNODE_p(ret)) = ((sizeof(t1)+sizeof(t2))/sizeof(regnode))
 
 #endif /* REGCOMP_INTERNAL_H */

--- a/t/re/reg_mesg.t
+++ b/t/re/reg_mesg.t
@@ -108,7 +108,7 @@ sub mark_as_utf8 {
     return @ret;
 }
 
-my $inf_m1 = ($Config::Config{reg_infty} || 65535) - 1;
+my $inf_m1 = ($Config::Config{reg_infty} || ((1<<31)-1)) - 1;
 my $inf_p1 = $inf_m1 + 2;
 
 my $B_hex = sprintf("\\x%02X", ord "B");


### PR DESCRIPTION
This allows us to resolve a test inconsistency between CURLYX and CURLY and CURLYM, which have different maximums. We use I32 and not U32 because the existing count logic uses -1 internally and using an I32 for the min/max prevents warnings about comparing signed and unsigned values when the count is compared against the min or max.

Note this patch leaves regnode_2 and regnode_2L pretty much identical. A follow up patch will make regnode_2 redundant, and  I plan a follow up patch from that which will remove regnode_2 entirely, A such for now I wont remove regnode_2 as part of this patch.