### PR TITLE
    regcomp_study.c - disable CURLYX optimizations when EVAL has been seen anywhere     

### DIFF
--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -83,8 +83,12 @@ Perl_debug_studydata(pTHX_ const char *where, scan_data_t *data,
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
     DEBUG_OPTIMISE_MORE_r({
-        if (!data)
+        if (!data) {
+            Perl_re_indentf(aTHX_  "%s: NO DATA",
+                depth,
+                where);
             return;
+        }
         Perl_re_indentf(aTHX_  "%s: M/S/D: %" IVdf "/%" IVdf "/%" IVdf " Pos:%" IVdf "/%" IVdf " Flags: 0x%" UVXf,
             depth,
             where,

--- a/t/re/pat_re_eval.t
+++ b/t/re/pat_re_eval.t
@@ -162,7 +162,9 @@ sub run_tests {
             [ 1, qr#^((??{"(?:bla|)"}))((??{$nested_tags}))$#, "bla blubb <bla><blubb></blubb></bla>", "a b <bla><blubb></blubb></bla>" ],
             [ 1, qr#^((??{"(?!)?"}))((??{$nested_tags}))$#, "bla blubb <bla><blubb></blubb></bla>", "a b <bla><blubb></blubb></bla>" ],
             [ 1, qr#^((??{"(?:|<(/?bla)>)"}))((??{$nested_tags}))\1$#, "bla blubb <bla><blubb></blubb></bla>", "a b <bla><blubb></blubb></bla>" ],
-            [ 0, qr#^((??{"(?!)"}))?((??{$nested_tags}))(?!)$#, "bla blubb undef", "a b undef" ],
+            [ 0, qr#^((??{"(?!)"}))?((??{$nested_tags}))(?!)$#, # changed in perl 5.37.7
+                 "bla blubb blub blu bl b bl b undef",
+                 "a b b u l b l b undef" ],
 
         ) { #"#silence vim highlighting
             $c++;


### PR DESCRIPTION
Historically we disabled CURLYX optimizations when they *contained* an EVAL, on the assumption that the optimization might
affect how many times, etc, the eval was called. However, this is also true for CURLYX with evals *afterwards*. If the CURLYN or CURLYM optimization can prune off the search space, then an eval afterwards will be affected. An when you take into account GOSUB, it means that an eval in front might be affected by an optimization after it.
    
So for now we disable CURLYN and CURLYM in any pattern with an EVAL.

Note this PR includes a patch from https://github.com/Perl/perl5/pull/20703, i will rebase that patch away when 20703 gets merged.