### PR TITLE
regcomp.c - add optimistic eval (*{ ... }) and (**{ ... })

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -27,6 +27,20 @@ here, but most should go in the L</Performance Enhancements> section.
 
 [ List each enhancement as a =head2 entry ]
 
+=head2 Optimistic Eval in Patterns
+
+The use of C<(?{ ... })> and C<(??{ ... })> in a pattern disables various
+optimizations globally in that pattern. This may or may not be desired by the
+programmer. This release adds the C<(*{ ... })> and C<(**{ ... })>
+equivalents. The only difference is that they do not and will never disable
+any optimisations in the regex engine. This may make them more unstable in the
+sense that they may be called more or less times in the future, however the
+number of times they execute will truly match how the regex engine functions.
+For example, certain types of optmisation are disabled when C<(?{ ... })> is
+included in a pattern, so that patterns which are O(N) in normal use become
+O(N*N) with a C<(?{ ... })> pattern in them. Switching to C<(*{ ... })> means
+the pattern will stay O(N).
+
 =head1 Security
 
 XXX Any security-related notices go here.  In particular, any security

--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -1990,6 +1990,18 @@ keep track of the number of nested parentheses. For example:
   /the (\S+)(?{ $color = $^N }) (\S+)(?{ $animal = $^N })/i;
   print "color = $color, animal = $animal\n";
 
+The use of this construct disables some optimisations globally in the
+pattern, and the pattern may execute much slower as a consequence.
+Use a C<*> instead of the C<?> block to create an optimistic form of
+this construct. C<(*{ ... })> should not disable any optimisations.
+
+=item C<(*{ I<code> })>
+X<(*{})> X<regex, optimistic code>
+
+This is *exactly* the same as C<(?{ I<code> })> with the exception
+that it does not disable B<any> optimisations at all in the regex engine.
+How often it is executed may vary from perl release to perl release.
+In a failing match it may not even be executed at all.
 
 =item C<(??{ I<code> })>
 X<(??{})>
@@ -2046,6 +2058,20 @@ Executing a postponed regular expression too many times without
 consuming any input string will also result in a fatal error.  The depth
 at which that happens is compiled into perl, so it can be changed with a
 custom build.
+
+The use of this construct disables some optimisations globally in the pattern,
+and the pattern may execute much slower as a consequence. Use a C<*> instead
+of the C<?> to create an optimistic form of this construct: C<(**{...})>
+maybe used as a replacement and should not disable any optimisations, but is
+likely to be even more volatile from perl version to perl version than
+C<(??{...})> is.
+
+=item C<(**{ I<code> })>
+X<(**{})> X<regex, postponed optimistic>
+
+This is exactly the same as C<(??{ I<code> })> however it does not disable
+B<any> optimisations. It is even more likely to change from version to version
+of perl. In a failing match it may not even be executed at all.
 
 =item C<(?I<PARNO>)> C<(?-I<PARNO>)> C<(?+I<PARNO>)> C<(?R)> C<(?0)>
 X<(?PARNO)> X<(?1)> X<(?R)> X<(?0)> X<(?-1)> X<(?+1)> X<(?-PARNO)> X<(?+PARNO)>
@@ -2201,7 +2227,15 @@ Full syntax: C<< (?(?=I<lookahead>)I<then>|I<else>) >>
 =item C<(?{ I<CODE> })>
 
 Treats the return value of the code block as the condition.
-Full syntax: C<< (?(?{ I<code> })I<then>|I<else>) >>
+Full syntax: C<< (?(?{ I<CODE> })I<then>|I<else>) >>
+
+Note use of this construct may globally affect the performance
+of the pattern. Consider using C<(*{ I<CODE> })>
+
+=item C<(*{ I<CODE> })>
+
+Treats the return value of the code block as the condition.
+Full syntax: C<< (?(*{ I<CODE> })I<then>|I<else>) >>
 
 =item C<(R)>
 
@@ -3293,14 +3327,15 @@ part of this regular expression needs to be converted explicitly
 
 =head2 Embedded Code Execution Frequency
 
-The exact rules for how often C<(??{})> and C<(?{})> are executed in a pattern
-are unspecified.  In the case of a successful match you can assume that
-they DWIM and will be executed in left to right order the appropriate
-number of times in the accepting path of the pattern as would any other
-meta-pattern.  How non-accepting pathways and match failures affect the
-number of times a pattern is executed is specifically unspecified and
-may vary depending on what optimizations can be applied to the pattern
-and is likely to change from version to version.
+The exact rules for how often C<(?{})> and C<(??{})> are executed in a pattern
+are unspecified, as are their even less well defined equivalents C<(*{})> and
+C<(**{})>. In the case of a successful match you can assume that they DWIM and
+will be executed in left to right order the appropriate number of times in the
+accepting path of the pattern as would any other meta-pattern. How non-
+accepting pathways and match failures affect the number of times a pattern is
+executed is specifically unspecified and may vary depending on what
+optimizations can be applied to the pattern and is likely to change from
+version to version.
 
 For instance in
 
@@ -3325,6 +3360,13 @@ example:
   "good" =~ /g(?:o(?{print "o"}))*d/;
 
 will output "o" twice.
+
+For historical and consistency reasons the use of normal code blocks
+anywhere in a pattern will disable certain optimisations. As of 5.37.7
+you can use an "optimistic" codeblock, C<(*{ ... })> or C<(**{ ... })>
+if you do *not* wish to disable these optimisations. This may result
+in code blocks being called less often than might have been had they
+not been optimistic.
 
 =head2 PCRE/Python Support
 

--- a/regcomp.h
+++ b/regcomp.h
@@ -108,6 +108,7 @@ typedef struct regexp_internal {
 #define PREGf_ANCH_SBOL         0x00000800
 #define PREGf_ANCH_GPOS         0x00001000
 #define PREGf_RECURSE_SEEN      0x00002000
+#define PREGf_PESSIMIZE_SEEN    0x00004000
 
 #define PREGf_ANCH              \
     ( PREGf_ANCH_SBOL | PREGf_ANCH_GPOS | PREGf_ANCH_MBOL )
@@ -976,6 +977,7 @@ ARGp_SET_inline(struct regnode *node, SV *ptr) {
 #define REG_UNFOLDED_MULTI_SEEN             0x00000400
 /* spare */
 #define REG_UNBOUNDED_QUANTIFIER_SEEN       0x00001000
+#define REG_PESSIMIZE_SEEN                  0x00002000
 
 
 START_EXTERN_C
@@ -1425,6 +1427,9 @@ typedef enum {
 #if defined(PERL_IN_REGEX_ENGINE)
 #include "reginline.h"
 #endif
+
+#define EVAL_OPTIMISTIC_FLAG    128
+#define EVAL_FLAGS_MASK         (EVAL_OPTIMISTIC_FLAG-1)
 
 #endif /* PERL_REGCOMP_H_ */
 

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -174,7 +174,7 @@ S_regdump_intflags(pTHX_ const char *lead, const U32 flags)
 
     ASSUME(REG_INTFLAGS_NAME_SIZE <= sizeof(flags)*8);
 
-    for (bit=0; bit<REG_INTFLAGS_NAME_SIZE; bit++) {
+    for (bit=0; bit<=REG_INTFLAGS_NAME_SIZE; bit++) {
         if (flags & (1<<bit)) {
             if (!set++ && lead)
                 Perl_re_printf( aTHX_  "%s", lead);
@@ -871,6 +871,10 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
     }
     else if (op == SBOL)
         Perl_sv_catpvf(aTHX_ sv, " /%s/", o->flags ? "\\A" : "^");
+    else if (op == EVAL) {
+        if (o->flags & EVAL_OPTIMISTIC_FLAG)
+            Perl_sv_catpvf(aTHX_ sv, " optimistic");
+    }
 
     /* add on the verb argument if there is one */
     if ( ( k == VERB || op == ACCEPT || op == OPFAIL ) && o->flags) {

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -1193,6 +1193,9 @@ static const scan_data_t zero_scan_data = {
             if (RExC_seen & REG_UNBOUNDED_QUANTIFIER_SEEN)                  \
                 Perl_re_printf( aTHX_ "REG_UNBOUNDED_QUANTIFIER_SEEN ");    \
                                                                             \
+            if (RExC_seen & REG_PESSIMIZE_SEEN)                             \
+                Perl_re_printf( aTHX_ "REG_PESSIMIZE_SEEN ");               \
+                                                                            \
             Perl_re_printf( aTHX_ "\n");                                    \
         });
 

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -2693,10 +2693,10 @@ Perl_study_chunk(pTHX_
                 if ( RE_OPTIMIZE_CURLYX_TO_CURLYN
                      && OP(oscan) == CURLYX
                      && data
-                     && !pRExC_state->code_blocks /* XXX: for now disable whenever eval
-                                                     is seen anywhere. We need a better
-                                                     way. */
-                     && ( ( data->flags & (SF_IN_PAR|SF_HAS_EVAL) ) == SF_IN_PAR )
+                     && !(RExC_seen & REG_PESSIMIZE_SEEN) /* XXX: for now disable whenever a
+                                                            non optimistic eval is seen
+                                                            anywhere.*/
+                     && ( data->flags & SF_IN_PAR ) /* has parens */
                      && !deltanext
                      && minnext == 1
                      && mutate_ok
@@ -2750,10 +2750,10 @@ Perl_study_chunk(pTHX_
                 if ( RE_OPTIMIZE_CURLYX_TO_CURLYM
                      && OP(oscan) == CURLYX
                      && data
-                     && !pRExC_state->code_blocks /* XXX: for now disable whenever eval
-                                                     is seen anywhere. We need a better
-                                                     way. */
-                     && !(data->flags & (SF_HAS_PAR|SF_HAS_EVAL))
+                     && !(RExC_seen & REG_PESSIMIZE_SEEN) /* XXX: for now disable whenever a
+                                                            non optimistic eval is seen
+                                                            anywhere.*/
+                     && !(data->flags & SF_HAS_PAR) /* no parens! */
                      && !deltanext     /* atom is fixed width */
                      && minnext != 0  /* CURLYM can't handle zero width */
                          /* Nor characters whose fold at run-time may be
@@ -3469,7 +3469,7 @@ Perl_study_chunk(pTHX_
             }
         }
         else if (OP(scan) == EVAL) {
-            if (data)
+            if (data && !(scan->flags & EVAL_OPTIMISTIC_FLAG) )
                 data->flags |= SF_HAS_EVAL;
         }
         else if ( REGNODE_TYPE(OP(scan)) == ENDLIKE ) {

--- a/regexec.c
+++ b/regexec.c
@@ -8585,7 +8585,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
             break;
 
         case LOGICAL:  /* modifier for EVAL and IFMATCH */
-            logical = scan->flags;
+            logical = scan->flags & EVAL_FLAGS_MASK; /* reserve a bit for optimistic eval */
             break;
 
 /*******************************************************************

--- a/regnodes.h
+++ b/regnodes.h
@@ -2876,11 +2876,12 @@ EXTCONST char * const PL_reg_intflags_name[] = {
 	"ANCH_SBOL",                  /* (1<<11) - 0x00000800 - PREGf_ANCH_SBOL */
 	"ANCH_GPOS",                  /* (1<<12) - 0x00001000 - PREGf_ANCH_GPOS */
 	"RECURSE_SEEN",               /* (1<<13) - 0x00002000 - PREGf_RECURSE_SEEN */
+	"PESSIMIZE_SEEN",             /* (1<<14) - 0x00004000 - PREGf_PESSIMIZE_SEEN */
 };
 #endif /* DOINIT */
 
 #ifdef DEBUGGING
-#  define REG_INTFLAGS_NAME_SIZE 14
+#  define REG_INTFLAGS_NAME_SIZE 15
 #endif
 
 /* The following have no fixed length. U8 so we can do strchr() on it. */

--- a/t/re/pat_re_eval.t
+++ b/t/re/pat_re_eval.t
@@ -24,7 +24,7 @@ BEGIN {
 
 our @global;
 
-plan tests => 510;  # Update this when adding/deleting tests.
+plan tests => 551;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -132,6 +132,70 @@ sub run_tests {
             "ACCEPT/CURLYX/EVAL - pattern should match");
         is( "$1-$2", "AB-B",
             "Make sure that ACCEPT works in CURLYX by using EVAL");
+    }
+    {
+        ok( "AB"=~/(A)(?(*{ 1 })B|C)/, "(?(*{ ... })yes|no) works as expected");
+        ok( "AC"=~/(A)(?(*{ 0 })B|C)/, "(?(*{ ... })yes|no) works as expected");
+    }
+
+    {
+        # Test if $^N and $+ work in (*{ }) (optimistic eval)
+        our @ctl_n = ();
+        our @plus = ();
+        our $nested_tags;
+        $nested_tags = qr{
+            <
+                ((\w)+)
+                (*{
+                       push @ctl_n, (defined $^N ? $^N : "undef");
+                       push @plus, (defined $+ ? $+ : "undef");
+                })
+            >
+            (**{$nested_tags})*
+            </\s* \w+ \s*>
+        }x;
+
+        # note the results of this may change from perl to perl as different optimisations
+        # are added or enabled. It is testing that things *work*, not that they produce
+        # a specific output. The whole idea of optimistic eval is to have an eval that
+        # does not disable optimizations in the way a normal eval does.
+        my $c = 0;
+        for my $test (
+            # Test structure:
+            #  [ Expected result, Regex, Expected value(s) of $^N, Expected value(s) of $+, "note" ]
+            [ 1, qr#^$nested_tags$#, "bla blubb bla", "a b a" ],
+            [ 1, qr#^($nested_tags)$#, "bla blubb <bla><blubb></blubb></bla>", "a b a" ],
+            [ 1, qr#^(|)$nested_tags$#, "bla blubb bla", "a b a" ],
+            [ 1, qr#^(?:|)$nested_tags$#, "bla blubb bla", "a b a" ],
+            [ 1, qr#^<(bl|bla)>$nested_tags<(/\1)>$#, "blubb /bla", "b /bla" ],
+            [ 1, qr#(**{"(|)"})$nested_tags$#, "bla blubb bla", "a b a" ],
+            [ 1, qr#^(**{"(bla|)"})$nested_tags$#, "bla blubb bla", "a b a" ],
+            [ 1, qr#^(**{"(|)"})(**{$nested_tags})$#, "bla blubb undef", "a b undef" ],
+            [ 1, qr#^(**{"(?:|)"})$nested_tags$#, "bla blubb bla", "a b a" ],
+            [ 1, qr#^((**{"(?:bla|)"}))((**{$nested_tags}))$#, "bla blubb <bla><blubb></blubb></bla>", "a b <bla><blubb></blubb></bla>" ],
+            [ 1, qr#^((**{"(?!)?"}))((**{$nested_tags}))$#, "bla blubb <bla><blubb></blubb></bla>", "a b <bla><blubb></blubb></bla>" ],
+            [ 1, qr#^((**{"(?:|<(/?bla)>)"}))((**{$nested_tags}))\1$#, "bla blubb <bla><blubb></blubb></bla>", "a b <bla><blubb></blubb></bla>" ],
+            [ 0, qr#^((**{"(?!)"}))?((**{$nested_tags}))(?!)$#,
+                 "bla blubb undef",
+                 "a b undef",
+                 "this test is expected to fail if CURLYX optimisations are disabled"],
+
+        ) { #"#silence vim highlighting
+            $c++;
+            @ctl_n = ();
+            @plus = ();
+            my $match = (("<bla><blubb></blubb></bla>" =~ $test->[1]) ? 1 : 0);
+            push @ctl_n, (defined $^N ? $^N : "undef");
+            push @plus, (defined $+ ? $+ : "undef");
+            ok($test->[0] == $match, "match $c");
+            if ($test->[0] != $match) {
+              # unset @ctl_n and @plus
+              @ctl_n = @plus = ();
+            }
+            my $note = $test->[4] ? " - $test->[4]" : "";
+            is("@ctl_n", $test->[2], "ctl_n $c$note");
+            is("@plus", $test->[3], "plus $c$note");
+        }
     }
 
     {

--- a/t/re/pat_rt_report.t
+++ b/t/re/pat_rt_report.t
@@ -20,7 +20,7 @@ use warnings;
 use 5.010;
 use Config;
 
-plan tests => 2510;  # Update this when adding/deleting tests.
+plan tests => 2514;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -747,14 +747,24 @@ sub run_tests {
     }
 
     {
-        my $message = 'Match is linear, not quadratic; Bug 22395';
+        my $message = 'Match is quadratic due to eval; See Bug 22395';
         our $count;
         for my $l (10, 100, 1000) {
             $count = 0;
-            ('a' x $l) =~ /(.*)(?{$count++})[bc]/;
-            local $::TODO = "Should be L+1 not L*(L+3)/2 (L=$l)";
-            is($count, $l + 1, $message);
+            ('a' x $l) =~ /(.*)(?{ $count++ })[bc]/;
+            is($count, $l*($l+3)/2+1, $message);
         }
+    }
+    {
+        my $message = 'Match is linear, not quadratic; Bug 22395.';
+        our $count;
+        my $ok= 0;
+        for my $l (10, 100, 1000) {
+            $count = 0;
+            ('a' x $l) =~ /(.*)(*{ $count++ })[bc]/;
+            $ok += is($count, $l + 1, $message);
+        }
+        is($ok,3, "Optimistic eval does not disable optimisations");
     }
 
     {


### PR DESCRIPTION
This adds (*{ ... }) and (**{ ... }) as equivalents to (?{ ... }) and (??{ ... }). The only difference being that the star variants are "optimisitic" and are defined to never disable optimisations. This is especially relevant now that use of (?{ ... }) prevents important optimisations anywhere in the pattern, instead of the older and inconsistent rules where it only affected the parts that contained the EVAL.

It is also very useful for injecting debugging style expressions to the pattern to understand what the regex engine is actually doing. The older style (?{ ... }) variants would change the regex engines behavior, meaning this was not as effective a tool as it could have been.

Similarly it is now possible to test that a given regex optimisation works correctly using (*{ ... }), which was not possible with (?{ ... }).