### PR TITLE
Remove full stop in the 'try' feature heading

### DIFF
--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -434,7 +434,7 @@ previous versions it was simply on all the time.
 You can use the L<bareword::filehandles> module on CPAN to disable
 bareword filehandles for older versions of perl.
 
-=head2 The 'try' feature.
+=head2 The 'try' feature
 
 B<WARNING>: This feature is still experimental and the implementation may
 change or be removed in future versions of Perl.  For this reason, Perl will

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -856,7 +856,7 @@ previous versions it was simply on all the time.
 You can use the L<bareword::filehandles> module on CPAN to disable
 bareword filehandles for older versions of perl.
 
-=head2 The 'try' feature.
+=head2 The 'try' feature
 
 B<WARNING>: This feature is still experimental and the implementation may
 change or be removed in future versions of Perl.  For this reason, Perl will


### PR DESCRIPTION
None of the other headings in feature.pm have full stops.