### PR TITLE
Fix building with clang-16

### DIFF
--- a/Configure
+++ b/Configure
@@ -7927,10 +7927,10 @@ $cat >malloc.c <<END
 #include <stdlib.h>
 #endif
 #ifdef TRY_MALLOC
-void *malloc();
+void *malloc(size_t);
 #endif
 #ifdef TRY_FREE
-void free();
+void free(void *);
 #endif
 END
 case "$malloctype" in


### PR DESCRIPTION
Clang 16 sets `-Werror,-Wdeprecated-non-prototype` which forbids ANSI style function declarations that leave out the parameter types, treating them instead like conflicting declarations.  This explicitly adds the argument type to prevent build failure.

Fixes https://github.com/Perl/perl5/issues/20715.