### PR TITLE
regexec.c - harden internals against missing logical_nparens

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2759,7 +2759,7 @@ Cp	|void	|regfree_internal					\
 EXp	|regexp_engine const *|current_re_engine
 Apdh	|REGEXP *|pregcomp	|NN SV * const pattern			\
 				|const U32 flags
-p	|REGEXP *|re_op_compile |NULLOK SV ** const patternp		\
+Xp	|REGEXP *|re_op_compile |NULLOK SV ** const patternp		\
 				|int pat_count				\
 				|NULLOK OP *expr			\
 				|NN const regexp_engine *eng		\

--- a/proto.h
+++ b/proto.h
@@ -3616,8 +3616,7 @@ Perl_re_intuit_string(pTHX_ REGEXP  * const r);
         assert(r)
 
 PERL_CALLCONV REGEXP *
-Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count, OP *expr, const regexp_engine *eng, REGEXP *old_re, bool *is_bare_re, const U32 rx_flags, const U32 pm_flags)
-        __attribute__visibility__("hidden");
+Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count, OP *expr, const regexp_engine *eng, REGEXP *old_re, bool *is_bare_re, const U32 rx_flags, const U32 pm_flags);
 #define PERL_ARGS_ASSERT_RE_OP_COMPILE          \
         assert(eng)
 

--- a/regexec.c
+++ b/regexec.c
@@ -12011,6 +12011,7 @@ Perl_reg_numbered_buff_fetch_flags(pTHX_ REGEXP * const re, const I32 paren,
     SSize_t i,t = 0;
     SSize_t s1, t1;
     I32 n = paren;
+    I32 logical_nparens = rx->logical_nparens ? rx->logical_nparens : rx->nparens;
 
     PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_FETCH_FLAGS;
 
@@ -12054,7 +12055,7 @@ Perl_reg_numbered_buff_fetch_flags(pTHX_ REGEXP * const re, const I32 paren,
         i = rx->sublen + rx->suboffset - t;
     }
     else /* when flags is true we do an absolute lookup, and compare against rx->nparens */
-    if (inRANGE(n, 0, flags ? (I32)rx->nparens : (I32)rx->logical_nparens)) {
+    if (inRANGE(n, 0, flags ? (I32)rx->nparens : logical_nparens)) {
         I32 *map = (!flags && n) ? rx->logical_to_parno : NULL;
         I32 true_parno = map ? map[n] : n;
         do {
@@ -12141,6 +12142,7 @@ Perl_reg_numbered_buff_length(pTHX_ REGEXP * const r, const SV * const sv,
     struct regexp *const rx = ReANY(r);
     I32 i;
     I32 s1, t1;
+    I32 logical_nparens = rx->logical_nparens ? rx->logical_nparens : rx->nparens;
 
     PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_LENGTH;
 
@@ -12188,7 +12190,7 @@ Perl_reg_numbered_buff_length(pTHX_ REGEXP * const r, const SV * const sv,
         return 0;
 
       default: /* $& / ${^MATCH}, $1, $2, ... */
-        if (paren <= (I32)rx->logical_nparens) {
+        if (paren <= logical_nparens) {
             I32 true_paren = rx->logical_to_parno
                              ? rx->logical_to_parno[paren]
                              : paren;


### PR DESCRIPTION
We can default a 0 rx->logical_nparens to rx->nparens. If rx->logical_nparens is zero then either rx->nparens is also zero, or it can be defaulted. This will fix most re::engine::XXX modules that do not know about the new field, provided they zero the rx structure during construction. If they don't then this patch won't hurt anything and we will have to patch them directly.

Also mark re_op_compile() as available to extensions. Marking it as hidden means that re::engine::PCRE2 and others cannot build.

This patch should go a long way towards fixing issue #20710.
See also: https://github.com/rurban/re-engine-PCRE2/issues/39