### PR TITLE
Allow `substr` operator to be overloaded

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,8 @@ lib/warnings.pm linguist-generated
 feature.h linguist-generated
 opcode.h linguist-generated
 opnames.h linguist-generated
+overload.h linguist-generated
+overload.inc linguist-generated
 perly.act linguist-generated
 perly.h linguist-generated
 perly.tab linguist-generated

--- a/embed.fnc
+++ b/embed.fnc
@@ -623,6 +623,10 @@ Adp	|SV *	|amagic_call	|NN SV *left				\
 				|NN SV *right				\
 				|int method				\
 				|int dir
+Adp	|SV *	|amagic_call_unx|NN SV *sv				\
+				|int method				\
+				|NN SV **args				\
+				|I32 nargs
 Adp	|SV *	|amagic_deref_call					\
 				|NN SV *ref				\
 				|int method

--- a/embed.h
+++ b/embed.h
@@ -128,6 +128,7 @@
 # define _to_utf8_upper_flags(a,b,c,d,e)        Perl__to_utf8_upper_flags(aTHX_ a,b,c,d,e)
 # define _utf8n_to_uvchr_msgs_helper            Perl__utf8n_to_uvchr_msgs_helper
 # define amagic_call(a,b,c,d)                   Perl_amagic_call(aTHX_ a,b,c,d)
+# define amagic_call_unx(a,b,c,d)               Perl_amagic_call_unx(aTHX_ a,b,c,d)
 # define amagic_deref_call(a,b)                 Perl_amagic_deref_call(aTHX_ a,b)
 # define apply_attrs_string(a,b,c,d)            Perl_apply_attrs_string(aTHX_ a,b,c,d)
 # define apply_builtin_cv_attributes(a,b)       Perl_apply_builtin_cv_attributes(aTHX_ a,b)

--- a/gv.c
+++ b/gv.c
@@ -4208,6 +4208,102 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int flags)
   }
 }
 
+SV *
+Perl_amagic_call_unx(pTHX_ SV *sv, int method, SV **args, I32 nargs)
+{
+    PERL_ARGS_ASSERT_AMAGIC_CALL_UNX;
+
+    if(!SvAMAGIC(sv))
+        return NULL;
+
+    HV *stash = SvSTASH(SvRV(sv));
+    if(!stash || !Gv_AMG(stash))
+        return NULL;
+
+    MAGIC *mg = mg_find((const SV *)stash, PERL_MAGIC_overload_table);
+    if(!mg)
+        return NULL;
+
+    CV **cvp = NULL;
+    AMT *amtp = NULL;
+    if(AMT_AMAGIC((AMT *)mg->mg_ptr)) {
+        amtp = (AMT *)mg->mg_ptr;
+        cvp  = amtp->table;
+    }
+    if(!cvp)
+        return NULL;
+
+    CV *cv = cvp[method];
+    if(!cv) {
+        // TODO: Has overloading generally, just not this overload specifically. Complain?
+        return NULL;
+    }
+
+    dSP;
+    U8 gimme = GIMME_V;
+    LISTOP myop;
+    const bool oldcatch = CATCH_GET;
+    CATCH_SET(TRUE);
+    Zero(&myop, 1, LISTOP);
+    myop.op_last = (OP *) &myop;
+    myop.op_next = NULL;
+    myop.op_flags = OPf_STACKED;
+
+    switch(gimme) {
+        case G_VOID:
+            myop.op_flags |= OPf_WANT_VOID;
+            break;
+        case G_LIST:
+        case G_SCALAR:
+            myop.op_flags |= OPf_WANT_SCALAR;
+            break;
+    }
+
+    PUSHSTACKi(PERLSI_OVERLOAD);
+    ENTER;
+    SAVEOP();
+    PL_op = (OP *) &myop;
+    if (PERLDB_SUB && PL_curstash != PL_debstash)
+        PL_op->op_private |= OPpENTERSUB_DB;
+    Perl_pp_pushmark(aTHX);
+
+    EXTEND(SP, 2 + nargs);
+    PUSHs(sv);
+    while(nargs) {
+        PUSHs(*args);
+        args++, nargs--;
+    }
+    PUSHs(MUTABLE_SV(cv));
+    PUTBACK;
+    I32 oldmark = TOPMARK;
+
+    if ((PL_op = PL_ppaddr[OP_ENTERSUB](aTHX)))
+        CALLRUNOPS(aTHX);
+    LEAVE;
+    SPAGAIN;
+
+    I32 nret = SP - (PL_stack_base + oldmark);
+
+    SV *res;
+    switch(gimme) {
+        case G_VOID:
+            res = &PL_sv_undef;
+            SP = PL_stack_base + oldmark;
+            break;
+
+        case G_LIST:
+        case G_SCALAR:
+            res = POPs;
+            break;
+    }
+
+    PUTBACK;
+    POPSTACK;
+    CATCH_SET(oldcatch);
+
+    return res;
+}
+
 /*
 =for apidoc gv_name_set
 

--- a/lib/overload.pm
+++ b/lib/overload.pm
@@ -3,7 +3,7 @@ package overload;
 use strict;
 no strict 'refs';
 
-our $VERSION = '1.36';
+our $VERSION = '1.37';
 
 our %ops = (
     with_assign         => "+ - * / % ** << >> x .",
@@ -15,6 +15,7 @@ our %ops = (
     unary               => "neg ! ~ ~.",
     mutators            => '++ --',
     func                => "atan2 cos sin exp abs log sqrt int",
+    stringy             => "substr",
     conversion          => 'bool "" 0+ qr',
     iterators           => '<>',
     filetest            => "-X",

--- a/lib/overload/numbers.pm
+++ b/lib/overload/numbers.pm
@@ -89,6 +89,7 @@ our @names = qw#
     (~~
     (-X
     (qr
+    (substr
 #;
 
 our @enums = qw#
@@ -167,6 +168,7 @@ our @enums = qw#
     smart
     ftest
     regexp
+    substr
 #;
 
 { my $i = 0; our %names = map { $_ => $i++ } @names }

--- a/mg.c
+++ b/mg.c
@@ -2367,6 +2367,18 @@ Perl_magic_getsubstr(pTHX_ SV *sv, MAGIC *mg)
     PERL_ARGS_ASSERT_MAGIC_GETSUBSTR;
     PERL_UNUSED_ARG(mg);
 
+    if (UNLIKELY(SvFLAGS(lsv) && (SVf_ROK|SVs_GMG))) {
+        SV *ret;
+        SV *args[] = {newSV_type_mortal(SVt_IV), newSV_type_mortal(SVt_IV)};
+        if(negoff) sv_setiv(args[0], LvTARGOFF(sv)); else sv_setuv(args[0], LvTARGOFF(sv));
+        if(negrem) sv_setiv(args[1], LvTARGLEN(sv)); else sv_setuv(args[0], LvTARGLEN(sv));
+
+        if((ret = amagic_call_unx(lsv, substr_amg, args, 2))) {
+            sv_setsv_nomg(lsv, ret);
+            return 0;
+        }
+    }
+
     if (!translate_substr_offsets(
             SvUTF8(lsv) ? sv_or_pv_len_utf8(lsv, tmps, len) : len,
             negoff ? -(IV)offs : (IV)offs, !negoff,
@@ -2400,6 +2412,17 @@ Perl_magic_setsubstr(pTHX_ SV *sv, MAGIC *mg)
     PERL_UNUSED_ARG(mg);
 
     SvGETMAGIC(lsv);
+
+    if (UNLIKELY(SvFLAGS(lsv) & (SVf_ROK|SVs_GMG))) {
+        SV *ret;
+        SV *args[] = {newSV_type_mortal(SVt_IV), newSV_type_mortal(SVt_IV), sv};
+        if(negoff) sv_setiv(args[0], LvTARGOFF(sv)); else sv_setuv(args[0], LvTARGOFF(sv));
+        if(neglen) sv_setiv(args[1], LvTARGLEN(sv)); else sv_setuv(args[0], LvTARGLEN(sv));
+
+        if((ret = amagic_call_unx(lsv, substr_amg, args, 3)))
+            return 0;
+    }
+
     if (SvROK(lsv))
         Perl_ck_warner(aTHX_ packWARN(WARN_SUBSTR),
                             "Attempt to use reference as lvalue in substr"

--- a/overload.h
+++ b/overload.h
@@ -89,6 +89,7 @@ enum {
     smart_amg,		/* 0x48 ~~       */
     ftest_amg,		/* 0x49 -X       */
     regexp_amg,		/* 0x4a qr       */
+    substr_amg,		/* 0x4b substr   */
     max_amg_code
     /* Do not leave a trailing comma here.  C9X allows it, C89 doesn't. */
 };

--- a/overload.inc
+++ b/overload.inc
@@ -91,7 +91,8 @@ static const U8 PL_AMG_namelens[NofAMmeth] = {
     3,
     3,
     3,
-    3
+    3,
+    7
 };
 
 static const char * const PL_AMG_names[NofAMmeth] = {
@@ -174,7 +175,8 @@ static const char * const PL_AMG_names[NofAMmeth] = {
     "(.=",		/* concat_ass */
     "(~~",		/* smart      */
     "(-X",		/* ftest      */
-    "(qr"
+    "(qr",		/* regexp     */
+    "(substr"
 };
 
 /* ex: set ro ft=C: */

--- a/pp.c
+++ b/pp.c
@@ -3355,6 +3355,14 @@ PP(pp_substr)
         assert(!repl_sv);
         repl_sv = POPs;
     }
+    if(UNLIKELY(SvFLAGS(sv) & (SVf_ROK|SVs_GMG))) {
+        SV *ret;
+        SV *args[] = {pos_sv, len_sv, repl_sv};
+        if((ret = amagic_call_unx(sv, substr_amg, args, 2 + !!repl_sv))) {
+            PUSHs(ret);
+            RETURN;
+        }
+    }
     if (lvalue && !repl_sv) {
         SV * ret;
         ret = newSV_type_mortal(SVt_PVLV);  /* Not TARG RT#67838 */

--- a/proto.h
+++ b/proto.h
@@ -192,6 +192,11 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int dir);
         assert(left); assert(right)
 
 PERL_CALLCONV SV *
+Perl_amagic_call_unx(pTHX_ SV *sv, int method, SV **args, I32 nargs);
+#define PERL_ARGS_ASSERT_AMAGIC_CALL_UNX        \
+        assert(sv); assert(args)
+
+PERL_CALLCONV SV *
 Perl_amagic_deref_call(pTHX_ SV *ref, int method);
 #define PERL_ARGS_ASSERT_AMAGIC_DEREF_CALL      \
         assert(ref)

--- a/regen/overload.pl
+++ b/regen/overload.pl
@@ -205,3 +205,4 @@ concat_ass	(.=
 smart		(~~
 ftest           (-X
 regexp          (qr
+substr          (substr


### PR DESCRIPTION
RFC0013 calls for core's `substr()` operator to support operator overloading, allowing strings to provide overloading that can perform arbitrary behaviours.

Still TODO:

 * [ ] Think about how to preserve the real `$pos` and `$len` SVs when invoking overload via LVALUE magic
 * [ ] Think about how `nomethod` is going to play with this, given the odd shape of its arguments
 * [ ] Documentation
 * [ ] More testing