### PR TITLE
check the IO object exists when writing to IO magic variables

### DIFF
--- a/mg.c
+++ b/mg.c
@@ -3072,25 +3072,55 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
             IoLINES(GvIOp(PL_last_in_gv)) = SvIV(sv);
         break;
     case '^':
-        Safefree(IoTOP_NAME(GvIOp(PL_defoutgv)));
-        IoTOP_NAME(GvIOp(PL_defoutgv)) = savesvpv(sv);
-        IoTOP_GV(GvIOp(PL_defoutgv)) =  gv_fetchsv(sv, GV_ADD, SVt_PVIO);
+        {
+            IO * const io = GvIO(PL_defoutgv);
+            if (!io)
+                break;
+
+            Safefree(IoTOP_NAME(io));
+            IoTOP_NAME(io) = savesvpv(sv);
+            IoTOP_GV(io) =  gv_fetchsv(sv, GV_ADD, SVt_PVIO);
+        }
         break;
     case '~':
-        Safefree(IoFMT_NAME(GvIOp(PL_defoutgv)));
-        IoFMT_NAME(GvIOp(PL_defoutgv)) = savesvpv(sv);
-        IoFMT_GV(GvIOp(PL_defoutgv)) =  gv_fetchsv(sv, GV_ADD, SVt_PVIO);
+        {
+            IO * const io = GvIO(PL_defoutgv);
+            if (!io)
+                break;
+
+            Safefree(IoFMT_NAME(io));
+            IoFMT_NAME(io) = savesvpv(sv);
+            IoFMT_GV(io) =  gv_fetchsv(sv, GV_ADD, SVt_PVIO);
+        }
         break;
     case '=':
-        IoPAGE_LEN(GvIOp(PL_defoutgv)) = (SvIV(sv));
+        {
+            IO * const io = GvIO(PL_defoutgv);
+            if (!io)
+                break;
+
+            IoPAGE_LEN(io) = (SvIV(sv));
+        }
         break;
     case '-':
-        IoLINES_LEFT(GvIOp(PL_defoutgv)) = (SvIV(sv));
-        if (IoLINES_LEFT(GvIOp(PL_defoutgv)) < 0L)
-                IoLINES_LEFT(GvIOp(PL_defoutgv)) = 0L;
+        {
+            IO * const io = GvIO(PL_defoutgv);
+            if (!io)
+                break;
+
+            IoLINES_LEFT(io) = (SvIV(sv));
+            if (IoLINES_LEFT(io) < 0L)
+                IoLINES_LEFT(io) = 0L;
+        }
         break;
     case '%':
-        IoPAGE(GvIOp(PL_defoutgv)) = (SvIV(sv));
+        {
+            IO * const io = GvIO(PL_defoutgv);
+            if (!io)
+                break;
+
+            IoPAGE(io) = (SvIV(sv));
+        }
         break;
     case '|':
         {

--- a/t/io/defout.t
+++ b/t/io/defout.t
@@ -14,7 +14,7 @@ BEGIN {
 
 $|=0;   # test.pl makes it 1, and that conflicts with the below.
 
-plan tests => 16;
+plan tests => 22;
 
 
 my $stdout = *STDOUT;
@@ -47,6 +47,20 @@ $= = 1; pass '$= = 1';
 $- = 1; pass '$- = 1';
 $% = 1; pass '$% = 1';
 $| = 1; pass '$| = 1';
+
+# test a NULLed GV
+my $t = tempfile;
+open FOO, ">", $t or die;
+select(FOO);
+my $io = *FOO{IO};
+*FOO = 0;
+$^ = 1; pass 'empty GV: $^ = 1';
+$~ = 1; pass 'empty GV: $~ = 1';
+$= = 1; pass 'empty GV: $= = 1';
+$- = 1; pass 'empty GV: $- = 1';
+$% = 1; pass 'empty GV: $% = 1';
+$| = 1; pass 'empty GV: $| = 1';
+close $io;
 
 # Switch to STDERR for this test, so we do not lose our test output
 my $stderr = *STDERR;


### PR DESCRIPTION
pp_select() ensures that the GV in PL_defoutgv has an IO object when it the default output is set, but can't prevent that GV being cleared afterwards, resulting in a seg fault when the variable is written.

To prevent this, check PL_defoutgv has an IO object before trying to write to it.

Fixes #20733