### PR TITLE
Expose {optimize,finalize}_optree() as real API functions

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1802,8 +1802,6 @@ Axmd	|OP *	|op_lvalue	|NULLOK OP *o				\
 poX	|OP *	|op_lvalue_flags|NULLOK OP *o				\
 				|I32 type				\
 				|U32 flags
-Apd	|void	|optimize_optree|NN OP *o
-Apd	|void	|finalize_optree|NN OP *o
 : Used in op.c and pp_sys.c
 p	|int	|mode_from_discipline					\
 				|NULLOK const char *s			\
@@ -3900,6 +3898,10 @@ EeiT	|void * |my_memrchr	|NN const char *s			\
 				|const STRLEN len
 # endif /* !defined(HAS_MEMRCHR) */
 #endif /* defined(PERL_CORE) || defined(PERL_EXT) */
+#if defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API)
+Apd	|void	|optimize_optree|NN OP *o
+Apd	|void	|finalize_optree|NN OP *o
+#endif /* defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API) */
 #if defined(PERL_DEBUG_READONLY_COW)
 p	|void	|sv_buf_to_ro	|NN SV *sv
 #endif /* defined(PERL_DEBUG_READONLY_COW) */

--- a/embed.fnc
+++ b/embed.fnc
@@ -1802,7 +1802,8 @@ Axmd	|OP *	|op_lvalue	|NULLOK OP *o				\
 poX	|OP *	|op_lvalue_flags|NULLOK OP *o				\
 				|I32 type				\
 				|U32 flags
-pd	|void	|finalize_optree|NN OP *o
+Apd	|void	|optimize_optree|NN OP *o
+Apd	|void	|finalize_optree|NN OP *o
 : Used in op.c and pp_sys.c
 p	|int	|mode_from_discipline					\
 				|NULLOK const char *s			\
@@ -4585,7 +4586,6 @@ p	|void	|check_hash_fields_and_hekify				\
 				|NULLOK SVOP *key_op			\
 				|int real
 p	|SV *	|op_varname	|NN const OP *o
-pd	|void	|optimize_optree|NN OP *o
 p	|void	|warn_elem_scalar_context				\
 				|NN const OP *o 			\
 				|NN SV *name				\

--- a/embed.h
+++ b/embed.h
@@ -227,7 +227,6 @@
 # define filter_add(a,b)                        Perl_filter_add(aTHX_ a,b)
 # define filter_del(a)                          Perl_filter_del(aTHX_ a)
 # define filter_read(a,b,c)                     Perl_filter_read(aTHX_ a,b,c)
-# define finalize_optree(a)                     Perl_finalize_optree(aTHX_ a)
 # define find_runcv(a)                          Perl_find_runcv(aTHX_ a)
 # define find_rundefsv()                        Perl_find_rundefsv(aTHX)
 # define foldEQ(a,b,c)                          Perl_foldEQ(aTHX_ a,b,c)
@@ -469,7 +468,6 @@
 # define op_scope(a)                            Perl_op_scope(aTHX_ a)
 # define op_sibling_splice                      Perl_op_sibling_splice
 # define op_wrap_finally(a,b)                   Perl_op_wrap_finally(aTHX_ a,b)
-# define optimize_optree(a)                     Perl_optimize_optree(aTHX_ a)
 # define packlist(a,b,c,d,e)                    Perl_packlist(aTHX_ a,b,c,d,e)
 # define pad_add_anon(a,b)                      Perl_pad_add_anon(aTHX_ a,b)
 # define pad_add_name_pv(a,b,c,d)               Perl_pad_add_name_pv(aTHX_ a,b,c,d)
@@ -1965,6 +1963,10 @@
                defined(DEBUGGING) */
 #   endif /* defined(PERL_IN_REGEXEC_C) */
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
+# if defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API)
+#   define finalize_optree(a)                   Perl_finalize_optree(aTHX_ a)
+#   define optimize_optree(a)                   Perl_optimize_optree(aTHX_ a)
+# endif /* defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API) */
 # if !defined(PERL_IMPLICIT_SYS)
 #   define my_pclose(a)                         Perl_my_pclose(aTHX_ a)
 #   define my_popen(a,b)                        Perl_my_popen(aTHX_ a,b)

--- a/embed.h
+++ b/embed.h
@@ -227,6 +227,7 @@
 # define filter_add(a,b)                        Perl_filter_add(aTHX_ a,b)
 # define filter_del(a)                          Perl_filter_del(aTHX_ a)
 # define filter_read(a,b,c)                     Perl_filter_read(aTHX_ a,b,c)
+# define finalize_optree(a)                     Perl_finalize_optree(aTHX_ a)
 # define find_runcv(a)                          Perl_find_runcv(aTHX_ a)
 # define find_rundefsv()                        Perl_find_rundefsv(aTHX)
 # define foldEQ(a,b,c)                          Perl_foldEQ(aTHX_ a,b,c)
@@ -468,6 +469,7 @@
 # define op_scope(a)                            Perl_op_scope(aTHX_ a)
 # define op_sibling_splice                      Perl_op_sibling_splice
 # define op_wrap_finally(a,b)                   Perl_op_wrap_finally(aTHX_ a,b)
+# define optimize_optree(a)                     Perl_optimize_optree(aTHX_ a)
 # define packlist(a,b,c,d,e)                    Perl_packlist(aTHX_ a,b,c,d,e)
 # define pad_add_anon(a,b)                      Perl_pad_add_anon(aTHX_ a,b)
 # define pad_add_name_pv(a,b,c,d)               Perl_pad_add_name_pv(aTHX_ a,b,c,d)
@@ -920,7 +922,6 @@
 #   define dump_all_perl(a)                     Perl_dump_all_perl(aTHX_ a)
 #   define dump_packsubs_perl(a,b)              Perl_dump_packsubs_perl(aTHX_ a,b)
 #   define dump_sub_perl(a,b)                   Perl_dump_sub_perl(aTHX_ a,b)
-#   define finalize_optree(a)                   Perl_finalize_optree(aTHX_ a)
 #   define find_lexical_cv(a)                   Perl_find_lexical_cv(aTHX_ a)
 #   define find_runcv_where(a,b,c)              Perl_find_runcv_where(aTHX_ a,b,c)
 #   define find_script(a,b,c,d)                 Perl_find_script(aTHX_ a,b,c,d)
@@ -1408,7 +1409,6 @@
 #     define no_bareword_allowed(a)             Perl_no_bareword_allowed(aTHX_ a)
 #     define op_prune_chain_head                Perl_op_prune_chain_head
 #     define op_varname(a)                      Perl_op_varname(aTHX_ a)
-#     define optimize_optree(a)                 Perl_optimize_optree(aTHX_ a)
 #     define warn_elem_scalar_context(a,b,c,d)  Perl_warn_elem_scalar_context(aTHX_ a,b,c,d)
 #     if defined(USE_ITHREADS)
 #       define op_relocate_sv(a,b)              Perl_op_relocate_sv(aTHX_ a,b)

--- a/proto.h
+++ b/proto.h
@@ -1127,8 +1127,7 @@ Perl_filter_read(pTHX_ int idx, SV *buf_sv, int maxlen)
         assert(buf_sv)
 
 PERL_CALLCONV void
-Perl_finalize_optree(pTHX_ OP *o)
-        __attribute__visibility__("hidden");
+Perl_finalize_optree(pTHX_ OP *o);
 #define PERL_ARGS_ASSERT_FINALIZE_OPTREE        \
         assert(o)
 
@@ -3263,6 +3262,11 @@ Perl_op_wrap_finally(pTHX_ OP *block, OP *finally)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_OP_WRAP_FINALLY        \
         assert(block); assert(finally)
+
+PERL_CALLCONV void
+Perl_optimize_optree(pTHX_ OP *o);
+#define PERL_ARGS_ASSERT_OPTIMIZE_OPTREE        \
+        assert(o)
 
 PERL_CALLCONV void
 Perl_package(pTHX_ OP *o)
@@ -7477,12 +7481,6 @@ PERL_CALLCONV SV *
 Perl_op_varname(pTHX_ const OP *o)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OP_VARNAME            \
-        assert(o)
-
-PERL_CALLCONV void
-Perl_optimize_optree(pTHX_ OP *o)
-        __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_OPTIMIZE_OPTREE       \
         assert(o)
 
 PERL_CALLCONV void

--- a/proto.h
+++ b/proto.h
@@ -1126,11 +1126,6 @@ Perl_filter_read(pTHX_ int idx, SV *buf_sv, int maxlen)
 #define PERL_ARGS_ASSERT_FILTER_READ            \
         assert(buf_sv)
 
-PERL_CALLCONV void
-Perl_finalize_optree(pTHX_ OP *o);
-#define PERL_ARGS_ASSERT_FINALIZE_OPTREE        \
-        assert(o)
-
 PERL_CALLCONV CV *
 Perl_find_lexical_cv(pTHX_ PADOFFSET off)
         __attribute__visibility__("hidden");
@@ -3262,11 +3257,6 @@ Perl_op_wrap_finally(pTHX_ OP *block, OP *finally)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_OP_WRAP_FINALLY        \
         assert(block); assert(finally)
-
-PERL_CALLCONV void
-Perl_optimize_optree(pTHX_ OP *o);
-#define PERL_ARGS_ASSERT_OPTIMIZE_OPTREE        \
-        assert(o)
 
 PERL_CALLCONV void
 Perl_package(pTHX_ OP *o)
@@ -6143,6 +6133,18 @@ S_my_memrchr(const char *s, const char c, const STRLEN len);
 #   endif /* !defined(HAS_MEMRCHR) */
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_CORE) || defined(PERL_EXT) */
+#if defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API)
+PERL_CALLCONV void
+Perl_finalize_optree(pTHX_ OP *o);
+# define PERL_ARGS_ASSERT_FINALIZE_OPTREE       \
+        assert(o)
+
+PERL_CALLCONV void
+Perl_optimize_optree(pTHX_ OP *o);
+# define PERL_ARGS_ASSERT_OPTIMIZE_OPTREE       \
+        assert(o)
+
+#endif /* defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API) */
 #if defined(PERL_DEBUG_READONLY_COW)
 PERL_CALLCONV void
 Perl_sv_buf_to_ro(pTHX_ SV *sv)


### PR DESCRIPTION
These are required by XS modules which want to create custom LOGOP-shaped optrees, to ensure that both sides of the tree get optimised and finalised.

See also
  https://github.com/Perl/perl5/issues/20743

Fixes #20743 