### PR TITLE
Configure - fix handling of quoted gcc output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -810,6 +810,7 @@ Kragen Sitaker                 <kragen@pobox.com>
 Krishna Sethuraman             <krishna@sgi.com>
 Kriton Kyrimis                 <kyrimis@princeton.edu>
 Kurt D. Starsinic              <kstar@wolfetech.com>
+Kurt Fitzner                   <kurt@va1der.ca>
 Kyriakos Georgiou
 Lajos Veres                    <vlajos@gmail.com>
 Larry Parmelee                 <parmelee@CS.Cornell.EDU>

--- a/Configure
+++ b/Configure
@@ -23778,7 +23778,7 @@ EOF
 for i in \`$cc -v -c tmp.c 2>&1 $postprocess_cc_v\`
 do
 	case "\$i" in
-	-D*) echo "\$i" | $sed 's/^-D//';;
+	-D*) echo "\$i" | $sed 's/^-D//;s/['\''\"]//g';;
 	-A*) $test "$gccversion" && echo "\$i" | $sed 's/^-A//' | $sed 's/\(.*\)(\(.*\))/\1=\2/';;
 	esac
 done


### PR DESCRIPTION
This patch was submitted in GH issue #20606. When gcc output contains quoted elements we fail to handle it properly. This tweaks the sed command to do so.

Fixes #20606.