### PR TITLE
win32/*akefile - delete before rename

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1195,6 +1195,7 @@ endif
 
 ..\config.sh : $(CFGSH_TMPL) config_sh.PL FindExt.pm $(HAVEMINIPERL)
 	$(MINIPERL) -I..\lib config_sh.PL $(CFG_VARS) $(CFGSH_TMPL) > ..\config.sh.tmp
+	if exist ..\config.sh del /f ..\config.sh
 	rename ..\config.sh.tmp config.sh
 
 # This target is for when changes to the main config.sh happen.

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -887,6 +887,7 @@ perlglob$(o)  : perlglob.c
 
 ..\config.sh : $(CFGSH_TMPL) config_sh.PL FindExt.pm $(MINIPERL)
 	$(MINIPERL) -I..\lib config_sh.PL $(CFG_VARS) $(CFGSH_TMPL) > ..\config.sh.tmp
+	if exist ..\config.sh del /f ..\config.sh
 	rename ..\config.sh.tmp config.sh
 
 # This target is for when changes to the main config.sh happen.


### PR DESCRIPTION
All of the other rename commands in win32/Makefile and win32/GNUmakefile are guarded by a del statement. This does the equivalent for the rename command that creates config.sh.

Fixes #20749.