### PR TITLE
embed.pl - the 's', 'S', 'i' and 'I' flags are mutually exclusive

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3949,7 +3949,7 @@ Adp	|I32	|my_pclose	|NULLOK PerlIO *ptr
 Adp	|PerlIO *|my_popen	|NN const char *cmd			\
 				|NN const char *mode
 # if defined(USE_ITHREADS)
-si	|bool	|PerlEnv_putenv |NN char *str
+i	|bool	|PerlEnv_putenv |NN char *str
 # endif /* defined(USE_ITHREADS) */
 #endif /* !defined(PERL_IMPLICIT_SYS) */
 #if defined(PERL_IN_AV_C)

--- a/embed.h
+++ b/embed.h
@@ -1645,7 +1645,7 @@
 #     define padname_dup(a,b)                   Perl_padname_dup(aTHX_ a,b)
 #     define padnamelist_dup(a,b)               Perl_padnamelist_dup(aTHX_ a,b)
 #     if !defined(PERL_IMPLICIT_SYS)
-#       define PerlEnv_putenv(a)                Perl_PerlEnv_putenv(aTHX_ a)
+#       define PerlEnv_putenv(a)                S_PerlEnv_putenv(aTHX_ a)
 #     endif /* !defined(PERL_IMPLICIT_SYS) */
 #   endif /* defined(USE_ITHREADS) */
 #   if defined(USE_LOCALE_COLLATE)

--- a/inline.h
+++ b/inline.h
@@ -287,7 +287,7 @@ S_strip_spaces(pTHX_ const char * orig, STRLEN * const len)
 /* Otherwise this function is implemented as macros in iperlsys.h */
 
 PERL_STATIC_INLINE bool
-Perl_PerlEnv_putenv(pTHX_ char * str)
+S_PerlEnv_putenv(pTHX_ char * str)
 {
     PERL_ARGS_ASSERT_PERLENV_PUTENV;
 

--- a/proto.h
+++ b/proto.h
@@ -6204,13 +6204,6 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode);
 # define PERL_ARGS_ASSERT_MY_POPEN              \
         assert(cmd); assert(mode)
 
-# if defined(USE_ITHREADS)
-STATIC bool
-Perl_PerlEnv_putenv(pTHX_ char *str);
-#   define PERL_ARGS_ASSERT_PERLENV_PUTENV      \
-        assert(str)
-
-# endif /* defined(USE_ITHREADS) */
 #endif /* !defined(PERL_IMPLICIT_SYS) */
 #if defined(PERL_IN_AV_C)
 STATIC MAGIC *
@@ -10011,6 +10004,13 @@ Perl_cop_file_avn(pTHX_ const COP *cop);
 #   define PERL_ARGS_ASSERT_COP_FILE_AVN        \
         assert(cop)
 
+#   if !defined(PERL_IMPLICIT_SYS)
+PERL_STATIC_INLINE bool
+S_PerlEnv_putenv(pTHX_ char *str);
+#     define PERL_ARGS_ASSERT_PERLENV_PUTENV    \
+        assert(str)
+
+#   endif /* !defined(PERL_IMPLICIT_SYS) */
 # endif /* defined(USE_ITHREADS) */
 #endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #if defined(PERL_USE_3ARG_SIGHANDLER)


### PR DESCRIPTION
We had a bug where we processed the first one in the flags definition. Sorting the flags or rearranging them changes the output, which shouldn't happen.