### PR TITLE
warn on array constant redefinition

### DIFF
--- a/op.c
+++ b/op.c
@@ -15306,7 +15306,7 @@ Perl_report_redefined_cv(pTHX_ const SV *name, const CV *old_cv,
 {
     const char *hvname;
     bool is_const = cBOOL(CvCONST(old_cv));
-    SV *old_const_sv = is_const ? cv_const_sv(old_cv) : NULL;
+    SV *old_const_sv = is_const ? cv_const_sv_or_av(old_cv) : NULL;
 
     PERL_ARGS_ASSERT_REPORT_REDEFINED_CV;
 
@@ -15329,14 +15329,20 @@ Perl_report_redefined_cv(pTHX_ const SV *name, const CV *old_cv,
         )
      || (is_const
          && ckWARN_d(WARN_REDEFINE)
-         && (!new_const_svp || sv_cmp(old_const_sv, *new_const_svp))
+         && (!new_const_svp ||
+             !*new_const_svp ||
+             !old_const_sv ||
+             SvTYPE(old_const_sv) == SVt_PVAV ||
+             SvTYPE(*new_const_svp) == SVt_PVAV ||
+             sv_cmp(old_const_sv, *new_const_svp))
         )
-    )
+        ) {
         Perl_warner(aTHX_ packWARN(WARN_REDEFINE),
                           is_const
                             ? "Constant subroutine %" SVf " redefined"
                             : "Subroutine %" SVf " redefined",
                           SVfARG(name));
+    }
 }
 
 /*

--- a/op.c
+++ b/op.c
@@ -10646,7 +10646,9 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
             if (ckWARN(WARN_REDEFINE)
              || (  ckWARN_d(WARN_REDEFINE)
                 && (  !const_sv || SvRV(gv) == const_sv
-                   || sv_cmp(SvRV(gv), const_sv)  ))) {
+                      || SvTYPE(const_sv) == SVt_PVAV
+                      || SvTYPE(SvRV(gv)) == SVt_PVAV
+                      || sv_cmp(SvRV(gv), const_sv)  ))) {
                 assert(cSVOPo);
                 Perl_warner(aTHX_ packWARN(WARN_REDEFINE),
                           "Constant subroutine %" SVf " redefined",

--- a/sv.c
+++ b/sv.c
@@ -3913,7 +3913,7 @@ Perl_gv_setref(pTHX_ SV *const dsv, SV *const ssv)
                     {
                         SV * const new_const_sv =
                             CvCONST((const CV *)sref)
-                                 ? cv_const_sv((const CV *)sref)
+                                 ? cv_const_sv_or_av((const CV *)sref)
                                  : NULL;
                         HV * const stash = GvSTASH((const GV *)dsv);
                         report_redefined_cv(

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -284,7 +284,6 @@ my @s = @f["]", "a"];
 @h[glob ""];
 @h[readline ""];
 @h[m ""];
-use constant phoo => 1..3;
 @h[+phoo]; # rv2av
 @h[sort foo];
 @h[reverse foo];
@@ -1018,6 +1017,13 @@ sub fred () { 1 }
 *fred = sub () { 2 };
 EXPECT
 Constant subroutine main::fred redefined at - line 3.
+########
+# op.c github #20742
+use constant fred => 1, 2;
+use constant fred => 2, 3;
+EXPECT
+OPTIONS regex
+Constant subroutine main::fred redefined at .*lib/constant\.pm line \d+
 ########
 # op.c
 use feature "lexical_subs", "state";

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -1025,6 +1025,13 @@ EXPECT
 OPTIONS regex
 Constant subroutine main::fred redefined at .*lib/constant\.pm line \d+
 ########
+# op.c related to github #20742
+# produced an assertion failure
+use constant x => 1, 2;
+sub x () { 1 }
+EXPECT
+Constant subroutine x redefined at - line 4.
+########
 # op.c
 use feature "lexical_subs", "state";
 my sub fred () { 1 }


### PR DESCRIPTION
Also, prevent a crash when redefining a list `constant` defined name with a normal sub.

Fixes #20742 