### PR TITLE
allow AUTOLOAD for the INC method of objects in @INC

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -6851,6 +6851,9 @@ Optional state for the subroutine.  The state is passed in as C<$_[1]>.
 
 =back
 
+C<AUTOLOAD> cannot be used to resolve the C<INCDIR> method, C<INC> is
+checked first, and C<AUTOLOAD> would resolve that.
+
 If an empty list, L<C<undef>|/undef EXPR>, or nothing that matches the
 first 3 values above is returned, then L<C<require>|/require VERSION>
 looks at the remaining elements of L<C<@INC>|perlvar/@INC>.

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4338,10 +4338,11 @@ S_require_file(pTHX_ SV *sv)
                          * call the method.
                          */
                         HV *pkg = SvSTASH(SvRV(loader));
-                        GV * gv = gv_fetchmethod_pvn_flags(pkg, "INC", 3, 0);
+                        GV * gv = gv_fetchmethod_pvn_flags(pkg, "INC", 3, GV_AUTOLOAD);
                         if (gv && isGV(gv)) {
                             method = "INC";
                         } else {
+                            /* no point to autoload here, it would have been found above */
                             gv = gv_fetchmethod_pvn_flags(pkg, "INCDIR", 6, 0);
                             if (gv && isGV(gv)) {
                                 method = "INCDIR";


### PR DESCRIPTION
This matches the behaviour in 5.36.

This does not allow AUTOLOAD for INCDIR, since if there is an AUTOLOAD the check for INC would have already succeeded.

Fixes #20665