### PR TITLE
perl.h and regcomp_internal.h comment and struct fixups.

### DIFF
--- a/pad.h
+++ b/pad.h
@@ -161,8 +161,9 @@ typedef enum {
 
 /* Note: the following three macros are actually defined in scope.h, but
  * they are documented here for completeness, since they directly or
- * indirectly affect pads.
+ * indirectly affect pads. */
 
+/*
 =for apidoc m|void|SAVEPADSV	|PADOFFSET po
 Save a pad slot (used to restore after an iteration)
 

--- a/perl.h
+++ b/perl.h
@@ -457,7 +457,9 @@ Now a no-op.
  * marking unused variables (they need e.g. a #pragma) and therefore
  * cpp macros like PERL_UNUSED_DECL cannot work for this purpose, even
  * if it were PERL_UNUSED_DECL(x), which it cannot be (see above).
+*/
 
+/*
 =for apidoc_section $directives
 =for apidoc AmnU||PERL_UNUSED_DECL
 Tells the compiler that the parameter in the function prototype just before it
@@ -476,7 +478,7 @@ Example usage:
 =back
 
 =cut
- */
+*/
 
 #ifndef PERL_UNUSED_DECL
 #  define PERL_UNUSED_DECL __attribute__unused__
@@ -486,7 +488,8 @@ Example usage:
  * for silencing unused variables that are actually used most of the time,
  * but we cannot quite get rid of, such as "ax" in PPCODE+noargs xsubs,
  * or variables/arguments that are used only in certain configurations.
-
+ */
+/*
 =for apidoc Am;||PERL_UNUSED_ARG|void x
 This is used to suppress compiler warnings that a parameter to a function is
 not used.  This situation can arise, for example, when a parameter is needed
@@ -504,7 +507,7 @@ This situation can arise, for example, when a C preprocessor conditional
 compilation causes it be used just some times.
 
 =cut
- */
+*/
 #ifndef PERL_UNUSED_ARG
 #  define PERL_UNUSED_ARG(x) ((void)sizeof(x))
 #endif
@@ -1394,7 +1397,9 @@ EXTERN_C int usleep(unsigned int);
 
 /* Macros for correct constant construction.  These are in C99 <stdint.h>
  * (so they will not be available in strict C89 mode), but they are nice, so
- * let's define them if necessary.
+ * let's define them if necessary. */
+
+/*
 =for apidoc_section $integer
 =for apidoc    Am|I16|INT16_C|number
 =for apidoc_item |I32|INT32_C|number

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -162,15 +162,6 @@ struct RExC_state_t {
     AV          *paren_name_list;       /* idx -> name */
     SV          *mysv1;
     SV          *mysv2;
-
-#define RExC_lastparse  (pRExC_state->lastparse)
-#define RExC_lastnum    (pRExC_state->lastnum)
-#define RExC_paren_name_list    (pRExC_state->paren_name_list)
-#define RExC_study_chunk_recursed_count    (pRExC_state->study_chunk_recursed_count)
-#define RExC_mysv       (pRExC_state->mysv1)
-#define RExC_mysv1      (pRExC_state->mysv1)
-#define RExC_mysv2      (pRExC_state->mysv2)
-
 #endif
     bool        seen_d_op;
     bool        strict;
@@ -180,6 +171,16 @@ struct RExC_state_t {
     bool        sWARN_EXPERIMENTAL__VLB;
     bool        sWARN_EXPERIMENTAL__REGEX_SETS;
 };
+
+#ifdef DEBUGGING
+#define RExC_lastparse  (pRExC_state->lastparse)
+#define RExC_lastnum    (pRExC_state->lastnum)
+#define RExC_paren_name_list    (pRExC_state->paren_name_list)
+#define RExC_study_chunk_recursed_count    (pRExC_state->study_chunk_recursed_count)
+#define RExC_mysv       (pRExC_state->mysv1)
+#define RExC_mysv1      (pRExC_state->mysv1)
+#define RExC_mysv2      (pRExC_state->mysv2)
+#endif
 
 #define RExC_flags      (pRExC_state->flags)
 #define RExC_pm_flags   (pRExC_state->pm_flags)


### PR DESCRIPTION
These are two minor cleanups of comments and struct definitions in regcomp_internal.h and perl.h

No functionality is changed.