### PR TITLE
.gitattributes: pin *.fnc files as plaintext

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,3 +22,4 @@ warnings.h linguist-generated
 *.pm linguist-language=Perl
 *.t linguist-language=Perl
 *.h linguist-language=C
+*.fnc linguist-language=Text


### PR DESCRIPTION
Otherwise *.fnc file are being displayed as PLSQL in GitHub Linguist stats of which there's 0.5% in total repository-wise.

![image](https://user-images.githubusercontent.com/68062695/217516064-a920a724-5a3b-4007-8a06-78f82851c545.png)

### The 4 .fnc files wrongly considered to contain PLSQL code

![image](https://user-images.githubusercontent.com/68062695/217516173-c9ee37fb-8973-4839-8e4e-1a5ca476cf11.png)

