### PR TITLE
perl.h: Make sure PERL_IMPLICIT_CONTEXT doesn't come back

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -79,13 +79,17 @@ is used in functions that take a thread context initial parameter.
 #endif
 
 /* PERL_IMPLICIT_CONTEXT is a legacy synonym for MULTIPLICITY */
-#ifdef MULTIPLICITY
-#  ifndef PERL_IMPLICIT_CONTEXT
-#    define PERL_IMPLICIT_CONTEXT
-#  endif
+#if defined(MULTIPLICITY)               \
+ && ! defined(PERL_CORE)                \
+ && ! defined(PERL_IMPLICIT_CONTEXT)
+#  define PERL_IMPLICIT_CONTEXT
 #endif
 #if defined(PERL_IMPLICIT_CONTEXT) && !defined(MULTIPLICITY)
 #  define MULTIPLICITY
+#endif
+#if defined(PERL_CORE) && defined(PERL_IMPLICIT_CONTEXT)
+#  pragma message("PERL_IMPLICIT_CONTEXT was removed from core perl. It does not do anything. Undeffing it for compilation")
+#  undef PERL_IMPLICIT_CONTEXT
 #endif
 
 /* undef WIN32 when building on Cygwin (for libwin32) - gph */


### PR DESCRIPTION
This is an obsolete name, retained for back compat with cpan.  Make sure the core doesn't have it defined.