### PR TITLE
Fix pv_escape() param discrepancy embed.fnc, source

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3167,7 +3167,7 @@ Apd	|char * |pv_display	|NN SV *dsv				\
 Apd	|char * |pv_escape	|NULLOK SV *dsv 			\
 				|NN char const * const str		\
 				|const STRLEN count			\
-				|const STRLEN max			\
+				|STRLEN max				\
 				|NULLOK STRLEN * const escaped		\
 				|U32 flags
 Apd	|char * |pv_pretty	|NN SV *dsv				\

--- a/proto.h
+++ b/proto.h
@@ -3561,7 +3561,7 @@ Perl_pv_display(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pv
         assert(dsv); assert(pv)
 
 PERL_CALLCONV char *
-Perl_pv_escape(pTHX_ SV *dsv, char const * const str, const STRLEN count, const STRLEN max, STRLEN * const escaped, U32 flags);
+Perl_pv_escape(pTHX_ SV *dsv, char const * const str, const STRLEN count, STRLEN max, STRLEN * const escaped, U32 flags);
 #define PERL_ARGS_ASSERT_PV_ESCAPE              \
         assert(str)
 


### PR DESCRIPTION
embed.fnc declared a STRLEN parameter as const, but it isn't