### PR TITLE
 snprintf() calls need to have proper radix

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -2283,7 +2283,7 @@ my_snprintf()
 
 #define PERL_SNPRINTF_CHECK(len, max, api) STMT_START { if ((max) > 0 && (Size_t)len > (max)) Perl_croak_nocontext("panic: %s buffer overflow", STRINGIFY(api)); } STMT_END
 
-#ifdef USE_QUADMATH
+#if defined(USE_LOCALE_NUMERIC) || defined(USE_QUADMATH)
 #  define my_snprintf Perl_my_snprintf
 #  define PERL_MY_SNPRINTF_GUARDED
 #elif defined(HAS_SNPRINTF) && defined(HAS_C99_VARIADIC_MACROS) && !(defined(DEBUGGING) && !defined(PERL_USE_GCC_BRACE_GROUPS)) && !defined(PERL_GCC_PEDANTIC)
@@ -2300,9 +2300,16 @@ my_snprintf()
 
 /* There is no quadmath_vsnprintf, and therefore my_vsnprintf()
  * dies if called under USE_QUADMATH. */
-#if defined(HAS_VSNPRINTF) && defined(HAS_C99_VARIADIC_MACROS) && !(defined(DEBUGGING) && !defined(PERL_USE_GCC_BRACE_GROUPS)) && !defined(PERL_GCC_PEDANTIC)
+#if !  defined(USE_LOCALE_NUMERIC)                                  \
+ &&    defined(HAS_VSNPRINTF)                                       \
+ &&    defined(HAS_C99_VARIADIC_MACROS)                             \
+ && ! (defined(DEBUGGING) && ! defined(PERL_USE_GCC_BRACE_GROUPS))  \
+ && !  defined(PERL_GCC_PEDANTIC)
 #  ifdef PERL_USE_GCC_BRACE_GROUPS
-#      define my_vsnprintf(buffer, max, ...) ({ int len = vsnprintf(buffer, max, __VA_ARGS__); PERL_SNPRINTF_CHECK(len, max, vsnprintf); len; })
+#      define my_vsnprintf(buffer, max, ...)                        \
+            ({ int len = vsnprintf(buffer, max, __VA_ARGS__);       \
+             PERL_SNPRINTF_CHECK(len, max, vsnprintf);              \
+             len; })
 #      define PERL_MY_VSNPRINTF_GUARDED
 #  else
 #    define my_vsnprintf(buffer, max, ...) vsnprintf(buffer, max, __VA_ARGS__)

--- a/perlio.c
+++ b/perlio.c
@@ -369,7 +369,10 @@ PerlIO_debug(const char *fmt, ...)
            should be, otherwise the system isn't likely to support quadmath.
            Nothing should be calling PerlIO_debug() with floating point anyway.
         */
+        DECLARATION_FOR_LC_NUMERIC_MANIPULATION;
+        STORE_LC_NUMERIC_SET_TO_NEEDED();
         const STRLEN len2 = vsnprintf(buffer + len1, sizeof(buffer) - len1, fmt, ap);
+        RESTORE_LC_NUMERIC();
 #    else
         STATIC_ASSERT_STMT(0);
 #    endif

--- a/util.c
+++ b/util.c
@@ -5284,33 +5284,37 @@ Perl_my_vsnprintf(char *buffer, const Size_t len, const char *format, va_list ap
     return 0;
 #else
     int retval;
-#ifdef NEED_VA_COPY
+
+#  ifdef NEED_VA_COPY
     va_list apc;
 
     PERL_ARGS_ASSERT_MY_VSNPRINTF;
     Perl_va_copy(ap, apc);
-# ifdef HAS_VSNPRINTF
+#    ifdef HAS_VSNPRINTF
     retval = vsnprintf(buffer, len, format, apc);
-# else
+#    else
+
     PERL_UNUSED_ARG(len);
     retval = vsprintf(buffer, format, apc);
-# endif
+#    endif
+
     va_end(apc);
-#else
-# ifdef HAS_VSNPRINTF
+#  else
+#    ifdef HAS_VSNPRINTF
     retval = vsnprintf(buffer, len, format, ap);
-# else
+#    else
     PERL_UNUSED_ARG(len);
     retval = vsprintf(buffer, format, ap);
-# endif
-#endif /* #ifdef NEED_VA_COPY */
+#    endif
+#  endif /* #ifdef NEED_VA_COPY */
+
     /* vsprintf() shows failure with < 0 */
     if (retval < 0
-#ifdef HAS_VSNPRINTF
+#  ifdef HAS_VSNPRINTF
     /* vsnprintf() shows failure with >= len */
         ||
         (len > 0 && (Size_t)retval >= len)
-#endif
+#  endif
     )
         Perl_croak_nocontext("panic: my_vsnprintf buffer overflow");
     return retval;


### PR DESCRIPTION


Calls to libc snprintf() were neglected to be changed when perl was
fixed to change the radix character to the proper one based on whether
or not 'use locale' is in effect.  Perl-level code is unaffected, but
core and XS code is.

This commit changes to wrap snprintf() calls with the macros designed
for the purpose, long used for similar situations elsewhere in the code.

Doing this requires the thread context.  I achieved this in a few places
by a dTHX, instead of assuming a caller would have the context already
available, and adding a pTHX_ parameter.  I tried doing it the other
way, and got a few breakages in our test suite.  Formatting already
requires significant CPU time, so this addition should just be in the
noise

This bug was found by new tests that will be added in a future commit.