### PR TITLE
Prefer SvREFCNT_dec() to calling sv_free()

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -6584,8 +6584,7 @@ and free the body itself.  The SV's head is I<not> freed, although
 its type is set to all 1's so that it won't inadvertently be assumed
 to be live during global destruction etc.
 This function should only be called when C<REFCNT> is zero.  Most of the time
-you'll want to call C<sv_free()> (or its macro wrapper C<SvREFCNT_dec>)
-instead.
+you'll want to call C<SvREFCNT_dec> instead.
 
 =cut
 */

--- a/toke.c
+++ b/toke.c
@@ -4814,7 +4814,7 @@ Perl_filter_del(pTHX_ filter_t funcp)
     /* if filter is on top of stack (usual case) just pop it off */
     datasv = FILTER_DATA(AvFILLp(PL_rsfp_filters));
     if (IoANY(datasv) == FPTR2DPTR(void *, funcp)) {
-        sv_free(av_pop(PL_rsfp_filters));
+        SvREFCNT_dec(av_pop(PL_rsfp_filters));
 
         return;
     }
@@ -6003,7 +6003,8 @@ yyl_colon(pTHX_ char *s)
                 if (!d) {
                     if (attrs)
                         op_free(attrs);
-                    sv_free(sv);
+                    ASSUME(sv && SvREFCNT(sv) == 1);
+                    SvREFCNT_dec(sv);
                     Perl_croak(aTHX_ "Unterminated attribute parameter in attribute list");
                 }
                 COPLINE_SET_FROM_MULTI_END;
@@ -8885,7 +8886,8 @@ yyl_keylookup(pTHX_ char *s, GV *gv)
                                   SVt_PVCV);
                 c.off = 0;
                 if (!c.gv) {
-                    sv_free(c.sv);
+                    ASSUME(c.sv && SvREFCNT(c.sv) == 1);
+                    SvREFCNT_dec(c.sv);
                     c.sv = NULL;
                     return yyl_just_a_word(aTHX_ s, len, 0, c);
                 }
@@ -9028,7 +9030,7 @@ yyl_try(pTHX_ char *s)
                     ++svp;
                     sv_catpvs(PL_linestr, ";");
                 }
-                sv_free(MUTABLE_SV(PL_preambleav));
+                SvREFCNT_dec(MUTABLE_SV(PL_preambleav));
                 PL_preambleav = NULL;
             }
             if (PL_minus_E)
@@ -11739,7 +11741,8 @@ Perl_scan_str(pTHX_ char *start, int keep_bracketed_quoted, int keep_delims, int
         COPLINE_INC_WITH_HERELINES;
         PL_bufptr = PL_bufend;
         if (!lex_next_chunk(0)) {
-            sv_free(sv);
+            ASSUME(sv);
+            SvREFCNT_dec(sv);
             CopLINE_set(PL_curcop, (line_t)PL_multi_start);
             return NULL;
         }


### PR DESCRIPTION
Nowadays, `Perl_sv_free()`  just does `SvREFCNT_dec()`, which is a macro wrapper for the simple inline
function `Perl_SvREFCNT_dec()`.

The first commit in this PR updates the apidoc for `Perl_sv_free` to reflect the reality that `SvREFCNT_dec`
is no longer a wrapper for `Perl_sv_free` and is probably now the preferred option.

The second commit replaces a few uses of `sv_free()` with `SvREFCNT_dec` in toke.c. Some `ASSUME()`
statements have been used to help compilers strip out some unnecessary checks in `Perl_SvREFCNT_dec`.
There may be some scope to improve some of the `ASSUMES()`.