### PR TITLE
cflags.SH - add -Wno-use-after-free on gcc 12/13

### DIFF
--- a/cflags.SH
+++ b/cflags.SH
@@ -379,6 +379,19 @@ esac
 ;;
 esac
 
+# gcc version 12 and 13 are overly aggressive with use-after-free warnings
+# and have false positives on code that shouldn't warn, and they haven't
+# sorted it out yet. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108115
+case "$gccversion" in
+"1"[23]*)
+    for f in -Wno-use-after-free
+    do
+        echo "cflags.SH: Adding $f because of false positives in gccversion '$gccversion'"
+        warn="$warn $f"
+    done
+;;
+esac
+
 echo "cflags.SH: cc       = $cc"
 echo "cflags.SH: ccflags  = $ccflags"
 echo "cflags.SH: stdflags = $stdflags"


### PR DESCRIPTION
This works around an overly eager/buggy use-after-free warning detection in gcc 12/13, which gets upset if we copy a pointer into a UV and then realloc the pointer and then use the UV value for diagnostics. Since the copied value is no longer a pointer gcc should not warn, as we are not "using" the pointer, just printing it out as a number. The gcc folks have been informed. See:

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108115

Fixes #20601.