### PR TITLE
S_do_chomp: remove unused svrecode SV

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -738,7 +738,6 @@ S_do_chomp(pTHX_ SV *retval, SV *sv, bool chomping)
     if (chomping) {
         if (s && len) {
             char *temp_buffer = NULL;
-            SV *svrecode = NULL;
             s += --len;
             if (RsPARA(PL_rs)) {
                 if (*s != '\n')
@@ -771,7 +770,7 @@ S_do_chomp(pTHX_ SV *retval, SV *sv, bool chomping)
                                is the buffer inside PL_rs, so don't free it.
                              */
                             assert (temp_buffer == rsptr);
-                            goto nope_free_sv;
+                            goto nope_free_nothing;
                         }
                         rsptr = temp_buffer;
                     }
@@ -804,8 +803,6 @@ S_do_chomp(pTHX_ SV *retval, SV *sv, bool chomping)
 
             nope_free_all:
             Safefree(temp_buffer);
-            nope_free_sv:
-            SvREFCNT_dec(svrecode);
             nope_free_nothing: ;
         }
     } else {


### PR DESCRIPTION
Some compilers might well be able to optimize this out, but might as well take it out completely.