### PR TITLE
Perl_leave_adjust_stacks: don't make mortal copies of SvIMMORTAL SVs

### DIFF
--- a/pp_hot.c
+++ b/pp_hot.c
@@ -5041,6 +5041,13 @@ Perl_leave_adjust_stacks(pTHX_ SV **from_sp, SV **to_sp, U8 gimme, int pass)
                     }
                 }
             }
+            else if (SvIMMORTAL(sv)){
+                /* Since SvIMMORTALs are never freed, even when their
+                 * refcount drops to zero, there's no benefit in
+                 * creating a mortal copy.
+                 */
+                *++to_sp = sv;
+            }
             else {
                 /* Make a mortal copy of the SV.
                  * The following code is the equivalent of sv_mortalcopy()


### PR DESCRIPTION
SvIMMORTAL SVs cannot be prematurely freed and so there is no need
to create a mortal copy of them. They also will not leak, so there
is no need to add the SV* to the temp stack.

This was observed while looking at https://github.com/Perl/perl5/issues/7579,
where every scope exit from the regex block in `$​::b2 = grep {/^50$/} @​​::array`
currently involves creating a mortal copy of &PL_sv_no. With this PR, that
snippet doesn't create any such mortals and therefore has better performance.

Note: I'm only 95% sure about this one, so it needs careful review!