### PR TITLE
Must call Perl_croak() on the proto_perl, not the target perl, when failing during sv_inc()

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -14556,7 +14556,7 @@ S_sv_dup_common(pTHX_ const SV *const ssv, CLONE_PARAMS *const param)
 
             switch (sv_type) {
             default:
-                Perl_croak(aTHX_ "Bizarre SvTYPE [%" IVdf "]", (IV)SvTYPE(ssv));
+                Perl_croak(param->proto_perl, "Bizarre SvTYPE [%" IVdf "]", (IV)SvTYPE(ssv));
                 NOT_REACHED; /* NOTREACHED */
                 break;
 


### PR DESCRIPTION
Found while investigating #20803.

This doesn't fix the original issue, but fixing it allows the true problem to become much more apparent.