### PR TITLE
sv.c: fix compilation with g++ <= 7

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -1084,6 +1084,7 @@ Perl_sv_upgrade(pTHX_ SV *const sv, svtype new_type)
             *((XPVOBJ*) SvANY(sv)) = (XPVOBJ) {
                 .xmg_stash = NULL, .xmg_u = {.xmg_magic = NULL},
                 .xobject_maxfield = -1,
+                .xobject_iter_sv_at = 0,
                 .xobject_fields = NULL,
             };
             break;


### PR DESCRIPTION
This compiler predates the addition of designated initializers to the C++ standard, so it's not surprising its implementation isn't fully compliant.

Omitting a field in a designated initializer list causes the following error:
```
sv.c: In function ‘void Perl_sv_upgrade(SV*, svtype)’:
sv.c:1088:13: sorry, unimplemented: non-trivial designated initializers not supported
```