### PR TITLE
Configure: don't probe for the malloc()/free() return type

### DIFF
--- a/Configure
+++ b/Configure
@@ -7917,46 +7917,20 @@ esac
 
 : compute the return types of malloc and free
 echo " "
-$cat >malloc.c <<END
-#$i_malloc I_MALLOC
-#$i_stdlib I_STDLIB
-#include <stdio.h>
-#include <sys/types.h>
-#ifdef I_MALLOC
-#include <malloc.h>
-#endif
-#ifdef I_STDLIB
-#include <stdlib.h>
-#endif
-#ifdef TRY_MALLOC
-void *malloc(size_t);
-#endif
-#ifdef TRY_FREE
-void free(void *);
-#endif
-END
 case "$malloctype" in
 '')
-	if $cc $ccflags -c -DTRY_MALLOC malloc.c >/dev/null 2>&1; then
-		malloctype='void *'
-	else
-		malloctype='char *'
-	fi
+	malloctype='void *'
 	;;
 esac
 echo "Your system wants malloc to return '$malloctype', it would seem." >&4
 
 case "$freetype" in
 '')
-	if $cc $ccflags -c -DTRY_FREE malloc.c >/dev/null 2>&1; then
-		freetype='void'
-	else
-		freetype='int'
-	fi
+	freetype='void'
 	;;
 esac
 echo "Your system uses $freetype free(), it would seem." >&4
-$rm -f malloc.[co]
+
 : determine where site specific architecture-dependent libraries go.
 : sitelib  default is /usr/local/lib/perl5/site_perl/$version
 : sitearch default is /usr/local/lib/perl5/site_perl/$version/$archname


### PR DESCRIPTION
We require a C99 compiler, or in the case that led to this commit, a C++ compiler, and for those the malloc() and free() return types are well defined.

This probe broke on Solaris when building with g++.

Unlike glibc, the libc headers on Solaris, when building using a C++ compiler, define the stdlib.h functions within the std:: namespace, then imports those names into the top level namespace with 'using std::malloc'.

This conflicts with the declarations used in the probe, causing the probe to fail to build, despite malloc() actually returning a void *.

Since these two functions have well defined return types according to the standard, assume their return values match.

Configure can still be invoked with different definitions for malloctype and freetype, or hints can override them, so someone on a non-standard system can at least get past this if they really need to (such a system will likely not build perl anyway.)