### PR TITLE
Tidy sv_dup() wrapper macros

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -3525,6 +3525,13 @@ Perl_padname_refcnt_inc(PADNAME *pn)
     return pn;
 }
 
+PERL_STATIC_INLINE PADNAMELIST *
+Perl_padnamelist_refcnt_inc(PADNAMELIST *pnl)
+{
+    PadnamelistREFCNT(pnl)++;
+    return pnl;
+}
+
 /* copy a string to a safe spot */
 
 /*

--- a/pad.c
+++ b/pad.c
@@ -2504,9 +2504,7 @@ Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
     PadlistMAX(dstpad) = max;
     Newx(PadlistARRAY(dstpad), max + 1, PAD *);
 
-    PadlistARRAY(dstpad)[0] = (PAD *)
-            padnamelist_dup(PadlistNAMES(srcpad), param);
-    PadnamelistREFCNT(PadlistNAMES(dstpad))++;
+    PadlistARRAY(dstpad)[0] = (PAD *)padnamelist_dup_inc(PadlistNAMES(srcpad), param);
     if (cloneall) {
         PADOFFSET depth;
         for (depth = 1; depth <= max; ++depth)
@@ -2740,8 +2738,7 @@ Perl_padnamelist_dup(pTHX_ PADNAMELIST *srcpad, CLONE_PARAMS *param)
     for (; max >= 0; max--)
       if (PadnamelistARRAY(srcpad)[max]) {
         PadnamelistARRAY(dstpad)[max] =
-            padname_dup(PadnamelistARRAY(srcpad)[max], param);
-        PadnameREFCNT_inc(PadnamelistARRAY(dstpad)[max]);
+            padname_dup_inc(PadnamelistARRAY(srcpad)[max], param);
       }
 
     return dstpad;

--- a/pad.c
+++ b/pad.c
@@ -2477,8 +2477,6 @@ Perl_pad_push(pTHX_ PADLIST *padlist, int depth)
 
 #if defined(USE_ITHREADS)
 
-#  define av_dup_inc(s,t)	MUTABLE_AV(sv_dup_inc((const SV *)s,t))
-
 /*
 =for apidoc padlist_dup
 

--- a/pad.h
+++ b/pad.h
@@ -330,6 +330,7 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PadnamelistMAX(pnl)		(pnl)->xpadnl_fill
 #define PadnamelistMAXNAMED(pnl)	(pnl)->xpadnl_max_named
 #define PadnamelistREFCNT(pnl)		(pnl)->xpadnl_refcnt
+#define PadnamelistREFCNT_inc(pnl)      Perl_padnamelist_refcnt_inc(pnl)
 #define PadnamelistREFCNT_dec(pnl)	Perl_padnamelist_free(aTHX_ pnl)
 
 #define PadARRAY(pad)		AvARRAY(pad)
@@ -385,6 +386,11 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #  define PADNAMEt_LVALUE       PADNAMEf_LVALUE
 #  define PADNAMEt_TYPED        PADNAMEf_TYPED
 #  define PADNAMEt_OUR          PADNAMEf_OUR
+#endif
+
+#ifdef USE_ITHREADS
+#  define padnamelist_dup_inc(pnl,param)  PadnamelistREFCNT_inc(padnamelist_dup(pnl,param))
+#  define padname_dup_inc(pn,param)       PadnameREFCNT_inc(padname_dup(pn,param))
 #endif
 
 #ifdef DEBUGGING

--- a/regcomp.c
+++ b/regcomp.c
@@ -13366,8 +13366,6 @@ Perl_regfree_internal(pTHX_ REGEXP * const rx)
     Safefree(ri);
 }
 
-#define av_dup_inc(s, t)	MUTABLE_AV(sv_dup_inc((const SV *)s, t))
-#define hv_dup_inc(s, t)	MUTABLE_HV(sv_dup_inc((const SV *)s, t))
 #define SAVEPVN(p, n)	((p) ? savepvn(p, n) : NULL)
 
 /*

--- a/sv.c
+++ b/sv.c
@@ -13781,21 +13781,6 @@ ptr_table_* functions.
 #endif
 
 
-/* Certain cases in Perl_ss_dup have been merged, by relying on the fact
-   that currently av_dup, gv_dup and hv_dup are the same as sv_dup.
-   If this changes, please unmerge ss_dup.
-   Likewise, sv_dup_inc_multiple() relies on this fact.  */
-#define sv_dup_inc_NN(s,t)	SvREFCNT_inc_NN(sv_dup_inc(s,t))
-#define av_dup(s,t)	MUTABLE_AV(sv_dup((const SV *)s,t))
-#define av_dup_inc(s,t)	MUTABLE_AV(sv_dup_inc((const SV *)s,t))
-#define hv_dup(s,t)	MUTABLE_HV(sv_dup((const SV *)s,t))
-#define hv_dup_inc(s,t)	MUTABLE_HV(sv_dup_inc((const SV *)s,t))
-#define cv_dup(s,t)	MUTABLE_CV(sv_dup((const SV *)s,t))
-#define cv_dup_inc(s,t)	MUTABLE_CV(sv_dup_inc((const SV *)s,t))
-#define io_dup(s,t)	MUTABLE_IO(sv_dup((const SV *)s,t))
-#define io_dup_inc(s,t)	MUTABLE_IO(sv_dup_inc((const SV *)s,t))
-#define gv_dup(s,t)	MUTABLE_GV(sv_dup((const SV *)s,t))
-#define gv_dup_inc(s,t)	MUTABLE_GV(sv_dup_inc((const SV *)s,t))
 #define SAVEPV(p)	((p) ? savepv(p) : NULL)
 #define SAVEPVN(p,n)	((p) ? savepvn(p,n) : NULL)
 

--- a/sv.h
+++ b/sv.h
@@ -2672,6 +2672,24 @@ Create a new IO, setting the reference count to 1.
                     - STRUCT_OFFSET(XPVNV, xnv_u.xnv_nv));  \
     } STMT_END
 
+#if defined(PERL_CORE) && defined(USE_ITHREADS)
+/* Certain cases in Perl_ss_dup have been merged, by relying on the fact
+   that currently av_dup, gv_dup and hv_dup are the same as sv_dup.
+   If this changes, please unmerge ss_dup.
+   Likewise, sv_dup_inc_multiple() relies on this fact.  */
+#  define sv_dup_inc_NN(s,t)	SvREFCNT_inc_NN(sv_dup_inc(s,t))
+#  define av_dup(s,t)	MUTABLE_AV(sv_dup((const SV *)s,t))
+#  define av_dup_inc(s,t)	MUTABLE_AV(sv_dup_inc((const SV *)s,t))
+#  define hv_dup(s,t)	MUTABLE_HV(sv_dup((const SV *)s,t))
+#  define hv_dup_inc(s,t)	MUTABLE_HV(sv_dup_inc((const SV *)s,t))
+#  define cv_dup(s,t)	MUTABLE_CV(sv_dup((const SV *)s,t))
+#  define cv_dup_inc(s,t)	MUTABLE_CV(sv_dup_inc((const SV *)s,t))
+#  define io_dup(s,t)	MUTABLE_IO(sv_dup((const SV *)s,t))
+#  define io_dup_inc(s,t)	MUTABLE_IO(sv_dup_inc((const SV *)s,t))
+#  define gv_dup(s,t)	MUTABLE_GV(sv_dup((const SV *)s,t))
+#  define gv_dup_inc(s,t)	MUTABLE_GV(sv_dup_inc((const SV *)s,t))
+#endif
+
 /*
  * ex: set ts=8 sts=4 sw=4 et:
  */


### PR DESCRIPTION
Also adds some padname-related macros with the _inc behaviour, because I'll need them in the upcoming bugfix for feature-class and threads (#20807)