### PR TITLE
re-work miniperl build on Win32

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6477,6 +6477,7 @@ win32/perlhost.h			Perl "host" implementation
 win32/perllib.c				Win32 port
 win32/pod.mak				Win32 port
 win32/runperl.c				Win32 port
+win32/set_depend_modtime.pl		Win32: update target modtime to match deps
 win32/vdir.h				Perl "host" virtual directory manager for Win32
 win32/vmem.h				Perl "host" memory manager for Win32
 win32/win32.c				Win32 port

--- a/autodoc.pl
+++ b/autodoc.pl
@@ -69,6 +69,12 @@ my %extra_input_pods = ( 'dist/ExtUtils-ParseXS/lib/perlxs.pod' => 1 );
 use strict;
 use warnings;
 
+my $config_h = 'config.h';
+if (@ARGV >= 2 && $ARGV[0] eq "-c") {
+    shift;
+    $config_h = shift;
+}
+
 my $nroff_min_indent = 4;   # for non-heading lines
 # 80 column terminal - 2 for pager adding 2 columns;
 my $max_width = 80 - 2 - $nroff_min_indent;
@@ -706,8 +712,6 @@ sub parse_config_h {
     use re '/aa';   # Everthing is ASCII in this file
 
     # Process config.h
-    my $config_h = 'config.h';
-    $config_h = 'win32/config.h' unless -e $config_h;
     die "Can't find $config_h" unless -e $config_h;
     open my $fh, '<', $config_h or die "Can't open $config_h: $!";
     while (<$fh>) {

--- a/lib/ExtUtils/t/Embed.t
+++ b/lib/ExtUtils/t/Embed.t
@@ -89,6 +89,8 @@ if ($^O eq 'VMS') {
    if ($^O eq 'MSWin32') {
     $inc = File::Spec->catdir($inc,'win32');
     push(@cmd,"-I$inc");
+    my $full = File::Spec->catdir($inc,'full');
+    push(@cmd,"-I$full");
     $inc = File::Spec->catdir($inc,'include');
     push(@cmd,"-I$inc");
     if ($cc eq 'cl') {

--- a/makedef.pl
+++ b/makedef.pl
@@ -38,7 +38,6 @@ use warnings;
 my $fold;
 my %ARGS;
 my %define;
-
 BEGIN {
     %ARGS = (CCTYPE => 'MSVC', TARG_DIR => '');
 
@@ -52,7 +51,7 @@ BEGIN {
 	my $flag = shift;
 	if ($flag =~ /^(?:CC_FLAGS=)?(-D\w.*)/) {
 	    process_cc_flags($1);
-	} elsif ($flag =~ /^(CCTYPE|FILETYPE|PLATFORM|TARG_DIR)=(.+)$/) {
+	} elsif ($flag =~ /^(CCTYPE|FILETYPE|PLATFORM|TARG_DIR|CONFIG_H)=(.+)$/) {
 	    $ARGS{$1} = $2;
 	} elsif ($flag eq '--sort-fold') {
 	    ++$fold;
@@ -104,7 +103,7 @@ my %exportperlmalloc =
 
 my $exportperlmalloc = PLATFORM eq 'os2';
 
-my $config_h = 'config.h';
+my $config_h = $ARGS{CONFIG_H} || "config.h";
 open(CFG, '<', $config_h) || die "Cannot open $config_h: $!\n";
 while (<CFG>) {
     $define{$1} = 1 if /^\s*\#\s*define\s+(MYMALLOC|MULTIPLICITY

--- a/t/porting/extrefs.t
+++ b/t/porting/extrefs.t
@@ -77,7 +77,8 @@ sub try_compile_and_link {
 	 . ' -DPERL_NO_INLINE_FUNCTIONS';
 
 	if ($^O eq "MSWin32") {
-	    $ccflags .= " -I../../win32 -I../../win32/include";
+	    $ccflags .= " -I../../win32 -I../../win32/include "
+             . "-I../../win32/full";
 	}
 
 	my $libs = '';

--- a/win32/.gitignore
+++ b/win32/.gitignore
@@ -5,6 +5,7 @@
 bin/*.bat
 html/
 mini/
+full/
 Extensions_static
 .coreheaders
 dlutils.c

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1247,7 +1247,7 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 #
 # MINIDIR generates config.h so miniperl.exe is not rebuilt when the 2nd
 # config.h is generated in CONFIGPM target, see also the comments for $(MINI_OBJ).
-	copy $(CFGH_TMPL) config.h
+	copy $(CFGH_TMPL) $(MINIDIR)\config.h
 	@(echo.&& \
 	echo #ifndef _config_h_footer_&& \
 	echo #define _config_h_footer_&& \
@@ -1290,7 +1290,7 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #undef USE_LONG_DOUBLE&& \
 	echo #undef I_QUADMATH&& \
 	echo #undef USE_QUADMATH&& \
-	echo #undef USE_CPLUSPLUS)>> config.h
+	echo #undef USE_CPLUSPLUS)>> $(MINIDIR)\config.h
 ifneq ($(CCTYPE),MSVC120)
 	@(echo #undef FILE_ptr&& \
 	echo #undef FILE_cnt&& \
@@ -1300,54 +1300,54 @@ ifneq ($(CCTYPE),MSVC120)
 	echo #define FILE_cnt^(fp^) PERLIO_FILE_cnt^(fp^)&& \
 	echo #define FILE_base^(fp^) PERLIO_FILE_base^(fp^)&& \
 	echo #define FILE_bufsiz^(fp^) ^(PERLIO_FILE_cnt^(fp^) + PERLIO_FILE_ptr^(fp^) - PERLIO_FILE_base^(fp^)^)&& \
-	echo #define I_STDBOOL)>> config.h
+	echo #define I_STDBOOL)>> $(MINIDIR)\config.h
 endif
 ifeq ($(WIN64),define)
 ifeq ($(CCTYPE),GCC)
-	@(echo #define LONG_DOUBLESIZE ^16)>> config.h
+	@(echo #define LONG_DOUBLESIZE ^16)>> $(MINIDIR)\config.h
 else
-	@(echo #define LONG_DOUBLESIZE ^8)>> config.h
+	@(echo #define LONG_DOUBLESIZE ^8)>> $(MINIDIR)\config.h
 endif
 	@(echo #define PTRSIZE ^8&& \
 	echo #define SSize_t $(INT64)&& \
 	echo #define HAS_ATOLL&& \
 	echo #define HAS_STRTOLL&& \
 	echo #define HAS_STRTOULL&& \
-	echo #define Size_t_size ^8)>> config.h
+	echo #define Size_t_size ^8)>> $(MINIDIR)\config.h
 else
 ifeq ($(CCTYPE),GCC)
-	@(echo #define LONG_DOUBLESIZE ^12)>> config.h
+	@(echo #define LONG_DOUBLESIZE ^12)>> $(MINIDIR)\config.h
 else
-	@(echo #define LONG_DOUBLESIZE ^8)>> config.h
+	@(echo #define LONG_DOUBLESIZE ^8)>> $(MINIDIR)\config.h
 endif
 	@(echo #define PTRSIZE ^4&& \
 	echo #define SSize_t int&& \
 	echo #undef HAS_ATOLL&& \
 	echo #undef HAS_STRTOLL&& \
 	echo #undef HAS_STRTOULL&& \
-	echo #define Size_t_size ^4)>> config.h
+	echo #define Size_t_size ^4)>> $(MINIDIR)\config.h
 endif
 ifeq ($(USE_64_BIT_INT),define)
 	@(echo #define IVTYPE $(INT64)&& \
 	echo #define UVTYPE unsigned $(INT64)&& \
 	echo #define IVSIZE ^8&& \
-	echo #define UVSIZE ^8)>> config.h
+	echo #define UVSIZE ^8)>> $(MINIDIR)\config.h
 ifeq ($(USE_LONG_DOUBLE),define)
 	@(echo #define NV_PRESERVES_UV&& \
-	echo #define NV_PRESERVES_UV_BITS 64)>> config.h
+	echo #define NV_PRESERVES_UV_BITS 64)>> $(MINIDIR)\config.h
 else ifeq ($(USE_QUADMATH),define)
 	@(echo #define NV_PRESERVES_UV&& \
-	echo #define NV_PRESERVES_UV_BITS 64)>> config.h
+	echo #define NV_PRESERVES_UV_BITS 64)>> $(MINIDIR)\config.h
 else
 	@(echo #undef NV_PRESERVES_UV&& \
-	echo #define NV_PRESERVES_UV_BITS 53)>> config.h
+	echo #define NV_PRESERVES_UV_BITS 53)>> $(MINIDIR)\config.h
 endif
 	@(echo #define IVdf "I64d"&& \
 	echo #define UVuf "I64u"&& \
 	echo #define UVof "I64o"&& \
 	echo #define UVxf "I64x"&& \
 	echo #define UVXf "I64X"&& \
-	echo #define USE_64_BIT_INT)>> config.h
+	echo #define USE_64_BIT_INT)>> $(MINIDIR)\config.h
 else
 	@(echo #define IVTYPE long&& \
 	echo #define UVTYPE unsigned long&& \
@@ -1360,7 +1360,7 @@ else
 	echo #define UVof "lo"&& \
 	echo #define UVxf "lx"&& \
 	echo #define UVXf "lX"&& \
-	echo #undef USE_64_BIT_INT)>> config.h
+	echo #undef USE_64_BIT_INT)>> $(MINIDIR)\config.h
 endif
 ifeq ($(USE_LONG_DOUBLE),define)
 	@(echo #define Gconvert^(x,n,t,b^) sprintf^(^(b^),"%%.*""Lg",^(n^),^(x^)^)&& \
@@ -1382,7 +1382,7 @@ ifeq ($(USE_LONG_DOUBLE),define)
 	echo #define NVgf "Lg"&& \
 	echo #undef I_QUADMATH&& \
 	echo #undef USE_QUADMATH&& \
-	echo #define USE_LONG_DOUBLE)>> config.h
+	echo #define USE_LONG_DOUBLE)>> $(MINIDIR)\config.h
 else ifeq ($(USE_QUADMATH),define)
 	@(echo #define Gconvert^(x,n,t,b^) sprintf^(^(b^),"%%.*""Lg",^(n^),^(x^)^)&& \
 	echo #define HAS_FREXPL&& \
@@ -1403,7 +1403,7 @@ else ifeq ($(USE_QUADMATH),define)
 	echo #define NVgf "Qg"&& \
 	echo #undef USE_LONG_DOUBLE&& \
 	echo #define I_QUADMATH&& \
-	echo #define USE_QUADMATH)>> config.h
+	echo #define USE_QUADMATH)>> $(MINIDIR)\config.h
 else
 	@(echo #define Gconvert^(x,n,t,b^) sprintf^(^(b^),"%%.*g",^(n^),^(x^)^)&& \
 	echo #undef HAS_FREXPL&& \
@@ -1424,23 +1424,23 @@ else
 	echo #define NVgf "g"&& \
 	echo #undef I_QUADMATH&& \
 	echo #undef USE_QUADMATH&& \
-	echo #undef USE_LONG_DOUBLE)>> config.h
+	echo #undef USE_LONG_DOUBLE)>> $(MINIDIR)\config.h
 endif
 ifeq ($(USE_CPLUSPLUS),define)
 	@(echo #define USE_CPLUSPLUS&& \
-	echo #endif)>> config.h
+	echo #endif)>> $(MINIDIR)\config.h
 else
 	@(echo #undef USE_CPLUSPLUS&& \
-	echo #endif)>> config.h
+	echo #endif)>> $(MINIDIR)\config.h
 endif
 #separate line since this is sentinal that this target is done
 	@rem. > $(MINIDIR)\.exists
 
 $(MINICORE_OBJ) : $(CORE_NOCFG_H)
-	$(CC) -c $(CFLAGS) $(MINIBUILDOPT) -DPERL_EXTERNAL_GLOB -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ $(PDBOUT) ..\$(*F).c
+	$(CC) -c -I$(MINIDIR) $(CFLAGS) $(MINIBUILDOPT) -DPERL_EXTERNAL_GLOB -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ $(PDBOUT) ..\$(*F).c
 
 $(MINIWIN32_OBJ) : $(CORE_NOCFG_H)
-	$(CC) -c $(CFLAGS) $(MINIBUILDOPT) -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ $(PDBOUT) $(*F).c
+	$(CC) -c -I$(MINIDIR) $(CFLAGS) $(MINIBUILDOPT) -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ $(PDBOUT) $(*F).c
 
 # -DPERL_IMPLICIT_SYS needs C++ for perllib.c
 # rules wrapped in .IFs break Win9X build (we end up with unbalanced []s

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1046,6 +1046,7 @@ CORE_NOCFG_H	=		\
 		.\win32.h
 
 CORE_H		= $(CORE_NOCFG_H) .\config.h ..\git_version.h
+MINI_CONFIG_H   = $(MINIDIR)\config.h
 
 UUDMAP_H	= ..\uudmap.h
 BITCOUNT_H	= ..\bitcount.h
@@ -1247,7 +1248,7 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 #
 # MINIDIR generates config.h so miniperl.exe is not rebuilt when the 2nd
 # config.h is generated in CONFIGPM target, see also the comments for $(MINI_OBJ).
-	copy $(CFGH_TMPL) $(MINIDIR)\config.h
+	copy $(CFGH_TMPL) $(MINI_CONFIG_H)
 	@(echo.&& \
 	echo #ifndef _config_h_footer_&& \
 	echo #define _config_h_footer_&& \
@@ -1290,7 +1291,7 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #undef USE_LONG_DOUBLE&& \
 	echo #undef I_QUADMATH&& \
 	echo #undef USE_QUADMATH&& \
-	echo #undef USE_CPLUSPLUS)>> $(MINIDIR)\config.h
+	echo #undef USE_CPLUSPLUS)>> $(MINI_CONFIG_H)
 ifneq ($(CCTYPE),MSVC120)
 	@(echo #undef FILE_ptr&& \
 	echo #undef FILE_cnt&& \
@@ -1300,54 +1301,54 @@ ifneq ($(CCTYPE),MSVC120)
 	echo #define FILE_cnt^(fp^) PERLIO_FILE_cnt^(fp^)&& \
 	echo #define FILE_base^(fp^) PERLIO_FILE_base^(fp^)&& \
 	echo #define FILE_bufsiz^(fp^) ^(PERLIO_FILE_cnt^(fp^) + PERLIO_FILE_ptr^(fp^) - PERLIO_FILE_base^(fp^)^)&& \
-	echo #define I_STDBOOL)>> $(MINIDIR)\config.h
+	echo #define I_STDBOOL)>> $(MINI_CONFIG_H)
 endif
 ifeq ($(WIN64),define)
 ifeq ($(CCTYPE),GCC)
-	@(echo #define LONG_DOUBLESIZE ^16)>> $(MINIDIR)\config.h
+	@(echo #define LONG_DOUBLESIZE ^16)>> $(MINI_CONFIG_H)
 else
-	@(echo #define LONG_DOUBLESIZE ^8)>> $(MINIDIR)\config.h
+	@(echo #define LONG_DOUBLESIZE ^8)>> $(MINI_CONFIG_H)
 endif
 	@(echo #define PTRSIZE ^8&& \
 	echo #define SSize_t $(INT64)&& \
 	echo #define HAS_ATOLL&& \
 	echo #define HAS_STRTOLL&& \
 	echo #define HAS_STRTOULL&& \
-	echo #define Size_t_size ^8)>> $(MINIDIR)\config.h
+	echo #define Size_t_size ^8)>> $(MINI_CONFIG_H)
 else
 ifeq ($(CCTYPE),GCC)
-	@(echo #define LONG_DOUBLESIZE ^12)>> $(MINIDIR)\config.h
+	@(echo #define LONG_DOUBLESIZE ^12)>> $(MINI_CONFIG_H)
 else
-	@(echo #define LONG_DOUBLESIZE ^8)>> $(MINIDIR)\config.h
+	@(echo #define LONG_DOUBLESIZE ^8)>> $(MINI_CONFIG_H)
 endif
 	@(echo #define PTRSIZE ^4&& \
 	echo #define SSize_t int&& \
 	echo #undef HAS_ATOLL&& \
 	echo #undef HAS_STRTOLL&& \
 	echo #undef HAS_STRTOULL&& \
-	echo #define Size_t_size ^4)>> $(MINIDIR)\config.h
+	echo #define Size_t_size ^4)>> $(MINI_CONFIG_H)
 endif
 ifeq ($(USE_64_BIT_INT),define)
 	@(echo #define IVTYPE $(INT64)&& \
 	echo #define UVTYPE unsigned $(INT64)&& \
 	echo #define IVSIZE ^8&& \
-	echo #define UVSIZE ^8)>> $(MINIDIR)\config.h
+	echo #define UVSIZE ^8)>> $(MINI_CONFIG_H)
 ifeq ($(USE_LONG_DOUBLE),define)
 	@(echo #define NV_PRESERVES_UV&& \
-	echo #define NV_PRESERVES_UV_BITS 64)>> $(MINIDIR)\config.h
+	echo #define NV_PRESERVES_UV_BITS 64)>> $(MINI_CONFIG_H)
 else ifeq ($(USE_QUADMATH),define)
 	@(echo #define NV_PRESERVES_UV&& \
-	echo #define NV_PRESERVES_UV_BITS 64)>> $(MINIDIR)\config.h
+	echo #define NV_PRESERVES_UV_BITS 64)>> $(MINI_CONFIG_H)
 else
 	@(echo #undef NV_PRESERVES_UV&& \
-	echo #define NV_PRESERVES_UV_BITS 53)>> $(MINIDIR)\config.h
+	echo #define NV_PRESERVES_UV_BITS 53)>> $(MINI_CONFIG_H)
 endif
 	@(echo #define IVdf "I64d"&& \
 	echo #define UVuf "I64u"&& \
 	echo #define UVof "I64o"&& \
 	echo #define UVxf "I64x"&& \
 	echo #define UVXf "I64X"&& \
-	echo #define USE_64_BIT_INT)>> $(MINIDIR)\config.h
+	echo #define USE_64_BIT_INT)>> $(MINI_CONFIG_H)
 else
 	@(echo #define IVTYPE long&& \
 	echo #define UVTYPE unsigned long&& \
@@ -1360,7 +1361,7 @@ else
 	echo #define UVof "lo"&& \
 	echo #define UVxf "lx"&& \
 	echo #define UVXf "lX"&& \
-	echo #undef USE_64_BIT_INT)>> $(MINIDIR)\config.h
+	echo #undef USE_64_BIT_INT)>> $(MINI_CONFIG_H)
 endif
 ifeq ($(USE_LONG_DOUBLE),define)
 	@(echo #define Gconvert^(x,n,t,b^) sprintf^(^(b^),"%%.*""Lg",^(n^),^(x^)^)&& \
@@ -1382,7 +1383,7 @@ ifeq ($(USE_LONG_DOUBLE),define)
 	echo #define NVgf "Lg"&& \
 	echo #undef I_QUADMATH&& \
 	echo #undef USE_QUADMATH&& \
-	echo #define USE_LONG_DOUBLE)>> $(MINIDIR)\config.h
+	echo #define USE_LONG_DOUBLE)>> $(MINI_CONFIG_H)
 else ifeq ($(USE_QUADMATH),define)
 	@(echo #define Gconvert^(x,n,t,b^) sprintf^(^(b^),"%%.*""Lg",^(n^),^(x^)^)&& \
 	echo #define HAS_FREXPL&& \
@@ -1403,7 +1404,7 @@ else ifeq ($(USE_QUADMATH),define)
 	echo #define NVgf "Qg"&& \
 	echo #undef USE_LONG_DOUBLE&& \
 	echo #define I_QUADMATH&& \
-	echo #define USE_QUADMATH)>> $(MINIDIR)\config.h
+	echo #define USE_QUADMATH)>> $(MINI_CONFIG_H)
 else
 	@(echo #define Gconvert^(x,n,t,b^) sprintf^(^(b^),"%%.*g",^(n^),^(x^)^)&& \
 	echo #undef HAS_FREXPL&& \
@@ -1424,14 +1425,14 @@ else
 	echo #define NVgf "g"&& \
 	echo #undef I_QUADMATH&& \
 	echo #undef USE_QUADMATH&& \
-	echo #undef USE_LONG_DOUBLE)>> $(MINIDIR)\config.h
+	echo #undef USE_LONG_DOUBLE)>> $(MINI_CONFIG_H)
 endif
 ifeq ($(USE_CPLUSPLUS),define)
 	@(echo #define USE_CPLUSPLUS&& \
-	echo #endif)>> $(MINIDIR)\config.h
+	echo #endif)>> $(MINI_CONFIG_H)
 else
 	@(echo #undef USE_CPLUSPLUS&& \
-	echo #endif)>> $(MINIDIR)\config.h
+	echo #endif)>> $(MINI_CONFIG_H)
 endif
 #separate line since this is sentinal that this target is done
 	@rem. > $(MINIDIR)\.exists

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1203,9 +1203,8 @@ endif
 ..\perl$(o) : ..\git_version.h
 
 ..\config.sh : $(CFGSH_TMPL) config_sh.PL FindExt.pm $(HAVEMINIPERL)
-	$(MINIPERL) -I..\lib config_sh.PL $(CFG_VARS) $(CFGSH_TMPL) > ..\config.sh.tmp
-	if exist ..\config.sh del /f ..\config.sh
-	rename ..\config.sh.tmp config.sh
+	$(MINIPERL) -I..\lib config_sh.PL -o ..\config.sh $(CFG_VARS) $(CFGSH_TMPL)
+	$(MINIPERL) -I..\lib set_depend_modtime.pl $@ $^
 
 # This target is for when changes to the main config.sh happen.
 # Edit config.gc, then make perl using GCC in a minimal configuration (i.e.

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -808,10 +808,10 @@ a ?= .lib
 .SUFFIXES : .c .i $(o) .dll $(a) .exe .rc .res
 
 %$(o): %.c
-	$(CC) -c -I$(<D) $(CFLAGS_O) $(OBJOUT_FLAG)$@ $(PDBOUT) $<
+	$(CC) -c -I$(<D) -I$(FULLDIR) $(CFLAGS_O) $(OBJOUT_FLAG)$@ $(PDBOUT) $<
 
 %.i: %.c
-	$(CC) -c -I$(<D) $(CFLAGS_O) -E $< >$@
+	$(CC) -c -I$(<D) -I$(FULLDIR) $(CFLAGS_O) -E $< >$@
 
 %.c: %.y
 	$(NOOP)
@@ -835,6 +835,8 @@ endif
 #miniperl alone
 MINIPERL	= ..\miniperl.exe
 HAVEMINIPERL	= ..\lib\buildcustomize.pl
+# contains config.h for the full perl build
+FULLDIR		= full
 MINIDIR		= mini
 PERLEXE		= ..\perl.exe
 WPERLEXE	= ..\wperl.exe
@@ -1045,8 +1047,9 @@ CORE_NOCFG_H	=		\
 		.\include\sys\socket.h	\
 		.\win32.h
 
-CORE_H		= $(CORE_NOCFG_H) .\config.h ..\git_version.h
+CONFIG_H	= $(FULLDIR)\config.h
 MINI_CONFIG_H   = $(MINIDIR)\config.h
+CORE_H		= $(CORE_NOCFG_H) $(CONFIG_H) ..\git_version.h
 
 UUDMAP_H	= ..\uudmap.h
 BITCOUNT_H	= ..\bitcount.h
@@ -1177,7 +1180,7 @@ endif
 
 ..\regexec$(o) : ..\regnodes.h ..\regcharclass.h
 
-reonly : ..\regnodes.h .\config.h ..\git_version.h $(GLOBEXE) $(HAVEMINIPERL)\
+reonly : ..\regnodes.h $(CONFIG_H) ..\git_version.h $(GLOBEXE) $(HAVEMINIPERL)\
 	$(CONFIGPM) $(UNIDATAFILES) $(PERLEXE)				\
 	Extensions_reonly
 
@@ -1217,9 +1220,10 @@ regen_config_h:
 
 $(CONFIGPM): ..\config.sh config_h.PL ..\git_version.h
 	$(MINIPERL) -I..\lib ..\configpm --chdir=..
-	-$(MINIPERL) -I..\lib config_h.PL "ARCHPREFIX=$(ARCHPREFIX)"
+	if not exist "$(FULLDIR)" mkdir "$(FULLDIR)"
+	$(MINIPERL) -I..\lib config_h.PL "CONFIG_H=$(CONFIG_H)" "ARCHPREFIX=$(ARCHPREFIX)"
 
-.\config.h : $(CONFIGPM)
+$(CONFIG_H) : $(CONFIGPM)
 
 # See the comment in Makefile.SH explaining this seemingly cranky ordering
 ..\lib\buildcustomize.pl : $(MINI_OBJ) ..\write_buildcustomize.pl
@@ -1454,9 +1458,9 @@ $(MINIWIN32_OBJ) : $(CORE_NOCFG_H)
 
 perllib$(o)	: perllib.c perllibst.h .\perlhost.h .\vdir.h .\vmem.h
 ifeq ($(USE_IMP_SYS),define)
-	$(CC) -c -I. $(CFLAGS_O) $(CXX_FLAG) $(OBJOUT_FLAG)$@ $(PDBOUT) perllib.c
+	$(CC) -c -I$(FULLDIR) -I. $(CFLAGS_O) $(CXX_FLAG) $(OBJOUT_FLAG)$@ $(PDBOUT) perllib.c
 else
-	$(CC) -c -I. $(CFLAGS_O) $(OBJOUT_FLAG)$@ $(PDBOUT) perllib.c
+	$(CC) -c -I$(FULLDIR) -I. $(CFLAGS_O) $(OBJOUT_FLAG)$@ $(PDBOUT) perllib.c
 endif
 
 # We can't have miniperl.exe depend on git_version.h, as miniperl creates it
@@ -1473,7 +1477,7 @@ perllibst.h : $(HAVEMINIPERL) $(CONFIGPM) create_perllibst_h.pl
 	$(MINIPERL) -I..\lib create_perllibst_h.pl
 
 perldll.def : $(HAVEMINIPERL) $(CONFIGPM) ..\embed.fnc ..\makedef.pl
-	$(MINIPERL) -I..\lib -w ..\makedef.pl PLATFORM=win32 $(OPTIMIZE) $(DEFINES) \
+	$(MINIPERL) -I..\lib -w ..\makedef.pl PLATFORM=win32 CONFIG_H=$(CONFIG_H) $(OPTIMIZE) $(DEFINES) \
 	$(BUILDOPT) CCTYPE=$(CCTYPE) TARG_DIR=..\ > perldll.def
 
 $(PERLEXPLIB) : $(PERLIMPLIB)
@@ -1541,10 +1545,10 @@ MakePPPort : $(HAVEMINIPERL) $(CONFIGPM)
 	rem. > $@
 
 perlmain$(o) : runperl.c $(CONFIGPM)
-	$(CC) $(subst -DPERLDLL,-UPERLDLL,$(CFLAGS_O)) $(OBJOUT_FLAG)$@ $(PDBOUT) -c runperl.c
+	$(CC) -I$(FULLDIR) $(subst -DPERLDLL,-UPERLDLL,$(CFLAGS_O)) $(OBJOUT_FLAG)$@ $(PDBOUT) -c runperl.c
 
 perlmainst$(o) : runperl.c $(CONFIGPM)
-	$(CC) $(CFLAGS_O) $(OBJOUT_FLAG)$@ $(PDBOUT) -c runperl.c
+	$(CC) -I$(FULLDIR) $(CFLAGS_O) $(OBJOUT_FLAG)$@ $(PDBOUT) -c runperl.c
 
 $(PERLEXE): $(CONFIGPM) $(PERLEXE_OBJ) $(PERLEXE_RES) $(PERLIMPLIB)
 ifeq ($(CCTYPE),GCC)
@@ -1659,7 +1663,7 @@ utils: $(HAVEMINIPERL) ..\utils\Makefile
 	copy ..\README.win32    ..\pod\perlwin32.pod
 	copy ..\pod\perldelta.pod ..\pod\perl5391delta.pod
 	$(MINIPERL) -I..\lib $(PL2BAT) $(UTILS)
-	$(MINIPERL) -I..\lib ..\autodoc.pl ..
+	$(MINIPERL) -I..\lib ..\autodoc.pl -c "win32\$(CONFIG_H)" ..
 	$(MINIPERL) -I..\lib ..\pod\perlmodlib.PL -q ..
 
 ..\pod\perltoc.pod: $(PERLEXE) $(PERLDLL) Extensions Extensions_nonxs $(NORMALIZE_DYN) utils
@@ -1874,7 +1878,8 @@ _clean :
 	-@erase perlglob$(o)
 	-@erase perlmain$(o)
 	-@erase perlmainst$(o)
-	-@erase /f config.h
+	-@erase /f $(CONFIG_H)
+	-if exist $(FULLDIR) rmdir /s /q $(FULLDIR)
 	-@erase /f ..\git_version.h
 	-@erase $(GLOBEXE)
 	-@erase $(PERLEXE)

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1436,11 +1436,15 @@ endif
 #separate line since this is sentinal that this target is done
 	@rem. > $(MINIDIR)\.exists
 
+$(MINIDIR)\\%$(o): %.c
+	$(CC) -c -I$(MINIDIR) $(CFLAGS) $(MINIBUILDOPT) -DPERL_EXTERNAL_GLOB -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ $(PDBOUT) $<
+
+$(MINIDIR)\\%$(o): ..\%.c
+	$(CC) -c -I$(MINIDIR) $(CFLAGS) $(MINIBUILDOPT) -DPERL_EXTERNAL_GLOB -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ $(PDBOUT) $<
+
 $(MINICORE_OBJ) : $(CORE_NOCFG_H)
-	$(CC) -c -I$(MINIDIR) $(CFLAGS) $(MINIBUILDOPT) -DPERL_EXTERNAL_GLOB -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ $(PDBOUT) ..\$(*F).c
 
 $(MINIWIN32_OBJ) : $(CORE_NOCFG_H)
-	$(CC) -c -I$(MINIDIR) $(CFLAGS) $(MINIBUILDOPT) -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ $(PDBOUT) $(*F).c
 
 # -DPERL_IMPLICIT_SYS needs C++ for perllib.c
 # rules wrapped in .IFs break Win9X build (we end up with unbalanced []s
@@ -1454,9 +1458,7 @@ else
 	$(CC) -c -I. $(CFLAGS_O) $(OBJOUT_FLAG)$@ $(PDBOUT) perllib.c
 endif
 
-# 1. we don't want to rebuild miniperl.exe when config.h changes
-# 2. we don't want to rebuild miniperl.exe with non-default config.h
-# 3. we can't have miniperl.exe depend on git_version.h, as miniperl creates it
+# We can't have miniperl.exe depend on git_version.h, as miniperl creates it
 $(MINI_OBJ)	: $(MINIDIR)\.exists $(CORE_NOCFG_H)
 
 $(WIN32_OBJ)	: $(CORE_H)

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1590,7 +1590,7 @@ Exts_static_general : ..\make_ext.pl $(CONFIGPM) Extension_lib $(GLOBEXE) $(HAVE
 	$(MINIPERL) -I..\lib ..\make_ext.pl "MAKE=$(PLMAKE)" --dir=$(CPANDIR) --dir=$(DISTDIR) --dir=$(EXTDIR) --static !Unicode/Normalize
 
 Extensions_static : list_static_libs.pl Exts_static_general $(NORMALIZE_STATIC)
-	$(MINIPERL) -I..\lib list_static_libs.pl > Extensions_static
+	$(MINIPERL) -I..\lib list_static_libs.pl -o Extensions_static
 
 Extensions_nonxs : ..\make_ext.pl ..\pod\perlfunc.pod $(CONFIGPM) $(GLOBEXE)
 	$(MINIPERL) -I..\lib ..\make_ext.pl "MAKE=$(PLMAKE)" --dir=$(CPANDIR) --dir=$(DISTDIR) --dir=$(EXTDIR) --nonxs !libs

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -895,9 +895,8 @@ perlglob$(o)  : perlglob.c
 ..\perl$(o) : ..\git_version.h
 
 ..\config.sh : $(CFGSH_TMPL) config_sh.PL FindExt.pm $(MINIPERL)
-	$(MINIPERL) -I..\lib config_sh.PL $(CFG_VARS) $(CFGSH_TMPL) > ..\config.sh.tmp
-	if exist ..\config.sh del /f ..\config.sh
-	rename ..\config.sh.tmp config.sh
+	$(MINIPERL) -I..\lib config_sh.PL -o ..\config.sh $(CFG_VARS) $(CFGSH_TMPL)
+	$(MINIPERL) -I..\lib set_depend_modtime.pl $@ $**
 
 # This target is for when changes to the main config.sh happen.
 # Edit config.vc, then make perl in a minimal configuration (i.e. with MULTI,

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -936,7 +936,7 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 # real config.h used to build perl.exe is generated from the top-level
 # config_h.SH by config_h.PL (run by miniperl.exe).
 #
-	copy $(CFGH_TMPL) config.h
+	copy $(CFGH_TMPL) $(MINIDIR)\config.h
 	@(echo.&& \
 	echo #ifndef _config_h_footer_&& \
 	echo #define _config_h_footer_&& \
@@ -959,7 +959,7 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #undef UVXf&& \
 	echo #undef USE_64_BIT_INT&& \
 	echo #undef USE_LONG_DOUBLE&& \
-	echo #undef USE_CPLUSPLUS)>> config.h
+	echo #undef USE_CPLUSPLUS)>> $(MINIDIR)\config.h
 !IF "$(CCTYPE)" != "MSVC120"
 	@(echo #undef FILE_ptr&& \
 	echo #undef FILE_cnt&& \
@@ -969,7 +969,7 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #define FILE_cnt^(fp^) PERLIO_FILE_cnt^(fp^)&& \
 	echo #define FILE_base^(fp^) PERLIO_FILE_base^(fp^)&& \
 	echo #define FILE_bufsiz^(fp^) ^(PERLIO_FILE_cnt^(fp^) + PERLIO_FILE_ptr^(fp^) - PERLIO_FILE_base^(fp^)^)&& \
-	echo #define I_STDBOOL)>> config.h
+	echo #define I_STDBOOL)>> $(MINIDIR)\config.h
 !ENDIF
 !IF "$(WIN64)"=="define"
 	@(echo #define PTRSIZE ^8&& \
@@ -977,14 +977,14 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #define HAS_ATOLL&& \
 	echo #define HAS_STRTOLL&& \
 	echo #define HAS_STRTOULL&& \
-	echo #define Size_t_size ^8)>> config.h
+	echo #define Size_t_size ^8)>> $(MINIDIR)\config.h
 !ELSE
 	@(echo #define PTRSIZE ^4&& \
 	echo #define SSize_t int&& \
 	echo #undef HAS_ATOLL&& \
 	echo #undef HAS_STRTOLL&& \
 	echo #undef HAS_STRTOULL&& \
-	echo #define Size_t_size ^4)>> config.h
+	echo #define Size_t_size ^4)>> $(MINIDIR)\config.h
 !ENDIF
 !IF "$(USE_64_BIT_INT)"=="define"
 	@(echo #define IVTYPE $(INT64)&& \
@@ -998,7 +998,7 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #define UVof "I64o"&& \
 	echo #define UVxf "I64x"&& \
 	echo #define UVXf "I64X"&& \
-	echo #define USE_64_BIT_INT)>> config.h
+	echo #define USE_64_BIT_INT)>> $(MINIDIR)\config.h
 !ELSE
 	@(echo #define IVTYPE long&& \
 	echo #define UVTYPE unsigned long&& \
@@ -1011,23 +1011,23 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #define UVof "lo"&& \
 	echo #define UVxf "lx"&& \
 	echo #define UVXf "lX"&& \
-	echo #undef USE_64_BIT_INT)>> config.h
+	echo #undef USE_64_BIT_INT)>> $(MINIDIR)\config.h
 !ENDIF
 !IF "$(USE_CPLUSPLUS)"=="define"
 	@(echo #define USE_CPLUSPLUS&& \
-	echo #endif)>> config.h
+	echo #endif)>> $(MINIDIR)\config.h
 !ELSE
 	@(echo #undef USE_CPLUSPLUS&& \
-	echo #endif)>> config.h
+	echo #endif)>> $(MINIDIR)\config.h
 !ENDIF
 #separate line since this is sentinal that this target is done
 	@rem. > $(MINIDIR)\.exists
 
 $(MINICORE_OBJ) : $(CORE_NOCFG_H)
-	$(CC) -c $(CFLAGS) -DPERL_EXTERNAL_GLOB -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ ..\$(*F).c
+	$(CC) -c -Imini $(CFLAGS) -DPERL_EXTERNAL_GLOB -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ ..\$(*F).c
 
 $(MINIWIN32_OBJ) : $(CORE_NOCFG_H)
-	$(CC) -c $(CFLAGS) -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ $(*F).c
+	$(CC) -c -Imini $(CFLAGS) -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ $(*F).c
 
 # -DPERL_IMPLICIT_SYS needs C++ for perllib.c
 # This is the only file that depends on perlhost.h, vmem.h, and vdir.h

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -1122,7 +1122,7 @@ Extensions_reonly: ..\make_ext.pl ..\lib\buildcustomize.pl $(PERLDEP) $(CONFIGPM
 Extensions_static : ..\make_ext.pl ..\lib\buildcustomize.pl list_static_libs.pl $(PERLDEP) $(CONFIGPM) Extensions_nonxs
 	$(XCOPY) ..\*.h $(COREDIR)\*.*
 	$(MINIPERL) -I..\lib ..\make_ext.pl "MAKE=$(MAKE)" --dir=$(CPANDIR) --dir=$(DISTDIR) --dir=$(EXTDIR) --static
-	$(MINIPERL) -I..\lib list_static_libs.pl > Extensions_static
+	$(MINIPERL) -I..\lib list_static_libs.pl -o Extensions_static
 
 Extensions_nonxs: ..\make_ext.pl ..\lib\buildcustomize.pl $(PERLDEP) $(CONFIGPM) ..\pod\perlfunc.pod
 	$(XCOPY) ..\*.h $(COREDIR)\*.*

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -428,7 +428,7 @@ RSC		= rc
 # Options
 #
 
-INCLUDES	= -I$(COREDIR) -I.\include -I. -I..
+INCLUDES	= -I.\include -I. -I..
 #PCHFLAGS	= -Fpc:\temp\vcmoduls.pch -YX
 DEFINES		= -DWIN32 -D_CONSOLE -DNO_STRICT
 LOCDEFS		= -DPERLDLL -DPERL_CORE
@@ -563,10 +563,10 @@ o = .obj
 .SUFFIXES : .c $(o) .cpp .asm .dll .lib .exe .rc .res
 
 .c$(o):
-	$(CC) -c -I$(<D) $(CFLAGS_O) $(OBJOUT_FLAG)$@ $<
+	$(CC) -c -I$(FULLDIR) -I$(<D) $(CFLAGS_O) $(OBJOUT_FLAG)$@ $<
 
 .c.i:
-	$(CC) -c -I$(<D) $(CFLAGS_O) -P $(OBJOUT_FLAG)$@ $<
+	$(CC) -c -I$(FULLDIR) -I$(<D) $(CFLAGS_O) -P $(OBJOUT_FLAG)$@ $<
 
 .y.c:
 	$(NOOP)
@@ -588,6 +588,8 @@ PERLSTATICLIB	= ..\perl539s.lib
 PERLDLL		= ..\perl539.dll
 
 MINIPERL	= ..\miniperl.exe
+# contains config.h for the full perl build
+FULLDIR		= .\full
 MINIDIR		= .\mini
 PERLEXE		= ..\perl.exe
 WPERLEXE	= ..\wperl.exe
@@ -775,8 +777,9 @@ CORE_NOCFG_H	=		\
 		.\include\sys\socket.h	\
 		.\win32.h
 
-CORE_H		= $(CORE_NOCFG_H) .\config.h ..\git_version.h
+CONFIG_H	= $(FULLDIR)\config.h
 MINI_CONFIG_H	= $(MINIDIR)\config.h
+CORE_H		= $(CORE_NOCFG_H) $(CONFIG_H) ..\git_version.h
 
 UUDMAP_H	= ..\uudmap.h
 BITCOUNT_H	= ..\bitcount.h
@@ -871,7 +874,7 @@ regnodes : ..\regnodes.h
 
 ..\regexec$(o) : ..\regnodes.h ..\regcharclass.h
 
-reonly : regnodes .\config.h ..\git_version.h $(GLOBEXE) $(CONFIGPM) \
+reonly : regnodes $(CONFIG_H) ..\git_version.h $(GLOBEXE) $(CONFIGPM) \
 	$(UNIDATAFILES) $(PERLEXE) Extensions_reonly
 	@echo	Perl and 're' are up to date.
 
@@ -912,10 +915,10 @@ $(CONFIGPM) : $(MINIPERL) ..\config.sh config_h.PL ..\git_version.h
 	$(XCOPY) ..\*.h $(COREDIR)\*.*
 	$(XCOPY) *.h $(COREDIR)\*.*
 	$(RCOPY) include $(COREDIR)\*.*
-	-$(MINIPERL) -I..\lib config_h.PL
-	if errorlevel 1 $(MAKE) /$(MAKEFLAGS) $(CONFIGPM)
+	if not exist "$(FULLDIR)" mkdir "$(FULLDIR)"
+	$(MINIPERL) -I..\lib config_h.PL "CONFIG_H=$(CONFIG_H)" 
 
-.\config.h : $(CONFIGPM)
+$(CONFIG_H) : $(CONFIGPM)
 
 # See the comment in Makefile.SH explaining this seemingly cranky ordering
 $(MINIPERL) : ..\lib\buildcustomize.pl
@@ -1038,7 +1041,7 @@ $(MINIWIN32_OBJ) : $(CORE_NOCFG_H)
 # This is the only file that depends on perlhost.h, vmem.h, and vdir.h
 !IF "$(USE_IMP_SYS)" == "define"
 perllib$(o)	: perllib.c .\perlhost.h .\vdir.h .\vmem.h
-	$(CC) -c -I. $(CFLAGS_O) $(CXX_FLAG) $(OBJOUT_FLAG)$@ perllib.c
+	$(CC) -c -I$(FULLDIR) -I. $(CFLAGS_O) $(CXX_FLAG) $(OBJOUT_FLAG)$@ perllib.c
 !ENDIF
 
 # We can't have miniperl.exe depend on git_version.h, as miniperl creates it
@@ -1050,7 +1053,7 @@ $(DLL_OBJ)	: $(CORE_H)
 
 perldll.def : $(MINIPERL) $(CONFIGPM) ..\embed.fnc ..\makedef.pl create_perllibst_h.pl ..\git_version.h
 	$(MINIPERL) -I..\lib create_perllibst_h.pl
-	$(MINIPERL) -I..\lib -w ..\makedef.pl PLATFORM=win32 $(OPTIMIZE) $(DEFINES) $(BUILDOPT) \
+	$(MINIPERL) -I..\lib -w ..\makedef.pl PLATFORM=win32 CONFIG_H=$(CONFIG_H) $(OPTIMIZE) $(DEFINES) $(BUILDOPT) \
 	    CCTYPE=$(CCTYPE) TARG_DIR=..\ > perldll.def
 
 $(PERLDLL): perldll.def $(PERLDLL_OBJ) $(PERLDLL_RES) Extensions_static
@@ -1085,13 +1088,13 @@ perlmain.c : runperl.c
 	copy runperl.c perlmain.c
 
 perlmain$(o) : perlmain.c
-	$(CC) $(CFLAGS_O:-DPERLDLL=-UPERLDLL) $(OBJOUT_FLAG)$@ -c perlmain.c
+	$(CC) -I$(FULLDIR) $(CFLAGS_O:-DPERLDLL=-UPERLDLL) $(OBJOUT_FLAG)$@ -c perlmain.c
 
 perlmainst.c : runperl.c
 	copy runperl.c perlmainst.c
 
 perlmainst$(o) : perlmainst.c
-	$(CC) $(CFLAGS_O) $(OBJOUT_FLAG)$@ -c perlmainst.c
+	$(CC) -I$(FULLDIR) $(CFLAGS_O) $(OBJOUT_FLAG)$@ -c perlmainst.c
 
 $(PERLEXE): $(PERLDLL) $(CONFIGPM) $(PERLEXE_OBJ) $(PERLEXE_RES)
 	$(LINK32) -out:$@ $(BLINK_FLAGS) \
@@ -1184,7 +1187,7 @@ utils: $(PERLEXE) ..\utils\Makefile
 	copy ..\pod\perldelta.pod ..\pod\perl5391delta.pod
 	cd ..\win32
 	$(PERLEXE) $(PL2BAT) $(UTILS)
-	$(MINIPERL) -I..\lib ..\autodoc.pl ..
+	$(MINIPERL) -I..\lib ..\autodoc.pl -c "win32\$(CONFIG_H)" ..
 	$(MINIPERL) -I..\lib ..\pod\perlmodlib.PL -q ..
 
 ..\pod\perltoc.pod: $(PERLEXE) Extensions Extensions_nonxs
@@ -1331,7 +1334,7 @@ $(UNIDATAFILES) ..\pod\perluniprops.pod : $(MINIPERL) $(CONFIGPM) ..\lib\unicore
 	cd ..\lib\unicore && \
 	..\$(MINIPERL) -I.. mktables -P ..\..\pod -maketest -makelist -p -check $@ $(FIRSTUNIFILE)
 
-minitest : .\config.h $(MINIPERL) ..\git_version.h $(GLOBEXE) $(CONFIGPM) $(UNIDATAFILES)
+minitest : $(CONFIG_H) $(MINIPERL) ..\git_version.h $(GLOBEXE) $(CONFIGPM) $(UNIDATAFILES)
 	$(XCOPY) $(MINIPERL) ..\t\$(NULL)
 	if exist ..\t\perl.exe del /f ..\t\perl.exe
 	rename ..\t\miniperl.exe perl.exe

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -776,6 +776,7 @@ CORE_NOCFG_H	=		\
 		.\win32.h
 
 CORE_H		= $(CORE_NOCFG_H) .\config.h ..\git_version.h
+MINI_CONFIG_H	= $(MINIDIR)\config.h
 
 UUDMAP_H	= ..\uudmap.h
 BITCOUNT_H	= ..\bitcount.h
@@ -936,7 +937,7 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 # real config.h used to build perl.exe is generated from the top-level
 # config_h.SH by config_h.PL (run by miniperl.exe).
 #
-	copy $(CFGH_TMPL) $(MINIDIR)\config.h
+	copy $(CFGH_TMPL) $(MINI_CONFIG_H)
 	@(echo.&& \
 	echo #ifndef _config_h_footer_&& \
 	echo #define _config_h_footer_&& \
@@ -959,7 +960,7 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #undef UVXf&& \
 	echo #undef USE_64_BIT_INT&& \
 	echo #undef USE_LONG_DOUBLE&& \
-	echo #undef USE_CPLUSPLUS)>> $(MINIDIR)\config.h
+	echo #undef USE_CPLUSPLUS)>> $(MINI_CONFIG_H)
 !IF "$(CCTYPE)" != "MSVC120"
 	@(echo #undef FILE_ptr&& \
 	echo #undef FILE_cnt&& \
@@ -969,7 +970,7 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #define FILE_cnt^(fp^) PERLIO_FILE_cnt^(fp^)&& \
 	echo #define FILE_base^(fp^) PERLIO_FILE_base^(fp^)&& \
 	echo #define FILE_bufsiz^(fp^) ^(PERLIO_FILE_cnt^(fp^) + PERLIO_FILE_ptr^(fp^) - PERLIO_FILE_base^(fp^)^)&& \
-	echo #define I_STDBOOL)>> $(MINIDIR)\config.h
+	echo #define I_STDBOOL)>> $(MINI_CONFIG_H)
 !ENDIF
 !IF "$(WIN64)"=="define"
 	@(echo #define PTRSIZE ^8&& \
@@ -977,14 +978,14 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #define HAS_ATOLL&& \
 	echo #define HAS_STRTOLL&& \
 	echo #define HAS_STRTOULL&& \
-	echo #define Size_t_size ^8)>> $(MINIDIR)\config.h
+	echo #define Size_t_size ^8)>> $(MINI_CONFIG_H)
 !ELSE
 	@(echo #define PTRSIZE ^4&& \
 	echo #define SSize_t int&& \
 	echo #undef HAS_ATOLL&& \
 	echo #undef HAS_STRTOLL&& \
 	echo #undef HAS_STRTOULL&& \
-	echo #define Size_t_size ^4)>> $(MINIDIR)\config.h
+	echo #define Size_t_size ^4)>> $(MINI_CONFIG_H)
 !ENDIF
 !IF "$(USE_64_BIT_INT)"=="define"
 	@(echo #define IVTYPE $(INT64)&& \
@@ -998,7 +999,7 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #define UVof "I64o"&& \
 	echo #define UVxf "I64x"&& \
 	echo #define UVXf "I64X"&& \
-	echo #define USE_64_BIT_INT)>> $(MINIDIR)\config.h
+	echo #define USE_64_BIT_INT)>> $(MINI_CONFIG_H)
 !ELSE
 	@(echo #define IVTYPE long&& \
 	echo #define UVTYPE unsigned long&& \
@@ -1011,14 +1012,14 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #define UVof "lo"&& \
 	echo #define UVxf "lx"&& \
 	echo #define UVXf "lX"&& \
-	echo #undef USE_64_BIT_INT)>> $(MINIDIR)\config.h
+	echo #undef USE_64_BIT_INT)>> $(MINI_CONFIG_H)
 !ENDIF
 !IF "$(USE_CPLUSPLUS)"=="define"
 	@(echo #define USE_CPLUSPLUS&& \
-	echo #endif)>> $(MINIDIR)\config.h
+	echo #endif)>> $(MINI_CONFIG_H)
 !ELSE
 	@(echo #undef USE_CPLUSPLUS&& \
-	echo #endif)>> $(MINIDIR)\config.h
+	echo #endif)>> $(MINI_CONFIG_H)
 !ENDIF
 #separate line since this is sentinal that this target is done
 	@rem. > $(MINIDIR)\.exists

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -1023,11 +1023,15 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 #separate line since this is sentinal that this target is done
 	@rem. > $(MINIDIR)\.exists
 
+.c{$(MINIDIR)}$(o):
+	$(CC) -c -Imini $(CFLAGS) -DPERL_EXTERNAL_GLOB -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ $<
+
+{..\}.c{$(MINIDIR)}$(o):
+	$(CC) -c -Imini $(CFLAGS) -DPERL_EXTERNAL_GLOB -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ $<
+
 $(MINICORE_OBJ) : $(CORE_NOCFG_H)
-	$(CC) -c -Imini $(CFLAGS) -DPERL_EXTERNAL_GLOB -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ ..\$(*F).c
 
 $(MINIWIN32_OBJ) : $(CORE_NOCFG_H)
-	$(CC) -c -Imini $(CFLAGS) -DPERL_IS_MINIPERL $(OBJOUT_FLAG)$@ $(*F).c
 
 # -DPERL_IMPLICIT_SYS needs C++ for perllib.c
 # This is the only file that depends on perlhost.h, vmem.h, and vdir.h
@@ -1036,9 +1040,7 @@ perllib$(o)	: perllib.c .\perlhost.h .\vdir.h .\vmem.h
 	$(CC) -c -I. $(CFLAGS_O) $(CXX_FLAG) $(OBJOUT_FLAG)$@ perllib.c
 !ENDIF
 
-# 1. we don't want to rebuild miniperl.exe when config.h changes
-# 2. we don't want to rebuild miniperl.exe with non-default config.h
-# 3. we can't have miniperl.exe depend on git_version.h, as miniperl creates it
+# We can't have miniperl.exe depend on git_version.h, as miniperl creates it
 $(MINI_OBJ)	: $(MINIDIR)\.exists $(CORE_NOCFG_H)
 
 $(WIN32_OBJ)	: $(CORE_H)

--- a/win32/config_h.PL
+++ b/win32/config_h.PL
@@ -23,6 +23,7 @@ while (@ARGV && $ARGV[0] =~ /^([\w_]+)=(.*)$/)
 
 $opt{CONFIG_H} ||= 'config.h';
 $opt{CORE_DIR} ||= '../lib/CORE';
+$opt{CORE_CONFIG_H} ||= $opt{CORE_DIR} . '/config.h';
 
 warn "Writing $opt{CONFIG_H}\n";
 
@@ -84,11 +85,11 @@ while (<SH>)
 close(H);
 close(SH);
 
-my $core_config_h = "$opt{CORE_DIR}/$opt{CONFIG_H}";
+my $core_config_h = $opt{CORE_CONFIG_H};
 if (compare("$file.new", $core_config_h)) {
     mkdir $opt{CORE_DIR} unless -d $opt{CORE_DIR};
     chmod(0666,$core_config_h);
-    copy("$file.new",$core_config_h) || die "Cannot copy:$!";
+    copy("$file.new",$core_config_h) || die "Cannot copy $file.new $core_config_h:$!";
     chmod(0444,$core_config_h);
 }
 

--- a/win32/config_sh.PL
+++ b/win32/config_sh.PL
@@ -62,6 +62,36 @@ sub loadopts {
     }
 }
 
+sub replace_template {
+    my ($template, %opt) = @_;
+
+    open my $fh, "<", $template
+        or die "$0: Cannot open $template: $!\n";
+    my $result = '';
+    local $_;
+    while (<$fh>) {
+        s/~([\w_]+)~/exists $opt{$1} ? $opt{$1} : ''/eg;
+        if (/^([\w_]+)=(.*)$/) {
+            my($k,$v) = ($1,$2);
+            # this depends on cf_time being empty in the template (or we'll
+            # get a loop)
+            if (exists $opt{$k}) {
+                $_ = "$k='$opt{$k}'\n";
+            }
+        }
+        $result .= $_;
+    }
+    close $fh;
+
+    $result;
+}
+
+my $out = '-';
+if (@ARGV >= 2 && $ARGV[0] eq '-o') {
+    shift;
+    $out = shift;
+}
+
 my $prebuilt; # are we making the prebuilt config used to bootstrap?
 if (@ARGV && $ARGV[0] eq '--prebuilt') {
     ++$prebuilt;
@@ -361,18 +391,35 @@ if ($opt{usecplusplus} eq 'define') {
 
 #if the fields above are defined, they override the defaults in the premade
 #config file
-while (<>) {
-    s/~([\w_]+)~/exists $opt{$1} ? $opt{$1} : ''/eg;
-    if (/^([\w_]+)=(.*)$/) {
-	my($k,$v) = ($1,$2);
-	# this depends on cf_time being empty in the template (or we'll
-	# get a loop)
-	if ($k eq 'cf_time') {
-	    $_ = "$k='" . localtime(time) . "'\n" if $v =~ /^\s*'\s*'/;
-	}
-	elsif (exists $opt{$k}) {
-	    $_ = "$k='$opt{$k}'\n";
-	}
+my $template = shift
+    or die "$0: No template supplied\n";
+if ($out ne '-') {
+    # preserve cf_time to avoid generating a new config.sh with no changes
+    my $cf_time;
+    if (open my $fh, "<", $out) {
+        my $old = '';
+        # scan for cf_time while reading in the whole file
+        while (<$fh>) {
+            $old .= $_;
+            if (/^cf_time='(.*)'/) {
+                $cf_time = $1;
+            }
+        }
+        close $fh;
+
+        my $replaced = replace_template($template, %opt, cf_time => $cf_time);
+        if ($replaced eq $old) {
+            # no configuration change, skip updating
+            print "$0: No changes for $out\n";
+            exit;
+        }
     }
-    print;
+    open my $fh, ">", $out
+        or die "$0: Cannot create $out: $!\n";
+    print $fh replace_template($template, %opt, cf_time => scalar localtime);
+    close $fh
+        or die "$0: Failed to close $template: $!\n";
+}
+else {
+    print replace_template($template, %opt, cf_time => scalar localtime);
 }

--- a/win32/list_static_libs.pl
+++ b/win32/list_static_libs.pl
@@ -5,6 +5,12 @@ use strict;
 
 use Config;
 
+my $out;
+if (@ARGV > 1 && $ARGV[0] eq "-o") {
+    shift;
+    $out = shift;
+}
+
 my @statics = split /\s+/, $Config{static_ext};
 
 my (@extralibs, %extralibs); # collect extralibs, preserving their order
@@ -13,5 +19,49 @@ for (@statics) {
     open my $fh, '<', $file or die "can't open $file for reading: $!";
     push @extralibs, grep {!$extralibs{$_}++} grep {/\S/} split /\s+/, join '', <$fh>;
 }
-print map {s|/|\\|g;m|([^\\]+)$|;"..\\lib\\auto\\$_\\$1$Config{_a} "} @statics;
-print map {"$_ "} @extralibs;
+
+my @libnames = join " ",
+    map {s|/|\\|g;m|([^\\]+)$|;"..\\lib\\auto\\$_\\$1$Config{_a}"} @statics,
+    @extralibs;
+my $result = join " ", @libnames;
+
+if ($out) {
+    my $do_update = 0;
+    # only write if:
+    #  - output doesn't exist
+    #  - there's a change in the content of the file
+    #  - one of the generated static libs is newer than the file
+    my $out_mtime;
+    if (open my $fh, "<", $out) {
+        $out_mtime = (stat $fh)[9];
+        my $current = do { local $/; <$fh> };
+        if ($current ne $result) {
+            ++$do_update;
+        }
+        close $fh;
+    }
+    else {
+        ++$do_update;
+    }
+    if (!$do_update && $out_mtime) {
+        for my $lib (@libnames) {
+            if ((stat $lib)[9] > $out_mtime) {
+                ++$do_update;
+                last;
+            }
+        }
+    }
+
+    unless ($do_update) {
+        print "$0: No changes, no libraries changed, nothing to do\n";
+        exit;
+    }
+
+    open my $fh, ">", $out
+        or die "Cannot create $out: $!";
+    print $fh $result;
+    close $fh or die "Failed to close $out: $!\n";
+}
+else {
+    print $result;
+}

--- a/win32/set_depend_modtime.pl
+++ b/win32/set_depend_modtime.pl
@@ -1,0 +1,24 @@
+#!perl
+use strict;
+use warnings;
+
+my $target = shift
+    or die usage();
+
+my $latest = (stat $target)[9]
+    or die "$0: Target $target not found: $!\n";
+for my $source (@ARGV) {
+    my @st = stat $source;
+    $st[9] > $latest and $latest = $st[9];
+}
+
+utime($latest, $latest, $target)
+    or die "Couldn't update modification time of $target: $!\n";
+
+sub usage {
+    <<EOS;
+Usage: $0 target sourcefiles...
+  Sets the modification time of target to the latest time out of
+  the target and all the source files.
+EOS
+}


### PR DESCRIPTION
These commits re-work the miniperl build:
- previously the miniperl config.h was overwritten by the full perl config, which, if the objects for miniperl were rebuilt, could lead to the newly compiled miniperl objects not matching the existing objects.  This also caused a problem @khwilliamson encountered where a Perl_putenv() definition was confused about whether the build was threaded or not.  Using a separate config.h (now in mini/ for miniperl) avoids this confusion.
- previously the miniperl object files didn't depend on their corresponding source files, presumably with the intent to avoid the above problem.  This could be frustrating if the developer was testing core changes by rapidly iterating on miniperl.  Since the miniperl object are now generated from a distinct config.h, this has been switched to a pattern (GNU make) or implicit rule (nmake) which adds an implicit dependency on the source file.

I believe this fixes some of the problems in #20749 