### PR TITLE
Calculate conflict markers instead of hardcoding

### DIFF
--- a/t/comp/parser.t
+++ b/t/comp/parser.t
@@ -580,16 +580,13 @@ eval 'qq{@{0]}${}},{})';
 is(1, 1, "RT #124207");
 
 # RT #127993 version control conflict markers
+my @conflict_markers = map { $_ x 7 } qw( < = > );
 " this should keep working
-<<<<<<<
+$conflict_markers[0]
 " =~ /
->>>>>>>
+$conflict_markers[2]
 /;
-for my $marker (qw(
-<<<<<<<
-=======
->>>>>>>
-)) {
+for my $marker (@conflict_markers) {
     eval "$marker";
     like $@, qr/^Version control conflict marker at \(eval \d+\) line 1, near "$marker"/, "VCS marker '$marker' at beginning";
     eval "\$_\n$marker";

--- a/t/lib/croak/toke
+++ b/t/lib/croak/toke
@@ -410,16 +410,17 @@ BEGIN <>
 EXPECT
 Illegal declaration of subroutine BEGIN at - line 1.
 ########
-# NAME multiple conflict markers
-<<<<<<< yours:sample.txt
+# NAME multiple conflict markers.
+# NOTE the <CONFLICT< style text is auto-replaced in test.pl run_multiple_progs
+<CONFLICT< yours:sample.txt
 my $some_code;
-=======
+=CONFLICT=
 my $some_other_code;
->>>>>>> theirs:sample.txt
+>CONFLICT> theirs:sample.txt
 EXPECT
-Version control conflict marker at - line 1, near "<<<<<<<"
-Version control conflict marker at - line 3, near "======="
-Version control conflict marker at - line 5, near ">>>>>>>"
+Version control conflict marker at - line 1, near "<CONFLICT<"
+Version control conflict marker at - line 3, near "=CONFLICT="
+Version control conflict marker at - line 5, near ">CONFLICT>"
 Execution of - aborted due to compilation errors.
 ########
 # NAME (Might be a runaway multi-line...) with Latin-1 delimiters in utf8

--- a/t/test.pl
+++ b/t/test.pl
@@ -1348,6 +1348,11 @@ sub run_multiple_progs {
 
         s/^# NOTE.*\n//mg; # remove any NOTE comments in the content
 
+        # unhide conflict markers - we hide them so that naive
+        # conflict marker detection logic doesn't get upset with our
+        # tests.
+        s/([<=>])CONFLICT\1/$1 x 7/ge;
+
 	my ($prog, $expected) = split(/\nEXPECT(?:\n|$)/, $_, 2);
 
 	my %reason;

--- a/t/test.pl
+++ b/t/test.pl
@@ -1345,6 +1345,9 @@ sub run_multiple_progs {
 	if (s/^(\s*-\w+)//) {
 	    $switch = $1;
 	}
+
+        s/^# NOTE.*\n//mg; # remove any NOTE comments in the content
+
 	my ($prog, $expected) = split(/\nEXPECT(?:\n|$)/, $_, 2);
 
 	my %reason;


### PR DESCRIPTION
It turns out that some tooling (Game of Trees) has special handling for conflict markers and will continually mark files that have them.

Since the test doesn't actually need them to be expanded, calculate them instead to not trigger the detection.

https://marc.gameoftrees.org/mail/1676484047.9764_0.html