### PR TITLE
Fix multiple "maybe-uninitialized" warnings from GCC 12 

### DIFF
--- a/dist/Devel-PPPort/PPPort_pm.PL
+++ b/dist/Devel-PPPort/PPPort_pm.PL
@@ -756,7 +756,7 @@ package Devel::PPPort;
 use strict;
 use vars qw($VERSION $data);
 
-$VERSION = '3.69';
+$VERSION = '3.70';
 
 sub _init_data
 {

--- a/dist/Devel-PPPort/parts/inc/misc
+++ b/dist/Devel-PPPort/parts/inc/misc
@@ -1175,10 +1175,10 @@ newXS("Devel::PPPort::dAXMARK", XS_Devel__PPPort_dAXMARK, file);
 int
 OpSIBLING_tests()
 	PREINIT:
-		OP *x;
-		OP *kid;
-		OP *middlekid;
-		OP *lastkid;
+		OP *x = NULL;
+		OP *kid = NULL;
+		OP *middlekid = NULL;
+		OP *lastkid = NULL;
 		int count = 0;
 		int failures = 0;
 		int i;

--- a/ext/mro/mro.pm
+++ b/ext/mro/mro.pm
@@ -12,7 +12,7 @@ use warnings;
 
 # mro.pm versions < 1.00 reserved for MRO::Compat
 #  for partial back-compat to 5.[68].x
-our $VERSION = '1.27';
+our $VERSION = '1.28';
 
 require XSLoader;
 XSLoader::load('mro');

--- a/ext/mro/mro.xs
+++ b/ext/mro/mro.xs
@@ -505,7 +505,6 @@ mro__nextcan(...)
         cxix = __dopoptosub_at(ccstack, cxix);
         for (;;) {
 	    GV* cvgv;
-	    STRLEN fq_subname_len;
 
             /* we may be in a higher stacklevel, so dig down deeper */
             while (cxix < 0) {
@@ -546,19 +545,14 @@ mro__nextcan(...)
 
 	    if(SvPOK(sv)) {
 		fq_subname = SvPVX(sv);
-		fq_subname_len = SvCUR(sv);
-
-                subname_utf8 = SvUTF8(sv) ? 1 : 0;
 		subname = strrchr(fq_subname, ':');
-	    } else {
-		subname = NULL;
-	    }
-
+            }
             if(!subname)
                 Perl_croak(aTHX_ "next::method/next::can/maybe::next::method cannot find enclosing method");
 
+            subname_utf8 = SvUTF8(sv) ? 1 : 0;
             subname++;
-            subname_len = fq_subname_len - (subname - fq_subname);
+            subname_len = SvCUR(sv) - (subname - fq_subname);
             if(memEQs(subname, subname_len, "__ANON__")) {
                 cxix = __dopoptosub_at(ccstack, cxix - 1);
                 continue;

--- a/toke.c
+++ b/toke.c
@@ -12101,7 +12101,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
                     NV nv_mult = 1.0;
 #endif
                     bool accumulate = TRUE;
-                    U8 b;
+                    U8 b = 0; /* silence compiler warning */
                     int lim = 1 << shift;
                     for (h++; ((isXDIGIT(*h) && (b = XDIGIT_VALUE(*h)) < lim) ||
                                *h == '_'); h++) {


### PR DESCRIPTION
This fixes most of the issues raised in https://github.com/Perl/perl5/issues/20816

Basically gcc 12 raises lots of bogus "maybe uninitialized" warnings, and it produces relatively useless diagnostic information about them as well, omitting for instance the location of the thing they are warning about, but including irrelevant header information about them at the same time.  The principle virtue of these warnings seems to be that when it does warn the code is at least cryptic, even if it isnt strictly speaking wrong. Making things less cryptic, or initializing variables an extra time doesnt seem to be a big deal.
