### PR TITLE
Correct "equivelent" in two more places


### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -744,7 +744,7 @@ endif
 endif
 
 # Avoid __intel_new_proc_init link error for libircmt.
-# libmmd is /MD equivelent, other variants exist.
+# libmmd is /MD equivalent, other variants exist.
 # libmmd is Intel C's math addon funcs to MS CRT, contains long doubles, C99,
 # and optimized C89 funcs
 ifeq ($(__ICC),define)

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -504,7 +504,7 @@ LIBBASEFILES	= $(LIBBASEFILES) msvcrt.lib vcruntime.lib
 !ENDIF
 
 # Avoid __intel_new_proc_init link error for libircmt.
-# libmmd is /MD equivelent, other variants exist.
+# libmmd is /MD equivalent, other variants exist.
 # libmmd is Intel C's math addon funcs to MS CRT, contains long doubles, C99,
 # and optimized C89 funcs
 !IF "$(__ICC)" == "define"


### PR DESCRIPTION
This PR follows dab4006c92d70a54e7909d0e670b71bfd3fb8221,

and ends the misspelling distribution-wide

remaining in two Windows-related files
