### PR TITLE
warnings::register - simplify use of caller

### DIFF
--- a/lib/warnings/register.pm
+++ b/lib/warnings/register.pm
@@ -1,6 +1,5 @@
-package warnings::register;
+package warnings::register 1.05;
 
-our $VERSION = '1.04';
 require warnings;
 
 # left here as cruft in case other users were using this undocumented routine
@@ -19,7 +18,7 @@ sub import
     shift;
     my @categories = @_;
 
-    my $package = (caller(0))[0];
+    my $package = caller;
     warnings::register_categories($package);
 
     warnings::register_categories($package . "::$_") for @categories;


### PR DESCRIPTION
caller in scalar context does much less work so not only is this easier to read, it should be a tad faster.

And for good measure, switch to the modern version declaration while bumping.