### PR TITLE
utf8.h: Rmv improper (STRLEN) cast

### DIFF
--- a/utf8.h
+++ b/utf8.h
@@ -106,7 +106,7 @@ typedef enum {
                                         matter */
     UTF8NESS_YES              =  2,  /* Defintely is UTF-8, wideness
                                         unspecified */
-    UTF8NESS_UNKNOWN = (STRLEN) -1,  /* Undetermined so far */
+    UTF8NESS_UNKNOWN          = -1,  /* Undetermined so far */
 } utf8ness_t;
 
 /* Use UTF-8 as the default script encoding?


### PR DESCRIPTION
An enum is supposed to be an int.  STRLEN may be too large for that.  (I suspect the cast was inadvertently left in converting from an earlier implementation that was never released.)

Spotted by H. Merijn Brand.