### PR TITLE
Fix a variety of build warnings, some clang related, some 32-bit build related, some from the ppport.h enable

### DIFF
--- a/class.c
+++ b/class.c
@@ -552,7 +552,7 @@ apply_class_attribute_isa(pTHX_ HV *stash, SV *value)
         if(!aux->xhv_class_adjust_blocks)
             aux->xhv_class_adjust_blocks = newAV();
 
-        for(U32 i = 0; i <= AvFILL(superaux->xhv_class_adjust_blocks); i++)
+        for(SSize_t i = 0; i <= AvFILL(superaux->xhv_class_adjust_blocks); i++)
             av_push(aux->xhv_class_adjust_blocks, AvARRAY(superaux->xhv_class_adjust_blocks)[i]);
     }
 
@@ -696,7 +696,7 @@ Perl_class_seal_stash(pTHX_ HV *stash)
 
         PADNAMELIST *fieldnames = aux->xhv_class_fields;
 
-        for(U32 i = 0; fieldnames && i <= PadnamelistMAX(fieldnames); i++) {
+        for(SSize_t i = 0; fieldnames && i <= PadnamelistMAX(fieldnames); i++) {
             PADNAME *pn = PadnamelistARRAY(fieldnames)[i];
             char sigil = PadnamePV(pn)[0];
             PADOFFSET fieldix = PadnameFIELDINFO(pn)->fieldix;

--- a/dist/Time-HiRes/HiRes.pm
+++ b/dist/Time-HiRes/HiRes.pm
@@ -50,7 +50,7 @@ our @EXPORT_OK = qw (usleep sleep ualarm alarm gettimeofday time tv_interval
                  stat lstat utime
                 );
 
-our $VERSION = '1.9773';
+our $VERSION = '1.9774';
 our $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 

--- a/dist/Time-HiRes/HiRes.xs
+++ b/dist/Time-HiRes/HiRes.xs
@@ -19,7 +19,9 @@ extern "C" {
 #include "perl.h"
 #include "XSUB.h"
 #include "reentr.h"
+#if !defined(IS_SAFE_PATHNAME) && defined(TIME_HIRES_UTIME) && defined(HAS_UTIMENSAT)
 #define NEED_ck_warner
+#endif
 #include "ppport.h"
 #if defined(__CYGWIN__) && defined(HAS_W32API_WINDOWS_H)
 #  include <w32api/windows.h>

--- a/dump.c
+++ b/dump.c
@@ -2685,7 +2685,7 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
                  * show one more than we have nparens. */
                 for(n = 0; n <= r->nparens; n++) {
                     sv_catpvf(d,"%" IVdf ":%" IVdf "%s",
-                        r->offs[n].start, r->offs[n].end,
+                        (IV)(r->offs[n].start), (IV)(r->offs[n].end),
                         n+1 > r->nparens ? " ]\n" : ", ");
                 }
                 Perl_dump_indent(aTHX_ level, file, "    %" SVf, d);

--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.30';
+our $VERSION = '1.31';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -7609,9 +7609,9 @@ test_siphash24()
             if (hash32 != vectors_32[i]) {
                 failed++;
                 printf( "Error in 32 bit result on test vector of length %d for siphash24\n"
-                        "    have: 0x%08x\n"
-                        "    want: 0x%08x\n",
-                    i, hash32, vectors_32[i]);
+                        "    have: 0x%08" UVxf "\n"
+                        "    want: 0x%08" UVxf "\n",
+                    i, (UV)hash32, (UV)vectors_32[i]);
             }
         }
         RETVAL= failed;
@@ -7830,9 +7830,9 @@ test_siphash13()
             if (hash32 != vectors_32[i]) {
                 failed++;
                 printf( "Error in 32 bit result on test vector of length %d for siphash13\n"
-                        "    have: 0x%08x\n"
-                        "    want: 0x%08x\n",
-                    i, hash32, vectors_32[i]);
+                        "    have: 0x%08" UVxf"\n"
+                        "    want: 0x%08" UVxf"\n",
+                    i, (UV)hash32, (UV)vectors_32[i]);
             }
         }
         RETVAL= failed;

--- a/regcomp.c
+++ b/regcomp.c
@@ -2279,10 +2279,6 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
             RExC_parno_to_logical_next[parno]= RExC_logical_to_parno[logical_parno];
             RExC_logical_to_parno[logical_parno] = parno;
         }
-        if (0)
-        for( int parno = 1; parno < RExC_total_parens ; parno++ )
-            PerlIO_printf(Perl_debug_log,"%d -> %d -> %d\n",
-                    parno, RExC_parno_to_logical[parno], RExC_parno_to_logical_next[parno]);
         RExC_rx->logical_to_parno = RExC_logical_to_parno;
         RExC_rx->parno_to_logical = RExC_parno_to_logical;
         RExC_rx->parno_to_logical_next = RExC_parno_to_logical_next;


### PR DESCRIPTION
I originally set out to see if I could replicate https://github.com/Perl/perl5/issues/20851 by building with 32 bit clang. But I could replicate that issue, but I did find these build warnings.

```
git diff --stat origin/blead
 class.c                   |  4 ++--
 dist/Time-HiRes/HiRes.pm  |  2 +-
 dist/Time-HiRes/HiRes.xs  |  2 ++
 dump.c                    |  2 +-
 ext/XS-APItest/APItest.pm |  2 +-
 ext/XS-APItest/APItest.xs | 12 ++++++------
 regcomp.c                 |  4 ++--
 7 files changed, 15 insertions(+), 13 deletions(-)
```
