### PR TITLE
POSIX.xs: Silence compiler warning

### DIFF
--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -1560,10 +1560,6 @@ END_EXTERN_C
 #endif
 #endif
 
-#if ! defined(HAS_LOCALECONV) && ! defined(HAS_LOCALECONV_L)
-#   define localeconv() not_here("localeconv")
-#endif /* HAS_LOCALECONV */
-
 #ifdef HAS_LONG_DOUBLE
 #  if LONG_DOUBLESIZE > NVSIZE
 #    undef HAS_LONG_DOUBLE  /* XXX until we figure out how to use them */
@@ -2062,7 +2058,8 @@ HV *
 localeconv()
     CODE:
 #ifndef HAS_LOCALECONV
-	localeconv(); /* A stub to call not_here(). */
+        RETVAL = NULL;
+        not_here("localeconv");
 #else
         RETVAL = Perl_localeconv(aTHX);
 #endif  /* HAS_LOCALECONV */

--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our ($AUTOLOAD, %SIGRT);
 
-our $VERSION = '2.11';
+our $VERSION = '2.12';
 
 require XSLoader;
 

--- a/ext/POSIX/lib/POSIX.pod
+++ b/ext/POSIX/lib/POSIX.pod
@@ -1840,7 +1840,7 @@ about these and the other arguments.
 
 If you want your code to be portable, your format (C<fmt>) argument
 should use only the conversion specifiers defined by the ANSI C
-standard (C89, to play safe).  These are C<aAbBcdHIjmMpSUwWxXyYZ%>.
+standard (C99, to play safe).  These are C<aAbBcdHIjmMpSUwWxXyYZ%>.
 But even then, the B<results> of some of the conversion specifiers are
 non-portable.  For example, the specifiers C<aAbBcpZ> change according
 to the locale settings of the user, and both how to set locales (the


### PR DESCRIPTION
This happens only in the unlikely event that localeconv() isn't present
on the system.

There are two ways used in this file to announce the lack of system.
This commit converts to the other way than previously, and the warning
goes away.