### PR TITLE
dist/I18N-LangTags - Add Makefile.PL from CPAN

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3788,10 +3788,11 @@ dist/FindBin/lib/FindBin.pm			Find name of currently executing program
 dist/FindBin/t/FindBin.t			See if FindBin works
 dist/I18N-Collate/lib/I18N/Collate.pm		Routines to do strxfrm-based collation
 dist/I18N-Collate/t/I18N-Collate.t		See if I18N::Collate works
-dist/I18N-LangTags/ChangeLog			I18N::LangTags
+dist/I18N-LangTags/ChangeLog			I18N::LangTags change history
 dist/I18N-LangTags/lib/I18N/LangTags.pm		I18N::LangTags
 dist/I18N-LangTags/lib/I18N/LangTags/Detect.pm	Detect language preferences
 dist/I18N-LangTags/lib/I18N/LangTags/List.pm	List of tags for human languages
+dist/I18N-LangTags/Makefile.PL			Build I18N::LangTags
 dist/I18N-LangTags/README			I18N::LangTags
 dist/I18N-LangTags/t/01_about_verbose.t		See whether I18N::LangTags works
 dist/I18N-LangTags/t/05_main.t			See whether I18N::LangTags works

--- a/dist/I18N-LangTags/.gitignore
+++ b/dist/I18N-LangTags/.gitignore
@@ -1,0 +1,1 @@
+!/Makefile.PL

--- a/dist/I18N-LangTags/Makefile.PL
+++ b/dist/I18N-LangTags/Makefile.PL
@@ -1,0 +1,27 @@
+use ExtUtils::MakeMaker;
+# See lib/ExtUtils/MakeMaker.pm for details of how to influence
+# the contents of the Makefile that is written.
+
+WriteMakefile(
+    'NAME'	    => 'I18N::LangTags',
+    'VERSION_FROM'  => 'lib/I18N/LangTags.pm', # finds $VERSION
+    'ABSTRACT_FROM' => 'lib/I18N/LangTags.pm', # 
+    'dist'          => { COMPRESS => 'gzip -6f', SUFFIX => 'gz', },
+    'PREREQ_PM'     => {	
+                         $^O =~ m/Win32/i ? (
+			    'Win32::Locale' => 0.01,
+					   ) : (),
+	               },
+    'INSTALLDIRS'   => ( $] < 5.011 ? 'perl' : 'site' ),
+);
+
+package MY;
+
+sub libscan
+{ # Determine things that should *not* be installed
+    my($self, $path) = @_;
+    return '' if $path =~ m/~/;
+    $path;
+}
+
+__END__


### PR DESCRIPTION
For some reason the CPAN module is not properly indexed. It is https://metacpan.org/release/SBURKE/I18N-LangTags-0.35.

This fixes this module for https://github.com/Perl/perl5/issues/20874