### PR TITLE
dist/Net-Ping - add missing build artifacts

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3901,6 +3901,7 @@ dist/Module-CoreList/t/pod.t			Module::CoreList tests
 dist/Module-CoreList/t/utils.t			Module::CoreList tests
 dist/Net-Ping/Changes			Net::Ping
 dist/Net-Ping/lib/Net/Ping.pm		Hello, anybody home?
+dist/Net-Ping/Makefile.PL		Build Net::Ping
 dist/Net-Ping/t/000_load.t
 dist/Net-Ping/t/001_new.t
 dist/Net-Ping/t/010_pingecho.t
@@ -3921,6 +3922,7 @@ dist/Net-Ping/t/500_ping_icmp.t		Ping Net::Ping
 dist/Net-Ping/t/501_ping_icmpv6.t	Ping Net::Ping
 dist/Net-Ping/t/510_ping_udp.t		Ping Net::Ping
 dist/Net-Ping/t/520_icmp_ttl.t		Ping Net::Ping
+dist/Net-Ping/TODO			TODO list for Net::Ping
 dist/PathTools/Changes			Changelog for PathTools dist
 dist/PathTools/Cwd.pm				Various cwd routines (getcwd, fastcwd, chdir)
 dist/PathTools/Cwd.xs				Cwd extension external subroutines

--- a/dist/Net-Ping/.gitignore
+++ b/dist/Net-Ping/.gitignore
@@ -1,0 +1,1 @@
+!/Makefile.PL

--- a/dist/Net-Ping/Makefile.PL
+++ b/dist/Net-Ping/Makefile.PL
@@ -1,0 +1,75 @@
+use strict;
+use warnings;
+use v5.002; # not using our in the CPAN release
+use ExtUtils::MakeMaker;
+
+my @extras = ();
+my $EUMM_VER = $ExtUtils::MakeMaker::VERSION;
+my @AUTHORS = (
+      'Reini Urban <rurban@cpan.org>',
+      'Steve Peters <steve@fisharerojo.org>',
+      'Matthew Musgrove <mr.muskrat@gmail.com>',
+      'Karl Williamson <khw@cpan.org>',
+      'Brian Fraser <fraserbn@gmail.com>',
+      'Mark Gardner <mjgardner@cpan.org>',
+  );
+
+push @extras,
+  AUTHOR => join(", ", @AUTHORS)
+  if $EUMM_VER gt '5.4301' and $EUMM_VER lt '6.57_02';
+push @extras,
+  AUTHOR => [ @AUTHORS ]
+  if $EUMM_VER ge '6.57_02';
+push @extras, SIGN => 1
+  if $EUMM_VER ge '6.18';
+push @extras, LICENSE => 'perl_5'
+  if $EUMM_VER ge '6.31' and $EUMM_VER le '6.46';
+push @extras,
+  META_MERGE => {
+      'meta-spec' => { version => 2 },
+        resources   => {
+            # TODO: 26 old issues still open at RT
+            # https://rt.cpan.org/Public/Dist/Display.html?Name=Net-Ping
+            bugtracker  => 'https://github.com/Perl/perl5/issues',
+            repository  => {
+                type => 'git',
+                url => 'https://github.com/Perl/perl5.git',
+                web => 'https://github.com/Perl/perl5',
+            },
+            license     => [ 'http://dev.perl.org/licenses/' ],
+        },
+        release_status => 'stable',
+  }
+  if $EUMM_VER gt '6.46';
+
+WriteMakefile(
+  NAME   => 'Net::Ping',
+  VERSION_FROM  => 'lib/Net/Ping.pm',
+  ABSTRACT_FROM => 'lib/Net/Ping.pm',
+  PREREQ_PM     => {
+    'Socket'      => '2.007',
+    'Test::More'  => 0,
+    'Time::HiRes' => 0,
+  },
+  TEST_REQUIRES => {
+    'Test::Pod'           => '1.22',
+    'Test::More'          => 0,
+  },
+  INSTALLDIRS => ( $] < 5.011 ? 'perl' : 'site' ),
+  clean      => { FILES => 'Net-Ping-*' },
+  @extras
+);
+
+package MY;
+
+sub depend {
+  "
+README : lib/Net/Ping.pm
+	pod2text lib/Net/Ping.pm > README
+release : dist
+	git tag \$(VERSION)
+	cpan-upload \$(DISTVNAME).tar\$(SUFFIX)
+	git push
+	git push --tags
+"
+}

--- a/dist/Net-Ping/TODO
+++ b/dist/Net-Ping/TODO
@@ -1,0 +1,34 @@
+TODO list for Net::Ping (in case anyone is looking for things to do)
+
+- More IPv6 support
+Some options like IP_TOS and IP_TTL are not available on IPv6
+
+- POD rewriting
+Some things, such as the return from $p->ping(), are cryptic.  The location of the
+source is off as well.
+
+- Device
+Setting the device uses SO_BINDTODEVICE.  This is Linux-only and should not work anywhere
+else.  I think deprecating this is probably the right thing to do.
+
+-TOS
+The incoming TOS value can be just about anything from my testing.  This valid values are
+supposed to be (in decimal) 0, 1, 2, 4, and 8 assuming we aren't talking DS and ECN.
+I don't know right now if this is a bug in Socket, Darwin (tesing on Mac OS X currently)
+or if that's just the way it is.  Time for some C level testing for this one.
+P.S. TOS is IPv4 only.
+
+- Tests
+Nicholas Clark converted the tests to Test::More which is a good start.  The tests need some
+cleanup and modernizing.  Below is the current test coverage when testing as root.
+
+----------------------------------- ------ ------ ------ ------ ------ ------
+File                                  stmt   bran   cond    sub   time  total
+----------------------------------- ------ ------ ------ ------ ------ ------
+blib/lib/Net/Ping.pm                  62.6   42.8   33.0   76.9  100.0   52.6
+Total                                 62.6   42.8   33.0   76.9  100.0   52.6
+----------------------------------- ------ ------ ------ ------ ------ ------
+
+This needs to be quite a bit higher all around to make me comfortable with a refactor.
+
+


### PR DESCRIPTION
Files copied from https://github.com/rurban/Net-Ping

This fixes the module for https://github.com/Perl/perl5/issues/20874