### PR TITLE
 mg.c: Split out functionality to a separate function

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1197,6 +1197,8 @@ eop	|void	|get_db_sub	|NULLOK SV **svp			\
 				|NN CV *cv
 ERTXp	|const char *|get_deprecated_property_msg			\
 				|const Size_t warning_offset
+: Used in mg.c
+Tp	|int	|get_extended_os_errno
 : Only used in perl.c
 p	|void	|get_hash_seed	|NN unsigned char * const seed_buffer
 AOdp	|HV *	|get_hv 	|NN const char *name			\

--- a/embed.h
+++ b/embed.h
@@ -926,6 +926,7 @@
 #   define find_script(a,b,c,d)                 Perl_find_script(aTHX_ a,b,c,d)
 #   define force_locale_unlock                  Perl_force_locale_unlock
 #   define free_tied_hv_pool()                  Perl_free_tied_hv_pool(aTHX)
+#   define get_extended_os_errno                Perl_get_extended_os_errno
 #   define get_hash_seed(a)                     Perl_get_hash_seed(aTHX_ a)
 #   define get_no_modify()                      Perl_get_no_modify(aTHX)
 #   define get_opargs()                         Perl_get_opargs(aTHX)

--- a/mg.c
+++ b/mg.c
@@ -916,7 +916,7 @@ Perl_magic_get(pTHX_ SV *sv, MAGIC *mg)
             sv_setnv(sv, (NV)errno);
             if (errno) {
                 utf8ness_t utf8ness;
-                const char * errstr = my_strerror(errnum, &utf8ness);
+                const char * errstr = my_strerror(errno, &utf8ness);
 
                 sv_setpv(sv, errstr);
 

--- a/proto.h
+++ b/proto.h
@@ -1223,6 +1223,11 @@ Perl_get_deprecated_property_msg(const Size_t warning_offset)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GET_DEPRECATED_PROPERTY_MSG
 
+PERL_CALLCONV int
+Perl_get_extended_os_errno(void)
+        __attribute__visibility__("hidden");
+#define PERL_ARGS_ASSERT_GET_EXTENDED_OS_ERRNO
+
 PERL_CALLCONV void
 Perl_get_hash_seed(pTHX_ unsigned char * const seed_buffer)
         __attribute__visibility__("hidden");


### PR DESCRIPTION


This commit creates a function that gets the extended errno on systems
(such as VMS and Windows) that have that, returning plain errno on
systems that don't.  Previously this code was interweaved into code with
a larger purpose.  The splitting makes it possible for other code that
just wants the errno to get it.

The new function is callable from elsewhere in core, but remains private
for now.  In principal it could be documented and made public if needed.