### PR TITLE
Trig.pm: Don't negatively judge Siberia in pod

### DIFF
--- a/dist/Math-Complex/lib/Math/Trig.pm
+++ b/dist/Math-Complex/lib/Math/Trig.pm
@@ -675,7 +675,7 @@ The midpoint between London and Tokyo being
     sub SWNE { rad2deg( $_[0] ), 90 - rad2deg( $_[1] ) }
     my @lonlat = SWNE(@M);
 
-or about 69 N 89 E, in the frozen wastes of Siberia.
+or about 69 N 89 E, on the Putorana Plateau of Siberia.
 
 B<NOTE>: you B<cannot> get from A to B like this:
 


### PR DESCRIPTION
The pod referred to a point as being in "frozen wastes".  But that judgement is a distraction from the point of the text, and not actually true.

I looked at the spot in Google Maps.  This area in the summer is
verdant, with many rivers and lakes.   It is part of the
https://en.wikipedia.org/wiki/Putorana_Plateau.  The closest place I
could (without expending much effort) find a non-satellite photograph
of is 60km away:

https://en.wikipedia.org/wiki/File:Putorana2._Lama_lake..jpg

Doesn't seem like a wasteland to me.

And for history buffs, the plateau contains part of the Siberian Traps, remnants of volanic eruptions generally implicated as a cause of the largest known extinction event, terminating the Permian.