### PR TITLE
Permit internal OP_GOTO when forbidding out-of-block ops

### DIFF
--- a/t/class/field.t
+++ b/t/class/field.t
@@ -282,4 +282,19 @@ no warnings 'experimental::class';
         'Values for missing');
 }
 
+# field initialiser expressions permit `goto` in do {} blocks
+{
+    class Test13 {
+        field $forwards = do { goto HERE; HERE: 1 };
+        field $backwards = do { my $x; HERE: ; goto HERE if !$x++; 2 };
+
+        method values { return ($forwards, $backwards) }
+    }
+
+    ok(eq_array(
+        [Test13->new->values],
+        [1, 2],
+        'Values for goto inside do {} blocks in field initialisers'));
+}
+
 done_testing;

--- a/t/op/defer.t
+++ b/t/op/defer.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan 26;
+plan 28;
 
 use feature 'defer';
 no warnings 'experimental::defer';
@@ -249,6 +249,17 @@ no warnings 'experimental::defer';
     #   We should consider what the behaviour ought to be here
     # This test is happy for either exception to be seen, does not care which
     like($e, qr/^Oopsie \d\n/, 'defer block can throw exception during exception unwind');
+}
+
+# goto
+{
+    ok(defined eval 'sub { defer { goto HERE; HERE: 1; } }',
+        'goto forwards within defer {} is permitted') or
+        diag("Failure was $@");
+
+    ok(defined eval 'sub { defer { HERE: 1; goto HERE; } }',
+        'goto backwards within defer {} is permitted') or
+        diag("Failure was $@");
 }
 
 {


### PR DESCRIPTION
`forbid_outofblock_ops()` is used by `defer {}`, `finally {}`, and class field-initialiser expressions to ensure that control flow won't leave the expression or block being used.

The current implementation is overly-restrictive and forbids any `OP_GOTO`.

This change permits a `goto` with a constant target statically determined to be within the same block, as these will be fine. (This is the same test code copied from my CPAN modules `Syntax::Keyword::Defer` and `Object::Pad`)