### PR TITLE
locale.c: Remove one use of nl_langinfo_l()

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -751,7 +751,8 @@ S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char * locale)
       * all instances of that have been removed */
 #    define QUERYLOCALE_ASSERT(index)                                       \
                         __ASSERT_(isSINGLE_BIT_SET(category_masks[index]))
-#    if ! defined(HAS_QUERYLOCALE) && defined(_NL_LOCALE_NAME)
+#    if ! defined(HAS_QUERYLOCALE) && (   defined(_NL_LOCALE_NAME)          \
+                                       && defined(HAS_NL_LANGINFO_L))
 #      define querylocale_l(index, locale_obj)                              \
             (QUERYLOCALE_ASSERT(index)                                      \
              mortalized_pv_copy(nl_langinfo_l(                              \
@@ -4169,36 +4170,8 @@ S_my_langinfo_i(pTHX_
  * implementation doesn't currently worry about it.  But it is a problem on
  * Windows boxes, which don't have nl_langinfo(). */
 
-#  if defined(HAS_THREAD_SAFE_NL_LANGINFO_L) && defined(USE_POSIX_2008_LOCALE)
-
-    /* Simplest is if we can use nl_langinfo_l()
-     *
-     * With it, we can change LC_CTYPE in the same call as the other category */
-#    ifdef USE_LOCALE_CTYPE
-#      define CTYPE_SAFETY_MASK LC_CTYPE_MASK
-#    else
-#      define CTYPE_SAFETY_MASK 0
-#    endif
-
-    locale_t cur = newlocale((category_masks[cat_index] | CTYPE_SAFETY_MASK),
-                             locale, (locale_t) 0);
-
-    retval = save_to_buffer(nl_langinfo_l(item, cur), retbufp, retbuf_sizep);
-
-    if (utf8ness) {
-        *utf8ness = get_locale_string_utf8ness_i(retval,
-                                                 LOCALE_UTF8NESS_UNKNOWN,
-                                                 locale, cat_index);
-    }
-
-    freelocale(cur);
-
-    return retval;
 /*--------------------------------------------------------------------------*/
-#  elif defined(HAS_NL_LANGINFO) /* nl_langinfo() is available.  */
-
-    /* The second version of my_langinfo() is if we have plain nl_langinfo() */
-
+#  if defined(HAS_NL_LANGINFO) /* nl_langinfo() is available.  */
 #    ifdef USE_LOCALE_CTYPE
 
     /* Ths function sorts out if things actually have to be switched or not,

--- a/perl.h
+++ b/perl.h
@@ -1260,17 +1260,19 @@ violations are fatal.
 
 #  include "perl_langinfo.h"    /* Needed for _NL_LOCALE_NAME */
 
-/* Allow use of glibc's undocumented querylocale() equivalent if asked for, and
- * appropriate */
 #  ifdef USE_POSIX_2008_LOCALE
 #    if  defined(HAS_QUERYLOCALE)                                           \
-              /* Has this internal undocumented item for nl_langinfo() */   \
+              /* Use querylocale if has it, or has the glibc internal       \
+               * undocumented equivalent. */                                \
      || (     defined(_NL_LOCALE_NAME)                                      \
               /* And asked for */                                           \
          &&   defined(USE_NL_LOCALE_NAME)                                   \
-              /* We need the below because we will be calling it within a   \
-               * macro, can't have it get messed up by another thread. */   \
-         &&   defined(HAS_THREAD_SAFE_NL_LANGINFO_L)                        \
+              /* nl_langinfo_l almost certainly will exist on systems that  \
+               * have _NL_LOCALE_NAME, so there is nothing lost by          \
+               * requiring it instead of also allowing plain nl_langinfo(). \
+               * And experience indicates that its glibc implementation is  \
+               * thread-safe, eliminating code complications */             \
+         &&   defined(HAS_NL_LANGINFO_L)                                    \
                /* On systems that accept any locale name, the real          \
                 * underlying locale is often returned by this internal      \
                 * item, so we can't use it */                               \


### PR DESCRIPTION
The limited POSIX guarantees of thread safety for nl_langinfo_l() aren't
enough for our uses, and I was naive to think that a simple Configure probe
could rule out all possible thread-safety issues that might exist in a
libc call.  I don't remember what the platforms were that falsely tested
ok for the probe, but if it were necessary to find out, revert this
patch, and start a smoke-me test.

What that Configure probe did was find one particular point of
non-safety.  And it turns out various platforms pass that, but don't
have a thread-safe nl_langinfo_l() generally.

There are two calls to nl_langinfo_l() in the code.  This commit removes
one, where the major advantage of using nl_langinfo_l() over plain
nl_langinfo() was efficiency.  There still had to be an alternate
implementation available that used plain nl_langinfo().  Since we can't
guarantee that the _l implementation doesn't have bugs, simply remove
it, and the existing alternative gets automatically used.

The remaining use of nl_langinfo_l() is only when using glibc, and is
disabled by default, requiring an explicit Configure parameter to
enable.  I have never seen a case where the glibc implementation failed
to be thread-safe.  This use may be enabled by default at some point,
but not until early in a development cycle.