### PR TITLE
locale.c: Split a static function in two

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4310,6 +4310,8 @@ S	|void	|populate_hash_from_localeconv				\
 ST	|unsigned int|get_category_index				\
 				|const int category			\
 				|NULLOK const char *locale
+ST	|int	|get_category_index_nowarn				\
+				|const int category
 Ri	|const char *|mortalized_pv_copy				\
 				|NULLOK const char * const pv
 S	|void	|new_LC_ALL	|NULLOK const char *unused		\

--- a/embed.h
+++ b/embed.h
@@ -1263,6 +1263,7 @@
 #     endif /* defined(HAS_LOCALECONV) */
 #     if defined(USE_LOCALE)
 #       define get_category_index               S_get_category_index
+#       define get_category_index_nowarn        S_get_category_index_nowarn
 #       define mortalized_pv_copy(a)            S_mortalized_pv_copy(aTHX_ a)
 #       define new_LC_ALL(a,b)                  S_new_LC_ALL(aTHX_ a,b)
 #       define save_to_buffer                   S_save_to_buffer

--- a/locale.c
+++ b/locale.c
@@ -426,19 +426,16 @@ STATIC void (*update_functions[]) (pTHX_ const char *, bool force) = {
  * checked for at compile time by using the #define LC_ALL_INDEX_ which is only
  * defined if we do have LC_ALL. */
 
-STATIC unsigned int
-S_get_category_index(const int category, const char * locale)
+STATIC int
+S_get_category_index_nowarn(const int category)
 {
     /* Given a category, return the equivalent internal index we generally use
-     * instead.
-     *
-     * 'locale' is for use in any generated diagnostics, and may be NULL
+     * instead, or negative if not found.
      *
      * Some sort of hash could be used instead of this loop, but the number of
      * elements is so far at most 12 */
 
     unsigned int i;
-    const char * conditional_warn_text = "; can't set it to ";
 
     PERL_ARGS_ASSERT_GET_CATEGORY_INDEX;
 
@@ -455,6 +452,25 @@ S_get_category_index(const int category, const char * locale)
                                    category, category_names[i], i));
             return i;
         }
+    }
+
+    return -1;
+}
+
+STATIC unsigned int
+S_get_category_index(const int category, const char * locale)
+{
+    /* Given a category, return the equivalent internal index we generally use
+     * instead.
+     *
+     * 'locale' is for use in any generated diagnostics, and may be NULL
+     */
+
+    const char * conditional_warn_text = "; can't set it to ";
+    const int index = get_category_index_nowarn(category);
+
+    if (index >= 0) {
+        return index;
     }
 
     /* Here, we don't know about this category, so can't handle it. */

--- a/proto.h
+++ b/proto.h
@@ -7043,6 +7043,10 @@ STATIC unsigned int
 S_get_category_index(const int category, const char *locale);
 #   define PERL_ARGS_ASSERT_GET_CATEGORY_INDEX
 
+STATIC int
+S_get_category_index_nowarn(const int category);
+#   define PERL_ARGS_ASSERT_GET_CATEGORY_INDEX_NOWARN
+
 STATIC void
 S_new_LC_ALL(pTHX_ const char *unused, bool force);
 #   define PERL_ARGS_ASSERT_NEW_LC_ALL


### PR DESCRIPTION
A future commit will want to use just the first part of the function.