### PR TITLE
sync test simple with cpan (and fix minor oversight in new Porting/sync-with-cpan logic)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -2517,342 +2517,342 @@ cpan/Test-Harness/t/unicode.t					Test::Harness test
 cpan/Test-Harness/t/yamlish.t					Test::Harness test
 cpan/Test-Harness/t/yamlish-output.t				Test::Harness test
 cpan/Test-Harness/t/yamlish-writer.t				Test::Harness test
-cpan/Test-Simple/lib/ok.pm
-cpan/Test-Simple/lib/Test/Builder.pm
-cpan/Test-Simple/lib/Test/Builder/Formatter.pm
-cpan/Test-Simple/lib/Test/Builder/IO/Scalar.pm
-cpan/Test-Simple/lib/Test/Builder/Module.pm
-cpan/Test-Simple/lib/Test/Builder/Tester.pm
-cpan/Test-Simple/lib/Test/Builder/Tester/Color.pm
-cpan/Test-Simple/lib/Test/Builder/TodoDiag.pm
-cpan/Test-Simple/lib/Test/More.pm
-cpan/Test-Simple/lib/Test/Simple.pm
-cpan/Test-Simple/lib/Test/Tester.pm
-cpan/Test-Simple/lib/Test/Tester/Capture.pm
-cpan/Test-Simple/lib/Test/Tester/CaptureRunner.pm
-cpan/Test-Simple/lib/Test/Tester/Delegate.pm
-cpan/Test-Simple/lib/Test/Tutorial.pod
-cpan/Test-Simple/lib/Test/use/ok.pm
-cpan/Test-Simple/lib/Test2.pm
-cpan/Test-Simple/lib/Test2/API.pm
-cpan/Test-Simple/lib/Test2/API/Breakage.pm
-cpan/Test-Simple/lib/Test2/API/Context.pm
-cpan/Test-Simple/lib/Test2/API/Instance.pm
-cpan/Test-Simple/lib/Test2/API/InterceptResult.pm
-cpan/Test-Simple/lib/Test2/API/InterceptResult/Event.pm
-cpan/Test-Simple/lib/Test2/API/InterceptResult/Facet.pm
-cpan/Test-Simple/lib/Test2/API/InterceptResult/Hub.pm
-cpan/Test-Simple/lib/Test2/API/InterceptResult/Squasher.pm
-cpan/Test-Simple/lib/Test2/API/Stack.pm
-cpan/Test-Simple/lib/Test2/Event.pm
-cpan/Test-Simple/lib/Test2/Event/Bail.pm
-cpan/Test-Simple/lib/Test2/Event/Diag.pm
-cpan/Test-Simple/lib/Test2/Event/Encoding.pm
-cpan/Test-Simple/lib/Test2/Event/Exception.pm
-cpan/Test-Simple/lib/Test2/Event/Fail.pm
-cpan/Test-Simple/lib/Test2/Event/Generic.pm
-cpan/Test-Simple/lib/Test2/Event/Note.pm
-cpan/Test-Simple/lib/Test2/Event/Ok.pm
-cpan/Test-Simple/lib/Test2/Event/Pass.pm
-cpan/Test-Simple/lib/Test2/Event/Plan.pm
-cpan/Test-Simple/lib/Test2/Event/Skip.pm
-cpan/Test-Simple/lib/Test2/Event/Subtest.pm
-cpan/Test-Simple/lib/Test2/Event/TAP/Version.pm
-cpan/Test-Simple/lib/Test2/Event/V2.pm
-cpan/Test-Simple/lib/Test2/Event/Waiting.pm
-cpan/Test-Simple/lib/Test2/EventFacet.pm
-cpan/Test-Simple/lib/Test2/EventFacet/About.pm
-cpan/Test-Simple/lib/Test2/EventFacet/Amnesty.pm
-cpan/Test-Simple/lib/Test2/EventFacet/Assert.pm
-cpan/Test-Simple/lib/Test2/EventFacet/Control.pm
-cpan/Test-Simple/lib/Test2/EventFacet/Error.pm
-cpan/Test-Simple/lib/Test2/EventFacet/Hub.pm
-cpan/Test-Simple/lib/Test2/EventFacet/Info.pm
-cpan/Test-Simple/lib/Test2/EventFacet/Info/Table.pm
-cpan/Test-Simple/lib/Test2/EventFacet/Meta.pm
-cpan/Test-Simple/lib/Test2/EventFacet/Parent.pm
-cpan/Test-Simple/lib/Test2/EventFacet/Plan.pm
-cpan/Test-Simple/lib/Test2/EventFacet/Render.pm
-cpan/Test-Simple/lib/Test2/EventFacet/Trace.pm
-cpan/Test-Simple/lib/Test2/Formatter.pm
-cpan/Test-Simple/lib/Test2/Formatter/TAP.pm
-cpan/Test-Simple/lib/Test2/Hub.pm
-cpan/Test-Simple/lib/Test2/Hub/Interceptor.pm
-cpan/Test-Simple/lib/Test2/Hub/Interceptor/Terminator.pm
-cpan/Test-Simple/lib/Test2/Hub/Subtest.pm
-cpan/Test-Simple/lib/Test2/IPC.pm
-cpan/Test-Simple/lib/Test2/IPC/Driver.pm
-cpan/Test-Simple/lib/Test2/IPC/Driver/Files.pm
-cpan/Test-Simple/lib/Test2/Tools/Tiny.pm
-cpan/Test-Simple/lib/Test2/Transition.pod
-cpan/Test-Simple/lib/Test2/Util.pm
-cpan/Test-Simple/lib/Test2/Util/ExternalMeta.pm
-cpan/Test-Simple/lib/Test2/Util/Facets2Legacy.pm
-cpan/Test-Simple/lib/Test2/Util/HashBase.pm
-cpan/Test-Simple/lib/Test2/Util/Trace.pm
-cpan/Test-Simple/t/HashBase.t
-cpan/Test-Simple/t/Legacy/00test_harness_check.t
-cpan/Test-Simple/t/Legacy/01-basic.t
-cpan/Test-Simple/t/Legacy/478-cmp_ok_hash.t
-cpan/Test-Simple/t/Legacy/auto.t
-cpan/Test-Simple/t/Legacy/bad_plan.t
-cpan/Test-Simple/t/Legacy/bail_out.t
-cpan/Test-Simple/t/Legacy/BEGIN_require_ok.t
-cpan/Test-Simple/t/Legacy/BEGIN_use_ok.t
-cpan/Test-Simple/t/Legacy/buffer.t
-cpan/Test-Simple/t/Legacy/Bugs/600.t
-cpan/Test-Simple/t/Legacy/Bugs/629.t
-cpan/Test-Simple/t/Legacy/Builder/Builder.t
-cpan/Test-Simple/t/Legacy/Builder/carp.t
-cpan/Test-Simple/t/Legacy/Builder/create.t
-cpan/Test-Simple/t/Legacy/Builder/current_test.t
-cpan/Test-Simple/t/Legacy/Builder/current_test_without_plan.t
-cpan/Test-Simple/t/Legacy/Builder/details.t
-cpan/Test-Simple/t/Legacy/Builder/done_testing.t
-cpan/Test-Simple/t/Legacy/Builder/done_testing_double.t
-cpan/Test-Simple/t/Legacy/Builder/done_testing_plan_mismatch.t
-cpan/Test-Simple/t/Legacy/Builder/done_testing_with_no_plan.t
-cpan/Test-Simple/t/Legacy/Builder/done_testing_with_number.t
-cpan/Test-Simple/t/Legacy/Builder/done_testing_with_plan.t
-cpan/Test-Simple/t/Legacy/Builder/fork_with_new_stdout.t
-cpan/Test-Simple/t/Legacy/Builder/has_plan.t
-cpan/Test-Simple/t/Legacy/Builder/has_plan2.t
-cpan/Test-Simple/t/Legacy/Builder/is_fh.t
-cpan/Test-Simple/t/Legacy/Builder/is_passing.t
-cpan/Test-Simple/t/Legacy/Builder/maybe_regex.t
-cpan/Test-Simple/t/Legacy/Builder/no_diag.t
-cpan/Test-Simple/t/Legacy/Builder/no_ending.t
-cpan/Test-Simple/t/Legacy/Builder/no_header.t
-cpan/Test-Simple/t/Legacy/Builder/no_plan_at_all.t
-cpan/Test-Simple/t/Legacy/Builder/ok_obj.t
-cpan/Test-Simple/t/Legacy/Builder/output.t
-cpan/Test-Simple/t/Legacy/Builder/reset.t
-cpan/Test-Simple/t/Legacy/Builder/reset_outputs.t
-cpan/Test-Simple/t/Legacy/Builder/try.t
-cpan/Test-Simple/t/Legacy/c_flag.t
-cpan/Test-Simple/t/Legacy/capture.t
-cpan/Test-Simple/t/Legacy/check_tests.t
-cpan/Test-Simple/t/Legacy/circular_data.t
-cpan/Test-Simple/t/Legacy/cmp_ok.t
-cpan/Test-Simple/t/Legacy/depth.t
-cpan/Test-Simple/t/Legacy/diag.t
-cpan/Test-Simple/t/Legacy/died.t
-cpan/Test-Simple/t/Legacy/dont_overwrite_die_handler.t
-cpan/Test-Simple/t/Legacy/eq_set.t
-cpan/Test-Simple/t/Legacy/exit.t
-cpan/Test-Simple/t/Legacy/explain.t
-cpan/Test-Simple/t/Legacy/explain_err_vars.t
-cpan/Test-Simple/t/Legacy/extra.t
-cpan/Test-Simple/t/Legacy/extra_one.t
-cpan/Test-Simple/t/Legacy/fail.t
-cpan/Test-Simple/t/Legacy/fail-like.t
-cpan/Test-Simple/t/Legacy/fail-more.t
-cpan/Test-Simple/t/Legacy/fail_one.t
-cpan/Test-Simple/t/Legacy/filehandles.t
-cpan/Test-Simple/t/Legacy/fork.t
-cpan/Test-Simple/t/Legacy/harness_active.t
-cpan/Test-Simple/t/Legacy/import.t
-cpan/Test-Simple/t/Legacy/is_deeply_dne_bug.t
-cpan/Test-Simple/t/Legacy/is_deeply_fail.t
-cpan/Test-Simple/t/Legacy/is_deeply_with_threads.t
-cpan/Test-Simple/t/Legacy/missing.t
-cpan/Test-Simple/t/Legacy/More.t
-cpan/Test-Simple/t/Legacy/new_ok.t
-cpan/Test-Simple/t/Legacy/no_log_results.t
-cpan/Test-Simple/t/Legacy/no_plan.t
-cpan/Test-Simple/t/Legacy/no_tests.t
-cpan/Test-Simple/t/Legacy/note.t
-cpan/Test-Simple/t/Legacy/overload.t
-cpan/Test-Simple/t/Legacy/overload_threads.t
-cpan/Test-Simple/t/Legacy/plan.t
-cpan/Test-Simple/t/Legacy/plan_bad.t
-cpan/Test-Simple/t/Legacy/plan_is_noplan.t
-cpan/Test-Simple/t/Legacy/plan_no_plan.t
-cpan/Test-Simple/t/Legacy/plan_shouldnt_import.t
-cpan/Test-Simple/t/Legacy/plan_skip_all.t
-cpan/Test-Simple/t/Legacy/Regression/637.t
-cpan/Test-Simple/t/Legacy/Regression/683_thread_todo.t
-cpan/Test-Simple/t/Legacy/Regression/6_cmp_ok.t
-cpan/Test-Simple/t/Legacy/Regression/736_use_ok.t
-cpan/Test-Simple/t/Legacy/Regression/789-read-only.t
-cpan/Test-Simple/t/Legacy/Regression/870-experimental-warnings.t
-cpan/Test-Simple/t/Legacy/Regression/is_capture.t
-cpan/Test-Simple/t/Legacy/require_ok.t
-cpan/Test-Simple/t/Legacy/run_test.t
-cpan/Test-Simple/t/Legacy/simple.t
-cpan/Test-Simple/t/Legacy/Simple/load.t
-cpan/Test-Simple/t/Legacy/skip.t
-cpan/Test-Simple/t/Legacy/skipall.t
-cpan/Test-Simple/t/Legacy/strays.t
-cpan/Test-Simple/t/Legacy/subtest/args.t
-cpan/Test-Simple/t/Legacy/subtest/bail_out.t
-cpan/Test-Simple/t/Legacy/subtest/basic.t
-cpan/Test-Simple/t/Legacy/subtest/callback.t
-cpan/Test-Simple/t/Legacy/subtest/die.t
-cpan/Test-Simple/t/Legacy/subtest/do.t
-cpan/Test-Simple/t/Legacy/subtest/events.t
-cpan/Test-Simple/t/Legacy/subtest/for_do_t.test
-cpan/Test-Simple/t/Legacy/subtest/fork.t
-cpan/Test-Simple/t/Legacy/subtest/implicit_done.t
-cpan/Test-Simple/t/Legacy/subtest/line_numbers.t
-cpan/Test-Simple/t/Legacy/subtest/plan.t
-cpan/Test-Simple/t/Legacy/subtest/predicate.t
-cpan/Test-Simple/t/Legacy/subtest/singleton.t
-cpan/Test-Simple/t/Legacy/subtest/threads.t
-cpan/Test-Simple/t/Legacy/subtest/todo.t
-cpan/Test-Simple/t/Legacy/subtest/wstat.t
-cpan/Test-Simple/t/Legacy/tbm_doesnt_set_exported_to.t
-cpan/Test-Simple/t/Legacy/Test2/Subtest.t
-cpan/Test-Simple/t/Legacy/Tester/tbt_01basic.t
-cpan/Test-Simple/t/Legacy/Tester/tbt_02fhrestore.t
-cpan/Test-Simple/t/Legacy/Tester/tbt_03die.t
-cpan/Test-Simple/t/Legacy/Tester/tbt_04line_num.t
-cpan/Test-Simple/t/Legacy/Tester/tbt_05faildiag.t
-cpan/Test-Simple/t/Legacy/Tester/tbt_06errormess.t
-cpan/Test-Simple/t/Legacy/Tester/tbt_07args.t
-cpan/Test-Simple/t/Legacy/Tester/tbt_08subtest.t
-cpan/Test-Simple/t/Legacy/Tester/tbt_09do.t
-cpan/Test-Simple/t/Legacy/Tester/tbt_09do_script.pl
-cpan/Test-Simple/t/Legacy/thread_taint.t
-cpan/Test-Simple/t/Legacy/threads.t
-cpan/Test-Simple/t/Legacy/todo.t
-cpan/Test-Simple/t/Legacy/undef.t
-cpan/Test-Simple/t/Legacy/use_ok.t
-cpan/Test-Simple/t/Legacy/useing.t
-cpan/Test-Simple/t/Legacy/utf8.t
-cpan/Test-Simple/t/Legacy/versions.t
-cpan/Test-Simple/t/Legacy_And_Test2/builder_loaded_late.t
-cpan/Test-Simple/t/Legacy_And_Test2/diag_event_on_ok.t
-cpan/Test-Simple/t/Legacy_And_Test2/hidden_warnings.t
-cpan/Test-Simple/t/Legacy_And_Test2/preload_diag_note.t
-cpan/Test-Simple/t/Legacy_And_Test2/thread_init_warning.t
-cpan/Test-Simple/t/lib/Dev/Null.pm
-cpan/Test-Simple/t/lib/Dummy.pm
-cpan/Test-Simple/t/lib/MyOverload.pm
-cpan/Test-Simple/t/lib/MyTest.pm
-cpan/Test-Simple/t/lib/NoExporter.pm
-cpan/Test-Simple/t/lib/SigDie.pm
-cpan/Test-Simple/t/lib/SkipAll.pm
-cpan/Test-Simple/t/lib/SmallTest.pm
-cpan/Test-Simple/t/lib/Test/Builder/NoOutput.pm
-cpan/Test-Simple/t/lib/Test/Simple/Catch.pm
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/death.plx
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/death_in_eval.plx
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/death_with_handler.plx
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/exit.plx
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/extras.plx
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/five_fail.plx
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/last_minute_death.plx
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/missing_done_testing.plx
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/one_fail.plx
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/one_fail_without_plan.plx
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/pre_plan_death.plx
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/require.plx
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/success.plx
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/too_few.plx
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/too_few_fail.plx
-cpan/Test-Simple/t/lib/Test/Simple/sample_tests/two_fail.plx
-cpan/Test-Simple/t/lib/TieOut.pm
-cpan/Test-Simple/t/regression/642_persistent_end.t
-cpan/Test-Simple/t/regression/662-tbt-no-plan.t
-cpan/Test-Simple/t/regression/684-nested_todo_diag.t
-cpan/Test-Simple/t/regression/694_note_diag_return_values.t
-cpan/Test-Simple/t/regression/696-intercept_skip_all.t
-cpan/Test-Simple/t/regression/721-nested-streamed-subtest.t
-cpan/Test-Simple/t/regression/757-reset_in_subtest.t
-cpan/Test-Simple/t/regression/812-todo.t
-cpan/Test-Simple/t/regression/817-subtest-todo.t
-cpan/Test-Simple/t/regression/862-intercept_tb_todo.t
-cpan/Test-Simple/t/regression/buffered_subtest_plan_buffered.t
-cpan/Test-Simple/t/regression/builder_does_not_init.t
-cpan/Test-Simple/t/regression/errors_facet.t
-cpan/Test-Simple/t/regression/fork_first.t
-cpan/Test-Simple/t/regression/inherit_trace.t
-cpan/Test-Simple/t/regression/no_name_in_subtest.t
-cpan/Test-Simple/t/regression/skip_reason_object_ipc.t
-cpan/Test-Simple/t/regression/todo_and_facets.t
-cpan/Test-Simple/t/Test2/acceptance/try_it_done_testing.t
-cpan/Test-Simple/t/Test2/acceptance/try_it_fork.t
-cpan/Test-Simple/t/Test2/acceptance/try_it_no_plan.t
-cpan/Test-Simple/t/Test2/acceptance/try_it_plan.t
-cpan/Test-Simple/t/Test2/acceptance/try_it_skip.t
-cpan/Test-Simple/t/Test2/acceptance/try_it_threads.t
-cpan/Test-Simple/t/Test2/acceptance/try_it_todo.t
-cpan/Test-Simple/t/Test2/behavior/disable_ipc_a.t
-cpan/Test-Simple/t/Test2/behavior/disable_ipc_b.t
-cpan/Test-Simple/t/Test2/behavior/disable_ipc_c.t
-cpan/Test-Simple/t/Test2/behavior/disable_ipc_d.t
-cpan/Test-Simple/t/Test2/behavior/err_var.t
-cpan/Test-Simple/t/Test2/behavior/Formatter.t
-cpan/Test-Simple/t/Test2/behavior/init_croak.t
-cpan/Test-Simple/t/Test2/behavior/intercept.t
-cpan/Test-Simple/t/Test2/behavior/ipc_wait_timeout.t
-cpan/Test-Simple/t/Test2/behavior/nested_context_exception.t
-cpan/Test-Simple/t/Test2/behavior/no_load_api.t
-cpan/Test-Simple/t/Test2/behavior/run_subtest_inherit.t
-cpan/Test-Simple/t/Test2/behavior/special_names.t
-cpan/Test-Simple/t/Test2/behavior/subtest_bailout.t
-cpan/Test-Simple/t/Test2/behavior/Subtest_buffer_formatter.t
-cpan/Test-Simple/t/Test2/behavior/Subtest_callback.t
-cpan/Test-Simple/t/Test2/behavior/Subtest_events.t
-cpan/Test-Simple/t/Test2/behavior/Subtest_plan.t
-cpan/Test-Simple/t/Test2/behavior/Subtest_todo.t
-cpan/Test-Simple/t/Test2/behavior/Taint.t
-cpan/Test-Simple/t/Test2/behavior/trace_signature.t
-cpan/Test-Simple/t/Test2/behavior/uuid.t
-cpan/Test-Simple/t/Test2/legacy/TAP.t
-cpan/Test-Simple/t/Test2/modules/API.t
-cpan/Test-Simple/t/Test2/modules/API/Breakage.t
-cpan/Test-Simple/t/Test2/modules/API/Context.t
-cpan/Test-Simple/t/Test2/modules/API/Instance.t
-cpan/Test-Simple/t/Test2/modules/API/InterceptResult.t
-cpan/Test-Simple/t/Test2/modules/API/InterceptResult/Event.t
-cpan/Test-Simple/t/Test2/modules/API/InterceptResult/Squasher.t
-cpan/Test-Simple/t/Test2/modules/API/Stack.t
-cpan/Test-Simple/t/Test2/modules/Event.t
-cpan/Test-Simple/t/Test2/modules/Event/Bail.t
-cpan/Test-Simple/t/Test2/modules/Event/Diag.t
-cpan/Test-Simple/t/Test2/modules/Event/Encoding.t
-cpan/Test-Simple/t/Test2/modules/Event/Exception.t
-cpan/Test-Simple/t/Test2/modules/Event/Fail.t
-cpan/Test-Simple/t/Test2/modules/Event/Generic.t
-cpan/Test-Simple/t/Test2/modules/Event/Note.t
-cpan/Test-Simple/t/Test2/modules/Event/Ok.t
-cpan/Test-Simple/t/Test2/modules/Event/Pass.t
-cpan/Test-Simple/t/Test2/modules/Event/Plan.t
-cpan/Test-Simple/t/Test2/modules/Event/Skip.t
-cpan/Test-Simple/t/Test2/modules/Event/Subtest.t
-cpan/Test-Simple/t/Test2/modules/Event/TAP/Version.t
-cpan/Test-Simple/t/Test2/modules/Event/V2.t
-cpan/Test-Simple/t/Test2/modules/Event/Waiting.t
-cpan/Test-Simple/t/Test2/modules/EventFacet.t
-cpan/Test-Simple/t/Test2/modules/EventFacet/About.t
-cpan/Test-Simple/t/Test2/modules/EventFacet/Amnesty.t
-cpan/Test-Simple/t/Test2/modules/EventFacet/Assert.t
-cpan/Test-Simple/t/Test2/modules/EventFacet/Control.t
-cpan/Test-Simple/t/Test2/modules/EventFacet/Error.t
-cpan/Test-Simple/t/Test2/modules/EventFacet/Info.t
-cpan/Test-Simple/t/Test2/modules/EventFacet/Meta.t
-cpan/Test-Simple/t/Test2/modules/EventFacet/Parent.t
-cpan/Test-Simple/t/Test2/modules/EventFacet/Plan.t
-cpan/Test-Simple/t/Test2/modules/EventFacet/Trace.t
-cpan/Test-Simple/t/Test2/modules/Formatter/TAP.t
-cpan/Test-Simple/t/Test2/modules/Hub.t
-cpan/Test-Simple/t/Test2/modules/Hub/Interceptor.t
-cpan/Test-Simple/t/Test2/modules/Hub/Interceptor/Terminator.t
-cpan/Test-Simple/t/Test2/modules/Hub/Subtest.t
-cpan/Test-Simple/t/Test2/modules/IPC.t
-cpan/Test-Simple/t/Test2/modules/IPC/Driver.t
-cpan/Test-Simple/t/Test2/modules/IPC/Driver/Files.t
-cpan/Test-Simple/t/Test2/modules/Tools/Tiny.t
-cpan/Test-Simple/t/Test2/modules/Util.t
-cpan/Test-Simple/t/Test2/modules/Util/ExternalMeta.t
-cpan/Test-Simple/t/Test2/modules/Util/Facets2Legacy.t
-cpan/Test-Simple/t/Test2/modules/Util/Trace.t
-cpan/Test-Simple/t/Test2/regression/693_ipc_ordering.t
-cpan/Test-Simple/t/Test2/regression/746-forking-subtest.t
-cpan/Test-Simple/t/Test2/regression/gh_16.t
-cpan/Test-Simple/t/Test2/regression/ipc_files_abort_exit.t
+cpan/Test-Simple/lib/ok.pm							Module related to Test::Simple
+cpan/Test-Simple/lib/Test/Builder.pm						Module related to Test::Simple
+cpan/Test-Simple/lib/Test/Builder/Formatter.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test/Builder/IO/Scalar.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test/Builder/Module.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test/Builder/Tester.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test/Builder/Tester/Color.pm				Module related to Test::Simple
+cpan/Test-Simple/lib/Test/Builder/TodoDiag.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test/More.pm						Module related to Test::Simple
+cpan/Test-Simple/lib/Test/Simple.pm						Module related to Test::Simple
+cpan/Test-Simple/lib/Test/Tester.pm						Module related to Test::Simple
+cpan/Test-Simple/lib/Test/Tester/Capture.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test/Tester/CaptureRunner.pm				Module related to Test::Simple
+cpan/Test-Simple/lib/Test/Tester/Delegate.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test/Tutorial.pod						Test::Simple
+cpan/Test-Simple/lib/Test/use/ok.pm						Module related to Test::Simple
+cpan/Test-Simple/lib/Test2.pm							Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/API.pm						Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/API/Breakage.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/API/Context.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/API/Instance.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/API/InterceptResult.pm				Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/API/InterceptResult/Event.pm				Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/API/InterceptResult/Facet.pm				Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/API/InterceptResult/Hub.pm				Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/API/InterceptResult/Squasher.pm			Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/API/Stack.pm						Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event.pm						Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event/Bail.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event/Diag.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event/Encoding.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event/Exception.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event/Fail.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event/Generic.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event/Note.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event/Ok.pm						Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event/Pass.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event/Plan.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event/Skip.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event/Subtest.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event/TAP/Version.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event/V2.pm						Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Event/Waiting.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/EventFacet.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/EventFacet/About.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/EventFacet/Amnesty.pm				Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/EventFacet/Assert.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/EventFacet/Control.pm				Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/EventFacet/Error.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/EventFacet/Hub.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/EventFacet/Info.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/EventFacet/Info/Table.pm				Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/EventFacet/Meta.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/EventFacet/Parent.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/EventFacet/Plan.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/EventFacet/Render.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/EventFacet/Trace.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Formatter.pm						Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Formatter/TAP.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Hub.pm						Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Hub/Interceptor.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Hub/Interceptor/Terminator.pm			Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Hub/Subtest.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/IPC.pm						Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/IPC/Driver.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/IPC/Driver/Files.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Tools/Tiny.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Transition.pod					Test::Simple
+cpan/Test-Simple/lib/Test2/Util.pm						Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Util/ExternalMeta.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Util/Facets2Legacy.pm				Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Util/HashBase.pm					Module related to Test::Simple
+cpan/Test-Simple/lib/Test2/Util/Trace.pm					Module related to Test::Simple
+cpan/Test-Simple/t/HashBase.t							Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/00test_harness_check.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/01-basic.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/478-cmp_ok_hash.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/auto.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/bad_plan.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/bail_out.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/BEGIN_require_ok.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/BEGIN_use_ok.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/buffer.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Bugs/600.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Bugs/629.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/Builder.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/carp.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/create.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/current_test.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/current_test_without_plan.t			Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/details.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/done_testing.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/done_testing_double.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/done_testing_plan_mismatch.t			Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/done_testing_with_no_plan.t			Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/done_testing_with_number.t			Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/done_testing_with_plan.t			Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/fork_with_new_stdout.t			Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/has_plan.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/has_plan2.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/is_fh.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/is_passing.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/maybe_regex.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/no_diag.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/no_ending.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/no_header.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/no_plan_at_all.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/ok_obj.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/output.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/reset.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/reset_outputs.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Builder/try.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/c_flag.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/capture.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/check_tests.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/circular_data.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/cmp_ok.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/depth.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/diag.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/died.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/dont_overwrite_die_handler.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/eq_set.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/exit.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/explain.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/explain_err_vars.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/extra.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/extra_one.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/fail.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/fail-like.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/fail-more.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/fail_one.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/filehandles.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/fork.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/harness_active.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/import.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/is_deeply_dne_bug.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/is_deeply_fail.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/is_deeply_with_threads.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/missing.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/More.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/new_ok.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/no_log_results.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/no_plan.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/no_tests.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/note.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/overload.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/overload_threads.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/plan.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/plan_bad.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/plan_is_noplan.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/plan_no_plan.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/plan_shouldnt_import.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/plan_skip_all.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Regression/637.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Regression/683_thread_todo.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Regression/6_cmp_ok.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Regression/736_use_ok.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Regression/789-read-only.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Regression/870-experimental-warnings.t		Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Regression/is_capture.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/require_ok.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/run_test.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/simple.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Simple/load.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/skip.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/skipall.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/strays.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/args.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/bail_out.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/basic.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/callback.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/die.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/do.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/events.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/for_do_t.test					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/fork.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/implicit_done.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/line_numbers.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/plan.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/predicate.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/singleton.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/threads.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/todo.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/subtest/wstat.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/tbm_doesnt_set_exported_to.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Test2/Subtest.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Tester/tbt_01basic.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Tester/tbt_02fhrestore.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Tester/tbt_03die.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Tester/tbt_04line_num.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Tester/tbt_05faildiag.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Tester/tbt_06errormess.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Tester/tbt_07args.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Tester/tbt_08subtest.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Tester/tbt_09do.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/Tester/tbt_09do_script.pl				Script related to Test::Simple
+cpan/Test-Simple/t/Legacy/thread_taint.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/threads.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/todo.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/undef.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/use_ok.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/useing.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/utf8.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy/versions.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy_And_Test2/builder_loaded_late.t			Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy_And_Test2/diag_event_on_ok.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy_And_Test2/hidden_warnings.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy_And_Test2/preload_diag_note.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Legacy_And_Test2/thread_init_warning.t			Test file related to Test::Simple
+cpan/Test-Simple/t/lib/Dev/Null.pm						Module related to Test::Simple
+cpan/Test-Simple/t/lib/Dummy.pm							Module related to Test::Simple
+cpan/Test-Simple/t/lib/MyOverload.pm						Module related to Test::Simple
+cpan/Test-Simple/t/lib/MyTest.pm						Module related to Test::Simple
+cpan/Test-Simple/t/lib/NoExporter.pm						Module related to Test::Simple
+cpan/Test-Simple/t/lib/SigDie.pm						Module related to Test::Simple
+cpan/Test-Simple/t/lib/SkipAll.pm						Module related to Test::Simple
+cpan/Test-Simple/t/lib/SmallTest.pm						Module related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Builder/NoOutput.pm					Module related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/Catch.pm					Module related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/death.plx			Script related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/death_in_eval.plx		Script related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/death_with_handler.plx		Script related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/exit.plx			Script related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/extras.plx			Script related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/five_fail.plx			Script related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/last_minute_death.plx		Script related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/missing_done_testing.plx	Script related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/one_fail.plx			Script related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/one_fail_without_plan.plx	Script related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/pre_plan_death.plx		Script related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/require.plx			Script related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/success.plx			Script related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/too_few.plx			Script related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/too_few_fail.plx		Script related to Test::Simple
+cpan/Test-Simple/t/lib/Test/Simple/sample_tests/two_fail.plx			Script related to Test::Simple
+cpan/Test-Simple/t/lib/TieOut.pm						Module related to Test::Simple
+cpan/Test-Simple/t/regression/642_persistent_end.t				Test file related to Test::Simple
+cpan/Test-Simple/t/regression/662-tbt-no-plan.t					Test file related to Test::Simple
+cpan/Test-Simple/t/regression/684-nested_todo_diag.t				Test file related to Test::Simple
+cpan/Test-Simple/t/regression/694_note_diag_return_values.t			Test file related to Test::Simple
+cpan/Test-Simple/t/regression/696-intercept_skip_all.t				Test file related to Test::Simple
+cpan/Test-Simple/t/regression/721-nested-streamed-subtest.t			Test file related to Test::Simple
+cpan/Test-Simple/t/regression/757-reset_in_subtest.t				Test file related to Test::Simple
+cpan/Test-Simple/t/regression/812-todo.t					Test file related to Test::Simple
+cpan/Test-Simple/t/regression/817-subtest-todo.t				Test file related to Test::Simple
+cpan/Test-Simple/t/regression/862-intercept_tb_todo.t				Test file related to Test::Simple
+cpan/Test-Simple/t/regression/buffered_subtest_plan_buffered.t			Test file related to Test::Simple
+cpan/Test-Simple/t/regression/builder_does_not_init.t				Test file related to Test::Simple
+cpan/Test-Simple/t/regression/errors_facet.t					Test file related to Test::Simple
+cpan/Test-Simple/t/regression/fork_first.t					Test file related to Test::Simple
+cpan/Test-Simple/t/regression/inherit_trace.t					Test file related to Test::Simple
+cpan/Test-Simple/t/regression/no_name_in_subtest.t				Test file related to Test::Simple
+cpan/Test-Simple/t/regression/skip_reason_object_ipc.t				Test file related to Test::Simple
+cpan/Test-Simple/t/regression/todo_and_facets.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/acceptance/try_it_done_testing.t			Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/acceptance/try_it_fork.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/acceptance/try_it_no_plan.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/acceptance/try_it_plan.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/acceptance/try_it_skip.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/acceptance/try_it_threads.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/acceptance/try_it_todo.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/disable_ipc_a.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/disable_ipc_b.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/disable_ipc_c.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/disable_ipc_d.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/err_var.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/Formatter.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/init_croak.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/intercept.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/ipc_wait_timeout.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/nested_context_exception.t			Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/no_load_api.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/run_subtest_inherit.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/special_names.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/subtest_bailout.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/Subtest_buffer_formatter.t			Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/Subtest_callback.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/Subtest_events.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/Subtest_plan.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/Subtest_todo.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/Taint.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/trace_signature.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/behavior/uuid.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/legacy/TAP.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/API.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/API/Breakage.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/API/Context.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/API/Instance.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/API/InterceptResult.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/API/InterceptResult/Event.t			Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/API/InterceptResult/Squasher.t			Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/API/Stack.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event/Bail.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event/Diag.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event/Encoding.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event/Exception.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event/Fail.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event/Generic.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event/Note.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event/Ok.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event/Pass.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event/Plan.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event/Skip.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event/Subtest.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event/TAP/Version.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event/V2.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Event/Waiting.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/EventFacet.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/EventFacet/About.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/EventFacet/Amnesty.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/EventFacet/Assert.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/EventFacet/Control.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/EventFacet/Error.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/EventFacet/Info.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/EventFacet/Meta.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/EventFacet/Parent.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/EventFacet/Plan.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/EventFacet/Trace.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Formatter/TAP.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Hub.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Hub/Interceptor.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Hub/Interceptor/Terminator.t			Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Hub/Subtest.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/IPC.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/IPC/Driver.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/IPC/Driver/Files.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Tools/Tiny.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Util.t						Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Util/ExternalMeta.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Util/Facets2Legacy.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/modules/Util/Trace.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/regression/693_ipc_ordering.t				Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/regression/746-forking-subtest.t			Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/regression/gh_16.t					Test file related to Test::Simple
+cpan/Test-Simple/t/Test2/regression/ipc_files_abort_exit.t			Test file related to Test::Simple
 cpan/Text-Balanced/lib/Text/Balanced.pm	Text::Balanced
 cpan/Text-Balanced/t/01_compile.t	See if Text::Balanced works
 cpan/Text-Balanced/t/02_extbrk.t	See if Text::Balanced works

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1105,7 +1105,8 @@ use File::Glob qw(:case);
     },
 
     'Test::Simple' => {
-        'DISTRIBUTION' => 'EXODIST/Test-Simple-1.302192.tar.gz',
+        'DISTRIBUTION' => 'EXODIST/Test-Simple-1.302193.tar.gz',
+        'SYNCINFO'     => 'yorton on Mon Mar  6 19:16:42 2023',
         'FILES'        => q[cpan/Test-Simple],
         'EXCLUDED'     => [
             qr{^examples/},

--- a/Porting/sync-with-cpan
+++ b/Porting/sync-with-cpan
@@ -474,11 +474,13 @@ else {
     }
     $new_file = (split '/', $new_path) [-1];
 
-    $re_update = "Re-";
-    print "The latest version of $module is $new_version, but blead already has it.\n";
-    print "Continuing may update MANIFEST or other metadata so it may make sense to continue anyway.\n";
-    print "Are you sure you want to continue?\n";
-    pause_for_input();
+    if ($old_version eq $new_version) {
+        $re_update = "Re-";
+        print "The latest version of $module is $new_version, but blead already has it.\n";
+        print "Continuing may update MANIFEST or other metadata so it may make sense to continue anyway.\n";
+        print "Are you sure you want to continue?\n";
+        pause_for_input();
+    }
 
     my $url = "https://cpan.metacpan.org/authors/id/$new_path";
     say "Fetching $url";

--- a/cpan/Test-Simple/lib/Test/Builder.pm
+++ b/cpan/Test-Simple/lib/Test/Builder.pm
@@ -4,7 +4,7 @@ use 5.006;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN {
     if( $] < 5.008 ) {

--- a/cpan/Test-Simple/lib/Test/Builder/Formatter.pm
+++ b/cpan/Test-Simple/lib/Test/Builder/Formatter.pm
@@ -2,7 +2,7 @@ package Test::Builder::Formatter;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN { require Test2::Formatter::TAP; our @ISA = qw(Test2::Formatter::TAP) }
 

--- a/cpan/Test-Simple/lib/Test/Builder/Module.pm
+++ b/cpan/Test-Simple/lib/Test/Builder/Module.pm
@@ -7,7 +7,7 @@ use Test::Builder;
 require Exporter;
 our @ISA = qw(Exporter);
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 =head1 NAME

--- a/cpan/Test-Simple/lib/Test/Builder/Tester.pm
+++ b/cpan/Test-Simple/lib/Test/Builder/Tester.pm
@@ -1,7 +1,7 @@
 package Test::Builder::Tester;
 
 use strict;
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Test::Builder;
 use Symbol;

--- a/cpan/Test-Simple/lib/Test/Builder/Tester/Color.pm
+++ b/cpan/Test-Simple/lib/Test/Builder/Tester/Color.pm
@@ -1,7 +1,7 @@
 package Test::Builder::Tester::Color;
 
 use strict;
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 require Test::Builder::Tester;
 

--- a/cpan/Test-Simple/lib/Test/Builder/TodoDiag.pm
+++ b/cpan/Test-Simple/lib/Test/Builder/TodoDiag.pm
@@ -2,7 +2,7 @@ package Test::Builder::TodoDiag;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN { require Test2::Event::Diag; our @ISA = qw(Test2::Event::Diag) }
 

--- a/cpan/Test-Simple/lib/Test/More.pm
+++ b/cpan/Test-Simple/lib/Test/More.pm
@@ -17,7 +17,7 @@ sub _carp {
     return warn @_, " at $file line $line\n";
 }
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Test::Builder::Module;
 our @ISA    = qw(Test::Builder::Module);
@@ -394,8 +394,13 @@ different from some other value:
 
   isnt $obj, $clone, "clone() produces a different object";
 
-For those grammatical pedants out there, there's an C<isn't()>
-function which is an alias of C<isnt()>.
+Historically we supported an C<isn't()> function as an alias of
+C<isnt()>, however in Perl 5.37.9 support for the use of aprostrophe as
+a package separator was deprecated and by Perl 5.42.0 support for it
+will have been removed completely. Accordingly use of C<isn't()> is also
+deprecated, and will produce warnings when used unless 'deprecated'
+warnings are specifically disabled in the scope where it is used. You
+are strongly advised to migrate to using C<isnt()> instead.
 
 =cut
 
@@ -411,8 +416,24 @@ sub isnt ($$;$) {
     return $tb->isnt_eq(@_);
 }
 
-# make this available as isn't()
-*isn::t = \&isnt;
+# Historically it was possible to use apostrophes as a package
+# separator. make this available as isn't() for perl's that support it.
+# However in 5.37.9 the apostrophe as a package separator was
+# deprecated, so warn users of isn't() that they should use isnt()
+# instead. We assume that if they are calling isn::t() they are doing so
+# via isn't() as we have no way to be sure that they aren't spelling it
+# with a double colon. We only trigger the warning if deprecation
+# warnings are enabled, so the user can silence the warning if they
+# wish.
+sub isn::t {
+    if (warnings::enabled("deprecated")) {
+        _carp
+        "Use of apostrophe as package separator was deprecated in Perl 5.37.9,\n",
+        "and will be removed in Perl 5.42.0.  You should change code that uses\n",
+        "Test::More::isn't() to use Test::More::isnt() as a replacement";
+    }
+    goto &isnt;
+}
 
 =item B<like>
 

--- a/cpan/Test-Simple/lib/Test/Simple.pm
+++ b/cpan/Test-Simple/lib/Test/Simple.pm
@@ -4,7 +4,7 @@ use 5.006;
 
 use strict;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Test::Builder::Module;
 our @ISA    = qw(Test::Builder::Module);

--- a/cpan/Test-Simple/lib/Test/Tester.pm
+++ b/cpan/Test-Simple/lib/Test/Tester.pm
@@ -18,7 +18,7 @@ require Exporter;
 
 use vars qw( @ISA @EXPORT );
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 @EXPORT = qw( run_tests check_tests check_test cmp_results show_space );
 @ISA = qw( Exporter );

--- a/cpan/Test-Simple/lib/Test/Tester/Capture.pm
+++ b/cpan/Test-Simple/lib/Test/Tester/Capture.pm
@@ -2,7 +2,7 @@ use strict;
 
 package Test::Tester::Capture;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 use Test::Builder;

--- a/cpan/Test-Simple/lib/Test/Tester/CaptureRunner.pm
+++ b/cpan/Test-Simple/lib/Test/Tester/CaptureRunner.pm
@@ -3,7 +3,7 @@ use strict;
 
 package Test::Tester::CaptureRunner;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 use Test::Tester::Capture;

--- a/cpan/Test-Simple/lib/Test/Tester/Delegate.pm
+++ b/cpan/Test-Simple/lib/Test/Tester/Delegate.pm
@@ -3,7 +3,7 @@ use warnings;
 
 package Test::Tester::Delegate;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Scalar::Util();
 

--- a/cpan/Test-Simple/lib/Test/use/ok.pm
+++ b/cpan/Test-Simple/lib/Test/use/ok.pm
@@ -1,7 +1,7 @@
 package Test::use::ok;
 use 5.005;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 __END__

--- a/cpan/Test-Simple/lib/Test2.pm
+++ b/cpan/Test-Simple/lib/Test2.pm
@@ -2,7 +2,7 @@ package Test2;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 1;

--- a/cpan/Test-Simple/lib/Test2/API.pm
+++ b/cpan/Test-Simple/lib/Test2/API.pm
@@ -10,7 +10,7 @@ BEGIN {
     $ENV{TEST2_ACTIVE} = 1;
 }
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 my $INST;

--- a/cpan/Test-Simple/lib/Test2/API/Breakage.pm
+++ b/cpan/Test-Simple/lib/Test2/API/Breakage.pm
@@ -2,7 +2,7 @@ package Test2::API::Breakage;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 use Test2::Util qw/pkg_to_file/;

--- a/cpan/Test-Simple/lib/Test2/API/Context.pm
+++ b/cpan/Test-Simple/lib/Test2/API/Context.pm
@@ -2,7 +2,7 @@ package Test2::API::Context;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 use Carp qw/confess croak/;

--- a/cpan/Test-Simple/lib/Test2/API/Instance.pm
+++ b/cpan/Test-Simple/lib/Test2/API/Instance.pm
@@ -2,7 +2,7 @@ package Test2::API::Instance;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 our @CARP_NOT = qw/Test2::API Test2::API::Instance Test2::IPC::Driver Test2::Formatter/;
 use Carp qw/confess carp/;

--- a/cpan/Test-Simple/lib/Test2/API/InterceptResult.pm
+++ b/cpan/Test-Simple/lib/Test2/API/InterceptResult.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Scalar::Util qw/blessed/;
 use Test2::Util  qw/pkg_to_file/;

--- a/cpan/Test-Simple/lib/Test2/API/InterceptResult/Event.pm
+++ b/cpan/Test-Simple/lib/Test2/API/InterceptResult/Event.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use List::Util   qw/first/;
 use Test2::Util  qw/pkg_to_file/;

--- a/cpan/Test-Simple/lib/Test2/API/InterceptResult/Facet.pm
+++ b/cpan/Test-Simple/lib/Test2/API/InterceptResult/Facet.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Facet;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN {
     require Test2::EventFacet;

--- a/cpan/Test-Simple/lib/Test2/API/InterceptResult/Hub.pm
+++ b/cpan/Test-Simple/lib/Test2/API/InterceptResult/Hub.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN { require Test2::Hub; our @ISA = qw(Test2::Hub) }
 use Test2::Util::HashBase;

--- a/cpan/Test-Simple/lib/Test2/API/InterceptResult/Squasher.pm
+++ b/cpan/Test-Simple/lib/Test2/API/InterceptResult/Squasher.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Squasher;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Carp qw/croak/;
 use List::Util qw/first/;

--- a/cpan/Test-Simple/lib/Test2/API/Stack.pm
+++ b/cpan/Test-Simple/lib/Test2/API/Stack.pm
@@ -2,7 +2,7 @@ package Test2::API::Stack;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 use Test2::Hub();

--- a/cpan/Test-Simple/lib/Test2/Event.pm
+++ b/cpan/Test-Simple/lib/Test2/Event.pm
@@ -2,7 +2,7 @@ package Test2::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Scalar::Util qw/blessed reftype/;
 use Carp qw/croak/;

--- a/cpan/Test-Simple/lib/Test2/Event/Bail.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Bail.pm
@@ -2,7 +2,7 @@ package Test2::Event::Bail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Diag.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Diag.pm
@@ -2,7 +2,7 @@ package Test2::Event::Diag;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Encoding.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Encoding.pm
@@ -2,7 +2,7 @@ package Test2::Event::Encoding;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Carp qw/croak/;
 

--- a/cpan/Test-Simple/lib/Test2/Event/Exception.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Exception.pm
@@ -2,7 +2,7 @@ package Test2::Event::Exception;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Fail.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Fail.pm
@@ -2,7 +2,7 @@ package Test2::Event::Fail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Test2::EventFacet::Info;
 

--- a/cpan/Test-Simple/lib/Test2/Event/Generic.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Generic.pm
@@ -5,7 +5,7 @@ use warnings;
 use Carp qw/croak/;
 use Scalar::Util qw/reftype/;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }
 use Test2::Util::HashBase;

--- a/cpan/Test-Simple/lib/Test2/Event/Note.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Note.pm
@@ -2,7 +2,7 @@ package Test2::Event::Note;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Ok.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Ok.pm
@@ -2,7 +2,7 @@ package Test2::Event::Ok;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Pass.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Pass.pm
@@ -2,7 +2,7 @@ package Test2::Event::Pass;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Test2::EventFacet::Info;
 

--- a/cpan/Test-Simple/lib/Test2/Event/Plan.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Plan.pm
@@ -2,7 +2,7 @@ package Test2::Event::Plan;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Skip.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Skip.pm
@@ -2,7 +2,7 @@ package Test2::Event::Skip;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 BEGIN { require Test2::Event::Ok; our @ISA = qw(Test2::Event::Ok) }

--- a/cpan/Test-Simple/lib/Test2/Event/Subtest.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Event::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN { require Test2::Event::Ok; our @ISA = qw(Test2::Event::Ok) }
 use Test2::Util::HashBase qw{subevents buffered subtest_id subtest_uuid start_stamp stop_stamp};

--- a/cpan/Test-Simple/lib/Test2/Event/TAP/Version.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/TAP/Version.pm
@@ -2,7 +2,7 @@ package Test2::Event::TAP::Version;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Carp qw/croak/;
 

--- a/cpan/Test-Simple/lib/Test2/Event/V2.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/V2.pm
@@ -2,7 +2,7 @@ package Test2::Event::V2;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Scalar::Util qw/reftype/;
 use Carp qw/croak/;

--- a/cpan/Test-Simple/lib/Test2/Event/Waiting.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Waiting.pm
@@ -2,7 +2,7 @@ package Test2::Event::Waiting;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/EventFacet.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Test2::Util::HashBase qw/-details/;
 use Carp qw/croak/;

--- a/cpan/Test-Simple/lib/Test2/EventFacet/About.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/About.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::About;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -package -no_display -uuid -eid };

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Amnesty.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Amnesty.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Amnesty;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 sub is_list { 1 }
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Assert.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Assert.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Assert;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -pass -no_debug -number };

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Control.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Control.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Control;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -global -terminate -halt -has_callback -encoding -phase };

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Error.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Error.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Error;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 sub facet_key { 'errors' }
 sub is_list { 1 }

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Hub.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Hub.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 sub is_list { 1 }
 sub facet_key { 'hubs' }

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Info.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Info.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Info;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 sub is_list { 1 }
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Info/Table.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Info/Table.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Info::Table;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Carp qw/confess/;
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Meta.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Meta.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Meta;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use vars qw/$AUTOLOAD/;

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Parent.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Parent.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Parent;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Carp qw/confess/;
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Plan.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Plan.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Plan;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -count -skip -none };

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Render.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Render.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Render;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 sub is_list { 1 }
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Trace.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Trace.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Trace;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 

--- a/cpan/Test-Simple/lib/Test2/Formatter.pm
+++ b/cpan/Test-Simple/lib/Test2/Formatter.pm
@@ -2,7 +2,7 @@ package Test2::Formatter;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 my %ADDED;

--- a/cpan/Test-Simple/lib/Test2/Formatter/TAP.pm
+++ b/cpan/Test-Simple/lib/Test2/Formatter/TAP.pm
@@ -2,7 +2,7 @@ package Test2::Formatter::TAP;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Test2::Util qw/clone_io/;
 

--- a/cpan/Test-Simple/lib/Test2/Hub.pm
+++ b/cpan/Test-Simple/lib/Test2/Hub.pm
@@ -2,7 +2,7 @@ package Test2::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 use Carp qw/carp croak confess/;

--- a/cpan/Test-Simple/lib/Test2/Hub/Interceptor.pm
+++ b/cpan/Test-Simple/lib/Test2/Hub/Interceptor.pm
@@ -2,7 +2,7 @@ package Test2::Hub::Interceptor;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 use Test2::Hub::Interceptor::Terminator();

--- a/cpan/Test-Simple/lib/Test2/Hub/Interceptor/Terminator.pm
+++ b/cpan/Test-Simple/lib/Test2/Hub/Interceptor/Terminator.pm
@@ -2,7 +2,7 @@ package Test2::Hub::Interceptor::Terminator;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 1;

--- a/cpan/Test-Simple/lib/Test2/Hub/Subtest.pm
+++ b/cpan/Test-Simple/lib/Test2/Hub/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Hub::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN { require Test2::Hub; our @ISA = qw(Test2::Hub) }
 use Test2::Util::HashBase qw/nested exit_code manual_skip_all/;

--- a/cpan/Test-Simple/lib/Test2/IPC.pm
+++ b/cpan/Test-Simple/lib/Test2/IPC.pm
@@ -2,7 +2,7 @@ package Test2::IPC;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 use Test2::API::Instance;

--- a/cpan/Test-Simple/lib/Test2/IPC/Driver.pm
+++ b/cpan/Test-Simple/lib/Test2/IPC/Driver.pm
@@ -2,7 +2,7 @@ package Test2::IPC::Driver;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 use Carp qw/confess/;

--- a/cpan/Test-Simple/lib/Test2/IPC/Driver/Files.pm
+++ b/cpan/Test-Simple/lib/Test2/IPC/Driver/Files.pm
@@ -2,7 +2,7 @@ package Test2::IPC::Driver::Files;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN { require Test2::IPC::Driver; our @ISA = qw(Test2::IPC::Driver) }
 

--- a/cpan/Test-Simple/lib/Test2/Tools/Tiny.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Tiny.pm
@@ -16,7 +16,7 @@ use Test2::API qw/context run_subtest test2_stack/;
 use Test2::Hub::Interceptor();
 use Test2::Hub::Interceptor::Terminator();
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 BEGIN { require Exporter; our @ISA = qw(Exporter) }
 our @EXPORT = qw{

--- a/cpan/Test-Simple/lib/Test2/Util.pm
+++ b/cpan/Test-Simple/lib/Test2/Util.pm
@@ -2,7 +2,7 @@ package Test2::Util;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use POSIX();
 use Config qw/%Config/;

--- a/cpan/Test-Simple/lib/Test2/Util/ExternalMeta.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/ExternalMeta.pm
@@ -2,7 +2,7 @@ package Test2::Util::ExternalMeta;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 
 use Carp qw/croak/;

--- a/cpan/Test-Simple/lib/Test2/Util/Facets2Legacy.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Facets2Legacy.pm
@@ -2,7 +2,7 @@ package Test2::Util::Facets2Legacy;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use Carp qw/croak confess/;
 use Scalar::Util qw/blessed/;

--- a/cpan/Test-Simple/lib/Test2/Util/HashBase.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/HashBase.pm
@@ -2,7 +2,7 @@ package Test2::Util::HashBase;
 use strict;
 use warnings;
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 #################################################################
 #                                                               #

--- a/cpan/Test-Simple/lib/Test2/Util/Trace.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Trace.pm
@@ -6,7 +6,7 @@ use strict;
 
 our @ISA = ('Test2::EventFacet::Trace');
 
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 1;
 

--- a/cpan/Test-Simple/lib/ok.pm
+++ b/cpan/Test-Simple/lib/ok.pm
@@ -1,5 +1,5 @@
 package ok;
-our $VERSION = '1.302192';
+our $VERSION = '1.302193';
 
 use strict;
 use Test::More ();

--- a/cpan/Test-Simple/t/Legacy/More.t
+++ b/cpan/Test-Simple/t/Legacy/More.t
@@ -8,7 +8,7 @@ BEGIN {
 }
 
 use lib 't/lib';
-use Test::More tests => 54;
+use Test::More tests => 57;
 
 # Make sure we don't mess with $@ or $!.  Test at bottom.
 my $Err   = "this should not be touched";
@@ -24,7 +24,24 @@ require_ok('Test::More');
 ok( 2 eq 2,             'two is two is two is two' );
 is(   "foo", "foo",       'foo is foo' );
 isnt( "foo", "bar",     'foo isnt bar');
-isn::t("foo", "bar",     'foo isn\'t bar');
+{
+    use warnings;
+    my $warning;
+    local $SIG{__WARN__}= sub { $warning = $_[0] };
+    isn::t("foo", "bar",     'foo isn\'t bar');
+    is($warning, "Use of apostrophe as package separator was deprecated in Perl 5.37.9,\n"
+               . "and will be removed in Perl 5.42.0.  You should change code that uses\n"
+               . "Test::More::isn't() to use Test::More::isnt() as a replacement"
+               . " at t/Legacy/More.t line 31\n",
+            "Got expected warning from isn::t() under use warnings");
+}
+{
+    no warnings "deprecated";
+    my $warning;
+    local $SIG{__WARN__}= sub { $warning = $_[0] };
+    isn::t("foo", "bar",     'foo isn\'t bar');
+    is($warning, undef, "No warnings from isn::t() under no warnings deprecated");
+}
 
 #'#
 like("fooble", '/^foo/',    'foo is like fooble');

--- a/cpan/Test-Simple/t/Legacy/Regression/870-experimental-warnings.t
+++ b/cpan/Test-Simple/t/Legacy/Regression/870-experimental-warnings.t
@@ -2,7 +2,10 @@ use strict;
 use warnings;
 use Test2::Tools::Tiny;
 
-BEGIN { skip_all "Only testing on 5.18+" if $] < 5.018 }
+BEGIN {
+    skip_all "Not testing before 5.18 or after 5.37.10"
+        if $] < 5.018 or $] >= 5.037010;
+}
 
 require Test::More;
 *cmp_ok = \&Test::More::cmp_ok;


### PR DESCRIPTION
Updates Test-Simple (aka Test::More) to v1.302193

This also includes a slight tweak to Porting/sync-with-cpan so it doesn't treat every update from CPAN downloads (as opposed to pre-downloaded tarballs) as a "re-update". If the version changes its not a re-update.