### PR TITLE
Time::HiRes: allow not checking atime between stat and lstat

### DIFF
--- a/dist/Time-HiRes/Changes
+++ b/dist/Time-HiRes/Changes
@@ -12,6 +12,9 @@ Revision history for the Perl extension Time::HiRes.
  - darwin: make sure the compiler can find the system perl headers
    https://github.com/Perl/perl5/issues/20362
  - darwin: make sure PERL_DARWIN is defined on darwin.
+ - don't compare stat and lstat atime if PERL_FILE_ATIME_CHANGES is set in
+   the environment.
+   https://github.com/Perl/perl5/issues/19321
 
 1.9764 [2020-08-10]
  - Fix a bunch of repeated-word typos

--- a/dist/Time-HiRes/t/stat.t
+++ b/dist/Time-HiRes/t/stat.t
@@ -36,7 +36,11 @@ for (1..5) {
     SKIP: {
         if($^O eq "haiku") {
             skip "testing stat access time on Haiku", 2;
-        }  
+        }
+        if ($ENV{PERL_FILE_ATIME_CHANGES}) {
+            # something else might access the file, changing atime
+            $lstat->[8] = $stat->[8];
+        }
         is_deeply $lstat, $stat, "write: stat and lstat returned same values";
         Time::HiRes::sleep(rand(0.1) + 0.1);
         open(X, '<', $$);


### PR DESCRIPTION
On a system with some sort of filesystem monitor such as a virus scanner the atime of the file can be modified by that monitor causing the test to fail.

Testers can set PERL_FILE_ATIME_CHANGES to a true value to avoid comparing atime between the stat() and lstat() calls.

Fixes #19321