### PR TITLE
dist/encoding-warnings: Add missing files from CPAN

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3861,7 +3861,9 @@ dist/Dumpvalue/t/Dumpvalue.t		See if Dumpvalue works
 dist/Dumpvalue/t/extend-coverage.t	Extend Dumpvalue's test coverage
 dist/Dumpvalue/t/lib/TieOut.pm		Helper module for Dumpvalue tests
 dist/Dumpvalue/t/rt-134441-dumpvalue.t	See if Dumpvalue works
+dist/encoding-warnings/Changes			encoding::warnings
 dist/encoding-warnings/lib/encoding/warnings.pm	warn on implicit encoding conversions
+dist/encoding-warnings/Makefile.PL		encoding::warnings
 dist/encoding-warnings/t/1-warning.t		tests for encoding::warnings
 dist/encoding-warnings/t/2-fatal.t		tests for encoding::warnings
 dist/encoding-warnings/t/3-normal.t		tests for encoding::warnings

--- a/dist/encoding-warnings/.gitignore
+++ b/dist/encoding-warnings/.gitignore
@@ -1,0 +1,1 @@
+!/Makefile.PL

--- a/dist/encoding-warnings/Changes
+++ b/dist/encoding-warnings/Changes
@@ -1,0 +1,27 @@
+[Changes for 0.11 - 2007-06-05]
+
+* This module's effect is now lexical for Perl 5.9.5 and later.
+* "no encoding::warnings" is made more inefficient by doing away
+  with an empty encoding handler.
+  Contributed by: Rafaël Garcia-Suarez
+
+[Changes for 0.04 - 2004-03-16]
+
+* This be 0.04, from the YAPC::Taipei::2004 release party.
+* Various POD grammar updates.
+* Mentions that we will be making encoding.pm to be lexical during 5.9.
+
+[Changes for 0.03 - 2004-03-15]
+
+* Fixes various typo and punctuations.
+* Unified terminology to use "byte-string" and "unicode-string".
+
+[Changes for 0.02 - 2004-03-14]
+
+* Added lots of documentations, as well as explained the subtlety of
+  "use encoding" better.  Prompted by Ton Hospel.
+* Do not bother decoding a string twice if it is us-ascii.
+
+[Changes for 0.01 - 2004-03-14]
+
+* Initial release on CPAN.

--- a/dist/encoding-warnings/Changes
+++ b/dist/encoding-warnings/Changes
@@ -1,27 +1,29 @@
-[Changes for 0.11 - 2007-06-05]
+Change log for encoding-warnings
 
-* This module's effect is now lexical for Perl 5.9.5 and later.
-* "no encoding::warnings" is made more inefficient by doing away
-  with an empty encoding handler.
-  Contributed by: Rafaël Garcia-Suarez
+0.11 - 2007-06-05
 
-[Changes for 0.04 - 2004-03-16]
+  - This module's effect is now lexical for Perl 5.9.5 and later.
+  - "no encoding::warnings" is made more inefficient by doing away
+    with an empty encoding handler.
+    Contributed by: Rafaël Garcia-Suarez
 
-* This be 0.04, from the YAPC::Taipei::2004 release party.
-* Various POD grammar updates.
-* Mentions that we will be making encoding.pm to be lexical during 5.9.
+0.04 - 2004-03-16
 
-[Changes for 0.03 - 2004-03-15]
+  - This be 0.04, from the YAPC::Taipei::2004 release party.
+  - Various POD grammar updates.
+  - Mentions that we will be making encoding.pm to be lexical during 5.9.
 
-* Fixes various typo and punctuations.
-* Unified terminology to use "byte-string" and "unicode-string".
+0.03 - 2004-03-15
 
-[Changes for 0.02 - 2004-03-14]
+  - Fixes various typo and punctuations.
+  - Unified terminology to use "byte-string" and "unicode-string".
 
-* Added lots of documentations, as well as explained the subtlety of
-  "use encoding" better.  Prompted by Ton Hospel.
-* Do not bother decoding a string twice if it is us-ascii.
+0.02 - 2004-03-14
 
-[Changes for 0.01 - 2004-03-14]
+  - Added lots of documentations, as well as explained the subtlety of
+    "use encoding" better.  Prompted by Ton Hospel.
+  - Do not bother decoding a string twice if it is us-ascii.
 
-* Initial release on CPAN.
+0.01 - 2004-03-14
+
+  - Initial release on CPAN.

--- a/dist/encoding-warnings/Changes
+++ b/dist/encoding-warnings/Changes
@@ -1,5 +1,17 @@
 Change log for encoding-warnings
 
+  - Converted Makefile.PL from using Module::Install to ExtUtils::MakeMaker
+
+0.14 - 2022-05-16
+
+  - Convert tests from Test.pm to Test::More
+
+0.13 - 2016-06-20
+
+  - Disable module on perl 5.26 and newer. Using it will be a no-op, but will
+    issue warnings.
+  - Skip tests on EBCDIC systems
+
 0.11 - 2007-06-05
 
   - This module's effect is now lexical for Perl 5.9.5 and later.

--- a/dist/encoding-warnings/Makefile.PL
+++ b/dist/encoding-warnings/Makefile.PL
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+WriteMakefile(
+  NAME          => 'encoding::warnings',
+  VERSION_FROM  => 'lib/encoding/warnings.pm',
+  ABSTRACT_FROM => 'lib/encoding/warnings.pm',
+  INSTALLDIRS   => ( $] >= 5.009002 && $] < 5.011 ? 'perl' : 'site' ),
+  LICENSE       => 'perl_5',
+  TEST_REQUIRES => {
+    'Test::More' => 0,
+  },
+  PREREQ_PM     => {},
+  AUTHOR        => 'Audrey Tang <cpan@audreyt.org>',
+  META_MERGE    => {
+    resources => {
+      repository  => 'https://github.com/perl/perl5.git',
+      bugtracker  => 'https://github.com/perl/perl5/issues',
+      MailingList => 'https://lists.perl.org/list/perl5-porters.html',
+    },
+  },
+);


### PR DESCRIPTION
This adds a `Makefile.PL` and `Changes` file taking content from CPAN.

The Makefile.PL is rewritten to use ExtUtils::MakeMaker rather than Module::Install, as the latter is not appropriate for use in core.

This module should probably just be deprecated and removed from core. It has been a no-op since perl 5.26.