### PR TITLE
mg.c - fix $+ combined with branch reset

### DIFF
--- a/mg.c
+++ b/mg.c
@@ -1141,20 +1141,26 @@ Perl_magic_get(pTHX_ SV *sv, MAGIC *mg)
             }
         }
         break;
-    case '+':
+    case '+':                   /* $+ */
         if (PL_curpm && (rx = PM_GETRE(PL_curpm))) {
             paren = RX_LASTPAREN(rx);
-            if (paren)
+            if (paren) {
+                I32 *parno_to_logical = RX_PARNO_TO_LOGICAL(rx);
+                if (parno_to_logical)
+                    paren = parno_to_logical[paren];
                 goto do_numbuf_fetch;
+            }
         }
         goto set_undef;
-    case '\016':		/* ^N */
+    case '\016':		/* $^N */
         if (PL_curpm && (rx = PM_GETRE(PL_curpm))) {
             paren = RX_LASTCLOSEPAREN(rx);
-            if (RX_PARNO_TO_LOGICAL(rx))
-                paren = RX_PARNO_TO_LOGICAL(rx)[paren];
-            if (paren)
+            if (paren) {
+                I32 *parno_to_logical = RX_PARNO_TO_LOGICAL(rx);
+                if (parno_to_logical)
+                    paren = parno_to_logical[paren];
                 goto do_numbuf_fetch;
+            }
         }
         goto set_undef;
     case '.':

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -2126,6 +2126,14 @@ AB\s+\x{100}	AB \x{100}X	y	-	-
 ((?|(?<a>a)(?-1)|(?<b>b)(?-1)|(?<c>c)(?-1)))	aa 	y	$1	aa		# GH 20653
 ((?|(?<a>a)(?-1)|(?<b>b)(?-1)|(?<c>c)(?-1)))	bb 	y	$1	bb		# GH 20653
 ((?|(?<a>a)(?-1)|(?<b>b)(?-1)|(?<c>c)(?-1)))	cc 	y	$1	cc		# GH 20653
+(?|(a)|(b))	b	y	$+	b		# GH 20912
+(?|(a)(?{$::plus_got=$+})|(b)(?{$::plus_got=$+}))	b	y	$::plus_got	b		# GH 20912
+(?|(a)|(b))	b	y	$^N	b		# GH 20912
+(?|(a)(?{$::caret_n_got=$^N})|(b)(?{$::caret_n_got=$^N}))	b	y	$::caret_n_got	b		# GH 20912
+(?|(a)|(b))	a	y	$+	a		# GH 20912
+(?|(a)(?{$::plus_got=$+})|(b)(?{$::plus_got=$+}))	a	y	$::plus_got	a		# GH 20912
+(?|(a)|(b))	a	y	$^N	a		# GH 20912
+(?|(a)(?{$::caret_n_got=$^N})|(b)(?{$::caret_n_got=$^N}))	a	y	$::caret_n_got	a		# GH 20912
 # Keep these lines at the end of the file
 # pat	string	y/n/etc	expr	expected-expr	skip-reason	comment
 # vim: softtabstop=0 noexpandtab


### PR DESCRIPTION
I missed that `$+` needs to do the parno_to_logical lookup. We had tests for `$^N`, but not `$+`. This also fixes the code for `$^N` to only do the lookup when the paren is not 0.

Fixes #20912