### PR TITLE
Zefram/remove version downgrade deprecation

### DIFF
--- a/embedvar.h
+++ b/embedvar.h
@@ -227,7 +227,6 @@
 # define PL_pidstatus                           (vTHX->Ipidstatus)
 # define PL_Posix_ptrs                          (vTHX->IPosix_ptrs)
 # define PL_preambleav                          (vTHX->Ipreambleav)
-# define PL_prevailing_version                  (vTHX->Iprevailing_version)
 # define PL_Private_Use                         (vTHX->IPrivate_Use)
 # define PL_Proc                                (vTHX->IProc)
 # define PL_profiledata                         (vTHX->Iprofiledata)

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -1080,12 +1080,6 @@ PERLVAR(I, wcrtomb_ps, mbstate_t)
 PERLVARA(I, mem_log, PERL_MEM_LOG_ARYLEN,  char)
 #endif
 
-/* The most recently seen `use VERSION` declaration, encoded in a single
- * U16 as (major << 8) | minor. We do this rather than store an entire SV
- * version object so we can fit the U16 into the uv of a SAVEHINTS and not
- * have to worry about SV refcounts during scope enter/exit. */
-PERLVAR(I, prevailing_version, U16)
-
 /* If you are adding a U8 or U16, check to see if there are 'Space' comments
  * above on where there are gaps which currently will be structure padding.  */
 

--- a/lib/strict.t
+++ b/lib/strict.t
@@ -3,7 +3,7 @@
 chdir 't' if -d 't';
 @INC = ( '.', '../lib' );
 
-our $local_tests = 7;
+our $local_tests = 6 + 3*3*38 + 3*11 + 3*18;
 require "../t/lib/common.pl";
 
 eval qq(use strict 'garbage');
@@ -28,7 +28,89 @@ like($@, qr/^Unknown 'strict' tag\(s\) 'foo bar'/);
         'use v5.10 after use v5.12 provokes deprecation warning');
 }
 
-eval 'use strict; use v5.10; ${"c"}';
-like($@,
-    qr/^Can't use string \("c"\) as a SCALAR ref while "strict refs" in use/,
-    "use v5.10 doesn't disable explicit strict ref");
+my $varname = "ccccc";
+sub test_strict_all {
+    my($preamble, $expect) = @_;
+    my $expect_r = $expect =~ /r/;
+    eval $preamble.'; ${"ccc"}';
+    like($@,
+        $expect_r ?
+            qr/\ACan't\ use\ string\ \("ccc"\)\ as\ a\ SCALAR\ ref
+                \ while\ "strict\ refs"\ in\ use/x :
+        qr/\A\z/,
+        "\"$preamble\" yields strict refs @{[$expect_r ? q(on) : q(off)]}");
+    my $expect_v = $expect =~ /v/;
+    ++$varname;
+    eval $preamble.'; $'.$varname;
+    like($@,
+        $expect_v ?
+            qr/\AGlobal\ symbol\ "\$\Q${varname}\E"\ requires
+                \ explicit\ package\ name\ /x :
+            qr/\A\z/,
+        "\"$preamble\" yields strict vars @{[$expect_v ? q(on) : q(off)]}");
+    my $expect_s = $expect =~ /s/;
+    eval $preamble.'; Ccc';
+    like($@,
+        $expect_s ?
+            qr/\ABareword\ "Ccc"\ not\ allowed
+                \ while\ "strict\ subs"\ in\ use/x :
+            qr/\A\z/,
+        "\"$preamble\" yields strict subs @{[$expect_s ? q(on) : q(off)]}");
+}
+
+foreach my $minor (0..10) {
+    test_strict_all "use v5.$minor", "";
+    test_strict_all "use strict; use v5.$minor", "rvs";
+    test_strict_all "no strict; use v5.$minor", "";
+}
+foreach my $minor (11..36) {
+    test_strict_all "use v5.$minor", "rvs";
+    test_strict_all "use strict; use v5.$minor", "rvs";
+    test_strict_all "no strict; use v5.$minor", "";
+}
+foreach my $minor (37..37) {
+    test_strict_all "use v5.$minor", "rvs";
+    test_strict_all "use strict; use v5.$minor", "rvs";
+    test_strict_all "no strict; use v5.$minor", "rvs";
+}
+
+{
+    test_strict_all "use v5.8; use v5.10", "";
+    test_strict_all "use v5.10; use v5.8", "";
+    test_strict_all "use v5.10; use v5.16", "rvs";
+    test_strict_all "use v5.10; use v5.37", "rvs";
+    {
+        local $SIG{__WARN__} = sub {};
+        test_strict_all "use v5.16; use v5.10", "";
+    }
+    test_strict_all "use v5.16; use v5.20", "rvs";
+    test_strict_all "use v5.20; use v5.16", "rvs";
+    test_strict_all "use v5.16; use v5.37", "rvs";
+    {
+        local $SIG{__WARN__} = sub {};
+        test_strict_all "use v5.37; use v5.10", "rvs";
+    }
+    test_strict_all "use v5.37; use v5.16", "rvs";
+    test_strict_all "use v5.37; use v5.37", "rvs";
+}
+
+{
+    test_strict_all "use strict 'refs'; use v5.10", "r";
+    test_strict_all "use strict 'vars'; use v5.10", "v";
+    test_strict_all "use strict 'subs'; use v5.10", "s";
+    test_strict_all "no strict 'refs'; use v5.10", "";
+    test_strict_all "no strict 'vars'; use v5.10", "";
+    test_strict_all "no strict 'subs'; use v5.10", "";
+    test_strict_all "use strict 'refs'; use v5.16", "rvs";
+    test_strict_all "use strict 'vars'; use v5.16", "rvs";
+    test_strict_all "use strict 'subs'; use v5.16", "rvs";
+    test_strict_all "no strict 'refs'; use v5.16", "vs";
+    test_strict_all "no strict 'vars'; use v5.16", "rs";
+    test_strict_all "no strict 'subs'; use v5.16", "rv";
+    test_strict_all "use strict 'refs'; use v5.37", "rvs";
+    test_strict_all "use strict 'vars'; use v5.37", "rvs";
+    test_strict_all "use strict 'subs'; use v5.37", "rvs";
+    test_strict_all "no strict 'refs'; use v5.37", "rvs";
+    test_strict_all "no strict 'vars'; use v5.37", "rvs";
+    test_strict_all "no strict 'subs'; use v5.37", "rvs";
+}

--- a/lib/strict.t
+++ b/lib/strict.t
@@ -3,7 +3,7 @@
 chdir 't' if -d 't';
 @INC = ( '.', '../lib' );
 
-our $local_tests = 6 + 3*3*38 + 3*11 + 3*18;
+our $local_tests = 4 + 3*3*38 + 3*11 + 3*18;
 require "../t/lib/common.pl";
 
 eval qq(use strict 'garbage');
@@ -17,16 +17,6 @@ like($@, qr/^Unknown 'strict' tag\(s\) 'foo bar'/);
 
 eval qq(no strict qw(foo bar));
 like($@, qr/^Unknown 'strict' tag\(s\) 'foo bar'/);
-
-{
-    my $warnings = "";
-    local $SIG{__WARN__} = sub { $warnings .= $_[0] };
-    eval 'use v5.12; use v5.10; ${"c"}';
-    is($@, '', 'use v5.10 disables implicit strict refs');
-    like($warnings,
-        qr/^Downgrading a use VERSION declaration to below v5.11 is deprecated, and will become fatal in Perl 5.40 at /,
-        'use v5.10 after use v5.12 provokes deprecation warning');
-}
 
 my $varname = "ccccc";
 sub test_strict_all {
@@ -79,17 +69,11 @@ foreach my $minor (37..37) {
     test_strict_all "use v5.10; use v5.8", "";
     test_strict_all "use v5.10; use v5.16", "rvs";
     test_strict_all "use v5.10; use v5.37", "rvs";
-    {
-        local $SIG{__WARN__} = sub {};
-        test_strict_all "use v5.16; use v5.10", "";
-    }
+    test_strict_all "use v5.16; use v5.10", "";
     test_strict_all "use v5.16; use v5.20", "rvs";
     test_strict_all "use v5.20; use v5.16", "rvs";
     test_strict_all "use v5.16; use v5.37", "rvs";
-    {
-        local $SIG{__WARN__} = sub {};
-        test_strict_all "use v5.37; use v5.10", "rvs";
-    }
+    test_strict_all "use v5.37; use v5.10", "rvs";
     test_strict_all "use v5.37; use v5.16", "rvs";
     test_strict_all "use v5.37; use v5.37", "rvs";
 }

--- a/lib/strict.t
+++ b/lib/strict.t
@@ -3,7 +3,7 @@
 chdir 't' if -d 't';
 @INC = ( '.', '../lib' );
 
-our $local_tests = 4 + 3*3*38 + 3*11 + 3*18;
+our $local_tests = 4 + 3*42 + 3*12 + 3*3*38 + 3*11 + 3*18;
 require "../t/lib/common.pl";
 
 eval qq(use strict 'garbage');
@@ -46,6 +46,66 @@ sub test_strict_all {
                 \ while\ "strict\ subs"\ in\ use/x :
             qr/\A\z/,
         "\"$preamble\" yields strict subs @{[$expect_s ? q(on) : q(off)]}");
+}
+
+{
+    test_strict_all "use strict", "rvs";
+    test_strict_all "no strict", "";
+    test_strict_all "use strict; no strict", "";
+    test_strict_all "no strict; use strict", "rvs";
+    test_strict_all "use strict; no strict 'firmly'", "";
+    test_strict_all "no strict; use strict 'firmly'", "rvs";
+    test_strict_all "use strict; no strict 'softly';", "rvs";
+    test_strict_all "no strict; use strict 'softly';", "";
+    test_strict_all "use strict; no strict 'forcing_softness';", "";
+    test_strict_all "no strict; use strict 'forcing_softness';", "rvs";
+    test_strict_all "use strict 'firmly'", "rvs";
+    test_strict_all "no strict 'firmly'", "";
+    test_strict_all "use strict 'firmly'; no strict", "";
+    test_strict_all "no strict 'firmly'; use strict", "rvs";
+    test_strict_all "use strict 'firmly'; no strict 'firmly'", "";
+    test_strict_all "no strict 'firmly'; use strict 'firmly'", "rvs";
+    test_strict_all "use strict 'firmly'; no strict 'softly';", "rvs";
+    test_strict_all "no strict 'firmly'; use strict 'softly';", "";
+    test_strict_all "use strict 'firmly'; no strict 'forcing_softness';", "";
+    test_strict_all "no strict 'firmly'; use strict 'forcing_softness';", "rvs";
+    test_strict_all "use strict 'softly'", "rvs";
+    test_strict_all "no strict 'softly'", "";
+    test_strict_all "use strict 'softly'; no strict", "";
+    test_strict_all "no strict 'softly'; use strict", "rvs";
+    test_strict_all "use strict 'softly'; no strict 'firmly'", "";
+    test_strict_all "no strict 'softly'; use strict 'firmly'", "rvs";
+    test_strict_all "use strict 'softly'; no strict 'softly'", "";
+    test_strict_all "no strict 'softly'; use strict 'softly'", "rvs";
+    test_strict_all "use strict 'softly'; no strict 'forcing_softness'", "";
+    test_strict_all "no strict 'softly'; use strict 'forcing_softness'", "rvs";
+    test_strict_all "use strict 'forcing_softness'", "rvs";
+    test_strict_all "no strict 'forcing_softness'", "";
+    test_strict_all "use strict 'forcing_softness'; no strict", "";
+    test_strict_all "no strict 'forcing_softness'; use strict", "rvs";
+    test_strict_all "use strict 'forcing_softness'; no strict 'firmly'", "";
+    test_strict_all "no strict 'forcing_softness'; use strict 'firmly'", "rvs";
+    test_strict_all "use strict 'forcing_softness'; no strict 'softly'", "";
+    test_strict_all "no strict 'forcing_softness'; use strict 'softly'", "rvs";
+    test_strict_all "use strict 'forcing_softness'; no strict 'forcing_softness'", "";
+    test_strict_all "no strict 'forcing_softness'; use strict 'forcing_softness'", "rvs";
+    test_strict_all "use strict; no strict 'forcing_softness'; use strict 'softly'", "rvs";
+    test_strict_all "no strict; use strict 'forcing_softness'; no strict 'softly'", "";
+}
+
+{
+    test_strict_all "use strict 'refs'; no strict 'softly'", "r";
+    test_strict_all "use strict 'vars'; no strict 'softly'", "v";
+    test_strict_all "use strict 'subs'; no strict 'softly'", "s";
+    test_strict_all "no strict 'refs'; use strict 'softly'", "vs";
+    test_strict_all "no strict 'vars'; use strict 'softly'", "rs";
+    test_strict_all "no strict 'subs'; use strict 'softly'", "rv";
+    test_strict_all "use strict softly => 'refs'", "r";
+    test_strict_all "use strict softly => 'vars'", "v";
+    test_strict_all "use strict softly => 'subs'", "s";
+    test_strict_all "no strict; use strict softly => 'refs'", "";
+    test_strict_all "no strict; use strict softly => 'vars'", "";
+    test_strict_all "no strict; use strict softly => 'subs'", "";
 }
 
 foreach my $minor (0..10) {

--- a/op.c
+++ b/op.c
@@ -7899,20 +7899,18 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
 
         U16 shortver = S_extract_shortver(aTHX_ use_version);
 
-        /* If a version >= 5.11.0 is requested, strictures are on by default! */
-        if (shortver >= SHORTVER(5, 11)) {
+        if (shortver >= SHORTVER(5, 37)) {
+            PL_hints |= HINT_STRICT_REFS | HINT_EXPLICIT_STRICT_REFS |
+                HINT_STRICT_SUBS | HINT_EXPLICIT_STRICT_SUBS |
+                HINT_STRICT_VARS | HINT_EXPLICIT_STRICT_VARS;
+        } else if (shortver >= SHORTVER(5, 11)) {
             if (!(PL_hints & HINT_EXPLICIT_STRICT_REFS))
                 PL_hints |= HINT_STRICT_REFS;
             if (!(PL_hints & HINT_EXPLICIT_STRICT_SUBS))
                 PL_hints |= HINT_STRICT_SUBS;
             if (!(PL_hints & HINT_EXPLICIT_STRICT_VARS))
                 PL_hints |= HINT_STRICT_VARS;
-
-            if (shortver >= SHORTVER(5, 35))
-                free_and_set_cop_warnings(&PL_compiling, pWARN_ALL);
-        }
-        /* otherwise they are off */
-        else {
+        } else {
             if(PL_prevailing_version >= SHORTVER(5, 11))
                 deprecate_fatal_in("5.40",
                     "Downgrading a use VERSION declaration to below v5.11");
@@ -7924,6 +7922,9 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
             if (!(PL_hints & HINT_EXPLICIT_STRICT_VARS))
                 PL_hints &= ~HINT_STRICT_VARS;
         }
+
+        if (shortver >= SHORTVER(5, 35))
+            free_and_set_cop_warnings(&PL_compiling, pWARN_ALL);
 
         PL_prevailing_version = shortver;
     }

--- a/op.c
+++ b/op.c
@@ -7783,7 +7783,7 @@ Perl_package_version( pTHX_ OP *v )
 }
 
 /* Extract the first two components of a "version" object as two 8bit integers
- * and return them packed into a single U16 in the format of PL_prevailing_version.
+ * and return them packed into a single U16.
  * This function only ever has to cope with version objects already known
  * bounded by the current perl version, so we know its components will fit
  * (Up until we reach perl version 5.256 anyway) */
@@ -7911,10 +7911,6 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
             if (!(PL_hints & HINT_EXPLICIT_STRICT_VARS))
                 PL_hints |= HINT_STRICT_VARS;
         } else {
-            if(PL_prevailing_version >= SHORTVER(5, 11))
-                deprecate_fatal_in("5.40",
-                    "Downgrading a use VERSION declaration to below v5.11");
-
             if (!(PL_hints & HINT_EXPLICIT_STRICT_REFS))
                 PL_hints &= ~HINT_STRICT_REFS;
             if (!(PL_hints & HINT_EXPLICIT_STRICT_SUBS))
@@ -7925,8 +7921,6 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
 
         if (shortver >= SHORTVER(5, 35))
             free_and_set_cop_warnings(&PL_compiling, pWARN_ALL);
-
-        PL_prevailing_version = shortver;
     }
 
     /* The "did you use incorrect case?" warning used to be here.

--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -34,7 +34,8 @@ This is because of an intended related change to the interaction between
 C<use VERSION> and C<use strict>. If you specify a version >= 5.11, strict is
 enabled implicitly. If you request a version < 5.11, strict will become
 disabled I<even if you had previously written> C<use strict>. This was not
-the previous behaviour of C<use VERSION>, which at present will track
+the previous behaviour of C<use VERSION>, which at present
+for versions < 5.37 will track
 explicitly-enabled strictness flags independently.
 
 =head3 Use of C<'> as a global name separator.

--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -16,20 +16,6 @@ which they will be removed.
 
 =head2 Perl 5.40
 
-=head3 Downgrading a C<use VERSION> to below v5.11
-
-Once Perl has seen a C<use VERSION> declaration that requests a version
-C<v5.11> or above, a subsequent second declaration that requests an earlier
-version will print a deprecation warning. For example,
-
-    use v5.14;
-    say "We can use v5.14's features here";
-
-    use v5.10;        # This prints a warning
-
-This behaviour will be removed in Perl 5.40; such a subsequent request will
-become a compile-time error.
-
 =head3 Use of C<'> as a global name separator.
 
 Perl allows use of C<'> instead of C<::> to replace the parts of a
@@ -46,6 +32,25 @@ The definition and documentation of three utility functions previously
 importable from L<Pod::Html> were moved to new package L<Pod::Html::Util> in
 Perl 5.36.  While they remain importable from L<Pod::Html> in Perl 5.36, as of
 Perl 5.38 they will only be importable, on request, from L<Pod::Html::Util>.
+
+=head3 Downgrading a C<use VERSION> to below v5.11
+
+Using a C<use VERSION> that requests a version lower than C<v5.11>,
+shadowing an earlier C<use VERSION> that requests version C<v5.11>
+or higher, was deprecated in Perl 5.36.  On that Perl version it
+generates a warning, which says that it will become fatal in Perl 5.40.
+This deprecation has been scrapped, so from Perl 5.38 onwards it no
+longer generates a warning.
+
+If your code contains nested version declarations with this pattern of
+version numbers, and you need to run that code on Perl 5.36, then it
+is desirable to avoid the now-spurious deprecation warning.  One way
+to do this is to replace the inner version declaration with equivalent
+L<feature> and L<strict> pragmata, to which Perl 5.36 won't object.
+Another way is to disable the warning with C<no warnings 'deprecated'>
+just before the inner declaration, then (presuming you generally
+want deprecation warnings enabled) reenable it with C<use warnings
+'deprecated'> just after the declaration.
 
 =head2 Perl 5.34
 

--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -30,14 +30,6 @@ version will print a deprecation warning. For example,
 This behaviour will be removed in Perl 5.40; such a subsequent request will
 become a compile-time error.
 
-This is because of an intended related change to the interaction between
-C<use VERSION> and C<use strict>. If you specify a version >= 5.11, strict is
-enabled implicitly. If you request a version < 5.11, strict will become
-disabled I<even if you had previously written> C<use strict>. This was not
-the previous behaviour of C<use VERSION>, which at present
-for versions < 5.37 will track
-explicitly-enabled strictness flags independently.
-
 =head3 Use of C<'> as a global name separator.
 
 Perl allows use of C<'> instead of C<::> to replace the parts of a

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2175,14 +2175,6 @@ somehow called on another platform.  This should not happen.
 
 (P) The internal handling of magical variables has been cursed.
 
-=item Downgrading a use VERSION declaration to below v5.11 is deprecated
-
-(S deprecated) This warning is emitted on a C<use VERSION> statement that
-requests a version below v5.11 (when the effects of C<use strict> would be
-disabled), after a previous declaration of one having a larger number (which
-would have enabled these effects). This is no longer
-supported.
-
 =item (Do you need to predeclare %s?)
 
 (S syntax) This is an educated guess made in conjunction with the message

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2180,8 +2180,7 @@ somehow called on another platform.  This should not happen.
 (S deprecated) This warning is emitted on a C<use VERSION> statement that
 requests a version below v5.11 (when the effects of C<use strict> would be
 disabled), after a previous declaration of one having a larger number (which
-would have enabled these effects). Because of a change to the way that
-C<use VERSION> interacts with the strictness flags, this is no longer
+would have enabled these effects). This is no longer
 supported.
 
 =item (Do you need to predeclare %s?)

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -10060,16 +10060,6 @@ declaration, including explicit warnings declarations.
 C<use VERSION> does not load the F<feature.pm>, F<strict.pm>, or
 F<warnings.pm> files.
 
-In the current implementation, any explicit use of C<use strict> or
-C<no strict> overrides C<use VERSION> for versions less than 5.37,
-even if the explicit stricture comes before the version pragma.
-However, this may be subject to change in a future release of Perl, so new
-code should not rely on this fact.  It is recommended that a
-C<use VERSION> declaration be the first significant statement within a
-file (possibly after a C<package> statement or any amount of whitespace or
-comment), so that its effects happen first, and other pragmata are applied
-after it.
-
 Specifying VERSION as a numeric argument of the form 5.024001 should
 generally be avoided as older less readable syntax compared to
 v5.24.1. Before perl 5.8.0 released in 2002 the more verbose numeric

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -10036,10 +10036,18 @@ bundle.  See L<feature>.
 If the specified Perl version is 5.37 or higher, strictures are enabled
 lexically, as if L<C<use strict>|strict> had been declared.  If the
 version is 5.11 or higher but less than 5.37, then strictures are enabled
-unless they were already explicitly disabled (by C<no strict>).  If the
+unless they were already firmly disabled (by C<no strict>),
+an effect equivalent to C<use strict 'softly'>.  If the
 version is less than 5.11, then strictures are disabled unless they were
-already explicitly enabled (by C<use strict> or C<use v5.38>).  Similarly,
-if the specified Perl version is 5.35 or higher, L<warnings> are enabled.
+already firmly enabled (by C<use strict> or C<use v5.38>),
+an effect equivalent to C<no strict 'softly'>.
+When declaring a Perl version lower than 5.15, beware that the effect
+of such a declaration on the lexical stricture status was different from
+this in Perl versions before 5.15.6.
+
+If the specified Perl version is 5.35 or higher, L<warnings> are enabled.
+If the specified Perl version is lower than 5.35, there is no effect on
+the lexical warning status.
 
 Later use of C<use VERSION> will override most behavior of a previous
 C<use VERSION>.  The feature set of the later-specified version completely

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -10014,9 +10014,11 @@ functionality from the command-line.
 
 =for Pod::Functions enable Perl language features and declare required version
 
-Lexically enables all features available in the requested version as
-defined by the L<feature> pragma, disabling any features not in the
-requested version's feature bundle.  See L<feature>.
+Performs a Perl version check, and also serves as a base pragma declaring
+the dialect of Perl in which a file is written.  As a lexically-scoped
+pragma it selects a bundle of features defined by the L<feature> pragma,
+adjusts the strictures controlled by the L<strict> pragma, and may also
+enable warnings as if by the L<warnings> pragma.
 
 VERSION may be either a v-string such as v5.24.1, which will be compared
 to L<C<$^V>|perlvar/$^V> (aka $PERL_VERSION), or a numeric argument of the
@@ -10026,16 +10028,41 @@ Perl interpreter; Perl will not attempt to parse the rest of the file.
 Compare with L<C<require>|/require VERSION>, which can do a similar check
 at run time.
 
-If the specified Perl version is 5.12 or higher, strictures are enabled
-lexically as with L<C<use strict>|strict>.  Similarly, if the specified
-Perl version is 5.35.0 or higher, L<warnings> are enabled.  Later use of
-C<use VERSION> will override all behavior of a previous C<use VERSION>,
-possibly removing the C<strict>, C<warnings>, and C<feature> added by it.
+The effect on feature selection is to lexically enable all features
+available in the requested version's bundle as defined by the L<feature>
+pragma, disabling any features not in the requested version's feature
+bundle.  See L<feature>.
+
+If the specified Perl version is 5.37 or higher, strictures are enabled
+lexically, as if L<C<use strict>|strict> had been declared.  If the
+version is 5.11 or higher but less than 5.37, then strictures are enabled
+unless they were already explicitly disabled (by C<no strict>).  If the
+version is less than 5.11, then strictures are disabled unless they were
+already explicitly enabled (by C<use strict> or C<use v5.38>).  Similarly,
+if the specified Perl version is 5.35 or higher, L<warnings> are enabled.
+
+Later use of C<use VERSION> will override most behavior of a previous
+C<use VERSION>.  The feature set of the later-specified version completely
+replaces that of the earlier-specified version, and also any explicit
+feature selection.  Where the later-specified version is less than 5.37,
+its stricture behaviour takes precedence over that of an earlier-specified
+version that is also less than 5.37, but not over explicit stricture
+declarations nor over an earlier-specified version 5.37 or higher.
+Where the later-specified version is 5.37 or higher, its stricture
+behaviour takes precedence over that of any earlier-specified version,
+and also any explicit stricture declaration.  Where the later-specified
+version is less than 5.35, it doesn't affect the lexical warnings status,
+so the warnings aspect of any prior C<use v5.36> and any explicit warnings
+declarations remain in effect.  Where the later-specified version is
+5.35 or higher, its warnings enablement takes precedence over any prior
+declaration, including explicit warnings declarations.
+
 C<use VERSION> does not load the F<feature.pm>, F<strict.pm>, or
 F<warnings.pm> files.
 
 In the current implementation, any explicit use of C<use strict> or
-C<no strict> overrides C<use VERSION>, even if it comes before it.
+C<no strict> overrides C<use VERSION> for versions less than 5.37,
+even if the explicit stricture comes before the version pragma.
 However, this may be subject to change in a future release of Perl, so new
 code should not rely on this fact.  It is recommended that a
 C<use VERSION> declaration be the first significant statement within a

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -3823,7 +3823,6 @@ S_doeval_compile(pTHX_ U8 gimme, CV* outside, U32 seq, HV *hh)
     SAVEHINTS();
     if (clear_hints) {
         PL_hints = HINTS_DEFAULT;
-        PL_prevailing_version = 0;
         hv_clear(GvHV(PL_hintgv));
         CLEARFEATUREBITS();
     }

--- a/scope.c
+++ b/scope.c
@@ -893,14 +893,14 @@ Perl_save_hints(pTHX)
             SS_ADD_INT(PL_hints);
             SS_ADD_PTR(save_cophh);
             SS_ADD_PTR(oldhh);
-            SS_ADD_UV(SAVEt_HINTS_HH | (PL_prevailing_version << 8));
+            SS_ADD_UV(SAVEt_HINTS_HH);
             SS_ADD_END(4);
         }
         GvHV(PL_hintgv) = NULL; /* in case copying dies */
         GvHV(PL_hintgv) = hv_copy_hints_hv(oldhh);
         SAVEFEATUREBITS();
     } else {
-        save_pushi32ptr(PL_hints, save_cophh, SAVEt_HINTS | (PL_prevailing_version << 8));
+        save_pushi32ptr(PL_hints, save_cophh, SAVEt_HINTS);
     }
 }
 
@@ -1594,7 +1594,6 @@ Perl_leave_scope(pTHX_ I32 base)
             cophh_free(CopHINTHASH_get(&PL_compiling));
             CopHINTHASH_set(&PL_compiling, (COPHH*)a1.any_ptr);
             *(I32*)&PL_hints = a0.any_i32;
-            PL_prevailing_version = (U16)(uv >> 8);
             if (type == SAVEt_HINTS_HH) {
                 SvREFCNT_dec(MUTABLE_SV(GvHV(PL_hintgv)));
                 GvHV(PL_hintgv) = MUTABLE_HV(a2.any_ptr);

--- a/t/comp/use.t
+++ b/t/comp/use.t
@@ -154,8 +154,8 @@ like $@, qr/^Can't use string/,
     local $SIG{__WARN__} = sub { $warnings .= $_[0] };
     eval 'use 5.012; use 5.01; ${"foo"} = "bar"';
     is $@, "", 'use 5.01 overrides implicit strict from prev ver decl';
-    like $warnings, qr/^Downgrading a use VERSION declaration to below v5.11 is deprecated, and will become fatal in Perl 5.40 at /,
-        'use 5.01 after use 5.012 provokes deprecation warning';
+    is $warnings, "",
+        'use 5.01 after use 5.012 no longer provokes deprecation warning';
 }
 eval 'no strict "subs"; use 5.012; ${"foo"} = "bar"';
 ok $@, 'no strict subs allows ver decl to enable refs';

--- a/t/lib/feature/implicit
+++ b/t/lib/feature/implicit
@@ -69,7 +69,6 @@ evalbytes;
 use 5;
 say "no"
 EXPECT
-Downgrading a use VERSION declaration to below v5.11 is deprecated, and will become fatal in Perl 5.40 at - line 8.
 yes
 evalbytes sub
 say sub
@@ -81,7 +80,6 @@ print 'ss' =~ /$sharp_s/i ? "ok\n" : "nok\n";
 use v5.8.8;
 print 'ss' =~ /$sharp_s/i ? "ok\n" : "nok\n";
 EXPECT
-Downgrading a use VERSION declaration to below v5.11 is deprecated, and will become fatal in Perl 5.40 at - line 5.
 ok
 nok
 ########
@@ -93,6 +91,5 @@ print eval "use utf8; q|$long_s|" eq $long_s ? "ok\n" : "nok\n";
 use v5.8.8;
 print eval "use utf8; q|$long_s|" eq "\x{17f}" ? "ok\n" : "nok\n";
 EXPECT
-Downgrading a use VERSION declaration to below v5.11 is deprecated, and will become fatal in Perl 5.40 at - line 6.
 ok
 ok


### PR DESCRIPTION
Zefram said in <ZAgxPYPklHlaGfgt@fysh.org> on perl5-porters mail /strictness and "use 5.whatever"/

I have an opinion on a change that was made when I wasn't around: the
deprecation and planned changes around the interaction of strictness
and "use 5.whatever" are a bad idea.  The actual planned changes are
unjustified, and the deprecation doesn't match the planned changes.

First I'll consider the intended changes.  As I understand it, the
intention is that in the future "use 5.whatever", for historical version
numbers, will unconditionally set the lexical stricture status, either on
or off, according to the version being requested.  This is in contrast
to the present situation, where such usage can turn strictures on, for
some versions, but won't turn on strictures that have previously been
explicitly turned off.  This means that, for example, "no strict; use
5.016;", which currently turns strictures off, will instead turn them
on, and "use strict; use 5.010;", which currently turns strictures on,
will instead turn them off.

What is the purpose of this change?  It wouldn't remove some facility that
is onerous to maintain.  The lexical stricture status will still exist.
All it would change is the arrangement of declarations by which the
strictures are controlled.  The only things that could be removed as a
result are the stricture-explicitly-set bits.  The cost of making this
change would be to break perfectly good existing programs that rely on,
for example, "no strict; use 5.016;" being a valid preambla that provides
a non-strict lexical status.  That is not an unreasonable combination
of declarations: there's nothing a priori wrong about stricture being
declared before feature bundle.  This preamble has been permitted and
had its present meaning ever since the release of Perl 5.16.

To thus change the meanings of "use 5.016;", "use 5.010;", and all the
others, is directly contrary to the promise of stability implied by the
use of an explicit version number.  It's fine for "use 5.038;" to take
precedence over a prior "no strict;", if it did so consistently from its
earliest legality in Perl 5.38.  But historical version numbers shouldn't
change their meanings.  (The situation is different for "use 5.012;"
and "use 5.014;", which did take precedence over a prior "no strict;"
in Perls 5.12 and 5.14, but then changed meaning in Perl 5.16.  That's a
historical mistake, but the 5.16 treatment should now probably stand.)

This planned change would only cause gratuitous breakage of code that
relied on the stability implied by using an explicit version number.
Doing so would not only be wrong in itself, but it would also discredit
that promise of stability, with respect to any version number, for the
indefinite future.  It would become understood that to reliably set up the
lexical state requires explicitly stating the stricture and feature flags,
because the version-number bundles are unstable.  This would result in
"use VERSION" becoming yet another of Perl's features that programmers
of good taste eschew but which cause a core maintenance burden forever.

Next, I'll look at the deprecation per se.  The deprecated thing is
having a "use 5.010;" shadow a prior "use 5.016;" or other use with a
higher version number.  As with the above, this is not actually enabling
the removal of anything problematic, but only tinkering with the way
that lexical state gets declared.  As with the above, "use 5.016; use
5.010;" is not an a priori unreasonable combination of declarations:
we generally permit lexical declarations to shadow earlier ones, taking
effect in a narrower scope.  And as with the above, this combination
of declarations has been legal and had its present meaning as long as
those declarations have individually been legal.

So, as with the situation regarding stricture flags, the future
fatalisation of what is now deprecated would just be gratuitous breakage.
A clean fatalisation of a particular combination of declarations is less
bad than leaving them legal and just changing their meaning, but it's
still an unjustified change that is contrary to the stability expectations
of this type of declaration.  Not only would the fatalisation do damage
to the feature's reputation for stability, but some of that damage has
already been done by means of the deprecation per se.

Finally, what about the relationship between the deprecation and
the planned future change in semantics?  There pretty much isn't one.
The thing that is currently deprecated and the thing that it is planned
to change (which supposedly motivates the deprecation) not only are
not the same thing, but have essentially no overlap.  Things such as
"no strict; use 5.016;", the meaning of which it is intended to change,
are not deprecated, and deprecated things such as "use 5.016; use 5.010;"
pose no difficulty for the planned change in stricture control.  The two
kinds of declaration combination are only quite loosely connected.

So the deprecation doesn't support the change that supposedly motivates
it, and it has no motivation of its own.  It is misconceived.

In my opinion, because neither the proposed semantic change nor
the deprecation have good justification, both should be abandoned.
The deprecation warning should be eliminated, and programmers who
were affected by it should be advised to muffle the warning (which
unfortunately can't be done any more specifically than the "deprecated"
category).  The documentation should stop warning about both future
changes.  Doing this before 5.38 would be the way to minimise the damage
done by the bad decision in 5.36.

If there is still some compelling reason to prohibit "use 5.016; use
5.010;", then this needs to be justified in its own right.  Reference to
a plan to change the treatment of stricture bits doesn't cover this issue.

If there is still some compelling reason to stop supporting the current
semantics of "no strict; use 5.016;", then it needs to be handled
differently.  It should not change to just have a different effect on the
stricture bits, but rather, if the current meaning is not acceptable,
this combination should become prohibited.  Any change in meaning,
whether to become prohibited or to be legal with a different meaning,
should be preceded by a deprecation cycle, where the deprecation warns
about the thing that's going to change meaning, not about an unrelated
thing located nearby.
