### PR TITLE
ext/Hash/Util.pm - support "protected hashes"

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4579,7 +4579,9 @@ ext/Hash-Util/Changes			Change history of Hash::Util
 ext/Hash-Util/lib/Hash/Util.pm		Hash::Util
 ext/Hash-Util/Makefile.PL		Makefile for Hash::Util
 ext/Hash-Util/t/builtin.t		See if Hash::Util builtin exports work as expected
-ext/Hash-Util/t/Util.t			See if Hash::Util works
+ext/Hash-Util/t/locked.t		See if Hash::Util locked hash support works as expected
+ext/Hash-Util/t/misc.t			See if Hash::Util misc functions work as expected
+ext/Hash-Util/t/protect.t		See if Hash::Util protected hash support works as expected
 ext/Hash-Util/Util.xs			XS bits of Hash::Util
 ext/Hash-Util-FieldHash/Changes				Changes for Hash::Util::FieldHash
 ext/Hash-Util-FieldHash/FieldHash.xs			XS portion

--- a/dist/Storable/Storable.pm
+++ b/dist/Storable/Storable.pm
@@ -28,7 +28,7 @@ our @EXPORT_OK = qw(
 our ($canonical, $forgive_me);
 
 BEGIN {
-  our $VERSION = '3.31';
+  our $VERSION = '3.32';
 }
 
 our $recursion_limit;

--- a/embed.fnc
+++ b/embed.fnc
@@ -4258,7 +4258,8 @@ S	|void	|hv_free_entries|NN HV *hv
 ST	|void	|hv_magic_check |NN HV *hv				\
 				|NN bool *needs_copy			\
 				|NN bool *needs_store
-Sr	|void	|hv_notallowed	|int flags				\
+Sr	|void	|hv_notallowed	|NN HV *hv				\
+				|int flags				\
 				|NN const char *key			\
 				|I32 klen				\
 				|NN const char *msg

--- a/embed.h
+++ b/embed.h
@@ -1246,7 +1246,7 @@
 #     define hv_free_ent_ret(a)                 S_hv_free_ent_ret(aTHX_ a)
 #     define hv_free_entries(a)                 S_hv_free_entries(aTHX_ a)
 #     define hv_magic_check                     S_hv_magic_check
-#     define hv_notallowed(a,b,c,d)             S_hv_notallowed(aTHX_ a,b,c,d)
+#     define hv_notallowed(a,b,c,d,e)           S_hv_notallowed(aTHX_ a,b,c,d,e)
 #     define refcounted_he_value(a)             S_refcounted_he_value(aTHX_ a)
 #     define save_hek_flags                     S_save_hek_flags
 #     define share_hek_flags(a,b,c,d)           S_share_hek_flags(aTHX_ a,b,c,d)

--- a/ext/Hash-Util/Util.xs
+++ b/ext/Hash-Util/Util.xs
@@ -7,6 +7,53 @@
 MODULE = Hash::Util		PACKAGE = Hash::Util
 
 void
+lock_hashkeys(hv)
+        HV *hv
+    PROTOTYPE: \%
+    CODE:
+        SvFLAGS((SV*)hv) |= (SVf_READONLY);
+
+void
+unlock_hashkeys(hv)
+        HV *hv
+    PROTOTYPE: \%
+    CODE:
+        if (SvFLAGS((SV*)hv) & SVf_PROTECT)
+            croak("Cannot _unlock_hashkeys() on a read-only hash");
+        SvFLAGS((SV*)hv) &= ~SVf_READONLY;
+
+void
+hashkeys_locked(hv)
+        HV *hv
+    PROTOTYPE: \%
+    ALIAS: hash_locked => hashkeys_locked
+    PPCODE:
+        PERL_UNUSED_ARG(ix);
+        if ((SvFLAGS((SV*)hv) & (SVf_READONLY|SVf_PROTECT)) == (SVf_READONLY))
+            XSRETURN_YES;
+        else
+            XSRETURN_NO;
+
+void
+hashkeys_protected(hv)
+        HV *hv
+    PROTOTYPE: \%
+    ALIAS: hash_readonly => hashkeys_protected
+    PPCODE:
+        PERL_UNUSED_ARG(ix);
+        if ((SvFLAGS((SV*)hv) & (SVf_READONLY|SVf_PROTECT)) == (SVf_READONLY|SVf_PROTECT))
+            XSRETURN_YES;
+        else
+            XSRETURN_NO;
+
+void
+protect_hashkeys(hv)
+        HV *hv
+    PROTOTYPE: \%
+    CODE:
+        SvFLAGS(hv) |= (SVf_READONLY|SVf_PROTECT);
+
+void
 _clear_placeholders(hashref)
         HV *hashref
     PROTOTYPE: \%
@@ -325,4 +372,3 @@ used_buckets(rhv)
     }
     XSRETURN_UNDEF;
 }
-

--- a/ext/Hash-Util/lib/Hash/Util.pm
+++ b/ext/Hash-Util/lib/Hash/Util.pm
@@ -7,7 +7,7 @@ use warnings;
 no warnings 'uninitialized';
 use warnings::register;
 no warnings 'experimental::builtin';
-use builtin qw(reftype);
+use builtin qw(reftype refaddr);
 
 require Exporter;
 our @EXPORT_OK  = qw(
@@ -20,6 +20,9 @@ our @EXPORT_OK  = qw(
                      lock_keys_plus
                      hash_locked hash_unlocked
                      hashref_locked hashref_unlocked
+                     hashkeys_locked
+                     unlock_hashkeys
+                     lock_hashkeys
                      hidden_keys legal_keys
 
                      lock_ref_keys unlock_ref_keys
@@ -33,6 +36,13 @@ our @EXPORT_OK  = qw(
                      lock_hash_recurse unlock_hash_recurse
                      lock_hashref_recurse unlock_hashref_recurse
 
+                     protect_hash
+                     protect_hashref
+                     protect_hashkeys
+                     protect_hash_recursive
+                     protect_hashref_recursive
+                     hashkeys_protected
+
                      hash_traversal_mask
 
                      bucket_ratio
@@ -42,7 +52,7 @@ our @EXPORT_OK  = qw(
 BEGIN {
     # make sure all our XS routines are available early so their prototypes
     # are correctly applied in the following code.
-    our $VERSION = '0.30';
+    our $VERSION = '0.31';
     require XSLoader;
     XSLoader::load();
 }
@@ -188,14 +198,14 @@ sub lock_ref_keys {
         foreach my $k (@keys) {
             $hash->{$k} = undef unless exists $hash->{$k};
         }
-        Internals::SvREADONLY %$hash, 1;
+        lock_hashkeys(%$hash);
 
         foreach my $k (@keys) {
             delete $hash->{$k} unless $original_keys{$k};
         }
     }
     else {
-        Internals::SvREADONLY %$hash, 1;
+        lock_hashkeys(%$hash);
     }
 
     return $hash;
@@ -204,7 +214,7 @@ sub lock_ref_keys {
 sub unlock_ref_keys {
     my $hash = shift;
 
-    Internals::SvREADONLY %$hash, 0;
+    unlock_hashkeys(%$hash);
     return $hash;
 }
 
@@ -214,8 +224,7 @@ sub unlock_keys (\%)   { unlock_ref_keys(@_) }
 #=item B<_clear_placeholders>
 #
 # This function removes any placeholder keys from a hash. See Perl_hv_clear_placeholders()
-# in hv.c for what it does exactly. It is currently exposed as XS by universal.c and
-# injected into the Hash::Util namespace.
+# in hv.c for what it does exactly.
 #
 # It is not intended for use outside of this module, and may be changed
 # or removed without notice or deprecation cycle.
@@ -249,7 +258,7 @@ sub lock_ref_keys_plus {
             push @delete,$key;
         }
     }
-    Internals::SvREADONLY(%$hash,1);
+    lock_hashkeys(%$hash);
     delete @{$hash}{@delete};
     return $hash
 }
@@ -276,11 +285,6 @@ Returns a reference to the %hash.
 
 sub lock_ref_value {
     my($hash, $key) = @_;
-    # I'm doubtful about this warning, as it seems not to be true.
-    # Marking a value in the hash as RO is useful, regardless
-    # of the status of the hash itself.
-    carp "Cannot usefully lock values in an unlocked hash"
-      if !Internals::SvREADONLY(%$hash) && warnings::enabled;
     Internals::SvREADONLY $hash->{$key}, 1;
     return $hash
 }
@@ -408,11 +412,9 @@ Returns true if the hash and its keys are locked.
 =cut
 
 sub hashref_locked {
-    my $hash=shift;
-    Internals::SvREADONLY(%$hash);
+    my $hash = shift;
+    hashkeys_locked(%$hash);
 }
-
-sub hash_locked(\%) { hashref_locked(@_) }
 
 =item B<hashref_unlocked>
 
@@ -426,19 +428,11 @@ Returns true if the hash and its keys are unlocked.
 =cut
 
 sub hashref_unlocked {
-    my $hash=shift;
-    !Internals::SvREADONLY(%$hash);
+    my $hash = shift;
+    !hashkeys_locked(%$hash);
 }
 
 sub hash_unlocked(\%) { hashref_unlocked(@_) }
-
-=for demerphqs_editor
-sub legal_ref_keys{}
-sub hidden_ref_keys{}
-sub all_keys{}
-
-=cut
-
 sub legal_keys(\%) { legal_ref_keys(@_)  }
 sub hidden_keys(\%){ hidden_ref_keys(@_) }
 
@@ -489,6 +483,61 @@ on the current implementation of restricted hashes. Should the
 implementation change this routine may become meaningless in which
 case it will behave identically to how it would behave on an
 unrestricted hash.
+
+=cut
+
+=item B<protect_hash_recursive>
+
+=cut
+
+sub _protect_any_recursive {
+    my ($value, $seen)= @_;
+    my $reftype = reftype($value);
+    if ($reftype) {
+        my $refaddr = refaddr($value);
+        return if $seen->{$refaddr}++;
+        if ($reftype eq "ARRAY") {
+            Internals::SvREADONLY @$value, 1;
+            for my $aval (@$value) {
+                Internals::SvREADONLY $aval, 1;
+                _protect_any_recursive($aval,$seen);
+            }
+        }
+        elsif ($reftype eq "HASH") {
+            protect_hashkeys(%$value);
+            for my $hval (values %$value) {
+                Internals::SvREADONLY $hval, 1;
+                _protect_any_recursive($hval,$seen);
+            }
+        }
+        elsif ($reftype eq "REF" or $reftype eq "SCALAR") {
+            Internals::SvREADONLY $_[0], 1;
+            _protect_any_recursive(${$_[0]},$seen);
+        }
+    } else {
+        Internals::SvREADONLY $_[0], 1;
+    }
+}
+
+sub protect_hashref_recursive {
+    my ($hash) = @_;
+    _protect_any_recursive($hash);
+}
+
+sub protect_hash_recursive (\%) {
+    my ($hash) = @_;
+    protect_hashref_recursive($hash);
+}
+
+sub protect_hashref {
+    my ($hash) = @_;
+    protect_hashkeys(%$hash);
+    Internals::SvREADONLY $_, 1 for values %$hash;
+}
+
+sub protect_hash (\%) {
+    protect_hashref($_[0]);
+}
 
 =item B<hash_seed>
 

--- a/ext/Hash-Util/t/misc.t
+++ b/ext/Hash-Util/t/misc.t
@@ -1,0 +1,102 @@
+#!/usr/bin/perl -Tw
+
+BEGIN {
+    if ($ENV{PERL_CORE}) {
+	require Config; import Config;
+	no warnings 'once';
+	if ($Config{extensions} !~ /\bHash\/Util\b/) {
+	    print "1..0 # Skip: Hash::Util was not built\n";
+	    exit 0;
+	}
+    }
+}
+
+use strict;
+use Test::More;
+
+sub numbers_first { # Sort helper: All digit entries sort in front of others
+                    # Makes sorting portable across ASCII/EBCDIC
+    return $a cmp $b if ($a =~ /^\d+$/) == ($b =~ /^\d+$/);
+    return -1 if $a =~ /^\d+$/;
+    return 1;
+}
+
+my @Exported_Funcs;
+BEGIN {
+    @Exported_Funcs = qw(
+                     bucket_array
+                     bucket_info
+                     bucket_stats
+                     hash_seed
+                     hash_value
+                     hv_store
+                    );
+    plan tests => 19 + @Exported_Funcs;
+    use_ok 'Hash::Util', @Exported_Funcs;
+}
+foreach my $func (@Exported_Funcs) {
+    can_ok __PACKAGE__, $func;
+}
+
+my $hash_seed = hash_seed();
+my $hash_seed_hex = unpack("H*", $hash_seed);
+ok(defined($hash_seed) && $hash_seed ne '', "hash_seed ($hash_seed_hex)");
+
+{
+    my $x='foo';
+    my %test;
+    hv_store(%test,'x',$x);
+    is($test{x},'foo','hv_store() stored');
+    $test{x}='bar';
+    is($x,'bar','hv_store() aliased');
+    is($test{x},'bar','hv_store() aliased and stored');
+}
+
+{
+    my $h1= hash_value("foo");
+    my $h2= hash_value("bar");
+    is( $h1, hash_value("foo"), "hash value for 'foo' is repeatable" );
+    is( $h2, hash_value("bar"), "hash value for 'bar' is repeatable" );
+
+    my $seed= hash_seed();
+    my $h1s= hash_value("foo",$seed);
+    my $h2s= hash_value("bar",$seed);
+
+    is( $h1s, hash_value("foo",$seed), "hash value for 'foo' is repeatable with a seed" );
+    is( $h2s, hash_value("bar",$seed), "hash value for 'bar' is repeatable with a seed" );
+
+    $seed= join "", map { chr $_ } 1..length($seed);
+
+    my $h1s2= hash_value("foo",$seed);
+    my $h2s2= hash_value("bar",$seed);
+
+    is( $h1s2, hash_value("foo",$seed), "hash value for 'foo' is repeatable with a different seed" );
+    is( $h2s2, hash_value("bar",$seed), "hash value for 'bar' is repeatable with a different seed" );
+
+    isnt($h1s,$h1s2, "hash value for 'foo' should differ between seeds");
+    isnt($h1s,$h1s2, "hash value for 'bar' should differ between seeds");
+
+}
+
+{
+    my @info1= bucket_info({});
+    my @info2= bucket_info({1..10});
+    my @stats1= bucket_stats({});
+    my @stats2= bucket_stats({1..10});
+    my $array1= bucket_array({});
+    my $array2= bucket_array({1..10});
+    is("@info1", "0 8 0",
+        "Check bucket_info results for empty hash are as expected");
+    like("@info2[0,1]", qr/5 (?:8|16)/,
+        "check bucket_info results for hash with 5 keys are as expected" );
+    is("@stats1", "0 8 0",
+        "Check bucket_stats for empty hash are as expected");
+    like("@stats2[0,1]", qr/5 (?:8|16)/,
+        "Check bucket_stats for hash with 5 keys are as expected");
+    my @keys1= sort map { ref $_ ? @$_ : () } @$array1;
+    my @keys2= sort map { ref $_ ? @$_ : () } @$array2;
+    is("@keys1", "",
+        "bucket_array for empty hash should be empty");
+    is("@keys2", "1 3 5 7 9",
+        "bucket_array for 5 keys should contain all 5 keys");
+}

--- a/ext/Hash-Util/t/protect.t
+++ b/ext/Hash-Util/t/protect.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Hash::Util qw(protect_hash
+                  protect_hash_recursive
+                  protect_hashkeys);
+{
+
+    my %hash = ( foo => 1, baz => 2, bop => 3, ary => [] );
+    protect_hash(%hash);
+    my $type = "protected hash";
+
+    ok(!eval { $hash{xxx} = 1 },        "assignment to unknown key in $type dies");
+    ok(!eval { $hash{foo} = 1 },        "assignment to existing key in $type dies");
+    ok( eval { my $y = $hash{yyy}; 1 }, "read from unknown key in $type does not die");
+    ok( eval { my $y = $hash{baz}; 1 }, "read from existing key in $type does not die");
+    ok(!eval { $hash{ary}= [ "other" ] }, "assignment to array in $type dies" );
+    ok( eval { push @{$hash{ary}}, "test"; 1}, "pushing into array in $type does not die");
+}
+{
+
+    my %hash = ( foo => 1, baz => 2, bop => 3, ary => [],
+                 subhash => { sk => 1, sa => [ "x" ] } );
+    protect_hash_recursive(%hash);
+    my $type = "recursively protected hash";
+
+    ok(!eval { $hash{xxx} = 1 },        "assignment to unknown key in $type dies");
+    ok(!eval { $hash{foo} = 1 },        "assignment to existing key in $type dies");
+    ok( eval { my $y = $hash{yyy}; 1 }, "read from unknown key in $type does not die");
+    ok( eval { my $y = $hash{baz}; 1 }, "read from existing key in $type does not die");
+    ok(!eval { $hash{ary}= [ "other" ]; 1 }, "assignment to array in $type dies" );
+    ok(!eval { push @{$hash{ary}}, "test"; 1}, "pushing into array in $type does die");
+    ok(!eval { push @{$hash{subhash}{sa}}, "test"; 1}, "pushing into sub array in $type does die");
+    ok(!eval { $hash{subhash}{sk}++; 1}, "plus-plus of sub key in $type does die");
+}
+
+done_testing();
+

--- a/hv.c
+++ b/hv.c
@@ -300,7 +300,7 @@ Perl_he_dup(pTHX_ const HE *e, bool shared, CLONE_PARAMS* param)
 #endif	/* USE_ITHREADS */
 
 static void
-S_hv_notallowed(pTHX_ int flags, const char *key, I32 klen,
+S_hv_notallowed(pTHX_ HV *hv, int flags, const char *key, I32 klen,
                 const char *msg)
 {
    /* Straight to SVt_PVN here, as needed by sv_setpvn_fresh and
@@ -320,7 +320,7 @@ S_hv_notallowed(pTHX_ int flags, const char *key, I32 klen,
     if (flags & HVhek_UTF8) {
         SvUTF8_on(sv);
     }
-    Perl_croak(aTHX_ msg, SVfARG(sv));
+    Perl_croak(aTHX_ msg, SVfARG(sv), SvFLAGS((SV*)hv) & SVf_PROTECT ? "read-only" : "restricted");
 }
 
 /* (klen == HEf_SVKEY) is special for MAGICAL hv entries, meaning key slot
@@ -911,10 +911,17 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
     }
 #endif
 
-    if (!entry && SvREADONLY(hv) && !(action & HV_FETCH_ISEXISTS)) {
-        hv_notallowed(flags, key, klen,
-                        "Attempt to access disallowed key '%" SVf "' in"
-                        " a restricted hash");
+    if (!entry && SvREADONLY(hv)) {
+        if (action & (HV_FETCH_ISSTORE|HV_FETCH_LVALUE)) {
+            hv_notallowed(hv, flags, key, klen,
+                            "Attempt to store value into unknown key '%" SVf "' in"
+                            " a %s hash");
+        }
+        else if (!(action & HV_FETCH_ISEXISTS) && !(SvFLAGS(hv) & SVf_PROTECT)) {
+            hv_notallowed(hv, flags, key, klen,
+                            "Attempt to access unknown key '%" SVf "' in"
+                            " a %s hash");
+        }
     }
     if (!(action & (HV_FETCH_LVALUE|HV_FETCH_ISSTORE))) {
         /* Not doing some form of store, so return failure.  */
@@ -1402,9 +1409,9 @@ S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
             return NULL;
         }
         if (SvREADONLY(hv) && sv && SvREADONLY(sv)) {
-            hv_notallowed(k_flags, key, klen,
-                            "Attempt to delete readonly key '%" SVf "' from"
-                            " a restricted hash");
+            hv_notallowed(hv, k_flags, key, klen,
+                            "Attempt to delete key '%" SVf "' from"
+                            " a %s hash");
         }
 
         /*
@@ -1558,9 +1565,9 @@ S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
 
   not_found:
     if (SvREADONLY(hv)) {
-        hv_notallowed(k_flags, key, klen,
-                        "Attempt to delete disallowed key '%" SVf "' from"
-                        " a restricted hash");
+        hv_notallowed(hv, k_flags, key, klen,
+                        "Attempt to delete unknown key '%" SVf "' from"
+                        " a %s hash");
     }
 
     if (k_flags & HVhek_FREEKEY)

--- a/lib/Internals.t
+++ b/lib/Internals.t
@@ -109,24 +109,25 @@ is($foo{'foo'}, 1);
 
 ok(  Internals::SvREADONLY %foo, 1 );
 ok(  Internals::SvREADONLY %foo );
+
 eval { undef(%foo); };
-like($@, $ro_err, q/Can't undef read-only hash/);
-TODO: {
-    local $TODO = 'Due to restricted hashes implementation';
-    eval { %foo = ('ping' => 'pong'); };
-    like($@, $ro_err, q/Can't modify read-only hash/);
-}
+like($@, $ro_err, q/Can't undef restricted hash/); # arguably this is the wrong message
+
+eval { %foo = ('ping' => 'pong'); };
+like($@, qr/Attempt to store value into unknown key 'ping' in a restricted hash/, 
+         q/Can't add to a restricted hash via list list assignment/);
 eval { $foo{'baz'} = 123; };
-like($@, qr/Attempt to access disallowed key/, q/Can't add to a read-only hash/);
+like($@, qr/Attempt to store value into unknown key 'baz' in a restricted hash/, 
+         q/Can't add to a restricted hash/);
 
 # These ops are allow for Hash::Util functionality
 $foo{2} = 'qux';
-is($foo{2}, 'qux', 'Can modify elements in a read-only hash');
+is($foo{2}, 'qux', 'Can modify elements in a restricted hash');
 my $qux = delete($foo{2});
-ok(! exists($foo{2}), 'Can delete keys from a read-only hash');
+ok(! exists($foo{2}), 'Can delete keys from a restricted hash');
 is($qux, 'qux');
 $foo{2} = 2;
-is($foo{2}, 2, 'Can add back deleted keys in a read-only hash');
+is($foo{2}, 2, 'Can add back deleted keys in a restricted hash');
 
 ok( !Internals::SvREADONLY %foo, 0 );
 ok( !Internals::SvREADONLY %foo );

--- a/proto.h
+++ b/proto.h
@@ -6972,10 +6972,10 @@ S_hv_magic_check(HV *hv, bool *needs_copy, bool *needs_store);
         assert(hv); assert(needs_copy); assert(needs_store)
 
 PERL_STATIC_NO_RET void
-S_hv_notallowed(pTHX_ int flags, const char *key, I32 klen, const char *msg)
+S_hv_notallowed(pTHX_ HV *hv, int flags, const char *key, I32 klen, const char *msg)
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_HV_NOTALLOWED         \
-        assert(key); assert(msg)
+        assert(hv); assert(key); assert(msg)
 
 STATIC SV *
 S_refcounted_he_value(pTHX_ const struct refcounted_he *he);


### PR DESCRIPTION
Restricted (aka locked) hashes are "read only" but have the special extra behavior that they die if code attempts to read from unknown keys. This is helpful for hash based objects but it makes locked hashes almost useless for most other purposes where someone might want a "read only" hash.

It turns out that we have two bits used to mark things are read only. SVf_READONLY and SVf_PROTECTED. Ironically, SVf_PROTECTED was added because SVf_READONLY was used for implementing "restricted hashes", and there is an expectation that is ok to turn off the SVf_READONLY flag as part of the "restricted/locked hash" API, and we needed a flag that means "really read only", so the internals will set BOTH flags when something is meant to be "really readonly", primarily on scalars. This means that we can implement a "true" read only hash by using the same trick for HV's.

Thus an HV that has both flags set can be treated separately from an HV that has only the SVf_READONLY flag set, and made to *not* die if someone wants to access a key that is not in the hash. (Yes this sounds confusing here, but in practice it is pretty straight forward.)

Because "readonly" is a bit awkward as it does not have a verb form, compared to the terms used for restricted hashes: "lock" is a verb, and "locked" an adjective, we use the term "protect" and "protected" to achieve API symmetry with "lock" and "locked".

With a compound structure like a hash there are multiple levels where "readonly" can apply. There is the level of the keys that the hash contains, there is the level of the values it contains, and there is the level of the values it contains recursively. With restricted hashes we support all three, and for protected hashes we need to do the same thing. This patch supports "protect_hashkeys", "protect_hash", and "protect_hash_recursive" to cover the three levels.

The function protect_hashkeys sets the flags such that the keys in a hash may not be changed, just like restricted hashes, with the key difference being that fetching a non-existent key does not throw an error, it simply returns undef, unless the fetch is in LVALUE context in which case it will be treated as a store and throw an exception.

The function protect_hash is like protect_hashkeys, but also marks the values in the hash as readonly. Note that for references this only affects the reference itself, it does not affect the referenced object. Thus in

        %hash = ( k => { k2 => 1 } ); protect_hash(%hash);

the value in $hash{k} may not be changed, but the contents of the hash it references may be changed, so for instance $hash{k}{other}=1 would be legal.

The function protect_hash_recursive() recursively protects the entire hash, marking every items it contains as read-only or protected, but recursively, going as deep down the dependency tree as required and possible.