### PR TITLE
Porting/cmpVERSION.pl - Handle new modules as not an error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -732,6 +732,7 @@ John W. Krahn
 John Wright                    <john@johnwright.org>
 Johnny Lam                     <jlam@jgrind.org>
 Jon Eveland                    <jweveland@yahoo.com>
+Jon Gentle                     <atrodo@atrodo.org>
 Jon Gunnip                     <jongunnip@hotmail.com>
 Jon Orwant                     <orwant@oreilly.com>
 Jonathan Biggar                <jon@sems.com>

--- a/Porting/cmpVERSION.pl
+++ b/Porting/cmpVERSION.pl
@@ -250,6 +250,12 @@ foreach my $pm_file (sort keys %module_diffs) {
     if (!defined $orig_pm_version || $orig_pm_version eq 'undef') { # sigh
         print "ok $count - SKIP Can't parse \$VERSION in $pm_file\n"
           if $tap;
+
+        # Behave like a version bump if the orig version could not be parsed,
+        # but the current file could
+        if (defined $pm_version && $pm_version ne 'undef' && $pm_file =~ m!^((?:dist|ext|cpan)/[^/]+)/!) {
+            $dist_bumped{$1}++;
+        }
     } elsif (!defined $pm_version || $pm_version eq 'undef') {
         my $nok = "not ok $count - in $pm_file version was $orig_pm_version, now unparsable\n";
         print $nok if $tap;


### PR DESCRIPTION
Checking that a module version was bumped when .c/.h files are updated has an edge case where the previous version was unknown, notably when adding a new module to cpan/. The fix for this is to mark new modules as a new version in those cases