### PR TITLE
Mark vtable in sv_unmagicext as const

### DIFF
--- a/dist/Devel-PPPort/parts/embed.fnc
+++ b/dist/Devel-PPPort/parts/embed.fnc
@@ -1943,7 +1943,7 @@ Apd	|bool	|sv_streq_flags	|NULLOK SV* sv1|NULLOK SV* sv2|const U32 flags
 CpMdb	|void	|sv_taint	|NN SV* sv
 CpdR	|bool	|sv_tainted	|NN SV *const sv
 Apd	|int	|sv_unmagic	|NN SV *const sv|const int type
-Apd	|int	|sv_unmagicext	|NN SV *const sv|const int type|NULLOK MGVTBL *vtbl
+Apd	|int	|sv_unmagicext	|NN SV *const sv|const int type|NULLOK const MGVTBL *vtbl
 ApdMb	|void	|sv_unref	|NN SV* sv
 Apd	|void	|sv_unref_flags	|NN SV *const ref|const U32 flags
 Cpd	|void	|sv_untaint	|NN SV *const sv

--- a/dist/Devel-PPPort/parts/inc/magic
+++ b/dist/Devel-PPPort/parts/inc/magic
@@ -211,7 +211,7 @@ mg_findext(const SV * sv, int type, const MGVTBL *vtbl) {
 #if { NEED sv_unmagicext }
 
 int
-sv_unmagicext(pTHX_ SV *const sv, const int type, MGVTBL *vtbl)
+sv_unmagicext(pTHX_ SV *const sv, const int type, const MGVTBL *vtbl)
 {
     MAGIC* mg;
     MAGIC** mgp;

--- a/embed.fnc
+++ b/embed.fnc
@@ -3319,7 +3319,7 @@ Adp	|int	|sv_unmagic	|NN SV * const sv			\
 				|const int type
 Adp	|int	|sv_unmagicext	|NN SV * const sv			\
 				|const int type 			\
-				|NULLOK MGVTBL *vtbl
+				|NULLOK const MGVTBL *vtbl
 AMbdp	|void	|sv_unref	|NN SV *sv
 Adp	|void	|sv_unref_flags |NN SV * const ref			\
 				|const U32 flags

--- a/proto.h
+++ b/proto.h
@@ -4886,7 +4886,7 @@ Perl_sv_unmagic(pTHX_ SV * const sv, const int type);
         assert(sv)
 
 PERL_CALLCONV int
-Perl_sv_unmagicext(pTHX_ SV * const sv, const int type, MGVTBL *vtbl);
+Perl_sv_unmagicext(pTHX_ SV * const sv, const int type, const MGVTBL *vtbl);
 #define PERL_ARGS_ASSERT_SV_UNMAGICEXT          \
         assert(sv)
 

--- a/sv.c
+++ b/sv.c
@@ -5912,7 +5912,7 @@ Perl_sv_magic(pTHX_ SV *const sv, SV *const obj, const int how,
 }
 
 static int
-S_sv_unmagicext_flags(pTHX_ SV *const sv, const int type, MGVTBL *vtbl, const U32 flags)
+S_sv_unmagicext_flags(pTHX_ SV *const sv, const int type, const MGVTBL *vtbl, const U32 flags)
 {
     MAGIC* mg;
     MAGIC** mgp;
@@ -5977,7 +5977,7 @@ Removes all magic of type C<type> with the specified C<vtbl> from an SV.
 */
 
 int
-Perl_sv_unmagicext(pTHX_ SV *const sv, const int type, MGVTBL *vtbl)
+Perl_sv_unmagicext(pTHX_ SV *const sv, const int type, const MGVTBL *vtbl)
 {
     PERL_ARGS_ASSERT_SV_UNMAGICEXT;
     return S_sv_unmagicext_flags(aTHX_ sv, type, vtbl, 1);


### PR DESCRIPTION
This marks the vtable argument to `sv_unmagicext` as const, just like it has been in `sv_magicext` since 2007 (53d44271720d88220a01b5620a93869665083b01. It not being marked as such caused compiler warnings when using it with a static const vtable (which in practice almost all vtables should be).