### PR TITLE
Revert "fixup, use old logic until 5.37 - TO BE SQUASHED"

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -3487,15 +3487,7 @@ Perl_mortal_getenv(const char * str)
 PERL_STATIC_INLINE bool
 Perl_sv_isbool(pTHX_ const SV *sv)
 {
-    /* change to the following in 5.37, logically the same but
-     * more efficient and more future proof */
-#if 0
-    return (SvBoolFlagsOK(sv) && BOOL_INTERNALS_sv_isbool(sv));
-#else
-    return SvIOK(sv) && SvPOK(sv) && SvIsCOW_static(sv) &&
-        (SvPVX_const(sv) == PL_Yes || SvPVX_const(sv) == PL_No);
-#endif
-
+    return SvBoolFlagsOK(sv) && BOOL_INTERNALS_sv_isbool(sv);
 }
 
 #ifdef USE_ITHREADS


### PR DESCRIPTION
This reverts commit 57e785fdb86b4eb41afd139372aab7841223385f.

This uses the new logic instead of the workaround. Thanks to Ilmari for the reminder.