### PR TITLE
Various regex engine minor changes for @iabyn

### DIFF
--- a/dist/Devel-PPPort/parts/embed.fnc
+++ b/dist/Devel-PPPort/parts/embed.fnc
@@ -523,7 +523,7 @@
 :
 :   U  autodoc.pl will not output a usage example
 :
-:   W  Add a _pDEPTH argument to function prototypes, and an _aDEPTH
+:   W  Add a comma_pDEPTH argument to function prototypes, and a comma_aDEPTH
 :      argument to the function calls. This means that under DEBUGGING
 :      a depth argument is added to the functions, which is used for
 :      example by the regex engine for debugging and trace output.

--- a/embed.fnc
+++ b/embed.fnc
@@ -557,7 +557,7 @@
 :
 :   'U'  autodoc.pl will not output a usage example
 :
-:   'W'  Add a _pDEPTH argument to function prototypes, and an _aDEPTH argument
+:   'W'  Add a comma_pDEPTH argument to function prototypes, and a comma_aDEPTH argument
 :        to the function calls. This means that under DEBUGGING a depth
 :        argument is added to the functions, which is used for example by the
 :        regex engine for debugging and trace output. A non DEBUGGING build

--- a/embed.fnc
+++ b/embed.fnc
@@ -5467,6 +5467,9 @@ ERS	|bool	|regtry 	|NN regmatch_info *reginfo		\
 				|NN char **startposp
 ES	|bool	|to_byte_substr |NN regexp *prog
 ES	|void	|to_utf8_substr |NN regexp *prog
+EWi	|void	|unwind_paren	|NN regexp *rex 			\
+				|U32 lp 				\
+				|U32 lcp
 # if defined(DEBUGGING)
 ES	|void	|debug_start_match					\
 				|NN const REGEXP *prog			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -5373,6 +5373,10 @@ ERS	|WB_enum|backup_one_WB	|NN WB_enum *previous			\
 				|NN const U8 * const strbeg		\
 				|NN U8 **curpos 			\
 				|const bool utf8_target
+EWi	|void	|capture_clear	|NN regexp *rex 			\
+				|U16 from_ix				\
+				|U16 to_ix				\
+				|NN const char *str
 ERS	|char * |find_byclass	|NN regexp *prog			\
 				|NN const regnode *c			\
 				|NN char *s				\

--- a/embed.h
+++ b/embed.h
@@ -1933,6 +1933,7 @@
 #     define backup_one_LB(a,b,c)               S_backup_one_LB(aTHX_ a,b,c)
 #     define backup_one_SB(a,b,c)               S_backup_one_SB(aTHX_ a,b,c)
 #     define backup_one_WB(a,b,c,d)             S_backup_one_WB(aTHX_ a,b,c,d)
+#     define capture_clear(a,b,c,d)             S_capture_clear(aTHX_ a,b,c,d comma_aDEPTH)
 #     define find_byclass(a,b,c,d,e)            S_find_byclass(aTHX_ a,b,c,d,e)
 #     define find_next_masked                   S_find_next_masked
 #     define find_span_end                      S_find_span_end

--- a/embed.h
+++ b/embed.h
@@ -1945,15 +1945,15 @@
 #     define isSB(a,b,c,d,e,f)                  S_isSB(aTHX_ a,b,c,d,e,f)
 #     define isWB(a,b,c,d,e,f,g)                S_isWB(aTHX_ a,b,c,d,e,f,g)
 #     define reg_check_named_buff_matched       S_reg_check_named_buff_matched
-#     define regcp_restore(a,b,c)               S_regcp_restore(aTHX_ a,b,c _aDEPTH)
-#     define regcppop(a,b)                      S_regcppop(aTHX_ a,b _aDEPTH)
-#     define regcppush(a,b,c)                   S_regcppush(aTHX_ a,b,c _aDEPTH)
+#     define regcp_restore(a,b,c)               S_regcp_restore(aTHX_ a,b,c comma_aDEPTH)
+#     define regcppop(a,b)                      S_regcppop(aTHX_ a,b comma_aDEPTH)
+#     define regcppush(a,b,c)                   S_regcppush(aTHX_ a,b,c comma_aDEPTH)
 #     define reghop3                            S_reghop3
 #     define reghop4                            S_reghop4
 #     define reghopmaybe3                       S_reghopmaybe3
 #     define reginclass(a,b,c,d,e)              S_reginclass(aTHX_ a,b,c,d,e)
 #     define regmatch(a,b,c)                    S_regmatch(aTHX_ a,b,c)
-#     define regrepeat(a,b,c,d,e,f)             S_regrepeat(aTHX_ a,b,c,d,e,f _aDEPTH)
+#     define regrepeat(a,b,c,d,e,f)             S_regrepeat(aTHX_ a,b,c,d,e,f comma_aDEPTH)
 #     define regtry(a,b)                        S_regtry(aTHX_ a,b)
 #     define to_byte_substr(a)                  S_to_byte_substr(aTHX_ a)
 #     define to_utf8_substr(a)                  S_to_utf8_substr(aTHX_ a)

--- a/embed.h
+++ b/embed.h
@@ -1958,6 +1958,7 @@
 #     define regtry(a,b)                        S_regtry(aTHX_ a,b)
 #     define to_byte_substr(a)                  S_to_byte_substr(aTHX_ a)
 #     define to_utf8_substr(a)                  S_to_utf8_substr(aTHX_ a)
+#     define unwind_paren(a,b,c)                S_unwind_paren(aTHX_ a,b,c comma_aDEPTH)
 #     if defined(DEBUGGING)
 #       define debug_start_match(a,b,c,d,e)     S_debug_start_match(aTHX_ a,b,c,d,e)
 #       define dump_exec_pos(a,b,c,d,e,f,g)     S_dump_exec_pos(aTHX_ a,b,c,d,e,f,g)

--- a/perl.h
+++ b/perl.h
@@ -30,7 +30,7 @@
 
 /*
 =for apidoc_section $debugging
-=for apidoc CmnW ||_aDEPTH
+=for apidoc CmnW ||comma_aDEPTH
 Some functions when compiled under DEBUGGING take an extra final argument named
 C<depth>, indicating the C stack depth.  This argument is omitted otherwise.
 This macro expands to either S<C<, depth>> under DEBUGGING, or to nothing at
@@ -38,20 +38,32 @@ all when not under DEBUGGING, reducing the number of C<#ifdef>'s in the code.
 
 The program is responsible for maintaining the correct value for C<depth>.
 
-=for apidoc CyW ||_pDEPTH
-This is used in the prototype declarations for functions that take a L</C<_aDEPTH>>
+=for apidoc CyW ||comma_pDEPTH
+This is used in the prototype declarations for functions that take a L</C<comma_aDEPTH>>
 final parameter, much like L<C<pTHX_>|perlguts/Background and MULTIPLICITY>
 is used in functions that take a thread context initial parameter.
+
+=for apidoc CmnW ||debug_aDEPTH
+Same as L</C<comma_aDEPTH>> but with no leading argument. Intended for functions with
+no normal arguments, and used by L</C<comma_aDEPTH>> itself.
+
+=for apidoc CmnW ||debug_pDEPTH
+Same as L</C<comma_pDEPTH>> but with no leading argument. Intended for functions with
+no normal arguments, and used by L</C<comma_pDEPTH>> itself.
 
 =cut
  */
 
 #ifdef DEBUGGING
-#  define _pDEPTH ,U32 depth
-#  define _aDEPTH ,depth
+#  define debug_pDEPTH U32 depth
+#  define comma_pDEPTH ,debug_pDEPTH
+#  define debug_aDEPTH depth
+#  define comma_aDEPTH ,debug_aDEPTH
 #else
-#  define _pDEPTH
-#  define _aDEPTH
+#  define debug_aDEPTH
+#  define comma_aDEPTH
+#  define debug_pDEPTH
+#  define comma_pDEPTH
 #endif
 
 /* NOTE 1: that with gcc -std=c89 the __STDC_VERSION__ is *not* defined

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -6575,6 +6575,11 @@ If you know that you have good reason to exceed the limit you can change
 it by setting C<${^MAX_NESTED_EVAL_BEGIN_BLOCKS}> to a different value from
 the default of 1000.
 
+=item Too many capture groups (limit is %d) in regex m/%s/
+
+(F) You have too many capture groups in your regex pattern. You need to rework
+your pattern to use less capture groups.
+
 =item Too many )'s
 
 (A) You've accidentally run your script through B<csh> instead of Perl.

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -379,11 +379,12 @@ Perl_rxres_save(pTHX_ void **rsp, REGEXP *rx)
     PERL_ARGS_ASSERT_RXRES_SAVE;
     PERL_UNUSED_CONTEXT;
 
+    /* deal with regexp_paren_pair items */
     if (!p || p[1] < RX_NPARENS(rx)) {
 #ifdef PERL_ANY_COW
-        i = 7 + (RX_NPARENS(rx)+1) * 4;
+        i = 7 + (RX_NPARENS(rx)+1) * 2;
 #else
-        i = 6 + (RX_NPARENS(rx)+1) * 4;
+        i = 6 + (RX_NPARENS(rx)+1) * 2;
 #endif
         if (!p)
             Newx(p, i, UV);

--- a/proto.h
+++ b/proto.h
@@ -8916,6 +8916,11 @@ S_foldEQ_latin1_s2_folded(pTHX_ const char *a, const char *b, I32 len);
 #   define PERL_ARGS_ASSERT_FOLDEQ_LATIN1_S2_FOLDED \
         assert(a); assert(b)
 
+PERL_STATIC_INLINE void
+S_unwind_paren(pTHX_ regexp *rex, U32 lp, U32 lcp comma_pDEPTH);
+#   define PERL_ARGS_ASSERT_UNWIND_PAREN        \
+        assert(rex)
+
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_REGEXEC_C) */
 #if defined(PERL_IN_REGEX_ENGINE)

--- a/proto.h
+++ b/proto.h
@@ -8906,6 +8906,11 @@ Perl_re_exec_indentf(pTHX_ const char *fmt, U32 depth, ...)
 
 # endif /* defined(DEBUGGING) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
+PERL_STATIC_INLINE void
+S_capture_clear(pTHX_ regexp *rex, U16 from_ix, U16 to_ix, const char *str comma_pDEPTH);
+#   define PERL_ARGS_ASSERT_CAPTURE_CLEAR       \
+        assert(rex); assert(str)
+
 PERL_STATIC_INLINE I32
 S_foldEQ_latin1_s2_folded(pTHX_ const char *a, const char *b, I32 len);
 #   define PERL_ARGS_ASSERT_FOLDEQ_LATIN1_S2_FOLDED \

--- a/proto.h
+++ b/proto.h
@@ -8819,17 +8819,17 @@ S_reg_check_named_buff_matched(const regexp *rex, const regnode *scan)
         assert(rex); assert(scan)
 
 STATIC void
-S_regcp_restore(pTHX_ regexp *rex, I32 ix, U32 *maxopenparen_p _pDEPTH);
+S_regcp_restore(pTHX_ regexp *rex, I32 ix, U32 *maxopenparen_p comma_pDEPTH);
 # define PERL_ARGS_ASSERT_REGCP_RESTORE         \
         assert(rex); assert(maxopenparen_p)
 
 STATIC void
-S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p _pDEPTH);
+S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH);
 # define PERL_ARGS_ASSERT_REGCPPOP              \
         assert(rex); assert(maxopenparen_p)
 
 STATIC CHECKPOINT
-S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen _pDEPTH);
+S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEPTH);
 # define PERL_ARGS_ASSERT_REGCPPUSH             \
         assert(rex)
 
@@ -8864,7 +8864,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
         assert(reginfo); assert(startpos); assert(prog)
 
 STATIC I32
-S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p, char *loceol, regmatch_info * const reginfo, I32 max _pDEPTH)
+S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p, char *loceol, regmatch_info * const reginfo, I32 max comma_pDEPTH)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_REGREPEAT             \
         assert(prog); assert(startposp); assert(p); assert(loceol); assert(reginfo); \

--- a/regcomp.c
+++ b/regcomp.c
@@ -4000,6 +4000,9 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
           capturing_parens:
             parno = RExC_npar;
             RExC_npar++;
+            if (RExC_npar >= U16_MAX)
+                FAIL2("Too many capture groups (limit is %" UVuf ")", (UV)RExC_npar);
+
             logical_parno = RExC_logical_npar;
             RExC_logical_npar++;
             if (! ALL_PARENS_COUNTED) {

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -1258,6 +1258,4 @@ static const scan_data_t zero_scan_data = {
 #define REGNODE_STEP_OVER(ret,t1,t2) \
     NEXT_OFF(REGNODE_p(ret)) = ((sizeof(t1)+sizeof(t2))/sizeof(regnode))
 
-#define VOLATILE_REF 1
-
 #endif /* REGCOMP_INTERNAL_H */

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -252,7 +252,7 @@ sub generate_proto_h {
         else {
             $ret .= "void" if !$has_context;
         }
-        $ret .= " _pDEPTH" if $has_depth;
+        $ret .= " comma_pDEPTH" if $has_depth;
         $ret .= ")";
         my @attrs;
         if ( $flags =~ /r/ ) {
@@ -487,7 +487,7 @@ sub embed_h {
                 $ret .= $replacelist;
                 if ($flags =~ /W/) {
                     if ($replacelist) {
-                        $ret .= " _aDEPTH";
+                        $ret .= " comma_aDEPTH";
                     } else {
                         die "Can't use W without other args (currently)";
                     }

--- a/regexec.c
+++ b/regexec.c
@@ -225,7 +225,7 @@ static regmatch_state * S_push_slab(pTHX);
  * are needed for the regexp context stack bookkeeping. */
 
 STATIC CHECKPOINT
-S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen _pDEPTH)
+S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEPTH)
 {
     const int retval = PL_savestack_ix;
     /* Number of bytes about to be stored in the stack */
@@ -382,7 +382,7 @@ STMT_START {                                                            \
 
 
 STATIC void
-S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p _pDEPTH)
+S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH)
 {
     UV i;
     U32 paren;
@@ -480,7 +480,7 @@ S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p _pDEPTH)
  * but without popping the stack */
 
 STATIC void
-S_regcp_restore(pTHX_ regexp *rex, I32 ix, U32 *maxopenparen_p _pDEPTH)
+S_regcp_restore(pTHX_ regexp *rex, I32 ix, U32 *maxopenparen_p comma_pDEPTH)
 {
     I32 tmpix = PL_savestack_ix;
     PERL_ARGS_ASSERT_REGCP_RESTORE;
@@ -10194,7 +10194,7 @@ NULL
  */
 STATIC I32
 S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
-            char * loceol, regmatch_info *const reginfo, I32 max _pDEPTH)
+            char * loceol, regmatch_info *const reginfo, I32 max comma_pDEPTH)
 {
     char *scan;     /* Pointer to current position in target string */
     I32 c;

--- a/regexp.h
+++ b/regexp.h
@@ -838,54 +838,71 @@ typedef struct regmatch_state {
             struct regmatch_state *prev_yes_state;
         } yes;
 
+
+        /* NOTE: Regarding 'cp' and 'lastcp' in the following structs...
+         *
+         * In the majority of cases we use 'cp' for the "normal"
+         * checkpoint for paren saves, and 'lastcp' for the addtional
+         * paren saves that are done only under RE_PESSIMISTIC_PARENS.
+         *
+         * There may be a few cases where both are used always.
+         * Regardless they tend be used something like this:
+         *
+         *   ST.cp = regcppush(rex, 0, maxopenparen);
+         *   REGCP_SET(ST.lastcp);
+         *
+         * thus ST.cp holds the checkpoint from before we push parens,
+         * and ST.lastcp holds the checkpoint from afterwards.
+         */
+
         /* branchlike members */
         /* this is a fake union member that matches the first elements
          * of each member that needs to behave like a branch */
         struct {
             /* this first element must match u.yes */
             struct regmatch_state *prev_yes_state;
-            U32 lastparen;
-            U32 lastcloseparen;
-            CHECKPOINT cp;
-            CHECKPOINT lastcp;
-            U16 before_paren;
-            U16 after_paren;
+            U32         lastparen;
+            U32         lastcloseparen;
+            CHECKPOINT  cp;         /* see note above "struct branchlike" */
+            CHECKPOINT  lastcp;     /* see note above "struct branchlike" */
+            U16         before_paren;
+            U16         after_paren;
 
         } branchlike;
 
         struct {
             /* the first elements must match u.branchlike */
             struct regmatch_state *prev_yes_state;
-            U32 lastparen;
-            U32 lastcloseparen;
-            CHECKPOINT cp;
-            CHECKPOINT lastcp;
-            U16 before_paren;
-            U16 after_paren;
+            U32         lastparen;
+            U32         lastcloseparen;
+            CHECKPOINT  cp;         /* see note above "struct branchlike" */
+            CHECKPOINT  lastcp;     /* see note above "struct branchlike" */
+            U16         before_paren;
+            U16         after_paren;
 
-            regnode *next_branch; /* next branch node */
+            regnode *next_branch;   /* next branch node */
         } branch;
 
         struct {
             /* the first elements must match u.branchlike */
             struct regmatch_state *prev_yes_state;
-            U32 lastparen;
-            U32 lastcloseparen;
-            CHECKPOINT cp;
-            CHECKPOINT lastcp;
-            U16 before_paren;
-            U16 after_paren;
+            U32         lastparen;
+            U32         lastcloseparen;
+            CHECKPOINT  cp;         /* see note above "struct branchlike" */
+            CHECKPOINT  lastcp;     /* see note above "struct branchlike" */
+            U16         before_paren;
+            U16         after_paren;
 
-            U32		accepted; /* how many accepting states left */
-            bool	longfold;/* saw a fold with a 1->n char mapping */
-            U16         *jump;  /* positive offsets from me */
+            U32         accepted;   /* how many accepting states left */
+            bool        longfold;   /* saw a fold with a 1->n char mapping */
+            U16         *jump;      /* positive offsets from me */
             U16         *j_before_paren;
             U16         *j_after_paren;
-            regnode	*me;	/* Which node am I - needed for jump tries*/
-            U8		*firstpos;/* pos in string of first trie match */
-            U32		firstchars;/* len in chars of firstpos from start */
-            U16		nextword;/* next word to try */
-            U16		topword; /* longest accepted word */
+            regnode     *me;        /* Which node am I - needed for jump tries*/
+            U8          *firstpos;  /* pos in string of first trie match */
+            U32         firstchars; /* len in chars of firstpos from start */
+            U16         nextword;   /* next word to try */
+            U16         topword;    /* longest accepted word */
         } trie;
 
         /* special types - these members are used to store state for special
@@ -896,31 +913,31 @@ typedef struct regmatch_state {
             struct regmatch_state *prev_curlyx;
             struct regmatch_state *prev_eval;
             REGEXP	*prev_rex;
-            CHECKPOINT	cp;	/* remember current savestack indexes */
-            CHECKPOINT	lastcp;
-            U32         close_paren; /* which close bracket is our end (+1) */
-            regnode	*B;	/* the node following us  */
+            CHECKPOINT  cp;             /* see note above "struct branchlike" */
+            CHECKPOINT  lastcp;         /* see note above "struct branchlike" */
+            U32         close_paren;    /* which close bracket is our end (+1) */
+            regnode     *B;             /* the node following us  */
             char        *prev_recurse_locinput;
         } eval;
 
         struct {
             /* this first element must match u.yes */
             struct regmatch_state *prev_yes_state;
-            I32 wanted;
-            I32 logical;	/* saved copy of 'logical' var */
-            U8  count;          /* number of beginning positions */
-            char *start;
-            char *end;
-            regnode  *me; /* the IFMATCH/SUSPEND/UNLESSM node  */
-            char *prev_match_end;
-        } ifmatch; /* and SUSPEND/UNLESSM */
+            I32     wanted;
+            I32     logical;    /* saved copy of 'logical' var */
+            U8      count;      /* number of beginning positions */
+            char    *start;
+            char    *end;
+            regnode *me;        /* the IFMATCH/SUSPEND/UNLESSM node  */
+            char    *prev_match_end;
+        } ifmatch;              /* and SUSPEND/UNLESSM */
 
         struct {
             /* this first element must match u.yes */
             struct regmatch_state *prev_yes_state;
             struct regmatch_state *prev_mark;
-            SV* mark_name;
-            char *mark_loc;
+            SV      *mark_name;
+            char    *mark_loc;
         } mark;
 
         struct {
@@ -933,25 +950,25 @@ typedef struct regmatch_state {
             /* this first element must match u.yes */
             struct regmatch_state *prev_yes_state;
             struct regmatch_state *prev_curlyx; /* previous cur_curlyx */
-            regnode	*me;	/* the CURLYX node  */
-            regnode	*B;	/* the B node in /A*B/  */
-            CHECKPOINT	cp;	/* remember current savestack index */
-            CHECKPOINT	lastcp;	/* remember current savestack index */
+            regnode     *me;        /* the CURLYX node  */
+            regnode     *B;         /* the B node in /A*B/  */
+            CHECKPOINT  cp;         /* see note above "struct branchlike" */
+            CHECKPOINT  lastcp;     /* see note above "struct branchlike" */
             bool	minmod;
-            int		parenfloor;/* how far back to strip paren data */
+            int         parenfloor; /* how far back to strip paren data */
 
             /* these two are modified by WHILEM */
-            int		count;	/* how many instances of A we've matched */
-            char	*lastloc;/* where previous A matched (0-len detect) */
+            int         count;      /* how many instances of A we've matched */
+            char        *lastloc;   /* where previous A matched (0-len detect) */
         } curlyx;
 
         struct {
             /* this first element must match u.yes */
             struct regmatch_state *prev_yes_state;
             struct regmatch_state *save_curlyx;
-            CHECKPOINT	cp;	/* remember current savestack indexes */
-            CHECKPOINT	lastcp;
-            char	*save_lastloc;	/* previous curlyx.lastloc */
+            CHECKPOINT  cp;             /* see note above "struct branchlike" */
+            CHECKPOINT  lastcp;         /* see note above "struct branchlike" */
+            char        *save_lastloc;  /* previous curlyx.lastloc */
             I32		cache_offset;
             I32		cache_mask;
         } whilem;
@@ -959,35 +976,35 @@ typedef struct regmatch_state {
         struct {
             /* this first element must match u.yes */
             struct regmatch_state *prev_yes_state;
-            CHECKPOINT cp;
-            CHECKPOINT	lastcp;	/* remember current savestack index */
-            U32 lastparen;
-            U32 lastcloseparen;
-            I32 alen;		/* length of first-matched A string */
-            I32 count;
-            bool minmod;
-            regnode *A, *B;	/* the nodes corresponding to /A*B/  */
-            regnode *me;	/* the curlym node */
+            U32         lastparen;
+            U32         lastcloseparen;
+            CHECKPOINT  cp;         /* see note above "struct branchlike" */
+            CHECKPOINT  lastcp;     /* see note above "struct branchlike" */
+            I32         alen;       /* length of first-matched A string */
+            I32         count;
+            bool        minmod;
+            regnode     *A, *B;     /* the nodes corresponding to /A*B/  */
+            regnode     *me;        /* the curlym node */
             struct next_matchable_info Binfo;
         } curlym;
 
         struct {
-            U32 paren;
-            CHECKPOINT cp;
-            CHECKPOINT lastcp;  /* remember current savestack index */
-            U32 lastparen;
-            U32 lastcloseparen;
-            char *maxpos;	/* highest possible point in string to match */
-            char *oldloc;	/* the previous locinput */
-            int count;
-            int min, max;	/* {m,n} */
-            regnode *A, *B;	/* the nodes corresponding to /A*B/  */
+            U32         paren;
+            U32         lastparen;
+            U32         lastcloseparen;
+            CHECKPOINT  cp;         /* see note above "struct branchlike" */
+            CHECKPOINT  lastcp;     /* see note above "struct branchlike" */
+            char        *maxpos;    /* highest possible point in string to match */
+            char        *oldloc;    /* the previous locinput */
+            int         count;
+            int         min, max;   /* {m,n} */
+            regnode     *A, *B;     /* the nodes corresponding to /A*B/  */
             struct next_matchable_info Binfo;
         } curly; /* and CURLYN/PLUS/STAR */
 
         struct {
-            CHECKPOINT cp;
-            CHECKPOINT lastcp;
+            CHECKPOINT  cp;
+            CHECKPOINT  lastcp;
         } backref; /* REF and friends */
     } u;
 } regmatch_state;

--- a/regexp.h
+++ b/regexp.h
@@ -62,8 +62,9 @@ struct reg_substr_data {
 #    define SV_SAVED_COPY
 #  endif
 
-/* offsets within a string of a particular /(.)/ capture */
-
+/* offsets within a string of a particular /(.)/ capture
+ * if you change this by adding new non-temporary fields
+ * then be sure to update Perl_rxres_save() in pp_ctl.c */
 typedef struct regexp_paren_pair {
     SSize_t start;
     SSize_t end;

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -478,7 +478,7 @@ a(?:b|c|d)+(.)	acdbcdbe	y	$1	e
 a(?:b|c|d){2}(.)	acdbcdbe	y	$1	b
 a(?:b|c|d){4,5}(.)	acdbcdbe	y	$1	b
 a(?:b|c|d){4,5}?(.)	acdbcdbe	y	$1	d
-((foo)|(bar))*	foobar	y	$1-$2-$3	bar--bar		# was bar-foo-bar prior to 5.37.7
+((foo)|(bar))*	foobar	y	$1-$2-$3	bar--bar		# was bar-foo-bar prior to 5.37.10
 :(?:	-	c	-	Sequence (? incomplete
 a(?:b|c|d){6,7}(.)	acdbcdbe	y	$1	e
 a(?:b|c|d){6,7}?(.)	acdbcdbe	y	$1	e


### PR DESCRIPTION
IN https://github.com/Perl/perl5/pull/20918#issuecomment-1474405156 @iabyn asked for some followups.

* Remove vestigal change in Perl_rxres_save()
* Fixes comment  'was bar-foo-bar prior to 5.37.7' to say '5.37.10' ?
* Rework CAPTURE_CLEAR() and UNWIND_PAREN() macros to be static inline.
* In regexp.h - document waht cp and lastcp are used for. 
* Document RE_PESSIMISTIC_PARENS and VOLATILE_REF better

Also includes two other changes I noticed when working on the above:

* Change _pDEPTH and _aDEPTH macros to not use leading underscores. Changed it to comma_pDEPTH and comma_aDEPTH, also added debug_pDEPTH and debug_aDEPTH for completeness (if we ever add a function with no normal arguments that wants to do recursion depth tracking under DEBUGGING).
* Throw an error if a pattern has more than U16_MAX open parens (aka capture groups in it). The code for some time has assumed that the id of all capture groups can fit in an U16, but we weren't validating that assumption during the regexp compile process.  Long term we should revisit all of the logic related to this and either switch it to use U32, or change the things that use U32 members for parent count related logic to use U16 instead. 
