### PR TITLE
embed.fnc - remove redundant deprecate_xxx() macro declarations

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3894,16 +3894,6 @@ EXpx	|SV *	|sv_setsv_cow	|NULLOK SV *dsv 			\
 				|NN SV *ssv
 #endif /* defined(PERL_ANY_COW) */
 #if defined(PERL_CORE)
-Cdm	|void	|deprecate	|U32 category				\
-				|"construct"
-Cdm	|void	|deprecate_disappears_in				\
-				|U32 category				\
-				|"when" 				\
-				|"construct"
-Cdm	|void	|deprecate_fatal_in					\
-				|U32 category				\
-				|"when" 				\
-				|"construct"
 p	|void	|opslab_force_free					\
 				|NN OPSLAB *slab
 p	|void	|opslab_free	|NN OPSLAB *slab

--- a/proto.h
+++ b/proto.h
@@ -6033,15 +6033,6 @@ Perl_sv_setsv_cow(pTHX_ SV *dsv, SV *ssv);
 
 #endif /* defined(PERL_ANY_COW) */
 #if defined(PERL_CORE)
-/* PERL_CALLCONV void
-deprecate(pTHX_ U32 category, const char * const construct); */
-
-/* PERL_CALLCONV void
-deprecate_disappears_in(pTHX_ U32 category, const char * const when, const char * const construct); */
-
-/* PERL_CALLCONV void
-deprecate_fatal_in(pTHX_ U32 category, const char * const when, const char * const construct); */
-
 PERL_CALLCONV void
 Perl_opslab_force_free(pTHX_ OPSLAB *slab)
         __attribute__visibility__("hidden");


### PR DESCRIPTION
autodoc.pl gets unhappy if you document a macro in place and ALSO list it in embed.fnc. The warnings it produce tend to get crowded out from a parallel make, but @iabyn noticed and (rightly) complained.

This removes the redundant definitions.