### PR TITLE
Simplify `use VERSION behaviour` on 5.37 onwards

### DIFF
--- a/lib/strict.t
+++ b/lib/strict.t
@@ -3,7 +3,7 @@
 chdir 't' if -d 't';
 @INC = ( '.', '../lib' );
 
-our $local_tests = 7;
+our $local_tests = 6 + 3*3*38 + 3*11 + 3*18;
 require "../t/lib/common.pl";
 
 eval qq(use strict 'garbage');
@@ -28,7 +28,89 @@ like($@, qr/^Unknown 'strict' tag\(s\) 'foo bar'/);
         'use v5.10 after use v5.12 provokes deprecation warning');
 }
 
-eval 'use strict; use v5.10; ${"c"}';
-like($@,
-    qr/^Can't use string \("c"\) as a SCALAR ref while "strict refs" in use/,
-    "use v5.10 doesn't disable explicit strict ref");
+my $varname = "ccccc";
+sub test_strict_all {
+    my($preamble, $expect) = @_;
+    my $expect_r = $expect =~ /r/;
+    eval $preamble.'; ${"ccc"}';
+    like($@,
+        $expect_r ?
+            qr/\ACan't\ use\ string\ \("ccc"\)\ as\ a\ SCALAR\ ref
+                \ while\ "strict\ refs"\ in\ use/x :
+        qr/\A\z/,
+        "\"$preamble\" yields strict refs @{[$expect_r ? q(on) : q(off)]}");
+    my $expect_v = $expect =~ /v/;
+    ++$varname;
+    eval $preamble.'; $'.$varname;
+    like($@,
+        $expect_v ?
+            qr/\AGlobal\ symbol\ "\$\Q${varname}\E"\ requires
+                \ explicit\ package\ name\ /x :
+            qr/\A\z/,
+        "\"$preamble\" yields strict vars @{[$expect_v ? q(on) : q(off)]}");
+    my $expect_s = $expect =~ /s/;
+    eval $preamble.'; Ccc';
+    like($@,
+        $expect_s ?
+            qr/\ABareword\ "Ccc"\ not\ allowed
+                \ while\ "strict\ subs"\ in\ use/x :
+            qr/\A\z/,
+        "\"$preamble\" yields strict subs @{[$expect_s ? q(on) : q(off)]}");
+}
+
+foreach my $minor (0..10) {
+    test_strict_all "use v5.$minor", "";
+    test_strict_all "use strict; use v5.$minor", "rvs";
+    test_strict_all "no strict; use v5.$minor", "";
+}
+foreach my $minor (11..36) {
+    test_strict_all "use v5.$minor", "rvs";
+    test_strict_all "use strict; use v5.$minor", "rvs";
+    test_strict_all "no strict; use v5.$minor", "";
+}
+foreach my $minor (37..37) {
+    test_strict_all "use v5.$minor", "rvs";
+    test_strict_all "use strict; use v5.$minor", "rvs";
+    test_strict_all "no strict; use v5.$minor", "rvs";
+}
+
+{
+    test_strict_all "use v5.8; use v5.10", "";
+    test_strict_all "use v5.10; use v5.8", "";
+    test_strict_all "use v5.10; use v5.16", "rvs";
+    test_strict_all "use v5.10; use v5.37", "rvs";
+    {
+        local $SIG{__WARN__} = sub {};
+        test_strict_all "use v5.16; use v5.10", "";
+    }
+    test_strict_all "use v5.16; use v5.20", "rvs";
+    test_strict_all "use v5.20; use v5.16", "rvs";
+    test_strict_all "use v5.16; use v5.37", "rvs";
+    {
+        local $SIG{__WARN__} = sub {};
+        test_strict_all "use v5.37; use v5.10", "rvs";
+    }
+    test_strict_all "use v5.37; use v5.16", "rvs";
+    test_strict_all "use v5.37; use v5.37", "rvs";
+}
+
+{
+    test_strict_all "use strict 'refs'; use v5.10", "r";
+    test_strict_all "use strict 'vars'; use v5.10", "v";
+    test_strict_all "use strict 'subs'; use v5.10", "s";
+    test_strict_all "no strict 'refs'; use v5.10", "";
+    test_strict_all "no strict 'vars'; use v5.10", "";
+    test_strict_all "no strict 'subs'; use v5.10", "";
+    test_strict_all "use strict 'refs'; use v5.16", "rvs";
+    test_strict_all "use strict 'vars'; use v5.16", "rvs";
+    test_strict_all "use strict 'subs'; use v5.16", "rvs";
+    test_strict_all "no strict 'refs'; use v5.16", "vs";
+    test_strict_all "no strict 'vars'; use v5.16", "rs";
+    test_strict_all "no strict 'subs'; use v5.16", "rv";
+    test_strict_all "use strict 'refs'; use v5.37", "rvs";
+    test_strict_all "use strict 'vars'; use v5.37", "rvs";
+    test_strict_all "use strict 'subs'; use v5.37", "rvs";
+    test_strict_all "no strict 'refs'; use v5.37", "rvs";
+    test_strict_all "no strict 'vars'; use v5.37", "rvs";
+    test_strict_all "no strict 'subs'; use v5.37", "rvs";
+}

--- a/lib/strict.t
+++ b/lib/strict.t
@@ -3,7 +3,7 @@
 chdir 't' if -d 't';
 @INC = ( '.', '../lib' );
 
-our $local_tests = 6 + 3*3*38 + 3*11 + 3*18;
+our $local_tests = 6 + 3*3*40 + 3*11 + 3*18;
 require "../t/lib/common.pl";
 
 eval qq(use strict 'garbage');
@@ -63,12 +63,12 @@ foreach my $minor (0..10) {
     test_strict_all "use strict; use v5.$minor", "rvs";
     test_strict_all "no strict; use v5.$minor", "";
 }
-foreach my $minor (11..36) {
+foreach my $minor (11..38) {
     test_strict_all "use v5.$minor", "rvs";
     test_strict_all "use strict; use v5.$minor", "rvs";
     test_strict_all "no strict; use v5.$minor", "";
 }
-foreach my $minor (37..37) {
+foreach my $minor (39..39) {
     test_strict_all "use v5.$minor", "rvs";
     test_strict_all "use strict; use v5.$minor", "rvs";
     test_strict_all "no strict; use v5.$minor", "rvs";
@@ -78,20 +78,20 @@ foreach my $minor (37..37) {
     test_strict_all "use v5.8; use v5.10", "";
     test_strict_all "use v5.10; use v5.8", "";
     test_strict_all "use v5.10; use v5.16", "rvs";
-    test_strict_all "use v5.10; use v5.37", "rvs";
+    test_strict_all "use v5.10; use v5.39", "rvs";
     {
         local $SIG{__WARN__} = sub {};
         test_strict_all "use v5.16; use v5.10", "";
     }
     test_strict_all "use v5.16; use v5.20", "rvs";
     test_strict_all "use v5.20; use v5.16", "rvs";
-    test_strict_all "use v5.16; use v5.37", "rvs";
+    test_strict_all "use v5.16; use v5.39", "rvs";
     {
         local $SIG{__WARN__} = sub {};
-        test_strict_all "use v5.37; use v5.10", "rvs";
+        test_strict_all "use v5.39; use v5.10", "rvs";
     }
-    test_strict_all "use v5.37; use v5.16", "rvs";
-    test_strict_all "use v5.37; use v5.37", "rvs";
+    test_strict_all "use v5.39; use v5.16", "rvs";
+    test_strict_all "use v5.39; use v5.39", "rvs";
 }
 
 {
@@ -107,10 +107,10 @@ foreach my $minor (37..37) {
     test_strict_all "no strict 'refs'; use v5.16", "vs";
     test_strict_all "no strict 'vars'; use v5.16", "rs";
     test_strict_all "no strict 'subs'; use v5.16", "rv";
-    test_strict_all "use strict 'refs'; use v5.37", "rvs";
-    test_strict_all "use strict 'vars'; use v5.37", "rvs";
-    test_strict_all "use strict 'subs'; use v5.37", "rvs";
-    test_strict_all "no strict 'refs'; use v5.37", "rvs";
-    test_strict_all "no strict 'vars'; use v5.37", "rvs";
-    test_strict_all "no strict 'subs'; use v5.37", "rvs";
+    test_strict_all "use strict 'refs'; use v5.39", "rvs";
+    test_strict_all "use strict 'vars'; use v5.39", "rvs";
+    test_strict_all "use strict 'subs'; use v5.39", "rvs";
+    test_strict_all "no strict 'refs'; use v5.39", "rvs";
+    test_strict_all "no strict 'vars'; use v5.39", "rvs";
+    test_strict_all "no strict 'subs'; use v5.39", "rvs";
 }

--- a/op.c
+++ b/op.c
@@ -7902,7 +7902,7 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
 
         U16 shortver = S_extract_shortver(aTHX_ use_version);
 
-        if (shortver >= SHORTVER(5, 37)) {
+        if (shortver >= SHORTVER(5, 39)) {
             PL_hints |= HINT_STRICT_REFS | HINT_EXPLICIT_STRICT_REFS |
                 HINT_STRICT_SUBS | HINT_EXPLICIT_STRICT_SUBS |
                 HINT_STRICT_VARS | HINT_EXPLICIT_STRICT_VARS;

--- a/op.c
+++ b/op.c
@@ -7902,8 +7902,12 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
 
         U16 shortver = S_extract_shortver(aTHX_ use_version);
 
-        /* If a version >= 5.11.0 is requested, strictures are on by default! */
-        if (shortver >= SHORTVER(5, 11)) {
+        if (shortver >= SHORTVER(5, 37)) {
+            PL_hints |= HINT_STRICT_REFS | HINT_EXPLICIT_STRICT_REFS |
+                HINT_STRICT_SUBS | HINT_EXPLICIT_STRICT_SUBS |
+                HINT_STRICT_VARS | HINT_EXPLICIT_STRICT_VARS;
+        }
+        else if (shortver >= SHORTVER(5, 11)) {
             if (!(PL_hints & HINT_EXPLICIT_STRICT_REFS))
                 PL_hints |= HINT_STRICT_REFS;
             if (!(PL_hints & HINT_EXPLICIT_STRICT_SUBS))
@@ -7929,6 +7933,9 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
             if (!(PL_hints & HINT_EXPLICIT_STRICT_VARS))
                 PL_hints &= ~HINT_STRICT_VARS;
         }
+
+        if (shortver >= SHORTVER(5, 35))
+            free_and_set_cop_warnings(&PL_compiling, pWARN_ALL);
 
         PL_prevailing_version = shortver;
     }

--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -117,7 +117,7 @@ C<use VERSION> and C<use strict>. If you specify a version >= 5.11, strict is
 enabled implicitly. If you request a version < 5.11, strict will become
 disabled I<even if you had previously written> C<use strict>. This was not
 the previous behaviour of C<use VERSION>, which at present
-for versions < 5.37 will track
+for versions < 5.39 will track
 explicitly-enabled strictness flags independently.
 
 Category: "deprecated::version_downgrade"

--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -116,7 +116,8 @@ This is because of an intended related change to the interaction between
 C<use VERSION> and C<use strict>. If you specify a version >= 5.11, strict is
 enabled implicitly. If you request a version < 5.11, strict will become
 disabled I<even if you had previously written> C<use strict>. This was not
-the previous behaviour of C<use VERSION>, which at present will track
+the previous behaviour of C<use VERSION>, which at present
+for versions < 5.37 will track
 explicitly-enabled strictness flags independently.
 
 Category: "deprecated::version_downgrade"

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -10115,9 +10115,11 @@ functionality from the command-line.
 
 =for Pod::Functions enable Perl language features and declare required version
 
-Lexically enables all features available in the requested version as
-defined by the L<feature> pragma, disabling any features not in the
-requested version's feature bundle.  See L<feature>.
+Performs a Perl version check, and also serves as a base pragma declaring
+the dialect of Perl in which a file is written.  As a lexically-scoped
+pragma it selects a bundle of features defined by the L<feature> pragma,
+adjusts the strictures controlled by the L<strict> pragma, and may also
+enable warnings as if by the L<warnings> pragma.
 
 VERSION may be either a v-string such as v5.24.1, which will be compared
 to L<C<$^V>|perlvar/$^V> (aka $PERL_VERSION), or a numeric argument of the
@@ -10127,16 +10129,41 @@ Perl interpreter; Perl will not attempt to parse the rest of the file.
 Compare with L<C<require>|/require VERSION>, which can do a similar check
 at run time.
 
-If the specified Perl version is 5.12 or higher, strictures are enabled
-lexically as with L<C<use strict>|strict>.  Similarly, if the specified
-Perl version is 5.35.0 or higher, L<warnings> are enabled.  Later use of
-C<use VERSION> will override all behavior of a previous C<use VERSION>,
-possibly removing the C<strict>, C<warnings>, and C<feature> added by it.
+The effect on feature selection is to lexically enable all features
+available in the requested version's bundle as defined by the L<feature>
+pragma, disabling any features not in the requested version's feature
+bundle.  See L<feature>.
+
+If the specified Perl version is 5.37 or higher, strictures are enabled
+lexically, as if L<C<use strict>|strict> had been declared.  If the
+version is 5.11 or higher but less than 5.37, then strictures are enabled
+unless they were already explicitly disabled (by C<no strict>).  If the
+version is less than 5.11, then strictures are disabled unless they were
+already explicitly enabled (by C<use strict> or C<use v5.38>).  Similarly,
+if the specified Perl version is 5.35 or higher, L<warnings> are enabled.
+
+Later use of C<use VERSION> will override most behavior of a previous
+C<use VERSION>.  The feature set of the later-specified version completely
+replaces that of the earlier-specified version, and also any explicit
+feature selection.  Where the later-specified version is less than 5.37,
+its stricture behaviour takes precedence over that of an earlier-specified
+version that is also less than 5.37, but not over explicit stricture
+declarations nor over an earlier-specified version 5.37 or higher.
+Where the later-specified version is 5.37 or higher, its stricture
+behaviour takes precedence over that of any earlier-specified version,
+and also any explicit stricture declaration.  Where the later-specified
+version is less than 5.35, it doesn't affect the lexical warnings status,
+so the warnings aspect of any prior C<use v5.36> and any explicit warnings
+declarations remain in effect.  Where the later-specified version is
+5.35 or higher, its warnings enablement takes precedence over any prior
+declaration, including explicit warnings declarations.
+
 C<use VERSION> does not load the F<feature.pm>, F<strict.pm>, or
 F<warnings.pm> files.
 
 In the current implementation, any explicit use of C<use strict> or
-C<no strict> overrides C<use VERSION>, even if it comes before it.
+C<no strict> overrides C<use VERSION> for versions less than 5.37,
+even if the explicit stricture comes before the version pragma.
 However, this may be subject to change in a future release of Perl, so new
 code should not rely on this fact.  It is recommended that a
 C<use VERSION> declaration be the first significant statement within a


### PR DESCRIPTION
(this description was all wrong but in any case I've now reverted it to a draft. We'll wait for 5.39 to apply it properly. I'll write something better by then)