### PR TITLE
Quiet hpux compiler warnings from `class.c`

### DIFF
--- a/class.c
+++ b/class.c
@@ -280,7 +280,7 @@ PP(pp_methstart)
         U32 fieldcount = (aux++)->uv;
         U32 max_fieldix = (aux++)->uv;
 
-        assert(ObjectMAXFIELD(instance)+1 > max_fieldix);
+        assert((U32)(ObjectMAXFIELD(instance)+1) > max_fieldix);
         PERL_UNUSED_VAR(max_fieldix);
 
         for(Size_t i = 0; i < fieldcount; i++) {

--- a/class.c
+++ b/class.c
@@ -104,7 +104,7 @@ PP(pp_initfield)
                     SV *key = *svp; svp++;
                     SV *val = svp <= SP ? *svp : &PL_sv_undef; svp++;
 
-                    hv_store_ent(hv, key, newSVsv(val), 0);
+                    (void)hv_store_ent(hv, key, newSVsv(val), 0);
                 }
             }
             val = (SV *)hv;
@@ -155,7 +155,7 @@ XS(injected_constructor)
              * But then,  %params = @_;  wouldn't do that
              */
 
-            hv_store_ent(params, name, SvREFCNT_inc(val), 0);
+            (void)hv_store_ent(params, name, SvREFCNT_inc(val), 0);
         }
     }
 
@@ -664,7 +664,7 @@ Perl_class_seal_stash(pTHX_ HV *stash)
                 continue;
 
             U32 fieldix = PadnameFIELDINFO(pn)->fieldix;
-            hv_store_ent(fieldix_to_padix, sv_2mortal(newSVuv(fieldix)), newSVuv(padix), 0);
+            (void)hv_store_ent(fieldix_to_padix, sv_2mortal(newSVuv(fieldix)), newSVuv(padix), 0);
         }
 
         OP *ops = NULL;
@@ -943,7 +943,7 @@ apply_field_attribute_param(pTHX_ PADNAME *pn, SV *value)
     if(!aux->xhv_class_param_map)
         aux->xhv_class_param_map = newHV();
 
-    hv_store_ent(aux->xhv_class_param_map, value, newSVuv(PadnameFIELDINFO(pn)->fieldix), 0);
+    (void)hv_store_ent(aux->xhv_class_param_map, value, newSVuv(PadnameFIELDINFO(pn)->fieldix), 0);
 }
 
 static struct {


### PR DESCRIPTION
Recent code provokes a few new warnings. This silences them.