### PR TITLE
Fixes and changes related to silencing HPUX build warnings

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -859,16 +859,6 @@ use File::Glob qw(:case);
             qw(t/appveyor-test.bat),
 
         ],
-        'CUSTOMIZED' => [
-            qw{
-                t/000_load.t
-                t/001_new.t
-                t/010_pingecho.t
-                t/450_service.t
-                t/500_ping_icmp.t
-                t/501_ping_icmpv6.t
-            }
-        ],
     },
 
     'NEXT' => {

--- a/dist/Devel-PPPort/PPPort_pm.PL
+++ b/dist/Devel-PPPort/PPPort_pm.PL
@@ -756,7 +756,7 @@ package Devel::PPPort;
 use strict;
 use vars qw($VERSION $data);
 
-$VERSION = '3.70';
+$VERSION = '3.71';
 
 sub _init_data
 {

--- a/dist/Devel-PPPort/parts/inc/misc
+++ b/dist/Devel-PPPort/parts/inc/misc
@@ -1434,8 +1434,8 @@ check_HeUTF8(utf8_key)
                 hash = newHV();
 
                 key = SvPV(utf8_key, klen);
-                if (SvUTF8(utf8_key)) klen *= -1;
-                hv_store(hash, key, klen, newSVpvs("string"), 0);
+                hv_store(hash, key, SvUTF8(utf8_key) ? -klen : klen,
+                    newSVpvs("string"), 0);
                 hv_iterinit(hash);
                 ent = hv_iternext(hash);
                 assert(ent);

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -11,7 +11,7 @@ use Symbol;
 
 our $VERSION;
 BEGIN {
-  $VERSION = '3.49';
+  $VERSION = '3.50';
   require ExtUtils::ParseXS::Constants; ExtUtils::ParseXS::Constants->VERSION($VERSION);
   require ExtUtils::ParseXS::CountLines; ExtUtils::ParseXS::CountLines->VERSION($VERSION);
   require ExtUtils::ParseXS::Utilities; ExtUtils::ParseXS::Utilities->VERSION($VERSION);
@@ -636,7 +636,16 @@ EOF
           $self->print_section();
           $self->death("PPCODE must be last thing") if @{ $self->{line} };
           print "\tLEAVE;\n" if $self->{ScopeThisXSUB};
+          print "#if defined(__HP_cc) || defined(__HP_aCC)\n",
+                "#pragma diag_suppress 2111\n",
+                "#endif\n"
+            if $^O eq "hpux";
           print "\tPUTBACK;\n\treturn;\n";
+          print "#if defined(__HP_cc) || defined(__HP_aCC)\n",
+                "#pragma diag_default 2111\n",
+                "#endif\n"
+            if $^O eq "hpux";
+
         }
         elsif ($self->check_keyword("CODE")) {
           my $consumed_code = $self->print_section();
@@ -798,6 +807,10 @@ EOF
 #    if (errbuf[0])
 #    Perl_croak(aTHX_ errbuf);
 EOF
+    print "#if defined(__HP_cc) || defined(__HP_aCC)\n",
+          "#pragma diag_suppress 2128\n",
+          "#endif\n"
+      if $^O eq "hpux";
 
     if ($xsreturn) {
       print Q(<<"EOF") unless $PPCODE;
@@ -809,6 +822,10 @@ EOF
 #    XSRETURN_EMPTY;
 EOF
     }
+    print "#if defined(__HP_cc) || defined(__HP_aCC)\n",
+          "#pragma diag_default 2128\n",
+          "#endif\n"
+      if $^O eq "hpux";
 
     print Q(<<"EOF");
 #]]

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Symbol;
 
-our $VERSION = '3.49';
+our $VERSION = '3.50';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
@@ -1,7 +1,7 @@
 package ExtUtils::ParseXS::CountLines;
 use strict;
 
-our $VERSION = '3.49';
+our $VERSION = '3.50';
 
 our $SECTION_END_MARKER;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
@@ -2,7 +2,7 @@ package ExtUtils::ParseXS::Eval;
 use strict;
 use warnings;
 
-our $VERSION = '3.49';
+our $VERSION = '3.50';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
@@ -5,7 +5,7 @@ use Exporter;
 use File::Spec;
 use ExtUtils::ParseXS::Constants ();
 
-our $VERSION = '3.49';
+our $VERSION = '3.50';
 
 our (@ISA, @EXPORT_OK);
 @ISA = qw(Exporter);

--- a/dist/ExtUtils-ParseXS/lib/perlxs.pod
+++ b/dist/ExtUtils-ParseXS/lib/perlxs.pod
@@ -2409,7 +2409,7 @@ or use the methods given in L<perlcall>.
 =head1 XS VERSION
 
 This document covers features supported by C<ExtUtils::ParseXS>
-(also known as C<xsubpp>) 3.49
+(also known as C<xsubpp>) 3.50
 
 =head1 AUTHOR DIAGNOSTICS
 

--- a/dist/ExtUtils-ParseXS/t/001-basic.t
+++ b/dist/ExtUtils-ParseXS/t/001-basic.t
@@ -94,6 +94,7 @@ is( $seen, 1, "Line numbers created in output file, as intended" );
     local $/ = undef;
     seek($IN, 0, 0);
     my $filecontents = <$IN>;
+    $filecontents =~ s/^#if defined\(__HP_cc\).*\n#.*\n#endif\n//gm;
     my $good_T_BOOL_re =
 qr|\QXS_EUPXS(XS_XSTest_T_BOOL)\E
 .+?

--- a/dist/Net-Ping/lib/Net/Ping.pm
+++ b/dist/Net-Ping/lib/Net/Ping.pm
@@ -22,7 +22,7 @@ use Time::HiRes;
 @ISA = qw(Exporter);
 @EXPORT = qw(pingecho);
 @EXPORT_OK = qw(wakeonlan);
-$VERSION = "2.75";
+$VERSION = "2.76";
 
 # Globals
 

--- a/dist/Net-Ping/t/450_service.t
+++ b/dist/Net-Ping/t/450_service.t
@@ -78,7 +78,7 @@ is($p->ping("127.0.0.1"), 1, 'first port is reachable');
 $p->{port_num} = $port2;
 
 {
-    local $TODO = "Believed not to work on $^O" if $^O =~ /^(?:hpux|MSWin32|os390)$/;
+    local $TODO = "Believed not to work on $^O" if $^O =~ /^(?:MSWin32|os390)$/;
     is($p->ping("127.0.0.1"), 1, 'second port is reachable');
 }
 
@@ -133,7 +133,7 @@ SKIP: {
 
   {
     local $TODO = "Believed not to work on $^O"
-      if $^O =~ /^(?:hpux|MSWin32|os390)$/;
+      if $^O =~ /^(?:MSWin32|os390)$/;
     is($p->ack(), '127.0.0.1', 'IP should be reachable');
   }
 }

--- a/dist/threads-shared/lib/threads/shared.pm
+++ b/dist/threads-shared/lib/threads/shared.pm
@@ -8,7 +8,7 @@ use Config;
 
 use Scalar::Util qw(reftype refaddr blessed);
 
-our $VERSION = '1.67'; # Please update the pod, too.
+our $VERSION = '1.68'; # Please update the pod, too.
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -196,7 +196,7 @@ threads::shared - Perl extension for sharing data structures between threads
 
 =head1 VERSION
 
-This document describes threads::shared version 1.67
+This document describes threads::shared version 1.68
 
 =head1 SYNOPSIS
 

--- a/dist/threads-shared/shared.xs
+++ b/dist/threads-shared/shared.xs
@@ -701,10 +701,10 @@ Perl_sharedsv_cond_timedwait(perl_cond *cond, perl_mutex *mut, double abs)
     abs -= (NV)ts.tv_sec;
     ts.tv_nsec = (long)(abs * 1000000000.0);
 
-    CLANG_DIAG_IGNORE_STMT(-Wthread-safety);
+    CLANG_DIAG_IGNORE(-Wthread-safety)
     /* warning: calling function 'pthread_cond_timedwait' requires holding mutex 'mut' exclusively [-Wthread-safety-analysis] */
     switch (pthread_cond_timedwait(cond, mut, &ts)) {
-	CLANG_DIAG_RESTORE_STMT;
+	CLANG_DIAG_RESTORE
 
         case 0:         got_it = 1; break;
         case ETIMEDOUT:             break;

--- a/dist/threads/lib/threads.pm
+++ b/dist/threads/lib/threads.pm
@@ -5,7 +5,7 @@ use 5.008;
 use strict;
 use warnings;
 
-our $VERSION = '2.35';      # remember to update version in POD!
+our $VERSION = '2.36';      # remember to update version in POD!
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -134,7 +134,7 @@ threads - Perl interpreter-based threads
 
 =head1 VERSION
 
-This document describes threads version 2.35
+This document describes threads version 2.36
 
 =head1 WARNING
 

--- a/dist/threads/threads.xs
+++ b/dist/threads/threads.xs
@@ -1054,10 +1054,10 @@ S_ithread_create(
     MUTEX_UNLOCK(&my_pool->create_destruct_mutex);
     return (thread);
 
-    CLANG_DIAG_IGNORE_STMT(-Wthread-safety);
+    CLANG_DIAG_IGNORE(-Wthread-safety)
     /* warning: mutex 'thread->mutex' is not held on every path through here [-Wthread-safety-analysis] */
 }
-CLANG_DIAG_RESTORE_DECL;
+CLANG_DIAG_RESTORE
 
 #endif /* USE_ITHREADS */
 

--- a/embed.fnc
+++ b/embed.fnc
@@ -5893,6 +5893,7 @@ S	|void	|warn_on_first_deprecated_use				\
 #if defined(PERL_IN_UTIL_C)
 S	|bool	|ckwarn_common	|U32 w
 S	|SV *	|mess_alloc
+Ti	|U32	|ptr_hash	|PTRV u
 S	|SV *	|with_queued_errors					\
 				|NN SV *ex
 So	|void	|xs_version_bootcheck					\

--- a/embed.h
+++ b/embed.h
@@ -1636,6 +1636,7 @@
 #   if defined(PERL_IN_UTIL_C)
 #     define ckwarn_common(a)                   S_ckwarn_common(aTHX_ a)
 #     define mess_alloc()                       S_mess_alloc(aTHX)
+#     define ptr_hash                           S_ptr_hash
 #     define with_queued_errors(a)              S_with_queued_errors(aTHX_ a)
 #     if defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL)
 #       define mem_log_common                   S_mem_log_common

--- a/handy.h
+++ b/handy.h
@@ -2730,6 +2730,7 @@ PoisonWith(0xEF) for catching access to freed memory.
  *    max(n) * sizeof(t) > MEM_SIZE_MAX
  */
 
+
 #  define _MEM_WRAP_NEEDS_RUNTIME_CHECK(n,t) \
     (  sizeof(MEM_SIZE) < sizeof(n) \
     || sizeof(t) > ((MEM_SIZE)1 << 8*(sizeof(MEM_SIZE) - sizeof(n))))

--- a/hints/hpux.sh
+++ b/hints/hpux.sh
@@ -805,13 +805,15 @@ case "$d_oldpthreads" in
 # and it seems to be buggy in HP-UX anyway.
 i_dbm=undef
 
-# In HP-UXes prior to 11.23 strtold() returned a HP-UX
-# specific union called long_double, not a C99 long double.
-case "`grep 'double strtold.const' /usr/include/stdlib.h`" in
-*"long double strtold"*) ;; # strtold should be safe.
-*) echo "Looks like your strtold() is non-standard..." >&4
-   d_strtold=undef ;;
-esac
+if [ "$xxOsRevMajor" -lt 11 ] || [ "$xxOsRevMajor" -eq 11 ] && [ "$xxOsRevMinor" -lt 23 ]; then
+    # In HP-UXes prior to 11.23 strtold() returned a HP-UX
+    # specific union called long_double, not a C99 long double.
+    case "`grep 'double strtold.const' /usr/include/stdlib.h`" in
+        *"long double strtold"*) ;; # strtold should be safe.
+        *) echo "Looks like your strtold() is non-standard..." >&4
+        d_strtold=undef ;;
+    esac
+fi
 
 # In pre-11 HP-UXes there really isn't isfinite(), despite what
 # Configure might think. (There is finite(), though.)

--- a/hv.c
+++ b/hv.c
@@ -480,7 +480,7 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
 
     if (!hv)
         return NULL;
-    if (SvTYPE(hv) == (svtype)SVTYPEMASK)
+    if (SvIS_FREED(hv))
         return NULL;
 
     assert(SvTYPE(hv) == SVt_PVHV);

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -927,7 +927,11 @@ PERLVARI(I, clocktick,	long,	0)	/* this many times() ticks in a second */
 PERLVARI(I, sharehook,	share_proc_t, Perl_sv_nosharing)
 PERLVARI(I, lockhook,	share_proc_t, Perl_sv_nosharing)
 
+#if defined(__HP_cc) || defined(__HP_aCC)
+#pragma diag_suppress 3215
+#endif
 GCC_DIAG_IGNORE(-Wdeprecated-declarations)
+
 #ifdef NO_MATHOMS
 #  define PERL_UNLOCK_HOOK Perl_sv_nosharing
 #else
@@ -937,6 +941,9 @@ GCC_DIAG_IGNORE(-Wdeprecated-declarations)
 PERLVARI(I, unlockhook,	share_proc_t, PERL_UNLOCK_HOOK)
 
 GCC_DIAG_RESTORE
+#if defined(__HP_cc) || defined(__HP_aCC)
+#pragma diag_default 3215
+#endif
 
 PERLVARI(I, threadhook,	thrhook_proc_t,	Perl_nothreadhook)
 

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -931,6 +931,7 @@ PERLVARI(I, lockhook,	share_proc_t, Perl_sv_nosharing)
 #pragma diag_suppress 3215
 #endif
 GCC_DIAG_IGNORE(-Wdeprecated-declarations)
+MSVC_DIAG_IGNORE(4996)
 
 #ifdef NO_MATHOMS
 #  define PERL_UNLOCK_HOOK Perl_sv_nosharing
@@ -940,6 +941,7 @@ GCC_DIAG_IGNORE(-Wdeprecated-declarations)
 #endif
 PERLVARI(I, unlockhook,	share_proc_t, PERL_UNLOCK_HOOK)
 
+MSVC_DIAG_RESTORE
 GCC_DIAG_RESTORE
 #if defined(__HP_cc) || defined(__HP_aCC)
 #pragma diag_default 3215

--- a/numeric.c
+++ b/numeric.c
@@ -924,7 +924,7 @@ Perl_grok_infnan(pTHX_ const char** sp, const char* send)
                      * of UVs and NVs can be different. */
 
                     if ((nantype & IS_NUMBER_NOT_INT) ||
-                        !(nantype && IS_NUMBER_IN_UV)) {
+                        !(nantype & IS_NUMBER_IN_UV)) {
                         /* treat "NaN(invalid)" the same as "NaNgarbage" */
                         return trail;
                     }

--- a/op.c
+++ b/op.c
@@ -2469,8 +2469,7 @@ Perl_scalarvoid(pTHX_ OP *arg)
         }
         o = next_kid;
     }
-
-    return arg;
+    NOT_REACHED;
 }
 
 

--- a/peep.c
+++ b/peep.c
@@ -2690,7 +2690,7 @@ Perl_rpeep(pTHX_ OP *o)
 {
     OP* oldop = NULL;
     OP* oldoldop = NULL;
-    OP** defer_queue[MAX_DEFERRED]; /* small queue of deferred branches */
+    OP** defer_queue[MAX_DEFERRED] = { NULL }; /* small queue of deferred branches */
     int defer_base = 0;
     int defer_ix = -1;
 

--- a/perl.c
+++ b/perl.c
@@ -1429,7 +1429,7 @@ perl_destruct(pTHXx)
         for (sva = PL_sv_arenaroot; sva; sva = MUTABLE_SV(SvANY(sva))) {
             svend = &sva[SvREFCNT(sva)];
             for (sv = sva + 1; sv < svend; ++sv) {
-                if (SvTYPE(sv) != (svtype)SVTYPEMASK) {
+                if (!SvIS_FREED(sv)) {
                     PerlIO_printf(Perl_debug_log, "leaked: sv=0x%p"
                         " flags=0x%" UVxf
                         " refcnt=%" UVuf pTHX__FORMAT "\n"

--- a/perl.c
+++ b/perl.c
@@ -1986,6 +1986,12 @@ S_Internals_V(pTHX_ CV *cv)
 #  ifdef DEBUGGING
                              " DEBUGGING"
 #  endif
+#  ifdef HAS_LONG_DOUBLE
+                             " HAS_LONG_DOUBLE"
+#  endif
+#  ifdef HAS_STRTOLD
+                             " HAS_STRTOLD"
+#  endif
 #  ifdef NO_MATHOMS
                              " NO_MATHOMS"
 #  endif

--- a/perl.h
+++ b/perl.h
@@ -11,6 +11,22 @@
 #ifndef H_PERL
 #define H_PERL 1
 
+#if defined(__HP_cc) || defined(__HP_aCC)
+/* The HPUX compiler for Itanium is very picky and warns about
+ * things that gcc doesn't and that we would prefer it does not.
+ * So on that platform silence certain warnings unlaterally. */
+
+/* silence "relational operator ">" always evaluates to 'false'"
+ * warnings. We get a LOT of these from the memwrap checks. */
+#pragma diag_suppress 4276
+
+/* silence "may cause misaligned access" warnings from our "OO in C"
+ * type logic. we do this a lot and if it was broken we would fail tests
+ * all over the place */
+#pragma diag_suppress 4232
+
+#endif /* end HPUX warning disablement */
+
 #ifdef PERL_FOR_X2P
 /*
  * This file is being used for x2p stuff.

--- a/perlio.c
+++ b/perlio.c
@@ -53,7 +53,7 @@
 #  include <rms.h>
 #endif
 
-#define PerlIO_lockcnt(f) (((PerlIOl*)(f))->head->flags)
+#define PerlIO_lockcnt(f) (((PerlIOl*)(void*)(f))->head->flags)
 
 /* Call the callback or PerlIOBase, and return failure. */
 #define Perl_PerlIO_or_Base(f, callback, base, failure, args) 	\

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -2989,7 +2989,13 @@ PP(pp_stat)
             Stat_t s;
             CLANG_DIAG_IGNORE_STMT(-Wtautological-compare);
             GCC_DIAG_IGNORE_STMT(-Wtype-limits);
+#if defined(__HP_cc) || defined(__HP_aCC)
+#pragma diag_suppress 2186
+#endif
             neg = PL_statcache.st_ino < 0;
+#if defined(__HP_cc) || defined(__HP_aCC)
+#pragma diag_default 2186
+#endif
             GCC_DIAG_RESTORE_STMT;
             CLANG_DIAG_RESTORE_STMT;
             if (neg) {

--- a/proto.h
+++ b/proto.h
@@ -9538,6 +9538,12 @@ S_mem_log_common(enum mem_log_type mlt, const UV n, const UV typesize, const cha
         assert(type_name); assert(filename); assert(funcname)
 
 # endif /* defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL) */
+# if !defined(PERL_NO_INLINE_FUNCTIONS)
+PERL_STATIC_INLINE U32
+S_ptr_hash(PTRV u);
+#   define PERL_ARGS_ASSERT_PTR_HASH
+
+# endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 # if defined(PERL_USES_PL_PIDSTATUS)
 STATIC void
 S_pidgone(pTHX_ Pid_t pid, int status);

--- a/regcomp.c
+++ b/regcomp.c
@@ -11247,10 +11247,7 @@ S_optimize_regclass(pTHX_
                 if (*invert) {
                     goto return_OPFAIL;
                 }
-                else {
-                    goto return_SANY;
-                }
-                return op;
+                goto return_SANY;
             }
         }
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -1837,7 +1837,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
                /* An OR of *one* alternative - should not happen now. */
             (OP(first) == BRANCH && OP(first_next) != BRANCH) ||
             /* for now we can't handle lookbehind IFMATCH*/
-            (OP(first) == IFMATCH && !first->flags && (sawlookahead = 1)) ||
+            (OP(first) == IFMATCH && !FLAGS(first) && (sawlookahead = 1)) ||
             (OP(first) == PLUS) ||
             (OP(first) == MINMOD) ||
                /* An {n,m} with n>0 */
@@ -2220,7 +2220,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
          */
         if (REGNODE_TYPE(fop) == NOTHING && nop == END)
             RExC_rx->extflags |= RXf_NULL;
-        else if ((fop == MBOL || (fop == SBOL && !first->flags)) && nop == END)
+        else if ((fop == MBOL || (fop == SBOL && !FLAGS(first))) && nop == END)
             /* when fop is SBOL first->flags will be true only when it was
              * produced by parsing /\A/, and not when parsing /^/. This is
              * very important for the split code as there we want to
@@ -2766,7 +2766,7 @@ S_handle_named_backref(pTHX_ RExC_state_t *pRExC_state,
                            : REFFN),
                     num, RExC_nestroot);
     if (RExC_nestroot && num >= (U32)RExC_nestroot)
-        REGNODE_p(ret)->flags = VOLATILE_REF;
+        FLAGS(REGNODE_p(ret)) = VOLATILE_REF;
     *flagp |= HASWIDTH;
 
     nextchar(pRExC_state);
@@ -6045,7 +6045,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                                        : REFF),
                                 num, RExC_nestroot);
                 if (RExC_nestroot && num >= RExC_nestroot)
-                    REGNODE_p(ret)->flags = VOLATILE_REF;
+                    FLAGS(REGNODE_p(ret)) = VOLATILE_REF;
                 if (OP(REGNODE_p(ret)) == REFF) {
                     RExC_seen_d_op = TRUE;
                 }
@@ -12024,7 +12024,7 @@ S_optimize_regclass(pTHX_
                         op = ANYOFHbbm;
                         *ret = REGNODE_GUTS(pRExC_state, op, REGNODE_ARG_LEN(op));
                         FILL_NODE(*ret, op);
-                        ((struct regnode_bbm *) REGNODE_p(*ret))->first_byte = low_utf8[0],
+                        FIRST_BYTE((struct regnode_bbm *) REGNODE_p(*ret)) = low_utf8[0],
 
                         /* The 64 bit (or 32 on EBCCDIC) map can be looked up
                          * directly based on the continuation byte, without
@@ -12050,7 +12050,7 @@ S_optimize_regclass(pTHX_
                     *ret = REGNODE_GUTS(pRExC_state, op,
                                        REGNODE_ARG_LEN(op) + STR_SZ(len));
                     FILL_NODE(*ret, op);
-                    ((struct regnode_anyofhs *) REGNODE_p(*ret))->str_len
+                    STR_LEN_U8((struct regnode_anyofhs *) REGNODE_p(*ret))
                                                                     = len;
                     Copy(low_utf8,  /* Add the common bytes */
                     ((struct regnode_anyofhs *) REGNODE_p(*ret))->string,
@@ -13044,7 +13044,7 @@ Perl_get_ANYOFHbbm_contents(pTHX_ const regnode * n) {
               &cp_list,
 
               /* The base cp is from the start byte plus a zero continuation */
-              TWO_BYTE_UTF8_TO_NATIVE(((struct regnode_bbm *) n)->first_byte,
+              TWO_BYTE_UTF8_TO_NATIVE(FIRST_BYTE((struct regnode_bbm *) n),
                                       UTF_CONTINUATION_MARK | 0));
     return cp_list;
 }

--- a/regcomp.c
+++ b/regcomp.c
@@ -1833,31 +1833,33 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
          * properly currently.
          *
          */
-        while ((OP(first) == OPEN && ((sawopen = 1)) ) ||
-               /* An OR of *one* alternative - should not happen now. */
-            (OP(first) == BRANCH && OP(first_next) != BRANCH) ||
-            /* for now we can't handle lookbehind IFMATCH*/
-            (OP(first) == IFMATCH && !FLAGS(first) && (sawlookahead = 1)) ||
-            (OP(first) == PLUS) ||
-            (OP(first) == MINMOD) ||
-               /* An {n,m} with n>0 */
-            (REGNODE_TYPE(OP(first)) == CURLY && ARG1i(first) > 0) ||
-            (OP(first) == NOTHING && REGNODE_TYPE(OP(first_next)) != END ))
+        while (1)
         {
-                /*
-                 * the only op that could be a regnode is PLUS, all the rest
-                 * will be regnode_1 or regnode_2.
-                 *
-                 * (yves doesn't think this is true)
-                 */
-                if (OP(first) == PLUS)
-                    sawplus = 1;
-                else
-                if (OP(first) == MINMOD)
-                    sawminmod = 1;
+            if (OP(first) == OPEN)
+                sawopen = 1;
+            else
+            if (OP(first) == IFMATCH && !FLAGS(first))
+                /* for now we can't handle lookbehind IFMATCH */
+                sawlookahead = 1;
+            else
+            if (OP(first) == PLUS)
+                sawplus = 1;
+            else
+            if (OP(first) == MINMOD)
+                sawminmod = 1;
+            else
+            if (!(
+                /* An OR of *one* alternative - should not happen now. */
+                (OP(first) == BRANCH && OP(first_next) != BRANCH) ||
+                /* An {n,m} with n>0 */
+                (REGNODE_TYPE(OP(first)) == CURLY && ARG1i(first) > 0) ||
+                (OP(first) == NOTHING && REGNODE_TYPE(OP(first_next)) != END)
+            )){
+                break;
+            }
 
-                first = REGNODE_AFTER(first);
-                first_next= regnext(first);
+            first = REGNODE_AFTER(first);
+            first_next= regnext(first);
         }
 
         /* Starting-point info. */

--- a/regcomp.h
+++ b/regcomp.h
@@ -211,7 +211,7 @@ typedef struct regexp_internal {
  */
 
 struct regnode_string {
-    U8	str_len;
+    U8	str_len_u8;
     U8  type;
     U16 next_off;
     char string[1];
@@ -221,7 +221,7 @@ struct regnode_lstring { /* Constructed this way to keep the string aligned. */
     U8	flags;
     U8  type;
     U16 next_off;
-    U32 str_len;    /* Only 18 bits allowed before would overflow 'next_off' */
+    U32 str_len_u32;    /* Only 18 bits allowed before would overflow 'next_off' */
     char string[1];
 };
 
@@ -551,7 +551,7 @@ struct regnode_ssc {
                                            regnode types.  For some, it's the \
                                            character set of the regnode */
 #define	STR_LENs(p)	(__ASSERT_(OP(p) != LEXACT && OP(p) != LEXACT_REQ8)  \
-                                    ((struct regnode_string *)p)->str_len)
+                                    ((struct regnode_string *)p)->str_len_u8)
 #define	STRINGs(p)	(__ASSERT_(OP(p) != LEXACT && OP(p) != LEXACT_REQ8)  \
                                     ((struct regnode_string *)p)->string)
 #define	OPERANDs(p)	STRINGs(p)
@@ -571,7 +571,7 @@ struct regnode_ssc {
  * using the flags nor next_off fields at all.  One could have an llstring node
  * and even an lllstring type. */
 #define	STR_LENl(p)	(__ASSERT_(OP(p) == LEXACT || OP(p) == LEXACT_REQ8)  \
-                                    (((struct regnode_lstring *)p)->str_len))
+                                    (((struct regnode_lstring *)p)->str_len_u32))
 #define	STRINGl(p)	(__ASSERT_(OP(p) == LEXACT || OP(p) == LEXACT_REQ8)  \
                                     (((struct regnode_lstring *)p)->string))
 #define	OPERANDl(p)	STRINGl(p)
@@ -589,9 +589,9 @@ struct regnode_ssc {
 #define setSTR_LEN(p,v)                                                     \
     STMT_START{                                                             \
         if (OP(p) == LEXACT || OP(p) == LEXACT_REQ8)                        \
-            ((struct regnode_lstring *)(p))->str_len = (v);                 \
+            ((struct regnode_lstring *)(p))->str_len_u32 = (v);             \
         else                                                                \
-            ((struct regnode_string *)(p))->str_len = (v);                  \
+            ((struct regnode_string *)(p))->str_len_u8 = (v);               \
     } STMT_END
 
 #define ANYOFR_BASE_BITS    20

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -438,7 +438,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         const reg_trie_data * const trie
             = (reg_trie_data*)progi->data->data[!IS_TRIE_AC(op) ? n : ac->trie];
 
-        Perl_sv_catpvf(aTHX_ sv, "-%s", REGNODE_NAME(o->flags));
+        Perl_sv_catpvf(aTHX_ sv, "-%s", REGNODE_NAME(FLAGS(o)));
         DEBUG_TRIE_COMPILE_r({
           if (trie->jump)
             sv_catpvs(sv, "(JUMP)");
@@ -475,7 +475,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         if (ARG3u(o)) /* check both ARG3a and ARG3b at the same time */
             Perl_sv_catpvf(aTHX_ sv, "<%d:%d>", ARG3a(o),ARG3b(o)); /* paren before, paren after */
         if (op == CURLYM || op == CURLYN || op == CURLYX)
-            Perl_sv_catpvf(aTHX_ sv, "[%d]", o->flags); /* Parenth number */
+            Perl_sv_catpvf(aTHX_ sv, "[%d]", FLAGS(o)); /* Parenth number */
         Perl_sv_catpvf(aTHX_ sv, "{%u,", (unsigned) lo);
         if (hi == REG_INFTY)
             sv_catpvs(sv, "INFTY");
@@ -483,8 +483,8 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
             Perl_sv_catpvf(aTHX_ sv, "%u", (unsigned) hi);
         sv_catpvs(sv, "}");
     }
-    else if (k == WHILEM && o->flags)                   /* Ordinal/of */
-        Perl_sv_catpvf(aTHX_ sv, "[%d/%d]", o->flags & 0xf, o->flags>>4);
+    else if (k == WHILEM && FLAGS(o))                   /* Ordinal/of */
+        Perl_sv_catpvf(aTHX_ sv, "[%d/%d]", FLAGS(o) & 0xf, FLAGS(o)>>4);
     else if (k == REF || k == OPEN || k == CLOSE
              || k == GROUPP || op == ACCEPT)
     {
@@ -586,7 +586,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
     }
     else if (k == LOGICAL)
         /* 2: embedded, otherwise 1 */
-        Perl_sv_catpvf(aTHX_ sv, "[%d]", o->flags);
+        Perl_sv_catpvf(aTHX_ sv, "[%d]", FLAGS(o));
     else if (k == ANYOF || k == ANYOFH || k == ANYOFR) {
         U8 flags;
         char * bitmap;
@@ -876,21 +876,21 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         sv_catpv(sv, bounds[FLAGS(o)]);
     }
     else if (k == BRANCHJ && (op == UNLESSM || op == IFMATCH)) {
-        Perl_sv_catpvf(aTHX_ sv, "[%d", -(o->flags));
-        if (o->next_off) {
-            Perl_sv_catpvf(aTHX_ sv, "..-%d", o->flags - o->next_off);
+        Perl_sv_catpvf(aTHX_ sv, "[%d", -(FLAGS(o)));
+        if (NEXT_OFF(o)) {
+            Perl_sv_catpvf(aTHX_ sv, "..-%d", FLAGS(o) - NEXT_OFF(o));
         }
         Perl_sv_catpvf(aTHX_ sv, "]");
     }
     else if (op == SBOL)
-        Perl_sv_catpvf(aTHX_ sv, " /%s/", o->flags ? "\\A" : "^");
+        Perl_sv_catpvf(aTHX_ sv, " /%s/", FLAGS(o) ? "\\A" : "^");
     else if (op == EVAL) {
-        if (o->flags & EVAL_OPTIMISTIC_FLAG)
+        if (FLAGS(o) & EVAL_OPTIMISTIC_FLAG)
             Perl_sv_catpvf(aTHX_ sv, " optimistic");
     }
 
     /* add on the verb argument if there is one */
-    if ( ( k == VERB || op == ACCEPT || op == OPFAIL ) && o->flags) {
+    if ( ( k == VERB || op == ACCEPT || op == OPFAIL ) && FLAGS(o)) {
         if ( ARG1u(o) )
             Perl_sv_catpvf(aTHX_ sv, ":%" SVf,
                        SVfARG((MUTABLE_SV(progi->data->data[ ARG1u( o ) ]))));

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -1517,7 +1517,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                 OP( convert ) = TRIE;
 
             /* store the type in the flags */
-            convert->flags = nodetype;
+            FLAGS(convert) = nodetype;
             DEBUG_r({
             optimize = convert
                       + NODE_STEP_REGNODE

--- a/regexec.c
+++ b/regexec.c
@@ -617,8 +617,7 @@ S_isFOO_utf8_lc(pTHX_ const U8 classnum, const U8* character, const U8* e)
             return _invlist_contains_cp(PL_XPosix_ptrs[classnum],
                                         utf8_to_uvchr_buf(character, e, NULL));
     }
-
-    return FALSE; /* Things like CNTRL are always below 256 */
+    NOT_REACHED; /* NOTREACHED */
 }
 
 STATIC U8 *

--- a/regexp.h
+++ b/regexp.h
@@ -29,10 +29,23 @@ struct regnode_meta {
     U8 off_by_arg;
 };
 
+/* this ensures that on alignment sensitive platforms
+ * this struct is aligned on 32 bit boundaries */
+union regnode_head {
+    struct {
+        union {
+            U8 flags;
+            U8 str_len_u8;
+            U8 first_byte;
+        } u_8;
+        U8  type;
+        U16 next_off;
+    } data;
+    U32 data_u32;
+};
+
 struct regnode {
-    U8	flags;
-    U8  type;
-    U16 next_off;
+    union regnode_head head;
 };
 
 typedef struct regnode regnode;

--- a/sv.c
+++ b/sv.c
@@ -387,7 +387,7 @@ S_visit(pTHX_ SVFUNC_t f, const U32 flags, const U32 mask)
         const SV * const svend = &sva[SvREFCNT(sva)];
         SV* sv;
         for (sv = sva + 1; sv < svend; ++sv) {
-            if (SvTYPE(sv) != (svtype)SVTYPEMASK
+            if (!SvIS_FREED(sv)
                     && (sv->sv_flags & mask) == flags
                     && SvREFCNT(sv))
             {
@@ -406,7 +406,7 @@ S_visit(pTHX_ SVFUNC_t f, const U32 flags, const U32 mask)
 static void
 do_report_used(pTHX_ SV *const sv)
 {
-    if (SvTYPE(sv) != (svtype)SVTYPEMASK) {
+    if (!SvIS_FREED(sv)) {
         PerlIO_printf(Perl_debug_log, "****\n");
         sv_dump(sv);
     }
@@ -6626,7 +6626,7 @@ Perl_sv_clear(pTHX_ SV *const orig_sv)
         HV *stash;
 
         assert(SvREFCNT(sv) == 0);
-        assert(SvTYPE(sv) != (svtype)SVTYPEMASK);
+        assert(!SvIS_FREED(sv));
 #if NVSIZE <= IVSIZE
         if (type <= SVt_NV) {
 #else
@@ -10035,7 +10035,7 @@ Perl_newSVsv_flags(pTHX_ SV *const old, I32 flags)
 
     if (!old)
         return NULL;
-    if (SvTYPE(old) == (svtype)SVTYPEMASK) {
+    if (SvIS_FREED(old)) {
         Perl_ck_warner_d(aTHX_ packWARN(WARN_INTERNAL), "semi-panic: attempt to dup freed string");
         return NULL;
     }
@@ -14516,7 +14516,7 @@ S_sv_dup_common(pTHX_ const SV *const ssv, CLONE_PARAMS *const param)
 
     PERL_ARGS_ASSERT_SV_DUP_COMMON;
 
-    if (SvTYPE(ssv) == (svtype)SVTYPEMASK) {
+    if (SvIS_FREED(ssv)) {
 #ifdef DEBUG_LEAKING_SCALARS_ABORT
         abort();
 #endif

--- a/t/op/sprintf2.t
+++ b/t/op/sprintf2.t
@@ -1189,6 +1189,8 @@ if($Config{nvsize} == 8) {
                                    or
                                $^O eq 'VMS'
                                    or
+                               $^O eq 'hpux'
+                                   or
                                ($^O eq 'MSWin32' and
                                 $Config{cc} eq 'cl' and
                                 $Config{ccversion} =~ /^(\d+)/ and
@@ -1215,9 +1217,13 @@ elsif($Config{nvtype} eq 'long double' && $Config{longdblkind} >= 5 && $Config{l
 }
 else {
     # IEEE-754 128-bit long double or __float128
-    cmp_ok(sprintf("%.115g", 0.3), 'eq',
+    TODO: {
+        local $::TODO = 'Extended precision %g formatting' if $^O eq 'hpux';
+
+        cmp_ok(sprintf("%.115g", 0.3), 'eq',
            '0.299999999999999999999999999999999990370350278063820734720110287075363407309491758923059023800306022167205810546875',
            "sprintf( \"%.115g\", 0.3 ) renders correctly");
+    }
 }
 
 done_testing();

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -5,12 +5,6 @@ ExtUtils::Constant cpan/ExtUtils-Constant/lib/ExtUtils/Constant/Base.pm 7560e101
 ExtUtils::Constant cpan/ExtUtils-Constant/t/Constant.t 165e9c7132b003fd192d32a737b0f51f9ba4999e
 Filter::Util::Call pod/perlfilter.pod d1e217d0bc6083755b9017050b8724472c58275a
 Locale::Maketext::Simple cpan/Locale-Maketext-Simple/lib/Locale/Maketext/Simple.pm 57ed38905791a17c150210cd6f42ead22a7707b6
-Net::Ping dist/Net-Ping/t/000_load.t deff5dc2ca54dae28cb19d3631427db127279ac2
-Net::Ping dist/Net-Ping/t/001_new.t 7b24e05672e22edfe3e6b5cc0277f815efe557e5
-Net::Ping dist/Net-Ping/t/010_pingecho.t 74437379673c8ba82f81574fd7e652f41a65c993
-Net::Ping dist/Net-Ping/t/450_service.t 4963cd2240f1e583aa950f2bbe8c478ceba3b949
-Net::Ping dist/Net-Ping/t/500_ping_icmp.t 3eeb60181c01b85f876bd6658644548fdf2e24d4
-Net::Ping dist/Net-Ping/t/501_ping_icmpv6.t cd719bca662b054b676dd2ee6e0c73c7a5e50cf9
 Pod::Perldoc cpan/Pod-Perldoc/lib/Pod/Perldoc.pm 582be34c077c9ff44d99914724a0cc2140bcd48c
 Test::Harness cpan/Test-Harness/t/harness.t 38b13cfc479d37d91c104b97dd364a74dfde0f2f
 Win32API::File cpan/Win32API-File/File.pm 8fd212857f821cb26648878b96e57f13bf21b99e

--- a/t/porting/globvar.t
+++ b/t/porting/globvar.t
@@ -27,7 +27,7 @@ my $yes = `$trial`;
 
 skip_all("Could not run `$trial`") if $?;
 
-my $defined = qr/^[0-9a-fA-F]{8,16}\s+[^Uu]\s+_?/m;
+my $defined = $^O eq "hpux" ? qr/\|/ : qr/^[0-9a-fA-F]{8,16}\s+[^Uu]\s+_?/m;
 
 skip_all("Could not spot definition of PL_Yes in output of `$trial`")
     unless $yes =~ /${defined}PL_Yes/m;
@@ -75,10 +75,14 @@ foreach (sort keys %exported) {
  }
 }
 
+$::TODO = $::TODO; # silence uninitialized warnings
 foreach (sort keys %unexported) {
  SKIP: {
         skip("We don't export '$_'", 1) if $skip{$_};
-        fail("'$_' is defined, but we do not export it");
+        TODO: {
+            local $::TODO = "HPUX exports everything" if $^O eq "hpux";
+            fail("'$_' is defined, but we do not export it");
+        }
     }
 }
 

--- a/util.c
+++ b/util.c
@@ -5535,9 +5535,9 @@ Perl_xs_handshake(const U32 key, void * v_my_perl, const char * file, ...)
         }
     }
     {
-        U32 xsverlen;
-        assert(HS_GETXSVERLEN(key) <= UCHAR_MAX && HS_GETXSVERLEN(key) <= HS_APIVERLEN_MAX);
-        if((xsverlen = HS_GETXSVERLEN(key)))
+        U32 xsverlen = HS_GETXSVERLEN(key);
+        assert(xsverlen <= UCHAR_MAX && xsverlen <= HS_APIVERLEN_MAX);
+        if(xsverlen)
             S_xs_version_bootcheck(aTHX_
                 items, ax, va_arg(args, char*), xsverlen);
     }


### PR DESCRIPTION
This is a collection of fixes that came up while trying to get things to build properly on HPUX Itanium. We were producing hundreds of warnings of different types, some actually valid warnings and issues, other cruft from HPUX being super picky and not understanding some of the tricks we use. 

In regard to false positive warnings, two notable examples are our OO in C type logic that we do with casting types with similar layouts from one type to another makes the HPUX compiler produce loads of "possible misalignment" warnings.  Since we test thoroughly and Itanium would segfault if we actually did use misaligned pointers these warnings can be silenced. Another case that produces literally hundreds of warnings is the memory wrap logic which produces a warning about a constant comparisons always being false. We hard silence these warning categories.

Another case is that the XS generated code from ParseXS.pm can produce code that is unreachable, so we silence those warnings on hpux as well.

Other examples are legitimate, for instance using && against a constant where we should be using &.

Another case is that the HPUX compiler whines about assignment in a while conditional, so I rewrote the code to not do that.

This includes some changes to the regnode structures used by the regex engine which I did as an initial response to the misalignment problem. I kept these changes as IMO they actually improve the code by making it more clear what parts of the regnode might have multiple meanings, and by ensuring all access to the contents of the regnode srtuctures is via macros which know the correct struct layout. This also means some of the declaration code can be refactored to share a common set of named unions.

There is a bugfix to cmp_version.t to deal with older git's that don't support taggerdate:unix.  

With all of these patch @Tux's HPUX box passes tests under use64bitall. (It fails GDBM tests when built without the use64bitall).