### PR TITLE
[doc] clarify behavior of File::Copy::cp re: permissions

### DIFF
--- a/lib/File/Copy.pm
+++ b/lib/File/Copy.pm
@@ -23,7 +23,7 @@ sub syscopy;
 sub cp;
 sub mv;
 
-$VERSION = '2.40';
+$VERSION = '2.41';
 
 require Exporter;
 @ISA = qw(Exporter);
@@ -395,9 +395,12 @@ You may use the syntax C<use File::Copy "cp"> to get at the C<cp>
 alias for this function. The syntax is I<exactly> the same.  The
 behavior is nearly the same as well: as of version 2.15, C<cp> will
 preserve the source file's permission bits like the shell utility
-C<cp(1)> would do, while C<copy> uses the default permissions for the
-target file (which may depend on the process' C<umask>, file
-ownership, inherited ACLs, etc.).  If an error occurs in setting
+C<cp(1)> would do with default options, while C<copy> uses the default
+permissions for the target file (which may depend on the process'
+C<umask>, file ownership, inherited ACLs, etc.).  That is, if the
+destination file already exists, C<cp> will leave its permissions
+unchanged; otherwise the permissions are taken from the source file
+and modified by the C<umask>.  If an error occurs in setting
 permissions, C<cp> will return 0, regardless of whether the file was
 successfully copied.
 


### PR DESCRIPTION
In particular, explain that "preserve permission bits like cp" means the default behavior of /bin/cp, not "cp -p" or "cp --preserve", so the umask still applies.