### PR TITLE
t/harness - rework App::Prove::State setup to not warn and use customizable state file

### DIFF
--- a/pod/perlhack.pod
+++ b/pod/perlhack.pod
@@ -942,6 +942,16 @@ Note that the command line above added a C<-j> parameter to make, so as
 to cause parallel compilation.  This may or may not work on your
 platform.
 
+Normally data on how long tests take is stored in F<t/test_state>,
+however you can change this to use a different filename by setting the
+C<PERL_TEST_STATE_FILE> environment variable to something different, or
+to a false value (0 or the empty string) to disable use of the state
+mechanism entirely.  There are no protections against the format of the
+state file changing over time, so if you have any issues related to this
+file it is up to you to delete the file manually and then let the
+harness recreate it, although the file format does not change frequently
+so this should not be necessary very often.
+
 =head2 Running tests by hand
 
 You can run part of the test suite by hand by using one of the

--- a/t/harness
+++ b/t/harness
@@ -139,7 +139,6 @@ sub _extract_tests {
 }
 
 my %total_time;
-
 sub _compute_tests_and_ordering($) {
     my @tests = $_[0]->@*;
 
@@ -147,10 +146,23 @@ sub _compute_tests_and_ordering($) {
     my %all_dirs;
     my %map_file_to_dir;
 
-    if ($jobs > 1) {
+    if (!$dump_tests) {
         require App::Prove::State;
-        $state = App::Prove::State->new({ store => 'test_state' });
-        $state->apply_switch('slow', 'save');
+        if (!$state) {
+            # silence unhelpful warnings from App::Prove::State about not having
+            # a save state, unless we actually set the PERL_TEST_STATE we don't care
+            # and we don't need to know if its fresh or not.
+            local $SIG{__WARN__} = $ENV{PERL_TEST_STATE} ? $SIG{__WARN__} : sub {
+                return if $_[0] and $_[0]=~/No saved state/;
+                warn $_[0];
+            };
+            my $state_file = $ENV{PERL_TEST_STATE_FILE} // 'test_state';
+            if ($state_file) { # set PERL_TEST_STATE_FILE to 0 to skip this
+                $state = App::Prove::State->new({ store => $state_file });
+                $state->apply_switch('save');
+                $state->apply_switch('slow') if $jobs > 1;
+            }
+        }
         # For some reason get_tests returns *all* the tests previously run,
         # (in the right order), not simply the selection in @tests
         # (in the right order). Not sure if this is a bug or a feature.


### PR DESCRIPTION

Currently we only store state if we are running parallel tests, so if you run the tests in series we do not store data on how long they took, and we can't use that information in a follow up parallel test run.

We also do not allow the state file to be customized to be outside of the repo, so git clean -dfx wipes it. This means you can't keep your test data over time, which can be a bit annoying.

We also currently construct the state object twice during setup, resulting in two (useless) warnings when the state file is missing, which also doubles the time to set up the tests because the yaml file gets read twice, and not very efficiently either.

This patch changes the logic so that we initialize the state object only once during startup, and we use the state file if we are going to run tests, parallel or not, provided the user does not explicitly disable it (see below). The order that tests are run is affected only when the tests are run in parallel.

It also allows the user to specify where the state file should live, with the $ENV{PERL_TEST_STATE_FILE} environment variable, which can be set to 0 or the empty string to disable use of the state file if needed.

We also take care to silence the warning about an empty state file, except in the case where the user has overriden the file name with the $ENV{PERL_TEST_STATE_FILE}.

Lastly this patch disables loading the state data /at all/, when the dump_tests option is invoked. There is no need nor point to load the state data when we are simply going to dump out the list of tests we will run.