### PR TITLE
Update ExtUtils-MakeMaker to v7.70

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1011,17 +1011,17 @@ cpan/ExtUtils-Install/t/lib/MakeMaker/Test/Utils.pm	MakeMaker test utilities
 cpan/ExtUtils-Install/t/lib/TieOut.pm			Testing library to capture prints
 cpan/ExtUtils-Install/t/Packlist.t			See if Packlist works
 cpan/ExtUtils-MakeMaker/bin/instmodsh						Give information about installed extensions
-cpan/ExtUtils-MakeMaker/lib/ExtUtils/Command.pm
+cpan/ExtUtils-MakeMaker/lib/ExtUtils/Command.pm					Module related to ExtUtils::MakeMaker
 cpan/ExtUtils-MakeMaker/lib/ExtUtils/Command/MM.pm				Calling MM functions from the cmd line
 cpan/ExtUtils-MakeMaker/lib/ExtUtils/Liblist.pm					Locates libraries
 cpan/ExtUtils-MakeMaker/lib/ExtUtils/Liblist/Kid.pm				Does the real work of the above
 cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker.pm				Write Makefiles for extensions
 cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Config.pm			MakeMaker wrapper for Config
 cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/FAQ.pod				MakeMaker FAQ
-cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Locale.pm
+cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Locale.pm			Module related to ExtUtils::MakeMaker
 cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Tutorial.pod			Writing a module with MakeMaker
-cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/version.pm
-cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/version/regex.pm
+cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/version.pm			Module related to ExtUtils::MakeMaker
+cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/version/regex.pm			Module related to ExtUtils::MakeMaker
 cpan/ExtUtils-MakeMaker/lib/ExtUtils/Mkbootstrap.pm				Writes a bootstrap file (see MakeMaker)
 cpan/ExtUtils-MakeMaker/lib/ExtUtils/Mksymlists.pm				Writes a linker options file for extensions
 cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm					MakeMaker adaptor class
@@ -1045,20 +1045,20 @@ cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Win95.pm				MakeMaker methods for Win95
 cpan/ExtUtils-MakeMaker/lib/ExtUtils/MY.pm					MakeMaker user override class
 cpan/ExtUtils-MakeMaker/lib/ExtUtils/testlib.pm					Fixes up @INC to use just-built extension
 cpan/ExtUtils-MakeMaker/t/00compile.t						See if MakeMaker modules compile
-cpan/ExtUtils-MakeMaker/t/01perl_bugs.t
-cpan/ExtUtils-MakeMaker/t/02-xsdynamic.t
-cpan/ExtUtils-MakeMaker/t/03-xsstatic.t
-cpan/ExtUtils-MakeMaker/t/04-xs-rpath-darwin.t
+cpan/ExtUtils-MakeMaker/t/01perl_bugs.t						Test file related to ExtUtils::MakeMaker
+cpan/ExtUtils-MakeMaker/t/02-xsdynamic.t					Test file related to ExtUtils::MakeMaker
+cpan/ExtUtils-MakeMaker/t/03-xsstatic.t						Test file related to ExtUtils::MakeMaker
+cpan/ExtUtils-MakeMaker/t/04-xs-rpath-darwin.t					Test file related to ExtUtils::MakeMaker
 cpan/ExtUtils-MakeMaker/t/arch_check.t						Test MakeMaker's arch_check()
 cpan/ExtUtils-MakeMaker/t/backwards.t						Check MakeMaker's backwards compatibility
 cpan/ExtUtils-MakeMaker/t/basic.t						See if MakeMaker can build a module
 cpan/ExtUtils-MakeMaker/t/build_man.t						Set if MakeMaker builds manpages
 cpan/ExtUtils-MakeMaker/t/cd.t							Test to see cd works
 cpan/ExtUtils-MakeMaker/t/config.t						Test ExtUtils::MakeMaker::Config
-cpan/ExtUtils-MakeMaker/t/cp.t
+cpan/ExtUtils-MakeMaker/t/cp.t							Test file related to ExtUtils::MakeMaker
 cpan/ExtUtils-MakeMaker/t/dir_target.t						Verify if dir_target() is supported
 cpan/ExtUtils-MakeMaker/t/echo.t						Test for ExtUtils::MakeMaker
-cpan/ExtUtils-MakeMaker/t/eu_command.t
+cpan/ExtUtils-MakeMaker/t/eu_command.t						Test file related to ExtUtils::MakeMaker
 cpan/ExtUtils-MakeMaker/t/FIRST_MAKEFILE.t					See if FIRST_MAKEFILE works
 cpan/ExtUtils-MakeMaker/t/fix_libs.t						Test for ExtUtils::MakeMaker
 cpan/ExtUtils-MakeMaker/t/fixin.t						See if ExtUtils::MakeMaker works
@@ -1096,7 +1096,7 @@ cpan/ExtUtils-MakeMaker/t/MM_Unix.t						See if ExtUtils::MM_UNIX works
 cpan/ExtUtils-MakeMaker/t/MM_VMS.t						See if ExtUtils::MM_VMS works
 cpan/ExtUtils-MakeMaker/t/MM_Win32.t						See if ExtUtils::MM_Win32 works
 cpan/ExtUtils-MakeMaker/t/oneliner.t						See if MM can generate perl one-liners
-cpan/ExtUtils-MakeMaker/t/os_unsupported.t
+cpan/ExtUtils-MakeMaker/t/os_unsupported.t					Test file related to ExtUtils::MakeMaker
 cpan/ExtUtils-MakeMaker/t/parse_abstract.t					See if parse_abstract works
 cpan/ExtUtils-MakeMaker/t/parse_version.t					See if parse_version works
 cpan/ExtUtils-MakeMaker/t/PL_FILES.t						Test PL_FILES in MakeMaker
@@ -1117,9 +1117,9 @@ cpan/ExtUtils-MakeMaker/t/test_boilerplate.t					MakeMaker test
 cpan/ExtUtils-MakeMaker/t/testdata/reallylongdirectoryname/arch1/Config.pm	test data for MakeMaker
 cpan/ExtUtils-MakeMaker/t/testdata/reallylongdirectoryname/arch2/Config.pm	test data for MakeMaker
 cpan/ExtUtils-MakeMaker/t/testlib.t						See if ExtUtils::testlib works
-cpan/ExtUtils-MakeMaker/t/unicode.t
+cpan/ExtUtils-MakeMaker/t/unicode.t						Test file related to ExtUtils::MakeMaker
 cpan/ExtUtils-MakeMaker/t/VERSION_FROM.t					See if MakeMaker's VERSION_FROM works
-cpan/ExtUtils-MakeMaker/t/vstrings.t
+cpan/ExtUtils-MakeMaker/t/vstrings.t						Test file related to ExtUtils::MakeMaker
 cpan/ExtUtils-MakeMaker/t/WriteEmptyMakefile.t					See if WriteEmptyMakefile works
 cpan/ExtUtils-MakeMaker/t/writemakefile_args.t					See if WriteMakefile works
 cpan/ExtUtils-Manifest/lib/ExtUtils/Manifest.pm		Utilities to write MANIFEST files

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -473,7 +473,8 @@ use File::Glob qw(:case);
     },
 
     'ExtUtils::MakeMaker' => {
-        'DISTRIBUTION' => 'BINGOS/ExtUtils-MakeMaker-7.66.tar.gz',
+        'DISTRIBUTION' => 'BINGOS/ExtUtils-MakeMaker-7.70.tar.gz',
+        'SYNCINFO'     => 'yorton on Sun Mar 26 16:20:23 2023',
         'FILES'        => q[cpan/ExtUtils-MakeMaker],
         'EXCLUDED'     => [
             qr{^t/lib/Test/},

--- a/Porting/sync-with-cpan
+++ b/Porting/sync-with-cpan
@@ -615,6 +615,8 @@ if (!$changes_file) {
     chomp(my @lines = <$ifh>);
     close $ifh;
     my $seen_new_version;
+    my $is_update = $new_version ne $old_version;
+
     for(my $idx = 0; $idx < @lines; $idx++) {
         if ($lines[$idx] =~ /$new_version/ ||
             ($pkg_dir eq "CPAN" and $lines[$idx] =~/^\d{4}-\d{2}-\d{2}/
@@ -624,7 +626,12 @@ if (!$changes_file) {
             $seen_new_version = 1;
             push @changes_info, $lines[$idx];
         } elsif ($seen_new_version) {
-            if (($lines[$idx]=~/\d\.\d/ and $lines[$idx]=~/20\d\d/) ||
+            if ($is_update && $pkg_dir eq "ExtUtils-MakeMaker") {
+                if ($lines[$idx] =~/$old_version/) {
+                    last;
+                }
+            }
+            elsif (($lines[$idx]=~/\d\.\d/ and $lines[$idx]=~/20\d\d/) ||
                 ($lines[$idx]=~/---------------------------------/) ||
                 ($pkg_dir eq "CPAN" and $lines[$idx] =~/^\d{4}-\d{2}-\d{2}/) ||
                 ($pkg_dir eq "version" and $lines[$idx] =~/^\d\.\d+/) ||
@@ -633,9 +640,9 @@ if (!$changes_file) {
                 0 # less commit churn if we have to tweak the heuristics above
             ){
                 last;
-            } else {
-                push @changes_info, $lines[$idx];
             }
+            push @changes_info, $lines[$idx];
+
         }
     }
     if (!@changes_info) {

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Command.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Command.pm
@@ -4,11 +4,10 @@ use 5.00503;
 use strict;
 use warnings;
 require Exporter;
-use vars qw(@ISA @EXPORT @EXPORT_OK $VERSION);
-@ISA       = qw(Exporter);
-@EXPORT    = qw(cp rm_f rm_rf mv cat eqtime mkpath touch test_f test_d chmod
-                dos2unix);
-$VERSION = '7.66';
+our @ISA     = qw(Exporter);
+our @EXPORT  = qw(cp rm_f rm_rf mv cat eqtime mkpath touch test_f test_d chmod
+                  dos2unix);
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 my $Is_VMS   = $^O eq 'VMS';

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Command/MM.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Command/MM.pm
@@ -10,7 +10,7 @@ our @ISA = qw(Exporter);
 
 our @EXPORT  = qw(test_harness pod2man perllocal_install uninstall
                   warn_if_old_packlist test_s cp_nonempty);
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 my $Is_VMS = $^O eq 'VMS';

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Liblist.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Liblist.pm
@@ -3,7 +3,7 @@ package ExtUtils::Liblist;
 use strict;
 use warnings;
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 use File::Spec;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Liblist/Kid.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Liblist/Kid.pm
@@ -11,7 +11,7 @@ use 5.006;
 
 use strict;
 use warnings;
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 use ExtUtils::MakeMaker::Config;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use ExtUtils::MakeMaker::Config;
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::Liblist;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_AIX.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_AIX.pm
@@ -2,7 +2,7 @@ package ExtUtils::MM_AIX;
 
 use strict;
 use warnings;
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 use ExtUtils::MakeMaker::Config;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Any.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Any.pm
@@ -2,7 +2,7 @@ package ExtUtils::MM_Any;
 
 use strict;
 use warnings;
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 use Carp;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_BeOS.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_BeOS.pm
@@ -27,7 +27,7 @@ require ExtUtils::MM_Any;
 require ExtUtils::MM_Unix;
 
 our @ISA = qw( ExtUtils::MM_Any ExtUtils::MM_Unix );
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Cygwin.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Cygwin.pm
@@ -10,7 +10,7 @@ require ExtUtils::MM_Unix;
 require ExtUtils::MM_Win32;
 our @ISA = qw( ExtUtils::MM_Unix );
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_DOS.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_DOS.pm
@@ -3,7 +3,7 @@ package ExtUtils::MM_DOS;
 use strict;
 use warnings;
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Any;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Darwin.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Darwin.pm
@@ -8,7 +8,7 @@ BEGIN {
     our @ISA = qw( ExtUtils::MM_Unix );
 }
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_MacOS.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_MacOS.pm
@@ -3,7 +3,7 @@ package ExtUtils::MM_MacOS;
 use strict;
 use warnings;
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 sub new {

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_NW5.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_NW5.pm
@@ -23,7 +23,7 @@ use warnings;
 use ExtUtils::MakeMaker::Config;
 use File::Basename;
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Win32;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_OS2.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_OS2.pm
@@ -6,7 +6,7 @@ use warnings;
 use ExtUtils::MakeMaker qw(neatvalue);
 use File::Spec;
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Any;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_OS390.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_OS390.pm
@@ -2,7 +2,7 @@ package ExtUtils::MM_OS390;
 
 use strict;
 use warnings;
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 use ExtUtils::MakeMaker::Config;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_QNX.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_QNX.pm
@@ -2,7 +2,7 @@ package ExtUtils::MM_QNX;
 
 use strict;
 use warnings;
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Unix;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_UWIN.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_UWIN.pm
@@ -2,7 +2,7 @@ package ExtUtils::MM_UWIN;
 
 use strict;
 use warnings;
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Unix;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Unix.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Unix.pm
@@ -13,10 +13,11 @@ our %Config_Override;
 
 use ExtUtils::MakeMaker qw($Verbose neatvalue _sprintf562);
 
-# If we make $VERSION an our variable parse_version() breaks
-use vars qw($VERSION);
-$VERSION = '7.66';
+# If $VERSION is in scope, parse_version() breaks
+{
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
+}
 
 require ExtUtils::MM_Any;
 our @ISA = qw(ExtUtils::MM_Any);
@@ -34,7 +35,7 @@ BEGIN {
     $Is{SunOS4}  = $^O eq 'sunos';
     $Is{Solaris} = $^O eq 'solaris';
     $Is{SunOS}   = $Is{SunOS4} || $Is{Solaris};
-    $Is{BSD}     = ($^O =~ /^(?:free|net|open)bsd$/ or
+    $Is{BSD}     = ($^O =~ /^(?:free|midnight|net|open)bsd$/ or
                    grep( $^O eq $_, qw(bsdos interix dragonfly) )
                   );
     $Is{Android} = $^O =~ /android/;
@@ -2196,7 +2197,7 @@ Add MM_Unix_VERSION.
 sub init_platform {
     my($self) = shift;
 
-    $self->{MM_Unix_VERSION} = $VERSION;
+    $self->{MM_Unix_VERSION} = our $VERSION;
     $self->{PERL_MALLOC_DEF} = '-DPERL_EXTMALLOC_DEF -Dmalloc=Perl_malloc '.
                                '-Dfree=Perl_mfree -Drealloc=Perl_realloc '.
                                '-Dcalloc=Perl_calloc';

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_VMS.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_VMS.pm
@@ -16,7 +16,7 @@ BEGIN {
 
 use File::Basename;
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Any;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_VOS.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_VOS.pm
@@ -2,7 +2,7 @@ package ExtUtils::MM_VOS;
 
 use strict;
 use warnings;
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Unix;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Win32.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Win32.pm
@@ -27,7 +27,7 @@ use ExtUtils::MakeMaker qw(neatvalue _sprintf562);
 require ExtUtils::MM_Any;
 require ExtUtils::MM_Unix;
 our @ISA = qw( ExtUtils::MM_Any ExtUtils::MM_Unix );
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 $ENV{EMXSHELL} = 'sh'; # to run `commands`

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Win95.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Win95.pm
@@ -3,7 +3,7 @@ package ExtUtils::MM_Win95;
 use strict;
 use warnings;
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 require ExtUtils::MM_Win32;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MY.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MY.pm
@@ -3,7 +3,7 @@ package ExtUtils::MY;
 use strict;
 require ExtUtils::MM;
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 our @ISA = qw(ExtUtils::MM);
 

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker.pm
@@ -25,7 +25,7 @@ my %Recognized_Att_Keys;
 our %macro_fsentity; # whether a macro is a filesystem name
 our %macro_dep; # whether a macro is a dependency
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 # Emulate something resembling CVS $Revision$
@@ -525,7 +525,10 @@ sub new {
                     # simulate "use warnings FATAL => 'all'" for vintage perls
                     die @_;
                 };
-                version->new( $perl_version )->numify;
+                my $v = version->new($perl_version);
+                # we care about parse issues, not numify warnings
+                no warnings;
+                $v->numify;
             };
             $perl_version =~ tr/_//d
                 if defined $perl_version;
@@ -1331,26 +1334,6 @@ sub neatvalue {
         push @m,"$key=>".neatvalue($v->{$key});
     }
     return "{ ".join(', ',@m)." }";
-}
-
-sub _find_magic_vstring {
-    my $value = shift;
-    return $value if $UNDER_CORE;
-    my $tvalue = '';
-    require B;
-    my $sv = B::svref_2object(\$value);
-    my $magic = ref($sv) eq 'B::PVMG' ? $sv->MAGIC : undef;
-    while ( $magic ) {
-        if ( $magic->TYPE eq 'V' ) {
-            $tvalue = $magic->PTR;
-            $tvalue =~ s/^v?(.+)$/v$1/;
-            last;
-        }
-        else {
-            $magic = $magic->MOREMAGIC;
-        }
-    }
-    return $tvalue;
 }
 
 sub selfdocument {

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Config.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Config.pm
@@ -3,7 +3,7 @@ package ExtUtils::MakeMaker::Config;
 use strict;
 use warnings;
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 use Config ();

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/FAQ.pod
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/FAQ.pod
@@ -1,6 +1,6 @@
 package ExtUtils::MakeMaker::FAQ;
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 1;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Locale.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Locale.pm
@@ -2,7 +2,7 @@ package ExtUtils::MakeMaker::Locale;
 
 use strict;
 use warnings;
-our $VERSION = "7.66";
+our $VERSION = "7.70";
 $VERSION =~ tr/_//d;
 
 use base 'Exporter';

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Tutorial.pod
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/Tutorial.pod
@@ -1,6 +1,6 @@
 package ExtUtils::MakeMaker::Tutorial;
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/version.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/version.pm
@@ -16,7 +16,7 @@ use warnings;
 
 use vars qw(@ISA $VERSION $CLASS $STRICT $LAX *declare *qv);
 
-$VERSION = '7.66';
+$VERSION = '7.70';
 $VERSION =~ tr/_//d;
 $CLASS = 'version';
 

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/version/regex.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MakeMaker/version/regex.pm
@@ -11,7 +11,7 @@ use warnings;
 
 use vars qw($VERSION $CLASS $STRICT $LAX);
 
-$VERSION = '7.66';
+$VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 #--------------------------------------------------------------------------#

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Mkbootstrap.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Mkbootstrap.pm
@@ -3,7 +3,7 @@ package ExtUtils::Mkbootstrap;
 use strict;
 use warnings;
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 require Exporter;

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Mksymlists.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Mksymlists.pm
@@ -11,7 +11,7 @@ use Config;
 
 our @ISA = qw(Exporter);
 our @EXPORT = qw(&Mksymlists);
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 sub Mksymlists {

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/testlib.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/testlib.pm
@@ -3,7 +3,7 @@ package ExtUtils::testlib;
 use strict;
 use warnings;
 
-our $VERSION = '7.66';
+our $VERSION = '7.70';
 $VERSION =~ tr/_//d;
 
 use Cwd;

--- a/cpan/ExtUtils-MakeMaker/t/eu_command.t
+++ b/cpan/ExtUtils-MakeMaker/t/eu_command.t
@@ -67,7 +67,14 @@ BEGIN {
 
     my ($now) = time;
     utime ($now, $now, $ARGV[0]);
-    sleep 2;
+
+    sleep 3; # note this affects the "newer file created"
+             # we used to sleep 2, but with the vagaries of sleep
+             # this meant that occasionally that test would fail
+             # on cygwin, by virtue of seeing only a one second
+             # difference. Sleeping 3 seconds should ensure
+             # that we get at least 2 seconds difference for
+             # that test.
 
     # Just checking modify time stamp, access time stamp is set
     # to the beginning of the day in Win95.

--- a/cpan/ExtUtils-MakeMaker/t/min_perl_version.t
+++ b/cpan/ExtUtils-MakeMaker/t/min_perl_version.t
@@ -17,7 +17,7 @@ use ExtUtils::MM;
 use Test::More
     !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
-    : (tests => 35);
+    : (tests => 37);
 use File::Path;
 
 use ExtUtils::MakeMaker;
@@ -121,6 +121,17 @@ note "Argument verification"; {
         );
     };
     is( $warnings, '', 'MIN_PERL_VERSION=X.Y.Z does not trigger a warning' );
+    is( $@, '',        '  nor a hard failure' );
+
+
+    $warnings = '';
+    eval {
+        WriteMakefile(
+            NAME             => 'Min::PerlVers',
+            MIN_PERL_VERSION => '5.005_04',
+        );
+    };
+    is( $warnings, '', 'MIN_PERL_VERSION=5.005_04 does not trigger a warning' );
     is( $@, '',        '  nor a hard failure' );
 
 


### PR DESCRIPTION
Update ExtUtils-MakeMaker to v7.70, also tweaks to Porting/sync-with-cpan to  pick up the full set of changes from EUMM from the last time it was merged. (See below)

   cpan/ExtUtils-MakeMaker - Update to version 7.70
    
    7.70    Sun 26 Mar 14:13:20 BST 2023
    
        No changes since v7.69_01
    
    7.69_01 Sat 25 Mar 11:06:19 GMT 2023
    
        Core reversions:
        - Reverted the PERL_CORE and PERL_SRC changes from v7.67_02
          These will be reintroduced after more testing in core
    
    7.68    Tue 14 Mar 21:38:00 GMT 2023
    
        No changes since v7.67_02
    
    7.67_02 Mon  6 Mar 10:53:22 GMT 2023
    
        Core fixes:
        - initialize PERL_CORE object var early and use it consistently
        - only search for PERL_SRC when PERL_CORE is true or unset
    
        Clean-ups:
        - remove use vars from non-bundled modules
        - remove unused _find_magic_vstring function
    
    7.67_01 Wed  1 Mar 12:38:00 GMT 2023
    
        Bug fixes:
        - Treat MidnightBSD as a BSD
        - fix MIN_PERL_VERSION for perl versions with underscores
    
        Test fixes:
        -  t/.../More.pm - remove isn't: apostrophe as a package sep is deprecated
