### PR TITLE
threads.xs: Set non thread context in ithread_set()

### DIFF
--- a/dist/threads/lib/threads.pm
+++ b/dist/threads/lib/threads.pm
@@ -5,7 +5,7 @@ use 5.008;
 use strict;
 use warnings;
 
-our $VERSION = '2.35';      # remember to update version in POD!
+our $VERSION = '2.36';      # remember to update version in POD!
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -134,7 +134,7 @@ threads - Perl interpreter-based threads
 
 =head1 VERSION
 
-This document describes threads version 2.35
+This document describes threads version 2.36
 
 =head1 WARNING
 

--- a/dist/threads/threads.xs
+++ b/dist/threads/threads.xs
@@ -205,6 +205,9 @@ S_ithread_set(pTHX_ ithread *thread)
 {
     dMY_CXT;
     MY_CXT.context = thread;
+#ifdef PERL_SET_NON_tTHX_CONTEXT
+    PERL_SET_NON_tTHX_CONTEXT(thread->interp);
+#endif
 }
 
 STATIC ithread *


### PR DESCRIPTION
This generally was getting set anyway, but a test yet to be committed found a case where it wasn't.