### PR TITLE
op.c: remove unneeded variable

### DIFF
--- a/op.c
+++ b/op.c
@@ -11179,12 +11179,11 @@ S_process_special_blocks(pTHX_ I32 floor, const char *const fullname,
             if (strEQ(name, "INIT")) {
 #ifdef MI_INIT_WORKAROUND_PACK
                 {
-                    HV *hv= CvSTASH(cv);
+                    HV *hv = CvSTASH(cv);
                     STRLEN len = hv ? HvNAMELEN(hv) : 0;
-                    char *pv= (len == sizeof(MI_INIT_WORKAROUND_PACK)-1)
+                    char *pv = (len == sizeof(MI_INIT_WORKAROUND_PACK)-1)
                             ? HvNAME_get(hv) : NULL;
-                    if ( pv && strEQ(pv,MI_INIT_WORKAROUND_PACK) )
-                    {
+                    if ( pv && strEQ(pv, MI_INIT_WORKAROUND_PACK) ) {
                         /* old versions of Module::Install::DSL contain code
                          * that creates an INIT in eval, which expect to run
                          * after an exit(0) in BEGIN. This unfortunately

--- a/op.c
+++ b/op.c
@@ -11037,19 +11037,18 @@ S_process_special_blocks(pTHX_ I32 floor, const char *const fullname,
 {
     const char *const colon = strrchr(fullname,':');
     const char *const name = colon ? colon + 1 : fullname;
-    int is_module_install_hack = 0;
 
     PERL_ARGS_ASSERT_PROCESS_SPECIAL_BLOCKS;
 
     if (*name == 'B') {
-        module_install_hack:
-        if (strEQ(name, "BEGIN") || is_module_install_hack) {
+        if (strEQ(name, "BEGIN")) {
+            /* can't goto a declaration, but a null statement is fine */
+            module_install_hack: ;
             const I32 oldscope = PL_scopestack_ix;
             SV *max_nest_sv = NULL;
             IV max_nest_iv;
             dSP;
             (void)CvGV(cv);
-            is_module_install_hack = 0;
             if (floor) LEAVE_SCOPE(floor);
             ENTER;
 
@@ -11196,7 +11195,6 @@ S_process_special_blocks(pTHX_ I32 floor, const char *const fullname,
                          */
                         Perl_warn(aTHX_ "Treating %s::INIT block as BEGIN block as workaround",
                                 MI_INIT_WORKAROUND_PACK);
-                        is_module_install_hack = 1;
                         goto module_install_hack;
                     }
 


### PR DESCRIPTION
`is_module_install_hack` is a local variable in S_process_special_blocks that is only used to silently treat INIT blocks (in package Module::Install::DSL) as BEGIN blocks. But instead of setting the variable and jumping before the `if` block that checks the variable, we can just jump into the block and get rid of the variable.