### PR TITLE
Support a value stack with over 2**31 entries on 64-bit machines

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5955,6 +5955,7 @@ t/bigmem/index.t			Check that index() handles large offsets
 t/bigmem/pos.t				Check that pos() handles large offsets
 t/bigmem/read.t				Check read() handles large offsets
 t/bigmem/regexp.t			Test regular expressions with large strings
+t/bigmem/stack.t			Check handling of large value stacks (including MARK values)
 t/bigmem/str.t				Test string primitives with large strings
 t/bigmem/subst.t			Test s/// with large strings
 t/bigmem/subst2.t			Test s//EXPR/e with large strings

--- a/XSUB.h
+++ b/XSUB.h
@@ -37,12 +37,12 @@ Variable which is setup by C<xsubpp> to designate the object in a C++
 XSUB.  This is always the proper type for the C++ object.  See C<L</CLASS>> and
 L<perlxs/"Using XS With C++">.
 
-=for apidoc Amn|I32|ax
+=for apidoc Amn|SSize_t|ax
 Variable which is setup by C<xsubpp> to indicate the stack base offset,
 used by the C<ST>, C<XSprePUSH> and C<XSRETURN> macros.  The C<dMARK> macro
 must be called prior to setup the C<MARK> variable.
 
-=for apidoc Amn|I32|items
+=for apidoc Amn|SSize_t|items
 Variable which is setup by C<xsubpp> to indicate the number of
 items on the stack.  See L<perlxs/"Variable-length Parameter Lists">.
 
@@ -157,13 +157,13 @@ is a lexical C<$_> in scope.
  * Try explicitly using XS_INTERNAL/XS_EXTERNAL instead, please. */
 #define XS(name) XS_EXTERNAL(name)
 
-#define dAX const I32 ax = (I32)(MARK - PL_stack_base + 1)
+#define dAX const SSize_t ax = (SSize_t)(MARK - PL_stack_base + 1)
 
 #define dAXMARK				\
-        I32 ax = POPMARK;	\
+        SSize_t ax = POPMARK;	\
         SV **mark = PL_stack_base + ax++
 
-#define dITEMS I32 items = (I32)(SP - MARK)
+#define dITEMS SSize_t items = (SSize_t)(SP - MARK)
 
 #define dXSARGS \
         dSP; dAXMARK; dITEMS

--- a/XSUB.h
+++ b/XSUB.h
@@ -174,16 +174,16 @@ is a lexical C<$_> in scope.
    Note these macros are not drop in replacements for dXSARGS since they set
    PL_xsubfilename. */
 #define dXSBOOTARGSXSAPIVERCHK  \
-        I32 ax = XS_BOTHVERSION_SETXSUBFN_POPMARK_BOOTCHECK;	\
+        SSize_t ax = XS_BOTHVERSION_SETXSUBFN_POPMARK_BOOTCHECK;	\
         SV **mark = PL_stack_base + ax - 1; dSP; dITEMS
 #define dXSBOOTARGSAPIVERCHK  \
-        I32 ax = XS_APIVERSION_SETXSUBFN_POPMARK_BOOTCHECK;	\
+        SSize_t ax = XS_APIVERSION_SETXSUBFN_POPMARK_BOOTCHECK;	\
         SV **mark = PL_stack_base + ax - 1; dSP; dITEMS
 /* dXSBOOTARGSNOVERCHK has no API in xsubpp to choose it so do
 #undef dXSBOOTARGSXSAPIVERCHK
 #define dXSBOOTARGSXSAPIVERCHK dXSBOOTARGSNOVERCHK */
 #define dXSBOOTARGSNOVERCHK  \
-        I32 ax = XS_SETXSUBFN_POPMARK;  \
+        SSize_t ax = XS_SETXSUBFN_POPMARK;  \
         SV **mark = PL_stack_base + ax - 1; dSP; dITEMS
 
 #define dXSTARG SV * const targ = ((PL_op->op_private & OPpENTERSUB_HASTARG) \

--- a/class.c
+++ b/class.c
@@ -146,7 +146,7 @@ XS(injected_constructor)
         params = newHV();
         SAVEFREESV((SV *)params);
 
-        for(I32 i = 1; i < items; i += 2) {
+        for(SSize_t i = 1; i < items; i += 2) {
             SV *name = ST(i);
             SV *val  = (i+1 < items) ? ST(i+1) : &PL_sv_undef;
 

--- a/cop.h
+++ b/cop.h
@@ -936,7 +936,7 @@ struct block_loop {
             IV  ix;   /* index relative to base of array */
         } ary;
         struct { /* CXt_LOOP_LIST, C<for (list)> */
-            I32 basesp; /* first element of list on stack */
+            SSize_t basesp; /* first element of list on stack */
             IV  ix;      /* index relative to basesp */
         } stack;
         struct { /* CXt_LOOP_LAZYIV, C<for (1..9)> */

--- a/cop.h
+++ b/cop.h
@@ -995,12 +995,12 @@ struct block {
     U16		blku_u16;	/* used by block_sub and block_eval (so far) */
     I32		blku_oldsaveix; /* saved PL_savestack_ix */
     /* all the fields above must be aligned with same-sized fields as sbu */
-    I32		blku_oldsp;	/* current sp floor: where nextstate pops to */
-    I32		blku_oldmarksp;	/* mark stack index */
+    SSize_t	blku_oldsp;	/* current sp floor: where nextstate pops to */
     COP *	blku_oldcop;	/* old curcop pointer */
     PMOP *	blku_oldpm;	/* values of pattern match vars */
     SSize_t     blku_old_tmpsfloor;     /* saved PL_tmps_floor */
     I32		blku_oldscopesp;	/* scope stack index */
+    I32		blku_oldmarksp;	/* mark stack index */
 
     union {
         struct block_sub	blku_sub;

--- a/deb.c
+++ b/deb.c
@@ -141,12 +141,12 @@ Perl_debstackptrs(pTHX)     /* Currently unused in cpan and core */
  */
 
 STATIC void
-S_deb_stack_n(pTHX_ SV** stack_base, I32 stack_min, I32 stack_max,
-        I32 mark_min, I32 mark_max, I32 nonrc_base)
+S_deb_stack_n(pTHX_ SV** stack_base, SSize_t stack_min, SSize_t stack_max,
+        SSize_t mark_min, SSize_t mark_max, SSize_t nonrc_base)
 {
 #ifdef DEBUGGING
-    I32 i = stack_max - 30;
-    const I32 *markscan = PL_markstack + mark_min;
+    SSize_t i = stack_max - 30;
+    const SSize_t *markscan = PL_markstack + mark_min;
 
     PERL_ARGS_ASSERT_DEB_STACK_N;
 

--- a/doio.c
+++ b/doio.c
@@ -2603,11 +2603,11 @@ leave:
 
 #endif /* OS2 || WIN32 */
 
-I32
+SSize_t
 Perl_apply(pTHX_ I32 type, SV **mark, SV **sp)
 {
     I32 val;
-    I32 tot = 0;
+    SSize_t tot = 0;
     const char *const what = PL_op_name[type];
     const char *s;
     STRLEN len;

--- a/doop.c
+++ b/doop.c
@@ -659,7 +659,7 @@ void
 Perl_do_join(pTHX_ SV *sv, SV *delim, SV **mark, SV **sp)
 {
     SV ** const oldmark = mark;
-    I32 items = sp - mark;
+    SSize_t items = sp - mark;
     STRLEN len;
     STRLEN delimlen;
     const char * const delims = SvPV_const(delim, delimlen);

--- a/embed.fnc
+++ b/embed.fnc
@@ -752,7 +752,7 @@ CTdpx	|U8 *	|bytes_from_utf8_loc					\
 				|NULLOK const U8 **first_unconverted
 Adpx	|U8 *	|bytes_to_utf8	|NN const U8 *s 			\
 				|NN STRLEN *lenp
-AOdp	|I32	|call_argv	|NN const char *sub_name		\
+AOdp	|SSize_t|call_argv	|NN const char *sub_name		\
 				|I32 flags				\
 				|NN char **argv
 
@@ -765,13 +765,13 @@ Adp	|const PERL_CONTEXT *|caller_cx 				\
 				|NULLOK const PERL_CONTEXT **dbcxp
 Cp	|void	|call_list	|I32 oldscope				\
 				|NN AV *paramList
-AOdp	|I32	|call_method	|NN const char *methname		\
+AOdp	|SSize_t|call_method	|NN const char *methname		\
 				|I32 flags
 CTadop	|Malloc_t|calloc	|MEM_SIZE elements			\
 				|MEM_SIZE size
-AOdp	|I32	|call_pv	|NN const char *sub_name		\
+AOdp	|SSize_t|call_pv	|NN const char *sub_name		\
 				|I32 flags
-AOdp	|I32	|call_sv	|NN SV *sv				\
+AOdp	|SSize_t|call_sv	|NN SV *sv				\
 				|volatile I32 flags
 : Used in several source files
 Rp	|bool	|cando		|Mode_t mode				\

--- a/embed.fnc
+++ b/embed.fnc
@@ -1120,7 +1120,7 @@ EXopx	|void	|emulate_cop_io |NN const COP * const c 		\
 				|NN SV * const sv
 AOdp	|SV *	|eval_pv	|NN const char *p			\
 				|I32 croak_on_error
-AOdp	|I32	|eval_sv	|NN SV *sv				\
+AOdp	|SSize_t|eval_sv	|NN SV *sv				\
 				|I32 flags
 Adp	|void	|fbm_compile	|NN SV *sv				\
 				|U32 flags

--- a/embed.fnc
+++ b/embed.fnc
@@ -3744,9 +3744,9 @@ Adp	|void	|wrap_op_checker|Optype opcode				\
 				|NN Perl_check_t *old_checker_p
 : Used in pp_ctl.c
 p	|void	|write_to_stderr|NN SV *msv
-Xp	|void	|xs_boot_epilog |const I32 ax
+Xp	|void	|xs_boot_epilog |const SSize_t ax
 
-FTXopv	|I32	|xs_handshake	|const U32 key				\
+FTXopv	|SSize_t|xs_handshake	|const U32 key				\
 				|NN void *v_my_perl			\
 				|NN const char *file			\
 				|...
@@ -5960,8 +5960,8 @@ Ti	|U32	|ptr_hash	|PTRV u
 S	|SV *	|with_queued_errors					\
 				|NN SV *ex
 So	|void	|xs_version_bootcheck					\
-				|U32 items				\
-				|U32 ax 				\
+				|SSize_t items				\
+				|SSize_t ax				\
 				|NN const char *xs_p			\
 				|STRLEN xs_len
 # if defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL)

--- a/embed.fnc
+++ b/embed.fnc
@@ -639,7 +639,7 @@ ETXip	|void	|append_utf8_from_native_byte				\
 				|const U8 byte				\
 				|NN U8 **dest
 : FIXME - this is only called by pp_chown. They should be merged.
-p	|I32	|apply		|I32 type				\
+p	|SSize_t|apply		|I32 type				\
 				|NN SV **mark				\
 				|NN SV **sp
 Apx	|void	|apply_attrs_string					\

--- a/embed.fnc
+++ b/embed.fnc
@@ -1946,7 +1946,7 @@ p	|int	|magic_wipepack |NN SV *sv				\
 				|NN MAGIC *mg
 
 CTadop	|Malloc_t|malloc	|MEM_SIZE nbytes
-Cp	|I32 *	|markstack_grow
+Cp	|SSize_t *|markstack_grow
 EXp	|int	|mbtowc_	|NULLOK const wchar_t *pwc		\
 				|NULLOK const char *s			\
 				|const Size_t len
@@ -2522,7 +2522,7 @@ p	|OP *	|pmruntime	|NN OP *o				\
 				|NULLOK OP *repl			\
 				|UV flags				\
 				|I32 floor
-Xiop	|I32	|POPMARK
+Xiop	|SSize_t|POPMARK
 Cdp	|void	|pop_scope
 Cipx	|void	|pop_stackinfo
 
@@ -3505,7 +3505,7 @@ Fpv	|OP *	|tied_method	|NN SV *methname			\
 				|U32 argc				\
 				|...
 Xp	|SSize_t|tmps_grow_p	|SSize_t ix
-Xiop	|I32	|TOPMARK
+Xiop	|SSize_t|TOPMARK
 Cm	|UV	|to_uni_fold	|UV c					\
 				|NN U8 *p				\
 				|NN STRLEN *lenp
@@ -4082,11 +4082,11 @@ Cp	|void	|croak_kw_unless_class					\
           defined(PERL_IN_TOKE_C) */
 #if defined(PERL_IN_DEB_C)
 S	|void	|deb_stack_n	|NN SV **stack_base			\
-				|I32 stack_min				\
-				|I32 stack_max				\
-				|I32 mark_min				\
-				|I32 mark_max				\
-				|I32 nonrc_base
+				|SSize_t stack_min			\
+				|SSize_t stack_max			\
+				|SSize_t mark_min			\
+				|SSize_t mark_max			\
+				|SSize_t nonrc_base
 #endif
 #if defined(PERL_IN_DOIO_C)
 S	|bool	|argvout_final	|NN MAGIC *mg				\

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -2760,7 +2760,7 @@ call_sv(sv, flags, ...)
     SV* sv
     I32 flags
     PREINIT:
-        I32 i;
+        SSize_t i;
     PPCODE:
         for (i=0; i<items-2; i++)
             ST(i) = ST(i+2); /* pop first two args */

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -3046,7 +3046,7 @@ eval_sv(sv, flags)
     SV* sv
     I32 flags
     PREINIT:
-        I32 i;
+        SSize_t i;
     PPCODE:
         PUTBACK;
         i = eval_sv(sv, flags);

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -3325,6 +3325,13 @@ sv_count()
         OUTPUT:
             RETVAL
 
+IV
+xs_items(...)
+        CODE:
+            RETVAL = items;
+        OUTPUT:
+            RETVAL
+
 void
 bhk_record(bool on)
     CODE:

--- a/inline.h
+++ b/inline.h
@@ -377,7 +377,7 @@ S_PadnameIN_SCOPE(const PADNAME * const pn, const U32 seq)
 
 /* ------------------------------- pp.h ------------------------------- */
 
-PERL_STATIC_INLINE I32
+PERL_STATIC_INLINE SSize_t
 Perl_TOPMARK(pTHX)
 {
     DEBUG_s(DEBUG_v(PerlIO_printf(Perl_debug_log,
@@ -387,7 +387,7 @@ Perl_TOPMARK(pTHX)
     return *PL_markstack_ptr;
 }
 
-PERL_STATIC_INLINE I32
+PERL_STATIC_INLINE SSize_t
 Perl_POPMARK(pTHX)
 {
     DEBUG_s(DEBUG_v(PerlIO_printf(Perl_debug_log,
@@ -3230,7 +3230,7 @@ Perl_cx_pushblock(pTHX_ U8 type, U8 gimme, SV** sp, I32 saveix)
     cx->cx_type        = type;
     cx->blk_gimme      = gimme;
     cx->blk_oldsaveix  = saveix;
-    cx->blk_oldsp      = (I32)(sp - PL_stack_base);
+    cx->blk_oldsp      = sp - PL_stack_base;
     assert(cxstack_ix <= 0
             || CxTYPE(cx-1) == CXt_SUBST
             || cx->blk_oldsp >= (cx-1)->blk_oldsp);

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -49,10 +49,10 @@ PERLVARI(I, tmps_ix,	SSize_t,	-1)
 PERLVARI(I, tmps_floor,	SSize_t,	-1)
 PERLVAR(I, tmps_max,	SSize_t)        /* first unalloced slot in tmps stack */
 
-PERLVAR(I, markstack,	I32 *)		/* stack_sp locations we're
+PERLVAR(I, markstack,	SSize_t *)	/* stack_sp locations we're
                                            remembering */
-PERLVAR(I, markstack_ptr, I32 *)
-PERLVAR(I, markstack_max, I32 *)
+PERLVAR(I, markstack_ptr, SSize_t *)
+PERLVAR(I, markstack_max, SSize_t *)
 
 PERLVARI(I, sub_generation, U32, 1)	/* incr to invalidate method cache */
 

--- a/perl.c
+++ b/perl.c
@@ -2971,7 +2971,7 @@ Approximate Perl equivalent: C<&{"$sub_name"}(@$argv)>.
 =cut
 */
 
-I32
+SSize_t
 Perl_call_argv(pTHX_ const char *sub_name, I32 flags, char **argv)
 
                         /* See G_* flags in cop.h */
@@ -3005,7 +3005,7 @@ Performs a callback to the specified Perl sub.  See L<perlcall>.
 =cut
 */
 
-I32
+SSize_t
 Perl_call_pv(pTHX_ const char *sub_name, I32 flags)
                         /* name of the subroutine */
                         /* See G_* flags in cop.h */
@@ -3024,7 +3024,7 @@ be on the stack.  See L<perlcall>.
 =cut
 */
 
-I32
+SSize_t
 Perl_call_method(pTHX_ const char *methname, I32 flags)
                         /* name of the subroutine */
                         /* See G_* flags in cop.h */
@@ -3068,14 +3068,14 @@ See L<perlcall>.
 =cut
 */
 
-I32
+SSize_t
 Perl_call_sv(pTHX_ SV *sv, volatile I32 flags)
                         /* See G_* flags in cop.h */
 {
     LOGOP myop;		/* fake syntax tree node */
     METHOP method_op;
-    I32 oldmark;
-    volatile I32 retval = 0;
+    SSize_t oldmark;
+    volatile SSize_t retval = 0;
     bool oldcatch = CATCH_GET;
     int ret;
     OP* const oldop = PL_op;

--- a/perl.c
+++ b/perl.c
@@ -5508,7 +5508,7 @@ read_e_script(pTHX_ int idx, SV *buf_sv, int maxlen)
 
 /* removes boilerplate code at the end of each boot_Module xsub */
 void
-Perl_xs_boot_epilog(pTHX_ const I32 ax)
+Perl_xs_boot_epilog(pTHX_ const SSize_t ax)
 {
   if (PL_unitcheckav)
         call_list(PL_scopestack_ix, PL_unitcheckav);

--- a/perl.c
+++ b/perl.c
@@ -4515,7 +4515,7 @@ Perl_init_stacks(pTHX)
     PL_tmps_ix = -1;
     PL_tmps_max = REASONABLE(128);
 
-    Newxz(PL_markstack,REASONABLE(32),I32);
+    Newxz(PL_markstack, REASONABLE(32), SSize_t);
     PL_markstack_ptr = PL_markstack;
     PL_markstack_max = PL_markstack + REASONABLE(32);
 

--- a/perl.c
+++ b/perl.c
@@ -3237,14 +3237,14 @@ current hints from C<PL_curcop>.
 =cut
 */
 
-I32
+SSize_t
 Perl_eval_sv(pTHX_ SV *sv, I32 flags)
 
                         /* See G_* flags in cop.h */
 {
     UNOP myop;		/* fake syntax tree node */
-    volatile I32 oldmark;
-    volatile I32 retval = 0;
+    volatile SSize_t oldmark;
+    volatile SSize_t retval = 0;
     int ret;
     OP* const oldop = PL_op;
     dJMPENV;

--- a/pp.c
+++ b/pp.c
@@ -5955,7 +5955,7 @@ PP_wrapped(pp_lslice, 0, 2)
 PP(pp_anonlist)
 {
     dMARK;
-    const I32 items = PL_stack_sp - MARK;
+    const SSize_t items = PL_stack_sp - MARK;
     SV * const av = MUTABLE_SV(av_make(items, MARK+1));
     /* attach new SV to stack before freeing everything else,
      * so no leak on croak */

--- a/pp.c
+++ b/pp.c
@@ -6584,7 +6584,7 @@ PP_wrapped(pp_split,
     const char *orig;
     const IV origlimit = limit;
     bool realarray = 0;
-    I32 base;
+    SSize_t base;
     const U8 gimme = GIMME_V;
     bool gimme_scalar;
     I32 oldsave = PL_savestack_ix;

--- a/pp.c
+++ b/pp.c
@@ -1848,10 +1848,7 @@ PP_wrapped(pp_repeat,
         if (count > 1) {
             SSize_t max;
 
-            if (  items > SSize_t_MAX / count   /* max would overflow */
-                                                /* repeatcpy would overflow */
-               || items > I32_MAX / (I32)sizeof(SV *)
-            )
+            if ( items > SSize_t_MAX / (SSize_t)sizeof(SV *) / count )
                Perl_croak(aTHX_ "%s","Out of memory during list extend");
             max = items * count;
             MEXTEND(MARK, max);

--- a/pp.c
+++ b/pp.c
@@ -758,9 +758,9 @@ S_do_chomp(pTHX_ SV *retval, SV *sv, bool chomping)
     if (chomping && (RsSNARF(PL_rs) || RsRECORD(PL_rs)))
         return 0;
     if (SvTYPE(sv) == SVt_PVAV) {
-        I32 i;
+        SSize_t i;
         AV *const av = MUTABLE_AV(sv);
-        const I32 max = AvFILL(av);
+        const SSize_t max = AvFILL(av);
 
         for (i = 0; i <= max; i++) {
             sv = MUTABLE_SV(av_fetch(av, i, FALSE));

--- a/pp.c
+++ b/pp.c
@@ -5907,7 +5907,7 @@ PP_wrapped(pp_lslice, 0, 2)
     SV ** const firstrelem = lastlelem + 1;
     const U8 mod = PL_op->op_flags & OPf_MOD;
 
-    const I32 max = lastrelem - lastlelem;
+    const SSize_t max = lastrelem - lastlelem;
     SV **lelem;
 
     if (GIMME_V != G_LIST) {
@@ -5916,7 +5916,7 @@ PP_wrapped(pp_lslice, 0, 2)
             *firstlelem = &PL_sv_undef;
         }
         else {
-            I32 ix = SvIV(*lastlelem);
+            SSize_t ix = SvIV(*lastlelem);
             if (ix < 0)
                 ix += max;
             if (ix < 0 || ix >= max)
@@ -5934,7 +5934,7 @@ PP_wrapped(pp_lslice, 0, 2)
     }
 
     for (lelem = firstlelem; lelem <= lastlelem; lelem++) {
-        I32 ix = SvIV(*lelem);
+        SSize_t ix = SvIV(*lelem);
         if (ix < 0)
             ix += max;
         if (ix < 0 || ix >= max)

--- a/pp.h
+++ b/pp.h
@@ -118,11 +118,11 @@ value for the OP, but some use it for other purposes.
 
 #define PUSHMARK(p) \
     STMT_START {                                                      \
-        I32 * mark_stack_entry;                                       \
+        SSize_t * mark_stack_entry;                                       \
         if (UNLIKELY((mark_stack_entry = ++PL_markstack_ptr)          \
                                            == PL_markstack_max))      \
             mark_stack_entry = markstack_grow();                      \
-        *mark_stack_entry  = (I32)((p) - PL_stack_base);              \
+        *mark_stack_entry  = (SSize_t)((p) - PL_stack_base);              \
         DEBUG_s(DEBUG_v(PerlIO_printf(Perl_debug_log,                 \
                 "MARK push %p %" IVdf "\n",                           \
                 PL_markstack_ptr, (IV)*mark_stack_entry)));           \
@@ -142,7 +142,7 @@ value for the OP, but some use it for other purposes.
 #define dSP		SV **sp = PL_stack_sp
 #define djSP		dSP
 #define dMARK		SV **mark = PL_stack_base + POPMARK
-#define dORIGMARK	const I32 origmark = (I32)(mark - PL_stack_base)
+#define dORIGMARK	const SSize_t origmark = (SSize_t)(mark - PL_stack_base)
 #define ORIGMARK	(PL_stack_base + origmark)
 
 #define SPAGAIN		sp = PL_stack_sp

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -1098,9 +1098,9 @@ PP(pp_mapwhile)
      */
 
     const U8 gimme = GIMME_V;
-    I32 items = (PL_stack_sp - PL_stack_base) - TOPMARK; /* how many new items */
-    I32 count;
-    I32 shift;
+    SSize_t items = (PL_stack_sp - PL_stack_base) - TOPMARK; /* how many new items */
+    SSize_t count;
+    SSize_t shift;
     SV** src;
     SV** dst;
 
@@ -1177,8 +1177,8 @@ PP(pp_mapwhile)
              * We have to do to this way so that everything gets correctly
              * freed if we die during the map.
              */
-            I32 tmpsbase;
-            I32 i = items;
+            SSize_t tmpsbase;
+            SSize_t i = items;
             /* make space for the slice */
             EXTEND_MORTAL(items);
             tmpsbase = PL_tmps_floor + 1;

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -5122,7 +5122,7 @@ PP(pp_grepwhile)
 
     /* All done yet? */
     if (UNLIKELY(PL_stack_base + *PL_markstack_ptr > PL_stack_sp)) {
-        I32 items;
+        SSize_t items;
         const U8 gimme = GIMME_V;
 
         LEAVE_with_name("grep");					/* exit outer scope */

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -3853,7 +3853,7 @@ PP_wrapped(pp_chdir, MAXARG, 0)
 PP_wrapped(pp_chown, 0, 1)
 {
     dSP; dMARK; dTARGET;
-    const I32 value = (I32)apply(PL_op->op_type, MARK, SP);
+    const IV value = apply(PL_op->op_type, MARK, SP);
 
     SP = MARK;
     XPUSHi(value);

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -5872,7 +5872,7 @@ PP_wrapped(pp_syscall, 0, 1)
 {
 #ifdef HAS_SYSCALL
     dSP; dMARK; dORIGMARK; dTARGET;
-    I32 items = SP - MARK;
+    SSize_t items = SP - MARK;
     unsigned long a[20];
     I32 i = 0;
     IV retval = -1;

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -941,10 +941,10 @@ PP_wrapped(pp_tie, 0, 1)
     HV* stash;
     GV *gv = NULL;
     SV *sv;
-    const I32 markoff = MARK - PL_stack_base;
+    const SSize_t markoff = MARK - PL_stack_base;
     const char *methname;
     int how = PERL_MAGIC_tied;
-    U32 items;
+    SSize_t items;
     SV *varsv = *++MARK;
 
     switch(SvTYPE(varsv)) {
@@ -997,7 +997,7 @@ PP_wrapped(pp_tie, 0, 1)
         ENTER_with_name("call_TIE");
         PUSHSTACKi(PERLSI_MAGIC);
         PUSHMARK(SP);
-        EXTEND(SP,(I32)items);
+        EXTEND(SP, items);
         while (items--)
             PUSHs(*MARK++);
         PUTBACK;
@@ -1047,7 +1047,7 @@ PP_wrapped(pp_tie, 0, 1)
         ENTER_with_name("call_TIE");
         PUSHSTACKi(PERLSI_MAGIC);
         PUSHMARK(SP);
-        EXTEND(SP,(I32)items);
+        EXTEND(SP, items);
         while (items--)
             PUSHs(*MARK++);
         PUTBACK;

--- a/proto.h
+++ b/proto.h
@@ -198,7 +198,7 @@ Perl_amagic_is_enabled(pTHX_ int method)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AMAGIC_IS_ENABLED
 
-PERL_CALLCONV I32
+PERL_CALLCONV SSize_t
 Perl_apply(pTHX_ I32 type, SV **mark, SV **sp)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_APPLY                  \

--- a/proto.h
+++ b/proto.h
@@ -419,7 +419,7 @@ Perl_bytes_to_utf8(pTHX_ const U8 *s, STRLEN *lenp);
 #define PERL_ARGS_ASSERT_BYTES_TO_UTF8          \
         assert(s); assert(lenp)
 
-PERL_CALLCONV I32
+PERL_CALLCONV SSize_t
 Perl_call_argv(pTHX_ const char *sub_name, I32 flags, char **argv);
 #define PERL_ARGS_ASSERT_CALL_ARGV              \
         assert(sub_name); assert(argv)
@@ -433,17 +433,17 @@ Perl_call_list(pTHX_ I32 oldscope, AV *paramList);
 #define PERL_ARGS_ASSERT_CALL_LIST              \
         assert(paramList)
 
-PERL_CALLCONV I32
+PERL_CALLCONV SSize_t
 Perl_call_method(pTHX_ const char *methname, I32 flags);
 #define PERL_ARGS_ASSERT_CALL_METHOD            \
         assert(methname)
 
-PERL_CALLCONV I32
+PERL_CALLCONV SSize_t
 Perl_call_pv(pTHX_ const char *sub_name, I32 flags);
 #define PERL_ARGS_ASSERT_CALL_PV                \
         assert(sub_name)
 
-PERL_CALLCONV I32
+PERL_CALLCONV SSize_t
 Perl_call_sv(pTHX_ SV *sv, volatile I32 flags);
 #define PERL_ARGS_ASSERT_CALL_SV                \
         assert(sv)

--- a/proto.h
+++ b/proto.h
@@ -2379,7 +2379,7 @@ Perl_malloc(MEM_SIZE nbytes)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_MALLOC
 
-PERL_CALLCONV I32 *
+PERL_CALLCONV SSize_t *
 Perl_markstack_grow(pTHX);
 #define PERL_ARGS_ASSERT_MARKSTACK_GROW
 
@@ -6608,7 +6608,7 @@ Perl_croak_kw_unless_class(pTHX_ const char *kw);
           defined(PERL_IN_TOKE_C) */
 #if defined(PERL_IN_DEB_C)
 STATIC void
-S_deb_stack_n(pTHX_ SV **stack_base, I32 stack_min, I32 stack_max, I32 mark_min, I32 mark_max, I32 nonrc_base);
+S_deb_stack_n(pTHX_ SV **stack_base, SSize_t stack_min, SSize_t stack_max, SSize_t mark_min, SSize_t mark_max, SSize_t nonrc_base);
 # define PERL_ARGS_ASSERT_DEB_STACK_N           \
         assert(stack_base)
 
@@ -9513,7 +9513,7 @@ Perl_CvGV(pTHX_ CV *sv);
 # define PERL_ARGS_ASSERT_CVGV                  \
         assert(sv)
 
-PERL_STATIC_INLINE I32
+PERL_STATIC_INLINE SSize_t
 Perl_POPMARK(pTHX);
 # define PERL_ARGS_ASSERT_POPMARK
 
@@ -9617,7 +9617,7 @@ Perl_SvUV_nomg(pTHX_ SV *sv);
 # define PERL_ARGS_ASSERT_SVUV_NOMG             \
         assert(sv)
 
-PERL_STATIC_INLINE I32
+PERL_STATIC_INLINE SSize_t
 Perl_TOPMARK(pTHX);
 # define PERL_ARGS_ASSERT_TOPMARK
 

--- a/proto.h
+++ b/proto.h
@@ -5317,10 +5317,10 @@ Perl_write_to_stderr(pTHX_ SV *msv)
         assert(msv)
 
 PERL_CALLCONV void
-Perl_xs_boot_epilog(pTHX_ const I32 ax);
+Perl_xs_boot_epilog(pTHX_ const SSize_t ax);
 #define PERL_ARGS_ASSERT_XS_BOOT_EPILOG
 
-PERL_CALLCONV I32
+PERL_CALLCONV SSize_t
 Perl_xs_handshake(const U32 key, void *v_my_perl, const char *file, ...);
 #define PERL_ARGS_ASSERT_XS_HANDSHAKE           \
         assert(v_my_perl); assert(file)
@@ -9451,7 +9451,7 @@ S_with_queued_errors(pTHX_ SV *ex);
         assert(ex)
 
 STATIC void
-S_xs_version_bootcheck(pTHX_ U32 items, U32 ax, const char *xs_p, STRLEN xs_len);
+S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p, STRLEN xs_len);
 # define PERL_ARGS_ASSERT_XS_VERSION_BOOTCHECK  \
         assert(xs_p)
 

--- a/proto.h
+++ b/proto.h
@@ -1092,7 +1092,7 @@ Perl_eval_pv(pTHX_ const char *p, I32 croak_on_error);
 #define PERL_ARGS_ASSERT_EVAL_PV                \
         assert(p)
 
-PERL_CALLCONV I32
+PERL_CALLCONV SSize_t
 Perl_eval_sv(pTHX_ SV *sv, I32 flags);
 #define PERL_ARGS_ASSERT_EVAL_SV                \
         assert(sv)

--- a/scope.c
+++ b/scope.c
@@ -163,13 +163,13 @@ Perl_pop_scope(pTHX)
     LEAVE_SCOPE(oldsave);
 }
 
-I32 *
+SSize_t *
 Perl_markstack_grow(pTHX)
 {
     const I32 oldmax = PL_markstack_max - PL_markstack;
     const I32 newmax = GROW(oldmax);
 
-    Renew(PL_markstack, newmax, I32);
+    Renew(PL_markstack, newmax, SSize_t);
     PL_markstack_max = PL_markstack + newmax;
     PL_markstack_ptr = PL_markstack + oldmax;
     DEBUG_s(DEBUG_v(PerlIO_printf(Perl_debug_log,

--- a/sv.c
+++ b/sv.c
@@ -16192,13 +16192,13 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
 
         /* next PUSHMARK() sets *(PL_markstack_ptr+1) */
         i = proto_perl->Imarkstack_max - proto_perl->Imarkstack;
-        Newx(PL_markstack, i, I32);
+        Newx(PL_markstack, i, SSize_t);
         PL_markstack_max	= PL_markstack + (proto_perl->Imarkstack_max
                                                   - proto_perl->Imarkstack);
         PL_markstack_ptr	= PL_markstack + (proto_perl->Imarkstack_ptr
                                                   - proto_perl->Imarkstack);
         Copy(proto_perl->Imarkstack, PL_markstack,
-             PL_markstack_ptr - PL_markstack + 1, I32);
+             PL_markstack_ptr - PL_markstack + 1, SSize_t);
 
         /* next push_scope()/ENTER sets PL_scopestack[PL_scopestack_ix]
          * NOTE: unlike the others! */

--- a/t/bigmem/stack.t
+++ b/t/bigmem/stack.t
@@ -159,6 +159,16 @@ my @tests =
               is($joined, "Hello!", "join");
           },
       ],
+      [
+          class_construct => sub {
+              use experimental 'class';
+              class Foo {
+                  field $x :param;
+              };
+              my $y = Foo->new((x => 1) x 0x4000_0001);
+              ok($y, "construct class based object with 2G parameters");
+          },
+      ],
      );
 
 # these tests are slow, let someone debug them one at a time

--- a/t/bigmem/stack.t
+++ b/t/bigmem/stack.t
@@ -139,6 +139,19 @@ my @tests =
               }
           }
       ],
+      [
+          apply => sub {
+            SKIP:
+              {
+                  skip "2**31 system calls take a very long time - define PERL_RUN_SLOW_TESTS to run me", 1
+                    unless $ENV{PERL_RUN_SLOW_TESTS};
+                  my $mode = (stat $0)[2];
+                  my $tries = 0x8000_0001;
+                  my $count = chmod $mode, ( $0 ) x $tries;
+                  is($count, $tries, "chmod with 2G files");
+              }
+          }
+      ],
      );
 
 # these tests are slow, let someone debug them one at a time

--- a/t/bigmem/stack.t
+++ b/t/bigmem/stack.t
@@ -42,6 +42,13 @@ $x[0x8000_0000] = "Hello";
     is($last2, "Hello", "list subscripting in list context (-2)");
     is($last1, "Goodbye", "list subscripting in list context (-1)");
 }
+
+{
+    # the iter context had an I32 stack offset
+    my $last = ( x(), iter() )[-1];
+    is($last, "abc", "check iteration not confused");
+}
+
 done_testing();
 
 sub x { @x }

--- a/t/bigmem/stack.t
+++ b/t/bigmem/stack.t
@@ -85,6 +85,17 @@ my @tests =
               chomp(@x);
               is($x[-1], "Hello", "chomp on a large array");
           }
+         ],
+      [
+          grepwhile => sub {
+            SKIP: {
+                  skip("This test is even slower - define PERL_RUN_SLOW_TESTS to run me", 1)
+                    unless $ENV{PERL_RUN_SLOW_TESTS};
+                  # grep ..., @x used too much memory
+                  my $count = grep 1, ( (undef) x 0x7FFF_FFFF, 1, 1 );
+                  is($count, 0x8000_0001, "grepwhile item count");
+              }
+          }
       ],
      );
 

--- a/t/bigmem/stack.t
+++ b/t/bigmem/stack.t
@@ -33,6 +33,15 @@ $x[0x8000_0000] = "Hello";
     is($count, 0x8000_0002, "got expected XS list size");
 }
 
+{
+    my $last = ( x() )[-1];
+    is($last, "Hello", "list subscripting");
+
+    my ($first, $last2, $last1) = ( "first", x(), "Goodbye" )[0, -2, -1];
+    is($first, "first", "list subscripting in list context (0)");
+    is($last2, "Hello", "list subscripting in list context (-2)");
+    is($last1, "Goodbye", "list subscripting in list context (-1)");
+}
 done_testing();
 
 sub x { @x }

--- a/t/bigmem/stack.t
+++ b/t/bigmem/stack.t
@@ -89,13 +89,26 @@ my @tests =
       [
           grepwhile => sub {
             SKIP: {
-                  skip("This test is even slower - define PERL_RUN_SLOW_TESTS to run me", 1)
+                  skip "This test is even slower - define PERL_RUN_SLOW_TESTS to run me", 1
                     unless $ENV{PERL_RUN_SLOW_TESTS};
                   # grep ..., @x used too much memory
                   my $count = grep 1, ( (undef) x 0x7FFF_FFFF, 1, 1 );
                   is($count, 0x8000_0001, "grepwhile item count");
               }
           }
+      ],
+      [
+          repeat => sub {
+            SKIP:
+              {
+                  $ENV{PERL_TEST_MEMORY} >= 70
+                       or skip "repeat test needs 70GB", 2;
+                  # pp_repeat would throw an unable to allocate error
+                  my ($lastm1, $middle) = ( ( x() ) x 2 )[-1, @x-1];
+                  is($lastm1, "Hello", "repeat lastm1");
+                  is($middle, "Hello", "repeat middle");
+              }
+          },
       ],
      );
 
@@ -139,5 +152,7 @@ sub list2 {
 }
 
 sub list {
+    # ensure this continues to use a pp_list op
+    # if you change it.
     return shift() ? (1, 2) : (2, 1);
 }

--- a/t/bigmem/stack.t
+++ b/t/bigmem/stack.t
@@ -1,0 +1,34 @@
+#!perl
+BEGIN {
+    chdir 't' if -d 't';
+    @INC = "../lib";
+    require './test.pl';
+}
+
+use strict;
+use Config qw(%Config);
+use XS::APItest;
+
+# memory usage checked with top
+$ENV{PERL_TEST_MEMORY} >= 60
+    or skip_all("Need ~60GB for this test");
+$Config{ptrsize} >= 8
+    or skip_all("Need 64-bit pointers for this test");
+
+my @x;
+$x[0x8000_0000] = "Hello";
+
+{
+    # unlike the grep example this avoids the mark manipulation done by grep
+    # so it's more of a pure mark type test
+    # it also fails/succeeds a lot faster
+    my $count = () =  (x(), z());
+    is($count, 0x8000_0002, "got expected (large) list size");
+}
+
+
+done_testing();
+
+sub x { @x }
+
+sub z { 1 }

--- a/t/bigmem/stack.t
+++ b/t/bigmem/stack.t
@@ -77,6 +77,14 @@ my @tests =
             my $l = ( x(), list2() )[-1];
             is($l, 2, "pp_list mark handling");
         }
+       ],
+      [
+          chomp_av => sub {
+              # not really stack related, but is 32-bit related
+              local $x[-1] = "Hello\n";
+              chomp(@x);
+              is($x[-1], "Hello", "chomp on a large array");
+          }
       ],
      );
 

--- a/t/bigmem/stack.t
+++ b/t/bigmem/stack.t
@@ -57,11 +57,34 @@ $x[0x8000_0000] = "Hello";
     # it would be nice to test split returning >2G (or >4G) items, but
     # I don't have the memory needed
 }
+
+{
+    # I expect this to crash if buggy
+    my $count = () = (x(), loader());
+    is($count, 0x8000_0001, "check loading XS with large stack");
+}
+
 done_testing();
 
 sub x { @x }
 
 sub z { 1 }
+
+sub iter {
+    my $result = '';
+    my $count = 0;
+    for my $item (qw(a b c)) {
+        $result .= $item;
+        die "iteration bug" if ++$count > 5;
+    }
+    $result;
+}
+
 sub do_split {
     return split //, $_[0];
+}
+
+sub loader {
+    require Cwd;
+    ();
 }

--- a/t/bigmem/stack.t
+++ b/t/bigmem/stack.t
@@ -26,6 +26,12 @@ $x[0x8000_0000] = "Hello";
     is($count, 0x8000_0002, "got expected (large) list size");
 }
 
+{
+    # check XS gets the right numbers in our predefined variables
+    # returned ~ -2G before fix
+    my $count = XS::APItest::xs_items(x(), z());
+    is($count, 0x8000_0002, "got expected XS list size");
+}
 
 done_testing();
 

--- a/t/bigmem/stack.t
+++ b/t/bigmem/stack.t
@@ -49,8 +49,19 @@ $x[0x8000_0000] = "Hello";
     is($last, "abc", "check iteration not confused");
 }
 
+{
+    # split had an I32 base offset
+    # this paniced with "Split loop"
+    my $count = () = ( x(), do_split("ABC") );
+    is($count, 0x8000_0004, "split base index");
+    # it would be nice to test split returning >2G (or >4G) items, but
+    # I don't have the memory needed
+}
 done_testing();
 
 sub x { @x }
 
 sub z { 1 }
+sub do_split {
+    return split //, $_[0];
+}

--- a/t/bigmem/stack.t
+++ b/t/bigmem/stack.t
@@ -152,6 +152,13 @@ my @tests =
               }
           }
       ],
+      [
+          join => sub {
+              no warnings 'uninitialized';
+              my $joined = join "", @x, "!";
+              is($joined, "Hello!", "join");
+          },
+      ],
      );
 
 # these tests are slow, let someone debug them one at a time

--- a/t/bigmem/stack.t
+++ b/t/bigmem/stack.t
@@ -72,6 +72,12 @@ my @tests =
             is($count, 0x8000_0001, "check loading XS with large stack");
         }
       ],
+      [ pp_list => sub
+        {
+            my $l = ( x(), list2() )[-1];
+            is($l, 2, "pp_list mark handling");
+        }
+      ],
      );
 
 # these tests are slow, let someone debug them one at a time
@@ -107,4 +113,12 @@ sub do_split {
 sub loader {
     require Cwd;
     ();
+}
+
+sub list2 {
+    scalar list(1);
+}
+
+sub list {
+    return shift() ? (1, 2) : (2, 1);
 }

--- a/t/bigmem/stack.t
+++ b/t/bigmem/stack.t
@@ -169,6 +169,18 @@ my @tests =
               ok($y, "construct class based object with 2G parameters");
           },
       ],
+      [
+          eval_sv_count => sub {
+            SKIP:
+              {
+                  $ENV{PERL_TEST_MEMORY} >= 70
+                    or skip "eval_sv_count test needs 70GB", 2;
+
+                  my $count = ( @x, XS::APItest::eval_sv('@x', G_LIST) )[-1];
+                  is($count, scalar @x, "check eval_sv result/mark handling");
+              }
+          }
+      ],
      );
 
 # these tests are slow, let someone debug them one at a time

--- a/util.c
+++ b/util.c
@@ -5472,11 +5472,12 @@ Perl_my_cxt_init(pTHX_ int *indexp, size_t size)
    'file' is the source filename of the caller.
 */
 
-I32
+SSize_t
 Perl_xs_handshake(const U32 key, void * v_my_perl, const char * file, ...)
 {
     va_list args;
-    U32 items, ax;
+    SSize_t items;
+    SSize_t ax;
     void * got;
     void * need;
     const char *stage = "first";
@@ -5538,13 +5539,15 @@ Perl_xs_handshake(const U32 key, void * v_my_perl, const char * file, ...)
         ax = POPMARK;
         {   SV **mark = PL_stack_base + ax++;
             {   dSP;
-                items = (I32)(SP - MARK);
+                items = (SSize_t)(SP - MARK);
             }
         }
     } else {
-        items = va_arg(args, U32);
-        ax = va_arg(args, U32);
+        items = va_arg(args, SSize_t);
+        ax = va_arg(args, SSize_t);
     }
+    assert(ax >= 0);
+    assert(items >= 0);
     {
         U32 apiverlen;
         assert(HS_GETAPIVERLEN(key) <= UCHAR_MAX);
@@ -5571,7 +5574,7 @@ Perl_xs_handshake(const U32 key, void * v_my_perl, const char * file, ...)
 
 
 STATIC void
-S_xs_version_bootcheck(pTHX_ U32 items, U32 ax, const char *xs_p,
+S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p,
                           STRLEN xs_len)
 {
     SV *sv;


### PR DESCRIPTION
This series changes the mark stack and various macros to use SSIze_t instead of I32 for marks.

It also fixes several places where perl uses an I32 as an index into the stack, or an index into a list on the stack, or as a count of items returned on the stack.

It doesn't attempt to fix all I32 problems, but I do have a little list I'll work through of potential problems to check out.

Fixes #20917