### PR TITLE
Improve embed.fnc autoformatting

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3795,8 +3795,9 @@ Rp	|int	|PerlSock_socket_cloexec				\
 				|int type				\
 				|int protocol
 #endif
-#if defined(HAS_SOCKETPAIR) || ( defined(AF_INET) && defined(HAS_SOCKET) && \
-    defined(PF_INET) && defined(SOCK_DGRAM) )
+#if   defined(HAS_SOCKETPAIR) ||                                     \
+    ( defined(AF_INET) && defined(HAS_SOCKET) && defined(PF_INET) && \
+      defined(SOCK_DGRAM) )
 Rp	|int	|PerlSock_socketpair_cloexec				\
 				|int domain				\
 				|int type				\
@@ -4015,8 +4016,8 @@ Cp	|OP *	|class_wrap_method_body 				\
 				|NULLOK OP *o
 Cp	|void	|croak_kw_unless_class					\
 				|NN const char *kw
-#endif /* defined(PERL_IN_CLASS_C) || defined(PERL_IN_OP_C)    || \
-          defined(PERL_IN_PAD_C)   || defined(PERL_IN_PERLY_C) || \
+#endif /* defined(PERL_IN_CLASS_C) || defined(PERL_IN_OP_C)    ||
+          defined(PERL_IN_PAD_C)   || defined(PERL_IN_PERLY_C) ||
           defined(PERL_IN_TOKE_C) */
 #if defined(PERL_IN_DEB_C)
 S	|void	|deb_stack_n	|NN SV **stack_base			\
@@ -4068,9 +4069,10 @@ RS	|Size_t |do_trans_invmap|NN SV * const sv			\
 RS	|Size_t |do_trans_simple|NN SV * const sv			\
 				|NN const OPtrans_map * const tbl
 #endif
-#if defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C)        || defined(PERL_IN_PP_C) \
-                            || defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_REGEXEC_C) || \
-    defined(PERL_IN_TOKE_C) || defined(PERL_IN_UTF8_C)
+#if defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
+    defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
+    defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
+    defined(PERL_IN_UTF8_C)
 ERTi	|bool * |get_invlist_offset_addr				\
 				|NN SV *invlist
 ERTi	|UV *	|invlist_array	|NN SV * const invlist
@@ -4127,7 +4129,7 @@ ERXp	|SV *	|_setup_canned_invlist					\
 				|const STRLEN size			\
 				|const UV element0			\
 				|NN UV **other_elements_ptr
-#endif /* defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
+#endif /* defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) ||
           defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C) */
 #if defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) || \
     defined(PERL_IN_TOKE_C)
@@ -4235,8 +4237,8 @@ S	|void	|require_tie_mod|NN GV *gv				\
 				|STRLEN len				\
 				|const U32 flags
 #endif /* defined(PERL_IN_GV_C) */
-#if defined(PERL_IN_GV_C) || defined(PERL_IN_OP_C) || defined(PERL_IN_PAD_C) \
-                          || defined(PERL_IN_SV_C)
+#if defined(PERL_IN_GV_C)  || defined(PERL_IN_OP_C) || \
+    defined(PERL_IN_PAD_C) || defined(PERL_IN_SV_C)
 : Used in gv.c
 op	|void	|sv_add_backref |NN SV * const tsv			\
 				|NN SV * const sv
@@ -4424,8 +4426,9 @@ S	|const char *|update_PL_curlocales_i				\
 				|NN const char *new_locale		\
 				|recalc_lc_all_t recalc_LC_ALL
 #     endif
-#   elif defined(USE_LOCALE_THREADS) && !defined(USE_THREAD_SAFE_LOCALE) && \
-         !defined(USE_THREAD_SAFE_LOCALE_EMULATION) /* && \
+#   elif  defined(USE_LOCALE_THREADS) &&                  \
+         !defined(USE_THREAD_SAFE_LOCALE) &&              \
+         !defined(USE_THREAD_SAFE_LOCALE_EMULATION) /* &&
          !defined(USE_POSIX_2008_LOCALE) */
 S	|const char *|less_dicey_setlocale_r				\
 				|const int category			\
@@ -4441,8 +4444,9 @@ S	|bool	|less_dicey_bool_setlocale_r				\
 				|NN const char *locale
 #     endif
 #   endif
-#   if !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) && ( \
-       !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || defined(WIN32) )
+#   if !(  defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) && \
+        ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) ||            \
+           defined(WIN32) )
 S	|const char *|calculate_LC_ALL					\
 				|NN const char **individ_locales
 #   endif
@@ -4460,8 +4464,8 @@ S	|const char *|wrap_wsetlocale					\
 				|const int category			\
 				|NULLOK const char *locale
 #   endif
-#   if defined(WIN32) || ( defined(USE_POSIX_2008_LOCALE) && \
-       !defined(USE_QUERYLOCALE) )
+#   if   defined(WIN32) || \
+       ( defined(USE_POSIX_2008_LOCALE) && !defined(USE_QUERYLOCALE) )
 S	|const char *|find_locale_from_environment			\
 				|const unsigned int index
 #   endif

--- a/embed.fnc
+++ b/embed.fnc
@@ -3702,15 +3702,6 @@ EXp	|int	|yylex
 p	|int	|yyparse	|int gramtype
 p	|void	|yyquit
 p	|void	|yyunlex
-#if ( defined(AF_INET) && defined(HAS_SOCKET) && defined(PF_INET) && \
-    defined(SOCK_DGRAM) ) || defined(HAS_SOCKETPAIR)
-Rp	|int	|PerlSock_socketpair_cloexec				\
-				|int domain				\
-				|int type				\
-				|int protocol				\
-				|NN int *pairfd
-#endif /* ( defined(AF_INET) && defined(HAS_SOCKET) && defined(PF_INET) && \
-          defined(SOCK_DGRAM) ) || defined(HAS_SOCKETPAIR) */
 #if defined(DEBUGGING)
 : Used in mg.c
 Rp	|int	|get_debug_opts |NN const char **s			\
@@ -3804,6 +3795,15 @@ Rp	|int	|PerlSock_socket_cloexec				\
 				|int type				\
 				|int protocol
 #endif /* defined(HAS_SOCKET) */
+#if defined(HAS_SOCKETPAIR) || ( defined(AF_INET) && defined(HAS_SOCKET) && \
+    defined(PF_INET) && defined(SOCK_DGRAM) )
+Rp	|int	|PerlSock_socketpair_cloexec				\
+				|int domain				\
+				|int type				\
+				|int protocol				\
+				|NN int *pairfd
+#endif /* defined(HAS_SOCKETPAIR) || ( defined(AF_INET) && \
+          defined(HAS_SOCKET) && defined(PF_INET) && defined(SOCK_DGRAM) ) */
 #if !defined(HAS_STRLCAT)
 ATdip	|Size_t |my_strlcat	|NULLOK char *dst			\
 				|NULLOK const char *src 		\
@@ -4451,10 +4451,9 @@ S	|bool	|less_dicey_bool_setlocale_r				\
 				|const int cat				\
 				|NN const char *locale
 #     endif /* 0 */
-#   endif /* ( defined(USE_LOCALE_THREADS) && \
-             !defined(USE_THREAD_SAFE_LOCALE) && \
-             !defined(USE_THREAD_SAFE_LOCALE_EMULATION) ) && \
-             !defined(USE_POSIX_2008_LOCALE) */
+#   endif /* !defined(USE_POSIX_2008_LOCALE) && ( defined(USE_LOCALE_THREADS) \
+             && !defined(USE_THREAD_SAFE_LOCALE) && \
+             !defined(USE_THREAD_SAFE_LOCALE_EMULATION) ) */
 #   if !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) )
 :	    regen/embed.pl can't currently cope with 'elif'
 #     if !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || defined(WIN32)
@@ -4463,12 +4462,6 @@ S	|const char *|calculate_LC_ALL					\
 #     endif /* !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || \
                defined(WIN32) */
 #   endif /* !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) */
-#   if ( defined(USE_POSIX_2008_LOCALE) && !defined(USE_QUERYLOCALE) ) || \
-       defined(WIN32)
-S	|const char *|find_locale_from_environment			\
-				|const unsigned int index
-#   endif /* ( defined(USE_POSIX_2008_LOCALE) && !defined(USE_QUERYLOCALE) ) \
-             || defined(WIN32) */
 #   if defined(WIN32)
 ST	|wchar_t *|Win_byte_string_to_wstring				\
 				|const UINT code_page			\
@@ -4483,6 +4476,12 @@ S	|const char *|wrap_wsetlocale					\
 				|const int category			\
 				|NULLOK const char *locale
 #   endif /* defined(WIN32) */
+#   if defined(WIN32) || ( defined(USE_POSIX_2008_LOCALE) && \
+       !defined(USE_QUERYLOCALE) )
+S	|const char *|find_locale_from_environment			\
+				|const unsigned int index
+#   endif /* defined(WIN32) || ( defined(USE_POSIX_2008_LOCALE) && \
+             !defined(USE_QUERYLOCALE) ) */
 # endif /* defined(USE_LOCALE) */
 # if defined(USE_POSIX_2008_LOCALE) || defined(DEBUGGING)
 S	|const char *|get_displayable_string				\
@@ -4659,10 +4658,6 @@ p	|void	|warn_elem_scalar_context				\
 				|NN SV *name				\
 				|bool is_hash				\
 				|bool is_slice
-# if defined(USE_ITHREADS)
-p	|void	|op_relocate_sv |NN SV **svp				\
-				|NN PADOFFSET *targp
-# endif /* defined(USE_ITHREADS) */
 #endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_PERLY_C) || \
     defined(PERL_IN_TOKE_C)
@@ -6098,6 +6093,10 @@ ARp	|SV *	|sv_dup 	|NULLOK const SV * const ssv		\
 				|NN CLONE_PARAMS * const param
 ARp	|SV *	|sv_dup_inc	|NULLOK const SV * const ssv		\
 				|NN CLONE_PARAMS * const param
+# if defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C)
+p	|void	|op_relocate_sv |NN SV **svp				\
+				|NN PADOFFSET *targp
+# endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
 #else /* if !defined(USE_ITHREADS) */
 Adm	|void	|CopFILEGV_set	|NN COP *c				\
 				|NN GV *gv

--- a/embed.fnc
+++ b/embed.fnc
@@ -4454,14 +4454,13 @@ S	|bool	|less_dicey_bool_setlocale_r				\
 #   endif /* !defined(USE_POSIX_2008_LOCALE) && ( defined(USE_LOCALE_THREADS) \
              && !defined(USE_THREAD_SAFE_LOCALE) && \
              !defined(USE_THREAD_SAFE_LOCALE_EMULATION) ) */
-#   if !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) )
-:	    regen/embed.pl can't currently cope with 'elif'
-#     if !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || defined(WIN32)
+#   if !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) && ( \
+       !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || defined(WIN32) )
 S	|const char *|calculate_LC_ALL					\
 				|NN const char **individ_locales
-#     endif /* !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || \
-               defined(WIN32) */
-#   endif /* !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) */
+#   endif /* !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) \
+             && ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || \
+             defined(WIN32) ) */
 #   if defined(WIN32)
 ST	|wchar_t *|Win_byte_string_to_wstring				\
 				|const UINT code_page			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -3712,31 +3712,31 @@ Cdp	|void	|pad_setsv	|PADOFFSET po				\
 Cdp	|SV *	|pad_sv 	|PADOFFSET po
 TXp	|void	|set_padlist	|NN CV *cv				\
 				|NULLOK PADLIST *padlist
-#endif /* defined(DEBUGGING) */
+#endif
 #if defined(DEBUG_LEAKING_SCALARS_FORK_DUMP)
 : Used in sv.c
 p	|void	|dump_sv_child	|NN SV *sv
-#endif /* defined(DEBUG_LEAKING_SCALARS_FORK_DUMP) */
+#endif
 #if !defined(EBCDIC)
 CRTip	|unsigned int|variant_byte_number				\
 				|PERL_UINTMAX_T word
-#endif /* !defined(EBCDIC) */
+#endif
 #if defined(F_FREESP) && !defined(HAS_CHSIZE) && !defined(HAS_TRUNCATE)
 ARdp	|I32	|my_chsize	|int fd 				\
 				|Off_t length
-#endif /* defined(F_FREESP) && !defined(HAS_CHSIZE) && !defined(HAS_TRUNCATE) */
+#endif
 #if !defined(HAS_GETENV_LEN)
 : Used in hv.c
 p	|char * |getenv_len	|NN const char *env_elem		\
 				|NN unsigned long *len
-#endif /* !defined(HAS_GETENV_LEN) */
+#endif
 #if !defined(HAS_MKOSTEMP)
 Tdop	|int	|my_mkostemp	|NN char *templte			\
 				|int flags
-#endif /* !defined(HAS_MKOSTEMP) */
+#endif
 #if !defined(HAS_MKSTEMP)
 Tdop	|int	|my_mkstemp	|NN char *templte
-#endif /* !defined(HAS_MKSTEMP) */
+#endif
 #if defined(HAS_MSG) || defined(HAS_SEM) || defined(HAS_SHM)
 : Defined in doio.c, used only in pp_sys.c
 p	|I32	|do_ipcctl	|I32 optype				\
@@ -3766,25 +3766,25 @@ ATdo	|const char *|Perl_langinfo					\
 ATdo	|const char *|Perl_langinfo8					\
 				|const nl_item item			\
 				|NULLOK utf8ness_t *utf8ness
-#else /* if !( defined(HAS_NL_LANGINFO) && defined(PERL_LANGINFO_H) ) */
+#else
 ATdo	|const char *|Perl_langinfo					\
 				|const int item
 ATdo	|const char *|Perl_langinfo8					\
 				|const int item 			\
 				|NULLOK utf8ness_t *utf8ness
-#endif /* !( defined(HAS_NL_LANGINFO) && defined(PERL_LANGINFO_H) ) */
+#endif
 #if defined(HAS_PIPE)
 Rp	|int	|PerlProc_pipe_cloexec					\
 				|NN int *pipefd
-#endif /* defined(HAS_PIPE) */
+#endif
 #if !defined(HAS_RENAME)
 : Used in pp_sys.c
 p	|I32	|same_dirent	|NN const char *a			\
 				|NN const char *b
-#endif /* !defined(HAS_RENAME) */
+#endif
 #if !defined(HAS_SIGNBIT)
 APTdox	|int	|Perl_signbit	|NV f
-#endif /* !defined(HAS_SIGNBIT) */
+#endif
 #if defined(HAS_SOCKET)
 Rp	|int	|PerlSock_accept_cloexec				\
 				|int listenfd				\
@@ -3794,7 +3794,7 @@ Rp	|int	|PerlSock_socket_cloexec				\
 				|int domain				\
 				|int type				\
 				|int protocol
-#endif /* defined(HAS_SOCKET) */
+#endif
 #if defined(HAS_SOCKETPAIR) || ( defined(AF_INET) && defined(HAS_SOCKET) && \
     defined(PF_INET) && defined(SOCK_DGRAM) )
 Rp	|int	|PerlSock_socketpair_cloexec				\
@@ -3802,39 +3802,38 @@ Rp	|int	|PerlSock_socketpair_cloexec				\
 				|int type				\
 				|int protocol				\
 				|NN int *pairfd
-#endif /* defined(HAS_SOCKETPAIR) || ( defined(AF_INET) && \
-          defined(HAS_SOCKET) && defined(PF_INET) && defined(SOCK_DGRAM) ) */
+#endif
 #if !defined(HAS_STRLCAT)
 ATdip	|Size_t |my_strlcat	|NULLOK char *dst			\
 				|NULLOK const char *src 		\
 				|Size_t size
-#endif /* !defined(HAS_STRLCAT) */
+#endif
 #if !defined(HAS_STRLCPY)
 ATds	|Size_t |my_strlcpy	|NULLOK char *dst			\
 				|NULLOK const char *src 		\
 				|Size_t size
-#endif /* !defined(HAS_STRLCPY) */
+#endif
 #if !defined(HAS_STRNLEN)
 ATdip	|Size_t |my_strnlen	|NN const char *str			\
 				|Size_t maxlen
-#endif /* !defined(HAS_STRNLEN) */
+#endif
 #if defined(HAVE_INTERP_INTERN)
 Cp	|void	|sys_intern_clear
 Cp	|void	|sys_intern_init
 # if defined(USE_ITHREADS)
 Cp	|void	|sys_intern_dup |NN struct interp_intern *src		\
 				|NN struct interp_intern *dst
-# endif /* defined(USE_ITHREADS) */
-#endif /* defined(HAVE_INTERP_INTERN) */
+# endif
+#endif
 #if defined(_MSC_VER)
 p	|int	|magic_regdatum_set					\
 				|NN SV *sv				\
 				|NN MAGIC *mg
-#else /* if !defined(_MSC_VER) */
+#else
 pr	|int	|magic_regdatum_set					\
 				|NN SV *sv				\
 				|NN MAGIC *mg
-#endif /* !defined(_MSC_VER) */
+#endif
 #if defined(MULTIPLICITY)
 ATdfpr	|void	|croak_nocontext|NULLOK const char *pat 		\
 				|...
@@ -3887,12 +3886,12 @@ Cp	|int	|get_mstats	|NN perl_mstats_t *buf			\
 RTp	|MEM_SIZE|malloced_size |NN void *p
 RTp	|MEM_SIZE|malloc_good_size					\
 				|size_t nbytes
-#endif /* defined(MYMALLOC) */
+#endif
 #if defined(PERL_ANY_COW)
 : Used in regexec.c
 EXpx	|SV *	|sv_setsv_cow	|NULLOK SV *dsv 			\
 				|NN SV *ssv
-#endif /* defined(PERL_ANY_COW) */
+#endif
 #if defined(PERL_CORE)
 p	|void	|opslab_force_free					\
 				|NN OPSLAB *slab
@@ -3906,7 +3905,7 @@ RTi	|bool	|should_warn_nl |NN const char *pv
 # if defined(PERL_DEBUG_READONLY_OPS)
 ep	|void	|Slab_to_ro	|NN OPSLAB *slab
 ep	|void	|Slab_to_rw	|NN OPSLAB * const slab
-# endif /* defined(PERL_DEBUG_READONLY_OPS) */
+# endif
 #endif /* defined(PERL_CORE) */
 #if defined(PERL_CORE) || defined(PERL_EXT)
 ERXdp	|bool	|isSCRIPT_RUN	|NN const U8 *s 			\
@@ -3927,29 +3926,29 @@ ERTdi	|Size_t |variant_under_utf8_count				\
 ETei	|void * |my_memrchr	|NN const char *s			\
 				|const char c				\
 				|const STRLEN len
-# endif /* !defined(HAS_MEMRCHR) */
-#endif /* defined(PERL_CORE) || defined(PERL_EXT) */
+# endif
+#endif
 #if defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API)
 Adp	|void	|finalize_optree|NN OP *o
 Adp	|void	|optimize_optree|NN OP *o
-#endif /* defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API) */
+#endif
 #if defined(PERL_DEBUG_READONLY_COW)
 p	|void	|sv_buf_to_ro	|NN SV *sv
-#endif /* defined(PERL_DEBUG_READONLY_COW) */
+#endif
 #if defined(PERL_DEBUG_READONLY_OPS)
 : FIXME - can be static.
 eopx	|PADOFFSET|op_refcnt_dec|NN OP *o
 : Used in OpREFCNT_inc() in sv.c
 eopx	|OP *	|op_refcnt_inc	|NULLOK OP *o
-#endif /* defined(PERL_DEBUG_READONLY_OPS) */
+#endif
 #if defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION)
 Mp	|bool	|do_exec	|NN const char *cmd
-#else /* if !defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION) */
+#else
 p	|bool	|do_exec	|NN const char *cmd
-#endif /* !defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION) */
+#endif
 #if defined(PERL_DONT_CREATE_GVSV)
 AMbdp	|GV *	|gv_SVadd	|NULLOK GV *gv
-#endif /* defined(PERL_DONT_CREATE_GVSV) */
+#endif
 #if defined(PERL_IMPLICIT_SYS)
 CTo	|PerlInterpreter *|perl_alloc_using				\
 				|NN struct IPerlMem *ipM		\
@@ -3974,18 +3973,18 @@ CTo	|PerlInterpreter *|perl_clone_using				\
 				|NN struct IPerlDir *ipD		\
 				|NN struct IPerlSock *ipS		\
 				|NN struct IPerlProc *ipP
-# endif /* defined(USE_ITHREADS) */
-#else /* if !defined(PERL_IMPLICIT_SYS) */
+# endif
+#else
 Adp	|I32	|my_pclose	|NULLOK PerlIO *ptr
 Adp	|PerlIO *|my_popen	|NN const char *cmd			\
 				|NN const char *mode
 # if defined(USE_ITHREADS)
 i	|bool	|PerlEnv_putenv |NN char *str
-# endif /* defined(USE_ITHREADS) */
-#endif /* !defined(PERL_IMPLICIT_SYS) */
+# endif
+#endif
 #if defined(PERL_IN_AV_C)
 S	|MAGIC *|get_aux_mg	|NN AV *av
-#endif /* defined(PERL_IN_AV_C) */
+#endif
 #if defined(PERL_IN_CLASS_C) || defined(PERL_IN_OP_C)    || \
     defined(PERL_IN_PAD_C)   || defined(PERL_IN_PERLY_C) || \
     defined(PERL_IN_TOKE_C)
@@ -4025,7 +4024,7 @@ S	|void	|deb_stack_n	|NN SV **stack_base			\
 				|I32 stack_max				\
 				|I32 mark_min				\
 				|I32 mark_max
-#endif /* defined(PERL_IN_DEB_C) */
+#endif
 #if defined(PERL_IN_DOIO_C)
 S	|bool	|argvout_final	|NN MAGIC *mg				\
 				|NN IO *io				\
@@ -4054,7 +4053,7 @@ S	|IO *	|openn_setup	|NN GV *gv				\
 				|NN PerlIO **saveofp			\
 				|NN int *savefd 			\
 				|NN char *savetype
-#endif /* defined(PERL_IN_DOIO_C) */
+#endif
 #if defined(PERL_IN_DOOP_C)
 RS	|Size_t |do_trans_complex					\
 				|NN SV * const sv			\
@@ -4068,7 +4067,7 @@ RS	|Size_t |do_trans_invmap|NN SV * const sv			\
 				|NN AV * const map
 RS	|Size_t |do_trans_simple|NN SV * const sv			\
 				|NN const OPtrans_map * const tbl
-#endif /* defined(PERL_IN_DOOP_C) */
+#endif
 #if defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C)        || defined(PERL_IN_PP_C) \
                             || defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_REGEXEC_C) || \
     defined(PERL_IN_TOKE_C) || defined(PERL_IN_UTF8_C)
@@ -4082,10 +4081,7 @@ ERTi	|UV	|_invlist_len	|NN SV * const invlist
 ERTXp	|SSize_t|_invlist_search|NN SV * const invlist			\
 				|const UV cp
 ERTi	|bool	|is_invlist	|NULLOK const SV * const invlist
-#endif /* defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
-          defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
-          defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
-          defined(PERL_IN_UTF8_C) */
+#endif
 #if defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY)
 ERi	|SV *	|add_cp_to_invlist					\
@@ -4097,8 +4093,7 @@ ERTi	|UV	|invlist_highest|NN SV * const invlist
 Ei	|void	|invlist_set_len|NN SV * const invlist			\
 				|const UV len				\
 				|const bool offset
-#endif /* defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
-          defined(PERL_IN_REGCOMP_ANY) */
+#endif
 #if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C)
 ERXp	|SV *	|_add_range_to_invlist					\
@@ -4163,8 +4158,7 @@ ERXp	|bool	|grok_bslash_x	|NN char **s				\
 				|const bool strict			\
 				|const bool allow_UV_MAX		\
 				|const bool utf8
-#endif /* defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) || \
-          defined(PERL_IN_TOKE_C) */
+#endif
 #if defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) || \
     defined(PERL_IN_TOKE_C)   || defined(PERL_IN_UTF8_C)
 ERXp	|const char *|form_cp_too_large_msg				\
@@ -4172,28 +4166,25 @@ ERXp	|const char *|form_cp_too_large_msg				\
 				|NULLOK const char *string		\
 				|const Size_t len			\
 				|const UV cp
-#endif /* defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) || \
-          defined(PERL_IN_TOKE_C)   || defined(PERL_IN_UTF8_C) */
+#endif
 #if defined(PERL_IN_DUMP_C)
 S	|CV *	|deb_curcv	|I32 ix
 Sd	|void	|debprof	|NN const OP *o
 S	|SV *	|pm_description |NN const PMOP *pm
 S	|UV	|sequence_num	|NULLOK const OP *o
-#endif /* defined(PERL_IN_DUMP_C) */
+#endif
 #if defined(PERL_IN_DUMP_C)  || defined(PERL_IN_HV_C) || \
     defined(PERL_IN_SCOPE_C) || defined(PERL_IN_SV_C)
 opx	|void	|hv_kill_backrefs					\
 				|NN HV *hv
-#endif /* defined(PERL_IN_DUMP_C)  || defined(PERL_IN_HV_C) || \
-          defined(PERL_IN_SCOPE_C) || defined(PERL_IN_SV_C) */
+#endif
 #if defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY)
 EXp	|void	|_invlist_dump	|NN PerlIO *file			\
 				|I32 level				\
 				|NN const char * const indent		\
 				|NN SV * const invlist
-#endif /* defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) || \
-          defined(PERL_IN_REGCOMP_ANY) */
+#endif
 #if defined(PERL_IN_GV_C)
 S	|bool	|find_default_stash					\
 				|NN HV **stash				\
@@ -4249,15 +4240,14 @@ S	|void	|require_tie_mod|NN GV *gv				\
 : Used in gv.c
 op	|void	|sv_add_backref |NN SV * const tsv			\
 				|NN SV * const sv
-#endif /* defined(PERL_IN_GV_C)  || defined(PERL_IN_OP_C) || \
-          defined(PERL_IN_PAD_C) || defined(PERL_IN_SV_C) */
+#endif
 #if defined(PERL_IN_GV_C) || defined(PERL_IN_UNIVERSAL_C)
 EGdp	|HV *	|gv_stashsvpvn_cached					\
 				|SV *namesv				\
 				|const char *name			\
 				|U32 namelen				\
 				|I32 flags
-#endif /* defined(PERL_IN_GV_C) || defined(PERL_IN_UNIVERSAL_C) */
+#endif
 #if defined(PERL_IN_HV_C)
 Sx	|void	|clear_placeholders					\
 				|NN HV *hv				\
@@ -4301,20 +4291,19 @@ S	|void	|unshare_hek_or_pvn					\
 				|U32 hash
 # if !defined(PURIFY)
 RS	|HE *	|new_he
-# endif /* !defined(PURIFY) */
+# endif
 #endif /* defined(PERL_IN_HV_C) */
 #if defined(PERL_IN_HV_C) || defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C)
 : Used in hv.c and mg.c
 opx	|void	|sv_kill_backrefs					\
 				|NN SV * const sv			\
 				|NULLOK AV * const av
-#endif /* defined(PERL_IN_HV_C) || defined(PERL_IN_MG_C) || \
-          defined(PERL_IN_SV_C) */
+#endif
 #if defined(PERL_IN_HV_C) || defined(PERL_IN_SV_C)
 op	|SV *	|hfree_next_entry					\
 				|NN HV *hv				\
 				|NN STRLEN *indexp
-#endif /* defined(PERL_IN_HV_C) || defined(PERL_IN_SV_C) */
+#endif
 #if defined(PERL_IN_LOCALE_C)
 S	|utf8ness_t|get_locale_string_utf8ness_i			\
 				|NULLOK const char *string		\
@@ -4330,7 +4319,7 @@ S	|void	|populate_hash_from_localeconv				\
 				|const U32 which_mask			\
 				|NN const lconv_offset_t *strings[2]	\
 				|NULLOK const lconv_offset_t *integers
-# endif /* defined(HAS_LOCALECONV) */
+# endif
 # if defined(USE_LOCALE)
 ST	|unsigned int|get_category_index				\
 				|const int category			\
@@ -4371,7 +4360,7 @@ RS	|char * |my_setlocale_debug_string_i				\
 				|NULLOK const char *locale		\
 				|NULLOK const char *retval		\
 				|const line_t line
-#   endif /* defined(DEBUGGING) */
+#   endif
 #   if defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L)
 S	|const char *|my_langinfo_i					\
 				|const nl_item item			\
@@ -4380,7 +4369,7 @@ S	|const char *|my_langinfo_i					\
 				|NN const char **retbufp		\
 				|NULLOK Size_t *retbuf_sizep		\
 				|NULLOK utf8ness_t *utf8ness
-#   else /* if !( defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L) ) */
+#   else
 S	|const char *|my_langinfo_i					\
 				|const int item 			\
 				|const unsigned int cat_index		\
@@ -4388,7 +4377,7 @@ S	|const char *|my_langinfo_i					\
 				|NN const char **retbufp		\
 				|NULLOK Size_t *retbuf_sizep		\
 				|NULLOK utf8ness_t *utf8ness
-#   endif /* !( defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L) ) */
+#   endif
 #   if defined(USE_LOCALE_COLLATE)
 S	|void	|new_collate	|NN const char *newcoll 		\
 				|bool force
@@ -4399,21 +4388,21 @@ S	|void	|print_collxfrm_input_and_return			\
 				|NULLOK const char *xbuf		\
 				|const STRLEN xlen			\
 				|const bool is_utf8
-#     endif /* defined(DEBUGGING) */
-#   endif /* defined(USE_LOCALE_COLLATE) */
+#     endif
+#   endif
 #   if defined(USE_LOCALE_CTYPE)
 ST	|bool	|is_codeset_name_UTF8					\
 				|NN const char *name
 S	|void	|new_ctype	|NN const char *newctype		\
 				|bool force
-#   endif /* defined(USE_LOCALE_CTYPE) */
+#   endif
 #   if defined(USE_LOCALE_NUMERIC)
 S	|void	|new_numeric	|NN const char *newnum			\
 				|bool force
-#   endif /* defined(USE_LOCALE_NUMERIC) */
+#   endif
 #   if defined(USE_PERL_SWITCH_LOCALE_CONTEXT) || defined(DEBUGGING)
 S	|const char *|get_LC_ALL_display
-#   endif /* defined(USE_PERL_SWITCH_LOCALE_CONTEXT) || defined(DEBUGGING) */
+#   endif
 #   if defined(USE_POSIX_2008_LOCALE)
 S	|const char *|emulate_setlocale_i				\
 				|const unsigned int index		\
@@ -4429,12 +4418,12 @@ S	|locale_t|use_curlocale_scratch
 #     if defined(USE_QUERYLOCALE)
 S	|const char *|calculate_LC_ALL					\
 				|const locale_t cur_obj
-#     else /* if !defined(USE_QUERYLOCALE) */
+#     else
 S	|const char *|update_PL_curlocales_i				\
 				|const unsigned int index		\
 				|NN const char *new_locale		\
 				|recalc_lc_all_t recalc_LC_ALL
-#     endif /* !defined(USE_QUERYLOCALE) */
+#     endif
 #   elif defined(USE_LOCALE_THREADS) && !defined(USE_THREAD_SAFE_LOCALE) && \
          !defined(USE_THREAD_SAFE_LOCALE_EMULATION) /* && \
          !defined(USE_POSIX_2008_LOCALE) */
@@ -4450,17 +4439,13 @@ S	|void	|less_dicey_void_setlocale_i				\
 S	|bool	|less_dicey_bool_setlocale_r				\
 				|const int cat				\
 				|NN const char *locale
-#     endif /* 0 */
-#   endif /* !defined(USE_POSIX_2008_LOCALE) && ( defined(USE_LOCALE_THREADS) \
-             && !defined(USE_THREAD_SAFE_LOCALE) && \
-             !defined(USE_THREAD_SAFE_LOCALE_EMULATION) ) */
+#     endif
+#   endif
 #   if !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) && ( \
        !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || defined(WIN32) )
 S	|const char *|calculate_LC_ALL					\
 				|NN const char **individ_locales
-#   endif /* !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) \
-             && ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || \
-             defined(WIN32) ) */
+#   endif
 #   if defined(WIN32)
 ST	|wchar_t *|Win_byte_string_to_wstring				\
 				|const UINT code_page			\
@@ -4474,25 +4459,24 @@ ST	|char * |Win_wstring_to_byte_string				\
 S	|const char *|wrap_wsetlocale					\
 				|const int category			\
 				|NULLOK const char *locale
-#   endif /* defined(WIN32) */
+#   endif
 #   if defined(WIN32) || ( defined(USE_POSIX_2008_LOCALE) && \
        !defined(USE_QUERYLOCALE) )
 S	|const char *|find_locale_from_environment			\
 				|const unsigned int index
-#   endif /* defined(WIN32) || ( defined(USE_POSIX_2008_LOCALE) && \
-             !defined(USE_QUERYLOCALE) ) */
+#   endif
 # endif /* defined(USE_LOCALE) */
 # if defined(USE_POSIX_2008_LOCALE) || defined(DEBUGGING)
 S	|const char *|get_displayable_string				\
 				|NN const char * const s		\
 				|NN const char * const e		\
 				|const bool is_utf8
-# endif /* defined(USE_POSIX_2008_LOCALE) || defined(DEBUGGING) */
+# endif
 #endif /* defined(PERL_IN_LOCALE_C) */
 #if defined(PERL_IN_MALLOC_C)
 ST	|int	|adjust_size_and_find_bucket				\
 				|NN size_t *nbytes_p
-#endif /* defined(PERL_IN_MALLOC_C) */
+#endif
 #if defined(PERL_IN_MG_C)
 
 S	|void	|fixup_errno_string					\
@@ -4513,7 +4497,7 @@ S	|void	|save_magic_flags					\
 				|U32 flags
 S	|void	|unwind_handler_stack					\
 				|NULLOK const void *p
-#endif /* defined(PERL_IN_MG_C) */
+#endif
 #if defined(PERL_IN_MG_C) || defined(PERL_IN_PP_C)
 Tp	|bool	|translate_substr_offsets				\
 				|STRLEN curlen				\
@@ -4523,7 +4507,7 @@ Tp	|bool	|translate_substr_offsets				\
 				|bool len_is_uv 			\
 				|NN STRLEN *posp			\
 				|NN STRLEN *lenp
-#endif /* defined(PERL_IN_MG_C) || defined(PERL_IN_PP_C) */
+#endif
 #if defined(PERL_IN_MRO_C)
 S	|void	|mro_clean_isarev					\
 				|NN HV * const isa			\
@@ -4541,11 +4525,11 @@ S	|void	|mro_gather_and_rename					\
 Sd	|AV *	|mro_get_linear_isa_dfs 				\
 				|NN HV *stash				\
 				|U32 level
-#endif /* defined(PERL_IN_MRO_C) */
+#endif
 #if defined(PERL_IN_NUMERIC_C)
 S	|void	|output_non_portable					\
 				|const U8 shift
-#endif /* defined(PERL_IN_NUMERIC_C) */
+#endif
 #if defined(PERL_IN_OP_C)
 S	|void	|apply_attrs	|NN HV *stash				\
 				|NN SV *target				\
@@ -4641,7 +4625,7 @@ S	|OP *	|voidnonfinal	|NULLOK OP *o
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_PAD_C)
 Ti	|bool	|PadnameIN_SCOPE|NN const PADNAME * const pn		\
 				|const U32 seq
-#endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PAD_C) */
+#endif
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C)
 p	|void	|check_hash_fields_and_hekify				\
 				|NULLOK UNOP *rop			\
@@ -4657,13 +4641,12 @@ p	|void	|warn_elem_scalar_context				\
 				|NN SV *name				\
 				|bool is_hash				\
 				|bool is_slice
-#endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
+#endif
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_PERLY_C) || \
     defined(PERL_IN_TOKE_C)
 Mbp	|OP *	|ref		|NULLOK OP *o				\
 				|I32 type
-#endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PERLY_C) || \
-          defined(PERL_IN_TOKE_C) */
+#endif
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY)
 ERTi	|STRLEN *|get_invlist_iter_addr 				\
 				|NN SV *invlist
@@ -4675,7 +4658,7 @@ ERTi	|bool	|invlist_iternext					\
 				|NN SV *invlist 			\
 				|NN UV *start				\
 				|NN UV *end
-#endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY) */
+#endif
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_SV_C)
 p	|void	|report_redefined_cv					\
 				|NN const SV *name			\
@@ -4687,7 +4670,7 @@ Rp	|SV *	|varname	|NULLOK const GV * const gv		\
 				|NULLOK const SV * const keyname	\
 				|SSize_t aindex 			\
 				|int subscript_type
-#endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_SV_C) */
+#endif
 #if defined(PERL_IN_PAD_C)
 Sd	|PADOFFSET|pad_alloc_name					\
 				|NN PADNAME *name			\
@@ -4710,15 +4693,15 @@ Sd	|void	|pad_reset
 # if defined(DEBUGGING)
 Sd	|void	|cv_dump	|NN const CV *cv			\
 				|NN const char *title
-# endif /* defined(DEBUGGING) */
-#endif /* defined(PERL_IN_PAD_C) */
+# endif
+#endif
 #if defined(PERL_IN_PEEP_C)
 S	|void	|finalize_op	|NN OP *o
 S	|void	|optimize_op	|NN OP *o
 Sd	|OP *	|traverse_op_tree					\
 				|NN OP *top				\
 				|NN OP *o
-#endif /* defined(PERL_IN_PEEP_C) */
+#endif
 #if defined(PERL_IN_PERL_C)
 S	|void	|find_beginning |NN SV *linestr_sv			\
 				|NN PerlIO *rsfp
@@ -4758,10 +4741,10 @@ S	|SV *	|incpush_if_exists					\
 				|NN AV * const av			\
 				|NN SV *dir				\
 				|NN SV * const stem
-# endif /* !defined(PERL_IS_MINIPERL) */
+# endif
 # if !defined(SETUID_SCRIPTS_ARE_SECURE_NOW)
 So	|void	|validate_suid	|NN PerlIO *rsfp
-# endif /* !defined(SETUID_SCRIPTS_ARE_SECURE_NOW) */
+# endif
 #endif /* defined(PERL_IN_PERL_C) */
 #if defined(PERL_IN_PERL_C) || defined(PERL_IN_REGCOMP_ANY) || \
     defined(PERL_IN_UTF8_C)
@@ -4770,15 +4753,14 @@ EXp	|bool	|_invlistEQ	|NN SV * const a			\
 				|const bool complement_b
 ERXp	|SV *	|_new_invlist_C_array					\
 				|NN const UV * const list
-#endif /* defined(PERL_IN_PERL_C) || defined(PERL_IN_REGCOMP_ANY) || \
-          defined(PERL_IN_UTF8_C) */
+#endif
 #if defined(PERL_IN_PP_C)
 S	|size_t |do_chomp	|NN SV *retval				\
 				|NN SV *sv				\
 				|bool chomping
 S	|OP *	|do_delete_local
 RS	|SV *	|refto		|NN SV *sv
-#endif /* defined(PERL_IN_PP_C) */
+#endif
 #if defined(PERL_IN_PP_C) || defined(PERL_IN_PP_HOT_C)
 RTi	|bool	|lossless_NV_to_IV					\
 				|const NV nv				\
@@ -4788,21 +4770,20 @@ Reop	|GV *	|softref2xv	|NN SV * const sv			\
 				|NN const char * const what		\
 				|const svtype type			\
 				|NN SV ***spp
-#endif /* defined(PERL_IN_PP_C) || defined(PERL_IN_PP_HOT_C) */
+#endif
 #if defined(PERL_IN_PP_C)   || defined(PERL_IN_REGCOMP_ANY) || \
     defined(PERL_IN_TOKE_C) || defined(PERL_IN_UNIVERSAL_C)
 ETi	|const char *|get_regex_charset_name				\
 				|const U32 flags			\
 				|NN STRLEN * const lenp
-#endif /* defined(PERL_IN_PP_C)   || defined(PERL_IN_REGCOMP_ANY) || \
-          defined(PERL_IN_TOKE_C) || defined(PERL_IN_UNIVERSAL_C) */
+#endif
 #if defined(PERL_IN_PP_C) || defined(PERL_IN_UTF8_C)
 p	|UV	|_to_upper_title_latin1 				\
 				|const U8 c				\
 				|NN U8 *p				\
 				|NN STRLEN *lenp			\
 				|const char S_or_s
-#endif /* defined(PERL_IN_PP_C) || defined(PERL_IN_UTF8_C) */
+#endif
 #if defined(PERL_IN_PP_CTL_C)
 RS	|PerlIO *|check_type_and_open					\
 				|NN SV *name
@@ -4850,20 +4831,20 @@ S	|void	|save_lines	|NULLOK AV *array			\
 				|NN SV *sv
 # if !defined(PERL_DISABLE_PMC)
 RS	|PerlIO *|doopen_pm	|NN SV *name
-# endif /* !defined(PERL_DISABLE_PMC) */
+# endif
 #endif /* defined(PERL_IN_PP_CTL_C) */
 #if defined(PERL_IN_PP_CTL_C) || defined(PERL_IN_UTIL_C)
 p	|bool	|invoke_exception_hook					\
 				|NULLOK SV *ex				\
 				|bool warn
-#endif /* defined(PERL_IN_PP_CTL_C) || defined(PERL_IN_UTIL_C) */
+#endif
 #if defined(PERL_IN_PP_HOT_C)
 S	|void	|do_oddball	|NN SV **oddkey 			\
 				|NN SV **firstkey
 i	|HV *	|opmethod_stash |NN SV *meth
 IR	|bool	|should_we_output_Debug_r				\
 				|NN regexp *prog
-#endif /* defined(PERL_IN_PP_HOT_C) */
+#endif
 #if defined(PERL_IN_PP_PACK_C)
 S	|int	|div128 	|NN SV *pnum				\
 				|NN bool *done
@@ -4944,7 +4925,7 @@ i	|I32	|amagic_cmp_locale_desc 				\
 				|NN SV * const str2
 i	|I32	|cmp_locale_desc|NN SV * const str1			\
 				|NN SV * const str2
-# endif /* defined(USE_LOCALE_COLLATE) */
+# endif
 #endif /* defined(PERL_IN_PP_SORT_C) */
 #if defined(PERL_IN_PP_SYS_C)
 S	|OP *	|doform 	|NN CV *cv				\
@@ -4955,8 +4936,8 @@ S	|SV *	|space_join_names_mortal				\
 # if !defined(HAS_MKDIR) || !defined(HAS_RMDIR)
 RS	|int	|dooneliner	|NN const char *cmd			\
 				|NN const char *filename
-# endif /* !defined(HAS_MKDIR) || !defined(HAS_RMDIR) */
-#endif /* defined(PERL_IN_PP_SYS_C) */
+# endif
+#endif
 #if defined(PERL_IN_REGCOMP_ANY)
 Ep	|void	|add_above_Latin1_folds 				\
 				|NN RExC_state_t *pRExC_state		\
@@ -5043,12 +5024,12 @@ ES	|void	|dump_trie_interim_table				\
 				|NN AV *revcharmap			\
 				|U32 next_alloc 			\
 				|U32 depth
-# endif /* defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING) */
+# endif
 #endif /* defined(PERL_IN_REGCOMP_ANY) */
 #if defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_SV_C)
 EXp	|SV *	|invlist_clone	|NN SV * const invlist			\
 				|NULLOK SV *newlist
-#endif /* defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_SV_C) */
+#endif
 #if defined(PERL_IN_REGCOMP_C)
 ES	|AV *	|add_multi_match|NULLOK AV *multi_char_matches		\
 				|NN SV *multi_string			\
@@ -5235,8 +5216,8 @@ ES	|void	|dump_regex_sets_structures				\
 				|NN AV *stack				\
 				|const IV fence 			\
 				|NN AV *fence_stack
-#   endif /* defined(ENABLE_REGEX_SETS_DEBUGGING) */
-# endif /* defined(DEBUGGING) */
+#   endif
+# endif
 #endif /* defined(PERL_IN_REGCOMP_C) */
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGCOMP_INVLIST_C)
 Ep	|void	|populate_bitmap_from_invlist				\
@@ -5249,28 +5230,26 @@ Ep	|void	|populate_invlist_from_bitmap				\
 				|const Size_t bitmap_len		\
 				|NN SV **invlist			\
 				|const UV offset
-#endif /* defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGCOMP_INVLIST_C) */
+#endif
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
     defined(PERL_IN_TOKE_C)
 ERp	|bool	|is_grapheme	|NN const U8 *strbeg			\
 				|NN const U8 *s 			\
 				|NN const U8 *strend			\
 				|const UV cp
-#endif /* defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
-          defined(PERL_IN_TOKE_C) */
+#endif
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
     defined(PERL_IN_UTF8_C)
 ETXp	|UV	|_to_fold_latin1|const U8 c				\
 				|NN U8 *p				\
 				|NN STRLEN *lenp			\
 				|const unsigned int flags
-#endif /* defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
-          defined(PERL_IN_UTF8_C) */
+#endif
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_TOKE_C)
 ERTXp	|bool	|regcurly	|NN const char *s			\
 				|NN const char *e			\
 				|NULLOK const char *result[5]
-#endif /* defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_TOKE_C) */
+#endif
 #if defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING)
 ES	|U8	|put_charclass_bitmap_innards				\
 				|NN SV *sv				\
@@ -5302,7 +5281,7 @@ ES	|void	|regdump_extflags					\
 ES	|void	|regdump_intflags					\
 				|NULLOK const char *lead		\
 				|const U32 flags
-#endif /* defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING) */
+#endif
 #if defined(PERL_IN_REGCOMP_INVLIST_C) && !defined(PERL_EXT_RE_BUILD)
 ES	|void	|_append_range_to_invlist				\
 				|NN SV * const invlist			\
@@ -5504,7 +5483,7 @@ ES	|void	|dump_exec_pos	|NN const char *locinput		\
 EFp	|int	|re_exec_indentf|NN const char *fmt			\
 				|U32 depth				\
 				|...
-# endif /* defined(DEBUGGING) */
+# endif
 #endif /* defined(PERL_IN_REGEXEC_C) */
 #if defined(PERL_IN_REGEX_ENGINE)
 CRip	|bool	|check_regnode_after					\
@@ -5549,7 +5528,7 @@ EFp	|int	|re_indentf	|NN const char *fmt			\
 				|...
 Efp	|int	|re_printf	|NN const char *fmt			\
 				|...
-# endif /* defined(DEBUGGING) */
+# endif
 # if defined(PERL_EXT_RE_BUILD)
 Ep	|SV *	|get_re_gclass_aux_data 				\
 				|NULLOK const regexp *prog		\
@@ -5558,7 +5537,7 @@ Ep	|SV *	|get_re_gclass_aux_data 				\
 				|NULLOK SV **listsvp			\
 				|NULLOK SV **lonly_utf8_locale		\
 				|NULLOK SV **output_invlist
-# else /* if !defined(PERL_EXT_RE_BUILD) */
+# else
 Ep	|SV *	|get_regclass_aux_data					\
 				|NULLOK const regexp *prog		\
 				|NN const struct regnode *node		\
@@ -5566,7 +5545,7 @@ Ep	|SV *	|get_regclass_aux_data					\
 				|NULLOK SV **listsvp			\
 				|NULLOK SV **lonly_utf8_locale		\
 				|NULLOK SV **output_invlist
-# endif /* !defined(PERL_EXT_RE_BUILD) */
+# endif
 #endif /* defined(PERL_IN_REGEX_ENGINE) */
 #if defined(PERL_IN_SCOPE_C)
 S	|void	|save_pushptri32ptr					\
@@ -5576,7 +5555,7 @@ S	|void	|save_pushptri32ptr					\
 				|const int type
 Sd	|SV *	|save_scalar_at |NN SV **sptr				\
 				|const U32 flags
-#endif /* defined(PERL_IN_SCOPE_C) */
+#endif
 #if defined(PERL_IN_SV_C)
 S	|void	|anonymise_cv_maybe					\
 				|NN GV *gv				\
@@ -5667,20 +5646,20 @@ S	|I32	|visit		|NN SVFUNC_t f				\
 				|const U32 mask
 # if defined(DEBUGGING)
 S	|void	|del_sv 	|NN SV *p
-# endif /* defined(DEBUGGING) */
+# endif
 # if !defined(NV_PRESERVES_UV)
 #   if defined(DEBUGGING)
 S	|int	|sv_2iuv_non_preserve					\
 				|NN SV * const sv			\
 				|I32 numtype
-#   else /* if !defined(DEBUGGING) */
+#   else
 S	|int	|sv_2iuv_non_preserve					\
 				|NN SV * const sv
-#   endif /* !defined(DEBUGGING) */
-# endif /* !defined(NV_PRESERVES_UV) */
+#   endif
+# endif
 # if defined(PERL_DEBUG_READONLY_COW)
 S	|void	|sv_buf_to_rw	|NN SV *sv
-# endif /* defined(PERL_DEBUG_READONLY_COW) */
+# endif
 # if defined(USE_ITHREADS)
 RS	|SV *	|sv_dup_common	|NN const SV * const ssv		\
 				|NN CLONE_PARAMS * const param
@@ -5694,7 +5673,7 @@ S	|SV **	|sv_dup_inc_multiple					\
 				|NN CLONE_PARAMS * const param
 S	|void	|unreferenced_to_tmp_stack				\
 				|NN AV * const unreferenced
-# endif /* defined(USE_ITHREADS) */
+# endif
 #endif /* defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_TOKE_C)
 S	|int	|ao		|int toketype
@@ -5785,13 +5764,13 @@ Sf	|void	|printbuf	|NN const char * const fmt		\
 				|NN const char * const s
 S	|int	|tokereport	|I32 rv 				\
 				|NN const YYSTYPE *lvalp
-# endif /* defined(DEBUGGING) */
+# endif
 # if defined(PERL_CR_FILTER)
 S	|I32	|cr_textfilter	|int idx				\
 				|NULLOK SV *sv				\
 				|int maxlen
 S	|void	|strip_return	|NN SV *sv
-# endif /* defined(PERL_CR_FILTER) */
+# endif
 # if !defined(PERL_NO_UTF16_FILTER)
 S	|U8 *	|add_utf16_textfilter					\
 				|NN U8 * const s			\
@@ -5800,7 +5779,7 @@ S	|I32	|utf16_textfilter					\
 				|int idx				\
 				|NN SV *sv				\
 				|int maxlen
-# endif /* !defined(PERL_NO_UTF16_FILTER) */
+# endif
 #endif /* defined(PERL_IN_TOKE_C) */
 #if defined(PERL_IN_UNIVERSAL_C)
 GS	|bool	|isa_lookup	|NULLOK HV *stash			\
@@ -5814,7 +5793,7 @@ GS	|bool	|sv_derived_from_svpvn					\
 				|NULLOK const char *name		\
 				|const STRLEN len			\
 				|U32 flags
-#endif /* defined(PERL_IN_UNIVERSAL_C) */
+#endif
 #if defined(PERL_IN_UTF8_C)
 RS	|UV	|check_locale_boundary_crossing 			\
 				|NN const U8 * const p			\
@@ -5882,7 +5861,7 @@ S	|void	|warn_on_first_deprecated_use				\
 				|const bool use_locale			\
 				|NN const char * const file		\
 				|const unsigned line
-# endif /* 0 */
+# endif
 #endif /* defined(PERL_IN_UTF8_C) */
 #if defined(PERL_IN_UTIL_C)
 S	|bool	|ckwarn_common	|U32 w
@@ -5906,11 +5885,11 @@ ST	|void	|mem_log_common |enum mem_log_type mlt			\
 				|NN const char *filename		\
 				|const int linenumber			\
 				|NN const char *funcname
-# endif /* defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL) */
+# endif
 # if defined(PERL_USES_PL_PIDSTATUS)
 S	|void	|pidgone	|Pid_t pid				\
 				|int status
-# endif /* defined(PERL_USES_PL_PIDSTATUS) */
+# endif
 #endif /* defined(PERL_IN_UTIL_C) */
 #if defined(PERL_MEM_LOG)
 CTp	|Malloc_t|mem_log_alloc |const UV nconst			\
@@ -5941,7 +5920,7 @@ CTp	|Malloc_t|mem_log_realloc					\
 				|NN const char *filename		\
 				|const int linenumber			\
 				|NN const char *funcname
-#endif /* defined(PERL_MEM_LOG) */
+#endif
 #if !defined(PERL_NO_INLINE_FUNCTIONS)
 Cipx	|void	|cx_popblock	|NN PERL_CONTEXT *cx
 Cipx	|void	|cx_popeval	|NN PERL_CONTEXT *cx
@@ -5990,19 +5969,19 @@ CTp	|Signal_t|csighandler	|int sig				\
 Tp	|Signal_t|sighandler	|int sig				\
 				|NULLOK Siginfo_t *info 		\
 				|NULLOK void *uap
-#else /* if !defined(PERL_USE_3ARG_SIGHANDLER) */
+#else
 CTp	|Signal_t|csighandler	|int sig
 Tp	|Signal_t|sighandler	|int sig
-#endif /* !defined(PERL_USE_3ARG_SIGHANDLER) */
+#endif
 #if defined(U64TYPE)
 CRTip	|unsigned|lsbit_pos64	|U64 word
 CRTip	|unsigned|msbit_pos64	|U64 word
 CRTip	|unsigned|single_1bit_pos64					\
 				|U64 word
-#endif /* defined(U64TYPE) */
+#endif
 #if defined(UNLINK_ALL_VERSIONS)
 Cp	|I32	|unlnk		|NN const char *f
-#endif /* defined(UNLINK_ALL_VERSIONS) */
+#endif
 #if defined(USE_C_BACKTRACE)
 Adp	|bool	|dump_c_backtrace					\
 				|NN PerlIO *fp				\
@@ -6016,7 +5995,7 @@ dp	|Perl_c_backtrace *|get_c_backtrace				\
 Adp	|SV *	|get_c_backtrace_dump					\
 				|int max_depth				\
 				|int skip
-#endif /* defined(USE_C_BACKTRACE) */
+#endif
 #if defined(USE_DTRACE)
 EXop	|void	|dtrace_probe_call					\
 				|NN CV *cv				\
@@ -6027,7 +6006,7 @@ EXop	|void	|dtrace_probe_load					\
 EXop	|void	|dtrace_probe_op|NN const OP *op
 EXop	|void	|dtrace_probe_phase					\
 				|enum perl_phase phase
-#endif /* defined(USE_DTRACE) */
+#endif
 #if defined(USE_ITHREADS)
 Adpx	|PADOFFSET|alloccopstash|NN HV *hv
 CRp	|void * |any_dup	|NULLOK void *v 			\
@@ -6095,11 +6074,11 @@ ARp	|SV *	|sv_dup_inc	|NULLOK const SV * const ssv		\
 # if defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C)
 p	|void	|op_relocate_sv |NN SV **svp				\
 				|NN PADOFFSET *targp
-# endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
+# endif
 #else /* if !defined(USE_ITHREADS) */
 Adm	|void	|CopFILEGV_set	|NN COP *c				\
 				|NN GV *gv
-#endif /* !defined(USE_ITHREADS) */
+#endif
 #if defined(USE_LOCALE_COLLATE)
 p	|int	|magic_freecollxfrm					\
 				|NN SV *sv				\
@@ -6121,8 +6100,7 @@ Ep	|char * |mem_collxfrm_	|NN const char *input_string		\
 				|STRLEN len				\
 				|NN STRLEN *xlen			\
 				|bool utf8
-# endif /* defined(PERL_IN_LOCALE_C) || defined(PERL_IN_MATHOMS_C) || \
-           defined(PERL_IN_SV_C) */
+# endif
 #endif /* defined(USE_LOCALE_COLLATE) */
 #if defined(USE_PERLIO)
 Adhp	|void	|PerlIO_clearerr|NULLOK PerlIO *f
@@ -6170,31 +6148,31 @@ Adhp	|SSize_t|PerlIO_write	|NULLOK PerlIO *f			\
 #endif /* defined(USE_PERLIO) */
 #if defined(USE_PERL_SWITCH_LOCALE_CONTEXT)
 CTop	|void	|switch_locale_context
-#endif /* defined(USE_PERL_SWITCH_LOCALE_CONTEXT) */
+#endif
 #if defined(USE_QUADMATH)
 Tdp	|bool	|quadmath_format_needed 				\
 				|NN const char *format
 Tdp	|bool	|quadmath_format_valid					\
 				|NN const char *format
-#endif /* defined(USE_QUADMATH) */
+#endif
 #if defined(VMS) || defined(WIN32)
 Cp	|int	|do_aspawn	|NULLOK SV *really			\
 				|NN SV **mark				\
 				|NN SV **sp
 Cp	|int	|do_spawn	|NN char *cmd
 Cp	|int	|do_spawn_nowait|NN char *cmd
-#endif /* defined(VMS) || defined(WIN32) */
+#endif
 #if defined(WIN32)
 CRTdp	|void * |get_context
 p	|bool	|get_win32_message_utf8ness				\
 				|NULLOK const char *string
 Teor	|void	|win32_croak_not_implemented				\
 				|NN const char *fname
-#else /* if !defined(WIN32) */
+#else
 p	|bool	|do_exec3	|NN const char *incmd			\
 				|int fd 				\
 				|int do_report
 CRTdip	|void * |get_context
-#endif /* !defined(WIN32) */
+#endif
 
 : ex: set ts=8 sts=4 sw=4 noet:

--- a/embed.h
+++ b/embed.h
@@ -1128,8 +1128,9 @@
 #     define PerlSock_accept_cloexec(a,b,c)     Perl_PerlSock_accept_cloexec(aTHX_ a,b,c)
 #     define PerlSock_socket_cloexec(a,b,c)     Perl_PerlSock_socket_cloexec(aTHX_ a,b,c)
 #   endif
-#   if defined(HAS_SOCKETPAIR) || ( defined(AF_INET) && defined(HAS_SOCKET) \
-       && defined(PF_INET) && defined(SOCK_DGRAM) )
+#   if   defined(HAS_SOCKETPAIR) ||                                     \
+       ( defined(AF_INET) && defined(HAS_SOCKET) && defined(PF_INET) && \
+         defined(SOCK_DGRAM) )
 #     define PerlSock_socketpair_cloexec(a,b,c,d) Perl_PerlSock_socketpair_cloexec(aTHX_ a,b,c,d)
 #   endif
 #   if defined(_MSC_VER)
@@ -1230,7 +1231,7 @@
 #     define ck_tell(a)                         Perl_ck_tell(aTHX_ a)
 #     define ck_trunc(a)                        Perl_ck_trunc(aTHX_ a)
 #     define ck_trycatch(a)                     Perl_ck_trycatch(aTHX_ a)
-#   endif /* defined(PERL_IN_GLOBALS_C) || defined(PERL_IN_OP_C) || \
+#   endif /* defined(PERL_IN_GLOBALS_C) || defined(PERL_IN_OP_C) ||
              defined(PERL_IN_PEEP_C) */
 #   if defined(PERL_IN_GV_C)
 #     define find_default_stash(a,b,c,d,e,f)    S_find_default_stash(aTHX_ a,b,c,d,e,f)
@@ -1310,8 +1311,9 @@
 #         else
 #           define update_PL_curlocales_i(a,b,c) S_update_PL_curlocales_i(aTHX_ a,b,c)
 #         endif
-#       elif defined(USE_LOCALE_THREADS) && !defined(USE_THREAD_SAFE_LOCALE) \
-             && !defined(USE_THREAD_SAFE_LOCALE_EMULATION) /* && \
+#       elif  defined(USE_LOCALE_THREADS) &&                  \
+             !defined(USE_THREAD_SAFE_LOCALE) &&              \
+             !defined(USE_THREAD_SAFE_LOCALE_EMULATION) /* &&
              !defined(USE_POSIX_2008_LOCALE) */
 #         define less_dicey_setlocale_r(a,b)    S_less_dicey_setlocale_r(aTHX_ a,b)
 #         define less_dicey_void_setlocale_i(a,b,c) S_less_dicey_void_setlocale_i(aTHX_ a,b,c)
@@ -1319,9 +1321,9 @@
 #           define less_dicey_bool_setlocale_r(a,b) S_less_dicey_bool_setlocale_r(aTHX_ a,b)
 #         endif
 #       endif
-#       if !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) && \
-           ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || \
-           defined(WIN32) )
+#       if !(  defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) && \
+            ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) ||            \
+               defined(WIN32) )
 #         define calculate_LC_ALL(a)            S_calculate_LC_ALL(aTHX_ a)
 #       endif
 #       if defined(WIN32)
@@ -1330,8 +1332,8 @@
 #         define win32_setlocale(a,b)           S_win32_setlocale(aTHX_ a,b)
 #         define wrap_wsetlocale(a,b)           S_wrap_wsetlocale(aTHX_ a,b)
 #       endif
-#       if defined(WIN32) || ( defined(USE_POSIX_2008_LOCALE) && \
-           !defined(USE_QUERYLOCALE) )
+#       if   defined(WIN32) || \
+           ( defined(USE_POSIX_2008_LOCALE) && !defined(USE_QUERYLOCALE) )
 #         define find_locale_from_environment(a) S_find_locale_from_environment(aTHX_ a)
 #       endif
 #     endif /* defined(USE_LOCALE) */
@@ -1889,7 +1891,7 @@
 #     define invlist_replace_list_destroys_src(a,b) S_invlist_replace_list_destroys_src(aTHX_ a,b)
 #     define invlist_set_previous_index         S_invlist_set_previous_index
 #     define invlist_trim                       S_invlist_trim
-#   endif /* defined(PERL_IN_REGCOMP_INVLIST_C) && \
+#   endif /*  defined(PERL_IN_REGCOMP_INVLIST_C) &&
              !defined(PERL_EXT_RE_BUILD) */
 #   if defined(PERL_IN_REGCOMP_STUDY_C)
 #     define get_ANYOF_cp_list_for_ssc(a,b)     S_get_ANYOF_cp_list_for_ssc(aTHX_ a,b)
@@ -1972,16 +1974,16 @@
 #   define class_setup_stash(a)                 Perl_class_setup_stash(aTHX_ a)
 #   define class_wrap_method_body(a)            Perl_class_wrap_method_body(aTHX_ a)
 #   define croak_kw_unless_class(a)             Perl_croak_kw_unless_class(aTHX_ a)
-# endif /* defined(PERL_IN_CLASS_C) || defined(PERL_IN_OP_C)    || \
-           defined(PERL_IN_PAD_C)   || defined(PERL_IN_PERLY_C) || \
+# endif /* defined(PERL_IN_CLASS_C) || defined(PERL_IN_OP_C)    ||
+           defined(PERL_IN_PAD_C)   || defined(PERL_IN_PERLY_C) ||
            defined(PERL_IN_TOKE_C) */
 # if defined(PERL_IN_REGEX_ENGINE)
 #   define check_regnode_after(a,b)             Perl_check_regnode_after(aTHX_ a,b)
 #   define regnext(a)                           Perl_regnext(aTHX_ a)
 #   define regnode_after(a,b)                   Perl_regnode_after(aTHX_ a,b)
 #   if defined(DEBUGGING)
-#     if ( !defined(MULTIPLICITY) || defined(PERL_CORE) ) && ( \
-         defined(PERL_CORE)       || defined(PERL_EXT) )
+#     if ( !defined(MULTIPLICITY) || defined(PERL_CORE) ) && \
+         (  defined(PERL_CORE)    || defined(PERL_EXT) )
 #       define re_indentf(a,...)                Perl_re_indentf(aTHX_ a,__VA_ARGS__)
 #       define re_printf(...)                   Perl_re_printf(aTHX_ __VA_ARGS__)
 #     endif
@@ -2119,9 +2121,9 @@
 # endif /* defined(USE_ITHREADS) */
 # if defined(USE_LOCALE_COLLATE)
 #   define sv_collxfrm_flags(a,b,c)             Perl_sv_collxfrm_flags(aTHX_ a,b,c)
-#   if ( defined(PERL_CORE)      || defined(PERL_EXT) ) && ( \
-       defined(PERL_IN_LOCALE_C) || defined(PERL_IN_MATHOMS_C) || \
-       defined(PERL_IN_SV_C) )
+#   if ( defined(PERL_CORE)        || defined(PERL_EXT) ) &&        \
+       ( defined(PERL_IN_LOCALE_C) || defined(PERL_IN_MATHOMS_C) || \
+         defined(PERL_IN_SV_C) )
 #     define mem_collxfrm_(a,b,c,d)             Perl_mem_collxfrm_(aTHX_ a,b,c,d)
 #   endif
 # endif

--- a/embed.h
+++ b/embed.h
@@ -837,12 +837,6 @@
 #   define sv_setpvf_mg(a,...)                  Perl_sv_setpvf_mg(aTHX_ a,__VA_ARGS__)
 #   define warn(...)                            Perl_warn(aTHX_ __VA_ARGS__)
 #   define warner(a,...)                        Perl_warner(aTHX_ a,__VA_ARGS__)
-#   if defined(PERL_CORE)
-#     define tied_method(a,b,c,d,e,...)         Perl_tied_method(aTHX_ a,b,c,d,e,__VA_ARGS__)
-#     if defined(PERL_IN_REGCOMP_C)
-#       define re_croak(a,...)                  S_re_croak(aTHX_ a,__VA_ARGS__)
-#     endif /* defined(PERL_IN_REGCOMP_C) */
-#   endif /* defined(PERL_CORE) */
 # endif /* !defined(MULTIPLICITY) || defined(PERL_CORE) */
 # if defined(MYMALLOC)
 #   define dump_mstats(a)                       Perl_dump_mstats(aTHX_ a)
@@ -1107,11 +1101,6 @@
 #   define opslab_free_nopad(a)                 Perl_opslab_free_nopad(aTHX_ a)
 #   define parser_free_nexttoke_ops(a,b)        Perl_parser_free_nexttoke_ops(aTHX_ a,b)
 #   define should_warn_nl                       S_should_warn_nl
-#   if ( defined(AF_INET) && defined(HAS_SOCKET) && defined(PF_INET) && \
-       defined(SOCK_DGRAM) ) || defined(HAS_SOCKETPAIR)
-#     define PerlSock_socketpair_cloexec(a,b,c,d) Perl_PerlSock_socketpair_cloexec(aTHX_ a,b,c,d)
-#   endif /* ( defined(AF_INET) && defined(HAS_SOCKET) && defined(PF_INET) && \
-             defined(SOCK_DGRAM) ) || defined(HAS_SOCKETPAIR) */
 #   if defined(DEBUGGING)
 #     define get_debug_opts(a,b)                Perl_get_debug_opts(aTHX_ a,b)
 #     define set_padlist                        Perl_set_padlist
@@ -1140,11 +1129,22 @@
 #     define PerlSock_accept_cloexec(a,b,c)     Perl_PerlSock_accept_cloexec(aTHX_ a,b,c)
 #     define PerlSock_socket_cloexec(a,b,c)     Perl_PerlSock_socket_cloexec(aTHX_ a,b,c)
 #   endif /* defined(HAS_SOCKET) */
+#   if defined(HAS_SOCKETPAIR) || ( defined(AF_INET) && defined(HAS_SOCKET) \
+       && defined(PF_INET) && defined(SOCK_DGRAM) )
+#     define PerlSock_socketpair_cloexec(a,b,c,d) Perl_PerlSock_socketpair_cloexec(aTHX_ a,b,c,d)
+#   endif /* defined(HAS_SOCKETPAIR) || ( defined(AF_INET) && \
+             defined(HAS_SOCKET) && defined(PF_INET) && defined(SOCK_DGRAM) ) */
 #   if defined(_MSC_VER)
 #     define magic_regdatum_set(a,b)            Perl_magic_regdatum_set(aTHX_ a,b)
 #   else /* if !defined(_MSC_VER) */
 #     define magic_regdatum_set(a,b)            Perl_magic_regdatum_set(aTHX_ a,b)
 #   endif /* !defined(_MSC_VER) */
+#   if !defined(MULTIPLICITY) || defined(PERL_CORE)
+#     define tied_method(a,b,c,d,e,...)         Perl_tied_method(aTHX_ a,b,c,d,e,__VA_ARGS__)
+#     if defined(PERL_IN_REGCOMP_C)
+#       define re_croak(a,...)                  S_re_croak(aTHX_ a,__VA_ARGS__)
+#     endif /* defined(PERL_IN_REGCOMP_C) */
+#   endif /* !defined(MULTIPLICITY) || defined(PERL_CORE) */
 #   if defined(PERL_DEBUG_READONLY_COW)
 #     define sv_buf_to_ro(a)                    Perl_sv_buf_to_ro(aTHX_ a)
 #   endif /* defined(PERL_DEBUG_READONLY_COW) */
@@ -1286,13 +1286,6 @@
 #       else /* if !( defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L) ) */
 #         define my_langinfo_i(a,b,c,d,e,f)     S_my_langinfo_i(aTHX_ a,b,c,d,e,f)
 #       endif /* !( defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L) ) */
-#       if ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || \
-           defined(WIN32) ) && !( defined(USE_POSIX_2008_LOCALE) && \
-           defined(USE_QUERYLOCALE) )
-#         define calculate_LC_ALL(a)            S_calculate_LC_ALL(aTHX_ a)
-#       endif /* ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || \
-                 defined(WIN32) ) && !( defined(USE_POSIX_2008_LOCALE) && \
-                 defined(USE_QUERYLOCALE) ) */
 #       if defined(USE_LOCALE_COLLATE)
 #         define new_collate(a,b)               S_new_collate(aTHX_ a,b)
 #         if defined(DEBUGGING)
@@ -1328,21 +1321,28 @@
 #         if 0
 #           define less_dicey_bool_setlocale_r(a,b) S_less_dicey_bool_setlocale_r(aTHX_ a,b)
 #         endif /* 0 */
-#       endif /* ( defined(USE_LOCALE_THREADS) && \
+#       endif /* !defined(USE_POSIX_2008_LOCALE) && ( \
+                 defined(USE_LOCALE_THREADS) && \
                  !defined(USE_THREAD_SAFE_LOCALE) && \
-                 !defined(USE_THREAD_SAFE_LOCALE_EMULATION) ) && \
-                 !defined(USE_POSIX_2008_LOCALE) */
-#       if ( defined(USE_POSIX_2008_LOCALE) && !defined(USE_QUERYLOCALE) ) || \
-           defined(WIN32)
-#         define find_locale_from_environment(a) S_find_locale_from_environment(aTHX_ a)
-#       endif /* ( defined(USE_POSIX_2008_LOCALE) && \
-                 !defined(USE_QUERYLOCALE) ) || defined(WIN32) */
+                 !defined(USE_THREAD_SAFE_LOCALE_EMULATION) ) */
+#       if !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) && \
+           ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || \
+           defined(WIN32) )
+#         define calculate_LC_ALL(a)            S_calculate_LC_ALL(aTHX_ a)
+#       endif /* !( defined(USE_POSIX_2008_LOCALE) && \
+                 defined(USE_QUERYLOCALE) ) && ( !defined(LC_ALL) || \
+                 defined(USE_POSIX_2008_LOCALE)                   || defined(WIN32) ) */
 #       if defined(WIN32)
 #         define Win_byte_string_to_wstring     S_Win_byte_string_to_wstring
 #         define Win_wstring_to_byte_string     S_Win_wstring_to_byte_string
 #         define win32_setlocale(a,b)           S_win32_setlocale(aTHX_ a,b)
 #         define wrap_wsetlocale(a,b)           S_wrap_wsetlocale(aTHX_ a,b)
 #       endif /* defined(WIN32) */
+#       if defined(WIN32) || ( defined(USE_POSIX_2008_LOCALE) && \
+           !defined(USE_QUERYLOCALE) )
+#         define find_locale_from_environment(a) S_find_locale_from_environment(aTHX_ a)
+#       endif /* defined(WIN32) || ( defined(USE_POSIX_2008_LOCALE) && \
+                 !defined(USE_QUERYLOCALE) ) */
 #     endif /* defined(USE_LOCALE) */
 #     if defined(USE_POSIX_2008_LOCALE) || defined(DEBUGGING)
 #       define get_displayable_string(a,b,c)    S_get_displayable_string(aTHX_ a,b,c)
@@ -1419,9 +1419,6 @@
 #     define op_prune_chain_head                Perl_op_prune_chain_head
 #     define op_varname(a)                      Perl_op_varname(aTHX_ a)
 #     define warn_elem_scalar_context(a,b,c,d)  Perl_warn_elem_scalar_context(aTHX_ a,b,c,d)
-#     if defined(USE_ITHREADS)
-#       define op_relocate_sv(a,b)              Perl_op_relocate_sv(aTHX_ a,b)
-#     endif /* defined(USE_ITHREADS) */
 #   endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
 #   if defined(PERL_IN_OP_C) || defined(PERL_IN_SV_C)
 #     define report_redefined_cv(a,b,c)         Perl_report_redefined_cv(aTHX_ a,b,c)
@@ -1661,6 +1658,9 @@
 #     if !defined(PERL_IMPLICIT_SYS)
 #       define PerlEnv_putenv(a)                S_PerlEnv_putenv(aTHX_ a)
 #     endif /* !defined(PERL_IMPLICIT_SYS) */
+#     if defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C)
+#       define op_relocate_sv(a,b)              Perl_op_relocate_sv(aTHX_ a,b)
+#     endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
 #   endif /* defined(USE_ITHREADS) */
 #   if defined(USE_LOCALE_COLLATE)
 #     define magic_freecollxfrm(a,b)            Perl_magic_freecollxfrm(aTHX_ a,b)
@@ -1783,11 +1783,6 @@
 #   if defined(PERL_IN_GV_C) || defined(PERL_IN_UNIVERSAL_C)
 #     define gv_stashsvpvn_cached(a,b,c,d)      Perl_gv_stashsvpvn_cached(aTHX_ a,b,c,d)
 #   endif /* defined(PERL_IN_GV_C) || defined(PERL_IN_UNIVERSAL_C) */
-#   if ( defined(PERL_IN_LOCALE_C) || defined(PERL_IN_MATHOMS_C) || \
-       defined(PERL_IN_SV_C) ) && defined(USE_LOCALE_COLLATE)
-#     define mem_collxfrm_(a,b,c,d)             Perl_mem_collxfrm_(aTHX_ a,b,c,d)
-#   endif /* ( defined(PERL_IN_LOCALE_C) || defined(PERL_IN_MATHOMS_C) || \
-             defined(PERL_IN_SV_C) ) && defined(USE_LOCALE_COLLATE) */
 #   if defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY)
 #     define get_invlist_iter_addr              S_get_invlist_iter_addr
 #     define invlist_iterfinish                 S_invlist_iterfinish
@@ -1971,12 +1966,10 @@
 #     if defined(DEBUGGING)
 #       define debug_start_match(a,b,c,d,e)     S_debug_start_match(aTHX_ a,b,c,d,e)
 #       define dump_exec_pos(a,b,c,d,e,f,g)     S_dump_exec_pos(aTHX_ a,b,c,d,e,f,g)
+#       if !defined(MULTIPLICITY) || defined(PERL_CORE)
+#         define re_exec_indentf(a,...)         Perl_re_exec_indentf(aTHX_ a,__VA_ARGS__)
+#       endif /* !defined(MULTIPLICITY) || defined(PERL_CORE) */
 #     endif /* defined(DEBUGGING) */
-#     if ( !defined(MULTIPLICITY) || defined(PERL_CORE) ) && \
-         defined(DEBUGGING)
-#       define re_exec_indentf(a,...)           Perl_re_exec_indentf(aTHX_ a,__VA_ARGS__)
-#     endif /* ( !defined(MULTIPLICITY) || defined(PERL_CORE) ) && \
-               defined(DEBUGGING) */
 #   endif /* defined(PERL_IN_REGEXEC_C) */
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API)
@@ -2008,26 +2001,30 @@
 #   define check_regnode_after(a,b)             Perl_check_regnode_after(aTHX_ a,b)
 #   define regnext(a)                           Perl_regnext(aTHX_ a)
 #   define regnode_after(a,b)                   Perl_regnode_after(aTHX_ a,b)
-#   if defined(PERL_CORE) || defined(PERL_EXT)
-#     if defined(DEBUGGING)
+#   if defined(DEBUGGING)
+#     if ( !defined(MULTIPLICITY) || defined(PERL_CORE) ) && ( \
+         defined(PERL_CORE)       || defined(PERL_EXT) )
+#       define re_indentf(a,...)                Perl_re_indentf(aTHX_ a,__VA_ARGS__)
+#       define re_printf(...)                   Perl_re_printf(aTHX_ __VA_ARGS__)
+#     endif /* ( !defined(MULTIPLICITY) || defined(PERL_CORE) ) && ( \
+               defined(PERL_CORE)       || defined(PERL_EXT) ) */
+#     if defined(PERL_CORE) || defined(PERL_EXT)
 #       define debug_peep(a,b,c,d,e)            Perl_debug_peep(aTHX_ a,b,c,d,e)
 #       define debug_show_study_flags(a,b,c)    Perl_debug_show_study_flags(aTHX_ a,b,c)
 #       define debug_studydata(a,b,c,d,e,f,g)   Perl_debug_studydata(aTHX_ a,b,c,d,e,f,g)
 #       define dumpuntil(a,b,c,d,e,f,g,h)       Perl_dumpuntil(aTHX_ a,b,c,d,e,f,g,h)
 #       define regprop(a,b,c,d,e)               Perl_regprop(aTHX_ a,b,c,d,e)
-#     endif /* defined(DEBUGGING) */
-#     if ( !defined(MULTIPLICITY) || defined(PERL_CORE) ) && \
-         defined(DEBUGGING)
-#       define re_indentf(a,...)                Perl_re_indentf(aTHX_ a,__VA_ARGS__)
-#       define re_printf(...)                   Perl_re_printf(aTHX_ __VA_ARGS__)
-#     endif /* ( !defined(MULTIPLICITY) || defined(PERL_CORE) ) && \
-               defined(DEBUGGING) */
-#     if defined(PERL_EXT_RE_BUILD)
+#     endif /* defined(PERL_CORE) || defined(PERL_EXT) */
+#   endif /* defined(DEBUGGING) */
+#   if defined(PERL_EXT_RE_BUILD)
+#     if defined(PERL_CORE) || defined(PERL_EXT)
 #       define get_re_gclass_aux_data(a,b,c,d,e,f) Perl_get_re_gclass_aux_data(aTHX_ a,b,c,d,e,f)
-#     else /* if !defined(PERL_EXT_RE_BUILD) */
-#       define get_regclass_aux_data(a,b,c,d,e,f) Perl_get_regclass_aux_data(aTHX_ a,b,c,d,e,f)
-#     endif /* !defined(PERL_EXT_RE_BUILD) */
-#   endif /* defined(PERL_CORE) || defined(PERL_EXT) */
+#     endif /* defined(PERL_CORE) || defined(PERL_EXT) */
+#   elif defined(PERL_CORE) || defined(PERL_EXT) /* && \
+         !defined(PERL_EXT_RE_BUILD) */
+#     define get_regclass_aux_data(a,b,c,d,e,f) Perl_get_regclass_aux_data(aTHX_ a,b,c,d,e,f)
+#   endif /* !defined(PERL_EXT_RE_BUILD) && ( defined(PERL_CORE) || \
+             defined(PERL_EXT) ) */
 # endif /* defined(PERL_IN_REGEX_ENGINE) */
 # if defined(PERL_IN_SV_C)
 #   define more_sv()                            Perl_more_sv(aTHX)
@@ -2147,6 +2144,13 @@
 # endif /* defined(USE_ITHREADS) */
 # if defined(USE_LOCALE_COLLATE)
 #   define sv_collxfrm_flags(a,b,c)             Perl_sv_collxfrm_flags(aTHX_ a,b,c)
+#   if ( defined(PERL_CORE)      || defined(PERL_EXT) ) && ( \
+       defined(PERL_IN_LOCALE_C) || defined(PERL_IN_MATHOMS_C) || \
+       defined(PERL_IN_SV_C) )
+#     define mem_collxfrm_(a,b,c,d)             Perl_mem_collxfrm_(aTHX_ a,b,c,d)
+#   endif /* ( defined(PERL_CORE)      || defined(PERL_EXT) ) && ( \
+             defined(PERL_IN_LOCALE_C) || defined(PERL_IN_MATHOMS_C) || \
+             defined(PERL_IN_SV_C) ) */
 # endif /* defined(USE_LOCALE_COLLATE) */
 # if defined(USE_PERLIO)
 #   define PerlIO_clearerr(a)                   Perl_PerlIO_clearerr(aTHX_ a)

--- a/embed.h
+++ b/embed.h
@@ -781,30 +781,29 @@
 # if defined(DEBUGGING)
 #   define pad_setsv(a,b)                       Perl_pad_setsv(aTHX_ a,b)
 #   define pad_sv(a)                            Perl_pad_sv(aTHX_ a)
-# endif /* defined(DEBUGGING) */
+# endif
 # if !defined(EBCDIC)
 #   define variant_byte_number                  Perl_variant_byte_number
-# endif /* !defined(EBCDIC) */
+# endif
 # if defined(F_FREESP) && !defined(HAS_CHSIZE) && !defined(HAS_TRUNCATE)
 #   define my_chsize(a,b)                       Perl_my_chsize(aTHX_ a,b)
-# endif /* defined(F_FREESP) && !defined(HAS_CHSIZE) && \
-           !defined(HAS_TRUNCATE) */
+# endif
 # if !defined(HAS_STRLCAT)
 #   define my_strlcat                           Perl_my_strlcat
-# endif /* !defined(HAS_STRLCAT) */
+# endif
 # if !defined(HAS_STRLCPY)
 #   define my_strlcpy                           Perl_my_strlcpy
-# endif /* !defined(HAS_STRLCPY) */
+# endif
 # if !defined(HAS_STRNLEN)
 #   define my_strnlen                           Perl_my_strnlen
-# endif /* !defined(HAS_STRNLEN) */
+# endif
 # if defined(HAVE_INTERP_INTERN)
 #   define sys_intern_clear()                   Perl_sys_intern_clear(aTHX)
 #   define sys_intern_init()                    Perl_sys_intern_init(aTHX)
 #   if defined(USE_ITHREADS)
 #     define sys_intern_dup(a,b)                Perl_sys_intern_dup(aTHX_ a,b)
-#   endif /* defined(USE_ITHREADS) */
-# endif /* defined(HAVE_INTERP_INTERN) */
+#   endif
+# endif
 # if defined(MULTIPLICITY)
 #   define croak_nocontext                      Perl_croak_nocontext
 #   define deb_nocontext                        Perl_deb_nocontext
@@ -844,15 +843,15 @@
 #   if defined(PERL_CORE)
 #     define malloc_good_size                   Perl_malloc_good_size
 #     define malloced_size                      Perl_malloced_size
-#   endif /* defined(PERL_CORE) */
-# endif /* defined(MYMALLOC) */
+#   endif
+# endif
 # if !defined(NO_MATHOMS)
 #   define sv_nolocking(a)                      Perl_sv_nolocking(aTHX_ a)
 #   define sv_nounlocking(a)                    Perl_sv_nounlocking(aTHX_ a)
 #   define utf8_to_uvchr(a,b)                   Perl_utf8_to_uvchr(aTHX_ a,b)
 #   define utf8_to_uvuni(a,b)                   Perl_utf8_to_uvuni(aTHX_ a,b)
 #   define utf8n_to_uvuni(a,b,c,d)              Perl_utf8n_to_uvuni(aTHX_ a,b,c,d)
-# endif /* !defined(NO_MATHOMS) */
+# endif
 # if defined(PERL_CORE)
 #   define PerlLIO_dup2_cloexec(a,b)            Perl_PerlLIO_dup2_cloexec(aTHX_ a,b)
 #   define PerlLIO_dup_cloexec(a)               Perl_PerlLIO_dup_cloexec(aTHX_ a)
@@ -1104,13 +1103,13 @@
 #   if defined(DEBUGGING)
 #     define get_debug_opts(a,b)                Perl_get_debug_opts(aTHX_ a,b)
 #     define set_padlist                        Perl_set_padlist
-#   endif /* defined(DEBUGGING) */
+#   endif
 #   if defined(DEBUG_LEAKING_SCALARS_FORK_DUMP)
 #     define dump_sv_child(a)                   Perl_dump_sv_child(aTHX_ a)
-#   endif /* defined(DEBUG_LEAKING_SCALARS_FORK_DUMP) */
+#   endif
 #   if !defined(HAS_GETENV_LEN)
 #     define getenv_len(a,b)                    Perl_getenv_len(aTHX_ a,b)
-#   endif /* !defined(HAS_GETENV_LEN) */
+#   endif
 #   if defined(HAS_MSG) || defined(HAS_SEM) || defined(HAS_SHM)
 #     define do_ipcctl(a,b,c)                   Perl_do_ipcctl(aTHX_ a,b,c)
 #     define do_ipcget(a,b,c)                   Perl_do_ipcget(aTHX_ a,b,c)
@@ -1118,69 +1117,68 @@
 #     define do_msgsnd(a,b)                     Perl_do_msgsnd(aTHX_ a,b)
 #     define do_semop(a,b)                      Perl_do_semop(aTHX_ a,b)
 #     define do_shmio(a,b,c)                    Perl_do_shmio(aTHX_ a,b,c)
-#   endif /* defined(HAS_MSG) || defined(HAS_SEM) || defined(HAS_SHM) */
+#   endif
 #   if defined(HAS_PIPE)
 #     define PerlProc_pipe_cloexec(a)           Perl_PerlProc_pipe_cloexec(aTHX_ a)
-#   endif /* defined(HAS_PIPE) */
+#   endif
 #   if !defined(HAS_RENAME)
 #     define same_dirent(a,b)                   Perl_same_dirent(aTHX_ a,b)
-#   endif /* !defined(HAS_RENAME) */
+#   endif
 #   if defined(HAS_SOCKET)
 #     define PerlSock_accept_cloexec(a,b,c)     Perl_PerlSock_accept_cloexec(aTHX_ a,b,c)
 #     define PerlSock_socket_cloexec(a,b,c)     Perl_PerlSock_socket_cloexec(aTHX_ a,b,c)
-#   endif /* defined(HAS_SOCKET) */
+#   endif
 #   if defined(HAS_SOCKETPAIR) || ( defined(AF_INET) && defined(HAS_SOCKET) \
        && defined(PF_INET) && defined(SOCK_DGRAM) )
 #     define PerlSock_socketpair_cloexec(a,b,c,d) Perl_PerlSock_socketpair_cloexec(aTHX_ a,b,c,d)
-#   endif /* defined(HAS_SOCKETPAIR) || ( defined(AF_INET) && \
-             defined(HAS_SOCKET) && defined(PF_INET) && defined(SOCK_DGRAM) ) */
+#   endif
 #   if defined(_MSC_VER)
 #     define magic_regdatum_set(a,b)            Perl_magic_regdatum_set(aTHX_ a,b)
-#   else /* if !defined(_MSC_VER) */
+#   else
 #     define magic_regdatum_set(a,b)            Perl_magic_regdatum_set(aTHX_ a,b)
-#   endif /* !defined(_MSC_VER) */
+#   endif
 #   if !defined(MULTIPLICITY) || defined(PERL_CORE)
 #     define tied_method(a,b,c,d,e,...)         Perl_tied_method(aTHX_ a,b,c,d,e,__VA_ARGS__)
 #     if defined(PERL_IN_REGCOMP_C)
 #       define re_croak(a,...)                  S_re_croak(aTHX_ a,__VA_ARGS__)
-#     endif /* defined(PERL_IN_REGCOMP_C) */
-#   endif /* !defined(MULTIPLICITY) || defined(PERL_CORE) */
+#     endif
+#   endif
 #   if defined(PERL_DEBUG_READONLY_COW)
 #     define sv_buf_to_ro(a)                    Perl_sv_buf_to_ro(aTHX_ a)
-#   endif /* defined(PERL_DEBUG_READONLY_COW) */
+#   endif
 #   if defined(PERL_DEBUG_READONLY_OPS)
 #     define Slab_to_ro(a)                      Perl_Slab_to_ro(aTHX_ a)
 #     define Slab_to_rw(a)                      Perl_Slab_to_rw(aTHX_ a)
-#   endif /* defined(PERL_DEBUG_READONLY_OPS) */
+#   endif
 #   if !defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION)
 #     define do_exec(a)                         Perl_do_exec(aTHX_ a)
-#   endif /* !defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION) */
+#   endif
 #   if defined(PERL_IN_AV_C)
 #     define get_aux_mg(a)                      S_get_aux_mg(aTHX_ a)
-#   endif /* defined(PERL_IN_AV_C) */
+#   endif
 #   if defined(PERL_IN_DEB_C)
 #     define deb_stack_n(a,b,c,d,e)             S_deb_stack_n(aTHX_ a,b,c,d,e)
-#   endif /* defined(PERL_IN_DEB_C) */
+#   endif
 #   if defined(PERL_IN_DOIO_C)
 #     define argvout_final(a,b,c)               S_argvout_final(aTHX_ a,b,c)
 #     define exec_failed(a,b,c)                 S_exec_failed(aTHX_ a,b,c)
 #     define ingroup(a,b)                       S_ingroup(aTHX_ a,b)
 #     define openn_cleanup(a,b,c,d,e,f,g,h,i,j,k,l,m) S_openn_cleanup(aTHX_ a,b,c,d,e,f,g,h,i,j,k,l,m)
 #     define openn_setup(a,b,c,d,e,f)           S_openn_setup(aTHX_ a,b,c,d,e,f)
-#   endif /* defined(PERL_IN_DOIO_C) */
+#   endif
 #   if defined(PERL_IN_DOOP_C)
 #     define do_trans_complex(a,b)              S_do_trans_complex(aTHX_ a,b)
 #     define do_trans_count(a,b)                S_do_trans_count(aTHX_ a,b)
 #     define do_trans_count_invmap(a,b)         S_do_trans_count_invmap(aTHX_ a,b)
 #     define do_trans_invmap(a,b)               S_do_trans_invmap(aTHX_ a,b)
 #     define do_trans_simple(a,b)               S_do_trans_simple(aTHX_ a,b)
-#   endif /* defined(PERL_IN_DOOP_C) */
+#   endif
 #   if defined(PERL_IN_DUMP_C)
 #     define deb_curcv(a)                       S_deb_curcv(aTHX_ a)
 #     define debprof(a)                         S_debprof(aTHX_ a)
 #     define pm_description(a)                  S_pm_description(aTHX_ a)
 #     define sequence_num(a)                    S_sequence_num(aTHX_ a)
-#   endif /* defined(PERL_IN_DUMP_C) */
+#   endif
 #   if defined(PERL_IN_GLOBALS_C) || defined(PERL_IN_OP_C) || \
        defined(PERL_IN_PEEP_C)
 #     define ck_anoncode(a)                     Perl_ck_anoncode(aTHX_ a)
@@ -1261,7 +1259,7 @@
 #     define unshare_hek_or_pvn(a,b,c,d)        S_unshare_hek_or_pvn(aTHX_ a,b,c,d)
 #     if !defined(PURIFY)
 #       define new_he()                         S_new_he(aTHX)
-#     endif /* !defined(PURIFY) */
+#     endif
 #   endif /* defined(PERL_IN_HV_C) */
 #   if defined(PERL_IN_LOCALE_C)
 #     define get_locale_string_utf8ness_i(a,b,c,d) S_get_locale_string_utf8ness_i(aTHX_ a,b,c,d)
@@ -1269,7 +1267,7 @@
 #     if defined(HAS_LOCALECONV)
 #       define my_localeconv(a)                 S_my_localeconv(aTHX_ a)
 #       define populate_hash_from_localeconv(a,b,c,d,e) S_populate_hash_from_localeconv(aTHX_ a,b,c,d,e)
-#     endif /* defined(HAS_LOCALECONV) */
+#     endif
 #     if defined(USE_LOCALE)
 #       define get_category_index               S_get_category_index
 #       define get_category_index_nowarn        S_get_category_index_nowarn
@@ -1280,29 +1278,28 @@
 #       define stdize_locale(a,b,c,d,e)         S_stdize_locale(aTHX_ a,b,c,d,e)
 #       if defined(DEBUGGING)
 #         define my_setlocale_debug_string_i(a,b,c,d) S_my_setlocale_debug_string_i(aTHX_ a,b,c,d)
-#       endif /* defined(DEBUGGING) */
+#       endif
 #       if defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L)
 #         define my_langinfo_i(a,b,c,d,e,f)     S_my_langinfo_i(aTHX_ a,b,c,d,e,f)
-#       else /* if !( defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L) ) */
+#       else
 #         define my_langinfo_i(a,b,c,d,e,f)     S_my_langinfo_i(aTHX_ a,b,c,d,e,f)
-#       endif /* !( defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L) ) */
+#       endif
 #       if defined(USE_LOCALE_COLLATE)
 #         define new_collate(a,b)               S_new_collate(aTHX_ a,b)
 #         if defined(DEBUGGING)
 #           define print_collxfrm_input_and_return(a,b,c,d,e) S_print_collxfrm_input_and_return(aTHX_ a,b,c,d,e)
-#         endif /* defined(DEBUGGING) */
-#       endif /* defined(USE_LOCALE_COLLATE) */
+#         endif
+#       endif
 #       if defined(USE_LOCALE_CTYPE)
 #         define is_codeset_name_UTF8           S_is_codeset_name_UTF8
 #         define new_ctype(a,b)                 S_new_ctype(aTHX_ a,b)
-#       endif /* defined(USE_LOCALE_CTYPE) */
+#       endif
 #       if defined(USE_LOCALE_NUMERIC)
 #         define new_numeric(a,b)               S_new_numeric(aTHX_ a,b)
-#       endif /* defined(USE_LOCALE_NUMERIC) */
+#       endif
 #       if defined(USE_PERL_SWITCH_LOCALE_CONTEXT) || defined(DEBUGGING)
 #         define get_LC_ALL_display()           S_get_LC_ALL_display(aTHX)
-#       endif /* defined(USE_PERL_SWITCH_LOCALE_CONTEXT) || \
-                 defined(DEBUGGING) */
+#       endif
 #       if defined(USE_POSIX_2008_LOCALE)
 #         define emulate_setlocale_i(a,b,c,d)   S_emulate_setlocale_i(aTHX_ a,b,c,d)
 #         define my_querylocale_i(a)            S_my_querylocale_i(aTHX_ a)
@@ -1310,9 +1307,9 @@
 #         define use_curlocale_scratch()        S_use_curlocale_scratch(aTHX)
 #         if defined(USE_QUERYLOCALE)
 #           define calculate_LC_ALL(a)          S_calculate_LC_ALL(aTHX_ a)
-#         else /* if !defined(USE_QUERYLOCALE) */
+#         else
 #           define update_PL_curlocales_i(a,b,c) S_update_PL_curlocales_i(aTHX_ a,b,c)
-#         endif /* !defined(USE_QUERYLOCALE) */
+#         endif
 #       elif defined(USE_LOCALE_THREADS) && !defined(USE_THREAD_SAFE_LOCALE) \
              && !defined(USE_THREAD_SAFE_LOCALE_EMULATION) /* && \
              !defined(USE_POSIX_2008_LOCALE) */
@@ -1320,37 +1317,31 @@
 #         define less_dicey_void_setlocale_i(a,b,c) S_less_dicey_void_setlocale_i(aTHX_ a,b,c)
 #         if 0
 #           define less_dicey_bool_setlocale_r(a,b) S_less_dicey_bool_setlocale_r(aTHX_ a,b)
-#         endif /* 0 */
-#       endif /* !defined(USE_POSIX_2008_LOCALE) && ( \
-                 defined(USE_LOCALE_THREADS) && \
-                 !defined(USE_THREAD_SAFE_LOCALE) && \
-                 !defined(USE_THREAD_SAFE_LOCALE_EMULATION) ) */
+#         endif
+#       endif
 #       if !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) && \
            ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || \
            defined(WIN32) )
 #         define calculate_LC_ALL(a)            S_calculate_LC_ALL(aTHX_ a)
-#       endif /* !( defined(USE_POSIX_2008_LOCALE) && \
-                 defined(USE_QUERYLOCALE) ) && ( !defined(LC_ALL) || \
-                 defined(USE_POSIX_2008_LOCALE)                   || defined(WIN32) ) */
+#       endif
 #       if defined(WIN32)
 #         define Win_byte_string_to_wstring     S_Win_byte_string_to_wstring
 #         define Win_wstring_to_byte_string     S_Win_wstring_to_byte_string
 #         define win32_setlocale(a,b)           S_win32_setlocale(aTHX_ a,b)
 #         define wrap_wsetlocale(a,b)           S_wrap_wsetlocale(aTHX_ a,b)
-#       endif /* defined(WIN32) */
+#       endif
 #       if defined(WIN32) || ( defined(USE_POSIX_2008_LOCALE) && \
            !defined(USE_QUERYLOCALE) )
 #         define find_locale_from_environment(a) S_find_locale_from_environment(aTHX_ a)
-#       endif /* defined(WIN32) || ( defined(USE_POSIX_2008_LOCALE) && \
-                 !defined(USE_QUERYLOCALE) ) */
+#       endif
 #     endif /* defined(USE_LOCALE) */
 #     if defined(USE_POSIX_2008_LOCALE) || defined(DEBUGGING)
 #       define get_displayable_string(a,b,c)    S_get_displayable_string(aTHX_ a,b,c)
-#     endif /* defined(USE_POSIX_2008_LOCALE) || defined(DEBUGGING) */
+#     endif
 #   endif /* defined(PERL_IN_LOCALE_C) */
 #   if defined(PERL_IN_MALLOC_C)
 #     define adjust_size_and_find_bucket        S_adjust_size_and_find_bucket
-#   endif /* defined(PERL_IN_MALLOC_C) */
+#   endif
 #   if defined(PERL_IN_MG_C)
 #     define fixup_errno_string(a)              S_fixup_errno_string(aTHX_ a)
 #     define magic_methcall1(a,b,c,d,e,f)       S_magic_methcall1(aTHX_ a,b,c,d,e,f)
@@ -1358,18 +1349,18 @@
 #     define restore_magic(a)                   S_restore_magic(aTHX_ a)
 #     define save_magic_flags(a,b,c)            S_save_magic_flags(aTHX_ a,b,c)
 #     define unwind_handler_stack(a)            S_unwind_handler_stack(aTHX_ a)
-#   endif /* defined(PERL_IN_MG_C) */
+#   endif
 #   if defined(PERL_IN_MG_C) || defined(PERL_IN_PP_C)
 #     define translate_substr_offsets           Perl_translate_substr_offsets
-#   endif /* defined(PERL_IN_MG_C) || defined(PERL_IN_PP_C) */
+#   endif
 #   if defined(PERL_IN_MRO_C)
 #     define mro_clean_isarev(a,b,c,d,e,f)      S_mro_clean_isarev(aTHX_ a,b,c,d,e,f)
 #     define mro_gather_and_rename(a,b,c,d,e)   S_mro_gather_and_rename(aTHX_ a,b,c,d,e)
 #     define mro_get_linear_isa_dfs(a,b)        S_mro_get_linear_isa_dfs(aTHX_ a,b)
-#   endif /* defined(PERL_IN_MRO_C) */
+#   endif
 #   if defined(PERL_IN_NUMERIC_C)
 #     define output_non_portable(a)             S_output_non_portable(aTHX_ a)
-#   endif /* defined(PERL_IN_NUMERIC_C) */
+#   endif
 #   if defined(PERL_IN_OP_C)
 #     define apply_attrs(a,b,c)                 S_apply_attrs(aTHX_ a,b,c)
 #     define apply_attrs_my(a,b,c,d)            S_apply_attrs_my(aTHX_ a,b,c,d)
@@ -1412,18 +1403,18 @@
 #   endif /* defined(PERL_IN_OP_C) */
 #   if defined(PERL_IN_OP_C) || defined(PERL_IN_PAD_C)
 #     define PadnameIN_SCOPE                    S_PadnameIN_SCOPE
-#   endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PAD_C) */
+#   endif
 #   if defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C)
 #     define check_hash_fields_and_hekify(a,b,c) Perl_check_hash_fields_and_hekify(aTHX_ a,b,c)
 #     define no_bareword_allowed(a)             Perl_no_bareword_allowed(aTHX_ a)
 #     define op_prune_chain_head                Perl_op_prune_chain_head
 #     define op_varname(a)                      Perl_op_varname(aTHX_ a)
 #     define warn_elem_scalar_context(a,b,c,d)  Perl_warn_elem_scalar_context(aTHX_ a,b,c,d)
-#   endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
+#   endif
 #   if defined(PERL_IN_OP_C) || defined(PERL_IN_SV_C)
 #     define report_redefined_cv(a,b,c)         Perl_report_redefined_cv(aTHX_ a,b,c)
 #     define varname(a,b,c,d,e,f)               Perl_varname(aTHX_ a,b,c,d,e,f)
-#   endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_SV_C) */
+#   endif
 #   if defined(PERL_IN_PAD_C)
 #     define pad_alloc_name(a,b,c,d)            S_pad_alloc_name(aTHX_ a,b,c,d)
 #     define pad_check_dup(a,b,c)               S_pad_check_dup(aTHX_ a,b,c)
@@ -1431,13 +1422,13 @@
 #     define pad_reset()                        S_pad_reset(aTHX)
 #     if defined(DEBUGGING)
 #       define cv_dump(a,b)                     S_cv_dump(aTHX_ a,b)
-#     endif /* defined(DEBUGGING) */
-#   endif /* defined(PERL_IN_PAD_C) */
+#     endif
+#   endif
 #   if defined(PERL_IN_PEEP_C)
 #     define finalize_op(a)                     S_finalize_op(aTHX_ a)
 #     define optimize_op(a)                     S_optimize_op(aTHX_ a)
 #     define traverse_op_tree(a,b)              S_traverse_op_tree(aTHX_ a,b)
-#   endif /* defined(PERL_IN_PEEP_C) */
+#   endif
 #   if defined(PERL_IN_PERL_C)
 #     define find_beginning(a,b)                S_find_beginning(aTHX_ a,b)
 #     define forbid_setid(a,b)                  S_forbid_setid(aTHX_ a,b)
@@ -1459,19 +1450,19 @@
 #     define usage()                            S_usage(aTHX)
 #     if !defined(PERL_IS_MINIPERL)
 #       define incpush_if_exists(a,b,c)         S_incpush_if_exists(aTHX_ a,b,c)
-#     endif /* !defined(PERL_IS_MINIPERL) */
+#     endif
 #   endif /* defined(PERL_IN_PERL_C) */
 #   if defined(PERL_IN_PP_C)
 #     define do_chomp(a,b,c)                    S_do_chomp(aTHX_ a,b,c)
 #     define do_delete_local()                  S_do_delete_local(aTHX)
 #     define refto(a)                           S_refto(aTHX_ a)
-#   endif /* defined(PERL_IN_PP_C) */
+#   endif
 #   if defined(PERL_IN_PP_C) || defined(PERL_IN_PP_HOT_C)
 #     define lossless_NV_to_IV                  S_lossless_NV_to_IV
-#   endif /* defined(PERL_IN_PP_C) || defined(PERL_IN_PP_HOT_C) */
+#   endif
 #   if defined(PERL_IN_PP_C) || defined(PERL_IN_UTF8_C)
 #     define _to_upper_title_latin1(a,b,c,d)    Perl__to_upper_title_latin1(aTHX_ a,b,c,d)
-#   endif /* defined(PERL_IN_PP_C) || defined(PERL_IN_UTF8_C) */
+#   endif
 #   if defined(PERL_IN_PP_CTL_C)
 #     define check_type_and_open(a)             S_check_type_and_open(aTHX_ a)
 #     define destroy_matcher(a)                 S_destroy_matcher(aTHX_ a)
@@ -1496,16 +1487,16 @@
 #     define save_lines(a,b)                    S_save_lines(aTHX_ a,b)
 #     if !defined(PERL_DISABLE_PMC)
 #       define doopen_pm(a)                     S_doopen_pm(aTHX_ a)
-#     endif /* !defined(PERL_DISABLE_PMC) */
+#     endif
 #   endif /* defined(PERL_IN_PP_CTL_C) */
 #   if defined(PERL_IN_PP_CTL_C) || defined(PERL_IN_UTIL_C)
 #     define invoke_exception_hook(a,b)         Perl_invoke_exception_hook(aTHX_ a,b)
-#   endif /* defined(PERL_IN_PP_CTL_C) || defined(PERL_IN_UTIL_C) */
+#   endif
 #   if defined(PERL_IN_PP_HOT_C)
 #     define do_oddball(a,b)                    S_do_oddball(aTHX_ a,b)
 #     define opmethod_stash(a)                  S_opmethod_stash(aTHX_ a)
 #     define should_we_output_Debug_r(a)        S_should_we_output_Debug_r(aTHX_ a)
-#   endif /* defined(PERL_IN_PP_HOT_C) */
+#   endif
 #   if defined(PERL_IN_PP_PACK_C)
 #     define div128(a,b)                        S_div128(aTHX_ a,b)
 #     define first_symbol                       S_first_symbol
@@ -1541,23 +1532,22 @@
 #       define amagic_cmp_locale(a,b)           S_amagic_cmp_locale(aTHX_ a,b)
 #       define amagic_cmp_locale_desc(a,b)      S_amagic_cmp_locale_desc(aTHX_ a,b)
 #       define cmp_locale_desc(a,b)             S_cmp_locale_desc(aTHX_ a,b)
-#     endif /* defined(USE_LOCALE_COLLATE) */
+#     endif
 #   endif /* defined(PERL_IN_PP_SORT_C) */
 #   if defined(PERL_IN_PP_SYS_C)
 #     define doform(a,b,c)                      S_doform(aTHX_ a,b,c)
 #     define space_join_names_mortal(a)         S_space_join_names_mortal(aTHX_ a)
 #     if !defined(HAS_MKDIR) || !defined(HAS_RMDIR)
 #       define dooneliner(a,b)                  S_dooneliner(aTHX_ a,b)
-#     endif /* !defined(HAS_MKDIR) || !defined(HAS_RMDIR) */
-#   endif /* defined(PERL_IN_PP_SYS_C) */
+#     endif
+#   endif
 #   if defined(PERL_IN_REGCOMP_INVLIST_C) && !defined(PERL_EXT_RE_BUILD)
 #     define initialize_invlist_guts(a,b)       S_initialize_invlist_guts(aTHX_ a,b)
-#   endif /* defined(PERL_IN_REGCOMP_INVLIST_C) && \
-             !defined(PERL_EXT_RE_BUILD) */
+#   endif
 #   if defined(PERL_IN_SCOPE_C)
 #     define save_pushptri32ptr(a,b,c,d)        S_save_pushptri32ptr(aTHX_ a,b,c,d)
 #     define save_scalar_at(a,b)                S_save_scalar_at(aTHX_ a,b)
-#   endif /* defined(PERL_IN_SCOPE_C) */
+#   endif
 #   if defined(PERL_IN_TOKE_C)
 #     define ao(a)                              S_ao(aTHX_ a)
 #     define check_uni()                        S_check_uni(aTHX)
@@ -1598,20 +1588,20 @@
 #     if defined(DEBUGGING)
 #       define printbuf(a,b)                    S_printbuf(aTHX_ a,b)
 #       define tokereport(a,b)                  S_tokereport(aTHX_ a,b)
-#     endif /* defined(DEBUGGING) */
+#     endif
 #     if defined(PERL_CR_FILTER)
 #       define cr_textfilter(a,b,c)             S_cr_textfilter(aTHX_ a,b,c)
 #       define strip_return(a)                  S_strip_return(aTHX_ a)
-#     endif /* defined(PERL_CR_FILTER) */
+#     endif
 #     if !defined(PERL_NO_UTF16_FILTER)
 #       define add_utf16_textfilter(a,b)        S_add_utf16_textfilter(aTHX_ a,b)
 #       define utf16_textfilter(a,b,c)          S_utf16_textfilter(aTHX_ a,b,c)
-#     endif /* !defined(PERL_NO_UTF16_FILTER) */
+#     endif
 #   endif /* defined(PERL_IN_TOKE_C) */
 #   if defined(PERL_IN_UNIVERSAL_C)
 #     define isa_lookup(a,b,c,d,e)              S_isa_lookup(aTHX_ a,b,c,d,e)
 #     define sv_derived_from_svpvn(a,b,c,d,e)   S_sv_derived_from_svpvn(aTHX_ a,b,c,d,e)
-#   endif /* defined(PERL_IN_UNIVERSAL_C) */
+#   endif
 #   if defined(PERL_IN_UTF8_C)
 #     define _to_utf8_case(a,b,c,d,e,f,g,h,i)   S__to_utf8_case(aTHX_ a,b,c,d,e,f,g,h,i)
 #     define check_locale_boundary_crossing(a,b,c,d) S_check_locale_boundary_crossing(aTHX_ a,b,c,d)
@@ -1628,7 +1618,7 @@
 #     define unexpected_non_continuation_text(a,b,c,d) S_unexpected_non_continuation_text(aTHX_ a,b,c,d)
 #     if 0
 #       define warn_on_first_deprecated_use(a,b,c,d,e,f) S_warn_on_first_deprecated_use(aTHX_ a,b,c,d,e,f)
-#     endif /* 0 */
+#     endif
 #   endif /* defined(PERL_IN_UTF8_C) */
 #   if defined(PERL_IN_UTIL_C)
 #     define ckwarn_common(a)                   S_ckwarn_common(aTHX_ a)
@@ -1637,19 +1627,19 @@
 #     define with_queued_errors(a)              S_with_queued_errors(aTHX_ a)
 #     if defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL)
 #       define mem_log_common                   S_mem_log_common
-#     endif /* defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL) */
+#     endif
 #     if defined(PERL_USES_PL_PIDSTATUS)
 #       define pidgone(a,b)                     S_pidgone(aTHX_ a,b)
-#     endif /* defined(PERL_USES_PL_PIDSTATUS) */
+#     endif
 #   endif /* defined(PERL_IN_UTIL_C) */
 #   if defined(PERL_USE_3ARG_SIGHANDLER)
 #     define sighandler                         Perl_sighandler
-#   else /* if !defined(PERL_USE_3ARG_SIGHANDLER) */
+#   else
 #     define sighandler                         Perl_sighandler
-#   endif /* !defined(PERL_USE_3ARG_SIGHANDLER) */
+#   endif
 #   if defined(USE_C_BACKTRACE)
 #     define get_c_backtrace(a,b)               Perl_get_c_backtrace(aTHX_ a,b)
-#   endif /* defined(USE_C_BACKTRACE) */
+#   endif
 #   if defined(USE_ITHREADS)
 #     define mro_meta_dup(a,b)                  Perl_mro_meta_dup(aTHX_ a,b)
 #     define padlist_dup(a,b)                   Perl_padlist_dup(aTHX_ a,b)
@@ -1657,28 +1647,28 @@
 #     define padnamelist_dup(a,b)               Perl_padnamelist_dup(aTHX_ a,b)
 #     if !defined(PERL_IMPLICIT_SYS)
 #       define PerlEnv_putenv(a)                S_PerlEnv_putenv(aTHX_ a)
-#     endif /* !defined(PERL_IMPLICIT_SYS) */
+#     endif
 #     if defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C)
 #       define op_relocate_sv(a,b)              Perl_op_relocate_sv(aTHX_ a,b)
-#     endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
+#     endif
 #   endif /* defined(USE_ITHREADS) */
 #   if defined(USE_LOCALE_COLLATE)
 #     define magic_freecollxfrm(a,b)            Perl_magic_freecollxfrm(aTHX_ a,b)
 #     define magic_setcollxfrm(a,b)             Perl_magic_setcollxfrm(aTHX_ a,b)
-#   endif /* defined(USE_LOCALE_COLLATE) */
+#   endif
 #   if defined(USE_PERLIO)
 #     define PerlIO_restore_errno(a)            Perl_PerlIO_restore_errno(aTHX_ a)
 #     define PerlIO_save_errno(a)               Perl_PerlIO_save_errno(aTHX_ a)
-#   endif /* defined(USE_PERLIO) */
+#   endif
 #   if defined(USE_QUADMATH)
 #     define quadmath_format_needed             Perl_quadmath_format_needed
 #     define quadmath_format_valid              Perl_quadmath_format_valid
-#   endif /* defined(USE_QUADMATH) */
+#   endif
 #   if defined(WIN32)
 #     define get_win32_message_utf8ness(a)      Perl_get_win32_message_utf8ness(aTHX_ a)
-#   else /* if !defined(WIN32) */
+#   else
 #     define do_exec3(a,b,c)                    Perl_do_exec3(aTHX_ a,b,c)
-#   endif /* !defined(WIN32) */
+#   endif
 # endif /* defined(PERL_CORE) */
 # if defined(PERL_CORE) || defined(PERL_EXT)
 #   define _byte_dump_string(a,b,c)             Perl__byte_dump_string(aTHX_ a,b,c)
@@ -1726,10 +1716,10 @@
 #   define variant_under_utf8_count             S_variant_under_utf8_count
 #   if !defined(HAS_MEMRCHR)
 #     define my_memrchr                         S_my_memrchr
-#   endif /* !defined(HAS_MEMRCHR) */
+#   endif
 #   if defined(PERL_ANY_COW)
 #     define sv_setsv_cow(a,b)                  Perl_sv_setsv_cow(aTHX_ a,b)
-#   endif /* defined(PERL_ANY_COW) */
+#   endif
 #   if defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
        defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
        defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
@@ -1740,18 +1730,14 @@
 #     define get_invlist_offset_addr            S_get_invlist_offset_addr
 #     define invlist_array                      S_invlist_array
 #     define is_invlist                         S_is_invlist
-#   endif /* defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
-             defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
-             defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
-             defined(PERL_IN_UTF8_C) */
+#   endif
 #   if defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
        defined(PERL_IN_REGCOMP_ANY)
 #     define add_cp_to_invlist(a,b)             S_add_cp_to_invlist(aTHX_ a,b)
 #     define invlist_extend(a,b)                S_invlist_extend(aTHX_ a,b)
 #     define invlist_highest                    S_invlist_highest
 #     define invlist_set_len(a,b,c)             S_invlist_set_len(aTHX_ a,b,c)
-#   endif /* defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
-             defined(PERL_IN_REGCOMP_ANY) */
+#   endif
 #   if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
        defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C)
 #     define _add_range_to_invlist(a,b,c)       Perl__add_range_to_invlist(aTHX_ a,b,c)
@@ -1760,46 +1746,40 @@
 #     define _invlist_union_maybe_complement_2nd(a,b,c,d) Perl__invlist_union_maybe_complement_2nd(aTHX_ a,b,c,d)
 #     define _new_invlist(a)                    Perl__new_invlist(aTHX_ a)
 #     define _setup_canned_invlist(a,b,c)       Perl__setup_canned_invlist(aTHX_ a,b,c)
-#   endif /* defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
-             defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C) */
+#   endif
 #   if defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) || \
        defined(PERL_IN_TOKE_C)
 #     define form_alien_digit_msg(a,b,c,d,e,f)  Perl_form_alien_digit_msg(aTHX_ a,b,c,d,e,f)
 #     define grok_bslash_c(a,b,c,d)             Perl_grok_bslash_c(aTHX_ a,b,c,d)
 #     define grok_bslash_o(a,b,c,d,e,f,g,h)     Perl_grok_bslash_o(aTHX_ a,b,c,d,e,f,g,h)
 #     define grok_bslash_x(a,b,c,d,e,f,g,h)     Perl_grok_bslash_x(aTHX_ a,b,c,d,e,f,g,h)
-#   endif /* defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) || \
-             defined(PERL_IN_TOKE_C) */
+#   endif
 #   if defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) || \
        defined(PERL_IN_TOKE_C)   || defined(PERL_IN_UTF8_C)
 #     define form_cp_too_large_msg(a,b,c,d)     Perl_form_cp_too_large_msg(aTHX_ a,b,c,d)
-#   endif /* defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) || \
-             defined(PERL_IN_TOKE_C)   || defined(PERL_IN_UTF8_C) */
+#   endif
 #   if defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) || \
        defined(PERL_IN_REGCOMP_ANY)
 #     define _invlist_dump(a,b,c,d)             Perl__invlist_dump(aTHX_ a,b,c,d)
-#   endif /* defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) || \
-             defined(PERL_IN_REGCOMP_ANY) */
+#   endif
 #   if defined(PERL_IN_GV_C) || defined(PERL_IN_UNIVERSAL_C)
 #     define gv_stashsvpvn_cached(a,b,c,d)      Perl_gv_stashsvpvn_cached(aTHX_ a,b,c,d)
-#   endif /* defined(PERL_IN_GV_C) || defined(PERL_IN_UNIVERSAL_C) */
+#   endif
 #   if defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY)
 #     define get_invlist_iter_addr              S_get_invlist_iter_addr
 #     define invlist_iterfinish                 S_invlist_iterfinish
 #     define invlist_iterinit                   S_invlist_iterinit
 #     define invlist_iternext                   S_invlist_iternext
-#   endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY) */
+#   endif
 #   if defined(PERL_IN_PERL_C) || defined(PERL_IN_REGCOMP_ANY) || \
        defined(PERL_IN_UTF8_C)
 #     define _invlistEQ(a,b,c)                  Perl__invlistEQ(aTHX_ a,b,c)
 #     define _new_invlist_C_array(a)            Perl__new_invlist_C_array(aTHX_ a)
-#   endif /* defined(PERL_IN_PERL_C) || defined(PERL_IN_REGCOMP_ANY) || \
-             defined(PERL_IN_UTF8_C) */
+#   endif
 #   if defined(PERL_IN_PP_C)   || defined(PERL_IN_REGCOMP_ANY) || \
        defined(PERL_IN_TOKE_C) || defined(PERL_IN_UNIVERSAL_C)
 #     define get_regex_charset_name             S_get_regex_charset_name
-#   endif /* defined(PERL_IN_PP_C)   || defined(PERL_IN_REGCOMP_ANY) || \
-             defined(PERL_IN_TOKE_C) || defined(PERL_IN_UNIVERSAL_C) */
+#   endif
 #   if defined(PERL_IN_REGCOMP_ANY)
 #     define add_above_Latin1_folds(a,b,c)      Perl_add_above_Latin1_folds(aTHX_ a,b,c)
 #     define construct_ahocorasick_from_trie(a,b,c) Perl_construct_ahocorasick_from_trie(aTHX_ a,b,c)
@@ -1823,11 +1803,11 @@
 #       define dump_trie(a,b,c,d)               S_dump_trie(aTHX_ a,b,c,d)
 #       define dump_trie_interim_list(a,b,c,d,e) S_dump_trie_interim_list(aTHX_ a,b,c,d,e)
 #       define dump_trie_interim_table(a,b,c,d,e) S_dump_trie_interim_table(aTHX_ a,b,c,d,e)
-#     endif /* defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING) */
+#     endif
 #   endif /* defined(PERL_IN_REGCOMP_ANY) */
 #   if defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_SV_C)
 #     define invlist_clone(a,b)                 Perl_invlist_clone(aTHX_ a,b)
-#   endif /* defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_SV_C) */
+#   endif
 #   if defined(PERL_IN_REGCOMP_C)
 #     define add_multi_match(a,b,c)             S_add_multi_match(aTHX_ a,b,c)
 #     define change_engine_size(a,b)            S_change_engine_size(aTHX_ a,b)
@@ -1872,26 +1852,24 @@
 #       define regtail_study(a,b,c,d)           S_regtail_study(aTHX_ a,b,c,d)
 #       if defined(ENABLE_REGEX_SETS_DEBUGGING)
 #         define dump_regex_sets_structures(a,b,c,d) S_dump_regex_sets_structures(aTHX_ a,b,c,d)
-#       endif /* defined(ENABLE_REGEX_SETS_DEBUGGING) */
-#     endif /* defined(DEBUGGING) */
+#       endif
+#     endif
 #   endif /* defined(PERL_IN_REGCOMP_C) */
 #   if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGCOMP_INVLIST_C)
 #     define populate_bitmap_from_invlist(a,b,c,d) Perl_populate_bitmap_from_invlist(aTHX_ a,b,c,d)
 #     define populate_invlist_from_bitmap(a,b,c,d) Perl_populate_invlist_from_bitmap(aTHX_ a,b,c,d)
-#   endif /* defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGCOMP_INVLIST_C) */
+#   endif
 #   if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
        defined(PERL_IN_TOKE_C)
 #     define is_grapheme(a,b,c,d)               Perl_is_grapheme(aTHX_ a,b,c,d)
-#   endif /* defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
-             defined(PERL_IN_TOKE_C) */
+#   endif
 #   if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
        defined(PERL_IN_UTF8_C)
 #     define _to_fold_latin1                    Perl__to_fold_latin1
-#   endif /* defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
-             defined(PERL_IN_UTF8_C) */
+#   endif
 #   if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_TOKE_C)
 #     define regcurly                           Perl_regcurly
-#   endif /* defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_TOKE_C) */
+#   endif
 #   if defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING)
 #     define put_charclass_bitmap_innards(a,b,c,d,e,f,g) S_put_charclass_bitmap_innards(aTHX_ a,b,c,d,e,f,g)
 #     define put_charclass_bitmap_innards_common(a,b,c,d,e,f) S_put_charclass_bitmap_innards_common(aTHX_ a,b,c,d,e,f)
@@ -1900,7 +1878,7 @@
 #     define put_range(a,b,c,d)                 S_put_range(aTHX_ a,b,c,d)
 #     define regdump_extflags(a,b)              S_regdump_extflags(aTHX_ a,b)
 #     define regdump_intflags(a,b)              S_regdump_intflags(aTHX_ a,b)
-#   endif /* defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING) */
+#   endif
 #   if defined(PERL_IN_REGCOMP_INVLIST_C) && !defined(PERL_EXT_RE_BUILD)
 #     define _append_range_to_invlist(a,b,c)    S__append_range_to_invlist(aTHX_ a,b,c)
 #     define _invlist_array_init                S__invlist_array_init
@@ -1968,18 +1946,18 @@
 #       define dump_exec_pos(a,b,c,d,e,f,g)     S_dump_exec_pos(aTHX_ a,b,c,d,e,f,g)
 #       if !defined(MULTIPLICITY) || defined(PERL_CORE)
 #         define re_exec_indentf(a,...)         Perl_re_exec_indentf(aTHX_ a,__VA_ARGS__)
-#       endif /* !defined(MULTIPLICITY) || defined(PERL_CORE) */
-#     endif /* defined(DEBUGGING) */
+#       endif
+#     endif
 #   endif /* defined(PERL_IN_REGEXEC_C) */
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API)
 #   define finalize_optree(a)                   Perl_finalize_optree(aTHX_ a)
 #   define optimize_optree(a)                   Perl_optimize_optree(aTHX_ a)
-# endif /* defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API) */
+# endif
 # if !defined(PERL_IMPLICIT_SYS)
 #   define my_pclose(a)                         Perl_my_pclose(aTHX_ a)
 #   define my_popen(a,b)                        Perl_my_popen(aTHX_ a,b)
-# endif /* !defined(PERL_IMPLICIT_SYS) */
+# endif
 # if defined(PERL_IN_CLASS_C) || defined(PERL_IN_OP_C)    || \
      defined(PERL_IN_PAD_C)   || defined(PERL_IN_PERLY_C) || \
      defined(PERL_IN_TOKE_C)
@@ -2006,25 +1984,22 @@
          defined(PERL_CORE)       || defined(PERL_EXT) )
 #       define re_indentf(a,...)                Perl_re_indentf(aTHX_ a,__VA_ARGS__)
 #       define re_printf(...)                   Perl_re_printf(aTHX_ __VA_ARGS__)
-#     endif /* ( !defined(MULTIPLICITY) || defined(PERL_CORE) ) && ( \
-               defined(PERL_CORE)       || defined(PERL_EXT) ) */
+#     endif
 #     if defined(PERL_CORE) || defined(PERL_EXT)
 #       define debug_peep(a,b,c,d,e)            Perl_debug_peep(aTHX_ a,b,c,d,e)
 #       define debug_show_study_flags(a,b,c)    Perl_debug_show_study_flags(aTHX_ a,b,c)
 #       define debug_studydata(a,b,c,d,e,f,g)   Perl_debug_studydata(aTHX_ a,b,c,d,e,f,g)
 #       define dumpuntil(a,b,c,d,e,f,g,h)       Perl_dumpuntil(aTHX_ a,b,c,d,e,f,g,h)
 #       define regprop(a,b,c,d,e)               Perl_regprop(aTHX_ a,b,c,d,e)
-#     endif /* defined(PERL_CORE) || defined(PERL_EXT) */
+#     endif
 #   endif /* defined(DEBUGGING) */
 #   if defined(PERL_EXT_RE_BUILD)
 #     if defined(PERL_CORE) || defined(PERL_EXT)
 #       define get_re_gclass_aux_data(a,b,c,d,e,f) Perl_get_re_gclass_aux_data(aTHX_ a,b,c,d,e,f)
-#     endif /* defined(PERL_CORE) || defined(PERL_EXT) */
-#   elif defined(PERL_CORE) || defined(PERL_EXT) /* && \
-         !defined(PERL_EXT_RE_BUILD) */
+#     endif
+#   elif defined(PERL_CORE) || defined(PERL_EXT)
 #     define get_regclass_aux_data(a,b,c,d,e,f) Perl_get_regclass_aux_data(aTHX_ a,b,c,d,e,f)
-#   endif /* !defined(PERL_EXT_RE_BUILD) && ( defined(PERL_CORE) || \
-             defined(PERL_EXT) ) */
+#   endif
 # endif /* defined(PERL_IN_REGEX_ENGINE) */
 # if defined(PERL_IN_SV_C)
 #   define more_sv()                            Perl_more_sv(aTHX)
@@ -2056,23 +2031,23 @@
 #     define visit(a,b,c)                       S_visit(aTHX_ a,b,c)
 #     if defined(DEBUGGING)
 #       define del_sv(a)                        S_del_sv(aTHX_ a)
-#     endif /* defined(DEBUGGING) */
+#     endif
 #     if !defined(NV_PRESERVES_UV)
 #       if defined(DEBUGGING)
 #         define sv_2iuv_non_preserve(a,b)      S_sv_2iuv_non_preserve(aTHX_ a,b)
-#       else /* if !defined(DEBUGGING) */
+#       else
 #         define sv_2iuv_non_preserve(a)        S_sv_2iuv_non_preserve(aTHX_ a)
-#       endif /* !defined(DEBUGGING) */
-#     endif /* !defined(NV_PRESERVES_UV) */
+#       endif
+#     endif
 #     if defined(PERL_DEBUG_READONLY_COW)
 #       define sv_buf_to_rw(a)                  S_sv_buf_to_rw(aTHX_ a)
-#     endif /* defined(PERL_DEBUG_READONLY_COW) */
+#     endif
 #     if defined(USE_ITHREADS)
 #       define sv_dup_common(a,b)               S_sv_dup_common(aTHX_ a,b)
 #       define sv_dup_hvaux(a,b,c)              S_sv_dup_hvaux(aTHX_ a,b,c)
 #       define sv_dup_inc_multiple(a,b,c,d)     S_sv_dup_inc_multiple(aTHX_ a,b,c,d)
 #       define unreferenced_to_tmp_stack(a)     S_unreferenced_to_tmp_stack(aTHX_ a)
-#     endif /* defined(USE_ITHREADS) */
+#     endif
 #   endif /* defined(PERL_CORE) */
 # endif /* defined(PERL_IN_SV_C) */
 # if defined(PERL_MEM_LOG)
@@ -2081,7 +2056,7 @@
 #   define mem_log_free                         Perl_mem_log_free
 #   define mem_log_new_sv                       Perl_mem_log_new_sv
 #   define mem_log_realloc                      Perl_mem_log_realloc
-# endif /* defined(PERL_MEM_LOG) */
+# endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 #   define cx_popblock(a)                       Perl_cx_popblock(aTHX_ a)
 #   define cx_popeval(a)                        Perl_cx_popeval(aTHX_ a)
@@ -2106,21 +2081,21 @@
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 # if defined(PERL_USE_3ARG_SIGHANDLER)
 #   define csighandler                          Perl_csighandler
-# else /* if !defined(PERL_USE_3ARG_SIGHANDLER) */
+# else
 #   define csighandler                          Perl_csighandler
-# endif /* !defined(PERL_USE_3ARG_SIGHANDLER) */
+# endif
 # if defined(U64TYPE)
 #   define lsbit_pos64                          Perl_lsbit_pos64
 #   define msbit_pos64                          Perl_msbit_pos64
 #   define single_1bit_pos64                    Perl_single_1bit_pos64
-# endif /* defined(U64TYPE) */
+# endif
 # if defined(UNLINK_ALL_VERSIONS)
 #   define unlnk(a)                             Perl_unlnk(aTHX_ a)
-# endif /* defined(UNLINK_ALL_VERSIONS) */
+# endif
 # if defined(USE_C_BACKTRACE)
 #   define dump_c_backtrace(a,b,c)              Perl_dump_c_backtrace(aTHX_ a,b,c)
 #   define get_c_backtrace_dump(a,b)            Perl_get_c_backtrace_dump(aTHX_ a,b)
-# endif /* defined(USE_C_BACKTRACE) */
+# endif
 # if defined(USE_ITHREADS)
 #   define alloccopstash(a)                     Perl_alloccopstash(aTHX_ a)
 #   define any_dup(a,b)                         Perl_any_dup(aTHX_ a,b)
@@ -2148,10 +2123,8 @@
        defined(PERL_IN_LOCALE_C) || defined(PERL_IN_MATHOMS_C) || \
        defined(PERL_IN_SV_C) )
 #     define mem_collxfrm_(a,b,c,d)             Perl_mem_collxfrm_(aTHX_ a,b,c,d)
-#   endif /* ( defined(PERL_CORE)      || defined(PERL_EXT) ) && ( \
-             defined(PERL_IN_LOCALE_C) || defined(PERL_IN_MATHOMS_C) || \
-             defined(PERL_IN_SV_C) ) */
-# endif /* defined(USE_LOCALE_COLLATE) */
+#   endif
+# endif
 # if defined(USE_PERLIO)
 #   define PerlIO_clearerr(a)                   Perl_PerlIO_clearerr(aTHX_ a)
 #   define PerlIO_close(a)                      Perl_PerlIO_close(aTHX_ a)
@@ -2180,12 +2153,12 @@
 #   define do_aspawn(a,b,c)                     Perl_do_aspawn(aTHX_ a,b,c)
 #   define do_spawn(a)                          Perl_do_spawn(aTHX_ a)
 #   define do_spawn_nowait(a)                   Perl_do_spawn_nowait(aTHX_ a)
-# endif /* defined(VMS) || defined(WIN32) */
+# endif
 # if defined(WIN32)
 #   define get_context                          Perl_get_context
-# else /* if !defined(WIN32) */
+# else
 #   define get_context                          Perl_get_context
-# endif /* !defined(WIN32) */
+# endif
 #endif /* !defined(PERL_NO_SHORT_NAMES) */
 
 /* ex: set ro ft=c: */

--- a/embedvar.h
+++ b/embedvar.h
@@ -365,7 +365,7 @@
 # define PL_xsubfilename                        (vTHX->Ixsubfilename)
 # if !defined(PL_sawampersand)
 #   define PL_sawampersand                      (vTHX->Isawampersand)
-# endif /* !defined(PL_sawampersand) */
+# endif
 #endif /* defined(MULTIPLICITY) */
 
 /* ex: set ro ft=c: */

--- a/proto.h
+++ b/proto.h
@@ -5345,17 +5345,6 @@ Perl_yyunlex(pTHX)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYUNLEX
 
-#if ( defined(AF_INET) && defined(HAS_SOCKET) && defined(PF_INET) && \
-    defined(SOCK_DGRAM) ) || defined(HAS_SOCKETPAIR)
-PERL_CALLCONV int
-Perl_PerlSock_socketpair_cloexec(pTHX_ int domain, int type, int protocol, int *pairfd)
-        __attribute__warn_unused_result__
-        __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_PERLSOCK_SOCKETPAIR_CLOEXEC \
-        assert(pairfd)
-
-#endif /* ( defined(AF_INET) && defined(HAS_SOCKET) && defined(PF_INET) && \
-          defined(SOCK_DGRAM) ) || defined(HAS_SOCKETPAIR) */
 #if defined(DEBUGGING)
 PERL_CALLCONV int
 Perl_get_debug_opts(pTHX_ const char **s, bool givehelp)
@@ -5529,6 +5518,17 @@ Perl_PerlSock_socket_cloexec(pTHX_ int domain, int type, int protocol)
 # define PERL_ARGS_ASSERT_PERLSOCK_SOCKET_CLOEXEC
 
 #endif /* defined(HAS_SOCKET) */
+#if defined(HAS_SOCKETPAIR) || ( defined(AF_INET) && defined(HAS_SOCKET) && \
+    defined(PF_INET) && defined(SOCK_DGRAM) )
+PERL_CALLCONV int
+Perl_PerlSock_socketpair_cloexec(pTHX_ int domain, int type, int protocol, int *pairfd)
+        __attribute__warn_unused_result__
+        __attribute__visibility__("hidden");
+# define PERL_ARGS_ASSERT_PERLSOCK_SOCKETPAIR_CLOEXEC \
+        assert(pairfd)
+
+#endif /* defined(HAS_SOCKETPAIR) || ( defined(AF_INET) && \
+          defined(HAS_SOCKET) && defined(PF_INET) && defined(SOCK_DGRAM) ) */
 #if !defined(HAS_STRLCPY)
 STATIC Size_t
 Perl_my_strlcpy(char *dst, const char *src, Size_t size);
@@ -6017,6 +6017,15 @@ Perl_gv_SVadd(pTHX_ GV *gv);
 #   define PERL_ARGS_ASSERT_GV_SVADD
 
 # endif /* defined(PERL_DONT_CREATE_GVSV) */
+# if defined(PERL_IN_OP_C) || defined(PERL_IN_PERLY_C) || \
+     defined(PERL_IN_TOKE_C)
+PERL_CALLCONV OP *
+Perl_ref(pTHX_ OP *o, I32 type)
+        __attribute__visibility__("hidden");
+#   define PERL_ARGS_ASSERT_REF
+
+# endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PERLY_C) || \
+           defined(PERL_IN_TOKE_C) */
 # if defined(USE_LOCALE_COLLATE)
 PERL_CALLCONV char *
 Perl_sv_collxfrm(pTHX_ SV * const sv, STRLEN * const nxp);
@@ -6085,32 +6094,6 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 *s, const U8 *send, const bool utf8_target)
 # define PERL_ARGS_ASSERT_ISSCRIPT_RUN          \
         assert(s); assert(send)
 
-# if !defined(PERL_NO_INLINE_FUNCTIONS)
-PERL_STATIC_INLINE bool
-Perl_is_utf8_non_invariant_string(const U8 * const s, STRLEN len)
-        __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_IS_UTF8_NON_INVARIANT_STRING \
-        assert(s)
-
-PERL_STATIC_INLINE STRLEN
-S_sv_or_pv_pos_u2b(pTHX_ SV *sv, const char *pv, STRLEN pos, STRLEN *lenp);
-#   define PERL_ARGS_ASSERT_SV_OR_PV_POS_U2B    \
-        assert(sv); assert(pv)
-
-PERL_STATIC_INLINE Size_t
-S_variant_under_utf8_count(const U8 * const s, const U8 * const e)
-        __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_VARIANT_UNDER_UTF8_COUNT \
-        assert(s); assert(e)
-
-#   if !defined(HAS_MEMRCHR)
-PERL_STATIC_INLINE void *
-S_my_memrchr(const char *s, const char c, const STRLEN len);
-#     define PERL_ARGS_ASSERT_MY_MEMRCHR        \
-        assert(s)
-
-#   endif /* !defined(HAS_MEMRCHR) */
-# endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 #if defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API)
 PERL_CALLCONV void
@@ -6327,37 +6310,6 @@ Perl__invlist_search(SV * const invlist, const UV cp)
 # define PERL_ARGS_ASSERT__INVLIST_SEARCH       \
         assert(invlist)
 
-# if !defined(PERL_NO_INLINE_FUNCTIONS)
-PERL_STATIC_INLINE bool
-S__invlist_contains_cp(SV * const invlist, const UV cp)
-        __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT__INVLIST_CONTAINS_CP \
-        assert(invlist)
-
-PERL_STATIC_INLINE UV
-S__invlist_len(SV * const invlist)
-        __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT__INVLIST_LEN        \
-        assert(invlist)
-
-PERL_STATIC_INLINE bool *
-S_get_invlist_offset_addr(SV *invlist)
-        __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_GET_INVLIST_OFFSET_ADDR \
-        assert(invlist)
-
-PERL_STATIC_INLINE UV *
-S_invlist_array(SV * const invlist)
-        __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_INVLIST_ARRAY       \
-        assert(invlist)
-
-PERL_STATIC_INLINE bool
-S_is_invlist(const SV * const invlist)
-        __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_IS_INVLIST
-
-# endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
           defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
           defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
@@ -6365,29 +6317,6 @@ S_is_invlist(const SV * const invlist)
 #if defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY)
 
-# if !defined(PERL_NO_INLINE_FUNCTIONS)
-PERL_STATIC_INLINE SV *
-S_add_cp_to_invlist(pTHX_ SV *invlist, const UV cp)
-        __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_ADD_CP_TO_INVLIST
-
-PERL_STATIC_INLINE void
-S_invlist_extend(pTHX_ SV * const invlist, const UV len);
-#   define PERL_ARGS_ASSERT_INVLIST_EXTEND      \
-        assert(invlist)
-
-PERL_STATIC_INLINE UV
-S_invlist_highest(SV * const invlist)
-        __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_INVLIST_HIGHEST     \
-        assert(invlist)
-
-PERL_STATIC_INLINE void
-S_invlist_set_len(pTHX_ SV * const invlist, const UV len, const bool offset);
-#   define PERL_ARGS_ASSERT_INVLIST_SET_LEN     \
-        assert(invlist)
-
-# endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
           defined(PERL_IN_REGCOMP_ANY) */
 #if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
@@ -7091,16 +7020,6 @@ S_my_langinfo_i(pTHX_ const int item, const unsigned int cat_index, const char *
         assert(locale); assert(retbufp)
 
 #   endif /* !( defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L) ) */
-#   if ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || defined(WIN32) \
-       ) && !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) )
-STATIC const char *
-S_calculate_LC_ALL(pTHX_ const char **individ_locales);
-#     define PERL_ARGS_ASSERT_CALCULATE_LC_ALL  \
-        assert(individ_locales)
-
-#   endif /* ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || \
-             defined(WIN32) ) && !( defined(USE_POSIX_2008_LOCALE) && \
-             defined(USE_QUERYLOCALE) ) */
 #   if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE const char *
 S_mortalized_pv_copy(pTHX_ const char * const pv)
@@ -7196,18 +7115,19 @@ S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char *locale);
         assert(locale)
 
 #     endif /* 0 */
-#   endif /* ( defined(USE_LOCALE_THREADS) && \
-             !defined(USE_THREAD_SAFE_LOCALE) && \
-             !defined(USE_THREAD_SAFE_LOCALE_EMULATION) ) && \
-             !defined(USE_POSIX_2008_LOCALE) */
-#   if ( defined(USE_POSIX_2008_LOCALE) && !defined(USE_QUERYLOCALE) ) || \
-       defined(WIN32)
+#   endif /* !defined(USE_POSIX_2008_LOCALE) && ( defined(USE_LOCALE_THREADS) \
+             && !defined(USE_THREAD_SAFE_LOCALE) && \
+             !defined(USE_THREAD_SAFE_LOCALE_EMULATION) ) */
+#   if !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) && ( \
+       !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || defined(WIN32) )
 STATIC const char *
-S_find_locale_from_environment(pTHX_ const unsigned int index);
-#     define PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT
+S_calculate_LC_ALL(pTHX_ const char **individ_locales);
+#     define PERL_ARGS_ASSERT_CALCULATE_LC_ALL  \
+        assert(individ_locales)
 
-#   endif /* ( defined(USE_POSIX_2008_LOCALE) && !defined(USE_QUERYLOCALE) ) \
-             || defined(WIN32) */
+#   endif /* !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) \
+             && ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || \
+             defined(WIN32) ) */
 #   if defined(WIN32)
 STATIC wchar_t *
 S_Win_byte_string_to_wstring(const UINT code_page, const char *byte_string);
@@ -7226,6 +7146,14 @@ S_wrap_wsetlocale(pTHX_ const int category, const char *locale);
 #     define PERL_ARGS_ASSERT_WRAP_WSETLOCALE
 
 #   endif /* defined(WIN32) */
+#   if defined(WIN32) || ( defined(USE_POSIX_2008_LOCALE) && \
+       !defined(USE_QUERYLOCALE) )
+STATIC const char *
+S_find_locale_from_environment(pTHX_ const unsigned int index);
+#     define PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT
+
+#   endif /* defined(WIN32) || ( defined(USE_POSIX_2008_LOCALE) && \
+             !defined(USE_QUERYLOCALE) ) */
 # endif /* defined(USE_LOCALE) */
 # if defined(USE_POSIX_2008_LOCALE) || defined(DEBUGGING)
 STATIC const char *
@@ -7523,53 +7451,14 @@ Perl_warn_elem_scalar_context(pTHX_ const OP *o, SV *name, bool is_hash, bool is
 # define PERL_ARGS_ASSERT_WARN_ELEM_SCALAR_CONTEXT \
         assert(o); assert(name)
 
-# if defined(USE_ITHREADS)
-PERL_CALLCONV void
-Perl_op_relocate_sv(pTHX_ SV **svp, PADOFFSET *targp)
-        __attribute__visibility__("hidden");
-#   define PERL_ARGS_ASSERT_OP_RELOCATE_SV      \
-        assert(svp); assert(targp)
-
-# endif /* defined(USE_ITHREADS) */
 #endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_PERLY_C) || \
     defined(PERL_IN_TOKE_C)
 
-# if !defined(NO_MATHOMS)
-PERL_CALLCONV OP *
-Perl_ref(pTHX_ OP *o, I32 type)
-        __attribute__visibility__("hidden");
-#   define PERL_ARGS_ASSERT_REF
-
-# endif /* !defined(NO_MATHOMS) */
 #endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PERLY_C) || \
           defined(PERL_IN_TOKE_C) */
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY)
 
-# if !defined(PERL_NO_INLINE_FUNCTIONS)
-PERL_STATIC_INLINE STRLEN *
-S_get_invlist_iter_addr(SV *invlist)
-        __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_GET_INVLIST_ITER_ADDR \
-        assert(invlist)
-
-PERL_STATIC_INLINE void
-S_invlist_iterfinish(SV *invlist);
-#   define PERL_ARGS_ASSERT_INVLIST_ITERFINISH  \
-        assert(invlist)
-
-PERL_STATIC_INLINE void
-S_invlist_iterinit(SV *invlist);
-#   define PERL_ARGS_ASSERT_INVLIST_ITERINIT    \
-        assert(invlist)
-
-PERL_STATIC_INLINE bool
-S_invlist_iternext(SV *invlist, UV *start, UV *end)
-        __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_INVLIST_ITERNEXT    \
-        assert(invlist); assert(start); assert(end)
-
-# endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY) */
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV void
@@ -7768,14 +7657,6 @@ Perl_softref2xv(pTHX_ SV * const sv, const char * const what, const svtype type,
 # define PERL_ARGS_ASSERT_SOFTREF2XV            \
         assert(sv); assert(what); assert(spp)
 
-# if !defined(PERL_NO_INLINE_FUNCTIONS)
-PERL_STATIC_INLINE bool
-S_lossless_NV_to_IV(const NV nv, IV *ivp)
-        __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_LOSSLESS_NV_TO_IV   \
-        assert(ivp)
-
-# endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_PP_C) || defined(PERL_IN_PP_HOT_C) */
 #if defined(PERL_IN_PP_C) || defined(PERL_IN_UTF8_C)
 PERL_CALLCONV UV
@@ -10069,6 +9950,94 @@ Perl_my_strnlen(const char *str, Size_t maxlen);
         assert(str)
 
 # endif /* !defined(HAS_STRNLEN) */
+# if defined(PERL_CORE) || defined(PERL_EXT)
+PERL_STATIC_INLINE bool
+Perl_is_utf8_non_invariant_string(const U8 * const s, STRLEN len)
+        __attribute__warn_unused_result__;
+#   define PERL_ARGS_ASSERT_IS_UTF8_NON_INVARIANT_STRING \
+        assert(s)
+
+PERL_STATIC_INLINE STRLEN
+S_sv_or_pv_pos_u2b(pTHX_ SV *sv, const char *pv, STRLEN pos, STRLEN *lenp);
+#   define PERL_ARGS_ASSERT_SV_OR_PV_POS_U2B    \
+        assert(sv); assert(pv)
+
+PERL_STATIC_INLINE Size_t
+S_variant_under_utf8_count(const U8 * const s, const U8 * const e)
+        __attribute__warn_unused_result__;
+#   define PERL_ARGS_ASSERT_VARIANT_UNDER_UTF8_COUNT \
+        assert(s); assert(e)
+
+#   if !defined(HAS_MEMRCHR)
+PERL_STATIC_INLINE void *
+S_my_memrchr(const char *s, const char c, const STRLEN len);
+#     define PERL_ARGS_ASSERT_MY_MEMRCHR        \
+        assert(s)
+
+#   endif /* !defined(HAS_MEMRCHR) */
+# endif /* defined(PERL_CORE) || defined(PERL_EXT) */
+# if defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
+     defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
+     defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
+     defined(PERL_IN_UTF8_C)
+PERL_STATIC_INLINE bool
+S__invlist_contains_cp(SV * const invlist, const UV cp)
+        __attribute__warn_unused_result__;
+#   define PERL_ARGS_ASSERT__INVLIST_CONTAINS_CP \
+        assert(invlist)
+
+PERL_STATIC_INLINE UV
+S__invlist_len(SV * const invlist)
+        __attribute__warn_unused_result__;
+#   define PERL_ARGS_ASSERT__INVLIST_LEN        \
+        assert(invlist)
+
+PERL_STATIC_INLINE bool *
+S_get_invlist_offset_addr(SV *invlist)
+        __attribute__warn_unused_result__;
+#   define PERL_ARGS_ASSERT_GET_INVLIST_OFFSET_ADDR \
+        assert(invlist)
+
+PERL_STATIC_INLINE UV *
+S_invlist_array(SV * const invlist)
+        __attribute__warn_unused_result__;
+#   define PERL_ARGS_ASSERT_INVLIST_ARRAY       \
+        assert(invlist)
+
+PERL_STATIC_INLINE bool
+S_is_invlist(const SV * const invlist)
+        __attribute__warn_unused_result__;
+#   define PERL_ARGS_ASSERT_IS_INVLIST
+
+# endif /* defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
+           defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
+           defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
+           defined(PERL_IN_UTF8_C) */
+# if defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
+     defined(PERL_IN_REGCOMP_ANY)
+PERL_STATIC_INLINE SV *
+S_add_cp_to_invlist(pTHX_ SV *invlist, const UV cp)
+        __attribute__warn_unused_result__;
+#   define PERL_ARGS_ASSERT_ADD_CP_TO_INVLIST
+
+PERL_STATIC_INLINE void
+S_invlist_extend(pTHX_ SV * const invlist, const UV len);
+#   define PERL_ARGS_ASSERT_INVLIST_EXTEND      \
+        assert(invlist)
+
+PERL_STATIC_INLINE UV
+S_invlist_highest(SV * const invlist)
+        __attribute__warn_unused_result__;
+#   define PERL_ARGS_ASSERT_INVLIST_HIGHEST     \
+        assert(invlist)
+
+PERL_STATIC_INLINE void
+S_invlist_set_len(pTHX_ SV * const invlist, const UV len, const bool offset);
+#   define PERL_ARGS_ASSERT_INVLIST_SET_LEN     \
+        assert(invlist)
+
+# endif /* defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
+           defined(PERL_IN_REGCOMP_ANY) */
 # if defined(PERL_IN_OP_C) || defined(PERL_IN_PAD_C)
 PERL_STATIC_INLINE bool
 S_PadnameIN_SCOPE(const PADNAME * const pn, const U32 seq);
@@ -10076,6 +10045,38 @@ S_PadnameIN_SCOPE(const PADNAME * const pn, const U32 seq);
         assert(pn)
 
 # endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PAD_C) */
+# if defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY)
+PERL_STATIC_INLINE STRLEN *
+S_get_invlist_iter_addr(SV *invlist)
+        __attribute__warn_unused_result__;
+#   define PERL_ARGS_ASSERT_GET_INVLIST_ITER_ADDR \
+        assert(invlist)
+
+PERL_STATIC_INLINE void
+S_invlist_iterfinish(SV *invlist);
+#   define PERL_ARGS_ASSERT_INVLIST_ITERFINISH  \
+        assert(invlist)
+
+PERL_STATIC_INLINE void
+S_invlist_iterinit(SV *invlist);
+#   define PERL_ARGS_ASSERT_INVLIST_ITERINIT    \
+        assert(invlist)
+
+PERL_STATIC_INLINE bool
+S_invlist_iternext(SV *invlist, UV *start, UV *end)
+        __attribute__warn_unused_result__;
+#   define PERL_ARGS_ASSERT_INVLIST_ITERNEXT    \
+        assert(invlist); assert(start); assert(end)
+
+# endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY) */
+# if defined(PERL_IN_PP_C) || defined(PERL_IN_PP_HOT_C)
+PERL_STATIC_INLINE bool
+S_lossless_NV_to_IV(const NV nv, IV *ivp)
+        __attribute__warn_unused_result__;
+#   define PERL_ARGS_ASSERT_LOSSLESS_NV_TO_IV   \
+        assert(ivp)
+
+# endif /* defined(PERL_IN_PP_C) || defined(PERL_IN_PP_HOT_C) */
 # if defined(PERL_IN_PP_C)   || defined(PERL_IN_REGCOMP_ANY) || \
      defined(PERL_IN_TOKE_C) || defined(PERL_IN_UNIVERSAL_C)
 PERL_STATIC_INLINE const char *
@@ -10341,6 +10342,14 @@ Perl_sv_dup_inc(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
 # define PERL_ARGS_ASSERT_SV_DUP_INC            \
         assert(param)
 
+# if defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C)
+PERL_CALLCONV void
+Perl_op_relocate_sv(pTHX_ SV **svp, PADOFFSET *targp)
+        __attribute__visibility__("hidden");
+#   define PERL_ARGS_ASSERT_OP_RELOCATE_SV      \
+        assert(svp); assert(targp)
+
+# endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
 #else /* if !defined(USE_ITHREADS) */
 /* PERL_CALLCONV void
 CopFILEGV_set(pTHX_ COP *c, GV *gv); */

--- a/proto.h
+++ b/proto.h
@@ -5518,8 +5518,9 @@ Perl_PerlSock_socket_cloexec(pTHX_ int domain, int type, int protocol)
 # define PERL_ARGS_ASSERT_PERLSOCK_SOCKET_CLOEXEC
 
 #endif /* defined(HAS_SOCKET) */
-#if defined(HAS_SOCKETPAIR) || ( defined(AF_INET) && defined(HAS_SOCKET) && \
-    defined(PF_INET) && defined(SOCK_DGRAM) )
+#if   defined(HAS_SOCKETPAIR) ||                                     \
+    ( defined(AF_INET) && defined(HAS_SOCKET) && defined(PF_INET) && \
+      defined(SOCK_DGRAM) )
 PERL_CALLCONV int
 Perl_PerlSock_socketpair_cloexec(pTHX_ int domain, int type, int protocol, int *pairfd)
         __attribute__warn_unused_result__
@@ -6228,8 +6229,8 @@ Perl_croak_kw_unless_class(pTHX_ const char *kw);
 # define PERL_ARGS_ASSERT_CROAK_KW_UNLESS_CLASS \
         assert(kw)
 
-#endif /* defined(PERL_IN_CLASS_C) || defined(PERL_IN_OP_C)    || \
-          defined(PERL_IN_PAD_C)   || defined(PERL_IN_PERLY_C) || \
+#endif /* defined(PERL_IN_CLASS_C) || defined(PERL_IN_OP_C)    ||
+          defined(PERL_IN_PAD_C)   || defined(PERL_IN_PERLY_C) ||
           defined(PERL_IN_TOKE_C) */
 #if defined(PERL_IN_DEB_C)
 STATIC void
@@ -6298,9 +6299,10 @@ S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
         assert(sv); assert(tbl)
 
 #endif /* defined(PERL_IN_DOOP_C) */
-#if defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C)        || defined(PERL_IN_PP_C) \
-                            || defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_REGEXEC_C) || \
-    defined(PERL_IN_TOKE_C) || defined(PERL_IN_UTF8_C)
+#if defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
+    defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
+    defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
+    defined(PERL_IN_UTF8_C)
 
 PERL_CALLCONV SSize_t
 Perl__invlist_search(SV * const invlist, const UV cp)
@@ -6308,9 +6310,9 @@ Perl__invlist_search(SV * const invlist, const UV cp)
 # define PERL_ARGS_ASSERT__INVLIST_SEARCH       \
         assert(invlist)
 
-#endif /* defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
-          defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
-          defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
+#endif /* defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        ||
+          defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) ||
+          defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      ||
           defined(PERL_IN_UTF8_C) */
 #if defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY)
@@ -6358,7 +6360,7 @@ Perl__setup_canned_invlist(pTHX_ const STRLEN size, const UV element0, UV **othe
 # define PERL_ARGS_ASSERT__SETUP_CANNED_INVLIST \
         assert(other_elements_ptr)
 
-#endif /* defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
+#endif /* defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) ||
           defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C) */
 #if defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) || \
     defined(PERL_IN_TOKE_C)
@@ -6386,7 +6388,7 @@ Perl_grok_bslash_x(pTHX_ char **s, const char * const send, UV *uv, const char *
 # define PERL_ARGS_ASSERT_GROK_BSLASH_X         \
         assert(s); assert(send); assert(uv); assert(message)
 
-#endif /* defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) || \
+#endif /* defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) ||
           defined(PERL_IN_TOKE_C) */
 #if defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) || \
     defined(PERL_IN_TOKE_C)   || defined(PERL_IN_UTF8_C)
@@ -6778,7 +6780,7 @@ Perl_ck_trycatch(pTHX_ OP *o)
 # define PERL_ARGS_ASSERT_CK_TRYCATCH           \
         assert(o)
 
-#endif /* defined(PERL_IN_GLOBALS_C) || defined(PERL_IN_OP_C) || \
+#endif /* defined(PERL_IN_GLOBALS_C) || defined(PERL_IN_OP_C) ||
           defined(PERL_IN_PEEP_C) */
 #if defined(PERL_IN_GV_C)
 STATIC bool
@@ -6833,8 +6835,8 @@ S_gv_stashpvn_internal(pTHX_ const char *name, U32 namelen, I32 flags);
 
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_GV_C) */
-#if defined(PERL_IN_GV_C) || defined(PERL_IN_OP_C) || defined(PERL_IN_PAD_C) \
-                          || defined(PERL_IN_SV_C)
+#if defined(PERL_IN_GV_C)  || defined(PERL_IN_OP_C) || \
+    defined(PERL_IN_PAD_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV void
 Perl_sv_add_backref(pTHX_ SV * const tsv, SV * const sv)
         __attribute__visibility__("hidden");
@@ -7088,8 +7090,9 @@ S_update_PL_curlocales_i(pTHX_ const unsigned int index, const char *new_locale,
         assert(new_locale)
 
 #     endif
-#   elif defined(USE_LOCALE_THREADS) && !defined(USE_THREAD_SAFE_LOCALE) && \
-         !defined(USE_THREAD_SAFE_LOCALE_EMULATION) /* && \
+#   elif  defined(USE_LOCALE_THREADS) &&                  \
+         !defined(USE_THREAD_SAFE_LOCALE) &&              \
+         !defined(USE_THREAD_SAFE_LOCALE_EMULATION) /* &&
          !defined(USE_POSIX_2008_LOCALE) */
 STATIC const char *
 S_less_dicey_setlocale_r(pTHX_ const int category, const char *locale);
@@ -7107,11 +7110,13 @@ S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char *locale);
         assert(locale)
 
 #     endif
-#   endif /* !defined(USE_POSIX_2008_LOCALE) && ( defined(USE_LOCALE_THREADS) \
-             && !defined(USE_THREAD_SAFE_LOCALE) && \
-             !defined(USE_THREAD_SAFE_LOCALE_EMULATION) ) */
-#   if !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) && ( \
-       !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || defined(WIN32) )
+#   endif /*  defined(USE_LOCALE_THREADS) &&
+             !defined(USE_POSIX_2008_LOCALE) &&
+             !defined(USE_THREAD_SAFE_LOCALE) &&
+             !defined(USE_THREAD_SAFE_LOCALE_EMULATION) */
+#   if !(  defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) && \
+        ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) ||            \
+           defined(WIN32) )
 STATIC const char *
 S_calculate_LC_ALL(pTHX_ const char **individ_locales);
 #     define PERL_ARGS_ASSERT_CALCULATE_LC_ALL  \
@@ -7136,8 +7141,8 @@ S_wrap_wsetlocale(pTHX_ const int category, const char *locale);
 #     define PERL_ARGS_ASSERT_WRAP_WSETLOCALE
 
 #   endif /* defined(WIN32) */
-#   if defined(WIN32) || ( defined(USE_POSIX_2008_LOCALE) && \
-       !defined(USE_QUERYLOCALE) )
+#   if   defined(WIN32) || \
+       ( defined(USE_POSIX_2008_LOCALE) && !defined(USE_QUERYLOCALE) )
 STATIC const char *
 S_find_locale_from_environment(pTHX_ const unsigned int index);
 #     define PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT
@@ -7618,7 +7623,7 @@ Perl__new_invlist_C_array(pTHX_ const UV * const list)
 # define PERL_ARGS_ASSERT__NEW_INVLIST_C_ARRAY  \
         assert(list)
 
-#endif /* defined(PERL_IN_PERL_C) || defined(PERL_IN_REGCOMP_ANY) || \
+#endif /* defined(PERL_IN_PERL_C) || defined(PERL_IN_REGCOMP_ANY) ||
           defined(PERL_IN_UTF8_C) */
 #if defined(PERL_IN_PP_C)
 STATIC size_t
@@ -9995,9 +10000,9 @@ S_is_invlist(const SV * const invlist)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_IS_INVLIST
 
-# endif /* defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
-           defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
-           defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
+# endif /* defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        ||
+           defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) ||
+           defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      ||
            defined(PERL_IN_UTF8_C) */
 # if defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
      defined(PERL_IN_REGCOMP_ANY)
@@ -10022,7 +10027,7 @@ S_invlist_set_len(pTHX_ SV * const invlist, const UV len, const bool offset);
 #   define PERL_ARGS_ASSERT_INVLIST_SET_LEN     \
         assert(invlist)
 
-# endif /* defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
+# endif /* defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) ||
            defined(PERL_IN_REGCOMP_ANY) */
 # if defined(PERL_IN_OP_C) || defined(PERL_IN_PAD_C)
 PERL_STATIC_INLINE bool

--- a/proto.h
+++ b/proto.h
@@ -5380,7 +5380,7 @@ Perl_dump_sv_child(pTHX_ SV *sv)
 # define PERL_ARGS_ASSERT_DUMP_SV_CHILD         \
         assert(sv)
 
-#endif /* defined(DEBUG_LEAKING_SCALARS_FORK_DUMP) */
+#endif
 #if !defined(EBCDIC)
 
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
@@ -5389,15 +5389,15 @@ Perl_variant_byte_number(PERL_UINTMAX_T word)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_VARIANT_BYTE_NUMBER
 
-# endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
-#endif /* !defined(EBCDIC) */
+# endif
+#endif
 #if defined(F_FREESP) && !defined(HAS_CHSIZE) && !defined(HAS_TRUNCATE)
 PERL_CALLCONV I32
 Perl_my_chsize(pTHX_ int fd, Off_t length)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MY_CHSIZE
 
-#endif /* defined(F_FREESP) && !defined(HAS_CHSIZE) && !defined(HAS_TRUNCATE) */
+#endif
 #if !defined(HAS_GETENV_LEN)
 PERL_CALLCONV char *
 Perl_getenv_len(pTHX_ const char *env_elem, unsigned long *len)
@@ -5405,7 +5405,7 @@ Perl_getenv_len(pTHX_ const char *env_elem, unsigned long *len)
 # define PERL_ARGS_ASSERT_GETENV_LEN            \
         assert(env_elem); assert(len)
 
-#endif /* !defined(HAS_GETENV_LEN) */
+#endif
 #if !defined(HAS_MKOSTEMP)
 PERL_CALLCONV int
 Perl_my_mkostemp(char *templte, int flags)
@@ -5413,7 +5413,7 @@ Perl_my_mkostemp(char *templte, int flags)
 # define PERL_ARGS_ASSERT_MY_MKOSTEMP           \
         assert(templte)
 
-#endif /* !defined(HAS_MKOSTEMP) */
+#endif
 #if !defined(HAS_MKSTEMP)
 PERL_CALLCONV int
 Perl_my_mkstemp(char *templte)
@@ -5421,7 +5421,7 @@ Perl_my_mkstemp(char *templte)
 # define PERL_ARGS_ASSERT_MY_MKSTEMP            \
         assert(templte)
 
-#endif /* !defined(HAS_MKSTEMP) */
+#endif
 #if defined(HAS_MSG) || defined(HAS_SEM) || defined(HAS_SHM)
 PERL_CALLCONV I32
 Perl_do_ipcctl(pTHX_ I32 optype, SV **mark, SV **sp)
@@ -5469,7 +5469,7 @@ PERL_CALLCONV const char *
 Perl_langinfo8(const nl_item item, utf8ness_t *utf8ness);
 # define PERL_ARGS_ASSERT_PERL_LANGINFO8
 
-#else /* if !( defined(HAS_NL_LANGINFO) && defined(PERL_LANGINFO_H) ) */
+#else
 PERL_CALLCONV const char *
 Perl_langinfo(const int item);
 # define PERL_ARGS_ASSERT_PERL_LANGINFO
@@ -5478,7 +5478,7 @@ PERL_CALLCONV const char *
 Perl_langinfo8(const int item, utf8ness_t *utf8ness);
 # define PERL_ARGS_ASSERT_PERL_LANGINFO8
 
-#endif /* !( defined(HAS_NL_LANGINFO) && defined(PERL_LANGINFO_H) ) */
+#endif
 #if defined(HAS_PIPE)
 PERL_CALLCONV int
 Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd)
@@ -5487,7 +5487,7 @@ Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd)
 # define PERL_ARGS_ASSERT_PERLPROC_PIPE_CLOEXEC \
         assert(pipefd)
 
-#endif /* defined(HAS_PIPE) */
+#endif
 #if !defined(HAS_RENAME)
 PERL_CALLCONV I32
 Perl_same_dirent(pTHX_ const char *a, const char *b)
@@ -5495,7 +5495,7 @@ Perl_same_dirent(pTHX_ const char *a, const char *b)
 # define PERL_ARGS_ASSERT_SAME_DIRENT           \
         assert(a); assert(b)
 
-#endif /* !defined(HAS_RENAME) */
+#endif
 #if !defined(HAS_SIGNBIT)
 PERL_CALLCONV int
 Perl_signbit(NV f)
@@ -5503,7 +5503,7 @@ Perl_signbit(NV f)
         __attribute__pure__;
 # define PERL_ARGS_ASSERT_PERL_SIGNBIT
 
-#endif /* !defined(HAS_SIGNBIT) */
+#endif
 #if defined(HAS_SOCKET)
 PERL_CALLCONV int
 Perl_PerlSock_accept_cloexec(pTHX_ int listenfd, struct sockaddr *addr, Sock_size_t *addrlen)
@@ -5527,14 +5527,13 @@ Perl_PerlSock_socketpair_cloexec(pTHX_ int domain, int type, int protocol, int *
 # define PERL_ARGS_ASSERT_PERLSOCK_SOCKETPAIR_CLOEXEC \
         assert(pairfd)
 
-#endif /* defined(HAS_SOCKETPAIR) || ( defined(AF_INET) && \
-          defined(HAS_SOCKET) && defined(PF_INET) && defined(SOCK_DGRAM) ) */
+#endif
 #if !defined(HAS_STRLCPY)
 STATIC Size_t
 Perl_my_strlcpy(char *dst, const char *src, Size_t size);
 # define PERL_ARGS_ASSERT_MY_STRLCPY
 
-#endif /* !defined(HAS_STRLCPY) */
+#endif
 #if defined(HAVE_INTERP_INTERN)
 PERL_CALLCONV void
 Perl_sys_intern_clear(pTHX);
@@ -5550,7 +5549,7 @@ Perl_sys_intern_dup(pTHX_ struct interp_intern *src, struct interp_intern *dst);
 #   define PERL_ARGS_ASSERT_SYS_INTERN_DUP      \
         assert(src); assert(dst)
 
-# endif /* defined(USE_ITHREADS) */
+# endif
 #endif /* defined(HAVE_INTERP_INTERN) */
 #if defined(_MSC_VER)
 PERL_CALLCONV int
@@ -5559,7 +5558,7 @@ Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
 # define PERL_ARGS_ASSERT_MAGIC_REGDATUM_SET    \
         assert(sv); assert(mg)
 
-#else /* if !defined(_MSC_VER) */
+#else
 PERL_CALLCONV_NO_RET int
 Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
         __attribute__noreturn__
@@ -5567,7 +5566,7 @@ Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
 # define PERL_ARGS_ASSERT_MAGIC_REGDATUM_SET    \
         assert(sv); assert(mg)
 
-#endif /* !defined(_MSC_VER) */
+#endif
 #if defined(MULTIPLICITY)
 PERL_CALLCONV_NO_RET void
 Perl_croak_nocontext(const char *pat, ...)
@@ -6016,7 +6015,7 @@ PERL_CALLCONV GV *
 Perl_gv_SVadd(pTHX_ GV *gv);
 #   define PERL_ARGS_ASSERT_GV_SVADD
 
-# endif /* defined(PERL_DONT_CREATE_GVSV) */
+# endif
 # if defined(PERL_IN_OP_C) || defined(PERL_IN_PERLY_C) || \
      defined(PERL_IN_TOKE_C)
 PERL_CALLCONV OP *
@@ -6024,15 +6023,14 @@ Perl_ref(pTHX_ OP *o, I32 type)
         __attribute__visibility__("hidden");
 #   define PERL_ARGS_ASSERT_REF
 
-# endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PERLY_C) || \
-           defined(PERL_IN_TOKE_C) */
+# endif
 # if defined(USE_LOCALE_COLLATE)
 PERL_CALLCONV char *
 Perl_sv_collxfrm(pTHX_ SV * const sv, STRLEN * const nxp);
 #   define PERL_ARGS_ASSERT_SV_COLLXFRM         \
         assert(sv); assert(nxp)
 
-# endif /* defined(USE_LOCALE_COLLATE) */
+# endif
 #endif /* !defined(NO_MATHOMS) */
 #if defined(PERL_ANY_COW)
 PERL_CALLCONV SV *
@@ -6040,7 +6038,7 @@ Perl_sv_setsv_cow(pTHX_ SV *dsv, SV *ssv);
 # define PERL_ARGS_ASSERT_SV_SETSV_COW          \
         assert(ssv)
 
-#endif /* defined(PERL_ANY_COW) */
+#endif
 #if defined(PERL_CORE)
 PERL_CALLCONV void
 Perl_opslab_force_free(pTHX_ OPSLAB *slab)
@@ -6085,7 +6083,7 @@ S_should_warn_nl(const char *pv)
 #   define PERL_ARGS_ASSERT_SHOULD_WARN_NL      \
         assert(pv)
 
-# endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
+# endif
 #endif /* defined(PERL_CORE) */
 #if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV bool
@@ -6114,7 +6112,7 @@ Perl_sv_buf_to_ro(pTHX_ SV *sv)
 # define PERL_ARGS_ASSERT_SV_BUF_TO_RO          \
         assert(sv)
 
-#endif /* defined(PERL_DEBUG_READONLY_COW) */
+#endif
 #if defined(PERL_DEBUG_READONLY_OPS)
 PERL_CALLCONV PADOFFSET
 Perl_op_refcnt_dec(pTHX_ OP *o);
@@ -6133,14 +6131,14 @@ Perl_do_exec(pTHX_ const char *cmd)
 # define PERL_ARGS_ASSERT_DO_EXEC               \
         assert(cmd)
 
-#else /* if !defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION) */
+#else
 PERL_CALLCONV bool
 Perl_do_exec(pTHX_ const char *cmd)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_EXEC               \
         assert(cmd)
 
-#endif /* !defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION) */
+#endif
 #if defined(PERL_IMPLICIT_SYS)
 PERL_CALLCONV PerlInterpreter *
 perl_alloc_using(struct IPerlMem *ipM, struct IPerlMem *ipMS, struct IPerlMem *ipMP, struct IPerlEnv *ipE, struct IPerlStdIO *ipStd, struct IPerlLIO *ipLIO, struct IPerlDir *ipD, struct IPerlSock *ipS, struct IPerlProc *ipP);
@@ -6155,7 +6153,7 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags, struct IPerlMem *ipM, st
         assert(proto_perl); assert(ipM); assert(ipMS); assert(ipMP); assert(ipE); \
         assert(ipStd); assert(ipLIO); assert(ipD); assert(ipS); assert(ipP)
 
-# endif /* defined(USE_ITHREADS) */
+# endif
 #else /* if !defined(PERL_IMPLICIT_SYS) */
 PERL_CALLCONV I32
 Perl_my_pclose(pTHX_ PerlIO *ptr);
@@ -6173,7 +6171,7 @@ S_get_aux_mg(pTHX_ AV *av);
 # define PERL_ARGS_ASSERT_GET_AUX_MG            \
         assert(av)
 
-#endif /* defined(PERL_IN_AV_C) */
+#endif
 #if defined(PERL_IN_CLASS_C) || defined(PERL_IN_OP_C)    || \
     defined(PERL_IN_PAD_C)   || defined(PERL_IN_PERLY_C) || \
     defined(PERL_IN_TOKE_C)
@@ -6239,7 +6237,7 @@ S_deb_stack_n(pTHX_ SV **stack_base, I32 stack_min, I32 stack_max, I32 mark_min,
 # define PERL_ARGS_ASSERT_DEB_STACK_N           \
         assert(stack_base)
 
-#endif /* defined(PERL_IN_DEB_C) */
+#endif
 #if defined(PERL_IN_DOIO_C)
 STATIC bool
 S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explicit);
@@ -6317,8 +6315,7 @@ Perl__invlist_search(SV * const invlist, const UV cp)
 #if defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY)
 
-#endif /* defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
-          defined(PERL_IN_REGCOMP_ANY) */
+#endif
 #if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C)
 PERL_CALLCONV SV *
@@ -6398,8 +6395,7 @@ Perl_form_cp_too_large_msg(pTHX_ const U8 which, const char *string, const Size_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_FORM_CP_TOO_LARGE_MSG
 
-#endif /* defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) || \
-          defined(PERL_IN_TOKE_C)   || defined(PERL_IN_UTF8_C) */
+#endif
 #if defined(PERL_IN_DUMP_C)
 STATIC CV *
 S_deb_curcv(pTHX_ I32 ix);
@@ -6428,8 +6424,7 @@ Perl_hv_kill_backrefs(pTHX_ HV *hv)
 # define PERL_ARGS_ASSERT_HV_KILL_BACKREFS      \
         assert(hv)
 
-#endif /* defined(PERL_IN_DUMP_C)  || defined(PERL_IN_HV_C) || \
-          defined(PERL_IN_SCOPE_C) || defined(PERL_IN_SV_C) */
+#endif
 #if defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY)
 PERL_CALLCONV void
@@ -6437,8 +6432,7 @@ Perl__invlist_dump(pTHX_ PerlIO *file, I32 level, const char * const indent, SV 
 # define PERL_ARGS_ASSERT__INVLIST_DUMP         \
         assert(file); assert(indent); assert(invlist)
 
-#endif /* defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) || \
-          defined(PERL_IN_REGCOMP_ANY) */
+#endif
 #if defined(PERL_IN_GLOBALS_C) || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_PEEP_C)
 PERL_CALLCONV OP *
@@ -6847,14 +6841,13 @@ Perl_sv_add_backref(pTHX_ SV * const tsv, SV * const sv)
 # define PERL_ARGS_ASSERT_SV_ADD_BACKREF        \
         assert(tsv); assert(sv)
 
-#endif /* defined(PERL_IN_GV_C)  || defined(PERL_IN_OP_C) || \
-          defined(PERL_IN_PAD_C) || defined(PERL_IN_SV_C) */
+#endif
 #if defined(PERL_IN_GV_C) || defined(PERL_IN_UNIVERSAL_C)
 PERL_CALLCONV HV *
 Perl_gv_stashsvpvn_cached(pTHX_ SV *namesv, const char *name, U32 namelen, I32 flags)
         __attribute__visibility__("hidden");
 
-#endif /* defined(PERL_IN_GV_C) || defined(PERL_IN_UNIVERSAL_C) */
+#endif
 #if defined(PERL_IN_HV_C)
 STATIC void
 S_clear_placeholders(pTHX_ HV *hv, U32 items);
@@ -6924,7 +6917,7 @@ S_new_he(pTHX)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_NEW_HE
 
-# endif /* !defined(PURIFY) */
+# endif
 #endif /* defined(PERL_IN_HV_C) */
 #if defined(PERL_IN_HV_C) || defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV void
@@ -6933,8 +6926,7 @@ Perl_sv_kill_backrefs(pTHX_ SV * const sv, AV * const av)
 # define PERL_ARGS_ASSERT_SV_KILL_BACKREFS      \
         assert(sv)
 
-#endif /* defined(PERL_IN_HV_C) || defined(PERL_IN_MG_C) || \
-          defined(PERL_IN_SV_C) */
+#endif
 #if defined(PERL_IN_HV_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV SV *
 Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
@@ -6942,7 +6934,7 @@ Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
 # define PERL_ARGS_ASSERT_HFREE_NEXT_ENTRY      \
         assert(hv); assert(indexp)
 
-#endif /* defined(PERL_IN_HV_C) || defined(PERL_IN_SV_C) */
+#endif
 #if defined(PERL_IN_LOCALE_C)
 STATIC utf8ness_t
 S_get_locale_string_utf8ness_i(pTHX_ const char *string, const locale_utf8ness_t known_utf8, const char *locale, const unsigned cat_index);
@@ -7006,27 +6998,27 @@ S_my_setlocale_debug_string_i(pTHX_ const unsigned cat_index, const char *locale
         __attribute__warn_unused_result__;
 #     define PERL_ARGS_ASSERT_MY_SETLOCALE_DEBUG_STRING_I
 
-#   endif /* defined(DEBUGGING) */
+#   endif
 #   if defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L)
 STATIC const char *
 S_my_langinfo_i(pTHX_ const nl_item item, const unsigned int cat_index, const char *locale, const char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
 #     define PERL_ARGS_ASSERT_MY_LANGINFO_I     \
         assert(locale); assert(retbufp)
 
-#   else /* if !( defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L) ) */
+#   else
 STATIC const char *
 S_my_langinfo_i(pTHX_ const int item, const unsigned int cat_index, const char *locale, const char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
 #     define PERL_ARGS_ASSERT_MY_LANGINFO_I     \
         assert(locale); assert(retbufp)
 
-#   endif /* !( defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L) ) */
+#   endif
 #   if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE const char *
 S_mortalized_pv_copy(pTHX_ const char * const pv)
         __attribute__warn_unused_result__;
 #     define PERL_ARGS_ASSERT_MORTALIZED_PV_COPY
 
-#   endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
+#   endif
 #   if defined(USE_LOCALE_COLLATE)
 STATIC void
 S_new_collate(pTHX_ const char *newcoll, bool force);
@@ -7039,7 +7031,7 @@ S_print_collxfrm_input_and_return(pTHX_ const char *s, const char *e, const char
 #       define PERL_ARGS_ASSERT_PRINT_COLLXFRM_INPUT_AND_RETURN \
         assert(s); assert(e)
 
-#     endif /* defined(DEBUGGING) */
+#     endif
 #   endif /* defined(USE_LOCALE_COLLATE) */
 #   if defined(USE_LOCALE_CTYPE)
 STATIC bool
@@ -7059,13 +7051,13 @@ S_new_numeric(pTHX_ const char *newnum, bool force);
 #     define PERL_ARGS_ASSERT_NEW_NUMERIC       \
         assert(newnum)
 
-#   endif /* defined(USE_LOCALE_NUMERIC) */
+#   endif
 #   if defined(USE_PERL_SWITCH_LOCALE_CONTEXT) || defined(DEBUGGING)
 STATIC const char *
 S_get_LC_ALL_display(pTHX);
 #     define PERL_ARGS_ASSERT_GET_LC_ALL_DISPLAY
 
-#   endif /* defined(USE_PERL_SWITCH_LOCALE_CONTEXT) || defined(DEBUGGING) */
+#   endif
 #   if defined(USE_POSIX_2008_LOCALE)
 STATIC const char *
 S_emulate_setlocale_i(pTHX_ const unsigned int index, const char *new_locale, const recalc_lc_all_t recalc_LC_ALL, const line_t line);
@@ -7089,13 +7081,13 @@ STATIC const char *
 S_calculate_LC_ALL(pTHX_ const locale_t cur_obj);
 #       define PERL_ARGS_ASSERT_CALCULATE_LC_ALL
 
-#     else /* if !defined(USE_QUERYLOCALE) */
+#     else
 STATIC const char *
 S_update_PL_curlocales_i(pTHX_ const unsigned int index, const char *new_locale, recalc_lc_all_t recalc_LC_ALL);
 #       define PERL_ARGS_ASSERT_UPDATE_PL_CURLOCALES_I \
         assert(new_locale)
 
-#     endif /* !defined(USE_QUERYLOCALE) */
+#     endif
 #   elif defined(USE_LOCALE_THREADS) && !defined(USE_THREAD_SAFE_LOCALE) && \
          !defined(USE_THREAD_SAFE_LOCALE_EMULATION) /* && \
          !defined(USE_POSIX_2008_LOCALE) */
@@ -7114,7 +7106,7 @@ S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char *locale);
 #       define PERL_ARGS_ASSERT_LESS_DICEY_BOOL_SETLOCALE_R \
         assert(locale)
 
-#     endif /* 0 */
+#     endif
 #   endif /* !defined(USE_POSIX_2008_LOCALE) && ( defined(USE_LOCALE_THREADS) \
              && !defined(USE_THREAD_SAFE_LOCALE) && \
              !defined(USE_THREAD_SAFE_LOCALE_EMULATION) ) */
@@ -7125,9 +7117,7 @@ S_calculate_LC_ALL(pTHX_ const char **individ_locales);
 #     define PERL_ARGS_ASSERT_CALCULATE_LC_ALL  \
         assert(individ_locales)
 
-#   endif /* !( defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) \
-             && ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) || \
-             defined(WIN32) ) */
+#   endif
 #   if defined(WIN32)
 STATIC wchar_t *
 S_Win_byte_string_to_wstring(const UINT code_page, const char *byte_string);
@@ -7152,8 +7142,7 @@ STATIC const char *
 S_find_locale_from_environment(pTHX_ const unsigned int index);
 #     define PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT
 
-#   endif /* defined(WIN32) || ( defined(USE_POSIX_2008_LOCALE) && \
-             !defined(USE_QUERYLOCALE) ) */
+#   endif
 # endif /* defined(USE_LOCALE) */
 # if defined(USE_POSIX_2008_LOCALE) || defined(DEBUGGING)
 STATIC const char *
@@ -7161,7 +7150,7 @@ S_get_displayable_string(pTHX_ const char * const s, const char * const e, const
 #   define PERL_ARGS_ASSERT_GET_DISPLAYABLE_STRING \
         assert(s); assert(e)
 
-# endif /* defined(USE_POSIX_2008_LOCALE) || defined(DEBUGGING) */
+# endif
 #endif /* defined(PERL_IN_LOCALE_C) */
 #if defined(PERL_IN_MALLOC_C)
 STATIC int
@@ -7169,7 +7158,7 @@ S_adjust_size_and_find_bucket(size_t *nbytes_p);
 # define PERL_ARGS_ASSERT_ADJUST_SIZE_AND_FIND_BUCKET \
         assert(nbytes_p)
 
-#endif /* defined(PERL_IN_MALLOC_C) */
+#endif
 #if defined(PERL_IN_MG_C)
 STATIC void
 S_fixup_errno_string(pTHX_ SV *sv);
@@ -7207,7 +7196,7 @@ Perl_translate_substr_offsets(STRLEN curlen, IV pos1_iv, bool pos1_is_uv, IV len
 # define PERL_ARGS_ASSERT_TRANSLATE_SUBSTR_OFFSETS \
         assert(posp); assert(lenp)
 
-#endif /* defined(PERL_IN_MG_C) || defined(PERL_IN_PP_C) */
+#endif
 #if defined(PERL_IN_MRO_C)
 STATIC void
 S_mro_clean_isarev(pTHX_ HV * const isa, const char * const name, const STRLEN len, HV * const exceptions, U32 hash, U32 flags);
@@ -7230,7 +7219,7 @@ STATIC void
 S_output_non_portable(pTHX_ const U8 shift);
 # define PERL_ARGS_ASSERT_OUTPUT_NON_PORTABLE
 
-#endif /* defined(PERL_IN_NUMERIC_C) */
+#endif
 #if defined(PERL_IN_OP_C)
 STATIC void
 S_apply_attrs(pTHX_ HV *stash, SV *target, OP *attrs);
@@ -7455,11 +7444,10 @@ Perl_warn_elem_scalar_context(pTHX_ const OP *o, SV *name, bool is_hash, bool is
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_PERLY_C) || \
     defined(PERL_IN_TOKE_C)
 
-#endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PERLY_C) || \
-          defined(PERL_IN_TOKE_C) */
+#endif
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY)
 
-#endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY) */
+#endif
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV void
 Perl_report_redefined_cv(pTHX_ const SV *name, const CV *old_cv, SV * const *new_const_svp)
@@ -7500,7 +7488,7 @@ S_cv_dump(pTHX_ const CV *cv, const char *title);
 #   define PERL_ARGS_ASSERT_CV_DUMP             \
         assert(cv); assert(title)
 
-# endif /* defined(DEBUGGING) */
+# endif
 #endif /* defined(PERL_IN_PAD_C) */
 #if defined(PERL_IN_PEEP_C)
 STATIC void
@@ -7608,14 +7596,14 @@ S_incpush_if_exists(pTHX_ AV * const av, SV *dir, SV * const stem);
 #   define PERL_ARGS_ASSERT_INCPUSH_IF_EXISTS   \
         assert(av); assert(dir); assert(stem)
 
-# endif /* !defined(PERL_IS_MINIPERL) */
+# endif
 # if !defined(SETUID_SCRIPTS_ARE_SECURE_NOW)
 STATIC void
 S_validate_suid(pTHX_ PerlIO *rsfp);
 #   define PERL_ARGS_ASSERT_VALIDATE_SUID       \
         assert(rsfp)
 
-# endif /* !defined(SETUID_SCRIPTS_ARE_SECURE_NOW) */
+# endif
 #endif /* defined(PERL_IN_PERL_C) */
 #if defined(PERL_IN_PERL_C) || defined(PERL_IN_REGCOMP_ANY) || \
     defined(PERL_IN_UTF8_C)
@@ -7657,7 +7645,7 @@ Perl_softref2xv(pTHX_ SV * const sv, const char * const what, const svtype type,
 # define PERL_ARGS_ASSERT_SOFTREF2XV            \
         assert(sv); assert(what); assert(spp)
 
-#endif /* defined(PERL_IN_PP_C) || defined(PERL_IN_PP_HOT_C) */
+#endif
 #if defined(PERL_IN_PP_C) || defined(PERL_IN_UTF8_C)
 PERL_CALLCONV UV
 Perl__to_upper_title_latin1(pTHX_ const U8 c, U8 *p, STRLEN *lenp, const char S_or_s)
@@ -7665,7 +7653,7 @@ Perl__to_upper_title_latin1(pTHX_ const U8 c, U8 *p, STRLEN *lenp, const char S_
 # define PERL_ARGS_ASSERT__TO_UPPER_TITLE_LATIN1 \
         assert(p); assert(lenp)
 
-#endif /* defined(PERL_IN_PP_C) || defined(PERL_IN_UTF8_C) */
+#endif
 #if defined(PERL_IN_PP_CTL_C)
 STATIC PerlIO *
 S_check_type_and_open(pTHX_ SV *name)
@@ -7779,7 +7767,7 @@ S_doopen_pm(pTHX_ SV *name)
 #   define PERL_ARGS_ASSERT_DOOPEN_PM           \
         assert(name)
 
-# endif /* !defined(PERL_DISABLE_PMC) */
+# endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE bool
 S_path_is_searchable(const char *name)
@@ -7787,7 +7775,7 @@ S_path_is_searchable(const char *name)
 #   define PERL_ARGS_ASSERT_PATH_IS_SEARCHABLE  \
         assert(name)
 
-# endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
+# endif
 #endif /* defined(PERL_IN_PP_CTL_C) */
 #if defined(PERL_IN_PP_CTL_C) || defined(PERL_IN_UTIL_C)
 PERL_CALLCONV bool
@@ -7795,7 +7783,7 @@ Perl_invoke_exception_hook(pTHX_ SV *ex, bool warn)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_INVOKE_EXCEPTION_HOOK
 
-#endif /* defined(PERL_IN_PP_CTL_C) || defined(PERL_IN_UTIL_C) */
+#endif
 #if defined(PERL_IN_PP_HOT_C)
 STATIC void
 S_do_oddball(pTHX_ SV **oddkey, SV **firstkey);
@@ -8002,7 +7990,7 @@ S_dooneliner(pTHX_ const char *cmd, const char *filename)
 #   define PERL_ARGS_ASSERT_DOONELINER          \
         assert(cmd); assert(filename)
 
-# endif /* !defined(HAS_MKDIR) || !defined(HAS_RMDIR) */
+# endif
 #endif /* defined(PERL_IN_PP_SYS_C) */
 #if defined(PERL_IN_REGCOMP_ANY)
 PERL_CALLCONV void
@@ -8144,7 +8132,7 @@ Perl_invlist_clone(pTHX_ SV * const invlist, SV *newlist);
 # define PERL_ARGS_ASSERT_INVLIST_CLONE         \
         assert(invlist)
 
-#endif /* defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_SV_C) */
+#endif
 #if defined(PERL_IN_REGCOMP_C)
 STATIC AV *
 S_add_multi_match(pTHX_ AV *multi_char_matches, SV *multi_string, const STRLEN cp_count);
@@ -8356,7 +8344,7 @@ S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state, AV *stack, const I
 #     define PERL_ARGS_ASSERT_DUMP_REGEX_SETS_STRUCTURES \
         assert(pRExC_state); assert(stack); assert(fence_stack)
 
-#   endif /* defined(ENABLE_REGEX_SETS_DEBUGGING) */
+#   endif
 # endif /* defined(DEBUGGING) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE Size_t
@@ -8394,8 +8382,7 @@ Perl_is_grapheme(pTHX_ const U8 *strbeg, const U8 *s, const U8 *strend, const UV
 # define PERL_ARGS_ASSERT_IS_GRAPHEME           \
         assert(strbeg); assert(s); assert(strend)
 
-#endif /* defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
-          defined(PERL_IN_TOKE_C) */
+#endif
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
     defined(PERL_IN_UTF8_C)
 PERL_CALLCONV UV
@@ -8403,8 +8390,7 @@ Perl__to_fold_latin1(const U8 c, U8 *p, STRLEN *lenp, const unsigned int flags);
 # define PERL_ARGS_ASSERT__TO_FOLD_LATIN1       \
         assert(p); assert(lenp)
 
-#endif /* defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
-          defined(PERL_IN_UTF8_C) */
+#endif
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_TOKE_C)
 PERL_CALLCONV bool
 Perl_regcurly(const char *s, const char *e, const char *result[5])
@@ -8412,7 +8398,7 @@ Perl_regcurly(const char *s, const char *e, const char *result[5])
 # define PERL_ARGS_ASSERT_REGCURLY              \
         assert(s); assert(e)
 
-#endif /* defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_TOKE_C) */
+#endif
 #if defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING)
 STATIC U8
 S_put_charclass_bitmap_innards(pTHX_ SV *sv, char *bitmap, SV *nonbitmap_invlist, SV *only_utf8_locale_invlist, const regnode * const node, const U8 flags, const bool force_as_is_display);
@@ -8848,14 +8834,14 @@ Perl_get_re_gclass_aux_data(pTHX_ const regexp *prog, const struct regnode *node
 #   define PERL_ARGS_ASSERT_GET_RE_GCLASS_AUX_DATA \
         assert(node)
 
-# else /* if !defined(PERL_EXT_RE_BUILD) */
+# else
 PERL_CALLCONV SV *
 Perl_get_regclass_aux_data(pTHX_ const regexp *prog, const struct regnode *node, bool doinit, SV **listsvp, SV **lonly_utf8_locale, SV **output_invlist)
         __attribute__visibility__("hidden");
 #   define PERL_ARGS_ASSERT_GET_REGCLASS_AUX_DATA \
         assert(node)
 
-# endif /* !defined(PERL_EXT_RE_BUILD) */
+# endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE bool
 Perl_check_regnode_after(pTHX_ const regnode *p, const STRLEN extra)
@@ -9013,7 +8999,7 @@ S_del_sv(pTHX_ SV *p);
 #   define PERL_ARGS_ASSERT_DEL_SV              \
         assert(p)
 
-# endif /* defined(DEBUGGING) */
+# endif
 # if !defined(NV_PRESERVES_UV)
 #   if defined(DEBUGGING)
 STATIC int
@@ -9021,13 +9007,13 @@ S_sv_2iuv_non_preserve(pTHX_ SV * const sv, I32 numtype);
 #     define PERL_ARGS_ASSERT_SV_2IUV_NON_PRESERVE \
         assert(sv)
 
-#   else /* if !defined(DEBUGGING) */
+#   else
 STATIC int
 S_sv_2iuv_non_preserve(pTHX_ SV * const sv);
 #     define PERL_ARGS_ASSERT_SV_2IUV_NON_PRESERVE \
         assert(sv)
 
-#   endif /* !defined(DEBUGGING) */
+#   endif
 # endif /* !defined(NV_PRESERVES_UV) */
 # if defined(PERL_DEBUG_READONLY_COW)
 STATIC void
@@ -9035,7 +9021,7 @@ S_sv_buf_to_rw(pTHX_ SV *sv);
 #   define PERL_ARGS_ASSERT_SV_BUF_TO_RW        \
         assert(sv)
 
-# endif /* defined(PERL_DEBUG_READONLY_COW) */
+# endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE void
 S_sv_unglob(pTHX_ SV * const sv, U32 flags);
@@ -9309,7 +9295,7 @@ S_isa_lookup(pTHX_ HV *stash, SV *namesv, const char *name, STRLEN len, U32 flag
 STATIC bool
 S_sv_derived_from_svpvn(pTHX_ SV *sv, SV *namesv, const char *name, const STRLEN len, U32 flags);
 
-#endif /* defined(PERL_IN_UNIVERSAL_C) */
+#endif
 #if defined(PERL_IN_UTF8_C)
 STATIC UV
 S__to_utf8_case(pTHX_ const UV original, const U8 *p, U8 *ustrp, STRLEN *lenp, SV *invlist, const I32 * const invmap, const U32 * const * const aux_tables, const U8 * const aux_table_lengths, const char * const normal);
@@ -9365,7 +9351,7 @@ S_warn_on_first_deprecated_use(pTHX_ U32 category, const char * const name, cons
 #   define PERL_ARGS_ASSERT_WARN_ON_FIRST_DEPRECATED_USE \
         assert(name); assert(alternative); assert(file)
 
-# endif /* 0 */
+# endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE int
 S_does_utf8_overflow(const U8 * const s, const U8 *e, const bool consider_overlongs)
@@ -9418,19 +9404,19 @@ S_mem_log_common(enum mem_log_type mlt, const UV n, const UV typesize, const cha
 #   define PERL_ARGS_ASSERT_MEM_LOG_COMMON      \
         assert(type_name); assert(filename); assert(funcname)
 
-# endif /* defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL) */
+# endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE U32
 S_ptr_hash(PTRV u);
 #   define PERL_ARGS_ASSERT_PTR_HASH
 
-# endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
+# endif
 # if defined(PERL_USES_PL_PIDSTATUS)
 STATIC void
 S_pidgone(pTHX_ Pid_t pid, int status);
 #   define PERL_ARGS_ASSERT_PIDGONE
 
-# endif /* defined(PERL_USES_PL_PIDSTATUS) */
+# endif
 #endif /* defined(PERL_IN_UTIL_C) */
 #if defined(PERL_MEM_LOG)
 PERL_CALLCONV Malloc_t
@@ -9942,14 +9928,14 @@ PERL_STATIC_INLINE Size_t
 Perl_my_strlcat(char *dst, const char *src, Size_t size);
 #   define PERL_ARGS_ASSERT_MY_STRLCAT
 
-# endif /* !defined(HAS_STRLCAT) */
+# endif
 # if !defined(HAS_STRNLEN)
 PERL_STATIC_INLINE Size_t
 Perl_my_strnlen(const char *str, Size_t maxlen);
 #   define PERL_ARGS_ASSERT_MY_STRNLEN          \
         assert(str)
 
-# endif /* !defined(HAS_STRNLEN) */
+# endif
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE bool
 Perl_is_utf8_non_invariant_string(const U8 * const s, STRLEN len)
@@ -9974,7 +9960,7 @@ S_my_memrchr(const char *s, const char c, const STRLEN len);
 #     define PERL_ARGS_ASSERT_MY_MEMRCHR        \
         assert(s)
 
-#   endif /* !defined(HAS_MEMRCHR) */
+#   endif
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
      defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
@@ -10044,7 +10030,7 @@ S_PadnameIN_SCOPE(const PADNAME * const pn, const U32 seq);
 #   define PERL_ARGS_ASSERT_PADNAMEIN_SCOPE     \
         assert(pn)
 
-# endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PAD_C) */
+# endif
 # if defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY)
 PERL_STATIC_INLINE STRLEN *
 S_get_invlist_iter_addr(SV *invlist)
@@ -10076,7 +10062,7 @@ S_lossless_NV_to_IV(const NV nv, IV *ivp)
 #   define PERL_ARGS_ASSERT_LOSSLESS_NV_TO_IV   \
         assert(ivp)
 
-# endif /* defined(PERL_IN_PP_C) || defined(PERL_IN_PP_HOT_C) */
+# endif
 # if defined(PERL_IN_PP_C)   || defined(PERL_IN_REGCOMP_ANY) || \
      defined(PERL_IN_TOKE_C) || defined(PERL_IN_UNIVERSAL_C)
 PERL_STATIC_INLINE const char *
@@ -10084,8 +10070,7 @@ S_get_regex_charset_name(const U32 flags, STRLEN * const lenp);
 #   define PERL_ARGS_ASSERT_GET_REGEX_CHARSET_NAME \
         assert(lenp)
 
-# endif /* defined(PERL_IN_PP_C)   || defined(PERL_IN_REGCOMP_ANY) || \
-           defined(PERL_IN_TOKE_C) || defined(PERL_IN_UNIVERSAL_C) */
+# endif
 # if defined(U64TYPE)
 PERL_STATIC_INLINE unsigned
 Perl_lsbit_pos64(U64 word)
@@ -10115,7 +10100,7 @@ S_PerlEnv_putenv(pTHX_ char *str);
 #     define PERL_ARGS_ASSERT_PERLENV_PUTENV    \
         assert(str)
 
-#   endif /* !defined(PERL_IMPLICIT_SYS) */
+#   endif
 # endif /* defined(USE_ITHREADS) */
 # if !defined(WIN32)
 PERL_STATIC_INLINE void *
@@ -10123,7 +10108,7 @@ Perl_get_context(void)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_GET_CONTEXT
 
-# endif /* !defined(WIN32) */
+# endif
 #endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #if defined(PERL_USE_3ARG_SIGHANDLER)
 PERL_CALLCONV Signal_t
@@ -10148,14 +10133,14 @@ Perl_sighandler(int sig)
 #endif /* !defined(PERL_USE_3ARG_SIGHANDLER) */
 #if defined(U64TYPE)
 
-#endif /* defined(U64TYPE) */
+#endif
 #if defined(UNLINK_ALL_VERSIONS)
 PERL_CALLCONV I32
 Perl_unlnk(pTHX_ const char *f);
 # define PERL_ARGS_ASSERT_UNLNK                 \
         assert(f)
 
-#endif /* defined(UNLINK_ALL_VERSIONS) */
+#endif
 #if defined(USE_C_BACKTRACE)
 PERL_CALLCONV bool
 Perl_dump_c_backtrace(pTHX_ PerlIO *fp, int max_depth, int skip);
@@ -10349,12 +10334,12 @@ Perl_op_relocate_sv(pTHX_ SV **svp, PADOFFSET *targp)
 #   define PERL_ARGS_ASSERT_OP_RELOCATE_SV      \
         assert(svp); assert(targp)
 
-# endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
+# endif
 #else /* if !defined(USE_ITHREADS) */
 /* PERL_CALLCONV void
 CopFILEGV_set(pTHX_ COP *c, GV *gv); */
 
-#endif /* !defined(USE_ITHREADS) */
+#endif
 #if defined(USE_LOCALE_COLLATE)
 PERL_CALLCONV int
 Perl_magic_freecollxfrm(pTHX_ SV *sv, MAGIC *mg)
@@ -10386,8 +10371,7 @@ Perl_mem_collxfrm_(pTHX_ const char *input_string, STRLEN len, STRLEN *xlen, boo
 #   define PERL_ARGS_ASSERT_MEM_COLLXFRM_       \
         assert(input_string); assert(xlen)
 
-# endif /* defined(PERL_IN_LOCALE_C) || defined(PERL_IN_MATHOMS_C) || \
-           defined(PERL_IN_SV_C) */
+# endif
 #endif /* defined(USE_LOCALE_COLLATE) */
 #if defined(USE_PERLIO)
 PERL_CALLCONV void
@@ -10500,7 +10484,7 @@ PERL_CALLCONV void
 Perl_switch_locale_context(void);
 # define PERL_ARGS_ASSERT_SWITCH_LOCALE_CONTEXT
 
-#endif /* defined(USE_PERL_SWITCH_LOCALE_CONTEXT) */
+#endif
 #if defined(USE_QUADMATH)
 PERL_CALLCONV bool
 Perl_quadmath_format_needed(const char *format)
@@ -10556,7 +10540,7 @@ Perl_do_exec3(pTHX_ const char *incmd, int fd, int do_report)
 # define PERL_ARGS_ASSERT_DO_EXEC3              \
         assert(incmd)
 
-#endif /* !defined(WIN32) */
+#endif
 
 #ifdef PERL_CORE
 #  include "pp_proto.h"


### PR DESCRIPTION
This is a collection of format fixes to the embed.fnc autoformat rules.

* Change canonical order of expressions so that expressions with less conditions go first. Eg, `X && (P || Q || R)` should put X first. 

* Flatten binary ops with sub expressions using the same operator. Eg, `X && (P && Q && R)` ends up as `X && P && Q && R`.

* Try to put parenthesized sub expressions on their own line. Eg, 
```
#if (defined(X) && defined(Y)) || (defined(P) && defined(Q))
``` 
now is formatted as:
```
#if (defined(X) && defined(Y)) || \
    (defined(P) && defined(Q))
```
An actual change from this PR is as follows:
```
-#if defined(HAS_SOCKETPAIR) || ( defined(AF_INET) && defined(HAS_SOCKET) && \
-    defined(PF_INET) && defined(SOCK_DGRAM) )
+#if   defined(HAS_SOCKETPAIR) ||                                     \
+    ( defined(AF_INET) && defined(HAS_SOCKET) && defined(PF_INET) && \
+      defined(SOCK_DGRAM) )
```

* Previously we showed a "governing expression comment" in all `#else` and `#endif` lines. This is now controlled by how many lines there were since the governing expression was output, specifically, if there are less 10 lines then it is NOT shown as it just ends up adding "noise" to the output.  This is configurable for code that wants to change the line count.   An example of this is the following test:
```
        #if !!!(defined(A) && defined(B))
        #define NOT_A_AND_B
        #endif
        #if defined(A)
        #if defined(B)
        #define A_AND_B
        #endif
        #endif
```
with the `add_commented_expr_after` config option set to 0, instead of its default of 10 this outputs as
```
        #if defined(A) && defined(B)
        # define A_AND_B
        #else /* if !( defined(A) && defined(B) ) */
        # define NOT_A_AND_B
        #endif /* !( defined(A) && defined(B) ) */
```
the "governing expression" are the `/* if !( defined(A) && defined(B) ) */` type clauses that have been added to the `#else` and `#endif`.  These comments make it much easier to tell what is going on when there are lot of lines between the `#else` or `#endif` and if the `#if` or `#elif` the clause relates to, but are less helpful when there are only a few lines between the two clauses. The default of '10 lines' was chosen arbitrarily, but seems to work out ok. We can adjust later if necessary.

* Improvements to lining up expressions. In the previous code we tried to stuff as much onto one line as possible (using Text::Wrap::wrap), and then we tried to line up `defined()` and `||` expressions. This worked ok in most situations, but in some cases it went a bit wrong, typically when the `||` operator ended up at the *start* of a new line. With this patch the splitting logic is more intelligent and ensures that operators are trailing on a line, not leading. An example is the following:
```
-#if defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C)        || defined(PERL_IN_PP_C) \
-                            || defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_REGEXEC_C) || \
-    defined(PERL_IN_TOKE_C) || defined(PERL_IN_UTF8_C)
+#if defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
+    defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
+    defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
+    defined(PERL_IN_UTF8_C)
```
As can be seen the old code got confused by the leading operator and pushed the next line over so it could line up the `||` operators. The new code ensures each line starts with a defined() function and ends up lining up the code much more nicely.

* Add test for a complex expression that Karl used as an example:
```
        #if  defined(DEBUGGING)                                                    \
             || (defined(USE_LOCALE) && (    defined(USE_THREADS)                  \
                                        ||   defined(HAS_IGNORED_LOCALE_CATEGORIES)\
                                        ||   defined(USE_POSIX_2008_LOCALE)        \
                                        || ! defined(LC_ALL)))
        # define X
        #endif
```
is now formatted (assuming it had enough lines that it triggered the "governing expression comment logic") as
```
        #if   defined(DEBUGGING) ||                                         \
            ( defined(USE_LOCALE) &&                                        \
            ( defined(HAS_IGNORED_LOCALE_CATEGORIES) || !defined(LC_ALL) || \
              defined(USE_POSIX_2008_LOCALE) || defined(USE_THREADS) ) )
        # define X
        #endif /*   defined(DEBUGGING) ||
                  ( defined(USE_LOCALE) &&
                  ( defined(HAS_IGNORED_LOCALE_CATEGORIES) || !defined(LC_ALL) ||
                    defined(USE_POSIX_2008_LOCALE) || defined(USE_THREADS) ) ) */
```
instead of
```
        #if ( ( defined(HAS_IGNORED_LOCALE_CATEGORIES) || !defined(LC_ALL) || \
            defined(USE_POSIX_2008_LOCALE)             || defined(USE_THREADS) ) && \
            defined(USE_LOCALE) )                      || defined(DEBUGGING)
        # define X
        #endif /* ( ( defined(HAS_IGNORED_LOCALE_CATEGORIES) || !defined(LC_ALL) || \
                  defined(USE_POSIX_2008_LOCALE)             || defined(USE_THREADS) ) && \
                  defined(USE_LOCALE) )                      || defined(DEBUGGING) */
```
Which was obviously not as nice to read. 