### PR TITLE
.PHONY not portable in dist/Locale-Maketext/Makefile.PL

### DIFF
--- a/dist/Locale-Maketext/Makefile.PL
+++ b/dist/Locale-Maketext/Makefile.PL
@@ -28,8 +28,15 @@ WriteMakefile(
 );
 
 sub MY::postamble {
-    return <<'MAKE_FRAG';
-.PHONY: tags critic
+    # .PHONY is not portable
+    my $self = shift;
+    my $phony_line = $self->can('is_make_type')
+                     && ($self->is_make_type('gmake')
+                         || $self->is_make_type('bsdmake'))
+                     ? '.PHONY: tags critic'
+                     : '';
+
+    return "$phony_line\n\n" . <<'MAKE_FRAG';
 
 tags:
 	ctags -f tags --recurse --totals \

--- a/dist/Locale-Maketext/lib/Locale/Maketext.pm
+++ b/dist/Locale-Maketext/lib/Locale/Maketext.pm
@@ -25,7 +25,7 @@ BEGIN {
 }
 
 
-our $VERSION = '1.32';
+our $VERSION = '1.33';
 our @ISA = ();
 
 our $MATCH_SUPERS = 1;


### PR DESCRIPTION
It breaks the build on VMS because .PHONY is a syntax error in the native make-like utilities.  It probably also breaks nmake builds on Windows.

The solution here is to exclude the entire postamble with the .PHONY directive and the developer convenience targets when the build is running in core.  This may be a slightly bigger hammer than necessary but seems safe and simple enough.