### PR TITLE
PERL_SET_LOCALE_CONTEXT: Actually do something

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -6365,7 +6365,7 @@ EXTCONST U8   PL_deBruijn_bitpos_tab64[];
 #ifdef USE_PERL_SWITCH_LOCALE_CONTEXT
 #  define PERL_SET_LOCALE_CONTEXT(i)                                        \
       STMT_START {                                                          \
-          if (UNLIKELY(PL_veto_switch_non_tTHX_context))                    \
+          if (LIKELY(! PL_veto_switch_non_tTHX_context))                    \
                 Perl_switch_locale_context();                               \
       } STMT_END
 #else


### PR DESCRIPTION
This is a macro that does a quick check before calling a function to actually do the work.  The sense of that check was reversed.

The check is repeated in the function, but this time correctly.

The bottom line was if the function should be called, the macro failed to call it.  If it shouldn't be called the macro would call it, but the check in the function caused it to return without doing anything.  Hence this whole thing was a no-op.

However, I cant get things to fail without this patch.  ISTR this was the result of a BBC, with another one likely affected, but I can't find them now.