### PR TITLE
Unbreak Perl build on legacy Darwin systems

### DIFF
--- a/dist/ExtUtils-CBuilder/Changes
+++ b/dist/ExtUtils-CBuilder/Changes
@@ -1,5 +1,17 @@
 Revision history for Perl extension ExtUtils::CBuilder.
 
+0.280243 - 2026-02-23
+
+  Fix:
+  - Unbreak Perl build on legacy Darwin systems.
+    On modern macOS the compiler defaults to
+    '-Werror,-Wimplicit-function-declaration'. This breaks the build on code
+    which calls a function without a prototype (invalid in C99).
+    Turning the check off with '-Wno-error=implicit-function-declaration' breaks
+    the build of Perl itself on legacy versions of Darwin with compilers which do
+    not recognise the flags.
+    https://github.com/Perl/perl5/issues/18902
+
 0.280242
 
  Fix:

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder.pm
@@ -7,7 +7,7 @@ use Perl::OSType qw/os_type/;
 
 use warnings;
 use strict;
-our $VERSION = '0.280242'; # VERSION
+our $VERSION = '0.280243'; # VERSION
 our @ISA;
 
 # We only use this once - don't waste a symbol table entry on it.

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
@@ -9,7 +9,7 @@ use Text::ParseWords;
 use IPC::Cmd qw(can_run);
 use File::Temp qw(tempfile);
 
-our $VERSION = '0.280242'; # VERSION
+our $VERSION = '0.280243'; # VERSION
 
 # More details about C/C++ compilers:
 # http://developers.sun.com/sunstudio/documentation/product/compiler.jsp

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Unix.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Unix.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Base;
 
-our $VERSION = '0.280242'; # VERSION
+our $VERSION = '0.280243'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Base);
 
 sub link_executable {

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/VMS.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/VMS.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Base;
 
-our $VERSION = '0.280242'; # VERSION
+our $VERSION = '0.280243'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Base);
 
 use File::Spec::Functions qw(catfile catdir);

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows.pm
@@ -8,7 +8,7 @@ use File::Spec;
 use ExtUtils::CBuilder::Base;
 use IO::File;
 
-our $VERSION = '0.280242'; # VERSION
+our $VERSION = '0.280243'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Base);
 
 =begin comment

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/BCC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/BCC.pm
@@ -1,6 +1,6 @@
 package ExtUtils::CBuilder::Platform::Windows::BCC;
 
-our $VERSION = '0.280242'; # VERSION
+our $VERSION = '0.280243'; # VERSION
 
 use strict;
 use warnings;

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/GCC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/GCC.pm
@@ -1,6 +1,6 @@
 package ExtUtils::CBuilder::Platform::Windows::GCC;
 
-our $VERSION = '0.280242'; # VERSION
+our $VERSION = '0.280243'; # VERSION
 
 use warnings;
 use strict;

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/MSVC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/MSVC.pm
@@ -1,6 +1,6 @@
 package ExtUtils::CBuilder::Platform::Windows::MSVC;
 
-our $VERSION = '0.280242'; # VERSION
+our $VERSION = '0.280243'; # VERSION
 
 use warnings;
 use strict;

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/aix.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/aix.pm
@@ -5,7 +5,7 @@ use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 use File::Spec;
 
-our $VERSION = '0.280242'; # VERSION
+our $VERSION = '0.280243'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub need_prelink { 1 }

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/android.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/android.pm
@@ -6,7 +6,7 @@ use File::Spec;
 use ExtUtils::CBuilder::Platform::Unix;
 use Config;
 
-our $VERSION = '0.280242'; # VERSION
+our $VERSION = '0.280243'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 # The Android linker will not recognize symbols from

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/cygwin.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/cygwin.pm
@@ -5,7 +5,7 @@ use strict;
 use File::Spec;
 use ExtUtils::CBuilder::Platform::Unix;
 
-our $VERSION = '0.280242'; # VERSION
+our $VERSION = '0.280243'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 # TODO: If a specific exe_file name is requested, if the exe created

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/darwin.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/darwin.pm
@@ -5,7 +5,7 @@ use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 use Config;
 
-our $VERSION = '0.280242'; # VERSION
+our $VERSION = '0.280243'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 my ($osver) = split /\./, $Config{osvers};
@@ -19,9 +19,6 @@ sub compile {
   # it's mistakenly in Config.pm as both.  Make the correction here.
   local $cf->{ccflags} = $cf->{ccflags};
   $cf->{ccflags} =~ s/-flat_namespace//;
-
-  # XCode 12 makes this fatal, breaking tons of XS modules
-  $cf->{ccflags} .= ($cf->{ccflags} ? ' ' : '').'-Wno-error=implicit-function-declaration';
 
   $self->SUPER::compile(@_);
 }

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/dec_osf.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/dec_osf.pm
@@ -5,7 +5,7 @@ use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 use File::Spec;
 
-our $VERSION = '0.280242'; # VERSION
+our $VERSION = '0.280243'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub link_executable {

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/os2.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/os2.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 
-our $VERSION = '0.280242'; # VERSION
+our $VERSION = '0.280243'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub need_prelink { 1 }


### PR DESCRIPTION
On modern macOS the compiler defaults to '-Werror,-Wimplicit-function-declaration' This breaks the build on code which calls a function without a prototype (invalid in C99).
Turning the check off with '-Wno-error=implicit-function-declaration' breaks the build of Perl itself on legacy versions of Darwin with compilers which do not recognise the flags.
Removing it allows Perl to once again build on Mac OS X as old as 10.4 with GCC 4.0.1.

Resolves #18902 