### PR TITLE
t/TEST: trim .DIR extension on VMS

### DIFF
--- a/t/TEST
+++ b/t/TEST
@@ -207,7 +207,7 @@ sub _find_files {
 	opendir DIR, $dir or die "Trouble opening $dir: $!";
 	foreach my $f (sort { $a cmp $b } readdir DIR) {
 	    next if $skip{$f};
-
+	    $dir =~ s/(?<!\^)\.dir(;1)?$//i if $is_vms; # trim .DIR extension
 	    my $fullpath = "$dir/$f";
 	    if (-d $fullpath) {
 		_find_files($patt, $fullpath);


### PR DESCRIPTION
Otherwise the test suite dies with:

Can't read op/hook.DIR/require.t.

The problem never arose until 93f6f9654a81b66c4 added another directory one level down from those immediately under t/.