### PR TITLE
t/harness: avoid brace expansion for -dumptests

### DIFF
--- a/t/harness
+++ b/t/harness
@@ -116,28 +116,6 @@ if ($ENV{HARNESS_OPTIONS}) {
 
 $jobs ||= 1;
 
-sub _extract_tests;
-sub _extract_tests {
-    # This can probably be done more tersely with a map, but I doubt that it
-    # would be as clear
-    my @results;
-    foreach (@_) {
-        my $ref = ref $_;
-        if ($ref) {
-            if ($ref eq 'ARRAY') {
-                push @results, _extract_tests @$_;
-            } elsif ($ref eq 'HASH') {
-                push @results, _extract_tests values %$_;
-            } else {
-                die "Unknown reference type $ref";
-            }
-        } else {
-            push @results, glob $_;
-        }
-    }
-    @results;
-}
-
 my %total_time;
 sub _compute_tests_and_ordering($) {
     my @tests = $_[0]->@*;
@@ -367,14 +345,12 @@ if (@ARGV) {
         push @$which, 'bigmem' if $ENV{PERL_TEST_MEMORY};
 
         if (@next) {
-            my $next = { par => '{' . join (',', @next) . '}/*.t' };
-            @next = _extract_tests ($next);
+            @next = map { glob ("$_/*.t") } @next;
             push @tests, @next;
             push @seq, _compute_tests_and_ordering(\@next)->@*;
         }
 
-        my $last = { par => '{' . join (',', @last) . '}/*.t' };
-        @last = _extract_tests ($last);
+        @last = map { glob ("$_/*.t") } @last;
 
         my ($non_ext, @ext_from_manifest)=
             _tests_from_manifest($Config{extensions}, $Config{known_extensions}, "all");


### PR DESCRIPTION
Brace expansion is not available in a POSIX shell, is handled slightly differently by the shells that do support it, and is unlikely to work when the underlying implementation for Perl's glob() function is not a Unix shell.  So instead of doing:

    {foo,bar,baz}/*.t

just accumulate the results of simpler glob operations:

    foo/*.t
    bar/*.t
    baz/*.t

This also allows us to dispense with the recursive function _extract_tests() and its fancy dispatch based on reference type; we would only ever be calling it with a simple string argument, so we might as well just call glob() directly.