### PR TITLE
reset(): call set magic when clearing SVs

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -10126,7 +10126,10 @@ Perl_sv_resetpvn(pTHX_ const char *s, STRLEN len, HV * const stash)
                 sv = GvSV(gv);
                 if (sv && !SvREADONLY(sv)) {
                     SV_CHECK_THINKFIRST_COW_DROP(sv);
-                    if (!isGV(sv)) SvOK_off(sv);
+                    if (!isGV(sv)) {
+                        SvOK_off(sv);
+                        SvSETMAGIC(sv);
+                    }
                 }
                 if (GvAV(gv)) {
                     av_clear(GvAV(gv));

--- a/t/op/reset.t
+++ b/t/op/reset.t
@@ -7,7 +7,7 @@ BEGIN {
 }
 use strict;
 
-plan tests => 40;
+plan tests => 45;
 
 package aiieee;
 
@@ -188,6 +188,30 @@ SKIP:
 			  "first pattern $eight$eight, second $nine$nine");
 	}
     }
+}
+
+# magic reset #20763
+{
+    {
+        local $^W = 1; # we're resetting this
+        my $warn = '';
+        local $SIG{__WARN__} = sub { $warn .= "@_\n" };
+        reset "\cW";
+        like($warn, qr/uninitialized/, "magic tries to SvIV() the new value");
+        $warn = '';
+        is($^W, 0, q"check $^W has been zeroed");
+        is($warn, '', "should be no more warnings");
+    }
+    {
+        local $| = 1;
+        no warnings 'uninitialized';
+        reset '|';
+        is($|, 0, q"check magic applied to $|");
+    }
+
+    eval { reset "1" };
+    like($@, qr/Modification of a read-only value attempted/,
+         "\$1 isn't marked read-only, but throws on set magic");
 }
 
 __DATA__


### PR DESCRIPTION
`reset()` with an argument would clear the specified SVs when requested but didn't call set magic, this would result in the effect on magic variables not applying, such as the `$|` and `$^W` used in the ticket.

This isn't a problem for AVs and HVs as their corresponding clear functions do call the appropriate clear magic.

Fixes #20763