### PR TITLE
eliminate or suppress various header warnings under MSVC with /W4

### DIFF
--- a/cop.h
+++ b/cop.h
@@ -29,6 +29,8 @@
  * GSAR 97-03-27
  */
 
+MSVC_DIAG_IGNORE(4324)
+
 struct jmpenv {
     struct jmpenv *	je_prev;
     Sigjmp_buf		je_buf;		/* uninit if je_prev is NULL */
@@ -37,6 +39,8 @@ struct jmpenv {
     U16                 je_old_delaymagic; /* saved PL_delaymagic */
     SSize_t             je_old_stack_hwm;
 };
+
+MSVC_DIAG_RESTORE
 
 typedef struct jmpenv JMPENV;
 

--- a/inline.h
+++ b/inline.h
@@ -2834,7 +2834,7 @@ Perl_cx_popsub_common(pTHX_ PERL_CONTEXT *cx)
     assert(CxTYPE(cx) == CXt_SUB);
 
     PL_comppad = cx->blk_sub.prevcomppad;
-    PL_curpad = LIKELY(PL_comppad) ? AvARRAY(PL_comppad) : NULL;
+    PL_curpad = LIKELY(PL_comppad != NULL) ? AvARRAY(PL_comppad) : NULL;
     cv = cx->blk_sub.cv;
     CvDEPTH(cv) = cx->blk_sub.olddepth;
     cx->blk_sub.cv = NULL;
@@ -2916,7 +2916,7 @@ Perl_cx_popformat(pTHX_ PERL_CONTEXT *cx)
     SvREFCNT_dec_NN(dfout);
 
     PL_comppad = cx->blk_format.prevcomppad;
-    PL_curpad = LIKELY(PL_comppad) ? AvARRAY(PL_comppad) : NULL;
+    PL_curpad = LIKELY(PL_comppad != NULL) ? AvARRAY(PL_comppad) : NULL;
     cv = cx->blk_format.cv;
     cx->blk_format.cv = NULL;
     --CvDEPTH(cv);

--- a/inline.h
+++ b/inline.h
@@ -2812,7 +2812,7 @@ Perl_cx_pushsub(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, bool hasargs)
 
     PERL_DTRACE_PROBE_ENTRY(cv);
     cx->blk_sub.old_cxsubix     = PL_curstackinfo->si_cxsubix;
-    PL_curstackinfo->si_cxsubix = cx - PL_curstackinfo->si_cxstack;
+    PL_curstackinfo->si_cxsubix = (I32)(cx - PL_curstackinfo->si_cxstack);
     cx->blk_sub.cv = cv;
     cx->blk_sub.olddepth = CvDEPTH(cv);
     cx->blk_sub.prevcomppad = PL_comppad;
@@ -2887,7 +2887,7 @@ Perl_cx_pushformat(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, GV *gv)
     PERL_ARGS_ASSERT_CX_PUSHFORMAT;
 
     cx->blk_format.old_cxsubix = PL_curstackinfo->si_cxsubix;
-    PL_curstackinfo->si_cxsubix= cx - PL_curstackinfo->si_cxstack;
+    PL_curstackinfo->si_cxsubix= (I32)(cx - PL_curstackinfo->si_cxstack);
     cx->blk_format.cv          = cv;
     cx->blk_format.retop       = retop;
     cx->blk_format.gv          = gv;
@@ -2948,7 +2948,7 @@ Perl_cx_pusheval(pTHX_ PERL_CONTEXT *cx, OP *retop, SV *namesv)
     Perl_push_evalortry_common(aTHX_ cx, retop, namesv);
 
     cx->blk_eval.old_cxsubix    = PL_curstackinfo->si_cxsubix;
-    PL_curstackinfo->si_cxsubix = cx - PL_curstackinfo->si_cxstack;
+    PL_curstackinfo->si_cxsubix = (I32)(cx - PL_curstackinfo->si_cxstack);
 }
 
 PERL_STATIC_INLINE void

--- a/inline.h
+++ b/inline.h
@@ -3491,6 +3491,7 @@ Perl_mortal_getenv(const char * str)
 PERL_STATIC_INLINE bool
 Perl_sv_isbool(pTHX_ const SV *sv)
 {
+    PERL_UNUSED_CONTEXT;
     return SvBoolFlagsOK(sv) && BOOL_INTERNALS_sv_isbool(sv);
 }
 

--- a/inline.h
+++ b/inline.h
@@ -3156,6 +3156,8 @@ range bytes match only themselves.
 PERL_STATIC_INLINE I32
 Perl_foldEQ(pTHX_ const char *s1, const char *s2, I32 len)
 {
+    PERL_UNUSED_CONTEXT;
+
     const U8 *a = (const U8 *)s1;
     const U8 *b = (const U8 *)s2;
 
@@ -3178,6 +3180,8 @@ Perl_foldEQ_latin1(pTHX_ const char *s1, const char *s2, I32 len)
      * representable without UTF-8, except for LATIN_SMALL_LETTER_SHARP_S, and
      * does not check for this.  Nor does it check that the strings each have
      * at least 'len' characters. */
+
+    PERL_UNUSED_CONTEXT;
 
     const U8 *a = (const U8 *)s1;
     const U8 *b = (const U8 *)s2;

--- a/sv_inline.h
+++ b/sv_inline.h
@@ -567,6 +567,8 @@ Perl_SvPVXtrue(pTHX_ SV *sv)
 {
     PERL_ARGS_ASSERT_SVPVXTRUE;
 
+    PERL_UNUSED_CONTEXT;
+
     if (! (XPV *) SvANY(sv)) {
         return false;
     }

--- a/utf8.h
+++ b/utf8.h
@@ -374,7 +374,8 @@ are in the character. */
 
 /* For use in UTF8_IS_CONTINUATION().  This turns out to be 0xC0 in UTF-8,
  * E0 in UTF-EBCDIC */
-#define UTF_IS_CONTINUATION_MASK    ((U8) (0xFF << UTF_ACCUMULATION_SHIFT))
+#define UTF_IS_CONTINUATION_MASK \
+    ((U8) ((0xFF << UTF_ACCUMULATION_SHIFT) & 0xFF))
 
 /* This defines the bits that are to be in the continuation bytes of a
  * multi-byte UTF-8 encoded character that mark it is a continuation byte.

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -274,7 +274,7 @@ typedef struct
     {
         FILE  _public_file;
         char* _ptr;
-    };
+    } u;
 
     char*            _base;
     int              _cnt;
@@ -289,7 +289,7 @@ typedef struct
 #define PERLIO_FILE_flag_RD 0x0001 /* _IOREAD   */
 #define PERLIO_FILE_flag_WR 0x0002 /* _IOWRITE  */
 #define PERLIO_FILE_flag_RW 0x0004 /* _IOUPDATE */
-#define PERLIO_FILE_ptr(f)  (((__crt_stdio_stream_data*)(f))->_ptr)
+#define PERLIO_FILE_ptr(f)  (((__crt_stdio_stream_data*)(f))->u._ptr)
 #define PERLIO_FILE_base(f) (((__crt_stdio_stream_data*)(f))->_base)
 #define PERLIO_FILE_cnt(f)  (((__crt_stdio_stream_data*)(f))->_cnt)
 #define PERLIO_FILE_flag(f) ((int)(((__crt_stdio_stream_data*)(f))->_flags))


### PR DESCRIPTION
As illustrated by #20999 it's common for projects to be built with the maximum warnings, and it's a common recommendation.

It's also something we follow with gcc, g++ and clang on POSIX-ish systems.

This change allows embedders of perl using MSVC to enable /W4 and include the perl headers, eliminating most warnings.

With these changes I get no warnings from the headers building `..\toke.obj` with `/W4`, which is at least a good start.

I haven't tried to eliminate all warnings in the perl build, that would be a much larger change.

https://github.com/cpp-best-practices/cppbestpractices/blob/master/02-Use_the_Tools_Available.md#compilers
https://www.learncpp.com/cpp-tutorial/configuring-your-compiler-warning-and-error-levels/
https://www.reddit.com/r/programming/comments/1m263m/turn_on_your_damn_warnings/