### PR TITLE
embed.fnc: mark uvuni_to_utf8() as a mathom

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3613,7 +3613,7 @@ Cp	|U8 *	|uvoffuni_to_utf8_flags_msgs				\
 				|UV input_uv				\
 				|const UV flags 			\
 				|NULLOK HV **msgs
-Cp	|U8 *	|uvuni_to_utf8	|NN U8 *d				\
+CDbp	|U8 *	|uvuni_to_utf8	|NN U8 *d				\
 				|UV uv
 EXdpx	|bool	|validate_proto |NN SV *name				\
 				|NULLOK SV *proto			\

--- a/embed.h
+++ b/embed.h
@@ -755,7 +755,6 @@
 # define utf8_to_uvchr_buf_helper(a,b,c)        Perl_utf8_to_uvchr_buf_helper(aTHX_ a,b,c)
 # define utf8n_to_uvchr_msgs                    Perl_utf8n_to_uvchr_msgs
 # define uvoffuni_to_utf8_flags_msgs(a,b,c,d)   Perl_uvoffuni_to_utf8_flags_msgs(aTHX_ a,b,c,d)
-# define uvuni_to_utf8(a,b)                     Perl_uvuni_to_utf8(aTHX_ a,b)
 # define valid_utf8_to_uvchr                    Perl_valid_utf8_to_uvchr
 # define vcmp(a,b)                              Perl_vcmp(aTHX_ a,b)
 # define vcroak(a,b)                            Perl_vcroak(aTHX_ a,b)
@@ -851,6 +850,7 @@
 #   define utf8_to_uvchr(a,b)                   Perl_utf8_to_uvchr(aTHX_ a,b)
 #   define utf8_to_uvuni(a,b)                   Perl_utf8_to_uvuni(aTHX_ a,b)
 #   define utf8n_to_uvuni(a,b,c,d)              Perl_utf8n_to_uvuni(aTHX_ a,b,c,d)
+#   define uvuni_to_utf8(a,b)                   Perl_uvuni_to_utf8(aTHX_ a,b)
 # endif
 # if defined(PERL_CORE)
 #   define PerlLIO_dup2_cloexec(a,b)            Perl_PerlLIO_dup2_cloexec(aTHX_ a,b)

--- a/proto.h
+++ b/proto.h
@@ -5139,11 +5139,6 @@ Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, const UV flags, HV **
 #define PERL_ARGS_ASSERT_UVOFFUNI_TO_UTF8_FLAGS_MSGS \
         assert(d)
 
-PERL_CALLCONV U8 *
-Perl_uvuni_to_utf8(pTHX_ U8 *d, UV uv);
-#define PERL_ARGS_ASSERT_UVUNI_TO_UTF8          \
-        assert(d)
-
 PERL_CALLCONV bool
 Perl_validate_proto(pTHX_ SV *name, SV *proto, bool warn, bool curstash);
 #define PERL_ARGS_ASSERT_VALIDATE_PROTO         \
@@ -6009,6 +6004,12 @@ Perl_utf8n_to_uvuni(pTHX_ const U8 *s, STRLEN curlen, STRLEN *retlen, U32 flags)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UTF8N_TO_UVUNI        \
         assert(s)
+
+PERL_CALLCONV U8 *
+Perl_uvuni_to_utf8(pTHX_ U8 *d, UV uv)
+        __attribute__deprecated__;
+# define PERL_ARGS_ASSERT_UVUNI_TO_UTF8         \
+        assert(d)
 
 # if defined(PERL_DONT_CREATE_GVSV)
 PERL_CALLCONV GV *


### PR DESCRIPTION
This was causing builds with -DNO_MATHOMS to fail on Win32, makedef.pl would generate an export, but since the definition is in mathoms.c linking would fail.