### PR TITLE
Add missing ccflags on VMS to dist/Time-HiRes/Makefile.PL

### DIFF
--- a/dist/Time-HiRes/Makefile.PL
+++ b/dist/Time-HiRes/Makefile.PL
@@ -81,7 +81,7 @@ __EOD__
         $ccflags .= ' -DPERL_NO_INLINE_FUNCTIONS';
 
         if ($^O eq 'VMS') {
-            $cccmd = "$Config{'cc'} /include=($COREincdir) $tmp.c";
+            $cccmd = "$Config{'cc'} $Config{'ccflags'} /include=($COREincdir) $tmp.c";
         }
 
         if ($args{silent} || !$VERBOSE) {


### PR DESCRIPTION
The absence of these flags has never previously caused a problem for running the probes, but on OpenVMS x86, warnings about long symbols cause the probes to fail, probably because those symbols are not getting optimized out as early in the new compiler. This in turn causes the build to fail due to defining a homegrown clockid_t which conflicts with the system version. So add the flags that specify symbol handling (as well as everything else being used to build Perl).