### PR TITLE
Still cleaning up Y2K residue

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4193,7 +4193,7 @@ This makes it easy to get a month name from a list:
     print "$abbr[$mon] $mday";
     # $mon=9, $mday=18 gives "Oct 18"
 
-C<$year> contains the number of years since 1900.  To get a 4-digit
+C<$year> contains the number of years since 1900.  To get the full
 year write:
 
     $year += 1900;


### PR DESCRIPTION
Else... you'll get something recognizable back when used last century (e.g., 99 for 1999) , but what currently (123) looks more like https://en.wikipedia.org/wiki/Republic_of_China_calendar (112) than anything anyone else on the planet would understand!

Also, my correction ensures the man page will still be correct after the year 9999!