### PR TITLE
Remove duplicate "the" in comments

### DIFF
--- a/Porting/config_H
+++ b/Porting/config_H
@@ -2390,7 +2390,7 @@
 #define HAS_DBMINIT_PROTO       /**/
 
 /* HAS_DIR_DD_FD:
- *	This symbol, if defined, indicates that the the DIR* dirstream
+ *	This symbol, if defined, indicates that the DIR* dirstream
  *	structure contains a member variable named dd_fd.
  */
 /*#define HAS_DIR_DD_FD		/ **/

--- a/Porting/updateAUTHORS.pl
+++ b/Porting/updateAUTHORS.pl
@@ -648,7 +648,7 @@ run from the root directory of a git repo of perl.
 In simple, execute the script and it will either die with a helpful
 message or it will update the files as necessary, possibly not at all
 if there is no need to do so. If the C<--validate> option is provided
-the the content will not be updated and instead the tool will act as a
+the content will not be updated and instead the tool will act as a
 test script validating that the F<AUTHORS> and F<.mailmap> files are
 up to date.
 

--- a/config_h.SH
+++ b/config_h.SH
@@ -2439,7 +2439,7 @@ sed <<!GROK!THIS! >$CONFIG_H -e 's!^#undef\(.*/\)\*!/\*#define\1 \*!' -e 's!^#un
 #$d_dbminitproto	HAS_DBMINIT_PROTO	/**/
 
 /* HAS_DIR_DD_FD:
- *	This symbol, if defined, indicates that the the DIR* dirstream
+ *	This symbol, if defined, indicates that the DIR* dirstream
  *	structure contains a member variable named dd_fd.
  */
 #$d_dir_dd_fd HAS_DIR_DD_FD		/**/

--- a/cygwin/cygwin.c
+++ b/cygwin/cygwin.c
@@ -178,7 +178,7 @@ wide_to_utf8(const wchar_t *wsrc)
 wchar_t*
 utf8_to_wide_extra_len(const char *buf, Size_t *extra_len)
 {
-    /* Return the the conversion to UTF-16 of the UTF-8 string 'buf'
+    /* Return the conversion to UTF-16 of the UTF-8 string 'buf'
      * (terminated by a NUL), making sure to have space for at least *extra_len
      * extra (wide) characters in the result.  The result must be freed by the
      * caller when no longer needed */

--- a/lib/unicore/uni_keywords.pl
+++ b/lib/unicore/uni_keywords.pl
@@ -1335,5 +1335,5 @@
 # 55d90fdc3f902e5c0b16b3378f9eaa36e970a1c09723c33de7d47d0370044012 lib/unicore/version
 # 0a6b5ab33bb1026531f816efe81aea1a8ffcd34a27cbea37dd6a70a63d73c844 regen/charset_translations.pl
 # c7ff8e0d207d3538c7feb4a1a152b159e5e902d20293b303569ea8323e84633e regen/mk_PL_charclass.pl
-# 2a64e8b4ca351f490530bdf8c7b4962c407b7ed6a1123eeb8d9e8e0e4236d16a regen/mk_invlists.pl
+# cdbafee25193032242e77f2a6332b731d8392ce342fa616dbabc2c14c7b44eb6 regen/mk_invlists.pl
 # ex: set ro ft=perl:

--- a/locale.c
+++ b/locale.c
@@ -3661,7 +3661,7 @@ S_populate_hash_from_localeconv(pTHX_ HV * hv,
                                        * populate */
                                       const U32 which_mask,
 
-                                      /* strings[0] points the the numeric
+                                      /* strings[0] points the numeric
                                        * string fields; [1] to the monetary */
                                       const lconv_offset_t * strings[2],
 

--- a/pod/perl5360delta.pod
+++ b/pod/perl5360delta.pod
@@ -325,7 +325,7 @@ block compiles, it means you're using perl v5.14.0 or later.
 We now probe for compiler support for C11 thread local storage, and where
 available use this for "implicit context" for XS extensions making API calls for
 a threaded Perl build.  This requires fewer function calls at the C level than
-POSIX thread specific storage. We continue to use the the pthreads approach if
+POSIX thread specific storage. We continue to use the pthreads approach if
 the C11 approach is not available.
 
 F<Configure> run with the defaults will build an unthreaded Perl (which is

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -1995,7 +1995,7 @@ At the end of I<pseudo-block> the function C<f> is called with the
 implicit context argument (if any), and C<p> which may be NULL.
 
 Note the I<end of the current pseudo-block> may occur much later than
-the the I<end of the current statement>. You may wish to look at the
+the I<end of the current statement>. You may wish to look at the
 C<MORTALDESTRUCTOR_X()> macro instead.
 
 =for apidoc Ayh||DESTRUCTORFUNC_t

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -4125,7 +4125,7 @@ PP(pp_iter)
                 if (UNLIKELY(pad_it)) {
                     /* We're "beyond the end" of the iterator here, filling the
                        extra lexicals with undef, so we mustn't do anything
-                       (further) to the the iterator itself at this point.
+                       (further) to the iterator itself at this point.
                        (Observe how the other two blocks modify the iterator's
                        value) */
                 }

--- a/regcomp.h
+++ b/regcomp.h
@@ -592,7 +592,7 @@ struct regnode_ssc {
  * Be aware that C<REGNODE_AFTER()> is not guaranteed to give a *useful*
  * result once the regex peephole optimizer has run (it will be correct
  * however!). By the time code in regexec.c executes various regnodes
- * may have been optimized out of the the C<next_off> chain. An example
+ * may have been optimized out of the C<next_off> chain. An example
  * can be seen above, node 13 will never be reached during execution
  * flow as it has been stitched out of the C<next_off> chain. Both 6 and
  * 11 would have pointed at it during compilation, but it exists only to

--- a/regen/mk_invlists.pl
+++ b/regen/mk_invlists.pl
@@ -760,7 +760,7 @@ sub output_invmap ($$$$$$$) {
         switch_pound_if($name, $where, $charset);
 
         # The inversion lists here have to be UV because inversion lists are
-        # capable of storing any code point, and even though the the ones here
+        # capable of storing any code point, and even though the ones here
         # are only Unicode ones, which need just 21 bits, they are linked to
         # directly, rather than copied.  The inversion map and aux tables also
         # only need be 21 bits, and so we can get away with declaring them

--- a/regen/unicode_constants.pl
+++ b/regen/unicode_constants.pl
@@ -594,7 +594,7 @@ foreach my $list (qw(Punctuation Symbol)) {
 
         if ($is_Symbol) {
 
-            # Skip if the the direction is followed by a vertical motion
+            # Skip if the direction is followed by a vertical motion
             # (which defeats the left-right directionality).
             if (        $name =~ / ^ .* $no_barb_re
                                    \b (UP|DOWN|NORTH|SOUTH) /gx

--- a/sv.c
+++ b/sv.c
@@ -6193,7 +6193,7 @@ Perl_sv_del_backref(pTHX_ SV *const tsv, SV *const sv)
             svp = (SV**)Perl_hv_backreferences_p(aTHX_ MUTABLE_HV(tsv));
     }
     else if (SvIS_FREED(tsv) && PL_phase == PERL_PHASE_DESTRUCT) {
-        /* It's possible for the the last (strong) reference to tsv to have
+        /* It's possible for the last (strong) reference to tsv to have
            become freed *before* the last thing holding a weak reference.
            If both survive longer than the backreferences array, then when
            the referent's reference count drops to 0 and it is freed, it's

--- a/uconfig.h
+++ b/uconfig.h
@@ -2404,7 +2404,7 @@
 /*#define HAS_DBMINIT_PROTO	/ **/
 
 /* HAS_DIR_DD_FD:
- *	This symbol, if defined, indicates that the the DIR* dirstream
+ *	This symbol, if defined, indicates that the DIR* dirstream
  *	structure contains a member variable named dd_fd.
  */
 /*#define HAS_DIR_DD_FD		/ **/
@@ -5382,6 +5382,6 @@
 #endif
 
 /* Generated from:
- * 174bcf68d4780b29467af80be166e1fc8ce42f57426a7bd489282f4c7e351597 config_h.SH
+ * e17a83ff6ae98071d846d4a001f6ce1a669df08c357fe153c2370adc4910135e config_h.SH
  * dac2aceefc94292b9ec73e8a4615ae98e521658172c452c5467759219568c800 uconfig.sh
  * ex: set ro ft=c: */

--- a/uni_keywords.h
+++ b/uni_keywords.h
@@ -10,7 +10,7 @@
 #define MPH_VALt I16
 
 /*
-generator script: regen/mk_invlists.pl
+generator script: ./regen/mk_invlists.pl
 split strategy: squeeze
 srand: 1785235451
 rows: 7498
@@ -7760,6 +7760,6 @@ match_uniprop( const unsigned char * const key, const U16 key_len ) {
  * 55d90fdc3f902e5c0b16b3378f9eaa36e970a1c09723c33de7d47d0370044012 lib/unicore/version
  * 0a6b5ab33bb1026531f816efe81aea1a8ffcd34a27cbea37dd6a70a63d73c844 regen/charset_translations.pl
  * c7ff8e0d207d3538c7feb4a1a152b159e5e902d20293b303569ea8323e84633e regen/mk_PL_charclass.pl
- * 2a64e8b4ca351f490530bdf8c7b4962c407b7ed6a1123eeb8d9e8e0e4236d16a regen/mk_invlists.pl
+ * cdbafee25193032242e77f2a6332b731d8392ce342fa616dbabc2c14c7b44eb6 regen/mk_invlists.pl
  * d6987e01ad538d1567394851cf199f99815f7701bebd6092be4bc7a6d8f147c6 regen/mph.pl
  * ex: set ro ft=c: */

--- a/util.c
+++ b/util.c
@@ -5930,7 +5930,7 @@ typedef struct {
     bfd* abfd;
     /* bfd_syms is the BFD symbol table. */
     asymbol** bfd_syms;
-    /* bfd_text is handle to the the ".text" section of the object file. */
+    /* bfd_text is handle to the ".text" section of the object file. */
     asection* bfd_text;
     /* Since opening the executable and scanning its symbols is quite
      * heavy operation, we remember the filename we used the last time,

--- a/win32/config_H.gc
+++ b/win32/config_H.gc
@@ -2411,7 +2411,7 @@
 /*#define HAS_DBMINIT_PROTO     / **/
 
 /* HAS_DIR_DD_FD:
- *	This symbol, if defined, indicates that the the DIR* dirstream
+ *	This symbol, if defined, indicates that the DIR* dirstream
  *	structure contains a member variable named dd_fd.
  */
 /*#define HAS_DIR_DD_FD		/ **/

--- a/win32/config_H.vc
+++ b/win32/config_H.vc
@@ -2411,7 +2411,7 @@
 /*#define HAS_DBMINIT_PROTO     / **/
 
 /* HAS_DIR_DD_FD:
- *	This symbol, if defined, indicates that the the DIR* dirstream
+ *	This symbol, if defined, indicates that the DIR* dirstream
  *	structure contains a member variable named dd_fd.
  */
 /*#define HAS_DIR_DD_FD		/ **/


### PR DESCRIPTION
Fix spelling in various files pertaining to core Perl.

---

PR based on the closed https://github.com/Perl/perl5/pull/21057

---

### Related PR's created on the upstream repositories

Linking them here as well to group the spree together.

- https://github.com/Dual-Life/Scalar-List-Utils/pull/126
- https://github.com/dankogai/p5-encode/pull/173
- https://github.com/pmqs/Compress-Raw-Zlib/pull/22

### Issue

- https://github.com/Perl/perl5/issues/21069

@jkeenan @rjbs FYI






