### PR TITLE
add missing const (win32)

### DIFF
--- a/win32/perllib.c
+++ b/win32/perllib.c
@@ -34,7 +34,7 @@ EXTERN_C void boot_DynaLoader (pTHX_ CV* cv);
 static void
 xs_init(pTHX)
 {
-    char *file = __FILE__;
+    const char *file = __FILE__;
     dXSUB_SYS;
     newXS("DynaLoader::boot_DynaLoader", boot_DynaLoader, file);
     /* other similar records will be included from "perllibst.h" */


### PR DESCRIPTION
Fixes a compiler warning:

    perllib.c: In function 'void xs_init(PerlInterpreter*)':
    perllib.c:37:18: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
         char *file = __FILE__;
                      ^~~~~~~~