### PR TITLE
POSIX: fix compiler warnings on windows

### DIFF
--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -1380,7 +1380,7 @@ char *tzname[] = { "" , "" };
 #if defined (WIN32)
 #  undef mkfifo
 #  define mkfifo(a,b) not_here("mkfifo")
-#  define ttyname(a) (char*)not_here("ttyname")
+#  define ttyname(a) (not_here("ttyname"), (char *)NULL)
 #  define sigset_t long
 #  define pid_t long
 #  ifdef _MSC_VER
@@ -1445,10 +1445,8 @@ typedef sigset_t* POSIX__SigSet;
 typedef HV* POSIX__SigAction;
 typedef int POSIX__SigNo;
 typedef int POSIX__Fd;
-#ifdef I_TERMIOS
 typedef struct termios* POSIX__Termios;
-#else /* Define termios types to int, and call not_here for the functions.*/
-#define POSIX__Termios int
+#ifndef I_TERMIOS /* Define termios types to int, and call not_here for the functions.*/
 #define speed_t int
 #define tcflag_t int
 #define cc_t int
@@ -1459,7 +1457,7 @@ typedef struct termios* POSIX__Termios;
 #define tcsendbreak(x,y) not_here("tcsendbreak")
 #define cfsetispeed(x,y) not_here("cfsetispeed")
 #define cfsetospeed(x,y) not_here("cfsetospeed")
-#define ctermid(x) (char *) not_here("ctermid")
+#define ctermid(x) (not_here("ctermid"), (char *)NULL)
 #define tcflow(x,y) not_here("tcflow")
 #define tcgetattr(x,y) not_here("tcgetattr")
 #define tcsetattr(x,y,z) not_here("tcsetattr")

--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our ($AUTOLOAD, %SIGRT);
 
-our $VERSION = '2.12';
+our $VERSION = '2.13';
 
 require XSLoader;
 


### PR DESCRIPTION
This should fix the following warnings:

    POSIX.c: In function 'XS_POSIX__Termios_getattr':
    POSIX.c:2126:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       termios_ref = (POSIX__Termios)SvPV_nolen(SvRV(sv));
                     ^
    POSIX.c: In function 'XS_POSIX__Termios_setattr':
    POSIX.c:2182:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       termios_ref = (POSIX__Termios)SvPV_nolen(SvRV(sv));
                     ^
    POSIX.c: In function 'XS_POSIX__Termios_getispeed':
    POSIX.c:2249:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       termios_ref = (POSIX__Termios)SvPV_nolen(SvRV(sv));
                     ^
    POSIX.c: In function 'XS_POSIX__Termios_getiflag':
    POSIX.c:2281:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       termios_ref = (POSIX__Termios)SvPV_nolen(SvRV(sv));
                     ^
    POSIX.c: In function 'XS_POSIX__Termios_getcc':
    POSIX.c:2334:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       termios_ref = (POSIX__Termios)SvPV_nolen(SvRV(sv));
                     ^
    POSIX.c: In function 'XS_POSIX__Termios_setispeed':
    POSIX.c:2374:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       termios_ref = (POSIX__Termios)SvPV_nolen(SvRV(sv));
                     ^
    POSIX.c: In function 'XS_POSIX__Termios_setiflag':
    POSIX.c:2416:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       termios_ref = (POSIX__Termios)SvPV_nolen(SvRV(sv));
                     ^
    POSIX.c: In function 'XS_POSIX__Termios_setcc':
    POSIX.c:2464:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       termios_ref = (POSIX__Termios)SvPV_nolen(SvRV(sv));
                     ^
    POSIX.xs: In function 'XS_POSIX_ctermid':
    POSIX.xs:1462:20: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
     #define ctermid(x) (char *) not_here("ctermid")
                        ^
    POSIX.xs:3639:11: note: in expansion of macro 'ctermid'
      RETVAL = ctermid(s);
               ^~~~~~~
    POSIX.c: In function 'XS_POSIX_ttyname':
    POSIX.xs:1383:22: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
     #  define ttyname(a) (char*)not_here("ttyname")
                          ^
    POSIX.c:5453:11: note: in expansion of macro 'ttyname'
      RETVAL = ttyname(fd);
               ^~~~~~~