### PR TITLE
Remove my_strftime8()

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2076,7 +2076,8 @@ Adfp	|char * |my_strftime	|NN const char *fmt			\
 				|int wday				\
 				|int yday				\
 				|int isdst
-Adfp	|char * |my_strftime8	|NN const char *fmt			\
+EXfp	|char * |my_strftime8_temp					\
+				|NN const char *fmt			\
 				|int sec				\
 				|int min				\
 				|int hour				\

--- a/embed.h
+++ b/embed.h
@@ -376,7 +376,6 @@
 # define my_setenv(a,b)                         Perl_my_setenv(aTHX_ a,b)
 # define my_socketpair                          Perl_my_socketpair
 # define my_strftime(a,b,c,d,e,f,g,h,i,j)       Perl_my_strftime(aTHX_ a,b,c,d,e,f,g,h,i,j)
-# define my_strftime8(a,b,c,d,e,f,g,h,i,j,k)    Perl_my_strftime8(aTHX_ a,b,c,d,e,f,g,h,i,j,k)
 # define my_strtod                              Perl_my_strtod
 # define newANONATTRSUB(a,b,c,d)                Perl_newANONATTRSUB(aTHX_ a,b,c,d)
 # define newANONHASH(a)                         Perl_newANONHASH(aTHX_ a)
@@ -1691,6 +1690,7 @@
 #   define mg_find_mglob(a)                     Perl_mg_find_mglob(aTHX_ a)
 #   define multiconcat_stringify(a)             Perl_multiconcat_stringify(aTHX_ a)
 #   define multideref_stringify(a,b)            Perl_multideref_stringify(aTHX_ a,b)
+#   define my_strftime8_temp(a,b,c,d,e,f,g,h,i,j,k) Perl_my_strftime8_temp(aTHX_ a,b,c,d,e,f,g,h,i,j,k)
 #   define op_clear(a)                          Perl_op_clear(aTHX_ a)
 #   define qerror(a)                            Perl_qerror(aTHX_ a)
 #   define reg_named_buff(a,b,c,d)              Perl_reg_named_buff(aTHX_ a,b,c,d)

--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -3589,7 +3589,7 @@ strftime(fmt, sec, min, hour, mday, mon, year, wday = -1, yday = -1, isdst = -1)
              * is normally frowned upon as a potential security risk;
              * but this is part of the API so we have to allow it */
             GCC_DIAG_IGNORE_STMT(-Wformat-nonliteral);
-	    buf = my_strftime8(SvPV_nolen(fmt), sec, min, hour, mday, mon, year, wday, yday, isdst, &is_utf8);
+	    buf = my_strftime8_temp(SvPV_nolen(fmt), sec, min, hour, mday, mon, year, wday, yday, isdst, &is_utf8);
             GCC_DIAG_RESTORE_STMT;
             sv = sv_newmortal();
 	    if (buf) {

--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our ($AUTOLOAD, %SIGRT);
 
-our $VERSION = '2.12';
+our $VERSION = '2.13';
 
 require XSLoader;
 

--- a/locale.c
+++ b/locale.c
@@ -4510,7 +4510,7 @@ S_my_langinfo_i(pTHX_
             /* The year was deliberately chosen so that January 1 is on the
              * first day of the week.  Since we're only getting one thing at a
              * time, it all works */
-            const char * temp = my_strftime8(format, 30, 30, hour, mday, mon,
+            const char * temp = my_strftime8_temp(format, 30, 30, hour, mday, mon,
                                              2011, 0, 0, 0, &is_utf8);
             retval = save_to_buffer(temp, retbufp, retbuf_sizep);
             Safefree(temp);
@@ -4804,22 +4804,16 @@ Perl_my_strftime(pTHX_ const char *fmt, int sec, int min, int hour, int mday, in
 /*
 =for apidoc_section $time
 =for apidoc      my_strftime
-=for apidoc_item my_strftime8
 
 strftime(), but with a different API so that the return value is a pointer
 to the formatted result (which MUST be arranged to be FREED BY THE
-CALLER).  This allows these functions to increase the buffer size as needed,
+CALLER).  This allows this function to increase the buffer size as needed,
 so that the caller doesn't have to worry about that.
 
-C<my_strftime8> is the same as plain C<my_strftime>, but has an extra
-parameter, a pointer to a variable declared as L</C<utf8ness_t>>.
-Upon return, its variable will be set to indicate how the resultant string
-should be treated with regards to its UTF-8ness.
-
-Note that yday and wday effectively are ignored by these functions, as
+Note that yday and wday effectively are ignored by this function, as
 mini_mktime() overwrites them
 
-Also note that they are always executed in the underlying locale of the program,
+Also note that it is always executed in the underlying locale of the program,
 giving localized results.  Mojibake can result on some platforms if LC_CTYPE
 and LC_TIME are not the same locale.
 
@@ -4955,14 +4949,14 @@ and LC_TIME are not the same locale.
 }
 
 char *
-Perl_my_strftime8(pTHX_ const char *fmt, int sec, int min, int hour, int mday,
+Perl_my_strftime8_temp(pTHX_ const char *fmt, int sec, int min, int hour, int mday,
                          int mon, int year, int wday, int yday, int isdst,
                          utf8ness_t * utf8ness)
 {   /* Documented above */
     char * retval = my_strftime(fmt, sec, min, hour, mday, mon, year, wday,
                                 yday, isdst);
 
-    PERL_ARGS_ASSERT_MY_STRFTIME8;
+    PERL_ARGS_ASSERT_MY_STRFTIME8_TEMP;
 
     if (utf8ness) {
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -348,7 +348,8 @@ well.
 
 =item *
 
-XXX
+The function C<my_strftime8>, added in v5.37.4, has been found to be
+defective, and is now removed.  It never was in a stable release.
 
 =back
 

--- a/proto.h
+++ b/proto.h
@@ -2669,9 +2669,9 @@ Perl_my_strftime(pTHX_ const char *fmt, int sec, int min, int hour, int mday, in
         assert(fmt)
 
 PERL_CALLCONV char *
-Perl_my_strftime8(pTHX_ const char *fmt, int sec, int min, int hour, int mday, int mon, int year, int wday, int yday, int isdst, utf8ness_t *utf8ness)
+Perl_my_strftime8_temp(pTHX_ const char *fmt, int sec, int min, int hour, int mday, int mon, int year, int wday, int yday, int isdst, utf8ness_t *utf8ness)
         __attribute__format__(__strftime__,pTHX_1,0);
-#define PERL_ARGS_ASSERT_MY_STRFTIME8           \
+#define PERL_ARGS_ASSERT_MY_STRFTIME8_TEMP      \
         assert(fmt)
 
 PERL_CALLCONV NV


### PR DESCRIPTION
The comment from Tony Cook

https://github.com/Perl/perl5/issues/20373#issuecomment-1524256091

made me realize that this function doesn't fully work.  It was added as public API earlier in the 5.37 series, but we don't want it making it into a stable release.  This commit renames it so that the original name will no longer work, but POSIX.xs can still, by changing to use the new name, which is undocumented