### PR TITLE
autodoc.pl: strftime format functions can use short names

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -1321,7 +1321,9 @@ sub docout ($$$) { # output the docs for one function group
         if (   ($item_flags =~ /p/ && $item_flags =~ /o/ && $item_flags !~ /M/)
 
                 # Can't handle threaded varargs
-            || ($item_flags =~ /f/ && $item_flags !~ /T/))
+            || (   $item_flags =~ /f/
+                && $item_flags !~ /T/
+                && $item_name !~ /strftime/))
         {
             $item->{name} = "Perl_$item_name";
             print $fh <<~"EOT";


### PR DESCRIPTION
It was saying you had to use the Perl_foo(aTHX_ ...) form, which isn't true.