### PR TITLE
Revert "PERL_SET_LOCALE_CONTEXT: Actually do something"

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -6365,7 +6365,7 @@ EXTCONST U8   PL_deBruijn_bitpos_tab64[];
 #ifdef USE_PERL_SWITCH_LOCALE_CONTEXT
 #  define PERL_SET_LOCALE_CONTEXT(i)                                        \
       STMT_START {                                                          \
-          if (LIKELY(! PL_veto_switch_non_tTHX_context))                    \
+          if (UNLIKELY(PL_veto_switch_non_tTHX_context))                    \
                 Perl_switch_locale_context();                               \
       } STMT_END
 #else


### PR DESCRIPTION
This reverts commit 9e254b0b5b145c9bfc3053e778e9f7fbb3760b45.
Date:   Wed Apr 5 12:26:26 2023 -0600

This fixes GH #21040

The reverted commit caused failures in platforms using the musl library, notably Alpine Linux.  I came up with a fix for that, which instead broke Windows.  In looking at that I realized the original fix is incomplete, and that things are too precarious to try to fix so close to 5.38.0.  For example, I spent hours, due to a %p format printing 0 for what turned out to be a non-NULL string pointer.  I think it has to do do with the fact that the failing code is in the middle of transitioning between threads, and the printing got confused as a result.

The reverted commit was part of a series fixing #20155 and #20231.  But the earlier part of the series succeeded in fixing those, without that commit, so reverting it should not cause things to break as a result.

This whole issue has to do with locales and threading.  Those still don't play well together.  I have a series of well over 200 commits that address this situation, for applying in early 5.39.  My point is that we are a long way from solving these kinds of issues; and they don't come up that much in the field because they just don't get used.  The reverted commit would help if it worked properly, but it's not the only thing wrong by a long shot.