### PR TITLE
PerlIO::via: sanity check READ method return value

### DIFF
--- a/ext/PerlIO-via/via.pm
+++ b/ext/PerlIO-via/via.pm
@@ -1,5 +1,5 @@
 package PerlIO::via;
-our $VERSION = '0.18';
+our $VERSION = '0.19';
 require XSLoader;
 XSLoader::load();
 1;
@@ -123,8 +123,10 @@ there isn't one.  Optional.  Default is fileno($fh).
 
 =item $obj->READ($buffer,$len,$fh)
 
-Returns the number of octets placed in $buffer (must be less than or
-equal to $len).  Optional.  Default is to use FILL instead.
+Returns the number of octets placed in $buffer (must be undef to
+indicate an error or a non-negative integer less than or equal to the
+minimum of $len and the length of the updated $buffer).  Optional.
+Default is to use FILL instead.
 
 =item $obj->WRITE($buffer,$fh)
 


### PR DESCRIPTION
Coverity complained that the range of SvIV(result) could be large and well outside the bounds of the buffer at SvPVX().

So sanity check that the value of result is within range, if it is out of range warn and return an error.

Also document the bottom of the range of expected return values from READ, -1 is less than $len and resulted in a crash.

Ideally we'd just use the length of the modified $buffer to avoid such range errors, but the API is already designed, so we can't.

CID 453853