### PR TITLE
op/sprintf2.t: skip extended precision test on AIX

### DIFF
--- a/t/op/sprintf2.t
+++ b/t/op/sprintf2.t
@@ -1191,6 +1191,8 @@ if($Config{nvsize} == 8) {
                                    or
                                $^O eq 'hpux'
                                    or
+                               $^O eq 'aix'
+                                   or
                                ($^O eq 'MSWin32' and
                                 $Config{cc} eq 'cl' and
                                 $Config{ccversion} =~ /^(\d+)/ and


### PR DESCRIPTION
This was failing in smokes on AIX