### PR TITLE
ExtUtils-Constant: Constant.t: skip test if compiler is not available

### DIFF
--- a/cpan/ExtUtils-Constant/t/Constant.t
+++ b/cpan/ExtUtils-Constant/t/Constant.t
@@ -6,6 +6,13 @@ unless ($Config{usedl}) {
     exit 0;
 }
 
+use ExtUtils::CBuilder;
+my $b = ExtUtils::CBuilder->new( quiet => 1 );
+unless ($b->have_compiler) {
+    print "1..0 # SKIP compiler not available\n";
+    exit 0;
+}
+
 # use warnings;
 use strict;
 use ExtUtils::MakeMaker;


### PR DESCRIPTION
Currently, the test fails if the compiler is not found: make: [Makefile:811: ../../../../config.h] Error 1 (ignored) /bin/sh: line 1: x86_64-wrs-linux-gcc: command not found make: *** [Makefile:331: ExtTest.o] Error 127
FAIL: cpan/ExtUtils-Constant/t/Constant

All the other testcases that require compiler support are skipped if the support is not there, so add a check in Constant.t as well.