### PR TITLE
hints/darwin.sh: Turn off POSIX 2008 locales

### DIFF
--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -357,6 +357,9 @@ EOM
         esac
     fi
 
+    # The OS is buggy with respect to this.
+    ccflags="$ccflags -DNO_POSIX_2008_LOCALE"
+
    lddlflags="${ldflags} -bundle -undefined dynamic_lookup"
    ;;
 esac


### PR DESCRIPTION
This is failing on smokes:
http://nntp.perl.org/group/perl.perl5.porters/266341

What I've noticed in working with changes to the locale handling code (that isn't ready for v5.38) is that querylocale() has intermittent failures, that aren't fully solved by using a mutex, and that versions of Darwin earlier than major 20 have other problems with the POSIX 2008 API.  These may be solved in Darwin 20 after disabling querylocale(), but the failure rate was so infrequent that I'm unsure if it has been fixed or just hasn't come up.  So it is safest to just disable POSIX 2008 in Darwin for 5.38.