### PR TITLE
AIX: skip some locale tests

### DIFF
--- a/lib/locale.t
+++ b/lib/locale.t
@@ -789,18 +789,24 @@ my $final_without_setlocale = $test_num;
 debug "Scanning for locales...\n";
 
 require POSIX; import POSIX ':locale_h';
-
 my $categories = [ 'LC_CTYPE', 'LC_NUMERIC', 'LC_ALL' ];
-debug "Scanning for just compatible";
-my @Locale = find_locales($categories);
-debug "Scanning for even incompatible";
-my @include_incompatible_locales = find_locales($categories,
-                                                'even incompatible locales');
-
+my @Locale;
+my @include_incompatible_locales;
+if ($^O eq "aix"
+    and version->new(($Config{osvers} =~ /^(\d+(\.\d+))/)[0]) < 7) {
+    # https://www.ibm.com/support/pages/apar/IV22097
+    skip("setlocale broken on old AIX");
+}
+else {
+    debug "Scanning for just compatible";
+    @Locale = find_locales($categories);
+    debug "Scanning for even incompatible";
+    @include_incompatible_locales = find_locales($categories,
+                                              'even incompatible locales');
+}
 # The locales included in the incompatible list that aren't in the compatible
 # one.
 my @incompatible_locales;
-
 if (@Locale < @include_incompatible_locales) {
     my %seen;
     @seen{@Locale} = ();

--- a/t/lib/warnings/regexec
+++ b/t/lib/warnings/regexec
@@ -212,11 +212,15 @@ setlocale(&POSIX::LC_CTYPE, $utf8_locale);
  "abc def" =~ /\b{wb}.*?/;
  "abc def" =~ /\B{wb}.*?/;
 EXPECT
-Use of \b{} or \B{} for non-UTF-8 locale is wrong.  Assuming a UTF-8 locale at - line 16.
-Use of \b{} or \B{} for non-UTF-8 locale is wrong.  Assuming a UTF-8 locale at - line 16.
-Use of \b{} or \B{} for non-UTF-8 locale is wrong.  Assuming a UTF-8 locale at - line 17.
-Use of \b{} or \B{} for non-UTF-8 locale is wrong.  Assuming a UTF-8 locale at - line 17.
-Use of \b{} or \B{} for non-UTF-8 locale is wrong.  Assuming a UTF-8 locale at - line 17.
+OPTION regex
+\AUse of \\b\{\} or \\B\{\} for non-UTF-8 locale is wrong\.  Assuming a UTF-8 locale at - line 16\.
+Use of \\b\{\} or \\B\{\} for non-UTF-8 locale is wrong\.  Assuming a UTF-8 locale at - line 16\.
+Use of \\b\{\} or \\B\{\} for non-UTF-8 locale is wrong\.  Assuming a UTF-8 locale at - line 17\.
+Use of \\b\{\} or \\B\{\} for non-UTF-8 locale is wrong\.  Assuming a UTF-8 locale at - line 17\.
+Use of \\b\{\} or \\B\{\} for non-UTF-8 locale is wrong\.  Assuming a UTF-8 locale at - line 17\.(?:
+Locale '.*' contains \(at least\) the following characters which have
+unexpected meanings: .*
+The Perl program will use the expected meanings; codeset=UTF-8)?\z
 ########
 # NAME (?[ ]) in non-UTF-8 locale
 require '../loc_tools.pl';

--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -21,6 +21,12 @@ BEGIN {
     }
 }
 use Config;
+
+if ($^O eq "aix" && ($Config{osvers} =~ /^(\d+)/)[0] < 7) {
+    # https://www.ibm.com/support/pages/apar/IV22174
+    skip_all("old AIX setlocale is broken in some cases");
+}
+
 use I18N::Langinfo qw(langinfo RADIXCHAR);
 my $have_strtod = $Config{d_strtod} eq 'define';
 my $have_localeconv = defined $Config{d_locconv} && $Config{d_locconv} eq 'define';


### PR DESCRIPTION
These tests fail on the EN_US.UTF-8 locale.

Some fail due to a bug fixed in later AIX (lib/locale.t, t/run/locale.t) and the other due to an apparent bug in the locale itself.

https://perl5.test-smoke.org/report/5034327