### PR TITLE
One character typo correction

### DIFF
--- a/hints/linux.sh
+++ b/hints/linux.sh
@@ -154,7 +154,7 @@ esac
 # (such as -lm) in /lib or /usr/lib.  So we have to ask gcc to tell us
 # where to look.  We don't want gcc's own libraries, however, so we
 # filter those out.
-# This could be conditional on Unbuntu, but other distributions may
+# This could be conditional on Ubuntu, but other distributions may
 # follow suit, and this scheme seems to work even on rather old gcc's.
 # This unconditionally uses gcc because even if the user is using another
 # compiler, we still need to find the math library and friends, and I don't


### PR DESCRIPTION
The commit message for 40f026236b back in 2011 got the correct spelling, but the error in the inline comment was not detected.