### PR TITLE
Davem/deparse

### DIFF
--- a/Porting/deparse-skips.txt
+++ b/Porting/deparse-skips.txt
@@ -32,6 +32,16 @@
 __DEPARSE_FAILURES__
 
 base/lex.t                # checks regexp stringification
+# class/*.t generally failing because OP_METHSTART not recognised
+class/class.t
+class/construct.t
+class/destruct.t
+class/field.t
+class/inherit.t
+class/method.t
+class/phasers.t
+class/threads.t
+#
 comp/final_line_num.t     # tests syntax error after BEGIN block
 comp/fold.t               # mutability of folded constants
 comp/parser.t             # crazy #line directives ==> shell syntax errors

--- a/Porting/deparse-skips.txt
+++ b/Porting/deparse-skips.txt
@@ -54,7 +54,6 @@ op/attrhand.t             # Custom attrs ignored; also AH provides none
 op/caller.t
 op/goto.t
 op/gv.t                   # glob copy constants
-op/hexfp.t
 op/index.t
 op/join.t                 # mutability of folded constants
 op/length.t               # utf8ness of deparsed strings
@@ -256,7 +255,6 @@ uni/variables.t
 ../ext/XS-APItest/t/call_checker.t
 ../ext/XS-APItest/t/cleanup.t
 ../ext/XS-APItest/t/fetch_pad_names.t
-../ext/XS-APItest/t/svpeek.t
 ../ext/XS-APItest/t/synthetic_scope.t
 ../lib/Config.t                         # Config_heavy.pl fns getting output
 ../lib/charnames.t

--- a/Porting/deparse-skips.txt
+++ b/Porting/deparse-skips.txt
@@ -73,9 +73,11 @@ op/sub.t
 op/switch.t
 op/symbolcache.t
 op/taint.t
+op/undef.t                # keys%{($h=undef)||{}} becomes keys%{{} unless .. }
 op/vec.t
 op/warn.t
 op/write.t
+perf/opcount.t            # keys%{($h=undef)||{}} becomes keys%{{} unless .. }
 porting/globvar.t
 re/overload.t             # [perl #123385] %^H output
 re/pat_advanced.t         # [perl #123417]

--- a/Porting/deparse-skips.txt
+++ b/Porting/deparse-skips.txt
@@ -203,10 +203,6 @@ uni/variables.t
 ../cpan/ExtUtils-MakeMaker/t/MM_VMS.t
 
 # see comment above about bignum failures
-../cpan/Math-BigInt/t/const-mbf.t
-../cpan/Math-BigInt/t/const-mbi.t
-
-# see comment above about bignum failures
 ../cpan/Math-BigRat/t/const-mbr.t
 
 

--- a/Porting/deparse-skips.txt
+++ b/Porting/deparse-skips.txt
@@ -82,6 +82,7 @@ re/overload.t             # [perl #123385] %^H output
 re/pat_advanced.t         # [perl #123417]
 re/pat_rt_report.t        # malformed utf8 constant; also /\c@/ -> /\c\@/
 re/pat.t                  # [perl #90590]
+re/pat_re_eval.t          # the new /(*{...})/ forms don't deparse
 re/regex_sets.t
 re/reg_fold.t             # [perl #123385] %^H output
 re/rxcode.t               # checks regexp stringification

--- a/Porting/deparse-skips.txt
+++ b/Porting/deparse-skips.txt
@@ -154,31 +154,46 @@ uni/variables.t
 #    }
 
 ../cpan/bignum/t/bigexp.t
+../cpan/bignum/t/bigfloat.t
 ../cpan/bignum/t/bigint.t
 ../cpan/bignum/t/bignum.t
 ../cpan/bignum/t/bigrat.t
+../cpan/bignum/t/const-bigfloat.t
 ../cpan/bignum/t/const-bigint.t
 ../cpan/bignum/t/const-bignum.t
 ../cpan/bignum/t/const-bigrat.t
+../cpan/bignum/t/down-mbi-up-mbf.t
+../cpan/bignum/t/down-mbi-up-mbr.t
+../cpan/bignum/t/down-mbi-up-undef.t
+../cpan/bignum/t/down-undef-up-mbf.t
+../cpan/bignum/t/e_pi-bigfloat.t
 ../cpan/bignum/t/e_pi-bigint.t
 ../cpan/bignum/t/e_pi-bignum.t
 ../cpan/bignum/t/e_pi-bigrat.t
+../cpan/bignum/t/import-bigfloat.t
 ../cpan/bignum/t/import-bigint.t
 ../cpan/bignum/t/import-bignum.t
 ../cpan/bignum/t/import-bigrat.t
 ../cpan/bignum/t/in_effect.t
+../cpan/bignum/t/infnan-bigfloat.t
 ../cpan/bignum/t/infnan-bigint.t
-../cpan/bignum/t/infnan-bignum.t
+../cpan/bignum/t/infnan-bignum-mbf.t
+../cpan/bignum/t/infnan-bignum-mbr.t
 ../cpan/bignum/t/infnan-bigrat.t
+../cpan/bignum/t/option_a-bignum.t
 ../cpan/bignum/t/option_a.t
-../cpan/bignum/t/option_l.t
+../cpan/bignum/t/option_l-bigfloat.t
+../cpan/bignum/t/option_l-bigint.t
+../cpan/bignum/t/option_l-bignum.t
+../cpan/bignum/t/option_l-bigrat.t
+../cpan/bignum/t/option_p-bignum.t
 ../cpan/bignum/t/option_p.t
 ../cpan/bignum/t/overrides.t
 ../cpan/bignum/t/ratopt_a.t
+../cpan/bignum/t/scope-bigfloat.t
 ../cpan/bignum/t/scope-bigint.t
 ../cpan/bignum/t/scope-bignum.t
 ../cpan/bignum/t/scope-bigrat.t
-../cpan/bignum/t/scope-nested-const.t
 
 # -------------
 

--- a/lib/B/Deparse.pm
+++ b/lib/B/Deparse.pm
@@ -7,7 +7,7 @@
 # This is based on the module of the same name by Malcolm Beattie,
 # but essentially none of his code remains.
 
-package B::Deparse 1.73;
+package B::Deparse 1.74;
 use strict;
 use Carp;
 use B qw(class main_root main_start main_cv svref_2object opnumber perlstring
@@ -3878,6 +3878,9 @@ sub pp_list {
 	    if ($padname->FLAGS & PADNAMEf_TYPED) {
 		$newtype = $padname->SvSTASH->NAME;
 	    }
+	} elsif ($lopname eq 'padsv_store') {
+            # don't interpret as my (list) if it has an implicit assign
+            $local = "";
 	} elsif ($lopname =~ /^(?:gv|rv2)([ash])v$/
 			&& $loppriv & OPpOUR_INTRO
 		or $lopname eq "null" && class($lop) eq 'UNOP'

--- a/lib/B/Deparse.pm
+++ b/lib/B/Deparse.pm
@@ -1316,7 +1316,7 @@ Carp::confess("NULL in deparse_sub") if !defined($cv) || $cv->isa("B::NULL");
 Carp::confess("SPECIAL in deparse_sub") if $cv->isa("B::SPECIAL");
     local $self->{'curcop'} = $self->{'curcop'};
 
-    my $has_sig = $self->{hinthash}{feature_signatures};
+    my $has_sig = $self->feature_enabled('signatures');
     if ($cv->FLAGS & SVf_POK) {
 	my $myproto = $cv->PV;
 	if ($has_sig) {
@@ -2334,6 +2334,7 @@ my %feature_keywords = (
    catch    => 'try',
    finally  => 'try',
    defer    => 'defer',
+   signatures => 'signatures',
 );
 
 # keywords that are strong and also have a prototype

--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -3345,3 +3345,10 @@ my $x = !1;
 ####
 # const NV: NV-ness preserved
 my(@x) = (-2.0, -1.0, -0.0, 0.0, 1.0, 2.0);
+####
+# PADSV_STORE optimised my should be handled
+() = (my $s = 1);
+####
+# PADSV_STORE optimised state should be handled
+# CONTEXT use feature "state";
+() = (state $s = 1);


### PR DESCRIPTION
Fix up regressions in Deparse.pm and update the list of files to skip/ignore for ./TEST -deparse.
I propose this gets merged before 3.38.0-RC1.

This is based on  the idea that about once per year I run 'cd t; ./TEST -deparse', which runs all the test files through Deparse before executing them, and see what test files have started failing or unexpectedly succeeding. (I normally do this not quite so close to the release date!)

The main fixes to Deparse.pm are:
* honour signatures under 'use v5.36' in addition to honouring under 'use feature "signatures"'.
* handle the new OP_PADSV_STORE op in list context. This was failing to deparse: @a = (my $x = 1).


And quite a few files have been added to Porting/deparse-skips.txt to skip new failing things for now, such as class/*.t