### PR TITLE
fix typo in Configure, ">& 4" to ">&4"

### DIFF
--- a/Configure
+++ b/Configure
@@ -24492,7 +24492,7 @@ case " $extensions"  in
 *" Fcntl "*"_File "*" IO "*) ;; # GDBM_File
 *" Fcntl "*" IO "*"_File "*) ;; # NDBM_File
 *) echo "WARNING: Extensions DB_File or *DBM_File, Fcntl, and IO not configured." >&4
-   echo "WARNING: The Perl you are building will be quite crippled." >& 4
+   echo "WARNING: The Perl you are building will be quite crippled." >&4
    ;;
 esac
 


### PR DESCRIPTION
In Configure, there is a typo while redirecting message if no suitable extensions found.