### PR TITLE
use the linker to link generate_uudmap$(EXE)

### DIFF
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -787,7 +787,7 @@ bitcount.h: generate_uudmap\$(HOST_EXE_EXT)
 
 $spitshell >>$Makefile <<'!NO!SUBS!'
 generate_uudmap$(HOST_EXE_EXT): generate_uudmap$(OBJ_EXT)
-	$(CC) -o generate_uudmap$(EXE_EXT) $(LDFLAGS) generate_uudmap$(OBJ_EXT) $(libs)
+	$(LD) -o generate_uudmap$(EXE_EXT) $(LDFLAGS) generate_uudmap$(OBJ_EXT) $(libs)
 
 !NO!SUBS!
 ;;


### PR DESCRIPTION
Recent versions of clang++ complain when building .c files as C++:

  clang-16: warning: treating 'c' input as 'c++' when in C++ mode,
  this behavior is deprecated [-Wdeprecated]

The solution for this would be to Configure with:

  ./Configure ... -Dcc=clang++\ -xc++ -Dld=clang++

this results in the link stage for generate_uudmap trying to compile generate_uudmap.o as C++ and hilarity ensues.

Fix this by using the linker to link.