### PR TITLE
Porting/bench.pl: handle changes to cachegrind

### DIFF
--- a/Porting/bench.pl
+++ b/Porting/bench.pl
@@ -902,22 +902,22 @@ sub parse_cachegrind {
             die "Error: while executing $id:\n"
               . "unexpected code or cachegrind output:\n$_\n";
         }
-        if (/I   refs:\s+([\d,]+)/) {
+        if (/I\s+refs:\s+([\d,]+)/) {
             $res{Ir} = $1;
         }
-        elsif (/I1  misses:\s+([\d,]+)/) {
+        elsif (/I1\s+misses:\s+([\d,]+)/) {
             $res{Ir_m1} = $1;
         }
-        elsif (/LLi misses:\s+([\d,]+)/) {
+        elsif (/LLi\s+misses:\s+([\d,]+)/) {
             $res{Ir_mm} = $1;
         }
-        elsif (/D   refs:\s+.*?([\d,]+) rd .*?([\d,]+) wr/) {
+        elsif (/D\s+refs:\s+.*?([\d,]+) rd .*?([\d,]+) wr/) {
             @res{qw(Dr Dw)} = ($1,$2);
         }
-        elsif (/D1  misses:\s+.*?([\d,]+) rd .*?([\d,]+) wr/) {
+        elsif (/D1\s+misses:\s+.*?([\d,]+) rd .*?([\d,]+) wr/) {
             @res{qw(Dr_m1 Dw_m1)} = ($1,$2);
         }
-        elsif (/LLd misses:\s+.*?([\d,]+) rd .*?([\d,]+) wr/) {
+        elsif (/LLd\s+misses:\s+.*?([\d,]+) rd .*?([\d,]+) wr/) {
             @res{qw(Dr_mm Dw_mm)} = ($1,$2);
         }
         elsif (/Branches:\s+.*?([\d,]+) cond .*?([\d,]+) ind/) {
@@ -1185,7 +1185,7 @@ sub grind_run {
                         $envstr .= "$_=$env->{$_} " for sort keys %$env;
                     }
                     my $cmd = "PERL_HASH_SEED=0 $envstr"
-                            . "valgrind --tool=cachegrind  --branch-sim=yes "
+                            . "valgrind --tool=cachegrind  --branch-sim=yes --cache-sim=yes "
                             . "--cachegrind-out-file=/dev/null "
                             . "$OPTS{grindargs} "
                             . "$perl $OPTS{perlargs} $args - $counts->[$j] 2>&1";


### PR DESCRIPTION
The spacing of some of the output fields changed:

https://sourceware.org/git/?p=valgrind.git;a=commit;h=2cccba7cae9f77aa6c2a498bc30a42bdb1ed8829

--cache-sim=no is now the default:

https://sourceware.org/git/?p=valgrind.git;a=commit;h=57dbcacfdbff0d4c12dcd52ff56f159631499dc6

Fixes #21105