### PR TITLE
IO::Socket::IP: detect if setsockopt() fails to clear IPV6_V6ONLY

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -677,6 +677,10 @@ use File::Glob qw(:case);
         'EXCLUDED'     => [
             qr{^examples/},
         ],
+        'CUSTOMIZED' => [
+            # https://rt.cpan.org/Ticket/Display.html?id=148293
+            'lib/IO/Socket/IP.pm'
+        ],
     },
 
     'IO::Zlib' => {

--- a/cpan/IO-Socket-IP/lib/IO/Socket/IP.pm
+++ b/cpan/IO-Socket-IP/lib/IO/Socket/IP.pm
@@ -12,7 +12,8 @@ use warnings;
 # $VERSION needs to be set before  use base 'IO::Socket'
 #  - https://rt.cpan.org/Ticket/Display.html?id=92107
 BEGIN {
-   our $VERSION = '0.41';
+   our $VERSION = '0.41_01';
+   $VERSION = eval $VERSION;
 }
 
 use base qw( IO::Socket );
@@ -154,6 +155,12 @@ sub import
          die "Cannot socket(PF_INET6) - $!";
 
       if( setsockopt $testsock, IPPROTO_IPV6, IPV6_V6ONLY, 0 ) {
+         if ($^O eq "dragonfly") {
+            # dragonflybsd 6.4 lies about successfully turning this off
+            if (getsockopt $testsock, IPPROTO_IPV6, IPV6_V6ONLY) {
+               return $can_disable_v6only = 0;
+            }
+         }
          return $can_disable_v6only = 1;
       }
       elsif( $! == EINVAL || $! == EOPNOTSUPP ) {

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -10,6 +10,7 @@ Digest::MD5 cpan/Digest-MD5/MD5.xs dc40839d25ba5e2d6f42fc9b81b409f1d0dbfb0e
 ExtUtils::Constant cpan/ExtUtils-Constant/lib/ExtUtils/Constant/Base.pm 7560e1018f806db5689dee78728ccb8374aea741
 ExtUtils::Constant cpan/ExtUtils-Constant/t/Constant.t 165e9c7132b003fd192d32a737b0f51f9ba4999e
 Filter::Util::Call pod/perlfilter.pod d1e217d0bc6083755b9017050b8724472c58275a
+IO::Socket::IP cpan/IO-Socket-IP/lib/IO/Socket/IP.pm a3390d0b3b617a0b810c75941bfc6e6d0be5b785
 Locale::Maketext::Simple cpan/Locale-Maketext-Simple/lib/Locale/Maketext/Simple.pm 57ed38905791a17c150210cd6f42ead22a7707b6
 MIME::Base64 cpan/MIME-Base64/Base64.xs ad617fe2d01932c35b92defa26d40aba601a95a8
 MIME::Base64 cpan/MIME-Base64/lib/MIME/Base64.pm 18e38d197c7c83f96b24f48bef514e93908e6a82


### PR DESCRIPTION
dragonfly bsd 6.4 succeeds in clearing this, even though it doesn't clear it.

https://rt.cpan.org/Ticket/Display.html?id=148293