### PR TITLE
 t/loc_tools.pl: Update text for searched for diagnostic

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -2424,6 +2424,9 @@ S_new_ctype(pTHX_ const char *newctype, bool force)
         if (   (UNLIKELY(bad_count))
             && (LIKELY(ckWARN_d(WARN_LOCALE)) || UNLIKELY(DEBUG_L_TEST)))
         {
+            /* WARNING.  If you change the wording of these; be sure to update
+             * t/loc_tools.pl correspondingly */
+
             if (PL_in_utf8_CTYPE_locale) {
                 PL_warn_locale = Perl_newSVpvf(aTHX_
                      "Locale '%s' contains (at least) the following characters"

--- a/t/loc_tools.pl
+++ b/t/loc_tools.pl
@@ -180,7 +180,7 @@ sub _trylocale ($$$$) { # For use only by other functions in this file!
         $badutf8 = 1 if grep { /Malformed UTF-8/ } @_;
         $unsupported = 1 if grep { /Locale .* is unsupported/i } @_;
         $plays_well = 0 if grep {
-                    /Locale .* may not work well(?#
+                    /The following characters .* may not have the same meaning as the Perl program expects(?#
                    )|The Perl program will use the expected meanings/i
             } @_;
     };


### PR DESCRIPTION
    
     This fixes #21113.
     
     This script looks for locales that have no idiosyncracies.  It excludes
     ones that generate warnings that there are potential issues with them.
     However, commit 667fa5f07f977e11018489f79c0e6531c9f79a72 changed the
     warning text, without updating this script with the new text.  Hence,
     problematic locales were let through.
     
     Simply update the searched-for text now, and add a cross-referencing
     comment to where the text is generated to keep this from happening
     again.
     
     The problem in this ticket is that a locale chosen on this platform
     happens to have idiosyncracies.  Other platforms happen to currently
     choose different locales that aren't problematic.  This change keeps any
     problematic locale from being chosen.
