### PR TITLE
Minor clarification in perlform.pod

### DIFF
--- a/pod/perlform.pod
+++ b/pod/perlform.pod
@@ -206,6 +206,7 @@ line.  The tilde will be translated to a space upon output.
 X<format, repeating lines>
 
 If you put two contiguous tilde characters "~~" anywhere into a line,
+then in addition to suppressing the line if all fields are blank,
 the line will be repeated until all the fields on the line are exhausted,
 i.e. undefined. For special (caret) text fields this will occur sooner or
 later, but if you use a text field of the at variety, the  expression you


### PR DESCRIPTION
This small update makes it more clear that the double tilde in a format implies the single tilde (see [the code of `doparseform` in `pp_ctl.c`](https://github.com/Perl/perl5/blob/v5.36.1/pp_ctl.c#L5638)).

Inspired by a question from user *hotpelmen* [on PerlMonks](https://www.perlmonks.org/?node_id=11152452).