### PR TITLE
warnings doc improvements

### DIFF
--- a/lib/warnings.pm
+++ b/lib/warnings.pm
@@ -1264,7 +1264,7 @@ this snippet of code:
         open(@_);
     }
 
-    sub new
+    sub open
     ...
     1;
 

--- a/lib/warnings.pm
+++ b/lib/warnings.pm
@@ -1207,7 +1207,7 @@ X<warning, reporting> X<warning, registering>
 
 The C<warnings> pragma provides a number of functions that are useful for
 module authors.  These are used when you want to report a module-specific
-warning to a calling module has enabled warnings via the C<warnings>
+warning to a calling module that has enabled warnings via the C<warnings>
 pragma.
 
 Consider the module C<MyMod::Abc> below.
@@ -1230,12 +1230,23 @@ Consider the module C<MyMod::Abc> below.
 The call to C<warnings::register> will create a new warnings category
 called "MyMod::Abc", i.e. the new category name matches the current
 package name.  The C<open> function in the module will display a warning
-message if it gets given a relative path as a parameter.  This warnings
+message if it gets given a relative path as a parameter.  This warning
 will only be displayed if the code that uses C<MyMod::Abc> has actually
-enabled them with the C<warnings> pragma like below.
+enabled them with the C<warnings> pragma as below - note that a plain
+C<use warnings> enables even warnings that have not yet been registered.
 
+    use warnings;
     use MyMod::Abc;
-    use warnings 'MyMod::Abc';
+    ...
+    abc::open("../fred.txt");
+
+The specific warning can be enabled or disabled, but only after the module
+has been imported:
+
+    # no warnings 'MyMod::Abc';     # error, unknown category before
+                                    # the module is loaded
+    use MyMod::Abc;
+    no warnings 'MyMod::Abc';       # ok after the module is loaded
     ...
     abc::open("../fred.txt");
 
@@ -1245,26 +1256,26 @@ this snippet of code:
 
     package MyMod::Abc;
 
-    sub open {
+    sub open2 {
         if (warnings::enabled("deprecated")) {
             warnings::warn("deprecated",
-                           "open is deprecated, use new instead");
+                           "open2 is deprecated, use open instead");
         }
-        new(@_);
+        open(@_);
     }
 
     sub new
     ...
     1;
 
-The function C<open> has been deprecated, so code has been included to
+The function C<open2> has been deprecated, so code has been included to
 display a warning message whenever the calling module has (at least) the
 "deprecated" warnings category enabled.  Something like this, say.
 
     use warnings 'deprecated';
     use MyMod::Abc;
     ...
-    MyMod::Abc::open($filename);
+    MyMod::Abc::open2($filename);
 
 Either the C<warnings::warn> or C<warnings::warnif> function should be
 used to actually display the warnings message.  This is because they can

--- a/lib/warnings.pm
+++ b/lib/warnings.pm
@@ -5,7 +5,7 @@
 
 package warnings;
 
-our $VERSION = "1.64";
+our $VERSION = "1.65";
 
 # Verify that we're called correctly so that warnings will work.
 # Can't use Carp, since Carp uses us!

--- a/lib/warnings/register.pm
+++ b/lib/warnings/register.pm
@@ -40,6 +40,7 @@ warnings::register - warnings import function
 
 Creates a warnings category with the same name as the current package.
 
-See L<warnings> for more information on this module's usage.
+See L<warnings/"Reporting Warnings from a Module"> for more information
+on this module's usage.
 
 =cut

--- a/lib/warnings/register.pm
+++ b/lib/warnings/register.pm
@@ -1,4 +1,4 @@
-package warnings::register 1.05;
+package warnings::register 1.06;
 
 require warnings;
 

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -16,7 +16,7 @@
 #
 # This script is normally invoked from regen.pl.
 
-$VERSION = '1.64';
+$VERSION = '1.65';
 
 BEGIN {
     require './regen/regen_lib.pl';

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -1438,7 +1438,7 @@ X<warning, reporting> X<warning, registering>
 
 The C<warnings> pragma provides a number of functions that are useful for
 module authors.  These are used when you want to report a module-specific
-warning to a calling module has enabled warnings via the C<warnings>
+warning to a calling module that has enabled warnings via the C<warnings>
 pragma.
 
 Consider the module C<MyMod::Abc> below.
@@ -1461,12 +1461,23 @@ Consider the module C<MyMod::Abc> below.
 The call to C<warnings::register> will create a new warnings category
 called "MyMod::Abc", i.e. the new category name matches the current
 package name.  The C<open> function in the module will display a warning
-message if it gets given a relative path as a parameter.  This warnings
+message if it gets given a relative path as a parameter.  This warning
 will only be displayed if the code that uses C<MyMod::Abc> has actually
-enabled them with the C<warnings> pragma like below.
+enabled them with the C<warnings> pragma as below - note that a plain
+C<use warnings> enables even warnings that have not yet been registered.
 
+    use warnings;
     use MyMod::Abc;
-    use warnings 'MyMod::Abc';
+    ...
+    abc::open("../fred.txt");
+
+The specific warning can be enabled or disabled, but only after the module
+has been imported:
+
+    # no warnings 'MyMod::Abc';     # error, unknown category before
+                                    # the module is loaded
+    use MyMod::Abc;
+    no warnings 'MyMod::Abc';       # ok after the module is loaded
     ...
     abc::open("../fred.txt");
 
@@ -1476,26 +1487,26 @@ this snippet of code:
 
     package MyMod::Abc;
 
-    sub open {
+    sub open2 {
         if (warnings::enabled("deprecated")) {
             warnings::warn("deprecated",
-                           "open is deprecated, use new instead");
+                           "open2 is deprecated, use open instead");
         }
-        new(@_);
+        open(@_);
     }
 
     sub new
     ...
     1;
 
-The function C<open> has been deprecated, so code has been included to
+The function C<open2> has been deprecated, so code has been included to
 display a warning message whenever the calling module has (at least) the
 "deprecated" warnings category enabled.  Something like this, say.
 
     use warnings 'deprecated';
     use MyMod::Abc;
     ...
-    MyMod::Abc::open($filename);
+    MyMod::Abc::open2($filename);
 
 Either the C<warnings::warn> or C<warnings::warnif> function should be
 used to actually display the warnings message.  This is because they can

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -1495,7 +1495,7 @@ this snippet of code:
         open(@_);
     }
 
-    sub new
+    sub open
     ...
     1;
 


### PR DESCRIPTION
- fix a couple of typos;
- clarify that 'use warnings' enables even warnings that have not yet been registered;
- rename function name in an example, since a later reference relates to the same function from a previous example;
- link to a more specific point from warnings::register