### PR TITLE
XSUB.h: remove setjmp and longjmp overrides

### DIFF
--- a/XSUB.h
+++ b/XSUB.h
@@ -504,7 +504,6 @@ Rethrows a previously caught exception.  See L<perlguts/"Exception Handling">.
 #    undef fgetpos
 #    undef ioctl
 #    undef getlogin
-#    undef setjmp
 #    undef getc
 #    undef ungetc
 #    undef fileno
@@ -609,8 +608,6 @@ Rethrows a previously caught exception.  See L<perlguts/"Exception Handling">.
 #    define sleep		PerlProc_sleep
 #    define times		PerlProc_times
 #    define wait		PerlProc_wait
-#    define setjmp		PerlProc_setjmp
-#    define longjmp		PerlProc_longjmp
 #    define signal		PerlProc_signal
 #    define getpid		PerlProc_getpid
 #    define gettimeofday	PerlProc_gettimeofday

--- a/dist/threads/lib/threads.pm
+++ b/dist/threads/lib/threads.pm
@@ -5,7 +5,7 @@ use 5.008;
 use strict;
 use warnings;
 
-our $VERSION = '2.36';      # remember to update version in POD!
+our $VERSION = '2.37';      # remember to update version in POD!
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -134,7 +134,7 @@ threads - Perl interpreter-based threads
 
 =head1 VERSION
 
-This document describes threads version 2.36
+This document describes threads version 2.37
 
 =head1 WARNING
 

--- a/dist/threads/threads.xs
+++ b/dist/threads/threads.xs
@@ -1,24 +1,12 @@
 #define PERL_NO_GET_CONTEXT
-/* Workaround for mingw 32-bit compiler by mingw-w64.sf.net - has to come before any #include.
- * It also defines USE_NO_MINGW_SETJMP_TWO_ARGS for the mingw.org 32-bit compilers ... but
- * that's ok as that compiler makes no use of that symbol anyway */
-#if defined(WIN32) && defined(__MINGW32__) && !defined(__MINGW64__)
-#  define USE_NO_MINGW_SETJMP_TWO_ARGS 1
-#endif
+/* Tell XSUB.h not to redefine common functions. Its setjmp() override has a
+ * circular definition in Perls < 5.40. */
+#define NO_XSLOCKS
+
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
-/* Workaround for XSUB.h bug under WIN32 */
-#ifdef WIN32
-#  undef setjmp
-#  if defined(USE_NO_MINGW_SETJMP_TWO_ARGS) || (!defined(__BORLANDC__) && !defined(__MINGW64__))
-#    define setjmp(x) _setjmp(x)
-#  endif
-#  if defined(__MINGW64__)
-#    include <intrin.h>
-#    define setjmp(x) _setjmpex((x), mingw_getsp())
-#  endif
-#endif
+
 #define NEED_PL_signals
 #define NEED_sv_2pv_flags
 #include "ppport.h"


### PR DESCRIPTION
Those redefinitions are in effect only when `PERL_IMPLICIT_SYS` is defined (pretty much only on Windows) and they're broken (circular) when `HAS_SIGSETJMP` isn't defined (e.g. on Windows). Also, even if they weren't broken, they don't provide any value.

The workaround in threads.xs for this issue is still needed, because it's a dual-life module and it's supposed to work on older Perls. However, it can be simplified by defining `NO_XSLOCKS` to suppress the redefinitions.

Fixes #21039

(This can wait for 5.39)