### PR TITLE
cv_undef_flags: there's nothing to clean up for our subs in cloned pads

### DIFF
--- a/pad.c
+++ b/pad.c
@@ -401,9 +401,12 @@ Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
             SV ** const curpad = AvARRAY(comppad);
             for (ix = PadnamelistMAX(comppad_name); ix > 0; ix--) {
                 PADNAME * const name = namepad[ix];
-                if (name && PadnamePV(name) && *PadnamePV(name) == '&')
-                    {
-                        CV * const innercv = MUTABLE_CV(curpad[ix]);
+                if (name && PadnamePV(name) && *PadnamePV(name) == '&') {
+                    CV * const innercv = MUTABLE_CV(curpad[ix]);
+                    if (PadnameIsOUR(name) && CvCLONED(&cvbody)) {
+                        assert(!innercv);
+                    }
+                    else {
                         U32 inner_rc;
                         assert(innercv);
                         assert(SvTYPE(innercv) != SVt_PVFM);
@@ -433,6 +436,7 @@ Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
                             }
                         }
                     }
+                }
             }
         }
 

--- a/t/op/lexsub.t
+++ b/t/op/lexsub.t
@@ -7,7 +7,7 @@ BEGIN {
     *bar::is = *is;
     *bar::like = *like;
 }
-plan 151;
+plan 152;
 
 # -------------------- our -------------------- #
 
@@ -105,6 +105,14 @@ sub bar::_cmp { $b cmp $a }
   package main;
   is join(" ", sort _cmp split //, 'oursub'), 'u u s r o b', 'sort our_sub'
 }
+
+# https://github.com/Perl/perl5/issues/21067
+# this would crash/assert
+fresh_perl_is(<<'PROG', "ok", { }, "pad cleanup for a closure referring to an our sub");
+our sub foo;
+0 if sub { eval "" if 0; \&foo if 0; };
+print "ok";
+PROG
 
 # -------------------- state -------------------- #
 


### PR DESCRIPTION
Fixes #21067

When an instance of a closure is created, the pad entries for the cloned sub are copied (S_clone_sv_pad()) from either the prototype sub (for lexicals belonging to the sub) or from the context (for lexicals from outside
the sub).

This doesn't happen for our variables, instead the cloned sub has these pad entries set to NULL.

This isn't an issue at runtime since references to lexical our sub/variables are compiled into GV or GVSV ops.

cv_undef_flags() assumed this these entries were non-NULL for all lexical subs.

Fix by checking if the entry is an our sub and the CV being freed is a clone, if so, skip the accesses to the NULL pad entry.

Added an assert to the new branch to ensure any changes in the above results in an early failure here and hopefully a fix.