### PR TITLE
getpgrp: getpgid used for PID != 0 is now a lot more portable

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -1027,9 +1027,6 @@ violations are fatal.
 #  define HAS_SETPGRP  /* Well, effectively it does . . . */
 #endif
 
-/* getpgid isn't POSIX, but at least Solaris and Linux have it, and it makes
-    our life easier :-) so we'll try it.
-*/
 #ifdef HAS_GETPGID
 #  define BSD_GETPGRP(pid)		getpgid((pid))
 #elif defined(HAS_GETPGRP) && defined(USE_BSD_GETPGRP)

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -3128,9 +3128,10 @@ Returns the current process group for the specified PID.  Use
 a PID of C<0> to get the current process group for the
 current process.  Will raise an exception if used on a machine that
 doesn't implement L<getpgrp(2)>.  If PID is omitted, returns the process
-group of the current process.  Note that the POSIX version of
-L<C<getpgrp>|/getpgrp PID> does not accept a PID argument, so only
-C<PID==0> is truly portable.
+group of the current process.
+
+Some very old machines may not support C<PID != 0> and will throw an
+exception if C<PID != 0>.
 
 Portability issues: L<perlport/getpgrp>.
 


### PR DESCRIPTION
POSIX.1 2004 lists getpgid as an XSI extension, 2017 edition lists it as BASE.

Removed the comments since it now seems irrelevant.

Fixes #19648