### PR TITLE
t/op/glob.t - defend against ls with colors enabled

### DIFF
--- a/t/op/glob.t
+++ b/t/op/glob.t
@@ -19,10 +19,16 @@ elsif ($^O eq 'VMS') {
   map { s/;.*$//; delete $files{lc($_)}; } split /[\n]/, `directory/noheading/notrailing/versions=1 [.op]`,
 }
 else {
+  local %ENV = %ENV;
+  # disable any env vars that might cause ls or dir to add colors or
+  # otherwise modify the output.
+  /COLOR|LS|CLI/i and delete $ENV{$_} for keys %ENV;
+
   map { $files{$_}++ } <op/*>;
   map { delete $files{"op/$_"} } split /\n/, `ls op/ | cat`;
 }
-ok( !(keys(%files)),'leftover op/* files' ) or diag(join(' ',sort keys %files));
+ok( !(keys(%files)),'glob and directory listing agree' )
+    or diag(join(' ',sort keys %files));
 
 cmp_ok($/,'eq',"\n",'sane input record separator');
 


### PR DESCRIPTION
Disable any ENV vars with the word "color", "ls" or "cli" in them (case insensitively) before running ls.  This appears to mostly be a BSD/darwin issue, but we do it on all platforms where we call ls in an abundance of caution.

Fixes #21156.