### PR TITLE
perldelta.pod: Fix GH references and formatting 

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -188,7 +188,7 @@ engine to run longer and use more memory.
 
 There are two new API functions for operating on optree fragments, ensuring
 you can invoke the required parts of the optree-generation process that might
-otherwise not get invoked (e.g. when creating a custom LOGOP).  To get access
+otherwise not get invoked (e.g. when creating a custom C<LOGOP>).  To get access
 to these functions, you first need to set a C<#define> to opt-in to using
 these functions.
 
@@ -247,9 +247,9 @@ and eof flags after an error occurred on the stream.
 
 In nearly all cases this clear is no longer done, so the error and
 eof flags now properly reflect the status of the stream after
-readline().
+C<readline()>.
 
-Since the error flag is no longer cleared calling close() on the
+Since the error flag is no longer cleared calling C<close()> on the
 stream may fail and if the stream was not explicitly closed, the
 implicit close of the stream may produce a warning.
 
@@ -268,17 +268,17 @@ flag yourself with C<< $handle->clearerr() >> to continue reading.
 =item *
 
 If your code encounters an error on the stream while reading with
-readline() you will need to call C<< $handle->clearerr >> to continue
+C<readline()> you will need to call C<< $handle->clearerr >> to continue
 reading.  The one case this occurred the underlying file descriptor was
-marked non-blocking, so the read() system call was failing with
+marked non-blocking, so the C<read()> system call was failing with
 C<EAGAIN>, which resulted in the error flag being set on the stream.
 
 =back
 
 The only case where error and eof flags continue to cleared on
-error is when reading from the child process for glob() in
+error is when reading from the child process for C<glob()> in
 F<miniperl>.  This allows it to correctly report errors from the child
-process on close().  This is unlikely to be an issue during normal
+process on C<close()>. This is unlikely to be an issue during normal
 perl development.
 
 [L<GH #20060|https://github.com/Perl/perl5/issues/20060>]
@@ -288,7 +288,7 @@ perl development.
 C<INIT> blocks will no longer run after an C<exit()> performed inside of
 a C<BEGIN>. This means that the combination of the C<-v> option and the
 C<-c> option no longer executes a compile check as well as showing the
-perl version. The C<-v> option executes an exit(0) after printing the
+perl version. The C<-v> option executes an C<exit(0)> after printing the
 version information inside of a C<BEGIN> block, and the C<-c> check is
 implemented by using C<INIT> hooks, resulting in the C<-v> option taking
 precedence.
@@ -378,15 +378,15 @@ These features will be entirely removed from perl in v5.42.0.
 
 Additional optree optimizations for common OP patterns. For example, multiple
 simple OPs replaced by a single streamlined OP, so as to be more efficient at
-runtime. L<[GH #19943]|https://github.com/Perl/perl5/pull/19943>,
-L<[GH #20063]|https://github.com/Perl/perl5/pull/20063>,
-L<[GH #20077]|https://github.com/Perl/perl5/pull/20077>.
+runtime. [L<GH #19943|https://github.com/Perl/perl5/pull/19943>],
+[L<GH #20063|https://github.com/Perl/perl5/pull/20063>],
+[L<GH #20077|https://github.com/Perl/perl5/pull/20077>].
 
 =item *
 
 Creating an anonymous sub no longer generates an C<srefgen> op, the
 reference generation is now done in the C<anoncode> or C<anonconst>
-op, saving runtime.  [github #20290]
+op, saving runtime. [L<GH #20290|https://github.com/Perl/perl5/pull/20290>]
 
 =back
 
@@ -398,11 +398,11 @@ op, saving runtime.  [github #20290]
 
 =item *
 
-Added the C<is_tainted()> builtin function. [L<github #19854|https://github.com/Perl/perl5/issues/19854>]
+Added the C<is_tainted()> builtin function. [L<GH #19854|https://github.com/Perl/perl5/issues/19854>]
 
 =item *
 
-Added the C<export_lexically()> builtin function as per PPC 0020. [L<github #19895|https://github.com/Perl/perl5/issues/19895>]
+Added the C<export_lexically()> builtin function as per PPC 0020. [L<GH #19895|https://github.com/Perl/perl5/issues/19895>]
 
 =item *
 
@@ -612,8 +612,8 @@ IO-Compress has been upgraded from version 2.106 to 2.204.
 
 L<IO::Socket::IP> has been upgraded from version 0.41 to 0.41_01.
 
-On DragonflyBSD, detect setsockopt() not actually clearing
-C<IPV6_V6ONLY> even when setsockopt() returns success.  [L<cpan
+On DragonflyBSD, detect C<setsockopt()> not actually clearing
+C<IPV6_V6ONLY> even when C<setsockopt()> returns success.  [L<CPAN
 #148293|https://rt.cpan.org/Ticket/Display.html?id=148293>]
 
 =item *
@@ -1368,7 +1368,7 @@ make the exact value clear to a reader. The exact rules on which
 characters are escaped may change over time but currently are that
 printable ASCII codepoints, with the exception of C<"> and C<\>, and
 unicode word characters whose codepoint is over 255 are output raw, and
-any other symbols are escaped much as Data::Dumper might escape them,
+any other symbols are escaped much as L<Data::Dumper> might escape them,
 using C<\n> for newline and C<\"> for double quotes, etc. Codepoints in
 the range 128-255 are always escaped as they can cause trouble on
 unicode terminals when output raw.
@@ -1509,7 +1509,7 @@ L<Smartmatch is deprecated|perldiag/"Smartmatch is deprecated"> replaces C<Smart
 
 C<make -j6 minitest> could fail due to a build conflict in building
 C<$(MINIPERL_EXE)> between the main make process and a child process.
-[github #19829]
+[L<GH #19829|https://github.com/Perl/perl5/issues/19829>]
 
 =item *
 
@@ -1542,11 +1542,11 @@ C<Configure> now properly handles quoted elements outputted by gcc.
 
 =item *
 
-C<Configure> probed for the return type of malloc() and free() by
+C<Configure> probed for the return type of C<malloc()> and C<free()> by
 testing whether declarations for those functions produced a function
 type mismatch with the implementation.  On Solaris, with a C++
 compiler, this check always failed, since Solaris instead imports
-malloc() and free() from C<std::> with C<using> for C++ builds.  Since
+C<malloc()> and C<free()> from C<std::> with C<using> for C++ builds.  Since
 the return types of malloc() and free() are well defined by the C
 standard, skip probing for them.  C<Configure> command-line arguments
 and hints can still override these type in the unlikely case that is
@@ -1592,14 +1592,16 @@ machines.  Its final release was in 1995.
 
 =item DragonflyBSD
 
-Skip tests to workaround an apparent bug in setproctitle().  [L<github #19894|https://github.com/Perl/perl5/issues/19894>]
+Skip tests to workaround an apparent bug in C<setproctitle()>.
+[L<GH #19894|https://github.com/Perl/perl5/issues/19894>]
 
 =item FreeBSD
 
 FreeBSD no longer uses thread-safe locale operations, to avoid L<a bug in
 FreeBSD|https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=265950>
 
-Replace the first part of archname with `uname -p` [L<github #19791|https://github.com/Perl/perl5/issues/19791>]
+Replace the first part of archname with C<uname -p>
+[L<GH #19791|https://github.com/Perl/perl5/issues/19791>]
 
 =item Solaris
 
@@ -1611,31 +1613,37 @@ Update Synology Readme for DSM 7.
 
 =item Windows
 
-Fix win32 memory alignment needed for gcc-12 from vmem.h.
+Fix win32 memory alignment needed for gcc-12 from F<vmem.h>.
 
-utimes() on Win32 would print a message to stderr if it failed to
-convert a supplied C<time_t> to to a C<FILETIME>. [github #19668]
+C<utimes()> on Win32 would print a message to stderr if it failed to
+convert a supplied C<time_t> to to a C<FILETIME>.
+[L<GH #19668|https://github.com/Perl/perl5/issues/19668>]
 
 In some cases, timestamps returned by L<stat()|perlfunc/stat> and
 L<lstat()|perlfunc/lstat> failed to take daylight saving time into account.
 [L<GH #20018|https://github.com/Perl/perl5/issues/20018>]
 [L<GH #20061|https://github.com/Perl/perl5/issues/20061>]
 
-stat() now works on AF_UNIX socket files. [github #20204]
+C<stat()> now works on C<AF_UNIX> socket files.
+[L<GH #20204|https://github.com/Perl/perl5/issues/20204>]
 
-readlink() now returns the C<PrintName> from a symbolic link reparse
+C<readlink()> now returns the C<PrintName> from a symbolic link reparse
 point instead of the C<SubstituteName>, which should make it better
-match the name the link was created with.  [github #20271]
+match the name the link was created with.
+[L<GH #20271|https://github.com/Perl/perl5/pull/20271>]
 
-lstat() on Windows now returns the length of the link target as the
-size of the file, as it does on POSIX systems.  [github #20476]
+C<lstat()> on Windows now returns the length of the link target as the
+size of the file, as it does on POSIX systems.
+[L<GH #20476|https://github.com/Perl/perl5/issues/20476>]
 
-symlink() on Windows now replaces any C</> in the target with C<\>,
+C<symlink()> on Windows now replaces any C</> in the target with C<\>,
 since Windows does not recognise C</> in symbolic links.  The reverse
-translation is B<not> done by readlink().  [github #20506]
+translation is B<not> done by C<readlink()>.
+[L<GH #20506|https://github.com/Perl/perl5/issues/20506>]
 
-symlink() where the target was an absolute path to a directory was
-incorrectly created as a file symbolic link.  [github #20533]
+C<symlink()> where the target was an absolute path to a directory was
+incorrectly created as a file symbolic link.
+[L<GH #20533|https://github.com/Perl/perl5/issues/20533>]
 
 C<POSIX::dup2> no longer creates broken sockets. [L<GH
 #20920|https://github.com/Perl/perl5/issues/20920>]
@@ -1875,7 +1883,7 @@ value will not be magical.
 The C<SSNEW()>, C<SSNEWt()>, C<SSNEWa()> and C<SSNEWat()> APIs now
 return a C<SSize_t> value.  The C<SSPTR()> and C<SSPTRt()> macros now
 expect a C<SSize_t> parameter, and enforce that on debugging builds.
-[github #20411]
+[L<GH #20411|https://github.com/Perl/perl5/issues/20411>]
 
 =item *
 
@@ -1963,7 +1971,7 @@ Avoid recursion and stack overflow parsing 'pack' template
 
 =item *
 
-An eval() as the last statement in a regex code block could trigger an
+An C<eval()> as the last statement in a regex code block could trigger an
 interpreter panic; e.g.
 
     /(?{ ...; eval {....}; })/
@@ -1973,7 +1981,7 @@ interpreter panic; e.g.
 =item *
 
 Disabling the C<bareword_filehandles> feature no longer treats C<< print
-Class->method >> as an error.  [L<github #19704|https://github.com/Perl/perl5/issues/19704>]
+Class->method >> as an error.  [L<GH #19704|https://github.com/Perl/perl5/issues/19704>]
 
 =item *
 
@@ -1988,13 +1996,13 @@ In addition, where the Perl subroutine is freed at the same time:
 this formerly could lead to crashes if the XS subroutine tried to use the
 value of C<PL_op>, since this was being set to NULL. This is now fixed.
 
-[L<github #19936|https://github.com/Perl/perl5/issues/19936>]
+[L<GH #19936|https://github.com/Perl/perl5/issues/19936>]
 
 =item *
 
-setsockopt() now uses the mechanism added in 5.36 to better
+C<setsockopt()> now uses the mechanism added in 5.36 to better
 distinguish between numeric and string values supplied as the
-C<OPTVAL> parameter.  [L<github #18761|https://github.com/Perl/perl5/issues/18761>]
+C<OPTVAL> parameter.  [L<GH #18761|https://github.com/Perl/perl5/issues/18761>]
 
 =item *
 
@@ -2002,20 +2010,21 @@ C<OPTVAL> parameter.  [L<github #18761|https://github.com/Perl/perl5/issues/1876
 255. Additionally, for code points 128-255, this operator will now always
 give the corresponding octet to the OS, regardless of how Perl stores
 such code points in memory. (Previously Perl leaked its internal string
-storage to the OS.) [L<github #19882|https://github.com/Perl/perl5/issues/19882>]
+storage to the OS.) [L<GH #19882|https://github.com/Perl/perl5/issues/19882>]
 
 =item *
 
-Fix panic issue from C<val {} inside /(?{...})/> [L<github #19390|https://github.com/Perl/perl5/issues/19390>]
+Fix panic issue from C<val {} inside /(?{...})/> [L<GH #19390|https://github.com/Perl/perl5/issues/19390>]
 
 =item *
 
-Fix multiple compiler warnings from regexp.c., locale.c [L<github #19915|https://github.com/Perl/perl5/issues/19915>]
+Fix multiple compiler warnings from F<regexp.c>, F<locale.c>
+[L<GH #19915|https://github.com/Perl/perl5/issues/19915>]
 
 =item *
 
 Fix a bug with querying locales on platforms that don't have C<LC_NUMERIC>
-[L<github #19890|https://github.com/Perl/perl5/issues/19890>]
+[L<GH #19890|https://github.com/Perl/perl5/issues/19890>]
 
 =item *
 
@@ -2031,7 +2040,7 @@ Avoid adding an offset to a NULL pointer in C<hv_delete_common>.
 
 =item *
 
-PerlIO::get_layers will now accept IO references too
+C<PerlIO::get_layers> will now accept IO references too
 
 Previously it would only take glob references or names of globs. Now it will
 also accept IO references.
@@ -2056,8 +2065,8 @@ switch wouldn't be freed.
 =item *
 
 Correctly handle C<OP_ANONCODE> ops generated by CPAN modules that
-don't include the OPf_REF flag when propagating lvalue context.
-L<[GH #20532]|https://github.com/Perl/perl5/pull/20532>
+don't include the C<OPf_REF> flag when propagating lvalue context.
+[L<GH #20532|https://github.com/Perl/perl5/pull/20532>]
 
 =item *
 
@@ -2075,10 +2084,10 @@ input is returned unchanged.
 
 =item *
 
-Double FETCH during stringification of tied scalars returning an
-overloaded object have been fixed. The FETCH method should only be
+Double C<FETCH> during stringification of tied scalars returning an
+overloaded object have been fixed. The C<FETCH> method should only be
 called once, but prior to this release was actually called twice.
-L<[GH #20574]|https://github.com/Perl/perl5/pull/20574>
+[L<GH #20574|https://github.com/Perl/perl5/pull/20574>]
 
 =item *
 


### PR DESCRIPTION
Fixes https://github.com/Perl/perl5/issues/21170

Includes `C<>` formatting fixes where deemed appropriate.