### PR TITLE
Time-HiRes: don't warn in C++ builds

### DIFF
--- a/dist/Time-HiRes/Changes
+++ b/dist/Time-HiRes/Changes
@@ -17,6 +17,8 @@ Revision history for the Perl extension Time::HiRes.
    https://github.com/Perl/perl5/issues/19321
  - don't use C++ guards around the perl header files, it caused C++
    build failures with MSVC.
+ - don't try to suppress C++ compatibility warnings in C++ builds, since
+   that warns.
 
 1.9764 [2020-08-10]
  - Fix a bunch of repeated-word typos

--- a/dist/Time-HiRes/HiRes.pm
+++ b/dist/Time-HiRes/HiRes.pm
@@ -50,7 +50,7 @@ our @EXPORT_OK = qw (usleep sleep ualarm alarm gettimeofday time tv_interval
                  stat lstat utime
                 );
 
-our $VERSION = '1.9775';
+our $VERSION = '1.9776';
 our $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 

--- a/dist/Time-HiRes/HiRes.xs
+++ b/dist/Time-HiRes/HiRes.xs
@@ -47,6 +47,14 @@
 #  define GCC_DIAG_RESTORE_STMT GCC_DIAG_RESTORE NOOP
 #endif
 
+#ifdef __cplusplus
+#  define GCC_DIAG_IGNORE_CPP_COMPAT_STMT NOOP
+#  define GCC_DIAG_IGNORE_CPP_COMPAT_RESTORE_STMT NOOP
+#else
+#  define GCC_DIAG_IGNORE_CPP_COMPAT_STMT GCC_DIAG_IGNORE_STMT(-Wc++-compat)
+#  define GCC_DIAG_IGNORE_CPP_COMPAT_RESTORE_STMT GCC_DIAG_RESTORE_STMT
+#endif
+
 #if PERL_VERSION_GE(5,7,3) && !PERL_VERSION_GE(5,10,1)
 #  undef SAVEOP
 #  define SAVEOP() SAVEVPTR(PL_op)
@@ -1238,7 +1246,7 @@ setitimer(which, seconds, interval = 0)
         /* on some platforms the 1st arg to setitimer is an enum, which
          * causes -Wc++-compat to complain about passing an int instead
          */
-        GCC_DIAG_IGNORE_STMT(-Wc++-compat);
+        GCC_DIAG_IGNORE_CPP_COMPAT_STMT;
         if (setitimer(which, &newit, &oldit) == 0) {
             EXTEND(sp, 1);
             PUSHs(sv_2mortal(newSVnv(TV2NV(oldit.it_value))));
@@ -1247,7 +1255,7 @@ setitimer(which, seconds, interval = 0)
                 PUSHs(sv_2mortal(newSVnv(TV2NV(oldit.it_interval))));
             }
         }
-        GCC_DIAG_RESTORE_STMT;
+        GCC_DIAG_IGNORE_CPP_COMPAT_RESTORE_STMT;
 
 void
 getitimer(which)
@@ -1258,7 +1266,7 @@ getitimer(which)
         /* on some platforms the 1st arg to getitimer is an enum, which
          * causes -Wc++-compat to complain about passing an int instead
          */
-        GCC_DIAG_IGNORE_STMT(-Wc++-compat);
+        GCC_DIAG_IGNORE_CPP_COMPAT_STMT;
         if (getitimer(which, &nowit) == 0) {
             EXTEND(sp, 1);
             PUSHs(sv_2mortal(newSVnv(TV2NV(nowit.it_value))));
@@ -1267,7 +1275,7 @@ getitimer(which)
                 PUSHs(sv_2mortal(newSVnv(TV2NV(nowit.it_interval))));
             }
         }
-        GCC_DIAG_RESTORE_STMT;
+        GCC_DIAG_IGNORE_CPP_COMPAT_RESTORE_STMT;
 
 #endif /* #if defined(HAS_GETITIMER) && defined(HAS_SETITIMER) */
 


### PR DESCRIPTION
g++ warns here:

warning: option ‘-Wc++-compat’ is valid for C/ObjC but not for C++ [-Wpragmas]

so don't try to suppress this warning for C++ builds.

I wasn't able to find a platform where the first argument to setitimer() or getitimer() is or was an enum.

There's a similar use in ODBM_File, but ODBM_File is never built as C++ since it uses a function with the same name as a C++ keyword.

There's also similar use in Encode, but we don't control that, and I don't think this warning justifies customization.