### PR TITLE
locale.c: Win32 also can determine the codeset

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -2444,7 +2444,7 @@ S_new_ctype(pTHX_ const char *newctype, bool force)
                             );
             }
 
-#    ifdef HAS_SOME_LANGINFO
+#    if defined(HAS_SOME_LANGINFO) || defined(WIN32)
 
             const char * scratch_buffer = NULL;
             Perl_sv_catpvf(aTHX_ PL_warn_locale, "; codeset=%s",


### PR DESCRIPTION
This code adds the codeset detail to debugging statements.  It didn't change when the ability to find the codeset on Windows platforms was added, so the detail was ommited for them, until this commit.