### PR TITLE
Need threads to use cur_locale obj

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -7301,7 +7301,7 @@ Perl_thread_locale_term(pTHX)
      * they affect libc's knowledge of the thread; libc has no knowledge of
      * aTHX */
 
-#ifdef USE_POSIX_2008_LOCALE
+#if defined(USE_POSIX_2008_LOCALE) && defined(USE_THREADS)
 
     /* C starts the new thread in the global C locale.  If we are thread-safe,
      * we want to not be in the global locale */

--- a/perl.c
+++ b/perl.c
@@ -1128,7 +1128,7 @@ perl_destruct(pTHXx)
         PL_curlocales[i] = NULL;
     }
 #endif
-#ifdef USE_POSIX_2008_LOCALE
+#if defined(USE_POSIX_2008_LOCALE) && defined(USE_THREADS)
     {
         /* This also makes sure we aren't using a locale object that gets freed
          * below */


### PR DESCRIPTION
On Configurations that are very unlikely to be seen in the wild, these bits of code were attempted to be compiled when they weren't actually needed, leading to undefined symbols compilation errors.

The configuration basically involved requiring the POSIX 2008 locale thread-safe API when no threads are in use.