### PR TITLE
op/sub.t: Cancel watchdog when done

### DIFF
--- a/t/op/sub.t
+++ b/t/op/sub.t
@@ -426,6 +426,7 @@ eval '
    CORE::state sub b; sub d { sub b {} sub d }
  ';
 eval '()=%e; sub e { sub e; eval q|$x| } e;';
+watchdog 0;
 
 fresh_perl_like(
     q#<s,,$0[sub{m]]]],}>0,shift#,


### PR DESCRIPTION
A watchdog timer should be cancelled after the test(s) it guards. Otherwise, when someone adds new tests after it in the file, and doesn't notice that the tests are under the watchdog, those new tests can fail. These failures may be intermittent, only happening under heavy load.