### PR TITLE
regen/unicode_constants.pl: Add generating first byte as string

### DIFF
--- a/regen/unicode_constants.pl
+++ b/regen/unicode_constants.pl
@@ -1043,3 +1043,7 @@ U+00C5 native
 U+00FF native
 U+00B5 native
 U+00B5 string
+U+066B string
+U+066B first
+U+066B tail
+U+066B first_s

--- a/regen/unicode_constants.pl
+++ b/regen/unicode_constants.pl
@@ -35,10 +35,12 @@ print $out_fh <<END;
  *
  * The macros that have the suffix "_UTF8" may have further suffixes, as
  * follows:
- *  "_FIRST_BYTE" if the value is just the first byte of the UTF-8
- *                representation; the value will be a numeric constant.
- *  "_TAIL"       if instead it represents all but the first byte.  This, and
- *                with no additional suffix are both string constants */
+ *  "_FIRST_BYTE"   if the value is just the first byte of the UTF-8
+ *                  representation; the value will be a numeric constant.
+ *  "_FIRST_BYTEs"  same, but the first byte is represented as a literal
+ *                  string
+ *  "_TAIL"         if instead it represents all but the first byte.  This,
+ *                  and with no additional suffix are both string constants */
 
 /*
 =for apidoc_section \$unicode
@@ -772,10 +774,17 @@ foreach my $charset (get_supported_code_pages()) {
                     $suffix .= '_TAIL';
                     $str = "\"$str\"";  # Will be a string constant
             }
-            elsif ($flag eq 'first') {
+            elsif ($flag =~ / ^ first (_s)? $ /x) {
+                my $wants_string = defined $1;
                 $str =~ s/ \\x ( .. ) .* /$1/x; # Get the two nibbles of the 1st byte
                 $suffix .= '_FIRST_BYTE';
-                $str = "0x$str";        # Is a numeric constant
+                if ($wants_string) {
+                    $suffix .= '_s';
+                    $str = "\"\\x$str\"";
+                }
+                else {
+                    $str = "0x$str";        # Is a numeric constant
+                }
             }
             else {
                 die "Unknown flag at line $.: $_\n";
@@ -984,6 +993,7 @@ read_only_bottom_close_and_rename($out_fh);
 #           code point doesn't exist, the line is just skipped: no output is
 #           generated for it
 #   first   indicates that the output is to be of the FIRST_BYTE form.
+#   first_s indicates that the output is to be of the FIRST_BYTEs form.
 #   tail    indicates that the output is of the _TAIL form.
 #   native  indicates that the output is the code point, converted to the
 #           platform's native character set if applicable

--- a/unicode_constants.h
+++ b/unicode_constants.h
@@ -90,6 +90,10 @@ bytes.
 #   define LATIN_SMALL_LETTER_Y_WITH_DIAERESIS_NATIVE  0xFF    /* U+00FF */
 #   define MICRO_SIGN_NATIVE  0xB5    /* U+00B5 */
 #   define MICRO_SIGN_UTF8  "\xC2\xB5"    /* U+00B5 */
+#   define ARABIC_DECIMAL_SEPARATOR_UTF8  "\xD9\xAB"    /* U+066B */
+#   define ARABIC_DECIMAL_SEPARATOR_UTF8_FIRST_BYTE  0xD9    /* U+066B */
+#   define ARABIC_DECIMAL_SEPARATOR_UTF8_TAIL  "\xAB"    /* U+066B */
+#   define ARABIC_DECIMAL_SEPARATOR_UTF8_FIRST_BYTE_s  "\xD9"    /* U+066B */
 
 #   ifdef PERL_IN_TOKE_C
        /* Paired characters for quote-like operators, in UTF-8 */
@@ -151,6 +155,10 @@ bytes.
 #   define LATIN_SMALL_LETTER_Y_WITH_DIAERESIS_NATIVE  0xDF    /* U+00FF */
 #   define MICRO_SIGN_NATIVE  0xA0    /* U+00B5 */
 #   define MICRO_SIGN_UTF8  "\x80\x64"    /* U+00B5 */
+#   define ARABIC_DECIMAL_SEPARATOR_UTF8  "\xB8\x62\x52"    /* U+066B */
+#   define ARABIC_DECIMAL_SEPARATOR_UTF8_FIRST_BYTE  0xB8    /* U+066B */
+#   define ARABIC_DECIMAL_SEPARATOR_UTF8_TAIL  "\x62\x52"    /* U+066B */
+#   define ARABIC_DECIMAL_SEPARATOR_UTF8_FIRST_BYTE_s  "\xB8"    /* U+066B */
 
 #   ifdef PERL_IN_TOKE_C
        /* Paired characters for quote-like operators, in UTF-8 */
@@ -212,6 +220,10 @@ bytes.
 #   define LATIN_SMALL_LETTER_Y_WITH_DIAERESIS_NATIVE  0xDF    /* U+00FF */
 #   define MICRO_SIGN_NATIVE  0xA0    /* U+00B5 */
 #   define MICRO_SIGN_UTF8  "\x78\x63"    /* U+00B5 */
+#   define ARABIC_DECIMAL_SEPARATOR_UTF8  "\xB7\x5F\x52"    /* U+066B */
+#   define ARABIC_DECIMAL_SEPARATOR_UTF8_FIRST_BYTE  0xB7    /* U+066B */
+#   define ARABIC_DECIMAL_SEPARATOR_UTF8_TAIL  "\x5F\x52"    /* U+066B */
+#   define ARABIC_DECIMAL_SEPARATOR_UTF8_FIRST_BYTE_s  "\xB7"    /* U+066B */
 
 #   ifdef PERL_IN_TOKE_C
        /* Paired characters for quote-like operators, in UTF-8 */

--- a/unicode_constants.h
+++ b/unicode_constants.h
@@ -16,10 +16,12 @@
  *
  * The macros that have the suffix "_UTF8" may have further suffixes, as
  * follows:
- *  "_FIRST_BYTE" if the value is just the first byte of the UTF-8
- *                representation; the value will be a numeric constant.
- *  "_TAIL"       if instead it represents all but the first byte.  This, and
- *                with no additional suffix are both string constants */
+ *  "_FIRST_BYTE"   if the value is just the first byte of the UTF-8
+ *                  representation; the value will be a numeric constant.
+ *  "_FIRST_BYTEs"  same, but the first byte is represented as a literal
+ *                  string
+ *  "_TAIL"         if instead it represents all but the first byte.  This,
+ *                  and with no additional suffix are both string constants */
 
 /*
 =for apidoc_section $unicode


### PR DESCRIPTION
This enhances this utility script to have the capability of getting the
first byte of a UTF-8 string expressed as a literal (single-byte) string
itself.