### PR TITLE
test.pl: Clarify watchdog() sub comments, best practice is to clear any you set

### DIFF
--- a/t/test.pl
+++ b/t/test.pl
@@ -1773,6 +1773,16 @@ sub warning_like {
 # force it to use an alarm by setting the optional second parameter to
 # 'alarm', or to use a separate process (if available on this platform) by
 # setting that parameter to 'process'.
+
+# It is good practice to CLEAR EVERY WATCHDOG timer.  Otherwise the timer
+# applies to the entire rest of the file.  Even if that works now, new tests
+# tend to get added to the end of the file, and people may not notice that
+# they are being timed.  Those tests may all complete before the timer kills
+# them, but then more new tests get added, even further away from the timer
+# setting code, with less likelihood of noticing that.  Those tests may also
+# generally work, but flap on heavily loaded smokers, leading to debugging
+# effort that wouldn't have had to be expended if the timer had been cancelled
+# in the first place
 #
 # NOTE:  If the test file uses 'threads', then call the watchdog() function
 #        _AFTER_ the 'threads' module is loaded.

--- a/t/test.pl
+++ b/t/test.pl
@@ -1762,10 +1762,17 @@ sub warning_like {
     }
 }
 
-# Set a watchdog to timeout the entire test file.  The input seconds is
-# multiplied by $ENV{PERL_TEST_TIME_OUT_FACTOR} (default 1; minimum 1).
-# Set this in your profile for slow boxes, or use it to override the timeout
-# temporarily for debugging.
+# Set or clear a watchdog timer.  The input seconds is:
+#   zero      to clear;
+#   non-zero  to set
+# and is multiplied by $ENV{PERL_TEST_TIME_OUT_FACTOR} (default 1; minimum 1).
+# Set this variable in your profile for slow boxes, or use it to override the
+# timeout temporarily for debugging.
+#
+# This will figure out a suitable method to implement the timer, but you can
+# force it to use an alarm by setting the optional second parameter to
+# 'alarm', or to use a separate process (if available on this platform) by
+# setting that parameter to 'process'.
 #
 # NOTE:  If the test file uses 'threads', then call the watchdog() function
 #        _AFTER_ the 'threads' module is loaded.
@@ -1965,8 +1972,8 @@ sub watchdog ($;$)
 
         # Don't proceed until the watchdog has set up its signal handler.
         # (Otherwise there is a possibility that we will exit with threads
-        # running.)  The watchdog tells us the handler is set by detaching
-        # itself.  (The 'is_running()' is a fail-safe.)
+        # running.)  The watchdog tells us that the handler is set by
+        # detaching itself.  (The 'is_running()' is a fail-safe.)
         while (     $watchdog_thread->is_running()
                && ! $watchdog_thread->is_detached())
         {


### PR DESCRIPTION
Failure to cancel a timer can lead to failing (or worse: flapping) tests
