### PR TITLE
perl.h: define locale mutex under more cirumstances

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -7056,7 +7056,7 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #define locale_panic_(m)  Perl_locale_panic((m), __FILE__, __LINE__, errno)
 
 /* Locale/thread synchronization macros. */
-#if ! defined(USE_LOCALE) || ! defined(USE_LOCALE_THREADS)
+#if ! defined(USE_LOCALE_THREADS)
 #  define LOCALE_LOCK_(cond)  NOOP
 #  define LOCALE_UNLOCK_      NOOP
 #  define LOCALE_INIT


### PR DESCRIPTION
Prior to this commit, it wasn't defined if we aren't paying attention to locales; but that doesn't mean they don't exist, and the operations that affect them are still callable; so they should have a mutex to prevent one thread from overwriting another's.