### PR TITLE
Configure: Add distribution-friendly make message

### DIFF
--- a/Configure
+++ b/Configure
@@ -2673,6 +2673,10 @@ make)
 	gmake)
 	echo "I can't find make or gmake, and my life depends on it." >&4
 	echo "Go find a public domain implementation or fix your PATH setting!" >&4
+	test -f /etc/debian_version && echo "Run \"apt install build-essential\" to install make and friends" >&4
+	test -f /etc/SUSE-brand     && echo "Run \"zypper install 'pattern:devel_C_C++'\" to install make and friends" >&4
+	test -f /etc/redhat-release && echo "Run \"yum groupinstall 'Development Tools'\" to install make and friends" >&4
+	test -f /etc/fedora-release && echo "Run \"dnf group install 'Development Tools'\" to install make and friends" >&4
 	exit 1
 	;;
 	esac


### PR DESCRIPTION
### Table

| OS | File | Package | Command |
|--------|--------|--------|--------|
| Debian | `/etc/debian_version` | [`build-essential`](https://packages.debian.org/sid/build-essential) | `apt install build-essential` |
| OpenSUSE | `/etc/SUSE-brand` | [`patterns-devel-C-C++`](https://packagehub.suse.com/packages/patterns-devel-C-C++/) | `zypper install 'pattern:devel_C_C++'` |
| Red Hat | `/etc/redhat-release` | `Development Tools` | `yum groupinstall 'Development Tools'`|
| Fedora | `/etc/fedora-release` | `Development Tools` | `dnf group install 'Development Tools'` |

View the raw diff here (esp. if the conversations overshadow the code in the `Files changed` tab):

- https://patch-diff.githubusercontent.com/raw/Perl/perl5/pull/21125.diff

*Couldn't find a link for `Development Tools` Yum package group searching* 😢 

-----

Straight to the point as
"Public domain implementation" wasn't very helpful.

Came across this message building Perl on a freshly
installed Ubuntu Linux doing:

```
git clone https://github.com/Perl/perl5
sh Configure -des -Dusedevel
```

### See

- https://github.com/Perl/perl5/pull/21125
