### PR TITLE
loc_tools.pl: Cache results; and add a couple more locale possibilities

### DIFF
--- a/t/loc_tools.pl
+++ b/t/loc_tools.pl
@@ -429,6 +429,8 @@ sub find_locales ($;$) {
     my $input_categories = shift;
     my $allow_incompatible = shift // 0;
 
+    die ("Usage: find_locales( category | [ categories ] )")
+                                                unless defined $input_categories;
     my @categories = (ref $input_categories)
                       ? $input_categories->@*
                       : $input_categories;

--- a/t/loc_tools.pl
+++ b/t/loc_tools.pl
@@ -249,6 +249,7 @@ sub _decode_encodings { # For use only by other functions in this file!
     foreach (split(/ /, shift)) {
 	if (/^(\d+)$/) {
 	    push @enc, "ISO8859-$1";
+	    push @enc, "ISO-8859-$1";
 	    push @enc, "iso8859$1";	# HP
 	    if ($1 eq '1') {
 		 push @enc, "roman8";	# HP

--- a/t/loc_tools.pl
+++ b/t/loc_tools.pl
@@ -462,6 +462,10 @@ sub find_locales ($;$) {
         _trylocale("C", \@categories, \@Locale, $allow_incompatible);
         _trylocale("POSIX", \@categories, \@Locale, $allow_incompatible);
 
+        if ($Config{d_has_C_UTF8} && $Config{d_has_C_UTF8} eq 'true') {
+            _trylocale("C.UTF-8", \@categories, \@Locale, $allow_incompatible);
+        }
+
         # There's no point in looking at anything more if we know that
         # setlocale will return success on any garbage or non-garbage name.
         return sort @Locale


### PR DESCRIPTION
Some of the functions in this file are slow, because it speculatively
tries various potential somewhat commonly-encountered locales to see
which ones actually work on this platform.

On many boxes, much of the potential list can be quickly gathered from a
call to a system command, but on other platforms, including Windows, the
list comes from trying all the possibilities in the <DATA> section of
the file, including permutations.

And the determination that each locale actually works takes time.

So this commit caches the list of available locales it finds, avoiding
doing all this work again if the calling test program calls it again.