### PR TITLE
Perl__byte_dump_string(): Properly handle NULL input

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -726,8 +726,8 @@ p	|OP *	|build_infix_plugin					\
 				|NN OP *lhs				\
 				|NN OP *rhs				\
 				|NN void *tokendata
-EXp	|char * |_byte_dump_string					\
-				|NN const U8 * const start		\
+EXp	|const char *|_byte_dump_string 				\
+				|NULLOK const U8 * const start		\
 				|const STRLEN len			\
 				|const bool format
 Adp	|int	|bytes_cmp_utf8 |NN const U8 *b 			\

--- a/proto.h
+++ b/proto.h
@@ -78,10 +78,9 @@ Perl_Slab_Free(pTHX_ void *op);
 /* PERL_CALLCONV void
 SvREFCNT_dec_set_NULL(pTHX_ SV *sv); */
 
-PERL_CALLCONV char *
+PERL_CALLCONV const char *
 Perl__byte_dump_string(pTHX_ const U8 * const start, const STRLEN len, const bool format);
-#define PERL_ARGS_ASSERT__BYTE_DUMP_STRING      \
-        assert(start)
+#define PERL_ARGS_ASSERT__BYTE_DUMP_STRING
 
 PERL_CALLCONV void
 Perl__force_out_malformed_utf8_message(pTHX_ const U8 * const p, const U8 * const e, const U32 flags, const bool die_here);

--- a/utf8.c
+++ b/utf8.c
@@ -935,7 +935,7 @@ Perl_is_utf8_FF_helper_(const U8 * const s0, const U8 * const e,
     return (require_partial) ? 0 : UTF8_MAXBYTES;
 }
 
-char *
+const char *
 Perl__byte_dump_string(pTHX_ const U8 * const start, const STRLEN len, const bool format)
 {
     /* Returns a mortalized C string that is a displayable copy of the 'len'
@@ -944,6 +944,10 @@ Perl__byte_dump_string(pTHX_ const U8 * const start, const STRLEN len, const boo
      *      0   \xab
      *      1    ab         (that is a space between two hex digit bytes)
      */
+
+    if (start == NULL) {
+        return "(nil)";
+    }
 
     const STRLEN output_len = 4 * len + 1;  /* 4 bytes per each input, plus a
                                                trailing NUL */


### PR DESCRIPTION
Instead of an assert, this returns (nil) and things can proceed.