### PR TITLE
perlhacktips: copy editing

### DIFF
--- a/pod/perlhacktips.pod
+++ b/pod/perlhacktips.pod
@@ -258,7 +258,7 @@ C<snprintf> in the VMS libc only added support for C<PRIdN> etc very recently,
 meaning that there are live supported installations without this, or formats
 such as C<%zu>.
 
-(perl's C<sv_catpvf> etc use parser code code in C<sv.c>, which supports the
+(perl's C<sv_catpvf> etc use parser code code in F<sv.c>, which supports the
 C<z> modifier, along with perl-specific formats such as C<SVf>.)
 
 =back
@@ -278,7 +278,7 @@ Write test code and verify that it works on platforms we need to support, before
 =back
 
 Likely you want to repeat the same plan as we used to get the current C99
-feature set. See the message at https://markmail.org/thread/odr4fjrn72u2fkpz
+feature set. See the message at L<https://markmail.org/thread/odr4fjrn72u2fkpz>
 for the C99 probes we used before. Note that the two most "fussy" compilers
 appear to be MSVC and the vendor compiler on VMS. To date all the *nix
 compilers have been far more flexible in what they support.
@@ -333,10 +333,11 @@ C<-xc99>
 C reserves for its implementation any symbol whose name begins with an
 underscore followed immediately by either an uppercase letter C<[A-Z]>
 or another underscore.  C++ further reserves any symbol containing two
-consecutive underscores, and further reserves in the global name space any
-symbol beginning with an underscore, not just ones followed by a
-capital.  We care about C++ because C<hdr> files need to be compilable by
-it, and some people do all their development using a C++ compiler.
+consecutive underscores, and further reserves in the global name space
+any symbol beginning with an underscore, not just ones followed by a
+capital.  We care about C++ because header files (F<*.h>) need to be
+compilable by it, and some people do all their development using a C++
+compiler.
 
 The consequences of failing to do this are probably none.  Unless you
 stumble on a name that the implementation uses, things will work.
@@ -359,11 +360,11 @@ use: C<_FOOBAR>)
 =back
 
 POSIX also reserves many symbols.  See Section 2.2.2 in
-L<http://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html>.
+L<https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html>.
 Perl also has conflicts with that.
 
 Perl reserves for its use any symbol beginning with C<Perl>, C<perl>, or
-C<PL_>.  Any time you introduce a macro into a C<hdr> file that doesn't
+C<PL_>.  Any time you introduce a macro into a header file that doesn't
 follow that convention, you are creating the possiblity of a namespace
 clash with an existing XS module, unless you restrict it by, say,
 
@@ -371,7 +372,7 @@ clash with an existing XS module, unless you restrict it by, say,
  #  define my_symbol
  #endif
 
-There are many symbols in C<hdr> files that aren't of this form, and
+There are many symbols in header files that aren't of this form, and
 which are accessible from XS namespace, intentionally or not, just about
 anything in F<config.h>, for example.
 
@@ -529,7 +530,7 @@ a call chain involving multiple macros using them will zap the other's
 use.  These have been very difficult to debug.
 
 For a concrete example of these pitfalls in action, see
-L<https://perlmonks.org/?node_id=11144355>
+L<https://perlmonks.org/?node_id=11144355>.
 
 =head2 Portability problems
 
@@ -575,19 +576,19 @@ Sometimes you can also play games with unions.
 
 =item *
 
-Assuming sizeof(int) == sizeof(long)
+Assuming C<sizeof(int) == sizeof(long)>
 
 There are platforms where longs are 64 bits, and platforms where ints
 are 64 bits, and while we are out to shock you, even platforms where
 shorts are 64 bits.  This is all legal according to the C standard.  (In
-other words, "long long" is not a portable way to specify 64 bits, and
-"long long" is not even guaranteed to be any wider than "long".)
+other words, C<long long> is not a portable way to specify 64 bits, and
+C<long long> is not even guaranteed to be any wider than C<long>.)
 
-Instead, use the definitions IV, UV, IVSIZE, I32SIZE, and so forth.
-Avoid things like I32 because they are B<not> guaranteed to be
+Instead, use the definitions C<IV>, C<UV>, C<IVSIZE>, C<I32SIZE>, and so forth.
+Avoid things like C<I32> because they are B<not> guaranteed to be
 I<exactly> 32 bits, they are I<at least> 32 bits, nor are they
-guaranteed to be B<int> or B<long>.  If you explicitly need
-64-bit variables, use I64 and U64.
+guaranteed to be C<int> or C<long>.  If you explicitly need 64-bit
+variables, use C<I64> and C<U64>.
 
 =item *
 
@@ -642,7 +643,7 @@ between different platforms the definitions might differ
 
 =item *
 
-That the sizeof(struct) or the alignments are the same everywhere
+That the C<sizeof(struct)> or the alignments are the same everywhere
 
 =over 8
 
@@ -654,8 +655,8 @@ the bytes can be anything
 =item *
 
 Structs are required to be aligned to the maximum alignment required by
-the fields - which for native types is for usually equivalent to
-sizeof() of the field
+the fields - which for native types is usually equivalent to
+C<sizeof(the_field)>.
 
 =back
 
@@ -1346,7 +1347,7 @@ subroutine:
 
 We can also dump out this op: the current op is always stored in
 C<PL_op>, and we can dump it with C<Perl_op_dump>.  This'll give us
-similar output to CPAN module B::Debug.
+similar output to CPAN module L<B::Debug>.
 
 =for apidoc_section $debugging
 =for apidoc Amnh||PL_op
@@ -1456,7 +1457,7 @@ cut-and-pasted code changes, all the other spots should probably be
 changed, too.  Therefore such code should probably be turned into a
 subroutine or a macro.
 
-cpd (L<https://pmd.github.io/latest/pmd_userdocs_cpd.html>) is part of the pmd project
+cpd (L<https://docs.pmd-code.org/latest/pmd_userdocs_cpd.html>) is part of the pmd project
 (L<https://pmd.github.io/>).  pmd was originally written for static
 analysis of Java code, but later the cpd part of it was extended to
 parse also C and C++.
@@ -1566,12 +1567,12 @@ factor 2.
 
 B<NOTE 2>: To minimize the number of memory leak false alarms (see
 L</PERL_DESTRUCT_LEVEL> for more information), you have to set the
-environment variable PERL_DESTRUCT_LEVEL to 2.  For example, like this:
+environment variable C<PERL_DESTRUCT_LEVEL> to 2.  For example, like this:
 
     env PERL_DESTRUCT_LEVEL=2 valgrind ./perl -Ilib ...
 
 B<NOTE 3>: There are known memory leaks when there are compile-time
-errors within eval or require, seeing C<S_doeval> in the call stack is
+errors within C<eval> or C<require>; seeing C<S_doeval> in the call stack is
 a good sign of these.  Fixing these leaks is non-trivial, unfortunately,
 but they must be fixed eventually.
 
@@ -1613,9 +1614,7 @@ valgrind allows to suppress such errors using suppression files.  The
 default suppression file that comes with valgrind already catches a lot
 of them.  Some additional suppressions are defined in F<t/perl.supp>.
 
-To get valgrind and for more information see
-
-    http://valgrind.org/
+To get valgrind and for more information see L<https://valgrind.org/>.
 
 =head2 AddressSanitizer
 
@@ -1805,7 +1804,7 @@ block, branch, and function call coverage, and C<-c> which instead of
 relative frequencies will use the actual counts.  For more information
 on the use of F<gcov> and basic block profiling with gcc, see the
 latest GNU CC manual.  As of gcc 4.8, this is at
-L<http://gcc.gnu.org/onlinedocs/gcc/Gcov-Intro.html#Gcov-Intro>
+L<https://gcc.gnu.org/onlinedocs/gcc/Gcov-Intro.html#Gcov-Intro>.
 
 =head2 callgrind profiling
 
@@ -1817,7 +1816,7 @@ is you can use it on perl and XS modules that have not been
 compiled with debugging symbols.
 
 If perl is compiled with debugging symbols (C<-g>), you can view
-the annotated source and click around, much like Devel::NYTProf's
+the annotated source and click around, much like L<Devel::NYTProf>'s
 HTML output.
 
 For basic usage:
@@ -1832,7 +1831,7 @@ To view the data, do:
     kcachegrind callgrind.out.PID
 
 If you'd prefer to view the data in a terminal, you can use
-F<callgrind_annotate>. In it's basic form:
+F<callgrind_annotate>.  In its basic form:
 
     callgrind_annotate callgrind.out.PID | less
 
@@ -1858,29 +1857,29 @@ the event count threshold.
 
 If you want to run any of the tests yourself manually using e.g.
 valgrind, please note that by default perl B<does not> explicitly
-cleanup all the memory it has allocated (such as global memory arenas)
-but instead lets the exit() of the whole program "take care" of such
+clean up all the memory it has allocated (such as global memory arenas)
+but instead lets the C<exit()> of the whole program "take care" of such
 allocations, also known as "global destruction of objects".
 
 There is a way to tell perl to do complete cleanup: set the environment
-variable PERL_DESTRUCT_LEVEL to a non-zero value.  The t/TEST wrapper
+variable C<PERL_DESTRUCT_LEVEL> to a non-zero value.  The F<t/TEST> wrapper
 does set this to 2, and this is what you need to do too, if you don't
 want to see the "global leaks": For example, for running under valgrind
 
     env PERL_DESTRUCT_LEVEL=2 valgrind ./perl -Ilib t/foo/bar.t
 
-(Note: the mod_perl apache module uses also this environment variable
-for its own purposes and extended its semantics.  Refer to the mod_perl
-documentation for more information.  Also, spawned threads do the
+(Note: the mod_perl Apache module uses this environment variable
+for its own purposes and extends its semantics.  Refer to L<the mod_perl
+documentation|https://perl.apache.org/docs/> for more information.  Also, spawned threads do the
 equivalent of setting this variable to the value 1.)
 
 If, at the end of a run you get the message I<N scalars leaked>, you
-can recompile with C<-DDEBUG_LEAKING_SCALARS>,
+can recompile with C<-DDEBUG_LEAKING_SCALARS>
 (C<Configure -Accflags=-DDEBUG_LEAKING_SCALARS>), which will cause the
 addresses of all those leaked SVs to be dumped along with details as to
 where each SV was originally allocated.  This information is also
-displayed by Devel::Peek.  Note that the extra details recorded with
-each SV increases memory usage, so it shouldn't be used in production
+displayed by L<Devel::Peek>.  Note that the extra details recorded with
+each SV increase memory usage, so it shouldn't be used in production
 environments.  It also converts C<new_SV()> from a macro into a real
 function, so you can use your favourite debugger to discover where
 those pesky SVs were allocated.

--- a/pod/perlhacktips.pod
+++ b/pod/perlhacktips.pod
@@ -21,9 +21,9 @@ to do that first.
 =head1 COMMON PROBLEMS
 
 Perl source now permits some specific C99 features which we know are
-supported by all platforms, but mostly plays by ANSI C89 rules.
-You don't care about some particular platform having broken Perl? I
-hear there is still a strong demand for J2EE programmers.
+supported by all platforms, but mostly plays by ANSI C89 rules.  You
+don't care about some particular platform having broken Perl?  I hear
+there is still a strong demand for J2EE programmers.
 
 =head2 Perl environment problems
 
@@ -114,20 +114,21 @@ L<perlguts>.
 
 =head2 C99
 
-Starting from 5.35.5 we now permit some C99 features in the core C source.
-However, code in dual life extensions still needs to be C89 only, because it
-needs to compile against earlier version of Perl running on older platforms.
-Also note that our headers need to also be valid as C++, because XS extensions
-written in C++ need to include them, hence I<member structure initialisers>
-can't be used in headers.
+Starting from 5.35.5 we now permit some C99 features in the core C
+source. However, code in dual life extensions still needs to be C89
+only, because it needs to compile against earlier version of Perl
+running on older platforms.  Also note that our headers need to also be
+valid as C++, because XS extensions written in C++ need to include
+them, hence I<member structure initialisers> can't be used in headers.
 
-C99 support is still far from complete on all platforms we currently support.
-As a baseline we can only assume C89 semantics with the specific C99 features
-described below, which we've verified work everywhere.  It's fine to probe for
-additional C99 features and use them where available, providing there is also a
-fallback for compilers that don't support the feature.  For example, we use C11
-thread local storage when available, but fall back to POSIX thread specific
-APIs otherwise, and we use C<char> for booleans if C<< <stdbool.h> >> isn't
+C99 support is still far from complete on all platforms we currently
+support. As a baseline we can only assume C89 semantics with the
+specific C99 features described below, which we've verified work
+everywhere.  It's fine to probe for additional C99 features and use
+them where available, providing there is also a fallback for compilers
+that don't support the feature.  For example, we use C11 thread local
+storage when available, but fall back to POSIX thread specific APIs
+otherwise, and we use C<char> for booleans if C<< <stdbool.h> >> isn't
 available.
 
 Code can use (and rely on) the following C99 features being present
@@ -142,8 +143,9 @@ mixed declarations and code
 
 64 bit integer types
 
-For consistency with the existing source code, use the typedefs C<I64> and
-C<U64>, instead of using C<long long> and C<unsigned long long> directly.
+For consistency with the existing source code, use the typedefs C<I64>
+and C<U64>, instead of using C<long long> and C<unsigned long long>
+directly.
 
 =item *
 
@@ -152,7 +154,8 @@ variadic macros
     void greet(char *file, unsigned int line, char *format, ...);
     #define logged_greet(...) greet(__FILE__, __LINE__, __VA_ARGS__);
 
-Note that C<__VA_OPT__> is a gcc extension not yet in any published standard.
+Note that C<__VA_OPT__> is a gcc extension not yet in any published
+standard.
 
 =item *
 
@@ -166,7 +169,8 @@ declarations in for loops
 
 member structure initialisers
 
-But not in headers, as support was only added to C++ relatively recently.
+But not in headers, as support was only added to C++ relatively
+recently.
 
 Hence this is fine in C and XS code, but not headers:
 
@@ -208,26 +212,26 @@ This is standards conformant:
         char message[];
     };
 
-However, the source code already uses the "unwarranted chumminess with the
-compiler" hack in many places:
+However, the source code already uses the "unwarranted chumminess with
+the compiler" hack in many places:
 
     struct greeting {
         unsigned int len;
         char message[1];
     };
 
-Strictly it B<is> undefined behaviour accessing beyond C<message[0]>, but this
-has been a commonly used hack since K&R times, and using it hasn't been a
-practical issue anywhere (in the perl source or any other common C code).
-Hence it's unclear what we would gain from actively changing to the C99
-approach.
+Strictly it B<is> undefined behaviour accessing beyond C<message[0]>,
+but this has been a commonly used hack since K&R times, and using it
+hasn't been a practical issue anywhere (in the perl source or any other
+common C code). Hence it's unclear what we would gain from actively
+changing to the C99 approach.
 
 =item *
 
 C<//> comments
 
-All compilers we tested support their use. Not all humans we tested support
-their use.
+All compilers we tested support their use. Not all humans we tested
+support their use.
 
 =back
 
@@ -241,8 +245,8 @@ variable length arrays
 
 Not supported by B<any> MSVC, and this is not going to change.
 
-Even "variable" length arrays where the variable is a constant expression
-are syntax errors under MSVC.
+Even "variable" length arrays where the variable is a constant
+expression are syntax errors under MSVC.
 
 =item *
 
@@ -254,61 +258,68 @@ Use C<PERL_INT_FAST8_T> etc as defined in F<handy.h>
 
 C99 format strings in C<< <inttypes.h> >>
 
-C<snprintf> in the VMS libc only added support for C<PRIdN> etc very recently,
-meaning that there are live supported installations without this, or formats
-such as C<%zu>.
+C<snprintf> in the VMS libc only added support for C<PRIdN> etc very
+recently, meaning that there are live supported installations without
+this, or formats such as C<%zu>.
 
-(perl's C<sv_catpvf> etc use parser code code in F<sv.c>, which supports the
-C<z> modifier, along with perl-specific formats such as C<SVf>.)
+(perl's C<sv_catpvf> etc use parser code code in F<sv.c>, which
+supports the C<z> modifier, along with perl-specific formats such as
+C<SVf>.)
 
 =back
 
-If you want to use a C99 feature not listed above then you need to do one of
+If you want to use a C99 feature not listed above then you need to do
+one of
 
 =over 4
 
 =item *
 
-Probe for it in F<Configure>, set a variable in F<config.sh>, and add fallback logic in the headers for platforms which don't have it.
+Probe for it in F<Configure>, set a variable in F<config.sh>, and add
+fallback logic in the headers for platforms which don't have it.
 
 =item *
 
-Write test code and verify that it works on platforms we need to support, before relying on it unconditionally.
+Write test code and verify that it works on platforms we need to
+support, before relying on it unconditionally.
 
 =back
 
-Likely you want to repeat the same plan as we used to get the current C99
-feature set. See the message at L<https://markmail.org/thread/odr4fjrn72u2fkpz>
-for the C99 probes we used before. Note that the two most "fussy" compilers
-appear to be MSVC and the vendor compiler on VMS. To date all the *nix
-compilers have been far more flexible in what they support.
+Likely you want to repeat the same plan as we used to get the current
+C99 feature set. See the message at
+L<https://markmail.org/thread/odr4fjrn72u2fkpz> for the C99 probes we
+used before. Note that the two most "fussy" compilers appear to be MSVC
+and the vendor compiler on VMS. To date all the *nix compilers have
+been far more flexible in what they support.
 
-On *nix platforms, F<Configure> attempts to set compiler flags appropriately.
-All vendor compilers that we tested defaulted to C99 (or C11) support.
-However, older versions of gcc default to C89, or permit I<most> C99 (with
-warnings), but forbid I<declarations in for loops> unless C<-std=gnu99> is
-added. The alternative C<-std=c99> B<might> seem better, but using it on some
-platforms can prevent C<< <unistd.h> >> declaring some prototypes being
-declared, which breaks the build. gcc's C<-ansi> flag implies C<-std=c89> so we
-can no longer set that, hence the Configure option C<-gccansipedantic> now only
-adds C<-pedantic>.
+On *nix platforms, F<Configure> attempts to set compiler flags
+appropriately. All vendor compilers that we tested defaulted to C99 (or
+C11) support. However, older versions of gcc default to C89, or permit
+I<most> C99 (with warnings), but forbid I<declarations in for loops>
+unless C<-std=gnu99> is added. The alternative C<-std=c99> B<might>
+seem better, but using it on some platforms can prevent C<< <unistd.h>
+>> declaring some prototypes being declared, which breaks the build.
+gcc's C<-ansi> flag implies C<-std=c89> so we can no longer set that,
+hence the Configure option C<-gccansipedantic> now only adds
+C<-pedantic>.
 
-The Perl core source code files (the ones at the top level of the source code
-distribution) are automatically compiled with as many as possible of the
-C<-std=gnu99>, C<-pedantic>, and a selection of C<-W> flags (see
-cflags.SH). Files in F<ext/> F<dist/> F<cpan/> etc are compiled with the same
-flags as the installed perl would use to compile XS extensions.
+The Perl core source code files (the ones at the top level of the
+source code distribution) are automatically compiled with as many as
+possible of the C<-std=gnu99>, C<-pedantic>, and a selection of C<-W>
+flags (see cflags.SH). Files in F<ext/> F<dist/> F<cpan/> etc are
+compiled with the same flags as the installed perl would use to compile
+XS extensions.
 
 Basically, it's safe to assume that F<Configure> and F<cflags.SH> have
-picked the best combination of flags for the version of gcc on the platform,
-and attempting to add more flags related to enforcing a C dialect will
-cause problems either locally, or on other systems that the code is shipped
-to.
+picked the best combination of flags for the version of gcc on the
+platform, and attempting to add more flags related to enforcing a C
+dialect will cause problems either locally, or on other systems that
+the code is shipped to.
 
-We believe that the C99 support in gcc 3.1 is good enough for us, but we don't
-have a 19 year old gcc handy to check this :-)
-If you have ancient vendor compilers that don't default to C99, the flags
-you might want to try are
+We believe that the C99 support in gcc 3.1 is good enough for us, but
+we don't have a 19 year old gcc handy to check this :-) If you have
+ancient vendor compilers that don't default to C99, the flags you might
+want to try are
 
 =over 4
 
@@ -363,21 +374,22 @@ POSIX also reserves many symbols.  See Section 2.2.2 in
 L<https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html>.
 Perl also has conflicts with that.
 
-Perl reserves for its use any symbol beginning with C<Perl>, C<perl>, or
-C<PL_>.  Any time you introduce a macro into a header file that doesn't
-follow that convention, you are creating the possiblity of a namespace
-clash with an existing XS module, unless you restrict it by, say,
+Perl reserves for its use any symbol beginning with C<Perl>, C<perl>,
+or C<PL_>.  Any time you introduce a macro into a header file that
+doesn't follow that convention, you are creating the possiblity of a
+namespace clash with an existing XS module, unless you restrict it by,
+say,
 
  #ifdef PERL_CORE
  #  define my_symbol
  #endif
 
 There are many symbols in header files that aren't of this form, and
-which are accessible from XS namespace, intentionally or not, just about
-anything in F<config.h>, for example.
+which are accessible from XS namespace, intentionally or not, just
+about anything in F<config.h>, for example.
 
-Having to use one of these prefixes detracts from the readability of the
-code, and hasn't been an actual issue for non-trivial names.  Things
+Having to use one of these prefixes detracts from the readability of
+the code, and hasn't been an actual issue for non-trivial names. Things
 like perl defining its own C<MAX> macro have been problematic, but they
 were quickly discovered, and a S<C<#ifdef PERL_CORE>> guard added.
 
@@ -387,45 +399,46 @@ the issues.
 =head3 Choosing good symbol names
 
 Ideally, a symbol name name should correctly and precisely describe its
-intended purpose.  But there is a tension between that and getting names
-that are overly long and hence awkward to type and read.  Metaphors
-could be helpful (a poetic name), but those tend to be culturally
-specific, and may not translate for someone whose native language isn't
-English, or even comes from a different cultural background.  Besides,
-the talent of writing poetry seems to be rare in programmers.
+intended purpose.  But there is a tension between that and getting
+names that are overly long and hence awkward to type and read.
+Metaphors could be helpful (a poetic name), but those tend to be
+culturally specific, and may not translate for someone whose native
+language isn't English, or even comes from a different cultural
+background.  Besides, the talent of writing poetry seems to be rare in
+programmers.
 
 Certain symbol names don't reflect their purpose, but are nonetheless
 fine to use because of long-standing conventions.  These often
 originated in the field of Mathematics, where C<i> and C<j> are
-frequently used as subscripts, and C<n> as a population count.  Since at
-least the 1950's, computer programs have used C<i>, I<etc.> as loop
+frequently used as subscripts, and C<n> as a population count.  Since
+at least the 1950's, computer programs have used C<i>, I<etc.> as loop
 variables.
 
 Our guidance is to choose a name that reasonably describes the purpose,
 and to comment its declaration more precisely.
 
-One certainly shouldn't use misleading nor ambiguous names.  C<last_foo>
+One certainly shouldn't use misleading nor ambiguous names. C<last_foo>
 could mean either the final C<foo> or the previous C<foo>, and so could
 be confusing to the reader, or even to the writer coming back to the
-code after a few months of working on something else.  Sometimes the
+code after a few months of working on something else. Sometimes the
 programmer has a particular line of thought in mind, and it doesn't
 occur to them that ambiguity is present.
 
 There are probably still many off-by-1 bugs around because the name
-L<perlapi/C<av_len>> doesn't correspond to what other I<-len> constructs
-mean, such as L<perlapi/C<sv_len>>.  Awkward (and controversial)
-synonyms were created to use instead that conveyed its true meaning
-(L<perlapi/C<av_top_index>>).  Eventually, though someone had the better
-idea to create a new name to signify what most people think C<-len>
-signifies.  So L<perlapi/C<av_count>> was born.  And we wish it had been
-thought up much earlier.
+L<perlapi/C<av_len>> doesn't correspond to what other I<-len>
+constructs mean, such as L<perlapi/C<sv_len>>.  Awkward (and
+controversial) synonyms were created to use instead that conveyed its
+true meaning (L<perlapi/C<av_top_index>>).  Eventually, though, someone
+had the better idea to create a new name to signify what most people
+think C<-len> signifies.  So L<perlapi/C<av_count>> was born.  And we
+wish it had been thought up much earlier.
 
 =head2 Writing safer macros
 
 Macros are used extensively in the Perl core for such things as hiding
 internal details from the caller, so that it doesn't have to be
-concerned about them.  For example, most lines of code don't need
-to know if they are running on a threaded versus unthreaded perl.  That
+concerned about them.  For example, most lines of code don't need to
+know if they are running on a threaded versus unthreaded perl.  That
 detail is automatically mostly hidden.
 
 It is often better to use an inline function instead of a macro.  They
@@ -446,16 +459,17 @@ complicating overkill, such as when the macro simply creates a mnemonic
 name for some constant value.
 
 If you do choose to use a non-trivial macro, be aware that there are
-several avoidable pitfalls that can occur.  Keep in mind that a macro is
-expanded within the lexical context of each place in the source it is
-called.  If you have a token C<foo> in the macro and the source happens
-also to have C<foo>, the meaning of the macro's C<foo> will become that
-of the caller's.  Sometimes that is exactly the behavior you want, but
-be aware that this tends to be confusing later on.  It effectively turns
-C<foo> into a reserved word for any code that calls the macro, and this
-fact is usually not documented nor considered.  It is safer to pass
-C<foo> as a parameter, so that C<foo> remains freely available to the
-caller and the macro interface is explicitly specified.
+several avoidable pitfalls that can occur.  Keep in mind that a macro
+is expanded within the lexical context of each place in the source it
+is called.  If you have a token C<foo> in the macro and the source
+happens also to have C<foo>, the meaning of the macro's C<foo> will
+become that of the caller's.  Sometimes that is exactly the behavior
+you want, but be aware that this tends to be confusing later on.  It
+effectively turns C<foo> into a reserved word for any code that calls
+the macro, and this fact is usually not documented nor considered.  It
+is safer to pass C<foo> as a parameter, so that C<foo> remains freely
+available to the caller and the macro interface is explicitly
+specified.
 
 Worse is when the equivalence between the two C<foo>'s is coincidental.
 Suppose for example, that the macro declares a variable
@@ -475,13 +489,13 @@ Then that declaration of C<foo> in the macro suddenly becomes
 
 That could mean that something completely different happens than
 intended.  It is hard to debug; the macro and call may not even be in
-the same file, so it would require some digging and gnashing of teeth to
-figure out.
+the same file, so it would require some digging and gnashing of teeth
+to figure out.
 
 Therefore, if a macro does use variables, their names should be such
-that it is very unlikely that they would collide with any caller, now or
-forever.  One way to do that, now being used in the perl source, is to
-include the name of the macro itself as part of the name of each
+that it is very unlikely that they would collide with any caller, now
+or forever.  One way to do that, now being used in the perl source, is
+to include the name of the macro itself as part of the name of each
 variable in the macro.  Suppose the macro is named C<SvPV>  Then we
 could have
 
@@ -492,42 +506,43 @@ guaranteed that a caller will never naively use C<foo_svpv_> (and run
 into problems).  (The lowercasing makes it clearer that this is a
 variable, but assumes that there won't be two elements whose names
 differ only in the case of their letters.)  The trailing underscore
-makes it even more unlikely to clash, as those, by convention, signify a
-private variable name.  (See L</Choosing legal symbol names> for
+makes it even more unlikely to clash, as those, by convention, signify
+a private variable name.  (See L</Choosing legal symbol names> for
 restrictions on what names you can use.)
 
 This kind of name collision doesn't happen with the macro's formal
-parameters, so they don't need to have complicated names.  But there are
-pitfalls when a a parameter is an expression, or has some Perl magic
-attached.  When calling a function, C will evaluate the parameter once,
-and pass the result to the function.  But when calling a macro, the
-parameter is copied as-is by the C preprocessor to each instance inside
-the macro.  This means that when evaluating a parameter having side
-effects, the function and macro results differ.  This is particularly
-fraught when a parameter has overload magic, say it is a tied variable
-that reads the next line in a file upon each evaluation.  Having it read
-multiple lines per call is probably not what the caller intended.  If a
-macro refers to a potentially overloadable parameter more than once, it
-should first make a copy and then use that copy the rest of the time.
-There are macros in the perl core that violate this, but are gradually
-being converted, usually by changing to use inline functions instead.
+parameters, so they don't need to have complicated names.  But there
+are pitfalls when a a parameter is an expression, or has some Perl
+magic attached.  When calling a function, C will evaluate the parameter
+once, and pass the result to the function.  But when calling a macro,
+the parameter is copied as-is by the C preprocessor to each instance
+inside the macro.  This means that when evaluating a parameter having
+side effects, the function and macro results differ.  This is
+particularly fraught when a parameter has overload magic, say it is a
+tied variable that reads the next line in a file upon each evaluation.
+Having it read multiple lines per call is probably not what the caller
+intended.  If a macro refers to a potentially overloadable parameter
+more than once, it should first make a copy and then use that copy the
+rest of the time. There are macros in the perl core that violate this,
+but are gradually being converted, usually by changing to use inline
+functions instead.
 
-Above we said "first make a copy".  In a macro, that is easier said than
-done, because macros are normally expressions, and declarations aren't
-allowed in expressions.  But the S<C<STMT_START> .. C<STMT_END>>
+Above we said "first make a copy".  In a macro, that is easier said
+than done, because macros are normally expressions, and declarations
+aren't allowed in expressions.  But the S<C<STMT_START> .. C<STMT_END>>
 construct, described in L<perlapi|perlapi/STMT_START>, allows you to
 have declarations in most contexts, as long as you don't need a return
-value.  If you do need a value returned, you can make the interface such
-that a pointer is passed to the construct, which then stores its result
-there.  (Or you can use GCC brace groups.  But these require a fallback
-if the code will ever get executed on a platform that lacks this
-non-standard extension to C.  And that fallback would be another code
-path, which can get out-of-sync with the brace group one, so doing this
-isn't advisable.)  In situations where there's no other way, Perl does
-furnish L<perlintern/C<PL_Sv>> and L<perlapi/C<PL_na>> to use (with a
-slight performance penalty) for some such common cases.  But beware that
-a call chain involving multiple macros using them will zap the other's
-use.  These have been very difficult to debug.
+value.  If you do need a value returned, you can make the interface
+such that a pointer is passed to the construct, which then stores its
+result there.  (Or you can use GCC brace groups.  But these require a
+fallback if the code will ever get executed on a platform that lacks
+this non-standard extension to C.  And that fallback would be another
+code path, which can get out-of-sync with the brace group one, so doing
+this isn't advisable.)  In situations where there's no other way, Perl
+does furnish L<perlintern/C<PL_Sv>> and L<perlapi/C<PL_na>> to use
+(with a slight performance penalty) for some such common cases.  But
+beware that a call chain involving multiple macros using them will zap
+the other's use.  These have been very difficult to debug.
 
 For a concrete example of these pitfalls in action, see
 L<https://perlmonks.org/?node_id=11144355>.
@@ -580,13 +595,13 @@ Assuming C<sizeof(int) == sizeof(long)>
 
 There are platforms where longs are 64 bits, and platforms where ints
 are 64 bits, and while we are out to shock you, even platforms where
-shorts are 64 bits.  This is all legal according to the C standard.  (In
+shorts are 64 bits.  This is all legal according to the C standard. (In
 other words, C<long long> is not a portable way to specify 64 bits, and
 C<long long> is not even guaranteed to be any wider than C<long>.)
 
-Instead, use the definitions C<IV>, C<UV>, C<IVSIZE>, C<I32SIZE>, and so forth.
-Avoid things like C<I32> because they are B<not> guaranteed to be
-I<exactly> 32 bits, they are I<at least> 32 bits, nor are they
+Instead, use the definitions C<IV>, C<UV>, C<IVSIZE>, C<I32SIZE>, and
+so forth. Avoid things like C<I32> because they are B<not> guaranteed
+to be I<exactly> 32 bits, they are I<at least> 32 bits, nor are they
 guaranteed to be C<int> or C<long>.  If you explicitly need 64-bit
 variables, use C<I64> and C<U64>.
 
@@ -681,20 +696,20 @@ isn't guaranteed to be in that range, use C<UNICODE_TO_NATIVE> instead.
 C<NATIVE_TO_LATIN1> and C<NATIVE_TO_UNICODE> translate the opposite
 direction.
 
-If you need the string representation of a character that doesn't have a
-mnemonic name in C, you should add it to the list in
-F<regen/unicode_constants.pl>, and have Perl create C<#define>'s for you,
-based on the current platform.
+If you need the string representation of a character that doesn't have
+a mnemonic name in C, you should add it to the list in
+F<regen/unicode_constants.pl>, and have Perl create C<#define>'s for
+you, based on the current platform.
 
 Note that the C<isI<FOO>> and C<toI<FOO>> macros in F<handy.h> work
 properly on native code points and strings.
 
 Also, the range 'A' - 'Z' in ASCII is an unbroken sequence of 26 upper
-case alphabetic characters.  That is not true in EBCDIC.  Nor for 'a' to
-'z'.  But '0' - '9' is an unbroken range in both systems.  Don't assume
-anything about other ranges.  (Note that special handling of ranges in
-regular expression patterns and transliterations makes it appear to Perl
-code that the aforementioned ranges are all unbroken.)
+case alphabetic characters.  That is not true in EBCDIC.  Nor for 'a'
+to 'z'.  But '0' - '9' is an unbroken range in both systems.  Don't
+assume anything about other ranges.  (Note that special handling of
+ranges in regular expression patterns and transliterations makes it
+appear to Perl code that the aforementioned ranges are all unbroken.)
 
 Many of the comments in the existing code ignore the possibility of
 EBCDIC, and may be wrong therefore, even if the code works.  This is
@@ -707,13 +722,13 @@ Unicode code points as sequences of bytes.  Macros  with the same names
 allow the calling code to think that there is only one such encoding.
 This is almost always referred to as C<utf8>, but it means the EBCDIC
 version as well.  Again, comments in the code may well be wrong even if
-the code itself is right.  For example, the concept of UTF-8 C<invariant
-characters> differs between ASCII and EBCDIC.  On ASCII platforms, only
-characters that do not have the high-order bit set (i.e.  whose ordinals
-are strict ASCII, 0 - 127) are invariant, and the documentation and
-comments in the code may assume that, often referring to something
-like, say, C<hibit>.  The situation differs and is not so simple on
-EBCDIC machines, but as long as the code itself uses the
+the code itself is right.  For example, the concept of UTF-8
+C<invariant characters> differs between ASCII and EBCDIC.  On ASCII
+platforms, only characters that do not have the high-order bit set
+(i.e.  whose ordinals are strict ASCII, 0 - 127) are invariant, and the
+documentation and comments in the code may assume that, often referring
+to something like, say, C<hibit>.  The situation differs and is not so
+simple on EBCDIC machines, but as long as the code itself uses the
 C<NATIVE_IS_INVARIANT()> macro appropriately, it works, even if the
 comments are wrong.
 
@@ -723,35 +738,35 @@ valid on both ASCII and EBCDIC platforms.  Sometimes, though, a test
 can't use a function and it's inconvenient to have different test
 versions depending on the platform.  There are 20 code points that are
 the same in all 4 character sets currently recognized by Perl (the 3
-EBCDIC code pages plus ISO 8859-1 (ASCII/Latin1)).  These can be used in
-such tests, though there is a small possibility that Perl will become
-available in yet another character set, breaking your test.  All but one
-of these code points are C0 control characters.  The most significant
-controls that are the same are C<\0>, C<\r>, and C<\N{VT}> (also
-specifiable as C<\cK>, C<\x0B>, C<\N{U+0B}>, or C<\013>).  The single
-non-control is U+00B6 PILCROW SIGN.  The controls that are the same have
-the same bit pattern in all 4 character sets, regardless of the UTF8ness
-of the string containing them.  The bit pattern for U+B6 is the same in
-all 4 for non-UTF8 strings, but differs in each when its containing
-string is UTF-8 encoded.  The only other code points that have some sort
-of sameness across all 4 character sets are the pair 0xDC and 0xFC.
-Together these represent upper- and lowercase LATIN LETTER U WITH
-DIAERESIS, but which is upper and which is lower may be reversed: 0xDC
-is the capital in Latin1 and 0xFC is the small letter, while 0xFC is the
-capital in EBCDIC and 0xDC is the small one.  This factoid may be
-exploited in writing case insensitive tests that are the same across all
-4 character sets.
+EBCDIC code pages plus ISO 8859-1 (ASCII/Latin1)).  These can be used
+in such tests, though there is a small possibility that Perl will
+become available in yet another character set, breaking your test.  All
+but one of these code points are C0 control characters.  The most
+significant controls that are the same are C<\0>, C<\r>, and C<\N{VT}>
+(also specifiable as C<\cK>, C<\x0B>, C<\N{U+0B}>, or C<\013>).  The
+single non-control is U+00B6 PILCROW SIGN.  The controls that are the
+same have the same bit pattern in all 4 character sets, regardless of
+the UTF8ness of the string containing them.  The bit pattern for U+B6
+is the same in all 4 for non-UTF8 strings, but differs in each when its
+containing string is UTF-8 encoded.  The only other code points that
+have some sort of sameness across all 4 character sets are the pair
+0xDC and 0xFC. Together these represent upper- and lowercase LATIN
+LETTER U WITH DIAERESIS, but which is upper and which is lower may be
+reversed: 0xDC is the capital in Latin1 and 0xFC is the small letter,
+while 0xFC is the capital in EBCDIC and 0xDC is the small one.  This
+factoid may be exploited in writing case insensitive tests that are the
+same across all 4 character sets.
 
 =item *
 
 Assuming the character set is just ASCII
 
-ASCII is a 7 bit encoding, but bytes have 8 bits in them.  The 128 extra
-characters have different meanings depending on the locale.  Absent a
-locale, currently these extra characters are generally considered to be
-unassigned, and this has presented some problems.  This has being
-changed starting in 5.12 so that these characters can be considered to
-be Latin-1 (ISO-8859-1).
+ASCII is a 7 bit encoding, but bytes have 8 bits in them.  The 128
+extra characters have different meanings depending on the locale.
+Absent a locale, currently these extra characters are generally
+considered to be unassigned, and this has presented some problems. This
+has being changed starting in 5.12 so that these characters can be
+considered to be Latin-1 (ISO-8859-1).
 
 =item *
 
@@ -820,8 +835,8 @@ fatal error.  One cause for people often making this mistake is that a
 "naked char" and therefore dereferencing a "naked char pointer" have an
 undefined signedness: it depends on the compiler and the flags of the
 compiler and the underlying platform whether the result is signed or
-unsigned.  For this very same reason using a 'char' as an array index is
-bad.
+unsigned.  For this very same reason using a 'char' as an array index
+is bad.
 
 =item *
 
@@ -848,8 +863,8 @@ Using printf formats for non-basic C types
    printf("i = %d\n", i);    /* BAD */
 
 While this might by accident work in some platform (where IV happens to
-be an C<int>), in general it cannot.  IV might be something larger.  Even
-worse the situation is with more specific types (defined by Perl's
+be an C<int>), in general it cannot.  IV might be something larger.
+Even worse the situation is with more specific types (defined by Perl's
 configuration step in F<config.h>):
 
    Uid_t who = ...;
@@ -904,10 +919,11 @@ Using gcc statement expressions
    val = ({...;...;...});    /* BAD */
 
 While a nice extension, it's not portable.  Historically, Perl used
-them in macros if available to gain some extra speed (essentially
-as a funky form of inlining), but we now support (or emulate) C99
-C<static inline> functions, so use them instead. Declare functions as
-C<PERL_STATIC_INLINE> to transparently fall back to emulation where needed.
+them in macros if available to gain some extra speed (essentially as a
+funky form of inlining), but we now support (or emulate) C99 C<static
+inline> functions, so use them instead. Declare functions as
+C<PERL_STATIC_INLINE> to transparently fall back to emulation where
+needed.
 
 =item *
 
@@ -925,8 +941,8 @@ for their use.
 
 =item *
 
-Testing for operating systems or versions when you should be testing for
-features
+Testing for operating systems or versions when you should be testing
+for features
 
   #ifdef __FOONIX__    /* BAD */
   foo = quux();
@@ -945,8 +961,8 @@ not perfect, because the below is a compile-time check):
 How does the HAS_QUUX become defined where it needs to be?  Well, if
 Foonix happens to be Unixy enough to be able to run the Configure
 script, and Configure has been taught about detecting and testing
-quux(), the HAS_QUUX will be correctly defined.  In other platforms, the
-corresponding configuration step will hopefully do the same.
+quux(), the HAS_QUUX will be correctly defined.  In other platforms,
+the corresponding configuration step will hopefully do the same.
 
 In a pinch, if you cannot wait for Configure to be educated, or if you
 have a good hunch of where quux() might be available, you can
@@ -965,23 +981,23 @@ temporarily try the following:
 But in any case, try to keep the features and operating systems
 separate.
 
-A good resource on the predefined macros for various operating
-systems, compilers, and so forth is
-L<http://sourceforge.net/p/predef/wiki/Home/>
+A good resource on the predefined macros for various operating systems,
+compilers, and so forth is
+L<https://sourceforge.net/p/predef/wiki/Home/>.
 
 =item *
 
 Assuming the contents of static memory pointed to by the return values
-of Perl wrappers for C library functions doesn't change.  Many C library
-functions return pointers to static storage that can be overwritten by
-subsequent calls to the same or related functions.  Perl has wrappers
-for some of these functions.  Originally many of those wrappers returned
-those volatile pointers.  But over time almost all of them have evolved
-to return stable copies.  To cope with the remaining ones, do a
-L<perlapi/savepv> to make a copy, thus avoiding these problems.  You
-will have to free the copy when you're done to avoid memory leaks.  If
-you don't have control over when it gets freed, you'll need to make the
-copy in a mortal scalar, like so
+of Perl wrappers for C library functions doesn't change.  Many C
+library functions return pointers to static storage that can be
+overwritten by subsequent calls to the same or related functions.  Perl
+has wrappers for some of these functions.  Originally many of those
+wrappers returned those volatile pointers.  But over time almost all of
+them have evolved to return stable copies.  To cope with the remaining
+ones, do a L<perlapi/savepv> to make a copy, thus avoiding these
+problems.  You will have to free the copy when you're done to avoid
+memory leaks.  If you don't have control over when it gets freed,
+you'll need to make the copy in a mortal scalar, like so
 
  SvPVX(sv_2mortal(newSVpv(volatile_string, 0)))
 
@@ -994,8 +1010,8 @@ copy in a mortal scalar, like so
 =item *
 
 Perl strings are NOT the same as C strings:  They may contain C<NUL>
-characters, whereas a C string is terminated by the first C<NUL>.
-That is why Perl API functions that deal with strings generally take a
+characters, whereas a C string is terminated by the first C<NUL>. That
+is why Perl API functions that deal with strings generally take a
 pointer to the first byte and either a length or a pointer to the byte
 just beyond the final one.
 
@@ -1008,20 +1024,20 @@ in your tests.  Now it's fairly rare in most real world cases to get
 C<NUL>s, so your code may seem to work, until one day a C<NUL> comes
 along.
 
-Here's an example.  It used to be a common paradigm, for decades, in the
-perl core to use S<C<strchr("list", c)>> to see if the character C<c> is
-any of the ones given in C<"list">, a double-quote-enclosed string of
-the set of characters that we are seeing if C<c> is one of.  As long as
-C<c> isn't a C<NUL>, it works.  But when C<c> is a C<NUL>, C<strchr>
-returns a pointer to the terminating C<NUL> in C<"list">.   This likely
-will result in a segfault or a security issue when the caller uses that
-end pointer as the starting point to read from.
+Here's an example.  It used to be a common paradigm, for decades, in
+the perl core to use S<C<strchr("list", c)>> to see if the character
+C<c> is any of the ones given in C<"list">, a double-quote-enclosed
+string of the set of characters that we are seeing if C<c> is one of.
+As long as C<c> isn't a C<NUL>, it works.  But when C<c> is a C<NUL>,
+C<strchr> returns a pointer to the terminating C<NUL> in C<"list">.
+This likely will result in a segfault or a security issue when the
+caller uses that end pointer as the starting point to read from.
 
-A solution to this and many similar issues is to use the C<mem>I<-foo> C
-library functions instead.  In this case C<memchr> can be used to see if
-C<c> is in C<"list"> and works even if C<c> is C<NUL>.  These functions
-need an additional parameter to give the string length.
-In the case of literal string parameters, perl has defined macros that
+A solution to this and many similar issues is to use the C<mem>I<-foo>
+C library functions instead.  In this case C<memchr> can be used to see
+if C<c> is in C<"list"> and works even if C<c> is C<NUL>.  These
+functions need an additional parameter to give the string length. In
+the case of literal string parameters, perl has defined macros that
 calculate the length for you.  See L<perlapi/String Handling>.
 
 =item *
@@ -1038,8 +1054,8 @@ snprintf() - the return type is unportable.  Use my_snprintf() instead.
 
 =head2 Security problems
 
-Last but not least, here are various tips for safer coding.
-See also L<perlclib> for libc/stdio replacements one should use.
+Last but not least, here are various tips for safer coding. See also
+L<perlclib> for libc/stdio replacements one should use.
 
 =over 4
 
@@ -1070,32 +1086,31 @@ Do not use sprintf() or vsprintf()
 If you really want just plain byte strings, use my_snprintf() and
 my_vsnprintf() instead, which will try to use snprintf() and
 vsnprintf() if those safer APIs are available.  If you want something
-fancier than a plain byte string, use
-L<C<Perl_form>()|perlapi/form> or SVs and
-L<C<Perl_sv_catpvf()>|perlapi/sv_catpvf>.
+fancier than a plain byte string, use L<C<Perl_form>()|perlapi/form> or
+SVs and L<C<Perl_sv_catpvf()>|perlapi/sv_catpvf>.
 
 Note that glibc C<printf()>, C<sprintf()>, etc. are buggy before glibc
 version 2.17.  They won't allow a C<%.s> format with a precision to
 create a string that isn't valid UTF-8 if the current underlying locale
-of the program is UTF-8.  What happens is that the C<%s> and its operand are
-simply skipped without any notice.
+of the program is UTF-8.  What happens is that the C<%s> and its
+operand are simply skipped without any notice.
 L<https://sourceware.org/bugzilla/show_bug.cgi?id=6530>.
 
 =item *
 
 Do not use atoi()
 
-Use grok_atoUV() instead.  atoi() has ill-defined behavior on overflows,
-and cannot be used for incremental parsing.  It is also affected by locale,
-which is bad.
+Use grok_atoUV() instead.  atoi() has ill-defined behavior on
+overflows, and cannot be used for incremental parsing.  It is also
+affected by locale, which is bad.
 
 =item *
 
 Do not use strtol() or strtoul()
 
-Use grok_atoUV() instead.  strtol() or strtoul() (or their IV/UV-friendly
-macro disguises, Strtol() and Strtoul(), or Atol() and Atoul() are
-affected by locale, which is bad.
+Use grok_atoUV() instead.  strtol() or strtoul() (or their
+IV/UV-friendly macro disguises, Strtol() and Strtoul(), or Atol() and
+Atoul() are affected by locale, which is bad.
 
 =for apidoc_section $numeric
 =for apidoc AmhD||Atol|const char * nptr
@@ -1122,14 +1137,14 @@ debugging, like this:
 
 C<-DDEBUGGING> turns on the C compiler's C<-g> flag to have it produce
 debugging information which will allow us to step through a running
-program, and to see in which C function we are at (without the debugging
-information we might see only the numerical addresses of the functions,
-which is not very helpful). It will also turn on the C<DEBUGGING>
-compilation symbol which enables all the internal debugging code in Perl.
-There are a whole bunch of things you can debug with this:
-L<perlrun|perlrun/-Dletters> lists them all, and the best way to find out
-about them is to play about with them.  The most useful options are
-probably
+program, and to see in which C function we are at (without the
+debugging information we might see only the numerical addresses of the
+functions, which is not very helpful). It will also turn on the
+C<DEBUGGING> compilation symbol which enables all the internal
+debugging code in Perl. There are a whole bunch of things you can debug
+with this: L<perlrun|perlrun/-Dletters> lists them all, and the best
+way to find out about them is to play about with them.  The most useful
+options are probably
 
     l  Context (loop) stack processing
     s  Stack snapshots (with v, displays all stacks)
@@ -1179,8 +1194,8 @@ Or if you have a core dump:
     gdb ./perl core
 
 You'll want to do that in your Perl source tree so the debugger can
-read the source code.  You should see the copyright message, followed by
-the prompt.
+read the source code.  You should see the copyright message, followed
+by the prompt.
 
     (gdb)
 
@@ -1372,12 +1387,12 @@ similar output to CPAN module L<B::Debug>.
 
 =head2 Using gdb to look at specific parts of a program
 
-With the example above, you knew to look for C<Perl_pp_add>, but what if
-there were multiple calls to it all over the place, or you didn't know what
-the op was you were looking for?
+With the example above, you knew to look for C<Perl_pp_add>, but what
+if there were multiple calls to it all over the place, or you didn't
+know what the op was you were looking for?
 
-One way to do this is to inject a rare call somewhere near what you're looking
-for.  For example, you could add C<study> before your method:
+One way to do this is to inject a rare call somewhere near what you're
+looking for.  For example, you could add C<study> before your method:
 
     study;
 
@@ -1385,9 +1400,8 @@ And in gdb do:
 
     (gdb) break Perl_pp_study
 
-And then step until you hit what you're
-looking for.  This works well in a loop
-if you want to only break at certain iterations:
+And then step until you hit what you're looking for.  This works well
+in a loop if you want to only break at certain iterations:
 
     for my $c (1..100) {
         study if $c == 50;
@@ -1395,8 +1409,8 @@ if you want to only break at certain iterations:
 
 =head2 Using gdb to look at what the parser/lexer are doing
 
-If you want to see what perl is doing when parsing/lexing your code, you can
-use C<BEGIN {}>:
+If you want to see what perl is doing when parsing/lexing your code,
+you can use C<BEGIN {}>:
 
     print "Before\n";
     BEGIN { study; }
@@ -1406,8 +1420,8 @@ And in gdb:
 
     (gdb) break Perl_pp_study
 
-If you want to see what the parser/lexer is doing inside of C<if> blocks and
-the like you need to be a little trickier:
+If you want to see what the parser/lexer is doing inside of C<if>
+blocks and the like you need to be a little trickier:
 
     if ($a && $b && do { BEGIN { study } 1 } && $c) { ... }
 
@@ -1429,15 +1443,15 @@ platforms, but please be aware that there are several different
 implementations of it by different vendors, which means that the flags
 are not identical across different platforms.
 
-There is a C<lint> target in Makefile, but you may have to
-diddle with the flags (see above).
+There is a C<lint> target in Makefile, but you may have to diddle with
+the flags (see above).
 
 =head2 Coverity
 
-Coverity (L<http://www.coverity.com/>) is a product similar to lint and as
-a testbed for their product they periodically check several open source
-projects, and they give out accounts to open source developers to the
-defect databases.
+Coverity (L<http://www.coverity.com/>) is a product similar to lint and
+as a testbed for their product they periodically check several open
+source projects, and they give out accounts to open source developers
+to the defect databases.
 
 There is Coverity setup for the perl5 project:
 L<https://scan.coverity.com/projects/perl5>
@@ -1445,10 +1459,11 @@ L<https://scan.coverity.com/projects/perl5>
 =head2 HP-UX cadvise (Code Advisor)
 
 HP has a C/C++ static analyzer product for HP-UX caller Code Advisor.
-(Link not given here because the URL is horribly long and seems horribly
-unstable; use the search engine of your choice to find it.)  The use of
-the C<cadvise_cc> recipe with C<Configure ... -Dcc=./cadvise_cc>
-(see cadvise "User Guide") is recommended; as is the use of C<+wall>.
+(Link not given here because the URL is horribly long and seems
+horribly unstable; use the search engine of your choice to find it.)
+The use of the C<cadvise_cc> recipe with C<Configure ...
+-Dcc=./cadvise_cc> (see cadvise "User Guide") is recommended; as is the
+use of C<+wall>.
 
 =head2 cpd (cut-and-paste detector)
 
@@ -1457,10 +1472,10 @@ cut-and-pasted code changes, all the other spots should probably be
 changed, too.  Therefore such code should probably be turned into a
 subroutine or a macro.
 
-cpd (L<https://docs.pmd-code.org/latest/pmd_userdocs_cpd.html>) is part of the pmd project
-(L<https://pmd.github.io/>).  pmd was originally written for static
-analysis of Java code, but later the cpd part of it was extended to
-parse also C and C++.
+cpd (L<https://docs.pmd-code.org/latest/pmd_userdocs_cpd.html>) is part
+of the pmd project (L<https://pmd.github.io/>).  pmd was originally
+written for static analysis of Java code, but later the cpd part of it
+was extended to parse also C and C++.
 
 Download the pmd-bin-X.Y.zip () from the SourceForge site, extract the
 pmd-X.Y.jar from it, and then run that on source code thusly:
@@ -1484,11 +1499,11 @@ coding nose clean.
 
 The C<-Wall> is by default on.
 
-It would be nice for C<-pedantic>) to be on always, but unfortunately it is not
-safe on all platforms - for example fatal conflicts with the system headers
-(Solaris being a prime example).  If Configure C<-Dgccansipedantic> is used,
-the C<cflags> frontend selects C<-pedantic> for the platforms where it is known
-to be safe.
+It would be nice for C<-pedantic>) to be on always, but unfortunately
+it is not safe on all platforms - for example fatal conflicts with the
+system headers (Solaris being a prime example).  If Configure
+C<-Dgccansipedantic> is used, the C<cflags> frontend selects
+C<-pedantic> for the platforms where it is known to be safe.
 
 The following extra flags are added:
 
@@ -1556,25 +1571,26 @@ C<-std1> mode on.
 
 B<NOTE 1>: Running under older memory debuggers such as Purify,
 valgrind or Third Degree greatly slows down the execution: seconds
-become minutes, minutes become hours.  For example as of Perl 5.8.1, the
-ext/Encode/t/Unicode.t takes extraordinarily long to complete under
-e.g. Purify, Third Degree, and valgrind.  Under valgrind it takes more
-than six hours, even on a snappy computer.  The said test must be doing
-something that is quite unfriendly for memory debuggers.  If you don't
-feel like waiting, that you can simply kill away the perl process.
+become minutes, minutes become hours.  For example as of Perl 5.8.1,
+the F<ext/Encode/t/Unicode.t> test takes extraordinarily long to
+complete under e.g. Purify, Third Degree, and valgrind.  Under valgrind
+it takes more than six hours, even on a snappy computer.  Said test
+must be doing something that is quite unfriendly for memory debuggers.
+If you don't feel like waiting, you can simply kill the perl process.
 Roughly valgrind slows down execution by factor 10, AddressSanitizer by
 factor 2.
 
 B<NOTE 2>: To minimize the number of memory leak false alarms (see
 L</PERL_DESTRUCT_LEVEL> for more information), you have to set the
-environment variable C<PERL_DESTRUCT_LEVEL> to 2.  For example, like this:
+environment variable C<PERL_DESTRUCT_LEVEL> to 2.  For example, like
+this:
 
     env PERL_DESTRUCT_LEVEL=2 valgrind ./perl -Ilib ...
 
 B<NOTE 3>: There are known memory leaks when there are compile-time
-errors within C<eval> or C<require>; seeing C<S_doeval> in the call stack is
-a good sign of these.  Fixing these leaks is non-trivial, unfortunately,
-but they must be fixed eventually.
+errors within C<eval> or C<require>; seeing C<S_doeval> in the call
+stack is a good sign of these.  Fixing these leaks is non-trivial,
+unfortunately, but they must be fixed eventually.
 
 B<NOTE 4>: L<DynaLoader> will not clean up after itself completely
 unless Perl is built with the Configure option
@@ -1583,9 +1599,9 @@ C<-Accflags=-DDL_UNLOAD_ALL_AT_EXIT>.
 =head2 valgrind
 
 The valgrind tool can be used to find out both memory leaks and illegal
-heap memory accesses.  As of version 3.3.0, Valgrind only supports Linux
-on x86, x86-64 and PowerPC and Darwin (OS X) on x86 and x86-64.  The
-special "test.valgrind" target can be used to run the tests under
+heap memory accesses.  As of version 3.3.0, Valgrind only supports
+Linux on x86, x86-64 and PowerPC and Darwin (OS X) on x86 and x86-64.
+The special "test.valgrind" target can be used to run the tests under
 valgrind.  Found errors and memory leaks are logged in files named
 F<testfile.valgrind> and by default output is displayed inline.
 
@@ -1593,14 +1609,15 @@ Example usage:
 
     make test.valgrind
 
-Since valgrind adds significant overhead, tests will take much longer to
-run.  The valgrind tests support being run in parallel to help with this:
+Since valgrind adds significant overhead, tests will take much longer
+to run.  The valgrind tests support being run in parallel to help with
+this:
 
     TEST_JOBS=9 make test.valgrind
 
 Note that the above two invocations will be very verbose as reachable
-memory and leak-checking is enabled by default.  If you want to just see
-pure errors, try:
+memory and leak-checking is enabled by default.  If you want to just
+see pure errors, try:
 
     VG_OPTS='-q --leak-check=no --show-reachable=no' TEST_JOBS=9 \
         make test.valgrind
@@ -1620,12 +1637,13 @@ To get valgrind and for more information see L<https://valgrind.org/>.
 
 AddressSanitizer ("ASan") consists of a compiler instrumentation module
 and a run-time C<malloc> library. ASan is available for a variety of
-architectures, operating systems, and compilers (see project link below).
-It checks for unsafe memory usage, such as use after free and buffer
-overflow conditions, and is fast enough that you can easily compile your
-debugging or optimized perl with it. Modern versions of ASan check for
-memory leaks by default on most platforms, otherwise (e.g. x86_64 OS X)
-this feature can be enabled via C<ASAN_OPTIONS=detect_leaks=1>.
+architectures, operating systems, and compilers (see project link
+below). It checks for unsafe memory usage, such as use after free and
+buffer overflow conditions, and is fast enough that you can easily
+compile your debugging or optimized perl with it. Modern versions of
+ASan check for memory leaks by default on most platforms, otherwise
+(e.g. x86_64 OS X) this feature can be enabled via
+C<ASAN_OPTIONS=detect_leaks=1>.
 
 
 To build perl with AddressSanitizer, your Configure invocation should
@@ -1663,13 +1681,12 @@ contains C<-shared> (at least on Linux).
 =item * -fsanitize-blacklist=`pwd`/asan_ignore
 
 AddressSanitizer will ignore functions listed in the C<asan_ignore>
-file. (This file should contain a short explanation of why each of
-the functions is listed.)
+file.  (This file should contain a short explanation of why each of the
+functions is listed.)
 
 =back
 
-See also
-L<https://github.com/google/sanitizers/wiki/AddressSanitizer>.
+See also L<https://github.com/google/sanitizers/wiki/AddressSanitizer>.
 
 
 =head1 PROFILING
@@ -1686,9 +1703,9 @@ program is spending its time.  The caveats are that very small/fast
 functions have lower probability of showing up in the profile, and that
 periodically interrupting the program (this is usually done rather
 frequently, in the scale of milliseconds) imposes an additional
-overhead that may skew the results.  The first problem can be alleviated
-by running the code for longer (in general this is a good idea for
-profiling), the second problem is usually kept in guard by the
+overhead that may skew the results.  The first problem can be
+alleviated by running the code for longer (in general this is a good
+idea for profiling), the second problem is usually kept in guard by the
 profiling tools themselves.
 
 The second method divides up the generated code into I<basic blocks>.
@@ -1790,10 +1807,10 @@ source code files, like this
 
     gcov sv.c
 
-which will cause F<sv.c.gcov> to be created.  The F<.gcov> files contain
-the source code annotated with relative frequencies of execution
-indicated by "#" markers.  If you want to generate F<.gcov> files for
-all profiled object files, you can run something like this:
+which will cause F<sv.c.gcov> to be created.  The F<.gcov> files
+contain the source code annotated with relative frequencies of
+execution indicated by "#" markers.  If you want to generate F<.gcov>
+files for all profiled object files, you can run something like this:
 
     for file in `find . -name \*.gcno`
     do sh -c "cd `dirname $file` && gcov `basename $file .gcno`"
@@ -1808,23 +1825,22 @@ L<https://gcc.gnu.org/onlinedocs/gcc/Gcov-Intro.html#Gcov-Intro>.
 
 =head2 callgrind profiling
 
-callgrind is a valgrind tool for profiling source code. Paired
-with kcachegrind (a Qt based UI), it gives you an overview of
-where code is taking up time, as well as the ability
-to examine callers, call trees, and more. One of its benefits
-is you can use it on perl and XS modules that have not been
-compiled with debugging symbols.
+callgrind is a valgrind tool for profiling source code. Paired with
+kcachegrind (a Qt based UI), it gives you an overview of where code is
+taking up time, as well as the ability to examine callers, call trees,
+and more. One of its benefits is you can use it on perl and XS modules
+that have not been compiled with debugging symbols.
 
-If perl is compiled with debugging symbols (C<-g>), you can view
-the annotated source and click around, much like L<Devel::NYTProf>'s
-HTML output.
+If perl is compiled with debugging symbols (C<-g>), you can view the
+annotated source and click around, much like L<Devel::NYTProf>'s HTML
+output.
 
 For basic usage:
 
     valgrind --tool=callgrind ./perl ...
 
-By default it will write output to F<callgrind.out.PID>, but you
-can change that with C<--callgrind-out-file=...>
+By default it will write output to F<callgrind.out.PID>, but you can
+change that with C<--callgrind-out-file=...>
 
 To view the data, do:
 
@@ -1841,13 +1857,13 @@ Some useful options are:
 
 =item * --threshold
 
-Percentage of counts (of primary sort event) we are interested in.
-The default is 99%, 100% might show things that seem to be missing.
+Percentage of counts (of primary sort event) we are interested in. The
+default is 99%, 100% might show things that seem to be missing.
 
 =item * --auto
 
-Annotate all source files containing functions that helped reach
-the event count threshold.
+Annotate all source files containing functions that helped reach the
+event count threshold.
 
 =back
 
@@ -1856,30 +1872,32 @@ the event count threshold.
 =head2 PERL_DESTRUCT_LEVEL
 
 If you want to run any of the tests yourself manually using e.g.
-valgrind, please note that by default perl B<does not> explicitly
-clean up all the memory it has allocated (such as global memory arenas)
-but instead lets the C<exit()> of the whole program "take care" of such
+valgrind, please note that by default perl B<does not> explicitly clean
+up all the memory it has allocated (such as global memory arenas) but
+instead lets the C<exit()> of the whole program "take care" of such
 allocations, also known as "global destruction of objects".
 
 There is a way to tell perl to do complete cleanup: set the environment
-variable C<PERL_DESTRUCT_LEVEL> to a non-zero value.  The F<t/TEST> wrapper
-does set this to 2, and this is what you need to do too, if you don't
-want to see the "global leaks": For example, for running under valgrind
+variable C<PERL_DESTRUCT_LEVEL> to a non-zero value.  The F<t/TEST>
+wrapper does set this to 2, and this is what you need to do too, if you
+don't want to see the "global leaks": For example, for running under
+valgrind
 
     env PERL_DESTRUCT_LEVEL=2 valgrind ./perl -Ilib t/foo/bar.t
 
-(Note: the mod_perl Apache module uses this environment variable
-for its own purposes and extends its semantics.  Refer to L<the mod_perl
-documentation|https://perl.apache.org/docs/> for more information.  Also, spawned threads do the
-equivalent of setting this variable to the value 1.)
+(Note: the mod_perl Apache module uses this environment variable for
+its own purposes and extends its semantics.  Refer to L<the mod_perl
+documentation|https://perl.apache.org/docs/> for more information.
+Also, spawned threads do the equivalent of setting this variable to the
+value 1.)
 
-If, at the end of a run you get the message I<N scalars leaked>, you
-can recompile with C<-DDEBUG_LEAKING_SCALARS>
-(C<Configure -Accflags=-DDEBUG_LEAKING_SCALARS>), which will cause the
-addresses of all those leaked SVs to be dumped along with details as to
-where each SV was originally allocated.  This information is also
-displayed by L<Devel::Peek>.  Note that the extra details recorded with
-each SV increase memory usage, so it shouldn't be used in production
+If, at the end of a run, you get the message I<N scalars leaked>, you
+can recompile with C<-DDEBUG_LEAKING_SCALARS> (C<Configure
+-Accflags=-DDEBUG_LEAKING_SCALARS>), which will cause the addresses of
+all those leaked SVs to be dumped along with details as to where each
+SV was originally allocated.  This information is also displayed by
+L<Devel::Peek>.  Note that the extra details recorded with each SV
+increase memory usage, so it shouldn't be used in production
 environments.  It also converts C<new_SV()> from a macro into a real
 function, so you can use your favourite debugger to discover where
 those pesky SVs were allocated.
@@ -1890,18 +1908,19 @@ leaking SVs that are still reachable and will be properly cleaned up
 during destruction of the interpreter.  In such cases, using the C<-Dm>
 switch can point you to the source of the leak.  If the executable was
 built with C<-DDEBUG_LEAKING_SCALARS>, C<-Dm> will output SV
-allocations in addition to memory allocations.  Each SV allocation has a
-distinct serial number that will be written on creation and destruction
-of the SV.  So if you're executing the leaking code in a loop, you need
-to look for SVs that are created, but never destroyed between each
-cycle.  If such an SV is found, set a conditional breakpoint within
-C<new_SV()> and make it break only when C<PL_sv_serial> is equal to the
-serial number of the leaking SV.  Then you will catch the interpreter in
-exactly the state where the leaking SV is allocated, which is
-sufficient in many cases to find the source of the leak.
+allocations in addition to memory allocations.  Each SV allocation has
+a distinct serial number that will be written on creation and
+destruction of the SV.  So if you're executing the leaking code in a
+loop, you need to look for SVs that are created, but never destroyed
+between each cycle.  If such an SV is found, set a conditional
+breakpoint within C<new_SV()> and make it break only when
+C<PL_sv_serial> is equal to the serial number of the leaking SV.  Then
+you will catch the interpreter in exactly the state where the leaking
+SV is allocated, which is sufficient in many cases to find the source
+of the leak.
 
 As C<-Dm> is using the PerlIO layer for output, it will by itself
-allocate quite a bunch of SVs, which are hidden to avoid recursion.  You
+allocate quite a bunch of SVs, which are hidden to avoid recursion. You
 can bypass the PerlIO layer if you use the SV logging provided by
 C<-DPERL_MEM_LOG> instead.
 
@@ -1911,8 +1930,8 @@ C<-DPERL_MEM_LOG> instead.
 =head2 PERL_MEM_LOG
 
 If compiled with C<-DPERL_MEM_LOG> (C<-Accflags=-DPERL_MEM_LOG>), both
-memory and SV allocations go through logging functions, which is
-handy for breakpoint setting.
+memory and SV allocations go through logging functions, which is handy
+for breakpoint setting.
 
 Unless C<-DPERL_MEM_LOG_NOIMPL> (C<-Accflags=-DPERL_MEM_LOG_NOIMPL>) is
 also compiled, the logging functions read $ENV{PERL_MEM_LOG} to
@@ -1929,8 +1948,8 @@ Memory logging is somewhat similar to C<-Dm> but is independent of
 C<-DDEBUGGING>, and at a higher level; all uses of Newx(), Renew(), and
 Safefree() are logged with the caller's source code file and line
 number (and C function name, if supported by the C compiler).  In
-contrast, C<-Dm> is directly at the point of C<malloc()>.  SV logging is
-similar.
+contrast, C<-Dm> is directly at the point of C<malloc()>.  SV logging
+is similar.
 
 Since the logging doesn't use PerlIO, all SV allocations are logged and
 no extra SV allocations are introduced by enabling the logging.  If
@@ -1980,15 +1999,15 @@ Note: you can define up to 20 conversion shortcuts in the gdb section.
 On some platforms Perl supports retrieving the C level backtrace
 (similar to what symbolic debuggers like gdb do).
 
-The backtrace returns the stack trace of the C call frames,
-with the symbol names (function names), the object names (like "perl"),
-and if it can, also the source code locations (file:line).
+The backtrace returns the stack trace of the C call frames, with the
+symbol names (function names), the object names (like "perl"), and if
+it can, also the source code locations (file:line).
 
-The supported platforms are Linux, and OS X (some *BSD might
-work at least partly, but they have not yet been tested).
+The supported platforms are Linux, and OS X (some *BSD might work at
+least partly, but they have not yet been tested).
 
-This feature hasn't been tested with multiple threads, but it will
-only show the backtrace of the thread doing the backtracing.
+This feature hasn't been tested with multiple threads, but it will only
+show the backtrace of the thread doing the backtracing.
 
 The feature needs to be enabled with C<Configure -Dusecbacktrace>.
 
@@ -2000,26 +2019,26 @@ information is needed for the symbol names and the source locations.
 Static functions might not be visible for the backtrace.
 
 Source code locations, even if available, can often be missing or
-misleading if the compiler has e.g. inlined code.  Optimizer can
-make matching the source code and the object code quite challenging.
+misleading if the compiler has e.g. inlined code.  Optimizer can make
+matching the source code and the object code quite challenging.
 
 =over 4
 
 =item Linux
 
-You B<must> have the BFD (-lbfd) library installed, otherwise C<perl> will
-fail to link.  The BFD is usually distributed as part of the GNU binutils.
+You B<must> have the BFD (-lbfd) library installed, otherwise C<perl>
+will fail to link.  The BFD is usually distributed as part of the GNU
+binutils.
 
-Summary: C<Configure ... -Dusecbacktrace>
-and you need C<-lbfd>.
+Summary: C<Configure ... -Dusecbacktrace> and you need C<-lbfd>.
 
 =item OS X
 
-The source code locations are supported B<only> if you have
-the Developer Tools installed.  (BFD is B<not> needed.)
+The source code locations are supported B<only> if you have the
+Developer Tools installed.  (BFD is B<not> needed.)
 
-Summary: C<Configure ... -Dusecbacktrace>
-and installing the Developer Tools would be good.
+Summary: C<Configure ... -Dusecbacktrace> and installing the Developer
+Tools would be good.
 
 =back
 
@@ -2031,10 +2050,10 @@ for Configure.
 Unless the above additional feature is enabled, nothing about the
 backtrace functionality is visible, except for the Perl/XS level.
 
-Furthermore, even if you have enabled this feature to be compiled,
-you need to enable it in runtime with an environment variable:
-C<PERL_C_BACKTRACE_ON_ERROR=10>.  It must be an integer higher
-than zero, telling the desired frame count.
+Furthermore, even if you have enabled this feature to be compiled, you
+need to enable it in runtime with an environment variable:
+C<PERL_C_BACKTRACE_ON_ERROR=10>.  It must be an integer higher than
+zero, telling the desired frame count.
 
 Retrieving the backtrace from Perl level (using for example an XS
 extension) would be much less exciting than one would hope: normally
@@ -2064,17 +2083,16 @@ L<perlclib>.
 
 =head2 Read-only optrees
 
-Under ithreads the optree is read only.  If you want to enforce this, to
-check for write accesses from buggy code, compile with
-C<-Accflags=-DPERL_DEBUG_READONLY_OPS>
-to enable code that allocates op memory
-via C<mmap>, and sets it read-only when it is attached to a subroutine.
-Any write access to an op results in a C<SIGBUS> and abort.
+Under ithreads the optree is read only.  If you want to enforce this,
+to check for write accesses from buggy code, compile with
+C<-Accflags=-DPERL_DEBUG_READONLY_OPS> to enable code that allocates op
+memory via C<mmap>, and sets it read-only when it is attached to a
+subroutine. Any write access to an op results in a C<SIGBUS> and abort.
 
 This code is intended for development only, and may not be portable
 even to all Unix variants.  Also, it is an 80% solution, in that it
-isn't able to make all ops read only.  Specifically it does not apply to
-op slabs belonging to C<BEGIN> blocks.
+isn't able to make all ops read only.  Specifically it does not apply
+to op slabs belonging to C<BEGIN> blocks.
 
 However, as an 80% solution it is still effective, as it has caught
 bugs in the past.
@@ -2085,8 +2103,8 @@ There wasn't necessarily a standard C<bool> type on compilers prior to
 C99, and so some workarounds were created.  The C<TRUE> and C<FALSE>
 macros are still available as alternatives for C<true> and C<false>.
 And the C<cBOOL> macro was created to correctly cast to a true/false
-value in all circumstances, but should no longer be necessary.
-Using S<C<(bool)> I<expr>>> should now always work.
+value in all circumstances, but should no longer be necessary.  Using
+S<C<(bool)> I<expr>>> should now always work.
 
 There are no plans to remove any of C<TRUE>, C<FALSE>, nor C<cBOOL>.
 
@@ -2096,8 +2114,8 @@ You may wish to run C<Configure> with something like
 
     -Accflags='-Wconversion -Wno-sign-conversion -Wno-shorten-64-to-32'
 
-or your compiler's equivalent to make it easier to spot any unsafe truncations
-that show up.
+or your compiler's equivalent to make it easier to spot any unsafe
+truncations that show up.
 
 =head2 The .i Targets
 
@@ -2112,3 +2130,4 @@ results.
 
 This document was originally written by Nathan Torkington, and is
 maintained by the perl5-porters mailing list.
+

--- a/t/porting/known_pod_issues.dat
+++ b/t/porting/known_pod_issues.dat
@@ -28,6 +28,7 @@ atof(3)
 atoi(3)
 Attribute::Constant
 autobox
+B::Debug
 B::Generate
 B::Lint
 B::Lint::Debug


### PR DESCRIPTION
- use F<> for filenames, not C<>
- use L<> for URLs and module names to create clickable links in renderers that support it
- change "C&lt;hdr> files" to "header files" everywhere
- update old links (new domains, http -> https, etc)
- use C<> for code snippets and type names in C
- use C<> for environment variables
- possessive  "it's" -> "its"
- "cleanup" (verb) -> "clean up"
- add link to mod_perl documentation
- random noun/verb agreements and punctuation