### PR TITLE
regexec.c: Use utf8_hop_safe() instead of rolling our own

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -11146,26 +11146,7 @@ S_reghop4(U8 *s, SSize_t off, const U8* llim, const U8* rlim)
 {
     PERL_ARGS_ASSERT_REGHOP4;
 
-    if (off >= 0) {
-        while (off-- && s < rlim) {
-            /* XXX could check well-formedness here */
-            s += UTF8SKIP(s);
-        }
-    }
-    else {
-        while (off++ && s > llim) {
-            s--;
-            if (UTF8_IS_CONTINUED(*s)) {
-                while (s > llim && UTF8_IS_CONTINUATION(*s))
-                    s--;
-                if (! UTF8_IS_START(*s)) {
-                    Perl_croak_nocontext("Malformed UTF-8 character (fatal)");
-                }
-            }
-            /* XXX could check well-formedness here */
-        }
-    }
-    return s;
+    return utf8_hop_safe(s, off, llim, rlim);
 }
 
 /* like reghop3, but returns NULL on overrun, rather than returning last


### PR DESCRIPTION
This is inlined, so shouldn't be slower, and avoids duplicate code