### PR TITLE
locale.c: Use wider than U32 for a counter

### DIFF
--- a/intrpvar.h
+++ b/intrpvar.h
@@ -772,7 +772,7 @@ PERLVAR(I, collxfrm_base, Size_t)	/* Basic overhead in *xfrm();
                                            mult == 0, base != 0 => ill-formed;
                                          */
 PERLVAR(I, collation_name, char *)	/* Name of current collation */
-PERLVARI(I, collation_ix, U32,	0)	/* Collation generation index */
+PERLVARI(I, collation_ix, PERL_UINTMAX_T, 0)	/* Collation generation index */
 PERLVARI(I, strxfrm_NUL_replacement, U8, 0)  /* Code point to replace NULs */
 PERLVARI(I, strxfrm_is_behaved, bool, TRUE)
                             /* Assume until proven otherwise that it works */

--- a/locale.c
+++ b/locale.c
@@ -2526,9 +2526,10 @@ S_new_collate(pTHX_ const char *newcoll, bool force)
      * cleared.  The next time the locale changes, the index is incremented,
      * and so we know during a comparison that the transformation is not
      * necessarily still valid, and so is recomputed.  Note that if the locale
-     * changes enough times, the index could wrap (a U32), and it is possible
-     * that a transformation would improperly be considered valid, leading to
-     * an unlikely bug */
+     * changes enough times, the index could wrap, and it is possible that a
+     * transformation would improperly be considered valid, leading to an
+     * unlikely bug.  The value is declared to the widest possible type on this
+     * platform. */
 
     /* Return if the locale isn't changing */
     if (strEQ(PL_collation_name, newcoll)) {
@@ -6194,7 +6195,7 @@ Perl_mem_collxfrm_(pTHX_ const char *input_string,
     }
 
     /* Store the collation id */
-    *(U32*)xbuf = PL_collation_ix;
+    *(PERL_UINTMAX_T *)xbuf = PL_collation_ix;
 
 #  if defined(USE_POSIX_2008_LOCALE) && defined HAS_STRXFRM_L
 #    ifdef USE_LOCALE_CTYPE


### PR DESCRIPTION
Processes that change locales are incrementing a counter that could eventully wrap if the process is long-lived.  It's not likely, but it's also easy to make this a U64 if available, and make the chances of it happening much closer to zero.