### PR TITLE
get_win32_message_utf8ness() Fix unlikely case

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -3123,12 +3123,18 @@ S_save_to_buffer(const char * string, const char **buf, Size_t *buf_size)
 bool
 Perl_get_win32_message_utf8ness(pTHX_ const char * string)
 {
-    /* NULL => locale irrelevant, 0 => category irrelevant
-     * so returns based on the UTF-8 legality of the input string, ignoring the
-     * locale and category completely.
-     *
-     * This is because Windows doesn't have LC_MESSAGES */
-    return get_locale_string_utf8ness_i(string, LOCALE_IS_UTF8, NULL, 0);
+    /* This is because Windows doesn't have LC_MESSAGES. */
+
+#    ifdef USE_LC_CTYPE
+
+    return get_locale_string_utf8ness_i(string, LOCALE_IS_UTF8,
+                                        NULL, LC_CTYPE_INDEX_);
+#    else
+
+    return false;
+
+#    endif
+
 }
 
 #  endif


### PR DESCRIPTION
This function calls get_locale_string_utf8ness_i().  The API of that function changed earlier in the 5.37 series, and this was not updated to correspond.  It is calling it with category 0, which it thinks is an out-of-bounds value, but it really is LC_ALL on Windows.  Thus it actually probably doesn't lead to a failure, but it theoretically could fail if LC_ALL is not uniform.

So it's better to not succeed just by accident.  This commit changes to now use LC_CTYPE as the category.  And if someone has managed to compile Windows without LC_CTYPE, it now just says that the input string isn't UTF-8, as without LC_CTYPE, you've only got the C locale.