### PR TITLE
Add ability to emulate mingw locales on other boxes

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4450,11 +4450,11 @@ S	|bool	|less_dicey_bool_setlocale_r				\
 #   endif
 #   if !(  defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) && \
         ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) ||            \
-           defined(WIN32) )
+           defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) )
 S	|const char *|calculate_LC_ALL_string				\
 				|NN const char **individ_locales
 #   endif
-#   if defined(WIN32)
+#   if defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES)
 ST	|wchar_t *|Win_byte_string_to_wstring				\
 				|const UINT code_page			\
 				|NULLOK const char *byte_string
@@ -4468,7 +4468,7 @@ S	|const char *|wrap_wsetlocale					\
 				|const int category			\
 				|NULLOK const char *locale
 #   endif
-#   if   defined(WIN32) || \
+#   if   defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) || \
        ( defined(USE_POSIX_2008_LOCALE) && !defined(USE_QUERYLOCALE) )
 S	|const char *|find_locale_from_environment			\
 				|const unsigned int index

--- a/embed.h
+++ b/embed.h
@@ -1320,16 +1320,16 @@
 #       endif
 #       if !(  defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) && \
             ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) ||            \
-               defined(WIN32) )
+               defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) )
 #         define calculate_LC_ALL_string(a)     S_calculate_LC_ALL_string(aTHX_ a)
 #       endif
-#       if defined(WIN32)
+#       if defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES)
 #         define Win_byte_string_to_wstring     S_Win_byte_string_to_wstring
 #         define Win_wstring_to_byte_string     S_Win_wstring_to_byte_string
 #         define win32_setlocale(a,b)           S_win32_setlocale(aTHX_ a,b)
 #         define wrap_wsetlocale(a,b)           S_wrap_wsetlocale(aTHX_ a,b)
 #       endif
-#       if   defined(WIN32) || \
+#       if   defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) || \
            ( defined(USE_POSIX_2008_LOCALE) && !defined(USE_QUERYLOCALE) )
 #         define find_locale_from_environment(a) S_find_locale_from_environment(aTHX_ a)
 #       endif

--- a/locale.c
+++ b/locale.c
@@ -147,6 +147,95 @@ static int debug_initialization = 0;
 #define PERL_IN_LOCALE_C
 #include "perl.h"
 
+#ifdef WIN32_USE_FAKE_OLD_MINGW_LOCALES
+
+   /* Use -Accflags=-DWIN32_USE_FAKE_OLD_MINGW_LOCALES on a POSIX or *nix box
+    * to get a semblance of pretending the locale handling is that of a MingW
+    * that doesn't use UCRT (hence 'OLD' in the name).  This exercizes code
+    * paths that are not compiled on non-Windows boxes, and allows for ASAN.
+    * This is thus a way to see if locale.c on Windows is likely going to
+    * compile, without having to use a real Win32 box.  And running the test
+    * suite will verify to a large extent our logic and memory allocation
+    * handling for such boxes.  And access to ASAN and PERL_MEMLOG Of course the underlying calls are to the POSIX
+    * libc, so any differences in implementation between those and the Windows
+    * versions will not be caught by this. */
+
+#  define WIN32
+#  undef P_CS_PRECEDES
+#  undef CURRENCY_SYMBOL
+#  define CP_UTF8 -1
+#  undef _configthreadlocale
+#  define _configthreadlocale(arg) NOOP
+
+#  define MultiByteToWideChar(cp, flags, byte_string, m1, wstring, req_size) \
+                    (mbsrtowcs(wstring, &(byte_string), req_size, NULL) + 1)
+#  define WideCharToMultiByte(cp, flags, wstring, m1, byte_string,          \
+                              req_size, default_char, found_default_char)   \
+                    (wcsrtombs(byte_string, &(wstring), req_size, NULL) + 1)
+
+#  ifdef USE_LOCALE
+
+static const wchar_t * wsetlocale_buf = NULL;
+static Size_t wsetlocale_buf_size = 0;
+static PerlInterpreter * wsetlocale_buf_aTHX = NULL;
+
+STATIC
+const wchar_t *
+S_wsetlocale(const int category, const wchar_t * wlocale)
+{
+    /* Windows uses a setlocale that takes a wchar_t* locale.  Other boxes
+     * don't have this, so this Windows replacement converts the wchar_t input
+     * to plain 'char*', calls plain setlocale(), and converts the result back
+     * to 'wchar_t*' */
+
+    const char * byte_locale = NULL;
+    if (wlocale) {
+        byte_locale = Win_wstring_to_byte_string(CP_UTF8, wlocale);
+    }
+
+    const char * byte_result = setlocale(category, byte_locale);
+    Safefree(byte_locale);
+    if (byte_result == NULL) {
+        return NULL;
+    }
+
+    const wchar_t * wresult = Win_byte_string_to_wstring(CP_UTF8, byte_result);
+
+    if (! wresult) {
+        return NULL;
+    }
+
+    /* Emulate a global static memory return from wsetlocale().  This currently
+     * leaks at process end; would require changing LOCALE_TERM to fix that */
+    Size_t string_size = wcslen(wresult) + 1;
+
+    if (wsetlocale_buf_size == 0) {
+        Newx(wsetlocale_buf, string_size, wchar_t);
+        wsetlocale_buf_size = string_size;
+
+#  ifdef MULTIPLICITY
+
+        dTHX;
+        wsetlocale_buf_aTHX = aTHX;
+
+#  endif
+
+    }
+    else if (string_size > wsetlocale_buf_size) {
+        Renew(wsetlocale_buf, string_size, wchar_t);
+        wsetlocale_buf_size = string_size;
+    }
+
+    Copy(wresult, wsetlocale_buf, string_size, wchar_t);
+    Safefree(wresult);
+
+    return wsetlocale_buf;
+}
+
+#  define _wsetlocale(category, wlocale)  S_wsetlocale(category, wlocale)
+#  endif
+#endif  /* WIN32_USE_FAKE_OLD_MINGW_LOCALES */
+
 #include "reentr.h"
 
 #ifdef I_WCHAR
@@ -4597,8 +4686,16 @@ S_my_langinfo_i(pTHX_
          * is documented and has been stable for many releases */
         UINT ___lc_codepage_func(void);
 
+#        ifndef WIN32_USE_FAKE_OLD_MINGW_LOCALES
+
         retval = save_to_buffer(Perl_form(aTHX_ "%d", ___lc_codepage_func()),
                                 retbufp, retbuf_sizep);
+#        else
+
+        retval = save_to_buffer(nl_langinfo(CODESET),
+                                retbufp, retbuf_sizep);
+#        endif
+
         DEBUG_Lv(PerlIO_printf(Perl_debug_log, "locale='%s' cp=%s\n",
                                                locale, retval));
         break;
@@ -7302,6 +7399,29 @@ Perl_thread_locale_term(pTHX)
     }
 
     PL_cur_locale_obj = LC_GLOBAL_LOCALE;
+
+#endif
+#ifdef WIN32_USE_FAKE_OLD_MINGW_LOCALES
+
+    /* When faking the mingw implementation, we coerce this function into doing
+     * something completely different from its intent -- namely to free up our
+     * static buffer to avoid a leak.  This function gets called for each
+     * thread that is terminating, so will give us a chance to free the buffer
+     * from the appropriate pool.  On unthreaded systems, it gets called by the
+     * mutex termination code. */
+
+#  ifdef MULTIPLICITY
+
+    if (aTHX != wsetlocale_buf_aTHX) {
+        return;
+    }
+
+#  endif
+
+    if (wsetlocale_buf_size > 0) {
+        Safefree(wsetlocale_buf);
+        wsetlocale_buf_size = 0;
+    }
 
 #endif
 

--- a/makedef.pl
+++ b/makedef.pl
@@ -113,6 +113,10 @@ while (<CFG>) {
 }
 close(CFG);
 
+if ($define{WIN32_USE_FAKE_OLD_MINGW_LOCALES}) {
+    $define{NO_POSIX_2008_LOCALE} = 1;
+}
+
 #==========================================================================
 # perl.h logic duplication begins
 

--- a/perl.h
+++ b/perl.h
@@ -44,6 +44,25 @@
 #   include "config.h"
 #endif
 
+/* This fakes up using Mingw for locale handling.  In order to not define WIN32
+ * in this file (and hence throughout the code that isn't expecting it), this
+ * doesn't define that, but defines the appropriate things that would otherwise
+ * be defined later in the file.  Hence those and here must be kept in sync */
+#ifdef WIN32_USE_FAKE_OLD_MINGW_LOCALES
+#  define UINT  unsigned int
+#  undef USE_THREAD_SAFE_LOCALE
+#  define NO_POSIX_2008_LOCALE
+#  undef HAS_NL_LANGINFO
+#  undef HAS_NL_LANGINFO_L
+#  undef _UCRT
+#  ifdef USE_LOCALE
+#    define TS_W32_BROKEN_LOCALECONV
+#    ifdef USE_THREADS
+#      define EMULATE_THREAD_SAFE_LOCALES
+#    endif
+#  endif
+#endif
+
 /*
 =for apidoc_section $debugging
 =for apidoc CmnW ||comma_aDEPTH
@@ -7157,8 +7176,14 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #    endif
 #  endif
 
-#  ifndef USE_POSIX_2008_LOCALE
-#    define LOCALE_TERM_POSIX_2008_  NOOP
+#  ifdef WIN32_USE_FAKE_OLD_MINGW_LOCALES
+    /* This function is coerced by this Configure option into cleaning up
+     * memory that is static to locale.c.  So we call it at termination.  Doing
+     * it this way is kludgy but confines having to deal with this
+     * Configuration to a bare minimum number of places. */
+#      define LOCALE_TERM_POSIX_2008_  Perl_thread_locale_term(NULL)
+#  elif ! defined(USE_POSIX_2008_LOCALE)
+#      define LOCALE_TERM_POSIX_2008_  NOOP
 #  else
      /* We have a locale object holding the 'C' locale for Posix 2008 */
 #    define LOCALE_TERM_POSIX_2008_                                         \

--- a/perl_langinfo.h
+++ b/perl_langinfo.h
@@ -6,7 +6,7 @@
 
 #include "config.h"
 
-#if defined(HAS_NL_LANGINFO) && defined(I_LANGINFO)
+#if defined(I_LANGINFO)
 #   include <langinfo.h>
 #endif
 

--- a/proto.h
+++ b/proto.h
@@ -7112,14 +7112,14 @@ S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char *locale);
              !defined(USE_THREAD_SAFE_LOCALE_EMULATION) */
 #   if !(  defined(USE_POSIX_2008_LOCALE) && defined(USE_QUERYLOCALE) ) && \
         ( !defined(LC_ALL) || defined(USE_POSIX_2008_LOCALE) ||            \
-           defined(WIN32) )
+           defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) )
 STATIC const char *
 S_calculate_LC_ALL_string(pTHX_ const char **individ_locales);
 #     define PERL_ARGS_ASSERT_CALCULATE_LC_ALL_STRING \
         assert(individ_locales)
 
 #   endif
-#   if defined(WIN32)
+#   if defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES)
 STATIC wchar_t *
 S_Win_byte_string_to_wstring(const UINT code_page, const char *byte_string);
 #     define PERL_ARGS_ASSERT_WIN_BYTE_STRING_TO_WSTRING
@@ -7136,8 +7136,8 @@ STATIC const char *
 S_wrap_wsetlocale(pTHX_ const int category, const char *locale);
 #     define PERL_ARGS_ASSERT_WRAP_WSETLOCALE
 
-#   endif /* defined(WIN32) */
-#   if   defined(WIN32) || \
+#   endif /* defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) */
+#   if   defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) || \
        ( defined(USE_POSIX_2008_LOCALE) && !defined(USE_QUERYLOCALE) )
 STATIC const char *
 S_find_locale_from_environment(pTHX_ const unsigned int index);


### PR DESCRIPTION
This commit allows the ability to Configure a perl to use much of the locale handling code that MingW executes.  It is an aid to development on more POSIX-like boxes to be able to compile and test while partially simulating a MingW environment.  This can catch many bugs earlier without having to access a MingW box.  Of course this is a partial simulation, so it misses some things,

This currently fails a couple of tests in the suite; there are commits in the pipeline to fix those.

Remember this only gets compiled if explicitly requested.