### PR TITLE
regen/HeaderParser.pm: require perl >= 5.10

### DIFF
--- a/regen/HeaderParser.pm
+++ b/regen/HeaderParser.pm
@@ -1,6 +1,7 @@
 package HeaderParser;
 use strict;
 use warnings;
+use v5.10;      # Needs named capture groups
 
 # these are required below in BEGIN statements, we cant have a
 # hard dependency on them as they might not be available when


### PR DESCRIPTION
This won't compile when run on earlier perls, and the reason isn't apparent without some digging.  It turns out that it uses named capture groups which came in 5.9.5..