### PR TITLE
allow mingw64 ci to succeed

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -521,27 +521,18 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v3
-      - name: Set up Perl build environment
-        run: |
-          # skip installing perl if it is already installed.
-          if (!(Test-Path "C:\strawberry\perl\bin")) {
-            choco install strawberryperl
-          }
-          echo @"
-          C:\strawberry\c\bin
-          C:\strawberry\perl\site\bin
-          C:\strawberry\perl\bin
-          "@ |
-            Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Install mingw-64
+        uses: egor-tensin/setup-mingw@v2
       - name: Host perl -V
-        run: perl -V
+        run: |
+          perl -V
       - name: gcc --version
         run: gcc --version
       - name: Build
         shell: cmd
         run: |
           cd win32
-          gmake CCHOME=C:\strawberry\c CFG=Debug -f GNUMakefile -j2
+          gmake CCHOME=C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64 CFG=Debug -f GNUMakefile -j2
       - name: Show Config
         shell: cmd
         run: |
@@ -552,7 +543,7 @@ jobs:
         run: |
           cd win32
           set HARNESS_OPTIONS=j2
-          gmake CCHOME=C:\strawberry\c CFG=Debug -f GNUMakefile test
+          gmake CCHOME=C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64 CFG=Debug -f GNUMakefile test
 
   #                            _
   #   ___ _   _  __ ___      _(_)_ __

--- a/win32/config_sh.PL
+++ b/win32/config_sh.PL
@@ -323,10 +323,6 @@ if ($opt{cc} =~ /\bcl/ and $opt{ccversion} =~ /^(\d+)/) {
 	$opt{i_stdint} = 'define';
     }
     if ($ccversion >= 19) { # VC14+
-	$opt{stdio_base} = 'PERLIO_FILE_base(fp)';
-	$opt{stdio_bufsiz} = '(PERLIO_FILE_cnt(fp) + PERLIO_FILE_ptr(fp) - PERLIO_FILE_base(fp))';
-	$opt{stdio_cnt} = 'PERLIO_FILE_cnt(fp)';
-	$opt{stdio_ptr} = 'PERLIO_FILE_ptr(fp)';
 	$opt{i_stdbool} = 'define' unless $prebuilt;
     }
 }
@@ -342,14 +338,17 @@ elsif ($opt{cc} =~ /\bicl/) {
 	$opt{i_stdint} = 'define';
     }
     if ($num_ver =~ /^(\d+)/ && $1 >= 19) { # VC14+
-	$opt{stdio_base} = 'PERLIO_FILE_base(fp)';
-	$opt{stdio_bufsiz} = '(PERLIO_FILE_cnt(fp) + PERLIO_FILE_ptr(fp) - PERLIO_FILE_base(fp))';
-	$opt{stdio_cnt} = 'PERLIO_FILE_cnt(fp)';
-	$opt{stdio_ptr} = 'PERLIO_FILE_ptr(fp)';
 	$opt{i_stdbool} = 'define';
     }
     $opt{ar} ='xilib';
 }
+
+# win32.h always defines these, and those definitions
+# depend on the current CRT
+$opt{stdio_base} = 'PERLIO_FILE_base(fp)';
+$opt{stdio_bufsiz} = '(PERLIO_FILE_cnt(fp) + PERLIO_FILE_ptr(fp) - PERLIO_FILE_base(fp))';
+$opt{stdio_cnt} = 'PERLIO_FILE_cnt(fp)';
+$opt{stdio_ptr} = 'PERLIO_FILE_ptr(fp)';
 
 if ($opt{useithreads} eq 'define' && $opt{ccflags} =~ /-DPERL_IMPLICIT_SYS\b/) {
     $opt{d_pseudofork} = 'define';

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -259,8 +259,10 @@ union PerlNan { unsigned __int64 __q; double __d; };
 extern const __declspec(selectany) union PerlNan __PL_nan_u = { 0x7FF8000000000000UI64 };
 #define NV_NAN ((NV)__PL_nan_u.__d)
 
+#endif /* ifdef _MSC_VER */
+
 /* The CRT was rewritten in VS2015. */
-#if _MSC_VER >= 1900
+#ifdef _UCRT
 
 /* No longer declared in stdio.h */
 EXTERN_C char *gets(char* buffer);
@@ -295,11 +297,7 @@ typedef struct
 #define PERLIO_FILE_flag(f) ((int)(((__crt_stdio_stream_data*)(f))->_flags))
 #define PERLIO_FILE_file(f) (*(int*)(&((__crt_stdio_stream_data*)(f))->_file))
 
-#endif
-
-#endif /* _MSC_VER */
-
-#if (!defined(_MSC_VER)) || (defined(_MSC_VER) && _MSC_VER < 1900)
+#else /* ifdef _UCRT */
 
 /* Note: PERLIO_FILE_ptr/base/cnt are not actually used for GCC or <VS2015
  * since FILE_ptr/base/cnt do the same thing anyway but it doesn't hurt to


### PR DESCRIPTION
mingw64 has been failing due to and apparent compiler bug, where it was generating what appears to be an invalid DLL, which failed to load.

This series of commits does two basic things:
- allows us to build with ucrt versions of mingw64 rather than just msvcrt (which is still supported)
- in CI, install a fresh mingw64 and test/build with that instead of the gcc bundled with strawberry perl.

This still uses the gmake from strawberry perl.

I expect some existing code that currently treats non-MSVC WIN32 builds can be updated to now check for PERL_WIN32_UCRT, but I wanted to get CI fixed first.

Fixes #21202