### PR TITLE
Revert "use the linker to link generate_uudmap$(EXE)"

### DIFF
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -787,7 +787,7 @@ bitcount.h: generate_uudmap\$(HOST_EXE_EXT)
 
 $spitshell >>$Makefile <<'!NO!SUBS!'
 generate_uudmap$(HOST_EXE_EXT): generate_uudmap$(OBJ_EXT)
-	$(LD) -o generate_uudmap$(EXE_EXT) $(LDFLAGS) generate_uudmap$(OBJ_EXT) $(libs)
+	$(CC) -o generate_uudmap$(EXE_EXT) $(LDFLAGS) generate_uudmap$(OBJ_EXT) $(libs)
 
 !NO!SUBS!
 ;;


### PR DESCRIPTION
This introduced smoke failures on AIX and HP-UX, for example on AIX:
```
[2023-07-11 23:38:52METDST] xlc_r -q64 -c -DPERL_CORE -q64 -DDEBUGGING -DPERL_DONT_CREATE_GVSV -qlanglvl=extended -D_ALL_SOURCE -D_ANSI_C_SOURCE -D_POSIX_SOURCE -qmaxmem=-1 -qnoansialias -qlanglvl=extc99 -DUSE_NATIVE_DLOPEN -DNEED_PTHREAD_INIT -DDEBUGGING -I/pro/local/include -q64 -DUSE_64_BIT_ALL -q64 -O -g generate_uudmap.c [2023-07-11 23:38:52METDST] ld -o generate_uudmap -L/usr/local/ppc64/lib64 -b64 -q64 -L/pro/local/lib -brtl -bdynamic -b64 generate_uudmap.o -lpthread -lbind -ldl -lld -lm -lcrypt -lpthreads -lc [2023-07-11 23:38:52METDST]
[2023-07-11 23:38:52METDST] If you compile perl5 on a different machine or from a different object [2023-07-11 23:38:52METDST] directory, copy the Policy.sh file from this object directory to the [2023-07-11 23:38:52METDST] new one before you run Configure -- this will help you with most of [2023-07-11 23:38:52METDST] the policy defaults.
[2023-07-11 23:38:52METDST] 5.39.0 <=> 5.014002
[2023-07-11 23:38:52METDST] ===== PROCURA Policy for aix/cc ======================== [2023-07-11 23:38:52METDST] ===== PROCURA Policy results ============================
[2023-07-11 23:38:52METDST] cc:         xlc_r
[2023-07-11 23:38:52METDST] ccversion:  -
[2023-07-11 23:38:52METDST] gccversion: -
[2023-07-11 23:38:52METDST] ccflags:    -q64 -DDEBUGGING -DPERL_DONT_CREATE_GVSV -qlanglvl=extended
[2023-07-11 23:38:52METDST] optimize:
[2023-07-11 23:38:52METDST] ld:
[2023-07-11 23:38:52METDST] ldflags:    -L/usr/local/ppc64/lib64 -b64 -q64 -L/pro/local/lib
[2023-07-11 23:38:52METDST] libswanted: cl pthread socket bind inet ndbm gdbm dbm db malloc dl ld sun m crypt sec util c cposix posix ucb bsd BSD
[2023-07-11 23:38:52METDST] libsdirs:    /usr/local/ppc64/lib64  /lib /pro/local/lib
[2023-07-11 23:38:52METDST] locincpth:  /pro/local/include
[2023-07-11 23:38:52METDST] loclibpth:  /usr/local/ppc64/lib64
[2023-07-11 23:38:52METDST] useshrplib:
[2023-07-11 23:38:52METDST] ===== PROCURA Policy done ===============================
[2023-07-11 23:38:52METDST] ld: 0706-012 The -q flag is not recognized.
[2023-07-11 23:38:52METDST] ld: 0706-012 The -6 flag is not recognized.
[2023-07-11 23:38:52METDST] ld: 0706-012 The -4 flag is not recognized.
[2023-07-11 23:38:52METDST] make: *** [generate_uudmap] Error 255
```
and HP-UX:
```
[2023-07-12 02:09:20+0200] ccache cc -c -DPERL_CORE -D_POSIX_C_SOURCE=199506L -D_REENTRANT -Ae -Wp,-H150000 -DDEBUGGING +Z -z -D_HPUX_SOURCE -Wl,+vnocompatwarnings +DD64 -DDEBUGGING -I/pro/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 +O2 +Onolimit -g generate_uudmap.c [2023-07-12 02:09:20+0200] /usr/bin/ld -o generate_uudmap -L/pro/local/lib +DD64 -L/usr/lib/hpux64 generate_uudmap.o -lcl -lpthread -ldl -lm -lsec -lc [2023-07-12 02:09:20+0200]
[2023-07-12 02:09:20+0200] If you compile perl5 on a different machine or from a different object [2023-07-12 02:09:20+0200] directory, copy the Policy.sh file from this object directory to the [2023-07-12 02:09:20+0200] new one before you run Configure -- this will help you with most of [2023-07-12 02:09:20+0200] the policy defaults.
[2023-07-12 02:09:20+0200] 5.39.0 <=> 5.026002
[2023-07-12 02:09:20+0200] ===== PROCURA Policy for hpux/ccache cc ======================== [2023-07-12 02:09:20+0200] ===== PROCURA Policy results ============================
[2023-07-12 02:09:20+0200] cc:         ccache cc
[2023-07-12 02:09:20+0200] ccversion:  -
[2023-07-12 02:09:20+0200] gccversion: -
[2023-07-12 02:09:20+0200] ccflags:    -DDEBUGGING +Z -z
[2023-07-12 02:09:20+0200] optimize:
[2023-07-12 02:09:20+0200] ld:
[2023-07-12 02:09:20+0200] ldflags:    -L/pro/local/lib
[2023-07-12 02:09:20+0200] libswanted: cl pthread cl pthread socket bind inet ndbm gdbm dbm db malloc dl ld sun m crypt sec util c cposix posix ucb bsd BSD
[2023-07-12 02:09:20+0200] libsdirs:    /lib /pro/local/lib
[2023-07-12 02:09:20+0200] locincpth:  /pro/local/include
[2023-07-12 02:09:20+0200] loclibpth:  /pro/local/lib
[2023-07-12 02:09:20+0200] useshrplib:
[2023-07-12 02:09:20+0200] ===== PROCURA Policy done ===============================
[2023-07-12 02:09:20+0200] ld: Unrecognized argument: +DD64
[2023-07-12 02:09:20+0200] Fatal error.
[2023-07-12 02:09:20+0200] make: *** [generate_uudmap] Error 1
```
This reverts commit 07e3b5cdb6f7260446b791acf0623e01a37e4739.