### PR TITLE
locale.c: Add missing mutex locks

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -3186,7 +3186,9 @@ Perl_mbtowc_(pTHX_ const wchar_t * pwc, const char * s, const Size_t len)
 #  if defined(USE_MBRTOWC)
 
     SETERRNO(0, 0);
+    MBRTOWC_LOCK_;
     retval = (SSize_t) mbrtowc((wchar_t *) pwc, s, len, &PL_mbrtowc_ps);
+    MBRTOWC_UNLOCK_;
 
 #  else
 
@@ -5470,6 +5472,9 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
                      * form qr/ ^ LC_ [A-Z]+ = /x, except LC_ALL which was
                      * already handled above.  These are assumed to be locale
                      * settings.  Output them and their values. */
+
+                    ENV_READ_LOCK;
+
                     for (e = environ; *e; e++) {
                         const STRLEN prefix_len = sizeof("LC_") - 1;
                         STRLEN uppers_len;
@@ -5485,6 +5490,8 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
                                 *e + prefix_len + uppers_len + 1);
                         }
                     }
+
+                    ENV_READ_UNLOCK;
                 }
 
 #  else


### PR DESCRIPTION
This adds locks around mbrtowc and reading the environment that a code review indicated were missing.  The mbrtowc lock is currently a no-op, but a future commit will change that.  The other lock is in code rarely compiled.