### PR TITLE
perl.h: Also recognize -DNO_THREAD_SAFE_LOCALE

### DIFF
--- a/makedef.pl
+++ b/makedef.pl
@@ -153,14 +153,14 @@ if ($define{USE_ITHREADS} && ! $define{NO_LOCALE_THREADS}) {
 }
 
 if (   $define{HAS_POSIX_2008_LOCALE}
-    && (  ! $define{HAS_SETLOCALE} || (     $define{USE_LOCALE_THREADS}
-                                       && ! $define{NO_POSIX_2008_LOCALE})))
+    && (! $define{HAS_SETLOCALE} || (     $define{USE_LOCALE_THREADS}
+                                     && ! $define{NO_POSIX_2008_LOCALE})
+                                     && ! $define{NO_THREAD_SAFE_LOCALE}))
 {
     $define{USE_POSIX_2008_LOCALE} = 1;
 }
 
-if ($define{USE_LOCALE_THREADS} && ! $define{NO_THREAD_SAFE_LOCALE})
-{
+if ($define{USE_LOCALE_THREADS} && ! $define{NO_THREAD_SAFE_LOCALE}) {
     if (    $define{USE_POSIX_2008_LOCALE}
         || ($define{WIN32} && (   $cctype !~ /\D/
                                && $cctype >= 80)))

--- a/perl.h
+++ b/perl.h
@@ -1258,9 +1258,11 @@ typedef enum {
    /* Use POSIX 2008 locales if available, and no alternative exists
     * ('setlocale()' is the alternative); or is threaded and not forbidden to
     * use them */
-#  if defined(HAS_POSIX_2008_LOCALE) && (  ! defined(HAS_SETLOCALE)            \
-                                         || (     defined(USE_LOCALE_THREADS)  \
-                                             && ! defined(NO_POSIX_2008_LOCALE)))
+#  if (       defined(HAS_POSIX_2008_LOCALE)                                \
+       && (    ! defined(HAS_SETLOCALE)                                     \
+           || (     defined(USE_LOCALE_THREADS)                             \
+               && ! defined(NO_POSIX_2008_LOCALE)))                         \
+               && ! defined(NO_THREAD_SAFE_LOCALE))
 #    define USE_POSIX_2008_LOCALE
 #  endif
 


### PR DESCRIPTION
It would be a reasonable Configure option to say
-Accflags=-DNO_THREAD_SAFE_LOCALE

This will be documented in a later commit