### PR TITLE
'h2ph' Tweaks for macOS 13 Ventura

### DIFF
--- a/t/lib/h2ph.h
+++ b/t/lib/h2ph.h
@@ -157,6 +157,12 @@ typedef unsigned int  __uint32_t;
 #define T_UNION_      (t_union)        other
 #define T_UNION_      (t_union*)      &other
 
+// Test "<header.h>" include paths
+#define __has_include(x) 0
+#if __has_include(<ptrcheck.h>)
+#include <ptrcheck.h>
+#endif
+
 /* comments (that look like string) inside enums... */
 
 enum {

--- a/t/lib/h2ph.h
+++ b/t/lib/h2ph.h
@@ -116,6 +116,47 @@ typdef struct empty_struct {
 } // trailing C++-style comment should not force continuation
 #endif
 
+struct empty_struct {
+}; // trailing C++-style comment should not force continuation
+
+typedef struct {
+} empty_struct; // trailing C++-style comment should not force continuation
+
+struct n_struct {
+    int  n;
+    char c;
+}; // trailing C++-style comment should not force continuation
+
+typedef struct {
+    int  n;
+    char c;
+} n_typedef; // trailing C++-style comment should not force continuation
+
+union n_union {
+    int  n;
+    char c;
+}; // trailing C++-style comment should not force continuation
+
+typedef union {
+    int  n;
+    char c;
+} t_union; // trailing C++-style comment should not force continuation
+
+// Test removal of typedefs
+typedef unsigned int  __uint32_t;
+#define _UINT_32      (__uint32_t)0x12345678
+
+#define _EMPTY_S      (empty_struct)   other
+#define _EMPTY_S      (empty_struct*) &other
+#define N_STRUCT      (n_struct)       other
+#define N_STRUCT      (n_struct*)     &other
+#define TYPE_DEF      (n_typedef)      other
+#define TYPE_DEF      (n_typedef*)    &other
+#define N_UNION_      (n_union)        other
+#define N_UNION_      (n_union*)      &other
+#define T_UNION_      (t_union)        other
+#define T_UNION_      (t_union*)      &other
+
 /* comments (that look like string) inside enums... */
 
 enum {

--- a/t/lib/h2ph.pht
+++ b/t/lib/h2ph.pht
@@ -88,6 +88,17 @@ unless(defined(&_H2PH_H_)) {
     }
     if(1) {
     }
+    eval 'sub _UINT_32 () {0x12345678;}' unless defined(&_UINT_32);
+    eval 'sub _EMPTY_S () {  &other;}' unless defined(&_EMPTY_S);
+    eval 'sub _EMPTY_S () {  &other;}' unless defined(&_EMPTY_S);
+    eval 'sub N_STRUCT () {  &other;}' unless defined(&N_STRUCT);
+    eval 'sub N_STRUCT () {  &other;}' unless defined(&N_STRUCT);
+    eval 'sub TYPE_DEF () {  &other;}' unless defined(&TYPE_DEF);
+    eval 'sub TYPE_DEF () {  &other;}' unless defined(&TYPE_DEF);
+    eval 'sub N_UNION_ () {  &other;}' unless defined(&N_UNION_);
+    eval 'sub N_UNION_ () {  &other;}' unless defined(&N_UNION_);
+    eval 'sub T_UNION_ () {  &other;}' unless defined(&T_UNION_);
+    eval 'sub T_UNION_ () {  &other;}' unless defined(&T_UNION_);
     eval("sub flim () { 0; }") unless defined(&flim);
     eval("sub flam () { 1; }") unless defined(&flam);
     eval 'sub blli_in_use {

--- a/t/lib/h2ph.pht
+++ b/t/lib/h2ph.pht
@@ -99,6 +99,13 @@ unless(defined(&_H2PH_H_)) {
     eval 'sub N_UNION_ () {  &other;}' unless defined(&N_UNION_);
     eval 'sub T_UNION_ () {  &other;}' unless defined(&T_UNION_);
     eval 'sub T_UNION_ () {  &other;}' unless defined(&T_UNION_);
+    eval 'sub __has_include {
+        my($x) = @_;
+	    eval q(0);
+    }' unless defined(&__has_include);
+    if( &__has_include("<ptrcheck.h>")) {
+	require 'ptrcheck.ph';
+    }
     eval("sub flim () { 0; }") unless defined(&flim);
     eval("sub flam () { 1; }") unless defined(&flam);
     eval 'sub blli_in_use {

--- a/utils/h2ph.PL
+++ b/utils/h2ph.PL
@@ -880,29 +880,29 @@ DEFINE
 
 	print PREAMBLE <<SIZEOF;
 %sizeof = (
-	char	=> $Config{charsize},
-	uchar	=> $Config{charsize},
-	u_char	=> $Config{charsize},
+	char	=> $Config{charsize}	// length(pack("c",  0)),
+	uchar	=> $Config{charsize}	// length(pack("C",  0)),
+	u_char	=> $Config{charsize}	// length(pack("C",  0)),
 
-	short	=> $Config{shortsize},
-	ushort	=> $Config{shortsize},
-	u_short => $Config{shortsize},
+	short	=> $Config{shortsize}	// length(pack("s!", 0)),
+	ushort	=> $Config{shortsize}	// length(pack("S!", 0)),
+	u_short => $Config{shortsize}	// length(pack("S!", 0)),
 
-	int	=> $Config{intsize},
-	uint	=> $Config{intsize},
-	u_int	=> $Config{intsize},
+	int	=> $Config{intsize}	// length(pack("i!", 0)),
+	uint	=> $Config{intsize}	// length(pack("I!", 0)),
+	u_int	=> $Config{intsize}	// length(pack("I!", 0)),
 
-	long	=> $Config{longsize},
-	ulong	=> $Config{longsize},
-	u_long	=> $Config{longsize},
+	long	=> $Config{longsize}	// length(pack("l!", 0)),
+	ulong	=> $Config{longsize}	// length(pack("L!", 0)),
+	u_long	=> $Config{longsize}	// length(pack("L!", 0)),
 
-	FILE	=> $Config{ptrsize},
-	key_t	=> $Config{ptrsize},
-	caddr_t	=> $Config{ptrsize},
+	FILE	=> $Config{ptrsize}	// length(pack("p",  0)),
+	key_t	=> $Config{ptrsize}	// length(pack("p",  0)),
+	caddr_t => $Config{ptrsize}	// length(pack("p",  0)),
+	size_t	=> $Config{sizesize}	// length(pack("p",  0)),
 
-	float	=> $Config{intsize},
-	double	=> $Config{doublesize},
-	size_t	=> $Config{sizesize},
+	float	=> $Config{floatsize}	// length(pack("f",  0.0)),
+	double	=> $Config{doublesize}	// length(pack("d",  0.0)),
 
 	%sizeof,   # Allow scripts to extend/customize %sizeof
 );

--- a/utils/h2ph.PL
+++ b/utils/h2ph.PL
@@ -880,29 +880,29 @@ DEFINE
 
 	print PREAMBLE <<SIZEOF;
 %sizeof = (
-	char	=> $Config{charsize}	// length(pack("c",  0)),
-	uchar	=> $Config{charsize}	// length(pack("C",  0)),
-	u_char	=> $Config{charsize}	// length(pack("C",  0)),
+	char	=> 1,
+	uchar	=> 1,
+	u_char	=> 1,
 
-	short	=> $Config{shortsize}	// length(pack("s!", 0)),
-	ushort	=> $Config{shortsize}	// length(pack("S!", 0)),
-	u_short => $Config{shortsize}	// length(pack("S!", 0)),
+	short	=> $Config{shortsize},
+	ushort	=> $Config{shortsize},
+	u_short => $Config{shortsize},
 
-	int	=> $Config{intsize}	// length(pack("i!", 0)),
-	uint	=> $Config{intsize}	// length(pack("I!", 0)),
-	u_int	=> $Config{intsize}	// length(pack("I!", 0)),
+	int	=> $Config{intsize},
+	uint	=> $Config{intsize},
+	u_int	=> $Config{intsize},
 
-	long	=> $Config{longsize}	// length(pack("l!", 0)),
-	ulong	=> $Config{longsize}	// length(pack("L!", 0)),
-	u_long	=> $Config{longsize}	// length(pack("L!", 0)),
+	long	=> $Config{longsize},
+	ulong	=> $Config{longsize},
+	u_long	=> $Config{longsize},
 
-	FILE	=> $Config{ptrsize}	// length(pack("p",  0)),
-	key_t	=> $Config{ptrsize}	// length(pack("p",  0)),
-	caddr_t => $Config{ptrsize}	// length(pack("p",  0)),
-	size_t	=> $Config{sizesize}	// length(pack("p",  0)),
+	FILE	=> $Config{ptrsize},
+	key_t	=> $Config{ptrsize},
+	caddr_t => $Config{ptrsize},
 
-	float	=> $Config{floatsize}	// length(pack("f",  0.0)),
-	double	=> $Config{doublesize}	// length(pack("d",  0.0)),
+	float	=> length(pack("f", 0.0)),
+	double	=> $Config{doublesize},
+	size_t	=> $Config{sizesize},
 
 	%sizeof,   # Allow scripts to extend/customize %sizeof
 );

--- a/utils/h2ph.PL
+++ b/utils/h2ph.PL
@@ -900,7 +900,7 @@ DEFINE
 	key_t	=> $Config{ptrsize},
 	caddr_t => $Config{ptrsize},
 
-	float	=> length(pack("f", 0.0)),
+	float	=> @{[ length(pack("f", 0.0)) ]},
 	double	=> $Config{doublesize},
 	size_t	=> $Config{sizesize},
 

--- a/utils/h2ph.PL
+++ b/utils/h2ph.PL
@@ -877,6 +877,35 @@ DEFINE
 		    quotemeta($define{$_}), "\" } }\n\n";
 	    }
 	}
+
+	print PREAMBLE <<SIZEOF;
+%sizeof = (
+	char	=> $Config{charsize},
+	uchar	=> $Config{charsize},
+	u_char	=> $Config{charsize},
+
+	short	=> $Config{shortsize},
+	ushort	=> $Config{shortsize},
+	u_short => $Config{shortsize},
+
+	int	=> $Config{intsize},
+	uint	=> $Config{intsize},
+	u_int	=> $Config{intsize},
+
+	long	=> $Config{longsize},
+	ulong	=> $Config{longsize},
+	u_long	=> $Config{longsize},
+
+	FILE	=> $Config{ptrsize},
+	key_t	=> $Config{ptrsize},
+	caddr_t	=> $Config{ptrsize},
+
+	float	=> $Config{intsize},
+	double	=> $Config{doublesize},
+	size_t	=> $Config{sizesize},
+);
+SIZEOF
+
 	print PREAMBLE "\n1;\n";  # avoid 'did not return a true value' when empty
     close PREAMBLE               or die "Cannot close $preamble:  $!";
 }
@@ -1022,7 +1051,7 @@ The usual warnings if it can't read or write the files involved.
 
 =head1 BUGS
 
-Doesn't construct the %sizeof array for you.
+Only constructs part of the %sizeof array for you.
 
 It doesn't handle all C constructs, but it does attempt to isolate
 definitions inside evals so that you can get at the definitions

--- a/utils/h2ph.PL
+++ b/utils/h2ph.PL
@@ -509,6 +509,8 @@ sub expr {
 		s/\([\w\s]+[\*\s]*\)// && next;      # then eliminate them.
 	    }
 	};
+	# "<headers.h>"-style include paths; just quote them for now
+	s/^(<[_A-Z\/]+(?:\.h)?>)//i && do { $new .= "\"$1\""; next;};
 	# struct/union member, including arrays:
 	s/^([_A-Z]\w*(\[[^\]]+\])?((\.|->)[_A-Z]\w*(\[[^\]]+\])?)+)//i && do {
 	    my $id = $1;

--- a/utils/h2ph.PL
+++ b/utils/h2ph.PL
@@ -380,6 +380,18 @@ while (defined (my $file = next_file())) {
                 $_ =~ s/\b\/\*[^*]*\*+([^\/*][^*]*\*+)*\///;
 	    }
 	    $isatype{$1} = 1 if /typedef[^\{]*(?:\{[^\}]*\}[^\{]*)*[^\{]*\W(\w+)\s*;\s*$/;
+	} elsif (/^(?:struct|union)/) {
+	    # Add typedefs to '%isatype' so we can eliminate them later...
+	    until( /(?:struct|union)\s+(?:\w+)\s*(?:\{[^\}]*\}[^\{]*)*[^\{]*\s*;\s*$/ ) {
+		last unless defined ($next = next_line($file));
+		chomp $next;
+		# We don't really care about the contents; we just want the name
+                $next =~ s/\b\/\/.*//;
+		$next =~ s/^\s*#.*//;
+		$_ .= $next;
+                $_ =~ s/\b\/\*[^*]*\*+([^\/*][^*]*\*+)*\///;
+	    }
+	    $isatype{$1} = 1 if /(?:struct|union)\s+(\w+)\s*(?:\{[^\}]*\}[^\{]*)*[^\{]*\s*;\s*$/;
 	}
     }
     $Is_converted{$file} = 1;

--- a/utils/h2ph.PL
+++ b/utils/h2ph.PL
@@ -368,6 +368,18 @@ while (defined (my $file = next_file())) {
 	    $new =~ s/(["\\])/\\$1/g;       #"]);
 	    # now that's almost like a macro (we hope)
 	    EMIT($proto);
+	} elsif (/^typedef/) {
+	    # Add typedefs to '%isatype' so we can eliminate them later...
+	    until( /typedef[^\{]*(?:\{[^\}]*\}[^\{]*)*[^\{]*\W(?:\w+)?\s*;\s*$/ ) {
+		last unless defined ($next = next_line($file));
+		chomp $next;
+		# We don't really care about the contents; we just want the name
+                $next =~ s/\b\/\/.*//;
+		$next =~ s/^\s*#.*//;
+		$_ .= $next;
+                $_ =~ s/\b\/\*[^*]*\*+([^\/*][^*]*\*+)*\///;
+	    }
+	    $isatype{$1} = 1 if /typedef[^\{]*(?:\{[^\}]*\}[^\{]*)*[^\{]*\W(\w+)\s*;\s*$/;
 	}
     }
     $Is_converted{$file} = 1;
@@ -1020,6 +1032,10 @@ Doesn't handle complicated expressions built piecemeal, a la:
 
 Doesn't necessarily locate all of your C compiler's internally-defined
 symbols.
+
+Only recognizes C<typedef>s, etc. that were defined B<during this run> --
+meaning C<h2ph -r /usr/include> (recursive) will likely work better than
+trying to individually convert B<.h> files one-by-one.
 
 =cut
 

--- a/utils/h2ph.PL
+++ b/utils/h2ph.PL
@@ -903,6 +903,8 @@ DEFINE
 	float	=> $Config{intsize},
 	double	=> $Config{doublesize},
 	size_t	=> $Config{sizesize},
+
+	%sizeof,   # Allow scripts to extend/customize %sizeof
 );
 SIZEOF
 


### PR DESCRIPTION
In the spirit of, *"Just Because You Can't Do **Everything** Doesn't Mean You Can't Do ***\*ANYthing\****..."*

I've updated `utils/h2ph.PL` to work under recent versions of MacOS/Xcode:

- Track `typedef`, `struct`, and `union` definitions and add them to `%isatype` so we can eliminate them later
- Strip/quote `#if __has_include(<ptrcheck.h>)` angle brackets
- Generate a stub `%sizeof` from the default `%isatype` entries

FWIW, this was the Simplest Thing That Could Possibly Work™ to let me run:
```
cd /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
sudo h2ph -r -l .

perl -e 'require "sys/ioctl.ph"; ioctl(STDIN, TIOCSTI(), $_) for split "", "Hello, World!"'
```

If it's at all useful, hooray!  🤩