### PR TITLE
autodie: don't try to modify our files

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -326,7 +326,6 @@ cpan/autodie/t/skip.t
 cpan/autodie/t/string-eval-basic.t			autodie - Basic string eval test
 cpan/autodie/t/string-eval-leak.t			autodie - String eval leak test
 cpan/autodie/t/sysopen.t				autodie - sysopen tests
-cpan/autodie/t/touch_me
 cpan/autodie/t/truncate.t				autodie - File truncation tests
 cpan/autodie/t/unlink.t					autodie - Unlink system tests.
 cpan/autodie/t/user-context.t				autodie - Context changes for usersubs

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -164,6 +164,16 @@ use File::Glob qw(:case);
                 t/socket.t
                 t/system.t
                 t/no-all.t
+                ),
+            # removed by https://github.com/pjf/autodie/pull/120 below
+            qw( t/touch_me )
+        ],
+        'CUSTOMIZED' => [
+            # https://github.com/Perl/perl5/issues/21233
+            # https://github.com/pjf/autodie/pull/120
+            qw( t/chmod.t
+                t/chown.t
+                t/utime.t
                 )
         ],
     },

--- a/cpan/autodie/t/chmod.t
+++ b/cpan/autodie/t/chmod.t
@@ -4,6 +4,7 @@ use Test::More tests => 7;
 use constant NO_SUCH_FILE => "this_file_had_better_not_exist";
 use constant ERROR_REGEXP => qr{Can't chmod\(0755, '${\(NO_SUCH_FILE)}'\):};
 use constant SINGLE_DIGIT_ERROR_REGEXP => qr{Can't chmod\(0010, '${\(NO_SUCH_FILE)}'\):};
+use File::Temp qw(tempfile);
 use autodie;
 
 # This tests RT #50423, Debian #550462
@@ -16,9 +17,11 @@ eval { chmod(8, NO_SUCH_FILE); };
 isa_ok($@, 'autodie::exception', 'exception thrown for chmod');
 like($@, SINGLE_DIGIT_ERROR_REGEXP, "Message should include numeric mode in octal form");
 
-eval { chmod(0755, $0); };
-ok(! $@, "We can chmod ourselves just fine.");
+my ($fh, $filename) = tempfile;
 
-eval { chmod(0755, $0, NO_SUCH_FILE) };
+eval { chmod(0755, $filename); };
+ok(! $@, "We can chmod a file we own just fine.");
+
+eval { chmod(0755, $filename, NO_SUCH_FILE) };
 isa_ok($@, 'autodie::exception', 'chmod exception on any file failure.');
 is($@->return,1,"Confirm autodie on a 'true' chown failure.");

--- a/cpan/autodie/t/chown.t
+++ b/cpan/autodie/t/chown.t
@@ -3,6 +3,7 @@ use strict;
 use Test::More;
 use constant NO_SUCH_FILE => "this_file_had_better_not_exist";
 use autodie;
+use File::Temp qw(tempfile);
 
 if ($^O eq 'MSWin32') {
     plan skip_all => 'chown() seems to always succeed on Windows';
@@ -20,9 +21,11 @@ isa_ok($@, 'autodie::exception', 'exception thrown for chown');
 # should die if the return value is not equal to the number of arguments
 # minus two.
 
-eval { chown($<, -1, $0); };
-ok(! $@, "Can chown ourselves just fine.");
+my ($fh, $filename) = tempfile;
 
-eval { chown($<, -1, $0, NO_SUCH_FILE); };
+eval { chown($<, -1, $filename); };
+ok(! $@, "Can chown a file we own just fine.");
+
+eval { chown($<, -1, $filename, NO_SUCH_FILE); };
 isa_ok($@, 'autodie::exception', "Exception if ANY file changemode fails");
 is($@->return, 1, "Confirm we're dying on a 'true' chown failure.");

--- a/cpan/autodie/t/touch_me
+++ b/cpan/autodie/t/touch_me
@@ -1,2 +1,0 @@
-For testing utime.
-Contents of this file are irrelevant.

--- a/cpan/autodie/t/utime.t
+++ b/cpan/autodie/t/utime.t
@@ -6,19 +6,18 @@ use FindBin qw($Bin);
 use File::Spec;
 use constant TOUCH_ME     => File::Spec->catfile($Bin, 'touch_me');
 use autodie;
+use File::Temp qw(tempfile);
+
+my ($fh, $filename) = tempfile;
 
 eval { utime(undef, undef, NO_SUCH_FILE); };
 isa_ok($@, 'autodie::exception', 'exception thrown for utime');
 
-my($atime, $mtime) = (stat TOUCH_ME)[8, 9];
+my($atime, $mtime) = (stat $filename)[8, 9];
 
-eval { utime(undef, undef, TOUCH_ME); };
+eval { utime(undef, undef, $filename); };
 ok(! $@, "We can utime a file just fine.") or diag $@;
 
-eval { utime(undef, undef, NO_SUCH_FILE, TOUCH_ME); };
+eval { utime(undef, undef, NO_SUCH_FILE, $filename); };
 isa_ok($@, 'autodie::exception', 'utime exception on single failure.');
 is($@->return, 1, "utime fails correctly on a 'true' failure.");
-
-# Reset timestamps so that Git doesn't think the file has changed when
-# running the test in the core perl distribution.
-utime($atime, $mtime, TOUCH_ME);

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -17,5 +17,8 @@ Time::Piece cpan/Time-Piece/Piece.pm 8cec8b66183ceddb9bf2b6af35dcdd345bc9adfa
 Time::Piece cpan/Time-Piece/Piece.xs 543152540ee17788a638b2c5746b86c3d04401d1
 Win32API::File cpan/Win32API-File/File.pm 8fd212857f821cb26648878b96e57f13bf21b99e
 Win32API::File cpan/Win32API-File/File.xs beb870fed4490d2faa547b4a8576b8d64d1d27c5
+autodie cpan/autodie/t/chmod.t 9ffe40120c7cc53460e82afc2b932d750bebef76
+autodie cpan/autodie/t/chown.t 1d11ed28baffff171aa1ddfc1462989480b3833d
+autodie cpan/autodie/t/utime.t 27e7f1974b24890e9194167f6ca226e3c4c67e2f
 version cpan/version/lib/version.pm a963b513cf812bd7f4d28b3422efd9904e70a34c
 version cpan/version/t/07locale.t b1cceee71544ce6b6c926d06656a52aabbfe8abf


### PR DESCRIPTION
This caused two problems, the main one is that building perl with -Dmksymlinks, the tests would (try to) modify the original files, which would fail, failing the tests, if the original files weren't owned by the user running the tests.

It also caused noise from some git tools, though this wasn't usually a big problem.

PR upstream as pjf/autodie#120

Fixes #21233, pjf/autodie#107