### PR TITLE
Skip this test when .mailmap is not visible

### DIFF
--- a/t/porting/authors.t
+++ b/t/porting/authors.t
@@ -19,6 +19,10 @@ skip_all(
     "This is a shallow clone, this test requires history.")
   if (-e "$source_dir/.git/shallow");
 
+skip_all(
+    "Cannot locate .mailmap: GH#21272.")
+  unless (-f ".mailmap");
+
 my $revision_range = ''; # could use 'v5.22.0..' as default, no reason to recheck all previous commits...
 if ( $ENV{TRAVIS} && defined $ENV{TRAVIS_COMMIT_RANGE} ) {
 	# travisci is adding a merge commit when smoking a pull request


### PR DESCRIPTION
... which appears to be the case when you configure with -Dmksymlinks.

For: https://github.com/Perl/perl5/issues/21272 and https://www.nntp.perl.org/group/perl.perl5.porters/2023/06/msg266520.html

@doughera88 