### PR TITLE
t/porting/authors.t - make robust to -Dmksymlinks to a git checkout

### DIFF
--- a/Porting/updateAUTHORS.pl
+++ b/Porting/updateAUTHORS.pl
@@ -22,6 +22,7 @@ my @OPTSPEC= qw(
     man
     authors_file=s
     mailmap_file=s
+    source_dir=s
 
     validate|tap
     verbose+

--- a/t/porting/authors.t
+++ b/t/porting/authors.t
@@ -11,6 +11,7 @@ use TestInit qw(T);    # T is chdir to the top level
 use strict;
 
 my $source_dir = find_git_or_skip('all');
+
 skip_all(
     "This distro may have modified some files in cpan/. Skipping validation.")
   if $ENV{'PERL_BUILD_PACKAGING'};
@@ -42,5 +43,5 @@ elsif( $ENV{GITHUB_ACTIONS} && length $ENV{GITHUB_BASE_REF} ) {
         if $branch_head;
 }
 
-exec("$^X Porting/updateAUTHORS.pl --validate $revision_range");
+exec("$^X Porting/updateAUTHORS.pl --source_dir=$source_dir --validate $revision_range");
 # EOF


### PR DESCRIPTION
If someone configures with -Dmksymlinks to a git checkout t/porting/authors.t gets confused, and fails test. This teaches it and Porting/updateAUTHORS.p[lm] to handle this build scenario properly.

Fixes #21272
Replaces #21274