### PR TITLE
Improve docs for legacy forms of open

### DIFF
--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -4,7 +4,7 @@
 # Any changes made here will be lost!
 
 package feature;
-our $VERSION = '1.83';
+our $VERSION = '1.84';
 
 our %feature = (
     fc                      => 'feature_fc',
@@ -434,7 +434,7 @@ for the exceptions listed below.
 The perl built-in filehandles C<STDIN>, C<STDOUT>, C<STDERR>, C<DATA>,
 C<ARGV>, C<ARGVOUT> and the special C<_> are always enabled.
 
-This feature is enabled under this name from Perl 5.34 onwards.  In
+This feature is available under this name from Perl 5.34 onwards.  In
 previous versions it was simply on all the time.
 
 You can use the L<bareword::filehandles> module on CPAN to disable

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -5018,18 +5018,6 @@ New code should favor the three-argument form of C<open> over this older
 form. Declaring the mode and the filename as two distinct arguments
 avoids any confusion between the two.
 
-=item Calling C<open> with one argument via global variables
-
-As a shortcut, a one-argument call takes the filename from the global
-scalar variable of the same name as the filehandle:
-
-    $ARTICLE = 100;
-    open(ARTICLE)
-        or die "Can't find article $ARTICLE: $!\n";
-
-Here C<$ARTICLE> must be a global (package) scalar variable - not one
-declared with L<C<my>|/my VARLIST> or L<C<state>|/state VARLIST>.
-
 =item Assigning a filehandle to a bareword
 
 An older style is to use a bareword as the filehandle, as
@@ -5041,9 +5029,23 @@ Then you can use C<FH> as the filehandle, in C<< close FH >> and C<<
 <FH> >> and so on.  Note that it's a global variable, so this form is
 not recommended when dealing with filehandles other than Perl's built-in ones
 (e.g. STDOUT and STDIN).  In fact, using a bareword for the filehandle is
-an error when the C<bareword_filehandles> feature has been disabled.  This
-feature is disabled by default when in the scope of C<use v5.36.0> or later.
+an error when the
+L<C<"bareword_filehandles"> feature|feature/"The 'bareword_filehandles' feature">
+has been disabled.  This feature is disabled automatically when in the
+scope of C<use v5.36.0> or later.
 
+=item Calling C<open> with one argument via global variables
+
+As a shortcut, a one-argument call takes the filename from the global
+scalar variable of the same name as the bareword filehandle:
+
+    $ARTICLE = 100;
+    open(ARTICLE)
+        or die "Can't find article $ARTICLE: $!\n";
+
+Here C<$ARTICLE> must be a global scalar variable in the same package
+as the filehandle - not one declared with L<C<my>|/my VARLIST> or
+L<C<state>|/state VARLIST>.
 
 =back
 

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -502,7 +502,7 @@ read_only_bottom_close_and_rename($h);
 
 __END__
 package feature;
-our $VERSION = '1.83';
+our $VERSION = '1.84';
 
 FEATURES
 
@@ -855,7 +855,7 @@ for the exceptions listed below.
 The perl built-in filehandles C<STDIN>, C<STDOUT>, C<STDERR>, C<DATA>,
 C<ARGV>, C<ARGVOUT> and the special C<_> are always enabled.
 
-This feature is enabled under this name from Perl 5.34 onwards.  In
+This feature is available under this name from Perl 5.34 onwards.  In
 previous versions it was simply on all the time.
 
 You can use the L<bareword::filehandles> module on CPAN to disable


### PR DESCRIPTION
 - Link to the bareword_filehandles feature
 - Move one-arg open after global filehandles, since it's a
   special form of them
 - Mention that the scalar variable has to be in the same package
   as the filehandle

In passing, make the docs for `bareword_filehandles` consistent with other retroactive-and-then-disabled features.