### PR TITLE
Disable network tests in dist test jobs

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -805,6 +805,7 @@ jobs:
       AUTHOR_TESTING: 1
       AUTOMATED_TESTING: 1
       RELEASE_TESTING: 1
+      NO_NETWORK_TESTING: 1
 
     strategy:
       fail-fast: false
@@ -839,6 +840,7 @@ jobs:
       AUTHOR_TESTING: 1
       AUTOMATED_TESTING: 1
       RELEASE_TESTING: 1
+      NO_NETWORK_TESTING: 1
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Net::Ping disables its network tests under PERL_CORE, but these tests are testing the dists under dist/ on other versions of Perl, not as part of core.