### PR TITLE
universal.c - handle version style imports as a version check

### DIFF
--- a/t/test.pl
+++ b/t/test.pl
@@ -363,7 +363,8 @@ sub is ($$@) {
             my $p = 0;
             $p++ while substr($got,$p,1) eq substr($expected,$p,1);
             push @mess,"#  diff at $p\n";
-            push @mess,"#    after "._qq(substr($got,$p-40<0 ? 0 : $p-40,40))."\n";
+            push @mess,"#    after "._qq(substr($got,$p < 40 ? 0  : $p - 40,
+                                                     $p < 40 ? $p : 40)) . "\n";
             push @mess,"#     have "._qq(substr($got,$p,40))."\n";
             push @mess,"#     want "._qq(substr($expected,$p,40))."\n";
         }


### PR DESCRIPTION
if someone does

    use Thing 1.234;

it is interpreted as

    BEGIN {
        require Thing;
        Thing->import();
        Thing->VERSION(1.234);
    }

however in the case of

    use Thing "1.234";

we treat it as

    BEGIN {
        require Thing;
        Thing->import("1.234");
    }

however if people use Exporter::import() as their
importer then its import will turn such cases silently into

    Thing->VERSION("1.234")

anyway.

With the new logic to detect if someone has called into
UNIVERSAL::import() with an argument we were not discriminating between
the two cases.

This patch basically does the same thing that Exporter would.

Note this patch doesn't have tests right now, however it is being implicitly tested by various code in the cpan/ directory. I will add them later when i have more time. I wanted to get this pushed ASAP as the core point is causing issues in https://github.com/Perl/perl5/issues/21269 