### PR TITLE
Add # flag to deserving apidoc lines

### DIFF
--- a/pod/perlapio.pod
+++ b/pod/perlapio.pod
@@ -144,7 +144,7 @@ functions which call stdio. In this case I<only> PerlIO * is a FILE *.
 This has been the default implementation since the abstraction was
 introduced in perl5.003_02.
 
-=for apidoc Amnh||USE_STDIO
+=for apidoc Amnh#||USE_STDIO
 
 =item 2. USE_PERLIO
 

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -2970,7 +2970,7 @@ are needed for the XSUBs themselves, because the XS() macro is
 correctly defined to pass in the implicit context if needed.
 
 =for apidoc_section $concurrency
-=for apidoc AmnhU||PERL_NO_GET_CONTEXT
+=for apidoc AmnhU#||PERL_NO_GET_CONTEXT
 
 The third, even more efficient way is to ape how it is done within
 the Perl guts:


### PR DESCRIPTION
These symbols are just #defined (or not) and have no value.  The flag to autodoc.pl to indicate this is '#'