### PR TITLE
make sure "use VERSION;" sets the flag needed for "used only once"

### DIFF
--- a/op.c
+++ b/op.c
@@ -7907,8 +7907,10 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
             if (!(PL_hints & HINT_EXPLICIT_STRICT_VARS))
                 PL_hints |= HINT_STRICT_VARS;
 
-            if (shortver >= SHORTVER(5, 35))
+            if (shortver >= SHORTVER(5, 35)) {
                 free_and_set_cop_warnings(&PL_compiling, pWARN_ALL);
+                PL_dowarn |= G_WARN_ONCE;
+            }
         }
         /* otherwise they are off */
         else {

--- a/t/lib/warnings/gv
+++ b/t/lib/warnings/gv
@@ -292,3 +292,10 @@ if ($ㄒ) {
 EXPECT
 Name "팣칵ぇ::ʎ" used only once: possible typo at - line 11.
 Use of uninitialized value $팣칵ぇ::ʎ in print at - line 11.
+########
+# https://github.com/Perl/perl5/issues/21271
+use v5.36;
+no strict;
+my $x = $i;
+EXPECT
+Name "main::i" used only once: possible typo at - line 4.


### PR DESCRIPTION
There's two parts to producing the "used only once" warning:

1. In a lexical scope with WARN_ONCE enabled, new GVs are created with the GVf_MULTI flag off, a second mention of such a name will set that flag.

2. After compilation, if G_WARN_ONCE is set in PL_dowarn, the entire package tree is walked to report names which don't have GVf_MULTI set.

In this case G_WARN_ONCE wasn't being set, so the second part didn't happen.

This flag is global, so using any other module that happened to enable the WARN_ONCE flag (anything that does C<use warnings;>) would allow warnings to be produced after compilation.

Fixes #21271