### PR TITLE
perl.h: Add Debug statement to locale mutex lock

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -7107,6 +7107,9 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
                          __FILE__, __LINE__));                              \
                 MUTEX_LOCK(&PL_locale_mutex);                               \
                 PL_locale_mutex_depth = 1;                                  \
+                DEBUG_Lv(PerlIO_printf(Perl_debug_log,                      \
+                         "%s: %d: locale locked; depth=1\n",               \
+                         __FILE__, __LINE__));                              \
             }                                                               \
             else {                                                          \
                 PL_locale_mutex_depth++;                                    \


### PR DESCRIPTION
This is helpful in seeing when a thread hangs waiting for the mutex to be free.