### PR TITLE
Minor build fixes

### DIFF
--- a/Porting/sync-with-cpan
+++ b/Porting/sync-with-cpan
@@ -380,7 +380,7 @@ pause_for_input("\n");
 # in the way, or other issues that might come up if the user bails out of the sync
 # script and then runs it again.
 my $clean_out= `git clean -dfx $type_dir`; # use backticks to hide the output
-system git => 'checkout -f',
+system git => 'checkout', '-f',
               $type_dir,
               'MANIFEST',
               'Porting/Maintainers.pl'; # let the user see the output

--- a/t/test.pl
+++ b/t/test.pl
@@ -363,7 +363,8 @@ sub is ($$@) {
             my $p = 0;
             $p++ while substr($got,$p,1) eq substr($expected,$p,1);
             push @mess,"#  diff at $p\n";
-            push @mess,"#    after "._qq(substr($got,$p-40<0 ? 0 : $p-40,40))."\n";
+            push @mess,"#    after "._qq(substr($got,$p < 40 ? 0  : $p - 40,
+                                                     $p < 40 ? $p : 40)) . "\n";
             push @mess,"#     have "._qq(substr($got,$p,40))."\n";
             push @mess,"#     want "._qq(substr($expected,$p,40))."\n";
         }


### PR DESCRIPTION
Fix the string diff we provide in t/test.pl - if the difference in two strings occured before the 40th character we would duplicate the start of the string in our diagnostics output. 

Fix git checkout usage in sync-with-cpan. I think older gits would deal with an argument like 'checkout -f' and automatically split it, but in newer gits it would throw an error. At least on the git I use it produces an exception where it should be treated as two arguments, not one.