### PR TITLE
regexec.c - fix Clang compiler warning constant-logical-operand

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -3585,7 +3585,7 @@ S_reg_set_capture_string(pTHX_ REGEXP * const rx,
                     }
                     n++;
                 }
-                if ((PL_sawampersand & SAWAMPERSAND_RIGHT)
+                if ((PL_sawampersand & SAWAMPERSAND_RIGHT) > 0
                     && min >  RXp_OFFS_END(prog,0)
                 )
                     min = RXp_OFFS_END(prog,0);


### PR DESCRIPTION
This should fix the warning:

```
regexec.c:3465:21: error: use of logical '&&' with constant operand [-Werror,-Wconstant-logical-operand]
 3464 |                 if ((PL_sawampersand & SAWAMPERSAND_RIGHT)
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 3465 |                     && min >  prog->offs[0].end
      |                     ^
regexec.c:3465:21: note: use '&' for a bitwise operation
 3465 |                     && min >  prog->offs[0].end
      |                     ^~
      |                     &
regexec.c:3465:21: note: remove constant to silence this warning
```