### PR TITLE
regexec.c - restructure code that boils down to a constant conditional

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -3545,6 +3545,10 @@ S_reg_set_capture_string(pTHX_ REGEXP * const rx,
             SSize_t max = strend - strbeg;
             SSize_t sublen;
 
+            /* NOTE: the following if block is not used or tested
+             * in standard builds. It is only used when PERL_SAWAMPERSAND is
+             * defined */
+
             if (    (flags & REXEC_COPY_SKIP_POST)
                 && !(prog->extflags & RXf_PMf_KEEPCOPY) /* //p */
                 && !(PL_sawampersand & SAWAMPERSAND_RIGHT)
@@ -3567,6 +3571,9 @@ S_reg_set_capture_string(pTHX_ REGEXP * const rx,
                 assert(max >= 0 && max <= strend - strbeg);
             }
 
+            /* NOTE: the following if block is not used or tested
+             * in standard builds. It is only used when PERL_SAWAMPERSAND is
+             * defined */
             if (    (flags & REXEC_COPY_SKIP_PRE)
                 && !(prog->extflags & RXf_PMf_KEEPCOPY) /* //p */
                 && !(PL_sawampersand & SAWAMPERSAND_LEFT)
@@ -3577,7 +3584,7 @@ S_reg_set_capture_string(pTHX_ REGEXP * const rx,
                  * by a capture. Due to lookbehind, this may be to
                  * the left of $&, so we have to scan all captures */
                 while (min && n <= RXp_LASTPAREN(prog)) {
-                    I32 start = RXp_OFFS_START(prog,n);
+                    SSize_t start = RXp_OFFS_START(prog,n);
                     if (   start != -1
                         && start < min)
                     {
@@ -3585,11 +3592,11 @@ S_reg_set_capture_string(pTHX_ REGEXP * const rx,
                     }
                     n++;
                 }
-                if ((PL_sawampersand & SAWAMPERSAND_RIGHT)
-                    && min >  RXp_OFFS_END(prog,0)
-                )
-                    min = RXp_OFFS_END(prog,0);
-
+                if (PL_sawampersand & SAWAMPERSAND_RIGHT) {
+                    SSize_t end = RXp_OFFS_END(prog,0);
+                    if ( min > end )
+                        min = end;
+                }
             }
 
             assert(min >= 0 && min <= max && min <= strend - strbeg);


### PR DESCRIPTION
When PERL_SAWAMPERSAND is not defined then Pl_sawampersand is defined
to be (SAWAMPERSAND_LEFT|SAWAMPERSAND_MIDDLE|SAWAMPERSAND_RIGHT).
Which means that the clause in the first if block:

```
    && !(PL_sawampersand & SAWAMPERSAND_RIGHT)
```

and the clause in the second if block:

```
    && !(PL_sawampersand & SAWAMPERSAND_LEFT)
```

will never be true. Thus neither of these blocks will execute in a
normal build where PERL_SAWAMPERSAND is not defined.

Nevertheless some versions of Clang notice that a related expression
guarded by these clauses is also constant, and mixes '&' and '&&'
together and then warns about it:

```
    $ clang-17 ... regexec.c
    regexec.c:3589:21: warning: use of logical '&&' with constant operand
        [-Wconstant-logical-operand]
     3588 |                 if ((PL_sawampersand & SAWAMPERSAND_RIGHT)
          |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3589 |                     && min >  RXp_OFFS_END(prog,0)
          |                     ^
    regexec.c:3589:21: note: use '&' for a bitwise operation
     3589 |                     && min >  RXp_OFFS_END(prog,0)
          |                     ^~
          |                     &
    regexec.c:3589:21: note: remove constant to silence this warning
```

Restructuring the clauses into a nested if should fix this. Along the
way we fix a related I32/SSize_t mismatch, and eliminate an unnecessary
duplicate use of RXp_OFFS_END(prog,0) call, which these days is a more
complex and expensive macro than it once was.

Thanks to the github user @Logikable for calling this to our attention
with a different patch. See also https://github.com/Perl/perl5/pull/21296.

