### PR TITLE
Split out the parts of lib/builtin.t that require -T into a separate file

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5065,6 +5065,7 @@ lib/blib.pm				For "use blib"
 lib/blib.t				blib.pm test
 lib/builtin.pm				builtin function namespace
 lib/builtin.t				test builtin function namespace
+lib/builtin-taint.t			test builtin function namespace in taint mode
 lib/bytes.pm				Pragma to enable byte operations
 lib/bytes.t				bytes.pm test
 lib/bytes_heavy.pl			Support routines for byte pragma

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1451,6 +1451,7 @@ use File::Glob qw(:case);
                 lib/_charnames.pm
                 lib/blib.{pm,t}
                 lib/builtin.{pm,t}
+                lib/builtin-taint.t
                 lib/bytes.{pm,t}
                 lib/bytes_heavy.pl
                 lib/charnames.{pm,t}

--- a/lib/builtin-taint.t
+++ b/lib/builtin-taint.t
@@ -1,0 +1,40 @@
+#!./perl -T
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+}
+
+use v5.36;
+no warnings 'experimental::builtin';
+
+package FetchStoreCounter {
+    sub TIESCALAR($class, @args) { bless \@args, $class }
+
+    sub FETCH($self)    { $self->[0]->$*++ }
+    sub STORE($self, $) { $self->[1]->$*++ }
+}
+
+# is_tainted
+{
+    use builtin qw( is_tainted );
+
+    is(is_tainted($0), !!${^TAINT}, "\$0 is tainted (if tainting is supported)");
+    ok(!is_tainted($1), "\$1 isn't tainted");
+
+    # Invokes magic
+    tie my $tied, FetchStoreCounter => (\my $fetchcount, \my $storecount);
+
+    my $_dummy = is_tainted($tied);
+    is($fetchcount, 1, 'is_tainted() invokes FETCH magic');
+
+    $tied = is_tainted($0);
+    is($storecount, 1, 'is_tainted() invokes STORE magic');
+
+    is(prototype(\&builtin::is_tainted), '$', 'is_tainted prototype');
+}
+
+# vim: tabstop=4 shiftwidth=4 expandtab autoindent softtabstop=4
+
+done_testing();

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -1,4 +1,4 @@
-#!./perl -T
+#!./perl
 
 BEGIN {
     chdir 't' if -d 't';
@@ -364,25 +364,6 @@ TODO: {
 
     our $str2 = "\t\nHello world!\t  ";
     is(trim($str2), "Hello world!", "trim on an our \$var");
-}
-
-# is_tainted
-{
-    use builtin qw( is_tainted );
-
-    is(is_tainted($0), !!${^TAINT}, "\$0 is tainted (if tainting is supported)");
-    ok(!is_tainted($1), "\$1 isn't tainted");
-
-    # Invokes magic
-    tie my $tied, FetchStoreCounter => (\my $fetchcount, \my $storecount);
-
-    my $_dummy = is_tainted($tied);
-    is($fetchcount, 1, 'is_tainted() invokes FETCH magic');
-
-    $tied = is_tainted($0);
-    is($storecount, 1, 'is_tainted() invokes STORE magic');
-
-    is(prototype(\&builtin::is_tainted), '$', 'is_tainted prototype');
 }
 
 # Lexical export


### PR DESCRIPTION
Reduces the scope of files that have `-T` on them