### PR TITLE
autodoc: A config.h entry may not clash with perlintern

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -985,6 +985,10 @@ sub parse_config_h {
                 $configs{$name}{section} = $section;
                 last;
             }
+            elsif (exists $docs{'intern'}{$section}{$name}) {
+                die "'$name' is in 'config.h' meaning it is part of the API,\n"
+                  . " but it is also in 'perlintern', meaning it isn't API\n";
+            }
         }
 
         my $handled = 0;    # Haven't handled this yet


### PR DESCRIPTION
Something in config.h is considered to be API; whereas something in perlintern isn't.  die if this contradiction happens.