### PR TITLE
disable duplicate IRC bot notifications on #p5p

### DIFF
--- a/.github/workflows/irc-notifications.yaml
+++ b/.github/workflows/irc-notifications.yaml
@@ -1,5 +1,8 @@
 name: "Push Notification"
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, reopened, closed]
+  push:
 # add create for tracking tags
 
 # IRC colors: https://modern.ircdocs.horse/formatting.html
@@ -18,7 +21,9 @@ jobs:
       port: 7062
       channel_p5p: "#p5p"
       channel_noise: "#p5p-commits"
-      color_orange: "\x037"
+      color_green: "\x0303"
+      color_orange: "\x0307"
+      color_pink: "\x0313"
       color_clear: "\x0F"
 
     steps:
@@ -94,10 +99,10 @@ jobs:
           port: ${{ env.port }}
           channel: ${{ env.channel_noise }}
           nickname: Commit
-          message:
-            "\x037${{ github.actor }}\x0F pushed to branch \x033${{ env.ref }}\x0F\n\
-            ${{ env.SUMUP }}\n\
-            ${{ github.event.compare }}"
+          message: |-
+            ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} pushed to branch ${{ env.color_green }}${{ env.ref }}${{ env.color_clear }}
+            ${{ env.SUMUP }}
+            ${{ github.event.compare }}
 
       - name: irc push to blead
         uses: rectalogic/notify-irc@v2
@@ -107,10 +112,10 @@ jobs:
           port: ${{ env.port }}
           channel: ${{ env.channel_noise }}
           nickname: inBlead
-          message:
-            "\x0313[blead]\x0F \x037${{ github.actor }}\x0F pushed to blead\n\
-            ${{ env.SUMUP }}\n\
-            ${{ github.event.compare }}"
+          message: |-
+            ${{ env.color_pink }}[blead]${{ env.color_clear }} ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} pushed to blead
+            ${{ env.SUMUP }}
+            ${{ github.event.compare }}
 
       - name: Shorten PR fields
         if: github.event_name == 'pull_request'
@@ -150,39 +155,39 @@ jobs:
 
       - name: irc opened pull request
         uses: rectalogic/notify-irc@v2
-        if: github.event_name == 'pull_request' && github.event.action == 'opened'
+        if: vars.NOTIFY_IRC_P5P == 'true' && github.event_name == 'pull_request' && github.event.action == 'opened'
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
           channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
-          message: |
+          message: |-
             ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} opened PR #${{ github.event.pull_request.number }}
             ${{ env.TITLE }}
             ${{ github.event.pull_request.html_url }}
 
       - name: irc merged pull request
         uses: rectalogic/notify-irc@v2
-        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: vars.NOTIFY_IRC_P5P == 'true' && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
           channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
-          message: |
+          message: |-
             ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} merged PR #${{ github.event.pull_request.number }}
             ${{ env.TITLE }}
             ${{ github.event.pull_request.html_url }}
 
       - name: irc closed pull request
         uses: rectalogic/notify-irc@v2
-        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == false
+        if: vars.NOTIFY_IRC_P5P == 'true' && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == false
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
           channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
-          message: |
+          message: |-
             ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} closed PR #${{ github.event.pull_request.number }}
             ${{ env.TITLE }}
             ${{ github.event.pull_request.html_url }}
@@ -195,7 +200,7 @@ jobs:
           port: ${{ env.port }}
           channel: ${{ env.channel_noise }}
           nickname: Pull-Request
-          message: |
+          message: |-
             ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} updated PR #${{ github.event.pull_request.number }}
             ${{ env.TITLE }}
             ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Currently every new pull request generates seven lines of activity in irc.perl.org/#p5p that look like this:

    <botifico> [perl5] khwilliamson opened pull request #21302: autodoc: A config.h entry may not clash with perlintern - https://github.com/Perl/perl5/pull/21302
    -!- Pull-Request [~pull-requ@40.84.179.161] has joined #p5p
    <Pull-Request> khwilliamson opened PR #21302
    <Pull-Request> autodoc: A config.h entry may not clash with perlintern
    <Pull-Request> https://github.com/Perl/perl5/pull/21302
    <Pull-Request>
    -!- Pull-Request [~pull-requ@40.84.179.161] has left #p5p []

Six of those are redundant because botifico already handles everything, so comment them out to reduce noise.

(The "merged PR" and "closed PR" cases don't seem to work at all. At least I don't see them in the channel. And I'm not sure why there's an empty line in the output.)