### PR TITLE
Avoid g++ warnings from last-element initialisers in recently-added code

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -507,7 +507,8 @@ static const struct BuiltinFuncDescriptor builtins[] = {
     /* list functions */
     { "builtin::indexed", &XS_builtin_indexed, &ck_builtin_funcN, 0 },
     { "builtin::export_lexically", &XS_builtin_export_lexically, NULL, 0 },
-    { 0 }
+
+    { NULL, NULL, NULL, 0 }
 };
 
 XS(XS_builtin_import);

--- a/class.c
+++ b/class.c
@@ -570,7 +570,7 @@ static struct {
       .requires_value = true,
       .apply          = &apply_class_attribute_isa,
     },
-    {0}
+    { NULL, false, NULL }
 };
 
 static void
@@ -955,7 +955,7 @@ static struct {
       .requires_value = false,
       .apply          = &apply_field_attribute_param,
     },
-    {0}
+    { NULL, false, NULL }
 };
 
 static void


### PR DESCRIPTION
gcc was happy with this, but g++ complained

```
  builtin.c:511:1: warning: missing initializer for member ‘BuiltinFuncDescriptor::xsub’ [-Wmissing-field-initializers]
    511 | };
        | ^
```