### PR TITLE
hints/linux: Add additional expression when matching clang

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1158,6 +1158,7 @@ Randy Stauner                  <rwstauner@cpan.org>
 Randy W. Sims
 Raphael Manfredi               <Raphael.Manfredi@pobox.com>
 Raul Dias                      <raul@dias.com.br>
+Raul E Rangel                  <rrangel@chromium.org>
 Raymund Will                   <ray@caldera.de>
 Redvers Davies                 <red@criticalintegration.com>
 Reini Urban                    <rurban@cpan.org>

--- a/hints/linux.sh
+++ b/hints/linux.sh
@@ -166,7 +166,7 @@ esac
 if [ -x /usr/bin/gcc ] ; then
     gcc=/usr/bin/gcc
 # clang also provides -print-search-dirs
-elif ${cc:-cc} --version 2>/dev/null | grep -q '^clang ' ; then
+elif ${cc:-cc} --version 2>/dev/null | grep -q -e '^clang version' -e ' clang version'; then
     gcc=${cc:-cc}
 else
     gcc=gcc


### PR DESCRIPTION
Newer versions of clang actually print the distro before `clang` when
calling `$CC --version`. This changes fixes the regex so it can match
this new pattern.

i.e.,

	$ clang --version
	Debian clang version 14.0.6

	$ x86_64-pc-linux-gnu-clang --version
	Chromium OS 17.0_pre496208_p20230501-r1 clang version 17.0.0

Fixes #21099
