### PR TITLE
Fix static compilation regexp linking errors

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -290,6 +290,7 @@ S_edit_distance(const UV* src,
 /* END of edit_distance() stuff
  * ========================================================= */
 
+#ifdef PERL_RE_BUILD_AUX
 /* add a data member to the struct reg_data attached to this regex, it should
  * always return a non-zero return. the 's' argument is the type of the items
  * being added and the n is the number of items. The length of 's' should match
@@ -340,6 +341,7 @@ Perl_reg_add_data(RExC_state_t* const pRExC_state, const char* const s, const U3
     assert(count>0);
     return count;
 }
+#endif /* PERL_RE_BUILD_AUX */
 
 /*XXX: todo make this not included in a non debugging perl, but appears to be
  * used anyway there, in 'use re' */
@@ -7443,6 +7445,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
 }
 
 
+#ifdef PERL_RE_BUILD_AUX
 void
 Perl_populate_anyof_bitmap_from_invlist(pTHX_ regnode *node, SV** invlist_ptr)
 {
@@ -7502,6 +7505,7 @@ Perl_populate_anyof_bitmap_from_invlist(pTHX_ regnode *node, SV** invlist_ptr)
         }
     }
 }
+#endif /* PERL_RE_BUILD_AUX */
 
 /* Parse POSIX character classes: [[:foo:]], [[=foo=]], [[.foo.]].
    Character classes ([:foo:]) can also be negated ([:^foo:]).
@@ -9095,6 +9099,7 @@ S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state,
 #undef IS_OPERATOR
 #undef IS_OPERAND
 
+#ifdef PERL_RE_BUILD_AUX
 void
 Perl_add_above_Latin1_folds(pTHX_ RExC_state_t *pRExC_state, const U8 cp, SV** invlist)
 {
@@ -9182,6 +9187,8 @@ Perl_add_above_Latin1_folds(pTHX_ RExC_state_t *pRExC_state, const U8 cp, SV** i
          }
     }
 }
+#endif /* PERL_RE_BUILD_AUX */
+
 
 STATIC void
 S_output_posix_warnings(pTHX_ RExC_state_t *pRExC_state, AV* posix_warnings)
@@ -12105,6 +12112,7 @@ S_optimize_regclass(pTHX_
 
 #undef HAS_NONLOCALE_RUNTIME_PROPERTY_DEFINITION
 
+#ifdef PERL_RE_BUILD_AUX
 void
 Perl_set_ANYOF_arg(pTHX_ RExC_state_t* const pRExC_state,
                 regnode* const node,
@@ -12261,6 +12269,7 @@ Perl_set_ANYOF_arg(pTHX_ RExC_state_t* const pRExC_state,
     RExC_rxi->data->data[n] = (void*)rv;
     ARG1u_SET(node, n);
 }
+#endif /* PERL_RE_BUILD_AUX */
 
 SV *
 
@@ -12999,6 +13008,8 @@ S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p,
 }
 #endif
 
+
+#ifdef PERL_RE_BUILD_AUX
 SV*
 Perl_get_ANYOFM_contents(pTHX_ const regnode * n) {
 
@@ -13047,7 +13058,7 @@ Perl_get_ANYOFHbbm_contents(pTHX_ const regnode * n) {
                                       UTF_CONTINUATION_MARK | 0));
     return cp_list;
 }
-
+#endif /* PERL_RE_BUILD_AUX */
 
 
 SV *

--- a/regcomp.h
+++ b/regcomp.h
@@ -1554,7 +1554,19 @@ typedef enum {
 #define EVAL_OPTIMISTIC_FLAG    128
 #define EVAL_FLAGS_MASK         (EVAL_OPTIMISTIC_FLAG-1)
 
-
+/* We define PERL_RE_BUILD_DEBUG if we are NOT compiling the re extension and
+ * we are under DEBUGGING, or if we are ARE compiling the re extension
+ * and this is not a DEBUGGING enabled build (identified by
+ * DEBUGGING_RE_ONLY being defined)
+ */
+#if ( defined(USE_DYNAMIC_LOADING) && defined(DEBUGGING)) || \
+    ( defined(PERL_EXT_RE_BUILD) && defined(DEBUGGING_RE_ONLY)) || \
+    (!defined(PERL_EXT_RE_BUILD) && defined(DEBUGGING))
+#define PERL_RE_BUILD_DEBUG
+#endif
+#if ( defined(USE_DYNAMIC_LOADING) || !defined(PERL_EXT_RE_BUILD) )
+#define PERL_RE_BUILD_AUX
+#endif
 
 #endif /* PERL_REGCOMP_H_ */
 

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -18,8 +18,7 @@
 #include "unicode_constants.h"
 #include "regcomp_internal.h"
 
-#ifdef DEBUGGING
-
+#ifdef PERL_RE_BUILD_DEBUG
 int
 Perl_re_printf(pTHX_ const char *fmt, ...)
 {
@@ -159,13 +158,160 @@ Perl_debug_peep(pTHX_ const char *str, const RExC_state_t *pRExC_state,
    });
 }
 
-#endif /* DEBUGGING */
+const regnode *
+Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
+            const regnode *last, const regnode *plast,
+            SV* sv, I32 indent, U32 depth)
+{
+    const regnode *next;
+    const regnode *optstart= NULL;
+
+    RXi_GET_DECL(r, ri);
+    DECLARE_AND_GET_RE_DEBUG_FLAGS;
+
+    PERL_ARGS_ASSERT_DUMPUNTIL;
+
+#ifdef DEBUG_DUMPUNTIL
+    Perl_re_printf( aTHX_  "--- %d : %d - %d - %d\n", indent, node-start,
+        last ? last-start : 0, plast ? plast-start : 0);
+#endif
+
+    if (plast && plast < last)
+        last= plast;
+
+    while (node && (!last || node < last)) {
+        const U8 op = OP(node);
+
+        if (op == CLOSE || op == SRCLOSE || op == WHILEM)
+            indent--;
+        next = regnext((regnode *)node);
+        const regnode *after = regnode_after((regnode *)node,0);
+
+        /* Where, what. */
+        if (op == OPTIMIZED) {
+            if (!optstart && RE_DEBUG_FLAG(RE_DEBUG_COMPILE_OPTIMISE))
+                optstart = node;
+            else
+                goto after_print;
+        } else
+            CLEAR_OPTSTART;
+
+        regprop(r, sv, node, NULL, NULL);
+        Perl_re_printf( aTHX_  "%4" IVdf ":%*s%s", (IV)(node - start),
+                      (int)(2*indent + 1), "", SvPVX_const(sv));
+
+        if (op != OPTIMIZED) {
+            if (next == NULL)           /* Next ptr. */
+                Perl_re_printf( aTHX_  " (0)");
+            else if (REGNODE_TYPE(op) == BRANCH
+                     && REGNODE_TYPE(OP(next)) != BRANCH )
+                Perl_re_printf( aTHX_  " (FAIL)");
+            else
+                Perl_re_printf( aTHX_  " (%" IVdf ")", (IV)(next - start));
+            Perl_re_printf( aTHX_ "\n");
+        }
+
+      after_print:
+        if (REGNODE_TYPE(op) == BRANCHJ) {
+            assert(next);
+            const regnode *nnode = (OP(next) == LONGJMP
+                                   ? regnext((regnode *)next)
+                                   : next);
+            if (last && nnode > last)
+                nnode = last;
+            DUMPUNTIL(after, nnode);
+        }
+        else if (REGNODE_TYPE(op) == BRANCH) {
+            assert(next);
+            DUMPUNTIL(after, next);
+        }
+        else if ( REGNODE_TYPE(op)  == TRIE ) {
+            const regnode *this_trie = node;
+            const U32 n = ARG1u(node);
+            const reg_ac_data * const ac = op>=AHOCORASICK ?
+               (reg_ac_data *)ri->data->data[n] :
+               NULL;
+            const reg_trie_data * const trie =
+                (reg_trie_data*)ri->data->data[op<AHOCORASICK ? n : ac->trie];
+#ifdef DEBUGGING
+            AV *const trie_words
+                           = MUTABLE_AV(ri->data->data[n + TRIE_WORDS_OFFSET]);
+#endif
+            const regnode *nextbranch= NULL;
+            I32 word_idx;
+            SvPVCLEAR(sv);
+            for (word_idx= 0; word_idx < (I32)trie->wordcount; word_idx++) {
+                SV ** const elem_ptr = av_fetch_simple(trie_words, word_idx, 0);
+
+                Perl_re_indentf( aTHX_  "%s ",
+                    indent+3,
+                    elem_ptr
+                    ? pv_pretty(sv, SvPV_nolen_const(*elem_ptr),
+                                SvCUR(*elem_ptr), PL_dump_re_max_len,
+                                PL_colors[0], PL_colors[1],
+                                (SvUTF8(*elem_ptr)
+                                 ? PERL_PV_ESCAPE_UNI
+                                 : 0)
+                                | PERL_PV_PRETTY_ELLIPSES
+                                | PERL_PV_PRETTY_LTGT
+                            )
+                    : "???"
+                );
+                if (trie->jump) {
+                    U16 dist= trie->jump[word_idx+1];
+                    Perl_re_printf( aTHX_  "(%" UVuf ")\n",
+                               (UV)((dist ? this_trie + dist : next) - start));
+                    if (dist) {
+                        if (!nextbranch)
+                            nextbranch= this_trie + trie->jump[0];
+                        DUMPUNTIL(this_trie + dist, nextbranch);
+                    }
+                    if (nextbranch && REGNODE_TYPE(OP(nextbranch))==BRANCH)
+                        nextbranch= regnext((regnode *)nextbranch);
+                } else {
+                    Perl_re_printf( aTHX_  "\n");
+                }
+            }
+            if (last && next > last)
+                node= last;
+            else
+                node= next;
+        }
+        else if ( op == CURLY ) {   /* "next" might be very big: optimizer */
+            DUMPUNTIL(after, after + 1); /* +1 is NOT a REGNODE_AFTER */
+        }
+        else if (REGNODE_TYPE(op) == CURLY && op != CURLYX) {
+            assert(next);
+            DUMPUNTIL(after, next);
+        }
+        else if ( op == PLUS || op == STAR) {
+            DUMPUNTIL(after, after + 1); /* +1 NOT a REGNODE_AFTER */
+        }
+        else if (REGNODE_TYPE(op) == EXACT || op == ANYOFHs) {
+            /* Literal string, where present. */
+            node = (const regnode *)REGNODE_AFTER_varies(node);
+        }
+        else {
+            node = REGNODE_AFTER_opcode(node,op);
+        }
+        if (op == CURLYX || op == OPEN || op == SROPEN)
+            indent++;
+        if (REGNODE_TYPE(op) == END)
+            break;
+    }
+    CLEAR_OPTSTART;
+#ifdef DEBUG_DUMPUNTIL
+    Perl_re_printf( aTHX_  "--- %d\n", (int)indent);
+#endif
+    return node;
+}
+
+#endif  /* PERL_RE_BUILD_DEBUG */
 
 /*
  - regdump - dump a regexp onto Perl_debug_log in vaguely comprehensible form
  */
 #ifdef DEBUGGING
-
 static void
 S_regdump_intflags(pTHX_ const char *lead, const U32 flags)
 {
@@ -907,8 +1053,8 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
 #endif  /* DEBUGGING */
 }
 
-#ifdef DEBUGGING
 
+#ifdef DEBUGGING
 STATIC void
 S_put_code_point(pTHX_ SV *sv, UV c)
 {
@@ -1517,154 +1663,4 @@ S_put_charclass_bitmap_innards(pTHX_ SV *sv,
 
     return did_output_something;
 }
-
-
-const regnode *
-Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
-            const regnode *last, const regnode *plast,
-            SV* sv, I32 indent, U32 depth)
-{
-    const regnode *next;
-    const regnode *optstart= NULL;
-
-    RXi_GET_DECL(r, ri);
-    DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_DUMPUNTIL;
-
-#ifdef DEBUG_DUMPUNTIL
-    Perl_re_printf( aTHX_  "--- %d : %d - %d - %d\n", indent, node-start,
-        last ? last-start : 0, plast ? plast-start : 0);
-#endif
-
-    if (plast && plast < last)
-        last= plast;
-
-    while (node && (!last || node < last)) {
-        const U8 op = OP(node);
-
-        if (op == CLOSE || op == SRCLOSE || op == WHILEM)
-            indent--;
-        next = regnext((regnode *)node);
-        const regnode *after = regnode_after((regnode *)node,0);
-
-        /* Where, what. */
-        if (op == OPTIMIZED) {
-            if (!optstart && RE_DEBUG_FLAG(RE_DEBUG_COMPILE_OPTIMISE))
-                optstart = node;
-            else
-                goto after_print;
-        } else
-            CLEAR_OPTSTART;
-
-        regprop(r, sv, node, NULL, NULL);
-        Perl_re_printf( aTHX_  "%4" IVdf ":%*s%s", (IV)(node - start),
-                      (int)(2*indent + 1), "", SvPVX_const(sv));
-
-        if (op != OPTIMIZED) {
-            if (next == NULL)           /* Next ptr. */
-                Perl_re_printf( aTHX_  " (0)");
-            else if (REGNODE_TYPE(op) == BRANCH
-                     && REGNODE_TYPE(OP(next)) != BRANCH )
-                Perl_re_printf( aTHX_  " (FAIL)");
-            else
-                Perl_re_printf( aTHX_  " (%" IVdf ")", (IV)(next - start));
-            Perl_re_printf( aTHX_ "\n");
-        }
-
-      after_print:
-        if (REGNODE_TYPE(op) == BRANCHJ) {
-            assert(next);
-            const regnode *nnode = (OP(next) == LONGJMP
-                                   ? regnext((regnode *)next)
-                                   : next);
-            if (last && nnode > last)
-                nnode = last;
-            DUMPUNTIL(after, nnode);
-        }
-        else if (REGNODE_TYPE(op) == BRANCH) {
-            assert(next);
-            DUMPUNTIL(after, next);
-        }
-        else if ( REGNODE_TYPE(op)  == TRIE ) {
-            const regnode *this_trie = node;
-            const U32 n = ARG1u(node);
-            const reg_ac_data * const ac = op>=AHOCORASICK ?
-               (reg_ac_data *)ri->data->data[n] :
-               NULL;
-            const reg_trie_data * const trie =
-                (reg_trie_data*)ri->data->data[op<AHOCORASICK ? n : ac->trie];
-#ifdef DEBUGGING
-            AV *const trie_words
-                           = MUTABLE_AV(ri->data->data[n + TRIE_WORDS_OFFSET]);
-#endif
-            const regnode *nextbranch= NULL;
-            I32 word_idx;
-            SvPVCLEAR(sv);
-            for (word_idx= 0; word_idx < (I32)trie->wordcount; word_idx++) {
-                SV ** const elem_ptr = av_fetch_simple(trie_words, word_idx, 0);
-
-                Perl_re_indentf( aTHX_  "%s ",
-                    indent+3,
-                    elem_ptr
-                    ? pv_pretty(sv, SvPV_nolen_const(*elem_ptr),
-                                SvCUR(*elem_ptr), PL_dump_re_max_len,
-                                PL_colors[0], PL_colors[1],
-                                (SvUTF8(*elem_ptr)
-                                 ? PERL_PV_ESCAPE_UNI
-                                 : 0)
-                                | PERL_PV_PRETTY_ELLIPSES
-                                | PERL_PV_PRETTY_LTGT
-                            )
-                    : "???"
-                );
-                if (trie->jump) {
-                    U16 dist= trie->jump[word_idx+1];
-                    Perl_re_printf( aTHX_  "(%" UVuf ")\n",
-                               (UV)((dist ? this_trie + dist : next) - start));
-                    if (dist) {
-                        if (!nextbranch)
-                            nextbranch= this_trie + trie->jump[0];
-                        DUMPUNTIL(this_trie + dist, nextbranch);
-                    }
-                    if (nextbranch && REGNODE_TYPE(OP(nextbranch))==BRANCH)
-                        nextbranch= regnext((regnode *)nextbranch);
-                } else {
-                    Perl_re_printf( aTHX_  "\n");
-                }
-            }
-            if (last && next > last)
-                node= last;
-            else
-                node= next;
-        }
-        else if ( op == CURLY ) {   /* "next" might be very big: optimizer */
-            DUMPUNTIL(after, after + 1); /* +1 is NOT a REGNODE_AFTER */
-        }
-        else if (REGNODE_TYPE(op) == CURLY && op != CURLYX) {
-            assert(next);
-            DUMPUNTIL(after, next);
-        }
-        else if ( op == PLUS || op == STAR) {
-            DUMPUNTIL(after, after + 1); /* +1 NOT a REGNODE_AFTER */
-        }
-        else if (REGNODE_TYPE(op) == EXACT || op == ANYOFHs) {
-            /* Literal string, where present. */
-            node = (const regnode *)REGNODE_AFTER_varies(node);
-        }
-        else {
-            node = REGNODE_AFTER_opcode(node,op);
-        }
-        if (op == CURLYX || op == OPEN || op == SROPEN)
-            indent++;
-        if (REGNODE_TYPE(op) == END)
-            break;
-    }
-    CLEAR_OPTSTART;
-#ifdef DEBUG_DUMPUNTIL
-    Perl_re_printf( aTHX_  "--- %d\n", (int)indent);
-#endif
-    return node;
-}
-
-#endif  /* DEBUGGING */
+#endif /* DEBUGGING */

--- a/regcomp_invlist.c
+++ b/regcomp_invlist.c
@@ -18,7 +18,7 @@
 #include "unicode_constants.h"
 #include "regcomp_internal.h"
 
-
+#ifdef PERL_RE_BUILD_AUX
 void
 Perl_populate_bitmap_from_invlist(pTHX_ SV * invlist, const UV offset, const U8 * bitmap, const Size_t len)
 {
@@ -70,6 +70,7 @@ Perl_populate_invlist_from_bitmap(pTHX_ const U8 * bitmap, const Size_t bitmap_l
         }
     }
 }
+#endif /* PERL_RE_BUILD_AUX */
 
 /* This section of code defines the inversion list object and its methods.  The
  * interfaces are highly subject to change, so as much as possible is static to

--- a/regexec.c
+++ b/regexec.c
@@ -4428,7 +4428,8 @@ S_regtry(pTHX_ regmatch_info *reginfo, char **startposp)
 */
 #define REPORT_CODE_OFF 29
 #define INDENT_CHARS(depth) ((int)(depth) % 20)
-#ifdef DEBUGGING
+
+#ifdef PERL_RE_BUILD_DEBUG
 int
 Perl_re_exec_indentf(pTHX_ const char *fmt, U32 depth, ...)
 {

--- a/t/op/goto.t
+++ b/t/op/goto.t
@@ -11,6 +11,7 @@ BEGIN {
 
 use warnings;
 use strict;
+use Config;
 plan tests => 133;
 our $TODO;
 
@@ -909,6 +910,7 @@ is $@,'', 'goto the first parameter of a binary expression [perl #132854]';
 SKIP:
 {
     skip "No XS::APItest in miniperl", 6 if is_miniperl();
+    skip "No XS::APItest in static perl", 6 if not $Config{usedl};
 
     require XS::APItest;
 
@@ -939,6 +941,7 @@ SKIP:
 SKIP:
 {
     skip "No XS::APItest in miniperl", 2 if is_miniperl();
+    skip "No XS::APItest in static perl", 2 if not $Config{usedl};
 
     # utf8::is_utf8() is just an example of an XS sub
     sub foo_19936 { *foo_19936 = {}; goto &utf8::is_utf8 }

--- a/t/porting/test_testlist.t
+++ b/t/porting/test_testlist.t
@@ -50,7 +50,7 @@ sub get_extensions {
                 $name = "PathTools" if $name eq "Cwd";
                 $name = "Scalar/List/Utils" if $name eq "List/Util";
                 my $sub_dir = $name;
-                $sub_dir =~ s!/!-!g;
+                $sub_dir =~ s!/!-!g unless $sub_dir =~ /^Encode/;
                 foreach my $dir (qw(cpan dist ext)) {
                     if (-e "$dir/$sub_dir") {
                         $extensions{"$dir/$sub_dir"} = $name;


### PR DESCRIPTION
This aims to fix #21319, but has some failing `use re 'strict'` tests that I can't quite explain.

Possibly @demerphq needs to look at it since it seems to involve 85900e28cc250e1c4603f11073b77d0c6b5cff46