### PR TITLE
Add note to `use strict` about enabling via `use VERSION`

### DIFF
--- a/lib/strict.pm
+++ b/lib/strict.pm
@@ -182,4 +182,10 @@ As of version 1.04 (Perl 5.10), strict verifies that it is used as
 "strict" to avoid the dreaded Strict trap on case insensitive file
 systems.
 
+Beginning with Perl 5.12, use of "use VERSION" (where VERSION >= 5.11.0) now
+lexically enables strictures just like "use strict" (in addition to the normal
+"use VERSION" effects and features.)  In other words, "use v5.011" or higher
+now implies "use strict" automatically, as noted in
+L<perl5120delta/"Implicit strictures"> and L<C<use VERSION>|perlfunc/use VERSION>.
+
 =cut


### PR DESCRIPTION
`use VERSION` (where VERSION >= 5.11.0) automatically enables `use strict` - this edit adds a note to the HISTORY section indicating the change.