### PR TITLE
Deëxperiment most of the `builtin` functions

### DIFF
--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -1,4 +1,4 @@
-package builtin 0.008;
+package builtin 0.009;
 
 use strict;
 use warnings;
@@ -40,12 +40,9 @@ can be requested for convenience.
 Individual named functions can be imported by listing them as import
 parameters on the C<use> statement for this pragma.
 
-The overall C<builtin> mechanism, as well as every individual function it
-provides, are currently B<experimental>.
-
-B<Warning>:  At present, the entire C<builtin> namespace is experimental.
-Calling functions in it will trigger warnings of the C<experimental::builtin>
-category.
+B<Warning>:  At present, many of the functions in the C<builtin> namespace are
+experimental.  Calling them will trigger warnings of the
+C<experimental::builtin> category.
 
 =head2 Lexical Import
 
@@ -105,6 +102,8 @@ This gives an equivalent value to expressions like C<!!0> or C<!1>.
 =head2 is_bool
 
     $bool = is_bool($val);
+
+This function is currently B<experimental>.
 
 Returns true when given a distinguished boolean value, or false if not. A
 distinguished boolean value is the result of any boolean-returning builtin
@@ -167,6 +166,8 @@ C<ARRAY> for array references, or C<HASH> for hash references.
 
     $bool = created_as_string($val);
 
+This function is currently B<experimental>.
+
 Returns a boolean representing if the argument value was originally created as
 a string. It will return true for any scalar expression whose most recent
 assignment or modification was of a string-like nature - such as assignment
@@ -187,6 +188,8 @@ strings. For example
 =head2 created_as_number
 
     $bool = created_as_number($val);
+
+This function is currently B<experimental>.
 
 Returns a boolean representing if the argument value was originally created as
 a number. It will return true for any scalar expression whose most recent
@@ -292,6 +295,8 @@ Returns true when given a tainted variable.
 =head2 export_lexically
 
     export_lexically($name1, $ref1, $name2, $ref2, ...)
+
+This function is currently B<experimental>.
 
 Exports new lexical names into the scope currently being compiled. Names given
 by the first of each pair of values will refer to the corresponding item whose

--- a/pod/perlexperiment.pod
+++ b/pod/perlexperiment.pod
@@ -178,8 +178,8 @@ Using this feature triggers warnings in the category C<experimental::builtin>.
 
 In Perl 5.36.0, a new namespace, C<builtin>, was created for new core functions
 that will not be present in every namespace, but will be available for
-importing.  The namespace itself is considered an experiment.  Specific
-functions within it may also be experimental.
+importing.  The namespace itself was considered experimental until Perl 5.39.2.
+Some specific functions within it remain experimental.
 
 The ticket for this experiment is
 L<[perl #19764]|https://github.com/Perl/perl5/issues/19764>.

--- a/t/lib/warnings/builtin
+++ b/t/lib/warnings/builtin
@@ -27,14 +27,8 @@ $true->();
 $false->();
 EXPECT
 Built-in function 'builtin::is_bool' is experimental at - line 6.
-Built-in function 'builtin::true' is experimental at - line 7.
-Built-in function 'builtin::false' is experimental at - line 8.
 Built-in function 'builtin::is_bool' is experimental at - line 9.
-Built-in function 'builtin::true' is experimental at - line 10.
-Built-in function 'builtin::false' is experimental at - line 11.
 Built-in function 'builtin::is_bool' is experimental at - line 12.
-Built-in function 'builtin::true' is experimental at - line 13.
-Built-in function 'builtin::false' is experimental at - line 14.
 ########
 # builtin.c - weakrefs
 use strict;
@@ -62,15 +56,6 @@ $is_weak->($ref);
 $weaken->($ref);
 $unweaken->($ref);
 EXPECT
-Built-in function 'builtin::is_weak' is experimental at - line 7.
-Built-in function 'builtin::weaken' is experimental at - line 8.
-Built-in function 'builtin::unweaken' is experimental at - line 9.
-Built-in function 'builtin::is_weak' is experimental at - line 10.
-Built-in function 'builtin::weaken' is experimental at - line 11.
-Built-in function 'builtin::unweaken' is experimental at - line 12.
-Built-in function 'builtin::is_weak' is experimental at - line 13.
-Built-in function 'builtin::weaken' is experimental at - line 14.
-Built-in function 'builtin::unweaken' is experimental at - line 15.
 ########
 # builtin.c - blessed refs
 use strict;
@@ -98,15 +83,6 @@ $blessed->($ref);
 $refaddr->($ref);
 $reftype->($ref);
 EXPECT
-Built-in function 'builtin::blessed' is experimental at - line 7.
-Built-in function 'builtin::refaddr' is experimental at - line 8.
-Built-in function 'builtin::reftype' is experimental at - line 9.
-Built-in function 'builtin::blessed' is experimental at - line 10.
-Built-in function 'builtin::refaddr' is experimental at - line 11.
-Built-in function 'builtin::reftype' is experimental at - line 12.
-Built-in function 'builtin::blessed' is experimental at - line 13.
-Built-in function 'builtin::refaddr' is experimental at - line 14.
-Built-in function 'builtin::reftype' is experimental at - line 15.
 ########
 # builtin.c - indexed
 use strict;
@@ -116,8 +92,5 @@ my @array = indexed 1..3;
 my $scalar = indexed 1..3;
 indexed 1..3;
 EXPECT
-Built-in function 'builtin::indexed' is experimental at - line 5.
-Built-in function 'builtin::indexed' is experimental at - line 6.
-Built-in function 'builtin::indexed' is experimental at - line 7.
 Useless use of builtin::indexed in scalar context at - line 6.
 Useless use of builtin::indexed in void context at - line 7.


### PR DESCRIPTION
This PR removes the experimental status and associated `experimental::builtin` warning from *most* of the functions in the `builtin::` space.

I have been somewhat conservative in which functions to downgrade and which remain. The now-stable functions are the true/false constants, the weakref and reference query functions (copied from `Scalar::Util`), the numercal rounding functions, `indexed` and `trim`.

Still remaining experimental are:

 * `is_bool` - because stable boolean tracking was only recently introduced and may not have been thoroughly tested yet
 * `created_as_string`, `created_as_number` - similar
 * `export_lexically` - because lexical export of subs is equally still quite new and may need more testing

See also https://github.com/Perl/perl5/issues/19764