### PR TITLE
Set errno when my_strftime() fails.

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -5793,6 +5793,7 @@ the program, giving results based on that locale.
      * platforms an invalid conversion specifier '%?' (for all illegal '?') is
      * treated as a literal, but others may fail when '?' is illegal */
     Safefree(buf);
+    SET_EINVAL;
     return NULL;
 
   strftime_success:


### PR DESCRIPTION
The libc strftime() doesn't have any way to distinguish between erroneous input and that which just doesn't generate any output; hence it doesn't set errno.

But my_strftime() has logic to reasonably confidently make that distinction, so it should set errno when it determines that it is erroneous input.