### PR TITLE
locale.c: debug with aTHX

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -276,13 +276,14 @@
  * initialization.  This is done before option parsing, and before any thread
  * creation, so can be a file-level static.  (Must come before #including
  * perl.h) */
+#include "config.h"
 #ifdef DEBUGGING
 static int debug_initialization = 0;
 #  define DEBUG_INITIALIZATION_set(v) (debug_initialization = v)
 #  define DEBUG_LOCALE_INITIALIZATION_  debug_initialization
-#  ifdef USE_LOCALE_THREADS
+#  if defined(USE_ITHREADS) && ! defined(NO_LOCALE_THREADS)
 #    define DEBUG_PRE_STMTS                                                     \
-     dSAVE_ERRNO; dTHX; PerlIO_printf(Perl_debug_log,"\n%s: %" LINE_Tf ": %p: ",\
+     dSAVE_ERRNO; dTHX; PerlIO_printf(Perl_debug_log,"\n%s: %" LINE_Tf ": 0x%p: ",\
                                       __FILE__, (line_t)__LINE__, aTHX);
 #  else
 #    define DEBUG_PRE_STMTS                                                     \


### PR DESCRIPTION
This commit automatically adds an aTHX element to debugging statements in this file.  I found this quite useful when debugging locale behavior in threaded perls.  

It would be better to use the thread id, but I don't know how to get that efficiently from C..