### PR TITLE
Add boolean cast to ndbm_EXISTS

### DIFF
--- a/ext/NDBM_File/NDBM_File.pm
+++ b/ext/NDBM_File/NDBM_File.pm
@@ -7,7 +7,7 @@ require Tie::Hash;
 require XSLoader;
 
 our @ISA = qw(Tie::Hash);
-our $VERSION = "1.16";
+our $VERSION = "1.17";
 
 XSLoader::load();
 

--- a/ext/NDBM_File/NDBM_File.xs
+++ b/ext/NDBM_File/NDBM_File.xs
@@ -97,7 +97,7 @@ ndbm_FETCH(db, key)
 	NDBM_File	db
 	datum_key	key
 
-#define ndbm_EXISTS(db,key)			dbm_fetch(db->dbp,key).dptr
+#define ndbm_EXISTS(db,key)			cBOOL(dbm_fetch(db->dbp,key).dptr)
 bool
 ndbm_EXISTS(db, key)
 	NDBM_File	db


### PR DESCRIPTION
The AIX compiler yields a warning when assigning the void* from dbm_fetch(...).dptr to the bool RETVAL, so wrap the call in cBOOL(...).