### PR TITLE
Rework initialization of locale handling

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4344,6 +4344,11 @@ Ri	|const char *|mortalized_pv_copy				\
 				|NULLOK const char * const pv
 S	|void	|new_LC_ALL	|NULLOK const char *unused		\
 				|bool force
+void
+S	|void	|output_check_environment_warning			\
+				|NULLOK const char * const language	\
+				|NULLOK const char * const lc_all	\
+				|NULLOK const char * const lang
 So	|void	|restore_toggled_locale_i				\
 				|const unsigned cat_index		\
 				|NULLOK const char *original_locale	\
@@ -4388,6 +4393,21 @@ S	|const char *|my_langinfo_i					\
 				|NULLOK Size_t *retbuf_sizep		\
 				|NULLOK utf8ness_t *utf8ness
 #   endif
+#   if defined(LC_ALL)
+S	|void	|give_perl_locale_control				\
+				|NN const char *lc_all_string		\
+				|const line_t caller_line
+S	|parse_LC_ALL_string_return|parse_LC_ALL_string 		\
+				|NN const char *string			\
+				|NN const char **output 		\
+				|bool always_use_full_array		\
+				|const bool panic_on_error		\
+				|const line_t caller_line
+#   else
+S	|void	|give_perl_locale_control				\
+				|NN const char **curlocales		\
+				|const line_t caller_line
+#   endif
 #   if defined(USE_LOCALE_COLLATE)
 S	|void	|new_collate	|NN const char *newcoll 		\
 				|bool force
@@ -4422,24 +4442,14 @@ S	|const char *|querylocale_2008_i				\
 				|const unsigned int index		\
 				|const line_t line
 S	|locale_t|use_curlocale_scratch
-#     if defined(LC_ALL)
-S	|parse_LC_ALL_string_return|parse_LC_ALL_string 		\
-				|NN const char *string			\
-				|NN const char **output 		\
-				|bool always_use_full_array		\
-				|const bool panic_on_error		\
-				|const line_t caller_line
-#     endif
 #     if !defined(USE_QUERYLOCALE)
 S	|void	|update_PL_curlocales_i 				\
 				|const unsigned int index		\
 				|NN const char *new_locale		\
 				|const line_t caller_line
 #     endif
-#   elif  defined(USE_LOCALE_THREADS) &&                  \
-         !defined(USE_THREAD_SAFE_LOCALE) &&              \
-         !defined(USE_THREAD_SAFE_LOCALE_EMULATION) /* &&
-         !defined(USE_POSIX_2008_LOCALE) */
+#   elif  defined(USE_LOCALE_THREADS) && !defined(USE_THREAD_SAFE_LOCALE) && \
+         !defined(USE_THREAD_SAFE_LOCALE_EMULATION)
 S	|bool	|less_dicey_bool_setlocale_r				\
 				|const int cat				\
 				|NN const char *locale

--- a/embed.h
+++ b/embed.h
@@ -1273,6 +1273,7 @@
 #       define get_category_index_helper(a,b,c) S_get_category_index_helper(aTHX_ a,b,c)
 #       define mortalized_pv_copy(a)            S_mortalized_pv_copy(aTHX_ a)
 #       define new_LC_ALL(a,b)                  S_new_LC_ALL(aTHX_ a,b)
+#       define output_check_environment_warning(a,b,c) S_output_check_environment_warning(aTHX_ a,b,c)
 #       define save_to_buffer(a,b,c)            S_save_to_buffer(aTHX_ a,b,c)
 #       define setlocale_failure_panic_via_i(a,b,c,d,e,f,g) S_setlocale_failure_panic_via_i(aTHX_ a,b,c,d,e,f,g)
 #       if defined(DEBUGGING)
@@ -1282,6 +1283,12 @@
 #         define my_langinfo_i(a,b,c,d,e,f)     S_my_langinfo_i(aTHX_ a,b,c,d,e,f)
 #       else
 #         define my_langinfo_i(a,b,c,d,e,f)     S_my_langinfo_i(aTHX_ a,b,c,d,e,f)
+#       endif
+#       if defined(LC_ALL)
+#         define give_perl_locale_control(a,b)  S_give_perl_locale_control(aTHX_ a,b)
+#         define parse_LC_ALL_string(a,b,c,d,e) S_parse_LC_ALL_string(aTHX_ a,b,c,d,e)
+#       else
+#         define give_perl_locale_control(a,b)  S_give_perl_locale_control(aTHX_ a,b)
 #       endif
 #       if defined(USE_LOCALE_COLLATE)
 #         define new_collate(a,b)               S_new_collate(aTHX_ a,b)
@@ -1303,16 +1310,12 @@
 #         define bool_setlocale_2008_i(a,b,c)   S_bool_setlocale_2008_i(aTHX_ a,b,c)
 #         define querylocale_2008_i(a,b)        S_querylocale_2008_i(aTHX_ a,b)
 #         define use_curlocale_scratch()        S_use_curlocale_scratch(aTHX)
-#         if defined(LC_ALL)
-#           define parse_LC_ALL_string(a,b,c,d,e) S_parse_LC_ALL_string(aTHX_ a,b,c,d,e)
-#         endif
 #         if !defined(USE_QUERYLOCALE)
 #           define update_PL_curlocales_i(a,b,c) S_update_PL_curlocales_i(aTHX_ a,b,c)
 #         endif
-#       elif  defined(USE_LOCALE_THREADS) &&                  \
-             !defined(USE_THREAD_SAFE_LOCALE) &&              \
-             !defined(USE_THREAD_SAFE_LOCALE_EMULATION) /* &&
-             !defined(USE_POSIX_2008_LOCALE) */
+#       elif  defined(USE_LOCALE_THREADS) &&     \
+             !defined(USE_THREAD_SAFE_LOCALE) && \
+             !defined(USE_THREAD_SAFE_LOCALE_EMULATION)
 #         define less_dicey_bool_setlocale_r(a,b) S_less_dicey_bool_setlocale_r(aTHX_ a,b)
 #         define less_dicey_setlocale_r(a,b)    S_less_dicey_setlocale_r(aTHX_ a,b)
 #       endif

--- a/locale.c
+++ b/locale.c
@@ -8068,7 +8068,6 @@ Perl_switch_to_global_locale(pTHX)
 
     DEBUG_L(PerlIO_printf(Perl_debug_log, "Entering switch_to_global; %s\n",
                                           get_LC_ALL_display()));
-    bool perl_controls = false;
 
 #  ifdef USE_THREAD_SAFE_LOCALE
 
@@ -8077,7 +8076,7 @@ Perl_switch_to_global_locale(pTHX)
 
 #    ifdef USE_POSIX_2008_LOCALE
 
-    perl_controls = (LC_GLOBAL_LOCALE != uselocale((locale_t) 0));
+    const bool perl_controls = (LC_GLOBAL_LOCALE != uselocale((locale_t) 0));
 
 #    elif defined(WIN32)
 
@@ -8085,11 +8084,13 @@ Perl_switch_to_global_locale(pTHX)
     if (config_return == -1) {
         locale_panic_("_configthreadlocale returned an error");
     }
-    perl_controls = (config_return == _ENABLE_PER_THREAD_LOCALE);
+    const bool perl_controls = (config_return == _ENABLE_PER_THREAD_LOCALE);
 
-#    else
-#      error Unexpected Configuration
 #    endif
+#  else
+
+    const bool perl_controls = false;
+
 #  endif
 
     /* No-op if already in global */

--- a/locale.c
+++ b/locale.c
@@ -6334,15 +6334,6 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 #  ifdef HAS_WCTOMBR
     wcrtomb(NULL, L'\0', &PL_wcrtomb_ps);
 #  endif
-#  ifdef USE_THREAD_SAFE_LOCALE
-#    ifdef WIN32
-
-    if (_configthreadlocale(_ENABLE_PER_THREAD_LOCALE) == -1) {
-        locale_panic_("_configthreadlocale returned an error");
-    }
-
-#    endif
-#  endif
 #  ifdef USE_PL_CURLOCALES
 
     for (unsigned int i = 0; i <= LC_ALL_INDEX_; i++) {

--- a/locale.c
+++ b/locale.c
@@ -6134,43 +6134,15 @@ S_output_check_environment_warning(pTHX_ const char * const language,
                                   lc_all ? lc_all : "unset",
                                   lc_all ? '"' : ')');
 
-#  if defined(USE_ENVIRON_ARRAY)
-
-    {
-        char **e;
-
-        /* Look through the environment for any variables of the
-         * form qr/ ^ LC_ [A-Z]+ = /x, except LC_ALL which was
-         * already handled above.  These are assumed to be locale
-         * settings.  Output them and their values. */
-
-        ENV_READ_LOCK;
-
-        for (e = environ; *e; e++) {
-            const STRLEN prefix_len = sizeof("LC_") - 1;
-            STRLEN uppers_len;
-
-            if (     strBEGINs(*e, "LC_")
-                && ! strBEGINs(*e, "LC_ALL=")
-                && (uppers_len = strspn(*e + prefix_len,
-                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
-                && ((*e)[prefix_len + uppers_len] == '='))
-            {
-                PerlIO_printf(Perl_error_log, "\t%.*s = \"%s\",\n",
-                    (int) (prefix_len + uppers_len), *e,
-                    *e + prefix_len + uppers_len + 1);
-            }
-        }
-
-        ENV_READ_UNLOCK;
+    for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
+        const char * value = PerlEnv_getenv(category_names[i]);
+        PerlIO_printf(Perl_error_log,
+                      "\t%s = %c%s%c,\n",
+                      category_names[i],
+                      value ? '"' : '(',
+                      value ? value : "unset",
+                      value ? '"' : ')');
     }
-
-#  else
-
-    PerlIO_printf(Perl_error_log,
-                  "\t(possibly more locale environment variables)\n");
-
-#  endif
 
     PerlIO_printf(Perl_error_log, "\tLANG = %c%s%c\n",
                                   lang ? '"' : '(',

--- a/locale.c
+++ b/locale.c
@@ -6065,6 +6065,10 @@ S_give_perl_locale_control(pTHX_
 {
     PERL_UNUSED_ARG(caller_line);
 
+    /* Now initialize some data structures.  This is entirely so that
+     * later-executed code doesn't have to concern itself with things not being
+     * initialized.  Arbitrarily use the C locale (which we know has to exist
+     * on the system). */
 
     /* This is called when the program is in the global locale and are
      * switching to per-thread (if available).  And it is called at
@@ -6363,21 +6367,20 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
     PL_numeric_radix_sv    = newSV(1);
     PL_underlying_radix_sv = newSV(1);
     Newxz(PL_numeric_name, 1, char);    /* Single NUL character */
-    new_numeric("C", false);
 
 #  endif
 #  ifdef USE_LOCALE_COLLATE
 
     Newxz(PL_collation_name, 1, char);
-    new_collate("C", false);
 
 #  endif
 #  ifdef USE_LOCALE_CTYPE
 
     Newxz(PL_ctype_name, 1, char);
-    new_ctype("C", false);
 
 #  endif
+
+    new_LC_ALL(NULL, true /* Don't shortcut */);
 
 /*===========================================================================*/
 

--- a/locale.c
+++ b/locale.c
@@ -8075,7 +8075,7 @@ Perl_sync_locale(pTHX)
 
 #    elif defined(USE_POSIX_2008_LOCALE)
 
-    was_in_global = (LC_GLOBAL_LOCALE == uselocale((locale_t) 0));
+    was_in_global = (LC_GLOBAL_LOCALE == uselocale(LC_GLOBAL_LOCALE));
 
 #    else
 #      error Unexpected Configuration

--- a/locale.c
+++ b/locale.c
@@ -945,11 +945,7 @@ Perl_locale_panic(const char * msg,
 #define setlocale_failure_panic_c(cat, cur, fail, line, higher_line)        \
    setlocale_failure_panic_i(cat##_INDEX_, cur, fail, line, higher_line)
 
-#if   defined(USE_LOCALE)                                                   \
- &&   defined(LC_ALL)                                                       \
- && (   defined(USE_FAKE_LC_ALL_POSITIONAL_NOTATION)                        \
-     || defined(USE_POSIX_2008_LOCALE)                                      \
-     || defined(USE_STDIZE_LOCALE))
+#if defined(LC_ALL) && defined(USE_LOCALE)
 
 STATIC parse_LC_ALL_string_return
 S_parse_LC_ALL_string(pTHX_ const char * string,
@@ -6060,6 +6056,136 @@ Perl_my_strftime8_temp(pTHX_ const char *fmt, int sec, int min, int hour, int md
     return retval;
 }
 
+#ifdef USE_LOCALE
+
+STATIC void
+S_give_perl_locale_control(pTHX_
+#  ifdef LC_ALL
+                           const char * lc_all_string,
+#  else
+                           const char ** locales,
+#  endif
+                           const line_t caller_line)
+{
+    PERL_UNUSED_ARG(caller_line);
+
+
+    /* This is called when the program is in the global locale and are
+     * switching to per-thread (if available).  And it is called at
+     * initialization time to do the same.
+     */
+
+#  if defined(WIN32) && defined(USE_THREAD_SAFE_LOCALE)
+
+    /* On Windows, convert to per-thread behavior.  This isn't necessary in
+     * POSIX 2008, as the conversion gets done automatically in the
+     * void_setlocale_i() calls below. */
+    if (_configthreadlocale(_ENABLE_PER_THREAD_LOCALE) == -1) {
+        locale_panic_("_configthreadlocale returned an error");
+    }
+
+#  endif
+#  if ! defined(USE_THREAD_SAFE_LOCALE)                               \
+   && ! defined(USE_POSIX_2008_LOCALE)
+#    if defined(LC_ALL)
+    PERL_UNUSED_ARG(lc_all_string);
+#    else
+    PERL_UNUSED_ARG(locales);
+#    endif
+#  else
+
+    /* This platform has per-thread locale handling.  Do the conversion. */
+
+#    if defined(LC_ALL)
+
+    void_setlocale_c_with_caller(LC_ALL, lc_all_string, __FILE__, caller_line);
+
+#    else
+
+    for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
+        void_setlocale_i_with_caller(i, locales[i], __FILE__, caller_line);
+    }
+
+#    endif
+#  endif
+
+    /* Finally, update our remaining records.  'true' => force recalculation.
+     * This is needed because we don't know what's happened while Perl hasn't
+     * had control, so we need to figure out the current state */
+    new_LC_ALL(NULL, true);
+}
+
+STATIC void
+S_output_check_environment_warning(pTHX_ const char * const language,
+                                         const char * const lc_all,
+                                         const char * const lang)
+{
+    PerlIO_printf(Perl_error_log,
+                  "perl: warning: Please check that your locale settings:\n");
+
+#  ifdef __GLIBC__
+
+    PerlIO_printf(Perl_error_log, "\tLANGUAGE = %c%s%c,\n",
+                                  language ? '"' : '(',
+                                  language ? language : "unset",
+                                  language ? '"' : ')');
+#  else
+    PERL_UNUSED_ARG(language);
+#  endif
+
+    PerlIO_printf(Perl_error_log, "\tLC_ALL = %c%s%c,\n",
+                                  lc_all ? '"' : '(',
+                                  lc_all ? lc_all : "unset",
+                                  lc_all ? '"' : ')');
+
+#  if defined(USE_ENVIRON_ARRAY)
+
+    {
+        char **e;
+
+        /* Look through the environment for any variables of the
+         * form qr/ ^ LC_ [A-Z]+ = /x, except LC_ALL which was
+         * already handled above.  These are assumed to be locale
+         * settings.  Output them and their values. */
+
+        ENV_READ_LOCK;
+
+        for (e = environ; *e; e++) {
+            const STRLEN prefix_len = sizeof("LC_") - 1;
+            STRLEN uppers_len;
+
+            if (     strBEGINs(*e, "LC_")
+                && ! strBEGINs(*e, "LC_ALL=")
+                && (uppers_len = strspn(*e + prefix_len,
+                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
+                && ((*e)[prefix_len + uppers_len] == '='))
+            {
+                PerlIO_printf(Perl_error_log, "\t%.*s = \"%s\",\n",
+                    (int) (prefix_len + uppers_len), *e,
+                    *e + prefix_len + uppers_len + 1);
+            }
+        }
+
+        ENV_READ_UNLOCK;
+    }
+
+#  else
+
+    PerlIO_printf(Perl_error_log,
+                  "\t(possibly more locale environment variables)\n");
+
+#  endif
+
+    PerlIO_printf(Perl_error_log, "\tLANG = %c%s%c\n",
+                                  lang ? '"' : '(',
+                                  lang ? lang : "unset",
+                                  lang ? '"' : ')');
+    PerlIO_printf(Perl_error_log,
+                  "    are supported and installed on your system.\n");
+}
+
+#endif
+
 /*
  * Initialize locale awareness.
  */
@@ -6403,70 +6529,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 
 #  endif /* LC_ALL */
 
-                PerlIO_printf(Perl_error_log,
-                    "perl: warning: Please check that your locale settings:\n");
-
-#  ifdef __GLIBC__
-
-                PerlIO_printf(Perl_error_log,
-                            "\tLANGUAGE = %c%s%c,\n",
-                            language ? '"' : '(',
-                            language ? language : "unset",
-                            language ? '"' : ')');
-#  endif
-
-                PerlIO_printf(Perl_error_log,
-                            "\tLC_ALL = %c%s%c,\n",
-                            lc_all ? '"' : '(',
-                            lc_all ? lc_all : "unset",
-                            lc_all ? '"' : ')');
-
-#  if defined(USE_ENVIRON_ARRAY)
-
-                {
-                    char **e;
-
-                    /* Look through the environment for any variables of the
-                     * form qr/ ^ LC_ [A-Z]+ = /x, except LC_ALL which was
-                     * already handled above.  These are assumed to be locale
-                     * settings.  Output them and their values. */
-
-                    ENV_READ_LOCK;
-
-                    for (e = environ; *e; e++) {
-                        const STRLEN prefix_len = sizeof("LC_") - 1;
-                        STRLEN uppers_len;
-
-                        if (     strBEGINs(*e, "LC_")
-                            && ! strBEGINs(*e, "LC_ALL=")
-                            && (uppers_len = strspn(*e + prefix_len,
-                                             "ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
-                            && ((*e)[prefix_len + uppers_len] == '='))
-                        {
-                            PerlIO_printf(Perl_error_log, "\t%.*s = \"%s\",\n",
-                                (int) (prefix_len + uppers_len), *e,
-                                *e + prefix_len + uppers_len + 1);
-                        }
-                    }
-
-                    ENV_READ_UNLOCK;
-                }
-
-#  else
-
-                PerlIO_printf(Perl_error_log,
-                            "\t(possibly more locale environment variables)\n");
-
-#  endif
-
-                PerlIO_printf(Perl_error_log,
-                            "\tLANG = %c%s%c\n",
-                            lang ? '"' : '(',
-                            lang ? lang : "unset",
-                            lang ? '"' : ')');
-
-                PerlIO_printf(Perl_error_log,
-                            "    are supported and installed on your system.\n");
+                output_check_environment_warning(language, lc_all, lang);
             }
 
             /* Calculate what fallback locales to try.  We have avoided this
@@ -8083,13 +8146,16 @@ Perl_sync_locale(pTHX)
 #  endif    /* USE_THREAD_SAFE_LOCALE */
 
     /* Here, we are in the global locale.  Get and save the values for each
-     * category. */
+     * category, and convert the current thread to use them */
 
 #  ifdef LC_ALL
 
     STDIZED_SETLOCALE_LOCK;
     const char * lc_all_string = savepv(stdized_setlocale(LC_ALL, NULL));
     STDIZED_SETLOCALE_UNLOCK;
+
+    give_perl_locale_control(lc_all_string, __LINE__);
+    Safefree(lc_all_string);
 
 #  else
 
@@ -8100,36 +8166,13 @@ Perl_sync_locale(pTHX)
         STDIZED_SETLOCALE_UNLOCK;
     }
 
-#  endif
-
-    /* Now we have to convert the current thread to use them */
-
-#  if defined(USE_THREAD_SAFE_LOCALE) && defined(WIN32)
-
-    /* On Windows, convert to per-thread behavior.  This isn't necessary in
-     * POSIX 2008, as the conversion gets done automatically below in the
-     * void_X calls.  */
-    if (_configthreadlocale(_ENABLE_PER_THREAD_LOCALE) == -1) {
-        locale_panic_("_configthreadlocale returned an error");
-    }
-
-#  endif
-#  ifdef LC_ALL
-
-    void_setlocale_c(LC_ALL, lc_all_string);
-    Safefree(lc_all_string);
-
-#  else
+    give_perl_locale_control((const char **) &current_globals, __LINE__);
 
     for (unsigned i = 0; i < LC_ALL_INDEX_; i++) {
-        void_setlocale_i(i, current_globals[i]);
         Safefree(current_globals[i]);
     }
 
 #  endif
-
-    /* And update our remaining records.  'true' => force recalculation */
-    new_LC_ALL(NULL, true);
 
     return was_in_global;
 

--- a/locale.c
+++ b/locale.c
@@ -6342,14 +6342,14 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 
     if (! PL_C_locale_obj) {
         PL_C_locale_obj = newlocale(LC_ALL_MASK, "C", (locale_t) 0);
-    }
-    if (! PL_C_locale_obj) {
-        locale_panic_(Perl_form(aTHX_
+        if (! PL_C_locale_obj) {
+            locale_panic_(Perl_form(aTHX_
                                 "Cannot create POSIX 2008 C locale object"));
-    }
+        }
 
-    DEBUG_Lv(PerlIO_printf(Perl_debug_log, "created C object %p\n",
-                           PL_C_locale_obj));
+        DEBUG_Lv(PerlIO_printf(Perl_debug_log, "created C object %p\n",
+                                               PL_C_locale_obj));
+    }
 
     /* Switch to using the POSIX 2008 interface now.  This would happen below
      * anyway, but deferring it can lead to leaks of memory that would also get

--- a/locale.c
+++ b/locale.c
@@ -8106,7 +8106,7 @@ Perl_switch_to_global_locale(pTHX)
 
 #    else   /* Must be USE_POSIX_2008_LOCALE) */
 
-    const char * cur_thread_locales[LC_ALL_INDEX_ + 1];
+    const char * cur_thread_locales[LC_ALL_INDEX_];
 
     /* Save each category's current per-thread state */
     for (unsigned i = 0; i < LC_ALL_INDEX_; i++) {

--- a/locale.c
+++ b/locale.c
@@ -6283,13 +6283,15 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
      * values for our db, instead of trying to change them.
      * */
 
-    int ok = 1;
-
 #ifndef USE_LOCALE
 
     PERL_UNUSED_ARG(printwarn);
+    const int ok = 1;
 
 #else  /* USE_LOCALE */
+
+    int ok = 0;
+
 #  ifdef __GLIBC__
 
     const char * const language = PerlEnv_getenv("LANGUAGE");
@@ -6499,12 +6501,10 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
             }
 
             if (LIKELY(! setlocale_failure)) {  /* All succeeded */
+                ok = 1;
                 break;  /* Exit trial_locales loop */
             }
         }
-
-        /* Here, something failed; will need to try a fallback. */
-        ok = 0;
 
         if (i == 0) {
             unsigned int j;
@@ -6644,7 +6644,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
         }   /* end of first time through the loop */
     }   /* end of looping through the trial locales */
 
-    if (ok < 1) {   /* If we tried to fallback */
+    if (trial_locales_count > 1) {   /* If we tried to fallback */
         const char* msg;
         if (! setlocale_failure) {  /* fallback succeeded */
            msg = "Falling back to";

--- a/locale.c
+++ b/locale.c
@@ -3641,11 +3641,7 @@ S_win32_setlocale(pTHX_ int category, const char* locale)
      * use the particular category's variable if set; otherwise to use the LANG
      * variable. */
 
-    if (locale == NULL) {
-        return wrap_wsetlocale(category, NULL);
-    }
-
-    if (strEQ(locale, "")) {
+    if (locale != NULL && strEQ(locale, "")) {
         /* Note this function may change the locale, but that's ok because we
          * are about to change it anyway */
         locale = find_locale_from_environment(get_category_index(category));

--- a/proto.h
+++ b/proto.h
@@ -6986,6 +6986,10 @@ S_new_LC_ALL(pTHX_ const char *unused, bool force);
 #   define PERL_ARGS_ASSERT_NEW_LC_ALL
 
 STATIC void
+S_output_check_environment_warning(pTHX_ const char * const language, const char * const lc_all, const char * const lang);
+#   define PERL_ARGS_ASSERT_OUTPUT_CHECK_ENVIRONMENT_WARNING
+
+STATIC void
 S_restore_toggled_locale_i(pTHX_ const unsigned cat_index, const char *original_locale, const line_t caller_line);
 #   define PERL_ARGS_ASSERT_RESTORE_TOGGLED_LOCALE_I
 
@@ -7022,6 +7026,24 @@ STATIC const char *
 S_my_langinfo_i(pTHX_ const int item, const unsigned int cat_index, const char *locale, const char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
 #     define PERL_ARGS_ASSERT_MY_LANGINFO_I     \
         assert(locale); assert(retbufp)
+
+#   endif
+#   if defined(LC_ALL)
+STATIC void
+S_give_perl_locale_control(pTHX_ const char *lc_all_string, const line_t caller_line);
+#     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
+        assert(lc_all_string)
+
+STATIC parse_LC_ALL_string_return
+S_parse_LC_ALL_string(pTHX_ const char *string, const char **output, bool always_use_full_array, const bool panic_on_error, const line_t caller_line);
+#     define PERL_ARGS_ASSERT_PARSE_LC_ALL_STRING \
+        assert(string); assert(output)
+
+#   else /* if !defined(LC_ALL) */
+STATIC void
+S_give_perl_locale_control(pTHX_ const char **curlocales, const line_t caller_line);
+#     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
+        assert(curlocales)
 
 #   endif
 #   if !defined(PERL_NO_INLINE_FUNCTIONS)
@@ -7084,13 +7106,6 @@ STATIC locale_t
 S_use_curlocale_scratch(pTHX);
 #     define PERL_ARGS_ASSERT_USE_CURLOCALE_SCRATCH
 
-#     if defined(LC_ALL)
-STATIC parse_LC_ALL_string_return
-S_parse_LC_ALL_string(pTHX_ const char *string, const char **output, bool always_use_full_array, const bool panic_on_error, const line_t caller_line);
-#       define PERL_ARGS_ASSERT_PARSE_LC_ALL_STRING \
-        assert(string); assert(output)
-
-#     endif
 #     if !defined(USE_QUERYLOCALE)
 STATIC void
 S_update_PL_curlocales_i(pTHX_ const unsigned int index, const char *new_locale, const line_t caller_line);


### PR DESCRIPTION
This code has always been difficult to understand, with a self-modifying loop.  This series of commits changes things to use a switch() statement instead, with ancillary changes as well.

@tonycoz, this code uses casts in order to increment an enum because of that not working without them on C++.  We could define a ++ operator for this enum, as you mentioned in a previous PR.  But that would be our first place where we fairly explicitly account for the core accommodating C++.  I like that idea, in part because I use C++ as my normal development compiler, but the decision needs to be vetted.