### PR TITLE
Add caller location info to e.g. RESTORE_LC_NUMERIC

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2921,8 +2921,12 @@ p	|void	|setfd_cloexec_or_inhexec_by_sysfdness			\
 Tp	|void	|setfd_inhexec	|int fd
 p	|void	|setfd_inhexec_for_sysfd				\
 				|int fd
-Xp	|void	|set_numeric_standard
-Xp	|void	|set_numeric_underlying
+Xp	|void	|set_numeric_standard					\
+				|NN const char *file			\
+				|const line_t caller_line
+Xp	|void	|set_numeric_underlying 				\
+				|NN const char *file			\
+				|const line_t caller_line
 Cp	|HEK *	|share_hek	|NN const char *str			\
 				|SSize_t len				\
 				|U32 hash

--- a/embed.h
+++ b/embed.h
@@ -1060,8 +1060,8 @@
 #   define scalar(a)                            Perl_scalar(aTHX_ a)
 #   define scalarvoid(a)                        Perl_scalarvoid(aTHX_ a)
 #   define set_caret_X()                        Perl_set_caret_X(aTHX)
-#   define set_numeric_standard()               Perl_set_numeric_standard(aTHX)
-#   define set_numeric_underlying()             Perl_set_numeric_underlying(aTHX)
+#   define set_numeric_standard(a,b)            Perl_set_numeric_standard(aTHX_ a,b)
+#   define set_numeric_underlying(a,b)          Perl_set_numeric_underlying(aTHX_ a,b)
 #   define setfd_cloexec                        Perl_setfd_cloexec
 #   define setfd_cloexec_for_nonsysfd(a)        Perl_setfd_cloexec_for_nonsysfd(aTHX_ a)
 #   define setfd_cloexec_or_inhexec_by_sysfdness(a) Perl_setfd_cloexec_or_inhexec_by_sysfdness(aTHX_ a)

--- a/locale.c
+++ b/locale.c
@@ -2789,15 +2789,18 @@ S_new_numeric(pTHX_ const char *newnum, bool force)
      * the radix being a non-dot.  (Core operations that need the underlying
      * locale change to it temporarily). */
     if (! PL_numeric_standard) {
-        set_numeric_standard();
+        set_numeric_standard(__FILE__, __LINE__);
     }
 }
 
 #  endif
 
 void
-Perl_set_numeric_standard(pTHX)
+Perl_set_numeric_standard(pTHX_ const char * const file, const line_t line)
 {
+    PERL_ARGS_ASSERT_SET_NUMERIC_STANDARD;
+    PERL_UNUSED_ARG(file);      /* Some Configurations ignore these */
+    PERL_UNUSED_ARG(line);
 
 #  ifdef USE_LOCALE_NUMERIC
 
@@ -2808,10 +2811,11 @@ Perl_set_numeric_standard(pTHX)
      * if toggling isn't necessary according to our records (which could be
      * wrong if some XS code has changed the locale behind our back) */
 
-    DEBUG_L(PerlIO_printf(Perl_debug_log,
-                                  "Setting LC_NUMERIC locale to standard C\n"));
+    DEBUG_L(PerlIO_printf(Perl_debug_log, "Setting LC_NUMERIC locale to"
+                                          " standard C; called from %s: %"
+                                          LINE_Tf "\n", file, line));
 
-    void_setlocale_c_with_caller(LC_NUMERIC, "C", __FILE__,  __LINE__);
+    void_setlocale_c_with_caller(LC_NUMERIC, "C", file, line);
     PL_numeric_standard = TRUE;
     sv_setpv(PL_numeric_radix_sv, C_decimal_point);
     SvUTF8_off(PL_numeric_radix_sv);
@@ -2823,8 +2827,11 @@ Perl_set_numeric_standard(pTHX)
 }
 
 void
-Perl_set_numeric_underlying(pTHX)
+Perl_set_numeric_underlying(pTHX_ const char * const file, const line_t line)
 {
+    PERL_ARGS_ASSERT_SET_NUMERIC_UNDERLYING;
+    PERL_UNUSED_ARG(file);      /* Some Configurations ignore these */
+    PERL_UNUSED_ARG(line);
 
 #  ifdef USE_LOCALE_NUMERIC
 
@@ -2836,11 +2843,12 @@ Perl_set_numeric_underlying(pTHX)
      * if toggling isn't necessary according to our records (which could be
      * wrong if some XS code has changed the locale behind our back) */
 
-    DEBUG_L(PerlIO_printf(Perl_debug_log, "Setting LC_NUMERIC locale to %s\n",
-                                          PL_numeric_name));
+    DEBUG_L(PerlIO_printf(Perl_debug_log, "Setting LC_NUMERIC locale to %s;"
+                                          " called from %s: %" LINE_Tf "\n",
+                                          PL_numeric_name, file, line));
+    /* Maybe not in init? assert(PL_locale_mutex_depth > 0);*/
 
-    void_setlocale_c_with_caller(LC_NUMERIC, PL_numeric_name,
-                                 __FILE__,  __LINE__);
+    void_setlocale_c_with_caller(LC_NUMERIC, PL_numeric_name, file, line);
     PL_numeric_underlying = TRUE;
     sv_setsv_nomg(PL_numeric_radix_sv, PL_underlying_radix_sv);
 
@@ -3650,14 +3658,14 @@ Perl_setlocale(const int category, const char * locale)
          * (if we aren't there already) so as to get the correct results.  Our
          * records for all the other categories are valid without switching */
         if (! PL_numeric_underlying) {
-            set_numeric_underlying();
+            set_numeric_underlying(__FILE__, __LINE__);
             toggled = TRUE;
         }
 
         retval = querylocale_c(LC_ALL);
 
         if (toggled) {
-            set_numeric_standard();
+            set_numeric_standard(__FILE__, __LINE__);
         }
 
         DEBUG_L(PerlIO_printf(Perl_debug_log, "%s\n",

--- a/perl.h
+++ b/perl.h
@@ -7447,7 +7447,8 @@ cannot have changed since the precalculation.
                     (! PL_numeric_underlying && PL_numeric_standard < 2)
 
 #  define DECLARATION_FOR_LC_NUMERIC_MANIPULATION                           \
-    void (*_restore_LC_NUMERIC_function)(pTHX) = NULL
+    void (*_restore_LC_NUMERIC_function)(pTHX_ const char * const file,     \
+                                               const line_t line) = NULL
 
 #  define STORE_LC_NUMERIC_SET_TO_NEEDED_IN(in)                             \
         STMT_START {                                                        \
@@ -7457,14 +7458,14 @@ cannot have changed since the precalculation.
                      || (! _in_lc_numeric && NOT_IN_NUMERIC_STANDARD_)));   \
             if (_in_lc_numeric) {                                           \
                 if (NOT_IN_NUMERIC_UNDERLYING_) {                           \
-                    Perl_set_numeric_underlying(aTHX);                      \
+                    Perl_set_numeric_underlying(aTHX_ __FILE__, __LINE__);  \
                     _restore_LC_NUMERIC_function                            \
                                             = &Perl_set_numeric_standard;   \
                 }                                                           \
             }                                                               \
             else {                                                          \
                 if (NOT_IN_NUMERIC_STANDARD_) {                             \
-                    Perl_set_numeric_standard(aTHX);                        \
+                    Perl_set_numeric_standard(aTHX_ __FILE__, __LINE__);    \
                     _restore_LC_NUMERIC_function                            \
                                             = &Perl_set_numeric_underlying; \
                 }                                                           \
@@ -7477,7 +7478,7 @@ cannot have changed since the precalculation.
 #  define RESTORE_LC_NUMERIC()                                              \
         STMT_START {                                                        \
             if (_restore_LC_NUMERIC_function) {                             \
-                _restore_LC_NUMERIC_function(aTHX);                         \
+                _restore_LC_NUMERIC_function(aTHX_ __FILE__, __LINE__);     \
             }                                                               \
             LC_NUMERIC_UNLOCK;                                              \
         } STMT_END
@@ -7490,7 +7491,7 @@ cannot have changed since the precalculation.
                                "%s: %d: lc_numeric standard=%d\n",          \
                                 __FILE__, __LINE__, PL_numeric_standard));  \
             if (UNLIKELY(NOT_IN_NUMERIC_STANDARD_)) {                       \
-                Perl_set_numeric_standard(aTHX);                            \
+                Perl_set_numeric_standard(aTHX_ __FILE__, __LINE__);        \
             }                                                               \
             DEBUG_Lv(PerlIO_printf(Perl_debug_log,                          \
                                  "%s: %d: lc_numeric standard=%d\n",        \
@@ -7501,7 +7502,7 @@ cannot have changed since the precalculation.
 	STMT_START {                                                        \
           /*assert(PL_locale_mutex_depth > 0);*/                            \
             if (NOT_IN_NUMERIC_UNDERLYING_) {                               \
-                Perl_set_numeric_underlying(aTHX);                          \
+                Perl_set_numeric_underlying(aTHX_ __FILE__, __LINE__);      \
             }                                                               \
         } STMT_END
 
@@ -7512,7 +7513,7 @@ cannot have changed since the precalculation.
             LC_NUMERIC_LOCK(NOT_IN_NUMERIC_STANDARD_);                      \
             if (NOT_IN_NUMERIC_STANDARD_) {                                 \
                 _restore_LC_NUMERIC_function = &Perl_set_numeric_underlying;\
-                Perl_set_numeric_standard(aTHX);                            \
+                Perl_set_numeric_standard(aTHX_ __FILE__, __LINE__);        \
             }                                                               \
         } STMT_END
 
@@ -7522,7 +7523,7 @@ cannot have changed since the precalculation.
 	STMT_START {                                                        \
             LC_NUMERIC_LOCK(NOT_IN_NUMERIC_UNDERLYING_);                    \
             if (NOT_IN_NUMERIC_UNDERLYING_) {                               \
-                Perl_set_numeric_underlying(aTHX);                          \
+                Perl_set_numeric_underlying(aTHX_ __FILE__, __LINE__);      \
                 _restore_LC_NUMERIC_function = &Perl_set_numeric_standard;  \
             }                                                               \
         } STMT_END

--- a/proto.h
+++ b/proto.h
@@ -4164,12 +4164,14 @@ Perl_set_context(void *t);
         assert(t)
 
 PERL_CALLCONV void
-Perl_set_numeric_standard(pTHX);
-#define PERL_ARGS_ASSERT_SET_NUMERIC_STANDARD
+Perl_set_numeric_standard(pTHX_ const char *file, const line_t caller_line);
+#define PERL_ARGS_ASSERT_SET_NUMERIC_STANDARD   \
+        assert(file)
 
 PERL_CALLCONV void
-Perl_set_numeric_underlying(pTHX);
-#define PERL_ARGS_ASSERT_SET_NUMERIC_UNDERLYING
+Perl_set_numeric_underlying(pTHX_ const char *file, const line_t caller_line);
+#define PERL_ARGS_ASSERT_SET_NUMERIC_UNDERLYING \
+        assert(file)
 
 PERL_CALLCONV void
 Perl_setdefout(pTHX_ GV *gv);


### PR DESCRIPTION
These help pinpointing the error source when a failure occurs.