### PR TITLE
Update Safe metadata

### DIFF
--- a/dist/Safe/Makefile.PL
+++ b/dist/Safe/Makefile.PL
@@ -7,4 +7,26 @@ WriteMakefile(
     VERSION_FROM => 'Safe.pm',
     INSTALLDIRS => ($] < 5.011 ? 'perl' : 'site'),
     ($core || $] >= 5.011) ? () : (INST_LIB => '$(INST_ARCHLIB)'),
+    AUTHOR => [
+        'Malcolm Beattie',
+        'Perl 5 Porters <perl5-porters@perl.org>'
+    ],
+    ABSTRACT_FROM => 'Safe.pm',
+    LICENSE => 'perl_5',
+    META_ADD => {
+        'meta-spec' => {
+            version => '2',
+            url     => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
+        },
+        'resources' => {
+            'bugtracker' => {
+                web => 'https://github.com/Perl/perl5/issues',
+            },
+            'repository' => {
+                url  => 'git://github.com/Perl/perl5.git',
+                web  => 'https://github.com/Perl/perl5',
+                type => 'git'
+            }
+        }
+    }
 );


### PR DESCRIPTION
In PR #21333, I proposed a fix that was reported 7 years ago in RT. At the time of report, Safe was already maintained in the Perl tree for 7 years. As a result, nobody was watching the RT queue for Safe when the reporter of the problem reported it. However the reporter did what CPAN meta data told him to: report to the RT queue.

With the submission of this meta data, I'd like to request one last release to CPAN so as to update the metadata and point to this repository. I asked irc.perl.org/#metacpan if there's another way, but there is no other way than a release...