### PR TITLE
locale.c: Don't compile unreachable code

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -4143,7 +4143,7 @@ Perl_get_win32_message_utf8ness(pTHX_ const char * string)
 {
     /* This is because Windows doesn't have LC_MESSAGES. */
 
-#    ifdef USE_LC_CTYPE
+#    ifdef USE_LOCALE_CTYPE
 
     return get_locale_string_utf8ness_i(string, LOCALE_IS_UTF8,
                                         NULL, LC_CTYPE_INDEX_);
@@ -5620,6 +5620,7 @@ S_my_langinfo_i(pTHX_
         }
 
 #    endif
+#    ifdef USE_LOCALE_CTYPE
 
       case CODESET:
 
@@ -5629,7 +5630,7 @@ S_my_langinfo_i(pTHX_
             break;
         }
 
-#    ifdef WIN32
+#      ifdef WIN32
 
         /* This function retrieves the code page.  It is subject to change, but
          * is documented and has been stable for many releases */
@@ -5649,7 +5650,7 @@ S_my_langinfo_i(pTHX_
                                                locale, retval));
         break;
 
-#    else
+#      else
 
         /* The codeset is important, but khw did not figure out a way for it to
          * be retrieved on non-Windows boxes without nl_langinfo().  But even
@@ -5657,7 +5658,7 @@ S_my_langinfo_i(pTHX_
          * UTF-8 locale or not.  If it is UTF-8, we (correctly) use that for
          * the code set. */
 
-#      if defined(HAS_MBTOWC) || defined(HAS_MBRTOWC)
+#        if defined(HAS_MBTOWC) || defined(HAS_MBRTOWC)
 
         /* If libc mbtowc() evaluates the bytes that form the REPLACEMENT
          * CHARACTER as that Unicode code point, this has to be a UTF-8 locale.
@@ -5675,7 +5676,7 @@ S_my_langinfo_i(pTHX_
 
         /* Here, it isn't a UTF-8 locale. */
 
-#      else     /* mbtowc() is not available.  The chances of this code getting
+#        else   /* mbtowc() is not available.  The chances of this code getting
                    compiled are very small, as it is a C99 required function,
                    and we are now requiring C99; perhaps if it is a defective
                    implementation.  But if so, there are other libc functions
@@ -5690,7 +5691,7 @@ S_my_langinfo_i(pTHX_
         utf8ness_t is_utf8 = UTF8NESS_UNKNOWN;
         const char * scratch_buf = NULL;
 
-#        if defined(USE_LOCALE_MONETARY) && defined(HAS_LOCALECONV)
+#          if defined(USE_LOCALE_MONETARY) && defined(HAS_LOCALECONV)
 
         /* Can't use this method unless localeconv() is available, as that's
          * the way we find out the currency symbol.
@@ -5703,8 +5704,8 @@ S_my_langinfo_i(pTHX_
                              &is_utf8);
         Safefree(scratch_buf);
 
-#        endif
-#        ifdef USE_LOCALE_TIME
+#          endif
+#          ifdef USE_LOCALE_TIME
 
         /* If we have ruled out being UTF-8, no point in checking further. */
         if (is_utf8 != UTF8NESS_NO) {
@@ -5758,7 +5759,7 @@ S_my_langinfo_i(pTHX_
             restore_toggled_locale_c(LC_TIME, orig_TIME_locale);
         }
 
-#        endif    /* LC_TIME */
+#          endif    /* LC_TIME */
 
         /* If nothing examined above rules out it being UTF-8, and at least one
          * thing fits as UTF-8 (and not plain ASCII), assume the codeset is
@@ -5789,7 +5790,7 @@ S_my_langinfo_i(pTHX_
          *              has non-ASCII error messages.  But again, wait until it
          *              turns out to be an actual problem. */
 
-#      endif    /* ! mbtowc() */
+#        endif    /* ! mbtowc() */
 
         /* Rejoin the mbtowc available/not-available cases.
          *
@@ -5823,7 +5824,7 @@ S_my_langinfo_i(pTHX_
             retval = code_set_name;
         }
 
-#      if defined(HAS_MBTOWC) || defined(HAS_MBRTOWC)
+#        if defined(HAS_MBTOWC) || defined(HAS_MBRTOWC)
 
         /* When these functions, are available, they were tried earlier and
          * indicated that the locale did not act like a proper UTF-8 one.  So
@@ -5833,7 +5834,7 @@ S_my_langinfo_i(pTHX_
             break;
         }
 
-#      endif
+#        endif
 
         /* Otherwise the code set name is considered to be everything between
          * the dot and the '@' */
@@ -5841,7 +5842,8 @@ S_my_langinfo_i(pTHX_
 
         break;
 
-#    endif
+#      endif    /* ! WIN32 */
+#    endif      /* USE_LOCALE_CTYPE */
 
     } /* Giant switch() of nl_langinfo() items */
 


### PR DESCRIPTION
This code is attempting to compute the nl_langinfo() codeset of the current locale.  If there is no LC_CTYPE available on the system, the codeset must be 'C', and the only callers to this static function know that, and return that answer without calling this function.  That means this part of the function will never be executed.  So don't compile it.