### PR TITLE
strftime: Always restore LC_CTYPE locale

### DIFF
--- a/ext/POSIX/t/time.t
+++ b/ext/POSIX/t/time.t
@@ -9,7 +9,7 @@ use strict;
 
 use Config;
 use POSIX;
-use Test::More tests => 19;
+use Test::More tests => 20;
 
 # go to UTC to avoid DST issues around the world when testing.  SUS3 says that
 # null should get you UTC, but some environments want the explicit names.
@@ -67,12 +67,6 @@ is(ctime($jan_16), strftime("%a %b %d %H:%M:%S %Y\n", CORE::localtime($jan_16)),
         "get ctime() equal to strftime()");
 is(ctime($jan_16), strftime("%a %b %d %H:%M:%S %Y\n", POSIX::localtime($jan_16)),
         "get ctime() equal to strftime()");
-is(strftime("%Y\x{5e74}%m\x{6708}%d\x{65e5}", CORE::gmtime($jan_16)),
-   "1970\x{5e74}01\x{6708}16\x{65e5}",
-   "strftime() can handle unicode chars in the format string");
-is(strftime("%Y\x{5e74}%m\x{6708}%d\x{65e5}", POSIX::gmtime($jan_16)),
-   "1970\x{5e74}01\x{6708}16\x{65e5}",
-   "strftime() can handle unicode chars in the format string");
 
 my $ss = chr 223;
 unlike($ss, qr/\w/, 'Not internally UTF-8 encoded');
@@ -81,6 +75,30 @@ is(ord strftime($ss, CORE::localtime), 223,
 is(ord strftime($ss, POSIX::localtime(time)),
    223, 'Format string has correct character');
 unlike($ss, qr/\w/, 'Still not internally UTF-8 encoded');
+
+my $zh_format = "%Y\x{5e74}%m\x{6708}%d\x{65e5}";
+my $zh_expected_result = "1970\x{5e74}01\x{6708}16\x{65e5}";
+TODO: {
+    local $TODO = 'Awaiting more fixes';
+    ok(strftime($zh_format, CORE::gmtime($jan_16)) ne $zh_expected_result,
+           "strftime() UTF-8 format doesn't return UTF-8 in non-UTF-8 locale");
+}
+
+my $utf8_locale = find_utf8_ctype_locale();
+SKIP: {
+    skip "No UTF-8 locale", 2 if ! defined $utf8_locale;
+
+    setlocale(LC_TIME, $utf8_locale)
+                               || die "Cannot setlocale() to $utf8_locale: $!";
+    # By setting LC_TIME only, we verify that the code properly handles the
+    # case where that and LC_CTYPE differ
+    is(strftime($zh_format, CORE::gmtime($jan_16)),
+                $zh_expected_result,
+                "strftime() can handle a UTF-8 format;  LC_CTYPE != LCTIME");
+    is(strftime($zh_format, POSIX::gmtime($jan_16)),
+                $zh_expected_result,
+                "Same, but uses POSIX::gmtime; previous test used CORE::");
+}
 
 if (locales_enabled('LC_TIME')) {
     setlocale(LC_TIME, $orig_time_loc) || die "Cannot setlocale(LC_TIME) back to orig: $!";

--- a/locale.c
+++ b/locale.c
@@ -5970,7 +5970,7 @@ the program, giving results based on that locale.
          * indicates we have at least one byte of spare space (which will be
          * used for the terminating NUL). */
         if (inRANGE(len, 1, bufsize - 1)) {
-            goto strftime_success;
+            goto strftime_return;
         }
 
         /* There are several possible reasons for a 0 return code for a
@@ -6004,7 +6004,7 @@ the program, giving results based on that locale.
     if (strEQ(fmt, "%p")) {
         Renew(buf, 1, char);
         *buf = '\0';
-        goto strftime_success;
+        goto strftime_return;
     }
 
     /* The other reason is that the format string is malformed.  Probably it is
@@ -6013,9 +6013,9 @@ the program, giving results based on that locale.
      * treated as a literal, but others may fail when '?' is illegal */
     Safefree(buf);
     SET_EINVAL;
-    return NULL;
+    buf = NULL;
 
-  strftime_success:
+  strftime_return:
 
 #  if defined(USE_LOCALE_CTYPE) && defined(USE_LOCALE_TIME)
 


### PR DESCRIPTION
my_strftime toggles LC_CTYPE to match LC_TIME to avoid mojibake.

In reading the code, I realized that there was a code path that doesn't properly restore it, namely when failure is returned.  This commit fixes that.