### PR TITLE
S_get_locale_string_utf8ness_i: Fix return

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -3927,7 +3927,7 @@ S_get_locale_string_utf8ness_i(pTHX_ const char * string,
                             : "nil"),
                            known_utf8));
     if (string == NULL) {
-        return UTF8NESS_NO;
+        return UTF8NESS_IMMATERIAL;
     }
 
     if (IN_BYTES) { /* respect 'use bytes' */


### PR DESCRIPTION
If the input is NULL, the utf8ness of the string isn't NO, but actually, IMMATERIAL, as there is nothing there that matters