### PR TITLE
Perl_force_locale_unlock: Add pTHX parameter

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1166,7 +1166,7 @@ Cp	|I32	|foldEQ_utf8_flags					\
 Adpx	|void	|forbid_outofblock_ops					\
 				|NN OP *o				\
 				|NN const char *blockname
-Tp	|void	|force_locale_unlock
+p	|void	|force_locale_unlock
 Cp	|void	|_force_out_malformed_utf8_message			\
 				|NN const U8 * const p			\
 				|NN const U8 * const e			\

--- a/embed.h
+++ b/embed.h
@@ -918,7 +918,7 @@
 #   define find_lexical_cv(a)                   Perl_find_lexical_cv(aTHX_ a)
 #   define find_runcv_where(a,b,c)              Perl_find_runcv_where(aTHX_ a,b,c)
 #   define find_script(a,b,c,d)                 Perl_find_script(aTHX_ a,b,c,d)
-#   define force_locale_unlock                  Perl_force_locale_unlock
+#   define force_locale_unlock()                Perl_force_locale_unlock(aTHX)
 #   define free_tied_hv_pool()                  Perl_free_tied_hv_pool(aTHX)
 #   define get_hash_seed(a)                     Perl_get_hash_seed(aTHX_ a)
 #   define get_no_modify()                      Perl_get_no_modify(aTHX)

--- a/locale.c
+++ b/locale.c
@@ -840,14 +840,12 @@ S_get_category_index_helper(pTHX_ const int category, bool * succeeded,
 #endif /* ifdef USE_LOCALE */
 
 void
-Perl_force_locale_unlock()
+Perl_force_locale_unlock(pTHX)
 {
     /* Remove any locale mutex, in preperation for an inglorious termination,
      * typically a  panic */
 
 #if defined(USE_LOCALE_THREADS)
-
-    dTHX;
 
     /* If recursively locked, clear all at once */
     if (PL_locale_mutex_depth > 1) {

--- a/proto.h
+++ b/proto.h
@@ -1162,7 +1162,7 @@ Perl_forbid_outofblock_ops(pTHX_ OP *o, const char *blockname);
         assert(o); assert(blockname)
 
 PERL_CALLCONV void
-Perl_force_locale_unlock(void)
+Perl_force_locale_unlock(pTHX)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_FORCE_LOCALE_UNLOCK
 


### PR DESCRIPTION
This replaces a dTHX inside the function, which is usable only by the perl core on platforms that allow hiding functions from external code. Thus this change should not break any applications.