### PR TITLE
Output line numbers for unsupported locale warnings

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -3227,7 +3227,7 @@ S_new_ctype(pTHX_ const char *newctype, bool force)
 
         Perl_ck_warner_d(aTHX_ packWARN(WARN_LOCALE),
                          "Locale '%s' is unsupported, and may crash the"
-                         " interpreter.\n",
+                         " interpreter",
                          newctype);
     }
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -3632,7 +3632,7 @@ the first approach, not using C<ispunct()> at all (see L<Note [5] in
 perlrecharclass|perlrecharclass/[5]>), and this message is raised to notify you that you
 are getting Perl's approach, not the locale's.
 
-=item Locale '%s' is unsupported, and may crash the interpreter.
+=item Locale '%s' is unsupported, and may crash the interpreter
 
 (S locale) The named locale is not supported by Perl, and using it leads
 to undefined behavior, including potentially crashing the computer.


### PR DESCRIPTION
This fixes #21352.

I'm reluctant to add a test, since, as the warning says, using such a locale can crash the interpreter, and so things currently are stacked against finding such locales on the system, and which locales are unsupported does vary by system.