### PR TITLE
-rpath wont work when targeting Mac OS X 10.3 on 10.5

### DIFF
--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -287,14 +287,14 @@ case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
    ldflags="${ldflags} -flat_namespace"
    lddlflags="${ldflags} -bundle -undefined suppress"
    ;;
-[7-9].*)   # OS X 10.3.x - 10.5.x
+[7-8].*)   # OS X 10.3.x - 10.4.x
    lddlflags="${ldflags} -bundle -undefined dynamic_lookup"
    case "$ld" in
        *MACOSX_DEPLOYMENT_TARGET*) ;;
        *) ld="env MACOSX_DEPLOYMENT_TARGET=10.3 ${ld}" ;;
    esac
    ;;
-*)        # OS X 10.6.x - current
+*)        # OS X 10.5.x - current
    # The MACOSX_DEPLOYMENT_TARGET is not needed,
    # but the -mmacosx-version-min option is always used.
 


### PR DESCRIPTION
Fixes build on Leopard 10.5 where the use of `-rpath` fails with 
`ld: -rpath can only be used when targetting Mac OS X 10.5 or later`.
Attempting to set `MACOSX_DEPLOYMENT_TARGET` is ignored.
We leave it set for 10.4 & prior as the linker would default to a deployment target of 10.1 on powerpc & 10.4 on intel builds and there's no issue with this on 10.4 currently.