### PR TITLE
pp_multiconcat: in Phase 7 (magic SVs) reuse an available targ pad

### DIFF
--- a/ext/B/B.pm
+++ b/ext/B/B.pm
@@ -20,7 +20,7 @@ sub import {
 # walkoptree comes from B.xs
 
 BEGIN {
-    $B::VERSION = '1.88';
+    $B::VERSION = '1.89';
     @B::EXPORT_OK = ();
 
     # Our BOOT code needs $VERSION set, and will append to @EXPORT_OK.

--- a/ext/B/B.xs
+++ b/ext/B/B.xs
@@ -1244,7 +1244,7 @@ aux_list(o, cv)
                 /* return (nargs, const string, segment len 0, 1, 2, ...) */
 
                 /* if this changes, this block of code probably needs fixing */
-                assert(PERL_MULTICONCAT_HEADER_SIZE == 5);
+                assert(PERL_MULTICONCAT_HEADER_SIZE == 6);
                 nargs = aux[PERL_MULTICONCAT_IX_NARGS].ssize;
                 EXTEND(SP, ((SSize_t)(2 + (nargs+1))));
                 PUSHs(sv_2mortal(newSViv((IV)nargs)));

--- a/peep.c
+++ b/peep.c
@@ -857,6 +857,7 @@ S_maybe_multiconcat(pTHX_ OP *o)
 
     /* Populate the aux struct */
 
+    aux[PERL_MULTICONCAT_MORTAL_PAD].pad_offset = pad_alloc(OP_MULTICONCAT, SVs_PADTMP);
     aux[PERL_MULTICONCAT_IX_NARGS].ssize     = nargs;
     aux[PERL_MULTICONCAT_IX_PLAIN_PV].pv    = utf8 ? NULL : const_str;
     aux[PERL_MULTICONCAT_IX_PLAIN_LEN].ssize = utf8 ?    0 : total_len;

--- a/perl.h
+++ b/perl.h
@@ -1605,13 +1605,14 @@ Use L</UV> to declare variables of the maximum usable size on this platform.
  * and if utf8 and non-utf8 differ, a second nargs+1 set for utf8.
  */
 
-#define PERL_MULTICONCAT_IX_NARGS     0 /* number of arguments */
-#define PERL_MULTICONCAT_IX_PLAIN_PV  1 /* non-utf8 constant string */
-#define PERL_MULTICONCAT_IX_PLAIN_LEN 2 /* non-utf8 constant string length */
-#define PERL_MULTICONCAT_IX_UTF8_PV   3 /* utf8 constant string */
-#define PERL_MULTICONCAT_IX_UTF8_LEN  4 /* utf8 constant string length */
-#define PERL_MULTICONCAT_IX_LENGTHS   5 /* first of nargs+1 const segment lens */
-#define PERL_MULTICONCAT_HEADER_SIZE 5 /* The number of fields of a
+#define PERL_MULTICONCAT_MORTAL_PAD   0 /* Local tmp stack for Phase 7 */
+#define PERL_MULTICONCAT_IX_NARGS     1 /* number of arguments */
+#define PERL_MULTICONCAT_IX_PLAIN_PV  2 /* non-utf8 constant string */
+#define PERL_MULTICONCAT_IX_PLAIN_LEN 3 /* non-utf8 constant string length */
+#define PERL_MULTICONCAT_IX_UTF8_PV   4 /* utf8 constant string */
+#define PERL_MULTICONCAT_IX_UTF8_LEN  5 /* utf8 constant string length */
+#define PERL_MULTICONCAT_IX_LENGTHS   6 /* first of nargs+1 const segment lens */
+#define PERL_MULTICONCAT_HEADER_SIZE 6 /* The number of fields of a
                                            multiconcat header */
 
 /* We no longer default to creating a new SV for GvSV.

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -1122,10 +1122,15 @@ PP(pp_multiconcat)
             }
 
             if (arg_count == 2 && i < n) {
-                /* for the first concat, create a mortal acting like the
-                 * padtmp from OP_CONST. In later iterations this will
-                 * be appended to */
-                nexttarg = sv_newmortal();
+                if (SvPADTMP(targ)) { /* Reuse current pad SV */
+                    SvPVCLEAR(targ);
+                    nexttarg = targ;
+                } else {
+                    /* for the first concat, create a mortal acting like the
+                     * padtmp from OP_CONST. In later iterations this will
+                     * be appended to */
+                    nexttarg = sv_newmortal();
+                }
                 nextappend = FALSE;
             }
             else {


### PR DESCRIPTION
When the op's own padslot is the targ for the op, using the SV in it for the string being built up, rather than creating a new mortal SV for the purpose, reduces the number of mortal SVs created during operation.

This is of relevance when the op will be called many times over within the same statement, such as when performing repeated concatenations during a substitution operation on a very large string. See GH #21360.