### PR TITLE
test.pl: avoid unnecessary work in like_yn()

### DIFF
--- a/t/test.pl
+++ b/t/test.pl
@@ -467,17 +467,17 @@ sub like_yn ($$$@) {
     # definitely not like(..., '/.../') like
     # Test::Builder::maybe_regex() does.
     unless (re::is_regexp($expected)) {
-	die "PANIC: The value '$expected' isn't a regexp. The like() function needs a qr// pattern, not a string";
+        die "PANIC: The value '$expected' isn't a regexp. The like() function needs a qr// pattern, not a string";
     }
 
     my $pass = ($flip) ? $_[1] !~ /$expected/ : $_[1] =~ /$expected/;
     unless ($pass) {
         my $display_got = display($_[1]);
         my $display_expected = display($expected);
-	unshift(@mess, "#      got '$display_got'\n",
-		$flip
-		? "# expected !~ /$display_expected/\n"
-                : "# expected /$display_expected/\n");
+        unshift(@mess, "#      got '$display_got'\n",
+            $flip
+            ? "# expected !~ /$display_expected/\n"
+            : "# expected /$display_expected/\n");
     }
     local $Level = $Level + 1;
     _ok($pass, _where(), $name, @mess);

--- a/t/test.pl
+++ b/t/test.pl
@@ -470,14 +470,10 @@ sub like_yn ($$$@) {
 	die "PANIC: The value '$expected' isn't a regexp. The like() function needs a qr// pattern, not a string";
     }
 
-    my $pass;
-    $pass = $_[1] =~ /$expected/ if !$flip;
-    $pass = $_[1] !~ /$expected/ if $flip;
-    my $display_got = $_[1];
-    $display_got = display($display_got);
-    my $display_expected = $expected;
-    $display_expected = display($display_expected);
+    my $pass = ($flip) ? $_[1] !~ /$expected/ : $_[1] =~ /$expected/;
     unless ($pass) {
+        my $display_got = display($_[1]);
+        my $display_expected = display($expected);
 	unshift(@mess, "#      got '$display_got'\n",
 		$flip
 		? "# expected !~ /$display_expected/\n"


### PR DESCRIPTION
`like_yn()` underpins `like()` and `unlike()` in _test.pl_, so is a fairly hot subroutine when running perl's test suite.

This commit is a light refactor that does two main things:
* Moves the `$display_got` and `$display_expected` definitions to only the branch where they will actually be used.
* Simplifies the definitions of `$pass`, `$display_got`, and `$display_expected` to make them clearer and more efficient.