### PR TITLE
locale.c: Compile utf8ness on platforms that need it

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4316,12 +4316,6 @@ op	|SV *	|hfree_next_entry					\
 				|NN STRLEN *indexp
 #endif
 #if defined(PERL_IN_LOCALE_C)
-S	|utf8ness_t|get_locale_string_utf8ness_i			\
-				|NULLOK const char *string		\
-				|const locale_utf8ness_t known_utf8	\
-				|NULLOK const char *locale		\
-				|const unsigned cat_index
-S	|bool	|is_locale_utf8 |NN const char *locale
 # if defined(HAS_LOCALECONV)
 S	|HV *	|my_localeconv	|const int item
 S	|void	|populate_hash_from_localeconv				\
@@ -4330,6 +4324,15 @@ S	|void	|populate_hash_from_localeconv				\
 				|const U32 which_mask			\
 				|NN const lconv_offset_t *strings[2]	\
 				|NULLOK const lconv_offset_t *integers
+# endif
+# if defined(HAS_LOCALECONV) || defined(HAS_SOME_LANGINFO) || \
+     defined(USE_LOCALE)
+S	|utf8ness_t|get_locale_string_utf8ness_i			\
+				|NULLOK const char *string		\
+				|const locale_utf8ness_t known_utf8	\
+				|NULLOK const char *locale		\
+				|const unsigned cat_index
+S	|bool	|is_locale_utf8 |NN const char *locale
 # endif
 # if defined(USE_LOCALE)
 S	|const char *|calculate_LC_ALL_string					\

--- a/embed.h
+++ b/embed.h
@@ -1262,11 +1262,14 @@
 #     endif
 #   endif /* defined(PERL_IN_HV_C) */
 #   if defined(PERL_IN_LOCALE_C)
-#     define get_locale_string_utf8ness_i(a,b,c,d) S_get_locale_string_utf8ness_i(aTHX_ a,b,c,d)
-#     define is_locale_utf8(a)                  S_is_locale_utf8(aTHX_ a)
 #     if defined(HAS_LOCALECONV)
 #       define my_localeconv(a)                 S_my_localeconv(aTHX_ a)
 #       define populate_hash_from_localeconv(a,b,c,d,e) S_populate_hash_from_localeconv(aTHX_ a,b,c,d,e)
+#     endif
+#     if defined(HAS_LOCALECONV) || defined(HAS_SOME_LANGINFO) || \
+         defined(USE_LOCALE)
+#       define get_locale_string_utf8ness_i(a,b,c,d) S_get_locale_string_utf8ness_i(aTHX_ a,b,c,d)
+#       define is_locale_utf8(a)                S_is_locale_utf8(aTHX_ a)
 #     endif
 #     if defined(USE_LOCALE)
 #       define calculate_LC_ALL_string(a,b,c)   S_calculate_LC_ALL_string(aTHX_ a,b,c)

--- a/locale.c
+++ b/locale.c
@@ -4681,6 +4681,9 @@ S_populate_hash_from_localeconv(pTHX_ HV * hv,
     PERL_ARGS_ASSERT_POPULATE_HASH_FROM_LOCALECONV;
     PERL_UNUSED_ARG(which_mask);    /* Some configurations don't use this;
                                        complicated to figure out which */
+#  ifndef USE_LOCALE
+    PERL_UNUSED_ARG(locale);
+#  endif
 
     /* Run localeconv() and copy some or all of its results to the input 'hv'
      * hash.  Most localeconv() implementations return the values in a global

--- a/locale.c
+++ b/locale.c
@@ -3879,6 +3879,8 @@ Perl_setlocale(const int category, const char * locale)
 
 }
 
+#if defined(USE_LOCALE) || defined(HAS_SOME_LANGINFO) || defined(HAS_LOCALECONV)
+
 STATIC utf8ness_t
 S_get_locale_string_utf8ness_i(pTHX_ const char * string,
                                      const locale_utf8ness_t known_utf8,
@@ -3994,8 +3996,8 @@ S_get_locale_string_utf8ness_i(pTHX_ const char * string,
 
     return UTF8NESS_YES;
 
+#    endif
 #  endif
-#endif
 
 }
 
@@ -4050,6 +4052,7 @@ S_is_locale_utf8(pTHX_ const char * locale)
 
 }
 
+#endif
 #ifdef USE_LOCALE
 
 STATIC const char *

--- a/proto.h
+++ b/proto.h
@@ -6951,15 +6951,6 @@ Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
 
 #endif
 #if defined(PERL_IN_LOCALE_C)
-STATIC utf8ness_t
-S_get_locale_string_utf8ness_i(pTHX_ const char *string, const locale_utf8ness_t known_utf8, const char *locale, const unsigned cat_index);
-# define PERL_ARGS_ASSERT_GET_LOCALE_STRING_UTF8NESS_I
-
-STATIC bool
-S_is_locale_utf8(pTHX_ const char *locale);
-# define PERL_ARGS_ASSERT_IS_LOCALE_UTF8        \
-        assert(locale)
-
 # if defined(HAS_LOCALECONV)
 STATIC HV *
 S_my_localeconv(pTHX_ const int item);
@@ -6971,6 +6962,19 @@ S_populate_hash_from_localeconv(pTHX_ HV *hv, const char *locale, const U32 whic
         assert(hv); assert(locale); assert(strings)
 
 # endif /* defined(HAS_LOCALECONV) */
+# if defined(HAS_LOCALECONV) || defined(HAS_SOME_LANGINFO) || \
+     defined(USE_LOCALE)
+STATIC utf8ness_t
+S_get_locale_string_utf8ness_i(pTHX_ const char *string, const locale_utf8ness_t known_utf8, const char *locale, const unsigned cat_index);
+#   define PERL_ARGS_ASSERT_GET_LOCALE_STRING_UTF8NESS_I
+
+STATIC bool
+S_is_locale_utf8(pTHX_ const char *locale);
+#   define PERL_ARGS_ASSERT_IS_LOCALE_UTF8      \
+        assert(locale)
+
+# endif /* defined(HAS_LOCALECONV) || defined(HAS_SOME_LANGINFO) ||
+           defined(USE_LOCALE) */
 # if defined(USE_LOCALE)
 STATIC const char *
 S_calculate_LC_ALL_string(pTHX_ const char **category_locales_list, const calc_LC_ALL_format format, const line_t caller_line);


### PR DESCRIPTION
These two functions need to be compiled on certain other platforms than
what was happening.

I don't remember which platforms