### PR TITLE
locale.c: Avoid unnecessary freeing and reallocating

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -3657,13 +3657,16 @@ S_win32_setlocale(pTHX_ int category, const char* locale)
 
 #    ifdef USE_PL_CUR_LC_ALL
 
-    /* If we need to keep track of LC_ALL, update it to the new value.  */
-    Safefree(PL_cur_LC_ALL);
-    if (category == LC_ALL) {
-        PL_cur_LC_ALL = savepv(result);
-    }
-    else {
-        PL_cur_LC_ALL = savepv(wrap_wsetlocale(LC_ALL, NULL));
+    /* Here, we need to keep track of LC_ALL.  If we set it directly above, we
+     * already know what it is; otherwise query the new value. */
+    const char * new_lc_all = ((category == LC_ALL)
+                               ? result
+                               : wrap_wsetlocale(LC_ALL, NULL));
+
+    /* And update if it has changed. */
+    if (strNE(new_lc_all, PL_cur_LC_ALL)) {
+        Safefree(PL_cur_LC_ALL);
+        PL_cur_LC_ALL = savepv(new_lc_all);
     }
 
 #    endif

--- a/locale.c
+++ b/locale.c
@@ -3655,6 +3655,11 @@ S_win32_setlocale(pTHX_ int category, const char* locale)
     DEBUG_L(PerlIO_printf(Perl_debug_log, "%s\n",
                           setlocale_debug_string_r(category, locale, result)));
 
+    if (! result) {
+        SET_EINVAL;
+        return NULL;
+    }
+
 #    ifdef USE_PL_CUR_LC_ALL
 
     /* Here, we need to keep track of LC_ALL.  If we set it directly above, we

--- a/locale.c
+++ b/locale.c
@@ -6308,6 +6308,11 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
     }
 
 #  endif
+#  ifdef USE_PL_CUR_LC_ALL
+
+    PL_cur_LC_ALL = savepv("C");
+
+#  endif
 #  if ! defined(PERL_LC_ALL_USES_NAME_VALUE_PAIRS) && defined(LC_ALL)
 
     LOCALE_LOCK;


### PR DESCRIPTION
Check first if an interpreter variable has actually changed before going to the trouble of freeing its memory and reallocating and populating it.