### PR TITLE
perl.h: Add UNLESS_PERL_MEM_LOG()

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -898,6 +898,15 @@ symbol would not be defined on C<L</EBCDIC>> platforms.
 #define STANDARD_C
 #endif
 
+/* Don't compile 'code' if PERL_MEM_LOG is defined.  This is used for
+ * constructs that don't play well when PERL_MEM_LOG is active, so that they
+ * automatically don't get compiled without having to use extra #ifdef's */
+#ifndef PERL_MEM_LOG
+#  define UNLESS_PERL_MEM_LOG(code)  code
+#else
+#  define UNLESS_PERL_MEM_LOG(code)
+#endif
+
 /* By compiling a perl with -DNO_TAINT_SUPPORT or -DSILENT_NO_TAINT_SUPPORT,
  * you get a perl without taint support, but doubtlessly with a lesser
  * degree of support. Do not do so unless you know exactly what it means

--- a/perl.h
+++ b/perl.h
@@ -7090,20 +7090,23 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
         STMT_START {                                                        \
             CLANG_DIAG_IGNORE(-Wthread-safety)                              \
             if (LIKELY(PL_locale_mutex_depth <= 0)) {                       \
-                DEBUG_Lv(PerlIO_printf(Perl_debug_log,                      \
+                UNLESS_PERL_MEM_LOG(DEBUG_Lv(PerlIO_printf(Perl_debug_log,  \
                          "%s: %d: locking locale; lock depth=1\n",          \
                          __FILE__, __LINE__));                              \
+                )                                                           \
                 MUTEX_LOCK(&PL_locale_mutex);                               \
                 PL_locale_mutex_depth = 1;                                  \
-                DEBUG_Lv(PerlIO_printf(Perl_debug_log,                      \
+                UNLESS_PERL_MEM_LOG(DEBUG_Lv(PerlIO_printf(Perl_debug_log,  \
                          "%s: %d: locale locked; lock depth=1\n",           \
                          __FILE__, __LINE__));                              \
+                )                                                           \
             }                                                               \
             else {                                                          \
                 PL_locale_mutex_depth++;                                    \
-                DEBUG_Lv(PerlIO_printf(Perl_debug_log,                      \
+                UNLESS_PERL_MEM_LOG(DEBUG_Lv(PerlIO_printf(Perl_debug_log,  \
                         "%s: %d: avoided locking locale; new lock depth=%d\n",\
                         __FILE__, __LINE__, PL_locale_mutex_depth));        \
+                )                                                           \
                 if (cond_to_panic_if_already_locked) {                      \
                     locale_panic_("Trying to lock locale incompatibly: "    \
                          STRINGIFY(cond_to_panic_if_already_locked));       \
@@ -7115,9 +7118,10 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  define LOCALE_UNLOCK_                                                    \
         STMT_START {                                                        \
             if (LIKELY(PL_locale_mutex_depth == 1)) {                       \
-                DEBUG_Lv(PerlIO_printf(Perl_debug_log,                      \
+                UNLESS_PERL_MEM_LOG(DEBUG_Lv(PerlIO_printf(Perl_debug_log,  \
                          "%s: %d: unlocking locale; new lock depth=0\n",    \
                          __FILE__, __LINE__));                              \
+                )                                                           \
                 PL_locale_mutex_depth = 0;                                  \
                 MUTEX_UNLOCK(&PL_locale_mutex);                             \
             }                                                               \
@@ -7129,9 +7133,10 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
             }                                                               \
             else {                                                          \
                 PL_locale_mutex_depth--;                                    \
-                DEBUG_Lv(PerlIO_printf(Perl_debug_log,                      \
+                UNLESS_PERL_MEM_LOG(DEBUG_Lv(PerlIO_printf(Perl_debug_log,  \
                     "%s: %d: avoided unlocking locale; new lock depth=%d\n",\
                     __FILE__, __LINE__, PL_locale_mutex_depth));            \
+                )                                                           \
             }                                                               \
         } STMT_END
 


### PR DESCRIPTION
This is to be used to wrap code that should not be compiled if
PERL_MEM_LOG is defined.  Some things don't play well with that, and
this keeps them from being compiled automatically without extra #ifdefs