### PR TITLE
various: timespec/timeval.tv_sec is time_t, not long, according to POSIX

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -72,6 +72,7 @@ Alexander Foken
 Alexander Gernler              <alexander_gernler@genua.de>
 Alexander Gough                <alex-p5p@earth.li>
 Alexander Hartmaier            <abraxxa@cpan.org>
+Alexander Kanavin              <alex@linutronix.de>
 Alexander Klimov               <ask@wisdom.weizmann.ac.il>
 Alexander Nikolov              <sasho648@gmail.com>
 Alexander Smishlajev           <als@turnhere.com>

--- a/dist/threads-shared/lib/threads/shared.pm
+++ b/dist/threads-shared/lib/threads/shared.pm
@@ -8,7 +8,7 @@ use Config;
 
 use Scalar::Util qw(reftype refaddr blessed);
 
-our $VERSION = '1.68'; # Please update the pod, too.
+our $VERSION = '1.69'; # Please update the pod, too.
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 

--- a/dist/threads-shared/shared.xs
+++ b/dist/threads-shared/shared.xs
@@ -697,7 +697,7 @@ Perl_sharedsv_cond_timedwait(perl_cond *cond, perl_mutex *mut, double abs)
     struct timespec ts;
     int got_it = 0;
 
-    ts.tv_sec = (long)abs;
+    ts.tv_sec = (time_t)abs;
     abs -= (NV)ts.tv_sec;
     ts.tv_nsec = (long)(abs * 1000000000.0);
 

--- a/doio.c
+++ b/doio.c
@@ -2874,9 +2874,9 @@ nothing in the core.
            else {
                 Zero(&utbuf, sizeof utbuf, char);
 #ifdef HAS_FUTIMES
-                utbuf[0].tv_sec = (long)SvIV(accessed);  /* time accessed */
+                utbuf[0].tv_sec = (time_t)SvIV(accessed);  /* time accessed */
                 utbuf[0].tv_usec = 0;
-                utbuf[1].tv_sec = (long)SvIV(modified);  /* time modified */
+                utbuf[1].tv_sec = (time_t)SvIV(modified);  /* time modified */
                 utbuf[1].tv_usec = 0;
 #elif defined(BIG_TIME)
                 utbuf.actime = (Time_t)SvNV(accessed);  /* time accessed */

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -1228,7 +1228,7 @@ PP(pp_sselect)
         value = SvNV_nomg(sv);
         if (value < 0.0)
             value = 0.0;
-        timebuf.tv_sec = (long)value;
+        timebuf.tv_sec = (time_t)value;
         value -= (NV)timebuf.tv_sec;
         timebuf.tv_usec = (long)(value * 1000000.0);
     }


### PR DESCRIPTION
This matters on 32 bit systems configured with 64 bit time_t (so they survive beyond 2038). Casting them to long is causing loss of bits and badly mismatched time data.