### PR TITLE
Set builtin::indexed proto to "@"

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -552,6 +552,8 @@ Perl_boot_core_builtin(pTHX)
             proto = "";
         else if(builtin->checker == &ck_builtin_func1)
             proto = "$";
+        else if(builtin->checker == &ck_builtin_funcN)
+            proto = "@";
 
         CV *cv = newXS_flags(builtin->name, builtin->xsub, __FILE__, proto, 0);
         XSANY.any_i32 = builtin->ckval;

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -305,6 +305,8 @@ package FetchStoreCounter {
         my $count = indexed 'i', 'ii', 'iii', 'iv';
         is($count, 8, 'indexed in scalar context yields size of list it would return');
     }
+
+    is(prototype(\&builtin::indexed), '@', 'indexed prototype');
 }
 
 # Vanilla trim tests


### PR DESCRIPTION
I can't see it making much difference in practice but I feel for consistency if nothing else it should be this.