### PR TITLE
OP_EMPTYAVHV: create ops in newANONHASH/newANONLIST rather than rpeep

### DIFF
--- a/op.c
+++ b/op.c
@@ -2440,6 +2440,12 @@ Perl_scalarvoid(pTHX_ OP *arg)
         case OP_SCALAR:
             scalar(o);
             break;
+        case OP_EMPTYAVHV:
+            if (!(o->op_private & OPpTARGET_MY))
+                useless = (o->op_private & OPpEMPTYAVHV_IS_HV) ?
+                           "anonymous hash ({})" :
+                           "anonymous array ([])";
+            break;
         }
 
         if (useless_sv) {
@@ -11661,13 +11667,18 @@ Perl_newFORM(pTHX_ I32 floor, OP *o, OP *block)
 OP *
 Perl_newANONLIST(pTHX_ OP *o)
 {
-    return op_convert_list(OP_ANONLIST, OPf_SPECIAL, o);
+    return (o) ? op_convert_list(OP_ANONLIST, OPf_SPECIAL, o)
+               : newOP(OP_EMPTYAVHV, 0);
 }
 
 OP *
 Perl_newANONHASH(pTHX_ OP *o)
 {
-    return op_convert_list(OP_ANONHASH, OPf_SPECIAL, o);
+    OP * anon = (o) ? op_convert_list(OP_ANONHASH, OPf_SPECIAL, o)
+                    : newOP(OP_EMPTYAVHV, 0);
+    if (!o)
+        anon->op_private |= OPpEMPTYAVHV_IS_HV;
+    return anon;
 }
 
 OP *
@@ -13073,18 +13084,26 @@ S_maybe_targlex(pTHX_ OP *o)
         OP * const kkid = OpSIBLING(kid);
 
         /* Can just relocate the target. */
-        if (kkid && kkid->op_type == OP_PADSV
-            && (!(kkid->op_private & OPpLVAL_INTRO)
-               || kkid->op_private & OPpPAD_STATE))
-        {
-            kid->op_targ = kkid->op_targ;
-            kkid->op_targ = 0;
-            /* Now we do not need PADSV and SASSIGN.
-             * Detach kid and free the rest. */
-            op_sibling_splice(o, NULL, 1, NULL);
-            op_free(o);
-            kid->op_private |= OPpTARGET_MY;	/* Used for context settings */
-            return kid;
+        if (kkid && kkid->op_type == OP_PADSV) {
+            if (kid->op_type == OP_EMPTYAVHV) {
+                kid->op_flags |= kid->op_flags |
+                              (o->op_flags & (OPf_WANT|OPf_PARENS));
+                kid->op_private |= OPpTARGET_MY |
+                              (kkid->op_private & (OPpLVAL_INTRO|OPpPAD_STATE));
+                goto swipe_and_detach;
+            } else if (!(kkid->op_private & OPpLVAL_INTRO)
+                   || (kkid->op_private & OPpPAD_STATE))
+            {
+                kid->op_private |= OPpTARGET_MY;       /* Used for context settings */
+            swipe_and_detach:
+                kid->op_targ = kkid->op_targ;
+                kkid->op_targ = 0;
+                /* Now we do not need PADSV and SASSIGN.
+                 * Detach kid and free the rest. */
+                op_sibling_splice(o, NULL, 1, NULL);
+                op_free(o);
+                return kid;
+            }
         }
     }
     return o;

--- a/opcode.h
+++ b/opcode.h
@@ -2018,7 +2018,7 @@ EXTCONST U32 PL_opargs[] INIT({
 	0x00224200,	/* lslice */
 	0x00002405,	/* anonlist */
 	0x00002405,	/* anonhash */
-	0x0000241c,	/* emptyavhv */
+	0x0000001c,	/* emptyavhv */
 	0x02993401,	/* splice */
 	0x0002341d,	/* push */
 	0x0000bb04,	/* pop */

--- a/peep.c
+++ b/peep.c
@@ -3151,62 +3151,6 @@ Perl_rpeep(pTHX_ OP *o)
                 }
             }
 
-            /* If the pushmark is associated with an empty anonhash
-             * or anonlist, null out the pushmark and swap in a
-             * specialised op for the parent.
-             *     4        <@> anonhash sK* ->5
-             *     3           <0> pushmark s ->4
-             * becomes:
-             *     3        <@> emptyavhv sK* ->4
-             *     -           <0> pushmark s ->3
-             */
-            if (!OpHAS_SIBLING(o) && (o->op_next == o->op_sibparent) && (
-                (o->op_next->op_type == OP_ANONHASH) ||
-                (o->op_next->op_type == OP_ANONLIST) ) &&
-                (o->op_next->op_flags & OPf_SPECIAL) ) {
-
-                OP* anon = o->op_next;
-                /* These next two are _potentially_ a padsv and an sassign */
-                OP* padsv = anon->op_next;
-                OP* sassign = (padsv) ? padsv->op_next: NULL;
-
-                anon->op_private = (anon->op_type == OP_ANONLIST) ?
-                                                0 : OPpEMPTYAVHV_IS_HV;
-                OpTYPE_set(anon, OP_EMPTYAVHV);
-                op_null(o);
-                o = anon;
-                if (oldop) /* A previous optimization may have NULLED it */
-                    oldop->op_next = anon;
-
-                /* Further optimise scalar assignment of an empty anonhash
-                 * or anonlist by subsuming the padsv & sassign OPs. */
-                if ((padsv->op_type == OP_PADSV) &&
-                    !(padsv->op_private & OPpDEREF) &&
-                    sassign && (sassign->op_type == OP_SASSIGN) ){
-
-                    /* Take some public flags from the sassign */
-                    anon->op_flags = OPf_KIDS | OPf_SPECIAL |
-                        (anon->op_flags & OPf_PARENS) |
-                        (sassign->op_flags & (OPf_WANT|OPf_PARENS));
-
-                    /* Take some private flags from the padsv */
-                    anon->op_private |= OPpTARGET_MY |
-                        (padsv->op_private & (OPpLVAL_INTRO|OPpPAD_STATE));
-
-                    /* Take the targ slot from the padsv*/
-                    anon->op_targ = padsv->op_targ;
-                    padsv->op_targ = 0;
-
-                    /* Clean up */
-                    anon->op_next = sassign->op_next;
-                    op_null(padsv);
-                    op_null(sassign);
-                }
-                break;
-
-            }
-
-
             /* Convert a series of PAD ops for my vars plus support into a
              * single padrange op. Basically
              *

--- a/regen/opcodes
+++ b/regen/opcodes
@@ -261,7 +261,7 @@ list		list			ck_null		m@	L
 lslice		list slice		ck_null		2	H L L
 anonlist	anonymous array ([])	ck_fun		ms@	L
 anonhash	anonymous hash ({})	ck_fun		ms@	L
-emptyavhv	empty anon hash/array	ck_fun		sT@	L
+emptyavhv	empty anon hash/array	ck_fun		sT0
 
 splice		splice			ck_fun		m@	A S? S? L
 push		push			ck_fun		imsT@	A L


### PR DESCRIPTION
The current implementation of the OP_EMPTYAVHV optimization does not optimize instances of empty anonymous hashes/lists on the RHS of LOGOP conditions, such as in `my $x = $y || {}`.

This commit addresses this by removing the peephole optimization in favour of having EMPTYAVHV OPs produced directly whenever a call is made to `newANONHASH` or `newANONLIST` with an empty child OP `o`. The standard TARGMY optimization in `S_maybe_targlex` has been slightly adapted to also optimize the `LVINTRO` case for this OP.

This commit also addresses some feedback nits from the last dev cycle: EMPTYAVHV is no longer a LISTOP, now just a BASEOP, and it does not use the OPf_SPECIAL flag. (Both were unnecessary carryovers from the ANONHASH and ANONLIST OPs.)