### PR TITLE
     Fix ignoring locale categories

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4457,6 +4457,7 @@ S	|void	|give_perl_locale_control				\
 S	|parse_LC_ALL_string_return|parse_LC_ALL_string 		\
 				|NN const char *string			\
 				|NN const char **output 		\
+				|const parse_LC_ALL_STRING_action	\
 				|bool always_use_full_array		\
 				|const bool panic_on_error		\
 				|const line_t caller_line

--- a/embed.h
+++ b/embed.h
@@ -1315,7 +1315,7 @@
 #       endif
 #       if defined(LC_ALL)
 #         define give_perl_locale_control(a,b)  S_give_perl_locale_control(aTHX_ a,b)
-#         define parse_LC_ALL_string(a,b,c,d,e) S_parse_LC_ALL_string(aTHX_ a,b,c,d,e)
+#         define parse_LC_ALL_string(a,b,c,d,e,f) S_parse_LC_ALL_string(aTHX_ a,b,c,d,e,f)
 #       else
 #         define give_perl_locale_control(a,b)  S_give_perl_locale_control(aTHX_ a,b)
 #       endif

--- a/locale.c
+++ b/locale.c
@@ -651,7 +651,7 @@ static const char C_thousands_sep[] = "";
 /* Below are parallel arrays for locale information indexed by our mapping of
  * category numbers into small non-negative indexes.  locale_table.h contains
  * an entry like this for each individual category used on this system:
- *      PERL_LOCALE_TABLE_ENTRY(LC_CTYPE, S_new_ctype)
+ *      PERL_LOCALE_TABLE_ENTRY(CTYPE, S_new_ctype)
  *
  * Each array redefines PERL_LOCALE_TABLE_ENTRY to generate the information
  * needed for that array, and #includes locale_table.h to get the valid
@@ -672,7 +672,7 @@ static const char C_thousands_sep[] = "";
 STATIC const int categories[] = {
 
 #  undef PERL_LOCALE_TABLE_ENTRY
-#  define PERL_LOCALE_TABLE_ENTRY(name, call_back)  name,
+#  define PERL_LOCALE_TABLE_ENTRY(name, call_back)  LC_ ## name,
 #  include "locale_table.h"
 
 #  ifdef LC_ALL
@@ -685,11 +685,14 @@ STATIC const int categories[] = {
                            to clash with a real category */
 };
 
+# define GET_NAME_AS_STRING(token)  # token
+# define GET_LC_NAME_AS_STRING(token) GET_NAME_AS_STRING(LC_ ## token)
+
 /* The second array is the category names. */
 STATIC const char * const category_names[] = {
 
 #  undef PERL_LOCALE_TABLE_ENTRY
-#  define PERL_LOCALE_TABLE_ENTRY(name, call_back)  # name,
+#  define PERL_LOCALE_TABLE_ENTRY(name, call_back)  GET_LC_NAME_AS_STRING(name),
 #  include "locale_table.h"
 
 #  ifdef LC_ALL
@@ -710,7 +713,8 @@ STATIC const char * const category_names[] = {
 STATIC const Size_t category_name_lengths[] = {
 
 #  undef PERL_LOCALE_TABLE_ENTRY
-#  define PERL_LOCALE_TABLE_ENTRY(name, call_back)  STRLENs(# name),
+#  define PERL_LOCALE_TABLE_ENTRY(name, call_back)                          \
+                                    STRLENs(GET_LC_NAME_AS_STRING(name)),
 #  include "locale_table.h"
 
     STRLENs(LC_ALL_STRING),
@@ -719,7 +723,8 @@ STATIC const Size_t category_name_lengths[] = {
 
 /* Each entry includes space for the '=' and ';' */
 #  undef PERL_LOCALE_TABLE_ENTRY
-#  define PERL_LOCALE_TABLE_ENTRY(name, call_back)  + STRLENs(# name) + 2
+#  define PERL_LOCALE_TABLE_ENTRY(name, call_back)                          \
+                                + STRLENs(GET_LC_NAME_AS_STRING(name)) + 2
 
 STATIC const Size_t lc_all_boiler_plate_length = 1  /* space for trailing NUL */
 #  include "locale_table.h"
@@ -742,7 +747,7 @@ STATIC void (*update_functions[]) (pTHX_ const char *, bool force) = {
 STATIC const int category_masks[] = {
 
 #    undef PERL_LOCALE_TABLE_ENTRY
-#    define PERL_LOCALE_TABLE_ENTRY(name, call_back)  name ## _MASK,
+#    define PERL_LOCALE_TABLE_ENTRY(name, call_back)  LC_ ## name ## _MASK,
 #    include "locale_table.h"
 
     LC_ALL_MASK,    /* Will rightly refuse to compile unless this is defined */
@@ -836,7 +841,7 @@ S_get_category_index_helper(pTHX_ const int category, bool * succeeded,
 
 #  undef PERL_LOCALE_TABLE_ENTRY
 #  define PERL_LOCALE_TABLE_ENTRY(name, call_back)                          \
-                                    case name: i =  name ## _INDEX_; break;
+                    case LC_ ## name: i =  LC_ ## name ## _INDEX_; break;
 
     switch (category) {
 

--- a/locale.c
+++ b/locale.c
@@ -730,7 +730,7 @@ STATIC const Size_t lc_all_boiler_plate_length = 1  /* space for trailing NUL */
 STATIC void (*update_functions[]) (pTHX_ const char *, bool force) = {
 
 #  undef PERL_LOCALE_TABLE_ENTRY
-#  define PERL_LOCALE_TABLE_ENTRY(index, call_back)  call_back,
+#  define PERL_LOCALE_TABLE_ENTRY(name, call_back)  call_back,
 #  include "locale_table.h"
 
     S_new_LC_ALL,

--- a/locale_table.h
+++ b/locale_table.h
@@ -22,45 +22,118 @@
  * changed into, or NULL if no such set up is needed
  */
 
-#ifdef USE_LOCALE_CTYPE
+#ifdef LC_CTYPE
+#  ifndef NO_LOCALE_CTYPE
+
     PERL_LOCALE_TABLE_ENTRY(LC_CTYPE, S_new_ctype)
+
+#    define USE_LOCALE_CTYPE
+#  endif
 #endif
-#ifdef USE_LOCALE_NUMERIC
+#ifdef LC_NUMERIC
+#  ifndef NO_LOCALE_NUMERIC
+
     PERL_LOCALE_TABLE_ENTRY(LC_NUMERIC, S_new_numeric)
+
+#    define USE_LOCALE_NUMERIC
+#  endif
 #endif
-#ifdef USE_LOCALE_COLLATE
+#ifdef LC_COLLATE
+#  if ! defined(NO_LOCALE_COLLATE) && defined(HAS_STRXFRM)
+
+        /* Perl outsources all its collation efforts to the libc strxfrm(), so
+         * if it isn't available on the system, default "C" locale collation
+         * gets used */
     PERL_LOCALE_TABLE_ENTRY(LC_COLLATE, S_new_collate)
+
+#    define USE_LOCALE_COLLATE
+#  endif
 #endif
-#ifdef USE_LOCALE_TIME
+#ifdef LC_TIME
+#  ifndef NO_LOCALE_TIME
+
     PERL_LOCALE_TABLE_ENTRY(LC_TIME, NULL)
+
+#    define USE_LOCALE_TIME
+#  endif
 #endif
-#ifdef USE_LOCALE_MESSAGES
+#ifdef LC_MESSAGES
+#  ifndef NO_LOCALE_MESSAGES
+
     PERL_LOCALE_TABLE_ENTRY(LC_MESSAGES, NULL)
+
+#    define USE_LOCALE_MESSAGES
+#  endif
 #endif
-#ifdef USE_LOCALE_MONETARY
+#ifdef LC_MONETARY
+#  ifndef NO_LOCALE_MONETARY
+
     PERL_LOCALE_TABLE_ENTRY(LC_MONETARY, NULL)
+
+#    define USE_LOCALE_MONETARY
+#  endif
 #endif
-#ifdef USE_LOCALE_ADDRESS
+#ifdef LC_ADDRESS
+#  ifndef NO_LOCALE_ADDRESS
+
     PERL_LOCALE_TABLE_ENTRY(LC_ADDRESS, NULL)
+
+#    define USE_LOCALE_ADDRESS
+#  endif
 #endif
-#ifdef USE_LOCALE_IDENTIFICATION
+#ifdef LC_IDENTIFICATION
+#  ifndef NO_LOCALE_IDENTIFICATION
+
     PERL_LOCALE_TABLE_ENTRY(LC_IDENTIFICATION, NULL)
+
+#    define USE_LOCALE_IDENTIFICATION
+#  endif
 #endif
-#ifdef USE_LOCALE_MEASUREMENT
+#ifdef LC_MEASUREMENT
+#  ifndef NO_LOCALE_MEASUREMENT
+
     PERL_LOCALE_TABLE_ENTRY(LC_MEASUREMENT, NULL)
+
+#    define USE_LOCALE_MEASUREMENT
+#  endif
 #endif
-#ifdef USE_LOCALE_PAPER
+#ifdef LC_PAPER
+#  ifndef NO_LOCALE_PAPER
+
     PERL_LOCALE_TABLE_ENTRY(LC_PAPER, NULL)
+
+#    define USE_LOCALE_PAPER
+#  endif
 #endif
-#ifdef USE_LOCALE_TELEPHONE
+#ifdef LC_TELEPHONE
+#  ifndef NO_LOCALE_TELEPHONE
+
     PERL_LOCALE_TABLE_ENTRY(LC_TELEPHONE, NULL)
+
+#    define USE_LOCALE_TELEPHONE
+#  endif
 #endif
-#ifdef USE_LOCALE_NAME
+#ifdef LC_NAME
+#  ifndef NO_LOCALE_NAME
+
     PERL_LOCALE_TABLE_ENTRY(LC_NAME, NULL)
+
+#    define USE_LOCALE_NAME
+#  endif
 #endif
-#ifdef USE_LOCALE_SYNTAX
+#ifdef LC_SYNTAX
+#  ifndef NO_LOCALE_SYNTAX
+
     PERL_LOCALE_TABLE_ENTRY(LC_SYNTAX, NULL)
+
+#    define USE_LOCALE_SYNTAX
+#  endif
 #endif
-#ifdef USE_LOCALE_TOD
+#ifdef LC_TOD
+#  ifndef NO_LOCALE_TOD
+
     PERL_LOCALE_TABLE_ENTRY(LC_TOD, NULL)
+
+#    define USE_LOCALE_TOD
+#  endif
 #endif

--- a/locale_table.h
+++ b/locale_table.h
@@ -23,117 +23,173 @@
  */
 
 #ifdef LC_CTYPE
-#  ifndef NO_LOCALE_CTYPE
 
     PERL_LOCALE_TABLE_ENTRY(CTYPE, S_new_ctype)
 
+#  ifdef NO_LOCALE_CTYPE
+#    define HAS_IGNORED_LOCALE_CATEGORIES_
+#    define LC_CTYPE_AVAIL_  false
+#  else
+#    define LC_CTYPE_AVAIL_  true
 #    define USE_LOCALE_CTYPE
 #  endif
 #endif
 #ifdef LC_NUMERIC
-#  ifndef NO_LOCALE_NUMERIC
 
     PERL_LOCALE_TABLE_ENTRY(NUMERIC, S_new_numeric)
 
+#  ifdef NO_LOCALE_NUMERIC
+#    define HAS_IGNORED_LOCALE_CATEGORIES_
+#    define LC_NUMERIC_AVAIL_  false
+#  else
+#    define LC_NUMERIC_AVAIL_  true
 #    define USE_LOCALE_NUMERIC
 #  endif
 #endif
 #ifdef LC_COLLATE
-#  if ! defined(NO_LOCALE_COLLATE) && defined(HAS_STRXFRM)
+
+    PERL_LOCALE_TABLE_ENTRY(COLLATE, S_new_collate)
 
         /* Perl outsources all its collation efforts to the libc strxfrm(), so
          * if it isn't available on the system, default "C" locale collation
          * gets used */
-    PERL_LOCALE_TABLE_ENTRY(COLLATE, S_new_collate)
-
+#  if defined(NO_LOCALE_COLLATE) || ! defined(HAS_STRXFRM)
+#    define HAS_IGNORED_LOCALE_CATEGORIES_
+#    define LC_COLLATE_AVAIL_  false
+#  else
+#    define LC_COLLATE_AVAIL_  true
 #    define USE_LOCALE_COLLATE
 #  endif
 #endif
 #ifdef LC_TIME
-#  ifndef NO_LOCALE_TIME
 
     PERL_LOCALE_TABLE_ENTRY(TIME, NULL)
 
+#  ifdef NO_LOCALE_TIME
+#    define HAS_IGNORED_LOCALE_CATEGORIES_
+#    define LC_TIME_AVAIL_  false
+#  else
+#    define LC_TIME_AVAIL_  true
 #    define USE_LOCALE_TIME
 #  endif
 #endif
 #ifdef LC_MESSAGES
-#  ifndef NO_LOCALE_MESSAGES
 
     PERL_LOCALE_TABLE_ENTRY(MESSAGES, NULL)
 
+#  ifdef NO_LOCALE_MESSAGES
+#    define HAS_IGNORED_LOCALE_CATEGORIES_
+#    define LC_MESSAGES_AVAIL_  false
+#  else
+#    define LC_MESSAGES_AVAIL_  true
 #    define USE_LOCALE_MESSAGES
 #  endif
 #endif
 #ifdef LC_MONETARY
-#  ifndef NO_LOCALE_MONETARY
 
     PERL_LOCALE_TABLE_ENTRY(MONETARY, NULL)
 
+#  ifdef NO_LOCALE_MONETARY
+#    define HAS_IGNORED_LOCALE_CATEGORIES_
+#    define LC_MONETARY_AVAIL_  false
+#  else
+#    define LC_MONETARY_AVAIL_  true
 #    define USE_LOCALE_MONETARY
 #  endif
 #endif
 #ifdef LC_ADDRESS
-#  ifndef NO_LOCALE_ADDRESS
 
     PERL_LOCALE_TABLE_ENTRY(ADDRESS, NULL)
 
+#  ifdef NO_LOCALE_ADDRESS
+#    define HAS_IGNORED_LOCALE_CATEGORIES_
+#    define LC_ADDRESS_AVAIL_  false
+#  else
+#    define LC_ADDRESS_AVAIL_  true
 #    define USE_LOCALE_ADDRESS
 #  endif
 #endif
 #ifdef LC_IDENTIFICATION
-#  ifndef NO_LOCALE_IDENTIFICATION
 
     PERL_LOCALE_TABLE_ENTRY(IDENTIFICATION, NULL)
 
+#  ifdef NO_LOCALE_IDENTIFICATION
+#    define HAS_IGNORED_LOCALE_CATEGORIES_
+#    define LC_IDENTIFICATION_AVAIL_  false
+#  else
+#    define LC_IDENTIFICATION_AVAIL_  true
 #    define USE_LOCALE_IDENTIFICATION
 #  endif
 #endif
 #ifdef LC_MEASUREMENT
-#  ifndef NO_LOCALE_MEASUREMENT
 
     PERL_LOCALE_TABLE_ENTRY(MEASUREMENT, NULL)
 
+#  ifdef NO_LOCALE_MEASUREMENT
+#    define HAS_IGNORED_LOCALE_CATEGORIES_
+#    define LC_MEASUREMENT_AVAIL_  false
+#  else
+#    define LC_MEASUREMENT_AVAIL_  true
 #    define USE_LOCALE_MEASUREMENT
 #  endif
 #endif
 #ifdef LC_PAPER
-#  ifndef NO_LOCALE_PAPER
 
     PERL_LOCALE_TABLE_ENTRY(PAPER, NULL)
 
+#  ifdef NO_LOCALE_PAPER
+#    define HAS_IGNORED_LOCALE_CATEGORIES_
+#    define LC_PAPER_AVAIL_  false
+#  else
+#    define LC_PAPER_AVAIL_  true
 #    define USE_LOCALE_PAPER
 #  endif
 #endif
 #ifdef LC_TELEPHONE
-#  ifndef NO_LOCALE_TELEPHONE
 
     PERL_LOCALE_TABLE_ENTRY(TELEPHONE, NULL)
 
+#  ifdef NO_LOCALE_TELEPHONE
+#    define HAS_IGNORED_LOCALE_CATEGORIES_
+#    define LC_TELEPHONE_AVAIL_  false
+#  else
+#    define LC_TELEPHONE_AVAIL_  true
 #    define USE_LOCALE_TELEPHONE
 #  endif
 #endif
 #ifdef LC_NAME
-#  ifndef NO_LOCALE_NAME
 
     PERL_LOCALE_TABLE_ENTRY(NAME, NULL)
 
+#  ifdef NO_LOCALE_NAME
+#    define HAS_IGNORED_LOCALE_CATEGORIES_
+#    define LC_NAME_AVAIL_  false
+#  else
+#    define LC_NAME_AVAIL_  true
 #    define USE_LOCALE_NAME
 #  endif
 #endif
 #ifdef LC_SYNTAX
-#  ifndef NO_LOCALE_SYNTAX
 
     PERL_LOCALE_TABLE_ENTRY(SYNTAX, NULL)
 
+#  ifdef NO_LOCALE_SYNTAX
+#    define HAS_IGNORED_LOCALE_CATEGORIES_
+#    define LC_SYNTAX_AVAIL_  false
+#  else
+#    define LC_SYNTAX_AVAIL_  true
 #    define USE_LOCALE_SYNTAX
 #  endif
 #endif
 #ifdef LC_TOD
-#  ifndef NO_LOCALE_TOD
 
     PERL_LOCALE_TABLE_ENTRY(TOD, NULL)
 
+#  ifdef NO_LOCALE_TOD
+#    define HAS_IGNORED_LOCALE_CATEGORIES_
+#    define LC_TOD_AVAIL_  false
+#  else
+#    define LC_TOD_AVAIL_  true
 #    define USE_LOCALE_TOD
 #  endif
 #endif

--- a/locale_table.h
+++ b/locale_table.h
@@ -25,7 +25,7 @@
 #ifdef LC_CTYPE
 #  ifndef NO_LOCALE_CTYPE
 
-    PERL_LOCALE_TABLE_ENTRY(LC_CTYPE, S_new_ctype)
+    PERL_LOCALE_TABLE_ENTRY(CTYPE, S_new_ctype)
 
 #    define USE_LOCALE_CTYPE
 #  endif
@@ -33,7 +33,7 @@
 #ifdef LC_NUMERIC
 #  ifndef NO_LOCALE_NUMERIC
 
-    PERL_LOCALE_TABLE_ENTRY(LC_NUMERIC, S_new_numeric)
+    PERL_LOCALE_TABLE_ENTRY(NUMERIC, S_new_numeric)
 
 #    define USE_LOCALE_NUMERIC
 #  endif
@@ -44,7 +44,7 @@
         /* Perl outsources all its collation efforts to the libc strxfrm(), so
          * if it isn't available on the system, default "C" locale collation
          * gets used */
-    PERL_LOCALE_TABLE_ENTRY(LC_COLLATE, S_new_collate)
+    PERL_LOCALE_TABLE_ENTRY(COLLATE, S_new_collate)
 
 #    define USE_LOCALE_COLLATE
 #  endif
@@ -52,7 +52,7 @@
 #ifdef LC_TIME
 #  ifndef NO_LOCALE_TIME
 
-    PERL_LOCALE_TABLE_ENTRY(LC_TIME, NULL)
+    PERL_LOCALE_TABLE_ENTRY(TIME, NULL)
 
 #    define USE_LOCALE_TIME
 #  endif
@@ -60,7 +60,7 @@
 #ifdef LC_MESSAGES
 #  ifndef NO_LOCALE_MESSAGES
 
-    PERL_LOCALE_TABLE_ENTRY(LC_MESSAGES, NULL)
+    PERL_LOCALE_TABLE_ENTRY(MESSAGES, NULL)
 
 #    define USE_LOCALE_MESSAGES
 #  endif
@@ -68,7 +68,7 @@
 #ifdef LC_MONETARY
 #  ifndef NO_LOCALE_MONETARY
 
-    PERL_LOCALE_TABLE_ENTRY(LC_MONETARY, NULL)
+    PERL_LOCALE_TABLE_ENTRY(MONETARY, NULL)
 
 #    define USE_LOCALE_MONETARY
 #  endif
@@ -76,7 +76,7 @@
 #ifdef LC_ADDRESS
 #  ifndef NO_LOCALE_ADDRESS
 
-    PERL_LOCALE_TABLE_ENTRY(LC_ADDRESS, NULL)
+    PERL_LOCALE_TABLE_ENTRY(ADDRESS, NULL)
 
 #    define USE_LOCALE_ADDRESS
 #  endif
@@ -84,7 +84,7 @@
 #ifdef LC_IDENTIFICATION
 #  ifndef NO_LOCALE_IDENTIFICATION
 
-    PERL_LOCALE_TABLE_ENTRY(LC_IDENTIFICATION, NULL)
+    PERL_LOCALE_TABLE_ENTRY(IDENTIFICATION, NULL)
 
 #    define USE_LOCALE_IDENTIFICATION
 #  endif
@@ -92,7 +92,7 @@
 #ifdef LC_MEASUREMENT
 #  ifndef NO_LOCALE_MEASUREMENT
 
-    PERL_LOCALE_TABLE_ENTRY(LC_MEASUREMENT, NULL)
+    PERL_LOCALE_TABLE_ENTRY(MEASUREMENT, NULL)
 
 #    define USE_LOCALE_MEASUREMENT
 #  endif
@@ -100,7 +100,7 @@
 #ifdef LC_PAPER
 #  ifndef NO_LOCALE_PAPER
 
-    PERL_LOCALE_TABLE_ENTRY(LC_PAPER, NULL)
+    PERL_LOCALE_TABLE_ENTRY(PAPER, NULL)
 
 #    define USE_LOCALE_PAPER
 #  endif
@@ -108,7 +108,7 @@
 #ifdef LC_TELEPHONE
 #  ifndef NO_LOCALE_TELEPHONE
 
-    PERL_LOCALE_TABLE_ENTRY(LC_TELEPHONE, NULL)
+    PERL_LOCALE_TABLE_ENTRY(TELEPHONE, NULL)
 
 #    define USE_LOCALE_TELEPHONE
 #  endif
@@ -116,7 +116,7 @@
 #ifdef LC_NAME
 #  ifndef NO_LOCALE_NAME
 
-    PERL_LOCALE_TABLE_ENTRY(LC_NAME, NULL)
+    PERL_LOCALE_TABLE_ENTRY(NAME, NULL)
 
 #    define USE_LOCALE_NAME
 #  endif
@@ -124,7 +124,7 @@
 #ifdef LC_SYNTAX
 #  ifndef NO_LOCALE_SYNTAX
 
-    PERL_LOCALE_TABLE_ENTRY(LC_SYNTAX, NULL)
+    PERL_LOCALE_TABLE_ENTRY(SYNTAX, NULL)
 
 #    define USE_LOCALE_SYNTAX
 #  endif
@@ -132,7 +132,7 @@
 #ifdef LC_TOD
 #  ifndef NO_LOCALE_TOD
 
-    PERL_LOCALE_TABLE_ENTRY(LC_TOD, NULL)
+    PERL_LOCALE_TABLE_ENTRY(TOD, NULL)
 
 #    define USE_LOCALE_TOD
 #  endif

--- a/perl.h
+++ b/perl.h
@@ -1157,49 +1157,6 @@ violations are fatal.
 #ifdef USE_LOCALE
 #   define HAS_SKIP_LOCALE_INIT /* Solely for XS code to test for this
                                    #define */
-#   if !defined(NO_LOCALE_COLLATE) && defined(LC_COLLATE) \
-       && defined(HAS_STRXFRM)
-#	define USE_LOCALE_COLLATE
-#   endif
-#   if !defined(NO_LOCALE_CTYPE) && defined(LC_CTYPE)
-#	define USE_LOCALE_CTYPE
-#   endif
-#   if !defined(NO_LOCALE_NUMERIC) && defined(LC_NUMERIC)
-#	define USE_LOCALE_NUMERIC
-#   endif
-#   if !defined(NO_LOCALE_MESSAGES) && defined(LC_MESSAGES)
-#	define USE_LOCALE_MESSAGES
-#   endif
-#   if !defined(NO_LOCALE_MONETARY) && defined(LC_MONETARY)
-#	define USE_LOCALE_MONETARY
-#   endif
-#   if !defined(NO_LOCALE_TIME) && defined(LC_TIME)
-#	define USE_LOCALE_TIME
-#   endif
-#   if !defined(NO_LOCALE_ADDRESS) && defined(LC_ADDRESS)
-#	define USE_LOCALE_ADDRESS
-#   endif
-#   if !defined(NO_LOCALE_IDENTIFICATION) && defined(LC_IDENTIFICATION)
-#	define USE_LOCALE_IDENTIFICATION
-#   endif
-#   if !defined(NO_LOCALE_MEASUREMENT) && defined(LC_MEASUREMENT)
-#	define USE_LOCALE_MEASUREMENT
-#   endif
-#   if !defined(NO_LOCALE_PAPER) && defined(LC_PAPER)
-#	define USE_LOCALE_PAPER
-#   endif
-#   if !defined(NO_LOCALE_TELEPHONE) && defined(LC_TELEPHONE)
-#	define USE_LOCALE_TELEPHONE
-#   endif
-#   if !defined(NO_LOCALE_NAME) && defined(LC_NAME)
-#	define USE_LOCALE_NAME
-#   endif
-#   if !defined(NO_LOCALE_SYNTAX) && defined(LC_SYNTAX)
-#	define USE_LOCALE_SYNTAX
-#   endif
-#   if !defined(NO_LOCALE_TOD) && defined(LC_TOD)
-#	define USE_LOCALE_TOD
-#   endif
 #endif
 
 /* XXX The Configure probe for categories must be updated when adding new

--- a/perl.h
+++ b/perl.h
@@ -1183,7 +1183,7 @@ typedef enum {
 /* Now create LC_foo_INDEX_ values for just those categories used on this
  * system */
 #    undef PERL_LOCALE_TABLE_ENTRY
-#    define PERL_LOCALE_TABLE_ENTRY(name, call_back)  name ## _INDEX_,
+#    define PERL_LOCALE_TABLE_ENTRY(name, call_back)  LC_ ## name ## _INDEX_,
 #    include "locale_table.h"
 
 #endif  /* USE_LOCALE */

--- a/perl.h
+++ b/perl.h
@@ -1175,17 +1175,18 @@ violations are fatal.
  * LC_NUMERIC, the code below will cause LC_NUMERIC_INDEX_ to be defined to be
  * 0.  That way the foo_INDEX_ values are contiguous non-negative integers,
  * regardless of how the platform defines the actual locale categories.
- */
+ *
+ * It is possible to tell perl it is not to pay attention to certain categories
+ * that exist on a platform (which means they are always kept in the "C"
+ * locale).  For the ones perl is supposed to pay attention to, The hdr file
+ * creates a 'USE_LOCALE_foo' #define.  If any are to be ignored by perl, it
+ * #defines HAS_IGNORED_LOCALE_CATEGORIES_ */
 typedef enum {
 
 #ifdef USE_LOCALE
-
-/* Now create LC_foo_INDEX_ values for just those categories used on this
- * system */
 #    undef PERL_LOCALE_TABLE_ENTRY
 #    define PERL_LOCALE_TABLE_ENTRY(name, call_back)  LC_ ## name ## _INDEX_,
 #    include "locale_table.h"
-
 #endif  /* USE_LOCALE */
 
     LC_ALL_INDEX_   /* Always defined, even if no LC_ALL on system */
@@ -1325,6 +1326,11 @@ typedef enum {
     EXTERNAL_FORMAT_FOR_QUERY
 } calc_LC_ALL_format;
 
+typedef enum {
+    no_override,
+    override_if_ignored,
+    check_that_overridden
+} parse_LC_ALL_STRING_action;
 
 typedef enum {
     invalid,

--- a/proto.h
+++ b/proto.h
@@ -7065,7 +7065,7 @@ S_give_perl_locale_control(pTHX_ const char *lc_all_string, const line_t caller_
         assert(lc_all_string)
 
 STATIC parse_LC_ALL_string_return
-S_parse_LC_ALL_string(pTHX_ const char *string, const char **output, bool always_use_full_array, const bool panic_on_error, const line_t caller_line);
+S_parse_LC_ALL_string(pTHX_ const char *string, const char **output, const parse_LC_ALL_STRING_action, bool always_use_full_array, const bool panic_on_error, const line_t caller_line);
 #     define PERL_ARGS_ASSERT_PARSE_LC_ALL_STRING \
         assert(string); assert(output)
 


### PR DESCRIPTION
    
     There have long been Configure options like
     
        `./Configure -DNO_LOCALE_TIME`
     
     to tell perl to not pay attention to the LC_TIME category.  This feature
     has never fully worked.  This commit fixes it.
     
     One problem is that the when the libc does know about LC_TIME, but perl
     is supposed to ignore that, it didn't have in place the logic to ignore
     it in many circumstances.
     
     This commit creates a boolean array for each locale category known to
     the platform's libc, indicating whether that category is to be ignored
     or not by perl.  If no category is to be ignored, the array and
     ancillary code are not compiled, so perl works like it did before this
     commit.
     
     But if one or more categories are to be ignored, the code comes into
     play.  A problem is that such categories really do exist on the
     platform, and so ignoring them just doesn't work properly.  On a
     platform with positional LC_ALL notation when not all categories have
     the same locale, LC_ALL legally could look something like
     
         `C/de_DE/nl_NL/en_GB/zh_TW.UTF-8/he_IL`
     
     Perl has to be smart enough to know which of those are categories to be
     ignore.  Prior to this commit, it wasn't.  In fact, all ignored
     categories do exist and do have a locale.  Those should all be C.
     Therefore this commit doesn't actually ignore any locales; it instead
     causes perl to refuse to change such ones away from C.
     
     We don't currently have tests for these configurations.  I have
     personally tested a couple hundred different combinations over and over,
     but that's way too much for CI.
