### PR TITLE
S_find_locale_from_environment: Handle disparate LC_ALL

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -3244,7 +3244,47 @@ S_find_locale_from_environment(pTHX_ const locale_category_index index)
     /* Use any "LC_ALL" environment variable, as it overrides everything else.
      * */
     if (lc_all && strNE(lc_all, "")) {
-        return lc_all;
+        if (index == LC_ALL_INDEX_) {
+            return lc_all;
+        }
+
+        /* Here, there is an LC_ALL environment variable, but we want the value
+         * for just one category from it.  This is fine if LC_ALL is a single
+         * locale that applies to all categories, but if not, we need just the
+         * component that is for the category the caller is asking for.  It
+         * turns out that no libc/shell that khw knows about permits such a
+         * disparate LC_ALL environment variable, but this easily handles such
+         * a case should it ever arise. */
+        switch (parse_LC_ALL_string(lc_all,
+                                    (const char **) &locale_names,
+                                    no_override,  /* Handled by other code */
+                                    false,    /* Return only [0] if suffices */
+                                    false,      /* Don't panic on error */
+                                    __LINE__))
+        {
+          case invalid:
+            return NULL;
+
+          case no_array:
+            return lc_all;
+
+          case only_element_0:
+            SAVEFREEPV(locale_names[0]);
+            return locale_names[0];
+
+          case full_array:
+            /* We need to mortalize the desired component, and free the rest */
+            for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
+                if (i == index) {
+                    SAVEFREEPV(locale_names[i]);
+                }
+                else {
+                    Safefree(locale_names[i]);
+                }
+            }
+
+            return locale_names[index];
+        }
     }
 
     /* Here, no usable LC_ALL environment variable.  We have to handle each

--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -47,8 +47,10 @@ delete local @ENV{'LANGUAGE', 'LANG', (grep /^LC_[A-Z]+$/, keys %ENV)};
 # 'debug'
 delete local $ENV{'PERL_DEBUG_LOCALE_INIT'} unless $debug;
 
-my $has_ctype = grep { $_ eq "LC_CTYPE" } platform_locale_categories();
+my @platform_categories = platform_locale_categories();
 my @changeable_from_C_categories = valid_locale_categories();
+
+my $has_ctype = grep { $_ eq "LC_CTYPE" } @platform_categories;
 
 SKIP: {
     skip("LC_CTYPE not available on the system", 1 ) unless $has_ctype;

--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -617,13 +617,13 @@ SKIP: {   # GH #20085
 }
 
 SKIP: {   # GH #20054
-    skip "Even illegal locale names are accepted", 1
+    skip "Even illegal locale names are accepted", 2
                     if $Config{d_setlocale_accepts_any_locale_name}
                     && $Config{d_setlocale_accepts_any_locale_name} eq 'define';
 	
     my @lc_all_locales = find_locales('LC_ALL');
     my $locale = $lc_all_locales[0];
-    skip "LC_ALL not enabled on this platform", 1 unless $locale;
+    skip "LC_ALL not enabled on this platform", 2 unless $locale;
     my $fallback = ($^O eq "MSWin32")
                     ? "system default"
                     : "standard";
@@ -634,6 +634,63 @@ SKIP: {   # GH #20054
                     EOT
                     qr/Falling back to the $fallback locale/,
                     {}, "check that illegal startup environment falls back");
+
+    SKIP: {
+        if (! $Config{d_perl_lc_all_uses_name_value_pairs}) {
+            skip("Test currently written only for name=value pairs LC_ALL syntax",
+                 1);
+        }
+
+        my @non_C_locales = grep { ! is_locale_C($_) } @lc_all_locales;
+
+        # We will look at all changeable categories on the platform, and
+        # spread their names out so that they are quickly distinguishable from
+        # each other.
+        my $index = 0;
+        my $delta = POSIX::floor(@non_C_locales / @changeable_from_C_categories);
+        $delta = 1 if $delta < 1;
+
+        my $lc_all_string = "";
+        my $lc_numeric;
+
+        # Set up an LC_ALL value with each changeable category set to a
+        # different locale (if possible), and the non-changeable ones set to
+        # "C".
+        foreach my $category (@platform_categories) {
+            next if $category eq "LC_ALL";
+            $lc_all_string .= ";" if $lc_all_string;
+
+            my $locale;
+            if (grep { $category eq $_ } @changeable_from_C_categories) {
+                $locale = $non_C_locales[$index];
+                $index += $delta;
+                $index = 0 if $index >= @non_C_locales;
+            }
+            else {
+                $locale = "C";
+            }
+
+            $lc_all_string .= "$category=" . $locale;
+            $lc_numeric = $locale if $category eq "LC_NUMERIC";
+        }
+
+        fresh_perl_is(<<~EOT,
+                        # Some platforms (or shells) can't handle setting from
+                        # a disparate LC_ALL "".  Suppress any message.
+                        local \$ENV{PERL_BADLANG} = 0;
+
+                        local \$ENV{LC_ALL} = '$lc_all_string';
+                        system(qq($^X -I../lib -I. -e 'use POSIX qw(locale_h);
+                                                    setlocale(LC_ALL, "C");
+                                                    setlocale(LC_NUMERIC, "");
+                                                    print setlocale(LC_NUMERIC);'
+                                ));
+                        EOT
+                    $lc_numeric,
+                    { eval $switches },
+                    'Fetching a single category from a disparate "" environment'
+                  . ' works');
+    }
 }
 
 done_testing();

--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -48,6 +48,7 @@ delete local @ENV{'LANGUAGE', 'LANG', (grep /^LC_[A-Z]+$/, keys %ENV)};
 delete local $ENV{'PERL_DEBUG_LOCALE_INIT'} unless $debug;
 
 my $has_ctype = grep { $_ eq "LC_CTYPE" } platform_locale_categories();
+my @changeable_from_C_categories = valid_locale_categories();
 
 SKIP: {
     skip("LC_CTYPE not available on the system", 1 ) unless $has_ctype;
@@ -519,14 +520,12 @@ SKIP: {
             skip("Test only valid when LC_ALL syntax is name=value pairs", 2);
         }
 
-        my @valid_categories = valid_locale_categories();
-
         my $valid_string = "";
         my $invalid_string = "";
 
         # Deliberately don't include all categories, so as to test this situation
-        for my $i (0 .. @valid_categories - 2) {
-            my $category = $valid_categories[$i];
+        for my $i (0 .. @changeable_from_C_categories - 2) {
+            my $category = $changeable_from_C_categories[$i];
             if ($category ne "LC_ALL") {
                 $invalid_string .= ";" if $invalid_string ne "";
                 $invalid_string .= "$category=foo_BAR";

--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -75,9 +75,14 @@ EOF
 
 }
 
+sub is_locale_C ($) {
+    my $locale = shift;
+    return $locale eq "C" || $locale eq 'POSIX' || $locale eq "C.UTF-8";
+}
+
 my $non_C_locale;
 foreach my $locale (@locales) {
-    next if $locale eq "C" || $locale eq 'POSIX' || $locale eq "C.UTF-8";
+    next if is_locale_C($locale);
     $non_C_locale = $locale;
     last;
 }


### PR DESCRIPTION
This PR was split off of https://github.com/Perl/perl5/pull/21340.   There are comments in that that apply to this.

When calling setlocale(foo, ""), there is a standardized result.  If there is an environment variable LC_ALL set, it is used regardless of what 'foo' is.

In general, LC_ALL may be set to a heterogenous set of categories and locales, so this could be equivalently

 setlocale(LC_TIME, "de_DE/C/en_US/zh_TW.UTF-8/he_IL");

Prior to this commit, the code did not handle this possibility. It turns out that on all boxes and shells we've tried, they prohibit the LC_ALL environment variable from being set to anything but a single locale name.  But it's easy to handle this eventuality with an already-existing function whose return must be examined and processed.  And doing so makes this code less prone to future changes in those boxes.