### PR TITLE
Porting/corelist-perldelta.pm: Fix name of IO::Compress module (not dist)

### DIFF
--- a/Porting/corelist-perldelta.pl
+++ b/Porting/corelist-perldelta.pl
@@ -169,7 +169,7 @@ sub corelist_delta {
   my %distToModules = (
     'IO-Compress' => [
       {
-        'name'         => 'IO-Compress',
+        'name'         => 'IO::Compress',
         'modification' => $getModifyType->( $changes{'IO::Compress::Base'} ),
         'data'         => $changes{'IO::Compress::Base'}
       }


### PR DESCRIPTION
Problem found when generating new perldelta for 5.39.2