### PR TITLE
`core-cpan-diff`: Add option bundling

### DIFF
--- a/Porting/core-cpan-diff
+++ b/Porting/core-cpan-diff
@@ -9,7 +9,7 @@ use warnings;
 
 use 5.010;
 
-use Getopt::Long;
+use Getopt::Long qw(:config bundling);
 use File::Basename ();
 use File::Copy     ();
 use File::Temp     ();


### PR DESCRIPTION
To enable `./perl -Ilib ./Porting/core-cpan-diff -ax`

https://perldoc.perl.org/Getopt::Long#bundling-(default:-disabled)