### PR TITLE
Smoke me/jkeenan/gh 21393 unused var

### DIFF
--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4451,9 +4451,8 @@ S_require_file(pTHX_ SV *sv)
         SAVETMPS;
         PUSHMARK(PL_stack_sp);
         rpp_xpush_1(name_sv); /* always use the object for method calls */
-        int count = call_sv(PL_hook__require__before, G_SCALAR);
+        call_sv(PL_hook__require__before, G_SCALAR);
         SV *rsv = *PL_stack_sp;
-        assert(count == 1); /* scalar context */
         if (SvOK(rsv) && SvROK(rsv) && SvTYPE(SvRV(rsv)) == SVt_PVCV) {
             /* the RC++ preserves it across the popping and/or FREETMPS
              * below */


### PR DESCRIPTION
This suppresses the `-Wunused_variable` warning reported in https://github.com/Perl/perl5/issues/21393 -- but since I'm just monkey-patching, please review.

(You may get a porting test failure because (I think) Module-CoreList needs to be updated after today's release.)