### PR TITLE
Maintainers.pl: use strict/warnings with "our"

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1488,7 +1488,7 @@ our %Modules = (
     },
 );
 
-my %DistName;
+our %DistName;
 
 # legacy CPAN flag
 for my $mod_name ( keys %Modules ) {
@@ -1522,7 +1522,7 @@ for ( keys %Modules ) {
     # Keep any existing MAINTAINER flag so that "overrides" can be applied
     next if exists $Modules{$_}{MAINTAINER};
 
-my %Maintainers;
+our %Maintainers;
 
     if ($Modules{$_}{UPSTREAM} eq 'blead') {
         $Modules{$_}{MAINTAINER} = 'P5P';

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -8,6 +8,8 @@
 
 package Maintainers;
 
+use strict;
+use warnings;
 use utf8;
 use File::Glob qw(:case);
 
@@ -15,7 +17,7 @@ use File::Glob qw(:case);
 # distribution, need not appear in core (i.e. core-cpan-diff won't
 # complain if it can't find them)
 
-@IGNORABLE = qw(
+our @IGNORABLE = qw(
     .cvsignore .dualLivedDiffConfig .gitignore .github .perlcriticrc .perltidyrc
     .travis.yml ANNOUNCE Announce Artistic AUTHORS BENCHMARK BUGS Build.PL
     CHANGELOG ChangeLog Changelog CHANGES Changes CONTRIBUTING CONTRIBUTING.md
@@ -124,7 +126,7 @@ use File::Glob qw(:case);
 #     ''     => 'lib/Foo/Bar/',
 #   }
 
-%Modules = (
+our %Modules = (
 
     'Archive::Tar' => {
         'DISTRIBUTION' => 'BINGOS/Archive-Tar-2.40.tar.gz',
@@ -1486,6 +1488,7 @@ use File::Glob qw(:case);
     },
 );
 
+my %DistName;
 
 # legacy CPAN flag
 for my $mod_name ( keys %Modules ) {
@@ -1518,6 +1521,8 @@ for ( keys %Modules ) {
 for ( keys %Modules ) {
     # Keep any existing MAINTAINER flag so that "overrides" can be applied
     next if exists $Modules{$_}{MAINTAINER};
+
+my %Maintainers;
 
     if ($Modules{$_}{UPSTREAM} eq 'blead') {
         $Modules{$_}{MAINTAINER} = 'P5P';


### PR DESCRIPTION
Add 2 pragmas, and scope globals with "our".

Scoped `%Maintainers` and `%DistName` (autovivified hashes) with `our`.

Fixes https://github.com/Perl/perl5/issues/21410