### PR TITLE
newSTATEOP(): copy cop_features of PL_curcop into returned COP

### DIFF
--- a/op.c
+++ b/op.c
@@ -8550,6 +8550,8 @@ Perl_newSTATEOP(pTHX_ I32 flags, char *label, OP *o)
 #endif
     CopSTASH_set(cop, PL_curstash);
 
+    cop->cop_features = PL_curcop->cop_features;
+
     if (cop->op_type == OP_DBSTATE) {
         /* this line can have a breakpoint - store the cop in IV */
         AV *av = CopFILEAVx(PL_curcop);


### PR DESCRIPTION
This doesn't currently break any tests, nor is it easily possible to write one, because current feature bits only apply at compiletime. But it's still confusing and very hard to debug subtle issues, and this would be necessary if we ever add a featurebit that needs runtime inspection.

Fixes #21413