### PR TITLE
Don't try to free an already-freed SV.

### DIFF
--- a/mg.c
+++ b/mg.c
@@ -544,6 +544,9 @@ Perl_mg_free(pTHX_ SV *sv)
 
     PERL_ARGS_ASSERT_MG_FREE;
 
+    if (SvIS_FREED(sv))
+        return 0;
+
     for (mg = SvMAGIC(sv); mg; mg = moremagic) {
         moremagic = mg->mg_moremagic;
         mg_free_struct(sv, mg);

--- a/sv.c
+++ b/sv.c
@@ -5932,6 +5932,8 @@ S_sv_unmagicext_flags(pTHX_ SV *const sv, const int type, const MGVTBL *vtbl, co
 
     if (SvTYPE(sv) < SVt_PVMG || !SvMAGIC(sv))
         return 0;
+    if (SvIS_FREED(sv))
+        return 0;
     mgp = &(((XPVMG*) SvANY(sv))->xmg_u.xmg_magic);
     for (mg = *mgp; mg; mg = *mgp) {
         const MGVTBL* const virt = mg->mg_virtual;
@@ -6938,6 +6940,9 @@ Perl_sv_clear(pTHX_ SV *const orig_sv)
         {
             U32 arena_index;
             const struct body_details *sv_type_details;
+
+            if (SvIS_FREED(sv))
+                goto get_next_sv;
 
             if (type == SVt_PVHV && HvHasAUX(sv)) {
                 arena_index = HVAUX_ARENA_ROOT_IX;


### PR DESCRIPTION
This fixes a segfault with Perl v5.39.1-256 compiled from source on WSL2 when running `perl -e 'grep a,@a=b,@a=c'`, and a **double free or corruption (out)** error when running the following script:

`perl -e 'grep%agc=ION2.ljt,s_re_deljt,%agc=Idbdeljt,splitxre_deljt,%agc=Idb-openON2..%xre_deljt,splitxt,d'`

After applying this PR, the double free message changed to `Attempt to free unreferenced scalar: SV 0x56218767b558, Perl interpreter: 0x5621876782a0 at AFL++/output/default/crashes/id:000077,sig:11,src:036114,time:106667371,execs:30357718,op:havoc,rep:4 line 1.`

WSL2 version: openSUSE 15.5
```
WSL version: 1.2.5.0
Kernel version: 5.15.90.1
WSLg version: 1.0.51
MSRDC version: 1.2.3770
Direct3D version: 1.608.2-61064218
DXCore version: 10.0.25131.1002-220531-1700.rs-onecore-base2-hyp
Windows version: 10.0.19045.3324
```

Perl version:
```
This is perl 5, version 39, subversion 2 (v5.39.2 (v5.39.1-256-g6a90d96b0f)) built for x86_64-linux-thread-multi

Copyright 1987-2023, Larry Wall

Perl may be copied only under the terms of either the Artistic License or the
GNU General Public License, which may be found in the Perl 5 source kit.

Complete documentation for Perl, including FAQ lists, should be found on
this system using "man perl" or "perldoc perl".  If you have access to the
Internet, point your browser at https://www.perl.org/, the Perl Home Page.
```

I was going to check if this crash also happens on Perl 5.38.0, but `perlbrew` said there was no makefile found.