### PR TITLE
`Maintainers.pl`: use `strict`/`warnings` pragmas with `our` scoping

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -8,6 +8,8 @@
 
 package Maintainers;
 
+use strict;
+use warnings;
 use utf8;
 use File::Glob qw(:case);
 
@@ -15,7 +17,7 @@ use File::Glob qw(:case);
 # distribution, need not appear in core (i.e. core-cpan-diff won't
 # complain if it can't find them)
 
-@IGNORABLE = qw(
+our @IGNORABLE = qw(
     .cvsignore .dualLivedDiffConfig .gitignore .github .perlcriticrc .perltidyrc
     .travis.yml ANNOUNCE Announce Artistic AUTHORS BENCHMARK BUGS Build.PL
     CHANGELOG ChangeLog Changelog CHANGES Changes CONTRIBUTING CONTRIBUTING.md
@@ -124,7 +126,7 @@ use File::Glob qw(:case);
 #     ''     => 'lib/Foo/Bar/',
 #   }
 
-%Modules = (
+our %Modules = (
 
     'Archive::Tar' => {
         'DISTRIBUTION' => 'BINGOS/Archive-Tar-2.40.tar.gz',
@@ -1486,7 +1488,7 @@ use File::Glob qw(:case);
     },
 );
 
-
+our %DistName;
 # legacy CPAN flag
 for my $mod_name ( keys %Modules ) {
     my $data = $Modules{$mod_name};
@@ -1514,6 +1516,7 @@ for ( keys %Modules ) {
     }
 }
 
+our %Maintainers;
 # legacy MAINTAINER field
 for ( keys %Modules ) {
     # Keep any existing MAINTAINER flag so that "overrides" can be applied


### PR DESCRIPTION
Add 2 pragmas, and scope globals with "our".

Scoped %Maintainers and %DistName (autovivified hashes) with our.

Fixes #21410

---

Archive: https://github.com/Perl/perl5/pull/21412