### PR TITLE
Allow Perl_setlocale to work fully on platforms with positional LC_ALL notation

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4401,6 +4401,7 @@ S	|void	|populate_hash_from_localeconv				\
 S	|const char *|calculate_LC_ALL_string					\
 				|NULLOK const char **category_locales_list	\
 				|const calc_LC_ALL_format format		\
+				|const calc_LC_ALL_return returning		\
 				|const line_t caller_line
 RS	|unsigned int|get_category_index_helper 			\
 				|const int category			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -4431,6 +4431,10 @@ Sr	|void	|setlocale_failure_panic_via_i				\
 				|const line_t immediate_caller_line	\
 				|NN const char *higher_caller_file	\
 				|const line_t higher_caller_line
+S	|void	|set_save_buffer_min_size				\
+				|const Size_t min_len			\
+				|NULLOK char **buf			\
+				|NULLOK Size_t *buf_size
 So	|const char *|toggle_locale_i					\
 				|const unsigned switch_cat_index	\
 				|NN const char *new_locale		\

--- a/embed.fnc
+++ b/embed.fnc
@@ -4409,6 +4409,8 @@ RS	|unsigned int|get_category_index_helper 			\
 				|const line_t caller_line
 Ri	|const char *|mortalized_pv_copy				\
 				|NULLOK const char * const pv
+S	|const char *|native_querylocale_i				\
+				|const unsigned int cat_index
 S	|void	|output_check_environment_warning			\
 				|NULLOK const char * const language	\
 				|NULLOK const char * const lc_all	\

--- a/embed.fnc
+++ b/embed.fnc
@@ -4408,9 +4408,6 @@ RS	|unsigned int|get_category_index_helper 			\
 				|const line_t caller_line
 Ri	|const char *|mortalized_pv_copy				\
 				|NULLOK const char * const pv
-S	|void	|new_LC_ALL	|NULLOK const char *unused		\
-				|bool force
-void
 S	|void	|output_check_environment_warning			\
 				|NULLOK const char * const language	\
 				|NULLOK const char * const lc_all	\
@@ -4467,6 +4464,8 @@ S	|const char *|my_langinfo_i					\
 S	|void	|give_perl_locale_control				\
 				|NN const char *lc_all_string		\
 				|const line_t caller_line
+S	|void	|new_LC_ALL	|NN const char *lc_all			\
+				|bool force
 S	|parse_LC_ALL_string_return|parse_LC_ALL_string 		\
 				|NN const char *string			\
 				|NN const char **output 		\
@@ -4478,6 +4477,8 @@ S	|parse_LC_ALL_string_return|parse_LC_ALL_string 		\
 S	|void	|give_perl_locale_control				\
 				|NN const char **curlocales		\
 				|const line_t caller_line
+S	|void	|new_LC_ALL	|NN const char **individ_locales	\
+				|bool force
 #   endif
 #   if defined(USE_LOCALE_COLLATE)
 S	|void	|new_collate	|NN const char *newcoll 		\

--- a/embed.fnc
+++ b/embed.fnc
@@ -4421,7 +4421,7 @@ So	|void	|restore_toggled_locale_i				\
 				|const line_t caller_line
 S	|const char *|save_to_buffer					\
 				|NULLOK const char *string		\
-				|NULLOK const char **buf		\
+				|NULLOK char **buf			\
 				|NULLOK Size_t *buf_size
 Sr	|void	|setlocale_failure_panic_via_i				\
 				|const unsigned int cat_index		\
@@ -4447,7 +4447,7 @@ S	|const char *|my_langinfo_i					\
 				|const nl_item item			\
 				|const unsigned int cat_index		\
 				|NN const char *locale			\
-				|NN const char **retbufp		\
+				|NN char **retbufp			\
 				|NULLOK Size_t *retbuf_sizep		\
 				|NULLOK utf8ness_t *utf8ness
 #   else
@@ -4455,7 +4455,7 @@ S	|const char *|my_langinfo_i					\
 				|const int item 			\
 				|const unsigned int cat_index		\
 				|NN const char *locale			\
-				|NN const char **retbufp		\
+				|NN char **retbufp			\
 				|NULLOK Size_t *retbuf_sizep		\
 				|NULLOK utf8ness_t *utf8ness
 #   endif

--- a/embed.h
+++ b/embed.h
@@ -1301,6 +1301,7 @@
 #       define calculate_LC_ALL_string(a,b,c,d) S_calculate_LC_ALL_string(aTHX_ a,b,c,d)
 #       define get_category_index_helper(a,b,c) S_get_category_index_helper(aTHX_ a,b,c)
 #       define mortalized_pv_copy(a)            S_mortalized_pv_copy(aTHX_ a)
+#       define native_querylocale_i(a)          S_native_querylocale_i(aTHX_ a)
 #       define output_check_environment_warning(a,b,c) S_output_check_environment_warning(aTHX_ a,b,c)
 #       define save_to_buffer(a,b,c)            S_save_to_buffer(aTHX_ a,b,c)
 #       define set_save_buffer_min_size(a,b,c)  S_set_save_buffer_min_size(aTHX_ a,b,c)

--- a/embed.h
+++ b/embed.h
@@ -1298,7 +1298,7 @@
 #       define populate_hash_from_localeconv(a,b,c,d,e) S_populate_hash_from_localeconv(aTHX_ a,b,c,d,e)
 #     endif
 #     if defined(USE_LOCALE)
-#       define calculate_LC_ALL_string(a,b,c)   S_calculate_LC_ALL_string(aTHX_ a,b,c)
+#       define calculate_LC_ALL_string(a,b,c,d) S_calculate_LC_ALL_string(aTHX_ a,b,c,d)
 #       define get_category_index_helper(a,b,c) S_get_category_index_helper(aTHX_ a,b,c)
 #       define mortalized_pv_copy(a)            S_mortalized_pv_copy(aTHX_ a)
 #       define output_check_environment_warning(a,b,c) S_output_check_environment_warning(aTHX_ a,b,c)

--- a/embed.h
+++ b/embed.h
@@ -1304,6 +1304,7 @@
 #       define new_LC_ALL(a,b)                  S_new_LC_ALL(aTHX_ a,b)
 #       define output_check_environment_warning(a,b,c) S_output_check_environment_warning(aTHX_ a,b,c)
 #       define save_to_buffer(a,b,c)            S_save_to_buffer(aTHX_ a,b,c)
+#       define set_save_buffer_min_size(a,b,c)  S_set_save_buffer_min_size(aTHX_ a,b,c)
 #       define setlocale_failure_panic_via_i(a,b,c,d,e,f,g) S_setlocale_failure_panic_via_i(aTHX_ a,b,c,d,e,f,g)
 #       if defined(DEBUGGING)
 #         define my_setlocale_debug_string_i(a,b,c,d) S_my_setlocale_debug_string_i(aTHX_ a,b,c,d)

--- a/embed.h
+++ b/embed.h
@@ -1301,7 +1301,6 @@
 #       define calculate_LC_ALL_string(a,b,c)   S_calculate_LC_ALL_string(aTHX_ a,b,c)
 #       define get_category_index_helper(a,b,c) S_get_category_index_helper(aTHX_ a,b,c)
 #       define mortalized_pv_copy(a)            S_mortalized_pv_copy(aTHX_ a)
-#       define new_LC_ALL(a,b)                  S_new_LC_ALL(aTHX_ a,b)
 #       define output_check_environment_warning(a,b,c) S_output_check_environment_warning(aTHX_ a,b,c)
 #       define save_to_buffer(a,b,c)            S_save_to_buffer(aTHX_ a,b,c)
 #       define set_save_buffer_min_size(a,b,c)  S_set_save_buffer_min_size(aTHX_ a,b,c)
@@ -1316,9 +1315,11 @@
 #       endif
 #       if defined(LC_ALL)
 #         define give_perl_locale_control(a,b)  S_give_perl_locale_control(aTHX_ a,b)
+#         define new_LC_ALL(a,b)                S_new_LC_ALL(aTHX_ a,b)
 #         define parse_LC_ALL_string(a,b,c,d,e,f) S_parse_LC_ALL_string(aTHX_ a,b,c,d,e,f)
 #       else
 #         define give_perl_locale_control(a,b)  S_give_perl_locale_control(aTHX_ a,b)
+#         define new_LC_ALL(a,b)                S_new_LC_ALL(aTHX_ a,b)
 #       endif
 #       if defined(USE_LOCALE_COLLATE)
 #         define new_collate(a,b)               S_new_collate(aTHX_ a,b)

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -784,13 +784,13 @@ PERLVARI(I, collation_standard, bool, TRUE)
 PERLVAR(I, in_utf8_COLLATE_locale, bool)
 #endif /* USE_LOCALE_COLLATE */
 
-PERLVARI(I, langinfo_buf, const char *, NULL)
+PERLVARI(I, langinfo_buf, char *, NULL)
 PERLVARI(I, langinfo_bufsize, Size_t, 0)
-PERLVARI(I, setlocale_buf, const char *, NULL)
+PERLVARI(I, setlocale_buf, char *, NULL)
 PERLVARI(I, setlocale_bufsize, Size_t, 0)
 
 #if   defined(USE_LOCALE_THREADS) && ! defined(USE_THREAD_SAFE_LOCALE)
-PERLVARI(I, less_dicey_locale_buf, const char *, NULL)
+PERLVARI(I, less_dicey_locale_buf, char *, NULL)
 PERLVARI(I, less_dicey_locale_bufsize, Size_t, 0)
 #endif
 

--- a/locale.c
+++ b/locale.c
@@ -4234,14 +4234,6 @@ time C<Perl_setlocale> is called from the same thread.
 
 */
 
-#ifndef USE_LOCALE_NUMERIC
-#  define affects_LC_NUMERIC(cat) 0
-#elif defined(LC_ALL)
-#  define affects_LC_NUMERIC(cat) (cat == LC_NUMERIC || cat == LC_ALL)
-#else
-#  define affects_LC_NUMERIC(cat) (cat == LC_NUMERIC)
-#endif
-
 const char *
 Perl_setlocale(const int category, const char * locale)
 {

--- a/locale.c
+++ b/locale.c
@@ -2859,27 +2859,27 @@ S_calculate_LC_ALL_string(pTHX_ const char ** category_locales_list,
          * so leave 'free_if_void_return' set to the default 'false'. */
     }
     else {  /* Here, not all categories have the same locale */
-        char * writable_alias;
 
-            Newx(writable_alias, total_len, char);
+            char * constructed;
+            Newx(constructed, total_len, char);
 
             /* If returning the new memory, it must be set up to be freed
              * later; otherwise at the end of this function */
             if (returning == WANT_TEMP_PV) {
-                SAVEFREEPV(writable_alias);
+                SAVEFREEPV(constructed);
             }
             else {
                 free_if_void_return = true;
             }
 
-        writable_alias[0] = '\0';
+        constructed[0] = '\0';
 
         /* Loop through all the categories */
         for (unsigned j = 0; j < LC_ALL_INDEX_; j++) {
 
             /* Add a separator, except before the first one */
             if (j != 0) {
-                my_strlcat(writable_alias, separator, total_len);
+                my_strlcat(constructed, separator, total_len);
             }
 
             const char * entry;
@@ -2895,7 +2895,7 @@ S_calculate_LC_ALL_string(pTHX_ const char ** category_locales_list,
                 i = map_LC_ALL_position_to_index[j];
 
                 entry = ENTRY(i, locales_list, format);
-                needed_len = my_strlcat(writable_alias, entry, total_len);
+                needed_len = my_strlcat(constructed, entry, total_len);
             }
             else
 
@@ -2909,9 +2909,9 @@ S_calculate_LC_ALL_string(pTHX_ const char ** category_locales_list,
                 entry = ENTRY(i, locales_list, format);
 
                 /* "name=locale;" */
-                my_strlcat(writable_alias, category_names[i], total_len);
-                my_strlcat(writable_alias, "=", total_len);
-                needed_len = my_strlcat(writable_alias, entry, total_len);
+                my_strlcat(constructed, category_names[i], total_len);
+                my_strlcat(constructed, "=", total_len);
+                needed_len = my_strlcat(constructed, entry, total_len);
             }
 
             if (LIKELY(needed_len <= total_len)) {
@@ -2924,14 +2924,13 @@ S_calculate_LC_ALL_string(pTHX_ const char ** category_locales_list,
                                         "\"%s\" was not entirely added to"
                                         " \"%.*s\"; needed=%zu, had=%zu",
                                         entry, (int) total_len,
-                                        writable_alias,
+                                        constructed,
                                         needed_len, total_len),
                                 __FILE__,
                                 caller_line);
         } /* End of loop through the categories */
 
-        retval = (const char *) writable_alias;
-
+        retval = constructed;
     } /* End of the categories' locales are displarate */
 
 #  if defined(USE_PL_CURLOCALES) && defined(LC_ALL)

--- a/locale.c
+++ b/locale.c
@@ -3823,21 +3823,61 @@ Perl_warn_problematic_locale()
 #  endif /* USE_LOCALE_CTYPE */
 
 STATIC void
-S_new_LC_ALL(pTHX_ const char *unused, bool force)
+
+#  ifdef LC_ALL
+
+S_new_LC_ALL(pTHX_ const char *lc_all, bool force)
+
+#  else
+
+S_new_LC_ALL(pTHX_ const char ** individ_locales, bool force)
+
+#  endif
+
 {
     PERL_ARGS_ASSERT_NEW_LC_ALL;
-    PERL_UNUSED_ARG(unused);
 
     /* new_LC_ALL() updates all the things we care about.  Note that this is
      * called just after a change, so uses the actual underlying locale just
      * set, and not the nominal one (should they differ, as they may in
      * LC_NUMERIC). */
 
+#  ifdef LC_ALL
+
+    const char * individ_locales[LC_ALL_INDEX_] = { NULL };
+
+    switch (parse_LC_ALL_string(lc_all,
+                                individ_locales,
+                                override_if_ignored,   /* Override any ignored
+                                                          categories */
+                                true,   /* Always fill array */
+                                true,   /* Panic if fails, as to get here it
+                                           earlier had to have succeeded */
+                                __LINE__))
+    {
+        case invalid:
+        case no_array:
+        case only_element_0:
+        locale_panic_("Unexpected return from parse_LC_ALL_string");
+
+        case full_array:
+        break;
+    }
+
+#  endif
+
     for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
         if (update_functions[i]) {
-            const char * this_locale = querylocale_i(i);
+            const char * this_locale = individ_locales[i];
             update_functions[i](aTHX_ this_locale, force);
         }
+
+#  ifdef LC_ALL
+
+        Safefree(individ_locales[i]);
+
+#  endif
+
     }
 }
 
@@ -6652,7 +6692,16 @@ S_give_perl_locale_control(pTHX_
     /* Finally, update our remaining records.  'true' => force recalculation.
      * This is needed because we don't know what's happened while Perl hasn't
      * had control, so we need to figure out the current state */
-    new_LC_ALL(NULL, true);
+
+#  if defined(LC_ALL)
+
+    new_LC_ALL(lc_all_string, true);
+
+#    else
+
+    new_LC_ALL(locales, true);
+
+#    endif
 }
 
 STATIC void
@@ -6954,7 +7003,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 
 #  endif
 
-    new_LC_ALL(NULL, true /* Don't shortcut */);
+    new_LC_ALL("C", true /* Don't shortcut */);
 
 /*===========================================================================*/
 

--- a/locale.c
+++ b/locale.c
@@ -3255,7 +3255,7 @@ S_new_numeric(pTHX_ const char *newnum, bool force)
 
 #      endif
 
-    const char * radix = NULL;
+    char * radix = NULL;
     utf8ness_t utf8ness = UTF8NESS_IMMATERIAL;
 
     /* Find and save this locale's radix character. */
@@ -3299,7 +3299,7 @@ S_new_numeric(pTHX_ const char *newnum, bool force)
      * get this value, which doesn't appear to be used in any of the Microsoft
      * library routines anyway. */
 
-    const char * scratch_buffer = NULL;
+    char * scratch_buffer = NULL;
     if (PL_numeric_underlying_is_standard) {
         PL_numeric_underlying_is_standard = strEQ(C_thousands_sep,
                                              my_langinfo_c(THOUSEP, LC_NUMERIC,
@@ -3771,7 +3771,7 @@ S_new_ctype(pTHX_ const char *newctype, bool force)
 
 #    if defined(HAS_SOME_LANGINFO) || defined(WIN32)
 
-            const char * scratch_buffer = NULL;
+            char * scratch_buffer = NULL;
             Perl_sv_catpvf(aTHX_ PL_warn_locale, "; codeset=%s",
                                  my_langinfo_c(CODESET, LC_CTYPE,
                                                newctype,
@@ -4397,7 +4397,7 @@ S_is_locale_utf8(pTHX_ const char * locale)
 
 #  else
 
-    const char * scratch_buffer = NULL;
+    char * scratch_buffer = NULL;
     const char * codeset;
     bool retval;
 
@@ -4428,7 +4428,7 @@ S_is_locale_utf8(pTHX_ const char * locale)
 #ifdef USE_LOCALE
 
 STATIC const char *
-S_save_to_buffer(pTHX_ const char * string, const char **buf, Size_t *buf_size)
+S_save_to_buffer(pTHX_ const char * string, char **buf, Size_t *buf_size)
 {
     /* Copy the NUL-terminated 'string' to a buffer whose address before this
      * call began at *buf, and whose available length before this call was
@@ -5642,7 +5642,7 @@ S_my_langinfo_i(pTHX_
                  * is stored, updated on exit. retbuf_sizep may be NULL for an
                  * empty-on-entry, single use buffer whose size we don't need
                  * to keep track of */
-                const char ** retbufp,
+                char ** retbufp,
                 Size_t * retbuf_sizep,
 
                 /* If not NULL, the location to store the UTF8-ness of 'item's

--- a/perl.h
+++ b/perl.h
@@ -1329,6 +1329,7 @@ typedef enum {
 typedef enum {
     WANT_VOID,
     WANT_TEMP_PV,
+    WANT_PL_setlocale_buf,
 } calc_LC_ALL_return;
 
 typedef enum {

--- a/perl.h
+++ b/perl.h
@@ -1327,6 +1327,11 @@ typedef enum {
 } calc_LC_ALL_format;
 
 typedef enum {
+    WANT_VOID,
+    WANT_TEMP_PV,
+} calc_LC_ALL_return;
+
+typedef enum {
     no_override,
     override_if_ignored,
     check_that_overridden

--- a/proto.h
+++ b/proto.h
@@ -7008,7 +7008,7 @@ S_populate_hash_from_localeconv(pTHX_ HV *hv, const char *locale, const U32 whic
 # endif /* defined(HAS_LOCALECONV) */
 # if defined(USE_LOCALE)
 STATIC const char *
-S_calculate_LC_ALL_string(pTHX_ const char **category_locales_list, const calc_LC_ALL_format format, const line_t caller_line);
+S_calculate_LC_ALL_string(pTHX_ const char **category_locales_list, const calc_LC_ALL_format format, const calc_LC_ALL_return returning, const line_t caller_line);
 #   define PERL_ARGS_ASSERT_CALCULATE_LC_ALL_STRING
 
 STATIC unsigned int

--- a/proto.h
+++ b/proto.h
@@ -7016,6 +7016,10 @@ S_get_category_index_helper(pTHX_ const int category, bool *success, const line_
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_GET_CATEGORY_INDEX_HELPER
 
+STATIC const char *
+S_native_querylocale_i(pTHX_ const unsigned int cat_index);
+#   define PERL_ARGS_ASSERT_NATIVE_QUERYLOCALE_I
+
 STATIC void
 S_output_check_environment_warning(pTHX_ const char * const language, const char * const lc_all, const char * const lang);
 #   define PERL_ARGS_ASSERT_OUTPUT_CHECK_ENVIRONMENT_WARNING

--- a/proto.h
+++ b/proto.h
@@ -7029,7 +7029,7 @@ S_restore_toggled_locale_i(pTHX_ const unsigned cat_index, const char *original_
 #   define PERL_ARGS_ASSERT_RESTORE_TOGGLED_LOCALE_I
 
 STATIC const char *
-S_save_to_buffer(pTHX_ const char *string, const char **buf, Size_t *buf_size);
+S_save_to_buffer(pTHX_ const char *string, char **buf, Size_t *buf_size);
 #   define PERL_ARGS_ASSERT_SAVE_TO_BUFFER
 
 PERL_STATIC_NO_RET void
@@ -7052,13 +7052,13 @@ S_my_setlocale_debug_string_i(pTHX_ const unsigned cat_index, const char *locale
 #   endif
 #   if defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L)
 STATIC const char *
-S_my_langinfo_i(pTHX_ const nl_item item, const unsigned int cat_index, const char *locale, const char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
+S_my_langinfo_i(pTHX_ const nl_item item, const unsigned int cat_index, const char *locale, char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
 #     define PERL_ARGS_ASSERT_MY_LANGINFO_I     \
         assert(locale); assert(retbufp)
 
 #   else
 STATIC const char *
-S_my_langinfo_i(pTHX_ const int item, const unsigned int cat_index, const char *locale, const char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
+S_my_langinfo_i(pTHX_ const int item, const unsigned int cat_index, const char *locale, char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
 #     define PERL_ARGS_ASSERT_MY_LANGINFO_I     \
         assert(locale); assert(retbufp)
 

--- a/proto.h
+++ b/proto.h
@@ -7032,6 +7032,10 @@ STATIC const char *
 S_save_to_buffer(pTHX_ const char *string, char **buf, Size_t *buf_size);
 #   define PERL_ARGS_ASSERT_SAVE_TO_BUFFER
 
+STATIC void
+S_set_save_buffer_min_size(pTHX_ const Size_t min_len, char **buf, Size_t *buf_size);
+#   define PERL_ARGS_ASSERT_SET_SAVE_BUFFER_MIN_SIZE
+
 PERL_STATIC_NO_RET void
 S_setlocale_failure_panic_via_i(pTHX_ const unsigned int cat_index, const char *current, const char *failed, const line_t proxy_caller_line, const line_t immediate_caller_line, const char *higher_caller_file, const line_t higher_caller_line)
         __attribute__noreturn__;

--- a/proto.h
+++ b/proto.h
@@ -7017,10 +7017,6 @@ S_get_category_index_helper(pTHX_ const int category, bool *success, const line_
 #   define PERL_ARGS_ASSERT_GET_CATEGORY_INDEX_HELPER
 
 STATIC void
-S_new_LC_ALL(pTHX_ const char *unused, bool force);
-#   define PERL_ARGS_ASSERT_NEW_LC_ALL
-
-STATIC void
 S_output_check_environment_warning(pTHX_ const char * const language, const char * const lc_all, const char * const lang);
 #   define PERL_ARGS_ASSERT_OUTPUT_CHECK_ENVIRONMENT_WARNING
 
@@ -7073,6 +7069,11 @@ S_give_perl_locale_control(pTHX_ const char *lc_all_string, const line_t caller_
 #     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
         assert(lc_all_string)
 
+STATIC void
+S_new_LC_ALL(pTHX_ const char *lc_all, bool force);
+#     define PERL_ARGS_ASSERT_NEW_LC_ALL        \
+        assert(lc_all)
+
 STATIC parse_LC_ALL_string_return
 S_parse_LC_ALL_string(pTHX_ const char *string, const char **output, const parse_LC_ALL_STRING_action, bool always_use_full_array, const bool panic_on_error, const line_t caller_line);
 #     define PERL_ARGS_ASSERT_PARSE_LC_ALL_STRING \
@@ -7084,7 +7085,12 @@ S_give_perl_locale_control(pTHX_ const char **curlocales, const line_t caller_li
 #     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
         assert(curlocales)
 
-#   endif
+STATIC void
+S_new_LC_ALL(pTHX_ const char **individ_locales, bool force);
+#     define PERL_ARGS_ASSERT_NEW_LC_ALL        \
+        assert(individ_locales)
+
+#   endif /* !defined(LC_ALL) */
 #   if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE const char *
 S_mortalized_pv_copy(pTHX_ const char * const pv)


### PR DESCRIPTION
This series of commits  effectively does is to change Perl_setlocale() to return its value in the native format which the libc functions are expecting.

This differs from what it used to return only on platforms which use positional notation and only for LC_ALL when not all categories are set  to the same locale.
