### PR TITLE
Add newLISTOPn()

### DIFF
--- a/class.c
+++ b/class.c
@@ -627,16 +627,6 @@ Perl_class_apply_attributes(pTHX_ HV *stash, OP *attrlist)
     op_free(attrlist);
 }
 
-static OP *
-S_newCROAKOP(pTHX_ SV *message)
-{
-    OP *o = newLISTOP(OP_LIST, 0,
-            newOP(OP_PUSHMARK, 0),
-            newSVOP(OP_CONST, 0, message));
-    return op_convert_list(OP_DIE, 0, o);
-}
-#define newCROAKOP(message)  S_newCROAKOP(aTHX_ message)
-
 void
 Perl_class_seal_stash(pTHX_ HV *stash)
 {
@@ -683,20 +673,17 @@ Perl_class_seal_stash(pTHX_ HV *stash)
             struct xpvhv_aux *superaux = HvAUX(superstash);
 
             /* Build an OP_ENTERSUB */
-            OP *o = NULL;
-            o = op_append_list(OP_LIST, o,
-                newPADxVOP(OP_PADSV, 0, PADIX_SELF));
-            o = op_append_list(OP_LIST, o,
-                newPADxVOP(OP_PADHV, OPf_REF, PADIX_PARAMS));
-            /* TODO: This won't work at all well under `use threads` because
-             * it embeds the CV * to the superclass initfields CV right into
-             * the optree. Maybe we'll have to pop it in the pad or something
-             */
-            o = op_append_list(OP_LIST, o,
-                newSVOP(OP_CONST, 0, (SV *)superaux->xhv_class_initfields_cv));
+            OP *o = newLISTOPn(OP_ENTERSUB, OPf_WANT_VOID|OPf_STACKED,
+                newPADxVOP(OP_PADSV, 0, PADIX_SELF),
+                newPADxVOP(OP_PADHV, OPf_REF, PADIX_PARAMS),
+                /* TODO: This won't work at all well under `use threads` because
+                 * it embeds the CV * to the superclass initfields CV right into
+                 * the optree. Maybe we'll have to pop it in the pad or something
+                 */
+                newSVOP(OP_CONST, 0, (SV *)superaux->xhv_class_initfields_cv),
+                NULL);
 
-            ops = op_append_list(OP_LINESEQ, ops,
-                op_convert_list(OP_ENTERSUB, OPf_WANT_VOID|OPf_STACKED, o));
+            ops = op_append_list(OP_LINESEQ, ops, o);
         }
 
         PADNAMELIST *fieldnames = aux->xhv_class_fields;
@@ -736,11 +723,14 @@ Perl_class_seal_stash(pTHX_ HV *stash)
             switch(sigil) {
                 case '$':
                     if(paramname) {
-                        if(!valop)
-                            valop = newCROAKOP(
+                        if(!valop) {
+                            SV *message =
                                 newSVpvf("Required parameter '%" SVf "' is missing for %" HvNAMEf_QUOTEDPREFIX " constructor",
-                                    SVfARG(paramname), HvNAMEfARG(stash))
-                            );
+                                    SVfARG(paramname), HvNAMEfARG(stash));
+                            valop = newLISTOPn(OP_DIE, 0,
+                                    newSVOP(OP_CONST, 0, message),
+                                    NULL);
+                        }
 
                         OP *helemop =
                             newBINOP(OP_HELEM, 0,

--- a/embed.fnc
+++ b/embed.fnc
@@ -2172,6 +2172,9 @@ ARdp	|OP *	|newLISTOP	|I32 type				\
 				|I32 flags				\
 				|NULLOK OP *first			\
 				|NULLOK OP *last
+AFRdp	|OP *	|newLISTOPn	|I32 type				\
+				|I32 flags				\
+				|...
 ARdp	|OP *	|newLOGOP	|I32 optype				\
 				|I32 flags				\
 				|NN OP *first				\

--- a/embed.h
+++ b/embed.h
@@ -852,6 +852,7 @@
 #   define form(...)                            Perl_form(aTHX_ __VA_ARGS__)
 #   define load_module(a,b,...)                 Perl_load_module(aTHX_ a,b,__VA_ARGS__)
 #   define mess(...)                            Perl_mess(aTHX_ __VA_ARGS__)
+#   define newLISTOPn(a,...)                    Perl_newLISTOPn(aTHX_ a,__VA_ARGS__)
 #   define newSVpvf(...)                        Perl_newSVpvf(aTHX_ __VA_ARGS__)
 #   define sv_catpvf(a,...)                     Perl_sv_catpvf(aTHX_ a,__VA_ARGS__)
 #   define sv_catpvf_mg(a,...)                  Perl_sv_catpvf_mg(aTHX_ a,__VA_ARGS__)

--- a/op.c
+++ b/op.c
@@ -7898,10 +7898,11 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
 
             /* Fake up a method call to VERSION */
             meth = newSVpvs_share("VERSION");
-            veop = op_convert_list(OP_ENTERSUB, OPf_STACKED,
-                            op_append_elem(OP_LIST,
-                                        op_prepend_elem(OP_LIST, pack, version),
-                                        newMETHOP_named(OP_METHOD_NAMED, 0, meth)));
+            veop = newLISTOPn(OP_ENTERSUB, OPf_STACKED,
+                    pack,
+                    version,
+                    newMETHOP_named(OP_METHOD_NAMED, 0, meth),
+                    NULL);
         }
     }
 
@@ -8978,7 +8979,7 @@ The C<flags> argument is currently ignored.
 OP *
 Perl_newTRYCATCHOP(pTHX_ I32 flags, OP *tryblock, OP *catchvar, OP *catchblock)
 {
-    OP *o, *catchop;
+    OP *catchop;
 
     PERL_ARGS_ASSERT_NEWTRYCATCHOP;
     assert(catchvar->op_type == OP_PADSV);
@@ -9010,10 +9011,10 @@ Perl_newTRYCATCHOP(pTHX_ I32 flags, OP *tryblock, OP *catchvar, OP *catchblock)
     op_free(catchvar);
 
     /* Build the optree structure */
-    o = newLISTOP(OP_LIST, 0, tryblock, catchop);
-    o = op_convert_list(OP_ENTERTRYCATCH, 0, o);
-
-    return o;
+    return newLISTOPn(OP_ENTERTRYCATCH, 0,
+            tryblock,
+            catchop,
+            NULL);
 }
 
 /*
@@ -11732,9 +11733,9 @@ Perl_newANONATTRSUB(pTHX_ I32 floor, OP *proto, OP *attrs, OP *block)
 
     if (is_const) {
         anoncode = newUNOP(OP_ANONCONST, OPf_REF,
-                           op_convert_list(OP_ENTERSUB,
-                                           OPf_STACKED|OPf_WANT_SCALAR,
-                                           anoncode));
+                newLISTOPn(OP_ENTERSUB, OPf_STACKED|OPf_WANT_SCALAR,
+                    anoncode,
+                    NULL));
     }
 
     return anoncode;

--- a/proto.h
+++ b/proto.h
@@ -2833,6 +2833,11 @@ Perl_newLISTOP(pTHX_ I32 type, I32 flags, OP *first, OP *last)
 #define PERL_ARGS_ASSERT_NEWLISTOP
 
 PERL_CALLCONV OP *
+Perl_newLISTOPn(pTHX_ I32 type, I32 flags, ...)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_NEWLISTOPN
+
+PERL_CALLCONV OP *
 Perl_newLOGOP(pTHX_ I32 optype, I32 flags, OP *first, OP *other)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLOGOP               \


### PR DESCRIPTION
A convenient shortcut when constructing optree fragments in C code, making the optree shape easier to read for the lack of machinery noise.