### PR TITLE
Socket - pack_sockaddr_un / unpack_sockaddr_un broken on AIX

### DIFF
--- a/cpan/Socket/Socket.xs
+++ b/cpan/Socket/Socket.xs
@@ -949,7 +949,7 @@ unpack_sockaddr_un(sun_sv)
         /* In this case, sun_len must be checked */
         int expectedlen = sizeof(addr.sun_len) + sizeof(addr.sun_family) + addr.sun_len;
         if (sockaddrlen != expectedlen)
-            croak("Invalid arg sun_len field for %s, length is %" UVuf ", but sun_len is %" UVuf,
+            croak("Bad arg length for %s, length is %" UVuf ", should be %" UVuf,
                     "Socket::unpack_sockaddr_un", (UV)sockaddrlen, (UV)expectedlen);
 #     endif
 #   else

--- a/cpan/Socket/Socket.xs
+++ b/cpan/Socket/Socket.xs
@@ -914,7 +914,8 @@ pack_sockaddr_un(pathname)
             addr_len = sizeof(sun_ad);
         }
 #  ifdef HAS_SOCKADDR_SA_LEN
-        sun_ad.sun_len = addr_len;
+        sun_ad.sun_len = len;
+        addr_len = sizeof(sun_ad.sun_len) + sizeof(sun_ad.sun_family) + len; 
 #  endif
         ST(0) = sv_2mortal(newSVpvn((char *)&sun_ad, addr_len));
 #else
@@ -946,7 +947,7 @@ unpack_sockaddr_un(sun_sv)
         }
 #     ifdef HAS_SOCKADDR_SA_LEN
         /* In this case, sun_len must be checked */
-        if (sockaddrlen != addr.sun_len)
+        if (sockaddrlen != sizeof(addr.sun_len) + sizeof(addr.sun_family) + addr.sun_len)
             croak("Invalid arg sun_len field for %s, length is %" UVuf ", but sun_len is %" UVuf,
                     "Socket::unpack_sockaddr_un", (UV)sockaddrlen, (UV)addr.sun_len);
 #     endif

--- a/cpan/Socket/Socket.xs
+++ b/cpan/Socket/Socket.xs
@@ -947,9 +947,10 @@ unpack_sockaddr_un(sun_sv)
         }
 #     ifdef HAS_SOCKADDR_SA_LEN
         /* In this case, sun_len must be checked */
-        if (sockaddrlen != sizeof(addr.sun_len) + sizeof(addr.sun_family) + addr.sun_len)
+        int expectedlen = sizeof(addr.sun_len) + sizeof(addr.sun_family) + addr.sun_len;
+        if (sockaddrlen != expectedlen)
             croak("Invalid arg sun_len field for %s, length is %" UVuf ", but sun_len is %" UVuf,
-                    "Socket::unpack_sockaddr_un", (UV)sockaddrlen, (UV)addr.sun_len);
+                    "Socket::unpack_sockaddr_un", (UV)sockaddrlen, (UV)expectedlen);
 #     endif
 #   else
         if (sockaddrlen != sizeof(addr))

--- a/cpan/Socket/Socket.xs
+++ b/cpan/Socket/Socket.xs
@@ -972,7 +972,7 @@ unpack_sockaddr_un(sun_sv)
         {
 #   if defined(HAS_SOCKADDR_SA_LEN)
             /* On *BSD sun_path not always ends with a '\0' */
-            int maxlen = addr.sun_len - 2; /* should use STRUCT_OFFSET(struct sockaddr_un, sun_path) instead of 2 */
+            int maxlen = addr.sun_len;
             if (maxlen > (int)sizeof(addr.sun_path))
                 maxlen = (int)sizeof(addr.sun_path);
 #   else

--- a/cpan/Socket/t/sockaddr.t
+++ b/cpan/Socket/t/sockaddr.t
@@ -12,7 +12,7 @@ use Socket qw(
     sockaddr_family
     sockaddr_un
 );
-use Test::More tests => 50;
+use Test::More tests => 52;
 
 # inet_aton, inet_ntoa
 {
@@ -167,6 +167,13 @@ SKIP: {
     ok( eval { pack_sockaddr_un( "x" x 0x10000 ); 1 },
         'pack_sockaddr_un(very long path) succeeds' ) or diag( "Died: $@" );
     is( $warnings, 1, 'pack_sockaddr_in(very long path) warns' );
+}
+
+# make sure packing and unpacking UNIX socket works
+SKIP: {
+    skip "AF_UNIX unsupported", 2 unless (eval { Socket::AF_UNIX; 1 });
+    ok(eval { Socket::pack_sockaddr_un('/path/to/socket.sock'); 1 }, 'can pack UNIX socket');
+    is(eval { Socket::unpack_sockaddr_un(pack_sockaddr_un('/path/to/socket.sock')) }, '/path/to/socket.sock', 'can unpack UNIX socket');
 }
 
 # warnings


### PR DESCRIPTION
This fixes packing and unpacking a UNIX sockaddr structure on BSD systems (most notably AIX).

Addresses #21423 