### PR TITLE
Implement `no builtin ...`

### DIFF
--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -1,10 +1,10 @@
-package builtin 0.009;
+package builtin 0.010;
 
 use strict;
 use warnings;
 
-# All code, including &import, is implemented by always-present functions in
-# the perl interpreter itself.
+# All code, including &import and &unimport, is implemented by always-present
+# functions in the perl interpreter itself.
 # See also `builtin.c` in perl source
 
 1;
@@ -75,6 +75,14 @@ don't accidentally appear as object methods from a class.
 
     # Can't locate object method "true" via package "An::Object::Class"
     #   at ...
+
+Imported symbols can also be removed again by using the C<no> keyword:
+
+    use builtin 'true';
+    my $yes = true;
+
+    no builtin 'true';
+    # true() is no longer aliased from builtin
 
 =head1 FUNCTIONS
 

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -252,6 +252,27 @@ package FetchStoreCounter {
     ok($recursecoderef->("rec"), 'true in self-recursive anon sub');
 }
 
+# imported builtins can be unexported
+{
+    package UnimportTest;
+
+    sub true() { return "true" };
+
+    {
+        use builtin 'true';
+        no builtin 'true';
+
+        ::is(true(), "true", 'no builtin can remove lexical import');
+    }
+
+    {
+        use builtin 'true';
+        { no builtin 'true'; }
+
+        ::is(true(), 1, 'no builtin is lexically scoped');
+    }
+}
+
 {
     use builtin qw( true false );
 

--- a/pad.h
+++ b/pad.h
@@ -150,6 +150,7 @@ typedef enum {
                                             * sub, but only one level up */
 #define padadd_FIELD            0x10       /* set PADNAMEt_FIELD */
 #define padfind_FIELD_OK        0x20       /* pad_findlex is permitted to see fields */
+#define padadd_TOMBSTONE        0x40       /* set PadnameIsTOMBSTONE on the new entry */
 
 /* ASSERT_CURPAD_LEGAL and ASSERT_CURPAD_ACTIVE respectively determine
  * whether PL_comppad and PL_curpad are consistent and whether they have
@@ -266,6 +267,11 @@ Whether this is a "state" variable.
 Whether this is a "field" variable.  PADNAMEs where this is true will
 have additional information available via C<PadnameFIELDINFO>.
 
+=for apidoc m|bool|PadnameIsTOMBSTONE|PADNAME * pn
+Whether this pad entry is a tombstone.  Such an entry indicates that a
+previously-valid pad entry has now been deleted within this scope, and
+should be ignored.
+
 =for apidoc m|HV *|PadnameTYPE|PADNAME * pn
 The stash associated with a typed lexical.  This returns the C<%Foo::> hash
 for C<my Foo $bar>.
@@ -358,16 +364,18 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PadnameIsSTATE(pn)	(PadnameFLAGS(pn) & PADNAMEf_STATE)
 #define PadnameLVALUE(pn)	(PadnameFLAGS(pn) & PADNAMEf_LVALUE)
 #define PadnameIsFIELD(pn)	(PadnameFLAGS(pn) & PADNAMEf_FIELD)
+#define PadnameIsTOMBSTONE(pn)  (PadnameFLAGS(pn) & PADNAMEf_TOMBSTONE)
 
-#define PadnameLVALUE_on(pn)	(PadnameFLAGS(pn) |= PADNAMEf_LVALUE)
-#define PadnameIsSTATE_on(pn)	(PadnameFLAGS(pn) |= PADNAMEf_STATE)
+#define PadnameLVALUE_on(pn)    (PadnameFLAGS(pn) |= PADNAMEf_LVALUE)
+#define PadnameIsSTATE_on(pn)   (PadnameFLAGS(pn) |= PADNAMEf_STATE)
 
-#define PADNAMEf_OUTER	0x01	/* outer lexical var */
-#define PADNAMEf_STATE	0x02	/* state var */
-#define PADNAMEf_LVALUE	0x04	/* used as lvalue */
-#define PADNAMEf_TYPED	0x08	/* for B; unused by core */
-#define PADNAMEf_OUR	0x10	/* for B; unused by core */
-#define PADNAMEf_FIELD  0x20    /* field var */
+#define PADNAMEf_OUTER      0x01    /* outer lexical var */
+#define PADNAMEf_STATE      0x02    /* state var */
+#define PADNAMEf_LVALUE     0x04    /* used as lvalue */
+#define PADNAMEf_TYPED      0x08    /* for B; unused by core */
+#define PADNAMEf_OUR        0x10    /* for B; unused by core */
+#define PADNAMEf_FIELD      0x20    /* field var */
+#define PADNAMEf_TOMBSTONE  0x40    /* padname has been deleted */
 
 /* backward compatibility */
 #ifndef PERL_CORE

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -657,6 +657,13 @@ is currently being compiled. Since this method is used to introduce new
 lexical subroutines into the scope currently being compiled, this is not
 going to have any effect.
 
+=item builtin::unimport can only be called at compile time
+
+(F) The C<unimport> method of the C<builtin> package was invoked when no code
+is currently being compiled. Since this method is used to remove
+previously-introduced lexical subroutines from the scope currently being
+compiled, this is not going to have any effect.
+
 =item Callback called exit
 
 (F) A subroutine invoked from an external package via call_sv()
@@ -2195,6 +2202,13 @@ the current directory for the specified file. Since perl v5.26.0, F<.>
 has been removed from C<@INC> by default, so this is no longer true. To
 search the current directory (and only the current directory) you can
 write C< do "./somefile"; >.
+
+=item '%s' does not appear to be an imported builtin function
+
+(F) An attempt was made to remove a previously-imported lexical from
+L<builtin> by using the C<unimport> method (likely via C<no builtin ...>
+syntax), but the requested function has not been imported into the current
+scope.
 
 =item Don't know how to get file name
 


### PR DESCRIPTION
Defines a new type of pad name entry, a "tombstone", that declares that a name does not exist.

Uses these tombstones to implement lexical unimport, thus ensuring that localized unimport within an inner scope gets correctly undone at end of that inner scope, allowing the name to become visible again in an outer scope.