### PR TITLE
Fix leak when smartmatching against a coderef

### DIFF
--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -5888,7 +5888,6 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
           sm_any_sub:
             DEBUG_M(Perl_deb(aTHX_ "    applying rule Any-CodeRef\n"));
             ENTER_with_name("smartmatch_coderef");
-            SAVETMPS;
             PUSHMARK(SP);
             PUSHs(d);
             PUTBACK;
@@ -5896,9 +5895,6 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
             SPAGAIN;
             if (c == 0)
                 PUSHs(&PL_sv_no);
-            else if (SvTEMP(TOPs))
-                SvREFCNT_inc_void(TOPs);
-            FREETMPS;
             LEAVE_with_name("smartmatch_coderef");
             RETURN;
         }

--- a/t/op/svleak.t
+++ b/t/op/svleak.t
@@ -15,7 +15,7 @@ BEGIN {
 
 use Config;
 
-plan tests => 153;
+plan tests => 154;
 
 # run some code N times. If the number of SVs at the end of loop N is
 # greater than (N-1)*delta at the end of loop 1, we've got a leak
@@ -645,6 +645,9 @@ my $refcount;
 }
 PERL
 }
+
+my $one = 1;
+leak 2, 0, sub { 1 ~~ sub { 1 + $one } }, 'Smartmatch doesn\'t leak';
 
 # the initial implementation of the require hook had some leaks
 


### PR DESCRIPTION
Previously, when smartmatching against a code reference, the return value would be leaked. This fixes that leak.