### PR TITLE
PerlIOScalar_pushed: move SvUPGRADE to where it might apply

### DIFF
--- a/perlio.c
+++ b/perlio.c
@@ -1101,11 +1101,11 @@ PerlIOScalar_pushed(pTHX_ PerlIO * f, const char *mode, SV * arg,
 		SvREFCNT_inc(get_sv
 			     (SvPV_nolen(arg), GV_ADD | GV_ADDMULTI));
 	}
+        SvUPGRADE(s->var, SVt_PV);
     }
     else {
 	s->var = newSVpvs("");
     }
-    SvUPGRADE(s->var, SVt_PV);
 
     code = PerlIOBase_pushed(aTHX_ f, mode, NULL, tab);
     if (!SvOK(s->var) || (PerlIOBase(f)->flags) & PERLIO_F_TRUNCATE)


### PR DESCRIPTION
`newSVpvs("")` returns an SV of type `SVt_PV`, therefore there's no point in calling `SvUPGRADE(..., SVt_PV)` on it.

The other nearby code paths _might_ set an SV that needs upgrading (I haven't looked into the logic), so the `SvUPGRADE` statement has been moved inside the relevant branch rather than being removed.