### PR TITLE
Make «use 5.036;» respect -X

### DIFF
--- a/op.c
+++ b/op.c
@@ -7967,7 +7967,7 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
             if (!(PL_hints & HINT_EXPLICIT_STRICT_VARS))
                 PL_hints |= HINT_STRICT_VARS;
 
-            if (shortver >= SHORTVER(5, 35)) {
+            if (shortver >= SHORTVER(5, 35) && !(PL_dowarn & G_WARN_ALL_MASK)) {
                 free_and_set_cop_warnings(&PL_compiling, pWARN_ALL);
                 PL_dowarn |= G_WARN_ONCE;
             }

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -395,6 +395,11 @@ Declared references can now be used with C<state> variables. [GH #21351]
 Trailing elements in an C<unshift>ed and resized array will now always be
 initialized. [GH #21265]
 
+=item * Make C<use 5.036> respect the -X flag
+
+perl's -X flag disables all warnings globally, but «use 5.036» didn't
+respect that until now. [GH #21431]
+
 =back
 
 =head1 Known Problems

--- a/t/run/switches.t
+++ b/t/run/switches.t
@@ -724,4 +724,32 @@ SWTEST
     like( $r, qr/ok/, 'Spaces on the #! line (#30660)' );
 }
 
+$r = runperl(
+    switches	=> [ '-W', ],
+    prog	=> 'my $b = $a + 0',
+	stderr => 1,
+);
+is( $r, "Use of uninitialized value \$a in addition (+) at -e line 1.\n", "-W" );
+
+$r = runperl(
+    switches	=> [ '-W', ],
+    prog	=> 'no warnings; my $b = $a + 0',
+	stderr => 1,
+);
+is( $r, "Use of uninitialized value \$a in addition (+) at -e line 1.\n", "-W with no warnings" );
+
+$r = runperl(
+    switches	=> [ '-X', ],
+    prog	=> 'use warnings; my $b = $a + 0',
+	stderr => 1,
+);
+is( $r, "", "-X with use warnings" );
+
+$r = runperl(
+    switches	=> [ '-X', ],
+    prog	=> 'use 5.036; my $b = $a + 0',
+	stderr => 1,
+);
+is( $r, "", "-X with use 5.36" );
+
 done_testing();


### PR DESCRIPTION
perl's -X flag disables all warnings globally, but «use 5.036» didn't respect that until now.

This fixes #21427