### PR TITLE
[doc] `File::Compare`: Improve Formatting and Styling

### DIFF
--- a/lib/File/Compare.pm
+++ b/lib/File/Compare.pm
@@ -1,4 +1,4 @@
-package File::Compare 1.1007;
+package File::Compare 1.1008;
 
 use v5.12;
 use warnings;
@@ -19,22 +19,22 @@ sub compare {
     croak("Usage: compare( file1, file2 [, buffersize]) ")
       unless(@_ == 2 || @_ == 3);
 
-    my ($from,$to,$size) = @_;
+    my ($from, $to, $size) = @_;
     my $text_mode = defined($size) && (ref($size) eq 'CODE' || $size < 0);
 
-    my ($fromsize,$closefrom,$closeto);
+    my ($fromsize, $closefrom, $closeto);
     local (*FROM, *TO);
 
     croak("from undefined") unless (defined $from);
     croak("to undefined") unless (defined $to);
 
     if (ref($from) && 
-        (UNIVERSAL::isa($from,'GLOB') || UNIVERSAL::isa($from,'IO::Handle'))) {
+        (UNIVERSAL::isa($from, 'GLOB') || UNIVERSAL::isa($from, 'IO::Handle'))) {
 	*FROM = *$from;
     } elsif (ref(\$from) eq 'GLOB') {
 	*FROM = $from;
     } else {
-	open(FROM,"<",$from) or goto fail_open1;
+	open(FROM, '<', $from) or goto fail_open1;
 	unless ($text_mode) {
 	    binmode FROM;
 	    $fromsize = -s FROM;
@@ -43,12 +43,12 @@ sub compare {
     }
 
     if (ref($to) &&
-        (UNIVERSAL::isa($to,'GLOB') || UNIVERSAL::isa($to,'IO::Handle'))) {
+        (UNIVERSAL::isa($to, 'GLOB') || UNIVERSAL::isa($to, 'IO::Handle'))) {
 	*TO = *$to;
     } elsif (ref(\$to) eq 'GLOB') {
 	*TO = $to;
     } else {
-	open(TO,"<",$to) or goto fail_open2;
+	open(TO, '<', $to) or goto fail_open2;
 	binmode TO unless $text_mode;
 	$closeto = 1;
     }
@@ -60,7 +60,7 @@ sub compare {
 
     if ($text_mode) {
 	local $/ = "\n";
-	my ($fline,$tline);
+	my ($fline, $tline);
 	while (defined($fline = <FROM>)) {
 	    goto fail_inner unless defined($tline = <TO>);
 	    if (ref $size) {
@@ -79,14 +79,14 @@ sub compare {
 	    $size = $Too_Big if $size > $Too_Big;
 	}
 
-	my ($fr,$tr,$fbuf,$tbuf);
+	my ($fr, $tr, $fbuf, $tbuf);
 	$fbuf = $tbuf = '';
-	while(defined($fr = read(FROM,$fbuf,$size)) && $fr > 0) {
-	    unless (defined($tr = read(TO,$tbuf,$fr)) && $tbuf eq $fbuf) {
+	while(defined($fr = read(FROM, $fbuf, $size)) && $fr > 0) {
+	    unless (defined($tr = read(TO, $tbuf, $fr)) && $tbuf eq $fbuf) {
 		goto fail_inner;
 	    }
 	}
-	goto fail_inner if defined($tr = read(TO,$tbuf,$size)) && $tr > 0;
+	goto fail_inner if defined($tr = read(TO, $tbuf, $size)) && $tr > 0;
     }
 
     close(TO) || goto fail_open2 if $closeto;
@@ -116,7 +116,7 @@ sub cmp;
 *cmp = \&compare;
 
 sub compare_text {
-    my ($from,$to,$cmp) = @_;
+    my ($from, $to, $cmp) = @_;
     croak("Usage: compare_text( file1, file2 [, cmp-function])")
 	unless @_ == 2 || @_ == 3;
     croak("Third arg to compare_text() function must be a code reference")
@@ -138,23 +138,23 @@ File::Compare - Compare files or filehandles
 
   	use File::Compare;
 
-	if (compare("file1","file2") == 0) {
+	if (compare("file1", "file2") == 0) {
 	    print "They're equal\n";
 	}
 
 =head1 DESCRIPTION
 
-The File::Compare::compare function compares the contents of two
+The C<File::Compare::compare> function compares the contents of two
 sources, each of which can be a file or a file handle.  It is exported
-from File::Compare by default.
+from C<File::Compare> by default.
 
-File::Compare::cmp is a synonym for File::Compare::compare.  It is
-exported from File::Compare only by request.
+C<File::Compare::cmp> is a synonym for C<File::Compare::compare>.  It is
+exported from C<File::Compare> only by request.
 
-File::Compare::compare_text does a line by line comparison of the two
-files. It stops as soon as a difference is detected. compare_text()
+C<File::Compare::compare_text> does a line by line comparison of the two
+files. It stops as soon as a difference is detected. C<compare_text()>
 accepts an optional third argument: This must be a CODE reference to
-a line comparison function, which returns 0 when both lines are considered
+a line comparison function, which returns C<0> when both lines are considered
 equal. For example:
 
     compare_text($file1, $file2)
@@ -165,10 +165,10 @@ is basically equivalent to
 
 =head1 RETURN
 
-File::Compare::compare and its sibling functions return 0 if the files
-are equal, 1 if the files are unequal, or -1 if an error was encountered.
+C<File::Compare::compare> and its sibling functions return C<0> if the files
+are equal, C<1> if the files are unequal, or C<-1> if an error was encountered.
 
 =head1 AUTHOR
 
-File::Compare was written by Nick Ing-Simmons.
+C<File::Compare> was written by Nick Ing-Simmons.
 Its original documentation was written by Chip Salzenberg.


### PR DESCRIPTION
Bump the version as well

Add `C<>` where appropriate in docs, add spacing for commas in code, and remove unnecessary double quotes in `open`.