### PR TITLE
perlop, perlsyn: make abstract more verbose/precise

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5526,7 +5526,7 @@ pod/perlnewmod.pod			Perl modules: preparing a new module for distribution
 pod/perlnumber.pod			Perl number semantics
 pod/perlobj.pod				Perl objects
 pod/perlootut.pod			Perl OO tutorial for beginners
-pod/perlop.pod				Perl operators and precedence
+pod/perlop.pod				Perl expressions: operators, precedence, string literals
 pod/perlopentut.pod			Perl open() tutorial
 pod/perlpacktut.pod			Perl pack() and unpack() tutorial
 pod/perlperf.pod			Perl Performance and Optimization Techniques
@@ -5553,7 +5553,7 @@ pod/perlsecpolicy.pod			Perl security report handling policy
 pod/perlsource.pod			Guide to the Perl source tree
 pod/perlstyle.pod			Perl style guide
 pod/perlsub.pod				Perl subroutines
-pod/perlsyn.pod				Perl syntax
+pod/perlsyn.pod				Perl syntax: declarations, statements, comments
 pod/perlthrtut.pod			Perl threads tutorial
 pod/perltie.pod				Perl objects hidden behind simple variables
 pod/perltodo.pod

--- a/pod/perl.pod
+++ b/pod/perl.pod
@@ -87,9 +87,9 @@ aux h2ph h2xs perlbug pl2pm pod2html pod2man splain xsubpp
 
 =head2 Reference Manual
 
-    perlsyn		Perl syntax
+    perlsyn		Perl syntax: declarations, statements, comments
     perldata		Perl data structures
-    perlop		Perl operators and precedence
+    perlop		Perl expressions: operators, precedence, string literals
     perlsub		Perl subroutines
     perlfunc		Perl built-in functions
       perlopentut	Perl open() tutorial

--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -1,7 +1,7 @@
 =head1 NAME
 X<operator>
 
-perlop - Perl operators and precedence
+perlop - Perl expressions: operators, precedence, string literals
 
 =head1 DESCRIPTION
 

--- a/pod/perlsyn.pod
+++ b/pod/perlsyn.pod
@@ -1,7 +1,7 @@
 =head1 NAME
 X<syntax>
 
-perlsyn - Perl syntax
+perlsyn - Perl syntax: declarations, statements, comments
 
 =head1 DESCRIPTION
 

--- a/t/porting/known_pod_issues.dat
+++ b/t/porting/known_pod_issues.dat
@@ -400,7 +400,7 @@ ext/pod-html/corpus/perlvar-copy.pod	Verbatim line length including indents exce
 ext/vms-filespec/lib/vms/filespec.pm	Verbatim line length including indents exceeds 78 by	1
 install	? Should you be using F<...> or maybe L<...> instead of	1
 install	Verbatim line length including indents exceeds 78 by	2
-pod/perl.pod	Verbatim line length including indents exceeds 78 by	5
+pod/perl.pod	Verbatim line length including indents exceeds 78 by	6
 pod/perlandroid.pod	Verbatim line length including indents exceeds 78 by	3
 pod/perlbook.pod	Verbatim line length including indents exceeds 78 by	1
 pod/perldebguts.pod	Verbatim line length including indents exceeds 78 by	-1


### PR DESCRIPTION
If you're looking for the syntax of Perl expressions or strings, you might think that "perlsyn - Perl syntax" is the document you need. But perlsyn is mostly about syntax at the statement level. Expressions (including how string literals are parsed, available escape sequences, etc) are documented in perlop instead.

Hopefully, making the abstract slightly more verbose will make it easier for people to find the documentation they're looking for.