### PR TITLE
perlmod: mention perlclass in classes section

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -231,6 +231,7 @@ Bruce Barnett                  <barnett@grymoire.crd.ge.com>
 Bruce Gray                     <bruce.gray@acm.org>
 Bruce J. Keeler                <bkeelerx@iwa.dp.intel.com>
 Bruce P. Schuck                <bruce@aps.org>
+Bruno Meneguele                <bmeneg@heredoc.io>
 Bryan Stenson                  <bryan@siliconvortex.com>
 Bud Huff                       <BAHUFF@us.oracle.com>
 Byron Brummer                  <byron@omix.com>

--- a/pod/perlmod.pod
+++ b/pod/perlmod.pod
@@ -426,13 +426,14 @@ The B<begincheck> program makes it all clear, eventually:
 =head2 Perl Classes
 X<class> X<@ISA>
 
-There is no special class syntax in Perl, but a package may act
+There is no stable class syntax in Perl, but a package may act
 as a class if it provides subroutines to act as methods.  Such a
 package may also derive some of its methods from another class (package)
 by listing the other package name(s) in its global @ISA array (which
 must be a package global, not a lexical).
 
-For more on this, see L<perlootut> and L<perlobj>.
+For more on packages acting as classes, see L<perlootut> and L<perlobj>.
+For more on the not-yet-stable class syntax, see L<perlclass>.
 
 =head2 Perl Modules
 X<module>


### PR DESCRIPTION
After L<perlclass> was created perlmod wasn't update to reflect added feature under `Perl Classes` section. This commit rewords `no special` to `no stable` syntax and also mentions perlclass documentation for more information.

Fixes #21188