### PR TITLE
libnet: deal with /etc/hostname containing fqdn

### DIFF
--- a/cpan/libnet/lib/Net/Domain.pm
+++ b/cpan/libnet/lib/Net/Domain.pm
@@ -107,6 +107,12 @@ sub _hostname {
   $host =~ s/(\A\.+|\.+\Z)//go;
   $host =~ s/\.\.+/\./go;
 
+  # deal with hostname returning fqdn
+  if ($host =~ /^([^\.]+)\.(.*)$/) {
+     $host = $1;
+     $domain = $2;
+  }
+
   $host;
 }
 


### PR DESCRIPTION
If /etc/hostname contains the fqdn then domainname() returns "domainname" rather than domainname from /etc/hostname