### PR TITLE
Implement builtin::stringify

### DIFF
--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -1,4 +1,4 @@
-package builtin 0.009;
+package builtin 0.010;
 
 use strict;
 use warnings;
@@ -21,6 +21,7 @@ builtin - Perl pragma to import built-in utility functions
         weaken unweaken is_weak
         blessed refaddr reftype
         created_as_string created_as_number
+        stringify
         ceil floor
         indexed
         trim
@@ -213,6 +214,26 @@ their creation history, these two functions are intended to be used by data
 serialisation modules such as JSON encoders or similar situations, where
 language interoperability concerns require making a distinction between values
 that are fundamentally stringlike versus numberlike in nature.
+
+=head2 stringify
+
+    $str = stringify($val);
+
+Returns a new plain perl string that represents the given argument.
+
+When given a value that is already a string, a copy of this value is returned
+unchanged. False booleans are treated like the empty string.
+
+Numbers are turned into a decimal representation. True booleans are treated
+like the number 1.
+
+References to objects in classes that have L<overload> and define the C<"">
+overload entry will use the delegated method to provide a value here.
+
+Non-object references, or references to objects in classes without a C<"">
+overload will return a string that names the underlying container type of
+the reference, its memory address, and possibly its class name if it is an
+object.
 
 =head2 ceil
 

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -173,6 +173,27 @@ package FetchStoreCounter {
     is(prototype(\&builtin::created_as_number), '$', 'created_as_number prototype');
 }
 
+# stringify
+{
+    use builtin qw( stringify );
+
+    is(stringify("abc"), "abc", 'stringify a plain string');
+    is(stringify(123),   "123", 'stringify a number');
+
+    my $aref = [];
+    is(stringify($aref), "$aref", 'stringify an array ref');
+
+    use builtin qw( created_as_string );
+    ok(!ref stringify($aref),               'stringified arrayref is not a ref');
+    ok(created_as_string(stringify($aref)), 'stringified arrayref is created as string');
+
+    package WithOverloadedStringify {
+        use overload '""' => sub { return "STRING" };
+    }
+
+    is(stringify(bless [], "WithOverloadedStringify"), "STRING", 'stringify invokes "" overload');
+}
+
 # ceil, floor
 {
     use builtin qw( ceil floor );


### PR DESCRIPTION
Adds a new function to the `builtin::` space, to wrap `OP_STRINGIFY`.

It's a neater way to request the current oddball behaviours that come out of special rules of `qq($var)` or `join "", $var`. By providing this as its own function it's more convenient and easier to find, and may pave the way to removing some of those specialcase handling rules at some point in the future.

(As discussed in this mailing list thread: https://www.nntp.perl.org/group/perl.perl5.porters/2023/08/msg266989.html)