### PR TITLE
Configure: ensure LC_ALL test code doesn't have escapes escaped

### DIFF
--- a/Configure
+++ b/Configure
@@ -17475,7 +17475,7 @@ $echo "Checking the syntax of LC_ALL when categories are set to different locale
 case $d_setlocale in
     $define)
 $rm -f try try.*
-$cat >try.c <<EOF
+$cat >try.c <<'EOF'
 #include <limits.h>
 #include <locale.h>
 #include <stdlib.h>
@@ -17832,7 +17832,8 @@ if eval $compile_ok; then
 	      perl_lc_all_category_positions_init=`echo "$output" | sed -n 2p`
 	    ;;
     esac
-
+else
+    $echo "Failed to compile lc_all probe" >&4
 fi
 $rm -f try try.*
 ;;


### PR DESCRIPTION
Some \\" was being converted to " with ksh on AIX, causing the program to fail to build and failing the entire build.

Example report: https://perl5.test-smoke.org/report/5039146

Errors:
"config.h", line 3640.3: 1506-218 (E) Unknown preprocessing directive #PERL_LC_ALL_USES_NAME_VALUE_PAIRS. "config.h", line 3641.4: 1506-218 (E) Unknown preprocessing directive #PERL_LC_ALL_SEPARATOR. "config.h", line 3642.4: 1506-218 (E) Unknown preprocessing directive #PERL_LC_ALL_CATEGORY_POSITIONS_INIT. "locale.c", line 6865.43: 1506-168 (S) Initializer must be enclosed in braces. "locale.c", line 6866.31: 1506-043 (S) The operand of the sizeof operator is not valid. "locale.c", line 6866.9: 1506-044 (S) Expression must be a non-negative integer constant. "locale.c", line 6870.18: 1506-043 (S) The operand of the sizeof operator is not valid.