### PR TITLE
perl.pod: use spaces instead of tabs for alignment

### DIFF
--- a/pod/perl.pod
+++ b/pod/perl.pod
@@ -4,16 +4,16 @@ perl - The Perl 5 language interpreter
 
 =head1 SYNOPSIS
 
-B<perl>	S<[ B<-sTtuUWX> ]>
-	S<[ B<-hv> ] [ B<-V>[:I<configvar>] ]>
-	S<[ B<-cw> ] [ B<-d>[B<t>][:I<debugger>] ] [ B<-D>[I<number/list>] ]>
-	S<[ B<-pna> ] [ B<-F>I<pattern> ] [ B<-l>[I<octal>] ] [ B<-0>[I<octal/hexadecimal>] ]>
-	S<[ B<-I>I<dir> ] [ B<-m>[B<->]I<module> ] [ B<-M>[B<->]I<'module...'> ] [ B<-f> ]>
-	S<[ B<-C [I<number/list>] >]>
-	S<[ B<-S> ]>
-	S<[ B<-x>[I<dir>] ]>
-	S<[ B<-i>[I<extension>] ]>
-	S<[ [B<-e>|B<-E>] I<'command'> ] [ B<--> ] [ I<programfile> ] [ I<argument> ]...>
+B<perl> S<[ B<-sTtuUWX> ]>
+        S<[ B<-hv> ] [ B<-V>[:I<configvar>] ]>
+        S<[ B<-cw> ] [ B<-d>[B<t>][:I<debugger>] ] [ B<-D>[I<number/list>] ]>
+        S<[ B<-pna> ] [ B<-F>I<pattern> ] [ B<-l>[I<octal>] ] [ B<-0>[I<octal/hexadecimal>] ]>
+        S<[ B<-I>I<dir> ] [ B<-m>[B<->]I<module> ] [ B<-M>[B<->]I<'module...'> ] [ B<-f> ]>
+        S<[ B<-C [I<number/list>] >]>
+        S<[ B<-S> ]>
+        S<[ B<-x>[I<dir>] ]>
+        S<[ B<-i>[I<extension>] ]>
+        S<[ [B<-e>|B<-E>] I<'command'> ] [ B<--> ] [ I<programfile> ] [ I<argument> ]...>
 
 For more information on these options, you can run C<perldoc perlrun>.
 
@@ -50,268 +50,268 @@ aux h2ph h2xs perlbug pl2pm pod2html pod2man splain xsubpp
 
 =head2 Overview
 
-    perl		Perl overview (this section)
-    perlintro		Perl introduction for beginners
-    perlrun		Perl execution and options
-    perltoc		Perl documentation table of contents
+    perl                Perl overview (this section)
+    perlintro           Perl introduction for beginners
+    perlrun             Perl execution and options
+    perltoc             Perl documentation table of contents
 
 =head2 Tutorials
 
-    perlreftut		Perl references short introduction
-    perldsc		Perl data structures intro
-    perllol		Perl data structures: arrays of arrays
+    perlreftut          Perl references short introduction
+    perldsc             Perl data structures intro
+    perllol             Perl data structures: arrays of arrays
 
-    perlrequick 	Perl regular expressions quick start
-    perlretut		Perl regular expressions tutorial
+    perlrequick         Perl regular expressions quick start
+    perlretut           Perl regular expressions tutorial
 
-    perlootut		Perl OO tutorial for beginners
+    perlootut           Perl OO tutorial for beginners
 
-    perlperf		Perl Performance and Optimization Techniques
+    perlperf            Perl Performance and Optimization Techniques
 
-    perlstyle		Perl style guide
+    perlstyle           Perl style guide
 
-    perlcheat		Perl cheat sheet
-    perltrap		Perl traps for the unwary
-    perldebtut		Perl debugging tutorial
+    perlcheat           Perl cheat sheet
+    perltrap            Perl traps for the unwary
+    perldebtut          Perl debugging tutorial
 
-    perlfaq		Perl frequently asked questions
-      perlfaq1		General Questions About Perl
-      perlfaq2		Obtaining and Learning about Perl
-      perlfaq3		Programming Tools
-      perlfaq4		Data Manipulation
-      perlfaq5		Files and Formats
-      perlfaq6		Regexes
-      perlfaq7		Perl Language Issues
-      perlfaq8		System Interaction
-      perlfaq9		Networking
+    perlfaq             Perl frequently asked questions
+      perlfaq1          General Questions About Perl
+      perlfaq2          Obtaining and Learning about Perl
+      perlfaq3          Programming Tools
+      perlfaq4          Data Manipulation
+      perlfaq5          Files and Formats
+      perlfaq6          Regexes
+      perlfaq7          Perl Language Issues
+      perlfaq8          System Interaction
+      perlfaq9          Networking
 
 =head2 Reference Manual
 
-    perlsyn		Perl syntax: declarations, statements, comments
-    perldata		Perl data structures
-    perlop		Perl expressions: operators, precedence, string literals
-    perlsub		Perl subroutines
-    perlfunc		Perl built-in functions
-      perlopentut	Perl open() tutorial
-      perlpacktut	Perl pack() and unpack() tutorial
-    perlpod		Perl plain old documentation
-    perlpodspec 	Perl plain old documentation format specification
-    perldocstyle	Perl style guide for core docs
-    perlpodstyle	Perl POD style guide
-    perldiag		Perl diagnostic messages
+    perlsyn             Perl syntax: declarations, statements, comments
+    perldata            Perl data structures
+    perlop              Perl expressions: operators, precedence, string literals
+    perlsub             Perl subroutines
+    perlfunc            Perl built-in functions
+      perlopentut       Perl open() tutorial
+      perlpacktut       Perl pack() and unpack() tutorial
+    perlpod             Perl plain old documentation
+    perlpodspec         Perl plain old documentation format specification
+    perldocstyle        Perl style guide for core docs
+    perlpodstyle        Perl POD style guide
+    perldiag            Perl diagnostic messages
     perldeprecation     Perl deprecations
-    perllexwarn 	Perl warnings and their control
-    perldebug		Perl debugging
-    perlvar		Perl predefined variables
-    perlre		Perl regular expressions, the rest of the story
-    perlrebackslash	Perl regular expression backslash sequences
-    perlrecharclass	Perl regular expression character classes
-    perlreref		Perl regular expressions quick reference
-    perlref		Perl references, the rest of the story
-    perlform		Perl formats
-    perlobj		Perl objects
-    perltie		Perl objects hidden behind simple variables
+    perllexwarn         Perl warnings and their control
+    perldebug           Perl debugging
+    perlvar             Perl predefined variables
+    perlre              Perl regular expressions, the rest of the story
+    perlrebackslash     Perl regular expression backslash sequences
+    perlrecharclass     Perl regular expression character classes
+    perlreref           Perl regular expressions quick reference
+    perlref             Perl references, the rest of the story
+    perlform            Perl formats
+    perlobj             Perl objects
+    perltie             Perl objects hidden behind simple variables
     perlclass           Perl class syntax
-      perldbmfilter	Perl DBM filters
+      perldbmfilter     Perl DBM filters
 
-    perlipc		Perl interprocess communication
-    perlfork		Perl fork() information
-    perlnumber		Perl number semantics
+    perlipc             Perl interprocess communication
+    perlfork            Perl fork() information
+    perlnumber          Perl number semantics
 
-    perlthrtut		Perl threads tutorial
+    perlthrtut          Perl threads tutorial
 
-    perlport		Perl portability guide
-    perllocale		Perl locale support
-    perluniintro	Perl Unicode introduction
-    perlunicode 	Perl Unicode support
-    perlunicook 	Perl Unicode cookbook
-    perlunifaq		Perl Unicode FAQ
-    perluniprops	Index of Unicode properties in Perl
-    perlunitut		Perl Unicode tutorial
-    perlebcdic		Considerations for running Perl on EBCDIC platforms
+    perlport            Perl portability guide
+    perllocale          Perl locale support
+    perluniintro        Perl Unicode introduction
+    perlunicode         Perl Unicode support
+    perlunicook         Perl Unicode cookbook
+    perlunifaq          Perl Unicode FAQ
+    perluniprops        Index of Unicode properties in Perl
+    perlunitut          Perl Unicode tutorial
+    perlebcdic          Considerations for running Perl on EBCDIC platforms
 
-    perlsec		Perl security
-    perlsecpolicy	Perl security report handling policy
+    perlsec             Perl security
+    perlsecpolicy       Perl security report handling policy
 
-    perlmod		Perl modules: how they work
-    perlmodlib		Perl modules: how to write and use
-    perlmodstyle	Perl modules: how to write modules with style
-    perlmodinstall	Perl modules: how to install from CPAN
-    perlnewmod		Perl modules: preparing a new module for distribution
-    perlpragma		Perl modules: writing a user pragma
+    perlmod             Perl modules: how they work
+    perlmodlib          Perl modules: how to write and use
+    perlmodstyle        Perl modules: how to write modules with style
+    perlmodinstall      Perl modules: how to install from CPAN
+    perlnewmod          Perl modules: preparing a new module for distribution
+    perlpragma          Perl modules: writing a user pragma
 
-    perlutil		utilities packaged with the Perl distribution
+    perlutil            utilities packaged with the Perl distribution
 
-    perlfilter		Perl source filters
+    perlfilter          Perl source filters
 
-    perldtrace		Perl's support for DTrace
+    perldtrace          Perl's support for DTrace
 
-    perlglossary	Perl Glossary
+    perlglossary        Perl Glossary
 
 =head2 Internals and C Language Interface
 
-    perlembed		Perl ways to embed perl in your C or C++ application
-    perldebguts 	Perl debugging guts and tips
-    perlxstut		Perl XS tutorial
-    perlxs		Perl XS application programming interface
-    perlxstypemap	Perl XS C/Perl type conversion tools
-    perlclib		Internal replacements for standard C library functions
-    perlguts		Perl internal functions for those doing extensions
-    perlcall		Perl calling conventions from C
-    perlmroapi		Perl method resolution plugin interface
-    perlreapi		Perl regular expression plugin interface
-    perlreguts		Perl regular expression engine internals
-    perlclassguts	Internals of class syntax
+    perlembed           Perl ways to embed perl in your C or C++ application
+    perldebguts         Perl debugging guts and tips
+    perlxstut           Perl XS tutorial
+    perlxs              Perl XS application programming interface
+    perlxstypemap       Perl XS C/Perl type conversion tools
+    perlclib            Internal replacements for standard C library functions
+    perlguts            Perl internal functions for those doing extensions
+    perlcall            Perl calling conventions from C
+    perlmroapi          Perl method resolution plugin interface
+    perlreapi           Perl regular expression plugin interface
+    perlreguts          Perl regular expression engine internals
+    perlclassguts       Internals of class syntax
 
-    perlapi		Perl API listing (autogenerated)
-    perlintern		Perl internal functions (autogenerated)
-    perliol		C API for Perl's implementation of IO in Layers
-    perlapio		Perl internal IO abstraction interface
+    perlapi             Perl API listing (autogenerated)
+    perlintern          Perl internal functions (autogenerated)
+    perliol             C API for Perl's implementation of IO in Layers
+    perlapio            Perl internal IO abstraction interface
 
-    perlhack		Perl hackers guide
-    perlsource		Guide to the Perl source tree
-    perlinterp		Overview of the Perl interpreter source and how it works
-    perlhacktut 	Walk through the creation of a simple C code patch
-    perlhacktips	Tips for Perl core C code hacking
-    perlpolicy		Perl development policies
-    perlgov		Perl Rules of Governance
-    perlgit		Using git with the Perl repository
+    perlhack            Perl hackers guide
+    perlsource          Guide to the Perl source tree
+    perlinterp          Overview of the Perl interpreter source and how it works
+    perlhacktut         Walk through the creation of a simple C code patch
+    perlhacktips        Tips for Perl core C code hacking
+    perlpolicy          Perl development policies
+    perlgov             Perl Rules of Governance
+    perlgit             Using git with the Perl repository
 
 =head2 History
 
-    perlhist		Perl history records
-    perldelta		Perl changes since previous version
-    perl5392delta	Perl changes in version 5.39.2
-    perl5391delta	Perl changes in version 5.39.1
-    perl5390delta	Perl changes in version 5.39.0
-    perl5380delta	Perl changes in version 5.38.0
-    perl5361delta	Perl changes in version 5.36.1
-    perl5360delta	Perl changes in version 5.36.0
-    perl5341delta	Perl changes in version 5.34.1
-    perl5340delta	Perl changes in version 5.34.0
-    perl5321delta	Perl changes in version 5.32.1
-    perl5320delta	Perl changes in version 5.32.0
-    perl5303delta	Perl changes in version 5.30.3
-    perl5302delta	Perl changes in version 5.30.2
-    perl5301delta	Perl changes in version 5.30.1
-    perl5300delta	Perl changes in version 5.30.0
-    perl5283delta	Perl changes in version 5.28.3
-    perl5282delta	Perl changes in version 5.28.2
-    perl5281delta	Perl changes in version 5.28.1
-    perl5280delta	Perl changes in version 5.28.0
-    perl5263delta	Perl changes in version 5.26.3
-    perl5262delta	Perl changes in version 5.26.2
-    perl5261delta	Perl changes in version 5.26.1
-    perl5260delta	Perl changes in version 5.26.0
-    perl5244delta	Perl changes in version 5.24.4
-    perl5243delta	Perl changes in version 5.24.3
-    perl5242delta	Perl changes in version 5.24.2
-    perl5241delta	Perl changes in version 5.24.1
-    perl5240delta	Perl changes in version 5.24.0
-    perl5224delta	Perl changes in version 5.22.4
-    perl5223delta	Perl changes in version 5.22.3
-    perl5222delta	Perl changes in version 5.22.2
-    perl5221delta	Perl changes in version 5.22.1
-    perl5220delta	Perl changes in version 5.22.0
-    perl5203delta	Perl changes in version 5.20.3
-    perl5202delta	Perl changes in version 5.20.2
-    perl5201delta	Perl changes in version 5.20.1
-    perl5200delta	Perl changes in version 5.20.0
-    perl5184delta	Perl changes in version 5.18.4
-    perl5182delta	Perl changes in version 5.18.2
-    perl5181delta	Perl changes in version 5.18.1
-    perl5180delta	Perl changes in version 5.18.0
-    perl5163delta	Perl changes in version 5.16.3
-    perl5162delta	Perl changes in version 5.16.2
-    perl5161delta	Perl changes in version 5.16.1
-    perl5160delta	Perl changes in version 5.16.0
-    perl5144delta	Perl changes in version 5.14.4
-    perl5143delta	Perl changes in version 5.14.3
-    perl5142delta	Perl changes in version 5.14.2
-    perl5141delta	Perl changes in version 5.14.1
-    perl5140delta	Perl changes in version 5.14.0
-    perl5125delta	Perl changes in version 5.12.5
-    perl5124delta	Perl changes in version 5.12.4
-    perl5123delta	Perl changes in version 5.12.3
-    perl5122delta	Perl changes in version 5.12.2
-    perl5121delta	Perl changes in version 5.12.1
-    perl5120delta	Perl changes in version 5.12.0
-    perl5101delta	Perl changes in version 5.10.1
-    perl5100delta	Perl changes in version 5.10.0
-    perl589delta	Perl changes in version 5.8.9
-    perl588delta	Perl changes in version 5.8.8
-    perl587delta	Perl changes in version 5.8.7
-    perl586delta	Perl changes in version 5.8.6
-    perl585delta	Perl changes in version 5.8.5
-    perl584delta	Perl changes in version 5.8.4
-    perl583delta	Perl changes in version 5.8.3
-    perl582delta	Perl changes in version 5.8.2
-    perl581delta	Perl changes in version 5.8.1
-    perl58delta 	Perl changes in version 5.8.0
-    perl561delta	Perl changes in version 5.6.1
-    perl56delta 	Perl changes in version 5.6
-    perl5005delta	Perl changes in version 5.005
-    perl5004delta	Perl changes in version 5.004
+    perlhist            Perl history records
+    perldelta           Perl changes since previous version
+    perl5392delta       Perl changes in version 5.39.2
+    perl5391delta       Perl changes in version 5.39.1
+    perl5390delta       Perl changes in version 5.39.0
+    perl5380delta       Perl changes in version 5.38.0
+    perl5361delta       Perl changes in version 5.36.1
+    perl5360delta       Perl changes in version 5.36.0
+    perl5341delta       Perl changes in version 5.34.1
+    perl5340delta       Perl changes in version 5.34.0
+    perl5321delta       Perl changes in version 5.32.1
+    perl5320delta       Perl changes in version 5.32.0
+    perl5303delta       Perl changes in version 5.30.3
+    perl5302delta       Perl changes in version 5.30.2
+    perl5301delta       Perl changes in version 5.30.1
+    perl5300delta       Perl changes in version 5.30.0
+    perl5283delta       Perl changes in version 5.28.3
+    perl5282delta       Perl changes in version 5.28.2
+    perl5281delta       Perl changes in version 5.28.1
+    perl5280delta       Perl changes in version 5.28.0
+    perl5263delta       Perl changes in version 5.26.3
+    perl5262delta       Perl changes in version 5.26.2
+    perl5261delta       Perl changes in version 5.26.1
+    perl5260delta       Perl changes in version 5.26.0
+    perl5244delta       Perl changes in version 5.24.4
+    perl5243delta       Perl changes in version 5.24.3
+    perl5242delta       Perl changes in version 5.24.2
+    perl5241delta       Perl changes in version 5.24.1
+    perl5240delta       Perl changes in version 5.24.0
+    perl5224delta       Perl changes in version 5.22.4
+    perl5223delta       Perl changes in version 5.22.3
+    perl5222delta       Perl changes in version 5.22.2
+    perl5221delta       Perl changes in version 5.22.1
+    perl5220delta       Perl changes in version 5.22.0
+    perl5203delta       Perl changes in version 5.20.3
+    perl5202delta       Perl changes in version 5.20.2
+    perl5201delta       Perl changes in version 5.20.1
+    perl5200delta       Perl changes in version 5.20.0
+    perl5184delta       Perl changes in version 5.18.4
+    perl5182delta       Perl changes in version 5.18.2
+    perl5181delta       Perl changes in version 5.18.1
+    perl5180delta       Perl changes in version 5.18.0
+    perl5163delta       Perl changes in version 5.16.3
+    perl5162delta       Perl changes in version 5.16.2
+    perl5161delta       Perl changes in version 5.16.1
+    perl5160delta       Perl changes in version 5.16.0
+    perl5144delta       Perl changes in version 5.14.4
+    perl5143delta       Perl changes in version 5.14.3
+    perl5142delta       Perl changes in version 5.14.2
+    perl5141delta       Perl changes in version 5.14.1
+    perl5140delta       Perl changes in version 5.14.0
+    perl5125delta       Perl changes in version 5.12.5
+    perl5124delta       Perl changes in version 5.12.4
+    perl5123delta       Perl changes in version 5.12.3
+    perl5122delta       Perl changes in version 5.12.2
+    perl5121delta       Perl changes in version 5.12.1
+    perl5120delta       Perl changes in version 5.12.0
+    perl5101delta       Perl changes in version 5.10.1
+    perl5100delta       Perl changes in version 5.10.0
+    perl589delta        Perl changes in version 5.8.9
+    perl588delta        Perl changes in version 5.8.8
+    perl587delta        Perl changes in version 5.8.7
+    perl586delta        Perl changes in version 5.8.6
+    perl585delta        Perl changes in version 5.8.5
+    perl584delta        Perl changes in version 5.8.4
+    perl583delta        Perl changes in version 5.8.3
+    perl582delta        Perl changes in version 5.8.2
+    perl581delta        Perl changes in version 5.8.1
+    perl58delta         Perl changes in version 5.8.0
+    perl561delta        Perl changes in version 5.6.1
+    perl56delta         Perl changes in version 5.6
+    perl5005delta       Perl changes in version 5.005
+    perl5004delta       Perl changes in version 5.004
 
 =head2 Miscellaneous
 
-    perlbook		Perl book information
-    perlcommunity	Perl community information
+    perlbook            Perl book information
+    perlcommunity       Perl community information
 
-    perldoc		Look up Perl documentation in Pod format
+    perldoc             Look up Perl documentation in Pod format
 
-    perlexperiment	A listing of experimental features in Perl
+    perlexperiment      A listing of experimental features in Perl
 
-    perlartistic	Perl Artistic License
-    perlgpl		GNU General Public License
+    perlartistic        Perl Artistic License
+    perlgpl             GNU General Public License
 
 =head2 Language-Specific
 
 =for buildtoc flag +r
 
-    perlcn		Perl for Simplified Chinese (in UTF-8)
-    perljp		Perl for Japanese (in EUC-JP)
-    perlko		Perl for Korean (in EUC-KR)
-    perltw		Perl for Traditional Chinese (in Big5)
+    perlcn              Perl for Simplified Chinese (in UTF-8)
+    perljp              Perl for Japanese (in EUC-JP)
+    perlko              Perl for Korean (in EUC-KR)
+    perltw              Perl for Traditional Chinese (in Big5)
 
 =head2 Platform-Specific
 
-    perlaix		Perl notes for AIX
-    perlamiga		Perl notes for AmigaOS
-    perlandroid		Perl notes for Android
-    perlbs2000		Perl notes for POSIX-BC BS2000
-    perlcygwin		Perl notes for Cygwin
-    perlfreebsd 	Perl notes for FreeBSD
-    perlhaiku		Perl notes for Haiku
-    perlhpux		Perl notes for HP-UX
-    perlhurd		Perl notes for Hurd
-    perlirix		Perl notes for Irix
-    perllinux		Perl notes for Linux
-    perlmacosx		Perl notes for Mac OS X
-    perlopenbsd 	Perl notes for OpenBSD
-    perlos2		Perl notes for OS/2
-    perlos390		Perl notes for OS/390
-    perlos400		Perl notes for OS/400
-    perlplan9		Perl notes for Plan 9
-    perlqnx		Perl notes for QNX
-    perlriscos		Perl notes for RISC OS
-    perlsolaris 	Perl notes for Solaris
-    perlsynology 	Perl notes for Synology
-    perltru64		Perl notes for Tru64
-    perlvms		Perl notes for VMS
-    perlvos		Perl notes for Stratus VOS
-    perlwin32		Perl notes for Windows
+    perlaix             Perl notes for AIX
+    perlamiga           Perl notes for AmigaOS
+    perlandroid         Perl notes for Android
+    perlbs2000          Perl notes for POSIX-BC BS2000
+    perlcygwin          Perl notes for Cygwin
+    perlfreebsd         Perl notes for FreeBSD
+    perlhaiku           Perl notes for Haiku
+    perlhpux            Perl notes for HP-UX
+    perlhurd            Perl notes for Hurd
+    perlirix            Perl notes for Irix
+    perllinux           Perl notes for Linux
+    perlmacosx          Perl notes for Mac OS X
+    perlopenbsd         Perl notes for OpenBSD
+    perlos2             Perl notes for OS/2
+    perlos390           Perl notes for OS/390
+    perlos400           Perl notes for OS/400
+    perlplan9           Perl notes for Plan 9
+    perlqnx             Perl notes for QNX
+    perlriscos          Perl notes for RISC OS
+    perlsolaris         Perl notes for Solaris
+    perlsynology        Perl notes for Synology
+    perltru64           Perl notes for Tru64
+    perlvms             Perl notes for VMS
+    perlvos             Perl notes for Stratus VOS
+    perlwin32           Perl notes for Windows
 
 =for buildtoc flag -r
 
 =head2 Stubs for Deleted Documents
 
-    perlboot		
-    perlbot		
+    perlboot
+    perlbot
     perlrepository
     perltodo
-    perltooc		
-    perltoot		
+    perltooc
+    perltoot
 
 =for buildtoc __END__
 
@@ -373,14 +373,14 @@ See L<perlrun/ENVIRONMENT>.
 
 Larry Wall <larry@wall.org>, with the help of oodles of other folks.
 
-If your Perl success stories and testimonials may be of help to others 
-who wish to advocate the use of Perl in their applications, 
-or if you wish to simply express your gratitude to Larry and the 
+If your Perl success stories and testimonials may be of help to others
+who wish to advocate the use of Perl in their applications,
+or if you wish to simply express your gratitude to Larry and the
 Perl developers, please write to perl-thanks@perl.org .
 
 =head1 FILES
 
- "@INC"			locations of perl libraries
+ "@INC"                 locations of perl libraries
 
 "@INC" above is a reference to the built-in variable of the same name;
 see L<perlvar> for more information.


### PR DESCRIPTION
On some platforms/formatters, the documentation overview in 'perldoc perl' renders badly (misaligned) because tabs are interpreted differently. This is presumably because some renderers output all of the leading spaces in a verbatim paragraph as-is, while others don't.

For example, https://perldoc.perl.org/perl currently shows for me:

                        |
                        v
    ...
    perlsyn         Perl syntax
    perldata                Perl data structures
    perlop          Perl operators and precedence
    perlsub         Perl subroutines
    perlfunc                Perl built-in functions
      perlopentut   Perl open() tutorial
      perlpacktut   Perl pack() and unpack() tutorial
    perlpod         Perl plain old documentation
    perlpodspec     Perl plain old documentation format specification
    perldocstyle    Perl style guide for core docs
    perlpodstyle    Perl POD style guide
    perldiag                Perl diagnostic messages
    perldeprecation     Perl deprecations
    perllexwarn     Perl warnings and their control
    perldebug               Perl debugging
    perlvar         Perl predefined variables
    ...
                        ^
                        |

All of the "Perl"s in the second column should be aligned like the "perldeprecation" line, which is the only one that uses spaces in the original POD document (the others use either one tab, two tabs, or a mix of spaces and tabs).

By using spaces everywhere we bypass the whole issue and get consistently aligned results, no matter how tabs are rendered.