### PR TITLE
perl.pod: fix position of perldbmfilter (under perltie)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -542,6 +542,7 @@ Lukas Mai <l.mai@web.de> Lukas Mai <lukasmai.403@gmail.com>
 Lukas Mai <l.mai@web.de> Lukas Mai <plokinom@gmail.com>
 Lukas Mai <l.mai@web.de> Lukas Mai <unknown>
 Lukas Mai <l.mai@web.de> mauke <l.mai@web.de>
+Lukas Mai <l.mai@web.de> mauke <lukasmai.403@gmail.com>
 Lupe Christoph <lupe@lupe-christoph.de> Lupe Christoph <lupe@alanya.m.isar.de>
 Luther Huffman <lutherh@stratcom.com> <lutherh@stratcom.com>
 Luther Huffman <lutherh@stratcom.com> Luther Huffman <lutherh@infinet.com>

--- a/pod/perl.pod
+++ b/pod/perl.pod
@@ -111,8 +111,8 @@ aux h2ph h2xs perlbug pl2pm pod2html pod2man splain xsubpp
     perlform            Perl formats
     perlobj             Perl objects
     perltie             Perl objects hidden behind simple variables
-    perlclass           Perl class syntax
       perldbmfilter     Perl DBM filters
+    perlclass           Perl class syntax
 
     perlipc             Perl interprocess communication
     perlfork            Perl fork() information


### PR DESCRIPTION
It was inadvertently moved under perlclass as part of fd11211b37c20262922903f6435c1c09ac046e5c.