### PR TITLE
class.c: Minor av microoptimization tweaks

### DIFF
--- a/class.c
+++ b/class.c
@@ -78,7 +78,6 @@ PP(pp_initfield)
 
                 av = newAV_alloc_x(count);
 
-                av_extend(av, count);
                 while(svp <= PL_stack_sp) {
                     av_push_simple(av, newSVsv(*svp));
                     svp++;

--- a/class.c
+++ b/class.c
@@ -857,8 +857,8 @@ Perl_class_wrap_method_body(pTHX_ OP *o)
         if(fieldix > max_fieldix)
             max_fieldix = fieldix;
 
-        av_push(fieldmap, newSVuv(padix));
-        av_push(fieldmap, newSVuv(fieldix));
+        av_push_simple(fieldmap, newSVuv(padix));
+        av_push_simple(fieldmap, newSVuv(fieldix));
     }
 
     UNOP_AUX_item *aux = NULL;


### PR DESCRIPTION
This PR does two things:
* In `pp_initfield`, it removes an unnecessary `av_extend`. (Probably my fault that it didn't get removed in a previous PR.)
* In `Perl_class_wrap_method_body`, it's possible to use the inline `av_push_simple` function rather than `av_push` on the newly created `fieldmap` AV.