### PR TITLE
class: don't leak the default initialiser ops if they're forbidden

### DIFF
--- a/class.c
+++ b/class.c
@@ -634,8 +634,8 @@ Perl_class_seal_stash(pTHX_ HV *stash)
     assert(HvSTASH_IS_CLASS(stash));
     struct xpvhv_aux *aux = HvAUX(stash);
 
-    /* generate initfields CV */
-    {
+    if (PL_parser->error_count == 0) {
+        /* generate initfields CV */
         I32 floor_ix = PL_savestack_ix;
         SAVEI32(PL_subline);
         save_item(PL_subname);
@@ -793,6 +793,18 @@ Perl_class_seal_stash(pTHX_ HV *stash)
         CvIsMETHOD_on(initfields);
 
         aux->xhv_class_initfields_cv = initfields;
+    }
+    else {
+        /* we had errors, clean up and don't populate initfields */
+        PADNAMELIST *fieldnames = aux->xhv_class_fields;
+        if (fieldnames) {
+            for(SSize_t i = PadnamelistMAX(fieldnames); i >= 0 ; i--) {
+                PADNAME *pn = PadnamelistARRAY(fieldnames)[i];
+                OP *valop = PadnameFIELDINFO(pn)->defop;
+                if (valop)
+                    op_free(valop);
+            }
+        }
     }
 }
 
@@ -1010,10 +1022,13 @@ Perl_class_set_field_defop(pTHX_ PADNAME *pn, OPCODE defmode, OP *defop)
 
     assert(HvSTASH_IS_CLASS(PL_curstash));
 
-    forbid_outofblock_ops(defop, "field initialiser expression");
-
     if(PadnameFIELDINFO(pn)->defop)
         op_free(PadnameFIELDINFO(pn)->defop);
+
+    /* set here to ensure clean up if forbid_outofblock_ops() throws */
+    PadnameFIELDINFO(pn)->defop = defop;
+
+    forbid_outofblock_ops(defop, "field initialiser expression");
 
     char sigil = PadnamePV(pn)[0];
     switch(sigil) {


### PR DESCRIPTION
Previously if forbid_outofblock_ops() here threw an error the ops from defop would leak, including leaking the slab(s) containing those ops.

The other callers to forbid_outofblock_ops() left the ops being checked on the parser stack when performing this check, so the parse stack clean up would release the ops, but the field initaliser code removes the OP from the parse stack before
class_set_field_defop() so the OP and its children leaked.

To prevent that, populate the defop for the field with the supplied ops before calling forbid_outofblock_ops(), then as the stack rewinds class_seal_stash() will check the error count and free the ops.

Fixes #20812