### PR TITLE
[doc] Fix 'comprised of'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -321,6 +321,7 @@ Damon Atkins                   <Damon.Atkins@nabaus.com.au>
 Dan Book                       <grinnz@grinnz.com>
 Dan Boorstein                  <dan_boo@bellsouth.net>
 Dan Brook                      <dbrook@easyspace.com>
+Dan Church                     <amphetamachine@gmail.com>
 Dan Collins                    <dcollinsn@gmail.com>
 Dan Dascalescu                 <bigbang7@gmail.com>
 Dan Dedrick                    <ddedrick@lexmark.com>

--- a/dist/Data-Dumper/Dumper.pm
+++ b/dist/Data-Dumper/Dumper.pm
@@ -30,7 +30,7 @@ our ( $Indent, $Trailingcomma, $Purity, $Pad, $Varname, $Useqq, $Terse, $Freezer
 our ( @ISA, @EXPORT, @EXPORT_OK, $VERSION );
 
 BEGIN {
-    $VERSION = '2.188'; # Don't forget to set version and release
+    $VERSION = '2.189'; # Don't forget to set version and release
                         # date in POD below!
 
     @ISA = qw(Exporter);
@@ -924,7 +924,7 @@ for details.
 Returns a newly created C<Data::Dumper> object.  The first argument is an
 anonymous array of values to be dumped.  The optional second argument is an
 anonymous array of names for the values.  The names need not have a leading
-C<$> sign, and must be comprised of alphanumeric characters.  You can begin
+C<$> sign, and must be composed of alphanumeric characters.  You can begin
 a name with a C<*> to specify that the dereferenced type must be dumped
 instead of the reference itself, for ARRAY and HASH references.
 
@@ -1455,7 +1455,7 @@ modify it under the same terms as Perl itself.
 
 =head1 VERSION
 
-Version 2.188
+Version 2.189
 
 =head1 SEE ALSO
 

--- a/dist/base/lib/fields.pm
+++ b/dist/base/lib/fields.pm
@@ -12,7 +12,7 @@ unless( eval q{require warnings::register; warnings::register->import; 1} ) {
 }
 our %attr;
 
-our $VERSION = '2.24';
+our $VERSION = '2.25';
 $VERSION =~ tr/_//d;
 
 # constant.pm is slow
@@ -261,7 +261,7 @@ The following functions are supported:
 
 =item new
 
-fields::new() creates and blesses a hash comprised of the fields declared
+fields::new() creates and blesses a hash of the fields declared
 using the C<fields> pragma into the specified class.  It is the
 recommended way to construct a fields-based object.
 

--- a/pod/perl5180delta.pod
+++ b/pod/perl5180delta.pod
@@ -141,8 +141,8 @@ Perl now supports Unicode 6.2.  A list of changes from Unicode
 =head2 Character name aliases may now include non-Latin1-range characters
 
 It is possible to define your own names for characters for use in
-C<\N{...}>, C<charnames::vianame()>, etc.  These names can now be
-comprised of characters from the whole Unicode range.  This allows for
+C<\N{...}>, C<charnames::vianame()>, etc.  These names can now
+consist of characters from the whole Unicode range.  This allows for
 names to be in your native language, and not just English.  Certain
 restrictions apply to the characters that may be used (you can't define
 a name that has punctuation in it, for example).  See L<charnames/CUSTOM

--- a/pod/perl561delta.pod
+++ b/pod/perl561delta.pod
@@ -3174,7 +3174,7 @@ C</"Support for CHECK blocks"> for more information.
 =item Treatment of list slices of undef has changed
 
 There is a potential incompatibility in the behavior of list slices
-that are comprised entirely of undefined values.
+that consist entirely of undefined values.
 See L</"Behavior of list slices is more consistent">.
 
 =item Format of $English::PERL_VERSION is different

--- a/pod/perl56delta.pod
+++ b/pod/perl56delta.pod
@@ -2569,7 +2569,7 @@ C</"Support for CHECK blocks"> for more information.
 =item Treatment of list slices of undef has changed
 
 There is a potential incompatibility in the behavior of list slices
-that are comprised entirely of undefined values.
+that consist entirely of undefined values.
 See L</"Behavior of list slices is more consistent">.
 
 =item Format of $English::PERL_VERSION is different

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -7015,7 +7015,7 @@ regex; marked by <-- HERE in m/%s/
 
 (F) A Unicode string property is one which expands to a sequence of
 multiple characters.  An example is C<\p{name=KATAKANA LETTER AINU P}>,
-which is comprised of the sequence C<\N{KATAKANA LETTER SMALL H}>
+which consists of the sequence C<\N{KATAKANA LETTER SMALL H}>
 followed by C<\N{COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK}>.
 Extended character classes, C<(?[...])> currently cannot handle these.
 

--- a/pod/perlunicode.pod
+++ b/pod/perlunicode.pod
@@ -383,8 +383,8 @@ C<"LATIN CAPITAL LETTER E WITH ACUTE"> is called a "pre-composed"
 character, and its equivalence with the "E" and the "COMBINING ACCENT"
 sequence is called canonical equivalence.  All pre-composed characters
 are said to have a decomposition (into the equivalent sequence), and the
-decomposition type is also called canonical.  A string may be comprised
-as much as possible of precomposed characters, or it may be comprised of
+decomposition type is also called canonical.  A string may consist
+as much as possible of precomposed characters, or it may consist of
 entirely decomposed characters.  Unicode calls these respectively,
 "Normalization Form Composed" (NFC) and "Normalization Form Decomposed".
 The C<L<Unicode::Normalize>> module contains functions that convert

--- a/sv.c
+++ b/sv.c
@@ -8276,7 +8276,7 @@ Perl_sv_cmp_flags(pTHX_ SV *const sv1, SV *const sv2,
                     * at the beginning of a character.  But neither or both are
                     * (or else earlier bytes would have been different).  And
                     * if we are in the middle of a character, the two
-                    * characters are comprised of the same number of bytes
+                    * characters have the same number of bytes
                     * (because in this case the start bytes are the same, and
                     * the start bytes encode the character's length). */
                  if (UTF8_IS_INVARIANT(*pv1))

--- a/t/uni/lex_utf8.t
+++ b/t/uni/lex_utf8.t
@@ -32,8 +32,8 @@ my $octal_first = "c\377Ć";
 my $octal_last = "cĆ\377";
 
 sub fixup (@) {
-    # @_ is a list of strings.  Each string is comprised of the digits that
-    # form a byte of the UTF-8 representation of a character, or sequence of
+    # @_ is a list of strings.  Each string consists of the digits that form
+    # a byte of the UTF-8 representation of a character, or sequence of
     # characters
 
     my $string = join "", map { chr 0 + $_ } @_;


### PR DESCRIPTION
Sorry to be the grammar pedant, but "comprised of" is pretty much always incorrect usage.

- It's not the meaning of the word; the whole comprises the parts, the parts compose the whole.
- The etymology of the word comes from Latin words meaning to hold or grasp together.
- "Comprised of" is often used unnecessarily to aggrandize a sentence instead of just using a more precise "composed of" or "consists of."
- Many English style manuals state "comprised of" is not to be used.

Example incorrect usage: "A group **comprised of** 12 members." 👎
Example correct usage: "A group **comprising** 12 members." 👍

Further reading: https://en.m.wikipedia.org/wiki/User:Giraffedata/comprised_of

## My change

I found "comprised of" being used in a handful of places, mostly in POD, and a couple of places in source code comments. I replaced them with a different word to fix the meaning after grokking what the doc was saying. Let me know if I didn't fully understand the meanings I fixed. 

Interestingly, there were way more correct usages in the repo than incorrect ones.

Existing instances of 'comprise' being used *correctly* in the Perl docs:
- [perlunicode.pod](https://github.com/Perl/perl5/blob/5e28db930c3316e1f70f9207d976da136612d6fc/pod/perlunicode.pod?plain=1#L603-L606): "Those [character types] listed above **comprised** the complete set for many Unicode releases, but others were added in Unicode 6.3; [...]" 👍
- [Encode / Supported.pod](https://github.com/Perl/perl5/blob/5e28db930c3316e1f70f9207d976da136612d6fc/cpan/Encode/lib/Encode/Supported.pod?plain=1#L513-L514): "You may also have found out by now why 7bit ISO-2022 cannot **comprise** a CCS [Coded Character Set]." 👍
- [cpan / perlfaq.pod](https://github.com/Perl/perl5/blob/5e28db930c3316e1f70f9207d976da136612d6fc/cpan/perlfaq/lib/perlfaq.pod?plain=1#L11-L12): "The perlfaq **comprises** several documents that answer the most commonly asked questions about Perl and Perl programming." 👍
- [bytes.pm](https://github.com/Perl/perl5/blob/5e28db930c3316e1f70f9207d976da136612d6fc/lib/bytes.pm#L69-L70): "This pragma allows for the examination of the individual bytes that together **comprise** a character." 👍
- [perldocstyle.pod](https://github.com/Perl/perl5/blob/5e28db930c3316e1f70f9207d976da136612d6fc/pod/perldocstyle.pod?plain=1#L503-L505): "Most of the perfunc man page **comprises** a single list, found under the header [...]" 👍