### PR TITLE
Davem/rc3

### DIFF
--- a/dist/threads/threads.xs
+++ b/dist/threads/threads.xs
@@ -1589,11 +1589,15 @@ ithread_object(...)
         }
         classname = (char *)SvPV_nolen(ST(0));
 
+        if (items < 2) {
+            XSRETURN_UNDEF;
+        }
+
         /* Turn $tid from PVLV to SV if needed (bug #73330) */
         arg = ST(1);
         SvGETMAGIC(arg);
 
-        if ((items < 2) || ! SvOK(arg)) {
+        if (! SvOK(arg)) {
             XSRETURN_UNDEF;
         }
 

--- a/embed.fnc
+++ b/embed.fnc
@@ -3498,7 +3498,7 @@ Apx	|void	|thread_locale_init
 Apx	|void	|thread_locale_term
 
 Fpv	|OP *	|tied_method	|NN SV *methname			\
-				|NN SV **sp				\
+				|NN SV **mark				\
 				|NN SV * const sv			\
 				|NN const MAGIC * const mg		\
 				|const U32 flags			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -2754,6 +2754,9 @@ APTdp	|char * |rninstr	|NN const char *big			\
 				|NN const char *little			\
 				|NN const char *lend
 p	|void	|rpeep		|NULLOK OP *o
+Adipx	|void	|rpp_context	|NN SV **mark				\
+				|U8 gimme				\
+				|SSize_t extra
 Adipx	|void	|rpp_extend	|SSize_t n
 Adipx	|void	|rpp_invoke_xs	|NN CV *cv
 Adipx	|bool	|rpp_is_lone	|NN SV *sv

--- a/embed.fnc
+++ b/embed.fnc
@@ -2769,6 +2769,8 @@ Adipx	|void	|rpp_push_2	|NN SV *sv1				\
 Adipx	|void	|rpp_push_1_norc|NN SV *sv
 Adipx	|void	|rpp_replace_1_1|NN SV *sv
 Adipx	|void	|rpp_replace_2_1|NN SV *sv
+Adipx	|void	|rpp_replace_at |NN SV **sp				\
+				|NN SV *sv
 Adipx	|bool	|rpp_stack_is_rc
 Adipx	|bool	|rpp_try_AMAGIC_1					\
 				|int method				\

--- a/embed.h
+++ b/embed.h
@@ -537,6 +537,7 @@
 # define repeatcpy                              Perl_repeatcpy
 # define require_pv(a)                          Perl_require_pv(aTHX_ a)
 # define rninstr                                Perl_rninstr
+# define rpp_context(a,b,c)                     Perl_rpp_context(aTHX_ a,b,c)
 # define rpp_extend(a)                          Perl_rpp_extend(aTHX_ a)
 # define rpp_invoke_xs(a)                       Perl_rpp_invoke_xs(aTHX_ a)
 # define rpp_is_lone(a)                         Perl_rpp_is_lone(aTHX_ a)

--- a/embed.h
+++ b/embed.h
@@ -550,6 +550,7 @@
 # define rpp_push_2(a,b)                        Perl_rpp_push_2(aTHX_ a,b)
 # define rpp_replace_1_1(a)                     Perl_rpp_replace_1_1(aTHX_ a)
 # define rpp_replace_2_1(a)                     Perl_rpp_replace_2_1(aTHX_ a)
+# define rpp_replace_at(a,b)                    Perl_rpp_replace_at(aTHX_ a,b)
 # define rpp_stack_is_rc()                      Perl_rpp_stack_is_rc(aTHX)
 # define rpp_try_AMAGIC_1(a,b)                  Perl_rpp_try_AMAGIC_1(aTHX_ a,b)
 # define rpp_try_AMAGIC_2(a,b)                  Perl_rpp_try_AMAGIC_2(aTHX_ a,b)

--- a/inline.h
+++ b/inline.h
@@ -679,6 +679,35 @@ Perl_rpp_replace_2_1(pTHX_ SV *sv)
 
 
 /*
+=for apidoc rpp_replace_at
+
+Replace the SV at address sp within the stack with C<sv>, while suitably
+adjusting reference counts. Equivalent to C<*sp = sv>, except with proper
+reference count handling.
+
+=cut
+*/
+
+PERL_STATIC_INLINE void
+Perl_rpp_replace_at(pTHX_ SV **sp, SV *sv)
+{
+    PERL_ARGS_ASSERT_RPP_REPLACE_AT;
+
+#ifdef PERL_RC_STACK
+    assert(rpp_stack_is_rc());
+    SV *oldsv = *sp;
+    *sp = sv;
+    SvREFCNT_inc_simple_void_NN(sv);
+    SvREFCNT_dec(oldsv);
+#else
+    *sp = sv;
+#endif
+}
+
+
+
+
+/*
 =for apidoc      rpp_try_AMAGIC_1
 =for apidoc_item rpp_try_AMAGIC_2
 

--- a/inline.h
+++ b/inline.h
@@ -705,6 +705,47 @@ Perl_rpp_replace_at(pTHX_ SV **sp, SV *sv)
 }
 
 
+/*
+=for apidoc rpp_context
+
+Impose void, scalar or list context on the stack.
+First, pop C<extra> items off the stack, then when C<gimme> is:
+C<G_LIST>:   return as-is.
+C<G_VOID>:   pop everything back to C<mark>
+C<G_SCALAR>: move the top stack item (or C<&PL_sv_undef> if none) to
+C<mark+1> and free everything above it.
+
+=cut
+*/
+
+PERL_STATIC_INLINE void
+Perl_rpp_context(pTHX_ SV **mark, U8 gimme, SSize_t extra)
+{
+    PERL_ARGS_ASSERT_RPP_CONTEXT;
+    assert(extra >= 0);
+    assert(mark <= PL_stack_sp - extra);
+
+    if (gimme == G_LIST)
+        mark = PL_stack_sp - extra;
+    else if (gimme == G_SCALAR) {
+        SV **svp = PL_stack_sp - extra;
+        mark++;
+        if (mark > svp) {
+            /* empty list (plus extra) */
+            rpp_popfree_to(svp);
+            rpp_extend(1);
+            *++PL_stack_sp = &PL_sv_undef;
+            return;
+        }
+        /* swap top and bottom list items */
+        SV *top = *svp;
+        *svp = *mark;
+        *mark = top;
+     }
+    rpp_popfree_to(mark);
+}
+
+
 
 
 /*

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -4759,6 +4759,7 @@ in summary:
 
  rpp_replace_1_1(sv)     (void)POPs; PUSHs(sv);
  rpp_replace_2_1(sv)     (void)POPs; (void)POPs; PUSHs(sv);
+ rpp_replace_at(sp, sv)  *sp = sv;
 
  rpp_try_AMAGIC_1()      tryAMAGICun_MG()
  rpp_try_AMAGIC_2()      tryAMAGICbin_MG()
@@ -4798,6 +4799,9 @@ becomes
 The rpp_replace_M_N() functions are shortcuts for popping and freeing C<M>
 items then pushing and bumping up the RCs of C<N> items. Note that they
 handle edge cases such as an old and new SV being the same.
+
+rpp_replace_at(sp, sv) is similar to rpp_replace_1_1(), except that
+it replaces an SV at an address in the stack rather than at the top.
 
 rpp_popfree_to(svp) is designed to replace code like
 

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -4761,6 +4761,11 @@ in summary:
  rpp_replace_2_1(sv)     (void)POPs; (void)POPs; PUSHs(sv);
  rpp_replace_at(sp, sv)  *sp = sv;
 
+ rpp_context(mark, gimme,
+             extra)      SP -= extra;
+                         // impose void/scalar/list context on return args
+                         SP = (gimme == G_VOID) ? mark : ....
+
  rpp_try_AMAGIC_1()      tryAMAGICun_MG()
  rpp_try_AMAGIC_2()      tryAMAGICbin_MG()
 
@@ -4768,6 +4773,7 @@ in summary:
  rpp_stack_is_rc()       no equivalent
 
  rpp_invoke_xs(cv)       CvXSUB(cv)(aTHX_ cv);
+
 
  (no replacement)        dATARGET   // just write the macro body in full
 
@@ -4871,6 +4877,15 @@ can be more efficiently written as
 
 By using this function, the code works correctly on both RC and non-RC
 builds.
+
+A common operation on list ops is to impose void, scalar or list context
+on the return arguments, possibly discarding all, or all except one, of
+them. rpp_context(mark, gimme, extra) does this. As a first step (for
+convenience and efficiency) it notionally pops C<extra> args off the
+stack. Then for list context, leaves things as is. For void context, the
+stack pointer is reset to mark, and everything above is popped. For
+scalar, the top argument (or &PL_sv_undef) is moved from the top to
+mark+1 and everything above is discarded.
 
 The macros which appear at the start of many PP functions to check for
 unary or binary op overloading (among other things) have been replaced

--- a/pp.c
+++ b/pp.c
@@ -2405,15 +2405,16 @@ PP(pp_sle)
 }
 
 
-PP_wrapped(pp_seq, 2, 0)
+PP(pp_seq)
 {
-    dSP;
-    tryAMAGICbin_MG(seq_amg, 0);
-    {
-      dPOPTOPssrl;
-      SETs(boolSV(sv_eq_flags(left, right, 0)));
-      RETURN;
-    }
+    if (rpp_try_AMAGIC_2(seq_amg, 0))
+        return NORMAL;
+
+    SV *right = PL_stack_sp[0];
+    SV *left  = PL_stack_sp[-1];
+
+    rpp_replace_2_1(boolSV(sv_eq_flags(left, right, 0)));;
+    return NORMAL;
 }
 
 
@@ -3004,15 +3005,16 @@ PP(pp_i_ge)
 }
 
 
-PP_wrapped(pp_i_eq, 2, 0)
+PP(pp_i_eq)
 {
-    dSP;
-    tryAMAGICbin_MG(eq_amg, 0);
-    {
-      dPOPTOPiirl_nomg;
-      SETs(boolSV(left == right));
-      RETURN;
-    }
+    if (rpp_try_AMAGIC_2(eq_amg, 0))
+        return NORMAL;
+
+    IV right   = SvIV_nomg(PL_stack_sp[0]);
+    IV left    = SvIV_nomg(PL_stack_sp[-1]);
+
+    rpp_replace_2_1(boolSV(left == right));
+    return NORMAL;
 }
 
 

--- a/pp.c
+++ b/pp.c
@@ -5867,26 +5867,17 @@ PP(pp_kvhslice)
     return NORMAL;
 }
 
+
 /* List operators. */
 
-PP_wrapped(pp_list, 0, 1)
+
+PP(pp_list)
 {
-    I32 markidx = POPMARK;
-    if (GIMME_V != G_LIST) {
-        /* don't initialize mark here, EXTEND() may move the stack */
-        SV **mark;
-        dSP;
-        EXTEND(SP, 1);          /* in case no arguments, as in @empty */
-        mark = PL_stack_base + markidx;
-        if (++MARK <= SP)
-            *MARK = *SP;		/* unwanted list, return last item */
-        else
-            *MARK = &PL_sv_undef;
-        SP = MARK;
-        PUTBACK;
-    }
+    dMARK;
+    rpp_context(mark, GIMME_V, 0);
     return NORMAL;
 }
+
 
 PP_wrapped(pp_lslice, 0, 2)
 {

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -1929,15 +1929,16 @@ PP(pp_aelemfast)
     return NORMAL;
 }
 
-PP_wrapped(pp_join, 0, 1)
+PP(pp_join)
 {
-    dSP; dMARK; dTARGET;
+    dMARK; dTARGET;
     MARK++;
-    do_join(TARG, *MARK, MARK, SP);
-    SP = MARK;
-    SETs(TARG);
-    RETURN;
+    do_join(TARG, *MARK, MARK, PL_stack_sp);
+    rpp_popfree_to(MARK - 1);
+    rpp_push_1(TARG);
+    return NORMAL;
 }
+
 
 /* Oversized hot code. */
 

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -265,13 +265,12 @@ PP(pp_and)
  *    (PL_op->op_private & OPpASSIGN_BACKWARDS) {or,and,dor}assign
 */
 
-PP_wrapped(pp_padsv_store,1,0)
+PP(pp_padsv_store)
 {
-    dSP;
     OP * const op = PL_op;
     SV** const padentry = &PAD_SVl(op->op_targ);
     SV* targ = *padentry; /* lvalue to assign into */
-    SV* const val = TOPs; /* RHS value to assign */
+    SV* const val = *PL_stack_sp; /* RHS value to assign */
 
     /* !OPf_STACKED is not handled by this OP */
     assert(op->op_flags & OPf_STACKED);
@@ -295,9 +294,10 @@ PP_wrapped(pp_padsv_store,1,0)
         );
     SvSetMagicSV(targ, val);
 
-    SETs(targ);
-    RETURN;
+    rpp_replace_1_1(targ);
+    return NORMAL;
 }
+
 
 /* A mashup of simplified AELEMFAST_LEX + SASSIGN OPs */
 

--- a/proto.h
+++ b/proto.h
@@ -9844,6 +9844,11 @@ Perl_rpp_replace_2_1(pTHX_ SV *sv);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_1       \
         assert(sv)
 
+PERL_STATIC_INLINE void
+Perl_rpp_replace_at(pTHX_ SV **sp, SV *sv);
+# define PERL_ARGS_ASSERT_RPP_REPLACE_AT        \
+        assert(sp); assert(sv)
+
 PERL_STATIC_INLINE bool
 Perl_rpp_stack_is_rc(pTHX);
 # define PERL_ARGS_ASSERT_RPP_STACK_IS_RC

--- a/proto.h
+++ b/proto.h
@@ -9789,6 +9789,11 @@ Perl_push_stackinfo(pTHX_ I32 type, UV flags);
 # define PERL_ARGS_ASSERT_PUSH_STACKINFO
 
 PERL_STATIC_INLINE void
+Perl_rpp_context(pTHX_ SV **mark, U8 gimme, SSize_t extra);
+# define PERL_ARGS_ASSERT_RPP_CONTEXT           \
+        assert(mark)
+
+PERL_STATIC_INLINE void
 Perl_rpp_extend(pTHX_ SSize_t n);
 # define PERL_ARGS_ASSERT_RPP_EXTEND
 

--- a/proto.h
+++ b/proto.h
@@ -5036,10 +5036,10 @@ Perl_thread_locale_term(pTHX);
 #define PERL_ARGS_ASSERT_THREAD_LOCALE_TERM
 
 PERL_CALLCONV OP *
-Perl_tied_method(pTHX_ SV *methname, SV **sp, SV * const sv, const MAGIC * const mg, const U32 flags, U32 argc, ...)
+Perl_tied_method(pTHX_ SV *methname, SV **mark, SV * const sv, const MAGIC * const mg, const U32 flags, U32 argc, ...)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_TIED_METHOD            \
-        assert(methname); assert(sp); assert(sv); assert(mg)
+        assert(methname); assert(mark); assert(sv); assert(mg)
 
 PERL_CALLCONV SSize_t
 Perl_tmps_grow_p(pTHX_ SSize_t ix);


### PR DESCRIPTION
Third set of PERL_RC_STACK commits. This PR mainly includes lots of unwrapping of list ops. It also includes a couple of new API functions:
rpp_replace_at() and rpp_context().

There are still a few 'hot' list functions still to be unwrapped, such as pp_multiconcat(), but currently 10 runs of the test suite take about 5% more CPU on average with -DPERL_RC_STACK.