### PR TITLE
Version bundles for `use builtin`

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -24,13 +24,12 @@ struct BuiltinFuncDescriptor {
     bool is_experimental;
 };
 
-#define warn_experimental_builtin(name, prefix) S_warn_experimental_builtin(aTHX_ name, prefix)
-static void S_warn_experimental_builtin(pTHX_ const char *name, bool prefix)
+#define warn_experimental_builtin(name) S_warn_experimental_builtin(aTHX_ name)
+static void S_warn_experimental_builtin(pTHX_ const char *name)
 {
     /* diag_listed_as: Built-in function '%s' is experimental */
     Perl_ck_warner_d(aTHX_ packWARN(WARN_EXPERIMENTAL__BUILTIN),
-                     "Built-in function '%s%s' is experimental",
-                     prefix ? "builtin::" : "", name);
+                     "Built-in function 'builtin::%s' is experimental", name);
 }
 
 /* These three utilities might want to live elsewhere to be reused from other
@@ -125,7 +124,7 @@ XS(XS_builtin_func1_scalar)
 
     switch(ix) {
         case OP_IS_BOOL:
-            warn_experimental_builtin(PL_op_name[ix], true);
+            warn_experimental_builtin(PL_op_name[ix]);
             Perl_pp_is_bool(aTHX);
             break;
 
@@ -266,7 +265,7 @@ XS(XS_builtin_export_lexically)
 {
     dXSARGS;
 
-    warn_experimental_builtin("export_lexically", true);
+    warn_experimental_builtin("export_lexically");
 
     if(!PL_compcv)
         Perl_croak(aTHX_
@@ -395,7 +394,7 @@ static OP *ck_builtin_func1(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
     const struct BuiltinFuncDescriptor *builtin = NUM2PTR(const struct BuiltinFuncDescriptor *, SvUV(ckobj));
 
     if(builtin->is_experimental)
-        warn_experimental_builtin(builtin->name, false);
+        warn_experimental_builtin(builtin->name);
 
     SV *prototype = newSVpvs("$");
     SAVEFREESV(prototype);
@@ -476,7 +475,7 @@ static OP *ck_builtin_funcN(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
     const struct BuiltinFuncDescriptor *builtin = NUM2PTR(const struct BuiltinFuncDescriptor *, SvUV(ckobj));
 
     if(builtin->is_experimental)
-        warn_experimental_builtin(builtin->name, false);
+        warn_experimental_builtin(builtin->name);
 
     SV *prototype = newSVpvs("@");
     SAVEFREESV(prototype);
@@ -491,29 +490,29 @@ static const char builtin_not_recognised[] = "'%" SVf "' is not recognised as a 
 
 static const struct BuiltinFuncDescriptor builtins[] = {
     /* constants */
-    { "builtin::true",   &XS_builtin_true,   &ck_builtin_const, BUILTIN_CONST_TRUE,  false },
-    { "builtin::false",  &XS_builtin_false,  &ck_builtin_const, BUILTIN_CONST_FALSE, false },
+    { "true",   &XS_builtin_true,   &ck_builtin_const, BUILTIN_CONST_TRUE,  false },
+    { "false",  &XS_builtin_false,  &ck_builtin_const, BUILTIN_CONST_FALSE, false },
 
     /* unary functions */
-    { "builtin::is_bool",    &XS_builtin_func1_scalar, &ck_builtin_func1, OP_IS_BOOL,    true  },
-    { "builtin::weaken",     &XS_builtin_func1_void,   &ck_builtin_func1, OP_WEAKEN,     false },
-    { "builtin::unweaken",   &XS_builtin_func1_void,   &ck_builtin_func1, OP_UNWEAKEN,   false },
-    { "builtin::is_weak",    &XS_builtin_func1_scalar, &ck_builtin_func1, OP_IS_WEAK,    false },
-    { "builtin::blessed",    &XS_builtin_func1_scalar, &ck_builtin_func1, OP_BLESSED,    false },
-    { "builtin::refaddr",    &XS_builtin_func1_scalar, &ck_builtin_func1, OP_REFADDR,    false },
-    { "builtin::reftype",    &XS_builtin_func1_scalar, &ck_builtin_func1, OP_REFTYPE,    false },
-    { "builtin::ceil",       &XS_builtin_func1_scalar, &ck_builtin_func1, OP_CEIL,       false },
-    { "builtin::floor",      &XS_builtin_func1_scalar, &ck_builtin_func1, OP_FLOOR,      false },
-    { "builtin::is_tainted", &XS_builtin_func1_scalar, &ck_builtin_func1, OP_IS_TAINTED, false },
-    { "builtin::trim",       &XS_builtin_trim,         &ck_builtin_func1, 0,             false },
-    { "builtin::stringify",  &XS_builtin_func1_scalar, &ck_builtin_func1, OP_STRINGIFY,  true },
+    { "is_bool",    &XS_builtin_func1_scalar, &ck_builtin_func1, OP_IS_BOOL,    true  },
+    { "weaken",     &XS_builtin_func1_void,   &ck_builtin_func1, OP_WEAKEN,     false },
+    { "unweaken",   &XS_builtin_func1_void,   &ck_builtin_func1, OP_UNWEAKEN,   false },
+    { "is_weak",    &XS_builtin_func1_scalar, &ck_builtin_func1, OP_IS_WEAK,    false },
+    { "blessed",    &XS_builtin_func1_scalar, &ck_builtin_func1, OP_BLESSED,    false },
+    { "refaddr",    &XS_builtin_func1_scalar, &ck_builtin_func1, OP_REFADDR,    false },
+    { "reftype",    &XS_builtin_func1_scalar, &ck_builtin_func1, OP_REFTYPE,    false },
+    { "ceil",       &XS_builtin_func1_scalar, &ck_builtin_func1, OP_CEIL,       false },
+    { "floor",      &XS_builtin_func1_scalar, &ck_builtin_func1, OP_FLOOR,      false },
+    { "is_tainted", &XS_builtin_func1_scalar, &ck_builtin_func1, OP_IS_TAINTED, false },
+    { "trim",       &XS_builtin_trim,         &ck_builtin_func1, 0,             false },
+    { "stringify",  &XS_builtin_func1_scalar, &ck_builtin_func1, OP_STRINGIFY,  true },
 
-    { "builtin::created_as_string", &XS_builtin_created_as_string, &ck_builtin_func1, 0, true },
-    { "builtin::created_as_number", &XS_builtin_created_as_number, &ck_builtin_func1, 0, true },
+    { "created_as_string", &XS_builtin_created_as_string, &ck_builtin_func1, 0, true },
+    { "created_as_number", &XS_builtin_created_as_number, &ck_builtin_func1, 0, true },
 
     /* list functions */
-    { "builtin::indexed",          &XS_builtin_indexed,          &ck_builtin_funcN, 0, false },
-    { "builtin::export_lexically", &XS_builtin_export_lexically, NULL,              0, true },
+    { "indexed",          &XS_builtin_indexed,          &ck_builtin_funcN, 0, false },
+    { "export_lexically", &XS_builtin_export_lexically, NULL,              0, true },
 
     { NULL, NULL, NULL, 0, false }
 };
@@ -607,7 +606,9 @@ Perl_boot_core_builtin(pTHX)
         else if(builtin->checker == &ck_builtin_funcN)
             proto = "@";
 
-        CV *cv = newXS_flags(builtin->name, builtin->xsub, __FILE__, proto, 0);
+        SV *name = newSVpvs_flags("builtin::", SVs_TEMP);
+        sv_catpv(name, builtin->name);
+        CV *cv = newXS_flags(SvPV_nolen(name), builtin->xsub, __FILE__, proto, 0);
         XSANY.any_i32 = builtin->ckval;
 
         if (   builtin->xsub == &XS_builtin_func1_void

--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -1,4 +1,4 @@
-package builtin 0.010;
+package builtin 0.011;
 
 use strict;
 use warnings;
@@ -28,6 +28,8 @@ builtin - Perl pragma to import built-in utility functions
         is_tainted
         export_lexically
     );
+
+    use builtin ':5.40';  # most of the above
 
 =head1 DESCRIPTION
 
@@ -84,6 +86,23 @@ Imported symbols can also be removed again by using the C<no> keyword:
 
     no builtin 'true';
     # true() is no longer aliased from builtin
+
+=head2 Version Bundles
+
+The entire set of builtin functions that were considered non-experimental by a
+version of perl can be imported all at once, by requesting a version bundle.
+This is done by giving the perl release version (without its subversion
+suffix) after a colon character:
+
+    use builtin ':5.40';
+
+The following bundles currently exist:
+
+    Version    Includes
+    -------    --------
+
+    :5.40      true false weaken unweaken is_weak blessed refaddr reftype
+               ceil floor is_tainted trim indexed
 
 =head1 FUNCTIONS
 

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -444,6 +444,18 @@ TODO: {
     is($HASH{key}, "val", 'Lexically exported hash is accessible');
 }
 
+# version bundles
+{
+    use builtin ':5.39';
+    ok(true, 'true() is available from :5.39 bundle');
+
+    # parse errors
+    foreach my $bundle (qw( :x :5.x :5.36x :5.36.1000 :5.1000 :5.36.1.2 )) {
+        ok(!defined eval "use builtin '$bundle';", $bundle.' is invalid bundle');
+        like($@, qr/^Invalid version bundle \Q$bundle\E at /);
+    }
+}
+
 # vim: tabstop=4 shiftwidth=4 expandtab autoindent softtabstop=4
 
 done_testing();

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -664,6 +664,12 @@ is currently being compiled. Since this method is used to remove
 previously-introduced lexical subroutines from the scope currently being
 compiled, this is not going to have any effect.
 
+=item Builtin version bundle "%s" is not supported by Perl
+
+(F) You attempted to C<use builtin :ver> for a version number that is either
+older than 5.39 (when the ability was added), or newer than the current perl
+version.
+
 =item Callback called exit
 
 (F) A subroutine invoked from an external package via call_sv()
@@ -3366,6 +3372,14 @@ See L<perlfunc/pack>.
 
 (W) The given character is not a valid pack or unpack type but used to be
 silently ignored.
+
+=item Invalid version bundle %s
+
+(F) A version number that is used to specify an import bundle during a
+C<use builtin ...> statement must be formatted as C<:MAJOR.MINOR> with an
+optional third component, which is ignored.  Each component must be a number
+of 1 to 3 digits. No other characters are permitted.  The value that was
+specified does not conform to these rules.
 
 =item Invalid version format (%s)
 


### PR DESCRIPTION
Adds the ability to import an entire collection of builtin functions at once by doing

    use builtin ':5.40';

This will import everything that was considered stable (i.e. not marked experimental) at the given perl version.

Does not (currently) integrate with `use VERSION` syntax but that would be the obvious final step to be added later.