### PR TITLE
dist/IO: Use ppport definition of OpSIBLING

### DIFF
--- a/dist/IO/IO.pm
+++ b/dist/IO/IO.pm
@@ -7,7 +7,7 @@ use Carp;
 use strict;
 use warnings;
 
-our $VERSION = "1.52";
+our $VERSION = "1.53";
 XSLoader::load 'IO', $VERSION;
 
 sub import {

--- a/dist/IO/IO.xs
+++ b/dist/IO/IO.xs
@@ -56,10 +56,6 @@ typedef FILE * OutputStream;
 # define NORETURN_FUNCTION_END /* NOT REACHED */ return 0
 #endif
 
-#ifndef OpSIBLING
-#  define OpSIBLING(o) (o)->op_sibling
-#endif
-
 static int not_here(const char *s) __attribute__noreturn__;
 static int
 not_here(const char *s)

--- a/dist/IO/lib/IO/Dir.pm
+++ b/dist/IO/lib/IO/Dir.pm
@@ -18,7 +18,7 @@ use File::stat;
 use File::Spec;
 
 our @ISA = qw(Tie::Hash Exporter);
-our $VERSION = "1.52";
+our $VERSION = "1.53";
 
 our @EXPORT_OK = qw(DIR_UNLINK);
 

--- a/dist/IO/lib/IO/File.pm
+++ b/dist/IO/lib/IO/File.pm
@@ -135,7 +135,7 @@ require Exporter;
 
 our @ISA = qw(IO::Handle IO::Seekable Exporter);
 
-our $VERSION = "1.52";
+our $VERSION = "1.53";
 
 our @EXPORT = @IO::Seekable::EXPORT;
 

--- a/dist/IO/lib/IO/Handle.pm
+++ b/dist/IO/lib/IO/Handle.pm
@@ -270,7 +270,7 @@ use IO ();	# Load the XS module
 require Exporter;
 our @ISA = qw(Exporter);
 
-our $VERSION = "1.52";
+our $VERSION = "1.53";
 
 our @EXPORT_OK = qw(
     autoflush

--- a/dist/IO/lib/IO/Pipe.pm
+++ b/dist/IO/lib/IO/Pipe.pm
@@ -13,7 +13,7 @@ use strict;
 use Carp;
 use Symbol;
 
-our $VERSION = "1.52";
+our $VERSION = "1.53";
 
 sub new {
     my $type = shift;

--- a/dist/IO/lib/IO/Poll.pm
+++ b/dist/IO/lib/IO/Poll.pm
@@ -12,7 +12,7 @@ use IO::Handle;
 use Exporter ();
 
 our @ISA = qw(Exporter);
-our $VERSION = "1.52";
+our $VERSION = "1.53";
 
 our @EXPORT = qw( POLLIN
 	      POLLOUT

--- a/dist/IO/lib/IO/Seekable.pm
+++ b/dist/IO/lib/IO/Seekable.pm
@@ -106,7 +106,7 @@ require Exporter;
 our @EXPORT = qw(SEEK_SET SEEK_CUR SEEK_END);
 our @ISA = qw(Exporter);
 
-our $VERSION = "1.52";
+our $VERSION = "1.53";
 
 sub seek {
     @_ == 3 or croak 'usage: $io->seek(POS, WHENCE)';

--- a/dist/IO/lib/IO/Select.pm
+++ b/dist/IO/lib/IO/Select.pm
@@ -10,7 +10,7 @@ use     strict;
 use warnings::register;
 require Exporter;
 
-our $VERSION = "1.52";
+our $VERSION = "1.53";
 
 our @ISA = qw(Exporter); # This is only so we can do version checking
 

--- a/dist/IO/lib/IO/Socket.pm
+++ b/dist/IO/lib/IO/Socket.pm
@@ -23,7 +23,7 @@ require IO::Socket::UNIX if ($^O ne 'epoc' && $^O ne 'symbian');
 
 our @ISA = qw(IO::Handle);
 
-our $VERSION = "1.52";
+our $VERSION = "1.53";
 
 our @EXPORT_OK = qw(sockatmark);
 

--- a/dist/IO/lib/IO/Socket/INET.pm
+++ b/dist/IO/lib/IO/Socket/INET.pm
@@ -14,7 +14,7 @@ use Exporter;
 use Errno;
 
 our @ISA = qw(IO::Socket);
-our $VERSION = "1.52";
+our $VERSION = "1.53";
 
 my $EINVAL = exists(&Errno::EINVAL) ? Errno::EINVAL() : 1;
 

--- a/dist/IO/lib/IO/Socket/UNIX.pm
+++ b/dist/IO/lib/IO/Socket/UNIX.pm
@@ -11,7 +11,7 @@ use IO::Socket;
 use Carp;
 
 our @ISA = qw(IO::Socket);
-our $VERSION = "1.52";
+our $VERSION = "1.53";
 
 IO::Socket::UNIX->register_domain( AF_UNIX );
 


### PR DESCRIPTION
This module uses ppport.h, and its definition of this macro is more robust than the module's.  And in any event, there shouldn't be redundant definitions, so that fixes to ppport.h automatically propagate to here and other modules.