### PR TITLE
locale.c: Change to use enum instead of int

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4374,7 +4374,7 @@ S	|utf8ness_t|get_locale_string_utf8ness_i			\
 				|NULLOK const char *string		\
 				|const locale_utf8ness_t known_utf8	\
 				|NULLOK const char *locale		\
-				|const unsigned cat_index
+				|const locale_category_index cat_index
 S	|void	|ints_to_tm	|NN struct tm *my_tm			\
 				|int sec				\
 				|int min				\
@@ -4408,20 +4408,20 @@ S	|const char *|calculate_LC_ALL_string					\
 				|const calc_LC_ALL_format format		\
 				|const calc_LC_ALL_return returning		\
 				|const line_t caller_line
-RS	|unsigned int|get_category_index_helper 			\
+RS	|locale_category_index|get_category_index_helper		\
 				|const int category			\
 				|NULLOK bool *success			\
 				|const line_t caller_line
 Ri	|const char *|mortalized_pv_copy				\
 				|NULLOK const char * const pv
 S	|const char *|native_querylocale_i				\
-				|const unsigned int cat_index
+				|const locale_category_index cat_index
 S	|void	|output_check_environment_warning			\
 				|NULLOK const char * const language	\
 				|NULLOK const char * const lc_all	\
 				|NULLOK const char * const lang
 So	|void	|restore_toggled_locale_i				\
-				|const unsigned cat_index		\
+				|const locale_category_index cat_index	\
 				|NULLOK const char *original_locale	\
 				|const line_t caller_line
 S	|const char *|save_to_buffer					\
@@ -4429,7 +4429,7 @@ S	|const char *|save_to_buffer					\
 				|NULLOK char **buf			\
 				|NULLOK Size_t *buf_size
 Sr	|void	|setlocale_failure_panic_via_i				\
-				|const unsigned int cat_index		\
+				|const locale_category_index cat_index	\
 				|NULLOK const char *current		\
 				|NN const char *failed			\
 				|const line_t proxy_caller_line 	\
@@ -4441,12 +4441,12 @@ S	|void	|set_save_buffer_min_size				\
 				|NULLOK char **buf			\
 				|NULLOK Size_t *buf_size
 So	|const char *|toggle_locale_i					\
-				|const unsigned switch_cat_index	\
+				|const locale_category_index cat_index	\
 				|NN const char *new_locale		\
 				|const line_t caller_line
 #   if defined(DEBUGGING)
 RS	|char * |my_setlocale_debug_string_i				\
-				|const unsigned cat_index		\
+				|const locale_category_index cat_index	\
 				|NULLOK const char *locale		\
 				|NULLOK const char *retval		\
 				|const line_t line
@@ -4454,7 +4454,7 @@ RS	|char * |my_setlocale_debug_string_i				\
 #   if defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L)
 S	|const char *|my_langinfo_i					\
 				|const nl_item item			\
-				|const unsigned int cat_index		\
+				|const locale_category_index cat_index	\
 				|NN const char *locale			\
 				|NN char **retbufp			\
 				|NULLOK Size_t *retbuf_sizep		\
@@ -4462,7 +4462,7 @@ S	|const char *|my_langinfo_i					\
 #   else
 S	|const char *|my_langinfo_i					\
 				|const int item 			\
-				|const unsigned int cat_index		\
+				|const locale_category_index cat_index	\
 				|NN const char *locale			\
 				|NN char **retbufp			\
 				|NULLOK Size_t *retbuf_sizep		\
@@ -4515,16 +4515,16 @@ S	|const char *|get_LC_ALL_display
 #   endif
 #   if defined(USE_POSIX_2008_LOCALE)
 S	|bool	|bool_setlocale_2008_i					\
-				|const unsigned int index		\
+				|const locale_category_index index	\
 				|NN const char *new_locale		\
 				|const line_t caller_line
 S	|const char *|querylocale_2008_i				\
-				|const unsigned int index		\
+				|const locale_category_index index	\
 				|const line_t line
 S	|locale_t|use_curlocale_scratch
 #     if !defined(USE_QUERYLOCALE)
 S	|void	|update_PL_curlocales_i 				\
-				|const unsigned int index		\
+				|const locale_category_index index	\
 				|NN const char *new_locale		\
 				|const line_t caller_line
 #     endif
@@ -4554,7 +4554,7 @@ S	|const char *|wrap_wsetlocale					\
 #   if   defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) || \
        ( defined(USE_POSIX_2008_LOCALE) && !defined(USE_QUERYLOCALE) )
 S	|const char *|find_locale_from_environment			\
-				|const unsigned int index
+				|const locale_category_index index
 #   endif
 # endif /* defined(USE_LOCALE) */
 # if defined(USE_LOCALE) || defined(DEBUGGING)

--- a/locale.c
+++ b/locale.c
@@ -442,20 +442,20 @@ S_wsetlocale(const int category, const wchar_t * wlocale)
 #endif  /* WIN32_USE_FAKE_OLD_MINGW_LOCALES */
 
 /* 'for' loop headers to hide the necessary casts */
-#define all_individual_category_indexes(i)                                  \
-    locale_category_index i = (locale_category_index) 0;                    \
-    i < LC_ALL_INDEX_;                                                      \
-    i = (locale_category_index) ((int) i + 1)
+#define for_all_individual_category_indexes(i)                              \
+    for (locale_category_index i = (locale_category_index) 0;               \
+         i < LC_ALL_INDEX_;                                                 \
+         i = (locale_category_index) ((int) i + 1))
 
-#define all_but_0th_individual_category_indexes(i)                          \
-    locale_category_index i = (locale_category_index) 1;                    \
-    i < LC_ALL_INDEX_;                                                      \
-    i = (locale_category_index) ((int) i + 1)
+#define for_all_but_0th_individual_category_indexes(i)                      \
+    for (locale_category_index i = (locale_category_index) 1;               \
+         i < LC_ALL_INDEX_;                                                 \
+         i = (locale_category_index) ((int) i + 1))
 
-#define all_category_indexes(i)                                             \
-    locale_category_index i = (locale_category_index) 0;                    \
-    i <= LC_ALL_INDEX_;                                                     \
-    i = (locale_category_index) ((int) i + 1)
+#define for_all_category_indexes(i)                                         \
+    for (locale_category_index i = (locale_category_index) 0;               \
+         i <= LC_ALL_INDEX_;                                                \
+         i = (locale_category_index) ((int) i + 1))
 
 #ifdef USE_LOCALE
 #  if defined(USE_FAKE_LC_ALL_POSITIONAL_NOTATION) && defined(LC_ALL)
@@ -506,7 +506,7 @@ S_positional_name_value_xlation(const char * locale, bool direction)
                                                       WANT_TEMP_PV,
                                                       __LINE__);
 
-        for (all_individual_category_indexes(i)) {
+        for_all_individual_category_indexes(i) {
             Safefree(individ_locales[i]);
         }
 
@@ -1200,7 +1200,7 @@ S_parse_LC_ALL_string(pTHX_ const char * string,
      * will be C for each ignored category and "" for the others.  Then the
      * caller can individually set each category, and get the right answer. */
     if (single_component && ! isNAME_C_OR_POSIX(string)) {
-        for (all_individual_category_indexes(i)) {
+        for_all_individual_category_indexes(i) {
            OVERRIDE_AND_SAVEPV(string, strlen(string), output[i], i, override);
         }
 
@@ -1214,7 +1214,7 @@ S_parse_LC_ALL_string(pTHX_ const char * string,
             return no_array;
         }
 
-        for (all_individual_category_indexes(i)) {
+        for_all_individual_category_indexes(i) {
             output[i] = savepv(string);
         }
 
@@ -1349,7 +1349,7 @@ S_parse_LC_ALL_string(pTHX_ const char * string,
 #  endif
 
     {   /* Here is the name=value notation */
-        for (all_individual_category_indexes(i)) {
+        for_all_individual_category_indexes(i) {
             if (! seen[i]) {
                 error = incomplete;
                 goto failure;
@@ -1365,7 +1365,7 @@ S_parse_LC_ALL_string(pTHX_ const char * string,
     }
 
     /* Free the dangling ones */
-    for (all_but_0th_individual_category_indexes(i)) {
+    for_all_but_0th_individual_category_indexes(i) {
         Safefree(output[i]);
         output[i] = NULL;
     }
@@ -1375,7 +1375,7 @@ S_parse_LC_ALL_string(pTHX_ const char * string,
   failure:
 
     /* Don't leave memory dangling that we allocated before the failure */
-    for (all_individual_category_indexes(i)) {
+    for_all_individual_category_indexes(i) {
         if (seen[i]) {
             Safefree(output[i]);
             output[i] = NULL;
@@ -1515,7 +1515,7 @@ S_posix_setlocale_with_complications(pTHX_ const int cat,
                                                  WANT_TEMP_PV,
                                                  caller_line);
 
-            for (all_individual_category_indexes(i)) {
+            for_all_individual_category_indexes(i) {
                 Safefree(new_locales[i]);
             }
 
@@ -2443,7 +2443,7 @@ S_bool_setlocale_2008_i(pTHX_
             /* Loop, using the previous iteration's result as the basis for the
              * next one.  (The first time we effectively use the locale in
              * force upon entry to this function.) */
-            for (all_individual_category_indexes(i)) {
+            for_all_individual_category_indexes(i) {
                 new_obj = newlocale(category_masks[i],
                                     new_locales[i],
                                     basis_obj);
@@ -2467,7 +2467,7 @@ S_bool_setlocale_2008_i(pTHX_
                  * failed */
                 freelocale(basis_obj);
 
-                for (all_individual_category_indexes(j)) {
+                for_all_individual_category_indexes(j) {
                     Safefree(new_locales[j]);
                 }
 
@@ -2475,7 +2475,7 @@ S_bool_setlocale_2008_i(pTHX_
             }
 
             /* Success for all categories. */
-            for (all_individual_category_indexes(i)) {
+            for_all_individual_category_indexes(i) {
                 update_PL_curlocales_i(i, new_locales[i], caller_line);
                 Safefree(new_locales[i]);
             }
@@ -2770,12 +2770,12 @@ S_calculate_LC_ALL_string(pTHX_ const char ** category_locales_list,
         locales_list = my_category_locales_list;
 
         if (format == EXTERNAL_FORMAT_FOR_QUERY) {
-            for (all_individual_category_indexes(i)) {
+            for_all_individual_category_indexes(i) {
                 locales_list[i] = query_nominal_locale_i(i);
             }
         }
         else {
-            for (all_individual_category_indexes(i)) {
+            for_all_individual_category_indexes(i) {
                 locales_list[i] = querylocale_i(i);
             }
         }
@@ -2847,7 +2847,7 @@ S_calculate_LC_ALL_string(pTHX_ const char ** category_locales_list,
 
     /* The total length then is just the sum of the above boiler-plate plus the
      * total strlen()s of the locale name of each individual category. */
-    for (all_individual_category_indexes(i)) {
+    for_all_individual_category_indexes(i) {
         const char * entry = ENTRY(i, locales_list, format);
 
         total_len += strlen(entry);
@@ -2894,7 +2894,7 @@ S_calculate_LC_ALL_string(pTHX_ const char ** category_locales_list,
         constructed[0] = '\0';
 
         /* Loop through all the categories */
-        for (all_individual_category_indexes(j)) {
+        for_all_individual_category_indexes(j) {
 
             /* Add a separator, except before the first one */
             if (j != 0) {
@@ -3936,7 +3936,7 @@ S_new_LC_ALL(pTHX_ const char ** individ_locales, bool force)
 
 #  endif
 
-    for (all_individual_category_indexes(i)) {
+    for_all_individual_category_indexes(i) {
         if (update_functions[i]) {
             const char * this_locale = individ_locales[i];
             update_functions[i](aTHX_ this_locale, force);
@@ -6744,7 +6744,7 @@ S_give_perl_locale_control(pTHX_
 
 #    else
 
-    for (all_individual_category_indexes(i)) {
+    for_all_individual_category_indexes(i) {
         void_setlocale_i_with_caller(i, locales[i], __FILE__, caller_line);
     }
 
@@ -6789,7 +6789,7 @@ S_output_check_environment_warning(pTHX_ const char * const language,
                                   lc_all ? lc_all : "unset",
                                   lc_all ? '"' : ')');
 
-    for (all_individual_category_indexes(i)) {
+    for_all_individual_category_indexes(i) {
         const char * value = PerlEnv_getenv(category_names[i]);
         PerlIO_printf(Perl_error_log,
                       "\t%s = %c%s%c,\n",
@@ -6945,7 +6945,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 #      endif
 #    endif
 
-    for (all_individual_category_indexes(i)) {
+    for_all_individual_category_indexes(i) {
         assert(category_name_lengths[i] == strlen(category_names[i]));
     }
 
@@ -7208,7 +7208,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
         bool setlocale_failure = FALSE;  /* This trial hasn't failed so far */
         bool dowarn = trial == 0 && locwarn;
 
-        for (all_individual_category_indexes(j)) {
+        for_all_individual_category_indexes(j) {
             STDIZED_SETLOCALE_LOCK;
             curlocales[j] = savepv(stdized_setlocale(categories[j], locale));
             STDIZED_SETLOCALE_UNLOCK;
@@ -7237,7 +7237,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
             PerlIO_printf(Perl_error_log,
                 "perl: warning: Setting locale failed for the categories:\n");
 
-            for (all_individual_category_indexes(j)) {
+            for_all_individual_category_indexes(j) {
                 if (! curlocales[j]) {
                     PerlIO_printf(Perl_error_log, "\t%s\n", category_names[j]);
                 }
@@ -7317,7 +7317,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
                                                    INTERNAL_FORMAT,
                                                    WANT_TEMP_PV,
                                                    __LINE__);
-                    for (all_individual_category_indexes(j)) {
+                    for_all_individual_category_indexes(j) {
                         Safefree(individ_locales[j]);
                     }
                 }
@@ -7351,7 +7351,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 
                 const char * system_locales[LC_ALL_INDEX_] = { NULL };
 
-                for (all_individual_category_indexes(j)) {
+                for_all_individual_category_indexes(j) {
                     STDIZED_SETLOCALE_LOCK;
                     system_locales[j] = savepv(stdized_setlocale(categories[j],
                                                                  NULL));
@@ -7370,7 +7370,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
                                                __LINE__);
                 description = "what the system says";
 
-                for (all_individual_category_indexes(j)) {
+                for_all_individual_category_indexes(j) {
                     Safefree(system_locales[j]);
                 }
 #  endif
@@ -7396,7 +7396,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 
     give_perl_locale_control((const char **) &curlocales, __LINE__);
 
-    for (all_individual_category_indexes(j)) {
+    for_all_individual_category_indexes(j) {
         Safefree(curlocales[j]);
     }
 
@@ -8768,7 +8768,7 @@ Perl_switch_to_global_locale(pTHX)
     const char * cur_thread_locales[LC_ALL_INDEX_];
 
     /* Save each category's current per-thread state */
-    for (all_individual_category_indexes(i)) {
+    for_all_individual_category_indexes(i) {
         cur_thread_locales[i] = querylocale_i(i);
     }
 
@@ -8776,7 +8776,7 @@ Perl_switch_to_global_locale(pTHX)
 
     /* Set the global to what was our per-thread state */
     POSIX_SETLOCALE_LOCK;
-    for (all_individual_category_indexes(i)) {
+    for_all_individual_category_indexes(i) {
         posix_setlocale(categories[i], cur_thread_locales[i]);
     }
     POSIX_SETLOCALE_UNLOCK;
@@ -8881,7 +8881,7 @@ Perl_sync_locale(pTHX)
 #  else
 
     const char * current_globals[LC_ALL_INDEX_];
-    for (all_individual_category_indexes(i)) {
+    for_all_individual_category_indexes(i) {
         STDIZED_SETLOCALE_LOCK;
         current_globals[i] = savepv(stdized_setlocale(categories[i], NULL));
         STDIZED_SETLOCALE_UNLOCK;
@@ -8889,7 +8889,7 @@ Perl_sync_locale(pTHX)
 
     give_perl_locale_control((const char **) &current_globals, __LINE__);
 
-    for (all_individual_category_indexes(i)) {
+    for_all_individual_category_indexes(i) {
         Safefree(current_globals[i]);
     }
 

--- a/locale.c
+++ b/locale.c
@@ -441,6 +441,22 @@ S_wsetlocale(const int category, const wchar_t * wlocale)
 #  endif
 #endif  /* WIN32_USE_FAKE_OLD_MINGW_LOCALES */
 
+/* 'for' loop headers to hide the necessary casts */
+#define all_individual_category_indexes(i)                                  \
+    locale_category_index i = (locale_category_index) 0;                    \
+    i < LC_ALL_INDEX_;                                                      \
+    i = (locale_category_index) ((int) i + 1)
+
+#define all_but_0th_individual_category_indexes(i)                          \
+    locale_category_index i = (locale_category_index) 1;                    \
+    i < LC_ALL_INDEX_;                                                      \
+    i = (locale_category_index) ((int) i + 1)
+
+#define all_category_indexes(i)                                             \
+    locale_category_index i = (locale_category_index) 0;                    \
+    i <= LC_ALL_INDEX_;                                                     \
+    i = (locale_category_index) ((int) i + 1)
+
 #ifdef USE_LOCALE
 #  if defined(USE_FAKE_LC_ALL_POSITIONAL_NOTATION) && defined(LC_ALL)
 
@@ -490,7 +506,7 @@ S_positional_name_value_xlation(const char * locale, bool direction)
                                                       WANT_TEMP_PV,
                                                       __LINE__);
 
-        for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
+        for (all_individual_category_indexes(i)) {
             Safefree(individ_locales[i]);
         }
 
@@ -816,10 +832,12 @@ STATIC const int category_masks[] = {
 
 /* On platforms that use positional notation for expressing LC_ALL, this maps
  * the position of each category to our corresponding internal index for it.
- * This is initialized at run time if needed */
+ * This is initialized at run time if needed.  LC_ALL_INDEX_ is not legal for
+ * an individual locale, hence marks the elements here as not actually
+ * initialized. */
 STATIC
 unsigned int
-map_LC_ALL_position_to_index[LC_ALL_INDEX_] = { PERL_UINT_MAX };
+map_LC_ALL_position_to_index[LC_ALL_INDEX_] = { LC_ALL_INDEX_ };
 
 #  endif
 #endif
@@ -885,7 +903,7 @@ S_get_displayable_string(pTHX_
 
 # define get_category_index(cat) get_category_index_helper(cat, NULL, __LINE__)
 
-STATIC unsigned int
+STATIC locale_category_index
 S_get_category_index_helper(pTHX_ const int category, bool * succeeded,
                                   const line_t caller_line)
 {
@@ -894,7 +912,7 @@ S_get_category_index_helper(pTHX_ const int category, bool * succeeded,
     /* Given a category, return the equivalent internal index we generally use
      * instead, warn or panic if not found. */
 
-    unsigned int i;
+    locale_category_index i;
 
 #  undef PERL_LOCALE_TABLE_ENTRY
 #  define PERL_LOCALE_TABLE_ENTRY(name, call_back)                          \
@@ -925,7 +943,7 @@ S_get_category_index_helper(pTHX_ const int category, bool * succeeded,
 
     if (succeeded) {
         *succeeded = false;
-        return 0;   /* Arbitrary */
+        return LC_ALL_INDEX_;   /* Arbitrary */
     }
 
     locale_panic_via_(Perl_form(aTHX_ "Unknown locale category %d", category),
@@ -1182,7 +1200,7 @@ S_parse_LC_ALL_string(pTHX_ const char * string,
      * will be C for each ignored category and "" for the others.  Then the
      * caller can individually set each category, and get the right answer. */
     if (single_component && ! isNAME_C_OR_POSIX(string)) {
-        for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
+        for (all_individual_category_indexes(i)) {
            OVERRIDE_AND_SAVEPV(string, strlen(string), output[i], i, override);
         }
 
@@ -1196,7 +1214,7 @@ S_parse_LC_ALL_string(pTHX_ const char * string,
             return no_array;
         }
 
-        for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
+        for (all_individual_category_indexes(i)) {
             output[i] = savepv(string);
         }
 
@@ -1331,7 +1349,7 @@ S_parse_LC_ALL_string(pTHX_ const char * string,
 #  endif
 
     {   /* Here is the name=value notation */
-        for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
+        for (all_individual_category_indexes(i)) {
             if (! seen[i]) {
                 error = incomplete;
                 goto failure;
@@ -1347,7 +1365,7 @@ S_parse_LC_ALL_string(pTHX_ const char * string,
     }
 
     /* Free the dangling ones */
-    for (unsigned int i = 1; i < LC_ALL_INDEX_; i++) {
+    for (all_but_0th_individual_category_indexes(i)) {
         Safefree(output[i]);
         output[i] = NULL;
     }
@@ -1357,7 +1375,7 @@ S_parse_LC_ALL_string(pTHX_ const char * string,
   failure:
 
     /* Don't leave memory dangling that we allocated before the failure */
-    for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
+    for (all_individual_category_indexes(i)) {
         if (seen[i]) {
             Safefree(output[i]);
             output[i] = NULL;
@@ -1497,7 +1515,7 @@ S_posix_setlocale_with_complications(pTHX_ const int cat,
                                                  WANT_TEMP_PV,
                                                  caller_line);
 
-            for (unsigned i = 0; i < LC_ALL_INDEX_; i++) {
+            for (all_individual_category_indexes(i)) {
                 Safefree(new_locales[i]);
             }
 
@@ -1920,7 +1938,8 @@ S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char * locale)
 #  define querylocale_r(cat)  querylocale_i(get_category_index(cat))
 
 STATIC const char *
-S_querylocale_2008_i(pTHX_ const unsigned int index, const line_t caller_line)
+S_querylocale_2008_i(pTHX_ const locale_category_index index,
+                           const line_t caller_line)
 {
     PERL_ARGS_ASSERT_QUERYLOCALE_2008_I;
     assert(index <= LC_ALL_INDEX_);
@@ -2150,7 +2169,7 @@ STATIC bool
 S_bool_setlocale_2008_i(pTHX_
 
         /* Our internal index of the 'category' setlocale is called with */
-        const unsigned int index,
+        const locale_category_index  index,
         const char * new_locale,    /* The locale to set the category to */
         const line_t caller_line    /* Called from this line number */
        )
@@ -2424,7 +2443,7 @@ S_bool_setlocale_2008_i(pTHX_
             /* Loop, using the previous iteration's result as the basis for the
              * next one.  (The first time we effectively use the locale in
              * force upon entry to this function.) */
-            for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
+            for (all_individual_category_indexes(i)) {
                 new_obj = newlocale(category_masks[i],
                                     new_locales[i],
                                     basis_obj);
@@ -2448,7 +2467,7 @@ S_bool_setlocale_2008_i(pTHX_
                  * failed */
                 freelocale(basis_obj);
 
-                for (unsigned int j = 0; j < LC_ALL_INDEX_; j++) {
+                for (all_individual_category_indexes(j)) {
                     Safefree(new_locales[j]);
                 }
 
@@ -2456,7 +2475,7 @@ S_bool_setlocale_2008_i(pTHX_
             }
 
             /* Success for all categories. */
-            for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
+            for (all_individual_category_indexes(i)) {
                 update_PL_curlocales_i(i, new_locales[i], caller_line);
                 Safefree(new_locales[i]);
             }
@@ -2563,7 +2582,7 @@ S_bool_setlocale_2008_i(pTHX_
 
 STATIC void
 S_update_PL_curlocales_i(pTHX_
-                         const unsigned int index,
+                         const locale_category_index index,
                          const char * new_locale,
                          const line_t caller_line)
 {
@@ -2593,7 +2612,6 @@ S_update_PL_curlocales_i(pTHX_
                                                it earlier had to have succeeded
                                                */
                                    caller_line))
-
         {
           case invalid:
           case no_array:
@@ -2752,12 +2770,12 @@ S_calculate_LC_ALL_string(pTHX_ const char ** category_locales_list,
         locales_list = my_category_locales_list;
 
         if (format == EXTERNAL_FORMAT_FOR_QUERY) {
-            for (unsigned i = 0; i < LC_ALL_INDEX_; i++) {
+            for (all_individual_category_indexes(i)) {
                 locales_list[i] = query_nominal_locale_i(i);
             }
         }
         else {
-            for (unsigned i = 0; i < LC_ALL_INDEX_; i++) {
+            for (all_individual_category_indexes(i)) {
                 locales_list[i] = querylocale_i(i);
             }
         }
@@ -2829,7 +2847,7 @@ S_calculate_LC_ALL_string(pTHX_ const char ** category_locales_list,
 
     /* The total length then is just the sum of the above boiler-plate plus the
      * total strlen()s of the locale name of each individual category. */
-    for (unsigned int i = 0;  i < LC_ALL_INDEX_; i++) {
+    for (all_individual_category_indexes(i)) {
         const char * entry = ENTRY(i, locales_list, format);
 
         total_len += strlen(entry);
@@ -2876,7 +2894,7 @@ S_calculate_LC_ALL_string(pTHX_ const char ** category_locales_list,
         constructed[0] = '\0';
 
         /* Loop through all the categories */
-        for (unsigned j = 0; j < LC_ALL_INDEX_; j++) {
+        for (all_individual_category_indexes(j)) {
 
             /* Add a separator, except before the first one */
             if (j != 0) {
@@ -2965,7 +2983,7 @@ S_calculate_LC_ALL_string(pTHX_ const char ** category_locales_list,
                          && ! defined(USE_QUERYLOCALE))
 
 STATIC const char *
-S_find_locale_from_environment(pTHX_ const unsigned int index)
+S_find_locale_from_environment(pTHX_ const locale_category_index index)
 {
     /* NB: This function may actually change the locale on Windows.  It
      * currently is designed to be called only from setting the locale on
@@ -3039,11 +3057,11 @@ S_find_locale_from_environment(pTHX_ const unsigned int index)
      * them all.  If only an individual category is desired, to avoid
      * duplicating logic, we use the same loop, but set up the limits so it is
      * only executed once, for that particular category. */
-    unsigned int lower, upper, offset;
+    locale_category_index lower, upper, offset;
     if (index == LC_ALL_INDEX_) {
-        lower = 0;
-        upper = LC_ALL_INDEX_ - 1;
-        offset = 0;
+        lower = (locale_category_index) 0;
+        upper = (locale_category_index) ((int) LC_ALL_INDEX_ - 1);
+        offset = (locale_category_index) 0;
     }
     else {
         lower = index;
@@ -3136,7 +3154,7 @@ S_get_LC_ALL_display(pTHX)
 
 STATIC void
 S_setlocale_failure_panic_via_i(pTHX_
-                                const unsigned int cat_index,
+                                const locale_category_index cat_index,
                                 const char * current,
                                 const char * failed,
                                 const line_t proxy_caller_line,
@@ -3918,7 +3936,7 @@ S_new_LC_ALL(pTHX_ const char ** individ_locales, bool force)
 
 #  endif
 
-    for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
+    for (all_individual_category_indexes(i)) {
         if (update_functions[i]) {
             const char * this_locale = individ_locales[i];
             update_functions[i](aTHX_ this_locale, force);
@@ -4138,7 +4156,7 @@ S_win32_setlocale(pTHX_ int category, const char* locale)
 #  endif
 
 STATIC const char *
-S_native_querylocale_i(pTHX_ const unsigned int cat_index)
+S_native_querylocale_i(pTHX_ const locale_category_index cat_index)
 {
     /* Determine the current locale and return it in the form the platform's
      * native locale handling understands.  This is different only from our
@@ -4255,9 +4273,9 @@ Perl_setlocale(const int category, const char * locale)
                           category, locale));
 
     bool valid_category;
-    unsigned int cat_index = get_category_index_helper(category,
-                                                       &valid_category,
-                                                       __LINE__);
+    locale_category_index cat_index = get_category_index_helper(category,
+                                                                &valid_category,
+                                                                __LINE__);
     if (! valid_category) {
         if (ckWARN(WARN_LOCALE)) {
             const char * conditional_warn_text;
@@ -4340,7 +4358,7 @@ STATIC utf8ness_t
 S_get_locale_string_utf8ness_i(pTHX_ const char * string,
                                      const locale_utf8ness_t known_utf8,
                                      const char * locale,
-                                     const unsigned cat_index)
+                                     const locale_category_index cat_index)
 {
     PERL_ARGS_ASSERT_GET_LOCALE_STRING_UTF8NESS_I;
 
@@ -4820,22 +4838,22 @@ S_my_localeconv(pTHX_ const int item)
      * If not paying attention to that either, the code below should end up not
      * using this.  Make sure that things blow up if that avoidance gets lost,
      * by setting the category to an out-of-bounds value */
-    unsigned int numeric_index;
-    unsigned int monetary_index;
+    locale_category_index numeric_index;
+    locale_category_index monetary_index;
 
 #  ifdef USE_LOCALE_NUMERIC
     numeric_index = LC_NUMERIC_INDEX_;
 #  elif defined(USE_LOCALE_CTYPE)
     numeric_index = LC_CTYPE_INDEX_;
 #  else
-    numeric_index = (unsigned) -1;
+    numeric_index = LC_ALL_INDEX_;      /* Out-of-bounds */
 #  endif
 #  ifdef USE_LOCALE_MONETARY
     monetary_index = LC_MONETARY_INDEX_;
 #  elif defined(USE_LOCALE_CTYPE)
     monetary_index = LC_CTYPE_INDEX_;
 #  else
-    monetary_index = (unsigned) -1;
+    monetary_index = LC_ALL_INDEX_;     /* Out-of-bounds */
 #  endif
 
     /* Some platforms, for correct non-mojibake results, require LC_CTYPE's
@@ -5090,8 +5108,9 @@ S_my_localeconv(pTHX_ const int item)
 
             /* Determine if the string should be marked as UTF-8. */
             if (UTF8NESS_YES == (get_locale_string_utf8ness_i(SvPVX(*value),
-                                                              locale_is_utf8,
-                                                              NULL, 0)))
+                                                  locale_is_utf8,
+                                                  NULL,
+                                                  (locale_category_index) 0)))
             {
                 SvUTF8_on(*value);
             }
@@ -5490,7 +5509,7 @@ const char *
 Perl_langinfo8(const nl_item item, utf8ness_t * utf8ness)
 {
     dTHX;
-    unsigned cat_index;
+    locale_category_index cat_index;
 
     PERL_ARGS_ASSERT_PERL_LANGINFO8;
 
@@ -5726,8 +5745,8 @@ Perl_sv_strftime_ints(pTHX_ SV * fmt, int sec, int min, int hour,
 STATIC const char *
 S_my_langinfo_i(pTHX_
                 const nl_item item,           /* The item to look up */
-                const unsigned int cat_index, /* The locale category that
-                                                 controls it */
+                const locale_category_index cat_index, /* The locale category
+                                                          that controls it */
                 /* The locale to look up 'item' in. */
                 const char * locale,
 
@@ -6725,7 +6744,7 @@ S_give_perl_locale_control(pTHX_
 
 #    else
 
-    for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
+    for (all_individual_category_indexes(i)) {
         void_setlocale_i_with_caller(i, locales[i], __FILE__, caller_line);
     }
 
@@ -6770,7 +6789,7 @@ S_output_check_environment_warning(pTHX_ const char * const language,
                                   lc_all ? lc_all : "unset",
                                   lc_all ? '"' : ')');
 
-    for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
+    for (all_individual_category_indexes(i)) {
         const char * value = PerlEnv_getenv(category_names[i]);
         PerlIO_printf(Perl_error_log,
                       "\t%s = %c%s%c,\n",
@@ -6926,7 +6945,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 #      endif
 #    endif
 
-    for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
+    for (all_individual_category_indexes(i)) {
         assert(category_name_lengths[i] == strlen(category_names[i]));
     }
 
@@ -6961,7 +6980,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 
     /* If we haven't done so already, translate the LC_ALL positions of
      * categories into our internal indices. */
-    if (map_LC_ALL_position_to_index[0] == PERL_UINT_MAX) {
+    if (map_LC_ALL_position_to_index[0] == LC_ALL_INDEX_) {
 
         /* Use this array, initialized by a config.h constant */
         int lc_all_category_positions[] = PERL_LC_ALL_CATEGORY_POSITIONS_INIT;
@@ -7189,7 +7208,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
         bool setlocale_failure = FALSE;  /* This trial hasn't failed so far */
         bool dowarn = trial == 0 && locwarn;
 
-        for (unsigned int j = 0; j < LC_ALL_INDEX_; j++) {
+        for (all_individual_category_indexes(j)) {
             STDIZED_SETLOCALE_LOCK;
             curlocales[j] = savepv(stdized_setlocale(categories[j], locale));
             STDIZED_SETLOCALE_UNLOCK;
@@ -7218,7 +7237,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
             PerlIO_printf(Perl_error_log,
                 "perl: warning: Setting locale failed for the categories:\n");
 
-            for (unsigned int j = 0; j < LC_ALL_INDEX_; j++) {
+            for (all_individual_category_indexes(j)) {
                 if (! curlocales[j]) {
                     PerlIO_printf(Perl_error_log, "\t%s\n", category_names[j]);
                 }
@@ -7298,7 +7317,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
                                                    INTERNAL_FORMAT,
                                                    WANT_TEMP_PV,
                                                    __LINE__);
-                    for (unsigned int j = 0; j < LC_ALL_INDEX_; j++) {
+                    for (all_individual_category_indexes(j)) {
                         Safefree(individ_locales[j]);
                     }
                 }
@@ -7332,7 +7351,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 
                 const char * system_locales[LC_ALL_INDEX_] = { NULL };
 
-                for (unsigned int j = 0; j < LC_ALL_INDEX_; j++) {
+                for (all_individual_category_indexes(j)) {
                     STDIZED_SETLOCALE_LOCK;
                     system_locales[j] = savepv(stdized_setlocale(categories[j],
                                                                  NULL));
@@ -7351,7 +7370,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
                                                __LINE__);
                 description = "what the system says";
 
-                for (unsigned int j = 0; j < LC_ALL_INDEX_; j++) {
+                for (all_individual_category_indexes(j)) {
                     Safefree(system_locales[j]);
                 }
 #  endif
@@ -7377,7 +7396,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 
     give_perl_locale_control((const char **) &curlocales, __LINE__);
 
-    for (unsigned int j = 0; j < LC_ALL_INDEX_; j++) {
+    for (all_individual_category_indexes(j)) {
         Safefree(curlocales[j]);
     }
 
@@ -8230,7 +8249,7 @@ Perl_strxfrm(pTHX_ SV * src)
 #ifdef USE_LOCALE
 
 STATIC const char *
-S_toggle_locale_i(pTHX_ const unsigned cat_index,
+S_toggle_locale_i(pTHX_ const locale_category_index cat_index,
                         const char * new_locale,
                         const line_t caller_line)
 {
@@ -8287,7 +8306,7 @@ S_toggle_locale_i(pTHX_ const unsigned cat_index,
 }
 
 STATIC void
-S_restore_toggled_locale_i(pTHX_ const unsigned int cat_index,
+S_restore_toggled_locale_i(pTHX_ const locale_category_index cat_index,
                                  const char * restore_locale,
                                  const line_t caller_line)
 {
@@ -8749,7 +8768,7 @@ Perl_switch_to_global_locale(pTHX)
     const char * cur_thread_locales[LC_ALL_INDEX_];
 
     /* Save each category's current per-thread state */
-    for (unsigned i = 0; i < LC_ALL_INDEX_; i++) {
+    for (all_individual_category_indexes(i)) {
         cur_thread_locales[i] = querylocale_i(i);
     }
 
@@ -8757,7 +8776,7 @@ Perl_switch_to_global_locale(pTHX)
 
     /* Set the global to what was our per-thread state */
     POSIX_SETLOCALE_LOCK;
-    for (unsigned int i = 0; i < LC_ALL_INDEX_; i++) {
+    for (all_individual_category_indexes(i)) {
         posix_setlocale(categories[i], cur_thread_locales[i]);
     }
     POSIX_SETLOCALE_UNLOCK;
@@ -8862,7 +8881,7 @@ Perl_sync_locale(pTHX)
 #  else
 
     const char * current_globals[LC_ALL_INDEX_];
-    for (unsigned i = 0; i < LC_ALL_INDEX_; i++) {
+    for (all_individual_category_indexes(i)) {
         STDIZED_SETLOCALE_LOCK;
         current_globals[i] = savepv(stdized_setlocale(categories[i], NULL));
         STDIZED_SETLOCALE_UNLOCK;
@@ -8870,7 +8889,7 @@ Perl_sync_locale(pTHX)
 
     give_perl_locale_control((const char **) &current_globals, __LINE__);
 
-    for (unsigned i = 0; i < LC_ALL_INDEX_; i++) {
+    for (all_individual_category_indexes(i)) {
         Safefree(current_globals[i]);
     }
 
@@ -8886,7 +8905,7 @@ Perl_sync_locale(pTHX)
 
 STATIC char *
 S_my_setlocale_debug_string_i(pTHX_
-                              const unsigned cat_index,
+                              const locale_category_index cat_index,
                               const char* locale, /* Optional locale name */
 
                               /* return value from setlocale() when attempting

--- a/proto.h
+++ b/proto.h
@@ -6971,7 +6971,7 @@ Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
 #endif
 #if defined(PERL_IN_LOCALE_C)
 STATIC utf8ness_t
-S_get_locale_string_utf8ness_i(pTHX_ const char *string, const locale_utf8ness_t known_utf8, const char *locale, const unsigned cat_index);
+S_get_locale_string_utf8ness_i(pTHX_ const char *string, const locale_utf8ness_t known_utf8, const char *locale, const locale_category_index cat_index);
 # define PERL_ARGS_ASSERT_GET_LOCALE_STRING_UTF8NESS_I
 
 STATIC void
@@ -7011,13 +7011,13 @@ STATIC const char *
 S_calculate_LC_ALL_string(pTHX_ const char **category_locales_list, const calc_LC_ALL_format format, const calc_LC_ALL_return returning, const line_t caller_line);
 #   define PERL_ARGS_ASSERT_CALCULATE_LC_ALL_STRING
 
-STATIC unsigned int
+STATIC locale_category_index
 S_get_category_index_helper(pTHX_ const int category, bool *success, const line_t caller_line)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_GET_CATEGORY_INDEX_HELPER
 
 STATIC const char *
-S_native_querylocale_i(pTHX_ const unsigned int cat_index);
+S_native_querylocale_i(pTHX_ const locale_category_index cat_index);
 #   define PERL_ARGS_ASSERT_NATIVE_QUERYLOCALE_I
 
 STATIC void
@@ -7025,7 +7025,7 @@ S_output_check_environment_warning(pTHX_ const char * const language, const char
 #   define PERL_ARGS_ASSERT_OUTPUT_CHECK_ENVIRONMENT_WARNING
 
 STATIC void
-S_restore_toggled_locale_i(pTHX_ const unsigned cat_index, const char *original_locale, const line_t caller_line);
+S_restore_toggled_locale_i(pTHX_ const locale_category_index cat_index, const char *original_locale, const line_t caller_line);
 #   define PERL_ARGS_ASSERT_RESTORE_TOGGLED_LOCALE_I
 
 STATIC const char *
@@ -7037,32 +7037,32 @@ S_set_save_buffer_min_size(pTHX_ const Size_t min_len, char **buf, Size_t *buf_s
 #   define PERL_ARGS_ASSERT_SET_SAVE_BUFFER_MIN_SIZE
 
 PERL_STATIC_NO_RET void
-S_setlocale_failure_panic_via_i(pTHX_ const unsigned int cat_index, const char *current, const char *failed, const line_t proxy_caller_line, const line_t immediate_caller_line, const char *higher_caller_file, const line_t higher_caller_line)
+S_setlocale_failure_panic_via_i(pTHX_ const locale_category_index cat_index, const char *current, const char *failed, const line_t proxy_caller_line, const line_t immediate_caller_line, const char *higher_caller_file, const line_t higher_caller_line)
         __attribute__noreturn__;
 #   define PERL_ARGS_ASSERT_SETLOCALE_FAILURE_PANIC_VIA_I \
         assert(failed); assert(higher_caller_file)
 
 STATIC const char *
-S_toggle_locale_i(pTHX_ const unsigned switch_cat_index, const char *new_locale, const line_t caller_line);
+S_toggle_locale_i(pTHX_ const locale_category_index cat_index, const char *new_locale, const line_t caller_line);
 #   define PERL_ARGS_ASSERT_TOGGLE_LOCALE_I     \
         assert(new_locale)
 
 #   if defined(DEBUGGING)
 STATIC char *
-S_my_setlocale_debug_string_i(pTHX_ const unsigned cat_index, const char *locale, const char *retval, const line_t line)
+S_my_setlocale_debug_string_i(pTHX_ const locale_category_index cat_index, const char *locale, const char *retval, const line_t line)
         __attribute__warn_unused_result__;
 #     define PERL_ARGS_ASSERT_MY_SETLOCALE_DEBUG_STRING_I
 
 #   endif
 #   if defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L)
 STATIC const char *
-S_my_langinfo_i(pTHX_ const nl_item item, const unsigned int cat_index, const char *locale, char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
+S_my_langinfo_i(pTHX_ const nl_item item, const locale_category_index cat_index, const char *locale, char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
 #     define PERL_ARGS_ASSERT_MY_LANGINFO_I     \
         assert(locale); assert(retbufp)
 
 #   else
 STATIC const char *
-S_my_langinfo_i(pTHX_ const int item, const unsigned int cat_index, const char *locale, char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
+S_my_langinfo_i(pTHX_ const int item, const locale_category_index cat_index, const char *locale, char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
 #     define PERL_ARGS_ASSERT_MY_LANGINFO_I     \
         assert(locale); assert(retbufp)
 
@@ -7143,12 +7143,12 @@ S_get_LC_ALL_display(pTHX);
 #   endif
 #   if defined(USE_POSIX_2008_LOCALE)
 STATIC bool
-S_bool_setlocale_2008_i(pTHX_ const unsigned int index, const char *new_locale, const line_t caller_line);
+S_bool_setlocale_2008_i(pTHX_ const locale_category_index index, const char *new_locale, const line_t caller_line);
 #     define PERL_ARGS_ASSERT_BOOL_SETLOCALE_2008_I \
         assert(new_locale)
 
 STATIC const char *
-S_querylocale_2008_i(pTHX_ const unsigned int index, const line_t line);
+S_querylocale_2008_i(pTHX_ const locale_category_index index, const line_t line);
 #     define PERL_ARGS_ASSERT_QUERYLOCALE_2008_I
 
 STATIC locale_t
@@ -7157,7 +7157,7 @@ S_use_curlocale_scratch(pTHX);
 
 #     if !defined(USE_QUERYLOCALE)
 STATIC void
-S_update_PL_curlocales_i(pTHX_ const unsigned int index, const char *new_locale, const line_t caller_line);
+S_update_PL_curlocales_i(pTHX_ const locale_category_index index, const char *new_locale, const line_t caller_line);
 #       define PERL_ARGS_ASSERT_UPDATE_PL_CURLOCALES_I \
         assert(new_locale)
 
@@ -7200,7 +7200,7 @@ S_wrap_wsetlocale(pTHX_ const int category, const char *locale);
 #   if   defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) || \
        ( defined(USE_POSIX_2008_LOCALE) && !defined(USE_QUERYLOCALE) )
 STATIC const char *
-S_find_locale_from_environment(pTHX_ const unsigned int index);
+S_find_locale_from_environment(pTHX_ const locale_category_index index);
 #     define PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT
 
 #   endif


### PR DESCRIPTION
Knowing that the domain is just a few values can lead the compiler to generate better code, and to catch programmer errors.

This also creates #defines for the interior of a C 'for' loop header, which I think are more readable.