### PR TITLE
fix handling of single-value anonhash { $foo }

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -6025,15 +6025,14 @@ PP(pp_anonhash)
     SV* const retval = (PL_op->op_flags & OPf_SPECIAL)
                                     ? newRV_noinc(MUTABLE_SV(hv))
                                     : MUTABLE_SV(hv);
-    /* This isn't quite true for an odd sized list (it's one too few) but it's
-       not worth the runtime +1 just to optimise for the warning case. */
-    SSize_t pairs = (PL_stack_sp - MARK) >> 1;
+    /* + 1 because a lone scalar {FOO} counts as a {FOO => undef} pair */
+    const SSize_t pairs = (PL_stack_sp - MARK + 1) >> 1;
 
     /* temporarily save the hv/hvref at the top of the stack to
      * avoid possible premature free */
     rpp_extend(1);
     rpp_push_1_norc(retval);
-    mark = ORIGMARK; /* in case stack was reallocated */
+    MARK = ORIGMARK; /* in case stack was reallocated */
 
     if (pairs == 0)
         return NORMAL;

--- a/t/op/hashwarn.t
+++ b/t/op/hashwarn.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc( qw(. ../lib) );
 }
 
-plan( tests => 18 );
+plan( tests => 20 );
 
 use strict;
 use warnings;
@@ -49,6 +49,12 @@ my $fail_not_hr   = 'Not a HASH reference at ';
     %hash = sub { print "fenice" };
     cmp_ok(scalar(@warnings),'==',1,'coderef count');
     cmp_ok(substr($warnings[0],0,length($fail_odd)),'eq',$fail_odd,'coderef msg');
+
+    # GH #21478
+    @warnings = ();
+    my $hashref = { 1 };
+    is(scalar(@warnings), 1, 'anon singleton count');
+    is(substr($warnings[0], 0, length($fail_odd_anon)), $fail_odd_anon, 'anon singleton msg');
 
     @warnings = ();
     $_ = { 1..10 };

--- a/t/op/ref.t
+++ b/t/op/ref.t
@@ -8,7 +8,7 @@ BEGIN {
 
 use strict qw(refs subs);
 
-plan(254);
+plan(257);
 
 # Test this first before we extend the stack with other operations.
 # This caused an asan failure due to a bad write past the end of the stack.
@@ -259,6 +259,13 @@ like (*STDOUT{IO}, qr/^IO::File=IO\(0x[0-9a-f]+\)$/,
 
 $anonhash = {};
 is (ref $anonhash, 'HASH');
+
+# GH #21478
+$anonhash = { 'one' };
+is scalar keys %$anonhash, 1, 'single value in anonhash creates a key (count)';
+ok exists $anonhash->{one},   'single value in anonhash creates a key (existence)';
+is $anonhash->{one}, undef,   'single value in anonhash creates a key (value)';
+
 $anonhash2 = {FOO => 'BAR', ABC => 'XYZ',};
 is (join('', sort values %$anonhash2), 'BARXYZ');
 


### PR DESCRIPTION
An early exit in pp_anonhash (added in 7a607afee585e60ce329b) inadvertently made `{ $foo }` behave like `{}`; i.e. a hashref constructor containing a single value ended up returning a reference to an empty hash (and did not emit an "Odd number of elements in anonymous hash" warning).

Fixes #21478.