### PR TITLE
ExtUtils::CBuilder Windows simplification addendum

### DIFF
--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
@@ -205,7 +205,13 @@ sub have_compiler {
     print $FH q<namespace Bogus { extern "C" int boot_compilet() { return 1; } };> . "\n";
   }
   else {
-    print $FH "int boot_compilet(void) { return 1; }\n";
+    # Use extern "C" if "cc" was set to a C++ compiler.
+    print $FH <<EOF;
+#ifdef __cplusplus
+extern "C"
+#endif
+int boot_compilet(void) { return 1; }
+EOF
   }
   close $FH;
 

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
@@ -202,7 +202,7 @@ sub have_compiler {
   binmode $FH;
 
   if ( $is_cplusplus ) {
-    print $FH "class Bogus { public: int boot_compilet() { return 1; } };\n";
+    print $FH q<namespace Bogus { extern "C" int boot_compilet() { return 1; } };> . "\n";
   }
   else {
     print $FH "int boot_compilet(void) { return 1; }\n";

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/GCC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/GCC.pm
@@ -47,23 +47,14 @@ sub format_linker_cmd {
     $path = "-L$path";
   }
 
-  my @cmds; # Stores the series of commands needed to build the module.
-
-  my $DLLTOOL = $cf->{dlltool} || 'dlltool';
-
-  push @cmds, [
-    $DLLTOOL, '--def'        , $spec{def_file},
-              '--output-exp' , $spec{explib}
-  ];
-
   # split off any -arguments included in ld
   my @ld = split / (?=-)/, $spec{ld};
 
-  push @cmds, [ grep {defined && length} (
+  return [ grep {defined && length} (
     @ld                       ,
+    $spec{def_file}           ,
     '-o', $spec{output}       ,
     "-Wl,--enable-auto-image-base" ,
-	'-Wl,--export-all-symbols',
     @{$spec{lddlflags}}       ,
     @{$spec{libpath}}         ,
     @{$spec{startup}}         ,
@@ -71,11 +62,8 @@ sub format_linker_cmd {
     @{$spec{other_ldflags}}   ,
     $spec{libperl}            ,
     @{$spec{perllibs}}        ,
-    $spec{explib}             ,
     $spec{map_file} ? ('-Map', $spec{map_file}) : ''
   ) ];
-
-  return @cmds;
 }
 
 sub write_linker_script {

--- a/dist/ExtUtils-CBuilder/t/03-cplusplus.t
+++ b/dist/ExtUtils-CBuilder/t/03-cplusplus.t
@@ -33,7 +33,7 @@ ok $b->have_cplusplus, "have_cplusplus";
 $source_file = File::Spec->catfile('t', 'cplust.cc');
 {
   open my $FH, '>', $source_file or die "Can't create $source_file: $!";
-  print $FH "class Bogus { public: int boot_cplust() { return 1; } };\n";
+  print $FH q<namespace Bogus { extern "C" int boot_cplust() { return 1; } };> . "\n";
   close $FH;
 }
 ok -e $source_file, "source file '$source_file' created";


### PR DESCRIPTION
This adds on top of @Leont's <https://github.com/Perl/perl5/pull/21450>.

It should also address <https://github.com/Perl/perl5/issues/21479>.

The commit at e5816fd57f863475789acadb86c2bba2b3656f09 is not ideal as `ExtUtils::CppGuess` should be set up to do C++ compilation a different way or somehow indicate to `Module::Build` that a C++ compiler is needed (is whether the build is C or C++ currently all dependent on the file extensions?). CC: @mohawk2 