### PR TITLE
do_join(): Take a copy of delimiter string (fixes #21458)

### DIFF
--- a/doop.c
+++ b/doop.c
@@ -699,16 +699,18 @@ Perl_do_join(pTHX_ SV *sv, SV *delim, SV **mark, SV **sp)
     }
 
     if (delimlen) {
+        bool delim_copied = false;
         const U32 delimflag = DO_UTF8(delim) ? SV_CATUTF8 : SV_CATBYTES;
         for (; items > 0; items--,mark++) {
             STRLEN len;
             const char *s;
-            if(*mark == delim) {
+            if(*mark == delim && !delim_copied) {
                 /* Take a copy in case delim SV is a tied SV with a
                  * self-modifying FETCH [GH #21458]
                  */
                 delims = savepvn(delims, delimlen);
                 SAVEFREEPV(delims);
+                delim_copied = true;
             }
             sv_catpvn_flags(sv,delims,delimlen,delimflag);
             s = SvPV_const(*mark,len);

--- a/doop.c
+++ b/doop.c
@@ -662,7 +662,7 @@ Perl_do_join(pTHX_ SV *sv, SV *delim, SV **mark, SV **sp)
     I32 items = sp - mark;
     STRLEN len;
     STRLEN delimlen;
-    const char * delims = SvPV_const(delim, delimlen);
+    const char * delimpv = SvPV_const(delim, delimlen);
 
     PERL_ARGS_ASSERT_DO_JOIN;
 
@@ -708,11 +708,11 @@ Perl_do_join(pTHX_ SV *sv, SV *delim, SV **mark, SV **sp)
                 /* Take a copy in case delim SV is a tied SV with a
                  * self-modifying FETCH [GH #21458]
                  */
-                delims = savepvn(delims, delimlen);
-                SAVEFREEPV(delims);
+                delimpv = savepvn(delimpv, delimlen);
+                SAVEFREEPV(delimpv);
                 delim_copied = true;
             }
-            sv_catpvn_flags(sv,delims,delimlen,delimflag);
+            sv_catpvn_flags(sv,delimpv,delimlen,delimflag);
             s = SvPV_const(*mark,len);
             sv_catpvn_flags(sv,s,len,
                             DO_UTF8(*mark) ? SV_CATUTF8 : SV_CATBYTES);

--- a/doop.c
+++ b/doop.c
@@ -662,7 +662,7 @@ Perl_do_join(pTHX_ SV *sv, SV *delim, SV **mark, SV **sp)
     I32 items = sp - mark;
     STRLEN len;
     STRLEN delimlen;
-    const char * const delims = SvPV_const(delim, delimlen);
+    const char * delims = SvPV_const(delim, delimlen);
 
     PERL_ARGS_ASSERT_DO_JOIN;
 
@@ -703,6 +703,13 @@ Perl_do_join(pTHX_ SV *sv, SV *delim, SV **mark, SV **sp)
         for (; items > 0; items--,mark++) {
             STRLEN len;
             const char *s;
+            if(*mark == delim) {
+                /* Take a copy in case delim SV is a tied SV with a
+                 * self-modifying FETCH [GH #21458]
+                 */
+                delims = savepvn(delims, delimlen);
+                SAVEFREEPV(delims);
+            }
             sv_catpvn_flags(sv,delims,delimlen,delimflag);
             s = SvPV_const(*mark,len);
             sv_catpvn_flags(sv,s,len,


### PR DESCRIPTION
In case FETCH on a tied scalar attempts to modify it

Fixes #21458