### PR TITLE
Remove non-null checks before op_free()

### DIFF
--- a/class.c
+++ b/class.c
@@ -800,9 +800,7 @@ Perl_class_seal_stash(pTHX_ HV *stash)
         if (fieldnames) {
             for(SSize_t i = PadnamelistMAX(fieldnames); i >= 0 ; i--) {
                 PADNAME *pn = PadnamelistARRAY(fieldnames)[i];
-                OP *valop = PadnameFIELDINFO(pn)->defop;
-                if (valop)
-                    op_free(valop);
+                op_free(PadnameFIELDINFO(pn)->defop);
             }
         }
     }
@@ -1022,8 +1020,7 @@ Perl_class_set_field_defop(pTHX_ PADNAME *pn, OPCODE defmode, OP *defop)
 
     assert(HvSTASH_IS_CLASS(PL_curstash));
 
-    if(PadnameFIELDINFO(pn)->defop)
-        op_free(PadnameFIELDINFO(pn)->defop);
+    op_free(PadnameFIELDINFO(pn)->defop);
 
     /* set here to ensure clean up if forbid_outofblock_ops() throws */
     PadnameFIELDINFO(pn)->defop = defop;

--- a/op.c
+++ b/op.c
@@ -3998,10 +3998,8 @@ S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV * name,
                         Perl_warner(aTHX_ packWARN(WARN_MISC),
                             "Attribute prototype(%" UTF8f ") discards earlier prototype attribute in same sub",
                             UTF8fARG(SvUTF8(cSVOPo_sv), new_len, newp));
-                        op_free(new_proto);
                     }
-                    else if (new_proto)
-                        op_free(new_proto);
+                    op_free(new_proto);
                     new_proto = o;
                     /* excise new_proto from the list */
                     op_sibling_splice(*attrs, lasto, 1, NULL);
@@ -4051,8 +4049,7 @@ S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV * name,
                 UTF8fARG(SvUTF8(cSVOPx_sv(new_proto)), new_len, newp),
                 SVfARG(svname));
         }
-        if (*proto)
-            op_free(*proto);
+        op_free(*proto);
         *proto = new_proto;
     }
 }
@@ -12316,8 +12313,7 @@ Perl_ck_trycatch(pTHX_ OP *o)
 
     /* cut whole sibling chain free from o */
     op_sibling_splice(o, NULL, -1, NULL);
-    if(to_free)
-        op_free(to_free);
+    op_free(to_free);
     op_free(o);
 
     enter = alloc_LOGOP(OP_ENTERTRYCATCH, NULL, NULL);

--- a/perl.c
+++ b/perl.c
@@ -1903,10 +1903,9 @@ perl_parse(pTHXx_ XSINIT_t xsinit, int argc, char **argv, char **env)
         return 0;
     }
 
-    if (PL_main_root) {
-        op_free(PL_main_root);
-        PL_main_root = NULL;
-    }
+    op_free(PL_main_root);
+    PL_main_root = NULL;
+
     PL_main_start = NULL;
     SvREFCNT_dec(PL_main_cv);
     PL_main_cv = NULL;

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4112,10 +4112,10 @@ S_doeval_compile(pTHX_ U8 gimme, CV* outside, U32 seq, HV *hh)
 
             if (!in_require)
                 invoke_exception_hook(ERRSV,FALSE);
-            if (PL_eval_root) {
-                op_free(PL_eval_root);
-                PL_eval_root = NULL;
-            }
+
+            op_free(PL_eval_root);
+            PL_eval_root = NULL;
+
             rpp_popfree_to(PL_stack_base + POPMARK); /* pop original mark */
             cx = CX_CUR();
             assert(CxTYPE(cx) == CXt_EVAL);

--- a/toke.c
+++ b/toke.c
@@ -6162,8 +6162,7 @@ yyl_colon(pTHX_ char *s)
             if (*d == '(') {
                 d = scan_str(d,TRUE,TRUE,FALSE,NULL);
                 if (!d) {
-                    if (attrs)
-                        op_free(attrs);
+                    op_free(attrs);
                     ASSUME(sv && SvREFCNT(sv) == 1);
                     SvREFCNT_dec(sv);
                     Perl_croak(aTHX_ "Unterminated attribute parameter in attribute list");
@@ -6211,8 +6210,7 @@ yyl_colon(pTHX_ char *s)
                       ? Perl_form(aTHX_ "Invalid separator character "
                                   "%c%c%c in attribute list", q, *s, q)
                       : "Unterminated attribute list" ) );
-            if (attrs)
-                op_free(attrs);
+            op_free(attrs);
             OPERATOR(PERLY_COLON);
         }
 
@@ -6220,8 +6218,7 @@ yyl_colon(pTHX_ char *s)
         if (PL_parser->sig_seen) {
             /* see comment about about sig_seen and parser error
              * handling */
-            if (attrs)
-                op_free(attrs);
+            op_free(attrs);
             Perl_croak(aTHX_ "Subroutine attributes must come "
                              "before the signature");
         }


### PR DESCRIPTION
The argument to op_free() is declared NULLOK, and the first thing it does is return if the op is null or already freed, so there's no point in callers checking for it.