### PR TITLE
smartmatch: $obj ~~ $scalar: one item in list cxt

### DIFF
--- a/lib/overload.t
+++ b/lib/overload.t
@@ -71,7 +71,7 @@ package main;
 
 $| = 1;
 BEGIN { require './test.pl'; require './charset_tools.pl' }
-plan tests => 5363;
+plan tests => 5367;
 
 use Scalar::Util qw(tainted);
 
@@ -3227,4 +3227,30 @@ package RT33789 {
         my $result = '1' . ( '2' . ( '3' . ( '4' . ( '5' . $o ) ) ) );
     }
     ::is($destroy, 1, "RT #133789: delayed destroy");
+}
+
+# GH #21477: with an overloaded object $obj, ($obj ~~ $scalar) wasn't
+# popping the original args off the stack. So in list context, rather than
+# returning (Y/N), it was returning ($obj, $scalar, Y/N)
+
+
+package GH21477 {
+    use overload
+        '""'  => sub { $_[0][0]; },
+        '~~'  => sub { $_[0][0] eq $_[1] },
+        'eq'  => sub { $_[0][0] eq $_[1] },
+    ;
+
+    my $o = bless ['cat'];
+
+    # smartmatch is deprecated and will be removed in 5.042
+    no warnings 'deprecated';
+
+    my @result = ($o ~~ 'cat');
+    ::is(scalar(@result), 1, "GH #21477: return one arg");
+    ::is($result[0], 1, "GH #21477: return true");
+
+    @result = ($o ~~ 'dog');
+    ::is(scalar(@result), 1, "GH #21477: return one arg - part 2");
+    ::is($result[0], "", "GH #21477: return false");
 }

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -6173,7 +6173,6 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
         SV *tmpsv;
         DEBUG_M(Perl_deb(aTHX_ "    applying rule Object-Any\n"));
         DEBUG_M(Perl_deb(aTHX_ "        attempting overload\n"));
-        rpp_xpush_2(d, e);
         tmpsv = amagic_call(d, e, smart_amg, AMGf_noright);
         if (tmpsv) {
             rpp_replace_2_1(tmpsv);


### PR DESCRIPTION
My recent commit, v5.39.2-101-g987819ee34,
    "make RC-stack-aware: unwrap startmatch [sic] and misc"
introduced a bug which broke Lingua::EN::Inflexion.

This was because the code path for handling overloaded objects of the form ($obj ~~ $scalar) was re-pushing the original args onto the stack before calling the overload method, which was unnecessary. This meant that in list context, rather than returning the one-element list (Y/N), it was returning the three-element list ($obj, $scalar, Y/N).

This commit fixes that.