### PR TITLE
Fix eval in package DB

### DIFF
--- a/cv.h
+++ b/cv.h
@@ -129,7 +129,7 @@ See L<perlguts/Autoloading with XSUBs>.
 #endif
 #define CVf_DYNFILE	0x1000	/* The filename is malloced  */
 #define CVf_AUTOLOAD	0x2000	/* SvPVX contains AUTOLOADed sub name  */
-#define CVf_HASEVAL	0x4000	/* contains string eval  */
+/* 0x4000 previously CVf_HASEVAL  */
 #define CVf_NAMED	0x8000  /* Has a name HEK */
 #define CVf_LEXICAL	0x10000 /* Omit package from name */
 #define CVf_ANONCONST	0x20000 /* :const - create anonconst op */
@@ -212,10 +212,6 @@ See L<perlguts/Autoloading with XSUBs>.
 #define CvAUTOLOAD(cv)		(CvFLAGS(cv) & CVf_AUTOLOAD)
 #define CvAUTOLOAD_on(cv)	(CvFLAGS(cv) |= CVf_AUTOLOAD)
 #define CvAUTOLOAD_off(cv)	(CvFLAGS(cv) &= ~CVf_AUTOLOAD)
-
-#define CvHASEVAL(cv)		(CvFLAGS(cv) & CVf_HASEVAL)
-#define CvHASEVAL_on(cv)	(CvFLAGS(cv) |= CVf_HASEVAL)
-#define CvHASEVAL_off(cv)	(CvFLAGS(cv) &= ~CVf_HASEVAL)
 
 #define CvNAMED(cv)		(CvFLAGS(cv) & CVf_NAMED)
 #define CvNAMED_on(cv)		(CvFLAGS(cv) |= CVf_NAMED)

--- a/dump.c
+++ b/dump.c
@@ -1774,7 +1774,6 @@ const struct flag_to_name cv_flags_names[] = {
     {CVf_CVGV_RC, "CVGV_RC,"},
     {CVf_DYNFILE, "DYNFILE,"},
     {CVf_AUTOLOAD, "AUTOLOAD,"},
-    {CVf_HASEVAL, "HASEVAL,"},
     {CVf_SLABBED, "SLABBED,"},
     {CVf_NAMED, "NAMED,"},
     {CVf_LEXICAL, "LEXICAL,"},

--- a/ext/Devel-Peek/t/Peek.t
+++ b/ext/Devel-Peek/t/Peek.t
@@ -364,8 +364,8 @@ do_test('reference to named subroutine without prototype',
   RV = $ADDR
   SV = PVCV\\($ADDR\\) at $ADDR
     REFCNT = (3|4)
-    FLAGS = \\((?:HASEVAL(?:,NAMED)?)?\\)	# $] < 5.015 || !thr
-    FLAGS = \\(DYNFILE(?:,HASEVAL(?:,NAMED)?)?\\) # $] >= 5.015 && thr
+    FLAGS = \\((?:HASEVAL,)?(?:NAMED)?\\)	# $] < 5.015 || !thr
+    FLAGS = \\(DYNFILE(?:,HASEVAL)?(?:,NAMED)?\\) # $] >= 5.015 && thr
     COMP_STASH = $ADDR\\t"main"
     START = $ADDR ===> \\d+
     ROOT = $ADDR
@@ -375,8 +375,8 @@ do_test('reference to named subroutine without prototype',
     DEPTH = 1(?:
     MUTEXP = $ADDR
     OWNER = $ADDR)?
-    FLAGS = 0x(?:[c4]00)?0			# $] < 5.015 || !thr
-    FLAGS = 0x[cd145]000			# $] >= 5.015 && thr
+    FLAGS = 0x(?:[c84]00)?0			# $] < 5.015 || !thr
+    FLAGS = 0x[cd1459]000			# $] >= 5.015 && thr
     OUTSIDE_SEQ = \\d+
     PADLIST = $ADDR
     PADNAME = $ADDR\\($ADDR\\) PAD = $ADDR\\($ADDR\\)

--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -2171,7 +2171,6 @@ my sub g {
     sub f { }
 }
 ####
-# TODO only partially fixed
 # lexical state subroutine with outer declaration and inner definition
 # CONTEXT use feature 'lexical_subs', 'state'; no warnings 'experimental::lexical_subs';
 ();

--- a/pad.c
+++ b/pad.c
@@ -1694,7 +1694,6 @@ Perl_pad_tidy(pTHX_ padtidy_type type)
                     "Pad clone on cv=0x%" UVxf "\n", PTR2UV(cv)));
                 CvCLONE_on(cv);
             }
-            CvHASEVAL_on(cv);
         }
     }
 
@@ -1986,8 +1985,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
     PL_compcv = cv;
     if (newcv) SAVEFREESV(cv); /* in case of fatal warnings */
 
-    if (CvHASEVAL(cv))
-        CvOUTSIDE(cv)	= MUTABLE_CV(SvREFCNT_inc_simple(outside));
+    CvOUTSIDE(cv)	= MUTABLE_CV(SvREFCNT_inc_simple(outside));
 
     SAVESPTR(PL_comppad_name);
     PL_comppad_name = protopad_name;

--- a/t/op/closure.t
+++ b/t/op/closure.t
@@ -687,7 +687,7 @@ $r = \$x
     isnt($s[0], $s[1], "cloneable with //ee");
 }
 
-# [perl #89544]
+# [perl #89544] aka [GH #11286]
 {
    sub trace::DESTROY {
        push @trace::trace, "destroyed";
@@ -711,6 +711,7 @@ $r = \$x
    };
 
    my $inner = $outer2->();
+   local $TODO = "we need outside links for debugger behaviour";
    is "@trace::trace", "destroyed",
       'closures only close over named variables, not entire subs';
 }

--- a/t/op/eval.t
+++ b/t/op/eval.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan(tests => 167);
+plan(tests => 169);
 
 eval 'pass();';
 
@@ -377,6 +377,19 @@ our $x = 1;
     is(DB::db4(),  3);
     is(DB::db5(),  3);
     is(db6(),      4);
+
+    # [GH #19370]
+    local $TODO = "outside not available when needed";
+    my sub d6 {
+        DB::db3();
+    }
+    is(d6(), 3);
+    my $y;
+    my $d7 = sub {
+        $y;
+        DB::db3();
+    };
+    is($d7->(), 3);
 }
 
 # [perl #19022] used to end up with shared hash warnings

--- a/t/op/eval.t
+++ b/t/op/eval.t
@@ -379,7 +379,6 @@ our $x = 1;
     is(db6(),      4);
 
     # [GH #19370]
-    local $TODO = "outside not available when needed";
     my sub d6 {
         DB::db3();
     }


### PR DESCRIPTION
This largely reverts a0d2bbd5c4 and adds a text for the documented behaviour of eval in package DB.

Fixes #19370.

a0d2bbd5c4 was originally added to fix #11286, but it also broke long documented behaviour as reported in #19370 that's used by the debugger.

The original eval-in-DB was implemented by @iabyn 