### PR TITLE
Fix two coverity scan reported issues

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -6538,6 +6538,7 @@ S_ints_to_tm(pTHX_ struct tm * mytm,
      * variables */
 
     /* Override with the passed-in values */
+    Zero(mytm, 1, struct tm);
     mytm->tm_sec = sec;
     mytm->tm_min = min;
     mytm->tm_hour = hour;

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -320,7 +320,7 @@ S_regdump_intflags(pTHX_ const char *lead, const U32 flags)
 
     ASSUME(REG_INTFLAGS_NAME_SIZE <= sizeof(flags)*8);
 
-    for (bit=0; bit<=REG_INTFLAGS_NAME_SIZE; bit++) {
+    for (bit=0; bit < REG_INTFLAGS_NAME_SIZE; bit++) {
         if (flags & (1<<bit)) {
             if (!set++ && lead)
                 Perl_re_printf( aTHX_  "%s", lead);

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -318,7 +318,7 @@ S_regdump_intflags(pTHX_ const char *lead, const U32 flags)
     int bit;
     int set=0;
 
-    ASSUME(REG_INTFLAGS_NAME_SIZE <= sizeof(flags)*8);
+    STATIC_ASSERT_STMT(REG_INTFLAGS_NAME_SIZE <= sizeof(flags) * CHARBITS);
 
     for (bit=0; bit < REG_INTFLAGS_NAME_SIZE; bit++) {
         if (flags & (1<<bit)) {
@@ -342,7 +342,7 @@ S_regdump_extflags(pTHX_ const char *lead, const U32 flags)
     int set=0;
     regex_charset cs;
 
-    ASSUME(REG_EXTFLAGS_NAME_SIZE <= sizeof(flags)*8);
+    STATIC_ASSERT_STMT(REG_EXTFLAGS_NAME_SIZE <= sizeof(flags) * CHARBITS);
 
     for (bit=0; bit<REG_EXTFLAGS_NAME_SIZE; bit++) {
         if (flags & (1U<<bit)) {


### PR DESCRIPTION
1) a loop with an off-by-one ending index

2) uninitialized structure members being passed along to standard library functions