### PR TITLE
Remove pointless use-after-free assert

### DIFF
--- a/class.c
+++ b/class.c
@@ -703,7 +703,6 @@ Perl_class_seal_stash(pTHX_ HV *stash)
                 /* have to clear the OPf_KIDS flag or op_free() will get upset */
                 valop->op_flags &= ~OPf_KIDS;
                 op_free(valop);
-                assert(valop->op_type == OP_FREED);
 
                 OP *fieldcop = o;
                 assert(fieldcop->op_type == OP_NEXTSTATE || fieldcop->op_type == OP_DBSTATE);


### PR DESCRIPTION
While op_free() doesn't actually free the op, but adds it to the slab's freelist and marks it as freed, that's not obvious when reading the code. Also, if op_free() fails to do its job, we have bigger problems than just here.