### PR TITLE
`t`: Convert indirect `Config` syntax in core's tests

### DIFF
--- a/t/TEST
+++ b/t/TEST
@@ -938,7 +938,7 @@ SHRDLU_1
 ###   ./perl harness
 ### in the 't' directory since most (>=80%) of the tests succeeded.
 SHRDLU_2
-	if (eval {require Config; import Config; 1}) {
+	if (eval {require Config; Config->import; 1}) {
 	    if ($::Config{usedl} && (my $p = $::Config{ldlibpthname})) {
 		warn <<SHRDLU_3;
 ### You may have to set your dynamic library search path,

--- a/t/io/errnosig.t
+++ b/t/io/errnosig.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc( qw(. ../lib) );
 }
 
-require Config; import Config;
+require Config; Config->import;
 plan(tests => 1);
 
 SKIP: {

--- a/t/io/msg.t
+++ b/t/io/msg.t
@@ -5,7 +5,7 @@ BEGIN {
 
   require "./test.pl";
   set_up_inc( '../lib' ) if -d '../lib' && -d '../ext';
-  require Config; import Config;
+  require Config; Config->import;
 
   if ($ENV{'PERL_CORE'} && $Config{'extensions'} !~ m[\bIPC/SysV\b]) {
     skip_all('-- IPC::SysV was not built');

--- a/t/io/perlio.t
+++ b/t/io/perlio.t
@@ -2,7 +2,7 @@ BEGIN {
 	chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib');
-	require Config; import Config;
+	require Config; Config->import;
 	skip_all_without_perlio();
 }
 

--- a/t/io/pipe.t
+++ b/t/io/pipe.t
@@ -4,7 +4,7 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib');
-    require Config; import Config;
+    require Config; Config->import;
 }
 if (!$Config{'d_fork'}) {
     skip_all("fork required to pipe");

--- a/t/io/sem.t
+++ b/t/io/sem.t
@@ -5,7 +5,7 @@ BEGIN {
 
   require "./test.pl";
   set_up_inc( '../lib' ) if -d '../lib' && -d '../ext';
-  require Config; import Config;
+  require Config; Config->import;
 
   if ($ENV{'PERL_CORE'} && $Config{'extensions'} !~ m[\bIPC/SysV\b]) {
     skip_all('-- IPC::SysV was not built');

--- a/t/io/semctl.t
+++ b/t/io/semctl.t
@@ -3,7 +3,7 @@ BEGIN {
   @INC = '../lib' if -d '../lib' && -d '../ext';
 
   require "./test.pl";
-  require Config; import Config;
+  require Config; Config->import;
 }
 
 use strict;

--- a/t/io/shm.t
+++ b/t/io/shm.t
@@ -20,7 +20,7 @@ BEGIN {
   require "./test.pl";
   set_up_inc('../lib') if -d '../lib' && -d '../ext';
 
-  require Config; import Config;
+  require Config; Config->import;
 
   if ($ENV{'PERL_CORE'} && $Config{'extensions'} !~ m[\bIPC/SysV\b]) {
     skip_all('-- IPC::SysV was not built');

--- a/t/io/socket.t
+++ b/t/io/socket.t
@@ -7,7 +7,7 @@ BEGIN {
 
     require "./test.pl";
     set_up_inc( '../lib' ) if -d '../lib' && -d '../ext';
-    require Config; import Config;
+    require Config; Config->import;
 
     skip_all_if_miniperl();
     for my $needed (qw(d_socket d_getpbyname)) {

--- a/t/io/socketpair.t
+++ b/t/io/socketpair.t
@@ -4,7 +4,7 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib');
-    require Config; import Config;
+    require Config; Config->import;
     skip_all_if_miniperl();
     for my $needed (qw(d_socket)) {
 	if ($Config{$needed} ne 'define') {

--- a/t/lib/commonsense.t
+++ b/t/lib/commonsense.t
@@ -8,7 +8,7 @@ BEGIN {
 
 plan( tests => 1);
 
-require Config; import Config;
+require Config; Config->import;
 
 if (($Config{'extensions'} !~ /\bFcntl\b/) ){
   BAIL_OUT("Perl configured without Fcntl module");

--- a/t/op/grent.t
+++ b/t/op/grent.t
@@ -11,7 +11,7 @@ if ($@ =~ /(The \w+ function is unimplemented)/) {
     skip_all "getgrgid unimplemented";
 }
 
-eval { require Config; import Config; };
+eval { require Config; Config->import; };
 my $reason;
 if ($Config{'i_grp'} ne 'define') {
 	$reason = '$Config{i_grp} not defined';

--- a/t/op/quotemeta.t
+++ b/t/op/quotemeta.t
@@ -4,7 +4,7 @@ BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
     set_up_inc(  qw(../lib .) );
-    require Config; import Config;
+    require Config; Config->import;
     require "./loc_tools.pl";
 }
 

--- a/t/perf/speed.t
+++ b/t/perf/speed.t
@@ -23,7 +23,7 @@ $| = 1;
 BEGIN {
     chdir 't' if -d 't';
     @INC = ('../lib');
-    require Config; import Config;
+    require Config; Config->import;
     require './test.pl';
 }
 

--- a/t/perf/taint.t
+++ b/t/perf/taint.t
@@ -17,7 +17,7 @@
 BEGIN {
     chdir 't' if -d 't';
     @INC = ('../lib');
-    require Config; import Config;
+    require Config; Config->import;
     require './test.pl';
     skip_all_if_miniperl("No Scalar::Util under miniperl");
     if (exists($Config{taint_support}) && !$Config{taint_support}) {

--- a/t/re/anyof.t
+++ b/t/re/anyof.t
@@ -16,7 +16,7 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib','.','../ext/re');
-    require Config; import Config;
+    require Config; Config->import;
     skip_all('no re module') unless defined &DynaLoader::boot_DynaLoader;
 }
 

--- a/t/re/fold_grind.pl
+++ b/t/re/fold_grind.pl
@@ -12,7 +12,7 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib');
-    require Config; import Config;
+    require Config; Config->import;
     skip_all_if_miniperl("no dynamic loading on miniperl, no Encode nor POSIX");
     if ($^O eq 'dec_osf') {
       skip_all("$^O cannot handle this test");

--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -18,7 +18,7 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib', '.', '../ext/re');
-    require Config; import Config;
+    require Config; Config->import;
     require './charset_tools.pl';
     require './loc_tools.pl';
 }

--- a/t/re/speed.t
+++ b/t/re/speed.t
@@ -18,7 +18,7 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib','.','../ext/re');
-    require Config; import Config;
+    require Config; Config->import;
 }
 
 skip_all('no re module') unless defined &DynaLoader::boot_DynaLoader;

--- a/t/re/stclass_threads.t
+++ b/t/re/stclass_threads.t
@@ -15,7 +15,7 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib', '.', '../ext/re');
-    require Config; import Config;
+    require Config; Config->import;
 }
 
 skip_all_without_config('useithreads');

--- a/t/re/subst.t
+++ b/t/re/subst.t
@@ -4,7 +4,7 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib');
-    require Config; import Config;
+    require Config; Config->import;
     require constant;
     constant->import(constcow => *Config::{NAME});
     require './charset_tools.pl';

--- a/t/run/runenv.t
+++ b/t/run/runenv.t
@@ -7,7 +7,7 @@
 BEGIN {
     chdir 't' if -d 't';
     @INC = '../lib';
-    require Config; import Config;
+    require Config; Config->import;
     require './test.pl';
     skip_all_without_config('d_fork');
 }

--- a/t/run/switchM.t
+++ b/t/run/switchM.t
@@ -4,7 +4,7 @@ BEGIN {
     chdir 't' if -d 't';
     @INC = '../lib';
     require Config;
-    import Config;
+    Config->import;
 
 }
 use strict;

--- a/t/run/switches.t
+++ b/t/run/switches.t
@@ -7,7 +7,7 @@
 BEGIN {
     chdir 't' if -d 't';
     @INC = '../lib';
-    require Config; import Config;
+    require Config; Config->import;
 }
 
 BEGIN { require "./test.pl";  require "./loc_tools.pl"; }

--- a/t/uni/fold.t
+++ b/t/uni/fold.t
@@ -10,7 +10,7 @@ BEGIN {
     set_up_inc('../lib');
     skip_all_without_unicode_tables();
     skip_all_if_miniperl("miniperl, no Unicode::Normalize");
-    require Config; import Config;
+    require Config; Config->import;
     require './charset_tools.pl';
     require './loc_tools.pl';   # Contains find_utf8_ctype_locale()
 }

--- a/t/uni/overload.t
+++ b/t/uni/overload.t
@@ -4,7 +4,7 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc( '../lib' );
-    require Config; import Config;
+    require Config; Config->import;
     require './charset_tools.pl';
     require './loc_tools.pl';
 }

--- a/t/win32/runenv.t
+++ b/t/win32/runenv.t
@@ -8,7 +8,7 @@
 BEGIN {
     chdir 't' if -d 't';
     @INC = '../lib';
-    require Config; import Config;
+    require Config; Config->import;
     require File::Temp; import File::Temp qw/:POSIX/;
 
     require Win32;


### PR DESCRIPTION
We have a lot of lines throughout the distribution with this particular indirect object notation.

This PR deals with the tests in `t/` directory which includes core files only.

Convert:

```perl
require Config; import Config;
```

To:

```perl
require Config; Config->import;
```

---

Two test files are excluded in this PR:

- `t/op/lc.t`: Unicode encoding issues 
- `t/re/bigfuzzy.t`: Binary data issues 
