### PR TITLE
Document that U<text> is the formatting code for underline

### DIFF
--- a/pod/perlpod.pod
+++ b/pod/perlpod.pod
@@ -380,6 +380,13 @@ Used for switches ("C<perl's BE<lt>-nE<gt> switch>"), programs
 emphasis ("C<be BE<lt>careful!E<gt>>"), and so on
 ("C<and that feature is known as BE<lt>autovivificationE<gt>>").
 
+=item C<UE<lt>textE<gt>> -- underline text
+
+This is a new addition in 2024 and may not be available in all processors or
+output formats.  Note further that some output formats cannot produce both
+italic and underline formatting and therefore even if both are recognised,
+they may not be visually distinct from each other.
+
 =item C<CE<lt>codeE<gt>> -- code text
 X<C> X<< CZ<><> >> X<POD, formatting code, code> X<code>
 

--- a/pod/perlpodspec.pod
+++ b/pod/perlpodspec.pod
@@ -467,6 +467,12 @@ See the brief discussion in L<perlpod/"Formatting Codes">.
 
 See the brief discussion in L<perlpod/"Formatting Codes">.
 
+=item C<UE<lt>textE<gt>> -- underline text
+
+See the brief discussion in L<perlpod/"Formatting Codes">.
+
+This was added in 2024 and might not be supported on all Pod parsers.
+
 =item C<CE<lt>codeE<gt>> -- code text
 
 See the brief discussion in L<perlpod/"Formatting Codes">.


### PR DESCRIPTION
It's been so long since anyone last altered the POD spec that I don't know if we even remember what the process is any more.

https://www.nntp.perl.org/group/perl.perl5.porters/2023/09/msg267057.html
https://www.nntp.perl.org/group/perl.pod-people/2023/09/msg2146.html

I'm attempting to move things forward a bit by adding some new features; I thought I'd start with something relatively small and simple here, in the hope that if we start by accepting changes to the `perlpod.pod` document first, then implementors can go and create things.

Here then is a suggestion that `U<...>` be added alongside `B<>` for bold and `I<>` for italic, which seems about the smallest simplest change we could think of.

Most of the Pod-related infrastructure in core perl is actually CPAN-first dual-life from `Pod-Simple` and similar, so there isn't really any code that can yet be altered along with this. I therefore feel that simply adding it to the spec is the first step towards making it into reality, and then proceed to implement it in the CPAN modules. While I wasn't able to implement anything for core perl to support this, I have successfully added it to a CPAN distribution of mine, and thus at least confirmed it simple enough to implement.

https://metacpan.org/pod/App::sdview::Parser::Pod
https://metacpan.org/pod/App::sdview::Output::Pod

This is a test of the process. If successful, I hope to open more discussions around other ideas; such as language-tagged code fences, tables, and maybe even a way to specify images.