### PR TITLE
Avoid build-time warning

### DIFF
--- a/ext/XS-Typemap/Typemap.pm
+++ b/ext/XS-Typemap/Typemap.pm
@@ -34,7 +34,7 @@ to the test script.
 use parent qw/ Exporter /;
 require XSLoader;
 
-our $VERSION = '0.19';
+our $VERSION = '0.20';
 
 our @EXPORT = (qw/
 	   T_SV

--- a/ext/XS-Typemap/Typemap.xs
+++ b/ext/XS-Typemap/Typemap.xs
@@ -917,7 +917,7 @@ T_ARRAY( dummy, array, ... )
  PREINIT:
   U32 size_RETVAL;
  CODE:
-  dummy += 0; /* Fix -Wall */
+  PERL_UNUSED_VAR(dummy); /* GH 21505 */
   size_RETVAL = ix_array;
   RETVAL = array;
  OUTPUT:


### PR DESCRIPTION
Compiling with clang-14, a statement in ext/XS-Typemap/Typemap.xs, once compiled to Typemap.c, was emitting a previously unobserved '-Wunused-but-set-variable' build-time warning.  This kludge suppresses that warning.

Change to Typemap.xs requires bumping $VERSION in Typemap.pm.

Fixes #21505