### PR TITLE
perlre: remove statement suggesting /p is a no-op

### DIFF
--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -1344,8 +1344,7 @@ and C<$'>, B<except> that they are only guaranteed to be defined after a
 successful match that was executed with the C</p> (preserve) modifier.
 The use of these variables incurs no global performance penalty, unlike
 their punctuation character equivalents, however at the trade-off that you
-have to tell perl when you want to use them.  As of Perl 5.20, these three
-variables are equivalent to C<$`>, C<$&> and C<$'>, and C</p> is ignored.
+have to tell perl when you want to use them.
 X</p> X<p modifier>
 
 =head2 Quoting metacharacters

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -1142,7 +1142,7 @@ compiled or executed with the C</p> modifier.
 
 This is similar to C<$&> (C<$MATCH>) except that to use it you must
 use the C</p> modifier when executing the pattern, and it does not incur
-and performance penalty associated with that variable.
+the performance penalty associated with that variable.
 
 See L</Performance issues> above.
 
@@ -1173,7 +1173,7 @@ executed with the C</p> modifier.
 
 This is similar to C<$`> ($PREMATCH) except that to use it you must
 use the C</p> modifier when executing the pattern, and it does not incur
-and performance penalty associated with that variable.
+the performance penalty associated with that variable.
 
 See L</Performance issues> above.
 
@@ -1209,7 +1209,7 @@ compiled or executed with the C</p> modifier.
 
 This is similar to C<$'> (C<$POSTMATCH>) except that to use it you must
 use the C</p> modifier when executing the pattern, and it does not incur
-and performance penalty associated with that variable.
+the performance penalty associated with that variable.
 
 See L</Performance issues> above.
 


### PR DESCRIPTION
Perl's documentation used to say that /p became a no-op starting in v5.20.0 and all regexes would now set ${^PREMATCH}, ${^MATCH}, and ${^POSTMATCH}. This is not the case.

This wording was removed from perlvar in commit 60c52570a7183b5ef7, but a similar sentence in perlre was missed.

This commit removes the erroneous statement from perlre and changes "and performance penalty" to "the performance penalty" in perlvar, which looks like a typo that got copy/pasted around.