### PR TITLE
say that `ord` returns code points

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -5196,9 +5196,9 @@ X<ord> X<encoding>
 
 =item ord
 
-=for Pod::Functions find a character's numeric representation
+=for Pod::Functions find a character's code point
 
-Returns the numeric value of the first character of EXPR.
+Returns the code point of the first character of EXPR.
 If EXPR is an empty string, returns 0.  If EXPR is omitted, uses
 L<C<$_>|perlvar/$_>.
 (Note I<character>, not byte.)


### PR DESCRIPTION
all the other uses of "numeric value" are in the `atoi` sense, where "numeric value" of '1' is 1, but `ord('1')` is 49; "code point" is more correct/precise, and already used in many places