### PR TITLE
Remove PL_underlying_numeric_obj

### DIFF
--- a/embedvar.h
+++ b/embedvar.h
@@ -330,7 +330,6 @@
 # define PL_top_env                             (vTHX->Itop_env)
 # define PL_toptarget                           (vTHX->Itoptarget)
 # define PL_TR_SPECIAL_HANDLING_UTF8            (vTHX->ITR_SPECIAL_HANDLING_UTF8)
-# define PL_underlying_numeric_obj              (vTHX->Iunderlying_numeric_obj)
 # define PL_underlying_radix_sv                 (vTHX->Iunderlying_radix_sv)
 # define PL_unicode                             (vTHX->Iunicode)
 # define PL_unitcheckav                         (vTHX->Iunitcheckav)

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -862,11 +862,6 @@ PERLVAR(I, numeric_name, char *)     /* Name of current numeric locale */
 PERLVAR(I, numeric_radix_sv, SV *)	/* The radix separator */
 PERLVAR(I, underlying_radix_sv, SV *)	/* The radix in the program's current underlying locale */
 
-#if defined(USE_LOCALE_NUMERIC) && defined(USE_POSIX_2008_LOCALE)
-
-PERLVARI(I, underlying_numeric_obj, locale_t, NULL)
-
-#endif
 #ifdef USE_POSIX_2008_LOCALE
 PERLVARI(I, scratch_locale_obj, locale_t, 0)
 #endif

--- a/locale.c
+++ b/locale.c
@@ -3319,9 +3319,6 @@ S_new_numeric(pTHX_ const char *newnum, bool force)
      *                  radix character string.  This is copied into
      *                  PL_numeric_radix_sv when the situation warrants.  It
      *                  exists to avoid having to recalculate it when toggling.
-     * PL_underlying_numeric_obj = (only on POSIX 2008 platforms)  An object
-     *                  with everything set up properly so as to avoid work on
-     *                  such platforms.
      */
 
     DEBUG_L( PerlIO_printf(Perl_debug_log,
@@ -3355,20 +3352,6 @@ S_new_numeric(pTHX_ const char *newnum, bool force)
     /* We are in the underlying locale until changed at the end of this
      * function */
     PL_numeric_underlying = TRUE;
-
-#    ifdef USE_POSIX_2008_LOCALE
-
-    /* We keep a special object for easy switching to.
-     *
-     * NOTE: This code may incorrectly show up as a leak under the address
-     * sanitizer. We do not free this object under normal teardown, however
-     * you can set PERL_DESTRUCT_LEVEL=2 to cause it to be freed.
-     */
-    PL_underlying_numeric_obj = newlocale(LC_NUMERIC_MASK,
-                                          PL_numeric_name,
-                                          PL_underlying_numeric_obj);
-
-#      endif
 
     char * radix = NULL;
     utf8ness_t utf8ness = UTF8NESS_IMMATERIAL;
@@ -7131,11 +7114,6 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 #    ifdef MULTIPLICITY
 
     PL_cur_locale_obj = PL_C_locale_obj;
-
-#    endif
-#    ifdef USE_LOCALE_NUMERIC
-
-    PL_underlying_numeric_obj = duplocale(PL_C_locale_obj);
 
 #    endif
 #  endif

--- a/makedef.pl
+++ b/makedef.pl
@@ -458,7 +458,6 @@ unless ($define{USE_POSIX_2008_LOCALE})
     ++$skip{$_} foreach qw(
         PL_C_locale_obj
         PL_scratch_locale_obj
-        PL_underlying_numeric_obj
     );
 }
 unless ($define{USE_PL_CURLOCALES})
@@ -607,13 +606,6 @@ unless ($define{USE_LOCALE_THREADS} && ! $define{USE_THREAD_SAFE_LOCALE}) {
                            PL_less_dicey_locale_buf
                            PL_less_dicey_locale_bufsize
 			  );
-}
-
-
-unless ($define{USE_LOCALE_NUMERIC}) {
-    ++$skip{$_} foreach qw(
-                    PL_underlying_numeric_obj
-			 );
 }
 
 unless ($define{USE_LOCALE_CTYPE}) {

--- a/perl.c
+++ b/perl.c
@@ -1158,15 +1158,6 @@ perl_destruct(pTHXx)
         freelocale(PL_scratch_locale_obj);
         PL_scratch_locale_obj = NULL;
     }
-#  ifdef USE_LOCALE_NUMERIC
-    if (PL_underlying_numeric_obj) {
-        DEBUG_Lv(PerlIO_printf(Perl_debug_log,
-                    "%s:%d: Freeing %p\n", __FILE__, __LINE__,
-                    PL_underlying_numeric_obj));
-        freelocale(PL_underlying_numeric_obj);
-        PL_underlying_numeric_obj = (locale_t) NULL;
-    }
-#  endif
 #endif
 #ifdef USE_LOCALE_NUMERIC
     Safefree(PL_numeric_name);

--- a/sv.c
+++ b/sv.c
@@ -16091,9 +16091,6 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
     PL_numeric_underlying = true;
     PL_numeric_underlying_is_standard = true;
 
-#  if defined(USE_POSIX_2008_LOCALE)
-    PL_underlying_numeric_obj = NULL;
-#  endif
 #endif /* !USE_LOCALE_NUMERIC */
 #if defined(USE_POSIX_2008_LOCALE)
     PL_scratch_locale_obj = NULL;


### PR DESCRIPTION
This object, only on POSIX 2008 systems, is no longer used.  I've been keeping it around in case I could figure out if it had any remaining utility, but don't see any.