### PR TITLE
regexec.c - make find_byclass() work with (*SKIP) and friends

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -1934,13 +1934,16 @@ STMT_START {                                                                    
         s++;                                                   \
     }
 
+#define LAST_REGTRY_SKIPPED_FORWARD(reginfo) (reginfo->cutpoint)
+
 /* We keep track of where the next character should start after an occurrence
  * of the one we're looking for.  Knowing that, we can see right away if the
  * next occurrence is adjacent to the previous.  When 'doevery' is FALSE, we
  * don't accept the 2nd and succeeding adjacent occurrences */
 #define FBC_CHECK_AND_TRY                                           \
         if (   (   doevery                                          \
-                || s != previous_occurrence_end)                    \
+                || s != previous_occurrence_end                     \
+                || LAST_REGTRY_SKIPPED_FORWARD(reginfo) )           \
             && (   reginfo->intuit                                  \
                 || (s <= reginfo->strend && regtry(reginfo, &s))))  \
         {                                                           \
@@ -4356,6 +4359,12 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
 
 /*
  - regtry - try match at specific point
+
+ NOTE: *startpos may be modifed by regtry() to signal to the caller
+       that the next match should start at a specific position in the
+       string. The macro LAST_REGTRY_SKIPPED_FORWARD(reginfo) can be
+       used to detect when this has happened.
+
  */
 STATIC bool			/* 0 failure, 1 success */
 S_regtry(pTHX_ regmatch_info *reginfo, char **startposp)

--- a/t/re/pat_advanced.t
+++ b/t/re/pat_advanced.t
@@ -1235,6 +1235,10 @@ sub run_tests {
         1 while /(a+b?)(*SKIP)(?{$count++; push @res,$1})(*FAIL)/g;
         is($count, 2, "Expect 2 with (*SKIP)");
         is("@res", "aaab aaab", "Adjacent (*SKIP) works as expected");
+
+        $_ = "dir/file.mp3";
+        my $got = m{ ( ([^/]+) (?: / (*SKIP)(*FAIL) | \z ) ) }x ? $1 : undef;
+        is($got, "file.mp3", "(*SKIP) and find_byclass() work together");
     }
 
     {   # Test the (*SKIP) pattern


### PR DESCRIPTION
This fixes https://github.com/Perl/perl5/issues/21534

When the previous_occurence_end logic was added it did not account for patterns where "s" is updated by regtry(). See 21d1ed5 which introduced this logic. That patch seemed to assume that regtry() would not alter s, but it does. This fix seems to work around the problem for the verb's, but it feels like a bodge instead of a proper fix, which I think would involve reworking the previous_occurrence_end logic to take into account that regtry() can modify s. But for now this should work.