### PR TITLE
Get /o off of perlop.pod

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -2106,9 +2106,8 @@ Examples:
  # poor man's grep
  $arg = shift;
  while (<>) {
-    print if /$arg/o; # compile only once (no longer needed!)
+    print if /$arg/;
  }
-
  if (($F1, $F2, $Etc) = ($foo =~ /^(\S+)\s+(\S+)\s*(.*)/))
 
 This last example splits C<$foo> into the first two words and the


### PR DESCRIPTION
Elsewhere in the page we see
> The bottom line is that using "/o" is almost never a good idea.

So I'll get rid of /o here too.

P.S., I also get rid of a newline, based on
```
$ echo 'while(<>){}if 0;'|perltidy
while (<>) { }
if 0;
```