### PR TITLE
Modernise Class::Struct-using core modules

### DIFF
--- a/lib/File/stat.pm
+++ b/lib/File/stat.pm
@@ -1,6 +1,5 @@
 package File::stat 1.14;
 use v5.38;
-no feature 'signatures'; # we use prototypes
 
 use warnings::register;
 use Carp;
@@ -185,7 +184,7 @@ struct 'File::stat' => [
      }
 ];
 
-sub populate (@) {
+sub populate {
     return unless @_;
     my $stob = new();
     @$stob = (
@@ -195,9 +194,9 @@ sub populate (@) {
     return $stob;
 } 
 
-sub lstat ($)  { populate(CORE::lstat(shift)) }
+sub lstat :prototype($) { populate(CORE::lstat(shift)) }
 
-sub stat ($) {
+sub stat :prototype($) {
     my $arg = shift;
     my $st = populate(CORE::stat $arg);
     return $st if defined $st;

--- a/lib/File/stat.pm
+++ b/lib/File/stat.pm
@@ -1,19 +1,13 @@
-package File::stat;
-use 5.006;
+package File::stat 1.14;
+use v5.38;
+no feature 'signatures'; # we use prototypes
 
-use strict;
-use warnings;
 use warnings::register;
 use Carp;
 use constant _IS_CYGWIN => $^O eq "cygwin";
 
 BEGIN { *warnif = \&warnings::warnif }
 
-our(@EXPORT, @EXPORT_OK, %EXPORT_TAGS);
-
-our $VERSION = '1.13';
-
-our @fields;
 our ( $st_dev, $st_ino, $st_mode,
     $st_nlink, $st_uid, $st_gid,
     $st_rdev, $st_size,
@@ -21,18 +15,16 @@ our ( $st_dev, $st_ino, $st_mode,
     $st_blksize, $st_blocks
 );
 
-BEGIN { 
-    use Exporter   ();
-    @EXPORT      = qw(stat lstat);
-    @fields      = qw( $st_dev	   $st_ino    $st_mode 
+use Exporter 'import';
+our @EXPORT      = qw(stat lstat);
+our @fields      = qw( $st_dev	   $st_ino    $st_mode
 		       $st_nlink   $st_uid    $st_gid 
 		       $st_rdev    $st_size 
 		       $st_atime   $st_mtime  $st_ctime 
 		       $st_blksize $st_blocks
 		    );
-    @EXPORT_OK   = ( @fields, "stat_cando" );
-    %EXPORT_TAGS = ( FIELDS => [ @fields, @EXPORT ] );
-}
+our @EXPORT_OK   = ( @fields, "stat_cando" );
+our %EXPORT_TAGS = ( FIELDS => [ @fields, @EXPORT ] );
 
 use Fcntl qw(S_IRUSR S_IWUSR S_IXUSR);
 
@@ -185,9 +177,6 @@ use overload
         }
     };
 
-# Class::Struct forbids use of @ISA
-sub import { goto &Exporter::import }
-
 use Class::Struct qw(struct);
 struct 'File::stat' => [
      map { $_ => '$' } qw{
@@ -223,7 +212,6 @@ sub stat ($) {
     return populate(CORE::stat $fh);
 }
 
-1;
 __END__
 
 =head1 NAME

--- a/lib/Net/hostent.pm
+++ b/lib/Net/hostent.pm
@@ -1,28 +1,21 @@
-package Net::hostent;
-use strict;
+package Net::hostent 1.04;
+use v5.38;
+no feature 'signatures'; # we use prototypes
 
-use 5.006_001;
-our $VERSION = '1.03';
-our (@EXPORT, @EXPORT_OK, %EXPORT_TAGS);
 our (
       $h_name, @h_aliases,
       $h_addrtype, $h_length,
       @h_addr_list, $h_addr
 );
- 
-BEGIN { 
-    use Exporter   ();
-    @EXPORT      = qw(gethostbyname gethostbyaddr gethost);
-    @EXPORT_OK   = qw(
+
+use Exporter 'import';
+our @EXPORT      = qw(gethostbyname gethostbyaddr gethost);
+our @EXPORT_OK   = qw(
 			$h_name	    	@h_aliases
 			$h_addrtype 	$h_length
 			@h_addr_list 	$h_addr
 		   );
-    %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
-}
-
-# Class::Struct forbids use of @ISA
-sub import { goto &Exporter::import }
+our %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
 
 use Class::Struct qw(struct);
 struct 'Net::hostent' => [
@@ -67,7 +60,6 @@ sub gethost($) {
     }
 }
 
-1;
 __END__
 
 =head1 NAME

--- a/lib/Net/hostent.pm
+++ b/lib/Net/hostent.pm
@@ -1,6 +1,5 @@
 package Net::hostent 1.04;
 use v5.38;
-no feature 'signatures'; # we use prototypes
 
 our (
       $h_name, @h_aliases,
@@ -28,7 +27,7 @@ struct 'Net::hostent' => [
 
 sub addr { shift->addr_list->[0] }
 
-sub populate (@) {
+sub populate {
     return unless @_;
     my $hob = new();
     $h_name 	 =    $hob->[0]     	     = $_[0];
@@ -40,9 +39,9 @@ sub populate (@) {
     return $hob;
 } 
 
-sub gethostbyname ($)  { populate(CORE::gethostbyname(shift)) } 
+sub gethostbyname :prototype($) { populate(CORE::gethostbyname(shift)) }
 
-sub gethostbyaddr ($;$) { 
+sub gethostbyaddr :prototype($;$) {
     my ($addr, $addrtype);
     $addr = shift;
     require Socket unless @_;
@@ -50,7 +49,7 @@ sub gethostbyaddr ($;$) {
     populate(CORE::gethostbyaddr($addr, $addrtype)) 
 } 
 
-sub gethost($) {
+sub gethost :prototype($) {
     my $addr = shift;
     if ($addr =~ /^\d+(?:\.\d+(?:\.\d+(?:\.\d+)?)?)?$/) {
        require Socket;

--- a/lib/Net/netent.pm
+++ b/lib/Net/netent.pm
@@ -1,6 +1,5 @@
 package Net::netent 1.02;
 use v5.38;
-no feature 'signatures'; # we use prototypes
 
 our (
     $n_name, @n_aliases,
@@ -23,7 +22,7 @@ struct 'Net::netent' => [
    net		=> '$',
 ];
 
-sub populate (@) {
+sub populate {
     return unless @_;
     my $nob = new();
     $n_name 	 =    $nob->[0]     	     = $_[0];
@@ -33,9 +32,9 @@ sub populate (@) {
     return $nob;
 } 
 
-sub getnetbyname ($)  { populate(CORE::getnetbyname(shift)) } 
+sub getnetbyname :prototype($) { populate(CORE::getnetbyname(shift)) }
 
-sub getnetbyaddr ($;$) { 
+sub getnetbyaddr :prototype($;$) {
     my ($net, $addrtype);
     $net = shift;
     require Socket if @_;
@@ -43,7 +42,7 @@ sub getnetbyaddr ($;$) {
     populate(CORE::getnetbyaddr($net, $addrtype)) 
 } 
 
-sub getnet($) {
+sub getnet :prototype($) {
     if ($_[0] =~ /^\d+(?:\.\d+(?:\.\d+(?:\.\d+)?)?)?$/) {
 	require Socket;
 	&getnetbyaddr(Socket::inet_aton(shift));

--- a/lib/Net/netent.pm
+++ b/lib/Net/netent.pm
@@ -1,26 +1,19 @@
-package Net::netent;
-use strict;
+package Net::netent 1.02;
+use v5.38;
+no feature 'signatures'; # we use prototypes
 
-use 5.006_001;
-our $VERSION = '1.01';
-our(@EXPORT, @EXPORT_OK, %EXPORT_TAGS);
 our (
     $n_name, @n_aliases,
     $n_addrtype, $n_net
 );
  
-BEGIN { 
-    use Exporter   ();
-    @EXPORT      = qw(getnetbyname getnetbyaddr getnet);
-    @EXPORT_OK   = qw(
+use Exporter 'import';
+our @EXPORT      = qw(getnetbyname getnetbyaddr getnet);
+our @EXPORT_OK   = qw(
 			$n_name	    	@n_aliases
 			$n_addrtype 	$n_net
 		   );
-    %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
-}
-
-# Class::Struct forbids use of @ISA
-sub import { goto &Exporter::import }
+our %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
 
 use Class::Struct qw(struct);
 struct 'Net::netent' => [
@@ -59,7 +52,6 @@ sub getnet($) {
     } 
 } 
 
-1;
 __END__
 
 =head1 NAME

--- a/lib/Net/protoent.pm
+++ b/lib/Net/protoent.pm
@@ -1,6 +1,5 @@
 package Net::protoent 1.03;
 use v5.38;
-no feature 'signatures'; # we use prototypes
 
 our ( $p_name, @p_aliases, $p_proto );
 
@@ -16,7 +15,7 @@ struct 'Net::protoent' => [
    proto	=> '$',
 ];
 
-sub populate (@) {
+sub populate {
     return unless @_;
     my $pob = new();
     $p_name 	 =    $pob->[0]     	     = $_[0];
@@ -25,11 +24,11 @@ sub populate (@) {
     return $pob;
 } 
 
-sub getprotoent      ( )  { populate(CORE::getprotoent()) } 
-sub getprotobyname   ($)  { populate(CORE::getprotobyname(shift)) } 
-sub getprotobynumber ($)  { populate(CORE::getprotobynumber(shift)) } 
+sub getprotoent      :prototype( ) { populate(CORE::getprotoent()) }
+sub getprotobyname   :prototype($) { populate(CORE::getprotobyname(shift)) }
+sub getprotobynumber :prototype($) { populate(CORE::getprotobynumber(shift)) }
 
-sub getproto ($;$) {
+sub getproto :prototype($;$) {
     no strict 'refs';
     return &{'getprotoby' . ($_[0]=~/^\d+$/ ? 'number' : 'name')}(@_);
 }

--- a/lib/Net/protoent.pm
+++ b/lib/Net/protoent.pm
@@ -1,19 +1,13 @@
-package Net::protoent;
-use strict;
+package Net::protoent 1.03;
+use v5.38;
+no feature 'signatures'; # we use prototypes
 
-use 5.006_001;
-our $VERSION = '1.02';
-our(@EXPORT, @EXPORT_OK, %EXPORT_TAGS);
 our ( $p_name, @p_aliases, $p_proto );
-BEGIN { 
-    use Exporter   ();
-    @EXPORT      = qw(getprotobyname getprotobynumber getprotoent getproto);
-    @EXPORT_OK   = qw( $p_name @p_aliases $p_proto );
-    %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
-}
 
-# Class::Struct forbids use of @ISA
-sub import { goto &Exporter::import }
+use Exporter 'import';
+our @EXPORT      = qw(getprotobyname getprotobynumber getprotoent getproto);
+our @EXPORT_OK   = qw( $p_name @p_aliases $p_proto );
+our %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
 
 use Class::Struct qw(struct);
 struct 'Net::protoent' => [
@@ -39,8 +33,6 @@ sub getproto ($;$) {
     no strict 'refs';
     return &{'getprotoby' . ($_[0]=~/^\d+$/ ? 'number' : 'name')}(@_);
 }
-
-1;
 
 __END__
 

--- a/lib/Net/servent.pm
+++ b/lib/Net/servent.pm
@@ -1,6 +1,5 @@
 package Net::servent 1.04;
 use v5.38;
-no feature 'signatures'; # we use prototypes
 
 our ( $s_name, @s_aliases, $s_port, $s_proto );
 
@@ -17,7 +16,7 @@ struct 'Net::servent' => [
    proto	=> '$',
 ];
 
-sub populate (@) {
+sub populate {
     return unless @_;
     my $sob = new();
     $s_name 	 =    $sob->[0]     	     = $_[0];
@@ -27,11 +26,11 @@ sub populate (@) {
     return $sob;
 }
 
-sub getservent    (   ) { populate(CORE::getservent()) }
-sub getservbyname ($;$) { populate(CORE::getservbyname(shift,shift||'tcp')) }
-sub getservbyport ($;$) { populate(CORE::getservbyport(shift,shift||'tcp')) }
+sub getservent    :prototype(   ) { populate(CORE::getservent()) }
+sub getservbyname :prototype($;$) { populate(CORE::getservbyname(shift,shift||'tcp')) }
+sub getservbyport :prototype($;$) { populate(CORE::getservbyport(shift,shift||'tcp')) }
 
-sub getserv ($;$) {
+sub getserv :prototype($;$) {
     no strict 'refs';
     return &{'getservby' . ($_[0]=~/^\d+$/ ? 'port' : 'name')}(@_);
 }

--- a/lib/Net/servent.pm
+++ b/lib/Net/servent.pm
@@ -1,19 +1,13 @@
-package Net::servent;
-use strict;
+package Net::servent 1.04;
+use v5.38;
+no feature 'signatures'; # we use prototypes
 
-use 5.006_001;
-our $VERSION = '1.03';
-our(@EXPORT, @EXPORT_OK, %EXPORT_TAGS);
 our ( $s_name, @s_aliases, $s_port, $s_proto );
-BEGIN {
-    use Exporter   ();
-    @EXPORT      = qw(getservbyname getservbyport getservent getserv);
-    @EXPORT_OK   = qw( $s_name @s_aliases $s_port $s_proto );
-    %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
-}
 
-# Class::Struct forbids use of @ISA
-sub import { goto &Exporter::import }
+use Exporter 'import';
+our @EXPORT      = qw(getservbyname getservbyport getservent getserv);
+our @EXPORT_OK   = qw( $s_name @s_aliases $s_port $s_proto );
+our %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
 
 use Class::Struct qw(struct);
 struct 'Net::servent' => [
@@ -41,8 +35,6 @@ sub getserv ($;$) {
     no strict 'refs';
     return &{'getservby' . ($_[0]=~/^\d+$/ ? 'port' : 'name')}(@_);
 }
-
-1;
 
 __END__
 

--- a/lib/Time/gmtime.pm
+++ b/lib/Time/gmtime.pm
@@ -1,27 +1,22 @@
-package Time::gmtime;
-use strict;
-use 5.006_001;
+package Time::gmtime 1.05;
+use v5.38;
+no feature 'signatures'; # we use prototypes
 
-use Time::tm;
+use parent 'Time::tm';
 
-our (@ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS, $VERSION);
 our (   $tm_sec, $tm_min, $tm_hour, $tm_mday,
         $tm_mon, $tm_year, $tm_wday, $tm_yday, 
 		$tm_isdst,
 );
- 
-BEGIN { 
-    use Exporter   ();
-    @ISA         = qw(Exporter Time::tm);
-    @EXPORT      = qw(gmtime gmctime);
-    @EXPORT_OK   = qw(  
+
+use Exporter 'import';
+our @EXPORT      = qw(gmtime gmctime);
+our @EXPORT_OK   = qw(
 			$tm_sec $tm_min $tm_hour $tm_mday 
 			$tm_mon $tm_year $tm_wday $tm_yday 
 			$tm_isdst
 		    );
-    %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
-    $VERSION     = 1.04;
-}
+our %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
 
 sub populate (@) {
     return unless @_;
@@ -37,7 +32,6 @@ sub populate (@) {
 sub gmtime (;$)    { populate CORE::gmtime(@_ ? shift : time)}
 sub gmctime (;$)   { scalar   CORE::gmtime(@_ ? shift : time)} 
 
-1;
 __END__
 
 =head1 NAME

--- a/lib/Time/gmtime.pm
+++ b/lib/Time/gmtime.pm
@@ -1,6 +1,5 @@
 package Time::gmtime 1.05;
 use v5.38;
-no feature 'signatures'; # we use prototypes
 
 use parent 'Time::tm';
 
@@ -18,7 +17,7 @@ our @EXPORT_OK   = qw(
 		    );
 our %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
 
-sub populate (@) {
+sub populate {
     return unless @_;
     my $tmob = Time::tm->new();
     @$tmob = (
@@ -29,8 +28,8 @@ sub populate (@) {
     return $tmob;
 } 
 
-sub gmtime (;$)    { populate CORE::gmtime(@_ ? shift : time)}
-sub gmctime (;$)   { scalar   CORE::gmtime(@_ ? shift : time)} 
+sub gmtime  :prototype(;$) { populate CORE::gmtime(@_ ? shift : time) }
+sub gmctime :prototype(;$) { scalar   CORE::gmtime(@_ ? shift : time) }
 
 __END__
 

--- a/lib/Time/localtime.pm
+++ b/lib/Time/localtime.pm
@@ -1,28 +1,23 @@
-package Time::localtime;
-use strict;
-use 5.006_001;
+package Time::localtime 1.04;
+use v5.38;
+no feature 'signatures'; # we use prototypes
 
-use Time::tm;
+use parent 'Time::tm';
 
-our (@ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS, $VERSION);
 our (  
       $tm_sec, $tm_min, $tm_hour, $tm_mday,
       $tm_mon, $tm_year, $tm_wday, $tm_yday,
       $tm_isdst
 );
- 
-BEGIN {
-    use Exporter   ();
-    @ISA         = qw(Exporter Time::tm);
-    @EXPORT      = qw(localtime ctime);
-    @EXPORT_OK   = qw(  
+
+use Exporter   'import';
+our @EXPORT      = qw(localtime ctime);
+our @EXPORT_OK   = qw(
 			$tm_sec $tm_min $tm_hour $tm_mday 
 			$tm_mon $tm_year $tm_wday $tm_yday 
 			$tm_isdst
 		    );
-    %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
-    $VERSION     = 1.03;
-}
+our %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
 
 sub populate (@) {
     return unless @_;
@@ -37,8 +32,6 @@ sub populate (@) {
 
 sub localtime (;$) { populate CORE::localtime(@_ ? shift : time)}
 sub ctime (;$)     { scalar   CORE::localtime(@_ ? shift : time) } 
-
-1;
 
 __END__
 

--- a/lib/Time/localtime.pm
+++ b/lib/Time/localtime.pm
@@ -1,6 +1,5 @@
 package Time::localtime 1.04;
 use v5.38;
-no feature 'signatures'; # we use prototypes
 
 use parent 'Time::tm';
 
@@ -19,7 +18,7 @@ our @EXPORT_OK   = qw(
 		    );
 our %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
 
-sub populate (@) {
+sub populate {
     return unless @_;
     my $tmob = Time::tm->new();
     @$tmob = (
@@ -30,8 +29,8 @@ sub populate (@) {
     return $tmob;
 } 
 
-sub localtime (;$) { populate CORE::localtime(@_ ? shift : time)}
-sub ctime (;$)     { scalar   CORE::localtime(@_ ? shift : time) } 
+sub localtime :prototype(;$) { populate CORE::localtime(@_ ? shift : time) }
+sub ctime     :prototype(;$) { scalar   CORE::localtime(@_ ? shift : time) }
 
 __END__
 

--- a/lib/Time/tm.pm
+++ b/lib/Time/tm.pm
@@ -1,14 +1,11 @@
-package Time::tm;
-use strict;
-
-our $VERSION = '1.00';
+package Time::tm 1.01;
+use v5.38;
 
 use Class::Struct qw(struct);
 struct('Time::tm' => [
      map { $_ => '$' } qw{ sec min hour mday mon year wday yday isdst }
 ]);
 
-1;
 __END__
 
 =head1 NAME

--- a/lib/User/grent.pm
+++ b/lib/User/grent.pm
@@ -1,6 +1,5 @@
 package User::grent 1.05;
 use v5.38;
-no feature 'signatures'; # we use prototypes
 
 our ($gr_name, $gr_gid, $gr_passwd, @gr_members);
 
@@ -17,7 +16,7 @@ struct 'User::grent' => [
     members => '@',
 ];
 
-sub populate (@) {
+sub populate {
     return unless @_;
     my $gob = new();
     ($gr_name, $gr_passwd, $gr_gid) = @$gob[0,1,2] = @_[0,1,2];
@@ -25,10 +24,10 @@ sub populate (@) {
     return $gob;
 } 
 
-sub getgrent ( ) { populate(CORE::getgrent()) } 
-sub getgrnam ($) { populate(CORE::getgrnam(shift)) } 
-sub getgrgid ($) { populate(CORE::getgrgid(shift)) } 
-sub getgr    ($) { ($_[0] =~ /^\d+/) ? &getgrgid : &getgrnam } 
+sub getgrent :prototype( ) { populate(CORE::getgrent()) }
+sub getgrnam :prototype($) { populate(CORE::getgrnam(shift)) }
+sub getgrgid :prototype($) { populate(CORE::getgrgid(shift)) }
+sub getgr    :prototype($) { ($_[0] =~ /^\d+/) ? &getgrgid : &getgrnam }
 
 __END__
 

--- a/lib/User/grent.pm
+++ b/lib/User/grent.pm
@@ -1,19 +1,13 @@
-package User::grent;
-use strict;
+package User::grent 1.05;
+use v5.38;
+no feature 'signatures'; # we use prototypes
 
-use 5.006_001;
-our $VERSION = '1.04';
-our(@EXPORT, @EXPORT_OK, %EXPORT_TAGS);
 our ($gr_name, $gr_gid, $gr_passwd, @gr_members);
-BEGIN { 
-    use Exporter   ();
-    @EXPORT      = qw(getgrent getgrgid getgrnam getgr);
-    @EXPORT_OK   = qw($gr_name $gr_gid $gr_passwd @gr_members);
-    %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
-}
 
-# Class::Struct forbids use of @ISA
-sub import { goto &Exporter::import }
+use Exporter 'import';
+our @EXPORT      = qw(getgrent getgrgid getgrnam getgr);
+our @EXPORT_OK   = qw($gr_name $gr_gid $gr_passwd @gr_members);
+our %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
 
 use Class::Struct qw(struct);
 struct 'User::grent' => [
@@ -36,7 +30,6 @@ sub getgrnam ($) { populate(CORE::getgrnam(shift)) }
 sub getgrgid ($) { populate(CORE::getgrgid(shift)) } 
 sub getgr    ($) { ($_[0] =~ /^\d+/) ? &getgrgid : &getgrnam } 
 
-1;
 __END__
 
 =head1 NAME

--- a/lib/User/pwent.pm
+++ b/lib/User/pwent.pm
@@ -1,6 +1,5 @@
 package User::pwent 1.03;
 use v5.38;
-no feature 'signatures'; # we use prototypes
 
 use Config;
 use Carp;
@@ -122,7 +121,7 @@ sub pw_has {
     return $cando;
 }
 
-sub _populate (@) {
+sub _populate {
     return unless @_;
     my $pwob = new();
 
@@ -163,10 +162,10 @@ sub _populate (@) {
     return $pwob;
 }
 
-sub getpwent ( ) { _populate(CORE::getpwent()) }
-sub getpwnam ($) { _populate(CORE::getpwnam(shift)) }
-sub getpwuid ($) { _populate(CORE::getpwuid(shift)) }
-sub getpw    ($) { ($_[0] =~ /^\d+\z/s) ? &getpwuid : &getpwnam }
+sub getpwent :prototype( ) { _populate(CORE::getpwent()) }
+sub getpwnam :prototype($) { _populate(CORE::getpwnam(shift)) }
+sub getpwuid :prototype($) { _populate(CORE::getpwuid(shift)) }
+sub getpw    :prototype($) { ($_[0] =~ /^\d+\z/s) ? &getpwuid : &getpwnam }
 
 _feature_init();
 

--- a/lib/User/pwent.pm
+++ b/lib/User/pwent.pm
@@ -1,25 +1,20 @@
-package User::pwent;
-
-use 5.006;
-our $VERSION = '1.02';
-
-use strict;
-use warnings;
+package User::pwent 1.03;
+use v5.38;
+no feature 'signatures'; # we use prototypes
 
 use Config;
 use Carp;
 
-our(@EXPORT, @EXPORT_OK, %EXPORT_TAGS);
 our ( $pw_name,    $pw_passwd,  $pw_uid,  $pw_gid,
     $pw_gecos,   $pw_dir,     $pw_shell,
     $pw_expire,  $pw_change,  $pw_class,
     $pw_age,
     $pw_quota,   $pw_comment,
     );
-BEGIN {
-    use Exporter   ();
-    @EXPORT      = qw(getpwent getpwuid getpwnam getpw);
-    @EXPORT_OK   = qw(
+
+use Exporter 'import';
+our @EXPORT      = qw(getpwent getpwuid getpwnam getpw);
+our @EXPORT_OK   = qw(
                         pw_has
 
                         $pw_name    $pw_passwd  $pw_uid  $pw_gid
@@ -28,20 +23,16 @@ BEGIN {
                         $pw_age
                         $pw_quota   $pw_comment
                    );
-    %EXPORT_TAGS = (
+our %EXPORT_TAGS = (
         FIELDS => [ grep(/^\$pw_/, @EXPORT_OK), @EXPORT ],
         ALL    => [ @EXPORT, @EXPORT_OK ],
     );
-}
 
 #
 # XXX: these mean somebody hacked this module's source
 #      without understanding the underlying assumptions.
 #
 my $IE = "[INTERNAL ERROR]";
-
-# Class::Struct forbids use of @ISA
-sub import { goto &Exporter::import }
 
 use Class::Struct qw(struct);
 struct 'User::pwent' => [
@@ -179,7 +170,6 @@ sub getpw    ($) { ($_[0] =~ /^\d+\z/s) ? &getpwuid : &getpwnam }
 
 _feature_init();
 
-1;
 __END__
 
 =head1 NAME


### PR DESCRIPTION
These modules couldn't inherit from Exporter because they use Class::Struct, and were written before Exporter could export its import method.

Now that it can, update them to do that, and remove the pointless BEGIN block around the Exporter setup.

In passing, bump the use VERSION statement to 5.38, but disable signatures, since the modules use prototypes.