### PR TITLE
Get Test2 tests working on VMS

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1144,6 +1144,13 @@ our %Modules = (
             # https://github.com/Test-More/Test2-Suite/issues/208
             't/acceptance/Workflow-Acceptance.t',
         ],
+        'CUSTOMIZED'   => [
+            qw( t/modules/Plugin/SRand.t
+                t/modules/Require/AuthorTesting.t
+                t/modules/Require/EnvVar.t
+                t/modules/Tools/GenTemp.t
+              )
+        ],
     },
 
     'Text::Abbrev' => {

--- a/cpan/Test2-Suite/t/modules/Plugin/SRand.t
+++ b/cpan/Test2-Suite/t/modules/Plugin/SRand.t
@@ -33,9 +33,8 @@ sub intercept_2(&) {
 }
 
 {
-    local %ENV = %ENV;
-    $ENV{HARNESS_IS_VERBOSE} = 1;
-    $ENV{T2_RAND_SEED} = 1234;
+    local $ENV{HARNESS_IS_VERBOSE} = 1;
+    local $ENV{T2_RAND_SEED} = 1234;
 
     my ($events, $warning);
     my $reseed_qr = qr/SRand loaded multiple times, re-seeding rand/;

--- a/cpan/Test2-Suite/t/modules/Require/AuthorTesting.t
+++ b/cpan/Test2-Suite/t/modules/Require/AuthorTesting.t
@@ -1,8 +1,7 @@
 use Test2::Bundle::Extended -target => 'Test2::Require::AuthorTesting';
 
 {
-    local %ENV = %ENV;
-    $ENV{AUTHOR_TESTING} = 0;
+    local $ENV{AUTHOR_TESTING} = 0;
     is($CLASS->skip(), 'Author test, set the $AUTHOR_TESTING environment variable to run it', "will skip");
 
     $ENV{AUTHOR_TESTING} = 1;

--- a/cpan/Test2-Suite/t/modules/Require/EnvVar.t
+++ b/cpan/Test2-Suite/t/modules/Require/EnvVar.t
@@ -1,8 +1,7 @@
 use Test2::Bundle::Extended -target => 'Test2::Require::EnvVar';
 
 {
-    local %ENV = %ENV;
-    $ENV{FOO} = 0;
+    local $ENV{FOO} = 0;
     is($CLASS->skip('FOO'), 'This test only runs if the $FOO environment variable is set', "will skip");
 
     $ENV{FOO} = 1;

--- a/cpan/Test2-Suite/t/modules/Tools/GenTemp.t
+++ b/cpan/Test2-Suite/t/modules/Tools/GenTemp.t
@@ -24,12 +24,12 @@ ok($tmp, "Got a temp dir ($tmp)");
 
 ok(-d File::Spec->canonpath($_), "Created dir $_") for (
     $tmp,
-    "$tmp/subdir",
-    "$tmp/subdir/nested",
+    File::Spec->catdir($tmp, 'subdir'),
+    File::Spec->catdir($tmp, 'subdir', 'nested'),
 );
 
 for my $file (qw{foo bar subdir/baz subdir/nested/bat}) {
-    my $cp = File::Spec->canonpath("$tmp/$file");
+    my $cp = File::Spec->catfile($tmp, $file);
     ok(-f $cp, "Created file $file");
     open(my $fh, '<', $cp) or die "Could not open file '$cp': $!";
     my $content = $file;

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -13,6 +13,10 @@ MIME::Base64 cpan/MIME-Base64/Base64.xs ad617fe2d01932c35b92defa26d40aba601a95a8
 MIME::Base64 cpan/MIME-Base64/lib/MIME/Base64.pm 18e38d197c7c83f96b24f48bef514e93908e6a82
 MIME::Base64 cpan/MIME-Base64/lib/MIME/QuotedPrint.pm 36cbb455ab57b9bbca7e86f50987c8b1df1a8122
 Pod::Perldoc cpan/Pod-Perldoc/lib/Pod/Perldoc.pm 582be34c077c9ff44d99914724a0cc2140bcd48c
+Test2::Suite cpan/Test2-Suite/t/modules/Plugin/SRand.t f1d6a3f8e3f1a34f185c4c833f1ce8128da1da37
+Test2::Suite cpan/Test2-Suite/t/modules/Require/AuthorTesting.t 929b2134c121e9934c8c44c487442a7d33ed328b
+Test2::Suite cpan/Test2-Suite/t/modules/Require/EnvVar.t cb3b2c14cf6107ba6f711d3c4f8f5cc9fe308144
+Test2::Suite cpan/Test2-Suite/t/modules/Tools/GenTemp.t b595f2937b18a690e82bef596ae4a7706ade8d25
 Time::Piece cpan/Time-Piece/Piece.pm 8cec8b66183ceddb9bf2b6af35dcdd345bc9adfa
 Time::Piece cpan/Time-Piece/Piece.xs 543152540ee17788a638b2c5746b86c3d04401d1
 Win32API::File cpan/Win32API-File/File.pm 8fd212857f821cb26648878b96e57f13bf21b99e


### PR DESCRIPTION
List assignment to %ENV is not supported, and mongrel filenames produced by concatenating hard-coded slashes with the return values from File::Spec functions don't work.