### PR TITLE
Fix various issues with the POSIX.xs typemap

### DIFF
--- a/ext/POSIX/typemap
+++ b/ext/POSIX/typemap
@@ -3,11 +3,7 @@ pid_t			T_NV
 Uid_t			T_NV
 Time_t			T_NV
 Gid_t			T_NV
-Uid_t			T_NV
 Off_t			T_NV
-Dev_t			T_NV
-NV			T_NV
-fd			T_IV
 speed_t			T_IV
 tcflag_t		T_IV
 cc_t			T_IV

--- a/ext/POSIX/typemap
+++ b/ext/POSIX/typemap
@@ -30,14 +30,14 @@ T_OPAQUEPTROBJ
 	}
 
 T_SIGNO
-	if ((sig = SvIV($arg)) < 0) {
+	if (($var = SvIV($arg)) < 0) {
 	   croak(\"%s: Negative signals are not allowed %d\",
 		${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-                                   sig);
+                                   $var);
 	}
 
 T_FD
-	if ((fd = (int)SvIV($arg)) < 0) {
+	if (($var = (int)SvIV($arg)) < 0) {
 	     SETERRNO(EBADF, RMS_IFI);
 	     XSRETURN_IV(-1);
 	}

--- a/ext/POSIX/typemap
+++ b/ext/POSIX/typemap
@@ -1,8 +1,8 @@
-Mode_t			T_NV
-pid_t			T_NV
-Uid_t			T_NV
-Time_t			T_NV
-Gid_t			T_NV
+Mode_t			T_IV
+pid_t			T_IV
+Uid_t			T_UV
+Time_t			T_IV
+Gid_t			T_UV
 Off_t			T_NV
 speed_t			T_IV
 tcflag_t		T_IV


### PR DESCRIPTION
It had 3 issues:
1. `T_SIGNO` and `T_FD` erroneously assumed the name of the variable
2. Several mappings were unused
3. All identifier types were stored in floating point types instead of integer types.

This aims to resolve these issues.