### PR TITLE
default mark indexes back to I32 but allow selection of SSize_t too

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5955,6 +5955,7 @@ t/bigmem/pos.t				Check that pos() handles large offsets
 t/bigmem/read.t				Check read() handles large offsets
 t/bigmem/regexp.t			Test regular expressions with large strings
 t/bigmem/stack.t			Check handling of large value stacks (including MARK values)
+t/bigmem/stack_over.t			Check handling of stack overflows with 32-bit MARK on 64-bit systems
 t/bigmem/str.t				Test string primitives with large strings
 t/bigmem/subst.t			Test s/// with large strings
 t/bigmem/subst2.t			Test s//EXPR/e with large strings

--- a/deb.c
+++ b/deb.c
@@ -146,7 +146,7 @@ S_deb_stack_n(pTHX_ SV** stack_base, SSize_t stack_min, SSize_t stack_max,
 {
 #ifdef DEBUGGING
     SSize_t i = stack_max - 30;
-    const SSize_t *markscan = PL_markstack + mark_min;
+    const Stack_off_t *markscan = PL_markstack + mark_min;
 
     PERL_ARGS_ASSERT_DEB_STACK_N;
 

--- a/dist/Devel-PPPort/parts/inc/misc
+++ b/dist/Devel-PPPort/parts/inc/misc
@@ -37,6 +37,9 @@ WIDEST_UTYPE
 XSRETURN
 NOT_REACHED
 ASSUME
+Stack_off_t
+Stack_off_t_MAX
+PERL_STACK_OFFSET_DEFINED
 
 =implementation
 
@@ -262,6 +265,12 @@ typedef NVTYPE NV;
 #  else
 #    define PTR2ul(p)     INT2PTR(unsigned long,p)
 #  endif
+#endif
+
+#ifndef PERL_STACK_OFFSET_DEFINED
+  typedef I32 Stack_off_t;
+#  define Stack_off_t_MAX I32_MAX
+#  define PERL_STACK_OFFSET_DEFINED
 #endif
 
 __UNDEFINED__  PTR2nat(p)      (PTRV)(p)
@@ -2580,7 +2589,21 @@ av_count(av)
         OUTPUT:
                 RETVAL
 
-=tests plan => 26827
+STRLEN
+mark_size_ok()
+        CODE:
+                RETVAL = sizeof(*PL_markstack_ptr) == sizeof(Stack_off_t);
+        OUTPUT:
+                RETVAL
+
+UV
+mark_max()
+        CODE:
+                RETVAL = Stack_off_t_MAX;
+        OUTPUT:
+                RETVAL
+
+=tests plan => 26829
 
 use vars qw($my_sv @my_av %my_hv);
 
@@ -3027,3 +3050,6 @@ for $name (keys %case_changing) {
 is(&Devel::PPPort::av_top_index([1,2,3]), 2);
 is(&Devel::PPPort::av_tindex([1,2,3,4]), 3);
 is(&Devel::PPPort::av_count([1,2,3,4]), 4);
+
+ok(&Devel::PPPort::mark_size_ok(), "check mark type size");
+ok(&Devel::PPPort::mark_max(), "got a mark max");

--- a/embed.fnc
+++ b/embed.fnc
@@ -1946,7 +1946,7 @@ p	|int	|magic_wipepack |NN SV *sv				\
 				|NN MAGIC *mg
 
 CTadop	|Malloc_t|malloc	|MEM_SIZE nbytes
-Cp	|SSize_t *|markstack_grow
+Cp	|Stack_off_t *|markstack_grow
 EXp	|int	|mbtowc_	|NULLOK const wchar_t *pwc		\
 				|NULLOK const char *s			\
 				|const Size_t len
@@ -2522,7 +2522,7 @@ p	|OP *	|pmruntime	|NN OP *o				\
 				|NULLOK OP *repl			\
 				|UV flags				\
 				|I32 floor
-Xiop	|SSize_t|POPMARK
+Xiop	|Stack_off_t|POPMARK
 Cdp	|void	|pop_scope
 Cipx	|void	|pop_stackinfo
 
@@ -3505,7 +3505,7 @@ Fpv	|OP *	|tied_method	|NN SV *methname			\
 				|U32 argc				\
 				|...
 Xp	|SSize_t|tmps_grow_p	|SSize_t ix
-Xiop	|SSize_t|TOPMARK
+Xiop	|Stack_off_t|TOPMARK
 Cm	|UV	|to_uni_fold	|UV c					\
 				|NN U8 *p				\
 				|NN STRLEN *lenp

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -3333,6 +3333,15 @@ xs_items(...)
             RETVAL
 
 void
+wide_marks(...)
+        PPCODE:
+#ifdef PERL_STACK_OFFSET_SSIZET
+          XSRETURN_YES;
+#else
+          XSRETURN_NO;
+#endif
+
+void
 bhk_record(bool on)
     CODE:
         dMY_CXT;

--- a/inline.h
+++ b/inline.h
@@ -377,7 +377,7 @@ S_PadnameIN_SCOPE(const PADNAME * const pn, const U32 seq)
 
 /* ------------------------------- pp.h ------------------------------- */
 
-PERL_STATIC_INLINE SSize_t
+PERL_STATIC_INLINE Stack_off_t
 Perl_TOPMARK(pTHX)
 {
     DEBUG_s(DEBUG_v(PerlIO_printf(Perl_debug_log,
@@ -387,7 +387,7 @@ Perl_TOPMARK(pTHX)
     return *PL_markstack_ptr;
 }
 
-PERL_STATIC_INLINE SSize_t
+PERL_STATIC_INLINE Stack_off_t
 Perl_POPMARK(pTHX)
 {
     DEBUG_s(DEBUG_v(PerlIO_printf(Perl_debug_log,
@@ -3230,7 +3230,7 @@ Perl_cx_pushblock(pTHX_ U8 type, U8 gimme, SV** sp, I32 saveix)
     cx->cx_type        = type;
     cx->blk_gimme      = gimme;
     cx->blk_oldsaveix  = saveix;
-    cx->blk_oldsp      = sp - PL_stack_base;
+    cx->blk_oldsp      = (Stack_off_t)(sp - PL_stack_base);
     assert(cxstack_ix <= 0
             || CxTYPE(cx-1) == CXt_SUBST
             || cx->blk_oldsp >= (cx-1)->blk_oldsp);

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -49,10 +49,10 @@ PERLVARI(I, tmps_ix,	SSize_t,	-1)
 PERLVARI(I, tmps_floor,	SSize_t,	-1)
 PERLVAR(I, tmps_max,	SSize_t)        /* first unalloced slot in tmps stack */
 
-PERLVAR(I, markstack,	SSize_t *)	/* stack_sp locations we're
+PERLVAR(I, markstack,	Stack_off_t *)	/* stack_sp locations we're
                                            remembering */
-PERLVAR(I, markstack_ptr, SSize_t *)
-PERLVAR(I, markstack_max, SSize_t *)
+PERLVAR(I, markstack_ptr, Stack_off_t *)
+PERLVAR(I, markstack_max, Stack_off_t *)
 
 PERLVARI(I, sub_generation, U32, 1)	/* incr to invalidate method cache */
 

--- a/perl.c
+++ b/perl.c
@@ -4506,7 +4506,7 @@ Perl_init_stacks(pTHX)
     PL_tmps_ix = -1;
     PL_tmps_max = REASONABLE(128);
 
-    Newxz(PL_markstack, REASONABLE(32), SSize_t);
+    Newxz(PL_markstack, REASONABLE(32), Stack_off_t);
     PL_markstack_ptr = PL_markstack;
     PL_markstack_max = PL_markstack + REASONABLE(32);
 

--- a/perl.h
+++ b/perl.h
@@ -4280,6 +4280,13 @@ hint to the compiler that this condition is likely to be false.
 #  define __has_builtin(x) 0 /* not a clang style compiler */
 #endif
 
+#ifdef PERL_STACK_OFFSET_SSIZET
+  typedef SSize_t Stack_off_t;
+#else
+  typedef I32 Stack_off_t;
+#endif
+#define PERL_STACK_OFFSET_DEFINED
+
 /*
 =for apidoc Am||ASSUME|bool expr
 C<ASSUME> is like C<assert()>, but it has a benefit in a release build. It is a

--- a/perl.h
+++ b/perl.h
@@ -4282,8 +4282,10 @@ hint to the compiler that this condition is likely to be false.
 
 #ifdef PERL_STACK_OFFSET_SSIZET
   typedef SSize_t Stack_off_t;
+#  define Stack_off_t_MAX SSize_t_MAX
 #else
   typedef I32 Stack_off_t;
+#  define Stack_off_t_MAX I32_MAX
 #endif
 #define PERL_STACK_OFFSET_DEFINED
 

--- a/pp.h
+++ b/pp.h
@@ -118,11 +118,11 @@ value for the OP, but some use it for other purposes.
 
 #define PUSHMARK(p) \
     STMT_START {                                                      \
-        SSize_t * mark_stack_entry;                                       \
+        Stack_off_t * mark_stack_entry;                               \
         if (UNLIKELY((mark_stack_entry = ++PL_markstack_ptr)          \
                                            == PL_markstack_max))      \
             mark_stack_entry = markstack_grow();                      \
-        *mark_stack_entry  = (SSize_t)((p) - PL_stack_base);              \
+        *mark_stack_entry  = (Stack_off_t)((p) - PL_stack_base);      \
         DEBUG_s(DEBUG_v(PerlIO_printf(Perl_debug_log,                 \
                 "MARK push %p %" IVdf "\n",                           \
                 PL_markstack_ptr, (IV)*mark_stack_entry)));           \

--- a/proto.h
+++ b/proto.h
@@ -2379,7 +2379,7 @@ Perl_malloc(MEM_SIZE nbytes)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_MALLOC
 
-PERL_CALLCONV SSize_t *
+PERL_CALLCONV Stack_off_t *
 Perl_markstack_grow(pTHX);
 #define PERL_ARGS_ASSERT_MARKSTACK_GROW
 
@@ -9513,7 +9513,7 @@ Perl_CvGV(pTHX_ CV *sv);
 # define PERL_ARGS_ASSERT_CVGV                  \
         assert(sv)
 
-PERL_STATIC_INLINE SSize_t
+PERL_STATIC_INLINE Stack_off_t
 Perl_POPMARK(pTHX);
 # define PERL_ARGS_ASSERT_POPMARK
 
@@ -9617,7 +9617,7 @@ Perl_SvUV_nomg(pTHX_ SV *sv);
 # define PERL_ARGS_ASSERT_SVUV_NOMG             \
         assert(sv)
 
-PERL_STATIC_INLINE SSize_t
+PERL_STATIC_INLINE Stack_off_t
 Perl_TOPMARK(pTHX);
 # define PERL_ARGS_ASSERT_TOPMARK
 

--- a/scope.c
+++ b/scope.c
@@ -47,10 +47,10 @@ Perl_stack_grow(pTHX_ SV **sp, SV **p, SSize_t n)
         128;
 #endif
     /* If the total might wrap, panic instead. This is really testing
-     * that (current + n + extra < SSize_t_MAX), but done in a way that
+     * that (current + n + extra < Stack_off_t_MAX), but done in a way that
      * can't wrap */
-    if (UNLIKELY(   current         > SSize_t_MAX - extra
-                 || current + extra > SSize_t_MAX - n
+    if (UNLIKELY(   current         > Stack_off_t_MAX - extra
+                 || current + extra > Stack_off_t_MAX - n
     ))
         /* diag_listed_as: Out of memory during %s extend */
         Perl_croak(aTHX_ "Out of memory during stack extend");

--- a/scope.c
+++ b/scope.c
@@ -163,13 +163,13 @@ Perl_pop_scope(pTHX)
     LEAVE_SCOPE(oldsave);
 }
 
-SSize_t *
+Stack_off_t *
 Perl_markstack_grow(pTHX)
 {
     const I32 oldmax = PL_markstack_max - PL_markstack;
     const I32 newmax = GROW(oldmax);
 
-    Renew(PL_markstack, newmax, SSize_t);
+    Renew(PL_markstack, newmax, Stack_off_t);
     PL_markstack_max = PL_markstack + newmax;
     PL_markstack_ptr = PL_markstack + oldmax;
     DEBUG_s(DEBUG_v(PerlIO_printf(Perl_debug_log,

--- a/sv.c
+++ b/sv.c
@@ -16189,13 +16189,13 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
 
         /* next PUSHMARK() sets *(PL_markstack_ptr+1) */
         i = proto_perl->Imarkstack_max - proto_perl->Imarkstack;
-        Newx(PL_markstack, i, SSize_t);
+        Newx(PL_markstack, i, Stack_off_t);
         PL_markstack_max	= PL_markstack + (proto_perl->Imarkstack_max
                                                   - proto_perl->Imarkstack);
         PL_markstack_ptr	= PL_markstack + (proto_perl->Imarkstack_ptr
                                                   - proto_perl->Imarkstack);
         Copy(proto_perl->Imarkstack, PL_markstack,
-             PL_markstack_ptr - PL_markstack + 1, SSize_t);
+             PL_markstack_ptr - PL_markstack + 1, Stack_off_t);
 
         /* next push_scope()/ENTER sets PL_scopestack[PL_scopestack_ix]
          * NOTE: unlike the others! */

--- a/t/bigmem/stack.t
+++ b/t/bigmem/stack.t
@@ -14,6 +14,8 @@ $ENV{PERL_TEST_MEMORY} >= 60
     or skip_all("Need ~60GB for this test");
 $Config{ptrsize} >= 8
     or skip_all("Need 64-bit pointers for this test");
+XS::APItest::wide_marks()
+    or skip_all("Not configured for SSize_t marks");
 
 my @x;
 $x[0x8000_0000] = "Hello";

--- a/t/bigmem/stack_over.t
+++ b/t/bigmem/stack_over.t
@@ -1,0 +1,27 @@
+#!perl
+BEGIN {
+    chdir 't' if -d 't';
+    @INC = "../lib";
+    require './test.pl';
+}
+
+use strict;
+use Config qw(%Config);
+use XS::APItest;
+
+# memory usage checked with top
+$ENV{PERL_TEST_MEMORY} >= 17
+    or skip_all("Need ~17GB for this test");
+$Config{ptrsize} >= 8
+    or skip_all("Need 64-bit pointers for this test");
+# this tests what happens when we don't have wide marks
+XS::APItest::wide_marks()
+    and skip_all("Configured for SSize_t marks");
+
+my @x;
+$x[0x8000_0000] = "Hello";
+
+sub x { @x }
+
+ok(!eval { () = x(); 1 }, "stack overflow");
+done_testing();


### PR DESCRIPTION
This also defines a new type to use for the mark stack which can be used by code to always use the correct size for pointers into the mark stack, and provides a fallback for that type in ppport.h for use with older perls.

If we are using I32 for mark indexes, then limit the size of the value stack to the limit of that type.

The idea here is to allow for a gradual migration to SSize_t stack indexes, though I expect most simple XS won't need any changes.