### PR TITLE
POSIX: fix mktime on 32-bit platforms with large time_t

### DIFF
--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -3526,6 +3526,8 @@ asctime(sec, min, hour, mday, mon, year, wday = 0, yday = 0, isdst = -1)
 		    SvOK_off(TARG);
 		else if (result == 0)
 		    sv_setpvs(TARG, "0 but true");
+		else if (sizeof (IV) < sizeof (time_t) && (result < IV_MIN || IV_MAX < result))
+                    sv_setnv(TARG, result);
 		else
 		    sv_setiv(TARG, (IV)result);
 	    } else {

--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our ($AUTOLOAD, %SIGRT);
 
-our $VERSION = '2.15';
+our $VERSION = '2.16';
 
 require XSLoader;
 


### PR DESCRIPTION
If IV is a 32-bit type, but time_t is bigger, then it is possible for mktime() to return values outside the 32-bit range (> 0x7fff_ffff after 2038-01-19). In that case, fall back to NV (i.e. floating point). A double-precision floating point number provides more than 52 bits of precision, which should be plenty.

Fixes #21551.