### PR TITLE
Bisection: Document use of '--one-liner' switch

### DIFF
--- a/Porting/bisect-runner.pl
+++ b/Porting/bisect-runner.pl
@@ -1102,6 +1102,48 @@ L<Commit 125e1a3|https://github.com/Perl/perl5/commit/125e1a36a939>
 
 =back
 
+=head2 When did a one-liner start to emit warnings?
+
+=over 4
+
+=item * Problem
+
+In L<GH issue 21555|https://github.com/Perl/perl5/issues/21555>, it was
+reported that the following one-liner was not emitting warnings in perl-5.16
+but was in perl-5.26 and later releases.
+
+    perl -we '"ab" =~ /.{-1,4}/;'
+
+The reporter's concern was the negative repeat in this (generated) regular
+expression.  The warning being emitted was:
+
+    Unescaped left brace in regex is passed through in regex;
+      marked by <-- HERE in m/.{ <-- HERE -1,4}/ at -e line 1.
+
+At what commit was that warning first emitted?
+
+=item * Solution
+
+We used F<perlbrew> to narrow down the range needing testing to the 5.25
+development cycle.  We then bisected with the C<--one-liner> switch and the
+following invocation:
+
+    export ERR=/tmp/err; rm $ERR
+
+    perl Porting/bisect.pl \
+      --start=v5.24.0 \
+      --end=v5.26.0 \
+      --one-liner 'system(qq|./perl -we "q{ab} =~ /.{-1,4}/" 2>$ENV{ERR}|);
+                  die "See $ENV{ERR} for warnings thrown" if -s $ENV{ERR};'
+
+Bisection pointed to a commit where a modification had been made to a warning.
+
+=item * Reference
+
+L<Commit 8e84dec|https://github.com/Perl/perl5/commit/8e84dec289>
+
+=back
+
 =head2 When did perl stop segfaulting on certain code?
 
 =over 4

--- a/t/porting/known_pod_issues.dat
+++ b/t/porting/known_pod_issues.dat
@@ -1,4 +1,4 @@
-# This file is the data file for t/porting/podcheck.t.
+# This file is the data file for porting/podcheck.t.
 # There are three types of lines.
 # Comment lines are white-space only or begin with a '#', like this one.  Any
 #   changes you make to the comment lines will be lost when the file is
@@ -423,6 +423,7 @@ pod/perlrun.pod	Verbatim line length including indents exceeds 78 by	3
 pod/perlsolaris.pod	Verbatim line length including indents exceeds 78 by	-1
 pod/perltie.pod	Verbatim line length including indents exceeds 78 by	3
 pod/perltru64.pod	Verbatim line length including indents exceeds 78 by	1
+porting/bisect-runner.pl	Verbatim line length including indents exceeds 78 by	2
 porting/epigraphs.pod	Verbatim line length including indents exceeds 78 by	-1
 porting/release_managers_guide.pod	Verbatim line length including indents exceeds 78 by	1
 lib/benchmark.pm	Verbatim line length including indents exceeds 78 by	2


### PR DESCRIPTION
... in the context of searching for first commit when a warning was emitted.

Allow for coding example to exceed 78-char line length.