### PR TITLE
Don't use buggy POSIX 2008 locales on Darwin

### DIFF
--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -364,6 +364,10 @@ esac
 # Darwin's querylocale() has races
 ccflags="$ccflags -DNO_THREAD_SAFE_QUERYLOCALE"
 
+# But it doesn't much matter because the whole implementation has bugs [GH
+# #21556]
+ccflags="$ccflags -DNO_POSIX_2008_LOCALE"
+
 ldlibpthname='DYLD_LIBRARY_PATH';
 
 # useshrplib=true results in much slower startup times.


### PR DESCRIPTION
This fixes #21556

A non-perl C reproducer program is attached to that bug report.

This shows that the current Darwin gets confused.  The solution here is to turn off the POSIX 2008 locale interface, which means that Darwin perls aren't thread-safe w.r.t locale handling.

Past experience has left me cynical about Apple's commitment to fixing reported bugs.  I have examined their locale-handling code previously (not about this bug), and it looked like an early port of *BSD code, which had many locale bugs, which *BSD seem to eventually fix.