### PR TITLE
don't clear IOK on @{"_<$file"} entries when a dbstate is freed

### DIFF
--- a/lib/perl5db.t
+++ b/lib/perl5db.t
@@ -3467,6 +3467,30 @@ EOS
     );
 }
 
+{
+    # https://github.com/Perl/perl5/issues/21564
+    # not a debugger bug, but with the way the fix for #19198 was broken
+    # this needs to be tested with a debugger of some sort (even a no-op
+    # debugger) so test it here.
+    my $wrapper = DebugWrap->new(
+        {
+            cmds =>
+            [
+                'c', # just run it, we check the output of the code
+                'q'
+            ],
+            prog => \<<'EOS',
+use v5.12;
+no strict;
+use B qw(svref_2object SVf_IOK);
+my $sv = svref_2object(\(${"_<$0"}[3])); # the "use B;" line
+say +($sv->FLAGS & SVf_IOK) ? "OK" : "FAIL";
+EOS
+        }
+    );
+    $wrapper->output_like(qr/\bOK\b/, "check the line is IOK");
+}
+
 done_testing();
 
 END {

--- a/op.c
+++ b/op.c
@@ -1361,7 +1361,6 @@ S_cop_free(pTHX_ COP* cop)
         if (av) {
             SV * const * const svp = av_fetch(av, CopLINE(cop), FALSE);
             if (svp && *svp != &PL_sv_undef && SvIVX(*svp) == PTR2IV(cop) ) {
-                (void)SvIOK_off(*svp);
                 SvIV_set(*svp, 0);
             }
         }


### PR DESCRIPTION
These are meant to be IOK even when non-breakable, and I broke that when fixing #19198.

Fixes #21564