### PR TITLE
Fix compiling without LC_ALL defined

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4416,10 +4416,19 @@ Ri	|const char *|mortalized_pv_copy				\
 				|NULLOK const char * const pv
 S	|const char *|native_querylocale_i				\
 				|const locale_category_index cat_index
+S	|void	|new_LC_ALL	|NN const char *lc_all			\
+				|bool force
 S	|void	|output_check_environment_warning			\
 				|NULLOK const char * const language	\
 				|NULLOK const char * const lc_all	\
 				|NULLOK const char * const lang
+S	|parse_LC_ALL_string_return|parse_LC_ALL_string 		\
+				|NN const char *string			\
+				|NN const char **output 		\
+				|const parse_LC_ALL_STRING_action	\
+				|bool always_use_full_array		\
+				|const bool panic_on_error		\
+				|const line_t caller_line
 So	|void	|restore_toggled_locale_i				\
 				|const locale_category_index cat_index	\
 				|NULLOK const char *original_locale	\
@@ -4472,21 +4481,10 @@ S	|const char *|my_langinfo_i					\
 S	|void	|give_perl_locale_control				\
 				|NN const char *lc_all_string		\
 				|const line_t caller_line
-S	|void	|new_LC_ALL	|NN const char *lc_all			\
-				|bool force
-S	|parse_LC_ALL_string_return|parse_LC_ALL_string 		\
-				|NN const char *string			\
-				|NN const char **output 		\
-				|const parse_LC_ALL_STRING_action	\
-				|bool always_use_full_array		\
-				|const bool panic_on_error		\
-				|const line_t caller_line
 #   else
 S	|void	|give_perl_locale_control				\
 				|NN const char **curlocales		\
 				|const line_t caller_line
-S	|void	|new_LC_ALL	|NN const char **individ_locales	\
-				|bool force
 #   endif
 #   if defined(USE_LOCALE_COLLATE)
 S	|void	|new_collate	|NN const char *newcoll 		\

--- a/embed.h
+++ b/embed.h
@@ -1304,7 +1304,9 @@
 #       define get_category_index_helper(a,b,c) S_get_category_index_helper(aTHX_ a,b,c)
 #       define mortalized_pv_copy(a)            S_mortalized_pv_copy(aTHX_ a)
 #       define native_querylocale_i(a)          S_native_querylocale_i(aTHX_ a)
+#       define new_LC_ALL(a,b)                  S_new_LC_ALL(aTHX_ a,b)
 #       define output_check_environment_warning(a,b,c) S_output_check_environment_warning(aTHX_ a,b,c)
+#       define parse_LC_ALL_string(a,b,c,d,e,f) S_parse_LC_ALL_string(aTHX_ a,b,c,d,e,f)
 #       define save_to_buffer(a,b,c)            S_save_to_buffer(aTHX_ a,b,c)
 #       define set_save_buffer_min_size(a,b,c)  S_set_save_buffer_min_size(aTHX_ a,b,c)
 #       define setlocale_failure_panic_via_i(a,b,c,d,e,f,g) S_setlocale_failure_panic_via_i(aTHX_ a,b,c,d,e,f,g)
@@ -1318,11 +1320,8 @@
 #       endif
 #       if defined(LC_ALL)
 #         define give_perl_locale_control(a,b)  S_give_perl_locale_control(aTHX_ a,b)
-#         define new_LC_ALL(a,b)                S_new_LC_ALL(aTHX_ a,b)
-#         define parse_LC_ALL_string(a,b,c,d,e,f) S_parse_LC_ALL_string(aTHX_ a,b,c,d,e,f)
 #       else
 #         define give_perl_locale_control(a,b)  S_give_perl_locale_control(aTHX_ a,b)
-#         define new_LC_ALL(a,b)                S_new_LC_ALL(aTHX_ a,b)
 #       endif
 #       if defined(USE_LOCALE_COLLATE)
 #         define new_collate(a,b)               S_new_collate(aTHX_ a,b)

--- a/locale.c
+++ b/locale.c
@@ -814,7 +814,7 @@ STATIC const bool category_available[] = {
 #  ifdef LC_ALL
     true,
 #  else
-    false
+    false,
 #  endif
 
     false   /* LC_UNKNOWN_AVAIL_ */
@@ -1065,7 +1065,7 @@ Perl_locale_panic(const char * msg,
 #define setlocale_failure_panic_c(cat, cur, fail, line, higher_line)        \
    setlocale_failure_panic_i(cat##_INDEX_, cur, fail, line, higher_line)
 
-#if defined(LC_ALL) && defined(USE_LOCALE)
+#if defined(USE_LOCALE)
 
 /* Expands to the code to
  *      result = savepvn(s, len)
@@ -3949,17 +3949,7 @@ Perl_warn_problematic_locale()
 #  endif /* USE_LOCALE_CTYPE */
 
 STATIC void
-
-#  ifdef LC_ALL
-
 S_new_LC_ALL(pTHX_ const char *lc_all, bool force)
-
-#  else
-
-S_new_LC_ALL(pTHX_ const char ** individ_locales, bool force)
-
-#  endif
-
 {
     PERL_ARGS_ASSERT_NEW_LC_ALL;
 
@@ -3967,8 +3957,6 @@ S_new_LC_ALL(pTHX_ const char ** individ_locales, bool force)
      * called just after a change, so uses the actual underlying locale just
      * set, and not the nominal one (should they differ, as they may in
      * LC_NUMERIC). */
-
-#  ifdef LC_ALL
 
     const char * individ_locales[LC_ALL_INDEX_] = { NULL };
 
@@ -3981,16 +3969,14 @@ S_new_LC_ALL(pTHX_ const char ** individ_locales, bool force)
                                            earlier had to have succeeded */
                                 __LINE__))
     {
-        case invalid:
-        case no_array:
-        case only_element_0:
+      case invalid:
+      case no_array:
+      case only_element_0:
         locale_panic_("Unexpected return from parse_LC_ALL_string");
 
-        case full_array:
+      case full_array:
         break;
     }
-
-#  endif
 
     for_all_individual_category_indexes(i) {
         if (update_functions[i]) {
@@ -3998,12 +3984,7 @@ S_new_LC_ALL(pTHX_ const char ** individ_locales, bool force)
             update_functions[i](aTHX_ this_locale, force);
         }
 
-#  ifdef LC_ALL
-
         Safefree(individ_locales[i]);
-
-#  endif
-
     }
 }
 
@@ -6870,9 +6851,13 @@ S_give_perl_locale_control(pTHX_
 
 #    else
 
-    new_LC_ALL(locales, true);
-
+    new_LC_ALL(calculate_LC_ALL_string(locales,
+                                       INTERNAL_FORMAT,
+                                       WANT_TEMP_PV,
+                                       caller_line),
+               true);
 #    endif
+
 }
 
 STATIC void

--- a/proto.h
+++ b/proto.h
@@ -7021,8 +7021,18 @@ S_native_querylocale_i(pTHX_ const locale_category_index cat_index);
 #   define PERL_ARGS_ASSERT_NATIVE_QUERYLOCALE_I
 
 STATIC void
+S_new_LC_ALL(pTHX_ const char *lc_all, bool force);
+#   define PERL_ARGS_ASSERT_NEW_LC_ALL          \
+        assert(lc_all)
+
+STATIC void
 S_output_check_environment_warning(pTHX_ const char * const language, const char * const lc_all, const char * const lang);
 #   define PERL_ARGS_ASSERT_OUTPUT_CHECK_ENVIRONMENT_WARNING
+
+STATIC parse_LC_ALL_string_return
+S_parse_LC_ALL_string(pTHX_ const char *string, const char **output, const parse_LC_ALL_STRING_action, bool always_use_full_array, const bool panic_on_error, const line_t caller_line);
+#   define PERL_ARGS_ASSERT_PARSE_LC_ALL_STRING \
+        assert(string); assert(output)
 
 STATIC void
 S_restore_toggled_locale_i(pTHX_ const locale_category_index cat_index, const char *original_locale, const line_t caller_line);
@@ -7073,28 +7083,13 @@ S_give_perl_locale_control(pTHX_ const char *lc_all_string, const line_t caller_
 #     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
         assert(lc_all_string)
 
-STATIC void
-S_new_LC_ALL(pTHX_ const char *lc_all, bool force);
-#     define PERL_ARGS_ASSERT_NEW_LC_ALL        \
-        assert(lc_all)
-
-STATIC parse_LC_ALL_string_return
-S_parse_LC_ALL_string(pTHX_ const char *string, const char **output, const parse_LC_ALL_STRING_action, bool always_use_full_array, const bool panic_on_error, const line_t caller_line);
-#     define PERL_ARGS_ASSERT_PARSE_LC_ALL_STRING \
-        assert(string); assert(output)
-
-#   else /* if !defined(LC_ALL) */
+#   else
 STATIC void
 S_give_perl_locale_control(pTHX_ const char **curlocales, const line_t caller_line);
 #     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
         assert(curlocales)
 
-STATIC void
-S_new_LC_ALL(pTHX_ const char **individ_locales, bool force);
-#     define PERL_ARGS_ASSERT_NEW_LC_ALL        \
-        assert(individ_locales)
-
-#   endif /* !defined(LC_ALL) */
+#   endif
 #   if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE const char *
 S_mortalized_pv_copy(pTHX_ const char * const pv)


### PR DESCRIPTION
It is legal to have a platform without the aggregate LC_ALL locale category defined, though I don't know of any such.  Recent changes broke compilation for that case.  This commit restores it.

(To check this, one has to munge perl.h slightly to force it to be #undef, and I hadn't tried that recently)