### PR TITLE
t/loc_tools: Add function returning all locale categories

### DIFF
--- a/t/loc_tools.pl
+++ b/t/loc_tools.pl
@@ -104,6 +104,10 @@ sub _my_fail($) {
     }
 }
 
+sub platform_locale_categories() {
+    return @platform_categories;
+}
+
 sub valid_locale_categories() {
     # Returns a list of the locale categories (expressed as strings, like
     # "LC_ALL") known to this program that are available on this platform.


### PR DESCRIPTION
We already keep this data internally, and have a function that returns the categories that we are permitted to use, but some future tests will need to know that there exist missing ones.