### PR TITLE
locale.c: Fix compilation for non-Windows, non nl_langinfo

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -6327,7 +6327,7 @@ S_my_langinfo_i(pTHX_
          * will find out whether a locale is UTF-8 or not */
 
         utf8ness_t is_utf8 = UTF8NESS_UNKNOWN;
-        const char * scratch_buf = NULL;
+        char * scratch_buf = NULL;
 
 #          if defined(USE_LOCALE_MONETARY) && defined(HAS_LOCALECONV)
 #            define LANGINFO_RECURSED_MONETARY  0x1


### PR DESCRIPTION
Remove this 'const' that a previous commit made illegal.  This hasn't shown up because it's rare for a platform to have this configuration.