### PR TITLE
locale.c: Don't use SvPVX without checking

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -5194,7 +5194,7 @@ S_my_localeconv(pTHX_ const int item)
             }
 
             /* Determine if the string should be marked as UTF-8. */
-            if (UTF8NESS_YES == (get_locale_string_utf8ness_i(SvPVX(*value),
+            if (UTF8NESS_YES == (get_locale_string_utf8ness_i(SvPV_nolen(*value),
                                                   locale_is_utf8,
                                                   NULL,
                                                   (locale_category_index) 0)))


### PR DESCRIPTION
It turns out that compile with -Accflags=-DNO_LOCALE_CONV can cause localeconv() to return SVs that are of SVt_NULL type, so doing an SvPVX can core dump.  SvPV_nolen will coerce the non-string into an empty one so that we don't have to care.