### PR TITLE
Fix a bug in VMS configure script and add trailing quotes

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -382,7 +382,7 @@ Ilya Zakharevich <ilya@math.berkeley.edu> Ilya Zakharevich <ilya@math.ohio-state
 Ingo Weinhold <ingo_weinhold@gmx.de> bonefish@cs.tu-berlin.de <bonefish@cs.tu-berlin.de>
 Ingo Weinhold <ingo_weinhold@gmx.de> Ingo Weinhold <unknown>
 Ingy döt Net <ingy@ttul.org> Brian Ingerson <ingy@ttul.org>
-Jake Hamby <jake.hamby@gmail.com> Jake Hamby <jehamby@lightside.com>
+Jake Hamby <jehamby@lightside.com> Jake Hamby <jake.hamby@gmail.com>
 James E Keenan <jkeenan@cpan.org> James E Keenan <jkeen@verizon.net>
 James E Keenan <jkeenan@cpan.org> James E. Keenan <jkeenan@cpan.org>
 James E Keenan <jkeenan@cpan.org> James Keenan <jkeenan@dromedary-001.ams6.corp.booking.com>

--- a/.mailmap
+++ b/.mailmap
@@ -382,6 +382,7 @@ Ilya Zakharevich <ilya@math.berkeley.edu> Ilya Zakharevich <ilya@math.ohio-state
 Ingo Weinhold <ingo_weinhold@gmx.de> bonefish@cs.tu-berlin.de <bonefish@cs.tu-berlin.de>
 Ingo Weinhold <ingo_weinhold@gmx.de> Ingo Weinhold <unknown>
 Ingy döt Net <ingy@ttul.org> Brian Ingerson <ingy@ttul.org>
+Jake Hamby <jake.hamby@gmail.com>
 James E Keenan <jkeenan@cpan.org> James E Keenan <jkeen@verizon.net>
 James E Keenan <jkeenan@cpan.org> James E. Keenan <jkeenan@cpan.org>
 James E Keenan <jkeenan@cpan.org> James Keenan <jkeenan@dromedary-001.ams6.corp.booking.com>

--- a/.mailmap
+++ b/.mailmap
@@ -382,7 +382,7 @@ Ilya Zakharevich <ilya@math.berkeley.edu> Ilya Zakharevich <ilya@math.ohio-state
 Ingo Weinhold <ingo_weinhold@gmx.de> bonefish@cs.tu-berlin.de <bonefish@cs.tu-berlin.de>
 Ingo Weinhold <ingo_weinhold@gmx.de> Ingo Weinhold <unknown>
 Ingy döt Net <ingy@ttul.org> Brian Ingerson <ingy@ttul.org>
-Jake Hamby <jake.hamby@gmail.com>
+Jake Hamby <jake.hamby@gmail.com> Jake Hamby <jehamby@lightside.com>
 James E Keenan <jkeenan@cpan.org> James E Keenan <jkeen@verizon.net>
 James E Keenan <jkeenan@cpan.org> James E. Keenan <jkeenan@cpan.org>
 James E Keenan <jkeenan@cpan.org> James Keenan <jkeenan@dromedary-001.ams6.corp.booking.com>

--- a/configure.com
+++ b/configure.com
@@ -4050,8 +4050,8 @@ $ WS "#include <stdlib.h>"
 $ WS "#include <math.h>"
 $ WS "int main()"
 $ WS "{"
-$ WS "  long double x = NaN;
-$ WS "  return isnanl(x) ? EXIT_SUCCESS : EXIT_FAILURE;
+$ WS "  long double x = NaN;"
+$ WS "  return isnanl(x) ? EXIT_SUCCESS : EXIT_FAILURE;"
 $ WS "}"
 $ CS
 $ tmp = "isnanl"
@@ -4065,8 +4065,8 @@ $ WS "#include <stdlib.h>"
 $ WS "#include <math.h>"
 $ WS "int main()"
 $ WS "{"
-$ WS "  long long x = llrint(1.5);
-$ WS "  return x == 2 ? EXIT_SUCCESS : EXIT_FAILURE;
+$ WS "  long long x = llrint(1.5);"
+$ WS "  return x == 2 ? EXIT_SUCCESS : EXIT_FAILURE;"
 $ WS "}"
 $ CS
 $ tmp = "llrint"
@@ -4080,8 +4080,8 @@ $ WS "#include <stdlib.h>"
 $ WS "#include <math.h>"
 $ WS "int main()"
 $ WS "{"
-$ WS "  long long x = llrintl(1.5);
-$ WS "  return x == 2 ? EXIT_SUCCESS : EXIT_FAILURE;
+$ WS "  long long x = llrintl(1.5);"
+$ WS "  return x == 2 ? EXIT_SUCCESS : EXIT_FAILURE;"
 $ WS "}"
 $ CS
 $ tmp = "llrintl"
@@ -4095,8 +4095,8 @@ $ WS "#include <stdlib.h>"
 $ WS "#include <math.h>"
 $ WS "int main()"
 $ WS "{"
-$ WS "  long long x = llround(1.5);
-$ WS "  return x == 2 ? EXIT_SUCCESS : EXIT_FAILURE;
+$ WS "  long long x = llround(1.5);"
+$ WS "  return x == 2 ? EXIT_SUCCESS : EXIT_FAILURE;"
 $ WS "}"
 $ CS
 $ tmp = "llround"
@@ -4110,8 +4110,8 @@ $ WS "#include <stdlib.h>"
 $ WS "#include <math.h>"
 $ WS "int main()"
 $ WS "{"
-$ WS "  long long x = llroundl(1.5);
-$ WS "  return x == 2 ? EXIT_SUCCESS : EXIT_FAILURE;
+$ WS "  long long x = llroundl(1.5);"
+$ WS "  return x == 2 ? EXIT_SUCCESS : EXIT_FAILURE;"
 $ WS "}"
 $ CS
 $ tmp = "llroundl"
@@ -4125,8 +4125,8 @@ $ WS "#include <stdlib.h>"
 $ WS "#include <math.h>"
 $ WS "int main()"
 $ WS "{"
-$ WS "  double x = llroundl(1.5);
-$ WS "  return x == 2.0 ? EXIT_SUCCESS : EXIT_FAILURE;
+$ WS "  double x = llroundl(1.5);"
+$ WS "  return x == 2.0 ? EXIT_SUCCESS : EXIT_FAILURE;"
 $ WS "}"
 $ CS
 $ tmp = "nearbyint"
@@ -4140,8 +4140,8 @@ $ WS "#include <stdlib.h>"
 $ WS "#include <math.h>"
 $ WS "int main()"
 $ WS "{"
-$ WS "  double x = round(1.5);
-$ WS "  return x == 2.0 ? EXIT_SUCCESS : EXIT_FAILURE;
+$ WS "  double x = round(1.5);"
+$ WS "  return x == 2.0 ? EXIT_SUCCESS : EXIT_FAILURE;"
 $ WS "}"
 $ CS
 $ tmp = "round"
@@ -4155,8 +4155,8 @@ $ WS "#include <stdlib.h>"
 $ WS "#include <math.h>"
 $ WS "int main()"
 $ WS "{"
-$ WS "  double x = scalbn(1.0, 3);
-$ WS "  return x == 8.0 ? EXIT_SUCCESS : EXIT_FAILURE;
+$ WS "  double x = scalbn(1.0, 3);"
+$ WS "  return x == 8.0 ? EXIT_SUCCESS : EXIT_FAILURE;"
 $ WS "}"
 $ CS
 $ tmp = "scalbn"
@@ -4170,8 +4170,8 @@ $ WS "#include <stdlib.h>"
 $ WS "#include <math.h>"
 $ WS "int main()"
 $ WS "{"
-$ WS "  long double x = scalbn(1.0, 3);
-$ WS "  return x == 8.0 ? EXIT_SUCCESS : EXIT_FAILURE;
+$ WS "  long double x = scalbn(1.0, 3);"
+$ WS "  return x == 8.0 ? EXIT_SUCCESS : EXIT_FAILURE;"
 $ WS "}"
 $ CS
 $ tmp = "scalbnl"
@@ -5091,9 +5091,9 @@ $ OS
 $ WS "#include <sys/stat.h>"
 $ WS "#include <stdio.h>"
 $ WS "#if defined(__DECC) || defined(__DECCXX)"
-$ WS "#include <stdlib.h>
+$ WS "#include <stdlib.h>"
 $ WS "#endif"
-$ WS "int main() {
+$ WS "int main() {"
 $ WS "#''uselargefiles' _LARGEFILE"
 $ WS "#ifdef _LARGEFILE"
 $ WS "    printf(""%d\n"", sizeof(__ino64_t));"

--- a/configure.com
+++ b/configure.com
@@ -2200,7 +2200,6 @@ $     echo4 "...and architecture name already has -ld."
 $   ENDIF
 $ ENDIF
 $!
-$ bool_dflt = "n"
 $ vms_prefix = "perl_root"
 $ vms_prefixup = F$EDIT(vms_prefix,"UPCASE")
 $!


### PR DESCRIPTION
Here's a bug fix for the "installation prefix" prompt in the VMS configure script, which currently thinks it's asking a yes/no question and not a generic string. I also added some missing trailing quotes as a separate commit, to fix the syntax highlighting in vim.

My future pull requests will be from individual topic branches with related fixes in each branch, so that I can make separate pull requests for each. I figure these two commits are non-controversial enough that I can put them in a single pull request.