### PR TITLE
make a new stub to clone into when pushing a new pad

### DIFF
--- a/pad.c
+++ b/pad.c
@@ -2468,8 +2468,19 @@ Perl_pad_push(pTHX_ PADLIST *padlist, int depth)
                         || PadnameIsSTATE(names[ix])
                         || sigil == '&')
                 {
-                    /* outer lexical or anon code */
-                    sv = SvREFCNT_inc(oldpad[ix]);
+                    SV *tmp = oldpad[ix];
+                    if (sigil == '&' && SvTYPE(tmp) == SVt_PVCV
+                        && !PadnameOUTER(names[ix])
+                        && CvLEXICAL(tmp) && CvCLONED(tmp)
+                        && !PadnameIsOUR(names[ix])
+                        && !PadnameIsSTATE(names[ix])) {
+                        /* lexical sub that needs cloning */
+                        sv = newSV_type(SVt_PVCV);
+                    }
+                    else {
+                        /* outer non-cloning lexical or anon code */
+                        sv = SvREFCNT_inc(tmp);
+                    }
                 }
                 else {		/* our own lexical */
                     if (sigil == '@')

--- a/t/op/lexsub.t
+++ b/t/op/lexsub.t
@@ -7,7 +7,8 @@ BEGIN {
     *bar::is = *is;
     *bar::like = *like;
 }
-plan 152;
+
+plan 156;
 
 # -------------------- our -------------------- #
 
@@ -978,4 +979,60 @@ is join("-", qw(aa bb), do { my sub lleexx; 123 }, qw(cc dd)),
         ok(eval 'ceil(1.5)', "no assertion failure calling a lexical sub from nested eval");
     }
     nested();
+}
+
+SKIP:
+{
+    # github #18606
+    sub rec1 {
+        my $x = shift;
+        my sub b { $x };
+        rec1(2) if $x == 1;
+        return b();
+    }
+    is(rec1(1), 1, "check recursively defined lexical sub is lexical");
+
+    sub rec2 {
+        my ($x, $name) = @_;
+
+        my sub b;
+        if ($x) {
+            # provides definition for my sub b
+            sub b { $name }
+        }
+        rec2($x-1, "inner") if $x;
+
+        b();
+    }
+    is(rec2(0, "outer"), "outer", "check again");
+    is(rec2(1, "outer"), "outer", "check some more");
+
+    fresh_perl_like(<<'EOS', qr/result=103/, {}, "test code from #18606");
+use strict; use warnings; use feature qw/say state/;
+say "Perl version $^V";
+
+sub process($;$) {
+  my ($value, $callback) = @_;
+  say "### process($value,", ($callback//"undef"), ")";
+
+  my sub inner {
+    if ($callback) {
+      return $callback->($value+1);
+    } else {
+      return $value+1;
+    }
+  }
+
+  inner();
+}
+
+my $result =
+  process(1, sub{
+                 my $arg = shift;
+                 say "#   callback called with arg $arg";
+                 process($arg+100);
+              });
+say "result=", ($result//"undef");
+EOS
+
 }


### PR DESCRIPTION
This previously put the same CV into the inner pad, so on a recursive call into the owning sub, from this sub, this CV would still be active, and the attempt to clone into the still busy CV would throw.

Fixes #18606