### PR TITLE
remove C++20 deprecated volatile argument

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -772,7 +772,7 @@ CTadop	|Malloc_t|calloc	|MEM_SIZE elements			\
 AOdp	|SSize_t|call_pv	|NN const char *sub_name		\
 				|I32 flags
 AOdp	|SSize_t|call_sv	|NN SV *sv				\
-				|volatile I32 flags
+				|I32 flags
 : Used in several source files
 Rp	|bool	|cando		|Mode_t mode				\
 				|bool effective 			\

--- a/perl.c
+++ b/perl.c
@@ -3060,7 +3060,7 @@ See L<perlcall>.
 */
 
 SSize_t
-Perl_call_sv(pTHX_ SV *sv, volatile I32 flags)
+Perl_call_sv(pTHX_ SV *sv, I32 arg_flags)
                         /* See G_* flags in cop.h */
 {
     LOGOP myop;		/* fake syntax tree node */
@@ -3070,6 +3070,10 @@ Perl_call_sv(pTHX_ SV *sv, volatile I32 flags)
     bool oldcatch = CATCH_GET;
     int ret;
     OP* const oldop = PL_op;
+    /* Since we don't modify flags after setjmp() we don't really need to make
+       flags volatile, but gcc complains that it could be clobbered anyway.
+     */
+    volatile I32 flags = arg_flags;
     dJMPENV;
 
     PERL_ARGS_ASSERT_CALL_SV;

--- a/proto.h
+++ b/proto.h
@@ -444,7 +444,7 @@ Perl_call_pv(pTHX_ const char *sub_name, I32 flags);
         assert(sub_name)
 
 PERL_CALLCONV SSize_t
-Perl_call_sv(pTHX_ SV *sv, volatile I32 flags);
+Perl_call_sv(pTHX_ SV *sv, I32 flags);
 #define PERL_ARGS_ASSERT_CALL_SV                \
         assert(sv)
 


### PR DESCRIPTION
This produced warnings like:
```
g++ -c   -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing \
  -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 \
  -xc++ -I/usr/lib/llvm-18/include -std=c++17 -fno-exceptions \
  -funwind-tables -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS \
  -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS  -fexceptions \
  -I/usr/lib/x86_64-linux-gnu/perl5/5.36/Imager/include -std=c++23 \
  -O2 -g   -DVERSION=\"1.000\" -DXS_VERSION=\"1.000\" -fPIC \
  "-I/usr/lib/x86_64-linux-gnu/perl/5.36/CORE"   LLVM.c
In file included from /usr/lib/x86_64-linux-gnu/perl/5.36/CORE/perl.h:5798,
                 from LLVM.xs:15:
/usr/lib/x86_64-linux-gnu/perl/5.36/CORE/proto.h:392:65: warning: ‘volatile’-qualified parameter is deprecated [-Wvolatile]
  392 | PERL_CALLCONV I32       Perl_call_sv(pTHX_ SV* sv, volatile I32 flags);
      |                                                    ~~~~~~~~~~~~~^~~~~
```
I haven't been able to produce this when building perl itself as C++ since it requires a modern -std argument to reproduce, and that breaks the build in other ways.