### PR TITLE
use the supplied handle in IO::Handle::blocking() on Win32

### DIFF
--- a/dist/IO/IO.pm
+++ b/dist/IO/IO.pm
@@ -7,7 +7,7 @@ use Carp;
 use strict;
 use warnings;
 
-our $VERSION = "1.53";
+our $VERSION = "1.54";
 XSLoader::load 'IO', $VERSION;
 
 sub import {

--- a/dist/IO/IO.xs
+++ b/dist/IO/IO.xs
@@ -86,12 +86,12 @@ io_blocking(pTHX_ InputStream f, int block)
     if (RETVAL >= 0) {
 	int mode = RETVAL;
 	int newmode = mode;
-#ifdef O_NONBLOCK
+#  ifdef O_NONBLOCK
 	/* POSIX style */
 
-# ifndef O_NDELAY
-#  define O_NDELAY O_NONBLOCK
-# endif
+#    ifndef O_NDELAY
+#      define O_NDELAY O_NONBLOCK
+#    endif
 	/* Note: UNICOS and UNICOS/mk a F_GETFL returns an O_NDELAY
 	 * after a successful F_SETFL of an O_NONBLOCK. */
 	RETVAL = RETVAL & (O_NONBLOCK | O_NDELAY) ? 0 : 1;
@@ -102,7 +102,7 @@ io_blocking(pTHX_ InputStream f, int block)
 	} else if (block > 0) {
 	    newmode &= ~(O_NDELAY|O_NONBLOCK);
 	}
-#else
+#  else
 	/* Not POSIX - better have O_NDELAY or we can't cope.
 	 * for BSD-ish machines this is an acceptable alternative
 	 * for SysV we can't tell "would block" from EOF but that is
@@ -115,7 +115,7 @@ io_blocking(pTHX_ InputStream f, int block)
 	} else if (block > 0) {
 	    newmode &= ~O_NDELAY;
 	}
-#endif
+#  endif
 	if (newmode != mode) {
             const int ret = fcntl(fd, F_SETFL, newmode);
 	    if (ret < 0)
@@ -123,8 +123,7 @@ io_blocking(pTHX_ InputStream f, int block)
 	}
     }
     return RETVAL;
-#else
-#   ifdef WIN32
+#elif defined(WIN32)
     if (block >= 0) {
 	unsigned long flags = !block;
 	/* ioctl claims to take char* but really needs a u_long sized buffer */
@@ -139,9 +138,8 @@ io_blocking(pTHX_ InputStream f, int block)
     }
     /* TODO: Perhaps set $! to ENOTSUP? */
     return -1;
-#   else
+#else
     return -1;
-#   endif
 #endif
 }
 

--- a/dist/IO/IO.xs
+++ b/dist/IO/IO.xs
@@ -72,8 +72,6 @@ static int
 io_blocking(pTHX_ InputStream f, int block)
 {
     int fd = -1;
-#if defined(HAS_FCNTL)
-    int RETVAL;
     if (!f) {
 	errno = EBADF;
 	return -1;
@@ -83,7 +81,8 @@ io_blocking(pTHX_ InputStream f, int block)
       errno = EBADF;
       return -1;
     }
-    RETVAL = fcntl(fd, F_GETFL, 0);
+#if defined(HAS_FCNTL)
+    int RETVAL = fcntl(fd, F_GETFL, 0);
     if (RETVAL >= 0) {
 	int mode = RETVAL;
 	int newmode = mode;
@@ -129,8 +128,8 @@ io_blocking(pTHX_ InputStream f, int block)
     if (block >= 0) {
 	unsigned long flags = !block;
 	/* ioctl claims to take char* but really needs a u_long sized buffer */
-	const int ret = ioctl(fd, FIONBIO, (char*)&flags);
-	if (ret != 0)
+
+	if (ioctl(fd, FIONBIO, (char*)&flags) != 0)
 	    return -1;
 	/* Win32 has no way to get the current blocking status of a socket.
 	 * However, we don't want to just return undef, because there's no way

--- a/dist/IO/lib/IO/Dir.pm
+++ b/dist/IO/lib/IO/Dir.pm
@@ -18,7 +18,7 @@ use File::stat;
 use File::Spec;
 
 our @ISA = qw(Tie::Hash Exporter);
-our $VERSION = "1.53";
+our $VERSION = "1.54";
 
 our @EXPORT_OK = qw(DIR_UNLINK);
 

--- a/dist/IO/lib/IO/File.pm
+++ b/dist/IO/lib/IO/File.pm
@@ -135,7 +135,7 @@ require Exporter;
 
 our @ISA = qw(IO::Handle IO::Seekable Exporter);
 
-our $VERSION = "1.53";
+our $VERSION = "1.54";
 
 our @EXPORT = @IO::Seekable::EXPORT;
 

--- a/dist/IO/lib/IO/Handle.pm
+++ b/dist/IO/lib/IO/Handle.pm
@@ -270,7 +270,7 @@ use IO ();	# Load the XS module
 require Exporter;
 our @ISA = qw(Exporter);
 
-our $VERSION = "1.53";
+our $VERSION = "1.54";
 
 our @EXPORT_OK = qw(
     autoflush

--- a/dist/IO/lib/IO/Pipe.pm
+++ b/dist/IO/lib/IO/Pipe.pm
@@ -13,7 +13,7 @@ use strict;
 use Carp;
 use Symbol;
 
-our $VERSION = "1.53";
+our $VERSION = "1.54";
 
 sub new {
     my $type = shift;

--- a/dist/IO/lib/IO/Poll.pm
+++ b/dist/IO/lib/IO/Poll.pm
@@ -12,7 +12,7 @@ use IO::Handle;
 use Exporter ();
 
 our @ISA = qw(Exporter);
-our $VERSION = "1.53";
+our $VERSION = "1.54";
 
 our @EXPORT = qw( POLLIN
 	      POLLOUT

--- a/dist/IO/lib/IO/Seekable.pm
+++ b/dist/IO/lib/IO/Seekable.pm
@@ -106,7 +106,7 @@ require Exporter;
 our @EXPORT = qw(SEEK_SET SEEK_CUR SEEK_END);
 our @ISA = qw(Exporter);
 
-our $VERSION = "1.53";
+our $VERSION = "1.54";
 
 sub seek {
     @_ == 3 or croak 'usage: $io->seek(POS, WHENCE)';

--- a/dist/IO/lib/IO/Select.pm
+++ b/dist/IO/lib/IO/Select.pm
@@ -10,7 +10,7 @@ use     strict;
 use warnings::register;
 require Exporter;
 
-our $VERSION = "1.53";
+our $VERSION = "1.54";
 
 our @ISA = qw(Exporter); # This is only so we can do version checking
 

--- a/dist/IO/lib/IO/Socket.pm
+++ b/dist/IO/lib/IO/Socket.pm
@@ -23,7 +23,7 @@ require IO::Socket::UNIX if ($^O ne 'epoc' && $^O ne 'symbian');
 
 our @ISA = qw(IO::Handle);
 
-our $VERSION = "1.53";
+our $VERSION = "1.54";
 
 our @EXPORT_OK = qw(sockatmark);
 

--- a/dist/IO/lib/IO/Socket/INET.pm
+++ b/dist/IO/lib/IO/Socket/INET.pm
@@ -14,7 +14,7 @@ use Exporter;
 use Errno;
 
 our @ISA = qw(IO::Socket);
-our $VERSION = "1.53";
+our $VERSION = "1.54";
 
 my $EINVAL = exists(&Errno::EINVAL) ? Errno::EINVAL() : 1;
 

--- a/dist/IO/lib/IO/Socket/UNIX.pm
+++ b/dist/IO/lib/IO/Socket/UNIX.pm
@@ -11,7 +11,7 @@ use IO::Socket;
 use Carp;
 
 our @ISA = qw(IO::Socket);
-our $VERSION = "1.53";
+our $VERSION = "1.54";
 
 IO::Socket::UNIX->register_domain( AF_UNIX );
 


### PR DESCRIPTION
The refactor in 375ed12a meant that fd was initialized to -1,
rather than PerlIO_fileno(f) on Win32.

fixes #17455 