### PR TITLE
perlsec: minor taint edit

### DIFF
--- a/pod/perlsec.pod
+++ b/pod/perlsec.pod
@@ -48,7 +48,7 @@ program more secure than the corresponding C program.
 Support for taint checks adds an overhead to all Perl programs,
 whether or not you're using the taint features.
 Perl 5.18 introduced C preprocessor symbols that can
-be used to disable the taint features.
+be used to disable the taint features when building perl.
 
 When taint is enabled,
 you may not use data derived from outside your program to affect

--- a/pod/perlsec.pod
+++ b/pod/perlsec.pod
@@ -45,7 +45,13 @@ these.  Other checks, however, are best supported by the language itself,
 and it is these checks especially that contribute to making a set-id Perl
 program more secure than the corresponding C program.
 
-You may not use data derived from outside your program to affect
+Support for taint checks adds an overhead to all Perl programs,
+whether or not you're using the taint features.
+Perl 5.18 introduced C preprocessor symbols that can
+be used to disable the taint features.
+
+When taint is enabled,
+you may not use data derived from outside your program to affect
 something else outside your program--at least, not by accident.  All
 command line arguments, environment variables, locale information (see
 L<perllocale>), results of certain system calls (C<readdir()>,
@@ -55,11 +61,6 @@ C<getpwxxx()> calls), and all file input are marked as "tainted".
 Tainted data may not be used directly or indirectly in any command
 that invokes a sub-shell, nor in any command that modifies files,
 directories, or processes, B<with the following exceptions>:
-
-Support for taint checks adds an overhead to all Perl programs,
-whether or not you're using the taint features.
-Perl 5.18 introduced C preprocessor symbols that can
-be used to disable the taint features.
 
 =over 4
 


### PR DESCRIPTION
Paragraph signalling option to disable taint landed in the middle of another sentence, breaking it. Move it up, and add a clarifying clause to the start of the para moving down.

(Para was introduced in 7c90a9467d0.)