### PR TITLE
release announcement: perl is the language, perl 5 is the version

### DIFF
--- a/Porting/release_announcement_template.txt
+++ b/Porting/release_announcement_template.txt
@@ -2,8 +2,8 @@
 
     -- [ATTRIBUTION]
 
-We are [SYNONYM FOR 'pleased'] to announce version [VERSION.SUBVERSION],
-the [N-TH] development release of version [VERSION] of Perl 5.
+We are [SYNONYM FOR 'pleased'] to announce version 5.[VERSION.SUBVERSION],
+the [N-TH] development release of version 5.[VERSION] of Perl.
 
 You will soon be able to download Perl 5.[VERSION.SUBVERSION] from your
 favorite CPAN mirror or find it at:
@@ -18,7 +18,7 @@ SHA256 digests for this release are:
 You can find a full list of changes in the file "perldelta.pod" located in
 the "pod" directory inside the release and on the web at
 
-https://metacpan.org/pod/release/[AUTHOR]/perl-5.[VERSION.SUBVERSION]/pod/perldelta.pod
+https://metacpan.org/release/[AUTHOR]/perl-5.[VERSION.SUBVERSION]/view/pod/perldelta.pod
 
 [ACKNOWLEDGEMENTS SECTION FROM PERLDELTA]
 


### PR DESCRIPTION
Update the release announcement template to refer to the language as Perl, and use the full version rather than omitting the 5.

Also update the metacpan link to match its new URLs.