### PR TITLE
`locale.pm`: Fix indirect syntax

### DIFF
--- a/lib/locale.pm
+++ b/lib/locale.pm
@@ -3,7 +3,7 @@ package locale;
 use strict;
 use warnings;
 
-our $VERSION = '1.10';
+our $VERSION = '1.11';
 use Config;
 
 $Carp::Internal{ (__PACKAGE__) } = 1;
@@ -15,37 +15,37 @@ locale - Perl pragma to use or avoid POSIX locales for built-in operations
 =head1 WARNING
 
 DO NOT USE this pragma in scripts that have multiple
-L<threads|threads> active.  The locale is not local to a single thread.
+L<threads> active.  The locale is not local to a single thread.
 Another thread may change the locale at any time, which could cause at a
 minimum that a given thread is operating in a locale it isn't expecting
 to be in.  On some platforms, segfaults can also occur.  The locale
 change need not be explicit; some operations cause perl to change the
-locale itself.  You are vulnerable simply by having done a C<"use
-locale">.
+locale itself.  You are vulnerable simply by having done a C<use
+locale>.
 
 =head1 SYNOPSIS
 
-    @x = sort @y;      # Native-platform/Unicode code point sort order
+    my @x1 = sort @y;      # Native-platform/Unicode code point sort order
     {
         use locale;
-        @x = sort @y;  # Locale-defined sort order
+        my @x2 = sort @y;  # Locale-defined sort order
     }
-    @x = sort @y;      # Native-platform/Unicode code point sort order
+    my @x3 = sort @y;      # Native-platform/Unicode code point sort order
                        # again
 
 =head1 DESCRIPTION
 
 This pragma tells the compiler to enable (or disable) the use of POSIX
-locales for built-in operations (for example, LC_CTYPE for regular
-expressions, LC_COLLATE for string comparison, and LC_NUMERIC for number
-formatting).  Each "use locale" or "no locale"
+locales for built-in operations (for example, C<LC_CTYPE> for regular
+expressions, C<LC_COLLATE> for string comparison, and C<LC_NUMERIC> for number
+formatting).  Each C<use locale> or C<no locale>
 affects statements to the end of the enclosing BLOCK.
 
 See L<perllocale> for more detailed information on how Perl supports
 locales.
 
 On systems that don't have locales, this pragma will cause your operations
-to behave as if in the "C" locale; attempts to change the locale will fail.
+to behave as if in the C<C> locale; attempts to change the locale will fail.
 
 =cut
 
@@ -110,7 +110,7 @@ sub import {
 
             $arg =~ s/^://;
 
-            eval { require POSIX; import POSIX 'locale_h'; };
+            eval { require POSIX; POSIX->import('locale_h'); };
 
             # Map our names to the ones defined by POSIX
             my $LC = "LC_" . uc($arg);
@@ -139,7 +139,7 @@ sub import {
 }
 
 sub unimport {
-    $^H &= ~($locale::hint_bits|$locale::partial_hint_bits);
+    $^H &= ~($locale::hint_bits | $locale::partial_hint_bits);
     $^H{locale} = 0;
 }
 


### PR DESCRIPTION
`POSIX` in `eval`

Fixes https://github.com/Perl/perl5/issues/21596