### PR TITLE
Revert "locale.c: Don't use SvPVX .." and replace

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -5194,12 +5194,12 @@ S_my_localeconv(pTHX_ const int item)
             /* 'value' will contain the string that may need to be marked as
              * UTF-8 */
             SV ** value = hv_fetch(hv, name, strlen(name), true);
-            if (! value) {
+            if (! value || ! SvPOK(*value)) {
                 continue;
             }
 
             /* Determine if the string should be marked as UTF-8. */
-            if (UTF8NESS_YES == (get_locale_string_utf8ness_i(SvPV_nolen(*value),
+            if (UTF8NESS_YES == (get_locale_string_utf8ness_i(SvPVX(*value),
                                                   locale_is_utf8,
                                                   NULL,
                                                   (locale_category_index) 0)))


### PR DESCRIPTION
Commit 2f1617ef716ae12369475fa6c11cbefd7ba7dfca works but under Configurations compiled with -DNO_LOCALE_NUMERIC or -DNO_LOCALE_MONETARY, "uninitialized" errors are emitted.

Revert that commit, and instead test for SvPOK before getting to the spot where the value would be used.