### PR TITLE
Experimentally enable glibc undocumented querylocale()

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -367,6 +367,10 @@ static int debug_initialization = 0;
 #define PERL_IN_LOCALE_C
 #include "perl.h"
 
+#if PERL_VERSION_GT(5,39,9)
+#  error Revert the commit that added this line
+#endif
+
 #ifdef WIN32_USE_FAKE_OLD_MINGW_LOCALES
 
    /* Use -Accflags=-DWIN32_USE_FAKE_OLD_MINGW_LOCALES on a POSIX or *nix box

--- a/perl.h
+++ b/perl.h
@@ -1246,6 +1246,11 @@ typedef enum {
 #  include "perl_langinfo.h"    /* Needed for _NL_LOCALE_NAME */
 
 #  ifdef USE_POSIX_2008_LOCALE
+    /* XXX experimentally use this undocumented GCC feature.  (Below also
+     * checks for its availability before actually using it.) */
+#    ifndef USE_NL_LOCALE_NAME
+#      define USE_NL_LOCALE_NAME
+#    endif
 #    if  defined(HAS_QUERYLOCALE)                                           \
               /* Use querylocale if has it, or has the glibc internal       \
                * undocumented equivalent. */                                \

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -19,6 +19,13 @@ L<perl5394delta>, which describes differences between 5.39.3 and 5.39.4.
 
 XXX Any important notices here
 
+glibc has an undocumented feature to return the current locale when
+using the POSIX 2008 locale API.  This feature is now experimentally
+enabled by default so as to see if there are problems with it.  This
+enabling expires in v5.39.10.  In the meantime, if you run into
+problems, open a bug ticket and Configure with
+C<-Accflags=-DNO_NL_LOCALE_NAME> to turn it off.
+
 =head1 Core Enhancements
 
 XXX New core language features go here.  Summarize user-visible core language


### PR DESCRIPTION
This is querylocale() by another name, and is undocumented, hence we haven't enabled it by default.  But it seems to work fine.  In order to gain wider experience in using it, it is here default-enabled through 5.39.9 (unless we decide to end the experiment earlier), at which point a compilation error will remind us to decide to keep it or take it out.

I put the check in locale.c instead of the more obvious perl.h, because the definition would come earlier in perl.h than the PERL_VERSION macros are defined, and I don't think its worth moving things around for just a potential of a few releases.