### PR TITLE
perl5300delta: mention removal of arybase module

### DIFF
--- a/pod/perl5300delta.pod
+++ b/pod/perl5300delta.pod
@@ -667,6 +667,14 @@ not usually on concerns over their design.
 
 =item *
 
+arybase has been removed. It used to provide the implementation of the C<$[>
+variable (also known as the C<array_base> feature), letting array and string
+indices start at a non-zero value. As the feature has been removed (see
+L</Assigning non-zero to C<$[> is fatal>), this internal module is gone as
+well.
+
+=item *
+
 B::Debug is no longer distributed with the core distribution.  It
 continues to be available on CPAN as
 C<< L<B::Debug|https://metacpan.org/pod/B::Debug> >>.


### PR DESCRIPTION
arybase was the internal module implementing the <span>$</span>[ feature. While the removal of <span>$</span>[ is documented, the removal of arybase was not. This commit tries to fix the oversight.

(Programmers were not supposed to use arybase directly, but it had its own POD documentation and was officially listed as a core module in perlmodlib, and previous perldeltas documented version changes in arybase, so I feel its removal should be mentioned as well.)

See also GH #21619.