### PR TITLE
Fix up locale.c when no mbtowc() nor mbrtowc()

### DIFF
--- a/embedvar.h
+++ b/embedvar.h
@@ -152,7 +152,6 @@
 # define PL_known_layers                        (vTHX->Iknown_layers)
 # define PL_langinfo_buf                        (vTHX->Ilanginfo_buf)
 # define PL_langinfo_bufsize                    (vTHX->Ilanginfo_bufsize)
-# define PL_langinfo_recursed                   (vTHX->Ilanginfo_recursed)
 # define PL_last_in_gv                          (vTHX->Ilast_in_gv)
 # define PL_lastfd                              (vTHX->Ilastfd)
 # define PL_lastgotoprobe                       (vTHX->Ilastgotoprobe)

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -793,13 +793,6 @@ PERLVARI(I, setlocale_bufsize, Size_t, 0)
 PERLVARI(I, less_dicey_locale_buf, char *, NULL)
 PERLVARI(I, less_dicey_locale_bufsize, Size_t, 0)
 #endif
-#if ! defined(HAS_NL_LANGINFO)          \
- &&   defined(USE_LOCALE_CTYPE)         \
- && ! defined(WIN32)                    \
- && ! defined(HAS_MBTOWC)               \
- && ! defined(HAS_MBRTOWC)
-PERLVARI(I, langinfo_recursed, unsigned int, 0)
-#endif
 
 #ifdef PERL_SAWAMPERSAND
 PERLVAR(I, sawampersand, U8)		/* must save all match strings */

--- a/locale.c
+++ b/locale.c
@@ -4501,12 +4501,7 @@ S_get_locale_string_utf8ness_i(pTHX_ const char * string,
      * If we already know the UTF-8ness of the locale, then we immediately know
      * what the string is */
     if (UNLIKELY(known_utf8 != LOCALE_UTF8NESS_UNKNOWN)) {
-        if (known_utf8 == LOCALE_IS_UTF8) {
-            return UTF8NESS_YES;
-        }
-        else {
-            return UTF8NESS_NO;
-        }
+        return (known_utf8 == LOCALE_IS_UTF8) ? UTF8NESS_YES : UTF8NESS_NO;
     }
 
 #    ifdef HAS_RELIABLE_UTF8NESS_DETERMINATION
@@ -4530,11 +4525,7 @@ S_get_locale_string_utf8ness_i(pTHX_ const char * string,
         locale = querylocale_i(cat_index);
     }
 
-    if (is_locale_utf8(locale)) {
-        return UTF8NESS_YES;
-    }
-
-    return UTF8NESS_NO;
+    return (is_locale_utf8(locale)) ? UTF8NESS_YES : UTF8NESS_NO;
 
 #    else
 

--- a/locale.c
+++ b/locale.c
@@ -4504,6 +4504,10 @@ S_get_locale_string_utf8ness_i(pTHX_ const char * string,
         return (known_utf8 == LOCALE_IS_UTF8) ? UTF8NESS_YES : UTF8NESS_NO;
     }
 
+    if (locale == NULL) {
+        locale = querylocale_i(cat_index);
+    }
+
 #    ifdef HAS_RELIABLE_UTF8NESS_DETERMINATION
 
     /* Here, we have available the libc functions that can be used to
@@ -4520,11 +4524,6 @@ S_get_locale_string_utf8ness_i(pTHX_ const char * string,
      * messages really could be UTF-8, and given that the odds are rather small
      * of something not being UTF-8 but being syntactically valid UTF-8, khw
      * has decided to call such strings as UTF-8. */
-
-    if (locale == NULL) {
-        locale = querylocale_i(cat_index);
-    }
-
     return (is_locale_utf8(locale)) ? UTF8NESS_YES : UTF8NESS_NO;
 
 #    else

--- a/locale.c
+++ b/locale.c
@@ -6395,28 +6395,27 @@ S_my_langinfo_i(pTHX_
 #          endif
 #          ifdef USE_LOCALE_TIME
 
-            /* We can also try various strings associated with LC_TIME, like
-             * the names of months or days of the week */
+        /* We can also try various strings associated with LC_TIME, like the
+         * names of months or days of the week */
 
-                DAY_1, DAY_2, DAY_3, DAY_4, DAY_5, DAY_6, DAY_7,
-                MON_1, MON_2, MON_3, MON_4, MON_5, MON_6, MON_7, MON_8,
-                                            MON_9, MON_10, MON_11, MON_12,
-                ALT_DIGITS, AM_STR, PM_STR,
-                ABDAY_1, ABDAY_2, ABDAY_3, ABDAY_4, ABDAY_5, ABDAY_6,
-                                                             ABDAY_7,
-                ABMON_1, ABMON_2, ABMON_3, ABMON_4, ABMON_5, ABMON_6,
-                ABMON_7, ABMON_8, ABMON_9, ABMON_10, ABMON_11, ABMON_12
+            DAY_1, DAY_2, DAY_3, DAY_4, DAY_5, DAY_6, DAY_7,
+            MON_1, MON_2, MON_3, MON_4, MON_5, MON_6, MON_7, MON_8,
+                                        MON_9, MON_10, MON_11, MON_12,
+            ALT_DIGITS, AM_STR, PM_STR,
+            ABDAY_1, ABDAY_2, ABDAY_3, ABDAY_4, ABDAY_5, ABDAY_6, ABDAY_7,
+            ABMON_1, ABMON_2, ABMON_3, ABMON_4, ABMON_5, ABMON_6,
+            ABMON_7, ABMON_8, ABMON_9, ABMON_10, ABMON_11, ABMON_12
 
 #          endif
-
         };
 
 #          ifdef USE_LOCALE_TIME
 
-            /* The code in the recursive call can handle switching the locales,
-             * but by doing it here, we avoid switching each iteration of the
-             * loop */
-            const char * orig_TIME_locale = toggle_locale_c(LC_TIME, locale);
+        /* The code in the recursive call below can handle switching the
+         * locales, but by doing it now here, that code will check and discover
+         * that there is no need to switch then restore, avoiding those each
+         * loop iteration */
+        const char * orig_TIME_locale = toggle_locale_c(LC_TIME, locale);
 
 #          endif
 
@@ -6456,43 +6455,43 @@ S_my_langinfo_i(pTHX_
         const locale_category_index  follow_on_cat_index = LC_ALL_INDEX_;
 #          endif
 
-            /* Everything set up; look through all the strings */
-            for (PERL_UINT_FAST8_T i = 0; i < C_ARRAY_LENGTH(trials); i++) {
-                (void) my_langinfo_i(trials[i], cat_index, locale,
-                                     &scratch_buf, &scratch_buf_size, NULL);
-                cat_index = follow_on_cat_index;
+        /* Everything set up; look through all the strings */
+        for (PERL_UINT_FAST8_T i = 0; i < C_ARRAY_LENGTH(trials); i++) {
+            (void) my_langinfo_i(trials[i], cat_index, locale,
+                                 &scratch_buf, &scratch_buf_size, NULL);
+            cat_index = follow_on_cat_index;
 
-                /* To prevent infinite recursive calls, we don't ask for the
-                 * UTF-8ness of the string (in 'trials[i]') above.  Instead we
-                 * examine the returned string here */
-                const Size_t len = strlen(scratch_buf);
-                const U8 * first_variant;
+            /* To prevent infinite recursive calls, we don't ask for the
+             * UTF-8ness of the string (in 'trials[i]') above.  Instead we
+             * examine the returned string here */
+            const Size_t len = strlen(scratch_buf);
+            const U8 * first_variant;
 
-                /* If the string is identical whether or not it is encoded as
-                 * UTF-8, it isn't helpful in determining UTF8ness. */
-                if (is_utf8_invariant_string_loc((U8 *) scratch_buf, len,
-                                                 &first_variant))
-                {
-                    continue;
-                }
-
-                /* Here, has non-ASCII.  If not legal UTF-8, isn't a UTF-8
-                 * locale */
-                if (! is_utf8_string(first_variant,
-                                     len - (first_variant - (U8 *) scratch_buf)))
-                {
-                    strings_utf8ness = UTF8NESS_NO;
-                    break;
-                }
-
-                /* Here, is a legal non-ASCII UTF-8 string; tentatively set the
-                 * return to YES; possibly overridden by later iterations */
-                strings_utf8ness = UTF8NESS_YES;
+            /* If the string is identical whether or not it is encoded as
+             * UTF-8, it isn't helpful in determining UTF8ness. */
+            if (is_utf8_invariant_string_loc((U8 *) scratch_buf, len,
+                                             &first_variant))
+            {
+                continue;
             }
+
+            /* Here, has non-ASCII.  If not legal UTF-8, isn't a UTF-8
+             * locale */
+            if (! is_utf8_string(first_variant,
+                                 len - (first_variant - (U8 *) scratch_buf)))
+            {
+                strings_utf8ness = UTF8NESS_NO;
+                break;
+            }
+
+            /* Here, is a legal non-ASCII UTF-8 string; tentatively set the
+             * return to YES; possibly overridden by later iterations */
+            strings_utf8ness = UTF8NESS_YES;
+        }
 
 #          ifdef USE_LOCALE_TIME
 
-            restore_toggled_locale_c(LC_TIME, orig_TIME_locale);
+        restore_toggled_locale_c(LC_TIME, orig_TIME_locale);
 
 #          endif
 

--- a/locale.c
+++ b/locale.c
@@ -6301,6 +6301,7 @@ S_my_langinfo_i(pTHX_
 
         utf8ness_t strings_utf8ness = UTF8NESS_UNKNOWN;
         char * scratch_buf = NULL;
+        Size_t scratch_buf_size = 0;
 
 #          if defined(USE_LOCALE_MONETARY) && defined(HAS_LOCALECONV)
 #            define LANGINFO_RECURSED_MONETARY  0x1
@@ -6319,12 +6320,11 @@ S_my_langinfo_i(pTHX_
          */
         if ((PL_langinfo_recursed & LANGINFO_RECURSED_MONETARY) == 0) {
             PL_langinfo_recursed |= LANGINFO_RECURSED_MONETARY;
-            (void) my_langinfo_c(CRNCYSTR, LC_MONETARY, locale, &scratch_buf,
-                                 NULL, &strings_utf8ness);
+            (void) my_langinfo_c(CRNCYSTR, LC_MONETARY, locale,
+                                 &scratch_buf, &scratch_buf_size,
+                                 &strings_utf8ness);
             PL_langinfo_recursed &= ~LANGINFO_RECURSED_MONETARY;
         }
-
-        Safefree(scratch_buf);
 
 #          endif
 #          ifdef USE_LOCALE_TIME
@@ -6370,10 +6370,9 @@ S_my_langinfo_i(pTHX_
 
             PL_langinfo_recursed |= LANGINFO_RECURSED_TIME;
             for (PERL_UINT_FAST8_T i = 0; i < C_ARRAY_LENGTH(times); i++) {
-                scratch_buf = NULL;
-                (void) my_langinfo_c(times[i], LC_TIME, locale, &scratch_buf,
-                                     NULL, &this_is_utf8);
-                Safefree(scratch_buf);
+                (void) my_langinfo_c(times[i], LC_TIME, locale,
+                                     &scratch_buf, &scratch_buf_size,
+                                     &this_is_utf8);
                 if (this_is_utf8 == UTF8NESS_NO) {
                     strings_utf8ness = UTF8NESS_NO;
                     break;
@@ -6397,6 +6396,9 @@ S_my_langinfo_i(pTHX_
         }
 
 #          endif    /* LC_TIME */
+
+        Safefree(scratch_buf);
+        scratch_buf = NULL;
 
         /* If nothing examined above rules out it being UTF-8, and at least one
          * thing fits as UTF-8 (and not plain ASCII), assume the codeset is

--- a/locale.c
+++ b/locale.c
@@ -6299,7 +6299,7 @@ S_my_langinfo_i(pTHX_
          * For non-English locales or non-dollar currency locales, we likely
          * will find out whether a locale is UTF-8 or not */
 
-        utf8ness_t is_utf8 = UTF8NESS_UNKNOWN;
+        utf8ness_t strings_utf8ness = UTF8NESS_UNKNOWN;
         char * scratch_buf = NULL;
 
 #          if defined(USE_LOCALE_MONETARY) && defined(HAS_LOCALECONV)
@@ -6320,7 +6320,7 @@ S_my_langinfo_i(pTHX_
         if ((PL_langinfo_recursed & LANGINFO_RECURSED_MONETARY) == 0) {
             PL_langinfo_recursed |= LANGINFO_RECURSED_MONETARY;
             (void) my_langinfo_c(CRNCYSTR, LC_MONETARY, locale, &scratch_buf,
-                                 NULL, &is_utf8);
+                                 NULL, &strings_utf8ness);
             PL_langinfo_recursed &= ~LANGINFO_RECURSED_MONETARY;
         }
 
@@ -6336,7 +6336,7 @@ S_my_langinfo_i(pTHX_
 #             endif
 
         /* If we have ruled out being UTF-8, no point in checking further. */
-        if (   is_utf8 != UTF8NESS_NO
+        if (   strings_utf8ness != UTF8NESS_NO
             && (PL_langinfo_recursed & LANGINFO_RECURSED_TIME) == 0)
         {
             /* But otherwise do check more.  This is done even if the currency
@@ -6375,18 +6375,18 @@ S_my_langinfo_i(pTHX_
                                      NULL, &this_is_utf8);
                 Safefree(scratch_buf);
                 if (this_is_utf8 == UTF8NESS_NO) {
-                    is_utf8 = UTF8NESS_NO;
+                    strings_utf8ness = UTF8NESS_NO;
                     break;
                 }
 
                 if (this_is_utf8 == UTF8NESS_YES) {
-                    is_utf8 = UTF8NESS_YES;
+                    strings_utf8ness = UTF8NESS_YES;
                 }
             }
             PL_langinfo_recursed &= ~LANGINFO_RECURSED_TIME;
 
-            /* Here we have gone through all the LC_TIME elements.  is_utf8 has
-             * been set as follows:
+            /* Here we have gone through all the LC_TIME elements.
+             * strings_utf8ness has been set as follows:
              *      UTF8NESS_NO           If at least one isn't legal UTF-8
              *      UTF8NESS_IMMMATERIAL  If all are ASCII
              *      UTF8NESS_YES          If all are legal UTF-8 (including
@@ -6401,7 +6401,7 @@ S_my_langinfo_i(pTHX_
         /* If nothing examined above rules out it being UTF-8, and at least one
          * thing fits as UTF-8 (and not plain ASCII), assume the codeset is
          * UTF-8. */
-        if (is_utf8 == UTF8NESS_YES) {
+        if (strings_utf8ness == UTF8NESS_YES) {
             retval = "UTF-8";
             break;
         }

--- a/sv.c
+++ b/sv.c
@@ -16117,13 +16117,6 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
     PL_less_dicey_locale_buf = NULL;
     PL_less_dicey_locale_bufsize = 0;
 #endif
-#if ! defined(HAS_NL_LANGINFO)          \
- &&   defined(USE_LOCALE_CTYPE)         \
- && ! defined(WIN32)                    \
- && ! defined(HAS_MBTOWC)               \
- && ! defined(HAS_MBRTOWC)
-    PL_langinfo_recursed = 0;
-#endif
 
     /* Unicode inversion lists */
 


### PR DESCRIPTION
This code was written when we still required only a C89 compiler for non-Windows systems without nl_langinfo().  Now that we require C99, mbtowc() and mbrtowc() should be available, and this code could be jettisoned.  But I'd like to get it in good shape before I forget the nuances, so that if it needs to be brought back (say because of a non-conforming compiler or buggy implementation), that it easily can.

I therefore re-examined the code and this series of commits is the result.  Notably the lines affected by its inclusion or not are reduced to just a single area of `locale.c`, to make it easier to revert the removal.  And I figured out a few ways to improve it and save some cycles.