### PR TITLE
win32: retire visual studio 2013 support

### DIFF
--- a/README.win32
+++ b/README.win32
@@ -41,7 +41,7 @@ additional software to run (other than what came with your operating
 system).  Currently, this port is capable of using one of the
 following compilers on the Intel x86 and x86_64 architectures:
 
-      Microsoft Visual C++    version 12.0 or later
+      Microsoft Visual C++    Visual C++ 2015 (version 14.0) or later
       Intel C++ Compiler      (experimental)
       Gcc by mingw.org        gcc version 3.4.5-5.3.0
       Gcc by mingw-w64.org    gcc version 4.4.3 or later
@@ -65,14 +65,8 @@ that are also supported by perl's makefile.
 =back
 
 The Microsoft Visual C++ compilers are also now being given away free. They
-are available as "Visual C++ 2013-2022 Community Edition" and are the same
-compilers that ship with "Visual C++ 2013-2022 Professional".
-
-Visual C++ 2013 is capable of B<targeting> XP and Windows Server 2003 but the
-build host requirement is Windows 7/Windows Server 2012. For more details see
-https://docs.microsoft.com/en-us/visualstudio/productinfo/vs2013-compatibility-vs
-and
-https://docs.microsoft.com/en-us/visualstudio/productinfo/vs2013-sysrequirements-vs
+are available as "Visual C++ 2015-2022 Community Edition" and are the same
+compilers that ship with "Visual C++ 2015-2022 Professional".
 
 The MinGW64 compiler is available at L<https://mingw-w64.org>.
 The latter is actually a cross-compiler targeting Win64. There's also a trimmed
@@ -129,23 +123,23 @@ console already set up for your target architecture (x86-32 or x86-64 or IA64).
 With the newer compilers, you may also use the older batch files if you choose
 so.
 
-=item Microsoft Visual C++ 2013-2022 Community Edition
+=item Microsoft Visual C++ 2015-2022 Community Edition
 
-These free versions of Visual C++ 2013-2022 Professional contain the same
+These free versions of Visual C++ 2015-2022 Professional contain the same
 compilers and linkers that ship with the full versions, and also contain
 everything necessary to build Perl.
 
 These packages can be downloaded from L<https://visualstudio.microsoft.com/>.
 
-Install Visual C++ 2013-2022 Community, then setup your environment
+Install Visual C++ 2015-2022 Community, then setup your environment
 using, e.g.
 
-F<C:\Program Files\Microsoft Visual Studio 12.0\Common7\Tools\vsvars32.bat>
+F<C:\Program Files\Microsoft Visual Studio 14.0\Common7\Tools\vsvars32.bat>
 
 (assuming the default installation location was chosen).
 
 Perl should now build using the F<win32/Makefile>.  You will need to edit that
-file to set C<CCTYPE> to one of C<MSVC120>-C<MSVC143> first.
+file to set C<CCTYPE> to one of C<MSVC140>-C<MSVC143> first.
 
 =item Microsoft C++ Build Tools
 
@@ -263,15 +257,6 @@ Type "gmake test" (or "nmake test").  This will run most
 of the tests from the testsuite (many tests will be skipped).
 
 There should be no test failures.
-
-If you build with Visual C++ 2013 then three tests currently may fail with
-Daylight Saving Time related problems: F<t/io/fs.t>,
-F<cpan/HTTP-Tiny/t/110_mirror.t> and F<lib/File/Copy.t>. The failures are
-caused by bugs in the CRT in VC++ 2013 which are fixed in VC++2015 and
-later, as explained by Microsoft here:
-L<https://connect.microsoft.com/VisualStudio/feedback/details/811534/utime-sometimes-fails-to-set-the-correct-file-times-in-visual-c-2013>. In the meantime,
-if you need fixed C<stat> and C<utime> functions then have a look at the
-CPAN distribution Win32::UTCFileTime.
 
 If you build with Visual C++ 2015 or later then F<ext/XS-APItest/t/locale.t>
 may crash (after all its tests have passed). This is due to a regression in the

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -160,8 +160,6 @@ DEFAULT_INC_EXCLUDES_DOT := define
 #
 # uncomment exactly one of the following
 #
-# Visual C++ 2013 (aka Visual C++ 12.0) (full version or Express Edition)
-#CCTYPE		:= MSVC120
 # Visual C++ 2015 (aka Visual C++ 14.0) (full version or Express Edition)
 #CCTYPE		:= MSVC140
 # Visual C++ 2017 (aka Visual C++ 14.1) (full version or Community Edition)
@@ -386,8 +384,6 @@ endif
 ifeq ($(CCHOME),)
 ifeq ($(CCTYPE),GCC)
 CCHOME		:= C:\MinGW
-else ifeq ($(CCTYPE),MSVC120)
-CCHOME		:= $(VCINSTALLDIR)
 else ifeq ($(CCTYPE),MSVC140)
 CCHOME		:= $(VCINSTALLDIR)
 else
@@ -503,13 +499,7 @@ CCLIBDIR := $(CCHOME)\lib;$(CCHOME)\$(GCCTARGET)\lib;$(CCHOME)\lib\gcc\$(GCCTARG
 ARCHPREFIX :=
 else
 CCINCDIR := $(CCHOME)\include
-ifeq ($(CCTYPE),MSVC120)
-ifeq ($(WIN64),define)
-CCLIBDIR := $(CCHOME)\lib\amd64
-else
-CCLIBDIR := $(CCHOME)\lib
-endif
-else ifeq ($(CCTYPE),MSVC140)
+ifeq ($(CCTYPE),MSVC140)
 ifeq ($(WIN64),define)
 CCLIBDIR := $(CCHOME)\lib\amd64
 else
@@ -685,11 +675,7 @@ CXX_FLAG	+= -std:c++20
 endif
 EXTRACFLAGS	= -nologo -GF -W3
 
-ifeq ($(CCTYPE),MSVC120)
-LIBC		= msvcrt.lib
-else
 LIBC		= ucrt.lib
-endif
 
 ifeq ($(CFG),Debug)
 OPTIMIZE	= -Od -Zi
@@ -701,11 +687,7 @@ OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
 EXTRACFLAGS	+= -MD
 else ifeq ($(CFG),DebugFull)
-ifeq ($(CCTYPE),MSVC120)
-LIBC		= msvcrtd.lib
-else
 LIBC		= ucrtd.lib
-endif
 OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
 DEFINES		+= -D_DEBUG -DDEBUGGING
@@ -734,24 +716,19 @@ endif
 
 # For now, silence warnings about "unsafe" CRT functions
 # and POSIX CRT function names being deprecated.
-DEFINES		+= -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE
-
-# Likewise for deprecated Winsock APIs in VC++ 14.0 onwards for now.
-ifneq ($(CCTYPE),MSVC120)
-DEFINES		+= -D_WINSOCK_DEPRECATED_NO_WARNINGS
-endif
+# Likewise for deprecated Winsock APIs
+DEFINES         += -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE \
+                   -D_WINSOCK_DEPRECATED_NO_WARNINGS
 
 LIBBASEFILES	= oldnames.lib kernel32.lib user32.lib gdi32.lib winspool.lib \
 	comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib \
 	netapi32.lib uuid.lib ws2_32.lib mpr.lib winmm.lib version.lib \
 	odbc32.lib odbccp32.lib comctl32.lib
 
-ifneq ($(CCTYPE),MSVC120)
 ifeq ($(CFG),DebugFull)
 LIBBASEFILES	+= msvcrtd.lib vcruntimed.lib
 else
 LIBBASEFILES	+= msvcrt.lib vcruntime.lib
-endif
 endif
 
 # Avoid __intel_new_proc_init link error for libircmt.
@@ -1302,7 +1279,6 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #undef I_QUADMATH&& \
 	echo #undef USE_QUADMATH&& \
 	echo #undef USE_CPLUSPLUS)>> $(MINI_CONFIG_H)
-ifneq ($(CCTYPE),MSVC120)
 	@(echo #undef FILE_ptr&& \
 	echo #undef FILE_cnt&& \
 	echo #undef FILE_base&& \
@@ -1312,7 +1288,6 @@ ifneq ($(CCTYPE),MSVC120)
 	echo #define FILE_base^(fp^) PERLIO_FILE_base^(fp^)&& \
 	echo #define FILE_bufsiz^(fp^) ^(PERLIO_FILE_cnt^(fp^) + PERLIO_FILE_ptr^(fp^) - PERLIO_FILE_base^(fp^)^)&& \
 	echo #define I_STDBOOL)>> $(MINI_CONFIG_H)
-endif
 ifeq ($(WIN64),define)
 ifeq ($(CCTYPE),GCC)
 	@(echo #define LONG_DOUBLESIZE ^16)>> $(MINI_CONFIG_H)

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -102,8 +102,6 @@ DEFAULT_INC_EXCLUDES_DOT = define
 #
 # uncomment exactly one of the following
 #
-# Visual C++ 2013 (aka Visual C++ 12.0) (full version or Express Edition)
-#CCTYPE		= MSVC120
 # Visual C++ 2015 (aka Visual C++ 14.0) (full version or Express Edition)
 #CCTYPE		= MSVC140
 # Visual C++ 2017 (aka Visual C++ 14.1) (full version or Community Edition)
@@ -193,7 +191,7 @@ DEFAULT_INC_EXCLUDES_DOT = define
 # Versions of Visual C++ up to VC++ 14.0 define $(VCINSTALLDIR), but from
 # VC++ 14.1 we need the subfolder given by $(VCToolsInstallDir).
 #
-!IF "$(CCTYPE)" == "MSVC120" || "$(CCTYPE)" == "MSVC140"
+!IF "$(CCTYPE)" == "MSVC140"
 CCHOME		= $(VCINSTALLDIR)
 !ELSE
 CCHOME		= $(VCTOOLSINSTALLDIR)
@@ -371,7 +369,7 @@ MINIDELAYLOAD	= -DELAYLOAD:advapi32.dll
 # Set the install location of the compiler headers/libraries.
 # These are saved into $Config{incpath} and $Config{libpth}.
 CCINCDIR	= $(CCHOME)\include
-!IF "$(CCTYPE)" == "MSVC120" || "$(CCTYPE)" == "MSVC140"
+!IF "$(CCTYPE)" == "MSVC140"
 !  IF "$(WIN64)" == "define"
 CCLIBDIR	= $(CCHOME)\lib\amd64
 !  ELSE
@@ -438,11 +436,7 @@ CXX_FLAG	= $(CXX_FLAG) -std:c++20
 !ENDIF
 EXTRACFLAGS	= -nologo -GF -W3
 
-!IF "$(CCTYPE)" == "MSVC120"
-LIBC		= msvcrt.lib
-!ELSE
 LIBC		= ucrt.lib
-!ENDIF
 
 !IF  "$(CFG)" == "Debug"
 OPTIMIZE	= -Od -Zi
@@ -454,11 +448,7 @@ OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
 EXTRACFLAGS	= $(EXTRACFLAGS) -MD
 !ELSEIF  "$(CFG)" == "DebugFull"
-!  IF "$(CCTYPE)" == "MSVC120"
-LIBC		= msvcrtd.lib
-!  ELSE
 LIBC		= ucrtd.lib
-!  ENDIF
 OPTIMIZE	= -Od -Zi
 LINK_DBG	= -debug
 DEFINES		= $(DEFINES) -D_DEBUG -DDEBUGGING
@@ -486,12 +476,9 @@ OPTIMIZE	= $(OPTIMIZE) -fp:precise
 
 # For now, silence warnings about "unsafe" CRT functions
 # and POSIX CRT function names being deprecated.
-DEFINES		= $(DEFINES) -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE
-
-# Likewise for deprecated Winsock APIs in VC++ 14.0 onwards for now.
-!IF "$(CCTYPE)" != "MSVC120"
-DEFINES		= $(DEFINES) -D_WINSOCK_DEPRECATED_NO_WARNINGS
-!ENDIF
+# Likewise for deprecated Winsock APIs
+DEFINES		= $(DEFINES) -D_CRT_SECURE_NO_DEPRECATE \
+                  -D_CRT_NONSTDC_NO_DEPRECATE -D_WINSOCK_DEPRECATED_NO_WARNINGS
 
 LIBBASEFILES	= \
 		oldnames.lib kernel32.lib user32.lib gdi32.lib winspool.lib \
@@ -499,12 +486,10 @@ LIBBASEFILES	= \
 		netapi32.lib uuid.lib ws2_32.lib mpr.lib winmm.lib \
 		version.lib odbc32.lib odbccp32.lib comctl32.lib
 
-!IF "$(CCTYPE)" != "MSVC120"
-!  IF  "$(CFG)" == "DebugFull"
+!IF  "$(CFG)" == "DebugFull"
 LIBBASEFILES	= $(LIBBASEFILES) msvcrtd.lib vcruntimed.lib
-!  ELSE
+!ELSE
 LIBBASEFILES	= $(LIBBASEFILES) msvcrt.lib vcruntime.lib
-!  ENDIF
 !ENDIF
 
 # Avoid __intel_new_proc_init link error for libircmt.
@@ -963,7 +948,6 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #undef USE_64_BIT_INT&& \
 	echo #undef USE_LONG_DOUBLE&& \
 	echo #undef USE_CPLUSPLUS)>> $(MINI_CONFIG_H)
-!IF "$(CCTYPE)" != "MSVC120"
 	@(echo #undef FILE_ptr&& \
 	echo #undef FILE_cnt&& \
 	echo #undef FILE_base&& \
@@ -973,7 +957,6 @@ $(MINIDIR)\.exists : $(CFGH_TMPL)
 	echo #define FILE_base^(fp^) PERLIO_FILE_base^(fp^)&& \
 	echo #define FILE_bufsiz^(fp^) ^(PERLIO_FILE_cnt^(fp^) + PERLIO_FILE_ptr^(fp^) - PERLIO_FILE_base^(fp^)^)&& \
 	echo #define I_STDBOOL)>> $(MINI_CONFIG_H)
-!ENDIF
 !IF "$(WIN64)"=="define"
 	@(echo #define PTRSIZE ^8&& \
 	echo #define SSize_t $(INT64)&& \


### PR DESCRIPTION
I recently (tried) to test VS 2013 builds, but while vs2013 in theory supports mixed declarations and code, in practice that support is broken, and failed to build toke.obj:

The one case I looked at in detail, VS 2013 required an extra ; after a conditional statement to accept the following declaration, for example:

```
C:\Users\Tony\dev\perl\git>cl /c mixed.c
Microsoft (R) C/C++ Optimizing Compiler Version 18.00.21005.1 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

mixed.c
mixed.c(8) : error C2143: syntax error : missing ';' before 'const'
mixed.c(9) : error C2065: 'pend' : undeclared identifier
mixed.c(9) : error C2100: illegal indirection

C:\Users\Tony\dev\perl\git>type mixed.c
/* adapted from S_intuit_more() in toke.c.
   don't run this code
*/
int g(const char *p) {
  if (!p)
    return (0);

  const char * const pend = p+1;
  return *pend;
}
```

regcomp.obj also failed to build due to the use of the "inline" keyword in regcomp.h.  This is fairly trivially fixable but inline is also C99.

Despite these build issues we haven't received any error reports for VS2013, so I don't think it's worth re-working any mixed declarations to support it.

It might be worth updating regcomp.h to use PERL_STATIC_INLINE but that's out of scope for this commit.