### PR TITLE
cpan/Getopt-Long - Update to version 2.57

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1150,12 +1150,15 @@ cpan/Filter-Util-Call/t/call.t			See if Filter::Util::Call works
 cpan/Filter-Util-Call/t/rt_101033.pm
 cpan/Filter-Util-Call/t/rt_101033.t
 cpan/Filter-Util-Call/t/rt_54452-rebless.t
-cpan/Getopt-Long/lib/Getopt/Long.pm	Fetch command options (GetOptions)
-cpan/Getopt-Long/t/gol-basic.t		See if Getopt::Long works
-cpan/Getopt-Long/t/gol-linkage.t	See if Getopt::Long works
-cpan/Getopt-Long/t/gol-oo.t		See if Getopt::Long works
-cpan/Getopt-Long/t/gol-xargv.t		See if Getopt::Long works
-cpan/Getopt-Long/t/gol-xstring.t	See if Getopt::Long works
+cpan/Getopt-Long/lib/Getopt/Long.pm		Fetch command options (GetOptions)
+cpan/Getopt-Long/lib/Getopt/Long/Parser.pm	Getopt-Long
+cpan/Getopt-Long/t/gol-basic.t			See if Getopt::Long works
+cpan/Getopt-Long/t/gol-linkage.t		See if Getopt::Long works
+cpan/Getopt-Long/t/gol-load1.t			Getopt-Long
+cpan/Getopt-Long/t/gol-load2.t			Getopt-Long
+cpan/Getopt-Long/t/gol-oo.t			See if Getopt::Long works
+cpan/Getopt-Long/t/gol-xargv.t			See if Getopt::Long works
+cpan/Getopt-Long/t/gol-xstring.t		See if Getopt::Long works
 cpan/HTTP-Tiny/corpus/auth-01.txt	Test file related to HTTP::Tiny
 cpan/HTTP-Tiny/corpus/auth-02.txt	Test file related to HTTP::Tiny
 cpan/HTTP-Tiny/corpus/auth-03.txt	Test file related to HTTP::Tiny

--- a/Makefile.SH
+++ b/Makefile.SH
@@ -1441,8 +1441,8 @@ _cleaner2:
 	-rmdir lib/IO/Compress/Zlib lib/IO/Compress/Zip lib/IO/Compress/Gzip
 	-rmdir lib/IO/Compress/Base lib/IO/Compress/Adapter lib/IO/Compress
 	-rmdir lib/IO lib/I18N/LangTags lib/I18N lib/Hash/Util lib/Hash
-	-rmdir lib/HTTP lib/Filter/Util lib/Filter lib/File/Spec
-	-rmdir lib/ExtUtils/Typemaps lib/ExtUtils/ParseXS
+	-rmdir lib/HTTP lib/Getopt/Long lib/Filter/Util lib/Filter
+	-rmdir lib/File/Spec lib/ExtUtils/Typemaps lib/ExtUtils/ParseXS
 	-rmdir lib/ExtUtils/MakeMaker/version lib/ExtUtils/MakeMaker
 	-rmdir lib/ExtUtils/Liblist lib/ExtUtils/Constant lib/ExtUtils/Command
 	-rmdir lib/ExtUtils/CBuilder/Platform/Windows

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -612,7 +612,8 @@ our %Modules = (
     },
 
     'Getopt::Long' => {
-        'DISTRIBUTION' => 'JV/Getopt-Long-2.54.tar.gz',
+        'DISTRIBUTION' => 'JV/Getopt-Long-2.57.tar.gz',
+        'SYNCINFO'     => 'jkeenan on Sat Nov 11 13:09:21 2023',
         'FILES'        => q[cpan/Getopt-Long],
         'EXCLUDED'     => [
             qr{^examples/},

--- a/cpan/Getopt-Long/lib/Getopt/Long/Parser.pm
+++ b/cpan/Getopt-Long/lib/Getopt/Long/Parser.pm
@@ -1,0 +1,177 @@
+#! perl
+
+# Parser.pm -- Getopt::Long object oriented interface
+# Author          : Johan Vromans
+# Created On      : Thu Nov  9 10:37:00 2023
+# Last Modified On: Sat Nov 11 17:48:49 2023
+# Update Count    : 13
+# Status          : Released
+
+package Getopt::Long::Parser;
+
+our $VERSION = 2.57;
+
+=head1 NAME
+
+Getopt::Long::Parser - Getopt::Long object oriented interface
+
+=head1 SYNOPSIS
+
+    use Getopt::Long::Parser;
+    my $p = Getopt::Long::Parser->new;
+    $p->configure( ...configuration options... );
+    if ( $p->getoptions( ...options descriptions... ) ) ...
+    if ( $p->getoptionsfromarray( \@array, ...options descriptions... ) ) ...
+
+Configuration options can be passed to the constructor:
+
+    my $p = Getopt::Long::Parser->new
+             config => [...configuration options...];
+
+=head1 DESCRIPTION
+
+Getopt::Long::Parser is an object oriented interface to
+L<Getopt::Long>. See its documentation for configuration and use.
+
+Note that Getopt::Long and Getopt::Long::Parser are not object
+oriented. Getopt::Long::Parser emulates an object oriented interface,
+which should be okay for most purposes.
+
+=head1 CONSTRUCTOR
+
+    my $p = Getopt::Long::Parser->new( %options );
+
+The constructor takes an optional hash with parameters.
+
+=over 4
+
+=item config
+
+An array reference with configuration settings.
+See L<Getopt::Long/"Configuring Getopt::Long"> for all possible settings.
+
+=back
+
+=cut
+
+# Getopt::Long has a stub for Getopt::Long::Parser::new.
+use Getopt::Long ();
+no warnings 'redefine';
+
+sub new {
+    my $that = shift;
+    my $class = ref($that) || $that;
+    my %atts = @_;
+
+    # Register the callers package.
+    my $self = { caller_pkg => (caller)[0] };
+
+    bless ($self, $class);
+
+    my $default_config = Getopt::Long::_default_config();
+
+    # Process config attributes.
+    if ( defined $atts{config} ) {
+	my $save = Getopt::Long::Configure ($default_config, @{$atts{config}});
+	$self->{settings} = Getopt::Long::Configure ($save);
+	delete ($atts{config});
+    }
+    # Else use default config.
+    else {
+	$self->{settings} = $default_config;
+    }
+
+    if ( %atts ) {		# Oops
+	die(__PACKAGE__.": unhandled attributes: ".
+	    join(" ", sort(keys(%atts)))."\n");
+    }
+
+    $self;
+}
+
+use warnings 'redefine';
+
+=head1 METHODS
+
+In the examples, $p is assumed to be the result of a call to the constructor.
+
+=head2 configure
+
+    $p->configure( %settings );
+
+Update the current config settings.
+See L<Getopt::Long/"Configuring Getopt::Long"> for all possible settings.
+
+=cut
+
+sub configure {
+    my ($self) = shift;
+
+    # Restore settings, merge new settings in.
+    my $save = Getopt::Long::Configure ($self->{settings}, @_);
+
+    # Restore orig config and save the new config.
+    $self->{settings} = Getopt::Long::Configure ($save);
+}
+
+=head2 getoptionsfromarray
+
+    $res = $p->getoptionsfromarray( $aref, @opts );
+
+=head2 getoptions
+
+    $res = $p->getoptions( @opts );
+
+The same as getoptionsfromarray( \@ARGV, @opts ).
+
+=cut
+
+sub getoptions {
+    my ($self) = shift;
+
+    return $self->getoptionsfromarray(\@ARGV, @_);
+}
+
+sub getoptionsfromarray {
+    my ($self) = shift;
+
+    # Restore config settings.
+    my $save = Getopt::Long::Configure ($self->{settings});
+
+    # Call main routine.
+    my $ret = 0;
+    $Getopt::Long::caller = $self->{caller_pkg};
+
+    eval {
+	# Locally set exception handler to default, otherwise it will
+	# be called implicitly here, and again explicitly when we try
+	# to deliver the messages.
+	local ($SIG{__DIE__}) = 'DEFAULT';
+	$ret = Getopt::Long::GetOptionsFromArray (@_);
+    };
+
+    # Restore saved settings.
+    Getopt::Long::Configure ($save);
+
+    # Handle errors and return value.
+    die ($@) if $@;
+    return $ret;
+}
+
+=head1 SEE ALSO
+
+L<Getopt::Long>
+
+=head1 AUTHOR
+
+Johan Vromans <jvromans@squirrel.nl>
+
+=head1 COPYRIGHT AND DISCLAIMER
+
+This program is Copyright 1990,2015,2023 by Johan Vromans.
+This program is free software; you can redistribute it and/or
+modify it under the same terms as Perl.
+
+=cut
+
+1;

--- a/cpan/Getopt-Long/t/gol-load1.t
+++ b/cpan/Getopt-Long/t/gol-load1.t
@@ -1,0 +1,37 @@
+#! perl
+
+# Verify that loading Getopt::Long does not load Getopt::Long::Parser
+# until/unless used.
+
+BEGIN {
+    if( $ENV{PERL_CORE} ) {
+        chdir 't';
+        @INC = ('../lib', 'lib');
+    }
+    else {
+        unshift @INC, 't/lib';
+    }
+}
+
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+use_ok("Getopt::Long");
+
+# Getopt::Long::Parser should not be loaded.
+ok( !defined $Getopt::Long::Parser::VERSION,
+    "Getopt::Long did not load Parser" );
+
+# Create a parser object.
+my $p = Getopt::Long::Parser->new;
+
+# Getopt::Long::Parser should now be loaded.
+ok( defined $Getopt::Long::Parser::VERSION,
+    "Parser $Getopt::Long::Parser::VERSION loaded" );
+
+# Verify version match.
+is( $Getopt::Long::VERSION, $Getopt::Long::Parser::VERSION,
+    "Parser version matches" );
+
+diag( "Testing Getopt::Long $Getopt::Long::VERSION, Perl $], $^X" );

--- a/cpan/Getopt-Long/t/gol-load2.t
+++ b/cpan/Getopt-Long/t/gol-load2.t
@@ -1,0 +1,27 @@
+#! perl
+
+# Verify that loading Getopt::Long::Parser also loads Getopt::Long.
+
+BEGIN {
+    if( $ENV{PERL_CORE} ) {
+        chdir 't';
+        @INC = ('../lib', 'lib');
+    }
+    else {
+        unshift @INC, 't/lib';
+    }
+}
+
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+use_ok("Getopt::Long::Parser");
+
+# Getopt::Long should have been loaded as well.
+ok( defined $Getopt::Long::VERSION,
+    "Getopt::Long::Parser loads Getopt::Long" );
+
+# Verify version match.
+is( $Getopt::Long::VERSION, $Getopt::Long::Parser::VERSION,
+    "Parser version matches" );

--- a/cpan/Getopt-Long/t/gol-oo.t
+++ b/cpan/Getopt-Long/t/gol-oo.t
@@ -9,11 +9,11 @@ BEGIN {
     }
 }
 
-use Getopt::Long;
+use Getopt::Long::Parser;
 my $want_version="2.24";
 die("Getopt::Long version $want_version required--this is only version ".
-    $Getopt::Long::VERSION)
-  unless $Getopt::Long::VERSION ge $want_version;
+    $Getopt::Long::Parser::VERSION)
+  unless $Getopt::Long::Parser::VERSION ge $want_version;
 print "1..14\n";
 
 @ARGV = qw(-Foo -baR --foo bar);

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -98,6 +98,7 @@
 /FindBin.pm
 /GDBM_File.pm
 /Getopt/Long.pm
+/Getopt/Long/
 /HTTP/
 /Hash/
 /I18N/

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1725,6 +1725,7 @@ distclean: realclean
 	-if exist $(LIBDIR)\ExtUtils\Typemaps rmdir /s /q $(LIBDIR)\ExtUtils\Typemaps
 	-if exist $(LIBDIR)\File\Spec rmdir /s /q $(LIBDIR)\File\Spec
 	-if exist $(LIBDIR)\Filter rmdir /s /q $(LIBDIR)\Filter
+	-if exist $(LIBDIR)\Getopt\Long rmdir /s /q $(LIBDIR)\Getopt\Long
 	-if exist $(LIBDIR)\Hash rmdir /s /q $(LIBDIR)\Hash
 	-if exist $(LIBDIR)\HTTP rmdir /s /q $(LIBDIR)\HTTP
 	-if exist $(LIBDIR)\I18N rmdir /s /q $(LIBDIR)\I18N

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -1242,6 +1242,7 @@ distclean: realclean
 	-if exist $(LIBDIR)\ExtUtils\Typemaps rmdir /s /q $(LIBDIR)\ExtUtils\Typemaps
 	-if exist $(LIBDIR)\File\Spec rmdir /s /q $(LIBDIR)\File\Spec
 	-if exist $(LIBDIR)\Filter rmdir /s /q $(LIBDIR)\Filter
+	-if exist $(LIBDIR)\Getopt\Long rmdir /s /q $(LIBDIR)\Getopt\Long
 	-if exist $(LIBDIR)\Hash rmdir /s /q $(LIBDIR)\Hash
 	-if exist $(LIBDIR)\HTTP rmdir /s /q $(LIBDIR)\HTTP
 	-if exist $(LIBDIR)\I18N rmdir /s /q $(LIBDIR)\I18N

--- a/write_buildcustomize.pl
+++ b/write_buildcustomize.pl
@@ -53,6 +53,7 @@ push @toolchain, qw(
 	dist/ExtUtils-ParseXS/lib
 	cpan/parent/lib
 	cpan/ExtUtils-Constant/lib
+    dist/base/lib
 ) if $^O eq 'MSWin32';
 push @toolchain, 'ext/VMS-Filespec/lib' if $^O eq 'VMS';
 


### PR DESCRIPTION
Changes in version 2.57
-----------------------

* Adapt tests for perl core, thanks to James Keenan. Packaging changes only, no functional changes.

Changes in version 2.56
-----------------------

* Do not use Getopt::Long to establish Getopt::Long::Parser version. Packaging changes only, no functional changes.

Changes in version 2.55
-----------------------

* Move Getopt::Long::Parser to a separate module and add documentation. Note that Getopt::Long uses Getopt::Long::Parser, so programs that use Getopt::Long and call the oo interface will still work.

* Allow periods in option names, e.g. to indicate levels in a hierarchical configuration. Since periods in option names have never been valid, they are now allowed by default unless pass_through is enabled.

* Fix long standing bug that duplicate options were not detected when the options differ in case while ignore_case is in effect. This will now yield a warning and become a fatal error in a future release.

Committer: Reflect changes in makefiles due to Getopt-Long reorganization.

In the course of synching Getopt-Long-2.57 into blead there were changes to MANIFEST et al. which led to regeneration of metadata.