### PR TITLE
Skip threaded locale test on OpenBSD and Dragonfly

### DIFF
--- a/lib/locale_threads.t
+++ b/lib/locale_threads.t
@@ -11,6 +11,8 @@ BEGIN {
     set_up_inc('../lib');
 
     skip_all_without_config('useithreads');
+    skip_all("Fails on threaded builds on OpenBSD and DragonFly BSD")
+        if ($^O =~ m/^(openbsd|dragonfly)$/);
 
     require './loc_tools.pl';
 


### PR DESCRIPTION
Due to repeated testing failures on threaded builds subsequent to e2934ffc33.