### PR TITLE
Don't use POSIX 2008 locale on Dragonfly

### DIFF
--- a/hints/dragonfly.sh
+++ b/hints/dragonfly.sh
@@ -87,3 +87,8 @@ case "$cc" in
   d_dlopen='define'
   ;;
 esac
+
+# Dragonfly leaks with a newlocale/freelocale combination.  See
+# https://bugs.dragonflybsd.org/issues/3361
+ccflags="$ccflags -DNO_POSIX_2008"
+


### PR DESCRIPTION
Tony Cook has shown with a C program that it leaks.