### PR TITLE
Fix a compiler warning for 32-bit build in pp.c

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -1621,6 +1621,7 @@ PP(pp_divide)
 #endif
             DIE(aTHX_ "Illegal division by zero");
         TARGn(left / right, 1);
+        goto ret;               /* redundant, but silence -Wunused-label */
     }
 
   ret:


### PR DESCRIPTION
This should fix the warning:
```
pp.c: In function ‘Perl_pp_divide’:
pp.c:1626:3: warning: label ‘ret’ defined but not used [-Wunused-label]
 1626 |   ret:
      |   ^~~
```
This warning is triggered when `PERL_TRY_UV_DIVIDE` is left undefined, e.g. on typical 32-bit configuration with `NV_PRESERVES_UV` defined, and not triggered on typical 64-bit build where IV and NV are both 64-bit.