### PR TITLE
Supported MSCV no longer has a broken localeconv()

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -1279,11 +1279,11 @@ typedef enum {
 #      define USE_PL_CUR_LC_ALL
 #    endif
 
-     /* Assume MingW has the broken localeconv() that Microsoft
+     /* Assume MingW without UCRT has the broken localeconv() that Microsoft
       * fixed in VS 2015 */
-#      ifndef _MSC_VER
-#        define TS_W32_BROKEN_LOCALECONV
-#      endif
+#    if ! defined(_MSC_VER) && ! defined(_UCRT)
+#      define TS_W32_BROKEN_LOCALECONV
+#    endif
 #  endif
 
    /* POSIX 2008 and Windows with thread-safe locales keep locale information

--- a/perl.h
+++ b/perl.h
@@ -1279,14 +1279,9 @@ typedef enum {
 #      define USE_PL_CUR_LC_ALL
 #    endif
 
-     /* Microsoft documentation reads in the change log for VS 2015: "The
-      * localeconv function declared in locale.h now works correctly when
-      * per-thread locale is enabled. In previous versions of the library, this
-      * function would return the lconv data for the global locale, not the
-      * thread's locale." */
+     /* Assume MingW has the broken localeconv() that Microsoft
+      * fixed in VS 2015 */
 #      ifndef _MSC_VER
-#        define TS_W32_BROKEN_LOCALECONV
-#      elif _MSC_VER < 1900
 #        define TS_W32_BROKEN_LOCALECONV
 #      endif
 #  endif


### PR DESCRIPTION
We no longer have to have an ugly, slow workaround that was required for VS 2013 and before.

We still need the workaround for MingW when not used with UCRT, but the 2nd commit removes it from when UCRT is used.