### PR TITLE
embed.fnc: we require C99 variadic macros now

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -65,9 +65,6 @@
 : backport the fixed version to modules.  The only disadvantage khw can think
 : of is the namespace pollution one.
 :
-: Since we don't require a C compiler to support variadic macros (C99), the
-: macros can't be generated in such situations.
-:
 : WARNING: Any macro created in a header file is visible to XS code, unless
 : care is taken to wrap it within C preprocessor guards like the following
 :


### PR DESCRIPTION
As pod/perlhacktips.pod states, we require C compilers to support C99 variadic macros now (since 5.35.5). So remove the comment saying otherwise from embed.fnc.