### PR TITLE
extend "Possible precedence issue" warning, cover more cases

### DIFF
--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -1818,26 +1818,28 @@ sub do_warn_7  { exit $a or $b; }
 sub do_warn_8  { exit $a and $b; }
 sub do_warn_9  { exit $a xor $b; }
 
-# Since exit is an unary operator, it is even stronger than
-# || and &&.
+# Since exit is a unary operator, it is even stronger than
+# ||, &&, ?:, and !=.
 sub do_warn_10 { exit $a || $b; }
 sub do_warn_11 { exit $a && $b; }
+sub do_warn_12 { exit $a ? 0 : $b; }
+sub do_warn_13 { exit $a != $b; }
 
-sub do_warn_12 { goto $a or $b; }
-sub do_warn_13 { goto $a and $b; }
-sub do_warn_14 { goto $a xor $b; }
-sub do_warn_15 { next $a or $b while(1);  }
-sub do_warn_16 { next $a and $b while(1); }
-sub do_warn_17 { next $a xor $b while(1); }
-sub do_warn_18 { last $a or $b while(1);  }
-sub do_warn_19 { last $a and $b while(1); }
-sub do_warn_20 { last $a xor $b while(1); }
-sub do_warn_21 { redo $a or $b while(1); }
-sub do_warn_22 { redo $a and $b while(1); }
-sub do_warn_23 { redo $a xor $b while(1); }
+sub do_warn_14 { goto $a or $b; }
+sub do_warn_15 { goto $a and $b; }
+sub do_warn_16 { goto $a xor $b; }
+sub do_warn_17 { next $a or $b while(1);  }
+sub do_warn_18 { next $a and $b while(1); }
+sub do_warn_19 { next $a xor $b while(1); }
+sub do_warn_20 { last $a or $b while(1);  }
+sub do_warn_21 { last $a and $b while(1); }
+sub do_warn_22 { last $a xor $b while(1); }
+sub do_warn_23 { redo $a or $b while(1); }
+sub do_warn_24 { redo $a and $b while(1); }
+sub do_warn_25 { redo $a xor $b while(1); }
 # These get re-written to "(return/die $a) and $b"
-sub do_warn_24 { $b if return $a; }
-sub do_warn_25 { $b if die $a; }
+sub do_warn_26 { $b if return $a; }
+sub do_warn_27 { $b if die $a; }
 EXPECT
 Possible precedence issue with control flow operator at - line 3.
 Possible precedence issue with control flow operator at - line 4.
@@ -1850,8 +1852,8 @@ Possible precedence issue with control flow operator at - line 10.
 Possible precedence issue with control flow operator at - line 11.
 Possible precedence issue with control flow operator at - line 15.
 Possible precedence issue with control flow operator at - line 16.
+Possible precedence issue with control flow operator at - line 17.
 Possible precedence issue with control flow operator at - line 18.
-Possible precedence issue with control flow operator at - line 19.
 Possible precedence issue with control flow operator at - line 20.
 Possible precedence issue with control flow operator at - line 21.
 Possible precedence issue with control flow operator at - line 22.
@@ -1862,8 +1864,10 @@ Possible precedence issue with control flow operator at - line 26.
 Possible precedence issue with control flow operator at - line 27.
 Possible precedence issue with control flow operator at - line 28.
 Possible precedence issue with control flow operator at - line 29.
+Possible precedence issue with control flow operator at - line 30.
 Possible precedence issue with control flow operator at - line 31.
-Possible precedence issue with control flow operator at - line 32.
+Possible precedence issue with control flow operator at - line 33.
+Possible precedence issue with control flow operator at - line 34.
 ########
 # op.c
 #  (same as above, except these should not warn)


### PR DESCRIPTION
Previously, code like

    return $a or $b;

would emit a warning of the form "Possible precedence issue with control flow operator" because it parses as (return $a) or $b.

However, the equally misleading

    exit $a != 0;      # exit($a) != 0
    exit $a ? 0 : $b;  # exit($a) ? 0 : $b

were not diagnosed.

This patch moves the check higher up in the compiler: Now any binary or ternary operator (not just logical operators) warns if its first operand is an unparenthesized control flow operator that does not terminate normally (i.e. next, last, redo, goto, exit, return, die).