### PR TITLE
elide right operand if left operand transfers control

### DIFF
--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -1857,7 +1857,7 @@ package foo;
 CORE::do({});
 CORE::do({});
 ####
-# [perl #77096] functions that do not follow the llafr
+# [perl #77096] functions that do not follow the looks-like-a-function rule
 () = (return 1) + time;
 () = (return ($1 + $2) * $3) + time;
 () = (return ($a xor $b)) + time;
@@ -1871,6 +1871,26 @@ CORE::do({});
 () = (last 1) + 3;
 () = (next 1) + 3;
 () = (redo 1) + 3;
+() = (-R $_) + 3;
+() = (-W $_) + 3;
+() = (-X $_) + 3;
+() = (-r $_) + 3;
+() = (-w $_) + 3;
+() = (-x $_) + 3;
+>>>>
+() = (return 1);
+() = (return ($1 + $2) * $3);
+() = (return ($a xor $b));
+() = (do 'file') + time;
+() = (do ($1 + $2) * $3) + time;
+() = (do ($1 xor $2)) + time;
+() = (goto 1);
+() = (require 'foo') + 3;
+() = (require foo) + 3;
+() = (CORE::dump 1);
+() = (last 1);
+() = (next 1);
+() = (redo 1);
 () = (-R $_) + 3;
 () = (-W $_) + 3;
 () = (-X $_) + 3;
@@ -1900,6 +1920,13 @@ $_ = ($a xor not +($1 || 2) ** 2);
 () = warn;
 () = warn() + 1;
 () = setpgrp() + 1;
+>>>>
+() = (eof) + 1;
+() = (return);
+() = (return, 1);
+() = warn;
+() = warn() + 1;
+() = setpgrp() + 1;
 ####
 # loopexes have assignment prec
 () = (CORE::dump a) | 'b';
@@ -1907,6 +1934,12 @@ $_ = ($a xor not +($1 || 2) ** 2);
 () = (last a) | 'b';
 () = (next a) | 'b';
 () = (redo a) | 'b';
+>>>>
+() = (CORE::dump a);
+() = (goto a);
+() = (last a);
+() = (next a);
+() = (redo a);
 ####
 # [perl #63558] open local(*FH)
 open local *FH;

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -5392,7 +5392,7 @@ Perl guesses a reasonable buffer size, but puts a sentinel byte at the
 end of the buffer just in case.  This sentinel byte got clobbered, and
 Perl assumes that memory is now corrupted.  See L<perlfunc/ioctl>.
 
-=item Possible precedence issue with control flow operator
+=item Possible precedence issue with control flow operator (%s)
 
 (W syntax) There is a possible problem with the mixing of a control
 flow operator (e.g. C<return>) and a low-precedence operator like

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -1841,33 +1841,33 @@ sub do_warn_25 { redo $a xor $b while(1); }
 sub do_warn_26 { $b if return $a; }
 sub do_warn_27 { $b if die $a; }
 EXPECT
-Possible precedence issue with control flow operator at - line 3.
-Possible precedence issue with control flow operator at - line 4.
-Possible precedence issue with control flow operator at - line 5.
-Possible precedence issue with control flow operator at - line 6.
-Possible precedence issue with control flow operator at - line 7.
-Possible precedence issue with control flow operator at - line 8.
-Possible precedence issue with control flow operator at - line 9.
-Possible precedence issue with control flow operator at - line 10.
-Possible precedence issue with control flow operator at - line 11.
-Possible precedence issue with control flow operator at - line 15.
-Possible precedence issue with control flow operator at - line 16.
-Possible precedence issue with control flow operator at - line 17.
-Possible precedence issue with control flow operator at - line 18.
-Possible precedence issue with control flow operator at - line 20.
-Possible precedence issue with control flow operator at - line 21.
-Possible precedence issue with control flow operator at - line 22.
-Possible precedence issue with control flow operator at - line 23.
-Possible precedence issue with control flow operator at - line 24.
-Possible precedence issue with control flow operator at - line 25.
-Possible precedence issue with control flow operator at - line 26.
-Possible precedence issue with control flow operator at - line 27.
-Possible precedence issue with control flow operator at - line 28.
-Possible precedence issue with control flow operator at - line 29.
-Possible precedence issue with control flow operator at - line 30.
-Possible precedence issue with control flow operator at - line 31.
-Possible precedence issue with control flow operator at - line 33.
-Possible precedence issue with control flow operator at - line 34.
+Possible precedence issue with control flow operator (return) at - line 3.
+Possible precedence issue with control flow operator (return) at - line 4.
+Possible precedence issue with control flow operator (return) at - line 5.
+Possible precedence issue with control flow operator (die) at - line 6.
+Possible precedence issue with control flow operator (die) at - line 7.
+Possible precedence issue with control flow operator (die) at - line 8.
+Possible precedence issue with control flow operator (exit) at - line 9.
+Possible precedence issue with control flow operator (exit) at - line 10.
+Possible precedence issue with control flow operator (exit) at - line 11.
+Possible precedence issue with control flow operator (exit) at - line 15.
+Possible precedence issue with control flow operator (exit) at - line 16.
+Possible precedence issue with control flow operator (exit) at - line 17.
+Possible precedence issue with control flow operator (exit) at - line 18.
+Possible precedence issue with control flow operator (goto) at - line 20.
+Possible precedence issue with control flow operator (goto) at - line 21.
+Possible precedence issue with control flow operator (goto) at - line 22.
+Possible precedence issue with control flow operator (next) at - line 23.
+Possible precedence issue with control flow operator (next) at - line 24.
+Possible precedence issue with control flow operator (next) at - line 25.
+Possible precedence issue with control flow operator (last) at - line 26.
+Possible precedence issue with control flow operator (last) at - line 27.
+Possible precedence issue with control flow operator (last) at - line 28.
+Possible precedence issue with control flow operator (redo) at - line 29.
+Possible precedence issue with control flow operator (redo) at - line 30.
+Possible precedence issue with control flow operator (redo) at - line 31.
+Possible precedence issue with control flow operator (return) at - line 33.
+Possible precedence issue with control flow operator (die) at - line 34.
 ########
 # op.c
 #  (same as above, except these should not warn)


### PR DESCRIPTION
This commit contains the following changes:

- The "possible precedence issue" warning now mentions (in parentheses) the name of the control flow operator that triggered the warning:

      $ ./perl -cwe 'return $a or $b'
      Possible precedence issue with control flow operator (return) at -e line 1.

- CORE::dump now counts as a control flow operator:

      $ ./perl -cwe 'CORE::dump or f()'
      Possible precedence issue with control flow operator (dump) at -e line 1.

- Any binary operator whose left operand is a control flow operator is optimized out along with any right operand it may have, even if no warning is triggered:

      $ ./perl -Ilib -MO=Deparse -we '(die $a) + $b'
      BEGIN { $^W = 1; }
      die $a;
      -e syntax OK

  (No warnings because explicit parentheses are used in the preceding example.)

      $ ./perl -Ilib -MO=Deparse -we 'exit $a ? 0 : 1'
      Possible precedence issue with control flow operator (exit) at -e line 1.
      BEGIN { $^W = 1; }
      exit $a;
      -e syntax OK

   (As discussed in PR #21647.)