### PR TITLE
harness: fix operator precedence in call to exit

### DIFF
--- a/t/harness
+++ b/t/harness
@@ -495,4 +495,4 @@ $h->callback(
 my $agg = $h->runtests(@tests);
 _cleanup_valgrind(\$htoolnm, \$hgrind_ct);
 printf "Finished test run at %s.\n", scalar(localtime);
-exit $agg->has_errors ? 1 : 0;
+exit($agg->has_errors ? 1 : 0);


### PR DESCRIPTION
Previously:

    $ ./perl -w -c t/harness
    Possible precedence issue with control flow operator at t/harness line 498.
    t/harness syntax OK