### PR TITLE
Fix a compiler warning for 32-bit build in locale.c

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -7288,7 +7288,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
     } trials;
 
     trials trial;
-    SSize_t already_checked = 0;
+    unsigned int already_checked = 0;
     const char * checked[C_trial];
 
 #  ifdef LC_ALL
@@ -7374,6 +7374,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
             }
 
             /* And, for future iterations, indicate we've tried this locale */
+            assert(already_checked < C_ARRAY_LENGTH(checked));
             checked[already_checked] = savepv(locale);
             SAVEFREEPV(checked[already_checked]);
             already_checked++;


### PR DESCRIPTION
This fixes a build-time warning on 32-bit target (where sizeof(unsigned int) == sizeof(SSize_t)):
```
locale.c: In function ‘Perl_init_i18nl10n’:
locale.c:7370:40: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘ssize_t’ {aka ‘int’} [-Wsign-compare]
 7370 |             for (unsigned int i = 0; i < already_checked; i++) {
      |                                        ^
```

The variable `already_checked` here never become negative, and never exceed `C_trial` which is a small positive integer, and therefore `unsigned int` should be enough.