### PR TITLE
In win32/GNUmakefile: xcopy libmcfgthread-1.dll to 't' directory

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1822,6 +1822,7 @@ test-prep-gcc :
 	if exist $(CCDLLDIR)\libstdc++-6.dll $(XCOPY) $(CCDLLDIR)\libstdc++-6.dll ..\t\$(NULL)
 	if exist $(CCDLLDIR)\libwinpthread-1.dll $(XCOPY) $(CCDLLDIR)\libwinpthread-1.dll ..\t\$(NULL)
 	if exist $(CCDLLDIR)\libquadmath-0.dll $(XCOPY) $(CCDLLDIR)\libquadmath-0.dll ..\t\$(NULL)
+	if exist $(CCDLLDIR)\libmcfgthread-1.dll $(XCOPY) $(CCDLLDIR)\libmcfgthread-1.dll ..\t\$(NULL)
 
 endif
 


### PR DESCRIPTION
This avoids test failures when the mingw-w64 port of gcc (that built perl) is configured to use MCF threads.
Fixes #21038

The xcopy occurs only if libmcfgthread-1.dll is found in gcc's bin directory.
If <code>bin/libmcfgthread-1.dll</code> does not exist, then gcc has not been configured to use MCF threads and action is neither required nor taken.