### PR TITLE
don't optimize (or warn about) control flow ops in OP_SASSIGN

### DIFF
--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -3384,3 +3384,10 @@ my(@x) = (-2.0, -1.0, -0.0, 0.0, 1.0, 2.0);
 # PADSV_STORE optimised state should be handled
 # CONTEXT use feature "state";
 () = (state $s = 1);
+####
+# control transfer in RHS of assignment
+my $x;
+$x = (return 'ok');
+$x //= (return 'ok');
+$x = exit 42;
+$x //= exit 42;

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -1871,6 +1871,7 @@ Possible precedence issue with control flow operator (die) at - line 34.
 ########
 # op.c
 #  (same as above, except these should not warn)
+use warnings;
 use constant FEATURE => 1;
 use constant MISSING_FEATURE => 0;
 
@@ -1924,6 +1925,12 @@ sub dont_warn_43 { last ($a xor $b) while(1); }
 sub dont_warn_44 { redo ($a or $b) while(1);  }
 sub dont_warn_45 { redo ($a and $b) while(1); }
 sub dont_warn_46 { redo ($a xor $b) while(1); }
+
+# These are not operator precedence issues (even though assignment internally
+# stores its RHS as the first operand)
+sub dont_warn_47 { $a = return $b; }
+sub dont_warn_48 { $a //= return $b; }
+sub dont_warn_49 { $a &&= exit $b; }
 EXPECT
 ########
 use feature "signatures";


### PR DESCRIPTION
In short, `$a = return $b` is stored "backwards": OP_SASSIGN has the RHS of the assignment as its first operand. Warning about precedence makes no sense here.

Logical assignment ops like //=, ||=, &&= are represented as OP_{DOR,OR,AND}ASSIGN wrapped around a weird single-child OP_SASSIGN. Trying to naively elide the inner OP_SASSIGN leaves a dangling outer OP_{DOR,OR,AND}ASSIGN (which B::Deparse doesn't know what to do with) or just makes the compiler loop indefinitely. So just don't.

Fixes #21665.