### PR TITLE
Add a work-around for older Perl's that need `@{^CAPTURE}`

### DIFF
--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -1096,8 +1096,8 @@ An array which exposes the contents of the capture buffers, if any, of
 the last successful pattern match, not counting patterns matched
 in nested blocks that have been exited already.
 
-Note that the 0 index of @{^CAPTURE} is equivalent to $1, the 1 index
-is equivalent to $2, etc.
+Note that the 0 index of C<@{^CAPTURE}> is equivalent to C<$1>, the 1 index
+is equivalent to C<$2>, etc.
 
     if ("foal"=~/(.)(.)(.)(.)/) {
         print join "-", @{^CAPTURE};
@@ -1119,6 +1119,19 @@ see L<perldata/"Demarcated variable names using braces"> for more
 information on this form and its uses.
 
 This variable was added in 5.25.7
+
+If you need access to this functionality in older Perls you can use this
+function immediately after your regexp.
+
+	sub get_captures {
+		no strict 'refs';
+
+		my $last_idx = scalar(@-) - 1;
+		my @arr      = 1 .. $last_idx;
+		my @ret      = map { $$_; } @arr;
+
+		return @ret;
+	}
 
 =item $MATCH
 


### PR DESCRIPTION
I was bit by a bug wherein I was accessing `@{^CAPTURE}` on Perl v5.16 which does not have this variable. This PR adds some documentation to allow a user a work-around if they are in the same situation.