### PR TITLE
skip porting/libperl.t on maint releases

### DIFF
--- a/t/porting/libperl.t
+++ b/t/porting/libperl.t
@@ -45,6 +45,11 @@ use strict;
 
 use Config;
 
+# maint (and tarballs of maint releases) may not have updates here to
+# deal with changes to nm's output in some toolchains
+$^V =~ /^v\d+\.\d*[13579]\./
+  or skip_all "on maint";
+
 if ($Config{cc} =~ /g\+\+/) {
     # XXX Could use c++filt, maybe.
     skip_all "on g++";


### PR DESCRIPTION
maint-* branches, whether supported or not, may not be updated to handle changes to nm's output due to updates to the operating system or toolchain.

The same applies doubly to release tarballs.

So skip this test for maint/version numbers.

Keep the test for devel releases, since they have limited support windows anyway, and we want this test to be done where possible.

Fixes #21677