### PR TITLE
win32/GNUmakefile: disable the .y to .c implicit rule

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1904,3 +1904,6 @@ nok: utils $(PERLEXE) $(PERLDLL) Extensions_nonxs Extensions
 
 nokfile: utils $(PERLEXE) $(PERLDLL) Extensions_nonxs Extensions
 	$(PERLEXE) ..\utils\perlbug -nok -s "(UNINSTALLED)" -F perl.nok
+
+# prevent implicit rule
+%.c : %.y


### PR DESCRIPTION
If perly.y happens to be newer than perly.c gmake 4.4.1 wouldn't bother trying to build the .c from .y, but it would delete the .c as an intermediate anyway.

Fixes #21651