### PR TITLE
add sv_mark_arenas() and sv_sweep_arenas()

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -5748,6 +5748,8 @@ S	|SSize_t|visit		|NN SVFUNC_t f				\
 				|const U32 mask
 # if defined(DEBUGGING)
 S	|void	|del_sv 	|NN SV *p
+p	|void	|sv_mark_arenas
+p	|void	|sv_sweep_arenas
 # endif
 # if !defined(NV_PRESERVES_UV)
 #   if defined(DEBUGGING)

--- a/embed.h
+++ b/embed.h
@@ -2068,6 +2068,8 @@
 #     define visit(a,b,c)                       S_visit(aTHX_ a,b,c)
 #     if defined(DEBUGGING)
 #       define del_sv(a)                        S_del_sv(aTHX_ a)
+#       define sv_mark_arenas()                 Perl_sv_mark_arenas(aTHX)
+#       define sv_sweep_arenas()                Perl_sv_sweep_arenas(aTHX)
 #     endif
 #     if !defined(NV_PRESERVES_UV)
 #       if defined(DEBUGGING)

--- a/pod/perlhacktips.pod
+++ b/pod/perlhacktips.pod
@@ -1927,6 +1927,55 @@ C<-DPERL_MEM_LOG> instead.
 =for apidoc_section $debugging
 =for apidoc Amnh||PL_sv_serial
 
+=head2 Leaked SV spotting: sv_mark_arenas() and sv_sweep_arenas()
+
+These functions exist only on C<DEBUGGING> builds. The first marks all
+live SVs which can be found in the SV arenas with the C<SVf_BREAK> flag.
+The second lists any such SVs which don't have the flag set, and resets
+the flag on the rest. They are intended to identify SVs which are being
+created, but not freed, between two points in code. They can be used
+either by temporarily adding calls to them in the relevant places in the
+code, or by calling them directly from a debugger.
+
+For example, suppose the following code was found to be leaking:
+
+    while (1) { eval '\(1..3)' }
+
+A F<gdb> session on a threaded perl might look something like this:
+
+    $ gdb ./perl
+    (gdb) break Perl_pp_entereval
+    (gdb) run -e'while (1) { eval q{\(1..3)} }'
+    ...
+    Breakpoint 1, Perl_pp_entereval ....
+    (gdb) call Perl_sv_mark_arenas(my_perl)
+    (gdb) continue
+    ...
+    Breakpoint 1, Perl_pp_entereval ....`
+    (gdb) call Perl_sv_sweep_arenas(my_perl)
+    Unmarked SV: 0xaf23a8: AV()
+    Unmarked SV: 0xaf2408: IV(1)
+    Unmarked SV: 0xaf2468: IV(2)
+    Unmarked SV: 0xaf24c8: IV(3)
+    Unmarked SV: 0xace6c8: PV("AV()"\0)
+    Unmarked SV: 0xace848: PV("IV(1)"\0)
+    (gdb) 
+
+Here, at the start of the first call to pp_entereval(), all existing SVs
+are marked. Then at the start of the second call, we list all the SVs
+which have been since been created but not yet freed. It is quickly clear
+that an array and its three elements are likely not being freed, perhaps
+as a result of a bug during constant folding. The final two SVs are just
+temporaries created during the debugging output and can be ignored.
+
+This trick relies on the C<SVf_BREAK> flag not otherwise being used. This
+flag is typically used only during global destruction, but also sometimes
+for a mark and sweep operation when looking for common elements on the two
+sides of a list assignment. The presence of the flag can also alter the
+behaviour of some specific actions in the core, such as choosing whether to
+copy or to COW a string SV. So turning it on can occasionally alter the
+behaviour of code slightly.
+
 =head2 PERL_MEM_LOG
 
 If compiled with C<-DPERL_MEM_LOG> (C<-Accflags=-DPERL_MEM_LOG>), both

--- a/proto.h
+++ b/proto.h
@@ -9051,7 +9051,17 @@ S_del_sv(pTHX_ SV *p);
 #   define PERL_ARGS_ASSERT_DEL_SV              \
         assert(p)
 
-# endif
+PERL_CALLCONV void
+Perl_sv_mark_arenas(pTHX)
+        __attribute__visibility__("hidden");
+#   define PERL_ARGS_ASSERT_SV_MARK_ARENAS
+
+PERL_CALLCONV void
+Perl_sv_sweep_arenas(pTHX)
+        __attribute__visibility__("hidden");
+#   define PERL_ARGS_ASSERT_SV_SWEEP_ARENAS
+
+# endif /* defined(DEBUGGING) */
 # if !defined(NV_PRESERVES_UV)
 #   if defined(DEBUGGING)
 STATIC int


### PR DESCRIPTION
These two functions can be used to help identify which SVs have leaked. See the new section in perlhacktips for full details, but basically the first function sets the SVf_BREAK flag on all existing SVs, while the second lists any SVs without that flag set (and so are likely candidates for having leaked).

Some notes for any PR discussion:
I'm surprised that no one's done this before, and I'm worried that it has already been done but I failed to spot it.
I've made these two functions non-API and only compiled in DEBUGGING builds for now. I'm not sure whether they should get wider accessibility.
The example I give in perlhacktips is the actual real-life first use I made of this new facility. After reducing a leaking test file (which was going to 2Gb) to a simple one-liner, and after a lot of semi-futile single-stepping, I was inspired to do this. It showed me the actual problem within minutes.