### PR TITLE
lib/locale.t: Fix#21697

### DIFF
--- a/lib/locale.t
+++ b/lib/locale.t
@@ -1039,6 +1039,8 @@ foreach my $Locale (@Locale) {
     debug "\n";
     debug "Locale = $Locale\n";
 
+    setlocale(&POSIX::LC_ALL, "C");     # Clear out old code set for a fresh
+                                        # start
     unless (setlocale(&POSIX::LC_ALL, $Locale)) {
         $setlocale_failed{$Locale} = $Locale;
 	next;


### PR DESCRIPTION
This was caused by two failures; the two commits fix one each.

