### PR TITLE
is_utf8_string(): Avoid a redundant conditional

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -2639,10 +2639,6 @@ Perl_is_utf8_string_loclen_flags(const U8 *s, STRLEN len, const U8 **ep, STRLEN 
     assert(0 == (flags & ~(UTF8_DISALLOW_ILLEGAL_INTERCHANGE
                           |UTF8_DISALLOW_PERL_EXTENDED)));
 
-    if (len == 0) {
-        len = strlen((const char *) s);
-    }
-
     if (flags == 0) {
         return is_utf8_string_loclen(s, len, ep, el);
     }
@@ -2657,6 +2653,10 @@ Perl_is_utf8_string_loclen_flags(const U8 *s, STRLEN len, const U8 **ep, STRLEN 
                                     == UTF8_DISALLOW_ILLEGAL_C9_INTERCHANGE)
     {
         return is_c9strict_utf8_string_loclen(s, len, ep, el);
+    }
+
+    if (len == 0) {
+        len = strlen((const char *) s);
     }
 
     if (is_utf8_invariant_string_loc(s, len, &first_variant)) {


### PR DESCRIPTION
This is actually implemented by Perl_is_utf8_string_loclen_flags(), and until this commit unconditionally tested if the input 'len' is 0, and does a strlen() if so.  It then potentially calls one of three API functions which each can handle an input 'len' of 0.  That means each of them test for len being 0 and call strlen() if so.

So, that means this function tests for 'len' 0, then checks to see if any of those functions apply, and if so, calls that one, which then tests for 'len' 0, redundantly.

But this function doesn't actually need to know the len unless none of those three functions apply, so moving the check to later means in all cases we only test for 'len' being 0 once.