### PR TITLE
lib/locale.t: Properly handle setlocale() failure

### DIFF
--- a/lib/locale.t
+++ b/lib/locale.t
@@ -2475,7 +2475,7 @@ foreach $test_num ($first_locales_test_number..$final_locales_test_number) {
     my $has_non_global_failure = $Problem{$test_num}
                             || ! defined $Okay{$test_num}
                             || ! @{$Okay{$test_num}};
-    print "not " if %setlocale_failed || $has_non_global_failure;
+    print "not " if $has_non_global_failure;
     print "ok $test_num";
     $test_names{$test_num} = "" unless defined $test_names{$test_num};
 
@@ -2485,7 +2485,7 @@ foreach $test_num ($first_locales_test_number..$final_locales_test_number) {
     if ($todo) {
         print " # TODO\n";
     }
-    elsif (%setlocale_failed || ! $has_non_global_failure) {
+    elsif (! $has_non_global_failure) {
         print "\n";
     }
     elsif ($has_non_global_failure) {
@@ -2696,6 +2696,15 @@ setlocale(&POSIX::LC_ALL, "C");
 # Give final advice.
 
 my $didwarn = 0;
+
+if (%setlocale_failed) {
+    print "#\nsetlocale() failed for these locales:\n";
+    for my $locale (keys %setlocale_failed) {
+        print "#\t$locale\n";
+    }
+    print "#\n";
+    $didwarn = 1;
+}
 
 foreach ($first_locales_test_number..$final_locales_test_number) {
     if ($Problem{$_}) {


### PR DESCRIPTION
This test file looks at all the locales on the system and tests for basic sanity.  If switching into a particular locale fails, its name is added to a list of such, and the individual tests for it are skipped. Failures for those are kept in a bunch of other lists, one for each type of failure.

At the end the lists are supposed to be output.  However, prior to this commit, the setlocale failure list did not get output, but instead triggered messages that each of the other failure types had occurred. But if a failure type is empty, no list of locales for it would be output.  That is, the header for the failure was output with no content as to which locales failed.  If no failures besides the setlocale one actually happen, you would get a series of these headers.  Unless you were familiar with the normal output of this .t, you would think there are a bunch of unspecified failures, when in fact there were only the setlocale ones.

This commit changes the test to output any setlocale failure list, and to not have one trigger the output of the headers for the other failure types.

This is a longstanding bug, unnoticed because it is rare for us to have a locale we can't actually set to.

This was originally a portion of #21701, but the other portion requires more work.  This stands on its own