### PR TITLE
Revamp localeconv() handling

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4415,12 +4415,12 @@ Sf	|char * |strftime_tm	|NN const char *fmt			\
 				|NN const struct tm *mytm
 # if defined(HAS_LOCALECONV)
 S	|HV *	|my_localeconv	|const int item
-S	|void	|populate_hash_from_localeconv					\
-				|NN HV *hv					\
-				|NN const char *locale				\
-				|const U32 which_mask				\
-				|NN const lconv_offset_t *strings[2]		\
-				|NULLOK const lconv_offset_t *integers[2]
+S	|void	|populate_hash_from_C_localeconv			\
+				|NN HV *hv				\
+				|NN const char *locale			\
+				|const U32 which_mask			\
+				|NN const lconv_offset_t *strings[2]	\
+				|NN const lconv_offset_t *integers[2]
 # endif
 # if defined(USE_LOCALE)
 S	|const char *|calculate_LC_ALL_string					\
@@ -4523,6 +4523,14 @@ ST	|bool	|is_codeset_name_UTF8					\
 				|NN const char *name
 S	|void	|new_ctype	|NN const char *newctype		\
 				|bool force
+#   endif
+#   if defined(USE_LOCALE_MONETARY) || defined(USE_LOCALE_NUMERIC)
+S	|void	|populate_hash_from_localeconv				\
+				|NN HV *hv				\
+				|NN const char *locale			\
+				|const U32 which_mask			\
+				|NN const lconv_offset_t *strings[2]	\
+				|NN const lconv_offset_t *integers[2]
 #   endif
 #   if defined(USE_LOCALE_NUMERIC)
 S	|void	|new_numeric	|NN const char *newnum			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -4415,12 +4415,12 @@ Sf	|char * |strftime_tm	|NN const char *fmt			\
 				|NN const struct tm *mytm
 # if defined(HAS_LOCALECONV)
 S	|HV *	|my_localeconv	|const int item
-S	|void	|populate_hash_from_localeconv				\
-				|NN HV *hv				\
-				|NN const char *locale			\
-				|const U32 which_mask			\
-				|NN const lconv_offset_t *strings[2]	\
-				|NULLOK const lconv_offset_t *integers
+S	|void	|populate_hash_from_localeconv					\
+				|NN HV *hv					\
+				|NN const char *locale				\
+				|const U32 which_mask				\
+				|NN const lconv_offset_t *strings[2]		\
+				|NULLOK const lconv_offset_t *integers[2]
 # endif
 # if defined(USE_LOCALE)
 S	|const char *|calculate_LC_ALL_string					\

--- a/embed.h
+++ b/embed.h
@@ -1307,7 +1307,7 @@
 #     define strftime_tm(a,b)                   S_strftime_tm(aTHX_ a,b)
 #     if defined(HAS_LOCALECONV)
 #       define my_localeconv(a)                 S_my_localeconv(aTHX_ a)
-#       define populate_hash_from_localeconv(a,b,c,d,e) S_populate_hash_from_localeconv(aTHX_ a,b,c,d,e)
+#       define populate_hash_from_C_localeconv(a,b,c,d,e) S_populate_hash_from_C_localeconv(aTHX_ a,b,c,d,e)
 #     endif
 #     if defined(USE_LOCALE)
 #       define calculate_LC_ALL_string(a,b,c,d) S_calculate_LC_ALL_string(aTHX_ a,b,c,d)
@@ -1342,6 +1342,9 @@
 #       if defined(USE_LOCALE_CTYPE)
 #         define is_codeset_name_UTF8           S_is_codeset_name_UTF8
 #         define new_ctype(a,b)                 S_new_ctype(aTHX_ a,b)
+#       endif
+#       if defined(USE_LOCALE_MONETARY) || defined(USE_LOCALE_NUMERIC)
+#         define populate_hash_from_localeconv(a,b,c,d,e) S_populate_hash_from_localeconv(aTHX_ a,b,c,d,e)
 #       endif
 #       if defined(USE_LOCALE_NUMERIC)
 #         define new_numeric(a,b)               S_new_numeric(aTHX_ a,b)

--- a/locale.c
+++ b/locale.c
@@ -5289,7 +5289,7 @@ S_my_localeconv(pTHX_ const int item)
             if (UTF8NESS_YES == (get_locale_string_utf8ness_i(SvPVX(*value),
                                                   LOCALE_IS_UTF8,
                                                   NULL,
-                                                  (locale_category_index) 0)))
+                                                  LC_ALL_INDEX_ /* OOB */)))
             {
                 SvUTF8_on(*value);
             }

--- a/locale.c
+++ b/locale.c
@@ -5005,8 +5005,8 @@ S_my_localeconv(pTHX_ const int item)
      * is supposed to use to get the key names to fill the hash with.  One
      * element is always for the NUMERIC strings (or NULL if none to use), and
      * the other element similarly for the MONETARY ones. */
-#  define NUMERIC_STRING_OFFSET   0
-#  define MONETARY_STRING_OFFSET  1
+#  define NUMERIC_OFFSET   0
+#  define MONETARY_OFFSET  1
     const lconv_offset_t * strings[2] = { NULL, NULL };
 
     /* This is a mask, with one bit to tell S_populate_hash_from_localeconv to
@@ -5078,14 +5078,14 @@ S_my_localeconv(pTHX_ const int item)
           case RADIXCHAR:
             locale = numeric_locale = PL_numeric_name;
             index_bits = INDEX_TO_BIT(LC_NUMERIC_INDEX_);
-            strings[NUMERIC_STRING_OFFSET] = DECIMAL_POINT_ADDRESS;
+            strings[NUMERIC_OFFSET] = DECIMAL_POINT_ADDRESS;
             integers = NULL;
             break;
 
           case THOUSEP:
             index_bits = INDEX_TO_BIT(LC_NUMERIC_INDEX_);
             locale = numeric_locale = PL_numeric_name;
-            strings[NUMERIC_STRING_OFFSET] = thousands_sep_string;
+            strings[NUMERIC_OFFSET] = thousands_sep_string;
             integers = NULL;
             break;
 
@@ -5099,7 +5099,7 @@ S_my_localeconv(pTHX_ const int item)
             /* This item needs the values for both the currency symbol, and
              * another one used to construct the nl_langino()-compatible
              * return. */
-            strings[MONETARY_STRING_OFFSET] = CURRENCY_SYMBOL_ADDRESS;
+            strings[MONETARY_OFFSET] = CURRENCY_SYMBOL_ADDRESS;
             integers = P_CS_PRECEDES_ADDRESS;
             break;
 
@@ -5141,8 +5141,8 @@ S_my_localeconv(pTHX_ const int item)
 
         /* We always pass both sets of strings. 'index_bits' tells
          * S_populate_hash_from_localeconv which to actually look at */
-        strings[NUMERIC_STRING_OFFSET] = lconv_numeric_strings;
-        strings[MONETARY_STRING_OFFSET] = lconv_monetary_strings;
+        strings[NUMERIC_OFFSET] = lconv_numeric_strings;
+        strings[MONETARY_OFFSET] = lconv_monetary_strings;
 
         /* And pass the integer values to populate; again 'index_bits' will
          * say to use them or not */
@@ -5218,7 +5218,7 @@ S_my_localeconv(pTHX_ const int item)
             continue;
         }
 
-        locale = (i == NUMERIC_STRING_OFFSET)
+        locale = (i == NUMERIC_OFFSET)
                  ? numeric_locale
                  : monetary_locale;
 
@@ -5410,7 +5410,7 @@ S_populate_hash_from_localeconv(pTHX_ HV * hv,
         /* One iteration is only for the numeric string fields.  Skip these
          * unless we are compiled to care about those fields and the input
          * parameters indicate we want their values */
-        if (   i == NUMERIC_STRING_OFFSET
+        if (   i == NUMERIC_OFFSET
 
 #  ifdef USE_LOCALE_NUMERIC
 
@@ -5424,7 +5424,7 @@ S_populate_hash_from_localeconv(pTHX_ HV * hv,
 
         /* The other iteration is only for the monetary string fields.  Again
          * skip it unless we want those values */
-        if (   i == MONETARY_STRING_OFFSET
+        if (   i == MONETARY_OFFSET
 
 #  ifdef USE_LOCALE_MONETARY
 
@@ -5457,7 +5457,7 @@ S_populate_hash_from_localeconv(pTHX_ HV * hv,
         }
 
         /* Add any int fields to the HV* */
-        if (i == MONETARY_STRING_OFFSET && integers) {
+        if (i == MONETARY_OFFSET && integers) {
             while (integers->name) {
                 const char value = *((const char *)(  lcbuf_as_string
                                                     + integers->offset));

--- a/locale.c
+++ b/locale.c
@@ -5269,11 +5269,6 @@ S_my_localeconv(pTHX_ const int item)
 
     for (unsigned int i = 0; i < 2; i++) {  /* Try both types of strings */
 
-        const char * locale = locales[i];
-        if (! is_locale_utf8(locale)) {
-            continue;   /* No string can be UTF-8 if the locale isn't */
-        }
-
         /* Examine each string */
         for (const lconv_offset_t *strp = strings[i]; strp->name; strp++) {
             const char * name = strp->name;
@@ -5287,8 +5282,8 @@ S_my_localeconv(pTHX_ const int item)
 
             /* Determine if the string should be marked as UTF-8. */
             if (UTF8NESS_YES == (get_locale_string_utf8ness_i(SvPVX(*value),
-                                                  LOCALE_IS_UTF8,
-                                                  NULL,
+                                                  LOCALE_UTF8NESS_UNKNOWN,
+                                                  locales[i],
                                                   LC_ALL_INDEX_ /* OOB */)))
             {
                 SvUTF8_on(*value);

--- a/locale.c
+++ b/locale.c
@@ -5269,6 +5269,11 @@ S_my_localeconv(pTHX_ const int item)
 
     for (unsigned int i = 0; i < 2; i++) {  /* Try both types of strings */
 
+        /* The return from this function is already adjusted */
+        if (populate[i] == S_populate_hash_from_C_localeconv) {
+            continue;
+        }
+
         /* Examine each string */
         for (const lconv_offset_t *strp = strings[i]; strp->name; strp++) {
             const char * name = strp->name;
@@ -5276,7 +5281,7 @@ S_my_localeconv(pTHX_ const int item)
             /* 'value' will contain the string that may need to be marked as
              * UTF-8 */
             SV ** value = hv_fetch(hv, name, strlen(name), true);
-            if (! value || ! SvPOK(*value)) {
+            if (value == NULL) {
                 continue;
             }
 

--- a/locale.c
+++ b/locale.c
@@ -4925,7 +4925,9 @@ S_my_localeconv(pTHX_ const int item)
         LCONV_NUMERIC_ENTRY(grouping),
 #   endif
         LCONV_NUMERIC_ENTRY(thousands_sep),
+#   define THOUSANDS_SEP_LITERAL  "thousands_sep"
         LCONV_NUMERIC_ENTRY(decimal_point),
+#   define DECIMAL_POINT_LITERAL "decimal_point"
         {NULL, 0}
     };
 
@@ -4954,6 +4956,7 @@ S_my_localeconv(pTHX_ const int item)
         LCONV_MONETARY_ENTRY(positive_sign),
         LCONV_MONETARY_ENTRY(negative_sign),
         LCONV_MONETARY_ENTRY(currency_symbol),
+#  define CURRENCY_SYMBOL_LITERAL  "currency_symbol"
         {NULL, 0}
     };
 
@@ -4978,6 +4981,7 @@ S_my_localeconv(pTHX_ const int item)
         LCONV_ENTRY(int_p_sign_posn),
         LCONV_ENTRY(int_n_sign_posn),
 #  endif
+#      define P_CS_PRECEDES_LITERAL    "p_cs_precedes"
         LCONV_ENTRY(p_cs_precedes),
         {NULL, 0}
     };
@@ -6031,7 +6035,6 @@ S_my_langinfo_i(pTHX_
 
     /* These items are available from localeconv(). */
 
-#      define P_CS_PRECEDES    "p_cs_precedes"
    /* case RADIXCHAR:   // May drop down to here in some configurations */
       case THOUSEP:
       case CRNCYSTR:
@@ -6057,11 +6060,12 @@ S_my_langinfo_i(pTHX_
              * with exactly both fields.  Delete this one, leaving just the
              * CRNCYSTR one in the hash */
             SV* precedes = hv_delete(result_hv,
-                                     P_CS_PRECEDES, STRLENs(P_CS_PRECEDES),
+                                     P_CS_PRECEDES_LITERAL,
+                                     STRLENs(P_CS_PRECEDES_LITERAL),
                                      0);
             if (! precedes) {
                 locale_panic_("my_localeconv() unexpectedly didn't return"
-                              " a value for " P_CS_PRECEDES);
+                              " a value for " P_CS_PRECEDES_LITERAL);
             }
 
             /* The modification is to prefix the localeconv() return with a

--- a/locale.c
+++ b/locale.c
@@ -4860,7 +4860,7 @@ Perl_localeconv(pTHX)
 
 }
 
-#if  defined(HAS_LOCALECONV)
+#if defined(HAS_LOCALECONV)
 
 HV *
 S_my_localeconv(pTHX_ const int item)
@@ -5066,44 +5066,47 @@ S_my_localeconv(pTHX_ const int item)
      *
      * For each, set up the appropriate parameters for the call below to
      * S_populate_hash_from_localeconv() */
-    if (item != 0) switch (item) {
-      default:
-        locale_panic_(Perl_form(aTHX_
-                    "Unexpected item passed to my_localeconv: %d", item));
-        break;
+    if (item != 0) {
+        switch (item) {
+          default:
+            locale_panic_(Perl_form(aTHX_
+                          "Unexpected item passed to my_localeconv: %d", item));
+            break;
 
 #    ifdef USE_LOCALE_NUMERIC
 
-      case RADIXCHAR:
-        locale = numeric_locale = PL_numeric_name;
-        index_bits = INDEX_TO_BIT(LC_NUMERIC_INDEX_);
-        strings[NUMERIC_STRING_OFFSET] = DECIMAL_POINT_ADDRESS;
-        integers = NULL;
-        break;
+          case RADIXCHAR:
+            locale = numeric_locale = PL_numeric_name;
+            index_bits = INDEX_TO_BIT(LC_NUMERIC_INDEX_);
+            strings[NUMERIC_STRING_OFFSET] = DECIMAL_POINT_ADDRESS;
+            integers = NULL;
+            break;
 
-      case THOUSEP:
-        index_bits = INDEX_TO_BIT(LC_NUMERIC_INDEX_);
-        locale = numeric_locale = PL_numeric_name;
-        strings[NUMERIC_STRING_OFFSET] = thousands_sep_string;
-        integers = NULL;
-        break;
+          case THOUSEP:
+            index_bits = INDEX_TO_BIT(LC_NUMERIC_INDEX_);
+            locale = numeric_locale = PL_numeric_name;
+            strings[NUMERIC_STRING_OFFSET] = thousands_sep_string;
+            integers = NULL;
+            break;
 
 #    endif
 #    ifdef USE_LOCALE_MONETARY
 
-      case CRNCYSTR:
-        index_bits = INDEX_TO_BIT(LC_MONETARY_INDEX_);
-        locale = monetary_locale = querylocale_c(LC_MONETARY);
+          case CRNCYSTR:
+            index_bits = INDEX_TO_BIT(LC_MONETARY_INDEX_);
+            locale = monetary_locale = querylocale_c(LC_MONETARY);
 
-        /* This item needs the values for both the currency symbol, and another
-         * one used to construct the nl_langino()-compatible return */
-        strings[MONETARY_STRING_OFFSET] = CURRENCY_SYMBOL_ADDRESS;
-        integers = P_CS_PRECEDES_ADDRESS;
-        break;
+            /* This item needs the values for both the currency symbol, and
+             * another one used to construct the nl_langino()-compatible
+             * return. */
+            strings[MONETARY_STRING_OFFSET] = CURRENCY_SYMBOL_ADDRESS;
+            integers = P_CS_PRECEDES_ADDRESS;
+            break;
 
 #    endif
 
-    } /* End of switch() */
+        } /* End of switch() */
+    }
 
     else    /* End of for just one item to emulate nl_langinfo() */
 

--- a/locale.c
+++ b/locale.c
@@ -4999,6 +4999,13 @@ S_my_localeconv(pTHX_ const int item)
                                           lconv_monetary_strings
                                         };
 
+    /* The LC_MONETARY category also has some integer-valued fields, whose
+     * information is kept in a separate parallel array to 'strings' */
+    const lconv_offset_t * integers[2] = {
+                                           NULL,
+                                           lconv_integers
+                                         };
+
     /* If we aren't paying attention to a given category, use LC_CTYPE instead;
      * If not paying attention to that either, the code below should end up not
      * using this.  Make sure that things blow up if that avoidance gets lost,
@@ -5043,10 +5050,6 @@ S_my_localeconv(pTHX_ const int item)
     /* This will be either 'numeric_locale' or 'monetary_locale' depending on
      * what we are working on at the moment */
     const char * locale;
-
-    /* The LC_MONETARY category also has some integer-valued fields, whose
-     * information is kept in a separate list */
-    const lconv_offset_t * integers = lconv_integers;
 
 #  ifdef HAS_SOME_LANGINFO
 
@@ -5113,7 +5116,6 @@ S_my_localeconv(pTHX_ const int item)
             strings[NUMERIC_OFFSET] = thousands_sep_string;
 
           numeric_common:
-            integers = NULL;
             index_bits = OFFSET_TO_BIT(NUMERIC_OFFSET);
             locale = numeric_locale = PL_numeric_name;
             break;
@@ -5133,7 +5135,7 @@ S_my_localeconv(pTHX_ const int item)
             }
 
             strings[MONETARY_OFFSET] = CURRENCY_SYMBOL_ADDRESS;
-            integers = P_CS_PRECEDES_ADDRESS;
+            integers[MONETARY_OFFSET] = P_CS_PRECEDES_ADDRESS;
 
             index_bits = OFFSET_TO_BIT(MONETARY_OFFSET);
             break;
@@ -5199,10 +5201,7 @@ S_my_localeconv(pTHX_ const int item)
         populate_hash_from_localeconv(hv,
                                       numeric_locale,
                                       OFFSET_TO_BIT(NUMERIC_OFFSET),
-                                      strings,
-                                      NULL      /* There are no NUMERIC integer
-                                                   fields */
-                                     );
+                                      strings, integers);
     }
 
     /* Here, the hash has been completely populated.
@@ -5272,12 +5271,14 @@ S_my_localeconv(pTHX_ const int item)
                 SvUTF8_on(*value);
             }
         }
-    }   /* End of fixing up UTF8ness */
 
+        if (integers[i] == NULL) {
+            continue;
+        }
 
-    /* Examine each integer */
-    for (; integers; integers++) {
-        const char * name = integers->name;
+        /* And each integer */
+        for (const lconv_offset_t *intp = integers[i]; intp->name; intp++) {
+            const char * name = intp->name;
 
         if (! name) {   /* Reached the end */
             break;
@@ -5291,6 +5292,7 @@ S_my_localeconv(pTHX_ const int item)
         /* Change CHAR_MAX to -1 */
         if (SvIV(*value) == CHAR_MAX) {
             sv_setiv(*value, -1);
+        }
         }
     }
 
@@ -5313,8 +5315,8 @@ S_populate_hash_from_localeconv(pTHX_ HV * hv,
                                        * monetary */
                                       const lconv_offset_t * strings[2],
 
-                                      /* And to the monetary integer fields */
-                                      const lconv_offset_t * integers)
+                                      /* And similarly the integer fields */
+                                      const lconv_offset_t * integers[2])
 {
     PERL_ARGS_ASSERT_POPULATE_HASH_FROM_LOCALECONV;
     PERL_UNUSED_ARG(which_mask);    /* Some configurations don't use this;
@@ -5463,14 +5465,17 @@ S_populate_hash_from_localeconv(pTHX_ HV * hv,
             category_strings++;
         }
 
-        /* Add any int fields to the HV* */
-        if (i == MONETARY_OFFSET && integers) {
-            while (integers->name) {
+        /* Add any int fields to the HV*. */
+        if (integers[i]) {
+            const lconv_offset_t * current = integers[i];
+            while (current->name) {
                 const char value = *((const char *)(  lcbuf_as_string
-                                                    + integers->offset));
-                (void) hv_store(hv, integers->name,
-                                strlen(integers->name), newSViv(value), 0);
-                integers++;
+                                                    + current->offset));
+                (void) hv_store(hv,
+                                current->name, strlen(current->name),
+                                newSViv(value),
+                                0);
+                current++;
             }
         }
     }   /* End of loop through the fields */

--- a/locale.c
+++ b/locale.c
@@ -5438,31 +5438,22 @@ S_populate_hash_from_localeconv(pTHX_ HV * hv,
 
         /* For each field for the given category ... */
         const lconv_offset_t * category_strings = strings[i];
-        while (1) {
-            const char * name = category_strings->name;
-            if (! name) {   /* Quit at the end */
-                break;
-            }
+        while (category_strings->name) {
 
-            /* we have set things up so that we know where in the returned
+            /* We have set things up so that we know where in the returned
              * structure, when viewed as a string, the corresponding value is.
              * */
             const char *value = *((const char **)(  lcbuf_as_string
                                                   + category_strings->offset));
-
-            /* Set to get next string on next iteration */
-            category_strings++;
-
-            /* Skip if this platform doesn't have this field. */
-            if (! value) {
-                continue;
+            if (value) {    /* Copy to the hash */
+                (void) hv_store(hv,
+                                category_strings->name,
+                                strlen(category_strings->name),
+                                newSVpv(value, strlen(value)),
+                                0);
             }
 
-            /* Copy to the hash */
-            (void) hv_store(hv,
-                            name, strlen(name),
-                            newSVpv(value, strlen(value)),
-                            0);
+            category_strings++;
         }
 
         /* Add any int fields to the HV* */

--- a/locale.c
+++ b/locale.c
@@ -5213,6 +5213,19 @@ S_my_localeconv(pTHX_ const int item)
                                   strings,
                                   integers
                                  );
+#    ifndef HAS_SOME_LANGINFO  /* Could be using this function to emulate
+                                nl_langinfo() */
+
+    /* We are done when called with an individual item.  There are no integer
+     * items to adjust, and it's best for the caller to determine if this
+     * string item is UTF-8 or not.  This is because the locale's UTF-8ness is
+     * calculated below, and in some Configurations, that can lead to a
+     * recursive call to here, which could recurse infinitely. */
+    if (item != 0) {
+        return hv;
+    }
+
+#    endif
 
     /* The above call may have done all the hash fields, but not always, as
      * already explained.  If we need a second call it is always for the
@@ -5243,20 +5256,6 @@ S_my_localeconv(pTHX_ const int item)
      * corrections determined at hash population time, at an extra maintenance
      * cost which khw doesn't think is worth it
      */
-
-#    ifndef HAS_SOME_LANGINFO
-
-    /* We are done when called with an individual item.  There are no integer
-     * items to adjust, and it's best for the caller to determine if this
-     * string item is UTF-8 or not.  This is because the locale's UTF-8ness is
-     * calculated below, and in some Configurations, that can lead to a
-     * recursive call to here, which could recurse infinitely. */
-
-    if (item != 0) {
-        return hv;
-    }
-
-#    endif
 
     for (unsigned int i = 0; i < 2; i++) {  /* Try both types of strings */
         if (! strings[i]) {     /* Skip if no strings of this type */

--- a/locale.c
+++ b/locale.c
@@ -5089,31 +5089,30 @@ S_my_localeconv(pTHX_ const int item)
 #    ifdef USE_LOCALE_NUMERIC
 
           case RADIXCHAR:
-            locale = numeric_locale = PL_numeric_name;
-            index_bits = OFFSET_TO_BIT(NUMERIC_OFFSET);
             strings[NUMERIC_OFFSET] = DECIMAL_POINT_ADDRESS;
-            integers = NULL;
-            break;
+            goto numeric_common;
 
           case THOUSEP:
+            strings[NUMERIC_OFFSET] = thousands_sep_string;
+
+          numeric_common:
+            integers = NULL;
             index_bits = OFFSET_TO_BIT(NUMERIC_OFFSET);
             locale = numeric_locale = PL_numeric_name;
-            strings[NUMERIC_OFFSET] = thousands_sep_string;
-            integers = NULL;
             break;
 
 #    endif
 #    ifdef USE_LOCALE_MONETARY
 
           case CRNCYSTR:
-            index_bits = OFFSET_TO_BIT(MONETARY_OFFSET);
-            locale = monetary_locale = querylocale_c(LC_MONETARY);
-
             /* This item needs the values for both the currency symbol, and
              * another one used to construct the nl_langino()-compatible
              * return. */
             strings[MONETARY_OFFSET] = CURRENCY_SYMBOL_ADDRESS;
             integers = P_CS_PRECEDES_ADDRESS;
+
+            index_bits = OFFSET_TO_BIT(MONETARY_OFFSET);
+            locale = monetary_locale = querylocale_c(LC_MONETARY);
             break;
 
 #    endif

--- a/proto.h
+++ b/proto.h
@@ -7012,7 +7012,7 @@ S_my_localeconv(pTHX_ const int item);
 #   define PERL_ARGS_ASSERT_MY_LOCALECONV
 
 STATIC void
-S_populate_hash_from_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers);
+S_populate_hash_from_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2]);
 #   define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_LOCALECONV \
         assert(hv); assert(locale); assert(strings)
 

--- a/proto.h
+++ b/proto.h
@@ -7012,9 +7012,9 @@ S_my_localeconv(pTHX_ const int item);
 #   define PERL_ARGS_ASSERT_MY_LOCALECONV
 
 STATIC void
-S_populate_hash_from_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2]);
-#   define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_LOCALECONV \
-        assert(hv); assert(locale); assert(strings)
+S_populate_hash_from_C_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2]);
+#   define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_C_LOCALECONV \
+        assert(hv); assert(locale); assert(strings); assert(integers)
 
 # endif /* defined(HAS_LOCALECONV) */
 # if defined(USE_LOCALE)
@@ -7134,6 +7134,13 @@ S_new_ctype(pTHX_ const char *newctype, bool force);
         assert(newctype)
 
 #   endif /* defined(USE_LOCALE_CTYPE) */
+#   if defined(USE_LOCALE_MONETARY) || defined(USE_LOCALE_NUMERIC)
+STATIC void
+S_populate_hash_from_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2]);
+#     define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_LOCALECONV \
+        assert(hv); assert(locale); assert(strings); assert(integers)
+
+#   endif
 #   if defined(USE_LOCALE_NUMERIC)
 STATIC void
 S_new_numeric(pTHX_ const char *newnum, bool force);


### PR DESCRIPTION
localeconv() is problematic.  It isn't thread-safe on any platform except modern Windows.  It returns lots of values, and from two different locale categories (which don't have to be set to the same locale), and it is buggy on Windows. And, it's used a lot in Windows, to find what the decimal point character is.

Thus there's lots of compensation locale.c does to accommodate this, and for the variances in Configurations.  This series of commits begins the process of simplifying it and speeding it up in some cases.

Often, the locale is C.  When this is the case, all the values are the same with one exception.  And those values are documented by the Standards, so are known at compile time, and thus no mutex locking is needed to make it thread-safe.  One commit introduces a stripped down function to use when the locale is C instead of the more general one.

Other commits simplify the code, in part by making greater use of tables.