### PR TITLE
perl.h: Need just MULTIPLICITY for context

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -570,7 +570,7 @@ compilation causes it be used just some times.
 #  define PERL_UNUSED_VAR(x) ((void)sizeof(x))
 #endif
 
-#if defined(USE_ITHREADS)
+#if defined(MULTIPLICITY)
 #  define PERL_UNUSED_CONTEXT PERL_UNUSED_ARG(my_perl)
 #else
 #  define PERL_UNUSED_CONTEXT


### PR DESCRIPTION
PERL_UNUSED_CONTEXT should be defined properly whenever there is a my_perl.  This happens whenever MULTIPLICITY is defined.  Prior to this commit PERL_UNUSED_CONTEXT got defined properly only when threads are being used.  You can have MULTIPLICITY without threads.