### PR TITLE
Use reentrant API when MULTIPLICITY

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -149,7 +149,7 @@ no normal arguments, and used by L</C<comma_pDEPTH>> itself.
 /* Use the reentrant APIs like localtime_r and getpwent_r */
 /* Win32 has naturally threadsafe libraries, no need to use any _r variants.
  * XXX KEEP makedef.pl copy of this code in sync */
-#if defined(USE_ITHREADS) && !defined(USE_REENTRANT_API) && !defined(WIN32)
+#if defined(MULTIPLICITY) && !defined(USE_REENTRANT_API) && !defined(WIN32)
 #   define USE_REENTRANT_API
 #endif
 


### PR DESCRIPTION
Prior to this commit it was only done when using threads.  You can have MULTIPLICITY without threads.  And when you do, there is shared global data that can get clobbered, and which the reentrant API automagically greatly reduces the possibility of.

I claim that the prior situation indicates that it is pretty rare in practice to have MULTIPLICITY defined without threads.  Otherwise, we would be getting tickets about race conditions.  I believe @leont thinks that many programs would not use the affected libc calls, so this wouldn't be occurring much in the field.