### PR TITLE
Fallback to use BitScan(Forward|Reverse) on MingW

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -1401,7 +1401,7 @@ Perl_is_utf8_invariant_string_loc(const U8* const s, STRLEN len, const U8 ** ep)
 #  endif
 #endif
 
-#if defined(_MSC_VER)
+#if defined(WIN32)
 #  include <intrin.h>
 #  pragma intrinsic(_BitScanForward)
 #  pragma intrinsic(_BitScanReverse)
@@ -1443,7 +1443,7 @@ Perl_lsbit_pos64(U64 word)
 
     return (unsigned) PERL_CTZ_64(word);
 
-#  elif U64SIZE == 8 && defined(_WIN64) && defined(_MSC_VER)
+#  elif U64SIZE == 8 && defined(_WIN64)
 #    define PERL_HAS_FAST_GET_LSB_POS64
 
     {
@@ -1497,7 +1497,7 @@ Perl_lsbit_pos32(U32 word)
 
     return (unsigned) PERL_CTZ_32(word);
 
-#elif U32SIZE == 4 && defined(_MSC_VER)
+#elif U32SIZE == 4 && defined(WIN32)
 #  define PERL_HAS_FAST_GET_LSB_POS32
 
     {
@@ -1551,7 +1551,7 @@ Perl_msbit_pos64(U64 word)
 
     return (unsigned) LZC_TO_MSBIT_POS_(U64, PERL_CLZ_64(word));
 
-#  elif U64SIZE == 8 && defined(_WIN64) && defined(_MSC_VER)
+#  elif U64SIZE == 8 && defined(_WIN64)
 #    define PERL_HAS_FAST_GET_MSB_POS64
 
     {
@@ -1607,8 +1607,7 @@ Perl_msbit_pos32(U32 word)
 #  define PERL_HAS_FAST_GET_MSB_POS32
 
     return (unsigned) LZC_TO_MSBIT_POS_(U32, PERL_CLZ_32(word));
-
-#elif U32SIZE == 4 && defined(_MSC_VER)
+#elif U32SIZE == 4 && defined(WIN32)
 #  define PERL_HAS_FAST_GET_MSB_POS32
 
     {


### PR DESCRIPTION
Perl has functions that return the positions of the least or most significant one bit in a word.  gcc has builtins that do these specific operations, and they get compiled to a single instruction on many hardware platforms.  Windows instead has various BitScan functions that do the same thing.

MingW has both gcc and Windows, so it should have access to both the builtins and to the BitScan functions, but prior to this commit, if we didn't find gcc builtins on MingW, we wouldn't bother to look for the BitScan functions.

Reading the code caused me to pause to try to figure out why not use these BitScan functions, and asked on #irc.  The answer from @xenu was that on MingW (as opposed to MSVC) they're emulated, and not as efficient as the gcc builtins.

Then I looked at the code again, and realized we don't try them unless the gcc builtins aren't available, unlikely these days.  But we should do something so that people who read this code in the future don't also end up spending time unnecessarily wondering why we treat MingW specially.

We could add a comment, but it seems to me better to just not make MingW a special case.  It's likely that the MingW emulation of the BitScan functions is better than our further fallback, so I see that as better and cleaner than special casing MingW.