### PR TITLE
hints/openbsd: Fix up some locale related hints

### DIFF
--- a/hints/openbsd.sh
+++ b/hints/openbsd.sh
@@ -158,6 +158,11 @@ esac
 # libc on this platform always keeps these categories in the C locale
 ccflags="$ccflags -DNO_LOCALE_NUMERIC -DNO_LOCALE_COLLATE -DNO_LOCALE_MONETARY -DNO_LOCALE_TIME -DNO_LOCALE_MESSAGES"
 
+# And the only possible mismatched LC_CTYPE locale is C.UTF-8 (as only it and
+# plain C are legal for this category).  All other categories deal only in
+# ASCII characters which are a subset of C.UTF-8.
+ccflags="$ccflags -DLIBC_HANDLES_MISMATCHED_CTYPE"
+
 # Seems that OpenBSD returns bogus values in _Thread_local variables in code in
 # shared objects, so we need to disable it. See GH #19109
 d_thread_local=undef

--- a/hints/openbsd.sh
+++ b/hints/openbsd.sh
@@ -155,6 +155,9 @@ esac
 # which is being fixed.  In the meantime, forbid POSIX 2008 locales
 #d_newlocale="$undef"
 
+# libc on this platform always keeps these categories in the C locale
+ccflags="$ccflags -DNO_LOCALE_NUMERIC -DNO_LOCALE_COLLATE -DNO_LOCALE_MONETARY -DNO_LOCALE_TIME -DNO_LOCALE_MESSAGES"
+
 # Seems that OpenBSD returns bogus values in _Thread_local variables in code in
 # shared objects, so we need to disable it. See GH #19109
 d_thread_local=undef


### PR DESCRIPTION
These two commits tell perl that the OpenBSD locale system is very restricted, and so the code to handle more general situations need not be compiled
