### PR TITLE
`perllol`: Remove indirect object syntax in `Dumpvalue` example

### DIFF
--- a/pod/perllol.pod
+++ b/pod/perllol.pod
@@ -227,7 +227,7 @@ Hmm... that's still a bit ugly.  How about this:
 	}
     }
 
-When you get tired of writing a custom print for your data structures,
+When you get tired of writing a custom C<print> for your data structures,
 you might look at the standard L<Dumpvalue> or L<Data::Dumper> modules.
 The former is what the Perl debugger uses, while the latter generates
 parsable Perl code.  For example:
@@ -236,14 +236,12 @@ parsable Perl code.  For example:
 
  sub show(+) {
 	require Dumpvalue;
-	state $prettily = new Dumpvalue::
-			    tick        => q("),
-			    compactDump => 1,  # comment these two lines
-                                               # out
-			    veryCompact => 1,  # if you want a bigger
-                                               # dump
-			;
-	dumpValue $prettily @_;
+    state $prettify = Dumpvalue->new(
+        tick        => q("),
+        compactDump => 1,  # comment these two lines out
+        veryCompact => 1,  # if you want a bigger dump
+    );
+	$prettify->dumpValue(@_);
  }
 
  # Assign a list of array references to an array.

--- a/pod/perlobj.pod
+++ b/pod/perlobj.pod
@@ -747,7 +747,7 @@ particularly for constructors, so you may still find it in the wild.
 However, we encourage you to avoid using it in new code.
 
 You can force Perl to interpret the bareword as a class name by
-appending "::" to it, like we saw earlier:
+appending C<::> to it, like we saw earlier:
 
   my $file = new File:: $path, $data;
 


### PR DESCRIPTION
Fix `dumpValue` method call syntax as well.

Change the variable name to `$prettify`
because the adverb doesn't make sense
without the indirect syntax.

The documentation shows correct examples:

https://perldoc.perl.org/Dumpvalue