### PR TITLE
return doesn't allow an indirect object

### DIFF
--- a/op.c
+++ b/op.c
@@ -13654,6 +13654,13 @@ Perl_ck_return(pTHX_ OP *o)
 
     PERL_ARGS_ASSERT_CK_RETURN;
 
+    if (o->op_flags & OPf_STACKED) {
+        kid = cUNOPx(OpSIBLING(cLISTOPo->op_first))->op_first;
+        if (kid->op_type != OP_SCOPE && kid->op_type != OP_LEAVE)
+            yyerror("Missing comma after first argument to return");
+        o->op_flags &= ~OPf_STACKED;
+    }
+
     kid = OpSIBLING(cLISTOPo->op_first);
     if (PL_compcv && CvLVALUE(PL_compcv)) {
         for (; kid; kid = OpSIBLING(kid))

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -73,7 +73,25 @@ XXX For a release on a stable branch, this section aspires to be:
     If any exist, they are bugs, and we request that you submit a
     report.  See L</Reporting Bugs> below.
 
-[ List each incompatible change as a =head2 entry ]
+=head2 C<return> no longer allows an indirect object
+
+The C<return> operator syntax now rejects indirect objects, in most
+cases this would compile and even run, but wasn't documented and could
+produce confusing results, for example:
+
+  # note that sum hasn't been defined
+  sub sum_positive {
+    return sum grep $_ > 0, @_;
+  }
+  say for sum_positive(-1, 2, 3)
+
+produced:
+
+  *main::sum
+  2
+  3
+
+[github #21716]
 
 =head1 Deprecations
 
@@ -232,7 +250,11 @@ and New Warnings
 
 =item *
 
-XXX L<message|perldiag/"message">
+L<Missing comma after first argument to return|perldiag/"Missing comma after first argument to return">
+
+(F) While certain operators allow you to specify a filehandle or an
+"indirect object" before the argument list, C<return> isn't one of
+them.
 
 =back
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -4003,6 +4003,12 @@ follow the C<\N>.
 (F) While certain functions allow you to specify a filehandle or an
 "indirect object" before the argument list, this ain't one of them.
 
+=item Missing comma after first argument to return
+
+(F) While certain operators allow you to specify a filehandle or an
+"indirect object" before the argument list, C<return> isn't one of
+them.
+
 =item Missing command in piped open
 
 (W pipe) You used the C<open(FH, "| command")> or

--- a/t/lib/croak/op
+++ b/t/lib/croak/op
@@ -300,3 +300,11 @@ LOOP: {
 }
 EXPECT
 Can't "last" out of a "finally" block at - line 4.
+########
+# NAME return HANDLE LIST isn't valid [github #21716]
+sub xx {
+  return sum map { $_+1} 1 .. 5;
+}
+EXPECT
+Missing comma after first argument to return at - line 2, near "5;"
+Execution of - aborted due to compilation errors.


### PR DESCRIPTION
Since return isn't actually a function, I didn't think the "function" part of the original message applied.

Fixes #21716