### PR TITLE
Add `av_unshift_sv()`

### DIFF
--- a/av.c
+++ b/av.c
@@ -923,6 +923,24 @@ Perl_av_unshift(pTHX_ AV *av, SSize_t num)
 }
 
 /*
+=for apidoc av_unshift_sv
+
+Unshift a single SV onto the beginning of the array.  The array will grow
+automatically to accommodate the addition.
+
+=cut
+*/
+
+void
+Perl_av_unshift_sv(pTHX_ AV *av, SV *sv)
+{
+    PERL_ARGS_ASSERT_AV_UNSHIFT_SV;
+
+    av_unshift(av, 1);
+    av_store(av, 0, sv);
+}
+
+/*
 =for apidoc av_shift
 
 Removes one SV from the start of the array, reducing its size by one and

--- a/embed.fnc
+++ b/embed.fnc
@@ -708,6 +708,8 @@ ARdm	|SSize_t|av_top_index	|NN AV *av
 Adp	|void	|av_undef	|NN AV *av
 Adp	|void	|av_unshift	|NN AV *av				\
 				|SSize_t num
+Adp	|void	|av_unshift_sv	|NN AV *av				\
+				|NN SV *sv
 : Used in perly.y
 Rp	|OP *	|bind_match	|I32 type				\
 				|NN OP *left				\

--- a/embed.h
+++ b/embed.h
@@ -153,6 +153,7 @@
 # define av_store_simple(a,b,c)                 Perl_av_store_simple(aTHX_ a,b,c)
 # define av_undef(a)                            Perl_av_undef(aTHX_ a)
 # define av_unshift(a,b)                        Perl_av_unshift(aTHX_ a,b)
+# define av_unshift_sv(a,b)                     Perl_av_unshift_sv(aTHX_ a,b)
 # define block_end(a,b)                         Perl_block_end(aTHX_ a,b)
 # define block_gimme()                          Perl_block_gimme(aTHX)
 # define block_start(a)                         Perl_block_start(aTHX_ a)

--- a/proto.h
+++ b/proto.h
@@ -346,6 +346,11 @@ Perl_av_unshift(pTHX_ AV *av, SSize_t num);
 #define PERL_ARGS_ASSERT_AV_UNSHIFT             \
         assert(av)
 
+PERL_CALLCONV void
+Perl_av_unshift_sv(pTHX_ AV *av, SV *sv);
+#define PERL_ARGS_ASSERT_AV_UNSHIFT_SV          \
+        assert(av); assert(sv)
+
 PERL_CALLCONV OP *
 Perl_bind_match(pTHX_ I32 type, OP *left, OP *right)
         __attribute__warn_unused_result__

--- a/toke.c
+++ b/toke.c
@@ -4873,8 +4873,7 @@ Perl_filter_add(pTHX_ filter_t funcp, SV *datasv)
     DEBUG_P(PerlIO_printf(Perl_debug_log, "filter_add func %p (%s)\n",
                           FPTR2DPTR(void *, IoANY(datasv)),
                           SvPV_nolen(datasv)));
-    av_unshift(PL_rsfp_filters, 1);
-    av_store(PL_rsfp_filters, 0, datasv) ;
+    av_unshift_sv(PL_rsfp_filters, datasv);
     if (
         !PL_parser->filtered
      && PL_parser->lex_flags & LEX_EVALBYTES


### PR DESCRIPTION
A new API function to handle this case, avoiding the need to unshift + assign separately.

A not-very-optimal implementation at present. A better one could be provided perhaps by merging the logic into `Perl_av_unshift` itself, but that is left for a later exercise.