### PR TITLE
Hoist nl_item typedef definition

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2488,6 +2488,11 @@ ATdo	|void	|perl_free	|NN PerlInterpreter *my_perl
 
 Cop	|const char *|PerlIO_context_layers				\
 				|NULLOK const char *mode
+ATdo	|const char *|Perl_langinfo					\
+				|const nl_item item
+ATdo	|const char *|Perl_langinfo8					\
+				|const nl_item item			\
+				|NULLOK utf8ness_t *utf8ness
 p	|int	|PerlLIO_dup2_cloexec					\
 				|int oldfd				\
 				|int newfd
@@ -3844,19 +3849,6 @@ p	|I32	|do_shmio	|I32 optype				\
 				|NN SV **mark				\
 				|NN SV **sp
 #endif /* defined(HAS_MSG) || defined(HAS_SEM) || defined(HAS_SHM) */
-#if defined(HAS_NL_LANGINFO) && defined(PERL_LANGINFO_H)
-ATdo	|const char *|Perl_langinfo					\
-				|const nl_item item
-ATdo	|const char *|Perl_langinfo8					\
-				|const nl_item item			\
-				|NULLOK utf8ness_t *utf8ness
-#else
-ATdo	|const char *|Perl_langinfo					\
-				|const int item
-ATdo	|const char *|Perl_langinfo8					\
-				|const int item 			\
-				|NULLOK utf8ness_t *utf8ness
-#endif
 #if defined(HAS_PIPE)
 Rp	|int	|PerlProc_pipe_cloexec					\
 				|NN int *pipefd
@@ -4437,6 +4429,13 @@ RS	|locale_category_index|get_category_index_helper		\
 				|const line_t caller_line
 Ri	|const char *|mortalized_pv_copy				\
 				|NULLOK const char * const pv
+S	|const char *|my_langinfo_i					\
+				|const nl_item item			\
+				|const locale_category_index cat_index	\
+				|NN const char *locale			\
+				|NN char **retbufp			\
+				|NULLOK Size_t *retbuf_sizep		\
+				|NULLOK utf8ness_t *utf8ness
 S	|const char *|native_querylocale_i				\
 				|const locale_category_index cat_index
 S	|void	|new_LC_ALL	|NN const char *lc_all			\
@@ -4482,23 +4481,6 @@ RS	|char * |my_setlocale_debug_string_i				\
 				|NULLOK const char *locale		\
 				|NULLOK const char *retval		\
 				|const line_t line
-#   endif
-#   if defined(HAS_NL_LANGINFO)
-S	|const char *|my_langinfo_i					\
-				|const nl_item item			\
-				|const locale_category_index cat_index	\
-				|NN const char *locale			\
-				|NN char **retbufp			\
-				|NULLOK Size_t *retbuf_sizep		\
-				|NULLOK utf8ness_t *utf8ness
-#   else
-S	|const char *|my_langinfo_i					\
-				|const int item 			\
-				|const locale_category_index cat_index	\
-				|NN const char *locale			\
-				|NN char **retbufp			\
-				|NULLOK Size_t *retbuf_sizep		\
-				|NULLOK utf8ness_t *utf8ness
 #   endif
 #   if defined(LC_ALL)
 S	|void	|give_perl_locale_control				\

--- a/embed.h
+++ b/embed.h
@@ -1314,6 +1314,7 @@
 #       define calculate_LC_ALL_string(a,b,c,d) S_calculate_LC_ALL_string(aTHX_ a,b,c,d)
 #       define get_category_index_helper(a,b,c) S_get_category_index_helper(aTHX_ a,b,c)
 #       define mortalized_pv_copy(a)            S_mortalized_pv_copy(aTHX_ a)
+#       define my_langinfo_i(a,b,c,d,e,f)       S_my_langinfo_i(aTHX_ a,b,c,d,e,f)
 #       define native_querylocale_i(a)          S_native_querylocale_i(aTHX_ a)
 #       define new_LC_ALL(a,b)                  S_new_LC_ALL(aTHX_ a,b)
 #       define output_check_environment_warning(a,b,c) S_output_check_environment_warning(aTHX_ a,b,c)
@@ -1323,11 +1324,6 @@
 #       define setlocale_failure_panic_via_i(a,b,c,d,e,f,g) S_setlocale_failure_panic_via_i(aTHX_ a,b,c,d,e,f,g)
 #       if defined(DEBUGGING)
 #         define my_setlocale_debug_string_i(a,b,c,d) S_my_setlocale_debug_string_i(aTHX_ a,b,c,d)
-#       endif
-#       if defined(HAS_NL_LANGINFO)
-#         define my_langinfo_i(a,b,c,d,e,f)     S_my_langinfo_i(aTHX_ a,b,c,d,e,f)
-#       else
-#         define my_langinfo_i(a,b,c,d,e,f)     S_my_langinfo_i(aTHX_ a,b,c,d,e,f)
 #       endif
 #       if defined(LC_ALL)
 #         define give_perl_locale_control(a,b)  S_give_perl_locale_control(aTHX_ a,b)

--- a/locale.c
+++ b/locale.c
@@ -5650,11 +5650,6 @@ S_populate_hash_from_localeconv(pTHX_ HV * hv,
 
 #  endif    /* defined(USE_LOCALE_NUMERIC) || defined(USE_LOCALE_MONETARY) */
 #endif /* defined(HAS_LOCALECONV) */
-#ifndef HAS_SOME_LANGINFO
-
-typedef int nl_item;    /* Substitute 'int' for emulated nl_langinfo() */
-
-#endif
 
 /*
 

--- a/perl_langinfo.h
+++ b/perl_langinfo.h
@@ -8,6 +8,10 @@
 
 #if defined(I_LANGINFO)
 #   include <langinfo.h>
+#else
+
+typedef int nl_item;    /* Substitute 'int' for emulated nl_langinfo() */
+
 #endif
 
 /* NOTE that this file is parsed by ext/XS-APItest/t/locale.t, so be careful

--- a/proto.h
+++ b/proto.h
@@ -57,6 +57,14 @@ Perl_PerlLIO_open_cloexec(pTHX_ const char *file, int flag)
 /* PERL_CALLCONV const XOP *
 Perl_custom_op_xop(pTHX_ const OP *o); */
 
+PERL_CALLCONV const char *
+Perl_langinfo(const nl_item item);
+#define PERL_ARGS_ASSERT_PERL_LANGINFO
+
+PERL_CALLCONV const char *
+Perl_langinfo8(const nl_item item, utf8ness_t *utf8ness);
+#define PERL_ARGS_ASSERT_PERL_LANGINFO8
+
 PERL_CALLCONV HV *
 Perl_localeconv(pTHX);
 #define PERL_ARGS_ASSERT_PERL_LOCALECONV
@@ -5494,25 +5502,6 @@ Perl_do_shmio(pTHX_ I32 optype, SV **mark, SV **sp)
         assert(mark); assert(sp)
 
 #endif /* defined(HAS_MSG) || defined(HAS_SEM) || defined(HAS_SHM) */
-#if defined(HAS_NL_LANGINFO) && defined(PERL_LANGINFO_H)
-PERL_CALLCONV const char *
-Perl_langinfo(const nl_item item);
-# define PERL_ARGS_ASSERT_PERL_LANGINFO
-
-PERL_CALLCONV const char *
-Perl_langinfo8(const nl_item item, utf8ness_t *utf8ness);
-# define PERL_ARGS_ASSERT_PERL_LANGINFO8
-
-#else
-PERL_CALLCONV const char *
-Perl_langinfo(const int item);
-# define PERL_ARGS_ASSERT_PERL_LANGINFO
-
-PERL_CALLCONV const char *
-Perl_langinfo8(const int item, utf8ness_t *utf8ness);
-# define PERL_ARGS_ASSERT_PERL_LANGINFO8
-
-#endif
 #if defined(HAS_PIPE)
 PERL_CALLCONV int
 Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd)
@@ -7035,6 +7024,11 @@ S_get_category_index_helper(pTHX_ const int category, bool *success, const line_
 #   define PERL_ARGS_ASSERT_GET_CATEGORY_INDEX_HELPER
 
 STATIC const char *
+S_my_langinfo_i(pTHX_ const nl_item item, const locale_category_index cat_index, const char *locale, char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
+#   define PERL_ARGS_ASSERT_MY_LANGINFO_I       \
+        assert(locale); assert(retbufp)
+
+STATIC const char *
 S_native_querylocale_i(pTHX_ const locale_category_index cat_index);
 #   define PERL_ARGS_ASSERT_NATIVE_QUERYLOCALE_I
 
@@ -7080,19 +7074,6 @@ STATIC char *
 S_my_setlocale_debug_string_i(pTHX_ const locale_category_index cat_index, const char *locale, const char *retval, const line_t line)
         __attribute__warn_unused_result__;
 #     define PERL_ARGS_ASSERT_MY_SETLOCALE_DEBUG_STRING_I
-
-#   endif
-#   if defined(HAS_NL_LANGINFO)
-STATIC const char *
-S_my_langinfo_i(pTHX_ const nl_item item, const locale_category_index cat_index, const char *locale, char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
-#     define PERL_ARGS_ASSERT_MY_LANGINFO_I     \
-        assert(locale); assert(retbufp)
-
-#   else
-STATIC const char *
-S_my_langinfo_i(pTHX_ const int item, const locale_category_index cat_index, const char *locale, char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
-#     define PERL_ARGS_ASSERT_MY_LANGINFO_I     \
-        assert(locale); assert(retbufp)
 
 #   endif
 #   if defined(LC_ALL)


### PR DESCRIPTION
nl_item is a typedef defined in <langinfo.h> for use by nl_langinfo(). But on platforms without this, perl emulates it, and hence needs to create its own nl_item typedef.

Prior to this commit, the definition was in locale.c, which meant that there needed to be two definitions in embed.fnc for each function that has an argument of this type.

Simply putting it in "perl_langinfo.h" when there is no <langinfo.h> allows those duplicate definitions to be removed