### PR TITLE
locale.c: Avoid unnecessary malloc

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -5969,9 +5969,8 @@ Perl_sv_strftime_tm(pTHX_ SV * fmt, const struct tm * mytm)
                              );
     SV * sv = NULL;
     if (retval) {
-        STRLEN len = strlen(retval);
-        sv = newSV(len);
-        sv_usepvn_flags(sv, retval, len, SV_HAS_TRAILING_NUL);
+        sv = newSV_type(SVt_PV);
+        sv_usepvn_flags(sv, retval, strlen(retval), SV_HAS_TRAILING_NUL);
 
         if (result_utf8ness == UTF8NESS_YES) {
             SvUTF8_on(sv);


### PR DESCRIPTION
Here an SV is being created with a size, but immediately sv_usepvn_flags() is called to place an already allocated and populated PV into it, so that initial size is wasted.