### PR TITLE
allow some basic infrastructure to load with -Dusedefaultstrict

### DIFF
--- a/TestInit.pm
+++ b/TestInit.pm
@@ -37,7 +37,7 @@
 
 package TestInit;
 
-$VERSION = 1.04;
+our $VERSION = 1.05;
 
 # Let tests know they're running in the perl core.  Useful for modules
 # which live dual lives on CPAN.

--- a/regen/embed_lib.pl
+++ b/regen/embed_lib.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 BEGIN {
-    for $n (qw(lib regen)) {
+    for my $n (qw(lib regen)) {
         if (-e "../$n") {
             push @INC, "../$n";
         } elsif (-e "./$n") {

--- a/t/test.pl
+++ b/t/test.pl
@@ -1014,7 +1014,7 @@ sub _num_to_alpha {
 my %tmpfiles;
 sub unlink_tempfiles {
     unlink_all keys %tmpfiles;
-    %tempfiles = ();
+    %tmpfiles = ();
 }
 
 END { unlink_tempfiles(); }
@@ -1796,11 +1796,11 @@ sub watchdog ($;$)
     if ($timeout == 0) {
         if ($watchdog_thread) {
             $watchdog_thread->kill('KILL');
-            undef $watch_dog_thread;
+            undef $watchdog_thread;
         }
         elsif ($watchdog) {
             kill('KILL', $watchdog);
-            undef $watch_dog;
+            undef $watchdog;
         }
         else {
             alarm(0);


### PR DESCRIPTION
The changes to t/test.pl appear to fix real bugs.

This allows `make test_harness` to run, but many tests will still fail under -Dusedefaultstrict

This addresses #21732 but does not fix it.  I'm unsure how supported that build option is.