### PR TITLE
Fix tr/\N{latin1}...\N{above latin1}/

### DIFF
--- a/t/op/tr.t
+++ b/t/op/tr.t
@@ -14,7 +14,7 @@ BEGIN {
 use utf8;
 require Config;
 
-plan tests => 315;
+plan tests => 317;
 
 # Test this first before we extend the stack with other operations.
 # This caused an asan failure due to a bad write past the end of the stack.
@@ -1195,6 +1195,14 @@ for ("", nullrocow) {
     my $c = "cb";
     eval '$c =~ tr{aabc}{d\x{d0000}}';
     is($c, "\x{d0000}\x{d0000}", "Shouldn't generate valgrind errors");
+}
+
+{   # GH #21748
+    my $c;
+    my $x = "\xcb";
+    $c = $x =~ tr[\N{U+00CB}\N{U+00EB}\N{U+2010}][\N{U+0401}\N{U+0451}\-];
+    is $x, "\x{401}", 'Latin1 \N{} followed by above Latin1 work properly';
+    is $c, 1, "Count for the above test";
 }
 
 1;

--- a/toke.c
+++ b/toke.c
@@ -4054,8 +4054,12 @@ S_scan_const(pTHX_ char *start)
                         }
 
                         /* Add the (Unicode) code point to the output. */
-                        if (! d_is_utf8 || OFFUNI_IS_INVARIANT(uv)) {
+                        if (OFFUNI_IS_INVARIANT(uv)) {
                             *d++ = (char) LATIN1_TO_NATIVE(uv);
+                        }
+                        else if (! d_is_utf8) {
+                            *d++ = (char) LATIN1_TO_NATIVE(uv);
+                            utf8_variant_count++;
                         }
                         else {
                             d = (char*) uvoffuni_to_utf8_flags((U8*)d, uv,


### PR DESCRIPTION
When a string is being parsed, it isn't made UTF-8 until necessary; that is, when it first finds a character that requires UTF-8 to represent.  If all the characters prior to that one are ASCII, all that is needed is to convert that one to UTF-8 and to turn on the UTF-8 flag, so that all future characters encountered in the parse will be represented in UTF-8.

This is because all ASCII characters have the same representation in UTF-8 as not; they are "UTF-8 invariant".  But if a UTF-8 *variant* character was in the string prior to the UTF-8-required one, it must be converted to its UTF-8 representation, when the string is converted.

All that is needed is to increment a count of variant characters as the parse proceeds.

If nothing in the string requires UTF-8 by the end of the parse, the count is ignored and the string remains non-UTF-8.

And if the count is zero when a UTF-8-required character is found, as mentioned above, that character is converted to UTF-8, and the flag is set to use UTF-8 going forward.

But a non-zero count at the first UTF-8-required character indicates that before proceeding, the already-parsed string must be reparsed to convert the variant characters already in it to UTF-8.

The count was not being incremented when the input notation used \N{}; this commit fixes that.  It was being incremented when the input notation used \x{}, which is much more common in the field, so this bug was unnoticed for a long time.

Fixes #21748

(Just for the record, on EBCDIC platforms more characters are UTF-8 invariant than ASCII platforms; the macros called here hide that from the code.)