### PR TITLE
cpan/Math-BigInt - Update to version 2.003001

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -759,7 +759,8 @@ our %Modules = (
     },
 
     'Math::BigInt' => {
-        'DISTRIBUTION' => 'PJACKLAM/Math-BigInt-2.002001.tar.gz',
+        'DISTRIBUTION' => 'PJACKLAM/Math-BigInt-2.003001.tar.gz',
+        'SYNCINFO'     => 'book on Tue Dec 26 22:44:58 2023',
         'SYNCINFO'     => 'jkeenan on Mon Dec 11 21:10:38 2023',
         'SYNCINFO'     => 'jkeenan on Fri Nov 24 20:23:52 2023',
         'SYNCINFO'     => 'jkeenan on Tue Nov 14 17:22:07 2023',

--- a/cpan/Math-BigInt/lib/Math/BigInt/Calc.pm
+++ b/cpan/Math-BigInt/lib/Math/BigInt/Calc.pm
@@ -7,7 +7,7 @@ use warnings;
 use Carp qw< carp croak >;
 use Math::BigInt::Lib;
 
-our $VERSION = '2.002001';
+our $VERSION = '2.003001';
 $VERSION =~ tr/_//d;
 
 our @ISA = ('Math::BigInt::Lib');

--- a/cpan/Math-BigInt/lib/Math/BigInt/Lib.pm
+++ b/cpan/Math-BigInt/lib/Math/BigInt/Lib.pm
@@ -4,7 +4,7 @@ use 5.006001;
 use strict;
 use warnings;
 
-our $VERSION = '2.002001';
+our $VERSION = '2.003001';
 $VERSION =~ tr/_//d;
 
 use Carp;
@@ -767,6 +767,91 @@ sub _log_int {
 
     return $y, 1 if $acmp == 0;         # result is exact
     return $y, 0;                       # result is too small
+}
+
+sub _ilog2 {
+    my ($class, $x) = @_;
+
+    return if $class -> _is_zero($x);
+
+    my $str = $class -> _to_hex($x);
+
+    # First do the bits in all but the most significant hex digit.
+
+    my $y = $class -> _new(length($str) - 1);
+    $y = $class -> _mul($y, $class -> _new(4));
+
+    # Now add the number of bits in the most significant hex digit.
+
+    my $n = int log(hex(substr($str, 0, 1))) / log(2);
+    $y = $class -> _add($y, $class -> _new($n));
+    return $y unless wantarray;
+
+    my $pow2 = $class -> _lsft($class -> _one(), $y, 2);
+    my $is_exact = $class -> _acmp($x, $pow2) == 0 ? 1 : 0;
+    return $y, $is_exact;
+}
+
+sub _ilog10 {
+    my ($class, $x) = @_;
+
+    return if $class -> _is_zero($x);
+
+    my $str = $class -> _str($x);
+    my $len = length($str);
+    my $y = $class -> _new($len - 1);
+    return $y unless wantarray;
+
+    #my $pow10 = $class -> _1ex($y);
+    #my $is_exact = $class -> _acmp($x, $pow10) ? 1 : 0;
+
+    my $is_exact = $str =~ /^10*$/ ? 1 : 0;
+    return $y, $is_exact;
+}
+
+sub _clog2 {
+    my ($class, $x) = @_;
+
+    return if $class -> _is_zero($x);
+
+    my $str = $class -> _to_hex($x);
+
+    # First do the bits in all but the most significant hex digit.
+
+    my $y = $class -> _new(length($str) - 1);
+    $y = $class -> _mul($y, $class -> _new(4));
+
+    # Now add the number of bits in the most significant hex digit.
+
+    my $n = int log(hex(substr($str, 0, 1))) / log(2);
+    $y = $class -> _add($y, $class -> _new($n));
+
+    # $y is now 1 too small unless $y is an exact power of 2.
+
+    my $pow2 = $class -> _lsft($class -> _one(), $y, 2);
+    my $is_exact = $class -> _acmp($x, $pow2) == 0 ? 1 : 0;
+    $y = $class -> _inc($y) if $is_exact == 0;
+    return $y, $is_exact if wantarray;
+    return $y;
+}
+
+sub _clog10 {
+    my ($class, $x) = @_;
+
+    return if $class -> _is_zero($x);
+
+    my $str = $class -> _str($x);
+    my $len = length($str);
+
+    if ($str =~ /^10*$/) {
+        my $y = $class -> _new($len - 1);
+        return $y, 1 if wantarray;
+        return $y;
+    }
+
+    my $y = $class -> _new($len);
+    return $y, 0 if wantarray;
+    return $y;
 }
 
 sub _sqrt {
@@ -2302,6 +2387,47 @@ Returns the logarithm of OBJ to base BASE truncted to an integer. This method
 has two output arguments, the OBJECT and a STATUS. The STATUS is Perl scalar;
 it is 1 if OBJ is the exact result, 0 if the result was truncted to give OBJ,
 and undef if it is unknown whether OBJ is the exact result.
+
+=item CLASS-E<gt>_ilog2(OBJ)
+
+Returns the base 2 logarithm of OBJ rounded downwards to the nearest integer,
+i.e., C<int(log2(OBJ))>. In list context, this method returns two output
+arguments, the OBJECT and a STATUS. The STATUS is Perl scalar; it is 1 if OBJ
+is the exact result, 0 if the result was truncted to give OBJ, and undef if it
+is unknown whether OBJ is the exact result.
+
+This method is equivalent to the more general method _log_int() when it is used
+with base 2 argument, but _ilog2() method might be faster.
+
+=item CLASS-E<gt>_ilog10(OBJ)
+
+Returns the base 10 logarithm of OBJ rounded downwards to the nearest integer,
+i.e., C<int(log2(OBJ))>. In list context, this method returns two output
+arguments, the OBJECT and a STATUS. The STATUS is Perl scalar; it is 1 if OBJ
+is the exact result, 0 if the result was truncted to give OBJ, and undef if it
+is unknown whether OBJ is the exact result.
+
+This method is equivalent to the more general method _log_int() when it is used
+with base 10 argument, but _ilog10() method might be faster.
+
+Also, the output from _ilog10() is always 1 smaller than the output from
+_len().
+
+=item CLASS-E<gt>_clog2(OBJ)
+
+Returns the base 2 logarithm of OBJ rounded upwards to the nearest integer,
+i.e., C<ceil(log2(OBJ))>. In list context, this method returns two output
+arguments, the OBJECT and a STATUS. The STATUS is Perl scalar; it is 1 if OBJ
+is the exact result, 0 if the result was truncted to give OBJ, and undef if it
+is unknown whether OBJ is the exact result.
+
+=item CLASS-E<gt>_clog10(OBJ)
+
+Returns the base 10 logarithm of OBJ rounded upnwards to the nearest integer,
+i.e., C<ceil(log2(OBJ))>. In list context, this method returns two output
+arguments, the OBJECT and a STATUS. The STATUS is Perl scalar; it is 1 if OBJ
+is the exact result, 0 if the result was truncted to give OBJ, and undef if it
+is unknown whether OBJ is the exact result.
 
 =item CLASS-E<gt>_gcd(OBJ1, OBJ2)
 

--- a/cpan/Math-BigInt/lib/Math/BigRat.pm
+++ b/cpan/Math-BigInt/lib/Math/BigRat.pm
@@ -3,11 +3,13 @@
 #
 
 # The following hash values are used:
-#   sign : +,-,NaN,+inf,-inf
-#   _d   : denominator
-#   _n   : numerator (value = _n/_d)
-#   _a   : accuracy
-#   _p   : precision
+
+#          sign : "+", "-", "+inf", "-inf", or "NaN"
+#            _d : denominator
+#            _n : numerator (value = _n/_d)
+#      accuracy : accuracy
+#     precision : precision
+
 # You should not look at the innards of a BigRat - use the methods for this.
 
 package Math::BigRat;
@@ -21,7 +23,7 @@ use Scalar::Util    qw< blessed >;
 
 use Math::BigFloat ();
 
-our $VERSION = '2.002001';
+our $VERSION = '2.003001';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(Math::BigFloat);
@@ -571,10 +573,10 @@ sub copy {
     $copy->{sign} = $self->{sign};
     $copy->{_d} = $LIB->_copy($self->{_d});
     $copy->{_n} = $LIB->_copy($self->{_n});
-    $copy->{_a} = $self->{_a} if defined $self->{_a};
-    $copy->{_p} = $self->{_p} if defined $self->{_p};
+    $copy->{accuracy} = $self->{accuracy} if defined $self->{accuracy};
+    $copy->{precision} = $self->{precision} if defined $self->{precision};
 
-    #($copy, $copy->{_a}, $copy->{_p})
+    #($copy, $copy->{accuracy}, $copy->{precision})
     #  = $copy->_find_round_parameters(@_);
 
     return $copy;
@@ -601,7 +603,7 @@ sub bnan {
     $self -> {_n}   = $LIB -> _zero();
     $self -> {_d}   = $LIB -> _one();
 
-    ($self, $self->{_a}, $self->{_p})
+    ($self, $self->{accuracy}, $self->{precision})
       = $self->_find_round_parameters(@_);
 
     return $self;
@@ -631,7 +633,7 @@ sub binf {
     $self -> {_n}   = $LIB -> _zero();
     $self -> {_d}   = $LIB -> _one();
 
-    ($self, $self->{_a}, $self->{_p})
+    ($self, $self->{accuracy}, $self->{precision})
       = $self->_find_round_parameters(@_);
 
     return $self;
@@ -656,7 +658,7 @@ sub bone {
     $self -> {_n}   = $LIB -> _one();
     $self -> {_d}   = $LIB -> _one();
 
-    ($self, $self->{_a}, $self->{_p})
+    ($self, $self->{accuracy}, $self->{precision})
       = $self->_find_round_parameters(@_);
 
     return $self;
@@ -678,7 +680,7 @@ sub bzero {
     $self -> {_n}   = $LIB -> _zero();
     $self -> {_d}   = $LIB -> _one();
 
-    ($self, $self->{_a}, $self->{_p})
+    ($self, $self->{accuracy}, $self->{precision})
       = $self->_find_round_parameters(@_);
 
     return $self;
@@ -1727,7 +1729,7 @@ sub bexp {
         $x->bpow($x_org, @params);
     } else {
         # else just round the already computed result
-        delete $x->{_a}; delete $x->{_p};
+        delete $x->{accuracy}; delete $x->{precision};
         # shortcut to not run through _find_round_parameters again
         if (defined $params[0]) {
             $x->bround($params[0], $params[2]); # then round accordingly
@@ -1737,7 +1739,7 @@ sub bexp {
     }
     if ($fallback) {
         # clear a/p after round, since user did not request it
-        delete $x->{_a}; delete $x->{_p};
+        delete $x->{accuracy}; delete $x->{precision};
     }
 
     $x;
@@ -2336,7 +2338,7 @@ sub as_int {
 
     # Copy the remaining instance variables.
 
-    ($y->{_a}, $y->{_p}) = ($x->{_a}, $x->{_p});
+    ($y->{accuracy}, $y->{precision}) = ($x->{accuracy}, $x->{precision});
 
     # Restore upgrading and downgrading.
 
@@ -2365,7 +2367,7 @@ sub as_rat {
 
     # Copy the remaining instance variables.
 
-    ($y->{_a}, $y->{_p}) = ($x->{_a}, $x->{_p});
+    ($y->{accuracy}, $y->{precision}) = ($x->{accuracy}, $x->{precision});
 
     # Restore upgrading and downgrading
 
@@ -2406,7 +2408,7 @@ sub as_float {
 
     # Copy the remaining instance variables.
 
-    ($y->{_a}, $y->{_p}) = ($x->{_a}, $x->{_p});
+    ($y->{accuracy}, $y->{precision}) = ($x->{accuracy}, $x->{precision});
 
     # Restore upgrading and downgrading.
 

--- a/cpan/Math-BigInt/t/big_pi_e.t
+++ b/cpan/Math-BigInt/t/big_pi_e.t
@@ -13,22 +13,22 @@ use Math::BigFloat;
 
 my $pi = Math::BigFloat::bpi();
 
-is($pi->{_a}, undef, 'A is not defined');
-is($pi->{_p}, undef, 'P is not defined');
+is($pi->{accuracy}, undef, 'A is not defined');
+is($pi->{precision}, undef, 'P is not defined');
 
 $pi = Math::BigFloat->bpi();
 
-is($pi->{_a}, undef, 'A is not defined');
-is($pi->{_p}, undef, 'P is not defined');
+is($pi->{accuracy}, undef, 'A is not defined');
+is($pi->{precision}, undef, 'P is not defined');
 
 $pi = Math::BigFloat->bpi(10);
 
-is($pi->{_a}, 10,    'A is defined');
-is($pi->{_p}, undef, 'P is not defined');
+is($pi->{accuracy}, 10,    'A is defined');
+is($pi->{precision}, undef, 'P is not defined');
 
 #############################################################################
 
 my $e = Math::BigFloat->new(1)->bexp();
 
-is($e->{_a}, undef, 'A is not defined');
-is($e->{_p}, undef, 'P is not defined');
+is($e->{accuracy}, undef, 'A is not defined');
+is($e->{precision}, undef, 'P is not defined');

--- a/cpan/Math-BigInt/t/bigfltpm.inc
+++ b/cpan/Math-BigInt/t/bigfltpm.inc
@@ -228,23 +228,23 @@ is($CLASS->new($monster)->mantissa(),
 
 $x = $CLASS->new(2);
 $x->bzero();
-is($x->{_a}, undef, qq|\$x = $CLASS->new(2); \$x->bzero(); \$x->{_a}|);
-is($x->{_p}, undef, qq|\$x = $CLASS->new(2); \$x->bzero(); \$x->{_p}|);
+is($x->{accuracy}, undef, qq|\$x = $CLASS->new(2); \$x->bzero(); \$x->{accuracy}|);
+is($x->{precision}, undef, qq|\$x = $CLASS->new(2); \$x->bzero(); \$x->{precision}|);
 
 $x = $CLASS->new(2);
 $x->binf();
-is($x->{_a}, undef, qq|\$x = $CLASS->new(2); \$x->binf(); \$x->{_a}|);
-is($x->{_p}, undef, qq|\$x = $CLASS->new(2); \$x->binf(); \$x->{_p}|);
+is($x->{accuracy}, undef, qq|\$x = $CLASS->new(2); \$x->binf(); \$x->{accuracy}|);
+is($x->{precision}, undef, qq|\$x = $CLASS->new(2); \$x->binf(); \$x->{precision}|);
 
 $x = $CLASS->new(2);
 $x->bone();
-is($x->{_a}, undef, qq|\$x = $CLASS->new(2); \$x->bone(); \$x->{_a}|);
-is($x->{_p}, undef, qq|\$x = $CLASS->new(2); \$x->bone(); \$x->{_p}|);
+is($x->{accuracy}, undef, qq|\$x = $CLASS->new(2); \$x->bone(); \$x->{accuracy}|);
+is($x->{precision}, undef, qq|\$x = $CLASS->new(2); \$x->bone(); \$x->{precision}|);
 
 $x = $CLASS->new(2);
 $x->bnan();
-is($x->{_a}, undef, qq|\$x = $CLASS->new(2); \$x->bnan(); \$x->{_a}|);
-is($x->{_p}, undef, qq|\$x = $CLASS->new(2); \$x->bnan(); \$x->{_p}|);
+is($x->{accuracy}, undef, qq|\$x = $CLASS->new(2); \$x->bnan(); \$x->{accuracy}|);
+is($x->{precision}, undef, qq|\$x = $CLASS->new(2); \$x->bnan(); \$x->{precision}|);
 
 ###############################################################################
 # bone/binf etc as plain calls (Lite failed them)

--- a/cpan/Math-BigInt/t/bigratpm.inc
+++ b/cpan/Math-BigInt/t/bigratpm.inc
@@ -159,23 +159,23 @@ is($x, 1200, qq|\$x = Math::BigInt->new(1200); \$y = $CLASS->new(\$x); $x|);
 
 $x = $CLASS->new(2);
 $x->bzero();
-is($x->{_a}, undef, qq|\$x = $CLASS->new(2); \$x->bzero(); \$x->{_a}|);
-is($x->{_p}, undef, qq|\$x = $CLASS->new(2); \$x->bzero(); \$x->{_p}|);
+is($x->{accuracy}, undef, qq|\$x = $CLASS->new(2); \$x->bzero(); \$x->{accuracy}|);
+is($x->{precision}, undef, qq|\$x = $CLASS->new(2); \$x->bzero(); \$x->{precision}|);
 
 $x = $CLASS->new(2);
 $x->binf();
-is($x->{_a}, undef, qq|\$x = $CLASS->new(2); \$x->binf(); \$x->{_a}|);
-is($x->{_p}, undef, qq|\$x = $CLASS->new(2); \$x->binf(); \$x->{_p}|);
+is($x->{accuracy}, undef, qq|\$x = $CLASS->new(2); \$x->binf(); \$x->{accuracy}|);
+is($x->{precision}, undef, qq|\$x = $CLASS->new(2); \$x->binf(); \$x->{precision}|);
 
 $x = $CLASS->new(2);
 $x->bone();
-is($x->{_a}, undef, qq|\$x = $CLASS->new(2); \$x->bone(); \$x->{_a}|);
-is($x->{_p}, undef, qq|\$x = $CLASS->new(2); \$x->bone(); \$x->{_p}|);
+is($x->{accuracy}, undef, qq|\$x = $CLASS->new(2); \$x->bone(); \$x->{accuracy}|);
+is($x->{precision}, undef, qq|\$x = $CLASS->new(2); \$x->bone(); \$x->{precision}|);
 
 $x = $CLASS->new(2);
 $x->bnan();
-is($x->{_a}, undef, qq|\$x = $CLASS->new(2); \$x->bnan(); \$x->{_a}|);
-is($x->{_p}, undef, qq|\$x = $CLASS->new(2); \$x->bnan(); \$x->{_p}|);
+is($x->{accuracy}, undef, qq|\$x = $CLASS->new(2); \$x->bnan(); \$x->{accuracy}|);
+is($x->{precision}, undef, qq|\$x = $CLASS->new(2); \$x->bnan(); \$x->{precision}|);
 
 __DATA__
 

--- a/cpan/Math-BigInt/t/config.t
+++ b/cpan/Math-BigInt/t/config.t
@@ -3,148 +3,236 @@
 use strict;
 use warnings;
 
-use Test::More tests => 72;
+use Test::More tests => 126;
 
-# test whether Math::BigInt->config() and Math::BigFloat->config() work
+# Test Math::BigInt->config(), Math::BigFloat->config(), and
+# Math::BigRat->config().
 
 use Math::BigInt lib => 'Calc';
 use Math::BigFloat;
+use Math::BigRat;
 
 my $mbi = 'Math::BigInt';
 my $mbf = 'Math::BigFloat';
+my $mbr = 'Math::BigRat';
 
-my @defaults =
-  ([ 'lib',         'Math::BigInt::Calc'           ],
-   [ 'lib_version', $Math::BigInt::Calc::VERSION, ],
-   [ 'upgrade',     undef,  ],
-   [ 'div_scale',   40,     ],
-   [ 'precision',   undef,  ],
-   [ 'accuracy',    undef,  ],
-   [ 'round_mode',  'even', ],
-   [ 'trap_nan',    0,      ],
-   [ 'trap_inf',    0,      ]);
+my @classes = ($mbi, $mbf, $mbr);
+
+# Default configuration.
+
+my %defaults = (
+  'accuracy'    => undef,
+  'precision'   => undef,
+  'round_mode'  => 'even',
+  'div_scale'   => 40,
+  'trap_inf'    => 0,
+  'trap_nan'    => 0,
+  'upgrade'     => undef,
+  'downgrade'   => undef,
+  'lib'         => 'Math::BigInt::Calc',
+  'lib_version' => $Math::BigInt::Calc::VERSION,
+);
 
 ##############################################################################
-# Math::BigInt
+# Test config() as a getter.
 
-{
-    can_ok($mbi, 'config');
+for my $class (@classes) {
 
-    my @table = @defaults;
-    unshift @table, ['class', $mbi ];
+    note <<"EOF";
 
-    # Test getting via the new-style $class->($key):
+Verify that $class->config("key") works.
 
-    for (my $i = 0 ; $i <= $#table ; ++ $i) {
-        my $key = $table[$i][0];
-        my $val = $table[$i][1];
-        is($mbi->config($key), $val, qq|$mbi->config("$key")|);
-    }
+EOF
 
-    # Test getting via the old-style $class->()->{$key}, which is still
+    can_ok($class, 'config');
+
+    my %table = (%defaults, 'class' => $class);
+
+    # Test getting via the new style $class->config($key).
+
+    subtest qq|New-style getter $class->config("\$key")| => sub {
+        plan tests => scalar keys %table;
+
+        for my $key (sort keys %table) {
+            my $val = $table{$key};
+            is($class->config($key), $val, qq|$class->config("$key")|);
+        }
+    };
+
+    # Test getting via the old style $class->config()->{$key}, which is still
     # supported:
 
-    my $cfg = $mbi->config();
-    is(ref($cfg), 'HASH', 'ref() of output from $mbi->config()');
+    my $cfg = $class->config();
+    is(ref($cfg), 'HASH', "ref() of output from $class->config()");
 
-    for (my $i = 0 ; $i <= $#table ; ++ $i) {
-        my $key = $table[$i][0];
-        my $val = $table[$i][1];
-        is($cfg->{$key}, $val, qq|$mbi->config()->{$key}|);
-    }
+    subtest qq|Old-style getter $class->config()->{"\$key"}| => sub {
+        plan tests => scalar keys %table;
 
-    # can set via hash ref?
-    $cfg = $mbi->config({ trap_nan => 1 });
-    is($cfg->{trap_nan}, 1, 'can set "trap_nan" via hash ref');
+       for my $key (sort keys %table) {
+            my $val = $table{$key};
+            is($cfg->{$key}, $val, qq|$class->config()->{$key}|);
+        }
+    };
 
-    # reset for later
-    $mbi->config(trap_nan => 0);
+    # Can set via hash ref?
+
+    $cfg = $class->config({ trap_nan => 1 });
+    is($cfg->{trap_nan}, 1, 'can set "trap_nan" to 1 via hash ref');
+
+    # Restore for later.
+
+    $cfg = $class->config({ trap_nan => 0 });
+    is($cfg->{trap_nan}, 0, 'can set "trap_nan" to 0 via hash ref');
 }
 
 ##############################################################################
-# Math::BigFloat
+# Test config() as a setter.
 
-{
-    can_ok($mbf, 'config');
-
-    my @table = @defaults;
-    unshift @table, ['class', $mbf ];
-
-    # Test getting via the new-style $class->($key):
-
-    for (my $i = 0 ; $i <= $#table ; ++ $i) {
-        my $key = $table[$i][0];
-        my $val = $table[$i][1];
-        is($mbf->config($key), $val, qq|$mbf->config("$key")|);
-    }
-
-    # Test getting via the old-style $class->()->{$key}, which is still
-    # supported:
-
-    my $cfg = $mbf->config();
-    is(ref($cfg), 'HASH', 'ref() of output from $mbf->config()');
-
-    for (my $i = 0 ; $i <= $#table ; ++ $i) {
-        my $key = $table[$i][0];
-        my $val = $table[$i][1];
-        is($cfg->{$key}, $val, qq|$mbf->config()->{$key}|);
-    }
-
-    # can set via hash ref?
-    $cfg = $mbf->config({ trap_nan => 1 });
-    is($cfg->{trap_nan}, 1, 'can set "trap_nan" via hash ref');
-
-    # reset for later
-    $mbf->config(trap_nan => 0);
-}
-
-##############################################################################
-# test setting values
+# Alternative configuration. All values should be different from the default
+# configuration.
 
 my $test = {
-    trap_nan   => 1,
-    trap_inf   => 1,
     accuracy   => 2,
     precision  => 3,
     round_mode => 'zero',
     div_scale  => '100',
+    trap_inf   => 1,
+    trap_nan   => 1,
     upgrade    => 'Math::BigInt::SomeClass',
     downgrade  => 'Math::BigInt::SomeClass',
 };
 
-my $cfg;
+for my $class (@classes) {
 
-foreach my $key (keys %$test) {
+    note <<"EOF";
 
-    # see if setting in MBI works
-    eval { $mbi->config($key => $test->{$key}); };
-    $cfg = $mbi->config();
-    is("$key = $cfg->{$key}", "$key = $test->{$key}", "$key = $test->{$key}");
-    $cfg = $mbf->config();
+Verify that $class->config("key" => value) works and that
+it doesn't affect the configuration of other classes.
 
-    # see if setting it in MBI leaves MBF alone
-    ok(($cfg->{$key} || 0) ne $test->{$key},
-       "$key ne \$cfg->{$key}");
+EOF
 
-    # see if setting in MBF works
-    eval { $mbf->config($key => $test->{$key}); };
-    $cfg = $mbf->config();
-    is("$key = $cfg->{$key}", "$key = $test->{$key}", "$key = $test->{$key}");
+    for my $key (sort keys %$test) {
+
+        # Get the original value for restoring it later.
+
+        my $orig = $class->config($key);
+
+        # Try setting the new value.
+
+        eval { $class->config($key => $test->{$key}); };
+        die $@ if $@;
+
+        # Verify that the value was set correctly.
+
+        is($class->config($key), $test->{$key},
+           qq|$class->config("$key") set to $test->{$key}|);
+
+        # Verify that setting it in class $class didn't affect other classes.
+
+        for my $other (@classes) {
+            next if $other eq $class;
+
+            isnt($other->config($key), $class->config($key),
+                 qq|$other->config("$key") isn't affected by setting | .
+                 qq|$class->config("$key")|);
+        }
+
+        # Restore the value.
+
+        $class->config($key => $orig);
+
+        # Verify that the value was restored.
+
+        is($class->config($key), $orig,
+           qq|$class->config("$key") reset to | .
+           (defined($orig) ? qq|"$orig"| : "undef"));
+    }
 }
 
-##############################################################################
-# test setting illegal keys (should croak)
+# Verify that setting via a hash doesn't modify the hash.
 
-eval { $mbi->config('some_garbage' => 1); };
-like($@,
-     qr/ ^ Illegal \s+ key\(s\) \s+ 'some_garbage' \s+ passed \s+ to \s+
-         Math::BigInt->config\(\) \s+ at
-       /x,
-     'Passing invalid key to Math::BigInt->config() causes an error.');
+# In the $test configuration, both accuracy and precision are defined, which
+# won't work, so set one of them to undef.
 
-eval { $mbf->config('some_garbage' => 1); };
-like($@,
-     qr/ ^ Illegal \s+ key\(s\) \s+ 'some_garbage' \s+ passed \s+ to \s+
-         Math::BigFloat->config\(\) \s+ at
-       /x,
-     'Passing invalid key to Math::BigFloat->config() causes an error.');
+$test->{accuracy} = undef;
+
+for my $class (@classes) {
+
+    note <<"EOF";
+
+Verify that $class->config({key1 => val1, key2 => val2, ...})
+doesn't modify the hash ref argument.
+
+EOF
+
+    subtest "Verify that $class->config(\$cfg) doesn't modify \$cfg" => sub {
+        plan tests => 2 * keys %$test;
+
+        # Make copy of the configuration hash and use it as input to config().
+
+        my $cfg = { %{ $test } };
+        eval { $class -> config($cfg); };
+        die $@ if $@;
+
+        # Verify that the configuration hash hasn't been modified.
+
+        for my $key (sort keys %$test) {
+            ok(exists $cfg->{$key}, qq|existens of \$cfg->{"$key"}|);
+            is($cfg->{$key}, $test->{$key}, qq|value of \$cfg->{"$key"}|);
+        }
+    };
+}
+
+# Special testing of setting both accuracy and precision simultaneouly with
+# config(). This didn't work correctly before.
+
+for my $class (@classes) {
+
+    note <<"EOF";
+
+Verify that $class->config({accuracy => \$a, precision => \$p})
+works as intended.
+
+EOF
+
+    $class -> config({"accuracy" => 4, "precision" => undef});
+
+    subtest qq|$class -> config({"accuracy" => 4, "precision" => undef})|
+      => sub {
+          plan tests => 2;
+
+          is($class -> config("accuracy"), 4,
+             qq|$class -> config("accuracy")|);
+          is($class -> config("precision"), undef,
+             qq|$class -> config("precision")|);
+      };
+
+    $class -> config({"accuracy" => undef, "precision" => 5});
+
+    subtest qq|$class -> config({"accuracy" => undef, "precision" => 5})|
+      => sub {
+          plan tests => 2;
+
+          is($class -> config("accuracy"), undef,
+             qq|$class -> config("accuracy")|);
+          is($class -> config("precision"), 5,
+             qq|$class -> config("precision")|);
+      };
+}
+
+# Test getting an invalid key (should croak)
+
+note <<"EOF";
+
+Verify behaviour when getting an invalid key.
+
+EOF
+
+for my $class (@classes) {
+    eval { $class->config('some_garbage' => 1); };
+    like($@,
+         qr/ ^ Illegal \s+ key\(s\) \s+ 'some_garbage' \s+ passed \s+ to \s+
+             $class->config\(\) \s+ at
+           /x,
+         "Passing invalid key to $class->config() causes an error.");
+}

--- a/cpan/Math-BigInt/t/mbimbf.inc
+++ b/cpan/Math-BigInt/t/mbimbf.inc
@@ -255,42 +255,42 @@ foreach my $class ($mbi, $mbf) {
 
     $x = $class->bzero();
     $x->accuracy(5);
-    is($x->{_a}, 5, qq|\$x = $class->bzero(); \$x->accuracy(5); \$x->{_a}|);
+    is($x->{accuracy}, 5, qq|\$x = $class->bzero(); \$x->accuracy(5); \$x->{accuracy}|);
 
     $x = $class->bzero();
     $x->precision(5);
-    is($x->{_p}, 5, qq|\$x = $class->bzero(); \$x->precision(5); \$x->{_p}|);
+    is($x->{precision}, 5, qq|\$x = $class->bzero(); \$x->precision(5); \$x->{precision}|);
 
     $x = $class->new(0);
     $x->accuracy(5);
-    is($x->{_a}, 5, qq|\$x = $class->new(0); \$x->accuracy(5); \$x->{_a}|);
+    is($x->{accuracy}, 5, qq|\$x = $class->new(0); \$x->accuracy(5); \$x->{accuracy}|);
 
     $x = $class->new(0);
     $x->precision(5);
-    is($x->{_p}, 5, qq|\$x = $class->new(0); \$x->precision(5); \$x->{_p}|);
+    is($x->{precision}, 5, qq|\$x = $class->new(0); \$x->precision(5); \$x->{precision}|);
 
     $x = $class->bzero();
     $x->round(5);
-    is($x->{_a}, 5, qq|\$x = $class->bzero(); \$x->round(5); \$x->{_a}|);
+    is($x->{accuracy}, 5, qq|\$x = $class->bzero(); \$x->round(5); \$x->{accuracy}|);
 
     $x = $class->bzero();
     $x->round(undef, 5);
-    is($x->{_p}, 5, qq|\$x = $class->bzero(); \$x->round(undef, 5); \$x->{_p}|);
+    is($x->{precision}, 5, qq|\$x = $class->bzero(); \$x->round(undef, 5); \$x->{precision}|);
 
     $x = $class->new(0);
     $x->round(5);
-    is($x->{_a}, 5, qq|\$x = $class->new(0); \$x->round(5); \$x->{_a}|);
+    is($x->{accuracy}, 5, qq|\$x = $class->new(0); \$x->round(5); \$x->{accuracy}|);
 
     $x = $class->new(0);
     $x->round(undef, 5);
-    is($x->{_p}, 5, qq|\$x = $class->new(0); \$x->round(undef, 5); \$x->{_p}|);
+    is($x->{precision}, 5, qq|\$x = $class->new(0); \$x->round(undef, 5); \$x->{precision}|);
 
     # see if trying to increasing A in bzero() doesn't do something
     $x = $class->bzero();
-    $x->{_a} = 3;
+    $x->{accuracy} = 3;
     $x->round(5);
-    is($x->{_a}, 3,
-       qq|\$x = $class->bzero(); \$x->{_a} = 3; \$x->round(5); \$x->{_a}|);
+    is($x->{accuracy}, 3,
+       qq|\$x = $class->bzero(); \$x->{accuracy} = 3; \$x->round(5); \$x->{accuracy}|);
 }
 
 ###############################################################################
@@ -349,8 +349,8 @@ foreach my $class ($mbi, $mbf) {
 
 $x = $mbf->new("123.456");
 $y = $mbf->new("654.321");
-$x->{_a} = 5;           # $x->accuracy(5) would round $x straight away
-$y->{_a} = 4;           # $y->accuracy(4) would round $x straight away
+$x->{accuracy} = 5;           # $x->accuracy(5) would round $x straight away
+$y->{accuracy} = 4;           # $y->accuracy(4) would round $x straight away
 
 $z = $x + $y;
 is($z, "777.8", q|$z = $x + $y|);
@@ -373,20 +373,20 @@ is($z, "15241", q|$z = $x * $x|);
 #is($x, '123.456');
 
 $z = $x->copy();
-$z->{_a} = 2;
+$z->{accuracy} = 2;
 $z = $z / 2;
 is($z, 62, q|$z = $z / 2|);
 
 $x = $mbf->new(123456);
-$x->{_a} = 4;
+$x->{accuracy} = 4;
 $z = $x->copy;
 $z++;
 is($z, 123500, q|$z++|);
 
 $x = $mbi->new(123456);
 $y = $mbi->new(654321);
-$x->{_a} = 5;           # $x->accuracy(5) would round $x straight away
-$y->{_a} = 4;           # $y->accuracy(4) would round $x straight away
+$x->{accuracy} = 5;           # $x->accuracy(5) would round $x straight away
+$y->{accuracy} = 4;           # $y->accuracy(4) would round $x straight away
 
 $z = $x + $y;
 is($z, 777800, q|$z = $x + $y|);
@@ -409,22 +409,22 @@ $z++;
 is($z, 123460, q|$z++|);
 
 $z = $x->copy();
-$z->{_a} = 2;
+$z->{accuracy} = 2;
 $z = $z / 2;
 is($z, 62000, q|$z = $z / 2|);
 
 $x = $mbi->new(123400);
-$x->{_a} = 4;
+$x->{accuracy} = 4;
 is($x->bnot(), -123400, q|$x->bnot()|);         # not -1234001
 
 # to be consistent with other methods, babs() and bneg() also support rounding
 
 $x = $mbi->new(-123401);
-$x->{_a} = 4;
+$x->{accuracy} = 4;
 is($x->babs(), 123400, q|$x->babs()|);
 
 $x = $mbi->new(-123401);
-$x->{_a} = 4;
+$x->{accuracy} = 4;
 is($x->bneg(), 123400, q|$x->bneg()|);
 
 # test bdiv rounding to A and R (bug in v1.48 and maybe earlier versions)
@@ -435,27 +435,27 @@ is($x, '123.4', q|$x|);
 
 $x = $mbi->new('123456');
 $y = $mbi->new('123456');
-$y->{_a} = 6;
+$y->{accuracy} = 6;
 is($x->bdiv($y), 1, q|$x->bdiv($y)|);
-is($x->{_a}, 6, q|$x->{_a}|);                   # carried over
+is($x->{accuracy}, 6, q|$x->{accuracy}|);                   # carried over
 
 $x = $mbi->new('123456');
 $y = $mbi->new('123456');
-$x->{_a} = 6;
+$x->{accuracy} = 6;
 is($x->bdiv($y), 1, q|$x->bdiv($y)|);
-is($x->{_a}, 6, q|$x->{_a}|);                   # carried over
+is($x->{accuracy}, 6, q|$x->{accuracy}|);                   # carried over
 
 $x = $mbi->new('123456');
 $y = $mbi->new('223456');
-$y->{_a} = 6;
+$y->{accuracy} = 6;
 is($x->bdiv($y), 0, q|$x->bdiv($y)|);
-is($x->{_a}, 6, q|$x->{_a}|);                   # carried over
+is($x->{accuracy}, 6, q|$x->{accuracy}|);                   # carried over
 
 $x = $mbi->new('123456');
 $y = $mbi->new('223456');
-$x->{_a} = 6;
+$x->{accuracy} = 6;
 is($x->bdiv($y), 0, q|$x->bdiv($y)|);
-is($x->{_a}, 6, q|$x->{_a}|);                   # carried over
+is($x->{accuracy}, 6, q|$x->{accuracy}|);                   # carried over
 
 ###############################################################################
 # test that bop(0) does the same than bop(undef)
@@ -466,7 +466,7 @@ is($x->copy()->bsqrt(0), $x->copy()->bsqrt(undef),
 is($x->copy->bsqrt(0), '35136.41828644462161665823116758077037159',
    q|$x->copy->bsqrt(...)|);
 
-is($x->{_a}, undef, q|$x->{_a}|);
+is($x->{accuracy}, undef, q|$x->{accuracy}|);
 
 # test that bsqrt() modifies $x and does not just return something else
 # (especially under Math::BigInt::BareCalc)
@@ -622,19 +622,19 @@ unlike($warn, qr/^Use of uninitialized value (\$y )?(in numeric ge \(>=\) |)at/,
 }
 
 $x = $mbf->new(10);
-$x->{_a} = 4;
+$x->{accuracy} = 4;
 is($x->bdiv(3), '3.333', q|$x->bdiv(3)|);
-is($x->{_a}, 4, q|$x->{_a}|);                # set's it since no fallback
+is($x->{accuracy}, 4, q|$x->{accuracy}|);                # set's it since no fallback
 
 $x = $mbf->new(10);
-$x->{_a} = 4;
+$x->{accuracy} = 4;
 $y = $mbf->new(3);
 is($x->bdiv($y), '3.333', q|$x->bdiv($y)|);
-is($x->{_a}, 4, q|$x->{_a}|);                   # set's it since no fallback
+is($x->{accuracy}, 4, q|$x->{accuracy}|);                   # set's it since no fallback
 
 # rounding to P of x
 $x = $mbf->new(10);
-$x->{_p} = -2;
+$x->{precision} = -2;
 is($x->bdiv(3), '3.33', q|$x->bdiv(3)|);
 
 # round in div with requested P
@@ -653,22 +653,22 @@ is($x->bdiv(3, undef, -2), '3.33', q|$x->bdiv(3, undef, -2)|);
 
 $x = $mbf->new(10);
 $y = $mbf->new(3);
-$y->{_a} = 4;
+$y->{accuracy} = 4;
 is($x->bdiv($y), '3.333', q|$x->bdiv($y) = '3.333'|);
-is($x->{_a}, 4, q|$x->{_a} = 4|);
-is($y->{_a}, 4, q|$y->{_a} = 4|);       # set's it since no fallback
-is($x->{_p}, undef, q|$x->{_p} = undef|);
-is($y->{_p}, undef, q|$y->{_p} = undef|);
+is($x->{accuracy}, 4, q|$x->{accuracy} = 4|);
+is($y->{accuracy}, 4, q|$y->{accuracy} = 4|);       # set's it since no fallback
+is($x->{precision}, undef, q|$x->{precision} = undef|);
+is($y->{precision}, undef, q|$y->{precision} = undef|);
 
 # rounding to P of y
 $x = $mbf->new(10);
 $y = $mbf->new(3);
-$y->{_p} = -2;
+$y->{precision} = -2;
 is($x->bdiv($y), '3.33', q|$x->bdiv($y) = '3.33'|);
-is($x->{_p}, -2, q|$x->{_p} = -2|);
- is($y->{_p}, -2, q|$y->{_p} = -2|);
-is($x->{_a}, undef, q|$x->{_a} = undef|);
-is($y->{_a}, undef, q|$y->{_a} = undef|);
+is($x->{precision}, -2, q|$x->{precision} = -2|);
+ is($y->{precision}, -2, q|$y->{precision} = -2|);
+is($x->{accuracy}, undef, q|$x->{accuracy} = undef|);
+is($y->{accuracy}, undef, q|$y->{accuracy} = undef|);
 
 ###############################################################################
 # test whether bround(-n) fails in MBF (undocumented in MBI)
@@ -681,91 +681,91 @@ like($@, qr/^bround\(\) needs positive accuracy/,
 note("test whether rounding to higher accuracy is no-op");
 
 $x = $mbf->new(1);
-$x->{_a} = 4;
+$x->{accuracy} = 4;
 is($x, "1.000", q|$x = "1.000"|);
 $x->bround(6);                  # must be no-op
-is($x->{_a}, 4, q|$x->{_a} = 4|);
+is($x->{accuracy}, 4, q|$x->{accuracy} = 4|);
 is($x, "1.000", q|$x = "1.000"|);
 
 $x = $mbi->new(1230);
-$x->{_a} = 3;
+$x->{accuracy} = 3;
 is($x, "1230", q|$x = "1230"|);
 $x->bround(6);                  # must be no-op
-is($x->{_a}, 3, q|$x->{_a} = 3|);
+is($x->{accuracy}, 3, q|$x->{accuracy} = 3|);
 is($x, "1230", q|$x = "1230"|);
 
-note("bround(n) should set _a");
+note("bround(n) should set accuracy");
 
 $x->bround(2);                  # smaller works
 is($x, "1200", q|$x = "1200"|);
-is($x->{_a}, 2, q|$x->{_a} = 2|);
+is($x->{accuracy}, 2, q|$x->{accuracy} = 2|);
 
 # bround(-n) is undocumented and only used by MBF
 
-note("bround(-n) should set _a");
+note("bround(-n) should set accuracy");
 
 $x = $mbi->new(12345);
 $x->bround(-1);
 is($x, "12300", q|$x = "12300"|);
-is($x->{_a}, 4, q|$x->{_a} = 4|);
+is($x->{accuracy}, 4, q|$x->{accuracy} = 4|);
 
-note("bround(-n) should set _a");
+note("bround(-n) should set accuracy");
 
 $x = $mbi->new(12345);
 $x->bround(-2);
 is($x, "12000", q|$x = "12000"|);
-is($x->{_a}, 3, q|$x->{_a} = 3|);
+is($x->{accuracy}, 3, q|$x->{accuracy} = 3|);
 
-note("bround(-n) should set _a");
+note("bround(-n) should set accuracy");
 
 $x = $mbi->new(12345);
-$x->{_a} = 5;
+$x->{accuracy} = 5;
 $x->bround(-3);
 is($x, "10000", q|$x = "10000"|);
-is($x->{_a}, 2, q|$x->{_a} = 2|);
+is($x->{accuracy}, 2, q|$x->{accuracy} = 2|);
 
-note("bround(-n) should set _a");
+note("bround(-n) should set accuracy");
 
 $x = $mbi->new(12345);
-$x->{_a} = 5;
+$x->{accuracy} = 5;
 $x->bround(-4);
 is($x, "0", q|$x = "0"|);
-is($x->{_a}, 1, q|$x->{_a} = 1|);
+is($x->{accuracy}, 1, q|$x->{accuracy} = 1|);
 
 note("bround(-n) should be no-op if n too big");
 
 $x = $mbi->new(12345);
 $x->bround(-5);
 is($x, "0", q|$x = "0"|);               # scale to "big" => 0
-is($x->{_a}, 0, q|$x->{_a} = 0|);
+is($x->{accuracy}, 0, q|$x->{accuracy} = 0|);
 
 note("bround(-n) should be no-op if n too big");
 
 $x = $mbi->new(54321);
 $x->bround(-5);
 is($x, "100000", q|$x = "100000"|);     # used by MBF to round 0.0054321 at 0.0_6_00000
-is($x->{_a}, 0, q|$x->{_a} = 0|);
+is($x->{accuracy}, 0, q|$x->{accuracy} = 0|);
 
 note("bround(-n) should be no-op if n too big");
 
 $x = $mbi->new(54321);
-$x->{_a} = 5;
+$x->{accuracy} = 5;
 $x->bround(-6);
 is($x, "100000", q|$x = "100000"|);     # no-op
-is($x->{_a}, 0, q|$x->{_a} = 0|);
+is($x->{accuracy}, 0, q|$x->{accuracy} = 0|);
 
-note("bround(n) should set _a");
+note("bround(n) should set accuracy");
 
 $x = $mbi->new(12345);
-$x->{_a} = 5;
+$x->{accuracy} = 5;
 $x->bround(5);                          # must be no-op
 is($x, "12345", q|$x = "12345"|);
-is($x->{_a}, 5, q|$x->{_a} = 5|);
+is($x->{accuracy}, 5, q|$x->{accuracy} = 5|);
 
-note("bround(n) should set _a");
+note("bround(n) should set accuracy");
 
 $x = $mbi->new(12345);
-$x->{_a} = 5;
+$x->{accuracy} = 5;
 $x->bround(6);                          # must be no-op
 is($x, "12345", q|$x = "12345"|);
 
@@ -791,7 +791,7 @@ note("MBI::bfround should clear A for negative P");
 $x = $mbi->new("1234");
 $x->accuracy(3);
 $x->bfround(-2);
-is($x->{_a}, undef, q|$x->{_a} = undef|);
+is($x->{accuracy}, undef, q|$x->{accuracy} = undef|);
 
 note("test that bfround() and bround() work with large numbers");
 
@@ -816,51 +816,51 @@ is($x, "0.00017611835153222965833039802747446283902782"
 note("rounding with already set precision/accuracy");
 
 $x = $mbf->new(1);
-$x->{_p} = -5;
+$x->{precision} = -5;
 is($x, "1.00000", q|$x = "1.00000"|);
 
 note("further rounding down");
 
 is($x->bfround(-2), "1.00", q|$x->bfround(-2) = "1.00"|);
-is($x->{_p}, -2, q|$x->{_p} = -2|);
+is($x->{precision}, -2, q|$x->{precision} = -2|);
 
 $x = $mbf->new(12345);
-$x->{_a} = 5;
+$x->{accuracy} = 5;
 is($x->bround(2), "12000", q|$x->bround(2) = "12000"|);
-is($x->{_a}, 2, q|$x->{_a} = 2|);
+is($x->{accuracy}, 2, q|$x->{accuracy} = 2|);
 
 $x = $mbf->new("1.2345");
-$x->{_a} = 5;
+$x->{accuracy} = 5;
 is($x->bround(2), "1.2", q|$x->bround(2) = "1.2"|);
-is($x->{_a}, 2, q|$x->{_a} = 2|);
+is($x->{accuracy}, 2, q|$x->{accuracy} = 2|);
 
 note("mantissa/exponent format and A/P");
 
 $x = $mbf->new("12345.678");
 $x->accuracy(4);
 is($x, "12350", q|$x = "12350"|);
-is($x->{_a}, 4, q|$x->{_a} = 4|);
-is($x->{_p}, undef, q|$x->{_p} = undef|);
+is($x->{accuracy}, 4, q|$x->{accuracy} = 4|);
+is($x->{precision}, undef, q|$x->{precision} = undef|);
 
-#is($x->{_m}->{_a}, undef, q|$x->{_m}->{_a} = undef|);
-#is($x->{_e}->{_a}, undef, q|$x->{_e}->{_a} = undef|);
-#is($x->{_m}->{_p}, undef, q|$x->{_m}->{_p} = undef|);
-#is($x->{_e}->{_p}, undef, q|$x->{_e}->{_p} = undef|);
+#is($x->{_m}->{accuracy}, undef, q|$x->{_m}->{accuracy} = undef|);
+#is($x->{_e}->{accuracy}, undef, q|$x->{_e}->{accuracy} = undef|);
+#is($x->{_m}->{precision}, undef, q|$x->{_m}->{precision} = undef|);
+#is($x->{_e}->{precision}, undef, q|$x->{_e}->{precision} = undef|);
 
 note("check for no A/P in case of fallback result");
 
 $x = $mbf->new(100) / 3;
-is($x->{_a}, undef, q|$x->{_a} = undef|);
-is($x->{_p}, undef, q|$x->{_p} = undef|);
+is($x->{accuracy}, undef, q|$x->{accuracy} = undef|);
+is($x->{precision}, undef, q|$x->{precision} = undef|);
 
 note("result & remainder");
 
 $x = $mbf->new(100) / 3;
 ($x, $y) = $x->bdiv(3);
-is($x->{_a}, undef, q|$x->{_a} = undef|);
-is($x->{_p}, undef, q|$x->{_p} = undef|);
-is($y->{_a}, undef, q|$y->{_a} = undef|);
-is($y->{_p}, undef, q|$y->{_p} = undef|);
+is($x->{accuracy}, undef, q|$x->{accuracy} = undef|);
+is($x->{precision}, undef, q|$x->{precision} = undef|);
+is($y->{accuracy}, undef, q|$y->{accuracy} = undef|);
+is($y->{precision}, undef, q|$y->{precision} = undef|);
 
 ###############################################################################
 # math with two numbers with different A and P
@@ -959,122 +959,122 @@ is($params[0], $x, q|$params[0] = $x|);               # self
 
 foreach my $class ($mbi, $mbf) {
     $x = $class->new(2)->bzero();
-    is($x->{_a}, undef, qq|\$x = $class->new(2)->bzero(); \$x->{_a}|);
-    is($x->{_p}, undef, qq|\$x = $class->new(2)->bzero(); \$x->{_p}|);
+    is($x->{accuracy}, undef, qq|\$x = $class->new(2)->bzero(); \$x->{accuracy}|);
+    is($x->{precision}, undef, qq|\$x = $class->new(2)->bzero(); \$x->{precision}|);
 
     $x = $class->new(2)->bone();
-    is($x->{_a}, undef, qq|\$x = $class->new(2)->bone(); \$x->{_a}|);
-    is($x->{_p}, undef, qq|\$x = $class->new(2)->bone(); \$x->{_p}|);
+    is($x->{accuracy}, undef, qq|\$x = $class->new(2)->bone(); \$x->{accuracy}|);
+    is($x->{precision}, undef, qq|\$x = $class->new(2)->bone(); \$x->{precision}|);
 
     $x = $class->new(2)->binf();
-    is($x->{_a}, undef, qq|\$x = $class->new(2)->binf(); \$x->{_a}|);
-    is($x->{_p}, undef, qq|\$x = $class->new(2)->binf(); \$x->{_p}|);
+    is($x->{accuracy}, undef, qq|\$x = $class->new(2)->binf(); \$x->{accuracy}|);
+    is($x->{precision}, undef, qq|\$x = $class->new(2)->binf(); \$x->{precision}|);
 
     $x = $class->new(2)->bnan();
-    is($x->{_a}, undef, qq|\$x = $class->new(2)->bnan(); \$x->{_a}|);
-    is($x->{_p}, undef, qq|\$x = $class->new(2)->bnan(); \$x->{_p}|);
+    is($x->{accuracy}, undef, qq|\$x = $class->new(2)->bnan(); \$x->{accuracy}|);
+    is($x->{precision}, undef, qq|\$x = $class->new(2)->bnan(); \$x->{precision}|);
 
     note "Verify that bnan() does not delete/undefine accuracy and precision.";
 
     $x = $class->new(2);
-    $x->{_a} = 1;
+    $x->{accuracy} = 1;
     $x->bnan();
-    is($x->{_a}, 1, qq|\$x = $class->new(2); \$x->{_a} = 1; \$x->bnan(); \$x->{_a}|);
+    is($x->{accuracy}, 1, qq|\$x = $class->new(2); \$x->{accuracy} = 1; \$x->bnan(); \$x->{accuracy}|);
 
     $x = $class->new(2);
-    $x->{_p} = 1;
+    $x->{precision} = 1;
     $x->bnan();
-    is($x->{_p}, 1, qq|\$x = $class->new(2); \$x->{_p} = 1; \$x->bnan(); \$x->{_p}|);
+    is($x->{precision}, 1, qq|\$x = $class->new(2); \$x->{precision} = 1; \$x->bnan(); \$x->{precision}|);
 
     note "Verify that binf() does not delete/undefine accuracy and precision.";
 
     $x = $class->new(2);
-    $x->{_a} = 1;
+    $x->{accuracy} = 1;
     $x->binf();
-    is($x->{_a}, 1, qq|\$x = $class->new(2); \$x->{_a} = 1; \$x->binf(); \$x->{_a}|);
+    is($x->{accuracy}, 1, qq|\$x = $class->new(2); \$x->{accuracy} = 1; \$x->binf(); \$x->{accuracy}|);
 
     $x = $class->new(2);
-    $x->{_p} = 1;
+    $x->{precision} = 1;
     $x->binf();
-    is($x->{_p}, 1, qq|\$x = $class->new(2); \$x->{_p} = 1; \$x->binf(); \$x->{_p}|);
+    is($x->{precision}, 1, qq|\$x = $class->new(2); \$x->{precision} = 1; \$x->binf(); \$x->{precision}|);
 
     note "Verify that accuracy can be set as argument to new().";
 
     $x = $class->new(2, 1);
-    is($x->{_a}, 1,     qq|\$x = $class->new(2, 1); \$x->{_a}|);
-    is($x->{_p}, undef, qq|\$x = $class->new(2, 1); \$x->{_p}|);
+    is($x->{accuracy}, 1,     qq|\$x = $class->new(2, 1); \$x->{accuracy}|);
+    is($x->{precision}, undef, qq|\$x = $class->new(2, 1); \$x->{precision}|);
 
     note "Verify that precision can be set as argument to new().";
 
     $x = $class->new(2, undef, 1);
-    is($x->{_a}, undef, qq|\$x = $class->new(2, undef, 1); \$x->{_a}|);
-    is($x->{_p}, 1,     qq|\$x = $class->new(2, undef, 1); \$x->{_p}|);
+    is($x->{accuracy}, undef, qq|\$x = $class->new(2, undef, 1); \$x->{accuracy}|);
+    is($x->{precision}, 1,     qq|\$x = $class->new(2, undef, 1); \$x->{precision}|);
 
     note "Verify that accuracy set with new() is preserved after calling bzero().";
 
     $x = $class->new(2, 1)->bzero();
-    is($x->{_a}, 1,     qq|\$x = $class->new(2, 1)->bzero(); \$x->{_a}|);
-    is($x->{_p}, undef, qq|\$x = $class->new(2, 1)->bzero(); \$x->{_p}|);
+    is($x->{accuracy}, 1,     qq|\$x = $class->new(2, 1)->bzero(); \$x->{accuracy}|);
+    is($x->{precision}, undef, qq|\$x = $class->new(2, 1)->bzero(); \$x->{precision}|);
 
     note "Verify that precision set with new() is preserved after calling bzero().";
 
     $x = $class->new(2, undef, 1)->bzero();
-    is($x->{_a}, undef, qq|\$x = $class->new(2, undef, 1)->bzero(); \$x->{_a}|);
-    is($x->{_p}, 1,     qq|\$x = $class->new(2, undef, 1)->bzero(); \$x->{_p}|);
+    is($x->{accuracy}, undef, qq|\$x = $class->new(2, undef, 1)->bzero(); \$x->{accuracy}|);
+    is($x->{precision}, 1,     qq|\$x = $class->new(2, undef, 1)->bzero(); \$x->{precision}|);
 
     note "Verify that accuracy set with new() is preserved after calling bone().";
 
     $x = $class->new(2, 1)->bone();
-    is($x->{_a}, 1,     qq|\$x = $class->new(2, 1)->bone(); \$x->{_a}|);
-    is($x->{_p}, undef, qq|\$x = $class->new(2, 1)->bone(); \$x->{_p}|);
+    is($x->{accuracy}, 1,     qq|\$x = $class->new(2, 1)->bone(); \$x->{accuracy}|);
+    is($x->{precision}, undef, qq|\$x = $class->new(2, 1)->bone(); \$x->{precision}|);
 
     note "Verify that precision set with new() is preserved after calling bone().";
 
     $x = $class->new(2, undef, 1)->bone();
-    is($x->{_a}, undef, qq|\$x = $class->new(2, undef, 1)->bone(); \$x->{_a}|);
-    is($x->{_p}, 1,     qq|\$x = $class->new(2, undef, 1)->bone(); \$x->{_p}|);
+    is($x->{accuracy}, undef, qq|\$x = $class->new(2, undef, 1)->bone(); \$x->{accuracy}|);
+    is($x->{precision}, 1,     qq|\$x = $class->new(2, undef, 1)->bone(); \$x->{precision}|);
 
     note "Verify that accuracy can be set with instance method bone('+').";
 
     $x = $class->new(2);
     $x->bone('+', 2, undef);
-    is($x->{_a}, 2,     qq|\$x = $class->new(2); \$x->{_a}|);
-    is($x->{_p}, undef, qq|\$x = $class->new(2); \$x->{_p}|);
+    is($x->{accuracy}, 2,     qq|\$x = $class->new(2); \$x->{accuracy}|);
+    is($x->{precision}, undef, qq|\$x = $class->new(2); \$x->{precision}|);
 
     note "Verify that precision can be set with instance method bone('+').";
 
     $x = $class->new(2);
     $x->bone('+', undef, 2);
-    is($x->{_a}, undef, qq|\$x = $class->new(2); \$x->bone('+', undef, 2); \$x->{_a}|);
-    is($x->{_p}, 2,     qq|\$x = $class->new(2); \$x->bone('+', undef, 2); \$x->{_p}|);
+    is($x->{accuracy}, undef, qq|\$x = $class->new(2); \$x->bone('+', undef, 2); \$x->{accuracy}|);
+    is($x->{precision}, 2,     qq|\$x = $class->new(2); \$x->bone('+', undef, 2); \$x->{precision}|);
 
     note "Verify that accuracy can be set with instance method bone('-').";
 
     $x = $class->new(2);
     $x->bone('-', 2, undef);
-    is($x->{_a}, 2,     qq|\$x = $class->new(2); \$x->bone('-', 2, undef); \$x->{_a}|);
-    is($x->{_p}, undef, qq|\$x = $class->new(2); \$x->bone('-', 2, undef); \$x->{_p}|);
+    is($x->{accuracy}, 2,     qq|\$x = $class->new(2); \$x->bone('-', 2, undef); \$x->{accuracy}|);
+    is($x->{precision}, undef, qq|\$x = $class->new(2); \$x->bone('-', 2, undef); \$x->{precision}|);
 
     note "Verify that precision can be set with instance method bone('-').";
 
     $x = $class->new(2);
     $x->bone('-', undef, 2);
-    is($x->{_a}, undef, qq|\$x = $class->new(2); \$x->bone('-', undef, 2); \$x->{_a}|);
-    is($x->{_p}, 2,     qq|\$x = $class->new(2); \$x->bone('-', undef, 2); \$x->{_p}|);
+    is($x->{accuracy}, undef, qq|\$x = $class->new(2); \$x->bone('-', undef, 2); \$x->{accuracy}|);
+    is($x->{precision}, 2,     qq|\$x = $class->new(2); \$x->bone('-', undef, 2); \$x->{precision}|);
 
     note "Verify that accuracy can be set with instance method bzero().";
 
     $x = $class->new(2);
     $x->bzero(2, undef);
-    is($x->{_a}, 2,     qq|\$x = $class->new(2);\$x->bzero(2, undef); \$x->{_a}|);
-    is($x->{_p}, undef, qq|\$x = $class->new(2);\$x->bzero(2, undef); \$x->{_p}|);
+    is($x->{accuracy}, 2,     qq|\$x = $class->new(2);\$x->bzero(2, undef); \$x->{accuracy}|);
+    is($x->{precision}, undef, qq|\$x = $class->new(2);\$x->bzero(2, undef); \$x->{precision}|);
 
     note "Verify that precision can be set with instance method bzero().";
 
     $x = $class->new(2);
     $x->bzero(undef, 2);
-    is($x->{_a}, undef, qq|\$x = $class->new(2); \$x->bzero(undef, 2); \$x->{_a}|);
-    is($x->{_p}, 2,     qq|\$x = $class->new(2); \$x->bzero(undef, 2); \$x->{_p}|);
+    is($x->{accuracy}, undef, qq|\$x = $class->new(2); \$x->bzero(undef, 2); \$x->{accuracy}|);
+    is($x->{precision}, 2,     qq|\$x = $class->new(2); \$x->bzero(undef, 2); \$x->{precision}|);
 }
 
 ###############################################################################
@@ -1314,16 +1314,16 @@ while (<DATA>) {
     # print "Check a=$a p=$p\n";
     # print "# Tried: '$try'\n";
     if ($a ne '') {
-        unless (is($x->{_a}, $a,    qq|\$x->{_a} == $a|) &&
-                is($x->{_p}, undef, qq|\$x->{_p} is undef|))
+        unless (is($x->{accuracy}, $a,    qq|\$x->{accuracy} == $a|) &&
+                is($x->{precision}, undef, qq|\$x->{precision} is undef|))
         {
             print "# Check: A = $a and P = undef\n";
             print "# Tried: $try\n";
         }
     }
     if ($p ne '') {
-        unless (is($x->{_p}, $p,    qq|\$x->{_p} == $p|) &&
-                is($x->{_a}, undef, qq|\$x->{_a} is undef|))
+        unless (is($x->{precision}, $p,    qq|\$x->{precision} == $p|) &&
+                is($x->{accuracy}, undef, qq|\$x->{accuracy} is undef|))
         {
             print "# Check: A = undef and P = $p\n";
             print "# Tried: $try\n";


### PR DESCRIPTION
2.003001 2023-12-26

 * Add configuration methods trap_inf() and trap_nan(). Previously it was only possible to modify these properties by using the config() method.

 * Fix CPAN RT #150796 so that config() no longer modifies the input when it is a hash ref.

 * Fix CPAN RT #150797 so that both accuracy and precision can be set simultaneously with config().

 * Add the following methods to Math::BigInt

   - bilog2()   base 2 logarithm rounded downwards, i.e., int(log2(x))
   - bilog10()  base 10 logarithm rounded downwards, i.e., int(log10(x))
   - bclog2()   base 2 logarithm rounded upwards, i.e., ceil(log2(x))
   - bclog10()  base 10 logarithm rounded upwards, i.e., ceil(log10(x))

 * Add the following backend library methods to Math::BigInt::Lib. These methods do the core computations for the corresponding methods in Math::BigInt (see above).

   - _ilog2()   base 2 logarithm rounded downwards
   - _ilog10()  base 10 logarithm rounded downwards
   - _clog2()   base 2 logarithm rounded upwards
   - _clog10()  base 10 logarithm rounded upwards