### PR TITLE
File glob export tags 20231226

### DIFF
--- a/ext/File-Glob/Glob.pm
+++ b/ext/File-Glob/Glob.pm
@@ -33,7 +33,7 @@ $EXPORT_TAGS{bsd_glob} = [@{$EXPORT_TAGS{glob}}];
 
 our @EXPORT_OK   = (@{$EXPORT_TAGS{'glob'}}, 'csh_glob');
 
-our $VERSION = '1.40';
+our $VERSION = '1.41';
 
 sub import {
     require Exporter;
@@ -190,7 +190,7 @@ uses this internally.
 
 =head2 POSIX FLAGS
 
-If no flags argument is give then C<GLOB_CSH> is set, and on VMS and
+If no flags argument is given then C<GLOB_CSH> is set, and on VMS and
 Windows systems, C<GLOB_NOCASE> too.  Otherwise the flags to use are
 determined solely by the flags argument.  The POSIX defined flags are:
 

--- a/ext/File-Glob/t/global.t
+++ b/ext/File-Glob/t/global.t
@@ -31,9 +31,9 @@ BEGIN {
 
 $_ = "op/*.t";
 my @r = glob;
-is($_, "op/*.t");
+is($_, "op/*.t", 'pattern intact after use of core glob function');
 
-cmp_ok(scalar @r, '>=', 3);
+cmp_ok(scalar @r, '>=', 3, 'check if core glob function works');
 
 @r = <*/*.t>;
 # at least t/global.t t/basic.t, t/taint.t


### PR DESCRIPTION
This pull request partially addresses the concerns raised in https://github.com/Perl/perl5/issues/21744.  The test suite now better exercises the `GLOB_MARK` and `GLOB_NOCHECK` flags, provides descriptions for two tests previously lacking them, does some tidying up of leading indents and corrects one spelling error in documentation.  Currently there are 6 commits in the p.r., but they should probably be squashed to one before merging.