### PR TITLE
 locale.c: Fix bug in getting langinfo(CRNCYSTR)

### DIFF
--- a/ext/I18N-Langinfo/t/Langinfo.t
+++ b/ext/I18N-Langinfo/t/Langinfo.t
@@ -14,8 +14,8 @@ my @constants = qw(ABDAY_1 DAY_1 ABMON_1 RADIXCHAR AM_STR THOUSEP D_T_FMT
                    D_FMT T_FMT);
 push @constants, @times;
 
-my %want = (    RADIXCHAR => ".",
-                THOUSEP	  => "",
+my %want = (    RADIXCHAR => qr/ ^ \. $ /x,
+                THOUSEP	  => qr/ ^$ /x,
            );
 
 # Abbreviated and full are swapped in many locales in early netbsd.  Skip
@@ -23,10 +23,10 @@ my %want = (    RADIXCHAR => ".",
 if (   $Config{osname} !~ / netbsd /ix
     || $Config{osvers} !~ / ^ [1-6] \. /x)
 {
-    $want{ABDAY_1} = "Sun";
-    $want{DAY_1}   = "Sunday";
-    $want{ABMON_1} = "Jan";
-    $want{MON_1}   = "January";
+    $want{ABDAY_1} = qr/ ^ Sun $ /x;
+    $want{DAY_1}   = qr/ ^ Sunday $ /x;
+    $want{ABMON_1} = qr/ ^ Jan $ /x;
+    $want{MON_1}   = qr/ ^ January $ /x;
 }
 
 sub disp_str ($) {
@@ -169,7 +169,7 @@ for my $i (1..@want) {
     SKIP: {
         skip "$try not defined", 1, if $@;
         no strict 'refs';
-        is (langinfo(&$try), $want{$try}, "$try => '$want{$try}'");
+        like (langinfo(&$try), $want{$try}, "$try => '$want{$try}'");
     }
 }
 

--- a/ext/I18N-Langinfo/t/Langinfo.t
+++ b/ext/I18N-Langinfo/t/Langinfo.t
@@ -16,6 +16,11 @@ push @constants, @times;
 
 my %want = (    RADIXCHAR => qr/ ^ \. $ /x,
                 THOUSEP	  => qr/ ^$ /x,
+
+                # Can be empty; otherwise first character must be one of
+                # these.  In the C locale, there is nothing after the first
+                # character.
+                CRNCYSTR  => qr/ ^ [+-.]? $ /x,
            );
 
 # Abbreviated and full are swapped in many locales in early netbsd.  Skip

--- a/locale.c
+++ b/locale.c
@@ -6231,15 +6231,13 @@ S_my_langinfo_i(pTHX_
 
             /* The modification is to prefix the localeconv() return with a
              * single byte, calculated as follows: */
-            char prefix = (LIKELY(SvIV(precedes) != -1))
-                          ? ((precedes != 0) ?  '-' : '+')
-
-                            /* khw couldn't find any documentation that
-                             * CHAR_MAX (which we modify to -1) is the signal,
-                             * but cygwin uses it thusly, and it makes sense
-                             * given that CHAR_MAX indicates the value isn't
-                             * used, so it neither precedes nor succeeds */
-                          : '.';
+            const char * prefix = (LIKELY(SvIV(precedes) != -1))
+                                   ? ((precedes != 0) ?  "-" : "+")
+                                   : ".";
+            /* (khw couldn't find any documentation that the dot is signalled
+             * by CHAR_MAX (which we modify to -1), but cygwin uses it thusly,
+             * and it makes sense given that CHAR_MAX indicates the value isn't
+             * used, so it neither precedes nor succeeds) */
 
             /* Now get CRNCYSTR */
             (void) hv_iterinit(result_hv);
@@ -6247,7 +6245,7 @@ S_my_langinfo_i(pTHX_
             string = hv_iterval(result_hv, entry);
 
             /* And perform the modification */
-            Perl_sv_setpvf(aTHX_ string, "%c%s", prefix, SvPV_nolen(string));
+            sv_insert(string, 0, 0, prefix, 1);
         }
 
         /* Here, 'string' contains the value we want to return */


### PR DESCRIPTION
This does not affect platforms that have libc `nl_langinfo()`.  Thus,
mainly Windows machines are affected.  The code was passing to
`sv_setpvf()` a pointer to the existing string of the passed in  SV.
This could lead to reallocating the SV with the pointer invalidated
before being used.

Tony Cook spotted the problem, and the fix used here, using `sv_insert()`
instead.