### PR TITLE
Fix a wrong sigil used in a perlre example

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -574,6 +574,7 @@ Marnix van Ammers <marnix@gmail.com> Marnix (ain't unix!) A. van Ammers <pttesac
 Martien Verbruggen <mgjv@comdyn.com.au> <mgjv@tradingpost.com.au>
 Martin Hasch <mhasch@cpan.org> Martin Becker <mhasch@cpan.org>
 Marty Pauley <marty+p5p@kasei.com> Marty Pauley <marty@martian.org>
+Mathias Kende <mathias@cpan.org> Mathias Kende <mathias@kende.fr>
 Mats Peterson <mats@sm6sxl.net> <mats@sm6sxl.net>
 Mats Peterson <mats@sm6sxl.net> mats@sm5sxl.net <mats@sm5sxl.net>
 Matsumoto Yasuhiro <mattn.jp@gmail.com> Yasuhiro Matsumoto <mattn.jp@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -931,6 +931,7 @@ Martyn Pearce                  <martyn@inpharmatica.co.uk>
 Marvin Humphrey                <marvin@rectangular.com>
 Masahiro KAJIURA               <masahiro.kajiura@toshiba.co.jp>
 Mashrab Kuvatov                <kmashrab@uni-bremen.de>
+Mathias Kende                  <mathias@cpan.org>
 Mathias Koerber                <mathias@dnssec1.singnet.com.sg>
 Mathieu Arnold                 <m@absolight.fr>
 Mats Peterson                  <mats@sm6sxl.net>

--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -1308,7 +1308,7 @@ C<@captured> array.
 Be aware that when interpolating a subscript of the C<@{^CAPTURE}>
 array you must use demarcated curly brace notation:
 
-    print "@{^CAPTURE[0]}";
+    print "${^CAPTURE[0]}";
 
 See L<perldata/"Demarcated variable names using braces"> for more on
 this notation.


### PR DESCRIPTION
In the description of the @^CAPTURE array, an example of demarcated variable name uses the @ sigil. The $ sigil is probably more correct in that case and raises less questions when reading this section (although the @ sigil will give the same result in that case).