### PR TITLE
Define setlocale_i() on unsafe threaded builds

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -1992,6 +1992,13 @@ S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char * locale)
 #  define void_setlocale_c(cat, locale) void_setlocale_r(cat, locale)
 #  define void_setlocale_i(i, locale)   void_setlocale_r(categories[i], locale)
 
+/*---------------------------------------------------------------------------*/
+
+/* setlocale_i is only defined for Configurations where the libc setlocale()
+ * suffices for both querying and setting the locale.  It allows for some
+ * shortcuts */
+#  define setlocale_i(i, locale)  less_dicey_setlocale_r(categories[i], locale)
+
 /*===========================================================================*/
 
 #elif defined(USE_POSIX_2008_LOCALE)


### PR DESCRIPTION
On threaded Configurations where thread-safe locale handling is not available, perl automatically does a modicum of prevention of races by executing locale changes in a critical section, and copying the results to a thread-safe location.

This commit defines setlocale_i() on such builds.  This macro is used to bypass more complex handling required in fully thread-safe builds, and is used where the libc setlocale() can be wrapped such that it works for both querying what the existing locale is, and changing the locale.