### PR TITLE
Remove references to nl_langinfo_l(), add comment

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4483,7 +4483,7 @@ RS	|char * |my_setlocale_debug_string_i				\
 				|NULLOK const char *retval		\
 				|const line_t line
 #   endif
-#   if defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L)
+#   if defined(HAS_NL_LANGINFO)
 S	|const char *|my_langinfo_i					\
 				|const nl_item item			\
 				|const locale_category_index cat_index	\

--- a/embed.h
+++ b/embed.h
@@ -1324,7 +1324,7 @@
 #       if defined(DEBUGGING)
 #         define my_setlocale_debug_string_i(a,b,c,d) S_my_setlocale_debug_string_i(aTHX_ a,b,c,d)
 #       endif
-#       if defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L)
+#       if defined(HAS_NL_LANGINFO)
 #         define my_langinfo_i(a,b,c,d,e,f)     S_my_langinfo_i(aTHX_ a,b,c,d,e,f)
 #       else
 #         define my_langinfo_i(a,b,c,d,e,f)     S_my_langinfo_i(aTHX_ a,b,c,d,e,f)

--- a/locale.c
+++ b/locale.c
@@ -6044,7 +6044,13 @@ S_my_langinfo_i(pTHX_
  * isn't, or vice versa).  There is explicit code to bring the categories into
  * sync.  This doesn't seem to be a problem with nl_langinfo(), so that
  * implementation doesn't currently worry about it.  But it is a problem on
- * Windows boxes, which don't have nl_langinfo(). */
+ * Windows boxes, which don't have nl_langinfo().
+ *
+ * One might be tempted to avoid any toggling by instead using nl_langinfo_l()
+ * on platforms that have it.  This would entail creating a locale object with
+ * newlocale() and freeing it afterwards.  But doing so runs significantly
+ * slower than just doing the toggle ourselves.  lib/locale_threads.t was
+ * slowed down by 25% on Ubuntu 22.04 */
 
 /*--------------------------------------------------------------------------*/
 #  if defined(HAS_NL_LANGINFO) /* nl_langinfo() is available.  */

--- a/proto.h
+++ b/proto.h
@@ -7082,7 +7082,7 @@ S_my_setlocale_debug_string_i(pTHX_ const locale_category_index cat_index, const
 #     define PERL_ARGS_ASSERT_MY_SETLOCALE_DEBUG_STRING_I
 
 #   endif
-#   if defined(HAS_NL_LANGINFO) || defined(HAS_NL_LANGINFO_L)
+#   if defined(HAS_NL_LANGINFO)
 STATIC const char *
 S_my_langinfo_i(pTHX_ const nl_item item, const locale_category_index cat_index, const char *locale, char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
 #     define PERL_ARGS_ASSERT_MY_LANGINFO_I     \


### PR DESCRIPTION
This was missed when we earlier removed the use of this function.  I have since run experiments using it, and found using it slows things down considerably in the context where we planned to use it.