### PR TITLE
locale.c: Silence compiler warning

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4556,10 +4556,14 @@ S	|void	|print_collxfrm_input_and_return			\
 #     endif
 #   endif
 #   if defined(USE_LOCALE_CTYPE)
-ST	|bool	|is_codeset_name_UTF8					\
-				|NN const char *name
 S	|void	|new_ctype	|NN const char *newctype		\
 				|bool force
+#     if    defined(HAS_NL_LANGINFO) || defined(WIN32) || \
+            defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) ||  \
+         ( !defined(HAS_MBRTOWC) && !defined(HAS_MBTOWC) )
+ST	|bool	|is_codeset_name_UTF8					\
+				|NN const char *name
+#     endif
 #   endif
 #   if defined(USE_LOCALE_NUMERIC)
 S	|void	|new_numeric	|NN const char *newnum			\

--- a/embed.h
+++ b/embed.h
@@ -1362,8 +1362,12 @@
 #         endif
 #       endif
 #       if defined(USE_LOCALE_CTYPE)
-#         define is_codeset_name_UTF8           S_is_codeset_name_UTF8
 #         define new_ctype(a,b)                 S_new_ctype(aTHX_ a,b)
+#         if    defined(HAS_NL_LANGINFO) || defined(WIN32) || \
+                defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) ||  \
+             ( !defined(HAS_MBRTOWC) && !defined(HAS_MBTOWC) )
+#           define is_codeset_name_UTF8         S_is_codeset_name_UTF8
+#         endif
 #       endif
 #       if defined(USE_LOCALE_NUMERIC)
 #         define new_numeric(a,b)               S_new_numeric(aTHX_ a,b)

--- a/proto.h
+++ b/proto.h
@@ -7169,16 +7169,20 @@ S_print_collxfrm_input_and_return(pTHX_ const char *s, const char *e, const char
 #     endif
 #   endif /* defined(USE_LOCALE_COLLATE) */
 #   if defined(USE_LOCALE_CTYPE)
-STATIC bool
-S_is_codeset_name_UTF8(const char *name);
-#     define PERL_ARGS_ASSERT_IS_CODESET_NAME_UTF8 \
-        assert(name)
-
 STATIC void
 S_new_ctype(pTHX_ const char *newctype, bool force);
 #     define PERL_ARGS_ASSERT_NEW_CTYPE         \
         assert(newctype)
 
+#     if    defined(HAS_NL_LANGINFO) || defined(WIN32) || \
+            defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) ||  \
+         ( !defined(HAS_MBRTOWC) && !defined(HAS_MBTOWC) )
+STATIC bool
+S_is_codeset_name_UTF8(const char *name);
+#       define PERL_ARGS_ASSERT_IS_CODESET_NAME_UTF8 \
+        assert(name)
+
+#     endif
 #   endif /* defined(USE_LOCALE_CTYPE) */
 #   if defined(USE_LOCALE_NUMERIC)
 STATIC void


### PR DESCRIPTION
This tightens when this function is compiled to the actual Configurations it is needed in.