### PR TITLE
locale.c: Refactor an #ifdef

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -6463,21 +6463,19 @@ S_my_langinfo_i(pTHX_
         }
 
 #      ifdef WIN32
-
-        const char * orig_CTYPE_locale = toggle_locale_c(LC_CTYPE, locale);
-
-#        ifndef WIN32_USE_FAKE_OLD_MINGW_LOCALES
-
-        /* This function retrieves the code page.  It is subject to change, but
-         * is documented and has been stable for many releases */
-        retval = save_to_buffer(Perl_form(aTHX_ "%d", ___lc_codepage_func()),
-                                retbufp, retbuf_sizep);
+#        ifdef WIN32_USE_FAKE_OLD_MINGW_LOCALES
+#          define GET_CODE_PAGE_AS_STRING  nl_langinfo(CODESET)
 #        else
-
-        retval = save_to_buffer(nl_langinfo(CODESET),
-                                retbufp, retbuf_sizep);
+            /* The Windows function retrieves the code page.  It is subject to
+             * change, but is documented and has been stable for many releases
+             * */
+#          define GET_CODE_PAGE_AS_STRING                                   \
+                                Perl_form(aTHX_ "%d", ___lc_codepage_func())
 #        endif
 
+        const char * orig_CTYPE_locale;
+        orig_CTYPE_locale = toggle_locale_c(LC_CTYPE, locale);
+        retval = save_to_buffer(GET_CODE_PAGE_AS_STRING, retbufp, retbuf_sizep);
         restore_toggled_locale_c(LC_CTYPE, orig_CTYPE_locale);
 
         DEBUG_Lv(PerlIO_printf(Perl_debug_log, "locale='%s' cp=%s\n",


### PR DESCRIPTION
I have some #ifdef'd code that when enabled makes the locale handling think it's running on a Windows MingW machine.  It doesn't emulate the whole platform by any means, but it does reproduce the different logic that is required for Windows in locale.c, and allows checking that changes made likely will compile there without having to actually go to a Windows machine.

It is mostly hidden from the rest of the code, except in the one spot where it gets set up.  This makes it unobtrusive, but more importantly maximizes the chances of it faithfully doing what Windows would do.

But there are two places in locale.c where I couldn't completely hide it.  One is in teardown to avoid a leak, and the other is this spot in the code where the codeset names are calculated.  There are big differences in the Windows name syntax (integers) from the POSIX ones (character strings).

This commit uses a macro to convert the integers into strings, so that the required #ifdef doesn't interrupt the logic flow.