### PR TITLE
locale.c: Reorder cases, code in a switch()

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -6067,6 +6067,14 @@ S_my_langinfo_i(pTHX_
         retval = "";
         break;
 
+#    ifdef HAS_LOCALECONV
+
+      case CRNCYSTR:
+      case THOUSEP:
+        goto use_localeconv;
+
+#    endif
+
       case RADIXCHAR:
 
 #    if      defined(HAS_SNPRINTF)                                          \
@@ -6162,9 +6170,10 @@ S_my_langinfo_i(pTHX_
 
     /* These items are available from localeconv(). */
 
-   /* case RADIXCHAR:   // May drop down to here in some configurations */
-      case THOUSEP:
-      case CRNCYSTR:
+   /* case RADIXCHAR:   // May drop down to here in some configurations
+      case THOUSEP:     // Jumps to here
+      case CRNCYSTR:    // Jumps to here */
+      use_localeconv:
        {
 
         /* The hash gets populated with just the field(s) related to 'item'. */

--- a/locale.c
+++ b/locale.c
@@ -6154,17 +6154,15 @@ S_my_langinfo_i(pTHX_
             Safefree(floatbuf);
         }
 
-#      ifdef HAS_LOCALECONV /* snprintf() failed; drop down to use
-                               localeconv() */
+#    endif  /* Trying snprintf() */
 
-        /* FALLTHROUGH */
+        /* Here snprintf() was not compiled, or failed */
 
-#      else                      /* snprintf() failed and no localeconv() */
+#    ifndef HAS_LOCALECONV    /* Requires localeconv() if no snprintf() */
 
         retval = C_decimal_point;
         break;
 
-#      endif
 #    endif
 #    ifdef HAS_LOCALECONV
 


### PR DESCRIPTION
These commits rationalize the statement ordering within a `switch()`, mostly in preparation for future commits.