### PR TITLE
locale.c: Minimize time spent with a toggled locale

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -6062,12 +6062,6 @@ S_my_langinfo_i(pTHX_
     retval = save_to_buffer(nl_langinfo(item), retbufp, retbuf_sizep);
     gwLOCALE_UNLOCK;
 
-    if (utf8ness) {
-        *utf8ness = get_locale_string_utf8ness_i(retval,
-                                                 LOCALE_UTF8NESS_UNKNOWN,
-                                                 locale, cat_index);
-    }
-
     restore_toggled_locale_i(cat_index, orig_switched_locale);
 
 #    ifdef WE_MUST_DEAL_WITH_MISMATCHED_CTYPE
@@ -6075,6 +6069,12 @@ S_my_langinfo_i(pTHX_
     restore_toggled_locale_c(LC_CTYPE, orig_CTYPE_locale);
 
 #    endif
+
+    if (utf8ness) {
+        *utf8ness = get_locale_string_utf8ness_i(retval,
+                                                 LOCALE_UTF8NESS_UNKNOWN,
+                                                 locale, cat_index);
+    }
 
     return retval;
 /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
It's better to disturb things the least amount of time as possible. Here it's just as convenient to reorder things so the untoggling is done sooner.