### PR TITLE
locale.c: C is the only locale under NO_LOCALE

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -2668,9 +2668,11 @@ S_bool_setlocale_2008_i(pTHX_
 #  define query_nominal_locale_i(i)                                         \
       (__ASSERT_(i != LC_ALL_INDEX_)                                        \
        ((i == LC_NUMERIC_INDEX_) ? PL_numeric_name : querylocale_i(i)))
-#else
+#elif defined(USE_LOCALE)
 #  define query_nominal_locale_i(i)                                         \
       (__ASSERT_(i != LC_ALL_INDEX_) querylocale_i(i))
+#else
+#  define query_nominal_locale_i(i)  "C"
 #endif
 
 #ifdef USE_PL_CURLOCALES


### PR DESCRIPTION
It is possible to Configure perl to not pay attention to locales at all. Effectively that means the only permissible locale is "C", which underlies all C programs at startup.

Thus, when asked what the current locale is, the answer is always going to be "C"; and we can define the macro that computes this info to just return "C" instead of doing any lookup.