### PR TITLE
op/tr.t: Suppress two warnings

### DIFF
--- a/t/op/tr.t
+++ b/t/op/tr.t
@@ -18,7 +18,7 @@ plan tests => 315;
 
 # Test this first before we extend the stack with other operations.
 # This caused an asan failure due to a bad write past the end of the stack.
-eval { my $x; die  1..127, $x =~ y/// };
+eval { no warnings 'uninitialized'; my $x; die  1..127, $x =~ y/// };
 
 $_ = "abcdefghijklmnopqrstuvwxyz";
 
@@ -33,8 +33,14 @@ is($_, "abcdefghijklmnopqrstuvwxyz",    'lc');
 tr/b-y/B-Y/;
 is($_, "aBCDEFGHIJKLMNOPQRSTUVWXYz",    'partial uc');
 
-tr/a-a/AB/;
-is($_, "ABCDEFGHIJKLMNOPQRSTUVWXYz",    'single char range a-a');
+{
+    # AB is 2 characters, longer than single char source, so otherwise gets
+    # warned about
+    no warnings 'misc';
+
+    tr/a-a/AB/;
+    is($_, "ABCDEFGHIJKLMNOPQRSTUVWXYz",    'single char range a-a');
+}
 
 eval 'tr/a/\N{KATAKANA LETTER AINU P}/;';
 like $@,


### PR DESCRIPTION
The warnings suppressed here are legitimate, but distract from the point of the tests.

Spotted by Jim Keenan.