### PR TITLE
FindBin: Update $VERSION

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -607,7 +607,7 @@ our %Modules = (
     },
 
     'FindBin' => {
-        'DISTRIBUTION' => 'TODDR/FindBin-1.53.tar.gz',
+        'DISTRIBUTION' => 'TODDR/FindBin-1.54.tar.gz',
         'FILES'        => q[dist/FindBin],
     },
 


### PR DESCRIPTION
Per incline comments in Porting/Maintainers.PL:

(For dist/ distributions, which are blead-first, a request should be placed with the releaser(s) to upload the corresponding cpan release, and the entry in this file should only be updated when that release has been done.)

FindBin-1.54 has been released on CPAN, so now we can update $VERSION in core to keep Porting/core-cpan-diff -ax happy.