### PR TITLE
cpan/Digest-MD5 - Update to version 2.59

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -731,7 +731,7 @@ cpan/Digest-MD5/t/files.t		See if Digest::MD5 extension works
 cpan/Digest-MD5/t/md5-aaa.t		See if Digest::MD5 extension works
 cpan/Digest-MD5/t/threads.t		See if Digest::MD5 extension works
 cpan/Digest-MD5/t/utf8.t		See if Digest::MD5 extension works
-cpan/Digest-MD5/t/warns.t
+cpan/Digest-MD5/t/warns.t		Test file related to Digest::MD5
 cpan/Digest-MD5/typemap			Digest::MD5 extension
 cpan/Digest-SHA/lib/Digest/SHA.pm	Digest::SHA extension
 cpan/Digest-SHA/Makefile.PL		Digest::SHA Makefile.PL

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -375,7 +375,8 @@ our %Modules = (
     },
 
     'Digest::MD5' => {
-        'DISTRIBUTION' => 'TODDR/Digest-MD5-2.58.tar.gz',
+        'DISTRIBUTION' => 'TODDR/Digest-MD5-2.59.tar.gz',
+        'SYNCINFO'     => 'root on Sat Dec 30 21:42:47 2023',
         'FILES'        => q[cpan/Digest-MD5],
         'EXCLUDED'     => [ 'rfc1321.txt', 'bin/md5sum.pl' ],
         'CUSTOMIZED'   => [

--- a/cpan/Digest-MD5/Makefile.PL
+++ b/cpan/Digest-MD5/Makefile.PL
@@ -20,16 +20,16 @@ if ($^O eq 'VMS') {
 
 
 WriteMakefile(
-    'NAME'	   => 'Digest::MD5',
+    'NAME'         => 'Digest::MD5',
     'VERSION_FROM' => 'MD5.pm',
     'ABSTRACT'     => 'Perl interface to the MD-5 algorithm',
     'AUTHOR'       => 'Gisle Aas <gisle@activestate.com>',
     'LICENSE'      => 'perl',
     'MIN_PERL_VERSION' => 5.006,
     'PREREQ_PM'    => {
-			'Digest::base' => '1.00',
-			'XSLoader' => 0,
-		      },
+        'Digest::base' => '1.00',
+        'XSLoader' => 0,
+    },
     'META_MERGE'   => {
         resources  => {
             license    => 'http://dev.perl.org/licenses/',

--- a/cpan/Digest-MD5/t/bits.t
+++ b/cpan/Digest-MD5/t/bits.t
@@ -3,8 +3,7 @@
 use strict;
 use warnings;
 
-use Test qw(plan ok);
-plan tests => 2;
+use Test::More tests => 2;
 
 use Digest::MD5;
 
@@ -12,18 +11,18 @@ my $md5 = Digest::MD5->new;
 
 if ($Digest::base::VERSION) {
     $md5->add_bits("01111111");
-    ok($md5->hexdigest, "83acb6e67e50e31db6ed341dd2de1595");
+    is($md5->hexdigest, "83acb6e67e50e31db6ed341dd2de1595");
     eval {
-	$md5->add_bits("0111");
+        $md5->add_bits("0111");
     };
-    ok($@ =~ /must be multiple of 8/);
+    like($@, qr/must be multiple of 8/);
 }
 else {
     print "# No Digest::base\n";
     eval {
-	$md5->add_bits("foo");
+        $md5->add_bits("foo");
     };
-    ok($@ =~ /^Can\'t locate Digest\/base\.pm in \@INC/);
+    like($@, qr/^Can\'t locate Digest\/base\.pm in \@INC/);
     ok(1);  # dummy
 }
 

--- a/cpan/Digest-MD5/t/md5-aaa.t
+++ b/cpan/Digest-MD5/t/md5-aaa.t
@@ -10,22 +10,22 @@ my $Is_EBCDIC = ord('A') == 193;
 my $testno = 0;
 while (<DATA>) {
     if (!$Is_EBCDIC) {
-	next if /^EBCDIC/;
+        next if /^EBCDIC/;
     }
     else {
-	next if !/^EBCDIC/;
-	s/^EBCDIC,\w+#//;
-   }
-   my($hexdigest, $message) = split;
-   $message =~ s/\"//g;
+        next if !/^EBCDIC/;
+        s/^EBCDIC,\w+#//;
+    }
+    my($hexdigest, $message) = split;
+    $message =~ s/\"//g;
 
-   my $failed;
-   $failed++ unless md5_hex($message) eq $hexdigest;
-   $failed++ unless Digest::MD5->new->add(split(//, $message))->digest
-                                              eq pack("H*", $hexdigest);
+    my $failed;
+    $failed++ unless md5_hex($message) eq $hexdigest;
+    $failed++ unless Digest::MD5->new->add(split(//, $message))->digest
+                                                eq pack("H*", $hexdigest);
 
-   print "not " if $failed;
-   print "ok ", ++$testno, "\n";
+    print "not " if $failed;
+    print "ok ", ++$testno, "\n";
 }
 
 

--- a/cpan/Digest-MD5/t/utf8.t
+++ b/cpan/Digest-MD5/t/utf8.t
@@ -1,12 +1,5 @@
 #!perl -w
 
-BEGIN {
-    if ($] < 5.006) {
-	print "1..0 # Skipped: your perl don't know unicode\n";
-	exit;
-    }
-}
-
 use strict;
 use warnings;
 
@@ -25,8 +18,8 @@ print "not " unless $@ && $@ =~ /^(Big byte|Wide character)/;
 print "ok 1\n";
 
 my $exp = ord "A" == 193 ? # EBCDIC
-	   "c307ec81deba65e9a222ca81cd8f6ccd" :
-	   "503debffe559537231ed24f25651ec20"; # Latin 1
+    "c307ec81deba65e9a222ca81cd8f6ccd" :
+    "503debffe559537231ed24f25651ec20"; # Latin 1
 
 chop($str);  # only bytes left
 print "not " unless md5_hex($str) eq $exp;


### PR DESCRIPTION
2.59 Sat Dec 30 2023
- Remove meaningless const type qualifier to silence HPUX builds.
- remove useless perl 5.6 check
- convert bits.t test to use Test::More
- Update Digest::MD5 Synopsis and Examples. Add `my` to synopsis
- MD5.xs: eliminate C++ guards