### PR TITLE
Fix an error in `perlvar`: `@+` may have *more* elements than `@-`.

### DIFF
--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -1358,7 +1358,7 @@ match and any capture buffers it contains.
 
 The number of elements it contains will be one more than the number of
 the highest capture buffers (also called a subgroup) that actually
-matched something. (As opposed to C<@+> which may have fewer elements.)
+matched something. (As opposed to C<@+> which may have more elements.)
 
 C<$-[0]> is the offset of the start of the last successful match.
 C<$-[I<n>]> is the offset of the start of the substring matched by


### PR DESCRIPTION
The `@+` variable is documented with (emphasis mine):

> You can use this to determine how many capture buffers there are in the pattern. (**As opposed to C<@-> which may have fewer elements.**)

While `@-` had:

> The number of elements it contains will be one more than the number of the **highest capture buffers [...] that actually matched something**. (As opposed to C<@+> which may have fewer elements.)

So the parenthesis in the `@-` documentation is probably just a erroneous copy/paste.
