### PR TITLE
handle/optimise some ops in void context

### DIFF
--- a/ext/B/t/optree_varinit.t
+++ b/ext/B/t/optree_varinit.t
@@ -264,13 +264,15 @@ checkOptree ( name	=> 'sub {my $a=()}',
 	      expect	=> <<'EOT_EOT', expect_nt => <<'EONT_EONT');
 1  <;> nextstate(main -439 optree.t:105) v:>,<,%
 2  <0> stub sP
-3  <1> padsv_store[$a:1516,1517] sKS/LVINTRO
-4  <1> leavesub[1 ref] K/REFC,1
+3  <0> padsv[$a:1567,1568] sRM*/LVINTRO
+4  <2> sassign sKS/2
+5  <1> leavesub[1 ref] K/REFC,1
 EOT_EOT
 # 1  <;> nextstate(main 438 optree_varinit.t:247) v:>,<,%
 # 2  <0> stub sP
-# 3  <1> padsv_store[$a:1516,1517] sKS/LVINTRO
-# 4  <1> leavesub[1 ref] K/REFC,1
+# 3  <0> padsv[$a:1567,1568] sRM*/LVINTRO
+# 4  <2> sassign sKS/2
+# 5  <1> leavesub[1 ref] K/REFC,1
 EONT_EONT
 
 checkOptree ( name	=> 'sub {our $a=()}',
@@ -428,21 +430,23 @@ checkOptree ( name	=> 'scalar context state',
 # 2  <;> nextstate(main 2 -e:1) v:%,{,fea=15
 # 3  <|> once(other->4)[$:2,3] sK/1
 # 4      <$> const[IV 1] s
-# 5      <1> padsv_store[$x:2,3] sKS/LVINTRO,STATE
-#            goto 6
-# 9  <0> padsv[$x:2,3] sRM*/STATE
-# 6  <1> padsv_store[$y:2,3] vKS/LVINTRO
-# 7  <;> nextstate(main 3 -e:1) v:%,{,fea=15
-# 8  <@> leave[1 ref] vKP/REFC
+# 5      <0> padsv[$x:2,3] sRM*/LVINTRO,STATE
+# 6      <2> sassign sKS/2
+#            goto 7
+# a  <0> padsv[$x:2,3] sRM*/STATE
+# 7  <1> padsv_store[$y:2,3] vKS/LVINTRO
+# 8  <;> nextstate(main 3 -e:1) v:%,{,fea=15
+# 9  <@> leave[1 ref] vKP/REFC
 EOT_EOT
 # 1  <0> enter v
 # 2  <;> nextstate(main 2 -e:1) v:%,{,fea=15
 # 3  <|> once(other->4)[$:2,3] sK/1
 # 4      <$> const(IV 1) s
-# 5      <1> padsv_store[$x:2,3] sKS/LVINTRO,STATE
-#            goto 6
-# 9  <0> padsv[$x:2,3] sRM*/STATE
-# 6  <1> padsv_store[$y:2,3] vKS/LVINTRO
-# 7  <;> nextstate(main 3 -e:1) v:%,{,fea=15
-# 8  <@> leave[1 ref] vKP/REFC
+# 5      <0> padsv[$x:2,3] sRM*/LVINTRO,STATE
+# 6      <2> sassign sKS/2
+#            goto 7
+# a  <0> padsv[$x:2,3] sRM*/STATE
+# 7  <1> padsv_store[$y:2,3] vKS/LVINTRO
+# 8  <;> nextstate(main 3 -e:1) v:%,{,fea=15
+# 9  <@> leave[1 ref] vKP/REFC
 EONT_EONT

--- a/ext/B/t/optree_varinit.t
+++ b/ext/B/t/optree_varinit.t
@@ -402,9 +402,9 @@ checkOptree ( name	=> 'void context state',
 # 2  <;> nextstate(main 2 -e:1) v:%,{,fea=15
 # 3  <|> once(other->4)[$:2,3] vK/1
 # 4      <$> const[IV 1] s
-# 5      <1> padsv_store[$x:2,3] KS/LVINTRO,STATE
+# 5      <1> padsv_store[$x:2,3] vKS/LVINTRO,STATE
 #            goto 6
-# 8  <0> padsv[$x:2,3] sRM*/STATE
+# 8  <0> padsv[$x:2,3] vRM*/STATE
 # 6  <;> nextstate(main 3 -e:1) v:%,{,fea=15
 # 7  <@> leave[1 ref] vKP/REFC
 EOT_EOT
@@ -412,9 +412,9 @@ EOT_EOT
 # 2  <;> nextstate(main 2 -e:1) v:%,{,fea=15
 # 3  <|> once(other->4)[$:2,3] vK/1
 # 4      <$> const(IV 1) s
-# 5      <1> padsv_store[$x:2,3] KS/LVINTRO,STATE
+# 5      <1> padsv_store[$x:2,3] vKS/LVINTRO,STATE
 #            goto 6
-# 8  <0> padsv[$x:2,3] sRM*/STATE
+# 8  <0> padsv[$x:2,3] vRM*/STATE
 # 6  <;> nextstate(main 3 -e:1) v:%,{,fea=15
 # 7  <@> leave[1 ref] vKP/REFC
 EONT_EONT
@@ -426,9 +426,9 @@ checkOptree ( name	=> 'scalar context state',
 	      expect	=> <<'EOT_EOT', expect_nt => <<'EONT_EONT');
 # 1  <0> enter v
 # 2  <;> nextstate(main 2 -e:1) v:%,{,fea=15
-# 3  <|> once(other->4)[$:2,3] K/1
+# 3  <|> once(other->4)[$:2,3] sK/1
 # 4      <$> const[IV 1] s
-# 5      <1> padsv_store[$x:2,3] KS/LVINTRO,STATE
+# 5      <1> padsv_store[$x:2,3] sKS/LVINTRO,STATE
 #            goto 6
 # 9  <0> padsv[$x:2,3] sRM*/STATE
 # 6  <1> padsv_store[$y:2,3] vKS/LVINTRO
@@ -437,9 +437,9 @@ checkOptree ( name	=> 'scalar context state',
 EOT_EOT
 # 1  <0> enter v
 # 2  <;> nextstate(main 2 -e:1) v:%,{,fea=15
-# 3  <|> once(other->4)[$:2,3] K/1
+# 3  <|> once(other->4)[$:2,3] sK/1
 # 4      <$> const(IV 1) s
-# 5      <1> padsv_store[$x:2,3] KS/LVINTRO,STATE
+# 5      <1> padsv_store[$x:2,3] sKS/LVINTRO,STATE
 #            goto 6
 # 9  <0> padsv[$x:2,3] sRM*/STATE
 # 6  <1> padsv_store[$y:2,3] vKS/LVINTRO

--- a/ext/B/t/optree_varinit.t
+++ b/ext/B/t/optree_varinit.t
@@ -9,7 +9,7 @@ BEGIN {
     }
 }
 use OptreeCheck;
-plan tests	=> 42;
+plan tests	=> 46;
 
 pass("OPTIMIZER TESTS - VAR INITIALIZATION");
 
@@ -391,4 +391,58 @@ EOT_EOT
 # 4  <0> padrange[$a:1,2; $b:1,2] RM/LVINTRO,range=2
 # 5  <2> aassign[t3] vKS
 # 6  <@> leave[1 ref] vKP/REFC
+EONT_EONT
+
+checkOptree ( name	=> 'void context state',
+	      prog	=> 'use feature qw(state); state $x = 1; 1',
+	      bcopts	=> '-exec',
+	      strip_open_hints => 1,
+	      expect	=> <<'EOT_EOT', expect_nt => <<'EONT_EONT');
+# 1  <0> enter v
+# 2  <;> nextstate(main 2 -e:1) v:%,{,fea=15
+# 3  <|> once(other->4)[$:2,3] vK/1
+# 4      <$> const[IV 1] s
+# 5      <1> padsv_store[$x:2,3] KS/LVINTRO,STATE
+#            goto 6
+# 8  <0> padsv[$x:2,3] sRM*/STATE
+# 6  <;> nextstate(main 3 -e:1) v:%,{,fea=15
+# 7  <@> leave[1 ref] vKP/REFC
+EOT_EOT
+# 1  <0> enter v
+# 2  <;> nextstate(main 2 -e:1) v:%,{,fea=15
+# 3  <|> once(other->4)[$:2,3] vK/1
+# 4      <$> const(IV 1) s
+# 5      <1> padsv_store[$x:2,3] KS/LVINTRO,STATE
+#            goto 6
+# 8  <0> padsv[$x:2,3] sRM*/STATE
+# 6  <;> nextstate(main 3 -e:1) v:%,{,fea=15
+# 7  <@> leave[1 ref] vKP/REFC
+EONT_EONT
+
+checkOptree ( name	=> 'scalar context state',
+	      prog	=> 'use feature qw(state); my $y = state $x = 1; 1',
+	      bcopts	=> '-exec',
+	      strip_open_hints => 1,
+	      expect	=> <<'EOT_EOT', expect_nt => <<'EONT_EONT');
+# 1  <0> enter v
+# 2  <;> nextstate(main 2 -e:1) v:%,{,fea=15
+# 3  <|> once(other->4)[$:2,3] K/1
+# 4      <$> const[IV 1] s
+# 5      <1> padsv_store[$x:2,3] KS/LVINTRO,STATE
+#            goto 6
+# 9  <0> padsv[$x:2,3] sRM*/STATE
+# 6  <1> padsv_store[$y:2,3] vKS/LVINTRO
+# 7  <;> nextstate(main 3 -e:1) v:%,{,fea=15
+# 8  <@> leave[1 ref] vKP/REFC
+EOT_EOT
+# 1  <0> enter v
+# 2  <;> nextstate(main 2 -e:1) v:%,{,fea=15
+# 3  <|> once(other->4)[$:2,3] K/1
+# 4      <$> const(IV 1) s
+# 5      <1> padsv_store[$x:2,3] KS/LVINTRO,STATE
+#            goto 6
+# 9  <0> padsv[$x:2,3] sRM*/STATE
+# 6  <1> padsv_store[$y:2,3] vKS/LVINTRO
+# 7  <;> nextstate(main 3 -e:1) v:%,{,fea=15
+# 8  <@> leave[1 ref] vKP/REFC
 EONT_EONT

--- a/gv.c
+++ b/gv.c
@@ -4018,6 +4018,15 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int flags)
     }
   }
 
+  /* If there's an optimised-away assignment such as $lex = $a + $b, where
+   * the  operator sets the targ lexical directly and skips the sassign,
+   * treat the op as scalar even if its marked as void */
+  if (   PL_op
+      && (PL_opargs[PL_op->op_type] & OA_TARGLEX)
+      && (PL_op->op_private & OPpTARGET_MY)
+  )
+      force_scalar = 1;
+
   switch (method) {
     /* in these cases, we're calling '+' or '-' as a fallback for a ++ or --
      * operation. we need this to return a value, so that it can be assigned

--- a/op.c
+++ b/op.c
@@ -2410,6 +2410,7 @@ Perl_scalarvoid(pTHX_ OP *arg)
         case OP_LINESEQ:
         case OP_LEAVEGIVEN:
         case OP_LEAVEWHEN:
+        case OP_ONCE:
         kids:
             next_kid = cLISTOPo->op_first;
             break;
@@ -8328,7 +8329,6 @@ S_newONCEOP(pTHX_ OP *initop, OP *padop)
 
     OpTYPE_set(condop, OP_ONCE);
     other->op_targ = target;
-    nullop->op_flags |= OPf_WANT_SCALAR;
 
     /* Store the initializedness of state vars in a separate
        pad entry.  */

--- a/peep.c
+++ b/peep.c
@@ -3934,6 +3934,11 @@ Perl_rpeep(pTHX_ OP *o)
                   * child (PADSV), and gets to it via op_other rather
                   * than op_next. Don't try to optimize this. */
                  && (lval != rhs)
+                 /* For efficiency, pp_padsv_store() doesn't push its
+                  * result onto the stack. For the relatively rare case of
+                  * the $lex assignment not in void context, we just do it
+                  * the old slow way. */
+                 && OP_GIMME(o,0) == G_VOID
                ) {
                 /* SASSIGN's bitfield flags, such as op_moresib and
                  * op_slabbed, will be carried over unchanged. */

--- a/peep.c
+++ b/peep.c
@@ -3985,6 +3985,11 @@ Perl_rpeep(pTHX_ OP *o)
             if (!(o->op_private & (OPpASSIGN_BACKWARDS|OPpASSIGN_CV_TO_GV))
                 && (lval->op_type == OP_NULL) && (lval->op_private == 2) &&
                 (cBINOPx(lval)->op_first->op_type == OP_AELEMFAST_LEX)
+                 /* For efficiency, pp_aelemfastlex_store() doesn't push its
+                  * result onto the stack. For the relatively rare case of
+                  * the array assignment not in void context, we just do it
+                  * the old slow way. */
+                 && OP_GIMME(o,0) == G_VOID
             ) {
                 OP * lex = cBINOPx(lval)->op_first;
                 /* SASSIGN's bitfield flags, such as op_moresib and

--- a/pp.c
+++ b/pp.c
@@ -6360,7 +6360,8 @@ PP(pp_push)
         || (PL_op->op_private & OPpTARGET_MY))
     {
         TARGi(AvFILL(ary) + 1, 1);
-        rpp_push_1(targ);
+        if ((PL_op->op_flags & OPf_WANT) != G_VOID)
+            rpp_push_1(targ);
     }
     return NORMAL;
 }
@@ -6444,7 +6445,8 @@ PP(pp_unshift)
         || (PL_op->op_private & OPpTARGET_MY))
     {
         TARGi(AvFILL(ary) + 1, 1);
-        rpp_push_1(targ);
+        if ((PL_op->op_flags & OPf_WANT) != G_VOID)
+            rpp_push_1(targ);
     }
     return NORMAL;
 }

--- a/pp.c
+++ b/pp.c
@@ -6350,7 +6350,9 @@ PP(pp_push)
         PL_delaymagic = old_delaymagic;
     }
     rpp_popfree_to_NN(ORIGMARK);
-    if (OP_GIMME(PL_op, 0) != G_VOID) {
+    if (   (PL_op->op_flags & OPf_WANT) != G_VOID
+        || (PL_op->op_private & OPpTARGET_MY))
+    {
         TARGi(AvFILL(ary) + 1, 1);
         rpp_push_1(targ);
     }
@@ -6432,7 +6434,9 @@ PP(pp_unshift)
         PL_delaymagic = old_delaymagic;
     }
     rpp_popfree_to_NN(ORIGMARK);
-    if (OP_GIMME(PL_op, 0) != G_VOID) {
+    if (   (PL_op->op_flags & OPf_WANT) != G_VOID
+        || (PL_op->op_private & OPpTARGET_MY))
+    {
         TARGi(AvFILL(ary) + 1, 1);
         rpp_push_1(targ);
     }

--- a/pp.c
+++ b/pp.c
@@ -940,9 +940,11 @@ PP(pp_undef)
     }
 
     if (PL_op->op_private & OPpTARGET_MY) {
+        /* $lex = undef, or undef $lex */
         SV** const padentry = &PAD_SVl(PL_op->op_targ);
         sv = *padentry;
-        rpp_xpush_1(sv);
+        if (UNLIKELY((PL_op->op_flags & OPf_WANT) != OPf_WANT_VOID))
+            rpp_xpush_1(sv);
         if ((PL_op->op_private & (OPpLVAL_INTRO|OPpPAD_STATE))
                                == OPpLVAL_INTRO)
         {
@@ -1046,8 +1048,12 @@ PP(pp_undef)
     }
 
 
-    if (!(PL_op->op_private & OPpTARGET_MY))
-        rpp_replace_1_1_NN(&PL_sv_undef);
+    if (!(PL_op->op_private & OPpTARGET_MY)) {
+        if (LIKELY((PL_op->op_flags & OPf_WANT) == OPf_WANT_VOID))
+            rpp_popfree_1_NN();
+        else
+            rpp_replace_1_1_NN(&PL_sv_undef);
+    }
 
     return NORMAL;
 }

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -2179,7 +2179,8 @@ PP(pp_print)
 
   just_say_no:
     rpp_popfree_to_NN(ORIGMARK);
-    rpp_xpush_IMM(retval);
+    if ((PL_op->op_flags & OPf_WANT) != OPf_WANT_VOID)
+        rpp_xpush_IMM(retval);
     return NORMAL;
 }
 

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -387,7 +387,8 @@ PP(pp_aelemfastlex_store)
 
     SvSetMagicSV(targ, val);
 
-    rpp_replace_1_1_NN(targ);
+    assert(GIMME_V == G_VOID);
+    rpp_popfree_1_NN();
     return NORMAL;
 }
 

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -336,7 +336,8 @@ PP(pp_padsv_store)
         );
     SvSetMagicSV(targ, val);
 
-    rpp_replace_1_1_NN(targ);
+    assert(GIMME_V == G_VOID);
+    rpp_popfree_1_NN();
     return NORMAL;
 }
 

--- a/t/perf/opcount.t
+++ b/t/perf/opcount.t
@@ -708,7 +708,7 @@ test_opcount(0, "builtin::true/false are replaced with constants",
                 });
 
 test_opcount(0, "builtin::is_bool is replaced with direct opcode",
-                sub { my $x; my $y; $y = builtin::is_bool($x); },
+                sub { my $x; my $y; $y = builtin::is_bool($x); 1; },
                 {
                     entersub => 0,
                     is_bool  => 1,
@@ -788,12 +788,12 @@ test_opcount(0, "builtin::is_tainted is replaced with direct opcode",
                     is_tainted => 1,
                 });
 
-# sassign + padsv combinations are replaced by padsv_store
+# void sassign + padsv combinations are replaced by padsv_store
 test_opcount(0, "sassign + padsv replaced by padsv_store",
-                sub { my $y; my $z = $y = 3; },
+                sub { my $y; my $z = $y = 3; 1; },
                 {
-                    padsv        => 1,
-                    padsv_store  => 2,
+                    padsv        => 2,
+                    padsv_store  => 1,
                 });
 
 # OPpTARGET_MY optimizations on undef
@@ -956,7 +956,7 @@ test_opcount(0, "Empty anonlist and direct lexical assignment",
                     sassign   => 0,
                 });
 test_opcount(0, "Empty anonlist ref and direct lexical assignment",
-                sub { my $x = \[] },
+                sub { my $x = \[]; 1; },
                 {
                     anonlist    => 0,
                     emptyavhv   => 1,
@@ -1001,7 +1001,7 @@ test_opcount(0, "Empty anonhash and direct lexical assignment",
                     sassign   => 0,
                 });
 test_opcount(0, "Empty anonhash ref and direct lexical assignment",
-                sub { my $x = \{} },
+                sub { my $x = \{}; 1 },
                 {
                     anonhash    => 0,
                     emptyavhv   => 1,

--- a/t/perf/opcount.t
+++ b/t/perf/opcount.t
@@ -889,7 +889,7 @@ test_opcount(0, 'my $y= 1; my @x= \($y= undef);',
 
 # aelemfast_lex + sassign are replaced by a combined OP
 test_opcount(0, "simple aelemfast_lex + sassign replacement",
-                sub { my @x; $x[0] = "foo" },
+                sub { my @x; $x[0] = "foo"; 1 },
                 {
                     aelemfast_lex      => 0,
                     aelemfastlex_store => 1,
@@ -900,7 +900,7 @@ test_opcount(0, "simple aelemfast_lex + sassign replacement",
 # aelemfast_lex + sassign are not replaced by a combined OP
 # when key <0 (not handled, to keep the pp_ function simple
 test_opcount(0, "aelemfast_lex + sassign replacement with neg key",
-                sub { my @x = (1,2); $x[-1] = 7 },
+                sub { my @x = (1,2); $x[-1] = 7; 1 },
                 {
                     aelemfast_lex      => 0,
                     aelemfastlex_store => 1,


### PR DESCRIPTION
This branch:

Fixes a couple of ops which weren't getting their context set correctly.
This doesn't make any change to the correct operation of those ops (they
don't change their behaviour based on context), but could allow for
future optimisations.

Skips a couple of portmanteau OP optimisations ({padv,elemfast}_store) in
non-void context. This allows those two be ops to be slightly faster in void
context (which is overwhelmingly how they are likely to be used), and
falls back to the old separate padsv/sassign op pair otherwise.

Updates a few other ops to handle void context slightly more efficiently.
