### PR TITLE
-DNO_LOCALE implies -DNO_LOCALE_COLLATE

### DIFF
--- a/locale_table.h
+++ b/locale_table.h
@@ -57,7 +57,7 @@
         /* Perl outsources all its collation efforts to the libc strxfrm(), so
          * if it isn't available on the system, default "C" locale collation
          * gets used */
-#  if defined(NO_LOCALE_COLLATE) || ! defined(HAS_STRXFRM)
+#  if defined(NO_LOCALE) || defined(NO_LOCALE_COLLATE) || ! defined(HAS_STRXFRM)
 
     PERL_LOCALE_TABLE_ENTRY(COLLATE, NULL)
 


### PR DESCRIPTION
This is a follow-on to the following commit,
which somehow missed this category.

 commit 08123d87ea3adde7ae36a205b3262804532efbed
 Author: Karl Williamson <khw@cpan.org>
 Date:   Tue Dec 19 15:00:33 2023 -0700

   -DNO_LOCALE implies -DNO_LOCALE_CTYPE, etc.

     If we aren't to pay attention to locales in general; we certainly
     shouldn't be paying attention to individual locale categories.

     This commit allows for cleaner #ifdefs