### PR TITLE
perl.h: #include locale_table.h even if NO_LOCALE

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -1159,6 +1159,15 @@ violations are fatal.
                                    #define */
 #endif
 
+/* Even if not using locales, this header should be #included so as to #define
+ * some symbols which avoid #ifdefs to get things to compile.  But make sure
+ * the macro it calls does nothing */
+#ifndef USE_LOCALE
+#    undef PERL_LOCALE_TABLE_ENTRY
+#    define PERL_LOCALE_TABLE_ENTRY(name, call_back)
+#    include "locale_table.h"
+#endif
+
 /* XXX The Configure probe for categories must be updated when adding new
  * categories here */
 


### PR DESCRIPTION
It defines some symbols which help in this circumstance, and others which would otherwise have to be #ifdef'd against in order to compile.