### PR TITLE
locale.c: Remove redundant lock

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -5506,7 +5506,6 @@ S_populate_hash_from_localeconv(pTHX_ HV * hv,
      * NUMERIC strings */
     const char * orig_NUMERIC_locale = NULL;
     if (which_mask & OFFSET_TO_BIT(NUMERIC_OFFSET)) {
-        LC_NUMERIC_LOCK(0);
 
 #      if defined(WIN32)
 
@@ -5666,9 +5665,6 @@ S_populate_hash_from_localeconv(pTHX_ HV * hv,
 #    ifdef USE_LOCALE_NUMERIC
 
     restore_toggled_locale_c(LC_NUMERIC, orig_NUMERIC_locale);
-    if (which_mask & OFFSET_TO_BIT(NUMERIC_OFFSET)) {
-        LC_NUMERIC_UNLOCK;
-    }
 
 #    endif
 #    ifdef WE_MUST_DEAL_WITH_MISMATCHED_CTYPE


### PR DESCRIPTION
This is a relic from a past implementation.  The operation is locked by a different macro to lock it, so this is redundant.