### PR TITLE
perldelta: Add API function sv_langinfo()

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3194,6 +3194,7 @@ CMbp	|IV	|sv_2iv 	|NN SV *sv
 Adp	|IV	|sv_2iv_flags	|NN SV * const sv			\
 				|const I32 flags
 Adip	|IV	|SvIV_nomg	|NN SV *sv
+Adp	|SV *	|sv_langinfo	|const nl_item item
 Adp	|STRLEN |sv_len 	|NULLOK SV * const sv
 Adp	|STRLEN |sv_len_utf8	|NULLOK SV * const sv
 Adp	|STRLEN |sv_len_utf8_nomg					\

--- a/embed.h
+++ b/embed.h
@@ -692,6 +692,7 @@
 # define sv_isa(a,b)                            Perl_sv_isa(aTHX_ a,b)
 # define sv_isa_sv(a,b)                         Perl_sv_isa_sv(aTHX_ a,b)
 # define sv_isobject(a)                         Perl_sv_isobject(aTHX_ a)
+# define sv_langinfo(a)                         Perl_sv_langinfo(aTHX_ a)
 # define sv_len(a)                              Perl_sv_len(aTHX_ a)
 # define sv_len_utf8(a)                         Perl_sv_len_utf8(aTHX_ a)
 # define sv_len_utf8_nomg(a)                    Perl_sv_len_utf8_nomg(aTHX_ a)

--- a/ext/I18N-Langinfo/Langinfo.pm
+++ b/ext/I18N-Langinfo/Langinfo.pm
@@ -70,7 +70,7 @@ our @EXPORT_OK = qw(
 	YESSTR
 );
 
-our $VERSION = '0.22';
+our $VERSION = '0.23';
 
 XSLoader::load();
 

--- a/ext/I18N-Langinfo/Langinfo.xs
+++ b/ext/I18N-Langinfo/Langinfo.xs
@@ -24,9 +24,6 @@ INCLUDE: const-xs.inc
 SV*
 langinfo(code)
 	int	code
-  PREINIT:
-        const char * value;
-        utf8ness_t   is_utf8;
   PROTOTYPE: _
   CODE:
 #ifdef HAS_NL_LANGINFO
@@ -36,8 +33,7 @@ langinfo(code)
 	} else
 #endif
         {
-            value = Perl_langinfo8(code, &is_utf8);
-            RETVAL = newSVpvn_utf8(value, strlen(value), is_utf8 == UTF8NESS_YES);
+            RETVAL = sv_langinfo(code);
         }
 
   OUTPUT:

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -348,7 +348,14 @@ well.
 
 =item *
 
-XXX
+A new function is now available to C<XS> code, L<perlapi/sv_langinfo>.
+This provides the same information as the existing
+L<perlapi/Perl_langinfo8>, but returns an SV instead of a S<C<char *>>,
+so that programmers don't have to concern themselves with the UTF-8ness
+of the result.  This new function is now the preferred interface for
+C<XS> code to the L<nl_langinfo(3)> C<libc> function.  From Perl space,
+this information continues to be provided by the L<I18N::Langinfo>
+module.
 
 =back
 

--- a/proto.h
+++ b/proto.h
@@ -4602,6 +4602,10 @@ PERL_CALLCONV int
 Perl_sv_isobject(pTHX_ SV *sv);
 #define PERL_ARGS_ASSERT_SV_ISOBJECT
 
+PERL_CALLCONV SV *
+Perl_sv_langinfo(pTHX_ const nl_item item);
+#define PERL_ARGS_ASSERT_SV_LANGINFO
+
 PERL_CALLCONV STRLEN
 Perl_sv_len(pTHX_ SV * const sv);
 #define PERL_ARGS_ASSERT_SV_LEN


### PR DESCRIPTION
This performs the same task as Perl_langinfo8(), but returns an SV. This is typically more convenient for the caller.

It turns out that nl_langinfo() has some weird returns that aren't yet exposed by perl, but future commits will.  An SV makes these easier to cope with.