### PR TITLE
XSUB.h: use Stack_off_t for AX and items

### DIFF
--- a/XSUB.h
+++ b/XSUB.h
@@ -37,12 +37,12 @@ Variable which is setup by C<xsubpp> to designate the object in a C++
 XSUB.  This is always the proper type for the C++ object.  See C<L</CLASS>> and
 L<perlxs/"Using XS With C++">.
 
-=for apidoc Amn|SSize_t|ax
+=for apidoc Amn|Stack_off_t|ax
 Variable which is setup by C<xsubpp> to indicate the stack base offset,
 used by the C<ST>, C<XSprePUSH> and C<XSRETURN> macros.  The C<dMARK> macro
 must be called prior to setup the C<MARK> variable.
 
-=for apidoc Amn|SSize_t|items
+=for apidoc Amn|Stack_off_t|items
 Variable which is setup by C<xsubpp> to indicate the number of
 items on the stack.  See L<perlxs/"Variable-length Parameter Lists">.
 
@@ -157,13 +157,13 @@ is a lexical C<$_> in scope.
  * Try explicitly using XS_INTERNAL/XS_EXTERNAL instead, please. */
 #define XS(name) XS_EXTERNAL(name)
 
-#define dAX const SSize_t ax = (SSize_t)(MARK - PL_stack_base + 1)
+#define dAX const Stack_off_t ax = (Stack_off_t)(MARK - PL_stack_base + 1)
 
 #define dAXMARK				\
-        SSize_t ax = POPMARK;	\
+        Stack_off_t ax = POPMARK;	\
         SV **mark = PL_stack_base + ax++
 
-#define dITEMS SSize_t items = (SSize_t)(SP - MARK)
+#define dITEMS Stack_off_t items = (Stack_off_t)(SP - MARK)
 
 #define dXSARGS \
         dSP; dAXMARK; dITEMS
@@ -174,16 +174,16 @@ is a lexical C<$_> in scope.
    Note these macros are not drop in replacements for dXSARGS since they set
    PL_xsubfilename. */
 #define dXSBOOTARGSXSAPIVERCHK  \
-        SSize_t ax = XS_BOTHVERSION_SETXSUBFN_POPMARK_BOOTCHECK;	\
+        Stack_off_t ax = XS_BOTHVERSION_SETXSUBFN_POPMARK_BOOTCHECK;	\
         SV **mark = PL_stack_base + ax - 1; dSP; dITEMS
 #define dXSBOOTARGSAPIVERCHK  \
-        SSize_t ax = XS_APIVERSION_SETXSUBFN_POPMARK_BOOTCHECK;	\
+        Stack_off_t ax = XS_APIVERSION_SETXSUBFN_POPMARK_BOOTCHECK;	\
         SV **mark = PL_stack_base + ax - 1; dSP; dITEMS
 /* dXSBOOTARGSNOVERCHK has no API in xsubpp to choose it so do
 #undef dXSBOOTARGSXSAPIVERCHK
 #define dXSBOOTARGSXSAPIVERCHK dXSBOOTARGSNOVERCHK */
 #define dXSBOOTARGSNOVERCHK  \
-        SSize_t ax = XS_SETXSUBFN_POPMARK;  \
+        Stack_off_t ax = XS_SETXSUBFN_POPMARK;  \
         SV **mark = PL_stack_base + ax - 1; dSP; dITEMS
 
 #define dXSTARG SV * const targ = ((PL_op->op_private & OPpENTERSUB_HASTARG) \

--- a/embed.fnc
+++ b/embed.fnc
@@ -3786,7 +3786,8 @@ Adp	|void	|wrap_op_checker|Optype opcode				\
 p	|void	|write_to_stderr|NN SV *msv
 Xp	|void	|xs_boot_epilog |const SSize_t ax
 
-FTXopv	|SSize_t|xs_handshake	|const U32 key				\
+FTXopv	|Stack_off_t|xs_handshake					\
+				|const U32 key				\
 				|NN void *v_my_perl			\
 				|NN const char *file			\
 				|...

--- a/proto.h
+++ b/proto.h
@@ -5351,7 +5351,7 @@ PERL_CALLCONV void
 Perl_xs_boot_epilog(pTHX_ const SSize_t ax);
 #define PERL_ARGS_ASSERT_XS_BOOT_EPILOG
 
-PERL_CALLCONV SSize_t
+PERL_CALLCONV Stack_off_t
 Perl_xs_handshake(const U32 key, void *v_my_perl, const char *file, ...);
 #define PERL_ARGS_ASSERT_XS_HANDSHAKE           \
         assert(v_my_perl); assert(file)

--- a/util.c
+++ b/util.c
@@ -5531,12 +5531,12 @@ Perl_my_cxt_init(pTHX_ int *indexp, size_t size)
    'file' is the source filename of the caller.
 */
 
-SSize_t
+Stack_off_t
 Perl_xs_handshake(const U32 key, void * v_my_perl, const char * file, ...)
 {
     va_list args;
-    SSize_t items;
-    SSize_t ax;
+    Stack_off_t items;
+    Stack_off_t ax;
     void * got;
     void * need;
     const char *stage = "first";
@@ -5598,12 +5598,12 @@ Perl_xs_handshake(const U32 key, void * v_my_perl, const char * file, ...)
         ax = POPMARK;
         {   SV **mark = PL_stack_base + ax++;
             {   dSP;
-                items = (SSize_t)(SP - MARK);
+                items = (Stack_off_t)(SP - MARK);
             }
         }
     } else {
-        items = va_arg(args, SSize_t);
-        ax = va_arg(args, SSize_t);
+        items = va_arg(args, Stack_off_t);
+        ax = va_arg(args, Stack_off_t);
     }
     assert(ax >= 0);
     assert(items >= 0);


### PR DESCRIPTION
I hadn't expected code to be taking pointers or references to AX, which turned out to be wrong, so make them Stack_off_t.

This allows XS::Framework or similar code to build with a default build of perl, but it will still fail to build if perl is built with -DPERL_STACK_OFFSET_SSIZET, which can only be fixed by updating XS::Framework to use Stack_off_t itself.

Fixes #21782