### PR TITLE
Fix blead not compiling with -DNO_LOCALE

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4428,6 +4428,15 @@ S	|char * |strftime8	|NN const char *fmt			\
 				|const bool came_from_sv
 Sf	|char * |strftime_tm	|NN const char *fmt			\
 				|NN const struct tm *mytm
+# if  defined(HAS_IGNORED_LOCALE_CATEGORIES_) || !defined(HAS_NL_LANGINFO) || \
+     !defined(LC_MESSAGES)
+S	|const char *|emulate_langinfo					\
+				|const int item 			\
+				|NN const char *locale			\
+				|NN char **retbufp			\
+				|NULLOK Size_t *retbuf_sizep		\
+				|NULLOK utf8ness_t *utf8ness
+# endif
 # if defined(HAS_LOCALECONV)
 S	|HV *	|my_localeconv	|const int item
 S	|void	|populate_hash_from_C_localeconv			\
@@ -4491,15 +4500,6 @@ RS	|char * |my_setlocale_debug_string_i				\
 				|NULLOK const char *locale		\
 				|NULLOK const char *retval		\
 				|const line_t line
-#   endif
-#   if defined(HAS_IGNORED_LOCALE_CATEGORIES_) || \
-       !defined(HAS_NL_LANGINFO) || !defined(LC_MESSAGES)
-S	|const char *|emulate_langinfo					\
-				|const int item 			\
-				|NN const char *locale			\
-				|NN char **retbufp			\
-				|NULLOK Size_t *retbuf_sizep		\
-				|NULLOK utf8ness_t *utf8ness
 #   endif
 #   if defined(HAS_NL_LANGINFO)
 S	|const char *|my_langinfo_i					\

--- a/embed.h
+++ b/embed.h
@@ -1313,6 +1313,10 @@
 #     define set_save_buffer_min_size(a,b,c)    S_set_save_buffer_min_size(aTHX_ a,b,c)
 #     define strftime8(a,b,c,d,e)               S_strftime8(aTHX_ a,b,c,d,e)
 #     define strftime_tm(a,b)                   S_strftime_tm(aTHX_ a,b)
+#     if defined(HAS_IGNORED_LOCALE_CATEGORIES_) || \
+         !defined(HAS_NL_LANGINFO) || !defined(LC_MESSAGES)
+#       define emulate_langinfo(a,b,c,d,e)      S_emulate_langinfo(aTHX_ a,b,c,d,e)
+#     endif
 #     if defined(HAS_LOCALECONV)
 #       define my_localeconv(a)                 S_my_localeconv(aTHX_ a)
 #       define populate_hash_from_C_localeconv(a,b,c,d,e) S_populate_hash_from_C_localeconv(aTHX_ a,b,c,d,e)
@@ -1329,10 +1333,6 @@
 #       define setlocale_failure_panic_via_i(a,b,c,d,e,f,g) S_setlocale_failure_panic_via_i(aTHX_ a,b,c,d,e,f,g)
 #       if defined(DEBUGGING)
 #         define my_setlocale_debug_string_i(a,b,c,d) S_my_setlocale_debug_string_i(aTHX_ a,b,c,d)
-#       endif
-#       if defined(HAS_IGNORED_LOCALE_CATEGORIES_) || \
-           !defined(HAS_NL_LANGINFO) || !defined(LC_MESSAGES)
-#         define emulate_langinfo(a,b,c,d,e)    S_emulate_langinfo(aTHX_ a,b,c,d,e)
 #       endif
 #       if defined(HAS_NL_LANGINFO)
 #         define my_langinfo_i(a,b,c,d,e,f)     S_my_langinfo_i(aTHX_ a,b,c,d,e,f)

--- a/proto.h
+++ b/proto.h
@@ -7015,6 +7015,14 @@ S_strftime_tm(pTHX_ const char *fmt, const struct tm *mytm)
 # define PERL_ARGS_ASSERT_STRFTIME_TM           \
         assert(fmt); assert(mytm)
 
+# if  defined(HAS_IGNORED_LOCALE_CATEGORIES_) || !defined(HAS_NL_LANGINFO) || \
+     !defined(LC_MESSAGES)
+STATIC const char *
+S_emulate_langinfo(pTHX_ const int item, const char *locale, char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
+#   define PERL_ARGS_ASSERT_EMULATE_LANGINFO    \
+        assert(locale); assert(retbufp)
+
+# endif
 # if defined(HAS_LOCALECONV)
 STATIC HV *
 S_my_localeconv(pTHX_ const int item);
@@ -7079,14 +7087,6 @@ STATIC char *
 S_my_setlocale_debug_string_i(pTHX_ const locale_category_index cat_index, const char *locale, const char *retval, const line_t line)
         __attribute__warn_unused_result__;
 #     define PERL_ARGS_ASSERT_MY_SETLOCALE_DEBUG_STRING_I
-
-#   endif
-#   if defined(HAS_IGNORED_LOCALE_CATEGORIES_) || \
-       !defined(HAS_NL_LANGINFO) || !defined(LC_MESSAGES)
-STATIC const char *
-S_emulate_langinfo(pTHX_ const int item, const char *locale, char **retbufp, Size_t *retbuf_sizep, utf8ness_t *utf8ness);
-#     define PERL_ARGS_ASSERT_EMULATE_LANGINFO  \
-        assert(locale); assert(retbufp)
 
 #   endif
 #   if defined(HAS_NL_LANGINFO)


### PR DESCRIPTION
This recently introduced failure was due to yet another problem with my doing a 'rebase -i'.  embed.fnc nowadays gets re-sorted as part of the build process, and I need to manually verify each time that the new ordering didn't screw anything up.  Anyway, this function declaration got placed in the wrong bucket of #ifdefs in embed.fnc.  This commit fixes that.