### PR TITLE
DynaLoader: dl_dyld.xs: don't undef bool

### DIFF
--- a/ext/DynaLoader/DynaLoader_pm.PL
+++ b/ext/DynaLoader/DynaLoader_pm.PL
@@ -90,7 +90,7 @@ package DynaLoader;
 # Tim.Bunce@ig.co.uk, August 1994
 
 BEGIN {
-    our $VERSION = '1.54';
+    our $VERSION = '1.55';
 }
 
 # Note: in almost any other piece of code "our" would have been a better

--- a/ext/DynaLoader/dl_dyld.xs
+++ b/ext/DynaLoader/dl_dyld.xs
@@ -48,7 +48,6 @@ been tested on NeXT platforms.
 #include "dlutils.c"	/* for SaveError() etc */
 
 #undef environ
-#undef bool
 #import <mach-o/dyld.h>
 
 static char *dlerror()


### PR DESCRIPTION
I expect this was added when we added our own bool, and before we used bool so liberally ourselves.  Now dl_dyld.xs fails to compile, since MY_CXT_CLONE indirectly uses UNLIKELY() which casts to bool.

Tested locally with:

  ./Configure -des -Dusedevel -Dusethreads -Ddlsrc=dl_dyld.xs

on a modern Darwin, which failed before this change and builds after.

Based on work done by Sevan Janiyan in #21751.

Fixes #21751