### PR TITLE
perlfunc: document relationship between wait() and waitpid()

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -10580,6 +10580,8 @@ L<C<$SIG{CHLD}>|perlvar/%SIG>, it may accidentally wait for the child
 created by L<C<qx>|/qxE<sol>STRINGE<sol>> or L<C<system>|/system LIST>.
 See L<perlipc> for details.
 
+Equivalent to L<C<waitpid(-1, 0)>|/waitpid PID,FLAGS>.
+
 Portability issues: L<perlport/wait>.
 
 =item waitpid PID,FLAGS


### PR DESCRIPTION
Finally fixes #15108, which was mostly fixed by mauke in a6b6b8e and 237516c.