### PR TITLE
Create CvSUBOVERRIDE to speed up common sub idioms

### DIFF
--- a/cv.h
+++ b/cv.h
@@ -90,6 +90,11 @@ See L<perlguts/Autoloading with XSUBs>.
 #define CvOUTSIDE_SEQ(sv) ((XPVCV*)MUTABLE_PTR(SvANY(sv)))->xcv_outside_seq
 #define CvFLAGS(sv)	  ((XPVCV*)MUTABLE_PTR(SvANY(sv)))->xcv_flags
 
+#if defined(PERL_CORE) || defined(PERL_EXT)
+#define CvSUBOVERRIDE(sv)	  ((XPVCV*)MUTABLE_PTR(SvANY(sv)))->xcv_suboverride
+#define CvSUBOVERRIDEAUX(sv)	  ((XPVCV*)MUTABLE_PTR(SvANY(sv)))->xcv_suboverride_aux
+#endif
+
 /* These two are sometimes called on non-CVs */
 #define CvPROTO(sv)                               \
         (                                          \
@@ -140,6 +145,9 @@ See L<perlguts/Autoloading with XSUBs>.
                                    CVf_METHOD; now CVf_NOWARN_AMBIGUOUS */
 #define CVf_XS_RCSTACK  0x200000 /* the XS function understands a
                                     reference-counted stack */
+#if defined(PERL_CORE) || defined(PERL_EXT)
+#define CVf_IsSUBOVERRIDE    0x400000 /* CV has a sub override function */
+#endif
 
 /* This symbol for optimised communication between toke.c and op.c: */
 #define CVf_BUILTIN_ATTRS	(CVf_NOWARN_AMBIGUOUS|CVf_LVALUE|CVf_ANONCONST)
@@ -265,6 +273,12 @@ Helper macro to turn off the C<CvREFCOUNTED_ANYSV> flag.
 #define CvXS_RCSTACK(cv)        (CvFLAGS(cv) & CVf_XS_RCSTACK)
 #define CvXS_RCSTACK_on(cv)     (CvFLAGS(cv) |= CVf_XS_RCSTACK)
 #define CvXS_RCSTACK_off(cv)    (CvFLAGS(cv) &= ~CVf_XS_RCSTACK)
+
+#if defined(PERL_CORE) || defined(PERL_EXT)
+#define CvIsSUBOVERRIDE(cv)	(CvFLAGS(cv) & CVf_IsSUBOVERRIDE)
+#define CvIsSUBOVERRIDE_on(cv)	(CvFLAGS(cv) |= CVf_IsSUBOVERRIDE)
+#define CvIsSUBOVERRIDE_off(cv)	(CvFLAGS(cv) &= ~CVf_IsSUBOVERRIDE)
+#endif
 
 /* Back-compat */
 #ifndef PERL_CORE

--- a/peep.c
+++ b/peep.c
@@ -4187,10 +4187,177 @@ Perl_rpeep(pTHX_ OP *o)
     LEAVE;
 }
 
+#ifdef PERL_CV_OVERRIDE
+
+static bool
+S_defgv_hek_accessor(pTHX_ CV *cv)
+{
+    dSP;
+    SV **mark = PL_stack_base + TOPMARK;
+
+    if ( SP - MARK != 2 )
+    {
+        return false;
+    }
+
+    /* This completely replaces MDEREF_INDEX_const | MDEREF_AV_gvav_aelem */
+    /* as we don't need to place this sv onto PL_defgv just to find it again */
+    mark = PL_stack_base + POPMARK;
+    SV *sv = *(MARK+1);
+    SV *keysv = CvSUBOVERRIDEAUX(cv);
+
+    SP = MARK;
+    PUTBACK;
+
+    /* MDEREF_HV_vivify_rv2hv_helem */
+    sv = vivify_ref(sv, OPpDEREF_HV);
+    SvGETMAGIC(sv);
+    if (LIKELY(SvROK(sv))) {
+        if (UNLIKELY(SvAMAGIC(sv))) {
+            sv = amagic_deref_call(sv, to_hv_amg);
+        }
+        sv = SvRV(sv);
+        if (UNLIKELY(SvTYPE(sv) != SVt_PVHV))
+            DIE(aTHX_ "Not a HASH reference");
+    }
+    else if (SvTYPE(sv) != SVt_PVHV) {
+        /* Let the real multi-deref handle softref2xv */
+        if (!isGV_with_GP(sv))
+            return false;
+        sv = MUTABLE_SV(GvHVn((GV*)sv));
+    }
+
+    /* MDEREF_INDEX_const */
+    SV **svp;
+    HV * const hv = (HV*)sv;
+    HE* he;
+
+    he = hv_fetch_ent(hv, keysv, 0, 0);
+    svp = he ? &HeVAL(he) : NULL;
+
+    sv = (svp && *svp ? *svp : &PL_sv_undef);
+    /* see note in pp_helem() */
+    if (SvRMAGICAL(hv) && SvGMAGICAL(sv))
+        mg_get(sv);
+
+#ifdef PERL_RC_STACK
+    SvREFCNT_inc(sv);
+#endif
+    XPUSHs(sv);
+    PUTBACK;
+    return true;
+}
+
+#define GV_AV_HV_CONST_MDEREF (\
+    (MDEREF_FLAG_last | MDEREF_INDEX_const | MDEREF_HV_vivify_rv2hv_helem)  \
+        << MDEREF_SHIFT                                                     \
+    | (MDEREF_INDEX_const | MDEREF_AV_gvav_aelem)                           \
+    )
+
+static void
+S_cv_override_create(pTHX_ OP *o)
+{
+    OP *no;
+    OP *topop;
+    CV *cv;
+
+    cv = PL_compcv;
+
+    if ( o != (OP *)CvSTART(cv) )
+        return;
+
+    if ( CvIsSUBOVERRIDE(cv) )
+        return;
+
+    topop = o->op_next;
+    no = o->op_next;
+
+    while ( topop && topop->op_type == OP_NULL )
+        topop = topop->op_next;
+
+    if ( !topop || !topop->op_next )
+        return;
+
+    /* Skip any intial OP_NEXTSTATE */
+    if ( topop->op_type == OP_NEXTSTATE )
+        topop = topop->op_next;
+
+
+    OP *multideref = NULL;
+    OP *maybe_md = NULL;
+
+    /* return $_[0]{foo} */
+    if ( !multideref
+        && (no = topop)       && no->op_type == OP_MULTIDEREF && ( maybe_md = no )
+        && (no = no->op_next) && no->op_type == OP_LEAVESUB
+    )
+    {
+      multideref = maybe_md;
+    }
+
+    /* @_ >  1 && ...; $_[0]{foo} */
+    /* @_ != 1 && ...; $_[0]{foo} */
+    if ( !multideref
+        && (no = topop)       && no->op_type == OP_GV && cGVOPx_gv(no) == PL_defgv
+        && (no = no->op_next) && no->op_type == OP_RV2AV
+        && (no = no->op_next) && no->op_type == OP_CONST && SvIV(cSVOPx_sv(no)) == 1
+        && (no = no->op_next) && ( no->op_type == OP_GT ||  no->op_type == OP_NE )
+        && (no = no->op_next) && ( no->op_type == OP_AND || no->op_type == OP_COND_EXPR )
+        && (no = no->op_next) && no->op_type == OP_NEXTSTATE
+        && (no = no->op_next) && no->op_type == OP_MULTIDEREF && ( maybe_md = no )
+        && (no = no->op_next) && no->op_type == OP_LEAVESUB
+    )
+    {
+      multideref = maybe_md;
+    }
+
+    /* return $_[0]{foo} if @_ == 1 */
+    if ( !multideref
+        && (no = topop)       && no->op_type == OP_GV && cGVOPx_gv(no) == PL_defgv
+        && (no = no->op_next) && no->op_type == OP_RV2AV
+        && (no = no->op_next) && no->op_type == OP_CONST && SvIV(cSVOPx_sv(no)) == 1
+        && (no = no->op_next) && ( no->op_type == OP_GT ||  no->op_type == OP_NE )
+        && (no = no->op_next) && ( no->op_type == OP_AND || no->op_type == OP_COND_EXPR )
+        && (no = no->op_next) && no->op_type == OP_MULTIDEREF && ( maybe_md = no )
+        && (no = no->op_next) && no->op_type == OP_LEAVESUB
+    )
+    {
+      multideref = maybe_md;
+    }
+
+    if ( multideref )
+    {
+        UNOP_AUX_item *items = cUNOP_AUXx(multideref)->op_aux;
+        Size_t size = (items-1)->ssize;
+        UV actions = items->uv;
+        if ( size == 4 && actions == GV_AV_HV_CONST_MDEREF )
+        {
+            SV *sv = UNOP_AUX_item_sv(++items);
+            IV elem = (++items)->iv;
+
+            if ( sv == (SV *)PL_defgv && elem == 0
+                && !( multideref->op_private & (OPpMULTIDEREF_EXISTS|OPpMULTIDEREF_DELETE))
+                && !( multideref->op_flags & OPf_MOD)
+                && !( multideref->op_private & OPpLVAL_DEFER)
+                && !( multideref->op_private & OPpLVAL_INTRO) )
+            {
+                SV *keysv = UNOP_AUX_item_sv(++items);
+                CvIsSUBOVERRIDE_on(cv);
+                CvSUBOVERRIDE(cv) = S_defgv_hek_accessor;
+                CvSUBOVERRIDEAUX(cv) = keysv;
+            }
+        }
+    }
+}
+#endif
+
 void
 Perl_peep(pTHX_ OP *o)
 {
     CALL_RPEEP(o);
+#ifdef PERL_CV_OVERRIDE
+    S_cv_override_create(aTHX_ o);
+#endif
 }
 
 /*

--- a/perl.c
+++ b/perl.c
@@ -1997,6 +1997,9 @@ S_Internals_V(pTHX_ CV *cv)
 #  ifdef PERL_COPY_ON_WRITE
                              " PERL_COPY_ON_WRITE"
 #  endif
+#  ifdef PERL_CV_OVERRIDE
+                             " PERL_CV_OVERRIDE"
+#  endif
 #  ifdef PERL_DISABLE_PMC
                              " PERL_DISABLE_PMC"
 #  endif

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -6255,6 +6255,14 @@ PP(pp_entersub)
         }
     }
 
+#ifdef PERL_CV_OVERRIDE
+    if ( UNLIKELY(CvIsSUBOVERRIDE(cv) && CvSUBOVERRIDE(cv) != NULL) )
+    {
+        if ( CvSUBOVERRIDE(cv)(aTHX_ cv) )
+            return NORMAL;
+    }
+#endif
+
     /* At this point we want to save PL_savestack_ix, either by doing a
      * cx_pushsub(), or for XS, doing an ENTER. But we don't yet know the final
      * CV we will be using (so we don't know whether its XS, so we can't

--- a/sv.h
+++ b/sv.h
@@ -648,7 +648,9 @@ typedef U32 cv_flags_t;
                                   * compilation) in the lexically enclosing	\
                                   * sub */					\
     cv_flags_t	xcv_flags;						\
-    I32	xcv_depth	/* >= 2 indicates recursive call */
+    I32	xcv_depth;	/* >= 2 indicates recursive call */			\
+    bool	(*xcv_suboverride)(pTHX_ CV *);					\
+    SV *	xcv_suboverride_aux
 
 /* This structure must match XPVCV in cv.h */
 

--- a/t/perf/benchmarks
+++ b/t/perf/benchmarks
@@ -163,6 +163,11 @@
         setup   => 'my $x; my @a = 1..4; sub f { @a }',
         code    => '$x = f()',
     },
+    'call::sub::accessor' => {
+        desc    => 'sub called to access hashref key',
+        setup   => 'my $x; my $b = {x => 1}; sub f { $_[0]->{x} }',
+        code    => '$x = f($b)',
+    },
 
     'call::goto::empty' => {
         desc    => 'goto &funtion with no args or body',


### PR DESCRIPTION
This new code path does two separate things designed to allow common function patterns to be replaced with a static C function at runtime:

First it adds two additional fields to CV and a check inside pp_entersub that, if set, will call a C function instead of setting up a perl stack frame and calling the original function. This call can return false to indicate it was unsuccessful and allow the original optree to operate as normal.

Second it adds an initial optimization that identifies a common accessor method pattern and attaches them with a static hash-key lookup function. The optimization is smart enough to handle cases when the function is also a mutator and passes control back to the optree to be executed.

This combination enables common OO-style accessor to return as quick as an XS version is able to.

A compiler flag, -Accflags=-DPERL_CV_OVERRIDE, must be given to enable the feature; both the check inside pp_entersub as well as initial optimization.

---

I have opened this as draft PR, I believe the concept in general is technically viable but I am unsure if it is a good fit. I can appreciate that as a new contributor this is touching some important bits, but I had an interest in learning about perl's internals and had this as a specific goal in mind. I had previously opened an earlier draft PR with a much different in-progress version; the feedback I received from that significantly changed the final approach.

I benchmarked the change with Porting/bench.pl, which my interpretation of the information indicates that on average the call:: benchmarks are about 2% slower overall, but the new call::sub::accessor benchmark is about 220% faster. I understand that making every call slower, even if by a small amount, is not going to work with every workload, and so I decided to put the optimization behind a compiler flag.

I did another benchmark by creating a script to compare several popular object systems. The results of those appear to show that this optimization allows accessors that use the optimized pattern to be within the range of speed of some popular XS accessor modules.

Both the script I created above as well as my output from Porting/bench.pl is available in the below gist. In both cases `blead` refers to a compiled version of perl without `-Accflags=-DPERL_CV_OVERRIDE`, and `hacked` refers to a compiled version of perl with that flag defined.
https://gist.github.com/atrodo/98f6cde36c8fa9954de34957be876493