### PR TITLE
Make S_lossless_NV_to_IV consistent with SvIV_please_nomg

### DIFF
--- a/t/op/numconvert.t
+++ b/t/op/numconvert.t
@@ -264,3 +264,20 @@ ok(!$nz, 'previously stringified -0.0 is boolean false');
 $nz = -0.0;
 is sprintf("%+.f", - -$nz), sprintf("%+.f", - -$nz),
   "negation does not coerce negative zeroes";
+
+# Test implicit IV <-> NV conversions in arithmetic operators.
+BEGIN { $::additional_tests += 2 }
+
+# Following 2 tests should pass regardless of NV_PRESERVES_UV_BITS.
+# If NV_PRESERVES_UV_BITS > 60, both of LHS and RHS should be integer,
+# otherwise both should be floating-point value (NV).
+sub plus_one { (shift) + 1 }
+{
+    my $first = plus_one(0x1p60);
+    my $second = plus_one(0x1p60);
+    is $second, $first,
+        "repeated evaluation of (0x1p60 + 1) should be identical";
+}
+
+is 0x1p60 - 1.0, 0x1p60 - 1,
+    "(0x1p60 - 1) and (0x1p60 - 1.0) should be identical";


### PR DESCRIPTION
I found that some arithmetic operations involving NV whose absolute value is larger than (1 << NV_PRESERVES_UV_BITS) have some inconsistencies:

    % perl -le 'print 0x1p60 + 0'
    1.15292150460685e+18
    % perl -le 'print 0x1p60 + 0.0'
    1152921504606846976

In the former case NV + IV is NV (I think this is correct because 0x1p60 is not
accurate integer in 64-bit NV), but in the latter case  while NV + NV becomes IV.

Another symptom is that such operation would return different result on the second and later time:

    % perl -le 'sub foo { $_[0] + 1 } print foo(1e+18); print foo(1e+18); print foo(1e+18)'
    1e+18
    1000000000000000001
    1000000000000000001
    %

This PR will fix these by making `S_lossless_NV_to_IV()` more consistent with `SvIV_please_nomg()` which will not implicitly convert such NVs  to IVs.