### PR TITLE
t/re/charset: spell the locale when `setlocale()` fails

### DIFF
--- a/t/re/charset.t
+++ b/t/re/charset.t
@@ -163,7 +163,7 @@ foreach my $charset (@charsets) {
                                             ? "C"
                                             : $utf8_locale
                            );
-        die "Couldn't change locale" unless $locale;
+        die "Couldn't change to locale " . (($charset eq 'l') ? "C" : $utf8_locale) unless $locale;
         $charset_display = $charset_mod . " ($locale)";
     }
     else {


### PR DESCRIPTION
Closes https://github.com/Perl/perl5/issues/21805