### PR TITLE
Add API function sv_langinfo()

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3194,6 +3194,7 @@ CMbp	|IV	|sv_2iv 	|NN SV *sv
 Adp	|IV	|sv_2iv_flags	|NN SV * const sv			\
 				|const I32 flags
 Adip	|IV	|SvIV_nomg	|NN SV *sv
+Adp	|SV *	|sv_langinfo	|const nl_item item
 Adp	|STRLEN |sv_len 	|NULLOK SV * const sv
 Adp	|STRLEN |sv_len_utf8	|NULLOK SV * const sv
 Adp	|STRLEN |sv_len_utf8_nomg					\

--- a/embed.h
+++ b/embed.h
@@ -692,6 +692,7 @@
 # define sv_isa(a,b)                            Perl_sv_isa(aTHX_ a,b)
 # define sv_isa_sv(a,b)                         Perl_sv_isa_sv(aTHX_ a,b)
 # define sv_isobject(a)                         Perl_sv_isobject(aTHX_ a)
+# define sv_langinfo(a)                         Perl_sv_langinfo(aTHX_ a)
 # define sv_len(a)                              Perl_sv_len(aTHX_ a)
 # define sv_len_utf8(a)                         Perl_sv_len_utf8(aTHX_ a)
 # define sv_len_utf8_nomg(a)                    Perl_sv_len_utf8_nomg(aTHX_ a)

--- a/ext/I18N-Langinfo/Langinfo.xs
+++ b/ext/I18N-Langinfo/Langinfo.xs
@@ -24,9 +24,6 @@ INCLUDE: const-xs.inc
 SV*
 langinfo(code)
 	int	code
-  PREINIT:
-        const char * value;
-        utf8ness_t   is_utf8;
   PROTOTYPE: _
   CODE:
 #ifdef HAS_NL_LANGINFO
@@ -36,8 +33,7 @@ langinfo(code)
 	} else
 #endif
         {
-            value = Perl_langinfo8(code, &is_utf8);
-            RETVAL = newSVpvn_utf8(value, strlen(value), is_utf8 == UTF8NESS_YES);
+            RETVAL = sv_langinfo(code);
         }
 
   OUTPUT:

--- a/locale.c
+++ b/locale.c
@@ -5795,11 +5795,18 @@ the same information.  But it is more thread-safe than regular
 C<nl_langinfo()>, and hides the quirks of Perl's locale handling from your
 code, and can be used on systems that lack a native C<nl_langinfo>.
 
-However, you should instead use the improved version of this:
-L</Perl_langinfo8>, which behaves identically except for an additional
+However, you should instead use either the improved version of this,
+L</Perl_langinfo8>, or even better, L</sv_langinfo>.  The latter returns an SV,
+handling all the possible non-standard returns of C<nl_langinfo()>, including
+the UTF8ness of any returned string.
+
+C<Perl_langinfo8> is identical to C<Perl_langinfo> except for an additional
 parameter, a pointer to a variable declared as L</C<utf8ness_t>>, into which it
 returns to you how you should treat the returned string with regards to it
 being encoded in UTF-8 or not.
+
+These two functions share private per-thread memory that will be changed the
+next time either one of them is called with any input, but not before.
 
 Concerning the differences between these and plain C<nl_langinfo()>:
 
@@ -5869,6 +5876,22 @@ The details for those items which may deviate from what this emulation returns
 and what a native C<nl_langinfo()> would return are specified in
 L<I18N::Langinfo>.
 
+=for apidoc  sv_langinfo
+
+This is the preferred interface for accessing the data that L<nl_langinfo(3)>
+provides (or Perl's emulation of it on platforms lacking it), returning an SV.
+Unlike, the earlier-defined interfaces to this (L</Perl_langinfo> and
+L</Perl_langinfo8>), which return strings, the UTF8ness of the result is
+automatically handled for you.  And like them, it is thread-safe and
+automatically handles getting the proper values for the C<RADIXCHAR> and
+C<THOUSEP> items (that calling the plain libc C<nl_langinfo()> could give the
+wrong results for).  Like them, this also doesn't play well with the libc
+C<localeconv()>; use L<C<POSIX::localeconv()>|POSIX/localeconv> instead.
+
+There are a few deviations from what a native C<nl_langinfo()> would return and
+what this returns on platforms that don't implement that function.  These are
+detailed in L<I18N::Langinfo>.
+
 =cut
 
 */
@@ -5883,6 +5906,17 @@ L<I18N::Langinfo>.
 #  define external_call_langinfo(item, sv, utf8p)                           \
                                     emulate_langinfo(item, "C", sv, utf8p)
 #endif
+
+SV *
+Perl_sv_langinfo(pTHX_ const nl_item  item) {
+    utf8ness_t dummy;   /* Having this tells the layers below that we want the
+                           UTF-8 flag in 'sv' to be set properly. */
+
+    SV * sv = newSV_type(SVt_PV);
+    (void) external_call_langinfo(item, sv, &dummy);
+
+    return sv;
+}
 
 const char *
 Perl_langinfo(const nl_item item)
@@ -9542,7 +9576,7 @@ the global locale), but only if you use the following operations:
 
 =item L<I18N::Langinfo>, items C<CRNCYSTR> and C<THOUSEP>
 
-=item L<perlapi/Perl_langinfo>, items C<CRNCYSTR> and C<THOUSEP>
+=item L<perlapi/sv_langinfo>, items C<CRNCYSTR> and C<THOUSEP>
 
 =back
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -353,6 +353,17 @@ as C<Stack_off_t> rather than C<SSize_t>.  This reverts back to
 compatibility with pre-64-bit stack support for default builds of perl
 where C<Stack_off_t> is C<I32>.  [GH #21782]
 
+=item *
+
+A new function is now available to C<XS> code, L<perlapi/sv_langinfo>.
+This provides the same information as the existing
+L<perlapi/Perl_langinfo8>, but returns an SV instead of a S<C<char *>>,
+so that programmers don't have to concern themselves with the UTF-8ness
+of the result.  This new function is now the preferred interface for
+C<XS> code to the L<nl_langinfo(3)> C<libc> function.  From Perl space,
+this information continues to be provided by the L<I18N::Langinfo>
+module.
+
 =back
 
 =head1 Selected Bug Fixes

--- a/proto.h
+++ b/proto.h
@@ -4603,6 +4603,10 @@ PERL_CALLCONV int
 Perl_sv_isobject(pTHX_ SV *sv);
 #define PERL_ARGS_ASSERT_SV_ISOBJECT
 
+PERL_CALLCONV SV *
+Perl_sv_langinfo(pTHX_ const nl_item item);
+#define PERL_ARGS_ASSERT_SV_LANGINFO
+
 PERL_CALLCONV STRLEN
 Perl_sv_len(pTHX_ SV * const sv);
 #define PERL_ARGS_ASSERT_SV_LEN


### PR DESCRIPTION
This performs the same task as Perl_langinfo8(), but returns an SV. This is typically more convenient for the caller.

It turns out that nl_langinfo() has some weird returns that aren't yet exposed by perl, but future commits will.  An SV makes these easier to cope with.