### PR TITLE
 Fix langinfo(ALT_DIGITS)

### DIFF
--- a/ext/I18N-Langinfo/Langinfo.pm
+++ b/ext/I18N-Langinfo/Langinfo.pm
@@ -110,12 +110,14 @@ our @EXPORT_OK = qw(
                     _NL_TELEPHONE_INT_PREFIX
                    );
 
-our $VERSION = '0.23';
+our $VERSION = '0.24';
 
 XSLoader::load();
 
 1;
 __END__
+
+=encoding utf8
 
 =head1 NAME
 
@@ -226,13 +228,52 @@ C<9$95>.
 
 =item *
 
-For an alternate representation of digits, for the
-radix character used between the integer and the fractional part
-of decimal numbers, the group separator string for large-ish floating point
-numbers (yes, the final two are redundant with
+For the radix character used between the integer and the fractional part of
+decimal numbers, and the group separator string for large-ish floating point
+numbers (yes, these are redundant with
 L<POSIX::localeconv()|POSIX/localeconv>):
 
-    ALT_DIGITS RADIXCHAR THOUSEP
+    RADIXCHAR THOUSEP
+
+=item *
+
+For any alternate digits used in this locale besides the standard C<0..9>:
+
+    ALT_DIGITS
+
+This returns a sequence of alternate numeric reprsesentations for the numbers
+C<0> ... up to C<99>.  The representations are returned in a single string,
+with a semi-colon C<;> used to separated the individual ones.
+
+Most locales don't have alternate digits, so the string will be empty.
+
+To access this data conveniently, you could do something like
+
+ use I18N::Langinfo qw(langinfo ALT_DIGITS);
+ my @alt_digits = split ';', langinfo(ALT_DIGITS);
+
+The array C<@alt_digits> will contain 0 elements if the current locale doesn't
+have alternate digits specified for it.  Otherwise, it will have as many
+elements as the locale defines, with C<[0]> containing the alternate digit for
+zero; C<[1]> for one; and so forth, up to potentially C<[99]> for the
+alternate representation of ninety-nine.
+
+Be aware that the alternate representation in some locales for the numbers
+0..9 will have a leading alternate-zero, so would look like the equivalent of
+00..09.
+
+Running this program
+
+ use I18N::Langinfo qw(langinfo ALT_DIGITS);
+ my @alt_digits = split ';', langinfo(ALT_DIGITS);
+ splice @alt_digits, 15;
+ print join " ", @alt_digits, "\n";
+
+on a Japanese locale yields
+
+S<C<〇 一 二 三 四 五 六 七 八 九 十 十一 十二 十三 十四>>
+
+on some platforms.
 
 =item *
 
@@ -393,6 +434,16 @@ Only the values for English are returned.  C<YESSTR> and C<NOSTR> have been
 removed from POSIX 2008, and are retained here for backwards compatibility.
 Your platform's C<nl_langinfo> may not support them.
 
+=item C<ALT_DIGITS>
+
+On systems with a C<L<strftime(3)>> that recognizes the POSIX-defined C<%O>
+format modifier (not Windows), perl tries hard to return these.  The result
+likely will go as high as what C<nl_langinfo()> would return, but not
+necessarily; and the numbers from C<0..9> will always be stripped of leading
+zeros.
+
+Without C<%O>, an empty string is always returned.
+
 =item C<D_FMT>
 
 Always evaluates to C<%x>, the locale's appropriate date representation.
@@ -406,11 +457,11 @@ Always evaluates to C<%X>, the locale's appropriate time representation.
 Always evaluates to C<%c>, the locale's appropriate date and time
 representation.
 
-=item C<ALT_DIGITS>
+=item C<CRNCYSTR>
 
-Currently this gives the same results as Linux does.  If you have examples of
-it needing to work differently, please file a report at
-L<https://github.com/Perl/perl5/issues>.
+The return may be incorrect for those rare locales where the currency symbol
+replaces the radix character.  If you have examples of it needing to work
+differently, please file a report at L<https://github.com/Perl/perl5/issues>.
 
 =item C<ERA_D_FMT>
 

--- a/locale.c
+++ b/locale.c
@@ -7095,7 +7095,7 @@ S_emulate_langinfo(pTHX_ const int item,
 #    endif
 #    if defined(WIN32) || ! defined(USE_LOCALE_TIME) || ! defined(HAS_STRFTIME)
 
-          case ALT_DIGITS: retval = "0"; break;
+          case ALT_DIGITS: retval = ""; break;
 #    else
           case ALT_DIGITS:
             format = "%Ow"; /* Find the alternate digit for 0 */

--- a/locale.c
+++ b/locale.c
@@ -6301,9 +6301,97 @@ S_langinfo_sv_i(pTHX_
 
         retval = nl_langinfo(item);
         Size_t total_len = strlen(retval);
+        char separator;
+
+        if (UNLIKELY(item == ALT_DIGITS) && total_len > 0) {
+
+            /* The return from nl_langinfo(ALT_DIGITS) is specified by the
+             * 2017 POSIX Standard as a string consisting of "semicolon-
+             * separated symbols. The first is the alternative symbol
+             * corresponding to zero, the second is the symbol corresponding to
+             * one, and so on.  Up to 100 alternative symbols may be
+             * specified".  Infuriatingly, Linux does not follow this, and uses
+             * the least C-language-friendly separator possible, the NUL.  In
+             * case other platforms also violate the standard, the code below
+             * looks for NUL and any graphic \W character as a potential
+             * separator. */
+            const char * sep_pos = strpbrk(retval,
+                                        " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~");
+            if (sep_pos) {
+                separator = *sep_pos;
+            }
+            else if (UNLIKELY(total_len >
+                                        2 * UVCHR_SKIP(PERL_UNICODE_MAX) * 4))
+            {   /* But as a check against the possibility that the separator is
+                 * some other character, look at the length of the returned
+                 * string.  If the separator is a NUL, the length will be just
+                 * for the first NUL-terminated segment; if it is some other
+                 * character, there is only a single segment with all returned
+                 * alternate digits, which will be quite a bit longer than just
+                 * the first one.  Many locales will always have a leading zero
+                 * to represent 0-9 (hence the 2* in the conditional above).
+                 * The conditional uses the worst case value of the most number
+                 * of byte possible for a Unicode character, and it is possible
+                 * that it requires several characters to represent a single
+                 * value; hence the final multiplier.  This length represents a
+                 * conservative upper limit of the number of bytes for the
+                 * alternative representation of 00, but if the string
+                 * represents even only the first 10 alternative digits, it
+                 * will be much longer than that.  So to reach here, the
+                 * separator must be some other byte. */
+                locale_panic_(Perl_form(aTHX_
+                                        "Can't find separator in ALT_DIGITS"
+                                        " representation '%s' for locale '%s'",
+                                        _byte_dump_string((U8 *) retval,
+                                                          total_len, 0),
+                                        locale));
+            }
+            else {
+                separator = '\0';
+
+                /* Must be using NUL to separate the digits.  There are up to
+                 * 100 of them.  Find the length of the entire sequence.
+                 *
+                 * The only way it could work if fewer is if it ends in two
+                 * NULs.  khw has seen cases where there is no 2nd NUL on a 100
+                 * digit return. */
+                const char * s = retval + total_len + 1;
+
+                for (unsigned int i = 1; i <= 99; i++) {
+                    Size_t len = strlen(s) + 1;
+                    total_len += len;
+
+                    if (len == 1) {     /* Only a NUL */
+                        break;
+                    }
+
+                    s += len;
+                }
+            }
+        }
+
         sv_setpvn(sv, retval, total_len);
 
         gwLOCALE_UNLOCK;
+
+        /* Convert the ALT_DIGITS separator to a semi-colon if not already */
+        if (UNLIKELY(item == ALT_DIGITS) && total_len > 0 && separator != ';') {
+
+            /* Operate directly on the string in the SV */
+            char * digit_string = SvPVX(sv);
+            char * s = digit_string;
+            char * e = s + total_len;
+
+            do {
+                char * this_end = (char *) memchr(s, separator, total_len);
+                if (! this_end || this_end >= e) {
+                    break;
+                }
+
+                *this_end = ';';
+                s = this_end;
+            } while (1);
+        }
 
         SvUTF8_off(sv);
         retval = SvPV_nolen(sv);
@@ -7145,34 +7233,7 @@ S_emulate_langinfo(pTHX_ const int item,
 
         restore_toggled_locale_c(LC_TIME, orig_TIME_locale);
 
-        /* If the item is 'ALT_DIGITS', '*retbuf' contains the alternate
-        * format for wday 0.  If the value is the same as the normal 0,
-        * there isn't an alternate, so clear the buffer.
-        *
-        * (wday was chosen because its range is all a single digit.
-        * Things like tm_sec have two digits as the minimum: '00'.) */
-        if (item == ALT_DIGITS && strEQ(temp, "0")) {
-            retval = "";
-            Safefree(temp);
-            break;
-        }
-
-        /* ALT_DIGITS is problematic.  Experiments on it showed that
-        * strftime() did not always work properly when going from alt-9 to
-        * alt-10.  Only a few locales have this item defined, and in all
-        * of them on Linux that khw was able to find, nl_langinfo() merely
-        * returned the alt-0 character, possibly doubled.  Most Unicode
-        * digits are in blocks of 10 consecutive code points, so that is
-        * sufficient information for such scripts, as we can infer alt-1,
-        * alt-2, ....  But for a Japanese locale, a CJK ideographic 0 is
-        * returned, and the CJK digits are not in code point order, so you
-        * can't really infer anything.  The localedef for this locale did
-        * specify the succeeding digits, so that strftime() works properly
-        * on them, without needing to infer anything.  But the
-        * nl_langinfo() return did not give sufficient information for the
-        * caller to understand what's going on.  So until there is
-        * evidence that it should work differently, this returns the alt-0
-        * string for ALT_DIGITS. */
+        if (LIKELY(item != ALT_DIGITS)) {
 
             /* If to return what strftime() returns, are done */
             if (! return_format) {
@@ -7206,6 +7267,130 @@ S_emulate_langinfo(pTHX_ const int item,
 
             Safefree(temp);
             break;
+        }
+
+        /* Here, the item is 'ALT_DIGITS' and temp contains the zeroth
+         * alternate digit.  If empty or doesn't differ from regular digits,
+         * return that there aren't alternate digits */
+        if (temp[0] == '\0' || strchr(temp, '0')) {
+            Safefree(temp);
+            retval = "";
+            break;
+        }
+
+        /* ALT_DIGITS requires special handling because it requires up to 100
+         * values.  Below we generate those by using the %O modifier to
+         * strftime() formats.
+         *
+         * We already have the alternate digit for zero in 'temp', generated
+         * using the %Ow format.  That was used because it seems least likely
+         * to have a leading zero.  But some locales return that anyway.  If
+         * the first half of temp is identical to the second half, assume that
+         * is the case, and use just the first half */
+        const char * alt0 = temp;    /* Clearer synonym */
+        Size_t alt0_len = strlen(alt0);
+        if ((alt0_len & 1) == 0) {
+            Size_t half_alt0_len = alt0_len / 2;
+            if (strnEQ(temp, temp + half_alt0_len, half_alt0_len)) {
+                alt0_len = half_alt0_len;
+            }
+        }
+
+        /* Save the 0 digit string */
+        sv_setpvn(sv, alt0, alt0_len);
+        sv_catpvn_nomg (sv, ";", 1);
+
+        /* Various %O formats can be used to derive the alternate digits.  Only
+         * %Oy can go up to the full 100 values.  If it doesn't work, we try
+         * various fallbacks in decreasing order of how many values they can
+         * deliver.  maxes[] tells the highest value that the format applies
+         * to; offsets[] compensates for 0-based vs 1-based indices; and vars[]
+         * holds what field in the 'struct tm' to applies to the corresponding
+         * format */
+        int year, min, sec;
+      const char  * fmts[] = {"%Oy", "%OM", "%OS", "%Od", "%OH", "%Om", "%Ow" };
+      const Size_t maxes[] = {  99,    59,    59,    31,    23,    11,    6   };
+      const int  offsets[] = {   0,     0,     0,     1,     0,     1,    0   };
+      int         * vars[] = {&year,  &min,  &sec,  &mday, &hour, &mon, &mday };
+        Size_t j = 0;   /* Current index into the above tables */
+
+        orig_TIME_locale = toggle_locale_c(LC_TIME, locale);
+
+        for (unsigned int i = 1; i <= 99; i++) {
+            struct tm  mytm;
+
+          redo:
+            if (j >= C_ARRAY_LENGTH(fmts)) {
+                break;  /* Exhausted formats early; can't continue */
+            }
+
+            if (i > maxes[j]) {
+                j++;    /* Exhausted this format; try next one */
+                goto redo;
+            }
+
+            year = (strchr(fmts[j], 'y')) ? 1900 : 2011;
+            hour = 0;
+            min = 0;
+            sec = 0;
+            mday = 1;
+            mon = 0;
+
+            /* Change the variable corresponding to this format to the
+            * current time being run in 'i' */
+            *(vars[j]) += i - offsets[j];
+
+            /* Do the strftime.  Once we have determined the UTF8ness (if
+            * we want it), assume the rest will be the same, and use
+            * strftime_tm(), which doesn't recalculate UTF8ness */
+            ints_to_tm(&mytm, sec, min, hour, mday, mon, year, 0, 0, 0);
+            char * temp;
+            if (utf8ness && is_utf8 != UTF8NESS_NO && is_utf8 != UTF8NESS_YES) {
+                temp = strftime8(fmts[j],
+                                 &mytm,
+                                 UTF8NESS_IMMATERIAL,
+                                 &is_utf8,
+                                 false    /* not calling from sv_strftime */
+                                );
+            }
+            else {
+                temp = strftime_tm(fmts[j], &mytm);
+            }
+
+            DEBUG_Lv(PerlIO_printf(Perl_debug_log,
+                                "i=%d, format=%s, alt='%s'\n",
+                                i, fmts[j], temp));
+
+            /* If no result (meaning this platform didn't recognize this
+            * format), or it returned regular digits, give up on this
+            * format, to try the next candidate one */
+            if (temp == NULL || strpbrk(temp, "0123456789")) {
+                Safefree(temp);
+                j++;
+                goto redo;
+            }
+
+            /* If there is a leading zero, skip past it, to get the second
+            * one in the string */
+            const char * current = temp;
+            if (strnEQ(temp, alt0, alt0_len)) {
+                current += alt0_len;
+            }
+
+            /* Append this number to the ongoing list, including the separator.
+             * */
+            sv_catpv_nomg (sv, current);
+            sv_catpvn_nomg (sv, ";", 1);
+            Safefree(temp);
+        } /* End of loop generating ALT_DIGIT strings */
+
+        Safefree(alt0);
+
+        restore_toggled_locale_c(LC_TIME, orig_TIME_locale);
+
+        retval_type = RETVAL_IN_sv;
+        break;
+
 #  endif
 
        }    /* End of braced group for outer switch 'default:' case */

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -129,6 +129,11 @@ L<XXX> has been upgraded from version A.xx to B.yy.
 
 XXX If there was something important to note about this change, include that here.
 
+L<I18N::Langinfo> has been upgraded from version 0.23 to 0.24.
+
+This fixes what is returned for the C<ALT_DIGITS> item, which has never
+before worked properly in Perl.
+
 =back
 
 =head2 Removed Modules and Pragmata


### PR DESCRIPTION

This has never worked properly before in Perl.  The code is returning
the result of the libc function nl_langinfo().  The documentation for it
that I have found (and presumably my predecessors) is very unclear.  But
what actually happens (from using gdb) is that the return is very C
unfriendly.

Instead of returning a NUL-terminated string, it returns 100 (perhaps
fewer) NUL-terminated strings in a row.  When it is fewer (given the
few examples I've seen), the final one ends with two NULs in a row.  (I
can't think of a way for it to work and be otherwise).  The 100th one
doesn't necessarily have two terminating NULs.

Prior to this commit, only the string for the zeroth digit was returned;
now the entire ALT_DIGIT string sequence is returned, forcing a double
NUL at the end of the final one.

This information is accessible in several ways.  Via XS, one can use any
of several functions, including the newly introduced sv_langinfo(),
returning an SV, which allows for easier handling of embedded NULs.
(Otherwise in XS, using the functions that return a char*, one has to
look for the double-NUL.)

From Perl-space, the access is via I18N::Langinfo, which behind the
scenes also uses an SV.  The documentation added in this commit gives
advice for how to turn the return into an `@array` for more convenient
access.