### PR TITLE
 locale.c: Use strtod over snprintf for radix determination

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -6337,7 +6337,6 @@ S_emulate_langinfo(pTHX_ const int item,
 
             /* Everything in between is the radix string */
             if (LIKELY(s < e)) {
-                *s = '\0';
                 sv_setpvn(sv, item_start, s - item_start);
                 SvUTF8_off(sv);
                 retval_type = RETVAL_IN_sv;


### PR DESCRIPTION


I have been a little leery of parsing a formatted number to look for the
radix character, which is what has been done with snprintf on MingW.  It
just seems brittle; it's possible (if unlikely) for the output to be
right-to-left, for example.

And then I saw cases where snprintf always used a dot on MingW; and the
Windows documentation makes no mention of the possibility of another
radix character.  Experimentation by Tony Cook showed that it could
output a comma instead; and the dots I was getting were probably cockpit
errors.

But almost all locales in the world use either a dot or a comma, and I
think it better to start with a string "1,5" or "1.5" and see which
strtod() parses correctly.  We then don't have to ourselves parse, but
see how strtod parses known strings by looking at what it calculates as
the value.  In a dot locale, for example, "1,5" will not yield anything
like 1.5.

Should we encounter a locale not using either a dot nor a comma, the
code drops down to call localeconv() to return the actual character
string.  On platforms where using localeconv() isn't known to have a
race (MSVC since VS2015, for example), the code previously always used
localeconv(), because of my leeriness about parsing an unknown string.

But now strtod is used, being less buggy and faster than localeconv; and
less brittle thant snprintf.

This change also avoids the malloc that the snprintf() version required.

@khwilliamson
