### PR TITLE
Configure: Handle case of no localeconv() found

### DIFF
--- a/Configure
+++ b/Configure
@@ -16105,6 +16105,8 @@ EOCP
 	fi;
 	$rm_try
 	;;
+*)      d_lc_monetary_2008="$undef"
+        ;;
 esac
 
 : see if lchown exists


### PR DESCRIPTION
If not found, there certainly won't be a subset of its returns