### PR TITLE
perlapi: Emphasize that setpv() doesn't change the UTF-8 flag

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -5023,8 +5023,9 @@ first encountered C<NUL> byte.
 In the forms that take a C<ptr> argument, if it is NULL, the SV will become
 undefined.
 
-The UTF-8 flag is not changed by these functions.  A terminating NUL byte is
-guaranteed in the result.
+B<The UTF-8 flag is not changed by these functions.>
+
+A terminating NUL byte is guaranteed in the result.
 
 The C<_mg> forms handle 'set' magic; the other forms skip all magic.
 


### PR DESCRIPTION
I keep getting tripped up by this.