### PR TITLE
Return C values if localeconv() not available

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4414,6 +4414,13 @@ S	|void	|ints_to_tm	|NN struct tm *my_tm			\
 				|int yday				\
 				|int isdst
 S	|bool	|is_locale_utf8 |NN const char *locale
+S	|HV *	|my_localeconv	|const int item
+S	|void	|populate_hash_from_C_localeconv			\
+				|NN HV *hv				\
+				|NN const char *locale			\
+				|const U32 which_mask			\
+				|NN const lconv_offset_t *strings[2]	\
+				|NN const lconv_offset_t *integers[2]
 S	|const char *|save_to_buffer					\
 				|NULLOK const char *string		\
 				|NULLOK char **buf			\
@@ -4436,15 +4443,6 @@ S	|const char *|emulate_langinfo					\
 				|NN const char *locale			\
 				|NN SV *sv				\
 				|NULLOK utf8ness_t *utf8ness
-# endif
-# if defined(HAS_LOCALECONV)
-S	|HV *	|my_localeconv	|const int item
-S	|void	|populate_hash_from_C_localeconv			\
-				|NN HV *hv				\
-				|NN const char *locale			\
-				|const U32 which_mask			\
-				|NN const lconv_offset_t *strings[2]	\
-				|NN const lconv_offset_t *integers[2]
 # endif
 # if defined(USE_LOCALE)
 S	|const char *|calculate_LC_ALL_string					\

--- a/embed.h
+++ b/embed.h
@@ -1309,6 +1309,8 @@
 #     define get_locale_string_utf8ness_i(a,b,c,d) S_get_locale_string_utf8ness_i(aTHX_ a,b,c,d)
 #     define ints_to_tm(a,b,c,d,e,f,g,h,i,j)    S_ints_to_tm(aTHX_ a,b,c,d,e,f,g,h,i,j)
 #     define is_locale_utf8(a)                  S_is_locale_utf8(aTHX_ a)
+#     define my_localeconv(a)                   S_my_localeconv(aTHX_ a)
+#     define populate_hash_from_C_localeconv(a,b,c,d,e) S_populate_hash_from_C_localeconv(aTHX_ a,b,c,d,e)
 #     define save_to_buffer(a,b,c)              S_save_to_buffer(aTHX_ a,b,c)
 #     define set_save_buffer_min_size(a,b,c)    S_set_save_buffer_min_size(aTHX_ a,b,c)
 #     define strftime8(a,b,c,d,e)               S_strftime8(aTHX_ a,b,c,d,e)
@@ -1316,10 +1318,6 @@
 #     if defined(HAS_IGNORED_LOCALE_CATEGORIES_) || \
          !defined(HAS_NL_LANGINFO) || !defined(LC_MESSAGES)
 #       define emulate_langinfo(a,b,c,d)        S_emulate_langinfo(aTHX_ a,b,c,d)
-#     endif
-#     if defined(HAS_LOCALECONV)
-#       define my_localeconv(a)                 S_my_localeconv(aTHX_ a)
-#       define populate_hash_from_C_localeconv(a,b,c,d,e) S_populate_hash_from_C_localeconv(aTHX_ a,b,c,d,e)
 #     endif
 #     if defined(USE_LOCALE)
 #       define calculate_LC_ALL_string(a,b,c,d) S_calculate_LC_ALL_string(aTHX_ a,b,c,d)

--- a/locale.c
+++ b/locale.c
@@ -4999,20 +4999,8 @@ fields), but directly callable from XS code.
 HV *
 Perl_localeconv(pTHX)
 {
-
-#if  ! defined(HAS_LOCALECONV)
-
-    return newHV();
-
-#else
-
     return my_localeconv(0);
-
-#endif
-
 }
-
-#if defined(HAS_LOCALECONV)
 
 HV *
 S_my_localeconv(pTHX_ const int item)
@@ -5158,7 +5146,8 @@ S_my_localeconv(pTHX_ const int item)
                                            lconv_integers
                                          };
 
-#  if ! defined(USE_LOCALE_NUMERIC) && ! defined(USE_LOCALE_MONETARY)
+#if  ! defined(HAS_LOCALECONV)                                          \
+ || (! defined(USE_LOCALE_NUMERIC) && ! defined(USE_LOCALE_MONETARY))
 
     /* If both NUMERIC and MONETARY must be the "C" locale, simply populate the
      * hash using the function that works on just that locale. */
@@ -5557,7 +5546,8 @@ S_populate_hash_from_C_localeconv(pTHX_ HV * hv,
     }
 }
 
-#  if defined(USE_LOCALE_NUMERIC) || defined(USE_LOCALE_MONETARY)
+#if defined(HAS_LOCALECONV) && (   defined(USE_LOCALE_NUMERIC)      \
+                                || defined(USE_LOCALE_MONETARY))
 
 STATIC void
 S_populate_hash_from_localeconv(pTHX_ HV * hv,
@@ -5782,7 +5772,6 @@ S_populate_hash_from_localeconv(pTHX_ HV * hv,
 }
 
 #  endif    /* defined(USE_LOCALE_NUMERIC) || defined(USE_LOCALE_MONETARY) */
-#endif /* defined(HAS_LOCALECONV) */
 
 /*
 

--- a/proto.h
+++ b/proto.h
@@ -6997,6 +6997,15 @@ S_is_locale_utf8(pTHX_ const char *locale);
 # define PERL_ARGS_ASSERT_IS_LOCALE_UTF8        \
         assert(locale)
 
+STATIC HV *
+S_my_localeconv(pTHX_ const int item);
+# define PERL_ARGS_ASSERT_MY_LOCALECONV
+
+STATIC void
+S_populate_hash_from_C_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2]);
+# define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_C_LOCALECONV \
+        assert(hv); assert(locale); assert(strings); assert(integers)
+
 STATIC const char *
 S_save_to_buffer(pTHX_ const char *string, char **buf, Size_t *buf_size);
 # define PERL_ARGS_ASSERT_SAVE_TO_BUFFER
@@ -7024,17 +7033,6 @@ S_emulate_langinfo(pTHX_ const int item, const char *locale, SV *sv, utf8ness_t 
         assert(locale); assert(sv)
 
 # endif
-# if defined(HAS_LOCALECONV)
-STATIC HV *
-S_my_localeconv(pTHX_ const int item);
-#   define PERL_ARGS_ASSERT_MY_LOCALECONV
-
-STATIC void
-S_populate_hash_from_C_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2]);
-#   define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_C_LOCALECONV \
-        assert(hv); assert(locale); assert(strings); assert(integers)
-
-# endif /* defined(HAS_LOCALECONV) */
 # if defined(USE_LOCALE)
 STATIC const char *
 S_calculate_LC_ALL_string(pTHX_ const char **category_locales_list, const calc_LC_ALL_format format, const calc_LC_ALL_return returning, const line_t caller_line);


### PR DESCRIPTION
localeconv() is a C89 function.  But the existing code handled the case if it isn't available anyway by returning an empty hash if POSIX::localeconv() is called.  Prior commits have made it actually easier to instead return the hash populated with the values that the C locale has, which is more desirable than the current state.  And that is what this commit does.

There are reasons that localeconv() might not be available.  We recently had a case where Configure didn't catch its existence.  And it still is broken on MingW, and until recently on older Windows releases that we now no longer support.  Workarounds were developed for those cases, but there may be other platforms where it ends up broken without a workaround, and this code handles them better and more simply than before this commit.