### PR TITLE
win32/GNUmakefile: enable warnings for gcc

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -619,9 +619,11 @@ OPTIMIZE	= -Os
 LINK_DBG	= -s
 endif
 
-EXTRACFLAGS	=
+EXTRACFLAGS	= -Wall -Wextra -Werror=pointer-arith -Wno-format -Wno-long-long -Werror=vla
 ifeq ($(USE_CPLUSPLUS),define)
 EXTRACFLAGS	+= $(CXX_FLAG)
+else
+EXTRACFLAGS	+= -std=c99
 endif
 CFLAGS		= $(EXTRACFLAGS) $(INCLUDES) $(DEFINES) $(LOCDEFS) $(OPTIMIZE)
 LINK_FLAGS	= $(LINK_DBG) -L"$(INST_COREDIR)" -L"$(subst ;," -L",$(CCLIBDIR))"


### PR DESCRIPTION
Warnings are already enabled for MSVC, so enable them for GCC too.

-Wformat is disabled since the default "__printf__" format checker doesn't understand the C99-isms like "%zd", resulting in many spurious warnings.  The __gnu_printf__ checker does understand them, but it doesn't understand the Windows specific "%I64d" and similar formats.

I'd hoped to detect `-Wformat` issues, but gcc is horribly broken here.