### PR TITLE
lib/locale.t: Output more locale related information in debug mode

### DIFF
--- a/lib/locale.t
+++ b/lib/locale.t
@@ -58,7 +58,16 @@ BEGIN {
 }
 
 use feature 'fc';
-use I18N::Langinfo qw(langinfo CODESET RADIXCHAR THOUSEP CRNCYSTR);
+my @langinfo;
+BEGIN {
+    @langinfo = qw(
+                    CODESET
+                    RADIXCHAR
+                    THOUSEP
+                    CRNCYSTR
+}
+
+use I18N::Langinfo 'langinfo', @langinfo;
 
 # =1 adds debugging output; =2 increases the verbosity somewhat
 our $debug = $ENV{PERL_DEBUG_FULL_TEST} // 0;
@@ -1056,11 +1065,12 @@ foreach my $Locale (@Locale) {
     my $is_utf8_locale = is_locale_utf8($Locale);
 
     if ($debug) {
-        debug "code set = " . langinfo(CODESET);
         debug "is utf8 locale? = $is_utf8_locale\n";
-        debug "radix = " . disp_str(langinfo(RADIXCHAR)) . "\n";
-        debug "numeric group separator = '" .  disp_str(langinfo(THOUSEP)) . "'\n";
-        debug "currency = " . disp_str(langinfo(CRNCYSTR));
+        for my $item (@langinfo) {
+            my $numeric_item = eval $item;
+            my $value = langinfo($numeric_item);
+            debug "$item = " . disp_str($value);
+        }
     }
 
     if (! $is_utf8_locale) {

--- a/lib/locale.t
+++ b/lib/locale.t
@@ -65,6 +65,26 @@ BEGIN {
                     RADIXCHAR
                     THOUSEP
                     CRNCYSTR
+                    ALT_DIGITS
+                    YESEXPR
+                    YESSTR
+                    NOEXPR
+                    NOSTR
+                    ERA
+                    ABDAY_1
+                    DAY_1
+                    ABMON_1
+                    MON_1
+                    AM_STR
+                    PM_STR
+                    D_FMT
+                    D_T_FMT
+                    ERA_D_FMT
+                    ERA_D_T_FMT
+                    ERA_T_FMT
+                    T_FMT
+                    T_FMT_AMPM
+                  );
 }
 
 use I18N::Langinfo 'langinfo', @langinfo;

--- a/lib/locale.t
+++ b/lib/locale.t
@@ -58,7 +58,7 @@ BEGIN {
 }
 
 use feature 'fc';
-use I18N::Langinfo qw(langinfo CODESET CRNCYSTR RADIXCHAR THOUSEP);
+use I18N::Langinfo qw(langinfo CODESET RADIXCHAR THOUSEP CRNCYSTR);
 
 # =1 adds debugging output; =2 increases the verbosity somewhat
 our $debug = $ENV{PERL_DEBUG_FULL_TEST} // 0;


### PR DESCRIPTION
This is handy for someone scanning through a platform's locales