### PR TITLE
locale.c: Remove redundant lock

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -5599,7 +5599,6 @@ S_populate_hash_from_localeconv(pTHX_ HV * hv,
      * NUMERIC strings */
     const char * orig_NUMERIC_locale = NULL;
     if (CALL_IS_FOR(NUMERIC)) {
-        LC_NUMERIC_LOCK(0);
 
 #      if defined(WIN32)
 
@@ -5759,9 +5758,6 @@ S_populate_hash_from_localeconv(pTHX_ HV * hv,
 #    ifdef USE_LOCALE_NUMERIC
 
     restore_toggled_locale_c(LC_NUMERIC, orig_NUMERIC_locale);
-    if (CALL_IS_FOR(NUMERIC)) {
-        LC_NUMERIC_UNLOCK;
-    }
 
 #    endif
 


### PR DESCRIPTION
This is a relic from a past implementation.  The operation is locked by a different macro to lock it, so this is redundant.