### PR TITLE
makedef.pl: Sync duplicated code with perl.h

### DIFF
--- a/makedef.pl
+++ b/makedef.pl
@@ -128,7 +128,7 @@ if ($define{USE_THREADS}) {
 
 $define{MULTIPLICITY} ||= $define{PERL_IMPLICIT_CONTEXT} ;
 
-if ($define{USE_THREADS} && ! $define{WIN32}) {
+if ($define{MULTIPLICITY} && ! $define{WIN32}) {
     $define{USE_REENTRANT_API} = 1;
 }
 


### PR DESCRIPTION
These two files each have a portion that must be manually kept in parallel.  This changes a line in makedef.pl to mirror the corresponding perl.h line