### PR TITLE
locale.c: Use hv_deletes instead of hv_delete.

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -6561,10 +6561,7 @@ S_emulate_langinfo(pTHX_ const int item,
              * what to change it to.  my_localeconv() has populated the hash
              * with exactly both fields.  Delete this one, leaving just the
              * CRNCYSTR one in the hash */
-            SV* precedes = hv_delete(result_hv,
-                                     P_CS_PRECEDES_LITERAL,
-                                     STRLENs(P_CS_PRECEDES_LITERAL),
-                                     0);
+            SV* precedes = hv_deletes(result_hv, P_CS_PRECEDES_LITERAL, 0);
             if (! precedes) {
                 locale_panic_("my_localeconv() unexpectedly didn't return"
                               " a value for " P_CS_PRECEDES_LITERAL);


### PR DESCRIPTION
I stumbled upon this macro where the parameter must be a literal.

It is hardly used in core.  Should it be API?