### PR TITLE
Fix not compiling when NO_LOCALE

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4437,7 +4437,8 @@ S	|char * |strftime8	|NN const char *fmt			\
 				|const bool came_from_sv
 Sf	|char * |strftime_tm	|NN const char *fmt			\
 				|NN const struct tm *mytm
-# if defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO)
+# if  defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO) || \
+     !defined(USE_LOCALE)
 S	|const char *|emulate_langinfo					\
 				|const int item 			\
 				|NN const char *locale			\

--- a/embed.h
+++ b/embed.h
@@ -1316,7 +1316,8 @@
 #     define set_save_buffer_min_size(a,b,c)    S_set_save_buffer_min_size(aTHX_ a,b,c)
 #     define strftime8(a,b,c,d,e)               S_strftime8(aTHX_ a,b,c,d,e)
 #     define strftime_tm(a,b)                   S_strftime_tm(aTHX_ a,b)
-#     if defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO)
+#     if  defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO) || \
+         !defined(USE_LOCALE)
 #       define emulate_langinfo(a,b,c,d)        S_emulate_langinfo(aTHX_ a,b,c,d)
 #     endif
 #     if defined(USE_LOCALE)

--- a/locale.c
+++ b/locale.c
@@ -6340,7 +6340,9 @@ S_maybe_override_codeset(pTHX_ const char * codeset,
                                const char * locale,
                                const char ** new_codeset);
 #endif
-#if ! defined(HAS_NL_LANGINFO) || defined(HAS_MISSING_LANGINFO_ITEM_)
+#if ! defined(USE_LOCALE)                   \
+ || ! defined(HAS_NL_LANGINFO)              \
+|| defined(HAS_MISSING_LANGINFO_ITEM_)
 
 STATIC const char *
 S_emulate_langinfo(pTHX_ const int item,

--- a/proto.h
+++ b/proto.h
@@ -7029,7 +7029,8 @@ S_strftime_tm(pTHX_ const char *fmt, const struct tm *mytm)
 # define PERL_ARGS_ASSERT_STRFTIME_TM           \
         assert(fmt); assert(mytm)
 
-# if defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO)
+# if  defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO) || \
+     !defined(USE_LOCALE)
 STATIC const char *
 S_emulate_langinfo(pTHX_ const int item, const char *locale, SV *sv, utf8ness_t *utf8ness);
 #   define PERL_ARGS_ASSERT_EMULATE_LANGINFO    \


### PR DESCRIPTION
This function is used when locale handling on the system doesn't exist or is turned off; therefore it must be compiled under that circumstance.