### PR TITLE
Don't mortalize my_localeconv() for internal use

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -4999,7 +4999,7 @@ fields), but directly callable from XS code.
 HV *
 Perl_localeconv(pTHX)
 {
-    return my_localeconv(0);
+    return (HV *) sv_2mortal((SV *) my_localeconv(0));
 }
 
 HV *
@@ -5010,7 +5010,6 @@ S_my_localeconv(pTHX_ const int item)
     /* This returns a mortalized hash containing all or certain elements
      * returned by localeconv(). */
     HV * hv = newHV();      /* The returned hash, initially empty */
-    sv_2mortal((SV*)hv);
 
     /* The function is used by Perl_localeconv() and POSIX::localeconv(), or
      * internally from this file, and is thread-safe.
@@ -6602,6 +6601,7 @@ S_emulate_langinfo(pTHX_ const int item,
                                                    cat_index);
         }
 
+        SvREFCNT_dec_NN(result_hv);
         break;
 
        }


### PR DESCRIPTION
For external consumption, retain the mortalization; but for internal explicitly decrement the reference count when done.

I don't know the area of code dealing with temporaries very well.  But it seems to me more desirable to leave a value around for as short a time as possible and then explicitly get rid of it.