### PR TITLE
POSIX.xs: Perl_localeconv() always returns something now

### DIFF
--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -2055,12 +2055,7 @@ open(filename, flags = O_RDONLY, mode = 0666)
 HV *
 localeconv()
     CODE:
-#ifndef HAS_LOCALECONV
-        RETVAL = NULL;
-        not_here("localeconv");
-#else
         RETVAL = Perl_localeconv(aTHX);
-#endif  /* HAS_LOCALECONV */
     OUTPUT:
 	RETVAL
 

--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our ($AUTOLOAD, %SIGRT);
 
-our $VERSION = '2.17';
+our $VERSION = '2.18';
 
 require XSLoader;
 

--- a/ext/POSIX/t/posix.t
+++ b/ext/POSIX/t/posix.t
@@ -365,7 +365,6 @@ unlike( $@, qr/Can't use string .* as a symbol ref/, "Can import autoloaded cons
 
 SKIP: {
     skip("locales not available", 26) unless locales_enabled([ qw(NUMERIC MONETARY) ]);
-    skip("localeconv() not available", 26) unless $Config{d_locconv};
     my $conv = localeconv;
     is(ref $conv, 'HASH', 'localeconv returns a hash reference');
 


### PR DESCRIPTION
Commit 0b52bb633d8c55bb15f05cdb19a4b7cb071ea271 changed this.  So now the POSIX module can always call it, and doesn't have to skip testing.