### PR TITLE
Add builtin::inf and builtin::nan

### DIFF
--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -1,4 +1,4 @@
-package builtin 0.012;
+package builtin 0.013;
 
 use strict;
 use warnings;
@@ -18,6 +18,7 @@ builtin - Perl pragma to import built-in utility functions
 
     use builtin qw(
         true false is_bool
+        inf nan
         weaken unweaken is_weak
         blessed refaddr reftype
         created_as_string created_as_number
@@ -142,6 +143,22 @@ or any variable containing one of these results.
 
 This function used to be named C<isbool>. A compatibility alias is provided
 currently but will be removed in a later version.
+
+=head2 inf
+
+    $num = inf;
+
+This function is currently B<experimental>.
+
+Returns the floating-point infinity value.
+
+=head2 nan
+
+    $num = nan;
+
+This function is currently B<experimental>.
+
+Returns the floating-point "Not-a-Number" value.
 
 =head2 weaken
 

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -51,6 +51,25 @@ package FetchStoreCounter {
     is(prototype(\&builtin::is_bool), '$', 'is_bool prototype');
 }
 
+# float constants
+{
+    use builtin qw( inf nan );
+
+    ok(inf, 'inf is true');
+    ok(inf > 1E10, 'inf is bigger than 1E10');
+    ok(inf == inf, 'inf is equal to inf');
+    ok(inf == inf + 1, 'inf is equal to inf + 1');
+
+    # Invoke the real XSUB
+    my $inf = ( \&builtin::inf )->();
+    ok($inf == $inf + 1, 'inf returned by real xsub');
+
+    ok(nan != nan, 'NaN is not equal to NaN');
+
+    my $nan = ( \&builtin::nan )->();
+    ok($nan != $nan, 'NaN returned by real xsub');
+}
+
 # weakrefs
 {
     use builtin qw( is_weak weaken unweaken );


### PR DESCRIPTION
Will take opinions on whether "nan" should be capitalised as "NaN" to match its general style elsewhere.

Also if anyone can suggest better documentation than "numerical not-a-number" that'd be great ;)