### PR TITLE
[doc] fix perlre \K example

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1463,6 +1463,7 @@ Yaroslav Kuzmin                <ykuzmin@rocketsoftware.com>
 Yary Hluchan
 Yasushi Nakajima               <sey@jkc.co.jp>
 Yitzchak Scott-Thoennes        <sthoenna@efn.org>
+Yusei Ueno                     <y.say1125@gmail.com>
 Yutaka OIWA                    <oiwa@is.s.u-tokyo.ac.jp>
 Yutaka OKAIE
 Yutao Feng

--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -1733,7 +1733,7 @@ equivalent C<< (?<=...) >> construct, and it is especially useful in
 situations where you want to efficiently remove something following
 something else in a string. For instance
 
-  s/(foo)bar/$1/g;
+  s/(?<=foo)bar/$1/g;
 
 can be rewritten as the much more efficient
 


### PR DESCRIPTION
**Where**
<!-- What module, script or perldoc URL needs to be fixed? -->
https://perldoc.perl.org/perlre#%5CK

**Description**
<!--  Please describe the documentation issue here. -->

The example seems wrong.

```
 For instance

s/(foo)bar/$1/g;

can be rewritten as the much more efficient

s/foo\Kbar//g;
```

Perhaps the below is correct.

```
s/(?<=foo)bar/$1/g;
```

