### PR TITLE
harness: take a test pattern through %ENV

### DIFF
--- a/pod/perlhack.pod
+++ b/pod/perlhack.pod
@@ -952,6 +952,14 @@ file it is up to you to delete the file manually and then let the
 harness recreate it, although the file format does not change frequently
 so this should not be necessary very often.
 
+=head2 Running only specific tests
+
+Running only specific tests of the core distribution can be done with
+
+    HARNESS_RE=PATTERN make test_harness
+
+Which will result in only the test files matching PATTERN to be run.
+
 =head2 Running tests by hand
 
 You can run part of the test suite by hand by using one of the

--- a/t/harness
+++ b/t/harness
@@ -97,6 +97,10 @@ while ($ARGV[0] && $ARGV[0]=~/^-?-(n?)re/) {
     }
 }
 
+if ($ENV{HARNESS_RE}) {
+  push @re, $ENV{HARNESS_RE};
+}
+
 my $jobs = $ENV{TEST_JOBS};
 my ($rules, $state, $color);
 


### PR DESCRIPTION
This is adding a `HARNESS_RE` environment variable used by `harness` to make it simpler to run specific tests of the core distribution without manually calling `harness`, which requires a more complex command line.