### PR TITLE
Fix #21867: Safe not able to use modules without an import method.

### DIFF
--- a/dist/Safe/Safe.pm
+++ b/dist/Safe/Safe.pm
@@ -3,7 +3,7 @@ package Safe;
 use 5.003_11;
 use Scalar::Util qw(reftype refaddr);
 
-$Safe::VERSION = "2.45";
+$Safe::VERSION = "2.46";
 
 # *** Don't declare any lexicals above this point ***
 #
@@ -77,8 +77,10 @@ my $default_root  = 0;
 my $default_share = [qw[
     *_
     &PerlIO::get_layers
+    &UNIVERSAL::import
     &UNIVERSAL::isa
     &UNIVERSAL::can
+    &UNIVERSAL::unimport
     &UNIVERSAL::VERSION
     &utf8::is_utf8
     &utf8::valid
@@ -822,4 +824,3 @@ Reworked to use the Opcode module and other changes added by Tim Bunce.
 Currently maintained by the Perl 5 Porters, <perl5-porters@perl.org>.
 
 =cut
-

--- a/dist/Safe/t/safeload.t
+++ b/dist/Safe/t/safeload.t
@@ -18,7 +18,7 @@ BEGIN {
 use strict;
 use Test::More;
 use Safe;
-plan(tests => 3);
+plan(tests => 4);
 
 my $c = new Safe;
 $c->permit(qw(require caller entereval unpack rand));
@@ -35,3 +35,8 @@ $r or diag $@;
 # perl version in 5.10-.
 ok !$c->reval(q{use 5.012; $undeclared; 1}),
    'reval does not prevent use 5.012 from enabling strict';
+
+# "use Tie::Scalar" depends on UNIVERSAL::import as Tie::Scalar does not have
+# its own import method.
+$r = $c->reval(q{ use Tie::Scalar; 1 });
+ok( defined $r, "Can load Tie::Scalar.pm in a Safe compartment" ) or diag $@;


### PR DESCRIPTION
This is done by adding &UNIVERSAL::import and unimport to Safe default_share array following the suggestion of @haarg.

See issue #21867 for reference.