### PR TITLE
locale.c: Fix ALT_DIGITS on Alpine

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -6321,6 +6321,22 @@ S_langinfo_sv_i(pTHX_
             if (sep_pos) {
                 separator = *sep_pos;
             }
+            else if (strpbrk(retval, "123456789")) {
+
+                /* Alternate digits, with the possible exception of 0,
+                 * shouldn't be standard digits, so if we get any back, return
+                 * that there aren't alternate digits.  0 is an exception
+                 * because there may be locales that do not have a zero, such
+                 * as Roman numerals.  It could therefore be that alt-0 is 0,
+                 * but alt-1 better be some multi-byte Unicode character(s)
+                 * like U+2160, ROMAN NUMERAL ONE.  This clause is necessary
+                 * because the total length of the ASCII digits won't trigger
+                 * the conditional in the next clause that protects against
+                 * non-Standard libc returns, such as in Alpine platforms, but
+                 * multi-byte returns will trigger it */
+                retval = "";
+                total_len = 0;
+            }
             else if (UNLIKELY(total_len >
                                         2 * UVCHR_SKIP(PERL_UNICODE_MAX) * 4))
             {   /* But as a check against the possibility that the separator is


### PR DESCRIPTION
Alpine, for the C and equivalent locales, doesn't return anything like what the Posix Standard says it should for nl_langinfo(ALT_DIGITS). It's supposed to be a string of up to 99 semi-colon-separated values. Instead, it is a string "0123456789".  There are no separators and these are standard digits, not alternate.  This commit causes any platform that returns a standard digit when alternates are requested to instead return the empty string, which is used elsewhere, and now here, to indicate there are no alternate digits for this locale.