### PR TITLE
Run only one of mini_mktime(), mktime()

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -7877,22 +7877,75 @@ S_ints_to_tm(pTHX_ struct tm * mytm,
     mytm->tm_wday = wday;
     mytm->tm_yday = yday;
     mytm->tm_isdst = isdst;
+
+/* If no mktime() can't call it; and if it doesn't have the extra fields that
+ * mini_mktime() doesn't handle, no need to call it; use our faster internal
+ * mini_mktime() instead */
+#if ! defined(HAS_MKTIME) || (   ! defined(HAS_TM_TM_GMTOFF)    \
+                              && ! defined(HAS_TM_TM_ZONE))
+
     mini_mktime(mytm);
 
-    /* use libc to get the values for tm_gmtoff and tm_zone on platforms that
-     * have them [perl #18238] */
-#if  defined(HAS_MKTIME)                                      \
- && (defined(HAS_TM_TM_GMTOFF) || defined(HAS_TM_TM_ZONE))
-    struct tm mytm2 = *mytm;
+#else
+
+    /* Otherwise we have to use the (slower) libc mktime(), which does take
+     * locale into consideration. [perl #18238] */
     MKTIME_LOCK;
-    mktime(&mytm2);
+
+    (void) mktime(mytm);
+
     MKTIME_UNLOCK;
+
+    /* More is needed if this is the very unlikely case of a leap second
+     * (sec==60).  Various mktime() routines handle these differently:
+     *  a)  Some don't know about their existence and normalize them to 0
+     *      seconds in the next minute;
+     *  b)  Others do the same, except if a table lookup indicates there
+     *      actually was an officially declared leap second at the instant the
+     *      input gives, in which case they leave the second at 60, and don't
+     *      adjust the minute.
+     *  c)  mini_mktime takes the caller's word for it that this is an actual
+     *      leap second, and leaves it at 60.
+     * In all cases, if the input was 60 and the result is not, libc did not
+     * act like mini_mktime, and to preserve long-standing behavior, we call
+     * mini_mktime for its result.
+     *
+     * (As an aside, this means the return of these, if we didn't ignore it
+     *  here, is not consistent across platforms.) */
+    if (UNLIKELY(sec == 60 && mytm->tm_sec != 60)) {
+
+        /* But since mini_mktime() doesn't handle these fields, save the
+         * results we already have for them */
 #  ifdef HAS_TM_TM_GMTOFF
-    mytm->tm_gmtoff = mytm2.tm_gmtoff;
+        long int gmtoff = mytm->tm_gmtoff;
 #  endif
 #  ifdef HAS_TM_TM_ZONE
-    mytm->tm_zone = mytm2.tm_zone;
+        const char *zone = mytm->tm_zone;
 #  endif
+
+        /* Repeat the entire process with mini_mktime */
+        Zero(mytm, 1, struct tm);
+        mytm->tm_sec = sec;
+        mytm->tm_min = min;
+        mytm->tm_hour = hour;
+        mytm->tm_mday = mday;
+        mytm->tm_mon = mon;
+        mytm->tm_year = year;
+        mytm->tm_wday = wday;
+        mytm->tm_yday = yday;
+        mytm->tm_isdst = isdst;
+        (void) mini_mktime(mytm);
+
+        /* And use the saved libc values for tm_gmtoff and tm_zone */
+#  ifdef HAS_TM_TM_GMTOFF
+        mytm->tm_gmtoff = gmtoff;
+#  endif
+#  ifdef HAS_TM_TM_ZONE
+        mytm->tm_zone = zone;
+#  endif
+
+    }
+
 #endif
 
     return;


### PR DESCRIPTION
mini_mktime() is a faster, stripped down version of mktime() that ignores locale-dependent information.   But it doesn't work when the structure it fills in contains fields that are locale-related.  A patch 20 some years ago called mktime() to fill in the missing fields.

But that ends up executing similar algorithms twice. If we need the locale-related info, why not just call mktime() once and be done with it.  I figured I must be missing something, so started a smoke-me branch with this change. [https://perl.develop-help.com/?b=smoke-me%2Fkhw-mktime](url).  So far everything is passing.

There is one glitch on my Linux glibc.  mktime() did not accept 60 for the second number (a leap second) , and mini_mktime() does.  And there is a test that includes a leap second.

The right thing to do to calculate the number of seconds since the epoch is to have a table of when actual leap seconds happened, and take that into account.  I guess there haven't been enough of them to make a difference. [https://en.wikipedia.org/wiki/Leap_second](url) has an extended discussion on this.

This commit uses plain mktime() when the fields exist that are not populated by min_mktime