### PR TITLE
Bugfixes to `builtin` import and tombstone behaviour

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5313,6 +5313,7 @@ lib/blib.t				blib.pm test
 lib/builtin.pm				builtin function namespace
 lib/builtin.t				test builtin function namespace
 lib/builtin-taint.t			test builtin function namespace in taint mode
+lib/builtin-unimport.t			test unimport of functions from builtin namespace
 lib/bytes.pm				Pragma to enable byte operations
 lib/bytes.t				bytes.pm test
 lib/bytes_heavy.pl			Support routines for byte pragma

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1475,6 +1475,7 @@ our %Modules = (
                 lib/blib.{pm,t}
                 lib/builtin.{pm,t}
                 lib/builtin-taint.t
+                lib/builtin-unimport.t
                 lib/bytes.{pm,t}
                 lib/bytes_heavy.pl
                 lib/charnames.{pm,t}

--- a/lib/builtin-unimport.t
+++ b/lib/builtin-unimport.t
@@ -34,6 +34,17 @@ no warnings 'experimental::builtin';
     }
 }
 
+# multiple imports are idempotent
+{
+    use builtin 'true';
+    use builtin 'true';
+    is(true(), "1", 'imported true() from two use lines');
+
+    no builtin 'true';
+    ok(!defined eval "true(); 1", 'true() is no longer visible after a single no');
+    like($@, qr/^Undefined subroutine &main::true called at /, 'Failure from missing function');
+}
+
 # vim: tabstop=4 shiftwidth=4 expandtab autoindent softtabstop=4
 
 done_testing();

--- a/lib/builtin-unimport.t
+++ b/lib/builtin-unimport.t
@@ -17,13 +17,13 @@ no warnings 'experimental::builtin';
 {
     package UnimportTest;
 
-    sub true() { return "true" };
+    sub true() { return "yes" };
 
     {
         use builtin 'true';
         no builtin 'true';
 
-        ::is(true(), "true", 'no builtin can remove lexical import');
+        ::is(true(), "yes", 'no builtin can remove lexical import');
     }
 
     {

--- a/lib/builtin-unimport.t
+++ b/lib/builtin-unimport.t
@@ -1,0 +1,39 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+}
+
+# This file mostly contains tests of the PADNAMEf_TOMBSTONE mechanism.
+# Currently the only way it is accessible from perl code is via unimport from
+# builtin.
+
+use v5.36;
+no warnings 'experimental::builtin';
+
+# imported builtins can be unexported
+{
+    package UnimportTest;
+
+    sub true() { return "true" };
+
+    {
+        use builtin 'true';
+        no builtin 'true';
+
+        ::is(true(), "true", 'no builtin can remove lexical import');
+    }
+
+    {
+        use builtin 'true';
+        { no builtin 'true'; }
+
+        ::is(true(), 1, 'no builtin is lexically scoped');
+    }
+}
+
+# vim: tabstop=4 shiftwidth=4 expandtab autoindent softtabstop=4
+
+done_testing();

--- a/lib/builtin-unimport.t
+++ b/lib/builtin-unimport.t
@@ -45,6 +45,31 @@ no warnings 'experimental::builtin';
     like($@, qr/^Undefined subroutine &main::true called at /, 'Failure from missing function');
 }
 
+# tombstone reveals earlier lexicals of the same name
+{
+   my sub true() { return "yes" }
+
+   {
+      is(true(), "yes", 'lexical true() before import+unimport');
+
+      use builtin 'true';
+      no builtin 'true';
+
+      is(true(), "yes", 'lexical true() after import+unimport');
+   }
+
+   {
+       use builtin 'true';
+       {
+           use builtin 'true';
+           no builtin 'true';
+       }
+       no builtin 'true';
+
+       is(true(), "yes", 'lexical true() after double nested import+unimport');
+   }
+}
+
 # vim: tabstop=4 shiftwidth=4 expandtab autoindent softtabstop=4
 
 done_testing();

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -273,27 +273,6 @@ package FetchStoreCounter {
     ok($recursecoderef->("rec"), 'true in self-recursive anon sub');
 }
 
-# imported builtins can be unexported
-{
-    package UnimportTest;
-
-    sub true() { return "true" };
-
-    {
-        use builtin 'true';
-        no builtin 'true';
-
-        ::is(true(), "true", 'no builtin can remove lexical import');
-    }
-
-    {
-        use builtin 'true';
-        { no builtin 'true'; }
-
-        ::is(true(), 1, 'no builtin is lexically scoped');
-    }
-}
-
 {
     use builtin qw( true false );
 


### PR DESCRIPTION
 * Make multiple imports idempotent, matching the behaviour of things like strict and feature flags
 * Fix various bugs to do with making previously-shadowed symbols visible again when unimporting named builtins