### PR TITLE
locale.c: Add missing check for error return

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -7232,6 +7232,12 @@ S_emulate_langinfo(pTHX_ const int item,
 
         restore_toggled_locale_c(LC_TIME, orig_TIME_locale);
 
+        /* If strftime() returned an error, we return an empty string */
+        if (! temp) {
+            retval = "";
+            break;
+        }
+
         if (LIKELY(item != ALT_DIGITS)) {
 
             /* If to return what strftime() returns, are done */


### PR DESCRIPTION
When strftime() fails, it returns NULL; the check for this was missing, which led to a segfault on Windows that didn't appear on other platforms because the particular test worked on other platforms.

Fixes GH #21880