### PR TITLE
locale.c: Avoid unused param warnings

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -6495,8 +6495,9 @@ S_emulate_langinfo(pTHX_ const int item,
                         "Entering emulate_langinfo item=%ld, using locale %s\n",
                         (long) item, locale));
 
-#  if defined(HAS_LOCALECONV) && (   defined(USE_LOCALE_NUMERIC)      \
-                                  || defined(USE_LOCALE_MONETARY))
+#  if   defined(HAS_LOCALECONV)                                         \
+   && ! defined(HAS_SOME_LANGINFO)                                      \
+   &&  (defined(USE_LOCALE_NUMERIC) || defined(USE_LOCALE_MONETARY))
 
     locale_category_index  cat_index;
     const char * localeconv_key;


### PR DESCRIPTION
Under some configurations the three declarations here warned; the #ifdef was missing a term