### PR TITLE
Langinfo.t: Set locale categories if no LC_ALL

### DIFF
--- a/ext/I18N-Langinfo/t/Langinfo.t
+++ b/ext/I18N-Langinfo/t/Langinfo.t
@@ -204,10 +204,16 @@ if (locales_enabled('LC_ALL')) {
     setlocale(LC_ALL, "C");
 }
 else { # If no LC_ALL, make sure the categories used in Langinfo are in C
-    setlocale(LC_CTYPE, "C")    if locales_enabled('LC_CTYPE');
-    setlocale(LC_MONETARY, "C") if locales_enabled('LC_MONETARY');
-    setlocale(LC_NUMERIC, "C")  if locales_enabled('LC_NUMERIC');
-    setlocale(LC_TIME, "C")     if locales_enabled('LC_TIME');
+    setlocale(LC_CTYPE, "C")          if locales_enabled('LC_CTYPE');
+    setlocale(LC_MONETARY, "C")       if locales_enabled('LC_MONETARY');
+    setlocale(LC_NUMERIC, "C")        if locales_enabled('LC_NUMERIC');
+    setlocale(LC_TIME, "C")           if locales_enabled('LC_TIME');
+    setlocale(LC_ADDRESS, "C")        if locales_enabled('LC_ADDRESS');
+    setlocale(LC_IDENTIFICATION, "C") if locales_enabled('LC_IDENTIFICATION');
+    setlocale(LC_MEASUREMENT, "C")    if locales_enabled('LC_MEASUREMENT');
+    setlocale(LC_NAME, "C")           if locales_enabled('LC_NAME');
+    setlocale(LC_PAPER, "C")          if locales_enabled('LC_PAPER');
+    setlocale(LC_TELEPHONE, "C")      if locales_enabled('LC_TELEPHONE');
 }
 
 for my $constant (@constants) {


### PR DESCRIPTION
This is a minor thing, but all these Linux extra categories need to be set to "C" for testing, when LC_ALL is not available on the platform.

This was overlooked in 3c45ca2e154f5fdc7ce2a0fdf51b192da3a1ae98