### PR TITLE
Compile S_emulate_langinfo() everywhere where needed

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -664,7 +664,8 @@ S_positional_newlocale(int mask, const char * locale, locale_t base)
  * in C.  This macro substitutes C for the locale appropriately, expanding to
  * nothing on the more typical case where all possible categories present on
  * the platform are handled. */
-#  ifdef HAS_IGNORED_LOCALE_CATEGORIES_
+#  if defined(HAS_IGNORED_LOCALE_CATEGORIES_)       \
+   || defined(HAS_MISSING_LANGINFO_ITEM_)
 #    define need_to_override_category(i)  (! category_available[i])
 #    define override_ignored_category(i, new_locale)                        \
                     ((need_to_override_category(i)) ? "C" : (new_locale))
@@ -866,7 +867,8 @@ STATIC void (*update_functions[]) (pTHX_ const char *, bool force) = {
     NULL,   /* No update for unknown category */
 };
 
-#  if defined(HAS_IGNORED_LOCALE_CATEGORIES_)
+#  if defined(HAS_IGNORED_LOCALE_CATEGORIES_)       \
+   || defined(HAS_MISSING_LANGINFO_ITEM_)
 
 /* Indicates if each category on this platform is available to use not in
  * the C locale */
@@ -6060,7 +6062,7 @@ S_external_call_langinfo(pTHX_ const nl_item item,
 
     } /* End of switch on item */
 
-#if defined(HAS_MISSING_LANGINFO_ITEM_)
+#  if defined(HAS_MISSING_LANGINFO_ITEM_)
 
     /* If the above didn't find the category's index, it has to be because the
      * item is unknown to us (and the callee will handle that), or the category
@@ -6169,7 +6171,7 @@ S_langinfo_sv_i(pTHX_
                            "Entering langinfo_sv_i item=%ld, using locale %s\n",
                            (long) item, locale));
 
-#  ifdef HAS_IGNORED_LOCALE_CATEGORIES_
+#  ifdef HAS_MISSING_LANGINFO_ITEM_
 
     if (! category_available[cat_index]) {
         return emulate_langinfo(item, locale, sv, utf8ness);

--- a/locale_table.h
+++ b/locale_table.h
@@ -28,12 +28,12 @@
     PERL_LOCALE_TABLE_ENTRY(CTYPE, NULL)
 
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
-#    define LC_CTYPE_AVAIL_  false
+#    define LC_CTYPE_AVAIL_  0
 #  else
 
     PERL_LOCALE_TABLE_ENTRY(CTYPE, S_new_ctype)
 
-#    define LC_CTYPE_AVAIL_  true
+#    define LC_CTYPE_AVAIL_  1
 #    define USE_LOCALE_CTYPE
 #  endif
 #endif
@@ -43,12 +43,12 @@
     PERL_LOCALE_TABLE_ENTRY(NUMERIC, NULL)
 
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
-#    define LC_NUMERIC_AVAIL_  false
+#    define LC_NUMERIC_AVAIL_  0
 #  else
 
     PERL_LOCALE_TABLE_ENTRY(NUMERIC, S_new_numeric)
 
-#    define LC_NUMERIC_AVAIL_  true
+#    define LC_NUMERIC_AVAIL_  1
 #    define USE_LOCALE_NUMERIC
 #  endif
 #endif
@@ -62,12 +62,12 @@
     PERL_LOCALE_TABLE_ENTRY(COLLATE, NULL)
 
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
-#    define LC_COLLATE_AVAIL_  false
+#    define LC_COLLATE_AVAIL_  0
 #  else
 
     PERL_LOCALE_TABLE_ENTRY(COLLATE, S_new_collate)
 
-#    define LC_COLLATE_AVAIL_  true
+#    define LC_COLLATE_AVAIL_  1
 #    define USE_LOCALE_COLLATE
 #  endif
 #endif
@@ -77,9 +77,9 @@
 
 #  if defined(NO_LOCALE) || defined(NO_LOCALE_TIME)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
-#    define LC_TIME_AVAIL_  false
+#    define LC_TIME_AVAIL_  0
 #  else
-#    define LC_TIME_AVAIL_  true
+#    define LC_TIME_AVAIL_  1
 #    define USE_LOCALE_TIME
 #  endif
 #endif
@@ -89,9 +89,9 @@
 
 #  if defined(NO_LOCALE) || defined(NO_LOCALE_MESSAGES)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
-#    define LC_MESSAGES_AVAIL_  false
+#    define LC_MESSAGES_AVAIL_  0
 #  else
-#    define LC_MESSAGES_AVAIL_  true
+#    define LC_MESSAGES_AVAIL_  1
 #    define USE_LOCALE_MESSAGES
 #  endif
 #endif
@@ -101,9 +101,9 @@
 
 #  if defined(NO_LOCALE) || defined(NO_LOCALE_MONETARY)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
-#    define LC_MONETARY_AVAIL_  false
+#    define LC_MONETARY_AVAIL_  0
 #  else
-#    define LC_MONETARY_AVAIL_  true
+#    define LC_MONETARY_AVAIL_  1
 #    define USE_LOCALE_MONETARY
 #  endif
 #endif
@@ -113,9 +113,9 @@
 
 #  if defined(NO_LOCALE) || defined(NO_LOCALE_ADDRESS)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
-#    define LC_ADDRESS_AVAIL_  false
+#    define LC_ADDRESS_AVAIL_  0
 #  else
-#    define LC_ADDRESS_AVAIL_  true
+#    define LC_ADDRESS_AVAIL_  1
 #    define USE_LOCALE_ADDRESS
 #  endif
 #endif
@@ -125,9 +125,9 @@
 
 #  if defined(NO_LOCALE) || defined(NO_LOCALE_IDENTIFICATION)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
-#    define LC_IDENTIFICATION_AVAIL_  false
+#    define LC_IDENTIFICATION_AVAIL_  0
 #  else
-#    define LC_IDENTIFICATION_AVAIL_  true
+#    define LC_IDENTIFICATION_AVAIL_  1
 #    define USE_LOCALE_IDENTIFICATION
 #  endif
 #endif
@@ -137,9 +137,9 @@
 
 #  if defined(NO_LOCALE) || defined(NO_LOCALE_MEASUREMENT)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
-#    define LC_MEASUREMENT_AVAIL_  false
+#    define LC_MEASUREMENT_AVAIL_  0
 #  else
-#    define LC_MEASUREMENT_AVAIL_  true
+#    define LC_MEASUREMENT_AVAIL_  1
 #    define USE_LOCALE_MEASUREMENT
 #  endif
 #endif
@@ -149,9 +149,9 @@
 
 #  if defined(NO_LOCALE) || defined(NO_LOCALE_PAPER)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
-#    define LC_PAPER_AVAIL_  false
+#    define LC_PAPER_AVAIL_  0
 #  else
-#    define LC_PAPER_AVAIL_  true
+#    define LC_PAPER_AVAIL_  1
 #    define USE_LOCALE_PAPER
 #  endif
 #endif
@@ -161,9 +161,9 @@
 
 #  if defined(NO_LOCALE) || defined(NO_LOCALE_TELEPHONE)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
-#    define LC_TELEPHONE_AVAIL_  false
+#    define LC_TELEPHONE_AVAIL_  0
 #  else
-#    define LC_TELEPHONE_AVAIL_  true
+#    define LC_TELEPHONE_AVAIL_  1
 #    define USE_LOCALE_TELEPHONE
 #  endif
 #endif
@@ -173,9 +173,9 @@
 
 #  if defined(NO_LOCALE) || defined(NO_LOCALE_NAME)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
-#    define LC_NAME_AVAIL_  false
+#    define LC_NAME_AVAIL_  0
 #  else
-#    define LC_NAME_AVAIL_  true
+#    define LC_NAME_AVAIL_  1
 #    define USE_LOCALE_NAME
 #  endif
 #endif
@@ -185,9 +185,9 @@
 
 #  if defined(NO_LOCALE) || defined(NO_LOCALE_SYNTAX)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
-#    define LC_SYNTAX_AVAIL_  false
+#    define LC_SYNTAX_AVAIL_  0
 #  else
-#    define LC_SYNTAX_AVAIL_  true
+#    define LC_SYNTAX_AVAIL_  1
 #    define USE_LOCALE_SYNTAX
 #  endif
 #endif
@@ -197,9 +197,9 @@
 
 #  if defined(NO_LOCALE) || defined(NO_LOCALE_TOD)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
-#    define LC_TOD_AVAIL_  false
+#    define LC_TOD_AVAIL_  0
 #  else
-#    define LC_TOD_AVAIL_  true
+#    define LC_TOD_AVAIL_  1
 #    define USE_LOCALE_TOD
 #  endif
 #endif

--- a/perl.h
+++ b/perl.h
@@ -1122,6 +1122,13 @@ violations are fatal.
 #   include <xlocale.h>
 #endif
 
+/* Even if not using locales, this header should be #included so as to #define
+ * some symbols which avoid #ifdefs to get things to compile.  But make sure
+ * the macro it calls does nothing */
+#undef PERL_LOCALE_TABLE_ENTRY
+#define PERL_LOCALE_TABLE_ENTRY(name, call_back)
+#include "locale_table.h"
+
 #include "perl_langinfo.h"    /* Needed for _NL_LOCALE_NAME */
 
 /* =========================================================================
@@ -1157,15 +1164,6 @@ violations are fatal.
 #ifdef USE_LOCALE
 #   define HAS_SKIP_LOCALE_INIT /* Solely for XS code to test for this
                                    #define */
-#endif
-
-/* Even if not using locales, this header should be #included so as to #define
- * some symbols which avoid #ifdefs to get things to compile.  But make sure
- * the macro it calls does nothing */
-#ifndef USE_LOCALE
-#    undef PERL_LOCALE_TABLE_ENTRY
-#    define PERL_LOCALE_TABLE_ENTRY(name, call_back)
-#    include "locale_table.h"
 #endif
 
 /* XXX The Configure probe for categories must be updated when adding new

--- a/perl_langinfo.h
+++ b/perl_langinfo.h
@@ -318,4 +318,20 @@ typedef int nl_item;    /* Substitute 'int' for emulated nl_langinfo() */
 #  define HAS_MISSING_LANGINFO_ITEM_
 #endif
 
+/* All these categories have to be emulated if not available on the platform */
+#if ! LC_CTYPE_AVAIL            \
+ || ! LC_MESSAGES_AVAIL         \
+ || ! LC_MONETARY_AVAIL         \
+ || ! LC_NUMERIC_AVAIL          \
+ || ! LC_TIME_AVAIL             \
+ || ! LC_ADDRESS_AVAIL_         \
+ || ! LC_IDENTIFICATION_AVAIL_  \
+ || ! LC_MEASUREMENT_AVAIL_     \
+ || ! LC_NAME_AVAIL_            \
+ || ! LC_PAPER_AVAIL_           \
+ || ! LC_TELEPHONE_AVAIL_
+
+#  define HAS_MISSING_LANGINFO_ITEM_
+#endif
+
 #endif  /* PERL_LANGINFO_H */


### PR DESCRIPTION
Prior to this series of commits, this function was not getting compiled in some Configurations where it was needed, and not getting called always when needed.