### PR TITLE
[inline.h] Silence "[-Wunknown-pragmas]" warnings in MinGW builds.

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -1504,11 +1504,14 @@ Perl_is_utf8_invariant_string_loc(const U8* const s, STRLEN len, const U8 ** ep)
 
 #if defined(WIN32)
 #  include <intrin.h>
-#  pragma intrinsic(_BitScanForward)
-#  pragma intrinsic(_BitScanReverse)
-#  ifdef _WIN64
-#    pragma intrinsic(_BitScanForward64)
-#    pragma intrinsic(_BitScanReverse64)
+   /* MinGW warns that it ignores "pragma intrinsic". */
+#  if defined(_MSC_VER)
+#    pragma intrinsic(_BitScanForward)
+#    pragma intrinsic(_BitScanReverse)
+#    if defined(_WIN64)
+#      pragma intrinsic(_BitScanForward64)
+#      pragma intrinsic(_BitScanReverse64)
+#    endif
 #  endif
 #endif
 


### PR DESCRIPTION
These warnings appeared first in perl-5.39.7, as a result of https://github.com/Perl/perl5/pull/21842.
MinGW does not recognize the "intrinsic" pragma, so it's simplest just to hide this pragma from MinGW's view.
