### PR TITLE
locale.c: Change API for static strftime-related functions

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4440,12 +4440,14 @@ S	|void	|set_save_buffer_min_size				\
 				|const Size_t min_len			\
 				|NULLOK char **buf			\
 				|NULLOK Size_t *buf_size
-S	|char * |strftime8	|NN const char *fmt			\
+S	|bool	|strftime8	|NN const char *fmt			\
+				|NN SV *sv				\
 				|NN const struct tm *mytm		\
 				|const utf8ness_t fmt_utf8ness		\
 				|NN utf8ness_t *result_utf8ness 	\
 				|const bool came_from_sv
-Sf	|char * |strftime_tm	|NN const char *fmt			\
+Sf	|bool	|strftime_tm	|NN const char *fmt			\
+				|NN SV *sv				\
 				|NN const struct tm *mytm
 # if defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO)
 S	|const char *|emulate_langinfo					\

--- a/embed.h
+++ b/embed.h
@@ -1321,8 +1321,8 @@
 #     define populate_hash_from_C_localeconv(a,b,c,d,e) S_populate_hash_from_C_localeconv(aTHX_ a,b,c,d,e)
 #     define save_to_buffer(a,b,c)              S_save_to_buffer(aTHX_ a,b,c)
 #     define set_save_buffer_min_size(a,b,c)    S_set_save_buffer_min_size(aTHX_ a,b,c)
-#     define strftime8(a,b,c,d,e)               S_strftime8(aTHX_ a,b,c,d,e)
-#     define strftime_tm(a,b)                   S_strftime_tm(aTHX_ a,b)
+#     define strftime8(a,b,c,d,e,f)             S_strftime8(aTHX_ a,b,c,d,e,f)
+#     define strftime_tm(a,b,c)                 S_strftime_tm(aTHX_ a,b,c)
 #     if defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO)
 #       define emulate_langinfo(a,b,c,d)        S_emulate_langinfo(aTHX_ a,b,c,d)
 #     endif

--- a/locale.c
+++ b/locale.c
@@ -8076,7 +8076,7 @@ S_strftime8(pTHX_ const char * fmt,
                   const struct tm * mytm,
                   const utf8ness_t fmt_utf8ness,
                   utf8ness_t * result_utf8ness,
-                  const bool came_from_sv)
+                  const bool called_externally)
 {
     PERL_ARGS_ASSERT_STRFTIME8;
 
@@ -8136,9 +8136,11 @@ S_strftime8(pTHX_ const char * fmt,
         }
         else {
             locale_utf8ness = LOCALE_IS_UTF8;
-            if (came_from_sv) {
+            if (called_externally) {
 
-                /* Upgrade 'fmt' to UTF-8 for a UTF-8 locale.  Otherwise the
+                /* All internal calls from this file use ASCII-only formats;
+                 * but otherwise the format could be anything, so make sure to
+                 * upgrade it to UTF-8 for a UTF-8 locale.  Otherwise the
                  * locale would find any UTF-8 variant characters to be
                  * malformed */
                 Size_t fmt_len = strlen(fmt);

--- a/proto.h
+++ b/proto.h
@@ -7041,16 +7041,16 @@ STATIC void
 S_set_save_buffer_min_size(pTHX_ const Size_t min_len, char **buf, Size_t *buf_size);
 # define PERL_ARGS_ASSERT_SET_SAVE_BUFFER_MIN_SIZE
 
-STATIC char *
-S_strftime8(pTHX_ const char *fmt, const struct tm *mytm, const utf8ness_t fmt_utf8ness, utf8ness_t *result_utf8ness, const bool came_from_sv);
+STATIC bool
+S_strftime8(pTHX_ const char *fmt, SV *sv, const struct tm *mytm, const utf8ness_t fmt_utf8ness, utf8ness_t *result_utf8ness, const bool came_from_sv);
 # define PERL_ARGS_ASSERT_STRFTIME8             \
-        assert(fmt); assert(mytm); assert(result_utf8ness)
+        assert(fmt); assert(sv); assert(mytm); assert(result_utf8ness)
 
-STATIC char *
-S_strftime_tm(pTHX_ const char *fmt, const struct tm *mytm)
+STATIC bool
+S_strftime_tm(pTHX_ const char *fmt, SV *sv, const struct tm *mytm)
         __attribute__format__(__strftime__,pTHX_1,0);
 # define PERL_ARGS_ASSERT_STRFTIME_TM           \
-        assert(fmt); assert(mytm)
+        assert(fmt); assert(sv); assert(mytm)
 
 # if defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO)
 STATIC const char *


### PR DESCRIPTION
This changes these functions to be called with an additional SV
parameter; their return becomes a bool success/fail.

This presents a couple of advantages:

libc strftime() now writes directly to the SV's PV, eliminating copying
or using sv_usepvn().

For internal calls where the result is immediately consumed entirely in
this file, we can use the already-existing scratch SV as the
destination.  This SV gets reused over and over, and likely will soon
reach a large enough size so that it doesn't have to grow.  Prior to
this commit, a size was guessed each time and the space freed
immediately after each use.