### PR TITLE
locale.c: Use a critical section when locale is toggled

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -9330,7 +9330,9 @@ Perl_mem_collxfrm_(pTHX_ const char *input_string,
                 /* In this case we use isCNTRL_LC() below, which relies on
                  * LC_CTYPE, so that must be switched to correspond with the
                  * LC_COLLATE locale */
-                if (! try_non_controls && ! PL_in_utf8_COLLATE_locale) {
+                const bool need_to_toggle = (   ! try_non_controls
+                                             && ! PL_in_utf8_COLLATE_locale);
+                if (need_to_toggle) {
                     orig_CTYPE_locale = toggle_locale_c(LC_CTYPE,
                                                         PL_collation_name);
                 }
@@ -9380,7 +9382,10 @@ Perl_mem_collxfrm_(pTHX_ const char *input_string,
                 } /* end of loop through all 255 characters */
 
 #  ifdef USE_LOCALE_CTYPE
-                restore_toggled_locale_c(LC_CTYPE, orig_CTYPE_locale);
+
+                if (need_to_toggle) {
+                    restore_toggled_locale_c(LC_CTYPE, orig_CTYPE_locale);
+                }
 #  endif
 
                 /* Stop looking if found */


### PR DESCRIPTION
Sometimes the locale for a category has to be toggled to some other locale, when the desired value is for a locale that isn't the current one.

This doesn't present any problem when locales are thread-safe.  The locale gets toggled back before any other work is done.

But when locales are not thread-safe and we have threads, another thread can execute in the now-wrong locale.  Perl, for a few releases now, tries to mitigate the issues with running locales under threads when yhread-safe locales are not in use, for mitigations that are easy to do. These very well may make things work for applications that don't change locales very much; say only on startup.

But now perl itself changes locales briefly behind an application's back.  It turns out it is easy to add a lock that will keep threads that otherwise would work to continue to work.

That's what this commit does, by adding TOGGLE_LOCK and TOGGLE_UNLOCK macros that are no-ops for all but the unsafe-threaded locale implementation.

The unused parameter to the macros is for future use.