### PR TITLE
XS::APItest: don't allow a NULL AV * through

### DIFF
--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -4178,6 +4178,9 @@ CODE:
         for (p = PL_stack_base + 1; p <= SP; p++)
             av_push_simple(av, SvREFCNT_inc(*p));
         break;
+
+    default:
+        croak("multicall_return: invalid context %" I32df, context);
     }
 
     POP_MULTICALL;


### PR DESCRIPTION
e6c95c59c changed how `av` is initialised in multicall_return, leaving it possible for it to be NULL after the switch.

Of course the values of "context" for that are invalid, so throw an error.  This should also resolve this for Coverity and perhaps other static analysis.

cid 480208