### PR TITLE
Warn on lexical sub shadowing

### DIFF
--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -276,6 +276,7 @@ package FetchStoreCounter {
 # imported builtins can be unexported
 {
     package UnimportTest;
+    no warnings 'shadow';
 
     sub true() { return "true" };
 

--- a/pad.c
+++ b/pad.c
@@ -954,6 +954,15 @@ S_pad_check_dup(pTHX_ PADNAME *name, U32 flags, const HV *ourstash)
             --off;
         }
     }
+    /* check the package for my sub &x vs. sub PACKAGE::x collisions */
+    if (PadnamePV(name)[0] == '&') {
+        /* PadnamePV is always in UTF-8 */
+        CV *cv = get_cvn_flags(PadnamePV(name)+1, PadnameLEN(name)-1, GV_NOTQUAL|SVf_UTF8);
+        if(cv)
+            warner(packWARN(WARN_SHADOW),
+                "Lexical subroutine %" PNf " masks previously declared package subroutine",
+                PNfARG(name));
+    }
 }
 
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -239,7 +239,11 @@ XXX L<message|perldiag/"message">
 
 =item *
 
-XXX L<message|perldiag/"message">
+L<Lexical subroutine %s masks previously declared package subroutine|perldiag/"Lexical subroutine %s masks previously declared package subroutine">
+
+The current package already contains a subroutine whose name matches that of
+a newly-declared lexical or lexically imported subroutine.  The latter will
+take precedence and make the package one inaccessible by name.
 
 =back
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -3573,6 +3573,12 @@ The number of items in a hash can be obtained by doing:
 
     scalar(keys %hash);
 
+=item Lexical subroutine %s masks previously declared package subroutine
+
+(W shadow) The current package already contains a subroutine whose name
+matches that of a newly-declared lexical or lexically imported subroutine.
+The latter will take precedence and make the package one inaccessible by name.
+
 =item Lexing code attempted to stuff non-Latin-1 character into Latin-1 input
 
 (F) An extension is attempting to insert text into the current parse

--- a/t/lib/warnings/builtin
+++ b/t/lib/warnings/builtin
@@ -100,3 +100,10 @@ use builtin qw(true false);
 use builtin ':5.39';
 use builtin ':5.39';
 EXPECT
+########
+# builtin.c - import warns of collisions with package subs
+use warnings 'shadow';
+sub true { "ok" }
+use builtin 'true';
+EXPECT
+Lexical subroutine &true masks previously declared package subroutine at - line 4.

--- a/t/lib/warnings/pad
+++ b/t/lib/warnings/pad
@@ -616,3 +616,13 @@ f();
 EXPECT
 Variable "$è" is not available at (eval 4) line 1.
 ########
+use warnings 'shadow';
+use utf8;
+sub π {}
+sub pi {}
+my sub π {}
+my sub pi {}
+EXPECT
+Lexical subroutine &π masks previously declared package subroutine at - line 5.
+Lexical subroutine &pi masks previously declared package subroutine at - line 6.
+########

--- a/t/op/attrproto.t
+++ b/t/op/attrproto.t
@@ -121,13 +121,13 @@ is @warnings, 0, "Malformed prototype isn't just a warning";
 {
     use feature "lexical_subs";
     no warnings "experimental::lexical_subs";
-    $ret = eval 'my sub foo(bar) : prototype(baz) {}; prototype \&foo;';
-    is $ret, "baz", "my sub foo honors the prototype attribute";
-    like shift @warnings, qr/Illegal character in prototype for foo : bar/,
+    $ret = eval 'my sub lexsub1(bar) : prototype(baz) {}; prototype \&lexsub1;';
+    is $ret, "baz", "my sub lexsub1 honors the prototype attribute";
+    like shift @warnings, qr/Illegal character in prototype for lexsub1 : bar/,
         "(lexical) bar triggers illegal proto warnings";
-    like shift @warnings, qr/Illegal character in prototype for foo : baz/,
+    like shift @warnings, qr/Illegal character in prototype for lexsub1 : baz/,
         "(lexical) baz triggers illegal proto warnings";
-    like shift @warnings, qr/Prototype \'bar\' overridden by attribute \'prototype\(baz\)\' in foo/,
+    like shift @warnings, qr/Prototype \'bar\' overridden by attribute \'prototype\(baz\)\' in lexsub1/,
         "(lexical) overridden warning triggered in anonymous sub";
     is @warnings, 0, "No more warnings";
 }

--- a/t/op/lexsub.t
+++ b/t/op/lexsub.t
@@ -217,11 +217,11 @@ package main;
   state $w ;
   local $SIG{__WARN__} = sub { $w .= shift };
   eval '#line 87 squidges
-    state sub foo;
-    state sub foo {};
+    state sub lexsub1;
+    state sub lexsub1 {};
   ';
   is $w,
-     '"state" subroutine &foo masks earlier declaration in same scope at '
+     '"state" subroutine &lexsub1 masks earlier declaration in same scope at '
    . "squidges line 88.\n",
      'warning for state sub masking earlier declaration';
 }
@@ -584,11 +584,11 @@ package main;
   my $w ;
   local $SIG{__WARN__} = sub { $w .= shift };
   eval '#line 87 squidges
-    my sub foo;
-    my sub foo {};
+    my sub lexsub2;
+    my sub lexsub2 {};
   ';
   is $w,
-     '"my" subroutine &foo masks earlier declaration in same scope at '
+     '"my" subroutine &lexsub2 masks earlier declaration in same scope at '
    . "squidges line 88.\n",
      'warning for my sub masking earlier declaration';
 }


### PR DESCRIPTION
Adds a new warning that prints (in the `shadow` category) whenever a new lexical sub is added whose name shadows over an existing package sub. This warning is useful in cases involving lexical import - especially of things like `use builtin ...` but is likely beneficial to know in other situations too.

Examples:

```
$ ./perl -Mwarnings -e 'sub true { "ok" }; use builtin "true";'
Lexical subroutine &true masks previously declared package subroutine at -e line 1.

$ ./perl -Mwarnings -e 'use constant true => 1; use builtin "true";'
Lexical subroutine &true masks previously declared package subroutine at -e line 1.
```

In particular this now helps warn users of a particular surprise they may encounter:

```
$ ./perl -Ilib -e 'use warnings; use Test::Deep; use builtin ":5.39";'
Lexical subroutine &blessed masks previously declared package subroutine at -e line 1.
Lexical subroutine &reftype masks previously declared package subroutine at -e line 1.
```