### PR TITLE
Silence some warnings in doio.c

### DIFF
--- a/doio.c
+++ b/doio.c
@@ -66,6 +66,8 @@ Perl_setfd_cloexec(int fd)
     assert(fd >= 0);
 #if defined(HAS_FCNTL) && defined(F_SETFD) && defined(FD_CLOEXEC)
     (void) fcntl(fd, F_SETFD, FD_CLOEXEC);
+#elif !defined(DEBUGGING)
+    PERL_UNUSED_ARG(fd);
 #endif
 }
 
@@ -75,6 +77,8 @@ Perl_setfd_inhexec(int fd)
     assert(fd >= 0);
 #if defined(HAS_FCNTL) && defined(F_SETFD) && defined(FD_CLOEXEC)
     (void) fcntl(fd, F_SETFD, 0);
+#elif !defined(DEBUGGING)
+    PERL_UNUSED_ARG(fd);
 #endif
 }
 
@@ -2967,6 +2971,9 @@ Perl_cando(pTHX_ Mode_t mode, bool effective, const Stat_t *statbufp)
      /* Atari stat() does pretty much the same thing. we set x_bit_set_in_stat
       * too so it will actually look into the files for magic numbers
       */
+# ifdef __MINGW32__
+    PERL_UNUSED_ARG(effective);
+# endif
     return cBOOL(mode & statbufp->st_mode);
 
 #else /* ! DOSISH */

--- a/doio.c
+++ b/doio.c
@@ -2971,9 +2971,7 @@ Perl_cando(pTHX_ Mode_t mode, bool effective, const Stat_t *statbufp)
      /* Atari stat() does pretty much the same thing. we set x_bit_set_in_stat
       * too so it will actually look into the files for magic numbers
       */
-# ifdef __MINGW32__
     PERL_UNUSED_ARG(effective);
-# endif
     return cBOOL(mode & statbufp->st_mode);
 
 #else /* ! DOSISH */


### PR DESCRIPTION
This PR aims to silence the first 3 of the 4 warnings presented in https://github.com/Perl/perl5/issues/21916.
See that Issue for details and discussion ... or discuss here if that's preferable.
At this stage there is no fix to silence the 4th warning.
Feel free to merge this PR anyway, if it looks ok.