### PR TITLE
only define ingroup() where needed (i.e. on !DOSISH systems)

### DIFF
--- a/doio.c
+++ b/doio.c
@@ -2998,16 +2998,17 @@ Perl_cando(pTHX_ Mode_t mode, bool effective, const Stat_t *statbufp)
 }
 #endif /* ! VMS */
 
+#ifndef DOSISH
 static bool
 S_ingroup(pTHX_ Gid_t testgid, bool effective)
 {
-#ifndef PERL_IMPLICIT_SYS
+# ifndef PERL_IMPLICIT_SYS
     /* PERL_IMPLICIT_SYS like Win32: getegid() etc. require the context. */
     PERL_UNUSED_CONTEXT;
-#endif
+# endif
     if (testgid == (effective ? PerlProc_getegid() : PerlProc_getgid()))
         return TRUE;
-#ifdef HAS_GETGROUPS
+# ifdef HAS_GETGROUPS
     {
         Groups_t *gary = NULL;
         I32 anum;
@@ -3027,10 +3028,11 @@ S_ingroup(pTHX_ Gid_t testgid, bool effective)
         }
         return rc;
     }
-#else
+# else
     return FALSE;
-#endif
+# endif
 }
+#endif /* ! DOSISH */
 
 #if defined(HAS_MSG) || defined(HAS_SEM) || defined(HAS_SHM)
 

--- a/embed.fnc
+++ b/embed.fnc
@@ -4132,8 +4132,6 @@ S	|bool	|argvout_final	|NN MAGIC *mg				\
 S	|void	|exec_failed	|NN const char *cmd			\
 				|int fd 				\
 				|int do_report
-RS	|bool	|ingroup	|Gid_t testgid				\
-				|bool effective
 ST	|bool	|is_fork_open	|NN const char *name
 S	|bool	|openn_cleanup	|NN GV *gv				\
 				|NN IO *io				\
@@ -4154,6 +4152,10 @@ S	|IO *	|openn_setup	|NN GV *gv				\
 				|NN PerlIO **saveofp			\
 				|NN int *savefd 			\
 				|NN char *savetype
+# if !defined(DOSISH)
+RS	|bool	|ingroup	|Gid_t testgid				\
+				|bool effective
+# endif
 #endif
 #if defined(PERL_IN_DOOP_C)
 RS	|Size_t |do_trans_complex					\

--- a/embed.h
+++ b/embed.h
@@ -1264,10 +1264,12 @@
 #   if defined(PERL_IN_DOIO_C)
 #     define argvout_final(a,b,c)               S_argvout_final(aTHX_ a,b,c)
 #     define exec_failed(a,b,c)                 S_exec_failed(aTHX_ a,b,c)
-#     define ingroup(a,b)                       S_ingroup(aTHX_ a,b)
 #     define is_fork_open                       S_is_fork_open
 #     define openn_cleanup(a,b,c,d,e,f,g,h,i,j,k,l,m) S_openn_cleanup(aTHX_ a,b,c,d,e,f,g,h,i,j,k,l,m)
 #     define openn_setup(a,b,c,d,e,f)           S_openn_setup(aTHX_ a,b,c,d,e,f)
+#     if !defined(DOSISH)
+#       define ingroup(a,b)                     S_ingroup(aTHX_ a,b)
+#     endif
 #   endif
 #   if defined(PERL_IN_DOOP_C)
 #     define do_trans_complex(a,b)              S_do_trans_complex(aTHX_ a,b)

--- a/proto.h
+++ b/proto.h
@@ -6663,11 +6663,6 @@ S_exec_failed(pTHX_ const char *cmd, int fd, int do_report);
         assert(cmd)
 
 STATIC bool
-S_ingroup(pTHX_ Gid_t testgid, bool effective)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_INGROUP
-
-STATIC bool
 S_is_fork_open(const char *name);
 # define PERL_ARGS_ASSERT_IS_FORK_OPEN          \
         assert(name)
@@ -6683,6 +6678,13 @@ S_openn_setup(pTHX_ GV *gv, char *mode, PerlIO **saveifp, PerlIO **saveofp, int 
         assert(gv); assert(mode); assert(saveifp); assert(saveofp); assert(savefd); \
         assert(savetype)
 
+# if !defined(DOSISH)
+STATIC bool
+S_ingroup(pTHX_ Gid_t testgid, bool effective)
+        __attribute__warn_unused_result__;
+#   define PERL_ARGS_ASSERT_INGROUP
+
+# endif
 #endif /* defined(PERL_IN_DOIO_C) */
 #if defined(PERL_IN_DOOP_C)
 STATIC Size_t


### PR DESCRIPTION
This avoids a compiler warning on MinGW systems:

    ..\doio.c: At top level:
    ..\doio.c:3002:1: warning: 'S_ingroup' defined but not used [-Wunused-function]
     3002 | S_ingroup(pTHX_ Gid_t testgid, bool effective)
          | ^~~~~~~~~

See issue #21916.