### PR TITLE
locale.c: Make sure UTF-8 flag is off on a scalar

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -6756,6 +6756,7 @@ S_emulate_langinfo(pTHX_ const int item,
 
         /* We just assume the codeset is ASCII; no need to check for it being
          * UTF-8 */
+        SvUTF8_off(sv);
 
         restore_toggled_locale_c(LC_CTYPE, orig_CTYPE_locale);
 


### PR DESCRIPTION
The contents of this scalar at this moment are the name of a code set, such as CP1252, UTF-8, 8859-1, etc.  I believe all such names contain just ASCII characters.

I finally got around to checking if the sv_setpvf() functions clear the UTF-8 flag.  They don't.  GH #21921 adds documentation to that effect.

One of those functions was used to populate this SV.  Since the result is ASCII, the UTF-8 flag is immaterial except for performance.  Prior to this commit, it retained its previous value, but its better practice (and can speed things up a bit) to turn it off for ASCII content.