### PR TITLE
locale.c: Use strchr before strpbrk

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -6321,8 +6321,10 @@ S_langinfo_sv_i(pTHX_
              * case other platforms also violate the standard, the code below
              * looks for NUL and any graphic \W character as a potential
              * separator. */
-            const char * sep_pos = strpbrk(retval,
-                                        " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~");
+            const char * sep_pos = strchr(retval, ';');
+            if (! sep_pos) {
+                sep_pos = strpbrk(retval, " !\"#$%&'()*+,-./:<=>?@[\\]^_`{|}~");
+            }
             if (sep_pos) {
                 separator = *sep_pos;
             }


### PR DESCRIPTION
I'm unsure if this is a good idea or not

Platforms that conform to the POSIX standard use a semi-colon here as a separator.  But there are non-conforming platforms which causes our code to look for any ASCII punctuation character instead, using strpbrk().

I looked at the glibc code for strpbrk, and it isn't that clever. Looking for a single character with strchr() is faster.  It seems to me that conforming platforms shouldn't be penalized, so this commit uses strchr to look for semi-colons, and only if that isn't found does it fall back to strpbrk.