### PR TITLE
Recognise a :reader attribute on class fields

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5956,6 +5956,7 @@ t/bigmem/subst.t			Test s/// with large strings
 t/bigmem/subst2.t			Test s//EXPR/e with large strings
 t/bigmem/vec.t				Check vec() handles large offsets
 t/charset_tools.pl			To aid in portable testing across platforms with different character sets
+t/class/accessor.t			See if accessor methods work
 t/class/class.t				See if class declarations work
 t/class/construct.t			See if class constructors work
 t/class/destruct.t			See if class destruction works

--- a/class.c
+++ b/class.c
@@ -489,6 +489,8 @@ static void S_split_attr_nameval(pTHX_ SV *sv, SV **namp, SV **valp)
 
         if(value_max >= value_at)
             *valp = sv_2mortal(newSVpvn_utf8(value_at, value_max - value_at + 1, do_utf8));
+        else
+            *valp = NULL;
     }
     else {
         *namp = sv;

--- a/pod/perlclass.pod
+++ b/pod/perlclass.pod
@@ -227,6 +227,36 @@ If there is no defaulting expression then the parameter is required by the
 constructor; the caller must pass it or an exception is thrown. With a
 defaulting expression this becomes optional.
 
+=head3 :reader
+
+A field with a C<:reader> attribute will generate a reader accessor method
+automatically.  The generated method will have an empty (i.e. zero-argument)
+signature, and its body will simply return the value of the field variable.
+
+    field $s :reader;
+
+    # Equivalent to
+    field $s;
+    method s () { return $s; }
+
+By default accessor method will have the same name as the field (minus the
+leading sigil), but a different name can be specified in the attribute's value.
+
+    field $x :reader(get_x);
+
+    # Generates a method
+    method get_x () { return $x; }
+
+Reader methods can be applied to non-scalar fields. When invoked in list
+context they yield the contents of the field; in scalar context they yield
+the count of elements, as if the field variable had been placed in scalar
+context.
+
+    field @users :reader;
+    ...
+
+    scalar $instance->users;
+
 =head2 Method attributes
 
 None yet.
@@ -301,20 +331,20 @@ that makes all field initializer expressions appear within the same CV on
 ADJUST blocks as well, merging them all into a single CV per class. This will
 make it faster to invoke if a class has more than one of them.
 
-=item * Accessor generator attributes
+=item * More accessor generator attributes
 
-Attributes to request that accessor methods be generated for fields. Likely
-C<:reader> and C<:writer>.
+Attributes to request that other kinds of accessor methods be generated for
+fields. Likely C<:writer>.
 
     class X {
-        field $name :reader;
+        field $name :writer;
     }
 
 Equivalent to
 
     class X {
         field $name;
-        method name { return $name; }
+        method set_name ($new) { $name = $new; return $self; }
     }
 
 =item * Metaprogramming

--- a/t/class/accessor.t
+++ b/t/class/accessor.t
@@ -1,0 +1,51 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+    require Config;
+}
+
+use v5.36;
+use feature 'class';
+no warnings 'experimental::class';
+
+# reader accessors
+{
+    class Testcase1 {
+        field $s :reader = "the scalar";
+        field @a :reader = qw( the array );
+        field %h :reader = qw( the hash );
+    }
+
+    my $o = Testcase1->new;
+    is($o->s, "the scalar", '$o->s accessor');
+    ok(eq_array([$o->a], [qw( the array )]), '$o->a accessor');
+    ok(eq_hash({$o->h}, {qw( the hash )}), '$o->h accessor');
+
+    is(scalar $o->a, 2, '$o->a accessor in scalar context');
+    is(scalar $o->h, 1, '$o->h accessor in scalar context');
+
+    # Read accessor does not permit arguments
+    ok(!eval { $o->s("value") },
+        'Reader accessor fails with argument');
+    like($@, qr/^Too many arguments for subroutine \'Testcase1::s\' \(got 1; expected 0\) at /,
+        'Failure from argument to accessor');
+}
+
+# Alternative names
+{
+    class Testcase2 {
+        field $f :reader(get_f) = "value";
+    }
+
+    is(Testcase2->new->get_f, "value", 'accessor with altered name');
+
+    ok(!eval { Testcase2->new->f },
+       'Accessor with altered name does not also generate original name');
+    like($@, qr/^Can't locate object method "f" via package "Testcase2" at /,
+       'Failure from lack of original name accessor');
+}
+
+done_testing;

--- a/t/class/accessor.t
+++ b/t/class/accessor.t
@@ -15,8 +15,11 @@ no warnings 'experimental::class';
 {
     class Testcase1 {
         field $s :reader = "the scalar";
+
         field @a :reader = qw( the array );
-        field %h :reader = qw( the hash );
+
+        # Present-but-empty parens counts as default
+        field %h :reader() = qw( the hash );
     }
 
     my $o = Testcase1->new;


### PR DESCRIPTION
Generates simple reader accessors.

Not yet addressed - any kind of writer or mutator.

perldelta to be written in a separate commit