### PR TITLE
perlapi, av.h: Need "apidoc_item"

### DIFF
--- a/av.h
+++ b/av.h
@@ -113,7 +113,7 @@ Note that there are both real and fake AVs; see the beginning of this file and
 'av.c'
 
 =for apidoc newAV
-=for apidoc newAV_mortal
+=for apidoc_item newAV_mortal
 =for apidoc_item newAV_alloc_x
 =for apidoc_item newAV_alloc_xz
 


### PR DESCRIPTION
Commit 0d564a3d013287cf0880fdc3264f30c20fe6188d added docs for newAV_mortal, but it needed to use "apidoc_item", not plain "apidoc".

Not doing so resulted in this build time warning:

Empty pod for newAV (from av.h) at autodoc.pl line 1265.

and the resulting pod/perlapi.pod was incorrect.

Plain "apidoc" is used to begin a new entry.  "apidoc_item" is for related subsidiary functions to the main entry.

Suggestions welcome as to how to make this relationship more obvious. Perhaps it should be renamed "apidoc_sub_item"