### PR TITLE
Permit a space after -M option to take module name from next argv

### DIFF
--- a/perl.c
+++ b/perl.c
@@ -2226,8 +2226,6 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
         case 'h':
         case 'i':
         case 'l':
-        case 'M':
-        case 'm':
         case 'n':
         case 'p':
         case 's':
@@ -2239,6 +2237,21 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
         case 'w':
             if ((s = moreswitches(s)))
                 goto reswitch;
+            break;
+
+        case 'M':
+            forbid_setid('M', FALSE);   /* XXX ? */
+            /* FALLTHROUGH */
+        case 'm':
+            forbid_setid('m', FALSE);   /* XXX ? */
+            if (*++s)                   /* -MModule */
+                s = S_moreswitch_m(aTHX_ c, s);
+            else if(argc && argv[1]) {  /* -M Module */
+                argc--; argv++;
+                s = S_moreswitch_m(aTHX_ c, *argv);
+            }
+            else
+                croak("Missing argument to -%c", c);
             break;
 
         case 't':

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -27,6 +27,15 @@ here, but most should go in the L</Performance Enhancements> section.
 
 [ List each enhancement as a =head2 entry ]
 
+=head2 Permit a space in C<-M> command-line option
+
+When processing command-line options, perl now allows a space between the
+C<-M> switch and the name of the module after it.
+
+    $ perl -M Data::Dumper=Dumper -E 'say Dumper [1,2,3]'
+
+This matches the existing behaviour of the C<-I> option.
+
 =head1 Security
 
 XXX Any security-related notices go here.  In particular, any security

--- a/pod/perlrun.pod
+++ b/pod/perlrun.pod
@@ -705,6 +705,12 @@ If the first character after the B<-M> or B<-m> is a dash (B<->)
 then the 'use' is replaced with 'no'.
 This makes no difference for B<-m>.
 
+Since Perl version 5.39.8, the C<-M> switch and the module name can now
+be passed in separate command-line arguments:
+
+  perl -M MODULE ...            # like perl -MMODULE ...
+  perl -M MODULE=arg1,arg2,...  # like perl -MMODULE=arg1,arg2,...
+
 A little builtin syntactic sugar means you can also say
 B<-mI<MODULE>=foo,bar> or B<-MI<MODULE>=foo,bar> as a shortcut for
 B<'-MI<MODULE> qw(foo bar)'>.  This avoids the need to use quotes when

--- a/t/run/switchM.t
+++ b/t/run/switchM.t
@@ -11,7 +11,7 @@ use strict;
 
 require './test.pl';
 
-plan(4);
+plan(5);
 
 like(runperl(switches => ['-Irun/flib', '-Mbroken'], stderr => 1),
      qr/^Global symbol "\$x" requires explicit package name \(did you (?x:
@@ -22,6 +22,11 @@ like(runperl(switches => ['-Irun/flib/', '-Mbroken'], stderr => 1),
      qr/^Global symbol "\$x" requires explicit package name \(did you (?x:
         )forget to declare "my \$x"\?\) at run\/flib\/broken.pm line 6\./,
      "Ensure -Irun/flib/ produces correct filename in warnings");
+
+like(runperl(switches => ['-Irun/flib/', '-M', 'broken'], stderr => 1),
+     qr/^Global symbol "\$x" requires explicit package name \(did you (?x:
+        )forget to declare "my \$x"\?\) at run\/flib\/broken.pm line 6\./,
+     "Ensure -Irun/flib/ produces correct filename in warnings with space after -M");
 
 SKIP: {
     my $no_pmc;


### PR DESCRIPTION
This permits `perl -M Module::Name`, matching the already existing (but not documented?) behaviour of `-I`.

Fixes #21932