### PR TITLE
 locale.c: Avoid copies

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -2236,8 +2236,7 @@ S_querylocale_2008_i(pTHX_ const locale_category_index index,
         else {
 
             QUERYLOCALE_LOCK;
-            retval = savepv(my_querylocale(index, cur_obj));
-            QUERYLOCALE_UNLOCK;
+            retval = my_querylocale(index, cur_obj);
 
             /* querylocale() may conflate the C locale with something that
              * isn't exactly the same.  See for example
@@ -2250,11 +2249,14 @@ S_querylocale_2008_i(pTHX_ const locale_category_index index,
              * rest of our code.  (The code is ordered this way so that if the
              * system distinugishes "C" from "POSIX", we do too.) */
             if (cur_obj == PL_C_locale_obj && ! isNAME_C_OR_POSIX(retval)) {
-                Safefree(retval);
-                retval = savepv("C");
+                QUERYLOCALE_UNLOCK;
+                retval = "C";
             }
-
-            SAVEFREEPV(retval);
+            else {
+                retval = savepv(retval);
+                QUERYLOCALE_UNLOCK;
+                SAVEFREEPV(retval);
+            }
         }
     }
 


### PR DESCRIPTION
Refactoring slightly as suggested by Tony Cook avoids having to make two
copies in some circumstances.