### PR TITLE
Accept 0 for first alternate digit when no nl_langinfo() 

### DIFF
--- a/lib/locale.t
+++ b/lib/locale.t
@@ -2551,7 +2551,8 @@ foreach my $Locale (@Locale) {
         $test_names{$locales_test_number} =
                  'Verify ALT_DIGITS returns nothing, or else non-ASCII and'
                . ' the single char digits evaluate to consecutive integers'
-               . ' starting at 0';
+               . ' starting at 0; 0 is accepted for alt-0 for locales without'
+               . ' a zero';
 
         my $alts = langinfo(ALT_DIGITS);
         if ($alts) {
@@ -2559,8 +2560,10 @@ foreach my $Locale (@Locale) {
             my $prev = -1;
             foreach my $num (@alts) {
                 if ($num =~ /[[:ascii:]]/) {
-                    push @f, disp_str($num);
-                    last;
+                    if ($prev != -1 || $num != 0) {
+                        push @f, disp_str($num);
+                        last;
+                    }
                 }
 
                 # We only look at single character strings; likely locales

--- a/locale.c
+++ b/locale.c
@@ -7377,10 +7377,10 @@ S_emulate_langinfo(pTHX_ const int item,
          * strftime() formats.
          *
          * We already have the alternate digit for zero in 'sv', generated
-         * using the %Ow format.  That was used because it seems least likely
-         * to have a leading zero.  But some locales return that anyway.  If
-         * the first half of 'sv' is identical to the second half, assume that
-         * is the case, and use just the first half */
+         * using the %Ow format, which was used because it seems least likely
+         * to have a leading zero.  But some locales return the equivalent of
+         * 00 anyway.  If the first half of 'sv' is identical to the second
+         * half, assume that is the case, and use just the first half */
         if ((alt0_len & 1) == 0) {
             Size_t half_alt0_len = alt0_len / 2;
             if (strnEQ(SvPVX(sv), SvPVX(sv) + half_alt0_len, half_alt0_len)) {

--- a/locale.c
+++ b/locale.c
@@ -7359,16 +7359,11 @@ S_emulate_langinfo(pTHX_ const int item,
         }
 
         /* Here, the item is 'ALT_DIGITS' and 'sv' contains the zeroth
-         * alternate digit.  If empty or doesn't differ from regular digits,
-         * return that there aren't alternate digits */
+         * alternate digit.  If empty, return that there aren't alternate
+         * digits */
         Size_t alt0_len = SvCUR(sv);
         if (alt0_len == 0) {
             retval_type = RETVAL_IN_sv;
-            break;
-        }
-
-        if (strchr(SvPVX(sv), '0')) {
-            retval = "";
             break;
         }
 
@@ -7484,6 +7479,14 @@ S_emulate_langinfo(pTHX_ const int item,
             sv_catpv_nomg (sv, current);
             sv_catpvn_nomg (sv, ";", 1);
         } /* End of loop generating ALT_DIGIT strings */
+
+        /* Above we accepted 0 for alt-0 in case the locale doesn't have a
+         * zero, but we rejected any other ASCII digits.  Now that we have
+         * processed everything, if that 0 is the only thing we found, it was a
+         * false positive, and the locale doesn't have alternate digits */
+        if (SvCUR(sv) == alt0_len + 1) {
+            SvCUR_set(sv, 0);
+        }
 
         SvREFCNT_dec_NN(alt_dig_sv);
 


### PR DESCRIPTION
Commit https://github.com/Perl/perl5/commit/85857715f96ef9f591dd5ca0322dc293e1f07867 allows a locale to have
an ASCII digit 0 to be the first alternate digit.  This is to
accommodate locales without a zero (such as Roman numerals) to use the
modern day Western 0, and still have the rest of the digits be
alternates.

This commit extends that to perl's emulation of nl_langinfo() on systems
that lack that libc function.