### PR TITLE
locale.c: Move unnecessary work out of toggled state

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -6319,6 +6319,7 @@ S_langinfo_sv_i(pTHX_
  *                  well.
  */
     const char * retval = NULL;
+    utf8ness_t is_utf8 = UTF8NESS_UNKNOWN;
 
     /* Do a bit of extra work so avoid
      *  switch() { default: ... }
@@ -6386,12 +6387,10 @@ S_langinfo_sv_i(pTHX_
 
         /* In all cases that get here, the char* instead delivers a numeric
          * value, so its UTF-8ness is meaningless */
+        is_utf8 = UTF8NESS_IMMATERIAL;
+
         if (sv == PL_scratch_langinfo) {
             retval = SvPV_nomg_const_nolen(sv);
-
-            if (utf8ness) {
-                *utf8ness = UTF8NESS_IMMATERIAL;
-            }
         }
 
         break;
@@ -6521,21 +6520,26 @@ S_langinfo_sv_i(pTHX_
 
         SvUTF8_off(sv);
         retval = SvPV_nomg_const_nolen(sv);
-
-        if (utf8ness) {
-            *utf8ness = get_locale_string_utf8ness_i(retval,
-                                                     LOCALE_UTF8NESS_UNKNOWN,
-                                                     locale, cat_index);
-            if (*utf8ness == UTF8NESS_YES) {
-                SvUTF8_on(sv);
-            }
-        }
     }
 
     GCC_DIAG_RESTORE_STMT;
 
     restore_toggled_locale_i(cat_index, orig_switched_locale);
     end_DEALING_WITH_MISMATCHED_CTYPE(locale)
+
+    if (utf8ness) {
+        if (LIKELY(is_utf8 == UTF8NESS_UNKNOWN)) {  /* default: case above */
+            is_utf8 = get_locale_string_utf8ness_i(retval,
+                                                   LOCALE_UTF8NESS_UNKNOWN,
+                                                   locale, cat_index);
+        }
+
+        *utf8ness = is_utf8;
+
+        if (*utf8ness == UTF8NESS_YES) {
+            SvUTF8_on(sv);
+        }
+    }
 
     return retval;
 }


### PR DESCRIPTION
In some Configurations, toggling the locale can interfere with other executing threads.  As of GH #21908, the current Configurations where this is true are critical sections.  This commit takes one such place and moves unnecessary work to outside the critical section/toggled locale.

The downside of this change is that we may have to retoggle to the locale later in the called function get_locale_string_utf8ness_i(), which may call is_locale_utf8().  This would be wasted effort in those Configurations where toggling doesn't interfere, but often the toggling is avoided, in part because of caching, and in part because the most frequent calls to this function result in ASCII data which don't require toggling.

A scheme could be created to avoid any such possibility, but I don't think it's worth it.