### PR TITLE
Fatalize downgrading a `use VERSION` past v5.11

### DIFF
--- a/lib/strict.t
+++ b/lib/strict.t
@@ -3,7 +3,7 @@
 chdir 't' if -d 't';
 @INC = ( '.', '../lib' );
 
-our $local_tests = 7;
+our $local_tests = 5;
 require "../t/lib/common.pl";
 
 eval qq(use strict 'garbage');
@@ -17,16 +17,6 @@ like($@, qr/^Unknown 'strict' tag\(s\) 'foo bar'/);
 
 eval qq(no strict qw(foo bar));
 like($@, qr/^Unknown 'strict' tag\(s\) 'foo bar'/);
-
-{
-    my $warnings = "";
-    local $SIG{__WARN__} = sub { $warnings .= $_[0] };
-    eval 'use v5.12; use v5.10; ${"c"}';
-    is($@, '', 'use v5.10 disables implicit strict refs');
-    like($warnings,
-        qr/^Downgrading a use VERSION declaration to below v5.11 is deprecated, and will become fatal in Perl 5.40 at /,
-        'use v5.10 after use v5.12 provokes deprecation warning');
-}
 
 eval 'use strict; use v5.10; ${"c"}';
 like($@,

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2225,14 +2225,14 @@ somehow called on another platform.  This should not happen.
 
 (P) The internal handling of magical variables has been cursed.
 
-=item Downgrading a use VERSION declaration to below v5.11 is deprecated
+=item Downgrading a use VERSION declaration to below v5.11 is not permitted
 
-(S deprecated::version_downgrade) This warning is emitted on a
-C<use VERSION> statement that requests a version below v5.11 (when the
-effects of C<use strict> would be disabled), after a previous
-declaration of one having a larger number (which would have enabled
-these effects). Because of a change to the way that C<use VERSION>
-interacts with the strictness flags, this is no longer supported.
+(F) A C<use VERSION> statement that requests a version below v5.11
+(when the effects of C<use strict> would be disabled) has been found
+after a previous declaration of one having a larger number (which would
+have enabled these effects).  Because of a change to the way that
+C<use VERSION> interacts with the strictness flags, this is no longer
+supported.
 
 =item (Do you need to predeclare %s?)
 

--- a/t/comp/use.t
+++ b/t/comp/use.t
@@ -6,7 +6,7 @@ BEGIN {
     $INC{"feature.pm"} = 1; # so we don't attempt to load feature.pm
 }
 
-print "1..88\n";
+print "1..85\n";
 
 # Can't require test.pl, as we're testing the use/require mechanism here.
 
@@ -149,14 +149,6 @@ like $@, qr/^Can't use string/,
 eval 'use strict "subs"; use 5.012; ${"foo"} = "bar"';
 like $@, qr/^Can't use string/,
     'explicit use strict "subs" does not stop ver decl from enabling refs';
-{
-    my $warnings = "";
-    local $SIG{__WARN__} = sub { $warnings .= $_[0] };
-    eval 'use 5.012; use 5.01; ${"foo"} = "bar"';
-    is $@, "", 'use 5.01 overrides implicit strict from prev ver decl';
-    like $warnings, qr/^Downgrading a use VERSION declaration to below v5.11 is deprecated, and will become fatal in Perl 5.40 at /,
-        'use 5.01 after use 5.012 provokes deprecation warning';
-}
 eval 'no strict "subs"; use 5.012; ${"foo"} = "bar"';
 ok $@, 'no strict subs allows ver decl to enable refs';
 eval 'no strict "subs"; use 5.012; $nonexistent_pack_var';
@@ -177,10 +169,6 @@ ok $@, 'no strict vars allows ver decl to enable subs';
     $result = eval 'use 5.39.0; my $t = true; $t eq "1"';
     is ($@, "", 'builtin funcs available after use 5.39.0');
     ok ($result, 'imported true is eq "1"');
-
-    eval 'use 5.39.0; use 5.36.0; my $t = true;';
-    like ($@, qr/^Bareword "true" not allowed while "strict subs" in use at /,
-        'builtin funcs are removed by use 5.36.0');
 }
 
 { use test_use }	# check that subparse saves pending tokens

--- a/t/lib/croak/op
+++ b/t/lib/croak/op
@@ -308,3 +308,9 @@ sub xx {
 EXPECT
 Missing comma after first argument to return at - line 2, near "5;"
 Execution of - aborted due to compilation errors.
+########
+# use VERSION across the 5.11 boundary
+use 5.012;
+use 5.010;
+EXPECT
+Downgrading a use VERSION declaration to below v5.11 is not permitted at - line 3.

--- a/t/lib/feature/implicit
+++ b/t/lib/feature/implicit
@@ -62,37 +62,34 @@ EXPECT
 # lower version after higher version
 sub evalbytes { print "evalbytes sub\n" }
 sub say { print "say sub\n" }
+use 5;
+say "no";
 use 5.015;
 evalbytes "say 'yes'";
 use 5.014;
 evalbytes;
-use 5;
-say "no"
 EXPECT
-Downgrading a use VERSION declaration to below v5.11 is deprecated, and will become fatal in Perl 5.40 at - line 8.
+say sub
 yes
 evalbytes sub
-say sub
 ########
 # Implicit unicode_string feature
-use v5.14;
+use v5.8.8;
 my $sharp_s = chr utf8::unicode_to_native(0xdf);
 print 'ss' =~ /$sharp_s/i ? "ok\n" : "nok\n";
-use v5.8.8;
+use v5.14;
 print 'ss' =~ /$sharp_s/i ? "ok\n" : "nok\n";
 EXPECT
-Downgrading a use VERSION declaration to below v5.11 is deprecated, and will become fatal in Perl 5.40 at - line 5.
-ok
 nok
+ok
 ########
 # Implicit unicode_eval feature
-use v5.15;
 require '../../t/charset_tools.pl';
 my $long_s = byte_utf8a_to_utf8n("\xc5\xbf");
-print eval "use utf8; q|$long_s|" eq $long_s ? "ok\n" : "nok\n";
 use v5.8.8;
 print eval "use utf8; q|$long_s|" eq "\x{17f}" ? "ok\n" : "nok\n";
+use v5.15;
+print eval "use utf8; q|$long_s|" eq $long_s ? "ok\n" : "nok\n";
 EXPECT
-Downgrading a use VERSION declaration to below v5.11 is deprecated, and will become fatal in Perl 5.40 at - line 6.
 ok
 ok


### PR DESCRIPTION
In Perl 5.36 we made this a deprecation warning, due to be removed in 5.40. Now it is being removed.

This removal means that the three shadow hints bits used to implement implicit vs explicit strict hints can be reclaimed at a later date, for use in other features.