### PR TITLE
t/loc_tools: Don't return duplicates

### DIFF
--- a/t/loc_tools.pl
+++ b/t/loc_tools.pl
@@ -679,7 +679,9 @@ sub find_locales ($;$) {
         }
     }
 
-    @Locale = sort @Locale;
+    my %Locale;
+    $Locale{$_} = 1 for @Locale;
+    @Locale = sort keys %Locale;
 
     return @Locale;
 }


### PR DESCRIPTION
Make sure the return of find_locales() (and hence any internal subs that call it) has no repeated locale names.