### PR TITLE
fix "uninitialized value" warnings for shift()/pop()

### DIFF
--- a/t/lib/warnings/9uninit
+++ b/t/lib/warnings/9uninit
@@ -2277,6 +2277,12 @@ $_ = length shift @$ref == 0;
 $_ = length pop @$ref == 0;
 
 $_ = splice(@arr, 0, 0) == 0;
+
+# GH #21960
+$_ = lc shift;
+$_ = sub { lc shift }->();
+$_ = lc pop;
+$_ = sub { lc pop }->();
 EXPECT
 Use of uninitialized value in numeric eq (==) at - line 6.
 Use of uninitialized value length($x) in numeric eq (==) at - line 7.
@@ -2292,3 +2298,7 @@ Use of uninitialized value length(pop(@arr)) in numeric eq (==) at - line 19.
 Use of uninitialized value in numeric eq (==) at - line 20.
 Use of uninitialized value in numeric eq (==) at - line 21.
 Use of uninitialized value in numeric eq (==) at - line 23.
+Use of uninitialized value shift(@ARGV) in lc at - line 26.
+Use of uninitialized value shift() in lc at - line 27.
+Use of uninitialized value pop(@ARGV) in lc at - line 28.
+Use of uninitialized value pop() in lc at - line 29.


### PR DESCRIPTION
This fixes an oversight introduced in 1b0ae12.

The Perl code "shift" (or "shift()") produces different optrees depending on where it occurs: At file scope, it shifts `@ARGV` and the corresponding OP has an explicit `@ARGV` child. But at subroutine scope, it shifts `@_`, and `@_` is not represented explicitly in the optree. Instead the parser just generates an OP_SHIFT without any children.

This latter case was not handled in S_find_uninit_var (and blindly accessing a non-existent child OP would crash perl). pop() was similarly affected.

Fix: Explicitly check whether OPf_KIDS is set on the OP before accessing the op_first field (plus some tests for this case).

Fixes #21960.