### PR TITLE
locale.c: Remove duplication in macro definitions

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -1854,6 +1854,15 @@ S_stdize_locale(pTHX_ const int category,
  *                      and query forms are essentially the same, and can be
  *                      combined to save CPU time.
  *
+ * Each implementation is fundamentally defined by just two macros: a
+ * bool_setlocale_X() and a querylocale_X().  The other macros are all
+ * derivable from these.  Each fundamental macro is either a '_i' suffix one or
+ * an '_r' suffix one, depending on what is the most efficient in getting to an
+ * input form that the underlying libc functions want.  The derived macro
+ * definitions are deferred in this file to after the code for all the
+ * implementations.  This makes each implementation shorter and clearer, and
+ * removes duplication.
+ *
  * Each implementation below is separated by ==== lines, and includes bool,
  * void, and query macros.  The query macros are first, followed by any
  * functions needed to implement them.  Then come the bool, again followed by
@@ -1878,36 +1887,7 @@ S_stdize_locale(pTHX_ const int category,
  * versions. */
 
 #  define querylocale_r(cat)  mortalized_pv_copy(stdized_setlocale(cat, NULL))
-#  define querylocale_c(cat)  querylocale_r(cat)
-#  define querylocale_i(i)    querylocale_c(categories[i])
-
-/*---------------------------------------------------------------------------*/
-
 #  define bool_setlocale_r(cat, locale) cBOOL(posix_setlocale(cat, locale))
-#  define bool_setlocale_i(i, locale)                                       \
-                                   bool_setlocale_c(categories[i], locale)
-#  define bool_setlocale_c(cat, locale)      bool_setlocale_r(cat, locale)
-
-/*---------------------------------------------------------------------------*/
-
-#  define void_setlocale_r_with_caller(cat, locale, file, line)             \
-     STMT_START {                                                           \
-        if (! bool_setlocale_r(cat, locale))                                \
-            setlocale_failure_panic_via_i(get_category_index(cat),          \
-                                          NULL, locale, __LINE__, 0,        \
-                                          file, line);                      \
-     } STMT_END
-
-#  define void_setlocale_c_with_caller(cat, locale, file, line)             \
-                    void_setlocale_r_with_caller(cat, locale, file, line)
-
-#  define void_setlocale_i_with_caller(i, locale, file, line)               \
-          void_setlocale_r_with_caller(categories[i], locale, file, line)
-
-#  define void_setlocale_r(cat, locale)                                     \
-            void_setlocale_r_with_caller(cat, locale, __FILE__, __LINE__)
-#  define void_setlocale_c(cat, locale) void_setlocale_r(cat, locale)
-#  define void_setlocale_i(i, locale)   void_setlocale_r(categories[i], locale)
 
 /*---------------------------------------------------------------------------*/
 
@@ -1955,8 +1935,6 @@ S_setlocale_i(pTHX_ const int category, const char * locale)
 
 #  define querylocale_r(cat)                                                \
                       mortalized_pv_copy(less_dicey_setlocale_r(cat, NULL))
-#  define querylocale_c(cat)  querylocale_r(cat)
-#  define querylocale_i(i)    querylocale_r(categories[i])
 
 STATIC const char *
 S_less_dicey_setlocale_r(pTHX_ const int category, const char * locale)
@@ -1980,9 +1958,6 @@ S_less_dicey_setlocale_r(pTHX_ const int category, const char * locale)
 
 #  define bool_setlocale_r(cat, locale)                                     \
                                less_dicey_bool_setlocale_r(cat, locale)
-#  define bool_setlocale_i(i, locale)                                       \
-                                bool_setlocale_r(categories[i], locale)
-#  define bool_setlocale_c(cat, locale) bool_setlocale_r(cat, locale)
 
 STATIC bool
 S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char * locale)
@@ -1999,27 +1974,6 @@ S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char * locale)
 
     return retval;
 }
-
-/*---------------------------------------------------------------------------*/
-
-#  define void_setlocale_r_with_caller(cat, locale, file, line)             \
-     STMT_START {                                                           \
-        if (! bool_setlocale_r(cat, locale))                                \
-            setlocale_failure_panic_via_i(get_category_index(cat),          \
-                                          NULL, locale, __LINE__, 0,        \
-                                          file, line);                      \
-     } STMT_END
-
-#  define void_setlocale_c_with_caller(cat, locale, file, line)             \
-                    void_setlocale_r_with_caller(cat, locale, file, line)
-
-#  define void_setlocale_i_with_caller(i, locale, file, line)               \
-          void_setlocale_r_with_caller(categories[i], locale, file, line)
-
-#  define void_setlocale_r(cat, locale)                                     \
-            void_setlocale_r_with_caller(cat, locale, __FILE__, __LINE__)
-#  define void_setlocale_c(cat, locale) void_setlocale_r(cat, locale)
-#  define void_setlocale_i(i, locale)   void_setlocale_r(categories[i], locale)
 
 /*---------------------------------------------------------------------------*/
 
@@ -2048,8 +2002,12 @@ S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char * locale)
 #  endif
 
 #  define querylocale_i(i)    querylocale_2008_i(i, __LINE__)
-#  define querylocale_c(cat)  querylocale_i(cat##_INDEX_)
-#  define querylocale_r(cat)  querylocale_i(get_category_index(cat))
+
+    /* We need to define this derivative macro here, as it is needed in
+     * the implementing function (for recursive calls).  It also gets defined
+     * where all the other derivative macros are defined, and the compiler
+     * will complain if the definition gets out of sync */
+#  define querylocale_c(cat)      querylocale_i(cat##_INDEX_)
 
 STATIC const char *
 S_querylocale_2008_i(pTHX_ const locale_category_index index,
@@ -2271,10 +2229,6 @@ S_querylocale_2008_i(pTHX_ const locale_category_index index,
 
 #  define bool_setlocale_i(i, locale)                                       \
                               bool_setlocale_2008_i(i, locale, __LINE__)
-#  define bool_setlocale_c(cat, locale)                                     \
-                                  bool_setlocale_i(cat##_INDEX_, locale)
-#  define bool_setlocale_r(cat, locale)                                     \
-                       bool_setlocale_i(get_category_index(cat), locale)
 
 /* If this doesn't exist on this platform, make it a no-op (to save #ifdefs) */
 #  ifndef update_PL_curlocales_i
@@ -2668,7 +2622,64 @@ S_bool_setlocale_2008_i(pTHX_
     return false;
 }
 
-/*---------------------------------------------------------------------------*/
+/*===========================================================================*/
+
+#else
+#  error Unexpected Configuration
+#endif   /* End of the various implementations of the setlocale and
+            querylocale macros used in the remainder of this program */
+
+/*===========================================================================*/
+
+/* Each implementation above is based on two fundamental macros #defined above:
+ *  1) either a querylocale_r or a querylocale_i
+ *  2) either a bool_setlocale_r or a bool_setlocale_i
+ *
+ * (Which one of each got #defined is based on which is most efficient in
+ * interacting with the underlying libc functions called.)
+ *
+ * To complete the implementation, macros for the missing two suffixes must be
+ * #defined, as well as all the void_setlocale_X() forms.  These all can be
+ * mechanically derived from the fundamental ones. */
+
+#ifdef querylocale_r
+#  define querylocale_c(cat)    querylocale_r(cat)
+#  define querylocale_i(i)      querylocale_r(categories[i])
+#elif defined(querylocale_i)
+#  define querylocale_c(cat)    querylocale_i(cat##_INDEX_)
+#  define querylocale_r(cat)    querylocale_i(get_category_index(cat))
+#else
+#  error No querylocale() form defined
+#endif
+
+#ifdef bool_setlocale_r
+#  define bool_setlocale_i(i, l)    bool_setlocale_r(categories[i], l)
+#  define bool_setlocale_c(cat, l)  bool_setlocale_r(cat, l)
+
+#  define void_setlocale_r_with_caller(cat, locale, file, line)             \
+     STMT_START {                                                           \
+        if (! bool_setlocale_r(cat, locale))                                \
+            setlocale_failure_panic_via_i(get_category_index(cat),          \
+                                          NULL, locale, __LINE__, 0,        \
+                                          file, line);                      \
+     } STMT_END
+
+#  define void_setlocale_c_with_caller(cat, locale, file, line)             \
+          void_setlocale_r_with_caller(cat, locale, file, line)
+
+#  define void_setlocale_i_with_caller(i, locale, file, line)               \
+          void_setlocale_r_with_caller(categories[i], locale, file, line)
+
+#  define void_setlocale_r(cat, locale)                                     \
+          void_setlocale_r_with_caller(cat, locale, __FILE__, __LINE__)
+#  define void_setlocale_c(cat, locale)                                     \
+          void_setlocale_r(cat, locale)
+#  define void_setlocale_i(i, locale)                                       \
+          void_setlocale_r(categories[i], locale)
+
+#elif defined(bool_setlocale_i)
+#  define bool_setlocale_c(cat, loc) bool_setlocale_i(cat##_INDEX_, loc)
+#  define bool_setlocale_r(c, loc)   bool_setlocale_i(get_category_index(c), l)
 
 #  define void_setlocale_i_with_caller(i, locale, file, line)               \
      STMT_START {                                                           \
@@ -2678,25 +2689,24 @@ S_bool_setlocale_2008_i(pTHX_
      } STMT_END
 
 #  define void_setlocale_r_with_caller(cat, locale, file, line)             \
-        void_setlocale_i_with_caller(get_category_index(cat), locale,       \
-                                     file, line)
+          void_setlocale_i_with_caller(get_category_index(cat), locale,     \
+                                       file, line)
 
 #  define void_setlocale_c_with_caller(cat, locale, file, line)             \
-            void_setlocale_i_with_caller(cat##_INDEX_, locale, file, line)
+          void_setlocale_i_with_caller(cat##_INDEX_, locale, file, line)
 
 #  define void_setlocale_i(i, locale)                                       \
-                void_setlocale_i_with_caller(i, locale, __FILE__, __LINE__)
+          void_setlocale_i_with_caller(i, locale, __FILE__, __LINE__)
 #  define void_setlocale_c(cat, locale)                                     \
-                                  void_setlocale_i(cat##_INDEX_, locale)
+          void_setlocale_i(cat##_INDEX_, locale)
 #  define void_setlocale_r(cat, locale)                                     \
-                  void_setlocale_i(get_category_index(cat), locale)
-
-/*===========================================================================*/
+          void_setlocale_i(get_category_index(cat), locale)
 
 #else
-#  error Unexpected Configuration
-#endif   /* End of the various implementations of the setlocale and
-            querylocale macros used in the remainder of this program */
+#  error No bool_setlocale() form defined
+#endif
+
+/*===========================================================================*/
 
 /* query_nominal_locale_i() is used when the caller needs the locale that an
  * external caller would be expecting, and not what we're secretly using


### PR DESCRIPTION
Because of the vagaries of locale handling on various platforms, there are three separate implementations in this file of locale interactions with libc.  These have been designed to present a common API to higher level code, and it turns out that each implementation can be completely defined by just two macros.  These macros present almost the same interface to the caller, but have very different expansions.

The interface to the caller varies only by the parameter type.  If this were C++, there would be two method names, and the compiler would decide which version to call depending on the parameter type.

But it is plain C, and so there are three different versions of each of the two macros, with suffixes in the names indicating the parameter type.

There are also three other derivaties of one of the macros.

Before this commit this underlying simplicity was obscured by each implementation defining all 9 of its macros.  But it only has to define the two, and common code later can define the 7 derivative ones.

Some of the implementations call libc functions that take a locale category number; others call functions that use an index into an array. For efficiency, each implementation defines the macro that interfaces most naturally with its called functions.

Thus there are two variations of the common derived macros, defining them in terms of the macro form the implementation defined.