### PR TITLE
t/run/locale.t: Several improvements

### DIFF
--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -511,15 +511,12 @@ EOF
     }
 
 SKIP: {
-        # Note: the setlocale Configure probe could be enhanced to give us the
-        # syntax to use, but khw doesn't think it's worth it at this time, as
-        # the current outliers seem to be skipped by the test just below
-        # anyway.  If the POSIX 2008 locale functions are being used, the
-        # syntax becomes mostly irrelevant, so do the test anyway if they are.
-        # It's a lot of trouble to figure out in a perl script.
         if ($Config{d_setlocale_accepts_any_locale_name})
         {
             skip("Can't distinguish between valid and invalid locale names on this system", 2);
+        }
+        if (! $Config{d_perl_lc_all_uses_name_value_pairs}) {
+            skip("Test only valid when LC_ALL syntax is name=value pairs", 2);
         }
 
         my @valid_categories = valid_locale_categories();

--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -47,7 +47,10 @@ delete local @ENV{'LANGUAGE', 'LANG', (grep /^LC_[A-Z]+$/, keys %ENV)};
 # 'debug'
 delete local $ENV{'PERL_DEBUG_LOCALE_INIT'} unless $debug;
 
-{
+my $has_ctype = grep { $_ eq "LC_CTYPE" } platform_locale_categories();
+
+SKIP: {
+    skip("LC_CTYPE not available on the system", 1 ) unless $has_ctype;
     fresh_perl_is(<<"EOF",
             use locale;
             use POSIX;
@@ -58,7 +61,8 @@ EOF
         1, { stderr => 'devnull' }, "/il matching of [bracketed] doesn't skip POSIX class if fails individ char");
 }
 
-{
+SKIP: {
+    skip("LC_CTYPE not available on the system", 1 ) unless $has_ctype;
     fresh_perl_is(<<"EOF",
             use locale;
             use POSIX;

--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -25,7 +25,7 @@ use Config;
 use I18N::Langinfo qw(langinfo RADIXCHAR);
 my $have_strtod = $Config{d_strtod} eq 'define';
 my $have_localeconv = defined $Config{d_locconv} && $Config{d_locconv} eq 'define';
-my @locales = find_locales( [ 'LC_ALL', 'LC_CTYPE', 'LC_NUMERIC' ]);
+my @locales = find_locales('LC_NUMERIC');
 skip_all("no locales available") unless @locales;
 note("locales available: @locales");
 

--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -560,7 +560,7 @@ EOF
 SKIP:
 {
     use locale;
-    # look for an english locale (so a < B, hopefully)
+    # look for an English locale (so 'a' < 'B', hopefully)
     my ($en) = grep { /^en_/ } find_locales( [ 'LC_COLLATE' ]);
     defined $en
         or skip "didn't find a suitable locale", 1;


### PR DESCRIPTION
Most notable is that on platforms where some category is restricted to always being in the C locale, prior to these commits, only the C locale would be tested for any category.  Now, that decision for one category doesn't affect the decision for other categories.