### PR TITLE
Update perldsc.pod adding vital deep slice shortcut

### DIFF
--- a/pod/perldsc.pod
+++ b/pod/perldsc.pod
@@ -652,6 +652,12 @@ X<hash of hashes> X<HoH>
      $HoH{flintstones}{$what} = $new_folks{$what};
  }
 
+ # same, but using a hash slice
+ @{ $HoH{flintstones} }{ keys %new_folks } = values %new_folks;
+
+ # same, but without a %new_folks variable
+ @{ $HoH{flintstones} }{ "wife", "pet" } = ( "wilma", "dino" );
+
 =head2 Access and Printing of a HASH OF HASHES
 
  # one element


### PR DESCRIPTION
Without showing this beginners always try
`${HoH}{flintstones}{"wife", "pet"} = ( "wilma", "dino" );` racking their brains for why it won't work. Plus such _deeper_ slices are not documented, so clearly, anywhere else!