### PR TITLE
Free up HINT bit

### DIFF
--- a/lib/locale.pm
+++ b/lib/locale.pm
@@ -3,7 +3,7 @@ package locale;
 use strict;
 use warnings;
 
-our $VERSION = '1.11';
+our $VERSION = '1.12';
 use Config;
 
 $Carp::Internal{ (__PACKAGE__) } = 1;
@@ -54,7 +54,6 @@ to behave as if in the C<C> locale; attempts to change the locale will fail.
 # argument.
 
 $locale::hint_bits = 0x4;
-$locale::partial_hint_bits = 0x10;  # If pragma has an argument
 
 # The pseudo-category :characters consists of 2 real ones; but it also is
 # given its own number, -1, because in the complement form it also has the
@@ -64,9 +63,9 @@ sub import {
     shift;  # should be 'locale'; not checked
 
     $^H{locale} = 0 unless defined $^H{locale};
+    $^H |= $locale::hint_bits;
     if (! @_) { # If no parameter, use the plain form that changes all categories
-        $^H |= $locale::hint_bits;
-
+        $^H{locale} = 0;
     }
     else {
         my @categories = ( qw(:ctype :collate :messages
@@ -103,11 +102,6 @@ sub import {
                 next;
             }
 
-            $^H |= $locale::partial_hint_bits;
-
-            # This form of the pragma overrides the other
-            $^H &= ~$locale::hint_bits;
-
             $arg =~ s/^://;
 
             eval { require POSIX; POSIX->import('locale_h'); };
@@ -139,7 +133,7 @@ sub import {
 }
 
 sub unimport {
-    $^H &= ~($locale::hint_bits | $locale::partial_hint_bits);
+    $^H &= ~($locale::hint_bits);
     $^H{locale} = 0;
 }
 

--- a/locale.c
+++ b/locale.c
@@ -9948,6 +9948,10 @@ Perl__is_in_locale_category(pTHX_ const bool compiling, const int category)
         return FALSE;
     }
 
+    if (category == PERL_IN_UNRESTRICTED_LOCALE_) {
+        return SvUV(these_categories) == 0;
+    }
+
     /* The pseudo-category 'not_characters' is -1, so just add 1 to each to get
      * a valid unsigned */
     assert(category >= -1);

--- a/perl.h
+++ b/perl.h
@@ -5926,7 +5926,7 @@ typedef enum {
 #define HINT_STRICT_REFS	0x00000002 /* strict pragma */
 #define HINT_LOCALE		0x00000004 /* locale pragma */
 #define HINT_BYTES		0x00000008 /* bytes pragma */
-#define HINT_LOCALE_PARTIAL	0x00000010 /* locale, but a subset of categories */
+/* #define spare_bit               0x00000010 */
 
 #define HINT_EXPLICIT_STRICT_REFS	0x00000020 /* strict.pm */
 #define HINT_EXPLICIT_STRICT_SUBS	0x00000040 /* strict.pm */
@@ -6933,16 +6933,23 @@ typedef struct am_table_short AMTS;
 
    /* Returns TRUE if the plain locale pragma without a parameter is in effect.
     * */
-#  define IN_LOCALE_RUNTIME	(PL_curcop                                  \
-                              && CopHINTS_get(PL_curcop) & HINT_LOCALE)
-
+#  define PERL_IN_UNRESTRICTED_LOCALE_  -2   /* Chosen so as to not conflict
+                                                with a real category number,
+                                                nor -1 already reserved */
    /* Returns TRUE if either form of the locale pragma is in effect */
 #  define IN_SOME_LOCALE_FORM_RUNTIME                                       \
-        cBOOL(CopHINTS_get(PL_curcop) & (HINT_LOCALE|HINT_LOCALE_PARTIAL))
+       (PL_curcop && UNLIKELY(CopHINTS_get(PL_curcop) & (HINT_LOCALE)))
 
-#  define IN_LOCALE_COMPILETIME	cBOOL(PL_hints & HINT_LOCALE)
-#  define IN_SOME_LOCALE_FORM_COMPILETIME                                   \
-                        cBOOL(PL_hints & (HINT_LOCALE|HINT_LOCALE_PARTIAL))
+#  define IN_LOCALE_RUNTIME                                                 \
+      (   IN_SOME_LOCALE_FORM_RUNTIME                                       \
+       && _is_in_locale_category(false, /* runtime */                       \
+                                 PERL_IN_UNRESTRICTED_LOCALE_))
+#  define IN_LOCALE_COMPILETIME	                                            \
+      (   IN_SOME_LOCALE_FORM_COMPILETIME                                  \
+       && _is_in_locale_category(true, /* is compiling */                   \
+                                 PERL_IN_UNRESTRICTED_LOCALE_ ))
+
+#  define IN_SOME_LOCALE_FORM_COMPILETIME  cBOOL(PL_hints & (HINT_LOCALE))
 
 /*
 =for apidoc_section $locale
@@ -6974,9 +6981,10 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  define IN_LC_ALL_COMPILETIME   IN_LOCALE_COMPILETIME
 #  define IN_LC_ALL_RUNTIME       IN_LOCALE_RUNTIME
 
-#  define IN_LC_PARTIAL_COMPILETIME   cBOOL(PL_hints & HINT_LOCALE_PARTIAL)
-#  define IN_LC_PARTIAL_RUNTIME                                             \
-              (PL_curcop && CopHINTS_get(PL_curcop) & HINT_LOCALE_PARTIAL)
+#  define IN_LC_PARTIAL_COMPILETIME   (     IN_SOME_LOCALE_FORM_COMPILETIME \
+                                       && ! IN_LOCALE_COMPILETIME)
+#  define IN_LC_PARTIAL_RUNTIME       (     IN_SOME_LOCALE_FORM_RUNTIME     \
+                                       && ! IN_LOCALE_RUNTIME)
 
 #  define IN_LC_COMPILETIME(category)                                       \
        (       IN_LC_ALL_COMPILETIME                                        \

--- a/utf8.h
+++ b/utf8.h
@@ -943,7 +943,7 @@ case any call to string overloading updates the internal UTF-8 encoding flag.
  * complicated by the probability of having categories in different locales. */
 #define IN_UNI_8_BIT                                                    \
             ((    (      (CopHINTS_get(PL_curcop) & HINT_UNI_8_BIT))    \
-                   || (   CopHINTS_get(PL_curcop) & HINT_LOCALE_PARTIAL \
+                   || (   CopHINTS_get(PL_curcop) & HINT_LOCALE         \
                             /* -1 below is for :not_characters */       \
                        && _is_in_locale_category(FALSE, -1)))           \
               && (! IN_BYTES))


### PR DESCRIPTION
There are two locale-related hint bits, one for each of the two 'use locale' forms.  This commit combines the bits into one.  There is no slowdown in checking if any of the forms is in effect, but deciding which one is slightly slower.  Most perl code doesn't use either form, so the slight slowdown should be acceptable.

But if there are other free bits available, there isn't any need for this slowdown, however rare.  Commit
4210e234cb45c0ad3ecd56b85152559b52131e16 just gave us the ability to free up 3 other HINTS bits.  Those should be consumed first before using this one.

But this code is already written and isn't trivial, so shouldn't be abandoned without a trace.  I did some research before writing it (and before those three bits became available), and this looked to be the lowest hanging fruit to get another bit, should it become necessary.

My intent is to revert this commit immediately, while adding a comment noting its commit number, so that a future maintainer needing a bit can reinstate it.