### PR TITLE
locale.c: Don't compile thread functions unless threaded

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3533,8 +3533,6 @@ CTop	|void	|sys_term
 Cdp	|void	|taint_env
 Cdp	|void	|taint_proper	|NULLOK const char *f			\
 				|NN const char * const s
-Apx	|void	|thread_locale_init
-Apx	|void	|thread_locale_term
 
 Fpv	|OP *	|tied_method	|NN SV *methname			\
 				|NN SV **mark				\
@@ -6304,6 +6302,10 @@ Tdp	|bool	|quadmath_format_needed 				\
 				|NN const char *format
 Tdp	|bool	|quadmath_format_valid					\
 				|NN const char *format
+#endif
+#if defined(USE_THREADS)
+Apx	|void	|thread_locale_init
+Apx	|void	|thread_locale_term
 #endif
 #if defined(VMS) || defined(WIN32)
 Cp	|int	|do_aspawn	|NULLOK SV *really			\

--- a/embed.h
+++ b/embed.h
@@ -776,8 +776,6 @@
 # define sync_locale()                          Perl_sync_locale(aTHX)
 # define taint_env()                            Perl_taint_env(aTHX)
 # define taint_proper(a,b)                      Perl_taint_proper(aTHX_ a,b)
-# define thread_locale_init()                   Perl_thread_locale_init(aTHX)
-# define thread_locale_term()                   Perl_thread_locale_term(aTHX)
 # define to_uni_lower(a,b,c)                    Perl_to_uni_lower(aTHX_ a,b,c)
 # define to_uni_title(a,b,c)                    Perl_to_uni_title(aTHX_ a,b,c)
 # define to_uni_upper(a,b,c)                    Perl_to_uni_upper(aTHX_ a,b,c)
@@ -2210,6 +2208,10 @@
 #   define PerlIO_unread(a,b,c)                 Perl_PerlIO_unread(aTHX_ a,b,c)
 #   define PerlIO_write(a,b,c)                  Perl_PerlIO_write(aTHX_ a,b,c)
 # endif /* defined(USE_PERLIO) */
+# if defined(USE_THREADS)
+#   define thread_locale_init()                 Perl_thread_locale_init(aTHX)
+#   define thread_locale_term()                 Perl_thread_locale_term(aTHX)
+# endif
 # if defined(VMS) || defined(WIN32)
 #   define do_aspawn(a,b,c)                     Perl_do_aspawn(aTHX_ a,b,c)
 #   define do_spawn(a)                          Perl_do_spawn(aTHX_ a)

--- a/proto.h
+++ b/proto.h
@@ -5062,14 +5062,6 @@ Perl_taint_proper(pTHX_ const char *f, const char * const s);
 #define PERL_ARGS_ASSERT_TAINT_PROPER           \
         assert(s)
 
-PERL_CALLCONV void
-Perl_thread_locale_init(pTHX);
-#define PERL_ARGS_ASSERT_THREAD_LOCALE_INIT
-
-PERL_CALLCONV void
-Perl_thread_locale_term(pTHX);
-#define PERL_ARGS_ASSERT_THREAD_LOCALE_TERM
-
 PERL_CALLCONV OP *
 Perl_tied_method(pTHX_ SV *methname, SV **mark, SV * const sv, const MAGIC * const mg, const U32 flags, U32 argc, ...)
         __attribute__visibility__("hidden");
@@ -10808,6 +10800,16 @@ Perl_quadmath_format_valid(const char *format)
         assert(format)
 
 #endif /* defined(USE_QUADMATH) */
+#if defined(USE_THREADS)
+PERL_CALLCONV void
+Perl_thread_locale_init(pTHX);
+# define PERL_ARGS_ASSERT_THREAD_LOCALE_INIT
+
+PERL_CALLCONV void
+Perl_thread_locale_term(pTHX);
+# define PERL_ARGS_ASSERT_THREAD_LOCALE_TERM
+
+#endif
 #if defined(VMS) || defined(WIN32)
 PERL_CALLCONV int
 Perl_do_aspawn(pTHX_ SV *really, SV **mark, SV **sp);


### PR DESCRIPTION
These functions are called only from threads.xs under USE_THREADS; omit them otherwise.