### PR TITLE
Fix warning in run/locale.t

### DIFF
--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -617,14 +617,15 @@ SKIP: {   # GH #20054
     my @lc_all_locales = find_locales('LC_ALL');
     my $locale = $lc_all_locales[0];
     skip "LC_ALL not enabled on this platform", 1 unless $locale;
-
-    local $ENV{LC_ALL} = "This is not a legal locale name";
-    local $ENV{LANG} = "Nor this neither";
-
     my $fallback = ($^O eq "MSWin32")
                     ? "system default"
                     : "standard";
-    fresh_perl_like("", qr/Falling back to the $fallback locale/,
+    fresh_perl_like(<<~EOT,
+                        local \$ENV{LC_ALL} = "This is not a legal locale name";
+                        local \$ENV{LANG} = "Nor this neither";
+                        system "\$^X -e1";
+                    EOT
+                    qr/Falling back to the $fallback locale/,
                     {}, "check that illegal startup environment falls back");
 }
 


### PR DESCRIPTION
A test in this file checks that garbage in the environment is properly handled.  But some shells (notably bash) warn when LC_ALL is set to a non-existent locale.  This commit avoids using a shell to do the setting up of the environment.

This was spotted by Dave Mitchell who also provided the outlines of the fix.