### PR TITLE
Update perlop.pod to finally say if one can do ... if $x with here-docs

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -2922,6 +2922,9 @@ This will print...
 
 ...with no leading whitespace.
 
+By the way, one must use if(){}. There is no way to
+do "... if $some_var;" with here-docs.
+
 The line containing the delimiter that marks the end of the here-doc
 determines the indentation template for the whole thing.  Compilation
 croaks if any non-empty line inside the here-doc does not begin with the


### PR DESCRIPTION
By the way **I am only guessing** what I wrote is true. It would be wonderful if I were wrong.

Please in that case rewrite my patch, finally documenting how to do it. 

Better yet would be to pull it out of the indebted here-doc example, making a more general example.

In any case, the page needs to finally say, one way or the other, if one can use the ... if $x form with here-docs.