### PR TITLE
avoid ext/XS-APItest/t/clone-with-stack.t crash

### DIFF
--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -4256,6 +4256,11 @@ CODE:
         PL_scopestack_ix = oldscope;
     }
 
+    /* the COP which PL_curcop points to is about to be freed, but might
+     * still be accessed when destructors, END() blocks etc are called.
+     * So point it somewhere safe.
+     */
+    PL_curcop = &PL_compiling;
     perl_destruct(interp_dup);
     perl_free(interp_dup);
 


### PR DESCRIPTION
a fresh_perl() TODO test in this file does something like

    use XS::APItest;
    BEGIN {
        clone_with_stack();
    }
    print "ok\n";

As a standalone program, this code gives errors under valgrind, and in ticket GH #21969 was causing "perl.exe has stopped working" on Windows 8.

The clone_with_stack() XS function is fairly dodgy - it clones the whole interpreter including stacks (i.e. what fork() emulation on windows does), but then continues the RUNOPS loop to completion itself, using the cloned interpreter, rather than relying on the caller to finish the ops loop.

This doesn't work very well under BEGIN (hence why it's a TODO test), but specifically, PL_curcop can be left pointing at an op which gets freed , but then is later accessed anyway.

This commit resets PL_curcop to &PL_compiling to avoid crashes.