### PR TITLE
Forbid subsequent `use VERSION` declarations past the v5.39 boundary

### DIFF
--- a/op.c
+++ b/op.c
@@ -8022,6 +8022,11 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
             /* use VERSION while another use VERSION is in scope
              * This should provoke at least a warning, if not an outright error
              */
+            if (shortver >= SHORTVER(5, 39))
+                croak("use VERSION of 5.39 or above is not permitted while another use VERSION is in scope");
+            if (PL_prevailing_version >= SHORTVER(5, 39))
+                croak("use VERSION is not permitted while another use VERSION of 5.39 or above is in scope");
+
             /* downgrading from >= 5.11 to < 5.11 is now fatal */
             if (PL_prevailing_version >= SHORTVER(5, 11) && shortver < SHORTVER(5, 11))
                 croak("Downgrading a use VERSION declaration to below v5.11 is not permitted");

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -7834,6 +7834,18 @@ in future Perl releases in incompatible ways.  This means that a pattern
 that compiles today may not in a future Perl release.  This warning is
 to alert you to that risk.
 
+=item use VERSION is not permitted while another use VERSION of 5.39 or above is in scope
+
+(F) Once you have a C<use VERSION> declaration that calls for a Perl version
+of at least 5.39, you cannot have a subsequent one while the first is visible,
+even if it requests a later version.
+
+=item use VERSION of 5.39 or above is not permitted while another use VERSION is in scope
+
+(F) Once you have a C<use VERSION> declaration in scope, you cannot have a
+subsequent one that calls for a Perl version of at least 5.39 while the first
+is visible.
+
 =item Use \x{...} for more than two hex characters in regex; marked by
 S<<-- HERE> in m/%s/
 

--- a/t/lib/croak/op
+++ b/t/lib/croak/op
@@ -309,6 +309,18 @@ EXPECT
 Missing comma after first argument to return at - line 2, near "5;"
 Execution of - aborted due to compilation errors.
 ########
+# subsequent use VERSION to 5.39
+use v5.20;
+use v5.39;
+EXPECT
+use VERSION of 5.39 or above is not permitted while another use VERSION is in scope at - line 3.
+########
+# subsequent use VERSION from 5.39
+use v5.39;
+use v5.20;
+EXPECT
+use VERSION is not permitted while another use VERSION of 5.39 or above is in scope at - line 3.
+########
 # use VERSION across the 5.11 boundary
 use 5.012;
 use 5.010;


### PR DESCRIPTION
A `use VERSION` statement of v5.39 or later will imply a `use builtin` version bundle, which may import new lexical functions into the calling scope. If we were to permit a subsequent statement when either is past this boundary, we might have to un-import lexical functions that should no longer be present. The concept of what it even means to un-import a lexical function is not well-defined.

By forbidding such a subsequent version declaration, we can avoid many awkward questions about what it would mean to implement un-import of lexicals.