### PR TITLE
Add some tests of non-ASCII UTF-8 handling of class.c

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5965,6 +5965,7 @@ t/class/inherit.t			See if class inheritance works
 t/class/method.t			See if class method declarations work
 t/class/phasers.t			See if class phaser blocks work
 t/class/threads.t			See if classes work across multiple threads
+t/class/utf8.t				See if class syntax works with non-ASCII UTF-8
 t/cmd/elsif.t				See if else-if works
 t/cmd/for.t				See if for loops work
 t/cmd/mod.t				See if statement modifiers work

--- a/t/class/utf8.t
+++ b/t/class/utf8.t
@@ -1,0 +1,56 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+    require Config;
+}
+
+use v5.36;
+use utf8;
+use feature 'class';
+no warnings 'experimental::class';
+
+# A bunch of test cases with non-ASCII, non-Latin1. Esperanto is good for that
+# as the accented characters are not in Latin1.
+
+STDOUT->binmode( ":encoding(UTF-8)" );
+
+my $manĝis;
+
+class Sandviĉon {
+   method manĝu { $manĝis++ }
+
+   field $tranĉaĵoj :param :reader = undef;
+}
+
+# class name
+{
+   my $s = Sandviĉon->new;
+   isa_ok( $s, "Sandviĉon", '$s' );
+}
+
+# methods
+{
+   my $s = Sandviĉon->new;
+   $s->manĝu;
+   ok( $manĝis, 'UTF-8 method name works' );
+}
+
+# field params + accessors default names
+{
+   my $s = Sandviĉon->new( tranĉaĵoj => 3 );
+   is( $s->tranĉaĵoj, 3, 'Can obtain value from field via accessor' );
+}
+
+class Sandwich {
+   field $slices :param(tranĉaĵoj) :reader(tranĉaĵoj) = undef;
+}
+
+{
+   my $s = Sandwich->new( tranĉaĵoj => 5 );
+   is( $s->tranĉaĵoj, 5, 'Can obtain value from field via accessor with overridden name' );
+}
+
+done_testing;


### PR DESCRIPTION
During some recent reviews of work in `class.c` I had some review comments to ensure that code handled non-ASCII UTF-8 identifiers correctly. Here is a test file that adds a bunch of tests to ensure that behaviour is maintained.