### PR TITLE
locale.c: Use widest int type for parameter

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4443,7 +4443,7 @@ Sf	|bool	|strftime_tm	|NN const char *fmt			\
 				|NN const struct tm *mytm
 # if defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO)
 S	|const char *|emulate_langinfo					\
-				|const int item 			\
+				|const PERL_INTMAX_T item		\
 				|NN const char *locale			\
 				|NN SV *sv				\
 				|NULLOK utf8ness_t *utf8ness

--- a/locale.c
+++ b/locale.c
@@ -6290,8 +6290,8 @@ S_langinfo_sv_i(pTHX_
      * the reentrant uses could infinitely recurse */
 
     DEBUG_Lv(PerlIO_printf(Perl_debug_log,
-                           "Entering langinfo_sv_i item=%ld, using locale %s\n",
-                           (long) item, locale));
+                           "Entering langinfo_sv_i item=%jd, using locale %s\n",
+                           (PERL_INTMAX_T) item, locale));
 
 #  ifdef HAS_MISSING_LANGINFO_ITEM_
 
@@ -6577,7 +6577,7 @@ S_maybe_override_codeset(pTHX_ const char * codeset,
 #if ! defined(HAS_NL_LANGINFO) || defined(HAS_MISSING_LANGINFO_ITEM_)
 
 STATIC const char *
-S_emulate_langinfo(pTHX_ const int item,
+S_emulate_langinfo(pTHX_ const PERL_INTMAX_T item,
                          const char * locale,
                          SV * sv,
                          utf8ness_t * utf8ness)
@@ -6636,8 +6636,8 @@ S_emulate_langinfo(pTHX_ const int item,
     int retval_type = RETVAL_IN_retval;
 
     DEBUG_Lv(PerlIO_printf(Perl_debug_log,
-                        "Entering emulate_langinfo item=%ld, using locale %s\n",
-                        (long) item, locale));
+                        "Entering emulate_langinfo item=%jd, using locale %s\n",
+                        item, locale));
 
 #  if   defined(HAS_LOCALECONV)                                         \
    && ! defined(HAS_SOME_LANGINFO)                                      \
@@ -7117,8 +7117,8 @@ S_emulate_langinfo(pTHX_ const int item,
              * invalid. */;
 #  if defined(I_LANGINFO)
 
-            Perl_croak_nocontext("panic: Unexpected nl_langinfo() item %ld",
-                                 (long) item);
+            Perl_croak_nocontext("panic: Unexpected nl_langinfo() item %jd",
+                                 item);
 
 #  else
             assert(item < 0);   /* Make sure using perl_langinfo.h */
@@ -7581,8 +7581,8 @@ S_emulate_langinfo(pTHX_ const int item,
         }
 
         DEBUG_Lv(PerlIO_printf(Perl_debug_log,
-                         "Leaving emulate_langinfo item=%ld, using locale %s\n",
-                         (long) item, locale));
+                         "Leaving emulate_langinfo item=%jd, using locale %s\n",
+                         item, locale));
 
         /* The caller shouldn't also be wanting a 'retval'; make sure segfaults
          * if they call this wrong */
@@ -7601,8 +7601,8 @@ S_emulate_langinfo(pTHX_ const int item,
     }
 
     DEBUG_Lv(PerlIO_printf(Perl_debug_log,
-                         "Leaving emulate_langinfo item=%ld, using locale %s\n",
-                         (long) item, locale));
+                         "Leaving emulate_langinfo item=%jd, using locale %s\n",
+                         item, locale));
     return retval;
 
 #  undef RETVAL_IN_retval

--- a/proto.h
+++ b/proto.h
@@ -7046,7 +7046,7 @@ S_strftime_tm(pTHX_ const char *fmt, SV *sv, const struct tm *mytm)
 
 # if defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO)
 STATIC const char *
-S_emulate_langinfo(pTHX_ const int item, const char *locale, SV *sv, utf8ness_t *utf8ness);
+S_emulate_langinfo(pTHX_ const PERL_INTMAX_T item, const char *locale, SV *sv, utf8ness_t *utf8ness);
 #   define PERL_ARGS_ASSERT_EMULATE_LANGINFO    \
         assert(locale); assert(sv)
 


### PR DESCRIPTION
nl_langinfo() is a libc function, specified by POSIX, that returns information about some particular element of a locale.  Which element is desired is passed to nl_langinfo() via a parameter with a typedef of 'nl_item'.  What that typedef actually is is opaque to perl.  On my Linux glibc, it is an 'int', but it could just as easily be an enum. POSIX lists all the elements that nl_langinfo() should handle, but some platforms have extensions beyond those.  Perl aims to handle any somewhat prominent such extension, which means it needs fallbacks if the particular item isn't available on a given platform.

emulate_langinfo() is used to handle such fallbacks.  If an element isn't available on a platform, perl has to create an element number that doesn't clash with any nl_item one.  perl also has to cope with platforms that don't have nl_langinfo() at all (Win32 is one).  In this case it has to create an 'nl_item' typedef.  We use 'int'.

So emulate_langinfo() has to be able to handle an 'int' or whatever the system specifies an nl_item may be.  This could be a 'long' or a 'long long'.  The only way to do that is to make the parameter as wide as the the platform permits.  That is what this commit does.

This commit also casts the item to the widest possible value with corresponding %j format for display in a Debug statement in the sv_langinfo_i() function.