### PR TITLE
locale.c: Special case  LC_ADDRESS country number in C locale

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -6371,6 +6371,13 @@ S_langinfo_sv_i(pTHX_
 
       case _NL_ADDRESS_COUNTRY_NUM:
 
+        /* Some glibc's return random values for this item and locale;
+         * workaround by special casing it. */
+        if (isNAME_C_OR_POSIX(locale)) {
+            sv_setuv(sv, 0);
+            goto non_string_common;
+        }
+
         /* FALLTHROUGH */
 
 #    endif


### PR DESCRIPTION
Some glibc implementations are returning random garbage for this in the C locale.  The country number is known to be 0 for that locale, so just use that and avoid calling glibc.