### PR TITLE
Yves/fix static build regex engine

### DIFF
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -1591,11 +1591,20 @@ test_prep test-prep: test_prep_pre \$(MINIPERL_EXE) \$(unidatafiles) \$(PERL_EXE
 ;;
 esac
 
+if test "$dlext" = "none"; then
+# this is a static build so we do NOT need to make_ext.pl for the re extension.
+$spitshell >>$Makefile <<'!NO!SUBS!'
+test_prep_reonly: $(MINIPERL_EXE) $(PERL_EXE) $(TEST_PERL_DLL)
+	cd t && (rm -f $(PERL_EXE); $(LNS) ../$(PERL_EXE) $(PERL_EXE))
+!NO!SUBS!
+else
+# this is a dynamic build so we DO need to make_ext.pl for the re extension.
 $spitshell >>$Makefile <<'!NO!SUBS!'
 test_prep_reonly: $(MINIPERL_EXE) $(PERL_EXE) $(dynamic_ext_re) $(TEST_PERL_DLL)
 	$(MINIPERL) make_ext.pl $(dynamic_ext_re) MAKE="$(MAKE)" LIBPERL_A=$(LIBPERL) LINKTYPE=dynamic
 	cd t && (rm -f $(PERL_EXE); $(LNS) ../$(PERL_EXE) $(PERL_EXE))
 !NO!SUBS!
+fi
 
 case "$targethost" in
 '') $spitshell >>$Makefile <<'!NO!SUBS!'

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -155,14 +155,6 @@ struct RExC_state_t {
     AV         *warn_text;
     HV         *unlexed_names;
     SV          *runtime_code_qr;       /* qr with the runtime code blocks */
-#ifdef DEBUGGING
-    const char  *lastparse;
-    I32         lastnum;
-    U32         study_chunk_recursed_count;
-    AV          *paren_name_list;       /* idx -> name */
-    SV          *mysv1;
-    SV          *mysv2;
-#endif
     bool        seen_d_op;
     bool        strict;
     bool        study_started;
@@ -170,6 +162,22 @@ struct RExC_state_t {
     bool        use_BRANCHJ;
     bool        sWARN_EXPERIMENTAL__VLB;
     bool        sWARN_EXPERIMENTAL__REGEX_SETS;
+    /* DEBUGGING only fields, keep these LAST so that we do not
+     * have any weirdness with static builds.
+     *
+     * We include these if we are building a DEBUGGING perl OR if we
+     * are not using dynamic linking (USE_DYNAMIC_LOADING).
+     *
+     * See GH Issue #21558 and also ba6e2c38aafc23cf114f3ba0d0ff3baead34328b
+     */
+#if defined(DEBUGGING) || !defined(USE_DYNAMIC_LOADING)
+    const char  *lastparse;
+    I32         lastnum;
+    U32         study_chunk_recursed_count;
+    AV          *paren_name_list;       /* idx -> name */
+    SV          *mysv1;
+    SV          *mysv2;
+#endif
 };
 
 #ifdef DEBUGGING


### PR DESCRIPTION
This fixes build issues in the regex engine with -Uusedl. It fixes make test_reonly in this build mode, and it fixes the issues reported in Issue #21558 regarding reg_mesg.t failing under -Uusedl. 

@tonycoz this should do it I think.