### PR TITLE
Simplify `use VERSION` behaviour with respect to imported builtins

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -636,7 +636,7 @@ static bool S_cv_is_builtin(pTHX_ CV *cv)
 }
 
 void
-Perl_import_builtin_bundle(pTHX_ U16 ver, bool do_unimport)
+Perl_import_builtin_bundle(pTHX_ U16 ver)
 {
     SV *ampname = sv_newmortal();
 
@@ -655,9 +655,6 @@ Perl_import_builtin_bundle(pTHX_ U16 ver, bool do_unimport)
 
         if(!got && want) {
             import_sym(newSVpvn_flags(builtins[i].name, strlen(builtins[i].name), SVs_TEMP));
-        }
-        else if(do_unimport && got && !want) {
-            pad_add_name_sv(ampname, padadd_STATE|padadd_TOMBSTONE, 0, 0);
         }
     }
 }
@@ -693,7 +690,7 @@ XS(XS_builtin_import)
                 Perl_croak(aTHX_ "Builtin version bundle \"%s\" is not supported by Perl " PERL_VERSION_STRING,
                         sympv);
 
-            import_builtin_bundle(want_ver, false);
+            import_builtin_bundle(want_ver);
 
             continue;
         }

--- a/embed.fnc
+++ b/embed.fnc
@@ -4078,8 +4078,7 @@ S	|MAGIC *|get_aux_mg	|NN AV *av
 #if defined(PERL_IN_BUILTIN_C) || defined(PERL_IN_OP_C)
 p	|void	|finish_export_lexical
 p	|void	|import_builtin_bundle					\
-				|U16 ver				\
-				|bool do_unimport
+				|U16 ver
 p	|void	|prepare_export_lexical
 #endif
 #if defined(PERL_IN_CLASS_C) || defined(PERL_IN_OP_C)    || \

--- a/embed.h
+++ b/embed.h
@@ -1202,7 +1202,7 @@
 #   endif
 #   if defined(PERL_IN_BUILTIN_C) || defined(PERL_IN_OP_C)
 #     define finish_export_lexical()            Perl_finish_export_lexical(aTHX)
-#     define import_builtin_bundle(a,b)         Perl_import_builtin_bundle(aTHX_ a,b)
+#     define import_builtin_bundle(a)           Perl_import_builtin_bundle(aTHX_ a)
 #     define prepare_export_lexical()           Perl_prepare_export_lexical(aTHX)
 #   endif
 #   if defined(PERL_IN_CLASS_C) || defined(PERL_IN_GLOBALS_C) || \

--- a/op.c
+++ b/op.c
@@ -8062,7 +8062,7 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
          */
         if ((shortver >= SHORTVER(5, 39)) || (PL_prevailing_version >= SHORTVER(5, 39))) {
             prepare_export_lexical();
-            import_builtin_bundle(shortver, false);
+            import_builtin_bundle(shortver);
             finish_export_lexical();
         }
 

--- a/op.c
+++ b/op.c
@@ -8062,7 +8062,7 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
          */
         if ((shortver >= SHORTVER(5, 39)) || (PL_prevailing_version >= SHORTVER(5, 39))) {
             prepare_export_lexical();
-            import_builtin_bundle(shortver, true);
+            import_builtin_bundle(shortver, false);
             finish_export_lexical();
         }
 

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -10170,10 +10170,15 @@ If the specified Perl version is 5.39.0 or higher, builtin functions are
 imported lexically as with L<C<use builtin>|builtin> with a corresponding
 version bundle.
 
-Later use of C<use VERSION> will override all behavior of a previous
-C<use VERSION>, possibly removing the C<strict>, C<warnings>, C<feature> and
-C<builtin> effects added by it.  C<use VERSION> does not load the
-F<feature.pm>, F<strict.pm>, F<warnings.pm> or F<builtin.pm> files.
+Later use of C<use VERSION> will override most behavior of a previous
+C<use VERSION>, possibly removing the C<strict>, C<warnings> and C<feature>
+effects added by it.  Because C<builtin> functions are created as lexical
+subroutines in the current scope, it is not possible to remove those again
+and therefore a C<use VERSION> will I<not> remove any that happen to be
+visible but would not have been imported by it.
+
+C<use VERSION> does not load the F<feature.pm>, F<strict.pm>, F<warnings.pm>
+or F<builtin.pm> files.
 
 In the current implementation, any explicit use of C<use strict> or
 C<no strict> overrides C<use VERSION>, even if it comes before it.

--- a/proto.h
+++ b/proto.h
@@ -6213,7 +6213,7 @@ Perl_finish_export_lexical(pTHX)
 # define PERL_ARGS_ASSERT_FINISH_EXPORT_LEXICAL
 
 PERL_CALLCONV void
-Perl_import_builtin_bundle(pTHX_ U16 ver, bool do_unimport)
+Perl_import_builtin_bundle(pTHX_ U16 ver)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_IMPORT_BUILTIN_BUNDLE
 

--- a/t/comp/use.t
+++ b/t/comp/use.t
@@ -6,7 +6,7 @@ BEGIN {
     $INC{"feature.pm"} = 1; # so we don't attempt to load feature.pm
 }
 
-print "1..85\n";
+print "1..87\n";
 
 # Can't require test.pl, as we're testing the use/require mechanism here.
 
@@ -168,6 +168,14 @@ ok $@, 'no strict vars allows ver decl to enable subs';
 
     $result = eval 'use 5.39.0; my $t = true; $t eq "1"';
     is ($@, "", 'builtin funcs available after use 5.39.0');
+    ok ($result, 'imported true is eq "1"');
+}
+
+{
+    my $result;
+
+    $result = eval 'use builtin "true"; use v5.36; my $t = true; $t eq "1"';
+    is ($@, "", 'builtin funcs not removed after use v5.36');
     ok ($result, 'imported true is eq "1"');
 }
 


### PR DESCRIPTION
Having `use VERSION` attempt to unimport builtin functions has proven to be an overly-complex and terrible design, which lead to the "tombstone" pad idea.

We've subsequently decided that was a mistake and wish to remove it. This is the first step of doing so. As it was only recently added in a development version and has not been in any stable release, there's no need to deprecate or warn about it - we can simply remove it.