### PR TITLE
class.c: Don't put OP_NEXSTATE before OP_METHSTART

### DIFF
--- a/class.c
+++ b/class.c
@@ -1018,7 +1018,6 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
     }
 
     OP *ops = newLISTOPn(OP_LINESEQ, 0,
-            newSTATEOP(0, NULL, NULL),
             methstartop,
             argcheckop,
             retop,


### PR DESCRIPTION
Generated :reader methods should not put an OP_NEXTSTATE before OP_METHSTART.

It doesn't show up in tests here, but it will confuse `B::Deparse`'s attempts to find the OP_METHSTART, as regular `method foo () { ... }` will not have such a thing there.