### PR TITLE
add OPpCONST_LINE flag to aid deparsing

### DIFF
--- a/Porting/deparse-skips.txt
+++ b/Porting/deparse-skips.txt
@@ -54,7 +54,6 @@ mro/complex_c3_utf8.t
 mro/isarev.t
 mro/isarev_utf8.t
 op/attrhand.t             # Custom attrs ignored; also AH provides none
-op/caller.t
 op/goto.t
 op/gv.t                   # glob copy constants
 op/index.t
@@ -230,8 +229,20 @@ uni/variables.t
 ../cpan/Test-Simple/t/regression/684-nested_todo_diag.t
 ../cpan/Test-Simple/t/Test2/behavior/run_subtest_inherit.t
 
-# these three use __LINE__, which gets deparsed as a number rather than
-# __LINE__.
+# These three are very sensitive to line numbers, and in particular
+# to wrong line numbers being output for the closing braces of a function,
+# e.g.
+#
+#    sub foo { .... } # all on line 30
+#
+# becomes
+#
+#    #line 30 ....
+#    sub foo {
+#        ...
+#    #line 10 ....
+#    }
+#
 ../cpan/Test2-Suite/t/behavior/filtering.t
 ../cpan/Test2-Suite/t/modules/Tools/Compare.t
 ../cpan/Test2-Suite/t/modules/Tools/Subtest.t

--- a/lib/B/Deparse.pm
+++ b/lib/B/Deparse.pm
@@ -7,7 +7,7 @@
 # This is based on the module of the same name by Malcolm Beattie,
 # but essentially none of his code remains.
 
-package B::Deparse 1.74;
+package B::Deparse 1.75;
 use strict;
 use Carp;
 use B qw(class main_root main_start main_cv svref_2object opnumber perlstring
@@ -15,6 +15,8 @@ use B qw(class main_root main_start main_cv svref_2object opnumber perlstring
 	 OPf_KIDS OPf_REF OPf_STACKED OPf_SPECIAL OPf_MOD OPf_PARENS
 	 OPpLVAL_INTRO OPpOUR_INTRO OPpENTERSUB_AMPER OPpSLICE OPpKVSLICE
          OPpCONST_BARE OPpEMPTYAVHV_IS_HV
+         OPpCONST_TOKEN_MASK
+         OPpCONST_TOKEN_LINE OPpCONST_TOKEN_FILE OPpCONST_TOKEN_PACKAGE
 	 OPpTRANS_SQUASH OPpTRANS_DELETE OPpTRANS_COMPLEMENT OPpTARGET_MY
 	 OPpEXISTS_SUB OPpSORT_NUMERIC OPpSORT_INTEGER OPpREPEAT_DOLIST
 	 OPpSORT_REVERSE OPpMULTIDEREF_EXISTS OPpMULTIDEREF_DELETE
@@ -5721,6 +5723,20 @@ sub pp_const {
 #	return $self->const_sv($op)->PV;
 #    }
     my $sv = $self->const_sv($op);
+
+    my $token = ($op->private & OPpCONST_TOKEN_MASK);
+    if ($token) { # handle __LINE__ etc
+        if ($token == OPpCONST_TOKEN_LINE) {
+            return "__LINE__";
+        }
+        elsif ($token == OPpCONST_TOKEN_FILE) {
+            return "__FILE__";
+        }
+        elsif ($token == OPpCONST_TOKEN_PACKAGE) {
+            return "__PACKAGE__";
+        }
+    }
+
     return $self->const($sv, $cx);
 }
 

--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -3391,3 +3391,8 @@ $x = (return 'ok');
 $x //= (return 'ok');
 $x = exit 42;
 $x //= exit 42;
+####
+# preserve __LINE__ etc
+my $x = __LINE__;
+my $y = __FILE__;
+my $z = __PACKAGE__;

--- a/lib/B/Op_private.pm
+++ b/lib/B/Op_private.pm
@@ -245,6 +245,20 @@ my @bf = (
             3, 'OPpLVREF_CV', 'CV',
         ],
     },
+    {
+        label     => 'TOKEN',
+        mask_def  => 'OPpCONST_TOKEN_MASK',
+        baseshift_def => 'OPpCONST_TOKEN_SHIFT',
+        bitcount_def => 'OPpCONST_TOKEN_BITS',
+        bitmin    => 6,
+        bitmax    => 7,
+        bitmask   => 192,
+        enum      => [
+            1, 'OPpCONST_TOKEN_LINE', 'LINE',
+            2, 'OPpCONST_TOKEN_FILE', 'FILE',
+            3, 'OPpCONST_TOKEN_PACKAGE', 'PACKAGE',
+        ],
+    },
 );
 
 @{$bits{aassign}}{6,5,4,2,1,0} = ('OPpASSIGN_COMMON_SCALAR', 'OPpASSIGN_COMMON_RC1', 'OPpASSIGN_COMMON_AGG', 'OPpASSIGN_TRUEBOOL', $bf[1], $bf[1]);
@@ -292,7 +306,7 @@ $bits{cmpchain_dup}{0} = $bf[0];
 @{$bits{concat}}{6,1,0} = ('OPpCONCAT_NESTED', $bf[1], $bf[1]);
 $bits{cond_expr}{0} = $bf[0];
 @{$bits{connect}}{3,2,1,0} = ($bf[4], $bf[4], $bf[4], $bf[4]);
-@{$bits{const}}{6,4,3,2,1} = ('OPpCONST_BARE', 'OPpCONST_ENTERED', 'OPpCONST_STRICT', 'OPpCONST_SHORTCIRCUIT', 'OPpCONST_NOVER');
+@{$bits{const}}{7,6,5,4,3,2,1} = ($bf[10], $bf[10], 'OPpCONST_BARE', 'OPpCONST_ENTERED', 'OPpCONST_STRICT', 'OPpCONST_SHORTCIRCUIT', 'OPpCONST_NOVER');
 @{$bits{coreargs}}{7,6,1,0} = ('OPpCOREARGS_PUSHMARK', 'OPpCOREARGS_SCALARMOD', 'OPpCOREARGS_DEREF2', 'OPpCOREARGS_DEREF1');
 $bits{cos}{0} = $bf[0];
 @{$bits{crypt}}{3,2,1,0} = ($bf[4], $bf[4], $bf[4], $bf[4]);
@@ -614,11 +628,17 @@ our %defines = (
     OPpASSIGN_TRUEBOOL       =>   4,
     OPpAVHVSWITCH_MASK       =>   3,
     OPpCONCAT_NESTED         =>  64,
-    OPpCONST_BARE            =>  64,
+    OPpCONST_BARE            =>  32,
     OPpCONST_ENTERED         =>  16,
     OPpCONST_NOVER           =>   2,
     OPpCONST_SHORTCIRCUIT    =>   4,
     OPpCONST_STRICT          =>   8,
+    OPpCONST_TOKEN_BITS      =>   2,
+    OPpCONST_TOKEN_FILE      => 128,
+    OPpCONST_TOKEN_LINE      =>  64,
+    OPpCONST_TOKEN_MASK      => 192,
+    OPpCONST_TOKEN_PACKAGE   => 192,
+    OPpCONST_TOKEN_SHIFT     =>   6,
     OPpCOREARGS_DEREF1       =>   1,
     OPpCOREARGS_DEREF2       =>   2,
     OPpCOREARGS_PUSHMARK     => 128,
@@ -736,6 +756,9 @@ our %labels = (
     OPpCONST_NOVER           => 'NOVER',
     OPpCONST_SHORTCIRCUIT    => 'SHORT',
     OPpCONST_STRICT          => 'STRICT',
+    OPpCONST_TOKEN_FILE      => 'FILE',
+    OPpCONST_TOKEN_LINE      => 'LINE',
+    OPpCONST_TOKEN_PACKAGE   => 'PACKAGE',
     OPpCOREARGS_DEREF1       => 'DEREF1',
     OPpCOREARGS_DEREF2       => 'DEREF2',
     OPpCOREARGS_PUSHMARK     => 'MARK',

--- a/opcode.h
+++ b/opcode.h
@@ -2292,6 +2292,7 @@ END_EXTERN_C
 #define OPpTRANS_CAN_FORCE_UTF8 0x01
 #define OPpARGELEM_AV           0x02
 #define OPpCONST_NOVER          0x02
+#define OPpCONST_TOKEN_BITS     0x02
 #define OPpCOREARGS_DEREF2      0x02
 #define OPpEVAL_HAS_HH          0x02
 #define OPpFT_ACCESS            0x02
@@ -2318,6 +2319,7 @@ END_EXTERN_C
 #define OPpTRANS_IDENTICAL      0x04
 #define OPpUSEINT               0x04
 #define OPpARGELEM_MASK         0x06
+#define OPpCONST_TOKEN_SHIFT    0x06
 #define OPpARG3_MASK            0x07
 #define OPpPADRANGE_COUNTSHIFT  0x07
 #define OPpCONST_STRICT         0x08
@@ -2347,6 +2349,7 @@ END_EXTERN_C
 #define OPpSUBSTR_REPL_FIRST    0x10
 #define OPpTARGET_MY            0x10
 #define OPpASSIGN_COMMON_RC1    0x20
+#define OPpCONST_BARE           0x20
 #define OPpDEREF_HV             0x20
 #define OPpEARLY_CV             0x20
 #define OPpEMPTYAVHV_IS_HV      0x20
@@ -2370,7 +2373,7 @@ END_EXTERN_C
 #define OPpASSIGN_BACKWARDS     0x40
 #define OPpASSIGN_COMMON_SCALAR 0x40
 #define OPpCONCAT_NESTED        0x40
-#define OPpCONST_BARE           0x40
+#define OPpCONST_TOKEN_LINE     0x40
 #define OPpCOREARGS_SCALARMOD   0x40
 #define OPpENTERSUB_DB          0x40
 #define OPpEVAL_EVALSV          0x40
@@ -2390,6 +2393,7 @@ END_EXTERN_C
 #define OPpPADRANGE_COUNTMASK   0x7f
 #define OPpARG_IF_UNDEF         0x80
 #define OPpASSIGN_CV_TO_GV      0x80
+#define OPpCONST_TOKEN_FILE     0x80
 #define OPpCOREARGS_PUSHMARK    0x80
 #define OPpDEFER_FINALLY        0x80
 #define OPpENTERSUB_NOPAREN     0x80
@@ -2401,6 +2405,8 @@ END_EXTERN_C
 #define OPpOPEN_OUT_CRLF        0x80
 #define OPpPV_IS_UTF8           0x80
 #define OPpTRANS_DELETE         0x80
+#define OPpCONST_TOKEN_MASK     0xc0
+#define OPpCONST_TOKEN_PACKAGE  0xc0
 START_EXTERN_C
 
 #ifndef DOINIT
@@ -2461,6 +2467,7 @@ EXTCONST char PL_op_private_labels[] = {
     'E','V','A','L','S','V','\0',
     'E','X','I','S','T','S','\0',
     'F','A','K','E','\0',
+    'F','I','L','E','\0',
     'F','I','N','A','L','L','Y','\0',
     'F','T','A','C','C','E','S','S','\0',
     'F','T','A','F','T','E','R','t','\0',
@@ -2488,6 +2495,7 @@ EXTCONST char PL_op_private_labels[] = {
     'K','E','Y','S','\0',
     'K','V','S','L','I','C','E','\0',
     'L','E','X','\0',
+    'L','I','N','E','\0',
     'L','I','N','E','N','U','M','\0',
     'L','V','\0',
     'L','V','D','E','F','E','R','\0',
@@ -2504,6 +2512,7 @@ EXTCONST char PL_op_private_labels[] = {
     'O','U','R','I','N','T','R','\0',
     'O','U','T','B','I','N','\0',
     'O','U','T','C','R','\0',
+    'P','A','C','K','A','G','E','\0',
     'R','E','F','C','\0',
     'R','E','P','A','R','S','E','\0',
     'R','E','P','L','1','S','T','\0',
@@ -2520,6 +2529,7 @@ EXTCONST char PL_op_private_labels[] = {
     'S','V','\0',
     'T','A','R','G','\0',
     'T','A','R','G','M','Y','\0',
+    'T','O','K','E','N','\0',
     'U','N','I','\0',
     'U','S','E','I','N','T','\0',
     'U','S','E','_','S','V','O','P','\0',
@@ -2545,14 +2555,15 @@ EXTCONST char PL_op_private_labels[] = {
 EXTCONST I16 PL_op_private_bitfields[] = {
     0, 8, -1,
     0, 8, -1,
-    0, 690, -1,
+    0, 714, -1,
     0, 8, -1,
     0, 8, -1,
-    0, 697, -1,
-    0, 686, -1,
-    1, -1, 0, 647, 1, 39, 2, 319, -1,
+    0, 721, -1,
+    0, 710, -1,
+    1, -1, 0, 665, 1, 39, 2, 324, -1,
     4, -1, 1, 185, 2, 192, 3, 199, -1,
-    4, -1, 0, 647, 1, 39, 2, 319, 3, 131, -1,
+    4, -1, 0, 665, 1, 39, 2, 324, 3, 131, -1,
+    6, 680, 1, 455, 2, 246, 3, 567, -1,
 
 };
 
@@ -2567,26 +2578,26 @@ EXTCONST I16  PL_op_private_bitdef_ix[] = {
        1, /* pushmark */
        3, /* wantarray */
        4, /* const */
-       9, /* gvsv */
-      11, /* gv */
-      12, /* gelem */
-      13, /* padsv */
-      16, /* padsv_store */
-      19, /* padav */
-      24, /* padhv */
+      10, /* gvsv */
+      12, /* gv */
+      13, /* gelem */
+      14, /* padsv */
+      17, /* padsv_store */
+      20, /* padav */
+      25, /* padhv */
       -1, /* padany */
-      31, /* rv2gv */
-      38, /* rv2sv */
-      43, /* av2arylen */
-      45, /* rv2cv */
+      32, /* rv2gv */
+      39, /* rv2sv */
+      44, /* av2arylen */
+      46, /* rv2cv */
       -1, /* anoncode */
        0, /* prototype */
        0, /* refgen */
        0, /* srefgen */
-      52, /* ref */
-      55, /* bless */
-      56, /* backtick */
-      55, /* glob */
+      53, /* ref */
+      56, /* bless */
+      57, /* backtick */
+      56, /* glob */
        0, /* readline */
       -1, /* rcatline */
        0, /* regcmaybe */
@@ -2594,20 +2605,20 @@ EXTCONST I16  PL_op_private_bitdef_ix[] = {
        0, /* regcomp */
       -1, /* match */
       -1, /* qr */
-      61, /* subst */
+      62, /* subst */
        0, /* substcont */
-      62, /* trans */
-      62, /* transr */
-      69, /* sassign */
-      72, /* aassign */
+      63, /* trans */
+      63, /* transr */
+      70, /* sassign */
+      73, /* aassign */
        0, /* chop */
        0, /* schop */
-      78, /* chomp */
-      78, /* schomp */
+      79, /* chomp */
+      79, /* schomp */
        0, /* defined */
-      80, /* undef */
+      81, /* undef */
        0, /* study */
-      85, /* pos */
+      86, /* pos */
        0, /* preinc */
        0, /* i_preinc */
        0, /* predec */
@@ -2616,314 +2627,314 @@ EXTCONST I16  PL_op_private_bitdef_ix[] = {
        0, /* i_postinc */
        0, /* postdec */
        0, /* i_postdec */
-      88, /* pow */
-      88, /* multiply */
-      88, /* i_multiply */
-      88, /* divide */
-      88, /* i_divide */
-      88, /* modulo */
-      88, /* i_modulo */
-      90, /* repeat */
-      88, /* add */
-      88, /* i_add */
-      88, /* subtract */
-      88, /* i_subtract */
-      92, /* concat */
-      95, /* multiconcat */
-     101, /* stringify */
-     103, /* left_shift */
-     103, /* right_shift */
-      12, /* lt */
-      12, /* i_lt */
-      12, /* gt */
-      12, /* i_gt */
-      12, /* le */
-      12, /* i_le */
-      12, /* ge */
-      12, /* i_ge */
-      12, /* eq */
-      12, /* i_eq */
-      12, /* ne */
-      12, /* i_ne */
-      12, /* ncmp */
-      12, /* i_ncmp */
-      12, /* slt */
-      12, /* sgt */
-      12, /* sle */
-      12, /* sge */
-      12, /* seq */
-      12, /* sne */
-      12, /* scmp */
-     105, /* bit_and */
-     105, /* bit_xor */
-     105, /* bit_or */
-     103, /* nbit_and */
-     103, /* nbit_xor */
-     103, /* nbit_or */
-     105, /* sbit_and */
-     105, /* sbit_xor */
-     105, /* sbit_or */
-      78, /* negate */
-      78, /* i_negate */
+      89, /* pow */
+      89, /* multiply */
+      89, /* i_multiply */
+      89, /* divide */
+      89, /* i_divide */
+      89, /* modulo */
+      89, /* i_modulo */
+      91, /* repeat */
+      89, /* add */
+      89, /* i_add */
+      89, /* subtract */
+      89, /* i_subtract */
+      93, /* concat */
+      96, /* multiconcat */
+     102, /* stringify */
+     104, /* left_shift */
+     104, /* right_shift */
+      13, /* lt */
+      13, /* i_lt */
+      13, /* gt */
+      13, /* i_gt */
+      13, /* le */
+      13, /* i_le */
+      13, /* ge */
+      13, /* i_ge */
+      13, /* eq */
+      13, /* i_eq */
+      13, /* ne */
+      13, /* i_ne */
+      13, /* ncmp */
+      13, /* i_ncmp */
+      13, /* slt */
+      13, /* sgt */
+      13, /* sle */
+      13, /* sge */
+      13, /* seq */
+      13, /* sne */
+      13, /* scmp */
+     106, /* bit_and */
+     106, /* bit_xor */
+     106, /* bit_or */
+     104, /* nbit_and */
+     104, /* nbit_xor */
+     104, /* nbit_or */
+     106, /* sbit_and */
+     106, /* sbit_xor */
+     106, /* sbit_or */
+      79, /* negate */
+      79, /* i_negate */
        0, /* not */
-     105, /* complement */
-     103, /* ncomplement */
-      78, /* scomplement */
-      12, /* smartmatch */
-     101, /* atan2 */
-      78, /* sin */
-      78, /* cos */
-     101, /* rand */
-     101, /* srand */
-      78, /* exp */
-      78, /* log */
-      78, /* sqrt */
-      78, /* int */
-      78, /* hex */
-      78, /* oct */
-      78, /* abs */
-     106, /* length */
-     109, /* substr */
-     112, /* vec */
-     114, /* index */
-     114, /* rindex */
-      55, /* sprintf */
-      55, /* formline */
-      78, /* ord */
-      78, /* chr */
-     101, /* crypt */
+     106, /* complement */
+     104, /* ncomplement */
+      79, /* scomplement */
+      13, /* smartmatch */
+     102, /* atan2 */
+      79, /* sin */
+      79, /* cos */
+     102, /* rand */
+     102, /* srand */
+      79, /* exp */
+      79, /* log */
+      79, /* sqrt */
+      79, /* int */
+      79, /* hex */
+      79, /* oct */
+      79, /* abs */
+     107, /* length */
+     110, /* substr */
+     113, /* vec */
+     115, /* index */
+     115, /* rindex */
+      56, /* sprintf */
+      56, /* formline */
+      79, /* ord */
+      79, /* chr */
+     102, /* crypt */
        0, /* ucfirst */
        0, /* lcfirst */
        0, /* uc */
        0, /* lc */
        0, /* quotemeta */
-     118, /* rv2av */
-     125, /* aelemfast */
-     125, /* aelemfast_lex */
-     125, /* aelemfastlex_store */
-     126, /* aelem */
-     131, /* aslice */
-     134, /* kvaslice */
+     119, /* rv2av */
+     126, /* aelemfast */
+     126, /* aelemfast_lex */
+     126, /* aelemfastlex_store */
+     127, /* aelem */
+     132, /* aslice */
+     135, /* kvaslice */
        0, /* aeach */
        0, /* avalues */
-      43, /* akeys */
+      44, /* akeys */
        0, /* each */
-      43, /* values */
-      43, /* keys */
-     135, /* delete */
-     139, /* exists */
-     141, /* rv2hv */
-     126, /* helem */
-     131, /* hslice */
-     134, /* kvhslice */
-     149, /* multideref */
-      55, /* unpack */
-      55, /* pack */
-     156, /* split */
-      55, /* join */
-     161, /* list */
-      12, /* lslice */
-      55, /* anonlist */
-      55, /* anonhash */
-     163, /* emptyavhv */
-      55, /* splice */
-     101, /* push */
+      44, /* values */
+      44, /* keys */
+     136, /* delete */
+     140, /* exists */
+     142, /* rv2hv */
+     127, /* helem */
+     132, /* hslice */
+     135, /* kvhslice */
+     150, /* multideref */
+      56, /* unpack */
+      56, /* pack */
+     157, /* split */
+      56, /* join */
+     162, /* list */
+      13, /* lslice */
+      56, /* anonlist */
+      56, /* anonhash */
+     164, /* emptyavhv */
+      56, /* splice */
+     102, /* push */
        0, /* pop */
        0, /* shift */
-     101, /* unshift */
-     168, /* sort */
-     173, /* reverse */
+     102, /* unshift */
+     169, /* sort */
+     174, /* reverse */
        0, /* grepstart */
-     175, /* grepwhile */
+     176, /* grepwhile */
        0, /* mapstart */
        0, /* mapwhile */
        0, /* range */
-     177, /* flip */
-     177, /* flop */
+     178, /* flip */
+     178, /* flop */
        0, /* and */
        0, /* or */
-      12, /* xor */
+      13, /* xor */
        0, /* dor */
-     179, /* cond_expr */
+     180, /* cond_expr */
        0, /* andassign */
        0, /* orassign */
        0, /* dorassign */
-     181, /* entersub */
-     188, /* leavesub */
-     188, /* leavesublv */
+     182, /* entersub */
+     189, /* leavesub */
+     189, /* leavesublv */
        0, /* argcheck */
-     190, /* argelem */
-     192, /* argdefelem */
-     195, /* caller */
-      55, /* warn */
-      55, /* die */
-      55, /* reset */
+     191, /* argelem */
+     193, /* argdefelem */
+     196, /* caller */
+      56, /* warn */
+      56, /* die */
+      56, /* reset */
       -1, /* lineseq */
-     197, /* nextstate */
-     197, /* dbstate */
+     198, /* nextstate */
+     198, /* dbstate */
       -1, /* unstack */
       -1, /* enter */
-     198, /* leave */
+     199, /* leave */
       -1, /* scope */
-     200, /* enteriter */
-     204, /* iter */
+     201, /* enteriter */
+     205, /* iter */
       -1, /* enterloop */
-     205, /* leaveloop */
+     206, /* leaveloop */
       -1, /* return */
-     207, /* last */
-     207, /* next */
-     207, /* redo */
-     207, /* dump */
-     207, /* goto */
-      55, /* exit */
-     209, /* method */
-     209, /* method_named */
-     209, /* method_super */
-     209, /* method_redir */
-     209, /* method_redir_super */
+     208, /* last */
+     208, /* next */
+     208, /* redo */
+     208, /* dump */
+     208, /* goto */
+      56, /* exit */
+     210, /* method */
+     210, /* method_named */
+     210, /* method_super */
+     210, /* method_redir */
+     210, /* method_redir_super */
        0, /* entergiven */
        0, /* leavegiven */
        0, /* enterwhen */
        0, /* leavewhen */
       -1, /* break */
       -1, /* continue */
-     211, /* open */
-      55, /* close */
-      55, /* pipe_op */
-      55, /* fileno */
-      55, /* umask */
-      55, /* binmode */
-      55, /* tie */
+     212, /* open */
+      56, /* close */
+      56, /* pipe_op */
+      56, /* fileno */
+      56, /* umask */
+      56, /* binmode */
+      56, /* tie */
        0, /* untie */
        0, /* tied */
-      55, /* dbmopen */
+      56, /* dbmopen */
        0, /* dbmclose */
-      55, /* sselect */
-      55, /* select */
-      55, /* getc */
-      55, /* read */
-      55, /* enterwrite */
-     188, /* leavewrite */
+      56, /* sselect */
+      56, /* select */
+      56, /* getc */
+      56, /* read */
+      56, /* enterwrite */
+     189, /* leavewrite */
       -1, /* prtf */
       -1, /* print */
       -1, /* say */
-      55, /* sysopen */
-      55, /* sysseek */
-      55, /* sysread */
-      55, /* syswrite */
-      55, /* eof */
-      55, /* tell */
-      55, /* seek */
-      55, /* truncate */
-      55, /* fcntl */
-      55, /* ioctl */
-     101, /* flock */
-      55, /* send */
-      55, /* recv */
-      55, /* socket */
-      55, /* sockpair */
-      55, /* bind */
-      55, /* connect */
-      55, /* listen */
-      55, /* accept */
-      55, /* shutdown */
-      55, /* gsockopt */
-      55, /* ssockopt */
+      56, /* sysopen */
+      56, /* sysseek */
+      56, /* sysread */
+      56, /* syswrite */
+      56, /* eof */
+      56, /* tell */
+      56, /* seek */
+      56, /* truncate */
+      56, /* fcntl */
+      56, /* ioctl */
+     102, /* flock */
+      56, /* send */
+      56, /* recv */
+      56, /* socket */
+      56, /* sockpair */
+      56, /* bind */
+      56, /* connect */
+      56, /* listen */
+      56, /* accept */
+      56, /* shutdown */
+      56, /* gsockopt */
+      56, /* ssockopt */
        0, /* getsockname */
        0, /* getpeername */
        0, /* lstat */
        0, /* stat */
-     216, /* ftrread */
-     216, /* ftrwrite */
-     216, /* ftrexec */
-     216, /* fteread */
-     216, /* ftewrite */
-     216, /* fteexec */
-     221, /* ftis */
-     221, /* ftsize */
-     221, /* ftmtime */
-     221, /* ftatime */
-     221, /* ftctime */
-     221, /* ftrowned */
-     221, /* fteowned */
-     221, /* ftzero */
-     221, /* ftsock */
-     221, /* ftchr */
-     221, /* ftblk */
-     221, /* ftfile */
-     221, /* ftdir */
-     221, /* ftpipe */
-     221, /* ftsuid */
-     221, /* ftsgid */
-     221, /* ftsvtx */
-     221, /* ftlink */
-     221, /* fttty */
-     221, /* fttext */
-     221, /* ftbinary */
-     101, /* chdir */
-     101, /* chown */
-      78, /* chroot */
-     101, /* unlink */
-     101, /* chmod */
-     101, /* utime */
-     101, /* rename */
-     101, /* link */
-     101, /* symlink */
+     217, /* ftrread */
+     217, /* ftrwrite */
+     217, /* ftrexec */
+     217, /* fteread */
+     217, /* ftewrite */
+     217, /* fteexec */
+     222, /* ftis */
+     222, /* ftsize */
+     222, /* ftmtime */
+     222, /* ftatime */
+     222, /* ftctime */
+     222, /* ftrowned */
+     222, /* fteowned */
+     222, /* ftzero */
+     222, /* ftsock */
+     222, /* ftchr */
+     222, /* ftblk */
+     222, /* ftfile */
+     222, /* ftdir */
+     222, /* ftpipe */
+     222, /* ftsuid */
+     222, /* ftsgid */
+     222, /* ftsvtx */
+     222, /* ftlink */
+     222, /* fttty */
+     222, /* fttext */
+     222, /* ftbinary */
+     102, /* chdir */
+     102, /* chown */
+      79, /* chroot */
+     102, /* unlink */
+     102, /* chmod */
+     102, /* utime */
+     102, /* rename */
+     102, /* link */
+     102, /* symlink */
        0, /* readlink */
-     101, /* mkdir */
-      78, /* rmdir */
-      55, /* open_dir */
+     102, /* mkdir */
+      79, /* rmdir */
+      56, /* open_dir */
        0, /* readdir */
        0, /* telldir */
-      55, /* seekdir */
+      56, /* seekdir */
        0, /* rewinddir */
        0, /* closedir */
       -1, /* fork */
-     225, /* wait */
-     101, /* waitpid */
-     101, /* system */
-     101, /* exec */
-     101, /* kill */
-     225, /* getppid */
-     101, /* getpgrp */
-     101, /* setpgrp */
-     101, /* getpriority */
-     101, /* setpriority */
-     225, /* time */
+     226, /* wait */
+     102, /* waitpid */
+     102, /* system */
+     102, /* exec */
+     102, /* kill */
+     226, /* getppid */
+     102, /* getpgrp */
+     102, /* setpgrp */
+     102, /* getpriority */
+     102, /* setpriority */
+     226, /* time */
       -1, /* tms */
        0, /* localtime */
-      55, /* gmtime */
+      56, /* gmtime */
        0, /* alarm */
-     101, /* sleep */
-      55, /* shmget */
-      55, /* shmctl */
-      55, /* shmread */
-      55, /* shmwrite */
-      55, /* msgget */
-      55, /* msgctl */
-      55, /* msgsnd */
-      55, /* msgrcv */
-      55, /* semop */
-      55, /* semget */
-      55, /* semctl */
+     102, /* sleep */
+      56, /* shmget */
+      56, /* shmctl */
+      56, /* shmread */
+      56, /* shmwrite */
+      56, /* msgget */
+      56, /* msgctl */
+      56, /* msgsnd */
+      56, /* msgrcv */
+      56, /* semop */
+      56, /* semget */
+      56, /* semctl */
        0, /* require */
        0, /* dofile */
       -1, /* hintseval */
-     226, /* entereval */
-     188, /* leaveeval */
+     227, /* entereval */
+     189, /* leaveeval */
        0, /* entertry */
       -1, /* leavetry */
        0, /* ghbyname */
-      55, /* ghbyaddr */
+      56, /* ghbyaddr */
       -1, /* ghostent */
        0, /* gnbyname */
-      55, /* gnbyaddr */
+      56, /* gnbyaddr */
       -1, /* gnetent */
        0, /* gpbyname */
-      55, /* gpbynumber */
+      56, /* gpbynumber */
       -1, /* gprotoent */
-      55, /* gsbyname */
-      55, /* gsbyport */
+      56, /* gsbyname */
+      56, /* gsbyport */
       -1, /* gservent */
        0, /* shostent */
        0, /* snetent */
@@ -2944,44 +2955,44 @@ EXTCONST I16  PL_op_private_bitdef_ix[] = {
       -1, /* sgrent */
       -1, /* egrent */
       -1, /* getlogin */
-      55, /* syscall */
+      56, /* syscall */
        0, /* lock */
        0, /* once */
       -1, /* custom */
-     233, /* coreargs */
-     237, /* avhvswitch */
+     234, /* coreargs */
+     238, /* avhvswitch */
        3, /* runcv */
        0, /* fc */
       -1, /* padcv */
       -1, /* introcv */
       -1, /* clonecv */
-     239, /* padrange */
-     241, /* refassign */
-     247, /* lvref */
-     253, /* lvrefslice */
-      16, /* lvavref */
+     240, /* padrange */
+     242, /* refassign */
+     248, /* lvref */
+     254, /* lvrefslice */
+      17, /* lvavref */
        0, /* anonconst */
-      12, /* isa */
+      13, /* isa */
        0, /* cmpchain_and */
        0, /* cmpchain_dup */
        0, /* entertrycatch */
       -1, /* leavetrycatch */
       -1, /* poptry */
        0, /* catch */
-     254, /* pushdefer */
+     255, /* pushdefer */
        0, /* is_bool */
        0, /* is_weak */
        0, /* weaken */
        0, /* unweaken */
-      52, /* blessed */
-      78, /* refaddr */
-      78, /* reftype */
-      78, /* ceil */
-      78, /* floor */
+      53, /* blessed */
+      79, /* refaddr */
+      79, /* reftype */
+      79, /* ceil */
+      79, /* floor */
        0, /* is_tainted */
-     256, /* helemexistsor */
-     258, /* methstart */
-     260, /* initfield */
+     257, /* helemexistsor */
+     259, /* methstart */
+     261, /* initfield */
       -1, /* classname */
 
 };
@@ -3002,85 +3013,85 @@ EXTCONST I16  PL_op_private_bitdef_ix[] = {
 
 EXTCONST U16  PL_op_private_bitdefs[] = {
     0x0003, /* scalar, prototype, refgen, srefgen, readline, regcmaybe, regcreset, regcomp, substcont, chop, schop, defined, study, preinc, i_preinc, predec, i_predec, postinc, i_postinc, postdec, i_postdec, not, ucfirst, lcfirst, uc, lc, quotemeta, aeach, avalues, each, pop, shift, grepstart, mapstart, mapwhile, range, and, or, dor, andassign, orassign, dorassign, argcheck, entergiven, leavegiven, enterwhen, leavewhen, untie, tied, dbmclose, getsockname, getpeername, lstat, stat, readlink, readdir, telldir, rewinddir, closedir, localtime, alarm, require, dofile, entertry, ghbyname, gnbyname, gpbyname, shostent, snetent, sprotoent, sservent, gpwnam, gpwuid, ggrnam, ggrgid, lock, once, fc, anonconst, cmpchain_and, cmpchain_dup, entertrycatch, catch, is_bool, is_weak, weaken, unweaken, is_tainted */
-    0x3abc, 0x4d99, /* pushmark */
+    0x3bfc, 0x4fd9, /* pushmark */
     0x00bd, /* wantarray, runcv */
-    0x0558, 0x1b70, 0x4e4c, 0x49e8, 0x3fe5, /* const */
-    0x3abc, 0x4319, /* gvsv */
+    0x065e, 0x0554, 0x1b70, 0x508c, 0x4c28, 0x4125, /* const */
+    0x3bfc, 0x4459, /* gvsv */
     0x19d5, /* gv */
     0x0067, /* gelem, lt, i_lt, gt, i_gt, le, i_le, ge, i_ge, eq, i_eq, ne, i_ne, ncmp, i_ncmp, slt, sgt, sle, sge, seq, sne, scmp, smartmatch, lslice, xor, isa */
-    0x3abc, 0x4d98, 0x03d7, /* padsv */
-    0x3abc, 0x4d98, 0x0003, /* padsv_store, lvavref */
-    0x3abc, 0x4d98, 0x06d4, 0x3bac, 0x4b69, /* padav */
-    0x3abc, 0x4d98, 0x06d4, 0x0770, 0x3bac, 0x4b68, 0x3621, /* padhv */
-    0x3abc, 0x1e38, 0x03d6, 0x3bac, 0x3f08, 0x4e44, 0x0003, /* rv2gv */
-    0x3abc, 0x4318, 0x03d6, 0x4e44, 0x0003, /* rv2sv */
-    0x3bac, 0x0003, /* av2arylen, akeys, values, keys */
-    0x3e7c, 0x1198, 0x0ef4, 0x014c, 0x5148, 0x4e44, 0x0003, /* rv2cv */
+    0x3bfc, 0x4fd8, 0x03d7, /* padsv */
+    0x3bfc, 0x4fd8, 0x0003, /* padsv_store, lvavref */
+    0x3bfc, 0x4fd8, 0x06d4, 0x3cec, 0x4da9, /* padav */
+    0x3bfc, 0x4fd8, 0x06d4, 0x0770, 0x3cec, 0x4da8, 0x36c1, /* padhv */
+    0x3bfc, 0x1e38, 0x03d6, 0x3cec, 0x4048, 0x5084, 0x0003, /* rv2gv */
+    0x3bfc, 0x4458, 0x03d6, 0x5084, 0x0003, /* rv2sv */
+    0x3cec, 0x0003, /* av2arylen, akeys, values, keys */
+    0x3fbc, 0x1198, 0x0ef4, 0x014c, 0x5388, 0x5084, 0x0003, /* rv2cv */
     0x06d4, 0x0770, 0x0003, /* ref, blessed */
     0x018f, /* bless, glob, sprintf, formline, unpack, pack, join, anonlist, anonhash, splice, warn, die, reset, exit, close, pipe_op, fileno, umask, binmode, tie, dbmopen, sselect, select, getc, read, enterwrite, sysopen, sysseek, sysread, syswrite, eof, tell, seek, truncate, fcntl, ioctl, send, recv, socket, sockpair, bind, connect, listen, accept, shutdown, gsockopt, ssockopt, open_dir, seekdir, gmtime, shmget, shmctl, shmread, shmwrite, msgget, msgctl, msgsnd, msgrcv, semop, semget, semctl, ghbyaddr, gnbyaddr, gpbynumber, gsbyname, gsbyport, syscall */
-    0x44fc, 0x4418, 0x2dd4, 0x2d10, 0x0003, /* backtick */
+    0x463c, 0x4558, 0x2e74, 0x2db0, 0x0003, /* backtick */
     0x06d5, /* subst */
-    0x129c, 0x24b8, 0x0ad4, 0x4cac, 0x2848, 0x5424, 0x08e1, /* trans, transr */
+    0x129c, 0x2558, 0x0ad4, 0x4eec, 0x28e8, 0x5724, 0x08e1, /* trans, transr */
     0x10dc, 0x05f8, 0x0067, /* sassign */
-    0x0d98, 0x0c94, 0x0b90, 0x3bac, 0x06c8, 0x0067, /* aassign */
-    0x51f0, 0x0003, /* chomp, schomp, negate, i_negate, scomplement, sin, cos, exp, log, sqrt, int, hex, oct, abs, ord, chr, chroot, rmdir, refaddr, reftype, ceil, floor */
-    0x3abc, 0x4d98, 0x3534, 0x51f0, 0x0003, /* undef */
-    0x06d4, 0x3bac, 0x0003, /* pos */
-    0x51f0, 0x0067, /* pow, multiply, i_multiply, divide, i_divide, modulo, i_modulo, add, i_add, subtract, i_subtract */
+    0x0d98, 0x0c94, 0x0b90, 0x3cec, 0x06c8, 0x0067, /* aassign */
+    0x5430, 0x0003, /* chomp, schomp, negate, i_negate, scomplement, sin, cos, exp, log, sqrt, int, hex, oct, abs, ord, chr, chroot, rmdir, refaddr, reftype, ceil, floor */
+    0x3bfc, 0x4fd8, 0x35d4, 0x5430, 0x0003, /* undef */
+    0x06d4, 0x3cec, 0x0003, /* pos */
+    0x5430, 0x0067, /* pow, multiply, i_multiply, divide, i_divide, modulo, i_modulo, add, i_add, subtract, i_subtract */
     0x1658, 0x0067, /* repeat */
-    0x3d98, 0x51f0, 0x0067, /* concat */
-    0x3abc, 0x0338, 0x1e34, 0x51f0, 0x4f2c, 0x0003, /* multiconcat */
-    0x51f0, 0x018f, /* stringify, atan2, rand, srand, crypt, push, unshift, flock, chdir, chown, unlink, chmod, utime, rename, link, symlink, mkdir, waitpid, system, exec, kill, getpgrp, setpgrp, getpriority, setpriority, sleep */
-    0x51f0, 0x5349, /* left_shift, right_shift, nbit_and, nbit_xor, nbit_or, ncomplement */
-    0x5349, /* bit_and, bit_xor, bit_or, sbit_and, sbit_xor, sbit_or, complement */
-    0x06d4, 0x51f0, 0x0003, /* length */
-    0x4750, 0x3bac, 0x012b, /* substr */
-    0x3bac, 0x0067, /* vec */
-    0x3d18, 0x06d4, 0x51f0, 0x018f, /* index, rindex */
-    0x3abc, 0x4318, 0x06d4, 0x3bac, 0x4b68, 0x4e44, 0x0003, /* rv2av */
+    0x3ed8, 0x5430, 0x0067, /* concat */
+    0x3bfc, 0x0338, 0x1e34, 0x5430, 0x516c, 0x0003, /* multiconcat */
+    0x5430, 0x018f, /* stringify, atan2, rand, srand, crypt, push, unshift, flock, chdir, chown, unlink, chmod, utime, rename, link, symlink, mkdir, waitpid, system, exec, kill, getpgrp, setpgrp, getpriority, setpriority, sleep */
+    0x5430, 0x5649, /* left_shift, right_shift, nbit_and, nbit_xor, nbit_or, ncomplement */
+    0x5649, /* bit_and, bit_xor, bit_or, sbit_and, sbit_xor, sbit_or, complement */
+    0x06d4, 0x5430, 0x0003, /* length */
+    0x4990, 0x3cec, 0x012b, /* substr */
+    0x3cec, 0x0067, /* vec */
+    0x3e58, 0x06d4, 0x5430, 0x018f, /* index, rindex */
+    0x3bfc, 0x4458, 0x06d4, 0x3cec, 0x4da8, 0x5084, 0x0003, /* rv2av */
     0x025f, /* aelemfast, aelemfast_lex, aelemfastlex_store */
-    0x3abc, 0x39b8, 0x03d6, 0x3bac, 0x0067, /* aelem, helem */
-    0x3abc, 0x3bac, 0x4b69, /* aslice, hslice */
-    0x3bad, /* kvaslice, kvhslice */
-    0x3abc, 0x4ab8, 0x36d4, 0x0003, /* delete */
-    0x5078, 0x0003, /* exists */
-    0x3abc, 0x4318, 0x06d4, 0x0770, 0x3bac, 0x4b68, 0x4e44, 0x3621, /* rv2hv */
-    0x3abc, 0x39b8, 0x1314, 0x1d50, 0x3bac, 0x4e44, 0x0003, /* multideref */
-    0x3abc, 0x4318, 0x0410, 0x37cc, 0x2b49, /* split */
-    0x3abc, 0x2579, /* list */
-    0x3abc, 0x4d98, 0x0214, 0x51f0, 0x018f, /* emptyavhv */
-    0x15b0, 0x330c, 0x4848, 0x3404, 0x4281, /* sort */
-    0x330c, 0x0003, /* reverse */
+    0x3bfc, 0x3af8, 0x03d6, 0x3cec, 0x0067, /* aelem, helem */
+    0x3bfc, 0x3cec, 0x4da9, /* aslice, hslice */
+    0x3ced, /* kvaslice, kvhslice */
+    0x3bfc, 0x4cf8, 0x3774, 0x0003, /* delete */
+    0x52b8, 0x0003, /* exists */
+    0x3bfc, 0x4458, 0x06d4, 0x0770, 0x3cec, 0x4da8, 0x5084, 0x36c1, /* rv2hv */
+    0x3bfc, 0x3af8, 0x1314, 0x1d50, 0x3cec, 0x5084, 0x0003, /* multideref */
+    0x3bfc, 0x4458, 0x0410, 0x386c, 0x2be9, /* split */
+    0x3bfc, 0x2619, /* list */
+    0x3bfc, 0x4fd8, 0x0214, 0x5430, 0x018f, /* emptyavhv */
+    0x15b0, 0x33ac, 0x4a88, 0x34a4, 0x43c1, /* sort */
+    0x33ac, 0x0003, /* reverse */
     0x06d4, 0x0003, /* grepwhile */
-    0x3858, 0x0003, /* flip, flop */
-    0x3abc, 0x0003, /* cond_expr */
-    0x3abc, 0x1198, 0x03d6, 0x014c, 0x5148, 0x4e44, 0x2c21, /* entersub */
-    0x45b8, 0x0003, /* leavesub, leavesublv, leavewrite, leaveeval */
+    0x3998, 0x0003, /* flip, flop */
+    0x3bfc, 0x0003, /* cond_expr */
+    0x3bfc, 0x1198, 0x03d6, 0x014c, 0x5388, 0x5084, 0x2cc1, /* entersub */
+    0x47f8, 0x0003, /* leavesub, leavesublv, leavewrite, leaveeval */
     0x02aa, 0x0003, /* argelem */
-    0x2a3c, 0x2918, 0x0003, /* argdefelem */
+    0x2adc, 0x29b8, 0x0003, /* argdefelem */
     0x00bc, 0x018f, /* caller */
-    0x2755, /* nextstate, dbstate */
-    0x395c, 0x45b9, /* leave */
-    0x3abc, 0x4318, 0x120c, 0x48c5, /* enteriter */
-    0x48c5, /* iter */
-    0x395c, 0x0067, /* leaveloop */
-    0x555c, 0x0003, /* last, next, redo, dump, goto */
-    0x40a4, 0x0003, /* method, method_named, method_super, method_redir, method_redir_super */
-    0x44fc, 0x4418, 0x2dd4, 0x2d10, 0x018f, /* open */
-    0x20f0, 0x234c, 0x2208, 0x1fc4, 0x0003, /* ftrread, ftrwrite, ftrexec, fteread, ftewrite, fteexec */
-    0x20f0, 0x234c, 0x2208, 0x0003, /* ftis, ftsize, ftmtime, ftatime, ftctime, ftrowned, fteowned, ftzero, ftsock, ftchr, ftblk, ftfile, ftdir, ftpipe, ftsuid, ftsgid, ftsvtx, ftlink, fttty, fttext, ftbinary */
-    0x51f1, /* wait, getppid, time */
-    0x1c78, 0x4654, 0x0fb0, 0x082c, 0x52c8, 0x2664, 0x0003, /* entereval */
-    0x3c7c, 0x0018, 0x14c4, 0x13e1, /* coreargs */
-    0x3bac, 0x00c7, /* avhvswitch */
-    0x3abc, 0x01fb, /* padrange */
-    0x3abc, 0x4d98, 0x04f6, 0x348c, 0x1ac8, 0x0067, /* refassign */
-    0x3abc, 0x4d98, 0x04f6, 0x348c, 0x1ac8, 0x0003, /* lvref */
-    0x3abd, /* lvrefslice */
-    0x1edc, 0x0003, /* pushdefer */
+    0x27f5, /* nextstate, dbstate */
+    0x3a9c, 0x47f9, /* leave */
+    0x3bfc, 0x4458, 0x120c, 0x4b05, /* enteriter */
+    0x4b05, /* iter */
+    0x3a9c, 0x0067, /* leaveloop */
+    0x585c, 0x0003, /* last, next, redo, dump, goto */
+    0x41e4, 0x0003, /* method, method_named, method_super, method_redir, method_redir_super */
+    0x463c, 0x4558, 0x2e74, 0x2db0, 0x018f, /* open */
+    0x2190, 0x23ec, 0x22a8, 0x2064, 0x0003, /* ftrread, ftrwrite, ftrexec, fteread, ftewrite, fteexec */
+    0x2190, 0x23ec, 0x22a8, 0x0003, /* ftis, ftsize, ftmtime, ftatime, ftctime, ftrowned, fteowned, ftzero, ftsock, ftchr, ftblk, ftfile, ftdir, ftpipe, ftsuid, ftsgid, ftsvtx, ftlink, fttty, fttext, ftbinary */
+    0x5431, /* wait, getppid, time */
+    0x1c78, 0x4894, 0x0fb0, 0x082c, 0x55c8, 0x2704, 0x0003, /* entereval */
+    0x3dbc, 0x0018, 0x14c4, 0x13e1, /* coreargs */
+    0x3cec, 0x00c7, /* avhvswitch */
+    0x3bfc, 0x01fb, /* padrange */
+    0x3bfc, 0x4fd8, 0x04f6, 0x352c, 0x1ac8, 0x0067, /* refassign */
+    0x3bfc, 0x4fd8, 0x04f6, 0x352c, 0x1ac8, 0x0003, /* lvref */
+    0x3bfd, /* lvrefslice */
+    0x1f7c, 0x0003, /* pushdefer */
     0x131c, 0x0003, /* helemexistsor */
-    0x2e7c, 0x0003, /* methstart */
-    0x3168, 0x2fc4, 0x0003, /* initfield */
+    0x2f1c, 0x0003, /* methstart */
+    0x3208, 0x3064, 0x0003, /* initfield */
 
 };
 
@@ -3094,7 +3105,7 @@ EXTCONST U8 PL_op_private_valid[] = {
     /* SCALAR     */ (OPpARG1_MASK),
     /* PUSHMARK   */ (OPpPAD_STATE|OPpLVAL_INTRO),
     /* WANTARRAY  */ (OPpOFFBYONE),
-    /* CONST      */ (OPpCONST_NOVER|OPpCONST_SHORTCIRCUIT|OPpCONST_STRICT|OPpCONST_ENTERED|OPpCONST_BARE),
+    /* CONST      */ (OPpCONST_NOVER|OPpCONST_SHORTCIRCUIT|OPpCONST_STRICT|OPpCONST_ENTERED|OPpCONST_BARE|OPpCONST_TOKEN_MASK),
     /* GVSV       */ (OPpOUR_INTRO|OPpLVAL_INTRO),
     /* GV         */ (OPpEARLY_CV),
     /* GELEM      */ (OPpARG2_MASK),

--- a/regen/op_private
+++ b/regen/op_private
@@ -661,7 +661,18 @@ addbits('const',
     2 => qw(OPpCONST_SHORTCIRCUIT SHORT),   # e.g. the constant 5 in (5 || foo)
     3 => qw(OPpCONST_STRICT       STRICT),  # bareword subject to strict 'subs'
     4 => qw(OPpCONST_ENTERED      ENTERED), # Has been entered as symbol
-    6 => qw(OPpCONST_BARE         BARE),    # Was a bare word (filehandle?)
+    5 => qw(OPpCONST_BARE         BARE),    # Was a bare word (filehandle?)
+    '6..7' => {                             # value derived from __LINE__ etc
+        mask_def      => 'OPpCONST_TOKEN_MASK',
+        baseshift_def => 'OPpCONST_TOKEN_SHIFT',
+        bitcount_def  => 'OPpCONST_TOKEN_BITS',
+        label         => 'TOKEN',
+        enum          => [ qw(
+                             1   OPpCONST_TOKEN_LINE    LINE
+                             2   OPpCONST_TOKEN_FILE    FILE
+                             3   OPpCONST_TOKEN_PACKAGE PACKAGE
+                         )],
+    },
 );
 
 

--- a/toke.c
+++ b/toke.c
@@ -7940,19 +7940,18 @@ yyl_word_or_keyword(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword, struct
         return yyl_just_a_word(aTHX_ s, len, orig_keyword, c);
 
     case KEY___FILE__:
-        FUN0OP( newSVOP(OP_CONST, 0, newSVpv(CopFILE(PL_curcop),0)) );
+        FUN0OP(newSVOP(OP_CONST, OPpCONST_TOKEN_FILE<<8,
+                newSVpv(CopFILE(PL_curcop),0)) );
 
     case KEY___LINE__:
-        FUN0OP(
-            newSVOP(OP_CONST, 0,
-                Perl_newSVpvf(aTHX_ "%" LINE_Tf, CopLINE(PL_curcop)))
-        );
+        FUN0OP(newSVOP(OP_CONST, OPpCONST_TOKEN_LINE<<8,
+                Perl_newSVpvf(aTHX_ "%" LINE_Tf, CopLINE(PL_curcop))));
 
     case KEY___PACKAGE__:
-        FUN0OP(
-            newSVOP(OP_CONST, 0, (PL_curstash
-                                     ? newSVhek(HvNAME_HEK(PL_curstash))
-                                     : &PL_sv_undef))
+        FUN0OP(newSVOP(OP_CONST, OPpCONST_TOKEN_PACKAGE<<8,
+                (PL_curstash
+                     ? newSVhek(HvNAME_HEK(PL_curstash))
+                     : &PL_sv_undef))
         );
 
     case KEY___DATA__:


### PR DESCRIPTION
Code like

    my $line = __LINE__;

was being deparsed as

    my $line = '42';

because __LINE__ is converted by the lexer into an ordinary OP_CONST whose SV is just a plain string holding the line number.

This commit adds a flag, OPpCONST_LINE, to OP_CONST, which is set to indicate that this OP_CONST was created from a __LINE__ construct.

Deparse.pm then uses this new flag to print out the literal string "__LINE__" rather than the constant's actual value.

This fixes one failing test file under
    cd t; ./TEST -deparse
and removes one (but not all) sources of failure from three others.