### PR TITLE
Remove the `builtin::unimport` function and `no builtin ...`

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -674,7 +674,7 @@ XS(XS_builtin_import)
         SV *sym = ST(i);
         STRLEN symlen;
         const char *sympv = SvPV(sym, symlen);
-        if(strEQ(sympv, "import") || strEQ(sympv, "unimport"))
+        if(strEQ(sympv, "import"))
             Perl_croak(aTHX_ builtin_not_recognised, sym);
 
         if(sympv[0] == ':') {
@@ -698,49 +698,6 @@ XS(XS_builtin_import)
         import_sym(sym);
     }
 
-    finish_export_lexical();
-}
-
-XS(XS_builtin_unimport);
-XS(XS_builtin_unimport)
-{
-    dXSARGS;
-
-    if(!PL_compcv)
-        Perl_croak(aTHX_
-                "builtin::unimport can only be called at compile time");
-
-    prepare_export_lexical();
-
-    for(int i = 1; i < items; i++) {
-        SV *sym = ST(i);
-        const char *sympv = SvPV_nolen(sym);
-        if(strEQ(sympv, "import") || strEQ(sympv, "unimport"))
-            Perl_croak(aTHX_ builtin_not_recognised, sym);
-
-        SV *ampname = sv_2mortal(Perl_newSVpvf(aTHX_ "&%" SVf, SVfARG(sym)));
-        SV *fqname = sv_2mortal(Perl_newSVpvf(aTHX_ "builtin::%" SVf, SVfARG(sym)));
-
-        CV *cv = get_cv(SvPV_nolen(fqname), SvUTF8(fqname) ? SVf_UTF8 : 0);
-        if(!cv)
-            Perl_croak(aTHX_ builtin_not_recognised, sym);
-
-        PADOFFSET off = pad_findmy_sv(ampname, 0);
-        if((off == NOT_IN_PAD) ||
-                (PL_curpad[off] != (SV *)cv))
-            Perl_croak(aTHX_
-                    "'%" SVf "' does not appear to be an imported builtin function", SVfARG(ampname));
-
-        /* Add a tombstone entry */
-        /* TODO: If the pad entry we found is going to go out of scope at the
-         * same time as this tombstone would, we could not bother adding the
-         * tombstone and instead COP_SEQ_MAX_HIGH_set() on the padname to
-         * clear it.
-         */
-        pad_add_name_sv(ampname, padadd_STATE|padadd_TOMBSTONE, 0, 0);
-    }
-
-    COP_SEQMAX_INC;
     finish_export_lexical();
 }
 
@@ -779,8 +736,7 @@ Perl_boot_core_builtin(pTHX)
         }
     }
 
-    newXS_flags("builtin::import",   &XS_builtin_import,   __FILE__, NULL, 0);
-    newXS_flags("builtin::unimport", &XS_builtin_unimport, __FILE__, NULL, 0);
+    newXS_flags("builtin::import", &XS_builtin_import, __FILE__, NULL, 0);
 }
 
 /*

--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -1,9 +1,9 @@
-package builtin 0.013;
+package builtin 0.014;
 
 use strict;
 use warnings;
 
-# All code, including &import and &unimport, is implemented by always-present
+# All code, including &import, is implemented by always-present
 # functions in the perl interpreter itself.
 # See also `builtin.c` in perl source
 
@@ -81,13 +81,15 @@ don't accidentally appear as object methods from a class.
     # Can't locate object method "true" via package "An::Object::Class"
     #   at ...
 
-Imported symbols can also be removed again by using the C<no> keyword:
+Once imported, a lexical function is much like any other lexical symbol
+(such as a variable) in that it cannot be removed again.  If you wish to
+limit the visiblity of an imported C<builtin> function, put it inside its
+own scope:
 
-    use builtin 'true';
-    my $yes = true;
-
-    no builtin 'true';
-    # true() is no longer aliased from builtin
+    {
+      use builtin 'refaddr';
+      ...
+    }
 
 =head2 Version Bundles
 

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -292,28 +292,6 @@ package FetchStoreCounter {
     ok($recursecoderef->("rec"), 'true in self-recursive anon sub');
 }
 
-# imported builtins can be unexported
-{
-    package UnimportTest;
-    no warnings 'shadow';
-
-    sub true() { return "true" };
-
-    {
-        use builtin 'true';
-        no builtin 'true';
-
-        ::is(true(), "true", 'no builtin can remove lexical import');
-    }
-
-    {
-        use builtin 'true';
-        { no builtin 'true'; }
-
-        ::is(true(), 1, 'no builtin is lexically scoped');
-    }
-}
-
 {
     use builtin qw( true false );
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -657,13 +657,6 @@ is currently being compiled. Since this method is used to introduce new
 lexical subroutines into the scope currently being compiled, this is not
 going to have any effect.
 
-=item builtin::unimport can only be called at compile time
-
-(F) The C<unimport> method of the C<builtin> package was invoked when no code
-is currently being compiled. Since this method is used to remove
-previously-introduced lexical subroutines from the scope currently being
-compiled, this is not going to have any effect.
-
 =item Builtin version bundle "%s" is not supported by Perl
 
 (F) You attempted to C<use builtin :ver> for a version number that is either


### PR DESCRIPTION
Following on from #22002, this removes the last place that `PADNAMEf_TOMBSTONE` is used. Once this is removed we can get rid of all the tombstone logic, and close a few of the related bugs / PRs with it.