### PR TITLE
allow multiple use v5.x declarations in some cases where it's harmless

### DIFF
--- a/op.c
+++ b/op.c
@@ -8022,18 +8022,25 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
             /* use VERSION while another use VERSION is in scope
              * This should provoke at least a warning, if not an outright error
              */
-            if (shortver >= SHORTVER(5, 39))
+            if (PL_prevailing_version < SHORTVER(5, 10)) {
+                /* if the old version had no side effects, we can allow this
+                 * without any warnings or errors */
+            }
+            else if (shortver >= SHORTVER(5, 39)) {
                 croak("use VERSION of 5.39 or above is not permitted while another use VERSION is in scope");
-            if (PL_prevailing_version >= SHORTVER(5, 39))
+            }
+            else if (PL_prevailing_version >= SHORTVER(5, 39)) {
                 croak("use VERSION is not permitted while another use VERSION of 5.39 or above is in scope");
-
-            /* downgrading from >= 5.11 to < 5.11 is now fatal */
-            if (PL_prevailing_version >= SHORTVER(5, 11) && shortver < SHORTVER(5, 11))
+            }
+            else if (PL_prevailing_version >= SHORTVER(5, 11) && shortver < SHORTVER(5, 11)) {
+                /* downgrading from >= 5.11 to < 5.11 is now fatal */
                 croak("Downgrading a use VERSION declaration to below v5.11 is not permitted");
-
-            /* OK let's at least warn */
-            deprecate_fatal_in(WARN_DEPRECATED__SUBSEQUENT_USE_VERSION, "5.46",
+            }
+            else {
+                /* OK let's at least warn */
+                deprecate_fatal_in(WARN_DEPRECATED__SUBSEQUENT_USE_VERSION, "5.46",
                     "use VERSION while another use VERSION is in scope");
+            }
         }
 
         /* If a version >= 5.11.0 is requested, strictures are on by default! */

--- a/t/lib/feature/implicit
+++ b/t/lib/feature/implicit
@@ -69,14 +69,13 @@ evalbytes "say 'yes'";
 use 5.014;
 evalbytes;
 EXPECT
-use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 6.
 use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 8.
 say sub
 yes
 evalbytes sub
 ########
 # Implicit unicode_string feature
-use v5.8.8;
+use v5.10;
 my $sharp_s = chr utf8::unicode_to_native(0xdf);
 print 'ss' =~ /$sharp_s/i ? "ok\n" : "nok\n";
 use v5.14;
@@ -89,7 +88,7 @@ ok
 # Implicit unicode_eval feature
 require '../../t/charset_tools.pl';
 my $long_s = byte_utf8a_to_utf8n("\xc5\xbf");
-use v5.8.8;
+use v5.10;
 print eval "use utf8; q|$long_s|" eq "\x{17f}" ? "ok\n" : "nok\n";
 use v5.15;
 print eval "use utf8; q|$long_s|" eq $long_s ? "ok\n" : "nok\n";

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -2163,3 +2163,20 @@ use v5.12;
 use v5.20;
 EXPECT
 use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 3.
+########
+use warnings;
+use v5.8;
+use v5.10;
+EXPECT
+########
+use warnings;
+use v5.10;
+use v5.8;
+EXPECT
+use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 3.
+########
+use warnings;
+use v5.12;
+use v5.12;
+EXPECT
+use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 3.

--- a/t/lib/warnings/pp_ctl
+++ b/t/lib/warnings/pp_ctl
@@ -249,7 +249,7 @@ EXPECT
 ########
 # pp_ctl.c
 use warnings;
-eval 'use 5.006; use 5.10.0';
+eval 'use 5.012; use 5.14.0';
 EXPECT
 use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at (eval 1) line 1.
 ########


### PR DESCRIPTION
allow multiple use v5.x declarations in some cases where it's harmless

We want to disallow using multiple "use v5.x" declarations in the same scope, but there are some cases we know to be harmless.

For versions before 5.10, the use declaration was only a version check with no side effects. If there was a previous version declarations that was below 5.10, we can safely ignore it without a warning or error.