### PR TITLE
Bump version for lib/warnings.pm; CoreList updates

### DIFF
--- a/dist/Module-CoreList/lib/Module/CoreList.pm
+++ b/dist/Module-CoreList/lib/Module/CoreList.pm
@@ -420,6 +420,7 @@ sub changes_between {
     5.039006 => '2023-12-30',
     5.039007 => '2024-01-20',
     5.039008 => '2024-02-23',
+    5.039009 => '2024-03-20',
   );
 
 for my $version ( sort { $a <=> $b } keys %released ) {
@@ -21306,6 +21307,14 @@ for my $version ( sort { $a <=> $b } keys %released ) {
             'mro'                   => '1.29',
             'perlfaq'               => '5.20240218',
             'warnings'              => '1.68',
+        },
+        removed => {
+        }
+    },
+    5.039009 => {
+        delta_from => 5.039008,
+        changed => {
+            'warnings'              => '1.69',
         },
         removed => {
         }

--- a/dist/Module-CoreList/lib/Module/CoreList/Utils.pm
+++ b/dist/Module-CoreList/lib/Module/CoreList/Utils.pm
@@ -2000,6 +2000,13 @@ my %delta = (
         removed => {
         }
     },
+    5.039009 => {
+        delta_from => 5.039008,
+        changed => {
+        },
+        removed => {
+        }
+    },
 );
 
 %utilities = Module::CoreList::_undelta(\%delta);

--- a/lib/warnings.pm
+++ b/lib/warnings.pm
@@ -5,7 +5,7 @@
 
 package warnings;
 
-our $VERSION = "1.68";
+our $VERSION = "1.69";
 
 # Verify that we're called correctly so that warnings will work.
 # Can't use Carp, since Carp uses us!

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -16,7 +16,7 @@
 #
 # This script is normally invoked from regen.pl.
 
-$VERSION = '1.68';
+$VERSION = '1.69';
 
 BEGIN {
     require './regen/regen_lib.pl';


### PR DESCRIPTION
When changes are made to warnings, the $VERSION in regen/warnings.pl needs to be incremented so that in the compiled file lib/warnings.pm $VERSION is updated there as well.

Prep Module::Corelist for 5.39.9 release.

Fixes https://github.com/Perl/perl5/issues/22020