### PR TITLE
revert change to regen/warnings.pl

### DIFF
--- a/lib/warnings.pm
+++ b/lib/warnings.pm
@@ -135,7 +135,7 @@ our %Offsets = (
     # Warnings Categories added in Perl 5.039002
     'deprecated::missing_import_called_with_args'=> 160,
 
-    # Warnings Categories added in Perl 5.039009
+    # Warnings Categories added in Perl 5.039008
     'deprecated::subsequent_use_version'=> 162,
 );
 

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -85,7 +85,7 @@ our $WARNING_TREE = {
                                 'deprecated::smartmatch'               => [ 5.037010, DEFAULT_ON],
                                 'deprecated::missing_import_called_with_args'   
                                                                        => [ 5.039002, DEFAULT_ON],
-                                'deprecated::subsequent_use_version'   => [ 5.039009, DEFAULT_ON],
+                                'deprecated::subsequent_use_version'   => [ 5.039008, DEFAULT_ON],
                         }],
         'void'          => [ 5.008, DEFAULT_OFF],
         'recursion'     => [ 5.008, DEFAULT_OFF],

--- a/warnings.h
+++ b/warnings.h
@@ -164,7 +164,7 @@
 
 #define WARN_DEPRECATED__MISSING_IMPORT_CALLED_WITH_ARGS 80
 
-/* Warnings Categories added in Perl 5.039009 */
+/* Warnings Categories added in Perl 5.039008 */
 
 #define WARN_DEPRECATED__SUBSEQUENT_USE_VERSION 81
 #define WARNsize			 21


### PR DESCRIPTION
This reverts a version bump made in e63d87953b9ae, which I think was incorrect: The "subsequent use version" warning appeared in 5.39.8, not 5.39.9.

Part of the fix to #22020.