### PR TITLE
assorted smoke fixes

### DIFF
--- a/dist/Tie-File/t/29_downcopy.t
+++ b/dist/Tie-File/t/29_downcopy.t
@@ -239,12 +239,19 @@ try(35272,  6728,     0);  # old=x><x     , new=0        ; old > new
 try(32768,  9232,     0);  # old=<x><x    , new=0        ; old > new
 try(42000,     0,     0);  # old=0        , new=0        ; old = new
 
+
 sub try {
   my ($pos, $len, $newlen) = @_;
+  try0($pos, $len, $newlen);
+  # if len is undef, it implies 'to the end of the string'
+  try0($pos, undef, $newlen);
+}
 
-  # try() is called with defined len, but then calls itself again with
-  # undef $len
-  my $line = (caller(defined $len ? 0 : 1))[2];
+
+sub try0 {
+  my ($pos, $len, $newlen) = @_;
+
+  my $line = (caller(1))[2];
   my $desc = sprintf "try(%5s, %5s, %5s) FLEN=%5s called from line %d",
                 map { defined $_ ? $_ : 'undef' }
                     $pos, $len, $newlen, $FLEN, $line;
@@ -293,11 +300,6 @@ sub try {
       print STDERR "# $0 Timeout after $alarm_time seconds at test $N - $desc\n";
       print "not ok $N - $desc\n"; $N++;
       print "not ok $N - $desc\n"; $N++;
-      if (defined $len) {
-        # Fail the tests in the recursive call as well
-        print "not ok $N - $desc\n"; $N++;
-        print "not ok $N - $desc\n"; $N++;
-      }
       return;
     } else {
       $@ = $err;
@@ -323,10 +325,6 @@ sub try {
   $N++;
   print $a_retval eq $x_retval ? "ok $N - $desc\n" : "not ok $N - $desc\n";
   $N++;
-
-  if (defined $len) {
-    try($pos, undef, $newlen);
-  }
 }
 
 END {

--- a/dist/Tie-File/t/29_downcopy.t
+++ b/dist/Tie-File/t/29_downcopy.t
@@ -241,6 +241,14 @@ try(42000,     0,     0);  # old=0        , new=0        ; old = new
 
 sub try {
   my ($pos, $len, $newlen) = @_;
+
+  # try() is called with defined len, but then calls itself again with
+  # undef $len
+  my $line = (caller(defined $len ? 0 : 1))[2];
+  my $desc = sprintf "try(%5s, %5s, %5s) FLEN=%5s called from line %d",
+                map { defined $_ ? $_ : 'undef' }
+                    $pos, $len, $newlen, $FLEN, $line;
+
   open F, '>', $file or die "Couldn't open file $file: $!";
   binmode F;
 
@@ -282,13 +290,13 @@ sub try {
   undef $o; untie @lines; alarm(0);
   if ($err) {
     if ($err =~ /^Alarm clock/) {
-      print STDERR "# $0 Timeout after $alarm_time seconds at test $N\n";
-      print "not ok $N\n"; $N++;
-      print "not ok $N\n"; $N++;
+      print STDERR "# $0 Timeout after $alarm_time seconds at test $N - $desc\n";
+      print "not ok $N - $desc\n"; $N++;
+      print "not ok $N - $desc\n"; $N++;
       if (defined $len) {
         # Fail the tests in the recursive call as well
-        print "not ok $N\n"; $N++;
-        print "not ok $N\n"; $N++;
+        print "not ok $N - $desc\n"; $N++;
+        print "not ok $N - $desc\n"; $N++;
       }
       return;
     } else {
@@ -311,9 +319,9 @@ sub try {
     for (@ARGS) { $_ = "UNDEF" unless defined }
     print "# try(@ARGS) expected file length $xlen, actual $alen!\n";
   }
-  print $actual eq $expected ? "ok $N\n" : "not ok $N\n";
+  print $actual eq $expected ? "ok $N - $desc\n" : "not ok $N - $desc\n";
   $N++;
-  print $a_retval eq $x_retval ? "ok $N\n" : "not ok $N\n";
+  print $a_retval eq $x_retval ? "ok $N - $desc\n" : "not ok $N - $desc\n";
   $N++;
 
   if (defined $len) {

--- a/dist/Tie-File/t/29_downcopy.t
+++ b/dist/Tie-File/t/29_downcopy.t
@@ -298,8 +298,8 @@ sub try0 {
   if ($err) {
     if ($err =~ /^Alarm clock/) {
       print STDERR "# $0 Timeout after $alarm_time seconds at test $N - $desc\n";
-      print "not ok $N - $desc\n"; $N++;
-      print "not ok $N - $desc\n"; $N++;
+      print "not ok $N - exp $desc TIMEOUT\n"; $N++;
+      print "not ok $N - ret $desc TIMEOUT\n"; $N++;
       return;
     } else {
       $@ = $err;
@@ -321,9 +321,9 @@ sub try0 {
     for (@ARGS) { $_ = "UNDEF" unless defined }
     print "# try(@ARGS) expected file length $xlen, actual $alen!\n";
   }
-  print $actual eq $expected ? "ok $N - $desc\n" : "not ok $N - $desc\n";
+  print $actual eq $expected ? "ok $N - exp $desc\n" : "not ok $N - exp $desc\n";
   $N++;
-  print $a_retval eq $x_retval ? "ok $N - $desc\n" : "not ok $N - $desc\n";
+  print $a_retval eq $x_retval ? "ok $N - ret $desc\n" : "not ok $N - ret $desc\n";
   $N++;
 }
 

--- a/dist/Tie-File/t/29a_upcopy.t
+++ b/dist/Tie-File/t/29a_upcopy.t
@@ -102,6 +102,12 @@ try($FLEN-20000, 200, undef);
 
 sub try {
   my ($src, $dst, $len) = @_;
+
+  my $line = (caller(0))[2];
+  my $desc = sprintf "try(%5s, %5s, %5s) FLEN=%5s called from line %d",
+                map { defined $_ ? $_ : 'undef' }
+                    $src, $dst, $len, $FLEN, $line;
+
   open F, '>', $file or die "Couldn't open file $file: $!";
   binmode F;
 
@@ -138,8 +144,8 @@ sub try {
   undef $o; untie @lines; alarm(0);
   if ($err) {
     if ($err =~ /^Alarm clock/) {
-      print STDERR "# $0 Timeout after $alarm_time seconds at test $N\n";
-      print "not ok $N\n"; $N++;
+      print STDERR "# $0 Timeout after $alarm_time seconds at test $N - $desc\n";
+      print "not ok $N - $desc\n"; $N++;
       return;
     } else {
       $@ = $err;
@@ -159,8 +165,6 @@ sub try {
   unless ($alen == $xlen) {
     print "# try(@_) expected file length $xlen, actual $alen!\n";
   }
-  my $desc = sprintf "try(%d, %d, %s)",
-                $src, $dst, (defined $len ? $len : "undef");
   print $actual eq $expected ? "ok $N - $desc\n" : "not ok $N - $desc\n";
   $N++;
 }

--- a/t/harness
+++ b/t/harness
@@ -29,6 +29,14 @@ my @_must_be_executed_serially = (
     # "Can't cd to .. from ./FF_find_t_RKdkBE/for_find/fb: Stale file handle"
     '../ext/File-Find/t/taint.t',
     '../ext/File-Find/t/find.t',
+
+    # CJKT.t creates some temporary files called "t/$$.utf", while
+    # Unicode.t expects to find a fixed number of *.utf files in that
+    # directory. Running the tests in parallel can cause failures like:
+    # "Bad plan.  You planned 56 tests but ran 57."
+    # Reported as https://rt.cpan.org/Ticket/Display.html?id=151983
+    'cpan/Encode/t/CJKT.t',
+    'cpan/Encode/t/Unicode.t',
 );
 
 my %must_be_executed_serially = map { $_ => 1 } @_must_be_executed_serially;


### PR DESCRIPTION
Stop some tests running in parallel which aren't safe to so so, and improve the diagnostics on some Tie::File tests which randomly timeout on slow hosts
