### PR TITLE
locale.c: Look for strict UTF-8, not loose

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -4755,8 +4755,8 @@ S_get_locale_string_utf8ness_i(pTHX_ const char * string,
     }
 
     /* Can't be UTF-8 if invalid */
-    if (! is_utf8_string((U8 *) first_variant,
-                         len - ((char *) first_variant - string)))
+    if (! is_strict_utf8_string((U8 *) first_variant,
+                                len - ((char *) first_variant - string)))
     {
         return UTF8NESS_NO;
     }
@@ -5039,7 +5039,7 @@ S_save_to_buffer(pTHX_ const char * string, char **buf, Size_t *buf_size)
 
     DEBUG_Lv(PerlIO_printf(Perl_debug_log,
                          "Copying '%s' to %p\n",
-                         ((is_utf8_string((U8 *) string, 0))
+                         ((is_strict_utf8_string((U8 *) string, 0))
                           ? string
                           :_byte_dump_string((U8 *) string, strlen(string), 0)),
                           *buf));
@@ -7985,8 +7985,8 @@ S_maybe_override_codeset(pTHX_ const char * codeset,
         }
 
         /* Here, has non-ASCII.  If not legal UTF-8, isn't a UTF-8 locale */
-        if (! is_utf8_string(first_variant,
-                                        len - (first_variant - (U8 *) result)))
+        if (! is_strict_utf8_string(first_variant,
+                                    len - (first_variant - (U8 *) result)))
         {
             strings_utf8ness = UTF8NESS_NO;
             break;
@@ -8529,7 +8529,7 @@ S_strftime8(pTHX_ const char * fmt,
     DEBUG_Lv(PerlIO_printf(Perl_debug_log,
                           "fmt=%s, retval=%s; utf8ness=%d",
                           fmt,
-                          ((is_utf8_string((U8 *) SvPVX(sv), 0))
+                          ((is_strict_utf8_string((U8 *) SvPVX(sv), 0))
                            ? SvPVX(sv)
                            :_byte_dump_string((U8 *) SvPVX(sv), SvCUR(sv) ,0)),
                           *result_utf8ness));


### PR DESCRIPTION
This is a small thing, but in reading the code, I realized that we are dealing with libc functions here; they don't traffic in Perl extensions nor esoteric code points.