### PR TITLE
regen/regen_lib.pl: Stop compile time warning

### DIFF
--- a/regen/regen_lib.pl
+++ b/regen/regen_lib.pl
@@ -230,6 +230,7 @@ sub read_only_bottom_close_and_rename {
 }
 
 sub tab {
+    no warnings 'numeric';
     my ($l, $t) = @_;
     $t .= "\t" x ($l - (length($t) + 1) / 8);
     $t;


### PR DESCRIPTION
This suppresses the warning about negative repeat counts