### PR TITLE
regen/reentr.pl: Update

### DIFF
--- a/reentr.c
+++ b/reentr.c
@@ -155,7 +155,7 @@ Perl_reentrant_size(pTHX) {
 #  endif /* HAS_SETLOCALE_R */
 
 #  ifdef HAS_STRERROR_R
-        PL_reentrant_buffer->_strerror_size = REENTRANTSMALLSIZE;
+        PL_reentrant_buffer->_strerror_size = 1024;
 #  endif /* HAS_STRERROR_R */
 
 #  ifdef HAS_TTYNAME_R

--- a/reentr.c
+++ b/reentr.c
@@ -2,7 +2,9 @@
  *
  *    reentr.c
  *
- *    Copyright (C) 2002, 2003, 2005, 2006, 2007 by Larry Wall and others
+ *    Copyright (C) 2002, 2003, 2005, 2006, 2007, 2008, 2009, 2010, 2011,
+ *    2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023,
+ *    2024 by Larry Wall and others
  *
  *    You may distribute under the terms of either the GNU General Public
  *    License or the Artistic License, as specified in the README file.

--- a/reentr.h
+++ b/reentr.h
@@ -1697,6 +1697,6 @@ typedef struct {
 
 #endif /* USE_REENTRANT_API */
 
-#endif
+#endif /* File hasn't already been #included */
 
 /* ex: set ro ft=c: */

--- a/reentr.h
+++ b/reentr.h
@@ -2,7 +2,9 @@
  *
  *    reentr.h
  *
- *    Copyright (C) 2002, 2003, 2005, 2006, 2007 by Larry Wall and others
+ *    Copyright (C) 2002, 2003, 2005, 2006, 2007, 2008, 2009, 2010, 2011,
+ *    2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023,
+ *    2024 by Larry Wall and others
  *
  *    You may distribute under the terms of either the GNU General Public
  *    License or the Artistic License, as specified in the README file.

--- a/regen/reentr.pl
+++ b/regen/reentr.pl
@@ -488,7 +488,11 @@ my %small_bufsizes = (
                         ctime     => 26,
                         setlocale => "REENTRANTSMALLSIZE",
                         getlogin  => "REENTRANTSMALLSIZE",
-                        strerror  => "REENTRANTSMALLSIZE",
+
+                        # glibc documents this size as being enough; assume
+                        # they know what they're doing
+                        strerror  => 1024,
+
                         ttyname   => "REENTRANTSMALLSIZE",
                      );
 

--- a/regen/reentr.pl
+++ b/regen/reentr.pl
@@ -483,21 +483,28 @@ define('ERRNO', 'E',
 # The loop also contains a lot of intrinsic logic about groups of
 # functions (since functions of certain kind operate the same way).
 
+my %small_bufsizes = (
+                        asctime   => 26,
+                        ctime     => 26,
+                        setlocale => "REENTRANTSMALLSIZE",
+                        getlogin  => "REENTRANTSMALLSIZE",
+                        strerror  => "REENTRANTSMALLSIZE",
+                        ttyname   => "REENTRANTSMALLSIZE",
+                     );
+
 for my $func (@seenf) {
     my $FUNC = uc $func;
     my $ifdef = "#  ifdef HAS_${FUNC}_R\n";
     my $endif = "#  endif /* HAS_${FUNC}_R */\n\n";
     if (exists $seena{$func}) {
         my @p = @{$seena{$func}};
-        if ($func =~ /^(asctime|ctime|getlogin|setlocale|strerror|ttyname)$/) {
+        if (exists $small_bufsizes{$func}) {
             pushssif $ifdef;
             push @struct, <<EOF;
         char*	_${func}_buffer;
         size_t	_${func}_size;
 EOF
-            my $size = ($func =~ /^(asctime|ctime)$/)
-                       ? 26
-                       : "REENTRANTSMALLSIZE";
+            my $size = $small_bufsizes{$func};
             push @size, <<EOF;
         PL_reentrant_buffer->_${func}_size = $size;
 EOF

--- a/regen/reentr.pl
+++ b/regen/reentr.pl
@@ -489,10 +489,18 @@ my %small_bufsizes = (
                         setlocale => "REENTRANTSMALLSIZE",
                         getlogin  => "REENTRANTSMALLSIZE",
 
+                        # POSIX specifies that the symbol LOGIN_NAME_MAX gives
+                        # this value; but not all systems have that;
+                        # L_cuserid is another possibility; XXX but both would
+                        # need Configure probes
+                        getlogin  => "REENTRANTSMALLSIZE",
+
                         # glibc documents this size as being enough; assume
                         # they know what they're doing
                         strerror  => 1024,
 
+                        # This value might be L_ctermid, but XXX would need a
+                        # Configure probe.
                         ttyname   => "REENTRANTSMALLSIZE",
                      );
 
@@ -1193,12 +1201,16 @@ EOF
 
 read_only_bottom_close_and_rename($c);
 
-# As of March 2020, the config.h entries that have reentrant prototypes that
+# As of February 2024, the config.h entries that have reentrant prototypes that
 # aren't in this file are:
 #       drand48
 #       random
 #       srand48
 #       srandom
+# Additionally, these are the POSIX defined _r functions that aren't defined
+#       getgrid_r
+#       rand_r
+#       strtok_r
 
 # The meanings of the flags are derivable from %map above
 # Fnc, arg flags| hdr   | ? struct type | prototypes...

--- a/regen/reentr.pl
+++ b/regen/reentr.pl
@@ -297,6 +297,8 @@ EOF
         define)
 EOF
     }
+
+    # Process the prototypes
     for my $p (@p) {
         my ($r, $a) = ($p =~ /^(.)_(.+)/);
         my $v = join(", ", map { $m{$_} } split '', $a);
@@ -763,13 +765,14 @@ EOF
 #      endif
 EOF
         }
-                    push @wrap, <<EOF;
+
+        push @wrap, <<EOF;
 #      if defined($func)
 #        define PERL_REENTR_USING_${FUNC}_R
 #      endif
 EOF
 
-            push @wrap, <<EOF;  #  defined(PERL_REENTR_API) && (PERL_REENTR_API+0 == 1)
+        push @wrap, <<EOF;  #  defined(PERL_REENTR_API) && (PERL_REENTR_API+0 == 1)
 #    endif
 EOF
 
@@ -801,7 +804,7 @@ typedef struct {
 
 #endif /* USE_REENTRANT_API */
 
-#endif
+#endif /* File hasn't already been #included */
 EOF
 
 read_only_bottom_close_and_rename($h);

--- a/regen/reentr.pl
+++ b/regen/reentr.pl
@@ -56,7 +56,7 @@ sub open_print_header {
                     { by => 'regen/reentr.pl',
                       from => 'data in regen/reentr.pl',
                       file => $file, style => '*',
-                      copyright => [2002, 2003, 2005 .. 2007],
+                      copyright => [2002, 2003, 2005 .. 2024],
                       quote => $quote });
 }
 


### PR DESCRIPTION
This series of commits updates the comments in this script, plus creates a hash that removes the need for some conditionals in the code, and increases the length of the `strerror_r` buffer to match the corresponding buffer Linux uses.  Usually that kind of detail isn't documented in the Linux man pages; that it is leads me to think that they've thought about this somewhat carefully, and it would be wise of us to make our buffer at least as large as theirs.