### PR TITLE
perl.h: Use ENV mutex even without locales

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -7800,7 +7800,7 @@ cannot have changed since the precalculation.
 
 #endif /* !USE_LOCALE_NUMERIC */
 
-#ifdef USE_LOCALE_THREADS
+#ifdef USE_THREADS
 #  define ENV_LOCK            PERL_WRITE_LOCK(&PL_env_mutex)
 #  define ENV_UNLOCK          PERL_WRITE_UNLOCK(&PL_env_mutex)
 #  define ENV_READ_LOCK       PERL_READ_LOCK(&PL_env_mutex)


### PR DESCRIPTION
I think this was a typo, which our testing never encountered issues with, since this is only triggered on a system without locales; which are extremely rare

Locking the mutex to prevent simultaneous writes to the environment should be independent of if we are using locales on the system.