### PR TITLE
perl.c: Add locks around a *environ access

### DIFF
--- a/perl.c
+++ b/perl.c
@@ -1665,6 +1665,7 @@ dup_environ(pTHX)
 
     size_t n_entries = 0, vars_size = 0;
 
+    ENV_READ_LOCK;
     for (char **ep = environ; *ep; ++ep) {
         ++n_entries;
         vars_size += strlen(*ep) + 1;
@@ -1682,9 +1683,14 @@ dup_environ(pTHX)
         new_environ[i] = (char *) CopyD(environ[i], vars + copied, len, char);
         copied += len;
     }
+
+    ENV_READ_UNLOCK;
+
     new_environ[n_entries] = NULL;
 
+    ENV_LOCK;
     environ = new_environ;
+    ENV_UNLOCK;
     /* Store a pointer in a global variable to ensure it's always reachable so
      * LeakSanitizer/Valgrind won't complain about it. We can't ever free it.
      * Even if libc allocates a new environ, it's possible that some of its


### PR DESCRIPTION
When reading the environment, a read lock is needed; when writing, a write lock.