### PR TITLE
Permit subsequent `use VERSION` of same version

### DIFF
--- a/op.c
+++ b/op.c
@@ -8036,6 +8036,9 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
                 /* if the old version had no side effects, we can allow this
                  * without any warnings or errors */
             }
+            else if (shortver == PL_prevailing_version) {
+                /* requesting the same version again is fine */
+            }
             else if (shortver >= SHORTVER(5, 39)) {
                 croak("use VERSION of 5.39 or above is not permitted while another use VERSION is in scope");
             }

--- a/op.c
+++ b/op.c
@@ -8052,7 +8052,7 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
             else {
                 /* OK let's at least warn */
                 deprecate_fatal_in(WARN_DEPRECATED__SUBSEQUENT_USE_VERSION, "5.46",
-                    "use VERSION while another use VERSION is in scope");
+                    "Changing use VERSION while another use VERSION is in scope");
             }
         }
 

--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -62,13 +62,14 @@ Category: "deprecated::unicode_property_name"
 
 =head2 Perl 5.46
 
-=head3 C<use VERSION> while another C<use VERSION> is in scope
+=head3 Changing C<use VERSION> while another C<use VERSION> is in scope
 
 A C<use VERSION> declaration has many implicit effects on the surrounding
 scope, such as L<strict> and L<feature> flags, or importing L<builtin>
-functions. Once you have a C<use VERSION> statement in scope, any other
-C<use VERSION> statement is now deprecated since Perl 5.39.8, due to the
-increasing complexity of swapping from one prevailing version to another.
+functions. Once you have a C<use VERSION> statement in scope, another
+C<use VERSION> statement with a different version is now deprecated since
+Perl 5.39.8, due to the increasing complexity of swapping from one
+prevailing version to another.
 
 Category: "deprecated::subsequent_use_version"
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -1694,6 +1694,31 @@ The required syntax is
     try { ... }
     catch ($var) { ... }
 
+=item Changing use VERSION while another use VERSION is in scope is now deprecated
+
+(W deprecated) Once you have a C<use VERSION> statement in scope, any
+C<use VERSION> statement that requests a different version is now deprecated,
+due to the increasing complexity of swapping from one prevailing version to
+another.
+
+It is suggested that you do not try to mix multiple different version
+declarations within the same file as it leads to complex behaviours about the
+visibility of features and builtin functions, as well as confusing human
+readers.
+
+If it is essential to have different C<use VERSION> declarations in different
+regions of the same file, you should surround each one by its own enclosing
+scope so the two do not mix.
+
+  {
+    use v5.20;
+    ...
+  }
+  {
+    use v5.36;
+    ...
+  }
+
 =item Character following "\c" must be printable ASCII
 
 (F) In C<\cI<X>>, I<X> must be a printable (non-control) ASCII character.
@@ -7844,30 +7869,6 @@ even if it requests a later version.
 (F) Once you have a C<use VERSION> declaration in scope, you cannot have a
 subsequent one that calls for a Perl version of at least 5.39 while the first
 is visible.
-
-=item use VERSION while another use VERSION is in scope is now deprecated
-
-(W deprecated) Once you have a C<use VERSION> statement in scope, any other
-C<use VERSION> statement is now deprecated, due to the increasing complexity
-of swapping from one prevailing version to another.
-
-It is suggested that you do not try to mix multiple different version
-declarations within the same file as it leads to complex behaviours about the
-visibility of features and builtin functions, as well as confusing human
-readers.
-
-If it is essential to have different C<use VERSION> declarations in different
-regions of the same file, you should surround each one by its own enclosing
-scope so the two do not mix.
-
-  {
-    use v5.20;
-    ...
-  }
-  {
-    use v5.36;
-    ...
-  }
 
 =item Use \x{...} for more than two hex characters in regex; marked by
 S<<-- HERE> in m/%s/

--- a/t/lib/feature/implicit
+++ b/t/lib/feature/implicit
@@ -69,7 +69,7 @@ evalbytes "say 'yes'";
 use 5.014;
 evalbytes;
 EXPECT
-use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 8.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 8.
 say sub
 yes
 evalbytes sub
@@ -81,7 +81,7 @@ print 'ss' =~ /$sharp_s/i ? "ok\n" : "nok\n";
 use v5.14;
 print 'ss' =~ /$sharp_s/i ? "ok\n" : "nok\n";
 EXPECT
-use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 5.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 5.
 nok
 ok
 ########
@@ -93,6 +93,6 @@ print eval "use utf8; q|$long_s|" eq "\x{17f}" ? "ok\n" : "nok\n";
 use v5.15;
 print eval "use utf8; q|$long_s|" eq $long_s ? "ok\n" : "nok\n";
 EXPECT
-use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 6.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 6.
 ok
 ok

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -2178,5 +2178,5 @@ use VERSION while another use VERSION is in scope is deprecated, and will become
 use warnings;
 use v5.12;
 use v5.12;
+# expect no warning because same version
 EXPECT
-use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 3.

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -2162,7 +2162,7 @@ use warnings;
 use v5.12;
 use v5.20;
 EXPECT
-use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 3.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 3.
 ########
 use warnings;
 use v5.8;
@@ -2173,7 +2173,7 @@ use warnings;
 use v5.10;
 use v5.8;
 EXPECT
-use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 3.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 3.
 ########
 use warnings;
 use v5.12;

--- a/t/lib/warnings/pp_ctl
+++ b/t/lib/warnings/pp_ctl
@@ -251,7 +251,7 @@ EXPECT
 use warnings;
 eval 'use 5.012; use 5.14.0';
 EXPECT
-use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at (eval 1) line 1.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at (eval 1) line 1.
 ########
 # SKIP ? !$Config{default_inc_includes_dot}
 # NAME check warning for do with no . in @INC


### PR DESCRIPTION
The recently-added warning about subsequent `use VERSION` statements even triggered on duplicate requests of the same version. It turns out there shouldn't be problems with doing that, so we can relax the message a little to not warn in that particular case.