### PR TITLE
Add is_inf and is_nan functions to builtin::

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -99,6 +99,20 @@ XS(XS_builtin_inf)
     XSRETURN_NV(NV_INF);
 }
 
+XS(XS_builtin_is_inf);
+XS(XS_builtin_is_inf)
+{
+    dXSARGS;
+    SV *val = ST(0);
+    if(items != 1)
+        croak_xs_usage(cv, "val");
+    SvGETMAGIC(val);
+    if(SvNOK(val) && Perl_isinf(SvNV(val)))
+        XSRETURN_YES;
+    else
+        XSRETURN_NO;
+}
+
 XS(XS_builtin_nan);
 XS(XS_builtin_nan)
 {
@@ -107,6 +121,20 @@ XS(XS_builtin_nan)
         croak_xs_usage(cv, "");
     EXTEND(SP, 1);
     XSRETURN_NV(NV_NAN);
+}
+
+XS(XS_builtin_is_nan);
+XS(XS_builtin_is_nan)
+{
+    dXSARGS;
+    SV *val = ST(0);
+    if(items != 1)
+        croak_xs_usage(cv, "val");
+    SvGETMAGIC(val);
+    if(SvNOK(val) && Perl_isnan(SvNV(val)))
+        XSRETURN_YES;
+    else
+        XSRETURN_NO;
 }
 
 enum {
@@ -550,6 +578,8 @@ static const struct BuiltinFuncDescriptor builtins[] = {
 
     /* unary functions */
     { "is_bool",         NO_BUNDLE, &XS_builtin_func1_scalar, &ck_builtin_func1, OP_IS_BOOL,    true  },
+    { "is_inf",          NO_BUNDLE, &XS_builtin_is_inf,       &ck_builtin_func1, 0,             true  },
+    { "is_nan",          NO_BUNDLE, &XS_builtin_is_nan,       &ck_builtin_func1, 0,             true  },
     { "weaken",     SHORTVER(5,39), &XS_builtin_func1_void,   &ck_builtin_func1, OP_WEAKEN,     false },
     { "unweaken",   SHORTVER(5,39), &XS_builtin_func1_void,   &ck_builtin_func1, OP_UNWEAKEN,   false },
     { "is_weak",    SHORTVER(5,39), &XS_builtin_func1_scalar, &ck_builtin_func1, OP_IS_WEAK,    false },

--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -1,4 +1,4 @@
-package builtin 0.014;
+package builtin 0.015;
 
 use strict;
 use warnings;
@@ -154,6 +154,17 @@ This function is currently B<experimental>.
 
 Returns the floating-point infinity value.
 
+=head2 is_inf
+
+    $inf = is_inf($val);
+
+This function is currently B<experimental>.
+
+Returns true when given the postive or negative floating-point infinity values,
+false if not. A floating-point infinity value can be generated when certain
+floating-point operations are performed, based on platform-specific floating
+point handling.
+
 =head2 nan
 
     $num = nan;
@@ -161,6 +172,16 @@ Returns the floating-point infinity value.
 This function is currently B<experimental>.
 
 Returns the floating-point "Not-a-Number" value.
+
+=head2 is_nan
+
+    $nan = is_nan($val);
+
+This function is currently B<experimental>.
+
+Returns true when given the floating-point "Not-A-Number" value, false if not.
+The floating-point NaN value can be generated when certain floating-point
+operations are performed, based on platform-specific floating point handling.
 
 =head2 weaken
 

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -51,14 +51,16 @@ package FetchStoreCounter {
     is(prototype(\&builtin::is_bool), '$', 'is_bool prototype');
 }
 
-# float constants
+# floats
 {
-    use builtin qw( inf nan );
+    use builtin qw( inf nan is_inf is_nan is_bool );
 
     ok(inf, 'inf is true');
     ok(inf > 1E10, 'inf is bigger than 1E10');
     ok(inf == inf, 'inf is equal to inf');
     ok(inf == inf + 1, 'inf is equal to inf + 1');
+
+    ok(inf != -inf, 'inf is not equal to -inf');
 
     # Invoke the real XSUB
     my $inf = ( \&builtin::inf )->();
@@ -68,6 +70,36 @@ package FetchStoreCounter {
 
     my $nan = ( \&builtin::nan )->();
     ok($nan != $nan, 'NaN returned by real xsub');
+
+    # Test is_inf and is_nan from various sources
+    ok(is_inf(inf), 'is_inf(inf) is true');
+    ok(is_inf(-inf), 'is_inf(-inf) is true');
+    ok(is_nan(nan), 'is_nan(nan) is true');
+
+    ok(is_inf($inf), 'is_inf(inf) from xsub is true');
+    ok(is_inf($inf), 'is_inf(inf) from xsub is true');
+    ok(is_nan($nan), 'is_nan(nan) from xsub is true');
+
+    ok(is_nan(1*(inf-inf)), 'is_nan is true for calculated nan');
+    ok(is_inf(9**9**9), 'is_inf is true for calculated inf');
+
+    # Try some obvious variations that should fail.
+    ok(!is_nan($inf), 'is_nan(inf) is false');
+    ok(!is_inf($nan), 'is_inf(nan) is false');
+
+    # Strings that look like stringified floats should not pass
+    ok(!is_nan('NaN'), 'is_nan(\'NaN\') is false');
+    ok(!is_inf('inf'), 'is_inf(\'inf\') is false');
+
+    ok(!is_nan(0), 'is_nan(0) is false');
+    ok(!is_inf(0), 'is_inf(0) is false');
+
+    ok(!is_nan(0.0), 'is_nan(0.0) is false');
+    ok(!is_inf(0.0), 'is_inf(0.0) is false');
+
+    # Ensure that is_nan and is_inf return real bools
+    ok(is_bool(is_nan($nan)), 'is_nan returns bool');
+    ok(is_bool(is_inf($inf)), 'is_inf returns bool');
 }
 
 # weakrefs


### PR DESCRIPTION
As it is not expected that these two functions are likely to be called very often, I didn't bother making inlined-opcode variants of them as per e.g. is_bool(). Instead these are just regular XSUBs like trim() is.

Testing-wise, I'm a little unsure about the use of `1 * (inf - inf)` to get a calculated NaN value, but I really couldn't think of anything else that actually works. Is it portable enough?