### PR TITLE
Remove the tombstone-related code from pad.h + pad.c

### DIFF
--- a/Porting/deparse-skips.txt
+++ b/Porting/deparse-skips.txt
@@ -279,11 +279,6 @@ uni/variables.t
 ../lib/dumpvar.t
 ../lib/English.t
 
-# 18 Feb 24. This is probably failing due to the new PADNAMEf_TOMBSTONE
-# thing, which is likely to be removed again before 5.40. The test failure
-# can be reduced to: use builtin 'true'; no builtin 'true';
-../lib/builtin.t
-
 ../lib/overload.t
 
 

--- a/pad.h
+++ b/pad.h
@@ -150,7 +150,6 @@ typedef enum {
                                             * sub, but only one level up */
 #define padadd_FIELD            0x10       /* set PADNAMEt_FIELD */
 #define padfind_FIELD_OK        0x20       /* pad_findlex is permitted to see fields */
-#define padadd_TOMBSTONE        0x40       /* set PadnameIsTOMBSTONE on the new entry */
 
 /* ASSERT_CURPAD_LEGAL and ASSERT_CURPAD_ACTIVE respectively determine
  * whether PL_comppad and PL_curpad are consistent and whether they have
@@ -263,11 +262,6 @@ Whether this is a "state" variable.
 Whether this is a "field" variable.  PADNAMEs where this is true will
 have additional information available via C<PadnameFIELDINFO>.
 
-=for apidoc m|bool|PadnameIsTOMBSTONE|PADNAME * pn
-Whether this pad entry is a tombstone.  Such an entry indicates that a
-previously-valid pad entry has now been deleted within this scope, and
-should be ignored.
-
 =for apidoc m|HV *|PadnameTYPE|PADNAME * pn
 The stash associated with a typed lexical.  This returns the C<%Foo::> hash
 for C<my Foo $bar>.
@@ -360,7 +354,6 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PadnameIsSTATE(pn)	(PadnameFLAGS(pn) & PADNAMEf_STATE)
 #define PadnameLVALUE(pn)	(PadnameFLAGS(pn) & PADNAMEf_LVALUE)
 #define PadnameIsFIELD(pn)	(PadnameFLAGS(pn) & PADNAMEf_FIELD)
-#define PadnameIsTOMBSTONE(pn)  (PadnameFLAGS(pn) & PADNAMEf_TOMBSTONE)
 
 #define PadnameLVALUE_on(pn)    (PadnameFLAGS(pn) |= PADNAMEf_LVALUE)
 #define PadnameIsSTATE_on(pn)   (PadnameFLAGS(pn) |= PADNAMEf_STATE)
@@ -371,7 +364,6 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PADNAMEf_TYPED      0x08    /* for B; unused by core */
 #define PADNAMEf_OUR        0x10    /* for B; unused by core */
 #define PADNAMEf_FIELD      0x20    /* field var */
-#define PADNAMEf_TOMBSTONE  0x40    /* padname has been deleted */
 
 /* backward compatibility */
 #ifndef PERL_CORE


### PR DESCRIPTION
This was a short-lived experimental feature intended to implement removal of lexical symbols, in order to provide syntax like `no builtin ...` or to remove implied imported builtins on a change of prevailing `use VERSION`. The model of removing a lexical has proven to be too subtle and complex to implement as well as raising various awkward questions about the semantics, so we decided to remove it again in Perl 5.39.8. There is now no longer any code that uses `PADNAMEf_TOMBSTONE`.

As `PADNAMEf_TOMBSTONE` was only added in earlier in the 5.39.x developent series, there is no need to retain the constants in .h files for compatibility or to reserve the numbers for them. They have never appeared in a stable release of Perl.