### PR TITLE
Fast exit undef/empty strings in `Data::Dumper::qquote()`

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3564,6 +3564,7 @@ dist/Data-Dumper/t/overload.t			See if Data::Dumper works for overloaded data
 dist/Data-Dumper/t/pair.t			See if Data::Dumper pair separator works
 dist/Data-Dumper/t/perl-74170.t			Regression test for stack reallocation
 dist/Data-Dumper/t/purity_deepcopy_maxdepth.t	See if three Data::Dumper functions work
+dist/Data-Dumper/t/qquote.t				See if Data::Dumper::qquote() works
 dist/Data-Dumper/t/qr.t				See if Data::Dumper works with qr|/|
 dist/Data-Dumper/t/quotekeys.t			See if Data::Dumper::Quotekeys works
 dist/Data-Dumper/t/recurse.t			See if Data::Dumper::Maxrecurse works

--- a/MANIFEST
+++ b/MANIFEST
@@ -3564,7 +3564,7 @@ dist/Data-Dumper/t/overload.t			See if Data::Dumper works for overloaded data
 dist/Data-Dumper/t/pair.t			See if Data::Dumper pair separator works
 dist/Data-Dumper/t/perl-74170.t			Regression test for stack reallocation
 dist/Data-Dumper/t/purity_deepcopy_maxdepth.t	See if three Data::Dumper functions work
-dist/Data-Dumper/t/qquote.t				See if Data::Dumper::qquote() works
+dist/Data-Dumper/t/qquote.t			See if Data::Dumper::qquote() works
 dist/Data-Dumper/t/qr.t				See if Data::Dumper works with qr|/|
 dist/Data-Dumper/t/quotekeys.t			See if Data::Dumper::Quotekeys works
 dist/Data-Dumper/t/recurse.t			See if Data::Dumper::Maxrecurse works

--- a/dist/Data-Dumper/Dumper.pm
+++ b/dist/Data-Dumper/Dumper.pm
@@ -30,7 +30,7 @@ our ( $Indent, $Trailingcomma, $Purity, $Pad, $Varname, $Useqq, $Terse, $Freezer
 our ( @ISA, @EXPORT, @EXPORT_OK, $VERSION );
 
 BEGIN {
-    $VERSION = '2.189'; # Don't forget to set version and release
+    $VERSION = '2.190'; # Don't forget to set version and release
                         # date in POD below!
 
     @ISA = qw(Exporter);
@@ -760,6 +760,7 @@ my $low_controls_re = qr/[$low_controls]/;
 # put a string value in double quotes
 sub qquote {
   local($_) = shift;
+  return qq("") unless defined && length;  # fast exit if undef/empty
   s/([\\\"\@\$])/\\$1/g;
 
   # This efficiently changes the high ordinal characters to \x{} if the utf8
@@ -1455,7 +1456,7 @@ modify it under the same terms as Perl itself.
 
 =head1 VERSION
 
-Version 2.189
+Version 2.190
 
 =head1 SEE ALSO
 

--- a/dist/Data-Dumper/t/qquote.t
+++ b/dist/Data-Dumper/t/qquote.t
@@ -1,0 +1,80 @@
+#!./perl -w
+# t/qquote.t - Test qquote()
+
+use strict;
+use warnings;
+
+use Test::More tests => 16;
+use Data::Dumper;
+
+{
+    my $warning = '';
+    local $SIG{__WARN__} = sub { $warning = $_[0] };
+
+    my $str = Data::Dumper::qquote("");
+    is($str,   q{""}, q{qquote("") returned ""});
+    is($warning, "",  q{qquote("") did not warn});
+}
+
+{
+    my $warning = '';
+    local $SIG{__WARN__} = sub { $warning = $_[0] };
+
+    my $str = Data::Dumper::qquote();
+    is($str,   q{""}, q{qquote() returned ""});
+    is($warning, "",  q{qquote() did not warn});
+}
+
+{
+    my $warning = '';
+    local $SIG{__WARN__} = sub { $warning = $_[0] };
+
+    my $str = Data::Dumper::qquote(undef);
+    is($str,   q{""}, q{qquote(undef) returned ""});
+    is($warning, "",  q{qquote(undef) did not warn});
+}
+
+{
+    my $warning = '';
+    local $SIG{__WARN__} = sub { $warning = $_[0] };
+
+    my $str = Data::Dumper::qquote("simple");
+    is($str,   q{"simple"}, q{qquote("simple") returned "simple"});
+    is($warning, "",        q{qquote("simple") did not warn});
+}
+
+{
+    my $warning = '';
+    local $SIG{__WARN__} = sub { $warning = $_[0] };
+
+    my $str = Data::Dumper::qquote(q{check 'single' quote});
+    is($str,   q{"check 'single' quote"}, q{qquote('single') returned correctly});
+    is($warning, "", q{qquote('single') did not warn});
+}
+
+{
+    my $warning = '';
+    local $SIG{__WARN__} = sub { $warning = $_[0] };
+
+    my $str = Data::Dumper::qquote(q{check "double" quote});
+    is($str,     q{"check \"double\" quote"}, q{qquote("double") returned correctly});
+    is($warning, "", 'qquote(undef) did not warn');
+}
+
+{
+    my $warning = '';
+    local $SIG{__WARN__} = sub { $warning = $_[0] };
+
+    my $str = Data::Dumper::qquote(qq{check \a quote});
+    is($str,     q{"check \a quote"}, q{qquote("\a") returned correctly});
+    is($warning, "", 'qquote(undef) did not warn');
+}
+
+{
+    my $warning = '';
+    local $SIG{__WARN__} = sub { $warning = $_[0] };
+
+    my $str = Data::Dumper::qquote(qq{check \cg quote});
+    is($str,     q{"check \a quote"}, q{qquote("\cg") returned correctly});
+    is($warning, "", 'qquote(undef) did not warn');
+}


### PR DESCRIPTION
This silences a squajillion (okay, five) "uninitialized" warnings, and is more efficient, anyway...