### PR TITLE
locale_threads.t: Reenable DragonFly testing

### DIFF
--- a/lib/locale_threads.t
+++ b/lib/locale_threads.t
@@ -11,8 +11,8 @@ BEGIN {
     set_up_inc('../lib');
 
     skip_all_without_config('useithreads');
-    skip_all("Fails on threaded builds on OpenBSD and DragonFly BSD")
-        if ($^O =~ m/^(openbsd|dragonfly)$/);
+    skip_all("Fails on threaded builds on OpenBSD")
+        if ($^O =~ m/^(openbsd)$/);
 
     require './loc_tools.pl';
 


### PR DESCRIPTION
This was instituted by 1d74e8214dd53cf0fa9e8c5aab3e6187685eadcd, but ae3e9dd0b31e37357f00d0a83f0b3f4a2713f420 should have fixed this.