### PR TITLE
t/op/require_errors.t, t/op/stat.t: skip permissions test on AFS

### DIFF
--- a/ext/POSIX/t/termios.t
+++ b/ext/POSIX/t/termios.t
@@ -3,6 +3,7 @@
 use strict;
 use Config;
 use Test::More;
+use Cwd "getcwd";
 
 BEGIN {
     plan skip_all => "POSIX is unavailable"
@@ -47,6 +48,10 @@ foreach (undef, qw(STDIN STDOUT STDERR)) {
     }
 }
 
+my $cwd = getcwd;
+my $is_afs_path = $Config{afs} eq "true" &&
+  $cwd && $cwd =~ /^\Q$Config{afsroot}/;
+
 open my $not_a_tty, '<', $^X or die "Can't open $^X: $!";
 
 if (defined $termios) {
@@ -75,6 +80,8 @@ if (defined $termios) {
         # https://bugs.dragonflybsd.org/issues/3252
         local $TODO = "dragonfly returns bad errno"
             if $^O eq 'dragonfly';
+        local $TODO = "AFS doesn't report ENOTTY as it should"
+            if $is_afs_path;
         cmp_ok($!, '==', POSIX::ENOTTY, 'and set errno to ENOTTY');
     }
 
@@ -85,6 +92,8 @@ if (defined $termios) {
         # https://bugs.dragonflybsd.org/issues/3252
         local $TODO = "dragonfly returns bad errno"
             if $^O eq 'dragonfly';
+        local $TODO = "AFS doesn't report ENOTTY as it should"
+            if $is_afs_path;
         cmp_ok($!, '==', POSIX::ENOTTY, 'and set errno to ENOTTY');
     }
 }
@@ -174,6 +183,8 @@ is(tcdrain(fileno $not_a_tty), undef, 'tcdrain on a non tty should fail');
     # https://bugs.dragonflybsd.org/issues/3252
     local $TODO = "dragonfly returns bad errno"
         if $^O eq 'dragonfly';
+    local $TODO = "AFS doesn't report ENOTTY as it should"
+        if $is_afs_path;
     cmp_ok($!, '==', POSIX::ENOTTY, 'and set errno to ENOTTY');
 }
 
@@ -183,6 +194,8 @@ is(tcflow(fileno $not_a_tty, TCOON), undef, 'tcflow on a non tty should fail');
     # https://bugs.dragonflybsd.org/issues/3252
     local $TODO = "dragonfly returns bad errno"
         if $^O eq 'dragonfly';
+    local $TODO = "AFS doesn't report ENOTTY as it should"
+        if $is_afs_path;
     cmp_ok($!, '==', POSIX::ENOTTY, 'and set errno to ENOTTY');
 }
 
@@ -193,6 +206,8 @@ is(tcflush(fileno $not_a_tty, TCOFLUSH), undef,
     # https://bugs.dragonflybsd.org/issues/3252
     local $TODO = "dragonfly returns bad errno"
         if $^O eq 'dragonfly';
+    local $TODO = "AFS doesn't report ENOTTY as it should"
+        if $is_afs_path;
     cmp_ok($!, '==', POSIX::ENOTTY, 'and set errno to ENOTTY');
 }
 
@@ -203,6 +218,8 @@ is(tcsendbreak(fileno $not_a_tty, 0), undef,
     # https://bugs.dragonflybsd.org/issues/3252
     local $TODO = "dragonfly returns bad errno"
         if $^O eq 'dragonfly';
+    local $TODO = "AFS doesn't report ENOTTY as it should"
+        if $is_afs_path;
     cmp_ok($!, '==', POSIX::ENOTTY, 'and set errno to ENOTTY');
 }
 

--- a/t/op/require_errors.t
+++ b/t/op/require_errors.t
@@ -177,9 +177,14 @@ SKIP: {
     push @INC, '../lib';
     require Cwd;
     require File::Spec::Functions;
+    require Config;
     if ($^O eq 'cygwin') {
         require Win32;
     }
+
+    my $cwd = Cwd::getcwd();
+    skip "AFS", 2 # github 22068
+      if $Config::Config{afs} eq "true" && $cwd && $cwd =~ /^\Q$Config::Config{afsroot}/;
 
     # Going to try to switch away from root.  Might not work.
     # (stolen from t/op/stat.t)
@@ -196,9 +201,9 @@ SKIP: {
 
     SKIP: {
         skip "Can't make the path absolute", 1
-            if !defined(Cwd::getcwd());
+            if !defined $cwd;
 
-        my $file = File::Spec::Functions::catfile(Cwd::getcwd(), $mod_file);
+        my $file = File::Spec::Functions::catfile($cwd, $mod_file);
         eval {
             require($file);
         };

--- a/t/op/stat.t
+++ b/t/op/stat.t
@@ -548,7 +548,10 @@ SKIP: {
 }
 
 # [perl #4253]
+SKIP:
 {
+    skip "AFS", 3 # github 22067
+      if $Config{afs} eq "true" && ($Curdir eq '.' || $Curdir =~ /^\Q$Config{afsroot}/);
     ok(open(F, ">", $tmpfile), 'can create temp file');
     close F;
     chmod 0077, $tmpfile;


### PR DESCRIPTION
Fixes #22068

Fixes #22067