### PR TITLE
Reorder perl.h with regard to mutex locking

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -7269,28 +7269,6 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #define gwLOCALE_LOCK    LOCALE_LOCK_(0)
 #define gwLOCALE_UNLOCK  LOCALE_UNLOCK_
 
-/* setlocale() generally returns in a global static buffer, but not on Windows
- * when operating in thread-safe mode */
-#if defined(WIN32) && defined(USE_THREAD_SAFE_LOCALE)
-#  define POSIX_SETLOCALE_LOCK                                              \
-            STMT_START {                                                    \
-                if (_configthreadlocale(0) == _DISABLE_PER_THREAD_LOCALE)   \
-                    gwLOCALE_LOCK;                                          \
-            } STMT_END
-#  define POSIX_SETLOCALE_UNLOCK                                            \
-            STMT_START {                                                    \
-                if (_configthreadlocale(0) == _DISABLE_PER_THREAD_LOCALE)   \
-                    gwLOCALE_UNLOCK;                                        \
-            } STMT_END
-#else
-#  define POSIX_SETLOCALE_LOCK      gwLOCALE_LOCK
-#  define POSIX_SETLOCALE_UNLOCK    gwLOCALE_UNLOCK
-#endif
-
-/* It handles _wsetlocale() as well */
-#define WSETLOCALE_LOCK      POSIX_SETLOCALE_LOCK
-#define WSETLOCALE_UNLOCK    POSIX_SETLOCALE_UNLOCK
-
 /* Similar to gwLOCALE_LOCK, there are functions that require both the locale
  * and environment to be constant during their execution, and don't change
  * either of those things, but do write to some sort of shared global space.
@@ -7320,6 +7298,28 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 /* Currently, the read lock is an exclusive lock */
 #define LOCALE_READ_LOCK                LOCALE_LOCK
 #define LOCALE_READ_UNLOCK              LOCALE_UNLOCK
+
+/* setlocale() generally returns in a global static buffer, but not on Windows
+ * when operating in thread-safe mode */
+#if defined(WIN32) && defined(USE_THREAD_SAFE_LOCALE)
+#  define POSIX_SETLOCALE_LOCK                                              \
+            STMT_START {                                                    \
+                if (_configthreadlocale(0) == _DISABLE_PER_THREAD_LOCALE)   \
+                    gwLOCALE_LOCK;                                          \
+            } STMT_END
+#  define POSIX_SETLOCALE_UNLOCK                                            \
+            STMT_START {                                                    \
+                if (_configthreadlocale(0) == _DISABLE_PER_THREAD_LOCALE)   \
+                    gwLOCALE_UNLOCK;                                        \
+            } STMT_END
+#else
+#  define POSIX_SETLOCALE_LOCK      gwLOCALE_LOCK
+#  define POSIX_SETLOCALE_UNLOCK    gwLOCALE_UNLOCK
+#endif
+
+/* It handles _wsetlocale() as well */
+#define WSETLOCALE_LOCK      POSIX_SETLOCALE_LOCK
+#define WSETLOCALE_UNLOCK    POSIX_SETLOCALE_UNLOCK
 
 
 #ifndef LC_NUMERIC_LOCK

--- a/perl.h
+++ b/perl.h
@@ -7049,134 +7049,6 @@ typedef struct am_table_short AMTS;
 #  define GETENV_UNLOCK   NOOP
 #endif
 
-#ifdef USE_LOCALE /* These locale things are all subject to change */
-
-   /* Returns TRUE if the plain locale pragma without a parameter is in effect.
-    * */
-#  define IN_LOCALE_RUNTIME	(PL_curcop                                  \
-                              && CopHINTS_get(PL_curcop) & HINT_LOCALE)
-
-   /* Returns TRUE if either form of the locale pragma is in effect */
-#  define IN_SOME_LOCALE_FORM_RUNTIME                                       \
-        cBOOL(CopHINTS_get(PL_curcop) & (HINT_LOCALE|HINT_LOCALE_PARTIAL))
-
-#  define IN_LOCALE_COMPILETIME	cBOOL(PL_hints & HINT_LOCALE)
-#  define IN_SOME_LOCALE_FORM_COMPILETIME                                   \
-                        cBOOL(PL_hints & (HINT_LOCALE|HINT_LOCALE_PARTIAL))
-
-/*
-=for apidoc_section $locale
-
-=for apidoc Amn|bool|IN_LOCALE
-
-Evaluates to TRUE if the plain locale pragma without a parameter (S<C<use
-locale>>) is in effect.
-
-=for apidoc Amn|bool|IN_LOCALE_COMPILETIME
-
-Evaluates to TRUE if, when compiling a perl program (including an C<eval>) if
-the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
-
-=for apidoc Amn|bool|IN_LOCALE_RUNTIME
-
-Evaluates to TRUE if, when executing a perl program (including an C<eval>) if
-the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
-
-=cut
-*/
-
-#  define IN_LOCALE                                                         \
-        (IN_PERL_COMPILETIME ? IN_LOCALE_COMPILETIME : IN_LOCALE_RUNTIME)
-#  define IN_SOME_LOCALE_FORM                                               \
-                    (IN_PERL_COMPILETIME ? IN_SOME_LOCALE_FORM_COMPILETIME  \
-                                         : IN_SOME_LOCALE_FORM_RUNTIME)
-
-#  define IN_LC_ALL_COMPILETIME   IN_LOCALE_COMPILETIME
-#  define IN_LC_ALL_RUNTIME       IN_LOCALE_RUNTIME
-
-#  define IN_LC_PARTIAL_COMPILETIME   cBOOL(PL_hints & HINT_LOCALE_PARTIAL)
-#  define IN_LC_PARTIAL_RUNTIME                                             \
-              (PL_curcop && CopHINTS_get(PL_curcop) & HINT_LOCALE_PARTIAL)
-
-#  define IN_LC_COMPILETIME(category)                                       \
-       (       IN_LC_ALL_COMPILETIME                                        \
-        || (   IN_LC_PARTIAL_COMPILETIME                                    \
-            && Perl__is_in_locale_category(aTHX_ TRUE, (category))))
-#  define IN_LC_RUNTIME(category)                                           \
-      (IN_LC_ALL_RUNTIME || (IN_LC_PARTIAL_RUNTIME                          \
-                 && Perl__is_in_locale_category(aTHX_ FALSE, (category))))
-#  define IN_LC(category)  \
-                    (IN_LC_COMPILETIME(category) || IN_LC_RUNTIME(category))
-
-#  if defined (PERL_CORE) || defined (PERL_IN_XSUB_RE)
-
-     /* This internal macro should be called from places that operate under
-      * locale rules.  If there is a problem with the current locale that
-      * hasn't been raised yet, it will output a warning this time.  Because
-      * this will so rarely  be true, there is no point to optimize for time;
-      * instead it makes sense to minimize space used and do all the work in
-      * the rarely called function */
-#    ifdef USE_LOCALE_CTYPE
-#      define CHECK_AND_WARN_PROBLEMATIC_LOCALE_                              \
-                STMT_START {                                                  \
-                    if (UNLIKELY(PL_warn_locale)) {                           \
-                        Perl_warn_problematic_locale();                       \
-                    }                                                         \
-                }  STMT_END
-#    else
-#      define CHECK_AND_WARN_PROBLEMATIC_LOCALE_
-#    endif
-
-
-     /* These two internal macros are called when a warning should be raised,
-      * and will do so if enabled.  The first takes a single code point
-      * argument; the 2nd, is a pointer to the first byte of the UTF-8 encoded
-      * string, and an end position which it won't try to read past */
-#    define _CHECK_AND_OUTPUT_WIDE_LOCALE_CP_MSG(cp)                        \
-        STMT_START {                                                        \
-            if (! IN_UTF8_CTYPE_LOCALE && ckWARN(WARN_LOCALE)) {            \
-                Perl_warner(aTHX_ packWARN(WARN_LOCALE),                    \
-                                       "Wide character (U+%" UVXf ") in %s",\
-                                       (UV) cp, OP_DESC(PL_op));            \
-            }                                                               \
-        }  STMT_END
-
-#    define _CHECK_AND_OUTPUT_WIDE_LOCALE_UTF8_MSG(s, send)                 \
-        STMT_START { /* Check if to warn before doing the conversion work */\
-            if (! IN_UTF8_CTYPE_LOCALE && ckWARN(WARN_LOCALE)) {            \
-                UV cp = utf8_to_uvchr_buf((U8 *) (s), (U8 *) (send), NULL); \
-                Perl_warner(aTHX_ packWARN(WARN_LOCALE),                    \
-                    "Wide character (U+%" UVXf ") in %s",                   \
-                    (cp == 0)                                               \
-                     ? UNICODE_REPLACEMENT                                  \
-                     : (UV) cp,                                             \
-                    OP_DESC(PL_op));                                        \
-            }                                                               \
-        }  STMT_END
-
-#  endif   /* PERL_CORE or PERL_IN_XSUB_RE */
-#else   /* No locale usage */
-#  define IN_LOCALE_RUNTIME                0
-#  define IN_SOME_LOCALE_FORM_RUNTIME      0
-#  define IN_LOCALE_COMPILETIME            0
-#  define IN_SOME_LOCALE_FORM_COMPILETIME  0
-#  define IN_LOCALE                        0
-#  define IN_SOME_LOCALE_FORM              0
-#  define IN_LC_ALL_COMPILETIME            0
-#  define IN_LC_ALL_RUNTIME                0
-#  define IN_LC_PARTIAL_COMPILETIME        0
-#  define IN_LC_PARTIAL_RUNTIME            0
-#  define IN_LC_COMPILETIME(category)      0
-#  define IN_LC_RUNTIME(category)          0
-#  define IN_LC(category)                  0
-#  define CHECK_AND_WARN_PROBLEMATIC_LOCALE_
-#  define _CHECK_AND_OUTPUT_WIDE_LOCALE_UTF8_MSG(s, send)
-#  define _CHECK_AND_OUTPUT_WIDE_LOCALE_CP_MSG(c)
-#endif
-
-#define locale_panic_via_(m, f, l)  Perl_locale_panic((m), __LINE__, f, l)
-#define locale_panic_(m)  locale_panic_via_((m), __FILE__, __LINE__)
-
 /* Locale/thread synchronization macros. */
 #if ! defined(USE_LOCALE_THREADS)   /* No threads, or no locales */
 #  define LOCALE_LOCK_(cond)  NOOP
@@ -7508,6 +7380,134 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #define STRFMON_UNLOCK      LC_MONETARY_UNLOCK
 
 /* End of locale/env synchronization */
+
+#ifdef USE_LOCALE /* These locale things are all subject to change */
+
+   /* Returns TRUE if the plain locale pragma without a parameter is in effect.
+    * */
+#  define IN_LOCALE_RUNTIME	(PL_curcop                                  \
+                              && CopHINTS_get(PL_curcop) & HINT_LOCALE)
+
+   /* Returns TRUE if either form of the locale pragma is in effect */
+#  define IN_SOME_LOCALE_FORM_RUNTIME                                       \
+        cBOOL(CopHINTS_get(PL_curcop) & (HINT_LOCALE|HINT_LOCALE_PARTIAL))
+
+#  define IN_LOCALE_COMPILETIME	cBOOL(PL_hints & HINT_LOCALE)
+#  define IN_SOME_LOCALE_FORM_COMPILETIME                                   \
+                        cBOOL(PL_hints & (HINT_LOCALE|HINT_LOCALE_PARTIAL))
+
+/*
+=for apidoc_section $locale
+
+=for apidoc Amn|bool|IN_LOCALE
+
+Evaluates to TRUE if the plain locale pragma without a parameter (S<C<use
+locale>>) is in effect.
+
+=for apidoc Amn|bool|IN_LOCALE_COMPILETIME
+
+Evaluates to TRUE if, when compiling a perl program (including an C<eval>) if
+the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
+
+=for apidoc Amn|bool|IN_LOCALE_RUNTIME
+
+Evaluates to TRUE if, when executing a perl program (including an C<eval>) if
+the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
+
+=cut
+*/
+
+#  define IN_LOCALE                                                         \
+        (IN_PERL_COMPILETIME ? IN_LOCALE_COMPILETIME : IN_LOCALE_RUNTIME)
+#  define IN_SOME_LOCALE_FORM                                               \
+                    (IN_PERL_COMPILETIME ? IN_SOME_LOCALE_FORM_COMPILETIME  \
+                                         : IN_SOME_LOCALE_FORM_RUNTIME)
+
+#  define IN_LC_ALL_COMPILETIME   IN_LOCALE_COMPILETIME
+#  define IN_LC_ALL_RUNTIME       IN_LOCALE_RUNTIME
+
+#  define IN_LC_PARTIAL_COMPILETIME   cBOOL(PL_hints & HINT_LOCALE_PARTIAL)
+#  define IN_LC_PARTIAL_RUNTIME                                             \
+              (PL_curcop && CopHINTS_get(PL_curcop) & HINT_LOCALE_PARTIAL)
+
+#  define IN_LC_COMPILETIME(category)                                       \
+       (       IN_LC_ALL_COMPILETIME                                        \
+        || (   IN_LC_PARTIAL_COMPILETIME                                    \
+            && Perl__is_in_locale_category(aTHX_ TRUE, (category))))
+#  define IN_LC_RUNTIME(category)                                           \
+      (IN_LC_ALL_RUNTIME || (IN_LC_PARTIAL_RUNTIME                          \
+                 && Perl__is_in_locale_category(aTHX_ FALSE, (category))))
+#  define IN_LC(category)  \
+                    (IN_LC_COMPILETIME(category) || IN_LC_RUNTIME(category))
+
+#  if defined (PERL_CORE) || defined (PERL_IN_XSUB_RE)
+
+     /* This internal macro should be called from places that operate under
+      * locale rules.  If there is a problem with the current locale that
+      * hasn't been raised yet, it will output a warning this time.  Because
+      * this will so rarely  be true, there is no point to optimize for time;
+      * instead it makes sense to minimize space used and do all the work in
+      * the rarely called function */
+#    ifdef USE_LOCALE_CTYPE
+#      define CHECK_AND_WARN_PROBLEMATIC_LOCALE_                              \
+                STMT_START {                                                  \
+                    if (UNLIKELY(PL_warn_locale)) {                           \
+                        Perl_warn_problematic_locale();                       \
+                    }                                                         \
+                }  STMT_END
+#    else
+#      define CHECK_AND_WARN_PROBLEMATIC_LOCALE_
+#    endif
+
+
+     /* These two internal macros are called when a warning should be raised,
+      * and will do so if enabled.  The first takes a single code point
+      * argument; the 2nd, is a pointer to the first byte of the UTF-8 encoded
+      * string, and an end position which it won't try to read past */
+#    define _CHECK_AND_OUTPUT_WIDE_LOCALE_CP_MSG(cp)                        \
+        STMT_START {                                                        \
+            if (! IN_UTF8_CTYPE_LOCALE && ckWARN(WARN_LOCALE)) {            \
+                Perl_warner(aTHX_ packWARN(WARN_LOCALE),                    \
+                                       "Wide character (U+%" UVXf ") in %s",\
+                                       (UV) cp, OP_DESC(PL_op));            \
+            }                                                               \
+        }  STMT_END
+
+#    define _CHECK_AND_OUTPUT_WIDE_LOCALE_UTF8_MSG(s, send)                 \
+        STMT_START { /* Check if to warn before doing the conversion work */\
+            if (! IN_UTF8_CTYPE_LOCALE && ckWARN(WARN_LOCALE)) {            \
+                UV cp = utf8_to_uvchr_buf((U8 *) (s), (U8 *) (send), NULL); \
+                Perl_warner(aTHX_ packWARN(WARN_LOCALE),                    \
+                    "Wide character (U+%" UVXf ") in %s",                   \
+                    (cp == 0)                                               \
+                     ? UNICODE_REPLACEMENT                                  \
+                     : (UV) cp,                                             \
+                    OP_DESC(PL_op));                                        \
+            }                                                               \
+        }  STMT_END
+
+#  endif   /* PERL_CORE or PERL_IN_XSUB_RE */
+#else   /* No locale usage */
+#  define IN_LOCALE_RUNTIME                0
+#  define IN_SOME_LOCALE_FORM_RUNTIME      0
+#  define IN_LOCALE_COMPILETIME            0
+#  define IN_SOME_LOCALE_FORM_COMPILETIME  0
+#  define IN_LOCALE                        0
+#  define IN_SOME_LOCALE_FORM              0
+#  define IN_LC_ALL_COMPILETIME            0
+#  define IN_LC_ALL_RUNTIME                0
+#  define IN_LC_PARTIAL_COMPILETIME        0
+#  define IN_LC_PARTIAL_RUNTIME            0
+#  define IN_LC_COMPILETIME(category)      0
+#  define IN_LC_RUNTIME(category)          0
+#  define IN_LC(category)                  0
+#  define CHECK_AND_WARN_PROBLEMATIC_LOCALE_
+#  define _CHECK_AND_OUTPUT_WIDE_LOCALE_UTF8_MSG(s, send)
+#  define _CHECK_AND_OUTPUT_WIDE_LOCALE_CP_MSG(c)
+#endif
+
+#define locale_panic_via_(m, f, l)  Perl_locale_panic((m), __LINE__, f, l)
+#define locale_panic_(m)  locale_panic_via_((m), __FILE__, __LINE__)
 
 #ifdef USE_LOCALE_NUMERIC
 

--- a/perl.h
+++ b/perl.h
@@ -7178,15 +7178,19 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #define locale_panic_(m)  locale_panic_via_((m), __FILE__, __LINE__)
 
 /* Locale/thread synchronization macros. */
-#if ! defined(USE_LOCALE_THREADS)
+#if ! defined(USE_LOCALE_THREADS)   /* No threads, or no locales */
 #  define LOCALE_LOCK_(cond)  NOOP
 #  define LOCALE_UNLOCK_      NOOP
+#  define LOCALE_LOCK         NOOP
+#  define LOCALE_UNLOCK       NOOP
 #  define LOCALE_INIT
 #  define LOCALE_TERM
 
 #else   /* Below: Threaded, and locales are supported */
 
-    /* A locale mutex is required on all such threaded builds. */
+    /* A locale mutex is required on all such threaded builds for at least
+     * situations where there is a global static buffer.  This base lock that
+     * handles these has a trailing underscore in the name */
 #  define LOCALE_LOCK_(cond_to_panic_if_already_locked)                     \
        PERL_REENTRANT_LOCK("locale",                                        \
                            &PL_locale_mutex, PL_locale_mutex_depth,         \
@@ -7194,13 +7198,19 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  define LOCALE_UNLOCK_                                                    \
        PERL_REENTRANT_UNLOCK("locale",                                      \
                              &PL_locale_mutex, PL_locale_mutex_depth)
-
-#  ifndef USE_THREAD_SAFE_LOCALE
-
-     /* By definition, a thread-unsafe locale means we need a critical
-      * section. */
-#    define LOCALE_LOCK    LOCALE_LOCK_(0)
-#    define LOCALE_UNLOCK  LOCALE_UNLOCK_
+#  ifdef USE_THREAD_SAFE_LOCALE
+    /* But for most situations, we use the macro name without a trailing
+     * underscore.
+     *
+     * In locale thread-safe Configurations, typical operations don't need
+     * locking */
+#    define LOCALE_LOCK         NOOP
+#    define LOCALE_UNLOCK       NOOP
+#  else
+     /* Whereas, thread-unsafe Configurations always requires locking */
+#    define LOCALE_LOCK_DOES_SOMETHING_
+#    define LOCALE_LOCK         LOCALE_LOCK_(0)
+#    define LOCALE_UNLOCK       LOCALE_UNLOCK_
 #    ifdef USE_LOCALE_NUMERIC
 #      define LC_NUMERIC_LOCK(cond_to_panic_if_already_locked)              \
                  LOCALE_LOCK_(cond_to_panic_if_already_locked)
@@ -7292,7 +7302,7 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
  * could change out from under us, we use an exclusive LOCALE lock to prevent
  * that, and a read ENV lock to prevent other threads that have nothing to do
  * with locales here from changing the environment. */
-#ifdef LOCALE_LOCK
+#ifdef LOCALE_LOCK_DOES_SOMETHING
 #  define gwENVr_LOCALEr_LOCK                                               \
                     STMT_START { LOCALE_LOCK; ENV_READ_LOCK; } STMT_END
 #  define gwENVr_LOCALEr_UNLOCK                                             \
@@ -7300,15 +7310,6 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #else
 #  define gwENVr_LOCALEr_LOCK           ENV_LOCK
 #  define gwENVr_LOCALEr_UNLOCK         ENV_UNLOCK
-#endif
-
-/* Now that we have defined gwENVr_LOCALEr_LOCK, we can finish defining
- * LOCALE_LOCK, which we kept undefined until here on a thread-safe system
- * so that we could use that fact to calculate what gwENVr_LOCALEr_LOCK should
- * be */
-#ifndef LOCALE_LOCK
-#  define LOCALE_LOCK                NOOP
-#  define LOCALE_UNLOCK              NOOP
 #endif
 
       /* On systems that don't have per-thread locales, even though we don't


### PR DESCRIPTION
These several commits reorder the complex mutex locking in perl.h so that it is all adjacent; for understandability and convenience in maintaining