### PR TITLE
Revert GH#21915 - warning on shadowing a lexical sub

### DIFF
--- a/pad.c
+++ b/pad.c
@@ -939,15 +939,6 @@ S_pad_check_dup(pTHX_ PADNAME *name, U32 flags, const HV *ourstash)
             --off;
         }
     }
-    /* check the package for my sub &x vs. sub PACKAGE::x collisions */
-    if (PadnamePV(name)[0] == '&') {
-        /* PadnamePV is always in UTF-8 */
-        CV *cv = get_cvn_flags(PadnamePV(name)+1, PadnameLEN(name)-1, GV_NOTQUAL|SVf_UTF8);
-        if(cv)
-            warner(packWARN(WARN_SHADOW),
-                "Lexical subroutine %" PNf " masks previously declared package subroutine",
-                PNfARG(name));
-    }
 }
 
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -3591,12 +3591,6 @@ The number of items in a hash can be obtained by doing:
 
     scalar(keys %hash);
 
-=item Lexical subroutine %s masks previously declared package subroutine
-
-(W shadow) The current package already contains a subroutine whose name
-matches that of a newly-declared lexical or lexically imported subroutine.
-The latter will take precedence and make the package one inaccessible by name.
-
 =item Lexing code attempted to stuff non-Latin-1 character into Latin-1 input
 
 (F) An extension is attempting to insert text into the current parse

--- a/t/lib/warnings/builtin
+++ b/t/lib/warnings/builtin
@@ -100,10 +100,3 @@ use builtin qw(true false);
 use builtin ':5.39';
 use builtin ':5.39';
 EXPECT
-########
-# builtin.c - import warns of collisions with package subs
-use warnings 'shadow';
-sub true { "ok" }
-use builtin 'true';
-EXPECT
-Lexical subroutine &true masks previously declared package subroutine at - line 4.

--- a/t/lib/warnings/pad
+++ b/t/lib/warnings/pad
@@ -616,13 +616,3 @@ f();
 EXPECT
 Variable "$è" is not available at (eval 4) line 1.
 ########
-use warnings 'shadow';
-use utf8;
-sub π {}
-sub pi {}
-my sub π {}
-my sub pi {}
-EXPECT
-Lexical subroutine &π masks previously declared package subroutine at - line 5.
-Lexical subroutine &pi masks previously declared package subroutine at - line 6.
-########


### PR DESCRIPTION
Revert "Warn about shadowing names when importing a lexical sub whose name matches a package one"

This partly reverts commit 31273fbcec76b8eef204e7d7c8dde2b78d0e0ce5 which was committed in https://github.com/Perl/perl5/pull/21915

It has been found that this warning creates too many warnings from otherwise-harmless situations, and additionally acts inconsistently with other behaviours such as lexical variables. In any case it only warns in the less likely package-then-lexical order, and not in the more likely lexical-then-package order which was the original intent of the discussion leading up to its invention.

We decided to remove it https://github.com/Perl/perl5/pull/21915#issuecomment-1998021478

I have left the changes to t/op/attrproto.t and t/op/lexsub.t in place because those were just renames for something that made debugging the tests confusing. They're not directly related to this warning, so should remain.