### PR TITLE
Keep using undocumented gcc locale feature

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -251,14 +251,13 @@
  *          querylocale() is called only while the locale mutex is locked, and
  *          the result is copied to a per-thread place before unlocking.
  *
- *      -Accflags=-DUSE_NL_LOCALE_NAME
- *          glibc has an undocumented equivalent function to querylocale().  It
- *          currently isn't used by default because it is undocumented.  But
- *          testing hasn't found any problems with it.  Using this Configure
- *          option enables it on systems that have it (with no effect on
- *          systems lacking it).  Enabling this removes the need for perl
- *          to keep its own records, hence is more efficient and guaranteed to
- *          be accurate.
+ *      -Accflags=-DNO_USE_NL_LOCALE_NAME
+ *          glibc has an undocumented equivalent function to querylocale(),
+ *          which our experience indicates is reliable.  But you can forbid its
+ *          use by specifying this Configure option (with no effect on systems
+ *          lacking it).  When this is function is enabled, it removes the need
+ *          for perl to keep its own records, hence is more efficient and
+ *          guaranteed to be accurate.
  *
  *      -Accflags=-DNO_LOCALE_CTYPE
  *      -Accflags=-DNO_LOCALE_NUMERIC
@@ -396,10 +395,6 @@ static int debug_initialization = 0;
 #else
 #  define start_DEALING_WITH_MISMATCHED_CTYPE(locale)
 #  define end_DEALING_WITH_MISMATCHED_CTYPE(locale)
-#endif
-
-#if PERL_VERSION_GT(5,39,9)
-#  error Revert the commit that added this line
 #endif
 
 #ifdef WIN32_USE_FAKE_OLD_MINGW_LOCALES

--- a/perl.h
+++ b/perl.h
@@ -1251,17 +1251,11 @@ typedef enum {
 #  endif
 
 #  ifdef USE_POSIX_2008_LOCALE
-    /* XXX experimentally use this undocumented GCC feature.  (Below also
-     * checks for its availability before actually using it.) */
-#    ifndef USE_NL_LOCALE_NAME
-#      define USE_NL_LOCALE_NAME
-#    endif
 #    if  defined(HAS_QUERYLOCALE)                                           \
               /* Use querylocale if has it, or has the glibc internal       \
-               * undocumented equivalent. */                                \
+               * undocumented equivalent (if not forbidden). */             \
      || (     defined(_NL_LOCALE_NAME)                                      \
-              /* And is asked for */                                        \
-         &&   defined(USE_NL_LOCALE_NAME)                                   \
+         && ! defined(NO_USE_NL_LOCALE_NAME)                                \
               /* nl_langinfo_l almost certainly will exist on systems that  \
                * have _NL_LOCALE_NAME, so there is nothing lost by          \
                * requiring it instead of also allowing plain nl_langinfo(). \


### PR DESCRIPTION
Since 5.39.7, this feature has been enabled experimentally by default. It is similar to querylocale(), found on *BSD systems.  That function returns the current locale, and was created because this ability is often required, and POSIX neglected to define anything for this purpose. I'm told that the next POSIX Standard update will include a function for this purpose.

I have been using the gcc feature successfully for years in my local work spaces; we started this experiment to see if it worked generally. And there have been zero reports of problems with it.

The experiment was designed to refuse to compile in 5.39.10, so as to make sure it didn't slip into 5.40 without it being explicitly decided to do so.  Now, the final steps in publishing 5.39.9 include bumping the release to 5.39.10, and those can't be done with the code as-is.

This commit declares the experiment a success, and enables this feature non-experimentally as the default, with the ability to turn it off by passing
    -Accflags=-DNO_USE_NL_LOCALE_NAME
to Configure.