### PR TITLE
regcomp: OPFAIL is neither SIMPLE nor HASWIDTH

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -12185,6 +12185,7 @@ S_optimize_regclass(pTHX_
 
   return_OPFAIL:
     op = OPFAIL;
+    *flagp &= ~(SIMPLE|HASWIDTH);
     *ret = reg1node(pRExC_state, op, 0);
     return op;
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -17,7 +17,7 @@
  * debugging support added, which makes "use re 'debug'" work.
  */
 
-/* NOTE: this is derived from Henry Spencer's regexp code, and should not
+/* NOTE: this is derived from Henry Spencer's regexp code, and should not be
  * confused with the original package (see point 3 below).  Thanks, Henry!
  */
 
@@ -689,7 +689,7 @@ S_concat_pat(pTHX_ RExC_state_t * const pRExC_state,
                 oplist = OpSIBLING(oplist); /* skip CONST */
                 assert(oplist);
             }
-            oplist = OpSIBLING(oplist);;
+            oplist = OpSIBLING(oplist);
         }
 
         /* apply magic and QR overloading to arg */
@@ -11183,7 +11183,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
 
         /* If optimized to something else and emitted, clean up and return */
         if (ret >= 0) {
-            SvREFCNT_dec(cp_list);;
+            SvREFCNT_dec(cp_list);
             SvREFCNT_dec(only_utf8_locale_list);
             SvREFCNT_dec(upper_latin1_only_utf8_matches);
             return ret;
@@ -11253,7 +11253,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                    : NULL,
                   only_utf8_locale_list);
 
-    SvREFCNT_dec(cp_list);;
+    SvREFCNT_dec(cp_list);
     SvREFCNT_dec(only_utf8_locale_list);
     return ret;
 }
@@ -11724,7 +11724,7 @@ S_optimize_regclass(pTHX_
              * convert to UTF-8 if not already there */
             if (value > 255) {
                 if (! UTF) {
-                    SvREFCNT_dec(cp_list);;
+                    SvREFCNT_dec(cp_list);
                     REQUIRE_UTF8(flagp);
                 }
 
@@ -11852,7 +11852,7 @@ S_optimize_regclass(pTHX_
             {
                 U8 ANYOFM_mask;
 
-                op = ANYOFM + inverted;;
+                op = ANYOFM + inverted;
 
                 /* We need to make the bits that differ be 0's */
                 ANYOFM_mask = ~ bits_differing; /* This goes into FLAGS */
@@ -15593,7 +15593,7 @@ S_parse_uniprop_string(pTHX_
                  * property hasn't been encountered yet, but at runtime, it's
                  * an error to try to use an undefined one */
                 if (! deferrable) {
-                    goto unknown_user_defined;;
+                    goto unknown_user_defined;
                 }
 
                 goto definition_deferred;

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -2157,6 +2157,13 @@ AB\s+\x{100}	AB \x{100}X	y	-	-
 /^(xa|(?:[Z=])*\1a){2}$/	xa=xaaa	n	-	-	# GH 10073 - RT72020
 /^(xa|(?:[Z=]|zzzz)*\1a){2}$/	xa=xaaa	n	-	-	# GH 10073 - RT72020
 
+# GH 22094 - a character class optimized to OPFAIL shouldn't panic when quantified
+[^\W\S]{6}	a	n	-	-
+[^\W\S]{1,3}	a	n	-	-
+[^\W\S]+	a	n	-	-
+[^\W\S]*	a	y	$&	
+[^\W\S]?	a	y	$&	
+
 # Keep these lines at the end of the file
 # pat	string	y/n/etc	expr	expected-expr	skip-reason	comment
 # vim: softtabstop=0 noexpandtab


### PR DESCRIPTION
This is an extension of fc7dfe8e82a76ba43c, which marked zero-width constructs as non-SIMPLE.

This change affects synthetic OPFAIL nodes generated by the regclass optimizer (empty character classes like [^\W\S] should always fail to match), but which were still marked SIMPLE (indicating they match exactly one character). If such a character class is under a quantifier, it would cause regrepeat() to panic at runtime.

Fixes #22094.