### PR TITLE
Revert "testsuite.yml: fix ASAN build tests"

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -720,9 +720,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v3
-      # this can be removed once https://github.com/actions/runner-images/issues/9491 is fixed
-      - name: Reduce ASLR entropy
-        run: sudo sysctl -w vm.mmap_rnd_bits=28
       - name: git cfg
         run: |
           git config diff.renameLimit 999999
@@ -771,9 +768,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v3
-      # this can be removed once https://github.com/actions/runner-images/issues/9491 is fixed
-      - name: Reduce ASLR entropy
-        run: sudo sysctl -w vm.mmap_rnd_bits=28
       - name: git cfg
         run: |
           git config diff.renameLimit 999999


### PR DESCRIPTION
This reverts commit d1971b5f57c5a31b1d61d7b2e5816942d69ed954.

ctions/runner-images#9491 has been fixed.