### PR TITLE
add CvEVAL_COMPILED() flag and fix closure bug.

### DIFF
--- a/cv.h
+++ b/cv.h
@@ -140,6 +140,7 @@ See L<perlguts/Autoloading with XSUBs>.
                                    CVf_METHOD; now CVf_NOWARN_AMBIGUOUS */
 #define CVf_XS_RCSTACK  0x200000 /* the XS function understands a
                                     reference-counted stack */
+#define CVf_EVAL_COMPILED 0x400000 /* an eval CV is fully compiled */
 
 /* This symbol for optimised communication between toke.c and op.c: */
 #define CVf_BUILTIN_ATTRS	(CVf_NOWARN_AMBIGUOUS|CVf_LVALUE|CVf_ANONCONST)
@@ -265,6 +266,10 @@ Helper macro to turn off the C<CvREFCOUNTED_ANYSV> flag.
 #define CvXS_RCSTACK(cv)        (CvFLAGS(cv) & CVf_XS_RCSTACK)
 #define CvXS_RCSTACK_on(cv)     (CvFLAGS(cv) |= CVf_XS_RCSTACK)
 #define CvXS_RCSTACK_off(cv)    (CvFLAGS(cv) &= ~CVf_XS_RCSTACK)
+
+#define CvEVAL_COMPILED(cv)     (CvFLAGS(cv) & CVf_EVAL_COMPILED)
+#define CvEVAL_COMPILED_on(cv)  (CvFLAGS(cv) |= CVf_EVAL_COMPILED)
+#define CvEVAL_COMPILED_off(cv) (CvFLAGS(cv) &= ~CVf_EVAL_COMPILED)
 
 /* Back-compat */
 #ifndef PERL_CORE

--- a/dump.c
+++ b/dump.c
@@ -1782,7 +1782,8 @@ const struct flag_to_name cv_flags_names[] = {
     {CVf_SIGNATURE,        "SIGNATURE,"},
     {CVf_REFCOUNTED_ANYSV, "REFCOUNTED_ANYSV,"},
     {CVf_IsMETHOD,         "IsMETHOD,"},
-    {CVf_XS_RCSTACK,       "XS_RCSTACK,"}
+    {CVf_XS_RCSTACK,       "XS_RCSTACK,"},
+    {CVf_EVAL_COMPILED,    "EVAL_COMPILED,"},
 };
 
 const struct flag_to_name hv_flags_names[] = {

--- a/op.c
+++ b/op.c
@@ -4702,6 +4702,7 @@ Perl_newPROG(pTHX_ OP *o)
         SAVEFREEOP(o);
         ENTER;
         S_process_optree(aTHX_ NULL, PL_eval_root, start);
+        CvEVAL_COMPILED_on(PL_compcv); /* this eval is now fully compiled */
         LEAVE;
         PL_savestack_ix = i;
     }

--- a/pad.c
+++ b/pad.c
@@ -1079,8 +1079,9 @@ index into the parent pad.
 */
 
 /* the CV has finished being compiled. This is not a sufficient test for
- * all CVs (eg XSUBs), but suffices for the CVs found in a lexical chain */
-#define CvCOMPILED(cv)	CvROOT(cv)
+ * all CVs (eg XSUBs), but suffices for the CVs found in a lexical chain.
+ * Note that a fully-compiled eval doesn't get CvROOT() set. */
+#define CvCOMPILED(cv)	(CvROOT(cv) || CvEVAL_COMPILED(cv))
 
 /* the CV does late binding of its lexicals */
 #define CvLATE(cv) (CvANON(cv) || CvCLONE(cv) || SvTYPE(cv) == SVt_PVFM)


### PR DESCRIPTION
[NB: I'm not expecting to merge this until after 5.40. Too much chance that something subtle changes in closure behaviour.]

EVAL CVs are treated a bit weirdly: their CvROOT() and CvSTART() fields don't get populated; instead the current values are stored in the PL_eval_root and PL_eval_start variables while they are being executed.

This caused a bug in closures and nested evals when an inner eval was repeated twice. The first inner eval accessed an outer lexical, which caused a fake cache entry to be added to the outer eval's pad. The second inner eval finds this cached entry, but incorrectly concludes that the outer eval is in fact an anon sub prototype and issues a 'variable is not available' warning. This is due to this simplistic definition in pad.c:

    #define CvCOMPILED(cv) CvROOT(cv)

This commit adds a new flag, CvEVAL_COMPILED(), to indicate a fully-compiled EVAL CV. This allows us to work around the limitation.

In an ideal world this would have been fixed instead by making EVAL CVs first-class citizens with CvROOT() etc, but plenty of stuff seems to assume otherwise. So I took the path of least resistance.

See https://www.perlmonks.org/?node_id=11158351