### PR TITLE
For consistency with other DISTRIBUTION entries

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1332,7 +1332,7 @@ our %Modules = (
     },
 
     'Win32' => {
-        'DISTRIBUTION' => "JDB/Win32-0.59.tar.gz",
+        'DISTRIBUTION' => 'JDB/Win32-0.59.tar.gz',
         'FILES'        => q[cpan/Win32],
     },
 


### PR DESCRIPTION
Use single quotes rather than double.  This will facilitate grepping this file.