### PR TITLE
fix core-cpan-diff and sync-with-cpan to handle dist files with v prefixed versions

### DIFF
--- a/Porting/core-cpan-diff
+++ b/Porting/core-cpan-diff
@@ -435,9 +435,8 @@ sub relatively_mapped {
 
 sub distro_base {
     my $d = shift;
-    $d =~ s/\.tar\.gz$//;
-    $d =~ s/\.gip$//;
-    $d =~ s/[\d\-_\.]+$//;
+    my $tail_pat = qr/\.(?:tar\.(?:g?z|bz2|Z)|zip|tgz|tbz)/;
+    $d =~ s{-v?([0-9._]+(?:-TRIAL[0-9]*)?)$tail_pat\z}{};
     return $d;
 }
 

--- a/Porting/exec-bit.txt
+++ b/Porting/exec-bit.txt
@@ -51,6 +51,7 @@ Porting/checkcfgvar.pl
 Porting/checkpodencoding.pl
 Porting/cmpVERSION.pl
 Porting/config_h.pl
+Porting/core-cpan-diff
 Porting/corecpan.pl
 Porting/corelist-perldelta.pl
 Porting/corelist.pl

--- a/Porting/sync-with-cpan
+++ b/Porting/sync-with-cpan
@@ -410,9 +410,10 @@ chdir "$type_dir";
 my  $pkg_dir      = $files[0];
     $pkg_dir      =~ s!.*/!!;
 
-my $tail_pat = qr/(?:\.tar\.gz|\.tgz|\.zip)\z/;
+my $tail_pat = qr/\.(?:tar\.(?:g?z|bz2|Z)|zip|tgz|tbz)/;
+my $version_pat = qr/-v?([0-9._]+(?:-TRIAL[0-9]*)?)$tail_pat\z/;
 
-my ($old_version) = $distribution =~ /-([0-9._]+(?:-TRIAL[0-9]*)?)$tail_pat/;
+my ($old_version) = $distribution =~ $version_pat;
 
 if (!$old_version) {
     die "WTF: failed to parse old version from '$distribution'\n";
@@ -457,7 +458,7 @@ if (defined $tarball) {
     die "Tarball $tarball does not exist\n" if !-e $tarball;
     die "Tarball $tarball is not a plain file\n" if !-f _;
     $new_file     = $tarball;
-    $new_version  = $version // ($new_file =~ /-([0-9._]+(?:-TRIAL[0-9]*)?)$tail_pat/) [0];
+    $new_version  = $version // ($new_file =~ $version_pat) [0];
     die "Blead and that tarball both have version $new_version of $module\n"
         if $new_version eq $old_version;
 }
@@ -504,7 +505,7 @@ system git => 'clean', '-dfxq', $pkg_dir;
 say "Unpacking $new_file";
 Archive::Tar->extract_archive( $new_file );
 
-(my $new_dir = basename($new_file)) =~ s/$tail_pat//;
+(my $new_dir = basename($new_file)) =~ s/$tail_pat\z//;
 # ensure 'make' will update all files
 my $t= time;
 for my $file (find_type_f($new_dir)) {


### PR DESCRIPTION
Allow a v prefix on versions expected by the core-cpan-diff and sync-with-cpan scripts. Also align the two scripts with each other, and handle the same file extensions expected by PAUSE.