### PR TITLE
testsuite.yml: workaround cygwin base address conflict in 5.39.10

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -602,10 +602,12 @@ jobs:
         env:
           PATH: /usr/bin:/bin
           SHELLOPTS: igncr
+        # The -Astatic_ext=mro works around a hash collision with
+        # --enable-auto-image-base and should be revertible in 5.39.11
         run: |
           cd ~/work
           set +e
-          ./Configure -des -Dusedevel -Doptimize=-g -DDEBUGGING || exit 1
+          ./Configure -des -Dusedevel -Doptimize=-g -DDEBUGGING -Astatic_ext=mro || exit 1
       - name: Build
         shell: sh
         env:

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -385,7 +385,31 @@ platform specific bugs also go here.
 
 =item *
 
-XXX
+fork() failures on cygwin with C<-DDEBUGGING> builds.
+
+Perl uses the C<--enable-auto-image-base> option to set the base
+images for DLLs for C<cygperl5_39_10.dll> and the DLLs needed for
+dynamically loaded modules on cygwin.
+
+With 5.39.10 if perl is built with C<-DDEBUGGING> or possibly other
+options that increase the address space used by F<cygperl5_39_10.dll>,
+the address space for F<cygperl5_39_10.dll> overlaps with the address
+space allocated for F<mro.dll>.
+
+The C<mro> module will still load, but if perl attempts to fork you
+will likely see an error like:
+
+ 0 [main] perl 34054 child_info_fork::abort: address space needed by \
+    'mro.dll' (0x400000) is already occupied
+
+You can workaround this by building without the C<-DDEBUGGING> option,
+or by making C<mro> a static extension:
+
+  ./Configure ... -Astatic_ext=mro
+
+We expect the name change of the F<cygperl5_39_10.dll> to
+F<cygperl5_39_11.dll> in 5.39.11 will fix this problem for the next
+release.  [github #22104]
 
 =back
 


### PR DESCRIPTION
This also adds a note to perldelta for the 5.39.10 release on how to avoid the problem.