### PR TITLE
Perl_rcpv_new(): add assert(pv)

### DIFF
--- a/op.c
+++ b/op.c
@@ -15888,8 +15888,10 @@ Perl_rcpv_new(pTHX_ const char *pv, STRLEN len, U32 flags) {
     if (!pv && (flags & RCPVf_NO_COPY) == 0)
         return NULL;
 
-    if (flags & RCPVf_USE_STRLEN)
+    if (flags & RCPVf_USE_STRLEN) {
+        assert(pv);
         len = strlen(pv);
+    }
 
     assert(len || (flags & RCPVf_ALLOW_EMPTY));
 


### PR DESCRIPTION
When this function is called with the RCPVf_USE_STRLEN flag, it gets the string length by calling strlen(pv). Coverity (CID 376192) points out that pv could be NULL.

This commit adds an assert(pv), so that the code will bail out on the line before the strlen() in this case, which is probably enough to silence Coverity. Perhaps we aught to have a proper croak() there, but this is a utility function mainly used in limited places in the core, where the caller likely knows that they're doing.