### PR TITLE
Perl_op_convert_list: Avoid unnecessary processing of CONST OPs

### DIFF
--- a/op.c
+++ b/op.c
@@ -5531,6 +5531,16 @@ Perl_op_convert_list(pTHX_ I32 type, I32 flags, OP *o)
         if (FEATURE_MODULE_TRUE_IS_ENABLED)
             flags |= OPf_SPECIAL;
     }
+    if (type == OP_STRINGIFY && OP_TYPE_IS(o, OP_CONST) &&
+        !(flags & OPf_FOLDED) ) {
+        assert(!OpSIBLING(o));
+        /* Don't wrap a single CONST in a list, process that list,
+         * then constant fold the list back to the starting OP.
+         * Note: Folded CONSTs do not seem to occur frequently
+         * enough for it to be worth the code bloat of also
+         * providing a fast path for them. */
+        return o;
+    }
     if (!o || o->op_type != OP_LIST)
         o = force_list(o, FALSE);
     else


### PR DESCRIPTION
When _Perl_op_convert_list_ is called to stringify a CONST OP, a fair amount
of activity occurs in order to return either an unchanged (if called without the
`OPf_FOLDED` flag) or only slightly changed (with `OPf_FOLDED`) OP.

In these commits, any changes are done directly and the CONST OP returned
without wrapping it in a new list OP and constant-folding it back again.

Please note: This almost certainly should be a **defer-next-dev** PR!