### PR TITLE
Revert not using min_mktime()

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3409,7 +3409,7 @@ Adm	|bool	|sv_streq	|NULLOK SV *sv1 			\
 Adp	|bool	|sv_streq_flags |NULLOK SV *sv1 			\
 				|NULLOK SV *sv2 			\
 				|const U32 flags
-Adp	|SV *	|sv_strftime_ints					\
+EXpx	|SV *	|sv_strftime_ints					\
 				|NN SV *fmt				\
 				|int sec				\
 				|int min				\

--- a/embed.h
+++ b/embed.h
@@ -748,7 +748,6 @@
 # define sv_setuv(a,b)                          Perl_sv_setuv(aTHX_ a,b)
 # define sv_setuv_mg(a,b)                       Perl_sv_setuv_mg(aTHX_ a,b)
 # define sv_streq_flags(a,b,c)                  Perl_sv_streq_flags(aTHX_ a,b,c)
-# define sv_strftime_ints(a,b,c,d,e,f,g,h,i,j)  Perl_sv_strftime_ints(aTHX_ a,b,c,d,e,f,g,h,i,j)
 # define sv_strftime_tm(a,b)                    Perl_sv_strftime_tm(aTHX_ a,b)
 # define sv_string_from_errnum(a,b)             Perl_sv_string_from_errnum(aTHX_ a,b)
 # define sv_tainted(a)                          Perl_sv_tainted(aTHX_ a)
@@ -1765,6 +1764,7 @@
 #   define skipspace_flags(a,b)                 Perl_skipspace_flags(aTHX_ a,b)
 #   define sv_magicext_mglob(a)                 Perl_sv_magicext_mglob(aTHX_ a)
 #   define sv_only_taint_gmagic                 Perl_sv_only_taint_gmagic
+#   define sv_strftime_ints(a,b,c,d,e,f,g,h,i,j) Perl_sv_strftime_ints(aTHX_ a,b,c,d,e,f,g,h,i,j)
 #   define utf16_to_utf8_base(a,b,c,d,e,f)      Perl_utf16_to_utf8_base(aTHX_ a,b,c,d,e,f)
 #   define utf8_to_utf16_base(a,b,c,d,e,f)      Perl_utf8_to_utf16_base(aTHX_ a,b,c,d,e,f)
 #   define validate_proto(a,b,c,d)              Perl_validate_proto(aTHX_ a,b,c,d)

--- a/ext/POSIX/lib/POSIX.pod
+++ b/ext/POSIX/lib/POSIX.pod
@@ -1825,18 +1825,22 @@ Identical to the string form of C<$!>, see L<perlvar/$ERRNO>.
 
 =item C<strftime>
 
-Convert date and time information to string.  Returns the string.
+Convert date and time information to string based on the current
+underlying locale of the program (except for any daylight savings time).
+Returns the string.
 
 Synopsis:
 
 	strftime(fmt, sec, min, hour, mday, mon, year,
 		 wday = -1, yday = -1, isdst = -1)
 
-The month (C<mon>), weekday (C<wday>), and yearday (C<yday>) begin at zero,
-I<i.e.>, January is 0, not 1; Sunday is 0, not 1; January 1st is 0, not 1.  The
-year (C<year>) is given in years since 1900, I<i.e.>, the year 1995 is 95; the
+The month (C<mon>) begins at zero,
+I<e.g.>, January is 0, not 1.  The
+year (C<year>) is given in years since 1900, I<e.g.>, the year 1995 is 95; the
 year 2001 is 101.  Consult your system's C<strftime()> manpage for details
 about these and the other arguments.
+
+The C<wday>, C<yday>, and C<isdst> parameters are all ignored.
 
 If you want your code to be portable, your format (C<fmt>) argument
 should use only the conversion specifiers defined by the ANSI C
@@ -1853,9 +1857,11 @@ safest route.
 
 The given arguments are made consistent as though by calling
 C<mktime()> before calling your system's C<strftime()> function,
-except that the C<isdst> value is not affected.
+except that the C<isdst> value is not affected, so that the returned
+value will always be as if the locale doesn't have daylight savings
+time.
 
-The string for Tuesday, December 12, 1995.
+The string for Tuesday, December 12, 1995 in the C<C> locale.
 
 	$str = POSIX::strftime( "%A, %B %d, %Y",
 				 0, 0, 0, 12, 11, 95, 2 );

--- a/ext/POSIX/t/time.t
+++ b/ext/POSIX/t/time.t
@@ -26,9 +26,6 @@ SKIP: {
           $^O eq "MSWin32" || $^O eq "interix";
     tzset();
     SKIP: {
-      TODO: {
-        local $TODO = "Make sure this test works to expose the problem";
-
         my @tzname = tzname();
 
         # See extensive discussion in GH #22062.
@@ -36,7 +33,6 @@ SKIP: {
         is(strftime("%Y-%m-%d %H:%M:%S", 0, 30, 2, 10, 2, 124, 0, 0, 0),
                     "2024-03-10 02:30:00",
                     "strftime() doesnt pay attention to dst");
-      };
     }
 }
 


### PR DESCRIPTION
This fixes GH #22062, which has extensive discussion not repeated in this commit message