### PR TITLE
% operator could not produce (IV_MIN - 1)

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -1676,7 +1676,7 @@ PP(pp_modulo)
                     right = biv;
                     right_neg = FALSE; /* effectively it's a UV now */
                 } else {
-                    right = (UV) (0 - (UV) biv);
+                    right = NEGATE_2UV(biv);
                 }
             }
         }
@@ -1706,7 +1706,7 @@ PP(pp_modulo)
                         left = aiv;
                         left_neg = FALSE; /* effectively it's a UV now */
                     } else {
-                        left = (UV) (0 - (UV) aiv);
+                        left = NEGATE_2UV(aiv);
                     }
                 }
         }
@@ -1763,10 +1763,8 @@ PP(pp_modulo)
             if ((left_neg != right_neg) && ans)
                 ans = right - ans;
             if (right_neg) {
-                /* XXX may warn: unary minus operator applied to unsigned type */
-                /* could change -foo to be (~foo)+1 instead	*/
-                if (ans <= ~((UV)IV_MAX)+1)
-                    sv_setiv(TARG, ~ans+1);
+                if (ans <= ABS_IV_MIN)
+                    sv_setiv(TARG, NEGATE_2IV(ans));
                 else
                     sv_setnv(TARG, -(NV)ans);
             }

--- a/t/op/64bitint.t
+++ b/t/op/64bitint.t
@@ -460,4 +460,13 @@ cmp_ok -0x8000000000000000 % -0x8000000000000000, '==',  0, 'IV_MIN % IV_MIN';
     }
 }
 
+# Attempts to generate (IV_MIN - 1)
+
+# Note that -0x8000000000000002 cannot be represented in 64-bit IV,
+# but both LHS and RHS are equally converted to (maybe rounded) NV
+# and thus these tests should still pass.
+cmp_ok  0x3ffffffffffffffe % -0xc000000000000000, '==', -0x8000000000000002, 'modulo is (IV_MIN-2)';
+cmp_ok  0x3fffffffffffffff % -0xc000000000000000, '==', -0x8000000000000001, 'modulo is (IV_MIN-1)';
+cmp_ok  0x4000000000000000 % -0xc000000000000000, '==', -0x8000000000000000, 'modulo is IV_MIN';
+
 done_testing();

--- a/t/opbasic/arith.t
+++ b/t/opbasic/arith.t
@@ -4,7 +4,7 @@
 # functions imported from t/test.pl or Test::More, as those programs/libraries
 # use operators which are what is being tested in this file.
 
-print "1..180\n";
+print "1..183\n";
 
 sub try ($$$) {
    print +($_[1] ? "ok" : "not ok") . " $_[0] - $_[2]\n";
@@ -438,3 +438,7 @@ tryeq $T++, -0x80000000 /  0x80000000, -1, 'IV_MIN / (IV_MAX+1)';
 tryeq $T++,  0x80000000 / -1, -0x80000000, '(IV_MAX+1) / -1';
 tryeq $T++,           0 % -0x80000000,  0, '0 % IV_MIN';
 tryeq $T++, -0x80000000 % -0x80000000,  0, 'IV_MIN % IV_MIN';
+
+tryeq $T++,  0x3ffffffe % -0xc0000000, -0x80000002, 'modulo is (IV_MIN-2)';
+tryeq $T++,  0x3fffffff % -0xc0000000, -0x80000001, 'modulo is (IV_MIN-1)';
+tryeq $T++,  0x40000000 % -0xc0000000, -0x80000000, 'modulo is IV_MIN';


### PR DESCRIPTION
I found a corner case where  `%` (modulo) operator returns wrong result when the result should be (IV_MIN - 1):

For 32-bit (i686-linux) perl:
```
$ perl -wle 'my $divisor = -0xc0000000; print "$_ % $divisor = ", $_ % $divisor for 0x3FFFFFFE .. 0x40000000'
1073741822 % -3221225472 = -2147483650
1073741823 % -3221225472 = 2147483647
1073741824 % -3221225472 = -2147483648
```

For `-Duse64bitint`  perl:
```
$ $ perl -le 'my $divisor = -0xc000000000000000; print "$_ % $divisor = ", $_ % $divisor for 0x3FFFFFFFFFFFFFFE .. 0x4000000000000000'
4611686018427387902 % -1.38350580552822e+19 = -9.22337203685478e+18
4611686018427387903 % -1.38350580552822e+19 = 9223372036854775807
4611686018427387904 % -1.38350580552822e+19 = -9223372036854775808
```

I think the second result of both example above should be contiguous to the first and third results (or at least should be negative, as _perlop_ says that `$m % $n` will be less than or equal to zero if `$n` is negative).

I hope this pull request will fix this.