### PR TITLE
perly LSTOPSUB: prevent a double op free between parse stack and CV

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6066,6 +6066,7 @@ t/lib/croak/class			Test croak calls from class.c
 t/lib/croak/gv				Test croak calls from gv.c
 t/lib/croak/mg				Test croak calls from mg.c
 t/lib/croak/op				Test croak calls from op.c
+t/lib/croak/parser			Test parser errors
 t/lib/croak/pp				Test croak calls from pp.c
 t/lib/croak/pp_ctl			Test croak calls from pp_ctl.c
 t/lib/croak/pp_hot			Test croak calls from pp_hot.c

--- a/perly.act
+++ b/perly.act
@@ -4,18 +4,18 @@
    Any changes made here will be lost!
  */
 
-case 2:
+case 2: /* @1: %empty  */
 #line 161 "perly.y"
-    {
+                        {
 			  parser->expect = XSTATE;
                           (yyval.ival) = 0;
 			}
 
     break;
 
-  case 3:
+  case 3: /* grammar: GRAMPROG @1 remember stmtseq  */
 #line 166 "perly.y"
-    {
+                        {
 			  newPROG(block_end((ps[-1].val.ival),(ps[0].val.opval)));
 			  PL_compiling.cop_seq = 0;
 			  (yyval.ival) = 0;
@@ -23,36 +23,36 @@ case 2:
 
     break;
 
-  case 4:
+  case 4: /* @2: %empty  */
 #line 172 "perly.y"
-    {
+                        {
 			  parser->expect = XTERM;
                           (yyval.ival) = 0;
 			}
 
     break;
 
-  case 5:
+  case 5: /* grammar: GRAMEXPR @2 optexpr  */
 #line 177 "perly.y"
-    {
+                        {
 			  PL_eval_root = (ps[0].val.opval);
 			  (yyval.ival) = 0;
 			}
 
     break;
 
-  case 6:
+  case 6: /* @3: %empty  */
 #line 182 "perly.y"
-    {
+                        {
 			  parser->expect = XBLOCK;
                           (yyval.ival) = 0;
 			}
 
     break;
 
-  case 7:
+  case 7: /* grammar: GRAMBLOCK @3 block  */
 #line 187 "perly.y"
-    {
+                        {
 			  PL_pad_reset_pending = TRUE;
 			  PL_eval_root = (ps[0].val.opval);
 			  (yyval.ival) = 0;
@@ -62,18 +62,18 @@ case 2:
 
     break;
 
-  case 8:
+  case 8: /* @4: %empty  */
 #line 195 "perly.y"
-    {
+                        {
 			  parser->expect = XSTATE;
                           (yyval.ival) = 0;
 			}
 
     break;
 
-  case 9:
+  case 9: /* grammar: GRAMBARESTMT @4 barestmt  */
 #line 200 "perly.y"
-    {
+                        {
 			  PL_pad_reset_pending = TRUE;
 			  PL_eval_root = (ps[0].val.opval);
 			  (yyval.ival) = 0;
@@ -83,18 +83,18 @@ case 2:
 
     break;
 
-  case 10:
+  case 10: /* @5: %empty  */
 #line 208 "perly.y"
-    {
+                        {
 			  parser->expect = XSTATE;
                           (yyval.ival) = 0;
 			}
 
     break;
 
-  case 11:
+  case 11: /* grammar: GRAMFULLSTMT @5 fullstmt  */
 #line 213 "perly.y"
-    {
+                        {
 			  PL_pad_reset_pending = TRUE;
 			  PL_eval_root = (ps[0].val.opval);
 			  (yyval.ival) = 0;
@@ -104,122 +104,122 @@ case 2:
 
     break;
 
-  case 12:
+  case 12: /* @6: %empty  */
 #line 221 "perly.y"
-    {
+                        {
 			  parser->expect = XSTATE;
                           (yyval.ival) = 0;
 			}
 
     break;
 
-  case 13:
+  case 13: /* grammar: GRAMSTMTSEQ @6 stmtseq  */
 #line 226 "perly.y"
-    {
+                        {
 			  PL_eval_root = (ps[0].val.opval);
 			  (yyval.ival) = 0;
 			}
 
     break;
 
-  case 14:
+  case 14: /* @7: %empty  */
 #line 231 "perly.y"
-    {
+                        {
 			  parser->expect = XSTATE;
 			  (yyval.ival) = 0;
 			}
 
     break;
 
-  case 15:
+  case 15: /* grammar: GRAMSUBSIGNATURE @7 subsigguts  */
 #line 236 "perly.y"
-    {
+                        {
 			  PL_eval_root = (ps[0].val.opval);
 			  (yyval.ival) = 0;
 			}
 
     break;
 
-  case 16:
+  case 16: /* sigsub_or_method_named: KW_SUB_named_sig  */
 #line 245 "perly.y"
-    { (yyval.ival) = KW_SUB_named_sig; }
+                        { (yyval.ival) = KW_SUB_named_sig; }
 
     break;
 
-  case 17:
+  case 17: /* sigsub_or_method_named: KW_METHOD_named  */
 #line 247 "perly.y"
-    { (yyval.ival) = KW_METHOD_named; }
+                        { (yyval.ival) = KW_METHOD_named; }
 
     break;
 
-  case 18:
+  case 18: /* block: PERLY_BRACE_OPEN remember stmtseq PERLY_BRACE_CLOSE  */
 #line 252 "perly.y"
-    { if (parser->copline > (line_t)(ps[-3].val.ival))
+                        { if (parser->copline > (line_t)(ps[-3].val.ival))
 			      parser->copline = (line_t)(ps[-3].val.ival);
 			  (yyval.opval) = block_end((ps[-2].val.ival), (ps[-1].val.opval));
 			}
 
     break;
 
-  case 19:
+  case 19: /* empty: %empty  */
 #line 259 "perly.y"
-    { (yyval.opval) = NULL; }
+                                { (yyval.opval) = NULL; }
 
     break;
 
-  case 20:
+  case 20: /* formblock: PERLY_EQUAL_SIGN remember PERLY_SEMICOLON FORMRBRACK formstmtseq PERLY_SEMICOLON PERLY_DOT  */
 #line 264 "perly.y"
-    { if (parser->copline > (line_t)(ps[-6].val.ival))
+                        { if (parser->copline > (line_t)(ps[-6].val.ival))
 			      parser->copline = (line_t)(ps[-6].val.ival);
 			  (yyval.opval) = block_end((ps[-5].val.ival), (ps[-2].val.opval));
 			}
 
     break;
 
-  case 21:
+  case 21: /* remember: %empty  */
 #line 271 "perly.y"
-    { (yyval.ival) = block_start(TRUE);
+                        { (yyval.ival) = block_start(TRUE);
 			  parser->parsed_sub = 0; }
 
     break;
 
-  case 22:
+  case 22: /* mblock: PERLY_BRACE_OPEN mremember stmtseq PERLY_BRACE_CLOSE  */
 #line 276 "perly.y"
-    { if (parser->copline > (line_t)(ps[-3].val.ival))
+                        { if (parser->copline > (line_t)(ps[-3].val.ival))
 			      parser->copline = (line_t)(ps[-3].val.ival);
 			  (yyval.opval) = block_end((ps[-2].val.ival), (ps[-1].val.opval));
 			}
 
     break;
 
-  case 23:
+  case 23: /* mremember: %empty  */
 #line 283 "perly.y"
-    { (yyval.ival) = block_start(FALSE);
+                        { (yyval.ival) = block_start(FALSE);
 			  parser->parsed_sub = 0; }
 
     break;
 
-  case 25:
+  case 25: /* $@8: %empty  */
 #line 292 "perly.y"
-    { parser->in_my = 1; }
+                        { parser->in_my = 1; }
 
     break;
 
-  case 26:
+  case 26: /* $@9: %empty  */
 #line 294 "perly.y"
-    { parser->in_my = 0; intro_my(); }
+                        { parser->in_my = 0; intro_my(); }
 
     break;
 
-  case 27:
+  case 27: /* catch_paren: PERLY_PAREN_OPEN $@8 scalar $@9 PERLY_PAREN_CLOSE  */
 #line 296 "perly.y"
-    { (yyval.opval) = (ps[-2].val.opval); }
+                        { (yyval.opval) = (ps[-2].val.opval); }
 
     break;
 
-  case 29:
+  case 29: /* stmtseq: stmtseq fullstmt  */
 #line 303 "perly.y"
-    {   (yyval.opval) = op_append_list(OP_LINESEQ, (ps[-1].val.opval), (ps[0].val.opval));
+                        {   (yyval.opval) = op_append_list(OP_LINESEQ, (ps[-1].val.opval), (ps[0].val.opval));
 			    PL_pad_reset_pending = TRUE;
 			    if ((ps[-1].val.opval) && (ps[0].val.opval))
 				PL_hints |= HINT_BLOCK_SCOPE;
@@ -227,9 +227,9 @@ case 2:
 
     break;
 
-  case 31:
+  case 31: /* formstmtseq: formstmtseq formline  */
 #line 314 "perly.y"
-    {   (yyval.opval) = op_append_list(OP_LINESEQ, (ps[-1].val.opval), (ps[0].val.opval));
+                        {   (yyval.opval) = op_append_list(OP_LINESEQ, (ps[-1].val.opval), (ps[0].val.opval));
 			    PL_pad_reset_pending = TRUE;
 			    if ((ps[-1].val.opval) && (ps[0].val.opval))
 				PL_hints |= HINT_BLOCK_SCOPE;
@@ -237,23 +237,23 @@ case 2:
 
     break;
 
-  case 32:
+  case 32: /* fullstmt: barestmt  */
 #line 323 "perly.y"
-    {
+                        {
 			  (yyval.opval) = (ps[0].val.opval) ? newSTATEOP(0, NULL, (ps[0].val.opval)) : NULL;
 			}
 
     break;
 
-  case 33:
+  case 33: /* fullstmt: labfullstmt  */
 #line 327 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 34:
+  case 34: /* labfullstmt: LABEL barestmt  */
 #line 331 "perly.y"
-    {
+                        {
                           SV *label = cSVOPx_sv((ps[-1].val.opval));
 			  (yyval.opval) = newSTATEOP(SvFLAGS(label) & SVf_UTF8,
                                             savepv(SvPVX_const(label)), (ps[0].val.opval));
@@ -262,9 +262,9 @@ case 2:
 
     break;
 
-  case 35:
+  case 35: /* labfullstmt: LABEL labfullstmt  */
 #line 338 "perly.y"
-    {
+                        {
                           SV *label = cSVOPx_sv((ps[-1].val.opval));
 			  (yyval.opval) = newSTATEOP(SvFLAGS(label) & SVf_UTF8,
                                             savepv(SvPVX_const(label)), (ps[0].val.opval));
@@ -273,15 +273,15 @@ case 2:
 
     break;
 
-  case 36:
+  case 36: /* barestmt: PLUGSTMT  */
 #line 348 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 37:
+  case 37: /* barestmt: KW_FORMAT startformsub formname formblock  */
 #line 350 "perly.y"
-    {
+                        {
 			  CV *fmtcv = PL_compcv;
 			  newFORM((ps[-2].val.ival), (ps[-1].val.opval), (ps[0].val.opval));
 			  (yyval.opval) = NULL;
@@ -293,9 +293,9 @@ case 2:
 
     break;
 
-  case 38:
+  case 38: /* $@10: %empty  */
 #line 362 "perly.y"
-    {
+                        {
                           init_named_cv(PL_compcv, (ps[-1].val.opval));
 			  parser->in_my = 0;
 			  parser->in_my_stash = NULL;
@@ -303,9 +303,9 @@ case 2:
 
     break;
 
-  case 39:
+  case 39: /* barestmt: KW_SUB_named subname startsub $@10 proto subattrlist optsubbody  */
 #line 368 "perly.y"
-    {
+                        {
 			  SvREFCNT_inc_simple_void(PL_compcv);
 			  (ps[-5].val.opval)->op_type == OP_CONST
 			      ? newATTRSUB((ps[-4].val.ival), (ps[-5].val.opval), (ps[-2].val.opval), (ps[-1].val.opval), (ps[0].val.opval))
@@ -318,9 +318,9 @@ case 2:
 
     break;
 
-  case 40:
+  case 40: /* $@11: %empty  */
 #line 383 "perly.y"
-    {
+                        {
                           init_named_cv(PL_compcv, (ps[-1].val.opval));
 			  if((ps[-2].val.ival) == KW_METHOD_named) {
 			      croak_kw_unless_class("method");
@@ -332,9 +332,9 @@ case 2:
 
     break;
 
-  case 41:
+  case 41: /* barestmt: sigsub_or_method_named subname startsub $@11 subattrlist optsigsubbody  */
 #line 393 "perly.y"
-    {
+                        {
 			  OP *body = (ps[0].val.opval);
 
 			  SvREFCNT_inc_simple_void(PL_compcv);
@@ -349,9 +349,9 @@ case 2:
 
     break;
 
-  case 42:
+  case 42: /* $@12: %empty  */
 #line 406 "perly.y"
-    {
+                        {
 			  switch((ps[-1].val.ival)) {
 			      case KEY_ADJUST:
 			         croak_kw_unless_class("ADJUST");
@@ -364,9 +364,9 @@ case 2:
 
     break;
 
-  case 43:
+  case 43: /* barestmt: PHASER startsub $@12 optsubbody  */
 #line 417 "perly.y"
-    {
+                        {
 			  OP *body = (ps[0].val.opval);
 			  SvREFCNT_inc_simple_void(PL_compcv);
 
@@ -383,9 +383,9 @@ case 2:
 
     break;
 
-  case 44:
+  case 44: /* barestmt: KW_PACKAGE BAREWORD BAREWORD PERLY_SEMICOLON  */
 #line 436 "perly.y"
-    {
+                        {
 			  package((ps[-1].val.opval));
 			  if ((ps[-2].val.opval))
 			      package_version((ps[-2].val.opval));
@@ -394,9 +394,9 @@ case 2:
 
     break;
 
-  case 45:
+  case 45: /* barestmt: KW_CLASS BAREWORD BAREWORD subattrlist PERLY_SEMICOLON  */
 #line 443 "perly.y"
-    {
+                        {
 			  package((ps[-2].val.opval));
 			  if ((ps[-3].val.opval))
 			      package_version((ps[-3].val.opval));
@@ -409,15 +409,15 @@ case 2:
 
     break;
 
-  case 46:
+  case 46: /* $@13: %empty  */
 #line 454 "perly.y"
-    { CvSPECIAL_on(PL_compcv); /* It's a BEGIN {} */ }
+                        { CvSPECIAL_on(PL_compcv); /* It's a BEGIN {} */ }
 
     break;
 
-  case 47:
+  case 47: /* barestmt: KW_USE_or_NO startsub $@13 BAREWORD BAREWORD optlistexpr PERLY_SEMICOLON  */
 #line 458 "perly.y"
-    {
+                        {
 			  SvREFCNT_inc_simple_void(PL_compcv);
 			  utilize((ps[-6].val.ival), (ps[-5].val.ival), (ps[-3].val.opval), (ps[-2].val.opval), (ps[-1].val.opval));
 			  parser->parsed_sub = 1;
@@ -426,9 +426,9 @@ case 2:
 
     break;
 
-  case 48:
+  case 48: /* barestmt: KW_IF PERLY_PAREN_OPEN remember mexpr PERLY_PAREN_CLOSE mblock else  */
 #line 465 "perly.y"
-    {
+                        {
 			  (yyval.opval) = block_end((ps[-4].val.ival),
 			      newCONDOP(0, (ps[-3].val.opval), op_scope((ps[-1].val.opval)), (ps[0].val.opval)));
 			  parser->copline = (line_t)(ps[-6].val.ival);
@@ -436,9 +436,9 @@ case 2:
 
     break;
 
-  case 49:
+  case 49: /* barestmt: KW_UNLESS PERLY_PAREN_OPEN remember mexpr PERLY_PAREN_CLOSE mblock else  */
 #line 471 "perly.y"
-    {
+                        {
 			  (yyval.opval) = block_end((ps[-4].val.ival),
                               newCONDOP(0, (ps[-3].val.opval), (ps[0].val.opval), op_scope((ps[-1].val.opval))));
 			  parser->copline = (line_t)(ps[-6].val.ival);
@@ -446,30 +446,30 @@ case 2:
 
     break;
 
-  case 50:
+  case 50: /* barestmt: KW_GIVEN PERLY_PAREN_OPEN remember mexpr PERLY_PAREN_CLOSE mblock  */
 #line 477 "perly.y"
-    {
+                        {
 			  (yyval.opval) = block_end((ps[-3].val.ival), newGIVENOP((ps[-2].val.opval), op_scope((ps[0].val.opval)), 0));
 			  parser->copline = (line_t)(ps[-5].val.ival);
 			}
 
     break;
 
-  case 51:
+  case 51: /* barestmt: KW_WHEN PERLY_PAREN_OPEN remember mexpr PERLY_PAREN_CLOSE mblock  */
 #line 482 "perly.y"
-    { (yyval.opval) = block_end((ps[-3].val.ival), newWHENOP((ps[-2].val.opval), op_scope((ps[0].val.opval)))); }
+                        { (yyval.opval) = block_end((ps[-3].val.ival), newWHENOP((ps[-2].val.opval), op_scope((ps[0].val.opval)))); }
 
     break;
 
-  case 52:
+  case 52: /* barestmt: KW_DEFAULT block  */
 #line 484 "perly.y"
-    { (yyval.opval) = newWHENOP(0, op_scope((ps[0].val.opval))); }
+                        { (yyval.opval) = newWHENOP(0, op_scope((ps[0].val.opval))); }
 
     break;
 
-  case 53:
+  case 53: /* barestmt: KW_WHILE PERLY_PAREN_OPEN remember texpr PERLY_PAREN_CLOSE mintro mblock cont  */
 #line 486 "perly.y"
-    {
+                        {
 			  (yyval.opval) = block_end((ps[-5].val.ival),
 				  newWHILEOP(0, 1, NULL,
 				      (ps[-4].val.opval), (ps[-1].val.opval), (ps[0].val.opval), (ps[-2].val.ival)));
@@ -478,9 +478,9 @@ case 2:
 
     break;
 
-  case 54:
+  case 54: /* barestmt: KW_UNTIL PERLY_PAREN_OPEN remember iexpr PERLY_PAREN_CLOSE mintro mblock cont  */
 #line 493 "perly.y"
-    {
+                        {
 			  (yyval.opval) = block_end((ps[-5].val.ival),
 				  newWHILEOP(0, 1, NULL,
 				      (ps[-4].val.opval), (ps[-1].val.opval), (ps[0].val.opval), (ps[-2].val.ival)));
@@ -489,21 +489,21 @@ case 2:
 
     break;
 
-  case 55:
+  case 55: /* $@14: %empty  */
 #line 500 "perly.y"
-    { parser->expect = XTERM; }
+                        { parser->expect = XTERM; }
 
     break;
 
-  case 56:
+  case 56: /* $@15: %empty  */
 #line 502 "perly.y"
-    { parser->expect = XTERM; }
+                        { parser->expect = XTERM; }
 
     break;
 
-  case 57:
+  case 57: /* barestmt: KW_FOR PERLY_PAREN_OPEN remember mnexpr PERLY_SEMICOLON $@14 texpr PERLY_SEMICOLON $@15 mintro mnexpr PERLY_PAREN_CLOSE mblock  */
 #line 505 "perly.y"
-    {
+                        {
 			  OP *initop = (ps[-9].val.opval);
 			  OP *forop = newWHILEOP(0, 1, NULL,
 				      scalar((ps[-6].val.opval)), (ps[0].val.opval), (ps[-2].val.opval), (ps[-3].val.ival));
@@ -520,18 +520,18 @@ case 2:
 
     break;
 
-  case 58:
+  case 58: /* barestmt: KW_FOR KW_MY remember my_scalar PERLY_PAREN_OPEN mexpr PERLY_PAREN_CLOSE mblock cont  */
 #line 520 "perly.y"
-    {
+                        {
 			  (yyval.opval) = block_end((ps[-6].val.ival), newFOROP(0, (ps[-5].val.opval), (ps[-3].val.opval), (ps[-1].val.opval), (ps[0].val.opval)));
 			  parser->copline = (line_t)(ps[-8].val.ival);
 			}
 
     break;
 
-  case 59:
+  case 59: /* barestmt: KW_FOR KW_MY remember PERLY_PAREN_OPEN my_list_of_scalars PERLY_PAREN_CLOSE PERLY_PAREN_OPEN mexpr PERLY_PAREN_CLOSE mblock cont  */
 #line 525 "perly.y"
-    {
+                        {
                           if ((ps[-6].val.opval)->op_type == OP_PADSV)
                             /* degenerate case of 1 var: for my ($x) ....
                                Flag it so it can be special-cased in newFOROP */
@@ -542,9 +542,9 @@ case 2:
 
     break;
 
-  case 60:
+  case 60: /* barestmt: KW_FOR scalar PERLY_PAREN_OPEN remember mexpr PERLY_PAREN_CLOSE mblock cont  */
 #line 534 "perly.y"
-    {
+                        {
 			  (yyval.opval) = block_end((ps[-4].val.ival), newFOROP(0,
 				      op_lvalue((ps[-6].val.opval), OP_ENTERLOOP), (ps[-3].val.opval), (ps[-1].val.opval), (ps[0].val.opval)));
 			  parser->copline = (line_t)(ps[-7].val.ival);
@@ -552,15 +552,15 @@ case 2:
 
     break;
 
-  case 61:
+  case 61: /* @16: %empty  */
 #line 540 "perly.y"
-    { parser->in_my = 0; (yyval.opval) = my((ps[0].val.opval)); }
+                        { parser->in_my = 0; (yyval.opval) = my((ps[0].val.opval)); }
 
     break;
 
-  case 62:
+  case 62: /* barestmt: KW_FOR my_refgen remember my_var @16 PERLY_PAREN_OPEN mexpr PERLY_PAREN_CLOSE mblock cont  */
 #line 542 "perly.y"
-    {
+                        {
 			  (yyval.opval) = block_end(
 				(ps[-7].val.ival),
 				newFOROP(0,
@@ -575,9 +575,9 @@ case 2:
 
     break;
 
-  case 63:
+  case 63: /* barestmt: KW_FOR REFGEN refgen_topic PERLY_PAREN_OPEN remember mexpr PERLY_PAREN_CLOSE mblock cont  */
 #line 555 "perly.y"
-    {
+                        {
 			  (yyval.opval) = block_end((ps[-4].val.ival), newFOROP(
 				0, op_lvalue(newUNOP(OP_REFGEN, 0,
 						     (ps[-6].val.opval)),
@@ -587,9 +587,9 @@ case 2:
 
     break;
 
-  case 64:
+  case 64: /* barestmt: KW_FOR PERLY_PAREN_OPEN remember mexpr PERLY_PAREN_CLOSE mblock cont  */
 #line 563 "perly.y"
-    {
+                        {
 			  (yyval.opval) = block_end((ps[-4].val.ival),
 				  newFOROP(0, NULL, (ps[-3].val.opval), (ps[-1].val.opval), (ps[0].val.opval)));
 			  parser->copline = (line_t)(ps[-6].val.ival);
@@ -597,9 +597,9 @@ case 2:
 
     break;
 
-  case 65:
+  case 65: /* $@17: %empty  */
 #line 569 "perly.y"
-    {
+                        {
 			  if(!(ps[0].val.opval)) {
 			      yyerror("catch block requires a (VAR)");
 			      YYERROR;
@@ -608,9 +608,9 @@ case 2:
 
     break;
 
-  case 66:
+  case 66: /* barestmt: KW_TRY mblock KW_CATCH remember catch_paren $@17 mblock finally  */
 #line 576 "perly.y"
-    {
+                        {
 			  (yyval.opval) = newTRYCATCHOP(0,
 				  (ps[-6].val.opval), (ps[-3].val.opval), block_end((ps[-4].val.ival), op_scope((ps[-1].val.opval))));
 			  if((ps[0].val.opval))
@@ -620,9 +620,9 @@ case 2:
 
     break;
 
-  case 67:
+  case 67: /* barestmt: block cont  */
 #line 584 "perly.y"
-    {
+                        {
 			  /* a block is a loop that happens once */
 			  (yyval.opval) = newWHILEOP(0, 1, NULL,
 				  NULL, (ps[-1].val.opval), (ps[0].val.opval), 0);
@@ -630,9 +630,9 @@ case 2:
 
     break;
 
-  case 68:
+  case 68: /* $@18: %empty  */
 #line 590 "perly.y"
-    {
+                        {
 			  package((ps[-2].val.opval));
 			  if ((ps[-3].val.opval)) {
 			      package_version((ps[-3].val.opval));
@@ -641,9 +641,9 @@ case 2:
 
     break;
 
-  case 69:
+  case 69: /* barestmt: KW_PACKAGE BAREWORD BAREWORD PERLY_BRACE_OPEN remember $@18 stmtseq PERLY_BRACE_CLOSE  */
 #line 597 "perly.y"
-    {
+                        {
 			  /* a block is a loop that happens once */
 			  (yyval.opval) = newWHILEOP(0, 1, NULL,
 				  NULL, block_end((ps[-3].val.ival), (ps[-1].val.opval)), NULL, 0);
@@ -653,9 +653,9 @@ case 2:
 
     break;
 
-  case 70:
+  case 70: /* $@19: %empty  */
 #line 605 "perly.y"
-    {
+                        {
 			  package((ps[-3].val.opval));
 
 			  if ((ps[-4].val.opval)) {
@@ -669,9 +669,9 @@ case 2:
 
     break;
 
-  case 71:
+  case 71: /* barestmt: KW_CLASS BAREWORD BAREWORD subattrlist PERLY_BRACE_OPEN remember $@19 stmtseq PERLY_BRACE_CLOSE  */
 #line 617 "perly.y"
-    {
+                        {
 			  /* a block is a loop that happens once */
 			  (yyval.opval) = newWHILEOP(0, 1, NULL,
 				  NULL, block_end((ps[-3].val.ival), (ps[-1].val.opval)), NULL, 0);
@@ -681,33 +681,33 @@ case 2:
 
     break;
 
-  case 72:
+  case 72: /* barestmt: fielddecl PERLY_SEMICOLON  */
 #line 625 "perly.y"
-    {
+                        {
 			  (yyval.opval) = (ps[-1].val.opval);
 			}
 
     break;
 
-  case 73:
+  case 73: /* barestmt: sideff PERLY_SEMICOLON  */
 #line 629 "perly.y"
-    {
+                        {
 			  (yyval.opval) = (ps[-1].val.opval);
 			}
 
     break;
 
-  case 74:
+  case 74: /* barestmt: KW_DEFER mblock  */
 #line 633 "perly.y"
-    {
+                        {
 			  (yyval.opval) = newDEFEROP(0, op_scope((ps[0].val.opval)));
 			}
 
     break;
 
-  case 75:
+  case 75: /* barestmt: YADAYADA PERLY_SEMICOLON  */
 #line 637 "perly.y"
-    {
+                        {
                           /* diag_listed_as: Unimplemented */
 			  (yyval.opval) = newLISTOP(OP_DIE, 0, newOP(OP_PUSHMARK, 0),
 				newSVOP(OP_CONST, 0, newSVpvs("Unimplemented")));
@@ -715,18 +715,18 @@ case 2:
 
     break;
 
-  case 76:
+  case 76: /* barestmt: PERLY_SEMICOLON  */
 #line 643 "perly.y"
-    {
+                        {
 			  (yyval.opval) = NULL;
 			  parser->copline = NOLINE;
 			}
 
     break;
 
-  case 77:
+  case 77: /* formline: THING formarg  */
 #line 651 "perly.y"
-    { OP *list;
+                        { OP *list;
 			  if ((ps[0].val.opval)) {
 			      OP *term = (ps[0].val.opval);
 			      list = op_append_elem(OP_LIST, (ps[-1].val.opval), term);
@@ -743,73 +743,73 @@ case 2:
 
     break;
 
-  case 79:
+  case 79: /* formarg: FORMLBRACK stmtseq FORMRBRACK  */
 #line 670 "perly.y"
-    { (yyval.opval) = op_unscope((ps[-1].val.opval)); }
+                        { (yyval.opval) = op_unscope((ps[-1].val.opval)); }
 
     break;
 
-  case 81:
+  case 81: /* sideff: error  */
 #line 678 "perly.y"
-    { (yyval.opval) = NULL; }
+                        { (yyval.opval) = NULL; }
 
     break;
 
-  case 82:
+  case 82: /* sideff: expr  */
 #line 680 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 83:
+  case 83: /* sideff: expr KW_IF condition  */
 #line 682 "perly.y"
-    { (yyval.opval) = newLOGOP(OP_AND, 0, (ps[0].val.opval), (ps[-2].val.opval)); }
+                        { (yyval.opval) = newLOGOP(OP_AND, 0, (ps[0].val.opval), (ps[-2].val.opval)); }
 
     break;
 
-  case 84:
+  case 84: /* sideff: expr KW_UNLESS condition  */
 #line 684 "perly.y"
-    { (yyval.opval) = newLOGOP(OP_OR, 0, (ps[0].val.opval), (ps[-2].val.opval)); }
+                        { (yyval.opval) = newLOGOP(OP_OR, 0, (ps[0].val.opval), (ps[-2].val.opval)); }
 
     break;
 
-  case 85:
+  case 85: /* sideff: expr KW_WHILE condition  */
 #line 686 "perly.y"
-    { (yyval.opval) = newLOOPOP(OPf_PARENS, 1, scalar((ps[0].val.opval)), (ps[-2].val.opval)); }
+                        { (yyval.opval) = newLOOPOP(OPf_PARENS, 1, scalar((ps[0].val.opval)), (ps[-2].val.opval)); }
 
     break;
 
-  case 86:
+  case 86: /* sideff: expr KW_UNTIL iexpr  */
 #line 688 "perly.y"
-    { (yyval.opval) = newLOOPOP(OPf_PARENS, 1, (ps[0].val.opval), (ps[-2].val.opval)); }
+                        { (yyval.opval) = newLOOPOP(OPf_PARENS, 1, (ps[0].val.opval), (ps[-2].val.opval)); }
 
     break;
 
-  case 87:
+  case 87: /* sideff: expr KW_FOR condition  */
 #line 690 "perly.y"
-    { (yyval.opval) = newFOROP(0, NULL, (ps[0].val.opval), (ps[-2].val.opval), NULL);
+                        { (yyval.opval) = newFOROP(0, NULL, (ps[0].val.opval), (ps[-2].val.opval), NULL);
 			  parser->copline = (line_t)(ps[-1].val.ival); }
 
     break;
 
-  case 88:
+  case 88: /* sideff: expr KW_WHEN condition  */
 #line 693 "perly.y"
-    { (yyval.opval) = newWHENOP((ps[0].val.opval), op_scope((ps[-2].val.opval))); }
+                        { (yyval.opval) = newWHENOP((ps[0].val.opval), op_scope((ps[-2].val.opval))); }
 
     break;
 
-  case 90:
+  case 90: /* else: KW_ELSE mblock  */
 #line 700 "perly.y"
-    {
+                        {
 			  ((ps[0].val.opval))->op_flags |= OPf_PARENS;
 			  (yyval.opval) = op_scope((ps[0].val.opval));
 			}
 
     break;
 
-  case 91:
+  case 91: /* else: KW_ELSIF PERLY_PAREN_OPEN mexpr PERLY_PAREN_CLOSE mblock else  */
 #line 705 "perly.y"
-    { parser->copline = (line_t)(ps[-5].val.ival);
+                        { parser->copline = (line_t)(ps[-5].val.ival);
 			    (yyval.opval) = newCONDOP(0,
 				newSTATEOP(OPf_SPECIAL,NULL,(ps[-3].val.opval)),
 				op_scope((ps[-1].val.opval)), (ps[0].val.opval));
@@ -818,95 +818,95 @@ case 2:
 
     break;
 
-  case 93:
+  case 93: /* cont: KW_CONTINUE block  */
 #line 717 "perly.y"
-    { (yyval.opval) = op_scope((ps[0].val.opval)); }
+                        { (yyval.opval) = op_scope((ps[0].val.opval)); }
 
     break;
 
-  case 94:
+  case 94: /* finally: %empty  */
 #line 722 "perly.y"
-    { (yyval.opval) = NULL; }
+                        { (yyval.opval) = NULL; }
 
     break;
 
-  case 95:
+  case 95: /* finally: KW_FINALLY block  */
 #line 724 "perly.y"
-    { (yyval.opval) = op_scope((ps[0].val.opval)); }
+                        { (yyval.opval) = op_scope((ps[0].val.opval)); }
 
     break;
 
-  case 96:
+  case 96: /* mintro: %empty  */
 #line 729 "perly.y"
-    { (yyval.ival) = (PL_min_intro_pending &&
+                        { (yyval.ival) = (PL_min_intro_pending &&
 			    PL_max_intro_pending >=  PL_min_intro_pending);
 			  intro_my(); }
 
     break;
 
-  case 99:
+  case 99: /* texpr: %empty  */
 #line 741 "perly.y"
-    { YYSTYPE tmplval;
+                        { YYSTYPE tmplval;
 			  (void)scan_num("1", &tmplval);
 			  (yyval.opval) = tmplval.opval; }
 
     break;
 
-  case 101:
+  case 101: /* iexpr: expr  */
 #line 749 "perly.y"
-    { (yyval.opval) = invert(scalar((ps[0].val.opval))); }
+                        { (yyval.opval) = invert(scalar((ps[0].val.opval))); }
 
     break;
 
-  case 102:
+  case 102: /* mexpr: expr  */
 #line 754 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); intro_my(); }
+                        { (yyval.opval) = (ps[0].val.opval); intro_my(); }
 
     break;
 
-  case 103:
+  case 103: /* mnexpr: nexpr  */
 #line 758 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); intro_my(); }
+                        { (yyval.opval) = (ps[0].val.opval); intro_my(); }
 
     break;
 
-  case 104:
+  case 104: /* formname: BAREWORD  */
 #line 761 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+                                { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 106:
+  case 106: /* startsub: %empty  */
 #line 766 "perly.y"
-    { (yyval.ival) = start_subparse(FALSE, 0);
+                        { (yyval.ival) = start_subparse(FALSE, 0);
 			    SAVEFREESV(PL_compcv); }
 
     break;
 
-  case 107:
+  case 107: /* startanonsub: %empty  */
 #line 772 "perly.y"
-    { (yyval.ival) = start_subparse(FALSE, CVf_ANON);
+                        { (yyval.ival) = start_subparse(FALSE, CVf_ANON);
 			    SAVEFREESV(PL_compcv); }
 
     break;
 
-  case 108:
+  case 108: /* startanonmethod: %empty  */
 #line 777 "perly.y"
-    { (yyval.ival) = start_subparse(FALSE, CVf_ANON|CVf_IsMETHOD);
+                        { (yyval.ival) = start_subparse(FALSE, CVf_ANON|CVf_IsMETHOD);
 			    SAVEFREESV(PL_compcv); }
 
     break;
 
-  case 109:
+  case 109: /* startformsub: %empty  */
 #line 782 "perly.y"
-    { (yyval.ival) = start_subparse(TRUE, 0);
+                        { (yyval.ival) = start_subparse(TRUE, 0);
 			    SAVEFREESV(PL_compcv); }
 
     break;
 
-  case 115:
+  case 115: /* subattrlist: COLONATTR THING  */
 #line 801 "perly.y"
-    {
+                        {
 			  OP *attrlist = (ps[0].val.opval);
 			  if(attrlist && !PL_parser->sig_seen)
 			      attrlist = apply_builtin_cv_attributes(PL_compcv, attrlist);
@@ -915,51 +915,51 @@ case 2:
 
     break;
 
-  case 116:
+  case 116: /* subattrlist: COLONATTR  */
 #line 808 "perly.y"
-    { (yyval.opval) = NULL; }
+                        { (yyval.opval) = NULL; }
 
     break;
 
-  case 117:
+  case 117: /* myattrlist: COLONATTR THING  */
 #line 813 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 118:
+  case 118: /* myattrlist: COLONATTR  */
 #line 815 "perly.y"
-    { (yyval.opval) = NULL; }
+                        { (yyval.opval) = NULL; }
 
     break;
 
-  case 119:
+  case 119: /* sigvarname: %empty  */
 #line 826 "perly.y"
-    { parser->in_my = 0; (yyval.opval) = NULL; }
+                        { parser->in_my = 0; (yyval.opval) = NULL; }
 
     break;
 
-  case 120:
+  case 120: /* sigvarname: PRIVATEREF  */
 #line 828 "perly.y"
-    { parser->in_my = 0; (yyval.opval) = (ps[0].val.opval); }
+                        { parser->in_my = 0; (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 121:
+  case 121: /* sigslurpsigil: PERLY_SNAIL  */
 #line 833 "perly.y"
-    { (yyval.ival) = '@'; }
+                        { (yyval.ival) = '@'; }
 
     break;
 
-  case 122:
+  case 122: /* sigslurpsigil: PERLY_PERCENT_SIGN  */
 #line 835 "perly.y"
-    { (yyval.ival) = '%'; }
+                        { (yyval.ival) = '%'; }
 
     break;
 
-  case 123:
+  case 123: /* sigslurpelem: sigslurpsigil sigvarname sigdefault  */
 #line 839 "perly.y"
-    {
+                        {
                             I32 sigil = (ps[-2].val.ival);
                             OP *var   = (ps[-1].val.opval);
                             OP *defop = (ps[0].val.opval);
@@ -977,15 +977,15 @@ case 2:
 
     break;
 
-  case 125:
+  case 125: /* sigdefault: ASSIGNOP  */
 #line 860 "perly.y"
-    { (yyval.opval) = newARGDEFELEMOP(0, newOP(OP_NULL, 0), parser->sig_elems); }
+                        { (yyval.opval) = newARGDEFELEMOP(0, newOP(OP_NULL, 0), parser->sig_elems); }
 
     break;
 
-  case 126:
+  case 126: /* sigdefault: ASSIGNOP term  */
 #line 862 "perly.y"
-    {
+                        {
                             I32 flags = 0;
                             if ((ps[-1].val.ival) == OP_DORASSIGN)
                                 flags |= OPpARG_IF_UNDEF << 8;
@@ -996,9 +996,9 @@ case 2:
 
     break;
 
-  case 127:
+  case 127: /* sigscalarelem: PERLY_DOLLAR sigvarname sigdefault  */
 #line 875 "perly.y"
-    {
+                        {
                             OP *var   = (ps[-1].val.opval);
                             OP *defop = (ps[0].val.opval);
 
@@ -1056,47 +1056,47 @@ case 2:
 
     break;
 
-  case 128:
+  case 128: /* sigelem: sigscalarelem  */
 #line 935 "perly.y"
-    { parser->in_my = KEY_sigvar; (yyval.opval) = (ps[0].val.opval); }
+                        { parser->in_my = KEY_sigvar; (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 129:
+  case 129: /* sigelem: sigslurpelem  */
 #line 937 "perly.y"
-    { parser->in_my = KEY_sigvar; (yyval.opval) = (ps[0].val.opval); }
+                        { parser->in_my = KEY_sigvar; (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 130:
+  case 130: /* siglist: siglist PERLY_COMMA  */
 #line 943 "perly.y"
-    { (yyval.opval) = (ps[-1].val.opval); }
+                        { (yyval.opval) = (ps[-1].val.opval); }
 
     break;
 
-  case 131:
+  case 131: /* siglist: siglist PERLY_COMMA sigelem  */
 #line 945 "perly.y"
-    {
+                        {
 			  (yyval.opval) = op_append_list(OP_LINESEQ, (ps[-2].val.opval), (ps[0].val.opval));
 			}
 
     break;
 
-  case 132:
+  case 132: /* siglist: sigelem  */
 #line 949 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 137:
+  case 137: /* subsignature: PERLY_PAREN_OPEN subsigguts PERLY_PAREN_CLOSE  */
 #line 966 "perly.y"
-    { (yyval.opval) = (ps[-1].val.opval); }
+                        { (yyval.opval) = (ps[-1].val.opval); }
 
     break;
 
-  case 138:
+  case 138: /* $@20: %empty  */
 #line 969 "perly.y"
-    {
+                        {
                             ENTER;
                             SAVEIV(parser->sig_elems);
                             SAVEIV(parser->sig_optelems);
@@ -1109,9 +1109,9 @@ case 2:
 
     break;
 
-  case 139:
+  case 139: /* subsigguts: $@20 optsiglist  */
 #line 980 "perly.y"
-    {
+                        {
                             OP            *sigops = (ps[0].val.opval);
                             struct op_argcheck_aux *aux;
                             OP            *check;
@@ -1166,15 +1166,15 @@ case 2:
 
     break;
 
-  case 141:
+  case 141: /* optsubbody: PERLY_SEMICOLON  */
 #line 1037 "perly.y"
-    { (yyval.opval) = NULL; }
+                                { (yyval.opval) = NULL; }
 
     break;
 
-  case 142:
+  case 142: /* subbody: remember PERLY_BRACE_OPEN stmtseq PERLY_BRACE_CLOSE  */
 #line 1043 "perly.y"
-    {
+                        {
 			  if (parser->copline > (line_t)(ps[-2].val.ival))
 			      parser->copline = (line_t)(ps[-2].val.ival);
 			  (yyval.opval) = block_end((ps[-3].val.ival), (ps[-1].val.opval));
@@ -1182,21 +1182,21 @@ case 2:
 
     break;
 
-  case 144:
+  case 144: /* optsigsubbody: PERLY_SEMICOLON  */
 #line 1055 "perly.y"
-    { (yyval.opval) = NULL; }
+                                   { (yyval.opval) = NULL; }
 
     break;
 
-  case 145:
+  case 145: /* $@21: %empty  */
 #line 1060 "perly.y"
-    { PL_parser->sig_seen = FALSE; }
+                        { PL_parser->sig_seen = FALSE; }
 
     break;
 
-  case 146:
+  case 146: /* sigsubbody: remember optsubsignature PERLY_BRACE_OPEN $@21 stmtseq PERLY_BRACE_CLOSE  */
 #line 1062 "perly.y"
-    {
+                        {
 			  if (parser->copline > (line_t)(ps[-3].val.ival))
 			      parser->copline = (line_t)(ps[-3].val.ival);
 			  (yyval.opval) = block_end((ps[-5].val.ival),
@@ -1205,64 +1205,64 @@ case 2:
 
     break;
 
-  case 147:
+  case 147: /* expr: expr ANDOP expr  */
 #line 1073 "perly.y"
-    { (yyval.opval) = newLOGOP(OP_AND, 0, (ps[-2].val.opval), (ps[0].val.opval)); }
+                        { (yyval.opval) = newLOGOP(OP_AND, 0, (ps[-2].val.opval), (ps[0].val.opval)); }
 
     break;
 
-  case 148:
+  case 148: /* expr: expr PLUGIN_LOGICAL_AND_LOW_OP expr  */
 #line 1075 "perly.y"
-    { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
+                        { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
 
     break;
 
-  case 149:
+  case 149: /* expr: expr OROP expr  */
 #line 1077 "perly.y"
-    { (yyval.opval) = newLOGOP((ps[-1].val.ival), 0, (ps[-2].val.opval), (ps[0].val.opval)); }
+                        { (yyval.opval) = newLOGOP((ps[-1].val.ival), 0, (ps[-2].val.opval), (ps[0].val.opval)); }
 
     break;
 
-  case 150:
+  case 150: /* expr: expr PLUGIN_LOGICAL_OR_LOW_OP expr  */
 #line 1079 "perly.y"
-    { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
+                        { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
 
     break;
 
-  case 152:
+  case 152: /* listexpr: listexpr PERLY_COMMA  */
 #line 1085 "perly.y"
-    { (yyval.opval) = (ps[-1].val.opval); }
+                        { (yyval.opval) = (ps[-1].val.opval); }
 
     break;
 
-  case 153:
+  case 153: /* listexpr: listexpr PERLY_COMMA term  */
 #line 1087 "perly.y"
-    {
+                        {
 			  OP* term = (ps[0].val.opval);
 			  (yyval.opval) = op_append_elem(OP_LIST, (ps[-2].val.opval), term);
 			}
 
     break;
 
-  case 155:
+  case 155: /* listop: LSTOP indirob listexpr  */
 #line 1096 "perly.y"
-    { (yyval.opval) = op_convert_list((ps[-2].val.ival), OPf_STACKED,
+                        { (yyval.opval) = op_convert_list((ps[-2].val.ival), OPf_STACKED,
 				op_prepend_elem(OP_LIST, newGVREF((ps[-2].val.ival),(ps[-1].val.opval)), (ps[0].val.opval)) );
 			}
 
     break;
 
-  case 156:
+  case 156: /* listop: FUNC PERLY_PAREN_OPEN indirob expr PERLY_PAREN_CLOSE  */
 #line 1100 "perly.y"
-    { (yyval.opval) = op_convert_list((ps[-4].val.ival), OPf_STACKED,
+                        { (yyval.opval) = op_convert_list((ps[-4].val.ival), OPf_STACKED,
 				op_prepend_elem(OP_LIST, newGVREF((ps[-4].val.ival),(ps[-2].val.opval)), (ps[-1].val.opval)) );
 			}
 
     break;
 
-  case 157:
+  case 157: /* listop: term ARROW methodname PERLY_PAREN_OPEN optexpr PERLY_PAREN_CLOSE  */
 #line 1104 "perly.y"
-    { (yyval.opval) = op_convert_list(OP_ENTERSUB, OPf_STACKED,
+                        { (yyval.opval) = op_convert_list(OP_ENTERSUB, OPf_STACKED,
 				op_append_elem(OP_LIST,
 				    op_prepend_elem(OP_LIST, scalar((ps[-5].val.opval)), (ps[-1].val.opval)),
 				    newMETHOP(OP_METHOD, 0, (ps[-3].val.opval))));
@@ -1270,18 +1270,18 @@ case 2:
 
     break;
 
-  case 158:
+  case 158: /* listop: term ARROW methodname  */
 #line 1110 "perly.y"
-    { (yyval.opval) = op_convert_list(OP_ENTERSUB, OPf_STACKED,
+                        { (yyval.opval) = op_convert_list(OP_ENTERSUB, OPf_STACKED,
 				op_append_elem(OP_LIST, scalar((ps[-2].val.opval)),
 				    newMETHOP(OP_METHOD, 0, (ps[0].val.opval))));
 			}
 
     break;
 
-  case 159:
+  case 159: /* listop: METHCALL0 indirob optlistexpr  */
 #line 1115 "perly.y"
-    { (yyval.opval) = op_convert_list(OP_ENTERSUB, OPf_STACKED,
+                        { (yyval.opval) = op_convert_list(OP_ENTERSUB, OPf_STACKED,
 				op_append_elem(OP_LIST,
 				    op_prepend_elem(OP_LIST, (ps[-1].val.opval), (ps[0].val.opval)),
 				    newMETHOP(OP_METHOD, 0, (ps[-2].val.opval))));
@@ -1289,9 +1289,9 @@ case 2:
 
     break;
 
-  case 160:
+  case 160: /* listop: METHCALL indirob PERLY_PAREN_OPEN optexpr PERLY_PAREN_CLOSE  */
 #line 1121 "perly.y"
-    { (yyval.opval) = op_convert_list(OP_ENTERSUB, OPf_STACKED,
+                        { (yyval.opval) = op_convert_list(OP_ENTERSUB, OPf_STACKED,
 				op_append_elem(OP_LIST,
 				    op_prepend_elem(OP_LIST, (ps[-3].val.opval), (ps[-1].val.opval)),
 				    newMETHOP(OP_METHOD, 0, (ps[-4].val.opval))));
@@ -1299,97 +1299,100 @@ case 2:
 
     break;
 
-  case 161:
+  case 161: /* listop: LSTOP optlistexpr  */
 #line 1127 "perly.y"
-    { (yyval.opval) = op_convert_list((ps[-1].val.ival), 0, (ps[0].val.opval)); }
+                        { (yyval.opval) = op_convert_list((ps[-1].val.ival), 0, (ps[0].val.opval)); }
 
     break;
 
-  case 162:
+  case 162: /* listop: FUNC PERLY_PAREN_OPEN optexpr PERLY_PAREN_CLOSE  */
 #line 1129 "perly.y"
-    { (yyval.opval) = op_convert_list((ps[-3].val.ival), 0, (ps[-1].val.opval)); }
+                        { (yyval.opval) = op_convert_list((ps[-3].val.ival), 0, (ps[-1].val.opval)); }
 
     break;
 
-  case 163:
+  case 163: /* listop: FUNC SUBLEXSTART optexpr SUBLEXEND  */
 #line 1131 "perly.y"
-    { (yyval.opval) = op_convert_list((ps[-3].val.ival), 0, (ps[-1].val.opval)); }
+                        { (yyval.opval) = op_convert_list((ps[-3].val.ival), 0, (ps[-1].val.opval)); }
 
     break;
 
-  case 164:
+  case 164: /* @22: %empty  */
 #line 1133 "perly.y"
-    { SvREFCNT_inc_simple_void(PL_compcv);
-			  (yyval.opval) = newANONATTRSUB((ps[-1].val.ival), 0, NULL, (ps[0].val.opval)); }
+                        { SvREFCNT_inc_simple_void(PL_compcv);
+                          (yyval.opval) = newANONATTRSUB((ps[-1].val.ival), 0, NULL, (ps[0].val.opval));
+                          /* prevent double op_free() if the following fails to parse */
+                          (ps[0].val.opval) = NULL;
+                        }
 
     break;
 
-  case 165:
-#line 1136 "perly.y"
-    { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED,
+  case 165: /* listop: LSTOPSUB startanonsub block @22 optlistexpr  */
+#line 1139 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED,
 				 op_append_elem(OP_LIST,
 				   op_prepend_elem(OP_LIST, (ps[-1].val.opval), (ps[0].val.opval)), (ps[-4].val.opval)));
 			}
 
     break;
 
-  case 168:
-#line 1151 "perly.y"
-    { (yyval.opval) = newBINOP(OP_GELEM, 0, (ps[-4].val.opval), scalar((ps[-2].val.opval))); }
+  case 168: /* subscripted: gelem PERLY_BRACE_OPEN expr PERLY_SEMICOLON PERLY_BRACE_CLOSE  */
+#line 1154 "perly.y"
+                        { (yyval.opval) = newBINOP(OP_GELEM, 0, (ps[-4].val.opval), scalar((ps[-2].val.opval))); }
 
     break;
 
-  case 169:
-#line 1153 "perly.y"
-    { (yyval.opval) = newBINOP(OP_AELEM, 0, oopsAV((ps[-3].val.opval)), scalar((ps[-1].val.opval)));
+  case 169: /* subscripted: scalar PERLY_BRACKET_OPEN expr PERLY_BRACKET_CLOSE  */
+#line 1156 "perly.y"
+                        { (yyval.opval) = newBINOP(OP_AELEM, 0, oopsAV((ps[-3].val.opval)), scalar((ps[-1].val.opval)));
 			}
 
     break;
 
-  case 170:
-#line 1156 "perly.y"
-    { (yyval.opval) = newBINOP(OP_AELEM, 0,
+  case 170: /* subscripted: term ARROW PERLY_BRACKET_OPEN expr PERLY_BRACKET_CLOSE  */
+#line 1159 "perly.y"
+                        { (yyval.opval) = newBINOP(OP_AELEM, 0,
 					ref(newAVREF((ps[-4].val.opval)),OP_RV2AV),
 					scalar((ps[-1].val.opval)));
 			}
 
     break;
 
-  case 171:
-#line 1161 "perly.y"
-    { (yyval.opval) = newBINOP(OP_AELEM, 0,
+  case 171: /* subscripted: subscripted PERLY_BRACKET_OPEN expr PERLY_BRACKET_CLOSE  */
+#line 1164 "perly.y"
+                        { (yyval.opval) = newBINOP(OP_AELEM, 0,
 					ref(newAVREF((ps[-3].val.opval)),OP_RV2AV),
 					scalar((ps[-1].val.opval)));
 			}
 
     break;
 
-  case 172:
-#line 1166 "perly.y"
-    { (yyval.opval) = newBINOP(OP_HELEM, 0, oopsHV((ps[-4].val.opval)), jmaybe((ps[-2].val.opval)));
+  case 172: /* subscripted: scalar PERLY_BRACE_OPEN expr PERLY_SEMICOLON PERLY_BRACE_CLOSE  */
+#line 1169 "perly.y"
+                        { (yyval.opval) = newBINOP(OP_HELEM, 0, oopsHV((ps[-4].val.opval)), jmaybe((ps[-2].val.opval)));
 			}
 
     break;
 
-  case 173:
-#line 1169 "perly.y"
-    { (yyval.opval) = newBINOP(OP_HELEM, 0,
+  case 173: /* subscripted: term ARROW PERLY_BRACE_OPEN expr PERLY_SEMICOLON PERLY_BRACE_CLOSE  */
+#line 1172 "perly.y"
+                        { (yyval.opval) = newBINOP(OP_HELEM, 0,
 					ref(newHVREF((ps[-5].val.opval)),OP_RV2HV),
 					jmaybe((ps[-2].val.opval))); }
 
     break;
 
-  case 174:
-#line 1173 "perly.y"
-    { (yyval.opval) = newBINOP(OP_HELEM, 0,
+  case 174: /* subscripted: subscripted PERLY_BRACE_OPEN expr PERLY_SEMICOLON PERLY_BRACE_CLOSE  */
+#line 1176 "perly.y"
+                        { (yyval.opval) = newBINOP(OP_HELEM, 0,
 					ref(newHVREF((ps[-4].val.opval)),OP_RV2HV),
 					jmaybe((ps[-2].val.opval))); }
 
     break;
 
-  case 175:
-#line 1177 "perly.y"
-    { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED,
+  case 175: /* subscripted: term ARROW PERLY_PAREN_OPEN PERLY_PAREN_CLOSE  */
+#line 1180 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED,
 				   newCVREF(0, scalar((ps[-3].val.opval))));
 			  if (parser->expect == XBLOCK)
 			      parser->expect = XOPERATOR;
@@ -1397,9 +1400,9 @@ case 2:
 
     break;
 
-  case 176:
-#line 1183 "perly.y"
-    { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED,
+  case 176: /* subscripted: term ARROW PERLY_PAREN_OPEN expr PERLY_PAREN_CLOSE  */
+#line 1186 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED,
 				   op_append_elem(OP_LIST, (ps[-1].val.opval),
 				       newCVREF(0, scalar((ps[-4].val.opval)))));
 			  if (parser->expect == XBLOCK)
@@ -1408,9 +1411,9 @@ case 2:
 
     break;
 
-  case 177:
-#line 1191 "perly.y"
-    { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED,
+  case 177: /* subscripted: subscripted PERLY_PAREN_OPEN expr PERLY_PAREN_CLOSE  */
+#line 1194 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED,
 				   op_append_elem(OP_LIST, (ps[-1].val.opval),
 					       newCVREF(0, scalar((ps[-3].val.opval)))));
 			  if (parser->expect == XBLOCK)
@@ -1419,9 +1422,9 @@ case 2:
 
     break;
 
-  case 178:
-#line 1198 "perly.y"
-    { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED,
+  case 178: /* subscripted: subscripted PERLY_PAREN_OPEN PERLY_PAREN_CLOSE  */
+#line 1201 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED,
 				   newCVREF(0, scalar((ps[-2].val.opval))));
 			  if (parser->expect == XBLOCK)
 			      parser->expect = XOPERATOR;
@@ -1429,278 +1432,278 @@ case 2:
 
     break;
 
-  case 179:
-#line 1204 "perly.y"
-    { (yyval.opval) = newSLICEOP(0, (ps[-1].val.opval), (ps[-4].val.opval)); }
+  case 179: /* subscripted: PERLY_PAREN_OPEN expr PERLY_PAREN_CLOSE PERLY_BRACKET_OPEN expr PERLY_BRACKET_CLOSE  */
+#line 1207 "perly.y"
+                        { (yyval.opval) = newSLICEOP(0, (ps[-1].val.opval), (ps[-4].val.opval)); }
 
     break;
 
-  case 180:
-#line 1206 "perly.y"
-    { (yyval.opval) = newSLICEOP(0, (ps[-1].val.opval), (ps[-3].val.opval)); }
+  case 180: /* subscripted: QWLIST PERLY_BRACKET_OPEN expr PERLY_BRACKET_CLOSE  */
+#line 1209 "perly.y"
+                        { (yyval.opval) = newSLICEOP(0, (ps[-1].val.opval), (ps[-3].val.opval)); }
 
     break;
 
-  case 181:
-#line 1208 "perly.y"
-    { (yyval.opval) = newSLICEOP(0, (ps[-1].val.opval), NULL); }
+  case 181: /* subscripted: PERLY_PAREN_OPEN PERLY_PAREN_CLOSE PERLY_BRACKET_OPEN expr PERLY_BRACKET_CLOSE  */
+#line 1211 "perly.y"
+                        { (yyval.opval) = newSLICEOP(0, (ps[-1].val.opval), NULL); }
 
     break;
 
-  case 182:
-#line 1213 "perly.y"
-    { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
+  case 182: /* termbinop: term PLUGIN_HIGH_OP term  */
+#line 1216 "perly.y"
+                        { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
 
     break;
 
-  case 183:
-#line 1215 "perly.y"
-    { (yyval.opval) = newASSIGNOP(OPf_STACKED, (ps[-2].val.opval), (ps[-1].val.ival), (ps[0].val.opval)); }
+  case 183: /* termbinop: term ASSIGNOP term  */
+#line 1218 "perly.y"
+                        { (yyval.opval) = newASSIGNOP(OPf_STACKED, (ps[-2].val.opval), (ps[-1].val.ival), (ps[0].val.opval)); }
 
     break;
 
-  case 184:
-#line 1217 "perly.y"
-    { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
+  case 184: /* termbinop: term PLUGIN_ASSIGN_OP term  */
+#line 1220 "perly.y"
+                        { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
 
     break;
 
-  case 185:
-#line 1219 "perly.y"
-    { (yyval.opval) = newBINOP((ps[-1].val.ival), 0, scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
+  case 185: /* termbinop: term POWOP term  */
+#line 1222 "perly.y"
+                        { (yyval.opval) = newBINOP((ps[-1].val.ival), 0, scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
 
     break;
 
-  case 186:
-#line 1221 "perly.y"
-    { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
+  case 186: /* termbinop: term PLUGIN_POW_OP term  */
+#line 1224 "perly.y"
+                        { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
 
     break;
 
-  case 187:
-#line 1223 "perly.y"
-    {   if ((ps[-1].val.ival) != OP_REPEAT)
+  case 187: /* termbinop: term MULOP term  */
+#line 1226 "perly.y"
+                        {   if ((ps[-1].val.ival) != OP_REPEAT)
 				scalar((ps[-2].val.opval));
 			    (yyval.opval) = newBINOP((ps[-1].val.ival), 0, (ps[-2].val.opval), scalar((ps[0].val.opval)));
 			}
 
     break;
 
-  case 188:
-#line 1228 "perly.y"
-    { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
+  case 188: /* termbinop: term PLUGIN_MUL_OP term  */
+#line 1231 "perly.y"
+                        { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
 
     break;
 
-  case 189:
-#line 1230 "perly.y"
-    { (yyval.opval) = newBINOP((ps[-1].val.ival), 0, scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
+  case 189: /* termbinop: term ADDOP term  */
+#line 1233 "perly.y"
+                        { (yyval.opval) = newBINOP((ps[-1].val.ival), 0, scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
 
     break;
 
-  case 190:
-#line 1232 "perly.y"
-    { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
+  case 190: /* termbinop: term PLUGIN_ADD_OP term  */
+#line 1235 "perly.y"
+                        { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
 
     break;
 
-  case 191:
-#line 1234 "perly.y"
-    { (yyval.opval) = newBINOP((ps[-1].val.ival), 0, scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
+  case 191: /* termbinop: term SHIFTOP term  */
+#line 1237 "perly.y"
+                        { (yyval.opval) = newBINOP((ps[-1].val.ival), 0, scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
 
     break;
 
-  case 192:
-#line 1236 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+  case 192: /* termbinop: termrelop  */
+#line 1239 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 193:
-#line 1238 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+  case 193: /* termbinop: termeqop  */
+#line 1241 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 194:
-#line 1240 "perly.y"
-    { (yyval.opval) = newBINOP((ps[-1].val.ival), 0, scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
+  case 194: /* termbinop: term BITANDOP term  */
+#line 1243 "perly.y"
+                        { (yyval.opval) = newBINOP((ps[-1].val.ival), 0, scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
 
     break;
 
-  case 195:
-#line 1242 "perly.y"
-    { (yyval.opval) = newBINOP((ps[-1].val.ival), 0, scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
+  case 195: /* termbinop: term BITOROP term  */
+#line 1245 "perly.y"
+                        { (yyval.opval) = newBINOP((ps[-1].val.ival), 0, scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
 
     break;
 
-  case 196:
-#line 1244 "perly.y"
-    { (yyval.opval) = newRANGE((ps[-1].val.ival), scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
+  case 196: /* termbinop: term DOTDOT term  */
+#line 1247 "perly.y"
+                        { (yyval.opval) = newRANGE((ps[-1].val.ival), scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
 
     break;
 
-  case 197:
-#line 1246 "perly.y"
-    { (yyval.opval) = newLOGOP(OP_AND, 0, (ps[-2].val.opval), (ps[0].val.opval)); }
+  case 197: /* termbinop: term ANDAND term  */
+#line 1249 "perly.y"
+                        { (yyval.opval) = newLOGOP(OP_AND, 0, (ps[-2].val.opval), (ps[0].val.opval)); }
 
     break;
 
-  case 198:
-#line 1248 "perly.y"
-    { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
+  case 198: /* termbinop: term PLUGIN_LOGICAL_AND_OP term  */
+#line 1251 "perly.y"
+                        { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
 
     break;
 
-  case 199:
-#line 1250 "perly.y"
-    { (yyval.opval) = newLOGOP((ps[-1].val.ival), 0, (ps[-2].val.opval), (ps[0].val.opval)); }
+  case 199: /* termbinop: term OROR term  */
+#line 1253 "perly.y"
+                        { (yyval.opval) = newLOGOP((ps[-1].val.ival), 0, (ps[-2].val.opval), (ps[0].val.opval)); }
 
     break;
 
-  case 200:
-#line 1252 "perly.y"
-    { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
+  case 200: /* termbinop: term PLUGIN_LOGICAL_OR_OP term  */
+#line 1255 "perly.y"
+                        { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
 
     break;
 
-  case 201:
-#line 1254 "perly.y"
-    { (yyval.opval) = newLOGOP(OP_DOR, 0, (ps[-2].val.opval), (ps[0].val.opval)); }
+  case 201: /* termbinop: term DORDOR term  */
+#line 1257 "perly.y"
+                        { (yyval.opval) = newLOGOP(OP_DOR, 0, (ps[-2].val.opval), (ps[0].val.opval)); }
 
     break;
 
-  case 202:
-#line 1256 "perly.y"
-    { (yyval.opval) = bind_match((ps[-1].val.ival), (ps[-2].val.opval), (ps[0].val.opval)); }
+  case 202: /* termbinop: term MATCHOP term  */
+#line 1259 "perly.y"
+                        { (yyval.opval) = bind_match((ps[-1].val.ival), (ps[-2].val.opval), (ps[0].val.opval)); }
 
     break;
 
-  case 203:
-#line 1258 "perly.y"
-    { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
+  case 203: /* termbinop: term PLUGIN_LOW_OP term  */
+#line 1261 "perly.y"
+                        { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
 
     break;
 
-  case 204:
-#line 1262 "perly.y"
-    { (yyval.opval) = cmpchain_finish((ps[0].val.opval)); }
+  case 204: /* termrelop: relopchain  */
+#line 1265 "perly.y"
+                        { (yyval.opval) = cmpchain_finish((ps[0].val.opval)); }
 
     break;
 
-  case 205:
-#line 1264 "perly.y"
-    { (yyval.opval) = newBINOP((ps[-1].val.ival), 0, scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
+  case 205: /* termrelop: term NCRELOP term  */
+#line 1267 "perly.y"
+                        { (yyval.opval) = newBINOP((ps[-1].val.ival), 0, scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
 
     break;
 
-  case 206:
-#line 1266 "perly.y"
-    { yyerror("syntax error"); YYERROR; }
+  case 206: /* termrelop: termrelop NCRELOP  */
+#line 1269 "perly.y"
+                        { yyerror("syntax error"); YYERROR; }
 
     break;
 
-  case 207:
-#line 1268 "perly.y"
-    { yyerror("syntax error"); YYERROR; }
+  case 207: /* termrelop: termrelop CHRELOP  */
+#line 1271 "perly.y"
+                        { yyerror("syntax error"); YYERROR; }
 
     break;
 
-  case 208:
-#line 1270 "perly.y"
-    { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
+  case 208: /* termrelop: term PLUGIN_REL_OP term  */
+#line 1273 "perly.y"
+                        { (yyval.opval) = build_infix_plugin((ps[-2].val.opval), (ps[0].val.opval), (ps[-1].val.pval)); }
 
     break;
 
-  case 209:
-#line 1274 "perly.y"
-    { (yyval.opval) = cmpchain_start((ps[-1].val.ival), (ps[-2].val.opval), (ps[0].val.opval)); }
+  case 209: /* relopchain: term CHRELOP term  */
+#line 1277 "perly.y"
+                        { (yyval.opval) = cmpchain_start((ps[-1].val.ival), (ps[-2].val.opval), (ps[0].val.opval)); }
 
     break;
 
-  case 210:
-#line 1276 "perly.y"
-    { (yyval.opval) = cmpchain_extend((ps[-1].val.ival), (ps[-2].val.opval), (ps[0].val.opval)); }
+  case 210: /* relopchain: relopchain CHRELOP term  */
+#line 1279 "perly.y"
+                        { (yyval.opval) = cmpchain_extend((ps[-1].val.ival), (ps[-2].val.opval), (ps[0].val.opval)); }
 
     break;
 
-  case 211:
-#line 1280 "perly.y"
-    { (yyval.opval) = cmpchain_finish((ps[0].val.opval)); }
+  case 211: /* termeqop: eqopchain  */
+#line 1283 "perly.y"
+                        { (yyval.opval) = cmpchain_finish((ps[0].val.opval)); }
 
     break;
 
-  case 212:
-#line 1282 "perly.y"
-    { (yyval.opval) = newBINOP((ps[-1].val.ival), 0, scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
+  case 212: /* termeqop: term NCEQOP term  */
+#line 1285 "perly.y"
+                        { (yyval.opval) = newBINOP((ps[-1].val.ival), 0, scalar((ps[-2].val.opval)), scalar((ps[0].val.opval))); }
 
     break;
 
-  case 213:
-#line 1284 "perly.y"
-    { yyerror("syntax error"); YYERROR; }
+  case 213: /* termeqop: termeqop NCEQOP  */
+#line 1287 "perly.y"
+                        { yyerror("syntax error"); YYERROR; }
 
     break;
 
-  case 214:
-#line 1286 "perly.y"
-    { yyerror("syntax error"); YYERROR; }
+  case 214: /* termeqop: termeqop CHEQOP  */
+#line 1289 "perly.y"
+                        { yyerror("syntax error"); YYERROR; }
 
     break;
 
-  case 215:
-#line 1290 "perly.y"
-    { (yyval.opval) = cmpchain_start((ps[-1].val.ival), (ps[-2].val.opval), (ps[0].val.opval)); }
+  case 215: /* eqopchain: term CHEQOP term  */
+#line 1293 "perly.y"
+                        { (yyval.opval) = cmpchain_start((ps[-1].val.ival), (ps[-2].val.opval), (ps[0].val.opval)); }
 
     break;
 
-  case 216:
-#line 1292 "perly.y"
-    { (yyval.opval) = cmpchain_extend((ps[-1].val.ival), (ps[-2].val.opval), (ps[0].val.opval)); }
+  case 216: /* eqopchain: eqopchain CHEQOP term  */
+#line 1295 "perly.y"
+                        { (yyval.opval) = cmpchain_extend((ps[-1].val.ival), (ps[-2].val.opval), (ps[0].val.opval)); }
 
     break;
 
-  case 217:
-#line 1297 "perly.y"
-    { (yyval.opval) = newUNOP(OP_NEGATE, 0, scalar((ps[0].val.opval))); }
+  case 217: /* termunop: PERLY_MINUS term  */
+#line 1300 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_NEGATE, 0, scalar((ps[0].val.opval))); }
 
     break;
 
-  case 218:
-#line 1299 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
-
-    break;
-
-  case 219:
+  case 218: /* termunop: PERLY_PLUS term  */
 #line 1302 "perly.y"
-    { (yyval.opval) = newUNOP(OP_NOT, 0, scalar((ps[0].val.opval))); }
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 220:
-#line 1304 "perly.y"
-    { (yyval.opval) = newUNOP((ps[-1].val.ival), 0, scalar((ps[0].val.opval))); }
+  case 219: /* termunop: PERLY_EXCLAMATION_MARK term  */
+#line 1305 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_NOT, 0, scalar((ps[0].val.opval))); }
 
     break;
 
-  case 221:
-#line 1306 "perly.y"
-    { (yyval.opval) = newUNOP(OP_POSTINC, 0,
+  case 220: /* termunop: PERLY_TILDE term  */
+#line 1307 "perly.y"
+                        { (yyval.opval) = newUNOP((ps[-1].val.ival), 0, scalar((ps[0].val.opval))); }
+
+    break;
+
+  case 221: /* termunop: term POSTINC  */
+#line 1309 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_POSTINC, 0,
 					op_lvalue(scalar((ps[-1].val.opval)), OP_POSTINC)); }
 
     break;
 
-  case 222:
-#line 1309 "perly.y"
-    { (yyval.opval) = newUNOP(OP_POSTDEC, 0,
+  case 222: /* termunop: term POSTDEC  */
+#line 1312 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_POSTDEC, 0,
 					op_lvalue(scalar((ps[-1].val.opval)), OP_POSTDEC));}
 
     break;
 
-  case 223:
-#line 1312 "perly.y"
-    { (yyval.opval) = op_convert_list(OP_JOIN, 0,
+  case 223: /* termunop: term POSTJOIN  */
+#line 1315 "perly.y"
+                        { (yyval.opval) = op_convert_list(OP_JOIN, 0,
 				       op_append_elem(
 					OP_LIST,
 					newSVREF(scalar(
@@ -1713,148 +1716,148 @@ case 2:
 
     break;
 
-  case 224:
-#line 1323 "perly.y"
-    { (yyval.opval) = newUNOP(OP_PREINC, 0,
+  case 224: /* termunop: PREINC term  */
+#line 1326 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_PREINC, 0,
 					op_lvalue(scalar((ps[0].val.opval)), OP_PREINC)); }
 
     break;
 
-  case 225:
-#line 1326 "perly.y"
-    { (yyval.opval) = newUNOP(OP_PREDEC, 0,
+  case 225: /* termunop: PREDEC term  */
+#line 1329 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_PREDEC, 0,
 					op_lvalue(scalar((ps[0].val.opval)), OP_PREDEC)); }
 
     break;
 
-  case 226:
-#line 1334 "perly.y"
-    { (yyval.opval) = newANONLIST((ps[-1].val.opval)); }
+  case 226: /* anonymous: PERLY_BRACKET_OPEN optexpr PERLY_BRACKET_CLOSE  */
+#line 1337 "perly.y"
+                        { (yyval.opval) = newANONLIST((ps[-1].val.opval)); }
 
     break;
 
-  case 227:
-#line 1336 "perly.y"
-    { (yyval.opval) = newANONHASH((ps[-2].val.opval)); }
+  case 227: /* anonymous: HASHBRACK optexpr PERLY_SEMICOLON PERLY_BRACE_CLOSE  */
+#line 1339 "perly.y"
+                        { (yyval.opval) = newANONHASH((ps[-2].val.opval)); }
 
     break;
 
-  case 228:
-#line 1338 "perly.y"
-    { SvREFCNT_inc_simple_void(PL_compcv);
+  case 228: /* anonymous: KW_SUB_anon startanonsub proto subattrlist subbody  */
+#line 1341 "perly.y"
+                        { SvREFCNT_inc_simple_void(PL_compcv);
 			  (yyval.opval) = newANONATTRSUB((ps[-3].val.ival), (ps[-2].val.opval), (ps[-1].val.opval), (ps[0].val.opval)); }
 
     break;
 
-  case 229:
-#line 1341 "perly.y"
-    { SvREFCNT_inc_simple_void(PL_compcv);
+  case 229: /* anonymous: KW_SUB_anon_sig startanonsub subattrlist sigsubbody  */
+#line 1344 "perly.y"
+                        { SvREFCNT_inc_simple_void(PL_compcv);
 			  (yyval.opval) = newANONATTRSUB((ps[-2].val.ival), NULL, (ps[-1].val.opval), (ps[0].val.opval)); }
 
     break;
 
-  case 230:
-#line 1344 "perly.y"
-    {
+  case 230: /* anonymous: KW_METHOD_anon startanonmethod subattrlist sigsubbody  */
+#line 1347 "perly.y"
+                        {
 			  SvREFCNT_inc_simple_void(PL_compcv);
 			  (yyval.opval) = newANONATTRSUB((ps[-2].val.ival), NULL, (ps[-1].val.opval), (ps[0].val.opval));
 			}
 
     break;
 
-  case 231:
-#line 1352 "perly.y"
-    { (yyval.opval) = dofile((ps[0].val.opval), (ps[-1].val.ival));}
+  case 231: /* termdo: KW_DO term  */
+#line 1355 "perly.y"
+                        { (yyval.opval) = dofile((ps[0].val.opval), (ps[-1].val.ival));}
 
     break;
 
-  case 232:
-#line 1354 "perly.y"
-    { (yyval.opval) = newUNOP(OP_NULL, OPf_SPECIAL, op_scope((ps[0].val.opval)));}
+  case 232: /* termdo: KW_DO block  */
+#line 1357 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_NULL, OPf_SPECIAL, op_scope((ps[0].val.opval)));}
 
     break;
 
-  case 237:
-#line 1362 "perly.y"
-    { (yyval.opval) = newCONDOP(0, (ps[-4].val.opval), (ps[-2].val.opval), (ps[0].val.opval)); }
+  case 237: /* term: term PERLY_QUESTION_MARK term PERLY_COLON term  */
+#line 1365 "perly.y"
+                        { (yyval.opval) = newCONDOP(0, (ps[-4].val.opval), (ps[-2].val.opval), (ps[0].val.opval)); }
 
     break;
 
-  case 238:
-#line 1364 "perly.y"
-    { (yyval.opval) = newUNOP(OP_REFGEN, 0, (ps[0].val.opval)); }
+  case 238: /* term: REFGEN term  */
+#line 1367 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_REFGEN, 0, (ps[0].val.opval)); }
 
     break;
 
-  case 239:
-#line 1366 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+  case 239: /* term: myattrterm  */
+#line 1369 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 240:
-#line 1368 "perly.y"
-    { (yyval.opval) = localize((ps[0].val.opval),0); }
+  case 240: /* term: KW_LOCAL term  */
+#line 1371 "perly.y"
+                        { (yyval.opval) = localize((ps[0].val.opval),0); }
 
     break;
 
-  case 241:
-#line 1370 "perly.y"
-    { (yyval.opval) = sawparens((ps[-1].val.opval)); }
+  case 241: /* term: PERLY_PAREN_OPEN expr PERLY_PAREN_CLOSE  */
+#line 1373 "perly.y"
+                        { (yyval.opval) = sawparens((ps[-1].val.opval)); }
 
     break;
 
-  case 242:
-#line 1372 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+  case 242: /* term: QWLIST  */
+#line 1375 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 243:
-#line 1374 "perly.y"
-    { (yyval.opval) = sawparens(newNULLLIST()); }
+  case 243: /* term: PERLY_PAREN_OPEN PERLY_PAREN_CLOSE  */
+#line 1377 "perly.y"
+                        { (yyval.opval) = sawparens(newNULLLIST()); }
 
     break;
 
-  case 244:
-#line 1376 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+  case 244: /* term: scalar  */
+#line 1379 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 245:
-#line 1378 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+  case 245: /* term: star  */
+#line 1381 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 246:
-#line 1380 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+  case 246: /* term: hsh  */
+#line 1383 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 247:
-#line 1382 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+  case 247: /* term: ary  */
+#line 1385 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 248:
-#line 1384 "perly.y"
-    { (yyval.opval) = newUNOP(OP_AV2ARYLEN, 0, ref((ps[0].val.opval), OP_AV2ARYLEN));}
+  case 248: /* term: arylen  */
+#line 1387 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_AV2ARYLEN, 0, ref((ps[0].val.opval), OP_AV2ARYLEN));}
 
     break;
 
-  case 249:
-#line 1386 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+  case 249: /* term: subscripted  */
+#line 1389 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 250:
-#line 1388 "perly.y"
-    { (yyval.opval) = op_prepend_elem(OP_ASLICE,
+  case 250: /* term: sliceme PERLY_BRACKET_OPEN expr PERLY_BRACKET_CLOSE  */
+#line 1391 "perly.y"
+                        { (yyval.opval) = op_prepend_elem(OP_ASLICE,
 				newOP(OP_PUSHMARK, 0),
 				    newLISTOP(OP_ASLICE, 0,
 					list((ps[-1].val.opval)),
@@ -1866,9 +1869,9 @@ case 2:
 
     break;
 
-  case 251:
-#line 1398 "perly.y"
-    { (yyval.opval) = op_prepend_elem(OP_KVASLICE,
+  case 251: /* term: kvslice PERLY_BRACKET_OPEN expr PERLY_BRACKET_CLOSE  */
+#line 1401 "perly.y"
+                        { (yyval.opval) = op_prepend_elem(OP_KVASLICE,
 				newOP(OP_PUSHMARK, 0),
 				    newLISTOP(OP_KVASLICE, 0,
 					list((ps[-1].val.opval)),
@@ -1880,9 +1883,9 @@ case 2:
 
     break;
 
-  case 252:
-#line 1408 "perly.y"
-    { (yyval.opval) = op_prepend_elem(OP_HSLICE,
+  case 252: /* term: sliceme PERLY_BRACE_OPEN expr PERLY_SEMICOLON PERLY_BRACE_CLOSE  */
+#line 1411 "perly.y"
+                        { (yyval.opval) = op_prepend_elem(OP_HSLICE,
 				newOP(OP_PUSHMARK, 0),
 				    newLISTOP(OP_HSLICE, 0,
 					list((ps[-2].val.opval)),
@@ -1894,9 +1897,9 @@ case 2:
 
     break;
 
-  case 253:
-#line 1418 "perly.y"
-    { (yyval.opval) = op_prepend_elem(OP_KVHSLICE,
+  case 253: /* term: kvslice PERLY_BRACE_OPEN expr PERLY_SEMICOLON PERLY_BRACE_CLOSE  */
+#line 1421 "perly.y"
+                        { (yyval.opval) = op_prepend_elem(OP_KVHSLICE,
 				newOP(OP_PUSHMARK, 0),
 				    newLISTOP(OP_KVHSLICE, 0,
 					list((ps[-2].val.opval)),
@@ -1908,182 +1911,182 @@ case 2:
 
     break;
 
-  case 254:
-#line 1428 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+  case 254: /* term: THING  */
+#line 1431 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 255:
-#line 1430 "perly.y"
-    { (yyval.opval) = newUNOP(OP_ENTERSUB, 0, scalar((ps[0].val.opval))); }
+  case 255: /* term: amper  */
+#line 1433 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_ENTERSUB, 0, scalar((ps[0].val.opval))); }
 
     break;
 
-  case 256:
-#line 1432 "perly.y"
-    { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED, scalar((ps[-2].val.opval)));
+  case 256: /* term: amper PERLY_PAREN_OPEN PERLY_PAREN_CLOSE  */
+#line 1435 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED, scalar((ps[-2].val.opval)));
 			}
 
     break;
 
-  case 257:
-#line 1435 "perly.y"
-    {
+  case 257: /* term: amper PERLY_PAREN_OPEN expr PERLY_PAREN_CLOSE  */
+#line 1438 "perly.y"
+                        {
 			  (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED,
 				op_append_elem(OP_LIST, (ps[-1].val.opval), scalar((ps[-3].val.opval))));
 			}
 
     break;
 
-  case 258:
-#line 1440 "perly.y"
-    { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED,
+  case 258: /* term: NOAMP subname optlistexpr  */
+#line 1443 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED,
 			    op_append_elem(OP_LIST, (ps[0].val.opval), scalar((ps[-1].val.opval))));
 			}
 
     break;
 
-  case 259:
-#line 1444 "perly.y"
-    { (yyval.opval) = newSVREF((ps[-3].val.opval)); }
+  case 259: /* term: term ARROW PERLY_DOLLAR PERLY_STAR  */
+#line 1447 "perly.y"
+                        { (yyval.opval) = newSVREF((ps[-3].val.opval)); }
 
     break;
 
-  case 260:
-#line 1446 "perly.y"
-    { (yyval.opval) = newAVREF((ps[-3].val.opval)); }
+  case 260: /* term: term ARROW PERLY_SNAIL PERLY_STAR  */
+#line 1449 "perly.y"
+                        { (yyval.opval) = newAVREF((ps[-3].val.opval)); }
 
     break;
 
-  case 261:
-#line 1448 "perly.y"
-    { (yyval.opval) = newHVREF((ps[-3].val.opval)); }
+  case 261: /* term: term ARROW PERLY_PERCENT_SIGN PERLY_STAR  */
+#line 1451 "perly.y"
+                        { (yyval.opval) = newHVREF((ps[-3].val.opval)); }
 
     break;
 
-  case 262:
-#line 1450 "perly.y"
-    { (yyval.opval) = newUNOP(OP_ENTERSUB, 0,
+  case 262: /* term: term ARROW PERLY_AMPERSAND PERLY_STAR  */
+#line 1453 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_ENTERSUB, 0,
 				       scalar(newCVREF((ps[-1].val.ival),(ps[-3].val.opval)))); }
 
     break;
 
-  case 263:
-#line 1453 "perly.y"
-    { (yyval.opval) = newGVREF(0,(ps[-3].val.opval)); }
+  case 263: /* term: term ARROW PERLY_STAR PERLY_STAR  */
+#line 1456 "perly.y"
+                        { (yyval.opval) = newGVREF(0,(ps[-3].val.opval)); }
 
     break;
 
-  case 264:
-#line 1455 "perly.y"
-    { (yyval.opval) = newOP((ps[0].val.ival), OPf_SPECIAL);
+  case 264: /* term: LOOPEX  */
+#line 1458 "perly.y"
+                        { (yyval.opval) = newOP((ps[0].val.ival), OPf_SPECIAL);
 			    PL_hints |= HINT_BLOCK_SCOPE; }
 
     break;
 
-  case 265:
-#line 1458 "perly.y"
-    { (yyval.opval) = newLOOPEX((ps[-1].val.ival),(ps[0].val.opval)); }
+  case 265: /* term: LOOPEX term  */
+#line 1461 "perly.y"
+                        { (yyval.opval) = newLOOPEX((ps[-1].val.ival),(ps[0].val.opval)); }
 
     break;
 
-  case 266:
-#line 1460 "perly.y"
-    { (yyval.opval) = newUNOP(OP_NOT, 0, scalar((ps[0].val.opval))); }
+  case 266: /* term: NOTOP listexpr  */
+#line 1463 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_NOT, 0, scalar((ps[0].val.opval))); }
 
     break;
 
-  case 267:
-#line 1462 "perly.y"
-    { (yyval.opval) = newOP((ps[0].val.ival), 0); }
+  case 267: /* term: UNIOP  */
+#line 1465 "perly.y"
+                        { (yyval.opval) = newOP((ps[0].val.ival), 0); }
 
     break;
 
-  case 268:
-#line 1464 "perly.y"
-    { (yyval.opval) = newUNOP((ps[-1].val.ival), 0, (ps[0].val.opval)); }
+  case 268: /* term: UNIOP block  */
+#line 1467 "perly.y"
+                        { (yyval.opval) = newUNOP((ps[-1].val.ival), 0, (ps[0].val.opval)); }
 
     break;
 
-  case 269:
-#line 1466 "perly.y"
-    { (yyval.opval) = newUNOP((ps[-1].val.ival), 0, (ps[0].val.opval)); }
+  case 269: /* term: UNIOP term  */
+#line 1469 "perly.y"
+                        { (yyval.opval) = newUNOP((ps[-1].val.ival), 0, (ps[0].val.opval)); }
 
     break;
 
-  case 270:
-#line 1468 "perly.y"
-    { (yyval.opval) = newOP(OP_REQUIRE, (ps[0].val.ival) ? OPf_SPECIAL : 0); }
+  case 270: /* term: KW_REQUIRE  */
+#line 1471 "perly.y"
+                        { (yyval.opval) = newOP(OP_REQUIRE, (ps[0].val.ival) ? OPf_SPECIAL : 0); }
 
     break;
 
-  case 271:
-#line 1470 "perly.y"
-    { (yyval.opval) = newUNOP(OP_REQUIRE, (ps[-1].val.ival) ? OPf_SPECIAL : 0, (ps[0].val.opval)); }
+  case 271: /* term: KW_REQUIRE term  */
+#line 1473 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_REQUIRE, (ps[-1].val.ival) ? OPf_SPECIAL : 0, (ps[0].val.opval)); }
 
     break;
 
-  case 272:
-#line 1472 "perly.y"
-    { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED, scalar((ps[0].val.opval))); }
+  case 272: /* term: UNIOPSUB  */
+#line 1475 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED, scalar((ps[0].val.opval))); }
 
     break;
 
-  case 273:
-#line 1474 "perly.y"
-    { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED,
+  case 273: /* term: UNIOPSUB term  */
+#line 1477 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED,
 			    op_append_elem(OP_LIST, (ps[0].val.opval), scalar((ps[-1].val.opval)))); }
 
     break;
 
-  case 274:
-#line 1477 "perly.y"
-    { (yyval.opval) = newOP((ps[0].val.ival), 0); }
+  case 274: /* term: FUNC0  */
+#line 1480 "perly.y"
+                        { (yyval.opval) = newOP((ps[0].val.ival), 0); }
 
     break;
 
-  case 275:
-#line 1479 "perly.y"
-    { (yyval.opval) = newOP((ps[-2].val.ival), 0);}
+  case 275: /* term: FUNC0 PERLY_PAREN_OPEN PERLY_PAREN_CLOSE  */
+#line 1482 "perly.y"
+                        { (yyval.opval) = newOP((ps[-2].val.ival), 0);}
 
     break;
 
-  case 276:
-#line 1481 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+  case 276: /* term: FUNC0OP  */
+#line 1484 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 277:
-#line 1483 "perly.y"
-    { (yyval.opval) = (ps[-2].val.opval); }
+  case 277: /* term: FUNC0OP PERLY_PAREN_OPEN PERLY_PAREN_CLOSE  */
+#line 1486 "perly.y"
+                        { (yyval.opval) = (ps[-2].val.opval); }
 
     break;
 
-  case 278:
-#line 1485 "perly.y"
-    { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED, scalar((ps[0].val.opval))); }
+  case 278: /* term: FUNC0SUB  */
+#line 1488 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_ENTERSUB, OPf_STACKED, scalar((ps[0].val.opval))); }
 
     break;
 
-  case 279:
-#line 1487 "perly.y"
-    { (yyval.opval) = ((ps[-2].val.ival) == OP_NOT)
+  case 279: /* term: FUNC1 PERLY_PAREN_OPEN PERLY_PAREN_CLOSE  */
+#line 1490 "perly.y"
+                        { (yyval.opval) = ((ps[-2].val.ival) == OP_NOT)
                           ? newUNOP((ps[-2].val.ival), 0, newSVOP(OP_CONST, 0, newSViv(0)))
                           : newOP((ps[-2].val.ival), OPf_SPECIAL); }
 
     break;
 
-  case 280:
-#line 1491 "perly.y"
-    { (yyval.opval) = newUNOP((ps[-3].val.ival), 0, (ps[-1].val.opval)); }
+  case 280: /* term: FUNC1 PERLY_PAREN_OPEN expr PERLY_PAREN_CLOSE  */
+#line 1494 "perly.y"
+                        { (yyval.opval) = newUNOP((ps[-3].val.ival), 0, (ps[-1].val.opval)); }
 
     break;
 
-  case 281:
-#line 1493 "perly.y"
-    {
+  case 281: /* @23: %empty  */
+#line 1496 "perly.y"
+                        {
 			    if (   (ps[0].val.opval)->op_type != OP_TRANS
 			        && (ps[0].val.opval)->op_type != OP_TRANSR
 				&& (((PMOP*)(ps[0].val.opval))->op_pmflags & PMf_HAS_CV))
@@ -2096,108 +2099,108 @@ case 2:
 
     break;
 
-  case 282:
-#line 1504 "perly.y"
-    { (yyval.opval) = pmruntime((ps[-5].val.opval), (ps[-2].val.opval), (ps[-1].val.opval), 1, (ps[-4].val.ival)); }
+  case 282: /* term: PMFUNC @23 SUBLEXSTART listexpr optrepl SUBLEXEND  */
+#line 1507 "perly.y"
+                        { (yyval.opval) = pmruntime((ps[-5].val.opval), (ps[-2].val.opval), (ps[-1].val.opval), 1, (ps[-4].val.ival)); }
 
     break;
 
-  case 286:
-#line 1513 "perly.y"
-    { (yyval.opval) = my_attrs((ps[-1].val.opval),(ps[0].val.opval)); }
+  case 286: /* myattrterm: KW_MY myterm myattrlist  */
+#line 1516 "perly.y"
+                        { (yyval.opval) = my_attrs((ps[-1].val.opval),(ps[0].val.opval)); }
 
     break;
 
-  case 287:
-#line 1515 "perly.y"
-    { (yyval.opval) = localize((ps[0].val.opval),1); }
+  case 287: /* myattrterm: KW_MY myterm  */
+#line 1518 "perly.y"
+                        { (yyval.opval) = localize((ps[0].val.opval),1); }
 
     break;
 
-  case 288:
-#line 1517 "perly.y"
-    { (yyval.opval) = newUNOP(OP_REFGEN, 0, my_attrs((ps[-1].val.opval),(ps[0].val.opval))); }
+  case 288: /* myattrterm: KW_MY REFGEN myterm myattrlist  */
+#line 1520 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_REFGEN, 0, my_attrs((ps[-1].val.opval),(ps[0].val.opval))); }
 
     break;
 
-  case 289:
-#line 1519 "perly.y"
-    { (yyval.opval) = newUNOP(OP_REFGEN, 0, localize((ps[0].val.opval),1)); }
+  case 289: /* myattrterm: KW_MY REFGEN term  */
+#line 1522 "perly.y"
+                        { (yyval.opval) = newUNOP(OP_REFGEN, 0, localize((ps[0].val.opval),1)); }
 
     break;
 
-  case 290:
-#line 1524 "perly.y"
-    { (yyval.opval) = sawparens((ps[-1].val.opval)); }
+  case 290: /* myterm: PERLY_PAREN_OPEN expr PERLY_PAREN_CLOSE  */
+#line 1527 "perly.y"
+                        { (yyval.opval) = sawparens((ps[-1].val.opval)); }
 
     break;
 
-  case 291:
-#line 1526 "perly.y"
-    { (yyval.opval) = sawparens(newNULLLIST()); }
-
-    break;
-
-  case 292:
+  case 291: /* myterm: PERLY_PAREN_OPEN PERLY_PAREN_CLOSE  */
 #line 1529 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+                        { (yyval.opval) = sawparens(newNULLLIST()); }
 
     break;
 
-  case 293:
-#line 1531 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+  case 292: /* myterm: scalar  */
+#line 1532 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 294:
-#line 1533 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+  case 293: /* myterm: hsh  */
+#line 1534 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 295:
-#line 1538 "perly.y"
-    {
+  case 294: /* myterm: ary  */
+#line 1536 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
+
+    break;
+
+  case 295: /* fieldvar: scalar  */
+#line 1541 "perly.y"
+                        {
 			  (yyval.pval) = PadnamelistARRAY(PL_comppad_name)[(ps[0].val.opval)->op_targ];
 			  op_free((ps[0].val.opval));
 			}
 
     break;
 
-  case 296:
-#line 1543 "perly.y"
-    {
+  case 296: /* fieldvar: hsh  */
+#line 1546 "perly.y"
+                        {
 			  (yyval.pval) = PadnamelistARRAY(PL_comppad_name)[(ps[0].val.opval)->op_targ];
 			  op_free((ps[0].val.opval));
 			}
 
     break;
 
-  case 297:
-#line 1548 "perly.y"
-    {
+  case 297: /* fieldvar: ary  */
+#line 1551 "perly.y"
+                        {
 			  (yyval.pval) = PadnamelistARRAY(PL_comppad_name)[(ps[0].val.opval)->op_targ];
 			  op_free((ps[0].val.opval));
 			}
 
     break;
 
-  case 298:
-#line 1556 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+  case 298: /* optfieldattrlist: COLONATTR THING  */
+#line 1559 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 299:
-#line 1558 "perly.y"
-    { (yyval.opval) = NULL; }
+  case 299: /* optfieldattrlist: COLONATTR  */
+#line 1561 "perly.y"
+                        { (yyval.opval) = NULL; }
 
     break;
 
-  case 301:
-#line 1564 "perly.y"
-    {
+  case 301: /* fielddecl: KW_FIELD fieldvar optfieldattrlist  */
+#line 1567 "perly.y"
+                        {
 			  parser->in_my = 0;
 			  if((ps[0].val.opval))
 			    class_apply_field_attributes((PADNAME *)(ps[-1].val.pval), (ps[0].val.opval));
@@ -2206,9 +2209,9 @@ case 2:
 
     break;
 
-  case 302:
-#line 1571 "perly.y"
-    {
+  case 302: /* $@24: %empty  */
+#line 1574 "perly.y"
+                        {
 			  parser->in_my = 0;
 			  if((ps[-1].val.opval))
 			    class_apply_field_attributes((PADNAME *)(ps[-2].val.pval), (ps[-1].val.opval));
@@ -2218,9 +2221,9 @@ case 2:
 
     break;
 
-  case 303:
-#line 1579 "perly.y"
-    {
+  case 303: /* fielddecl: KW_FIELD fieldvar optfieldattrlist ASSIGNOP $@24 term  */
+#line 1582 "perly.y"
+                        {
 			  class_set_field_defop((PADNAME *)(ps[-4].val.pval), (ps[-2].val.ival), (ps[0].val.opval));
 			  LEAVE;
 			  (yyval.opval) = newOP(OP_NULL, 0);
@@ -2228,125 +2231,126 @@ case 2:
 
     break;
 
-  case 309:
-#line 1599 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+  case 309: /* optrepl: PERLY_SLASH expr  */
+#line 1602 "perly.y"
+                                        { (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 310:
-#line 1605 "perly.y"
-    { parser->in_my = 0; (yyval.opval) = my((ps[0].val.opval)); }
+  case 310: /* my_scalar: scalar  */
+#line 1608 "perly.y"
+                        { parser->in_my = 0; (yyval.opval) = my((ps[0].val.opval)); }
 
     break;
 
-  case 311:
-#line 1610 "perly.y"
-    { (yyval.opval) = (ps[-1].val.opval); }
+  case 311: /* list_of_scalars: list_of_scalars PERLY_COMMA  */
+#line 1613 "perly.y"
+                        { (yyval.opval) = (ps[-1].val.opval); }
 
     break;
 
-  case 312:
-#line 1612 "perly.y"
-    {
+  case 312: /* list_of_scalars: list_of_scalars PERLY_COMMA scalar  */
+#line 1615 "perly.y"
+                        {
 			  (yyval.opval) = op_append_elem(OP_LIST, (ps[-2].val.opval), (ps[0].val.opval));
 			}
 
     break;
 
-  case 314:
-#line 1619 "perly.y"
-    { parser->in_my = 0; (yyval.opval) = (ps[0].val.opval); }
+  case 314: /* my_list_of_scalars: list_of_scalars  */
+#line 1622 "perly.y"
+                        { parser->in_my = 0; (yyval.opval) = (ps[0].val.opval); }
 
     break;
 
-  case 322:
-#line 1636 "perly.y"
-    { (yyval.opval) = newCVREF((ps[-1].val.ival),(ps[0].val.opval)); }
+  case 322: /* amper: PERLY_AMPERSAND indirob  */
+#line 1639 "perly.y"
+                        { (yyval.opval) = newCVREF((ps[-1].val.ival),(ps[0].val.opval)); }
 
     break;
 
-  case 323:
-#line 1640 "perly.y"
-    { (yyval.opval) = newSVREF((ps[0].val.opval)); }
+  case 323: /* scalar: PERLY_DOLLAR indirob  */
+#line 1643 "perly.y"
+                        { (yyval.opval) = newSVREF((ps[0].val.opval)); }
 
     break;
 
-  case 324:
-#line 1644 "perly.y"
-    { (yyval.opval) = newAVREF((ps[0].val.opval));
+  case 324: /* ary: PERLY_SNAIL indirob  */
+#line 1647 "perly.y"
+                        { (yyval.opval) = newAVREF((ps[0].val.opval));
 			  if ((yyval.opval)) (yyval.opval)->op_private |= (ps[-1].val.ival);
 			}
 
     break;
 
-  case 325:
-#line 1650 "perly.y"
-    { (yyval.opval) = newHVREF((ps[0].val.opval));
+  case 325: /* hsh: PERLY_PERCENT_SIGN indirob  */
+#line 1653 "perly.y"
+                        { (yyval.opval) = newHVREF((ps[0].val.opval));
 			  if ((yyval.opval)) (yyval.opval)->op_private |= (ps[-1].val.ival);
 			}
 
     break;
 
-  case 326:
-#line 1656 "perly.y"
-    { (yyval.opval) = newAVREF((ps[0].val.opval)); }
+  case 326: /* arylen: DOLSHARP indirob  */
+#line 1659 "perly.y"
+                        { (yyval.opval) = newAVREF((ps[0].val.opval)); }
 
     break;
 
-  case 327:
-#line 1658 "perly.y"
-    { (yyval.opval) = newAVREF((ps[-3].val.opval)); }
+  case 327: /* arylen: term ARROW DOLSHARP PERLY_STAR  */
+#line 1661 "perly.y"
+                        { (yyval.opval) = newAVREF((ps[-3].val.opval)); }
 
     break;
 
-  case 328:
-#line 1662 "perly.y"
-    { (yyval.opval) = newGVREF(0,(ps[0].val.opval)); }
+  case 328: /* star: PERLY_STAR indirob  */
+#line 1665 "perly.y"
+                        { (yyval.opval) = newGVREF(0,(ps[0].val.opval)); }
 
     break;
 
-  case 330:
-#line 1667 "perly.y"
-    { (yyval.opval) = newAVREF((ps[-2].val.opval)); }
+  case 330: /* sliceme: term ARROW PERLY_SNAIL  */
+#line 1670 "perly.y"
+                        { (yyval.opval) = newAVREF((ps[-2].val.opval)); }
 
     break;
 
-  case 332:
-#line 1672 "perly.y"
-    { (yyval.opval) = newHVREF((ps[-2].val.opval)); }
+  case 332: /* kvslice: term ARROW PERLY_PERCENT_SIGN  */
+#line 1675 "perly.y"
+                        { (yyval.opval) = newHVREF((ps[-2].val.opval)); }
 
     break;
 
-  case 334:
-#line 1677 "perly.y"
-    { (yyval.opval) = newGVREF(0,(ps[-2].val.opval)); }
+  case 334: /* gelem: term ARROW PERLY_STAR  */
+#line 1680 "perly.y"
+                        { (yyval.opval) = newGVREF(0,(ps[-2].val.opval)); }
 
     break;
 
-  case 335:
-#line 1682 "perly.y"
-    { (yyval.opval) = scalar((ps[0].val.opval)); }
+  case 335: /* indirob: BAREWORD  */
+#line 1685 "perly.y"
+                        { (yyval.opval) = scalar((ps[0].val.opval)); }
 
     break;
 
-  case 336:
-#line 1684 "perly.y"
-    { (yyval.opval) = scalar((ps[0].val.opval)); }
+  case 336: /* indirob: scalar  */
+#line 1687 "perly.y"
+                        { (yyval.opval) = scalar((ps[0].val.opval)); }
 
     break;
 
-  case 337:
-#line 1686 "perly.y"
-    { (yyval.opval) = op_scope((ps[0].val.opval)); }
-
-    break;
-
-  case 338:
+  case 337: /* indirob: block  */
 #line 1689 "perly.y"
-    { (yyval.opval) = (ps[0].val.opval); }
+                        { (yyval.opval) = op_scope((ps[0].val.opval)); }
 
     break;
+
+  case 338: /* indirob: PRIVATEREF  */
+#line 1692 "perly.y"
+                        { (yyval.opval) = (ps[0].val.opval); }
+
+    break;
+
 
 
 
@@ -2354,6 +2358,6 @@ case 2:
     
 
 /* Generated from:
- * d200edcf6b5ba783b2b4e34928c5787fcab506e14d318042f4e46dee90ba0898 perly.y
+ * 823630846fc59cc2a19502726ec723b568eabded55fdc5e9722c600e1098779e perly.y
  * acf1cbfd2545faeaaa58b1cf0cf9d7f98b5be0752eb7a54528ef904a9e2e1ca7 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.h
+++ b/perly.h
@@ -4,14 +4,14 @@
    Any changes made here will be lost!
  */
 
-#define PERL_BISON_VERSION  30003
+#define PERL_BISON_VERSION  30007
 
 #ifdef PERL_CORE
-/* A Bison parser, made by GNU Bison 3.3.  */
+/* A Bison parser, made by GNU Bison 3.7.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2019 Free Software Foundation,
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2020 Free Software Foundation,
    Inc.
 
    This program is free software: you can redistribute it and/or modify
@@ -40,8 +40,9 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
-/* Undocumented macros, especially those whose name start with YY_,
-   are private implementation details.  Do not rely on them.  */
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
 
 /* Debug traces.  */
 #ifndef YYDEBUG
@@ -51,140 +52,145 @@
 extern int yydebug;
 #endif
 
-/* Token type.  */
+/* Token kinds.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
   enum yytokentype
   {
-    GRAMPROG = 258,
-    GRAMEXPR = 259,
-    GRAMBLOCK = 260,
-    GRAMBARESTMT = 261,
-    GRAMFULLSTMT = 262,
-    GRAMSTMTSEQ = 263,
-    GRAMSUBSIGNATURE = 264,
-    PERLY_AMPERSAND = 265,
-    PERLY_BRACE_OPEN = 266,
-    PERLY_BRACE_CLOSE = 267,
-    PERLY_BRACKET_OPEN = 268,
-    PERLY_BRACKET_CLOSE = 269,
-    PERLY_COMMA = 270,
-    PERLY_DOLLAR = 271,
-    PERLY_DOT = 272,
-    PERLY_EQUAL_SIGN = 273,
-    PERLY_MINUS = 274,
-    PERLY_PERCENT_SIGN = 275,
-    PERLY_PLUS = 276,
-    PERLY_SEMICOLON = 277,
-    PERLY_SLASH = 278,
-    PERLY_SNAIL = 279,
-    PERLY_STAR = 280,
-    KW_FORMAT = 281,
-    KW_PACKAGE = 282,
-    KW_CLASS = 283,
-    KW_LOCAL = 284,
-    KW_MY = 285,
-    KW_FIELD = 286,
-    KW_IF = 287,
-    KW_ELSE = 288,
-    KW_ELSIF = 289,
-    KW_UNLESS = 290,
-    KW_FOR = 291,
-    KW_UNTIL = 292,
-    KW_WHILE = 293,
-    KW_CONTINUE = 294,
-    KW_GIVEN = 295,
-    KW_WHEN = 296,
-    KW_DEFAULT = 297,
-    KW_TRY = 298,
-    KW_CATCH = 299,
-    KW_FINALLY = 300,
-    KW_DEFER = 301,
-    KW_REQUIRE = 302,
-    KW_DO = 303,
-    KW_USE_or_NO = 304,
-    KW_SUB_named = 305,
-    KW_SUB_named_sig = 306,
-    KW_SUB_anon = 307,
-    KW_SUB_anon_sig = 308,
-    KW_METHOD_named = 309,
-    KW_METHOD_anon = 310,
-    BAREWORD = 311,
-    METHCALL0 = 312,
-    METHCALL = 313,
-    THING = 314,
-    PMFUNC = 315,
-    PRIVATEREF = 316,
-    QWLIST = 317,
-    FUNC0OP = 318,
-    FUNC0SUB = 319,
-    UNIOPSUB = 320,
-    LSTOPSUB = 321,
-    PLUGEXPR = 322,
-    PLUGSTMT = 323,
-    LABEL = 324,
-    LOOPEX = 325,
-    DOTDOT = 326,
-    YADAYADA = 327,
-    FUNC0 = 328,
-    FUNC1 = 329,
-    FUNC = 330,
-    UNIOP = 331,
-    LSTOP = 332,
-    POWOP = 333,
-    MULOP = 334,
-    ADDOP = 335,
-    DOLSHARP = 336,
-    HASHBRACK = 337,
-    NOAMP = 338,
-    COLONATTR = 339,
-    FORMLBRACK = 340,
-    FORMRBRACK = 341,
-    SUBLEXSTART = 342,
-    SUBLEXEND = 343,
-    PHASER = 344,
-    PREC_LOW = 345,
-    PLUGIN_LOW_OP = 346,
-    OROP = 347,
-    PLUGIN_LOGICAL_OR_LOW_OP = 348,
-    ANDOP = 349,
-    PLUGIN_LOGICAL_AND_LOW_OP = 350,
-    NOTOP = 351,
-    ASSIGNOP = 352,
-    PLUGIN_ASSIGN_OP = 353,
-    PERLY_QUESTION_MARK = 354,
-    PERLY_COLON = 355,
-    OROR = 356,
-    DORDOR = 357,
-    PLUGIN_LOGICAL_OR_OP = 358,
-    ANDAND = 359,
-    PLUGIN_LOGICAL_AND_OP = 360,
-    BITOROP = 361,
-    BITANDOP = 362,
-    CHEQOP = 363,
-    NCEQOP = 364,
-    CHRELOP = 365,
-    NCRELOP = 366,
-    PLUGIN_REL_OP = 367,
-    SHIFTOP = 368,
-    PLUGIN_ADD_OP = 369,
-    PLUGIN_MUL_OP = 370,
-    MATCHOP = 371,
-    PERLY_EXCLAMATION_MARK = 372,
-    PERLY_TILDE = 373,
-    UMINUS = 374,
-    REFGEN = 375,
-    PLUGIN_POW_OP = 376,
-    PREINC = 377,
-    PREDEC = 378,
-    POSTINC = 379,
-    POSTDEC = 380,
-    POSTJOIN = 381,
-    PLUGIN_HIGH_OP = 382,
-    ARROW = 383,
-    PERLY_PAREN_CLOSE = 384,
-    PERLY_PAREN_OPEN = 385
+    YYEMPTY = -2,
+    YYEOF = 0,                     /* "end of file"  */
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+    GRAMPROG = 258,                /* GRAMPROG  */
+    GRAMEXPR = 259,                /* GRAMEXPR  */
+    GRAMBLOCK = 260,               /* GRAMBLOCK  */
+    GRAMBARESTMT = 261,            /* GRAMBARESTMT  */
+    GRAMFULLSTMT = 262,            /* GRAMFULLSTMT  */
+    GRAMSTMTSEQ = 263,             /* GRAMSTMTSEQ  */
+    GRAMSUBSIGNATURE = 264,        /* GRAMSUBSIGNATURE  */
+    PERLY_AMPERSAND = 265,         /* PERLY_AMPERSAND  */
+    PERLY_BRACE_OPEN = 266,        /* PERLY_BRACE_OPEN  */
+    PERLY_BRACE_CLOSE = 267,       /* PERLY_BRACE_CLOSE  */
+    PERLY_BRACKET_OPEN = 268,      /* PERLY_BRACKET_OPEN  */
+    PERLY_BRACKET_CLOSE = 269,     /* PERLY_BRACKET_CLOSE  */
+    PERLY_COMMA = 270,             /* PERLY_COMMA  */
+    PERLY_DOLLAR = 271,            /* PERLY_DOLLAR  */
+    PERLY_DOT = 272,               /* PERLY_DOT  */
+    PERLY_EQUAL_SIGN = 273,        /* PERLY_EQUAL_SIGN  */
+    PERLY_MINUS = 274,             /* PERLY_MINUS  */
+    PERLY_PERCENT_SIGN = 275,      /* PERLY_PERCENT_SIGN  */
+    PERLY_PLUS = 276,              /* PERLY_PLUS  */
+    PERLY_SEMICOLON = 277,         /* PERLY_SEMICOLON  */
+    PERLY_SLASH = 278,             /* PERLY_SLASH  */
+    PERLY_SNAIL = 279,             /* PERLY_SNAIL  */
+    PERLY_STAR = 280,              /* PERLY_STAR  */
+    KW_FORMAT = 281,               /* KW_FORMAT  */
+    KW_PACKAGE = 282,              /* KW_PACKAGE  */
+    KW_CLASS = 283,                /* KW_CLASS  */
+    KW_LOCAL = 284,                /* KW_LOCAL  */
+    KW_MY = 285,                   /* KW_MY  */
+    KW_FIELD = 286,                /* KW_FIELD  */
+    KW_IF = 287,                   /* KW_IF  */
+    KW_ELSE = 288,                 /* KW_ELSE  */
+    KW_ELSIF = 289,                /* KW_ELSIF  */
+    KW_UNLESS = 290,               /* KW_UNLESS  */
+    KW_FOR = 291,                  /* KW_FOR  */
+    KW_UNTIL = 292,                /* KW_UNTIL  */
+    KW_WHILE = 293,                /* KW_WHILE  */
+    KW_CONTINUE = 294,             /* KW_CONTINUE  */
+    KW_GIVEN = 295,                /* KW_GIVEN  */
+    KW_WHEN = 296,                 /* KW_WHEN  */
+    KW_DEFAULT = 297,              /* KW_DEFAULT  */
+    KW_TRY = 298,                  /* KW_TRY  */
+    KW_CATCH = 299,                /* KW_CATCH  */
+    KW_FINALLY = 300,              /* KW_FINALLY  */
+    KW_DEFER = 301,                /* KW_DEFER  */
+    KW_REQUIRE = 302,              /* KW_REQUIRE  */
+    KW_DO = 303,                   /* KW_DO  */
+    KW_USE_or_NO = 304,            /* KW_USE_or_NO  */
+    KW_SUB_named = 305,            /* KW_SUB_named  */
+    KW_SUB_named_sig = 306,        /* KW_SUB_named_sig  */
+    KW_SUB_anon = 307,             /* KW_SUB_anon  */
+    KW_SUB_anon_sig = 308,         /* KW_SUB_anon_sig  */
+    KW_METHOD_named = 309,         /* KW_METHOD_named  */
+    KW_METHOD_anon = 310,          /* KW_METHOD_anon  */
+    BAREWORD = 311,                /* BAREWORD  */
+    METHCALL0 = 312,               /* METHCALL0  */
+    METHCALL = 313,                /* METHCALL  */
+    THING = 314,                   /* THING  */
+    PMFUNC = 315,                  /* PMFUNC  */
+    PRIVATEREF = 316,              /* PRIVATEREF  */
+    QWLIST = 317,                  /* QWLIST  */
+    FUNC0OP = 318,                 /* FUNC0OP  */
+    FUNC0SUB = 319,                /* FUNC0SUB  */
+    UNIOPSUB = 320,                /* UNIOPSUB  */
+    LSTOPSUB = 321,                /* LSTOPSUB  */
+    PLUGEXPR = 322,                /* PLUGEXPR  */
+    PLUGSTMT = 323,                /* PLUGSTMT  */
+    LABEL = 324,                   /* LABEL  */
+    LOOPEX = 325,                  /* LOOPEX  */
+    DOTDOT = 326,                  /* DOTDOT  */
+    YADAYADA = 327,                /* YADAYADA  */
+    FUNC0 = 328,                   /* FUNC0  */
+    FUNC1 = 329,                   /* FUNC1  */
+    FUNC = 330,                    /* FUNC  */
+    UNIOP = 331,                   /* UNIOP  */
+    LSTOP = 332,                   /* LSTOP  */
+    POWOP = 333,                   /* POWOP  */
+    MULOP = 334,                   /* MULOP  */
+    ADDOP = 335,                   /* ADDOP  */
+    DOLSHARP = 336,                /* DOLSHARP  */
+    HASHBRACK = 337,               /* HASHBRACK  */
+    NOAMP = 338,                   /* NOAMP  */
+    COLONATTR = 339,               /* COLONATTR  */
+    FORMLBRACK = 340,              /* FORMLBRACK  */
+    FORMRBRACK = 341,              /* FORMRBRACK  */
+    SUBLEXSTART = 342,             /* SUBLEXSTART  */
+    SUBLEXEND = 343,               /* SUBLEXEND  */
+    PHASER = 344,                  /* PHASER  */
+    PREC_LOW = 345,                /* PREC_LOW  */
+    PLUGIN_LOW_OP = 346,           /* PLUGIN_LOW_OP  */
+    OROP = 347,                    /* OROP  */
+    PLUGIN_LOGICAL_OR_LOW_OP = 348, /* PLUGIN_LOGICAL_OR_LOW_OP  */
+    ANDOP = 349,                   /* ANDOP  */
+    PLUGIN_LOGICAL_AND_LOW_OP = 350, /* PLUGIN_LOGICAL_AND_LOW_OP  */
+    NOTOP = 351,                   /* NOTOP  */
+    ASSIGNOP = 352,                /* ASSIGNOP  */
+    PLUGIN_ASSIGN_OP = 353,        /* PLUGIN_ASSIGN_OP  */
+    PERLY_QUESTION_MARK = 354,     /* PERLY_QUESTION_MARK  */
+    PERLY_COLON = 355,             /* PERLY_COLON  */
+    OROR = 356,                    /* OROR  */
+    DORDOR = 357,                  /* DORDOR  */
+    PLUGIN_LOGICAL_OR_OP = 358,    /* PLUGIN_LOGICAL_OR_OP  */
+    ANDAND = 359,                  /* ANDAND  */
+    PLUGIN_LOGICAL_AND_OP = 360,   /* PLUGIN_LOGICAL_AND_OP  */
+    BITOROP = 361,                 /* BITOROP  */
+    BITANDOP = 362,                /* BITANDOP  */
+    CHEQOP = 363,                  /* CHEQOP  */
+    NCEQOP = 364,                  /* NCEQOP  */
+    CHRELOP = 365,                 /* CHRELOP  */
+    NCRELOP = 366,                 /* NCRELOP  */
+    PLUGIN_REL_OP = 367,           /* PLUGIN_REL_OP  */
+    SHIFTOP = 368,                 /* SHIFTOP  */
+    PLUGIN_ADD_OP = 369,           /* PLUGIN_ADD_OP  */
+    PLUGIN_MUL_OP = 370,           /* PLUGIN_MUL_OP  */
+    MATCHOP = 371,                 /* MATCHOP  */
+    PERLY_EXCLAMATION_MARK = 372,  /* PERLY_EXCLAMATION_MARK  */
+    PERLY_TILDE = 373,             /* PERLY_TILDE  */
+    UMINUS = 374,                  /* UMINUS  */
+    REFGEN = 375,                  /* REFGEN  */
+    PLUGIN_POW_OP = 376,           /* PLUGIN_POW_OP  */
+    PREINC = 377,                  /* PREINC  */
+    PREDEC = 378,                  /* PREDEC  */
+    POSTINC = 379,                 /* POSTINC  */
+    POSTDEC = 380,                 /* POSTDEC  */
+    POSTJOIN = 381,                /* POSTJOIN  */
+    PLUGIN_HIGH_OP = 382,          /* PLUGIN_HIGH_OP  */
+    ARROW = 383,                   /* ARROW  */
+    PERLY_PAREN_CLOSE = 384,       /* PERLY_PAREN_CLOSE  */
+    PERLY_PAREN_OPEN = 385         /* PERLY_PAREN_OPEN  */
   };
+  typedef enum yytokentype yytoken_kind_t;
 #endif
 
 /* Value type.  */
@@ -213,7 +219,6 @@ S_is_opval_token(int type) {
 #endif /* PERL_IN_TOKE_C */
 #endif /* PERL_CORE */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-
 union YYSTYPE
 {
 
@@ -223,8 +228,8 @@ union YYSTYPE
     OP *opval;
     GV *gvval;
 
-};
 
+};
 typedef union YYSTYPE YYSTYPE;
 # define YYSTYPE_IS_TRIVIAL 1
 # define YYSTYPE_IS_DECLARED 1
@@ -236,6 +241,6 @@ int yyparse (void);
 
 
 /* Generated from:
- * d200edcf6b5ba783b2b4e34928c5787fcab506e14d318042f4e46dee90ba0898 perly.y
+ * 823630846fc59cc2a19502726ec723b568eabded55fdc5e9722c600e1098779e perly.y
  * acf1cbfd2545faeaaa58b1cf0cf9d7f98b5be0752eb7a54528ef904a9e2e1ca7 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.tab
+++ b/perly.tab
@@ -4,6 +4,261 @@
    Any changes made here will be lost!
  */
 
+/* Symbol kind.  */
+enum yysymbol_kind_t
+{
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_GRAMPROG = 3,                   /* GRAMPROG  */
+  YYSYMBOL_GRAMEXPR = 4,                   /* GRAMEXPR  */
+  YYSYMBOL_GRAMBLOCK = 5,                  /* GRAMBLOCK  */
+  YYSYMBOL_GRAMBARESTMT = 6,               /* GRAMBARESTMT  */
+  YYSYMBOL_GRAMFULLSTMT = 7,               /* GRAMFULLSTMT  */
+  YYSYMBOL_GRAMSTMTSEQ = 8,                /* GRAMSTMTSEQ  */
+  YYSYMBOL_GRAMSUBSIGNATURE = 9,           /* GRAMSUBSIGNATURE  */
+  YYSYMBOL_PERLY_AMPERSAND = 10,           /* PERLY_AMPERSAND  */
+  YYSYMBOL_PERLY_BRACE_OPEN = 11,          /* PERLY_BRACE_OPEN  */
+  YYSYMBOL_PERLY_BRACE_CLOSE = 12,         /* PERLY_BRACE_CLOSE  */
+  YYSYMBOL_PERLY_BRACKET_OPEN = 13,        /* PERLY_BRACKET_OPEN  */
+  YYSYMBOL_PERLY_BRACKET_CLOSE = 14,       /* PERLY_BRACKET_CLOSE  */
+  YYSYMBOL_PERLY_COMMA = 15,               /* PERLY_COMMA  */
+  YYSYMBOL_PERLY_DOLLAR = 16,              /* PERLY_DOLLAR  */
+  YYSYMBOL_PERLY_DOT = 17,                 /* PERLY_DOT  */
+  YYSYMBOL_PERLY_EQUAL_SIGN = 18,          /* PERLY_EQUAL_SIGN  */
+  YYSYMBOL_PERLY_MINUS = 19,               /* PERLY_MINUS  */
+  YYSYMBOL_PERLY_PERCENT_SIGN = 20,        /* PERLY_PERCENT_SIGN  */
+  YYSYMBOL_PERLY_PLUS = 21,                /* PERLY_PLUS  */
+  YYSYMBOL_PERLY_SEMICOLON = 22,           /* PERLY_SEMICOLON  */
+  YYSYMBOL_PERLY_SLASH = 23,               /* PERLY_SLASH  */
+  YYSYMBOL_PERLY_SNAIL = 24,               /* PERLY_SNAIL  */
+  YYSYMBOL_PERLY_STAR = 25,                /* PERLY_STAR  */
+  YYSYMBOL_KW_FORMAT = 26,                 /* KW_FORMAT  */
+  YYSYMBOL_KW_PACKAGE = 27,                /* KW_PACKAGE  */
+  YYSYMBOL_KW_CLASS = 28,                  /* KW_CLASS  */
+  YYSYMBOL_KW_LOCAL = 29,                  /* KW_LOCAL  */
+  YYSYMBOL_KW_MY = 30,                     /* KW_MY  */
+  YYSYMBOL_KW_FIELD = 31,                  /* KW_FIELD  */
+  YYSYMBOL_KW_IF = 32,                     /* KW_IF  */
+  YYSYMBOL_KW_ELSE = 33,                   /* KW_ELSE  */
+  YYSYMBOL_KW_ELSIF = 34,                  /* KW_ELSIF  */
+  YYSYMBOL_KW_UNLESS = 35,                 /* KW_UNLESS  */
+  YYSYMBOL_KW_FOR = 36,                    /* KW_FOR  */
+  YYSYMBOL_KW_UNTIL = 37,                  /* KW_UNTIL  */
+  YYSYMBOL_KW_WHILE = 38,                  /* KW_WHILE  */
+  YYSYMBOL_KW_CONTINUE = 39,               /* KW_CONTINUE  */
+  YYSYMBOL_KW_GIVEN = 40,                  /* KW_GIVEN  */
+  YYSYMBOL_KW_WHEN = 41,                   /* KW_WHEN  */
+  YYSYMBOL_KW_DEFAULT = 42,                /* KW_DEFAULT  */
+  YYSYMBOL_KW_TRY = 43,                    /* KW_TRY  */
+  YYSYMBOL_KW_CATCH = 44,                  /* KW_CATCH  */
+  YYSYMBOL_KW_FINALLY = 45,                /* KW_FINALLY  */
+  YYSYMBOL_KW_DEFER = 46,                  /* KW_DEFER  */
+  YYSYMBOL_KW_REQUIRE = 47,                /* KW_REQUIRE  */
+  YYSYMBOL_KW_DO = 48,                     /* KW_DO  */
+  YYSYMBOL_KW_USE_or_NO = 49,              /* KW_USE_or_NO  */
+  YYSYMBOL_KW_SUB_named = 50,              /* KW_SUB_named  */
+  YYSYMBOL_KW_SUB_named_sig = 51,          /* KW_SUB_named_sig  */
+  YYSYMBOL_KW_SUB_anon = 52,               /* KW_SUB_anon  */
+  YYSYMBOL_KW_SUB_anon_sig = 53,           /* KW_SUB_anon_sig  */
+  YYSYMBOL_KW_METHOD_named = 54,           /* KW_METHOD_named  */
+  YYSYMBOL_KW_METHOD_anon = 55,            /* KW_METHOD_anon  */
+  YYSYMBOL_BAREWORD = 56,                  /* BAREWORD  */
+  YYSYMBOL_METHCALL0 = 57,                 /* METHCALL0  */
+  YYSYMBOL_METHCALL = 58,                  /* METHCALL  */
+  YYSYMBOL_THING = 59,                     /* THING  */
+  YYSYMBOL_PMFUNC = 60,                    /* PMFUNC  */
+  YYSYMBOL_PRIVATEREF = 61,                /* PRIVATEREF  */
+  YYSYMBOL_QWLIST = 62,                    /* QWLIST  */
+  YYSYMBOL_FUNC0OP = 63,                   /* FUNC0OP  */
+  YYSYMBOL_FUNC0SUB = 64,                  /* FUNC0SUB  */
+  YYSYMBOL_UNIOPSUB = 65,                  /* UNIOPSUB  */
+  YYSYMBOL_LSTOPSUB = 66,                  /* LSTOPSUB  */
+  YYSYMBOL_PLUGEXPR = 67,                  /* PLUGEXPR  */
+  YYSYMBOL_PLUGSTMT = 68,                  /* PLUGSTMT  */
+  YYSYMBOL_LABEL = 69,                     /* LABEL  */
+  YYSYMBOL_LOOPEX = 70,                    /* LOOPEX  */
+  YYSYMBOL_DOTDOT = 71,                    /* DOTDOT  */
+  YYSYMBOL_YADAYADA = 72,                  /* YADAYADA  */
+  YYSYMBOL_FUNC0 = 73,                     /* FUNC0  */
+  YYSYMBOL_FUNC1 = 74,                     /* FUNC1  */
+  YYSYMBOL_FUNC = 75,                      /* FUNC  */
+  YYSYMBOL_UNIOP = 76,                     /* UNIOP  */
+  YYSYMBOL_LSTOP = 77,                     /* LSTOP  */
+  YYSYMBOL_POWOP = 78,                     /* POWOP  */
+  YYSYMBOL_MULOP = 79,                     /* MULOP  */
+  YYSYMBOL_ADDOP = 80,                     /* ADDOP  */
+  YYSYMBOL_DOLSHARP = 81,                  /* DOLSHARP  */
+  YYSYMBOL_HASHBRACK = 82,                 /* HASHBRACK  */
+  YYSYMBOL_NOAMP = 83,                     /* NOAMP  */
+  YYSYMBOL_COLONATTR = 84,                 /* COLONATTR  */
+  YYSYMBOL_FORMLBRACK = 85,                /* FORMLBRACK  */
+  YYSYMBOL_FORMRBRACK = 86,                /* FORMRBRACK  */
+  YYSYMBOL_SUBLEXSTART = 87,               /* SUBLEXSTART  */
+  YYSYMBOL_SUBLEXEND = 88,                 /* SUBLEXEND  */
+  YYSYMBOL_PHASER = 89,                    /* PHASER  */
+  YYSYMBOL_PREC_LOW = 90,                  /* PREC_LOW  */
+  YYSYMBOL_PLUGIN_LOW_OP = 91,             /* PLUGIN_LOW_OP  */
+  YYSYMBOL_OROP = 92,                      /* OROP  */
+  YYSYMBOL_PLUGIN_LOGICAL_OR_LOW_OP = 93,  /* PLUGIN_LOGICAL_OR_LOW_OP  */
+  YYSYMBOL_ANDOP = 94,                     /* ANDOP  */
+  YYSYMBOL_PLUGIN_LOGICAL_AND_LOW_OP = 95, /* PLUGIN_LOGICAL_AND_LOW_OP  */
+  YYSYMBOL_NOTOP = 96,                     /* NOTOP  */
+  YYSYMBOL_ASSIGNOP = 97,                  /* ASSIGNOP  */
+  YYSYMBOL_PLUGIN_ASSIGN_OP = 98,          /* PLUGIN_ASSIGN_OP  */
+  YYSYMBOL_PERLY_QUESTION_MARK = 99,       /* PERLY_QUESTION_MARK  */
+  YYSYMBOL_PERLY_COLON = 100,              /* PERLY_COLON  */
+  YYSYMBOL_OROR = 101,                     /* OROR  */
+  YYSYMBOL_DORDOR = 102,                   /* DORDOR  */
+  YYSYMBOL_PLUGIN_LOGICAL_OR_OP = 103,     /* PLUGIN_LOGICAL_OR_OP  */
+  YYSYMBOL_ANDAND = 104,                   /* ANDAND  */
+  YYSYMBOL_PLUGIN_LOGICAL_AND_OP = 105,    /* PLUGIN_LOGICAL_AND_OP  */
+  YYSYMBOL_BITOROP = 106,                  /* BITOROP  */
+  YYSYMBOL_BITANDOP = 107,                 /* BITANDOP  */
+  YYSYMBOL_CHEQOP = 108,                   /* CHEQOP  */
+  YYSYMBOL_NCEQOP = 109,                   /* NCEQOP  */
+  YYSYMBOL_CHRELOP = 110,                  /* CHRELOP  */
+  YYSYMBOL_NCRELOP = 111,                  /* NCRELOP  */
+  YYSYMBOL_PLUGIN_REL_OP = 112,            /* PLUGIN_REL_OP  */
+  YYSYMBOL_SHIFTOP = 113,                  /* SHIFTOP  */
+  YYSYMBOL_PLUGIN_ADD_OP = 114,            /* PLUGIN_ADD_OP  */
+  YYSYMBOL_PLUGIN_MUL_OP = 115,            /* PLUGIN_MUL_OP  */
+  YYSYMBOL_MATCHOP = 116,                  /* MATCHOP  */
+  YYSYMBOL_PERLY_EXCLAMATION_MARK = 117,   /* PERLY_EXCLAMATION_MARK  */
+  YYSYMBOL_PERLY_TILDE = 118,              /* PERLY_TILDE  */
+  YYSYMBOL_UMINUS = 119,                   /* UMINUS  */
+  YYSYMBOL_REFGEN = 120,                   /* REFGEN  */
+  YYSYMBOL_PLUGIN_POW_OP = 121,            /* PLUGIN_POW_OP  */
+  YYSYMBOL_PREINC = 122,                   /* PREINC  */
+  YYSYMBOL_PREDEC = 123,                   /* PREDEC  */
+  YYSYMBOL_POSTINC = 124,                  /* POSTINC  */
+  YYSYMBOL_POSTDEC = 125,                  /* POSTDEC  */
+  YYSYMBOL_POSTJOIN = 126,                 /* POSTJOIN  */
+  YYSYMBOL_PLUGIN_HIGH_OP = 127,           /* PLUGIN_HIGH_OP  */
+  YYSYMBOL_ARROW = 128,                    /* ARROW  */
+  YYSYMBOL_PERLY_PAREN_CLOSE = 129,        /* PERLY_PAREN_CLOSE  */
+  YYSYMBOL_PERLY_PAREN_OPEN = 130,         /* PERLY_PAREN_OPEN  */
+  YYSYMBOL_YYACCEPT = 131,                 /* $accept  */
+  YYSYMBOL_grammar = 132,                  /* grammar  */
+  YYSYMBOL_133_1 = 133,                    /* @1  */
+  YYSYMBOL_134_2 = 134,                    /* @2  */
+  YYSYMBOL_135_3 = 135,                    /* @3  */
+  YYSYMBOL_136_4 = 136,                    /* @4  */
+  YYSYMBOL_137_5 = 137,                    /* @5  */
+  YYSYMBOL_138_6 = 138,                    /* @6  */
+  YYSYMBOL_139_7 = 139,                    /* @7  */
+  YYSYMBOL_sigsub_or_method_named = 140,   /* sigsub_or_method_named  */
+  YYSYMBOL_block = 141,                    /* block  */
+  YYSYMBOL_empty = 142,                    /* empty  */
+  YYSYMBOL_formblock = 143,                /* formblock  */
+  YYSYMBOL_remember = 144,                 /* remember  */
+  YYSYMBOL_mblock = 145,                   /* mblock  */
+  YYSYMBOL_mremember = 146,                /* mremember  */
+  YYSYMBOL_catch_paren = 147,              /* catch_paren  */
+  YYSYMBOL_148_8 = 148,                    /* $@8  */
+  YYSYMBOL_149_9 = 149,                    /* $@9  */
+  YYSYMBOL_stmtseq = 150,                  /* stmtseq  */
+  YYSYMBOL_formstmtseq = 151,              /* formstmtseq  */
+  YYSYMBOL_fullstmt = 152,                 /* fullstmt  */
+  YYSYMBOL_labfullstmt = 153,              /* labfullstmt  */
+  YYSYMBOL_barestmt = 154,                 /* barestmt  */
+  YYSYMBOL_155_10 = 155,                   /* $@10  */
+  YYSYMBOL_156_11 = 156,                   /* $@11  */
+  YYSYMBOL_157_12 = 157,                   /* $@12  */
+  YYSYMBOL_158_13 = 158,                   /* $@13  */
+  YYSYMBOL_159_14 = 159,                   /* $@14  */
+  YYSYMBOL_160_15 = 160,                   /* $@15  */
+  YYSYMBOL_161_16 = 161,                   /* @16  */
+  YYSYMBOL_162_17 = 162,                   /* $@17  */
+  YYSYMBOL_163_18 = 163,                   /* $@18  */
+  YYSYMBOL_164_19 = 164,                   /* $@19  */
+  YYSYMBOL_formline = 165,                 /* formline  */
+  YYSYMBOL_formarg = 166,                  /* formarg  */
+  YYSYMBOL_condition = 167,                /* condition  */
+  YYSYMBOL_sideff = 168,                   /* sideff  */
+  YYSYMBOL_else = 169,                     /* else  */
+  YYSYMBOL_cont = 170,                     /* cont  */
+  YYSYMBOL_finally = 171,                  /* finally  */
+  YYSYMBOL_mintro = 172,                   /* mintro  */
+  YYSYMBOL_nexpr = 173,                    /* nexpr  */
+  YYSYMBOL_texpr = 174,                    /* texpr  */
+  YYSYMBOL_iexpr = 175,                    /* iexpr  */
+  YYSYMBOL_mexpr = 176,                    /* mexpr  */
+  YYSYMBOL_mnexpr = 177,                   /* mnexpr  */
+  YYSYMBOL_formname = 178,                 /* formname  */
+  YYSYMBOL_startsub = 179,                 /* startsub  */
+  YYSYMBOL_startanonsub = 180,             /* startanonsub  */
+  YYSYMBOL_startanonmethod = 181,          /* startanonmethod  */
+  YYSYMBOL_startformsub = 182,             /* startformsub  */
+  YYSYMBOL_subname = 183,                  /* subname  */
+  YYSYMBOL_proto = 184,                    /* proto  */
+  YYSYMBOL_subattrlist = 185,              /* subattrlist  */
+  YYSYMBOL_myattrlist = 186,               /* myattrlist  */
+  YYSYMBOL_sigvarname = 187,               /* sigvarname  */
+  YYSYMBOL_sigslurpsigil = 188,            /* sigslurpsigil  */
+  YYSYMBOL_sigslurpelem = 189,             /* sigslurpelem  */
+  YYSYMBOL_sigdefault = 190,               /* sigdefault  */
+  YYSYMBOL_sigscalarelem = 191,            /* sigscalarelem  */
+  YYSYMBOL_sigelem = 192,                  /* sigelem  */
+  YYSYMBOL_siglist = 193,                  /* siglist  */
+  YYSYMBOL_optsiglist = 194,               /* optsiglist  */
+  YYSYMBOL_optsubsignature = 195,          /* optsubsignature  */
+  YYSYMBOL_subsignature = 196,             /* subsignature  */
+  YYSYMBOL_subsigguts = 197,               /* subsigguts  */
+  YYSYMBOL_198_20 = 198,                   /* $@20  */
+  YYSYMBOL_optsubbody = 199,               /* optsubbody  */
+  YYSYMBOL_subbody = 200,                  /* subbody  */
+  YYSYMBOL_optsigsubbody = 201,            /* optsigsubbody  */
+  YYSYMBOL_sigsubbody = 202,               /* sigsubbody  */
+  YYSYMBOL_203_21 = 203,                   /* $@21  */
+  YYSYMBOL_expr = 204,                     /* expr  */
+  YYSYMBOL_listexpr = 205,                 /* listexpr  */
+  YYSYMBOL_listop = 206,                   /* listop  */
+  YYSYMBOL_207_22 = 207,                   /* @22  */
+  YYSYMBOL_methodname = 208,               /* methodname  */
+  YYSYMBOL_subscripted = 209,              /* subscripted  */
+  YYSYMBOL_termbinop = 210,                /* termbinop  */
+  YYSYMBOL_termrelop = 211,                /* termrelop  */
+  YYSYMBOL_relopchain = 212,               /* relopchain  */
+  YYSYMBOL_termeqop = 213,                 /* termeqop  */
+  YYSYMBOL_eqopchain = 214,                /* eqopchain  */
+  YYSYMBOL_termunop = 215,                 /* termunop  */
+  YYSYMBOL_anonymous = 216,                /* anonymous  */
+  YYSYMBOL_termdo = 217,                   /* termdo  */
+  YYSYMBOL_term = 218,                     /* term  */
+  YYSYMBOL_219_23 = 219,                   /* @23  */
+  YYSYMBOL_myattrterm = 220,               /* myattrterm  */
+  YYSYMBOL_myterm = 221,                   /* myterm  */
+  YYSYMBOL_fieldvar = 222,                 /* fieldvar  */
+  YYSYMBOL_optfieldattrlist = 223,         /* optfieldattrlist  */
+  YYSYMBOL_fielddecl = 224,                /* fielddecl  */
+  YYSYMBOL_225_24 = 225,                   /* $@24  */
+  YYSYMBOL_optlistexpr = 226,              /* optlistexpr  */
+  YYSYMBOL_optexpr = 227,                  /* optexpr  */
+  YYSYMBOL_optrepl = 228,                  /* optrepl  */
+  YYSYMBOL_my_scalar = 229,                /* my_scalar  */
+  YYSYMBOL_list_of_scalars = 230,          /* list_of_scalars  */
+  YYSYMBOL_my_list_of_scalars = 231,       /* my_list_of_scalars  */
+  YYSYMBOL_my_var = 232,                   /* my_var  */
+  YYSYMBOL_refgen_topic = 233,             /* refgen_topic  */
+  YYSYMBOL_my_refgen = 234,                /* my_refgen  */
+  YYSYMBOL_amper = 235,                    /* amper  */
+  YYSYMBOL_scalar = 236,                   /* scalar  */
+  YYSYMBOL_ary = 237,                      /* ary  */
+  YYSYMBOL_hsh = 238,                      /* hsh  */
+  YYSYMBOL_arylen = 239,                   /* arylen  */
+  YYSYMBOL_star = 240,                     /* star  */
+  YYSYMBOL_sliceme = 241,                  /* sliceme  */
+  YYSYMBOL_kvslice = 242,                  /* kvslice  */
+  YYSYMBOL_gelem = 243,                    /* gelem  */
+  YYSYMBOL_indirob = 244                   /* indirob  */
+};
+typedef enum yysymbol_kind_t yysymbol_kind_t;
+
+
+
+
 #define YYFINAL  16
 /* YYLAST -- Last index in YYTABLE.  */
 #define YYLAST   3705
@@ -17,13 +272,16 @@
 /* YYNSTATES -- Number of states.  */
 #define YYNSTATES  670
 
-#define YYUNDEFTOK  2
+/* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   385
+
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, with out-of-bounds checking.  */
-#define YYTRANSLATE(YYX)                                                \
-  ((unsigned) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex.  */
@@ -72,7 +330,7 @@ static const yytype_uint8 yytranslate[] =
 
 #if YYDEBUG
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
-static const yytype_uint16 yyrline[] =
+static const yytype_int16 yyrline[] =
 {
        0,   161,   161,   160,   172,   171,   182,   181,   195,   194,
      208,   207,   221,   220,   231,   230,   244,   246,   251,   259,
@@ -90,43 +348,50 @@ static const yytype_uint16 yyrline[] =
      942,   944,   948,   954,   955,   960,   961,   965,   969,   969,
     1036,  1037,  1042,  1054,  1055,  1060,  1059,  1072,  1074,  1076,
     1078,  1080,  1084,  1086,  1091,  1095,  1099,  1103,  1109,  1114,
-    1120,  1126,  1128,  1130,  1133,  1132,  1143,  1144,  1148,  1152,
-    1155,  1160,  1165,  1168,  1172,  1176,  1182,  1190,  1197,  1203,
-    1205,  1207,  1212,  1214,  1216,  1218,  1220,  1222,  1227,  1229,
-    1231,  1233,  1235,  1237,  1239,  1241,  1243,  1245,  1247,  1249,
-    1251,  1253,  1255,  1257,  1261,  1263,  1265,  1267,  1269,  1273,
-    1275,  1279,  1281,  1283,  1285,  1289,  1291,  1296,  1298,  1301,
-    1303,  1305,  1308,  1311,  1322,  1325,  1333,  1335,  1337,  1340,
-    1343,  1351,  1353,  1357,  1358,  1359,  1360,  1361,  1363,  1365,
-    1367,  1369,  1371,  1373,  1375,  1377,  1379,  1381,  1383,  1385,
-    1387,  1397,  1407,  1417,  1427,  1429,  1431,  1434,  1439,  1443,
-    1445,  1447,  1449,  1452,  1454,  1457,  1459,  1461,  1463,  1465,
-    1467,  1469,  1471,  1473,  1476,  1478,  1480,  1482,  1484,  1486,
-    1490,  1493,  1492,  1505,  1506,  1507,  1512,  1514,  1516,  1518,
-    1523,  1525,  1528,  1530,  1532,  1537,  1542,  1547,  1555,  1557,
-    1559,  1563,  1571,  1570,  1588,  1589,  1593,  1594,  1598,  1599,
-    1604,  1609,  1611,  1615,  1618,  1622,  1623,  1624,  1627,  1628,
-    1631,  1632,  1635,  1639,  1643,  1649,  1655,  1657,  1661,  1665,
-    1666,  1670,  1671,  1675,  1676,  1681,  1683,  1685,  1688
+    1120,  1126,  1128,  1130,  1133,  1132,  1146,  1147,  1151,  1155,
+    1158,  1163,  1168,  1171,  1175,  1179,  1185,  1193,  1200,  1206,
+    1208,  1210,  1215,  1217,  1219,  1221,  1223,  1225,  1230,  1232,
+    1234,  1236,  1238,  1240,  1242,  1244,  1246,  1248,  1250,  1252,
+    1254,  1256,  1258,  1260,  1264,  1266,  1268,  1270,  1272,  1276,
+    1278,  1282,  1284,  1286,  1288,  1292,  1294,  1299,  1301,  1304,
+    1306,  1308,  1311,  1314,  1325,  1328,  1336,  1338,  1340,  1343,
+    1346,  1354,  1356,  1360,  1361,  1362,  1363,  1364,  1366,  1368,
+    1370,  1372,  1374,  1376,  1378,  1380,  1382,  1384,  1386,  1388,
+    1390,  1400,  1410,  1420,  1430,  1432,  1434,  1437,  1442,  1446,
+    1448,  1450,  1452,  1455,  1457,  1460,  1462,  1464,  1466,  1468,
+    1470,  1472,  1474,  1476,  1479,  1481,  1483,  1485,  1487,  1489,
+    1493,  1496,  1495,  1508,  1509,  1510,  1515,  1517,  1519,  1521,
+    1526,  1528,  1531,  1533,  1535,  1540,  1545,  1550,  1558,  1560,
+    1562,  1566,  1574,  1573,  1591,  1592,  1596,  1597,  1601,  1602,
+    1607,  1612,  1614,  1618,  1621,  1625,  1626,  1627,  1630,  1631,
+    1634,  1635,  1638,  1642,  1646,  1652,  1658,  1660,  1664,  1668,
+    1669,  1673,  1674,  1678,  1679,  1684,  1686,  1688,  1691
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || 0
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if YYDEBUG || 0
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "GRAMPROG", "GRAMEXPR", "GRAMBLOCK",
-  "GRAMBARESTMT", "GRAMFULLSTMT", "GRAMSTMTSEQ", "GRAMSUBSIGNATURE",
-  "PERLY_AMPERSAND", "PERLY_BRACE_OPEN", "PERLY_BRACE_CLOSE",
-  "PERLY_BRACKET_OPEN", "PERLY_BRACKET_CLOSE", "PERLY_COMMA",
-  "PERLY_DOLLAR", "PERLY_DOT", "PERLY_EQUAL_SIGN", "PERLY_MINUS",
-  "PERLY_PERCENT_SIGN", "PERLY_PLUS", "PERLY_SEMICOLON", "PERLY_SLASH",
-  "PERLY_SNAIL", "PERLY_STAR", "KW_FORMAT", "KW_PACKAGE", "KW_CLASS",
-  "KW_LOCAL", "KW_MY", "KW_FIELD", "KW_IF", "KW_ELSE", "KW_ELSIF",
-  "KW_UNLESS", "KW_FOR", "KW_UNTIL", "KW_WHILE", "KW_CONTINUE", "KW_GIVEN",
-  "KW_WHEN", "KW_DEFAULT", "KW_TRY", "KW_CATCH", "KW_FINALLY", "KW_DEFER",
-  "KW_REQUIRE", "KW_DO", "KW_USE_or_NO", "KW_SUB_named",
+  "\"end of file\"", "error", "\"invalid token\"", "GRAMPROG", "GRAMEXPR",
+  "GRAMBLOCK", "GRAMBARESTMT", "GRAMFULLSTMT", "GRAMSTMTSEQ",
+  "GRAMSUBSIGNATURE", "PERLY_AMPERSAND", "PERLY_BRACE_OPEN",
+  "PERLY_BRACE_CLOSE", "PERLY_BRACKET_OPEN", "PERLY_BRACKET_CLOSE",
+  "PERLY_COMMA", "PERLY_DOLLAR", "PERLY_DOT", "PERLY_EQUAL_SIGN",
+  "PERLY_MINUS", "PERLY_PERCENT_SIGN", "PERLY_PLUS", "PERLY_SEMICOLON",
+  "PERLY_SLASH", "PERLY_SNAIL", "PERLY_STAR", "KW_FORMAT", "KW_PACKAGE",
+  "KW_CLASS", "KW_LOCAL", "KW_MY", "KW_FIELD", "KW_IF", "KW_ELSE",
+  "KW_ELSIF", "KW_UNLESS", "KW_FOR", "KW_UNTIL", "KW_WHILE", "KW_CONTINUE",
+  "KW_GIVEN", "KW_WHEN", "KW_DEFAULT", "KW_TRY", "KW_CATCH", "KW_FINALLY",
+  "KW_DEFER", "KW_REQUIRE", "KW_DO", "KW_USE_or_NO", "KW_SUB_named",
   "KW_SUB_named_sig", "KW_SUB_anon", "KW_SUB_anon_sig", "KW_METHOD_named",
   "KW_METHOD_anon", "BAREWORD", "METHCALL0", "METHCALL", "THING", "PMFUNC",
   "PRIVATEREF", "QWLIST", "FUNC0OP", "FUNC0SUB", "UNIOPSUB", "LSTOPSUB",
@@ -162,12 +427,18 @@ static const char *const yytname[] =
   "my_var", "refgen_topic", "my_refgen", "amper", "scalar", "ary", "hsh",
   "arylen", "star", "sliceme", "kvslice", "gelem", "indirob", YY_NULLPTR
 };
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
-# ifdef YYPRINT
+#ifdef YYPRINT
 /* YYTOKNUM[NUM] -- (External) token number corresponding to the
    (internal) symbol number NUM (which must be that of a token).  */
-static const yytype_uint16 yytoknum[] =
+static const yytype_int16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
      265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
@@ -184,17 +455,17 @@ static const yytype_uint16 yytoknum[] =
      375,   376,   377,   378,   379,   380,   381,   382,   383,   384,
      385
 };
-# endif
+#endif
 
-#define YYPACT_NINF -544
+#define YYPACT_NINF (-544)
 
-#define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-544)))
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF -337
+#define YYTABLE_NINF (-337)
 
-#define yytable_value_is_error(Yytable_value) \
-  (!!((Yytable_value) == (-337)))
+#define yytable_value_is_error(Yyn) \
+  ((Yyn) == YYTABLE_NINF)
 
   /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
      STATE-NUM.  */
@@ -272,7 +543,7 @@ static const yytype_int16 yypact[] =
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
      Performed when YYTABLE does not specify something else to do.  Zero
      means the default is an error.  */
-static const yytype_uint16 yydefact[] =
+static const yytype_int16 yydefact[] =
 {
        0,     2,     4,     6,     8,    10,    12,    14,     0,    21,
       19,     0,     0,     0,    19,   138,     1,    19,     0,    19,
@@ -1243,7 +1514,7 @@ static const yytype_uint8 yyr1[] =
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
+static const yytype_int8 yyr2[] =
 {
        0,     2,     0,     4,     0,     3,     0,     3,     0,     3,
        0,     3,     0,     3,     0,     3,     1,     1,     4,     0,
@@ -1288,7 +1559,7 @@ typedef enum {
 /* type of each token/terminal */
 static const toketypes yy_type_tab[] =
 {
-  toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
+  toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival,
@@ -1298,7 +1569,7 @@ static const toketypes yy_type_tab[] =
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
-  toketype_ival, toketype_ival, toketype_ival, toketype_ival,
+  toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
   toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
@@ -1336,6 +1607,6 @@ static const toketypes yy_type_tab[] =
 };
 
 /* Generated from:
- * d200edcf6b5ba783b2b4e34928c5787fcab506e14d318042f4e46dee90ba0898 perly.y
+ * 823630846fc59cc2a19502726ec723b568eabded55fdc5e9722c600e1098779e perly.y
  * acf1cbfd2545faeaaa58b1cf0cf9d7f98b5be0752eb7a54528ef904a9e2e1ca7 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.y
+++ b/perly.y
@@ -1131,7 +1131,10 @@ listop	:	LSTOP indirob listexpr /* map {...} @args or print $fh @args */
 			{ $$ = op_convert_list($FUNC, 0, $optexpr); }
 	|	LSTOPSUB startanonsub block /* sub f(&@);   f { foo } ... */
 			{ SvREFCNT_inc_simple_void(PL_compcv);
-			  $<opval>$ = newANONATTRSUB($startanonsub, 0, NULL, $block); }[anonattrsub]
+                          $<opval>$ = newANONATTRSUB($startanonsub, 0, NULL, $block);
+                          /* prevent double op_free() if the following fails to parse */
+                          $block = NULL;
+                        }[anonattrsub]
 		    optlistexpr		%prec LSTOP  /* ... @bar */
 			{ $$ = newUNOP(OP_ENTERSUB, OPf_STACKED,
 				 op_append_elem(OP_LIST,

--- a/t/lib/croak/parser
+++ b/t/lib/croak/parser
@@ -1,0 +1,7 @@
+__END__
+# NAME double free of op
+sub all (&@);
+all { $_->[0] } map { [ }
+EXPECT
+syntax error at - line 2, near "[ }"
+Execution of - aborted due to compilation errors.


### PR DESCRIPTION
The reproducer resulted in the "block" OP being both on the parser stack and attacked to the CV.  If an error occurred while parsing the rest of the list operator clean up would release the OP as attached to the CV, and the same OP on the parse stack, resulting in a double free.

It's unclear to me whether bison is intended to support modifying the parse stack entry like this, but it appears to work here.

Fixes #21724