### PR TITLE
Configure: eliminate some left over debug output

### DIFF
--- a/Configure
+++ b/Configure
@@ -17810,9 +17810,7 @@ EOF
 set try
 if eval $compile_ok; then
     output=`$run ./try 2>/dev/null`
-    echo "'$output'" >&4
     separator=`echo "$output" | $sed 1q`
-    echo "'$separator'" >&4
     case $separator in
 	"\"=;\"")
           d_perl_lc_all_uses_name_value_pairs="$define"


### PR DESCRIPTION
The LC_ALL syntax detection wrote some of what it detected to the console with no labels.

On Linux this was:

  "=;"

for both lines, but I've seen more complex output on other systems.