### PR TITLE
perlipc.pod: fix the "exec from signal handler" example

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1478,6 +1478,7 @@ Zbynek Vyskovsky               <kvr@centrum.cz>
 Zefram                         <zefram@fysh.org>
 Zsbán Ambrus                   <ambrus@math.bme.hu>
 Ævar Arnfjörð Bjarmason        <avar@cpan.org>
+Štěpán Němec                   <stepnem@smrk.net>
 Дилян Палаузов                 <git-dpa@aegee.org>
 Михаил Козачков                <mchlkzch@gmail.com>
 小鸡                             <345865759@163.com>

--- a/pod/perlipc.pod
+++ b/pod/perlipc.pod
@@ -204,18 +204,15 @@ info to show that it works; it should be replaced with the real code.
   my $script = File::Basename::basename($0);
   my $SELF  = catfile($FindBin::Bin, $script);
 
-  # Use SA_NODEFER to prevent SIGHUP from being blocked in
-  # the new process (due to signal mask preservation across exec).
-  my $sigset = POSIX::SigSet->new();
-  my $action = POSIX::SigAction->new("sigHUP_handler",
-				     $sigset,
-				     &POSIX::SA_NODEFER);
-  POSIX::sigaction(&POSIX::SIGHUP, $action);
-
-  sub sigHUP_handler {
+  $SIG{HUP} = sub {
       print "got SIGHUP\n";
-      exec($SELF, @ARGV)        || die "$0: couldn't restart: $!";
-  }
+      exec($SELF, @ARGV) || die "$0: couldn't restart: $!";
+  };
+
+  # Make sure SIGHUP isn't blocked (as it normally would be, due to the
+  # handler function calling exec rather than returning)
+  POSIX::sigprocmask(&POSIX::SIG_UNBLOCK,
+    POSIX::SigSet->new(&POSIX::SIGHUP));
 
   code();
 

--- a/pod/perlipc.pod
+++ b/pod/perlipc.pod
@@ -204,7 +204,8 @@ info to show that it works; it should be replaced with the real code.
   my $script = File::Basename::basename($0);
   my $SELF  = catfile($FindBin::Bin, $script);
 
-  # POSIX unmasks the sigprocmask properly
+  # Use SA_NODEFER to prevent SIGHUP from being blocked in
+  # the new process (due to signal mask preservation across exec).
   my $sigset = POSIX::SigSet->new();
   my $action = POSIX::SigAction->new("sigHUP_handler",
 				     $sigset,

--- a/pod/perlipc.pod
+++ b/pod/perlipc.pod
@@ -205,10 +205,16 @@ info to show that it works; it should be replaced with the real code.
   my $SELF  = catfile($FindBin::Bin, $script);
 
   # POSIX unmasks the sigprocmask properly
-  $SIG{HUP} = sub {
+  my $sigset = POSIX::SigSet->new();
+  my $action = POSIX::SigAction->new("sigHUP_handler",
+				     $sigset,
+				     &POSIX::SA_NODEFER);
+  POSIX::sigaction(&POSIX::SIGHUP, $action);
+
+  sub sigHUP_handler {
       print "got SIGHUP\n";
       exec($SELF, @ARGV)        || die "$0: couldn't restart: $!";
-  };
+  }
 
   code();
 


### PR DESCRIPTION
I was scratching my head wondering why my signal handlers
calling exec[1] didn't work, and neither did the perlipc
example.

Fortunately a search turned up
https://www.perlmonks.org/?node_id=440900 which still cites
the old (and apparently still correct) documentation.

I don't know if something changed since 2011 or if the
pertinent changes in commit de7ba5179657 were wrong to begin
with.

For convenience I've also put the test script demonstrating
the issue (included in the commit message, with further
details) into a gist:

https://gist.github.com/stepnem/738d7d2e21bc4ab3d1d0a715c4a8bf86

[1] Note that the exec seems important; a simpler handler
(e.g., just printing or setting a variable) appears to work
fine without POSIX.