### PR TITLE
Additions to perlexperiment pod

### DIFF
--- a/pod/perlexperiment.pod
+++ b/pod/perlexperiment.pod
@@ -174,6 +174,19 @@ executed until the containing block is being exited.
 The ticket for this experiment is
 L<[perl #17949]|https://github.com/Perl/perl5/issues/17949>.
 
+=item The C<class> feature
+
+Introduced in Perl 5.38.0
+
+This feature provides new syntax and semantics for using object oriented
+programming based on classes.  For more information see L<perlclass>.
+
+Using this feature triggers warnings in the category
+C<experimental::class>.
+
+The ticket for this experiment is
+L<[perl #22139]|https://github.com/Perl/perl5/issues/22139>.
+
 =back
 
 =head2 Accepted features

--- a/pod/perlexperiment.pod
+++ b/pod/perlexperiment.pod
@@ -151,7 +151,8 @@ arguments.
 
 Introduced in Perl 5.36.0.
 
-Using this feature triggers warnings in the category C<experimental::builtin>.
+Using certain functions of this feature triggers warnings in the category
+C<experimental::builtin>.
 
 In Perl 5.36.0, a new namespace, C<builtin>, was created for new core functions
 that will not be present in every namespace, but will be available for


### PR DESCRIPTION
* Only certain `builtin` functions now provoke experimental warnings
* Mention the 'class' feature

Fixes #21243 