### PR TITLE
allow perl to build with the re extension static

### DIFF
--- a/ext/re/Makefile.PL
+++ b/ext/re/Makefile.PL
@@ -28,6 +28,13 @@ foreach my $tuple (@files) {
 }
 
 my $defines = '-DPERL_EXT_RE_BUILD -DPERL_EXT_RE_DEBUG -DPERL_EXT';
+my %args;
+for my $arg (@ARGV) {
+    $args{$1} = $2 if $arg =~ /^(\w+)=(.*)$/;
+}
+if ($args{LINKTYPE} eq "static") {
+    $defines .= ' -DPERL_EXT_RE_STATIC';
+}
 
 my @libs;
 if ($^O eq 'cygwin' && $Config{usequadmath}) {

--- a/regcomp.h
+++ b/regcomp.h
@@ -1559,12 +1559,12 @@ typedef enum {
  * and this is not a DEBUGGING enabled build (identified by
  * DEBUGGING_RE_ONLY being defined)
  */
-#if ( defined(USE_DYNAMIC_LOADING) && defined(DEBUGGING)) || \
+#if ( !defined(PERL_EXT_RE_STATIC) && defined(DEBUGGING)) ||       \
     ( defined(PERL_EXT_RE_BUILD) && defined(DEBUGGING_RE_ONLY)) || \
     (!defined(PERL_EXT_RE_BUILD) && defined(DEBUGGING))
 #define PERL_RE_BUILD_DEBUG
 #endif
-#if ( defined(USE_DYNAMIC_LOADING) || !defined(PERL_EXT_RE_BUILD) )
+#if !defined(PERL_EXT_RE_STATIC)
 #define PERL_RE_BUILD_AUX
 #endif
 


### PR DESCRIPTION
Previously configuring with -Uusedl built successfully, but didn't with -Dstatic_ext=re, now both build successfully.

Fixes #21550