### PR TITLE
yyl_dollar: we don't need to diagnose tick-in-id here

### DIFF
--- a/t/lib/warnings/toke
+++ b/t/lib/warnings/toke
@@ -1802,3 +1802,8 @@ EXPECT
 warn: Bareword found where operator expected (Do you need to predeclare "foo"?) at - line 3, near "foo bar"
 syntax error at - line 3, near "foo bar"
 Execution of - aborted due to compilation errors.
+########
+# NAME SIG assign heuristic warning [github #22145]
+use warnings;
+$SIG{INT} = uc'default';
+EXPECT

--- a/toke.c
+++ b/toke.c
@@ -5455,8 +5455,7 @@ yyl_dollar(pTHX_ char *s)
                     } while (isSPACE(*t));
                     if (isIDFIRST_lazy_if_safe(t, PL_bufend, UTF)) {
                         STRLEN len;
-                        t = scan_word6(t, tmpbuf, sizeof tmpbuf, TRUE,
-                                      &len, TRUE);
+                        t = scan_word(t, tmpbuf, sizeof tmpbuf, TRUE, &len);
                         while (isSPACE(*t))
                             t++;
                         if (  *t == ';'


### PR DESCRIPTION
when scanning for an id for a heuristic.

Fixes #22145