### PR TITLE
perlfunc: fix split example with limit higher than number of splits

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -8334,10 +8334,10 @@ the LIMIT value C<1> means that EXPR may be split a maximum of zero
 times, producing a maximum of one field (namely, the entire value of
 EXPR).  For instance:
 
-    my @x = split(//, "abc", 1); # ("abc")
-    my @x = split(//, "abc", 2); # ("a", "bc")
-    my @x = split(//, "abc", 3); # ("a", "b", "c")
-    my @x = split(//, "abc", 4); # ("a", "b", "c")
+    my @x = split(/,/, "a,b,c", 1); # ("a,b,c")
+    my @x = split(/,/, "a,b,c", 2); # ("a", "b,c")
+    my @x = split(/,/, "a,b,c", 3); # ("a", "b", "c")
+    my @x = split(/,/, "a,b,c", 4); # ("a", "b", "c")
 
 If LIMIT is negative, it is treated as if it were instead arbitrarily
 large; as many fields as possible are produced.


### PR DESCRIPTION
When calling split with a LIMIT higher than the number of possible output fields, no extra fields will be produced. The previous example trying to demonstrate this had an error because it used an empty match, which meant a final empty string could be produced.

Fixes #22150