### PR TITLE
_PC_CHOWN_RESTRICTED can only be used via pathconf/fpathconf not sysconf

### DIFF
--- a/cpan/File-Temp/lib/File/Temp.pm
+++ b/cpan/File-Temp/lib/File/Temp.pm
@@ -749,7 +749,7 @@ sub _is_verysafe {
   if (defined $chown_restricted) {
 
     # Return if the current directory is safe
-    return _is_safe($path,$err_ref) if POSIX::sysconf( $chown_restricted );
+    return _is_safe($path,$err_ref) if POSIX::pathconf( $path, $chown_restricted );
 
   }
 

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -1283,8 +1283,8 @@ the group to any of your secondary groups.  On insecure systems, these
 restrictions may be relaxed, but this is not a portable assumption.
 On POSIX systems, you can detect this condition this way:
 
-    use POSIX qw(sysconf _PC_CHOWN_RESTRICTED);
-    my $can_chown_giveaway = ! sysconf(_PC_CHOWN_RESTRICTED);
+    use POSIX qw(pathconf _PC_CHOWN_RESTRICTED);
+    my $can_chown_giveaway = ! pathconf($path_of_interest,_PC_CHOWN_RESTRICTED);
 
 Portability issues: L<perlport/chown>.
 


### PR DESCRIPTION
The documentation regarding availability of chown (perldoc -f chown) incorrectly uses the sysconf() function rather than the pathconf() function along with a path.

_PC_* can only be used as parameters to pathconf()/fpathconf(). Only _SC_* values can be used against sysconf().

Cannot speak to other systems but on all linux systems the original code would be returning the value for "_SC_TZNAME_MAX, The maximum number of bytes in a timezone name."

There is also an matching misuse in cpan/File-Temp/lib/File/Temp.pm

