### PR TITLE
Don't output msg for harmless use of unsupported locale

### DIFF
--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -3174,6 +3174,7 @@ mblen(s, n = ~0)
     CODE:
         errno = 0;
 
+        CHECK_AND_WARN_PROBLEMATIC_LOCALE_;
         SvGETMAGIC(s);
         if (! SvOK(s)) {
 #ifdef USE_MBRLEN
@@ -3268,6 +3269,7 @@ wctomb(s, wchar)
 	wchar_t		wchar
     CODE:
         errno = 0;
+        CHECK_AND_WARN_PROBLEMATIC_LOCALE_;
         SvGETMAGIC(s);
         if (s == &PL_sv_undef) {
 #ifdef USE_WCRTOMB
@@ -3307,7 +3309,8 @@ strcoll(s1, s2)
 	char *		s1
 	char *		s2
     CODE:
-        LC_COLLATE_LOCK;
+        CHECK_AND_WARN_PROBLEMATIC_LOCALE_;
+	LC_COLLATE_LOCK;
         RETVAL = strcoll(s1, s2);
         LC_COLLATE_UNLOCK;
     OUTPUT:
@@ -3365,6 +3368,7 @@ strtol(str, base = 0)
 	long num;
 	char *unparsed;
     PPCODE:
+        CHECK_AND_WARN_PROBLEMATIC_LOCALE_;
 	if (base == 0 || inRANGE(base, 2, 36)) {
             num = strtol(str, &unparsed, base);
 #if IVSIZE < LONGSIZE
@@ -3399,6 +3403,7 @@ strtoul(str, base = 0)
     PPCODE:
 	PERL_UNUSED_VAR(str);
 	PERL_UNUSED_VAR(base);
+        CHECK_AND_WARN_PROBLEMATIC_LOCALE_;
 	if (base == 0 || inRANGE(base, 2, 36)) {
             num = strtoul(str, &unparsed, base);
 #if UVSIZE < LONGSIZE
@@ -3428,6 +3433,7 @@ strxfrm(src)
 	SV *		src
     CODE:
 #ifdef USE_LOCALE_COLLATE
+      CHECK_AND_WARN_PROBLEMATIC_LOCALE_;
       ST(0) = Perl_strxfrm(aTHX_ src);
 #else
       ST(0) = src;

--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our ($AUTOLOAD, %SIGRT);
 
-our $VERSION = '2.18';
+our $VERSION = '2.19';
 
 require XSLoader;
 

--- a/perl.h
+++ b/perl.h
@@ -7456,7 +7456,7 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #  define IN_LC(category)  \
                     (IN_LC_COMPILETIME(category) || IN_LC_RUNTIME(category))
 
-#  if defined (PERL_CORE) || defined (PERL_IN_XSUB_RE)
+#  if defined (PERL_CORE) || defined (PERL_IN_XSUB_RE) || defined(PERL_EXT_POSIX)
 
      /* This internal macro should be called from places that operate under
       * locale rules.  If there is a problem with the current locale that


### PR DESCRIPTION
This fixes GH #21562

Perl doesn't support all possible locales.  Locales that remap elements of the ASCII character set or change their case pairs won't work fully, for example.  Hence, some Turkish locales arent supported because Turkish has different behavior in regard to 'I' and 'i' than other locales that use the Latin alphabet.

The only multi-byte locales that perl supports are UTF-8 ones (and there actually is special handling here to support Turkish).  Other multi-byte locales can be dangerous to use, possibly crashing or hanging the Perl interpreter.  Locales with shift states are particularly prone to this.

Since perl is written in C, there is always an underlying locale.  But most C functions don't look at locales at all, and the Perl interpreter takes care to call the ones that do only within the scope of 'use locale' or for certain function calls in the POSIX:: module that always use the program's current underlying locale.

Prior to this commit, if a dangerous locale underlied the program at startup, a warning to that effect was emitted, even if that locale never gets accessed.

This commit changes things so that no warning is output until and if the dangerous underlying locale is actually attempted to be used.

Pre-existing code also deferred warnings about locales (like the Turkish ones mentioned above) that aren't fully compatible with perl.  So it was a simple matter to just modify this code a bit, and add some extra checks for sane locales being in effect