### PR TITLE
_PC_CHOWN_RESTRICTED can only be used via pathconf/fpathconf, not sysconf

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -168,6 +168,7 @@ Ben Tilly <ben_tilly@operamail.com> <ben_tilly@hotmail.com>
 Ben Tilly <ben_tilly@operamail.com> <btilly@gmail.com>
 Ben Tilly <ben_tilly@operamail.com> Benjamin J. Tilly <unknown>
 Benjamin Holzman <bah@ecnvantage.com> <bholzman@longitude.com>
+Bernard Quatermass <bernard@quatermass.co.uk> Bernard Quatermass <toolsmith@quatermass.co.uk>
 Bharanee Rathna <unknown> bharanee rathna <unknown>
 Bilbo <bilbo@ua.fm> bilbo@ua.fm <bilbo@ua.fm>
 Billy Constantine <wdconsta@cs.adelaide.edu.au> wdconsta <wdconsta@cs.adelaide.edu.au>

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -1283,8 +1283,9 @@ the group to any of your secondary groups.  On insecure systems, these
 restrictions may be relaxed, but this is not a portable assumption.
 On POSIX systems, you can detect this condition this way:
 
-    use POSIX qw(sysconf _PC_CHOWN_RESTRICTED);
-    my $can_chown_giveaway = ! sysconf(_PC_CHOWN_RESTRICTED);
+    use POSIX qw(pathconf _PC_CHOWN_RESTRICTED);
+    my $can_chown_giveaway =
+        ! pathconf($path_of_interest, _PC_CHOWN_RESTRICTED);
 
 Portability issues: L<perlport/chown>.
 


### PR DESCRIPTION
The documentation regarding availability of chown (`perldoc -f chown`) incorrectly uses the sysconf() function rather than the pathconf() function along with a path.

\_PC\* can only be used as parameters to pathconf()/fpathconf(). Only \_SC\* values can be used against sysconf().

Cannot speak to other systems but on all linux systems the original code would be returning the value for "_SC_TZNAME_MAX, The maximum number of bytes in a timezone name."