### PR TITLE
Fix stringified IV_MIN sometimes unintentionally treated as NV

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -2658,19 +2658,14 @@ Perl_sv_2nv_flags(pTHX_ SV *const sv, const I32 flags)
             SvNOK_on(sv);
         } else {
             /* value has been set.  It may not be precise.  */
-            if ((numtype & IS_NUMBER_NEG) && (value >= (UV)IV_MIN)) {
-                /* 2s complement assumption for (UV)IV_MIN  */
+            if ((numtype & IS_NUMBER_NEG) && (value > ABS_IV_MIN)) {
                 SvNOK_on(sv); /* Integer is too negative.  */
             } else {
                 SvNOKp_on(sv);
                 SvIOKp_on(sv);
 
                 if (numtype & IS_NUMBER_NEG) {
-                    /* -IV_MIN is undefined, but we should never reach
-                     * this point with both IS_NUMBER_NEG and value ==
-                     * (UV)IV_MIN */
-                    assert(value != (UV)IV_MIN);
-                    SvIV_set(sv, -(IV)value);
+                    SvIV_set(sv, NEGATE_2IV(value));
                 } else if (value <= (UV)IV_MAX) {
                     SvIV_set(sv, (IV)value);
                 } else {

--- a/t/op/numconvert.t
+++ b/t/op/numconvert.t
@@ -281,3 +281,18 @@ sub plus_one { (shift) + 1 }
 
 is 0x1p60 - 1.0, 0x1p60 - 1,
     "(0x1p60 - 1) and (0x1p60 - 1.0) should be identical";
+
+my @iv_min_test;
+BEGIN {
+    @iv_min_test = ('2147483647', '2147483648',
+                    '9223372036854775807', '9223372036854775808');
+    $::additional_tests += @iv_min_test;
+}
+
+foreach my $str (@iv_min_test) {
+    my $x = "-$str";
+    my $y = $x + 1.23;
+    my $z = $x + 0;
+    my $w = "-$str" + 0;
+    is $z, $w, "previously NV-ified '-$str' has correct numeric value";
+}


### PR DESCRIPTION
String representation of IV_MIN (`"-9223372036854775808"` in typical 64bit build) is expected to be treated as IV in numeric context, but current perl sometimes treat it as NV.

In `!NV_PRESERVES_UV` case (e.g. IV and NV are both 64-bit, as in typical x86_64 build), if such string is once referred in NV context (with `sv_2nv_flags()`), it will be unexpectedly treated as NV in subsequent numeric references:

```
$ perl -wle 'my $x = my $y = "-9223372036854775808"; my $z = $x + 1.23; print $x + 0; print $y + 0'
-9.22337203685478e+18
-9223372036854775808
$
```

This change will hopefully resolve this.