### PR TITLE
Avoid unnecessary "changing use VERSION ..." message around string eval (fixes #22121)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6109,6 +6109,7 @@ t/lib/strict/refs			Tests of "use strict 'refs'" for strict.t
 t/lib/strict/subs			Tests of "use strict 'subs'" for strict.t
 t/lib/strict/vars			Tests of "use strict 'vars'" for strict.t
 t/lib/subs/subs				Tests of "use subs"
+t/lib/test_22121.pm			A test file for t/lib/warnings/op
 t/lib/test_require.pm			A test file for t/op/inccode.t
 t/lib/test_use.pm			A test pragma for t/comp/use.t
 t/lib/test_use_14937.pm			A test pragma for t/comp/use.t

--- a/op.c
+++ b/op.c
@@ -12416,6 +12416,8 @@ Perl_ck_eval(pTHX_ OP *o)
     PERL_ARGS_ASSERT_CK_EVAL;
 
     PL_hints |= HINT_BLOCK_SCOPE;
+    if(PL_prevailing_version != 0)
+        PL_hints |= HINT_LOCALIZE_HH;
     if (o->op_flags & OPf_KIDS) {
         SVOP * const kid = cSVOPx(cUNOPo->op_first);
         assert(kid);
@@ -12457,6 +12459,7 @@ Perl_ck_eval(pTHX_ OP *o)
      && !(o->op_private & OPpEVAL_COPHH) && GvHV(PL_hintgv)) {
         /* Store a copy of %^H that pp_entereval can pick up. */
         HV *hh = hv_copy_hints_hv(GvHV(PL_hintgv));
+        hv_stores(hh, "CORE/prevailing_version", newSVuv(PL_prevailing_version));
         OP *hhop;
         hhop = newSVOP(OP_HINTSEVAL, 0, MUTABLE_SV(hh));
         /* append hhop to only child  */

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4062,6 +4062,7 @@ S_doeval_compile(pTHX_ U8 gimme, CV* outside, U32 seq, HV *hh)
     else {
         PL_hints = saveop->op_private & OPpEVAL_COPHH
                      ? oldcurcop->cop_hints : (U32)saveop->op_targ;
+        PL_prevailing_version = 0; /* we might change this below */
 
         /* making 'use re eval' not be in scope when compiling the
          * qr/mabye_has_runtime_code_block/ ensures that we don't get
@@ -4076,6 +4077,11 @@ S_doeval_compile(pTHX_ U8 gimme, CV* outside, U32 seq, HV *hh)
             SvREFCNT_dec(GvHV(PL_hintgv));
             GvHV(PL_hintgv) = hh;
             FETCHFEATUREBITSHH(hh);
+            SV *versv, **svp;
+            if((svp = hv_fetchs(hh, "CORE/prevailing_version", 0)) && (versv = *svp) && SvOK(versv)) {
+                SAVEI16(PL_prevailing_version);
+                PL_prevailing_version = SvUV(versv);
+            }
         }
     }
     SAVECOMPILEWARNINGS();

--- a/t/lib/test_22121.pm
+++ b/t/lib/test_22121.pm
@@ -1,0 +1,3 @@
+# a test file for t/lib/warnings/op
+eval "use v5.14;";
+1;

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -2180,3 +2180,9 @@ use v5.12;
 use v5.12;
 # expect no warning because same version
 EXPECT
+########
+# GH #22121
+use v5.20;
+use test_22121;
+# expect no warning because different scope
+EXPECT


### PR DESCRIPTION
We need to save the value of PL_prevailing_version at the time the eval op was compiled, so it can be put in place during the running code.
    
Ideally we'd do something more robust, like change the OP_ENTERVAL op class into UNOP_AUX, so that the aux vector can store additional information like the version number and perhaps the frozen hints hash.
    
In practice it is far too close to the 5.40 release to contemplate such a change now, so this is a less intrusive but hackier change to achieve the same aim.

This is in two commits, because the first commit fixes the bug but leaves an ugly `$^H{"CORE/prevailing_version"}` in the hints hash inside a string eval. Probably not a huge disaster but it's messy. The second commit tidies that up too, but is implemented in a bit of a weird way around not triggering `PERL_MAGIC_hinthash` while deleting the key. It's not great but gets the job done.

We can discuss whether we want to merge both commits, or just one the first one.