### PR TITLE
remove underscore from VERSION in podlators

### DIFF
--- a/cpan/podlators/lib/Pod/Man.pm
+++ b/cpan/podlators/lib/Pod/Man.pm
@@ -30,7 +30,8 @@ BEGIN {
 }
 
 our @ISA = qw(Pod::Simple);
-our $VERSION = '5.01_01';
+our $VERSION = '5.01_02';
+$VERSION =~ tr/_//d;
 
 # Ensure that $Pod::Simple::nbsp and $Pod::Simple::shy are available.  Code
 # taken from Pod::Simple 3.32, but was only added in 3.30.

--- a/cpan/podlators/lib/Pod/ParseLink.pm
+++ b/cpan/podlators/lib/Pod/ParseLink.pm
@@ -21,7 +21,8 @@ use Exporter;
 
 our @ISA = qw(Exporter);
 our @EXPORT = qw(parselink);
-our $VERSION = '5.01_01';
+our $VERSION = '5.01_02';
+$VERSION =~ tr/_//d;
 
 ##############################################################################
 # Implementation

--- a/cpan/podlators/lib/Pod/Text.pm
+++ b/cpan/podlators/lib/Pod/Text.pm
@@ -24,7 +24,8 @@ use Exporter ();
 use Pod::Simple ();
 
 our @ISA = qw(Pod::Simple Exporter);
-our $VERSION = '5.01_01';
+our $VERSION = '5.01_02';
+$VERSION =~ tr/_//d;
 
 # We have to export pod2text for backward compatibility.
 our @EXPORT = qw(pod2text);

--- a/cpan/podlators/lib/Pod/Text/Color.pm
+++ b/cpan/podlators/lib/Pod/Text/Color.pm
@@ -20,7 +20,8 @@ use Pod::Text ();
 use Term::ANSIColor qw(color colored);
 
 our @ISA = qw(Pod::Text);
-our $VERSION = '5.01_01';
+our $VERSION = '5.01_02';
+$VERSION =~ tr/_//d;
 
 ##############################################################################
 # Overrides

--- a/cpan/podlators/lib/Pod/Text/Overstrike.pm
+++ b/cpan/podlators/lib/Pod/Text/Overstrike.pm
@@ -26,7 +26,8 @@ use warnings;
 use Pod::Text ();
 
 our @ISA = qw(Pod::Text);
-our $VERSION = '5.01_01';
+our $VERSION = '5.01_02';
+$VERSION =~ tr/_//d;
 
 ##############################################################################
 # Overrides

--- a/cpan/podlators/lib/Pod/Text/Termcap.pm
+++ b/cpan/podlators/lib/Pod/Text/Termcap.pm
@@ -21,7 +21,8 @@ use POSIX ();
 use Term::Cap;
 
 our @ISA = qw(Pod::Text);
-our $VERSION = '5.01_01';
+our $VERSION = '5.01_02';
+$VERSION =~ tr/_//d;
 
 ##############################################################################
 # Overrides

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -15,10 +15,10 @@ Time::Piece cpan/Time-Piece/Piece.pm 8cec8b66183ceddb9bf2b6af35dcdd345bc9adfa
 Time::Piece cpan/Time-Piece/Piece.xs 543152540ee17788a638b2c5746b86c3d04401d1
 Win32API::File cpan/Win32API-File/File.pm 8fd212857f821cb26648878b96e57f13bf21b99e
 Win32API::File cpan/Win32API-File/File.xs beb870fed4490d2faa547b4a8576b8d64d1d27c5
-podlators cpan/podlators/lib/Pod/Man.pm 69b80c16ed960c222ab6726cde177cf2949d366d
-podlators cpan/podlators/lib/Pod/ParseLink.pm e84ac4d8121c7ed733a23f5ead5c2481f34dafa3
-podlators cpan/podlators/lib/Pod/Text.pm 367a5ec329148637c83ddcf072f929ba1e9eb953
-podlators cpan/podlators/lib/Pod/Text/Color.pm f1401820e6799270bdd1b4513be9c849521fb533
-podlators cpan/podlators/lib/Pod/Text/Overstrike.pm 9def24cfb97743ac6d935fd84a86ae560e70c9ca
-podlators cpan/podlators/lib/Pod/Text/Termcap.pm b86e1cf3a01cc6084436ae61b2e97fcffe064817
+podlators cpan/podlators/lib/Pod/Man.pm 830bd4708c735e7ddfc3622c58f005ed68647357
+podlators cpan/podlators/lib/Pod/ParseLink.pm ed1b133f2abf739b1d7d480a9c0285a2b7441d6a
+podlators cpan/podlators/lib/Pod/Text.pm c454bab685ca35bccdcd8e87bc4a0922f6fc77f7
+podlators cpan/podlators/lib/Pod/Text/Color.pm 318662cdfdd07a95be82c3080106ed1d410e18e0
+podlators cpan/podlators/lib/Pod/Text/Overstrike.pm ac9e6c6483aa785a4cd9b0ded64130a52e5178c9
+podlators cpan/podlators/lib/Pod/Text/Termcap.pm dc5c03b6310febae555202480bdcf8877c16efa8
 version cpan/version/lib/version.pm 8080cfe1fb21d5248c8ff5133b298d249d11e8e8


### PR DESCRIPTION
When using versions with underscores, best practice is to remove the underscore on a later line, to allow using the version as a number when accessing the variable directly.