### PR TITLE
hints/dragonfly.sh: actually disable the POSIX 2008 locale API

### DIFF
--- a/hints/dragonfly.sh
+++ b/hints/dragonfly.sh
@@ -90,5 +90,5 @@ esac
 
 # Dragonfly leaks with a newlocale/freelocale combination.  See
 # https://bugs.dragonflybsd.org/issues/3361
-ccflags="$ccflags -DNO_POSIX_2008"
+ccflags="$ccflags -DNO_POSIX_2008_LOCALE"
 


### PR DESCRIPTION
ae3e9dd0b was intended to disable this API, due to a leak in the DragonflyBSD implementation, but the wrong macro was used, which I missed in review.

Use the right macro.