### PR TITLE
Revert "testsuite.yml: workaround cygwin base address conflict in 5.39.10"

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -602,12 +602,10 @@ jobs:
         env:
           PATH: /usr/bin:/bin
           SHELLOPTS: igncr
-        # The -Astatic_ext=mro works around a hash collision with
-        # --enable-auto-image-base and should be revertible in 5.39.11
         run: |
           cd ~/work
           set +e
-          ./Configure -des -Dusedevel -Doptimize=-g -DDEBUGGING -Astatic_ext=mro || exit 1
+          ./Configure -des -Dusedevel -Doptimize=-g -DDEBUGGING || exit 1
       - name: Build
         shell: sh
         env:


### PR DESCRIPTION
This reverts commit c635fa2209aa81381fc45f5e89f5b16144056521.

With the 5.39.11 version bump there's no longer any risk of this collision.