### PR TITLE
pat codeblocks: add size to struct reg_code_blocks and fix leak

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -758,6 +758,9 @@ S_concat_pat(pTHX_ RExC_state_t * const pRExC_state,
              */
             struct reg_code_blocks *cbs =  pRExC_state->code_blocks;
             if (cbs) {
+                for (int n = 0; n < cbs->count; n++) {
+                    SvREFCNT_dec(cbs->cb[n].src_regex);
+                }
                 cbs->count = 0;
             }
         }

--- a/regexp.h
+++ b/regexp.h
@@ -113,7 +113,8 @@ struct reg_code_block {
 
 struct reg_code_blocks {
     int refcnt; /* we may be pointed to from a regex and from the savestack */
-    int  count;    /* how many code blocks */
+    int  count; /* how many code block slots currently in use */
+    int  size;  /* how many slots allocated in code_block[]  */
     struct reg_code_block *cb; /* array of reg_code_block's */
 };
 

--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -28,7 +28,7 @@ skip_all_without_unicode_tables();
 my $has_locales = locales_enabled('LC_CTYPE');
 my $utf8_locale = find_utf8_ctype_locale();
 
-plan tests => 1265;  # Update this when adding/deleting tests.
+plan tests => 1293;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -2512,6 +2512,121 @@ SKIP:
         ok($str =~ s/$copy/PQR/, 'replaced $copy with PQR');
         is($str, "PQR", 'final string should be PQR');
     }
+
+
+    # Various tests for regexes with code blocks interpolated from an
+    # array, related to fixing GH #16627.
+    #
+    # Prior to the fix, some of these tests would wrongly need 'use re
+    # "eval"', or would assert fail, or crash, or produce unpredictable
+    # results.
+
+    {
+        local $" = '-'; # separator when interpolating arrays
+
+        my $pat;
+
+        my $A = 'A';
+        my $B = 'B';
+        my $C = 'C';
+        my $D = 'D';
+        my $E = 'E';
+
+        my $a = 'aa';
+        my $b = 'bb';
+        my $c = 'cc';
+        my $d = 'dd';
+        my $e = 'ee';
+
+        my @r = (qr/(??{$B})/);
+
+        # array with single element, usually following a literal code block
+
+        like "B",   qr/^@r$/,                   "code in array 1";
+        like "AB" , qr/^(??{$A})@r$/,           "code in array 2";
+        like "XAB", qr/^X(??{$A})@r$/,          "code in array 3";
+        $pat =   qr/^X(??{$A})@r(??{$C})$/;
+        like "XABC",    $pat,                    "code in array 4";
+        unlike "",      $pat,                    "code in array 4 not 1";
+        unlike "XAC",   $pat,                    "code in array 4 not 2";
+        unlike "XAbbC", $pat,                    "code in array 4 not 3";
+
+        {
+            my $B = 'Q';
+            push  @r, qr/(??{$B})/;
+        }
+
+        # array with two elements, usually following a literal code block
+        #
+        like "B-Q",    qr/^@r$/,                  "code in array 5";
+        like "AB-Q",   qr/^(??{$A})@r$/,          "code in array 6";
+        like "XAB-Q",  qr/^X(??{$A})@r$/,         "code in array 7";
+        $pat =   qr/^X(??{$A})@r(??{$C})$/;
+        like "XAB-QC",   $pat,                    "code in array 8";
+        unlike "",       $pat,                    "code in array 8 not 1";
+        unlike "XAC",    $pat,                    "code in array 8 not 2";
+        unlike "XAB-BC", $pat,                    "code in array 8 not 3";
+
+        # Simple overload package which returns a lower-cased version
+        # of a concatenated string, with a '=' used to join
+
+        package LcConcat {
+            use overload
+                '""' => sub { ${$_[0]} },
+                '.' =>  sub {
+                                my ($x, $y) = @_[ $_[2] ? (1,0) : (0,1) ];
+                                my ($xx, $yy) = ("$x", "$y");
+                                lc("$xx=$yy");
+                            }
+                ;
+        }
+
+        my $r = qr/(??{$E})/;
+        bless $r, 'LcConcat';
+
+        # Overloading concatenation converts literal compile-time code
+        # blocks into run-time recompiled affairs, so need to enable eval
+        use re 'eval';
+
+        # First, use an overloaded *scalar* to establish baseline
+        # behaviour (i.e. not yet using an array of scalars).
+        # Note that the overloaded concatenation converts everything in
+        # the pattern to its left to lowercase, so (??{$B}) becomes
+        # (??{$b}) etc.
+
+        like "=ee",     qr/^$r$/,                  "code in array 9";
+        {
+            no re 'eval';
+            eval q{my $x = qr/^$r$/; 1};
+            like $@, qr/Eval-group not allowed/,   "code in array 9 - err";
+        }
+        like "aa=ee",   qr/^(??{$A})$r$/,          "code in array 10";
+        like "xaa=ee",  qr/^X(??{$A})$r$/,         "code in array 11";
+        $pat = qr/^X(??{$A})$r(??{$C})$/;
+        like "xaa=eeC",  $pat,                     "code in array 12";
+        unlike "",       $pat,                     "code in array 12 not 1";
+        unlike "XA=EC",  $pat,                     "code in array 12 not 2";
+
+        # Then add an overloaded scalar to an *array* to see if it's
+        # still handled ok by the array interpolation code
+
+        push @r, $r;
+
+        like "bb-bb-=ee",     qr/^@r$/,            "code in array 13";
+        {
+            no re 'eval';
+            eval q{my $x = qr/^@r$/; 1};
+            like $@, qr/Eval-group not allowed/,   "code in array 13 - err";
+        }
+        like "aabb-bb-=ee",   qr/^(??{$A})@r$/,    "code in array 14";
+        like "xaabb-bb-=ee",  qr/^X(??{$A})@r$/,   "code in array 15";
+        $pat = qr/^X(??{$A})@r(??{$C})$/;
+        like "xaabb-bb-=eeC",  $pat,               "code in array 16";
+        unlike "",             $pat,               "code in array 16 not 1";
+        unlike "XAB-B-=EC",    $pat,               "code in array 16 not 2";
+
+    }
+
 } # End of sub run_tests
 
 1;


### PR DESCRIPTION
The first commit reworks some of the detail of how arrays are interpolated arrays into patterns which have code blocks, and fixes GH #16627.
The second follow up commit fixes a small leak I spotted in that same area of code.