### PR TITLE
Fcntl: remove pointless S_ISENFMT function

### DIFF
--- a/ext/Fcntl/Fcntl.pm
+++ b/ext/Fcntl/Fcntl.pm
@@ -688,11 +688,6 @@ equivalent to C<S_IFMT($mode) == S_IFCHR>.
 Convenience function to check for directories: C<S_ISDIR($mode)> is
 equivalent to C<S_IFMT($mode) == S_IFDIR>.
 
-=item C<S_ISENFMT>
-
-Broken function; do not use. (C<S_ISENFMT($mode)> should always return false,
-anyway.)
-
 =item C<S_ISFIFO>
 
 Convenience function to check for fifos: C<S_ISFIFO($mode)> is
@@ -857,7 +852,7 @@ use strict;
 
 use Exporter 'import';
 require XSLoader;
-our $VERSION = '1.18';
+our $VERSION = '1.19';
 
 XSLoader::load();
 
@@ -876,7 +871,7 @@ our %EXPORT_TAGS = (
 		     S_IREAD S_IWRITE S_IEXEC
 		     S_ISREG S_ISDIR S_ISLNK S_ISSOCK
 		     S_ISBLK S_ISCHR S_ISFIFO
-		     S_ISWHT S_ISENFMT
+		     S_ISWHT
 		     S_IFMT S_IMODE
                   )],
 );

--- a/ext/Fcntl/Fcntl.xs
+++ b/ext/Fcntl/Fcntl.xs
@@ -118,8 +118,4 @@ BOOT:
         cv = newXS("Fcntl::S_ISWHT", XS_Fcntl_S_ISREG, file);
         XSANY.any_i32 = S_IFWHT;
 #endif
-#ifdef S_ENFMT
-        cv = newXS("Fcntl::S_ISENFMT", XS_Fcntl_S_ISREG, file);
-        XSANY.any_i32 = S_ENFMT;
-#endif
     }

--- a/ext/Fcntl/t/mode.t
+++ b/ext/Fcntl/t/mode.t
@@ -18,7 +18,7 @@ if (-c $devnull) {
     push @tests, ['CHR', $devnull, (stat $devnull)[2]];
 }
 
-plan(tests => 34 + 6 + 9 * @tests);
+plan(tests => 34 + 6 + 8 * @tests);
 foreach (@tests) {
     my ($type, $name, $mode) = @$_;
 
@@ -62,10 +62,6 @@ foreach (@tests) {
  SKIP: {
 	skip 'No S_IFWHT', 1 unless defined eval {S_IFWHT};
 	ok(!S_ISWHT($mode), "!S_ISWHT $name");
-    }
- SKIP: {
-	skip 'No S_ENFMT', 1 unless defined eval {S_ENFMT};
-	ok(!S_ISENFMT($mode), "!S_ISENFMT $name");
     }
 }
 

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -9011,11 +9011,9 @@ and the C<S_IF*> functions are
     S_ISREG($mode) S_ISDIR($mode) S_ISLNK($mode)
     S_ISBLK($mode) S_ISCHR($mode) S_ISFIFO($mode) S_ISSOCK($mode)
 
-    # No direct -X operator counterpart, but for the first one
-    # the -g operator is often equivalent.  The ENFMT stands for
-    # record flocking enforcement, a platform-dependent feature.
+    # No direct -X operator counterpart.
 
-    S_ISENFMT($mode) S_ISWHT($mode)
+    S_ISWHT($mode)
 
 See your native L<chmod(2)> and L<stat(2)> documentation for more details
 about the C<S_*> constants.  To get status info for a symbolic link


### PR DESCRIPTION
S_ISENFMT($mode) has no equivalent C macro. It was implemented (in XS) as the equivalent of `($mode & S_IFMT) == S_ENFMT`, which is always false because S_ENFMT is not a file type and thus not covered by the S_IFMT mask.

(See commits ca6e1c2, 0e6f150, 0f68039, fb59364, 87eca6e for the history of this function, which has always been broken in various ways ever since it was added in 2000.)

Fixes #22190.