### PR TITLE
S_new_SV: mark args unused, make inline, correct typo

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2248,6 +2248,10 @@ AMbdp	|CV *	|newSUB 	|I32 floor				\
 				|NULLOK OP *proto			\
 				|NULLOK OP *block
 ARdp	|SV *	|newSV		|const STRLEN len
+: Perl_new_sv is inline, so needs to be visible outside of sv.c
+Ciop	|SV *	|new_sv 	|NN const char *file			\
+				|int line				\
+				|NN const char *func
 Rp	|SV *	|newSVavdefelem |NN AV *av				\
 				|SSize_t ix				\
 				|bool extendible

--- a/proto.h
+++ b/proto.h
@@ -9851,6 +9851,11 @@ Perl_newSV_type_mortal(pTHX_ const svtype type)
         __attribute__always_inline__;
 # define PERL_ARGS_ASSERT_NEWSV_TYPE_MORTAL
 
+PERL_STATIC_INLINE SV *
+Perl_new_sv(pTHX_ const char *file, int line, const char *func);
+# define PERL_ARGS_ASSERT_NEW_SV                \
+        assert(file); assert(func)
+
 PERL_STATIC_INLINE void
 Perl_pop_stackinfo(pTHX);
 # define PERL_ARGS_ASSERT_POP_STACKINFO

--- a/sv.h
+++ b/sv.h
@@ -193,7 +193,7 @@ typedef enum {
 #  define HVAUX_ARENA_ROOT_IX   SVt_IV
 #endif
 #ifdef PERL_IN_SV_C
-#  define SVt_FIRST SVt_NULL	/* the type of SV that new_SV() in sv.c returns */
+#  define SVt_FIRST SVt_NULL	/* the type of SV that new_SV() in sv_inline.h returns */
 #endif
 
 #define PERL_ARENA_ROOTS_SIZE	(SVt_LAST)


### PR DESCRIPTION
When sv_inline.h was created in
https://github.com/Perl/perl5/commit/75acd14e43f2ffb698fc7032498f31095b56adb5
and a number of things moved into it, the S_new_SV debugging function should
have been made PERL_STATIC_INLINE. This commit now does that.It also marks
the arguments to S_new_SV as PERL_UNUSED_ARG, reducing warnings on some
builds, and corrects a transcription error in the __FUNCTION__ argument.

The first two changes were suggested in #22125 and the third noticed during
preparation of this PR.