### PR TITLE
PerlIO-encoding: Detect no progress made on input

### DIFF
--- a/ext/PerlIO-encoding/encoding.pm
+++ b/ext/PerlIO-encoding/encoding.pm
@@ -1,7 +1,7 @@
 package PerlIO::encoding;
 
 use strict;
-our $VERSION = '0.31';
+our $VERSION = '0.32';
 our $DEBUG = 0;
 $DEBUG and warn __PACKAGE__, " called by ", join(", ", caller), "\n";
 

--- a/ext/PerlIO-encoding/encoding.xs
+++ b/ext/PerlIO-encoding/encoding.xs
@@ -249,6 +249,7 @@ PerlIOEncode_fill(pTHX_ PerlIO * f)
     IV code = 0;
     PerlIO *n;
     SSize_t avail;
+    bool already_retried = false;
 
     if (PerlIO_flush(f) != 0)
 	return -1;
@@ -380,7 +381,12 @@ PerlIOEncode_fill(pTHX_ PerlIO * f)
 	    s = SvPV(e->dataSV,len);
 	    sv_setpvn(e->dataSV,s,len);
 	    PerlIO_set_ptrcnt(n, ptr+use, (avail-use));
-	    goto retry;
+            if (! already_retried) {
+                already_retried = true;
+                goto retry;
+            }
+
+            code = -1;
 	}
     }
     else {


### PR DESCRIPTION
This fixes GH #10258

If retrying getting the next byte doesn't make progress, fail

I'm unsure what all should be done, or if this needs to worry about input from a slow source. @leont ?   But it starts the discussion