### PR TITLE
Don't use CriticalSection on MingW without UCRT

### DIFF
--- a/win32/win32thread.h
+++ b/win32/win32thread.h
@@ -7,11 +7,14 @@ typedef struct win32_cond { LONG waiters; HANDLE sem; } perl_cond;
 typedef DWORD perl_key;
 typedef HANDLE perl_os_thread;
 
-#ifndef DONT_USE_CRITICAL_SECTION
+#if ! defined(DONT_USE_CRITICAL_SECTION)        \
+ &&  (defined(_MSC_VER) || defined(_UCRT))
 
 /* Critical Sections used instead of mutexes: lightweight,
  * but can't be communicated to child processes, and can't get
- * HANDLE to it for use elsewhere.
+ * HANDLE to it for use elsewhere.  And they are buggy on MingW without UCRT.
+ * (Unclear in what msvc version the bugs were fixed; assuming they are fixed
+ * in any version recent enough to have _MSC_VER defined.)
  */
 typedef CRITICAL_SECTION perl_mutex;
 #define MUTEX_INIT(m) InitializeCriticalSection(m)


### PR DESCRIPTION
I ran a test that uses mutexes extensively (and isn't in blead) on MingW, and got lots of failures.  After adding lots of trace statements, and poring over logs, it became clear that the EnterCriticalSection() calls (and kin) were not doing what they are supposed to do, locking out other threads.

This locking mechanism is the default for Windows, but win32thread.h allows for the use of a heavier-weight locking mechanism, selected by a Configuration option, or by adding to it the single line

  #define DONT_USE_CRITICAL_SECTION

Doing so "magically" caused those errors to go away.

This tells me that the error is in the CriticalSection libc calls.

I then ran the same test on MSVC, and the errors didn't happen.  It is using a later libc that the MingW I tested on is.  From this, I infer that this bug has been fixed in later libc versions.  (This is true of some other bugs we already have workarounds for.)

This commit causes the CriticalSection calls to not be used on MingW when it isn't compiled to use the later libc version UCRT.  I don't know when libc was fixed, but until evidence to the contrary surfaces, I took the easy way out, and assume any version is ok that is recent enough to have _MSVC_VER defined .