### PR TITLE
perlguts: Mention av_count()

### DIFF
--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -563,12 +563,16 @@ to these new elements.
 
 Here are some other functions:
 
+    Size_t  av_count(AV*);
     SSize_t av_top_index(AV*);
     SV**    av_fetch(AV*, SSize_t key, I32 lval);
     SV**    av_store(AV*, SSize_t key, SV* val);
 
+C<av_count> returns the number of elements in the array (including
+any empty slots (undefined ones) that are intermixed with filled-in ones).
 The C<av_top_index> function returns the highest index value in an array (just
-like $#array in Perl).  If the array is empty, -1 is returned.  The
+like $#array in Perl).  If the array is empty, -1 is returned.  It is
+always equal to S<C<av_count() - 1>>.  The
 C<av_fetch> function returns the value at index C<key>, but if C<lval>
 is non-zero, then C<av_fetch> will store an undef value at that index.
 The C<av_store> function stores the value C<val> at index C<key>, and does


### PR DESCRIPTION
av_count() generally is a better option than av_top_index(), so mention it as well as the existing mention of av_top_index()