### PR TITLE
add a step to the RMG to ensure the PSC membership is up to date

### DIFF
--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -428,6 +428,14 @@ If you decide any should be fixed, after that gets done, run
 to make sure those fixes were successful, and follow the directions in
 the output about regenerating the data base.
 
+=for checklist skip BLEAD-FINAL BLEAD-POINT RC
+
+=head3 Update perlgov
+
+When doing a MAINT release, check that perlgov lists the I<current>
+Perl Steering Council and Core Team members, in case they have changed
+since the corresponding stable release has been shipped.
+
 =head3 Update perldelta
 
 Get perldelta in a mostly finished state.


### PR DESCRIPTION
When releasing 5.34.3 and 5.36.3, the PSC membership hadn't been updated, showing an incorrect list. Adding this step to make sure the maintenance branch will get the update if needed.