### PR TITLE
perlretut/perlrecharclass: [:blank:] isn't a GNU extension anymore

### DIFF
--- a/pod/perlrecharclass.pod
+++ b/pod/perlrecharclass.pod
@@ -795,7 +795,8 @@ Perl recognizes the following POSIX character classes:
  alpha  Any alphabetical character (e.g., [A-Za-z]).
  alnum  Any alphanumeric character (e.g., [A-Za-z0-9]).
  ascii  Any character in the ASCII character set.
- blank  A GNU extension, equal to a space or a horizontal tab ("\t").
+ blank  Any horizontal whitespace character (e.g. space or horizontal
+        tab ("\t")).
  cntrl  Any control character.  See Note [2] below.
  digit  Any decimal digit (e.g., [0-9]), equivalent to "\d".
  graph  Any printable character, excluding a space.  See Note [3] below.

--- a/pod/perlreref.pod
+++ b/pod/perlreref.pod
@@ -163,8 +163,7 @@ POSIX character classes and their Unicode and Perl equivalents:
  blank   PosixBlank       XPosixBlank   \h       Horizontal whitespace;
                                                    full-range also
                                                    written as
-                                                   \p{HorizSpace} (GNU
-                                                   extension)
+                                                   \p{HorizSpace}
  cntrl   PosixCntrl       XPosixCntrl            Control characters
  digit   PosixDigit       XPosixDigit   \d       Decimal digits
  graph   PosixGraph       XPosixGraph            'alnum' plus 'punct'

--- a/pod/perlretut.pod
+++ b/pod/perlretut.pod
@@ -2118,9 +2118,9 @@ Unicode standard, or the Unicode Consortium's website L<https://www.unicode.org>
 As if all those classes weren't enough, Perl also defines POSIX-style
 character classes.  These have the form C<[:I<name>:]>, with I<name> the
 name of the POSIX class.  The POSIX classes are C<alpha>, C<alnum>,
-C<ascii>, C<cntrl>, C<digit>, C<graph>, C<lower>, C<print>, C<punct>,
-C<space>, C<upper>, and C<xdigit>, and two extensions, C<word> (a Perl
-extension to match C<\w>), and C<blank> (a GNU extension).  The C</a>
+C<ascii>, C<blank>, C<cntrl>, C<digit>, C<graph>, C<lower>, C<print>,
+C<punct>, C<space>, C<upper>, C<xdigit>, and C<word> (a Perl extension to
+match C<\w>).  The C</a>
 modifier restricts these to matching just in the ASCII range; otherwise
 they can match the same as their corresponding Perl Unicode classes:
 C<[:upper:]> is the same as C<\p{IsUpper}>, I<etc>.  (There are some


### PR DESCRIPTION
The wctype category "blank" and the corresponding isblank() function have been standardized in C99 and POSIX 2001. It is not correct to call it a GNU extension anymore.