### PR TITLE
Add known bugs in `class` feature to perlclass.pod

### DIFF
--- a/pod/perlclass.pod
+++ b/pod/perlclass.pod
@@ -381,6 +381,38 @@ including an ability for them to provide new class or field attributes.
 
 =back
 
+=head1 KNOWN BUGS
+
+The following bugs have been found in the experimental C<class> feature:
+
+=over 4
+
+=item *
+
+Since Perl v5.38, inheriting from a parent class which is declared in the same
+file and which hadn't already been sealed can cause a segmentation fault.
+[L<GH #20890|https://github.com/Perl/perl5/issues/20890>]
+
+=item *
+
+Since Perl v5.38 and with the experimental C<refaliasing> feature, trying to
+replace a field variable causes a segmentation fault.
+[L<GH #20947|https://github.com/Perl/perl5/issues/20947>]
+
+=item *
+
+Since Perl v5.38, it's possible to craft a class with leaky encapsulation,
+which can cause a segmentation fault.
+[L<GH #20956|https://github.com/Perl/perl5/issues/20956>]
+
+=item *
+
+In Perl v5.38, inheriting from a class would not always attempt to load the
+parent class (fixed in Perl v5.40).
+[L<GH #21332|https://github.com/Perl/perl5/issues/21332>]
+
+=back
+
 =head1 AUTHORS
 
 Paul Evans

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -709,6 +709,16 @@ functions, C<newANONLIST()>, C<newANONHASH()>, C<newSVREF()> and similar.
 
 =back
 
+=head3 L<perlclass>
+
+=over 4
+
+=item *
+
+Added a list of known bugs in the experimental C<class> feature.
+
+=back
+
 =head3 L<perlfunc>
 
 =over 4


### PR DESCRIPTION
When the experimental `class` feature was added in v5.38, it had some known problems that could cause segmentation faults, including #20956, #20947, and #20890 (duplicate: #21221).

As these issues persist to this day, I think they should be mentioned *somewhere* in Perl’s documentation. This change adds them to `perl5380delta`, and includes a brief erratum in the new v5.40 `perldelta`.