### PR TITLE
Upgrade to github-ci checkout action v4

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -79,7 +79,7 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1000
       - name: git setup
@@ -187,7 +187,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgdbm-dev libdb-dev
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
         if: steps.ci_config.outputs.ci_skip_sanity != 'true'
@@ -273,7 +273,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgdbm-dev libdb-dev
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: git cfg
         run: |
           git config diff.renameLimit 999999
@@ -325,7 +325,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y build-essential git-core libgdbm-dev libdb-dev
-      # actions/checkout@v2 and actions/checkout@v3 don't work in a i386 container:
+      # actions/checkout@v2 and higher don't work in a i386 container:
       # the GitHub runner uses `node` that is installed on the host inside the container.
       # The host is (likely) running x86_64 and using a binary build for x86_64 inside a
       # i386 container just doesn't work.
@@ -385,7 +385,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgdbm-dev libdb-dev
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: git cfg
         run: |
           git config diff.renameLimit 999999
@@ -437,7 +437,7 @@ jobs:
           - "-Duseithreads -Duseshrplib"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Configure
         run: |
           sh ./Configure -des -Dusedevel ${{ matrix.CONFIGURE_ARGS }}
@@ -466,7 +466,7 @@ jobs:
 
     steps:
       - run: git config --global core.autocrlf false
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       #- name: Install clcache
       #  shell: cmd
       #  run: |
@@ -522,7 +522,7 @@ jobs:
 
     steps:
       - run: git config --global core.autocrlf false
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install mingw-64
         run: |
           mkdir C:\perl_ci && cd C:\perl_ci
@@ -668,7 +668,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgdbm-dev libdb-dev
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: git cfg
         run: |
           git config diff.renameLimit 999999
@@ -719,7 +719,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgdbm-dev libdb-dev
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: git cfg
         run: |
           git config diff.renameLimit 999999
@@ -767,7 +767,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgdbm-dev libdb-dev
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: git cfg
         run: |
           git config diff.renameLimit 999999
@@ -822,7 +822,7 @@ jobs:
       image: perldocker/perl-tester:${{ matrix.perl-version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: perl -V
         run: perl -V
       - name: Build and test dist modules
@@ -848,7 +848,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: perl -V
         run: /usr/bin/perl -V
       - name: Build and test dist modules


### PR DESCRIPTION
Without this upgrade, we keep getting this warning:

~~~
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
~~~