### PR TITLE
fix warning/typo in pod/perlretut.pod %count should be %count2

### DIFF
--- a/pod/perlretut.pod
+++ b/pod/perlretut.pod
@@ -2853,7 +2853,7 @@ for another vowel. Thus, match or no match makes no difference, and the
 regexp engine proceeds until the entire string has been inspected.
 (It's remarkable that an alternative solution using something like
 
-   $count{lc($_)}++ for split('', "supercalifragilisticexpialidocious");
+   $count2{lc($_)}++ for split('', "supercalifragilisticexpialidocious");
    printf "%3d '%s'\n", $count2{$_}, $_ for ( qw{ a e i o u } );
 
 is considerably slower.)


### PR DESCRIPTION
Merge pull request https://github.com/d-c-d/perl5/pull/1 from d-c-d/d-c-d-patch-issue-22263

address typo in issue #22263 
https://github.com/Perl/perl5/issues/22263 
