### PR TITLE
Simplify builtin.pm

### DIFF
--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -1,13 +1,11 @@
-package builtin 0.014;
+package builtin 0.015;
 
-use strict;
-use warnings;
+use v5.40;
 
 # All code, including &import, is implemented by always-present
 # functions in the perl interpreter itself.
 # See also `builtin.c` in perl source
 
-1;
 __END__
 
 =head1 NAME


### PR DESCRIPTION
Replace explicit strict/warnings with use current version. This halves the number of packages a -E will load, from:
```
$ perl -E 'say for sort keys %INC'
builtin.pm
feature.pm
strict.pm
warnings.pm
```
To just builtin and feature. (pre-5.40 was just feature.pm).

While this .pm does very little and we could easily get away without using strict or warnings I prefer that we dogfood best practices and doing so allows us to remove the explicit return true so it costs us nothing in verbosity.