### PR TITLE
bytes_(to|from_utf8) functions  no longer experimental

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -739,7 +739,7 @@ Adp	|int	|bytes_cmp_utf8 |NN const U8 *b 			\
 				|STRLEN blen				\
 				|NN const U8 *u 			\
 				|STRLEN ulen
-AMdpx	|U8 *	|bytes_from_utf8|NN const U8 *s 			\
+AMdp	|U8 *	|bytes_from_utf8|NN const U8 *s 			\
 				|NN STRLEN *lenp			\
 				|NN bool *is_utf8p
 CTdpx	|U8 *	|bytes_from_utf8_loc					\
@@ -747,7 +747,7 @@ CTdpx	|U8 *	|bytes_from_utf8_loc					\
 				|NN STRLEN *lenp			\
 				|NN bool *is_utf8p			\
 				|NULLOK const U8 **first_unconverted
-Adpx	|U8 *	|bytes_to_utf8	|NN const U8 *s 			\
+Adp	|U8 *	|bytes_to_utf8	|NN const U8 *s 			\
 				|NN STRLEN *lenp
 AOdp	|SSize_t|call_argv	|NN const char *sub_name		\
 				|I32 flags				\


### PR DESCRIPTION
I don't know why these have been marked such for so long, but I think it's time to remove that.

They have been updated when necessary, and I see no reason for others not to use them.