### PR TITLE
UTF8_CHK_SKIP: Remove redundancy

### DIFF
--- a/utf8.h
+++ b/utf8.h
@@ -801,8 +801,7 @@ C<L</UTF8_SAFE_SKIP>>, for example when interfacing with a C library.
 */
 
 #define UTF8_CHK_SKIP(s)                                                       \
-            (UNLIKELY(s[0] == '\0') ? 1 : MIN(UTF8SKIP(s),                     \
-                                    my_strnlen((char *) (s), UTF8SKIP(s))))
+           (UNLIKELY(s[0] == '\0') ? 1 : my_strnlen((char *) (s), UTF8SKIP(s)))
 /*
 
 =for apidoc Am|STRLEN|UTF8_SAFE_SKIP|char* s|char* e


### PR DESCRIPTION
We don't have to do the MIN() because my_strnlen() returns the min anyway.