### PR TITLE
t/run/todo.t: Avoid "Odd number of elements" warning

### DIFF
--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -22,8 +22,6 @@ use warnings;
 # it is redundant to the test demonstrating the bug that was intentionally
 # fixed, so can be removed altogether.)
 
-my $switches = "";
-
 our $TODO;
 TODO: {
     local $TODO = "GH 16250";
@@ -33,7 +31,10 @@ TODO: {
         "abcde5678" =~ / b .* (*plb:(*plb:(.{4}))? (.{5}) ) .$ /x;
         print $1 // "undef", ":", $2 // "undef", "\n";
         EOF
-    "undef:de567\nundef:de567", { $switches }, "");
+        "undef:de567\nundef:de567",
+        {}, # Anonymous hash must have even number of elements
+        ""
+    );
 }
 
 done_testing();


### PR DESCRIPTION
The third argument to t/test.pl's fresh_perl_is() function is an anonymous hash; therefore, it must have an even number of elements.  In this case, that even number would be 0.  As it stood, we were getting this warning:

"Odd number of elements in anonymous hash at run/todo.t line 30."