### PR TITLE
Account for missing field SVs in object instances during method start…

### DIFF
--- a/t/class/destruct.t
+++ b/t/class/destruct.t
@@ -57,4 +57,23 @@ package DestructionNotify {
     is($destroyed, "zyx", 'Destruction notify triggered by object destruction in the correct order');
 }
 
+# GH22278
+{
+    my $observed;
+
+    class Testcase2 {
+        field $f1 :param :reader;
+        field $f2 :param :reader;
+        method DESTROY {
+            $observed = $f1;
+        }
+    }
+
+    my $e = eval { Testcase2->new( f1 => "field 1" ); 1 } ? undef : $@;
+    pass('Testcase2 constructor did not segfault');
+    like($e, qr/^Required parameter 'f2' is missing for "Testcase2" constructor at /,
+        'Constructor throws but does not crash');
+    is($observed, "field 1", 'Prior field is still initialised correctly');
+}
+
 done_testing;


### PR DESCRIPTION
In case of DESTROY aborting a constructor

Fixes #22278