### PR TITLE
perl.h: Convert reentrant locks to allow many readers, avoid deadlock if hold write lock then request it as read-only

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -6450,6 +6450,21 @@ EXTCONST U8   PL_deBruijn_bitpos_tab64[];
         CLANG_DIAG_RESTORE                                                  \
     } STMT_END
 
+#  define PERL_REENTRANT_READ_LOCK(name, mutex, counter)                    \
+    STMT_START {                                                            \
+        CLANG_DIAG_IGNORE(-Wthread-safety)                                  \
+        if (counter <= 0) {                                                 \
+            assert(counter == 0);                                           \
+            PERL_READ_LOCK(mutex);                                          \
+        }                                                                   \
+        else {                                                              \
+            /* This thread already has a write lock on this mutex.  Just    \
+             * increment the number of readers it has */                    \
+            (mutex)->readers_count++;                                       \
+        }                                                                   \
+        CLANG_DIAG_RESTORE                                                  \
+    } STMT_END
+
 #  define PERL_REENTRANT_UNLOCK(name, mutex, counter)                       \
     STMT_START {                                                            \
         if (LIKELY(counter == 1)) {                                         \
@@ -6473,6 +6488,27 @@ EXTCONST U8   PL_deBruijn_bitpos_tab64[];
                 __FILE__, __LINE__, counter));                              \
             )                                                               \
         }                                                                   \
+    } STMT_END
+
+#  define PERL_REENTRANT_READ_UNLOCK(name, mutex, counter)                  \
+    STMT_START {                                                            \
+        CLANG_DIAG_IGNORE(-Wthread-safety)                                  \
+        if (counter <= 0) {                                                 \
+            assert(count == 0);                                             \
+            PERL_READ_UNLOCK(mutex);                                        \
+        }                                                                   \
+        else if (LIKELY((mutex)->readers_count > 0)) {                      \
+            /* This thread already has a write lock on this mutex.  Just    \
+             * deccrement the number of readers it has */                   \
+            (mutex)->readers_count--;                                       \
+        }                                                                   \
+        else {                                                              \
+            Perl_croak_nocontext("panic: %s: %d: attempting to read unlock" \
+                                 " already unlocked " name "; counter was"  \
+                                 " %zd\n", __FILE__, __LINE__,              \
+                                 (mutex)->readers_count);                   \
+        }                                                                   \
+        CLANG_DIAG_RESTORE                                                  \
     } STMT_END
 
 #endif

--- a/perl.h
+++ b/perl.h
@@ -6386,13 +6386,17 @@ EXTCONST U8   PL_deBruijn_bitpos_tab64[];
 #  define PERL_SET_THX(t)		NOOP
 #endif
 
+/* Create a reentrant lock mechanism.  Currently these are also
+ * many-readers/1-writer locks, simply because that's all that is so far needed
+ * */
 #ifdef WIN32
     /* Windows mutexes are all general semaphores; we don't currently bother
      * with reproducing the same panic behavior as on other systems */
 #  define PERL_REENTRANT_LOCK(name, mutex, counter,                         \
                               cond_to_panic_if_already_locked)              \
-        MUTEX_LOCK(mutex)
-#  define PERL_REENTRANT_UNLOCK(name, mutex, counter)  MUTEX_UNLOCK(mutex)
+        PERL_WRITE_LOCK(mutex)
+
+#  define PERL_REENTRANT_UNLOCK(name, mutex, counter)  PERL_WRITE_UNLOCK(mutex)
 #else
 
     /* Simulate a general (or recursive) semaphore on 'mutex' whose name will
@@ -6421,7 +6425,7 @@ EXTCONST U8   PL_deBruijn_bitpos_tab64[];
                                 "%s: %d: locking " name "; lock depth=1\n", \
                                 __FILE__, __LINE__));                       \
             )                                                               \
-            MUTEX_LOCK(mutex);                                         \
+            PERL_WRITE_LOCK(mutex);                                         \
             counter = 1;                                                    \
             UNLESS_PERL_MEM_LOG(DEBUG_Lv(PerlIO_printf(Perl_debug_log,      \
                                 "%s: %d: " name " locked; lock depth=1\n",  \
@@ -6454,7 +6458,7 @@ EXTCONST U8   PL_deBruijn_bitpos_tab64[];
                           __FILE__, __LINE__));                             \
             )                                                               \
             counter = 0;                                                    \
-            MUTEX_UNLOCK(mutex);                                       \
+            PERL_WRITE_UNLOCK(mutex);                                       \
         }                                                                   \
         else if (counter <= 0) {                                            \
             Perl_croak_nocontext("panic: %s: %d: attempting to unlock"      \
@@ -7389,11 +7393,10 @@ typedef struct am_table_short AMTS;
                         }                                                   \
                     } STMT_END
 #  endif
-
-#  define LOCALE_INIT           MUTEX_INIT(&PL_locale_mutex)
-#  define LOCALE_TERM           STMT_START {                                \
-                                    LOCALE_TERM_POSIX_2008_;                \
-                                    MUTEX_DESTROY(&PL_locale_mutex);        \
+#  define LOCALE_INIT           PERL_RW_MUTEX_INIT(&PL_locale_mutex)
+#  define LOCALE_TERM           STMT_START {                                  \
+                                    LOCALE_TERM_POSIX_2008_;                  \
+                                    PERL_RW_MUTEX_DESTROY(&PL_locale_mutex);  \
                                 } STMT_END
 #endif
 

--- a/perlvars.h
+++ b/perlvars.h
@@ -99,7 +99,7 @@ PERLVARI(G, mmap_page_size, IV, 0)
 #if defined(USE_ITHREADS)
 PERLVAR(G, hints_mutex, perl_mutex)    /* Mutex for refcounted he refcounting */
 PERLVAR(G, env_mutex, perl_RnW1_mutex_t)      /* Mutex for accessing ENV */
-PERLVAR(G, locale_mutex, perl_mutex)   /* Mutex related to locale handling */
+PERLVAR(G, locale_mutex, perl_RnW1_mutex_t)   /* Mutex related to locale handling */
 #endif
 
 #ifdef USE_POSIX_2008_LOCALE


### PR DESCRIPTION
This is in preparation for future use of these.
The only current mutex that is reentrant is the one for locales.
