### PR TITLE
 Fix up and make sv_strftime_ints() public

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3434,7 +3434,7 @@ Adm	|bool	|sv_streq	|NULLOK SV *sv1 			\
 Adp	|bool	|sv_streq_flags |NULLOK SV *sv1 			\
 				|NULLOK SV *sv2 			\
 				|const U32 flags
-EXpx	|SV *	|sv_strftime_ints					\
+Adp	|SV *	|sv_strftime_ints					\
 				|NN SV *fmt				\
 				|int sec				\
 				|int min				\
@@ -3442,8 +3442,6 @@ EXpx	|SV *	|sv_strftime_ints					\
 				|int mday				\
 				|int mon				\
 				|int year				\
-				|int wday				\
-				|int yday				\
 				|int isdst
 Adp	|SV *	|sv_strftime_tm |NN SV *fmt				\
 				|NN const struct tm *mytm
@@ -4444,8 +4442,6 @@ S	|void	|ints_to_tm	|NN struct tm *my_tm			\
 				|int mday				\
 				|int mon				\
 				|int year				\
-				|int wday				\
-				|int yday				\
 				|int isdst
 S	|bool	|is_locale_utf8 |NN const char *locale
 S	|HV *	|my_localeconv	|const int item

--- a/embed.h
+++ b/embed.h
@@ -748,6 +748,7 @@
 # define sv_setuv(a,b)                          Perl_sv_setuv(aTHX_ a,b)
 # define sv_setuv_mg(a,b)                       Perl_sv_setuv_mg(aTHX_ a,b)
 # define sv_streq_flags(a,b,c)                  Perl_sv_streq_flags(aTHX_ a,b,c)
+# define sv_strftime_ints(a,b,c,d,e,f,g,h)      Perl_sv_strftime_ints(aTHX_ a,b,c,d,e,f,g,h)
 # define sv_strftime_tm(a,b)                    Perl_sv_strftime_tm(aTHX_ a,b)
 # define sv_string_from_errnum(a,b)             Perl_sv_string_from_errnum(aTHX_ a,b)
 # define sv_tainted(a)                          Perl_sv_tainted(aTHX_ a)
@@ -1315,7 +1316,7 @@
 #   endif /* defined(PERL_IN_HV_C) */
 #   if defined(PERL_IN_LOCALE_C)
 #     define get_locale_string_utf8ness_i(a,b,c,d) S_get_locale_string_utf8ness_i(aTHX_ a,b,c,d)
-#     define ints_to_tm(a,b,c,d,e,f,g,h,i,j,k)  S_ints_to_tm(aTHX_ a,b,c,d,e,f,g,h,i,j,k)
+#     define ints_to_tm(a,b,c,d,e,f,g,h,i)      S_ints_to_tm(aTHX_ a,b,c,d,e,f,g,h,i)
 #     define is_locale_utf8(a)                  S_is_locale_utf8(aTHX_ a)
 #     define my_localeconv(a)                   S_my_localeconv(aTHX_ a)
 #     define populate_hash_from_C_localeconv(a,b,c,d,e) S_populate_hash_from_C_localeconv(aTHX_ a,b,c,d,e)
@@ -1764,7 +1765,6 @@
 #   define skipspace_flags(a,b)                 Perl_skipspace_flags(aTHX_ a,b)
 #   define sv_magicext_mglob(a)                 Perl_sv_magicext_mglob(aTHX_ a)
 #   define sv_only_taint_gmagic                 Perl_sv_only_taint_gmagic
-#   define sv_strftime_ints(a,b,c,d,e,f,g,h,i,j) Perl_sv_strftime_ints(aTHX_ a,b,c,d,e,f,g,h,i,j)
 #   define utf16_to_utf8_base(a,b,c,d,e,f)      Perl_utf16_to_utf8_base(aTHX_ a,b,c,d,e,f)
 #   define utf8_to_utf16_base(a,b,c,d,e,f)      Perl_utf8_to_utf16_base(aTHX_ a,b,c,d,e,f)
 #   define validate_proto(a,b,c,d)              Perl_validate_proto(aTHX_ a,b,c,d)

--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -3582,8 +3582,7 @@ strftime(fmt, sec, min, hour, mday, mon, year, wday = -1, yday = -1, isdst = -1)
 	int		isdst
     CODE:
 	{
-            SV *sv = sv_strftime_ints(fmt, sec, min, hour, mday, mon, year,
-                                      wday, yday, isdst);
+            SV *sv = sv_strftime_ints(fmt, sec, min, hour, mday, mon, year, 0);
 	    if (sv) {
                 sv = sv_2mortal(sv);
             }

--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our ($AUTOLOAD, %SIGRT);
 
-our $VERSION = '2.20';
+our $VERSION = '2.21';
 
 require XSLoader;
 

--- a/locale.c
+++ b/locale.c
@@ -8241,17 +8241,17 @@ S_ints_to_tm(pTHX_ struct tm * mytm,
  && (defined(HAS_TM_TM_GMTOFF) || defined(HAS_TM_TM_ZONE))
 
     const char * orig_TIME_locale = toggle_locale_c(LC_TIME, locale);
-    struct tm mytm2 = *mytm;
+    struct tm aux_tm = *mytm;
     MKTIME_LOCK;
-    mktime(&mytm2);
+    mktime(&aux_tm);
     MKTIME_UNLOCK;
     restore_toggled_locale_c(LC_TIME, orig_TIME_locale);
 
 #  ifdef HAS_TM_TM_GMTOFF
-    mytm->tm_gmtoff = mytm2.tm_gmtoff;
+    mytm->tm_gmtoff = aux_tm.tm_gmtoff;
 #  endif
 #  ifdef HAS_TM_TM_ZONE
-    mytm->tm_zone = mytm2.tm_zone;
+    mytm->tm_zone = aux_tm.tm_zone;
 #  endif
 #endif
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -348,7 +348,12 @@ well.
 
 =item *
 
-XXX
+The L<perlapi/C<sv_strftime_ints>> function is introduced.  This is an
+enhanced version of L<perlapi/C<my_strftime>>, which is retained for
+backwards compatibility.  Both are to call L<strftime(3)> when you have
+the year, month, hour, etc.  The new function handles UTF8ness for you,
+and allows you to specify if you want the possibility of daylight
+savings time to be considered.  C<my_strftime> never considers DST.
 
 =back
 

--- a/proto.h
+++ b/proto.h
@@ -4900,7 +4900,7 @@ Perl_sv_streq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags);
 #define PERL_ARGS_ASSERT_SV_STREQ_FLAGS
 
 PERL_CALLCONV SV *
-Perl_sv_strftime_ints(pTHX_ SV *fmt, int sec, int min, int hour, int mday, int mon, int year, int wday, int yday, int isdst);
+Perl_sv_strftime_ints(pTHX_ SV *fmt, int sec, int min, int hour, int mday, int mon, int year, int isdst);
 #define PERL_ARGS_ASSERT_SV_STRFTIME_INTS       \
         assert(fmt)
 
@@ -6999,7 +6999,7 @@ S_get_locale_string_utf8ness_i(pTHX_ const char *string, const locale_utf8ness_t
 # define PERL_ARGS_ASSERT_GET_LOCALE_STRING_UTF8NESS_I
 
 STATIC void
-S_ints_to_tm(pTHX_ struct tm *my_tm, const char *locale, int sec, int min, int hour, int mday, int mon, int year, int wday, int yday, int isdst);
+S_ints_to_tm(pTHX_ struct tm *my_tm, const char *locale, int sec, int min, int hour, int mday, int mon, int year, int isdst);
 # define PERL_ARGS_ASSERT_INTS_TO_TM            \
         assert(my_tm); assert(locale)
 


### PR DESCRIPTION
This enhanced function now allows you to specify if you want the system
to consider the possibility of daylight savings time being in effect.
Formerly, it was never considered.  As a result, the function is good
enough to be made public.