### PR TITLE
bytes_from_utf8_loc() is no longer experimental

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -742,7 +742,7 @@ Adp	|int	|bytes_cmp_utf8 |NN const U8 *b 			\
 AMdp	|U8 *	|bytes_from_utf8|NN const U8 *s 			\
 				|NN STRLEN *lenp			\
 				|NN bool *is_utf8p
-CTdpx	|U8 *	|bytes_from_utf8_loc					\
+CTdp	|U8 *	|bytes_from_utf8_loc					\
 				|NN const U8 *s 			\
 				|NN STRLEN *lenp			\
 				|NN bool *is_utf8p			\


### PR DESCRIPTION
commit 06cd43176585d5d116c8eaea20e1df5ca7105b05 removed this mark from plain bytes_from_utf8().  This should follow suit.