### PR TITLE
class.c: store the stash in the constructor CV stash slot

### DIFF
--- a/class.c
+++ b/class.c
@@ -131,7 +131,7 @@ XS(injected_constructor)
 {
     dXSARGS;
 
-    HV *stash = (HV *)XSANY.any_sv;
+    HV *stash = CvSTASH(cv);
     assert(HvSTASH_IS_CLASS(stash));
 
     struct xpvhv_aux *aux = HvAUX(stash);
@@ -371,8 +371,7 @@ Perl_class_setup_stash(pTHX_ HV *stash)
         SAVEFREESV(newname);
 
         CV *newcv = newXS_flags(SvPV_nolen(newname), injected_constructor, __FILE__, NULL, nameflags);
-        CvXSUBANY(newcv).any_sv = (SV *)stash;
-        CvREFCOUNTED_ANYSV_on(newcv);
+        CvSTASH_set(newcv, stash);
     }
 
     /* TODO:


### PR DESCRIPTION
This code previously stored the stash for the class in the CV's any_cv slot, and marked that to be released when the CV is released.

But it does not bump the reference count of the stash that I can see.

When I tried releasing the constructor SV while working on #22169 I found perl would crash, incrementing the stash reference count prevents that, but leaves us with a reference loop.

But it turns out that CVs already have a slot to store their stash in and an API that correctly handles reference counting for that slot.

So use CvSTASH_set()/SvSTASH() to manage the stash for "$class::new" methods.