### PR TITLE
Use alert control character as quoting character in INPUT templates

### DIFF
--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -2107,13 +2107,13 @@ sub generate_init {
     }
     if ($self->{defaults}->{$var} eq 'NO_INIT') {
       $self->{deferred} .= $self->eval_input_typemap_code(
-        qq/"\\n\\tif (items >= $num) {\\n$expr;\\n\\t}\\n"/,
+        qq/qq\a\\n\\tif (items >= $num) {\\n$expr;\\n\\t}\\n\a/,
         $eval_vars
       );
     }
     else {
       $self->{deferred} .= $self->eval_input_typemap_code(
-        qq/"\\n\\tif (items < $num)\\n\\t    $var = $self->{defaults}->{$var};\\n\\telse {\\n$expr;\\n\\t}\\n"/,
+        qq/qq\a\\n\\tif (items < $num)\\n\\t    $var = $self->{defaults}->{$var};\\n\\telse {\\n$expr;\\n\\t}\\n\a/,
         $eval_vars
       );
     }
@@ -2123,15 +2123,15 @@ sub generate_init {
       print ";\n";
     }
     else {
-      $self->eval_input_typemap_code(qq/print "\\t$var;\\n"/, $eval_vars);
+      $self->eval_input_typemap_code(qq/print qq\a\\t$var;\\n\a/, $eval_vars);
     }
     $self->{deferred}
-      .= $self->eval_input_typemap_code(qq/"\\n$expr;\\n"/, $eval_vars);
+      .= $self->eval_input_typemap_code(qq/qq\a\\n$expr;\\n\a/, $eval_vars);
   }
   else {
     die "panic: do not know how to handle this branch for function pointers"
       if $printed_name;
-    $self->eval_input_typemap_code(qq/print "$expr;\\n"/, $eval_vars);
+    $self->eval_input_typemap_code(qq/print qq\a$expr;\\n\a/, $eval_vars);
   }
 }
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -11,7 +11,7 @@ use Symbol;
 
 our $VERSION;
 BEGIN {
-  $VERSION = '3.51';
+  $VERSION = '3.52';
   require ExtUtils::ParseXS::Constants; ExtUtils::ParseXS::Constants->VERSION($VERSION);
   require ExtUtils::ParseXS::CountLines; ExtUtils::ParseXS::CountLines->VERSION($VERSION);
   require ExtUtils::ParseXS::Utilities; ExtUtils::ParseXS::Utilities->VERSION($VERSION);

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Symbol;
 
-our $VERSION = '3.51';
+our $VERSION = '3.52';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
@@ -1,7 +1,7 @@
 package ExtUtils::ParseXS::CountLines;
 use strict;
 
-our $VERSION = '3.51';
+our $VERSION = '3.52';
 
 our $SECTION_END_MARKER;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
@@ -2,7 +2,7 @@ package ExtUtils::ParseXS::Eval;
 use strict;
 use warnings;
 
-our $VERSION = '3.51';
+our $VERSION = '3.52';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
@@ -5,7 +5,7 @@ use Exporter;
 use File::Spec;
 use ExtUtils::ParseXS::Constants ();
 
-our $VERSION = '3.51';
+our $VERSION = '3.52';
 
 our (@ISA, @EXPORT_OK);
 @ISA = qw(Exporter);

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Cmd.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Cmd.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::Cmd;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.51';
+our $VERSION = '3.52';
 
 use ExtUtils::Typemaps;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/InputMap.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/InputMap.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::InputMap;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.51';
+our $VERSION = '3.52';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/OutputMap.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/OutputMap.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::OutputMap;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.51';
+our $VERSION = '3.52';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Type.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Type.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 require ExtUtils::Typemaps;
 
-our $VERSION = '3.51';
+our $VERSION = '3.52';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/perlxs.pod
+++ b/dist/ExtUtils-ParseXS/lib/perlxs.pod
@@ -2209,7 +2209,7 @@ this model, the less likely conflicts will occur.
 =head1 XS VERSION
 
 This document covers features supported by C<ExtUtils::ParseXS>
-(also known as C<xsubpp>) 3.51
+(also known as C<xsubpp>) 3.52
 
 =head1 AUTHOR DIAGNOSTICS
 

--- a/lib/ExtUtils/typemap
+++ b/lib/ExtUtils/typemap
@@ -71,9 +71,9 @@ T_SVREF
 		    $var = SvRV(xsub_tmp_sv);
 		}
 		else{
-		    Perl_croak_nocontext(\"%s: %s is not a reference\",
-				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-				\"$var\");
+		    Perl_croak_nocontext("%s: %s is not a reference",
+				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq["$pname"]},
+				"$var");
 		}
 	} STMT_END
 T_SVREF_REFCOUNT_FIXED
@@ -84,9 +84,9 @@ T_SVREF_REFCOUNT_FIXED
 		    $var = SvRV(xsub_tmp_sv);
 		}
 		else{
-		    Perl_croak_nocontext(\"%s: %s is not a reference\",
-				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-				\"$var\");
+		    Perl_croak_nocontext("%s: %s is not a reference",
+				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq["$pname"]},
+				"$var");
 		}
 	} STMT_END
 T_AVREF
@@ -97,9 +97,9 @@ T_AVREF
 		    $var = (AV*)SvRV(xsub_tmp_sv);
 		}
 		else{
-		    Perl_croak_nocontext(\"%s: %s is not an ARRAY reference\",
-				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-				\"$var\");
+		    Perl_croak_nocontext("%s: %s is not an ARRAY reference",
+				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq["$pname"]},
+				"$var");
 		}
 	} STMT_END
 T_AVREF_REFCOUNT_FIXED
@@ -110,9 +110,9 @@ T_AVREF_REFCOUNT_FIXED
 		    $var = (AV*)SvRV(xsub_tmp_sv);
 		}
 		else{
-		    Perl_croak_nocontext(\"%s: %s is not an ARRAY reference\",
-				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-				\"$var\");
+		    Perl_croak_nocontext("%s: %s is not an ARRAY reference",
+				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq["$pname"]},
+				"$var");
 		}
 	} STMT_END
 T_HVREF
@@ -123,9 +123,9 @@ T_HVREF
 		    $var = (HV*)SvRV(xsub_tmp_sv);
 		}
 		else{
-		    Perl_croak_nocontext(\"%s: %s is not a HASH reference\",
-				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-				\"$var\");
+		    Perl_croak_nocontext("%s: %s is not a HASH reference",
+				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq["$pname"]},
+				"$var");
 		}
 	} STMT_END
 T_HVREF_REFCOUNT_FIXED
@@ -136,9 +136,9 @@ T_HVREF_REFCOUNT_FIXED
 		    $var = (HV*)SvRV(xsub_tmp_sv);
 		}
 		else{
-		    Perl_croak_nocontext(\"%s: %s is not a HASH reference\",
-				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-				\"$var\");
+		    Perl_croak_nocontext("%s: %s is not a HASH reference",
+				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq["$pname"]},
+				"$var");
 		}
 	} STMT_END
 T_CVREF
@@ -149,9 +149,9 @@ T_CVREF
 		SvGETMAGIC(xsub_tmp_sv);
                 $var = sv_2cv(xsub_tmp_sv, &st, &gvp, 0);
 		if (!$var) {
-		    Perl_croak_nocontext(\"%s: %s is not a CODE reference\",
-				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-				\"$var\");
+		    Perl_croak_nocontext("%s: %s is not a CODE reference",
+				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq["$pname"]},
+				"$var");
 		}
 	} STMT_END
 T_CVREF_REFCOUNT_FIXED
@@ -162,9 +162,9 @@ T_CVREF_REFCOUNT_FIXED
 		SvGETMAGIC(xsub_tmp_sv);
                 $var = sv_2cv(xsub_tmp_sv, &st, &gvp, 0);
 		if (!$var) {
-		    Perl_croak_nocontext(\"%s: %s is not a CODE reference\",
-				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-				\"$var\");
+		    Perl_croak_nocontext("%s: %s is not a CODE reference",
+				${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq["$pname"]},
+				"$var");
 		}
 	} STMT_END
 T_SYSRET
@@ -209,59 +209,59 @@ T_PTRREF
 	    $var = INT2PTR($type,tmp);
 	}
 	else
-	    Perl_croak_nocontext(\"%s: %s is not a reference\",
-			${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-			\"$var\")
+	    Perl_croak_nocontext("%s: %s is not a reference",
+			${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq["$pname"]},
+			"$var")
 T_REF_IV_REF
-	if (sv_isa($arg, \"${ntype}\")) {
+	if (sv_isa($arg, "$ntype")) {
 	    IV tmp = SvIV((SV*)SvRV($arg));
 	    $var = *INT2PTR($type *, tmp);
 	}
 	else {
-		const char* refstr = SvROK($arg) ? \"\" : SvOK($arg) ? \"scalar \" : \"undef\";
-	    Perl_croak_nocontext(\"%s: Expected %s to be of type %s; got %s%\" SVf \" instead\",
-			${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-			\"$var\", \"$ntype\",
+		const char* refstr = SvROK($arg) ? "" : SvOK($arg) ? "scalar " : "undef";
+	    Perl_croak_nocontext("%s: Expected %s to be of type %s; got %s%" SVf " instead",
+			${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq["$pname"]},
+			"$var", "$ntype",
 			refstr, $arg
 		);
 	}
 T_REF_IV_PTR
-	if (sv_isa($arg, \"${ntype}\")) {
+	if (sv_isa($arg, "$ntype")) {
 	    IV tmp = SvIV((SV*)SvRV($arg));
 	    $var = INT2PTR($type, tmp);
 	}
 	else {
-		const char* refstr = SvROK($arg) ? \"\" : SvOK($arg) ? \"scalar \" : \"undef\";
-	    Perl_croak_nocontext(\"%s: Expected %s to be of type %s; got %s%\" SVf \" instead\",
-			${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-			\"$var\", \"$ntype\",
+		const char* refstr = SvROK($arg) ? "" : SvOK($arg) ? "scalar " : "undef";
+	    Perl_croak_nocontext("%s: Expected %s to be of type %s; got %s%" SVf " instead",
+			${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq["$pname"]},
+			"$var", "$ntype",
 			refstr, $arg
 		);
 	}
 T_PTROBJ
-	if (SvROK($arg) && sv_derived_from($arg, \"${ntype}\")) {
+	if (SvROK($arg) && sv_derived_from($arg, "$ntype")) {
 	    IV tmp = SvIV((SV*)SvRV($arg));
 	    $var = INT2PTR($type,tmp);
 	}
 	else {
-		const char* refstr = SvROK($arg) ? \"\" : SvOK($arg) ? \"scalar \" : \"undef\";
-	    Perl_croak_nocontext(\"%s: Expected %s to be of type %s; got %s%\" SVf \" instead\",
-			${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-			\"$var\", \"$ntype\",
+		const char* refstr = SvROK($arg) ? "" : SvOK($arg) ? "scalar " : "undef";
+	    Perl_croak_nocontext("%s: Expected %s to be of type %s; got %s%" SVf " instead",
+			${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq["$pname"]},
+			"$var", "$ntype",
 			refstr, $arg
 		);
 	}
 T_PTRDESC
-	if (sv_isa($arg, \"${ntype}\")) {
+	if (sv_isa($arg, "$ntype")) {
 	    IV tmp = SvIV((SV*)SvRV($arg));
 	    ${type}_desc = (\U${type}_DESC\E*) tmp;
 	    $var = ${type}_desc->ptr;
 	}
 	else {
-		const char* refstr = SvROK($arg) ? \"\" : SvOK($arg) ? \"scalar \" : \"undef\";
-	    Perl_croak_nocontext(\"%s: Expected %s to be of type %s; got %s%\" SVf \" instead\",
-			${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-			\"$var\", \"$ntype\",
+		const char* refstr = SvROK($arg) ? "" : SvOK($arg) ? "scalar " : "undef";
+	    Perl_croak_nocontext("%s: Expected %s to be of type %s; got %s%" SVf " instead",
+			${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq["$pname"]},
+			"$var", "$ntype",
 			refstr, $arg
 		);
 	}
@@ -271,19 +271,19 @@ T_REFREF
 	    $var = *INT2PTR($type,tmp);
 	}
 	else
-	    Perl_croak_nocontext(\"%s: %s is not a reference\",
-			${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-			\"$var\")
+	    Perl_croak_nocontext("%s: %s is not a reference",
+			${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq["$pname"]},
+			"$var")
 T_REFOBJ
-	if (sv_isa($arg, \"${ntype}\")) {
+	if (sv_isa($arg, "$ntype")) {
 	    IV tmp = SvIV((SV*)SvRV($arg));
 	    $var = *INT2PTR($type,tmp);
 	}
 	else {
-		const char* refstr = SvROK($arg) ? \"\" : SvOK($arg) ? \"scalar \" : \"undef\";
-	    Perl_croak_nocontext(\"%s: Expected %s to be of type %s; got %s%\" SVf \" instead\",
-			${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq[\"$pname\"]},
-			\"$var\", \"$ntype\",
+		const char* refstr = SvROK($arg) ? "" : SvOK($arg) ? "scalar " : "undef";
+	    Perl_croak_nocontext("%s: Expected %s to be of type %s; got %s%" SVf " instead",
+			${$ALIAS?\q[GvNAME(CvGV(cv))]:\qq["$pname"]},
+			"$var", "$ntype",
 			refstr, $arg
 		);
 	}
@@ -376,13 +376,13 @@ T_PTR
 T_PTRREF
 	sv_setref_pv($arg, Nullch, (void*)$var);
 T_REF_IV_REF
-	sv_setref_pv($arg, \"${ntype}\", (void*)new $ntype($var));
+	sv_setref_pv($arg, "$ntype", (void*)new $ntype($var));
 T_REF_IV_PTR
-	sv_setref_pv($arg, \"${ntype}\", (void*)$var);
+	sv_setref_pv($arg, "$ntype", (void*)$var);
 T_PTROBJ
-	sv_setref_pv($arg, \"${ntype}\", (void*)$var);
+	sv_setref_pv($arg, "$ntype", (void*)$var);
 T_PTRDESC
-	sv_setref_pv($arg, \"${ntype}\", (void*)new\U${type}_DESC\E($var));
+	sv_setref_pv($arg, "$ntype", (void*)new\U${type}_DESC\E($var));
 T_REFREF
 	NOT_IMPLEMENTED
 T_REFOBJ


### PR DESCRIPTION
This way, one no longer needs to escape double quotes inside an input template. It also cleans up the standard typemaps to make use of this.

Parsexs has done this for OUTPUT templates since the very beginning, I can't find any reason for why we weren't also doing it for INPUT templates.