### PR TITLE
avoid casting away const in a couple of silly places

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -4217,7 +4217,7 @@ implementation stolen from PostgreSQL.
 PERL_STATIC_INLINE Size_t
 Perl_my_strnlen(const char *str, Size_t maxlen)
 {
-    const char *end = (char *) memchr(str, '\0', maxlen);
+    const char *end = (const char *) memchr(str, '\0', maxlen);
 
     PERL_ARGS_ASSERT_MY_STRNLEN;
 

--- a/utf8.h
+++ b/utf8.h
@@ -801,7 +801,7 @@ C<L</UTF8_SAFE_SKIP>>, for example when interfacing with a C library.
 */
 
 #define UTF8_CHK_SKIP(s)                                                       \
-           (UNLIKELY(s[0] == '\0') ? 1 : my_strnlen((char *) (s), UTF8SKIP(s)))
+           (UNLIKELY(s[0] == '\0') ? 1 : my_strnlen((const char *) (s), UTF8SKIP(s)))
 /*
 
 =for apidoc Am|STRLEN|UTF8_SAFE_SKIP|char* s|char* e


### PR DESCRIPTION
See the commit messages for how to reproduce the cast-qual warnings.
