### PR TITLE
OP_PADSV_STORE: only in void context

### DIFF
--- a/ext/B/t/optree_varinit.t
+++ b/ext/B/t/optree_varinit.t
@@ -264,13 +264,15 @@ checkOptree ( name	=> 'sub {my $a=()}',
 	      expect	=> <<'EOT_EOT', expect_nt => <<'EONT_EONT');
 1  <;> nextstate(main -439 optree.t:105) v:>,<,%
 2  <0> stub sP
-3  <1> padsv_store[$a:1516,1517] sKS/LVINTRO
-4  <1> leavesub[1 ref] K/REFC,1
+3  <0> padsv[$a:1567,1568] sRM*/LVINTRO
+4  <2> sassign sKS/2
+5  <1> leavesub[1 ref] K/REFC,1
 EOT_EOT
 # 1  <;> nextstate(main 438 optree_varinit.t:247) v:>,<,%
 # 2  <0> stub sP
-# 3  <1> padsv_store[$a:1516,1517] sKS/LVINTRO
-# 4  <1> leavesub[1 ref] K/REFC,1
+# 3  <0> padsv[$a:1567,1568] sRM*/LVINTRO
+# 4  <2> sassign sKS/2
+# 5  <1> leavesub[1 ref] K/REFC,1
 EONT_EONT
 
 checkOptree ( name	=> 'sub {our $a=()}',
@@ -428,21 +430,23 @@ checkOptree ( name	=> 'scalar context state',
 # 2  <;> nextstate(main 2 -e:1) v:%,{,fea=15
 # 3  <|> once(other->4)[$:2,3] sK/1
 # 4      <$> const[IV 1] s
-# 5      <1> padsv_store[$x:2,3] sKS/LVINTRO,STATE
-#            goto 6
-# 9  <0> padsv[$x:2,3] sRM*/STATE
-# 6  <1> padsv_store[$y:2,3] vKS/LVINTRO
-# 7  <;> nextstate(main 3 -e:1) v:%,{,fea=15
-# 8  <@> leave[1 ref] vKP/REFC
+# 5      <0> padsv[$x:2,3] sRM*/LVINTRO,STATE
+# 6      <2> sassign sKS/2
+#            goto 7
+# a  <0> padsv[$x:2,3] sRM*/STATE
+# 7  <1> padsv_store[$y:2,3] vKS/LVINTRO
+# 8  <;> nextstate(main 3 -e:1) v:%,{,fea=15
+# 9  <@> leave[1 ref] vKP/REFC
 EOT_EOT
 # 1  <0> enter v
 # 2  <;> nextstate(main 2 -e:1) v:%,{,fea=15
 # 3  <|> once(other->4)[$:2,3] sK/1
 # 4      <$> const(IV 1) s
-# 5      <1> padsv_store[$x:2,3] sKS/LVINTRO,STATE
-#            goto 6
-# 9  <0> padsv[$x:2,3] sRM*/STATE
-# 6  <1> padsv_store[$y:2,3] vKS/LVINTRO
-# 7  <;> nextstate(main 3 -e:1) v:%,{,fea=15
-# 8  <@> leave[1 ref] vKP/REFC
+# 5      <0> padsv[$x:2,3] sRM*/LVINTRO,STATE
+# 6      <2> sassign sKS/2
+#            goto 7
+# a  <0> padsv[$x:2,3] sRM*/STATE
+# 7  <1> padsv_store[$y:2,3] vKS/LVINTRO
+# 8  <;> nextstate(main 3 -e:1) v:%,{,fea=15
+# 9  <@> leave[1 ref] vKP/REFC
 EONT_EONT

--- a/peep.c
+++ b/peep.c
@@ -3934,6 +3934,11 @@ Perl_rpeep(pTHX_ OP *o)
                   * child (PADSV), and gets to it via op_other rather
                   * than op_next. Don't try to optimize this. */
                  && (lval != rhs)
+                 /* For efficiency, pp_padsv_store() doesn't push its
+                  * result onto the stack. For the relatively rare case of
+                  * the $lex assignment not in void context, we just do it
+                  * the old slow way. */
+                 && OP_GIMME(o,0) == G_VOID
                ) {
                 /* SASSIGN's bitfield flags, such as op_moresib and
                  * op_slabbed, will be carried over unchanged. */

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -337,7 +337,8 @@ PP(pp_padsv_store)
         );
     SvSetMagicSV(targ, val);
 
-    rpp_replace_1_1_NN(targ);
+    assert(GIMME_V == G_VOID);
+    rpp_popfree_1_NN();
     return NORMAL;
 }
 

--- a/t/perf/opcount.t
+++ b/t/perf/opcount.t
@@ -707,7 +707,7 @@ test_opcount(0, "builtin::true/false are replaced with constants",
                 });
 
 test_opcount(0, "builtin::is_bool is replaced with direct opcode",
-                sub { my $x; my $y; $y = builtin::is_bool($x); },
+                sub { my $x; my $y; $y = builtin::is_bool($x); 1; },
                 {
                     entersub => 0,
                     is_bool  => 1,
@@ -787,12 +787,12 @@ test_opcount(0, "builtin::is_tainted is replaced with direct opcode",
                     is_tainted => 1,
                 });
 
-# sassign + padsv combinations are replaced by padsv_store
+# void sassign + padsv combinations are replaced by padsv_store
 test_opcount(0, "sassign + padsv replaced by padsv_store",
-                sub { my $y; my $z = $y = 3; },
+                sub { my $y; my $z = $y = 3; 1; },
                 {
-                    padsv        => 1,
-                    padsv_store  => 2,
+                    padsv        => 2,
+                    padsv_store  => 1,
                 });
 
 # OPpTARGET_MY optimizations on undef
@@ -955,7 +955,7 @@ test_opcount(0, "Empty anonlist and direct lexical assignment",
                     sassign   => 0,
                 });
 test_opcount(0, "Empty anonlist ref and direct lexical assignment",
-                sub { my $x = \[] },
+                sub { my $x = \[]; 1; },
                 {
                     anonlist    => 0,
                     emptyavhv   => 1,
@@ -1000,7 +1000,7 @@ test_opcount(0, "Empty anonhash and direct lexical assignment",
                     sassign   => 0,
                 });
 test_opcount(0, "Empty anonhash ref and direct lexical assignment",
-                sub { my $x = \{} },
+                sub { my $x = \{}; 1 },
                 {
                     anonhash    => 0,
                     emptyavhv   => 1,


### PR DESCRIPTION
(The original commit, v5.39.6-108-gc90e7ed39e, was reverted by v5.39.8-35-gdc524b6cbd, and is now being re-applied. Originally it broke some CPAN distributions and as it was near code-freeze time and was only an optimisation, it seemed better to leave it for later. Since we're now early in the cycle of 5.41.x, there's more time to fix up any fallout.)

----

For the optimisation which converts $lex  = expr into an OP_PADSV_STORE op, only optimise if the scalar assign is in VOID context.

This allows us to stop pp_padsv_store() from uselessly pushing the result onto the stack, only to be immediately popped again by the following nextstate or unstack op. This becomes more important on PERL_RC_STACK builds, as each push or pop involves manipulating the SV's reference count.

I'm working on the assumption that scalar/list/unknown cxt lexical assigns are rare enough that not optimising them is less of a loss than optimising the void case. So:

    $lex = ....;             # void:    now even faster
    $other = $lex = ...;     # scalar:  now slow again
    foo($lex = ..., ....);   # list:    now slow again

    sub {
        ....
        $lex = ...;          # unknown: now slow again
    }