### PR TITLE
Apostrophe in name removal

### DIFF
--- a/cpan/Scalar-List-Utils/ListUtil.xs
+++ b/cpan/Scalar-List-Utils/ListUtil.xs
@@ -1947,8 +1947,10 @@ PREINIT:
     STRLEN namelen;
     const char* nameptr = SvPV(name, namelen);
     int utf8flag = SvUTF8(name);
+#if PERL_VERSION_LT(5, 41, 0)
     int quotes_seen = 0;
     bool need_subst = FALSE;
+#endif
 PPCODE:
     if (!SvROK(sub) && SvGMAGICAL(sub))
         mg_get(sub);
@@ -1971,19 +1973,24 @@ PPCODE:
         if (s > nameptr && *s == ':' && s[-1] == ':') {
             end = s - 1;
             begin = ++s;
+#if PERL_VERSION_LT(5, 41, 0)
             if (quotes_seen)
                 need_subst = TRUE;
+#endif
         }
+#if PERL_VERSION_LT(5, 41, 0)
         else if (s > nameptr && *s != '\0' && s[-1] == '\'') {
             end = s - 1;
             begin = s;
             if (quotes_seen++)
                 need_subst = TRUE;
         }
+#endif
     }
     s--;
     if (end) {
         SV* tmp;
+#if PERL_VERSION_LT(5, 41, 0)
         if (need_subst) {
             STRLEN length = end - nameptr + quotes_seen - (*end == '\'' ? 1 : 0);
             char* left;
@@ -2002,6 +2009,7 @@ PPCODE:
             stash = gv_stashpvn(left, length, GV_ADD | utf8flag);
         }
         else
+#endif
             stash = gv_stashpvn(nameptr, end - nameptr, GV_ADD | utf8flag);
         nameptr = begin;
         namelen -= begin - nameptr;

--- a/cpan/Scalar-List-Utils/lib/List/Util.pm
+++ b/cpan/Scalar-List-Utils/lib/List/Util.pm
@@ -16,7 +16,7 @@ our @EXPORT_OK  = qw(
   sample shuffle uniq uniqint uniqnum uniqstr zip zip_longest zip_shortest mesh mesh_longest mesh_shortest
   head tail pairs unpairs pairkeys pairvalues pairmap pairgrep pairfirst
 );
-our $VERSION    = "1.63";
+our $VERSION    = "1.63_01";
 our $XS_VERSION = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/cpan/Scalar-List-Utils/lib/List/Util/XS.pm
+++ b/cpan/Scalar-List-Utils/lib/List/Util/XS.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use List::Util;
 
-our $VERSION = "1.63";       # FIXUP
+our $VERSION = "1.63_01";       # FIXUP
 $VERSION =~ tr/_//d;         # FIXUP
 
 1;

--- a/cpan/Scalar-List-Utils/lib/Scalar/Util.pm
+++ b/cpan/Scalar-List-Utils/lib/Scalar/Util.pm
@@ -17,7 +17,7 @@ our @EXPORT_OK = qw(
   dualvar isdual isvstring looks_like_number openhandle readonly set_prototype
   tainted
 );
-our $VERSION    = "1.63";
+our $VERSION    = "1.63_01";
 $VERSION =~ tr/_//d;
 
 require List::Util; # List::Util loads the XS

--- a/cpan/Scalar-List-Utils/lib/Sub/Util.pm
+++ b/cpan/Scalar-List-Utils/lib/Sub/Util.pm
@@ -15,7 +15,7 @@ our @EXPORT_OK = qw(
   subname set_subname
 );
 
-our $VERSION    = "1.63";
+our $VERSION    = "1.63_01";
 $VERSION =~ tr/_//d;
 
 require List::Util; # as it has the XS

--- a/cpan/Scalar-List-Utils/t/exotic_names.t
+++ b/cpan/Scalar-List-Utils/t/exotic_names.t
@@ -45,7 +45,7 @@ sub caller3_ok {
         ),
     );
 
-    $expected =~ s/'/::/g;
+    $expected =~ s/'/::/g if $] < 5.041;
 
     # this is apparently how things worked before 5.16
     utf8::encode($expected) if $] < 5.016 and $ord > 255;
@@ -83,7 +83,8 @@ push @ordinal,
 
 plan tests => @ordinal * 2 * 3;
 
-my $legal_ident_char = "A-Z_a-z0-9'";
+my $legal_ident_char = "A-Z_a-z0-9";
+$legal_ident_char .= "'" if $] < 5.041;
 $legal_ident_char .= join '', map chr, 0x100, 0x498
     unless $] < 5.008;
 

--- a/cpan/parent/lib/parent.pm
+++ b/cpan/parent/lib/parent.pm
@@ -1,7 +1,7 @@
 package parent;
 use strict;
 
-our $VERSION = '0.241';
+our $VERSION = '0.241_001';
 
 sub import {
     my $class = shift;

--- a/cpan/parent/t/compile-time-file.t
+++ b/cpan/parent/t/compile-time-file.t
@@ -24,7 +24,7 @@ use lib 't/lib';
 
 {
     package Child3;
-    use parent "Dummy'Outside";
+    use if $] < 5.041, parent => "Dummy'Outside";
 }
 
 my $obj = {};
@@ -39,9 +39,13 @@ isa_ok $obj, 'Dummy::InlineChild';
 can_ok $obj, 'exclaim';
 is $obj->exclaim, "I CAN FROM Dummy::InlineChild", 'Inheritance is set up correctly for inlined classes';
 
+SKIP:
+{
+  skip "No ' in names from 5.041", 3 if $] >= 5.041;
 $obj = {};
 bless $obj, 'Child3';
 isa_ok $obj, 'Dummy::Outside';
 can_ok $obj, 'exclaim';
 is $obj->exclaim, "I CAN FROM Dummy::Outside", "Inheritance is set up correctly for classes inherited from via '";
 
+}

--- a/embed.fnc
+++ b/embed.fnc
@@ -2995,12 +2995,6 @@ EXpx	|char * |scan_word	|NN char *s				\
 				|STRLEN destlen 			\
 				|int allow_package			\
 				|NN STRLEN *slp
-EXpx	|char * |scan_word6	|NN char *s				\
-				|NN char *dest				\
-				|STRLEN destlen 			\
-				|int allow_package			\
-				|NN STRLEN *slp 			\
-				|bool warn_tick
 Cp	|U32	|seed
 : Only used by perl.c/miniperl.c, but defined in caretx.c
 ep	|void	|set_caret_X
@@ -5894,8 +5888,7 @@ S	|void	|parse_ident	|NN char **s				\
 				|NN char * const e			\
 				|int allow_package			\
 				|bool is_utf8				\
-				|bool check_dollar			\
-				|bool tick_warn
+				|bool check_dollar
 S	|int	|pending_ident
 RS	|char * |scan_const	|NN char *start
 RS	|char * |scan_formline	|NN char *s

--- a/embed.h
+++ b/embed.h
@@ -1629,7 +1629,7 @@
 #     define lop(a,b,c)                         S_lop(aTHX_ a,b,c)
 #     define missingterm(a,b)                   S_missingterm(aTHX_ a,b)
 #     define no_op(a,b)                         S_no_op(aTHX_ a,b)
-#     define parse_ident(a,b,c,d,e,f,g)         S_parse_ident(aTHX_ a,b,c,d,e,f,g)
+#     define parse_ident(a,b,c,d,e,f)           S_parse_ident(aTHX_ a,b,c,d,e,f)
 #     define pending_ident()                    S_pending_ident(aTHX)
 #     define scan_const(a)                      S_scan_const(aTHX_ a)
 #     define scan_formline(a)                   S_scan_formline(aTHX_ a)
@@ -1765,7 +1765,6 @@
 #   define report_uninit(a)                     Perl_report_uninit(aTHX_ a)
 #   define scan_str(a,b,c,d,e)                  Perl_scan_str(aTHX_ a,b,c,d,e)
 #   define scan_word(a,b,c,d,e)                 Perl_scan_word(aTHX_ a,b,c,d,e)
-#   define scan_word6(a,b,c,d,e,f)              Perl_scan_word6(aTHX_ a,b,c,d,e,f)
 #   define skipspace_flags(a,b)                 Perl_skipspace_flags(aTHX_ a,b)
 #   define sv_magicext_mglob(a)                 Perl_sv_magicext_mglob(aTHX_ a)
 #   define sv_only_taint_gmagic                 Perl_sv_only_taint_gmagic

--- a/gv.c
+++ b/gv.c
@@ -1179,7 +1179,7 @@ Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN le
          * method name.
          *
          * leaves last_separator pointing to the beginning of the
-         * last package separator (either ' or ::) or 0
+         * last package separator (::) or 0
          * if none was found.
          *
          * leaves name pointing at the beginning of the
@@ -1188,11 +1188,7 @@ Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN le
         const char *name_cursor = name;
         const char * const name_em1 = name_end - 1; /* name_end minus 1 */
         for (name_cursor = name; name_cursor < name_end ; name_cursor++) {
-            if (*name_cursor == '\'') {
-                last_separator = name_cursor;
-                name = name_cursor + 1;
-            }
-            else if (name_cursor < name_em1 && *name_cursor == ':' && name_cursor[1] == ':') {
+            if (name_cursor < name_em1 && *name_cursor == ':' && name_cursor[1] == ':') {
                 last_separator = name_cursor++;
                 name = name_cursor + 1;
             }
@@ -1802,7 +1798,6 @@ S_parse_gv_stash_name(pTHX_ HV **stash, GV **gv, const char **name,
     const char *name_cursor;
     const char *const name_end = nambeg + full_len;
     const char *const name_em1 = name_end - 1;
-    char smallbuf[64]; /* small buffer to avoid a malloc when possible */
 
     PERL_ARGS_ASSERT_PARSE_GV_STASH_NAME;
 
@@ -1816,8 +1811,7 @@ S_parse_gv_stash_name(pTHX_ HV **stash, GV **gv, const char **name,
 
     for (name_cursor = *name; name_cursor < name_end; name_cursor++) {
         if (name_cursor < name_em1 &&
-            ((*name_cursor == ':' && name_cursor[1] == ':')
-           || *name_cursor == '\''))
+            (*name_cursor == ':' && name_cursor[1] == ':'))
         {
             if (!*stash)
                 *stash = PL_defstash;
@@ -1831,22 +1825,6 @@ S_parse_gv_stash_name(pTHX_ HV **stash, GV **gv, const char **name,
                 if (*name_cursor == ':') {
                     key = *name;
                     *len += 2;
-                }
-                else { /* using ' for package separator */
-                    /* use our pre-allocated buffer when possible to save a malloc */
-                    char *tmpbuf;
-                    if ( *len+2 <= sizeof smallbuf)
-                        tmpbuf = smallbuf;
-                    else {
-                        /* only malloc once if needed */
-                        if (tmpfullbuf == NULL) /* only malloc&free once, a little more than needed */
-                            Newx(tmpfullbuf, full_len+2, char);
-                        tmpbuf = tmpfullbuf;
-                    }
-                    Copy(*name, tmpbuf, *len, char);
-                    tmpbuf[(*len)++] = ':';
-                    tmpbuf[(*len)++] = ':';
-                    key = tmpbuf;
                 }
                 gvp = (GV**)hv_fetch(*stash, key, is_utf8 ? -((I32)*len) : (I32)*len, add);
                 *gv = gvp ? *gvp : NULL;

--- a/lib/overload.t
+++ b/lib/overload.t
@@ -2399,7 +2399,7 @@ is eval {"$a"}, overload::StrVal($a),
 {
  package mane;
  use overload q\""\ => "bear::strength";
- use overload bool  => "bear'bouillon";
+ use overload bool  => "bear::bouillon";
 }
 @bear::ISA = 'food';
 sub food::strength { 'twine' }

--- a/mg.c
+++ b/mg.c
@@ -1853,7 +1853,7 @@ Perl_magic_setsig(pTHX_ SV *sv, MAGIC *mg)
              * access to a known hint bit in a known OP, we can't
              * tell whether HINT_STRICT_REFS is in force or not.
              */
-            if (!memchr(s, ':', len) && !memchr(s, '\'', len))
+            if (!memchr(s, ':', len))
                 Perl_sv_insert_flags(aTHX_ sv, 0, 0, STR_WITH_LEN("main::"),
                                      SV_GMAGIC);
             if (i)

--- a/op.c
+++ b/op.c
@@ -10758,7 +10758,7 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
            ec ? GV_NOADD_NOINIT
               :   (IN_PERL_RUNTIME && PL_curstash != CopSTASH(PL_curcop))
                || PL_curstash != PL_defstash
-               || memchr(name, ':', namlen) || memchr(name, '\'', namlen)
+               || memchr(name, ':', namlen)
                     ? gv_fetch_flags
                     : GV_ADDMULTI | GV_NOINIT | GV_NOTQUAL;
         gv = gv_fetchsv(cSVOPo->op_sv, flags, SVt_PVCV);
@@ -13419,7 +13419,6 @@ Perl_ck_method(pTHX_ OP *o)
 {
     SV *sv, *methsv, *rclass;
     const char* method;
-    char* compatptr;
     int utf8;
     STRLEN len, nsplit = 0, i;
     OP* new_op;
@@ -13429,14 +13428,6 @@ Perl_ck_method(pTHX_ OP *o)
     if (kid->op_type != OP_CONST) return o;
 
     sv = kSVOP->op_sv;
-
-    /* replace ' with :: */
-    while ((compatptr = (char *) memchr(SvPVX(sv), '\'',
-                                        SvEND(sv) - SvPVX(sv) )))
-    {
-        *compatptr = ':';
-        sv_insert(sv, compatptr - SvPVX_const(sv), 0, ":", 1);
-    }
 
     method = SvPVX_const(sv);
     len = SvCUR(sv);

--- a/pod/perldata.pod
+++ b/pod/perldata.pod
@@ -136,21 +136,16 @@ generic characters, and identifiers should match
 That is, any word character in the ASCII range, as long as the first
 character is not a digit.
 
-There are two package separators in Perl: A double colon (C<::>) and a single
-quote (C<'>).  Use of C<'> as the package separator is deprecated and will be
-removed in Perl 5.40.  Normal identifiers can start or end with a double
-colon, and can contain several parts delimited by double colons.  Single
-quotes have similar rules, but with the exception that they are not legal at
-the end of an identifier: That is, C<$'foo> and C<$foo'bar> are legal, but
-C<$foo'bar'> is not.
+There is one package separator in Perl: A double colon (C<::>).
+Normal identifiers can start or end with a double colon, and can
+contain several parts delimited by double colons.
+
+Previously you could use C<'> as a package separator, this was removed
+in Perl 5.42.
 
 Additionally, if the identifier is preceded by a sigil --
 that is, if the identifier is part of a variable name -- it
 may optionally be enclosed in braces.
-
-While you can mix double colons with singles quotes, the quotes must come
-after the colons: C<$::::'foo> and C<$foo::'bar> are legal, but C<$::'::foo>
-and C<$foo'::bar> are not.
 
 Put together, a grammar to match a basic identifier becomes
 
@@ -164,9 +159,9 @@ Put together, a grammar to match a basic identifier becomes
           )
       )
       (?<normal_identifier>
-          (?: :: )* '?
+          (?: :: )*
            (?&basic_identifier)
-           (?: (?= (?: :: )+ '? | (?: :: )* ' ) (?&normal_identifier) )?
+           (?: (?= :: ) (?&normal_identifier) )?
           (?: :: )*
       )
       (?<basic_identifier>

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -487,7 +487,7 @@ results.
 of Perl.  Check the #! line, or manually feed your script into
 Perl yourself.
 
-=item Bad name after %s
+=item Bad name after %s::
 
 (F) You started to name a symbol by using a package prefix, and then
 didn't finish the symbol.  In particular, you can't interpolate outside
@@ -4796,22 +4796,6 @@ take place when going past the end of the string when either
 C<sysread()>ing a file, or when seeking past the end of a scalar opened
 for I/O (in anticipation of future reads and to imitate the behavior
 with real files).
-
-=item Old package separator "'" deprecated
-
-(D deprecated::apostrophe_as_package_separator, syntax) You used the old package
-separator "'" in a variable, subroutine or package name. Support for the
-old package separator will be removed in Perl 5.42.
-
-=item Old package separator used in string
-
-(D deprecated::apostrophe_as_package_separator, syntax) You used the old package
-separator, "'", in a variable named inside a double-quoted string; e.g.,
-C<"In $name's house">. This is equivalent to C<"In $name::s house">. If
-you meant the former, put a backslash before the apostrophe
-(C<"In $name\'s house">).
-
-Support for the old package separator will be removed in Perl 5.42.
 
 =item Only scalar fields can take a :param attribute
 

--- a/pod/perlmod.pod
+++ b/pod/perlmod.pod
@@ -69,21 +69,6 @@ colon: C<$Package::Variable>.  If the package name is null, the
 C<main> package is assumed.  That is, C<$::sail> is equivalent to
 C<$main::sail>.
 
-The old package delimiter was a single quote, but double colon is now the
-preferred delimiter, in part because it's more readable to humans, and
-in part because it's more readable to B<emacs> macros.  It also makes C++
-programmers feel like they know what's going on--as opposed to using the
-single quote as separator, which was there to make Ada programmers feel
-like they knew what was going on.  Because the old-fashioned syntax is still
-supported for backwards compatibility, if you try to use a string like
-C<"This is $owner's house">, you'll be accessing C<$owner::s>; that is,
-the $s variable in package C<owner>, which is probably not what you meant.
-Use braces to disambiguate, as in C<"This is ${owner}'s house">.
-X<::> X<'>
-
-Using C<'> as a package separator is deprecated and will be removed in
-Perl 5.40.
-
 Packages may themselves contain package separators, as in
 C<$OUTER::INNER::var>.  This implies nothing about the order of
 name lookups, however.  There are no relative packages: all symbols
@@ -93,6 +78,9 @@ within package C<OUTER> that C<$INNER::var> refers to
 C<$OUTER::INNER::var>.  C<INNER> refers to a totally
 separate global package. The custom of treating package names as a
 hierarchy is very strong, but the language in no way enforces it.
+
+Previously you could use C<'> as a package separator, this was removed
+in Perl 5.42.
 
 Only identifiers starting with letters (or underscore) are stored
 in a package's symbol table.  All other symbols are kept in package

--- a/proto.h
+++ b/proto.h
@@ -4183,11 +4183,6 @@ Perl_scan_word(pTHX_ char *s, char *dest, STRLEN destlen, int allow_package, STR
 #define PERL_ARGS_ASSERT_SCAN_WORD              \
         assert(s); assert(dest); assert(slp)
 
-PERL_CALLCONV char *
-Perl_scan_word6(pTHX_ char *s, char *dest, STRLEN destlen, int allow_package, STRLEN *slp, bool warn_tick);
-#define PERL_ARGS_ASSERT_SCAN_WORD6             \
-        assert(s); assert(dest); assert(slp)
-
 PERL_CALLCONV U32
 Perl_seed(pTHX);
 #define PERL_ARGS_ASSERT_SEED
@@ -9309,7 +9304,7 @@ S_no_op(pTHX_ const char * const what, char *s);
         assert(what)
 
 STATIC void
-S_parse_ident(pTHX_ char **s, char **d, char * const e, int allow_package, bool is_utf8, bool check_dollar, bool tick_warn);
+S_parse_ident(pTHX_ char **s, char **d, char * const e, int allow_package, bool is_utf8, bool check_dollar);
 # define PERL_ARGS_ASSERT_PARSE_IDENT           \
         assert(s); assert(d); assert(e)
 

--- a/t/comp/package.t
+++ b/t/comp/package.t
@@ -18,14 +18,11 @@ $bar = 4;
 
 {
     package ABC;
-    no warnings qw(syntax deprecated);
     $blurfl = 5;
-    $main'a = $'b;
+    $main::a = $::b;
 }
-{
-    no warnings qw(syntax deprecated);
-    $ABC'dyick = 6;
-}
+
+$ABC::dyick = 6;
 
 $xyz = 2;
 
@@ -36,13 +33,10 @@ $ABC = join(':', sort(keys %ABC::));
 if ('a' lt 'A') {
     print $xyz eq 'bar:main:new:xyz:ABC' ? "ok 1\n" : "not ok 1 '$xyz'\n";
 } else {
-    print $xyz eq 'ABC:BEGIN:bar:main:new:xyz' ? "ok 1\n" : "not ok 1 '$xyz'\n";
-}    
-print $ABC eq 'BEGIN:blurfl:dyick' ? "ok 2\n" : "not ok 2 '$ABC'\n";
-{
-    no warnings qw(syntax deprecated);
-    print $main'blurfl == 123 ? "ok 3\n" : "not ok 3\n";
+    print $xyz eq 'ABC:bar:main:new:xyz' ? "ok 1\n" : "not ok 1 '$xyz'\n";
 }
+print $ABC eq 'blurfl:dyick' ? "ok 2\n" : "not ok 2 '$ABC'\n";
+print $main::blurfl == 123 ? "ok 3\n" : "not ok 3\n";
 
 package ABC;
 

--- a/t/comp/parser.t
+++ b/t/comp/parser.t
@@ -8,7 +8,7 @@ BEGIN {
     chdir 't' if -d 't';
 }
 
-print "1..191\n";
+print "1..189\n";
 
 sub failed {
     my ($got, $expected, $name) = @_;
@@ -222,8 +222,12 @@ EOF
 # tests for "Bad name"
 eval q{ foo::$bar };
 like( $@, qr/Bad name after foo::/, 'Bad name after foo::' );
-eval q{ foo''bar };
-like( $@, qr/Bad name after foo'/, 'Bad name after foo\'' );
+{
+    # since ' is no longer usable in symbols, the error is no longer "Bad name"
+    no warnings "syntax"; # suppress String found where operator expeected
+    eval q{ foo''bar };
+    like( $@, qr/syntax error at \(eval \d+\) line 1, near "foo''/, 'Syntax error for foo\'' );
+}
 
 # test for ?: context error
 eval q{($a ? $x : ($y)) = 5};
@@ -368,12 +372,11 @@ like($@, qr/BEGIN failed--compilation aborted/, 'BEGIN 7' );
 }
 
 {
-    no warnings;
     # [perl #113016] CORE::print::foo
-    sub CORE'print'foo { 43 } # apostrophes intentional; do not tempt fate
-    sub CORE'foo'bar { 43 }
+    sub CORE::print::foo { 43 }
+    sub CORE::foo::bar { 43 }
     is CORE::print::foo, 43, 'CORE::print::foo is not CORE::print ::foo';
-    is scalar eval "CORE::foo'bar", 43, "CORE::foo'bar is not an error";
+    is scalar eval "CORE::foo::bar", 43, "CORE::foo'bar is not an error";
 }
 
 # bug #71748
@@ -451,11 +454,6 @@ END
 eval 's/${<<END}//';
 eval 's//${<<END}/';
 print "ok ", ++$test, " - unterminated here-docs in s/// in string eval\n";
-{
-    no warnings qw(syntax deprecated);
-    sub 'Hello'_he_said (_);
-}
-is prototype "Hello::_he_said", '_', 'initial tick in sub declaration';
 
 {
     my @x = 'string';
@@ -473,21 +471,6 @@ is 1,1, ' no crash for "no ... syntax error"';
 for my $pkg(()){}
 $pkg = 3;
 is $pkg, 3, '[perl #114942] for my $foo()){} $foo';
-
-# Check that format 'Foo still works after removing the hack from
-# force_word
-{
-    no warnings qw(syntax deprecated);
-    $test++;
-    format 'one =
-ok @<< - format 'foo still works
-$test
-.
-}
-{
-    local $~ = "one";
-    write();
-}
 
 $test++;
 format ::two =

--- a/t/lib/croak/toke
+++ b/t/lib/croak/toke
@@ -353,7 +353,8 @@ has cxxc => (
 EXPECT
 Bareword found where operator expected (Do you need to predeclare "isa"?) at - line 9, near "isa => 'Int"
   (Might be a runaway multi-line '' string starting on line 4)
-Bad name after Int' at - line 9.
+syntax error at - line 9, near "isa => 'Int"
+Execution of - aborted due to compilation errors.
 ########
 # NAME Bad name after :: (with other helpful messages)
 sub has{}
@@ -610,4 +611,19 @@ EXPECT
 syntax error at - line 2, near "[
 =="
   (Might be a runaway multi-line // string starting on line 1)
+Execution of - aborted due to compilation errors.
+########
+# NAME tick in names: initial character of sub name
+sub 'Hello'_he_said (_);
+EXPECT
+Illegal declaration of anonymous subroutine at - line 1.
+########
+# NAME tick in names: initial character of format name
+    format 'one =
+ok @<< - format 'foo still works
+$test
+.
+EXPECT
+syntax error at - line 2, near "ok @<< - format '"
+  (Might be a runaway multi-line '' string starting on line 1)
 Execution of - aborted due to compilation errors.

--- a/t/lib/warnings/toke
+++ b/t/lib/warnings/toke
@@ -408,6 +408,10 @@ sort ("")
 EXPECT
 
 ########
+# NAME ' no longer is part of the symbol character set
+# previously these would parse like:
+# "${foo'bar}", but now they parse like "${foo}'bar"
+# and any ' parsing for symbols is now gone, so no warning
 @foo::bar = 1..3;
 () = "$foo'bar";
 () = "@foo'bar";
@@ -421,19 +425,8 @@ no warnings 'syntax', 'deprecated' ;
 () = "@foo'bar";
 () = "$#foo'bar";
 EXPECT
-Old package separator used in string at - line 2.
-	(Did you mean "$foo\'bar" instead?)
-Old package separator used in string at - line 3.
-	(Did you mean "@foo\'bar" instead?)
-Old package separator used in string at - line 4.
-	(Did you mean "$#foo\'bar" instead?)
-Old package separator used in string at - line 6.
-	(Did you mean "$foo\'bar" instead?)
-Old package separator used in string at - line 7.
-	(Did you mean "@foo\'bar" instead?)
-Old package separator used in string at - line 8.
-	(Did you mean "$#foo\'bar" instead?)
 ########
+# similar to the test above in that the parsing has changed
 use warnings 'syntax'; use utf8;
 @fooл::barл = 1..3;
 () = "$fooл'barл";
@@ -444,12 +437,7 @@ no warnings 'syntax', 'deprecated' ;
 () = "@fooл'barл";
 () = "$#fooл'barл";
 EXPECT
-Old package separator used in string at - line 3.
-	(Did you mean "$fooл\'barл" instead?)
-Old package separator used in string at - line 4.
-	(Did you mean "@fooл\'barл" instead?)
-Old package separator used in string at - line 5.
-	(Did you mean "$#fooл\'barл" instead?)
+Possible unintended interpolation of @fooл in string at - line 5.
 ########
 # NAME deprecation of ' in names
 sub foo'bar { 1 }
@@ -458,11 +446,8 @@ $a'b = 1;
 %a'd = ();
 package a'e;
 EXPECT
-Old package separator "'" deprecated at - line 1.
-Old package separator "'" deprecated at - line 2.
-Old package separator "'" deprecated at - line 3.
-Old package separator "'" deprecated at - line 4.
-Old package separator "'" deprecated at - line 5.
+OPTION fatal
+Illegal declaration of subroutine main::foo at - line 1.
 ########
 # toke.c
 use warnings 'ambiguous' ;

--- a/t/op/magic.t
+++ b/t/op/magic.t
@@ -5,7 +5,7 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc( '../lib' );
-    plan (tests => 208); # some tests are run in BEGIN block
+    plan (tests => 209); # some tests are run in BEGIN block
 }
 
 # Test that defined() returns true for magic variables created on the fly,
@@ -674,6 +674,14 @@ foreach my $sig (qw(__WARN__ INT)) {
     is delete $SIG{$sig}, 'main::' . lc $sig, "Can delete from $sig";
     is $SIG{$sig}, undef, "$sig is now gone";
     is delete $SIG{$sig}, undef, "$sig remains gone";
+}
+
+# test Perl_magic_setsig main:: qualification
+# this previously did it for names containing '
+{
+    local $SIG{INT} = "foo'bar";
+    is($SIG{INT}, "main::foo'bar",
+       "' in signal handler name no longer a package separator");
 }
 
 # And now one which doesn't exist;

--- a/t/op/method.t
+++ b/t/op/method.t
@@ -13,7 +13,7 @@ BEGIN {
 use strict;
 no warnings 'once';
 
-plan(tests => 163);
+plan(tests => 161);
 
 {
     # RT #126042 &{1==1} * &{1==1} would crash
@@ -253,12 +253,6 @@ sub OtherSouper::method { "Isidore Ropen, Draft Manager" }
    my @ret = $o->SUPER::method('whatever');
    ::is $ret[0], $o, 'object passed to SUPER::method';
    ::is $ret[1], 'whatever', 'argument passed to SUPER::method';
-   {
-       no warnings qw(syntax deprecated);
-       @ret = $o->SUPER'method('whatever');
-   }
-   ::is $ret[0], $o, "object passed to SUPER'method";
-   ::is $ret[1], 'whatever', "argument passed to SUPER'method";
    @ret = Saab->SUPER::method;
    ::is $ret[0], 'Saab', "package name passed to SUPER::method";
    @ret = OtherSaab->SUPER::method;

--- a/t/op/ref.t
+++ b/t/op/ref.t
@@ -272,10 +272,8 @@ is (join('', sort values %$anonhash2), 'BARXYZ');
 # Test bless operator.
 
 package MYHASH;
-{
-    no warnings qw(syntax deprecated);
-    $object = bless $main'anonhash2;
-}
+$object = bless $main::anonhash2;
+
 main::is (ref $object, 'MYHASH');
 main::is ($object->{ABC}, 'XYZ');
 
@@ -299,10 +297,7 @@ sub mymethod {
 $string = "bad";
 $object = "foo";
 $string = "good";
-{
-    no warnings qw(syntax deprecated);
-    $main'anonhash2 = "foo";
-}
+$main::anonhash2 = "foo";
 $string = "";
 
 DESTROY {
@@ -319,10 +314,7 @@ package OBJ;
 
 @ISA = ('BASEOBJ');
 
-{
-    no warnings qw(syntax deprecated);
-    $main'object = bless {FOO => 'foo', BAR => 'bar'};
-}
+$main::object = bless {FOO => 'foo', BAR => 'bar'};
 
 package main;
 
@@ -335,13 +327,10 @@ is ($object->doit("BAR"), 'bar');
 $foo = doit $object "FOO";
 main::is ($foo, 'foo');
 
-{
-    no warnings qw(syntax deprecated);
-    sub BASEOBJ'doit {
-        local $ref = shift;
-        die "Not an OBJ" unless ref $ref eq 'OBJ';
-        $ref->{shift()};
-    }
+sub BASEOBJ::doit {
+    local $ref = shift;
+    die "Not an OBJ" unless ref $ref eq 'OBJ';
+    $ref->{shift()};
 }
 
 package UNIVERSAL;

--- a/t/op/sort.t
+++ b/t/op/sort.t
@@ -240,7 +240,7 @@ eval <<'CODE';
     no warnings qw(deprecated syntax);
     my @result = sort main'Backwards 'one', 'two';
 CODE
-cmp_ok($@,'eq','',q(old skool package));
+cmp_ok($@,'ne','',q(old skool package));
 
 eval <<'CODE';
     # "sort 'one', 'two'" should not try to parse "'one" as a sort sub

--- a/t/op/stash.t
+++ b/t/op/stash.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc( qw(../lib) );
 }
 
-plan( tests => 55 );
+plan( tests => 54 );
 
 # Used to segfault (bug #15479)
 fresh_perl_like(
@@ -300,10 +300,6 @@ fresh_perl_is(
     ok eval { Bear::::baz() },
      'packages ending with :: are self-consistent';
 }
-
-# [perl #88138] ' not equivalent to :: before a null
-${"a'\0b"} = "c";
-is ${"a::\0b"}, "c", "' is equivalent to :: before a null";
 
 # [perl #101486] Clobbering the current package
 ok eval '

--- a/t/op/stash_parse_gv.t
+++ b/t/op/stash_parse_gv.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc(qw(../lib));
 }
 
-plan( tests => 5 );
+plan( tests => 3 );
 
 my $long  = 'x' x 100;
 my $short = 'abcd';
@@ -14,9 +14,7 @@ my $short = 'abcd';
 my @tests = (
     [ $long, 'long package name: one word' ],
     [ join( '::', $long, $long ), 'long package name: multiple words' ],
-    [ join( q['], $long, $long ), q[long package name: multiple words using "'" separator] ],
     [ join( '::', $long, $short, $long ), 'long & short package name: multiple words' ],
-    [ join( q['], $long, $short, $long ), q[long & short package name: multiple words using "'" separator] ],
 );
 
 foreach my $t (@tests) {

--- a/t/uni/package.t
+++ b/t/uni/package.t
@@ -9,9 +9,6 @@ BEGIN {
 
 plan (tests => 18);
 
-# Works on either ASCII or EBCDIC
-my $prefix = ("a" lt "A") ? "bar:BEGIN" : "BEGIN:bar";
-
 use utf8;
 use open qw( :utf8 :std );
 
@@ -37,23 +34,17 @@ ok 1, "sanity check. If we got this far, UTF-8 in package names is legal.";
         $ㄅĽuṞfⳐ = 5;
     }
     
-    {
-        no warnings qw(syntax deprecated);
-        $압Ƈ'd읯ⱪ = 6;        #'
-    }
+    $압Ƈ::d읯ⱪ = 6;
     
     $ꑭʑ = 2;
     
     $ꑭʑ = join(':', sort(keys %ꑭʑ::));
     $압Ƈ = join(':', sort(keys %압Ƈ::));
     
-    ::is $ꑭʑ, "$prefix:ニュー:ꑭʑ:압Ƈ", "comp/stash.t test 1";
+    ::is $ꑭʑ, "bar:ニュー:ꑭʑ:압Ƈ", "comp/stash.t test 1";
     ::is $압Ƈ, "d읯ⱪ:ㄅĽuṞfⳐ", "comp/stash.t test 2";
 
-    {
-        no warnings qw(syntax deprecated);
-        ::is $main'ㄅĽuṞfⳐ, 123, "comp/stash.t test 3";
-    }
+    ::is $main::ㄅĽuṞfⳐ, 123, "comp/stash.t test 3";
 
     package 압Ƈ;
 

--- a/t/uni/parser.t
+++ b/t/uni/parser.t
@@ -187,8 +187,12 @@ is ${"main::\345\225\217"}, undef, "..and using the encoded form doesn't";
 # tests for "Bad name"
 eval q{ Ｆｏｏ::$bar };
 like( $@, qr/Bad name after Ｆｏｏ::/, 'Bad name after Ｆｏｏ::' );
-eval q{ Ｆｏｏ''bar };
-like( $@, qr/Bad name after Ｆｏｏ'/, 'Bad name after Ｆｏｏ\'' );
+{
+    # since ' is no longer usable in symbols, the error is no longer "Bad name"
+    no warnings "syntax"; # suppress String found where operator expeected
+    eval q{ Ｆｏｏ''bar };
+    like( $@, qr/syntax error at \(eval \d+\) line 1, near \"Ｆｏｏ\'\'/, 'Syntax error for Ｆｏｏ\'' );
+}
 
 {
     no warnings 'utf8';

--- a/t/uni/stash.t
+++ b/t/uni/stash.t
@@ -13,7 +13,7 @@ BEGIN {
 use utf8;
 use open qw( :utf8 :std );
 
-plan( tests => 49 );
+plan( tests => 48 );
 
 #These come from op/my_stash.t
 {
@@ -283,8 +283,4 @@ plan( tests => 49 );
         ok eval { Bèàr::::bàz() },
         'packages ending with :: are self-consistent';
     }
-    
-    # [perl #88138] ' not equivalent to :: before a null
-    ${"à'\0b"} = "c";
-    is ${"à::\0b"}, "c", "' is equivalent to :: before a null";
 }

--- a/t/uni/variables.t
+++ b/t/uni/variables.t
@@ -14,7 +14,7 @@ use utf8;
 use open qw( :utf8 :std );
 no warnings qw(misc reserved);
 
-plan (tests => 66880);
+plan (tests => 66879);
 
 # ${single:colon} should not be treated as a simple variable, but as a
 # block with a label inside.
@@ -35,16 +35,11 @@ plan (tests => 66880);
         );
 }
 
-# ${yadda'etc} and ${yadda::etc} should both work under strict
+# and ${yadda::etc} should both work under strict
 {
     local $@;
     eval q<use strict; ${flark::fleem}>;
     is($@, '', q<${package::var} works>);
-
-    no warnings qw(syntax deprecated);
-    local $@;
-    eval q<use strict; ${fleem'flark}>;
-    is($@, '', q<...as does ${package'var}>);
 }
 
 # The first character in ${...} should respect the rules


### PR DESCRIPTION
Do the removal described in perldeprecation

=head3 Use of C<'> as a global name separator

Perl allows use of C<'> instead of C<::> to replace the parts of a
package or global variable name, for example C<A::B> and C<A'B> are
equivalent.

C<'> will no longer be recognized as a name separator in Perl 5.42.
