### PR TITLE
21_win32.t: provide reason why file is skipped

### DIFF
--- a/dist/Tie-File/t/21_win32.t
+++ b/dist/Tie-File/t/21_win32.t
@@ -14,7 +14,8 @@ use warnings;
 my $file = "tf21-$$.txt";
 
 unless ($^O =~ /^(MSWin32|dos)$/) {
-  print "1..0\n";
+  my $reason = 'not Win32';
+  print "1..0 # Skip: $reason\n";
   exit;
 }
 


### PR DESCRIPTION
Following example of dist/IO/t/io_pipe.t.