### PR TITLE
perlapi: Fix description of my_strftime()

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -8122,12 +8122,14 @@ S<C<SV *>>.
 This means the UTF-8ness of the result is unspecified.  The result MUST be
 arranged to be FREED BY THE CALLER).
 
-=item It has extra parameters C<yday>, C<wday> and C<is_dst>.
+=item The C<is_dst> parameter is ignored.
 
-These are completely ignored, and exist only for historical reasons.
+Daylight savings time is never considered to be in effect.
 
-Daylight savings time is never considered to be in effect, and C<yday> and
-C<wday> are calculated from the other arguments.
+=item It has extra parameters C<yday> and C<wday> that are ignored.
+
+These exist only for historical reasons; the values for the corresponding
+fields in S<C<struct tm>> are calculated from the other arguments.
 
 =back
 


### PR DESCRIPTION
I realized that the pod added in
86a9c18b6fab1949a26de790418b8b897a71e4ac is somewhat wrong. The is_dst parameter to my_stftime() also occurs in sv_strftime_ints(), but in the former it is ignored.