### PR TITLE
POSIX::strftime: Mark args as unused

### DIFF
--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -3601,6 +3601,10 @@ strftime(fmt, sec, min, hour, mday, mon, year, wday = -1, yday = -1, isdst = -1)
 	int		isdst
     CODE:
 	{
+            PERL_UNUSED_ARG(wday);
+            PERL_UNUSED_ARG(yday);
+            PERL_UNUSED_ARG(isdst);
+
             SV *sv = sv_strftime_ints(fmt, sec, min, hour, mday, mon, year, 0);
 	    if (sv) {
                 sv = sv_2mortal(sv);


### PR DESCRIPTION
This fixes GH #22308

The signature for this function sets these arguments to values, as they are optional.  But they are no longer actually used, so mark them as such to avoid a compiler warning.