### PR TITLE
vmsify: don't add dot when drop dots feature is active

### DIFF
--- a/vms/vms.c
+++ b/vms/vms.c
@@ -8843,16 +8843,6 @@ int_tovmsspec(const char *path, char *rslt, int dir_flag, int * utf8_flag)
         *(cp1++) = *(cp2++);
     }
   }
-  if ((no_type_seen == 1) && DECC_READDIR_DROPDOTNOTYPE) {
-  char *lcp1;
-    lcp1 = cp1;
-    lcp1--;
-     /* Fix me for "^]", but that requires making sure that you do
-      * not back up past the start of the filename
-      */
-    if ((*lcp1 != ']') && (*lcp1 != '*') && (*lcp1 != '%'))
-      *cp1++ = '.';
-  }
   *cp1 = '\0';
 
   if (utf8_flag != NULL)


### PR DESCRIPTION
When a feature to omit the trailing dot on files with no extension is enabled, we have been actually appending a dot since the huge omnibus patch f7ddb74ae664d8 19 years ago.  The implementation may have been done backwards from its intention, or it may have intended to add the dot only when it would get removed on a round trip back through unixify. Which raises the question why add it at all? So don't.

There are relatively few situations where the absence of the dot can cause trouble, notably when a specific application has its own default file type that we want to override.  But there are lots of situations where the presence of a dot causes trouble, such as File::Temp's confusion when its template that should end in 'XXXX' gets 'XXXX.' instead.

There is no change to default behavior here, only the behavior when DECC$READDIR_DROPDOTNOTYPE is present in the environment.