### PR TITLE
Move api declaration of hv_fetchs()

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -407,13 +407,6 @@ string/length pair.
 Like C<sv_setref_pvn>, but takes a literal string instead of
 a string/length pair.
 
-=for apidoc_section $HV
-
-=for apidoc Am|SV**|hv_fetchs|HV* tb|"key"|I32 lval
-Like C<hv_fetch>, but takes a literal string instead of a
-string/length pair.
-=for apidoc_section $lexer
-
 =cut
 */
 

--- a/hv.c
+++ b/hv.c
@@ -416,10 +416,11 @@ In C<hv_exists_ent>, the key is specified by the SV C<keysv>; its UTF8ness is
 the same as that SV.  There is an additional parameter, C<hash>, which can be a
 valid precomputed hash value, or 0 to ask for it to be computed.
 
-=for apidoc hv_fetch
-=for apidoc_item ||hv_fetchs|HV *hv|"key"|I32 lval
+=for apidoc      hv_fetch
+=for apidoc_item hv_fetchs
 
-These return the SV which corresponds to the specified key in the hash.
+These each return the SV which corresponds to the specified key in the hash.
+They differ only in how the key is specified.
 
 In C<hv_fetchs>, the key must be a C language string literal, enclosed in
 double quotes.  It is never treated as being in UTF-8.  There is no
@@ -427,6 +428,7 @@ length_parameter.
 
 In C<hv_fetch>, the absolute value of C<klen> is the length of the key.  If
 C<klen> is negative the key is assumed to be in UTF-8-encoded Unicode.
+C<key> may contain embedded NUL characters.
 
 In both, if C<lval> is set, then the fetch will be part of a store.  This means
 that if there is no value in the hash associated with the given key, then one

--- a/hv.h
+++ b/hv.h
@@ -557,6 +557,10 @@ whether it is valid to call C<HvAUX()>.
 #define hv_existss(hv, key) \
     hv_exists((hv), ASSERT_IS_LITERAL(key), (sizeof(key)-1))
 
+/*
+=for apidoc_defn Am|SV**|hv_fetchs|HV* hv|"key"|I32 lval
+=cut
+*/
 #define hv_fetchs(hv, key, lval) \
     hv_fetch((hv), ASSERT_IS_LITERAL(key), (sizeof(key)-1), (lval))
 


### PR DESCRIPTION
This moves it adjacent to where the macro is defined.  It did not belong in handy.h at all.  It also adds a bit of clarification to the actual pod