### PR TITLE
Clarify separate assignments are needed in the reverse as well

### DIFF
--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -238,6 +238,16 @@ Break this sort of statement up into separate assignments:
     ptr = SvPVbyte(s, len);
     foo(ptr, len);
 
+The reverse is also incorrect C<SvPVbyte(foo(x), len));> and must be split into
+separate assignments.
+
+   char *ptr;
+   STRLEN len;
+   SV *s = foo(x);
+   ptr = SvPVbyte(s, len);
+
+Failure to do so will likely result in a Segmentation fault.
+
 =back
 
 If you want to know if the scalar value is TRUE, you can use:


### PR DESCRIPTION
It took me a while to find my bug and when I did it took me quite a while to find the reference to "Also remember that C doesn't allow you to safely say C<foo(SvPVbyte(s, len), len);>". 

This clarification is based on the assumption that the reverse is true.  In my case it required separate assignments for versions 5.8.9, 5.10.1 and 5.34.3.  Interestingly 5.38.2 worked fine.

Not sure if this is worthy  of inclusion but could have helped me...

Also mention 'Segmentation fault' which might have saved me some time

```
SV* extractBioString(pTHX_ BIO* p_stringBio)
 {
      SV* sv;
      BUF_MEM* bptr;
 
      CHECK_OPEN_SSL(BIO_flush(p_stringBio) == 1);
      BIO_get_mem_ptr(p_stringBio, &bptr);
      sv = newSVpv(bptr->data, bptr->length);
 
      CHECK_OPEN_SSL(BIO_set_close(p_stringBio, BIO_CLOSE) == 1);
      BIO_free(p_stringBio);
      return sv;
 } 

const char * attribute_id;
STRLEN len

/* This will cause a segmentation fault */
attribute_id = SvPVbyte(extractBioString(aTHX_ attr_bio), len);

/* This correctly uses separate assignments */
SV * attr_sv = extractBioString(aTHX_ attr_bio);
attribute_id = SvPVbyte(attr_sv, len);

```

