### PR TITLE
add `&CORE::chdir` (properly)

### DIFF
--- a/gv.c
+++ b/gv.c
@@ -633,7 +633,6 @@ S_maybe_add_coresub(pTHX_ HV * const stash, GV *gv,
     case KEY_until: case KEY_use  : case KEY_when     : case KEY_while :
     case KEY_x    : case KEY_xor  : case KEY_y        :
         return NULL;
-    case KEY_chdir:
     case KEY_chomp: case KEY_chop: case KEY_defined: case KEY_delete:
     case KEY_eof  : case KEY_exec: case KEY_exists :
     case KEY_lstat:

--- a/lib/CORE.pod
+++ b/lib/CORE.pod
@@ -49,7 +49,7 @@ ampersand syntax and through references does not work for the following
 functions, as they have special syntax that cannot always be translated
 into a simple list (e.g., C<eof> vs C<eof()>):
 
-C<chdir>, C<chomp>, C<chop>, C<defined>, C<delete>, C<eof>, C<exec>,
+C<chomp>, C<chop>, C<defined>, C<delete>, C<eof>, C<exec>,
 C<exists>, C<lstat>, C<split>, C<stat>, C<system>, C<truncate>, C<unlink>
 
 =head1 OVERRIDING CORE FUNCTIONS

--- a/op.c
+++ b/op.c
@@ -14645,7 +14645,7 @@ Perl_ck_entersub_args_core(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
             /* Usually, OPf_SPECIAL on an op with no args means that it had
              * parens, but these have their own meaning for that flag: */
             && opnum != OP_VALUES && opnum != OP_KEYS && opnum != OP_EACH
-            && opnum != OP_DELETE && opnum != OP_EXISTS)
+            && opnum != OP_DELETE && opnum != OP_EXISTS && opnum != OP_CHDIR)
                 flags |= OPf_SPECIAL;
         /* excise cvop from end of sibling chain */
         op_sibling_splice(parent, prev, 1, NULL);

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -27,6 +27,14 @@ here, but most should go in the L</Performance Enhancements> section.
 
 [ List each enhancement as a =head2 entry ]
 
+=head2 More CORE:: subs
+
+C<chdir> has been added as a subroutine to the CORE:: namespace.
+
+Previously, code like C<&CORE::chdir($dir)> or C<< my $ref = \&CORE::chdir;
+$ref->($dir) >> would throw an error saying C<&CORE::chdir cannot be called
+directly>. These cases are now fully supported.
+
 =head1 Security
 
 XXX Any security-related notices go here.  In particular, any security

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -3905,9 +3905,11 @@ PP_wrapped(pp_chdir, MAXARG, 0)
     dSP; dTARGET;
     const char *tmps = NULL;
     GV *gv = NULL;
+    /* pp_coreargs pushes a NULL to indicate no args passed to
+     * CORE::chdir() */
+    SV * const sv = MAXARG == 1 ? POPs : NULL;
 
-    if( MAXARG == 1 ) {
-        SV * const sv = POPs;
+    if (sv) {
         if (PL_op->op_flags & OPf_SPECIAL) {
             gv = gv_fetchsv(sv, 0, SVt_PVIO);
             if (!gv) {

--- a/t/op/coreamp.t
+++ b/t/op/coreamp.t
@@ -405,6 +405,29 @@ sub {
   ::caller_test();
 }->();
 
+use if !is_miniperl, File::Spec::Functions, qw(curdir);
+
+test_proto 'chdir';
+unless (is_miniperl) {
+    $tests += 7;
+    my $good_dir = curdir();
+    my $bad_dir = 'no_such_dir+*?~';
+    is mychdir($good_dir), 1, 'mychdir(".") succeeds';
+    is mychdir($bad_dir), 0, 'mychdir($bad_dir) fails';
+    is &CORE::chdir($good_dir), 1, '&chdir(".") succeeds';
+    is &CORE::chdir($bad_dir), 0, '&chdir($bad_dir) fails';
+    {
+        local $ENV{HOME} = $good_dir;
+        is &CORE::chdir(), 1, '&chdir() succeeds with $ENV{HOME} = "."';
+        $ENV{HOME} = $bad_dir;
+        is &CORE::chdir(), 0, '&chdir() fails with $ENV{HOME} = $bad_dir';
+    }
+    {
+        delete local @ENV{qw(HOME LOGDIR SYS$LOGIN)};
+        is &CORE::chdir(), 0, '&chdir() fails with @ENV{qw(HOME LOGDIR SYS$LOGIN)} unset';
+    }
+}
+
 test_proto 'chmod';
 $tests += 3;
 is &CORE::chmod(), 0, '&chmod with no args';

--- a/t/op/coresubs.t
+++ b/t/op/coresubs.t
@@ -170,8 +170,13 @@ $tests++;
 # This subroutine is outside the warnings scope:
 sub foo { goto &CORE::abs }
 use warnings;
-$SIG{__WARN__} = sub { like shift, qr\^Use of uninitialized\ };
-foo(undef);
+{
+  local $SIG{__WARN__} = sub { like shift, qr\^Use of uninitialized\ };
+  foo(undef);
+}
+
+$tests++;
+is eval('mychdir(curdir())'), 1, "inlined chdir with parenthesized args accepts a string";
 
 $tests+=2;
 is runperl(prog => 'print CORE->lc, qq-\n-'), "core\n",


### PR DESCRIPTION
Previously, CORE::chdir was not "ampable", i.e. it could not be called
through a coderef or with a sigil: `&CORE::chdir($dir);`

The only thing allowed was to make a compile-time alias, whose calls
would then be inlined to chdir again:

    BEGIN { *foo = \&CORE::chdir; }
    foo ".";  # actually does chdir "."

However, this was broken if the function call used parentheses, in which
case chdir would always try to use its argument as a filehandle, not the
name of a directory:

    BEGIN { *foo = \&CORE::chdir; }
    foo(".");
    # Triggers a warning:
    # chdir() on unopened filehandle . at file line 2.

This commit fixes the problem and makes chdir fully "ampable", so
`&CORE::chdir()` no longer triggers the `&CORE::chdir cannot be called
directly` error.