### PR TITLE
perlapi: Move macro defns to where defined

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1614,8 +1614,6 @@ p	|bool	|io_close	|NN IO *io				\
 				|NULLOK GV *gv				\
 				|bool is_explicit			\
 				|bool warn_on_fail
-APRTdm	|bool	|is_ascii_string|NN const U8 * const s			\
-				|STRLEN len
 ARTdip	|Size_t |isC9_STRICT_UTF8_CHAR					\
 				|NN const U8 * const s0 		\
 				|NN const U8 * const e
@@ -1637,9 +1635,6 @@ dp	|bool	|isinfnansv	|NN SV *sv
 Cp	|bool	|_is_in_locale_category 				\
 				|const bool compiling			\
 				|const int category
-APRTdm	|bool	|is_invariant_string					\
-				|NN const U8 * const s			\
-				|STRLEN len
 ARdp	|I32	|is_lvalue_sub
 : used to check for NULs in pathnames and other names
 ARdip	|bool	|is_safe_syscall|NN const char *pv			\
@@ -1702,9 +1697,6 @@ ATdip	|bool	|is_utf8_fixed_width_buf_loclen_flags			\
 CRp	|bool	|_is_utf8_FOO	|const U8 classnum			\
 				|NN const U8 *p 			\
 				|NN const U8 * const e
-ARTdmo	|bool	|is_utf8_invariant_string				\
-				|NN const U8 * const s			\
-				|STRLEN len
 ARTdip	|bool	|is_utf8_invariant_string_loc				\
 				|NN const U8 * const s			\
 				|STRLEN len				\

--- a/inline.h
+++ b/inline.h
@@ -1310,7 +1310,7 @@ so the name C<is_utf8_invariant_string> is preferred.
 See also
 C<L</is_utf8_string>> and C<L</is_utf8_fixed_width_buf_flags>>.
 
-=for apidoc_defn is_utf8_invariant_string bool|NN const U8 * const s|STRLEN len
+=for apidoc_defn ARTm|bool|is_utf8_invariant_string|NN const U8 * const s|STRLEN len
 
 =cut
 

--- a/proto.h
+++ b/proto.h
@@ -1815,21 +1815,11 @@ Perl_io_close(pTHX_ IO *io, GV *gv, bool is_explicit, bool warn_on_fail)
         assert(io)
 
 /* PERL_CALLCONV bool
-is_ascii_string(const U8 * const s, STRLEN len)
-        __attribute__warn_unused_result__
-        __attribute__pure__; */
-
-/* PERL_CALLCONV bool
 is_c9strict_utf8_string(const U8 *s, STRLEN len)
         __attribute__warn_unused_result__; */
 
 /* PERL_CALLCONV bool
 is_c9strict_utf8_string_loc(const U8 *s, STRLEN len, const U8 **ep); */
-
-/* PERL_CALLCONV bool
-is_invariant_string(const U8 * const s, STRLEN len)
-        __attribute__warn_unused_result__
-        __attribute__pure__; */
 
 PERL_CALLCONV I32
 Perl_is_lvalue_sub(pTHX)
@@ -1862,10 +1852,6 @@ is_utf8_fixed_width_buf_flags(const U8 * const s, STRLEN len, const U32 flags); 
 
 /* PERL_CALLCONV bool
 is_utf8_fixed_width_buf_loc_flags(const U8 * const s, STRLEN len, const U8 **ep, const U32 flags); */
-
-/* PERL_CALLCONV bool
-is_utf8_invariant_string(const U8 * const s, STRLEN len)
-        __attribute__warn_unused_result__; */
 
 /* PERL_CALLCONV bool
 is_utf8_string(const U8 *s, STRLEN len)

--- a/utf8.h
+++ b/utf8.h
@@ -127,8 +127,8 @@ typedef enum {
 #define FOLD_FLAGS_NOMIX_ASCII  0x4
 
 /*
-=for apidoc_defn is_ascii_string     bool|NN const U8 * const s|STRLEN len
-=for apidoc_defn is_invariant_string bool|NN const U8 * const s|STRLEN len
+=for apidoc_defn APRTdm|bool|is_ascii_string|NN const U8 * const s|STRLEN len
+=for apidoc_defn APRTdm|bool|is_invariant_string|NN const U8 * const s|STRLEN len
 =cut
 */
 #define is_ascii_string(s, len)     is_utf8_invariant_string(s, len)


### PR DESCRIPTION
This moves the API definitions of is_ascii_string, is_invariant_string, and is_utf8_invariant_string to the spots in the source code where each is #defined, thus making it easier to maintain