### PR TITLE
perlapi, perlintern: Show all function signatures

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -497,10 +497,6 @@
 :
 :          embed.h: suppress "#define foo Perl_foo"
 :
-:        autodoc.pl adds a note that this function must be explicitly called as
-:        Perl_$name, and with an aTHX_ parameter unless the 'T' flag is also
-:        specified.
-:
 :        mnemonic: 'omit' generated macro
 :
 :   'P'  Pure function:


### PR DESCRIPTION
Suppose someone wants to use the long name of an element in these pods.  I realized that there was no way to know its signature, or even if such a name exists without also looking through the source code.
     
For example, macros don't have long names, and that an item is is a macro or not was not shown.  Some long names take a pTHX, and some don't.  This also wasn't shown.
     
This commit simply shows all legal signatures, eliminating all ambiguity.  It enables not having to output the warning messages that certain forms aren't available; as that fact is immediately known.
