### PR TITLE
t/op/chdir.t: clean up old 'no warnings' declarations

### DIFF
--- a/t/op/chdir.t
+++ b/t/op/chdir.t
@@ -166,8 +166,6 @@ sub clean_env {
 }
 
 END {
-    no warnings 'uninitialized';
-
     # Restore the environment for VMS (and doesn't hurt for anyone else)
     @ENV{@magic_envs} = @Saved_Env{@magic_envs};
 
@@ -178,9 +176,6 @@ END {
 
 
 foreach my $key (@magic_envs) {
-    # We're going to be using undefs a lot here.
-    no warnings 'uninitialized';
-
     clean_env;
     $ENV{$key} = catdir $Cwd, 'op';
 


### PR DESCRIPTION
The test code has changed over the years: The literal undefs have been removed and other parts have been moved into helper functions, so the lexical `no warnings 'uninitialized'` declarations no longer serve any purpose.