### PR TITLE
Fix POSIX::strftime()

### DIFF
--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -3588,7 +3588,7 @@ difftime(time1, time2)
 #     sv_setpv(TARG, ...) could be used rather than
 #     ST(0) = sv_2mortal(newSVpv(...))
 void
-strftime(fmt, sec, min, hour, mday, mon, year, wday = -1, yday = -1, isdst = -1)
+strftime(fmt, sec, min, hour, mday, mon, year, wday = -1, yday = -1, isdst = 0)
 	SV *		fmt
 	int		sec
 	int		min
@@ -3603,9 +3603,11 @@ strftime(fmt, sec, min, hour, mday, mon, year, wday = -1, yday = -1, isdst = -1)
 	{
             PERL_UNUSED_ARG(wday);
             PERL_UNUSED_ARG(yday);
-            PERL_UNUSED_ARG(isdst);
 
-            SV *sv = sv_strftime_ints(fmt, sec, min, hour, mday, mon, year, 0);
+            /* -isdst triggers backwards compatibility mode for non-zero
+             * 'isdst' */
+            SV *sv = sv_strftime_ints(fmt, sec, min, hour, mday, mon, year,
+                                           -abs(isdst));
 	    if (sv) {
                 sv = sv_2mortal(sv);
             }

--- a/ext/POSIX/lib/POSIX.pod
+++ b/ext/POSIX/lib/POSIX.pod
@@ -1872,7 +1872,7 @@ Returns the string.
 Synopsis:
 
 	strftime(fmt, sec, min, hour, mday, mon, year,
-		 wday = -1, yday = -1, isdst = -1)
+		 wday = -1, yday = -1, isdst = 0)
 
 The month (C<mon>) begins at zero,
 I<e.g.>, January is 0, not 1.  The
@@ -1880,7 +1880,11 @@ year (C<year>) is given in years since 1900, I<e.g.>, the year 1995 is 95; the
 year 2001 is 101.  Consult your system's C<strftime()> manpage for details
 about these and the other arguments.
 
-The C<wday>, C<yday>, and C<isdst> parameters are all ignored.
+The C<wday> and C<yday> parameters are both ignored.  Their values are
+always determinable from the other parameters.
+
+C<isdst> should be C<1> or C<0>, depending on whether or not daylight
+savings time is in effect for the given time or not.
 
 If you want your code to be portable, your format (C<fmt>) argument
 should use only the conversion specifiers defined by the ANSI C
@@ -1895,11 +1899,10 @@ The C<Z> specifier is notoriously unportable since the names of
 timezones are non-standard. Sticking to the numeric specifiers is the
 safest route.
 
-The given arguments are made consistent as though by calling
-C<mktime()> before calling your system's C<strftime()> function,
-except that the C<isdst> value is not affected, so that the returned
-value will always be as if the locale doesn't have daylight savings
-time.
+The arguments, except for C<isdst>, are made consistent as though by
+calling C<mktime()> before calling your system's C<strftime()> function.
+To get correct results, you must set C<isdst> to be the proper value.
+When omitted, the function assumes daylight savings is not in effect.
 
 The string for Tuesday, December 12, 1995 in the C<C> locale.
 

--- a/ext/POSIX/t/time.t
+++ b/ext/POSIX/t/time.t
@@ -9,7 +9,7 @@ use strict;
 
 use Config;
 use POSIX;
-use Test::More tests => 26;
+use Test::More tests => 27;
 
 # For the first go to UTC to avoid DST issues around the world when testing.  SUS3 says that
 # null should get you UTC, but some environments want the explicit names.
@@ -204,4 +204,13 @@ SKIP: {
     my $time = time();
     is(mktime(CORE::localtime($time)), $time, "mktime()");
     is(mktime(POSIX::localtime($time)), $time, "mktime()");
+}
+ 
+SKIP: {
+    skip "'%s' not implemented in strftime", 1 if $^O eq "VMS"
+                                               || $^O eq "MSWin32";
+    # Somewhat arbitrarily, put in 60 seconds of slack;  if this fails, it
+    # will likely be off by 1 hour
+    ok(abs(POSIX::strftime('%s', localtime) - time) < 60,
+       'GH #22351; pr: GH #22369');
 }


### PR DESCRIPTION
I don't know what to do about testing this.  The example furnished in the ticket uses the command line `date`  with the `%s` format, which I kind of doubt is portable.

This fixes GH #22351

The new sv_strftime_ints() API function acts consistently with regards to daylight savings time, with POSIX-mandated behavior, which takes the current locale into account.

POSIX::strftime() is problematic in regard to this.  This commit adds a backwards compatibility mode to preserve its behavior that inadvertently was changed by 86a9c18b6fab1949a26de790418b8b897a71e4ac.

These functions are intended to wrap libc strftime(), including normalizing the input values.  For example, if you pass 63 seconds as a value, they will typically change that to be 3 seconds into the next minute up.  In C, the mktime() function is typically called first to do that normalization.  (I don't know what happens if plain strftime() is called with unnormalized values.).  mktime() looks at the current locale, determines if daylight savings time is in effect, and adjusts accordingly.  Perl calls its own mktime-equivalent for you, eliminating the need for explicitly calling something that would need to always be called anyway, hence saving an extra step.

mini_mktime() is the Perl mktime-equivalent.  It is unaffected by locales, and does not consider the possibility of there being daylight savings time.  The problem is that libc strftime() is affected by locale, and does consider dst.  Perl uses these two functions together, and this inconsistency between them is bound to cause problems.

The 'isdst' parameter to POSIX::strftime() is used to indicate if daylight savings is in effect for the time and date given by the other parameters.  If perl used mktime() to normalize those values, it would calculate this for itself, using the passed-in value only as a hint. But since it uses mini_mktime(), it has to take that value as-is. Thus, daylight savings alone, out of all the input values, is not normalized.  This is contrary to the documentation, and I didn't know this when I wrote the blamed commit.

It turns out that typical uses of this function, like

    POSIX::strftime('%s', localtime)
    POSIX::strftime('%s', gmtime)

cause the correct 'isdst' to be passed.  But this is a defect in the interface that can bite you; changing it would cause cpan breakage.

I wrote the API function sv_strftime_ints() to not have these issues. And, to workaround a defect in the POSIX definition of mktime().  It turns out you can't tell it you don't want to adjust for dayight time, except by changing the locale to one that doesn't have dst, such as the "C" locale.  But this isn't a Perl-level function.