### PR TITLE
Perl_call_argv(): clean up the temps it creates when G_DISCARD is set

### DIFF
--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.36';
+our $VERSION = '1.37';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -2820,6 +2820,18 @@ call_argv(subname, flags, ...)
         EXTEND(SP, 1);
         PUSHs(sv_2mortal(newSViv(i)));
 
+bool
+call_argv_cleanup()
+  CODE:
+    IV old_count = PL_sv_count;
+    char one[] = "one"; /* non const strings */
+    char two[] = "two";
+    char *args[] = { one, two, NULL };
+    Perl_call_argv(aTHX_ "called_by_argv_cleanup", G_DISCARD | G_LIST, args);
+    RETVAL = PL_sv_count == old_count;
+  OUTPUT:
+    RETVAL
+
 void
 call_method(methname, flags, ...)
     char* methname

--- a/ext/XS-APItest/t/call.t
+++ b/ext/XS-APItest/t/call.t
@@ -11,7 +11,7 @@ use strict;
 
 BEGIN {
     require '../../t/test.pl';
-    plan(542);
+    plan(544);
     use_ok('XS::APItest')
 };
 use Config;
@@ -34,6 +34,13 @@ sub i {
 }
 call_sv_C();
 is($call_sv_count, 7, "call_sv_C passes");
+
+my $did_argv;
+sub called_by_argv_cleanup {
+    $did_argv++ if @_;
+}
+ok(call_argv_cleanup(), "call_argv() cleans up temps if asked to");
+ok($did_argv, "call_argv_cleanup() did the actual call with arguments");
 
 sub d {
     die "its_dead_jim\n";


### PR DESCRIPTION
We can only do this clean up for G_DISCARD since otherwise we might free the return values on the stack.

Fixes #22255