### PR TITLE
updateAUTHORS.pl: accept hyphens instead of underscores in all options

### DIFF
--- a/Porting/updateAUTHORS.pl
+++ b/Porting/updateAUTHORS.pl
@@ -81,9 +81,8 @@ sub main {
         \%opts,
         map {
             # support hyphens as well as underbars,
-            # underbars must be first. Only handles two
-            # part words right now.
-            ref $_ ? $_ : s/\b([a-z]+)_([a-z]+)\b/${1}_${2}|${1}-${2}/gr
+            # underbars must be first.
+            ref $_ ? $_ : s{\b([a-z]+(?:_[a-z]+)+)\b}{"$1|".($1 =~ tr/_/-/r)}egr
         } @OPTSPEC,
     ) or pod2usage(2);
     $opts{commit_range}= join " ", @ARGV;


### PR DESCRIPTION
Not just two-part words.