### PR TITLE
autodoc: Remove useless loop

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -1974,9 +1974,6 @@ for (sort keys %funcflags) {
     warn "no docs for $_\n";
 }
 
-for my $key (sort keys %deferreds) {
-    warn "no docs for $key\n";
-}
 
 foreach (sort keys %missing) {
     warn "Function '$_', documented in $missing{$_}, not listed in embed.fnc"


### PR DESCRIPTION
Commit ef302588bff6e9cead3506a3d6117d3edd1ca9e0 added this loop, but there was a logic error.  It also added a loop above it that completely empties the hash this loop is iterating over.  Hence there is never anything there by the time this loop is encountered.