### PR TITLE
Add tests for lvalue subs returning vec() or substr() and called twice in one expression

### DIFF
--- a/t/op/sub_lval.t
+++ b/t/op/sub_lval.t
@@ -5,7 +5,7 @@ BEGIN {
     require './test.pl';
     set_up_inc('../lib');
 }
-plan tests=>211;
+plan tests=>213;
 
 sub a : lvalue { my $a = 34; ${\(bless \$a)} }  # Return a temporary
 sub b : lvalue { ${\shift} }
@@ -1095,4 +1095,26 @@ is "@119797", "4 5 6", 'writing to array returned by bare block';
     }
     junkreturn = "b";
     is($x, "b", "junkreturn");
+}
+
+# v5.18 fails to return correct value from lvalue subroutine which returns
+# vec() and are called twice in rvalue context of one expression
+{
+    my $vec = '';
+    sub wrap_vec : lvalue {
+        vec($vec, $_[0], 8);
+    }
+    wrap_vec(0) = 3;
+    wrap_vec(1) = wrap_vec(0) + 2;
+    cmp_ok(wrap_vec(0) + wrap_vec(1), '==', 8, 'wrap_vec');
+}
+
+# Ditto for returning substr()
+{
+    my $str = 'hijk';
+    sub wrap_substr : lvalue {
+        substr($str, $_[0], 1);
+    }
+    wrap_substr(1) = 'o';
+    is(wrap_substr(1) . wrap_substr(3), 'ok', 'wrap_substr');
 }

--- a/t/op/sub_lval.t
+++ b/t/op/sub_lval.t
@@ -1098,7 +1098,7 @@ is "@119797", "4 5 6", 'writing to array returned by bare block';
 }
 
 # v5.18 fails to return correct value from lvalue subroutine which returns
-# vec() and are called twice in rvalue context of one expression
+# vec() and is called twice in rvalue context of one expression
 {
     my $vec = '';
     sub wrap_vec : lvalue {


### PR DESCRIPTION
I found that Perl prior to v5.20 (at least v5.16.3 bundled in CentOS Linux 7 and locally-built v5.18.4) fail to return correct value from subroutine returning `vec()` and `substr()` as lvalue but called multiple times in rvalue context of one expression:

    $ perl -wle 'my $x = "\002"; sub myvec1 :lvalue { vec($x, $_[0], 1) }' \
        -e 'print myvec1(0); print myvec1(1); print myvec1(0) + myvec1(1)'
    0
    1
    2
    $

This apparently had been fixed in the commit 169504d53dbeb12d5171b2b44e7db3c2b81af314 (in 2013), but testcases for these symptoms doesn't seem to exist so I'd like to add ones to prevent accidental regression.