### PR TITLE
INSTALL: clarify requirements and minor touch-ups

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -10,11 +10,11 @@ INSTALL - Build and Installation guide for perl 5.
 
 =head1 SYNOPSIS
 
-First, make sure you have an up-to-date version of Perl.  If you
-didn't get your Perl source from CPAN, check the latest version at
+First, make sure you have an up-to-date version of the Perl source code.  If
+you didn't get your Perl source from CPAN, check the latest version at
 L<https://www.cpan.org/src/>.  Perl uses a version scheme where even-numbered
-subreleases (like 5.8.x and 5.10.x) are stable maintenance releases and
-odd-numbered subreleases (like 5.7.x and 5.9.x) are unstable
+subreleases (like 5.38.x and 5.40.x) are stable maintenance releases and
+odd-numbered subreleases (like 5.39.x and 5.41.x) are unstable
 development releases.  Development releases should not be used in
 production environments.  Fixes and new features are first carefully
 tested in development releases and only if they prove themselves to be

--- a/INSTALL
+++ b/INSTALL
@@ -1,7 +1,7 @@
 # vim: syntax=pod
 
-If you read this file _as_is_, just ignore the funny characters you see.
-It is written in the POD format (see F<pod/perlpod.pod>) which is specially
+If you read this file _as_is_, just ignore the funny characters you see.  It is
+written in the POD format (see the file pod/perlpod.pod), which is specially
 designed to be readable as is.
 
 =head1 NAME

--- a/INSTALL
+++ b/INSTALL
@@ -33,10 +33,10 @@ Each of these is explained in further detail below.
 The above commands will install Perl to F</usr/local> (or some other
 platform-specific directory -- see the appropriate file in F<hints/>.)
 If that's not okay with you, you can run Configure interactively, by
-just typing "sh Configure" (without the -de args). You can also specify
-any prefix location by adding C<"-Dprefix='/some/dir'"> to Configure's args.
+just typing C<sh Configure> (without the C<-de> argument). You can also specify
+any prefix location by adding C<-Dprefix='/some/dir'> to Configure's arguments.
 To explicitly name the perl binary, use the command
-"make install PERLNAME=myperl".
+C<make install PERLNAME=myperl>.
 
 Building perl from source requires an ANSI compliant C compiler.
 C89 with a minimal subset of C99 features is required. Some other


### PR DESCRIPTION
You don't need an installed, runnable "up-to-date version of Perl" to build perl, just a reasonably recent source tree.
    
Also, update references to 5.8 and 5.10 to the more current versions 5.38 and 5.40.

And minor POD changes.
