### PR TITLE
cpan/Win32: import PR 39

### DIFF
--- a/cpan/Win32/Win32.pm
+++ b/cpan/Win32/Win32.pm
@@ -8,7 +8,7 @@ package Win32;
     require DynaLoader;
 
     @ISA = qw|Exporter DynaLoader|;
-    $VERSION = '0.59';
+    $VERSION = '0.59_01';
     $XS_VERSION = $VERSION;
     $VERSION = eval $VERSION;
 

--- a/cpan/Win32/Win32.xs
+++ b/cpan/Win32/Win32.xs
@@ -102,6 +102,10 @@ typedef LONG (WINAPI *PFNRegGetValueA)(HKEY, LPCSTR, LPCSTR, DWORD, LPDWORD, PVO
 #   define CSIDL_FLAG_CREATE          0x8000
 #endif
 
+#ifndef RRF_SUBKEY_WOW6464KEY
+#  define RRF_SUBKEY_WOW6464KEY 0x00010000
+#endif
+
 /* Use explicit struct definition because wSuiteMask and
  * wProductType are not defined in the VC++ 6.0 headers.
  * WORD type has been replaced by unsigned short because
@@ -1693,7 +1697,7 @@ XS(w32_IsDeveloperModeEnabled)
         HKEY_LOCAL_MACHINE,
         "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock",
         "AllowDevelopmentWithoutDevLicense",
-        RRF_RT_REG_DWORD | KEY_WOW64_64KEY,
+        RRF_RT_REG_DWORD | RRF_SUBKEY_WOW6464KEY,
         NULL,
         &val,
         &val_size


### PR DESCRIPTION
https://github.com/perl-libwin32/win32/pull/37 was submitted in June 2022, it fixes a bug that causes tests to fail for Win32.pm for 32-bit builds on windows, including in perl (and in 5.40.)

Jan requested a minor change to that PR which wasn't followed up on, so I submitted https://github.com/perl-libwin32/win32/pull/39 which includes that requested change in August 2023.

This still hasn't been acted on.

So import this change into blead.