### PR TITLE
perl.h: remove UNION_ANY_DEFINITION support

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -4398,9 +4398,6 @@ intrinsic function, see its documents for more details.
 void init_os_extras(void);
 #endif
 
-#ifdef UNION_ANY_DEFINITION
-UNION_ANY_DEFINITION;
-#else
 union any {
     void*       any_ptr;
     SV*         any_sv;
@@ -4423,7 +4420,6 @@ union any {
     void        (*any_dptr) (void*);
     void        (*any_dxptr) (pTHX_ void*);
 };
-#endif
 
 typedef I32 (*filter_t) (pTHX_ int, SV *, int);
 


### PR DESCRIPTION
This macro, if defined, is supposed to provide an alternative definition of the `union any` type. It was added in commit 0f4eea8fa1779e0 (June 1998) to let win32.h override `union any` with its own definition. That override was removed from win32.h in commit c06b86730d867c (July 1999).

For the past 25 years, this feature has been sitting there undocumented and unused.