### PR TITLE
File::Spec::{Unix,OS2}->path(): Keep trailing empty PATH elements

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,6 +24,7 @@ A. C. Yardley                  <yardley@tanet.net>
 A. Sinan Unur                  <nanis@cpan.org>
 Aaron B. Dossett               <aaron@iglou.com>
 Aaron Crane                    <arc@cpan.org>
+Aaron Dill                     <aaronsacks2006@gmail.com>
 Aaron J. Mackey                <ajm6q@virginia.edu>
 Aaron Kaplan
 Aaron Priven                   <aaron@priven.com>

--- a/dist/PathTools/Cwd.pm
+++ b/dist/PathTools/Cwd.pm
@@ -3,7 +3,7 @@ use strict;
 use Exporter;
 
 
-our $VERSION = '3.91';
+our $VERSION = '3.92';
 my $xs_version = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/dist/PathTools/lib/File/Spec.pm
+++ b/dist/PathTools/lib/File/Spec.pm
@@ -4,7 +4,7 @@ use strict;
 
 # Keep $VERSION consistent in all *.pm files in this distribution, including
 # Cwd.pm.
-our $VERSION = '3.91';
+our $VERSION = '3.92';
 $VERSION =~ tr/_//d;
 
 my %module = (

--- a/dist/PathTools/lib/File/Spec/AmigaOS.pm
+++ b/dist/PathTools/lib/File/Spec/AmigaOS.pm
@@ -3,7 +3,7 @@ package File::Spec::AmigaOS;
 use strict;
 require File::Spec::Unix;
 
-our $VERSION = '3.91';
+our $VERSION = '3.92';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Cygwin.pm
+++ b/dist/PathTools/lib/File/Spec/Cygwin.pm
@@ -3,7 +3,7 @@ package File::Spec::Cygwin;
 use strict;
 require File::Spec::Unix;
 
-our $VERSION = '3.91';
+our $VERSION = '3.92';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Epoc.pm
+++ b/dist/PathTools/lib/File/Spec/Epoc.pm
@@ -2,7 +2,7 @@ package File::Spec::Epoc;
 
 use strict;
 
-our $VERSION = '3.91';
+our $VERSION = '3.92';
 $VERSION =~ tr/_//d;
 
 require File::Spec::Unix;

--- a/dist/PathTools/lib/File/Spec/Functions.pm
+++ b/dist/PathTools/lib/File/Spec/Functions.pm
@@ -3,7 +3,7 @@ package File::Spec::Functions;
 use File::Spec;
 use strict;
 
-our $VERSION = '3.91';
+our $VERSION = '3.92';
 $VERSION =~ tr/_//d;
 
 require Exporter;

--- a/dist/PathTools/lib/File/Spec/Mac.pm
+++ b/dist/PathTools/lib/File/Spec/Mac.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.91';
+our $VERSION = '3.92';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/OS2.pm
+++ b/dist/PathTools/lib/File/Spec/OS2.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.91';
+our $VERSION = '3.92';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/OS2.pm
+++ b/dist/PathTools/lib/File/Spec/OS2.pm
@@ -25,7 +25,7 @@ sub file_name_is_absolute {
 sub path {
     my $path = $ENV{PATH};
     $path =~ s:\\:/:g;
-    my @path = split(';',$path);
+    my @path = split(';',$path,-1);
     foreach (@path) { $_ = '.' if $_ eq '' }
     return @path;
 }

--- a/dist/PathTools/lib/File/Spec/Unix.pm
+++ b/dist/PathTools/lib/File/Spec/Unix.pm
@@ -3,7 +3,7 @@ package File::Spec::Unix;
 use strict;
 use Cwd ();
 
-our $VERSION = '3.91';
+our $VERSION = '3.92';
 $VERSION =~ tr/_//d;
 
 =head1 NAME
@@ -253,7 +253,7 @@ Takes no argument, returns the environment variable PATH as an array.
 
 sub path {
     return () unless exists $ENV{PATH};
-    my @path = split(':', $ENV{PATH});
+    my @path = split(':', $ENV{PATH}, -1);
     foreach (@path) { $_ = '.' if $_ eq '' }
     return @path;
 }

--- a/dist/PathTools/lib/File/Spec/VMS.pm
+++ b/dist/PathTools/lib/File/Spec/VMS.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.91';
+our $VERSION = '3.92';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Win32.pm
+++ b/dist/PathTools/lib/File/Spec/Win32.pm
@@ -5,7 +5,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.91';
+our $VERSION = '3.92';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/t/Spec.t
+++ b/dist/PathTools/t/Spec.t
@@ -854,5 +854,21 @@ for ( @tests ) {
 }
 
 is +File::Spec::Unix->canonpath(), undef;
+# Test that trailing empty path components are removed
+# See Perl/perl5#22346
+my @path_tests = (
+  [ 'File::Spec::Unix->path()', "", '' ],
+  [ 'File::Spec::Unix->path()', ":", '.,.' ],
+  [ 'File::Spec::Unix->path()', "/some/path:", '/some/path,.' ],
+  [ 'File::Spec::Unix->path()', "/some/path::", '/some/path,.,.' ],
+  [ 'File::Spec::Unix->path()', ":/some/path:", '.,/some/path,.' ],
+);
+
+for ( @path_tests ) {
+  my ($function, $path, $expected) = @$_;
+  local $ENV{PATH} = $path;
+  my $got = join ',', eval $function;
+  is $got, $expected, $function . " with PATH=$path";
+}
 
 done_testing();

--- a/dist/PathTools/t/Spec.t
+++ b/dist/PathTools/t/Spec.t
@@ -862,6 +862,12 @@ my @path_tests = (
   [ 'File::Spec::Unix->path()', "/some/path:", '/some/path,.' ],
   [ 'File::Spec::Unix->path()', "/some/path::", '/some/path,.,.' ],
   [ 'File::Spec::Unix->path()', ":/some/path:", '.,/some/path,.' ],
+
+  [ 'File::Spec::OS2->path()', "", '' ],
+  [ 'File::Spec::OS2->path()', ";", '.,.' ],
+  [ 'File::Spec::OS2->path()', "/some/path;", '/some/path,.' ],
+  [ 'File::Spec::OS2->path()', "/some/path;;", '/some/path,.,.' ],
+  [ 'File::Spec::OS2->path()', ";/some/path;", '.,/some/path,.' ],
 );
 
 for ( @path_tests ) {


### PR DESCRIPTION
Fixes #22346 by ensuring that trailing PATH elements are maintained *on
Unix and OS2*
