### PR TITLE
PathTools: Keep $VERSION consistent in all *.pm files

### DIFF
--- a/dist/PathTools/Cwd.pm
+++ b/dist/PathTools/Cwd.pm
@@ -3,7 +3,7 @@ use strict;
 use Exporter;
 
 
-our $VERSION = '3.90';
+our $VERSION = '3.91';
 my $xs_version = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/dist/PathTools/lib/File/Spec.pm
+++ b/dist/PathTools/lib/File/Spec.pm
@@ -2,7 +2,9 @@ package File::Spec;
 
 use strict;
 
-our $VERSION = '3.90';
+# Keep $VERSION consistent in all *.pm files in this distribution, including
+# Cwd.pm.
+our $VERSION = '3.91';
 $VERSION =~ tr/_//d;
 
 my %module = (


### PR DESCRIPTION
Corrects oversight in aa5929628d0; spotted by Aaron Dill in GH #22346.