### PR TITLE
Allow `can()` to take a list of methods

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1063,6 +1063,7 @@ Olli Savia
 Ollivier Robert                <roberto@keltia.freenix.fr>
 OpossumPetya                   <russianspy@narod.ru>
 Osvaldo Villalon               <ovillalon@dextratech.com>
+Ovid                           <curtis.poe@gmail.com>
 Owain G. Ainsworth             <oga@nicotinebsd.org>
 Owen Taylor                    <owt1@cornell.edu>
 Pali                           <pali@cpan.org>

--- a/t/uni/universal.t
+++ b/t/uni/universal.t
@@ -13,7 +13,7 @@ BEGIN {
 use utf8;
 use open qw( :utf8 :std );
 
-plan tests => 103;
+plan tests => 105;
 
 $a = {};
 bless $a, "Bòb";
@@ -195,3 +195,11 @@ ok( scalar $child->can(qw(bar baz)), 'can(@methods) in scalar content should ret
 
 ok( !Child->can(qw(foo baz no_such_method)), 'can(@methods) with non-existent methods should already return nothing' );
 ok( !scalar Child->can(qw(foo baz no_such_method)), 'can(@methods) with non-existent methods should return false in scalar context' );
+
+#
+# Check that can() returns an empty list when called with missing methods
+#
+@methods = Child->can(qw(no_such_method));
+ok( !@methods, 'can(@methods) with non-existent methods should already return nothing even when assigned to an array' );
+@methods = $child->can(qw(no_such_method));
+ok( !@methods, 'can(@methods) with non-existent methods should return even when assigned to an array' );

--- a/universal.c
+++ b/universal.c
@@ -512,13 +512,11 @@ XS(XS_UNIVERSAL_can)
             GV * const gv = gv_fetchmethod_sv_flags(pkg, ST(i), 0);
             if (!gv || !isGV(gv) || !GvCV(gv))
                 XSRETURN_UNDEF;
+            else {
+                ST(i-1) = sv_2mortal(newRV(MUTABLE_SV(GvCV(gv))));
+            }
         }
-
         EXTEND(SP, items - 1);
-        for (i = 1; i < items; i++) {
-            GV * const gv = gv_fetchmethod_sv_flags(pkg, ST(i), 0);
-            ST(i-1) = sv_2mortal(newRV(MUTABLE_SV(GvCV(gv))));
-        }
         XSRETURN(items - 1);
     }
 

--- a/universal.c
+++ b/universal.c
@@ -488,7 +488,7 @@ XS(XS_UNIVERSAL_can)
        precedence here over the numeric form, as (!1)->foo treats the
        invocant as the empty string, though it is a dualvar. */
     if (!SvOK(sv) || (SvPOK(sv) && !SvCUR(sv)))
-        XSRETURN_UNDEF;
+        XSRETURN_EMPTY;
 
     if (SvROK(sv)) {
         sv = MUTABLE_SV(SvRV(sv));
@@ -512,7 +512,7 @@ XS(XS_UNIVERSAL_can)
         for (i = 1; i < items; i++) {
             GV * const gv = gv_fetchmethod_sv_flags(pkg, ST(i), 0);
             if (!gv || !isGV(gv) || !GvCV(gv))
-                XSRETURN_UNDEF;
+                XSRETURN_EMPTY;
             else {
                 ST(i-1) = sv_2mortal(newRV(MUTABLE_SV(GvCV(gv))));
             }
@@ -520,7 +520,7 @@ XS(XS_UNIVERSAL_can)
         XSRETURN(items - 1);
     }
 
-    XSRETURN_UNDEF;
+    XSRETURN_EMPTY;
 }
 
 XS(XS_UNIVERSAL_DOES); /* prototype to pass -Wmissing-prototypes */

--- a/universal.c
+++ b/universal.c
@@ -508,6 +508,7 @@ XS(XS_UNIVERSAL_can)
     }
 
     if (pkg) {
+        EXTEND(SP, items - 1);
         for (i = 1; i < items; i++) {
             GV * const gv = gv_fetchmethod_sv_flags(pkg, ST(i), 0);
             if (!gv || !isGV(gv) || !GvCV(gv))
@@ -516,7 +517,6 @@ XS(XS_UNIVERSAL_can)
                 ST(i-1) = sv_2mortal(newRV(MUTABLE_SV(GvCV(gv))));
             }
         }
-        EXTEND(SP, items - 1);
         XSRETURN(items - 1);
     }
 


### PR DESCRIPTION
Not very familiar with core hacking, so feedback needed to see if this is sane at all.

Based on [this discussion on P5P](https://www.nntp.perl.org/group/perl.perl5.porters/2024/07/msg268421.html), this **draft** PR attempts to extend `can()` to accept a list of methods. If _all_ of the methods are available, returns a list of coderefs matching those methods, in order. If _any_ of the methods is not available, it returns `undef`.

# Notes

1. Code is in `universal.c`
2. Tests are in `t/universal.t`
3. No docs yet written because I want to know if this is sane
4. Happy to write a PPC first
5. It returns a list, so in scalar context, we get a coderef, not a number.

I wasn't sure how we felt about checking context in the core, so I punted on the last issue, but returning a coderef feels wrong.
