### PR TITLE
op.c: treat bitwise-{and,xor,or} assignment as lvalue

### DIFF
--- a/op.c
+++ b/op.c
@@ -3190,6 +3190,12 @@ Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
     case OP_BIT_AND:
     case OP_BIT_XOR:
     case OP_BIT_OR:
+    case OP_NBIT_AND:
+    case OP_NBIT_XOR:
+    case OP_NBIT_OR:
+    case OP_SBIT_AND:
+    case OP_SBIT_XOR:
+    case OP_SBIT_OR:
     case OP_I_MULTIPLY:
     case OP_I_DIVIDE:
     case OP_I_MODULO:

--- a/t/op/bop.t
+++ b/t/op/bop.t
@@ -363,82 +363,82 @@ SKIP: {
 
 # New string- and number-specific bitwise ops
 {
-  use feature "bitwise";
-  no warnings "experimental::bitwise";
-  is "22" & "66", 2,    'numeric & with strings';
-  is "22" | "66", 86,   'numeric | with strings';
-  is "22" ^ "66", 84,   'numeric ^ with strings';
-  is ~"22" & 0xff, 233, 'numeric ~ with string';
-  is 22 &. 66, 22,     '&. with numbers';
-  is 22 |. 66, 66,     '|. with numbers';
-  is 22 ^. 66, "\4\4", '^. with numbers';
-  if ($::IS_EBCDIC) {
-    # ord('2') is 0xF2 on EBCDIC
-    is ~.22, "\x0d\x0d", '~. with number';
-  }
-  else {
-    # ord('2') is 0x32 on ASCII
-    is ~.22, "\xcd\xcd", '~. with number';
-  }
-  $_ = "22";
-  is $_ &= "66", 2,  'numeric &= with strings';
-  $_ = "22";
-  is $_ |= "66", 86, 'numeric |= with strings';
-  $_ = "22";
-  is $_ ^= "66", 84, 'numeric ^= with strings';
-  $_ = 22;
-  is $_ &.= 66, 22,     '&.= with numbers';
-  $_ = 22;
-  is $_ |.= 66, 66,     '|.= with numbers';
-  $_ = 22;
-  is $_ ^.= 66, "\4\4", '^.= with numbers';
+    use feature "bitwise";
+    no warnings "experimental::bitwise";
+    is "22" & "66", 2,    'numeric & with strings';
+    is "22" | "66", 86,   'numeric | with strings';
+    is "22" ^ "66", 84,   'numeric ^ with strings';
+    is ~"22" & 0xff, 233, 'numeric ~ with string';
+    is 22 &. 66, 22,     '&. with numbers';
+    is 22 |. 66, 66,     '|. with numbers';
+    is 22 ^. 66, "\4\4", '^. with numbers';
+    if ($::IS_EBCDIC) {
+        # ord('2') is 0xF2 on EBCDIC
+        is ~.22, "\x0d\x0d", '~. with number';
+    }
+    else {
+        # ord('2') is 0x32 on ASCII
+        is ~.22, "\xcd\xcd", '~. with number';
+    }
+    $_ = "22";
+    is $_ &= "66", 2,  'numeric &= with strings';
+    $_ = "22";
+    is $_ |= "66", 86, 'numeric |= with strings';
+    $_ = "22";
+    is $_ ^= "66", 84, 'numeric ^= with strings';
+    $_ = 22;
+    is $_ &.= 66, 22,     '&.= with numbers';
+    $_ = 22;
+    is $_ |.= 66, 66,     '|.= with numbers';
+    $_ = 22;
+    is $_ ^.= 66, "\4\4", '^.= with numbers';
 
- # signed vs. unsigned
- ok ((~0 > 0 && do { use integer; ~0 } == -1));
+    # signed vs. unsigned
+    ok ((~0 > 0 && do { use integer; ~0 } == -1));
 
- my $bits = 0;
- for (my $i = ~0; $i; $i >>= 1) { ++$bits; }
- my $cusp = 1 << ($bits - 1);
+    my $bits = 0;
+    for (my $i = ~0; $i; $i >>= 1) { ++$bits; }
+    my $cusp = 1 << ($bits - 1);
 
- ok (($cusp & -1) > 0 && do { use integer; $cusp & -1 } < 0);
- ok (($cusp | 1) > 0 && do { use integer; $cusp | 1 } < 0);
- ok (($cusp ^ 1) > 0 && do { use integer; $cusp ^ 1 } < 0);
- ok ((1 << ($bits - 1)) == $cusp &&
-     do { use integer; 1 << ($bits - 1) } == -$cusp);
- ok (($cusp >> 1) == ($cusp / 2) &&
-    do { use integer; abs($cusp >> 1) } == ($cusp / 2));
+    ok (($cusp & -1) > 0 && do { use integer; $cusp & -1 } < 0);
+    ok (($cusp | 1) > 0 && do { use integer; $cusp | 1 } < 0);
+    ok (($cusp ^ 1) > 0 && do { use integer; $cusp ^ 1 } < 0);
+    ok ((1 << ($bits - 1)) == $cusp &&
+        do { use integer; 1 << ($bits - 1) } == -$cusp);
+    ok (($cusp >> 1) == ($cusp / 2) &&
+        do { use integer; abs($cusp >> 1) } == ($cusp / 2));
 }
 # Repeat some of those, with 'use v5.27'
 {
-  use v5.27;
+    use v5.27;
 
-  is "22" & "66", 2,    'numeric & with strings';
-  is "22" | "66", 86,   'numeric | with strings';
-  is "22" ^ "66", 84,   'numeric ^ with strings';
-  is ~"22" & 0xff, 233, 'numeric ~ with string';
-  is 22 &. 66, 22,     '&. with numbers';
-  is 22 |. 66, 66,     '|. with numbers';
-  is 22 ^. 66, "\4\4", '^. with numbers';
-  if ($::IS_EBCDIC) {
-    # ord('2') is 0xF2 on EBCDIC
-    is ~.22, "\x0d\x0d", '~. with number';
-  }
-  else {
-    # ord('2') is 0x32 on ASCII
-    is ~.22, "\xcd\xcd", '~. with number';
-  }
-  $_ = "22";
-  is $_ &= "66", 2,  'numeric &= with strings';
-  $_ = "22";
-  is $_ |= "66", 86, 'numeric |= with strings';
-  $_ = "22";
-  is $_ ^= "66", 84, 'numeric ^= with strings';
-  $_ = 22;
-  is $_ &.= 66, 22,     '&.= with numbers';
-  $_ = 22;
-  is $_ |.= 66, 66,     '|.= with numbers';
-  $_ = 22;
-  is $_ ^.= 66, "\4\4", '^.= with numbers';
+    is "22" & "66", 2,    'numeric & with strings';
+    is "22" | "66", 86,   'numeric | with strings';
+    is "22" ^ "66", 84,   'numeric ^ with strings';
+    is ~"22" & 0xff, 233, 'numeric ~ with string';
+    is 22 &. 66, 22,     '&. with numbers';
+    is 22 |. 66, 66,     '|. with numbers';
+    is 22 ^. 66, "\4\4", '^. with numbers';
+    if ($::IS_EBCDIC) {
+        # ord('2') is 0xF2 on EBCDIC
+        is ~.22, "\x0d\x0d", '~. with number';
+    }
+    else {
+        # ord('2') is 0x32 on ASCII
+        is ~.22, "\xcd\xcd", '~. with number';
+    }
+    $_ = "22";
+    is $_ &= "66", 2,  'numeric &= with strings';
+    $_ = "22";
+    is $_ |= "66", 86, 'numeric |= with strings';
+    $_ = "22";
+    is $_ ^= "66", 84, 'numeric ^= with strings';
+    $_ = 22;
+    is $_ &.= 66, 22,     '&.= with numbers';
+    $_ = 22;
+    is $_ |.= 66, 66,     '|.= with numbers';
+    $_ = 22;
+    is $_ ^.= 66, "\4\4", '^.= with numbers';
 }
 
 # ref tests


### PR DESCRIPTION
Previously, `($x &= $y) += $z` was fine (since `&=` returns an lvalue), but not under feature "bitwise":

    Can't modify numeric bitwise and (&) in addition (+) at ...

Similar for `^=` and `|=`.

Extend the lvalue behavior of the old number/string mixed bitwise assignment operators (`&= ^= |=`) to the new separate bitwise assignment operators available under feature "bitwise" (`&= ^= |= &.= ^.= |.=`).

Fixes #22412.
