### PR TITLE
Small fixes to make argnames in `embed.fnc` match the real functions

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4173,9 +4173,9 @@ RS	|Size_t |do_trans_count |NN SV * const sv			\
 				|NN const OPtrans_map * const tbl
 RS	|Size_t |do_trans_count_invmap					\
 				|NN SV * const sv			\
-				|NN AV * const map
+				|NN AV * const invmap
 RS	|Size_t |do_trans_invmap|NN SV * const sv			\
-				|NN AV * const map
+				|NN AV * const invmap
 RS	|Size_t |do_trans_simple|NN SV * const sv			\
 				|NN const OPtrans_map * const tbl
 #endif

--- a/gv.c
+++ b/gv.c
@@ -317,17 +317,17 @@ Perl_cvgv_from_hek(pTHX_ CV *cv)
 /* Assign CvSTASH(cv) = st, handling weak references. */
 
 void
-Perl_cvstash_set(pTHX_ CV *cv, HV *st)
+Perl_cvstash_set(pTHX_ CV *cv, HV *stash)
 {
-    HV *oldst = CvSTASH(cv);
+    HV *oldstash = CvSTASH(cv);
     PERL_ARGS_ASSERT_CVSTASH_SET;
-    if (oldst == st)
+    if (oldstash == stash)
         return;
-    if (oldst)
-        sv_del_backref(MUTABLE_SV(oldst), MUTABLE_SV(cv));
-    SvANY(cv)->xcv_stash = st;
-    if (st)
-        Perl_sv_add_backref(aTHX_ MUTABLE_SV(st), MUTABLE_SV(cv));
+    if (oldstash)
+        sv_del_backref(MUTABLE_SV(oldstash), MUTABLE_SV(cv));
+    SvANY(cv)->xcv_stash = stash;
+    if (stash)
+        Perl_sv_add_backref(aTHX_ MUTABLE_SV(stash), MUTABLE_SV(cv));
 }
 
 /*

--- a/proto.h
+++ b/proto.h
@@ -6666,16 +6666,16 @@ S_do_trans_count(pTHX_ SV * const sv, const OPtrans_map * const tbl)
         assert(sv); assert(tbl)
 
 STATIC Size_t
-S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const map)
+S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_COUNT_INVMAP \
-        assert(sv); assert(map)
+        assert(sv); assert(invmap)
 
 STATIC Size_t
-S_do_trans_invmap(pTHX_ SV * const sv, AV * const map)
+S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_INVMAP       \
-        assert(sv); assert(map)
+        assert(sv); assert(invmap)
 
 STATIC Size_t
 S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)


### PR DESCRIPTION
During some other work I found a few cases where the argument names in `embed.fnc` didn't match the actual names the function definitions really use. This is important for making the `PERL_ARGS_ASSERT_...` macros work properly.

The two invmap ones are fixed by changing the argument name in embed.fnc; the cvstash one is fixed by renaming the argument in the real code.