### PR TITLE
Move text from perlhacktips to perlclib

### DIFF
--- a/pod/perlclib.pod
+++ b/pod/perlclib.pod
@@ -10,7 +10,7 @@ C<libc>.  This document gives some guidance on interfacing with that
 library.
 
 One thing Perl porters should note is that F<perl> doesn't tend to use that
-much of the C standard library internally; you'll see very little use of, 
+much of the C standard library internally; you'll see very little use of,
 for example, the F<ctype.h> functions in there. This is because Perl
 tends to reimplement or abstract standard library functions, so that we
 know exactly how they're going to operate.
@@ -104,7 +104,7 @@ C<sv>, C<av>, C<hv>, etc. represent variables of their respective types.
 
 Instead of the F<stdio.h> functions, you should use the Perl abstraction
 layer. Instead of C<FILE*> types, you need to be handling C<PerlIO*>
-types.  Don't forget that with the new PerlIO layered I/O abstraction 
+types.  Don't forget that with the new PerlIO layered I/O abstraction
 C<FILE*> types may not even be available. See also the C<perlapio>
 documentation for more information about the following functions:
 
@@ -628,7 +628,7 @@ MULTIPLICITY, but not the other way around.
 MULTIPLICITY without threading means that only one thing runs at a time,
 so there are no concurrency issues, but each component or instance can
 affect the global state, potentially interfering with the execution of
-other instance.  This can happen if one instance:
+other instances.  This can happen if one instance:
 
 =over
 

--- a/pod/perlclib.pod
+++ b/pod/perlclib.pod
@@ -138,7 +138,8 @@ different from their C library counterparts:
 
   fputs(s, stream)            PerlIO_puts(perlio, s)
 
-There is no equivalent to C<fgets>; one should use C<sv_gets> instead:
+There is no equivalent to C<fgets> (or the deprecated C<gets>); one
+should use C<sv_gets> instead:
 
   fgets(s, n, stream)         sv_gets(sv, perlio, append)
 
@@ -163,6 +164,10 @@ There is no equivalent to C<fgets>; one should use C<sv_gets> instead:
   t* p = malloc(n)               Newx(p, n, t)
   t* p = calloc(n, s)            Newxz(p, n, t)
   p = realloc(p, n)              Renew(p, n, t)
+
+It is not portable to try to allocate 0 bytes; allocating 1 or more is
+portable.
+
   memcpy(dst, src, n)            Copy(src, dst, n, t)
   memmove(dst, src, n)           Move(src, dst, n, t)
   memcpy(dst, src, sizeof(t))    StructCopy(src, dst, t)
@@ -218,11 +223,24 @@ If you do need raw strings, use these instead:
 Similiarly, you can use SVs for creating strings from formats
 
   sprintf(s, fmt, ...)         sv_setpvf(sv, fmt, ...)
+  vsprintf(str, fmt, va_list)  sv_vsetpvf(sv, fmt, va_list)
 
+Or for raw strings,
+
+  my_snprintf(dt, len, fmt, ...)
+  my_vsnprintf(dt, len, fmt, va_list)
+  vsprintf(str, fmt, va_list)  sv_vsnprintf(sv, fmt, va_list)
 
 Note also the existence of C<sv_catpvf> and C<sv_vcatpvfn>, combining
-concatenation with formatting.
+concatenation with formatting; and L<C<Perl_form>()|perlapi/form> for
+another form of formatted populating.
 
+Note that glibc C<printf()>, C<sprintf()>, etc. are buggy before glibc
+version 2.17.  They won't allow a C<%.s> format with a precision to
+create a string that isn't valid UTF-8 if the current underlying locale
+of the program is UTF-8.  What happens is that the C<%s> and its
+operand are simply skipped without any notice.
+L<https://sourceware.org/bugzilla/show_bug.cgi?id=6530>.
 
 =head2 Character Class Tests
 
@@ -293,7 +311,8 @@ for collation.
   strtol(s, &p, n)            Strtol(s, &p, b)
   strtoul(s, &p, n)           Strtoul(s, &p, b)
 
-But note that these are subject to locale; see L</Dealing with locales>.
+But note that even the alternative functions are subject to locale; see
+L</Dealing with locales>.
 
 Typical use is to do range checks on C<uv> before casting:
 
@@ -386,9 +405,9 @@ think you do, use the C<JMPENV> stack in F<scope.h> instead.
   strftime()             Perl_sv_strftime_tm()
   strtod()               my_strtod() or Strtod()
   system(s)              Don't. Look at pp_system or use my_popen.
- ~tempnam()              mkstemp() or tmpfile()
- ~tmpnam()               mkstemp() or tmpfile()
-  tmpnam_r()             mkstemp() or tmpfile()
+ ~tempnam()              mkstemp()
+ ~tmpnam()               mkstemp()
+  tmpnam_r()             mkstemp()
   uselocale()            Perl_setlocale()
   vsnprintf()            my_vsnprintf()
   wctob()                wcrtomb()

--- a/pod/perlclib.pod
+++ b/pod/perlclib.pod
@@ -166,6 +166,10 @@ There is no equivalent to C<fgets>; one should use C<sv_gets> instead:
   memcpy(dst, src, n)            Copy(src, dst, n, t)
   memmove(dst, src, n)           Move(src, dst, n, t)
   memcpy(dst, src, sizeof(t))    StructCopy(src, dst, t)
+
+Notice the different order of arguments to C<Copy> and C<Move> than used
+in C<memcpy> and C<memmove>.
+
   memset(dst, 0, n * sizeof(t))  Zero(dst, n, t)
   memzero(dst, 0)                Zero(dst, n, char)
   free(p)                        Safefree(p)
@@ -173,38 +177,6 @@ There is no equivalent to C<fgets>; one should use C<sv_gets> instead:
   strdup(p)                      savepv(p)
   strndup(p, n)                  savepvn(p, n) (Hey, strndup doesn't
                                                 exist!)
-
-  strstr(big, little)            instr(big, little)
-  memmem(big, blen, little, len) ninstr(big, bigend, little, little_end)
-  strcmp(s1, s2)                 strLE(s1, s2) / strEQ(s1, s2)
-                                               / strGT(s1,s2)
-  strncmp(s1, s2, n)             strnNE(s1, s2, n) / strnEQ(s1, s2, n)
-
-  memcmp(p1, p2, n)              memNE(p1, p2, n)
-  !memcmp(p1, p2, n)             memEQ(p1, p2, n)
-
-Notice the different order of arguments to C<Copy> and C<Move> than used
-in C<memcpy> and C<memmove>.
-
-Most of the time, though, you'll want to be dealing with SVs internally
-instead of raw C<char *> strings:
-
-  strlen(s)                   sv_len(sv)
-  strcpy(dt, src)             sv_setpv(sv, s)
-  strncpy(dt, src, n)         sv_setpvn(sv, s, n)
-  strcat(dt, src)             sv_catpv(sv, s)
-  strncat(dt, src)            sv_catpvn(sv, s)
-  sprintf(s, fmt, ...)        sv_setpvf(sv, fmt, ...)
-
-If you do need raw strings, some platforms have safer interfaces, and
-Perl makes sure a version of these are available on all platforms:
-
-  strlcat(dt, src, sizeof(dt)) my_strlcat(dt, src, sizeof(dt))
-  strlcpy(dt, src, sizeof(dt)) my_strlcpy(dt, src, sizeof(dt))
-  strnlen(s)                   my_strnlen(s, maxlen)
-
-Note also the existence of C<sv_catpvf> and C<sv_vcatpvfn>, combining
-concatenation with formatting.
 
 Sometimes instead of zeroing the allocated heap by using Newxz() you
 should consider "poisoning" the data.  This means writing a bit
@@ -218,6 +190,39 @@ macros, which have similar arguments to Zero():
   PoisonNew(dst, n, t)        equal to PoisonWith(dst, n, t, 0xAB)
   PoisonFree(dst, n, t)       equal to PoisonWith(dst, n, t, 0xEF)
   Poison(dst, n, t)           equal to PoisonFree(dst, n, t)
+
+  strstr(big, little)            instr(big, little)
+  memmem(big, blen, little, len) ninstr(big, bigend, little, little_end)
+  strcmp(s1, s2)                 strLE(s1, s2) / strEQ(s1, s2)
+                                               / strGT(s1,s2)
+  strncmp(s1, s2, n)             strnNE(s1, s2, n) / strnEQ(s1, s2, n)
+
+  memcmp(p1, p2, n)              memNE(p1, p2, n)
+  !memcmp(p1, p2, n)             memEQ(p1, p2, n)
+
+Most of the time, though, you'll want to be dealing with SVs internally
+instead of raw C<char *> strings:
+
+  strlen(s)                   sv_len(sv)
+  strcpy(dt, src)             sv_setpv(sv, s)
+  strncpy(dt, src, n)         sv_setpvn(sv, s, n)
+  strcat(dt, src)             sv_catpv(sv, s)
+  strncat(dt, src)            sv_catpvn(sv, s)
+
+If you do need raw strings, use these instead:
+
+  my_strnlen(s, maxlen)
+  my_strlcpy(dt, src, sizeof(dt))
+  my_strlcat(dt, src, sizeof(dt))
+
+Similiarly, you can use SVs for creating strings from formats
+
+  sprintf(s, fmt, ...)         sv_setpvf(sv, fmt, ...)
+
+
+Note also the existence of C<sv_catpvf> and C<sv_vcatpvfn>, combining
+concatenation with formatting.
+
 
 =head2 Character Class Tests
 

--- a/pod/perlhacktips.pod
+++ b/pod/perlhacktips.pod
@@ -453,6 +453,7 @@ functions are fully supported in modern compilers.
 Nevertheless, there are situations where a function won't do, and a
 macro is required.  One example is when a parameter can be any of
 several types.  A function has to be declared with a single explicit
+parameter type, so a macro may be called for.
 
 Or maybe the code involved is so trivial that a function would be just
 complicating overkill, such as when the macro simply creates a mnemonic
@@ -550,7 +551,7 @@ L<https://perlmonks.org/?node_id=11144355>.
 =head2 Portability problems
 
 The following are common causes of compilation and/or execution
-failures, not common to Perl as such.  The C FAQ is good bedtime
+failures, not specific to Perl as such.  The C FAQ is good bedtime
 reading.  Please test your changes with as many C compilers and
 platforms as possible; we will, anyway, and it's nice to save oneself
 from public embarrassment.
@@ -601,7 +602,7 @@ C<long long> is not even guaranteed to be any wider than C<long>.)
 
 Instead, use the definitions C<IV>, C<UV>, C<IVSIZE>, C<I32SIZE>, and
 so forth. Avoid things like C<I32> because they are B<not> guaranteed
-to be I<exactly> 32 bits, they are I<at least> 32 bits, nor are they
+to be I<exactly> 32 bits (they are I<at least> 32 bits), nor are they
 guaranteed to be C<int> or C<long>.  If you explicitly need 64-bit
 variables, use C<I64> and C<U64>.
 
@@ -879,7 +880,8 @@ intelligence, but for many types the right format is available as with
 either 'f' or '_f' suffix, for example:
 
    IVdf /* IV in decimal */
-   UVxf /* UV is hexadecimal */
+   UVxf /* UV in hexadecimal */
+   U32of /* A U32 in octal */
 
    printf("i = %"IVdf"\n", i); /* The IVdf is a string constant. */
 

--- a/pod/perlhacktips.pod
+++ b/pod/perlhacktips.pod
@@ -992,30 +992,28 @@ L<https://sourceforge.net/p/predef/wiki/Home/>.
 Assuming the contents of static memory pointed to by the return values
 of Perl wrappers for C library functions doesn't change.  Many C
 library functions return pointers to static storage that can be
-overwritten by subsequent calls to the same or related functions.  Perl
-has wrappers for some of these functions.  Originally many of those
-wrappers returned those volatile pointers.  But over time almost all of
-them have evolved to return stable copies.  To cope with the remaining
-ones, do a L<perlapi/savepv> to make a copy, thus avoiding these
-problems.  You will have to free the copy when you're done to avoid
-memory leaks.  If you don't have control over when it gets freed,
-you'll need to make the copy in a mortal scalar, like so
+overwritten by subsequent calls to the same or related functions.  If
+you handle those returns before one of those functions that share the
+storage gets called, this is fine, but in embedded perls, or when using
+threads, such a function may get called before you get a chance to
+handle it.
 
- SvPVX(sv_2mortal(newSVpv(volatile_string, 0)))
+L<perlclib/Dealing with embedded perls and threads> contains a list of
+problematic functions with good advice as to how to cope with them.
 
 =back
 
 =head2 Problematic System Interfaces
 
-=over 4
+There are lots of issues with using various C library functions,
+including security ones.  You should read L<perlclib> which covers
+things in detail.
 
-=item *
-
-Perl strings are NOT the same as C strings:  They may contain C<NUL>
-characters, whereas a C string is terminated by the first C<NUL>. That
-is why Perl API functions that deal with strings generally take a
-pointer to the first byte and either a length or a pointer to the byte
-just beyond the final one.
+Remember that Perl strings are NOT the same as C strings:  They may
+contain C<NUL> characters, whereas a C string is terminated by the first
+C<NUL>. That is why Perl API functions that deal with strings generally
+take a pointer to the first byte and either a length or a pointer to the
+byte just beyond the final one.
 
 And this is the reason that many of the C library string handling
 functions should not be used.  They don't cope with the full generality
@@ -1041,84 +1039,6 @@ if C<c> is in C<"list"> and works even if C<c> is C<NUL>.  These
 functions need an additional parameter to give the string length. In
 the case of literal string parameters, perl has defined macros that
 calculate the length for you.  See L<perlapi/String Handling>.
-
-=item *
-
-malloc(0), realloc(0), calloc(0, 0) are non-portable.  To be portable
-allocate at least one byte.  (In general you should rarely need to work
-at this low level, but instead use the various malloc wrappers.)
-
-=item *
-
-snprintf() - the return type is unportable.  Use my_snprintf() instead.
-
-=back
-
-=head2 Security problems
-
-Last but not least, here are various tips for safer coding. See also
-L<perlclib> for libc/stdio replacements one should use.
-
-=over 4
-
-=item *
-
-Do not use gets()
-
-Or we will publicly ridicule you.  Seriously.
-
-=item *
-
-Do not use tmpfile()
-
-Use mkstemp() instead.
-
-=item *
-
-Do not use strcpy() or strcat() or strncpy() or strncat()
-
-Use my_strlcpy() and my_strlcat() instead: they either use the native
-implementation, or Perl's own implementation (borrowed from the public
-domain implementation of INN).
-
-=item *
-
-Do not use sprintf() or vsprintf()
-
-If you really want just plain byte strings, use my_snprintf() and
-my_vsnprintf() instead, which will try to use snprintf() and
-vsnprintf() if those safer APIs are available.  If you want something
-fancier than a plain byte string, use L<C<Perl_form>()|perlapi/form> or
-SVs and L<C<Perl_sv_catpvf()>|perlapi/sv_catpvf>.
-
-Note that glibc C<printf()>, C<sprintf()>, etc. are buggy before glibc
-version 2.17.  They won't allow a C<%.s> format with a precision to
-create a string that isn't valid UTF-8 if the current underlying locale
-of the program is UTF-8.  What happens is that the C<%s> and its
-operand are simply skipped without any notice.
-L<https://sourceware.org/bugzilla/show_bug.cgi?id=6530>.
-
-=item *
-
-Do not use atoi()
-
-Use grok_atoUV() instead.  atoi() has ill-defined behavior on
-overflows, and cannot be used for incremental parsing.  It is also
-affected by locale, which is bad.
-
-=item *
-
-Do not use strtol() or strtoul()
-
-Use grok_atoUV() instead.  strtol() or strtoul() (or their
-IV/UV-friendly macro disguises, Strtol() and Strtoul(), or Atol() and
-Atoul() are affected by locale, which is bad.
-
-=for apidoc_section $numeric
-=for apidoc AmhD||Atol|const char * nptr
-=for apidoc AmhD||Atoul|const char * nptr
-
-=back
 
 =head1 DEBUGGING
 


### PR DESCRIPTION
perlclib has extensive detail on interfacing with `libc`.  Some of the text in perlhacktips was redundant with that, and is removed.  The non-redundant parts are folded in with the perlclib text