### PR TITLE
Update perldata.pod else everybody will think sigil=$

### DIFF
--- a/pod/perldata.pod
+++ b/pod/perldata.pod
@@ -192,7 +192,7 @@ fully-qualified.  They come in six forms (but don't use forms 5 and 6):
 =item 1.
 
 A sigil, followed solely by digits matching C<\p{POSIX_Digit}>, like
-C<$0>, C<$1>, or C<$10000>.
+C<$0>, C<@1>, or C<%10000>.
 
 =item 2.
 


### PR DESCRIPTION
No matter all my life I thought "Sigil" only meant "$".

It's not because "S" looks like "$", it was because of this one sided example! 

Well, no more discrimination allowed in this sentence. Equal opportunity for all!