### PR TITLE
perlapi: Some elements are not functions, but are considered so

### DIFF
--- a/gv.c
+++ b/gv.c
@@ -2529,12 +2529,12 @@ S_maybe_multimagic_gv(pTHX_ GV *gv, const char *name, const svtype sv_type)
 }
 
 /*
-=for apidoc gv_fetchpv
-=for apidoc_item |GV *|gv_fetchpvn|const char * nambeg|STRLEN full_len|I32 flags|const svtype sv_type
-=for apidoc_item ||gv_fetchpvn_flags
-=for apidoc_item |GV *|gv_fetchpvs|"name"|I32 flags|const svtype sv_type
-=for apidoc_item ||gv_fetchsv
-=for apidoc_item |GV *|gv_fetchsv_nomg|SV *name|I32 flags|const svtype sv_type
+=for apidoc      gv_fetchpv
+=for apidoc_item gv_fetchpvn
+=for apidoc_item gv_fetchpvn_flags
+=for apidoc_item gv_fetchpvs
+=for apidoc_item gv_fetchsv
+=for apidoc_item gv_fetchsv_nomg
 
 These all return the GV of type C<sv_type> whose name is given by the inputs,
 or NULL if no GV of that name and type could be found.  See L<perlguts/Stashes

--- a/gv.h
+++ b/gv.h
@@ -300,7 +300,13 @@ Return the CV from the GV.
 #define gv_fullname3(sv,gv,prefix) gv_fullname4(sv,gv,prefix,TRUE)
 #define gv_efullname3(sv,gv,prefix) gv_efullname4(sv,gv,prefix,TRUE)
 #define gv_fetchmethod(stash, name) gv_fetchmethod_autoload(stash, name, TRUE)
+
+/*
+=for apidoc_defn Am|GV *|gv_fetchsv_nomg|SV *name|I32 flags|const svtype sv_type
+=cut
+*/
 #define gv_fetchsv_nomg(n,f,t) gv_fetchsv(n,(f)|GV_NO_SVGMAGIC,t)
+
 #define gv_init(gv,stash,name,len,multi) \
         gv_init_pvn(gv,stash,name,len,GV_ADDMULTI*cBOOL(multi))
 #define gv_fetchmeth(stash,name,len,level) gv_fetchmeth_pvn(stash, name, len, level, 0)

--- a/handy.h
+++ b/handy.h
@@ -467,6 +467,10 @@ Perl_xxx(aTHX_ ...) form for any API calls where it's used.
 */
 #define lex_stuff_pvs(pv,flags) Perl_lex_stuff_pvn(aTHX_ STR_WITH_LEN(pv), flags)
 
+/*
+=for apidoc_defn Am|CV *|get_cvs|"name"|I32 flags
+=cut
+*/
 #define get_cvs(str, flags)					\
         Perl_get_cvn_flags(aTHX_ STR_WITH_LEN(str), (flags))
 

--- a/handy.h
+++ b/handy.h
@@ -462,8 +462,14 @@ Perl_xxx(aTHX_ ...) form for any API calls where it's used.
 #define gv_stashpvs(str, create) \
     Perl_gv_stashpvn(aTHX_ STR_WITH_LEN(str), create)
 
-#define gv_fetchpvs(namebeg, flags, sv_type) \
-    Perl_gv_fetchpvn_flags(aTHX_ STR_WITH_LEN(namebeg), flags, sv_type)
+
+/*
+=for apidoc_defn Am|GV *|gv_fetchpvs|"name"|I32 flags|const svtype sv_type
+=for apidoc_defn Am|GV *|gv_fetchpvn|const char * nambeg|STRLEN full_len|I32 flags|const svtype sv_type
+=cut
+*/
+#define gv_fetchpvs(name, flags, sv_type)                                   \
+            Perl_gv_fetchpvn_flags(aTHX_ STR_WITH_LEN(name), flags, sv_type)
 #define  gv_fetchpvn  gv_fetchpvn_flags
 
 

--- a/handy.h
+++ b/handy.h
@@ -435,8 +435,15 @@ Perl_xxx(aTHX_ ...) form for any API calls where it's used.
     Perl_sv_catpvn_flags(aTHX_ dsv, STR_WITH_LEN(str), SV_GMAGIC)
 #define sv_catpvs_mg(dsv, str) \
     Perl_sv_catpvn_flags(aTHX_ dsv, STR_WITH_LEN(str), SV_GMAGIC|SV_SMAGIC)
+
+/*
+=for apidoc_defn Am|void|sv_setpvs   |SV *const sv|"literal string"
+=for apidoc_defn Am|void|sv_setpvs_mg|SV *const sv|"literal string"
+=cut
+*/
 #define sv_setpvs(dsv, str) Perl_sv_setpvn(aTHX_ dsv, STR_WITH_LEN(str))
 #define sv_setpvs_mg(dsv, str) Perl_sv_setpvn_mg(aTHX_ dsv, STR_WITH_LEN(str))
+
 #define sv_setref_pvs(rv, classname, str) \
     Perl_sv_setref_pvn(aTHX_ rv, classname, STR_WITH_LEN(str))
 

--- a/hv.c
+++ b/hv.c
@@ -2609,8 +2609,8 @@ Perl_hv_eiter_set(pTHX_ HV *hv, HE *eiter) {
 }
 
 /*
-=for apidoc        hv_name_set
-=for apidoc_item ||hv_name_sets|HV *hv|"name"|U32 flags
+=for apidoc      hv_name_set
+=for apidoc_item hv_name_sets
 
 These each set the name of stash C<hv> to the specified name.
 

--- a/hv.c
+++ b/hv.c
@@ -1250,8 +1250,8 @@ Perl_hv_bucket_ratio(pTHX_ HV *hv)
 }
 
 /*
-=for apidoc hv_delete
-=for apidoc_item ||hv_deletes|HV *hv|"key"|U32 flags
+=for apidoc      hv_delete
+=for apidoc_item hv_deletes
 
 These delete a key/value pair in the hash.  The value's SV is removed from
 the hash, made mortal, and returned to the caller.

--- a/hv.h
+++ b/hv.h
@@ -577,6 +577,7 @@ whether it is valid to call C<HvAUX()>.
 
 /*
 =for apidoc_defn Am|SV**|hv_fetchs|HV* hv|"key"|I32 lval
+=for apidoc_defn Am|SV *|hv_deletes|HV *hv|"key"|U32 flags
 =cut
 */
 #define hv_fetchs(hv, key, lval) \

--- a/hv.h
+++ b/hv.h
@@ -578,6 +578,7 @@ whether it is valid to call C<HvAUX()>.
 /*
 =for apidoc_defn Am|SV**|hv_fetchs|HV* hv|"key"|I32 lval
 =for apidoc_defn Am|SV *|hv_deletes|HV *hv|"key"|U32 flags
+=for apidoc_defn Am|void|hv_name_sets|HV *hv|"name"|U32 flags
 =cut
 */
 #define hv_fetchs(hv, key, lval) \

--- a/perl.c
+++ b/perl.c
@@ -2956,9 +2956,9 @@ Perl_get_hv(pTHX_ const char *name, I32 flags)
 /*
 =for apidoc_section $CV
 
-=for apidoc            get_cv
-=for apidoc_item       get_cvn_flags
-=for apidoc_item |CV *|get_cvs|"string"|I32 flags
+=for apidoc      get_cv
+=for apidoc_item get_cvn_flags
+=for apidoc_item get_cvs
 
 These return the CV of the specified Perl subroutine.  C<flags> are passed to
 C<gv_fetchpvn_flags>.  If C<GV_ADD> is set and the Perl subroutine does not

--- a/sv.c
+++ b/sv.c
@@ -5009,13 +5009,13 @@ Perl_sv_setpv_bufsize(pTHX_ SV *const sv, const STRLEN cur, const STRLEN len)
 }
 
 /*
-=for apidoc            sv_setpv
-=for apidoc_item       sv_setpv_mg
-=for apidoc_item       sv_setpvn
-=for apidoc_item       sv_setpvn_fresh
-=for apidoc_item       sv_setpvn_mg
-=for apidoc_item |void|sv_setpvs|SV* sv|"literal string"
-=for apidoc_item |void|sv_setpvs_mg|SV* sv|"literal string"
+=for apidoc      sv_setpv
+=for apidoc_item sv_setpv_mg
+=for apidoc_item sv_setpvn
+=for apidoc_item sv_setpvn_fresh
+=for apidoc_item sv_setpvn_mg
+=for apidoc_item sv_setpvs
+=for apidoc_item sv_setpvs_mg
 
 These copy a string into the SV C<sv>, making sure it is C<L</SvPOK_only>>.
 

--- a/sv.h
+++ b/sv.h
@@ -2240,6 +2240,10 @@ immediately written again.
 #define sv_catpv_nomg(dsv, sstr) sv_catpv_flags(dsv, sstr, 0)
 #define sv_setsv(dsv, ssv) \
         sv_setsv_flags(dsv, ssv, SV_GMAGIC|SV_DO_COW_SVSETSV)
+/*
+=for apidoc_defn Am|void|sv_setsv_nomg|SV *dsv|SV *ssv
+=cut
+*/
 #define sv_setsv_nomg(dsv, ssv) sv_setsv_flags(dsv, ssv, SV_DO_COW_SVSETSV)
 #define sv_catsv(dsv, ssv) sv_catsv_flags(dsv, ssv, SV_GMAGIC)
 #define sv_catsv_nomg(dsv, ssv) sv_catsv_flags(dsv, ssv, 0)

--- a/sv.h
+++ b/sv.h
@@ -297,14 +297,14 @@ struct object {
 Returns the value of the object's reference count. Exposed
 to perl code via Internals::SvREFCNT().
 
-=for apidoc            SvREFCNT_inc
-=for apidoc_item       SvREFCNT_inc_NN
-=for apidoc_item |SV* |SvREFCNT_inc_simple|SV* sv
-=for apidoc_item |SV* |SvREFCNT_inc_simple_NN|SV* sv
-=for apidoc_item |void|SvREFCNT_inc_simple_void|SV* sv
-=for apidoc_item |void|SvREFCNT_inc_simple_void_NN|SV* sv
-=for apidoc_item       SvREFCNT_inc_void
-=for apidoc_item |void|SvREFCNT_inc_void_NN|SV* sv
+=for apidoc      SvREFCNT_inc
+=for apidoc_item SvREFCNT_inc_NN
+=for apidoc_item SvREFCNT_inc_simple
+=for apidoc_item SvREFCNT_inc_simple_NN
+=for apidoc_item SvREFCNT_inc_simple_void
+=for apidoc_item SvREFCNT_inc_simple_void_NN
+=for apidoc_item SvREFCNT_inc_void
+=for apidoc_item SvREFCNT_inc_void_NN
 
 These all increment the reference count of the given SV.
 The ones without C<void> in their names return the SV.
@@ -374,12 +374,22 @@ perform the upgrade if necessary.  See C<L</svtype>>.
 #define SvFLAGS(sv)	(sv)->sv_flags
 #define SvREFCNT(sv)	(sv)->sv_refcnt
 
+/*
+=for apidoc_defn Am|SV *|SvREFCNT_inc_simple|SV *sv
+=cut
+*/
 #define SvREFCNT_inc(sv)		Perl_SvREFCNT_inc(MUTABLE_SV(sv))
 #define SvREFCNT_inc_simple(sv)		SvREFCNT_inc(sv)
 #define SvREFCNT_inc_NN(sv)		Perl_SvREFCNT_inc_NN(MUTABLE_SV(sv))
 #define SvREFCNT_inc_void(sv)		Perl_SvREFCNT_inc_void(MUTABLE_SV(sv))
 
-/* These guys don't need the curly blocks */
+/*
+=for apidoc_defn Am|void|SvREFCNT_inc_simple_void|SV *sv
+
+These guys don't need the curly blocks
+
+=cut
+*/
 #define SvREFCNT_inc_simple_void(sv)	                                \
         STMT_START {                                                    \
             SV * sv_ = MUTABLE_SV(sv);                                  \
@@ -387,6 +397,12 @@ perform the upgrade if necessary.  See C<L</svtype>>.
                 SvREFCNT(sv_)++;                                        \
         } STMT_END
 
+/*
+=for apidoc_defn Am|SV *|SvREFCNT_inc_simple_NN|SV *sv
+=for apidoc_defn Am|void|SvREFCNT_inc_void_NN|SV *sv
+=for apidoc_defn Am|void|SvREFCNT_inc_simple_void_NN|SV *sv
+=cut
+*/
 #define SvREFCNT_inc_simple_NN(sv)	(++(SvREFCNT(sv)),MUTABLE_SV(sv))
 #define SvREFCNT_inc_void_NN(sv)	(void)(++SvREFCNT(MUTABLE_SV(sv)))
 #define SvREFCNT_inc_simple_void_NN(sv)	(void)(++SvREFCNT(MUTABLE_SV(sv)))

--- a/sv.h
+++ b/sv.h
@@ -2061,6 +2061,11 @@ END_EXTERN_C
 #define SvPVutf8x_force(sv, len) sv_pvutf8n_force(sv, &len)
 #define SvPVbytex_force(sv, len) sv_pvbyten_force(sv, &len)
 
+/*
+=for apidoc_defn Am|bool|SvTRUEx|SV *sv
+=for apidoc_defn Am|bool|SvTRUE_nomg_NN|SV *sv
+=cut
+*/
 #define SvTRUEx(sv)        SvTRUE(sv)
 #define SvTRUEx_nomg(sv)   SvTRUE_nomg(sv)
 #define SvTRUE_nomg_NN(sv) SvTRUE_common(sv, TRUE)

--- a/sv.h
+++ b/sv.h
@@ -2315,8 +2315,8 @@ immediately written again.
 #endif
 
 /*
-=for apidoc newRV
-=for apidoc_item ||newRV_inc|
+=for apidoc         newRV
+=for apidoc_item m||newRV_inc|
 
 These are identical.  They create an RV wrapper for an SV.  The reference count
 for the original SV is incremented.

--- a/sv.h
+++ b/sv.h
@@ -2242,6 +2242,7 @@ immediately written again.
         sv_setsv_flags(dsv, ssv, SV_GMAGIC|SV_DO_COW_SVSETSV)
 /*
 =for apidoc_defn Am|void|sv_setsv_nomg|SV *dsv|SV *ssv
+=for apidoc_defn Am|void|sv_catsv_nomg|SV *dsv|SV *ssv
 =cut
 */
 #define sv_setsv_nomg(dsv, ssv) sv_setsv_flags(dsv, ssv, SV_DO_COW_SVSETSV)

--- a/sv_inline.h
+++ b/sv_inline.h
@@ -754,9 +754,9 @@ Perl_SvPADSTALE_off(SV *sv)
 
 /*
 =for apidoc_section $SV
-=for apidoc      SvIV
-=for apidoc_item SvIV_nomg
-=for apidoc_item SvIVx
+=for apidoc         SvIV
+=for apidoc_item    SvIV_nomg
+=for apidoc_item m||SvIVx
 
 These each coerce the given SV to IV and return it.  The returned value in many
 circumstances will get stored in C<sv>'s IV slot, but not in all cases.  (Use
@@ -769,9 +769,9 @@ guaranteed to evaluate C<sv> only once.
 
 C<SvIV_nomg> is the same as C<SvIV>, but does not perform 'get' magic.
 
-=for apidoc      SvNV
-=for apidoc_item SvNV_nomg
-=for apidoc_item SvNVx
+=for apidoc         SvNV
+=for apidoc_item    SvNV_nomg
+=for apidoc_item m||SvNVx
 
 These each coerce the given SV to NV and return it.  The returned value in many
 circumstances will get stored in C<sv>'s NV slot, but not in all cases.  (Use
@@ -784,9 +784,9 @@ guaranteed to evaluate C<sv> only once.
 
 C<SvNV_nomg> is the same as C<SvNV>, but does not perform 'get' magic.
 
-=for apidoc      SvUV
-=for apidoc_item SvUV_nomg
-=for apidoc_item SvUVx
+=for apidoc         SvUV
+=for apidoc_item    SvUV_nomg
+=for apidoc_item m||SvUVx
 
 These each coerce the given SV to UV and return it.  The returned value in many
 circumstances will get stored in C<sv>'s UV slot, but not in all cases.  (Use


### PR DESCRIPTION
This series of commits marks some API elements as non-functions.  Prior to these, perlapi created wrong signatures for them with the 'Perl_' prefix