### PR TITLE
Make some similar functions use same parameter names with same constness

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3071,7 +3071,7 @@ Adp	|void	|sv_catpv	|NN SV * const dsv			\
 Adfpv	|void	|sv_catpvf	|NN SV * const sv			\
 				|NN const char * const pat		\
 				|...
-Adp	|void	|sv_catpv_flags |NN SV *dsv				\
+Adp	|void	|sv_catpv_flags |NN SV * const dsv			\
 				|NN const char *sstr			\
 				|const I32 flags
 Adfpv	|void	|sv_catpvf_mg	|NN SV * const sv			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -3079,23 +3079,23 @@ Adfpv	|void	|sv_catpvf_mg	|NN SV * const sv			\
 				|...
 Adp	|void	|sv_catpv_mg	|NN SV * const dsv			\
 				|NULLOK const char * const sstr
-AMbdp	|void	|sv_catpvn	|NN SV *dsv				\
+AMbdp	|void	|sv_catpvn	|NN SV * const dsv			\
 				|NN const char *sstr			\
 				|STRLEN len
 Adp	|void	|sv_catpvn_flags|NN SV * const dsv			\
 				|NN const char *sstr			\
 				|const STRLEN len			\
 				|const I32 flags
-AMbdp	|void	|sv_catpvn_mg	|NN SV *dsv				\
+AMbdp	|void	|sv_catpvn_mg	|NN SV * const dsv			\
 				|NN const char *sstr			\
 				|STRLEN len
-AMbdp	|void	|sv_catsv	|NN SV *dsv				\
-				|NULLOK SV *sstr
+AMbdp	|void	|sv_catsv	|NN SV * const dsv			\
+				|NULLOK SV * const sstr
 Adp	|void	|sv_catsv_flags |NN SV * const dsv			\
 				|NULLOK SV * const sstr 		\
 				|const I32 flags
-AMbdp	|void	|sv_catsv_mg	|NN SV *dsv				\
-				|NULLOK SV *sstr
+AMbdp	|void	|sv_catsv_mg	|NN SV * const dsv			\
+				|NULLOK SV * const sstr
 Adp	|void	|sv_chop	|NN SV * const sv			\
 				|NULLOK const char * const ptr
 : Used only in perl.c

--- a/mathoms.c
+++ b/mathoms.c
@@ -256,7 +256,7 @@ Perl_sv_catpvn_mg(pTHX_ SV *dsv, const char *sstr, STRLEN len)
  */
 
 void
-Perl_sv_catsv(pTHX_ SV *dsv, SV *sstr)
+Perl_sv_catsv(pTHX_ SV *dsv, SV * const sstr)
 {
     PERL_ARGS_ASSERT_SV_CATSV;
 
@@ -264,7 +264,7 @@ Perl_sv_catsv(pTHX_ SV *dsv, SV *sstr)
 }
 
 void
-Perl_sv_catsv_mg(pTHX_ SV *dsv, SV *sstr)
+Perl_sv_catsv_mg(pTHX_ SV *dsv, SV * const sstr)
 {
     PERL_ARGS_ASSERT_SV_CATSV_MG;
 

--- a/proto.h
+++ b/proto.h
@@ -4380,7 +4380,7 @@ Perl_sv_catpv(pTHX_ SV * const dsv, const char *sstr);
         assert(dsv)
 
 PERL_CALLCONV void
-Perl_sv_catpv_flags(pTHX_ SV *dsv, const char *sstr, const I32 flags);
+Perl_sv_catpv_flags(pTHX_ SV * const dsv, const char *sstr, const I32 flags);
 #define PERL_ARGS_ASSERT_SV_CATPV_FLAGS         \
         assert(dsv); assert(sstr)
 

--- a/proto.h
+++ b/proto.h
@@ -5908,22 +5908,22 @@ Perl_sv_2uv(pTHX_ SV *sv);
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_catpvn(pTHX_ SV *dsv, const char *sstr, STRLEN len);
+Perl_sv_catpvn(pTHX_ SV * const dsv, const char *sstr, STRLEN len);
 # define PERL_ARGS_ASSERT_SV_CATPVN             \
         assert(dsv); assert(sstr)
 
 PERL_CALLCONV void
-Perl_sv_catpvn_mg(pTHX_ SV *dsv, const char *sstr, STRLEN len);
+Perl_sv_catpvn_mg(pTHX_ SV * const dsv, const char *sstr, STRLEN len);
 # define PERL_ARGS_ASSERT_SV_CATPVN_MG          \
         assert(dsv); assert(sstr)
 
 PERL_CALLCONV void
-Perl_sv_catsv(pTHX_ SV *dsv, SV *sstr);
+Perl_sv_catsv(pTHX_ SV * const dsv, SV * const sstr);
 # define PERL_ARGS_ASSERT_SV_CATSV              \
         assert(dsv)
 
 PERL_CALLCONV void
-Perl_sv_catsv_mg(pTHX_ SV *dsv, SV *sstr);
+Perl_sv_catsv_mg(pTHX_ SV * const dsv, SV * const sstr);
 # define PERL_ARGS_ASSERT_SV_CATSV_MG           \
         assert(dsv)
 

--- a/sv.c
+++ b/sv.c
@@ -5772,7 +5772,7 @@ Perl_sv_catpv(pTHX_ SV *const dsv, const char *sstr)
 }
 
 void
-Perl_sv_catpv_flags(pTHX_ SV *dsv, const char *sstr, const I32 flags)
+Perl_sv_catpv_flags(pTHX_ SV * const dsv, const char *sstr, const I32 flags)
 {
     PERL_ARGS_ASSERT_SV_CATPV_FLAGS;
     sv_catpvn_flags(dsv, sstr, strlen(sstr), flags);

--- a/sv.h
+++ b/sv.h
@@ -2242,7 +2242,7 @@ immediately written again.
         sv_setsv_flags(dsv, ssv, SV_GMAGIC|SV_DO_COW_SVSETSV)
 /*
 =for apidoc_defn Am|void|sv_setsv_nomg|SV *dsv|SV *ssv
-=for apidoc_defn Am|void|sv_catsv_nomg|SV *dsv|SV *ssv
+=for apidoc_defn Am|void|sv_catsv_nomg|SV * const dsv|SV * const sstr
 =cut
 */
 #define sv_setsv_nomg(dsv, ssv) sv_setsv_flags(dsv, ssv, SV_DO_COW_SVSETSV)


### PR DESCRIPTION
An advantage of combining API elements that do almost the same thing into a single group, is that disparities in their signatures become much more visible.  These are typically harmless, but sloppy practice.  These two commits fix a couple of those cases
`sv_catpv` and `sv_catsv`