### PR TITLE
make tests pass when build directory name contains @ $ \ "

### DIFF
--- a/t/io/pipe.t
+++ b/t/io/pipe.t
@@ -260,7 +260,7 @@ SKIP: {
     my $prog = <<PROG;
 \$SIG{ALRM}=sub{die};
 alarm 1;
-\$Perl = "$Perl";
+\$Perl = q\0$Perl\0;
 my \$cmd = qq(\$Perl -e "sleep 3");
 my \$pid = open my \$fh, "|\$cmd" or die "\$!\n";
 close \$fh;


### PR DESCRIPTION
If you build and test perl from a directory whose name contains an `@` sign (such as `/tmp/hello@world/perl5`), one of the tests in `t/io/pipe.t` fails.

This is because it takes the path to the perl binary (which is `/tmp/hello@world/perl5/perl` in our example) and interpolates it in double-quotes into a string that is then eval'd and run (via `fresh_perl()`). Thus the code that the interpreter in the child process sees is:

    $Perl = "/tmp/hello@world/perl5/perl";

which of course tries to interpolate the (non-existent) `@world` array. (Similar problems would be caused by paths containing `$` or `"` characters).

Switching to single quotes, as in

    $Perl = '/tmp/hello@world/perl5/perl';

would fix this case, but would still be vulnerable to a path containing `'` symbols.

Sidestep the problem by using `q` (to prevent variable interpolation) with a NUL byte delimiter (which cannot occur in path names).

Found while investigating #22446.