### PR TITLE
t/porting/cpphdrcheck.t: fix cc version fallback

### DIFF
--- a/t/porting/cpphdrcheck.t
+++ b/t/porting/cpphdrcheck.t
@@ -124,7 +124,7 @@ sub find_ccpp ($cc) {
         # intel C, Sun C
         # Sun C sends -V output to stderr
         my $ver = `$cc -V 2>&1`;
-        unless ($ver) {
+        if (!$ver || ($? && $ver =~ /\berror\b/)) {
             # gcc, clang
             $ver = `$cc --version 2>$devnull`;
         }


### PR DESCRIPTION
The `unless ($ver)` check doesn't work as intended because `` `$cc -V 2>&1` `` captures stderr (intentionally, for Sun C). This means with gcc or clang `$ver` ends up containing a true-ish string, either

    gcc: error: unrecognized command-line option ‘-V’
    gcc: fatal error: no input files
    compilation terminated.

or

    clang: error: argument to '-V' is missing (expected 1 value)
    clang: error: no input files

so the `$cc --version` fallback never runs.

Checking for a non-zero exit status and the word "error" in the output seems to work reliably, though.