### PR TITLE
perlipc.pod: correct the safe signals bypass suggestion

### DIFF
--- a/pod/perlipc.pod
+++ b/pod/perlipc.pod
@@ -310,7 +310,8 @@ written twice.
 Some networking library functions like gethostbyname() are known to have
 their own implementations of timeouts which may conflict with your
 timeouts.  If you have problems with such functions, try using the POSIX
-sigaction() function, which bypasses Perl safe signals.  Be warned that
+sigaction() function with SigAction objects, which bypass Perl safe signals
+unless you set their C<safe> flag explicitly.  Be warned that
 this does subject you to possible memory corruption, as described above.
 
 Instead of setting C<$SIG{ALRM}>:


### PR DESCRIPTION
This is a followup to the https://github.com/Perl/perl5/pull/22136#issuecomment-2262174418 discussion.