### PR TITLE
Use special macros to negate IV or UV

### DIFF
--- a/pp_hot.c
+++ b/pp_hot.c
@@ -1938,9 +1938,7 @@ PP(pp_add)
                         auv = aiv;
                         auvok = 1;	/* Now acting as a sign flag.  */
                     } else {
-                        /* Using 0- here and later to silence bogus warning
-                         * from MS VC */
-                        auv = (UV) (0 - (UV) aiv);
+                        auv = NEGATE_2UV(aiv);
                     }
                 }
                 a_valid = 1;
@@ -1960,7 +1958,7 @@ PP(pp_add)
                     buv = biv;
                     buvok = 1;
                 } else
-                    buv = (UV) (0 - (UV) biv);
+                    buv = NEGATE_2UV(biv);
             }
             /* ?uvok if value is >= 0. basically, flagged as UV if it's +ve,
                else "IV" now, independent of how it came in.
@@ -1999,9 +1997,8 @@ PP(pp_add)
                     TARGu(result,1);
                 else {
                     /* Negate result */
-                    if (result <= (UV)IV_MIN)
-                        TARGi(result == (UV)IV_MIN
-                                ? IV_MIN : -(IV)result, 1);
+                    if (result <= ABS_IV_MIN)
+                        TARGi(NEGATE_2IV(result), 1);
                     else {
                         /* result valid, but out of range for IV.  */
                         TARGn(-(NV)result, 1);

--- a/sv.c
+++ b/sv.c
@@ -2242,9 +2242,8 @@ S_sv_2iuv_common(pTHX_ SV *const sv)
                 }
             } else {
                 /* 2s complement assumption  */
-                if (value <= (UV)IV_MIN) {
-                    SvIV_set(sv, value == (UV)IV_MIN
-                                    ? IV_MIN : -(IV)value);
+                if (value <= ABS_IV_MIN) {
+                    SvIV_set(sv, NEGATE_2IV(value));
                 } else {
                     /* Too negative for an IV.  This is a double upgrade, but
                        I'm assuming it will be rare.  */
@@ -2396,10 +2395,10 @@ Perl_sv_2iv_flags(pTHX_ SV *const sv, const I32 flags)
                 == IS_NUMBER_IN_UV) {
                 /* It's definitely an integer */
                 if (numtype & IS_NUMBER_NEG) {
-                    if (value < (UV)IV_MIN)
-                        return -(IV)value;
+                    if (value <= ABS_IV_MIN)
+                        return NEGATE_2IV(value);
                 } else {
-                    if (value < (UV)IV_MAX)
+                    if (value <= (UV)IV_MAX)
                         return (IV)value;
                 }
             }


### PR DESCRIPTION
Negating IV or UV with countermeasures for signed integer overflow seems to be a common idiom in various sources in perl, such as `pp_*` functions and SV conversion functions.

This patch will unify such codes by adopting macros `NEGATE_2IV`, `NEGATE_2UV` and `ABS_IV_MIN` which I added in b9b8c7d2e8567b5c6652a643b4a44af22e06f2bc, and will hopefully simplify the source code and make the compiled code (slightly) smaller and faster (by eliminating the need of special treatment of IV_MIN).