### PR TITLE
open: only treat literal undef as special

### DIFF
--- a/doio.c
+++ b/doio.c
@@ -965,14 +965,9 @@ Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len,
                 IoTYPE(io) = IoTYPE_STD;
             }
             else {
-                if (num_svs) {
-                    fp = PerlIO_openn(aTHX_ type,mode,-1,0,0,NULL,num_svs,svp);
-                }
-                else {
-                    SV *namesv = newSVpvn_flags(type, tend - type, SVs_TEMP);
-                    type = NULL;
-                    fp = PerlIO_openn(aTHX_ type,mode,-1,0,0,NULL,1,&namesv);
-                }
+                SV *namesv = newSVpvn_flags(type, tend - type, SVs_TEMP);
+                type = NULL;
+                fp = PerlIO_openn(aTHX_ type,mode,-1,0,0,NULL,1,&namesv);
             }
         }
     }

--- a/doio.c
+++ b/doio.c
@@ -849,6 +849,9 @@ Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len,
                 }
                 else {
                     if (num_svs) {
+                        if (*svp == &PL_sv_undef && PL_op && !(PL_op->op_flags & OPf_SPECIAL)) {
+                            *svp = sv_newmortal();
+                        }
                         fp = PerlIO_openn(aTHX_ type,mode,-1,0,0,NULL,num_svs,svp);
                     }
                     else {
@@ -884,6 +887,9 @@ Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len,
             }
             else {
                 if (num_svs) {
+                    if (*svp == &PL_sv_undef && PL_op && !(PL_op->op_flags & OPf_SPECIAL)) {
+                        *svp = sv_newmortal();
+                    }
                     fp = PerlIO_openn(aTHX_ type,mode,-1,0,0,NULL,num_svs,svp);
                 }
                 else {

--- a/op.h
+++ b/op.h
@@ -164,6 +164,8 @@ Deprecated.  Use C<GIMME_V> instead.
                                 /*  On OP_RETURN, module_true is in effect */
                                 /*  On OP_NEXT/OP_LAST/OP_REDO, there is no
                                  *  loop label */
+                                /*  On OP_OPEN, create a temporary file if the
+                                 *  filename argument is &PL_sv_undef */
 /* There is no room in op_flags for this one, so it has its own bit-
    field member (op_folded) instead.  The flag is only used to tell
    op_convert_list to set op_folded.  */

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -389,6 +389,22 @@ manager will later use a regex to expand these into links.
 
 =item *
 
+L<C<open>|perlfunc/open> automatically creates an anonymous temporary file when
+passed C<undef> as a filename:
+
+    open(my $fh, "+>", undef) or die ...
+
+Due the way this feature was implemented, it would also trigger for
+non-existent elements of arrays or hashes:
+
+    open(my $fh, "+>", $hash{no_such_key}) or die ...
+    # unexpectedly succeeds and creates a temp file
+
+Now a temporary file is only created if a literal C<undef> is passed.
+[GH #22385]
+
+=item *
+
 Compound assignment operators return lvalues that can be further modified:
 
     ($x &= $y) += $z;


### PR DESCRIPTION
Passing undef as the filename to open should create a temporary file. Previously, this was implemented as a simple `if (arg == &PL_sv_undef)` check. However, other operations (such as accessing non-existent array/hash elements) also return `&PL_sv_undef` directly, which `open` would then silently interpret as directions to create a temp file.

Solution: Check (at compile time) whether the filename argument is an `OP_UNDEF`, and if so, set the `OPf_SPECIAL` flag on `OP_OPEN`. At runtime, if `&PL_sv_undef` is passed but `OPf_SPECIAL` is not set, replace it by a new mortal SV, which is treated as a regular filename (that happens to be undef) by PerlIO.

(For runtime calls via `&CORE::open`, we cannot distinguish between `undef` and `delete $hash{nosuchkey}` as arguments, so to keep the `undef` case working, we always set `OPf_SPECIAL` in the generated core sub for `open`.)

This functionality probably should be a private op flag (something like `OPpUNDEF_MEANS_TEMPFILE`?), but as far as I can tell, all possible private bits are already taken in `OP_OPEN`.

Fixes #22385.