### PR TITLE
warn about logical negation as operand of isa

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -5508,6 +5508,19 @@ If instead you intended to match the word 'foo' at the end of the line
 followed by whitespace and the word 'bar' on the next line then you can use
 C<m/$(?)\/> (for example: C<m/foo$(?)\s+bar/>).
 
+=item Possible precedence problem on isa operator
+
+(W precedence) You wrote something like
+
+    !$obj isa Some::Class
+
+but because C<!> has higher precedence than C<isa>, this is interpreted as
+C<(!$obj) isa Some::Class>, which checks whether a boolean is an instance of
+C<Some::Class>. If you want to negate the result of C<isa> instead, use one of:
+
+    !($obj isa Some::Class)   # explicit parentheses
+    not $obj isa Some::Class  # low-precedence 'not' operator
+
 =item Possible unintended interpolation of %s in string
 
 (W ambiguous) You said something like '@foo' in a double-quoted string

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -1577,6 +1577,18 @@ Possible precedence problem on bitwise |. operator at - line 26.
 Possible precedence problem on bitwise &. operator at - line 27.
 ########
 # op.c
+use warnings 'precedence';
+use feature 'isa';
+$a = !$b isa Some::Class;  # should warn
+$a = (!$b) isa Some::Class;
+$a = !($b) isa Some::Class;  # should warn
+$a = !($b isa Some::Class);
+$a = not $b isa Some::Class;
+EXPECT
+Possible precedence problem on isa operator at - line 4.
+Possible precedence problem on isa operator at - line 6.
+########
+# op.c
 use integer;
 use warnings 'precedence';
 $a = $b & $c == $d;


### PR DESCRIPTION
Code like `!$obj isa Some::Class` doesn't make sense, so emit a precedence warning.

(If you really want to test whether a boolean is an instance of some class, write `(!$obj) isa Some::Class`.)