### PR TITLE
toke.c: Use clearer synonym

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -3533,15 +3533,15 @@ S_scan_const(pTHX_ char *start)
                      * of the range is above that value.  We don't count the
                      * end points here, as they will already have been counted
                      * as they were parsed. */
-                    if (range_min >= UTF_CONTINUATION_MARK) {
+                    if (! OFFUNI_IS_INVARIANT(range_min)) {
 
                         /* The whole range is made up of variants */
                         extras = (range_max - 1) - (range_min + 1) + 1;
                     }
-                    else if (range_max >= UTF_CONTINUATION_MARK) {
+                    else if (! OFFUNI_IS_INVARIANT(range_max)) {
 
                         /* Only the higher portion of the range is variants */
-                        extras = (range_max - 1) - UTF_CONTINUATION_MARK + 1;
+                        extras = (range_max - 1) - MIN_OFFUNI_VARIANT_CP + 1;
                     }
 
                     utf8_variant_count += extras;

--- a/utf8.h
+++ b/utf8.h
@@ -373,8 +373,9 @@ are in the character. */
  * One could solve for two linear equations and come up with it.) */
 #define UTF_CONTINUATION_MARK       (UTF_IS_CONTINUATION_MASK & 0xB0)
 
-/* This value is clearer in some contexts; still applies to UTF, not UTF-8 */
+/* These values are clearer in some contexts; still apply to UTF, not UTF-8 */
 #define UTF_MIN_CONTINUATION_BYTE  UTF_CONTINUATION_MARK
+#define MIN_OFFUNI_VARIANT_CP  UTF_MIN_CONTINUATION_BYTE
 
 /* This is the name to use if you are working in UTF-8, as opposed to plain
  * 'UTF', which is I8 on EBCDIC platforms */
@@ -389,8 +390,7 @@ are in the character. */
 /* Is the representation of the Unicode code point 'cp' the same regardless of
  * being encoded in UTF-8 or not? This is a fundamental property of
  * UTF-8,EBCDIC */
-#define OFFUNI_IS_INVARIANT(c)                                              \
-                        (((WIDEST_UTYPE)(c)) < UTF_MIN_CONTINUATION_BYTE)
+#define OFFUNI_IS_INVARIANT(c) (((WIDEST_UTYPE)(c)) < MIN_OFFUNI_VARIANT_CP)
 
 /*
 =for apidoc Am|bool|UVCHR_IS_INVARIANT|UV cp


### PR DESCRIPTION
MARK here is very internal to UTF-8 guts.  There is a clearer synonym available.