### PR TITLE
 locale.c: Add debugging, work around for Darwin bug

### DIFF
--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -368,6 +368,9 @@ ccflags="$ccflags -DNO_THREAD_SAFE_QUERYLOCALE"
 # #21556]
 ccflags="$ccflags -DNO_POSIX_2008_LOCALE"
 
+# See comments in locale.c about this #define
+ccflags="$ccflags -DHAS_BROKEN_LANGINFO_CODESET"
+
 ldlibpthname='DYLD_LIBRARY_PATH';
 
 # useshrplib=true results in much slower startup times.


### PR DESCRIPTION
I just discovered that the libc function nl_langinfo() can unexpectedly
return an empty string on z/OS.  I added a panic when this happens to
help debug the issue, and found out that an empty string is returnable
on Darwin as well, and who knows on what other platforms.  This is not
supposed to happen when the function is given legal inputs, as it is
here.

The behavior is different between the two platforms.  So far, Darwin has
only done this for the CODESET query.  Doing some debugging on that
platform seems to indicate that the bug is that the OS is only looking
at the locale name to find the codeset, whereas that name can be a
simplified alias for the real locale.  The actual codeset requires
actually opening the definition file and reading it.  This is something
that glibc, for example, seems to be doing.  I have found many instances
on various platforms where the locale name clearly is the wrong codeset,
whereas the one returned by nl_langinfo() is.

A major use internally of nl_langinfo() is to determine if the LC_CTYPE
locale is UTF-8 or not.  But there are other methods to determine this
that we already turn to when nl_langinfo() is not available.  This is
the first indication I've seen of buggy implementations of this
function.  The other methods are reliable.  This commit allows a hints
file to indicate that the CODESET part of nl_langinfo() is buggy, and to
use those other methods for UTF8ness determination.

I expect that a non-empty nl_langinfo() return is the correct codeset on
Darwin; it really isn't feasible for perl to bypass the system call
designed to return the desired information and try to get at it
ourselves.  Much code doesn't need the actual codeset; just its UTF8ness
is the typical need, so this commit fixes that.

It remains to be seen what else is going on, and on which platforms.
This commit makes the panic display enough information, should it
happen, to indicate a path for debugging.