### PR TITLE
Langinfo.t: Fix broken pattern

### DIFF
--- a/ext/I18N-Langinfo/t/Langinfo.t
+++ b/ext/I18N-Langinfo/t/Langinfo.t
@@ -21,7 +21,7 @@ my %want = (    RADIXCHAR => qr/ ^ \. $ /x,
                 # Can be empty; otherwise first character must be one of
                 # these.  In the C locale, there is nothing after the first
                 # character.
-                CRNCYSTR  => qr/ ^ [+-.]? $ /x,
+                CRNCYSTR  => qr/ ^ [-+.]? $ /x,
 
                 _NL_ADDRESS_COUNTRY_NUM => qr/^ 0 $/x,
                 _NL_IDENTIFICATION_TERRITORY => qr/ ^ ISO $/x,


### PR DESCRIPTION
/[+-.]/ was supposed to match the three characters listed in it, but the minus is in the middle, meaning it matched a range, which turns out to be those three characters plus a comma (on ASCII platforms).

On EBCDIC platforms, this is an error since the range would go backwards.