### PR TITLE
threads.xs: only access the pool values when we hold the mutex

### DIFF
--- a/dist/threads/lib/threads.pm
+++ b/dist/threads/lib/threads.pm
@@ -5,7 +5,7 @@ use 5.008;
 use strict;
 use warnings;
 
-our $VERSION = '2.41';      # remember to update version in POD!
+our $VERSION = '2.42';      # remember to update version in POD!
 my $XS_VERSION = $VERSION;
 #$VERSION = eval $VERSION;
 
@@ -134,7 +134,7 @@ threads - Perl interpreter-based threads
 
 =head1 VERSION
 
-This document describes threads version 2.41
+This document describes threads version 2.42
 
 =head1 WARNING
 

--- a/dist/threads/threads.xs
+++ b/dist/threads/threads.xs
@@ -355,10 +355,19 @@ S_exit_warning(pTHX)
 {
     int veto_cleanup, warn;
     dMY_POOL;
+    IV running_threads;
+    IV joinable_threads;
+    IV detached_threads;
 
     MUTEX_LOCK(&MY_POOL.create_destruct_mutex);
-    veto_cleanup = (MY_POOL.total_threads > 0);
-    warn         = (MY_POOL.running_threads || MY_POOL.joinable_threads);
+
+    running_threads  = MY_POOL.running_threads;
+    joinable_threads = MY_POOL.joinable_threads;
+    detached_threads = MY_POOL.detached_threads;
+
+    veto_cleanup     = (MY_POOL.total_threads > 0);
+    warn             = (running_threads || joinable_threads);
+
     MUTEX_UNLOCK(&MY_POOL.create_destruct_mutex);
 
     if (warn) {
@@ -367,9 +376,9 @@ S_exit_warning(pTHX)
                             IVdf " running and unjoined\n\t%"
                             IVdf " finished and unjoined\n\t%"
                             IVdf " running and detached\n",
-                            MY_POOL.running_threads,
-                            MY_POOL.joinable_threads,
-                            MY_POOL.detached_threads);
+                            running_threads,
+                            joinable_threads,
+                            detached_threads);
         }
     }
 


### PR DESCRIPTION
Coverity complained specifically about accessing detached_threads and joinable_threads since we consistently otherwise hold the mutex when accessing them, but this code accesses those values for the warning without the mutex held.

running_threads has a similar issue.

fixes cid 498878, cid 498883