### PR TITLE
toke.c: Remove redundant code in scan_num()

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -12658,16 +12658,13 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
             UV uv;
             const int flags = grok_number (PL_tokenbuf, d - PL_tokenbuf, &uv);
 
+            /* scan_num only parses tokens beginning with a digit or '.'
+               which can't be a negative number. */
+            assert(!(flags & IS_NUMBER_NEG));
+
             if (flags == IS_NUMBER_IN_UV) {
-              if (uv <= IV_MAX)
-                sv = newSViv(uv); /* Prefer IVs over UVs. */
-              else
+                /* Note that newSVuv will create IV if uv <= IV_MAX */
                 sv = newSVuv(uv);
-            } else if (flags == (IS_NUMBER_IN_UV | IS_NUMBER_NEG)) {
-              if (uv <= (UV) IV_MIN)
-                sv = newSViv(-(IV)uv);
-              else
-                floatit = TRUE;
             } else
               floatit = TRUE;
         }


### PR DESCRIPTION
In preparing #22457, I've found that `Perl_scan_num` has similar code for negating UV, but further found that it will never executed.

`scan_num()` is called to parse tokens beginning with a digit, decimal point (`.`) or `v` (for v-string) only (otherwise `scan_num` will croak), and all of such tokens themselves cannot be negative. Therefore `grok_number()` for such token never returns `IS_NUMBER_NEG`, and `if (flags == (IS_NUMBER_IN_UV | IS_NUMBER_NEG))) ...` will never get true.

This PR will propose the removal of that always-false code.

In addition, `if (uv <= IV_MAX) sv = newSViv(uv); else sv = newSVuv(uv);` is simplified to `sv = newSVuv(uv);`, as `newSVuv()` itself will do the same thing.

With these changes no behavioral change are intended.