### PR TITLE
Don't retain 'storable-testfile-*' after completion of testing

### DIFF
--- a/dist/Storable/t/lib/STTestLib.pm
+++ b/dist/Storable/t/lib/STTestLib.pm
@@ -22,7 +22,7 @@ sub slurp {
 sub write_and_retrieve {
     my $data = shift;
 
-    my ($fh, $filename) = tempfile('storable-testfile-XXXXX', TMPDIR => 1);
+    my ($fh, $filename) = tempfile('storable-testfile-XXXXX', TMPDIR => 1, UNLINK => 1);
     binmode $fh;
     print $fh $data or die "Can't print to '$filename': $!";
     close $fh or die "Can't close '$filename': $!";
@@ -32,7 +32,7 @@ sub write_and_retrieve {
 
 sub tempfilename {
     local $^W;
-    my (undef, $file) = tempfile('storable-testfile-XXXXX', TMPDIR => 1, UNLINK => 1, OPEN => 0);
+    my (undef, $file) = tempfile('storable-testfile-XXXXX', TMPDIR => 1, UNLINK => 1);
     return $file;
 }
 

--- a/dist/Storable/t/malice.t
+++ b/dist/Storable/t/malice.t
@@ -280,9 +280,6 @@ test_things($contents, \&write_and_retrieve, 'file');
 my $stored = freeze \%hash;
 test_things($stored, sub { eval { thaw $_[0] } }, 'string');
 
-# Network order.
-unlink $file or die "Can't unlink '$file': $!";
-
 ok (defined nstore(\%hash, $file), "nstore() returned defined value");
 
 $expected = 20 + length ($file_magic_str) + $network_magic + $fancy;


### PR DESCRIPTION
When run in Perl core, make test was leaving 109 files in /tmp.  The two changes in this patch cleaned up 103 and 6 files, respectively.