### PR TITLE
warn about !$x == $y, !$x =~ /abc/, and similar constructs

### DIFF
--- a/embed.h
+++ b/embed.h
@@ -1242,6 +1242,7 @@
 #     define ck_rfun(a)                         Perl_ck_rfun(aTHX_ a)
 #     define ck_rvconst(a)                      Perl_ck_rvconst(aTHX_ a)
 #     define ck_sassign(a)                      Perl_ck_sassign(aTHX_ a)
+#     define ck_scmp(a)                         Perl_ck_scmp(aTHX_ a)
 #     define ck_select(a)                       Perl_ck_select(aTHX_ a)
 #     define ck_shift(a)                        Perl_ck_shift(aTHX_ a)
 #     define ck_sort(a)                         Perl_ck_sort(aTHX_ a)

--- a/opcode.h
+++ b/opcode.h
@@ -1494,12 +1494,12 @@ INIT({
 	Perl_ck_cmp,		/* i_ne */
 	Perl_ck_null,		/* ncmp */
 	Perl_ck_null,		/* i_ncmp */
-	Perl_ck_null,		/* slt */
-	Perl_ck_null,		/* sgt */
-	Perl_ck_null,		/* sle */
-	Perl_ck_null,		/* sge */
-	Perl_ck_null,		/* seq */
-	Perl_ck_null,		/* sne */
+	Perl_ck_scmp,		/* slt */
+	Perl_ck_scmp,		/* sgt */
+	Perl_ck_scmp,		/* sle */
+	Perl_ck_scmp,		/* sge */
+	Perl_ck_scmp,		/* seq */
+	Perl_ck_scmp,		/* sne */
 	Perl_ck_null,		/* scmp */
 	Perl_ck_bitop,		/* bit_and */
 	Perl_ck_bitop,		/* bit_xor */

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -5427,6 +5427,42 @@ Note this may be also triggered for constructs like:
 
     sub { 1 if die; }
 
+=item Possible precedence problem between ! and %s
+
+(W precedence) You wrote something like
+
+    !$x < $y               # parsed as: (!$x) < $y
+    !$x eq $y              # parsed as: (!$x) eq $y
+    !$x =~ /regex/         # parsed as: (!$x) =~ /regex/
+    !$obj isa Some::Class  # parsed as: (!$obj) isa Some::Class
+
+but because C<!> has higher precedence than comparison operators, C<=~>, and
+C<isa>, this is interpreted as comparing/matching the logical negation of the
+first operand, instead of negating the result of the comparison/match.
+
+To disambiguate, either use a negated comparison/binding operator:
+
+    $x >= $y
+    $x ne $y
+    $x !~ /regex/
+
+... or parentheses:
+
+    !($x < $y)
+    !($x eq $y)
+    !($x =~ /regex/)
+    !($obj isa Some::Class)
+
+... or the low-precedence C<not> operator:
+
+    not $x < $y
+    not $x eq $y
+    not $x =~ /regex/
+    not $obj isa Some::Class
+
+(If you did mean to compare the boolean result of negating the first operand,
+parenthesize as C<< (!$x) < $y >>, C<< (!$x) eq $y >>, etc.)
+
 =item Possible precedence problem on bitwise %s operator
 
 (W precedence) Your program uses a bitwise logical operator in conjunction
@@ -5452,19 +5488,6 @@ C<m/${\}/> (for example: C<m/foo${\}s+bar/>).
 If instead you intended to match the word 'foo' at the end of the line
 followed by whitespace and the word 'bar' on the next line then you can use
 C<m/$(?)\/> (for example: C<m/foo$(?)\s+bar/>).
-
-=item Possible precedence problem on isa operator
-
-(W precedence) You wrote something like
-
-    !$obj isa Some::Class
-
-but because C<!> has higher precedence than C<isa>, this is interpreted as
-C<(!$obj) isa Some::Class>, which checks whether a boolean is an instance of
-C<Some::Class>. If you want to negate the result of C<isa> instead, use one of:
-
-    !($obj isa Some::Class)   # explicit parentheses
-    not $obj isa Some::Class  # low-precedence 'not' operator
 
 =item Possible unintended interpolation of %s in string
 

--- a/proto.h
+++ b/proto.h
@@ -6466,6 +6466,13 @@ Perl_ck_sassign(pTHX_ OP *o)
         assert(o)
 
 PERL_CALLCONV OP *
+Perl_ck_scmp(pTHX_ OP *o)
+        __attribute__warn_unused_result__
+        __attribute__visibility__("hidden");
+# define PERL_ARGS_ASSERT_CK_SCMP               \
+        assert(o)
+
+PERL_CALLCONV OP *
 Perl_ck_select(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");

--- a/regen/opcodes
+++ b/regen/opcodes
@@ -153,12 +153,12 @@ i_ne		integer ne (!=)		ck_cmp		ifs2	S S<
 ncmp		numeric comparison (<=>)	ck_null		Iifst2	S S<
 i_ncmp		integer comparison (<=>)	ck_null		ifst2	S S<
 
-slt		string lt		ck_null		ifs2	S S
-sgt		string gt		ck_null		ifs2	S S
-sle		string le		ck_null		ifs2	S S
-sge		string ge		ck_null		ifs2	S S
-seq		string eq		ck_null		ifs2	S S
-sne		string ne		ck_null		ifs2	S S
+slt		string lt		ck_scmp		ifs2	S S
+sgt		string gt		ck_scmp		ifs2	S S
+sle		string le		ck_scmp		ifs2	S S
+sge		string ge		ck_scmp		ifs2	S S
+seq		string eq		ck_scmp		ifs2	S S
+sne		string ne		ck_scmp		ifs2	S S
 scmp		string comparison (cmp)	ck_null		ifst2	S S
 
 bit_and		bitwise and (&)		ck_bitop	fst2	S S|

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -1582,9 +1582,82 @@ $a = (!$b) isa Some::Class;
 $a = !($b) isa Some::Class;  # should warn
 $a = !($b isa Some::Class);
 $a = not $b isa Some::Class;
+
+my $code = "#line 1 [cmp]\n";
+for my $op (qw( == != < > <= >= eq ne lt gt le ge )) {
+    $code .= "\$a = !\$a $op \$b;\n";  # should warn
+    $code .= "\$a = (!\$a) $op \$b;\n";
+    $code .= "\$a = !(\$a) $op \$b;\n";  # should warn
+    $code .= "\$a = !(\$a $op \$b);\n";
+    $code .= "\$a = not \$a $op \$b;\n";
+}
+$a = $b = 0;
+eval $code;
+die $@ if $@;
+
+$_ = '';
+$a = !/x/;
+
+$code = "#line 1 [bind]\n";
+for my $rhs (qw( /x/ $b tr/x/x/ tr!x!y!r s!x!y!r )) {
+    for my $bind ('=~', $rhs =~ /!r\z/ ? () : '!~') {
+        $code .= "\$a = !\$a $bind $rhs;\n";  # should warn
+        $code .= "\$a = (!\$a) $bind $rhs;\n";
+        $code .= "\$a = !(\$a) $bind $rhs;\n";  # should warn
+        $code .= "\$a = !(\$a $bind $rhs);\n";
+        $code .= "\$a = not \$a $bind $rhs;\n";
+    }
+}
+$a = $b = 0;
+eval $code;
+die $@ if $@;
+
+# doesn't compile, but should warn anyway
+eval "#line 1 [extra]\n" . '$a = !$a =~ s/x/y/';
 EXPECT
-Possible precedence problem on isa operator at - line 4.
-Possible precedence problem on isa operator at - line 6.
+Possible precedence problem between ! and derived class test at - line 4.
+Possible precedence problem between ! and derived class test at - line 6.
+Possible precedence problem between ! and numeric eq (==) at [cmp] line 1.
+Possible precedence problem between ! and numeric eq (==) at [cmp] line 3.
+Possible precedence problem between ! and numeric ne (!=) at [cmp] line 6.
+Possible precedence problem between ! and numeric ne (!=) at [cmp] line 8.
+Possible precedence problem between ! and numeric lt (<) at [cmp] line 11.
+Possible precedence problem between ! and numeric lt (<) at [cmp] line 13.
+Possible precedence problem between ! and numeric gt (>) at [cmp] line 16.
+Possible precedence problem between ! and numeric gt (>) at [cmp] line 18.
+Possible precedence problem between ! and numeric le (<=) at [cmp] line 21.
+Possible precedence problem between ! and numeric le (<=) at [cmp] line 23.
+Possible precedence problem between ! and numeric ge (>=) at [cmp] line 26.
+Possible precedence problem between ! and numeric ge (>=) at [cmp] line 28.
+Possible precedence problem between ! and string eq at [cmp] line 31.
+Possible precedence problem between ! and string eq at [cmp] line 33.
+Possible precedence problem between ! and string ne at [cmp] line 36.
+Possible precedence problem between ! and string ne at [cmp] line 38.
+Possible precedence problem between ! and string lt at [cmp] line 41.
+Possible precedence problem between ! and string lt at [cmp] line 43.
+Possible precedence problem between ! and string gt at [cmp] line 46.
+Possible precedence problem between ! and string gt at [cmp] line 48.
+Possible precedence problem between ! and string le at [cmp] line 51.
+Possible precedence problem between ! and string le at [cmp] line 53.
+Possible precedence problem between ! and string ge at [cmp] line 56.
+Possible precedence problem between ! and string ge at [cmp] line 58.
+Possible precedence problem between ! and pattern match (m//) at [bind] line 1.
+Possible precedence problem between ! and pattern match (m//) at [bind] line 3.
+Possible precedence problem between ! and pattern match (m//) at [bind] line 6.
+Possible precedence problem between ! and pattern match (m//) at [bind] line 8.
+Possible precedence problem between ! and pattern match (m//) at [bind] line 11.
+Possible precedence problem between ! and pattern match (m//) at [bind] line 13.
+Possible precedence problem between ! and pattern match (m//) at [bind] line 16.
+Possible precedence problem between ! and pattern match (m//) at [bind] line 18.
+Possible precedence problem between ! and transliteration (tr///) at [bind] line 21.
+Possible precedence problem between ! and transliteration (tr///) at [bind] line 23.
+Possible precedence problem between ! and transliteration (tr///) at [bind] line 26.
+Possible precedence problem between ! and transliteration (tr///) at [bind] line 28.
+Possible precedence problem between ! and transliteration (tr///) at [bind] line 31.
+Possible precedence problem between ! and transliteration (tr///) at [bind] line 33.
+Possible precedence problem between ! and substitution (s///) at [bind] line 36.
+Possible precedence problem between ! and substitution (s///) at [bind] line 38.
+Possible precedence problem between ! and substitution (s///) at [extra] line 1.
 ########
 # op.c
 use integer;

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -1577,6 +1577,8 @@ Possible precedence problem on bitwise &. operator at - line 27.
 # op.c
 use warnings 'precedence';
 use feature 'isa';
+use constant A_CONSTANT => 42;
+
 $a = !$b isa Some::Class;  # should warn
 $a = (!$b) isa Some::Class;
 $a = !($b) isa Some::Class;  # should warn
@@ -1589,6 +1591,8 @@ for my $op (qw( == != < > <= >= eq ne lt gt le ge )) {
     $code .= "\$a = (!\$a) $op \$b;\n";
     $code .= "\$a = !(\$a) $op \$b;\n";  # should warn
     $code .= "\$a = !(\$a $op \$b);\n";
+    $code .= "\$a = !\$a $op !0;\n";
+    $code .= "\$a = !\$a $op !A_CONSTANT;\n";
     $code .= "\$a = not \$a $op \$b;\n";
 }
 $a = $b = 0;
@@ -1615,32 +1619,32 @@ die $@ if $@;
 # doesn't compile, but should warn anyway
 eval "#line 1 [extra]\n" . '$a = !$a =~ s/x/y/';
 EXPECT
-Possible precedence problem between ! and derived class test at - line 4.
 Possible precedence problem between ! and derived class test at - line 6.
+Possible precedence problem between ! and derived class test at - line 8.
 Possible precedence problem between ! and numeric eq (==) at [cmp] line 1.
 Possible precedence problem between ! and numeric eq (==) at [cmp] line 3.
-Possible precedence problem between ! and numeric ne (!=) at [cmp] line 6.
 Possible precedence problem between ! and numeric ne (!=) at [cmp] line 8.
-Possible precedence problem between ! and numeric lt (<) at [cmp] line 11.
-Possible precedence problem between ! and numeric lt (<) at [cmp] line 13.
-Possible precedence problem between ! and numeric gt (>) at [cmp] line 16.
-Possible precedence problem between ! and numeric gt (>) at [cmp] line 18.
-Possible precedence problem between ! and numeric le (<=) at [cmp] line 21.
-Possible precedence problem between ! and numeric le (<=) at [cmp] line 23.
-Possible precedence problem between ! and numeric ge (>=) at [cmp] line 26.
-Possible precedence problem between ! and numeric ge (>=) at [cmp] line 28.
-Possible precedence problem between ! and string eq at [cmp] line 31.
-Possible precedence problem between ! and string eq at [cmp] line 33.
-Possible precedence problem between ! and string ne at [cmp] line 36.
-Possible precedence problem between ! and string ne at [cmp] line 38.
-Possible precedence problem between ! and string lt at [cmp] line 41.
-Possible precedence problem between ! and string lt at [cmp] line 43.
-Possible precedence problem between ! and string gt at [cmp] line 46.
-Possible precedence problem between ! and string gt at [cmp] line 48.
-Possible precedence problem between ! and string le at [cmp] line 51.
-Possible precedence problem between ! and string le at [cmp] line 53.
-Possible precedence problem between ! and string ge at [cmp] line 56.
-Possible precedence problem between ! and string ge at [cmp] line 58.
+Possible precedence problem between ! and numeric ne (!=) at [cmp] line 10.
+Possible precedence problem between ! and numeric lt (<) at [cmp] line 15.
+Possible precedence problem between ! and numeric lt (<) at [cmp] line 17.
+Possible precedence problem between ! and numeric gt (>) at [cmp] line 22.
+Possible precedence problem between ! and numeric gt (>) at [cmp] line 24.
+Possible precedence problem between ! and numeric le (<=) at [cmp] line 29.
+Possible precedence problem between ! and numeric le (<=) at [cmp] line 31.
+Possible precedence problem between ! and numeric ge (>=) at [cmp] line 36.
+Possible precedence problem between ! and numeric ge (>=) at [cmp] line 38.
+Possible precedence problem between ! and string eq at [cmp] line 43.
+Possible precedence problem between ! and string eq at [cmp] line 45.
+Possible precedence problem between ! and string ne at [cmp] line 50.
+Possible precedence problem between ! and string ne at [cmp] line 52.
+Possible precedence problem between ! and string lt at [cmp] line 57.
+Possible precedence problem between ! and string lt at [cmp] line 59.
+Possible precedence problem between ! and string gt at [cmp] line 64.
+Possible precedence problem between ! and string gt at [cmp] line 66.
+Possible precedence problem between ! and string le at [cmp] line 71.
+Possible precedence problem between ! and string le at [cmp] line 73.
+Possible precedence problem between ! and string ge at [cmp] line 78.
+Possible precedence problem between ! and string ge at [cmp] line 80.
 Possible precedence problem between ! and pattern match (m//) at [bind] line 1.
 Possible precedence problem between ! and pattern match (m//) at [bind] line 3.
 Possible precedence problem between ! and pattern match (m//) at [bind] line 6.


### PR DESCRIPTION
Commit 2f48e46b3f6d2d introduced a warning for logical negation as the left operand of the `isa` operator, which likely indicates a precedence problem (i.e. the programmer wrote `! $x isa $y` when they probably meant `!($x isa $y)`).

This commit extends the warning to all (in)equality comparisons (`==`, `!=`, `<`, `>`, `<=`, `>=`, `eq`, `ne`, `lt`, `gt`, `le`, `ge`) as well as binding operations (`=~`, `!~`).

As an indication that such a warning is useful in the real world, the core currently contains two files with (likely broken) code that triggers this warning:

  - ./cpan/Test-Simple/lib/Test2/Hub.pm
  - ./cpan/Scalar-List-Utils/t/uniqnum.t