### PR TITLE
Porting/sync-with-cpan: fix SYNCINFO update logic

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -401,7 +401,6 @@ our %Modules = (
     'Encode' => {
         'DISTRIBUTION' => 'DANKOGAI/Encode-3.21.tar.gz',
         'SYNCINFO'     => 'jkeenan on Sun Feb 25 19:56:46 2024',
-        'SYNCINFO'     => 'jkeenan on Fri Nov 10 15:12:07 2023',
         'FILES'        => q[cpan/Encode],
         'EXCLUDED'     => [
             qw( t/whatwg-aliases.json
@@ -612,7 +611,6 @@ our %Modules = (
     'Getopt::Long' => {
         'DISTRIBUTION' => 'JV/Getopt-Long-2.58.tar.gz',
         'SYNCINFO'     => 'jkeenan on Wed Jun 12 08:25:08 2024',
-        'SYNCINFO'     => 'jkeenan on Sat Nov 11 13:09:21 2023',
         'FILES'        => q[cpan/Getopt-Long],
         'EXCLUDED'     => [
             qr{^examples/},
@@ -761,8 +759,6 @@ our %Modules = (
     'Math::BigInt' => {
         'DISTRIBUTION' => 'PJACKLAM/Math-BigInt-2.003003.tar.gz',
         'SYNCINFO'     => 'jkeenan on Wed Jun 12 08:50:03 2024',
-        'SYNCINFO'     => 'corion on Thu Jan 11 20:23:12 2024',
-        'SYNCINFO'     => 'book on Tue Dec 26 22:44:58 2023',
         'FILES'        => q[cpan/Math-BigInt],
         'EXCLUDED'     => [
             qr{^xt/},
@@ -776,8 +772,6 @@ our %Modules = (
     'Math::BigInt::FastCalc' => {
         'DISTRIBUTION' => 'PJACKLAM/Math-BigInt-FastCalc-0.5018.tar.gz',
         'SYNCINFO'     => 'corion on Thu Jan 11 20:24:21 2024',
-        'SYNCINFO'     => 'jkeenan on Sat Dec 30 14:31:28 2023',
-        'SYNCINFO'     => 'jkeenan on Sun Sep 24 08:29:56 2023',
         'FILES'        => q[cpan/Math-BigInt-FastCalc],
         'EXCLUDED'     => [
             qr{^inc/},
@@ -925,7 +919,6 @@ our %Modules = (
     'Pod::Checker' => {
         'DISTRIBUTION' => 'MAREKR/Pod-Checker-1.77.tar.gz',
         'SYNCINFO'     => 'jkeenan on Mon Feb  5 16:37:53 2024',
-        'SYNCINFO'     => 'corion on Tue Jan  9 20:34:18 2024',
         'FILES'        => q[cpan/Pod-Checker],
     },
 
@@ -1086,7 +1079,6 @@ our %Modules = (
     'Term::Table' => {
         'DISTRIBUTION' => 'EXODIST/Term-Table-0.020.tar.gz',
         'SYNCINFO'     => 'jkeenan on Mon Aug  5 21:13:24 2024',
-        'SYNCINFO'     => 'jkeenan on Wed Nov  1 19:16:24 2023',
         'FILES'        => q[cpan/Term-Table],
         'EXCLUDED'     => [
             qw( appveyor.yml ),
@@ -1122,8 +1114,6 @@ our %Modules = (
     'Test::Simple' => {
         'DISTRIBUTION' => 'EXODIST/Test-Simple-1.302200.tar.gz',
         'SYNCINFO'     => 'jkeenan on Tue Aug  6 07:52:25 2024',
-        'SYNCINFO'     => 'LeoNerd on Sat Apr 27 10:20:58 2024',
-        'SYNCINFO'     => 'jkeenan on Fri Dec  1 07:01:54 2023',
         'FILES'        => q[cpan/Test-Simple],
         'EXCLUDED'     => [
             qr{^examples/},

--- a/Porting/sync-with-cpan
+++ b/Porting/sync-with-cpan
@@ -144,10 +144,6 @@ Show help.
 
 =item *
 
-Update F<Porting/Maintainers.pl>
-
-=item *
-
 Optional, run a full test suite
 
 =item *

--- a/Porting/sync-with-cpan
+++ b/Porting/sync-with-cpan
@@ -824,10 +824,7 @@ while (<$Maintainers_pl>) {
             my $date = localtime;
             my $user = $ENV{USER} ? "$ENV{USER} on " : "";
             my $key = "SYNCINFO";
-            if ( /^'([A-Z_]+)'\s+=>/ and $1 eq $key) {
-                s/(=>\s+)'[^']+'/$1'$user$date'/;
-            }
-            else {
+            unless (s/^ \s* '\Q$key\E' \s* => \s* \K '[^']+' /'$user$date'/x) {
                 print $new_Maintainers_pl
                     "        '$key'     => '$user$date',\n";
             }


### PR DESCRIPTION
The intent of the code was to update the `'SYNCINFO' => '...'` line if it was already there, and add it if not. However, the regex that checked for the presence of SYNCINFO didn't handle leading spaces: It only checked for `'SYNCINFO'` at the beginning of the line. Since all SYNCINFO entries were added with leading spaces (properly indented), this never matched and new SYNCINFO lines were added each time.

Furthermore, since the new SYNCINFO lines were added early, the latest SYNCINFO was always at the top. The generated code is part of a hash initializer, so the last (oldest) entry would always "win", overwriting the newer SYNCINFO at runtime. In practice this means once a module had a SYNCINFO key in `Porting/Maintainers.pl`, consumers of this data would never see any updates to SYNCINFO.

There was another issue: If a `'SYNCINFO' =>` line was present, but the rest of the line couldn't be parsed, the code simply wouldn't do anything, neither updating nor adding any SYNCINFO entries.

This commit modifies the regex to allow leading whitespace when checking for SYNCINFO lines. It also performs the test and update in a single s/// instead of reparsing bits and pieces. Finally, it removes old accumulated SYNCINFO entries from `Porting/Maintainers.pl`.