### PR TITLE
perldelta for ae78ae4a0f2, smart match removal

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -56,6 +56,21 @@ now been removed.
 
 [github #22303]
 
+=head2 Switch and Smart Match operator removed
+
+The "switch" feature and the smartmatch operator, C<~~>, were introduced in
+v5.10.  Their behavior was significantly changed in v5.10.1.  When the
+"experiment" system was added in v5.18.0, switch and smartmatch were
+retroactively declared experimental.  Over the years, proposals to fix or
+supplement the features have come and gone.
+
+They were deprecated in Perl v5.38.0 and scheduled for removal in Perl
+5.42.0
+
+These features have now been entirely removed.
+
+[github #22370]
+
 =head1 Deprecations
 
 XXX Any deprecated features, syntax, modules etc. should be listed here.

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -69,6 +69,32 @@ They were deprecated in Perl v5.38.0 and scheduled for removal in Perl
 
 These features have now been entirely removed.
 
+If you code currently uses C<given>/C<when> or smart match this can be
+replaced with an C<if>/C<else> chain, or there are several alternative
+"switch" or smart match implementations on CPAN.
+
+In no particular order:
+
+=over
+
+=item *
+
+L<Syntax::Infix::Smartmatch|https://metacpan.org/pod/Syntax::Infix::Smartmatch>
+
+=item *
+
+L<Switch::Back|https://metacpan.org/pod/Switch::Back>
+
+=item *
+
+L<Syntax::Operator::Matches|https://metacpan.org/pod/Syntax::Operator::Matches>
+
+=item *
+
+L<Syntax::Keyword::Match|https://metacpan.org/pod/Syntax::Keyword::Match>
+
+=back
+
 [github #22370]
 
 =head1 Deprecations


### PR DESCRIPTION
Largely copied from the deprecation notice in perl5380delta