### PR TITLE
perlcall: Note that plain GIMME is deprecated

### DIFF
--- a/pod/perlcall.pod
+++ b/pod/perlcall.pod
@@ -375,7 +375,7 @@ executing subroutine in Perl with I<wantarray>.  The equivalent test
 can be made in C by using the C<GIMME_V> macro, which returns
 C<G_LIST> if you have been called in a list context, C<G_SCALAR> if
 in a scalar context, or C<G_VOID> if in a void context (i.e., the
-return value will not be used).  An older version of this macro is
+return value will not be used).  A deprecated older version of this macro is
 called C<GIMME>; in a void context it returns C<G_SCALAR> instead of
 C<G_VOID>.  An example of using the C<GIMME_V> macro is shown in
 section L</Using GIMME_V>.


### PR DESCRIPTION
Don't mention it without also mentioning that it is deprecated to use.