### PR TITLE
my_strnlen() Do assert() before the op it protects against

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -3892,9 +3892,9 @@ implementation stolen from PostgreSQL.
 PERL_STATIC_INLINE Size_t
 Perl_my_strnlen(const char *str, Size_t maxlen)
 {
-    const char *end = (const char *) memchr(str, '\0', maxlen);
-
     PERL_ARGS_ASSERT_MY_STRNLEN;
+
+    const char *end = (const char *) memchr(str, '\0', maxlen);
 
     if (end == NULL) return maxlen;
     return end - str;


### PR DESCRIPTION
The initialization of this variable should always have been split off from the declaration and done after the assert() that PERL_ARGS_ASSERT macro expands to.

But in C99 we can just swap the lines and leave the declaration and initialization joined.