### PR TITLE
Fix \d script run with unusual Unicode data layout

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -11889,7 +11889,22 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 * s, const U8 * send, const bool utf8_target)
                              */
             }
 
-            zero_of_char = decimals_array[index_of_zero_of_char];
+            /* Here, is a digit.  Unicode guarantees that the range that
+             * contains it will include all 10 consecutive digits.  It also
+             * guarantees that the numeric value of the first digit in the
+             * range will be 0.  But, be careful, that first digit need not be
+             * the zero of this run!  This happens if Unicode has allocated
+             * several adjacent 10-digit runs.  'decimals_invlist' groups them
+             * all into a single range, and the first character is indeed a
+             * DIGIT 0, but is the zero of only the first run.  U+1D7CE, for
+             * example, starts a single range of 50 \d characters.  These
+             * actually form 5 adjacent runs of 10 digits each, all in the
+             * Common script.
+             *      (cp - U+1D7CE) % 10
+             * yields a value 0..9 which is the offset from cp's zero digit
+             * code point. */
+            zero_of_char =   cp
+                         -  ((cp - decimals_array[index_of_zero_of_char]) % 10);
         }
 
         /* Here, the character is a decimal digit, and the zero of its sequence

--- a/t/re/script_run.t
+++ b/t/re/script_run.t
@@ -117,6 +117,13 @@ foreach my $type ('script_run', 'sr', 'atomic_script_run', 'asr') {
     like("\x{1d7ce}αβγ", qr/^(*sr:.{4})/,
          "Non-ASCII Common digits work with Greek"); # perl #133547
 
+    # GH #22535
+    unlike("A\x{1d7f5}\x{1d7ff}B", qr/^(*sr:.{4})/,
+           "Verify works when Unicode has multiple adjacent \\d runs,"
+         . " in different runs");
+    like("A\x{1d7f6}\x{1d7ff}B", qr/^(*sr:.{4})/,
+         "Verify works when Unicode has multiple adjacent \\d runs, same run");
+
     fresh_perl_is('print scalar "0" =~ m!(((*sr:()|)0)(*sr:)0|)!;',
                   1, {}, '[perl #133997]');
 


### PR DESCRIPTION
This fixes GH #22535

Unicode guarantees that \d code points occur in groups of 10 consecutive ones, with the lowest having a numeric value of 0 and the highest having a value of 9.

A script run in a regular expression pattern matches only characters in a single script.  Further, if more than a single digit is matched, all must come from the same group of 10 consecutive code points.

The 'Common' script has many such groups, not just 0-9.  Perl's implementation assumed that all groups were isolated from each other in the Unicode ordering of code points.  This is true in all but one case where there are 5 groups which adjoin each other.  This commit changes the implementation to be cognizant of this possibility.