### PR TITLE
t/test.pl: Handle displaying of read-only items

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6644,6 +6644,7 @@ t/TEST					The regression tester
 t/test.pl				Simple testing library
 t/test_pl/_num_to_alpha.t		Tests for the simple testing library
 t/test_pl/can_isa_ok.t			Tests for the simple testing library
+t/test_pl/display.t			Tests for the simple testing library
 t/test_pl/plan_skip_all.t		Tests for the simple testing library
 t/test_pl/tempfile.t			Tests for the simple testing library
 t/thread_it.pl				Run regression tests in a new thread

--- a/t/test.pl
+++ b/t/test.pl
@@ -313,7 +313,8 @@ foreach my $x (split //, 'enrtfa\\\'"') {
 # Trying to avoid setting $_, or relying on local $_ to work.
 sub display {
     my @result;
-    foreach my $x (@_) {
+    foreach my $element (@_) {
+        my $x = $element; # Make a copy in case @_ contains unmodifiable elements
         if (defined $x and not ref $x) {
             my $y = '';
             foreach my $c (unpack($chars_template, $x)) {

--- a/t/test_pl/display.t
+++ b/t/test_pl/display.t
@@ -1,0 +1,11 @@
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+}
+
+# This test used to die. See GH #22537.
+my $t = eval { display("ABC \x{20AC}") };
+is $@, '', "display() doesn't die on read-only strings";
+is $t, 'ABC \\x{20ac}', 'display() escapes Unicode characters correctly';
+
+done_testing();


### PR DESCRIPTION
The function display() prettifies its input for display for better human consumption.  But it does this by actually modifiying the input, so will crash when passed a read-only value,  The simple solution is to make a copy of the input, and modify that instead.

I'm somewhat surprised this hasn't come up before.  A simple

    like("A", qr/B/)

triggers it.