### PR TITLE
japh: Adapt Autoload 1 test to removal of apostrophe

### DIFF
--- a/t/japh/abigail.t
+++ b/t/japh/abigail.t
@@ -313,9 +313,9 @@ SWITCHES
 SKIP: Times::JulianDay not part of the main distribution.
 
 #######  Autoload 1.
-sub _'_{$_'_=~s/$a/$_/}map{$$_=$Z++}Y,a..z,A..X;*{($_::_=sprintf+q=%X==>"$A$Y".
+sub _::_{$_::_=~s/$a/$_/}map{$$_=$Z++}Y,a..z,A..X;*{($_::_=sprintf+q=%X==>"$A$Y".
 "$b$r$T$u")=~s~0~O~g;map+_::_,U=>T=>L=>$Z;$_::_}=*_;sub _{print+/.*::(.*)/s};;;
-*{chr($b*$e)}=*_'_;*__=*{chr(1<<$e)};                # Perl 5.6.0 broke this...
+*{chr($b*$e)}=*_::_;*__=*{chr(1<<$e)};                # Perl 5.6.0 broke this...
 _::_(r(e(k(c(a(H(__(l(r(e(P(__(r(e(h(t(o(n(a(__(t(us(J())))))))))))))))))))))))
 EXPECT: Just__another__Perl__Hacker
 


### PR DESCRIPTION
There are 4 other tests in t/japh/abigail.t currently failing.