### PR TITLE
Add exit code test (refurbish p.r. 19152 for issue 19020)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6337,7 +6337,7 @@ t/op/isa.t				See if isa works
 t/op/join.t				See if join works
 t/op/kill0.t				See if kill works
 t/op/kill0_child			Process tree script that is kill()ed
-t/op/kill9_shell_exit.t	Check for correct exit code on shell execution kill signal
+t/op/kill9_shell_exit.t			Check for correct exit code on shell execution kill signal
 t/op/kvaslice.t				See if index/value array slices work
 t/op/kvhslice.t				See if key/value hash slices work
 t/op/lc.t				See if lc, uc, lcfirst, ucfirst, quotemeta work

--- a/MANIFEST
+++ b/MANIFEST
@@ -6337,6 +6337,7 @@ t/op/isa.t				See if isa works
 t/op/join.t				See if join works
 t/op/kill0.t				See if kill works
 t/op/kill0_child			Process tree script that is kill()ed
+t/op/kill9_shell_exit.t	Check for correct exit code on shell execution kill signal
 t/op/kvaslice.t				See if index/value array slices work
 t/op/kvhslice.t				See if key/value hash slices work
 t/op/lc.t				See if lc, uc, lcfirst, ucfirst, quotemeta work

--- a/t/op/kill9_shell_exit.t
+++ b/t/op/kill9_shell_exit.t
@@ -1,0 +1,20 @@
+#!./perl -w
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+}
+
+use strict;
+use warnings;
+
+plan( 'tests' => 4 );
+
+my $res  = system qq($^X -e'\''kill "KILL", \$\$; sleep 100'\'');
+my $exit = $?;
+
+is( $res, $exit, "system() result ($res) and \$? ($exit) are the same" );
+is( $exit, 9, "\$? ($exit) from a KILL signal is 9" );
+is( $exit >> 8, 0, 'OS exit code (shifted) is 0' );
+is( $exit & 127, 9, 'KILL signal (bitwise ANDed exit) is 9' );

--- a/t/op/kill9_shell_exit.t
+++ b/t/op/kill9_shell_exit.t
@@ -14,7 +14,18 @@ plan( 'tests' => 4 );
 my $res  = system qq($^X -e'\''kill "KILL", \$\$; sleep 100'\'');
 my $exit = $?;
 
+our $TODO;
+
 is( $res, $exit, "system() result ($res) and \$? ($exit) are the same" );
-is( $exit, 9, "\$? ($exit) from a KILL signal is 9" );
-is( $exit >> 8, 0, 'OS exit code (shifted) is 0' );
-is( $exit & 127, 9, 'KILL signal (bitwise ANDed exit) is 9' );
+TODO: {
+    local $TODO = "GH #19020 on $^O";
+    is( $exit, 9, "\$? ($exit) from a KILL signal is 9" );
+}
+TODO: {
+    local $TODO = "GH #19020 on $^O";
+    is( $exit >> 8, 0, 'OS exit code (shifted) is 0' );
+}
+TODO: {
+    local $TODO = "GH #19020 on $^O";
+    is( $exit & 127, 9, 'KILL signal (bitwise ANDed exit) is 9' );
+}


### PR DESCRIPTION
This branch and p.r. exist in order to get come clean data on the problem originally described by @xsawyerx in https://github.com/Perl/perl5/issues/19020, who then submitted a p.r. in https://github.com/Perl/perl5/pull/19152.  I have created  new branch from that p.r., rebased on blead, with corrected MANIFEST,and titled it in order to trigger smoke-me tests.