### PR TITLE
Add a test to prove that -I and -M take effect in the order documented in perlrun

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6618,6 +6618,7 @@ t/run/runenv.t				Test if perl honors its environment variables.
 t/run/runenv_hashseed.t			Test if perl honors PERL_HASH_SEED.
 t/run/runenv_randseed.t			Test if perl honors PERL_RAND_SEED.
 t/run/script.t				See if script invocation works
+t/run/switch-I-and-M.t			Test order of application of -I and -M
 t/run/switch0.t				Test the -0 switch
 t/run/switcha.t				Test the -a switch
 t/run/switchC.t				Test the -C switch

--- a/t/run/switch-I-and-M.t
+++ b/t/run/switch-I-and-M.t
@@ -16,6 +16,6 @@ $ENV{PERL5LIB} = "e1:e2";
 
 # this isn't *quite* identical to what's in perlrun.pod, because
 # test.pl:_create_runperl adds -I../lib and -I.
-like(runperl(switches => [qw(-Ii1 -Mlib=m1 -Ii2 -Mlib=m2)], prog => 'print join(chr(32), @INC)'),
+like(runperl(switches => [qw(-Ii1 -Mlib=m1 -Ii2 -Mlib=m2)], prog => 'print join(q( ), @INC)'),
      qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2 \E},
      "Order of application of -I and -M matches documentation");

--- a/t/run/switch-I-and-M.t
+++ b/t/run/switch-I-and-M.t
@@ -1,0 +1,21 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    @INC = '../lib';
+}
+
+use strict;
+
+require './test.pl';
+
+plan(1);
+
+$ENV{PERL5OPT} = "-Mlib=optm1 -Iopti1 -Mlib=optm2 -Iopti2";
+$ENV{PERL5LIB} = "e1:e2";
+
+# this isn't *quite* identical to what's in perlrun.pod, because
+# test.pl:_create_runperl adds -I../lib and -I.
+like(runperl(switches => [qw(-Ii1 -Mlib=m1 -Ii2 -Mlib=m2)], prog => 'print join(chr(32), @INC)'),
+     qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2 \E},
+     "Order of application of -I and -M matches documentation");


### PR DESCRIPTION
A while back I wrote [some documentation](https://perldoc.perl.org/perlrun#ORDER-OF-APPLICATION) about the order in which the `-I` and `-M` switches and `PERL5LIB` take effect. The recent ground-breaking change to allow `-M` to be followed by a space prompted me to check to make sure that the code change for that hadn't had any side-effects. Good news! It didn't!

But I really shouldn't have had to check, I should have written a regression test at the same time as I wrote the doco. This PR adds that regression test.