### PR TITLE
Add tests to prove that -I and -M take effect in the order documented in perlrun.pod

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6618,6 +6618,7 @@ t/run/runenv.t				Test if perl honors its environment variables.
 t/run/runenv_hashseed.t			Test if perl honors PERL_HASH_SEED.
 t/run/runenv_randseed.t			Test if perl honors PERL_RAND_SEED.
 t/run/script.t				See if script invocation works
+t/run/switch-I-and-M.t			Test order of application of -I and -M
 t/run/switch0.t				Test the -0 switch
 t/run/switcha.t				Test the -a switch
 t/run/switchC.t				Test the -C switch

--- a/t/run/switch-I-and-M.t
+++ b/t/run/switch-I-and-M.t
@@ -6,16 +6,24 @@ BEGIN {
 }
 
 use strict;
+use Config;
 
 require './test.pl';
 
-plan(1);
+plan(2);
 
+# first test using -Margs ...
 $ENV{PERL5OPT} = "-Mlib=optm1 -Iopti1 -Mlib=optm2 -Iopti2";
-$ENV{PERL5LIB} = "e1:e2";
+$ENV{PERL5LIB} = join($Config{path_sep}, qw(e1 e2));
 
 # this isn't *quite* identical to what's in perlrun.pod, because
 # test.pl:_create_runperl adds -I../lib and -I.
 like(runperl(switches => [qw(-Ii1 -Mlib=m1 -Ii2 -Mlib=m2)], prog => 'print join(q( ), @INC)'),
-     qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2 \E},
+     qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2\E\b},
      "Order of application of -I and -M matches documentation");
+
+# and now using -M args with a space. NB that '-M foo' isn't supported
+# in PERL5OPT, just like how '-I foo' isn't.
+like(runperl(switches => [qw(-Ii1 -M lib=m1 -Ii2 -M lib=m2)], prog => 'print join(q( ), @INC)', stderr => 1),
+     qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2\E\b},
+     "Order of application of -I and -M matches documentation when -M has a space");

--- a/t/run/switch-I-and-M.t
+++ b/t/run/switch-I-and-M.t
@@ -6,6 +6,7 @@ BEGIN {
 }
 
 use strict;
+use warnings;
 use Config;
 
 require './test.pl';

--- a/t/run/switch-I-and-M.t
+++ b/t/run/switch-I-and-M.t
@@ -16,6 +16,6 @@ $ENV{PERL5LIB} = "e1:e2";
 
 # this isn't *quite* identical to what's in perlrun.pod, because
 # test.pl:_create_runperl adds -I../lib and -I.
-like(runperl(switches => [qw(-Ii1 -Mlib=m1 -Ii2 -Mlib=m2)], prog => 'print join(chr(32), @INC)'),
+like(runperl(switches => [qw(-Ii1 -Mlib=m1 -Ii2 -Mlib=m2)], prog => 'print join(q( ), @INC)'),
      qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2 \E},
      "Order of application of -I and -M matches documentation");

--- a/t/run/switch-I-and-M.t
+++ b/t/run/switch-I-and-M.t
@@ -10,7 +10,7 @@ use Config;
 
 require './test.pl';
 
-plan(2);
+plan(3);
 
 # first test using -Margs ...
 $ENV{PERL5OPT} = "-Mlib=optm1 -Iopti1 -Mlib=optm2 -Iopti2";
@@ -22,8 +22,13 @@ like(runperl(switches => [qw(-Ii1 -Mlib=m1 -Ii2 -Mlib=m2)], prog => 'print join(
      qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2\E\b},
      "Order of application of -I and -M matches documentation");
 
-# and now using -M args with a space. NB that '-M foo' isn't supported
-# in PERL5OPT, just like how '-I foo' isn't.
-like(runperl(switches => [qw(-Ii1 -M lib=m1 -Ii2 -M lib=m2)], prog => 'print join(q( ), @INC)', stderr => 1),
+# and now using -M and -I args with a space. NB that '-M foo' and '-I foo'
+# aren't supported in PERL5OPT.
+like(runperl(switches => [qw(-I i1 -M lib=m1 -I i2 -M lib=m2)], prog => 'print join(q( ), @INC)', stderr => 1),
      qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2\E\b},
-     "Order of application of -I and -M matches documentation when -M has a space");
+     "... still matches when the switch is followed by a space then its parameter");
+
+# and now with a mixture of args with and without spaces
+like(runperl(switches => [qw(-Ii1 -Mlib=m1 -I i2 -M lib=m2)], prog => 'print join(q( ), @INC)', stderr => 1),
+     qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2\E\b},
+     "... still matches when we've got a mixture of args with and without spaces");

--- a/t/run/switch-I-and-M.t
+++ b/t/run/switch-I-and-M.t
@@ -18,17 +18,32 @@ $ENV{PERL5LIB} = join($Config{path_sep}, qw(e1 e2));
 
 # this isn't *quite* identical to what's in perlrun.pod, because
 # test.pl:_create_runperl adds -I../lib and -I.
-like(runperl(switches => [qw(-Ii1 -Mlib=m1 -Ii2 -Mlib=m2)], prog => 'print join(q( ), @INC)'),
-     qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2\E\b},
-     "Order of application of -I and -M matches documentation");
+like(
+    runperl(
+        switches => [qw(-Ii1 -Mlib=m1 -Ii2 -Mlib=m2)],
+        prog     => 'print join(q( ), @INC)'
+    ),
+    qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2\E\b},
+    "Order of application of -I and -M matches documentation"
+);
 
 # and now using -M and -I args with a space. NB that '-M foo' and '-I foo'
 # aren't supported in PERL5OPT.
-like(runperl(switches => [qw(-I i1 -M lib=m1 -I i2 -M lib=m2)], prog => 'print join(q( ), @INC)', stderr => 1),
-     qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2\E\b},
-     "... still matches when the switch is followed by a space then its parameter");
+like(
+    runperl(
+        switches => [qw(-I i1 -M lib=m1 -I i2 -M lib=m2)],
+        prog     => 'print join(q( ), @INC)'
+    ),
+    qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2\E\b},
+    "... still matches when the switch is followed by a space then its parameter"
+);
 
 # and now with a mixture of args with and without spaces
-like(runperl(switches => [qw(-Ii1 -Mlib=m1 -I i2 -M lib=m2)], prog => 'print join(q( ), @INC)', stderr => 1),
-     qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2\E\b},
-     "... still matches when we've got a mixture of args with and without spaces");
+like(
+    runperl(
+        switches => [qw(-Ii1 -Mlib=m1 -I i2 -M lib=m2)],
+        prog     => 'print join(q( ), @INC)'
+    ),
+    qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2\E\b},
+    "... still matches when we've got a mixture of args with and without spaces"
+);

--- a/t/run/switch-I-and-M.t
+++ b/t/run/switch-I-and-M.t
@@ -1,0 +1,21 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    @INC = '../lib';
+}
+
+use strict;
+
+require './test.pl';
+
+plan(1);
+
+$ENV{PERL5OPT} = "-Mlib=optm1 -Iopti1 -Mlib=optm2 -Iopti2";
+$ENV{PERL5LIB} = "e1:e2";
+
+# this isn't *quite* identical to what's in perlrun.pod, because
+# test.pl:_create_runperl adds -I../lib and -I.
+like(runperl(switches => [qw(-Ii1 -Mlib=m1 -Ii2 -Mlib=m2)], prog => 'print join(chr(32), @INC)'),
+     qr{^\Qoptm2 optm1 m2 m1 opti2 opti1 ../lib . i1 i2 e1 e2 \E},
+     "Order of application of -I and -M matches documentation");

--- a/t/run/switchM.t
+++ b/t/run/switchM.t
@@ -8,6 +8,7 @@ BEGIN {
 
 }
 use strict;
+use warnings;
 
 require './test.pl';
 


### PR DESCRIPTION
A while back I added [documentation](https://perldoc.perl.org/perlrun#ORDER-OF-APPLICATION) of the order in which `-I` and `-M` arguments take effect, but I didn't write a regression test to make sure that if anything changed there people would notice. This adds that test.