### PR TITLE
embed.fnc: Fix resume_compcv entry

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2763,11 +2763,11 @@ p	|void	|report_wrongway_fh					\
 				|NULLOK const GV *gv			\
 				|const char have
 AOdp	|void	|require_pv	|NN const char *pv
-AMp	|void	|resume_compcv	|NN struct suspended_compcv *buffer	\
+Cop	|void	|resume_compcv	|NN struct suspended_compcv *buffer	\
 				|bool save
-dm	|void	|resume_compcv_and_save 				\
+Adm	|void	|resume_compcv_and_save 				\
 				|NN struct suspended_compcv *buffer
-dm	|void	|resume_compcv_final					\
+Adm	|void	|resume_compcv_final					\
 				|NN struct suspended_compcv *buffer
 APTdp	|char * |rninstr	|NN const char *big			\
 				|NN const char *bigend			\


### PR DESCRIPTION
The flags indicate that there is a Perl_resume_compcv(), that it is intended to be public API, though undocumented, and that there is a macro defining its short name 'resume_compcv'.  But there is no such macro.

Instead, there are two macros that call this through its long form, and are documented: 'resume_compcv_and_save' and 'resume_compcv_final'.

Change the flags to indicate this is internal without a short name, but needs to be publicly accessible, so those macros can use it.