### PR TITLE
open: allow bareword args for all dup modes

### DIFF
--- a/t/io/open.t
+++ b/t/io/open.t
@@ -10,7 +10,7 @@ $|  = 1;
 use warnings;
 use Config;
 
-plan tests => 188;
+plan tests => 186 + 6*3 + 6*2;
 
 sub ok_cloexec {
     SKIP: {
@@ -254,9 +254,23 @@ like( $@, qr/Bad filehandle:\s+$afile/,          '       right error' );
     ok( open(STDOUT,     ">&", $stdout),        'restore dupped STDOUT from lexical fh');
 
     {
-	use strict; # the below should not warn
-	ok( open(my $stdout, ">&", STDOUT),         'dup STDOUT into lexical fh');
-	ok_cloexec($stdout);
+	use strict; # the below should not die
+	for my $dupmode (qw( >& >>& <& +>& +>>& +<& )) {
+	    my $stdout;
+	    ok( eval("open(\$stdout, '$dupmode', STDOUT)"), "dup STDOUT into lexical fh with '$dupmode'" );
+	    is $@, "", "no errors for using '$dupmode' with bareword",
+	    ok_cloexec($stdout);
+	}
+
+	# sanity check
+	for my $xmode (qw( > >> < +> +>> +< )) {
+	    is(
+	        eval("open(my \$fh, '$xmode', STDOUT) unless \$xmode"),
+	        undef,
+	        "open with bareword filename fails to compile with '$xmode'"
+	    );
+	    like $@, qr/^Bareword "STDOUT" not allowed while "strict subs" in use /;
+        }
     }
 
     # used to try to open a file [perl #17830]


### PR DESCRIPTION
Previously, only ">&" used to exempt the third open argument from
"strict subs":

    use strict;
    open my $fh1, ">&", STDOUT;   # bareword allowed
    open my $fh2, ">>&", STDOUT;  # error: Bareword "STDOUT" not allowed

Now all dup modes (>&, >>&, <&, +>&, +>>&, +<&) allow bareword
filehandles.

Fixes #22464.