### PR TITLE
Devel::Peek: remove doc of non-existent exports

### DIFF
--- a/ext/Devel-Peek/Peek.pm
+++ b/ext/Devel-Peek/Peek.pm
@@ -3,7 +3,7 @@
 
 package Devel::Peek;
 
-$VERSION = '1.34';
+$VERSION = '1.35';
 $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -556,8 +556,7 @@ it has no prototype (C<PROTOTYPE> field is missing).
 
 C<Dump>, C<mstat>, C<DeadCode>, C<DumpArray>, C<DumpWithOP> and
 C<DumpProg>, C<fill_mstats>, C<mstats_fillhash>, C<mstats2hash> by
-default. Additionally available C<SvREFCNT>, C<SvREFCNT_inc> and
-C<SvREFCNT_dec>.
+default. Additionally available is C<SvREFCNT>.
 
 =head1 BUGS
 


### PR DESCRIPTION
The doc says `SvREFCNT_inc` and `SvREFCNT_dec` can be imported. They can't (as they don't exist as Perl functions in the module).