### PR TITLE
ck_open: report bareword dup handles under no feature bareword_filehandles

### DIFF
--- a/op.c
+++ b/op.c
@@ -13487,8 +13487,11 @@ Perl_ck_open(pTHX_ OP *o)
              (oa = OpSIBLING(first)) &&                 /* The fh. */
              (oa = OpSIBLING(oa)) &&                    /* The mode. */
              S_is_dup_mode(oa) &&                       /* A dup open. */
-             (last == OpSIBLING(oa)))                   /* The bareword. */
-              last->op_private &= ~OPpCONST_STRICT;
+             (last == OpSIBLING(oa))) {                 /* The bareword. */
+             if (!FEATURE_BAREWORD_FILEHANDLES_IS_ENABLED)
+                 no_bareword_filehandle(SvPVX(cSVOPx_sv(last)));
+             last->op_private &= ~OPpCONST_STRICT;
+         }
     }
     {
         /* mark as special if filename is a literal undef */

--- a/t/lib/feature/bareword_filehandles
+++ b/t/lib/feature/bareword_filehandles
@@ -556,3 +556,15 @@ Beta
 stdout
 >Delta
 >Epsilon
+########
+# NAME bareword handle in open dup handle calls
+use strict;
+open BAREWORD, ">&", STDOUT;
+open my $fh2, ">&", BAREWORD;
+no feature "bareword_filehandles";
+open my $fh3, ">&", STDOUT;
+open my $fh4, ">&", BAREWORD;
+EXPECT
+OPTIONS fatal
+Bareword filehandle "BAREWORD" not allowed under 'no feature "bareword_filehandles"' at - line 6.
+Execution of - aborted due to compilation errors.


### PR DESCRIPTION
Noticed this when reviewing #22552, this enforces `no feature "bareword_filehandles";` for these handles.