### PR TITLE
locale.c: Fix compilation on platforms with only a C locale

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -103,6 +103,7 @@ Andreas König                  <a.koenig@mind.de>
 Andreas Marienborg             <andreas.marienborg@gmail.com>
 Andreas Schwab                 <schwab@suse.de>
 Andreas Voegele                <andreas@andreasvoegele.com>
+Andrei Horodniceanu            <a.horodniceanu@proton.me>
 Andrei Yelistratov             <andrew@sundale.net>
 Andrej Borsenkow               <Andrej.Borsenkow@mow.siemens.ru>
 Andrew Bettison                <andrewb@zip.com.au>

--- a/locale.c
+++ b/locale.c
@@ -8963,6 +8963,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
      * categories into our internal indices. */
     if (map_LC_ALL_position_to_index[0] == LC_ALL_INDEX_) {
 
+#    ifdef PERL_LC_ALL_CATEGORY_POSITIONS_INIT
         /* Use this array, initialized by a config.h constant */
         int lc_all_category_positions[] = PERL_LC_ALL_CATEGORY_POSITIONS_INIT;
         STATIC_ASSERT_STMT(   C_ARRAY_LENGTH(lc_all_category_positions)
@@ -8975,6 +8976,21 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
             map_LC_ALL_position_to_index[i] =
                               get_category_index(lc_all_category_positions[i]);
         }
+#    else
+        /* It is possible for both PERL_LC_ALL_USES_NAME_VALUE_PAIRS and
+         * PERL_LC_ALL_CATEGORY_POSITIONS_INIT not to be defined, e.g. on
+         * systems with only a C locale during ./Configure.  Assume that this
+         * can only happen as part of some sort of bootstrapping so allow
+         * compilation to succeed by ignoring correctness.
+         */
+        for (unsigned int i = 0;
+             i < C_ARRAY_LENGTH(map_LC_ALL_position_to_index);
+             i++)
+        {
+            map_LC_ALL_position_to_index[i] = 0;
+        }
+#    endif
+
     }
 
     LOCALE_UNLOCK;


### PR DESCRIPTION
Reported downstream in: https://bugs.gentoo.org/939014. The bug is about being impossible to bootstrap a Gentoo prefix with perl-5.40.0.

A Gentoo prefix is a Linux installation under some custom directory, modifiable by a non-root user. Bootstrapping such an installation starts with a host compiler and a shell and builds packages until the full installation is complete. Because of the nature of perl, it ends up being compiled relatively early during the whole process, before the installation is complete and the user has had the chance to select which locales to generate.

In this situation perl ends up being compiled on a bare system with only the C locale. The code in `Configure` https://github.com/Perl/perl5/blob/67e852168ec3177f4cc76c2ad00a677ce7479667/Configure#L17672-L17675 then exits early failing to prove the format of `LC_ALL` which then takes the second `case` branch https://github.com/Perl/perl5/blob/67e852168ec3177f4cc76c2ad00a677ce7479667/Configure#L17812-L17834 which makes all three of `PERL_LC_ALL_USES_NAME_VALUE_PAIRS`, `PERL_LC_ALL_SEPARATOR`, and `PERL_LC_ALL_CATEGORY_POSITIONS_INIT` end up being undefined. The `locale.c` code, however, assumes that either `PERL_LC_ALL_USES_NAME_VALUE_PAIRS` or the other two macros are defined which leads to a compilation failure because of the usage of `PERL_LC_ALL_CATEGORY_POSITIONS_INIT`:
```
x86_64-pc-linux-gnu-gcc -c -DPERL_CORE -O2 -pipe -O2 -pipe -fno-strict-aliasing -DNO_PERL_RAND_SEED -fwrapv -I/home/gabi/ghentu/usr/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -std=c99 -O2 -pipe -O2 -pipe -fno-strict-aliasing -Wall -Werror=pointer-arith -Werror=vla -Wextra -Wno-long-long -Wno-declaration-after-statement -Wc++-compat -Wwrite-strings -fPIC locale.c
locale.c: In function 'Perl_init_i18nl10n':
locale.c:8812:43: error: 'PERL_LC_ALL_CATEGORY_POSITIONS_INIT' undeclared (first use in this function)
 8812 |         int lc_all_category_positions[] = PERL_LC_ALL_CATEGORY_POSITIONS_INIT;
      |                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
locale.c:8812:43: note: each undeclared identifier is reported only once for each function it appears in
```

There is already code: https://github.com/Perl/perl5/blob/67e852168ec3177f4cc76c2ad00a677ce7479667/locale.c#L649-L658 that prevents compilation failures with missing `PERL_LC_ALL_SEPARATOR`. This is a similar situation in  purpose but, because `PERL_LC_ALL_CATEGORY_POSITIONS_INIT` is suppose to be an array initializer and, if generated inside the code, it would require a `#include "locale_table.h"` I think it's simpler to replace its single usage point. The `map_LC_ALL_position_to_index` array should still be initialized, even with logically wrong values, to prevent possible out-of-bounds errors in other parts of the code.