### PR TITLE
Fix typos in documentation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -135,6 +135,7 @@ Andy Dougherty <doughera@lafayette.edu> Andy Dougherty <doughera@lafcol.lafayett
 Andy Dougherty <doughera@lafayette.edu> Andy Dougherty <doughera@newton.phys.lafayette.edu>
 Anno Siegel <anno4000@lublin.zrz.tu-berlin.de> <anno4000@mailbox.tu-berlin.de>
 Anno Siegel <anno4000@lublin.zrz.tu-berlin.de> <siegel@zrz.tu-berlin.de>
+Antanas Vaitkus <antanas.vaitkus90@gmail.com> vaitkus <antanas.vaitkus90@gmail.com>
 Anton Berezin <tobez@tobez.org> <tobez@plab.ku.dk>
 Arnold D. Robbins <arnold@gnu.ai.mit.edu> <arnold@gnu.ai.mit.edu>
 Arnold D. Robbins <arnold@gnu.ai.mit.edu> Arnold D. Robbins <arnold@emoryu2.arpa>

--- a/AUTHORS
+++ b/AUTHORS
@@ -127,6 +127,7 @@ Andy Dougherty                 <doughera@lafayette.edu>
 Andy Lester                    <andy@petdance.com>
 Andy Wardley
 Anno Siegel                    <anno4000@lublin.zrz.tu-berlin.de>
+Antanas Vaitkus                <antanas.vaitkus90@gmail.com>
 Anthony David                  <adavid@netinfo.com.au>
 Anthony Heading                <anthony@ajrh.net>
 Anton Berezin                  <tobez@tobez.org>

--- a/pod/perl5101delta.pod
+++ b/pod/perl5101delta.pod
@@ -995,7 +995,7 @@ replaced by C<->, so that F<ext/Data/Dumper/> is now F<ext/Data-Dumper/>,
 etc.  The names of the extensions as specified to F<Configure>, and as
 reported by C<%Config::Config> under the keys C<dynamic_ext>,
 C<known_extensions>, C<nonxs_ext> and C<static_ext> have not changed, and
-still use C</>. Hence this change will not have any affect once perl is
+still use C</>. Hence this change will not have any effect once perl is
 installed. However, C<Attribute::Handlers>, C<Safe> and C<mro> have now
 become extensions in their own right, so if you run F<Configure> with
 options to specify an exact list of extensions to build, you will need to

--- a/pod/perl5101delta.pod
+++ b/pod/perl5101delta.pod
@@ -1449,7 +1449,7 @@ Two flag bits are currently supported.
 
 =item C<SVf_UTF8>
 
-This will call C<SvUTF8_on()> for you. (Note that this does not convert an
+This will call C<SvUTF8_on()> for you. (Note that this does not convert a
 sequence of ISO 8859-1 characters to UTF-8). A wrapper, C<newSVpvn_utf8()>
 is available for this.
 

--- a/pod/perl5122delta.pod
+++ b/pod/perl5122delta.pod
@@ -231,7 +231,7 @@ stack for their return values in cases where no argument was passed in.
 
 =item *
 
-When matching unicode strings under some conditions inappropriate backtracking would
+When matching Unicode strings under some conditions inappropriate backtracking would
 result in a C<Malformed UTF-8 character (fatal)> error. This should no longer occur.
 See  L<[GH #10434]|https://github.com/Perl/perl5/issues/10434>
 

--- a/pod/perl5123delta.pod
+++ b/pod/perl5123delta.pod
@@ -43,7 +43,7 @@ had been broken since version 5.10.0.
 
 =item Solaris
 
-A separate DTrace is now build for miniperl, which means that perl can be
+A separate DTrace is now built for miniperl, which means that perl can be
 compiled with -Dusedtrace on Solaris again.
 
 =item VMS

--- a/pod/perl5140delta.pod
+++ b/pod/perl5140delta.pod
@@ -1022,7 +1022,7 @@ L<Unicode::Casing>, which provides improved functionality.
 The following module will be removed from the core distribution in a
 future release, and should be installed from CPAN instead.  Distributions
 on CPAN that require this should add it to their prerequisites.  The
-core version of these module now issues a deprecation warning.
+core version of this module now issues a deprecation warning.
 
 If you ship a packaged version of Perl, either alone or as part of a
 larger system, then you should carefully consider the repercussions of

--- a/pod/perl5140delta.pod
+++ b/pod/perl5140delta.pod
@@ -1085,7 +1085,7 @@ the regex to utf8 is necessary but this isn't known when the compilation begins.
 =head2 String appending is 100 times faster
 
 When doing a lot of string appending, perls built to use the system's
-C<malloc> could end up allocating a lot more memory than needed in a
+C<malloc> could end up allocating a lot more memory than needed in an
 inefficient way.
 
 C<sv_grow>, the function used to allocate more memory if necessary

--- a/pod/perl5160delta.pod
+++ b/pod/perl5160delta.pod
@@ -2124,7 +2124,7 @@ OPs are freed.  C<MADPROP>s are now allocated with C<PerlMemShared_malloc()>
 
 =item *
 
-F<makedef.pl> has been refactored.  This should have no noticeable affect on
+F<makedef.pl> has been refactored.  This should have no noticeable effect on
 any of the platforms that use it as part of their build (AIX, VMS, Win32).
 
 =item *

--- a/pod/perl5180delta.pod
+++ b/pod/perl5180delta.pod
@@ -855,7 +855,7 @@ down to a single op and are hence faster than before.
 A new C preprocessor define C<NO_TAINT_SUPPORT> was added that, if set,
 disables Perl's taint support altogether.  Using the -T or -t command
 line flags will cause a fatal error.  Beware that both core tests as
-well as many a CPAN distribution's tests will fail with this change.  On
+well as many CPAN distribution's tests will fail with this change.  On
 the upside, it provides a small performance benefit due to reduced
 branching.
 

--- a/pod/perl5180delta.pod
+++ b/pod/perl5180delta.pod
@@ -2291,7 +2291,7 @@ C<PL_glob_index> is gone.
 
 =item *
 
-The private Perl_croak_no_modify has had its context parameter removed.  It is
+The private Perl_croak_no_modify has had its context parameter removed.  It
 now has a void prototype.  Users of the public API croak_no_modify remain
 unaffected.
 
@@ -2340,7 +2340,7 @@ C<mg_length> has been deprecated.
 
 C<sv_len> now always returns a byte count and C<sv_len_utf8> a character
 count.  Previously, C<sv_len> and C<sv_len_utf8> were both buggy and would
-sometimes returns bytes and sometimes characters.  C<sv_len_utf8> no longer
+sometimes return bytes and sometimes characters.  C<sv_len_utf8> no longer
 assumes that its argument is in UTF-8.  Neither of these creates UTF-8 caches
 for tied or overloaded values or for non-PVs any more.
 

--- a/pod/perl5200delta.pod
+++ b/pod/perl5200delta.pod
@@ -1529,7 +1529,7 @@ built-in functions not only on aggregate types, but on references to
 them.  The feature was not deployed to its original intended
 specification, and now may become redundant to postfix dereferencing.
 It has always been categorized as an experimental feature, and in
-v5.20.0 is carries a warning as such.
+v5.20.0 it carries a warning as such.
 
 Warnings will now be issued at compile time when these operations are
 detected.
@@ -1971,7 +1971,7 @@ up as /system/bin/sh, and "sh" as /bin/sh.
 
 By default, B<gcc> 4.9 does some optimizations that break perl.  The B<-fwrapv>
 option disables those optimizations (and probably others), so for B<gcc> 4.3
-and later (since the there might be similar problems lurking on older versions
+and later (since there might be similar problems lurking on older versions
 too, but B<-fwrapv> was broken before 4.3, and the optimizations probably won't
 go away), F<Configure> now adds B<-fwrapv> unless the user requests
 B<-fno-wrapv>, which disables B<-fwrapv>, or B<-fsanitize=undefined>, which

--- a/pod/perl5260delta.pod
+++ b/pod/perl5260delta.pod
@@ -2622,7 +2622,7 @@ L<[GH #15657]|https://github.com/Perl/perl5/issues/15657>
 
 =item *
 
-Occasionally C<local()>s in a code block within a patterns weren't being
+Occasionally C<local()>s in a code block within a pattern weren't being
 undone when the pattern matching backtracked over the code block.
 L<[GH #15056]|https://github.com/Perl/perl5/issues/15056>
 

--- a/pod/perl5260delta.pod
+++ b/pod/perl5260delta.pod
@@ -1637,7 +1637,7 @@ L<[GH #15291]|https://github.com/Perl/perl5/issues/15291>
 
 Experimental "%s" subs not enabled
 
-This warning was been removed, as lexical subs are no longer experimental.
+This warning has been removed, as lexical subs are no longer experimental.
 
 =item *
 
@@ -1926,7 +1926,7 @@ L<[perl #128020]|https://rt.perl.org/Public/Bug/Display.html?id=128020>
 
 =item *
 
-C<-Ddefault_inc_excludes_dot> has added, and enabled by default.
+C<-Ddefault_inc_excludes_dot> was added, and enabled by default.
 
 =item *
 

--- a/pod/perl5280delta.pod
+++ b/pod/perl5280delta.pod
@@ -1711,7 +1711,7 @@ applicable.
 =item *
 
 Perl now includes a default F<.travis.yml> file for Travis CI testing
-on github mirrors.
+on GitHub mirrors.
 L<[GH #14558]|https://github.com/Perl/perl5/issues/14558>
 
 =item *

--- a/pod/perl5320delta.pod
+++ b/pod/perl5320delta.pod
@@ -1661,7 +1661,7 @@ floating point number. L<[GH #17062]|https://github.com/Perl/perl5/issues/17062>
 =item *
 
 Matching a non-C<SVf_UTF8> string against a regular expression
-containing unicode literals could leak a SV on each match attempt.
+containing Unicode literals could leak a SV on each match attempt.
 L<[GH #17140]|https://github.com/Perl/perl5/issues/17140>
 
 =item *

--- a/pod/perl5340delta.pod
+++ b/pod/perl5340delta.pod
@@ -1300,7 +1300,7 @@ operations.
 
 C<semctl()>, C<msgctl()>, and C<shmctl()> now attempt to downgrade the C<ARG>
 parameter if its value is being used as input to C<IPC_SET> or
-C<SETALL> calls.  A failed downgrade will thrown an exception.
+C<SETALL> calls.  A failed downgrade will throw an exception.
 
 =item *
 

--- a/pod/perl5361delta.pod
+++ b/pod/perl5361delta.pod
@@ -68,7 +68,7 @@ interpreter panic; e.g.
 =item *
 
 An C<eval EXPR> referring to a lexical sub defined in grandparent scope no
-longer produces an assertion failures.
+longer produces an assertion failure.
 [L<GH #19857|https://github.com/Perl/perl5/issues/19857>]
 
 =item *

--- a/pod/perl5380delta.pod
+++ b/pod/perl5380delta.pod
@@ -1568,7 +1568,7 @@ Unicode normalization tests have been added.
 
 =item *
 
-t/test.pl: Add ability to cancel an watchdog timer
+t/test.pl: Add ability to cancel a watchdog timer
 
 =back
 

--- a/pod/perl5380delta.pod
+++ b/pod/perl5380delta.pod
@@ -1367,11 +1367,11 @@ output double quoted strings with various characters escaped so as to
 make the exact value clear to a reader. The exact rules on which
 characters are escaped may change over time but currently are that
 printable ASCII codepoints, with the exception of C<"> and C<\>, and
-unicode word characters whose codepoint is over 255 are output raw, and
+Unicode word characters whose codepoint is over 255 are output raw, and
 any other symbols are escaped much as Data::Dumper might escape them,
 using C<\n> for newline and C<\"> for double quotes, etc. Codepoints in
 the range 128-255 are always escaped as they can cause trouble on
-unicode terminals when output raw.
+Unicode terminals when output raw.
 
 In older versions of perl the one liner
 

--- a/pod/perl5400delta.pod
+++ b/pod/perl5400delta.pod
@@ -728,7 +728,7 @@ of them will destroy the previous returns from any.  This hasn't been true
 since 5.6.0, except it does remain true if these are called during global
 destruction.  With that caveat, the return of each of these is a fresh
 string in a temporary that will automatically be freed by a call to
-L<perlapi/C<FREETMPS>> or at at places such as statement boundaries.
+L<perlapi/C<FREETMPS>> or at places such as statement boundaries.
 
 =item *
 

--- a/pod/perl5413delta.pod
+++ b/pod/perl5413delta.pod
@@ -285,7 +285,7 @@ passed C<undef> as a filename:
 
     open(my $fh, "+>", undef) or die ...
 
-Due the way this feature was implemented, it would also trigger for
+Due to the way this feature was implemented, it would also trigger for
 non-existent elements of arrays or hashes:
 
     open(my $fh, "+>", $hash{no_such_key}) or die ...

--- a/pod/perl561delta.pod
+++ b/pod/perl561delta.pod
@@ -2642,7 +2642,7 @@ so it was truncated to the string shown.
 
 =item Can't declare class for non-scalar %s in "%s"
 
-(S) Currently, only scalar variables can declared with a specific class
+(S) Currently, only scalar variables can be declared with a specific class
 qualifier in a "my" or "our" declaration.  The semantics may be extended
 for other types of variables in future.
 

--- a/pod/perl56delta.pod
+++ b/pod/perl56delta.pod
@@ -2037,7 +2037,7 @@ so it was truncated to the string shown.
 
 =item Can't declare class for non-scalar %s in "%s"
 
-(S) Currently, only scalar variables can declared with a specific class
+(S) Currently, only scalar variables can be declared with a specific class
 qualifier in a "my" or "our" declaration.  The semantics may be extended
 for other types of variables in future.
 

--- a/pod/perl56delta.pod
+++ b/pod/perl56delta.pod
@@ -77,7 +77,7 @@ will be needed to complete the toolkit for dealing with Unicode.
 
 The new C<\N> escape interpolates named characters within strings.
 For example, C<"Hi! \N{WHITE SMILING FACE}"> evaluates to a string
-with a unicode smiley face at the end.
+with a Unicode smiley face at the end.
 
 =head2 "our" declarations
 
@@ -92,7 +92,7 @@ variables.  See L<perlfunc/our>.
 
 Literals of the form C<v1.2.3.4> are now parsed as a string composed
 of characters with the specified ordinals.  This is an alternative, more
-readable way to construct (possibly unicode) strings instead of
+readable way to construct (possibly Unicode) strings instead of
 interpolating characters, as in C<"\x{1}\x{2}\x{3}\x{4}">.  The leading
 C<v> may be omitted if there are more than two ordinals, so C<1.2.3> is
 parsed the same as C<v1.2.3>.

--- a/pod/perl581delta.pod
+++ b/pod/perl581delta.pod
@@ -831,7 +831,7 @@ sv_setsv, are again available.
 Certain Perl core C APIs like cxinc and regatom are no longer
 available at all to code outside the Perl core of the Perl core
 extensions.  This is intentional.  They never should have been
-available with the shorter names, and if you application depends on
+available with the shorter names, and if your application depends on
 them, you should (be ashamed and) contact perl5-porters to discuss
 what are the proper APIs.
 

--- a/pod/perl589delta.pod
+++ b/pod/perl589delta.pod
@@ -1307,7 +1307,7 @@ char-classes as an escaping mechanism will see a speedup. (Yves Orton)
 
 =item *
 
-Creating anonymous array and hash references (ie. C<[]> and C<{}>) now incurs
+Creating anonymous array and hash references (i.e. C<[]> and C<{}>) now incurs
 no more overhead than creating an anonymous list or hash. Nicholas Clark
 provided changes with a saving of two ops and one stack push, which was measured
 as a slightly better than 5% improvement for these operations.

--- a/pod/perl58delta.pod
+++ b/pod/perl58delta.pod
@@ -2898,7 +2898,7 @@ The C<-M> and C<-m> options now warn if you didn't supply the module name.
 =item *
 
 If you in C<use> specify a required minimum version, modules matching
-the name and but not defining a $VERSION will cause a fatal failure.
+the name but not defining a $VERSION will cause a fatal failure.
 
 =item *
 

--- a/pod/perl58delta.pod
+++ b/pod/perl58delta.pod
@@ -270,7 +270,7 @@ ugly, but the current implementation slows down normal array and hash
 use quite noticeably. The C<fields> pragma interface will remain
 available.  The I<restricted hashes> interface is expected to
 be the replacement interface (see L<Hash::Util>).  If your existing
-programs depends on the underlying implementation, consider using
+programs depend on the underlying implementation, consider using
 L<Class::PseudoHash> from CPAN.
 
 =item *

--- a/pod/perlbook.pod
+++ b/pod/perlbook.pod
@@ -139,7 +139,7 @@ You might want to keep these desktop references close by your keyboard:
 =item I<Mastering Perl>
 
     by brian d foy
- ISBN 9978-1-4493-9311-3 [2st edition January 2014]
+ ISBN 9978-1-4493-9311-3 [2nd edition January 2014]
  ISBN 978-1-4493-6487-8 [ebook]
  https://www.masteringperl.org/
 
@@ -289,7 +289,7 @@ Perl book (which came later) is not completely accidental:
 =item I<Programming Pearls>
 
  by Jon Bentley
- ISBN 978-0-201-65788-3 [2 edition, October 1999]
+ ISBN 978-0-201-65788-3 [2nd edition, October 1999]
 
 =item I<More Programming Pearls>
 

--- a/pod/perlclib.pod
+++ b/pod/perlclib.pod
@@ -1012,7 +1012,7 @@ Some of these reentrant functions that are available on all platforms
 should always be used anyway; they are in the lists directly under
 L<libc functions to avoid>.
 
-Others may not be available on some platforms, or have issues that makes
+Others may not be available on some platforms, or have issues that make
 them undesirable to use even when they are available.  Or it may just be
 more complicated and tedious to use the reentrant version.  For these,
 perl has a mechanism for automatically substituting that reentrant

--- a/pod/perlclib.pod
+++ b/pod/perlclib.pod
@@ -604,7 +604,7 @@ your language very well.
 
 Earlier we mentioned that explicit action is required to have your code
 get called with the numeric portions of the locale not meeting the
-the typical expectations of having a dot for the radix character and no
+typical expectations of having a dot for the radix character and no
 punctuation separating groups of digits.  That action is to call the
 function L<perlapi/C<switch_to_global_locale>>.
 
@@ -1046,7 +1046,7 @@ L<libc functions to avoid>.
 
 Even so, some of the preferred alternatives are considered obsolete or
 otherwise unwise to use on some platforms.  These are marked with a '?'.
-Also, some alternatives aren't Perl-defined functions and aren't in in
+Also, some alternatives aren't Perl-defined functions and aren't in
 the POSIX Standard, so won't be widely available.  These are marked with
 '~'.  (Remember that the automatic substitution only happens when they
 are available and desirable, so you can just use the unpreferred

--- a/pod/perldata.pod
+++ b/pod/perldata.pod
@@ -1197,7 +1197,7 @@ it represents all types.  This used to be the preferred way to
 pass arrays and hashes by reference into a function, but now that
 we have real references, this is seldom needed.  
 
-The main use of typeglobs in modern Perl is create symbol table aliases.
+The main use of typeglobs in modern Perl is to create symbol table aliases.
 This assignment:
 
     *this = *that;

--- a/pod/perldebguts.pod
+++ b/pod/perldebguts.pod
@@ -961,7 +961,7 @@ grasp of what happens.
 Assume that an integer cannot take less than 20 bytes of memory, a
 float cannot take less than 24 bytes, a string cannot take less
 than 32 bytes (all these examples assume 32-bit architectures, the
-result are quite a bit worse on 64-bit architectures).  If a variable
+results are quite a bit worse on 64-bit architectures).  If a variable
 is accessed in two of three different ways (which require an integer,
 a float, or a string), the memory footprint may increase yet another
 20 bytes.  A sloppy malloc(3) implementation can inflate these

--- a/pod/perldebguts.pod
+++ b/pod/perldebguts.pod
@@ -595,7 +595,7 @@ will be lost.
  NBOUNDL          no         Like NBOUND/NBOUNDU, but \w and \W are
                              defined by current locale
  NBOUNDU          no         Match "" at any non-boundary of a given
-                             type using using /u rules.
+                             type using /u rules.
  NBOUNDA          no         Match "" betweeen any \w\w or \W\W, where
                              \w is [_a-zA-Z0-9]
 
@@ -867,7 +867,7 @@ will be lost.
  # Special opcode with the property that no opcode in a compiled program
  # will ever be of this type. Thus it can be used as a flag value that
  # no other opcode has been seen. END is used similarly, in that an END
- # node cant be optimized. So END implies "unoptimizable" and PSEUDO
+ # node can't be optimized. So END implies "unoptimizable" and PSEUDO
  # mean "not seen anything to optimize yet".
  PSEUDO           off        Pseudo opcode for internal use.
 

--- a/pod/perldebtut.pod
+++ b/pod/perldebtut.pod
@@ -287,7 +287,7 @@ to see what is happening:
 
 	DB<9> p $data{$key}
 
-Not much in there, lets have a look at our hash:
+Not much in there, let's have a look at our hash:
 
 	DB<10> p %data
 	Hello Worldziptomandwelcomejerrywelcomethisthat 

--- a/pod/perldebug.pod
+++ b/pod/perldebug.pod
@@ -654,7 +654,7 @@ Perl debugger, use a leading semicolon, too.
 X<debugger command, m>
 
 List which methods may be called on the result of the evaluated
-expression.  The expression may evaluated to a reference to a
+expression.  The expression may be evaluated to a reference to a
 blessed object, or to a package name.
 
 =item M

--- a/pod/perldebug.pod
+++ b/pod/perldebug.pod
@@ -621,7 +621,7 @@ Restart the debugger by C<exec()>ing a new session.  We try to maintain
 your history across this, but internal settings and command-line options
 may be lost.
 
-The following setting are currently preserved: history, breakpoints,
+The following settings are currently preserved: history, breakpoints,
 actions, debugger options, and the Perl command-line
 options B<-w>, B<-I>, and B<-e>.
 

--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -18,7 +18,7 @@ which they will be removed.
 
 =head3 Unicode Delimiter Will be Paired
 
-Some unicode delimiters used to be allowed as single characters, but
+Some Unicode delimiters used to be allowed as single characters, but
 in the future will be part of a balanced pair. This deprecation category
 is used to mark the ones that will change from being unpaired to paired.
 
@@ -37,7 +37,7 @@ Category: "deprecated::dot_in_inc"
 
 =head3 Unicode Property Name
 
-Various types of unicode property name will generate deprecated warnings
+Various types of Unicode property name will generate deprecated warnings
 when used in a regex pattern. For instance surrogate characters will result
 in deprecation warnings.
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -737,7 +737,7 @@ format can only be used with positive integers.  See L<perlfunc/pack>.
 
 (F) You manipulated Perl's symbol table directly, stored a reference
 in it, then tried to access that symbol via conventional Perl syntax.
-The access triggers Perl to autovivify that typeglob, but it there is
+The access triggers Perl to autovivify that typeglob, but there is
 no legal conversion from that type of reference to a typeglob.
 
 =item Cannot copy to %s
@@ -2902,7 +2902,7 @@ this support.  Talk to your Perl administrator.
 (F) A parameter in a subroutine signature contained an unexpected character
 following the C<$>, C<@> or C<%> sigil character.  Normally the sigil
 should be followed by the variable name or C<=> etc.  Perhaps you are
-trying use a prototype while in the scope of C<use feature 'signatures'>?
+trying to use a prototype while in the scope of C<use feature 'signatures'>?
 For example:
 
     sub foo ($$) {}            # legal - a prototype

--- a/pod/perlebcdic.pod
+++ b/pod/perlebcdic.pod
@@ -105,7 +105,7 @@ Portuguese, Spanish, and Swedish.  Dutch is covered albeit without
 the ij ligature.  French is covered too but without the oe ligature.
 German can use ISO 8859-1 but must do so without German-style
 quotation marks.  This set is based on Western European extensions
-to ASCII and is commonly encountered in world wide web work.
+to ASCII and is commonly encountered in World Wide Web work.
 In IBM character code set identification terminology, ISO 8859-1 is
 also known as CCSID 819 (or sometimes 0819 or even 00819).
 

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -5460,7 +5460,7 @@ of values, as follows:
        as possible.  Bit eight (the high bit) is set on each byte
        except the last.
 
-    x  A null byte (a.k.a ASCII NUL, "\000", chr(0))
+    x  A null byte (a.k.a. ASCII NUL, "\000", chr(0))
     X  Back up a byte.
     @  Null-fill or truncate to absolute position, counted from the
        start of the innermost ()-group.

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -8372,7 +8372,7 @@ string's internal encoding.
 
 As of Perl 5.39.9 the C</x> default modifier does NOT affect
 C<split STRING> but does affect C<split PATTERN>, this means that
-C<split " "> will produces the expected I<awk> emulation regardless as
+C<split " "> will produce the expected I<awk> emulation regardless as
 to whether it is used in the scope of a C<use re "/x"> statement. If you
 want to split by spaces under C<use re "/x"> you must do something like
 C<split /(?-x: )/> or C<split /\x{20}/> instead of C<split / />.

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -7094,7 +7094,7 @@ If the hook is an array reference, its first element must be a
 subroutine reference or an object as described above. When the first
 element is an object that supports an C<INC> or C<INCDIR> method then
 the method will be called with the object as the first argument, the
-filename requested as the second, and the hook array reference as the
+filename requested as the second, and the hook array reference as
 the third. When the first element is a subroutine then it will be
 called with the array as the first argument, and the filename as the
 second, no third parameter will be passed in. In both forms you can

--- a/pod/perlgit.pod
+++ b/pod/perlgit.pod
@@ -553,14 +553,14 @@ to push your changes back with the C<camel> remote:
 The C<fetch> command just updates the C<camel> refs, as the objects
 themselves should have been fetched when pulling from C<origin>.
 
-=head2 Working with Github pull requests
+=head2 Working with GitHub pull requests
 
 Pull requests typically originate from outside of the C<Perl/perl.git>
 repository, so if you want to test or work with it locally a vanilla
 C<git fetch> from the C<Perl/perl5.git> repository won't fetch it.
 
-However Github does provide a mechanism to fetch a pull request to a
-local branch.  They are available on Github remotes under C<pull/>, so
+However GitHub does provide a mechanism to fetch a pull request to a
+local branch.  They are available on GitHub remotes under C<pull/>, so
 you can use C<< git fetch pull/I<PRID>/head:I<localname> >> to make a
 local copy.  eg.  to fetch pull request 9999 to the local branch
 C<local-branch-name> run:
@@ -580,7 +580,7 @@ which rebases C<local-branch-name> on C<blead>, and checks it out.
 
 Alternatively you can configure the remote to fetch all pull requests
 as remote-tracking branches.  To do this edit the remote in
-F<.git/config>, for example if your github remote is C<origin> you'd
+F<.git/config>, for example if your GitHub remote is C<origin> you'd
 have:
 
   [remote "origin"]

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -1274,7 +1274,7 @@ settable with L<< IO::Handle's untaint() method|IO::Handle/"$io->untaint" >>.
 =for apidoc Amnh||IOf_FLUSH
 =for apidoc Amnh||IOf_UNTAINT
 
-The IO object may also contains a directory handle:
+The IO object may also contain a directory handle:
 
   DIR *IoDIRP(io);
 

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -2613,7 +2613,7 @@ of free()ing (i.e. their type is changed to OP_NULL).
 
 After the compile tree for a subroutine (or for an C<eval> or a file)
 is created, an additional pass over the code is performed.  This pass
-is neither top-down or bottom-up, but in the execution order (with
+is neither top-down nor bottom-up, but in the execution order (with
 additional complications for conditionals).  Optimizations performed
 at this stage are subject to the same restrictions as in the pass 2.
 

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -517,7 +517,7 @@ so SvIOK is false.  (In perl 5.18 onwards, tied scalars use
 the flags the same way as untied scalars.)  Another is when
 numeric conversion has occurred and precision has been lost: only the
 private flag is set on 'lossy' values.  So when an NV is converted to an
-IV with loss, SvIOKp, SvNOKp and SvNOK will be set, while SvIOK wont be.
+IV with loss, SvIOKp, SvNOKp and SvNOK will be set, while SvIOK won't be.
 
 In general, though, it's best to use the C<Sv*V> macros.
 
@@ -4088,7 +4088,7 @@ be invoked on scope exit. A full list of such macros can be found in
 F<scope.h>.
 
 There is no public API for popping individual values or items from the save
-stack. Instead, via the scope stack, the C<ENTER> and C<LEAVE> pair form a way
+stack. Instead, via the scope stack, the C<ENTER> and C<LEAVE> pair forms a way
 to start and stop nested scopes. Leaving a nested scope via C<LEAVE> will
 restore all of the saved values that had been pushed since the most recent
 C<ENTER>.

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -2048,7 +2048,7 @@ from the related C<SAVEDESTRUCTOR_X()> in that it MUST be either NULL or
 an C<SV*>.
 
 Note the I<end of the current statement> may occur much before the
-the I<end of the current pseudo-block>.  You may wish to look at the
+I<end of the current pseudo-block>.  You may wish to look at the
 C<SAVEDESTRUCTOR_X()> macro instead.
 
 =for apidoc Amh||MORTALSVFUNC_X|SVFUNC_t f|SV *sv
@@ -2061,7 +2061,7 @@ See the documentation for C<mortal_destructor_sv()> for details on
 the C<args> parameter is handled.
 
 Note the I<end of the current statement> may occur much before the
-the I<end of the current pseudo-block>.  If you wish to call a perl
+I<end of the current pseudo-block>.  If you wish to call a perl
 function at the end of the current pseudo block you should use the
 C<SAVEDESTRUCTOR_X()> API instead, which will require you create a
 C wrapper to call the Perl function.
@@ -4443,7 +4443,7 @@ C<for (list) {}>), and what args (if any) it returns; and that will
 already have been sorted out earlier by C<leave_adjust_stacks()>.
 
 Finally, the context stack pointer is actually decremented by C<CX_POP(cx)>.
-After this point, it's possible that that the current context frame could
+After this point, it's possible that the current context frame could
 be overwritten by other contexts being pushed. Although things like ties
 and C<DESTROY> are supposed to work within a new context stack, it's best
 not to assume this. Indeed on debugging builds, C<CX_POP(cx)> deliberately
@@ -4493,7 +4493,7 @@ short), are called via special wrapper functions which adjust the stack
 before and after. At the moment there is no API to write an RC XS
 function, so all XS code will continue to be called via a wrapper (which
 makes them slightly slower), but means that in general, CPAN distributions
-containing XS code code continue to work without modification.
+containing XS code continue to work without modification.
 
 However, PP functions, either in perl core, or those in XS functions used
 to implement custom ops or to override the PP functions for built-in ops,

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -3678,7 +3678,7 @@ in a single byte.
 =head2 How do I compare strings?
 
 L<perlapi/sv_cmp> and L<perlapi/sv_cmp_flags> do a lexigraphic
-comparison of two SV's, and handle UTF-8ness properly.  Note, however,
+comparison of two SVs, and handle UTF-8ness properly.  Note, however,
 that Unicode specifies a much fancier mechanism for collation, available
 via the L<Unicode::Collate> module.
 

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -2082,7 +2082,7 @@ provide pointers to the modifiable data explicitly (either C pointers,
 or Perlish C<GV *>s).  Where the above macros take C<int>, a similar
 function takes C<int *>.
 
-Other macros above have functions implementing them, but its probably
+Other macros above have functions implementing them, but it's probably
 best to just use the macro, and not those or the ones below.
 
 =over 4
@@ -3512,7 +3512,7 @@ So don't do that!
 
 (Note that we don't have to test for invariant characters in the
 examples above.  The functions work on any well-formed UTF-8 input.
-It's just that its faster to avoid the function overhead when it's not
+It's just that it's faster to avoid the function overhead when it's not
 needed.)
 
 =head2 How does Perl store UTF-8 strings?
@@ -4422,7 +4422,7 @@ C<cx_popsub>. In part, this looks like:
     cx->blk_sub.cv = NULL;
     SvREFCNT_dec(cv);
 
-where its processing the just-executed CV. Note that before it decrements
+where it's processing the just-executed CV. Note that before it decrements
 the CV's reference count, it nulls the C<blk_sub.cv>. This means that if
 it re-enters, the CV won't be freed twice. It also means that you can't
 rely on such type-specific fields having useful values after the return

--- a/pod/perlhacktips.pod
+++ b/pod/perlhacktips.pod
@@ -1825,7 +1825,7 @@ will need to build perl with C<CFG=Debug> or C<CFG=DebugSymbols>.
 
 The Visual Studio profiler is a sampling profiler.
 
-See L<the visual studio
+See L<the Visual Studio
 documentation|https://github.com/MicrosoftDocs/visualstudio-docs/blob/main/docs/profiling/beginners-guide-to-performance-profiling.md>
 to get started.
 

--- a/pod/perlhacktips.pod
+++ b/pod/perlhacktips.pod
@@ -262,7 +262,7 @@ C<snprintf> in the VMS libc only added support for C<PRIdN> etc very
 recently, meaning that there are live supported installations without
 this, or formats such as C<%zu>.
 
-(perl's C<sv_catpvf> etc use parser code code in F<sv.c>, which
+(perl's C<sv_catpvf> etc use parser code in F<sv.c>, which
 supports the C<z> modifier, along with perl-specific formats such as
 C<SVf>.)
 
@@ -401,7 +401,7 @@ the issues.
 
 =head3 Choosing good symbol names
 
-Ideally, a symbol name name should correctly and precisely describe its
+Ideally, a symbol name should correctly and precisely describe its
 intended purpose.  But there is a tension between that and getting
 names that are overly long and hence awkward to type and read.
 Metaphors could be helpful (a poetic name), but those tend to be
@@ -516,7 +516,7 @@ restrictions on what names you can use.)
 
 This kind of name collision doesn't happen with the macro's formal
 parameters, so they don't need to have complicated names.  But there
-are pitfalls when a a parameter is an expression, or has some Perl
+are pitfalls when a parameter is an expression, or has some Perl
 magic attached.  When calling a function, C will evaluate the parameter
 once, and pass the result to the function.  But when calling a macro,
 the parameter is copied as-is by the C preprocessor to each instance

--- a/pod/perlipc.pod
+++ b/pod/perlipc.pod
@@ -973,7 +973,7 @@ Here's a sample TCP client using Internet-domain sockets:
 
 And here's a corresponding server to go along with it.  We'll
 leave the address as C<INADDR_ANY> so that the kernel can choose
-the appropriate interface on multihomed hosts.  If you want sit
+the appropriate interface on multihomed hosts.  If you want to sit
 on a particular interface (like the external side of a gateway
 or firewall machine), fill this in with your real address instead.
 

--- a/pod/perlipc.pod
+++ b/pod/perlipc.pod
@@ -1445,7 +1445,7 @@ simultaneously copies everything from standard input to the socket.
 To accomplish the same thing using just one process would be I<much>
 harder, because it's easier to code two processes to do one thing than it
 is to code one process to do two things.  (This keep-it-simple principle
-a cornerstones of the Unix philosophy, and good software engineering as
+is a cornerstone of the Unix philosophy, and good software engineering as
 well, which is probably why it's spread to other systems.)
 
 Here's the code:

--- a/pod/perllocale.pod
+++ b/pod/perllocale.pod
@@ -63,7 +63,7 @@ platforms where they are available.  And Unicode supports a database of
 more types of information than the basic locale systems have.  This
 database is called C<CLDR>, the "Common Locale Data Repository",
 L<http://cldr.unicode.org/>.  There are various CPAN modules that
-provides access to this XML-encoded data, such as L<Locale::CLDR>,
+provide access to this XML-encoded data, such as L<Locale::CLDR>,
 L<CLDR::Number>, and L<DateTime::Format::CLDR>.
 
 =head1 WHAT IS A LOCALE

--- a/pod/perllocale.pod
+++ b/pod/perllocale.pod
@@ -1095,7 +1095,7 @@ currency values.)
 
 Perl essentially takes no notice of this category.  On POSIX systems, you
 can call C<strfmon()> from XS code to create formatted strings, and/or you
-you can query the C<LC_MONETARY> locale-specific values with
+can query the C<LC_MONETARY> locale-specific values with
 L</The localeconv function> and use the information that it returns in your
 application's own formatting of currency amounts.  However, you may well
 find that the information, voluminous and complex though it may be, still

--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -2188,7 +2188,7 @@ A string which is (possibly) interpolated and then executed as a
 system command, via F</bin/sh> or its equivalent if required.  Shell
 wildcards, pipes, and redirections will be honored.  Similarly to
 C<system>, if the string contains no shell metacharacters then it will
-executed directly.  The collected standard output of the command is
+be executed directly.  The collected standard output of the command is
 returned; standard error is unaffected.  In scalar context, it comes
 back as a single (potentially multi-line) string, or C<undef> if the
 shell (or command) could not be started.  In list context, returns a
@@ -3375,7 +3375,7 @@ Bitstrings of any size may be manipulated by the bitwise operators
 If the operands to a binary bitwise op are strings of different
 sizes, B<|> and B<^> ops act as though the shorter operand had
 additional zero bits on the right, while the B<&> op acts as though
-the longer operand were truncated to the length of the shorter.
+the longer operand was truncated to the length of the shorter.
 The granularity for such extension or truncation is one or more
 bytes.
 

--- a/pod/perlpacktut.pod
+++ b/pod/perlpacktut.pod
@@ -495,7 +495,7 @@ L</"Packing and Unpacking C Structures"> for more on that.
 For packing floating point numbers you have the choice between the
 pack codes C<f>, C<d>, C<F> and C<D>. C<f> and C<d> pack into (or unpack
 from) single-precision or double-precision representation as it is provided
-by your system. If your systems supports it, C<D> can be used to pack and
+by your system. If your system supports it, C<D> can be used to pack and
 unpack (C<long double>) values, which can offer even more resolution
 than C<f> or C<d>.  B<Note that there are different long double formats.>
 

--- a/pod/perlperf.pod
+++ b/pod/perlperf.pod
@@ -173,9 +173,9 @@ actually worth the eyestrain, or the loss of maintainability.
 =head2  Search and replace or tr
 
 If we have a string which needs to be modified, while a regex will almost
-always be much more flexible, C<tr>, an oft underused tool, can still be a
-useful.  One scenario might be replace all vowels with another character.  The
-regex solution might look like this:
+always be much more flexible, C<tr>, an oft underused tool, can still be
+useful.  One scenario might be to replace all vowels with another character.
+The regex solution might look like this:
 
  $str =~ s/[aeiou]/x/g
 

--- a/pod/perlperf.pod
+++ b/pod/perlperf.pod
@@ -588,7 +588,7 @@ systems which provide C<clock_gettime()>.  It can be started and stopped even
 by the program being profiled.  It's a one-line entry to profile C<mod_perl>
 applications.  It's written in C<c> and is probably the fastest profiler
 available for Perl.  The list of coolness just goes on.  Enough of that, let's
-see how to it works - just use the familiar C<-d> switch to plug it in and run
+see how it works - just use the familiar C<-d> switch to plug it in and run
 the code.
 
  $> perl -d:NYTProf wordmatch -f perl5db.pl
@@ -1104,7 +1104,7 @@ completely optimized away, and you can't get much more efficient than that.
 
 =head1 POSTSCRIPT
 
-This document has provided several way to go about identifying hot-spots, and
+This document has provided several ways to go about identifying hot-spots, and
 checking whether any modifications have improved the runtime of the code.
 
 As a final thought, remember that it's not (at the time of writing) possible to

--- a/pod/perlpodstyle.pod
+++ b/pod/perlpodstyle.pod
@@ -222,7 +222,7 @@ For licensing the easiest way is to use the same licensing as Perl itself:
     modify it under the same terms as Perl itself.
 
 This makes it easy for people to use your module with Perl.  Note that
-this licensing example is neither an endorsement or a requirement, you are
+this licensing example is neither an endorsement nor a requirement, you are
 of course free to choose any licensing.
 
 =item SEE ALSO

--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -2021,7 +2021,7 @@ L</Embedded Code Execution Frequency>.
 This is a "postponed" regular subexpression.  It behaves in I<exactly> the
 same way as a C<(?{ I<code> })> code block as described above, except that
 its return value, rather than being assigned to C<$^R>, is treated as a
-pattern, compiled if it's a string (or used as-is if its a qr// object),
+pattern, compiled if it's a string (or used as-is if it's a qr// object),
 then matched as if it were inserted instead of this construct.
 
 During the matching of this sub-pattern, it has its own set of

--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -2667,7 +2667,7 @@ could be all Cyrillic (except for the dot), or they could be a mixture
 of the two.  In the case of an internet address the C<.com> would be in
 Latin, And any Cyrillic ones would cause it to be a mixture, not a
 script run.  Someone clicking on such a link would not be directed to
-the real Paypal website, but an attacker would craft a look-alike one to
+the real PayPal website, but an attacker would craft a look-alike one to
 attempt to gather sensitive information from the person.
 
 Starting in Perl 5.28, it is now easy to detect strings that aren't

--- a/pod/perlretut.pod
+++ b/pod/perlretut.pod
@@ -633,7 +633,7 @@ that matches.
 
 Alternation allows a regexp to choose among alternatives, but by
 itself it is unsatisfying.  The reason is that each alternative is a whole
-regexp, but sometime we want alternatives for just part of a
+regexp, but sometimes we want alternatives for just part of a
 regexp.  For instance, suppose we want to search for housecats or
 housekeepers.  The regexp C<housecat|housekeeper> fits the bill, but is
 inefficient because we had to type C<house> twice.  It would be nice to

--- a/pod/perlrun.pod
+++ b/pod/perlrun.pod
@@ -1140,7 +1140,7 @@ provides for fast access to the buffer (not common on modern architectures);
 otherwise, it uses the ":unix:perlio" implementation.
 
 On Win32 the default in this release (5.30) is ":unix:crlf". Win32's ":stdio"
-has a number of bugs/mis-features for Perl IO which are somewhat depending
+has a number of bugs/mis-features for Perl IO which are somewhat dependent
 on the version and vendor of the C compiler. Using our own C<:crlf> layer as
 the buffer avoids those issues and makes things more uniform.
 

--- a/pod/perlsub.pod
+++ b/pod/perlsub.pod
@@ -439,7 +439,7 @@ is not important, it may be omitted just as the parameter's name was:
     }
 
 Optional positional parameters must come after all mandatory positional
-parameters.  (If there are no mandatory positional parameters then an
+parameters.  (If there are no mandatory positional parameters then the
 optional positional parameters can be the first thing in the signature.)
 If there are multiple optional positional parameters and not enough
 arguments are supplied to fill them all, they will be filled from left

--- a/pod/perlsub.pod
+++ b/pod/perlsub.pod
@@ -1301,7 +1301,7 @@ in C<@Fields>.
         @Fields = split /^\s*=+\s*$/;
     }
 
-It particular, it's important to C<local>ize $_ in any routine that assigns
+In particular, it's important to C<local>ize $_ in any routine that assigns
 to it.  Look out for implicit assignments in C<while> conditionals.
 
 =item 2.

--- a/pod/perlsub.pod
+++ b/pod/perlsub.pod
@@ -1363,7 +1363,7 @@ do that, you need to understand references as detailed in L<perlref>.
 This section may not make much sense to you otherwise.
 
 Here are a few simple examples.  First, let's pass in several arrays
-to a function and have it C<pop> all of then, returning a new list
+to a function and have it C<pop> all of them, returning a new list
 of all their former last elements:
 
     @tailings = popmany ( \@w, \@x, \@y, \@z );

--- a/pod/perlsyn.pod
+++ b/pod/perlsyn.pod
@@ -60,7 +60,7 @@ the beginning or the end of the script.  However, if you're using
 lexically-scoped private variables created with C<my()>,
 C<state()>, or C<our()>, you'll have to make sure
 your format or subroutine definition is within the same block scope
-as the my if you expect to be able to access those private variables.
+as the my() if you expect to be able to access those private variables.
 
 Declaring a subroutine allows a subroutine name to be used as if it were a
 list operator from that point forward in the program.  You can declare a

--- a/pod/perlsyn.pod
+++ b/pod/perlsyn.pod
@@ -550,7 +550,7 @@ If the size of the LIST is not an exact multiple of the number of iterator
 variables, then on the last iteration the "excess" iterator variables are
 aliases to C<undef>, as if the LIST had C<, undef> appended as many times as
 needed for its length to become an exact multiple.  This happens whether
-LIST is a literal LIST or an array - ie arrays are not extended if their
+LIST is a literal LIST or an array - i.e. arrays are not extended if their
 size is not a multiple of the iteration size, consistent with iterating an
 array one-at-a-time.  As these padding elements are not lvalues, attempting
 to modify them will fail, consistent with the behaviour when iterating a

--- a/pod/perlthrtut.pod
+++ b/pod/perlthrtut.pod
@@ -26,7 +26,7 @@ If you have neither, you don't have any thread support built in.
 If you have both, you are in trouble.
 
 The L<threads> and L<threads::shared> modules are included in the core Perl
-distribution.  Additionally, they are maintained as a separate modules on
+distribution.  Additionally, they are maintained as separate modules on
 CPAN, so you can check there for any updates.
 
 =head1 What Is A Thread Anyway?

--- a/pod/perlthrtut.pod
+++ b/pod/perlthrtut.pod
@@ -299,7 +299,7 @@ automatically.
 
     $thr->detach();   # Now we officially don't care any more
 
-    sleep(15);        # Let thread run for awhile
+    sleep(15);        # Let thread run for a while
 
     sub sub1 {
         my $count = 0;

--- a/pod/perltie.pod
+++ b/pod/perltie.pod
@@ -1127,7 +1127,7 @@ This is the output when it is executed:
     The End
 
 So far so good.  Those of you who have been paying attention will have
-spotted that the tied object hasn't been used so far.  So lets add an
+spotted that the tied object hasn't been used so far.  So let's add an
 extra method to the Remember class to allow comments to be included in
 the file; say, something like this:
 

--- a/pod/perltie.pod
+++ b/pod/perltie.pod
@@ -243,7 +243,7 @@ ARRAY reference, we'll choose a HASH reference to represent our object.
 A HASH works out well as a generic record type: the C<{ELEMSIZE}> field will
 store the maximum element size allowed, and the C<{ARRAY}> field will hold the
 true ARRAY ref.  If someone outside the class tries to dereference the
-object returned (doubtless thinking it an ARRAY ref), they'll blow up.
+object returned (doubtless thinking it is an ARRAY ref), they'll blow up.
 This just goes to show you that you should respect an object's privacy.
 
     sub TIEARRAY {

--- a/pod/perlunicode.pod
+++ b/pod/perlunicode.pod
@@ -636,7 +636,7 @@ scripts, Katakana and Hiragana, but nowhere else.  The C<Script>
 property places all characters that are used in multiple scripts in the
 C<Common> script, while the C<Script_Extensions> property places those
 that are used in only a few scripts into each of those scripts; while
-still using C<Common> for those used in many scripts.  Thus both these
+still using C<Common> for those used in many scripts.  Thus both of these
 match:
 
  "0" =~ /\p{sc=Common}/     # Matches

--- a/pod/perlunicook.pod
+++ b/pod/perlunicook.pod
@@ -439,7 +439,7 @@ canonical combining classes and weeds out singletons.
 
 Unless you’ve used C</a> or C</aa>, C<\d> matches more than
 ASCII digits only, but Perl’s implicit string-to-number
-conversion does not current recognize these.  Here’s how to
+conversion does not currently recognize these.  Here’s how to
 convert such strings manually.
 
  use v5.14;  # needed for num() function

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -821,7 +821,7 @@ C<require__before> hooks are called in FIFO order, and if the hook
 returns a code reference those code references will be called in FILO
 order.  In other words if A requires B requires C, then
 C<require__before> will be called first for A, then B and then C, and
-the post-action code reference will executed first for C, then B and
+the post-action code reference will be executed first for C, then B and
 then finally A.
 
 Well behaved code should ensure that when setting up a

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -787,7 +787,7 @@ which are hard or impossible to wrap are called. The keys of this hash
 are named after the keyword that is being hooked, followed by two
 underbars and then a phase term; either "before" or "after".
 
-Perl will throw an error if you attempt modify a key which is not
+Perl will throw an error if you attempt to modify a key which is not
 documented to exist, or if you attempt to store anything other than a
 code reference or undef in the hash.  If you wish to use an object to
 implement a hook you can use currying to embed the object into an

--- a/pod/perlvms.pod
+++ b/pod/perlvms.pod
@@ -1135,7 +1135,7 @@ status value to be passed through.  The special value of 0xFFFF is
 almost a NOOP as it will cause the current native VMS status in the
 C library to become the current native Perl VMS status, and is handled
 this way as it is known to not be a valid native VMS status value.
-It is recommend that only values in the range of normal Unix parent or
+It is recommended that only values in the range of normal Unix parent or
 child status numbers, 0 to 255 are used.
 
 The pragma C<use vmsish 'status'> makes C<$?> reflect the actual 

--- a/pod/perlvms.pod
+++ b/pod/perlvms.pod
@@ -594,7 +594,7 @@ may be specified.
 
 =item binmode FILEHANDLE
 
-The C<binmode> operator will attempt to insure that no translation
+The C<binmode> operator will attempt to ensure that no translation
 of carriage control occurs on input from or output to this filehandle.
 Since this involves reopening the file and then restoring its
 file position indicator, if this function returns FALSE, the
@@ -623,7 +623,7 @@ functions, in order to authenticate users.  If you're
 going to do this, remember that the encrypted password in
 the UAF was generated using uppercase username and
 password strings; you'll have to upcase the arguments to
-C<crypt> to insure that you'll get the proper value:
+C<crypt> to ensure that you'll get the proper value:
 
     sub validate_passwd {
         my($user,$passwd) = @_;

--- a/regcomp.sym
+++ b/regcomp.sym
@@ -77,7 +77,7 @@ BOUNDA      BOUND,      no        ; Match "" at any boundary between \w\W or \W\
 # All NBOUND nodes are required by code in regexec.c to be greater than all BOUND ones
 NBOUND      NBOUND,     no        ; Like NBOUNDA for non-utf8, otherwise like BOUNDU
 NBOUNDL     NBOUND,     no        ; Like NBOUND/NBOUNDU, but \w and \W are defined by current locale
-NBOUNDU     NBOUND,     no        ; Match "" at any non-boundary of a given type using using /u rules.
+NBOUNDU     NBOUND,     no        ; Match "" at any non-boundary of a given type using /u rules.
 NBOUNDA     NBOUND,     no        ; Match "" betweeen any \w\w or \W\W, where \w is [_a-zA-Z0-9]
 
 #* [Special] alternatives:
@@ -315,7 +315,7 @@ OPTIMIZED   NOTHING,    off       ; Placeholder for dump.
 #* Special opcode with the property that no opcode in a compiled program
 #* will ever be of this type. Thus it can be used as a flag value that
 #* no other opcode has been seen. END is used similarly, in that an END
-#* node cant be optimized. So END implies "unoptimizable" and PSEUDO
+#* node can't be optimized. So END implies "unoptimizable" and PSEUDO
 #* mean "not seen anything to optimize yet".
 PSEUDO      PSEUDO,     off       ; Pseudo opcode for internal use.
 

--- a/regnodes.h
+++ b/regnodes.h
@@ -290,7 +290,7 @@ typedef struct regnode                           tregnode_WHILEM;
 
 #define NBOUNDU                      14        /* 0x0e Match "" at any
                                                   non-boundary of a given type
-                                                  using using /u rules. */
+                                                  using /u rules. */
 #define NBOUNDU_tb                      28     /*      0x01c */
 #define NBOUNDU_t8                      29     /*      0x01d */
 #define NBOUNDU_tb_pb                      56  /*      0x038 */


### PR DESCRIPTION
This PR fixes multiple typos and minor grammatical issues in the pod files.