### PR TITLE
perlvar: remove indirect object syntax

### DIFF
--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -1524,28 +1524,25 @@ This variable was added in Perl v5.10.0.
 
 Variables that depend on the currently selected filehandle may be set
 by calling an appropriate object method on the C<IO::Handle> object,
-although this is less efficient than using the regular built-in
+although this is slightly less efficient than using the regular built-in
 variables.  (Summary lines below for this contain the word HANDLE.)
-First you must say
+
+In Perl versions before v5.14.0, you had to say
 
     use IO::Handle;
 
-after which you may use either
-
-    method HANDLE EXPR
-
-or more safely,
+before using
 
     HANDLE->method(EXPR)
+
+Since Perl v5.14.0, you can use all filehandles as objects without manually
+loading any modules first.
 
 Each method returns the old value of the C<IO::Handle> attribute.  The
 methods each take an optional EXPR, which, if supplied, specifies the
 new value for the C<IO::Handle> attribute in question.  If not
 supplied, most methods do nothing to the current value--except for
 C<autoflush()>, which will assume a 1 for you, just to be different.
-
-Because loading in the C<IO::Handle> class is an expensive operation,
-you should learn how to use the regular built-in variables.
 
 A few of these variables are considered "read-only".  This means that
 if you try to assign to this variable, either directly or indirectly
@@ -1570,12 +1567,12 @@ But the following code is quite bad:
     my $content = <$fh>;
     close $fh;
 
-since some other module, may want to read data from some file in the
+since some other module may want to read data from some file in the
 default "line mode", so if the code we have just presented has been
 executed, the global value of C<$/> is now changed for any other code
 running inside the same Perl interpreter.
 
-Usually when a variable is localized you want to make sure that this
+Usually when a variable is localized, you want to make sure that this
 change affects the shortest scope possible.  So unless you are already
 inside some short C<{}> block, you should create one yourself.  For
 example:


### PR DESCRIPTION
- remove the `method HANDLE EXPR` example
- mention that an explicit `use IO::Handle` has not been required since perl v5.14 (that was 13 years ago)
- remove the advice to prefer built-in variables over IO::Handle methods because:
  - `STDOUT->autoflush(1);` is about 200x more readable than `$|++;` or similar nonsense
  - loading IO::Handle isn't actually that expensive (and if it is, we should figure out how to speed up `$fh->autoflush` in core, not discourage programmers from using it)
  - the performance advice is from 1999 and hasn't been updated since (commits 14218588221b, 19799a22062e)
  - as far as I can tell, this advice is mostly Tom Christiansen's personal opinion and not the general consensus of the Perl community
- move a comma from one paragraph to the next (technically unrelated, but it's in the general vicinity of the preceding changes)

---
<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry and check the appropriate box.
-->
* [ ] This set of changes requires a perldelta entry, and it is included.
* [ ] This set of changes requires a perldelta entry, and I need help writing it.
* [x] This set of changes does not require a perldelta entry.
