### PR TITLE
github PR template: add a horizontal line separator

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ Significant changes to Perl must be documented in perldelta.
 Consider if the changes in this pull request are worthy of a perldelta
 entry and check the appropriate box.
 -->
+---------------------------------------------------------------------------------
 * [ ] This set of changes requires a perldelta entry, and it is included.
 * [ ] This set of changes requires a perldelta entry, and I need help writing it.
 * [ ] This set of changes does not require a perldelta entry.


### PR DESCRIPTION
I think it looks better if there is visual separation between the pull request description proper and the perldelta checkboxes at the bottom.

(In Markdown, a row of hyphens renders as an HTML `<hr>` (horizontal rule) element, which looks like a nice section separator.)

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry and check the appropriate box.
-->
---------------------------------------------------------------------------------
* [ ] This set of changes requires a perldelta entry, and it is included.
* [ ] This set of changes requires a perldelta entry, and I need help writing it.
* [x] This set of changes does not require a perldelta entry.
