### PR TITLE
perldelta: Add notes about recent op_dump() and xop_dump additions

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -350,6 +350,19 @@ well.
 
 XXX
 
+=item *
+
+The C<op_dump()> function has been expanded to include additional information
+about the recent C<OP_METHSTART> and C<OP_INITFIELD> ops, as well as for
+C<OP_ARGCHECK> and C<OP_ARGELEM> which had not been done previously.
+
+=item *
+
+C<op_dump()> now also has the facility to print extra debugging information
+about custom operators, if those operators register a helper function via the
+new C<xop_dump> element of the C<XOP> structure. For more information, see the
+relevant additions to L<perlguts|perlguts/"Custom Operators">.
+
 =back
 
 =head1 Selected Bug Fixes


### PR DESCRIPTION
---------------------------------------------------------------------------------
* [ ] This set of changes requires a perldelta entry, and it is included.
* [ ] This set of changes requires a perldelta entry, and I need help writing it.
* [ ] This set of changes does not require a perldelta entry.

None of the above. This set of changes *is* the perldelta entry ;)