### PR TITLE
Devel::Peek: fix build warning

### DIFF
--- a/ext/Devel-Peek/Peek.pm
+++ b/ext/Devel-Peek/Peek.pm
@@ -3,7 +3,7 @@
 
 package Devel::Peek;
 
-$VERSION = '1.35';
+$VERSION = '1.36';
 $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 

--- a/ext/Devel-Peek/Peek.xs
+++ b/ext/Devel-Peek/Peek.xs
@@ -411,7 +411,8 @@ static const XOP my_xop = {
     "Devel_Peek_Dump",					/* xop_name */
     "Dump",						/* xop_desc */
     OA_BINOP,						/* xop_class */
-    NULL						/* xop_peep */
+    NULL,                                               /* xop_peep */
+    NULL                                                /* xop_dump */
 };
 
 MODULE = Devel::Peek		PACKAGE = Devel::Peek


### PR DESCRIPTION
This was:

Peek.xs:415:1: warning: missing initializer for field ‘xop_dump’ of ‘XOP’ {aka ‘const struct custom_op’} [-Wmissing-field-initializers]
  415 | };
      | ^
In file included from ../../perl.h:4542,
                 from Peek.xs:3:
../../op.h:926:21: note: ‘xop_dump’ declared here
  926 |     void          (*xop_dump)(pTHX_ const OP *o, struct Perl_OpDumpContext *ctx);
      |                     ^~~~~~~~

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry and check the appropriate box.
-->
---------------------------------------------------------------------------------
* [ ] This set of changes requires a perldelta entry, and it is included.
* [ ] This set of changes requires a perldelta entry, and I need help writing it.
* [ x] This set of changes does not require a perldelta entry.
