### PR TITLE
Make `struct shared_he` opaque

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -166,7 +166,7 @@ Unused or not for public use
 #define PV_BYTE_HEX_LC  "x%02" UVxf
 
 char *
-Perl_pv_escape( pTHX_ SV *dsv, char const * const str, 
+Perl_pv_escape( pTHX_ SV *dsv, char const * const str,
                 const STRLEN count, STRLEN max,
                 STRLEN * const escaped, U32 flags )
 {
@@ -226,21 +226,21 @@ Perl_pv_escape( pTHX_ SV *dsv, char const * const str,
             /* This won't alter the UTF-8 flag */
             SvPVCLEAR(dsv);
     }
-    
+
     if ((flags & PERL_PV_ESCAPE_UNI_DETECT) && is_utf8_string((U8*)pv, count))
         isuni = 1;
-    
+
     for ( ; pv < end ; pv += readsize ) {
         const UV u= (isuni) ? utf8_to_uvchr_buf((U8*)pv, (U8*) end, &readsize) : (U8)*pv;
         const U8 c = (U8)u;
         const char *source_buf = octbuf;
-        
+
         if ( ( u > 255 )
           || (flags & PERL_PV_ESCAPE_ALL)
           || (( ! isASCII(u) ) && (flags & (PERL_PV_ESCAPE_NONASCII|PERL_PV_ESCAPE_DWIM))))
         {
-            if (flags & PERL_PV_ESCAPE_FIRSTCHAR) 
-                chsize = my_snprintf( octbuf, PV_ESCAPE_OCTBUFSIZE, 
+            if (flags & PERL_PV_ESCAPE_FIRSTCHAR)
+                chsize = my_snprintf( octbuf, PV_ESCAPE_OCTBUFSIZE,
                                       "%" UVxf, u);
             else
             if ((flags & PERL_PV_ESCAPE_NON_WC) && isWORDCHAR_uvchr(u)) {
@@ -248,21 +248,21 @@ Perl_pv_escape( pTHX_ SV *dsv, char const * const str,
                 source_buf = pv;
             }
             else
-                chsize = my_snprintf( octbuf, PV_ESCAPE_OCTBUFSIZE, 
+                chsize = my_snprintf( octbuf, PV_ESCAPE_OCTBUFSIZE,
                                       ((flags & PERL_PV_ESCAPE_DWIM) && !isuni)
                                       ? ( use_uc_hex ? ("%c" PV_BYTE_HEX_UC) : ("%c" PV_BYTE_HEX_LC) )
                                       : "%cx{%02" UVxf "}", esc, u);
 
         } else if (flags & PERL_PV_ESCAPE_NOBACKSLASH) {
-            chsize = 1;            
-        } else {         
+            chsize = 1;
+        } else {
             if ( (c == dq) || (c == esc) || !isPRINT(c) ) {
                 chsize = 2;
                 switch (c) {
-                
+
                 case '\\' : /* FALLTHROUGH */
                 case '%'  : if ( c == esc )  {
-                                octbuf[1] = esc;  
+                                octbuf[1] = esc;
                             } else {
                                 chsize = 1;
                             }
@@ -272,10 +272,10 @@ Perl_pv_escape( pTHX_ SV *dsv, char const * const str,
                 case '\r' : octbuf[1] = 'r';  break;
                 case '\n' : octbuf[1] = 'n';  break;
                 case '\f' : octbuf[1] = 'f';  break;
-                case '"'  : 
-                        if ( dq == '"' ) 
+                case '"'  :
+                        if ( dq == '"' )
                                 octbuf[1] = '"';
-                        else 
+                        else
                             chsize = 1;
                         break;
                 default:
@@ -323,7 +323,7 @@ Perl_pv_escape( pTHX_ SV *dsv, char const * const str,
                 Perl_sv_catpvf( aTHX_ dsv, "%c", c);
             wrote++;
         }
-        if ( flags & PERL_PV_ESCAPE_FIRSTCHAR ) 
+        if ( flags & PERL_PV_ESCAPE_FIRSTCHAR )
             break;
     }
     if (escaped != NULL)
@@ -339,7 +339,7 @@ C<pv_escape()> and supporting quoting and ellipses.
 If the C<PERL_PV_PRETTY_QUOTE> flag is set then the result will be
 double quoted with any double quotes in the string escaped.  Otherwise
 if the C<PERL_PV_PRETTY_LTGT> flag is set then the result be wrapped in
-angle brackets. 
+angle brackets.
 
 If the C<PERL_PV_PRETTY_ELLIPSES> flag is set and not all characters in
 string were output then an ellipsis C<...> will be appended to the
@@ -356,22 +356,22 @@ Returns a pointer to the prettified text as held by C<dsv>.
 =for apidoc Amnh||PERL_PV_PRETTY_LTGT
 =for apidoc Amnh||PERL_PV_PRETTY_ELLIPSES
 
-=cut           
+=cut
 */
 
 char *
-Perl_pv_pretty( pTHX_ SV *dsv, char const * const str, const STRLEN count, 
-  const STRLEN max, char const * const start_color, char const * const end_color, 
-  const U32 flags ) 
+Perl_pv_pretty( pTHX_ SV *dsv, char const * const str, const STRLEN count,
+  const STRLEN max, char const * const start_color, char const * const end_color,
+  const U32 flags )
 {
     const U8 *quotes = (U8*)((flags & PERL_PV_PRETTY_QUOTE) ? "\"\"" :
                              (flags & PERL_PV_PRETTY_LTGT)  ? "<>" : NULL);
     STRLEN escaped;
     STRLEN max_adjust= 0;
     STRLEN orig_cur;
- 
+
     PERL_ARGS_ASSERT_PV_PRETTY;
-   
+
     if (!(flags & PERL_PV_PRETTY_NOCLEAR)) {
         /* This won't alter the UTF-8 flag */
         SvPVCLEAR(dsv);
@@ -380,8 +380,8 @@ Perl_pv_pretty( pTHX_ SV *dsv, char const * const str, const STRLEN count,
 
     if ( quotes )
         Perl_sv_catpvf(aTHX_ dsv, "%c", quotes[0]);
-        
-    if ( start_color != NULL ) 
+
+    if ( start_color != NULL )
         sv_catpv(dsv, start_color);
 
     if ((flags & PERL_PV_PRETTY_EXACTSIZE)) {
@@ -396,12 +396,12 @@ Perl_pv_pretty( pTHX_ SV *dsv, char const * const str, const STRLEN count,
 
     pv_escape( dsv, str, count, max - max_adjust, &escaped, flags | PERL_PV_ESCAPE_NOCLEAR );
 
-    if ( end_color != NULL ) 
+    if ( end_color != NULL )
         sv_catpv(dsv, end_color);
 
     if ( quotes )
         Perl_sv_catpvf(aTHX_ dsv, "%c", quotes[1]);
-    
+
     if ( (flags & PERL_PV_PRETTY_ELLIPSES) && ( escaped < count ) )
             sv_catpvs(dsv, "...");
 
@@ -409,7 +409,7 @@ Perl_pv_pretty( pTHX_ SV *dsv, char const * const str, const STRLEN count,
         while( SvCUR(dsv) - orig_cur < max )
             sv_catpvs(dsv," ");
     }
- 
+
     return SvPVX(dsv);
 }
 
@@ -795,7 +795,7 @@ S_opdump_link(pTHX_ const OP *base, const OP *o, PerlIO *file)
 =for apidoc_section $debugging
 =for apidoc dump_all
 
-Dumps the entire optree of the current program starting at C<PL_main_root> to 
+Dumps the entire optree of the current program starting at C<PL_main_root> to
 C<STDERR>.  Also dumps the optrees for all visible subroutines in
 C<PL_defstash>.
 
@@ -2047,7 +2047,7 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
     if ((flags & SVs_PADTMP))
             sv_catpvs(d, "PADTMP,");
     append_flags(d, flags, first_sv_flags_names);
-    if (flags & SVf_ROK)  {	
+    if (flags & SVf_ROK)  {
                                 sv_catpvs(d, "ROK,");
         if (SvWEAKREF(sv))	sv_catpvs(d, "WEAKREF,");
     }
@@ -2350,7 +2350,7 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
             if (ents) {
                 HE *const *const last = ents + HvMAX(sv);
                 count = last + 1 - ents;
-                
+
                 do {
                     if (!*ents)
                         --count;
@@ -3375,7 +3375,7 @@ Perl_op_class(pTHX_ const OP *o)
             return OPclass_SVOP;
 #endif
     }
-    
+
 #ifdef USE_ITHREADS
     if (o->op_type == OP_GV || o->op_type == OP_GVSV ||
         o->op_type == OP_RCATLINE)
@@ -3412,7 +3412,7 @@ Perl_op_class(pTHX_ const OP *o)
 
     case OA_PVOP_OR_SVOP:
         /*
-         * Character translations (tr///) are usually a PVOP, keeping a 
+         * Character translations (tr///) are usually a PVOP, keeping a
          * pointer to a table of shorts used to look up translations.
          * Under utf8, however, a simple table isn't practical; instead,
          * the OP is an SVOP (or, under threads, a PADOP),

--- a/embed.fnc
+++ b/embed.fnc
@@ -3016,6 +3016,8 @@ Xp	|void	|set_numeric_underlying 				\
 Cp	|HEK *	|share_hek	|NN const char *str			\
 				|SSize_t len				\
 				|U32 hash
+Cp	|struct hek *|share_hek_hek					\
+				|NN const struct hek *hek
 Tp	|Signal_t|sighandler1	|int sig
 Tp	|Signal_t|sighandler3	|int sig				\
 				|NULLOK Siginfo_t *info 		\

--- a/embed.h
+++ b/embed.h
@@ -635,6 +635,7 @@
 # define set_context                            Perl_set_context
 # define setdefout(a)                           Perl_setdefout(aTHX_ a)
 # define share_hek(a,b,c)                       Perl_share_hek(aTHX_ a,b,c)
+# define share_hek_hek(a)                       Perl_share_hek_hek(aTHX_ a)
 # define single_1bit_pos32                      Perl_single_1bit_pos32
 # define sortsv(a,b,c)                          Perl_sortsv(aTHX_ a,b,c)
 # define sortsv_flags(a,b,c,d)                  Perl_sortsv_flags(aTHX_ a,b,c,d)

--- a/hv.c
+++ b/hv.c
@@ -16,7 +16,7 @@
  *     [p.278 of _The Lord of the Rings_, II/iii: "The Ring Goes South"]
  */
 
-/* 
+/*
 =head1 HV Handling
 A HV structure represents a Perl hash.  It consists mainly of an array
 of pointers, each of which points to a linked list of HE structures.  The
@@ -513,7 +513,7 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
                                            ((flags & HVhek_UTF8)
                                             ? SVf_UTF8 : 0));
                 }
-                
+
                 mg->mg_obj = keysv;         /* pass key */
                 uf->uf_index = action;      /* pass action */
                 magic_getuvar(MUTABLE_SV(hv), mg);
@@ -912,7 +912,7 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
 
   not_found:
 #ifdef DYNAMIC_ENV_FETCH  /* %ENV lookup?  If so, try to fetch the value now */
-    if (!(action & HV_FETCH_ISSTORE) 
+    if (!(action & HV_FETCH_ISSTORE)
         && SvRMAGICAL((const SV *)hv)
         && mg_find((const SV *)hv, PERL_MAGIC_env)) {
         unsigned long len;
@@ -1245,7 +1245,7 @@ Perl_hv_bucket_ratio(pTHX_ HV *hv)
     }
     else
         sv = &PL_sv_zero;
-    
+
     return sv;
 }
 
@@ -1314,7 +1314,7 @@ S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
                         /* No longer an element */
                         sv_unmagic(sv, PERL_MAGIC_tiedelem);
                         return sv;
-                    }		
+                    }
                     return NULL;		/* element cannot be deleted */
                 }
 #ifdef ENV_IS_CASELESS
@@ -1456,7 +1456,7 @@ S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
                 HvHASKFLAGS_off(hv);
         }
 
-        /* If this is a stash and the key ends with ::, then someone is 
+        /* If this is a stash and the key ends with ::, then someone is
          * deleting a package.
          */
         if (sv && SvTYPE(sv) == SVt_PVGV && HvHasENAME(hv)) {
@@ -2759,7 +2759,7 @@ Perl_hv_ename_add(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
         {
             assert(*hekp);
             if (
-                 (HEK_UTF8(*hekp) || (flags & SVf_UTF8)) 
+                 (HEK_UTF8(*hekp) || (flags & SVf_UTF8))
                     ? hek_eq_pvn_flags(aTHX_ *hekp, name, (I32)len, flags)
                     : (HEK_LEN(*hekp) == (I32)len && memEQ(HEK_KEY(*hekp), name, len))
                ) {
@@ -2822,7 +2822,7 @@ Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
         HEK **victim = namep + (count < 0 ? -count : count);
         while (victim-- > namep + 1)
             if (
-             (HEK_UTF8(*victim) || (flags & SVf_UTF8)) 
+             (HEK_UTF8(*victim) || (flags & SVf_UTF8))
                 ? hek_eq_pvn_flags(aTHX_ *victim, name, (I32)len, flags)
                 : (HEK_LEN(*victim) == (I32)len && memEQ(HEK_KEY(*victim), name, len))
             ) {
@@ -2845,7 +2845,7 @@ Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
                 return;
             }
         if (
-            count > 0 && ((HEK_UTF8(*namep) || (flags & SVf_UTF8)) 
+            count > 0 && ((HEK_UTF8(*namep) || (flags & SVf_UTF8))
                 ? hek_eq_pvn_flags(aTHX_ *namep, name, (I32)len, flags)
                 : (HEK_LEN(*namep) == (I32)len && memEQ(HEK_KEY(*namep), name, len))
             )
@@ -2854,7 +2854,7 @@ Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
         }
     }
     else if(
-        (HEK_UTF8(aux->xhv_name_u.xhvnameu_name) || (flags & SVf_UTF8)) 
+        (HEK_UTF8(aux->xhv_name_u.xhvnameu_name) || (flags & SVf_UTF8))
                 ? hek_eq_pvn_flags(aTHX_ aux->xhv_name_u.xhvnameu_name, name, (I32)len, flags)
                 : (HEK_LEN(aux->xhv_name_u.xhvnameu_name) == (I32)len &&
                             memEQ(HEK_KEY(aux->xhv_name_u.xhvnameu_name), name, len))
@@ -4004,7 +4004,7 @@ Perl_refcounted_he_free(pTHX_ struct refcounted_he *he) {
         HINTS_REFCNT_LOCK;
         new_count = --he->refcounted_he_refcnt;
         HINTS_REFCNT_UNLOCK;
-        
+
         if (new_count) {
             return;
         }

--- a/hv.c
+++ b/hv.c
@@ -4120,6 +4120,21 @@ Perl_cop_store_label(pTHX_ COP *const cop, const char *label, STRLEN len,
         = refcounted_he_new_pvs(cop->cop_hints_hash, ":", labelsv, 0);
 }
 
+/* share doesn't mean "shared" but "shared string table" */
+/* TODO: should this be atomic increment ??? */
+struct hek *
+Perl_share_hek_hek (pTHX_ const struct hek *hek)
+{
+    PERL_ARGS_ASSERT_SHARE_HEK_HEK;
+    ((struct shared_he *)(((char *)hek)
+                          - STRUCT_OFFSET(struct shared_he,
+                                          shared_he_hek)))
+        ->shared_he_he.he_valu.hent_refcount++
+    ;
+
+    return (struct hek *) hek;
+}
+
 /*
 =for apidoc_section $HV
 =for apidoc hv_assert

--- a/hv.c
+++ b/hv.c
@@ -177,6 +177,11 @@ S_new_he(pTHX)
 
 #endif
 
+struct shared_he {
+    struct he shared_he_he;
+    struct hek shared_he_hek;
+};
+
 STATIC HEK *
 S_save_hek_flags(const char *str, I32 len, U32 hash, int flags)
 {

--- a/hv.h
+++ b/hv.h
@@ -121,7 +121,7 @@ struct xpvhv_aux {
     HE		*xhv_eiter;	/* current entry of iterator */
     I32		xhv_riter;	/* current root of iterator */
 
-/* Concerning xhv_name_count: When non-zero, xhv_name_u contains a pointer 
+/* Concerning xhv_name_count: When non-zero, xhv_name_u contains a pointer
  * to an array of HEK pointers, this being the length. The first element is
  * the name of the stash, which may be NULL. If xhv_name_count is positive,
  * then *xhv_name is one of the effective names. If xhv_name_count is nega-
@@ -500,7 +500,7 @@ whether it is valid to call C<HvAUX()>.
 #ifndef PERL_USE_LARGE_HV_ALLOC
 /* Default to allocating the correct size - default to assuming that malloc()
    is not broken and is efficient at allocating blocks sized at powers-of-two.
-*/   
+*/
 #  define PERL_HV_ARRAY_ALLOC_BYTES(size) ((size) * sizeof(HE*))
 #else
 #  define MALLOC_OVERHEAD 16

--- a/hv.h
+++ b/hv.h
@@ -63,10 +63,7 @@ struct hek {
        is UTF-8 or WAS-UTF-8, or an SV */
 };
 
-struct shared_he {
-    struct he shared_he_he;
-    struct hek shared_he_hek;
-};
+struct shared_he;
 
 /* Subject to change.
    Don't access this directly.

--- a/hv.h
+++ b/hv.h
@@ -520,13 +520,6 @@ whether it is valid to call C<HvAUX()>.
 #define Perl_sharepvn(pv, len, hash) HEK_KEY(share_hek(pv, len, hash))
 #define sharepvn(pv, len, hash)	     Perl_sharepvn(pv, len, hash)
 
-#define share_hek_hek(hek)						\
-    (++(((struct shared_he *)(((char *)hek)				\
-                              - STRUCT_OFFSET(struct shared_he,		\
-                                              shared_he_hek)))		\
-        ->shared_he_he.he_valu.hent_refcount),				\
-     hek)
-
 #define hv_store_ent(hv, keysv, val, hash)				\
     ((HE *) hv_common((hv), (keysv), NULL, 0, 0, HV_FETCH_ISSTORE,	\
                       (val), (hash)))

--- a/pad.c
+++ b/pad.c
@@ -114,7 +114,7 @@ write is called (if necessary).
 The flag C<SVs_PADSTALE> is cleared on lexicals each time the C<my()> is executed,
 and set on scope exit.  This allows the
 C<"Variable $x is not available"> warning
-to be generated in evals, such as 
+to be generated in evals, such as
 
     { my $x = 1; sub f { eval '$x'} } f();
 
@@ -1181,7 +1181,7 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV* cv,
                 DEBUG_Xv(PerlIO_printf(Perl_debug_log,
                     "Pad findlex cv=0x%" UVxf " matched: offset=%ld flags=0x%lx index=%lu\n",
                     PTR2UV(cv), (long)offset, (unsigned long)*out_flags,
-                    (unsigned long) PARENT_PAD_INDEX(*out_name) 
+                    (unsigned long) PARENT_PAD_INDEX(*out_name)
                 ));
             }
 
@@ -2008,7 +2008,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
                     S_unavailable(aTHX_ namesv);
                     sv = NULL;
                 }
-                else 
+                else
                     SvREFCNT_inc_simple_void_NN(sv);
             }
             if (!sv) {
@@ -2569,8 +2569,8 @@ Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
                                interacts with lexicals.  */
                             pad1a[ix] = sv_dup_inc(oldpad[ix], param);
                         } else {
-                            SV *sv; 
-                            
+                            SV *sv;
+
                             if (sigil == '@')
                                 sv = MUTABLE_SV(newAV());
                             else if (sigil == '%')

--- a/proto.h
+++ b/proto.h
@@ -4240,6 +4240,11 @@ Perl_share_hek(pTHX_ const char *str, SSize_t len, U32 hash);
 #define PERL_ARGS_ASSERT_SHARE_HEK              \
         assert(str)
 
+PERL_CALLCONV struct hek *
+Perl_share_hek_hek(pTHX_ const struct hek *hek);
+#define PERL_ARGS_ASSERT_SHARE_HEK_HEK          \
+        assert(hek)
+
 PERL_CALLCONV Signal_t
 Perl_sighandler1(int sig)
         __attribute__visibility__("hidden");

--- a/scope.c
+++ b/scope.c
@@ -370,7 +370,7 @@ Implements C<SAVERCPV>.
 
 Saves and restores a refcounted string, similar to what
 save_generic_svref would do for a SV*. Can be used to restore
-a refcounted string to its previous state. Performs the 
+a refcounted string to its previous state. Performs the
 appropriate refcount counting so that nothing should leak
 or be prematurely freed.
 
@@ -1345,7 +1345,7 @@ Perl_leave_scope(pTHX_ I32 base)
             bool had_method;
 
             a0 = ap[0]; a1 = ap[1];
-            /* possibly taking a method out of circulation */	
+            /* possibly taking a method out of circulation */
             had_method = cBOOL(GvCVu(a0.any_gv));
             gp_free(a0.any_gv);
             GvGP_set(a0.any_gv, (GP*)a1.any_ptr);
@@ -1353,7 +1353,7 @@ Perl_leave_scope(pTHX_ I32 base)
                 if (memEQs(GvNAME(a0.any_gv), GvNAMELEN(a0.any_gv), "ISA"))
                     mro_isa_changed_in(hv);
                 else if (had_method || GvCVu(a0.any_gv))
-                    /* putting a method back into circulation ("local")*/	
+                    /* putting a method back into circulation ("local")*/
                     gv_method_changed(a0.any_gv);
             }
             SvREFCNT_dec_NN(a0.any_gv);

--- a/sv.c
+++ b/sv.c
@@ -11012,7 +11012,7 @@ whatever was being referenced by the RV.  This can almost be thought of
 as a reversal of C<L</newSVrv>>.
 
 C<sv_unref_flags> has an extra parameter, C<flags>, which can contain
-the C<SV_IMMEDIATE_UNREF> bit to force the reference count to be decremented 
+the C<SV_IMMEDIATE_UNREF> bit to force the reference count to be decremented
 no matter what.
 
 When that bit isn't set, or with plain C<sv_unref> always, the reference count


### PR DESCRIPTION
Making structures use internally to implement some internal behaviour opaque with accessor functions only
makes code less fragile and makes related maintenance much easier.

Change doesn't affect language nor API.
