### PR TITLE
sv_gets: use a SSize_t append character index

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5972,6 +5972,7 @@ t/bigmem/stack_over.t			Check handling of stack overflows with 32-bit MARK on 64
 t/bigmem/str.t				Test string primitives with large strings
 t/bigmem/subst.t			Test s/// with large strings
 t/bigmem/subst2.t			Test s//EXPR/e with large strings
+t/bigmem/sv_gets.t			Test reading a lot with sv_gets()
 t/bigmem/vec.t				Check vec() handles large offsets
 t/charset_tools.pl			To aid in portable testing across platforms with different character sets
 t/class/accessor.t			See if accessor methods work

--- a/embed.fnc
+++ b/embed.fnc
@@ -3175,7 +3175,7 @@ ATdpx	|SV *	|sv_get_backrefs|NN SV * const sv
 Adip	|void	|SvGETMAGIC	|NN SV *sv
 Adp	|char * |sv_gets	|NN SV * const sv			\
 				|NN PerlIO * const fp			\
-				|I32 append
+				|SSize_t append
 Cdp	|char * |sv_grow	|NN SV * const sv			\
 				|STRLEN newlen
 Cdp	|char * |sv_grow_fresh	|NN SV * const sv			\

--- a/proto.h
+++ b/proto.h
@@ -4557,7 +4557,7 @@ Perl_sv_get_backrefs(SV * const sv);
         assert(sv)
 
 PERL_CALLCONV char *
-Perl_sv_gets(pTHX_ SV * const sv, PerlIO * const fp, I32 append);
+Perl_sv_gets(pTHX_ SV * const sv, PerlIO * const fp, SSize_t append);
 #define PERL_ARGS_ASSERT_SV_GETS                \
         assert(sv); assert(fp)
 

--- a/t/bigmem/sv_gets.t
+++ b/t/bigmem/sv_gets.t
@@ -1,0 +1,48 @@
+#!perl
+BEGIN {
+    chdir 't' if -d 't';
+    @INC = "../lib";
+}
+
+use strict;
+require './test.pl';
+use Config qw(%Config);
+
+# 2 for the child, 2 for the parent
+$ENV{PERL_TEST_MEMORY} >= 4
+    or skip_all("Need ~4Gb for this test");
+$Config{ptrsize} >= 8
+    or skip_all("Need 64-bit pointers for this test");
+
+{
+    # https://www.perlmonks.org/?node_id=11161665
+    my $x = `$^X -e "print q/x/ x 0x80000000"`;
+    is(length $x, 0x80000000, "check entire input read");
+    undef $x;
+}
+
+{
+    # sv_gets_append_to_utf8 append parameter
+    my $x = "x";
+    $x x= 0x8000_0000;
+    utf8::upgrade($x);
+    # using bareword handle because the rcatline optimization isn't done
+    # for non-barewords
+    # for $fh
+    # we chdired to "t"
+    open FH, "<", "TEST" or die $!;
+    $x .= <FH>;
+    pass("didn't crash appending readline to large upgraded scalar");
+}
+
+{
+    # sv_gets_read_record append parameter
+    my $x = "x";
+    $x x= 0x8000_0000;
+    open FH, "<", "TEST" or die $!;
+    local $/ = \100;
+    $x .= <FH>;
+    pass("didn't crash appending readline record to large scalar");
+}
+
+done_testing();


### PR DESCRIPTION
This used an I32, which could overflow when reading from a large source.

https://www.perlmonks.org/?node_id=11161665

perldelta something like:

```
Fix sv_gets() and hence C<readpipe> aka C<qx//>, C<readline> to accept a C<SSize_t> append offset
instead of C<I32>.  This prevents integer overflows when appending to a large C<SV>.
L<https://www.perlmonks.org/?node_id=11161665>
```

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->


<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry and check the appropriate box.
-->
---------------------------------------------------------------------------------
* [x] This set of changes requires a perldelta entry, and it is included.
* [ ] This set of changes requires a perldelta entry, and I need help writing it.
* [ ] This set of changes does not require a perldelta entry.
