### PR TITLE
perldelta: Add notes about fix related to broken compilation on environments with very limited number of locales (e.g. Gentoo Prefix)

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -254,7 +254,8 @@ L</Platform Support> section, instead.
 
 =item *
 
-XXX
+Fix compilation on platforms (e.g. "Gentoo Prefix") with only a C locale [GH #22569]
+Bug first reported downstream L<bugs.gentoo.org/939014|https://bugs.gentoo.org/939014> 
 
 =back
 


### PR DESCRIPTION
Adding the perldelta for a change fixing compilation on environments with limited number of locales #22569 

---------------------------------------------------------------------------------
* [ ] This set of changes requires a perldelta entry, and it is included.
* [ ] This set of changes requires a perldelta entry, and I need help writing it.
* [ ] This set of changes does not require a perldelta entry.

This is a perldelta entry :) 