### PR TITLE
Some Invalid UTF-8 Sequences Cause Panic

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -933,6 +933,7 @@ Marty Lucich                   <marty@netcom.com>
 Marty Pauley                   <marty+p5p@kasei.com>
 Martyn Pearce                  <martyn@inpharmatica.co.uk>
 Marvin Humphrey                <marvin@rectangular.com>
+Masahiro Honma                 <hira.tara@gmail.com>
 Masahiro KAJIURA               <masahiro.kajiura@toshiba.co.jp>
 Mashrab Kuvatov                <kmashrab@uni-bremen.de>
 Mathias Kende                  <mathias@cpan.org>

--- a/inline.h
+++ b/inline.h
@@ -3026,14 +3026,9 @@ Perl_utf8n_to_uvchr_msgs(const U8 *s,
     }
     else {
         UV state = PL_strict_utf8_dfa_tab[256 + type];
-        if (UNLIKELY(state == 1)) {
-            /* Here is potentially problematic.  Use the full mechanism */
-            return _utf8n_to_uvchr_msgs_helper(s0, curlen, retlen, flags,
-                                               errors, msgs);
-        }
         uv = (0xff >> type) & NATIVE_UTF8_TO_I8(*s);
 
-        while (++s < send) {
+        while (LIKELY(state != 1) && ++s < send) {
             type  = PL_strict_utf8_dfa_tab[*s];
             state = PL_strict_utf8_dfa_tab[256 + state + type];
 
@@ -3044,10 +3039,6 @@ Perl_utf8n_to_uvchr_msgs(const U8 *s,
                 uv = UNI_TO_NATIVE(uv);
 #endif
                 goto success;
-            }
-
-            if (UNLIKELY(state == 1)) {
-                break;
             }
         }
 

--- a/inline.h
+++ b/inline.h
@@ -3026,6 +3026,11 @@ Perl_utf8n_to_uvchr_msgs(const U8 *s,
     }
     else {
         UV state = PL_strict_utf8_dfa_tab[256 + type];
+        if (UNLIKELY(state == 1)) {
+            /* Here is potentially problematic.  Use the full mechanism */
+            return _utf8n_to_uvchr_msgs_helper(s0, curlen, retlen, flags,
+                                               errors, msgs);
+        }
         uv = (0xff >> type) & NATIVE_UTF8_TO_I8(*s);
 
         while (++s < send) {

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -175,6 +175,16 @@ This prevents integer overflows when appending to a large C<SV> for
 C<readpipe> aka C<qx//> and C<readline>.
 L<https://www.perlmonks.org/?node_id=11161665>
 
+=item *
+
+Fixed an issue where `utf8n_to_uvchr` failed to correctly identify
+certain invalid UTF-8 sequences as invalid. Specifically, sequences
+that start with continuation bytes or unassigned bytes could cause
+unexpected behavior or a panic. This fix ensures that such invalid
+sequences are now properly detected and handled. This correction
+also resolves related issues in modules that handle UTF-8 processing,
+such as `Encode.pm`.
+
 =back
 
 =head1 Acknowledgements


### PR DESCRIPTION
Hello,

Since commit a460925186154b270b7a647a4f30b2f01fd97c4b, `utf8n_to_uvchr` has been broken, causing some peculiar behavior when handling invalid UTF-8 sequences.

For example, invalid UTF-8 sequences cause a panic message:

```
# This is expected
$ perl -E 'say "use strict; use warnings; use utf8; \"\xf4\xE3\x81\x82\""' | perl
Malformed UTF-8 character: \xf4\xe3\x81\x82 (unexpected non-continuation byte 0xe3, immediately after start byte 0xf4; need 4 bytes, got 1) at - line 1.
Malformed UTF-8 character (fatal) at - line 1.

# This isn't expected
$ perl -E 'say "use strict; use warnings; use utf8; \"\xff\xE3\x81\x82\""' | perl
panic: _force_out_malformed_utf8_message should be called only when there are errors found at - line 1.
```

This bug also affects `Encode.pm`:

```
# This is expected
$ perl -MEncode -E 'say encode "UTF-8", decode "UTF-8", "\xf4\xE3\x81\x82", Encode::FB_PERLQQ'
\xF4あ

# This isn't expected
$ perl -MEncode -E 'say encode "UTF-8", decode "UTF-8", "\xff\xE3\x81\x82", Encode::FB_PERLQQ'
\xFF\xE3\x81\x82
```

This PR fixes those problems.

* [x] This set of changes requires a perldelta entry, and it is included.
* [ ] This set of changes requires a perldelta entry, and I need help writing it.
* [ ] This set of changes does not require a perldelta entry.
