### PR TITLE
Storable: remove more pre-5.6 compatbility code

### DIFF
--- a/dist/Storable/lib/Storable.pm
+++ b/dist/Storable/lib/Storable.pm
@@ -123,11 +123,8 @@ EOM
 }
 
 sub file_magic {
-    require IO::File;
-
     my $file = shift;
-    my $fh = IO::File->new;
-    open($fh, "<", $file) || die "Can't open '$file': $!";
+    open(my $fh, "<", $file) || die "Can't open '$file': $!";
     binmode($fh);
     defined(sysread($fh, my $buf, 32)) || die "Can't read from '$file': $!";
     close($fh);


### PR DESCRIPTION
This one goes back to commit ab6f8ca19 and was originally meant to provide compatibility with perl 5.004. There is no point in this now that we use three-arg open and 'no warnings' unconditionally elsewhere.

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry and check the appropriate box.
-->
---------------------------------------------------------------------------------
* [ ] This set of changes requires a perldelta entry, and it is included.
* [ ] This set of changes requires a perldelta entry, and I need help writing it.
* [x] This set of changes does not require a perldelta entry.
