### PR TITLE
bodies_by_type[SVt_PVNV]: handle __float128 NV alignment on 32-bit

### DIFF
--- a/sv_inline.h
+++ b/sv_inline.h
@@ -218,12 +218,25 @@ static const struct body_details bodies_by_type[] = {
       SVt_PVIV, FALSE, NONV, HASARENA,
       FIT_ARENA(0, sizeof(XPVIV) - STRUCT_OFFSET(XPV, xpv_cur)) },
 
+#if NVSIZE > 8 && PTRSIZE < 8 && MEM_ALIGNBYTES > 8
+    /* NV may need strict 16 byte alignment.
+
+       On 64-bit systems the NV ends up aligned despite the hack
+       avoiding allocation of xmg_stash and xmg_u, so only do this
+       for 32-bit systems.
+    */
+    { sizeof(XPVNV),
+      sizeof(XPVNV),
+      0,
+      SVt_PVNV, FALSE, HADNV, HASARENA,
+      FIT_ARENA(0, sizeof(XPVNV)) },
+#else
     { sizeof(XPVNV) - STRUCT_OFFSET(XPV, xpv_cur),
       copy_length(XPVNV, xnv_u) - STRUCT_OFFSET(XPV, xpv_cur),
       + STRUCT_OFFSET(XPV, xpv_cur),
       SVt_PVNV, FALSE, HADNV, HASARENA,
       FIT_ARENA(0, sizeof(XPVNV) - STRUCT_OFFSET(XPV, xpv_cur)) },
-
+#endif
     { sizeof(XPVMG), copy_length(XPVMG, xnv_u), 0, SVt_PVMG, FALSE, HADNV,
       HASARENA, FIT_ARENA(0, sizeof(XPVMG)) },
 


### PR DESCRIPTION
On i686 systems with -msse __float128 requires 16 byte alignment, but for XPVNV bodies the hack used by new_body_allocated() to avoid allocating the unused xmg_stash and xmg_u fields means that the base of the XPVNV body ends up mis-aligned on 32-bit systems.

One 64-bit systems the combined size of those fields is 16-bytes so the modified pointer is still properly aligned.

Fixes #22577

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
perldelta something like the following in Selected bug fixes:

> Builds with C<-msse> and quadmath on 32-bit x86 systems would crash with a misaligned access early in the build. [GH #22577]



<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry and check the appropriate box.
-->
---------------------------------------------------------------------------------
* [x] This set of changes requires a perldelta entry, and it is included.
* [ ] This set of changes requires a perldelta entry, and I need help writing it.
* [ ] This set of changes does not require a perldelta entry.
