### PR TITLE
op/pack.t: handle sizeof (IV) > sizeof (void *)

### DIFF
--- a/t/op/pack.t
+++ b/t/op/pack.t
@@ -348,10 +348,14 @@ SKIP:
     # based on https://github.com/Perl/perl5/issues/22380
     eval { require XS::APItest; 1 }
       or skip "Cannot load XS::APItest", 2;
+    my $intptr_format
+        = $Config{ptrsize} == 4 ? 'l'
+        : $Config{ptrsize} == 8 ? 'q'
+        : skip "Don't know how to unpack $Config{ptrsize}-byte pointers as integers", 2;
     # writable "P"
     my $orig = "x" x 36;
     my $data = $orig;
-    my $ptr = unpack 'j', pack 'P', $data;
+    my $ptr = unpack $intptr_format, pack 'P', $data;
     XS::APItest::modify_pv($ptr, length $data);
     is($data, "y" x 36, "check \$data was modified");
     is($orig, "x" x 36, "check \$orig wasn't modified");


### PR DESCRIPTION
This test tries to get the integer representation of a pointer via unpack 'j', pack 'P'. But an IV is not necessarily the same size as a pointer. In particular, on 32-bit platforms with -Duse64bitint we have sizeof (IV) == 8 and sizeof (void *) == 4, which makes unpack 'j' fail (the input string is too short) and return undef.

Work around the issue by checking for the most common pointer sizes (4 and 8 bytes) and selecting an appropriate integer unpack format. In all other cases (exotic platforms?), just skip the test.

Fixes #22618 ­– hopefully.

---------------------------------------------------------------------------------
* [ ] This set of changes requires a perldelta entry, and it is included.
* [ ] This set of changes requires a perldelta entry, and I need help writing it.
* [x] This set of changes does not require a perldelta entry.
