### PR TITLE
op.c: More debugging assert()s in `Perl_newMYSUB()`

### DIFF
--- a/op.c
+++ b/op.c
@@ -10243,7 +10243,9 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
            my sub foo; sub { sub foo { } }
      */
   redo:
+    assert(pax > 0);
     name = PadlistNAMESARRAY(CvPADLIST(outcv))[pax];
+    assert(name);
     if (PadnameOUTER(name) && PARENT_PAD_INDEX(name)) {
         pax = PARENT_PAD_INDEX(name);
         outcv = CvOUTSIDE(outcv);
@@ -10285,7 +10287,7 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
     else if (PadnameIsSTATE(name) || CvDEPTH(outcv))
         cv = *spot;
     else {
-        assert (SvTYPE(*spot) == SVt_PVCV);
+        assert (*spot && SvTYPE(*spot) == SVt_PVCV);
         if (CvNAMED(*spot))
             hek = CvNAME_HEK(*spot);
         else {


### PR DESCRIPTION
As this function doesn't appear to be documented, it was quite difficult to work out how to use it. Adding these assert calls helped me narrow down what was failing about my use of it.

I don't think this is big enough to warrant a perldelta entry.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
