### PR TITLE
sv.c: Remove redundant `PERL_ABS` in S_hextract.

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -11735,7 +11735,7 @@ S_hextract(pTHX_ const NV nv, int* exponent, bool *subnormal,
     assert(HEXTRACTSIZE <= VHEX_SIZE);
 
     PERL_UNUSED_VAR(ix); /* might happen */
-    (void)Perl_frexp(PERL_ABS(nv), exponent);
+    (void)Perl_frexp(nv, exponent);
     *subnormal = FALSE;
     if (vend && (vend <= vhex || vend > vmaxend)) {
         /* diag_listed_as: Hexadecimal float: internal error (%s) */


### PR DESCRIPTION
It seems redundant to take the absolute value of the first argument of `frexp()` here, because the sign of the first argument will only affect its return value which is discarded in this case.

This change should not change the behavior of perl (will just slightly save the code size and CPU cycles), so I think that:
* This set of changes does not require a perldelta entry.
