### PR TITLE
Document that empty PATH components are also insecure.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -318,6 +318,7 @@ Geoffrey T. Dairiki <dairiki@dairiki.org> Geoffrey T. Dairiki <dairiki at dairik
 George Greer <perl@greerga.m-l.org> George Greer <greerga@m-l.org>
 Gerard Goossen <gerard@ggoossen.net> Gerard Goossen <gerard@tty.nl>
 Gerrit P. Haase <gp@familiehaase.de> <gerrit@familiehaase.de>
+Gianni Ceccarelli <dakkar@thenautilus.net> dakkar <dakkar@thenautilus.net>
 Gianni Ceccarelli <dakkar@thenautilus.net> Gianni Ceccarelli <gceccarelli@veritone.com>
 Gideon Israel Dsouza <gideon@cpan.org> <gideon@cpan.org>
 Gideon Israel Dsouza <gideon@cpan.org> Gideon Israel Dsouza <gidisrael@gmail.com>

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -3123,8 +3123,9 @@ L<perlsec> for more information.
 
 (F) You can't use system(), exec(), or a piped open in a setuid or
 setgid script if C<$ENV{PATH}> contains a directory that is writable by
-the world.  Also, the PATH must not contain any relative directory.
-See L<perlsec>.
+the world.  Also, the PATH must not contain any relative directory or
+empty component (so C<''>, C<':'>, and C<'/usr/bin::/usr/local/bin'>
+would all trigger this error). See L<perlsec>.
 
 =item Insecure $ENV{%s} while running %s
 

--- a/pod/perlsec.pod
+++ b/pod/perlsec.pod
@@ -274,14 +274,17 @@ default.
 
 For "Insecure C<$ENV{PATH}>" messages, you need to set C<$ENV{'PATH'}> to
 a known value, and each directory in the path must be absolute and
-non-writable by others than its owner and group.  You may be surprised to
-get this message even if the pathname to your executable is fully
-qualified.  This is I<not> generated because you didn't supply a full path
-to the program; instead, it's generated because you never set your PATH
-environment variable, or you didn't set it to something that was safe.
-Because Perl can't guarantee that the executable in question isn't itself
-going to turn around and execute some other program that is dependent on
-your PATH, it makes sure you set the PATH.
+non-writable by others than its owner and group. Notice that, at least on
+Unix-like environments, an empty component of the PATH may be interpreted
+as if it were C<.> (the local directory), which will also trigger this
+message.  You may be surprised to get this message even if the pathname
+to your executable is fully qualified.  This is I<not> generated because
+you didn't supply a full path to the program; instead, it's generated
+because you never set your PATH environment variable, or you didn't set
+it to something that was safe.  Because Perl can't guarantee that the
+executable in question isn't itself going to turn around and execute some
+other program that is dependent on your PATH, it makes sure you set the
+PATH.
 
 The PATH isn't the only environment variable which can cause problems.
 Because some shells may use the variables IFS, CDPATH, ENV, and


### PR DESCRIPTION
I was recently surprised by a change in behaviour between perl 5.36 and 5.38: an empty `$ENV{PATH}` triggered the "Insecure directory" error under taint mode.

That is correct and desired behaviour (see 5ede4453c4877110eb5214ff400c173210b101b1 (and technically 9eb153ffbbde62558146e8f9b837034f42878e13 and 92ec2fce1aace295365d7d86c61c98df8202fc9d)), but the documentation makes no mention of this.

Now it does.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
