### PR TITLE
[Win32] Remove obsolete code from perl.h.

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -2560,22 +2560,7 @@ You probably want to be using L<C</INT2PTR>> instead.
 #  endif
 #endif
 
-/* On MS Windows,with 64-bit mingw-w64 compilers, we
-   need to attend to a __float128 alignment issue if
-   USE_QUADMATH is defined. Otherwise we simply:
-   typedef NVTYPE NV
-   32-bit mingw.org compilers might also require
-   aligned(32) - at least that's what I found with my
-   Math::Foat128 module. But this is as yet untested
-   here, so no allowance is being made for mingw.org
-   compilers at this stage. -- sisyphus January 2021
-*/
-#if (defined(USE_LONG_DOUBLE) || defined(USE_QUADMATH)) && defined(__MINGW64__)
-   /* 64-bit build, mingw-w64 compiler only */
-   typedef NVTYPE NV __attribute__ ((aligned(8)));
-#else
-   typedef NVTYPE NV;
-#endif
+typedef NVTYPE NV;
 
 #ifdef I_IEEEFP
 #   include <ieeefp.h>

--- a/win32/vmem.h
+++ b/win32/vmem.h
@@ -71,12 +71,14 @@ inline void MEMODSlx(char *str, long x)
 class VMem;
 
 /*
- * Address an alignment issue with x64 mingw-w64 ports of gcc-12 and
- * (presumably) later. We do the same thing again 16 lines further down.
- * See https://github.com/Perl/perl5/issues/19824
+ * Address an alignment issue with x64 mingw-w64 ports of gcc.
+ * (We do the same thing again a little further down.)
+ * See https://github.com/Perl/perl5/issues/19824.
+ * Later modified as a result of discussions in
+ * https://github.com/Perl/perl5/issues/22577 
  */
 
-#if defined(__MINGW64__) && __GNUC__ > 11
+#if defined(__MINGW64__)
 typedef struct _MemoryBlockHeader* PMEMORY_BLOCK_HEADER __attribute__ ((aligned(16)));
 #else
 typedef struct _MemoryBlockHeader* PMEMORY_BLOCK_HEADER;
@@ -87,7 +89,7 @@ typedef struct _MemoryBlockHeader {
     PMEMORY_BLOCK_HEADER    pPrev;
     VMem *owner;
 
-#if defined(__MINGW64__) && __GNUC__ > 11
+#if defined(__MINGW64__)
 } MEMORY_BLOCK_HEADER __attribute__ ((aligned(16))), *PMEMORY_BLOCK_HEADER;
 #else
 } MEMORY_BLOCK_HEADER, *PMEMORY_BLOCK_HEADER;


### PR DESCRIPTION

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
This PR does not actually repair any breakage.
As discussed in https://github.com/Perl/perl5/issues/22577, this PR simply removes an obsolete Win32-specific memory alignment instruction from perl.h.
I've now built and tested this PR using x64 gcc versions 10.3.0/11.3.0/12.2.0/13.2.0/14.2.0 x nvtypes double/long double/__float128.
All 15 builds proceeded normally, with all tests passing.

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
