### PR TITLE
Fix broken floating-point constants after setlocale for 5.38.2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -129,6 +129,7 @@ Anthony Heading                <anthony@ajrh.net>
 Anton Berezin                  <tobez@tobez.org>
 Anton Nikishaev                <me@lelf.lu>
 Anton Tagunov                  <tagunov@motor.ru>
+Anton Voloshin                 <ashutosh108@gmail.com>
 Archer Sully                   <archer@meer.net>
 Aristotle Pagaltzis            <pagaltzis@gmx.de>
 Arjen Laarhoven                <arjen@nl.demon.net>

--- a/locale.c
+++ b/locale.c
@@ -1907,6 +1907,9 @@ S_new_numeric(pTHX_ const char *newnum, bool force)
      * our records, do nothing.  (Our records can be wrong when sync'ing to the
      * locale set up by an external library, hence the 'force' parameter) */
     if (! force && strEQ(PL_numeric_name, newnum)) {
+        if (! PL_numeric_underlying_is_standard) {
+            set_numeric_standard();
+        }
         return;
     }
 


### PR DESCRIPTION


<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
See GH #22176

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
* This set of changes requires a perldelta entry, and I need help writing it.
* This set of changes does not require a perldelta entry.
