### PR TITLE
Revert eval in DB fix, changing back to 5.38 CV outside referencing behaviour

### DIFF
--- a/cv.h
+++ b/cv.h
@@ -147,7 +147,7 @@ See L<perlguts/Autoloading with XSUBs>.
 #endif
 #define CVf_DYNFILE	0x1000	/* The filename is malloced  */
 #define CVf_AUTOLOAD	0x2000	/* SvPVX contains AUTOLOADed sub name  */
-/* 0x4000 previously CVf_HASEVAL  */
+#define CVf_HASEVAL	0x4000	/* contains string eval  */
 #define CVf_NAMED	0x8000  /* Has a name HEK */
 #define CVf_LEXICAL	0x10000 /* Omit package from name */
 #define CVf_ANONCONST	0x20000 /* :const - create anonconst op */
@@ -231,6 +231,10 @@ See L<perlguts/Autoloading with XSUBs>.
 #define CvAUTOLOAD(cv)		(CvFLAGS(cv) & CVf_AUTOLOAD)
 #define CvAUTOLOAD_on(cv)	(CvFLAGS(cv) |= CVf_AUTOLOAD)
 #define CvAUTOLOAD_off(cv)	(CvFLAGS(cv) &= ~CVf_AUTOLOAD)
+
+#define CvHASEVAL(cv)		(CvFLAGS(cv) & CVf_HASEVAL)
+#define CvHASEVAL_on(cv)	(CvFLAGS(cv) |= CVf_HASEVAL)
+#define CvHASEVAL_off(cv)	(CvFLAGS(cv) &= ~CVf_HASEVAL)
 
 #define CvNAMED(cv)		(CvFLAGS(cv) & CVf_NAMED)
 #define CvNAMED_on(cv)		(CvFLAGS(cv) |= CVf_NAMED)

--- a/dump.c
+++ b/dump.c
@@ -1899,6 +1899,7 @@ const struct flag_to_name cv_flags_names[] = {
     {CVf_CVGV_RC, "CVGV_RC,"},
     {CVf_DYNFILE, "DYNFILE,"},
     {CVf_AUTOLOAD, "AUTOLOAD,"},
+    {CVf_HASEVAL, "HASEVAL,"},
     {CVf_SLABBED, "SLABBED,"},
     {CVf_NAMED, "NAMED,"},
     {CVf_LEXICAL, "LEXICAL,"},

--- a/ext/Devel-Peek/t/Peek.t
+++ b/ext/Devel-Peek/t/Peek.t
@@ -364,8 +364,8 @@ do_test('reference to named subroutine without prototype',
   RV = $ADDR
   SV = PVCV\\($ADDR\\) at $ADDR
     REFCNT = (3|4)
-    FLAGS = \\((?:HASEVAL,)?(?:NAMED)?\\)	# $] < 5.015 || !thr
-    FLAGS = \\(DYNFILE(?:,HASEVAL)?(?:,NAMED)?\\) # $] >= 5.015 && thr
+    FLAGS = \\((?:HASEVAL(?:,NAMED)?)?\\)	# $] < 5.015 || !thr
+    FLAGS = \\(DYNFILE(?:,HASEVAL(?:,NAMED)?)?\\) # $] >= 5.015 && thr
     COMP_STASH = $ADDR\\t"main"
     START = $ADDR ===> \\d+
     ROOT = $ADDR
@@ -375,8 +375,8 @@ do_test('reference to named subroutine without prototype',
     DEPTH = 1(?:
     MUTEXP = $ADDR
     OWNER = $ADDR)?
-    FLAGS = 0x(?:[c84]00)?0			# $] < 5.015 || !thr
-    FLAGS = 0x[cd1459]000			# $] >= 5.015 && thr
+    FLAGS = 0x(?:[c4]00)?0			# $] < 5.015 || !thr
+    FLAGS = 0x[cd145]000			# $] >= 5.015 && thr
     OUTSIDE_SEQ = \\d+
     PADLIST = $ADDR
     PADNAME = $ADDR\\($ADDR\\) PAD = $ADDR\\($ADDR\\)

--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -2150,6 +2150,7 @@ my sub g {
     sub f { }
 }
 ####
+# TODO only partially fixed
 # lexical state subroutine with outer declaration and inner definition
 # CONTEXT use feature 'lexical_subs', 'state'; no warnings 'experimental::lexical_subs';
 ();

--- a/pad.c
+++ b/pad.c
@@ -1684,6 +1684,7 @@ Perl_pad_tidy(pTHX_ padtidy_type type)
                     "Pad clone on cv=0x%" UVxf "\n", PTR2UV(cv)));
                 CvCLONE_on(cv);
             }
+            CvHASEVAL_on(cv);
         }
     }
 
@@ -1975,7 +1976,8 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
     PL_compcv = cv;
     if (newcv) SAVEFREESV(cv); /* in case of fatal warnings */
 
-    CvOUTSIDE(cv) = CvREFCNT_inc_simple(outside);
+    if (CvHASEVAL(cv))
+        CvOUTSIDE(cv)	= CvREFCNT_inc_simple(outside);
 
     SAVESPTR(PL_comppad_name);
     PL_comppad_name = protopad_name;

--- a/t/op/closure.t
+++ b/t/op/closure.t
@@ -687,7 +687,7 @@ $r = \$x
     isnt($s[0], $s[1], "cloneable with //ee");
 }
 
-# [perl #89544] aka [GH #11286]
+# [perl #89544]
 {
    sub trace::DESTROY {
        push @trace::trace, "destroyed";
@@ -711,7 +711,6 @@ $r = \$x
    };
 
    my $inner = $outer2->();
-   local $TODO = "we need outside links for debugger behaviour";
    is "@trace::trace", "destroyed",
       'closures only close over named variables, not entire subs';
 }

--- a/t/op/eval.t
+++ b/t/op/eval.t
@@ -379,6 +379,7 @@ our $x = 1;
     is(db6(),      4);
 
     # [GH #19370]
+    local $TODO = "outside not available when needed";
     my sub d6 {
         DB::db3();
     }


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
Reverts 386907f06 changing CV outside linking to match 5.38.

This is generally suitable for backporting to 5.40, more complex changes (like making outside a weakref) probably aren't.

* This set of changes requires a perldelta entry, and I need help writing it.

I might add the perldelta later.

This is draft, I plan to add some other TODO tests for the other issues that came up in discussion.