### PR TITLE
op.c: Silence compiler warning

### DIFF
--- a/op.c
+++ b/op.c
@@ -6058,13 +6058,13 @@ Perl_newBINOP(pTHX_ I32 type, I32 flags, OP *first, OP *last)
 
 /* Total number of bytes a given code point would occupy in the output */
 #define TOTAL_LEN(num)                                                      \
-            ((int) ((num == 0)                                              \
-                    ? 1    /* Plain 0 has no ornamentation */               \
-                    : ((num >= IV_MAX)                                      \
-                       ? STRLENs(INFTY)                                   \
-                       : ((STRLENs("0x") + ((NUM_HEX_CHARS(num) <= 2)       \
-                          ? 2  /* Otherwise, minimum of 2 hex digits */     \
-                          : NUM_HEX_CHARS(num)))))))
+            ((unsigned) ((num == 0)                                         \
+                         ? 1    /* Plain 0 has no ornamentation */          \
+                         : ((num >= IV_MAX)                                 \
+                            ? STRLENs(INFTY)                                \
+                            : ((STRLENs("0x") + ((NUM_HEX_CHARS(num) <= 2)  \
+                               ? 2  /* Otherwise, minimum of 2 hex digits */\
+                               : NUM_HEX_CHARS(num)))))))
 
 /* To make evident, Configure with `-DDEBUGGING`, build, run 
  *  `./perl -Ilib -Dy t/op/tr.t`


### PR DESCRIPTION


<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
This fixes GH #22614

Not all compilers warned on this.  Make both operands unsigned.  The one that had been declared signed is always non-negative anyway.

In this case, the multiple evaluations MAX gives is ok.

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
