### PR TITLE
refcounted_he_(new|fetch)_pvn: Don't roll-own code

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3709,6 +3709,9 @@ Admp	|bool	|utf8_to_bytes_new_pv					\
 Admp	|bool	|utf8_to_bytes_overwrite				\
 				|NN U8 **s_ptr				\
 				|NN STRLEN *lenp
+Admp	|bool	|utf8_to_bytes_temp_pv					\
+				|NN U8 const **s_ptr			\
+				|NN STRLEN *lenp
 EMXp	|U8 *	|utf16_to_utf8	|NN U8 *p				\
 				|NN U8 *d				\
 				|Size_t bytelen 			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -3699,6 +3699,10 @@ CDbdp	|UV	|utf8n_to_uvuni |NN const U8 *s 			\
 Adpx	|U8 *	|utf8_to_bytes	|NN U8 *s				\
 				|NN STRLEN *lenp
 Cp	|bool	|utf8_to_bytes_ |NN U8 **s_ptr				\
+				|NN STRLEN *lenp			\
+				|Perl_utf8_to_bytes_arg result_as
+Admp	|bool	|utf8_to_bytes_overwrite				\
+				|NN U8 **s_ptr				\
 				|NN STRLEN *lenp
 EMXp	|U8 *	|utf16_to_utf8	|NN U8 *p				\
 				|NN U8 *d				\

--- a/embed.fnc
+++ b/embed.fnc
@@ -3698,6 +3698,8 @@ CDbdp	|UV	|utf8n_to_uvuni |NN const U8 *s 			\
 				|U32 flags
 Adpx	|U8 *	|utf8_to_bytes	|NN U8 *s				\
 				|NN STRLEN *lenp
+Cp	|bool	|utf8_to_bytes_ |NN U8 **s_ptr				\
+				|NN STRLEN *lenp
 EMXp	|U8 *	|utf16_to_utf8	|NN U8 *p				\
 				|NN U8 *d				\
 				|Size_t bytelen 			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -3700,7 +3700,12 @@ Adpx	|U8 *	|utf8_to_bytes	|NN U8 *s				\
 				|NN STRLEN *lenp
 Cp	|bool	|utf8_to_bytes_ |NN U8 **s_ptr				\
 				|NN STRLEN *lenp			\
+				|NN U8 **free_me			\
 				|Perl_utf8_to_bytes_arg result_as
+Admp	|bool	|utf8_to_bytes_new_pv					\
+				|NN U8 const **s_ptr			\
+				|NN STRLEN *lenp			\
+				|NN U8 *free_me
 Admp	|bool	|utf8_to_bytes_overwrite				\
 				|NN U8 **s_ptr				\
 				|NN STRLEN *lenp

--- a/embed.h
+++ b/embed.h
@@ -859,7 +859,8 @@
 # define utf8_hop_safe                          Perl_utf8_hop_safe
 # define utf8_length(a,b)                       Perl_utf8_length(aTHX_ a,b)
 # define utf8_to_bytes(a,b)                     Perl_utf8_to_bytes(aTHX_ a,b)
-# define utf8_to_bytes_(a,b,c)                  Perl_utf8_to_bytes_(aTHX_ a,b,c)
+# define utf8_to_bytes_(a,b,c,d)                Perl_utf8_to_bytes_(aTHX_ a,b,c,d)
+# define utf8_to_bytes_new_pv(a,b,c)            Perl_utf8_to_bytes_new_pv(aTHX,a,b,c)
 # define utf8_to_bytes_overwrite(a,b)           Perl_utf8_to_bytes_overwrite(aTHX,a,b)
 # define utf8_to_uvchr_buf_helper(a,b,c)        Perl_utf8_to_uvchr_buf_helper(aTHX_ a,b,c)
 # define utf8n_to_uvchr_msgs                    Perl_utf8n_to_uvchr_msgs

--- a/embed.h
+++ b/embed.h
@@ -862,6 +862,7 @@
 # define utf8_to_bytes_(a,b,c,d)                Perl_utf8_to_bytes_(aTHX_ a,b,c,d)
 # define utf8_to_bytes_new_pv(a,b,c)            Perl_utf8_to_bytes_new_pv(aTHX,a,b,c)
 # define utf8_to_bytes_overwrite(a,b)           Perl_utf8_to_bytes_overwrite(aTHX,a,b)
+# define utf8_to_bytes_temp_pv(a,b)             Perl_utf8_to_bytes_temp_pv(aTHX,a,b)
 # define utf8_to_uvchr_buf_helper(a,b,c)        Perl_utf8_to_uvchr_buf_helper(aTHX_ a,b,c)
 # define utf8n_to_uvchr_msgs                    Perl_utf8n_to_uvchr_msgs
 # define uvchr_to_utf8(a,b)                     Perl_uvchr_to_utf8(aTHX,a,b)

--- a/embed.h
+++ b/embed.h
@@ -859,6 +859,7 @@
 # define utf8_hop_safe                          Perl_utf8_hop_safe
 # define utf8_length(a,b)                       Perl_utf8_length(aTHX_ a,b)
 # define utf8_to_bytes(a,b)                     Perl_utf8_to_bytes(aTHX_ a,b)
+# define utf8_to_bytes_(a,b)                    Perl_utf8_to_bytes_(aTHX_ a,b)
 # define utf8_to_uvchr_buf_helper(a,b,c)        Perl_utf8_to_uvchr_buf_helper(aTHX_ a,b,c)
 # define utf8n_to_uvchr_msgs                    Perl_utf8n_to_uvchr_msgs
 # define uvchr_to_utf8(a,b)                     Perl_uvchr_to_utf8(aTHX,a,b)

--- a/embed.h
+++ b/embed.h
@@ -859,7 +859,8 @@
 # define utf8_hop_safe                          Perl_utf8_hop_safe
 # define utf8_length(a,b)                       Perl_utf8_length(aTHX_ a,b)
 # define utf8_to_bytes(a,b)                     Perl_utf8_to_bytes(aTHX_ a,b)
-# define utf8_to_bytes_(a,b)                    Perl_utf8_to_bytes_(aTHX_ a,b)
+# define utf8_to_bytes_(a,b,c)                  Perl_utf8_to_bytes_(aTHX_ a,b,c)
+# define utf8_to_bytes_overwrite(a,b)           Perl_utf8_to_bytes_overwrite(aTHX,a,b)
 # define utf8_to_uvchr_buf_helper(a,b,c)        Perl_utf8_to_uvchr_buf_helper(aTHX_ a,b,c)
 # define utf8n_to_uvchr_msgs                    Perl_utf8n_to_uvchr_msgs
 # define uvchr_to_utf8(a,b)                     Perl_uvchr_to_utf8(aTHX,a,b)

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -376,7 +376,22 @@ well.
 
 =item *
 
-XXX
+Three new API functions are introduced to convert strings encoded in
+UTF-8 to native bytes format (if possible).  These are easier to use
+than the existing ones, and they avoid unnecessary memory allocations.
+The functions are L<perlapi/C<utf8_to_bytes_overwrite>> which is used
+when it is ok for the input string to be overwritten with the converted
+result; and L<perlapi/C<utf8_to_bytes_new_pv>> and
+L<perlapi/C<utf8_to_bytes_temp_pv>> when the original string must be
+preserved intact.  C<utf8_to_bytes_temp_pv> returns the result in a
+temporary using L<perlapi>/C<SAVEFREEPV> that will automatically be
+destroyed.  With C<utf8_to_bytes_new_pv>, you are responsible for
+freeing the newly allocated memory that is returned if the conversion is
+successful.
+
+The latter two functions are designed to replace
+L<perlapi/C<bytes_from_utf8>> which creates memory unnecessarily, or
+unnecessarily large.
 
 =item *
 

--- a/proto.h
+++ b/proto.h
@@ -5356,6 +5356,9 @@ Perl_utf8_to_bytes_new_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp, U8 *free_me); */
 /* PERL_CALLCONV bool
 Perl_utf8_to_bytes_overwrite(pTHX_ U8 **s_ptr, STRLEN *lenp); */
 
+/* PERL_CALLCONV bool
+Perl_utf8_to_bytes_temp_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp); */
+
 PERL_CALLCONV U8 *
 Perl_utf8_to_utf16_base(pTHX_ U8 *s, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low);
 #define PERL_ARGS_ASSERT_UTF8_TO_UTF16_BASE     \

--- a/proto.h
+++ b/proto.h
@@ -5346,9 +5346,12 @@ Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp);
         assert(s); assert(lenp)
 
 PERL_CALLCONV bool
-Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp, Perl_utf8_to_bytes_arg result_as);
+Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp, U8 **free_me, Perl_utf8_to_bytes_arg result_as);
 #define PERL_ARGS_ASSERT_UTF8_TO_BYTES_         \
-        assert(s_ptr); assert(lenp)
+        assert(s_ptr); assert(lenp); assert(free_me)
+
+/* PERL_CALLCONV bool
+Perl_utf8_to_bytes_new_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp, U8 *free_me); */
 
 /* PERL_CALLCONV bool
 Perl_utf8_to_bytes_overwrite(pTHX_ U8 **s_ptr, STRLEN *lenp); */

--- a/proto.h
+++ b/proto.h
@@ -5345,6 +5345,11 @@ Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp);
 #define PERL_ARGS_ASSERT_UTF8_TO_BYTES          \
         assert(s); assert(lenp)
 
+PERL_CALLCONV bool
+Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp);
+#define PERL_ARGS_ASSERT_UTF8_TO_BYTES_         \
+        assert(s_ptr); assert(lenp)
+
 PERL_CALLCONV U8 *
 Perl_utf8_to_utf16_base(pTHX_ U8 *s, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low);
 #define PERL_ARGS_ASSERT_UTF8_TO_UTF16_BASE     \

--- a/proto.h
+++ b/proto.h
@@ -5346,9 +5346,12 @@ Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp);
         assert(s); assert(lenp)
 
 PERL_CALLCONV bool
-Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp);
+Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp, Perl_utf8_to_bytes_arg result_as);
 #define PERL_ARGS_ASSERT_UTF8_TO_BYTES_         \
         assert(s_ptr); assert(lenp)
+
+/* PERL_CALLCONV bool
+Perl_utf8_to_bytes_overwrite(pTHX_ U8 **s_ptr, STRLEN *lenp); */
 
 PERL_CALLCONV U8 *
 Perl_utf8_to_utf16_base(pTHX_ U8 *s, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low);

--- a/utf8.c
+++ b/utf8.c
@@ -2382,7 +2382,6 @@ Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp, U8 ** free_me,
                           Perl_utf8_to_bytes_arg result_as)
 {
     PERL_ARGS_ASSERT_UTF8_TO_BYTES_;
-    PERL_UNUSED_CONTEXT;
 
     if (result_as == PL_utf8_to_bytes_new_memory) {
         *free_me = NULL;
@@ -2574,7 +2573,13 @@ Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp, U8 ** free_me,
     *lenp = d - d0;
 
     if (result_as != PL_utf8_to_bytes_overwrite) {
-        *s_ptr = *free_me = d0;
+        *s_ptr = d0;
+        if (result_as == PL_utf8_to_bytes_use_temporary) {
+            SAVEFREEPV(*s_ptr);
+        }
+        else {
+            *free_me = *s_ptr;
+        }
     }
 
     return true;

--- a/utf8.c
+++ b/utf8.c
@@ -2378,7 +2378,8 @@ If you need a copy of the string, see L</bytes_from_utf8>.
 */
 
 bool
-Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp)
+Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp,
+                          Perl_utf8_to_bytes_arg result_as)
 {
     PERL_ARGS_ASSERT_UTF8_TO_BYTES_;
     PERL_UNUSED_CONTEXT;
@@ -2597,7 +2598,7 @@ Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
 {
     PERL_ARGS_ASSERT_UTF8_TO_BYTES;
 
-    if (utf8_to_bytes_(&s, lenp)) {
+    if (utf8_to_bytes_overwrite(&s, lenp)) {
         return s;
     }
 

--- a/utf8.c
+++ b/utf8.c
@@ -2534,6 +2534,17 @@ Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
             continue;
         }
 
+                goto cant_convert;
+    }
+
+    /* Success! */
+    *d = '\0';
+    *lenp = d - save;
+
+    return save;
+
+  cant_convert: ;
+
     /* Here, it is malformed.  This shouldn't happen on EBCDIC, and on ASCII
      * platforms, we know that the only start bytes in the text are C2 and C3,
      * and the code above has made sure that it doesn't end with a start byte.
@@ -2580,13 +2591,6 @@ Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
 
     *lenp = ((STRLEN) -1);
     return NULL;
-    }
-
-    /* Success! */
-    *d = '\0';
-    *lenp = d - save;
-
-    return save;
 }
 
 /*

--- a/utf8.c
+++ b/utf8.c
@@ -2399,6 +2399,7 @@ Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp,
     U8 * const s0 = *s_ptr;
     const U8 * const send = s0 + *lenp;
     U8 * s = first_variant;
+    Size_t invariant_length = first_variant - s0;
 
 #ifndef EBCDIC      /* The below relies on the bit patterns of UTF-8 */
 
@@ -2504,7 +2505,8 @@ Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp,
         s++;
     }
 
-    U8 * d = s = first_variant;
+    U8 *d0 = s0;
+    U8 * d = d0 + invariant_length;
 
     /* For the cases where the per-word algorithm wasn't used, everything is
      * well-formed and can definitely be translated.  When the per word
@@ -2516,6 +2518,7 @@ Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp,
      * malformed, and because we prioritize speed in the normal case over the
      * malformed one, we go ahead and do the translation, and undo it if found
      * to be necessary. */
+    s = first_variant;
     while (s < send) {
         U8 c = *s++;
         if (! UVCHR_IS_INVARIANT(c)) {
@@ -2541,7 +2544,7 @@ Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp,
 
     /* Success! */
     *d = '\0';
-    *lenp = d - s0;
+    *lenp = d - d0;
 
     return true;
 

--- a/utf8.c
+++ b/utf8.c
@@ -2518,7 +2518,6 @@ Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
     U8 * d = s = first_variant;
 
     while (s < send) {
-        U8 * s1;
 
         if (UVCHR_IS_INVARIANT(*s)) {
             *d++ = *s++;
@@ -2561,7 +2560,7 @@ Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
          * byte that will be the source for the first byte (or bytes) at
          * 's' that need to be changed back.  Note that s1 can expand to
          * two bytes */
-        s1 = d;
+        U8 * s1 = d;
         while (s >= d) {
             s--;
             if (! UVCHR_IS_INVARIANT(*s1)) {

--- a/utf8.c
+++ b/utf8.c
@@ -2393,8 +2393,8 @@ Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
     /* Nothing before 'first_variant' needs to be changed, so start the real
      * work there */
 
-    U8 * const save = s;
-    U8 * const send = s + *lenp;
+    U8 * const s0 = s;
+    U8 * const send = s0 + *lenp;
     s = first_variant;
 
 #ifndef EBCDIC      /* The below relies on the bit patterns of UTF-8 */
@@ -2541,9 +2541,9 @@ Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
 
     /* Success! */
     *d = '\0';
-    *lenp = d - save;
+    *lenp = d - s0;
 
-    return save;
+    return s0;
 
   cant_convert: ;
 

--- a/utf8.c
+++ b/utf8.c
@@ -2396,7 +2396,7 @@ Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp)
      * work there */
 
     U8 * const s0 = *s_ptr;
-    U8 * const send = s0 + *lenp;
+    const U8 * const send = s0 + *lenp;
     U8 * s = first_variant;
 
 #ifndef EBCDIC      /* The below relies on the bit patterns of UTF-8 */

--- a/utf8.h
+++ b/utf8.h
@@ -1306,6 +1306,15 @@ point's representation.
 
 #define Perl_is_utf8_char_buf(buf, buf_end) isUTF8_CHAR(buf, buf_end)
 
+typedef enum {
+    PL_utf8_to_bytes_overwrite = 0,
+    PL_utf8_to_bytes_new_memory,
+    PL_utf8_to_bytes_use_temporary,
+} Perl_utf8_to_bytes_arg;
+
+#define Perl_utf8_to_bytes_overwrite(mTHX, s, l)                            \
+        Perl_utf8_to_bytes_(aTHX_ s, l, PL_utf8_to_bytes_overwrite)
+
 /* Do not use; should be deprecated.  Use isUTF8_CHAR() instead; this is
  * retained solely for backwards compatibility */
 #define IS_UTF8_CHAR(p, n)      (isUTF8_CHAR(p, (p) + (n)) == n)

--- a/utf8.h
+++ b/utf8.h
@@ -1321,6 +1321,9 @@ typedef enum {
 #define Perl_utf8_to_bytes_new_pv(mTHX, s, l, f)                            \
         Perl_utf8_to_bytes_(aTHX_ (U8 **) s, l, f,                          \
                                   PL_utf8_to_bytes_new_memory)
+#define Perl_utf8_to_bytes_temp_pv(mTHX, s, l)                              \
+        Perl_utf8_to_bytes_(aTHX_ (U8 **) s, l, INT2PTR(U8 **, 1),          \
+                                  PL_utf8_to_bytes_use_temporary)
 
 /* Do not use; should be deprecated.  Use isUTF8_CHAR() instead; this is
  * retained solely for backwards compatibility */

--- a/utf8.h
+++ b/utf8.h
@@ -1312,8 +1312,15 @@ typedef enum {
     PL_utf8_to_bytes_use_temporary,
 } Perl_utf8_to_bytes_arg;
 
+/* INT2PTR() is because this parameter should not be used in this case, but
+ * there is a NN assertion for it.  It causes that to pass but to still
+ * segfault if wrongly gets used */
 #define Perl_utf8_to_bytes_overwrite(mTHX, s, l)                            \
-        Perl_utf8_to_bytes_(aTHX_ s, l, PL_utf8_to_bytes_overwrite)
+        Perl_utf8_to_bytes_(aTHX_ s, l, INT2PTR(U8 **, 1),                  \
+                                  PL_utf8_to_bytes_overwrite)
+#define Perl_utf8_to_bytes_new_pv(mTHX, s, l, f)                            \
+        Perl_utf8_to_bytes_(aTHX_ (U8 **) s, l, f,                          \
+                                  PL_utf8_to_bytes_new_memory)
 
 /* Do not use; should be deprecated.  Use isUTF8_CHAR() instead; this is
  * retained solely for backwards compatibility */


### PR DESCRIPTION


<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
The function bytes_from_utf8() already does what what these two instances of duplicated code do.

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
