### PR TITLE
bytes_from_utf8_loc: Move declarations, rename variable

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -2680,11 +2680,6 @@ and subtracting the after-call value of C<*lenp> from it.
 U8 *
 Perl_bytes_from_utf8_loc(const U8 *s, STRLEN *lenp, bool *is_utf8p, const U8** first_unconverted)
 {
-    U8 *d;
-    const U8 *original = s;
-    U8 *converted_start;
-    const U8 *send = s + *lenp;
-
     PERL_ARGS_ASSERT_BYTES_FROM_UTF8_LOC;
 
     if (! *is_utf8p) {
@@ -2692,12 +2687,17 @@ Perl_bytes_from_utf8_loc(const U8 *s, STRLEN *lenp, bool *is_utf8p, const U8** f
             *first_unconverted = NULL;
         }
 
-        return (U8 *) original;
+        return (U8 *) s;
     }
 
+    const U8 * const s0 = s;
+    const U8 * send = s + *lenp;
+
+    U8 *d;
     Newx(d, (*lenp) + 1, U8);
 
-    converted_start = d;
+    U8 *converted_start = d;
+
     while (s < send) {
         U8 c = *s++;
         if (! UTF8_IS_INVARIANT(c)) {
@@ -2711,7 +2711,7 @@ Perl_bytes_from_utf8_loc(const U8 *s, STRLEN *lenp, bool *is_utf8p, const U8** f
                 }
                 else {
                     Safefree(converted_start);
-                    return (U8 *) original;
+                    return (U8 *) s0;
                 }
             }
 

--- a/utf8.c
+++ b/utf8.c
@@ -2691,12 +2691,22 @@ Perl_bytes_from_utf8_loc(const U8 *s, STRLEN *lenp, bool *is_utf8p, const U8** f
     }
 
     const U8 * const s0 = s;
-    const U8 * send = s + *lenp;
+    const U8 * const send = s + *lenp;
+    const U8 * first_variant;
+
+    /* The initial portion of 's' that consists of invariants can be Copied
+     * as-is.  If it is entirely invariant, the whole thing can be Copied. */
+    if (is_utf8_invariant_string_loc(s, *lenp, &first_variant)) {
+        first_variant = send;
+    }
 
     U8 *d;
     Newx(d, (*lenp) + 1, U8);
+    Copy(s, d, first_variant - s, U8);
 
     U8 *converted_start = d;
+    d += first_variant - s;
+    s = first_variant;
 
     while (s < send) {
         U8 c = *s++;


### PR DESCRIPTION
Now that we have c99, we can declare close to first use.  s0 seems to be
the more common name for a variable that preserves the position a string
's' had on input.  This also adds a const to make sure the function
doesn't change s0.<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
    bytes_from_utf8: Copy initial invariants as-is
     
     The paradigm used in this commit is in place in several other places in
     core.  When dealing with UTF-8, it may well be that the first part of a
     string contains only characters that are the same when encoded as UTF-8
     as when not.  There is a function that finds the first position in a
     string not like that.  It works on a whole word at a time instead of
     per-byte, effectively speeding things up by a factor of 8.
     
     In this case, calling that function tells us that we can use memcpy() to
     do the initial part of our task, before having to switch to looking at
     individual bytes.


<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
