### PR TITLE
bytes_to_utf8: Don't redo work

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -2398,14 +2398,14 @@ Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
 
     U8 * const save = s;
     U8 * const send = s + *lenp;
-    U8 * d;
+    s = first_variant;
 
 #ifndef EBCDIC      /* The below relies on the bit patterns of UTF-8 */
 
     /* There is some start-up/tear-down overhead with this, so no real gain
-     * unless the string is long enough.  The current value is just a
-     * guess. */
-    if (*lenp > 5 * PERL_WORDSIZE) {
+     * unless the remaining portion of the string is long enough.  The current
+     * value is just a guess. */
+    if ((send - s) > 5 * PERL_WORDSIZE) {
 
         /* First, go through the string a word at-a-time to verify that it is
          * downgradable.  If it contains any start byte besides C2 and C3, then
@@ -2518,7 +2518,7 @@ Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
      * and should a malformed one come along, it undoes what it already has
      * done */
 
-    d = s = first_variant;
+    U8 * d = s = first_variant;
 
     while (s < send) {
         U8 * s1;


### PR DESCRIPTION


<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->We have gone to some trouble to find the first UTF-8 variant character in the input string.  There is no need to look again for variants in the portion of the string that we have already determined doesn't have any such variants.

This missing statement appears to have been an oversight.

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
