### PR TITLE
perl_langinfo.h: Fix to work on Android

### DIFF
--- a/perl_langinfo.h
+++ b/perl_langinfo.h
@@ -252,8 +252,11 @@ typedef int nl_item;    /* Substitute 'int' for emulated nl_langinfo() */
  * langinfo.h.  There is a slight possibility that one of these numbers could
  * conflict with some other value, in which case after much gnashing of teeth
  * you will find this comment, and end up having to adjust the numbers.   But
- * glibc values are not (so far) negative */
-#if ! defined(HAS_NL_LANGINFO) || ! defined(LC_ADDRESS)
+ * glibc values are not (so far) negative.
+ *
+ * Android is special in that it doesn't define any of these, but has the
+ * corresponding category */
+#if defined(__ANDROID__) || ! defined(HAS_NL_LANGINFO) || ! defined(LC_ADDRESS)
 #  define _NL_ADDRESS_POSTAL_FMT   -58
 #  define _NL_ADDRESS_COUNTRY_NAME -59
 #  define _NL_ADDRESS_COUNTRY_POST -60
@@ -269,7 +272,7 @@ typedef int nl_item;    /* Substitute 'int' for emulated nl_langinfo() */
 
 #  define HAS_MISSING_LANGINFO_ITEM_
 #endif
-#if ! defined(HAS_NL_LANGINFO) || ! defined(LC_IDENTIFICATION)
+#if defined(__ANDROID__) || ! defined(HAS_NL_LANGINFO) || ! defined(LC_IDENTIFICATION)
 #  define _NL_IDENTIFICATION_TITLE        -70
 #  define _NL_IDENTIFICATION_SOURCE       -71
 #  define _NL_IDENTIFICATION_ADDRESS      -72
@@ -288,11 +291,11 @@ typedef int nl_item;    /* Substitute 'int' for emulated nl_langinfo() */
 
 #  define HAS_MISSING_LANGINFO_ITEM_
 #endif
-#if ! defined(HAS_NL_LANGINFO) || ! defined(LC_MEASUREMENT)
+#if defined(__ANDROID__) || ! defined(HAS_NL_LANGINFO) || ! defined(LC_MEASUREMENT)
 #  define _NL_MEASUREMENT_MEASUREMENT -85
 #  define HAS_MISSING_LANGINFO_ITEM_
 #endif
-#if ! defined(HAS_NL_LANGINFO) || ! defined(LC_NAME)
+#if defined(__ANDROID__) || ! defined(HAS_NL_LANGINFO) || ! defined(LC_NAME)
 #  define _NL_NAME_NAME_FMT     -86
 #  define _NL_NAME_NAME_GEN     -87
 #  define _NL_NAME_NAME_MR      -88
@@ -302,13 +305,13 @@ typedef int nl_item;    /* Substitute 'int' for emulated nl_langinfo() */
 
 #  define HAS_MISSING_LANGINFO_ITEM_
 #endif
-#if ! defined(HAS_NL_LANGINFO) || ! defined(LC_PAPER)
+#if defined(__ANDROID__) || ! defined(HAS_NL_LANGINFO) || ! defined(LC_PAPER)
 #  define _NL_PAPER_HEIGHT  -92
 #  define _NL_PAPER_WIDTH   -93
 
 #  define HAS_MISSING_LANGINFO_ITEM_
 #endif
-#if ! defined(HAS_NL_LANGINFO) || ! defined(LC_TELEPHONE)
+#if defined(__ANDROID__) || ! defined(HAS_NL_LANGINFO) || ! defined(LC_TELEPHONE)
 #  define _NL_TELEPHONE_TEL_INT_FMT  -94
 #  define _NL_TELEPHONE_TEL_DOM_FMT  -95
 #  define _NL_TELEPHONE_INT_SELECT   -96

--- a/perl_langinfo.h
+++ b/perl_langinfo.h
@@ -254,66 +254,65 @@ typedef int nl_item;    /* Substitute 'int' for emulated nl_langinfo() */
  * you will find this comment, and end up having to adjust the numbers.   But
  * glibc values are not (so far) negative */
 #if ! defined(HAS_NL_LANGINFO) || ! defined(LC_ADDRESS)
-#  define _NL_ADDRESS_POSTAL_FMT -58
+#  define _NL_ADDRESS_POSTAL_FMT   -58
 #  define _NL_ADDRESS_COUNTRY_NAME -59
 #  define _NL_ADDRESS_COUNTRY_POST -60
-#  define _NL_ADDRESS_COUNTRY_AB2 -61
-#  define _NL_ADDRESS_COUNTRY_AB3 -62
-#  define _NL_ADDRESS_COUNTRY_CAR -63
-#  define _NL_ADDRESS_COUNTRY_NUM -64
+#  define _NL_ADDRESS_COUNTRY_AB2  -61
+#  define _NL_ADDRESS_COUNTRY_AB3  -62
+#  define _NL_ADDRESS_COUNTRY_CAR  -63
+#  define _NL_ADDRESS_COUNTRY_NUM  -64
 #  define _NL_ADDRESS_COUNTRY_ISBN -65
-#  define _NL_ADDRESS_LANG_NAME -66
-#  define _NL_ADDRESS_LANG_AB -67
-#  define _NL_ADDRESS_LANG_TERM -68
-#  define _NL_ADDRESS_LANG_LIB -69
+#  define _NL_ADDRESS_LANG_NAME    -66
+#  define _NL_ADDRESS_LANG_AB      -67
+#  define _NL_ADDRESS_LANG_TERM    -68
+#  define _NL_ADDRESS_LANG_LIB     -69
 
 #  define HAS_MISSING_LANGINFO_ITEM_
 #endif
 #if ! defined(HAS_NL_LANGINFO) || ! defined(LC_IDENTIFICATION)
-#  define _NL_IDENTIFICATION_TITLE -70
-#  define _NL_IDENTIFICATION_SOURCE -71
-#  define _NL_IDENTIFICATION_ADDRESS -72
-#  define _NL_IDENTIFICATION_CONTACT -73
-#  define _NL_IDENTIFICATION_EMAIL -74
-#  define _NL_IDENTIFICATION_TEL -75
-#  define _NL_IDENTIFICATION_FAX -76
-#  define _NL_IDENTIFICATION_LANGUAGE -77
-#  define _NL_IDENTIFICATION_TERRITORY -78
-#  define _NL_IDENTIFICATION_AUDIENCE -79
-#  define _NL_IDENTIFICATION_APPLICATION -80
+#  define _NL_IDENTIFICATION_TITLE        -70
+#  define _NL_IDENTIFICATION_SOURCE       -71
+#  define _NL_IDENTIFICATION_ADDRESS      -72
+#  define _NL_IDENTIFICATION_CONTACT      -73
+#  define _NL_IDENTIFICATION_EMAIL        -74
+#  define _NL_IDENTIFICATION_TEL          -75
+#  define _NL_IDENTIFICATION_FAX          -76
+#  define _NL_IDENTIFICATION_LANGUAGE     -77
+#  define _NL_IDENTIFICATION_TERRITORY    -78
+#  define _NL_IDENTIFICATION_AUDIENCE     -79
+#  define _NL_IDENTIFICATION_APPLICATION  -80
 #  define _NL_IDENTIFICATION_ABBREVIATION -81
-#  define _NL_IDENTIFICATION_REVISION -82
-#  define _NL_IDENTIFICATION_DATE -83
-#  define _NL_IDENTIFICATION_CATEGORY -84
+#  define _NL_IDENTIFICATION_REVISION     -82
+#  define _NL_IDENTIFICATION_DATE         -83
+#  define _NL_IDENTIFICATION_CATEGORY     -84
 
 #  define HAS_MISSING_LANGINFO_ITEM_
 #endif
 #if ! defined(HAS_NL_LANGINFO) || ! defined(LC_MEASUREMENT)
 #  define _NL_MEASUREMENT_MEASUREMENT -85
-
 #  define HAS_MISSING_LANGINFO_ITEM_
 #endif
 #if ! defined(HAS_NL_LANGINFO) || ! defined(LC_NAME)
-#  define _NL_NAME_NAME_FMT -86
-#  define _NL_NAME_NAME_GEN -87
-#  define _NL_NAME_NAME_MR -88
-#  define _NL_NAME_NAME_MRS -89
-#  define _NL_NAME_NAME_MISS -90
-#  define _NL_NAME_NAME_MS -91
+#  define _NL_NAME_NAME_FMT     -86
+#  define _NL_NAME_NAME_GEN     -87
+#  define _NL_NAME_NAME_MR      -88
+#  define _NL_NAME_NAME_MRS     -89
+#  define _NL_NAME_NAME_MISS    -90
+#  define _NL_NAME_NAME_MS      -91
 
 #  define HAS_MISSING_LANGINFO_ITEM_
 #endif
 #if ! defined(HAS_NL_LANGINFO) || ! defined(LC_PAPER)
-#  define _NL_PAPER_HEIGHT -92
-#  define _NL_PAPER_WIDTH -93
+#  define _NL_PAPER_HEIGHT  -92
+#  define _NL_PAPER_WIDTH   -93
 
 #  define HAS_MISSING_LANGINFO_ITEM_
 #endif
 #if ! defined(HAS_NL_LANGINFO) || ! defined(LC_TELEPHONE)
-#  define _NL_TELEPHONE_TEL_INT_FMT -94
-#  define _NL_TELEPHONE_TEL_DOM_FMT -95
-#  define _NL_TELEPHONE_INT_SELECT -96
-#  define _NL_TELEPHONE_INT_PREFIX -97
+#  define _NL_TELEPHONE_TEL_INT_FMT  -94
+#  define _NL_TELEPHONE_TEL_DOM_FMT  -95
+#  define _NL_TELEPHONE_INT_SELECT   -96
+#  define _NL_TELEPHONE_INT_PREFIX   -97
 
 #  define HAS_MISSING_LANGINFO_ITEM_
 #endif


### PR DESCRIPTION
See GH #22627.
     
libc has a few locale categories that aren't used elsewhere, AFAIK.    Android has a crippled implementation of them, in that it has none of the items that comprise the categories.
     
In a typical langinfo.h, these are enum fields, so their existence can't  be checked with an #ifdef, but in Android, everything is a #define, so much be checked with #ifdef.  To get around this without writing a Configure probe, this commit just creates defines when they are missing the category (which catches the non-Androids) or when using Android.


<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
