### PR TITLE
optimize/cleanup generate_uudmap.c

### DIFF
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -771,7 +771,7 @@ globals$(OBJ_EXT): $(generated_headers)
 
 uudmap.h mg_data.h: bitcount.h
 
-generate_uudmap$(OBJ_EXT): mg_raw.h
+generate_uudmap$(OBJ_EXT): generate_uudmap.c mg_raw.h
 
 !NO!SUBS!
 

--- a/generate_uudmap.c
+++ b/generate_uudmap.c
@@ -71,9 +71,9 @@ format_mg_data(FILE *out, const void *thing, size_t count) {
 
   while (1) {
       if (p->value) {
-          fprintf(out, "    %s\n    %s", p->comment, p->value);
+          fprintf(out, "  %s\n  %s", p->comment, p->value);
       } else {
-          fputs("    0", out);
+          fputs("  0", out);
       }
       ++p;
       if (!--count)
@@ -87,15 +87,15 @@ static void
 format_char_block(FILE *out, const void *thing, size_t count) {
   const char *block = (const char *)thing;
 
-  fputs("    ", out);
+  fputs("  ", out);
   while (count--) {
     fprintf(out, "%d", *block);
     block++;
     if (count) {
-      fputs(", ", out);
-      if (!(count & 15)) {
-        fputs("\n    ", out);
-      }
+      if (!(count & 15))
+        fputs(",\n  ", out);
+      else
+        fputs(", ", out);
     }
   }
   fputc('\n', out);

--- a/generate_uudmap.c
+++ b/generate_uudmap.c
@@ -43,13 +43,15 @@
    "hello world" won't port easily to it.  */
 #include <errno.h>
 
+static const char * progname;
+
 struct mg_data_raw_t {
     unsigned char type;
     const char *value;
     const char *comment;
 };
 
-static struct mg_data_raw_t mg_data_raw[] = {
+static const struct mg_data_raw_t mg_data_raw[] = {
 #ifdef WIN32
 #  include "..\mg_raw.h"
 #else
@@ -62,8 +64,6 @@ struct mg_data_t {
     const char *value;
     const char *comment;
 };
-
-static struct mg_data_t mg_data[256];
 
 static void
 format_mg_data(FILE *out, const void *thing, size_t count) {
@@ -102,7 +102,7 @@ format_char_block(FILE *out, const void *thing, size_t count) {
 }
 
 static void
-output_to_file(const char *progname, const char *filename,
+output_to_file(const char *filename,
                void (format_function)(FILE *out, const void *thing, size_t count),
                const void *thing, size_t count,
                const char *header
@@ -129,71 +129,75 @@ output_to_file(const char *progname, const char *filename,
   }
 }
 
-
 static const char PL_uuemap[]
 = "`!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_";
 
 typedef unsigned char U8;
 
-/* This will ensure it is initialized to all zeros.  */
-static char PL_uudmap[256];
-static char PL_bitcount[256];
-
 int main(int argc, char **argv) {
   size_t i;
-  int bits;
-  struct mg_data_raw_t *p = mg_data_raw;
 
+  progname = argv[0];
   if (argc < 4 || argv[1][0] == '\0' || argv[2][0] == '\0'
       || argv[3][0] == '\0') {
-    fprintf(stderr, "Usage: %s uudemap.h bitcount.h mg_data.h\n", argv[0]);
+    fprintf(stderr, "Usage: %s uudemap.h bitcount.h mg_data.h\n", progname);
     return 1;
   }
 
-  for (i = 0; i < sizeof(PL_uuemap) - 1; ++i)
-    PL_uudmap[(U8)PL_uuemap[i]] = (char)i;
-  /*
-   * Because ' ' and '`' map to the same value,
-   * we need to decode them both the same.
-   */
-  PL_uudmap[(U8)' '] = 0;
+  do {
+    char PL_uudmap[256] = {0};
+    for (i = 0; i < sizeof(PL_uuemap) - 1; ++i)
+      PL_uudmap[(U8)PL_uuemap[i]] = (char)i;
+    /*
+     * Because ' ' and '`' map to the same value,
+     * we need to decode them both the same.
+     */
+    PL_uudmap[(U8)' '] = 0;
+    output_to_file(argv[1], &format_char_block,
+                   (const void *)PL_uudmap, sizeof(PL_uudmap),
+          " * These values will populate PL_uumap[], as used by unpack('u')"
+    );
+  } while(0);
 
-  output_to_file(argv[0], argv[1], &format_char_block,
-                 (const void *)PL_uudmap, sizeof(PL_uudmap),
-        " * These values will populate PL_uumap[], as used by unpack('u')"
-  );
+  do {
+    char PL_bitcount[256] = {0};
+    int bits;
+    for (bits = 1; bits < 256; bits++) {
+      if (bits & 1)	PL_bitcount[bits]++;
+      if (bits & 2)	PL_bitcount[bits]++;
+      if (bits & 4)	PL_bitcount[bits]++;
+      if (bits & 8)	PL_bitcount[bits]++;
+      if (bits & 16)	PL_bitcount[bits]++;
+      if (bits & 32)	PL_bitcount[bits]++;
+      if (bits & 64)	PL_bitcount[bits]++;
+      if (bits & 128)	PL_bitcount[bits]++;
+    }
 
-  for (bits = 1; bits < 256; bits++) {
-    if (bits & 1)	PL_bitcount[bits]++;
-    if (bits & 2)	PL_bitcount[bits]++;
-    if (bits & 4)	PL_bitcount[bits]++;
-    if (bits & 8)	PL_bitcount[bits]++;
-    if (bits & 16)	PL_bitcount[bits]++;
-    if (bits & 32)	PL_bitcount[bits]++;
-    if (bits & 64)	PL_bitcount[bits]++;
-    if (bits & 128)	PL_bitcount[bits]++;
-  }
+    output_to_file(argv[2], &format_char_block,
+                   (const void *)PL_bitcount, sizeof(PL_bitcount),
+       " * These values will populate PL_bitcount[]:\n"
+       " * this is a count of bits for each U8 value 0..255"
+    );
+  } while(0);
 
-  output_to_file(argv[0], argv[2], &format_char_block,
-                 (const void *)PL_bitcount, sizeof(PL_bitcount),
-     " * These values will populate PL_bitcount[]:\n"
-     " * this is a count of bits for each U8 value 0..255"
-  );
+  do {
+    struct mg_data_t mg_data[256] = {{NULL,NULL}};
+    const struct mg_data_raw_t *p = mg_data_raw;
+    while (p->value) {
+        mg_data[p->type].value = p->value;
+        mg_data[p->type].comment = p->comment;
+        ++p;
+    }
 
-  while (p->value) {
-      mg_data[p->type].value = p->value;
-      mg_data[p->type].comment = p->comment;
-      ++p;
-  }
-      
-  output_to_file(argv[0], argv[3], &format_mg_data,
-                 (const void *)mg_data, sizeof(mg_data)/sizeof(mg_data[0]),
-     " * These values will populate PL_magic_data[]: this is an array of\n"
-     " * per-magic U8 values containing an index into PL_magic_vtables[]\n"
-     " * plus two flags:\n"
-     " *    PERL_MAGIC_READONLY_ACCEPTABLE\n"
-     " *    PERL_MAGIC_VALUE_MAGIC"
-  );
+    output_to_file(argv[3], &format_mg_data,
+                   (const void *)mg_data, sizeof(mg_data)/sizeof(mg_data[0]),
+       " * These values will populate PL_magic_data[]: this is an array of\n"
+       " * per-magic U8 values containing an index into PL_magic_vtables[]\n"
+       " * plus two flags:\n"
+       " *    PERL_MAGIC_READONLY_ACCEPTABLE\n"
+       " *    PERL_MAGIC_VALUE_MAGIC"
+    );
+  } while (0);
 
   return 0;
 }

--- a/generate_uudmap.c
+++ b/generate_uudmap.c
@@ -124,9 +124,13 @@ format_mg_data(FILE *out, const void *thing, unsigned int count) {
 
 static void
 format_char_block(FILE *out, const void *thing, unsigned int count) {
+  char buf [(sizeof("-255,\n  ")-1) * 256]; /* 2048, oversized vs ~900 */
+  char * start = buf;
+  char * p = start;
+  char * p2;
   const char *block = (const char *)thing;
 
-  fputs("  ", out);
+  xstrputs("  ");
   while (count--) {
     const char * fmt;
     char c = *block;
@@ -139,9 +143,10 @@ format_char_block(FILE *out, const void *thing, unsigned int count) {
     }
     else
       fmt = "%d";
-    fprintf(out, fmt, c);
+    p += sprintf(p, fmt, c);
   }
-  fputc('\n', out);
+  xstrputc('\n');
+  fwrite(start, sizeof(char), p-start, out);
 }
 
 static void

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1506,7 +1506,7 @@ $(UUDMAP_H) $(MG_DATA_H) : $(BITCOUNT_H)
 $(BITCOUNT_H) : $(GENUUDMAP)
 	$(GENUUDMAP) $(GENERATED_HEADERS)
 
-$(GENUUDMAP) : ..\mg_raw.h
+$(GENUUDMAP) : ..\generate_uudmap.c ..\mg_raw.h
 ifeq ($(CCTYPE),GCC)
 	$(LINK32) $(CFLAGS_O) -o..\generate_uudmap.exe ..\generate_uudmap.c \
 	$(BLINK_FLAGS) $(LIBFILES)

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -1058,7 +1058,7 @@ $(UUDMAP_H) $(MG_DATA_H) : $(BITCOUNT_H)
 $(BITCOUNT_H) : $(GENUUDMAP)
 	$(GENUUDMAP) $(GENERATED_HEADERS)
 
-$(GENUUDMAP_OBJ) : ..\mg_raw.h
+$(GENUUDMAP_OBJ) : ..\generate_uudmap.c ..\mg_raw.h
 
 $(GENUUDMAP) : $(GENUUDMAP_OBJ)
 	$(LINK32) -out:$@ @<<


### PR DESCRIPTION
See patch decriptions, fputc() is very unwise CPU wise. Original intent was to put all 3 output .h files in stack array buffers, but it was impossible to get sanely get mg_data.h under 4096 bytes, so I stopped after eliminating the worst FD I/O calls (putch()) and outputting ~80-100 byte lines is better. Full "mimifying" mg_data.h got it ~3700 bytes for me, but that is unreadable. After this patch mg_data is 4.3KB. 4096 byte boundary is artificial picked, since rumors on Google say some POSIX OSes require root/rlimit/cgroups/faux-sudo/ writing "/proc" and magic compiler flags, if you want > 8KB C stacks. Therefore, don't crash "so early", and defer the crash risk much later, to Configure or Makefile.SH or perl.bin crashing, not generate_uudmap.bin.

Also a benefit is stripping pointless ", 0, 0, 0}"s, less work for CC.

This is branched out into this pull, since major problems in sv_inline.h is another topic. Not sure if I will actually need a pre-perl generated .h or not to fix that, but I need the provisions at minimum.