### PR TITLE
replace various sv_catpv(sv,"cstr") calls with len counted calls

### DIFF
--- a/ext/GDBM_File/GDBM_File.pm
+++ b/ext/GDBM_File/GDBM_File.pm
@@ -733,7 +733,7 @@ require XSLoader;
 );
 
 # This module isn't dual life, so no need for dev version numbers.
-$VERSION = '1.24';
+$VERSION = '1.25';
 
 our $gdbm_errno;
 

--- a/ext/GDBM_File/GDBM_File.xs
+++ b/ext/GDBM_File/GDBM_File.xs
@@ -241,7 +241,7 @@ get_gdbm_errno(pTHX_ IV idx, SV *sv)
     if (gdbm_check_syserr(gdbm_errno)) {
         SV *val = get_sv("!", 0);
         if (val) {
-            sv_catpv(sv, ": ");
+            sv_catpvs(sv, ": ");
             sv_catsv(sv, val);
         }
     }

--- a/mg.c
+++ b/mg.c
@@ -819,7 +819,7 @@ S_fixup_errno_string(pTHX_ SV* sv)
     assert(SvOK(sv));
 
     if(strEQ(SvPVX(sv), "")) {
-        sv_catpv(sv, UNKNOWN_ERRNO_MSG);
+        sv_catpvs(sv, UNKNOWN_ERRNO_MSG);
     }
 }
 

--- a/perlio.c
+++ b/perlio.c
@@ -5466,6 +5466,7 @@ PerlIO_tmpfile_flags(int imode)
           f = PerlIO_fdopen(fd, "w+b");
 #elif ! defined(OS2)
      int fd = -1;
+     /* Perl_my_mkostemp_cloexec() writes to this buf */
      char tempname[] = "/tmp/PerlIO_XXXXXX";
      const char * const tmpdir = TAINTING_get ? NULL : PerlEnv_getenv("TMPDIR");
      SV * sv = NULL;
@@ -5474,7 +5475,7 @@ PerlIO_tmpfile_flags(int imode)
      if (tmpdir && *tmpdir) {
          /* if TMPDIR is set and not empty, we try that first */
          sv = newSVpv(tmpdir, 0);
-         sv_catpv(sv, tempname + 4);
+         sv_catpvn(sv, tempname + 4, C_ARRAY_LENGTH(tempname)-4);
          fd = Perl_my_mkostemp_cloexec(SvPVX(sv), imode | O_VMS_DELETEONCLOSE);
      }
      if (fd < 0) {
@@ -5486,7 +5487,7 @@ PerlIO_tmpfile_flags(int imode)
      if (fd < 0) {
          /* Try cwd */
          sv = newSVpvs(".");
-         sv_catpv(sv, tempname + 4);
+         sv_catpvn(sv, tempname + 4, C_ARRAY_LENGTH(tempname)-4);
          fd = Perl_my_mkostemp_cloexec(SvPVX(sv), imode | O_VMS_DELETEONCLOSE);
      }
      umask(old_umask);

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4960,7 +4960,7 @@ S_require_file(pTHX_ SV *sv)
                          == NULL)
                         continue;
                     sv_setpv(namesv, unixdir);
-                    sv_catpv(namesv, unixname);
+                    sv_catpvn(namesv, unixname, unixlen);
 #else
                     /* The equivalent of		    
                        Perl_sv_setpvf(aTHX_ namesv, "%s/%s", dir, name);


### PR DESCRIPTION
-perf reasons, even though I guess most of the code is rarely called since
 they are error branches, do it anyways, it is only 1 more assembly op
 (2-4 bytes) vs not including len, and skips strlen() overhead

-GDBM_File.xs
-'sv_catpv(sv, ": ");'
gdbm: Define error codes; provide the global $gdbm_errno variable. 8b8b12225a4af2826a4714f04e9f7464766199c6 10/11/2021 11:58:44 AM

regcomp.c
-'sv_catpv(substitute_parse, ")");'
-"sv_catpv(substitute_parse, SvPVX(this_sequence));" len is known, its an
  an SV with contents gen by core, probably from regexp pl code, if it was
  passing control codes to console on the regular, I assume that would've
  been fixed long ago, therefore we not trying eliminate user's null chars
9d53c4576e551530162e7cd79ab72ed81b1e1a0f 10/11/2012 11:49:31 PM PATCH: [perl #89774] multi-char fold + its fold in char class

-'const char overflow_msg[] = "Code point'
 This was creating uncond a RW array on C stack from a RO global string,
 then sometimes passing ptr to C stk alloced array, to sv_catpv()
-"sv_catpv(msg, prefix);" pass len to RO string
73b95840bb1b55d761ec2dd075d2a8c37fa94bf4 8/20/2018 8:31:04 PM Move \p{user-defined} to core from utf8_heavy.pl

-mg.c
Revision: b35e4f8b3f15f0474d08f63e1f479787e261f485 12/14/2013 9:48:00 PM Fix HP-UX $! failure
-"sv_catpv(sv, UNKNOWN_ERRNO_MSG);" is a const literal

-perlio.c
-add comment about the unusual but correct stack array, its length can
 be const computed so do it

-pp_ctl.c
46fc3d4c69a0adf236bfcba70daee7fd597cf30d 4/22/1997 8:00:00 AM [inseparable changes from match from perl-5.003_97g to perl-5.003_97h] -"sv_catpv(namesv, unixname);" seems to be left over after converting this
 area of code from an unsafe "strcat()" design, use len since we know it

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
TODO: fill description here

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
* This set of changes requires a perldelta entry, and I need help writing it.
* This set of changes does not require a perldelta entry.
