### PR TITLE
Set `builtin::` globs to readonly so that attempted replacements of them do not break optimisations

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6080,6 +6080,7 @@ t/lib/common.pl				Helper for lib/{warnings,feature}.t
 t/lib/commonsense.t			See if configuration meets basic needs
 t/lib/Count.pm				Helper for t/op/method.t
 t/lib/croak.t				Test calls to Perl_croak() in the C source.
+t/lib/croak/builtin			Test croak calls from builtin.c
 t/lib/croak/class			Test croak calls from class.c
 t/lib/croak/gv				Test croak calls from gv.c
 t/lib/croak/mg				Test croak calls from mg.c

--- a/builtin.c
+++ b/builtin.c
@@ -804,6 +804,13 @@ Perl_boot_core_builtin(pTHX)
         if(builtin->checker) {
             cv_set_call_checker_flags(cv, builtin->checker, newSVuv(PTR2UV(builtin)), 0);
         }
+
+        /* Because of all these callcheckers and other optimisations, it would
+         * all break if we permitted runtime replacement of the functions,
+         * e.g. by glob tricks like `*builtin::reftype = sub { ... }`.
+         * Prevent modification of the GV so as to avoid this problem.
+         */
+        SvREADONLY_on((SV *)CvGV(cv));
     }
 
     newXS_flags("builtin::import", &XS_builtin_import, __FILE__, NULL, 0);

--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -1,4 +1,4 @@
-package builtin 0.015;
+package builtin 0.016;
 
 use v5.40;
 
@@ -105,6 +105,16 @@ The following bundles currently exist:
 
     :5.40      true false weaken unweaken is_weak blessed refaddr reftype
                ceil floor is_tainted trim indexed
+
+=head2 Read-only Functions
+
+Various optimisations that apply to many functions in the L<builtin> package
+would be broken if the functions are ever replaced or changed, such as by
+assignment into glob references.  Because of this, the globs that contain
+them are set read-only since Perl version 5.41.5, preventing such replacement.
+
+    $ perl -e '*builtin::reftype = sub { "BOO" }'
+    Modification of a read-only value attempted at -e line 1.
 
 =head1 FUNCTIONS
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -27,6 +27,16 @@ here, but most should go in the L</Performance Enhancements> section.
 
 [ List each enhancement as a =head2 entry ]
 
+=head2 Functions in the C<builtin::> package no longer permit replacement
+
+Various optimisations that apply to many functions in the L<builtin> package
+would be broken if the functions are ever replaced or changed, such as by
+assignment into glob references.  Because of this, the globs that contain
+them are now set read-only, preventing such replacement.
+
+    $ perl -e '*builtin::reftype = sub { "BOO" }'
+    Modification of a read-only value attempted at -e line 1.
+
 =head1 Security
 
 XXX Any security-related notices go here. In particular, any security

--- a/t/lib/croak/builtin
+++ b/t/lib/croak/builtin
@@ -1,0 +1,6 @@
+__END__
+########
+# Attempted replacement of builtin:: functions is not allowed as of Perl 5.41.5
+*builtin::reftype = sub { "BOO" };
+EXPECT
+Modification of a read-only value attempted at - line 2.


### PR DESCRIPTION
A possible thought, based on discussions on p5p@ about optimisations around builtin functions.

Currently just emits the default "Modification of read-only value" message. I did attempt to have it say something special in this situation but that involves editing `Perll_sv_setsv_flags()` in sv.c, one of the hottest paths in the entire interpreter. I didn't think that was especially worth it just for this very rare case.

This is an **alternative to** https://github.com/Perl/perl5/pull/22668

* This set of changes requires a perldelta entry, and it is included.
