### PR TITLE
win32/Makefile: update compilation flags for Visual C++

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -697,8 +697,7 @@ EXTRACFLAGS	+= -MDd
 
 else
 # Enable Whole Program Optimizations (WPO) and Link Time Code Generation (LTCG).
-# -O1 yields smaller code, which turns out to be faster than -O2 on x86 and x64
-OPTIMIZE	= -O1 -Zi -GL
+OPTIMIZE	= -O2 -Zi -GL -Gw
 # we enable debug symbols in release builds also
 LINK_DBG	= -debug -opt:ref,icf -ltcg
 # you may want to enable this if you want COFF symbols in the executables

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -455,8 +455,7 @@ DEFINES		= $(DEFINES) -D_DEBUG -DDEBUGGING
 EXTRACFLAGS	= $(EXTRACFLAGS) -MDd
 !ELSE
 # Enable Whole Program Optimizations (WPO) and Link Time Code Generation (LTCG).
-# -O1 yields smaller code, which turns out to be faster than -O2 on x86 and x64
-OPTIMIZE	= -O1 -Zi -GL
+OPTIMIZE	= -O2 -Zi -GL -Gw
 # we enable debug symbols in release builds also
 LINK_DBG	= -debug -opt:ref,icf -ltcg
 # you may want to enable this if you want COFF symbols in the executables


### PR DESCRIPTION
Makefile contains the following comment from 2002:

```
# -O1 yields smaller code, which turns out to be faster than -O2
```

Visual C++ documentation says that -O2 "creates fast code", while -O1 "creates small code". It's unlikely that, after 20 years, -O2 still generates worse code. If it does, it should be reported to Microsoft.

Also added -Gw (optimize global data).
