### PR TITLE
implement C_BP macro for throwing a C debugger breakpoint WIP

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -802,6 +802,8 @@ CRTp	|I32	|cast_i32	|NV f
 CRTp	|IV	|cast_iv	|NV f
 CRTp	|U32	|cast_ulong	|NV f
 CRTp	|UV	|cast_uv	|NV f
+FTXdp	|void	|c_bp		|NN const char *file_metadata		\
+				|...
 p	|bool	|check_utf8_print					\
 				|NN const U8 *s 			\
 				|const STRLEN len

--- a/embed.h
+++ b/embed.h
@@ -917,6 +917,7 @@
 #   define boot_core_builtin()                  Perl_boot_core_builtin(aTHX)
 #   define boot_core_mro()                      Perl_boot_core_mro(aTHX)
 #   define build_infix_plugin(a,b,c)            Perl_build_infix_plugin(aTHX_ a,b,c)
+#   define c_bp                                 Perl_c_bp
 #   define cando(a,b,c)                         Perl_cando(aTHX_ a,b,c)
 #   define check_utf8_print(a,b)                Perl_check_utf8_print(aTHX_ a,b)
 #   define closest_cop(a,b,c,d)                 Perl_closest_cop(aTHX_ a,b,c,d)

--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.38';
+our $VERSION = '1.39';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -5,10 +5,18 @@
 
 /* Do *not* define PERL_NO_GET_CONTEXT.  This is the one place where we get
    to test implicit Perl_get_context().  */
+/* for GetErrorMode */
+#ifdef WIN32
+#   define _WIN32_WINNT 0x0601
+#endif
 
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
+
+#ifdef WIN32
+#  include <windows.h>
+#endif
 
 /* PERL_VERSION_xx sanity checks */
 #if !PERL_VERSION_EQ(PERL_VERSION_MAJOR, PERL_VERSION_MINOR, PERL_VERSION_PATCH)
@@ -3151,6 +3159,20 @@ my_cxt_setsv(sv)
         SvREFCNT_dec(MY_CXT.sv);
         my_cxt_setsv_p(sv _aMY_CXT);
         SvREFCNT_inc(sv);
+
+void
+test_C_BP_breakpoint()
+    CODE:
+    {
+#ifdef WIN32
+      UINT em = GetErrorMode();
+      SetErrorMode( SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX );
+#endif
+      C_BP;
+#ifdef WIN32
+      SetErrorMode(em);
+#endif
+    }
 
 bool
 sv_setsv_cow_hashkey_core()

--- a/handy.h
+++ b/handy.h
@@ -155,7 +155,9 @@ required, but is kept for backwards compatibility.
 /* Try to figure out __func__ or __FUNCTION__ equivalent, if any.
  * XXX Should really be a Configure probe, with HAS__FUNCTION__
  *     and FUNCTION__ as results.
- * XXX Similarly, a Configure probe for __FILE__ and __LINE__ is needed. */
+ * XXX Similarly, a Configure probe for __FILE__ and __LINE__ is needed.
+ * Remember to also update CBPFUNCTION__ in util.h
+ */
 #if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || (defined(__SUNPRO_C)) /* C99 or close enough. */
 #  define FUNCTION__ __func__
 #  define SAFE_FUNCTION__ __func__

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -346,6 +346,18 @@ well.
 
 =over 4
 
+=item * C_BP XS macro added for C debugger breakpoints
+
+A cross platform macro C<C_BP> was added, that triggers a C breakpoint in the
+appropriate OS/platform specific C debugger, if the C debugger is already
+started. If a C debugger is not available, the C<C_BP> will immedialty kill
+the perl process similar to a SEGV. This new macro makes Perl core hacking
+and XS development easier. The macro is never intended to be shipped in stable
+or production code or even alpha beta code, and is strictly development
+helper tool for local use. It is similar to C<assert()> but launches or triggers
+a breakpoint in the C debugger, and you can resume execution use the step
+controls in the C debugger.
+
 =item *
 
 XXX

--- a/proto.h
+++ b/proto.h
@@ -418,6 +418,11 @@ Perl_bytes_to_utf8(pTHX_ const U8 *s, STRLEN *lenp);
 #define PERL_ARGS_ASSERT_BYTES_TO_UTF8          \
         assert(s); assert(lenp)
 
+PERL_CALLCONV void
+Perl_c_bp(const char *file_metadata, ...);
+#define PERL_ARGS_ASSERT_C_BP                   \
+        assert(file_metadata)
+
 PERL_CALLCONV SSize_t
 Perl_call_argv(pTHX_ const char *sub_name, I32 flags, char **argv);
 #define PERL_ARGS_ASSERT_CALL_ARGV              \


### PR DESCRIPTION
My fingers hurt typing DebugBreak() all these years. Time for an API. Commit is a WIP since there is some dead code from 1st impl, but I decided the "speed" of ```memcpy```, isn't worth the extra 0x30 bytes of machine code, and '\0' padding to 8 byte alignment boundaries done by MSVC of 4 separate c strings in RO data section vs 1 c string (```snprintf``` fmt str). Just call ```snprintf()``` the slow way. Runtime speed is irrelevant here. This code will never run except for an XS dev or p5p dev writing a new module or bug fixing.

If there aren't suggested changes, I'll clean it up into a final version in a day or 2. The code could also be added to ppport.h to mk life easier for all XS devs on all PL releases.

----------------------------
-short macro name, less to type
-cross platform
-makes it easier to work on Perl core or XS CPAN
-emits debug info to console for CI/smoke/unattended machine -writes to STDOUT and STDERR, incase one of the 2 FDs are redirected
 to a disk file or piped to another process, or that disk file is temp
 flagged, and OS instantly deletes it
-breaking TAP testing is good
-C_BP; is less to type vs DebugBreak(); or __debugbreak(); on Win32

---------------------------------------------------------------------------------

* This set of changes requires a perldelta entry, and I need help writing it.

