### PR TITLE
Fix arm64 darwin hints when using use64bitall with Configure

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -886,6 +886,7 @@ Marco Fontani                  <MFONTANI@cpan.org>
 Marco Peereboom                <marco@conformal.com>
 Marcus Holland-Moritz          <mhx-perl@gmx.net>
 Marek Rouchal                  <marek.rouchal@infineon.com>
+Marin Tsanov                   <btg.tsanov.marin@gmail.com>
 Mark A Biggar                  <mab@wdl.loral.com>
 Mark A. Hershberger            <mah@everybody.org>
 Mark A. Stratman               <stratman@gmail.com>

--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -427,6 +427,7 @@ EOM
     case `uname -p` in 
     powerpc) arch=ppc64 ;;
     i386) arch=x86_64 ;;
+    arm) arch=arm64 ;;
     *) cat <<EOM >&4
 
 *** Don't recognize processor, can't specify 64 bit compilation.

--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -433,6 +433,7 @@ EOM
 *** Don't recognize processor, can't specify 64 bit compilation.
 
 EOM
+     exit 1
     ;;
     esac
     for var in ccflags cppflags ld ldflags


### PR DESCRIPTION
When using 64-bit addressing (by passing `-Duse64bitall` to Configure) on macOS arm64, clang throws the following cryptic error when compiling a test program:

```
Use which C compiler? [cc]
  
clang: error: invalid arch name '-arch -B/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/gcc'
clang: error: invalid arch name '-arch -Wl,-syslibroot,/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk'
Uh-oh, the C compiler 'cc' doesn't seem to be working.

'cc' ' -fno-common -DPERL_DARWIN -mmacosx-version-min=11 -arch  -B/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/gcc -B/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/gcc -F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks -mmacosx-version-min=11' ' -mmacosx-version-min=11 -arch  -Wl,-syslibroot,/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk'
```

The first commit is to handle the `arm` output from `uname -p` and respectively to pass the proper architecture - `arm64` right after the `-arch` flag that would otherwise be dangling.

Just in case some time in the future Apple introduces a yet another CPU architecture to their Mac devices, I decided to add an extra `exit 1` with the second commit so that the Configure error would be the last thing that is displayed to the user. This way, we don't see the cryptic clang error:

```
Which of these apply, if any? [darwin]  
Adding -mmacosx-version-min=10.14 to ccflags
Adding -mmacosx-version-min=10.14 to ldflags

*** Don't recognize processor, can't specify 64 bit compilation.
```

After the second commit is added, the following Configure output that I saw before went missing:

```
Configure uses the operating system name and version to set some defaults.
The default value is probably right if the name rings a bell. Otherwise,
since spelling matters for me, either accept the default or answer "none"
to leave it blank.

Operating system name? [darwin]  
 
Operating system version? [24.0.0]  

By default, perl5 will be installed in /Users/mtsan/perl/gen/out/bin, manual pages
under /Users/mtsan/perl/gen/out/man, etc..., i.e. with /Users/mtsan/perl/gen/out as prefix for all
installation directories. Typically this is something like /usr/local.
If you wish to have binaries under /usr/bin but other parts of the
installation under /usr/local, that's ok: you will be prompted
separately for each of the installation directories, the prefix being
only used to set the defaults.

Installation prefix to use? (~name ok)
[/Users/mtsan/perl/gen/out]  
 
AFS does not seem to be running...

In some special cases, particularly when building perl5 for distribution,
it is convenient to distinguish the directory in which files should be
installed from the directory (/Users/mtsan/perl/gen/out) in which they will
eventually reside.  For most users, these two directories are the same.

What installation prefix should I use for installing files? (~name ok)
[/Users/mtsan/perl/gen/out]  

Perl can be built to offer a form of threading support on some systems
To do so, Configure can be run with -Dusethreads.

Note that Perl built with threading support runs slightly slower
and uses slightly more memory than plain Perl.

If this doesn't make any sense to you, just accept the default 'y'.
Build a threading Perl? [y]  
(Your platform does not have any specific hints for threaded builds.
 Assuming POSIX threads, then.)

Perl can be built so that multiple Perl interpreters can coexist
within the same Perl executable.
This multiple interpreter support is required for interpreter-based threads.
 
Use which C compiler? [cc]
```

Personally, I believe that this is a good tradeoff. If Configure can't do better but pass a dangling `-arch` flag, then maybe it is a good idea to exit as early as possible so that the user can either add a hint for their CPU architecture (and then create a PR here like I did) or just call Configure without 64-bit addressing. However, if any of the reviewers think that this is something that should not be done, I'll be fine with reverting the second commit.

**This set of changes does not require a perldelta entry.**
