### PR TITLE
Small optimize to `pp_int` in pp.c

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -3318,7 +3318,7 @@ PP(pp_int)
       }
       else if (SvIOK(sv)) {
         if (SvIsUV(sv))
-            TARGu(SvUV_nomg(sv), 1);
+            TARGu(SvUVX(sv), 1);
         else
             TARGi(iv, 1);
       }


### PR DESCRIPTION
Similar to commit 75122876d2e240d7aafe35db62c52dc639af3437, `SvUV_nomg(sv)` in `pp_int` in pp.c could be safely replaced with simple `SvUVX(sv)`, as `SvIOK(sv)` and `SvIsUV(sv)` are already tested.

This patch should not change any behavior of perl (merely very slight performance optimization), so I think it does not require a perldelta entry.