### PR TITLE
Set current user as an owner for parent directories

### DIFF
--- a/cpan/File-Path/lib/File/Path.pm
+++ b/cpan/File-Path/lib/File/Path.pm
@@ -94,6 +94,7 @@ sub mkpath {
         $paths = [$paths] unless UNIVERSAL::isa( $paths, 'ARRAY' );
         $data->{verbose} = $verbose;
         $data->{mode} = defined $mode ? $mode : oct '777';
+        $data->{owner} = $<;
     }
     else {
         my %args_permitted = map { $_ => 1 } ( qw|


### PR DESCRIPTION
The problem happens in a Docker container with mounted case-sensitive APFS when running `miniperl_top "-I../../lib" -MExtUtils::Command -e 'mkpath' -- ../../lib/auto/lib as
```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
ERROR: Can't create '../../lib/auto'
Do not have write permissions on '../../lib/auto'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

where ../../lib/auto has root as an owner instead of the current user. 

The PR should fix the issue by setting the owner for all created directories.

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
TODO: fill description here

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
* This set of changes requires a perldelta entry, and I need help writing it.
* This set of changes does not require a perldelta entry.
