### PR TITLE
Return WIN32_NO_SOCKETS for miniperl.exe

### DIFF
--- a/win32/perllib.c
+++ b/win32/perllib.c
@@ -253,8 +253,10 @@ DllMain(HINSTANCE hModule,	/* DLL module handle */
             A. Not called at all.
             B. Called after memory allocation for Heap has been forcibly removed by OS.
             PerlIO_cleanup() was done here but fails (B).
-         */     
+         */
+#ifndef WIN32_NO_SOCKETS
         EndSockets();
+#endif
 #if defined(USE_ITHREADS)
         if (PL_curinterp)
             FREE_THREAD_KEY;

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -5464,7 +5464,9 @@ Perl_win32_init(int *argcp, char ***argvp)
     g_osver.dwOSVersionInfoSize = sizeof(g_osver);
     GetVersionEx(&g_osver);
 
+#ifndef WIN32_NO_SOCKETS
     win32_hook_closehandle_in_crt();
+#endif
 
     ansify_path();
 
@@ -5513,7 +5515,9 @@ Perl_win32_term(void)
     RegCloseKey(HKCU_Perl_hnd);
     /* the handles are in an undefined state until the next PERL_SYS_INIT3 */
 #endif
+#ifndef WIN32_NO_SOCKETS
     win32_unhook_closehandle_in_crt();
+#endif
 }
 
 void

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -5461,9 +5461,6 @@ Perl_win32_init(int *argcp, char ***argvp)
      */
     InitCommonControls();
 
-    WSADATA wsadata;
-    WSAStartup(MAKEWORD(2, 2), &wsadata);
-
     g_osver.dwOSVersionInfoSize = sizeof(g_osver);
     GetVersionEx(&g_osver);
 

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -15,6 +15,12 @@
 
 /* Win32 only optimizations for faster building */
 #ifdef PERL_IS_MINIPERL
+/* this macro will remove Winsock only on miniperl, PERL_IMPLICIT_SYS and
+ * makedef.pl create dependencies that will keep Winsock linked in even with
+ * this macro defined, even though sockets will be umimplemented from a script
+ * level in full perl
+ */
+#  define WIN32_NO_SOCKETS
 /* less I/O calls during each require */
 #  define PERL_DISABLE_PMC
 
@@ -23,6 +29,29 @@
 
 /* allow minitest to work */
 #  define PERL_TEXTMODE_SCRIPTS
+#endif
+
+#ifdef WIN32_NO_SOCKETS
+#  undef HAS_SOCKET
+#  undef HAS_GETPROTOBYNAME
+#  undef HAS_GETPROTOBYNUMBER
+#  undef HAS_GETPROTOENT
+#  undef HAS_GETNETBYNAME
+#  undef HAS_GETNETBYADDR
+#  undef HAS_GETNETENT
+#  undef HAS_GETSERVBYNAME
+#  undef HAS_GETSERVBYPORT
+#  undef HAS_GETSERVENT
+#  undef HAS_GETHOSTBYNAME
+#  undef HAS_GETHOSTBYADDR
+#  undef HAS_GETHOSTENT
+#  undef HAS_SELECT
+#  undef HAS_IOCTL
+#  undef HAS_NTOHL
+#  undef HAS_HTONL
+#  undef HAS_HTONS
+#  undef HAS_NTOHS
+#  define WIN32SCK_IS_STDSCK
 #endif
 
 #if defined(PERL_IMPLICIT_SYS)


### PR DESCRIPTION
https://github.com/Perl/perl5/commit/8a548d15292f2166cb07a69fc5fc943391b7fba5

Removed the optimization for miniperl.exe, build speed is important for new code. Bring back the macro for miniperl.exe only. Measureable time savings for me. see commit message.

---------------------------------------------------------------------------------
??????????? maybe, its a small build perf opt
* This set of changes requires a perldelta entry, and it is included.
* This set of changes requires a perldelta entry, and I need help writing it.
* This set of changes does not require a perldelta entry.
