### PR TITLE
regexec.c: Remove do-nothing call

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -4094,7 +4094,6 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
         /* XXXX check_substr already used to find "s", can optimize if
            check_substr==must. */
         dontbother = 0;
-        strend = HOPc(strend, -dontbother);
         while ( (s <= last) &&
                 (s = fbm_instr((unsigned char*)HOP4c(s, back_min, strbeg,  strend),
                                   (unsigned char*)strend, must,


### PR DESCRIPTION
Hopping 0 does nothing.  I thought at first this was moving to the beginning of the next character, but having read the source code, no, it does nothing.


* This set of changes does not require a perldelta entry.
