### PR TITLE
Update POD for Newx/Renew/Safefree vs libc analogs about heap corruption

### DIFF
--- a/pod/perlclib.pod
+++ b/pod/perlclib.pod
@@ -166,7 +166,10 @@ should use C<sv_gets> instead:
   p = realloc(p, n)              Renew(p, n, t)
 
 It is not portable to try to allocate 0 bytes; allocating 1 or more is
-portable.
+portable.  Never pass pointers between C<Newx>, C<Renew>, C<Safefree> and
+I<libc> equivalents C<malloc>, C<realloc>, C<free>.  They are not from the
+same memory pool or allocator.  Either an instant or delayed I<SEGV> will
+occur, or subtle memory leaks or subtle heap corruption.
 
   memcpy(dst, src, n)            Copy(src, dst, n, t)
   memmove(dst, src, n)           Move(src, dst, n, t)

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -231,10 +231,22 @@ Additionally, the following selected changes have been made:
 
 =head3 L<perl5416delta>
 
+=head4 F<pod/perlguts.pod> and F<pod/perlclib.pod>
+
 =over 4
 
-=item *
+=item Memory Allocation in C/XS
 
+Documentation was updated to reflect that mixing C<Newx>, C<Renew>, and
+C<Safefree> vs C<malloc>, C<realloc>, and C<free> are not allowed, and mixing
+pointers between the 2 classes of APIs is not allowed. Updates made in
+F<pod/perlguts.pod> and F<pod/perlclib.pod>.
+
+=back
+
+=over 4
+
+=item
 Added the change note for apostrophes in names being reinstated, which
 was delayed by the review cycle.
 

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -2384,7 +2384,10 @@ marked with correct flags.
 All memory meant to be used with the Perl API functions should be manipulated
 using the macros described in this section.  The macros provide the necessary
 transparency between differences in the actual malloc implementation that is
-used within perl.
+used within perl. Never pass pointers between C<Newx>, C<Renew>, C<Safefree>
+and I<libc> equivalents C<malloc>, C<realloc>, C<free>.  They are not from the
+same memory pool or allocator.  Either an instant or delayed I<SEGV> will
+occur, or subtle memory leaks or subtle heap corruption.
 
 The following three macros are used to initially allocate memory :
 


### PR DESCRIPTION
This isn't documented anywhere except in perlapi, in the per-macro/per-function section. A seasoned dev, will read perlguts ONCE, write code, then pass a Newx() pointer, to some 3rd party library or native OS API, and then instant disaster, or invisible disaster. If Newx() and libc malloc() pointers are interchangeable, on ONE particular OS, with ONE particular perl build, with ONE particular set of build flags, that is undefined behavior. Have fun with #define USE_MDH or -DUSE_MDH or -DDEBUGGING or #define MYMALLOC -DMYMALLOC.

Also, for anyone reading this in the future.

DO NOT EVER DOCUMENT the permutations where Newx() is libc malloc().

Perl core reserves the right, to separate Newx() and malloc(), at any time in a maint release if there are technical reasons to do so.

Also libperl.so/.dll embedders, if libperl is unloaded from the process, and deallocs all Newx() blocks globally, and a 3rd party library still loaded in the process, thinking it owns that "malloc()" block, that was given ownership of, in 3rd party lib API contract, SEGV time.

---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
