### PR TITLE
blib.pm dont shell out to "cmd.exe" on Win32+Win32.pm

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -29,6 +29,12 @@ struct BuiltinFuncDescriptor {
     bool is_experimental;
 };
 
+#ifdef WIN32
+    XS_EXTERNAL(w32_GetCwd);
+#elif defined(HAS_GETCWD)
+    XS_EXTERNAL(XS_Internals_getcwd);
+#endif
+
 #define warn_experimental_builtin(name) S_warn_experimental_builtin(aTHX_ name)
 static void S_warn_experimental_builtin(pTHX_ const char *name)
 {
@@ -640,6 +646,11 @@ static const struct BuiltinFuncDescriptor builtins[] = {
     /* list functions */
     { "indexed",          SHORTVER(5,39), &XS_builtin_indexed,          &ck_builtin_funcN, 0, false },
     { "export_lexically",      NO_BUNDLE, &XS_builtin_export_lexically, NULL,              0, true },
+#ifdef WIN32
+    { "getcwd",        NO_BUNDLE, &w32_GetCwd,           NULL, 0, true },
+#elif defined(HAS_GETCWD)
+    { "getcwd",        NO_BUNDLE, &XS_Internals_getcwd,  NULL, 0, true },
+#endif
 
     { NULL, 0, NULL, NULL, 0, false }
 };

--- a/cpan/Win32/Win32.pm
+++ b/cpan/Win32/Win32.pm
@@ -8,7 +8,7 @@ package Win32;
     require DynaLoader;
 
     @ISA = qw|Exporter DynaLoader|;
-    $VERSION = '0.59_01';
+    $VERSION = '0.59_04';
     $XS_VERSION = $VERSION;
     $VERSION = eval $VERSION;
 

--- a/dist/PathTools/Cwd.pm
+++ b/dist/PathTools/Cwd.pm
@@ -3,7 +3,7 @@ use strict;
 use Exporter;
 
 
-our $VERSION = '3.92';
+our $VERSION = '3.93';
 my $xs_version = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/dist/PathTools/Cwd.xs
+++ b/dist/PathTools/Cwd.xs
@@ -302,6 +302,7 @@ int Perl_getcwd_sv(pTHX_ SV *sv)
 	/* Some getcwd()s automatically allocate a buffer of the given
 	 * size from the heap if they are given a NULL buffer pointer.
 	 * The problem is that this behaviour is not portable. */
+	/* XXX bug use PerlEnv_get_childdir/PerlEnv_free_childenv all OSes? */
 	if (getcwd(buf, sizeof(buf) - 1)) {
 	    STRLEN len = strlen(buf);
 	    sv_setpvn(sv, buf, len);

--- a/iperlsys.h
+++ b/iperlsys.h
@@ -470,6 +470,7 @@ typedef void*           (*LPEnvGetChildenv)(struct IPerlEnv*);
 typedef void            (*LPEnvFreeChildenv)(struct IPerlEnv*, void* env);
 typedef char*           (*LPEnvGetChilddir)(struct IPerlEnv*);
 typedef void            (*LPEnvFreeChilddir)(struct IPerlEnv*, char* dir);
+typedef unsigned int    (*LPEnvGetChilddir_tbuf)(struct IPerlEnv*, char* ptr, PH_GCDB_T info);
 #  ifdef HAS_ENVGETENV
 typedef char*           (*LPENVGetenv)(struct IPerlEnv*, const char *varname);
 typedef char*           (*LPENVGetenv_len)(struct IPerlEnv*,
@@ -497,6 +498,7 @@ struct IPerlEnv
     LPEnvFreeChildenv   pFreeChildenv;
     LPEnvGetChilddir    pGetChilddir;
     LPEnvFreeChilddir   pFreeChilddir;
+    LPEnvGetChilddir_tbuf    pGetChilddir_tbuf;
 #  ifdef HAS_ENVGETENV
     LPENVGetenv         pENVGetenv;
     LPENVGetenv_len     pENVGetenv_len;
@@ -532,6 +534,8 @@ struct IPerlEnvInfo
         (*PL_Env->pGetChilddir)(PL_Env)
 #  define PerlEnv_free_childdir(d)                              \
         (*PL_Env->pFreeChilddir)(PL_Env, (d))
+#  define PerlEnv_get_childdir_tbuf(_p,_i)                         \
+        (*PL_Env->pGetChilddir_tbuf)(PL_Env,(_p),(_i))
 #  ifdef HAS_ENVGETENV
 #    define PerlEnv_ENVgetenv(str)                              \
         (*PL_Env->pENVGetenv)(PL_Env,(str))
@@ -583,6 +587,7 @@ struct IPerlEnvInfo
 #  define PerlEnv_get_childenv()                win32_get_childenv()
 #  define PerlEnv_free_childenv(e)      win32_free_childenv((e))
 #  define PerlEnv_get_childdir()                win32_get_childdir()
+#  define PerlEnv_get_childdir_tbuf(_p,_i)      win32_get_childdir_tbuf((_p),(_i))
 #  define PerlEnv_free_childdir(d)      win32_free_childdir((d))
 #  else
 #    define PerlEnv_clearenv(str)               (ENV_LOCK, (clearenv(str)   \

--- a/lib/Internals.pod
+++ b/lib/Internals.pod
@@ -57,6 +57,22 @@ to implement higher-level behavior which should be used instead.
 See the core implementation for the exact meaning of the readonly flag for
 each internal variable type.
 
+=item Internals::getcwd()
+
+Internally core maintained version of L<Cwd::getcwd()|Cwd/getcwd> or
+L<Win32::GetCwd()|Win32/Win32::GetCwd()>. Only for use if loading L<Cwd::|Cwd> or
+calling C<Win32::GetCwd()> and its C<AUTOLOAD> to L<Win32.pm|Win32> will
+somehow break a TAP test in a C<.t>.
+
+Not defined on all platforms and all perl build flag configs.  May not set
+C<PWD> env var.  May disappear at any time.  Probe for the sub's existance
+before calling it and write C<if>/C<else> if C<Internals::getcwd> is
+unavailable.  Although this would be a bug, there is no guarentee it will
+return the same identical string as L<Cwd::getcwd()|Cwd/getcwd> or
+L<Win32::GetCwd()|Win32/Win32::GetCwd()>.  The public implementations can get patched
+in the future for some future discovered bug while this sub keeps the buggy
+return value.
+
 =item hv_clear_placeholders(%hash)
 
 Clear any placeholders from a locked hash. Should not be used directly.

--- a/lib/Internals.pod
+++ b/lib/Internals.pod
@@ -57,22 +57,6 @@ to implement higher-level behavior which should be used instead.
 See the core implementation for the exact meaning of the readonly flag for
 each internal variable type.
 
-=item Internals::getcwd()
-
-Internally core maintained version of L<Cwd::getcwd()|Cwd/getcwd> or
-L<Win32::GetCwd()|Win32/Win32::GetCwd()>. Only for use if loading L<Cwd::|Cwd> or
-calling C<Win32::GetCwd()> and its C<AUTOLOAD> to L<Win32.pm|Win32> will
-somehow break a TAP test in a C<.t>.
-
-Not defined on all platforms and all perl build flag configs.  May not set
-C<PWD> env var.  May disappear at any time.  Probe for the sub's existance
-before calling it and write C<if>/C<else> if C<Internals::getcwd> is
-unavailable.  Although this would be a bug, there is no guarentee it will
-return the same identical string as L<Cwd::getcwd()|Cwd/getcwd> or
-L<Win32::GetCwd()|Win32/Win32::GetCwd()>.  The public implementations can get patched
-in the future for some future discovered bug while this sub keeps the buggy
-return value.
-
 =item hv_clear_placeholders(%hash)
 
 Clear any placeholders from a locked hash. Should not be used directly.

--- a/lib/blib.pm
+++ b/lib/blib.pm
@@ -39,7 +39,7 @@ Nick Ing-Simmons nik@tiuk.ti.com
 use Cwd;
 use File::Spec;
 
-our $VERSION = '1.07';
+our $VERSION = '1.08';
 our $Verbose = 0;
 
 sub import
@@ -52,7 +52,11 @@ sub import
      # That means that it would not be possible to run `make test`
      # for the Win32 module because blib.pm would always load the
      # installed version before @INC gets updated with the blib path.
-     chomp($dir = `cd`);
+     if(defined &Internals::getcwd) {
+       $dir = Internals::getcwd();
+     } else {
+       chomp($dir = `cd`);
+     }
  }
  else {
      $dir = getcwd;

--- a/lib/blib.pm
+++ b/lib/blib.pm
@@ -52,8 +52,8 @@ sub import
      # That means that it would not be possible to run `make test`
      # for the Win32 module because blib.pm would always load the
      # installed version before @INC gets updated with the blib path.
-     if(defined &Internals::getcwd) {
-       $dir = Internals::getcwd();
+     if(defined &builtin::getcwd) {
+       $dir = builtin::getcwd();
      } else {
        chomp($dir = `cd`);
      }

--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -1,4 +1,4 @@
-package builtin 0.015;
+package builtin 0.016;
 
 use v5.40;
 
@@ -173,6 +173,29 @@ This function is currently B<experimental>.
 Returns the floating-point "Not-a-Number" value.
 
 Available starting with Perl 5.40.
+
+=head2 getcwd
+
+    $cwd = builtin::getcwd();
+
+Core maintained version of L<Cwd::getcwd()|Cwd/getcwd> or
+L<Win32::GetCwd()|Win32/Win32::GetCwd()>.  It is suggested that you only use
+this sub if loading L<Cwd::|Cwd> or calling C<Win32::GetCwd()> and its
+C<AUTOLOAD> to L<Win32.pm|Win32> will somehow break a TAP test in a C<.t> or
+for some esoteric reason L<@INC|perlvar/@INC> L<%INC|perlvar/%INC> or
+L<$INC|perlvar/$INC> are unusable or temporarily broken or undef, or you are
+running perl.bin without perl's L<PERL5LIB|perlrun/PERL5LIB> or
+L<PERLLIB|perlrun/PERLLIB>.
+
+C<builtin::getcwd> may not always return the same string as
+L<Cwd::getcwd()|Cwd/getcwd> or L<Win32::GetCwd()|Win32/Win32::GetCwd()>.
+This sub may have less Perl specific OS portability fixes vs the 2
+subs above, and could return C<undef> in situations where those 2 would return
+a successful string value.  C<builtin::getcwd> is not guarenteed to set
+C<PWD> env var.  Although this would be a bug, there is no guarentee it will
+return the same identical string. Note the public implementations of the other
+2 subs can get patched in the future for some future discovered bug while this
+sub keeps the buggy return value string.
 
 =head2 weaken
 

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -440,6 +440,19 @@ TODO: {
     is($HASH{key}, "val", 'Lexically exported hash is accessible');
 }
 
+# Test getcwd
+{
+    require Cwd;
+
+    eval "getcwd()";
+    ok($@, "no main::getcwd");
+
+    TODO: {
+        local $::TODO = "backslash vs forward slash problems on Win32";
+        is(builtin::getcwd(), Cwd::getcwd(), "builtin::getcwd() eq Cwd::getcwd()");
+    }
+}
+
 # load_module
 {
     use builtin qw( load_module );

--- a/makedef.pl
+++ b/makedef.pl
@@ -347,6 +347,7 @@ if ($define{'PERL_IMPLICIT_SYS'}) {
     ++$skip{$_} foreach qw(
 		    Perl_my_popen
 		    Perl_my_pclose
+		    win32_get_childdir_tbuf
 			 );
     ++$export{$_} foreach qw(perl_get_host_info perl_alloc_override);
     ++$export{perl_clone_host} if $define{USE_ITHREADS};
@@ -844,6 +845,7 @@ if (PLATFORM eq 'win32') {
 		    win32_free_childenv
 		    win32_get_childdir
 		    win32_get_childenv
+		    win32_get_childdir_tbuf
 		    win32_spawnvp
 		    Perl_init_os_extras
 		    Perl_win32_init

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -131,6 +131,12 @@ shelling out to a new C<cmd.exe>, this was fixed and the C<cwd> when using
 C<blib.pm> and L<Win32.pm|Win32> is obtained with a fast same-process API
 function call the way C<Win32::GetCwd()> and C<Cwd::> do it.
 
+=item builtin.pm
+
+C<builtin.pm> was updated from 0.015 to 0.016.
+
+C<builtin::getcwd()> was added as experimental.
+
 =back
 
 =head2 Removed Modules and Pragmata
@@ -348,12 +354,9 @@ well.
 
 =over 4
 
-=item Internals::getcwd() is documented as very limited platform availability
+=item *
 
-C<Internals::getcwd()> is documented as experimental, unsupported, not-bug-free
-and removeable in the future, and very limited availability on random
-platforms and perl core build flags. Basically C<Win32> only, and only for
-esoteric C<.t> TAP situations and esoteric internal core reasons.
+XXX
 
 =back
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -123,11 +123,13 @@ XXX Remove this section if F<Porting/corelist-perldelta.pl> did not add any cont
 
 =over 4
 
-=item *
+=item blib.pm
 
-L<XXX> has been upgraded from version A.xx to B.yy.
-
-XXX If there was something important to note about this change, include that here.
+C<blib.pm> was updated from 1.07 to 1.08. Previously when L<Win32.pm|Win32>,
+and only that module, the C<cwd()> was obtained through inefficiently
+shelling out to a new C<cmd.exe>, this was fixed and the C<cwd> when using
+C<blib.pm> and L<Win32.pm|Win32> is obtained with a fast same-process API
+function call the way C<Win32::GetCwd()> and C<Cwd::> do it.
 
 =back
 
@@ -346,9 +348,12 @@ well.
 
 =over 4
 
-=item *
+=item Internals::getcwd() is documented as very limited platform availability
 
-XXX
+C<Internals::getcwd()> is documented as experimental, unsupported, not-bug-free
+and removeable in the future, and very limited availability on random
+platforms and perl core build flags. Basically C<Win32> only, and only for
+esoteric C<.t> TAP situations and esoteric internal core reasons.
 
 =back
 

--- a/universal.c
+++ b/universal.c
@@ -1136,16 +1136,17 @@ XS(XS_re_regexp_pattern)
 XS(XS_Internals_getcwd)
 {
     dXSARGS;
-    SV *sv = sv_newmortal();
-
     if (items != 0)
         croak_xs_usage(cv, "");
+    EXTEND(SP,1);
+    dXSTARG;
+    PUSHs(TARG);
+    PUTBACK;
 
-    (void)getcwd_sv(sv);
+    (void)getcwd_sv(TARG);
 
-    SvTAINTED_on(sv);
-    PUSHs(sv);
-    XSRETURN(1);
+    SvTAINTED_on(TARG);
+    SvSETMAGIC(TARG);
 }
 
 #endif
@@ -1314,6 +1315,10 @@ struct xsub_details {
     int ix;
 };
 
+#ifdef WIN32
+    XS_EXTERNAL(w32_GetCwd);
+#endif
+
 static const struct xsub_details these_details[] = {
     {"UNIVERSAL::isa", XS_UNIVERSAL_isa, NULL, 0 },
     {"UNIVERSAL::can", XS_UNIVERSAL_can, NULL, 0 },
@@ -1344,6 +1349,11 @@ static const struct xsub_details these_details[] = {
     {"re::regexp_pattern", XS_re_regexp_pattern, "$", 0 },
 #if defined(HAS_GETCWD) && defined(PERL_IS_MINIPERL)
     {"Internals::getcwd", XS_Internals_getcwd, "", 0 },
+#elif defined(WIN32)
+    /* Always offer backup, Win32CORE.c vs AUTOLOAD vs Win32.pm
+       vs Win32.dll vs loading a .pm or .dll at all, has rare dep/recursion
+       problems in certain modules or .t files. See w32_GetCwd() . */
+    {"Internals::getcwd", w32_GetCwd, "", 0 },
 #endif
     {"Tie::Hash::NamedCapture::_tie_it", XS_NamedCapture_tie_it, NULL, 0 },
     {"Tie::Hash::NamedCapture::TIEHASH", XS_NamedCapture_TIEHASH, NULL, 0 },

--- a/universal.c
+++ b/universal.c
@@ -1131,9 +1131,9 @@ XS(XS_re_regexp_pattern)
     NOT_REACHED; /* NOTREACHED */
 }
 
-#if defined(HAS_GETCWD) && defined(PERL_IS_MINIPERL)
+#if defined(HAS_GETCWD)
 
-XS(XS_Internals_getcwd)
+XS_EXTERNAL(XS_Internals_getcwd)
 {
     dXSARGS;
     if (items != 0)
@@ -1353,7 +1353,7 @@ static const struct xsub_details these_details[] = {
     /* Always offer backup, Win32CORE.c vs AUTOLOAD vs Win32.pm
        vs Win32.dll vs loading a .pm or .dll at all, has rare dep/recursion
        problems in certain modules or .t files. See w32_GetCwd() . */
-    {"Internals::getcwd", w32_GetCwd, "", 0 },
+    /*{"Internals::getcwd", w32_GetCwd, "", 0 },*/
 #endif
     {"Tie::Hash::NamedCapture::_tie_it", XS_NamedCapture_tie_it, NULL, 0 },
     {"Tie::Hash::NamedCapture::TIEHASH", XS_NamedCapture_TIEHASH, NULL, 0 },

--- a/util.c
+++ b/util.c
@@ -4124,6 +4124,7 @@ Perl_getcwd_sv(pTHX_ SV *sv)
         /* Some getcwd()s automatically allocate a buffer of the given
          * size from the heap if they are given a NULL buffer pointer.
          * The problem is that this behaviour is not portable. */
+        /* XXX bug use PerlEnv_get_childdir/PerlEnv_free_childenv all OSes? */
         if (getcwd(buf, sizeof(buf) - 1)) {
             sv_setpv(sv, buf);
             return TRUE;

--- a/win32/perllib.c
+++ b/win32/perllib.c
@@ -52,6 +52,8 @@ win32_checkTLS(PerlInterpreter *host_perl)
     dTHX;
     if (host_perl != my_perl) {
         int *nowhere = NULL;
+        *nowhere = 0; /* this segfault is deliberate,
+                         so you can see the stack trace */
         abort();
     }
 }
@@ -232,7 +234,8 @@ BOOL APIENTRY
 DllMain(HINSTANCE hModule,	/* DLL module handle */
         DWORD fdwReason,	/* reason called */
         LPVOID lpvReserved)	/* reserved */
-{ 
+{
+    PERL_UNUSED_ARG(lpvReserved);
     switch (fdwReason) {
         /* The DLL is attaching to a process due to process
          * initialization or a call to LoadLibrary.

--- a/win32/vdir.h
+++ b/win32/vdir.h
@@ -32,27 +32,25 @@ public:
     int SetCurrentDirectoryW(WCHAR *lpBuffer);
     inline int GetDefault(void) { return nDefault; };
 
-    inline char* GetCurrentDirectoryA(int dwBufSize, char *lpBuffer)
+    inline unsigned int GetCurrentDirectoryA(int dwBufSize, char *lpBuffer)
     {
         char* ptr = dirTableA[nDefault];
-        while (--dwBufSize)
-        {
-            if ((*lpBuffer++ = *ptr++) == '\0')
-                break;
-        }
-        *lpBuffer = '\0';
-        return /* unused */ NULL;
+        unsigned int len = (unsigned int)strlen(ptr);
+        unsigned int cpylen = len <= ((unsigned int)dwBufSize)-1
+                                  ? len : ((unsigned int)dwBufSize)-1;
+        lpBuffer = (char*)memcpy((void*)lpBuffer, (void*)ptr, cpylen);
+        lpBuffer[cpylen] = '\0';
+        return len;
     };
-    inline WCHAR* GetCurrentDirectoryW(int dwBufSize, WCHAR *lpBuffer)
+    inline unsigned int GetCurrentDirectoryW(int dwBufSize, WCHAR *lpBuffer)
     {
         WCHAR* ptr = dirTableW[nDefault];
-        while (--dwBufSize)
-        {
-            if ((*lpBuffer++ = *ptr++) == '\0')
-                break;
-        }
-        *lpBuffer = '\0';
-        return /* unused */ NULL;
+        unsigned int len = (unsigned int)wcslen(ptr);
+        unsigned int cpylen = len <= ((unsigned int)dwBufSize)-1
+                                  ? len : ((unsigned int)dwBufSize)-1;
+        lpBuffer = (WCHAR*)memcpy((void*)lpBuffer, (void*)ptr, cpylen*sizeof(WCHAR));
+        lpBuffer[cpylen] = '\0';
+        return len;
     };
 
     DWORD CalculateEnvironmentSpace(void);

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -360,6 +360,12 @@ typedef unsigned int	uintptr_t;
 #  define _UINTPTR_T_DEFINED
 #endif
 
+typedef struct {
+  unsigned int want_wide: 1;
+  unsigned int want_utf8_maybe: 1;
+  unsigned int len_tchar: 29;
+} PH_GCDB_T;
+
 START_EXTERN_C
 
 /* For UNIX compatibility. */

--- a/win32/win32iop.h
+++ b/win32/win32iop.h
@@ -159,6 +159,9 @@ DllExport void		win32_free_childenv(void* d);
 DllExport void		win32_clearenv(void);
 DllExport char *	win32_get_childdir(void);
 DllExport void		win32_free_childdir(char* d);
+#ifndef PERL_IMPLICIT_SYS
+DllExport unsigned int	win32_get_childdir_tbuf(char* ptr, PH_GCDB_T info);
+#endif
 DllExport Sighandler_t	win32_signal(int sig, Sighandler_t subcode);
 
 
@@ -343,6 +346,7 @@ END_EXTERN_C
 #define free_childenv(d)	win32_free_childenv(d)
 #define clearenv()		win32_clearenv()
 #define get_childdir()		win32_get_childdir()
+#define get_childdir_tbuf(_p,_i)		win32_get_childdir_tbuf((_p),(_i))
 #define free_childdir(d)	win32_free_childdir(d)
 
 #undef getenv


### PR DESCRIPTION
-document Internals::getcwd() enough, with scary warnings, for future
 core devs, or CPAN devs.  A permanent reason for Internals::getcwd() to
 exist on Win32 full perl was found. See code comments.
-optimize a bit the built-in perl core cwd() XSUBs, use TARG, and group
 stack manipulation together for C compiler variable liveness reasons aka
 less variables to save in non-vol regs or on C stack around function
 calls.

---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
