### PR TITLE
t/porting/podcheck.t don't open Win32 MSVC related compiler binary files

### DIFF
--- a/t/porting/podcheck.t
+++ b/t/porting/podcheck.t
@@ -427,6 +427,16 @@ my $non_pods = qr/
                            | lst      # assorted listing files
                            | bat      # Windows,OS2 batch files
                            | cmd      # Windows,OS2 command files
+                           | pdb      # Windows, C debugger symbols
+                           | dmp      # Windows, C debugger temps
+                           | nam      # Windows, C debugger temps
+                           | id0      # Windows, C debugger temps
+                           | id1      # Windows, C debugger temps
+                           | obj      # Windows .o equivalent
+                           | lib      # Windows .a equivalent
+                           | def      # Windows compiler DLL related (ASCII)
+                           | exp      # Windows compiler DLL related (binary)
+                           | pch      # Windows pre-compiled headers
                            | lis      # VMS compiler listings
                            | map      # VMS linker maps
                            | opt      # VMS linker options files


### PR DESCRIPTION
-Don't open binary build products and binary C debugger related disk files
 these can't be parsed for POD, or are access-denied locked disk files for
 paused processes in C debuggers. Users shouldn't exit open IDE windows
 and open C debugger windows, just to make podcheck.t pass.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.

Don't think it does.  Its too perl core dev specific.
