### PR TITLE
Add utf8_hop functions that return error detection

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -1899,7 +1899,7 @@ sub docout ($fh, $section_name, $element_name, $docref) {
                     # Here, has a long name and we didn't create one just
                     # above.  Check that there really is a long name entry.
                     my $real_proto = delete $protos{"Perl_$name"};
-                    if ($real_proto) {
+                    if ($real_proto || $flags =~ /m/) {
 
                         # Set up to redo the loop at the end.  This iteration
                         # adds the short form; the redo causes its long form

--- a/embed.fnc
+++ b/embed.fnc
@@ -3631,10 +3631,16 @@ ARTdip	|U8 *	|utf8_hop_forward_overshoot				\
 				|SSize_t off				\
 				|NN const U8 * const end		\
 				|NULLOK SSize_t *remaining
-ARTdip	|U8 *	|utf8_hop_safe	|NN const U8 *s 			\
+ARTdip	|U8 *	|utf8_hop_overshoot					\
+				|NN const U8 *s 			\
 				|SSize_t off				\
-				|NN const U8 *start			\
-				|NN const U8 *end
+				|NN const U8 * const start		\
+				|NN const U8 * const end		\
+				|NULLOK SSize_t *remaining
+ARTdmp	|U8 *	|utf8_hop_safe	|NN const U8 *s 			\
+				|SSize_t off				\
+				|NN const U8 * const start		\
+				|NN const U8 * const end
 ARdp	|STRLEN |utf8_length	|NN const U8 *s0			\
 				|NN const U8 *e
 

--- a/embed.fnc
+++ b/embed.fnc
@@ -3622,10 +3622,15 @@ ARTdip	|U8 *	|utf8_hop_back_overshoot				\
 				|SSize_t off				\
 				|NN const U8 * const start		\
 				|NULLOK SSize_t *remaining
-ARTdip	|U8 *	|utf8_hop_forward					\
+ARTdmp	|U8 *	|utf8_hop_forward					\
 				|NN const U8 *s 			\
 				|SSize_t off				\
-				|NN const U8 *end
+				|NN const U8 * const end
+ARTdip	|U8 *	|utf8_hop_forward_overshoot				\
+				|NN const U8 *s 			\
+				|SSize_t off				\
+				|NN const U8 * const end		\
+				|NULLOK SSize_t *remaining
 ARTdip	|U8 *	|utf8_hop_safe	|NN const U8 *s 			\
 				|SSize_t off				\
 				|NN const U8 *start			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -3614,9 +3614,14 @@ ARdip	|IV	|utf8_distance	|NN const U8 *a 			\
 				|NN const U8 *b
 ARTdip	|U8 *	|utf8_hop	|NN const U8 *s 			\
 				|SSize_t off
-ARTdip	|U8 *	|utf8_hop_back	|NN const U8 *s 			\
+ARTdmp	|U8 *	|utf8_hop_back	|NN const U8 *s 			\
 				|SSize_t off				\
-				|NN const U8 *start
+				|NN const U8 * const start
+ARTdip	|U8 *	|utf8_hop_back_overshoot				\
+				|NN const U8 *s 			\
+				|SSize_t off				\
+				|NN const U8 * const start		\
+				|NULLOK SSize_t *remaining
 ARTdip	|U8 *	|utf8_hop_forward					\
 				|NN const U8 *s 			\
 				|SSize_t off				\

--- a/embed.h
+++ b/embed.h
@@ -789,6 +789,7 @@
 # define utf8_hop_back                          Perl_utf8_hop_back
 # define utf8_hop_back_overshoot                Perl_utf8_hop_back_overshoot
 # define utf8_hop_forward                       Perl_utf8_hop_forward
+# define utf8_hop_forward_overshoot             Perl_utf8_hop_forward_overshoot
 # define utf8_hop_safe                          Perl_utf8_hop_safe
 # define utf8_length(a,b)                       Perl_utf8_length(aTHX_ a,b)
 # define utf8_to_bytes(a,b)                     Perl_utf8_to_bytes(aTHX_ a,b)

--- a/embed.h
+++ b/embed.h
@@ -790,6 +790,7 @@
 # define utf8_hop_back_overshoot                Perl_utf8_hop_back_overshoot
 # define utf8_hop_forward                       Perl_utf8_hop_forward
 # define utf8_hop_forward_overshoot             Perl_utf8_hop_forward_overshoot
+# define utf8_hop_overshoot                     Perl_utf8_hop_overshoot
 # define utf8_hop_safe                          Perl_utf8_hop_safe
 # define utf8_length(a,b)                       Perl_utf8_length(aTHX_ a,b)
 # define utf8_to_bytes(a,b)                     Perl_utf8_to_bytes(aTHX_ a,b)

--- a/embed.h
+++ b/embed.h
@@ -787,6 +787,7 @@
 # define utf8_distance(a,b)                     Perl_utf8_distance(aTHX_ a,b)
 # define utf8_hop                               Perl_utf8_hop
 # define utf8_hop_back                          Perl_utf8_hop_back
+# define utf8_hop_back_overshoot                Perl_utf8_hop_back_overshoot
 # define utf8_hop_forward                       Perl_utf8_hop_forward
 # define utf8_hop_safe                          Perl_utf8_hop_safe
 # define utf8_length(a,b)                       Perl_utf8_length(aTHX_ a,b)

--- a/inline.h
+++ b/inline.h
@@ -2691,10 +2691,12 @@ Perl_utf8_hop_forward(const U8 *s, SSize_t off, const U8 *end)
 
         while (off-- && s < end) {
             STRLEN skip = UTF8SKIP(s);
-            if ((STRLEN)(end - s) <= skip) {
-                GCC_DIAG_IGNORE(-Wcast-qual)
-                return (U8 *)end;
-                GCC_DIAG_RESTORE
+
+            /* Quit without counting this character if it overshoots the edge.
+             * */
+            if ((STRLEN)(end - s) < skip) {
+                s = end;
+                break;
             }
             s += skip;
         }

--- a/proto.h
+++ b/proto.h
@@ -5130,6 +5130,10 @@ Perl_utf16_to_utf8_reversed(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen);
 Perl_utf8_hop_back(const U8 *s, SSize_t off, const U8 * const start)
         __attribute__warn_unused_result__; */
 
+/* PERL_CALLCONV U8 *
+Perl_utf8_hop_forward(const U8 *s, SSize_t off, const U8 * const end)
+        __attribute__warn_unused_result__; */
+
 PERL_CALLCONV STRLEN
 Perl_utf8_length(pTHX_ const U8 *s0, const U8 *e)
         __attribute__warn_unused_result__;
@@ -10086,9 +10090,9 @@ Perl_utf8_hop_back_overshoot(const U8 *s, SSize_t off, const U8 * const start, S
         assert(s); assert(start)
 
 PERL_STATIC_INLINE U8 *
-Perl_utf8_hop_forward(const U8 *s, SSize_t off, const U8 *end)
+Perl_utf8_hop_forward_overshoot(const U8 *s, SSize_t off, const U8 * const end, SSize_t *remaining)
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_UTF8_HOP_FORWARD      \
+# define PERL_ARGS_ASSERT_UTF8_HOP_FORWARD_OVERSHOOT \
         assert(s); assert(end)
 
 PERL_STATIC_INLINE U8 *

--- a/proto.h
+++ b/proto.h
@@ -5134,6 +5134,10 @@ Perl_utf8_hop_back(const U8 *s, SSize_t off, const U8 * const start)
 Perl_utf8_hop_forward(const U8 *s, SSize_t off, const U8 * const end)
         __attribute__warn_unused_result__; */
 
+/* PERL_CALLCONV U8 *
+Perl_utf8_hop_safe(const U8 *s, SSize_t off, const U8 * const start, const U8 * const end)
+        __attribute__warn_unused_result__; */
+
 PERL_CALLCONV STRLEN
 Perl_utf8_length(pTHX_ const U8 *s0, const U8 *e)
         __attribute__warn_unused_result__;
@@ -10096,9 +10100,9 @@ Perl_utf8_hop_forward_overshoot(const U8 *s, SSize_t off, const U8 * const end, 
         assert(s); assert(end)
 
 PERL_STATIC_INLINE U8 *
-Perl_utf8_hop_safe(const U8 *s, SSize_t off, const U8 *start, const U8 *end)
+Perl_utf8_hop_overshoot(const U8 *s, SSize_t off, const U8 * const start, const U8 * const end, SSize_t *remaining)
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_UTF8_HOP_SAFE         \
+# define PERL_ARGS_ASSERT_UTF8_HOP_OVERSHOOT    \
         assert(s); assert(start); assert(end)
 
 PERL_STATIC_INLINE UV

--- a/proto.h
+++ b/proto.h
@@ -5126,6 +5126,10 @@ Perl_utf16_to_utf8_reversed(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen);
 #define PERL_ARGS_ASSERT_UTF16_TO_UTF8_REVERSED \
         assert(p); assert(d); assert(newlen)
 
+/* PERL_CALLCONV U8 *
+Perl_utf8_hop_back(const U8 *s, SSize_t off, const U8 * const start)
+        __attribute__warn_unused_result__; */
+
 PERL_CALLCONV STRLEN
 Perl_utf8_length(pTHX_ const U8 *s0, const U8 *e)
         __attribute__warn_unused_result__;
@@ -10076,9 +10080,9 @@ Perl_utf8_hop(const U8 *s, SSize_t off)
         assert(s)
 
 PERL_STATIC_INLINE U8 *
-Perl_utf8_hop_back(const U8 *s, SSize_t off, const U8 *start)
+Perl_utf8_hop_back_overshoot(const U8 *s, SSize_t off, const U8 * const start, SSize_t *remaining)
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_UTF8_HOP_BACK         \
+# define PERL_ARGS_ASSERT_UTF8_HOP_BACK_OVERSHOOT \
         assert(s); assert(start)
 
 PERL_STATIC_INLINE U8 *


### PR DESCRIPTION
These commits add versions of the utf8_hop functions that return extra information that can tell the caller if the request could not be completely filled.  This will help simplify several portions of the perl core.

The function names end with `_overshoot` that indicate to return how far the function call would have overshot the edge of the string if that had been allowed to happen.  I'm open to a better name, but I didn't find one in a thesaurus.

* This set of changes requires a perldelta entry, and I need help writing it.

Once this is settled, I can write the perldelta
