### PR TITLE
pod: fields.pm corrections

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1156,6 +1156,7 @@ Pravus                         <pravus@cpan.org>
 Premchai                       <premchai21@yahoo.com>
 Prymmer/Kahn                   <pvhp@best.com>
 pxm                            <pxm@nubz.org>
+pyrrhlin                       <1197072+myrrhlin@users.noreply.github.com>
 Quentin Fennessy               <quentin@arrakeen.amd.com>
 Radu Greab                     <radu@netsoft.ro>
 raf                            <raf@tradingpost.com.au>

--- a/dist/base/lib/fields.pm
+++ b/dist/base/lib/fields.pm
@@ -12,7 +12,7 @@ unless( eval q{require warnings::register; warnings::register->import; 1} ) {
 }
 our %attr;
 
-our $VERSION = '2.25';
+our $VERSION = '2.26';
 $VERSION =~ tr/_//d;
 
 # constant.pm is slow
@@ -252,7 +252,7 @@ to subclasses.
 
 Also, B<in Perl 5.8.x and earlier>, this pragma uses pseudo-hashes, the
 effect being that you can have objects with named fields which are as
-compact and as fast arrays to access, as long as the objects are
+compact and fast as arrays to access, as long as the objects are
 accessed through properly typed variables.
 
 The following functions are supported:
@@ -293,7 +293,7 @@ pseudo-hashes directly.
 If the first argument is a reference to an array, the pseudo-hash will
 be created with keys from that array.  If a second argument is supplied,
 it must also be a reference to an array whose elements will be used as
-the values.  If the second array contains less elements than the first,
+the values.  If the second array contains fewer elements than the first,
 the trailing elements of the pseudo-hash will not be initialized.
 This makes it particularly useful for creating a pseudo-hash from
 subroutine arguments:


### PR DESCRIPTION
correct some confusing word order, clearly was intended to
be 'as ... fast as'

also, 'fewer' elements rather than 'less'

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
