### PR TITLE
convert last small purpose of builtin.pm to C and NOOP require's I/O

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -774,6 +774,9 @@ XS(XS_builtin_import)
 void
 Perl_boot_core_builtin(pTHX)
 {
+    HV * inc_hv;
+    GV * ver_gv;
+    SV * ver_sv;
     I32 i;
     for(i = 0; builtins[i].name; i++) {
         const struct BuiltinFuncDescriptor *builtin = &builtins[i];
@@ -807,6 +810,13 @@ Perl_boot_core_builtin(pTHX)
     }
 
     newXS_flags("builtin::import", &XS_builtin_import, __FILE__, NULL, 0);
+
+    inc_hv = GvHVn(PL_incgv);
+    hv_store(inc_hv, "builtin.pm", STRLENs("builtin.pm"), newSVpvs(__FILE__), 0);
+    ver_gv = gv_fetchpvs("builtin::VERSION", GV_ADDMULTI, SVt_PV);
+    ver_sv = GvSV(ver_gv);
+    /* Remember to keep $VERSION in this file and $VERSION in builtin.pm synced. */
+    sv_setpvs(ver_sv, "0.016");
 }
 
 /*

--- a/builtin.c
+++ b/builtin.c
@@ -447,7 +447,7 @@ static OP *ck_builtin_func1(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
 
     entersubop = ck_entersub_args_proto(entersubop, namegv, prototype);
 
-    OPCODE opcode = builtin->ckval;
+    OPCODE opcode = (OPCODE)builtin->ckval;
     if(!opcode)
         return entersubop;
 
@@ -752,7 +752,7 @@ XS(XS_builtin_import)
             if(!S_parse_version(sympv + 1, sympv + symlen, &vmajor, &vminor))
                 Perl_croak(aTHX_ "Invalid version bundle %" SVf_QUOTEDPREFIX, sym);
 
-            U16 want_ver = SHORTVER(vmajor, vminor);
+            U16 want_ver = (U16)SHORTVER(vmajor, vminor);
 
             if(want_ver < SHORTVER(5,39) ||
                     /* round up devel version to next major release; e.g. 5.39 => 5.40 */
@@ -774,9 +774,6 @@ XS(XS_builtin_import)
 void
 Perl_boot_core_builtin(pTHX)
 {
-    HV * inc_hv;
-    GV * ver_gv;
-    SV * ver_sv;
     I32 i;
     for(i = 0; builtins[i].name; i++) {
         const struct BuiltinFuncDescriptor *builtin = &builtins[i];
@@ -792,7 +789,7 @@ Perl_boot_core_builtin(pTHX)
         SV *name = newSVpvs_flags("builtin::", SVs_TEMP);
         sv_catpv(name, builtin->name);
         CV *cv = newXS_flags(SvPV_nolen(name), builtin->xsub, __FILE__, proto, 0);
-        XSANY.any_i32 = builtin->ckval;
+        XSANY.any_i32 = (I32)builtin->ckval;
 
         if (   builtin->xsub == &XS_builtin_func1_void
             || builtin->xsub == &XS_builtin_func1_scalar)
@@ -811,10 +808,11 @@ Perl_boot_core_builtin(pTHX)
 
     newXS_flags("builtin::import", &XS_builtin_import, __FILE__, NULL, 0);
 
-    inc_hv = GvHVn(PL_incgv);
-    hv_store(inc_hv, "builtin.pm", STRLENs("builtin.pm"), newSVpvs(__FILE__), 0);
-    ver_gv = gv_fetchpvs("builtin::VERSION", GV_ADDMULTI, SVt_PV);
-    ver_sv = GvSV(ver_gv);
+    HV * inc_hv = GvHVn(PL_incgv);
+    hv_stores(inc_hv, "builtin.pm", newSVpvs(__FILE__));
+
+    GV * ver_gv = gv_fetchpvs("builtin::VERSION", GV_ADDMULTI, SVt_PV);
+    SV * ver_sv = GvSV(ver_gv);
     /* Remember to keep $VERSION in this file and $VERSION in builtin.pm synced. */
     sv_setpvs(ver_sv, "0.016");
 }

--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -1,10 +1,16 @@
-package builtin 0.015;
+package builtin 0.016;
 
 use v5.40;
 
 # All code, including &import, is implemented by always-present
-# functions in the perl interpreter itself.
-# See also `builtin.c` in perl source
+# functions in the perl interpreter itself in `builtin.c`.
+#
+# $builtin::VERSION and %INC are also set by the interpreter in `builtin.c`
+# since this file is a NOOP.  Therefore this file is unlikely to ever execute
+# and primarily serves as POD.
+#
+# Remember to keep $VERSION in this file and $VERSION in builtin.c synced!
+
 
 __END__
 

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -645,6 +645,13 @@ EOS
     }
 }
 
+like($INC{'builtin.pm'}, qr/builtin\.c/, 'check that \'builtin.pm\' is in %INC');
+{
+    my $xsv = $builtin::VERSION;
+    delete $INC{'builtin.pm'};
+    eval "use builtin;";
+    is($xsv, $builtin::VERSION, 'XS $VERSION matches PP $VERSION');
+}
 # vim: tabstop=4 shiftwidth=4 expandtab autoindent softtabstop=4
 
 done_testing();

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -123,11 +123,22 @@ XXX Remove this section if F<Porting/corelist-perldelta.pl> did not add any cont
 
 =over 4
 
-=item *
+=item builtin.pm
 
-L<XXX> has been upgraded from version A.xx to B.yy.
+L<builtin.pm|/builtin.pm> has been upgraded from version 0.015 to 0.016.
+As an optimization the C<builtin::> package and module is now fully
+implemented in C to save on file system I/O and startup time.
 
-XXX If there was something important to note about this change, include that here.
+Specifically the C<use builtin;> statement  and any permutations of
+C<use builtin;> will not internally perform a per process first time
+C<require;> anymore and C<$INC{'builtin.pm'}> is already filled in at
+process startup.  All C<.pm> functionality is embedded in the interpreter at
+startup now.  This optimization removes all I/O calls and time overhead of
+parsing the C<builtin.pm> file.  The C<builtin.pm> file will remain as
+documentation.
+
+C<builtin::>'s C<import()>, C<$VERSION>, and all available subroutines/APIs
+have not changed.  No changes are required to previously written code.
 
 =back
 


### PR DESCRIPTION
See commit text.  Embedding modern Perl's near universal .pm'es/pragmas into static XS/C to avoid parsing/IO, is advantageous for all perl CI everywhere. builtin.pm was very easy to do, b/c it already was 99% static XS. And its part of the .pm dep tree of  `-E""`.

-E say is supposed to be shorter to type, but whats the point if it requires typing a  `-I../lib` every time for core hacking.

More philosophically, I want the `-E"say();"` from my first `-e"print();"` many years ago. I only do perl, because I couldn't get the C compiler to ever work, after loaning a big purple C book from my middle school library. Don't know why the book even was there in that library. 

Many decades ago, perl5 was supposed to be a *better* shell script, or batch file. And perl was promised to be a single executable disk binary. Not 100s or 1000s of disk files for the C++ STL/.NET/Node/Java base class libraries, just to do hello world. A *broken* first ever newbie dev perl install that can do atleast `-E"say()"` will maybe keep someone in the perl community. A "features.pm file not found" error, well, that person moves onto another programing language in a few minutes and never looks back at perl.

node.bin is a fat packed pre-compiled pre-jitted ~70 MB single OS binary file with the basic class library burned in (`undump()` sort of). No env var or broken install problems on that platform. The .js files on disk from the installer are only for the JS debugger to use. Node can't be compared to P5, but P5 can atleast knock the low hanging fruit off and embed the basic .pm/pragmas or primary execution paths of them/lazy load pragma .pm'es etc.

-------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
