### PR TITLE
Enable glibc undocumented querylocale()

### DIFF
--- a/intrpvar.h
+++ b/intrpvar.h
@@ -748,18 +748,12 @@ PERLVAR(I, padix_floor,	PADOFFSET)	/* how low may inner block reset padix */
 #if defined(USE_POSIX_2008_LOCALE) && defined(MULTIPLICITY)
 PERLVARI(I, cur_locale_obj, locale_t, NULL)
 #endif
-#ifdef USE_PL_CURLOCALES
 
 /* This is the most number of categories we've encountered so far on any
  * platform, doesn't include LC_ALL */
 PERLVARA(I, curlocales, 12, const char *)
-
-#endif
-#ifdef USE_PL_CUR_LC_ALL
-
 PERLVARI(I, cur_LC_ALL, const char *, NULL)
 
-#endif
 #ifdef USE_LOCALE_COLLATE
 
 /* The emory needed to store the collxfrm transformation of a string with

--- a/makedef.pl
+++ b/makedef.pl
@@ -169,7 +169,11 @@ if ($define{USE_LOCALE_THREADS} && ! $define{NO_THREAD_SAFE_LOCALE})
     }
 }
 
-if ($define{USE_POSIX_2008_LOCALE} && $define{HAS_QUERYLOCALE})
+if (    $define{USE_POSIX_2008_LOCALE}
+    && (   $define{HAS_QUERYLOCALE}
+        || (     $Config{cppsymbols} =~ /__GLIBC__/
+            &&   $define{HAS_NL_LANGINFO_L}
+            && ! $define{SETLOCALE_ACCEPTS_ANY_LOCALE_NAME})))
 {
     $define{USE_QUERYLOCALE} = 1;
 

--- a/perl.h
+++ b/perl.h
@@ -1287,14 +1287,13 @@ violations are fatal.
 #  endif
 
 #  include "perl_langinfo.h"    /* Needed for _NL_LOCALE_NAME */
-
 #  ifdef USE_POSIX_2008_LOCALE
+
 #    if  defined(HAS_QUERYLOCALE)                                           \
               /* Use querylocale if has it, or has the glibc internal       \
-               * undocumented equivalent. */                                \
+               * undocumented equivalent (if not forbidden). */             \
      || (     defined(_NL_LOCALE_NAME)                                      \
-              /* And asked for */                                           \
-         &&   defined(USE_NL_LOCALE_NAME)                                   \
+         && ! defined(NO_USE_NL_LOCALE_NAME)                                \
               /* nl_langinfo_l almost certainly will exist on systems that  \
                * have _NL_LOCALE_NAME, so there is nothing lost by          \
                * requiring it instead of also allowing plain nl_langinfo(). \


### PR DESCRIPTION
This is for maint 5.38.  This code is already effectively in 5.40.

This is querylocale() by another name.  This is required because of GH #21366.

In order to maintain the ABI with previous releases of 5.38, the two symbols PL_curlocales and PL_cur_LC_ALL are now always compiled.  This keeps the structure size the same as before this commit, with the space these occupy now unused.


* This set of changes requires a perldelta entry, and I need help writing it.

