### PR TITLE
makedef.pl: Synchronize with perl.h

### DIFF
--- a/makedef.pl
+++ b/makedef.pl
@@ -177,6 +177,7 @@ if ($define{USE_LOCALE_THREADS} && ! $define{NO_THREAD_SAFE_LOCALE}) {
 if (    $define{USE_POSIX_2008_LOCALE}
     && (   $define{HAS_QUERYLOCALE}
         || (     $Config{cppsymbols} =~ /__GLIBC__/
+            && ! $define{NO_USE_NL_LOCALE_NAME}
             &&   $define{HAS_NL_LANGINFO_L}
             && ! $define{SETLOCALE_ACCEPTS_ANY_LOCALE_NAME})))
 {


### PR DESCRIPTION
There are a couple of places in perl.h that need to be converted to perl and copied to makedef.  It's easy to forget to do this when updating it; and this commit corrects one such omission.


* This set of changes does not require a perldelta entry.
