### PR TITLE
perl_destruct(): improve dtor loop for PL_sv_consts array

### DIFF
--- a/perl.c
+++ b/perl.c
@@ -1350,8 +1350,11 @@ perl_destruct(pTHXx)
 
     /* constant strings */
     for (i = 0; i < SV_CONSTS_COUNT; i++) {
-        SvREFCNT_dec(PL_sv_consts[i]);
-        PL_sv_consts[i] = NULL;
+        SV * sv = PL_sv_consts[i];
+        if(sv) {
+            PL_sv_consts[i] = NULL;
+            SvREFCNT_dec_NN(sv);
+        }
     }
 
     /* Destruct the global string table. */


### PR DESCRIPTION
-don't write a NULL if old value NULL
-do "abs address generation" of "PL_sv_consts[i]" only once, not before
 Perl_sv_free2() func call, and again after Perl_sv_free2(), less machine
 code on some CPU archs/some CCs.
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
