### PR TITLE
hints/linux.sh: use GNUmakefile on case-insensitive file systems (e.g. WSL)

### DIFF
--- a/hints/linux.sh
+++ b/hints/linux.sh
@@ -486,3 +486,10 @@ case "$libdb_needs_pthread" in
     libswanted="$libswanted pthread"
     ;;
 esac
+
+# Detect case-insensitive file systems
+echo X >UU/casesense.tmp
+if test -f UU/CASESENSE.TMP && test -f UU/CaSeSeNsE.tMp; then
+    firstmakefile='GNUmakefile'
+fi
+rm -f UU/casesense.tmp


### PR DESCRIPTION
... because the Windows file system is case insensitive.

See the discussion in #22715.


---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
