### PR TITLE
Perl_sv_setsv_flags - IV/NV & cold code optimisation

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -5811,6 +5811,9 @@ S	|void	|assert_uft8_cache_coherent				\
 				|STRLEN from_cache			\
 				|STRLEN real				\
 				|NN SV * const sv
+S	|void	|croak_sv_setsv_flags					\
+				|NN SV * const dsv			\
+				|NN SV * const ssv
 S	|bool	|curse		|NN SV * const sv			\
 				|const bool check_refcnt
 RS	|STRLEN |expect_number	|NN const char ** const pattern

--- a/embed.h
+++ b/embed.h
@@ -2157,6 +2157,7 @@
 #     define F0convert                          S_F0convert
 #     define anonymise_cv_maybe(a,b)            S_anonymise_cv_maybe(aTHX_ a,b)
 #     define assert_uft8_cache_coherent(a,b,c,d) S_assert_uft8_cache_coherent(aTHX_ a,b,c,d)
+#     define croak_sv_setsv_flags(a,b)          S_croak_sv_setsv_flags(aTHX_ a,b)
 #     define curse(a,b)                         S_curse(aTHX_ a,b)
 #     define expect_number(a)                   S_expect_number(aTHX_ a)
 #     define find_array_subscript(a,b)          S_find_array_subscript(aTHX_ a,b)

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -503,6 +503,19 @@ L<C<valid_identifier_pvn()>|perlapi/valid_identifier_pvn> and
 L<C<valid_identifier_sv()>|perlapi/valid_identifier_sv> have been added, which
 test if a string would be considered by Perl to be a valid identifier name.
 
+=item *
+
+When assigning from an SVt_IV into a SVt_NV (or vice versa), providing that
+both are "bodyless" types, Perl_sv_setsv_flags will now just change the
+destination type to match the source type. Previously, an SVt_IV would have
+been upgraded to a SVt_PVNV to store an NV, and an SVt_NV would have been
+upgraded to a SVt_PVIV to store an IV. This change prevents the need to
+allocate - and later free - the relevant body struct.
+
+=item *
+
+XXX
+
 =back
 
 =head1 Selected Bug Fixes

--- a/proto.h
+++ b/proto.h
@@ -8923,6 +8923,11 @@ S_assert_uft8_cache_coherent(pTHX_ const char * const func, STRLEN from_cache, S
 # define PERL_ARGS_ASSERT_ASSERT_UFT8_CACHE_COHERENT \
         assert(func); assert(sv)
 
+STATIC void
+S_croak_sv_setsv_flags(pTHX_ SV * const dsv, SV * const ssv);
+# define PERL_ARGS_ASSERT_CROAK_SV_SETSV_FLAGS  \
+        assert(dsv); assert(ssv)
+
 STATIC bool
 S_curse(pTHX_ SV * const sv, const bool check_refcnt);
 # define PERL_ARGS_ASSERT_CURSE                 \

--- a/sv.c
+++ b/sv.c
@@ -4201,7 +4201,7 @@ Perl_sv_setsv_flags(pTHX_ SV *dsv, SV* ssv, const I32 flags)
     STATIC_ASSERT_STMT(SVt_IV   == 1);
     STATIC_ASSERT_STMT(SVt_NV   == 2);
 #if NVSIZE <= IVSIZE
-    if (both_type <= 2) {
+    if ((stype <= SVt_NV) & (dtype <= SVt_NV)) {
 #else
     if (both_type <= 1) {
 #endif
@@ -4275,6 +4275,10 @@ Perl_sv_setsv_flags(pTHX_ SV *dsv, SV* ssv, const I32 flags)
         SvREFCNT_dec(old_rv);
         return;
     }
+
+#if NVSIZE <= IVSIZE
+    both_type = (stype | dtype);
+#endif
 
     if (UNLIKELY(both_type == SVTYPEMASK)) {
         if (SvIS_FREED(dsv)) {


### PR DESCRIPTION
`Perl_sv_setsv_flags` is one of the hottest functions in the interpreter,
at least when looking at the coverage from running the test harness.

This PR basically does two things:
* The "fast number" code early in the function now handles one SV being
  an IV and the other a NV, if both are "bodyless" types. This has the
  upshot that an IV will only be upgraded to an NV, not a PVNV, to store
  an NV value. An NV will be downgraded to an IV, not upgraded to a PVIV,
  to store an IV value. This saves having to allocate/free actual bodies.
  
  Having done this, subsequent code paths later in the function are
  rendered completely unreachable and have been excised.
  
  These changes should be transparent to most Perl users, only anyone who
  is actually looking at SV types - presumably in test code - might notice.
  
* The croak-ing code within extremely cold fail-safe code paths has been
  moved out into a helper function. (I'd have put this in cold.c if we
  had one.) This new function need not be optimised.
  
  This change should be entirely transparent.
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.

