### PR TITLE
op.c: Further optimisations of foreach+indexed to apply to LIST as well

### DIFF
--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -2615,6 +2615,10 @@ foreach my ($idx, $elem) (builtin::indexed @arr) {
     die;
 }
 ####
+foreach my ($idx, $elem) (builtin::indexed 'x', 'y', 'z') {
+    die;
+}
+####
 my @ducks;
 foreach my ($tick, $trick, $track) (@ducks) {
     study $_;

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -357,7 +357,7 @@ package FetchStoreCounter {
     }
 
     ok(eq_array(\@output, [qw( [0]=zero [1]=one [2]=two [3]=three [4]=four [5]=five )] ),
-        'foreach + builtin::indexed' );
+        'foreach + builtin::indexed ARRAY' );
 
     undef @output;
 
@@ -368,7 +368,16 @@ package FetchStoreCounter {
     }
 
     ok(eq_array(\@output, [qw( [0]=zero [1]=one [2]=two [3]=three [4]=four [5]=five )] ),
-        'foreach + imported indexed' );
+        'foreach + imported indexed ARRAY' );
+
+    undef @output;
+
+    foreach my ( $idx, $val ) ( builtin::indexed qw( six seven eight nine ) ) {
+        push @output, "[$idx]=$val";
+    }
+
+    ok(eq_array(\@output, [qw( [0]=six [1]=seven [2]=eight [3]=nine )] ),
+        'foreach + builtin::indexed LIST' );
 }
 
 # Vanilla trim tests

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -105,6 +105,30 @@ There may well be none in a stable release.
 
 XXX
 
+=item *
+
+Code that uses the C<indexed> function from the L<builtin> module to generate
+a list of index/value pairs out of an array or list which is then passed into
+a two-variable C<foreach> list to unpack those again is now optimised to be
+more efficient.
+
+    my @array = (...);
+
+    foreach my ($idx, $val) (builtin::indexed @array) {
+        ...
+    }
+
+Z<>
+
+    foreach my ($idx, $val) (builtin::indexed LIST...) {
+        ...
+    }
+
+In particular, a temporary list twice the size of the original is no longer
+generated.  Instead, the loop iterates down the original array or list
+in-place directly, in the same way that C<foreach (@array)> or
+C<foreach (LIST)> would do.
+
 =back
 
 =head1 Modules and Pragmata

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -5031,6 +5031,16 @@ PP(pp_iter)
                 sv = PL_stack_base[ix];
             }
 
+            if (UNLIKELY(pflags & OPpITER_INDEXED) && (i == 0)) {
+                SvREFCNT_dec(*itersvp);
+                /* here ix is really a stack pointer offset; we have to
+                 * calculate the real index */
+                *itersvp = newSViv(ix - cx->blk_loop.state_u.stack.basesp - 1);
+
+                ++i;
+                ++itersvp;
+            }
+
             av = NULL;
             goto loop_ary_common;
 

--- a/t/perf/opcount.t
+++ b/t/perf/opcount.t
@@ -1011,13 +1011,21 @@ test_opcount(0, "Empty anonhash ref and direct lexical assignment",
                     srefgen     => 1,
                 });
 
-test_opcount(0, "foreach 2 lexicals on builtin::indexed",
+test_opcount(0, "foreach 2 lexicals on builtin::indexed ARRAY",
                 sub { my @input = (); foreach my ($i, $x) (builtin::indexed @input) { } },
                 {
                     entersub => 0, # no call to builtin::indexed
                     enteriter => 1,
                     iter => 1,
                     padav => 2,
+                });
+
+test_opcount(0, "foreach 2 lexicals on builtin::indexed LIST",
+                sub { foreach my ($i, $x) (builtin::indexed qw( x y z )) { } },
+                {
+                    entersub => 0, # no call to builtin::indexed
+                    enteriter => 1,
+                    iter => 1,
                 });
 
 done_testing();


### PR DESCRIPTION
This builds on the work of commit a8394b4e8c, expanding it to apply to any `foreach` loop iterating over any kind of list, not just an in-place array.

* This set of changes requires a perldelta entry, and it is included.