### PR TITLE
pp_reverse: don't COW buffer just to then un-COW it

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -6517,10 +6517,10 @@ PP_wrapped(pp_reverse, 0, 1)
             SP = MARK + 1;
             SETs(TARG);
         } else if (SP > MARK) {
-            sv_setsv(TARG, *SP);
+            sv_setsv_flags(TARG, *SP, SV_GMAGIC);
             SETs(TARG);
         } else {
-            sv_setsv(TARG, DEFSV);
+            sv_setsv_flags(TARG, DEFSV, SV_GMAGIC);
             XPUSHs(TARG);
         }
         SvSETMAGIC(TARG); /* remove any utf8 length magic */


### PR DESCRIPTION
When it has a single argument, scaler-mode `pp_reverse` copies the source PV buffer to the destination PV buffer via the `sv_setsv()` macro. This expands to:

        sv_setsv_flags(dsv, ssv, SV_GMAGIC|SV_DO_COW_SVSETSV)

The `SV_DO_COW_SVSETSV` flag means that Perl_sv_setsv_flags will try to achieve the "copy" via these mechanisms:
* Swipe the source buffer (if possible)
* COW the buffer (if possible)
* Copy the buffer

However, using COW makes no sense because pp_reverse is going to then modify the buffer. Almost immediately after the `sv_setsv` call, any COWing will be reversed by the call to `SvPV_force` and a full copy of the buffer taken. So this commit expands the `sv_setsv` call and drops the COW flag.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
