### PR TITLE
DB: fix typo in documentation

### DIFF
--- a/lib/DB.pm
+++ b/lib/DB.pm
@@ -41,7 +41,7 @@ BEGIN {
   $DB::subname = '';    # currently executing sub (fully qualified name)
   $DB::lineno = '';     # current line number
 
-  $DB::VERSION = $DB::VERSION = '1.08';
+  $DB::VERSION = $DB::VERSION = '1.09';
 
   # initialize private globals to avoid warnings
 
@@ -560,7 +560,7 @@ DB - programmatic interface to the Perl debugging API
     CLIENT->done()          # de-register from the debugging API
     CLIENT->skippkg('hide::hide')  # ask DB not to stop in this package
     CLIENT->cont([WHERE])       # run some more (until BREAK or 
-                                # another breakpointt)
+                                # another breakpoint)
     CLIENT->step()              # single step
     CLIENT->next()              # step over
     CLIENT->ret()               # return from current subroutine


### PR DESCRIPTION
Fixes #22732.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
