### PR TITLE
Update perlfunc.pod alerting of month off-by-one trap

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -4249,7 +4249,7 @@ This makes it easy to get a month name from a list:
 
     my @abbr = qw(Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec);
     print "$abbr[$mon] $mday";
-    # $mon=9, $mday=18 gives "Oct 18"
+    # $mon=9, $mday=18 gives "Oct 18" (not "Sep 18"!)
 
 C<$year> contains the number of years since 1900.  To get the full
 year write:


### PR DESCRIPTION
Else users quickly checking the man page will not realize that they are about to make a mistake filling out e.g., a circuit court form.

(What's worse is Sep contains the etymological root for "7", and Oct "8", so users' minds may already be off guard.)