### PR TITLE
fix various typos in C source comments

### DIFF
--- a/gv.c
+++ b/gv.c
@@ -3458,7 +3458,7 @@ and could be used to tell if a given object would stringify to something
 other than the normal default ref stringification.
 
 Note that the fact that this function returns TRUE does not mean you
-can succesfully perform the operation with amagic_call(), for instance
+can successfully perform the operation with amagic_call(), for instance
 any overloaded method might throw a fatal exception,  however if this
 function returns FALSE you can be confident that it will NOT perform
 the given overload operation.

--- a/perl.h
+++ b/perl.h
@@ -1231,12 +1231,12 @@ typedef enum {
  * platform that instead uses positional notation.  By doing this, you can find
  * many bugs without trying it out on a real such platform.  It would be
  * possible to create the reverse definitions for people who have ready access
- * to a posiional notation box, but harder to get a name=value box */
+ * to a positional notation box, but harder to get a name=value box */
 #  if defined(USE_FAKE_LC_ALL_POSITIONAL_NOTATION)            \
    && defined(PERL_LC_ALL_USES_NAME_VALUE_PAIRS)
 #    undef  PERL_LC_ALL_USES_NAME_VALUE_PAIRS
 
-#    define  PERL_LC_ALL_CATEGORY_POSITIONS_INIT /* Assumes glibc cateories */\
+#    define  PERL_LC_ALL_CATEGORY_POSITIONS_INIT /* Assumes glibc categories */\
                                   { 12, 11, 10, 9, 8, 7, 5, 4, 3, 2, 1, 0 }
 #    define  PERL_LC_ALL_SEPARATOR "/ = /"
 #  endif
@@ -5424,7 +5424,7 @@ string.  All you are interested in is the first character of that string.  To
 get uppercase letters (for the values 10..15), add 16 to the index.  Hence,
 C<PL_hexdigit[11]> is C<'b'>, and C<PL_hexdigit[11+16]> is C<'B'>.  Adding 16
 to an index whose representation is '0'..'9' yields the same as not adding 16.
-Indices outside the range 0..31 result in (bad) undedefined behavior.
+Indices outside the range 0..31 result in (bad) undefined behavior.
 
 =cut
 */
@@ -5531,7 +5531,7 @@ EXTCONST  unsigned char PL_fold[] = {
 
 EXTCONST  unsigned char PL_fold_latin1[] = {
     /* Full latin1 complement folding, except for three problematic code points:
-     *	Micro sign (181 = 0xB5) and y with diearesis (255 = 0xFF) have their
+     *	Micro sign (181 = 0xB5) and y with diaeresis (255 = 0xFF) have their
      *	fold complements outside the Latin1 range, so can't match something
      *	that isn't in utf8.
      *	German lower case sharp s (223 = 0xDF) folds to two characters, 'ss',
@@ -7188,7 +7188,7 @@ typedef struct am_table_short AMTS;
  * They require some sort of exclusive lock against similar functions, and a
  * read lock on both the locale and environment.  However, on systems which
  * have per-thread locales, the locale is constant during the execution of
- * these functions, and so no locale lock is necssary.  For such systems, an
+ * these functions, and so no locale lock is necessary.  For such systems, an
  * exclusive ENV lock is necessary and sufficient.  On systems where the locale
  * could change out from under us, we use an exclusive LOCALE lock to prevent
  * that, and a read ENV lock to prevent other threads that have nothing to do
@@ -7276,7 +7276,7 @@ typedef struct am_table_short AMTS;
 #define STRFTIME_LOCK                   ENVr_LOCALEr_LOCK
 #define STRFTIME_UNLOCK                 ENVr_LOCALEr_UNLOCK
 
-/* These time-related functions all requre that the environment and locale
+/* These time-related functions all require that the environment and locale
  * don't change while they are executing (at least in glibc; this appears to be
  * contrary to the POSIX standard).  tzset() writes global variables, so
  * always needs to have write locking.  ctime, localtime, mktime, and strftime
@@ -7312,7 +7312,7 @@ typedef struct am_table_short AMTS;
 #define TZSET_LOCK         gwENVr_LOCALEr_LOCK
 #define TZSET_UNLOCK       gwENVr_LOCALEr_UNLOCK
 
-/* Similiarly, these functions need a constant environment and/or locale.  And
+/* Similarly, these functions need a constant environment and/or locale.  And
  * some have a buffer that is shared with another thread executing the same or
  * a related call.  A mutex could be created for each class, but for now, share
  * the ENV mutex with everything, as none probably gets called so much that
@@ -9174,7 +9174,7 @@ END_EXTERN_C
 
 #endif /* DOUBLE_HAS_NAN */
 
-/* these are used to faciliate the env var PERL_RAND_SEED,
+/* these are used to facilitate the env var PERL_RAND_SEED,
  * which allows consistent behavior from code that calls
  * srand() with no arguments, either explicitly or implicitly.
  */

--- a/pod/perldebguts.pod
+++ b/pod/perldebguts.pod
@@ -596,8 +596,8 @@ will be lost.
                              defined by current locale
  NBOUNDU          no         Match "" at any non-boundary of a given
                              type using /u rules.
- NBOUNDA          no         Match "" betweeen any \w\w or \W\W, where
-                             \w is [_a-zA-Z0-9]
+ NBOUNDA          no         Match "" between any \w\w or \W\W, where \w
+                             is [_a-zA-Z0-9]
 
  # [Special] alternatives:
  REG_ANY          no         Match any one character (except newline).

--- a/regcomp.sym
+++ b/regcomp.sym
@@ -78,7 +78,7 @@ BOUNDA      BOUND,      no        ; Match "" at any boundary between \w\W or \W\
 NBOUND      NBOUND,     no        ; Like NBOUNDA for non-utf8, otherwise like BOUNDU
 NBOUNDL     NBOUND,     no        ; Like NBOUND/NBOUNDU, but \w and \W are defined by current locale
 NBOUNDU     NBOUND,     no        ; Match "" at any non-boundary of a given type using /u rules.
-NBOUNDA     NBOUND,     no        ; Match "" betweeen any \w\w or \W\W, where \w is [_a-zA-Z0-9]
+NBOUNDA     NBOUND,     no        ; Match "" between any \w\w or \W\W, where \w is [_a-zA-Z0-9]
 
 #* [Special] alternatives:
 REG_ANY     REG_ANY,    no 0 S    ; Match any one character (except newline).
@@ -108,7 +108,7 @@ ANYOFRb     ANYOFR,     packed 1  S ; Like ANYOFR, but all matches share the sam
 # operations.  (We don't have to compare the final byte as it has to be
 # different or else this wouldn't be a range.)  So we might as well dispense
 # with the comparisons that ANYOFRs would do, and go directly to do the
-# conversion .
+# conversion.
 
 ANYOFHbbm   ANYOFHbbm   none bbm S ; Like ANYOFHb, but only for 2-byte UTF-8 characters; uses a bitmap to match the continuation byte
 

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -148,7 +148,7 @@ struct RExC_state_t {
     int         code_index;             /* next code_blocks[] slot */
     struct reg_code_blocks *code_blocks;/* positions of literal (?{})
                                             within pattern */
-    SSize_t     maxlen;                        /* mininum possible number of chars in string to match */
+    SSize_t     maxlen;                        /* minimum possible number of chars in string to match */
     scan_frame *frame_head;
     scan_frame *frame_last;
     U32         frame_count;
@@ -430,7 +430,7 @@ struct RExC_state_t {
 #define TRYAGAIN        0x10    /* Weeded out a declaration. */
 #define RESTART_PARSE   0x20    /* Need to redo the parse */
 #define NEED_UTF8       0x40    /* In conjunction with RESTART_PARSE, need to
-                                   calcuate sizes as UTF-8 */
+                                   calculate sizes as UTF-8 */
 
 #define REG_NODE_NUM(x) ((x) ? (int)((x)-RExC_emit_start) : -1)
 
@@ -563,7 +563,7 @@ struct RExC_state_t {
                  _invlist_intersection_maybe_complement_2nd(a, b, TRUE, output)
 
 /* We add a marker if we are deferring expansion of a property that is both
- * 1) potentiallly user-defined; and
+ * 1) potentially user-defined; and
  * 2) could also be an official Unicode property.
  *
  * Without this marker, any deferred expansion can only be for a user-defined

--- a/regnodes.h
+++ b/regnodes.h
@@ -298,7 +298,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define NBOUNDU_t8_pb                      58  /*      0x03a */
 #define NBOUNDU_t8_p8                      59  /*      0x03b */
 
-#define NBOUNDA                      15        /* 0x0f Match "" betweeen any
+#define NBOUNDA                      15        /* 0x0f Match "" between any
                                                   \w\w or \W\W, where \w is
                                                   [_a-zA-Z0-9] */
 #define NBOUNDA_tb                      30     /*      0x01e */

--- a/scope.c
+++ b/scope.c
@@ -1894,10 +1894,10 @@ the code reference.
 
 When operating in a C callback mode the C<args> parameter will be passed
 directly to the C function as a C<void *> pointer. No additional
-processing of the argument will be peformed, and it is the callers
+processing of the argument will be performed, and it is the callers
 responsibility to free the C<args> parameter if necessary.
 
-Be aware that there is a signficant difference in timing between the
+Be aware that there is a significant difference in timing between the
 I<end of the current statement> and the I<end of the current pseudo
 block>. If you are looking for a mechanism to trigger a function at the
 end of the B<current pseudo block> you should look at
@@ -1910,7 +1910,7 @@ B<end of the current statement> with the arguments provided. It is a
 wrapper around C<mortal_destructor_sv()> which ensures that the latter
 function is called appropriately.
 
-Be aware that there is a signficant difference in timing between the
+Be aware that there is a significant difference in timing between the
 I<end of the current statement> and the I<end of the current pseudo
 block>. If you are looking for a mechanism to trigger a function at the
 end of the B<current pseudo block> you should look at
@@ -1920,7 +1920,7 @@ L<perlapi/C<SAVEDESTRUCTOR_X>> instead of this function.
 
 This function is called via magic to implement the
 C<mortal_destructor_sv()> and C<mortal_destructor_x()> functions. It
-should not be called directly and has no user servicable parts.
+should not be called directly and has no user serviceable parts.
 
 =cut
 */


### PR DESCRIPTION
Fixes #22741, #22739, #22736.

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
