### PR TITLE
fix typos in various perl*.pod documents

### DIFF
--- a/pod/perl5260delta.pod
+++ b/pod/perl5260delta.pod
@@ -2828,7 +2828,7 @@ L<[GH #15606]|https://github.com/Perl/perl5/issues/15606>
 
 =item *
 
-Avoid a heap-after-use error in the parser when creating an error messge
+Avoid a heap-after-use error in the parser when creating an error message
 for a syntactically invalid heredoc.
 L<[GH #15527]|https://github.com/Perl/perl5/issues/15527>
 

--- a/pod/perl5340delta.pod
+++ b/pod/perl5340delta.pod
@@ -1207,7 +1207,7 @@ hashref of optimization data discovered about a compiled regexp.
 
 The C<PERL_GLOBAL_STRUCT> compilation option has been removed, and
 with it the need or the C<dVAR> macro.  C<dVAR> remains defined as a
-no-op outside C<PERL_CORE> for backwards compatiblity with XS modules.
+no-op outside C<PERL_CORE> for backwards compatibility with XS modules.
 
 =item *
 

--- a/pod/perl5360delta.pod
+++ b/pod/perl5360delta.pod
@@ -1178,7 +1178,7 @@ PERL_IMPLICIT_CONTEXT will remain defined for compatibility with XS modules.
 =item *
 
 The API constant formerly named C<G_ARRAY>, indicating list context, has now
-been renamed to a more accurate C<G_LIST>.  A compatibilty macro C<G_ARRAY> has
+been renamed to a more accurate C<G_LIST>.  A compatibility macro C<G_ARRAY> has
 been added to allow existing code to work unaffected.  New code should be
 written using the new constant instead.  This is supported by C<Devel::PPPort>
 version 3.63.
@@ -1476,7 +1476,7 @@ could cause a memory write to a freed C<dbstate> op.
 =item *
 
 When bareword filehandles are disabled, the parser was interpreting
-any bareword as a filehandle, even when immediatey followed by parens.
+any bareword as a filehandle, even when immediately followed by parens.
 
 =back
 

--- a/pod/perl5380delta.pod
+++ b/pod/perl5380delta.pod
@@ -216,7 +216,7 @@ have a constant target label, and that label is found within the block.
 
 =head2 New regexp variable ${^LAST_SUCCESSFUL_PATTERN}
 
-This allows access to the last succesful pattern that matched in the current
+This allows access to the last successful pattern that matched in the current
 scope.  Many aspects of the regex engine refer to the "last successful
 pattern". The empty pattern reuses it, and all of the magic regex vars relate
 to it. This allows access to its pattern. The following code
@@ -1428,7 +1428,7 @@ account.
 
 Removed C<< Complex regular subexpression recursion limit (%d) exceeded >>
 
-The regular expresion engine has not used recursion in some time. This
+The regular expression engine has not used recursion in some time. This
 warning no longer makes sense.
 
 See [L<GH #19636|https://github.com/Perl/perl5/pull/19636>].

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -6984,7 +6984,7 @@ enough to figure out what you really meant.
 =item Unexpected characters while parsing class :isa attribute: %s
 
 (F) You tried to specify something other than a single class name with an
-optional trailing verison number as the value for a C<class> C<:isa>
+optional trailing version number as the value for a C<class> C<:isa>
 attribute.  This confused the parser.
 
 =item Unexpected exit %u
@@ -7044,7 +7044,7 @@ the only way to do that in Perl is to mark it as serious.
 
 (F) A Unicode property wildcard looks like a delimited regular
 expression pattern (all within the braces of the enclosing C<\p{...}>.
-The closing delimtter to match the opening one was not found.  If the
+The closing delimiter to match the opening one was not found.  If the
 opening one is escaped by preceding it with a backslash, the closing one
 must also be so escaped.
 
@@ -7710,7 +7710,7 @@ only C.  This usually means there's a better way to do it in Perl.
 a starting delimiter of a string outside the scope of
 S<C<use feature 'extra_paired_delimiters'>>. This character is the
 mirror image of another Unicode character; within the scope of that
-feature, the two are considered a pair for delimitting strings. It is
+feature, the two are considered a pair for delimiting strings. It is
 planned to make that feature the default, at which point this usage
 would become illegal; hence this warning.
 
@@ -7734,7 +7734,7 @@ subpatterns in regex; marked by S<<-- HERE> in m/%s/
 (F) You were using a wildcard subpattern a Unicode property value, and
 the subpattern contained something that is illegal.  Not all regular
 expression capabilities are legal in such subpatterns, and this is one.
-Rewrite your subppattern to not use the offending construct.
+Rewrite your subpattern to not use the offending construct.
 See L<perlunicode/Wildcards in Property Values>.
 
 =item Use of -l on filehandle%s

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -1001,7 +1001,7 @@ confusion.
 Also avoid C<bless>ing things into the class name C<0>; this
 will cause code which (erroneously) checks the result of
 L<C<ref>|/ref EXPR> to see if a reference is C<bless>ed to fail,
-as "0", a falsy value, is returned.
+as "0", a false value, is returned.
 
 See L<perlmod/"Perl Modules"> for more details.
 
@@ -3582,7 +3582,7 @@ is used as a C<while>/C<for> condition, then the condition actually
 tests for definedness of the expression's value, not for its regular
 truth value.
 
-Internal implemenation details:
+Internal implementation details:
 
 This is the internal function implementing the C<< <*.c> >> operator,
 but you can use it directly. The C<< <*.c> >> operator is discussed in

--- a/pod/perllocale.pod
+++ b/pod/perllocale.pod
@@ -1104,7 +1104,7 @@ to crack.
 
 See also C<CRNCYSTR> in L<I18N::Langinfo>.
 
-=head2 Category C<LC_TIME>: Respresentation of time
+=head2 Category C<LC_TIME>: Representation of time
 
 Output produced by C<POSIX::strftime()>, which builds a formatted
 human-readable date/time string, is affected by the current C<LC_TIME>
@@ -1251,7 +1251,7 @@ C<LC_CTYPE> is in effect, and the subpattern
 regular expression contains a locale-dependent construct.  These
 constructs include C<\w> (to match an alphanumeric character), C<\W>
 (non-alphanumeric character), C<\b> and C<\B> (word-boundary and
-non-boundardy, which depend on what C<\w> and C<\W> match), C<\s>
+non-boundary, which depend on what C<\w> and C<\W> match), C<\s>
 (whitespace character), C<\S> (non whitespace character), C<\d> and
 C<\D> (digits and non-digits), and the POSIX character classes, such as
 C<[:alpha:]> (see L<perlrecharclass/POSIX Character Classes>).

--- a/pod/perlperf.pod
+++ b/pod/perlperf.pod
@@ -167,7 +167,7 @@ it managed to execute an average of 628,930 times a second during our test, the
 direct approach managed to run an additional 204,403 times, unfortunately.
 Unfortunately, because there are many examples of code written using the
 multiple layer direct variable access, and it's usually horrible.  It is,
-however, minusculy faster.  The question remains whether the minute gain is
+however, minusculely faster.  The question remains whether the minute gain is
 actually worth the eyestrain, or the loss of maintainability.
 
 =head2  Search and replace or tr
@@ -198,7 +198,7 @@ noticing it's assigned only the once.
 
  my $STR = "$$-this and that";
 
- timethese( 1000000, {
+ timethese(1000000, {
  'sr'  => sub { my $str = $STR; $str =~ s/[aeiou]/x/g; return $str; },
  'tr'  => sub { my $str = $STR; $str =~ tr/aeiou/xxxxx/; return $str; },
  });

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -812,7 +812,7 @@ In order to make it easy to perform an action with shared state both
 before and after the require keyword was executed the C<require__before>
 hook may return a "post-action" coderef which will in turn be executed when
 the C<require> completes.  This coderef will be executed regardless as to
-whether the require completed succesfully or threw an exception.  It will
+whether the require completed successfully or threw an exception.  It will
 be called with the filename that was required.  You can check %INC to
 determine if the require was successful.  Any other return from the
 C<require__before> hook will be silently ignored.


### PR DESCRIPTION
Fixes #22735.
Fixes #22734.

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
