### PR TITLE
utf8n_to_uvchr():  Simplify and fix some overlongs edge cases 

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -1601,6 +1601,15 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
                      * the overflow handling code */
         && LIKELY(! (possible_problems & UTF8_GOT_OVERFLOW)))
     {
+        /* By examining just the first byte, we can see if this is using
+         * non-standard UTF-8.  Even if it is an overlong that reduces to a
+         * small code point, it is still using this Perl invention, so mark it
+         * as such */
+        if (UNLIKELY(UTF8_IS_PERL_EXTENDED(s0))) {
+            possible_problems |= UTF8_GOT_SUPER;
+        }
+        else {
+            /* See if the input has malformations besides possibly overlong */
             if (UNLIKELY(possible_problems & ~UTF8_GOT_LONG)) {
 
             /* Here, there is a malformation other than overlong, we need to
@@ -1646,6 +1655,7 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
                     possible_problems |= UTF8_GOT_NONCHAR;
                 }
             }
+        }
     }
 
   ready_to_handle_errors:

--- a/utf8.c
+++ b/utf8.c
@@ -1593,19 +1593,18 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
     /* Here, we have found all the possible problems, except for when the input
      * is for a problematic code point not allowed by the input parameters.
      * Check now for those parameters */
-    if (flags & ( UTF8_DISALLOW_ILLEGAL_INTERCHANGE
-                 |UTF8_WARN_ILLEGAL_INTERCHANGE))
+    if (   flags & ( UTF8_DISALLOW_ILLEGAL_INTERCHANGE
+                    |UTF8_WARN_ILLEGAL_INTERCHANGE)
+
+                    /* if overflow, we know without looking further that this
+                     * is a non-Unicode code point, which we deal with below in
+                     * the overflow handling code */
+        && LIKELY(! (possible_problems & UTF8_GOT_OVERFLOW)))
     {
                                 /* uv is valid for overlongs */
         if (   (      LIKELY(! (possible_problems & ~UTF8_GOT_LONG))
                    && isUNICODE_POSSIBLY_PROBLEMATIC(uv))
             || (   UNLIKELY(possible_problems)
-
-                          /* if overflow, we know without looking further
-                           * precisely which of the problematic types it is,
-                           * and we deal with those in the overflow handling
-                           * code */
-                && LIKELY(! (possible_problems & UTF8_GOT_OVERFLOW))
                 && (   isUTF8_POSSIBLY_PROBLEMATIC(*adjusted_s0)
                     || UNLIKELY(UTF8_IS_PERL_EXTENDED(s0)))))
         {

--- a/utf8.c
+++ b/utf8.c
@@ -1459,6 +1459,10 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
     expectlen = UTF8SKIP(s);
     uv = *s;
 
+    /* This is a helper function; invariants should have been handled before
+     * calling it */
+    assert(! NATIVE_BYTE_IS_INVARIANT(*s0));
+
     /* A well-formed UTF-8 character, as the vast majority of calls to this
      * function will be for, has this expected length.  For efficiency, set
      * things up here to return it.  It will be overridden only in those rare

--- a/utf8.c
+++ b/utf8.c
@@ -1601,16 +1601,11 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
                      * the overflow handling code */
         && LIKELY(! (possible_problems & UTF8_GOT_OVERFLOW)))
     {
-                                /* uv is valid for overlongs */
-        if (   (      LIKELY(! (possible_problems & ~UTF8_GOT_LONG))
-                   && isUNICODE_POSSIBLY_PROBLEMATIC(uv))
-            || (   UNLIKELY(possible_problems)
-                && (   isUTF8_POSSIBLY_PROBLEMATIC(*adjusted_s0)
-                    || UNLIKELY(UTF8_IS_PERL_EXTENDED(s0)))))
-        {
         /* If there were no malformations, or the only malformation is an
          * overlong, 'uv' is valid */
-        if (LIKELY(! (possible_problems & ~UTF8_GOT_LONG))) {
+        if (   LIKELY(! (possible_problems & ~UTF8_GOT_LONG))
+            && isUNICODE_POSSIBLY_PROBLEMATIC(uv))
+        {
             if (UNLIKELY(UNICODE_IS_SURROGATE(uv))) {
                 possible_problems |= UTF8_GOT_SURROGATE;
             }
@@ -1621,9 +1616,12 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
                 possible_problems |= UTF8_GOT_NONCHAR;
             }
         }
-        else {  /* Otherwise, need to look at the source UTF-8, possibly
-                   adjusted to be non-overlong */
-
+        else if (   UNLIKELY(possible_problems)
+                        /* Otherwise, need to look at the source UTF-8,
+                         * possibly adjusted to be non-overlong */
+                 && (   isUTF8_POSSIBLY_PROBLEMATIC(*adjusted_s0)
+                     || UNLIKELY(UTF8_IS_PERL_EXTENDED(s0))))
+        {
             if (UNLIKELY(NATIVE_UTF8_TO_I8(*adjusted_s0)
                                                     > UTF_START_BYTE_110000_))
             {
@@ -1644,7 +1642,6 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
 
             /* We need a complete well-formed UTF-8 character to discern
              * non-characters, so can't look for them here */
-        }
         }
     }
 

--- a/utf8.c
+++ b/utf8.c
@@ -1591,10 +1591,12 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
     }
 
     /* Here, we have found all the possible problems, except for when the input
-     * is for a problematic code point not allowed by the input parameters. */
-
+     * is for a problematic code point not allowed by the input parameters.
+     * Check now for those parameters */
+    if (   (flags & ( UTF8_DISALLOW_ILLEGAL_INTERCHANGE
+                     |UTF8_WARN_ILLEGAL_INTERCHANGE))
                                 /* uv is valid for overlongs */
-    if (   (   (      LIKELY(! (possible_problems & ~UTF8_GOT_LONG))
+        && (   (      LIKELY(! (possible_problems & ~UTF8_GOT_LONG))
                    && isUNICODE_POSSIBLY_PROBLEMATIC(uv))
             || (   UNLIKELY(possible_problems)
 
@@ -1604,9 +1606,7 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
                            * code */
                 && LIKELY(! (possible_problems & UTF8_GOT_OVERFLOW))
                 && (   isUTF8_POSSIBLY_PROBLEMATIC(*adjusted_s0)
-                    || UNLIKELY(UTF8_IS_PERL_EXTENDED(s0)))))
-        && ((flags & ( UTF8_DISALLOW_ILLEGAL_INTERCHANGE
-                      |UTF8_WARN_ILLEGAL_INTERCHANGE))))
+                    || UNLIKELY(UTF8_IS_PERL_EXTENDED(s0))))))
     {
         /* If there were no malformations, or the only malformation is an
          * overlong, 'uv' is valid */

--- a/utf8.c
+++ b/utf8.c
@@ -1526,7 +1526,7 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
      * separate.
      *
      * A convenience macro that matches either of the too-short conditions.  */
-#   define UTF8_GOT_TOO_SHORT (UTF8_GOT_SHORT|UTF8_GOT_NON_CONTINUATION)
+#define UTF8_GOT_TOO_SHORT (UTF8_GOT_SHORT|UTF8_GOT_NON_CONTINUATION)
 
     /* Check for overflow.  The algorithm requires us to not look past the end
      * of the current character, even if partial, so the upper limit is 's' */
@@ -1538,8 +1538,8 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
      * point value.  Simply see if it is expressible in fewer bytes.  Otherwise
      * we must look at the UTF-8 byte sequence itself to see if it is for an
      * overlong */
-    if (     (   LIKELY(! possible_problems)
-              && UNLIKELY(expectlen > (STRLEN) OFFUNISKIP(uv)))
+    if (   (   LIKELY(! possible_problems)
+            && UNLIKELY(expectlen > (STRLEN) OFFUNISKIP(uv)))
         || (       UNLIKELY(possible_problems)
             && (   UNLIKELY(! UTF8_IS_START(*s0))
                 || (UNLIKELY(0 < is_utf8_overlong(s0, s - s0))))))

--- a/utf8.c
+++ b/utf8.c
@@ -1593,10 +1593,11 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
     /* Here, we have found all the possible problems, except for when the input
      * is for a problematic code point not allowed by the input parameters.
      * Check now for those parameters */
-    if (   (flags & ( UTF8_DISALLOW_ILLEGAL_INTERCHANGE
-                     |UTF8_WARN_ILLEGAL_INTERCHANGE))
+    if (flags & ( UTF8_DISALLOW_ILLEGAL_INTERCHANGE
+                 |UTF8_WARN_ILLEGAL_INTERCHANGE))
+    {
                                 /* uv is valid for overlongs */
-        && (   (      LIKELY(! (possible_problems & ~UTF8_GOT_LONG))
+        if (   (      LIKELY(! (possible_problems & ~UTF8_GOT_LONG))
                    && isUNICODE_POSSIBLY_PROBLEMATIC(uv))
             || (   UNLIKELY(possible_problems)
 
@@ -1606,8 +1607,8 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
                            * code */
                 && LIKELY(! (possible_problems & UTF8_GOT_OVERFLOW))
                 && (   isUTF8_POSSIBLY_PROBLEMATIC(*adjusted_s0)
-                    || UNLIKELY(UTF8_IS_PERL_EXTENDED(s0))))))
-    {
+                    || UNLIKELY(UTF8_IS_PERL_EXTENDED(s0)))))
+        {
         /* If there were no malformations, or the only malformation is an
          * overlong, 'uv' is valid */
         if (LIKELY(! (possible_problems & ~UTF8_GOT_LONG))) {
@@ -1644,6 +1645,7 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
 
             /* We need a complete well-formed UTF-8 character to discern
              * non-characters, so can't look for them here */
+        }
         }
     }
 

--- a/utf8.c
+++ b/utf8.c
@@ -1605,14 +1605,8 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
                 && LIKELY(! (possible_problems & UTF8_GOT_OVERFLOW))
                 && (   isUTF8_POSSIBLY_PROBLEMATIC(*adjusted_s0)
                     || UNLIKELY(UTF8_IS_PERL_EXTENDED(s0)))))
-        && ((flags & ( UTF8_DISALLOW_NONCHAR
-                      |UTF8_DISALLOW_SURROGATE
-                      |UTF8_DISALLOW_SUPER
-                      |UTF8_DISALLOW_PERL_EXTENDED
-                      |UTF8_WARN_NONCHAR
-                      |UTF8_WARN_SURROGATE
-                      |UTF8_WARN_SUPER
-                      |UTF8_WARN_PERL_EXTENDED))))
+        && ((flags & ( UTF8_DISALLOW_ILLEGAL_INTERCHANGE
+                      |UTF8_WARN_ILLEGAL_INTERCHANGE))))
     {
         /* If there were no malformations, or the only malformation is an
          * overlong, 'uv' is valid */

--- a/utf8.c
+++ b/utf8.c
@@ -1456,8 +1456,7 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
     }
 
     /* We now know we can examine the first byte of the input */
-    expectlen = UTF8SKIP(s);
-    uv = *s;
+    expectlen = UTF8SKIP(s0);
 
     /* This is a helper function; invariants should have been handled before
      * calling it */
@@ -1472,7 +1471,7 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
     }
 
     /* A continuation character can't start a valid sequence */
-    if (UNLIKELY(UTF8_IS_CONTINUATION(uv))) {
+    if (UNLIKELY(UTF8_IS_CONTINUATION(*s0))) {
         possible_problems |= UTF8_GOT_CONTINUATION;
         curlen = 1;
         uv = UNICODE_REPLACEMENT;
@@ -1487,7 +1486,7 @@ Perl__utf8n_to_uvchr_msgs_helper(const U8 *s,
     /* Convert to I8 on EBCDIC (no-op on ASCII), then remove the leading bits
      * that indicate the number of bytes in the character's whole UTF-8
      * sequence, leaving just the bits that are part of the value.  */
-    uv = NATIVE_UTF8_TO_I8(uv) & UTF_START_MASK(expectlen);
+    uv = NATIVE_UTF8_TO_I8(*s0) & UTF_START_MASK(expectlen);
 
     /* Setup the loop end point, making sure to not look past the end of the
      * input string, and flag it as too short if the size isn't big enough. */


### PR DESCRIPTION
This commits came about from my reading the code, and doing more rigorous testing (the commits for which are WIP) that revealed some corner case issues with handling overlong sequences and ones that overflow the platform's word size.  The changes here address the overlong ones.  Current test cases do not catch these obscure bugs; those will come in later pull requests.

* This set of changes may require a perldelta entry, but it is premature
