### PR TITLE
New OP_TYPE_IS_COP_NN() macro

### DIFF
--- a/gv.c
+++ b/gv.c
@@ -504,8 +504,7 @@ Perl_gv_init_pvn(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, U32 flag
     isGV_with_GP_on(gv);
 
     if (really_sub && !CvISXSUB(has_constant) && CvSTART(has_constant)
-     && (  CvSTART(has_constant)->op_type == OP_NEXTSTATE
-        || CvSTART(has_constant)->op_type == OP_DBSTATE))
+     && (OP_TYPE_IS_COP_NN(CvSTART(has_constant))))
         PL_curcop = (COP *)CvSTART(has_constant);
     GvGP_set(gv, Perl_newGP(aTHX_ gv));
     PL_curcop = old;

--- a/op.c
+++ b/op.c
@@ -2136,8 +2136,7 @@ Perl_scalarvoid(pTHX_ OP *arg)
         const char* useless = NULL;
         OP * next_kid = NULL;
 
-        if (o->op_type == OP_NEXTSTATE
-            || o->op_type == OP_DBSTATE
+        if (OP_TYPE_IS_COP_NN(o)
             || (o->op_type == OP_NULL && (o->op_targ == OP_NEXTSTATE
                                           || o->op_targ == OP_DBSTATE)))
             PL_curcop = (COP*)o;                /* for warning below */
@@ -4516,13 +4515,12 @@ Perl_op_scope(pTHX_ OP *o)
             OP *kid;
             OpTYPE_set(o, OP_SCOPE);
             kid = cLISTOPo->op_first;
-            if (kid->op_type == OP_NEXTSTATE || kid->op_type == OP_DBSTATE) {
+            if (OP_TYPE_IS_COP_NN(kid)) {
                 op_null(kid);
 
                 /* The following deals with things like 'do {1 for 1}' */
                 kid = OpSIBLING(kid);
-                if (kid &&
-                    (kid->op_type == OP_NEXTSTATE || kid->op_type == OP_DBSTATE))
+                if (kid && OP_TYPE_IS_COP_NN(kid))
                     op_null(kid);
             }
         }
@@ -4538,7 +4536,7 @@ Perl_op_unscope(pTHX_ OP *o)
     if (o && o->op_type == OP_LINESEQ) {
         OP *kid = cLISTOPo->op_first;
         for(; kid; kid = OpSIBLING(kid))
-            if (kid->op_type == OP_NEXTSTATE || kid->op_type == OP_DBSTATE)
+            if (OP_TYPE_IS_COP_NN(kid))
                 op_null(kid);
     }
     return o;

--- a/op.h
+++ b/op.h
@@ -1080,6 +1080,9 @@ C<sib> is non-null. For a higher-level interface, see C<L</op_sibling_splice>>.
 #define OP_TYPE_ISNT_AND_WASNT(o, type) \
     ( (o) && OP_TYPE_ISNT_AND_WASNT_NN(o, type) )
 
+#define OP_TYPE_IS_COP_NN(o) \
+    (OP_TYPE_IS_NN(o, OP_NEXTSTATE) || OP_TYPE_IS_NN(o, OP_DBSTATE))
+
 /* should match anything that uses ck_ftst in regen/opcodes */
 #define OP_IS_STAT(op) (OP_IS_FILETEST(op) || (op) == OP_LSTAT || (op) == OP_STAT)
 

--- a/peep.c
+++ b/peep.c
@@ -1253,9 +1253,7 @@ S_finalize_op(pTHX_ OP* o)
         case OP_EXEC:
             if (OpHAS_SIBLING(o)) {
                 OP *sib = OpSIBLING(o);
-                if ((  sib->op_type == OP_NEXTSTATE || sib->op_type == OP_DBSTATE)
-                    && ckWARN(WARN_EXEC)
-                    && OpHAS_SIBLING(sib))
+                if (OP_TYPE_IS_COP_NN(sib) && ckWARN(WARN_EXEC) && OpHAS_SIBLING(sib))
                 {
                     const OPCODE type = OpSIBLING(sib)->op_type;
                     if (type != OP_EXIT && type != OP_WARN && type != OP_DIE) {
@@ -3343,8 +3341,7 @@ Perl_rpeep(pTHX_ OP *o)
                     ) {
                         U8 old_count;
                         assert(oldoldop->op_next == oldop);
-                        assert(   oldop->op_type == OP_NEXTSTATE
-                               || oldop->op_type == OP_DBSTATE);
+                        assert(OP_TYPE_IS_COP_NN(oldop));
                         assert(oldop->op_next == o);
 
                         old_count
@@ -3379,8 +3376,7 @@ Perl_rpeep(pTHX_ OP *o)
                             && (p->op_private & OPpLVAL_INTRO) == intro
                             && !(p->op_private & ~OPpLVAL_INTRO)
                             && p->op_next
-                            && (   p->op_next->op_type == OP_NEXTSTATE
-                                || p->op_next->op_type == OP_DBSTATE)
+                            && OP_TYPE_IS_COP_NN(p->op_next)
                             && count < OPpPADRANGE_COUNTMASK
                             && base + count == p->op_targ
                     ) {

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -3034,7 +3034,7 @@ S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstac
         OP * const kid1 = cUNOPo->op_first;
         /* First try all the kids at this level, since that's likeliest. */
         for (kid = cUNOPo->op_first; kid; kid = OpSIBLING(kid)) {
-            if (kid->op_type == OP_NEXTSTATE || kid->op_type == OP_DBSTATE) {
+            if (OP_TYPE_IS_COP_NN(kid)) {
                 STRLEN kid_label_len;
                 U32 kid_label_flags;
                 const char *kid_label = CopLABEL_len_flags(kCOP,
@@ -3057,7 +3057,7 @@ S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstac
             bool first_kid_of_binary = FALSE;
             if (kid == PL_lastgotoprobe)
                 continue;
-            if (kid->op_type == OP_NEXTSTATE || kid->op_type == OP_DBSTATE) {
+            if (OP_TYPE_IS_COP_NN(kid)) {
                 if (ops == opstack)
                     *ops++ = kid;
                 else if (ops[-1] != UNENTERABLE

--- a/regexec.c
+++ b/regexec.c
@@ -8317,8 +8317,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                     }
 
                     if (o->op_type != OP_STUB) {
-                        assert(    o->op_type == OP_NEXTSTATE
-                                || o->op_type == OP_DBSTATE
+                        assert(OP_TYPE_IS_COP_NN(o)
                                 || (o->op_type == OP_NULL
                                     &&  (  o->op_targ == OP_NEXTSTATE
                                         || o->op_targ == OP_DBSTATE


### PR DESCRIPTION
I'm doing a lot of hackery in peep.c and op.c, and on occasions need to detect if an op is OP_NEXTSTATE (or OP_DBSTATE). Basically, almost any time you care about OP_NEXTSTATE you need to also check for OP_DBSTATE as well, so it's a lot easier to avoid mistakes if you just have a macro that checks for either.

There's some leftover code in a few places that still checks for `->op_type == OP_NEXTSTATE` directly without also caring about OP_DBSTATE and honestly I don't know if those are bugs. But with this macro in place, it's easier to find those now.

* This set of changes does not require a perldelta entry.