### PR TITLE
S_newONCEOP: Rejig the op_next padop (Closes #18630)

### DIFF
--- a/ext/B/t/optree_varinit.t
+++ b/ext/B/t/optree_varinit.t
@@ -406,7 +406,7 @@ checkOptree ( name	=> 'void context state',
 # 4      <$> const[IV 1] s
 # 5      <1> padsv_store[$x:2,3] vKS/LVINTRO,STATE
 #            goto 6
-# 8  <0> padsv[$x:2,3] vRM*/STATE
+# 8  <0> padsv[$x:2,3] v/STATE
 # 6  <;> nextstate(main 3 -e:1) v:%,{,fea=15
 # 7  <@> leave[1 ref] vKP/REFC
 EOT_EOT
@@ -416,7 +416,7 @@ EOT_EOT
 # 4      <$> const(IV 1) s
 # 5      <1> padsv_store[$x:2,3] vKS/LVINTRO,STATE
 #            goto 6
-# 8  <0> padsv[$x:2,3] vRM*/STATE
+# 8  <0> padsv[$x:2,3] v/STATE
 # 6  <;> nextstate(main 3 -e:1) v:%,{,fea=15
 # 7  <@> leave[1 ref] vKP/REFC
 EONT_EONT
@@ -433,7 +433,7 @@ checkOptree ( name	=> 'scalar context state',
 # 5      <0> padsv[$x:2,3] sRM*/LVINTRO,STATE
 # 6      <2> sassign sKS/2
 #            goto 7
-# a  <0> padsv[$x:2,3] sRM*/STATE
+# a  <0> padsv[$x:2,3] s/STATE
 # 7  <1> padsv_store[$y:2,3] vKS/LVINTRO
 # 8  <;> nextstate(main 3 -e:1) v:%,{,fea=15
 # 9  <@> leave[1 ref] vKP/REFC
@@ -445,7 +445,7 @@ EOT_EOT
 # 5      <0> padsv[$x:2,3] sRM*/LVINTRO,STATE
 # 6      <2> sassign sKS/2
 #            goto 7
-# a  <0> padsv[$x:2,3] sRM*/STATE
+# a  <0> padsv[$x:2,3] s/STATE
 # 7  <1> padsv_store[$y:2,3] vKS/LVINTRO
 # 8  <;> nextstate(main 3 -e:1) v:%,{,fea=15
 # 9  <@> leave[1 ref] vKP/REFC

--- a/ext/B/t/optree_varinit.t
+++ b/ext/B/t/optree_varinit.t
@@ -405,8 +405,6 @@ checkOptree ( name	=> 'void context state',
 # 3  <|> once(other->4)[$:2,3] vK/1
 # 4      <$> const[IV 1] s
 # 5      <1> padsv_store[$x:2,3] vKS/LVINTRO,STATE
-#            goto 6
-# 8  <0> padsv[$x:2,3] v/STATE
 # 6  <;> nextstate(main 3 -e:1) v:%,{,fea=15
 # 7  <@> leave[1 ref] vKP/REFC
 EOT_EOT
@@ -415,8 +413,6 @@ EOT_EOT
 # 3  <|> once(other->4)[$:2,3] vK/1
 # 4      <$> const(IV 1) s
 # 5      <1> padsv_store[$x:2,3] vKS/LVINTRO,STATE
-#            goto 6
-# 8  <0> padsv[$x:2,3] v/STATE
 # 6  <;> nextstate(main 3 -e:1) v:%,{,fea=15
 # 7  <@> leave[1 ref] vKP/REFC
 EONT_EONT
@@ -433,7 +429,7 @@ checkOptree ( name	=> 'scalar context state',
 # 5      <0> padsv[$x:2,3] sRM*/LVINTRO,STATE
 # 6      <2> sassign sKS/2
 #            goto 7
-# a  <0> padsv[$x:2,3] s/STATE
+# a  <0> padsv[$x:2,3] s
 # 7  <1> padsv_store[$y:2,3] vKS/LVINTRO
 # 8  <;> nextstate(main 3 -e:1) v:%,{,fea=15
 # 9  <@> leave[1 ref] vKP/REFC
@@ -445,7 +441,7 @@ EOT_EOT
 # 5      <0> padsv[$x:2,3] sRM*/LVINTRO,STATE
 # 6      <2> sassign sKS/2
 #            goto 7
-# a  <0> padsv[$x:2,3] s/STATE
+# a  <0> padsv[$x:2,3] s
 # 7  <1> padsv_store[$y:2,3] vKS/LVINTRO
 # 8  <;> nextstate(main 3 -e:1) v:%,{,fea=15
 # 9  <@> leave[1 ref] vKP/REFC

--- a/op.c
+++ b/op.c
@@ -8596,18 +8596,18 @@ static OP *
 S_newONCEOP(pTHX_ OP *initop, OP *padop)
 {
     const PADOFFSET target = padop->op_targ;
-    OP *const other = newOP(OP_PADSV,
-                            padop->op_flags
+    OP *const nexop = newOP(padop->op_type,
+                            (padop->op_flags & ~(OPf_REF|OPf_MOD|OPf_SPECIAL))
                             | ((padop->op_private & ~OPpLVAL_INTRO) << 8));
     OP *const first = newOP(OP_NULL, 0);
-    OP *const nullop = newCONDOP(0, first, initop, other);
+    OP *const nullop = newCONDOP(0, first, initop, nexop);
     /* XXX targlex disabled for now; see ticket #124160
-        newCONDOP(0, first, S_maybe_targlex(aTHX_ initop), other);
+        newCONDOP(0, first, S_maybe_targlex(aTHX_ initop), nexop);
      */
     OP *const condop = first->op_next;
 
     OpTYPE_set(condop, OP_ONCE);
-    other->op_targ = target;
+    nexop->op_targ = target;
 
     /* Store the initializedness of state vars in a separate
        pad entry.  */

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -366,7 +366,9 @@ manager will later use a regex to expand these into links.
 
 =item *
 
-XXX
+Declaring a lexically scoped array or hash using C<state> within a subroutine
+and then immediately returning no longer triggers a "Bizarre copy of HASH/ARRAY
+in subroutine exit" error. [GH #18630]
 
 =back
 

--- a/t/op/state.t
+++ b/t/op/state.t
@@ -9,7 +9,7 @@ BEGIN {
 
 use strict;
 
-plan tests => 164;
+plan tests => 166;
 
 # Before loading feature.pm, test it with CORE::
 ok eval 'CORE::state $x = 1;', 'CORE::state outside of feature.pm scope';
@@ -509,10 +509,12 @@ for (1,2) {
     sub gh_18630H {state %h=(a=>1)}
     my $res = join '', gh_18630H, gh_18630H;
     is($res, "a1a1", 'HASH copied successfully in subroutine exit');
+    is(scalar gh_18630H, 1, 'gh_18630H scalar call returns key count');
 
     sub gh_18630A {state @a = qw(b 2)}
     $res = join '', gh_18630A , gh_18630A;
     is($res, "b2b2", 'ARRAY copied successfully in subroutine exit');
+    is(scalar gh_18630A, 2, 'gh_18630A scalar call returns element count');
 }
 
 __DATA__

--- a/t/op/state.t
+++ b/t/op/state.t
@@ -9,7 +9,7 @@ BEGIN {
 
 use strict;
 
-plan tests => 162;
+plan tests => 164;
 
 # Before loading feature.pm, test it with CORE::
 ok eval 'CORE::state $x = 1;', 'CORE::state outside of feature.pm scope';
@@ -504,7 +504,16 @@ for (1,2) {
         or diag "got these warnings:\n@warnings";
 }
 
+#  [GH #18630] Returning state hash-assign risks "Bizarre copy of HASH in subroutine exit"
+{
+    sub gh_18630H {state %h=(a=>1)}
+    my $res = join '', gh_18630H, gh_18630H;
+    is($res, "a1a1", 'HASH copied successfully in subroutine exit');
 
+    sub gh_18630A {state @a = qw(b 2)}
+    $res = join '', gh_18630A , gh_18630A;
+    is($res, "b2b2", 'ARRAY copied successfully in subroutine exit');
+}
 
 __DATA__
 (state $a) = 1;


### PR DESCRIPTION
Two related changes pertaining to the padop executed when an OP_ONCE is encountered for the nth time.

* _S_newONCEOP_: correctly copy array/hash at subroutine exit 
Should a _state_ array or hash be declared immediately prior to
returning, the error `Bizarre copy of HASH in subroutine exit` error
would be triggered. Now, the array or hash is returned without error.
Closes #18630

* _S_newONCEOP_/_Perl_scalarvoid_: skip over padops uselss in void context
Rejigs how the nth-time padop is handled in void context to avoid the
warning "Useless use of private variable in void context". The OPf_STATE
flag is removed and the op_next chain now explicitly skips the padop.

---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
