### PR TITLE
class.c: Define a :writer attribute, applicable to scalar fields only

### DIFF
--- a/pod/perlclass.pod
+++ b/pod/perlclass.pod
@@ -260,6 +260,33 @@ context.
 
     scalar $instance->users;
 
+=head3 :writer
+
+A field with a C<:writer> attribute will generate a writer accessor method
+automatically.  The generated method will have a signature that consumes
+exactly one argument, and its body will assign that scalar argument to the
+field, and return the invocant object itself.
+
+    field $s :writer;
+
+    # Equivalent to
+    field $s;
+    method set_s($new) { $s = $new; return $self; }
+
+By default the accessor method will have the name of the field minus the
+leading sigil with the string C<set_> prefixed to it, but a different name
+can be specified in the attribute's value.
+
+    field $x :writer(write_x);
+
+    # Generates a method
+    method write_x ($new) { ... }
+
+Curerently, writer accessors can only be applied to scalar fields.  Attempts
+to apply this attribute to a non-scalar field will result in a fatal exception
+at compile-time.  This may be relaxed in a future version to allow writers on
+array or hash fields.  For now, these will have to be created manually.
+
 =head2 Method attributes
 
 None yet.

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -27,6 +27,20 @@ here, but most should go in the L</Performance Enhancements> section.
 
 [ List each enhancement as a =head2 entry ]
 
+=head2 New C<:writer> attribute on field variables
+
+Classes defined using C<use feature 'class'> are now able to automatically
+create writer accessors for scalar fields, by using the C<:writer> attribute,
+similar to the way that C<:reader> already creates reader accessors.
+
+    class Point {
+        field $x :reader :writer :param;
+        field $y :reader :writer :param;
+    }
+
+    my $p = Point->new( x => 20, y => 40 );
+    $p->set_x(60);
+
 =head1 Security
 
 XXX Any security-related notices go here. In particular, any security

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -699,6 +699,13 @@ checking.  Alternatively, if you are certain that you're calling the
 function correctly, you may put an ampersand before the name to avoid
 the warning.  See L<perlsub>.
 
+=item Cannot apply a :writer attribute to a non-scalar field
+
+(F) An attempt was made to use the C<:writer> attribute on a field that is
+not a scalar (i.e. an array or hash).  At the present version, these are only
+permitted on scalar fields.  You will have to manually create a writer
+accessor method yourself.
+
 =item Cannot assign :param(%s) to field %s because that name is already in use
 
 (F) An attempt was made to apply a parameter name to a field, when the name

--- a/t/class/accessor.t
+++ b/t/class/accessor.t
@@ -37,17 +37,42 @@ no warnings 'experimental::class';
         'Failure from argument to accessor');
 }
 
-# Alternative names
+# writer accessors on scalars
 {
     class Testcase2 {
-        field $f :reader(get_f) = "value";
+        field $s :reader :writer = "initial";
     }
 
-    is(Testcase2->new->get_f, "value", 'accessor with altered name');
+    my $o = Testcase2->new;
+    is($o->s, "initial", '$o->s accessor before modification');
+    is($o->set_s("new-value"), $o, '$o->set_s accessor returns instance');
+    is($o->s, "new-value", '$o->s accessor after modification');
 
-    ok(!eval { Testcase2->new->f },
+    # Write accessor wants exactly one argument
+    ok(!eval { $o->set_s() },
+        'Reader accessor fails with no argument');
+    like($@, qr/^Too few arguments for subroutine \'Testcase2::set_s\' \(got 0; expected 1\) at /,
+        'Failure from argument to accessor');
+    ok(!eval { $o->set_s(1, 2) },
+        'Reader accessor fails with 2 arguments');
+    like($@, qr/^Too many arguments for subroutine \'Testcase2::set_s\' \(got 2; expected 1\) at /,
+        'Failure from argument to accessor');
+}
+
+# Alternative names
+{
+    class Testcase3 {
+        field $f :reader(get_f) :writer(write_f) = "value";
+    }
+
+    is(Testcase3->new->get_f, "value",
+        'read accessor with altered name');
+    ok(Testcase3->new->write_f("new"),
+        'write accessor with altered name');
+
+    ok(!eval { Testcase3->new->f },
        'Accessor with altered name does not also generate original name');
-    like($@, qr/^Can't locate object method "f" via package "Testcase2" at /,
+    like($@, qr/^Can't locate object method "f" via package "Testcase3" at /,
        'Failure from lack of original name accessor');
 }
 

--- a/t/lib/croak/class
+++ b/t/lib/croak/class
@@ -165,3 +165,23 @@ class XXX {
 }
 EXPECT
 "abc-def" is not a valid name for a generated method at - line 6.
+########
+# Invalid method name for :writer attribute
+use v5.36;
+use feature 'class';
+no warnings 'experimental::class';
+class XXX {
+  field $x :writer(set-abc-def);
+}
+EXPECT
+"set-abc-def" is not a valid name for a generated method at - line 6.
+########
+# Writer on non-scalar field
+use v5.36;
+use feature 'class';
+no warnings 'experimental::class';
+class XXX {
+  field @things :writer;
+}
+EXPECT
+Cannot apply a :writer attribute to a non-scalar field at - line 6.


### PR DESCRIPTION
Permits automatic creation of writer accessor methods, in addition to the reader ones we already had.

---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.