### PR TITLE
perlpodspec: Note that "=item *" has nothing else

### DIFF
--- a/pod/perlpodspec.pod
+++ b/pod/perlpodspec.pod
@@ -1425,9 +1425,9 @@ Each "=over" ... "=back" region should be one of the following:
 
 =item *
 
-An "=over" ... "=back" region containing only "=item *" commands,
-each followed by some number of ordinary/verbatim paragraphs, other
-nested "=over" ... "=back" regions, "=for..." paragraphs, and
+An "=over" ... "=back" region containing only C<m/\A=item\s+\*\s*\z/>
+commands, each followed by some number of ordinary/verbatim paragraphs,
+other nested "=over" ... "=back" regions, "=for..." paragraphs, and
 "=begin"..."=end" regions.
 
 (Pod processors must tolerate a bare "=item" as if it were "=item

--- a/t/porting/podcheck.t
+++ b/t/porting/podcheck.t
@@ -1105,7 +1105,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         my $addr = refaddr $self;
 
         $in_NAME{$addr} = 1 if $running_simple_text{$addr} eq 'NAME';
-        return $self->SUPER::end_head(@_);
+        return $self->SUPER::end_head1(@_);
     }
 
     sub start_Verbatim {

--- a/t/porting/podcheck.t
+++ b/t/porting/podcheck.t
@@ -1086,14 +1086,21 @@ package My::Pod::Checker {      # Extend Pod::Checker
         $self->SUPER::end_Para(@_);
     }
 
+    sub start_head {
+        my $self = shift;
+        my $addr = refaddr $self;
+        $running_CFL_text{$addr} = "";
+        $running_simple_text{$addr} = "";
+
+        return $self->SUPER::start_head(@_);
+    }
+
     sub start_head1 {
         my $self = shift;
         check_see_but_not_link($self);
 
         my $addr = refaddr $self;
         $start_line{$addr} = $_[0]->{start_line};
-        $running_CFL_text{$addr} = "";
-        $running_simple_text{$addr} = "";
 
         return $self->SUPER::start_head1(@_);
     }

--- a/t/porting/podcheck.t
+++ b/t/porting/podcheck.t
@@ -1765,6 +1765,7 @@ sub is_pod_file {
                     $checker->name($name);
                     $id_to_checker{$name} = $checker
                         if $filename =~ m{^cpan/};
+                    $valid_modules{$name} = 1;
                 }
             }
             elsif ($filename =~ m{^cpan/}) {

--- a/t/porting/podcheck.t
+++ b/t/porting/podcheck.t
@@ -924,7 +924,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         return $self->SUPER::start_Para(@_);
     }
 
-    sub start_item {
+    sub start_item {    # Pod::Checker has no corresponding method
         my $self = shift;
         check_see_but_not_link($self);
 
@@ -2061,7 +2061,7 @@ foreach my $filename (@files) {
 
 # Here, all files have been parsed, and all links and link targets are stored.
 # Now go through the files again and see which don't have matches.
-if (! $has_input_files) {
+if (! $has_input_files) {   # No xref unless processing all files
     foreach my $filename (@files) {
         next if $filename_to_checker{$filename}->get_skip;
 


### PR DESCRIPTION
`=item * foo bar`

is not supposed to be a bullet list; it is a text (definition) list whose first character is an asterisk.  This commit makes it explicit that a bullet list contains only asterisk characters on the =item lines

This is implied later on in the existing documentation where it says that

>  The "=item [text]" paragraph should not match
 C<m/\A=item\s+\d+\.?\s*\z/> or C<m/\A=item\s+\*\s*\z/>, nor should it
 match just C<m/\A=item\s*\z/>.

The text already says numbered lists must match
`<m/\A=item\s+\d+\.?\s*\z/`.  This commit adapts that text to the bullet list case.

* This set of changes does not require a perldelta entry.
