### PR TITLE
podcheck.t: Fix multiple link targets bug

### DIFF
--- a/t/porting/podcheck.t
+++ b/t/porting/podcheck.t
@@ -1105,7 +1105,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         my $addr = refaddr $self;
 
         $in_NAME{$addr} = 1 if $running_simple_text{$addr} eq 'NAME';
-        return $self->SUPER::end_head(@_);
+        return $self->SUPER::end_head1(@_);
     }
 
     sub start_Verbatim {

--- a/t/porting/podcheck.t
+++ b/t/porting/podcheck.t
@@ -1086,14 +1086,21 @@ package My::Pod::Checker {      # Extend Pod::Checker
         $self->SUPER::end_Para(@_);
     }
 
+    sub start_head {
+        my $self = shift;
+        my $addr = refaddr $self;
+        $running_CFL_text{$addr} = "";
+        $running_simple_text{$addr} = "";
+
+        return $self->SUPER::start_head(@_);
+    }
+
     sub start_head1 {
         my $self = shift;
         check_see_but_not_link($self);
 
         my $addr = refaddr $self;
         $start_line{$addr} = $_[0]->{start_line};
-        $running_CFL_text{$addr} = "";
-        $running_simple_text{$addr} = "";
 
         return $self->SUPER::start_head1(@_);
     }

--- a/t/porting/podcheck.t
+++ b/t/porting/podcheck.t
@@ -1765,6 +1765,7 @@ sub is_pod_file {
                     $checker->name($name);
                     $id_to_checker{$name} = $checker
                         if $filename =~ m{^cpan/};
+                    $valid_modules{$name} = 1;
                 }
             }
             elsif ($filename =~ m{^cpan/}) {

--- a/t/porting/podcheck.t
+++ b/t/porting/podcheck.t
@@ -924,7 +924,7 @@ package My::Pod::Checker {      # Extend Pod::Checker
         return $self->SUPER::start_Para(@_);
     }
 
-    sub start_item {
+    sub start_item {    # Pod::Checker has no corresponding method
         my $self = shift;
         check_see_but_not_link($self);
 
@@ -2061,7 +2061,7 @@ foreach my $filename (@files) {
 
 # Here, all files have been parsed, and all links and link targets are stored.
 # Now go through the files again and see which don't have matches.
-if (! $has_input_files) {
+if (! $has_input_files) {   # No xref unless processing all files
     foreach my $filename (@files) {
         next if $filename_to_checker{$filename}->get_skip;
 


### PR DESCRIPTION

podcheck.t would wrongly warn about duplicate link targets.  It is
ambiguous if you have, say

 =head1 foo
 ...
 =item foo

and then try to create a link to 'foo'.  Which 'foo' should it go to?
So podcheck looks for such ambiguous links.  However, it was incorrectly
warning on

 =head1 foo
 ...
 =item * foo

 The latter is a bullet list, which is not an appropriate link target.
 The logic was flawed in the node() method, when it encountered the
 second foo, it didn't realize it was for a bullet list, and pushed it
 onto a list which caused the count to be larger than 1, which caused it
 later to think there were two link targets with the same name.

 The solution here is to instead note that linkable targets are only in
 =headN or definition lists.  The acquisition of the names of them are
 moved to the methods that get called upon the termination of each of
 these by the parsing routines.  The count is incremented at that point.
 This means the node() method extension no longer does anything useful
 and is removed; as well as an auxiliary field, linkable_item.  We no
 longer need to distinguish between =headN and =item.

* This set of changes does not require a perldelta entry.
