### PR TITLE
toke.c: minor adjustment of #ifdef to stop confusing code editors

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -9394,11 +9394,11 @@ yyl_try(pTHX_ char *s)
         }
         if (PL_expect == XBLOCK) {
             const char *t = s;
-#ifdef PERL_STRICT_CR
-            while (SPACE_OR_TAB(*t))
-#else
-            while (SPACE_OR_TAB(*t) || *t == '\r')
+            while (SPACE_OR_TAB(*t)
+#ifndef PERL_STRICT_CR
+                    || *t == '\r'
 #endif
+            )
                 t++;
             if (*t == '\n' || *t == '#') {
                 ENTER_with_name("lex_format");


### PR DESCRIPTION
Quite possibly the stupidest PR I've ever had to raise. It makes no change to the compiled output behaviour. It isn't even a change for the benefit of human readers. This change is here purely to stop confusing static analysis and code editing tools.

Before this change, the two separate `while` statements would upset the code folding as parsed by tree-sitter-c (and likely many others, I haven't tested), into thinking this was two nested loops. Having failed to find the end of both of them before the end of the function, various confusions result, usually ending up in the entire rest of the file (and it's a long file) getting folded into one giant region. This likely causes various static analysis tools similarly to not see any of the subsequent functions in the file.

By adjusting the code so that just the condition part is inside the `#ifdef`, it means that code parsing tools have a much easier time working out the high-level structure of this file.

* This set of changes does not require a perldelta entry.
