### PR TITLE
remove PERL_STRICT_CR

### DIFF
--- a/perl.c
+++ b/perl.c
@@ -2231,9 +2231,7 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
       reswitch:
         switch ((c = *s)) {
         case 'C':
-#ifndef PERL_STRICT_CR
         case '\r':
-#endif
         case ' ':
         case '0':
         case 'F':
@@ -3955,9 +3953,7 @@ Perl_moreswitches(pTHX_ const char *s)
         break;
     case '-':
     case 0:
-#if defined(WIN32) || !defined(PERL_STRICT_CR)
     case '\r':
-#endif
     case '\n':
     case '\t':
         break;

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -256,6 +256,20 @@ L</Platform Support> section, instead.
 
 XXX
 
+=item *
+
+The (mostly undocumented) configuration macro C<PERL_STRICT_CR> has been
+removed. When enabled (e.g. with C<./Configure -A ccflags=-DPERL_STRICT_CR>),
+it would make the perl parser throw a fatal error when it encountered a CR
+(carriage return) character in source files. The default (and now only)
+behavior of the perl parser is to strip CRs paired with newline characters and
+otherwise treat them as whitespace.
+
+(C<PERL_STRICT_CR> was originally introduced in perl 5.005 to optionally
+restore backward compatibility with perl 5.004, which had made CR in source
+files an error. Before that, CR was accepted, but retained literally in quoted
+multi-line constructs such as here-documents, even at the end of a line.)
+
 =back
 
 =head1 Testing

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2889,14 +2889,6 @@ declaration.  The '_' in a prototype must be followed by a ';',
 indicating the rest of the parameters are optional, or one of '@'
 or '%', since those two will accept 0 or more final parameters.
 
-=item Illegal character \%o (carriage return)
-
-(F) Perl normally treats carriage returns in the program text as
-it would any other whitespace, which means you should never see
-this error when Perl was built using standard options.  For some
-reason, your version of Perl appears to have been built without
-this support.  Talk to your Perl administrator.
-
 =item Illegal character following sigil in a subroutine signature
 
 (F) A parameter in a subroutine signature contained an unexpected character

--- a/t/porting/diag.t
+++ b/t/porting/diag.t
@@ -740,9 +740,6 @@ Wrong syntax (suid) fd script name "%s"
 
 __CATEGORIES__
 
-# This is a warning, but is currently followed immediately by a croak (toke.c)
-Illegal character \%o (carriage return)
-
 # Because uses WARN_MISSING as a synonym for WARN_UNINITIALIZED (sv.c)
 Missing argument in %s
 


### PR DESCRIPTION
Background:
-----------

Before perl 5.004, the perl parser would skip over CR (carriage return) between tokens in source files, treating it as whitespace, but would retain CRs in quoted constructs such as multi-line strings and here-documents.

In 5.004, the behavior was changed to make CR in source files a fatal error ("Illegal character %s (carriage return)") to avoid surprises with unexpected literal CRs in string constants when scripts were copied from DOS/Windows without newline conversion.

In 5.005, the behavior changed again. Now CR was back to being ignored, but harder: Even in quoted constructs, CR was ignored when immediately followed by a newline. However, the 5.004 behavior could be restored by compiling perl with the `PERL_STRICT_CR` macro defined (e.g. with `./Configure -A ccflags=-DPERL_STRICT_CR ...`). This option was undocumented except for a brief note in perl5005delta. (Also, the "Illegal character ..." error was changed to a warning, but perldiag wasn't updated and so still listed the message as "fatal" (F).)

And that's how things have been ever since 1998.

Foreground:
-----------

This patch removes all checks for PERL_STRICT_CR entirely, treating it as always off.

Rationale: It simplifies the code and reduces clutter. (Plus I don't see the need to perpetually maintain an undocumented configuration option that enables compatibility with an ancient perl version used sometime around 1997-1998.)

References:
-----------

- 4fdae80067 ("Make \r in script an error (per Larry)")
- ff0cee690d ("Fix carriage-return message")
- 54310121b4 ("Improve diagnostic on \r in program text")
- 2db4f57cd9
- f63a84b229
- 637e912262
- b8957cf14d
- 6a27c1886b

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
