### PR TITLE
class.c: Complain if :reader attribute is asked to create a method with an invalid name

### DIFF
--- a/class.c
+++ b/class.c
@@ -979,6 +979,9 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
         /* Default to name minus the sigil */
         value = newSVpvn_utf8(PadnamePV(pn) + 1, PadnameLEN(pn) - 1, PadnameUTF8(pn));
 
+    if(!valid_identifier_sv(value))
+        croak("%" SVf_QUOTEDPREFIX " is not a valid name for a generated method", value);
+
     PADOFFSET fieldix = PadnameFIELDINFO(pn)->fieldix;
 
     I32 floor_ix = start_subparse(FALSE, 0);

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -3499,6 +3499,13 @@ should use the printf/sprintf functions instead.
 overload::constant needs to be a code reference.  Either
 an anonymous subroutine, or a reference to a subroutine.
 
+=item "%s" is not a valid name for a generated method
+
+(F) A custom method name was passed to an attribute on a field, such as
+C<:reader>, which creates a new method.  These generated methods must have
+valid names, but the value given to the attribute would result in an
+invalid name.
+
 =item '%s' is not an overloadable type
 
 (W overload) You tried to overload a constant type the overload package is

--- a/t/lib/croak/class
+++ b/t/lib/croak/class
@@ -155,3 +155,13 @@ class C { BEGIN { C->new; } };
 EXPECT
 Cannot create an object of incomplete class "C" at - line 4.
 BEGIN failed--compilation aborted at - line 4.
+########
+# Invalid method name for :reader attribute
+use v5.36;
+use feature 'class';
+no warnings 'experimental::class';
+class XXX {
+  field $x :reader(abc-def);
+}
+EXPECT
+"abc-def" is not a valid name for a generated method at - line 6.


### PR DESCRIPTION
As per subject.

I don't feel this is big enough to warrant a perldelta.