### PR TITLE
uvoffuni_to_utf8_flags_msgs(): Return proper bit

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3760,6 +3760,17 @@ Cp	|U8 *	|uvoffuni_to_utf8_flags_msgs				\
 				|UV input_uv				\
 				|const UV flags 			\
 				|NULLOK HV **msgs
+
+Admp	|U8 *	|uv_to_utf8	|NN U8 *d				\
+				|UV uv
+Admp	|U8 *	|uv_to_utf8_flags					\
+				|NN U8 *d				\
+				|UV uv					\
+				|UV flags
+Admp	|U8 *	|uv_to_utf8_msgs|NN U8 *d				\
+				|UV uv					\
+				|UV flags				\
+				|NULLOK HV **msgs
 CDbp	|U8 *	|uvuni_to_utf8	|NN U8 *d				\
 				|UV uv
 EXdpx	|bool	|validate_proto |NN SV *name				\

--- a/embed.h
+++ b/embed.h
@@ -861,6 +861,9 @@
 # define utf8_to_bytes(a,b)                     Perl_utf8_to_bytes(aTHX_ a,b)
 # define utf8_to_uvchr_buf_helper(a,b,c)        Perl_utf8_to_uvchr_buf_helper(aTHX_ a,b,c)
 # define utf8n_to_uvchr_msgs                    Perl_utf8n_to_uvchr_msgs
+# define uv_to_utf8(a,b)                        Perl_uv_to_utf8(aTHX,a,b)
+# define uv_to_utf8_flags(a,b,c)                Perl_uv_to_utf8_flags(aTHX,a,b,c)
+# define uv_to_utf8_msgs(a,b,c,d)               Perl_uv_to_utf8_msgs(aTHX,a,b,c,d)
 # define uvchr_to_utf8(a,b)                     Perl_uvchr_to_utf8(aTHX,a,b)
 # define uvchr_to_utf8_flags(a,b,c)             Perl_uvchr_to_utf8_flags(aTHX,a,b,c)
 # define uvchr_to_utf8_flags_msgs(a,b,c,d)      Perl_uvchr_to_utf8_flags_msgs(aTHX,a,b,c,d)

--- a/proto.h
+++ b/proto.h
@@ -5372,6 +5372,15 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
         assert(idop)
 
 /* PERL_CALLCONV U8 *
+Perl_uv_to_utf8(pTHX_ U8 *d, UV uv); */
+
+/* PERL_CALLCONV U8 *
+Perl_uv_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags); */
+
+/* PERL_CALLCONV U8 *
+Perl_uv_to_utf8_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs); */
+
+/* PERL_CALLCONV U8 *
 Perl_uvchr_to_utf8(pTHX_ U8 *d, UV uv); */
 
 /* PERL_CALLCONV U8 *

--- a/utf8.c
+++ b/utf8.c
@@ -234,7 +234,9 @@ Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, UV flags, HV** msgs)
             if (msgs) {
                 *msgs = new_msg_hv(Perl_form(aTHX_ format, input_uv),
                                    category,
-                                   UNICODE_GOT_PERL_EXTENDED);
+                                   (flags & UNICODE_WARN_PERL_EXTENDED)
+                                   ? UNICODE_GOT_PERL_EXTENDED
+                                   : UNICODE_GOT_SUPER);
             }
             else {
                 Perl_ck_warner_d(aTHX_ category, format, input_uv);

--- a/utf8.h
+++ b/utf8.h
@@ -142,12 +142,17 @@ typedef enum {
 #define uvoffuni_to_utf8_flags(d,uv,flags)                                     \
                                uvoffuni_to_utf8_flags_msgs(d, uv, flags, 0)
 
-#define Perl_uvchr_to_utf8(mTHX, d, u)                                          \
-        Perl_uvchr_to_utf8_flags(aTHX, d, u, 0)
-#define Perl_uvchr_to_utf8_flags(mTHX, d, u, f)                                 \
-        Perl_uvchr_to_utf8_flags_msgs(aTHX, d, u, f, 0)
-#define Perl_uvchr_to_utf8_flags_msgs(mTHX, d, u, f , m)                        \
+#define Perl_uv_to_utf8(mTHX, d, u)                                         \
+        Perl_uv_to_utf8_flags(aTHX, d, u, 0)
+#define Perl_uv_to_utf8_flags(mTHX, d, u, f)                                \
+        Perl_uv_to_utf8_msgs(aTHX, d, u, f, 0)
+#define Perl_uv_to_utf8_msgs(mTHX, d, u, f , m)                             \
         Perl_uvoffuni_to_utf8_flags_msgs(aTHX_ d, NATIVE_TO_UNI(u), f, m)
+
+#define Perl_uvchr_to_utf8              Perl_uv_to_utf8
+#define Perl_uvchr_to_utf8_flags        Perl_uv_to_utf8_flags
+#define Perl_uvchr_to_utf8_flags_msgs   Perl_uv_to_utf8_msgs
+
 #define utf8_to_uvchr_buf(s, e, lenp)                                           \
             utf8_to_uvchr_buf_helper((const U8 *) (s), (const U8 *) e, lenp)
 #define utf8n_to_uvchr(s, len, lenp, flags)                                    \


### PR DESCRIPTION
More rigorous testing, yet to be committed, showed that this was returning the wrong bit in some circumstances.  It is supposed to return the bit corresponding to the most restrictive flag that is passed as input to the function

* This set of changes does not require a perldelta entry.
