### PR TITLE
uvoffuni_to_utf8_flags_msgs(): Return proper bit

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -234,7 +234,9 @@ Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, UV flags, HV** msgs)
             if (msgs) {
                 *msgs = new_msg_hv(Perl_form(aTHX_ format, input_uv),
                                    category,
-                                   UNICODE_GOT_PERL_EXTENDED);
+                                   (flags & UNICODE_WARN_PERL_EXTENDED)
+                                   ? UNICODE_GOT_PERL_EXTENDED
+                                   : UNICODE_GOT_SUPER);
             }
             else {
                 Perl_ck_warner_d(aTHX_ category, format, input_uv);


### PR DESCRIPTION
This replaces #22779, which I accidentally closed, and could not reopen

More rigorous testing, yet to be committed, showed that this was returning the wrong bit in some circumstances.  It is supposed to return the bit corresponding to the most restrictive flag that is passed as input to the function


* This set of changes does not require a perldelta entry.
