### PR TITLE
toke.c: remove PERL_CR_FILTER

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -5956,12 +5956,6 @@ Sf	|void	|printbuf	|NN const char * const fmt		\
 S	|int	|tokereport	|I32 rv 				\
 				|NN const YYSTYPE *lvalp
 # endif
-# if defined(PERL_CR_FILTER)
-S	|I32	|cr_textfilter	|int idx				\
-				|NULLOK SV *sv				\
-				|int maxlen
-S	|void	|strip_return	|NN SV *sv
-# endif
 # if !defined(PERL_NO_UTF16_FILTER)
 S	|U8 *	|add_utf16_textfilter					\
 				|NN U8 * const s			\

--- a/embed.h
+++ b/embed.h
@@ -1726,10 +1726,6 @@
 #       define printbuf(a,b)                    S_printbuf(aTHX_ a,b)
 #       define tokereport(a,b)                  S_tokereport(aTHX_ a,b)
 #     endif
-#     if defined(PERL_CR_FILTER)
-#       define cr_textfilter(a,b,c)             S_cr_textfilter(aTHX_ a,b,c)
-#       define strip_return(a)                  S_strip_return(aTHX_ a)
-#     endif
 #     if !defined(PERL_NO_UTF16_FILTER)
 #       define add_utf16_textfilter(a,b)        S_add_utf16_textfilter(aTHX_ a,b)
 #       define utf16_textfilter(a,b,c)          S_utf16_textfilter(aTHX_ a,b,c)

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -284,6 +284,12 @@ restore backward compatibility with perl 5.004, which had made CR in source
 files an error. Before that, CR was accepted, but retained literally in quoted
 multi-line constructs such as here-documents, even at the end of a line.)
 
+=item *
+
+Similarly, the (even less documented) configuration macro C<PERL_CR_FILTER> has
+been removed. When enabled, it would install a default source filter to strip
+carriage returns from source code before the parser proper got to see it.
+
 =back
 
 =head1 Testing

--- a/proto.h
+++ b/proto.h
@@ -9284,17 +9284,6 @@ S_tokereport(pTHX_ I32 rv, const YYSTYPE *lvalp);
         assert(lvalp)
 
 # endif /* defined(DEBUGGING) */
-# if defined(PERL_CR_FILTER)
-STATIC I32
-S_cr_textfilter(pTHX_ int idx, SV *sv, int maxlen);
-#   define PERL_ARGS_ASSERT_CR_TEXTFILTER
-
-STATIC void
-S_strip_return(pTHX_ SV *sv);
-#   define PERL_ARGS_ASSERT_STRIP_RETURN        \
-        assert(sv)
-
-# endif /* defined(PERL_CR_FILTER) */
 # if !defined(PERL_NO_UTF16_FILTER)
 STATIC U8 *
 S_add_utf16_textfilter(pTHX_ U8 * const s, bool reversed);


### PR DESCRIPTION
When enabled (e.g. with `./Configure -A ccflags=-DPERL_CR_FILTER`), this would define an implicit source filter that turns \r\n pairs into \n whenever the parser reads a line of Perl source code.

As far as I can tell, perl already does the equivalent of this (without a source filter) on all platforms and has done so since 5.005.

(Also, the code could read out-of-bounds if the last character of the line read was a \r.)

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and ~~I need help writing it~~ it is included.
