### PR TITLE
fix trim() handling of TARG (and minor refactor)

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -225,7 +225,6 @@ XS(XS_builtin_trim)
     SV *source = TOPs;
     STRLEN len;
     const U8 *start;
-    SV *dest;
 
     SvGETMAGIC(source);
 
@@ -273,33 +272,14 @@ XS(XS_builtin_trim)
         }
     }
 
-    dest = TARG;
+    sv_setpvn(TARG, (const char *)start, len);
 
-    if (SvPOK(dest) && (dest == source)) {
-        sv_chop(dest, (const char *)start);
-        SvCUR_set(dest, len);
-    }
-    else {
-        SvUPGRADE(dest, SVt_PV);
-        SvGROW(dest, len + 1);
+    if (DO_UTF8(source))
+        SvUTF8_on(TARG);
+    else
+        SvUTF8_off(TARG);
 
-        Copy(start, SvPVX(dest), len, U8);
-        SvPVX(dest)[len] = '\0';
-        SvPOK_on(dest);
-        SvCUR_set(dest, len);
-
-        if (DO_UTF8(source))
-            SvUTF8_on(dest);
-        else
-            SvUTF8_off(dest);
-
-        if (SvTAINTED(source))
-            SvTAINT(dest);
-    }
-
-    SvSETMAGIC(dest);
-
-    SETs(dest);
+    SETTARG;
 
     XSRETURN(1);
 }

--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -1,4 +1,4 @@
-package builtin 0.016;
+package builtin 0.017;
 
 use v5.40;
 

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -678,6 +678,14 @@ EOS
     }
 }
 
+# github #22784
+{
+    use builtin qw( trim );
+    sub f { 0+trim($_[0]) }
+    is(f(4), 4, "populate TARG.iv");
+    is(f(123), 123, "check TARG.IOK is reset properly");
+}
+
 # vim: tabstop=4 shiftwidth=4 expandtab autoindent softtabstop=4
 
 done_testing();


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
Fix mishandling of re-use of TARG in trim.

Fixes #22784 

Note that this code could simply have done sv_setpvn(), but trim() goes it's own way in handling taint, inconsistent with the rest of perl, as implemented by sv_setpvn(), so we see this bug.

I did consider just replacing this code with sv_setpvn(), but I don't know if the difference from normal perl taint usage was intentional, I didn't see any mention of it in #19433, the PR that added trim().

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.

perldelta:
```
builtin::trim() didn't properly clear C<TARG> which could result in out of date cached numeric versions of the value
being used on a second evaluation.  Properly clear any cached values. [GH #22784]
```