### PR TITLE
Remove caveat about temporary arrays in for range loops

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -806,15 +806,9 @@ operators depending on the context.  In list context, it returns a
 list of values counting (up by ones) from the left value to the right
 value.  If the left value is greater than the right value then it
 returns the empty list.  The range operator is useful for writing
-S<C<foreach (1..10)>> loops and for doing slice operations on arrays.  In
-the current implementation, no temporary array is created when the
-range operator is used as the expression in C<foreach> loops, but older
-versions of Perl might burn a lot of memory when you write something
-like this:
-
-    for (1 .. 1_000_000) {
-	# code
-    }
+S<C<foreach (1..10)>> loops and for doing slice operations on arrays.
+No temporary array is created when the range operator is used as the
+expression in C<foreach> loops.
 
 The range operator also works on strings, using the magical
 auto-increment, see below.


### PR DESCRIPTION
The optimisation to not create the array was introduced in Perl 5.005 (commit 89ea29081d863efc8d483f9cbe1c4e1dbb831359), there's no need to have a caveat about versions older than that any more.

* This set of changes does not require a perldelta entry.
