### PR TITLE
Fix maint 5.38 locale initialization bug

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -129,6 +129,7 @@ Anthony Heading                <anthony@ajrh.net>
 Anton Berezin                  <tobez@tobez.org>
 Anton Nikishaev                <me@lelf.lu>
 Anton Tagunov                  <tagunov@motor.ru>
+Anton Voloshin                 <ashutosh108@gmail.com>
 Archer Sully                   <archer@meer.net>
 Aristotle Pagaltzis            <pagaltzis@gmx.de>
 Arjen Laarhoven                <arjen@nl.demon.net>

--- a/locale.c
+++ b/locale.c
@@ -1907,6 +1907,9 @@ S_new_numeric(pTHX_ const char *newnum, bool force)
      * our records, do nothing.  (Our records can be wrong when sync'ing to the
      * locale set up by an external library, hence the 'force' parameter) */
     if (! force && strEQ(PL_numeric_name, newnum)) {
+        if (! PL_numeric_underlying_is_standard) {
+            set_numeric_standard();
+        }
         return;
     }
 

--- a/locale.c
+++ b/locale.c
@@ -5288,6 +5288,16 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
      * malloc'd in the interim */
     uselocale(PL_C_locale_obj);
 
+#    ifdef USE_PL_CURLOCALES
+
+    /* Tell our querylocale emulation that we are in the C locale */
+    for (i = 0; i < NOMINAL_LC_ALL_INDEX; i++) {
+        (void) emulate_setlocale_i(i, "C",
+                                   RECALCULATE_LC_ALL_ON_FINAL_INTERATION,
+                                   __LINE__);
+    }
+
+#    endif
 #    ifdef USE_LOCALE_NUMERIC
 
     PL_underlying_numeric_obj = duplocale(PL_C_locale_obj);


### PR DESCRIPTION
This fixes #21366

On systems that have POSIX 2008 locales and haven't implemented a means
to find out what the current locale is, perl emulates this capability,
as best it can.

(Not having this capability is a defect in the POSIX standard, which has
been finally remedied in POSIX 2024

https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/functions/getlocalename_l.html

but it will take time for implementations to catch up.)

In the absence of guidance from the Standard, some vendors created such
a means of getting this information, typically through a libc call named
'querylocale()'.

Perl uses whatever means is available and not buggy.  (Unfortunately
there are bugs or glitches in many of the implementations, so perl
doesn't use those.)

But when it doesn't have a useful means to get this information, perl
implements an emulation of it.  This works by perl trying to intercept
all changes to the locale and storing the new value, so that the
querylocale() emulation can simply return that when asked.

To save cycles, when asked to change the locale, perl skips actually
doing the change if it thinks it would be a no-op, that the new value is
the same as the old value.

Perl starts off setting itself to use the C locale and then reads the
environment to switch to what that specifies.

This bug here is that perl failed to tell the querylocale emulation at
the start that it was really in the C locale.  Due to the way initialization
proceeds, the querylocale emulation thought that perl was already in the
locale specified by the environment, so the code that changes the locale
skipped any changes.

This commit merely initializes the querylocale emulation records to C.
That way, if the environment specifies a different locale, perl knows it
isn't a no-op and does the change.

On glibc systems, there is a (mostly undocumented) means of finding the
current locale that turns out to work well.  Perl can use this.  In 5.38
we didn't know that it was reliable, given its undocumented status, so
it was by default turned off.  In 5.40, it is by default on.  This bug
does not come up if it is enabled.  To enable, call Configure adding the
option -Accflags=-DUSE_NL_LOCALE_NAME
