### PR TITLE
Configure: Fix compilation error on some systems

### DIFF
--- a/Configure
+++ b/Configure
@@ -17724,7 +17724,7 @@ main (const int argc, const char ** argv)
         /* Here isn't name=value pairs.  Find the position of the alternate */
         const char * alt_pos = strstr(lc_all, alternate);
         if (! alt_pos) {
-            fprintf(stderr, "Couldn't find '%s' in '%'s\n", alternate, lc_all);
+            fprintf(stderr, "Couldn't find '%s' in '%s'\n", alternate, lc_all);
             return 1;
         }
 


### PR DESCRIPTION
See https://github.com/Perl/perl5/issues/22793

This typo in a printf format causes some C compilations to fail; others to just warn.  However stderr is redirected to /dev/null, so we weren't aware of this issue.

When it fails, other issues cause perl to not be usable on the system.

This commit should be added to maint 5.40 and 5.38

* This set of changes requires a perldelta entry, to be furnished