### PR TITLE
Configure: Avoid printf format type mismatch

### DIFF
--- a/Configure
+++ b/Configure
@@ -22979,7 +22979,7 @@ else
 #include <signal.h>
 #include <stdio.h>
 int main() {
-printf("$xx %d\n", SIG${xx});
+printf("$xx %ld\n", (long) SIG${xx});
 return 0;
 }
 EOCP


### PR DESCRIPTION
Sometimes the value being printed is a long; sometimes not.  In order to get it to always work properly, cast to a long and use %ld


* This set of changes may require a perldelta entry, and I need help writing it.

