### PR TITLE
sv_inline.h:Perl_new_sv: prevent unused parameter warnings

### DIFF
--- a/sv_inline.h
+++ b/sv_inline.h
@@ -72,7 +72,8 @@ PERL_STATIC_INLINE SV*
 Perl_new_sv(pTHX_ const char *file, int line, const char *func)
 {
     SV* sv;
-#ifndef DEBUG_LEAKING_SCALARS
+#if !defined(DEBUG_LEAKING_SCALARS) || \
+     (!defined(DEBUGGING) && !defined(PERL_MEM_LOG))
     PERL_UNUSED_ARG(file);
     PERL_UNUSED_ARG(line);
     PERL_UNUSED_ARG(func);


### PR DESCRIPTION
This would warn if you built with -DDEBUG_LEAKING_SCALARS and without -DDEBUGGING and without -DPERL_MEM_LOG, since these enable the code that actually uses the parameters.

sv_inline.h: In function 'Perl_new_sv':
sv_inline.h:72:31: warning: unused parameter 'file' [-Wunused-parameter]
   72 | Perl_new_sv(pTHX_ const char *file, int line, const char *func)
      |                   ~~~~~~~~~~~~^~~~
sv_inline.h:72:41: warning: unused parameter 'line' [-Wunused-parameter]
   72 | Perl_new_sv(pTHX_ const char *file, int line, const char *func)
      |                                     ~~~~^~~~
sv_inline.h:72:59: warning: unused parameter 'func' [-Wunused-parameter]
   72 | Perl_new_sv(pTHX_ const char *file, int line, const char *func)
      |                                               ~~~~~~~~~~~~^~~~

Fixes #22806

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
TODO: fill description here

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
 This set of changes does not require a perldelta entry.
