### PR TITLE
deprecate the ':all' feature bundle

### DIFF
--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -4,7 +4,7 @@
 # Any changes made here will be lost!
 
 package feature;
-our $VERSION = '1.92';
+our $VERSION = '1.93';
 
 our %feature = (
     fc                              => 'feature_fc',
@@ -801,6 +801,8 @@ sub __common {
         my $name = shift;
         if (substr($name, 0, 1) eq ":") {
             my $v = substr($name, 1);
+            carp('Feature bundle ":all" is deprecated and should not be used')
+              if $v eq 'all';
             if (!exists $feature_bundle{$v}) {
                 $v =~ s/^([0-9]+)\.([0-9]+).[0-9]+$/$1.$2/;
                 if (!exists $feature_bundle{$v}) {
@@ -839,6 +841,11 @@ sub unknown_feature_bundle {
     my $feature = shift;
     croak(sprintf('Feature bundle "%s" is not supported by Perl %vd',
             $feature, $^V));
+}
+
+sub carp {
+    require Carp;
+    Carp::carp(@_);
 }
 
 sub croak {

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -167,6 +167,12 @@ L<XXX> has been upgraded from version A.xx to B.yy.
 
 XXX If there was something important to note about this change, include that here.
 
+=item *
+
+L<feature> has been upgraded from version 1.89 to 1.93.
+
+The C<:all> feature bundle now warns, suggesting you should not use it.
+
 =back
 
 =head2 Removed Modules and Pragmata

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -546,7 +546,7 @@ read_only_bottom_close_and_rename($h);
 
 __END__
 package feature;
-our $VERSION = '1.92';
+our $VERSION = '1.93';
 
 FEATURES
 
@@ -1175,6 +1175,8 @@ sub __common {
         my $name = shift;
         if (substr($name, 0, 1) eq ":") {
             my $v = substr($name, 1);
+            carp('Feature bundle ":all" is deprecated and should not be used')
+              if $v eq 'all';
             if (!exists $feature_bundle{$v}) {
                 $v =~ s/^([0-9]+)\.([0-9]+).[0-9]+$/$1.$2/;
                 if (!exists $feature_bundle{$v}) {
@@ -1213,6 +1215,11 @@ sub unknown_feature_bundle {
     my $feature = shift;
     croak(sprintf('Feature bundle "%s" is not supported by Perl %vd',
             $feature, $^V));
+}
+
+sub carp {
+    require Carp;
+    Carp::carp(@_);
 }
 
 sub croak {

--- a/t/comp/require.t
+++ b/t/comp/require.t
@@ -368,7 +368,6 @@ BEGIN {
     my @params = (
             'use v5.37',
             'use feature ":5.38"',
-            'use feature ":all"',
             'use feature "module_true"',
             'no feature "module_true"',
             '',

--- a/t/lib/feature/bundle
+++ b/t/lib/feature/bundle
@@ -100,6 +100,7 @@ Assigning non-zero to $[ is no longer possible at - line 5.
 no feature ':all'; # turns array_base (and everything else) off
 $[ = 1;
 EXPECT
+Feature bundle ":all" is deprecated and should not be used at - line 2.
 Assigning non-zero to $[ is no longer possible at - line 3.
 ########
 # NAME $^H accidentally enabling all features

--- a/t/op/lexsub.t
+++ b/t/op/lexsub.t
@@ -442,7 +442,7 @@ like runperl(
 # This used to fail an assertion, but only as a standalone script
 is runperl(switches => ['-lXMfeature=:all'],
            prog     => 'state sub x {}; undef &x; print defined &x',
-           stderr   => 1), "\n", 'undefining state sub';
+           stderr   => 1), "Feature bundle \":all\" is deprecated and should not be used at -e line 0.\n\n", 'undefining state sub';
 {
   state sub x { is +(caller 0)[3], 'x', 'state sub name in caller' }
   x
@@ -475,7 +475,7 @@ is runperl(switches => ['-lXMfeature=:all'],
                           x()
                         }
                         x()',
-           stderr   => 1), "42\n",
+           stderr   => 1), "Feature bundle \":all\" is deprecated and should not be used at -e line 0.\n42\n",
   'closure behaviour of state sub in predeclared package sub';
 
 # -------------------- my -------------------- #
@@ -830,7 +830,7 @@ pass "pad taking ownership once more of packagified my-sub";
 # This used to fail an assertion, but only as a standalone script
 is runperl(switches => ['-lXMfeature=:all'],
            prog     => 'my sub x {}; undef &x; print defined &x',
-           stderr   => 1), "\n", 'undefining my sub';
+           stderr   => 1), "Feature bundle \":all\" is deprecated and should not be used at -e line 0.\n\n", 'undefining my sub';
 {
   my sub x { is +(caller 0)[3], 'x', 'my sub name in caller' }
   x


### PR DESCRIPTION
As discussed in perl/PPCs#60, `:all` is very unlikely to be useful.

Since it will enable all features a future Perl might support, it will also enable some that might be incompatible with the code as written (see `bitwise`, for example, which changes the meaning of the existing bitwise operators).

With the addition of "negative" features in v5.32, `:all` became even less useful, since it would re-enable features deemed undesirable in modern Perl.

As this point in time, `:all` is effectively a footgun.

If the keyword `all` (from PPC0027) is added as a feature, there's an extra risk of confusion between `use feature 'all'` and `use feature ':all'`.

This patch makes `:all` warn. We should consider removing that bundle entirely in the future.

---
* This set of changes requires a perldelta entry, and it is included.
