### PR TITLE
utf8_to_uv_msgs: Do some code cleanup

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -1667,10 +1667,6 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
           || UTF8_IS_NONCHAR(s0, e));
     */
 
-    if (errors) {
-        *errors = 0;
-    }
-
     /* Accumulate the code point translation of the input byte sequence
      * s0 .. e-1, looking for malformations.
      *

--- a/utf8.c
+++ b/utf8.c
@@ -1733,15 +1733,6 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
     /* This is a helper function; invariants should have been handled before
      * calling it */
     assert(! NATIVE_BYTE_IS_INVARIANT(*s0));
-
-    /* A well-formed UTF-8 character, as the vast majority of calls to this
-     * function will be for, has this expected length.  For efficiency, set
-     * things up here to return it.  It will be overridden only in those rare
-     * cases where a malformation is found */
-    if (advance_p) {
-        *advance_p = expectlen;
-    }
-
     /* A continuation character can't start a valid sequence */
     if (UNLIKELY(UTF8_IS_CONTINUATION(*s0))) {
         possible_problems |= UTF8_GOT_CONTINUATION;
@@ -2550,13 +2541,6 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
             }
         }   /* End of 'while (possible_problems)' */
 
-        /* Since there was a possible problem, the returned length may need to
-         * be changed from the one stored at the beginning of this function.
-         * Instead of trying to figure out if it has changed, just do it. */
-        if (advance_p) {
-            *advance_p = curlen;
-        }
-
         if (msgs_return) {
             *msgs = msgs_return;
         }
@@ -2574,6 +2558,10 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
             uv = UNICODE_REPLACEMENT;
         }
     } /* End of there was a possible problem */
+
+    if (advance_p) {
+        *advance_p = curlen;
+    }
 
     *cp_p = UNI_TO_NATIVE(uv);
     return success;

--- a/utf8.c
+++ b/utf8.c
@@ -1640,8 +1640,6 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
     Size_t expectlen;    /* How long should this sequence be? */
     Size_t avail_len;    /* When input is too short, gives what that is */
 
-    dTHX;
-
     /* Here, is one of:
      *  a)  malformed;
      *  b)  a problematic code point (surrogate, non-unicode, or nonchar); or
@@ -1955,6 +1953,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
     bool success = true;
 
     if (UNLIKELY(possible_problems)) {
+        dTHX;
 
         /* Here, the input sequence is potentially problematic.  The code here
          * determines if that is indeed the case and how to handle it.  The

--- a/utf8.c
+++ b/utf8.c
@@ -1629,11 +1629,6 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
 
     const U8 * s = s0;
 
-    /* The ending position, plus 1, of the first character in the sequence
-     * beginning at s0.  In other words, 'e', adjusted down to to be no more
-     * than a single character */
-    const U8 * send = e;
-
     U32 possible_problems;  /* A bit is set here for each potential problem
                                found as we go along */
     UV uv = 0;
@@ -1659,8 +1654,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
     }
 
     /* Each of the affected Hanguls starts with \xED */
-
-    if (is_HANGUL_ED_utf8_safe(s0, send)) { /* Always false on EBCDIC */
+    if (is_HANGUL_ED_utf8_safe(s0, e)) { /* Always false on EBCDIC */
         if (advance_p) {
             *advance_p = 3;
         }
@@ -1675,10 +1669,10 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
      * APItest/t/utf8_warn_base.pl, this can make sure the dfa does precisely
      * what it is intended to do, and that no flaws in it are masked by
      * dropping down and executing the code below
-    assert(! isUTF8_CHAR(s0, send)
-          || UTF8_IS_SURROGATE(s0, send)
-          || UTF8_IS_SUPER(s0, send)
-          || UTF8_IS_NONCHAR(s0,send));
+    assert(! isUTF8_CHAR(s0, e)
+          || UTF8_IS_SURROGATE(s0, e)
+          || UTF8_IS_SUPER(s0, e)
+          || UTF8_IS_NONCHAR(s0, e));
     */
 
     s = s0;
@@ -1719,6 +1713,11 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
      * another, and if we abandon searching for others after finding the
      * allowed one, we could allow in something that shouldn't have been.
      */
+
+    /* The ending position, plus 1, of the first character in the sequence
+     * beginning at s0.  In other words, 'e', adjusted down to to be no more
+     * than a single character */
+    const U8 * send = e;
 
     Size_t curlen;
     if (UNLIKELY(s0 >= send)) {

--- a/utf8.c
+++ b/utf8.c
@@ -1732,15 +1732,16 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
     /* We now know we can examine the first byte of the input */
     expectlen = UTF8SKIP(s0);
 
-    /* This is a helper function; invariants should have been handled before
-     * calling it */
-    assert(! NATIVE_BYTE_IS_INVARIANT(*s0));
     /* A continuation character can't start a valid sequence */
     if (UNLIKELY(UTF8_IS_CONTINUATION(*s0))) {
         possible_problems |= UTF8_GOT_CONTINUATION;
         curlen = 1;
         goto ready_to_handle_errors;
     }
+
+    /* This is a helper function; invariants should have been handled before
+     * calling it */
+    assert(! NATIVE_BYTE_IS_INVARIANT(*s0));
 
     /* Here is not a continuation byte, nor an invariant.  The only thing left
      * is a start byte (possibly for an overlong).  (We can't use UTF8_IS_START


### PR DESCRIPTION
This should not change behavior.
It moves declarations and initializations closer to first use.  The biggest change is that several cases in a switch have virtually identical logic, which this extracts out into common code

* This set of changes does not require a perldelta entry.
