### PR TITLE
cpan/parent - Update to version 0.243

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -885,8 +885,8 @@ our %Modules = (
     },
 
     'parent' => {
-        'DISTRIBUTION' => 'CORION/parent-0.242.tar.gz',
-        'SYNCINFO'     => 'jkeenan on Wed Aug 14 21:41:51 2024',
+        'DISTRIBUTION' => 'CORION/parent-0.243.tar.gz',
+        'SYNCINFO'     => 'tib on Wed Dec  4 17:52:22 2024',
         'FILES'        => q[cpan/parent],
         'EXCLUDED'     => [
             qr{^xt}

--- a/cpan/parent/lib/parent.pm
+++ b/cpan/parent/lib/parent.pm
@@ -1,7 +1,7 @@
 package parent;
 use strict;
 
-our $VERSION = '0.242_001';
+our $VERSION = '0.243';
 
 sub import {
     my $class = shift;

--- a/cpan/parent/t/compile-time-file.t
+++ b/cpan/parent/t/compile-time-file.t
@@ -24,7 +24,7 @@ use lib 't/lib';
 
 {
     package Child3;
-    use if $] != 5.041_003, parent => "Dummy'Outside";
+    use parent "Dummy'Outside";
 }
 
 my $obj = {};
@@ -39,12 +39,9 @@ isa_ok $obj, 'Dummy::InlineChild';
 can_ok $obj, 'exclaim';
 is $obj->exclaim, "I CAN FROM Dummy::InlineChild", 'Inheritance is set up correctly for inlined classes';
 
-SKIP:
-{
-    skip "No ' in names in 5.041_003", 3 if $] == 5.041_003;
-    $obj = {};
-    bless $obj, 'Child3';
-    isa_ok $obj, 'Dummy::Outside';
-    can_ok $obj, 'exclaim';
-    is $obj->exclaim, "I CAN FROM Dummy::Outside", "Inheritance is set up correctly for classes inherited from via '";
-}
+$obj = {};
+bless $obj, 'Child3';
+isa_ok $obj, 'Dummy::Outside';
+can_ok $obj, 'exclaim';
+is $obj->exclaim, "I CAN FROM Dummy::Outside", "Inheritance is set up correctly for classes inherited from via '";
+


### PR DESCRIPTION
0.243 2024-11-27
    . Reinstate test for apostrophe as package separator, as the package
      separator is allowed again
    . No code change, only tests have been amended