### PR TITLE
  Turn is_utf8_common() into a macro

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -6109,9 +6109,6 @@ RTi	|int	|does_utf8_overflow					\
 				|NN const U8 *e
 RTi	|int	|isFF_overlong	|NN const U8 * const s			\
 				|const STRLEN len
-Ri	|bool	|is_utf8_common |NN const U8 * const p			\
-				|NN const U8 * const e			\
-				|NN SV * const invlist
 RTi	|int	|is_utf8_overlong					\
 				|NN const U8 * const s			\
 				|const STRLEN len

--- a/embed.h
+++ b/embed.h
@@ -1780,7 +1780,6 @@
 #     define check_locale_boundary_crossing(a,b,c,d) S_check_locale_boundary_crossing(aTHX_ a,b,c,d)
 #     define does_utf8_overflow                 S_does_utf8_overflow
 #     define isFF_overlong                      S_isFF_overlong
-#     define is_utf8_common(a,b,c)              S_is_utf8_common(aTHX_ a,b,c)
 #     define is_utf8_overlong                   S_is_utf8_overlong
 #     define new_msg_hv(a,b,c)                  S_new_msg_hv(aTHX_ a,b,c)
 #     define to_case_cp_list(a,b,c,d,e,f,g,h)   S_to_case_cp_list(aTHX_ a,b,c,d,e,f,g,h)

--- a/proto.h
+++ b/proto.h
@@ -9503,12 +9503,6 @@ S_isFF_overlong(const U8 * const s, const STRLEN len)
 #   define PERL_ARGS_ASSERT_ISFF_OVERLONG       \
         assert(s)
 
-PERL_STATIC_INLINE bool
-S_is_utf8_common(pTHX_ const U8 * const p, const U8 * const e, SV * const invlist)
-        __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_IS_UTF8_COMMON      \
-        assert(p); assert(e); assert(invlist)
-
 PERL_STATIC_INLINE int
 S_is_utf8_overlong(const U8 * const s, const STRLEN len)
         __attribute__warn_unused_result__;

--- a/utf8.c
+++ b/utf8.c
@@ -3848,20 +3848,6 @@ Perl__to_uni_fold_flags(pTHX_ UV c, U8* p, STRLEN *lenp, U8 flags)
     }
 }
 
-PERL_STATIC_INLINE bool
-S_is_utf8_common(pTHX_ const U8 *const p, const U8 * const e,
-                       SV* const invlist)
-{
-    PERL_ARGS_ASSERT_IS_UTF8_COMMON;
-
-    /* returns a boolean giving whether or not the UTF8-encoded character that
-     * starts at <p>, and extending no further than <e - 1> is in the inversion
-     * list <invlist>. */
-
-    UV cp = utf8_to_uv_or_die(p, e, NULL);
-    return _invlist_contains_cp(invlist, cp);
-}
-
 #if 0	/* Not currently used, but may be needed in the future */
 PERLVAR(I, seen_deprecated_macro, HV *)
 
@@ -3909,12 +3895,18 @@ S_warn_on_first_deprecated_use(pTHX_ U32 category,
 }
 #endif
 
+/* returns a boolean giving whether or not the UTF8-encoded character that
+ * starts at <p>, and extending no further than <e - 1> is in the inversion
+ * list <invlist>. */
+#define IS_UTF8_IN_INVLIST(p, e, invlist)                                   \
+            _invlist_contains_cp(invlist, utf8_to_uv_or_die(p, e, NULL))
+
 bool
 Perl__is_utf8_FOO(pTHX_ const U8 classnum, const U8 *p, const U8 * const e)
 {
     PERL_ARGS_ASSERT__IS_UTF8_FOO;
 
-    return is_utf8_common(p, e, PL_XPosix_ptrs[classnum]);
+    return IS_UTF8_IN_INVLIST(p, e, PL_XPosix_ptrs[classnum]);
 }
 
 bool
@@ -3922,7 +3914,7 @@ Perl__is_utf8_perl_idstart(pTHX_ const U8 *p, const U8 * const e)
 {
     PERL_ARGS_ASSERT__IS_UTF8_PERL_IDSTART;
 
-    return is_utf8_common(p, e, PL_utf8_perl_idstart);
+    return IS_UTF8_IN_INVLIST(p, e, PL_utf8_perl_idstart);
 }
 
 bool
@@ -3930,7 +3922,7 @@ Perl__is_utf8_perl_idcont(pTHX_ const U8 *p, const U8 * const e)
 {
     PERL_ARGS_ASSERT__IS_UTF8_PERL_IDCONT;
 
-    return is_utf8_common(p, e, PL_utf8_perl_idcont);
+    return IS_UTF8_IN_INVLIST(p, e, PL_utf8_perl_idcont);
 }
 
 STATIC UV


### PR DESCRIPTION
This function is now trivial; no need to have it a function

This change does not require a perldelta
