### PR TITLE
turkic_lc:: Convert to preferred utf8_to_uv()

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -4163,8 +4163,9 @@ S_turkic_lc(pTHX_ const U8 * const p0, const U8 * const e,
             /* For the dot above to modify the 'I', it must be part of a
              * combining sequence immediately following the 'I', and no other
              * modifier with a ccc of 230 may intervene */
-            cp = utf8_to_uvchr_buf(p, e, NULL);
-            if (! _invlist_contains_cp(PL_CCC_non0_non230, cp)) {
+            if (   ! utf8_to_uv(p, e, &cp, NULL)
+                || ! _invlist_contains_cp(PL_CCC_non0_non230, cp))
+            {
                 break;
             }
 


### PR DESCRIPTION
from utf8_to_uvchr_buf()


* This set of changes does not require a perldelta entry.
