### PR TITLE
sv_clear: with zero SvREFCNT, call sv_free2, not sv_free

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -7120,12 +7120,18 @@ Perl_sv_clear(pTHX_ SV *const orig_sv)
                 }
             }
 
-            /* unrolled SvREFCNT_dec and sv_free2 follows: */
+            /* Do the equivalent of SvREFCNT_dec(sv), except:
+             - for the case of RC==1, inline the actions normally taken
+               by sv_free2() prior it calling sv_clear(), and handle the
+               sv_clear() actions ourselves (without needing to
+               recurse).
+             - For the exceptional case of RC==0, do a traditional
+               recursive free. */
 
             if (!sv)
                 continue;
             if (!SvREFCNT(sv)) {
-                sv_free(sv);
+                Perl_sv_free2(aTHX_ sv, 0);
                 continue;
             }
             if (--(SvREFCNT(sv)))


### PR DESCRIPTION
Towards the bottom of `Perl_sv_clear`, there is a region described as being `* unrolled SvREFCNT_dec and sv_free2 follows: */`. This was originally accurate when introduced in https://github.com/Perl/perl5/commit/5239d5c4bfde4ec02e1787e9dc9ada189ad868e5 but the definitions of `Perl_sv_free`, `Perl_sv_free2`, and `SvREFCNT_dec` were updated in https://github.com/Perl/perl5/commit/75a9bf9690b77515a287eb483ea2709b73810c41 and this region of code didn't get updated to match.

I'm unsure of how to best refactor this code region, but right now the call to `sv_free(sv)` ultimately boils down to a call to `sv_free2`, so this commit just goes there directly.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
