### PR TITLE
02-perlbug-docs.md - perldoc program bugs go to cpan

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-perlbug-docs.md
+++ b/.github/ISSUE_TEMPLATE/02-perlbug-docs.md
@@ -7,6 +7,11 @@ assignees: ''
 
 ---
 
+<!--
+Note: Bugs in the perldoc program itself should be reported to the CPAN module
+maintainer via the bug tracker listed on https://metacpan.org/pod/Pod::Perldoc
+-->
+
 **Where**
 <!-- What module, script or perldoc URL needs to be fixed? -->
 


### PR DESCRIPTION
https://github.com/Perl/perl5/issues/18678 noted that it is not immediately apparent how/where to report bugs in the perldoc program. This commit adds a comment to the issue template to hopefully make it a little clearer.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
