### PR TITLE
Add utf8_to_uv_or_die()

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3780,6 +3780,10 @@ CTp	|bool	|utf8_to_uv_msgs_helper_				\
 				|U32 flags				\
 				|NULLOK U32 *errors			\
 				|NULLOK AV **msgs
+ATdip	|UV	|utf8_to_uv_or_die					\
+				|NN const U8 * const s			\
+				|NN const U8 *e 			\
+				|NULLOK Size_t *advance_p
 CDbdp	|UV	|utf8_to_uvuni	|NN const U8 *s 			\
 				|NULLOK STRLEN *retlen
 : Used in perly.y

--- a/embed.fnc
+++ b/embed.fnc
@@ -1241,7 +1241,7 @@ p	|void	|force_locale_unlock
 Cp	|void	|force_out_malformed_utf8_message_			\
 				|NN const U8 * const p			\
 				|NN const U8 * const e			\
-				|const U32 flags			\
+				|U32 flags				\
 				|const bool die_here
 Adfpv	|char * |form		|NN const char *pat			\
 				|...
@@ -3757,19 +3757,19 @@ ATdmp	|bool	|utf8_to_uv_errors					\
 				|NN const U8 * const e			\
 				|NN UV *cp_p				\
 				|NULLOK Size_t *advance_p		\
-				|const U32 flags			\
+				|U32 flags				\
 				|NULLOK U32 *errors
 ATdmp	|bool	|utf8_to_uv_flags					\
 				|NN const U8 * const s			\
 				|NN const U8 * const e			\
 				|NN UV *cp_p				\
 				|NULLOK Size_t *advance_p		\
-				|const U32 flag
+				|U32 flags
 ATdip	|bool	|utf8_to_uv_msgs|NN const U8 * const s0 		\
 				|NN const U8 *e 			\
 				|NN UV *cp_p				\
 				|NULLOK Size_t *advance_p		\
-				|const U32 flags			\
+				|U32 flags				\
 				|NULLOK U32 *errors			\
 				|NULLOK AV **msgs
 CTp	|bool	|utf8_to_uv_msgs_helper_				\
@@ -3777,7 +3777,7 @@ CTp	|bool	|utf8_to_uv_msgs_helper_				\
 				|NN const U8 * const e			\
 				|NN UV *cp_p				\
 				|NULLOK Size_t *advance_p		\
-				|const U32 flags			\
+				|U32 flags				\
 				|NULLOK U32 *errors			\
 				|NULLOK AV **msgs
 CDbdp	|UV	|utf8_to_uvuni	|NN const U8 *s 			\

--- a/embed.h
+++ b/embed.h
@@ -870,6 +870,7 @@
 # define utf8_to_uv_flags                       Perl_utf8_to_uv_flags
 # define utf8_to_uv_msgs                        Perl_utf8_to_uv_msgs
 # define utf8_to_uv_msgs_helper_                Perl_utf8_to_uv_msgs_helper_
+# define utf8_to_uv_or_die                      Perl_utf8_to_uv_or_die
 # define utf8n_to_uvchr                         Perl_utf8n_to_uvchr
 # define utf8n_to_uvchr_error                   Perl_utf8n_to_uvchr_error
 # define utf8n_to_uvchr_msgs                    Perl_utf8n_to_uvchr_msgs

--- a/inline.h
+++ b/inline.h
@@ -3053,7 +3053,7 @@ Perl_utf8_to_uv_msgs(const U8 * const s0,
                      const U8 * const e,
                      UV * cp_p,
                      Size_t *advance_p,
-                     const U32 flags,
+                     U32 flags,
                      U32 * errors,
                      AV ** msgs)
 {
@@ -3142,7 +3142,7 @@ PERL_STATIC_INLINE UV
 Perl_utf8n_to_uvchr_msgs(const U8 * const s0,
                          STRLEN curlen,
                          STRLEN *retlen,
-                         const U32 flags,
+                         U32 flags,
                          U32 * errors,
                          AV ** msgs)
 {

--- a/inline.h
+++ b/inline.h
@@ -3139,6 +3139,16 @@ Perl_utf8_to_uv_msgs(const U8 * const s0,
 }
 
 PERL_STATIC_INLINE UV
+Perl_utf8_to_uv_or_die(const U8 *s, const U8 *e, STRLEN *advance_p)
+{
+    PERL_ARGS_ASSERT_UTF8_TO_UV_OR_DIE;
+
+    UV cp;
+    (void) utf8_to_uv_flags(s, e, &cp, advance_p, UTF8_DIE_IF_MALFORMED);
+    return cp;
+}
+
+PERL_STATIC_INLINE UV
 Perl_utf8n_to_uvchr_msgs(const U8 * const s0,
                          STRLEN curlen,
                          STRLEN *retlen,

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -436,9 +436,10 @@ New API functions are introduced to convert strings encoded in UTF-8 to
 their ordinal code point equivalent.  These are safe to use by default,
 and generally more convenient to use than the existing ones.
 
-L<perlapi/C<utf8_to_uv>> replaces L<perlapi/C<utf8_to_uvchr>> (which is
-retained for backwards compatibility), but you should convert to use the
-new form, as likely you aren't using the old one safely.
+L<perlapi/C<utf8_to_uv>> and L<perlapi/C<utf8_to_uv_or_die>> replace
+L<perlapi/C<utf8_to_uvchr>> (which is retained for backwards
+compatibility), but you should convert to use the new forms, as likely
+you aren't using the old one safely.
 
 To convert in the opposite direction, you can now use
 L<perlapi/C<uv_to_utf8>>.  This is not a new function, but a new synonym

--- a/proto.h
+++ b/proto.h
@@ -10035,6 +10035,11 @@ Perl_utf8_to_uv_msgs(const U8 * const s0, const U8 *e, UV *cp_p, Size_t *advance
         assert(s0); assert(e); assert(cp_p)
 
 PERL_STATIC_INLINE UV
+Perl_utf8_to_uv_or_die(const U8 * const s, const U8 *e, Size_t *advance_p);
+# define PERL_ARGS_ASSERT_UTF8_TO_UV_OR_DIE     \
+        assert(s); assert(e)
+
+PERL_STATIC_INLINE UV
 Perl_utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen);
 # define PERL_ARGS_ASSERT_UTF8_TO_UVCHR_BUF     \
         assert(s); assert(send)

--- a/proto.h
+++ b/proto.h
@@ -1187,7 +1187,7 @@ Perl_force_locale_unlock(pTHX)
 #define PERL_ARGS_ASSERT_FORCE_LOCALE_UNLOCK
 
 PERL_CALLCONV void
-Perl_force_out_malformed_utf8_message_(pTHX_ const U8 * const p, const U8 * const e, const U32 flags, const bool die_here);
+Perl_force_out_malformed_utf8_message_(pTHX_ const U8 * const p, const U8 * const e, U32 flags, const bool die_here);
 #define PERL_ARGS_ASSERT_FORCE_OUT_MALFORMED_UTF8_MESSAGE_ \
         assert(p); assert(e)
 
@@ -5372,13 +5372,13 @@ Perl_utf8_to_utf16_base(pTHX_ U8 *s, U8 *d, Size_t bytelen, Size_t *newlen, cons
 Perl_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p); */
 
 /* PERL_CALLCONV bool
-Perl_utf8_to_uv_errors(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, const U32 flags, U32 *errors); */
+Perl_utf8_to_uv_errors(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors); */
 
 /* PERL_CALLCONV bool
-Perl_utf8_to_uv_flags(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, const U32 flag); */
+Perl_utf8_to_uv_flags(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags); */
 
 PERL_CALLCONV bool
-Perl_utf8_to_uv_msgs_helper_(const U8 * const s0, const U8 * const e, UV *cp_p, Size_t *advance_p, const U32 flags, U32 *errors, AV **msgs);
+Perl_utf8_to_uv_msgs_helper_(const U8 * const s0, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors, AV **msgs);
 #define PERL_ARGS_ASSERT_UTF8_TO_UV_MSGS_HELPER_ \
         assert(s0); assert(e); assert(cp_p)
 
@@ -10030,7 +10030,7 @@ Perl_utf8_hop_overshoot(const U8 *s, SSize_t off, const U8 * const start, const 
         assert(s); assert(start); assert(end)
 
 PERL_STATIC_INLINE bool
-Perl_utf8_to_uv_msgs(const U8 * const s0, const U8 *e, UV *cp_p, Size_t *advance_p, const U32 flags, U32 *errors, AV **msgs);
+Perl_utf8_to_uv_msgs(const U8 * const s0, const U8 *e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors, AV **msgs);
 # define PERL_ARGS_ASSERT_UTF8_TO_UV_MSGS       \
         assert(s0); assert(e); assert(cp_p)
 

--- a/utf8.c
+++ b/utf8.c
@@ -1991,6 +1991,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
         bool disallowed = FALSE;
         const U32 orig_problems = possible_problems;
         U32 error_flags_return = 0;
+        AV * msgs_return = NULL;
 
         /* The following macro returns 0 if no message needs to be generated
          * for this problem even if everything else says to.  Otherwise returns
@@ -2471,17 +2472,17 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
 
             } /* End of switch() on the possible problems */
 
-            /* Display the message (if any) for the problem being handled in
-             * this iteration of the loop */
+            /* Display or save the message (if any) for the problem being
+             * handled in this iteration of the loop */
             if (message) {
                 if (msgs) {
-                    if (*msgs == NULL) {
-                        *msgs = newAV();
+                    if (msgs_return == NULL) {
+                        msgs_return = newAV();
                     }
 
-                    av_push(*msgs, newRV_noinc((SV*) new_msg_hv(message,
-                                                              pack_warn,
-                                                              this_flag_bit)));
+                    av_push(msgs_return,
+                            newRV_noinc((SV*) new_msg_hv(message, pack_warn,
+                                                         this_flag_bit)));
                 }
                 else if (PL_op)
                     Perl_warner(aTHX_ pack_warn, "%s in %s", message,
@@ -2496,6 +2497,10 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
          * Instead of trying to figure out if it has changed, just do it. */
         if (advance_p) {
             *advance_p = curlen;
+        }
+
+        if (msgs_return) {
+            *msgs = msgs_return;
         }
 
         if (errors) {

--- a/utf8.h
+++ b/utf8.h
@@ -1214,6 +1214,8 @@ point's representation.
 
 #define UTF8_CHECK_ONLY			0x8000
 #define UTF8_NO_CONFIDENCE_IN_CURLEN_   0x10000  /* Internal core use only */
+#define UTF8_DIE_IF_MALFORMED           0x20000
+#define UTF8_FORCE_WARN_IF_MALFORMED    0x40000
 
 /* For backwards source compatibility.  They do nothing, as the default now
  * includes what they used to mean.  The first one's meaning was to allow the


### PR DESCRIPTION
This new function dies if the UTF-8 input to it is malformed.  There are
quite a few places in the core where we expect the input to be
well formed, and just assume that it is.  This function is a drop-in
replacement for those, and we won't blindly continue if the assumption
is wrong.  There are also a bunch of places that don't make that
assumption, but check it and die immediately if malformed.  This
function replaces those too, along with the code needed to test the
return and die.

* This set of changes requires a perldelta entry, to be furnished
