### PR TITLE
Introduce symbol table API into pad

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -692,15 +692,11 @@ static bool S_cv_is_builtin(pTHX_ CV *cv)
 void
 Perl_import_builtin_bundle(pTHX_ U16 ver)
 {
-    SV *ampname = sv_newmortal();
-
     for(int i = 0; builtins[i].name; i++) {
-        sv_setpvf(ampname, "&%s", builtins[i].name);
-
         bool want = (builtins[i].since_ver <= ver);
 
         bool got = false;
-        PADOFFSET off = pad_findmy_sv(ampname, 0);
+        PADOFFSET off = pad_find_my_symbol_pv (Perl_Symbol_Table_Code, builtins[i].name, 0);
         CV *cv;
         if(off != NOT_IN_PAD &&
                 SvTYPE((cv = (CV *)PL_curpad[off])) == SVt_PVCV &&

--- a/class.c
+++ b/class.c
@@ -766,7 +766,7 @@ Perl_class_seal_stash(pTHX_ HV *stash)
                     }
                     break;
 
-                case '@':
+                case Perl_Symbol_Table_Array:
                     op_priv = OPpINITFIELD_AV;
                     break;
 
@@ -1030,7 +1030,7 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
         OPCODE optype = 0;
         switch(PadnamePV(pn)[0]) {
             case Perl_Symbol_Table_Scalar: optype = OP_PADSV; break;
-            case '@': optype = OP_PADAV; break;
+            case Perl_Symbol_Table_Array:  optype = OP_PADAV; break;
             case '%': optype = OP_PADHV; break;
             default: NOT_REACHED;
         }
@@ -1244,7 +1244,7 @@ Perl_class_set_field_defop(pTHX_ PADNAME *pn, OPCODE defmode, OP *defop)
             defop = op_contextualize(defop, G_SCALAR);
             break;
 
-        case '@':
+        case Perl_Symbol_Table_Array:
         case '%':
             defop = op_contextualize(op_force_list(defop), G_LIST);
             break;

--- a/class.c
+++ b/class.c
@@ -699,7 +699,7 @@ Perl_class_seal_stash(pTHX_ HV *stash)
 
         for(SSize_t i = 0; fieldnames && i <= PadnamelistMAX(fieldnames); i++) {
             PADNAME *pn = PadnamelistARRAY(fieldnames)[i];
-            char sigil = PadnamePV(pn)[0];
+            char sigil = Padname_Symbol_Table (pn);
             PADOFFSET fieldix = PadnameFIELDINFO(pn)->fieldix;
 
             /* Extract the OP_{NEXT,DB}STATE op from the defop so we can
@@ -1028,7 +1028,7 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
     OP *retop;
     {
         OPCODE optype = 0;
-        switch(PadnamePV(pn)[0]) {
+        switch(Padname_Symbol_Table (pn)) {
             case Perl_Symbol_Table_Scalar: optype = OP_PADSV; break;
             case Perl_Symbol_Table_Array:  optype = OP_PADAV; break;
             case Perl_Symbol_Table_Hash:   optype = OP_PADHV; break;
@@ -1238,7 +1238,7 @@ Perl_class_set_field_defop(pTHX_ PADNAME *pn, OPCODE defmode, OP *defop)
 
     forbid_outofblock_ops(defop, "field initialiser expression");
 
-    char sigil = PadnamePV(pn)[0];
+    char sigil = Padname_Symbol_Table (pn);
     switch(sigil) {
         case Perl_Symbol_Table_Scalar:
             defop = op_contextualize(defop, G_SCALAR);

--- a/class.c
+++ b/class.c
@@ -729,7 +729,7 @@ Perl_class_seal_stash(pTHX_ HV *stash)
 
             U8 op_priv = 0;
             switch(sigil) {
-                case '$':
+                case Perl_Symbol_Table_Scalar:
                     if(paramname) {
                         if(!valop) {
                             SV *message =
@@ -947,7 +947,7 @@ apply_field_attribute_param(pTHX_ PADNAME *pn, SV *value)
         /* Default to name minus the sigil */
         value = newSVpvn_utf8(PadnamePV(pn) + 1, PadnameLEN(pn) - 1, PadnameUTF8(pn));
 
-    if(PadnamePV(pn)[0] != '$')
+    if(PadnamePV(pn)[0] != Perl_Symbol_Table_Scalar)
         croak("Only scalar fields can take a :param attribute");
 
     if(PadnameFIELDINFO(pn)->paramname)
@@ -1029,7 +1029,7 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
     {
         OPCODE optype = 0;
         switch(PadnamePV(pn)[0]) {
-            case '$': optype = OP_PADSV; break;
+            case Perl_Symbol_Table_Scalar: optype = OP_PADSV; break;
             case '@': optype = OP_PADAV; break;
             case '%': optype = OP_PADHV; break;
             default: NOT_REACHED;
@@ -1240,7 +1240,7 @@ Perl_class_set_field_defop(pTHX_ PADNAME *pn, OPCODE defmode, OP *defop)
 
     char sigil = PadnamePV(pn)[0];
     switch(sigil) {
-        case '$':
+        case Perl_Symbol_Table_Scalar:
             defop = op_contextualize(defop, G_SCALAR);
             break;
 

--- a/class.c
+++ b/class.c
@@ -947,7 +947,7 @@ apply_field_attribute_param(pTHX_ PADNAME *pn, SV *value)
         /* Default to name minus the sigil */
         value = newSVpvn_utf8(PadnamePV(pn) + 1, PadnameLEN(pn) - 1, PadnameUTF8(pn));
 
-    if(PadnamePV(pn)[0] != Perl_Symbol_Table_Scalar)
+    if(! Padname_Is_Symbol_Table_Scalar (pn))
         croak("Only scalar fields can take a :param attribute");
 
     if(PadnameFIELDINFO(pn)->paramname)

--- a/class.c
+++ b/class.c
@@ -155,7 +155,7 @@ XS(injected_constructor)
             SV *name = ST(i);
             SV *val  = (i+1 < items) ? ST(i+1) : &PL_sv_undef;
 
-            /* TODO: think about sanity-checking name for being 
+            /* TODO: think about sanity-checking name for being
              *   defined
              *   not ref (but overloaded objects?? boo)
              *   not duplicate

--- a/class.c
+++ b/class.c
@@ -699,7 +699,7 @@ Perl_class_seal_stash(pTHX_ HV *stash)
 
         for(SSize_t i = 0; fieldnames && i <= PadnamelistMAX(fieldnames); i++) {
             PADNAME *pn = PadnamelistARRAY(fieldnames)[i];
-            char sigil = Padname_Symbol_Table (pn);
+            perl_symbol_table_id sigil = Padname_Symbol_Table (pn);
             PADOFFSET fieldix = PadnameFIELDINFO(pn)->fieldix;
 
             /* Extract the OP_{NEXT,DB}STATE op from the defop so we can
@@ -1238,7 +1238,7 @@ Perl_class_set_field_defop(pTHX_ PADNAME *pn, OPCODE defmode, OP *defop)
 
     forbid_outofblock_ops(defop, "field initialiser expression");
 
-    char sigil = Padname_Symbol_Table (pn);
+    perl_symbol_table_id sigil = Padname_Symbol_Table (pn);
     switch(sigil) {
         case Perl_Symbol_Table_Scalar:
             defop = op_contextualize(defop, G_SCALAR);

--- a/class.c
+++ b/class.c
@@ -994,7 +994,14 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
     padix = pad_add_name_pvs("$self", 0, NULL, NULL);
     assert(padix == PADIX_SELF);
 
-    padix = pad_add_name_pvn(PadnamePV(pn), PadnameLEN(pn), 0, NULL, NULL);
+    padix = pad_add_symbol_pvn (
+        /* symbol_table = */ Padname_Symbol_Table (pn),
+        /* namepv       = */ Padname_Symbol_Name (pn),
+        /* namelen      = */ Padname_Symbol_Name_Length (pn),
+        /* flags        = */ 0,
+        /* typestash    = */ NULL,
+        /* ourstash     = */ NULL
+    );
     intro_my();
 
     OP *methstartop;

--- a/class.c
+++ b/class.c
@@ -945,7 +945,7 @@ apply_field_attribute_param(pTHX_ PADNAME *pn, SV *value)
 {
     if(!value)
         /* Default to name minus the sigil */
-        value = newSVpvn_utf8(PadnamePV(pn) + 1, PadnameLEN(pn) - 1, PadnameUTF8(pn));
+        value = newSVpvn_utf8(Padname_Symbol_Name (pn), PadnameLEN(pn) - 1, PadnameUTF8(pn));
 
     if(! Padname_Is_Symbol_Table_Scalar (pn))
         croak("Only scalar fields can take a :param attribute");
@@ -977,7 +977,7 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
         SvREFCNT_inc(value);
     else
         /* Default to name minus the sigil */
-        value = newSVpvn_utf8(PadnamePV(pn) + 1, PadnameLEN(pn) - 1, PadnameUTF8(pn));
+        value = newSVpvn_utf8(Padname_Symbol_Name (pn), PadnameLEN(pn) - 1, PadnameUTF8(pn));
 
     if(!valid_identifier_sv(value))
         croak("%" SVf_QUOTEDPREFIX " is not a valid name for a generated method", value);

--- a/class.c
+++ b/class.c
@@ -399,10 +399,10 @@ Perl_class_setup_stash(pTHX_ HV *stash)
         /* We don't want to make `$self` visible during the expression but we
          * still need to give it a name. Make it unusable from pure perl
          */
-        PADOFFSET padix = pad_add_name_pvs("$(self)", 0, NULL, NULL);
+        PADOFFSET padix = pad_add_symbol_pvs (Perl_Symbol_Table_Scalar, "(self)", 0, NULL, NULL);
         assert(padix == PADIX_SELF);
 
-        padix = pad_add_name_pvs("%(params)", 0, NULL, NULL);
+        padix = pad_add_symbol_pvs (Perl_Symbol_Table_Hash, "(params)", 0, NULL, NULL);
         assert(padix == PADIX_PARAMS);
 
         PERL_UNUSED_VAR(padix);
@@ -843,7 +843,7 @@ Perl_class_prepare_method_parse(pTHX_ CV *cv)
 
     PADOFFSET padix;
 
-    padix = pad_add_name_pvs("$self", 0, NULL, NULL);
+    padix = pad_add_symbol_pvs (Perl_Symbol_Table_Scalar, "self", 0, NULL, NULL);
     assert(padix == PADIX_SELF);
     PERL_UNUSED_VAR(padix);
 
@@ -991,7 +991,7 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
 
     PADOFFSET padix;
 
-    padix = pad_add_name_pvs("$self", 0, NULL, NULL);
+    padix = pad_add_symbol_pvs (Perl_Symbol_Table_Scalar, "self", 0, NULL, NULL);
     assert(padix == PADIX_SELF);
 
     padix = pad_add_symbol_pvn (

--- a/class.c
+++ b/class.c
@@ -945,7 +945,7 @@ apply_field_attribute_param(pTHX_ PADNAME *pn, SV *value)
 {
     if(!value)
         /* Default to name minus the sigil */
-        value = newSVpvn_utf8(Padname_Symbol_Name (pn), PadnameLEN(pn) - 1, PadnameUTF8(pn));
+        value = newSVpvn_utf8(Padname_Symbol_Name (pn), Padname_Symbol_Name_Length (pn), PadnameUTF8(pn));
 
     if(! Padname_Is_Symbol_Table_Scalar (pn))
         croak("Only scalar fields can take a :param attribute");
@@ -977,7 +977,7 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
         SvREFCNT_inc(value);
     else
         /* Default to name minus the sigil */
-        value = newSVpvn_utf8(Padname_Symbol_Name (pn), PadnameLEN(pn) - 1, PadnameUTF8(pn));
+        value = newSVpvn_utf8(Padname_Symbol_Name (pn), Padname_Symbol_Name_Length (pn), PadnameUTF8(pn));
 
     if(!valid_identifier_sv(value))
         croak("%" SVf_QUOTEDPREFIX " is not a valid name for a generated method", value);

--- a/class.c
+++ b/class.c
@@ -770,7 +770,7 @@ Perl_class_seal_stash(pTHX_ HV *stash)
                     op_priv = OPpINITFIELD_AV;
                     break;
 
-                case '%':
+                case Perl_Symbol_Table_Hash:
                     op_priv = OPpINITFIELD_HV;
                     break;
 
@@ -1031,7 +1031,7 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
         switch(PadnamePV(pn)[0]) {
             case Perl_Symbol_Table_Scalar: optype = OP_PADSV; break;
             case Perl_Symbol_Table_Array:  optype = OP_PADAV; break;
-            case '%': optype = OP_PADHV; break;
+            case Perl_Symbol_Table_Hash:   optype = OP_PADHV; break;
             default: NOT_REACHED;
         }
 
@@ -1245,7 +1245,7 @@ Perl_class_set_field_defop(pTHX_ PADNAME *pn, OPCODE defmode, OP *defop)
             break;
 
         case Perl_Symbol_Table_Array:
-        case '%':
+        case Perl_Symbol_Table_Hash:
             defop = op_contextualize(op_force_list(defop), G_LIST);
             break;
     }

--- a/dump.c
+++ b/dump.c
@@ -166,7 +166,7 @@ Unused or not for public use
 #define PV_BYTE_HEX_LC  "x%02" UVxf
 
 char *
-Perl_pv_escape( pTHX_ SV *dsv, char const * const str, 
+Perl_pv_escape( pTHX_ SV *dsv, char const * const str,
                 const STRLEN count, STRLEN max,
                 STRLEN * const escaped, U32 flags )
 {
@@ -226,21 +226,21 @@ Perl_pv_escape( pTHX_ SV *dsv, char const * const str,
             /* This won't alter the UTF-8 flag */
             SvPVCLEAR(dsv);
     }
-    
+
     if ((flags & PERL_PV_ESCAPE_UNI_DETECT) && is_utf8_string((U8*)pv, count))
         isuni = 1;
-    
+
     for ( ; pv < end ; pv += readsize ) {
         const UV u= (isuni) ? utf8_to_uvchr_buf((U8*)pv, (U8*) end, &readsize) : (U8)*pv;
         const U8 c = (U8)u;
         const char *source_buf = octbuf;
-        
+
         if ( ( u > 255 )
           || (flags & PERL_PV_ESCAPE_ALL)
           || (( ! isASCII(u) ) && (flags & (PERL_PV_ESCAPE_NONASCII|PERL_PV_ESCAPE_DWIM))))
         {
-            if (flags & PERL_PV_ESCAPE_FIRSTCHAR) 
-                chsize = my_snprintf( octbuf, PV_ESCAPE_OCTBUFSIZE, 
+            if (flags & PERL_PV_ESCAPE_FIRSTCHAR)
+                chsize = my_snprintf( octbuf, PV_ESCAPE_OCTBUFSIZE,
                                       "%" UVxf, u);
             else
             if ((flags & PERL_PV_ESCAPE_NON_WC) && isWORDCHAR_uvchr(u)) {
@@ -248,21 +248,21 @@ Perl_pv_escape( pTHX_ SV *dsv, char const * const str,
                 source_buf = pv;
             }
             else
-                chsize = my_snprintf( octbuf, PV_ESCAPE_OCTBUFSIZE, 
+                chsize = my_snprintf( octbuf, PV_ESCAPE_OCTBUFSIZE,
                                       ((flags & PERL_PV_ESCAPE_DWIM) && !isuni)
                                       ? ( use_uc_hex ? ("%c" PV_BYTE_HEX_UC) : ("%c" PV_BYTE_HEX_LC) )
                                       : "%cx{%02" UVxf "}", esc, u);
 
         } else if (flags & PERL_PV_ESCAPE_NOBACKSLASH) {
-            chsize = 1;            
-        } else {         
+            chsize = 1;
+        } else {
             if ( (c == dq) || (c == esc) || !isPRINT(c) ) {
                 chsize = 2;
                 switch (c) {
-                
+
                 case '\\' : /* FALLTHROUGH */
                 case '%'  : if ( c == esc )  {
-                                octbuf[1] = esc;  
+                                octbuf[1] = esc;
                             } else {
                                 chsize = 1;
                             }
@@ -272,10 +272,10 @@ Perl_pv_escape( pTHX_ SV *dsv, char const * const str,
                 case '\r' : octbuf[1] = 'r';  break;
                 case '\n' : octbuf[1] = 'n';  break;
                 case '\f' : octbuf[1] = 'f';  break;
-                case '"'  : 
-                        if ( dq == '"' ) 
+                case '"'  :
+                        if ( dq == '"' )
                                 octbuf[1] = '"';
-                        else 
+                        else
                             chsize = 1;
                         break;
                 default:
@@ -323,7 +323,7 @@ Perl_pv_escape( pTHX_ SV *dsv, char const * const str,
                 Perl_sv_catpvf( aTHX_ dsv, "%c", c);
             wrote++;
         }
-        if ( flags & PERL_PV_ESCAPE_FIRSTCHAR ) 
+        if ( flags & PERL_PV_ESCAPE_FIRSTCHAR )
             break;
     }
     if (escaped != NULL)
@@ -339,7 +339,7 @@ C<pv_escape()> and supporting quoting and ellipses.
 If the C<PERL_PV_PRETTY_QUOTE> flag is set then the result will be
 double quoted with any double quotes in the string escaped.  Otherwise
 if the C<PERL_PV_PRETTY_LTGT> flag is set then the result be wrapped in
-angle brackets. 
+angle brackets.
 
 If the C<PERL_PV_PRETTY_ELLIPSES> flag is set and not all characters in
 string were output then an ellipsis C<...> will be appended to the
@@ -356,22 +356,22 @@ Returns a pointer to the prettified text as held by C<dsv>.
 =for apidoc Amnh||PERL_PV_PRETTY_LTGT
 =for apidoc Amnh||PERL_PV_PRETTY_ELLIPSES
 
-=cut           
+=cut
 */
 
 char *
-Perl_pv_pretty( pTHX_ SV *dsv, char const * const str, const STRLEN count, 
-  const STRLEN max, char const * const start_color, char const * const end_color, 
-  const U32 flags ) 
+Perl_pv_pretty( pTHX_ SV *dsv, char const * const str, const STRLEN count,
+  const STRLEN max, char const * const start_color, char const * const end_color,
+  const U32 flags )
 {
     const U8 *quotes = (U8*)((flags & PERL_PV_PRETTY_QUOTE) ? "\"\"" :
                              (flags & PERL_PV_PRETTY_LTGT)  ? "<>" : NULL);
     STRLEN escaped;
     STRLEN max_adjust= 0;
     STRLEN orig_cur;
- 
+
     PERL_ARGS_ASSERT_PV_PRETTY;
-   
+
     if (!(flags & PERL_PV_PRETTY_NOCLEAR)) {
         /* This won't alter the UTF-8 flag */
         SvPVCLEAR(dsv);
@@ -380,8 +380,8 @@ Perl_pv_pretty( pTHX_ SV *dsv, char const * const str, const STRLEN count,
 
     if ( quotes )
         Perl_sv_catpvf(aTHX_ dsv, "%c", quotes[0]);
-        
-    if ( start_color != NULL ) 
+
+    if ( start_color != NULL )
         sv_catpv(dsv, start_color);
 
     if ((flags & PERL_PV_PRETTY_EXACTSIZE)) {
@@ -396,12 +396,12 @@ Perl_pv_pretty( pTHX_ SV *dsv, char const * const str, const STRLEN count,
 
     pv_escape( dsv, str, count, max - max_adjust, &escaped, flags | PERL_PV_ESCAPE_NOCLEAR );
 
-    if ( end_color != NULL ) 
+    if ( end_color != NULL )
         sv_catpv(dsv, end_color);
 
     if ( quotes )
         Perl_sv_catpvf(aTHX_ dsv, "%c", quotes[1]);
-    
+
     if ( (flags & PERL_PV_PRETTY_ELLIPSES) && ( escaped < count ) )
             sv_catpvs(dsv, "...");
 
@@ -409,7 +409,7 @@ Perl_pv_pretty( pTHX_ SV *dsv, char const * const str, const STRLEN count,
         while( SvCUR(dsv) - orig_cur < max )
             sv_catpvs(dsv," ");
     }
- 
+
     return SvPVX(dsv);
 }
 
@@ -795,7 +795,7 @@ S_opdump_link(pTHX_ const OP *base, const OP *o, PerlIO *file)
 =for apidoc_section $debugging
 =for apidoc dump_all
 
-Dumps the entire optree of the current program starting at C<PL_main_root> to 
+Dumps the entire optree of the current program starting at C<PL_main_root> to
 C<STDERR>.  Also dumps the optrees for all visible subroutines in
 C<PL_defstash>.
 
@@ -2047,7 +2047,7 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
     if ((flags & SVs_PADTMP))
             sv_catpvs(d, "PADTMP,");
     append_flags(d, flags, first_sv_flags_names);
-    if (flags & SVf_ROK)  {	
+    if (flags & SVf_ROK)  {
                                 sv_catpvs(d, "ROK,");
         if (SvWEAKREF(sv))	sv_catpvs(d, "WEAKREF,");
     }
@@ -2350,7 +2350,7 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
             if (ents) {
                 HE *const *const last = ents + HvMAX(sv);
                 count = last + 1 - ents;
-                
+
                 do {
                     if (!*ents)
                         --count;
@@ -3375,7 +3375,7 @@ Perl_op_class(pTHX_ const OP *o)
             return OPclass_SVOP;
 #endif
     }
-    
+
 #ifdef USE_ITHREADS
     if (o->op_type == OP_GV || o->op_type == OP_GVSV ||
         o->op_type == OP_RCATLINE)
@@ -3412,7 +3412,7 @@ Perl_op_class(pTHX_ const OP *o)
 
     case OA_PVOP_OR_SVOP:
         /*
-         * Character translations (tr///) are usually a PVOP, keeping a 
+         * Character translations (tr///) are usually a PVOP, keeping a
          * pointer to a table of shorts used to look up translations.
          * Under utf8, however, a simple table isn't practical; instead,
          * the OP is an SVOP (or, under threads, a PADOP),

--- a/dump.c
+++ b/dump.c
@@ -3056,7 +3056,7 @@ S_append_padvar(pTHX_ PADOFFSET off, CV *cv, SV *out, int n,
         {
             STRLEN cur = SvCUR(out);
             Perl_sv_catpvf(aTHX_ out, "[%" UTF8f,
-                                 UTF8fARG(1, PadnameLEN(sv) - 1,
+                                 UTF8fARG(1, Padname_Symbol_Name_Length (sv),
                                           Padname_Symbol_Name (sv)));
             if (is_scalar)
                 SvPVX(out)[cur] = '$';

--- a/dump.c
+++ b/dump.c
@@ -3057,7 +3057,7 @@ S_append_padvar(pTHX_ PADOFFSET off, CV *cv, SV *out, int n,
             STRLEN cur = SvCUR(out);
             Perl_sv_catpvf(aTHX_ out, "[%" UTF8f,
                                  UTF8fARG(1, PadnameLEN(sv) - 1,
-                                          PadnamePV(sv) + 1));
+                                          Padname_Symbol_Name (sv)));
             if (is_scalar)
                 SvPVX(out)[cur] = '$';
         }

--- a/embed.fnc
+++ b/embed.fnc
@@ -2501,6 +2501,10 @@ Adp	|PADOFFSET|pad_findmy_pvn					\
 				|U32 flags
 Adp	|PADOFFSET|pad_findmy_sv|NN SV *name				\
 				|U32 flags
+Adp	|PADOFFSET|pad_find_my_symbol_pv				\
+				|perl_symbol_table_id find_symbol_table \
+				|NN const char *name			\
+				|U32 flags
 Adp	|PADOFFSET|pad_find_my_symbol_pvn				\
 				|perl_symbol_table_id find_symbol_table \
 				|NN const char *namepv			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -2483,6 +2483,12 @@ Adp	|PADOFFSET|pad_add_symbol_pvn					\
 				|U32 flags				\
 				|NULLOK HV *typestash			\
 				|NULLOK HV *ourstash
+Adp	|PADOFFSET|pad_add_symbol_sv					\
+				|perl_symbol_table_id symbol_table	\
+				|NN SV *name				\
+				|U32 flags				\
+				|NULLOK HV *typestash			\
+				|NULLOK HV *ourstash
 p	|void	|pad_add_weakref|NN CV *func
 Adpx	|PADOFFSET|pad_alloc	|I32 optype				\
 				|U32 tmptype

--- a/embed.fnc
+++ b/embed.fnc
@@ -2501,6 +2501,11 @@ Adp	|PADOFFSET|pad_findmy_pvn					\
 				|U32 flags
 Adp	|PADOFFSET|pad_findmy_sv|NN SV *name				\
 				|U32 flags
+Adp	|PADOFFSET|pad_find_my_symbol_pvn				\
+				|perl_symbol_table_id find_symbol_table \
+				|NN const char *namepv			\
+				|STRLEN namelen 			\
+				|U32 flags
 dp	|void	|pad_fixup_inner_anons					\
 				|NN PADLIST *padlist			\
 				|NN CV *old_cv				\

--- a/embed.fnc
+++ b/embed.fnc
@@ -4962,7 +4962,8 @@ Sd	|PADOFFSET|pad_alloc_name					\
 Sd	|void	|pad_check_dup	|NN PADNAME *name			\
 				|U32 flags				\
 				|NULLOK const HV *ourstash
-Sd	|PADOFFSET|pad_findlex	|NN const char *namepv			\
+Sd	|PADOFFSET|pad_findlex	|perl_symbol_table_id find_symbol_table \
+				|NN const char *namepv			\
 				|STRLEN namelen 			\
 				|U32 flags				\
 				|NN const CV *cv			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -2257,6 +2257,10 @@ ARTdpx	|PADNAME *|newPADNAMEouter					\
 				|NN PADNAME *outer
 ARTdpx	|PADNAME *|newPADNAMEpvn|NN const char *s			\
 				|STRLEN len
+ARTdpx	|PADNAME *|new_padname_symbol_pvn				\
+				|perl_symbol_table_id symbol_table	\
+				|NN const char *name			\
+				|STRLEN name_len
 ARdip	|OP *	|newPADxVOP	|I32 type				\
 				|I32 flags				\
 				|PADOFFSET padix

--- a/embed.fnc
+++ b/embed.fnc
@@ -2470,6 +2470,13 @@ Adp	|PADOFFSET|pad_add_name_sv					\
 				|U32 flags				\
 				|NULLOK HV *typestash			\
 				|NULLOK HV *ourstash
+Adp	|PADOFFSET|pad_add_symbol_pvn					\
+				|perl_symbol_table_id symbol_table	\
+				|NN const char *namepv			\
+				|STRLEN namelen 			\
+				|U32 flags				\
+				|NULLOK HV *typestash			\
+				|NULLOK HV *ourstash
 p	|void	|pad_add_weakref|NN CV *func
 Adpx	|PADOFFSET|pad_alloc	|I32 optype				\
 				|U32 tmptype

--- a/embed.fnc
+++ b/embed.fnc
@@ -2510,6 +2510,10 @@ Adp	|PADOFFSET|pad_find_my_symbol_pvn				\
 				|NN const char *namepv			\
 				|STRLEN namelen 			\
 				|U32 flags
+Adp	|PADOFFSET|pad_find_my_symbol_sv				\
+				|perl_symbol_table_id find_symbol_table \
+				|NN SV *name				\
+				|U32 flags
 dp	|void	|pad_fixup_inner_anons					\
 				|NN PADLIST *padlist			\
 				|NN CV *old_cv				\

--- a/embed.fnc
+++ b/embed.fnc
@@ -2470,6 +2470,12 @@ Adp	|PADOFFSET|pad_add_name_sv					\
 				|U32 flags				\
 				|NULLOK HV *typestash			\
 				|NULLOK HV *ourstash
+Adp	|PADOFFSET|pad_add_symbol_pv					\
+				|perl_symbol_table_id symbol_table	\
+				|NN const char *name			\
+				|const U32 flags			\
+				|NULLOK HV *typestash			\
+				|NULLOK HV *ourstash
 Adp	|PADOFFSET|pad_add_symbol_pvn					\
 				|perl_symbol_table_id symbol_table	\
 				|NN const char *namepv			\

--- a/embed.h
+++ b/embed.h
@@ -510,6 +510,7 @@
 # define pad_add_name_sv(a,b,c,d)               Perl_pad_add_name_sv(aTHX_ a,b,c,d)
 # define pad_add_symbol_pv(a,b,c,d,e)           Perl_pad_add_symbol_pv(aTHX_ a,b,c,d,e)
 # define pad_add_symbol_pvn(a,b,c,d,e,f)        Perl_pad_add_symbol_pvn(aTHX_ a,b,c,d,e,f)
+# define pad_add_symbol_sv(a,b,c,d,e)           Perl_pad_add_symbol_sv(aTHX_ a,b,c,d,e)
 # define pad_alloc(a,b)                         Perl_pad_alloc(aTHX_ a,b)
 # define pad_findmy_pv(a,b)                     Perl_pad_findmy_pv(aTHX_ a,b)
 # define pad_findmy_pvn(a,b,c)                  Perl_pad_findmy_pvn(aTHX_ a,b,c)

--- a/embed.h
+++ b/embed.h
@@ -514,6 +514,7 @@
 # define pad_alloc(a,b)                         Perl_pad_alloc(aTHX_ a,b)
 # define pad_find_my_symbol_pv(a,b,c)           Perl_pad_find_my_symbol_pv(aTHX_ a,b,c)
 # define pad_find_my_symbol_pvn(a,b,c,d)        Perl_pad_find_my_symbol_pvn(aTHX_ a,b,c,d)
+# define pad_find_my_symbol_sv(a,b,c)           Perl_pad_find_my_symbol_sv(aTHX_ a,b,c)
 # define pad_findmy_pv(a,b)                     Perl_pad_findmy_pv(aTHX_ a,b)
 # define pad_findmy_pvn(a,b,c)                  Perl_pad_findmy_pvn(aTHX_ a,b,c)
 # define pad_findmy_sv(a,b)                     Perl_pad_findmy_sv(aTHX_ a,b)

--- a/embed.h
+++ b/embed.h
@@ -479,6 +479,7 @@
 # define newWHILEOP(a,b,c,d,e,f,g)              Perl_newWHILEOP(aTHX_ a,b,c,d,e,f,g)
 # define newXS(a,b,c)                           Perl_newXS(aTHX_ a,b,c)
 # define newXS_flags(a,b,c,d,e)                 Perl_newXS_flags(aTHX_ a,b,c,d,e)
+# define new_padname_symbol_pvn                 Perl_new_padname_symbol_pvn
 # define new_stackinfo(a,b)                     Perl_new_stackinfo(aTHX_ a,b)
 # define new_stackinfo_flags(a,b,c)             Perl_new_stackinfo_flags(aTHX_ a,b,c)
 # define new_version(a)                         Perl_new_version(aTHX_ a)

--- a/embed.h
+++ b/embed.h
@@ -1578,7 +1578,7 @@
 #   if defined(PERL_IN_PAD_C)
 #     define pad_alloc_name(a,b,c,d)            S_pad_alloc_name(aTHX_ a,b,c,d)
 #     define pad_check_dup(a,b,c)               S_pad_check_dup(aTHX_ a,b,c)
-#     define pad_findlex(a,b,c,d,e,f,g,h,i)     S_pad_findlex(aTHX_ a,b,c,d,e,f,g,h,i)
+#     define pad_findlex(a,b,c,d,e,f,g,h,i,j)   S_pad_findlex(aTHX_ a,b,c,d,e,f,g,h,i,j)
 #     define pad_reset()                        S_pad_reset(aTHX)
 #     if defined(DEBUGGING)
 #       define cv_dump(a,b)                     S_cv_dump(aTHX_ a,b)

--- a/embed.h
+++ b/embed.h
@@ -512,6 +512,7 @@
 # define pad_add_symbol_pvn(a,b,c,d,e,f)        Perl_pad_add_symbol_pvn(aTHX_ a,b,c,d,e,f)
 # define pad_add_symbol_sv(a,b,c,d,e)           Perl_pad_add_symbol_sv(aTHX_ a,b,c,d,e)
 # define pad_alloc(a,b)                         Perl_pad_alloc(aTHX_ a,b)
+# define pad_find_my_symbol_pvn(a,b,c,d)        Perl_pad_find_my_symbol_pvn(aTHX_ a,b,c,d)
 # define pad_findmy_pv(a,b)                     Perl_pad_findmy_pv(aTHX_ a,b)
 # define pad_findmy_pvn(a,b,c)                  Perl_pad_findmy_pvn(aTHX_ a,b,c)
 # define pad_findmy_sv(a,b)                     Perl_pad_findmy_sv(aTHX_ a,b)

--- a/embed.h
+++ b/embed.h
@@ -508,6 +508,7 @@
 # define pad_add_name_pv(a,b,c,d)               Perl_pad_add_name_pv(aTHX_ a,b,c,d)
 # define pad_add_name_pvn(a,b,c,d,e)            Perl_pad_add_name_pvn(aTHX_ a,b,c,d,e)
 # define pad_add_name_sv(a,b,c,d)               Perl_pad_add_name_sv(aTHX_ a,b,c,d)
+# define pad_add_symbol_pv(a,b,c,d,e)           Perl_pad_add_symbol_pv(aTHX_ a,b,c,d,e)
 # define pad_add_symbol_pvn(a,b,c,d,e,f)        Perl_pad_add_symbol_pvn(aTHX_ a,b,c,d,e,f)
 # define pad_alloc(a,b)                         Perl_pad_alloc(aTHX_ a,b)
 # define pad_findmy_pv(a,b)                     Perl_pad_findmy_pv(aTHX_ a,b)

--- a/embed.h
+++ b/embed.h
@@ -512,6 +512,7 @@
 # define pad_add_symbol_pvn(a,b,c,d,e,f)        Perl_pad_add_symbol_pvn(aTHX_ a,b,c,d,e,f)
 # define pad_add_symbol_sv(a,b,c,d,e)           Perl_pad_add_symbol_sv(aTHX_ a,b,c,d,e)
 # define pad_alloc(a,b)                         Perl_pad_alloc(aTHX_ a,b)
+# define pad_find_my_symbol_pv(a,b,c)           Perl_pad_find_my_symbol_pv(aTHX_ a,b,c)
 # define pad_find_my_symbol_pvn(a,b,c,d)        Perl_pad_find_my_symbol_pvn(aTHX_ a,b,c,d)
 # define pad_findmy_pv(a,b)                     Perl_pad_findmy_pv(aTHX_ a,b)
 # define pad_findmy_pvn(a,b,c)                  Perl_pad_findmy_pvn(aTHX_ a,b,c)

--- a/embed.h
+++ b/embed.h
@@ -508,6 +508,7 @@
 # define pad_add_name_pv(a,b,c,d)               Perl_pad_add_name_pv(aTHX_ a,b,c,d)
 # define pad_add_name_pvn(a,b,c,d,e)            Perl_pad_add_name_pvn(aTHX_ a,b,c,d,e)
 # define pad_add_name_sv(a,b,c,d)               Perl_pad_add_name_sv(aTHX_ a,b,c,d)
+# define pad_add_symbol_pvn(a,b,c,d,e,f)        Perl_pad_add_symbol_pvn(aTHX_ a,b,c,d,e,f)
 # define pad_alloc(a,b)                         Perl_pad_alloc(aTHX_ a,b)
 # define pad_findmy_pv(a,b)                     Perl_pad_findmy_pv(aTHX_ a,b)
 # define pad_findmy_pvn(a,b,c)                  Perl_pad_findmy_pvn(aTHX_ a,b,c)

--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.40';
+our $VERSION = '1.41';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -1195,9 +1195,15 @@ static OP *THX_parse_keyword_subsignature(pTHX)
             case OP_ARGELEM: {
                 PADOFFSET padix = kid->op_targ;
                 PADNAMELIST *names = PadlistNAMES(CvPADLIST(find_runcv(0)));
-                char *namepv = PadnamePV(padnamelist_fetch(names, padix));
+                PADNAME *pv = padnamelist_fetch(names, padix);
                 retop = op_append_list(OP_LIST, retop, newSVOP(OP_CONST, 0,
-                    newSVpvf(kid->op_flags & OPf_KIDS ? "argelem:%s:d" : "argelem:%s", namepv)));
+                    newSVpvf(
+                        kid->op_flags & OPf_KIDS
+                        ? "argelem:" Padname_Symbol_Printf_Format ":d"
+                        : "argelem:" Padname_Symbol_Printf_Format
+                        ,
+                        Padname_Symbol_Printf_Params (pv)
+                    )));
                 break;
             }
             default:

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -794,6 +794,7 @@ enum Pad_Find_Method {
     PAD_FIND_MY_SYMBOL_FOO,
     PAD_FIND_MY_SYMBOL_PV,
     PAD_FIND_MY_SYMBOL_PVN,
+    PAD_FIND_MY_SYMBOL_SV,
 };
 
 STATIC OP *
@@ -851,6 +852,9 @@ THX_ck_entersub_pad_scalar(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
             padoff = pad_find_my_symbol_pvn (Perl_Symbol_Table_Scalar, namepv, namelen, SvUTF8(a1));
             break;
         }
+        case PAD_FIND_MY_SYMBOL_SV: {
+            padoff = pad_find_my_symbol_sv (Perl_Symbol_Table_Scalar, a1, 0);
+        } break;
         default: croak("bad type value for pad_scalar()");
     }
     op_free(entersubop);
@@ -4388,6 +4392,7 @@ BOOT:
     EXPORT_ENUM (stash, PAD_FIND_MY_SYMBOL_FOO);
     EXPORT_ENUM (stash, PAD_FIND_MY_SYMBOL_PV);
     EXPORT_ENUM (stash, PAD_FIND_MY_SYMBOL_PVN);
+    EXPORT_ENUM (stash, PAD_FIND_MY_SYMBOL_SV);
 }
 
 BOOT:

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -791,6 +791,7 @@ enum Pad_Find_Method {
     PAD_FINDMY_PV,
     PAD_FINDMY_PVN,
     PAD_FINDMY_SV,
+    PAD_FIND_MY_SYMBOL_PV,
     PAD_FIND_MY_SYMBOL_PVN,
 };
 
@@ -833,6 +834,11 @@ THX_ck_entersub_pad_scalar(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
         case PAD_FINDMY_FOO: {
             padoff = pad_findmy_pvs("$foo", 0);
         } break;
+        case PAD_FIND_MY_SYMBOL_PV: {
+            char *namepv = SvPV_nolen(a1);
+            padoff = pad_find_my_symbol_pv (Perl_Symbol_Table_Scalar, namepv, SvUTF8(a1));
+            break;
+        }
         case PAD_FIND_MY_SYMBOL_PVN: {
             char *namepv;
             STRLEN namelen;
@@ -4374,6 +4380,7 @@ BOOT:
     EXPORT_ENUM (stash, PAD_FINDMY_PV);
     EXPORT_ENUM (stash, PAD_FINDMY_PVN);
     EXPORT_ENUM (stash, PAD_FINDMY_SV);
+    EXPORT_ENUM (stash, PAD_FIND_MY_SYMBOL_PV);
     EXPORT_ENUM (stash, PAD_FIND_MY_SYMBOL_PVN);
 }
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -791,6 +791,7 @@ enum Pad_Find_Method {
     PAD_FINDMY_PV,
     PAD_FINDMY_PVN,
     PAD_FINDMY_SV,
+    PAD_FIND_MY_SYMBOL_FOO,
     PAD_FIND_MY_SYMBOL_PV,
     PAD_FIND_MY_SYMBOL_PVN,
 };
@@ -834,6 +835,10 @@ THX_ck_entersub_pad_scalar(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
         case PAD_FINDMY_FOO: {
             padoff = pad_findmy_pvs("$foo", 0);
         } break;
+        case PAD_FIND_MY_SYMBOL_FOO: {
+            padoff = pad_find_my_symbol_pvs (Perl_Symbol_Table_Scalar, "foo", 0);
+            break;
+        }
         case PAD_FIND_MY_SYMBOL_PV: {
             char *namepv = SvPV_nolen(a1);
             padoff = pad_find_my_symbol_pv (Perl_Symbol_Table_Scalar, namepv, SvUTF8(a1));
@@ -4380,6 +4385,7 @@ BOOT:
     EXPORT_ENUM (stash, PAD_FINDMY_PV);
     EXPORT_ENUM (stash, PAD_FINDMY_PVN);
     EXPORT_ENUM (stash, PAD_FINDMY_SV);
+    EXPORT_ENUM (stash, PAD_FIND_MY_SYMBOL_FOO);
     EXPORT_ENUM (stash, PAD_FIND_MY_SYMBOL_PV);
     EXPORT_ENUM (stash, PAD_FIND_MY_SYMBOL_PVN);
 }

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -1259,7 +1259,7 @@ static OP *THX_parse_keyword_with_vars(pTHX)
             croak("unexpected '%c'; expecting an identifier", (int)c);
         }
 
-        varname = newSVpvs("$");
+        varname = newSVpvs("");
         if (lex_bufutf8()) {
             SvUTF8_on(varname);
         }
@@ -1272,7 +1272,7 @@ static OP *THX_parse_keyword_with_vars(pTHX)
             lex_read_unichar(0);
         }
 
-        padoff = pad_add_name_sv(varname, padadd_NO_DUP_CHECK, NULL, NULL);
+        padoff = pad_add_symbol_sv (Perl_Symbol_Table_Scalar, varname, padadd_NO_DUP_CHECK, NULL, NULL);
 
         {
             OP *my_var = newOP(OP_PADSV, OPf_MOD | (OPpLVAL_INTRO << 8));
@@ -4674,7 +4674,7 @@ lexical_import(SV *name, CV *cv)
         SAVESPTR(PL_comppad_name); PL_comppad_name = PadlistNAMES(pl);
         SAVESPTR(PL_comppad);      PL_comppad      = PadlistARRAY(pl)[1];
         SAVESPTR(PL_curpad);       PL_curpad       = PadARRAY(PL_comppad);
-        off = pad_add_name_sv(sv_2mortal(newSVpvf("&%" SVf,name)),
+        off = pad_add_symbol_sv (Perl_Symbol_Table_Code, sv_2mortal(newSVpvf("%" SVf,name)),
                               padadd_STATE, 0, 0);
         SvREFCNT_dec(PL_curpad[off]);
         PL_curpad[off] = SvREFCNT_inc(cv);

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -787,10 +787,11 @@ THX_ck_entersub_postinc(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
 }
 
 enum Pad_Find_Method {
-    PAD_FINDMY_SV  = 1,
-    PAD_FINDMY_PVN = 2,
-    PAD_FINDMY_PV  = 3,
-    PAD_FINDMY_FOO = 4,
+    PAD_FINDMY_FOO,
+    PAD_FINDMY_PV,
+    PAD_FINDMY_PVN,
+    PAD_FINDMY_SV,
+    PAD_FIND_MY_SYMBOL_PVN,
 };
 
 STATIC OP *
@@ -832,6 +833,13 @@ THX_ck_entersub_pad_scalar(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
         case PAD_FINDMY_FOO: {
             padoff = pad_findmy_pvs("$foo", 0);
         } break;
+        case PAD_FIND_MY_SYMBOL_PVN: {
+            char *namepv;
+            STRLEN namelen;
+            namepv = SvPV(a1, namelen);
+            padoff = pad_find_my_symbol_pvn (Perl_Symbol_Table_Scalar, namepv, namelen, SvUTF8(a1));
+            break;
+        }
         default: croak("bad type value for pad_scalar()");
     }
     op_free(entersubop);
@@ -4362,10 +4370,11 @@ BOOT:
 {
     HV *stash = gv_stashpv("XS::APItest", TRUE);
 
+    EXPORT_ENUM (stash, PAD_FINDMY_FOO);
     EXPORT_ENUM (stash, PAD_FINDMY_PV);
     EXPORT_ENUM (stash, PAD_FINDMY_PVN);
-    EXPORT_ENUM (stash, PAD_FINDMY_FOO);
     EXPORT_ENUM (stash, PAD_FINDMY_SV);
+    EXPORT_ENUM (stash, PAD_FIND_MY_SYMBOL_PVN);
 }
 
 BOOT:

--- a/ext/XS-APItest/t/fetch_pad_names.t
+++ b/ext/XS-APItest/t/fetch_pad_names.t
@@ -12,7 +12,7 @@ else {
     plan tests => 77;
 }
 
-use XS::APItest qw( fetch_pad_names pad_scalar );
+use XS::APItest qw( fetch_pad_names pad_scalar PAD_FINDMY_SV );
 
 local $SIG{__WARN__} = sub { warn $_[0] unless $_[0] =~ /Wide character in print at/ };
 
@@ -34,7 +34,11 @@ $cv = sub {
     my $zest = 'invariant';
     my $zèst = 'latin-1';
     
-    return [pad_scalar(1, "zèst"), pad_scalar(1, "z\350st"), pad_scalar(1, "z\303\250st")];
+    return [
+        pad_scalar (PAD_FINDMY_SV, "zèst"),
+        pad_scalar (PAD_FINDMY_SV, "z\350st"),
+        pad_scalar (PAD_FINDMY_SV, "z\303\250st"),
+    ];
 };
 
 my $names_av    = fetch_pad_names($cv);
@@ -65,7 +69,11 @@ $cv = do {
     sub {
         use utf8;
         my $партнеры = $ascii;
-        return [$партнеры, pad_scalar(1, "партнеры"), pad_scalar(1, "\320\277\320\260\321\200\321\202\320\275\320\265\321\200\321\213")];
+        return [
+            $партнеры,
+            pad_scalar (PAD_FINDMY_SV, "партнеры"),
+            pad_scalar (PAD_FINDMY_SV, "\320\277\320\260\321\200\321\202\320\275\320\265\321\200\321\213"),
+        ];
     };
 };
 
@@ -109,7 +117,7 @@ $cv = eval <<"END";
         use utf8;
         my \$Leon = 'Invariant';
         my $leon1 = 'Latin-1';
-        return [ \$Leon, $leon1, $leon2, pad_scalar(1, "L\x{e9}on"), pad_scalar(1, "L\x{c3}\x{a9}on")];
+        return [ \$Leon, $leon1, $leon2, pad_scalar(PAD_FINDMY_SV, "L\x{e9}on"), pad_scalar(PAD_FINDMY_SV, "L\x{c3}\x{a9}on")];
     };
 END
 
@@ -225,10 +233,10 @@ $cv = sub {
 
     return [
         $tèst,
-        pad_scalar(1, "tèst"),              #"UTF-8"
-        pad_scalar(1, "t\350st"),           #"Latin-1"
-        pad_scalar(1, "t\x{c3}\x{a8}st"),   #"Octal"
-        pad_scalar(1, test()),              #'UTF-8 enc'
+        pad_scalar (PAD_FINDMY_SV, "tèst"),              #"UTF-8"
+        pad_scalar (PAD_FINDMY_SV, "t\350st"),           #"Latin-1"
+        pad_scalar (PAD_FINDMY_SV, "t\x{c3}\x{a8}st"),   #"Octal"
+        pad_scalar (PAD_FINDMY_SV, test()),              #'UTF-8 enc'
         ];
 };
 
@@ -261,12 +269,12 @@ $cv = do {
         return [
                 $ニコニコ,
                 $にこにこ,
-                pad_scalar(1, "にこにこ"),
-                pad_scalar(1, "\x{306b}\x{3053}\x{306b}\x{3053}"),
-                pad_scalar(1, "\343\201\253\343\201\223\343\201\253\343\201\223"),
-                pad_scalar(1, "ニコニコ"),
-                pad_scalar(1, "\x{30cb}\x{30b3}\x{30cb}\x{30b3}"),
-                pad_scalar(1, "\343\203\213\343\202\263\343\203\213\343\202\263"),
+                pad_scalar (PAD_FINDMY_SV, "にこにこ"),
+                pad_scalar (PAD_FINDMY_SV, "\x{306b}\x{3053}\x{306b}\x{3053}"),
+                pad_scalar (PAD_FINDMY_SV, "\343\201\253\343\201\223\343\201\253\343\201\223"),
+                pad_scalar (PAD_FINDMY_SV, "ニコニコ"),
+                pad_scalar (PAD_FINDMY_SV, "\x{30cb}\x{30b3}\x{30cb}\x{30b3}"),
+                pad_scalar (PAD_FINDMY_SV, "\343\203\213\343\202\263\343\203\213\343\202\263"),
             ];
     }
 };
@@ -302,7 +310,7 @@ general_tests( $cv->(), $names_av, {
         use constant utf8_e => $utf8_e;
     }
     my $e = 'Invariant';
-    is pad_scalar(1, "e"), pad_scalar(1, utf8_e), 'Fetches the same thing, even if invariant but with differing utf8ness.';
+    is pad_scalar (PAD_FINDMY_SV, "e"), pad_scalar (PAD_FINDMY_SV, utf8_e), 'Fetches the same thing, even if invariant but with differing utf8ness.';
 }
 
 

--- a/ext/XS-APItest/t/pad_scalar.t
+++ b/ext/XS-APItest/t/pad_scalar.t
@@ -1,13 +1,14 @@
 use warnings;
 use strict;
 
-use Test::More tests => 110;
+use Test::More tests => 113;
 
 use XS::APItest qw (
     PAD_FINDMY_FOO
     PAD_FINDMY_PV
     PAD_FINDMY_PVN
     PAD_FINDMY_SV
+    PAD_FIND_MY_SYMBOL_FOO
     PAD_FIND_MY_SYMBOL_PV
     PAD_FIND_MY_SYMBOL_PVN
     pad_scalar
@@ -17,6 +18,7 @@ is pad_scalar (PAD_FINDMY_SV,          "foo"), "NOT_IN_PAD", q (undeclared '$foo
 is pad_scalar (PAD_FINDMY_PVN,         "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_findmy_pvn ());
 is pad_scalar (PAD_FINDMY_PV,          "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_findmy_pv ());
 is pad_scalar (PAD_FINDMY_FOO,         "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_findmy_pvs ());
+is pad_scalar (PAD_FIND_MY_SYMBOL_FOO, "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_find_my_symbol_pvs ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PV,  "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_find_my_symbol_pv ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_find_my_symbol_pvn ());
 
@@ -32,6 +34,7 @@ is pad_scalar (PAD_FINDMY_SV,          "foo"), "NOT_MY", q ('our $foo'; pad_find
 is pad_scalar (PAD_FINDMY_PVN,         "foo"), "NOT_MY", q ('our $foo'; pad_findmy_pvn ());
 is pad_scalar (PAD_FINDMY_PV,          "foo"), "NOT_MY", q ('our $foo'; pad_findmy_pv ());
 is pad_scalar (PAD_FINDMY_FOO,         "foo"), "NOT_MY", q ('our $foo'; pad_findmy_pvs ());
+is pad_scalar (PAD_FIND_MY_SYMBOL_FOO, "foo"), "NOT_MY", q ('our $foo'; pad_find_my_symbol_pvs ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PV,  "foo"), "NOT_MY", q ('our $foo'; pad_find_my_symbol_pv ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "foo"), "NOT_MY", q ('our $foo'; pad_find_my_symbol_pvn ());
 
@@ -79,12 +82,12 @@ sub bb() {
     my $counter = 0;
     my $foo = \$counter;
     return sub {
-        ok pad_scalar (PAD_FINDMY_SV,          "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
-        ok pad_scalar (PAD_FINDMY_PVN,         "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
-        ok pad_scalar (PAD_FINDMY_PV,          "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
-        ok pad_scalar (PAD_FINDMY_FOO,         "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
-        ok pad_scalar (PAD_FIND_MY_SYMBOL_PV,  "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
-        ok pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FINDMY_SV,          "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FINDMY_PVN,         "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FINDMY_PV,          "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FINDMY_FOO,         "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FIND_MY_SYMBOL_PV,  "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
 
         my $modulus = pad_scalar (PAD_FINDMY_SV, "counter") % 5;
 
@@ -121,6 +124,7 @@ is pad_scalar (PAD_FINDMY_SV,          "foo"), "NOT_MY", q ('my $foo' still unde
 is pad_scalar (PAD_FINDMY_PVN,         "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_findmy_pvn ());
 is pad_scalar (PAD_FINDMY_PV,          "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_findmy_pv ());
 is pad_scalar (PAD_FINDMY_FOO,         "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_findmy_pvs ());
+is pad_scalar (PAD_FIND_MY_SYMBOL_FOO, "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_find_my_symbol_pvs ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PV,  "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_find_my_symbol_pv ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_find_my_symbol_pvn ());
 

--- a/ext/XS-APItest/t/pad_scalar.t
+++ b/ext/XS-APItest/t/pad_scalar.t
@@ -1,7 +1,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 113;
+use Test::More tests => 139;
 
 use XS::APItest qw (
     PAD_FINDMY_FOO
@@ -11,6 +11,7 @@ use XS::APItest qw (
     PAD_FIND_MY_SYMBOL_FOO
     PAD_FIND_MY_SYMBOL_PV
     PAD_FIND_MY_SYMBOL_PVN
+    PAD_FIND_MY_SYMBOL_SV
     pad_scalar
 );
 
@@ -21,12 +22,14 @@ is pad_scalar (PAD_FINDMY_FOO,         "foo"), "NOT_IN_PAD", q (undeclared '$foo
 is pad_scalar (PAD_FIND_MY_SYMBOL_FOO, "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_find_my_symbol_pvs ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PV,  "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_find_my_symbol_pv ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_find_my_symbol_pvn ());
+is pad_scalar (PAD_FIND_MY_SYMBOL_SV,  "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_find_my_symbol_sv ());
 
 is pad_scalar (PAD_FINDMY_SV,          "bar"), "NOT_IN_PAD", q (undeclared '$bar'; pad_findmy_sv ());
 is pad_scalar (PAD_FINDMY_PVN,         "bar"), "NOT_IN_PAD", q (undeclared '$bar'; pad_findmy_pvn ());
 is pad_scalar (PAD_FINDMY_PV,          "bar"), "NOT_IN_PAD", q (undeclared '$bar'; pad_findmy_pv ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PV,  "bar"), "NOT_IN_PAD", q (undeclared '$bar'; pad_find_my_symbol_pv ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "bar"), "NOT_IN_PAD", q (undeclared '$bar'; pad_find_my_symbol_pvn ());
+is pad_scalar (PAD_FIND_MY_SYMBOL_SV,  "bar"), "NOT_IN_PAD", q (undeclared '$bar'; pad_find_my_symbol_sv ());
 
 our $foo = "wibble";
 my $bar = "wobble";
@@ -37,12 +40,14 @@ is pad_scalar (PAD_FINDMY_FOO,         "foo"), "NOT_MY", q ('our $foo'; pad_find
 is pad_scalar (PAD_FIND_MY_SYMBOL_FOO, "foo"), "NOT_MY", q ('our $foo'; pad_find_my_symbol_pvs ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PV,  "foo"), "NOT_MY", q ('our $foo'; pad_find_my_symbol_pv ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "foo"), "NOT_MY", q ('our $foo'; pad_find_my_symbol_pvn ());
+is pad_scalar (PAD_FIND_MY_SYMBOL_SV,  "foo"), "NOT_MY", q ('our $foo'; pad_find_my_symbol_sv ());
 
 is pad_scalar (PAD_FINDMY_SV,          "bar"), "wobble", q ('my $bar'; pad_findmy_sv ());
 is pad_scalar (PAD_FINDMY_PVN,         "bar"), "wobble", q ('my $bar'; pad_findmy_pvn ());
 is pad_scalar (PAD_FINDMY_PV,          "bar"), "wobble", q ('my $bar'; pad_findmy_pv ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PV,  "bar"), "wobble", q ('my $bar'; pad_find_my_symbol_pv ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "bar"), "wobble", q ('my $bar'; pad_find_my_symbol_pvn ());
+is pad_scalar (PAD_FIND_MY_SYMBOL_SV,  "bar"), "wobble", q ('my $bar'; pad_find_my_symbol_sv ());
 
 sub aa($);
 sub aa($) {
@@ -57,6 +62,7 @@ sub aa($) {
     ok \pad_scalar (PAD_FINDMY_PV,          "xyz") == \$xyz, $prefix . q (private variable; pad_findmy_pv ());
     ok \pad_scalar (PAD_FIND_MY_SYMBOL_PV,  "xyz") == \$xyz, $prefix . q (private variable; pad_find_my_symbol_pv ());
     ok \pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "xyz") == \$xyz, $prefix . q (private variable; pad_find_my_symbol_pvn ());
+    ok \pad_scalar (PAD_FIND_MY_SYMBOL_SV,  "xyz") == \$xyz, $prefix . q (private variable; pad_find_my_symbol_sv ());
 
     if ($_[0]) {
         aa(0); # recursive call
@@ -65,6 +71,7 @@ sub aa($) {
         ok \pad_scalar (PAD_FINDMY_PV,          "xyz") == \$xyz, q (private variable (after recursive call); pad_findmy_pv ());
         ok \pad_scalar (PAD_FIND_MY_SYMBOL_PV,  "xyz") == \$xyz, q (private variable (after recursive call); pad_find_my_symbol_pv ());
         ok \pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "xyz") == \$xyz, q (private variable (after recursive call); pad_find_my_symbol_pvn ());
+        ok \pad_scalar (PAD_FIND_MY_SYMBOL_SV,  "xyz") == \$xyz, q (private variable (after recursive call); pad_find_my_symbol_sv ());
     }
 
     is pad_scalar (PAD_FINDMY_SV,          "bar"), "wobble", $prefix . q (Global 'my $bar'; pad_findmy_sv ());
@@ -72,6 +79,7 @@ sub aa($) {
     is pad_scalar (PAD_FINDMY_PV,          "bar"), "wobble", $prefix . q (Global 'my $bar'; pad_findmy_pv ());
     is pad_scalar (PAD_FIND_MY_SYMBOL_PV,  "bar"), "wobble", $prefix . q (Global 'my $bar'; pad_find_my_symbol_pv ());
     is pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "bar"), "wobble", $prefix . q (Global 'my $bar'; pad_find_my_symbol_pvn ());
+    is pad_scalar (PAD_FIND_MY_SYMBOL_SV,  "bar"), "wobble", $prefix . q (Global 'my $bar'; pad_find_my_symbol_sv ());
 }
 
 aa(1);
@@ -82,14 +90,15 @@ sub bb() {
     my $counter = 0;
     my $foo = \$counter;
     return sub {
-        ok pad_scalar (PAD_FINDMY_SV,          "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
-        ok pad_scalar (PAD_FINDMY_PVN,         "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
-        ok pad_scalar (PAD_FINDMY_PV,          "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
-        ok pad_scalar (PAD_FINDMY_FOO,         "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
-        ok pad_scalar (PAD_FIND_MY_SYMBOL_PV,  "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
-        ok pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FINDMY_SV,          "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FINDMY_PVN,         "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FINDMY_PV,          "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FINDMY_FOO,         "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FIND_MY_SYMBOL_PV,  "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FIND_MY_SYMBOL_SV,  "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
 
-        my $modulus = pad_scalar (PAD_FINDMY_SV, "counter") % 5;
+        my $modulus = pad_scalar (PAD_FINDMY_SV, "counter") % 6;
 
         return pad_scalar (PAD_FINDMY_SV,  "counter")++
             if $modulus == 0;
@@ -103,8 +112,11 @@ sub bb() {
         return pad_scalar (PAD_FIND_MY_SYMBOL_PV, "counter")++
             if $modulus == 3;
 
+        return pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "counter")++
+            if $modulus == 4;
+
         $all_increment_called = 1;
-        return pad_scalar (PAD_FIND_MY_SYMBOL_PVN,  "counter")++;
+        return pad_scalar (PAD_FIND_MY_SYMBOL_SV,  "counter")++;
     };
 }
 my $a = bb();
@@ -117,6 +129,7 @@ is $b->(), 0;
 is $b->(), 1;
 is $a->(), 4;
 is $b->(), 2;
+is $a->(), 5;
 
 ok $all_increment_called, q (all pad scalar methods called for increment);
 
@@ -127,5 +140,6 @@ is pad_scalar (PAD_FINDMY_FOO,         "foo"), "NOT_MY", q ('my $foo' still unde
 is pad_scalar (PAD_FIND_MY_SYMBOL_FOO, "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_find_my_symbol_pvs ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PV,  "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_find_my_symbol_pv ());
 is pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_find_my_symbol_pvn ());
+is pad_scalar (PAD_FIND_MY_SYMBOL_SV,  "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_find_my_symbol_sv ());
 
 1;

--- a/ext/XS-APItest/t/pad_scalar.t
+++ b/ext/XS-APItest/t/pad_scalar.t
@@ -1,7 +1,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 76;
+use Test::More tests => 73;
 
 use XS::APItest qw (
     PAD_FINDMY_FOO
@@ -11,48 +11,60 @@ use XS::APItest qw (
     pad_scalar
 );
 
-is pad_scalar (PAD_FINDMY_SV,  "foo"), "NOT_IN_PAD";
-is pad_scalar (PAD_FINDMY_PVN, "foo"), "NOT_IN_PAD";
-is pad_scalar (PAD_FINDMY_PV,  "foo"), "NOT_IN_PAD";
-is pad_scalar (PAD_FINDMY_FOO, "foo"), "NOT_IN_PAD";
-is pad_scalar (PAD_FINDMY_SV,  "bar"), "NOT_IN_PAD";
-is pad_scalar (PAD_FINDMY_PVN, "bar"), "NOT_IN_PAD";
-is pad_scalar (PAD_FINDMY_PV,  "bar"), "NOT_IN_PAD";
+is pad_scalar (PAD_FINDMY_SV,  "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_findmy_sv ());
+is pad_scalar (PAD_FINDMY_PVN, "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_findmy_pvn ());
+is pad_scalar (PAD_FINDMY_PV,  "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_findmy_pv ());
+is pad_scalar (PAD_FINDMY_FOO, "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_findmy_pvs ());
+
+is pad_scalar (PAD_FINDMY_SV,  "bar"), "NOT_IN_PAD", q (undeclared '$bar'; using pad_findmy_sv ());
+is pad_scalar (PAD_FINDMY_PVN, "bar"), "NOT_IN_PAD", q (undeclared '$bar'; using pad_findmy_pvn ());
+is pad_scalar (PAD_FINDMY_PV,  "bar"), "NOT_IN_PAD", q (undeclared '$bar'; using pad_findmy_pv ());
 
 our $foo = "wibble";
 my $bar = "wobble";
-is pad_scalar (PAD_FINDMY_SV,  "foo"), "NOT_MY";
-is pad_scalar (PAD_FINDMY_PVN, "foo"), "NOT_MY";
-is pad_scalar (PAD_FINDMY_PV,  "foo"), "NOT_MY";
-is pad_scalar (PAD_FINDMY_FOO, "foo"), "NOT_MY";
-is pad_scalar (PAD_FINDMY_SV,  "bar"), "wobble";
-is pad_scalar (PAD_FINDMY_PVN, "bar"), "wobble";
-is pad_scalar (PAD_FINDMY_PV,  "bar"), "wobble";
+is pad_scalar (PAD_FINDMY_SV,  "foo"), "NOT_MY", q ('our $foo'; pad_findmy_sv ());
+is pad_scalar (PAD_FINDMY_PVN, "foo"), "NOT_MY", q ('our $foo'; pad_findmy_pvn ());
+is pad_scalar (PAD_FINDMY_PV,  "foo"), "NOT_MY", q ('our $foo'; pad_findmy_pv ());
+is pad_scalar (PAD_FINDMY_FOO, "foo"), "NOT_MY", q ('our $foo'; pad_findmy_pvs ());
+
+is pad_scalar (PAD_FINDMY_SV,  "bar"), "wobble", q ('my $bar'; pad_findmy_sv ());
+is pad_scalar (PAD_FINDMY_PVN, "bar"), "wobble", q ('my $bar'; pad_findmy_pvn ());
+is pad_scalar (PAD_FINDMY_PV,  "bar"), "wobble", q ('my $bar'; pad_findmy_pv ());
 
 sub aa($);
 sub aa($) {
     my $xyz;
-    ok \pad_scalar (PAD_FINDMY_SV,  "xyz") == \$xyz;
-    ok \pad_scalar (PAD_FINDMY_PVN, "xyz") == \$xyz;
-    ok \pad_scalar (PAD_FINDMY_PV,  "xyz") == \$xyz;
-    aa(0) if $_[0];
-    ok \pad_scalar (PAD_FINDMY_SV,  "xyz") == \$xyz;
-    ok \pad_scalar (PAD_FINDMY_PVN, "xyz") == \$xyz;
-    ok \pad_scalar (PAD_FINDMY_PV,  "xyz") == \$xyz;
-    is pad_scalar (PAD_FINDMY_SV,  "bar"), "wobble";
-    is pad_scalar (PAD_FINDMY_PVN, "bar"), "wobble";
-    is pad_scalar (PAD_FINDMY_PV,  "bar"), "wobble";
+    my $prefix = $_[0]
+        ? ''
+        : '(recursive call) '
+        ;
+
+    ok \pad_scalar (PAD_FINDMY_SV,  "xyz") == \$xyz, $prefix . q (private variable; pad_findmy_sv ());
+    ok \pad_scalar (PAD_FINDMY_PVN, "xyz") == \$xyz, $prefix . q (private variable; pad_findmy_pvn ());
+    ok \pad_scalar (PAD_FINDMY_PV,  "xyz") == \$xyz, $prefix . q (private variable; pad_findmy_pv ());
+
+    if ($_[0]) {
+        aa(0); # recursive call
+        ok \pad_scalar (PAD_FINDMY_SV,  "xyz") == \$xyz, q (private variable (after recursive call); pad_findmy_sv ());
+        ok \pad_scalar (PAD_FINDMY_PVN, "xyz") == \$xyz, q (private variable (after recursive call); pad_findmy_pvn ());
+        ok \pad_scalar (PAD_FINDMY_PV,  "xyz") == \$xyz, q (private variable (after recursive call); pad_findmy_pv ());
+    }
+
+    is pad_scalar (PAD_FINDMY_SV,  "bar"), "wobble", $prefix . q (Global 'my $bar'; pad_findmy_sv ());
+    is pad_scalar (PAD_FINDMY_PVN, "bar"), "wobble", $prefix . q (Global 'my $bar'; pad_findmy_pvn ());
+    is pad_scalar (PAD_FINDMY_PV,  "bar"), "wobble", $prefix . q (Global 'my $bar'; pad_findmy_pv ());
 }
+
 aa(1);
 
 sub bb() {
     my $counter = 0;
     my $foo = \$counter;
     return sub {
-	ok pad_scalar (PAD_FINDMY_SV,  "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
-	ok pad_scalar (PAD_FINDMY_PVN, "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
-	ok pad_scalar (PAD_FINDMY_PV,  "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
-	ok pad_scalar (PAD_FINDMY_FOO, "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
+	ok pad_scalar (PAD_FINDMY_SV,  "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
+	ok pad_scalar (PAD_FINDMY_PVN, "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
+	ok pad_scalar (PAD_FINDMY_PV,  "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
+	ok pad_scalar (PAD_FINDMY_FOO, "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
 	if(pad_scalar (PAD_FINDMY_SV,  "counter") % 3 == 0) {
 	    return pad_scalar (PAD_FINDMY_SV,  "counter")++;
 	} elsif(pad_scalar (PAD_FINDMY_SV,  "counter") % 3 == 1) {
@@ -73,9 +85,9 @@ is $b->(), 1;
 is $a->(), 4;
 is $b->(), 2;
 
-is pad_scalar (PAD_FINDMY_SV,  "foo"), "NOT_MY";
-is pad_scalar (PAD_FINDMY_PVN, "foo"), "NOT_MY";
-is pad_scalar (PAD_FINDMY_PV,  "foo"), "NOT_MY";
-is pad_scalar (PAD_FINDMY_FOO, "foo"), "NOT_MY";
+is pad_scalar (PAD_FINDMY_SV,  "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_findmy_sv ());
+is pad_scalar (PAD_FINDMY_PVN, "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_findmy_pvn ());
+is pad_scalar (PAD_FINDMY_PV,  "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_findmy_pv ());
+is pad_scalar (PAD_FINDMY_FOO, "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_findmy_pvs ());
 
 1;

--- a/ext/XS-APItest/t/pad_scalar.t
+++ b/ext/XS-APItest/t/pad_scalar.t
@@ -1,35 +1,40 @@
 use warnings;
 use strict;
 
-use Test::More tests => 73;
+use Test::More tests => 92;
 
 use XS::APItest qw (
     PAD_FINDMY_FOO
     PAD_FINDMY_PV
     PAD_FINDMY_PVN
     PAD_FINDMY_SV
+    PAD_FIND_MY_SYMBOL_PVN
     pad_scalar
 );
 
-is pad_scalar (PAD_FINDMY_SV,  "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_findmy_sv ());
-is pad_scalar (PAD_FINDMY_PVN, "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_findmy_pvn ());
-is pad_scalar (PAD_FINDMY_PV,  "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_findmy_pv ());
-is pad_scalar (PAD_FINDMY_FOO, "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_findmy_pvs ());
+is pad_scalar (PAD_FINDMY_SV,          "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_findmy_sv ());
+is pad_scalar (PAD_FINDMY_PVN,         "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_findmy_pvn ());
+is pad_scalar (PAD_FINDMY_PV,          "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_findmy_pv ());
+is pad_scalar (PAD_FINDMY_FOO,         "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_findmy_pvs ());
+is pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "foo"), "NOT_IN_PAD", q (undeclared '$foo'; pad_find_my_symbol_pvn ());
 
-is pad_scalar (PAD_FINDMY_SV,  "bar"), "NOT_IN_PAD", q (undeclared '$bar'; using pad_findmy_sv ());
-is pad_scalar (PAD_FINDMY_PVN, "bar"), "NOT_IN_PAD", q (undeclared '$bar'; using pad_findmy_pvn ());
-is pad_scalar (PAD_FINDMY_PV,  "bar"), "NOT_IN_PAD", q (undeclared '$bar'; using pad_findmy_pv ());
+is pad_scalar (PAD_FINDMY_SV,          "bar"), "NOT_IN_PAD", q (undeclared '$bar'; pad_findmy_sv ());
+is pad_scalar (PAD_FINDMY_PVN,         "bar"), "NOT_IN_PAD", q (undeclared '$bar'; pad_findmy_pvn ());
+is pad_scalar (PAD_FINDMY_PV,          "bar"), "NOT_IN_PAD", q (undeclared '$bar'; pad_findmy_pv ());
+is pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "bar"), "NOT_IN_PAD", q (undeclared '$bar'; pad_find_my_symbol_pvn ());
 
 our $foo = "wibble";
 my $bar = "wobble";
-is pad_scalar (PAD_FINDMY_SV,  "foo"), "NOT_MY", q ('our $foo'; pad_findmy_sv ());
-is pad_scalar (PAD_FINDMY_PVN, "foo"), "NOT_MY", q ('our $foo'; pad_findmy_pvn ());
-is pad_scalar (PAD_FINDMY_PV,  "foo"), "NOT_MY", q ('our $foo'; pad_findmy_pv ());
-is pad_scalar (PAD_FINDMY_FOO, "foo"), "NOT_MY", q ('our $foo'; pad_findmy_pvs ());
+is pad_scalar (PAD_FINDMY_SV,          "foo"), "NOT_MY", q ('our $foo'; pad_findmy_sv ());
+is pad_scalar (PAD_FINDMY_PVN,         "foo"), "NOT_MY", q ('our $foo'; pad_findmy_pvn ());
+is pad_scalar (PAD_FINDMY_PV,          "foo"), "NOT_MY", q ('our $foo'; pad_findmy_pv ());
+is pad_scalar (PAD_FINDMY_FOO,         "foo"), "NOT_MY", q ('our $foo'; pad_findmy_pvs ());
+is pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "foo"), "NOT_MY", q ('our $foo'; pad_find_my_symbol_pvn ());
 
-is pad_scalar (PAD_FINDMY_SV,  "bar"), "wobble", q ('my $bar'; pad_findmy_sv ());
-is pad_scalar (PAD_FINDMY_PVN, "bar"), "wobble", q ('my $bar'; pad_findmy_pvn ());
-is pad_scalar (PAD_FINDMY_PV,  "bar"), "wobble", q ('my $bar'; pad_findmy_pv ());
+is pad_scalar (PAD_FINDMY_SV,          "bar"), "wobble", q ('my $bar'; pad_findmy_sv ());
+is pad_scalar (PAD_FINDMY_PVN,         "bar"), "wobble", q ('my $bar'; pad_findmy_pvn ());
+is pad_scalar (PAD_FINDMY_PV,          "bar"), "wobble", q ('my $bar'; pad_findmy_pv ());
+is pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "bar"), "wobble", q ('my $bar'; pad_find_my_symbol_pvn ());
 
 sub aa($);
 sub aa($) {
@@ -39,39 +44,52 @@ sub aa($) {
         : '(recursive call) '
         ;
 
-    ok \pad_scalar (PAD_FINDMY_SV,  "xyz") == \$xyz, $prefix . q (private variable; pad_findmy_sv ());
-    ok \pad_scalar (PAD_FINDMY_PVN, "xyz") == \$xyz, $prefix . q (private variable; pad_findmy_pvn ());
-    ok \pad_scalar (PAD_FINDMY_PV,  "xyz") == \$xyz, $prefix . q (private variable; pad_findmy_pv ());
+    ok \pad_scalar (PAD_FINDMY_SV,          "xyz") == \$xyz, $prefix . q (private variable; pad_findmy_sv ());
+    ok \pad_scalar (PAD_FINDMY_PVN,         "xyz") == \$xyz, $prefix . q (private variable; pad_findmy_pvn ());
+    ok \pad_scalar (PAD_FINDMY_PV,          "xyz") == \$xyz, $prefix . q (private variable; pad_findmy_pv ());
+    ok \pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "xyz") == \$xyz, $prefix . q (private variable; pad_find_my_symbol_pvn ());
 
     if ($_[0]) {
         aa(0); # recursive call
-        ok \pad_scalar (PAD_FINDMY_SV,  "xyz") == \$xyz, q (private variable (after recursive call); pad_findmy_sv ());
-        ok \pad_scalar (PAD_FINDMY_PVN, "xyz") == \$xyz, q (private variable (after recursive call); pad_findmy_pvn ());
-        ok \pad_scalar (PAD_FINDMY_PV,  "xyz") == \$xyz, q (private variable (after recursive call); pad_findmy_pv ());
+        ok \pad_scalar (PAD_FINDMY_SV,          "xyz") == \$xyz, q (private variable (after recursive call); pad_findmy_sv ());
+        ok \pad_scalar (PAD_FINDMY_PVN,         "xyz") == \$xyz, q (private variable (after recursive call); pad_findmy_pvn ());
+        ok \pad_scalar (PAD_FINDMY_PV,          "xyz") == \$xyz, q (private variable (after recursive call); pad_findmy_pv ());
+        ok \pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "xyz") == \$xyz, q (private variable (after recursive call); pad_find_my_symbol_pvn ());
     }
 
-    is pad_scalar (PAD_FINDMY_SV,  "bar"), "wobble", $prefix . q (Global 'my $bar'; pad_findmy_sv ());
-    is pad_scalar (PAD_FINDMY_PVN, "bar"), "wobble", $prefix . q (Global 'my $bar'; pad_findmy_pvn ());
-    is pad_scalar (PAD_FINDMY_PV,  "bar"), "wobble", $prefix . q (Global 'my $bar'; pad_findmy_pv ());
+    is pad_scalar (PAD_FINDMY_SV,          "bar"), "wobble", $prefix . q (Global 'my $bar'; pad_findmy_sv ());
+    is pad_scalar (PAD_FINDMY_PVN,         "bar"), "wobble", $prefix . q (Global 'my $bar'; pad_findmy_pvn ());
+    is pad_scalar (PAD_FINDMY_PV,          "bar"), "wobble", $prefix . q (Global 'my $bar'; pad_findmy_pv ());
+    is pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "bar"), "wobble", $prefix . q (Global 'my $bar'; pad_find_my_symbol_pvn ());
 }
 
 aa(1);
+
+my $all_increment_called = 0;
 
 sub bb() {
     my $counter = 0;
     my $foo = \$counter;
     return sub {
-	ok pad_scalar (PAD_FINDMY_SV,  "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
-	ok pad_scalar (PAD_FINDMY_PVN, "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
-	ok pad_scalar (PAD_FINDMY_PV,  "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
-	ok pad_scalar (PAD_FINDMY_FOO, "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
-	if(pad_scalar (PAD_FINDMY_SV,  "counter") % 3 == 0) {
-	    return pad_scalar (PAD_FINDMY_SV,  "counter")++;
-	} elsif(pad_scalar (PAD_FINDMY_SV,  "counter") % 3 == 1) {
-	    return pad_scalar (PAD_FINDMY_PVN, "counter")++;
-	} else {
-	    return pad_scalar (PAD_FINDMY_PV,  "counter")++;
-	}
+        ok pad_scalar (PAD_FINDMY_SV,          "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FINDMY_PVN,         "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FINDMY_PV,          "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FINDMY_FOO,         "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
+        ok pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "foo") == \pad_scalar (PAD_FINDMY_SV, "counter");
+
+        my $modulus = pad_scalar (PAD_FINDMY_SV, "counter") % 4;
+
+        return pad_scalar (PAD_FINDMY_SV,  "counter")++
+            if $modulus == 0;
+
+        return pad_scalar (PAD_FINDMY_PVN, "counter")++
+            if $modulus == 1;
+
+        return pad_scalar (PAD_FINDMY_PV,  "counter")++
+            if $modulus == 2;
+
+        $all_increment_called = 1;
+        return pad_scalar (PAD_FIND_MY_SYMBOL_PVN,  "counter")++;
     };
 }
 my $a = bb();
@@ -85,9 +103,12 @@ is $b->(), 1;
 is $a->(), 4;
 is $b->(), 2;
 
-is pad_scalar (PAD_FINDMY_SV,  "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_findmy_sv ());
-is pad_scalar (PAD_FINDMY_PVN, "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_findmy_pvn ());
-is pad_scalar (PAD_FINDMY_PV,  "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_findmy_pv ());
-is pad_scalar (PAD_FINDMY_FOO, "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_findmy_pvs ());
+ok $all_increment_called, q (all pad scalar methods called for increment);
+
+is pad_scalar (PAD_FINDMY_SV,          "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_findmy_sv ());
+is pad_scalar (PAD_FINDMY_PVN,         "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_findmy_pvn ());
+is pad_scalar (PAD_FINDMY_PV,          "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_findmy_pv ());
+is pad_scalar (PAD_FINDMY_FOO,         "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_findmy_pvs ());
+is pad_scalar (PAD_FIND_MY_SYMBOL_PVN, "foo"), "NOT_MY", q ('my $foo' still undeclared; pad_find_my_symbol_pvn ());
 
 1;

--- a/ext/XS-APItest/t/pad_scalar.t
+++ b/ext/XS-APItest/t/pad_scalar.t
@@ -55,7 +55,7 @@ sub bb() {
 	ok pad_scalar (PAD_FINDMY_FOO, "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
 	if(pad_scalar (PAD_FINDMY_SV,  "counter") % 3 == 0) {
 	    return pad_scalar (PAD_FINDMY_SV,  "counter")++;
-	} elsif(pad_scalar (PAD_FINDMY_SV,  "counter") % 3 == 0) {
+	} elsif(pad_scalar (PAD_FINDMY_SV,  "counter") % 3 == 1) {
 	    return pad_scalar (PAD_FINDMY_PVN, "counter")++;
 	} else {
 	    return pad_scalar (PAD_FINDMY_PV,  "counter")++;

--- a/ext/XS-APItest/t/pad_scalar.t
+++ b/ext/XS-APItest/t/pad_scalar.t
@@ -3,39 +3,45 @@ use strict;
 
 use Test::More tests => 76;
 
-use XS::APItest qw(pad_scalar);
+use XS::APItest qw (
+    PAD_FINDMY_FOO
+    PAD_FINDMY_PV
+    PAD_FINDMY_PVN
+    PAD_FINDMY_SV
+    pad_scalar
+);
 
-is pad_scalar(1, "foo"), "NOT_IN_PAD";
-is pad_scalar(2, "foo"), "NOT_IN_PAD";
-is pad_scalar(3, "foo"), "NOT_IN_PAD";
-is pad_scalar(4, "foo"), "NOT_IN_PAD";
-is pad_scalar(1, "bar"), "NOT_IN_PAD";
-is pad_scalar(2, "bar"), "NOT_IN_PAD";
-is pad_scalar(3, "bar"), "NOT_IN_PAD";
+is pad_scalar (PAD_FINDMY_SV,  "foo"), "NOT_IN_PAD";
+is pad_scalar (PAD_FINDMY_PVN, "foo"), "NOT_IN_PAD";
+is pad_scalar (PAD_FINDMY_PV,  "foo"), "NOT_IN_PAD";
+is pad_scalar (PAD_FINDMY_FOO, "foo"), "NOT_IN_PAD";
+is pad_scalar (PAD_FINDMY_SV,  "bar"), "NOT_IN_PAD";
+is pad_scalar (PAD_FINDMY_PVN, "bar"), "NOT_IN_PAD";
+is pad_scalar (PAD_FINDMY_PV,  "bar"), "NOT_IN_PAD";
 
 our $foo = "wibble";
 my $bar = "wobble";
-is pad_scalar(1, "foo"), "NOT_MY";
-is pad_scalar(2, "foo"), "NOT_MY";
-is pad_scalar(3, "foo"), "NOT_MY";
-is pad_scalar(4, "foo"), "NOT_MY";
-is pad_scalar(1, "bar"), "wobble";
-is pad_scalar(2, "bar"), "wobble";
-is pad_scalar(3, "bar"), "wobble";
+is pad_scalar (PAD_FINDMY_SV,  "foo"), "NOT_MY";
+is pad_scalar (PAD_FINDMY_PVN, "foo"), "NOT_MY";
+is pad_scalar (PAD_FINDMY_PV,  "foo"), "NOT_MY";
+is pad_scalar (PAD_FINDMY_FOO, "foo"), "NOT_MY";
+is pad_scalar (PAD_FINDMY_SV,  "bar"), "wobble";
+is pad_scalar (PAD_FINDMY_PVN, "bar"), "wobble";
+is pad_scalar (PAD_FINDMY_PV,  "bar"), "wobble";
 
 sub aa($);
 sub aa($) {
     my $xyz;
-    ok \pad_scalar(1, "xyz") == \$xyz;
-    ok \pad_scalar(2, "xyz") == \$xyz;
-    ok \pad_scalar(3, "xyz") == \$xyz;
+    ok \pad_scalar (PAD_FINDMY_SV,  "xyz") == \$xyz;
+    ok \pad_scalar (PAD_FINDMY_PVN, "xyz") == \$xyz;
+    ok \pad_scalar (PAD_FINDMY_PV,  "xyz") == \$xyz;
     aa(0) if $_[0];
-    ok \pad_scalar(1, "xyz") == \$xyz;
-    ok \pad_scalar(2, "xyz") == \$xyz;
-    ok \pad_scalar(3, "xyz") == \$xyz;
-    is pad_scalar(1, "bar"), "wobble";
-    is pad_scalar(2, "bar"), "wobble";
-    is pad_scalar(3, "bar"), "wobble";
+    ok \pad_scalar (PAD_FINDMY_SV,  "xyz") == \$xyz;
+    ok \pad_scalar (PAD_FINDMY_PVN, "xyz") == \$xyz;
+    ok \pad_scalar (PAD_FINDMY_PV,  "xyz") == \$xyz;
+    is pad_scalar (PAD_FINDMY_SV,  "bar"), "wobble";
+    is pad_scalar (PAD_FINDMY_PVN, "bar"), "wobble";
+    is pad_scalar (PAD_FINDMY_PV,  "bar"), "wobble";
 }
 aa(1);
 
@@ -43,16 +49,16 @@ sub bb() {
     my $counter = 0;
     my $foo = \$counter;
     return sub {
-	ok pad_scalar(1, "foo") == \pad_scalar(1, "counter");
-	ok pad_scalar(2, "foo") == \pad_scalar(1, "counter");
-	ok pad_scalar(3, "foo") == \pad_scalar(1, "counter");
-	ok pad_scalar(4, "foo") == \pad_scalar(1, "counter");
-	if(pad_scalar(1, "counter") % 3 == 0) {
-	    return pad_scalar(1, "counter")++;
-	} elsif(pad_scalar(1, "counter") % 3 == 0) {
-	    return pad_scalar(2, "counter")++;
+	ok pad_scalar (PAD_FINDMY_SV,  "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
+	ok pad_scalar (PAD_FINDMY_PVN, "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
+	ok pad_scalar (PAD_FINDMY_PV,  "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
+	ok pad_scalar (PAD_FINDMY_FOO, "foo") == \pad_scalar(PAD_FINDMY_SV, "counter");
+	if(pad_scalar (PAD_FINDMY_SV,  "counter") % 3 == 0) {
+	    return pad_scalar (PAD_FINDMY_SV,  "counter")++;
+	} elsif(pad_scalar (PAD_FINDMY_SV,  "counter") % 3 == 0) {
+	    return pad_scalar (PAD_FINDMY_PVN, "counter")++;
 	} else {
-	    return pad_scalar(3, "counter")++;
+	    return pad_scalar (PAD_FINDMY_PV,  "counter")++;
 	}
     };
 }
@@ -67,9 +73,9 @@ is $b->(), 1;
 is $a->(), 4;
 is $b->(), 2;
 
-is pad_scalar(1, "foo"), "NOT_MY";
-is pad_scalar(2, "foo"), "NOT_MY";
-is pad_scalar(3, "foo"), "NOT_MY";
-is pad_scalar(4, "foo"), "NOT_MY";
+is pad_scalar (PAD_FINDMY_SV,  "foo"), "NOT_MY";
+is pad_scalar (PAD_FINDMY_PVN, "foo"), "NOT_MY";
+is pad_scalar (PAD_FINDMY_PV,  "foo"), "NOT_MY";
+is pad_scalar (PAD_FINDMY_FOO, "foo"), "NOT_MY";
 
 1;

--- a/handy.h
+++ b/handy.h
@@ -417,6 +417,44 @@ Perl_xxx(aTHX_ ...) form for any API calls where it's used.
 #define newSVpvs_share(str) Perl_newSVpvn_share(aTHX_ STR_WITH_LEN(str), 0)
 
 /*
+=for apidoc_section $utility
+
+=for apidoc Amu|Function call|EXPAND_CALL|Macro, Arguments_List
+
+When calling macro C<Function> with arguments containing another macro
+which expands as multiple arguments (for example: C<STR_WITH_LEN>) we
+need to expand arguments before expanding C<Function> macro.
+
+Usage:
+
+    #define my_macro(Arg1, Arg2) \
+        EXPAND_CALL (Macro, (Arg1, STR_WITH_LEN (Arg2))
+
+Note: C<Arguments_List> must include C<()> to enforce single expression
+
+Example:
+
+    #define pad_add_symbol_pvs(Table, Name, Flags, Type, Our) \
+        EXPAND_CALL (                                         \
+            pad_add_symbol_pvn,                               \
+            (Table, STR_WITH_LEN (Name), Flags, Type, Our)    \
+        )
+
+In this case C<pad_add_symbol_pvn> is macro so calling it directly fails
+because C<STR_WITH_LEN> expands as two arguments, but for preprocessor, when used
+directly, it is only one.
+
+Using C<EXPAND_CALL> introduces additional step where any macro used in arguments
+is expanded before expanding C<Macro> itself.
+
+=cut
+
+*/
+
+#define EXPAND_CALL(Macro, Args)                                      \
+    Macro Args
+
+/*
 =for apidoc_defn Am|void|sv_catpvs_flags|SV * const dsv|"literal string"|I32 flags
 =for apidoc_defn Am|void|sv_catpvs_nomg|SV * const dsv|"literal string"
 =for apidoc_defn Am|void|sv_catpvs|SV * const dsv|"literal string"

--- a/op.c
+++ b/op.c
@@ -9814,7 +9814,7 @@ Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
             PADNAME * const pn = PAD_COMPNAME(padoff);
             const char * const name = PadnamePV(pn);
 
-            if (PadnameLEN(pn) == 2 && name[0] == '$' && name[1] == '_')
+            if (PadnameLEN(pn) == 2 && name[0] == Perl_Symbol_Table_Scalar && name[1] == '_')
                 enteriterpflags |= OPpITER_DEF;
         }
     }
@@ -14068,7 +14068,7 @@ S_simplify_sort(pTHX_ OP *o)
         do {
             if (kid->op_type == OP_PADSV) {
                 PADNAME * const name = PAD_COMPNAME(kid->op_targ);
-                if (PadnameLEN(name) == 2 && *PadnamePV(name) == '$'
+                if (PadnameLEN(name) == 2 && *PadnamePV(name) == Perl_Symbol_Table_Scalar
                  && (  PadnamePV(name)[1] == 'a'
                     || PadnamePV(name)[1] == 'b'  ))
                     /* diag_listed_as: "my %s" used in sort comparison */

--- a/op.c
+++ b/op.c
@@ -809,7 +809,7 @@ Perl_allocmy(pTHX_ const char *const name, const STRLEN len, const U32 flags)
     else if(PL_parser->in_my == KEY_field)
         addflags |= padadd_FIELD;
 
-    off = pad_add_name_pvn(name, len, addflags,
+    off = pad_add_symbol_pvn (*name, name + 1, len - 1, addflags,
                     PL_parser->in_my_stash,
                     (is_our
                         /* $_ is always in main::, even with our */
@@ -8622,7 +8622,7 @@ S_newONCEOP(pTHX_ OP *initop, OP *padop)
     /* Store the initializedness of state vars in a separate
        pad entry.  */
     condop->op_targ =
-      pad_add_name_pvn("$",1,padadd_NO_DUP_CHECK|padadd_STATE,0,0);
+      pad_add_symbol_pvn (Perl_Symbol_Table_Scalar, "", 0, padadd_NO_DUP_CHECK|padadd_STATE,0,0);
     /* hijacking PADSTALE for uninitialized state variables */
     SvPADSTALE_on(PAD_SVl(condop->op_targ));
 
@@ -9390,10 +9390,10 @@ Perl_newRANGE(pTHX_ I32 flags, OP *left, OP *right)
     right->op_next = flop;
 
     range->op_targ =
-        pad_add_name_pvn("$", 1, padadd_NO_DUP_CHECK|padadd_STATE, 0, 0);
+        pad_add_symbol_pvn (Perl_Symbol_Table_Scalar, "", 0, padadd_NO_DUP_CHECK|padadd_STATE, 0, 0);
     sv_upgrade(PAD_SV(range->op_targ), SVt_PVNV);
     flip->op_targ =
-        pad_add_name_pvn("$", 1, padadd_NO_DUP_CHECK|padadd_STATE, 0, 0);;
+        pad_add_symbol_pvn (Perl_Symbol_Table_Scalar, "", 0, padadd_NO_DUP_CHECK|padadd_STATE, 0, 0);
     sv_upgrade(PAD_SV(flip->op_targ), SVt_PVNV);
     SvPADTMP_on(PAD_SV(flip->op_targ));
 

--- a/op.c
+++ b/op.c
@@ -9814,7 +9814,7 @@ Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
             PADNAME * const pn = PAD_COMPNAME(padoff);
             const char * const name = PadnamePV(pn);
 
-            if (PadnameLEN(pn) == 2 && name[0] == Perl_Symbol_Table_Scalar && name[1] == '_')
+            if (PadnameLEN(pn) == 2 && Padname_Is_Symbol_Table_Scalar (pn) && name[1] == '_')
                 enteriterpflags |= OPpITER_DEF;
         }
     }
@@ -14068,7 +14068,7 @@ S_simplify_sort(pTHX_ OP *o)
         do {
             if (kid->op_type == OP_PADSV) {
                 PADNAME * const name = PAD_COMPNAME(kid->op_targ);
-                if (PadnameLEN(name) == 2 && *PadnamePV(name) == Perl_Symbol_Table_Scalar
+                if (PadnameLEN(name) == 2 && Padname_Is_Symbol_Table_Scalar (name)
                  && (  PadnamePV(name)[1] == 'a'
                     || PadnamePV(name)[1] == 'b'  ))
                     /* diag_listed_as: "my %s" used in sort comparison */

--- a/op.c
+++ b/op.c
@@ -13973,14 +13973,10 @@ Perl_ck_sort(pTHX_ OP *o)
         }
         else if (kid->op_type == OP_CONST
               && kid->op_private & OPpCONST_BARE) {
-            char tmpbuf[256];
             STRLEN len;
             PADOFFSET off;
             const char * const name = SvPV(kSVOP_sv, len);
-            *tmpbuf = '&';
-            assert (len < 256);
-            Copy(name, tmpbuf+1, len, char);
-            off = pad_findmy_pvn(tmpbuf, len+1, 0);
+            off = pad_find_my_symbol_pvn (Perl_Symbol_Table_Code, name, len, 0);
             if (off != NOT_IN_PAD) {
                 if (PAD_COMPNAME_FLAGS_isOUR(off)) {
                     SV * const fq =

--- a/op.c
+++ b/op.c
@@ -9814,7 +9814,7 @@ Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
             PADNAME * const pn = PAD_COMPNAME(padoff);
             const char * const name = Padname_Symbol_Name (pn);
 
-            if (PadnameLEN(pn) == 2 && Padname_Is_Symbol_Table_Scalar (pn) && name[0] == '_')
+            if (Padname_Symbol_Name_Length (pn) == 1 && Padname_Is_Symbol_Table_Scalar (pn) && name[0] == '_')
                 enteriterpflags |= OPpITER_DEF;
         }
     }
@@ -10289,7 +10289,7 @@ S_already_defined(pTHX_ CV *const cv, OP * const block, OP * const o,
         const line_t oldline = CopLINE(PL_curcop);
         SV *namesv = o
             ? cSVOPo->op_sv
-            : newSVpvn_flags( Padname_Symbol_Name (name), PadnameLEN(name)-1,
+            : newSVpvn_flags( Padname_Symbol_Name (name), Padname_Symbol_Name_Length (name),
                (PadnameUTF8(name)) ? SVf_UTF8|SVs_TEMP : SVs_TEMP
               );
         if (PL_parser && PL_parser->copline != NOLINE)
@@ -10400,11 +10400,11 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
             hek = CvNAME_HEK(*spot);
         else {
             U32 hash;
-            PERL_HASH(hash, Padname_Symbol_Name (name), PadnameLEN(name)-1);
+            PERL_HASH(hash, Padname_Symbol_Name (name), Padname_Symbol_Name_Length (name));
             CvNAME_HEK_set(*spot, hek =
                 share_hek(
                     Padname_Symbol_Name (name),
-                    (PadnameLEN(name)-1) * (PadnameUTF8(name) ? -1 : 1),
+                    (Padname_Symbol_Name_Length (name)) * (PadnameUTF8(name) ? -1 : 1),
                     hash
                 )
             );
@@ -10559,9 +10559,9 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
         if (hek) (void)share_hek_hek(hek);
         else {
             U32 hash;
-            PERL_HASH(hash, Padname_Symbol_Name (name), PadnameLEN(name)-1);
+            PERL_HASH(hash, Padname_Symbol_Name (name), Padname_Symbol_Name_Length (name));
             hek = share_hek(Padname_Symbol_Name (name),
-                      (PadnameLEN(name)-1) * (PadnameUTF8(name) ? -1 : 1),
+                      (Padname_Symbol_Name_Length (name)) * (PadnameUTF8(name) ? -1 : 1),
                       hash);
         }
         CvNAME_HEK_set(cv, hek);
@@ -10622,7 +10622,7 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
             else
                 sv_setpvs(tmpstr, "__ANON__::");
 
-            sv_catpvn_flags(tmpstr, Padname_Symbol_Name (name), PadnameLEN(name)-1,
+            sv_catpvn_flags(tmpstr, Padname_Symbol_Name (name), Padname_Symbol_Name_Length (name),
                             PadnameUTF8(name) ? SV_CATUTF8 : SV_CATBYTES);
             (void)hv_store_ent(GvHV(PL_DBsub), tmpstr, sv, 0);
             hv = GvHVn(db_postponed);
@@ -13069,7 +13069,7 @@ Perl_ck_fun(pTHX_ OP *o)
                                 PADNAME * const pn
                                     = PAD_COMPNAME_SV(kid->op_targ);
                                 name = Padname_Symbol_Name (pn);
-                                len  = PadnameLEN(pn) - 1;
+                                len  = Padname_Symbol_Name_Length (pn);
                                 name_utf8 = PadnameUTF8(pn);
                             }
                             else if (kid->op_type == OP_RV2SV
@@ -14068,7 +14068,7 @@ S_simplify_sort(pTHX_ OP *o)
         do {
             if (kid->op_type == OP_PADSV) {
                 PADNAME * const name = PAD_COMPNAME(kid->op_targ);
-                if (PadnameLEN(name) == 2 && Padname_Is_Symbol_Table_Scalar (name)
+                if (Padname_Symbol_Name_Length (name) == 1 && Padname_Is_Symbol_Table_Scalar (name)
                  && (  Padname_Symbol_Name (name)[0] == 'a'
                     || Padname_Symbol_Name (name)[0] == 'b'  ))
                     /* diag_listed_as: "my %s" used in sort comparison */

--- a/op.c
+++ b/op.c
@@ -9812,9 +9812,9 @@ Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
             Perl_croak(aTHX_ "Can't use %s for loop variable", PL_op_desc[sv->op_type]);
         if (padoff) {
             PADNAME * const pn = PAD_COMPNAME(padoff);
-            const char * const name = PadnamePV(pn);
+            const char * const name = Padname_Symbol_Name (pn);
 
-            if (PadnameLEN(pn) == 2 && Padname_Is_Symbol_Table_Scalar (pn) && name[1] == '_')
+            if (PadnameLEN(pn) == 2 && Padname_Is_Symbol_Table_Scalar (pn) && name[0] == '_')
                 enteriterpflags |= OPpITER_DEF;
         }
     }
@@ -10289,7 +10289,7 @@ S_already_defined(pTHX_ CV *const cv, OP * const block, OP * const o,
         const line_t oldline = CopLINE(PL_curcop);
         SV *namesv = o
             ? cSVOPo->op_sv
-            : newSVpvn_flags( PadnamePV(name)+1,PadnameLEN(name)-1,
+            : newSVpvn_flags( Padname_Symbol_Name (name), PadnameLEN(name)-1,
                (PadnameUTF8(name)) ? SVf_UTF8|SVs_TEMP : SVs_TEMP
               );
         if (PL_parser && PL_parser->copline != NOLINE)
@@ -10400,10 +10400,10 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
             hek = CvNAME_HEK(*spot);
         else {
             U32 hash;
-            PERL_HASH(hash, PadnamePV(name)+1, PadnameLEN(name)-1);
+            PERL_HASH(hash, Padname_Symbol_Name (name), PadnameLEN(name)-1);
             CvNAME_HEK_set(*spot, hek =
                 share_hek(
-                    PadnamePV(name)+1,
+                    Padname_Symbol_Name (name),
                     (PadnameLEN(name)-1) * (PadnameUTF8(name) ? -1 : 1),
                     hash
                 )
@@ -10559,8 +10559,8 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
         if (hek) (void)share_hek_hek(hek);
         else {
             U32 hash;
-            PERL_HASH(hash, PadnamePV(name)+1, PadnameLEN(name)-1);
-            hek = share_hek(PadnamePV(name)+1,
+            PERL_HASH(hash, Padname_Symbol_Name (name), PadnameLEN(name)-1);
+            hek = share_hek(Padname_Symbol_Name (name),
                       (PadnameLEN(name)-1) * (PadnameUTF8(name) ? -1 : 1),
                       hash);
         }
@@ -10622,7 +10622,7 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
             else
                 sv_setpvs(tmpstr, "__ANON__::");
 
-            sv_catpvn_flags(tmpstr, PadnamePV(name)+1, PadnameLEN(name)-1,
+            sv_catpvn_flags(tmpstr, Padname_Symbol_Name (name), PadnameLEN(name)-1,
                             PadnameUTF8(name) ? SV_CATUTF8 : SV_CATBYTES);
             (void)hv_store_ent(GvHV(PL_DBsub), tmpstr, sv, 0);
             hv = GvHVn(db_postponed);
@@ -13068,8 +13068,8 @@ Perl_ck_fun(pTHX_ OP *o)
                             if (kid->op_type == OP_PADSV) {
                                 PADNAME * const pn
                                     = PAD_COMPNAME_SV(kid->op_targ);
-                                name = PadnamePV (pn);
-                                len  = PadnameLEN(pn);
+                                name = Padname_Symbol_Name (pn);
+                                len  = PadnameLEN(pn) - 1;
                                 name_utf8 = PadnameUTF8(pn);
                             }
                             else if (kid->op_type == OP_RV2SV
@@ -14069,8 +14069,8 @@ S_simplify_sort(pTHX_ OP *o)
             if (kid->op_type == OP_PADSV) {
                 PADNAME * const name = PAD_COMPNAME(kid->op_targ);
                 if (PadnameLEN(name) == 2 && Padname_Is_Symbol_Table_Scalar (name)
-                 && (  PadnamePV(name)[1] == 'a'
-                    || PadnamePV(name)[1] == 'b'  ))
+                 && (  Padname_Symbol_Name (name)[0] == 'a'
+                    || Padname_Symbol_Name (name)[0] == 'b'  ))
                     /* diag_listed_as: "my %s" used in sort comparison */
                     Perl_warner(aTHX_ packWARN(WARN_SYNTAX),
                                      "\"%s %s\" used in sort comparison",

--- a/op.c
+++ b/op.c
@@ -6074,7 +6074,7 @@ Perl_newBINOP(pTHX_ I32 type, I32 flags, OP *first, OP *last)
                                ? 2  /* Otherwise, minimum of 2 hex digits */\
                                : NUM_HEX_CHARS(num)))))))
 
-/* To make evident, Configure with `-DDEBUGGING`, build, run 
+/* To make evident, Configure with `-DDEBUGGING`, build, run
  *  `./perl -Ilib -Dy t/op/tr.t`
  */
 void

--- a/pad.c
+++ b/pad.c
@@ -114,7 +114,7 @@ write is called (if necessary).
 The flag C<SVs_PADSTALE> is cleared on lexicals each time the C<my()> is executed,
 and set on scope exit.  This allows the
 C<"Variable $x is not available"> warning
-to be generated in evals, such as 
+to be generated in evals, such as
 
     { my $x = 1; sub f { eval '$x'} } f();
 
@@ -1181,7 +1181,7 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV* cv,
                 DEBUG_Xv(PerlIO_printf(Perl_debug_log,
                     "Pad findlex cv=0x%" UVxf " matched: offset=%ld flags=0x%lx index=%lu\n",
                     PTR2UV(cv), (long)offset, (unsigned long)*out_flags,
-                    (unsigned long) PARENT_PAD_INDEX(*out_name) 
+                    (unsigned long) PARENT_PAD_INDEX(*out_name)
                 ));
             }
 
@@ -2008,7 +2008,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
                     S_unavailable(aTHX_ namesv);
                     sv = NULL;
                 }
-                else 
+                else
                     SvREFCNT_inc_simple_void_NN(sv);
             }
             if (!sv) {
@@ -2569,8 +2569,8 @@ Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
                                interacts with lexicals.  */
                             pad1a[ix] = sv_dup_inc(oldpad[ix], param);
                         } else {
-                            SV *sv; 
-                            
+                            SV *sv;
+
                             if (sigil == '@')
                                 sv = MUTABLE_SV(newAV());
                             else if (sigil == '%')

--- a/pad.c
+++ b/pad.c
@@ -404,7 +404,7 @@ Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
             SV ** const curpad = AvARRAY(comppad);
             for (ix = PadnamelistMAX(comppad_name); ix > 0; ix--) {
                 PADNAME * const name = namepad[ix];
-                if (name && PadnamePV(name) && *PadnamePV(name) == Perl_Symbol_Table_Code) {
+                if (name && PadnamePV(name) && Padname_Is_Symbol_Table_Code (name)) {
                     CV * const innercv = MUTABLE_CV(curpad[ix]);
                     if (PadnameIsOUR(name) && CvCLONED(&cvbody)) {
                         assert(!innercv);
@@ -907,7 +907,7 @@ S_pad_check_dup(pTHX_ PADNAME *name, U32 flags, const HV *ourstash)
                     PL_parser->in_my == KEY_sigvar ? "my"    :
                     PL_parser->in_my == KEY_field  ? "field" :
                                                      "state" ),
-                *PadnamePV(pn) == Perl_Symbol_Table_Code ? "subroutine" : "variable",
+                Padname_Is_Symbol_Table_Code (pn) ? "subroutine" : "variable",
                 PNfARG(pn),
                 (COP_SEQ_RANGE_HIGH(pn) == PERL_PADSEQ_INTRO
                     ? "scope" : "statement"));
@@ -1094,7 +1094,7 @@ S_unavailable(pTHX_ PADNAME *name)
     /* diag_listed_as: Variable "%s" is not available */
     Perl_ck_warner(aTHX_ packWARN(WARN_CLOSURE),
                         "%s \"%" PNf "\" is not available",
-                         *PadnamePV(name) == Perl_Symbol_Table_Code
+                         Padname_Is_Symbol_Table_Code (name)
                                          ? "Subroutine"
                                          : "Variable",
                          PNfARG(name));
@@ -1536,7 +1536,7 @@ Perl_pad_leavemy(pTHX)
                 (unsigned long)COP_SEQ_RANGE_HIGH(sv))
             );
             if (!PadnameIsSTATE(sv) && !PadnameIsOUR(sv)
-             && *PadnamePV(sv) == Perl_Symbol_Table_Code && PadnameLEN(sv) > 1) {
+             && Padname_Is_Symbol_Table_Code (sv) && PadnameLEN(sv) > 1) {
                 OP *kid = newOP(OP_INTROCV, 0);
                 kid->op_targ = off;
                 o = op_prepend_elem(OP_LINESEQ, kid, o);
@@ -1708,7 +1708,7 @@ Perl_pad_tidy(pTHX_ padtidy_type type)
                 continue;
             namesv = namep[ix];
             if (!(PadnamePV(namesv) &&
-                   (!PadnameLEN(namesv) || *PadnamePV(namesv) == Perl_Symbol_Table_Code)))
+                   (!PadnameLEN(namesv) || Padname_Is_Symbol_Table_Code (namesv))))
             {
                 SvREFCNT_dec(PL_curpad[ix]);
                 PL_curpad[ix] = NULL;
@@ -2092,7 +2092,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
                     PADNAME * const name =
                         (ix <= fname) ? pname[ix] : NULL;
                     if (name && name != &PL_padname_undef
-                     && !PadnameOUTER(name) && PadnamePV(name)[0] == Perl_Symbol_Table_Code
+                     && !PadnameOUTER(name) && Padname_Is_Symbol_Table_Code (name)
                      && PadnameIsSTATE(name) && !CvCLONED(PL_curpad[ix]))
                     {
                         CV * const protokey = CvOUTSIDE(ppad[ix]);
@@ -2119,7 +2119,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
                     PADNAME * const name =
                         (ix <= fname) ? pname[ix] : NULL;
                     if (name && name != &PL_padname_undef
-                     && !PadnameOUTER(name) && PadnamePV(name)[0] == Perl_Symbol_Table_Code
+                     && !PadnameOUTER(name) && Padname_Is_Symbol_Table_Code (name)
                      && PadnameIsSTATE(name) && !CvCLONED(PL_curpad[ix]))
                         S_cv_clone(aTHX_ (CV *)ppad[ix],
                                          (CV *)PL_curpad[ix],
@@ -2129,7 +2129,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
         else for (ix = fpad; ix > 0; ix--) {
             PADNAME * const name = (ix <= fname) ? pname[ix] : NULL;
             if (name && name != &PL_padname_undef && !PadnameOUTER(name)
-             && PadnamePV(name)[0] == Perl_Symbol_Table_Code && PadnameIsSTATE(name))
+             && Padname_Is_Symbol_Table_Code (name) && PadnameIsSTATE(name))
                 S_cv_clone(aTHX_ (CV *)ppad[ix], (CV *)PL_curpad[ix], cv,
                                  NULL);
         }
@@ -2367,7 +2367,7 @@ Perl_pad_fixup_inner_anons(pTHX_ PADLIST *padlist, CV *old_cv, CV *new_cv)
     for (ix = PadnamelistMAX(comppad_name); ix > 0; ix--) {
         const PADNAME *name = namepad[ix];
         if (name && name != &PL_padname_undef && !PadnameIsOUR(name)
-            && *PadnamePV(name) == Perl_Symbol_Table_Code)
+            && Padname_Is_Symbol_Table_Code (name))
         {
           CV *innercv = MUTABLE_CV(curpad[ix]);
           if (UNLIKELY(PadnameOUTER(name))) {

--- a/pad.c
+++ b/pad.c
@@ -655,12 +655,19 @@ Perl_pad_add_name_pvn(pTHX_ const char *namepv, STRLEN namelen,
     /* if it's not a simple scalar, replace with an AV or HV */
     assert(SvTYPE(PL_curpad[offset]) == SVt_NULL);
     assert(SvREFCNT(PL_curpad[offset]) == 1);
-    if (namelen != 0 && *namepv == Perl_Symbol_Table_Array)
-        sv_upgrade(PL_curpad[offset], SVt_PVAV);
-    else if (namelen != 0 && *namepv == Perl_Symbol_Table_Hash)
-        sv_upgrade(PL_curpad[offset], SVt_PVHV);
-    else if (namelen != 0 && *namepv == Perl_Symbol_Table_Code)
-        sv_upgrade(PL_curpad[offset], SVt_PVCV);
+    if (namelen != 0) {
+        switch (*namepv) {
+            case Perl_Symbol_Table_Array:
+                sv_upgrade(PL_curpad[offset], SVt_PVAV);
+                break;
+            case Perl_Symbol_Table_Hash:
+                sv_upgrade(PL_curpad[offset], SVt_PVHV);
+                break;
+            case Perl_Symbol_Table_Code:
+                sv_upgrade(PL_curpad[offset], SVt_PVCV);
+                break;
+        }
+    }
     assert(SvPADMY(PL_curpad[offset]));
     DEBUG_Xv(PerlIO_printf(Perl_debug_log,
                            "Pad addname: %ld \"" Padname_Symbol_Printf_Format "\" new lex=0x%" UVxf "\n",
@@ -1254,14 +1261,21 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV* cv,
                     }
                 }
                 if (!*out_capture) {
-                    if (namelen != 0 && *namepv == Perl_Symbol_Table_Array)
-                        *out_capture = newSV_type_mortal(SVt_PVAV);
-                    else if (namelen != 0 && *namepv == Perl_Symbol_Table_Hash)
-                        *out_capture = newSV_type_mortal(SVt_PVHV);
-                    else if (namelen != 0 && *namepv == Perl_Symbol_Table_Code)
-                        *out_capture = newSV_type_mortal(SVt_PVCV);
-                    else
-                        *out_capture = newSV_type_mortal(SVt_NULL);
+                    if (namelen != 0) {
+                        switch (*namepv) {
+                            case Perl_Symbol_Table_Array:
+                                *out_capture = newSV_type_mortal(SVt_PVAV);
+                                break;
+                            case Perl_Symbol_Table_Hash:
+                                *out_capture = newSV_type_mortal(SVt_PVHV);
+                                break;
+                            case Perl_Symbol_Table_Code:
+                                *out_capture = newSV_type_mortal(SVt_PVCV);
+                                break;
+                            default:
+                                *out_capture = newSV_type_mortal(SVt_NULL);
+                        }
+                    }
                 }
             }
 

--- a/pad.c
+++ b/pad.c
@@ -577,7 +577,7 @@ S_pad_alloc_name(pTHX_ PADNAME *name, U32 flags, HV *typestash,
     }
 
     padnamelist_store(PL_comppad_name, offset, name);
-    if (PadnameLEN(name) > 1)
+    if (Padname_Symbol_Name_Length (name) > 0)
         PadnamelistMAXNAMED(PL_comppad_name) = offset;
     return offset;
 }
@@ -1538,7 +1538,7 @@ Perl_pad_leavemy(pTHX)
                 (unsigned long)COP_SEQ_RANGE_HIGH(sv))
             );
             if (!PadnameIsSTATE(sv) && !PadnameIsOUR(sv)
-             && Padname_Is_Symbol_Table_Code (sv) && PadnameLEN(sv) > 1) {
+             && Padname_Is_Symbol_Table_Code (sv) && Padname_Symbol_Name_Length (sv) > 0) {
                 OP *kid = newOP(OP_INTROCV, 0);
                 kid->op_targ = off;
                 o = op_prepend_elem(OP_LINESEQ, kid, o);
@@ -2031,19 +2031,19 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
                         sv = newSV_type(SVt_PVCV);
                         CvLEXICAL_on(sv);
                     }
-                    else if (PadnameLEN(namesv)>1 && !PadnameIsOUR(namesv))
+                    else if (Padname_Symbol_Name_Length (namesv) > 0 && !PadnameIsOUR(namesv))
                     {
                         /* my sub */
                         /* Just provide a stub, but name it.  It will be
                            upgraded to the real thing on scope entry. */
                         U32 hash;
                         PERL_HASH(hash, Padname_Symbol_Name (namesv),
-                                  PadnameLEN(namesv) - 1);
+                                  Padname_Symbol_Name_Length (namesv));
                         sv = newSV_type(SVt_PVCV);
                         CvNAME_HEK_set(
                             sv,
                             share_hek(Padname_Symbol_Name (namesv),
-                                      1 - PadnameLEN(namesv),
+                                      - Padname_Symbol_Name_Length (namesv),
                                       hash)
                         );
                         CvLEXICAL_on(sv);

--- a/pad.c
+++ b/pad.c
@@ -909,7 +909,7 @@ S_pad_check_dup(pTHX_ PADNAME *name, U32 flags, const HV *ourstash)
                     PL_parser->in_my == KEY_sigvar ? "my"    :
                     PL_parser->in_my == KEY_field  ? "field" :
                                                      "state" ),
-                Perl_Symbol_Table_Title_lc (Padname_Symbol_Table (pn)),
+                Padname_Symbol_Table_Title_lc (pn),
                 PNfARG(pn),
                 (COP_SEQ_RANGE_HIGH(pn) == PERL_PADSEQ_INTRO
                     ? "scope" : "statement"));
@@ -1096,9 +1096,7 @@ S_unavailable(pTHX_ PADNAME *name)
     /* diag_listed_as: Variable "%s" is not available */
     Perl_ck_warner(aTHX_ packWARN(WARN_CLOSURE),
                         "%s \"%" PNf "\" is not available",
-                         Padname_Is_Symbol_Table_Code (name)
-                                         ? "Subroutine"
-                                         : "Variable",
+                         Padname_Symbol_Table_Title_ucfirst (name),
                          PNfARG(name));
 }
 

--- a/pad.c
+++ b/pad.c
@@ -2037,12 +2037,12 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
                         /* Just provide a stub, but name it.  It will be
                            upgraded to the real thing on scope entry. */
                         U32 hash;
-                        PERL_HASH(hash, PadnamePV(namesv)+1,
+                        PERL_HASH(hash, Padname_Symbol_Name (namesv),
                                   PadnameLEN(namesv) - 1);
                         sv = newSV_type(SVt_PVCV);
                         CvNAME_HEK_set(
                             sv,
-                            share_hek(PadnamePV(namesv)+1,
+                            share_hek(Padname_Symbol_Name (namesv),
                                       1 - PadnameLEN(namesv),
                                       hash)
                         );

--- a/pad.c
+++ b/pad.c
@@ -909,7 +909,7 @@ S_pad_check_dup(pTHX_ PADNAME *name, U32 flags, const HV *ourstash)
                     PL_parser->in_my == KEY_sigvar ? "my"    :
                     PL_parser->in_my == KEY_field  ? "field" :
                                                      "state" ),
-                Padname_Is_Symbol_Table_Code (pn) ? "subroutine" : "variable",
+                Perl_Symbol_Table_Title_lc (Padname_Symbol_Table (pn)),
                 PNfARG(pn),
                 (COP_SEQ_RANGE_HIGH(pn) == PERL_PADSEQ_INTRO
                     ? "scope" : "statement"));
@@ -1220,7 +1220,7 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV* cv,
                                            shared */
                         Perl_warner(aTHX_ packWARN(WARN_CLOSURE),
                             "%s \"%" UTF8f "\" will not stay shared",
-                             *namepv == Perl_Symbol_Table_Code ? "Subroutine" : "Variable",
+                             Perl_Symbol_Table_Title_ucfirst (*namepv),
                              UTF8fARG(1, namelen, namepv));
                     }
 

--- a/pad.c
+++ b/pad.c
@@ -754,9 +754,11 @@ Perl_pad_alloc(pTHX_ I32 optype, U32 tmptype)
              * can be reused; not so for constants.
              */
             PADNAME *pn;
-            if (++retval <= names_fill &&
-                   (pn = names[retval]) && PadnamePV(pn))
-                continue;
+            if (++retval <= names_fill) {
+                pn = names[retval];
+                if (Padname_Is_Symbol (pn))
+                    continue;
+            }
             sv = *av_fetch_simple(PL_comppad, retval, TRUE);
             if (!(SvFLAGS(sv) &
 #ifdef USE_PAD_RESET
@@ -2059,7 +2061,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
             }
           }
         }
-        else if (namesv && PadnamePV(namesv)) {
+        else if (Padname_Is_Symbol (namesv)) {
             sv = SvREFCNT_inc_NN(ppad[ix]);
         }
         else {
@@ -2581,8 +2583,8 @@ Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
                         }
                     }
                 }
-                else if ((  names_fill >= ix && names[ix]
-                         && PadnamePV(names[ix])  )) {
+                else if ((  names_fill >= ix
+                         && Padname_Is_Symbol (names[ix])  )) {
                     pad1a[ix] = sv_dup_inc(oldpad[ix], param);
                 }
                 else {

--- a/pad.c
+++ b/pad.c
@@ -1037,6 +1037,7 @@ C<flags> is reserved and must be zero.
 
 =for apidoc pad_find_my_symbol_pv
 =for apidoc_item pad_find_my_symbol_pvn
+=for apidoc_item pad_find_my_symbol_pvs
 
 Similar to C<pad_findmy_pv> but with explicit symbol table parameter.
 
@@ -1047,6 +1048,9 @@ Difference:
 
     pad_findmy_pvn ("$self", 5, 0);
     pad_find_my_symbol_pvn (Perl_Symbol_Scalar, "self", 5, 0);
+
+    pad_findmy_pvs ("$self", 0);
+    pad_find_my_symbol_pvs (Perl_Symbol_Scalar, "self", 0);
 
 =cut
 */

--- a/pad.c
+++ b/pad.c
@@ -663,8 +663,8 @@ Perl_pad_add_name_pvn(pTHX_ const char *namepv, STRLEN namelen,
         sv_upgrade(PL_curpad[offset], SVt_PVCV);
     assert(SvPADMY(PL_curpad[offset]));
     DEBUG_Xv(PerlIO_printf(Perl_debug_log,
-                           "Pad addname: %ld \"%s\" new lex=0x%" UVxf "\n",
-                           (long)offset, PadnamePV(name),
+                           "Pad addname: %ld \"" Padname_Symbol_Printf_Format "\" new lex=0x%" UVxf "\n",
+                           (long)offset, Padname_Symbol_Printf_Params (name),
                            PTR2UV(PL_curpad[offset])));
 
     return offset;
@@ -1323,10 +1323,9 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV* cv,
                               );
 
         DEBUG_Xv(PerlIO_printf(Perl_debug_log,
-                               "Pad addname: %ld \"%.*s\" FAKE\n",
+                               "Pad addname: %ld \"" Padname_Symbol_Printf_Format "\" FAKE\n",
                                (long)new_offset,
-                               (int) PadnameLEN(new_name),
-                               PadnamePV(new_name)));
+                               Padname_Symbol_Printf_Params (new_name)));
         PARENT_FAKELEX_FLAGS_set(new_name, *out_flags);
 
         PARENT_PAD_INDEX_set(new_name, 0);
@@ -1477,8 +1476,8 @@ Perl_intro_my(pTHX)
             COP_SEQ_RANGE_HIGH_set(sv, PERL_PADSEQ_INTRO); /* Don't know scope end yet. */
             COP_SEQ_RANGE_LOW_set(sv, PL_cop_seqmax);
             DEBUG_Xv(PerlIO_printf(Perl_debug_log,
-                "Pad intromy: %ld \"%s\", (%lu,%lu)\n",
-                (long)i, PadnamePV(sv),
+                "Pad intromy: %ld \"" Padname_Symbol_Printf_Format "\", (%lu,%lu)\n",
+                (long)i, Padname_Symbol_Printf_Params(sv),
                 (unsigned long)COP_SEQ_RANGE_LOW(sv),
                 (unsigned long)COP_SEQ_RANGE_HIGH(sv))
             );
@@ -1530,8 +1529,8 @@ Perl_pad_leavemy(pTHX)
         {
             COP_SEQ_RANGE_HIGH_set(sv, PL_cop_seqmax);
             DEBUG_Xv(PerlIO_printf(Perl_debug_log,
-                "Pad leavemy: %ld \"%s\", (%lu,%lu)\n",
-                (long)off, PadnamePV(sv),
+                "Pad leavemy: %ld \"" Padname_Symbol_Printf_Format "\", (%lu,%lu)\n",
+                (long)off, Padname_Symbol_Printf_Params (sv),
                 (unsigned long)COP_SEQ_RANGE_LOW(sv),
                 (unsigned long)COP_SEQ_RANGE_HIGH(sv))
             );
@@ -1831,24 +1830,24 @@ Perl_do_dump_pad(pTHX_ I32 level, PerlIO *file, PADLIST *padlist, int full)
         if (namesv) {
             if (PadnameOUTER(namesv))
                 Perl_dump_indent(aTHX_ level+1, file,
-                    "%2d. 0x%" UVxf "<%lu> FAKE \"%s\" flags=0x%lx index=%lu\n",
+                    "%2d. 0x%" UVxf "<%lu> FAKE \"" Padname_Symbol_Printf_Format "\" flags=0x%lx index=%lu\n",
                     (int) ix,
                     PTR2UV(ppad[ix]),
                     (unsigned long) (ppad[ix] ? SvREFCNT(ppad[ix]) : 0),
-                    PadnamePV(namesv),
+                    Padname_Symbol_Printf_Params (namesv),
                     (unsigned long)PARENT_FAKELEX_FLAGS(namesv),
                     (unsigned long)PARENT_PAD_INDEX(namesv)
 
                 );
             else
                 Perl_dump_indent(aTHX_ level+1, file,
-                    "%2d. 0x%" UVxf "<%lu> (%lu,%lu) \"%s\"\n",
+                    "%2d. 0x%" UVxf "<%lu> (%lu,%lu) \"" Padname_Symbol_Printf_Format "\"\n",
                     (int) ix,
                     PTR2UV(ppad[ix]),
                     (unsigned long) (ppad[ix] ? SvREFCNT(ppad[ix]) : 0),
                     (unsigned long)COP_SEQ_RANGE_LOW(namesv),
                     (unsigned long)COP_SEQ_RANGE_HIGH(namesv),
-                    PadnamePV(namesv)
+                    Padname_Symbol_Printf_Params (namesv)
                 );
         }
         else if (full) {

--- a/pad.c
+++ b/pad.c
@@ -2014,7 +2014,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
                     SvREFCNT_inc_simple_void_NN(sv);
             }
             if (!sv) {
-                const char sigil = PadnamePV(namesv)[0];
+                const char sigil = Padname_Symbol_Table (namesv);
                 if (sigil == Perl_Symbol_Table_Code)
                     /* If there are state subs, we need to clone them, too.
                        But they may need to close over variables we have
@@ -2447,7 +2447,7 @@ Perl_pad_push(pTHX_ PADLIST *padlist, int depth)
         for ( ;ix > 0; ix--) {
             SV *sv;
             if (names_fill >= ix && PadnameLEN(names[ix])) {
-                const char sigil = PadnamePV(names[ix])[0];
+                const char sigil = Padname_Symbol_Table (names[ix]);
                 if (PadnameOUTER(names[ix])
                         || PadnameIsSTATE(names[ix])
                         || sigil == Perl_Symbol_Table_Code)
@@ -2556,7 +2556,7 @@ Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
                     pad1a[ix] = NULL;
                 } else if (names_fill >= ix && names[ix] &&
                            PadnameLEN(names[ix])) {
-                    const char sigil = PadnamePV(names[ix])[0];
+                    const char sigil = Padname_Symbol_Table (names[ix]);
                     if (PadnameOUTER(names[ix])
                         || PadnameIsSTATE(names[ix])
                         || sigil == Perl_Symbol_Table_Code)

--- a/pad.c
+++ b/pad.c
@@ -1115,7 +1115,7 @@ PADOFFSET
 Perl_pad_findmy_pv(pTHX_ const char *name, U32 flags)
 {
     PERL_ARGS_ASSERT_PAD_FINDMY_PV;
-    return pad_findmy_pvn(name, strlen(name), flags);
+    return pad_find_my_symbol_pvn (*name, name + 1, strlen(name) - 1, flags);
 }
 
 PADOFFSET
@@ -1125,7 +1125,7 @@ Perl_pad_findmy_sv(pTHX_ SV *name, U32 flags)
     STRLEN namelen;
     PERL_ARGS_ASSERT_PAD_FINDMY_SV;
     namepv = SvPVutf8(name, namelen);
-    return pad_findmy_pvn(namepv, namelen, flags);
+    return pad_find_my_symbol_pvn (*namepv, namepv + 1, namelen - 1, flags);
 }
 
 /*

--- a/pad.c
+++ b/pad.c
@@ -701,7 +701,7 @@ Perl_pad_add_name_pv(pTHX_ const char *name,
                      const U32 flags, HV *typestash, HV *ourstash)
 {
     PERL_ARGS_ASSERT_PAD_ADD_NAME_PV;
-    return pad_add_name_pvn(name, strlen(name), flags, typestash, ourstash);
+    return pad_add_symbol_pvn (*name, name + 1, strlen(name) - 1, flags, typestash, ourstash);
 }
 
 PADOFFSET
@@ -711,7 +711,7 @@ Perl_pad_add_name_sv(pTHX_ SV *name, U32 flags, HV *typestash, HV *ourstash)
     STRLEN namelen;
     PERL_ARGS_ASSERT_PAD_ADD_NAME_SV;
     namepv = SvPVutf8(name, namelen);
-    return pad_add_name_pvn(namepv, namelen, flags, typestash, ourstash);
+    return pad_add_symbol_pvn (*namepv, namepv + 1, namelen - 1, flags, typestash, ourstash);
 }
 
 /*

--- a/pad.c
+++ b/pad.c
@@ -1035,15 +1035,18 @@ C<flags> is reserved and must be zero.
 
 =for apidoc Amnh||NOT_IN_PAD
 
-=for apidoc pad_find_my_symbol_pvn
+=for apidoc pad_find_my_symbol_pv
+=for apidoc_item pad_find_my_symbol_pvn
 
-Similar to C<pad_findmy_pvn> but with explicit symbol table parameter.
+Similar to C<pad_findmy_pv> but with explicit symbol table parameter.
 
 Difference:
 
-    pad_findmy_pvn ("$self", 5, 0);
+    pad_findmy_pv ("$self", 0);
+    pad_find_my_symbol_pv (Perl_Symbol_Scalar, "self", 0);
 
-    pad_find_my_symbol_pvn (Perl_Symbol_Scalar, "self", 5);
+    pad_findmy_pvn ("$self", 5, 0);
+    pad_find_my_symbol_pvn (Perl_Symbol_Scalar, "self", 5, 0);
 
 =cut
 */
@@ -1116,6 +1119,18 @@ Perl_pad_findmy_pv(pTHX_ const char *name, U32 flags)
 {
     PERL_ARGS_ASSERT_PAD_FINDMY_PV;
     return pad_find_my_symbol_pvn (*name, name + 1, strlen(name) - 1, flags);
+}
+
+PADOFFSET
+Perl_pad_find_my_symbol_pv(
+    pTHX_
+    perl_symbol_table_id find_symbol_table,
+    const char *         name,
+    U32                  flags
+)
+{
+    PERL_ARGS_ASSERT_PAD_FIND_MY_SYMBOL_PV;
+    return pad_find_my_symbol_pvn (find_symbol_table, name, strlen (name), flags);
 }
 
 PADOFFSET

--- a/pad.c
+++ b/pad.c
@@ -655,7 +655,7 @@ Perl_pad_add_name_pvn(pTHX_ const char *namepv, STRLEN namelen,
     /* if it's not a simple scalar, replace with an AV or HV */
     assert(SvTYPE(PL_curpad[offset]) == SVt_NULL);
     assert(SvREFCNT(PL_curpad[offset]) == 1);
-    if (namelen != 0 && *namepv == '@')
+    if (namelen != 0 && *namepv == Perl_Symbol_Table_Array)
         sv_upgrade(PL_curpad[offset], SVt_PVAV);
     else if (namelen != 0 && *namepv == '%')
         sv_upgrade(PL_curpad[offset], SVt_PVHV);
@@ -1254,7 +1254,7 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV* cv,
                     }
                 }
                 if (!*out_capture) {
-                    if (namelen != 0 && *namepv == '@')
+                    if (namelen != 0 && *namepv == Perl_Symbol_Table_Array)
                         *out_capture = newSV_type_mortal(SVt_PVAV);
                     else if (namelen != 0 && *namepv == '%')
                         *out_capture = newSV_type_mortal(SVt_PVHV);
@@ -2047,7 +2047,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
                         CvLEXICAL_on(sv);
                     }
                     else sv = SvREFCNT_inc(ppad[ix]);
-                else if (sigil == '@')
+                else if (sigil == Perl_Symbol_Table_Array)
                     sv = MUTABLE_SV(newAV());
                 else if (sigil == '%')
                     sv = MUTABLE_SV(newHV());
@@ -2465,7 +2465,7 @@ Perl_pad_push(pTHX_ PADLIST *padlist, int depth)
                     }
                 }
                 else {		/* our own lexical */
-                    if (sigil == '@')
+                    if (sigil == Perl_Symbol_Table_Array)
                         sv = MUTABLE_SV(newAV());
                     else if (sigil == '%')
                         sv = MUTABLE_SV(newHV());
@@ -2571,7 +2571,7 @@ Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
                         } else {
                             SV *sv;
 
-                            if (sigil == '@')
+                            if (sigil == Perl_Symbol_Table_Array)
                                 sv = MUTABLE_SV(newAV());
                             else if (sigil == '%')
                                 sv = MUTABLE_SV(newHV());

--- a/pad.c
+++ b/pad.c
@@ -586,6 +586,7 @@ S_pad_alloc_name(pTHX_ PADNAME *name, U32 flags, HV *typestash,
 =for apidoc      pad_add_name_pv
 =for apidoc_item pad_add_name_pvn
 =for apidoc_item pad_add_name_sv
+=for apidoc_item pad_add_symbol_pv
 =for apidoc_item pad_add_symbol_pvn
 
 These each allocate a place in the currently-compiling pad for a named lexical
@@ -702,6 +703,20 @@ Perl_pad_add_name_pv(pTHX_ const char *name,
 {
     PERL_ARGS_ASSERT_PAD_ADD_NAME_PV;
     return pad_add_symbol_pvn (*name, name + 1, strlen(name) - 1, flags, typestash, ourstash);
+}
+
+PADOFFSET
+Perl_pad_add_symbol_pv(
+    pTHX_
+    perl_symbol_table_id symbol_table,
+    const char *name,
+    const U32 flags,
+    HV *typestash,
+    HV *ourstash
+)
+{
+    PERL_ARGS_ASSERT_PAD_ADD_SYMBOL_PV;
+    return pad_add_symbol_pvn (symbol_table, name, strlen(name), flags, typestash, ourstash);
 }
 
 PADOFFSET

--- a/pad.c
+++ b/pad.c
@@ -632,7 +632,7 @@ Perl_pad_add_name_pvn(pTHX_ const char *namepv, STRLEN namelen,
         Perl_croak(aTHX_ "panic: pad_add_name_pvn illegal flag bits 0x%" UVxf,
                    (UV)flags);
 
-    name = newPADNAMEpvn(namepv, namelen);
+    name = new_padname_symbol_pvn (*namepv, namepv + 1, namelen - 1);
 
     if ((flags & (padadd_NO_DUP_CHECK)) == 0) {
         ENTER;
@@ -819,7 +819,7 @@ PADOFFSET
 Perl_pad_add_anon(pTHX_ CV* func, I32 optype)
 {
     PADOFFSET ix;
-    PADNAME * const name = newPADNAMEpvn("&", 1);
+    PADNAME * const name = new_padname_symbol_pvn (Perl_Symbol_Table_Code, "", 0);
 
     PERL_ARGS_ASSERT_PAD_ADD_ANON;
     assert (SvTYPE(func) == SVt_PVCV);
@@ -846,7 +846,7 @@ void
 Perl_pad_add_weakref(pTHX_ CV* func)
 {
     const PADOFFSET ix = pad_alloc(OP_NULL, SVs_PADMY);
-    PADNAME * const name = newPADNAMEpvn("&", 1);
+    PADNAME * const name = new_padname_symbol_pvn (Perl_Symbol_Table_Code, "", 0);
     SV * const rv = newRV_inc((SV *)func);
 
     PERL_ARGS_ASSERT_PAD_ADD_WEAKREF;
@@ -2945,6 +2945,7 @@ Perl_padname_dup(pTHX_ PADNAME *src, CLONE_PARAMS *param)
 
     dst = PadnameOUTER(src)
      ? newPADNAMEouter(padname_dup(PADNAME_FROM_PV(PadnamePV(src)), param))
+        /* TODO: PadnameLEN(src) sometimes evaluates to 0 */
      : newPADNAMEpvn(PadnamePV(src), PadnameLEN(src));
     ptr_table_store(PL_ptr_table, src, dst);
     PadnameLEN(dst) = PadnameLEN(src);

--- a/pad.c
+++ b/pad.c
@@ -588,6 +588,7 @@ S_pad_alloc_name(pTHX_ PADNAME *name, U32 flags, HV *typestash,
 =for apidoc_item pad_add_name_sv
 =for apidoc_item pad_add_symbol_pv
 =for apidoc_item pad_add_symbol_pvn
+=for apidoc_item pad_add_symbol_sv
 
 These each allocate a place in the currently-compiling pad for a named lexical
 variable.  They store the name and other metadata in the name part of the
@@ -727,6 +728,23 @@ Perl_pad_add_name_sv(pTHX_ SV *name, U32 flags, HV *typestash, HV *ourstash)
     PERL_ARGS_ASSERT_PAD_ADD_NAME_SV;
     namepv = SvPVutf8(name, namelen);
     return pad_add_symbol_pvn (*namepv, namepv + 1, namelen - 1, flags, typestash, ourstash);
+}
+
+PADOFFSET
+Perl_pad_add_symbol_sv (
+    pTHX_
+    perl_symbol_table_id symbol_table,
+    SV *                 name,
+    U32                  flags,
+    HV *                 typestash,
+    HV *                 ourstash
+)
+{
+    char *namepv;
+    STRLEN namelen;
+    PERL_ARGS_ASSERT_PAD_ADD_SYMBOL_SV;
+    namepv = SvPVutf8(name, namelen);
+    return pad_add_symbol_pvn (symbol_table, namepv, namelen, flags, typestash, ourstash);
 }
 
 /*

--- a/pad.c
+++ b/pad.c
@@ -577,7 +577,7 @@ S_pad_alloc_name(pTHX_ PADNAME *name, U32 flags, HV *typestash,
     }
 
     padnamelist_store(PL_comppad_name, offset, name);
-    if (Padname_Symbol_Name_Length (name) > 0)
+    if (! Padname_Symbol_Is_Anonymous (name))
         PadnamelistMAXNAMED(PL_comppad_name) = offset;
     return offset;
 }
@@ -1538,7 +1538,7 @@ Perl_pad_leavemy(pTHX)
                 (unsigned long)COP_SEQ_RANGE_HIGH(sv))
             );
             if (!PadnameIsSTATE(sv) && !PadnameIsOUR(sv)
-             && Padname_Is_Symbol_Table_Code (sv) && Padname_Symbol_Name_Length (sv) > 0) {
+             && Padname_Is_Symbol_Table_Code (sv) && ! Padname_Symbol_Is_Anonymous (sv)) {
                 OP *kid = newOP(OP_INTROCV, 0);
                 kid->op_targ = off;
                 o = op_prepend_elem(OP_LINESEQ, kid, o);
@@ -2031,7 +2031,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
                         sv = newSV_type(SVt_PVCV);
                         CvLEXICAL_on(sv);
                     }
-                    else if (Padname_Symbol_Name_Length (namesv) > 0 && !PadnameIsOUR(namesv))
+                    else if (! Padname_Symbol_Is_Anonymous (namesv) && ! PadnameIsOUR(namesv))
                     {
                         /* my sub */
                         /* Just provide a stub, but name it.  It will be

--- a/pad.c
+++ b/pad.c
@@ -2025,7 +2025,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
                     SvREFCNT_inc_simple_void_NN(sv);
             }
             if (!sv) {
-                const char sigil = Padname_Symbol_Table (namesv);
+                const perl_symbol_table_id sigil = Padname_Symbol_Table (namesv);
                 if (sigil == Perl_Symbol_Table_Code)
                     /* If there are state subs, we need to clone them, too.
                        But they may need to close over variables we have
@@ -2458,7 +2458,7 @@ Perl_pad_push(pTHX_ PADLIST *padlist, int depth)
         for ( ;ix > 0; ix--) {
             SV *sv;
             if (names_fill >= ix && PadnameLEN(names[ix])) {
-                const char sigil = Padname_Symbol_Table (names[ix]);
+                const perl_symbol_table_id sigil = Padname_Symbol_Table (names[ix]);
                 if (PadnameOUTER(names[ix])
                         || PadnameIsSTATE(names[ix])
                         || sigil == Perl_Symbol_Table_Code)
@@ -2567,7 +2567,7 @@ Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
                     pad1a[ix] = NULL;
                 } else if (names_fill >= ix && names[ix] &&
                            PadnameLEN(names[ix])) {
-                    const char sigil = Padname_Symbol_Table (names[ix]);
+                    const perl_symbol_table_id sigil = Padname_Symbol_Table (names[ix]);
                     if (PadnameOUTER(names[ix])
                         || PadnameIsSTATE(names[ix])
                         || sigil == Perl_Symbol_Table_Code)

--- a/pad.c
+++ b/pad.c
@@ -1038,6 +1038,7 @@ C<flags> is reserved and must be zero.
 =for apidoc pad_find_my_symbol_pv
 =for apidoc_item pad_find_my_symbol_pvn
 =for apidoc_item pad_find_my_symbol_pvs
+=for apidoc_item pad_find_my_symbol_sv
 
 Similar to C<pad_findmy_pv> but with explicit symbol table parameter.
 
@@ -1051,6 +1052,10 @@ Difference:
 
     pad_findmy_pvs ("$self", 0);
     pad_find_my_symbol_pvs (Perl_Symbol_Scalar, "self", 0);
+
+    // sv (string) means SV * with context "string"
+    pad_findmy_sv (sv ("$self"), 0);
+    pad_find_my_symbol_pvs (Perl_Symbol_Scalar, sv ("self"), 0);
 
 =cut
 */
@@ -1145,6 +1150,21 @@ Perl_pad_findmy_sv(pTHX_ SV *name, U32 flags)
     PERL_ARGS_ASSERT_PAD_FINDMY_SV;
     namepv = SvPVutf8(name, namelen);
     return pad_find_my_symbol_pvn (*namepv, namepv + 1, namelen - 1, flags);
+}
+
+PADOFFSET
+Perl_pad_find_my_symbol_sv(
+    pTHX_
+    perl_symbol_table_id find_symbol_table,
+    SV *                 name,
+    U32                  flags
+)
+{
+    char *namepv;
+    STRLEN namelen;
+    PERL_ARGS_ASSERT_PAD_FIND_MY_SYMBOL_SV;
+    namepv = SvPVutf8(name, namelen);
+    return pad_find_my_symbol_pvn (find_symbol_table, namepv, namelen, flags);
 }
 
 /*

--- a/pad.c
+++ b/pad.c
@@ -657,7 +657,7 @@ Perl_pad_add_name_pvn(pTHX_ const char *namepv, STRLEN namelen,
     assert(SvREFCNT(PL_curpad[offset]) == 1);
     if (namelen != 0 && *namepv == Perl_Symbol_Table_Array)
         sv_upgrade(PL_curpad[offset], SVt_PVAV);
-    else if (namelen != 0 && *namepv == '%')
+    else if (namelen != 0 && *namepv == Perl_Symbol_Table_Hash)
         sv_upgrade(PL_curpad[offset], SVt_PVHV);
     else if (namelen != 0 && *namepv == Perl_Symbol_Table_Code)
         sv_upgrade(PL_curpad[offset], SVt_PVCV);
@@ -1256,7 +1256,7 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV* cv,
                 if (!*out_capture) {
                     if (namelen != 0 && *namepv == Perl_Symbol_Table_Array)
                         *out_capture = newSV_type_mortal(SVt_PVAV);
-                    else if (namelen != 0 && *namepv == '%')
+                    else if (namelen != 0 && *namepv == Perl_Symbol_Table_Hash)
                         *out_capture = newSV_type_mortal(SVt_PVHV);
                     else if (namelen != 0 && *namepv == Perl_Symbol_Table_Code)
                         *out_capture = newSV_type_mortal(SVt_PVCV);
@@ -2049,7 +2049,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
                     else sv = SvREFCNT_inc(ppad[ix]);
                 else if (sigil == Perl_Symbol_Table_Array)
                     sv = MUTABLE_SV(newAV());
-                else if (sigil == '%')
+                else if (sigil == Perl_Symbol_Table_Hash)
                     sv = MUTABLE_SV(newHV());
                 else
                     sv = newSV_type(SVt_NULL);
@@ -2467,7 +2467,7 @@ Perl_pad_push(pTHX_ PADLIST *padlist, int depth)
                 else {		/* our own lexical */
                     if (sigil == Perl_Symbol_Table_Array)
                         sv = MUTABLE_SV(newAV());
-                    else if (sigil == '%')
+                    else if (sigil == Perl_Symbol_Table_Hash)
                         sv = MUTABLE_SV(newHV());
                     else
                         sv = newSV_type(SVt_NULL);
@@ -2573,7 +2573,7 @@ Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
 
                             if (sigil == Perl_Symbol_Table_Array)
                                 sv = MUTABLE_SV(newAV());
-                            else if (sigil == '%')
+                            else if (sigil == Perl_Symbol_Table_Hash)
                                 sv = MUTABLE_SV(newHV());
                             else
                                 sv = newSV_type(SVt_NULL);

--- a/pad.h
+++ b/pad.h
@@ -332,6 +332,14 @@ Whether PADNAME represents symbol for given symbol table.
     }
 
 
+=for apidoc Am|char *|Padname_Symbol_Name|PADNAME * pn
+Extract symbol name from valid symbol (see L</Padname_Is_Symbol>).
+For backward compatibility its index C<-1> is valid index for read.
+
+    # pseudocode
+    Padname_Symbol_Name ("$self") == "self"
+
+
 =for apidoc Am|char|Padname_Symbol_Table|PADNAME * pn
 Extract symbol table identifier from valid symbol (see L</Padname_Is_Symbol>).
 
@@ -396,6 +404,9 @@ enum Perl_Symbol_Table {
 
 #define Padname_Is_Symbol_Table_Scalar(Pn)                              \
     Padname_Is_Symbol_Table (Pn, Perl_Symbol_Table_Scalar)
+
+#define Padname_Symbol_Name(Pn)                                         \
+    (PadnamePV (Pn) + 1)
 
 #define Padname_Symbol_Table(Pn)                                        \
     (PadnamePV (Pn)[0])

--- a/pad.h
+++ b/pad.h
@@ -358,6 +358,12 @@ Extract symbol table identifier from valid symbol (see L</Padname_Is_Symbol>).
     Padname_Symbol_Table ("$self") == Perl_Symbol_Table_Scalar
 
 
+=for apidoc      Am|char|Perl_Sigil_To_Symbol_Table|char
+Converts sigil to symbol table
+
+    Perl_Sigil_To_Symbol_Table ('$') == Perl_Symbol_Table_Scalar
+
+
 =for apidoc      Ay||Perl_Symbol_Table
 =for apidoc_item Perl_Symbol_Table_Array
 =for apidoc_item Perl_Symbol_Table_Code
@@ -427,6 +433,9 @@ enum Perl_Symbol_Table {
 
 #define Padname_Symbol_Table(Pn)                                        \
     (PadnamePV (Pn)[0])
+
+#define Perl_Sigil_To_Symbol_Table(Sigil)                               \
+    (Sigil)
 
 #define PadlistARRAY(pl)	(pl)->xpadl_arr.xpadlarr_alloc
 #define PadlistMAX(pl)		(pl)->xpadl_max

--- a/pad.h
+++ b/pad.h
@@ -332,6 +332,13 @@ Whether PADNAME represents symbol for given symbol table.
     }
 
 
+=for apidoc Am|char|Padname_Symbol_Table|PADNAME * pn
+Extract symbol table identifier from valid symbol (see L</Padname_Is_Symbol>).
+
+    # pseudocode
+    Padname_Symbol_Table ("$self") == Perl_Symbol_Table_Scalar
+
+
 =for apidoc      Ay||Perl_Symbol_Table
 =for apidoc_item Perl_Symbol_Table_Array
 =for apidoc_item Perl_Symbol_Table_Code
@@ -389,6 +396,9 @@ enum Perl_Symbol_Table {
 
 #define Padname_Is_Symbol_Table_Scalar(Pn)                              \
     Padname_Is_Symbol_Table (Pn, Perl_Symbol_Table_Scalar)
+
+#define Padname_Symbol_Table(Pn)                                        \
+    (PadnamePV (Pn)[0])
 
 #define PadlistARRAY(pl)	(pl)->xpadl_arr.xpadlarr_alloc
 #define PadlistMAX(pl)		(pl)->xpadl_max

--- a/pad.h
+++ b/pad.h
@@ -313,6 +313,20 @@ current pad equal to C<npad>
 =for apidoc m|void|PAD_RESTORE_LOCAL|PAD *opad
 Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 
+
+=for apidoc Am|bool|Padname_Is_Symbol_Table|PADNAME * pn|Perl_Symbol_Table symbol_table
+=for apidoc_item m|bool|Padname_Is_Symbol_Table_Array|PADNAME * pn
+=for apidoc_item m|bool|Padname_Is_Symbol_Table_Code|PADNAME * pn
+=for apidoc_item m|bool|Padname_Is_Symbol_Table_Hash|PADNAME * pn
+=for apidoc_item m|bool|Padname_Is_Symbol_Table_Scalar|PADNAME * pn
+
+Whether PADNAME represents symbol for given symbol table.
+
+    if (! Padname_Is_Symbol_Table_Code (pn)) {
+        ...
+    }
+
+
 =for apidoc      Ay||Perl_Symbol_Table
 =for apidoc_item Perl_Symbol_Table_Array
 =for apidoc_item Perl_Symbol_Table_Code
@@ -352,6 +366,21 @@ enum Perl_Symbol_Table {
     Perl_Symbol_Table_Hash   = '%',
     Perl_Symbol_Table_Scalar = '$',
 };
+
+#define Padname_Is_Symbol_Table(Pn, Table)                              \
+    (PadnamePV (Pn)[0] == (Table))
+
+#define Padname_Is_Symbol_Table_Array(Pn)                               \
+    Padname_Is_Symbol_Table (Pn, Perl_Symbol_Table_Array)
+
+#define Padname_Is_Symbol_Table_Code(Pn)                                \
+    Padname_Is_Symbol_Table (Pn, Perl_Symbol_Table_Code)
+
+#define Padname_Is_Symbol_Table_Hash(Pn)                                \
+    Padname_Is_Symbol_Table (Pn, Perl_Symbol_Table_Hash)
+
+#define Padname_Is_Symbol_Table_Scalar(Pn)                              \
+    Padname_Is_Symbol_Table (Pn, Perl_Symbol_Table_Scalar)
 
 #define PadlistARRAY(pl)	(pl)->xpadl_arr.xpadlarr_alloc
 #define PadlistMAX(pl)		(pl)->xpadl_max

--- a/pad.h
+++ b/pad.h
@@ -394,6 +394,12 @@ For example, C<'&'> can be:
 
 =back
 
+
+=for apidoc      Am|const char const *|Perl_Symbol_Table_Title_lc|Perl_Symbol_Table symbol_table
+=for apidoc_item  m|const char const *|Perl_Symbol_Table_Title_ucfirst|Perl_Symbol_Table symbol_table
+
+Expand as a title of symbol table, for example C<subroutine> or C<variable>.
+
 =cut
 */
 
@@ -436,6 +442,12 @@ enum Perl_Symbol_Table {
 
 #define Perl_Sigil_To_Symbol_Table(Sigil)                               \
     (Sigil)
+
+#define Perl_Symbol_Table_Title_lc(Table)                               \
+    (((Table) == Perl_Symbol_Table_Code) ? "subroutine" : "variable")
+
+#define Perl_Symbol_Table_Title_ucfirst(Table)                          \
+    (((Table) == Perl_Symbol_Table_Code) ? "Subroutine" : "Variable")
 
 #define PadlistARRAY(pl)	(pl)->xpadl_arr.xpadlarr_alloc
 #define PadlistMAX(pl)		(pl)->xpadl_max

--- a/pad.h
+++ b/pad.h
@@ -453,17 +453,21 @@ enum Perl_Symbol_Table {
     ((STRLEN) ((PadnamePV (Pn)) ? (PadnameLEN (Pn) - 1) : 0))
 
 #define Padname_Symbol_Printf_Format                                    \
-    "%.*s"
+    "%c%.*s"
 
 #define Padname_Symbol_Printf_Params(Pn)                                \
-    (int) PadnameLEN (Pn),                                              \
-    PadnamePV (Pn)
+    Perl_Symbol_Table_To_Sigil (Padname_Symbol_Table (Pn)),             \
+    (int) Padname_Symbol_Name_Length (Pn),                              \
+    Padname_Symbol_Name (Pn)
 
 #define Padname_Symbol_Table(Pn)                                        \
     (PadnamePV (Pn)[0])
 
 #define Perl_Sigil_To_Symbol_Table(Sigil)                               \
     (Sigil)
+
+#define Perl_Symbol_Table_To_Sigil(Symbol_Table)                        \
+    (Symbol_Table)
 
 #define Perl_Symbol_Table_Title_lc(Table)                               \
     (((Table) == Perl_Symbol_Table_Code) ? "subroutine" : "variable")

--- a/pad.h
+++ b/pad.h
@@ -736,6 +736,15 @@ Similar to L</pad_add_symbol_pvn>, but takes a literal string instead of a strin
 #define pad_findmy_pvs(name,flags) \
     EXPAND_CALL (pad_findmy_pvn, (STR_WITH_LEN(name), flags))
 
+/*
+=for apidoc_defn Am|PADOFFSET|pad_find_my_symbol_pvs|"symbol_table"|"name"|U32 flags
+
+=cut
+*/
+
+#define pad_find_my_symbol_pvs(Symbol_Table, Name, Flags)               \
+    EXPAND_CALL (pad_find_my_symbol_pvn, (Symbol_Table, STR_WITH_LEN(Name), Flags))
+
 struct suspended_compcv
 {
     CV *compcv;

--- a/pad.h
+++ b/pad.h
@@ -358,6 +358,14 @@ Extract symbol table identifier from valid symbol (see L</Padname_Is_Symbol>).
     Padname_Symbol_Table ("$self") == Perl_Symbol_Table_Scalar
 
 
+=for apidoc Am|const char *|Padname_Symbol_Printf_Format
+C<printf> format (as literal string) to output symbol name with its sigil
+
+
+=for apidoc Amu|args|Padname_Symbol_Printf_Params|PADNAME * pn
+C<printf> arguments required by L</Padname_Symbol_Printf_Format>
+
+
 =for apidoc      Am|const char const *|Padname_Symbol_Table_Title_lc|PADNAME * pn
 =for apidoc_item  m|const char const *|Padname_Symbol_Table_Title_ucfirst|PADNAME * pn
 
@@ -443,6 +451,13 @@ enum Perl_Symbol_Table {
 
 #define Padname_Symbol_Name_Length(Pn)                                  \
     ((STRLEN) ((PadnamePV (Pn)) ? (PadnameLEN (Pn) - 1) : 0))
+
+#define Padname_Symbol_Printf_Format                                    \
+    "%.*s"
+
+#define Padname_Symbol_Printf_Params(Pn)                                \
+    (int) PadnameLEN (Pn),                                              \
+    PadnamePV (Pn)
 
 #define Padname_Symbol_Table(Pn)                                        \
     (PadnamePV (Pn)[0])

--- a/pad.h
+++ b/pad.h
@@ -358,6 +358,13 @@ Extract symbol table identifier from valid symbol (see L</Padname_Is_Symbol>).
     Padname_Symbol_Table ("$self") == Perl_Symbol_Table_Scalar
 
 
+=for apidoc      Am|const char const *|Padname_Symbol_Table_Title_lc|PADNAME * pn
+=for apidoc_item  m|const char const *|Padname_Symbol_Table_Title_ucfirst|PADNAME * pn
+
+Similar to L</Perl_Symbol_Table_Title_lc> / L</Perl_Symbol_Table_Title_ucfirst>
+but computes symbol table from valid symbol (see L</Padname_Is_Symbol>).
+
+
 =for apidoc      Am|char|Perl_Sigil_To_Symbol_Table|char
 Converts sigil to symbol table
 
@@ -448,6 +455,12 @@ enum Perl_Symbol_Table {
 
 #define Perl_Symbol_Table_Title_ucfirst(Table)                          \
     (((Table) == Perl_Symbol_Table_Code) ? "Subroutine" : "Variable")
+
+#define Padname_Symbol_Table_Title_lc(Pn)                               \
+    Perl_Symbol_Table_Title_lc (Padname_Symbol_Table (Pn))
+
+#define Padname_Symbol_Table_Title_ucfirst(Pn)                          \
+    Perl_Symbol_Table_Title_ucfirst (Padname_Symbol_Table (Pn))
 
 #define PadlistARRAY(pl)	(pl)->xpadl_arr.xpadlarr_alloc
 #define PadlistMAX(pl)		(pl)->xpadl_max

--- a/pad.h
+++ b/pad.h
@@ -714,6 +714,20 @@ instead of a string/length pair.
     EXPAND_CALL (pad_add_name_pvn, (STR_WITH_LEN(name), flags, typestash, ourstash))
 
 /*
+=for apidoc Am|PADOFFSET|pad_add_symbol_pvs|symbol_table|"name"|U32 flags|HV *typestash|HV *ourstash
+
+Similar to L</pad_add_symbol_pvn>, but takes a literal string instead of a string/length pair.
+
+    # Example: create pad entry for "$self"
+    pad_add_symbol_pvs (Perl_Symbol_Scalar, "self", 0, NULL, NULL);
+
+=cut
+*/
+
+#define pad_add_symbol_pvs(Symbol_Table, Name, Flags, Typestash, Ourstash) \
+    EXPAND_CALL (pad_add_symbol_pvn, (Symbol_Table, STR_WITH_LEN (Name), Flags, Typestash, Ourstash))
+
+/*
 =for apidoc_defn Am|PADOFFSET|pad_findmy_pvs|"name"|U32 flags
 
 =cut

--- a/pad.h
+++ b/pad.h
@@ -711,7 +711,7 @@ instead of a string/length pair.
 */
 
 #define pad_add_name_pvs(name,flags,typestash,ourstash) \
-    Perl_pad_add_name_pvn(aTHX_ STR_WITH_LEN(name), flags, typestash, ourstash)
+    EXPAND_CALL (pad_add_name_pvn, (STR_WITH_LEN(name), flags, typestash, ourstash))
 
 /*
 =for apidoc_defn Am|PADOFFSET|pad_findmy_pvs|"name"|U32 flags
@@ -720,7 +720,7 @@ instead of a string/length pair.
 */
 
 #define pad_findmy_pvs(name,flags) \
-    Perl_pad_findmy_pvn(aTHX_ STR_WITH_LEN(name), flags)
+    EXPAND_CALL (pad_findmy_pvn, (STR_WITH_LEN(name), flags))
 
 struct suspended_compcv
 {

--- a/pad.h
+++ b/pad.h
@@ -141,7 +141,7 @@ typedef enum {
         padtidy_FORMAT		/* or a format */
 } padtidy_type;
 
-/* flags for pad_add_name_pvn. */
+/* flags for pad_add_name_pvn / pad_add_symbol_pvn. */
 
 #define padadd_OUR		0x01	   /* our declaration. */
 #define padadd_STATE		0x02	   /* state declaration. */

--- a/pad.h
+++ b/pad.h
@@ -332,6 +332,10 @@ Whether PADNAME represents symbol for given symbol table.
     }
 
 
+=for apidoc Am|bool|Padname_Symbol_Is_Anonymous|PADNAME * pn
+Whether valid PADNAME represents anonymous symbol (has zero length name).
+
+
 =for apidoc Am|char *|Padname_Symbol_Name|PADNAME * pn
 Extract symbol name from valid symbol (see L</Padname_Is_Symbol>).
 For backward compatibility its index C<-1> is valid index for read.
@@ -411,6 +415,9 @@ enum Perl_Symbol_Table {
 
 #define Padname_Is_Symbol_Table_Scalar(Pn)                              \
     Padname_Is_Symbol_Table (Pn, Perl_Symbol_Table_Scalar)
+
+#define Padname_Symbol_Is_Anonymous(Pn)                                 \
+    (Padname_Symbol_Name_Length (Pn) == 0)
 
 #define Padname_Symbol_Name(Pn)                                         \
     (PadnamePV (Pn) + 1)

--- a/pad.h
+++ b/pad.h
@@ -415,8 +415,15 @@ For example, C<'&'> can be:
 
 Expand as a title of symbol table, for example C<subroutine> or C<variable>.
 
+
+=for apidoc Ay | | perl_symbol_table_id
+
+Typedef how symbol table id is represented
+
 =cut
 */
+
+typedef char perl_symbol_table_id;
 
 enum Perl_Symbol_Table {
     Perl_Symbol_Table_Array  = '@',

--- a/pad.h
+++ b/pad.h
@@ -313,8 +313,45 @@ current pad equal to C<npad>
 =for apidoc m|void|PAD_RESTORE_LOCAL|PAD *opad
 Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 
+=for apidoc      Ay||Perl_Symbol_Table
+=for apidoc_item Perl_Symbol_Table_Array
+=for apidoc_item Perl_Symbol_Table_Code
+=for apidoc_item Perl_Symbol_Table_Hash
+=for apidoc_item Perl_Symbol_Table_Scalar
+
+Symbol table identifies how symbol value is represented internally.
+
+For example, C<'&'> can be:
+
+=over
+
+=item Internal identification of symbol
+
+    &foo
+
+=item External identification of expression
+
+    goto &foo;
+
+=item Predefined variable name
+
+    $&
+
+=item Prototype
+
+    sub foo :prototype(&);
+
+=back
+
 =cut
 */
+
+enum Perl_Symbol_Table {
+    Perl_Symbol_Table_Array  = '@',
+    Perl_Symbol_Table_Code   = '&',
+    Perl_Symbol_Table_Hash   = '%',
+    Perl_Symbol_Table_Scalar = '$',
+};
 
 #define PadlistARRAY(pl)	(pl)->xpadl_arr.xpadlarr_alloc
 #define PadlistMAX(pl)		(pl)->xpadl_max

--- a/pad.h
+++ b/pad.h
@@ -314,6 +314,11 @@ current pad equal to C<npad>
 Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 
 
+=for apidoc Am|bool|Padname_Is_Symbol|PADNAME * pn
+Checks whether C<pn> represents valid symbol (aka: has name, empty string ok)
+Every other C<Padname_Symbol> or C<Padname_Symbol_Table> macro expects valid symbol.
+
+
 =for apidoc Am|bool|Padname_Is_Symbol_Table|PADNAME * pn|Perl_Symbol_Table symbol_table
 =for apidoc_item m|bool|Padname_Is_Symbol_Table_Array|PADNAME * pn
 =for apidoc_item m|bool|Padname_Is_Symbol_Table_Code|PADNAME * pn
@@ -366,6 +371,9 @@ enum Perl_Symbol_Table {
     Perl_Symbol_Table_Hash   = '%',
     Perl_Symbol_Table_Scalar = '$',
 };
+
+#define Padname_Is_Symbol(Pn)                                           \
+    ((Pn) && PadnamePV (Pn))
 
 #define Padname_Is_Symbol_Table(Pn, Table)                              \
     (PadnamePV (Pn)[0] == (Table))

--- a/pad.h
+++ b/pad.h
@@ -340,6 +340,13 @@ For backward compatibility its index C<-1> is valid index for read.
     Padname_Symbol_Name ("$self") == "self"
 
 
+=for apidoc Am|STRLEN|Padname_Symbol_Name_Length|PADNAME * pn
+Length of name of valid symbol (see L</Padname_Is_Symbol>).
+
+    # pseudocode
+    Padname_Symbol_Name_Length ("$self") == 4
+
+
 =for apidoc Am|char|Padname_Symbol_Table|PADNAME * pn
 Extract symbol table identifier from valid symbol (see L</Padname_Is_Symbol>).
 
@@ -407,6 +414,9 @@ enum Perl_Symbol_Table {
 
 #define Padname_Symbol_Name(Pn)                                         \
     (PadnamePV (Pn) + 1)
+
+#define Padname_Symbol_Name_Length(Pn)                                  \
+    ((STRLEN) ((PadnamePV (Pn)) ? (PadnameLEN (Pn) - 1) : 0))
 
 #define Padname_Symbol_Table(Pn)                                        \
     (PadnamePV (Pn)[0])

--- a/proto.h
+++ b/proto.h
@@ -3448,6 +3448,11 @@ Perl_pad_block_start(pTHX_ int full)
 #define PERL_ARGS_ASSERT_PAD_BLOCK_START
 
 PERL_CALLCONV PADOFFSET
+Perl_pad_find_my_symbol_pvn(pTHX_ perl_symbol_table_id find_symbol_table, const char *namepv, STRLEN namelen, U32 flags);
+#define PERL_ARGS_ASSERT_PAD_FIND_MY_SYMBOL_PVN \
+        assert(namepv)
+
+PERL_CALLCONV PADOFFSET
 Perl_pad_findmy_pv(pTHX_ const char *name, U32 flags);
 #define PERL_ARGS_ASSERT_PAD_FINDMY_PV          \
         assert(name)

--- a/proto.h
+++ b/proto.h
@@ -3193,6 +3193,12 @@ Perl_newXS_len_flags(pTHX_ const char *name, STRLEN len, XSUBADDR_t subaddr, con
 #define PERL_ARGS_ASSERT_NEWXS_LEN_FLAGS        \
         assert(subaddr)
 
+PERL_CALLCONV PADNAME *
+Perl_new_padname_symbol_pvn(perl_symbol_table_id symbol_table, const char *name, STRLEN name_len)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_NEW_PADNAME_SYMBOL_PVN \
+        assert(name)
+
 PERL_CALLCONV PERL_SI *
 Perl_new_stackinfo(pTHX_ I32 stitems, I32 cxitems)
         __attribute__warn_unused_result__;

--- a/proto.h
+++ b/proto.h
@@ -3448,6 +3448,11 @@ Perl_pad_block_start(pTHX_ int full)
 #define PERL_ARGS_ASSERT_PAD_BLOCK_START
 
 PERL_CALLCONV PADOFFSET
+Perl_pad_find_my_symbol_pv(pTHX_ perl_symbol_table_id find_symbol_table, const char *name, U32 flags);
+#define PERL_ARGS_ASSERT_PAD_FIND_MY_SYMBOL_PV  \
+        assert(name)
+
+PERL_CALLCONV PADOFFSET
 Perl_pad_find_my_symbol_pvn(pTHX_ perl_symbol_table_id find_symbol_table, const char *namepv, STRLEN namelen, U32 flags);
 #define PERL_ARGS_ASSERT_PAD_FIND_MY_SYMBOL_PVN \
         assert(namepv)

--- a/proto.h
+++ b/proto.h
@@ -3425,6 +3425,12 @@ Perl_pad_add_symbol_pvn(pTHX_ perl_symbol_table_id symbol_table, const char *nam
         assert(namepv); assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
         assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
+PERL_CALLCONV PADOFFSET
+Perl_pad_add_symbol_sv(pTHX_ perl_symbol_table_id symbol_table, SV *name, U32 flags, HV *typestash, HV *ourstash);
+#define PERL_ARGS_ASSERT_PAD_ADD_SYMBOL_SV      \
+        assert(name); assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
+        assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
+
 PERL_CALLCONV void
 Perl_pad_add_weakref(pTHX_ CV *func)
         __attribute__visibility__("hidden");

--- a/proto.h
+++ b/proto.h
@@ -3413,6 +3413,12 @@ Perl_pad_add_name_sv(pTHX_ SV *name, U32 flags, HV *typestash, HV *ourstash);
         assert(name); assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
         assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
+PERL_CALLCONV PADOFFSET
+Perl_pad_add_symbol_pvn(pTHX_ perl_symbol_table_id symbol_table, const char *namepv, STRLEN namelen, U32 flags, HV *typestash, HV *ourstash);
+#define PERL_ARGS_ASSERT_PAD_ADD_SYMBOL_PVN     \
+        assert(namepv); assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
+        assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
+
 PERL_CALLCONV void
 Perl_pad_add_weakref(pTHX_ CV *func)
         __attribute__visibility__("hidden");

--- a/proto.h
+++ b/proto.h
@@ -3414,6 +3414,12 @@ Perl_pad_add_name_sv(pTHX_ SV *name, U32 flags, HV *typestash, HV *ourstash);
         assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
 PERL_CALLCONV PADOFFSET
+Perl_pad_add_symbol_pv(pTHX_ perl_symbol_table_id symbol_table, const char *name, const U32 flags, HV *typestash, HV *ourstash);
+#define PERL_ARGS_ASSERT_PAD_ADD_SYMBOL_PV      \
+        assert(name); assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
+        assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
+
+PERL_CALLCONV PADOFFSET
 Perl_pad_add_symbol_pvn(pTHX_ perl_symbol_table_id symbol_table, const char *namepv, STRLEN namelen, U32 flags, HV *typestash, HV *ourstash);
 #define PERL_ARGS_ASSERT_PAD_ADD_SYMBOL_PVN     \
         assert(namepv); assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \

--- a/proto.h
+++ b/proto.h
@@ -7555,7 +7555,7 @@ S_pad_check_dup(pTHX_ PADNAME *name, U32 flags, const HV *ourstash);
         assert(name)
 
 STATIC PADOFFSET
-S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV *cv, U32 seq, int warn, SV **out_capture, PADNAME **out_name, int *out_flags);
+S_pad_findlex(pTHX_ perl_symbol_table_id find_symbol_table, const char *namepv, STRLEN namelen, U32 flags, const CV *cv, U32 seq, int warn, SV **out_capture, PADNAME **out_name, int *out_flags);
 # define PERL_ARGS_ASSERT_PAD_FINDLEX           \
         assert(namepv); assert(cv); assert(out_name); assert(out_flags)
 

--- a/proto.h
+++ b/proto.h
@@ -3458,6 +3458,11 @@ Perl_pad_find_my_symbol_pvn(pTHX_ perl_symbol_table_id find_symbol_table, const 
         assert(namepv)
 
 PERL_CALLCONV PADOFFSET
+Perl_pad_find_my_symbol_sv(pTHX_ perl_symbol_table_id find_symbol_table, SV *name, U32 flags);
+#define PERL_ARGS_ASSERT_PAD_FIND_MY_SYMBOL_SV  \
+        assert(name)
+
+PERL_CALLCONV PADOFFSET
 Perl_pad_findmy_pv(pTHX_ const char *name, U32 flags);
 #define PERL_ARGS_ASSERT_PAD_FINDMY_PV          \
         assert(name)

--- a/toke.c
+++ b/toke.c
@@ -9933,7 +9933,7 @@ S_pending_ident(pTHX)
                                    in "our" */
                 yyerror_pv(Perl_form(aTHX_ "No package name allowed for "
                                   "%s %s in \"our\"",
-                                  *PL_tokenbuf=='&' ? "subroutine" : "variable",
+                                  Perl_Symbol_Table_Title_lc (Perl_Sigil_To_Symbol_Table (*PL_tokenbuf)),
                                   PL_tokenbuf), UTF ? SVf_UTF8 : 0);
             tmp = allocmy(PL_tokenbuf, tokenbuf_len, UTF ? SVf_UTF8 : 0);
         }
@@ -9946,7 +9946,7 @@ S_pending_ident(pTHX)
                 yyerror_pv(Perl_form(aTHX_ PL_no_myglob,
                             PL_in_my == KEY_my ? "my" :
                             PL_in_my == KEY_field ? "field" : "state",
-                            *PL_tokenbuf == '&' ? "subroutine" : "variable",
+                            Perl_Symbol_Table_Title_lc (Perl_Sigil_To_Symbol_Table (*PL_tokenbuf)),
                             PL_tokenbuf),
                             UTF ? SVf_UTF8 : 0);
                 GCC_DIAG_RESTORE_STMT;

--- a/toke.c
+++ b/toke.c
@@ -5558,8 +5558,8 @@ yyl_sub(pTHX_ char *s, const int key)
             format_name = S_newSV_maybe_utf8(aTHX_ s, d - s);
         *PL_tokenbuf = '&';
         if (memchr(tmpbuf, ':', len) || key != KEY_sub
-         || pad_findmy_pvn(
-                PL_tokenbuf, len + 1, 0
+         || pad_find_my_symbol_pvn (
+                Perl_Symbol_Table_Code, PL_tokenbuf + 1, len, 0
             ) != NOT_IN_PAD)
             sv_setpvn(PL_subname, tmpbuf, len);
         else {
@@ -9001,10 +9001,7 @@ yyl_keylookup(pTHX_ char *s, GV *gv)
 
     /* Check for lexical sub */
     if (PL_expect != XOPERATOR) {
-        char tmpbuf[sizeof PL_tokenbuf + 1];
-        *tmpbuf = '&';
-        Copy(PL_tokenbuf, tmpbuf+1, len, char);
-        c.off = pad_findmy_pvn(tmpbuf, len+1, 0);
+        c.off = pad_find_my_symbol_pvn (Perl_Symbol_Table_Code, PL_tokenbuf, len, 0);
         if (c.off != NOT_IN_PAD) {
             assert(c.off); /* we assume this is boolean-true below */
             if (PAD_COMPNAME_FLAGS_isOUR(c.off)) {
@@ -9985,8 +9982,7 @@ S_pending_ident(pTHX)
 
     if (!has_colon) {
         if (!PL_in_my)
-            tmp = pad_findmy_pvn(PL_tokenbuf, tokenbuf_len,
-                                 0);
+            tmp = pad_find_my_symbol_pvn (*PL_tokenbuf, PL_tokenbuf + 1, tokenbuf_len - 1, 0);
         if (tmp != NOT_IN_PAD) {
             /* might be an "our" variable" */
             if (PAD_COMPNAME_FLAGS_isOUR(tmp)) {
@@ -10102,10 +10098,7 @@ S_checkcomma(pTHX_ const char *s, const char *name, const char *what)
                 return;
             if (s - w <= 254) {
                 PADOFFSET off;
-                char tmpbuf[256];
-                Copy(w, tmpbuf+1, s - w, char);
-                *tmpbuf = '&';
-                off = pad_findmy_pvn(tmpbuf, s-w+1, 0);
+                off = pad_find_my_symbol_pvn (Perl_Symbol_Table_Code, w, s-w, 0);
                 if (off != NOT_IN_PAD) return;
             }
             Perl_croak(aTHX_ "No comma allowed after %s", what);
@@ -11443,7 +11436,7 @@ S_scan_inputsymbol(pTHX_ char *start)
             /* try to find it in the pad for this block, otherwise find
                add symbol table ops
             */
-            const PADOFFSET tmp = pad_findmy_pvn(d, len, 0);
+            const PADOFFSET tmp = pad_find_my_symbol_pvn (Perl_Symbol_Table_Scalar, d + 1, len - 1, 0);
             if (tmp != NOT_IN_PAD) {
                 if (PAD_COMPNAME_FLAGS_isOUR(tmp)) {
                     HV * const stash = PAD_COMPNAME_OURSTASH(tmp);


### PR DESCRIPTION
# Changes summary

For purpose of this changes let's distinguish between:
- _sigil_ - expression type representation in source code
- _symbol type_ - internal identification of symbol type

For implementation of _sigil_-less symbols we will still need their _symbol type_, eg:
- attributes
- named patterns
- data contracts
- ...

## replace literals representing type of symbol stored in pad with explicit tokens

For example, `'&'` in code can mean also:
- subroutine _symbol type_
- subroutine _sigil_
- code-block prototype
- predefined variable name

This set of changes replaces its usage as _symbol type_ with C token `Perl_Symbol_Table_Code`.

## Extend padname API with "split" macros

Instead of relying on layout of string content explicit macros providing symbol type and symbol name are introduced, eg:
```
// current approach:
*PadnamePV (pn)
PadnamePV (pn)[0]

// new approach
Padname_Symbol_Table (pn)
```

- change allows to change underlying data type and values (eg to index to registry array)
- using explicit token expresses intention and makes it easier to search code base

## Provide padname functions with split symbol type and symbol name parameters

Alternatives to existing functions but with two parameters.
Example:
```
// current
pad_add_name_pvs("$(self)", 0, NULL, NULL);

// new approach
pad_add_symbol_pvs (Perl_Symbol_Table_Scalar, "(self)", 0, NULL, NULL);
```

# Possible follow-ups

- replace more characters literals with macros, eg:
  - `Perl_Var_Match`
  - `Perl_Prototype_Code`
- provide builtin symbol table registry
- use this approach also with global symbols

# Open questions

- what (if anything) to put into `perldelta` ?
- mark old functions as deprecated ?
