### PR TITLE
Drop the 5 (implement PPC0025)

### DIFF
--- a/Configure
+++ b/Configure
@@ -7135,16 +7135,16 @@ $echo "(You have $package $version_patchlevel_string.)"
 case "$osname" in
 dos|vms)
 	: XXX Should be a Configure test for double-dots in filenames.
-	version=`echo $revision $patchlevel $subversion | \
-		 $awk '{ printf "%d_%d_%d", $1, $2, $3 }'`
-	api_versionstring=`echo $api_revision $api_version $api_subversion | \
-		 $awk '{ printf "%d_%d_%d", $1, $2, $3 }'`
+	version=`echo $patchlevel $subversion | \
+		 $awk '{ printf "%d_%d", $1, $2 }'`
+	api_versionstring=`echo $api_version $api_subversion | \
+		 $awk '{ printf "%d_%d", $1, $2 }'`
 	;;
 *)
-	version=`echo $revision $patchlevel $subversion | \
-		 $awk '{ printf "%d.%d.%d", $1, $2, $3 }'`
+	version=`echo $patchlevel $subversion | \
+		 $awk '{ printf "%d.%d", $1, $2 }'`
 	api_versionstring=`echo $api_revision $api_version $api_subversion | \
-		 $awk '{ printf "%d.%d.%d", $1, $2, $3 }'`
+		 $awk '{ printf "%d.%d", $1, $2 }'`
 	;;
 esac
 : Special case the 5.005_xx maintenance series, which used 5.005

--- a/Porting/makerel
+++ b/Porting/makerel
@@ -62,11 +62,10 @@ my @patchlevel_h = <PATCHLEVEL>;
 close PATCHLEVEL;
 my $patchlevel_h = join "", grep { /^#\s*define/ } @patchlevel_h;
 print $patchlevel_h;
-my $revision = $1 if $patchlevel_h =~ /PERL_REVISION\s+(\d+)/;
 my $patchlevel = $1 if $patchlevel_h =~ /PERL_VERSION\s+(\d+)/;
 my $subversion = $1 if $patchlevel_h =~ /PERL_SUBVERSION\s+(\d+)/;
 die "Unable to parse patchlevel.h" unless $subversion >= 0;
-my $vers = sprintf("%d.%d.%d", $revision, $patchlevel, $subversion);
+my $vers = sprintf("%d.%d", $patchlevel, $subversion);
 
 # fetch list of local patches
 my (@local_patches, @lpatch_tags, $lpatch_tags);

--- a/dist/Module-CoreList/lib/Module/CoreList.pm
+++ b/dist/Module-CoreList/lib/Module/CoreList.pm
@@ -12,7 +12,7 @@ sub _looks_like_invocant ($) { local $@; !!eval { $_[0]->isa(__PACKAGE__) } }
 sub _undelta {
     my ($delta) = @_;
     my (%expanded, $delta_from, $base, $changed, $removed);
-    for my $v (sort keys %$delta) {
+    for my $v (sort { $a <=> $b } keys %$delta) {
         ($delta_from, $changed, $removed) = @{$delta->{$v}}{qw( delta_from changed removed )};
         $base = $delta_from ? $expanded{$delta_from} : {};
         my %full = ( %$base, %{$changed || {}} );
@@ -54,7 +54,7 @@ sub first_release_raw {
 
     my @perls = $version
         ? grep { defined $version{$_}{ $module } &&
-                        $version{$_}{ $module } ge $version } keys %version
+                        $version{$_}{ $module } >= $version } keys %version
         : grep { exists $version{$_}{ $module }             } keys %version;
 
     return @perls;
@@ -69,7 +69,7 @@ sub first_release_by_date {
 sub first_release {
     my @perls = &first_release_raw;
     return unless @perls;
-    return (sort { $a cmp $b } @perls)[0];
+    return (sort { $a <=> $b } @perls)[0];
 }
 
 sub find_modules {
@@ -123,9 +123,9 @@ sub removed_from_by_date {
 sub removed_raw {
   shift if defined $_[1] and $_[1] =~ PKG_PATTERN and _looks_like_invocant $_[0];
   my $mod = shift;
-  return unless my @perls = sort { $a cmp $b } first_release_raw($mod);
+  return unless my @perls = sort { $a <=> $b } first_release_raw($mod);
   my $last = pop @perls;
-  my @removed = grep { $_ > $last } sort { $a cmp $b } keys %version;
+  my @removed = grep { $_ > $last } sort { $a <=> $b } keys %version;
   return @removed;
 }
 
@@ -461,7 +461,7 @@ sub changes_between {
   );
 
 for my $version ( sort { $a <=> $b } keys %released ) {
-    my $family = int ($version * 1000) / 1000;
+    my $family = $version > 43 ? int($version) : int( $version * 1000 ) / 1000;
     push @{ $families{ $family }} , $version;
 }
 

--- a/dist/Module-CoreList/lib/Module/CoreList/Utils.pm
+++ b/dist/Module-CoreList/lib/Module/CoreList/Utils.pm
@@ -32,7 +32,7 @@ sub first_release_raw {
 
     my @perls = $version
         ? grep { exists $utilities{$_}{ $util } &&
-                        $utilities{$_}{ $util } ge $version } keys %utilities
+                        $utilities{$_}{ $util } >= $version } keys %utilities
         : grep { exists $utilities{$_}{ $util }             } keys %utilities;
 
     return grep { exists $Module::CoreList::released{$_} } @perls;
@@ -47,7 +47,7 @@ sub first_release_by_date {
 sub first_release {
     my @perls = &first_release_raw;
     return unless @perls;
-    return (sort { $a cmp $b } @perls)[0];
+    return (sort { $a <=> $b } @perls)[0];
 }
 
 sub removed_from {
@@ -63,10 +63,10 @@ sub removed_from_by_date {
 sub removed_raw {
   my $util = shift;
   $util = shift if eval { $util->isa(__PACKAGE__) };
-  return unless my @perls = sort { $a cmp $b } first_release_raw($util);
+  return unless my @perls = sort { $a <=> $b } first_release_raw($util);
   @perls = grep { exists $Module::CoreList::released{$_} } @perls;
   my $last = pop @perls;
-  my @removed = grep { $_ > $last } sort { $a cmp $b } keys %utilities;
+  my @removed = grep { $_ > $last } sort { $a <=> $b } keys %utilities;
   return @removed;
 }
 

--- a/ext/XS-APItest/t/xsub_h.t
+++ b/ext/XS-APItest/t/xsub_h.t
@@ -117,7 +117,7 @@ foreach $XS_VERSION (undef, @versions) {
 is_deeply([XS_APIVERSION_valid("Pie")], [], "XS_APIVERSION_BOOTCHECK passes");
 is(eval {XS_APIVERSION_invalid("Pie"); 1}, undef,
    "XS_APIVERSION_BOOTCHECK croaks for an invalid version");
-like($@, qr/Perl API version v1.0.16 of Pie does not match v5\.\d+\.\d+/,
+like($@, qr/Perl API version v1.0.16 of Pie does not match v(?:5\.\d+\.\d+|\d+\.\d+) /,
      "expected error");
 
 my @xsreturn;

--- a/lib/B/Deparse-core.t
+++ b/lib/B/Deparse-core.t
@@ -38,8 +38,9 @@ use warnings;
 use strict;
 use Test::More;
 
-use feature (sprintf(":%vd", $^V)); # to avoid relying on the feature
-                                    # logic to add CORE::
+# to avoid relying on the feature logic to add CORE::
+use feature (sprintf(":%s", $^V =~ /^v(5\.\d+|\d+)/g));
+
 use B::Deparse;
 my $deparse = B::Deparse->new();
 

--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -1763,7 +1763,7 @@ CORE::evalbytes '';
 ####
 # feature features when feature has been disabled by use VERSION
 # CONTEXT no warnings 'deprecated';
-use feature (sprintf(":%vd", $^V));
+use feature (sprintf(":%s", $^V =~ /^v(5\.\d+|\d+)/g));
 use 1;
 CORE::say $_;
 CORE::state $x;
@@ -1794,7 +1794,7 @@ CORE::evalbytes '';
 # (the above test with CONTEXT, and the output is equivalent but different)
 # CONTEXT use feature ':5.10'; no warnings 'deprecated';
 # feature features when feature has been disabled by use VERSION
-use feature (sprintf(":%vd", $^V));
+use feature (sprintf(":%s", $^V =~ /^v(5\.\d+|\d+)/g));
 use 1;
 CORE::say $_;
 CORE::state $x;

--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -75,8 +75,9 @@ $feature_bundle{"5.38"} = $feature_bundle{"5.37"};
 $feature_bundle{"5.40"} = $feature_bundle{"5.39"};
 $feature_bundle{"5.42"} = $feature_bundle{"5.41"};
 $feature_bundle{"5.43"} = $feature_bundle{"5.41"};
-$feature_bundle{"5.44"} = $feature_bundle{"5.41"};
 $feature_bundle{"5.9.5"} = $feature_bundle{"5.10"};
+$feature_bundle{"43"} = $feature_bundle{"5.41"};
+$feature_bundle{"44"} = $feature_bundle{"5.41"};
 my %noops = (
     postderef => 1,
     lexical_subs => 1,
@@ -858,7 +859,7 @@ The following feature bundles are available:
             module_true postderef_qq say signatures
             state try unicode_eval unicode_strings
 
-  :5.44     bitwise current_sub evalbytes fc isa
+  :44       bitwise current_sub evalbytes fc isa
             module_true postderef_qq say signatures
             state try unicode_eval unicode_strings
 

--- a/lib/perl5db.pl
+++ b/lib/perl5db.pl
@@ -523,7 +523,7 @@ BEGIN {eval 'use IO::Handle'}; # Needed for flush only? breaks under miniperl
 
 BEGIN {
     require feature;
-    $^V =~ /^v(\d+\.\d+)/;
+    $^V =~ /^v(5\.\d+|\d+)/;
     feature->import(":$1");
     $_initial_cwd = Cwd::getcwd();
 }

--- a/myconfig.SH
+++ b/myconfig.SH
@@ -29,7 +29,7 @@ $startsh
 
 # Note that the text lines /^Summary of/ .. /^\s*$/ are copied into Config.pm.
 cat <<'!NO!SUBS!'
-Summary of my $package (revision $revision $version_patchlevel_string) configuration:
+Summary of my $package ($version_patchlevel_string) configuration:
   $git_commit_id_title $git_commit_id$git_ancestor_line
   Platform:
     osname=$osname

--- a/op.c
+++ b/op.c
@@ -8598,7 +8598,7 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
             }
             else {
                 /* OK let's at least warn */
-                deprecate_fatal_in(WARN_DEPRECATED__SUBSEQUENT_USE_VERSION, "5.46",
+                deprecate_fatal_in(WARN_DEPRECATED__SUBSEQUENT_USE_VERSION, "46",
                     "Changing use VERSION while another use VERSION is in scope");
             }
         }

--- a/perl.c
+++ b/perl.c
@@ -4027,9 +4027,8 @@ S_minus_v(pTHX)
 #endif /* #ifdef PERL_PATCHNUM */
         PIO_stdout =  PerlIO_stdout();
             PerlIO_printf(PIO_stdout,
-                "\nThis is perl "	STRINGIFY(PERL_REVISION)
-                ", version "		STRINGIFY(PERL_VERSION)
-                ", subversion "		STRINGIFY(PERL_SUBVERSION)
+                "\nThis is perl, version "	STRINGIFY(PERL_VERSION)
+                ", subversion "			STRINGIFY(PERL_SUBVERSION)
                 " (%" SVf ") built for "	ARCHNAME, SVfARG(level)
                 );
             SvREFCNT_dec_NN(level);

--- a/perl.h
+++ b/perl.h
@@ -5447,12 +5447,10 @@ EXTERN_C char **environ;  /* environment variables supplied via exec */
 #include "patchlevel.h"
 #undef PERL_PATCHLEVEL_H_IMPLICIT
 
-#define PERL_VERSION_STRING	STRINGIFY(PERL_REVISION) "." \
-                                STRINGIFY(PERL_VERSION) "." \
-                                STRINGIFY(PERL_SUBVERSION)
+#define PERL_VERSION_STRING	STRINGIFY(PERL_VERSION) "." \
+                                STRINGIFY(PERL_SUBVERSION) ".0"
 
-#define PERL_API_VERSION_STRING	STRINGIFY(PERL_API_REVISION) "." \
-                                STRINGIFY(PERL_API_VERSION) "." \
+#define PERL_API_VERSION_STRING	STRINGIFY(PERL_API_VERSION) "." \
                                 STRINGIFY(PERL_API_SUBVERSION)
 
 START_EXTERN_C

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4598,44 +4598,12 @@ S_require_version(pTHX_ SV *sv)
     }
     else {
         if ( vcmp(sv,PL_patchlevel) > 0 ) {
-            I32 first = 0;
-            AV *lav;
             SV * const req = SvRV(sv);
-            SV * const pv = *hv_fetchs(MUTABLE_HV(req), "original", FALSE);
-
-            /* get the left hand term */
-            lav = AV_FROM_REF(*hv_fetchs(MUTABLE_HV(req), "version", FALSE));
-
-            first  = SvIV(*av_fetch(lav,0,0));
-            if (   first > (int)PERL_REVISION    /* probably 'use 6.0' */
-                || hv_exists(MUTABLE_HV(req), "qv", 2 ) /* qv style */
-                || av_count(lav) > 2             /* FP with > 3 digits */
-                || strstr(SvPVX(pv),".0")        /* FP with leading 0 */
-               ) {
-                DIE(aTHX_ "Perl %" SVf " required--this is only "
-                    "%" SVf ", stopped",
-                    SVfARG(sv_2mortal(vnormal(req))),
-                    SVfARG(sv_2mortal(vnormal(PL_patchlevel)))
-                );
-            }
-            else { /* probably 'use 5.10' or 'use 5.8' */
-                SV *hintsv;
-                I32 second = 0;
-
-                if (av_count(lav) > 1)
-                    second = SvIV(*av_fetch(lav,1,0));
-
-                second /= second >= 600  ? 100 : 10;
-                hintsv = newSVpvf("v%d.%d.0", (int)first, (int)second);
-                upg_version(hintsv, TRUE);
-
-                DIE(aTHX_ "Perl %" SVf " required (did you mean %" SVf "?)"
-                    "--this is only %" SVf ", stopped",
-                    SVfARG(sv_2mortal(vnormal(req))),
-                    SVfARG(sv_2mortal(vnormal(sv_2mortal(hintsv)))),
-                    SVfARG(sv_2mortal(vnormal(PL_patchlevel)))
-                );
-            }
+            DIE(aTHX_ "Perl %" SVf " required--this is only "
+                "%" SVf ", stopped",
+                SVfARG(sv_2mortal(vnormal(req))),
+                SVfARG(sv_2mortal(vnormal(PL_patchlevel)))
+            );
         }
     }
 

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -120,7 +120,17 @@ my %feature_bundle = (
     "5.41"  => [ +V5_41 ],
     # using 5.43 features bundle
     "5.43"  => [ +V5_43 ],
+    # using 43 features bundle
+    "43"    => [ +V5_43 ],
 );
+
+# actually, 5.9.5 ends up between 5.43 and 43
+sub as_bundles {
+     $a eq 'default' ? -1 : $b eq 'default'   ?  1 # default first
+   : $a eq 'all'     ?  1 : $b eq 'all'       ? -1 # all last
+   : $a =~ /\./      ? $b =~ /\./ ? $a cmp $b : -1 # 5.x in order, before
+   :                   $b =~ /\./ ? 1 : $a <=> $b; # integers in order
+}
 
 my @noops = qw( postderef lexical_subs );
 my @removed = qw( array_base );
@@ -147,13 +157,18 @@ for my $feature (sort keys %feature) {
 my $cop_feature_size = $mask == 1 ? $index : $index + 1;
 
 for (keys %feature_bundle) {
-    next unless /^5\.(\d*[13579])\z/;
-    $feature_bundle{"5.".($1+1)} ||= $feature_bundle{$_};
+    if (/^5\.(\d*[13579])\z/) { # 5.x dev series
+        $feature_bundle{"5.".($1+1)} ||= $feature_bundle{$_};
+    }
+    elsif (/^(4[3579]|[5-9][13579]|[1-9][0-9]+[13579])\z/) { # 43 and above
+        $feature_bundle{($1+1)} ||= $feature_bundle{$_};
+    }
 }
+delete $feature_bundle{"5.44"}; # this one does not exist
 
 my %UniqueBundles; # "say state switch" => 5.10
 my %Aliases;       #  5.12 => 5.11
-for( sort keys %feature_bundle ) {
+for( sort as_bundles keys %feature_bundle ) {
     my $value = join(' ', sort @{$feature_bundle{$_}});
     if (exists $UniqueBundles{$value}) {
 	$Aliases{$_} = $UniqueBundles{$value};
@@ -165,8 +180,7 @@ for( sort keys %feature_bundle ) {
 			   # start   end
 my %BundleRanges; # say => ['5.10', '5.15'] # unique bundles for values
 for my $bund (
-    sort { $a eq 'default' ? -1 : $b eq 'default' ? 1 : $a cmp $b }
-         values %UniqueBundles
+    sort as_bundles values %UniqueBundles
 ) {
     next if $bund =~ /[^\d.]/ and $bund ne 'default';
     for (@{$feature_bundle{$bund}}) {
@@ -212,7 +226,7 @@ die "No HINT_FEATURE_MASK defined in perl.h" unless $HintMask;
 die "No HINT_UNI_8_BIT defined in perl.h"    unless $Uni8Bit;
 
 my @HintedBundles =
-    ('default', grep !/[^\d.]/, sort values %UniqueBundles);
+    ('default', grep !/[^\d.]/, sort as_bundles values %UniqueBundles);
 
 
 ###########################################################################
@@ -259,7 +273,7 @@ for( sort { $UniqueBundles{$a} cmp $UniqueBundles{$b} }
 }
 print $pm ");\n\n";
 
-for (sort keys %Aliases) {
+for (sort as_bundles keys %Aliases) {
     print $pm
 	qq'\$feature_bundle{"$_"} = \$feature_bundle{"$Aliases{$_}"};\n';
 };
@@ -296,7 +310,7 @@ format PODTURES =
 $::bundle, $::feature
 .
 
-for ('default', sort grep /\.\d[02468]/, keys %feature_bundle) {
+for ('default', sort as_bundles grep /[02468]\z/, keys %feature_bundle) {
     $::bundle = ":$_";
     $::feature = join ' ', @{$feature_bundle{$_}};
     write $pm;

--- a/regen/regen_lib.pl
+++ b/regen/regen_lib.pl
@@ -377,7 +377,7 @@ sub perl_version {
     die "can't locate PERL_REVISION in '$plh'"   unless defined $v1;
     die "can't locate PERL_VERSION in '$plh'"    unless defined $v2;
     die "can't locate PERL_SUBVERSION in '$plh'" unless defined $v3;
-    return ($v1,$v2,$v3, sprintf("%d.%03d%03d", $v1, $v2, $v3));
+    return ($v2,$v3, 0, sprintf("%d.%03d%03d", $v2, $v3, 0));
 }
 
 

--- a/t/comp/require.t
+++ b/t/comp/require.t
@@ -86,7 +86,7 @@ print "# $@\nnot " if $@;
 print "ok ",$i++," - require v5 ignores sub named v5\n";
 
 eval { require 10.0.2; };
-print "# $@\nnot " unless $@ =~ /^\QPerl v10.0.2 required\E/;
+print "# $@\nnot " if $@;
 print "ok ",$i++," - require 10.0.2\n";
 
 my $ver = 5.005_63;
@@ -97,12 +97,12 @@ print "ok ",$i++," - require 5.005_63\n";
 # check inaccurate fp
 $ver = 10.2;
 eval { require $ver; };
-print "# $@\nnot " unless $@ =~ /^\QPerl v10.200.0 required\E/;
+print "# $@\nnot " if $@;
 print "ok ",$i++," - require 10.2\n";
 
 $ver = 10.000_02;
 eval { require $ver; };
-print "# $@\nnot " unless $@ =~ /^\QPerl v10.0.20 required\E/;
+print "# $@\nnot " if $@;
 print "ok ",$i++," - require 10.000_02\n";
 
 print "not " unless 5.5.1 gt v5.5;

--- a/t/comp/use.t
+++ b/t/comp/use.t
@@ -6,7 +6,7 @@ BEGIN {
     $INC{"feature.pm"} = 1; # so we don't attempt to load feature.pm
 }
 
-print "1..87\n";
+print "1..88\n";
 
 # Can't require test.pl, as we're testing the use/require mechanism here.
 
@@ -87,7 +87,7 @@ eval q{ use v5.5.630; };
 is ($@, '');
 
 eval q{ use 10.0.2; };
-like ($@, qr/^\QPerl v10.0.2 required\E/);
+is ($@, '');
 
 eval "use 5.000";	# implicit semicolon
 is ($@, '');
@@ -96,41 +96,46 @@ eval "use 5.000;";
 is ($@, '');
 
 eval "use 6.000;";
-like ($@, qr/\QPerl v6.0.0 required--this is only $^V, stopped\E/);
+is ($@, '');
 
 eval "no 6.000;";
-is ($@, '');
+like ($@, qr/\QPerls since v6.0.0 too modern--this is $^V, stopped\E/);
 
 eval "no 5.000;";
 like ($@, qr/\QPerls since v5.0.0 too modern--this is $^V, stopped\E/);
 
 eval "use 5.6;";
-like ($@, qr/\QPerl v5.600.0 required (did you mean v5.6.0?)--this is only $^V, stopped\E/);
+is ($@, '');
 
 eval "use 5.8;";
-like ($@, qr/\QPerl v5.800.0 required (did you mean v5.8.0?)--this is only $^V, stopped\E/);
+is ($@, '');
 
 eval "use 5.9;";
-like ($@, qr/\QPerl v5.900.0 required (did you mean v5.9.0?)--this is only $^V, stopped\E/);
+is ($@, '');
 
 eval "use 5.10;";
-like ($@, qr/\QPerl v5.100.0 required (did you mean v5.10.0?)--this is only $^V, stopped\E/);
+is ($@, '');
 
 eval "use 5.11;";
-like ($@, qr/\QPerl v5.110.0 required (did you mean v5.11.0?)--this is only $^V, stopped\E/);
+is ($@, '');
 
 eval sprintf "use %.6f;", $];
 is ($@, '');
 
 
-eval sprintf "use %.6f;", $] - 0.000001;
+eval sprintf "use %.6f;", $] - 0.001;
 is ($@, '');
 
+my $Vthis = int $];
+my $Vnext = $Vthis + 1;
 eval sprintf("use %.6f;", $] + 1);
-like ($@, qr/Perl v6\.\d+\.\d+ required--this is only \Q$^V\E, stopped/a);
+like ($@, qr/Perl v$Vnext\.\d+\.\d+ required--this is only \Q$^V\E, stopped/a);
 
-eval sprintf "use %.6f;", $] + 0.00001;
-like ($@, qr/Perl v5\.\d+\.\d+ required--this is only \Q$^V\E, stopped/a);
+eval sprintf "use %.6f;", $] + 0.001;
+like ($@, qr/Perl v$Vthis\.\d+\.\d+ required--this is only \Q$^V\E, stopped/a);
+
+eval sprintf "use %.3f;", $Vthis + .999;
+like ($@, qr/Perl v$Vthis\.\d+\.\d+ required--this is only \Q$^V\E, stopped/a);
 
 # check that "use 5.11.0" (and higher) loads strictures
 eval 'use 5.11.0; ${"foo"} = "bar";';

--- a/t/lib/feature/implicit
+++ b/t/lib/feature/implicit
@@ -74,7 +74,7 @@ evalbytes "say 'yes'";
 use 5.014;
 evalbytes;
 EXPECT
-Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 8.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 46 at - line 8.
 say sub
 yes
 evalbytes sub
@@ -86,7 +86,7 @@ print 'ss' =~ /$sharp_s/i ? "ok\n" : "nok\n";
 use v5.14;
 print 'ss' =~ /$sharp_s/i ? "ok\n" : "nok\n";
 EXPECT
-Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 5.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 46 at - line 5.
 nok
 ok
 ########
@@ -98,6 +98,6 @@ print eval "use utf8; q|$long_s|" eq "\x{17f}" ? "ok\n" : "nok\n";
 use v5.15;
 print eval "use utf8; q|$long_s|" eq $long_s ? "ok\n" : "nok\n";
 EXPECT
-Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 6.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 46 at - line 6.
 ok
 ok

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -2261,7 +2261,7 @@ use warnings;
 use v5.12;
 use v5.20;
 EXPECT
-Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 3.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 46 at - line 3.
 ########
 use warnings;
 use v5.8;
@@ -2272,7 +2272,7 @@ use warnings;
 use v5.10;
 use v5.8;
 EXPECT
-Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 3.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 46 at - line 3.
 ########
 use warnings;
 use v5.12;

--- a/t/lib/warnings/pp_ctl
+++ b/t/lib/warnings/pp_ctl
@@ -251,7 +251,7 @@ EXPECT
 use warnings;
 eval 'use 5.012; use 5.14.0';
 EXPECT
-Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at (eval 1) line 1.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 46 at (eval 1) line 1.
 ########
 # SKIP ? !$Config{default_inc_includes_dot}
 # NAME check warning for do with no . in @INC

--- a/t/run/switches.t
+++ b/t/run/switches.t
@@ -331,7 +331,7 @@ is runperl(stderr => 1, prog => '#!perl -M'),
         my $ver = $Config{PERL_VERSION};
         my $rel = $Config{PERL_SUBVERSION};
         like( runperl( switches => ['-v'] ),
-	      qr/This is perl 5, version \Q$ver\E, subversion \Q$rel\E \(v\Q$v\E(?:[-*\w]+| \([^)]+\))?\) built for \Q$Config{archname}\E.+Copyright.+Larry Wall.+Artistic License.+GNU General Public License/s,
+	      qr/This is perl, version \Q$ver\E, subversion \Q$rel\E \(v\Q$v\E(?:[-*\w]+| \([^)]+\))?\) built for \Q$Config{archname}\E.+Copyright.+Larry Wall.+Artistic License.+GNU General Public License/s,
               '-v looks okay' );
     }
 }


### PR DESCRIPTION
This is a draft MR, to test how things would actually work.

Many of the remaining failing tests are dual-life modules (which perform a string comparison againsg `$]`), or misplaced expectations (`use v6` should now work, and enable the `:5.41` feature and builtin bundles).

* This set of changes requires a perldelta entry, and I need help writing it.
