### PR TITLE
Avoid uninitialized value warning

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -1637,7 +1637,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
     SSize_t curlen = send - s0;
     U32 possible_problems;  /* A bit is set here for each potential problem
                                found as we go along */
-    UV uv;
+    UV uv = 0;
     SSize_t expectlen;    /* How long should this sequence be? */
     SSize_t avail_len;    /* When input is too short, gives what that is */
 


### PR DESCRIPTION
Using same trick as in S_scan_const() in toke.c

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
TODO: fill description here

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
* This set of changes requires a perldelta entry, and I need help writing it.
* This set of changes does not require a perldelta entry.
