### PR TITLE
Undefined subroutine &%s called, close to label '%s'

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -260,6 +260,18 @@ and L</New Warnings>
 
 =item *
 
+L<Undefined subroutine &%s called, close to label '%s'|perldiag/"Undefined subroutine &%s called, close to label '%s'">
+
+(F) The subroutine indicated hasn't been defined, or if it was, it has
+since been undefined.
+
+This error could also indicate a mistyped package separator, when a
+single colon was typed instead of two colons. For example, C<Foo:bar()>
+would be parsed as the label C<Foo> followed by an unqualified function
+name: C<foo: bar()>.
+
+=item *
+
 XXX L<message|perldiag/"message">
 
 =back

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -6820,6 +6820,16 @@ Perhaps it's in a different package?  See L<perlfunc/sort>.
 (F) The subroutine indicated hasn't been defined, or if it was, it has
 since been undefined.
 
+=item Undefined subroutine &%s called, close to label '%s'
+
+(F) The subroutine indicated hasn't been defined, or if it was, it has
+since been undefined.
+
+This error could also indicate a mistyped package separator, when a
+single colon was typed instead of two colons. For example, C<Foo:bar()>
+would be parsed as the label C<Foo> followed by an unqualified function
+name: C<foo: bar()>.
+
 =item Undefined subroutine called
 
 (F) The anonymous subroutine you're trying to call hasn't been defined,

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -6228,6 +6228,14 @@ S_croak_undefined_subroutine(pTHX_ CV const *cv, GV const *gv)
         SV *sub_name = newSV_type_mortal(SVt_PV);
         gv_efullname3(sub_name, gv, NULL);
 
+        /* Heuristic to spot BOOP:boop() typo, when the intention was
+         * to call BOOP::boop(). */
+        const char * label = CopLABEL(PL_curcop);
+        if (label && OpSIBLING(PL_curcop) == PL_op) {
+            croak("Undefined subroutine &%" SVf " called, close to label '%s'",
+                SVfARG(sub_name), label);
+        }
+
         croak("Undefined subroutine &%" SVf " called", SVfARG(sub_name));
     }
     NOT_REACHED; /* NOTREACHED */

--- a/t/lib/croak/pp_hot
+++ b/t/lib/croak/pp_hot
@@ -46,6 +46,15 @@ Undefined subroutine &main::foo called at - line 3.
 EXPECT
 Undefined subroutine &main::foo called at - line 2.
 ########
+# NAME package separator typo, creating a label by accident
+   package BEEP;
+   sub boop;
+   package main;
+   BEEP:boop();
+EXPECT
+Undefined subroutine &main::boop called, close to label 'BEEP' at - line 4.
+
+########
 # NAME calling undef scalar
    &{+undef};
 EXPECT


### PR DESCRIPTION
https://github.com/Perl/perl5/issues/17839 requested a compile-time
warning for the situation whereby a single colon is accdentally typed
as a package separator when calling a function. For example:
```
package BOOP;
sub beep;
package main;
BOOP:beep();  # Meant to be BOOP::beep();
```
However, because of both Perl's syntax and the potential to populate the
stash at runtime, this falls somewhere between very difficult and
impossible. As an alternative, some enhanced fatal error wording was
requested and these commits attempt to provide that.

The above example would previously die with the message:
```
Undefined subroutine &main::beep called at ... line 4.
```
Now it dies with the message:
```
Undefined subroutine &main::beep called, close to label 'BOOP' at ... line 4.
```

For some of the same reasons mentioned, distinguishing this typo from
other errors at runtime - such as the target subroutine not being
present at all - is also nigh on impossible. The hope is that the
error message will give some additional clue when the error is the
result of a typo, without distracting the user in all other cases.

As part of these commits, some common `DIE()` calls in `pp_entersub` were
extracted into a new helper function, `S_croak_undefined_subroutine`, to
avoid adding (and slightly reduce) cold code bloating in `pp_entersub`.