### PR TITLE
Amend documentation of shift operators in perlop.pod.

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -480,22 +480,17 @@ Shifting by negative number of bits means the reverse shift: left
 shift becomes right shift, right shift becomes left shift.  This is
 unlike in C, where negative shift is undefined.
 
-Shifting by more bits than the size of the integers means most of the
-time zero (all bits fall off), except that under S<C<use integer>>
-right overshifting a negative shiftee results in -1.  This is unlike
-in C, where shifting by too many bits is undefined.  A common C
-behavior is "shift by modulo wordbits", so that for example
-
-    1 >> 64 == 1 >> (64 % 64) == 1 >> 0 == 1  # Common C behavior.
-
-but that is completely accidental.
+Shifting by a value greater than or equal to integer size (in bits)
+results in zero (all bits fall off), except that under S<C<use integer>>
+right shifting a negative value by such an amount results in -1.
+This is unlike in C, where shifting by too many bits is undefined.
 
 If you get tired of being subject to your platform's native integers,
 the S<C<use bigint>> pragma neatly sidesteps the issue altogether:
 
     print 20 << 20;  # 20971520
-    print 20 << 40;  # 5120 on 32-bit machines,
-                     # 21990232555520 on 64-bit machines
+    print 20 << 32;  # 0 with 32-bit integer,
+                     # 85899345920 with 64-bit integer
     use bigint;
     print 20 << 100; # 25353012004564588029934064107520
 


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
The perlop.pod documentation for "Shift Operators" implied that "all bits would fall off" if the size of the bit-shift was greater than the bitsize of the integer.
AFAICT, "all bits fall off" if the size of the bit-shift is greater than <b>or equal to</b> the bitsize of the integer.
So I've made that correction.

There was also some waffle about what C does. I've reduced that to the pre-existing statement <code>This is unlike in C,  where shifting by too many bits is undefined. </code> because I think the rest is irrelevant.

And there was also the <b>incorrect</b> statement:
```
print 20 << 40;  # 5120 on 32-bit machines,
```
which I've changed to:
```
print 20 << 32;  # 0 on 32-bit machines,
```
<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
