### PR TITLE
t/run/todo.t: Reposition formerly TODO-ed tests which are now passing

### DIFF
--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -28,7 +28,7 @@ skip_all_without_unicode_tables();
 my $has_locales = locales_enabled('LC_CTYPE');
 my $utf8_locale = find_utf8_ctype_locale();
 
-plan tests => 1295;  # Update this when adding/deleting tests.
+plan tests => 1296;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -2642,6 +2642,11 @@ use warnings;
 local $SIG{__WARN__} = sub { die; };
 eval "qr/()x{/;" for 1..10;
 PROG
+    }
+
+    {   # Fixed by acababb42be12ff2986b73c1bfa963b70bb5d54e
+        "abab" =~ /(?:[^b]*(?=(b)|(a))ab)*/;
+        is($1, undef, "GH #16894");
     }
 } # End of sub run_tests
 

--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -28,7 +28,7 @@ skip_all_without_unicode_tables();
 my $has_locales = locales_enabled('LC_CTYPE');
 my $utf8_locale = find_utf8_ctype_locale();
 
-plan tests => 1296;  # Update this when adding/deleting tests.
+plan tests => 1297;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -2648,6 +2648,13 @@ PROG
         "abab" =~ /(?:[^b]*(?=(b)|(a))ab)*/;
         is($1, undef, "GH #16894");
     }
+
+    {
+        fresh_perl('s/d|(?{})!//.$&>0for$0,l..a0,0..0',
+               { stderr => 'devnull' });
+        is($?, 0, "No assertion failure (GH 16952)");
+    }
+
 } # End of sub run_tests
 
 1;

--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -28,7 +28,7 @@ skip_all_without_unicode_tables();
 my $has_locales = locales_enabled('LC_CTYPE');
 my $utf8_locale = find_utf8_ctype_locale();
 
-plan tests => 1298;  # Update this when adding/deleting tests.
+plan tests => 1299;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -2625,6 +2625,14 @@ SKIP:
         unlike "",             $pat,               "code in array 16 not 1";
         unlike "XAB-B-=EC",    $pat,               "code in array 16 not 2";
 
+    }
+
+    {
+        fresh_perl('use re "eval";
+                    my @r;
+                    for$0(qw(0 0)){push@r,qr/@r(?{})/};',
+                   { stderr => 'devnull' });
+        is($?, 0, "No assertion failure (GH 16627)");
     }
 
     {

--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -28,7 +28,7 @@ skip_all_without_unicode_tables();
 my $has_locales = locales_enabled('LC_CTYPE');
 my $utf8_locale = find_utf8_ctype_locale();
 
-plan tests => 1297;  # Update this when adding/deleting tests.
+plan tests => 1298;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -2653,6 +2653,12 @@ PROG
         fresh_perl('s/d|(?{})!//.$&>0for$0,l..a0,0..0',
                { stderr => 'devnull' });
         is($?, 0, "No assertion failure (GH 16952)");
+    }
+
+    {
+        fresh_perl('$_ = "a"; s{ x | (?{ s{}{x} }) }{}gx;',
+                   { stderr => 'devnull' });
+        is($?, 0, "No assertion failure (GH 16876)");
     }
 
 } # End of sub run_tests

--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -27,11 +27,6 @@ use warnings;
 
 my $switches = "";
 
-{   # Fixed by acababb42be12ff2986b73c1bfa963b70bb5d54e
-    "abab" =~ /(?:[^b]*(?=(b)|(a))ab)*/;
-    is($1, undef, "GH #16894");
-}
-
 our $TODO;
 TODO: {
     local $TODO = "GH 16250";

--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -47,13 +47,6 @@ TODO: {
 }
 
 TODO: {
-    local $::TODO = 'GH 16952';
-    fresh_perl('s/d|(?{})!//.$&>0for$0,l..a0,0..0',
-               { stderr => 'devnull' });
-    is($?, 0, "No assertion failure");
-}
-
-TODO: {
     local $::TODO = 'GH 16971';
     fresh_perl('split(/00|0\G/, "000")',
                { stderr => 'devnull' });

--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -40,13 +40,6 @@ TODO: {
 }
 
 TODO: {
-    local $::TODO = 'GH 16876';
-    fresh_perl('$_ = "a"; s{ x | (?{ s{}{x} }) }{}gx;',
-               { stderr => 'devnull' });
-    is($?, 0, "No assertion failure");
-}
-
-TODO: {
     local $::TODO = 'GH 16971';
     fresh_perl('split(/00|0\G/, "000")',
                { stderr => 'devnull' });

--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -46,12 +46,4 @@ TODO: {
     is($?, 0, "No assertion failure");
 }
 
-{
-    fresh_perl('use re "eval";
-                my @r;
-                for$0(qw(0 0)){push@r,qr/@r(?{})/};',
-               { stderr => 'devnull' });
-    is($?, 0, "No assertion failure");
-}
-
 done_testing();


### PR DESCRIPTION
Several of the tests in `t/run/todo.t` are now PASSing.  They should be placed in more appropriate locations for the long run.

Branch: smoke-me/jkeenan/reposition-todo-pass-tests-20241215

