### PR TITLE
Revert "op_scope/newCONDOP: Optimise away empty else blocks in OP_COND_EXPR

### DIFF
--- a/lib/B/Deparse.pm
+++ b/lib/B/Deparse.pm
@@ -3966,22 +3966,13 @@ sub pp_cond_expr {
     my $true = $cond->sibling;
     my $false = $true->sibling;
     my $cuddle = $self->{'cuddle'};
-
-    if (class($false) eq "NULL") { # Empty else {} block was optimised away
-        unless ($cx < 1 and (is_scope($true) and $true->name ne "null")) {
-            $cond = $self->deparse($cond, 8);
-            $true = $self->deparse($true, 6);
-            return $self->maybe_parens("$cond ? $true : ()", $cx, 8);
-        }
-    } else { # Both true and false branches are present
-        unless ($cx < 1 and (is_scope($true) and $true->name ne "null")
-               and (is_scope($false) || is_ifelse_cont($false))
-               and $self->{'expand'} < 7) {
-            $cond = $self->deparse($cond, 8);
-            $true = $self->deparse($true, 6);
-            $false = $self->deparse($false, 8);
-            return $self->maybe_parens("$cond ? $true : $false", $cx, 8);
-        }
+    unless ($cx < 1 and (is_scope($true) and $true->name ne "null") and
+	    (is_scope($false) || is_ifelse_cont($false))
+	    and $self->{'expand'} < 7) {
+	$cond = $self->deparse($cond, 8);
+	$true = $self->deparse($true, 6);
+	$false = $self->deparse($false, 8);
+	return $self->maybe_parens("$cond ? $true : $false", $cx, 8);
     }
 
     $cond = $self->deparse($cond, 1);

--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -3378,7 +3378,3 @@ $_ = (!$p) isa 'Some::Class';
 $_ = (!$p) =~ tr/1//;
 $_ = (!$p) =~ /1/;
 $_ = (!$p) =~ s/1//r;
-####
-# Else block of a ternary is optimised away
-my $x;
-my(@y) = $x ? [1, 2] : ();

--- a/op.c
+++ b/op.c
@@ -4517,12 +4517,6 @@ Perl_op_scope(pTHX_ OP *o)
 {
     if (o) {
         if (o->op_flags & OPf_PARENS || PERLDB_NOOPT || TAINTING_get) {
-
-            /* There's no need to wrap an empty stub in an enter/leave.
-             * This also makes eliding empty if/else blocks simpler. */
-            if (OP_TYPE_IS(o, OP_STUB) && (o->op_flags & OPf_PARENS))
-                return o;
-
             o = op_prepend_elem(OP_LINESEQ,
                     newOP(OP_ENTER, (o->op_flags & OPf_WANT)), o);
             OpTYPE_set(o, OP_LEAVE);
@@ -9274,6 +9268,7 @@ Perl_newCONDOP(pTHX_ I32 flags, OP *first, OP *trueop, OP *falseop)
     logop = alloc_LOGOP(OP_COND_EXPR, first, LINKLIST(trueop));
     logop->op_flags |= (U8)flags;
     logop->op_private = (U8)(1 | (flags >> 8));
+    logop->op_next = LINKLIST(falseop);
 
     CHECKOP(OP_COND_EXPR, /* that's logop->op_type */
             logop);
@@ -9282,23 +9277,13 @@ Perl_newCONDOP(pTHX_ I32 flags, OP *first, OP *trueop, OP *falseop)
     start = LINKLIST(first);
     first->op_next = (OP*)logop;
 
-    /* make first & trueop siblings */
-    /* falseop may also be a sibling, if not optimised away */
+    /* make first, trueop, falseop siblings */
     op_sibling_splice((OP*)logop, first,  0, trueop);
+    op_sibling_splice((OP*)logop, trueop, 0, falseop);
 
     o = newUNOP(OP_NULL, 0, (OP*)logop);
 
-    if (OP_TYPE_IS(falseop, OP_STUB) && (falseop->op_flags & OPf_PARENS)) {
-        /* The `else` block is empty. Optimise it away. */
-        logop->op_next = o;
-        op_free(falseop);
-    } else {
-        op_sibling_splice((OP*)logop, trueop, 0, falseop);
-        logop->op_next = LINKLIST(falseop);
-        falseop->op_next = o;
-    }
-
-    trueop->op_next = o;
+    trueop->op_next = falseop->op_next = o;
 
     o->op_next = start;
     return o;


### PR DESCRIPTION
This reverts commit 7015de19863573066cc75ff79721681082895466.

See BBC issue https://github.com/Perl/perl5/issues/22866 for details. Reverting in case there is a bug in the commit.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
