### PR TITLE
Simplify the recommended alternatives to rand()

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -6691,13 +6691,9 @@ including:
 
 =over
 
-=item * L<Data::Entropy>
+=item * L<Crypt::URandom>
 
-=item * L<Crypt::Random>
-
-=item * L<Math::Random::Secure>
-
-=item * L<Math::TrulyRandom>
+=item * L<Crypt::PRNG>
 
 =back
 

--- a/t/porting/known_pod_issues.dat
+++ b/t/porting/known_pod_issues.dat
@@ -76,7 +76,8 @@ Cpanel::JSON::XS
 cpanp(1)
 CPANPLUS
 crypt(3)
-Crypt::Random
+Crypt::PRNG
+Crypt::URandom
 ctime(3)
 curl(1)
 Dancer
@@ -216,7 +217,6 @@ Math::BigInt::Constant
 Math::BigInt::GMP
 Math::BigInt::Pari
 Math::Random::MT::Perl
-Math::Random::Secure
 Math::TrulyRandom
 mbrlen(3)
 mbrtowc(3)


### PR DESCRIPTION
The CPAN Security Group (CPANSec) is currently working on guides to generating security-quality random data.  We are focusing on modules that have secure defaults and are fairly lightweight.

We would like to change the recommended modules to ones that we think are better options.

Crypt::URandom has fewer prerequisites than Crypt::Random, and works with Windows. (Older versions were pure-Perl.)

Crypt::PRNG has secure defaults and methods for generating different kinds of random data.

Math::Random::Secure has a lot of prerequisites and in the end is just relying on /dev/urandom, like Crypt::URandom does.

Math::TrulyRandom is from 1996, and it's unclear how well that technique will work on modern systems, especially VMs and containers.

Data::Entropy has recently updated to fix security issues, and has been marked as deprecated. 

