### PR TITLE
builtin: avoid passing bad parent argument to op_sibling_splice

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -431,19 +431,21 @@ static OP *ck_builtin_func1(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
     if(!opcode)
         return entersubop;
 
-    OP *parent = entersubop, *pushop, *argop;
-
-    pushop = cUNOPx(entersubop)->op_first;
+    OP *pushop = cUNOPx(entersubop)->op_first;
     if (!OpHAS_SIBLING(pushop)) {
         pushop = cUNOPx(pushop)->op_first;
     }
 
-    argop = OpSIBLING(pushop);
+    OP *argop = OpSIBLING(pushop);
 
     if (!argop || !OpHAS_SIBLING(argop) || OpHAS_SIBLING(OpSIBLING(argop)))
         return entersubop;
 
-    (void)op_sibling_splice(parent, pushop, 1, NULL);
+    {
+        OP *const excised = op_sibling_splice(NULL, pushop, 1, NULL);
+        PERL_UNUSED_VAR(excised);
+        assert(excised == argop);
+    }
 
     U8 wantflags = entersubop->op_flags & OPf_WANT;
 


### PR DESCRIPTION
op_sibling_splice() is supposed to be called with a parent/child op pair as the first two arguments. But in `op_sibling_splice(parent, pushop, 1, NULL)`, `parent` is not necessarily a parent of `pushop`; it can also be a grandparent. In practice, this is harmless, however, as the parent argument is only used when splicing the first or last sibling of an op chain, which is never the case here (as ensured by the `argop` checks).

So just avoid `parent` altogether and pass `NULL` as the first argument instead, which is a documented part of the op_sibling_splice() API (and will raise a proper error if our assumptions don't hold in the future).

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
