### PR TITLE
[DBM_Filter] do not look like it contains documentation of Tie::Hash

### DIFF
--- a/lib/DBM_Filter.pm
+++ b/lib/DBM_Filter.pm
@@ -2,12 +2,11 @@ package DBM_Filter ;
 
 use strict;
 use warnings;
-our $VERSION = '0.06';
 
-package Tie::Hash ;
+our $VERSION = '0.07';
 
-use strict;
-use warnings;
+package
+    Tie::Hash ;
 
 use Carp;
 


### PR DESCRIPTION
Problem:
`DBM_Filter` contains line `package Tie::Hash` which fools metacpan into showing wrong documentation: https://metacpan.org/pod/Tie::Hash

Split of package line should prevent that.

* This set of changes does not require a perldelta entry.
