### PR TITLE
[Data-Dumper] fix string comparisons with $] to use numeric compariso…

### DIFF
--- a/dist/Data-Dumper/Dumper.pm
+++ b/dist/Data-Dumper/Dumper.pm
@@ -17,7 +17,7 @@ use warnings;
 use 5.008_001;
 require Exporter;
 
-use constant IS_PRE_516_PERL => $] < 5.016;
+use constant IS_PRE_516_PERL => "$]" < 5.016;
 use constant SUPPORTS_CORE_BOOLS => defined &builtin::is_bool;
 
 use Carp ();
@@ -30,7 +30,7 @@ our ( $Indent, $Trailingcomma, $Purity, $Pad, $Varname, $Useqq, $Terse, $Freezer
 our ( @ISA, @EXPORT, @EXPORT_OK, $VERSION );
 
 BEGIN {
-    $VERSION = '2.190'; # Don't forget to set version and release
+    $VERSION = '2.191'; # Don't forget to set version and release
                         # date in POD below!
 
     @ISA = qw(Exporter);
@@ -210,7 +210,7 @@ sub Dump {
   return &Dumpxs
     unless $Data::Dumper::Useperl || (ref($_[0]) && $_[0]->{useperl})
             # Use pure perl version on earlier releases on EBCDIC platforms
-        || (! $IS_ASCII && $] lt 5.021_010);
+        || (! $IS_ASCII && "$]" < 5.021_010);
   return &Dumpperl;
 }
 
@@ -1456,7 +1456,7 @@ modify it under the same terms as Perl itself.
 
 =head1 VERSION
 
-Version 2.190
+Version 2.191
 
 =head1 SEE ALSO
 

--- a/dist/Data-Dumper/t/dumper.t
+++ b/dist/Data-Dumper/t/dumper.t
@@ -1670,7 +1670,7 @@ EOW
 {
   # [github #18614 - handling of Unicode characters in regexes]
   # [github #18764 - ... without breaking subsequent Latin-1]
-  if ($] lt '5.010') {
+  if ("$]" < 5.010) {
       SKIP_BOTH("Incomplete support for UTF-8 in old perls");
       last;
   }
@@ -1683,11 +1683,11 @@ EOW
 #  '\xb6'
 #];
 EOW
-  if ($] lt '5.010001') {
+  if ("$]" < 5.010001) {
       $want =~ s!qr/!qr/(?-xism:!g;
       $want =~ s!/,!)/,!g;
   }
-  elsif ($] gt '5.014') {
+  elsif ("$]" > 5.014) {
       $want =~ s{/(,?)$}{/u$1}mg;
   }
   my $want_xs = $want;
@@ -1713,7 +1713,7 @@ EOW
 #  qr/ $bs$bs$bs\\/ /
 #];
 EOW
-  if ($] lt '5.010001') {
+  if ("$]" < 5.010001) {
       $want =~ s!qr/!qr/(?-xism:!g;
       $want =~ s! /! )/!g;
   }
@@ -1724,7 +1724,7 @@ EOW
 #############
 {
   # [github #18614, github #18764, perl #58608 corner cases]
-  if ($] lt '5.010') {
+  if ("$]" < 5.010) {
       SKIP_BOTH("Incomplete support for UTF-8 in old perls");
       last;
   }
@@ -1738,11 +1738,11 @@ EOW
 #  '\xB6'
 #];
 EOW
-  if ($] lt '5.010001') {
+  if ("$]" < 5.010001) {
       $want =~ s!qr/!qr/(?-xism:!g;
       $want =~ s!/,!)/,!g;
   }
-  elsif ($] gt '5.014') {
+  elsif ("$]" > 5.014) {
       $want =~ s{/(,?)$}{/u$1}mg;
   }
   my $want_xs = $want;
@@ -1772,10 +1772,10 @@ EOW
 #  '\xB6'
 #];
 EOW
-  if ($] lt '5.014') {
+  if ("$]" < 5.014) {
       $want =~ s{/u,$}{/,}mg;
   }
-  if ($] lt '5.010001') {
+  if ("$]" < 5.010001) {
       $want =~ s!qr/!qr/(?-xism:!g;
       $want =~ s!/,!)/,!g;
   }


### PR DESCRIPTION
…n instead

The fix follows Zefram's suggestion from
https://www.nntp.perl.org/group/perl.perl5.porters/2012/05/msg186846.html

> On older perls, however, $] had a numeric value that was built up using
> floating-point arithmetic, such as 5+0.006+0.000002.  This would not
> necessarily match the conversion of the complete value from string form
> [perl #72210].  You can work around that by explicitly stringifying
> $] (which produces a correct string) and having *that* numify (to a
> correctly-converted floating point value) for comparison.  I cultivate
> the habit of always stringifying $] to work around this, regardless of
> the threshold where the bug was fixed.  So I'd write
>
>     use if "$]" >= 5.014, warnings => "non_unicode";

* This set of changes does not require a perldelta entry.
