### PR TITLE
Fix Data::Dumper pure-perl tests

### DIFF
--- a/dist/Data-Dumper/t/bugs.t
+++ b/dist/Data-Dumper/t/bugs.t
@@ -83,6 +83,7 @@ SKIP: {
 
 # writing out of bounds with malformed utf8
 SKIP: {
+    skip("No XS available", 1) if !defined &Data::Dumper::Dumpxs;
     eval { require Encode };
     skip("Encode not available", 1) if $@;
     local $^W=1;

--- a/dist/Data-Dumper/t/deparse.t
+++ b/dist/Data-Dumper/t/deparse.t
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 use Data::Dumper;
-use Test::More tests =>  16;
+use Test::More tests => 16;
 use lib qw( ./t/lib );
 use Testing qw( _dumptostr );
 
@@ -14,11 +14,18 @@ use Testing qw( _dumptostr );
 
 note("\$Data::Dumper::Deparse and Deparse()");
 
-for my $useperl (0, 1) {
-    local $Data::Dumper::Useperl = $useperl;
+run_tests_for_deparse();
+SKIP: {
+    skip "XS version was unavailable, so we already ran with pure Perl", 8
+        if $Data::Dumper::Useperl;
+    local $Data::Dumper::Useperl = 1;
+    run_tests_for_deparse();
+}
+
+sub run_tests_for_deparse {
+    my $useperl = $Data::Dumper::Useperl ? 1 : 0;
 
     my ($obj, %dumps, $deparse, $starting);
-    use strict;
     my $struct = { foo => "bar\nbaz", quux => sub { "fleem" } };
     $obj = Data::Dumper->new( [ $struct ] );
     $dumps{'noprev'} = _dumptostr($obj);

--- a/dist/Data-Dumper/t/dumpperl.t
+++ b/dist/Data-Dumper/t/dumpperl.t
@@ -6,7 +6,7 @@ use warnings;
 
 use Carp;
 use Data::Dumper;
-use Test::More tests => 31;
+use Test::More tests => 11;
 use lib qw( ./t/lib );
 use Testing qw( _dumptostr );
 
@@ -20,23 +20,7 @@ $Data::Dumper::Indent=1;
     run_tests_for_pure_perl_implementations();
 }
 
-{
-    local $Data::Dumper::Useperl=0;
-    local $Data::Dumper::Useqq=1;
-    local $Data::Dumper::Deparse=0;
-    note('$Data::Dumper::Useqq => 1');
-    run_tests_for_pure_perl_implementations();
-}
-    
-{
-    local $Data::Dumper::Useperl=0;
-    local $Data::Dumper::Useqq=0;
-    local $Data::Dumper::Deparse=1;
-    note('$Data::Dumper::Deparse => 1');
-    run_tests_for_pure_perl_implementations();
-}
-    
-    
+
 
 sub run_tests_for_pure_perl_implementations {
 

--- a/dist/Data-Dumper/t/quotekeys.t
+++ b/dist/Data-Dumper/t/quotekeys.t
@@ -20,7 +20,7 @@ my $is_ascii = ord("A") == 65;
 
 run_tests_for_quotekeys();
 SKIP: {
-    skip "XS version was unavailable, so we already ran with pure Perl", 5
+    skip "XS version was unavailable, so we already ran with pure Perl", 9
         if $Data::Dumper::Useperl;
     local $Data::Dumper::Useperl = 1;
     run_tests_for_quotekeys();

--- a/dist/Data-Dumper/t/sortkeys.t
+++ b/dist/Data-Dumper/t/sortkeys.t
@@ -11,7 +11,7 @@ use Testing qw( _dumptostr );
 
 run_tests_for_sortkeys();
 SKIP: {
-    skip "XS version was unavailable, so we already ran with pure Perl", 13 
+    skip "XS version was unavailable, so we already ran with pure Perl", 11
         if $Data::Dumper::Useperl;
     local $Data::Dumper::Useperl = 1;
     run_tests_for_sortkeys();


### PR DESCRIPTION
Most of the tests in Data-Dumper were written under the assumption that the XS parts of the module may be unavailable. However, this part of the test suite hasn't seen much use in the last 15 or so years, so some of it has started failing. Some of this is due to outdated skip counts or assumptions that certain options force the use of the pure-perl implementation; these fail because tests were added/removed and the XS implementation has grown support for `Useqq` and `Deparse`. In other cases, the test assumes that XS is always available.

This PR updates the tests so they all pass even if XS is not available. (If instead we decide to make XS mandatory, we should remove all the "XS available?" checks from the tests to avoid further bit-rot of dead code.)

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
