### PR TITLE
make shmread/shmwrite work with args beyond I32/2GB

### DIFF
--- a/doio.c
+++ b/doio.c
@@ -3356,15 +3356,15 @@ I32
 Perl_do_shmio(pTHX_ I32 optype, SV **mark, SV **sp)
 {
 #ifdef HAS_SHM
+    PERL_ARGS_ASSERT_DO_SHMIO;
+    PERL_UNUSED_ARG(sp);
+
     char *shm;
     struct shmid_ds shmds;
     const I32 id = SvIVx(*++mark);
     SV * const mstr = *++mark;
     const I32 mpos = SvIVx(*++mark);
     const I32 msize = SvIVx(*++mark);
-
-    PERL_ARGS_ASSERT_DO_SHMIO;
-    PERL_UNUSED_ARG(sp);
 
     SETERRNO(0,0);
     if (shmctl(id, IPC_STAT, &shmds) == -1)

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -368,6 +368,11 @@ manager will later use a regex to expand these into links.
 
 XXX
 
+=item *
+
+L<perlfunc/shmread> and L<perlfunc/shmwrite> are no longer limited to 31-bit
+values for their POS and SIZE arguments. [GH #22895]
+
 =back
 
 =head1 Known Problems

--- a/t/io/shm.t
+++ b/t/io/shm.t
@@ -44,7 +44,7 @@ END { shmctl $key, IPC_RMID, 0 if defined $key }
 }
 
 if (not defined $key) {
-  my $info = "IPC::SharedMem->new failed: $!";
+  my $info = "shmget() failed: $!";
   if ($! == &IPC::SysV::ENOSPC || $! == &IPC::SysV::ENOSYS ||
       $! == &IPC::SysV::ENOMEM || $! == &IPC::SysV::EACCES) {
     skip_all($info);
@@ -54,7 +54,7 @@ if (not defined $key) {
   }
 }
 else {
-	plan(tests => 21);
+	plan(tests => 28);
 	pass('acquired shared mem');
 }
 
@@ -85,10 +85,14 @@ my ($fetch, $store) = (0, 0);
   sub TIESCALAR { bless [undef] }
   sub FETCH     { ++$fetch; $_[0][0] }
   sub STORE     { ++$store; $_[0][0] = $_[1] } }
-tie $ct, 'Counted';
+tie my $ct, 'Counted';
 shmread $key, $ct, 0, 1;
 is($fetch, 1, "shmread FETCH once");
 is($store, 1, "shmread STORE once");
+($fetch, $store) = (0, 0);
+shmwrite $key, $ct, 0, 1;
+is($fetch, 1, "shmwrite FETCH once");
+is($store, 0, "shmwrite STORE none");
 
 {
     # check reading into an upgraded buffer is sane
@@ -104,4 +108,26 @@ is($store, 1, "shmread STORE once");
     $rdbuf = "";
     ok(shmread($key, $rdbuf, 0, 4), "read it back (upgraded source)");
     is($rdbuf, $text, "check we got back the expected (upgraded source)");
+}
+
+# GH #22895 - 2^31 boundary
+SKIP: {
+    skip("need at least 5GB of memory for this test", 5)
+        unless ($ENV{PERL_TEST_MEMORY} // 0) >= 5;
+
+    # delete previous allocation
+    shmctl $key, IPC_RMID, 0;
+    $key = undef;
+
+    my $int32_max = 0x7fff_ffff;
+    $key = shmget(IPC_PRIVATE, $int32_max+2, S_IRWXU) // die "shmget(2GB+1) failed: $!";
+    my $bigbuf = 'A' x $int32_max;
+    ok(shmwrite($key, $bigbuf, 0, length($bigbuf)), "wrote $int32_max bytes");
+    $bigbuf .= 'X';
+    ok(shmwrite($key, $bigbuf, 0, length($bigbuf)), "wrote $int32_max+1 bytes");
+    my $smallbuf = 'X';
+    ok(shmwrite($key, $smallbuf, $int32_max, 1), "wrote 1 byte at offset $int32_max");
+    ok(shmwrite($key, $smallbuf, $int32_max+1, 1), "wrote 1 byte at offset $int32_max+1");
+    my $int30x = 0x4000_0000;
+    ok(shmwrite($key, $bigbuf, $int30x, $int30x), "wrote $int30x bytes at offset $int30x");
 }


### PR DESCRIPTION
Extend mpos/msize to the full size_t/STRLEN range (whatever that is on the current platform).

Tests included.

Fixes #22895.

---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
