### PR TITLE
Fix compiler warnings from utf8.c on 32-bit build

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -1634,12 +1634,12 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
      * than a single character */
     const U8 * send = e;
 
-    SSize_t curlen = send - s0;
+    Size_t curlen = send - s0;
     U32 possible_problems;  /* A bit is set here for each potential problem
                                found as we go along */
     UV uv = 0;
-    SSize_t expectlen;    /* How long should this sequence be? */
-    SSize_t avail_len;    /* When input is too short, gives what that is */
+    Size_t expectlen;    /* How long should this sequence be? */
+    Size_t avail_len;    /* When input is too short, gives what that is */
 
     dTHX;
 
@@ -1892,7 +1892,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
                  * full length with occurrences of the smallest continuation
                  * byte.  For surrogates we could just look at the bytes, but
                  * this single algorithm works for both those and supers. */
-                for (unsigned i = curlen; i < expectlen; i++) {
+                for (Size_t i = curlen; i < expectlen; i++) {
                     uv = UTF8_ACCUMULATE(uv, UTF8_MIN_CONTINUATION_BYTE);
                 }
             }

--- a/utf8.c
+++ b/utf8.c
@@ -1634,7 +1634,6 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
      * than a single character */
     const U8 * send = e;
 
-    Size_t curlen = send - s0;
     U32 possible_problems;  /* A bit is set here for each potential problem
                                found as we go along */
     UV uv = 0;
@@ -1723,11 +1722,13 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
      * allowed one, we could allow in something that shouldn't have been.
      */
 
-    if (UNLIKELY(curlen <= 0)) {
+    Size_t curlen;
+    if (UNLIKELY(s0 >= send)) {
         possible_problems |= UTF8_GOT_EMPTY;
         curlen = 0;
         goto ready_to_handle_errors;
     }
+    curlen = send - s0;
 
     /* We now know we can examine the first byte of the input */
     expectlen = UTF8SKIP(s0);

--- a/utf8.c
+++ b/utf8.c
@@ -2096,7 +2096,8 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
             switch (this_problem) {
               default:
                 Perl_croak(aTHX_ "panic: Unexpected case value in "
-                                 " utf8n_to_uvchr_msgs() %d", this_problem);
+                                 " utf8n_to_uvchr_msgs() %" U32uf,
+                           this_problem);
                 /* NOTREACHED */
                 break;
 


### PR DESCRIPTION
This set of changes will silence compiler warnings from `Perl_utf8_to_uv_msgs_helper_` function at utf8.c on 32-bit (e.g. x86) build:
```
utf8.c:1819:35: warning: comparison of integer expressions of different signedness: ‘ssize_t’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
 1819 |             && UNLIKELY(expectlen > OFFUNISKIP(uv)))
      |                                   ^
utf8.c:1895:45: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘ssize_t’ {aka ‘int’} [-Wsign-compare]
 1895 |                 for (unsigned i = curlen; i < expectlen; i++) {
      |                                             ^
utf8.c:2098:34: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘U32’ {aka ‘long unsigned int’} [-Wformat=]
 2098 |                 Perl_croak(aTHX_ "panic: Unexpected case value in "
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2099 |                                  " utf8n_to_uvchr_msgs() %d", this_problem);
      |                                                               ~~~~~~~~~~~~
      |                                                               |
      |                                                               U32 {aka long unsigned int}
```

---------------------------------------------------------------------------------
* These changes should not change the behavior of perl, so I think that it does not require a perldelta entry.