### PR TITLE
doio: fix shmread() on non-string buffers

### DIFF
--- a/doio.c
+++ b/doio.c
@@ -3421,17 +3421,8 @@ Perl_do_shmio(pTHX_ I32 optype, SV **mark, SV **sp)
         return -1;
 
     if (optype == OP_SHMREAD) {
-        SvGETMAGIC(mstr);
-        SvUPGRADE(mstr, SVt_PV);
-        /* suppress warning when reading into undef var (tchrist 3/Mar/00) */
-        if (! SvOK(mstr))
-            SvPVCLEAR(mstr);
-        SvPOK_only(mstr);
-        char *const mbuf = SvGROW(mstr, (STRLEN)msize+1);
-
-        Copy(shm + mpos, mbuf, msize, char);
-        SvCUR_set(mstr, msize);
-        *SvEND(mstr) = '\0';
+        sv_setpvn(mstr, shm + mpos, msize);
+        SvUTF8_off(mstr);
         SvSETMAGIC(mstr);
         /* who knows who has been playing with this shared memory? */
         SvTAINTED_on(mstr);

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -373,6 +373,14 @@ XXX
 L<perlfunc/shmread> and L<perlfunc/shmwrite> are no longer limited to 31-bit
 values for their POS and SIZE arguments. [GH #22895]
 
+=item *
+
+L<perlfunc/shmread> is now better behaved if VAR is not a plain string. If VAR
+is a tied variable, it calls C<STORE> once; previously, it would also call
+C<FETCH>, but without using the result. If VAR is a reference, the referenced
+entity has its refcount properly decremented when VAR is turned into a string;
+previously, it would leak memory. [GH #22898]
+
 =back
 
 =head1 Known Problems


### PR DESCRIPTION
- If the buffer is a reference, don't leak memory (or abort, on debugging perls). The problem is that SvPOK_only() blindly turns off some SV flags, but does not decrement any refcounts if ROK was on.
- If the buffer is tied, don't call FETCH. Conceptually, shmread() is a bytestring assignment (from a shared memory segment to a scalar variable), so it should only STORE. (This is also why most of the code can be replaced by sv_setpvn().)

Fixes #22898.


---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.