### PR TITLE
cygwin: disable CI until cygwin fix signal handling

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -563,13 +563,14 @@ jobs:
   # | (__| |_| | (_| |\ V  V /| | | | |
   #  \___|\__, |\__, | \_/\_/ |_|_| |_|
   #       |___/ |___/
+  # disabled until cygwin get a signal handling fix out
 
   cygwin:
     name: "cygwin"
     runs-on: windows-2019
     timeout-minutes: 120
     needs: sanity_check
-    if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_cygwin == 'true'))
+    if: (! cancelled() && (needs.sanity_check.outputs.ci_force_cygwin == 'true'))
 
     steps:
       # we use Cygwin git, so no need to configure git here.


### PR DESCRIPTION
cygwin 3.5.5 broke signal handling and broke CI.

To reduce noise disable cygwin CI for now.

Given the way the universe works, cygwin will be fixed immediately after this is applied to blead.

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->


<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
