### PR TITLE
     do_chomp: Use bytes_to_utf8_free_me

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -2865,9 +2865,24 @@ automatically freed, via a call to C<L</SAVEFREEPV>>.
 
 For C<utf8_to_bytes_new_pv>, C<*free_me> has been set to C<*s_ptr>, and it is
 the caller's responsibility to free the new memory when done using it.
-The results of this parameter can simply be passed to C<L</Safefree>> when
-done, as that handles a C<NULL> parameter, and/or it can be used as a boolean
-(non-NULL meaning C<true>) to indicate that the input was indeed changed.
+The following paradigm is convenient to use for this:
+
+ void * free_me;
+ if (utf8_to_bytes_new_pv(&s, &len, &free_me) {
+    ...
+ }
+ else {
+    ...
+ }
+
+ ...
+
+ Safefree(free_me);
+
+C<free_me> can be used as a boolean (non-NULL meaning C<true>) to indicate that
+the input was indeed changed if you need to revisit that later in the code.
+Your design is likely flawed if you find yourself using C<free_me> for any
+other purpose.
 
 =back
 

--- a/utf8.c
+++ b/utf8.c
@@ -3279,6 +3279,8 @@ allows the following convenient paradigm:
 You don't have to know if memory was allocated or not.  Just call C<Safefree>
 unconditionally.  C<free_me> will contain a suitable value to pass to
 C<Safefree> for it to do the right thing, regardless.
+Your design is likely flawed if you find yourself using C<free_me> for anything
+other than passing to C<Safefree>.
 
 Upon return, the number of variants in the string can be computed by having
 saved the value of C<*lenp> before the call, and subtracting the after-call


### PR DESCRIPTION
This won't allocate new memory unless it is needed.