### PR TITLE
readline: clear the error flag if the error happens to be EAGAIN

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6424,6 +6424,7 @@ t/op/range.t				See if .. works
 t/op/read.t				See if read() works
 t/op/readdir.t				See if readdir() works
 t/op/readline.t				See if <> / readline / rcatline work
+t/op/readline_nb.t			Test <> error handling on non-blocking handles
 t/op/recurse.t				See if deep recursion works
 t/op/ref.t				See if refs and objects work
 t/op/refstack.t				See if a ref counted stack fixes things

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -388,6 +388,13 @@ This has now been fixed, and runs as expected. ([GH #23064]).
         say "This line would never run";
     }
 
+=item *
+
+L<perlfunc/readline> now clears the error flag if an error occurs when
+reading and that error is C<EAGAIN> or C<EWOULDBLOCK>.  This allows
+old code that depended on C<readline> to clear all errors to ignore
+these relatively harmless errors.  [GH #22883]
+
 =back
 
 =head1 Known Problems

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -3985,6 +3985,21 @@ PP(pp_match)
     return NORMAL;
 }
 
+/* errno can be either EAGAIN or EWOULDBLOCK for a socket() read that
+   is non-blocking but would have blocked if blocking
+*/
+PERL_STATIC_INLINE bool
+error_is_would_block(int err) {
+#ifdef EAGAIN
+    if (err == EAGAIN)
+        return true;
+#endif
+#ifdef EWOULDBLOCK
+    if (err == EWOULDBLOCK)
+        return true;
+#endif
+    return false;
+}
 
 /* Perl_do_readline(): implement <$fh>, readline($fh) and glob('*.h')
  *
@@ -4227,6 +4242,9 @@ Perl_do_readline(pTHX)
                               (int)(STATUS_CURRENT >> 8),
                               (STATUS_CURRENT & 0x80) ? ", core dumped" : "");
                 }
+            }
+            else if (error_is_would_block(errno)) {
+                PerlIO_clearerr(fp);
             }
 
             if (gimme == G_SCALAR) {

--- a/t/op/readline_nb.t
+++ b/t/op/readline_nb.t
@@ -1,0 +1,36 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+    require Config; Config->import;
+
+    skip_all_if_miniperl();
+}
+
+use strict;
+use IO::Select;
+
+$Config{d_pipe}
+  or skip_all("No pipe");
+
+my ($in, $out);
+pipe($in, $out)
+  or skip_all("Cannot pipe: $!");
+
+$in->blocking(0)
+  or skip_all("Cannot make pipe non-blocking");
+
+my $line = <$in>;
+is($line, undef, "error reading");
+ok(!$in->error, "but did not set error flag");
+close $out;
+$line = <$in>;
+is($line, undef, "nothing to read, but eof");
+ok(!$in->error, "still did not set error flag");
+ok($in->eof, "did set eof");
+ok(close($in), "close success");
+
+
+done_testing();


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
(or the equivalent EWOULDBLOCK)
    
This allows questionable code that tries to combine select and the
readline flavour of buffered I/O to limp along.  Such code is still
risky due to select() checking the underlying OS handle and not
the perl handle.
    
Fixes #22883
<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
