### PR TITLE
pp_substr: avoid unnecessary work prior to inserting a replacement string

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -3690,17 +3690,16 @@ PP_wrapped(pp_substr,
         }
 
         if (repl) {
-            SV* repl_sv_copy = NULL;
+            void * free_me = NULL;
 
             if (repl_need_utf8_upgrade) {
-                repl_sv_copy = newSVsv(repl_sv);
-                sv_utf8_upgrade(repl_sv_copy);
-                repl = SvPV_const(repl_sv_copy, repl_len);
+                repl = (char*)bytes_to_utf8_free_me(
+                                        (U8*)repl, &repl_len, &free_me);
             }
             if (!SvOK(sv))
                 SvPVCLEAR(sv);
             sv_insert_flags(sv, byte_pos, byte_len, repl, repl_len, 0);
-            SvREFCNT_dec(repl_sv_copy);
+            Safefree(free_me);
         }
     }
     if (PL_op->op_private & OPpSUBSTR_REPL_FIRST)

--- a/pp.c
+++ b/pp.c
@@ -3696,8 +3696,11 @@ PP_wrapped(pp_substr,
                 repl = (char*)bytes_to_utf8_free_me(
                                         (U8*)repl, &repl_len, &free_me);
             }
-            if (!SvOK(sv))
-                SvPVCLEAR(sv);
+
+            /* The earlier SvPV_force_nomg(sv, curlen) should have ensured
+             * that sv is SvOK, even if it wasn't beforehand. */
+            assert(SvOK(sv));
+
             sv_insert_flags(sv, byte_pos, byte_len, repl, repl_len, 0);
             Safefree(free_me);
         }


### PR DESCRIPTION
There look to be a couple of inefficiencies in `pp_substr` when preparing to insert a replacement string:

```
        if (repl) {
            SV* repl_sv_copy = NULL;

            if (repl_need_utf8_upgrade) {
                repl_sv_copy = newSVsv(repl_sv);
                sv_utf8_upgrade(repl_sv_copy);
                repl = SvPV_const(repl_sv_copy, repl_len);
            }
            if (!SvOK(sv))
                SvPVCLEAR(sv);
            sv_insert_flags(sv, byte_pos, byte_len, repl, repl_len, 0);
            SvREFCNT_dec(repl_sv_copy);
        }
```
As per the two commit messages:
* `repl_sv_copy = newSVsv(repl_sv);` is overkill when we can do `repl_sv_copy = newSVpvn(repl, repl_len);`, which is a much more straightforward process.
* By the time we get to this block, `sv` should definitely be `SvOK`. (This check has been changed to an assertion, rather than just removed, out of an abundance of caution.)

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
