### PR TITLE
perl5db.pl: Fix regex in cmd_a allowing short actions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -785,7 +785,8 @@ Scott Wiersdorf <scott@perlcode.org> scott@perlcode.org <scott@perlcode.org>
 Sean Davis <dive@endersgame.net> Sean Davis <dive@ender.com>
 Sebastian Schmidt <yath@yath.de> <yath@yath.de>
 Sebastian Schmidt <yath@yath.de> yath-perlbug@yath.de <yath-perlbug@yath.de>
-Sergey Zhmylove <zhmylove@narod.ru> zhmylove <zhmylove@narod.ru>
+Sergei Zhmylev <zhmylove@narod.ru> Sergey Zhmylove <zhmylove@narod.ru>
+Sergei Zhmylev <zhmylove@narod.ru> zhmylove <zhmylove@narod.ru>
 Shawn M Moore <sartak@gmail.com> Shawn M Moore <code@sartak.org>
 Shawn M Moore <sartak@gmail.com> Shawn M Moore <sartak@bestpractical.com>
 Shigeya Suzuki <shigeya@wide.ad.jp> Shigeya Suzuki <shigeya@foretune.co.jp>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1272,11 +1272,11 @@ Sebastian Schmidt              <yath@yath.de>
 Sebastian Steinlechner         <steinlechner@gmx.net>
 Sebastian Wittmeier            <Sebastian.Wittmeier@ginko.de>
 Sebastien Barre                <Sebastien.Barre@utc.fr>
+Sergei Zhmylev                 <zhmylove@narod.ru>
 Sergey Alekseev                <varnie29a@mail.ru>
 Sergey Aleynikov               <sergey.aleynikov@gmail.com>
 Sergey Poznyakoff              <gray@gnu.org>
 Sergey Skvortsov
-Sergey Zhmylove                <zhmylove@narod.ru>
 Sergiy Borodych                <bor@cpan.org>
 Sevan Janiyan                  <venture37@geeklan.co.uk>
 Shawn                          <svicalifornia@gmail.com>

--- a/lib/perl5db.pl
+++ b/lib/perl5db.pl
@@ -532,7 +532,7 @@ BEGIN {
 use vars qw($VERSION $header);
 
 # bump to X.XX in blead, only use X.XX_XX in maint
-$VERSION = '1.81';
+$VERSION = '1.82';
 
 $header = "perl5db.pl version $VERSION";
 
@@ -4798,7 +4798,7 @@ sub cmd_a {
     $line =~ s/\A\./$dbline/;
 
     # Should be a line number followed by an expression.
-    if ( my ($lineno, $expr) = $line =~ /^\s*(\d*)\s*(\S.+)/ ) {
+    if ( my ($lineno, $expr) = $line =~ /^\s*(\d*)\s*(\S.*)/ ) {
 
         if (! length($lineno)) {
             $lineno = $dbline;
@@ -4826,7 +4826,7 @@ sub cmd_a {
                 _set_breakpoint_enabled_status($filename, $lineno, 1);
             }
         } ## end if (length $expr)
-    } ## end if ($line =~ /^\s*(\d*)\s*(\S.+)/)
+    } ## end if ($line =~ /^\s*(\d*)\s*(\S.*)/)
     else {
 
         # Syntax wrong.


### PR DESCRIPTION
The regex pattern in the `a` command was updated from `(\S.+)` to `(\S.*)` to correctly handle short actions, including single-character expressions after the line number.

There is a problem with `a` command in `perl -d` resulting into strange behaviour.
Current version of code `my ($lineno, $expr) = $line =~ /^\s*(\d*)\s*(\S.+)/` splits a command `a 11 T` as: `$lineno="1"` and `$expr="1 T"` because it does not accept single characters as `$expr`.

Replacing it with `\S.*` fixes the problem:

```perl
my @lines = (
    "T",
    "TT",
    "1 T",
    "22 T",
    "3 TT",
    "44 TT",
);

for my $line (@lines) {
    my ($lineno, $expr) = $line =~ /^\s*(\d*)\s*(\S.*)/;
    print "line=$line \t lineno=$lineno \t expr=$expr\n";
}
```

```
line=T   lineno=         expr=T
line=TT          lineno=         expr=TT
line=1 T         lineno=1        expr=T
line=22 T        lineno=22       expr=T
line=3 TT        lineno=3        expr=TT
line=44 TT       lineno=44       expr=TT
```

* This set of changes does not require a perldelta entry.
