### PR TITLE
Prevent double definitions of vararg functions

### DIFF
--- a/embed.h
+++ b/embed.h
@@ -76,7 +76,8 @@
    extra argument but grab the context pointer using the macro dTHX.
  */
 
-#   if defined(MULTIPLICITY) && !defined(PERL_NO_SHORT_NAMES)
+#   if  defined(MULTIPLICITY) && !defined(PERL_NO_SHORT_NAMES) && \
+       !defined(PERL_WANT_VARARGS)
 #     define croak                              Perl_croak_nocontext
 #     define deb                                Perl_deb_nocontext
 #     define die                                Perl_die_nocontext
@@ -90,7 +91,8 @@
 #     define sv_setpvf_mg                       Perl_sv_setpvf_mg_nocontext
 #     define warn                               Perl_warn_nocontext
 #     define warner                             Perl_warner_nocontext
-#   endif /* defined(MULTIPLICITY) && !defined(PERL_NO_SHORT_NAMES) */
+#   endif /*  defined(MULTIPLICITY) && !defined(PERL_NO_SHORT_NAMES) &&
+             !defined(PERL_WANT_VARARGS) */
 # endif /* !defined(PERL_NOCOMPAT) */
 #endif /* !defined(PERL_CORE) */
 #if !defined(PERL_NO_SHORT_NAMES)

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -651,7 +651,7 @@ sub generate_embed_h {
        provides a set of compatibility functions that don't take an
        extra argument but grab the context pointer using the macro dTHX.
      */
-    #if defined(MULTIPLICITY) && !defined(PERL_NO_SHORT_NAMES)
+    #if defined(MULTIPLICITY) && !defined(PERL_NO_SHORT_NAMES) && !defined(PERL_WANT_VARARGS)
     END
 
     foreach (@nocontext) {


### PR DESCRIPTION
This fixes a flaw in 29b0ccbf86239e4f179d573e3465722f9c023e08 that causes warnings about these macros being redefined when `PERL_WANT_VARARGS` is defined on a multiplicity perl.