### PR TITLE
OP_SUBSTR_LEFT: GH#22914 - multiple pointers to replacement OP

### DIFF
--- a/t/op/substr_left.t
+++ b/t/op/substr_left.t
@@ -104,5 +104,12 @@ $str = "\x00\x01\x02\x03\x04\x05";
 $result = substr($str, 0, 3, "");
 is($result, "\x00\x01\x02", 'hex EXPR: returns correct characters');
 is($str, "\x03\x04\x05", 'hex EXPR: retains correct characters');
+# GH #22914. LEN has more than one pointer to REPL.
+$str = "perl";
+# Hopefully $INC[0] ne '/dev/random' is a reasonable test assumption...
+# (We need a condition that no future clever optimiser will strip)
+$result = substr($str, 0, $INC[0] eq '/dev/random' ? 2: 3, '');
+is($result, 'per', 'GH#22914: non-trivial LEN returns correct characters');
+is($str, 'l', 'GH#22914: non-trivial LEN retains correct characters');
 
 done_testing();

--- a/t/perf/opcount.t
+++ b/t/perf/opcount.t
@@ -1034,7 +1034,7 @@ test_opcount(0, "substr with const zero offset and '' repl (void)",
                 {
                     substr       => 0,
                     substr_left  => 1,
-                    const        => 2,
+                    const        => 1,
                 });
 
 test_opcount(0, "substr with const zero offset and '' repl (lexical)",
@@ -1042,7 +1042,7 @@ test_opcount(0, "substr with const zero offset and '' repl (lexical)",
                 {
                     substr       => 0,
                     substr_left  => 1,
-                    const        => 2,
+                    const        => 1,
                     padsv        => 3,
                     sassign      => 1
                 });
@@ -1052,7 +1052,7 @@ test_opcount(0, "substr with const zero offset and '' repl (lexical TARGMY)",
                 {
                     substr       => 0,
                     substr_left  => 1,
-                    const        => 2,
+                    const        => 1,
                     padsv        => 3,
                     padsv_store  => 0,
                     sassign      => 0
@@ -1063,7 +1063,7 @@ test_opcount(0, "substr with const zero offset and '' repl (gv)",
                 {
                     substr       => 0,
                     substr_left  => 1,
-                    const        => 2,
+                    const        => 1,
                     gvsv         => 1,
                     sassign      => 1
                 });


### PR DESCRIPTION
The recent initial commit for OP_SUBSTR_LEFT failed to account for
there being multiple paths from a non-trivial LENGTH to the ""
replacement CONST OP. This could result in the replacement SV
being erroneously pushed to the stack, causing `pp_substr_left`
to try to operate on the wrong SV.

This commit nulls out the replacement OP, so that even if it
is encountered, no erroneous SV is pushed. Contrary to the
comment in the original commit, this actually does not break
B::Deparse.

Thanks to @mauke for figuring this out and preparing a patch
before I'd even opened my browser.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
