### PR TITLE
perlsub: mention when //= and ||= in signatures were added

### DIFF
--- a/pod/perlsub.pod
+++ b/pod/perlsub.pod
@@ -401,9 +401,9 @@ one parameter vary according to the earlier parameters.  For example,
         print "$first_name $surname is known as \"$nickname\"";
     }
 
-A default value expression can also be written using the C<//=> operator,
-where it will be evaluated and used if the caller omitted a value or the
-value provided was C<undef>.
+Since Perl 5.38, a default value expression can also be written using the
+C<//=> operator, where it will be evaluated and used if the caller omitted
+a value or the value provided was C<undef>.
 
     sub foo ($name //= "world") {
         print "Hello, $name";
@@ -411,9 +411,9 @@ value provided was C<undef>.
 
     foo(undef);  # will print "Hello, world"
 
-Similarly, the C<||=> operator can be used to provide a default
-expression to be used whenever the caller provided a false value (and
-remember that a missing or C<undef> value are also false).
+Similarly since Perl 5.38, the C<||=> operator can be used to provide a
+default expression to be used whenever the caller provided a false value
+(and remember that a missing or C<undef> value are also false).
 
     sub foo ($x ||= 10) {
         return 5 + $x;


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
Mention that these signature operators were added in 5.38: https://perldoc.perl.org/perl5380delta#Defined-or-and-logical-or-assignment-default-expressions-in-signatures

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
