### PR TITLE
feature.h: use the correct format for U32 for cop_feature_bits

### DIFF
--- a/feature.h
+++ b/feature.h
@@ -748,7 +748,7 @@ S_fetch_feature_bits_hh(pTHX_ HV *hh) {
 
 #define DUMP_FEATURE_BITS(file, cop) \
     STMT_START { \
-        PerlIO_printf(file, "0x%08x", cop->cop_features.bits[0]); \
+        PerlIO_printf(file, "0x%" U32xf, cop->cop_features.bits[0]); \
     } STMT_END
 
 #endif /* PERL_IN_DUMP_C */

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -585,7 +585,7 @@ my $any_bits_set = "(                              \\\n      " .
 
 my $dump_bits = "STMT_START { \\\n        " .
   join(qq( \\\n        PerlIO_putc(file, ','); \\\n        ),
-       map { qq(PerlIO_printf(file, "0x%08x", cop->cop_features.bits[$_]);) }
+       map { qq(PerlIO_printf(file, "0x%" U32xf, cop->cop_features.bits[$_]);) }
        0 .. $cop_feature_size-1) .
   " \\\n    } STMT_END";
 


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
Fixes from 32-bit builds:
```
In file included from dump.c:31:0:
dump.c: In function 'S_do_op_dump_bar':
feature.h:751:29: warning: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'U32 {aka long unsigned int}' [-Wformat=]
         PerlIO_printf(file, "0x%08x", cop->cop_features.bits[0]); \
                             ^
feature.h:751:29: note: in definition of macro 'DUMP_FEATURE_BITS'
         PerlIO_printf(file, "0x%08x", cop->cop_features.bits[0]); \
                             ^~~~~~~~
```

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
