### PR TITLE
perlclass: the statement form only affects the enclosing scope

### DIFF
--- a/pod/perlclass.pod
+++ b/pod/perlclass.pod
@@ -70,8 +70,8 @@ used within the scope of this declaration.
 
 Classes can be declared in either block or statement syntax. If a block is
 used, the body of the block contains the implementation of the class. If the
-statement form is used, the remainder of the file is used up until the next
-C<class> or C<package> statement.
+statement form is used, the remainder of the current scope or file is used up
+until the next C<class> or C<package> statement.
 
 A C<class> declaration can optionally have a version number, similar to the
 C<package> keyword. It can also optionally have attributes. If both are


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
Clarify that "class X::Y;" will only affect the remainder of the current scope, whether or not it is the file scope.

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
