### PR TITLE
Reflect change in CPAN releasor

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1246,7 +1246,7 @@ our %Modules = (
     },
 
     'Time::Piece' => {
-        'DISTRIBUTION' => 'ESAYM/Time-Piece-1.35.tar.gz',
+        'DISTRIBUTION' => 'PEVANS/Time-Piece-1.35_001.tar.gz',
         'SYNCINFO'     => 'LeoNerd on Fri Jan 17 15:27:02 2025',
         'FILES'        => q[cpan/Time-Piece],
         'EXCLUDED'     => [ qw[reverse_deps.txt] ],

--- a/cpan/Time-Piece/Piece.pm
+++ b/cpan/Time-Piece/Piece.pm
@@ -19,7 +19,7 @@ our %EXPORT_TAGS = (
     ':override' => 'internal',
     );
 
-our $VERSION = '1.3401_01';
+our $VERSION = '1.35_001';
 
 XSLoader::load( 'Time::Piece', $VERSION );
 

--- a/cpan/Time-Piece/Seconds.pm
+++ b/cpan/Time-Piece/Seconds.pm
@@ -1,7 +1,7 @@
 package Time::Seconds;
 use strict;
 
-our $VERSION = '1.35';
+our $VERSION = '1.35_001';
 
 use Exporter 5.57 'import';
 

--- a/cpan/Time-Piece/t/lib/Time/Piece/Twin.pm
+++ b/cpan/Time-Piece/t/lib/Time/Piece/Twin.pm
@@ -1,4 +1,4 @@
 # this package is identical, but will be ->isa('Time::Piece::Twin');
 package Time::Piece::Twin;
 use base qw(Time::Piece);
-our $VERSION = "1.35";
+our $VERSION = "1.35_001";


### PR DESCRIPTION
On CPAN Time-Piece has a new release from a new releasor.  For consistent results out of 'Porting/core-cpan-diff', we should have changed the CPANID of the releasor in Maintainers.pl before synching. We'll correct that here and standardize all $VERSIONs in cpan/Time-Piece to indicate we're now a bit ahead of CPAN.

* This set of changes does not require a perldelta entry.
