### PR TITLE
Perl_do_print: stringify an SVt_IV IV/UV more efficiently

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3644,6 +3644,11 @@ EXop	|bool	|try_amagic_bin |int method				\
 				|int flags
 EXop	|bool	|try_amagic_un	|int method				\
 				|int flags
+ARTp	|char * |uiv_2buf	|NN char * const buf			\
+				|const IV iv				\
+				|UV uv					\
+				|const int is_uv			\
+				|NN char ** const peob
 Adp	|SSize_t|unpackstring	|NN const char *pat			\
 				|NN const char *patend			\
 				|NN const char *s			\
@@ -5886,11 +5891,6 @@ ST	|STRLEN |sv_pos_u2b_midway					\
 				|const STRLEN uend
 i	|void	|sv_unglob	|NN SV * const sv			\
 				|U32 flags
-RTi	|char * |uiv_2buf	|NN char * const buf			\
-				|const IV iv				\
-				|UV uv					\
-				|const int is_uv			\
-				|NN char ** const peob
 S	|void	|utf8_mg_len_cache_update				\
 				|NN SV * const sv			\
 				|NN MAGIC ** const mgp			\

--- a/embed.h
+++ b/embed.h
@@ -851,6 +851,7 @@
 # define to_uni_lower(a,b,c)                    Perl_to_uni_lower(aTHX_ a,b,c)
 # define to_uni_title(a,b,c)                    Perl_to_uni_title(aTHX_ a,b,c)
 # define to_uni_upper(a,b,c)                    Perl_to_uni_upper(aTHX_ a,b,c)
+# define uiv_2buf                               Perl_uiv_2buf
 # define unpackstring(a,b,c,d,e)                Perl_unpackstring(aTHX_ a,b,c,d,e)
 # define unshare_hek(a)                         Perl_unshare_hek(aTHX_ a)
 # define unsharepvn(a,b,c)                      Perl_unsharepvn(aTHX_ a,b,c)
@@ -2181,7 +2182,6 @@
 #     define sv_pos_u2b_forwards                S_sv_pos_u2b_forwards
 #     define sv_pos_u2b_midway                  S_sv_pos_u2b_midway
 #     define sv_unglob(a,b)                     S_sv_unglob(aTHX_ a,b)
-#     define uiv_2buf                           S_uiv_2buf
 #     define utf8_mg_len_cache_update(a,b,c)    S_utf8_mg_len_cache_update(aTHX_ a,b,c)
 #     define utf8_mg_pos_cache_update(a,b,c,d,e) S_utf8_mg_pos_cache_update(aTHX_ a,b,c,d,e)
 #     define visit(a,b,c)                       S_visit(aTHX_ a,b,c)

--- a/handy.h
+++ b/handy.h
@@ -3103,7 +3103,6 @@ STMT_START {                    \
     (x) ^= ((x) << 26);         \
 } STMT_END
 
-#ifdef PERL_CORE
 /* Convenience macros for dealing with IV_MIN:
    In two's complement system, the absolute value of IV_MIN (i.e. -IV_MIN)
    cannot be represented in an IV.  Thus we cannot use simple negation
@@ -3159,8 +3158,6 @@ undefined behavior when C<uv> is equal to C<L</ABS_IV_MIN>>.
    a single negation by optimizing compilers. */
 #  define NEGATE_2IV(uv) (ASSUME((uv) <= ABS_IV_MIN), \
                           (uv) < 8U ? -(IV)(uv) : -(IV)((uv) - 8U) - 8)
-
-#endif  /* PERL_CORE */
 
 #endif  /* PERL_HANDY_H_ */
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -89,6 +89,12 @@ There may well be none in a stable release.
 
 =item *
 
+The stringification of integers by L<perlfunc/print> and L<perlfunc/say>,
+when coming from an SVt_IV, is now more efficient.
+[GH #22927]
+
+=item *
+
 XXX
 
 =back

--- a/proto.h
+++ b/proto.h
@@ -5293,6 +5293,12 @@ PERL_CALLCONV bool
 Perl_try_amagic_un(pTHX_ int method, int flags);
 #define PERL_ARGS_ASSERT_TRY_AMAGIC_UN
 
+PERL_CALLCONV char *
+Perl_uiv_2buf(char * const buf, const IV iv, UV uv, const int is_uv, char ** const peob)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_UIV_2BUF               \
+        assert(buf); assert(peob)
+
 PERL_CALLCONV SSize_t
 Perl_unpackstring(pTHX_ const char *pat, const char *patend, const char *s, const char *strend, U32 flags);
 #define PERL_ARGS_ASSERT_UNPACKSTRING           \
@@ -9071,13 +9077,7 @@ S_sv_unglob(pTHX_ SV * const sv, U32 flags);
 #   define PERL_ARGS_ASSERT_SV_UNGLOB           \
         assert(sv)
 
-PERL_STATIC_INLINE char *
-S_uiv_2buf(char * const buf, const IV iv, UV uv, const int is_uv, char ** const peob)
-        __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_UIV_2BUF            \
-        assert(buf); assert(peob)
-
-# endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
+# endif
 # if defined(USE_ITHREADS)
 STATIC SV *
 S_sv_dup_common(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)

--- a/sv.c
+++ b/sv.c
@@ -2794,15 +2794,26 @@ static const union {
     '9', '8', '9', '9'
 }};
 
-/* uiv_2buf(): private routine for use by sv_2pv_flags(): print an IV or
- * UV as a string towards the end of buf, and return pointers to start and
- * end of it.
+/* uiv_2buf(): originally a private routine for use by sv_2pv_flags(),
+ * now in use by do_print() and part of the public API. It prints an
+ * IV or UV as a string towards the end of buf, and return pointers
+ * to the start and end of it.
  *
  * We assume that buf is at least TYPE_CHARS(UV) long.
  */
 
-PERL_STATIC_INLINE char *
-S_uiv_2buf(char *const buf, const IV iv, UV uv, const int is_uv, char **const peob)
+/*
+=for apidoc uiv_2buf
+
+This function converts an IV or UV to its string representation.
+
+It is used internally by sv_2pv_flags() and do_print().
+
+=cut
+*/
+
+char *
+Perl_uiv_2buf(char *const buf, const IV iv, UV uv, const int is_uv, char **const peob)
 {
     char *ptr = buf + TYPE_CHARS(UV);
     char * const ebuf = ptr;

--- a/t/perf/benchmarks
+++ b/t/perf/benchmarks
@@ -1938,6 +1938,18 @@
         code    => '$p = pos($s);',
     },
 
+    # func::print::iv_stringify should outperform func::print::iv_strings
+    'func::print::iv_stringify' => {
+        desc    => 'do_print stringification of SVt_IV integers',
+        setup   => 'open(my $fh, ">", \$x) or die $!;',
+        code    => 'print $fh 1,2,3,4,5,6,7,8,9,0;',
+    },
+    'func::print::iv_strings' => {
+        desc    => 'do_print pre-stringified SVt_IV integers',
+        setup   => 'open(my $fh, ">", \$x) or die $!;',
+        code    => 'print $fh "1","2","3","4","5","6","7","8","9","0";',
+    },
+
     'func::ref::notaref_bool' => {
         desc    => 'ref($notaref) in boolean context',
         setup   => 'my $r = "boo"',
@@ -1969,8 +1981,6 @@
         setup   => 'my $x; my $r = bless []',
         code    => '$x = ref $r',
     },
-
-
 
     'func::sort::num' => {
         desc    => 'plain numeric sort',
@@ -2033,7 +2043,6 @@
         setup   => 'sub f { ($a . "") cmp ($b . "") } my @a = reverse  "a".."j";',
         code    => '@a = sort f @a',
     },
-
 
     'func::split::vars' => {
         desc    => 'split into two lexical vars',


### PR DESCRIPTION
https://stackoverflow.com/questions/79244888 points out that `pp_print`
is really slow at stringifying integers. It's bizarrely much faster to add
additional operations to do the stringification first. 

Here are some sample timings:
````
1003 ms | 'for (my $i=1; $i<=10000000;$i++) { say $i }'
 630 ms | 'for (my $i=1; $i<=10000000;$i++) { say "$i" }'
 695 ms | 'for (my $i=1; $i<=10000000;$i++) { say $i."" }'
 553 ms | 'my $i = "str"; for ($i=1; $i<=10000000;$i++) { say $i }'
````

Note from the last timing that stringification in `pp_print` is _not_
always slow, only when the IV is stored in a SVt_IV. This traces back
to `Perl_do_print` which has a special path for just this case:
```
    if (SvTYPE(sv) == SVt_IV && SvIOK(sv)) {
        assert(!SvGMAGICAL(sv));
        if (SvIsUV(sv))
            PerlIO_printf(fp, "%" UVuf, (UV)SvUVX(sv));
        else
            PerlIO_printf(fp, "%" IVdf, (IV)SvIVX(sv));
        return !PerlIO_error(fp);
    }
```
(There are no code comments to say why it does this. Perhaps deliberately
preserving the type for some reason?)

`PerlIO_printf` calls `PerlIO_vprintf`, which calls `Perl_vnewSVpvf`, which
creates a new (effectively) temporary SV, then sends that to
`Perl_sv_vcatpvfn_flags` for stringification and storage of the IV.
`PerlIO_vprintf` then writes out the buffer from the temp SV and frees it.

All the other routes essentially call `SvPV_const` on `$i` or a `PADTMP`.
This invokes `sv_2pv_flags` and its helper, `S_uiv_2buf`, does the work.
No temporary SVs are created and freed in such cases.

This PR changes `Perl_do_print` to also use a small buffer and
`S_uiv_2buf` to do the stringification more efficiently, whilst still
avoiding a type upgrade, Re-measuring after this PR:

```
 470 ms 'for (my $i=1; $i<=10000000;$i++) { say $i }'
```

---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.

