### PR TITLE
doop.c Use new utf8_to_uv_or_die()

### DIFF
--- a/doop.c
+++ b/doop.c
@@ -82,7 +82,7 @@ S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
             short ch;
 
             /* Need to check this, otherwise 128..255 won't match */
-            const UV c = utf8n_to_uvchr(s, send - s, &ulen, UTF8_ALLOW_DEFAULT);
+            const UV c = utf8_to_uv_or_die(s, send, &ulen);
             if (c < 0x100 && (ch = tbl->map[c]) >= 0) {
                 matches++;
                 d = uv_to_utf8(d, (UV)ch);
@@ -149,7 +149,7 @@ S_do_trans_count(pTHX_ SV * const sv, const OPtrans_map * const tbl)
         const bool complement = cBOOL(PL_op->op_private & OPpTRANS_COMPLEMENT);
         while (s < send) {
             STRLEN ulen;
-            const UV c = utf8n_to_uvchr(s, send - s, &ulen, UTF8_ALLOW_DEFAULT);
+            const UV c = utf8_to_uv_or_die(s, send, &ulen);
             if (c < 0x100) {
                 if (tbl->map[c] >= 0)
                     matches++;
@@ -266,8 +266,7 @@ S_do_trans_complex(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 
         while (s < send) {
             STRLEN len;
-            const UV comp = utf8n_to_uvchr(s, send - s, &len,
-                                           UTF8_ALLOW_DEFAULT);
+            const UV comp = utf8_to_uv_or_die(s, send, &len);
             UV     ch;
             short sch;
 
@@ -371,10 +370,7 @@ S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
             s_len = 1;
         }
         else {
-            from = utf8_to_uvchr_buf(s, send, &s_len);
-            if (from == 0 && *s != '\0') {
-                force_out_malformed_utf8_message_(s, send, 0, MALFORMED_UTF8_DIE);
-            }
+            from = utf8_to_uv_or_die(s, send, &s_len);
         }
 
         /* Look the code point up in the data structure for this tr/// to get
@@ -490,10 +486,7 @@ S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
             s_len = 1;
         }
         else {
-            from = utf8_to_uvchr_buf(s, send, &s_len);
-            if (from == 0 && *s != '\0') {
-                force_out_malformed_utf8_message_(s, send, 0, MALFORMED_UTF8_DIE);
-            }
+            from = utf8_to_uv_or_die(s, send, &s_len);
         }
 
         /* Look the code point up in the data structure for this tr/// to get


### PR DESCRIPTION
This replaces the older forms.  For two of the instances, this gives equivalent functionality, where they croaked if an operand to tr/// was malformed.  For the other instances, it didn't croak, but now does. This makes the behavior consistent for tr///, as all the affected instances are supposed to be equivalent.  For performance reasons, one or another of the functions would be called, and depending on which one the same input would croak or not.


* This set of changes does not require a perldelta entry.
