### PR TITLE
Convert uv_to_utf8-type macros to inline functions

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3818,13 +3818,13 @@ Cp	|U8 *	|uvoffuni_to_utf8_flags_msgs				\
 				|const UV flags 			\
 				|NULLOK HV **msgs
 
-Admp	|U8 *	|uv_to_utf8	|NN U8 *d				\
+Adip	|U8 *	|uv_to_utf8	|NN U8 *d				\
 				|UV uv
-Admp	|U8 *	|uv_to_utf8_flags					\
+Adip	|U8 *	|uv_to_utf8_flags					\
 				|NN U8 *d				\
 				|UV uv					\
 				|UV flags
-Admp	|U8 *	|uv_to_utf8_msgs|NN U8 *d				\
+Adip	|U8 *	|uv_to_utf8_msgs|NN U8 *d				\
 				|UV uv					\
 				|UV flags				\
 				|NULLOK HV **msgs

--- a/embed.h
+++ b/embed.h
@@ -875,9 +875,9 @@
 # define utf8n_to_uvchr                         Perl_utf8n_to_uvchr
 # define utf8n_to_uvchr_error                   Perl_utf8n_to_uvchr_error
 # define utf8n_to_uvchr_msgs                    Perl_utf8n_to_uvchr_msgs
-# define uv_to_utf8(a,b)                        Perl_uv_to_utf8(aTHX,a,b)
-# define uv_to_utf8_flags(a,b,c)                Perl_uv_to_utf8_flags(aTHX,a,b,c)
-# define uv_to_utf8_msgs(a,b,c,d)               Perl_uv_to_utf8_msgs(aTHX,a,b,c,d)
+# define uv_to_utf8(a,b)                        Perl_uv_to_utf8(aTHX_ a,b)
+# define uv_to_utf8_flags(a,b,c)                Perl_uv_to_utf8_flags(aTHX_ a,b,c)
+# define uv_to_utf8_msgs(a,b,c,d)               Perl_uv_to_utf8_msgs(aTHX_ a,b,c,d)
 # define uvchr_to_utf8(a,b)                     Perl_uvchr_to_utf8(aTHX,a,b)
 # define uvchr_to_utf8_flags(a,b,c)             Perl_uvchr_to_utf8_flags(aTHX,a,b,c)
 # define uvchr_to_utf8_flags_msgs(a,b,c,d)      Perl_uvchr_to_utf8_flags_msgs(aTHX,a,b,c,d)

--- a/inline.h
+++ b/inline.h
@@ -1231,6 +1231,24 @@ Perl_append_utf8_from_native_byte(const U8 byte, U8** dest)
     }
 }
 
+PERL_STATIC_INLINE U8 *
+Perl_uv_to_utf8(pTHX_ U8 *d, UV input_uv)
+{
+    return uv_to_utf8_flags(d, input_uv, 0);
+}
+
+PERL_STATIC_INLINE U8 *
+Perl_uv_to_utf8_flags(pTHX_ U8 *d, UV input_uv, UV flags)
+{
+    return uv_to_utf8_msgs(d, input_uv, flags, NULL);
+}
+
+PERL_STATIC_INLINE U8 *
+Perl_uv_to_utf8_msgs(pTHX_ U8 *d, UV input_uv, UV flags, HV** msgs)
+{
+    return uvoffuni_to_utf8_flags_msgs(d, NATIVE_TO_UNI(input_uv), flags, msgs);
+}
+
 /*
 =for apidoc valid_utf8_to_uvchr
 Like C<L<perlapi/utf8_to_uvchr_buf>>, but should only be called when it is

--- a/proto.h
+++ b/proto.h
@@ -5398,15 +5398,6 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
         assert(idop)
 
 /* PERL_CALLCONV U8 *
-Perl_uv_to_utf8(pTHX_ U8 *d, UV uv); */
-
-/* PERL_CALLCONV U8 *
-Perl_uv_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags); */
-
-/* PERL_CALLCONV U8 *
-Perl_uv_to_utf8_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs); */
-
-/* PERL_CALLCONV U8 *
 Perl_uvchr_to_utf8(pTHX_ U8 *d, UV uv); */
 
 /* PERL_CALLCONV U8 *
@@ -10056,6 +10047,21 @@ PERL_STATIC_INLINE UV
 Perl_utf8n_to_uvchr_msgs(const U8 * const s0, STRLEN curlen, STRLEN *retlen, const U32 flags, U32 *errors, AV **msgs);
 # define PERL_ARGS_ASSERT_UTF8N_TO_UVCHR_MSGS   \
         assert(s0)
+
+PERL_STATIC_INLINE U8 *
+Perl_uv_to_utf8(pTHX_ U8 *d, UV uv);
+# define PERL_ARGS_ASSERT_UV_TO_UTF8            \
+        assert(d)
+
+PERL_STATIC_INLINE U8 *
+Perl_uv_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags);
+# define PERL_ARGS_ASSERT_UV_TO_UTF8_FLAGS      \
+        assert(d)
+
+PERL_STATIC_INLINE U8 *
+Perl_uv_to_utf8_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs);
+# define PERL_ARGS_ASSERT_UV_TO_UTF8_MSGS       \
+        assert(d)
 
 PERL_STATIC_INLINE UV
 Perl_valid_utf8_to_uvchr(const U8 *s, STRLEN *retlen)

--- a/utf8.h
+++ b/utf8.h
@@ -142,13 +142,6 @@ typedef enum {
 #define uvoffuni_to_utf8_flags(d,uv,flags)                                     \
                                uvoffuni_to_utf8_flags_msgs(d, uv, flags, 0)
 
-#define Perl_uv_to_utf8(mTHX, d, u)                                         \
-        Perl_uv_to_utf8_flags(aTHX, d, u, 0)
-#define Perl_uv_to_utf8_flags(mTHX, d, u, f)                                \
-        Perl_uv_to_utf8_msgs(aTHX, d, u, f, 0)
-#define Perl_uv_to_utf8_msgs(mTHX, d, u, f , m)                             \
-        Perl_uvoffuni_to_utf8_flags_msgs(aTHX_ d, NATIVE_TO_UNI(u), f, m)
-
 /* This is needed to cast the parameters for all those calls that had them
  * improperly as chars */
 #define utf8_to_uvchr_buf(s, e, lenp)                                          \


### PR DESCRIPTION
This solves the problem of using mTHX pointed out in GH #22902


* This set of changes does not require a perldelta entry.
