### PR TITLE
pp.h: replace erroneous bitwise AND with logical AND

### DIFF
--- a/pp.h
+++ b/pp.h
@@ -483,7 +483,7 @@ Does not use C<TARG>.  See also C<L</XPUSHu>>, C<L</mPUSHu>> and C<L</PUSHu>>.
         IV TARGi_iv = i;                                                \
         if (LIKELY(                                                     \
               ((SvFLAGS(TARG) & (SVTYPEMASK|SVf_THINKFIRST|SVf_IVisUV)) == SVt_IV) \
-            & (do_taint ? !TAINT_get : 1)))                             \
+            && (do_taint ? !TAINT_get : 1)))                            \
         {                                                               \
             /* Cheap SvIOK_only().                                      \
              * Assert that flags which SvIOK_only() would test or       \
@@ -505,8 +505,8 @@ Does not use C<TARG>.  See also C<L</XPUSHu>>, C<L</mPUSHu>> and C<L</PUSHu>>.
         UV TARGu_uv = u;                                                \
         if (LIKELY(                                                     \
               ((SvFLAGS(TARG) & (SVTYPEMASK|SVf_THINKFIRST|SVf_IVisUV)) == SVt_IV) \
-            & (do_taint ? !TAINT_get : 1)                               \
-            & (TARGu_uv <= (UV)IV_MAX)))                                \
+            && (do_taint ? !TAINT_get : 1)                              \
+            && (TARGu_uv <= (UV)IV_MAX)))                               \
         {                                                               \
             /* Cheap SvIOK_only().                                      \
              * Assert that flags which SvIOK_only() would test or       \
@@ -528,7 +528,7 @@ Does not use C<TARG>.  See also C<L</XPUSHu>>, C<L</mPUSHu>> and C<L</PUSHu>>.
         NV TARGn_nv = n;                                                \
         if (LIKELY(                                                     \
               ((SvFLAGS(TARG) & (SVTYPEMASK|SVf_THINKFIRST)) == SVt_NV) \
-            & (do_taint ? !TAINT_get : 1)))                             \
+            && (do_taint ? !TAINT_get : 1)))                            \
         {                                                               \
             /* Cheap SvNOK_only().                                      \
              * Assert that flags which SvNOK_only() would test or       \


### PR DESCRIPTION
This set of changes does not require a perldelta entry.
