### PR TITLE
fix refassign in non-void context

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -7513,7 +7513,7 @@ PP(pp_refassign)
            in leavesub?  */
     }
     else
-        rpp_popfree_to_NN(PL_stack_sp - (extra + 1));
+        rpp_popfree_to_NN(PL_stack_sp - (extra + cBOOL(GIMME_V == G_VOID)));
 
     return NORMAL;
 }

--- a/t/op/lvref.t
+++ b/t/op/lvref.t
@@ -5,7 +5,7 @@ BEGIN {
     set_up_inc("../lib");
 }
 
-plan 201;
+plan 203;
 
 eval '\$x = \$y';
 like $@, qr/^Experimental aliasing via reference not enabled/,
@@ -223,6 +223,17 @@ package ArrayTest {
     is \@i, \@ThatArray, '(\local @a)';
   }
   is \@i, $old, '(\local @a) unwound';
+}
+
+# scalar assignment in scalar context
+# GH #22710
+
+{
+    my @a;
+    my $ra = ["a", "b"];
+    my $x = (\@a = $ra);
+    is \@a, $ra, 'scalar cxt same array';
+    is $x,  $ra, 'scalar cxt return value same array';
 }
 
 # Test list assignments in both lval and rval list context


### PR DESCRIPTION
GH #22710

The experimental refassign feature, \@a = $aref, which allows an array/hash etc to be aliased rather than copied, got broken in rvalue non-void context by v5.39.5-56-g604c0355d2. So in something like

    my $x = (\@a = $aref);

the stack was underflowing. This is because previously pp_refassign() would leave its RH argument on the stack when returning, while my commit above made it always pop the argument off the stack.

This commit makes it only pop the arg in void context.

* This set of changes requires a perldelta entry, but is not written yet

