### PR TITLE
Prefer utf8_to_bytes_overwrite to utf8_to_bytes

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -2789,7 +2789,7 @@ S_scomplement(pTHX_ SV *targ, SV *sv)
         tmps = (U8*)SvPV_nomg(TARG, len);
 
         if (SvUTF8(TARG)) {
-            if (len && ! utf8_to_bytes(tmps, &len)) {
+            if (len && ! utf8_to_bytes_overwrite(&tmps, &len)) {
                 Perl_croak(aTHX_ FATAL_ABOVE_FF_MSG, PL_op_desc[PL_op->op_type]);
             }
             SvCUR_set(TARG, len);

--- a/sv.c
+++ b/sv.c
@@ -3644,7 +3644,7 @@ Perl_sv_utf8_downgrade_flags(pTHX_ SV *const sv, const bool fail_ok, const U32 f
             }
             s = (U8 *) SvPV_flags(sv, len, mg_flags);
 
-            if (!utf8_to_bytes(s, &len)) {
+            if (!utf8_to_bytes_overwrite(&s, &len)) {
                 if (fail_ok)
                     return FALSE;
                 else {


### PR DESCRIPTION
The latter has never lost its experimental status

* This set of changes does not require a perldelta entry.
