### PR TITLE
Revert "cygwin: disable CI until cygwin fix signal handling"

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -563,14 +563,13 @@ jobs:
   # | (__| |_| | (_| |\ V  V /| | | | |
   #  \___|\__, |\__, | \_/\_/ |_|_| |_|
   #       |___/ |___/
-  # disabled until cygwin get a signal handling fix out
 
   cygwin:
     name: "cygwin"
     runs-on: windows-2019
     timeout-minutes: 120
     needs: sanity_check
-    if: (! cancelled() && (needs.sanity_check.outputs.ci_force_cygwin == 'true'))
+    if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_cygwin == 'true'))
 
     steps:
       # we use Cygwin git, so no need to configure git here.


### PR DESCRIPTION
Cygwin 3.5.6 has been released.

3.5.6 has it's own problems, but they don't appear to have an effect on our tests.

This reverts commit e7475a138717d483c65c97815b6266e23f55f0ed.

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->


<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
