### PR TITLE
Doing some #ifdef cleanup for drand48()

### DIFF
--- a/util.c
+++ b/util.c
@@ -4742,10 +4742,10 @@ Perl_seed(pTHX)
 #endif
     u += SEED_C3 * (U32)PerlProc_getpid();
     u += SEED_C4 * (U32)PTR2UV(PL_stack_sp);
-#ifndef PLAN9           /* XXX Plan9 assembler chokes on this; fix needed  */
+
     UV ptruv = PTR2UV(&when);
     u += SEED_C5 * ptr_hash(ptruv);
-#endif
+
     return u;
 }
 

--- a/util.c
+++ b/util.c
@@ -4703,11 +4703,6 @@ Perl_seed(pTHX)
     int fd;
 #endif
     U32 u;
-#ifdef HAS_GETTIMEOFDAY
-    struct timeval when;
-#else
-    Time_t when;
-#endif
 
 /* This test is an escape hatch, this symbol isn't set by Configure. */
 #ifndef PERL_NO_DEV_RANDOM
@@ -4729,12 +4724,17 @@ Perl_seed(pTHX)
 #endif
 
 #ifdef HAS_GETTIMEOFDAY
+    struct timeval when;
+
     PerlProc_gettimeofday(&when,NULL);
     u = (U32)SEED_C1 * when.tv_sec + (U32)SEED_C2 * when.tv_usec;
 #else
+    Time_t when;
+
     (void)time(&when);
     u = (U32)SEED_C1 * when;
 #endif
+
     u += SEED_C3 * (U32)PerlProc_getpid();
     u += SEED_C4 * (U32)PTR2UV(PL_stack_sp);
 

--- a/util.c
+++ b/util.c
@@ -4693,15 +4693,10 @@ Perl_seed(pTHX)
      * value from (tv_sec * SEED_C1 + tv_usec).  The multipliers should
      * probably be bigger too.
      */
-#if RANDBITS > 16
-#  define SEED_C1	1000003
-#define   SEED_C4	73819
-#else
-#  define SEED_C1	25747
-#define   SEED_C4	20639
-#endif
+#define   SEED_C1	1000003
 #define   SEED_C2	3
 #define   SEED_C3	269
+#define   SEED_C4	73819
 #define   SEED_C5	26107
 
 #ifndef PERL_NO_DEV_RANDOM

--- a/util.c
+++ b/util.c
@@ -4721,11 +4721,7 @@ Perl_seed(pTHX)
     * if there isn't enough entropy available.  You can compile with
     * PERL_RANDOM_DEVICE to it if you'd prefer Perl to block until there
     * is enough real entropy to fill the seed. */
-#  ifdef __amigaos4__
-#    define PERL_RANDOM_DEVICE "RANDOM:SIZE=4"
-#  else
-#    define PERL_RANDOM_DEVICE "/dev/urandom"
-#  endif
+#define PERL_RANDOM_DEVICE "/dev/urandom"
 #endif
     fd = PerlLIO_open_cloexec(PERL_RANDOM_DEVICE, 0);
     if (fd != -1) {

--- a/util.c
+++ b/util.c
@@ -4741,6 +4741,7 @@ Perl_seed(pTHX)
     UV ptruv = PTR2UV(&when);
     u += SEED_C5 * ptr_hash(ptruv);
 
+    /* Make sure we mix the bits of up real good for better randomness */
     u = ptr_hash(u);
 
     return u;

--- a/util.c
+++ b/util.c
@@ -4699,9 +4699,6 @@ Perl_seed(pTHX)
 #define   SEED_C4	73819
 #define   SEED_C5	26107
 
-#ifndef PERL_NO_DEV_RANDOM
-    int fd;
-#endif
     U32 u;
 
 /* This test is an escape hatch, this symbol isn't set by Configure. */
@@ -4713,7 +4710,7 @@ Perl_seed(pTHX)
     * is enough real entropy to fill the seed. */
 #define PERL_RANDOM_DEVICE "/dev/urandom"
 #endif
-    fd = PerlLIO_open_cloexec(PERL_RANDOM_DEVICE, 0);
+    int fd = PerlLIO_open_cloexec(PERL_RANDOM_DEVICE, 0);
     if (fd != -1) {
         if (PerlLIO_read(fd, (void*)&u, sizeof u) != sizeof u)
             u = 0;

--- a/util.c
+++ b/util.c
@@ -4741,6 +4741,8 @@ Perl_seed(pTHX)
     UV ptruv = PTR2UV(&when);
     u += SEED_C5 * ptr_hash(ptruv);
 
+    u = ptr_hash(u);
+
     return u;
 }
 


### PR DESCRIPTION
The code for random initialization in `util.c` is riddled with a lot of exceptions in the form of `#ifdefs`. The code is actually quite complicated to read because of all the ifdefs. This pull request removes `ifdefs` for Plan9 and AmigaOS 4.x. This should simplify the code, and make it more readable.

This PR also removes support for `RAND_BITS < 16` which, from what I can tell is only appropriate on Plan9? It is probably safe to remove as well? That section could be removed from the PR if we still need it. As far as I know we don't actively support any 16 bit platforms anymore.