### PR TITLE
Fix leak, broken collation of UTF-8 string in non-UTF8 locale

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -9961,6 +9961,7 @@ Perl_mem_collxfrm_(pTHX_ const char *input_string,
                 s+= UTF8SKIP(s);
             }
 
+            len = d - sans_highs;
             *d++ = '\0';
 
             s = sans_highs;

--- a/locale.c
+++ b/locale.c
@@ -10151,28 +10151,28 @@ Perl_mem_collxfrm_(pTHX_ const char *input_string,
         first_time = FALSE;
     }
 
-    CLEANUP_STRXFRM;
-
     DEBUG_L(print_collxfrm_input_and_return(s, s + len, xbuf, *xlen, utf8));
-
-    /* Free up unneeded space; retain enough for trailing NUL */
-    Renew(xbuf, COLLXFRM_HDR_LEN + *xlen + 1, char);
+    CLEANUP_STRXFRM;
 
     if (s != input_string) {
         Safefree(s);
     }
+
+    /* Free up unneeded space; retain enough for trailing NUL */
+    Renew(xbuf, COLLXFRM_HDR_LEN + *xlen + 1, char);
 
     return xbuf;
 
   bad:
 
-    CLEANUP_STRXFRM;
     DEBUG_L(print_collxfrm_input_and_return(s, s + len, NULL, 0, utf8));
+    CLEANUP_STRXFRM;
 
-    Safefree(xbuf);
     if (s != input_string) {
         Safefree(s);
     }
+
+    Safefree(xbuf);
     *xlen = 0;
 
     return NULL;

--- a/locale.c
+++ b/locale.c
@@ -9954,7 +9954,6 @@ Perl_mem_collxfrm_(pTHX_ const char *input_string,
                 }
             }
             s[d++] = '\0';
-            Renew(s, d, char);   /* Free up unused space */
             }
         }
 


### PR DESCRIPTION
This supercedes #22811

It started out just trying to convert to using the new forms for converting between bytes and UTF-8, but more problems were found.

* This set of changes does not require a perldelta entry.
