### PR TITLE
Enable "Useless use of %s in void context" warning for chained comparisons

### DIFF
--- a/op.c
+++ b/op.c
@@ -2234,6 +2234,7 @@ Perl_scalarvoid(pTHX_ OP *arg)
         case OP_GETLOGIN:
         case OP_PROTOTYPE:
         case OP_RUNCV:
+        case OP_CMPCHAIN_AND:
         func_ops:
             if (   (PL_opargs[o->op_type] & OA_TARGLEX)
                 && (o->op_private & OPpTARGET_MY)

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -238,6 +238,12 @@ negation (C<!!>) is used as a convert-to-boolean operator.
 
 =item *
 
+L<Useless use of %s in void context|perldiag/"Useless use of %s in void context">
+
+This warning now triggers for use of a chained comparison like C<< 0 < $x < 1 >>.
+
+=item *
+
 XXX Describe change here
 
 =back

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -422,10 +422,12 @@ $a <=> $b;		# OP_NCMP
 "dsatrewq";
 "diatrewq";
 "igatrewq";
+0 <= $a;                # OP_LE
 use 5.015;
 __SUB__	;		# OP_RUNCV
 [];			# OP_ANONLIST
 grep /42/, (1,2);	# OP_GREP. Not warned about (yet). Grep git logs for void_unusual to see why...
+0 <= $a < 10;           # OP_CMPCHAIN_AND
 EXPECT
 Useless use of a constant ("111") in void context at - line 2.
 Useless use of repeat (x) in void context at - line 3.
@@ -470,8 +472,10 @@ Useless use of numeric comparison (<=>) in void context at - line 55.
 Useless use of a constant ("dsatrewq") in void context at - line 56.
 Useless use of a constant ("diatrewq") in void context at - line 57.
 Useless use of a constant ("igatrewq") in void context at - line 58.
-Useless use of __SUB__ in void context at - line 60.
-Useless use of anonymous array ([]) in void context at - line 61.
+Useless use of numeric le (<=) in void context at - line 59.
+Useless use of __SUB__ in void context at - line 61.
+Useless use of anonymous array ([]) in void context at - line 62.
+Useless use of comparison chaining in void context at - line 64.
 ########
 # op.c
 use warnings 'scalar' ; close STDIN ;


### PR DESCRIPTION
This particular warning was not issued for chained comparisons such as `1 < $a < 2` in void context.
```
% perl -we '$a = 1.5; 1 < $a'
Useless use of numeric lt (<) in void context at -e line 1.
% perl -we '$a = 1.5; 1 < $a < 2'
%		# (no warnings)
```

This change will enable the warning for such cases.
* This set of changes requires a perldelta entry, and it is included.