### PR TITLE
Tidy up unnecessary sv.c calls in various places

### DIFF
--- a/hv.c
+++ b/hv.c
@@ -698,7 +698,7 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
                     }
                     if (TAINTING_get)
                         TAINT_set(SvTAINTED(keysv));
-                    keysv = sv_2mortal(newSVsv(keysv));
+                    keysv = sv_mortalcopy_flags(keysv, SV_GMAGIC|SV_NOSTEAL);
                     mg_copy(MUTABLE_SV(hv), val, (char*)keysv, HEf_SVKEY);
                 } else {
                     mg_copy(MUTABLE_SV(hv), val, key, klen);

--- a/mro_core.c
+++ b/mro_core.c
@@ -1192,7 +1192,7 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes,
                             }
                         }
                         else {
-                            subname = sv_2mortal(newSVsv(namesv));
+                            subname = sv_mortalcopy_flags(namesv, SV_GMAGIC|SV_NOSTEAL);
                             if (len == 1) sv_catpvs(subname, ":");
                             else {
                                 sv_catpvs(subname, "::");
@@ -1275,7 +1275,7 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes,
                             }
                         }
                         else {
-                            subname = sv_2mortal(newSVsv(namesv));
+                            subname = sv_mortalcopy_flags(namesv, SV_GMAGIC|SV_NOSTEAL);
                             if (len == 1) sv_catpvs(subname, ":");
                             else {
                                 sv_catpvs(subname, "::");

--- a/op.c
+++ b/op.c
@@ -4072,7 +4072,7 @@ S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV * name,
 
             if (curstash && svname == (SV *)name
              && !memchr(SvPVX(svname), ':', SvCUR(svname))) {
-                svname = sv_2mortal(newSVsv(PL_curstname));
+                svname = sv_mortalcopy_flags(PL_curstname, SV_GMAGIC|SV_NOSTEAL);
                 sv_catpvs(svname, "::");
                 sv_catsv(svname, (SV *)name);
             }

--- a/pp.c
+++ b/pp.c
@@ -3398,7 +3398,7 @@ PP(pp_oct)
     if (DO_UTF8(sv)) {
          /* If Unicode, try to downgrade
           * If not possible, croak. */
-         SV* const tsv = sv_2mortal(newSVsv(sv));
+         SV* const tsv = sv_mortalcopy_flags(sv, SV_GMAGIC|SV_NOSTEAL);
 
          SvUTF8_on(tsv);
          (void)sv_utf8_downgrade(tsv, FALSE);

--- a/pp.c
+++ b/pp.c
@@ -4063,8 +4063,7 @@ PP(pp_chr)
         {
             if (ckWARN(WARN_UTF8)) {
                 if (SvGMAGICAL(top)) {
-                    SV *top2 = sv_newmortal();
-                    sv_setsv_nomg(top2, top);
+                    SV *top2 = sv_mortalcopy_flags(top, SV_DO_COW_SVSETSV);
                     top = top2;
                 }
                 Perl_warner(aTHX_ packWARN(WARN_UTF8),

--- a/pp.c
+++ b/pp.c
@@ -6151,8 +6151,7 @@ PP(pp_anonhash)
         if (++MARK < PL_stack_sp)
         {
             SvGETMAGIC(*MARK);
-            val = newSV_type(SVt_NULL);
-            sv_setsv_nomg(val, *MARK);
+            val = newSVsv_flags(*MARK, SV_DO_COW_SVSETSV);
         }
         else
         {
@@ -7738,11 +7737,9 @@ PP_wrapped(pp_argelem,
 
         i = 0;
         while (argc--) {
-            SV *tmpsv;
             SV **svp = av_fetch(defav, ix + i, FALSE);
             SV *val = svp ? *svp : &PL_sv_undef;
-            tmpsv = newSV_type(SVt_NULL);
-            sv_setsv(tmpsv, val);
+            SV *tmpsv = newSVsv_flags(val, SV_GMAGIC|SV_DO_COW_SVSETSV);
             av_store((AV*)targ, i++, tmpsv);
             TAINT_NOT;
         }
@@ -7757,10 +7754,8 @@ PP_wrapped(pp_argelem,
             /* see "target should usually be empty" comment above */
             for (i = 0; i < argc; i++) {
                 SV **svp = av_fetch(defav, ix + i, FALSE);
-                SV *newsv = newSV_type(SVt_NULL);
-                sv_setsv_flags(newsv,
-                                svp ? *svp : &PL_sv_undef,
-                                (SV_DO_COW_SVSETSV|SV_NOSTEAL));
+                SV *newsv = newSVsv_flags(svp ? *svp : &PL_sv_undef,
+                                    (SV_DO_COW_SVSETSV|SV_NOSTEAL));
                 if (!av_store(defav, ix + i, newsv))
                     SvREFCNT_dec_NN(newsv);
             }
@@ -7773,21 +7768,15 @@ PP_wrapped(pp_argelem,
 
         i = 0;
         while (argc) {
-            SV *tmpsv;
-            SV **svp;
-            SV *key;
-            SV *val;
-
+            SV **svp = av_fetch(defav, ix + i++, FALSE);
+            SV *key = svp ? *svp : &PL_sv_undef;
             svp = av_fetch(defav, ix + i++, FALSE);
-            key = svp ? *svp : &PL_sv_undef;
-            svp = av_fetch(defav, ix + i++, FALSE);
-            val = svp ? *svp : &PL_sv_undef;
+            SV *val = svp ? *svp : &PL_sv_undef;
 
             argc -= 2;
             if (UNLIKELY(SvGMAGICAL(key)))
                 key = sv_mortalcopy(key);
-            tmpsv = newSV_type(SVt_NULL);
-            sv_setsv(tmpsv, val);
+            SV *tmpsv = newSVsv_flags(val, SV_GMAGIC|SV_DO_COW_SVSETSV);
             hv_store_ent((HV*)targ, key, tmpsv, 0);
             TAINT_NOT;
         }

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -1517,7 +1517,7 @@ PP_wrapped(pp_flop, (GIMME_V == G_LIST) ? 2 : 1, 0)
                 XPUSHs(sv);
                 if (strEQ(SvPVX_const(sv),tmps))
                     break;
-                sv = sv_2mortal(newSVsv(sv));
+                sv = sv_mortalcopy_flags(sv, SV_GMAGIC|SV_NOSTEAL);
                 sv_inc(sv);
             }
         }
@@ -2315,7 +2315,7 @@ PP_wrapped(pp_caller, MAXARG, 0)
             }
             else {
                 /* I think this is will always be "", but be sure */
-                PUSHs(sv_2mortal(newSVsv(cur_text)));
+                PUSHs(sv_mortalcopy_flags(cur_text, SV_GMAGIC|SV_NOSTEAL));
             }
 
             PUSHs(&PL_sv_no);

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4738,8 +4738,7 @@ S_require_file(pTHX_ SV *sv)
                         loader = *av_fetch(AV_FROM_REF(loader), 0, TRUE);
                         if (SvGMAGICAL(loader)) {
                             SvGETMAGIC(loader);
-                            SV *l = sv_newmortal();
-                            sv_setsv_nomg(l, loader);
+                            SV *l = sv_mortalcopy_flags(loader, SV_DO_COW_SVSETSV);
                             loader = l;
                         }
                     }

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -6745,8 +6745,7 @@ Perl_vivify_ref(pTHX_ SV *sv, U32 to_what)
     if (SvGMAGICAL(sv)) {
         /* copy the sv without magic to prevent magic from being
            executed twice */
-        SV* msv = sv_newmortal();
-        sv_setsv_nomg(msv, sv);
+        SV* msv = sv_mortalcopy_flags(sv, SV_DO_COW_SVSETSV);
         return msv;
     }
     return sv;

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -5505,7 +5505,7 @@ PP(pp_subst)
                    However, I suspect it isn't worth the complexity of
                    unravelling the C<goto force_it> for the small number of
                    cases where it would be viable to drop into the copy code. */
-                TARG = sv_2mortal(newSVsv(TARG));
+                TARG = sv_mortalcopy_flags(TARG, SV_GMAGIC|SV_NOSTEAL);
             }
             orig = SvPV_force_nomg(TARG, len);
             goto force_it;

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -563,14 +563,12 @@ PP_wrapped(pp_warn, 0, 1)
       SvGETMAGIC(errsv);
       if (SvROK(errsv)) {
         if (SvGMAGICAL(errsv)) {
-            exsv = sv_newmortal();
-            sv_setsv_nomg(exsv, errsv);
+            exsv = sv_mortalcopy_flags(errsv, SV_DO_COW_SVSETSV);
         }
         else exsv = errsv;
       }
       else if (SvPOKp(errsv) ? SvCUR(errsv) : SvNIOKp(errsv)) {
-        exsv = sv_newmortal();
-        sv_setsv_nomg(exsv, errsv);
+        exsv = sv_mortalcopy_flags(errsv, SV_DO_COW_SVSETSV);
         sv_catpvs(exsv, "\t...caught");
       }
       else {

--- a/regcomp.c
+++ b/regcomp.c
@@ -806,7 +806,7 @@ S_concat_pat(pTHX_ RExC_state_t * const pRExC_state,
                 } else {
                     /* a string with no trailing null, we need to copy it
                      * so it has a trailing null */
-                    pat = sv_2mortal(newSVsv(msv));
+                    pat = sv_mortalcopy_flags(msv, SV_GMAGIC|SV_NOSTEAL);
                 }
             }
 
@@ -16065,7 +16065,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
     must_sv = re_intuit_string(subpattern_re);
     if (must_sv) {
         /* regexec.c can free the re_intuit_string() return. GH #17734 */
-        must_sv = sv_2mortal(newSVsv(must_sv));
+        must_sv = sv_mortalcopy_flags(must_sv, SV_GMAGIC|SV_NOSTEAL);
         must = SvPV(must_sv, must_len);
     }
     else {

--- a/sv.c
+++ b/sv.c
@@ -10316,8 +10316,7 @@ Perl_sv_2io(pTHX_ SV *const sv)
         if (!io) {
             SV *newsv = sv;
             if (SvGMAGICAL(sv)) {
-                newsv = sv_newmortal();
-                sv_setsv_nomg(newsv, sv);
+                newsv = sv_mortalcopy_flags(sv, SV_DO_COW_SVSETSV);
             }
             Perl_croak(aTHX_ "Bad filehandle: %" SVf, SVfARG(newsv));
         }

--- a/toke.c
+++ b/toke.c
@@ -1842,7 +1842,7 @@ Perl_validate_proto(pTHX_ SV *name, SV *proto, bool warn, bool curstash)
             : pv_pretty(tmpsv, p, origlen, 60, NULL, NULL, PERL_PV_ESCAPE_NONASCII);
 
         if (curstash && !memchr(SvPVX(name), ':', SvCUR(name))) {
-            SV *name2 = sv_2mortal(newSVsv(PL_curstname));
+            SV *name2 = sv_mortalcopy_flags(PL_curstname, SV_GMAGIC|SV_NOSTEAL);
             sv_catpvs(name2, "::");
             sv_catsv(name2, (SV *)name);
             name = name2;

--- a/universal.c
+++ b/universal.c
@@ -1104,7 +1104,7 @@ XS(XS_re_regexp_pattern)
         } else {
             /* Scalar, so use the string that Perl would return */
             /* return the pattern in (?msixn:..) format */
-            pattern = sv_2mortal(newSVsv(MUTABLE_SV(re)));
+            pattern = sv_mortalcopy_flags(MUTABLE_SV(re), SV_GMAGIC|SV_NOSTEAL);
             PUSHs(pattern);
             XSRETURN(1);
         }


### PR DESCRIPTION
The commits in this PR essentially replace 2 function calls with just one
that achieves the same outcome. Changes are across multiple files.
grouped by similarity.

* Replace `sv_2mortal(newSVsv(sv));` with `sv_mortalcopy_flags(sv);`
* Replace `newsv = sv_newmortal(); sv_setsv_nomg(newsv, sv);` with
`newsv = sv_mortalcopy_flags(sv, SV_DO_COW_SVSETSV);`
* Replace `newSV_type()` + `sv_setsv_flags()` with `newSVsv_flags();`

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
