### PR TITLE
Minor edits to rmg

### DIFF
--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -709,7 +709,7 @@ modules on CPAN. It can use a full, local CPAN mirror and/or fall back
 on HTTP::Tiny to fetch package metadata remotely.
 
 (If you'd prefer to have a full CPAN mirror, see
-L<How to mirror CPAN|https://www.cpan.org/misc/cpan-faq.html#How_mirror_CPAN>)
+L<How to mirror CPAN|https://www.cpan.org/misc/how-to-mirror.html>)
 
 Change to your perl checkout, and if necessary,
 

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -1463,22 +1463,6 @@ Assuming you're using git 1.7.x or newer:
  $ git checkout -b maint-5.X v5.X.0
  $ git push origin -u maint-5.X
 
-
-=for checklist skip BLEAD-POINT MAINT RC
-
-=head3 Make the maint branch available in the APC
-
-Clone the new branch into /srv/gitcommon/branches on camel so the APC will
-receive its changes.
-
- $ git clone --branch maint-5.14 /gitroot/perl.git \
- ?  /srv/gitcommon/branches/perl-5.14.x
- $ chmod -R g=u /srv/gitcommon/branches/perl-5.14.x
-
-And nag the sysadmins to make this directory available via rsync.
-
-XXX Who are the sysadmins?  Contact info?
-
 =for checklist skip BLEAD-POINT RC
 
 =head3 Copy perldelta.pod to blead

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -1305,11 +1305,6 @@ You can include the customary link to the release announcement even before your
 message reaches the web-visible archives by looking for the X-List-Archive
 header in your message after receiving it back via perl5-porters.
 
-=head3 Blog about your epigraph
-
-If you have a blog, please consider writing an entry in your blog explaining
-why you chose that particular quote for your epigraph.
-
 =head3 Update the link to the latest perl on perlweb
 
 Submit a pull request to L<https://github.com/perlorg/perlweb>.  For a dev

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -374,10 +374,9 @@ This comes down to:
 =head3 Monitor smoke tests for failures
 
 Similarly, monitor the smoking of core tests, and try to fix.  See
-L<https://tux.nl/perl5/smoke/index.html>, L<https://perl5.test-smoke.org/>
-and L<http://perl.develop-help.com> for a summary. See also
-L<https://www.nntp.perl.org/group/perl.daily-build.reports/> which has
-the raw reports.
+L<CoreSmokeDB Web|https://perl5.test-smoke.org/>, L<Perl Smoke Web|http://perl.develop-help.com> 
+and L<Smoke Status Report|https://tux.nl/perl5/smoke/index.html> for a summary. See also
+L<Raw Reports Mailing List|https://www.nntp.perl.org/group/perl.daily-build.reports/> which has emailed raw reports.
 
 Similarly, monitor the smoking of perl for compiler warnings, and try to
 fix.

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -15,14 +15,12 @@ document that starts with a checklist for your release.
 
 This script is run as:
 
- $ perl Porting/make-rmg-checklist \
-     --version [5.X.Y-RC#] > /tmp/rmg.pod
+ $ perl Porting/make-rmg-checklist --version [5.X.Y-RC#] > /tmp/rmg.pod
 
 You can also pass the C<--html> flag to generate an HTML document instead of
 POD.
 
- $ perl Porting/make-rmg-checklist --html \
-     --version [5.X.Y-RC#] > /tmp/rmg.html
+ $ perl Porting/make-rmg-checklist --html --version [5.X.Y-RC#] > /tmp/rmg.html
 
 =head1 SYNOPSIS
 
@@ -767,10 +765,7 @@ Finally, commit the new version of Module::CoreList:
 (unless this is for MAINT; in which case commit it to blead first, then
 cherry-pick it back).
 
- $ git commit -m 'Update Module::CoreList for 5.X.Y' \
-     dist/Module-CoreList/Changes \
-     dist/Module-CoreList/lib/Module/CoreList.pm \
-     dist/Module-CoreList/lib/Module/CoreList/Utils.pm
+ $ git commit -m 'Update Module::CoreList for 5.X.Y' dist/Module-CoreList/Changes dist/Module-CoreList/lib/Module/CoreList.pm dist/Module-CoreList/lib/Module/CoreList/Utils.pm
 
 =head4 Rebuild and test
 
@@ -787,13 +782,11 @@ section, which can be generated with something like:
 For non-MAINT releases, fill in the "New/Updated Modules" sections now
 that Module::CoreList is updated:
 
- $ ./perl -Ilib Porting/corelist-perldelta.pl \
-     --mode=update pod/perldelta.pod
+ $ ./perl -Ilib Porting/corelist-perldelta.pl --mode=update pod/perldelta.pod
 
 For a MAINT release use something like this instead:
 
- $ ./perl -Ilib Porting/corelist-perldelta.pl 5.020001 5.020002 \
-     --mode=update pod/perldelta.pod
+ $ ./perl -Ilib Porting/corelist-perldelta.pl 5.020001 5.020002 --mode=update pod/perldelta.pod
 
 Ideally, also fill in a summary of the major changes to each module for which
 an entry has been added by F<corelist-perldelta.pl>.
@@ -814,8 +807,7 @@ run through pod and spell checkers, e.g.
 Also, you may want to generate and view an HTML version of it to check
 formatting, e.g.
 
- $ ./perl -Ilib ext/Pod-Html/bin/pod2html pod/perldelta.pod > \
-     ~/perldelta.html
+ $ ./perl -Ilib ext/Pod-Html/bin/pod2html pod/perldelta.pod > ~/perldelta.html
 
 If you make changes, be sure to commit them.
 
@@ -1083,8 +1075,7 @@ Check that basic configuration and tests work on each test machine:
 Check that the test harness and install work on each test machine:
 
  $ make distclean
- $ ./Configure -des -Dprefix=/install/path && \
-       make all test_harness install
+ $ ./Configure -des -Dprefix=/install/path && make all test_harness install
  $ cd /install/path
 
 (Remember C<-Dusedevel> above, for a development release.)
@@ -1588,8 +1579,7 @@ test_porting makefile target to check that they're ok.
 
 Run
 
- $ ./perl -Ilib -MModule::CoreList \
- -le 'print Module::CoreList->find_version($]) ? "ok" : "not ok"'
+ $ ./perl -Ilib -MModule::CoreList -le 'print Module::CoreList->find_version($]) ? "ok" : "not ok"'
 
 and check that it outputs "ok" to prove that Module::CoreList now knows
 about blead's current version.

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -15,13 +15,13 @@ document that starts with a checklist for your release.
 
 This script is run as:
 
- perl Porting/make-rmg-checklist \
+ $ perl Porting/make-rmg-checklist \
      --version [5.X.Y-RC#] > /tmp/rmg.pod
 
 You can also pass the C<--html> flag to generate an HTML document instead of
 POD.
 
- perl Porting/make-rmg-checklist --html \
+ $ perl Porting/make-rmg-checklist --html \
      --version [5.X.Y-RC#] > /tmp/rmg.html
 
 =head1 SYNOPSIS
@@ -251,7 +251,7 @@ Additionally, all files listed as "modified" but not "customized for blead"
 should have entries added under the C<CUSTOMIZED> key in
 F<Porting/Maintainers.pl>, as well as checksums updated via:
 
- cd t; ../perl -I../lib porting/customized.t --regen
+ $ cd t; ../perl -I../lib porting/customized.t --regen
 
 =head4 Sync CPAN modules with the corresponding cpanE<sol> distro
 
@@ -259,7 +259,7 @@ In most cases, once a new version of a distribution shipped with core has been
 uploaded to CPAN, the core version thereof can be synchronized automatically
 with the program F<Porting/sync-with-cpan>. For example:
 
- perl Porting/sync-with-cpan Archive::Tar
+ $ perl Porting/sync-with-cpan Archive::Tar
 
 (But see the comments at the beginning of that program.  In particular, it has
 not yet been exercised on Windows as much as it has on Unix-like platforms.)
@@ -405,7 +405,7 @@ problems in pods.  However, it can be taught to ignore problems, and
 sometimes people do so for problems that really should be fixed before
 release.  To see what it is ignoring, run
 
- ./perl -Ilib t/porting/podcheck.t --counts
+ $ ./perl -Ilib t/porting/podcheck.t --counts
 
 Any problems listed as pedantic aren't worth your time investigating.
 These have a C<?> at the beginning of the text, or are for the too-long
@@ -416,13 +416,13 @@ mean that someone clicking on the pod in a web page will get a 404.
 
 To find out more about any real problems, capture the output from
 
- ./perl -Ilib t/porting/podcheck.t --show-all
+ $ ./perl -Ilib t/porting/podcheck.t --show-all
 
 and grep for those real problems.  (It can take a minute or so to run.)
 
 If you decide any should be fixed, after that gets done, run
 
- ./perl -Ilib t/porting/podcheck.t
+ $ ./perl -Ilib t/porting/podcheck.t
 
 to make sure those fixes were successful, and follow the directions in
 the output about regenerating the data base.
@@ -628,7 +628,7 @@ need to freeze blead during the release. This is less important for
 BLEAD-FINAL, MAINT, and RC releases, since blead will already be frozen in
 those cases. Create the branch by running
 
- git checkout -b release-5.X.Y
+ $ git checkout -b release-5.X.Y
 
 =head3 Build a clean perl
 
@@ -1116,11 +1116,11 @@ for files in the wrong place, or files no longer included which should be.
 For example, suppose the about-to-be-released version is 5.10.1 and the
 previous is 5.10.0:
 
- cd installdir-5.10.0/
- find . -type f | perl -pe's/5\.10\.0/5.10.1/g' | sort > /tmp/f1
- cd installdir-5.10.1/
- find . -type f | sort > /tmp/f2
- diff -u /tmp/f[12]
+ $ cd installdir-5.10.0/
+ $ find . -type f | perl -pe's/5\.10\.0/5.10.1/g' | sort > /tmp/f1
+ $ cd installdir-5.10.1/
+ $ find . -type f | sort > /tmp/f2
+ $ diff -u /tmp/f[12]
 
 =head4 Disable C<local::lib> if it's turned on
 
@@ -1217,8 +1217,8 @@ Upload the .gz and .xz versions of the tarball.
 Note: You can also use the command-line utility to upload your tarballs, if
 you have it configured:
 
- cpan-upload perl-5.X.Y.tar.gz
- cpan-upload perl-5.X.Y.tar.xz
+ $ cpan-upload perl-5.X.Y.tar.gz
+ $ cpan-upload perl-5.X.Y.tar.xz
 
 Do not proceed any further until you are sure that your tarballs are on CPAN.
 Check your authors directory metacpan.org to confirm that your uploads have
@@ -1278,11 +1278,11 @@ either, check that the email you are sending from is subscribed to the list.
 
 Merge the (local) release branch back into master now, and delete it.
 
- git checkout blead
- git pull
- git merge release-5.X.Y
- git push
- git branch -d release-5.X.Y
+ $ git checkout blead
+ $ git pull
+ $ git merge release-5.X.Y
+ $ git push
+ $ git branch -d release-5.X.Y
 
 Note: The merge will create a merge commit if other changes have been pushed
 to blead while you've been working on your release branch. Do NOT rebase your
@@ -1366,7 +1366,7 @@ Skip to the end of its test output to see the options it offers you.
 
 When C<make test_porting> passes, commit the new perldelta.
 
- git commit -m'New perldelta for 5.X.Y'
+ $ git commit -m'New perldelta for 5.X.Y'
 
 =back
 

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -709,7 +709,7 @@ modules on CPAN. It can use a full, local CPAN mirror and/or fall back
 on HTTP::Tiny to fetch package metadata remotely.
 
 (If you'd prefer to have a full CPAN mirror, see
-L<https://www.cpan.org/misc/cpan-faq.html#How_mirror_CPAN>)
+L<How to mirror CPAN|https://www.cpan.org/misc/cpan-faq.html#How_mirror_CPAN>)
 
 Change to your perl checkout, and if necessary,
 
@@ -1638,7 +1638,7 @@ be considered.
 =head1 SOURCE
 
 Based on
-L<https://www.nntp.perl.org/group/perl.perl5.porters/2009/05/msg146638.html>,
+L<git, process and progress (Nicholas Clark)|https://www.nntp.perl.org/group/perl.perl5.porters/2009/05/msg146638.html>,
 plus a whole bunch of other sources, including private correspondence.
 
 =cut

--- a/t/porting/known_pod_issues.dat
+++ b/t/porting/known_pod_issues.dat
@@ -436,6 +436,6 @@ pod/perltie.pod	Verbatim line length including indents exceeds 78 by	3
 pod/perltru64.pod	Verbatim line length including indents exceeds 78 by	1
 porting/bisect-runner.pl	Verbatim line length including indents exceeds 78 by	2
 porting/epigraphs.pod	Verbatim line length including indents exceeds 78 by	-1
-porting/release_managers_guide.pod	Verbatim line length including indents exceeds 78 by	1
+porting/release_managers_guide.pod	Verbatim line length including indents exceeds 78 by	8
 lib/benchmark.pm	Verbatim line length including indents exceeds 78 by	2
 lib/config.pod	? Should you be using L<...> instead of	-1


### PR DESCRIPTION
# Description
- Avoid multilines commands to ease copy pasting
- Prefix commands with $ when missing
- Remove mention of APC
- Remove section on blogging epigraph, in practice, nobody does. It artificially grow the guide and it's already well big enough
- Small edit of section on perl5 smoke tests 
- Give short link names to some long links
- Change link related to mirroring CPAN

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
