### PR TITLE
Doc fixes

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -9572,6 +9572,17 @@ the string.  A positive OFFSET greater than the length of SCALAR
 results in the string being padded to the required size with C<"\0">
 bytes before the result of the read is appended.
 
+    open(my $FH, "<", "input.txt") or die("Cannot open file: $!");
+
+    my $buf = "";
+    my $num = 0;
+
+    # Read up to 64 bytes
+    $num = sysread($FH, $buf, 64);
+
+    # Read up to 32 bytes into position 512 of $buf
+    $num = sysread($FH, $buf, 32, 512);
+
 There is no syseof() function, which is ok, since
 L<C<eof>|/eof FILEHANDLE> doesn't work well on device files (like ttys)
 anyway.  Use L<C<sysread>|/sysread FILEHANDLE,SCALAR,LENGTH,OFFSET> and


### PR DESCRIPTION
Here is a quicky code example for `sysread()`. Very similar to the last example for `read()`.
