### PR TITLE
update Test-Simple 1.302207 -> 1.302209

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -2709,6 +2709,7 @@ cpan/Test-Simple/lib/Test2/Util/Guard.pm					Test-Simple
 cpan/Test-Simple/lib/Test2/Util/HashBase.pm					Module related to Test::Simple
 cpan/Test-Simple/lib/Test2/Util/Importer.pm					Test-Simple
 cpan/Test-Simple/lib/Test2/Util/Ref.pm						Test-Simple
+cpan/Test-Simple/lib/Test2/Util/Sig.pm						Test-Simple
 cpan/Test-Simple/lib/Test2/Util/Stash.pm					Test-Simple
 cpan/Test-Simple/lib/Test2/Util/Sub.pm						Test-Simple
 cpan/Test-Simple/lib/Test2/Util/Table.pm					Test-Simple

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1126,8 +1126,8 @@ our %Modules = (
     },
 
     'Test::Simple' => {
-        'DISTRIBUTION' => 'EXODIST/Test-Simple-1.302207.tar.gz',
-        'SYNCINFO'     => 'jkeenan on Sun Jan  5 06:26:14 2025',
+        'DISTRIBUTION' => 'EXODIST/Test-Simple-1.302209.tar.gz',
+        'SYNCINFO'     => 'eric on Wed Feb  5 17:23:19 2025',
         'FILES'        => q[cpan/Test-Simple],
         'EXCLUDED'     => [
             qr{^examples/},

--- a/cpan/Test-Simple/lib/Test/Builder.pm
+++ b/cpan/Test-Simple/lib/Test/Builder.pm
@@ -4,7 +4,7 @@ use 5.006;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Scalar::Util qw/blessed reftype weaken/;
 
@@ -963,13 +963,23 @@ sub cmp_ok {
         # over it, which can lead to issues with Devel::Cover
         my $bits_code = defined $warning_bits ? qq["\Q$warning_bits\E"] : 'undef';
 
-        # This is so that warnings come out at the caller's level
+        # Make sure warnings and location matches the caller. Can't do the
+        # comparison directly in the eval, as closing over variables can
+        # capture them forever when running with Devel::Cover.
+        my $check;
         $succ = eval qq[
 BEGIN {\${^WARNING_BITS} = $bits_code};
 #line $line "(eval in cmp_ok) $file"
-\$test = (\$got $type \$expect);
+\$check = sub { \$_[0] $type \$_[1] };
 1;
 ];
+
+        if ($succ) {
+            $succ = eval {
+                $test = $check->($got, $expect);
+                1;
+            };
+        }
         $error = $@;
     }
     local $Level = $Level + 1;

--- a/cpan/Test-Simple/lib/Test/Builder/Formatter.pm
+++ b/cpan/Test-Simple/lib/Test/Builder/Formatter.pm
@@ -2,7 +2,7 @@ package Test::Builder::Formatter;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN { require Test2::Formatter::TAP; our @ISA = qw(Test2::Formatter::TAP) }
 

--- a/cpan/Test-Simple/lib/Test/Builder/Module.pm
+++ b/cpan/Test-Simple/lib/Test/Builder/Module.pm
@@ -7,7 +7,7 @@ use Test::Builder;
 require Exporter;
 our @ISA = qw(Exporter);
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 =head1 NAME

--- a/cpan/Test-Simple/lib/Test/Builder/Tester.pm
+++ b/cpan/Test-Simple/lib/Test/Builder/Tester.pm
@@ -1,7 +1,7 @@
 package Test::Builder::Tester;
 
 use strict;
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test::Builder;
 use Symbol;

--- a/cpan/Test-Simple/lib/Test/Builder/Tester/Color.pm
+++ b/cpan/Test-Simple/lib/Test/Builder/Tester/Color.pm
@@ -1,7 +1,7 @@
 package Test::Builder::Tester::Color;
 
 use strict;
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 require Test::Builder::Tester;
 

--- a/cpan/Test-Simple/lib/Test/Builder/TodoDiag.pm
+++ b/cpan/Test-Simple/lib/Test/Builder/TodoDiag.pm
@@ -2,7 +2,7 @@ package Test::Builder::TodoDiag;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN { require Test2::Event::Diag; our @ISA = qw(Test2::Event::Diag) }
 

--- a/cpan/Test-Simple/lib/Test/More.pm
+++ b/cpan/Test-Simple/lib/Test/More.pm
@@ -17,7 +17,7 @@ sub _carp {
     return warn @_, " at $file line $line\n";
 }
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test::Builder::Module;
 our @ISA    = qw(Test::Builder::Module);

--- a/cpan/Test-Simple/lib/Test/Simple.pm
+++ b/cpan/Test-Simple/lib/Test/Simple.pm
@@ -4,7 +4,7 @@ use 5.006;
 
 use strict;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test::Builder::Module;
 our @ISA    = qw(Test::Builder::Module);

--- a/cpan/Test-Simple/lib/Test/Tester.pm
+++ b/cpan/Test-Simple/lib/Test/Tester.pm
@@ -16,7 +16,7 @@ use Test::Tester::Delegate;
 
 require Exporter;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 our @EXPORT = qw( run_tests check_tests check_test cmp_results show_space );
 our @ISA = qw( Exporter );

--- a/cpan/Test-Simple/lib/Test/Tester/Capture.pm
+++ b/cpan/Test-Simple/lib/Test/Tester/Capture.pm
@@ -2,7 +2,7 @@ use strict;
 
 package Test::Tester::Capture;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 use Test::Builder;

--- a/cpan/Test-Simple/lib/Test/Tester/CaptureRunner.pm
+++ b/cpan/Test-Simple/lib/Test/Tester/CaptureRunner.pm
@@ -3,7 +3,7 @@ use strict;
 
 package Test::Tester::CaptureRunner;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 use Test::Tester::Capture;

--- a/cpan/Test-Simple/lib/Test/Tester/Delegate.pm
+++ b/cpan/Test-Simple/lib/Test/Tester/Delegate.pm
@@ -3,7 +3,7 @@ use warnings;
 
 package Test::Tester::Delegate;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Scalar::Util();
 

--- a/cpan/Test-Simple/lib/Test/use/ok.pm
+++ b/cpan/Test-Simple/lib/Test/use/ok.pm
@@ -1,7 +1,7 @@
 package Test::use::ok;
 use 5.005;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 __END__

--- a/cpan/Test-Simple/lib/Test2.pm
+++ b/cpan/Test-Simple/lib/Test2.pm
@@ -2,7 +2,7 @@ package Test2;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 1;

--- a/cpan/Test-Simple/lib/Test2/API.pm
+++ b/cpan/Test-Simple/lib/Test2/API.pm
@@ -10,7 +10,7 @@ BEGIN {
     $ENV{TEST2_ACTIVE} = 1;
 }
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 my $INST;

--- a/cpan/Test-Simple/lib/Test2/API/Breakage.pm
+++ b/cpan/Test-Simple/lib/Test2/API/Breakage.pm
@@ -2,7 +2,7 @@ package Test2::API::Breakage;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 use Test2::Util qw/pkg_to_file/;

--- a/cpan/Test-Simple/lib/Test2/API/Context.pm
+++ b/cpan/Test-Simple/lib/Test2/API/Context.pm
@@ -2,7 +2,7 @@ package Test2::API::Context;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 use Carp qw/confess croak/;

--- a/cpan/Test-Simple/lib/Test2/API/Instance.pm
+++ b/cpan/Test-Simple/lib/Test2/API/Instance.pm
@@ -2,7 +2,7 @@ package Test2::API::Instance;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 our @CARP_NOT = qw/Test2::API Test2::API::Instance Test2::IPC::Driver Test2::Formatter/;
 use Carp qw/confess carp/;

--- a/cpan/Test-Simple/lib/Test2/API/InterceptResult.pm
+++ b/cpan/Test-Simple/lib/Test2/API/InterceptResult.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Scalar::Util qw/blessed/;
 use Test2::Util  qw/pkg_to_file/;

--- a/cpan/Test-Simple/lib/Test2/API/InterceptResult/Event.pm
+++ b/cpan/Test-Simple/lib/Test2/API/InterceptResult/Event.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use List::Util   qw/first/;
 use Test2::Util  qw/pkg_to_file/;

--- a/cpan/Test-Simple/lib/Test2/API/InterceptResult/Facet.pm
+++ b/cpan/Test-Simple/lib/Test2/API/InterceptResult/Facet.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Facet;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN {
     require Test2::EventFacet;

--- a/cpan/Test-Simple/lib/Test2/API/InterceptResult/Hub.pm
+++ b/cpan/Test-Simple/lib/Test2/API/InterceptResult/Hub.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN { require Test2::Hub; our @ISA = qw(Test2::Hub) }
 use Test2::Util::HashBase;

--- a/cpan/Test-Simple/lib/Test2/API/InterceptResult/Squasher.pm
+++ b/cpan/Test-Simple/lib/Test2/API/InterceptResult/Squasher.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Squasher;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak/;
 use List::Util qw/first/;

--- a/cpan/Test-Simple/lib/Test2/API/Stack.pm
+++ b/cpan/Test-Simple/lib/Test2/API/Stack.pm
@@ -2,7 +2,7 @@ package Test2::API::Stack;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 use Test2::Hub();

--- a/cpan/Test-Simple/lib/Test2/AsyncSubtest.pm
+++ b/cpan/Test-Simple/lib/Test2/AsyncSubtest.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Test2::IPC;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 our @CARP_NOT = qw/Test2::Util::HashBase/;
 

--- a/cpan/Test-Simple/lib/Test2/AsyncSubtest/Event/Attach.pm
+++ b/cpan/Test-Simple/lib/Test2/AsyncSubtest/Event/Attach.pm
@@ -2,7 +2,7 @@ package Test2::AsyncSubtest::Event::Attach;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use base 'Test2::Event';
 use Test2::Util::HashBase qw/id/;

--- a/cpan/Test-Simple/lib/Test2/AsyncSubtest/Event/Detach.pm
+++ b/cpan/Test-Simple/lib/Test2/AsyncSubtest/Event/Detach.pm
@@ -2,7 +2,7 @@ package Test2::AsyncSubtest::Event::Detach;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use base 'Test2::Event';
 use Test2::Util::HashBase qw/id/;

--- a/cpan/Test-Simple/lib/Test2/AsyncSubtest/Formatter.pm
+++ b/cpan/Test-Simple/lib/Test2/AsyncSubtest/Formatter.pm
@@ -2,7 +2,7 @@ package Test2::AsyncSubtest::Formatter;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 die "Should not load this anymore";
 

--- a/cpan/Test-Simple/lib/Test2/AsyncSubtest/Hub.pm
+++ b/cpan/Test-Simple/lib/Test2/AsyncSubtest/Hub.pm
@@ -2,7 +2,7 @@ package Test2::AsyncSubtest::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use base 'Test2::Hub::Subtest';
 use Test2::Util::HashBase qw/ast_ids ast/;

--- a/cpan/Test-Simple/lib/Test2/Bundle.pm
+++ b/cpan/Test-Simple/lib/Test2/Bundle.pm
@@ -2,7 +2,7 @@ package Test2::Bundle;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Bundle/Extended.pm
+++ b/cpan/Test-Simple/lib/Test2/Bundle/Extended.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Test2::V0;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN {
     push @Test2::Bundle::Extended::ISA => 'Test2::V0';

--- a/cpan/Test-Simple/lib/Test2/Bundle/More.pm
+++ b/cpan/Test-Simple/lib/Test2/Bundle/More.pm
@@ -2,7 +2,7 @@ package Test2::Bundle::More;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Plugin::ExitSummary;
 

--- a/cpan/Test-Simple/lib/Test2/Bundle/Simple.pm
+++ b/cpan/Test-Simple/lib/Test2/Bundle/Simple.pm
@@ -2,7 +2,7 @@ package Test2::Bundle::Simple;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Plugin::ExitSummary;
 

--- a/cpan/Test-Simple/lib/Test2/Compare.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare.pm
@@ -2,7 +2,7 @@ package Test2::Compare;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Scalar::Util qw/blessed/;
 use Test2::Util qw/try/;

--- a/cpan/Test-Simple/lib/Test2/Compare/Array.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Array.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/inref meta ending items order for_each/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Bag.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Bag.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/ending meta items for_each/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Base.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Base.pm
@@ -2,7 +2,7 @@ package Test2::Compare::Base;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/confess croak/;
 use Scalar::Util qw/blessed/;

--- a/cpan/Test-Simple/lib/Test2/Compare/Bool.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Bool.pm
@@ -6,7 +6,7 @@ use Carp qw/confess/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Custom.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Custom.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/code name operator stringify_got/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/DeepRef.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/DeepRef.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Delta.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Delta.pm
@@ -2,7 +2,7 @@ package Test2::Compare::Delta;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw{verified id got chk children dne exception note};
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Event.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Event.pm
@@ -8,7 +8,7 @@ use Test2::Compare::EventMeta();
 
 use base 'Test2::Compare::Object';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/etype/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/EventMeta.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/EventMeta.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Meta';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Float.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Float.pm
@@ -6,7 +6,7 @@ use Carp qw/confess/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 our $DEFAULT_TOLERANCE = 1e-08;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Hash.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Hash.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/inref meta ending items order for_each_key for_each_val/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Isa.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Isa.pm
@@ -7,7 +7,7 @@ use Scalar::Util qw/blessed/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Meta.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Meta.pm
@@ -7,7 +7,7 @@ use Test2::Compare::Isa();
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/items/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Negatable.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Negatable.pm
@@ -2,7 +2,7 @@ package Test2::Compare::Negatable;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 require overload;
 require Test2::Util::HashBase;

--- a/cpan/Test-Simple/lib/Test2/Compare/Number.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Number.pm
@@ -6,7 +6,7 @@ use Carp qw/confess/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/input mode/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Object.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Object.pm
@@ -8,7 +8,7 @@ use Test2::Compare::Meta();
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/calls meta refcheck ending/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/OrderedSubset.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/OrderedSubset.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/inref items/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Pattern.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Pattern.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/pattern stringify_got/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Ref.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Ref.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Regex.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Regex.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Scalar.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Scalar.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/item/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Set.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Set.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/checks _reduction/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/String.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/String.pm
@@ -6,7 +6,7 @@ use Carp qw/confess/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Undef.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Undef.pm
@@ -6,7 +6,7 @@ use Carp qw/confess/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase;
 

--- a/cpan/Test-Simple/lib/Test2/Compare/Wildcard.pm
+++ b/cpan/Test-Simple/lib/Test2/Compare/Wildcard.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/expect/;
 

--- a/cpan/Test-Simple/lib/Test2/Env.pm
+++ b/cpan/Test-Simple/lib/Test2/Env.pm
@@ -2,7 +2,7 @@ package Test2::Env;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Event.pm
+++ b/cpan/Test-Simple/lib/Test2/Event.pm
@@ -2,7 +2,7 @@ package Test2::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Scalar::Util qw/blessed reftype/;
 use Carp qw/croak/;

--- a/cpan/Test-Simple/lib/Test2/Event/Bail.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Bail.pm
@@ -2,7 +2,7 @@ package Test2::Event::Bail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Diag.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Diag.pm
@@ -2,7 +2,7 @@ package Test2::Event::Diag;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Encoding.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Encoding.pm
@@ -2,7 +2,7 @@ package Test2::Event::Encoding;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak/;
 

--- a/cpan/Test-Simple/lib/Test2/Event/Exception.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Exception.pm
@@ -2,7 +2,7 @@ package Test2::Event::Exception;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Fail.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Fail.pm
@@ -2,7 +2,7 @@ package Test2::Event::Fail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::EventFacet::Info;
 

--- a/cpan/Test-Simple/lib/Test2/Event/Generic.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Generic.pm
@@ -5,7 +5,7 @@ use warnings;
 use Carp qw/croak/;
 use Scalar::Util qw/reftype/;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }
 use Test2::Util::HashBase;

--- a/cpan/Test-Simple/lib/Test2/Event/Note.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Note.pm
@@ -2,7 +2,7 @@ package Test2::Event::Note;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Ok.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Ok.pm
@@ -2,7 +2,7 @@ package Test2::Event::Ok;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Pass.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Pass.pm
@@ -2,7 +2,7 @@ package Test2::Event::Pass;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::EventFacet::Info;
 

--- a/cpan/Test-Simple/lib/Test2/Event/Plan.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Plan.pm
@@ -2,7 +2,7 @@ package Test2::Event::Plan;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/Event/Skip.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Skip.pm
@@ -2,7 +2,7 @@ package Test2::Event::Skip;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 BEGIN { require Test2::Event::Ok; our @ISA = qw(Test2::Event::Ok) }

--- a/cpan/Test-Simple/lib/Test2/Event/Subtest.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Event::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN { require Test2::Event::Ok; our @ISA = qw(Test2::Event::Ok) }
 use Test2::Util::HashBase qw{subevents buffered subtest_id subtest_uuid start_stamp stop_stamp};

--- a/cpan/Test-Simple/lib/Test2/Event/TAP/Version.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/TAP/Version.pm
@@ -2,7 +2,7 @@ package Test2::Event::TAP::Version;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak/;
 

--- a/cpan/Test-Simple/lib/Test2/Event/V2.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/V2.pm
@@ -2,7 +2,7 @@ package Test2::Event::V2;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Scalar::Util qw/reftype/;
 use Carp qw/croak/;

--- a/cpan/Test-Simple/lib/Test2/Event/Waiting.pm
+++ b/cpan/Test-Simple/lib/Test2/Event/Waiting.pm
@@ -2,7 +2,7 @@ package Test2::Event::Waiting;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/cpan/Test-Simple/lib/Test2/EventFacet.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/-details/;
 use Carp qw/croak/;

--- a/cpan/Test-Simple/lib/Test2/EventFacet/About.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/About.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::About;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -package -no_display -uuid -eid };

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Amnesty.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Amnesty.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Amnesty;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 sub is_list { 1 }
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Assert.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Assert.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Assert;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -pass -no_debug -number };

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Control.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Control.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Control;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -global -terminate -halt -has_callback -encoding -phase };

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Error.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Error.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Error;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 sub facet_key { 'errors' }
 sub is_list { 1 }

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Hub.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Hub.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 sub is_list { 1 }
 sub facet_key { 'hubs' }

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Info.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Info.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Info;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 sub is_list { 1 }
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Info/Table.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Info/Table.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Info::Table;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/confess/;
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Meta.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Meta.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Meta;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Parent.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Parent.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Parent;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/confess/;
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Plan.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Plan.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Plan;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -count -skip -none };

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Render.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Render.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Render;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 sub is_list { 1 }
 

--- a/cpan/Test-Simple/lib/Test2/EventFacet/Trace.pm
+++ b/cpan/Test-Simple/lib/Test2/EventFacet/Trace.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Trace;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 

--- a/cpan/Test-Simple/lib/Test2/Formatter.pm
+++ b/cpan/Test-Simple/lib/Test2/Formatter.pm
@@ -2,7 +2,7 @@ package Test2::Formatter;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 my %ADDED;

--- a/cpan/Test-Simple/lib/Test2/Formatter/TAP.pm
+++ b/cpan/Test-Simple/lib/Test2/Formatter/TAP.pm
@@ -2,7 +2,7 @@ package Test2::Formatter::TAP;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util qw/clone_io/;
 

--- a/cpan/Test-Simple/lib/Test2/Hub.pm
+++ b/cpan/Test-Simple/lib/Test2/Hub.pm
@@ -2,7 +2,7 @@ package Test2::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 use Carp qw/carp croak confess/;

--- a/cpan/Test-Simple/lib/Test2/Hub/Interceptor.pm
+++ b/cpan/Test-Simple/lib/Test2/Hub/Interceptor.pm
@@ -2,7 +2,7 @@ package Test2::Hub::Interceptor;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 use Test2::Hub::Interceptor::Terminator();

--- a/cpan/Test-Simple/lib/Test2/Hub/Interceptor/Terminator.pm
+++ b/cpan/Test-Simple/lib/Test2/Hub/Interceptor/Terminator.pm
@@ -2,7 +2,7 @@ package Test2::Hub::Interceptor::Terminator;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 1;

--- a/cpan/Test-Simple/lib/Test2/Hub/Subtest.pm
+++ b/cpan/Test-Simple/lib/Test2/Hub/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Hub::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN { require Test2::Hub; our @ISA = qw(Test2::Hub) }
 use Test2::Util::HashBase qw/nested exit_code manual_skip_all/;

--- a/cpan/Test-Simple/lib/Test2/IPC.pm
+++ b/cpan/Test-Simple/lib/Test2/IPC.pm
@@ -2,7 +2,7 @@ package Test2::IPC;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 use Test2::API::Instance;

--- a/cpan/Test-Simple/lib/Test2/IPC/Driver.pm
+++ b/cpan/Test-Simple/lib/Test2/IPC/Driver.pm
@@ -2,7 +2,7 @@ package Test2::IPC::Driver;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 use Carp qw/confess/;

--- a/cpan/Test-Simple/lib/Test2/IPC/Driver/Files.pm
+++ b/cpan/Test-Simple/lib/Test2/IPC/Driver/Files.pm
@@ -2,7 +2,7 @@ package Test2::IPC::Driver::Files;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN { require Test2::IPC::Driver; our @ISA = qw(Test2::IPC::Driver) }
 
@@ -14,7 +14,8 @@ use Storable();
 use File::Spec();
 use POSIX();
 
-use Test2::Util qw/try get_tid pkg_to_file IS_WIN32 ipc_separator do_rename do_unlink try_sig_mask/;
+use Test2::Util qw/try get_tid pkg_to_file IS_WIN32 ipc_separator do_rename do_unlink/;
+use Test2::Util::Sig qw/try_sig_mask/;
 use Test2::API qw/test2_ipc_set_pending/;
 
 sub is_viable { 1 }

--- a/cpan/Test-Simple/lib/Test2/Manual.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual.pm
@@ -2,7 +2,7 @@ package Test2::Manual;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Anatomy.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Anatomy.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Anatomy/API.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Anatomy/API.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::API;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Anatomy/Context.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Anatomy/Context.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::Context;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Anatomy/EndToEnd.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Anatomy/EndToEnd.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::EndToEnd;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Anatomy/Event.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Anatomy/Event.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Anatomy/Hubs.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Anatomy/Hubs.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::Hubs;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Anatomy/IPC.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Anatomy/IPC.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::IPC;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Anatomy/Utilities.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Anatomy/Utilities.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::Utilities;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Concurrency.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Concurrency.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Concurrency;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Contributing.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Contributing.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Contributing;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Testing.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Testing.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Testing;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Testing/Introduction.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Testing/Introduction.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Testing::Introduction;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Testing/Migrating.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Testing/Migrating.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Testing::Migrating;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Testing/Planning.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Testing/Planning.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Testing::Planning;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Testing/Todo.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Testing/Todo.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Testing::Todo;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Tooling.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Tooling.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Tooling;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Tooling/FirstTool.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Tooling/FirstTool.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::FirstTool;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Tooling/Formatter.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Tooling/Formatter.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::Formatter;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Tooling/Nesting.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Tooling/Nesting.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Tooling::Nesting;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Tooling/Plugin/TestExit.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Tooling/Plugin/TestExit.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::Plugin::TestExit;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Tooling/Plugin/TestingDone.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Tooling/Plugin/TestingDone.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::Plugin::TestingDone;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Tooling/Plugin/ToolCompletes.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Tooling/Plugin/ToolCompletes.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::Plugin::ToolCompletes;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Tooling/Plugin/ToolStarts.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Tooling/Plugin/ToolStarts.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::Plugin::ToolStarts;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Tooling/Subtest.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Tooling/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Tooling::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Tooling/TestBuilder.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Tooling/TestBuilder.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::TestBuilder;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Manual/Tooling/Testing.pm
+++ b/cpan/Test-Simple/lib/Test2/Manual/Tooling/Testing.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Tooling::Testing;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Mock.pm
+++ b/cpan/Test-Simple/lib/Test2/Mock.pm
@@ -2,7 +2,7 @@ package Test2::Mock;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak confess/;
 our @CARP_NOT = (__PACKAGE__);

--- a/cpan/Test-Simple/lib/Test2/Plugin.pm
+++ b/cpan/Test-Simple/lib/Test2/Plugin.pm
@@ -2,7 +2,7 @@ package Test2::Plugin;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Plugin/BailOnFail.pm
+++ b/cpan/Test-Simple/lib/Test2/Plugin/BailOnFail.pm
@@ -2,7 +2,7 @@ package Test2::Plugin::BailOnFail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::API qw/test2_add_callback_context_release/;
 

--- a/cpan/Test-Simple/lib/Test2/Plugin/DieOnFail.pm
+++ b/cpan/Test-Simple/lib/Test2/Plugin/DieOnFail.pm
@@ -2,7 +2,7 @@ package Test2::Plugin::DieOnFail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::API qw/test2_add_callback_context_release/;
 

--- a/cpan/Test-Simple/lib/Test2/Plugin/ExitSummary.pm
+++ b/cpan/Test-Simple/lib/Test2/Plugin/ExitSummary.pm
@@ -2,7 +2,7 @@ package Test2::Plugin::ExitSummary;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::API qw/test2_add_callback_exit/;
 

--- a/cpan/Test-Simple/lib/Test2/Plugin/SRand.pm
+++ b/cpan/Test-Simple/lib/Test2/Plugin/SRand.pm
@@ -2,7 +2,7 @@ package Test2::Plugin::SRand;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/carp/;
 

--- a/cpan/Test-Simple/lib/Test2/Plugin/Times.pm
+++ b/cpan/Test-Simple/lib/Test2/Plugin/Times.pm
@@ -10,7 +10,7 @@ use Test2::API qw{
 
 use Time::HiRes qw/time/;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 my $ADDED_HOOK = 0;
 my $START;

--- a/cpan/Test-Simple/lib/Test2/Plugin/UTF8.pm
+++ b/cpan/Test-Simple/lib/Test2/Plugin/UTF8.pm
@@ -2,7 +2,7 @@ package Test2::Plugin::UTF8;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak/;
 

--- a/cpan/Test-Simple/lib/Test2/Require.pm
+++ b/cpan/Test-Simple/lib/Test2/Require.pm
@@ -2,7 +2,7 @@ package Test2::Require;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::API qw/context/;
 use Carp qw/croak/;

--- a/cpan/Test-Simple/lib/Test2/Require/AuthorTesting.pm
+++ b/cpan/Test-Simple/lib/Test2/Require/AuthorTesting.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 sub skip {
     my $class = shift;

--- a/cpan/Test-Simple/lib/Test2/Require/AutomatedTesting.pm
+++ b/cpan/Test-Simple/lib/Test2/Require/AutomatedTesting.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 sub skip {
     my $class = shift;

--- a/cpan/Test-Simple/lib/Test2/Require/EnvVar.pm
+++ b/cpan/Test-Simple/lib/Test2/Require/EnvVar.pm
@@ -5,7 +5,7 @@ use warnings;
 use Carp qw/confess/;
 use base 'Test2::Require';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 sub skip {
     my $class = shift;

--- a/cpan/Test-Simple/lib/Test2/Require/ExtendedTesting.pm
+++ b/cpan/Test-Simple/lib/Test2/Require/ExtendedTesting.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 sub skip {
     my $class = shift;

--- a/cpan/Test-Simple/lib/Test2/Require/Fork.pm
+++ b/cpan/Test-Simple/lib/Test2/Require/Fork.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util qw/CAN_FORK/;
 

--- a/cpan/Test-Simple/lib/Test2/Require/Module.pm
+++ b/cpan/Test-Simple/lib/Test2/Require/Module.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util qw/pkg_to_file/;
 

--- a/cpan/Test-Simple/lib/Test2/Require/NonInteractiveTesting.pm
+++ b/cpan/Test-Simple/lib/Test2/Require/NonInteractiveTesting.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 sub skip {
     my $class = shift;

--- a/cpan/Test-Simple/lib/Test2/Require/Perl.pm
+++ b/cpan/Test-Simple/lib/Test2/Require/Perl.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util qw/pkg_to_file/;
 use Scalar::Util qw/reftype/;

--- a/cpan/Test-Simple/lib/Test2/Require/RealFork.pm
+++ b/cpan/Test-Simple/lib/Test2/Require/RealFork.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util qw/CAN_REALLY_FORK/;
 

--- a/cpan/Test-Simple/lib/Test2/Require/ReleaseTesting.pm
+++ b/cpan/Test-Simple/lib/Test2/Require/ReleaseTesting.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 sub skip {
     my $class = shift;

--- a/cpan/Test-Simple/lib/Test2/Require/Threads.pm
+++ b/cpan/Test-Simple/lib/Test2/Require/Threads.pm
@@ -2,9 +2,9 @@ package Test2::Require::Threads;
 use strict;
 use warnings;
 
-use base 'Test2::Require';
+BEGIN { require Test2::Require; our @ISA = qw(Test2::Require) }
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util qw/CAN_THREAD/;
 

--- a/cpan/Test-Simple/lib/Test2/Suite.pm
+++ b/cpan/Test-Simple/lib/Test2/Suite.pm
@@ -2,7 +2,7 @@ package Test2::Suite;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Todo.pm
+++ b/cpan/Test-Simple/lib/Test2/Todo.pm
@@ -9,7 +9,7 @@ use Test2::API qw/test2_stack/;
 
 use overload '""' => \&reason, fallback => 1;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 sub init {
     my $self = shift;

--- a/cpan/Test-Simple/lib/Test2/Tools.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools.pm
@@ -2,7 +2,7 @@ package Test2::Tools;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/Tools/AsyncSubtest.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/AsyncSubtest.pm
@@ -2,7 +2,7 @@ package Test2::Tools::AsyncSubtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::IPC;
 use Test2::AsyncSubtest;

--- a/cpan/Test-Simple/lib/Test2/Tools/Basic.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Basic.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Basic;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak/;
 use Test2::API qw/context/;

--- a/cpan/Test-Simple/lib/Test2/Tools/Class.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Class.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Class;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::API qw/context/;
 use Test2::Util::Ref qw/render_ref/;

--- a/cpan/Test-Simple/lib/Test2/Tools/ClassicCompare.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/ClassicCompare.pm
@@ -2,7 +2,7 @@ package Test2::Tools::ClassicCompare;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 our @EXPORT = qw/is is_deeply isnt like unlike cmp_ok/;
 use base 'Exporter';

--- a/cpan/Test-Simple/lib/Test2/Tools/Compare.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Compare.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Compare;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak/;
 use Scalar::Util qw/reftype/;

--- a/cpan/Test-Simple/lib/Test2/Tools/Defer.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Defer.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Defer;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak/;
 

--- a/cpan/Test-Simple/lib/Test2/Tools/Encoding.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Encoding.pm
@@ -8,7 +8,7 @@ use Test2::API qw/test2_stack/;
 
 use base 'Exporter';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 our @EXPORT = qw/set_encoding/;
 

--- a/cpan/Test-Simple/lib/Test2/Tools/Event.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Event.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util qw/pkg_to_file/;
 

--- a/cpan/Test-Simple/lib/Test2/Tools/Exception.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Exception.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Exception;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/carp/;
 use Test2::API qw/context test2_add_pending_diag test2_clear_pending_diags/;

--- a/cpan/Test-Simple/lib/Test2/Tools/Exports.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Exports.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Exports;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak carp/;
 use Test2::API qw/context/;

--- a/cpan/Test-Simple/lib/Test2/Tools/GenTemp.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/GenTemp.pm
@@ -3,7 +3,7 @@ package Test2::Tools::GenTemp;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use File::Temp qw/tempdir/;
 use File::Spec;

--- a/cpan/Test-Simple/lib/Test2/Tools/Grab.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Grab.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Grab;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::Grabber;
 use Test2::EventFacet::Trace();

--- a/cpan/Test-Simple/lib/Test2/Tools/Mock.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Mock.pm
@@ -11,7 +11,7 @@ use Test2::Mock();
 
 use base 'Exporter';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 our @CARP_NOT = (__PACKAGE__, 'Test2::Mock');
 our @EXPORT = qw/mock mocked/;

--- a/cpan/Test-Simple/lib/Test2/Tools/Ref.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Ref.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Ref;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Scalar::Util qw/reftype refaddr/;
 use Test2::API qw/context/;

--- a/cpan/Test-Simple/lib/Test2/Tools/Refcount.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Refcount.pm
@@ -13,7 +13,7 @@ use Test2::API qw(context release);
 use Scalar::Util qw( weaken refaddr );
 use B qw( svref_2object );
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 our @EXPORT = qw(
    is_refcount

--- a/cpan/Test-Simple/lib/Test2/Tools/Spec.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Spec.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Spec;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak/;
 use Test2::Workflow qw/parse_args build current_build root_build init_root build_stack/;

--- a/cpan/Test-Simple/lib/Test2/Tools/Subtest.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::API qw/context run_subtest/;
 use Test2::Util qw/try/;

--- a/cpan/Test-Simple/lib/Test2/Tools/Target.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Target.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Target;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak/;
 

--- a/cpan/Test-Simple/lib/Test2/Tools/Tester.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Tester.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Tester;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak/;
 use Test2::Util::Ref qw/rtype/;

--- a/cpan/Test-Simple/lib/Test2/Tools/Tiny.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Tiny.pm
@@ -10,7 +10,7 @@ use Test2::API qw/context run_subtest test2_stack/;
 use Test2::Hub::Interceptor();
 use Test2::Hub::Interceptor::Terminator();
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 BEGIN { require Exporter; our @ISA = qw(Exporter) }
 our @EXPORT = qw{

--- a/cpan/Test-Simple/lib/Test2/Tools/Warnings.pm
+++ b/cpan/Test-Simple/lib/Test2/Tools/Warnings.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Warnings;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::API qw/context test2_add_pending_diag/;
 

--- a/cpan/Test-Simple/lib/Test2/Util.pm
+++ b/cpan/Test-Simple/lib/Test2/Util.pm
@@ -2,15 +2,13 @@ package Test2::Util;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
-use POSIX();
 use Config qw/%Config/;
 use Carp qw/croak/;
 
 BEGIN {
-    local ($@, $!, $SIG{__DIE__});
-    *HAVE_PERLIO = eval { require PerlIO; PerlIO->VERSION(1.02); } ? sub() { 1 } : sub() { 0 };
+    *HAVE_PERLIO = defined &PerlIO::get_layers ? sub() { 1 } : sub() { 0 };
 }
 
 our @EXPORT_OK = qw{
@@ -248,30 +246,10 @@ BEGIN {
     }
 }
 
+#for backwards compatibility
 sub try_sig_mask(&) {
-    my $code = shift;
-
-    my ($old, $blocked);
-    unless(IS_WIN32) {
-        my $to_block = POSIX::SigSet->new(
-            POSIX::SIGINT(),
-            POSIX::SIGALRM(),
-            POSIX::SIGHUP(),
-            POSIX::SIGTERM(),
-            POSIX::SIGUSR1(),
-            POSIX::SIGUSR2(),
-        );
-        $old = POSIX::SigSet->new;
-        $blocked = POSIX::sigprocmask(POSIX::SIG_BLOCK(), $to_block, $old);
-        # Silently go on if we failed to log signals, not much we can do.
-    }
-
-    my ($ok, $err) = &try($code);
-
-    # If our block was successful we want to restore the old mask.
-    POSIX::sigprocmask(POSIX::SIG_SETMASK(), $old, POSIX::SigSet->new()) if defined $blocked;
-
-    return ($ok, $err);
+    require Test2::Util::Sig;
+    goto &Test2::Util::Sig::try_sig_mask;
 }
 
 1;
@@ -368,32 +346,6 @@ cross-platform when trying to rename files you recently altered.
 
 Unlink a file, this wraps C<unlink()> in a way that makes it more reliable
 cross-platform when trying to unlink files you recently altered.
-
-=item ($ok, $err) = try_sig_mask { ... }
-
-Complete an action with several signals masked, they will be unmasked at the
-end allowing any signals that were intercepted to get handled.
-
-This is primarily used when you need to make several actions atomic (against
-some signals anyway).
-
-Signals that are intercepted:
-
-=over 4
-
-=item SIGINT
-
-=item SIGALRM
-
-=item SIGHUP
-
-=item SIGTERM
-
-=item SIGUSR1
-
-=item SIGUSR2
-
-=back
 
 =back
 

--- a/cpan/Test-Simple/lib/Test2/Util/ExternalMeta.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/ExternalMeta.pm
@@ -2,7 +2,7 @@ package Test2::Util::ExternalMeta;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 
 use Carp qw/croak/;

--- a/cpan/Test-Simple/lib/Test2/Util/Facets2Legacy.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Facets2Legacy.pm
@@ -2,12 +2,12 @@ package Test2::Util::Facets2Legacy;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak confess/;
 use Scalar::Util qw/blessed/;
 
-use base 'Exporter';
+BEGIN { require Exporter; our @ISA = qw(Exporter) }
 our @EXPORT_OK = qw{
     causes_fail
     diagnostics

--- a/cpan/Test-Simple/lib/Test2/Util/Grabber.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Grabber.pm
@@ -2,7 +2,7 @@ package Test2::Util::Grabber;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Hub::Interceptor();
 use Test2::EventFacet::Trace();

--- a/cpan/Test-Simple/lib/Test2/Util/Guard.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Guard.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use Carp qw(confess);
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 sub new {
     confess "Can't create a Test2::Util::Guard in void context" unless (defined wantarray);

--- a/cpan/Test-Simple/lib/Test2/Util/HashBase.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/HashBase.pm
@@ -2,7 +2,7 @@ package Test2::Util::HashBase;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 #################################################################
 #                                                               #

--- a/cpan/Test-Simple/lib/Test2/Util/Importer.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Importer.pm
@@ -2,7 +2,7 @@ package Test2::Util::Importer;
 use strict; no strict 'refs';
 use warnings; no warnings 'once';
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 my %SIG_TO_SLOT = (
     '&' => 'CODE',

--- a/cpan/Test-Simple/lib/Test2/Util/Ref.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Ref.pm
@@ -2,7 +2,7 @@ package Test2::Util::Ref;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Scalar::Util qw/reftype blessed refaddr/;
 

--- a/cpan/Test-Simple/lib/Test2/Util/Sig.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Sig.pm
@@ -1,0 +1,123 @@
+package Test2::Util::Sig;
+use strict;
+use warnings;
+
+our $VERSION = '1.302209';
+
+use POSIX();
+use Test2::Util qw/try IS_WIN32/;
+
+our @EXPORT_OK = qw{
+    try_sig_mask
+};
+BEGIN { require Exporter; our @ISA = qw(Exporter) }
+
+sub try_sig_mask(&) {
+    my $code = shift;
+
+    my ($old, $blocked);
+    unless(IS_WIN32) {
+        my $to_block = POSIX::SigSet->new(
+            POSIX::SIGINT(),
+            POSIX::SIGALRM(),
+            POSIX::SIGHUP(),
+            POSIX::SIGTERM(),
+            POSIX::SIGUSR1(),
+            POSIX::SIGUSR2(),
+        );
+        $old = POSIX::SigSet->new;
+        $blocked = POSIX::sigprocmask(POSIX::SIG_BLOCK(), $to_block, $old);
+        # Silently go on if we failed to log signals, not much we can do.
+    }
+
+    my ($ok, $err) = &try($code);
+
+    # If our block was successful we want to restore the old mask.
+    POSIX::sigprocmask(POSIX::SIG_SETMASK(), $old, POSIX::SigSet->new()) if defined $blocked;
+
+    return ($ok, $err);
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Test2::Util::Sig - Signal tools used by Test2 and friends.
+
+=head1 DESCRIPTION
+
+Collection of signal tools used by L<Test2> and friends.
+
+=head1 EXPORTS
+
+All exports are optional. You must specify subs to import.
+
+=over 4
+
+=item ($ok, $err) = try_sig_mask { ... }
+
+Complete an action with several signals masked, they will be unmasked at the
+end allowing any signals that were intercepted to get handled.
+
+This is primarily used when you need to make several actions atomic (against
+some signals anyway).
+
+Signals that are intercepted:
+
+=over 4
+
+=item SIGINT
+
+=item SIGALRM
+
+=item SIGHUP
+
+=item SIGTERM
+
+=item SIGUSR1
+
+=item SIGUSR2
+
+=back
+
+=back
+
+=head1 SOURCE
+
+The source code repository for Test2 can be found at
+L<https://github.com/Test-More/test-more/>.
+
+=head1 MAINTAINERS
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=back
+
+=head1 AUTHORS
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=item Kent Fredric E<lt>kentnl@cpan.orgE<gt>
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright Chad Granum E<lt>exodist@cpan.orgE<gt>.
+
+This program is free software; you can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+See L<https://dev.perl.org/licenses/>
+
+=cut

--- a/cpan/Test-Simple/lib/Test2/Util/Stash.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Stash.pm
@@ -2,7 +2,7 @@ package Test2::Util::Stash;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak/;
 use B;

--- a/cpan/Test-Simple/lib/Test2/Util/Sub.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Sub.pm
@@ -2,7 +2,7 @@ package Test2::Util::Sub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak carp/;
 use B();

--- a/cpan/Test-Simple/lib/Test2/Util/Table.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Table.pm
@@ -2,7 +2,7 @@ package Test2::Util::Table;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use base 'Term::Table';
 

--- a/cpan/Test-Simple/lib/Test2/Util/Table/Cell.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Table/Cell.pm
@@ -2,7 +2,7 @@ package Test2::Util::Table::Cell;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use base 'Term::Table::Cell';
 

--- a/cpan/Test-Simple/lib/Test2/Util/Table/LineBreak.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Table/LineBreak.pm
@@ -2,7 +2,7 @@ package Test2::Util::Table::LineBreak;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use base 'Term::Table::LineBreak';
 

--- a/cpan/Test-Simple/lib/Test2/Util/Term.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Term.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Term::Table::Util qw/term_size USE_GCS USE_TERM_READKEY uni_length/;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::Importer 'Test2::Util::Importer' => 'import';
 our @EXPORT_OK = qw/term_size USE_GCS USE_TERM_READKEY uni_length/;

--- a/cpan/Test-Simple/lib/Test2/Util/Times.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Times.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use List::Util qw/sum/;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 our @EXPORT_OK = qw/render_bench render_duration/;
 use base 'Exporter';

--- a/cpan/Test-Simple/lib/Test2/Util/Trace.pm
+++ b/cpan/Test-Simple/lib/Test2/Util/Trace.pm
@@ -6,7 +6,7 @@ use strict;
 
 our @ISA = ('Test2::EventFacet::Trace');
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 1;
 

--- a/cpan/Test-Simple/lib/Test2/V0.pm
+++ b/cpan/Test-Simple/lib/Test2/V0.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Test2::Util::Importer;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak/;
 

--- a/cpan/Test-Simple/lib/Test2/Workflow.pm
+++ b/cpan/Test-Simple/lib/Test2/Workflow.pm
@@ -2,7 +2,7 @@ package Test2::Workflow;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 our @EXPORT_OK = qw/parse_args current_build build root_build init_root build_stack/;
 use base 'Exporter';

--- a/cpan/Test-Simple/lib/Test2/Workflow/BlockBase.pm
+++ b/cpan/Test-Simple/lib/Test2/Workflow/BlockBase.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::BlockBase;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Util::HashBase qw/code frame _info _lines/;
 use Test2::Util::Sub qw/sub_info/;

--- a/cpan/Test-Simple/lib/Test2/Workflow/Build.pm
+++ b/cpan/Test-Simple/lib/Test2/Workflow/Build.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::Build;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::Workflow::Task::Group;
 

--- a/cpan/Test-Simple/lib/Test2/Workflow/Runner.pm
+++ b/cpan/Test-Simple/lib/Test2/Workflow/Runner.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::Runner;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::API();
 use Test2::Todo();

--- a/cpan/Test-Simple/lib/Test2/Workflow/Task.pm
+++ b/cpan/Test-Simple/lib/Test2/Workflow/Task.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::Task;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Test2::API();
 use Test2::Event::Exception();

--- a/cpan/Test-Simple/lib/Test2/Workflow/Task/Action.pm
+++ b/cpan/Test-Simple/lib/Test2/Workflow/Task/Action.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::Task::Action;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use base 'Test2::Workflow::Task';
 use Test2::Util::HashBase qw/around/;

--- a/cpan/Test-Simple/lib/Test2/Workflow/Task/Group.pm
+++ b/cpan/Test-Simple/lib/Test2/Workflow/Task/Group.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::Task::Group;
 use strict;
 use warnings;
 
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use Carp qw/croak/;
 

--- a/cpan/Test-Simple/lib/ok.pm
+++ b/cpan/Test-Simple/lib/ok.pm
@@ -1,5 +1,5 @@
 package ok;
-our $VERSION = '1.302207';
+our $VERSION = '1.302209';
 
 use strict;
 use Test::More ();


### PR DESCRIPTION
Test Simple was lagging slightly behind cpan

* This set of changes does not require a perldelta entry, as it will be generated automatically during the release process.
