### PR TITLE
classes: don't allocate object fields if there are none

### DIFF
--- a/class.c
+++ b/class.c
@@ -37,10 +37,14 @@ Perl_newSVobject(pTHX_ Size_t fieldcount)
 {
     SV *sv = newSV_type(SVt_PVOBJ);
 
-    Newx(ObjectFIELDS(sv), fieldcount, SV *);
+    if (fieldcount) {
+        Newx(ObjectFIELDS(sv), fieldcount, SV *);
+        Zero(ObjectFIELDS(sv), fieldcount, SV *);
+    }
+    else {
+        ObjectFIELDS(sv) = NULL;
+    }
     ObjectMAXFIELD(sv) = fieldcount - 1;
-
-    Zero(ObjectFIELDS(sv), fieldcount, SV *);
 
     return sv;
 }

--- a/ext/Devel-Peek/t/Peek.t
+++ b/ext/Devel-Peek/t/Peek.t
@@ -1675,4 +1675,45 @@ EODUMP
             $head . 'NV = 0\.99999999\d+' . $tail);
 }
 
+{
+    use experimental "class";
+    # this could crash [github #22959]
+    class Foo {
+    };
+    do_test('class object with no fields', Foo->new, <<~'EOS');
+    SV = IV\($ADDR\) at $ADDR
+      REFCNT = \d+
+      FLAGS = \(ROK\)
+      RV = $ADDR
+      SV = PVOBJ\($ADDR\) at $ADDR
+        REFCNT = 1
+        FLAGS = \(OBJECT\)
+        STASH = $ADDR\s+"Foo"
+        MAXFIELD = -1
+        FIELDS = 0x0
+    EOS
+
+    # test object with fields too
+    class Foo2 {
+        field $x = 0;
+    };
+    do_test('class object with a field', Foo2->new, <<~'EOS');
+    SV = IV\($ADDR\) at $ADDR
+      REFCNT = \d+
+      FLAGS = \(ROK\)
+      RV = $ADDR
+      SV = PVOBJ\($ADDR\) at $ADDR
+        REFCNT = 1
+        FLAGS = \(OBJECT\)
+        STASH = $ADDR\s+"Foo2"
+        MAXFIELD = 0
+        FIELDS = $ADDR
+        Field No\. 0 \(\$x\)
+        SV = IV\($ADDR\) at $ADDR
+          REFCNT = 1
+          FLAGS = \(IOK,pIOK\)
+          IV = 0
+    EOS
+}
+
 done_testing();

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -395,7 +395,10 @@ manager will later use a regex to expand these into links.
 
 =item *
 
-XXX
+The C<ObjectFIELDS()> for an object and C<xhv_class_fields> for the
+object's stash weren't always NULL or not-NULL, confusing sv_dump()
+(and hence Devel::Peek's Dump()) into crashing on an object with no
+defined fields in some cases.  [github #22959]
 
 =back
 


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
This was crashing on dump, since the dump code assumed xhv_class_fields was non-NULL when ObjectFIELDS() was non-NULL.

Also add tests for dumping objects, one for this case and another for an object with fields, since there were no such tests.
    
Fixes #22959


<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.

