### PR TITLE
regexec.c - Fix GH 22892 - AHO-CORASICK doesn't handle certain edge cases properly

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -3409,6 +3409,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                             {
                                 DEBUG_TRIE_EXECUTE_r(
                                     Perl_re_printf( aTHX_ " - legal\n"));
+                                failed = 0;
                                 state = tmp;
                                 break;
                             }

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -2164,6 +2164,12 @@ AB\s+\x{100}	AB \x{100}X	y	-	-
 [^\W\S]*	a	y	$&	
 [^\W\S]?	a	y	$&	
 
+ABCF|BCDE|C	ABCDEX	y	$&	BCDE	-	# GH 22892 - AHO-CORASICK bug
+ABCF|BCDE|C	ABCDX	y	$&	C	-	# GH 22892 - AHO-CORASICK bug
+ABCF|BCDE|C(G)	ABCDE	y	$&	BCDE	-	# GH 22892 - AHO-CORASICK bug
+ABCF|BCDE|C[Gg]	ABCDE	y	$&	BCDE	-	# GH 22892 - AHO-CORASICK bug
+ABCF|BCD[Ee]|C[Gg]	ABCDE	y	$&	BCDE	-	# GH 22892 - AHO-CORASICK bug
+
 # Keep these lines at the end of the file
 # pat	string	y/n/etc	expr	expected-expr	skip-reason	comment
 # vim: softtabstop=0 noexpandtab


### PR DESCRIPTION
In some circumstances the AHO-CORASICK logic wasn't matching properly when there were two possibilities whose proper prefix matches a proper suffix of a third possibilty, and one of those possibilities was shorter than the other.

This was because we were resetting the failed flag properly. This bug must be rare because it took more than a decade for anyone to notice.

This patch fixes the problem by resetting the failed flag after a successful transition.

A good example of this problem is as follows:

    "ABCDE" =~ m/ABCF|BCDE|C/

This should match 'BCDE' and not 'C'. Because of the flag issue we were matching 'C' instead.

I dont think this set of changes does requires a perldelta entry.
