### PR TITLE
Add describe (patchlevel) to .git_patch and read it from make_patchnum.pl

### DIFF
--- a/.git_patch
+++ b/.git_patch
@@ -1,1 +1,1 @@
-$Format:%H|%ci|%D$
+$Format:%H|%ci|%(describe)|%D$

--- a/make_patchnum.pl
+++ b/make_patchnum.pl
@@ -135,7 +135,7 @@ if (my $patch_file= read_file(".patch")) {
 }
 elsif ($git_patch_file = read_file(".git_patch") and $git_patch_file !~ /\A\$Format:%H/) {
     chomp $git_patch_file;
-    ($commit_id, my $commit_date, my $names)
+    ($commit_id, my $commit_date, $describe, my $names)
         = split /\|/, $git_patch_file;
 
     my @names = split /,\s*/, $names;
@@ -146,7 +146,6 @@ elsif ($git_patch_file = read_file(".git_patch") and $git_patch_file !~ /\A\$For
     }
     if (!$branch) {
         ($branch) = map m{^tag: (.*)}, @names;
-        $describe = $branch;
     }
     if (!$branch) {
         my ($pr) = map m{^refs/pull/([0-9]+)/}, @names;
@@ -156,7 +155,6 @@ elsif ($git_patch_file = read_file(".git_patch") and $git_patch_file !~ /\A\$For
         $branch = $names[0] || $commit_id;
     }
 
-    $describe ||= $commit_id;
     $extra_info = "git_commit_date='$commit_date'\n";
     $extra_info .= "git_snapshot_date='$commit_date'\n";
     $commit_title = "Snapshot of:";


### PR DESCRIPTION
# Description
This change request is related to #17199

> These are obviously rather different. One notable difference is the git_describe value. It isn't possible to get a describe-style identifier using this mechanism.

It seems that since then, we can now generate describe-style identifier (also known as "patchlevel" in Test::Smoke) using `export-subst`

@haarg @demerphq @atoomic @toddr 

This change is also preliminary work to make Test::Smoke rely more on `.git_patch`

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
