### PR TITLE
Regex engine diagnostics and style cleanups

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -1792,7 +1792,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
     }
     else if (! MUST_RESTART(flags)) {
         ReREFCNT_dec(Rx);
-        Perl_croak(aTHX_ "panic: reg returned failure to re_op_compile, flags=%#" UVxf, (UV) flags);
+        Perl_croak(aTHX_ "panic: reg returned failure to re_op_compile, flags: %#" UVxf, (UV) flags);
     }
 
     /* Here, we either have success, or we have to redo the parse for some reason */
@@ -4040,7 +4040,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                     br = regbranch(pRExC_state, &flags, 1, depth+1);
                     if (br == 0) {
                         RETURN_FAIL_ON_RESTART(flags,flagp);
-                        FAIL2("panic: regbranch returned failure, flags=%#" UVxf,
+                        FAIL2("panic: regbranch returned failure, flags: %#" UVxf,
                               (UV) flags);
                     } else
                     if (! REGTAIL(pRExC_state, br, reg1node(pRExC_state,
@@ -4061,7 +4061,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
 
                         if (!regbranch(pRExC_state, &flags, 1, depth+1)) {
                             RETURN_FAIL_ON_RESTART(flags, flagp);
-                            FAIL2("panic: regbranch returned failure, flags=%#" UVxf,
+                            FAIL2("panic: regbranch returned failure, flags: %#" UVxf,
                                   (UV) flags);
                         }
                         if (! REGTAIL(pRExC_state, ret, lastbr)) {
@@ -4240,7 +4240,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
 
     if (br == 0) {
         RETURN_FAIL_ON_RESTART(flags, flagp);
-        FAIL2("panic: regbranch returned failure, flags=%#" UVxf, (UV) flags);
+        FAIL2("panic: regbranch returned failure, flags: %#" UVxf, (UV) flags);
     }
     if (*RExC_parse == '|') {
         if (RExC_use_BRANCHJ) {
@@ -4289,7 +4289,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
 
         if (br == 0) {
             RETURN_FAIL_ON_RESTART(flags, flagp);
-            FAIL2("panic: regbranch returned failure, flags=%#" UVxf, (UV) flags);
+            FAIL2("panic: regbranch returned failure, flags: %#" UVxf, (UV) flags);
         }
         if (!  REGTAIL(pRExC_state, lastbr, br)) {  /* BRANCH -> BRANCH. */
             REQUIRE_BRANCHJ(flagp, 0);
@@ -4567,7 +4567,7 @@ S_regbranch(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, I32 first, U32 depth)
             if (flags & TRYAGAIN)
                 continue;
             RETURN_FAIL_ON_RESTART(flags, flagp);
-            FAIL2("panic: regpiece returned failure, flags=%#" UVxf, (UV) flags);
+            FAIL2("panic: regpiece returned failure, flags: %#" UVxf, (UV) flags);
         }
         else if (ret == 0)
             ret = latest;
@@ -4800,7 +4800,7 @@ S_regpiece(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
     ret = regatom(pRExC_state, &flags, depth+1);
     if (ret == 0) {
         RETURN_FAIL_ON_RESTART_OR_FLAGS(flags, flagp, TRYAGAIN);
-        FAIL2("panic: regatom returned failure, flags=%#" UVxf, (UV) flags);
+        FAIL2("panic: regatom returned failure, flags: %#" UVxf, (UV) flags);
     }
     I32 npar_after = RExC_npar-1;
 
@@ -5474,7 +5474,7 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
 
     if (! *node_p) {
         RETURN_FAIL_ON_RESTART(flags, flagp);
-        FAIL2("panic: reg returned failure to grok_bslash_N, flags=%#" UVxf,
+        FAIL2("panic: reg returned failure to grok_bslash_N, flags: %#" UVxf,
             (UV) flags);
     }
     *flagp |= flags&(HASWIDTH|SIMPLE|POSTPONED);
@@ -5649,7 +5649,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                        NULL);
         if (ret == 0) {
             RETURN_FAIL_ON_RESTART_FLAGP(flagp);
-            FAIL2("panic: regclass returned failure to regatom, flags=%#" UVxf,
+            FAIL2("panic: regclass returned failure to regatom, flags: %#" UVxf,
                   (UV) *flagp);
         }
         if (*RExC_parse != ']') {
@@ -5672,7 +5672,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                     goto tryagain;
                 }
                 RETURN_FAIL_ON_RESTART(flags, flagp);
-                FAIL2("panic: reg returned failure to regatom, flags=%#" UVxf,
+                FAIL2("panic: reg returned failure to regatom, flags: %#" UVxf,
                                                                  (UV) flags);
         }
         *flagp |= flags&(HASWIDTH|SIMPLE|POSTPONED);
@@ -5931,7 +5931,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
             /* regclass() can only return RESTART_PARSE and NEED_UTF8 if
              * multi-char folds are allowed.  */
             if (!ret)
-                FAIL2("panic: regclass returned failure to regatom, flags=%#" UVxf,
+                FAIL2("panic: regclass returned failure to regatom, flags: %#" UVxf,
                       (UV) *flagp);
 
             RExC_parse--;   /* regclass() leaves this one too far ahead */
@@ -9178,7 +9178,7 @@ redo_curchar:
     return node;
 
   regclass_failed:
-    FAIL2("panic: regclass returned failure to handle_sets, " "flags=%#" UVxf,
+    FAIL2("panic: regclass returned failure to handle_sets, " "flags: %#" UVxf,
                                                                 (UV) *flagp);
 }
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -249,14 +249,14 @@ S_edit_distance(const UV* src,
     /* work loops    */
     /* i = src index */
     /* j = tgt index */
-    for (i=1;i<=x;i++) {
+    for (i = 1; i <= x; i++) {
         if (i < x)
             head = uniquePush(head, src[i]);
         scores[(i+1) * (y + 2) + 1] = i;
         scores[(i+1) * (y + 2) + 0] = score_ceil;
         swapCount = 0;
 
-        for (j=1;j<=y;j++) {
+        for (j = 1; j <= y; j++) {
             if (i == 1) {
                 if(j < y)
                 head = uniquePush(head, tgt[j]);
@@ -322,7 +322,7 @@ Perl_reg_add_data(RExC_state_t* const pRExC_state, const char* const s, const U3
          * we always fill the 0 slot of the data array with a '%' entry, which
          * means "zero" (all the other types are letters) which exists purely
          * so the return from reg_add_data is ALWAYS true, so we can tell it apart
-         * from a "no value" idx=0 in places where we would return an index
+         * from a "no value" idx = 0 in places where we would return an index
          * into reg_add_data.  This is particularly important with the new "single
          * pass, usually, but not always" strategy that we use, where the code
          * will use a 0 to represent "not able to compute this yet".
@@ -338,7 +338,7 @@ Perl_reg_add_data(RExC_state_t* const pRExC_state, const char* const s, const U3
     }
     RExC_rxi->data->count = count + n;
     Copy(s, RExC_rxi->data->what + count, n, U8);
-    assert(count>0);
+    assert(count > 0);
     return count;
 }
 #endif /* PERL_RE_BUILD_AUX */
@@ -555,7 +555,7 @@ S_pat_upgrade_to_utf8(pTHX_ RExC_state_t * const pRExC_state,
 {
     U8 *const src = (U8*)*pat_p;
     U8 *dst, *d;
-    int n=0;
+    int n = 0;
     STRLEN s = 0;
     bool do_end = 0;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
@@ -669,7 +669,7 @@ S_concat_pat(pTHX_ RExC_state_t * const pRExC_state,
 
                 Newx(array, maxarg, SV*);
                 SAVEFREEPV(array);
-                for (i=0; i < maxarg; i++) {
+                for (i = 0; i < maxarg; i++) {
                     SV ** const svp = av_fetch(av, i, FALSE);
                     array[i] = svp ? *svp : &PL_sv_undef;
                 }
@@ -838,7 +838,7 @@ S_concat_pat(pTHX_ RExC_state_t * const pRExC_state,
                     pRExC_state->code_blocks = S_alloc_code_blocks(aTHX_
                                                     ri->code_blocks->count);
 
-                for (i=0; i < ri->code_blocks->count; i++) {
+                for (i = 0; i < ri->code_blocks->count; i++) {
                     struct reg_code_block *src, *dst;
                     STRLEN offset =  orig_patlen
                         + ReANY((REGEXP *)rx)->pre_prefix;
@@ -1692,7 +1692,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
     RExC_end_op = NULL;
     RExC_recurse = NULL;
     RExC_study_chunk_recursed = NULL;
-    RExC_study_chunk_recursed_bytes= 0;
+    RExC_study_chunk_recursed_bytes = 0;
     RExC_recurse_count = 0;
     RExC_sets_depth = 0;
     pRExC_state->code_index = 0;
@@ -1704,8 +1704,8 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
     DEBUG_PARSE_r({
         Perl_re_printf( aTHX_
             "Starting parse and generation\n");
-        RExC_lastnum=0;
-        RExC_lastparse=NULL;
+        RExC_lastnum = 0;
+        RExC_lastparse = NULL;
     });
 
     /* Allocate space and zero-initialize. Note, the two step process
@@ -1881,8 +1881,8 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
     DEBUG_PARSE_r({
         Perl_re_printf( aTHX_
             "Required size %" IVdf " nodes\n", (IV)RExC_size);
-        RExC_lastnum=0;
-        RExC_lastparse=NULL;
+        RExC_lastnum = 0;
+        RExC_lastparse = NULL;
     });
 
     SetProgLen(RExC_rxi,RExC_size);
@@ -1912,7 +1912,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
     if (RExC_seen & REG_RECURSE_SEEN) {
         /* Note, RExC_total_parens is 1 + the number of parens in a pattern.
          * So its 1 if there are no parens. */
-        RExC_study_chunk_recursed_bytes= (RExC_total_parens >> 3) +
+        RExC_study_chunk_recursed_bytes = (RExC_total_parens >> 3) +
                                          ((RExC_total_parens & 0x07) != 0);
         Newx(RExC_study_chunk_recursed,
              RExC_study_chunk_recursed_bytes * RExC_total_parens, U8);
@@ -1922,7 +1922,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
   reStudy:
     RExC_rx->minlen = minlen = sawlookahead = sawplus = sawopen = sawminmod = 0;
     DEBUG_r(
-        RExC_study_chunk_recursed_count= 0;
+        RExC_study_chunk_recursed_count = 0;
     );
     Zero(RExC_rx->substrs, 1, struct reg_substr_data);
     if (RExC_study_chunk_recursed) {
@@ -1937,7 +1937,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
         StructCopy(&zero_scan_data, &data, scan_data_t);
         copyRExC_state = *pRExC_state;
     } else {
-        U32 seen=RExC_seen;
+        U32 seen = RExC_seen;
         DEBUG_OPTIMISE_r(Perl_re_printf( aTHX_ "Restudying\n"));
 
         *pRExC_state = copyRExC_state;
@@ -2005,7 +2005,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
             if (!(
                 /* An OR of *one* alternative - should not happen now. */
                 (OP(first) == BRANCH && OP(first_next) != BRANCH) ||
-                /* An {n,m} with n>0 */
+                /* An {n,m} with n > 0 */
                 (REGNODE_TYPE(OP(first)) == CURLY && ARG1i(first) > 0) ||
                 (OP(first) == NOTHING && REGNODE_TYPE(OP(first_next)) != END)
             )){
@@ -2013,7 +2013,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
             }
 
             first = REGNODE_AFTER(first);
-            first_next= regnext(first);
+            first_next = regnext(first);
         }
 
         /* Starting-point info. */
@@ -2029,7 +2029,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
         }
 #ifdef TRIE_STCLASS
         else if (REGNODE_TYPE(OP(first)) == TRIE &&
-                ((reg_trie_data *)RExC_rxi->data->data[ ARG1u(first) ])->minlen>0)
+                ((reg_trie_data *)RExC_rxi->data->data[ ARG1u(first) ])->minlen > 0)
         {
             /* this can happen only on restudy
              * Search for "restudy" in this file to find
@@ -2234,9 +2234,9 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
 
         /* XXX Unneeded? dmq (shouldn't as this is handled elsewhere)
         if ( (STRLEN)minlen < longest_length[1] )
-            minlen= longest_length[1];
+            minlen = longest_length[1];
         if ( (STRLEN)minlen < longest_length[0] )
-            minlen= longest_length[0];
+            minlen = longest_length[0];
         */
     }
     else {
@@ -2430,7 +2430,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
         /* we rebuild this below */
         Zero(RExC_logical_to_parno, RExC_total_parens, I32);
         for( int parno = RExC_total_parens-1 ; parno > 0 ; parno-- ) {
-            int logical_parno= RExC_parno_to_logical[parno];
+            int logical_parno = RExC_parno_to_logical[parno];
             assert(logical_parno);
             RExC_parno_to_logical_next[parno]= RExC_logical_to_parno[logical_parno];
             RExC_logical_to_parno[logical_parno] = parno;
@@ -2530,7 +2530,7 @@ S_reg_scan_name(pTHX_ RExC_state_t *pRExC_state, U32 flags)
                              SVs_TEMP | (UTF ? SVf_UTF8 : 0));
     if ( flags == REG_RSN_RETURN_NAME)
         return sv_name;
-    else if (flags==REG_RSN_RETURN_DATA) {
+    else if (flags == REG_RSN_RETURN_DATA) {
         HE *he_str = NULL;
         SV *sv_dat = NULL;
         if ( ! sv_name )      /* should not happen*/
@@ -2582,8 +2582,8 @@ S_reg_scan_name(pTHX_ RExC_state_t *pRExC_state, U32 flags)
         (int)((depth*2)), "",                                   \
         (funcname)                                              \
     );                                                          \
-    RExC_lastnum=RExC_emit;                                     \
-    RExC_lastparse=RExC_parse;                                  \
+    RExC_lastnum = RExC_emit;                                     \
+    RExC_lastparse = RExC_parse;                                  \
 })
 
 
@@ -2957,7 +2957,7 @@ S_reg_la_NOTHING(pTHX_ RExC_state_t *pRExC_state, U32 flags,
     RExC_seen_zerolen++;
 
     if (*RExC_parse == ')') {
-        regnode_offset ret= reg_node(pRExC_state, NOTHING);
+        regnode_offset ret = reg_node(pRExC_state, NOTHING);
         nextchar(pRExC_state);
         return ret;
     }
@@ -3003,7 +3003,7 @@ S_reg_la_OPFAIL(pTHX_ RExC_state_t *pRExC_state, U32 flags,
         vFAIL2("Sequence (%s... not terminated", type);
 
     if (*RExC_parse == ')') {
-        regnode_offset ret= reg1node(pRExC_state, OPFAIL, 0);
+        regnode_offset ret = reg1node(pRExC_state, OPFAIL, 0);
         nextchar(pRExC_state);
         return ret; /* return produced regop */
     }
@@ -3073,7 +3073,7 @@ S_reg_la_OPFAIL(pTHX_ RExC_state_t *pRExC_state, U32 flags,
  *  happen.  */
 STATIC regnode_offset
 S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
-    /* paren: Parenthesized? 0=top; 1,2=inside '(': changed to letter.
+    /* paren: Parenthesized? 0 = top; 1,2 = inside '(': changed to letter.
      * 2 is like 1, but indicates that nextchar() has been called to advance
      * RExC_parse beyond the '('.  Things like '(?' are indivisible tokens, and
      * this flag alerts us to the need to check for that */
@@ -3235,13 +3235,13 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                     op = COMMIT;
                 break;
             case 'F':  /* (*FAIL) */
-                if ( verb_len==1 || memEQs(start_verb, verb_len,"FAIL") ) {
+                if ( verb_len == 1 || memEQs(start_verb, verb_len,"FAIL") ) {
                     op = OPFAIL;
                 }
                 break;
             case ':':  /* (*:NAME) */
             case 'M':  /* (*MARK:NAME) */
-                if ( verb_len==0 || memEQs(start_verb, verb_len,"MARK") ) {
+                if ( verb_len == 0 || memEQs(start_verb, verb_len,"MARK") ) {
                     op = MARKPOINT;
                     arg_required = 1;
                 }
@@ -3543,7 +3543,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                 {               /* (?<...>) */
                     char *name_start;
                     SV *svname;
-                    paren= '>';
+                    paren = '>';
                 /* FALLTHROUGH */
             case '\'':          /* (?'...') */
                     name_start = RExC_parse;
@@ -3553,7 +3553,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                         || *RExC_parse != paren)
                     {
                         vFAIL2("Sequence (?%c... not terminated",
-                            paren=='>' ? '<' : (char) paren);
+                            paren == '>' ? '<' : (char) paren);
                     }
                     {
                         HE *he_str;
@@ -3562,10 +3562,10 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                             Perl_croak(aTHX_
                                 "panic: reg_scan_name returned NULL");
                         if (!RExC_paren_names) {
-                            RExC_paren_names= newHV();
+                            RExC_paren_names = newHV();
                             sv_2mortal(MUTABLE_SV(RExC_paren_names));
 #ifdef DEBUGGING
-                            RExC_paren_name_list= newAV();
+                            RExC_paren_name_list = newAV();
                             sv_2mortal(MUTABLE_SV(RExC_paren_name_list));
 #endif
                         }
@@ -3896,7 +3896,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
             }
             case '(':           /* (?(?{...})...) and (?(?=...)...) */
             {
-                int is_define= 0;
+                int is_define = 0;
                 const int DEFINE_len = sizeof("DEFINE") - 1;
                 if (    RExC_parse < RExC_end - 1
                     && (   (       RExC_parse[0] == '?'        /* (?(?...)) */
@@ -3951,7 +3951,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                     char *name_start= RExC_parse;
                     RExC_parse_inc_by(1);
                     U32 num = 0;
-                    SV *sv_dat=reg_scan_name(pRExC_state, REG_RSN_RETURN_DATA);
+                    SV *sv_dat = reg_scan_name(pRExC_state, REG_RSN_RETURN_DATA);
                     if (   RExC_parse == name_start
                         || RExC_parse >= RExC_end
                         || *RExC_parse != ch)
@@ -4396,8 +4396,8 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
         }
 
         if (have_branch) {
-            char is_nothing= 1;
-            if (depth==1)
+            char is_nothing = 1;
+            if (depth == 1)
                 RExC_seen |= REG_TOP_LEVEL_BRANCHES_SEEN;
 
             /* Hook the tails of the branches to the closing node. */
@@ -4413,7 +4413,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                     }
                     if ( OP(nextoper) != NOTHING
                          || regnext(nextoper) != REGNODE_p(ender))
-                        is_nothing= 0;
+                        is_nothing = 0;
                 }
                 else if (op == BRANCHJ) {
                     bool shut_gcc_up = REGTAIL_STUDY(pRExC_state,
@@ -4425,12 +4425,12 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                     if ( OP(nopr) != NOTHING
                          || regnext(nopr) != REGNODE_p(ender))
                     */
-                        is_nothing= 0;
+                        is_nothing = 0;
                 }
             }
             if (is_nothing) {
                 regnode * ret_as_regnode = REGNODE_p(ret);
-                br= REGNODE_TYPE(OP(ret_as_regnode)) != BRANCH
+                br = REGNODE_TYPE(OP(ret_as_regnode)) != BRANCH
                                ? regnext(ret_as_regnode)
                                : ret_as_regnode;
                 DEBUG_PARSE_r({
@@ -4450,10 +4450,10 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                 OP(br)= NOTHING;
                 if (OP(REGNODE_p(ender)) == TAIL) {
                     NEXT_OFF(br)= 0;
-                    RExC_emit= REGNODE_OFFSET(br) + NODE_STEP_REGNODE;
+                    RExC_emit = REGNODE_OFFSET(br) + NODE_STEP_REGNODE;
                 } else {
                     regnode *opt;
-                    for ( opt= br + 1; opt < REGNODE_p(ender) ; opt++ )
+                    for ( opt = br + 1; opt < REGNODE_p(ender) ; opt++ )
                         OP(opt)= OPTIMIZED;
                     NEXT_OFF(br)= REGNODE_p(ender) - br;
                 }
@@ -4463,7 +4463,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
 
     {
         const char *p;
-         /* Even/odd or x=don't care: 010101x10x */
+         /* Even/odd or x = don't care: 010101x10x */
         static const char parens[] = "=!aA<,>Bbt";
          /* flag below is set to 0 up through 'A'; 1 for larger */
 
@@ -5740,7 +5740,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                 ret = reg_node(pRExC_state, KEEPS);
                 /* XXX:dmq : disabling in-place substitution seems to
                  * be necessary here to avoid cases of memory corruption, as
-                 * with: C<$_="x" x 80; s/x\K/y/> -- rgs
+                 * with: C<$_ = "x" x 80; s/x\K/y/> -- rgs
                  */
                 RExC_seen |= REG_LOOKBEHIND_SEEN;
                 goto finish_meta_pat;
@@ -9201,7 +9201,7 @@ S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state,
         PerlIO_printf(Perl_debug_log, "Nothing on stack\n");
     }
     else {
-        PerlIO_printf(Perl_debug_log, "Stack: (fence=%d)\n", (int) fence);
+        PerlIO_printf(Perl_debug_log, "Stack: (fence:%d)\n", (int) fence);
         for (i = stack_top; i >= 0; i--) {
             SV ** element_ptr = av_fetch(stack, i, FALSE);
             if (! element_ptr) {
@@ -12954,7 +12954,7 @@ S_reginsert(pTHX_ RExC_state_t *pRExC_state, const U8 op,
         /* remember that RExC_npar is rex->nparens + 1,
          * iow it is 1 more than the number of parens seen in
          * the pattern so far. */
-        for ( paren=0 ; paren < RExC_npar ; paren++ ) {
+        for ( paren = 0 ; paren < RExC_npar ; paren++ ) {
             /* note, RExC_open_parens[0] is the start of the
              * regex, it can't move. RExC_close_parens[0] is the end
              * of the regex, it *can* move. */
@@ -13015,7 +13015,7 @@ S_regtail(pTHX_ RExC_state_t * pRExC_state,
     for (;;) {
         regnode * const temp = regnext(REGNODE_p(scan));
         DEBUG_PARSE_r({
-            DEBUG_PARSE_MSG((scan==p ? "tail" : ""));
+            DEBUG_PARSE_MSG((scan == p ? "tail" : ""));
             regprop(RExC_rx, RExC_mysv, REGNODE_p(scan), NULL, pRExC_state);
             Perl_re_printf( aTHX_  "~ %s (%zu) %s %s\n",
                 SvPV_nolen_const(RExC_mysv), scan,
@@ -13099,16 +13099,16 @@ S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p,
         if ( exact ) {
             if (REGNODE_TYPE(OP(REGNODE_p(scan))) == EXACT) {
                 if (exact == PSEUDO )
-                    exact= OP(REGNODE_p(scan));
+                    exact = OP(REGNODE_p(scan));
                 else if (exact != OP(REGNODE_p(scan)) )
-                    exact= 0;
+                    exact = 0;
             }
             else if (OP(REGNODE_p(scan)) != NOTHING) {
-                exact= 0;
+                exact = 0;
             }
         }
         DEBUG_PARSE_r({
-            DEBUG_PARSE_MSG((scan==p ? "tsdy" : ""));
+            DEBUG_PARSE_MSG((scan == p ? "tsdy" : ""));
             regprop(RExC_rx, RExC_mysv, REGNODE_p(scan), NULL, pRExC_state);
             Perl_re_printf( aTHX_  "~ %s (%zu) -> %s\n",
                 SvPV_nolen_const(RExC_mysv),
@@ -13503,7 +13503,7 @@ Perl_regfree_internal(pTHX_ REGEXP * const rx)
                 { /* Aho Corasick add-on structure for a trie node.
                      Used in stclass optimization only */
                     U32 refcount;
-                    reg_ac_data *aho=(reg_ac_data*)ri->data->data[n];
+                    reg_ac_data *aho = (reg_ac_data*)ri->data->data[n];
                     OP_REFCNT_LOCK;
                     refcount = --aho->refcount;
                     OP_REFCNT_UNLOCK;
@@ -13529,7 +13529,7 @@ Perl_regfree_internal(pTHX_ REGEXP * const rx)
                 {
                     /* trie structure. */
                     U32 refcount;
-                    reg_trie_data *trie=(reg_trie_data*)ri->data->data[n];
+                    reg_trie_data *trie = (reg_trie_data*)ri->data->data[n];
                     OP_REFCNT_LOCK;
                     refcount = --trie->refcount;
                     OP_REFCNT_UNLOCK;
@@ -13555,7 +13555,7 @@ Perl_regfree_internal(pTHX_ REGEXP * const rx)
                 /* NO-OP a '%' data contains a null pointer, so that reg_add_data
                  * always returns non-zero, this should only ever happen in the
                  * 0 index */
-                assert(n==0);
+                assert(n == 0);
                 break;
             default:
                 Perl_croak(aTHX_ "panic: regfree data code '%c'",
@@ -14598,7 +14598,7 @@ S_parse_uniprop_string(pTHX_
            As_Is                /* upon based on parsing */
          } stricter = Not_Strict;
 
-    /* nv= or numeric_value=, or possibly one of the cjk numeric properties
+    /* nv = or numeric_value=, or possibly one of the cjk numeric properties
      * (though it requires extra effort to download them from Unicode and
      * compile perl to know about them) */
     bool is_nv_type = FALSE;
@@ -15469,7 +15469,7 @@ S_parse_uniprop_string(pTHX_
             /* Create a temporary placeholder in the hash to detect recursion
              * */
             SWITCH_TO_GLOBAL_CONTEXT;
-            placeholder= newSVuv(PTR2IV(ORIGINAL_CONTEXT));
+            placeholder = newSVuv(PTR2IV(ORIGINAL_CONTEXT));
             (void) hv_store_ent(PL_user_def_props, key, placeholder, 0);
             RESTORE_CONTEXT;
 
@@ -16057,7 +16057,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
     all_names_start = SvPVX(names_string);
     cur_pos = all_names_start;
 
-    algorithmic_names= sv_2mortal(SvRV(algorithmic_names));
+    algorithmic_names = sv_2mortal(SvRV(algorithmic_names));
 
     /* Compile the subpattern consisting of the name being looked for */
     subpattern_re = compile_wildcard(wname, wname_len, FALSE /* /-i */ );

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -177,7 +177,7 @@ Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
 #endif
 
     if (plast && plast < last)
-        last= plast;
+        last = plast;
 
     while (node && (!last || node < last)) {
         const U8 op = OP(node);
@@ -228,11 +228,11 @@ Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
         else if ( REGNODE_TYPE(op)  == TRIE ) {
             const regnode *this_trie = node;
             const U32 n = ARG1u(node);
-            const reg_ac_data * const ac = op>=AHOCORASICK ?
+            const reg_ac_data * const ac = op >= AHOCORASICK ?
                (reg_ac_data *)ri->data->data[n] :
                NULL;
             const reg_trie_data * const trie =
-                (reg_trie_data*)ri->data->data[op<AHOCORASICK ? n : ac->trie];
+                (reg_trie_data*)ri->data->data[op < AHOCORASICK ? n : ac->trie];
 #ifdef DEBUGGING
             AV *const trie_words
                            = MUTABLE_AV(ri->data->data[n + TRIE_WORDS_OFFSET]);
@@ -258,24 +258,24 @@ Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
                     : "???"
                 );
                 if (trie->jump) {
-                    U16 dist= trie->jump[word_idx+1];
+                    U16 dist = trie->jump[word_idx+1];
                     Perl_re_printf( aTHX_  "(%" UVuf ")\n",
                                (UV)((dist ? this_trie + dist : next) - start));
                     if (dist) {
                         if (!nextbranch)
-                            nextbranch= this_trie + trie->jump[0];
+                            nextbranch = this_trie + trie->jump[0];
                         DUMPUNTIL(this_trie + dist, nextbranch);
                     }
                     if (nextbranch && REGNODE_TYPE(OP(nextbranch))==BRANCH)
-                        nextbranch= regnext((regnode *)nextbranch);
+                        nextbranch = regnext((regnode *)nextbranch);
                 } else {
                     Perl_re_printf( aTHX_  "\n");
                 }
             }
             if (last && next > last)
-                node= last;
+                node = last;
             else
-                node= next;
+                node = next;
         }
         else if ( op == CURLY ) {   /* "next" might be very big: optimizer */
             DUMPUNTIL(after, after + 1); /* +1 is NOT a REGNODE_AFTER */
@@ -316,12 +316,12 @@ static void
 S_regdump_intflags(pTHX_ const char *lead, const U32 flags)
 {
     int bit;
-    int set=0;
+    int set = 0;
 
     STATIC_ASSERT_STMT(REG_INTFLAGS_NAME_SIZE <= sizeof(flags) * CHARBITS);
 
-    for (bit=0; bit < REG_INTFLAGS_NAME_SIZE; bit++) {
-        if (flags & (1<<bit)) {
+    for (bit = 0; bit < REG_INTFLAGS_NAME_SIZE; bit++) {
+        if (flags & (1 << bit)) {
             if (!set++ && lead)
                 Perl_re_printf( aTHX_  "%s", lead);
             Perl_re_printf( aTHX_  "%s ", PL_reg_intflags_name[bit]);
@@ -339,14 +339,14 @@ static void
 S_regdump_extflags(pTHX_ const char *lead, const U32 flags)
 {
     int bit;
-    int set=0;
+    int set = 0;
     regex_charset cs;
 
     STATIC_ASSERT_STMT(REG_EXTFLAGS_NAME_SIZE <= sizeof(flags) * CHARBITS);
 
-    for (bit=0; bit<REG_EXTFLAGS_NAME_SIZE; bit++) {
-        if (flags & (1U<<bit)) {
-            if ((1U<<bit) & RXf_PMf_CHARSET) {  /* Output separately, below */
+    for (bit = 0; bit < REG_EXTFLAGS_NAME_SIZE; bit++) {
+        if (flags & (1U << bit)) {
+            if ((1U << bit) & RXf_PMf_CHARSET) {  /* Output separately, below */
                 continue;
             }
             if (!set++ && lead)
@@ -635,13 +635,13 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
              || k == GROUPP || op == ACCEPT)
     {
         AV *name_list= NULL;
-        U32 parno= (op == ACCEPT)              ? ARG2u(o) :
+        U32 parno = (op == ACCEPT)              ? ARG2u(o) :
                    (op == OPEN || op == CLOSE) ? PARNO(o) :
                                                  ARG1u(o);
         if ( RXp_PAREN_NAMES(prog) ) {
-            name_list= MUTABLE_AV(progi->data->data[progi->name_list_idx]);
+            name_list = MUTABLE_AV(progi->data->data[progi->name_list_idx]);
         } else if ( pRExC_state ) {
-            name_list= RExC_paren_name_list;
+            name_list = RExC_paren_name_list;
         }
         if ( name_list ) {
             if ( k != REF || (op < REFN)) {
@@ -667,18 +667,18 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
                  * S_reg_add_data()
                  */
                 SV *sv_dat= MUTABLE_SV(progi->data->data[ parno ]);
-                I32 *nums=(I32*)SvPVX(sv_dat);
+                I32 *nums = (I32*)SvPVX(sv_dat);
                 SV **name= av_fetch_simple(name_list, nums[0], 0 );
                 I32 n;
                 if (name) {
-                    for ( n=0; n<SvIVX(sv_dat); n++ ) {
+                    for ( n = 0; n < SvIVX(sv_dat); n++ ) {
                         Perl_sv_catpvf(aTHX_ sv, "%s%" IVdf,
                                     (n ? "," : ""), (IV)nums[n]);
                     }
                     Perl_sv_catpvf(aTHX_ sv, " '%" SVf "'", SVfARG(*name));
                 }
             }
-        } else if (parno>0) {
+        } else if (parno > 0) {
             UV logical_parno = parno;
             if (prog->parno_to_logical)
                 logical_parno = prog->parno_to_logical[parno];
@@ -712,9 +712,9 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
                          ? prog->parno_to_logical[parno]
                          : parno;
         if ( RXp_PAREN_NAMES(prog) ) {
-            name_list= MUTABLE_AV(progi->data->data[progi->name_list_idx]);
+            name_list = MUTABLE_AV(progi->data->data[progi->name_list_idx]);
         } else if ( pRExC_state ) {
-            name_list= RExC_paren_name_list;
+            name_list = RExC_paren_name_list;
         }
 
         /* Paren and offset */
@@ -945,7 +945,9 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         Perl_sv_catpvf(aTHX_ sv, "%s]", PL_colors[1]);
 
         if (op == ANYOFHs) {
-            Perl_sv_catpvf(aTHX_ sv, " (Leading UTF-8 bytes=%s", _byte_dump_string((U8 *) ((struct regnode_anyofhs *) o)->string, FLAGS(o), 1));
+            Perl_sv_catpvf(aTHX_ sv, " (Leading UTF-8 bytes = %s", 
+                _byte_dump_string((U8 *) ((struct regnode_anyofhs *) o)->string, 
+                FLAGS(o), 1));
         }
         else if (REGNODE_TYPE(op) != ANYOF) {
             U8 lowest = (op != ANYOFHr)
@@ -960,7 +962,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
             if (op != ANYOFR || ! isASCII(ANYOFRbase(o) + ANYOFRdelta(o)))
 #endif
             {
-                Perl_sv_catpvf(aTHX_ sv, " (First UTF-8 byte=%02X", lowest);
+                Perl_sv_catpvf(aTHX_ sv, " (First UTF-8 byte = %02X", lowest);
                 if (lowest != highest) {
                     Perl_sv_catpvf(aTHX_ sv, "-%02X", highest);
                 }
@@ -1006,7 +1008,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
             }
         }
         else {
-            Perl_sv_catpvf(aTHX_ sv, "[illegal type=%d])", index);
+            Perl_sv_catpvf(aTHX_ sv, "[illegal type = %d])", index);
         }
     }
     else if (k == BOUND || k == NBOUND) {

--- a/regcomp_invlist.c
+++ b/regcomp_invlist.c
@@ -409,7 +409,9 @@ S__append_range_to_invlist(pTHX_ SV* const invlist,
         if (   array[final_element] > start
             || ELEMENT_RANGE_MATCHES_INVLIST(final_element))
         {
-            Perl_croak(aTHX_ "panic: attempting to append to an inversion list, but wasn't at the end of the list, final=%" UVuf ", start=%" UVuf ", match=%c",
+            Perl_croak(aTHX_ "panic: attempting to append to an inversion list, but "
+                             "wasn't at the end of the list, final = %" UVuf 
+                             ", start = %" UVuf ", match = %c",
                      array[final_element], start,
                      ELEMENT_RANGE_MATCHES_INVLIST(final_element) ? 't' : 'f');
         }
@@ -942,7 +944,7 @@ Perl__invlist_intersection_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
 
     /* Size the intersection for the worst case: that the intersection ends up
      * fragmenting everything to be completely disjoint */
-    r= _new_invlist(len_a + len_b);
+    r = _new_invlist(len_a + len_b);
 
     /* Will contain U+0000 iff both components do */
     array_r = _invlist_array_init(r,    len_a > 0 && array_a[0] == 0
@@ -975,7 +977,7 @@ Perl__invlist_intersection_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
         }
         else {
             cp_in_set = ELEMENT_RANGE_MATCHES_INVLIST(i_b);
-            cp= array_b[i_b++];
+            cp = array_b[i_b++];
         }
 
         /* Here, have chosen which of the two inputs to look at.  Only output

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -32,7 +32,7 @@ S_unwind_scan_frames(pTHX_ const void *p)
     do {
         scan_frame *n= f->next_frame;
         Safefree(f);
-        f= n;
+        f = n;
     } while (f);
 }
 
@@ -1527,13 +1527,13 @@ Perl_study_chunk(pTHX_
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
     PERL_ARGS_ASSERT_STUDY_CHUNK;
-    RExC_study_started= 1;
+    RExC_study_started = 1;
 
     Zero(&data_fake, 1, scan_data_t);
 
     if ( depth == 0 ) {
         while (first_non_open && OP(first_non_open) == OPEN)
-            first_non_open=regnext(first_non_open);
+            first_non_open = regnext(first_non_open);
     }
 
   fake_study_recurse:
@@ -1542,7 +1542,8 @@ Perl_study_chunk(pTHX_
     );
     DEBUG_OPTIMISE_MORE_r(
     {
-        Perl_re_indentf( aTHX_  "study_chunk stopparen=%ld recursed_count=%lu depth=%lu recursed_depth=%lu scan=%p last=%p",
+        Perl_re_indentf( aTHX_  "study_chunk stopparen = %ld recursed_count = %lu "
+                                "depth = %lu recursed_depth = %lu scan = %p last = %p",
             depth, (long)stopparen,
             (unsigned long)RExC_study_chunk_recursed_count,
             (unsigned long)depth, (unsigned long)recursed_depth,
@@ -1621,7 +1622,7 @@ Perl_study_chunk(pTHX_
             DEBUG_PEEP("scan", scan, depth, flags);
             DEBUG_PEEP("next", next, depth, flags);
 
-            /* we suppose the run is continuous, last=next...
+            /* we suppose the run is continuous, last = next...
              * NOTE we dont use the return here! */
             /* DEFINEP study_chunk() recursion */
             (void)study_chunk(pRExC_state, &scan, &minlen,
@@ -1649,7 +1650,7 @@ Perl_study_chunk(pTHX_
                  * check there too. */
                 SSize_t max1 = 0, min1 = OPTIMIZE_INFTY, num = 0;
                 regnode_ssc accum;
-                regnode * const startbranch=scan;
+                regnode * const startbranch = scan;
 
                 if (flags & SCF_DO_SUBSTR) {
                     /* Cannot merge strings after this. */
@@ -1692,7 +1693,7 @@ Perl_study_chunk(pTHX_
                     if (flags & SCF_WHILEM_VISITED_POS)
                         f |= SCF_WHILEM_VISITED_POS;
 
-                    /* we suppose the run is continuous, last=next...*/
+                    /* we suppose the run is continuous, last = next...*/
                     /* recurse study_chunk() for each BRANCH in an alternation */
                     minnext = study_chunk(pRExC_state, &scan, minlenp,
                                       &deltanext, next, &data_fake, stopparen,
@@ -1777,8 +1778,8 @@ Perl_study_chunk(pTHX_
                    whatever it is. We now start at the beginning of the
                    sequence and look for subsequences of
 
-                   BRANCH->EXACT=>x1
-                   BRANCH->EXACT=>x2
+                   BRANCH->EXACT => x1
+                   BRANCH->EXACT => x2
                    tail
 
                    which would be constructed from a pattern like
@@ -1813,7 +1814,7 @@ Perl_study_chunk(pTHX_
 
                 */
 
-                    int made=0;
+                    int made = 0;
                     if (!re_trie_maxbuff) {
                         re_trie_maxbuff = get_sv(RE_TRIE_MAXBUF_NAME, 1);
                         if (!SvIOK(re_trie_maxbuff))
@@ -1825,7 +1826,7 @@ Perl_study_chunk(pTHX_
                         regnode *prev = (regnode *)NULL;
                         regnode *tail = scan;
                         U8 trietype = 0;
-                        U32 count=0;
+                        U32 count = 0;
 
                         /* var tail is used because there may be a TAIL
                            regop in the way. Ie, the exacts will point to the
@@ -1952,7 +1953,7 @@ Perl_study_chunk(pTHX_
                                   Perl_re_printf( aTHX_ "\t=> %d:%s\t",
                                     REG_NODE_NUM(noper_next), SvPV_nolen_const(RExC_mysv));
                                 }
-                                Perl_re_printf( aTHX_  "(First==%d,Last==%d,Cur==%d,tt==%s,ntt==%s,nntt==%s)\n",
+                                Perl_re_printf( aTHX_  "(First == %d,Last == %d,Cur == %d,tt == %s,ntt == %s,nntt == %s)\n",
                                    REG_NODE_NUM(first), REG_NODE_NUM(prev), REG_NODE_NUM(cur),
                                    REGNODE_NAME(trietype), REGNODE_NAME(noper_trietype), REGNODE_NAME(noper_next_trietype)
                                 );
@@ -2050,7 +2051,7 @@ Perl_study_chunk(pTHX_
                             regprop(RExC_rx, RExC_mysv, cur, NULL, pRExC_state);
                             Perl_re_indentf( aTHX_  "- %s (%d) <SCAN FINISHED> ",
                               depth+1, SvPV_nolen_const( RExC_mysv ), REG_NODE_NUM(cur));
-                            Perl_re_printf( aTHX_  "(First==%d, Last==%d, Cur==%d, tt==%s)\n",
+                            Perl_re_printf( aTHX_  "(First == %d, Last == %d, Cur == %d, tt == %s)\n",
                                REG_NODE_NUM(first), REG_NODE_NUM(prev), REG_NODE_NUM(cur),
                                REGNODE_NAME(trietype)
                             );
@@ -2061,14 +2062,14 @@ Perl_study_chunk(pTHX_
                                 /* the last branch of the sequence was part of
                                  * a trie, so we have to construct it here
                                  * outside of the loop */
-                                made= make_trie( pRExC_state, startbranch,
+                                made = make_trie( pRExC_state, startbranch,
                                                  first, scan, tail, count,
                                                  trietype, depth+1 );
 #ifdef TRIE_STUDY_OPT
                                 if ( ((made == MADE_EXACT_TRIE &&
                                      startbranch == first)
                                      || ( first_non_open == first )) &&
-                                     depth==0 ) {
+                                     depth == 0 ) {
                                     flags |= SCF_TRIE_RESTUDY;
                                     if ( startbranch == first
                                          && scan >= tail )
@@ -2097,7 +2098,7 @@ Perl_study_chunk(pTHX_
                                     });
                                     OP(startbranch)= NOTHING;
                                     NEXT_OFF(startbranch)= tail - startbranch;
-                                    for ( opt= startbranch + 1; opt < tail ; opt++ )
+                                    for ( opt = startbranch + 1; opt < tail ; opt++ )
                                         OP(opt)= OPTIMIZED;
                                 }
                             }
@@ -2113,7 +2114,7 @@ Perl_study_chunk(pTHX_
             I32 paren = 0;
             regnode *start = NULL;
             regnode *end = NULL;
-            U32 my_recursed_depth= recursed_depth;
+            U32 my_recursed_depth = recursed_depth;
 
             if (OP(scan) != SUSPEND) { /* GOSUB */
                 /* Do setup, note this code has side effects beyond
@@ -2153,7 +2154,7 @@ Perl_study_chunk(pTHX_
                      * enclosing scope - see GH 18096, for example.
                      */
                     is_inf = is_inf_internal = 1;
-                    scan= regnext(scan);
+                    scan = regnext(scan);
                     continue;
                 }
 
@@ -2181,7 +2182,7 @@ Perl_study_chunk(pTHX_
                     /* we havent recursed into this paren yet, so recurse into it */
                     DEBUG_STUDYDATA("gosub-set", data, depth, is_inf, min, stopmin, delta);
                     PAREN_SET(recursed_depth, paren);
-                    my_recursed_depth= recursed_depth + 1;
+                    my_recursed_depth = recursed_depth + 1;
                 } else {
                     DEBUG_STUDYDATA("gosub-inf", data, depth, is_inf, min, stopmin, delta);
                     /* some form of infinite recursion, assume infinite length
@@ -2195,7 +2196,7 @@ Perl_study_chunk(pTHX_
                         ssc_anything(data->start_class);
                     flags &= ~SCF_DO_STCLASS;
 
-                    start= NULL; /* reset start so we dont recurse later on. */
+                    start = NULL; /* reset start so we dont recurse later on. */
                 }
             } else {
                 paren = stopparen;
@@ -2208,7 +2209,7 @@ Perl_study_chunk(pTHX_
                 if (!RExC_frame_last) {
                     Newxz(newframe, 1, scan_frame);
                     SAVEDESTRUCTOR_X(S_unwind_scan_frames, newframe);
-                    RExC_frame_head= newframe;
+                    RExC_frame_head = newframe;
                     RExC_frame_count++;
                 } else if (!RExC_frame_last->next_frame) {
                     Newxz(newframe, 1, scan_frame);
@@ -2216,9 +2217,9 @@ Perl_study_chunk(pTHX_
                     newframe->prev_frame= RExC_frame_last;
                     RExC_frame_count++;
                 } else {
-                    newframe= RExC_frame_last->next_frame;
+                    newframe = RExC_frame_last->next_frame;
                 }
-                RExC_frame_last= newframe;
+                RExC_frame_last = newframe;
 
                 newframe->next_regnode = regnext(scan);
                 newframe->last_regnode = last;
@@ -2237,7 +2238,7 @@ Perl_study_chunk(pTHX_
                 stopparen = paren;
                 last = end;
                 depth = depth + 1;
-                recursed_depth= my_recursed_depth;
+                recursed_depth = my_recursed_depth;
 
                 continue;
             }
@@ -2463,7 +2464,7 @@ Perl_study_chunk(pTHX_
                 scan = regnext(scan);
                 goto optimize_curly_tail;
             case CURLY:
-                if (stopparen>0 && (OP(scan)==CURLYN || OP(scan)==CURLYM)
+                if (stopparen > 0 && (OP(scan) == CURLYN || OP(scan) == CURLYM)
                     && (FLAGS(scan) == stopparen))
                 {
                     mincount = 1;
@@ -2810,14 +2811,14 @@ Perl_study_chunk(pTHX_
                     /* It is counted once already... */
                     data->pos_min += minnext * (mincount - counted);
 #if 0
-    Perl_re_printf( aTHX_  "counted=%" UVuf " deltanext=%" UVuf
-                              " OPTIMIZE_INFTY=%" UVuf " minnext=%" UVuf
-                              " maxcount=%" UVuf " mincount=%" UVuf
-                              " data->pos_delta=%" UVuf "\n",
+    Perl_re_printf( aTHX_  "counted = %" UVuf " deltanext = %" UVuf
+                              " OPTIMIZE_INFTY = %" UVuf " minnext = %" UVuf
+                              " maxcount = %" UVuf " mincount = %" UVuf
+                              " data->pos_delta = %" UVuf "\n",
         (UV)counted, (UV)deltanext, (UV)OPTIMIZE_INFTY, (UV)minnext,
         (UV)maxcount, (UV)mincount, (UV)data->pos_delta);
     if (deltanext != OPTIMIZE_INFTY)
-        Perl_re_printf( aTHX_  "LHS=%" UVuf " RHS=%" UVuf "\n",
+        Perl_re_printf( aTHX_  "LHS = %" UVuf " RHS = %" UVuf "\n",
             (UV)(-counted * deltanext + (minnext + deltanext) * maxcount
             - minnext * mincount), (UV)(OPTIMIZE_INFTY - data->pos_delta));
 #endif
@@ -3164,7 +3165,7 @@ Perl_study_chunk(pTHX_
                  * we are dealing with variable length lookbehind that
                  * contains capturing buffers, which are considered
                  * experimental */
-                cur_last_close_op= *(data_fake.last_close_opp);
+                cur_last_close_op = *(data_fake.last_close_opp);
 
                 data_fake.pos_delta = delta;
                 if ( flags & SCF_DO_STCLASS && !FLAGS(scan)
@@ -3274,7 +3275,7 @@ Perl_study_chunk(pTHX_
                         f |= SCF_DO_SUBSTR;
                         if (FLAGS(scan))
                             scan_commit(pRExC_state, &data_fake, minlenp, is_inf);
-                        data_fake.last_found=newSVsv(data->last_found);
+                        data_fake.last_found = newSVsv(data->last_found);
                     }
                 }
                 else {
@@ -3447,13 +3448,13 @@ Perl_study_chunk(pTHX_
                 ssc_init_zero(pRExC_state, &accum);
 
             if (!trie->jump) {
-                min1= trie->minlen;
-                max1= trie->maxlen;
+                min1 = trie->minlen;
+                max1 = trie->maxlen;
             } else {
                 const regnode *nextbranch= NULL;
                 U32 word;
 
-                for ( word=1 ; word <= trie->wordcount ; word++)
+                for ( word = 1 ; word <= trie->wordcount ; word++)
                 {
                     SSize_t deltanext = 0, minnext = 0;
                     U32 f = (flags & SCF_TRIE_DOING_RESTUDY);
@@ -3483,7 +3484,7 @@ Perl_study_chunk(pTHX_
                     if (trie->jump[word]) {
                         if (!nextbranch)
                             nextbranch = trie_node + trie->jump[0];
-                        scan= trie_node + trie->jump[word];
+                        scan = trie_node + trie->jump[word];
                         /* We go from the jump point to the branch that follows
                            it. Note this means we need the vestigal unused
                            branches even though they arent otherwise used. */
@@ -3494,7 +3495,7 @@ Perl_study_chunk(pTHX_
                             mutate_ok);
                     }
                     if (nextbranch && REGNODE_TYPE(OP(nextbranch))==BRANCH)
-                        nextbranch= regnext((regnode*)nextbranch);
+                        nextbranch = regnext((regnode*)nextbranch);
 
                     if (min1 > (SSize_t)(minnext + trie->minlen))
                         min1 = minnext + trie->minlen;
@@ -3558,14 +3559,14 @@ Perl_study_chunk(pTHX_
                     flags |= SCF_DO_STCLASS_OR;
                 }
             }
-            scan= tail;
+            scan = tail;
             DEBUG_STUDYDATA("after TRIE study", data, depth, is_inf, min, stopmin, delta);
             continue;
         }
 #else
         else if (REGNODE_TYPE(OP(scan)) == TRIE) {
             reg_trie_data *trie = (reg_trie_data*)RExC_rxi->data->data[ ARG1u(scan) ];
-            U8*bang=NULL;
+            U8 *bang = NULL;
 
             min += trie->minlen;
             delta += (trie->maxlen - trie->minlen);
@@ -3703,7 +3704,7 @@ Perl_study_chunk(pTHX_
         data->pos_delta = OPTIMIZE_INFTY - data->pos_min;
     if (is_par > (I32)U8_MAX)
         is_par = 0;
-    if (is_par && pars==1 && data) {
+    if (is_par && pars == 1 && data) {
         data->flags |= SF_IN_PAR;
         data->flags &= ~SF_HAS_PAR;
     }

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -52,8 +52,8 @@ S_dump_trie(pTHX_ const struct _reg_trie_data *trie, HV *widecharmap,
             AV *revcharmap, U32 depth)
 {
     U32 state;
-    SV *sv=sv_newmortal();
-    int colwidth= widecharmap ? 6 : 4;
+    SV *sv = sv_newmortal();
+    int colwidth = widecharmap ? 6 : 4;
     U16 word;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
@@ -128,7 +128,7 @@ S_dump_trie(pTHX_ const struct _reg_trie_data *trie, HV *widecharmap,
     }
     Perl_re_indentf( aTHX_  "word_info N:(prev,len)=",
                                 depth);
-    for (word=1; word <= trie->wordcount; word++) {
+    for (word = 1; word <= trie->wordcount; word++) {
         Perl_re_printf( aTHX_  " %d:(%d,%d)",
             (int)word, (int)(trie->wordinfo[word].prev),
             (int)(trie->wordinfo[word].len));
@@ -147,8 +147,8 @@ S_dump_trie_interim_list(pTHX_ const struct _reg_trie_data *trie,
                          U32 depth)
 {
     U32 state;
-    SV *sv=sv_newmortal();
-    int colwidth= widecharmap ? 6 : 4;
+    SV *sv = sv_newmortal();
+    int colwidth = widecharmap ? 6 : 4;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
     PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_LIST;
@@ -159,7 +159,7 @@ S_dump_trie_interim_list(pTHX_ const struct _reg_trie_data *trie,
     Perl_re_indentf( aTHX_  "%s",
             depth+1, "------:-----+-----------------\n" );
 
-    for( state=1 ; state < next_alloc ; state ++ ) {
+    for( state = 1; state < next_alloc; state++ ) {
         U16 charid;
 
         Perl_re_indentf( aTHX_  " %4" UVXf " :",
@@ -208,8 +208,8 @@ S_dump_trie_interim_table(pTHX_ const struct _reg_trie_data *trie,
 {
     U32 state;
     U16 charid;
-    SV *sv=sv_newmortal();
-    int colwidth= widecharmap ? 6 : 4;
+    SV *sv = sv_newmortal();
+    int colwidth = widecharmap ? 6 : 4;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
     PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_TABLE;
@@ -238,20 +238,20 @@ S_dump_trie_interim_table(pTHX_ const struct _reg_trie_data *trie,
     Perl_re_printf( aTHX_ "\n");
     Perl_re_indentf( aTHX_  "State+-", depth+1 );
 
-    for( charid=0 ; charid < trie->uniquecharcount ; charid++ ) {
+    for( charid = 0; charid < trie->uniquecharcount; charid++ ) {
         Perl_re_printf( aTHX_  "%.*s", colwidth,"--------");
     }
 
     Perl_re_printf( aTHX_  "\n" );
 
-    for( state=1 ; state < next_alloc ; state += trie->uniquecharcount ) {
+    for( state = 1; state < next_alloc; state += trie->uniquecharcount ) {
 
         Perl_re_indentf( aTHX_  "%4" UVXf " : ",
             depth+1,
             (UV)TRIE_NODENUM( state ) );
 
         for( charid = 0 ; charid < trie->uniquecharcount ; charid++ ) {
-            UV v=(UV)SAFE_TRIE_NODENUM( trie->trans[ state + charid ].next );
+            UV v = (UV)SAFE_TRIE_NODENUM( trie->trans[ state + charid ].next );
             if (v)
                 Perl_re_printf( aTHX_  "%*" UVXf, colwidth, v );
             else
@@ -304,7 +304,7 @@ will be in parenthesis.
       |
       +-s->(3)-+-h->(4)-+-e->[5]
 
-      Accept Word Mapping: 3=>1 (he),5=>2 (she), 7=>3 (his), 9=>4 (hers)
+      Accept Word Mapping: 3 => 1 (he), 5 => 2 (she), 7 => 3 (his), 9 => 4 (hers)
 
 This shows that when matching against the string 'hers' we will begin at state 1
 read 'h' and move to state 2, read 'e' and move to state 3 which is accepting,
@@ -347,7 +347,7 @@ The regexp /(ac|ad|ab)+/ will produce the following debug output:
   17:   NOTHING(18)
   18: END(0)
 
-This would be optimizable with startbranch=5, first=5, last=16, tail=16
+This would be optimizable with startbranch = 5, first = 5, last = 16, tail = 16
 and should turn into:
 
    1: CURLYM[1] {1,32767}(18)
@@ -370,7 +370,7 @@ Cases where tail != last would be like /(?foo|bar)baz/:
    8: EXACT <baz>(10)
   10: END(0)
 
-which would be optimizable with startbranch=1, first=1, last=7, tail=8
+which would be optimizable with startbranch = 1, first = 1, last = 7, tail = 8
 and would end up looking like:
 
     1: TRIE(8)
@@ -450,7 +450,7 @@ is the recommended Unicode-aware way of saying
 } STMT_END
 
 #define TRIE_HANDLE_WORD(state) STMT_START {                    \
-    U16 dupe= trie->states[ state ].wordnum;                    \
+    U16 dupe = trie->states[ state ].wordnum;                    \
     regnode * const noper_next = regnext( noper );              \
                                                                 \
     DEBUG_r({                                                   \
@@ -492,7 +492,7 @@ is the recommended Unicode-aware way of saying
         if (!jumper)                                            \
             jumper = noper_next;                                \
         if (!nextbranch)                                        \
-            nextbranch= regnext(cur);                           \
+            nextbranch = regnext(cur);                           \
     }                                                           \
                                                                 \
     if ( dupe ) {                                               \
@@ -514,7 +514,7 @@ is the recommended Unicode-aware way of saying
          && state == trie->trans[ base - ucharcount + charid ].check    \
          && trie->trans[ base - ucharcount + charid ].next )            \
            ? trie->trans[ base - ucharcount + charid ].next             \
-           : ( state==1 ? special : 0 )                                 \
+           : ( state == 1 ? special : 0 )                                 \
       )
 
 /* Helper function for make_trie(): set a trie bit for both the character
@@ -578,7 +578,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
      */
 #else
     const U32 data_slot = reg_add_data( pRExC_state, STR_WITH_LEN("tu"));
-    STRLEN trie_charcount=0;
+    STRLEN trie_charcount = 0;
 #endif
     SV *re_trie_maxbuff;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
@@ -621,7 +621,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
     }
     DEBUG_TRIE_COMPILE_r({
         Perl_re_indentf( aTHX_
-          "make_trie start==%d, first==%d, last==%d, tail==%d depth=%d\n",
+          "make_trie start == %d, first == %d, last == %d, tail == %d depth = %d\n",
           depth+1,
           REG_NODE_NUM(startbranch), REG_NODE_NUM(first),
           REG_NODE_NUM(last), REG_NODE_NUM(tail), (int)depth);
@@ -690,7 +690,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 
             regnode *noper_next= regnext(noper);
             if (noper_next < tail)
-                noper= noper_next;
+                noper = noper_next;
         }
 
         if (    noper < tail
@@ -699,15 +699,15 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                 || (flags == EXACTFU && (   OP(noper) == EXACTFU_REQ8
                                          || OP(noper) == EXACTFUP))))
         {
-            uc= (U8*)STRING(noper);
-            e= uc + STR_LEN(noper);
+            uc = (U8*)STRING(noper);
+            e = uc + STR_LEN(noper);
         } else {
             trie->minlen= 0;
             continue;
         }
 
 
-        if ( set_bit ) { /* bitmap only alloced when !(UTF&&Folding) */
+        if ( set_bit ) { /* bitmap only alloced when !(UTF && Folding) */
             TRIE_BITMAP_SET(trie,*uc); /* store the raw first byte
                                           regardless of encoding */
             if (OP( noper ) == EXACTFUP) {
@@ -784,7 +784,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
              * branch */
             if ( uvc < 256 ) {
                 if ( folder ) {
-                    U8 folded= folder[ (U8) uvc ];
+                    U8 folded = folder[ (U8) uvc ];
                     if ( !trie->charmap[ folded ] ) {
                         trie->charmap[ folded ]=( ++trie->uniquecharcount );
                         TRIE_STORE_REVCHAR( folded );
@@ -913,7 +913,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
             if (OP(noper) == NOTHING) {
                 regnode *noper_next= regnext(noper);
                 if (noper_next < tail)
-                    noper= noper_next;
+                    noper = noper_next;
                 /* we will undo this assignment if noper does not
                  * point at a trieable type in the else clause of
                  * the following statement. */
@@ -942,7 +942,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                         if ( !svpp ) {
                             charid = 0;
                         } else {
-                            charid=(U16)SvIV( *svpp );
+                            charid = (U16)SvIV( *svpp );
                         }
                     }
                     /* charid is now 0 if we dont know the char read, or
@@ -983,7 +983,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                  * on a trieable type. So we need to reset noper back to point at the first regop
                  * in the branch before we call TRIE_HANDLE_WORD()
                 */
-                noper= REGNODE_AFTER(cur);
+                noper = REGNODE_AFTER(cur);
             }
             TRIE_HANDLE_WORD(state);
 
@@ -1010,8 +1010,8 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
             U32 zp = 0;
 
 
-            for( state=1 ; state < next_alloc ; state ++ ) {
-                U32 base=0;
+            for( state = 1; state < next_alloc; state ++ ) {
+                U32 base = 0;
 
                 /*
                 DEBUG_TRIE_COMPILE_MORE_r(
@@ -1020,16 +1020,16 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                 */
 
                 if (trie->states[state].trans.list) {
-                    U16 minid=TRIE_LIST_ITEM( state, 1).forid;
-                    U16 maxid=minid;
+                    U16 minid = TRIE_LIST_ITEM( state, 1).forid;
+                    U16 maxid = minid;
                     U16 idx;
 
                     for( idx = 2 ; idx <= TRIE_LIST_USED( state ) ; idx++ ) {
                         const U16 forid = TRIE_LIST_ITEM( state, idx).forid;
                         if ( forid < minid ) {
-                            minid=forid;
+                            minid = forid;
                         } else if ( forid > maxid ) {
-                            maxid=forid;
+                            maxid = forid;
                         }
                     }
                     if ( transcount < tp + maxid - minid + 1) {
@@ -1063,7 +1063,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                             zp = tp;
                         }
                     } else {
-                        for ( idx=1; idx <= TRIE_LIST_USED( state ) ; idx++ ) {
+                        for ( idx = 1; idx <= TRIE_LIST_USED( state ) ; idx++ ) {
                             const U32 tid = base
                                            - trie->uniquecharcount
                                            + TRIE_LIST_ITEM( state, idx ).forid;
@@ -1080,7 +1080,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                     Perl_re_printf( aTHX_  " base: %d\n",base);
                 );
                 */
-                trie->states[ state ].trans.base=base;
+                trie->states[ state ].trans.base = base;
             }
             trie->lasttrans = tp + 1;
         }
@@ -1147,7 +1147,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
             if (OP(noper) == NOTHING) {
                 regnode *noper_next= regnext(noper);
                 if (noper_next < tail)
-                    noper= noper_next;
+                    noper = noper_next;
                 /* we will undo this assignment if noper does not
                  * point at a trieable type in the else clause of
                  * the following statement. */
@@ -1196,7 +1196,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                  * on a trieable type. So we need to reset noper back to point at the first regop
                  * in the branch before we call TRIE_HANDLE_WORD().
                 */
-                noper= REGNODE_AFTER(cur);
+                noper = REGNODE_AFTER(cur);
             }
             accept_state = TRIE_NODENUM( state );
             TRIE_HANDLE_WORD(accept_state);
@@ -1272,7 +1272,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         */
         const U32 laststate = TRIE_NODENUM( next_alloc );
         U32 state, charid;
-        U32 pos = 0, zp=0;
+        U32 pos = 0, zp = 0;
         trie->statecount = laststate;
 
         for ( state = 1 ; state < laststate ; state++ ) {
@@ -1349,7 +1349,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 
     {   /* Modify the program and insert the new TRIE node */
         U8 nodetype =(U8) flags;
-        char *str=NULL;
+        char *str = NULL;
 
 #ifdef DEBUGGING
         regnode *optimize = NULL;
@@ -1413,7 +1413,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                                 /* clear the bitmap */
                                 Zero(trie->bitmap, ANYOF_BITMAP_SIZE, char);
                                 DEBUG_OPTIMISE_r(
-                                    Perl_re_indentf( aTHX_  "New Start State=%" UVuf " Class: [",
+                                    Perl_re_indentf( aTHX_  "New Start State = %" UVuf " Class: [",
                                         depth+1,
                                         (UV)state));
                                 if (first_ofs >= 0) {
@@ -1441,8 +1441,8 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                     STRLEN len;
                     char *ch = SvPV( *tmp, len );
                     DEBUG_OPTIMISE_r({
-                        SV *sv=sv_newmortal();
-                        Perl_re_indentf( aTHX_  "Prefix State: %" UVuf " Ofs:%" UVuf " Char='%s'\n",
+                        SV *sv = sv_newmortal();
+                        Perl_re_indentf( aTHX_  "Prefix State: %" UVuf " Ofs: %" UVuf " Char: '%s'\n",
                             depth+1,
                             (UV)state, (UV)first_ofs,
                             pv_pretty(sv, SvPV_nolen_const(*tmp), SvCUR(*tmp), 6,
@@ -1452,9 +1452,9 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                             )
                         );
                     });
-                    if ( state==1 ) {
+                    if ( state == 1 ) {
                         OP( convert ) = nodetype;
-                        str=STRING(convert);
+                        str = STRING(convert);
                         setSTR_LEN(convert, 0);
                     }
                     assert( ( STR_LEN(convert) + len ) < 256 );
@@ -1463,7 +1463,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                         *str++ = *ch++;
                 } else {
 #ifdef DEBUGGING
-                    if (state>1)
+                    if (state > 1)
                         DEBUG_OPTIMISE_r(Perl_re_printf( aTHX_ "]\n"));
 #endif
                     break;
@@ -1572,7 +1572,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         U32 state;
         U16 prev;
 
-        for (word=1; word <= trie->wordcount; word++) {
+        for (word = 1; word <= trie->wordcount; word++) {
             prev = 0;
             if (trie->wordinfo[word].prev)
                 continue;
@@ -1603,7 +1603,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 #endif
     return trie->jump
            ? MADE_JUMP_TRIE
-           : trie->startstate>1
+           : trie->startstate > 1
              ? MADE_EXACT_TRIE
              : MADE_TRIE;
 }
@@ -1635,7 +1635,7 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
  */
  /* add a fail transition */
     const U32 trie_offset = ARG1u(source);
-    reg_trie_data *trie=(reg_trie_data *)RExC_rxi->data->data[trie_offset];
+    reg_trie_data *trie = (reg_trie_data *)RExC_rxi->data->data[trie_offset];
     U32 *q;
     const U32 ucharcount = trie->uniquecharcount;
     const U32 numstates = trie->statecount;
@@ -1672,8 +1672,8 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
     ARG1u_SET( stclass, data_slot );
     aho = (reg_ac_data *) PerlMemShared_calloc( 1, sizeof(reg_ac_data) );
     RExC_rxi->data->data[ data_slot ] = (void*)aho;
-    aho->trie=trie_offset;
-    aho->states=(reg_trie_state *)PerlMemShared_malloc( numstates * sizeof(reg_trie_state) );
+    aho->trie = trie_offset;
+    aho->states = (reg_trie_state *)PerlMemShared_malloc( numstates * sizeof(reg_trie_state) );
     Copy( trie->states, aho->states, numstates, reg_trie_state );
     Newx( q, numstates, U32);
     aho->fail = (U32 *) PerlMemShared_calloc( numstates, sizeof(U32) );
@@ -1726,7 +1726,7 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
         Perl_re_indentf( aTHX_  "Stclass Failtable (%" UVuf " states): 0",
                       depth, (UV)numstates
         );
-        for( q_read=1; q_read<numstates; q_read++ ) {
+        for( q_read = 1; q_read < numstates; q_read++ ) {
             Perl_re_printf( aTHX_  ", %" UVuf, (UV)fail[q_read]);
         }
         Perl_re_printf( aTHX_  "\n");

--- a/regexec.c
+++ b/regexec.c
@@ -3318,7 +3318,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                 U32 pointpos = 0;
 
                 while ( state && uc <= (U8*)strend ) {
-                    int failed=0;
+                    bool failed = false;
                     U32 word = aho->states[ state ].wordnum;
 
                     if( state==1 ) {
@@ -3409,14 +3409,14 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                             {
                                 DEBUG_TRIE_EXECUTE_r(
                                     Perl_re_printf( aTHX_ " - legal\n"));
-                                failed = 0;
+                                failed = false;
                                 state = tmp;
                                 break;
                             }
                             else {
                                 DEBUG_TRIE_EXECUTE_r(
                                     Perl_re_printf( aTHX_ " - fail\n"));
-                                failed = 1;
+                                failed = true;
                                 state = aho->fail[state];
                             }
                         }
@@ -3424,7 +3424,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                             /* we must be accepting here */
                             DEBUG_TRIE_EXECUTE_r(
                                     Perl_re_printf( aTHX_ " - accepting\n"));
-                            failed = 1;
+                            failed = true;
                             break;
                         }
                     } while(state);

--- a/regexec.c
+++ b/regexec.c
@@ -255,7 +255,7 @@ S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEP
     DEBUG_BUFFERS_r(
         if ((int)maxopenparen > (int)parenfloor)
             Perl_re_exec_indentf( aTHX_
-                "rex=0x%" UVxf " offs=0x%" UVxf ": saving capture indices:\n",
+                "rex = 0x%" UVxf " offs = 0x%" UVxf ": saving capture indices:\n",
                 depth,
                 PTR2UV(rex),
                 PTR2UV(RXp_OFFSp(rex))
@@ -303,7 +303,7 @@ S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEP
 #define REGCP_SET(cp)                                           \
     DEBUG_STATE_r(                                              \
         Perl_re_exec_indentf( aTHX_                             \
-            "Setting an EVAL scope, savestack=%" IVdf ",\n",    \
+            "Setting an EVAL scope, savestack = %" IVdf ",\n",    \
             depth, (IV)PL_savestack_ix                          \
         )                                                       \
     );                                                          \
@@ -313,7 +313,7 @@ S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEP
     DEBUG_STATE_r(                                              \
         if (cp != PL_savestack_ix)                              \
             Perl_re_exec_indentf( aTHX_                         \
-                "Clearing an EVAL scope, savestack=%"           \
+                "Clearing an EVAL scope, savestack = %"           \
                 IVdf "..%" IVdf "\n",                           \
                 depth, (IV)(cp), (IV)PL_savestack_ix            \
             )                                                   \
@@ -331,7 +331,7 @@ S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEP
         RXp_LASTPAREN(rex) = (ix);                                          \
     RXp_LASTCLOSEPAREN(rex) = (ix);                                         \
     DEBUG_BUFFERS_r(Perl_re_exec_indentf( aTHX_                             \
-        "CLOSE: rex=0x%" UVxf " offs=0x%" UVxf ": \\%" UVuf ": set %" IVdf " .. %" IVdf " max: %" UVuf "\n", \
+        "CLOSE: rex = 0x%" UVxf " offs = 0x%" UVxf ": \\%" UVuf ": set %" IVdf " .. %" IVdf " max: %" UVuf "\n", \
         depth,                                                              \
         PTR2UV(rex),                                                        \
         PTR2UV(RXp_OFFSp(rex)),                                             \
@@ -352,7 +352,7 @@ S_unwind_paren(pTHX_ regexp *rex, U32 lp, U32 lcp comma_pDEPTH) {
     U32 n;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
     DEBUG_BUFFERS_r(Perl_re_exec_indentf( aTHX_
-        "UNWIND_PAREN: rex=0x%" UVxf " offs=0x%" UVxf
+        "UNWIND_PAREN: rex = 0x%" UVxf " offs = 0x%" UVxf
         ": invalidate (%" UVuf " .. %" UVuf ") set lcp: %" UVuf "\n",
         depth,
         PTR2UV(rex),
@@ -425,7 +425,7 @@ S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH)
     DEBUG_BUFFERS_r(
         if (i || RXp_LASTPAREN(rex) + 1 <= rex->nparens)
             Perl_re_exec_indentf( aTHX_
-                "rex=0x%" UVxf " offs=0x%" UVxf ": restoring capture indices to:\n",
+                "rex = 0x%" UVxf " offs = 0x%" UVxf ": restoring capture indices to:\n",
                 depth,
                 PTR2UV(rex),
                 PTR2UV(RXp_OFFSp(rex))
@@ -1026,15 +1026,15 @@ Perl_re_intuit_start(pTHX_
     /* dump the various substring data */
     DEBUG_OPTIMISE_MORE_r({
         int i;
-        for (i=0; i<=2; i++) {
+        for (i = 0; i <= 2; i++) {
             SV *sv = (utf8_target ? prog->substrs->data[i].utf8_substr
                                   : prog->substrs->data[i].substr);
             if (!sv)
                 continue;
 
             Perl_re_printf( aTHX_
-                "  substrs[%d]: min=%" IVdf " max=%" IVdf " end shift=%" IVdf
-                " useful=%" IVdf " utf8=%d [%s]\n",
+                "  substrs[%d]: min = %" IVdf " max = %" IVdf " end shift = %" IVdf
+                " useful = %" IVdf " utf8 = %d [%s]\n",
                 i,
                 (IV)prog->substrs->data[i].min_offset,
                 (IV)prog->substrs->data[i].max_offset,
@@ -1083,8 +1083,8 @@ Perl_re_intuit_start(pTHX_
              * This works for \G too, because the caller will already have
              * subtracted gofs from pos, and gofs is the offset from the
              * \G to the start of the regex. For example, in /.abc\Gdef/,
-             * where substr="abcdef", pos()=3, gofs=4, offset_min=1:
-             * caller will have set strpos=pos()-4; we look for the substr
+             * where substr = "abcdef", pos() = 3, gofs = 4, offset_min = 1:
+             * caller will have set strpos = pos()-4; we look for the substr
              * at position pos()-4+1, which lines up with the "a" */
 
             if (prog->check_offset_min == prog->check_offset_max) {
@@ -1169,7 +1169,7 @@ Perl_re_intuit_start(pTHX_
 
         DEBUG_OPTIMISE_MORE_r({
             Perl_re_printf( aTHX_
-                "  At restart: rx_origin=%" IVdf " Check offset min: %" IVdf
+                "  At restart: rx_origin = %" IVdf " Check offset min: %" IVdf
                 " Start shift: %" IVdf " End shift %" IVdf
                 " Real end Shift: %" IVdf "\n",
                 (IV)(rx_origin - strbeg),
@@ -1350,7 +1350,7 @@ Perl_re_intuit_start(pTHX_
              */
             assert(rx_origin <= last1);
             last =
-                /* this condition handles the offset==infinity case, and
+                /* this condition handles the offset == infinity case, and
                  * is a short-cut otherwise. Although it's comparing a
                  * byte offset to a char length, it does so in a safe way,
                  * since 1 char always occupies 1 or more bytes,
@@ -1599,7 +1599,7 @@ Perl_re_intuit_start(pTHX_
          *   before strend; accidentally, minlen >= 1 guaranties no false
          *   positives at rx_origin + 1 even for \b or \B.  But (minlen? 1 :
          *   0) below assumes that regstclass does not come from lookahead...
-         *   If regstclass takes bytelength more than 1: If charlength==1, OK.
+         *   If regstclass takes bytelength more than 1: If charlength == 1, OK.
          *   This leaves EXACTF-ish only, which are dealt with in
          *   find_byclass().
          */
@@ -1611,7 +1611,7 @@ Perl_re_intuit_start(pTHX_
             endpos = HOP3clim(rx_max_float, cl_l, strend);
         }
         else
-            endpos= strend;
+            endpos = strend;
 
         DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
             "  looking for class: start_shift: %" IVdf " check_at: %" IVdf
@@ -1815,11 +1815,11 @@ STMT_START {                                                                    
         /* FALLTHROUGH */                                                           \
     case trie_utf8_fold:                                                            \
       do_trie_utf8_fold:                                                            \
-        if ( foldlen>0 ) {                                                          \
+        if ( foldlen > 0 ) {                                                          \
             uvc = utf8n_to_uvchr( (const U8*) uscan, foldlen, &len, uniflags );     \
             foldlen -= len;                                                         \
             uscan += len;                                                           \
-            len=0;                                                                  \
+            len = 0;                                                                  \
         } else {                                                                    \
             uvc = _toFOLD_utf8_flags( (const U8*) uc, uc_end, foldbuf, &foldlen,    \
                                                                             flags); \
@@ -1837,11 +1837,11 @@ STMT_START {                                                                    
         /* FALLTHROUGH */                                                           \
     case trie_latin_utf8_fold:                                                      \
       do_trie_latin_utf8_fold:                                                      \
-        if ( foldlen>0 ) {                                                          \
+        if ( foldlen > 0 ) {                                                          \
             uvc = utf8n_to_uvchr( (const U8*) uscan, foldlen, &len, uniflags );     \
             foldlen -= len;                                                         \
             uscan += len;                                                           \
-            len=0;                                                                  \
+            len = 0;                                                                  \
         } else {                                                                    \
             len = 1;                                                                \
             uvc = _to_fold_latin1( (U8) *uc, foldbuf, &foldlen, flags);             \
@@ -3262,7 +3262,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                             is always 1:1, but for Unicode, especially
                             case folded Unicode this is not true. */
             U8 foldbuf[ UTF8_MAXBYTES_CASE + 1 ];
-            U8 *bitmap=NULL;
+            U8 *bitmap = NULL;
 
 
             DECLARE_AND_GET_RE_DEBUG_FLAGS;
@@ -3272,19 +3272,19 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
              * running the match */
             ENTER;
             SAVETMPS;
-            sv_points=newSV(maxlen * sizeof(U8 *));
+            sv_points = newSV(maxlen * sizeof(U8 *));
             SvCUR_set(sv_points,
                 maxlen * sizeof(U8 *));
             SvPOK_on(sv_points);
             sv_2mortal(sv_points);
-            points=(U8**)SvPV_nolen(sv_points );
+            points = (U8**)SvPV_nolen(sv_points );
             if ( trie_type != trie_utf8_fold
                  && (trie->bitmap || OP(c)==AHOCORASICKC) )
             {
                 if (trie->bitmap)
-                    bitmap=(U8*)trie->bitmap;
+                    bitmap = (U8*)trie->bitmap;
                 else
-                    bitmap=(U8*)ANYOF_BITMAP(c);
+                    bitmap = (U8*)ANYOF_BITMAP(c);
             }
             /* this is the Aho-Corasick algorithm modified a touch
                to include special handling for long "unknown char" sequences.
@@ -3313,7 +3313,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                 U8 *uscan = (U8*)NULL;
                 U8 *leftmost = NULL;
 #ifdef DEBUGGING
-                U32 accepted_word= 0;
+                U32 accepted_word = 0;
 #endif
                 U32 pointpos = 0;
 
@@ -3321,7 +3321,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                     bool failed = false;
                     U32 word = aho->states[ state ].wordnum;
 
-                    if( state==1 ) {
+                    if( state == 1 ) {
                         if ( bitmap ) {
                             DEBUG_TRIE_EXECUTE_r(
                                 if (  uc <= (U8*)last_start
@@ -3347,7 +3347,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                                     uc++;
                                 }
                             }
-                            s= (char *)uc;
+                            s = (char *)uc;
                         }
                         if (uc >(U8*)last_start) break;
                     }
@@ -3356,10 +3356,10 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                         U8 *lpos= points[ (pointpos - trie->wordinfo[word].len)
                                                                     % maxlen ];
                         if (!leftmost || lpos < leftmost) {
-                            DEBUG_r(accepted_word=word);
-                            leftmost= lpos;
+                            DEBUG_r(accepted_word = word);
+                            leftmost = lpos;
                         }
-                        if (base==0) break;
+                        if (base == 0) break;
 
                     }
                     points[pointpos++ % maxlen]= uc;
@@ -3410,7 +3410,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                                     - 1 - trie->uniquecharcount)) >= 0)
                                  && ((U32)offset < trie->lasttrans)
                                  && trie->trans[offset].check == state
-                                 && (tmp=trie->trans[offset].next))
+                                 && (tmp = trie->trans[offset].next))
                             {
                                 failed = false;
                                 state = tmp;
@@ -3447,7 +3447,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                                       - trie->wordinfo[aho->states[ state ]
                                                     .wordnum].len) % maxlen ];
                     if (!leftmost || lpos < leftmost) {
-                        DEBUG_r(accepted_word=aho->states[ state ].wordnum);
+                        DEBUG_r(accepted_word = aho->states[ state ].wordnum);
                         leftmost = lpos;
                     }
                 }
@@ -3825,7 +3825,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
 
     multiline = prog->extflags & RXf_PMf_MULTILINE;
 
-    if (strend - s < (minlen+(prog->check_offset_min<0?prog->check_offset_min:0))) {
+    if (strend - s < (minlen + ((prog->check_offset_min < 0) ? prog->check_offset_min : 0))) {
         DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
                               "String too short [regexec_flags]...\n"));
         goto phooey;
@@ -3883,7 +3883,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
         old_regmatch_state = PL_regmatch_state;
         old_regmatch_slab  = PL_regmatch_slab;
 
-        for (i=0; i <= max; i++) {
+        for (i = 0; i <= max; i++) {
             if (i == 1)
                 reginfo->info_aux = &(PL_regmatch_state->u.info_aux);
             else if (i ==2)
@@ -3923,7 +3923,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
         SAVEFREEPV(swap);
         Newxz(RXp_OFFSp(prog), (prog->nparens + 1), regexp_paren_pair);
         DEBUG_BUFFERS_r(Perl_re_exec_indentf( aTHX_
-            "rex=0x%" UVxf " saving  offs: orig=0x%" UVxf " new=0x%" UVxf "\n",
+            "rex = 0x%" UVxf " saving  offs: orig = 0x%" UVxf " new = 0x%" UVxf "\n",
             0,
             PTR2UV(prog),
             PTR2UV(swap),
@@ -4087,7 +4087,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
             back_min = prog->float_min_offset;
         }
 
-        if (back_min<0) {
+        if (back_min < 0) {
             last = strend;
         } else {
             last = HOP3c(strend,	/* Cannot start after this */
@@ -4100,7 +4100,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
             last1 = s - 1;	/* bogus */
 
         /* XXXX check_substr already used to find "s", can optimize if
-           check_substr==must. */
+           check_substr == must. */
         dontbother = 0;
         while ( (s <= last) &&
                 (s = fbm_instr((unsigned char*)HOP4c(s, back_min, strbeg,  strend),
@@ -4234,7 +4234,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
                         /* non multiline match, so compare with the "\n" at the
                          * end of the string */
                         if (memEQ(checkpos, little, len)) {
-                            last= checkpos;
+                            last = checkpos;
                         } else {
                             DEBUG_EXECUTE_r(
                                 Perl_re_printf( aTHX_
@@ -4334,7 +4334,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
          * data to the new offs buffer
          */
         DEBUG_BUFFERS_r(Perl_re_exec_indentf( aTHX_
-            "rex=0x%" UVxf " rolling back offs: 0x%" UVxf " will be freed; restoring data to =0x%" UVxf "\n",
+            "rex = 0x%" UVxf " rolling back offs: 0x%" UVxf " will be freed; restoring data to =0x%" UVxf "\n",
             0,
             PTR2UV(prog),
             PTR2UV(RXp_OFFSp(prog)),
@@ -4388,7 +4388,7 @@ S_regtry(pTHX_ regmatch_info *reginfo, char **startposp)
 
     PERL_ARGS_ASSERT_REGTRY;
 
-    reginfo->cutpoint=NULL;
+    reginfo->cutpoint = NULL;
 
     RXp_OFFSp(prog)[0].start = *startposp - reginfo->strbeg;
     RXp_LASTPAREN(prog) = 0;
@@ -4500,7 +4500,7 @@ S_debug_start_match(pTHX_ const REGEXP *prog, const bool utf8_target,
             "%s%s REx%s %s against %s\n",
                        PL_colors[4], blurb, PL_colors[5], s0, s1);
 
-        if (utf8_target||utf8_pat)
+        if (utf8_target || utf8_pat)
             Perl_re_printf( aTHX_  "UTF-8 %s%s%s...\n",
                 utf8_pat ? "pattern" : "",
                 utf8_pat && utf8_target ? " and " : "",
@@ -4565,7 +4565,7 @@ S_dump_exec_pos(pTHX_ const char *locinput,
         RE_PV_COLOR_DECL(s2,len2,is_uni,PERL_DEBUG_PAD(2),
                     locinput, loc_regeol - locinput, 10, 0, 1);
 
-        const STRLEN tlen=len0+len1+len2;
+        const STRLEN tlen = len0 + len1 + len2;
         Perl_re_printf( aTHX_
                     "%4" IVdf " <%.*s%.*s%s%.*s>%*s|%4" UVuf "| ",
                     (IV)(locinput - loc_bostr),
@@ -4596,11 +4596,11 @@ S_reg_check_named_buff_matched(const regexp *rex, const regnode *scan)
     I32 n;
     RXi_GET_DECL(rex,rexi);
     SV *sv_dat= MUTABLE_SV(rexi->data->data[ ARG1u( scan ) ]);
-    I32 *nums=(I32*)SvPVX(sv_dat);
+    I32 *nums = (I32*)SvPVX(sv_dat);
 
     PERL_ARGS_ASSERT_REG_CHECK_NAMED_BUFF_MATCHED;
 
-    for ( n=0; n<SvIVX(sv_dat); n++ ) {
+    for ( n = 0; n < SvIVX(sv_dat); n++ ) {
         if ((I32)RXp_LASTPAREN(rex) >= nums[n] &&
             RXp_OFFS_END(rex,nums[n]) != -1)
         {
@@ -6285,18 +6285,18 @@ S_backup_one_WB(pTHX_ WB_enum * previous, const U8 * const strbeg, U8 ** curpos,
     st->resume_state = state; \
     goto push_yes_state;
 
-#define DEBUG_STATE_pp(pp)                                  \
-    DEBUG_STATE_r({                                         \
-        DUMP_EXEC_POS(locinput, scan, utf8_target,depth);   \
-        Perl_re_printf( aTHX_                               \
-            "%*s" pp " %s%s%s%s%s\n",                       \
-            INDENT_CHARS(depth), "",                        \
-            REGNODE_NAME(st->resume_state),                  \
-            ((st==yes_state||st==mark_state) ? "[" : ""),   \
-            ((st==yes_state) ? "Y" : ""),                   \
-            ((st==mark_state) ? "M" : ""),                  \
-            ((st==yes_state||st==mark_state) ? "]" : "")    \
-        );                                                  \
+#define DEBUG_STATE_pp(pp)                                      \
+    DEBUG_STATE_r({                                             \
+        DUMP_EXEC_POS(locinput, scan, utf8_target,depth);       \
+        Perl_re_printf( aTHX_                                   \
+            "%*s" pp " %s%s%s%s%s\n",                           \
+            INDENT_CHARS(depth), "",                            \
+            REGNODE_NAME(st->resume_state),                     \
+            ((st == yes_state || st == mark_state) ? "[" : ""), \
+            ((st == yes_state) ? "Y" : ""),                     \
+            ((st == mark_state) ? "M" : ""),                    \
+            ((st == yes_state || st == mark_state) ? "]" : "")  \
+        );                                                      \
     });
 
 /*
@@ -6722,8 +6722,8 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                     = (reg_trie_data*)rexi->data->data[ ARG1u( scan ) ];
                 ST.before_paren = trie->before_paren;
                 ST.after_paren = trie->after_paren;
-                assert(ST.before_paren<=rex->nparens);
-                assert(ST.after_paren<=rex->nparens);
+                assert(ST.before_paren <= rex->nparens);
+                assert(ST.after_paren <= rex->nparens);
 
                 HV * widecharmap = MUTABLE_HV(rexi->data->data[ ARG1u( scan ) + 1 ]);
                 U32 state = trie->startstate;
@@ -6818,7 +6818,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                                              len, uvc, charid, foldlen,
                                              foldbuf, uniflags);
                         charcount++;
-                        if (foldlen>0)
+                        if (foldlen > 0)
                             ST.longfold = TRUE;
                         if (charid &&
                              ( ((offset =
@@ -6895,7 +6895,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 REGCP_UNWIND(ST.cp);
                 UNWIND_PAREN(ST.lastparen, ST.lastcloseparen);
                 if (ST.after_paren) {
-                    assert(ST.before_paren<=rex->nparens && ST.after_paren<=rex->nparens);
+                    assert(ST.before_paren <= rex->nparens && ST.after_paren <= rex->nparens);
                     CAPTURE_CLEAR(ST.before_paren+1, ST.after_paren, "TRIE_next_fail");
                 }
             }
@@ -6916,7 +6916,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 U16 const nextword = ST.nextword;
                 reg_trie_wordinfo * const wordinfo
                     = ((reg_trie_data*)rexi->data->data[ARG1u(ST.me)])->wordinfo;
-                for (word=ST.topword; word; word=wordinfo[word].prev) {
+                for (word = ST.topword; word; word = wordinfo[word].prev) {
                     if (word > nextword && (!min || word < min))
                         min = word;
                 }
@@ -8180,7 +8180,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                     DECLARE_AND_GET_RE_DEBUG_FLAGS;
                     DEBUG_STACK_r({
                         Perl_re_exec_indentf( aTHX_
-                            "entering GOSUB, prev_recurse_locinput=%p recurse_locinput[%d]=%p\n",
+                            "entering GOSUB, prev_recurse_locinput = %p recurse_locinput[%d]=%p\n",
                             depth, ST.prev_recurse_locinput, arg, rex->recurse_locinput[arg]
                         );
                     });
@@ -8196,7 +8196,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
             /* NOTREACHED */
 
         case EVAL:  /*   /(?{...})B/   /(??{A})B/  and  /(?(?{...})X|Y)B/   */
-            if (logical == 2 && cur_eval && cur_eval->locinput==locinput) {
+            if (logical == 2 && cur_eval && cur_eval->locinput == locinput) {
                 if ( ++nochange_depth > max_nochange_depth )
                     Perl_croak(aTHX_ "EVAL without pos change exceeded limit in regex");
             } else {
@@ -8341,7 +8341,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 nop = nop->op_next;
 
                 DEBUG_STATE_r( Perl_re_printf( aTHX_
-                    "  re EVAL PL_op=0x%" UVxf "\n", PTR2UV(nop)) );
+                    "  re EVAL PL_op = 0x%" UVxf "\n", PTR2UV(nop)) );
 
                 RXp_OFFSp(rex)[0].end = locinput - reginfo->strbeg;
                 if (reginfo->info_aux_eval->pos_magic)
@@ -8534,14 +8534,14 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
         case EVAL_postponed_AB: /* cleanup after a successful (??{A})B */
             /* note: this is called twice; first after popping B, then A */
             DEBUG_STACK_r({
-                Perl_re_exec_indentf( aTHX_  "EVAL_AB cur_eval=%p prev_eval=%p\n",
+                Perl_re_exec_indentf( aTHX_  "EVAL_AB cur_eval = %p prev_eval = %p\n",
                     depth, cur_eval, ST.prev_eval);
             });
 
 #define SET_RECURSE_LOCINPUT(STR,VAL)\
             if ( cur_eval && CUR_EVAL.close_paren ) {\
                 DEBUG_STACK_r({ \
-                    Perl_re_exec_indentf( aTHX_  STR " GOSUB%d ce=%p recurse_locinput=%p\n",\
+                    Perl_re_exec_indentf( aTHX_  STR " GOSUB%d ce = %p recurse_locinput = %p\n",\
                         depth,    \
                         CUR_EVAL.close_paren - 1,\
                         cur_eval, \
@@ -8589,7 +8589,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
         case EVAL_postponed_AB_fail: /* unsuccessfully ran A or B in (??{A})B */
             /* note: this is called twice; first after popping B, then A */
             DEBUG_STACK_r({
-                Perl_re_exec_indentf( aTHX_  "EVAL_AB_fail cur_eval=%p prev_eval=%p\n",
+                Perl_re_exec_indentf( aTHX_  "EVAL_AB_fail cur_eval = %p prev_eval = %p\n",
                     depth, cur_eval, ST.prev_eval);
             });
 
@@ -8621,7 +8621,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
             if (n > maxopenparen)
                 maxopenparen = n;
             DEBUG_BUFFERS_r(Perl_re_exec_indentf( aTHX_
-                "OPEN: rex=0x%" UVxf " offs=0x%" UVxf ": \\%" UVuf ": set %" IVdf " tmp; maxopenparen=%" UVuf "\n",
+                "OPEN: rex = 0x%" UVxf " offs = 0x%" UVxf ": \\%" UVuf ": set %" IVdf " tmp; maxopenparen = %" UVuf "\n",
                 depth,
                 PTR2UV(rex),
                 PTR2UV(RXp_OFFSp(rex)),
@@ -8753,20 +8753,20 @@ For example, if matching against the string a1a2a3b (where the aN are
 substrings that match /A/), then the match progresses as follows: (the
 pushed states are interspersed with the bits of strings matched so far):
 
-    <CURLYX cnt=-1>
-    <CURLYX cnt=0><WHILEM>
-    <CURLYX cnt=1><WHILEM> a1 <WHILEM>
-    <CURLYX cnt=2><WHILEM> a1 <WHILEM> a2 <WHILEM>
-    <CURLYX cnt=3><WHILEM> a1 <WHILEM> a2 <WHILEM> a3 <WHILEM>
-    <CURLYX cnt=3><WHILEM> a1 <WHILEM> a2 <WHILEM> a3 <WHILEM> b
+    <CURLYX cnt = -1>
+    <CURLYX cnt = 0><WHILEM>
+    <CURLYX cnt = 1><WHILEM> a1 <WHILEM>
+    <CURLYX cnt = 2><WHILEM> a1 <WHILEM> a2 <WHILEM>
+    <CURLYX cnt = 3><WHILEM> a1 <WHILEM> a2 <WHILEM> a3 <WHILEM>
+    <CURLYX cnt = 3><WHILEM> a1 <WHILEM> a2 <WHILEM> a3 <WHILEM> b
 
 (Contrast this with something like CURLYM, which maintains only a single
 backtrack state:
 
-    <CURLYM cnt=0> a1
-    a1 <CURLYM cnt=1> a2
-    a1 a2 <CURLYM cnt=2> a3
-    a1 a2 a3 <CURLYM cnt=3> b
+    <CURLYM cnt = 0> a1
+    a1 <CURLYM cnt = 1> a2
+    a1 a2 <CURLYM cnt = 2> a3
+    a1 a2 a3 <CURLYM cnt = 3> b
 )
 
 Each WHILEM state block marks a point to backtrack to upon partial failure
@@ -8796,17 +8796,17 @@ cur_
 curlyx backtrack stack
 ------ ---------------
 NULL
-CO     <CO prev=NULL> <WO>
-CI     <CO prev=NULL> <WO> <CI prev=CO> <WI> ai
-CO     <CO prev=NULL> <WO> <CI prev=CO> <WI> ai <WI prev=CI> bi
-NULL   <CO prev=NULL> <WO> <CI prev=CO> <WI> ai <WI prev=CI> bi <WO prev=CO> bo
+CO     <CO prev = NULL> <WO>
+CI     <CO prev = NULL> <WO> <CI prev = CO> <WI> ai
+CO     <CO prev = NULL> <WO> <CI prev = CO> <WI> ai <WI prev = CI> bi
+NULL   <CO prev = NULL> <WO> <CI prev = CO> <WI> ai <WI prev = CI> bi <WO prev = CO> bo
 
 At this point the pattern succeeds, and we work back down the stack to
 clean up, restoring as we go:
 
-CO     <CO prev=NULL> <WO> <CI prev=CO> <WI> ai <WI prev=CI> bi
-CI     <CO prev=NULL> <WO> <CI prev=CO> <WI> ai
-CO     <CO prev=NULL> <WO>
+CO     <CO prev = NULL> <WO> <CI prev = CO> <WI> ai <WI prev = CI> bi
+CI     <CO prev = NULL> <WO> <CI prev = CO> <WI> ai
+CO     <CO prev = NULL> <WO>
 NULL
 
 *******************************************************************/
@@ -9224,7 +9224,7 @@ NULL
                     ST.count = ST.minmod ? ARG1i(ST.me) : ARG2i(ST.me);
             }
             DEBUG_EXECUTE_r(
-                Perl_re_exec_indentf( aTHX_  "CURLYM now matched %" IVdf " times, len=%" IVdf "...\n",
+                Perl_re_exec_indentf( aTHX_  "CURLYM now matched %" IVdf " times, len = %" IVdf "...\n",
                           depth, (IV) ST.count, (IV)ST.alen)
             );
 
@@ -9277,7 +9277,7 @@ NULL
             }
 
             DEBUG_EXECUTE_r(
-                Perl_re_exec_indentf( aTHX_  "CURLYM trying tail with matches=%" IVdf "...\n",
+                Perl_re_exec_indentf( aTHX_  "CURLYM trying tail with matches = %" IVdf "...\n",
                     depth, (IV)ST.count)
             );
             if (! NEXTCHR_IS_EOS && ST.Binfo.count >= 0) {
@@ -9289,8 +9289,8 @@ NULL
                 {
                     DEBUG_OPTIMISE_r(
                         Perl_re_exec_indentf( aTHX_
-                            "CURLYM Fast bail next target=0x%X anded==0x%X"
-                                                                " mask=0x%X\n",
+                            "CURLYM Fast bail next target = 0x%X anded == 0x%X"
+                                                                " mask = 0x%X\n",
                             depth,
                             (int) nextbyte, ST.Binfo.first_byte_anded,
                                             ST.Binfo.first_byte_mask)
@@ -9677,7 +9677,7 @@ NULL
           fake_end:
             if (cur_eval) {
                 /* we've just finished A in /(??{A})B/; now continue with B */
-                is_accepted= false;
+                is_accepted = false;
                 SET_RECURSE_LOCINPUT("FAKE-END[before]", CUR_EVAL.prev_recurse_locinput);
                 st->u.eval.prev_rex = rex_sv;		/* inner */
 
@@ -9701,7 +9701,7 @@ NULL
                 st->u.eval.prev_eval = cur_eval;
                 cur_eval = CUR_EVAL.prev_eval;
                 DEBUG_EXECUTE_r(
-                    Perl_re_exec_indentf( aTHX_  "END: EVAL trying tail ... (cur_eval=%p)\n",
+                    Perl_re_exec_indentf( aTHX_  "END: EVAL trying tail ... (cur_eval = %p)\n",
                                       depth, cur_eval););
                 if ( nochange_depth )
                     nochange_depth--;
@@ -9715,7 +9715,7 @@ NULL
 
             if (locinput < reginfo->till) {
                 DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
-                                      "%sEND: Match possible, but length=%ld is smaller than requested=%ld, failing!%s\n",
+                                      "%sEND: Match possible, but length = %ld is smaller than requested = %ld, failing!%s\n",
                                       PL_colors[4],
                                       (long)(locinput - startpos),
                                       (long)(reginfo->till - startpos),
@@ -9892,7 +9892,7 @@ NULL
                 /* deal with (?(?!)X|Y) properly,
                  * make sure we trigger the no branch
                  * of the trailing IFTHEN structure*/
-                sw= 0;
+                sw = 0;
                 break;
             } else {
                 sayNO;
@@ -9976,7 +9976,7 @@ NULL
                    is one so they can test to see how things lead to this
                    cut */
                 if (mark_state)
-                    sv_commit=mark_state->u.mark.mark_name;
+                    sv_commit = mark_state->u.mark.mark_name;
             }
             no_final = 1;
             sayNO;
@@ -9984,7 +9984,7 @@ NULL
 #undef ST
 
         case LNBREAK: /* \R */
-            if ((n=is_LNBREAK_safe(locinput, loceol, utf8_target))) {
+            if ((n = is_LNBREAK_safe(locinput, loceol, utf8_target))) {
                 locinput += n;
             } else
                 sayNO;
@@ -10116,8 +10116,8 @@ NULL
         PL_regmatch_state = st;
 
         if (no_final) {
-            locinput= st->locinput;
-            loceol= st->loceol;
+            locinput = st->locinput;
+            loceol = st->loceol;
             script_run_begin = st->sr0;
         }
         state_num = st->resume_state + no_final;
@@ -10168,8 +10168,8 @@ NULL
             st = SLAB_LAST(PL_regmatch_slab);
         }
         PL_regmatch_state = st;
-        locinput= st->locinput;
-        loceol= st->loceol;
+        locinput = st->locinput;
+        loceol = st->loceol;
         script_run_begin = st->sr0;
 
         DEBUG_STATE_pp("pop");
@@ -10847,7 +10847,7 @@ S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
 
       case LNBREAK_t8:
         while (    hardcount < max && scan < this_eol
-               && (c=is_LNBREAK_utf8_safe(scan, this_eol)))
+               && (c = is_LNBREAK_utf8_safe(scan, this_eol)))
         {
             scan += c;
             hardcount++;
@@ -11996,10 +11996,10 @@ Perl_reg_named_buff_fetch(pTHX_ REGEXP * const r, SV * const namesv,
         HE *he_str = hv_fetch_ent( RXp_PAREN_NAMES(rx), namesv, 0, 0 );
         if (he_str) {
             IV i;
-            SV* sv_dat=HeVAL(he_str);
-            I32 *nums=(I32*)SvPVX(sv_dat);
+            SV* sv_dat = HeVAL(he_str);
+            I32 *nums = (I32*)SvPVX(sv_dat);
             AV * const retarray = (flags & RXapif_ALL) ? newAV_alloc_x(SvIVX(sv_dat)) : NULL;
-            for ( i=0; i<SvIVX(sv_dat); i++ ) {
+            for ( i = 0; i < SvIVX(sv_dat); i++ ) {
                 if ((I32)(rx->nparens) >= nums[i]
                     && RXp_OFFS_VALID(rx,nums[i]))
                 {

--- a/regexec.c
+++ b/regexec.c
@@ -3372,8 +3372,12 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                             dump_exec_pos( (char *)uc, c, strend,
                                         real_start, s, utf8_target, 0);
                             Perl_re_printf( aTHX_
-                                " Charid:%3u CP:%4" UVxf " ",
-                                 charid, uvc);
+                                "%sAHOC: Chid:%-3u CP:%#-6" UVxf " ",
+                                 PL_colors[4], charid, uvc);
+                            if (isPRINT_A(uvc))
+                                Perl_re_printf( aTHX_ "'%c' ", (int)uvc );
+                            else
+                                Perl_re_printf( aTHX_ "    " ); /* four spaces to match "'x' " */
                         });
                     }
                     else {
@@ -3393,8 +3397,9 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                                 dump_exec_pos((char *)uc, c, strend, real_start,
                                     s,   utf8_target, 0 );
                             Perl_re_printf( aTHX_
-                                "%sState: %4" UVxf ", word=%" UVxf,
-                                failed ? " Fail transition to " : "",
+                                "%s%sSt:%#-6" UVxf " W:%#-4" UVxf,
+                                PL_colors[4],
+                                failed ? "AHOC: Fail transition to     " : "",
                                 (UV)state, (UV)word);
                         });
                         if ( base ) {
@@ -3407,17 +3412,19 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                                  && trie->trans[offset].check == state
                                  && (tmp=trie->trans[offset].next))
                             {
-                                DEBUG_TRIE_EXECUTE_r(
-                                    Perl_re_printf( aTHX_ " - legal\n"));
                                 failed = false;
                                 state = tmp;
+                                DEBUG_TRIE_EXECUTE_r(
+                                    Perl_re_printf( aTHX_ " - accept -> St:%#-6" UVxf "%s\n",
+                                        (UV)state, PL_colors[5]));
                                 break;
                             }
                             else {
-                                DEBUG_TRIE_EXECUTE_r(
-                                    Perl_re_printf( aTHX_ " - fail\n"));
                                 failed = true;
                                 state = aho->fail[state];
+                                DEBUG_TRIE_EXECUTE_r(
+                                    Perl_re_printf( aTHX_ " - reject -> St:%#-6" UVxf "%s\n",
+                                        (UV)state,PL_colors[5]));
                             }
                         }
                         else {


### PR DESCRIPTION
This patch sequence primarily changes diagnostic output or makes style changes to remove artifacts from my older coding style. 
The only non-debugging code this changes is to use a boolean for a variable that used to use an int and values of 1/0, 

One part of the change enhances the TRIE and AHO-CORASICK diagnostics so they are consistent with each other and include a bit more information than they used to.

The other part reworks the style of assignment and (in)equality operators and a few other minor whitespace changes so that as much as possible the form used for an equivalency check is the same unhugged form everywhere.

This patch was motivated by some frustration I encountered while debugging #22892 and writing #22978
