### PR TITLE
util.c: fix goto &somesub in $SIG{__DIE__} handlers

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6309,6 +6309,7 @@ t/op/delete.t				See if delete works
 t/op/die.t				See if die works
 t/op/die_except.t			See if die/eval avoids $@ clobberage
 t/op/die_exit.t				See if die and exit status interaction works
+t/op/die_goto.t				See if a die handler is disabled during goto
 t/op/die_keeperr.t			See if G_KEEPERR works for destructors
 t/op/die_unwind.t			Check die/eval early-$@ backcompat hack
 t/op/do.t				See if subroutines work

--- a/t/op/die_goto.t
+++ b/t/op/die_goto.t
@@ -1,0 +1,39 @@
+#!./perl -w
+# This test checks for RT #123878/GH #14527, keeping the die handler still
+# disabled into goto'd function. And the other documented
+# exceptions to enable dying from a die handler.
+
+print "1..4\n";
+
+eval {
+  sub f1 { die "ok 1\n" }
+  $SIG{__DIE__} = \&f1;
+  die;
+};
+print $@;
+
+eval {
+  sub loopexit { for (0..2) { next if $_ } }
+  $SIG{__DIE__} = \&loopexit;
+  die "ok 2\n";
+};
+print $@;
+
+eval {
+  sub foo1 { die "ok 3\n" }
+  sub bar1 { foo1() }
+  $SIG{__DIE__} = \&bar1;
+  die;
+};
+print $@;
+
+eval {
+  sub foo2 { die "ok 4\n" }
+  sub bar2 { goto &foo2 }
+  $SIG{__DIE__} = \&bar2;
+  die;
+};
+print $@;
+
+# Deep recursion on subroutine "main::foo2" at t/op/die_goto.t line 32.
+# Segmentation fault (core dumped)

--- a/util.c
+++ b/util.c
@@ -1719,13 +1719,13 @@ Perl_invoke_exception_hook(pTHX_ SV *ex, bool warn)
     GV *gv;
     CV *cv;
     SV **const hook = warn ? &PL_warnhook : &PL_diehook;
-    /* sv_2cv might call Perl_croak() or Perl_warner() */
     SV * const oldhook = *hook;
 
     if (!oldhook || oldhook == PERL_WARNHOOK_FATAL)
         return FALSE;
 
     ENTER;
+    /* sv_2cv might call Perl_croak() or Perl_warner() */
     SAVESPTR(*hook);
     *hook = NULL;
     cv = sv_2cv(oldhook, &stash, &gv, 0);
@@ -1736,10 +1736,11 @@ Perl_invoke_exception_hook(pTHX_ SV *ex, bool warn)
 
         ENTER;
         save_re_context();
-        if (warn) {
-            SAVESPTR(*hook);
-            *hook = NULL;
-        }
+
+        /* call_sv(cv) might call Perl_croak() or Perl_warner() */
+        SAVESPTR(*hook);
+        *hook = NULL;
+
         exarg = newSVsv(ex);
         SvREADONLY_on(exarg);
         SAVEFREESV(exarg);


### PR DESCRIPTION
Custom die() handlers via `$SIG{__DIE__}` are supposed to be disabled during their own execution, so throwing an exception from a `$SIG{__DIE__}` handler does not recurse indefinitely.

This was implemented as a simple `!CvDEPTH(cv)` check, which basically just verifies that the handler sub is not currently part of the call stack. However, if the handler sub does not return normally, but uses `goto &othersub` to transfer control to a different subroutine, this check fails: `CvDEPTH(cv)` will be 0 (since the registered handler is not running anymore), but the `$SIG{__DIE__}->()` call has not returned yet.

(Partial) fix: Locally (or rather temporarily) unset PL_diehook for the duration of the handler call.

The reason this is not a full fix is that clearing PL_diehook is not reflected in `$SIG{__DIE__}`, so any modification of `$SIG{__DIE__}` including seeming no-ops such as `{ local $SIG{__DIE__}; }` will reinstate PL_diehook.

Fixes #14527 (partially).

-------------------
* This set of changes does not require a perldelta entry.
