### PR TITLE
memcollxfrm: Handle above-Unicode code points

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -9962,7 +9962,7 @@ Perl_mem_collxfrm_(pTHX_ const char *input_string,
             }
 
             len = d - sans_highs;
-            *d++ = '\0';
+            *d = '\0';
 
             s = sans_highs;
         }

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -471,6 +471,13 @@ object's stash weren't always NULL or not-NULL, confusing sv_dump()
 (and hence Devel::Peek's Dump()) into crashing on an object with no
 defined fields in some cases.  [github #22959]
 
+=item *
+
+When comparing strings when using a UTF-8 locale, the behavior was
+previously undefined if either or both contained an above-Unicode code
+point, such as 0x110000.  Now all such code points will collate the same
+as the highest Unicode code point, U+10FFFF.
+
 =back
 
 =head1 Known Problems

--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -594,7 +594,7 @@ SKIP:
                                                             @non_utf8_locales;
     my $locale = $non_utf8_locales[0];
 
-    fresh_perl_is(<<"EOF", "ok\n", {}, "Handles above Latin1 and NUL in non-UTF8 locale");
+    fresh_perl_is(<<"EOF", "ok\n", {}, "cmp() handles above Latin1 and NUL in non-UTF8 locale");
 use locale;
 use POSIX qw(setlocale LC_COLLATE);
 if (setlocale(LC_COLLATE, '$locale')) {

--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -584,12 +584,12 @@ else {
 EOF
 }
 
+@locales = find_locales( [ qw(LC_CTYPE LC_COLLATE) ] );
+my ($utf8_ref, $non_utf8_ref) = classify_locales_wrt_utf8ness(\@locales);
+my @non_utf8_locales = grep { $_ !~ / \b C \b | POSIX /x } $non_utf8_ref->@*;
+
 SKIP:
 {
-    my @locales = find_locales( [ qw(LC_CTYPE LC_COLLATE) ] );
-    my (undef, $non_utf8_ref) = classify_locales_wrt_utf8ness(\@locales);
-    my @non_utf8_locales = grep { $_ !~ / \b C \b | POSIX /x }
-                                                            $non_utf8_ref->@*;
     skip "didn't find a suitable non-UTF-8 locale", 1 unless
                                                             @non_utf8_locales;
     my $locale = $non_utf8_locales[0];

--- a/utf8.h
+++ b/utf8.h
@@ -1065,13 +1065,18 @@ this macro matches
 #define UTF_START_BYTE_110000_  UTF_START_BYTE(PERL_UNICODE_MAX + 1, 21)
 #define UTF_FIRST_CONT_BYTE_110000_                                         \
                           UTF_FIRST_CONT_BYTE(PERL_UNICODE_MAX + 1, 21)
+
+/* Internal macro when we don't care about it being well-formed, and know we
+ * have two bytes available to read */
+#define UTF8_IS_SUPER_NO_CHECK_(s)                                          \
+     (       NATIVE_UTF8_TO_I8(s[0]) >= UTF_START_BYTE_110000_              \
+      && (   NATIVE_UTF8_TO_I8(s[0]) >  UTF_START_BYTE_110000_              \
+          || NATIVE_UTF8_TO_I8(s[1]) >= UTF_FIRST_CONT_BYTE_110000_))
+
 #define UTF8_IS_SUPER(s, e)                                                 \
-    (   ((e) - (s)) >= UNISKIP_BY_MSB_(20)                                  \
-     && (       NATIVE_UTF8_TO_I8(s[0]) >= UTF_START_BYTE_110000_           \
-         && (   NATIVE_UTF8_TO_I8(s[0]) >  UTF_START_BYTE_110000_           \
-             || NATIVE_UTF8_TO_I8(s[1]) >= UTF_FIRST_CONT_BYTE_110000_)))   \
+    ((((e) - (s)) >= UNISKIP_BY_MSB_(20) && UTF8_IS_SUPER_NO_CHECK_(s))     \
      ? isUTF8_CHAR(s, e)                                                    \
-     : 0
+     : 0)
 
 /*
 =for apidoc Am|bool|UNICODE_IS_NONCHAR|const UV uv


### PR DESCRIPTION
 As stated in the comments added by this commit, it is undefined behavior to call strxfrm() on above-Unicode code points, and especially calling it with Perl's invented extended UTF-8.  This commit changes all such input into a legal value, replacing all above-Unicode with the highest permanently unassigned code point, U+10FFFF.


* This set of changes may require a perldelta entry, and please state your opinion

