### PR TITLE
Add missing tie line to ODBM_File example

### DIFF
--- a/ext/ODBM_File/ODBM_File.pm
+++ b/ext/ODBM_File/ODBM_File.pm
@@ -7,7 +7,7 @@ require Tie::Hash;
 require XSLoader;
 
 our @ISA = qw(Tie::Hash);
-our $VERSION = "1.19";
+our $VERSION = "1.20";
 
 XSLoader::load();
 
@@ -24,12 +24,15 @@ ODBM_File - Tied access to odbm files
  use Fcntl;   # For O_RDWR, O_CREAT, etc.
  use ODBM_File;
 
-  # Now read and change the hash
-  $h{newkey} = newvalue;
-  print $h{oldkey}; 
-  ...
+ tie(%h, 'ODBM_File', 'filename.dbmx', O_RDWR|O_CREAT, 0640)
+   or die "Couldn't tie ODBM file 'filename.dbmx': $!; aborting";
 
-  untie %h;
+ # Now read and change the hash
+ $h{newkey} = newvalue;
+ print $h{oldkey};
+ ...
+
+ untie %h;
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
Fix the example in the ODBM_File docs to include the tie command.

The critical line that shows the tie command was removed in 2000 when the docs were brought in line with the other *DBM_File docs. Oops.