### PR TITLE
regen/HeaderParser.pm - deal with odd C preprocessor construct gracefully

### DIFF
--- a/regen/HeaderParser.pm
+++ b/regen/HeaderParser.pm
@@ -659,6 +659,13 @@ sub parse_fh {
                 $type= "content";
                 $sub_type= "#error";
             }
+            elsif ($flat =~ /#\s*\z/) {
+                # deal with the null directive
+                # see: https://en.cppreference.com/w/c/preprocessor
+                # and: https://stackoverflow.com/questions/35207515
+                $type= "content";
+                $sub_type= "text";
+            }
             else {
                 confess "Do not know what to do with $line";
             }

--- a/t/porting/header_parser.t
+++ b/t/porting/header_parser.t
@@ -40,6 +40,7 @@ $hp->parse_text(<<~'EOF');
       line */
     #define C /* this is
                  a hidden line continuation */ D
+    # /* null directive */
     EOF
 my $normal= $hp->lines_as_str();
 my $lines= $hp->lines();
@@ -211,6 +212,18 @@ is($lines_as_str,<<~'DUMP_EOF', "Simple data structure as expected") or show_tex
             "start_line_num" => 11,
             "sub_type" => "#define",
             "type" => "content"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [],
+            "flat" => "#",
+            "level" => 0,
+            "line" => "# /* null directive */\n",
+            "n_lines" => 1,
+            "raw" => "# /* null directive */\n",
+            "source" => "(buffer)",
+            "start_line_num" => 13,
+            "sub_type" => "text",
+            "type" => "content"
           }, 'HeaderLine' )
         ];
         DUMP_EOF
@@ -228,6 +241,7 @@ is($normal,<<~'EOF',"Normalized text as expected");
       line */
     #define C /* this is
                  a hidden line continuation */ D
+    # /* null directive */
     EOF
 
 {


### PR DESCRIPTION
Karl wanted to use HeaderParser for other things than it was intended, for instance parsing scope.h, but scope.h contains a C preprocessor like line that looks like this:

```
   # /* a comment */
```

Which as @mauke points out below is the legal "null directive"

* This set of changes does not require a perldelta entry.
