### PR TITLE
HeaderParser: properly anchor regexes for cpp directives

### DIFF
--- a/regen/HeaderParser.pm
+++ b/regen/HeaderParser.pm
@@ -1611,11 +1611,11 @@ is the same as
 This type of comment usage is often overlooked by people writing header file
 parsers for the first time.
 
-=item Indented pre processor directives.
+=item Indented preprocessor directives
 
 It is easy to forget that there may be multiple spaces between the "#"
 character and the directive. It also easy to forget that there may be spaces
-in *front* of the "#" character. Both of these cases are often overlooked.
+in I<front> of the "#" character. Both of these cases are often overlooked.
 
 =back
 
@@ -1839,7 +1839,7 @@ style and form. For example:
     # endif /* !defined(BAR) */
     #endif /* defined(FOO) */
 
-HeaderParser uses two space tab stops for indenting C pre-processor
+HeaderParser uses two space tab stops for indenting C preprocessor
 directives. It puts the spaces between the "#" and the directive. The "#" is
 considered "part" of the indent, even though the space comes after it. This
 means the first indent level "looks" like one space, and following indents

--- a/regen/HeaderParser.pm
+++ b/regen/HeaderParser.pm
@@ -601,7 +601,7 @@ sub parse_fh {
                     s/^(#(?:el)?if)(n?)def\s+(\w+)/$if ${not}defined($sym)/;
             }
             my $cond;    # used in various expressions below
-            if ($flat =~ /^#endif/) {
+            if ($flat =~ /^#endif\b/) {
                 if (!@cond) {
                     confess "Not expecting $flat";
                 }
@@ -639,27 +639,27 @@ sub parse_fh {
                 $type= "cond";
                 $sub_type= "#else";
             }
-            elsif ($flat =~ /#undef/) {
+            elsif ($flat =~ /^#undef\b/) {
                 $type= "content";
                 $sub_type= "#undef";
             }
-            elsif ($flat =~ /#pragma\b/) {
+            elsif ($flat =~ /^#pragma\b/) {
                 $type= "content";
                 $sub_type= "#pragma";
             }
-            elsif ($flat =~ /#include\b/) {
+            elsif ($flat =~ /^#include\b/) {
                 $type= "content";
                 $sub_type= "#include";
             }
-            elsif ($flat =~ /#define\b/) {
+            elsif ($flat =~ /^#define\b/) {
                 $type= "content";
                 $sub_type= "#define";
             }
-            elsif ($flat =~ /#error\b/) {
+            elsif ($flat =~ /^#error\b/) {
                 $type= "content";
                 $sub_type= "#error";
             }
-            elsif ($flat =~ /#\s*\z/) {
+            elsif ($flat =~ /^#\s*\z/) {
                 # deal with the null directive
                 # see: https://en.cppreference.com/w/c/preprocessor
                 # and: https://stackoverflow.com/questions/35207515

--- a/t/porting/header_parser.t
+++ b/t/porting/header_parser.t
@@ -41,6 +41,10 @@ $hp->parse_text(<<~'EOF');
     #define C /* this is
                  a hidden line continuation */ D
     # /* null directive */
+    #error #undef
+    #error #pragma
+    #error #include
+    #error #define
     EOF
 my $normal= $hp->lines_as_str();
 my $lines= $hp->lines();
@@ -224,6 +228,54 @@ is($lines_as_str,<<~'DUMP_EOF', "Simple data structure as expected") or show_tex
             "start_line_num" => 13,
             "sub_type" => "text",
             "type" => "content"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [],
+            "flat" => "#error #undef",
+            "level" => 0,
+            "line" => "#error #undef\n",
+            "n_lines" => 1,
+            "raw" => "#error #undef\n",
+            "source" => "(buffer)",
+            "start_line_num" => 14,
+            "sub_type" => "#error",
+            "type" => "content"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [],
+            "flat" => "#error #pragma",
+            "level" => 0,
+            "line" => "#error #pragma\n",
+            "n_lines" => 1,
+            "raw" => "#error #pragma\n",
+            "source" => "(buffer)",
+            "start_line_num" => 15,
+            "sub_type" => "#error",
+            "type" => "content"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [],
+            "flat" => "#error #include",
+            "level" => 0,
+            "line" => "#error #include\n",
+            "n_lines" => 1,
+            "raw" => "#error #include\n",
+            "source" => "(buffer)",
+            "start_line_num" => 16,
+            "sub_type" => "#error",
+            "type" => "content"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [],
+            "flat" => "#error #define",
+            "level" => 0,
+            "line" => "#error #define\n",
+            "n_lines" => 1,
+            "raw" => "#error #define\n",
+            "source" => "(buffer)",
+            "start_line_num" => 17,
+            "sub_type" => "#error",
+            "type" => "content"
           }, 'HeaderLine' )
         ];
         DUMP_EOF
@@ -242,6 +294,10 @@ is($normal,<<~'EOF',"Normalized text as expected");
     #define C /* this is
                  a hidden line continuation */ D
     # /* null directive */
+    #error #undef
+    #error #pragma
+    #error #include
+    #error #define
     EOF
 
 {


### PR DESCRIPTION
Consistently use `^` in front of and `\b` behind preprocessor directives.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
