### PR TITLE
fix header parser single quote bug

### DIFF
--- a/t/porting/header_parser.t
+++ b/t/porting/header_parser.t
@@ -41,7 +41,7 @@ EOF_BLURB
 {
     my @warn;
     local $SIG{__WARN__}= sub { push @warn, $_[0]; warn $_[0] };
-    my $hp= HeaderParser->new();
+    my $hp= HeaderParser->new(indent_defines=>1);
     $hp->parse_text(<<~'EOF');
         #ifdef A
         #ifdef B
@@ -566,7 +566,7 @@ EOF_BLURB
             ],
             "flat" => "#define MATCH 1",
             "level" => 1,
-            "line" => "            #define MATCH 1\n",
+            "line" => "# define MATCH 1\n",
             "n_lines" => 1,
             "raw" => "            #define MATCH 1\n",
             "source" => "(buffer)",
@@ -598,7 +598,7 @@ EOF_BLURB
             ],
             "flat" => "#define MATCH 0",
             "level" => 1,
-            "line" => "    #define MATCH 0\n",
+            "line" => "# define MATCH 0\n",
             "n_lines" => 1,
             "raw" => "    #define MATCH 0\n",
             "source" => "(buffer)",
@@ -663,9 +663,9 @@ EOF_BLURB
         #if CH == '\"' || CH == '\''   || CH == '\\' || CH == '\102' || CH == '\a' || \
             CH == '\b' || CH == '\f'   || CH == '\n' || CH == '\r'   || CH == '\t' || \
             CH == '\v' || CH == '\x43' || CH == '\?'
-                    #define MATCH 1
+        # define MATCH 1
         #else
-            #define MATCH 0
+        # define MATCH 0
         #endif
         EOF_NORMAL
     {

--- a/t/porting/header_parser.t
+++ b/t/porting/header_parser.t
@@ -21,45 +21,115 @@ skip_all_if_miniperl("needs Data::Dumper");
 
 require Data::Dumper;
 
-sub show_text {
-    my ($as_text)= @_;
-    print STDERR $as_text=~s/^/" " x 8/mger;
-}
+my $update_key= "PERL_DEV_UPDATE_TESTFILE";
+my $is_term = -t;
 
-my $hp= HeaderParser->new();
-$hp->parse_text(<<~'EOF');
-    #ifdef A
-    #ifdef B
-    #define AB
-    content 1
-    #endif
-    content 2
-    #define A
-    #endif
-    /*comment
-      line */
-    #define C /* this is
-                 a hidden line continuation */ D
-    #de\
-    fine E\
-    F 42 /\
-    * a different kind of
-    hidden line continuation *\
-    /
-    #\
-    if defined E\
-    F
-    #endif
-    # /* null directive */
-    #error #undef
-    #error #pragma
-    #error #include
-    #error #define
-    EOF
-my $normal= $hp->lines_as_str();
-my $lines= $hp->lines();
-my $lines_as_str= Data::Dumper->new([$lines])->Sortkeys(1)->Useqq(1)->Indent(1)->Dump();
-is($lines_as_str,<<~'DUMP_EOF', "Simple data structure as expected") or show_text($lines_as_str);
+sub show_text {
+    my ($as_text, $can_update)= @_;
+    print STDERR "\n# Full text is as follows:\n\n" if $is_term;
+    print STDERR $as_text=~s/^/" " x 8/mger;
+    print STDERR <<EOF_BLURB if $is_term and $can_update
+
+# You can set the env var $update_key to true and rerun
+# this test script ($0) to automatically fix this test.
+# Eg:
+#
+#   $update_key=1 ./perl -Ilib $0
+
+EOF_BLURB
+}
+{
+    my @warn;
+    local $SIG{__WARN__}= sub { push @warn, $_[0]; warn $_[0] };
+    my $hp= HeaderParser->new();
+    $hp->parse_text(<<~'EOF');
+        #ifdef A
+        #ifdef B
+        #define AB
+        content 1
+        #endif
+        content 2
+        #define A
+        #endif
+        /*comment
+          line */
+        #define C /* this is
+                     a hidden line continuation */ D
+        #de\
+        fine E\
+        F 42 /\
+        * a different kind of
+        hidden line continuation *\
+        /
+        #\
+        if defined E\
+        F
+        #endif
+        # /* null directive */
+        #error #undef
+        #error #pragma
+        #error #include
+        #error #define
+        #if 1
+        #if CH == 'x' || CH == '\\' || CH == '\n' || CH == 'AB'
+        #define CH_IS_IT
+        #endif
+        #endif
+        #if defined          (foo)
+        foo
+        #endif
+        #if (CH == '\a' ||          /* Bell (alert) */           \
+             CH == '\b'   || /* Backspace */ \
+                CH == '\f'   ||       /* Form feed */ \
+             CH == '\n'   || /* Newline */ \
+             CH == '\r'   || /* Carriage return */ \
+                    CH == '\t'   || /* Horizontal tab */ \
+             CH == '\v'   || /* Vertical tab */ \
+             CH == '\''         || /* Single quote */ \
+              CH == '\"'   || /* Double quote (rare in single quotes) */ \
+             CH == '\?'   || /* Question mark (avoids trigraphs) */ \
+                CH == '\\'   || /* Backslash */ \
+             CH == '\102' || /* Octal escape for 'B' (ASCII 66) */ \
+             CH == '\x43')   /* Hexadecimal escape for 'C' (ASCII 67) */
+                    #define MATCH 1
+        #else
+            #define MATCH 0
+        #endif
+        EOF
+
+    my $normal= $hp->lines_as_str();
+    my $lines= $hp->lines();
+    my $lines_dump= Data::Dumper->new([$lines])->Sortkeys(1)->Useqq(1)->Indent(1)->Dump();
+
+
+    if ($ENV{$update_key}) {
+        open my $ifh, "<", $0 or die "Failed to read '$0': $!";
+        open my $ofh, ">", "$0.tmp" or die "Failed to open for write: '$0.tmp': $!";
+        my %content = (
+            'EOF_DUMP'   => $lines_dump,
+            'EOF_NORMAL' => $normal
+        );
+        while (<$ifh>) {
+            if (/^\s*is\b.*<<~'(EOF_\w+)'/) {
+                my $here_doc_name = $1;
+                print $ofh $_;
+                my $indent= " " x 8;
+                print $ofh $content{$here_doc_name} =~ s/^/$indent/mgr;
+                while (<$ifh>) {
+                    next unless /^\s+$here_doc_name\s*$/;
+                    print $ofh $_;
+                    last;
+                }
+            } else {
+                print $ofh $_;
+            }
+        }
+        close $ofh;
+        close $ifh;
+        rename "$0.tmp", "$0" or die "Failed to rename '$0.tmp' to '$0': $!";
+    }
+
+    is($lines_dump,<<~'EOF_DUMP', "Simple data structure as expected") or show_text($lines_dump,1);
         $VAR1 = [
           bless( {
             "cond" => [
@@ -331,38 +401,279 @@ is($lines_as_str,<<~'DUMP_EOF', "Simple data structure as expected") or show_tex
             "start_line_num" => 27,
             "sub_type" => "#error",
             "type" => "content"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [
+              [
+                1
+              ]
+            ],
+            "flat" => "#if 1",
+            "level" => 0,
+            "line" => "#if 1\n",
+            "n_lines" => 1,
+            "raw" => "#if 1\n",
+            "source" => "(buffer)",
+            "start_line_num" => 28,
+            "sub_type" => "#if",
+            "type" => "cond"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [
+              [
+                1
+              ],
+              [
+                "CH == '\\\\' || CH == 'AB' || CH == '\\n' || CH == 'x'"
+              ]
+            ],
+            "flat" => "#if CH == '\\\\' || CH == 'AB' || CH == '\\n' || CH == 'x'",
+            "level" => 1,
+            "line" => "# if CH == '\\\\' || CH == 'AB' || CH == '\\n' || CH == 'x'\n",
+            "n_lines" => 1,
+            "raw" => "#if CH == 'x' || CH == '\\\\' || CH == '\\n' || CH == 'AB'\n",
+            "source" => "(buffer)",
+            "start_line_num" => 29,
+            "sub_type" => "#if",
+            "type" => "cond"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [
+              [
+                1
+              ],
+              [
+                "CH == '\\\\' || CH == 'AB' || CH == '\\n' || CH == 'x'"
+              ]
+            ],
+            "flat" => "#define CH_IS_IT",
+            "level" => 2,
+            "line" => "#   define CH_IS_IT\n",
+            "n_lines" => 1,
+            "raw" => "#define CH_IS_IT\n",
+            "source" => "(buffer)",
+            "start_line_num" => 30,
+            "sub_type" => "#define",
+            "type" => "content"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [
+              [
+                1
+              ],
+              [
+                "CH == '\\\\' || CH == 'AB' || CH == '\\n' || CH == 'x'"
+              ]
+            ],
+            "flat" => "#endif",
+            "inner_lines" => 2,
+            "level" => 1,
+            "line" => "# endif\n",
+            "n_lines" => 1,
+            "raw" => "#endif\n",
+            "source" => "(buffer)",
+            "start_line_num" => 31,
+            "sub_type" => "#endif",
+            "type" => "cond"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [
+              [
+                1
+              ]
+            ],
+            "flat" => "#endif",
+            "inner_lines" => 4,
+            "level" => 0,
+            "line" => "#endif\n",
+            "n_lines" => 1,
+            "raw" => "#endif\n",
+            "source" => "(buffer)",
+            "start_line_num" => 32,
+            "sub_type" => "#endif",
+            "type" => "cond"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [
+              [
+                "defined(foo)"
+              ]
+            ],
+            "flat" => "#if defined(foo)",
+            "level" => 0,
+            "line" => "#if defined(foo)\n",
+            "n_lines" => 1,
+            "raw" => "#if defined          (foo)\n",
+            "source" => "(buffer)",
+            "start_line_num" => 33,
+            "sub_type" => "#if",
+            "type" => "cond"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [
+              [
+                "defined(foo)"
+              ]
+            ],
+            "flat" => "foo",
+            "level" => 1,
+            "line" => "foo\n",
+            "n_lines" => 1,
+            "raw" => "foo\n",
+            "source" => "(buffer)",
+            "start_line_num" => 34,
+            "sub_type" => "text",
+            "type" => "content"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [
+              [
+                "defined(foo)"
+              ]
+            ],
+            "flat" => "#endif",
+            "inner_lines" => 2,
+            "level" => 0,
+            "line" => "#endif\n",
+            "n_lines" => 1,
+            "raw" => "#endif\n",
+            "source" => "(buffer)",
+            "start_line_num" => 35,
+            "sub_type" => "#endif",
+            "type" => "cond"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [
+              [
+                "CH == '\\\"' || CH == '\\'' || CH == '\\\\' || CH == '\\102' || CH == '\\a' || CH == '\\b' || CH == '\\f' || CH == '\\n' || CH == '\\r' || CH == '\\t' || CH == '\\v' || CH == '\\x43' || CH == '\\?'"
+              ]
+            ],
+            "flat" => "#if CH == '\\\"' || CH == '\\'' || CH == '\\\\' || CH == '\\102' || CH == '\\a' || CH == '\\b' || CH == '\\f' || CH == '\\n' || CH == '\\r' || CH == '\\t' || CH == '\\v' || CH == '\\x43' || CH == '\\?'",
+            "level" => 0,
+            "line" => "#if CH == '\\\"' || CH == '\\''   || CH == '\\\\' || CH == '\\102' || CH == '\\a' || \\\n    CH == '\\b' || CH == '\\f'   || CH == '\\n' || CH == '\\r'   || CH == '\\t' || \\\n    CH == '\\v' || CH == '\\x43' || CH == '\\?'\n",
+            "n_lines" => 13,
+            "raw" => "#if (CH == '\\a' ||          /* Bell (alert) */           \\\n     CH == '\\b'   || /* Backspace */ \\\n        CH == '\\f'   ||       /* Form feed */ \\\n     CH == '\\n'   || /* Newline */ \\\n     CH == '\\r'   || /* Carriage return */ \\\n            CH == '\\t'   || /* Horizontal tab */ \\\n     CH == '\\v'   || /* Vertical tab */ \\\n     CH == '\\''         || /* Single quote */ \\\n      CH == '\\\"'   || /* Double quote (rare in single quotes) */ \\\n     CH == '\\?'   || /* Question mark (avoids trigraphs) */ \\\n        CH == '\\\\'   || /* Backslash */ \\\n     CH == '\\102' || /* Octal escape for 'B' (ASCII 66) */ \\\n     CH == '\\x43')   /* Hexadecimal escape for 'C' (ASCII 67) */\n",
+            "source" => "(buffer)",
+            "start_line_num" => 36,
+            "sub_type" => "#if",
+            "type" => "cond"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [
+              [
+                "CH == '\\\"' || CH == '\\'' || CH == '\\\\' || CH == '\\102' || CH == '\\a' || CH == '\\b' || CH == '\\f' || CH == '\\n' || CH == '\\r' || CH == '\\t' || CH == '\\v' || CH == '\\x43' || CH == '\\?'"
+              ]
+            ],
+            "flat" => "#define MATCH 1",
+            "level" => 1,
+            "line" => "            #define MATCH 1\n",
+            "n_lines" => 1,
+            "raw" => "            #define MATCH 1\n",
+            "source" => "(buffer)",
+            "start_line_num" => 49,
+            "sub_type" => "#define",
+            "type" => "content"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [
+              [
+                "!( CH == '\\\"' || CH == '\\'' || CH == '\\\\' || CH == '\\102' || CH == '\\a' || CH == '\\b' || CH == '\\f' || CH == '\\n' || CH == '\\r' || CH == '\\t' || CH == '\\v' || CH == '\\x43' || CH == '\\?' )"
+              ]
+            ],
+            "flat" => "#else",
+            "level" => 0,
+            "line" => "#else\n",
+            "n_lines" => 1,
+            "raw" => "#else\n",
+            "source" => "(buffer)",
+            "start_line_num" => 50,
+            "sub_type" => "#else",
+            "type" => "cond"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [
+              [
+                "!( CH == '\\\"' || CH == '\\'' || CH == '\\\\' || CH == '\\102' || CH == '\\a' || CH == '\\b' || CH == '\\f' || CH == '\\n' || CH == '\\r' || CH == '\\t' || CH == '\\v' || CH == '\\x43' || CH == '\\?' )"
+              ]
+            ],
+            "flat" => "#define MATCH 0",
+            "level" => 1,
+            "line" => "    #define MATCH 0\n",
+            "n_lines" => 1,
+            "raw" => "    #define MATCH 0\n",
+            "source" => "(buffer)",
+            "start_line_num" => 51,
+            "sub_type" => "#define",
+            "type" => "content"
+          }, 'HeaderLine' ),
+          bless( {
+            "cond" => [
+              [
+                "!( CH == '\\\"' || CH == '\\'' || CH == '\\\\' || CH == '\\102' || CH == '\\a' || CH == '\\b' || CH == '\\f' || CH == '\\n' || CH == '\\r' || CH == '\\t' || CH == '\\v' || CH == '\\x43' || CH == '\\?' )"
+              ]
+            ],
+            "flat" => "#endif",
+            "inner_lines" => 2,
+            "level" => 0,
+            "line" => "#endif\n",
+            "n_lines" => 1,
+            "raw" => "#endif\n",
+            "source" => "(buffer)",
+            "start_line_num" => 52,
+            "sub_type" => "#endif",
+            "type" => "cond"
           }, 'HeaderLine' )
         ];
-        DUMP_EOF
+        EOF_DUMP
 
-is($normal,<<~'EOF',"Normalized text as expected");
-    #if defined(A)
-    # if defined(B)
-    #   define AB
-    content 1
-    # endif
-    content 2
-    # define A
-    #endif
-    /*comment
-      line */
-    #define C /* this is
-                 a hidden line continuation */ D
-    #de\
-    fine E\
-    F 42 /\
-    * a different kind of
-    hidden line continuation *\
-    /
-    #if defined(EF)
-    #endif
-    # /* null directive */
-    #error #undef
-    #error #pragma
-    #error #include
-    #error #define
-    EOF
-
+    is($normal,<<~'EOF_NORMAL',"Normalized text as expected") || show_text($normal,1);
+        #if defined(A)
+        # if defined(B)
+        #   define AB
+        content 1
+        # endif
+        content 2
+        # define A
+        #endif
+        /*comment
+          line */
+        #define C /* this is
+                     a hidden line continuation */ D
+        #de\
+        fine E\
+        F 42 /\
+        * a different kind of
+        hidden line continuation *\
+        /
+        #if defined(EF)
+        #endif
+        # /* null directive */
+        #error #undef
+        #error #pragma
+        #error #include
+        #error #define
+        #if 1
+        # if CH == '\\' || CH == 'AB' || CH == '\n' || CH == 'x'
+        #   define CH_IS_IT
+        # endif
+        #endif
+        #if defined(foo)
+        foo
+        #endif
+        #if CH == '\"' || CH == '\''   || CH == '\\' || CH == '\102' || CH == '\a' || \
+            CH == '\b' || CH == '\f'   || CH == '\n' || CH == '\r'   || CH == '\t' || \
+            CH == '\v' || CH == '\x43' || CH == '\?'
+                    #define MATCH 1
+        #else
+            #define MATCH 0
+        #endif
+        EOF_NORMAL
+    {
+        local $::TODO = "We currently don't handle comments in expressions properly";
+        ok($normal=~/Vertical tab/ ? 1 : 0,"comments in logical expressions");
+    }
+    is(join("\n",@warn),"", "No warnings generated from main parse");
+}
 {
     my @warn;
     local $SIG{__WARN__}= sub { push @warn, $_[0]; warn $_[0] };
@@ -374,9 +685,10 @@ is($normal,<<~'EOF',"Normalized text as expected");
         EOF
     };
     my $err= !$ok ? $@ : "";
-    ok(!$ok,"Should throw an error");
+    ok(!$ok, my $tname= "Should throw an error, missing #endif");
     like($err,qr/Unterminated conditional block starting line 1 with last conditional operation at line 3/,
          "Got expected error message");
+    is(join("\n",@warn),"", "No warnings generated from $tname");
 }
 {
     my @warn;
@@ -389,9 +701,10 @@ is($normal,<<~'EOF',"Normalized text as expected");
         EOF
     };
     my $err= !$ok ? $@ : "";
-    ok(!$ok,"Should throw an error");
+    ok(!$ok, my $tname= "Should throw an error, unterminated #if");
     like($err,qr/Unterminated conditional block starting line 3/,
          "Unterminated block detected");
+    is(join("\n",@warn),"", "No warnings generated from $tname");
 }
 {
     my @warn;
@@ -403,15 +716,18 @@ is($normal,<<~'EOF',"Normalized text as expected");
         EOF
     };
     my $err= !$ok ? $@ : "";
-    ok(!$ok,"Should throw an error");
+    ok(!$ok, my $tname= "Should throw an error, bad directive");
     is($err,
        "Error at line 1\n" .
        "Line 1: #if 1 * * 10 > 5\n" .
        "Error in multiplication expression: " .
        "Unexpected token '*', expecting literal, unary, or expression.\n",
          "Expected token error") or warn $err;
+    is(join("\n",@warn),"", "No warnings generated from $tname");
 }
 {
+    my @warn;
+    local $SIG{__WARN__}= sub { push @warn, $_[0]; warn $_[0] };
     my $hp= HeaderParser->new(debug=>0,add_commented_expr_after=>0);
 
     $hp->parse_text(<<~'EOF');
@@ -430,7 +746,7 @@ is($normal,<<~'EOF',"Normalized text as expected");
         EOF
     my $grouped= $hp->group_content();
     my $as_text= $hp->lines_as_str($grouped);
-    is($as_text,<<~'EOF',"inverted simple clauses get merged properly") or show_text($as_text);
+    is($as_text,<<~'EOF',my $tname= "inverted simple clauses get merged properly") or show_text($as_text);
         #if defined(A)
         # if defined(B)
         #   define P
@@ -441,8 +757,11 @@ is($normal,<<~'EOF',"Normalized text as expected");
         # endif /* !defined(B) */
         #endif /* defined(A) */
         EOF
+    is(join("\n",@warn),"", "No warnings generated from $tname");
 }
 {
+    my @warn;
+    local $SIG{__WARN__}= sub { push @warn, $_[0]; warn $_[0] };
     my $hp= HeaderParser->new(debug=>0,add_commented_expr_after=>0);
     $hp->parse_text(<<~'EOF');
         #if defined(A) && defined(B)
@@ -460,7 +779,7 @@ is($normal,<<~'EOF',"Normalized text as expected");
         EOF
     my $grouped= $hp->group_content();
     my $as_text= $hp->lines_as_str($grouped);
-    is($as_text,<<~'EOF',"inverted complex clauses get merged properly") or show_text($as_text);
+    is($as_text,<<~'EOF', my $tname= "inverted complex clauses get merged properly") or show_text($as_text);
         #if defined(A) && defined(B)
         # if defined(C) && defined(D)
         #   define P
@@ -471,8 +790,11 @@ is($normal,<<~'EOF',"Normalized text as expected");
         # endif /* !( defined(C) && defined(D) ) */
         #endif /* defined(A) && defined(B) */
         EOF
+    is(join("\n",@warn),"", "No warnings generated from $tname");
 }
 {
+    my @warn;
+    local $SIG{__WARN__}= sub { push @warn, $_[0]; warn $_[0] };
     my $hp= HeaderParser->new(debug=>0,add_commented_expr_after=>0);
     $hp->parse_text(<<~'EOF');
         #if defined(A)
@@ -487,7 +809,7 @@ is($normal,<<~'EOF',"Normalized text as expected");
         EOF
     my $grouped= $hp->group_content();
     my $as_text= $hp->lines_as_str($grouped);
-    is($as_text,<<~'EOF',"test nested elif round trip") or show_text($as_text);
+    is($as_text,<<~'EOF', my $tname= "nested elif round trip") or show_text($as_text);
         #if defined(A)
         # define HAS_A
         #elif defined(B) /* && !defined(A) */
@@ -498,8 +820,11 @@ is($normal,<<~'EOF',"Normalized text as expected");
         # define HAS_D
         #endif /* !defined(A) && !defined(B) && !defined(C) */
         EOF
+    is(join("\n",@warn),"", "No warnings generated from $tname");
 }
 {
+    my @warn;
+    local $SIG{__WARN__}= sub { push @warn, $_[0]; warn $_[0] };
     my $hp= HeaderParser->new(debug=>0,add_commented_expr_after=>0);
     $hp->parse_text(<<~'EOF');
         #if defined(A)
@@ -521,7 +846,7 @@ is($normal,<<~'EOF',"Normalized text as expected");
         EOF
     my $grouped= $hp->group_content();
     my $as_text= $hp->lines_as_str($grouped);
-    is($as_text,<<~'EOF',"test elif composition from disparate statements") or show_text($as_text);
+    is($as_text,<<~'EOF',my $tname= "test elif composition from disparate statements") or show_text($as_text);
         #if defined(A)
         # define HAS_A
         #elif defined(B) /* && !defined(A) */
@@ -532,8 +857,11 @@ is($normal,<<~'EOF',"Normalized text as expected");
         # define HAS_D
         #endif /* !defined(A) && !defined(B) && !defined(C) */
         EOF
+    is(join("\n",@warn),"", "No warnings generated from $tname");
 }
 {
+    my @warn;
+    local $SIG{__WARN__}= sub { push @warn, $_[0]; warn $_[0] };
     my $hp= HeaderParser->new(debug=>0,add_commented_expr_after=>0);
     $hp->parse_text(<<~'EOF');
         #if defined(A)
@@ -558,7 +886,7 @@ is($normal,<<~'EOF',"Normalized text as expected");
         EOF
     my $grouped= $hp->group_content();
     my $as_text= $hp->lines_as_str($grouped);
-    is($as_text,<<~'EOF',"test else composition") or show_text($as_text);
+    is($as_text,<<~'EOF', my $tname= "test else composition") or show_text($as_text);
         #if defined(A)
         # define HAS_A
         # if defined(C)
@@ -576,8 +904,11 @@ is($normal,<<~'EOF',"Normalized text as expected");
         # define HAS_C
         #endif /* defined(C) */
         EOF
+    is(join("\n",@warn),"", "No warnings generated from $tname");
 }
 {
+    my @warn;
+    local $SIG{__WARN__}= sub { push @warn, $_[0]; warn $_[0] };
     my $hp= HeaderParser->new(debug=>0,add_commented_expr_after=>0);
     $hp->parse_text(<<~'EOF');
         #if !defined(A)
@@ -593,7 +924,7 @@ is($normal,<<~'EOF',"Normalized text as expected");
         EOF
     my $grouped= $hp->group_content();
     my $as_text= $hp->lines_as_str($grouped);
-    is($as_text,<<~'EOF',"normalization into if/else") or show_text($as_text);
+    is($as_text,<<~'EOF', my $tname= "normalization into if/else") or show_text($as_text);
         #if defined(A)
         # define A1
         # define A2
@@ -602,8 +933,11 @@ is($normal,<<~'EOF',"Normalized text as expected");
         # define NOT_A2
         #endif /* !defined(A) */
         EOF
+    is(join("\n",@warn),"", "No warnings generated from $tname");
 }
 {
+    my @warn;
+    local $SIG{__WARN__}= sub { push @warn, $_[0]; warn $_[0] };
     my $hp= HeaderParser->new(debug=>0,add_commented_expr_after=>0);
     $hp->parse_text(<<~'EOF');
         #if !!!(defined(A) && defined(B))
@@ -617,15 +951,18 @@ is($normal,<<~'EOF',"Normalized text as expected");
         EOF
     my $grouped= $hp->group_content();
     my $as_text= $hp->lines_as_str($grouped);
-    is($as_text,<<~'EOF',"normalization with complex else") or show_text($as_text);
+    is($as_text,<<~'EOF',my $tname = "normalization with complex else") or show_text($as_text);
         #if defined(A) && defined(B)
         # define A_AND_B
         #else /* if !( defined(A) && defined(B) ) */
         # define NOT_A_AND_B
         #endif /* !( defined(A) && defined(B) ) */
         EOF
+    is(join("\n",@warn),"", "No warnings generated from $tname");
 }
 {
+    my @warn;
+    local $SIG{__WARN__}= sub { push @warn, $_[0]; warn $_[0] };
     my $hp= HeaderParser->new(debug=>0,add_commented_expr_after=>0);
     $hp->parse_text(<<~'EOF');
         #if defined(A) && !!defined(A) && !!!!defined(A)
@@ -634,13 +971,16 @@ is($normal,<<~'EOF',"Normalized text as expected");
         EOF
     my $grouped= $hp->group_content();
     my $as_text= $hp->lines_as_str($grouped);
-    is($as_text,<<~'EOF',"simplification") or show_text($as_text);
+    is($as_text,<<~'EOF', my $tname = "simplification") or show_text($as_text);
         #if defined(A)
         # define HAS_A
         #endif /* defined(A) */
         EOF
+    is(join("\n",@warn),"", "No warnings generated from $tname");
 }
 {
+    my @warn;
+    local $SIG{__WARN__}= sub { push @warn, $_[0]; warn $_[0] };
     local $::TODO;
     $::TODO= "Absorbtion not implemented yet";
     # currently we don't handle absorbtion: (A && (A || B || C ...)) == A
@@ -652,13 +992,16 @@ is($normal,<<~'EOF',"Normalized text as expected");
         EOF
     my $grouped= $hp->group_content();
     my $as_text= $hp->lines_as_str($grouped);
-    is($as_text,<<~'EOF',"simplification by absorbtion"); # or show_text($as_text);
+    is($as_text,<<~'EOF',my $tname= "simplification by absorbtion"); # or show_text($as_text);
         #if defined(X)
         # define HAS_X
         #endif /* defined(X) */
         EOF
+    is(join("\n",@warn),"", "No warnings generated from $tname");
 }
 {
+    my @warn;
+    local $SIG{__WARN__}= sub { push @warn, $_[0]; warn $_[0] };
     my $hp= HeaderParser->new(debug=>0,add_commented_expr_after=>0);
     $hp->parse_text(<<~'EOF');
         #if defined(A) && (defined(B) && defined(C))
@@ -667,13 +1010,16 @@ is($normal,<<~'EOF',"Normalized text as expected");
         EOF
     my $grouped= $hp->group_content();
     my $as_text= $hp->lines_as_str($grouped);
-    is($as_text,<<~'EOF',"expression flattening") or show_text($as_text);
+    is($as_text,<<~'EOF', my $tname= "expression flattening") or show_text($as_text);
         #if defined(A) && defined(B) && defined(C)
         # define HAS_A
         #endif /* defined(A) && defined(B) && defined(C) */
         EOF
+    is(join("\n",@warn),"", "No warnings generated from $tname");
 }
 {
+    my @warn;
+    local $SIG{__WARN__}= sub { push @warn, $_[0]; warn $_[0] };
     my $hp= HeaderParser->new(debug=>0,add_commented_expr_after=>3);
     $hp->parse_text(<<~'EOF');
         #if defined(A)
@@ -700,7 +1046,7 @@ is($normal,<<~'EOF',"Normalized text as expected");
         EOF
     my $grouped= $hp->group_content();
     my $as_text= $hp->lines_as_str($grouped);
-    is($as_text,<<~'EOF',"auto-comments") or show_text($as_text);
+    is($as_text,<<~'EOF', my $tname= "auto-comments") or show_text($as_text);
         #if defined(A)
         # define HAS_A1
         # define HAS_A2
@@ -723,8 +1069,11 @@ is($normal,<<~'EOF',"Normalized text as expected");
         # define HAS_CC3
         #endif /* !defined(C) && defined(CC) */
         EOF
+    is(join("\n",@warn),"", "No warnings generated from $tname");
 }
 {
+    my @warn;
+    local $SIG{__WARN__}= sub { push @warn, $_[0]; warn $_[0] };
     my $hp= HeaderParser->new(debug=>0,add_commented_expr_after=>0);
     $hp->parse_text(<<~'EOF');
         #if  defined(DEBUGGING)                                                    \
@@ -737,7 +1086,7 @@ is($normal,<<~'EOF',"Normalized text as expected");
         EOF
     my $grouped= $hp->group_content();
     my $as_text= $hp->lines_as_str($grouped);
-    is($as_text,<<~'EOF',"Karls example") or show_text($as_text);
+    is($as_text,<<~'EOF', my $tname= "Karls example") or show_text($as_text);
         #if   defined(DEBUGGING) ||                                         \
             ( defined(USE_LOCALE) &&                                        \
             ( defined(HAS_IGNORED_LOCALE_CATEGORIES) || !defined(LC_ALL) || \
@@ -748,6 +1097,7 @@ is($normal,<<~'EOF',"Normalized text as expected");
                   ( defined(HAS_IGNORED_LOCALE_CATEGORIES) || !defined(LC_ALL) ||
                     defined(USE_POSIX_2008_LOCALE) || defined(USE_THREADS) ) ) */
         EOF
+    is(join("\n",@warn),"", "No warnings generated from $tname");
 }
 
 done_testing();


### PR DESCRIPTION
HeaderParser.pm - parse single quoted backslash properly
    
@khwilliamson  gave me a test script which was breaking because we did not handle single quoted escapes like '\\' and '\n' and the  like. This fixes the tokenizer pattern to handle these without dieing, although we do not validate that the escape sequence itself is legal, we no longer choke on having backslash something in the single quote.

This patch sequence also includes a commit which teaches t/porting/header_parser.t how to update its own Data::Dumper based test. Updating this test manually was annoying, so I made the script do it for us when needed. 

* This set of changes does not require a perldelta entry.
