### PR TITLE
remove internal calls to pp_pushmark()

### DIFF
--- a/gv.c
+++ b/gv.c
@@ -4201,7 +4201,7 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int flags)
     PL_op = (OP *) &myop;
     if (PERLDB_SUB && PL_curstash != PL_debstash)
         PL_op->op_private |= OPpENTERSUB_DB;
-    Perl_pp_pushmark(aTHX);
+    PUSHMARK(PL_stack_sp);
 
     EXTEND(SP, notfound + 5);
     PUSHs(lr>0? right: left);

--- a/op.c
+++ b/op.c
@@ -5182,7 +5182,7 @@ S_gen_constant_list(pTHX_ OP *o)
 #ifdef PERL_USE_HWM
         PL_curstackinfo->si_stack_hwm = 0; /* stop valgrind complaining */
 #endif
-        Perl_pp_pushmark(aTHX);
+        PUSHMARK(PL_stack_sp);
         CALLRUNOPS(aTHX);
         PL_op = curop;
         assert (!(curop->op_flags & OPf_SPECIAL));

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -256,8 +256,6 @@ PP(pp_null)
     return NORMAL;
 }
 
-/* This is sometimes called directly by pp_coreargs, pp_grepstart and
-   amagic_call. */
 PP(pp_pushmark)
 {
     PUSHMARK(PL_stack_sp);

--- a/regen/op_private
+++ b/regen/op_private
@@ -804,7 +804,7 @@ addbits('coreargs',
    #2 reserved for OPpDONT_INIT_GV in rv2gv
    #4 reserved for OPpALLOW_FAKE   in rv2gv
     6 => qw(OPpCOREARGS_SCALARMOD $MOD  ), # \$ rather than \[$@%*]
-    7 => qw(OPpCOREARGS_PUSHMARK  MARK  ), # Call pp_pushmark
+    7 => qw(OPpCOREARGS_PUSHMARK  MARK  ), # Call PUSHMARK
 );
 
 


### PR DESCRIPTION
Perl_pp_pushmark is a fairly simple function that does two things:
1. `PUSHMARK(PL_stack_sp);`
2. It returns `PL_op->op_next`.

All internal uses ignore the return value and can just use PUSHMARK directly, without going through a pp_* function.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
