### PR TITLE
perlvar: fix $SIG{__DIE__} POD re: exiting from a sub

### DIFF
--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -737,11 +737,10 @@ empty subroutine:
 The routine indicated by C<$SIG{__DIE__}> is called when a fatal
 exception is about to be thrown.  The error message is passed as the
 first argument.  When a C<__DIE__> hook routine returns, the exception
-processing continues as it would have in the absence of the hook,
-unless the hook routine itself exits via a C<goto &sub>, a loop exit,
-or a C<die()>.  The C<__DIE__> handler is explicitly disabled during
-the call, so that you can die from a C<__DIE__> handler.  Similarly
-for C<__WARN__>.
+processing continues as it would have in the absence of the hook, unless
+the hook routine itself throws an exception.  The C<__DIE__> handler is
+explicitly disabled during the call, so that you can die from a
+C<__DIE__> handler.  Similarly for C<__WARN__>.
 
 The C<$SIG{__DIE__}> hook is called even inside an C<eval()>. It was
 never intended to happen this way, but an implementation glitch made
@@ -750,7 +749,7 @@ at a distance like rewriting a pending exception in C<$@>. Plans to
 rectify this have been scrapped, as users found that rewriting a
 pending exception is actually a useful feature, and not a bug.
 
-The C<$SIG{__DIE__}> doesn't support C<'IGNORE'>; it has the same
+The C<$SIG{__DIE__}> hook doesn't support C<'IGNORE'>; it has the same
 effect as C<'DEFAULT'>.
 
 C<__DIE__>/C<__WARN__> handlers are very special in one respect: they

--- a/t/op/die_goto.t
+++ b/t/op/die_goto.t
@@ -5,7 +5,7 @@ use v5.36;
 # disabled into goto'd function. And the other documented
 # exceptions to enable dying from a die handler.
 
-print "1..6\n";
+print "1..5\n";
 
 eval {
     sub f1 { die "ok 1\n" }
@@ -15,14 +15,7 @@ eval {
 print $@;
 
 eval {
-    sub loopexit { for (0..2) { next if $_ } }
-    $SIG{__DIE__} = \&loopexit;
-    die "ok 2\n";
-};
-print $@;
-
-eval {
-    sub foo1 { die "ok 3\n" }
+    sub foo1 { die "ok 2\n" }
     sub bar1 { foo1() }
     $SIG{__DIE__} = \&bar1;
     die;
@@ -31,7 +24,7 @@ print $@;
 
 # GH #14527
 eval {
-    sub foo2 { die "ok 4\n" }
+    sub foo2 { die "ok 3\n" }
     sub bar2 { goto &foo2 }
     $SIG{__DIE__} = \&bar2;
     die;
@@ -42,7 +35,7 @@ print $@;
 
 # GH #22987 (die)
 eval {
-    sub foo3 { die "ok 5\n" }
+    sub foo3 { die "ok 4\n" }
     sub bar3 { { local $SIG{__DIE__}; } goto &foo3 }
     $SIG{__DIE__} = \&bar3;
     die;
@@ -61,4 +54,4 @@ eval {
     $SIG{__DIE__} = \&hybrid;
     hybrid;
 };
-print $@ eq "2\n" ? "ok 6\n" : "not ok 6\n" . "\$\@ = $@" =~ s/^/# /mgr;
+print $@ eq "2\n" ? "ok 5\n" : "not ok 5\n" . "\$\@ = $@" =~ s/^/# /mgr;


### PR DESCRIPTION
The documentation claims that you can make die() not throw an exception by setting a `$SIG{__DIE__}` handler that performs a non-local exit via goto/next/last/redo LABEL or throws another exception. The latter is true, but it just replaces one exception by another (you still end up throwing some exception). The former has never worked as advertised: You cannot transfer control out of a %SIG handler (except by regular return).

(At some point, "goto" was changed to "goto &sub", which is even wronger: "goto &sub" is effectively just a function call. It definitely does not stop exception processing/stack unwinding.)

"Fixes" #8987 by making the documentation match the implementation. (It does not make the implementation match the documentation, which is what Father Chrysostomos was working on in 2012, but there have been no updates since then. In the meantime, this is better than nothing.)

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
