### PR TITLE
perlreref: fix definition of \R

### DIFF
--- a/pod/perlreref.pod
+++ b/pod/perlreref.pod
@@ -142,7 +142,7 @@ and L<perlunicode> for details.
            like '.' without /s modifier)
    \v      A vertical whitespace
    \V      A non vertical whitespace
-   \R      A generic newline           (?>\v|\x0D\x0A)
+   \R      A generic newline           (?>\x0D\x0A|\v)
 
    \pP     Match P-named (Unicode) property
    \p{...} Match Unicode property with name longer than 1 character


### PR DESCRIPTION
The order of alternatives matters because Carriage Return (\x0D) is matched by \v (vertical whitespace), meaning the old pattern was effectively equivalent to just \v.

Fixes #23002.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
