### PR TITLE
Faster string reversal when source/dest buffers are distinct

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3114,6 +3114,8 @@ Adp	|SV *	|sv_bless	|NN SV * const sv			\
 Cdmp	|bool	|sv_2bool	|NN SV * const sv
 Cdp	|bool	|sv_2bool_flags |NN SV *sv				\
 				|I32 flags
+Cp	|bool	|sv_can_swipe_pv_buf					\
+				|NN SV *sv
 Adp	|bool	|sv_cat_decode	|NN SV *dsv				\
 				|NN SV *encoding			\
 				|NN SV *ssv				\

--- a/embed.h
+++ b/embed.h
@@ -707,6 +707,7 @@
 # define sv_2uv_flags(a,b)                      Perl_sv_2uv_flags(aTHX_ a,b)
 # define sv_backoff                             Perl_sv_backoff
 # define sv_bless(a,b)                          Perl_sv_bless(aTHX_ a,b)
+# define sv_can_swipe_pv_buf(a)                 Perl_sv_can_swipe_pv_buf(aTHX_ a)
 # define sv_cat_decode(a,b,c,d,e,f)             Perl_sv_cat_decode(aTHX_ a,b,c,d,e,f)
 # define sv_catpv(a,b)                          Perl_sv_catpv(aTHX_ a,b)
 # define sv_catpv_flags(a,b,c)                  Perl_sv_catpv_flags(aTHX_ a,b,c)

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -89,6 +89,13 @@ There may well be none in a stable release.
 
 =item *
 
+String reversal from a single argument, when the string buffer is not
+"swiped", is now done in a single pass and is noticeably faster.
+The extent of the improvement is compiler & hardware dependent.
+[GH #23012]
+
+=item *
+
 XXX
 
 =back

--- a/pp.c
+++ b/pp.c
@@ -6604,8 +6604,7 @@ PP_wrapped(pp_reverse, 0, 1)
             SP = oldsp;
         }
     }
-    else {
-        char *up;
+    else { /* GIMME_V != G_LIST. Doing string reversal. */
         dTARGET;
         STRLEN len;
 
@@ -6614,17 +6613,88 @@ PP_wrapped(pp_reverse, 0, 1)
             do_join(TARG, &PL_sv_no, MARK, SP);
             SP = MARK + 1;
             SETs(TARG);
-        } else if (SP > MARK) {
-            sv_setsv_flags(TARG, *SP, SV_GMAGIC);
-            SETs(TARG);
         } else {
-            sv_setsv_flags(TARG, DEFSV, SV_GMAGIC);
-            XPUSHs(TARG);
+            SV * src_sv = NULL;
+            /* Determine the source SV and get TARG on the stack */
+            if (SP > MARK) {
+                src_sv = *SP;
+                SETs(TARG);
+            } else {
+                src_sv = DEFSV;
+                XPUSHs(TARG);
+            }
+            assert(src_sv);
+            assert(src_sv != TARG);
+
+            if (/* Fallback to sv_setsv_flags() + in-place reversal if: */
+                /*     src_sv may need careful handling */
+                SvTYPE(src_sv) > SVt_PVMG || SvGMAGICAL(src_sv) ||
+                    SvVOK(src_sv) ||
+                /*     src_sv doesn't contain a valid string */
+                !(SvFLAGS(src_sv) & SVp_POK) ||
+                /*     TARG may need careful handling */
+                SvTYPE(TARG) > SVt_PVMG ||
+                /*     sv_setsv_flags() will swipe src_sv's buffer */
+                sv_can_swipe_pv_buf(src_sv)
+            ) {
+                sv_setsv_flags(TARG, src_sv, SV_GMAGIC);
+                /* FALLTHROUGH */
+            } else { /* Source & destination buffers are distinct. By not
+                      * calling sv_setsv_flags(), we can do a reverse copy
+                      * in a single pass, rather than 2-3 passes. */
+
+                const char * src = SvPV_const(src_sv, len);
+
+                /* Prepare the TARG. */
+                if (SvTYPE(TARG) < SVt_PV) {
+                    SvUPGRADE(TARG, SvTYPE(src_sv)); /* No buffer allocation here */
+                } else if(SvTHINKFIRST(TARG)) {
+                     SV_CHECK_THINKFIRST_COW_DROP(TARG); /* Drops any buffer */
+                }
+                SvSETMAGIC(TARG);
+                SvGROW(TARG, len + 1);
+                SvCUR_set(TARG, len);
+                SvPOK_only(TARG);
+                *SvEND(TARG) = '\0';
+                if (SvTAINTED(src_sv))
+                    SvTAINT(TARG);
+
+                /* Do the reverse copy */
+                if (DO_UTF8(src_sv)) {
+                    SvUTF8_on(TARG);
+
+                    const U8* s = (const U8*)src;
+                    U8* dd = (U8*)(SvPVX(TARG) + len);
+                    const U8* send = (const U8*)(s + len);
+                    int bytes = 0;
+                    while (s < send) {
+                        bytes = UTF8SKIP(s);
+                        if (bytes == 1) {
+                            *--dd = *s++;
+                        } else {
+                            dd -= bytes;
+                            U8* d2 = dd;
+                            while (bytes-- > 0)
+                                *d2++ = *s++;
+                        }
+                    }
+                } else {
+                    char * outp= SvPVX(TARG);
+                    const char *p = src + len;
+                    while (p != src)
+                        *outp++ = *--p;
+                }
+            RETURN;
+            }
         }
+
+        /* Traditional in-place reversal routines */
         SvSETMAGIC(TARG); /* remove any utf8 length magic */
 
-        up = SvPV_force(TARG, len);
+        char *up = SvPV_force(TARG, len);
+
         if (len > 1) {
+            /* The traditional way, operate on the current byte buffer */
             char *down;
             if (DO_UTF8(TARG)) {	/* first reverse each character */
                 U8* s = (U8*)SvPVX(TARG);
@@ -6656,8 +6726,8 @@ PP_wrapped(pp_reverse, 0, 1)
                 *up++ = *down;
                 *down-- = tmp;
             }
-            (void)SvPOK_only_UTF8(TARG);
         }
+        (void)SvPOK_only_UTF8(TARG);
     }
     RETURN;
 }

--- a/proto.h
+++ b/proto.h
@@ -4535,6 +4535,11 @@ Perl_sv_bless(pTHX_ SV * const sv, HV * const stash);
         assert(sv); assert(stash)
 
 PERL_CALLCONV bool
+Perl_sv_can_swipe_pv_buf(pTHX_ SV *sv);
+#define PERL_ARGS_ASSERT_SV_CAN_SWIPE_PV_BUF    \
+        assert(sv)
+
+PERL_CALLCONV bool
 Perl_sv_cat_decode(pTHX_ SV *dsv, SV *encoding, SV *ssv, int *offset, char *tstr, int tlen);
 #define PERL_ARGS_ASSERT_SV_CAT_DECODE          \
         assert(dsv); assert(encoding); assert(ssv); assert(offset); assert(tstr)

--- a/sv.c
+++ b/sv.c
@@ -4187,6 +4187,33 @@ S_sv_buf_to_rw(pTHX_ SV *sv)
 # define sv_buf_to_rw(sv)	NOOP
 #endif
 
+
+/* The test in this macro was extracted from Perl_sv_setsv_flags so that it
+ * could be used elsewhere. */
+#define S_SvPV_can_swipe_buf(ssv, sflags, cur, len)                   \
+    (( /* Either ... */                                                    \
+      /* slated for free anyway (and not COW)? */                          \
+      ((sflags & (SVs_TEMP|SVf_IsCOW)) == SVs_TEMP)                        \
+      /* or a swipable TARG */                                             \
+      || ((sflags &                                                        \
+            (SVs_PADTMP|SVf_READONLY|SVf_PROTECT|SVf_IsCOW))== SVs_PADTMP  \
+            /* whose buffer is worth stealing */                           \
+            && CHECK_COWBUF_THRESHOLD(cur,len)                             \
+         )                                                                 \
+    ) && !(sflags & SVf_OOK)     /* and not involved in OOK hack? */       \
+      && (SvREFCNT(ssv) == 1)      /* and no other references to it? */    \
+      && len                    /* and really is a string */               \
+    )
+
+/* Perl_sv_can_swipe_pv_buf was originally created for pp_reverse. */
+bool
+Perl_sv_can_swipe_pv_buf(pTHX_ SV *sv)
+{
+    PERL_ARGS_ASSERT_SV_CAN_SWIPE_PV_BUF;
+    assert(sv);
+    return S_SvPV_can_swipe_buf(sv, SvFLAGS(sv), SvCUR(sv), SvLEN(sv)) ? true : false;
+}
+
 void
 Perl_sv_setsv_flags(pTHX_ SV *dsv, SV* ssv, const I32 flags)
 {
@@ -4593,23 +4620,7 @@ Perl_sv_setsv_flags(pTHX_ SV *dsv, SV* ssv, const I32 flags)
            and doing it now facilitates the COW check.  */
         (void)SvPOK_only(dsv);
 
-        if (
-                 (              /* Either ... */
-                                /* slated for free anyway (and not COW)? */
-                    (sflags & (SVs_TEMP|SVf_IsCOW)) == SVs_TEMP
-                                /* or a swipable TARG */
-                 || ((sflags &
-                           (SVs_PADTMP|SVf_READONLY|SVf_PROTECT|SVf_IsCOW))
-                       == SVs_PADTMP
-                                /* whose buffer is worth stealing */
-                     && CHECK_COWBUF_THRESHOLD(cur,len)
-                    )
-                 ) &&
-                 !(sflags & SVf_OOK) &&   /* and not involved in OOK hack? */
-                 (!(flags & SV_NOSTEAL)) &&
-                                        /* and we're allowed to steal temps */
-                 SvREFCNT(ssv) == 1 &&   /* and no other references to it? */
-                 len)             /* and really is a string */
+        if ( !(flags & SV_NOSTEAL) && S_SvPV_can_swipe_buf(ssv, sflags, cur, len) )
         {	/* Passes the swipe test.  */
             if (SvPVX_const(dsv))	/* we know that dtype >= SVt_PV */
                 SvPV_free(dsv);

--- a/t/op/reverse.t
+++ b/t/op/reverse.t
@@ -6,7 +6,9 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan tests => 25;
+plan tests => 26;
+
+is(reverse("a"), "a", 'single char reverse');
 
 is(reverse("abc"), "cba", 'simple reverse');
 


### PR DESCRIPTION
`pp_reverse()` has traditionally operated on a single string buffer,
reversing it in place.

When `pp_reverse()` takes a single SV argument, whose buffer cannot be
swiped by `sv_setsv_flags()`, a straight copy of the buffer is taken
and then that is reversed. In such cases, two complete passes over the
entire string are needed to reverse a non-UTF8 string, and reversing a
UTF8 string takes three complete passes.

This PR enables `pp_reverse()` to apply the "swipe" test itself
and, for straightforward copy cases, to avoid calling `sv_setsv_flags()`.
Instead, it does the work of preparing the `TARG` SV and reverse copies
the string (UTF8 or otherwise) in a single pass.

Non-UTF8 performance is more than doubled. UTF8 performance is improved
by ~40%. (This is using `gcc version 12.2.0` on Linux running on a midrange Zen3 CPU.)

* `my $x = "X"x(1024*1000*10); my $y; for (0..1_000) { $y = reverse $x }`

PATCHED
```
          2,300.42 msec task-clock                       #    0.994 CPUs utilized          
                 2      context-switches                 #    0.869 /sec                   
                 0      cpu-migrations                   #    0.000 /sec                   
             2,472      page-faults                      #    1.075 K/sec                  
    10,523,888,668      cycles                           #    4.575 GHz                    
         3,407,581      stalled-cycles-frontend          #    0.03% frontend cycles idle   
        17,098,625      stalled-cycles-backend           #    0.16% backend cycles idle    
    61,520,603,431      instructions                     #    5.85  insn per cycle         
    10,255,033,319      branches                         #    4.458 G/sec                  
```       

BLEAD       
```
          5,693.74 msec task-clock                       #    0.996 CPUs utilized          
                 4      context-switches                 #    0.703 /sec                   
                 0      cpu-migrations                   #    0.000 /sec                   
             2,471      page-faults                      #  433.985 /sec                   
    26,417,106,165      cycles                           #    4.640 GHz                    
         4,123,476      stalled-cycles-frontend          #    0.02% frontend cycles idle   
        16,843,163      stalled-cycles-backend           #    0.06% backend cycles idle    
    41,985,580,059      instructions                     #    1.59  insn per cycle         
     5,210,998,998      branches                         #  915.215 M/sec                  
```
       
* `my $x = "\x{263A}\x{263A}x\x{263A}y\x{263A}"x(1024*1000); my $y; for (0..1_000) { $y = reverse $x }`

PATCHED
```
         13,473.52 msec task-clock                       #    0.999 CPUs utilized          
                 8      context-switches                 #    0.594 /sec                   
                 0      cpu-migrations                   #    0.000 /sec                   
             2,869      page-faults                      #  212.936 /sec                   
    64,319,489,828      cycles                           #    4.774 GHz                    
        19,171,494      stalled-cycles-frontend          #    0.03% frontend cycles idle   
        29,132,509      stalled-cycles-backend           #    0.05% backend cycles idle    
   139,440,302,209      instructions                     #    2.17  insn per cycle         
    32,809,474,409      branches                         #    2.435 G/sec                  
```

BLEAD
```
         21,833.47 msec task-clock                       #    0.999 CPUs utilized          
                18      context-switches                 #    0.824 /sec                   
                 0      cpu-migrations                   #    0.000 /sec                   
             2,362      page-faults                      #  108.183 /sec                   
    99,685,066,602      cycles                           #    4.566 GHz                    
        17,824,958      stalled-cycles-frontend          #    0.02% frontend cycles idle   
        34,272,539      stalled-cycles-backend           #    0.03% backend cycles idle    
   378,833,407,708      instructions                     #    3.80  insn per cycle         
    72,845,191,845      branches                         #    3.336 G/sec                  
```
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it will be included shortly.
