### PR TITLE
Use short names for common vararg functions.

### DIFF
--- a/av.c
+++ b/av.c
@@ -99,7 +99,7 @@ Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp,
     PERL_ARGS_ASSERT_AV_EXTEND_GUTS;
 
     if (key < -1) /* -1 is legal */
-        Perl_croak(aTHX_
+        croak(
             "panic: av_extend_guts() negative count (%" IVdf ")", (IV)key);
 
     if (key > *maxp) {

--- a/av.c
+++ b/av.c
@@ -370,7 +370,7 @@ Perl_av_store(pTHX_ AV *av, SSize_t key, SV *val)
     }
 
     if (SvREADONLY(av) && key >= AvFILL(av))
-        Perl_croak_no_modify();
+        croak_no_modify();
 
     if (!AvREAL(av) && AvREIFY(av))
         av_reify(av);
@@ -646,7 +646,7 @@ Perl_av_clear(pTHX_ AV *av)
 #endif
 
     if (SvREADONLY(av))
-        Perl_croak_no_modify();
+        croak_no_modify();
 
     /* Give any tie a chance to cleanup first */
     if (SvRMAGICAL(av)) {
@@ -796,7 +796,7 @@ Perl_av_push(pTHX_ AV *av, SV *val)
     assert(SvTYPE(av) == SVt_PVAV);
 
     if (SvREADONLY(av))
-        Perl_croak_no_modify();
+        croak_no_modify();
 
     if ((mg = SvTIED_mg((const SV *)av, PERL_MAGIC_tied))) {
         Perl_magic_methcall(aTHX_ MUTABLE_SV(av), mg, SV_CONST(PUSH), G_DISCARD, 1,
@@ -828,7 +828,7 @@ Perl_av_pop(pTHX_ AV *av)
     assert(SvTYPE(av) == SVt_PVAV);
 
     if (SvREADONLY(av))
-        Perl_croak_no_modify();
+        croak_no_modify();
     if ((mg = SvTIED_mg((const SV *)av, PERL_MAGIC_tied))) {
         retval = Perl_magic_methcall(aTHX_ MUTABLE_SV(av), mg, SV_CONST(POP), 0, 0);
         if (retval)
@@ -887,7 +887,7 @@ Perl_av_unshift(pTHX_ AV *av, SSize_t num)
     assert(SvTYPE(av) == SVt_PVAV);
 
     if (SvREADONLY(av))
-        Perl_croak_no_modify();
+        croak_no_modify();
 
     if ((mg = SvTIED_mg((const SV *)av, PERL_MAGIC_tied))) {
         Perl_magic_methcall(aTHX_ MUTABLE_SV(av), mg, SV_CONST(UNSHIFT),
@@ -954,7 +954,7 @@ Perl_av_shift(pTHX_ AV *av)
     assert(SvTYPE(av) == SVt_PVAV);
 
     if (SvREADONLY(av))
-        Perl_croak_no_modify();
+        croak_no_modify();
     if ((mg = SvTIED_mg((const SV *)av, PERL_MAGIC_tied))) {
         retval = Perl_magic_methcall(aTHX_ MUTABLE_SV(av), mg, SV_CONST(SHIFT), 0, 0);
         if (retval)
@@ -1083,7 +1083,7 @@ Perl_av_delete(pTHX_ AV *av, SSize_t key, I32 flags)
     assert(SvTYPE(av) == SVt_PVAV);
 
     if (SvREADONLY(av))
-        Perl_croak_no_modify();
+        croak_no_modify();
 
     if (SvRMAGICAL(av)) {
         const MAGIC * const tied_magic

--- a/builtin.c
+++ b/builtin.c
@@ -221,7 +221,7 @@ XS(XS_builtin_func1_scalar)
             break;
 
         default:
-            Perl_die(aTHX_ "panic: unhandled opcode %" IVdf
+            die("panic: unhandled opcode %" IVdf
                            " for xs_builtin_func1_scalar()", (IV) ix);
     }
 
@@ -392,7 +392,7 @@ XS(XS_builtin_func1_void)
             break;
 
         default:
-            Perl_die(aTHX_ "panic: unhandled opcode %" IVdf
+            die("panic: unhandled opcode %" IVdf
                            " for xs_builtin_func1_void()", (IV) ix);
     }
 

--- a/builtin.c
+++ b/builtin.c
@@ -308,11 +308,11 @@ XS(XS_builtin_export_lexically)
     warn_experimental_builtin("export_lexically");
 
     if(!PL_compcv)
-        Perl_croak(aTHX_
+        croak(
                 "export_lexically can only be called at compile time");
 
     if(items % 2)
-        Perl_croak(aTHX_ "Odd number of elements in export_lexically");
+        croak("Odd number of elements in export_lexically");
 
     for(int i = 0; i < items; i += 2) {
         SV *name = ST(i);
@@ -320,7 +320,7 @@ XS(XS_builtin_export_lexically)
 
         if(!SvROK(ref))
             /* diag_listed_as: Expected %s reference in export_lexically */
-            Perl_croak(aTHX_ "Expected a reference in export_lexically");
+            croak("Expected a reference in export_lexically");
 
         char sigil = SvPVX(name)[0];
         SV *rv = SvRV(ref);
@@ -358,7 +358,7 @@ XS(XS_builtin_export_lexically)
         }
 
         if(bad)
-            Perl_croak(aTHX_ "Expected %s reference in export_lexically", bad);
+            croak("Expected %s reference in export_lexically", bad);
     }
 
     prepare_export_lexical();
@@ -695,7 +695,7 @@ static void S_import_sym(pTHX_ SV *sym)
 
     CV *cv = get_cv(SvPV_nolen(fqname), SvUTF8(fqname) ? SVf_UTF8 : 0);
     if(!cv)
-        Perl_croak(aTHX_ builtin_not_recognised, sym);
+        croak(builtin_not_recognised, sym);
 
     export_lexical(ampname, (SV *)cv);
 }
@@ -737,7 +737,7 @@ XS(XS_builtin_import)
     dXSARGS;
 
     if(!PL_compcv)
-        Perl_croak(aTHX_
+        croak(
                 "builtin::import can only be called at compile time");
 
     prepare_export_lexical();
@@ -747,19 +747,19 @@ XS(XS_builtin_import)
         STRLEN symlen;
         const char *sympv = SvPV(sym, symlen);
         if(strEQ(sympv, "import"))
-            Perl_croak(aTHX_ builtin_not_recognised, sym);
+            croak(builtin_not_recognised, sym);
 
         if(sympv[0] == ':') {
             UV vmajor, vminor;
             if(!S_parse_version(sympv + 1, sympv + symlen, &vmajor, &vminor))
-                Perl_croak(aTHX_ "Invalid version bundle %" SVf_QUOTEDPREFIX, sym);
+                croak("Invalid version bundle %" SVf_QUOTEDPREFIX, sym);
 
             U16 want_ver = SHORTVER(vmajor, vminor);
 
             if(want_ver < SHORTVER(5,39) ||
                     /* round up devel version to next major release; e.g. 5.39 => 5.40 */
                     want_ver > SHORTVER(PERL_REVISION, PERL_VERSION + (PERL_VERSION % 2)))
-                Perl_croak(aTHX_ "Builtin version bundle \"%s\" is not supported by Perl " PERL_VERSION_STRING,
+                croak("Builtin version bundle \"%s\" is not supported by Perl " PERL_VERSION_STRING,
                         sympv);
 
             import_builtin_bundle(want_ver);

--- a/class.c
+++ b/class.c
@@ -141,7 +141,7 @@ XS(injected_constructor)
     struct xpvhv_aux *aux = HvAUX(stash);
 
     if((items - 1) % 2)
-        Perl_warn(aTHX_ "Odd number of arguments passed to %" HvNAMEf_QUOTEDPREFIX " constructor",
+        warn("Odd number of arguments passed to %" HvNAMEf_QUOTEDPREFIX " constructor",
                 HvNAMEfARG(stash));
 
     if (!aux->xhv_class_initfields_cv) {

--- a/class.c
+++ b/class.c
@@ -230,7 +230,7 @@ XS(injected_constructor)
         SAVEFREESV(paramnames);
 
         while((he = hv_iternext(params)))
-            Perl_sv_catpvf(aTHX_ paramnames, ", %" SVf, SVfARG(HeSVKEY_force(he)));
+            sv_catpvf(paramnames, ", %" SVf, SVfARG(HeSVKEY_force(he)));
 
         croak("Unrecognised parameters for %" HvNAMEf_QUOTEDPREFIX " constructor: %" SVf,
                 HvNAMEfARG(stash), SVfARG(paramnames));

--- a/class.c
+++ b/class.c
@@ -145,7 +145,7 @@ XS(injected_constructor)
                 HvNAMEfARG(stash));
 
     if (!aux->xhv_class_initfields_cv) {
-        Perl_croak(aTHX_ "Cannot create an object of incomplete class %" HvNAMEf_QUOTEDPREFIX,
+        croak("Cannot create an object of incomplete class %" HvNAMEf_QUOTEDPREFIX,
                    HvNAMEfARG(stash));
     }
 

--- a/cygwin/cygwin.c
+++ b/cygwin/cygwin.c
@@ -217,7 +217,7 @@ XS(Cygwin_cwd)
        There is Cwd->cwd() usage in the wild, and previous versions didn't die.
      */
     if(items > 1)
-        Perl_croak(aTHX_ "Usage: Cwd::cwd()");
+        croak("Usage: Cwd::cwd()");
     if((cwd = getcwd(NULL, -1))) {
         ST(0) = sv_2mortal(newSVpv(cwd, 0));
         free(cwd);
@@ -234,7 +234,7 @@ XS(XS_Cygwin_pid_to_winpid)
     pid_t pid, RETVAL;
 
     if (items != 1)
-        Perl_croak(aTHX_ "Usage: Cygwin::pid_to_winpid(pid)");
+        croak("Usage: Cygwin::pid_to_winpid(pid)");
 
     pid = (pid_t)SvIV(ST(0));
 
@@ -252,7 +252,7 @@ XS(XS_Cygwin_winpid_to_pid)
     pid_t pid, RETVAL;
 
     if (items != 1)
-        Perl_croak(aTHX_ "Usage: Cygwin::winpid_to_pid(pid)");
+        croak("Usage: Cygwin::winpid_to_pid(pid)");
 
     pid = (pid_t)SvIV(ST(0));
 
@@ -293,7 +293,7 @@ S_convert_path_common(pTHX_ const direction_t direction)
         const char *name = (direction == to_posix)
                      ? "win::win_to_posix_path"
                      : "posix_to_win_path";
-        Perl_croak(aTHX_ "Usage: Cygwin::%s(pathname, [absolute])", name);
+        croak("Usage: Cygwin::%s(pathname, [absolute])", name);
     }
 
     src_path = SvPVx(ST(0), len);
@@ -301,7 +301,7 @@ S_convert_path_common(pTHX_ const direction_t direction)
         absolute_flag = SvTRUE(ST(1));
 
     if (!len)
-        Perl_croak(aTHX_ "can't convert empty path");
+        croak("can't convert empty path");
     isutf8 = SvUTF8(ST(0));
 
 #if HAVE_CYGWIN_VERSION(0, 181)
@@ -411,7 +411,7 @@ XS(XS_Cygwin_mount_table)
     struct mntent *mnt;
 
     if (items != 0)
-        Perl_croak(aTHX_ "Usage: Cygwin::mount_table");
+        croak("Usage: Cygwin::mount_table");
     /* => array of [mnt_dir mnt_fsname mnt_type mnt_opts] */
 
     setmntent (0, 0);
@@ -435,7 +435,7 @@ XS(XS_Cygwin_mount_flags)
     flags[0] = '\0';
 
     if (items != 1)
-        Perl_croak(aTHX_ "Usage: Cygwin::mount_flags( mnt_dir | '/cygdrive' )");
+        croak("Usage: Cygwin::mount_flags( mnt_dir | '/cygdrive' )");
 
     pathname = SvPV_nolen(ST(0));
 
@@ -513,7 +513,7 @@ XS(XS_Cygwin_is_binmount)
     char *pathname;
 
     if (items != 1)
-        Perl_croak(aTHX_ "Usage: Cygwin::is_binmount(pathname)");
+        croak("Usage: Cygwin::is_binmount(pathname)");
 
     pathname = SvPV_nolen(ST(0));
 

--- a/doio.c
+++ b/doio.c
@@ -2632,11 +2632,11 @@ Perl_apply(pTHX_ I32 type, SV **mark, SV **sp)
        platforms where kill was not defined.  */
 #ifndef HAS_KILL
     if (type == OP_KILL)
-        Perl_die(aTHX_ PL_no_func, what);
+        die(PL_no_func, what);
 #endif
 #ifndef HAS_CHOWN
     if (type == OP_CHOWN)
-        Perl_die(aTHX_ PL_no_func, what);
+        die(PL_no_func, what);
 #endif
 
 
@@ -2675,7 +2675,7 @@ Perl_apply(pTHX_ I32 type, SV **mark, SV **sp)
                         } else if (fchmod(fd, val))
                             tot--;
 #else
-                        Perl_die(aTHX_ PL_no_func, "fchmod");
+                        die(PL_no_func, "fchmod");
 #endif
                     }
                     else {
@@ -2716,7 +2716,7 @@ Perl_apply(pTHX_ I32 type, SV **mark, SV **sp)
                         } else if (fchown(fd, val, val2))
                             tot--;
 #else
-                        Perl_die(aTHX_ PL_no_func, "fchown");
+                        die(PL_no_func, "fchown");
 #endif
                     }
                     else {
@@ -2908,7 +2908,7 @@ nothing in the core.
                         } else if (futimes(fd, (struct timeval *) utbufp))
                             tot--;
 #else
-                        Perl_die(aTHX_ PL_no_func, "futimes");
+                        die(PL_no_func, "futimes");
 #endif
                     }
                     else {

--- a/doio.c
+++ b/doio.c
@@ -506,7 +506,7 @@ Perl_do_openn(pTHX_ GV *gv, const char *oname, I32 len, int as_raw,
         /* sysopen style args, i.e. integer mode and permissions */
 
         if (num_svs != 0) {
-            Perl_croak(aTHX_ "panic: sysopen with multiple args, num_svs=%ld",
+            croak("panic: sysopen with multiple args, num_svs=%ld",
                        (long) num_svs);
         }
         return do_open_raw(gv, oname, len, rawmode, rawperm, NULL);
@@ -671,7 +671,7 @@ Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len,
             if (num_svs) {
                 if (type[1] != IoTYPE_STD) {
                   unknown_open_mode:
-                    Perl_croak(aTHX_ "Unknown open() mode '%.*s'", (int)olen, oname);
+                    croak("Unknown open() mode '%.*s'", (int)olen, oname);
                 }
                 type++;
             }
@@ -754,7 +754,7 @@ Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len,
                     UV uv;
                     if (num_svs > 1) {
                         /* diag_listed_as: More than one argument to '%s' open */
-                        Perl_croak(aTHX_ "More than one argument to '%c&' open",IoTYPE(io));
+                        croak("More than one argument to '%c&' open",IoTYPE(io));
                     }
                     while (isSPACE(*type))
                         type++;
@@ -844,7 +844,7 @@ Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len,
                     IoTYPE(io) = IoTYPE_STD;
                     if (num_svs > 1) {
                         /* diag_listed_as: More than one argument to '%s' open */
-                        Perl_croak(aTHX_ "More than one argument to '>%c' open",IoTYPE_STD);
+                        croak("More than one argument to '>%c' open",IoTYPE_STD);
                     }
                 }
                 else {
@@ -882,7 +882,7 @@ Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len,
                 IoTYPE(io) = IoTYPE_STD;
                 if (num_svs > 1) {
                     /* diag_listed_as: More than one argument to '%s' open */
-                    Perl_croak(aTHX_ "More than one argument to '<%c' open",IoTYPE_STD);
+                    croak("More than one argument to '<%c' open",IoTYPE_STD);
                 }
             }
             else {
@@ -1652,7 +1652,7 @@ S_dir_unchanged(pTHX_ const char *orig_pv, MAGIC *mg) {
         && PerlLIO_stat(".", &statbuf) >= 0
         && ( statbuf.st_dev != orig_cwd_stat->st_dev
                      || statbuf.st_ino != orig_cwd_stat->st_ino)) {
-        Perl_croak(aTHX_ "Cannot complete in-place edit of %s: %s",
+        croak("Cannot complete in-place edit of %s: %s",
                    orig_pv, "Current directory has changed");
     }
 #else
@@ -1663,7 +1663,7 @@ S_dir_unchanged(pTHX_ const char *orig_pv, MAGIC *mg) {
     */
     if (!PERL_FILE_IS_ABSOLUTE(orig_pv)
         && PerlLIO_stat(SvPVX(*temp_psv), &statbuf) < 0) {
-        Perl_croak(aTHX_ "Cannot complete in-place edit of %s: %s",
+        croak("Cannot complete in-place edit of %s: %s",
                    orig_pv,
                    "Work file is missing - did you change directory?");
     }
@@ -1777,7 +1777,7 @@ S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explict) {
 #  else
                             UNLINK(SvPVX(*temp_psv));
 #  endif
-                            Perl_croak(aTHX_ "Can't rename %s to %s: %s, skipping file",
+                            croak("Can't rename %s to %s: %s, skipping file",
                                        SvPVX(*orig_psv), SvPVX(*back_psv), Strerror(errno));
                         }
                         /* should we warn here? */
@@ -1787,7 +1787,7 @@ S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explict) {
                     (void)UNLINK(SvPVX(*back_psv));
                     if (link(orig_pv, SvPVX(*back_psv))) {
                         if (!is_explict) {
-                            Perl_croak(aTHX_ "Can't rename %s to %s: %s, skipping file",
+                            croak("Can't rename %s to %s: %s, skipping file",
                                        SvPVX(*orig_psv), SvPVX(*back_psv), Strerror(errno));
                         }
                         goto abort_inplace;
@@ -1824,7 +1824,7 @@ S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explict) {
                     UNLINK(SvPVX(*temp_psv));
 #endif
                     /* diag_listed_as: Cannot complete in-place edit of %s: %s */
-                    Perl_croak(aTHX_ "Cannot complete in-place edit of %s: failed to rename work file '%s' to '%s': %s",
+                    croak("Cannot complete in-place edit of %s: failed to rename work file '%s' to '%s': %s",
                                orig_pv, SvPVX(*temp_psv), orig_pv, Strerror(errno));
                 }
             abort_inplace:
@@ -1845,7 +1845,7 @@ S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explict) {
             UNLINK(SvPVX_const(*temp_psv));
 #endif
             if (!is_explict) {
-                Perl_croak(aTHX_ "Failed to close in-place work file %s: %s",
+                croak("Failed to close in-place work file %s: %s",
                            SvPVX(*temp_psv), Strerror(errno));
             }
         }
@@ -2123,7 +2123,7 @@ Perl_mode_from_discipline(pTHX_ const char *s, STRLEN len)
                 if (!end)
                     end = s+len;
 #ifndef PERLIO_LAYERS
-                Perl_croak(aTHX_ "IO layers (like '%.*s') unavailable", end-s, s);
+                croak("IO layers (like '%.*s') unavailable", end-s, s);
 #else
                 len -= end-s;
                 s = end;
@@ -2356,7 +2356,7 @@ Perl_my_lstat_flags(pTHX_ const U32 flags)
     if (PL_op->op_flags & OPf_REF) {
         if (cGVOP_gv == PL_defgv) {
             if (PL_laststype != OP_LSTAT)
-                Perl_croak(aTHX_ "%s", no_prev_lstat);
+                croak("%s", no_prev_lstat);
             if (PL_laststatval < 0)
                 SETERRNO(EBADF,RMS_IFI);
             return PL_laststatval;
@@ -2374,7 +2374,7 @@ Perl_my_lstat_flags(pTHX_ const U32 flags)
     if ((PL_op->op_private & (OPpFT_STACKED|OPpFT_AFTER_t))
              == OPpFT_STACKED) {
       if (PL_laststype != OP_LSTAT)
-        Perl_croak(aTHX_ "%s", no_prev_lstat);
+        croak("%s", no_prev_lstat);
       return PL_laststatval;
     }
 
@@ -2435,7 +2435,7 @@ Perl_do_aexec5(pTHX_ SV *really, SV **mark, SV **sp,
 {
     PERL_ARGS_ASSERT_DO_AEXEC5;
 #if defined(__LIBCATAMOUNT__)
-    Perl_croak(aTHX_ "exec? I'm not *that* kind of operating system");
+    croak("exec? I'm not *that* kind of operating system");
 #else
     assert(sp >= mark);
     ENTER;
@@ -2760,7 +2760,7 @@ nothing in the core.
                 len -= 3;
             }
            if ((val = whichsig_pvn(s, len)) < 0)
-               Perl_croak(aTHX_ "Unrecognized signal name \"%" SVf "\"",
+               croak("Unrecognized signal name \"%" SVf "\"",
                                 SVfARG(*mark));
         }
         else
@@ -2779,7 +2779,7 @@ nothing in the core.
             Pid_t proc;
             SvGETMAGIC(*mark);
             if (!(SvNIOK(*mark) || looks_like_number(*mark)))
-                Perl_croak(aTHX_ "Can't kill a non-numeric process ID");
+                croak("Can't kill a non-numeric process ID");
             proc = SvIV_nomg(*mark);
             APPLY_TAINT_PROPER();
 #ifdef HAS_KILLPG
@@ -3074,7 +3074,7 @@ Perl_do_ipcget(pTHX_ I32 optype, SV **mark, SV **sp)
 #if !defined(HAS_MSG) || !defined(HAS_SEM) || !defined(HAS_SHM)
     default:
         /* diag_listed_as: msg%s not implemented */
-        Perl_croak(aTHX_ "%s not implemented", PL_op_desc[optype]);
+        croak("%s not implemented", PL_op_desc[optype]);
 #endif
     }
     return -1;			/* should never happen */
@@ -3134,14 +3134,14 @@ Perl_do_ipcctl(pTHX_ I32 optype, SV **mark, SV **sp)
         }
 #else
         /* diag_listed_as: sem%s not implemented */
-        Perl_croak(aTHX_ "%s not implemented", PL_op_desc[optype]);
+        croak("%s not implemented", PL_op_desc[optype]);
 #endif
         break;
 #endif
 #if !defined(HAS_MSG) || !defined(HAS_SEM) || !defined(HAS_SHM)
     default:
         /* diag_listed_as: shm%s not implemented */
-        Perl_croak(aTHX_ "%s not implemented", PL_op_desc[optype]);
+        croak("%s not implemented", PL_op_desc[optype]);
 #endif
     }
 
@@ -3161,7 +3161,7 @@ Perl_do_ipcctl(pTHX_ I32 optype, SV **mark, SV **sp)
             STRLEN len;
             a = SvPVbyte(astr, len);
             if (len != infosize)
-                Perl_croak(aTHX_ "Bad arg length for %s, is %lu, should be %ld",
+                croak("Bad arg length for %s, is %lu, should be %ld",
                       PL_op_desc[optype],
                       (unsigned long)len,
                       (long)infosize);
@@ -3208,7 +3208,7 @@ Perl_do_ipcctl(pTHX_ I32 optype, SV **mark, SV **sp)
             ret = Semctl(id, n, cmd, unsemds);
 #else
             /* diag_listed_as: sem%s not implemented */
-            Perl_croak(aTHX_ "%s not implemented", PL_op_desc[optype]);
+            croak("%s not implemented", PL_op_desc[optype]);
 #endif
         }
         break;
@@ -3242,7 +3242,7 @@ Perl_do_msgsnd(pTHX_ SV **mark, SV **sp)
     const char * const mbuf = SvPVbyte(mstr, len);
 
     if (len < sizeof(long))
-        Perl_croak(aTHX_ "Arg too short for msgsnd");
+        croak("Arg too short for msgsnd");
 
     const STRLEN msize = len - sizeof(long);
 
@@ -3257,7 +3257,7 @@ Perl_do_msgsnd(pTHX_ SV **mark, SV **sp)
     PERL_UNUSED_ARG(sp);
     PERL_UNUSED_ARG(mark);
     /* diag_listed_as: msg%s not implemented */
-    Perl_croak(aTHX_ "msgsnd not implemented");
+    croak("msgsnd not implemented");
     return -1;
 #endif
 }
@@ -3306,7 +3306,7 @@ Perl_do_msgrcv(pTHX_ SV **mark, SV **sp)
     PERL_UNUSED_ARG(sp);
     PERL_UNUSED_ARG(mark);
     /* diag_listed_as: msg%s not implemented */
-    Perl_croak(aTHX_ "msgrcv not implemented");
+    croak("msgrcv not implemented");
     return -1;
 #endif
 }
@@ -3352,7 +3352,7 @@ Perl_do_semop(pTHX_ SV **mark, SV **sp)
     }
 #else
     /* diag_listed_as: sem%s not implemented */
-    Perl_croak(aTHX_ "semop not implemented");
+    croak("semop not implemented");
 #endif
 }
 
@@ -3444,7 +3444,7 @@ Perl_do_shmio(pTHX_ I32 optype, SV **mark, SV **sp)
     return shmdt(shm);
 #else
     /* diag_listed_as: shm%s not implemented */
-    Perl_croak_nocontext("shm I/O not implemented");
+    croak("shm I/O not implemented");
     return -1;
 #endif
 }

--- a/doop.c
+++ b/doop.c
@@ -906,8 +906,8 @@ Perl_do_vecset(pTHX_ SV *sv)
     if (errflags) {
         assert(!(errflags & ~(LVf_NEG_OFF|LVf_OUT_OF_RANGE)));
         if (errflags & LVf_NEG_OFF)
-            Perl_croak_nocontext("Negative offset to vec in lvalue context");
-        Perl_croak_nocontext("Out of memory during vec in lvalue context");
+            croak("Negative offset to vec in lvalue context");
+        croak("Out of memory during vec in lvalue context");
     }
 
     if (!targ)
@@ -937,7 +937,7 @@ Perl_do_vecset(pTHX_ SV *sv)
     else if (size > 8) {
         int n = size/8;
         if (offset > Size_t_MAX / n - 1) /* would overflow */
-            Perl_croak_nocontext("Out of memory during vec in lvalue context");
+            croak("Out of memory during vec in lvalue context");
         offset *= n;
     }
 

--- a/doop.c
+++ b/doop.c
@@ -804,7 +804,7 @@ Perl_do_vecget(pTHX_ SV *sv, STRLEN offset, int size)
     PERL_ARGS_ASSERT_DO_VECGET;
 
     if (size < 1 || ! isPOWER_OF_2(size))
-        Perl_croak(aTHX_ "Illegal number of bits in vec");
+        croak("Illegal number of bits in vec");
 
     if (SvUTF8(sv)) {
         if (Perl_sv_utf8_downgrade_flags(aTHX_ sv, TRUE, 0)) {
@@ -812,7 +812,7 @@ Perl_do_vecget(pTHX_ SV *sv, STRLEN offset, int size)
             s = (unsigned char *) SvPV_flags(sv, srclen, svpv_flags);
         }
         else {
-            Perl_croak(aTHX_ "Use of strings with code points over 0xFF"
+            croak("Use of strings with code points over 0xFF"
                              " as arguments to vec is forbidden");
         }
     }
@@ -928,7 +928,7 @@ Perl_do_vecset(pTHX_ SV *sv)
     size = LvTARGLEN(sv);
 
     if (size < 1 || (size & (size-1))) /* size < 1 or not a power of two */
-        Perl_croak(aTHX_ "Illegal number of bits in vec");
+        croak("Illegal number of bits in vec");
 
     if (size < 8) {
         bitoffs = ((offset%8)*size)%8;
@@ -1039,7 +1039,7 @@ Perl_do_vop(pTHX_ I32 optype, SV *sv, SV *left, SV *right)
      * result is the same as the other operand, so the dangling part is just
      * appended to the final result, unchanged. */
     if (left_utf8 || right_utf8) {
-        Perl_croak(aTHX_ FATAL_ABOVE_FF_MSG, PL_op_desc[optype]);
+        croak(FATAL_ABOVE_FF_MSG, PL_op_desc[optype]);
     }
     else {  /* Neither is UTF-8 */
         len = MIN(leftlen, rightlen);
@@ -1224,7 +1224,7 @@ PP(do_kv)
         const I32 flags = is_lvalue_sub();
         if (flags && !(flags & OPpENTERSUB_INARGS))
             /* diag_listed_as: Can't modify %s in %s */
-            Perl_croak(aTHX_ "Can't modify keys in list assignment");
+            croak("Can't modify keys in list assignment");
     }
 
     /* push all keys and/or values onto stack */

--- a/doop.c
+++ b/doop.c
@@ -592,7 +592,7 @@ Perl_do_trans(pTHX_ SV *sv)
     PERL_ARGS_ASSERT_DO_TRANS;
 
     if (SvREADONLY(sv) && ! identical) {
-        Perl_croak_no_modify();
+        croak_no_modify();
     }
     (void)SvPV_const(sv, len);
     if (!len)

--- a/dquote.c
+++ b/dquote.c
@@ -117,7 +117,7 @@ Perl_form_alien_digit_msg(pTHX_
 
         /* It also isn't a UTF-8 invariant character, so no display shortcuts
          * are available.  Use \\x{...} */
-        Perl_sv_setpvf(aTHX_ display_char, "\\x{%02x}", *first_bad);
+        sv_setpvf(display_char, "\\x{%02x}", *first_bad);
     }
 
     /* Ready to start building the message */
@@ -216,7 +216,7 @@ Perl_form_cp_too_large_msg(pTHX_
         prefix = "0x";
     }
 
-    Perl_sv_setpvf(aTHX_ message_sv, "Use of code point %s", prefix);
+    sv_setpvf(message_sv, "Use of code point %s", prefix);
     if (string) {
         sv_catpvf(message_sv, "%.*s", (int) len, string);
     }

--- a/dquote.c
+++ b/dquote.c
@@ -144,7 +144,7 @@ Perl_form_alien_digit_msg(pTHX_
     if (isPRINT(*first_bad)) {
         sv_catpvs(message_sv, "'");
     }
-    Perl_sv_catpvf(aTHX_ message_sv, " terminates \\%c early.  Resolved as "
+    sv_catpvf(message_sv, " terminates \\%c early.  Resolved as "
                                      "\"\\%c", symbol, symbol);
     if (braced) {
         sv_catpvs(message_sv, "{");
@@ -218,13 +218,13 @@ Perl_form_cp_too_large_msg(pTHX_
 
     Perl_sv_setpvf(aTHX_ message_sv, "Use of code point %s", prefix);
     if (string) {
-        Perl_sv_catpvf(aTHX_ message_sv, "%.*s", (int) len, string);
+        sv_catpvf(message_sv, "%.*s", (int) len, string);
     }
     else {
-        Perl_sv_catpvf(aTHX_ message_sv, format, cp);
+        sv_catpvf(message_sv, format, cp);
     }
-    Perl_sv_catpvf(aTHX_ message_sv, " is not allowed; the permissible max is %s", prefix);
-    Perl_sv_catpvf(aTHX_ message_sv, format, MAX_LEGAL_CP);
+    sv_catpvf(message_sv, " is not allowed; the permissible max is %s", prefix);
+    sv_catpvf(message_sv, format, MAX_LEGAL_CP);
 
     return SvPVX_const(message_sv);
 }

--- a/dquote.c
+++ b/dquote.c
@@ -46,7 +46,7 @@ Perl_grok_bslash_c(pTHX_ const char   source,
         const char control = toCTRL('{');
         if (isPRINT_A(control)) {
             /* diag_listed_as: Use "%s" instead of "%s" */
-            *message = Perl_form(aTHX_ PERL_DIAG_DIE_SYNTAX("Use \"%c\" instead of \"\\c{\""), control);
+            *message = form(PERL_DIAG_DIE_SYNTAX("Use \"%c\" instead of \"\\c{\""), control);
         }
         else {
             *message = "Sequence \"\\c{\" invalid";
@@ -67,7 +67,7 @@ Perl_grok_bslash_c(pTHX_ const char   source,
         clearer[i++] = '\0';
 
         if (packed_warn) {
-            *message = Perl_form(aTHX_ format, source, clearer);
+            *message = form(format, source, clearer);
             *packed_warn = packWARN(WARN_SYNTAX);
         }
         else {

--- a/dump.c
+++ b/dump.c
@@ -2972,7 +2972,7 @@ Perl_runops_debug(pTHX)
 #endif
 #ifdef PERL_USE_HWM
         if (PL_curstackinfo->si_stack_hwm < PL_stack_sp - PL_stack_base)
-            Perl_croak_nocontext(
+            croak(
                 "panic: previous op failed to extend arg stack: "
                 "base=%p, sp=%p, hwm=%p\n",
                     PL_stack_base, PL_stack_sp,

--- a/dump.c
+++ b/dump.c
@@ -300,7 +300,7 @@ Perl_pv_escape( pTHX_ SV *dsv, char const * const str,
             if (restart) {
                 /* this only happens with PERL_PV_ESCAPE_TRUNC_MIDDLE */
                 if (dsv)
-                    Perl_sv_catpvf( aTHX_ dsv,"%s...%s", qe, qs);
+                    sv_catpvf( dsv,"%s...%s", qe, qs);
                 wrote += extra_len;
                 pv = restart;
                 max = tail;
@@ -321,7 +321,7 @@ Perl_pv_escape( pTHX_ SV *dsv, char const * const str,
                how to keep it clear that it's unlike the s of catpvs, which is
                really an array of octets, not a string.  */
             if (dsv)
-                Perl_sv_catpvf( aTHX_ dsv, "%c", c);
+                sv_catpvf( dsv, "%c", c);
             wrote++;
         }
         if ( flags & PERL_PV_ESCAPE_FIRSTCHAR ) 
@@ -380,7 +380,7 @@ Perl_pv_pretty( pTHX_ SV *dsv, char const * const str, const STRLEN count,
     orig_cur= SvCUR(dsv);
 
     if ( quotes )
-        Perl_sv_catpvf(aTHX_ dsv, "%c", quotes[0]);
+        sv_catpvf(dsv, "%c", quotes[0]);
         
     if ( start_color != NULL ) 
         sv_catpv(dsv, start_color);
@@ -401,7 +401,7 @@ Perl_pv_pretty( pTHX_ SV *dsv, char const * const str, const STRLEN count,
         sv_catpv(dsv, end_color);
 
     if ( quotes )
-        Perl_sv_catpvf(aTHX_ dsv, "%c", quotes[1]);
+        sv_catpvf(dsv, "%c", quotes[1]);
     
     if ( (flags & PERL_PV_PRETTY_ELLIPSES) && ( escaped < count ) )
             sv_catpvs(dsv, "...");
@@ -538,14 +538,14 @@ Perl_sv_peek(pTHX_ SV *sv)
             }
         }
         if (is_tmp || SvREFCNT(sv) > 1 || SvPADTMP(sv)) {
-            Perl_sv_catpvf(aTHX_ t, "<");
+            sv_catpvf(t, "<");
             if (SvREFCNT(sv) > 1)
-                Perl_sv_catpvf(aTHX_ t, "%" UVuf, (UV)SvREFCNT(sv));
+                sv_catpvf(t, "%" UVuf, (UV)SvREFCNT(sv));
             if (SvPADTMP(sv))
-                Perl_sv_catpvf(aTHX_ t, "%s",  "P");
+                sv_catpvf(t, "%s",  "P");
             if (is_tmp)
-                Perl_sv_catpvf(aTHX_ t, "%s", SvTEMP(t) ? "T" : "t");
-            Perl_sv_catpvf(aTHX_ t, ">");
+                sv_catpvf(t, "%s", SvTEMP(t) ? "T" : "t");
+            sv_catpvf(t, ">");
         }
     }
 
@@ -564,7 +564,7 @@ Perl_sv_peek(pTHX_ SV *sv)
     if (type == SVt_PVCV) {
         SV * const tmp = newSVpvs_flags("", SVs_TEMP);
         GV* gvcv = CvGV(sv);
-        Perl_sv_catpvf(aTHX_ t, "CV(%s)", gvcv
+        sv_catpvf(t, "CV(%s)", gvcv
                        ? generic_pv_escape( tmp, GvNAME(gvcv), GvNAMELEN(gvcv), GvNAMEUTF8(gvcv))
                        : "");
         goto finish;
@@ -587,11 +587,11 @@ Perl_sv_peek(pTHX_ SV *sv)
             if (SvOOK(sv)) {
                 STRLEN delta;
                 SvOOK_offset(sv, delta);
-                Perl_sv_catpvf(aTHX_ t, "[%s]", pv_display(tmp, SvPVX_const(sv)-delta, delta, 0, 127));
+                sv_catpvf(t, "[%s]", pv_display(tmp, SvPVX_const(sv)-delta, delta, 0, 127));
             }
-            Perl_sv_catpvf(aTHX_ t, "%s)", pv_display(tmp, SvPVX_const(sv), SvCUR(sv), SvLEN(sv), 127));
+            sv_catpvf(t, "%s)", pv_display(tmp, SvPVX_const(sv), SvCUR(sv), SvLEN(sv), 127));
             if (SvUTF8(sv))
-                Perl_sv_catpvf(aTHX_ t, " [UTF8 \"%s\"]",
+                sv_catpvf(t, " [UTF8 \"%s\"]",
                                sv_uni_display(tmp, sv, 6 * SvCUR(sv),
                                               UNI_DISPLAY_QQ));
             SvREFCNT_dec_NN(tmp);
@@ -600,14 +600,14 @@ Perl_sv_peek(pTHX_ SV *sv)
     else if (SvNOKp(sv)) {
         DECLARATION_FOR_LC_NUMERIC_MANIPULATION;
         STORE_LC_NUMERIC_SET_STANDARD();
-        Perl_sv_catpvf(aTHX_ t, "(%" NVgf ")",SvNVX(sv));
+        sv_catpvf(t, "(%" NVgf ")",SvNVX(sv));
         RESTORE_LC_NUMERIC();
     }
     else if (SvIOKp(sv)) {
         if (SvIsUV(sv))
-            Perl_sv_catpvf(aTHX_ t, "(%" UVuf ")", (UV)SvUVX(sv));
+            sv_catpvf(t, "(%" UVuf ")", (UV)SvUVX(sv));
         else
-            Perl_sv_catpvf(aTHX_ t, "(%" IVdf ")", (IV)SvIVX(sv));
+            sv_catpvf(t, "(%" IVdf ")", (IV)SvIVX(sv));
     }
     else
         sv_catpvs(t, "()");
@@ -950,7 +950,7 @@ S_gv_display(pTHX_ GV *gv)
         if (isGV_with_GP(gv))
             gv_fullname3(raw, gv, NULL);
         else {
-            Perl_sv_catpvf(aTHX_ raw, "cv ref: %s",
+            sv_catpvf(raw, "cv ref: %s",
                     SvPV_nolen_const(cv_name(CV_FROM_REF((SV*)gv), name, 0)));
         }
         rawpv = SvPV_const(raw, len);
@@ -1310,7 +1310,7 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
                         sv_catpvs(tmpsv, "=");
                     }
                     if (enum_label == -1)
-                        Perl_sv_catpvf(aTHX_ tmpsv, "0x%" UVxf, (UV)val);
+                        sv_catpvf(tmpsv, "0x%" UVxf, (UV)val);
                     else
                         sv_catpv(tmpsv, &PL_op_private_labels[enum_label]);
 
@@ -1329,7 +1329,7 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
             }
             if (oppriv) {
                 sv_catpvs(tmpsv, ",");
-                Perl_sv_catpvf(aTHX_ tmpsv, "0x%" UVxf, (UV)oppriv);
+                sv_catpvf(tmpsv, "0x%" UVxf, (UV)oppriv);
             }
         }
         if (tmpsv && SvCUR(tmpsv)) {
@@ -2428,7 +2428,7 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
                     while (hekp < endp) {
                         if (*hekp) {
                             SV *tmp = newSVpvs_flags("", SVs_TEMP);
-                            Perl_sv_catpvf(aTHX_ names, ", \"%s\"",
+                            sv_catpvf(names, ", \"%s\"",
                               generic_pv_escape(tmp, HEK_KEY(*hekp), HEK_LEN(*hekp), HEK_UTF8(*hekp)));
                         } else {
                             /* This should never happen. */
@@ -3069,14 +3069,14 @@ S_append_padvar(pTHX_ PADOFFSET off, CV *cv, SV *out, int n,
         if (namepad && (sv = padnamelist_fetch(namepad, off + i)))
         {
             STRLEN cur = SvCUR(out);
-            Perl_sv_catpvf(aTHX_ out, "[%" UTF8f,
+            sv_catpvf(out, "[%" UTF8f,
                                  UTF8fARG(1, PadnameLEN(sv) - 1,
                                           PadnamePV(sv) + 1));
             if (is_scalar)
                 SvPVX(out)[cur] = '$';
         }
         else
-            Perl_sv_catpvf(aTHX_ out, "[%" UVuf "]", (UV)(off+i));
+            sv_catpvf(out, "[%" UVuf "]", (UV)(off+i));
         if (i < n - 1)
             sv_catpvs_nomg(out, ",");
     }
@@ -3095,7 +3095,7 @@ S_append_gv_name(pTHX_ GV *gv, SV *out)
     }
     sv = newSV_type(SVt_NULL);
     gv_fullname4(sv, gv, NULL, FALSE);
-    Perl_sv_catpvf(aTHX_ out, "$%" SVf, SVfARG(sv));
+    sv_catpvf(out, "$%" SVf, SVfARG(sv));
     SvREFCNT_dec_NN(sv);
 }
 
@@ -3216,7 +3216,7 @@ Perl_multideref_stringify(pTHX_ const OP *o, CV *cv)
                     }
                 }
                 else
-                    Perl_sv_catpvf(aTHX_ out, "%" IVdf, (++items)->iv);
+                    sv_catpvf(out, "%" IVdf, (++items)->iv);
                 break;
             case MDEREF_INDEX_padsv:
                 S_append_padvar(aTHX_ (++items)->pad_offset, cv, out, 1, 0, 1);
@@ -3283,7 +3283,7 @@ Perl_multiconcat_stringify(pTHX_ const OP *o)
 
     lens = aux + PERL_MULTICONCAT_IX_LENGTHS;
     while (nargs-- >= 0) {
-        Perl_sv_catpvf(aTHX_ out, ",%" IVdf, (IV)lens->ssize);
+        sv_catpvf(out, ",%" IVdf, (IV)lens->ssize);
         lens++;
     }
     return out;

--- a/dump.c
+++ b/dump.c
@@ -3494,7 +3494,7 @@ Perl_op_class(pTHX_ const OP *o)
     case OA_UNOP_AUX:
         return OPclass_UNOP_AUX;
     }
-    Perl_warn(aTHX_ "Can't determine class of operator %s, assuming BASEOP\n",
+    warn("Can't determine class of operator %s, assuming BASEOP\n",
          OP_NAME(o));
     return OPclass_BASEOP;
 }

--- a/embed.fnc
+++ b/embed.fnc
@@ -2443,7 +2443,7 @@ Adp	|OP *	|op_prepend_elem|I32 optype				\
 Cdp	|void	|op_refcnt_lock
 Cdp	|void	|op_refcnt_unlock
 Adpx	|OP *	|op_scope	|NULLOK OP *o
-ATdp	|OP *	|op_sibling_splice					\
+Adp	|OP *	|op_sibling_splice					\
 				|NULLOK OP *parent			\
 				|NULLOK OP *start			\
 				|int del_count				\

--- a/embed.h
+++ b/embed.h
@@ -505,7 +505,7 @@
 # define op_refcnt_lock()                       Perl_op_refcnt_lock(aTHX)
 # define op_refcnt_unlock()                     Perl_op_refcnt_unlock(aTHX)
 # define op_scope(a)                            Perl_op_scope(aTHX_ a)
-# define op_sibling_splice                      Perl_op_sibling_splice
+# define op_sibling_splice(a,b,c,d)             Perl_op_sibling_splice(aTHX_ a,b,c,d)
 # define op_wrap_finally(a,b)                   Perl_op_wrap_finally(aTHX_ a,b)
 # define opdump_printf(a,...)                   Perl_opdump_printf(aTHX_ a,__VA_ARGS__)
 # define packlist(a,b,c,d,e)                    Perl_packlist(aTHX_ a,b,c,d,e)

--- a/gv.c
+++ b/gv.c
@@ -79,7 +79,7 @@ Perl_gv_add_by_type(pTHX_ GV *gv, svtype type)
         } else {
             what = type == SVt_PVAV ? "array" : "scalar";
         }
-        Perl_croak(aTHX_ "Bad symbol for %s", what);
+        croak("Bad symbol for %s", what);
     }
 
     if (type == SVt_PVHV) {
@@ -468,7 +468,7 @@ Perl_gv_init_pvn(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, U32 flag
         case SVt_PVHV:
         case SVt_PVFM:
         case SVt_PVIO:
-            Perl_croak(aTHX_ "Cannot convert a reference to %s to typeglob",
+            croak("Cannot convert a reference to %s to typeglob",
                        sv_reftype(has_constant, 0));
             NOT_REACHED; /* NOTREACHED */
             break;
@@ -877,7 +877,7 @@ S_gv_fetchmeth_internal(pTHX_ HV* stash, SV* meth, const char* name, STRLEN len,
     hvname = HvNAME_get(stash);
     hvnamelen = HvNAMELEN_get(stash);
     if (!hvname)
-      Perl_croak(aTHX_ "Can't use anonymous symbol table for method lookup");
+      croak("Can't use anonymous symbol table for method lookup");
 
     assert(hvname);
     assert(name || meth);
@@ -1246,7 +1246,7 @@ Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN le
                     if (gv)
                         return gv;
                 }
-                Perl_croak(aTHX_
+                croak(
                            "Can't locate object method %" UTF8f_QUOTEDPREFIX ""
                            " via package %" HEKf_QUOTEDPREFIX,
                                     UTF8fARG(is_utf8, name_end - name, name),
@@ -1262,7 +1262,7 @@ Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN le
                     packnamesv = error_report;
                 }
 
-                Perl_croak(aTHX_
+                croak(
                            "Can't locate object method %" UTF8f_QUOTEDPREFIX ""
                            " via package %" SVf_QUOTEDPREFIX ""
                            " (perhaps you forgot to load %" SVf_QUOTEDPREFIX "?)",
@@ -1404,7 +1404,7 @@ Perl_gv_autoload_pvn(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags)
         !(flags & GV_AUTOLOAD_ISMETHOD)
      && (GvCVGEN(gv) || GvSTASH(gv) != stash)
     )
-        Perl_croak(aTHX_ "Use of inherited AUTOLOAD for non-method %" SVf
+        croak("Use of inherited AUTOLOAD for non-method %" SVf
                          "::%" UTF8f "() is no longer allowed",
                          SVfARG(packname),
                          UTF8fARG(is_utf8, len, name));
@@ -1547,10 +1547,10 @@ S_require_tie_mod(pTHX_ GV *gv, const char varname, const char * name,
         assert(sp == PL_stack_sp);
         stash = gv_stashpvn(name, len, 0);
         if (!stash)
-            Perl_croak(aTHX_ "panic: Can't use %c%c because %s is not available",
+            croak("panic: Can't use %c%c because %s is not available",
                     type, varname, name);
         else if (! GET_HV_FETCH_TIE_FUNC)
-            Perl_croak(aTHX_ "panic: Can't use %c%c because %s does not define _tie_it",
+            croak("panic: Can't use %c%c because %s does not define _tie_it",
                     type, varname, name);
       }
       /* Now call the tie function.  It should be in *gvp.  */
@@ -2400,7 +2400,7 @@ S_gv_magicalize(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len,
         case '#':		/* $# */
         if (sv_type == SVt_PV)
             /* diag_listed_as: $* is no longer supported as of Perl 5.30 */
-            Perl_croak(aTHX_ "$%c is no longer supported as of Perl 5.30", *name);
+            croak("$%c is no longer supported as of Perl 5.30", *name);
         break;
         case '\010':	/* $^H */
             {
@@ -2505,7 +2505,7 @@ S_maybe_multimagic_gv(pTHX_ GV *gv, const char *name, const svtype sv_type)
     } else if (sv_type == SVt_PV) {
         if (*name == '*' || *name == '#') {
             /* diag_listed_as: $* is no longer supported as of Perl 5.30 */
-            Perl_croak(aTHX_ "$%c is no longer supported as of Perl 5.30", *name);
+            croak("$%c is no longer supported as of Perl 5.30", *name);
         }
     }
     if (sv_type==SVt_PV || sv_type==SVt_PVGV) {
@@ -3272,7 +3272,7 @@ Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing)
                                                     ? gvsv
                                                     : newSVpvs_flags("???", SVs_TEMP);
                         /* diag_listed_as: Can't resolve method "%s" overloading "%s" in package "%s" */
-                        Perl_croak(aTHX_ "%s method \"%" SVf256
+                        croak("%s method \"%" SVf256
                                     "\" overloading \"%s\" "\
                                     "in package \"%" HEKf256 "\"",
                                    (GvCVGEN(gv) ? "Stub found while resolving"
@@ -3713,7 +3713,7 @@ Perl_amagic_deref_call(pTHX_ SV *ref, int method) {
     while ((tmpsv = amagic_call(ref, &PL_sv_undef, method,
                                 AMGf_noright | AMGf_unary))) {
         if (!SvROK(tmpsv))
-            Perl_croak(aTHX_ "Overloaded dereference did not return a reference");
+            croak("Overloaded dereference did not return a reference");
         if (tmpsv == ref || SvRV(tmpsv) == SvRV(ref)) {
             /* Bail out if it returns us the same reference.  */
             return tmpsv;
@@ -4029,7 +4029,7 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int flags)
         if (use_default_op) {
           DEBUG_o( Perl_deb(aTHX_ "%" SVf, SVfARG(msg)) );
         } else {
-          Perl_croak(aTHX_ "%" SVf, SVfARG(msg));
+          croak("%" SVf, SVfARG(msg));
         }
         return NULL;
       }
@@ -4288,7 +4288,7 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int flags)
       return boolSV(ans);
     } else if (method==copy_amg) {
       if (!SvROK(res)) {
-        Perl_croak(aTHX_ "Copy method did not return a reference");
+        croak("Copy method did not return a reference");
       }
       return SvREFCNT_inc(SvRV(res));
     } else {
@@ -4317,7 +4317,7 @@ Perl_gv_name_set(pTHX_ GV *gv, const char *name, U32 len, U32 flags)
     PERL_ARGS_ASSERT_GV_NAME_SET;
 
     if (len > I32_MAX)
-        Perl_croak(aTHX_ "panic: gv name too long (%" UVuf ")", (UV) len);
+        croak("panic: gv name too long (%" UVuf ")", (UV) len);
 
     if (!(flags & GV_ADD) && GvNAME_HEK(gv)) {
         unshare_hek(GvNAME_HEK(gv));
@@ -4427,7 +4427,7 @@ Perl_gv_override(pTHX_ const char * const name, const STRLEN len)
 static void
 core_xsub(pTHX_ CV* cv)
 {
-    Perl_croak(aTHX_
+    croak(
        "&CORE::%s cannot be called directly", GvNAME(CvGV(cv))
     );
 }

--- a/gv.c
+++ b/gv.c
@@ -2883,7 +2883,7 @@ Perl_newGVgen_flags(pTHX_ const char *pack, U32 flags)
     PERL_ARGS_ASSERT_NEWGVGEN_FLAGS;
     assert(!(flags & ~SVf_UTF8));
 
-    return gv_fetchpv(Perl_form(aTHX_ "%" UTF8f "::_GEN_%ld",
+    return gv_fetchpv(form("%" UTF8f "::_GEN_%ld",
                                 UTF8fARG(flags, strlen(pack), pack),
                                 (long)PL_gensym++),
                       GV_ADD, SVt_PVGV);

--- a/gv.c
+++ b/gv.c
@@ -3107,7 +3107,7 @@ Perl_gp_free(pTHX_ GV *gv)
        && !gp->gp_form) break;
 
       if (--attempts == 0) {
-        Perl_die(aTHX_
+        die(
           "panic: gp_free failed to free glob pointer - "
           "something is repeatedly re-creating entries"
         );

--- a/hv.c
+++ b/hv.c
@@ -320,7 +320,7 @@ S_hv_notallowed(pTHX_ int flags, const char *key, I32 klen,
     if (flags & HVhek_UTF8) {
         SvUTF8_on(sv);
     }
-    Perl_croak(aTHX_ msg, SVfARG(sv));
+    croak(msg, SVfARG(sv));
 }
 
 /* (klen == HEf_SVKEY) is special for MAGICAL hv entries, meaning key slot
@@ -890,7 +890,7 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
                        so putting this test here is cheap  */
                     if (flags & HVhek_FREEKEY)
                         Safefree(key);
-                    Perl_croak(aTHX_ S_strtab_error,
+                    croak(S_strtab_error,
                                action & HV_FETCH_LVALUE ? "fetch" : "store");
                 }
                 else {
@@ -1018,7 +1018,7 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
            this test here is cheap  */
         if (flags & HVhek_FREEKEY)
             Safefree(key);
-        Perl_croak(aTHX_ S_strtab_error,
+        croak(S_strtab_error,
                    action & HV_FETCH_LVALUE ? "fetch" : "store");
     }
     else {
@@ -1444,7 +1444,7 @@ S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
         if (hv == PL_strtab) {
             if (k_flags & HVhek_FREEKEY)
                 Safefree(key);
-            Perl_croak(aTHX_ S_strtab_error, "delete");
+            croak(S_strtab_error, "delete");
         }
 
         sv = HeVAL(entry);
@@ -2611,7 +2611,7 @@ Perl_hv_rand_set(pTHX_ HV *hv, U32 new_xhv_rand) {
     }
     iter->xhv_rand = new_xhv_rand;
 #else
-    Perl_croak(aTHX_ "This Perl has not been built with support for randomized hash key traversal but something called Perl_hv_rand_set().");
+    croak("This Perl has not been built with support for randomized hash key traversal but something called Perl_hv_rand_set().");
 #endif
 }
 
@@ -2677,7 +2677,7 @@ Perl_hv_name_set(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
     PERL_ARGS_ASSERT_HV_NAME_SET;
 
     if (len > I32_MAX)
-        Perl_croak(aTHX_ "panic: hv name too long (%" UVuf ")", (UV) len);
+        croak("panic: hv name too long (%" UVuf ")", (UV) len);
 
     if (HvHasAUX(hv)) {
         iter = HvAUX(hv);
@@ -2781,7 +2781,7 @@ Perl_hv_ename_add(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
     PERL_ARGS_ASSERT_HV_ENAME_ADD;
 
     if (len > I32_MAX)
-        Perl_croak(aTHX_ "panic: hv name too long (%" UVuf ")", (UV) len);
+        croak("panic: hv name too long (%" UVuf ")", (UV) len);
 
     PERL_HASH(hash, name, len);
 
@@ -2843,7 +2843,7 @@ Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
     PERL_ARGS_ASSERT_HV_ENAME_DELETE;
 
     if (len > I32_MAX)
-        Perl_croak(aTHX_ "panic: hv name too long (%" UVuf ")", (UV) len);
+        croak("panic: hv name too long (%" UVuf ")", (UV) len);
 
     if (!HvHasAUX(hv)) return;
 
@@ -3583,7 +3583,7 @@ S_refcounted_he_value(pTHX_ const struct refcounted_he *he)
             SvUTF8_on(value);
         break;
     default:
-        Perl_croak(aTHX_ "panic: refcounted_he_value bad flags %" UVxf,
+        croak("panic: refcounted_he_value bad flags %" UVxf,
                    (UV)he->refcounted_he_data[0]);
     }
     return value;
@@ -3605,7 +3605,7 @@ Perl_refcounted_he_chain_2hv(pTHX_ const struct refcounted_he *chain, U32 flags)
     U32 placeholders, max;
 
     if (flags)
-        Perl_croak(aTHX_ "panic: refcounted_he_chain_2hv bad flags %" UVxf,
+        croak("panic: refcounted_he_chain_2hv bad flags %" UVxf,
             (UV)flags);
 
     /* We could chase the chain once to get an idea of the number of keys,
@@ -3724,7 +3724,7 @@ Perl_refcounted_he_fetch_pvn(pTHX_ const struct refcounted_he *chain,
     void * free_me = NULL;
 
     if (flags & ~(REFCOUNTED_HE_KEY_UTF8|REFCOUNTED_HE_EXISTS))
-        Perl_croak(aTHX_ "panic: refcounted_he_fetch_pvn bad flags %" UVxf,
+        croak("panic: refcounted_he_fetch_pvn bad flags %" UVxf,
             (UV)flags);
     if (!chain)
         goto ret;
@@ -3799,7 +3799,7 @@ Perl_refcounted_he_fetch_sv(pTHX_ const struct refcounted_he *chain,
     STRLEN keylen;
     PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_SV;
     if (flags & REFCOUNTED_HE_KEY_UTF8)
-        Perl_croak(aTHX_ "panic: refcounted_he_fetch_sv bad flags %" UVxf,
+        croak("panic: refcounted_he_fetch_sv bad flags %" UVxf,
             (UV)flags);
     keypv = SvPV_const(key, keylen);
     if (SvUTF8(key))
@@ -3961,7 +3961,7 @@ Perl_refcounted_he_new_sv(pTHX_ struct refcounted_he *parent,
     STRLEN keylen;
     PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_SV;
     if (flags & REFCOUNTED_HE_KEY_UTF8)
-        Perl_croak(aTHX_ "panic: refcounted_he_new_sv bad flags %" UVxf,
+        croak("panic: refcounted_he_new_sv bad flags %" UVxf,
             (UV)flags);
     keypv = SvPV_const(key, keylen);
     if (SvUTF8(key))
@@ -4101,7 +4101,7 @@ Perl_cop_store_label(pTHX_ COP *const cop, const char *label, STRLEN len,
     PERL_ARGS_ASSERT_COP_STORE_LABEL;
 
     if (flags & ~(SVf_UTF8))
-        Perl_croak(aTHX_ "panic: cop_store_label illegal flag bits 0x%" UVxf,
+        croak("panic: cop_store_label illegal flag bits 0x%" UVxf,
                    (UV)flags);
     labelsv = newSVpvn_flags(label, len, SVs_TEMP);
     if (flags & SVf_UTF8)

--- a/hv.c
+++ b/hv.c
@@ -1272,7 +1272,7 @@ Perl_hv_bucket_ratio(pTHX_ HV *hv)
 
     if (HvUSEDKEYS((HV *)hv)) {
         sv = sv_newmortal();
-        Perl_sv_setpvf(aTHX_ sv, "%ld/%ld",
+        sv_setpvf(sv, "%ld/%ld",
                 (long)HvFILL(hv), (long)HvMAX(hv) + 1);
     }
     else

--- a/hv.c
+++ b/hv.c
@@ -2072,7 +2072,7 @@ Perl_hv_clear(pTHX_ HV *hv)
                     if (HeVAL(entry)) {
                         if (SvREADONLY(HeVAL(entry))) {
                             SV* const keysv = hv_iterkeysv(entry);
-                            Perl_croak_nocontext(
+                            croak(
                                 "Attempt to delete readonly key '%" SVf "' from a restricted hash",
                                 (void*)keysv);
                         }
@@ -3410,7 +3410,7 @@ S_share_hek_flags(pTHX_ const char *str, STRLEN len, U32 hash, int flags)
     assert(!(flags & HVhek_NOTSHARED));
 
     if (UNLIKELY(len > (STRLEN) I32_MAX)) {
-        Perl_croak_nocontext("Sorry, hash keys must be smaller than 2**31 bytes");
+        croak("Sorry, hash keys must be smaller than 2**31 bytes");
     }
 
     /* what follows is the moral equivalent of:

--- a/hv.c
+++ b/hv.c
@@ -3499,7 +3499,7 @@ Perl_hv_placeholders_p(pTHX_ HV *hv)
         mg = sv_magicext(MUTABLE_SV(hv), 0, PERL_MAGIC_rhash, 0, 0, 0);
 
         if (!mg) {
-            Perl_die(aTHX_ "panic: hv_placeholders_p");
+            die("panic: hv_placeholders_p");
         }
     }
     return &(mg->mg_len);
@@ -3543,7 +3543,7 @@ Perl_hv_placeholders_set(pTHX_ HV *hv, I32 ph)
         mg->mg_len = ph;
     } else if (ph) {
         if (!sv_magicext(MUTABLE_SV(hv), 0, PERL_MAGIC_rhash, 0, 0, ph))
-            Perl_die(aTHX_ "panic: hv_placeholders_set");
+            die("panic: hv_placeholders_set");
     }
     /* else we don't need to add magic to record 0 placeholders.  */
 }

--- a/locale.c
+++ b/locale.c
@@ -347,11 +347,11 @@ static int debug_initialization = 0;
         const char * errno_string;                                          \
         if (GET_ERRNO == 0) { /* Skip output if both errno types are 0 */   \
             if (LIKELY(extended == 0)) errno_string = "";                   \
-            else errno_string = Perl_form(aTHX_ "; $^E=%d", extended);      \
+            else errno_string = form("; $^E=%d", extended);                 \
         }                                                                   \
         else if (LIKELY(extended == GET_ERRNO))                             \
-            errno_string = Perl_form(aTHX_ "; $!=%d", GET_ERRNO);           \
-        else errno_string = Perl_form(aTHX_ "; $!=%d, $^E=%d",              \
+            errno_string = form("; $!=%d", GET_ERRNO);                      \
+        else errno_string = form("; $!=%d, $^E=%d",                         \
                                                     GET_ERRNO, extended);
 #  else
      /* Output the errno, if non-zero */
@@ -360,7 +360,7 @@ static int debug_initialization = 0;
         const char * errno_string = "";                                     \
         if (GET_ERRNO != 0) {                                               \
             dTHX;                                                           \
-            errno_string = Perl_form(aTHX_ "; $!=%d", GET_ERRNO);           \
+            errno_string = form("; $!=%d", GET_ERRNO);                      \
         }
 #  endif
 
@@ -956,14 +956,14 @@ S_get_displayable_string(pTHX_
             if (cp == ' ' || cp == '\\') {
                 my_strlcat(ret, "\\", size);
             }
-            my_strlcat(ret, Perl_form(aTHX_ "%c", (U8) cp), size);
+            my_strlcat(ret, form("%c", (U8) cp), size);
             prev_was_printable = TRUE;
         }
         else {
             if (! first_time) {
                 my_strlcat(ret, " ", size);
             }
-            my_strlcat(ret, Perl_form(aTHX_ "%02" UVXf, cp), size);
+            my_strlcat(ret, form("%02" UVXf, cp), size);
             prev_was_printable = FALSE;
         }
         t += (is_utf8) ? UTF8SKIP(t) : 1;
@@ -1021,7 +1021,7 @@ S_get_category_index_helper(pTHX_ const int category, bool * succeeded,
         return LC_ALL_INDEX_;   /* Arbitrary */
     }
 
-    locale_panic_via_(Perl_form(aTHX_ "Unknown locale category %d", category),
+    locale_panic_via_(form("Unknown locale category %d", category),
                       __FILE__, caller_line);
     NOT_REACHED; /* NOTREACHED */
 }
@@ -1096,7 +1096,7 @@ Perl_locale_panic(const char * msg,
     if (   strNE(__FILE__, higher_caller_file)
         || immediate_caller_line != higher_caller_line)
     {
-        called_by = Perl_form(aTHX_ "\nCalled by %s: %" LINE_Tf "\n",
+        called_by = form("\nCalled by %s: %" LINE_Tf "\n",
                                     higher_caller_file, higher_caller_line);
     }
 
@@ -1108,7 +1108,7 @@ Perl_locale_panic(const char * msg,
 
     const int extended_errnum = get_extended_os_errno();
     if (errno != extended_errnum) {
-        errno_text = Perl_form(aTHX_ "; errno=%d, $^E=%d",
+        errno_text = form("; errno=%d, $^E=%d",
                                      errno, extended_errnum);
     }
     else
@@ -1116,7 +1116,7 @@ Perl_locale_panic(const char * msg,
 #endif
 
     {
-        errno_text = Perl_form(aTHX_ "; errno=%d", errno);
+        errno_text = form("; errno=%d", errno);
     }
 
     /* diag_listed_as: panic: %s */
@@ -1158,7 +1158,7 @@ Perl_locale_panic(const char * msg,
                 const char * temp = savepvn(s, len);                        \
                 result = savepv(override_ignored_category(i, temp));        \
                 if (action == check_that_overridden && strNE(result, temp)) { \
-                    locale_panic_(Perl_form(aTHX_                           \
+                    locale_panic_(form(                                     \
                                 "%s expected to be '%s', instead is '%s'",  \
                                 category_names[i], result, temp));          \
                 }                                                           \
@@ -1480,7 +1480,7 @@ S_parse_LC_ALL_string(pTHX_ const char * string,
             break;
     }
 
-    msg = Perl_form(aTHX_ "'%.*s' %s\n",
+    msg = form("'%.*s' %s\n",
                           (int) (display_end - display_start),
                           display_start, msg);
 
@@ -2587,7 +2587,7 @@ S_bool_setlocale_2008_i(pTHX_
      * now switch into it */
     if (! uselocale(new_obj)) {
         freelocale(new_obj);
-        locale_panic_(Perl_form(aTHX_ "(called from %" LINE_Tf "):"
+        locale_panic_(form("(called from %" LINE_Tf "):"
                                       " bool_setlocale_2008_i: switching"
                                       " into new locale failed",
                                       caller_line));
@@ -3142,7 +3142,7 @@ S_calculate_LC_ALL_string(pTHX_ const char ** category_locales_list,
             }
 
             /* If would have overflowed, panic */
-            locale_panic_via_(Perl_form(aTHX_
+            locale_panic_via_(form(
                                         "Internal length calculation wrong.\n"
                                         "\"%s\" was not entirely added to"
                                         " \"%.*s\"; needed=%zu, had=%zu",
@@ -3399,14 +3399,14 @@ S_setlocale_failure_panic_via_i(pTHX_
     const char * proxy_text = "";
     if (proxy_caller_line != 0 && proxy_caller_line != immediate_caller_line)
     {
-        proxy_text = Perl_form(aTHX_ "\nCalled via %s: %" LINE_Tf,
+        proxy_text = form("\nCalled via %s: %" LINE_Tf,
                                       __FILE__, proxy_caller_line);
     }
     if (   strNE(__FILE__, higher_caller_file)
         || (   immediate_caller_line != 0
             && immediate_caller_line != higher_caller_line))
     {
-        proxy_text = Perl_form(aTHX_ "%s\nCalled via %s: %" LINE_Tf,
+        proxy_text = form("%s\nCalled via %s: %" LINE_Tf,
                                       proxy_text, __FILE__,
                                       immediate_caller_line);
     }
@@ -3414,7 +3414,7 @@ S_setlocale_failure_panic_via_i(pTHX_
     /* 'false' in the get_displayable_string() calls makes it not think the
      * locale is UTF-8, so just dumps bytes.  Actually figuring it out can be
      * too complicated for a panic situation. */
-    const char * msg = Perl_form(aTHX_
+    const char * msg = form(
                             "Can't change locale for %s (%d) from '%s' to '%s'"
                             " %s",
                             name, cat,
@@ -3854,7 +3854,7 @@ S_new_ctype(pTHX_ const char *newctype, bool force)
                               "Unsupported, MB_CUR_MAX=%d\n", mb_cur_max));
 
         if (! IN_LC(LC_CTYPE) || ckWARN_d(WARN_LOCALE)) {
-            char * msg = Perl_form(aTHX_
+            char * msg = form(
                                    "Locale '%s' is unsupported, and may hang"
                                    " or crash the interpreter",
                                      newctype);
@@ -4619,7 +4619,7 @@ S_my_setlocale_debug_string_i(pTHX_
 #    define THREAD_ARGUMENT
 #  endif
 
-    return Perl_form(aTHX_
+    return form(
                      "%s:%" LINE_Tf ": " THREAD_FORMAT
                      " setlocale(%s[%d], %s%s%s) returned %s%s%s\n",
 
@@ -4664,7 +4664,7 @@ S_toggle_locale_i(pTHX_ const locale_category_index cat_index,
                            caller_line));
 
     if (! locale_to_restore_to) {
-        locale_panic_via_(Perl_form(aTHX_
+        locale_panic_via_(form(
                                     "Could not find current %s locale",
                                     category_names[cat_index]),
                          __FILE__, caller_line);
@@ -5084,7 +5084,7 @@ S_save_to_buffer(pTHX_ const char * string, char **buf, Size_t *buf_size)
     /* Catch glitches.  Usually this is because LC_CTYPE needs to be the same
      * locale as whatever is being worked on */
     if (UNLIKELY(instr(string, REPLACEMENT_CHARACTER_UTF8))) {
-        locale_panic_(Perl_form(aTHX_
+        locale_panic_(form(
                                 "Unexpected REPLACEMENT_CHARACTER in '%s'\n%s",
                                 string, get_LC_ALL_display()));
     }
@@ -5443,7 +5443,7 @@ S_my_localeconv(pTHX_ const int item)
 
         switch (item) {
           default:
-            locale_panic_(Perl_form(aTHX_
+            locale_panic_(form(
                           "Unexpected item passed to my_localeconv: %d", item));
             break;
 
@@ -6603,7 +6603,7 @@ S_langinfo_sv_i(pTHX_
              * of this bug */
             case CODESET:
 #  endif
-                locale_panic_(Perl_form(aTHX_
+                locale_panic_(form(
                                         "nl_langinfo returned empty for %ld"
                                         " in supposed locale \n'%s';"
                                         " which really is\n'%s'\n"
@@ -6679,7 +6679,7 @@ S_langinfo_sv_i(pTHX_
                  * represents even only the first 10 alternative digits, it
                  * will be much longer than that.  So to reach here, the
                  * separator must be some other byte. */
-                locale_panic_(Perl_form(aTHX_
+                locale_panic_(form(
                                         "Can't find separator in ALT_DIGITS"
                                         " representation '%s' for locale '%s'",
                                         _byte_dump_string((U8 *) retval,
@@ -9030,7 +9030,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
      * malloc'd in the interim.  We arbitrarily switch to the C locale,
      * overridden below  */
     if (! uselocale(PL_C_locale_obj)) {
-        locale_panic_(Perl_form(aTHX_
+        locale_panic_(form(
                                 "Can't uselocale(0x%p), LC_ALL supposed to"
                                 " be 'C'",
                                 PL_C_locale_obj));
@@ -10950,7 +10950,7 @@ Perl_switch_locale_context(pTHX)
 #  ifdef USE_POSIX_2008_LOCALE
 
     if (! uselocale(PL_cur_locale_obj)) {
-        locale_panic_(Perl_form(aTHX_
+        locale_panic_(form(
                                 "Can't uselocale(0x%p), LC_ALL supposed to"
                                 " be '%s'",
                                 PL_cur_locale_obj, get_LC_ALL_display()));
@@ -10959,7 +10959,7 @@ Perl_switch_locale_context(pTHX)
 #  elif defined(WIN32)
 
     if (! bool_setlocale_c(LC_ALL, PL_cur_LC_ALL)) {
-        locale_panic_(Perl_form(aTHX_ "Can't setlocale(%s)", PL_cur_LC_ALL));
+        locale_panic_(form("Can't setlocale(%s)", PL_cur_LC_ALL));
     }
 
 #  endif
@@ -10991,7 +10991,7 @@ Perl_thread_locale_init(pTHX)
 
         /* Not being able to change to the C locale is severe; don't keep
          * going.  */
-        locale_panic_(Perl_form(aTHX_
+        locale_panic_(form(
                                 "Can't uselocale(0x%p), 'C'", PL_C_locale_obj));
         NOT_REACHED; /* NOTREACHED */
     }

--- a/locale.c
+++ b/locale.c
@@ -7316,7 +7316,7 @@ S_emulate_langinfo(pTHX_ const PERL_INTMAX_T item,
              * invalid. */;
 #  if defined(I_LANGINFO)
 
-            Perl_croak_nocontext("panic: Unexpected nl_langinfo() item %jd",
+            croak("panic: Unexpected nl_langinfo() item %jd",
                                  item);
 
 #  else

--- a/locale.c
+++ b/locale.c
@@ -7075,7 +7075,7 @@ S_emulate_langinfo(pTHX_ const PERL_INTMAX_T item,
 
         const char * orig_CTYPE_locale;
         orig_CTYPE_locale = toggle_locale_c(LC_CTYPE, locale);
-        Perl_sv_setpvf(aTHX_ sv, CODE_PAGE_FORMAT, CODE_PAGE_FUNCTION);
+        sv_setpvf(sv, CODE_PAGE_FORMAT, CODE_PAGE_FUNCTION);
         retval_type = RETVAL_IN_sv;
 
         /* We just assume the codeset is ASCII; no need to check for it being

--- a/locale.c
+++ b/locale.c
@@ -1120,7 +1120,7 @@ Perl_locale_panic(const char * msg,
     }
 
     /* diag_listed_as: panic: %s */
-    Perl_croak(aTHX_ "%s: %" LINE_Tf ": panic: %s%s%s\n",
+    croak("%s: %" LINE_Tf ": panic: %s%s%s\n",
                      __FILE__, immediate_caller_line,
                      msg, errno_text, called_by);
 }
@@ -8450,7 +8450,7 @@ S_strftime_tm(pTHX_ const char *fmt,
     bool succeeded = false;
 
 #ifndef HAS_STRFTIME
-    Perl_croak(aTHX_ "panic: no strftime");
+    croak("panic: no strftime");
 #endif
 
     start_DEALING_WITH_MISMATCHED_CTYPE(locale);

--- a/locale.c
+++ b/locale.c
@@ -4035,14 +4035,14 @@ S_new_ctype(pTHX_ const char *newctype, bool force)
             }
 
             if (PL_in_utf8_CTYPE_locale) {
-                Perl_sv_catpvf(aTHX_ PL_warn_locale,
+                sv_catpvf(PL_warn_locale,
                      "Locale '%s' contains (at least) the following characters"
                      " which have\nunexpected meanings: %s\nThe Perl program"
                      " will use the expected meanings",
                       newctype, bad_chars_list);
             }
             else {
-                Perl_sv_catpvf(aTHX_ PL_warn_locale,
+                sv_catpvf(PL_warn_locale,
                                   "\nThe following characters (and maybe"
                                   " others) may not have the same meaning as"
                                   " the Perl program expects: %s\n",
@@ -4052,12 +4052,12 @@ S_new_ctype(pTHX_ const char *newctype, bool force)
 
 #    if defined(HAS_SOME_LANGINFO) || defined(WIN32)
 
-            Perl_sv_catpvf(aTHX_ PL_warn_locale, "; codeset=%s",
+            sv_catpvf(PL_warn_locale, "; codeset=%s",
                                  langinfo_c(CODESET, LC_CTYPE, newctype, NULL));
 
 #    endif
 
-            Perl_sv_catpvf(aTHX_ PL_warn_locale, "\n");
+            sv_catpvf(PL_warn_locale, "\n");
 
             /* If we are actually in the scope of the locale or are debugging,
              * output the message now.  If not in that scope, we save the

--- a/mg.c
+++ b/mg.c
@@ -323,7 +323,7 @@ Perl_mg_size(pTHX_ SV *sv)
         case SVt_PVHV:
             /* FIXME */
         default:
-            Perl_croak(aTHX_ "Size magic not implemented");
+            croak("Size magic not implemented");
 
     }
     NOT_REACHED; /* NOTREACHED */
@@ -1637,7 +1637,7 @@ Perl_csighandler3(int sig, Siginfo_t *sip PERL_UNUSED_DECL, void *uap PERL_UNUSE
 #endif
         /* Add one to say _a_ signal is pending */
         if (++PL_sig_pending >= SIG_PENDING_DIE_COUNT)
-            Perl_croak(aTHX_ "Maximal count of pending signals (%lu) exceeded",
+            croak("Maximal count of pending signals (%lu) exceeded",
                        (unsigned long)SIG_PENDING_DIE_COUNT);
     }
 }
@@ -1759,7 +1759,7 @@ Perl_magic_setsig(pTHX_ SV *sv, MAGIC *mg)
         }
         else if (sv) {
             SV *tmp = sv_newmortal();
-            Perl_croak(aTHX_ "No such hook: %s",
+            croak("No such hook: %s",
                                 pv_pretty(tmp, s, len, 0, NULL, NULL, 0));
         }
         i = 0;
@@ -1927,7 +1927,7 @@ Perl_magic_sethook(pTHX_ SV *sv, MAGIC *mg)
     }
     else {
         SV *tmp = sv_newmortal();
-        Perl_croak(aTHX_ "Attempt to set unknown hook '%s' in %%{^HOOK}",
+        croak("Attempt to set unknown hook '%s' in %%{^HOOK}",
                             pv_pretty(tmp, s, len, 0, NULL, NULL, 0));
     }
     if (sv && SvOK(sv) && (!SvROK(sv) || SvTYPE(SvRV(sv))!= SVt_PVCV))
@@ -2262,7 +2262,7 @@ Perl_magic_sizepack(pTHX_ SV *sv, MAGIC *mg)
     if (retsv) {
         retval = SvIV(retsv)-1;
         if (retval < -1)
-            Perl_croak(aTHX_ "FETCHSIZE returned a negative value");
+            croak("FETCHSIZE returned a negative value");
     }
     return (U32) retval;
 }
@@ -2335,7 +2335,7 @@ Perl_magic_setdbline(pTHX_ SV *sv, MAGIC *mg)
 
     /* The magic ptr/len for the debugger's hash should always be an SV.  */
     if (UNLIKELY(mg->mg_len != HEf_SVKEY)) {
-        Perl_croak(aTHX_ "panic: magic_setdbline len=%" IVdf ", ptr='%s'",
+        croak("panic: magic_setdbline len=%" IVdf ", ptr='%s'",
                    (IV)mg->mg_len, mg->mg_ptr);
     }
 
@@ -2526,7 +2526,7 @@ Perl_magic_setsubstr(pTHX_ SV *sv, MAGIC *mg)
             negoff ? -(IV)lvoff : (IV)lvoff, !negoff,
             neglen ? -(IV)lvlen : (IV)lvlen, !neglen, &lvoff, &lvlen
     ))
-        Perl_croak(aTHX_ "substr outside of string");
+        croak("substr outside of string");
     oldtarglen = lvlen;
     if (DO_UTF8(sv)) {
         sv_utf8_upgrade_nomg(lsv);
@@ -2695,10 +2695,10 @@ Perl_vivify_defelem(pTHX_ SV *sv)
         if (he)
             value = HeVAL(he);
         if (!value || value == &PL_sv_undef)
-            Perl_croak(aTHX_ PL_no_helem_sv, SVfARG(mg->mg_obj));
+            croak(PL_no_helem_sv, SVfARG(mg->mg_obj));
     }
     else if (LvSTARGOFF(sv) < 0)
-        Perl_croak(aTHX_ PL_no_aelem, LvSTARGOFF(sv));
+        croak(PL_no_aelem, LvSTARGOFF(sv));
     else {
         AV *const av = MUTABLE_AV(LvTARG(sv));
         if ((I32)LvTARGLEN(sv) < 0 && LvSTARGOFF(sv) > AvFILL(av))
@@ -2706,7 +2706,7 @@ Perl_vivify_defelem(pTHX_ SV *sv)
         else {
             SV* const * const svp = av_fetch(av, LvSTARGOFF(sv), TRUE);
             if (!svp || !(value = *svp))
-                Perl_croak(aTHX_ PL_no_aelem, LvSTARGOFF(sv));
+                croak(PL_no_aelem, LvSTARGOFF(sv));
         }
     }
     SvREFCNT_inc_simple_void(value);
@@ -2859,7 +2859,7 @@ Perl_magic_setlvref(pTHX_ SV *sv, MAGIC *mg)
 {
     const char *bad = NULL;
     PERL_ARGS_ASSERT_MAGIC_SETLVREF;
-    if (!SvROK(sv)) Perl_croak(aTHX_ "Assigned value is not a reference");
+    if (!SvROK(sv)) croak("Assigned value is not a reference");
     switch (mg->mg_private & OPpLVREF_TYPE) {
     case OPpLVREF_SV:
         if (SvTYPE(SvRV(sv)) > SVt_PVLV)
@@ -2879,7 +2879,7 @@ Perl_magic_setlvref(pTHX_ SV *sv, MAGIC *mg)
     }
     if (bad)
         /* diag_listed_as: Assigned value is not %s reference */
-        Perl_croak(aTHX_ "Assigned value is not a%s reference", bad);
+        croak("Assigned value is not a%s reference", bad);
     switch (mg->mg_obj ? SvTYPE(mg->mg_obj) : 0) {
     case 0:
     {
@@ -2981,7 +2981,7 @@ S_set_dollarzero(pTHX_ SV *sv)
         /* Set the legacy process name in addition to the POSIX name on Linux */
         if (prctl(PR_SET_NAME, (unsigned long)s, 0, 0, 0) != 0) {
             /* diag_listed_as: SKIPME */
-            Perl_croak(aTHX_ "Can't set $0 with prctl(): %s", Strerror(errno));
+            croak("Can't set $0 with prctl(): %s", Strerror(errno));
         }
 #endif
     }
@@ -3067,7 +3067,7 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
 #endif
         }
         else if (strEQ(mg->mg_ptr + 1, "NCODING") && SvOK(sv))
-            Perl_croak(aTHX_ "${^ENCODING} is no longer supported");
+            croak("${^ENCODING} is no longer supported");
         break;
     case '\006':	/* ^F */
         if (mg->mg_ptr[1] == '\0') {
@@ -3281,13 +3281,13 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
                     IV val = SvIV(referent);
                     if (val <= 0) {
                         sv_setsv(sv, PL_rs);
-                        Perl_croak(aTHX_ "Setting $/ to a reference to %s is forbidden",
+                        croak("Setting $/ to a reference to %s is forbidden",
                                          val < 0 ? "a negative integer" : "zero");
                     }
                 } else {
                     sv_setsv(sv, PL_rs);
                     /* diag_listed_as: Setting $/ to %s reference is forbidden */
-                    Perl_croak(aTHX_ "Setting $/ to a%s %s reference is forbidden",
+                    croak("Setting $/ to a%s %s reference is forbidden",
                                       *reftype == 'A' ? "n" : "", reftype);
                 }
             }
@@ -3306,7 +3306,7 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
         break;
     case '[':
         if (SvIV(sv) != 0)
-            Perl_croak(aTHX_ "Assigning non-zero to $[ is no longer possible");
+            croak("Assigning non-zero to $[ is no longer possible");
         break;
     case '?':
 #ifdef COMPLEX_STATUS
@@ -3364,7 +3364,7 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
 #  endif
             PERL_UNUSED_RESULT(PerlProc_setuid(new_uid));
         } else {
-            Perl_croak(aTHX_ "setruid() not implemented");
+            croak("setruid() not implemented");
         }
 #endif
         break;
@@ -3388,7 +3388,7 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
         if (new_euid == PerlProc_getuid())		/* special case $> = $< */
             PERL_UNUSED_RESULT(PerlProc_setuid(new_euid));
         else {
-            Perl_croak(aTHX_ "seteuid() not implemented");
+            croak("seteuid() not implemented");
         }
 #endif
         break;
@@ -3412,7 +3412,7 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
         if (new_gid == PerlProc_getegid())			/* special case $( = $) */
             PERL_UNUSED_RESULT(PerlProc_setgid(new_gid));
         else {
-            Perl_croak(aTHX_ "setrgid() not implemented");
+            croak("setrgid() not implemented");
         }
 #endif
         break;
@@ -3493,7 +3493,7 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
         if (new_egid == PerlProc_getgid())			/* special case $) = $( */
             PERL_UNUSED_RESULT(PerlProc_setgid(new_egid));
         else {
-            Perl_croak(aTHX_ "setegid() not implemented");
+            croak("setegid() not implemented");
         }
 #endif
         break;

--- a/mg.c
+++ b/mg.c
@@ -1261,7 +1261,7 @@ Perl_magic_get(pTHX_ SV *sv, MAGIC *mg)
                 Newx(gary, num_groups, Groups_t);
                 num_groups = getgroups(num_groups, gary);
                 for (i = 0; i < num_groups; i++)
-                    Perl_sv_catpvf(aTHX_ sv, " %" IVdf, (IV)gary[i]);
+                    sv_catpvf(sv, " %" IVdf, (IV)gary[i]);
                 Safefree(gary);
             }
         }

--- a/mg.c
+++ b/mg.c
@@ -735,7 +735,7 @@ Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
     PERL_UNUSED_CONTEXT;
     PERL_UNUSED_ARG(sv);
     PERL_UNUSED_ARG(mg);
-    Perl_croak_no_modify();
+    croak_no_modify();
     NORETURN_FUNCTION_END;
 }
 
@@ -3010,7 +3010,7 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
              */
           croakparen:
             if (!PL_localizing) {
-                Perl_croak_no_modify();
+                croak_no_modify();
             }
         }
         return 0;

--- a/mg.c
+++ b/mg.c
@@ -1440,7 +1440,7 @@ Perl_magic_set_all_env(pTHX_ SV *sv, MAGIC *mg)
     PERL_ARGS_ASSERT_MAGIC_SET_ALL_ENV;
     PERL_UNUSED_ARG(mg);
 #if defined(VMS)
-    Perl_die(aTHX_ "Can't make list assignment to %%ENV on this system");
+    die("Can't make list assignment to %%ENV on this system");
 #else
     if (PL_localizing) {
         HE* entry;
@@ -1463,7 +1463,7 @@ Perl_magic_clear_all_env(pTHX_ SV *sv, MAGIC *mg)
     PERL_UNUSED_ARG(sv);
     PERL_UNUSED_ARG(mg);
 #if defined(VMS)
-    Perl_die(aTHX_ "Can't make list assignment to %%ENV on this system");
+    die("Can't make list assignment to %%ENV on this system");
 #else
     my_clearenv();
 #endif

--- a/mro_core.c
+++ b/mro_core.c
@@ -95,7 +95,7 @@ Perl_mro_set_private_data(pTHX_ struct mro_meta *const smeta,
     if (!Perl_hv_common(aTHX_ smeta->mro_linear_all, NULL,
                         which->name, which->length, which->kflags,
                         HV_FETCH_ISSTORE, data, which->hash)) {
-        Perl_croak(aTHX_ "panic: hv_store() failed in set_mro_private_data() "
+        croak("panic: hv_store() failed in set_mro_private_data() "
                    "for '%.*s' %d", (int) which->length, which->name,
                    which->kflags);
     }
@@ -146,7 +146,7 @@ Perl_mro_register(pTHX_ const struct mro_alg *mro) {
                         mro->name, mro->length, mro->kflags,
                         HV_FETCH_ISSTORE, wrapper, mro->hash)) {
         SvREFCNT_dec_NN(wrapper);
-        Perl_croak(aTHX_ "panic: hv_store() failed in mro_register() "
+        croak("panic: hv_store() failed in mro_register() "
                    "for '%.*s' %d", (int) mro->length, mro->name, mro->kflags);
     }
 }
@@ -250,10 +250,10 @@ S_mro_get_linear_isa_dfs(pTHX_ HV *stash, U32 level)
         : HvNAME_HEK(stash);
 
     if (!stashhek)
-      Perl_croak(aTHX_ "Can't linearize anonymous symbol table");
+      croak("Can't linearize anonymous symbol table");
 
     if (level > 100)
-        Perl_croak(aTHX_
+        croak(
                   "Recursive inheritance detected in package '%" HEKf "'",
                    HEKfARG(stashhek));
 
@@ -418,11 +418,11 @@ Perl_mro_get_linear_isa(pTHX_ HV *stash)
 
     PERL_ARGS_ASSERT_MRO_GET_LINEAR_ISA;
     if(!HvHasAUX(stash))
-        Perl_croak(aTHX_ "Can't linearize anonymous symbol table");
+        croak("Can't linearize anonymous symbol table");
 
     meta = HvMROMETA(stash);
     if (!meta->mro_which)
-        Perl_croak(aTHX_ "panic: invalid MRO!");
+        croak("panic: invalid MRO!");
     isa = meta->mro_which->resolve(aTHX_ stash, 0);
 
     if (meta->mro_which != &dfs_alg) { /* skip for dfs, for speed */
@@ -521,7 +521,7 @@ Perl_mro_isa_changed_in(pTHX_ HV* stash)
     PERL_ARGS_ASSERT_MRO_ISA_CHANGED_IN;
 
     if(!stashname)
-        Perl_croak(aTHX_ "Can't call mro_isa_changed_in() on anonymous symbol table");
+        croak("Can't call mro_isa_changed_in() on anonymous symbol table");
 
 
     /* wipe out the cached linearizations for this stash */
@@ -1334,7 +1334,7 @@ Perl_mro_method_changed_in(pTHX_ HV *stash)
     const char * const stashname = HvENAME_get(stash);
 
     if(!stashname)
-        Perl_croak(aTHX_ "Can't call mro_method_changed_in() on anonymous symbol table");
+        croak("Can't call mro_method_changed_in() on anonymous symbol table");
 
     const STRLEN stashname_len = HvENAMELEN_get(stash);
 
@@ -1400,7 +1400,7 @@ Perl_mro_set_mro(pTHX_ struct mro_meta *const meta, SV *const name)
     PERL_ARGS_ASSERT_MRO_SET_MRO;
 
     if (!which)
-        Perl_croak(aTHX_ "Invalid mro name: '%" SVf "'", name);
+        croak("Invalid mro name: '%" SVf "'", name);
 
     if(meta->mro_which != which) {
         if (meta->mro_linear_current && !meta->mro_linear_all) {
@@ -1446,7 +1446,7 @@ XS(XS_mro_method_changed_in)
     classname = ST(0);
 
     class_stash = gv_stashsv(classname, 0);
-    if(!class_stash) Perl_croak(aTHX_ "No such class: '%" SVf "'!", SVfARG(classname));
+    if(!class_stash) croak("No such class: '%" SVf "'!", SVfARG(classname));
 
     mro_method_changed_in(class_stash);
 

--- a/op.c
+++ b/op.c
@@ -679,7 +679,7 @@ S_no_fh_allowed(pTHX_ OP *o)
 {
     PERL_ARGS_ASSERT_NO_FH_ALLOWED;
 
-    yyerror(Perl_form(aTHX_ "Missing comma after first argument to %s function",
+    yyerror(form("Missing comma after first argument to %s function",
                  OP_DESC(o)));
     return o;
 }
@@ -688,7 +688,7 @@ STATIC OP *
 S_too_few_arguments_pv(pTHX_ OP *o, const char* name, U32 flags)
 {
     PERL_ARGS_ASSERT_TOO_FEW_ARGUMENTS_PV;
-    yyerror_pv(Perl_form(aTHX_ "Not enough arguments for %s", name), flags);
+    yyerror_pv(form("Not enough arguments for %s", name), flags);
     return o;
 }
 
@@ -697,7 +697,7 @@ S_too_many_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
 {
     PERL_ARGS_ASSERT_TOO_MANY_ARGUMENTS_PV;
 
-    yyerror_pv(Perl_form(aTHX_ "Too many arguments for %s", name), flags);
+    yyerror_pv(form("Too many arguments for %s", name), flags);
     return o;
 }
 
@@ -706,7 +706,7 @@ S_bad_type_pv(pTHX_ I32 n, const char *t, const OP *o, const OP *kid)
 {
     PERL_ARGS_ASSERT_BAD_TYPE_PV;
 
-    yyerror_pv(Perl_form(aTHX_ "Type of arg %d to %s must be %s (not %s)",
+    yyerror_pv(form("Type of arg %d to %s must be %s (not %s)",
                  (int)n, PL_op_desc[(o)->op_type], t, OP_DESC(kid)), 0);
 }
 
@@ -716,7 +716,7 @@ S_bad_type_gv(pTHX_ I32 n, GV *gv, const OP *kid, const char *t)
     SV * const namesv = cv_name((CV *)gv, NULL, 0);
     PERL_ARGS_ASSERT_BAD_TYPE_GV;
 
-    yyerror_pv(Perl_form(aTHX_ "Type of arg %d to %" SVf " must be %s (not %s)",
+    yyerror_pv(form("Type of arg %d to %" SVf " must be %s (not %s)",
                  (int)n, SVfARG(namesv), t, OP_DESC(kid)), SvUTF8(namesv));
 }
 
@@ -788,12 +788,12 @@ Perl_allocmy(pTHX_ const char *const name, const STRLEN len, const U32 flags)
          && isASCII(name[1])
          && (!isPRINT(name[1]) || memCHRs("\t\n\r\f", name[1]))) {
             /* diag_listed_as: Can't use global %s in %s */
-            yyerror(Perl_form(aTHX_ "Can't use global %c^%c%.*s in %s",
+            yyerror(form("Can't use global %c^%c%.*s in %s",
                               name[0], toCTRL(name[1]),
                               (int)(len - 2), name + 2,
                               type));
         } else {
-            yyerror_pv(Perl_form(aTHX_ "Can't use global %.*s in %s",
+            yyerror_pv(form("Can't use global %.*s in %s",
                               (int) len, name,
                               type), flags & SVf_UTF8);
         }
@@ -2927,7 +2927,7 @@ S_lvref(pTHX_ OP *o, I32 type)
             o->op_flags |= OPf_STACKED;
             if (o->op_flags & OPf_PARENS) {
                 if (o->op_private & OPpLVAL_INTRO) {
-                     yyerror(Perl_form(aTHX_ "Can't modify reference to "
+                     yyerror(form("Can't modify reference to "
                           "localized parenthesized array in list assignment"));
                     goto do_next;
                 }
@@ -2961,7 +2961,7 @@ S_lvref(pTHX_ OP *o, I32 type)
         case OP_RV2HV:
             if (o->op_flags & OPf_PARENS) {
               parenhash:
-                yyerror(Perl_form(aTHX_ "Can't modify reference to "
+                yyerror(form("Can't modify reference to "
                                      "parenthesized hash in list assignment"));
                     goto do_next;
             }
@@ -3023,7 +3023,7 @@ S_lvref(pTHX_ OP *o, I32 type)
         default:
           badref:
             /* diag_listed_as: Can't modify reference to %s in %s assignment */
-            yyerror(Perl_form(aTHX_ "Can't modify reference to %s in %s",
+            yyerror(form("Can't modify reference to %s in %s",
                          o->op_type == OP_NULL && o->op_flags & OPf_SPECIAL
                           ? "do block"
                           : OP_DESC(o),
@@ -3184,7 +3184,7 @@ Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
                     return NULL;
 
                 namesv = cv_name(cv, NULL, 0);
-                yyerror_pv(Perl_form(aTHX_ "Can't modify non-lvalue "
+                yyerror_pv(form("Can't modify non-lvalue "
                                      "subroutine call of &%" SVf " in %s",
                                      SVfARG(namesv), PL_op_desc[type]),
                            SvUTF8(namesv));
@@ -3198,7 +3198,7 @@ Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
         /* grep, foreach, subcalls, refgen */
         if (S_potential_mod_type(type))
             break;
-        yyerror(Perl_form(aTHX_ "Can't modify %s in %s",
+        yyerror(form("Can't modify %s in %s",
                      (o->op_type == OP_NULL && (o->op_flags & OPf_SPECIAL)
                       ? "do block"
                       : OP_DESC(o)),
@@ -4105,7 +4105,7 @@ S_cant_declare(pTHX_ OP *o)
     if (o->op_type == OP_NULL
      && (o->op_flags & (OPf_SPECIAL|OPf_KIDS)) == OPf_KIDS)
         o = cUNOPo->op_first;
-    yyerror(Perl_form(aTHX_ "Can't declare %s in \"%s\"",
+    yyerror(form("Can't declare %s in \"%s\"",
                              o->op_type == OP_NULL
                                && o->op_flags & OPf_SPECIAL
                                  ? "do block"
@@ -13253,7 +13253,7 @@ Perl_ck_fun(pTHX_ OP *o)
                     bad_type_pv(1, "array", o, kid);
                 }
                 else if (kid->op_type != OP_RV2AV && kid->op_type != OP_PADAV) {
-                    yyerror_pv(Perl_form(aTHX_ "Experimental %s on scalar is now forbidden",
+                    yyerror_pv(form("Experimental %s on scalar is now forbidden",
                                          PL_op_desc[type]), 0);
                 }
                 else {
@@ -14015,7 +14015,7 @@ Perl_ck_refassign(pTHX_ OP *o)
     default:
       bad:
         /* diag_listed_as: Can't modify reference to %s in %s assignment */
-        yyerror(Perl_form(aTHX_ "Can't modify reference to %s in scalar "
+        yyerror(form("Can't modify reference to %s in scalar "
                                 "assignment",
                                  OP_DESC(varop)));
         return o;
@@ -14800,7 +14800,7 @@ Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
         if (proto >= proto_end)
         {
             SV * const namesv = cv_name((CV *)namegv, NULL, 0);
-            yyerror_pv(Perl_form(aTHX_ "Too many arguments for %" SVf,
+            yyerror_pv(form("Too many arguments for %" SVf,
                                         SVfARG(namesv)), SvUTF8(namesv));
             return entersubop;
         }
@@ -14892,7 +14892,7 @@ Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
                                      OP_LVALUE_NO_CROAK
                                     )) goto wrapref;
                             bad_type_gv(arg, namegv, o3,
-                                    Perl_form(aTHX_ "one of %.*s",(int)(end - p), p));
+                                    form("one of %.*s",(int)(end - p), p));
                         } else
                             goto oops;
                         break;
@@ -14981,7 +14981,7 @@ Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
         (*proto != '@' && *proto != '%' && *proto != ';' && *proto != '_'))
     {
         SV * const namesv = cv_name((CV *)namegv, NULL, 0);
-        yyerror_pv(Perl_form(aTHX_ "Not enough arguments for %" SVf,
+        yyerror_pv(form("Not enough arguments for %" SVf,
                                     SVfARG(namesv)), SvUTF8(namesv));
     }
     return entersubop;
@@ -15042,7 +15042,7 @@ Perl_ck_entersub_args_core(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
         for (cvop = aop; OpSIBLING(cvop); cvop = OpSIBLING(cvop)) ;
         if (aop != cvop) {
             SV *namesv = cv_name((CV *)namegv, NULL, CV_NAME_NOTQUAL);
-            yyerror_pv(Perl_form(aTHX_ "Too many arguments for %" SVf,
+            yyerror_pv(form("Too many arguments for %" SVf,
                 SVfARG(namesv)), SvUTF8(namesv));
         }
 
@@ -15118,7 +15118,7 @@ Perl_ck_entersub_args_core(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
                 OP *nextop;
 
                 namesv = cv_name((CV *)namegv, NULL, CV_NAME_NOTQUAL);
-                yyerror_pv(Perl_form(aTHX_ "Too many arguments for %" SVf,
+                yyerror_pv(form("Too many arguments for %" SVf,
                     SVfARG(namesv)), SvUTF8(namesv));
                 while (aop) {
                     nextop = OpSIBLING(aop);

--- a/op.c
+++ b/op.c
@@ -6588,7 +6588,7 @@ S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
             sv_catpvn(inverted_tstr, (char *) temp, temp_end_pos - temp);
 
             if (start != end) {
-                Perl_sv_catpvf(aTHX_ inverted_tstr, "%c", RANGE_INDICATOR);
+                sv_catpvf(inverted_tstr, "%c", RANGE_INDICATOR);
                 temp_end_pos = uv_to_utf8(temp, end);
                 sv_catpvn(inverted_tstr, (char *) temp, temp_end_pos - temp);
             }
@@ -10383,16 +10383,16 @@ Perl_cv_ckproto_len_flags(pTHX_ const CV *cv, const GV *gv, const char *p,
     }
     sv_setpvs(msg, "Prototype mismatch:");
     if (name)
-        Perl_sv_catpvf(aTHX_ msg, " sub %" SVf, SVfARG(name));
+        sv_catpvf(msg, " sub %" SVf, SVfARG(name));
     if (cvp)
-        Perl_sv_catpvf(aTHX_ msg, " (%" UTF8f ")",
+        sv_catpvf(msg, " (%" UTF8f ")",
             UTF8fARG(SvUTF8(cv),clen,cvp)
         );
     else
         sv_catpvs(msg, ": none");
     sv_catpvs(msg, " vs ");
     if (p)
-        Perl_sv_catpvf(aTHX_ msg, "(%" UTF8f ")", UTF8fARG(flags & SVf_UTF8,len,p));
+        sv_catpvf(msg, "(%" UTF8f ")", UTF8fARG(flags & SVf_UTF8,len,p));
     else
         sv_catpvs(msg, "none");
     Perl_warner(aTHX_ packWARN(WARN_PROTOTYPE), "%" SVf, SVfARG(msg));

--- a/op.c
+++ b/op.c
@@ -11076,7 +11076,7 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
         has_name = TRUE;
     } else if (PERLDB_NAMEANON && CopLINE(PL_curcop)) {
         SV * const sv = sv_newmortal();
-        Perl_sv_setpvf(aTHX_ sv, "%s[%s:%" LINE_Tf "]",
+        sv_setpvf(sv, "%s[%s:%" LINE_Tf "]",
                        PL_curstash ? "__ANON__" : "__ANON__::__ANON__",
                        CopFILE(PL_curcop), CopLINE(PL_curcop));
         gv = gv_fetchsv(sv, gv_fetch_flags, SVt_PVCV);

--- a/op.c
+++ b/op.c
@@ -668,7 +668,7 @@ Perl_op_refcnt_dec(pTHX_ OP *o)
 #define CHECKOP(type,o) \
     ((PL_op_mask && PL_op_mask[type])				\
      ? ( op_free((OP*)o),					\
-         Perl_croak(aTHX_ "'%s' trapped by operation mask", PL_op_desc[type]),	\
+         croak("'%s' trapped by operation mask", PL_op_desc[type]),	\
          (OP*)0 )						\
      : PL_check[type](aTHX_ (OP*)o))
 
@@ -768,7 +768,7 @@ Perl_allocmy(pTHX_ const char *const name, const STRLEN len, const U32 flags)
     PERL_ARGS_ASSERT_ALLOCMY;
 
     if (flags & ~SVf_UTF8)
-        Perl_croak(aTHX_ "panic: allocmy illegal flag bits 0x%" UVxf,
+        croak("panic: allocmy illegal flag bits 0x%" UVxf,
                    (UV)flags);
 
     is_idfirst = flags & SVf_UTF8
@@ -1771,7 +1771,7 @@ Perl_op_contextualize(pTHX_ OP *o, I32 context)
         case G_LIST:   return list(o);
         case G_VOID:   return scalarvoid(o);
         default:
-            Perl_croak(aTHX_ "panic: op_contextualize bad context %ld",
+            croak("panic: op_contextualize bad context %ld",
                        (long) context);
     }
 }
@@ -2799,7 +2799,7 @@ Perl_check_hash_fields_and_hekify(pTHX_ UNOP *rop, SVOP *key_op, int real)
         if (   check_fields
             && !hv_fetch_ent(GvHV(*fields), *svp, FALSE, 0))
         {
-            Perl_croak(aTHX_ "No such class field \"%" SVf "\" "
+            croak("No such class field \"%" SVf "\" "
                         "in variable %" PNf " of type %" HEKf,
                         SVfARG(*svp), PNfARG(lexname),
                         HEKfARG(HvNAME_HEK(PadnameTYPE(lexname))));
@@ -3146,7 +3146,7 @@ Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
 
                 if (kid->op_type != OP_PUSHMARK) {
                     if (kid->op_type != OP_NULL || kid->op_targ != OP_LIST)
-                        Perl_croak(aTHX_
+                        croak(
                                 "panic: unexpected lvalue entersub "
                                 "args: type/targ %ld:%" UVuf,
                                 (long)kid->op_type, (UV)kid->op_targ);
@@ -3162,7 +3162,7 @@ Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
                 if (kid->op_type == OP_NULL && kid->op_targ == OP_RV2SV)
                     kid = kUNOP->op_first;
                 if (kid->op_type == OP_NULL)
-                    Perl_croak(aTHX_
+                    croak(
                                "panic: unexpected constant lvalue entersub "
                                "entry via type/targ %ld:%" UVuf,
                                (long)kid->op_type, (UV)kid->op_targ);
@@ -3361,7 +3361,7 @@ Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
     case OP_PADSV:
         PL_modcount++;
         if (!type) /* local() */
-            Perl_croak(aTHX_ "Can't localize lexical variable %" PNf,
+            croak("Can't localize lexical variable %" PNf,
                               PNfARG(PAD_COMPNAME(o->op_targ)));
         if (!(o->op_private & OPpLVAL_INTRO)
          || (  type != OP_SASSIGN && type != OP_AASSIGN
@@ -3488,7 +3488,7 @@ Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
         if (type == OP_NULL) { /* local */
           local_refgen:
             if (!FEATURE_MYREF_IS_ENABLED)
-                Perl_croak(aTHX_ "The experimental declared_refs "
+                croak("The experimental declared_refs "
                                  "feature is not enabled");
             Perl_ck_warner_d(aTHX_
                      packWARN(WARN_EXPERIMENTAL__DECLARED_REFS),
@@ -3514,7 +3514,7 @@ Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
             S_lvref(aTHX_ kid, type);
             if (!PL_parser || PL_parser->error_count == ec) {
                 if (!FEATURE_REFALIASING_IS_ENABLED)
-                    Perl_croak(aTHX_
+                    croak(
                        "Experimental aliasing via reference not enabled");
                 Perl_ck_warner_d(aTHX_
                                  packWARN(WARN_EXPERIMENTAL__REFALIASING),
@@ -4156,7 +4156,7 @@ S_my_kid(pTHX_ OP *o, OP *attrs, OP **imopsp)
     }
     else if (type == OP_REFGEN || type == OP_SREFGEN) {
         if (!FEATURE_MYREF_IS_ENABLED)
-            Perl_croak(aTHX_ "The experimental declared_refs "
+            croak("The experimental declared_refs "
                              "feature is not enabled");
         Perl_ck_warner_d(aTHX_
              packWARN(WARN_EXPERIMENTAL__DECLARED_REFS),
@@ -5093,7 +5093,7 @@ S_fold_constants(pTHX_ OP *const o)
         PL_diehook  = olddiehook;
         /* XXX note that this croak may fail as we've already blown away
          * the stack - eg any nested evals */
-        Perl_croak(aTHX_ "panic: fold_constants JMPENV_PUSH returned %d", ret);
+        croak("panic: fold_constants JMPENV_PUSH returned %d", ret);
     }
     PL_dowarn   = oldwarn;
     PL_warnhook = oldwarnhook;
@@ -5206,7 +5206,7 @@ S_gen_constant_list(pTHX_ OP *o)
         JMPENV_POP;
         PL_warnhook = oldwarnhook;
         PL_diehook = olddiehook;
-        Perl_croak(aTHX_ "panic: gen_constant_list JMPENV_PUSH returned %d",
+        croak("panic: gen_constant_list JMPENV_PUSH returned %d",
             ret);
     }
 
@@ -8198,7 +8198,7 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
     PERL_ARGS_ASSERT_UTILIZE;
 
     if (idop->op_type != OP_CONST)
-        Perl_croak(aTHX_ "Module name must be constant");
+        croak("Module name must be constant");
 
     veop = NULL;
 
@@ -8213,7 +8213,7 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
             SV *meth;
 
             if (version->op_type != OP_CONST || !SvNIOKp(vesv))
-                Perl_croak(aTHX_ "Version number must be a constant number");
+                croak("Version number must be a constant number");
 
             /* Make copy of idop so we don't free it twice */
             pack = newSVOP(OP_CONST, 0, newSVsv(cSVOPx(idop)->op_sv));
@@ -9124,7 +9124,7 @@ S_new_logop(pTHX_ I32 type, I32 flags, OP** firstp, OP** otherp)
                 && o2->op_private & OPpLVAL_INTRO
                 && !(o2->op_private & OPpPAD_STATE))
             {
-        Perl_croak(aTHX_ "This use of my() in false conditional is "
+        croak("This use of my() in false conditional is "
                           "no longer allowed");
             }
 
@@ -9770,12 +9770,12 @@ Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
             parens = 1;
 
             if (!pushmark || pushmark->op_type != OP_PUSHMARK) {
-                Perl_croak(aTHX_ "panic: newFORLOOP, found %s, expecting pushmark",
+                croak("panic: newFORLOOP, found %s, expecting pushmark",
                            pushmark ? PL_op_desc[pushmark->op_type] : "NULL");
             }
             first_padsv = OpSIBLING(pushmark);
             if (!first_padsv || first_padsv->op_type != OP_PADSV) {
-                Perl_croak(aTHX_ "panic: newFORLOOP, found %s, expecting padsv",
+                croak("panic: newFORLOOP, found %s, expecting padsv",
                            first_padsv ? PL_op_desc[first_padsv->op_type] : "NULL");
             }
             padoff = first_padsv->op_targ;
@@ -9785,13 +9785,13 @@ Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
             padsv = cUNOPx(OpSIBLING(first_padsv));
             do {
                 if (!padsv || padsv->op_type != OP_PADSV) {
-                    Perl_croak(aTHX_ "panic: newFORLOOP, found %s at %zd, expecting padsv",
+                    croak("panic: newFORLOOP, found %s at %zd, expecting padsv",
                                padsv ? PL_op_desc[padsv->op_type] : "NULL",
                                how_many_more);
                 }
                 ++how_many_more;
                 if (padsv->op_targ != padoff + how_many_more) {
-                    Perl_croak(aTHX_ "panic: newFORLOOP, padsv at %zd targ is %zd, not %zd",
+                    croak("panic: newFORLOOP, padsv at %zd targ is %zd, not %zd",
                                how_many_more, padsv->op_targ, padoff + how_many_more);
                 }
 
@@ -9818,7 +9818,7 @@ Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
             sv = NULL;
         }
         else
-            Perl_croak(aTHX_ "Can't use %s for loop variable", PL_op_desc[sv->op_type]);
+            croak("Can't use %s for loop variable", PL_op_desc[sv->op_type]);
         if (padoff) {
             PADNAME * const pn = PAD_COMPNAME(padoff);
             const char * const name = PadnamePV(pn);
@@ -11629,7 +11629,7 @@ S_process_special_blocks(pTHX_ I32 floor, const char *const fullname,
              * effectively a no-op, as max_nest_iv will never be negative here.
              */
             if (PL_eval_begin_nest_depth >= (UV)max_nest_iv) {
-                Perl_croak(aTHX_ "Too many nested BEGIN blocks, maximum of %" IVdf " allowed",
+                croak("Too many nested BEGIN blocks, maximum of %" IVdf " allowed",
                              max_nest_iv);
             }
             SAVEINT(PL_eval_begin_nest_depth);
@@ -12317,7 +12317,7 @@ Perl_newAVREF(pTHX_ OP *o)
         return o;
     }
     else if ((o->op_type == OP_RV2AV || o->op_type == OP_PADAV)) {
-        Perl_croak(aTHX_ "Can't use an array as a reference");
+        croak("Can't use an array as a reference");
     }
     return newUNOP(OP_RV2AV, 0, scalar(o));
 }
@@ -12372,7 +12372,7 @@ Perl_newHVREF(pTHX_ OP *o)
         return o;
     }
     else if ((o->op_type == OP_RV2HV || o->op_type == OP_PADHV)) {
-        Perl_croak(aTHX_ "Can't use a hash as a reference");
+        croak("Can't use a hash as a reference");
     }
     return newUNOP(OP_RV2HV, 0, scalar(o));
 }
@@ -12781,7 +12781,7 @@ Perl_ck_delete(pTHX_ OP *o)
             o->op_private |= OPpKVSLICE;
             break;
         default:
-            Perl_croak(aTHX_ "delete argument is not a HASH or ARRAY "
+            croak("delete argument is not a HASH or ARRAY "
                              "element or slice");
         }
         if (kid->op_private & OPpLVAL_INTRO)
@@ -12968,14 +12968,14 @@ Perl_ck_exists(pTHX_ OP *o)
             (void) ref(kid, o->op_type);
             if (kid->op_type != OP_RV2CV
                         && !(PL_parser && PL_parser->error_count))
-                Perl_croak(aTHX_
+                croak(
                           "exists argument is not a subroutine name");
             o->op_private |= OPpEXISTS_SUB;
         }
         else if (kid->op_type == OP_AELEM)
             o->op_flags |= OPf_SPECIAL;
         else if (kid->op_type != OP_HELEM)
-            Perl_croak(aTHX_ "exists argument is not a HASH or ARRAY "
+            croak("exists argument is not a HASH or ARRAY "
                              "element or a subroutine");
         op_null(kid);
     }
@@ -13052,7 +13052,7 @@ Perl_ck_rvconst(pTHX_ OP *o)
                 break;
             }
             if (badthing)
-                Perl_croak(aTHX_
+                croak(
                            "Can't use bareword (\"%" SVf "\") as %s ref while \"strict refs\" in use",
                            SVfARG(kidsv), badthing);
         }
@@ -13512,7 +13512,7 @@ Perl_ck_grep(pTHX_ OP *o)
         return o;
     kid = OpSIBLING(cLISTOPo->op_first);
     if (kid->op_type != OP_NULL)
-        Perl_croak(aTHX_ "panic: ck_grep, type=%u", (unsigned) kid->op_type);
+        croak("panic: ck_grep, type=%u", (unsigned) kid->op_type);
     kid = kUNOP->op_first;
 
     gwop = alloc_LOGOP(type, o, LINKLIST(kid));
@@ -13576,13 +13576,13 @@ Perl_ck_defined(pTHX_ OP *o)		/* 19990527 MJD */
         switch (cUNOPo->op_first->op_type) {
         case OP_RV2AV:
         case OP_PADAV:
-            Perl_croak(aTHX_ "Can't use 'defined(@array)'"
+            croak("Can't use 'defined(@array)'"
                              " (Maybe you should just omit the defined()?)");
             NOT_REACHED; /* NOTREACHED */
             break;
         case OP_RV2HV:
         case OP_PADHV:
-            Perl_croak(aTHX_ "Can't use 'defined(%%hash)'"
+            croak("Can't use 'defined(%%hash)'"
                              " (Maybe you should just omit the defined()?)");
             NOT_REACHED; /* NOTREACHED */
             break;
@@ -14021,7 +14021,7 @@ Perl_ck_refassign(pTHX_ OP *o)
         return o;
     }
     if (!FEATURE_REFALIASING_IS_ENABLED)
-        Perl_croak(aTHX_
+        croak(
                   "Experimental aliasing via reference not enabled");
     Perl_ck_warner_d(aTHX_
                      packWARN(WARN_EXPERIMENTAL__REFALIASING),
@@ -14639,7 +14639,7 @@ Perl_rv2cv_op_cv(pTHX_ OP *cvop, U32 flags)
     GV *gv;
     PERL_ARGS_ASSERT_RV2CV_OP_CV;
     if (flags & ~RV2CVOPCV_FLAG_MASK)
-        Perl_croak(aTHX_ "panic: rv2cv_op_cv bad flags %x", (unsigned)flags);
+        croak("panic: rv2cv_op_cv bad flags %x", (unsigned)flags);
     if (cvop->op_type != OP_RV2CV)
         return NULL;
     if (cvop->op_private & OPpENTERSUB_AMPER)
@@ -14778,7 +14778,7 @@ Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
     const char *e = NULL;
     PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_PROTO;
     if (SvTYPE(protosv) == SVt_PVCV ? !SvPOK(protosv) : !SvOK(protosv))
-        Perl_croak(aTHX_ "panic: ck_entersub_args_proto CV with no proto, "
+        croak("panic: ck_entersub_args_proto CV with no proto, "
                    "flags=%lx", (unsigned long) SvFLAGS(protosv));
     if (SvTYPE(protosv) == SVt_PVCV)
          proto = CvPROTO(protosv), proto_len = CvPROTOLEN(protosv);
@@ -14963,7 +14963,7 @@ Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
                 continue;
             default:
             oops: {
-                Perl_croak(aTHX_ "Malformed prototype for %" SVf ": %" SVf,
+                croak("Malformed prototype for %" SVf ": %" SVf,
                                   SVfARG(cv_name((CV *)namegv, NULL, 0)),
                                   SVfARG(protosv));
             }
@@ -15891,7 +15891,7 @@ Perl_custom_op_get_field(pTHX_ const OP *o, const xop_flags_enum field)
                     break;
                 default:
                   field_panic:
-                    Perl_croak(aTHX_
+                    croak(
                         "panic: custom_op_get_field(): invalid field %d\n",
                         (int)field);
                     break;
@@ -15944,7 +15944,7 @@ Perl_custom_op_register(pTHX_ Perl_ppaddr_t ppaddr, const XOP *xop)
         PL_custom_ops = newHV();
 
     if (!hv_store_ent(PL_custom_ops, keysv, newSViv(PTR2IV(xop)), 0))
-        Perl_croak(aTHX_ "panic: can't register custom OP %s", xop->xop_name);
+        croak("panic: can't register custom OP %s", xop->xop_name);
 }
 
 /*
@@ -16297,7 +16297,7 @@ const_av_xsub(pTHX_ CV* cv)
     }
 #endif
     if (SvRMAGICAL(av))
-        Perl_croak(aTHX_ "Magical list constants are not supported");
+        croak("Magical list constants are not supported");
     if (GIMME_V != G_LIST) {
         EXTEND(SP, 1);
         ST(0) = sv_2mortal(newSViv((IV)AvFILLp(av)+1));

--- a/op.c
+++ b/op.c
@@ -1590,7 +1590,7 @@ see C<L</OpMORESIB_set>>, C<L</OpLASTSIB_set>>, C<L</OpMAYBESIB_set>>.
 */
 
 OP *
-Perl_op_sibling_splice(OP *parent, OP *start, int del_count, OP* insert)
+Perl_op_sibling_splice(pTHX_ OP *parent, OP *start, int del_count, OP* insert)
 {
     OP *first;
     OP *rest;
@@ -1673,7 +1673,7 @@ Perl_op_sibling_splice(OP *parent, OP *start, int del_count, OP* insert)
     return last_del ? first : NULL;
 
   no_parent:
-    Perl_croak_nocontext("panic: op_sibling_splice(): NULL parent");
+    croak("panic: op_sibling_splice(): NULL parent");
 }
 
 /*
@@ -2788,7 +2788,7 @@ Perl_check_hash_fields_and_hekify(pTHX_ UNOP *rop, SVOP *key_op, int real)
             SSize_t keylen;
             const char * const key = SvPV_const(sv, *(STRLEN*)&keylen);
             if (keylen > I32_MAX) {
-                Perl_croak_nocontext("Sorry, hash keys must be smaller than 2**31 bytes");
+                croak("Sorry, hash keys must be smaller than 2**31 bytes");
             }
 
             SV *nsv = newSVpvn_share(key, SvUTF8(sv) ? -(I32)keylen : (I32)keylen, 0);
@@ -11147,12 +11147,12 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
         PL_compcv = 0;
         if (isBEGIN) {
             if (PL_in_eval & EVAL_KEEPERR)
-                Perl_croak_nocontext("BEGIN not safe after errors--compilation aborted");
+                croak("BEGIN not safe after errors--compilation aborted");
             else {
                 SV * const errsv = ERRSV;
                 /* force display of errors found but not reported */
                 sv_catpvs(errsv, "BEGIN not safe after errors--compilation aborted");
-                Perl_croak_nocontext("%" SVf, SVfARG(errsv));
+                croak("%" SVf, SVfARG(errsv));
             }
         }
         goto done;

--- a/op.c
+++ b/op.c
@@ -457,7 +457,7 @@ Perl_Slab_to_ro(pTHX_ OPSLAB *slab)
         /*DEBUG_U(PerlIO_printf(Perl_debug_log,"mprotect ->ro %lu at %p\n",
                               (unsigned long) slab->opslab_size, (void *)slab));*/
         if (mprotect(slab, OpSLABSizeBytes(slab->opslab_size), PROT_READ))
-            Perl_warn(aTHX_ "mprotect for %p %lu failed with %d", (void *)slab,
+            warn("mprotect for %p %lu failed with %d", (void *)slab,
                              (unsigned long)slab->opslab_size, errno);
     }
 }
@@ -476,7 +476,7 @@ Perl_Slab_to_rw(pTHX_ OPSLAB *const slab)
                               (unsigned long) size, (void *)slab2));*/
         if (mprotect((void *)slab2, OpSLABSizeBytes(slab2->opslab_size),
                      PROT_READ|PROT_WRITE)) {
-            Perl_warn(aTHX_ "mprotect RW for %p %lu failed with %d", (void *)slab,
+            warn("mprotect RW for %p %lu failed with %d", (void *)slab,
                              (unsigned long)slab2->opslab_size, errno);
         }
     }
@@ -11712,7 +11712,7 @@ S_process_special_blocks(pTHX_ I32 floor, const char *const fullname,
                          * be BEGIN blocks. Which works out, since the INIT
                          * blocks it creates are eval'ed and so are late.
                          */
-                        Perl_warn(aTHX_ "Treating %s::INIT block as BEGIN block as workaround",
+                        warn("Treating %s::INIT block as BEGIN block as workaround",
                                 MI_INIT_WORKAROUND_PACK);
                         goto module_install_hack;
                     }

--- a/os2/os2.c
+++ b/os2/os2.c
@@ -1652,7 +1652,7 @@ my_syspopen4(pTHX_ char *cmd, char *mode, I32 cnt, SV** args)
     SV *sv;
 
     if (cnt)
-        Perl_croak(aTHX_ "List form of piped open not implemented");
+        croak("List form of piped open not implemented");
 
 #  ifdef TRYSHELL
     res = popen(cmd, mode);
@@ -1890,7 +1890,7 @@ XS(XS_OS2_replaceModule)
 {
     dXSARGS;
     if (items < 1 || items > 3)
-        Perl_croak(aTHX_ "Usage: OS2::replaceModule(target [, source [, backup]])");
+        croak("Usage: OS2::replaceModule(target [, source [, backup]])");
     {
         char *	target = (char *)SvPV_nolen(ST(0));
         char *	source = (items < 2) ? NULL : (char *)SvPV_nolen(ST(1));
@@ -1946,7 +1946,7 @@ XS(XS_OS2_perfSysCall)
 {
     dXSARGS;
     if (items < 0 || items > 4)
-        Perl_croak(aTHX_ "Usage: OS2::perfSysCall(ulCommand = CMD_KI_RDCNT, ulParm1= 0, ulParm2= 0, ulParm3= 0)");
+        croak("Usage: OS2::perfSysCall(ulCommand = CMD_KI_RDCNT, ulParm1= 0, ulParm2= 0, ulParm3= 0)");
     SP -= items;
     {
         dXSTARG;
@@ -2901,7 +2901,7 @@ XS(XS_OS2_DevCap)
             hScreenDC = (HDC)SvIV(ST(0));
         else {				/* DevCap_hwnd */
             if (!Perl_hmq)
-                Perl_croak(aTHX_ "Getting a window's device context without a message queue would lock PM");
+                croak("Getting a window's device context without a message queue would lock PM");
             hwnd = (HWND)SvIV(ST(0));
             hScreenDC = pWinOpenWindowDC(hwnd); /* No need to DevCloseDC() */
             if (CheckWinError(hScreenDC))
@@ -3234,7 +3234,7 @@ XS(XS_OS2_SysInfoFor)
         int start = (int)SvIV(ST(0));
 
         if (count > C_ARRAY_LENGTH(si) || count <= 0)
-            Perl_croak(aTHX_ "unexpected count %d for OS2::SysInfoFor()", count);
+            croak("unexpected count %d for OS2::SysInfoFor()", count);
         if (CheckOSError(DosQuerySysInfo(start,
                                          start + count - 1,
                                          (PVOID)si,
@@ -3793,7 +3793,7 @@ module_name_at(void *pp, enum module_name_how how)
 
     if (how & mod_name_HMODULE) {
         if ((how & ~mod_name_HMODULE) == mod_name_shortname)
-            Perl_croak(aTHX_ "Can't get short module name from a handle");
+            croak("Can't get short module name from a handle");
         mod = (HMODULE)pp;
         how &= ~mod_name_HMODULE;
     } else if (!_DosQueryModFromEIP(&mod, &obj, sizeof(buf), buf, &offset, addr))
@@ -3822,7 +3822,7 @@ module_name_of_cv(SV *cv, enum module_name_how how)
             return module_name_at((void*)SvIV(cv), how & ~mod_name_C_function);
         else if (how & mod_name_HMODULE)
             return module_name_at((void*)SvIV(cv), how);
-        Perl_croak(aTHX_ "Not an XSUB reference");
+        croak("Not an XSUB reference");
     }
     return module_name_at(CvXSUB(SvRV(cv)), how);
 }
@@ -3831,7 +3831,7 @@ XS(XS_OS2_DLLname)
 {
     dXSARGS;
     if (items > 2)
-        Perl_croak(aTHX_ "Usage: OS2::DLLname( [ how, [\\&xsub] ] )");
+        croak("Usage: OS2::DLLname( [ how, [\\&xsub] ] )");
     {
         SV *	RETVAL;
         int	how;
@@ -3859,7 +3859,7 @@ XS(XS_OS2__headerInfo)
 {
     dXSARGS;
     if (items > 4 || items < 2)
-        Perl_croak(aTHX_ "Usage: OS2::_headerInfo(req,size[,handle,[offset]])");
+        croak("Usage: OS2::_headerInfo(req,size[,handle,[offset]])");
     {
         ULONG	req = (ULONG)SvIV(ST(0));
         STRLEN	size = (STRLEN)SvIV(ST(1)), n_a;
@@ -3867,13 +3867,13 @@ XS(XS_OS2__headerInfo)
         ULONG	offset = (items >= 4 ? (ULONG)SvIV(ST(3)) : 0);
 
         if (size <= 0)
-            Perl_croak(aTHX_ "OS2::_headerInfo(): unexpected size: %d", (int)size);
+            croak("OS2::_headerInfo(): unexpected size: %d", (int)size);
         ST(0) = newSVpvs("");
         SvGROW(ST(0), size + 1);
         sv_2mortal(ST(0));
 
         if (!_Dos32QueryHeaderInfo(handle, offset, SvPV(ST(0), n_a), size, req)) 
-            Perl_croak(aTHX_ "OS2::_headerInfo(%ld,%ld,%ld,%ld) error: %s",
+            croak("OS2::_headerInfo(%ld,%ld,%ld,%ld) error: %s",
                        req, size, handle, offset, os2error(Perl_rc));
         SvCUR_set(ST(0), size);
         *SvEND(ST(0)) = 0;
@@ -3888,14 +3888,14 @@ XS(XS_OS2_libPath)
 {
     dXSARGS;
     if (items != 0)
-        Perl_croak(aTHX_ "Usage: OS2::libPath()");
+        croak("Usage: OS2::libPath()");
     {
         ULONG	size;
         STRLEN	n_a;
 
         if (!_Dos32QueryHeaderInfo(0, 0, &size, sizeof(size), 
                                    DQHI_QUERYLIBPATHSIZE)) 
-            Perl_croak(aTHX_ "OS2::_headerInfo(%ld,%ld,%ld,%ld) error: %s",
+            croak("OS2::_headerInfo(%ld,%ld,%ld,%ld) error: %s",
                        DQHI_QUERYLIBPATHSIZE, sizeof(size), 0, 0,
                        os2error(Perl_rc));
         ST(0) = newSVpvs("");
@@ -3907,7 +3907,7 @@ XS(XS_OS2_libPath)
            unrelated data! */
         if (!_Dos32QueryHeaderInfo(0, 0, SvPV(ST(0), n_a), size,
                                    DQHI_QUERYLIBPATH)) 
-            Perl_croak(aTHX_ "OS2::_headerInfo(%ld,%ld,%ld,%ld) error: %s",
+            croak("OS2::_headerInfo(%ld,%ld,%ld,%ld) error: %s",
                        DQHI_QUERYLIBPATH, size, 0, 0, os2error(Perl_rc));
         SvCUR_set(ST(0), size);
         *SvEND(ST(0)) = 0;
@@ -3922,7 +3922,7 @@ XS(XS_OS2__control87)
 {
     dXSARGS;
     if (items != 2)
-        Perl_croak(aTHX_ "Usage: OS2::_control87(new,mask)");
+        croak("Usage: OS2::_control87(new,mask)");
     {
         unsigned	new = (unsigned)SvIV(ST(0));
         unsigned	mask = (unsigned)SvIV(ST(1));
@@ -3941,7 +3941,7 @@ XS(XS_OS2_mytype)
     int which = 0;
 
     if (items < 0 || items > 1)
-        Perl_croak(aTHX_ "Usage: OS2::mytype([which])");
+        croak("Usage: OS2::mytype([which])");
     if (items == 1)
         which = (int)SvIV(ST(0));
     {
@@ -3962,7 +3962,7 @@ XS(XS_OS2_mytype)
             RETVAL = my_type();		/* Morphed type */
             break;
         default:
-            Perl_croak(aTHX_ "OS2::mytype(which): unknown which=%d", which);
+            croak("OS2::mytype(which): unknown which=%d", which);
         }
         XSprePUSH; PUSHi((IV)RETVAL);
     }
@@ -3978,7 +3978,7 @@ XS(XS_OS2_mytype_set)
     if (items == 1)
         type = (int)SvIV(ST(0));
     else
-        Perl_croak(aTHX_ "Usage: OS2::mytype_set(type)");
+        croak("Usage: OS2::mytype_set(type)");
     my_type_set(type);
     XSRETURN_YES;
 }
@@ -3988,7 +3988,7 @@ XS(XS_OS2_get_control87)
 {
     dXSARGS;
     if (items != 0)
-        Perl_croak(aTHX_ "Usage: OS2::get_control87()");
+        croak("Usage: OS2::get_control87()");
     {
         unsigned	RETVAL;
         dXSTARG;
@@ -4004,7 +4004,7 @@ XS(XS_OS2_set_control87)
 {
     dXSARGS;
     if (items < 0 || items > 2)
-        Perl_croak(aTHX_ "Usage: OS2::set_control87(new=MCW_EM, mask=MCW_EM)");
+        croak("Usage: OS2::set_control87(new=MCW_EM, mask=MCW_EM)");
     {
         unsigned	new;
         unsigned	mask;
@@ -4033,7 +4033,7 @@ XS(XS_OS2_incrMaxFHandles)		/* DosSetRelMaxFH */
 {
     dXSARGS;
     if (items < 0 || items > 1)
-        Perl_croak(aTHX_ "Usage: OS2::incrMaxFHandles(delta = 0)");
+        croak("Usage: OS2::incrMaxFHandles(delta = 0)");
     {
         LONG	delta;
         ULONG	RETVAL, rc;
@@ -4098,7 +4098,7 @@ XS(XS_OS2_pipe)
 {
     dXSARGS;
     if (items < 2 || items > 8)
-        Perl_croak(aTHX_ "Usage: OS2::pipe(pszName, ulOpenMode, connect= 1, count= 1, ulInbufLength= 8192, ulOutbufLength= ulInbufLength, ulPipeMode= count | NP_NOWAIT | NP_TYPE_BYTE | NP_READMODE_BYTE, ulTimeout= 0)");
+        croak("Usage: OS2::pipe(pszName, ulOpenMode, connect= 1, count= 1, ulInbufLength= 8192, ulOutbufLength= ulInbufLength, ulPipeMode= count | NP_NOWAIT | NP_TYPE_BYTE | NP_READMODE_BYTE, ulTimeout= 0)");
     {
         ULONG	RETVAL;
         PCSZ	pszName = ( SvOK(ST(0)) ? (PCSZ)SvPV_nolen(ST(0)) : NULL );
@@ -4113,7 +4113,7 @@ XS(XS_OS2_pipe)
         double	timeout;
 
         if (!pszName || !*pszName)
-            Perl_croak(aTHX_ "OS2::pipe(): empty pipe name");
+            croak("OS2::pipe(): empty pipe name");
         s = SvPV(OpenMode, len);
         if (memEQs(s, len, "wait")) {	/* DosWaitNPipe() */
             ULONG ms = 0xFFFFFFFF, ret = ERROR_INTERRUPT; /* Indefinite */
@@ -4126,7 +4126,7 @@ XS(XS_OS2_pipe)
                 else if (timeout && !ms)
                     ms = 1;
             } else if (items > 3)
-                Perl_croak(aTHX_ "OS2::pipe(): too many arguments for wait-for-connect: %ld", (long)items);
+                croak("OS2::pipe(): too many arguments for wait-for-connect: %ld", (long)items);
 
             while (ret == ERROR_INTERRUPT)
                 ret = DosWaitNPipe(pszName, ms);	/* XXXX Update ms? */
@@ -4142,7 +4142,7 @@ XS(XS_OS2_pipe)
             char *b = buf;
 
             if (items < 3 || items > 5)
-                Perl_croak(aTHX_ "usage: OS2::pipe(pszName, 'call', write [, timeout= 0xFFFFFFFF, buffsize = 8192])");
+                croak("usage: OS2::pipe(pszName, 'call', write [, timeout= 0xFFFFFFFF, buffsize = 8192])");
             s = SvPV(ST(2), l);
             if (items >= 4) {
                 timeout = (double)SvNV(ST(3));
@@ -4175,7 +4175,7 @@ XS(XS_OS2_pipe)
             W = strchr(s, 'W') != 0;
             b = strchr(s, 'b') != 0;
             if (r + w + R + W + b != len || (r && R) || (w && W))
-                Perl_croak(aTHX_ "OS2::pipe(): unknown OpenMode argument: `%s'", s);
+                croak("OS2::pipe(): unknown OpenMode argument: `%s'", s);
             if ((r || R) && (w || W))
                 ulOpenMode = NP_INHERIT | NP_NOWRITEBEHIND | NP_ACCESS_DUPLEX;
             else if (r || R)
@@ -4187,7 +4187,7 @@ XS(XS_OS2_pipe)
             if (W)
                 message = 1;
             else if (w && R)
-                Perl_croak(aTHX_ "OS2::pipe(): can't have message read mode for non-message pipes");
+                croak("OS2::pipe(): can't have message read mode for non-message pipes");
         } else
             ulOpenMode = (ULONG)SvUV(OpenMode);	/* ST(1) */
 
@@ -4217,7 +4217,7 @@ XS(XS_OS2_pipe)
             else if (memEQs(s, len, "wait"))
                 connect = 1;			/* wait */
             else
-                Perl_croak(aTHX_ "OS2::pipe(): unknown connect argument: `%s'", s);
+                croak("OS2::pipe(): unknown connect argument: `%s'", s);
         }
 
         if (items < 4)
@@ -4236,7 +4236,7 @@ XS(XS_OS2_pipe)
             ulOutbufLength = (ULONG)SvUV(ST(5));
 
         if (count < -1 || count == 0 || count >= 255)
-            Perl_croak(aTHX_ "OS2::pipe(): count should be -1 or between 1 and 254: %ld", (long)count);
+            croak("OS2::pipe(): count should be -1 or between 1 and 254: %ld", (long)count);
         if (count < 0 )
             count = 255;		/* Unlimited */
 
@@ -4285,7 +4285,7 @@ XS(XS_OS2_pipeCntl)
 {
     dXSARGS;
     if (items < 2 || items > 3)
-        Perl_croak(aTHX_ "Usage: OS2::pipeCntl(pipe, op [, wait])");
+        croak("Usage: OS2::pipeCntl(pipe, op [, wait])");
     {
         ULONG	rc;
         PerlIO *perlio = IoIFP(sv_2io(ST(0)));
@@ -4297,7 +4297,7 @@ XS(XS_OS2_pipeCntl)
         int	peek = 0, state = 0, info = 0;
 
         if (fn < 0)
-            Perl_croak(aTHX_ "OS2::pipeCntl(): not a pipe");	
+            croak("OS2::pipeCntl(): not a pipe");	
         if (items == 3)
             wait = (SvTRUE(ST(2)) ? 1 : -1);
 
@@ -4340,12 +4340,12 @@ XS(XS_OS2_pipeCntl)
             break;
         default:
           unknown:
-            Perl_croak(aTHX_ "OS2::pipeCntl(): unknown argument: `%s'", s);
+            croak("OS2::pipeCntl(): unknown argument: `%s'", s);
             break;
         }
 
         if (items == 3 && !connect)
-            Perl_croak(aTHX_ "OS2::pipeCntl(): no wait argument for `%s'", s);
+            croak("OS2::pipeCntl(): no wait argument for `%s'", s);
 
         XSprePUSH;		/* Do not need arguments any more */
         if (disconnect) {
@@ -4454,7 +4454,7 @@ XS(XS_OS2_open)
 {
     dXSARGS;
     if (items < 2 || items > 6)
-        Perl_croak(aTHX_ "Usage: OS2::open(pszFileName, ulOpenMode, ulOpenFlags= OPEN_ACTION_OPEN_IF_EXISTS | OPEN_ACTION_FAIL_IF_NEW, ulAttribute= FILE_NORMAL, ulFileSize= 0, pEABuf= NULL)");
+        croak("Usage: OS2::open(pszFileName, ulOpenMode, ulOpenFlags= OPEN_ACTION_OPEN_IF_EXISTS | OPEN_ACTION_FAIL_IF_NEW, ulAttribute= FILE_NORMAL, ulFileSize= 0, pEABuf= NULL)");
     {
 #line 39 "pipe.xs"
         ULONG rc;

--- a/pad.c
+++ b/pad.c
@@ -332,7 +332,7 @@ Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
             assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); /*unsafe is safe */
             if (CvDEPTHunsafe(&cvbody)) {
                 assert(SvTYPE(cv) == SVt_PVCV);
-                Perl_croak_nocontext("Can't undef active subroutine");
+                croak("Can't undef active subroutine");
             }
             ENTER;
 

--- a/pad.c
+++ b/pad.c
@@ -629,7 +629,7 @@ Perl_pad_add_name_pvn(pTHX_ const char *namepv, STRLEN namelen,
     PERL_ARGS_ASSERT_PAD_ADD_NAME_PVN;
 
     if (flags & ~(padadd_OUR|padadd_STATE|padadd_NO_DUP_CHECK|padadd_FIELD))
-        Perl_croak(aTHX_ "panic: pad_add_name_pvn illegal flag bits 0x%" UVxf,
+        croak("panic: pad_add_name_pvn illegal flag bits 0x%" UVxf,
                    (UV)flags);
 
     name = newPADNAMEpvn(namepv, namelen);
@@ -724,7 +724,7 @@ Perl_pad_alloc(pTHX_ I32 optype, U32 tmptype)
     ASSERT_CURPAD_ACTIVE("pad_alloc");
 
     if (AvARRAY(PL_comppad) != PL_curpad)
-        Perl_croak(aTHX_ "panic: pad_alloc, %p!=%p",
+        croak("panic: pad_alloc, %p!=%p",
                    AvARRAY(PL_comppad), PL_curpad);
     if (PL_pad_reset_pending)
         pad_reset();
@@ -989,7 +989,7 @@ Perl_pad_findmy_pvn(pTHX_ const char *namepv, STRLEN namelen, U32 flags)
     PERL_ARGS_ASSERT_PAD_FINDMY_PVN;
 
     if (flags)
-        Perl_croak(aTHX_ "panic: pad_findmy_pvn illegal flag bits 0x%" UVxf,
+        croak("panic: pad_findmy_pvn illegal flag bits 0x%" UVxf,
                    (UV)flags);
 
     /* compilation errors can zero PL_compcv */
@@ -1115,7 +1115,7 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV* cv,
 
     flags &= ~(padadd_STALEOK|padfind_FIELD_OK); /* one-shot flags */
     if (flags)
-        Perl_croak(aTHX_ "panic: pad_findlex illegal flag bits 0x%" UVxf,
+        croak("panic: pad_findlex illegal flag bits 0x%" UVxf,
                    (UV)flags);
 
     *out_flags = 0;
@@ -1374,7 +1374,7 @@ Perl_pad_sv(pTHX_ PADOFFSET po)
     ASSERT_CURPAD_ACTIVE("pad_sv");
 
     if (!po)
-        Perl_croak(aTHX_ "panic: pad_sv po");
+        croak("panic: pad_sv po");
     DEBUG_X(PerlIO_printf(Perl_debug_log,
         "Pad 0x%" UVxf "[0x%" UVxf "] sv:      %ld sv=0x%" UVxf "\n",
         PTR2UV(PL_comppad), PTR2UV(PL_curpad), (long)po, PTR2UV(PL_curpad[po]))
@@ -1565,10 +1565,10 @@ Perl_pad_swipe(pTHX_ PADOFFSET po, bool refadjust)
     if (!PL_curpad)
         return;
     if (AvARRAY(PL_comppad) != PL_curpad)
-        Perl_croak(aTHX_ "panic: pad_swipe curpad, %p!=%p",
+        croak("panic: pad_swipe curpad, %p!=%p",
                    AvARRAY(PL_comppad), PL_curpad);
     if (!po || ((SSize_t)po) > AvFILLp(PL_comppad))
-        Perl_croak(aTHX_ "panic: pad_swipe po=%ld, fill=%ld",
+        croak("panic: pad_swipe po=%ld, fill=%ld",
                    (long)po, (long)AvFILLp(PL_comppad));
 
     DEBUG_X(PerlIO_printf(Perl_debug_log,
@@ -1619,7 +1619,7 @@ S_pad_reset(pTHX)
 {
 #ifdef USE_PAD_RESET
     if (AvARRAY(PL_comppad) != PL_curpad)
-        Perl_croak(aTHX_ "panic: pad_reset curpad, %p!=%p",
+        croak("panic: pad_reset curpad, %p!=%p",
                    AvARRAY(PL_comppad), PL_curpad);
 
     DEBUG_X(PerlIO_printf(Perl_debug_log,
@@ -1773,10 +1773,10 @@ Perl_pad_free(pTHX_ PADOFFSET po)
     if (!PL_curpad)
         return;
     if (AvARRAY(PL_comppad) != PL_curpad)
-        Perl_croak(aTHX_ "panic: pad_free curpad, %p!=%p",
+        croak("panic: pad_free curpad, %p!=%p",
                    AvARRAY(PL_comppad), PL_curpad);
     if (!po)
-        Perl_croak(aTHX_ "panic: pad_free po");
+        croak("panic: pad_free po");
 
     DEBUG_X(PerlIO_printf(Perl_debug_log,
             "Pad 0x%" UVxf "[0x%" UVxf "] free:    %ld\n",
@@ -2186,7 +2186,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
                         ) == o
                      && !OpSIBLING(o))
                     {
-                        Perl_croak(aTHX_
+                        croak(
                             "Constants from lexical variables potentially modified "
                             "elsewhere are no longer permitted");
                     }
@@ -2277,7 +2277,7 @@ Perl_cv_clone(pTHX_ CV *proto)
 {
     PERL_ARGS_ASSERT_CV_CLONE;
 
-    if (!CvPADLIST(proto)) Perl_croak(aTHX_ "panic: no pad in cv_clone");
+    if (!CvPADLIST(proto)) croak("panic: no pad in cv_clone");
     return S_cv_clone(aTHX_ proto, NULL, NULL, NULL);
 }
 

--- a/pad.c
+++ b/pad.c
@@ -358,7 +358,7 @@ Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
                 LEAVE;
             }
 #ifdef DEBUGGING
-            else Perl_warn(aTHX_ "Slab leaked from cv %p", (void*)cv);
+            else warn("Slab leaked from cv %p", (void*)cv);
 #endif
         }
     }
@@ -520,7 +520,7 @@ Perl_cv_forget_slab(pTHX_ CV *cv)
     if      (CvROOT(cv))  slab = OpSLAB(CvROOT(cv));
     else if (CvSTART(cv)) slab = (OPSLAB *)CvSTART(cv);
 #ifdef DEBUGGING
-    else if (slabbed)     Perl_warn(aTHX_ "Slab leaked from cv %p", (void*)cv);
+    else if (slabbed)     warn("Slab leaked from cv %p", (void*)cv);
 #endif
 
     if (slab) {

--- a/perl.c
+++ b/perl.c
@@ -2276,7 +2276,7 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
 #if defined(SILENT_NO_TAINT_SUPPORT)
             /* silently ignore */
 #elif defined(NO_TAINT_SUPPORT)
-            Perl_croak_nocontext("This perl was compiled without taint support. "
+            croak("This perl was compiled without taint support. "
                        "Cowardly refusing to run with -t or -T flags");
 #else
             CHECK_MALLOC_TOO_LATE_FOR('t');
@@ -2291,7 +2291,7 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
 #if defined(SILENT_NO_TAINT_SUPPORT)
             /* silently ignore */
 #elif defined(NO_TAINT_SUPPORT)
-            Perl_croak_nocontext("This perl was compiled without taint support. "
+            croak("This perl was compiled without taint support. "
                        "Cowardly refusing to run with -t or -T flags");
 #else
             CHECK_MALLOC_TOO_LATE_FOR('T');
@@ -2409,7 +2409,7 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
 #if defined(SILENT_NO_TAINT_SUPPORT)
             /* silently ignore */
 #elif defined(NO_TAINT_SUPPORT)
-            Perl_croak_nocontext("This perl was compiled without taint support. "
+            croak("This perl was compiled without taint support. "
                        "Cowardly refusing to run with -t or -T flags");
 #else
             CHECK_MALLOC_TOO_LATE_FOR('T');
@@ -2448,7 +2448,7 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
 #if defined(SILENT_NO_TAINT_SUPPORT)
             /* silently ignore */
 #elif defined(NO_TAINT_SUPPORT)
-                    Perl_croak_nocontext("This perl was compiled without taint support. "
+                    croak("This perl was compiled without taint support. "
                                "Cowardly refusing to run with -t or -T flags");
 #else
                     if( !TAINTING_get) {
@@ -3910,7 +3910,7 @@ Perl_moreswitches(pTHX_ const char *s)
 #if defined(SILENT_NO_TAINT_SUPPORT)
             /* silently ignore */
 #elif defined(NO_TAINT_SUPPORT)
-        Perl_croak_nocontext("This perl was compiled without taint support. "
+        croak("This perl was compiled without taint support. "
                    "Cowardly refusing to run with -t or -T flags");
 #else
         if (!TAINTING_get)
@@ -4088,7 +4088,7 @@ Perl_my_unexec(pTHX)
 #  ifdef VMS
      lib$signal(SS$_DEBUG);  /* ssdef.h #included from vmsish.h */
 #  elif defined(WIN32) || defined(__CYGWIN__)
-    Perl_croak_nocontext("dump is not supported");
+    croak("dump is not supported");
 #  else
     ABORT();		/* for use with undump */
 #  endif
@@ -4329,7 +4329,7 @@ S_validate_suid(pTHX_ PerlIO *rsfp)
         int fd = PerlIO_fileno(rsfp);
         Stat_t statbuf;
         if (fd < 0 || PerlLIO_fstat(fd, &statbuf) < 0) { /* may be either wrapped or real suid */
-            Perl_croak_nocontext( "Illegal suidscript");
+            croak( "Illegal suidscript");
         }
         if ((my_euid != my_uid && my_euid == statbuf.st_uid && statbuf.st_mode & S_ISUID)
             ||

--- a/perl.c
+++ b/perl.c
@@ -4163,7 +4163,7 @@ S_init_main_stash(pTHX)
     PL_replgv = gv_fetchpvs("\022", GV_ADD|GV_NOTQUAL, SVt_PV); /* ^R */
     SvREFCNT_inc_simple_void(PL_replgv);
     GvMULTI_on(PL_replgv);
-    (void)Perl_form(aTHX_ "%240s","");	/* Preallocate temp - for immediate signals. */
+    (void)form("%240s","");	/* Preallocate temp - for immediate signals. */
 #ifdef PERL_DONT_CREATE_GVSV
     (void)gv_SVadd(PL_errgv);
 #endif

--- a/perl.c
+++ b/perl.c
@@ -587,7 +587,7 @@ Perl_dump_sv_child(pTHX_ SV *sv)
     }
 
     if (returned_errno || *buffer) {
-        Perl_warn(aTHX_ "Debug leaking scalars child failed%s%.*s with errno"
+        warn("Debug leaking scalars child failed%s%.*s with errno"
                   " %d: %s", (*buffer ? " at " : ""), (int) *buffer, buffer + 1,
                   returned_errno, Strerror(returned_errno));
     }
@@ -5385,7 +5385,7 @@ Perl_my_exit(pTHX_ U32 status)
     }
     if (PL_exit_flags & PERL_EXIT_WARN) {
         PL_exit_flags |= PERL_EXIT_ABORT; /* Protect against reentrant calls */
-        Perl_warn(aTHX_ "Unexpected exit %lu", (unsigned long)status);
+        warn("Unexpected exit %lu", (unsigned long)status);
         PL_exit_flags &= ~PERL_EXIT_ABORT;
     }
     switch (status) {
@@ -5503,7 +5503,7 @@ Perl_my_failure_exit(pTHX)
     }
     if (PL_exit_flags & PERL_EXIT_WARN) {
         PL_exit_flags |= PERL_EXIT_ABORT; /* Protect against reentrant calls */
-        Perl_warn(aTHX_ "Unexpected exit failure %ld", (long)PL_statusvalue);
+        warn("Unexpected exit failure %ld", (long)PL_statusvalue);
         PL_exit_flags &= ~PERL_EXIT_ABORT;
     }
     my_exit_jump();

--- a/perl.c
+++ b/perl.c
@@ -3786,7 +3786,7 @@ Perl_moreswitches(pTHX_ const char *s)
                 sv_catpvn(sv, start, s-start);
                 /* Don't use NUL as q// delimiter here, this string goes in the
                  * environment. */
-                Perl_sv_catpvf(aTHX_ sv, " split(/,/,q{%s});", ++s);
+                sv_catpvf(sv, " split(/,/,q{%s});", ++s);
             }
             s = end;
             my_setenv("PERL5DB", SvPV_nolen_const(sv));
@@ -5190,7 +5190,7 @@ S_incpush(pTHX_ const char *const dir, STRLEN len, U32 flags)
             if (addoldvers) {
                 for (incver = incverlist; *incver; incver++) {
                     /* .../xxx if -d .../xxx */
-                    Perl_sv_catpvf(aTHX_ subdir, "/%s", *incver);
+                    sv_catpvf(subdir, "/%s", *incver);
                     subdir = S_incpush_if_exists(aTHX_ av, subdir, libdir);
                 }
             }
@@ -5328,7 +5328,7 @@ Perl_call_list(pTHX_ I32 oldscope, AV *paramList)
                 if (paramList == PL_beginav)
                     sv_catpvs(atsv, "BEGIN failed--compilation aborted");
                 else
-                    Perl_sv_catpvf(aTHX_ atsv,
+                    sv_catpvf(atsv,
                                    "%s failed--call queue aborted",
                                    paramList == PL_checkav ? "CHECK"
                                    : paramList == PL_initav ? "INIT"

--- a/perl.c
+++ b/perl.c
@@ -440,7 +440,7 @@ perl_construct(pTHXx)
         PL_mmap_page_size = sysconf(_SC_MMAP_PAGE_SIZE);
 #   endif
         if ((long) PL_mmap_page_size < 0) {
-            Perl_croak(aTHX_ "panic: sysconf: %s",
+            croak("panic: sysconf: %s",
                 errno ? Strerror(errno) : "pagesize unknown");
         }
       }
@@ -450,7 +450,7 @@ perl_construct(pTHXx)
       PL_mmap_page_size = PAGESIZE;       /* compiletime, bad */
 #endif
       if (PL_mmap_page_size <= 0)
-        Perl_croak(aTHX_ "panic: bad pagesize %" IVdf,
+        croak("panic: bad pagesize %" IVdf,
                    (IV) PL_mmap_page_size);
     }
 #endif /* HAS_MMAP */
@@ -2164,10 +2164,10 @@ S_moreswitch_m(pTHX_ char option, const char *s)
         }
     }
     if (s == start)
-        Perl_croak(aTHX_ "Module name required with -%c option",
+        croak("Module name required with -%c option",
                             option);
     if (colon)
-        Perl_croak(aTHX_ "Invalid module name %.*s with -%c option: "
+        croak("Invalid module name %.*s with -%c option: "
                             "contains single ':'",
                             (int)(s - start), start, option);
     end = s + strlen(s);
@@ -2175,7 +2175,7 @@ S_moreswitch_m(pTHX_ char option, const char *s)
         sv_catpvn(sv, start, end - start);
         if (option == 'm') {
             if (*s != '\0')
-                Perl_croak(aTHX_ "Can't use '%c' after -mname", *s);
+                croak("Can't use '%c' after -mname", *s);
             sv_catpvs( sv, " ()");
         }
     } else {
@@ -2318,7 +2318,7 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
                 argc--,argv++;
             }
             else
-                Perl_croak(aTHX_ "No code specified for -%c", c);
+                croak("No code specified for -%c", c);
             sv_catpvs(PL_e_script, "\n");
             break;
 
@@ -2339,7 +2339,7 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
                 incpush(s, len, INCPUSH_ADD_SUB_DIRS|INCPUSH_ADD_OLD_VERS);
             }
             else
-                Perl_croak(aTHX_ "No directory specified for -I");
+                croak("No directory specified for -I");
             break;
         case 'S':
             forbid_setid('S', FALSE);
@@ -2387,7 +2387,7 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
             s--;
             /* FALLTHROUGH */
         default:
-            Perl_croak(aTHX_ "Unrecognized switch: -%s  (-h will show valid options)",s);
+            croak("Unrecognized switch: -%s  (-h will show valid options)",s);
         }
     }
     }
@@ -2432,7 +2432,7 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
                 if (!*s)
                     break;
                 if (!memCHRs("CDIMUdmtwW", *s))
-                    Perl_croak(aTHX_ "Illegal switch in PERL5OPT: -%c", *s);
+                    croak("Illegal switch in PERL5OPT: -%c", *s);
                 while (++s && *s) {
                     if (isSPACE(*s)) {
                         if (!popt_copy) {
@@ -2577,7 +2577,7 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
             lex_start_flags |= LEX_START_COPIED;
             find_beginning(linestr_sv, rsfp);
             if (cddir && PerlDir_chdir( (char *)cddir ) < 0)
-                Perl_croak(aTHX_ "Can't chdir to %s",cddir);
+                croak("Can't chdir to %s",cddir);
         }
     }
 
@@ -2669,7 +2669,7 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
          else if (strEQ(s, "safe"))
               PL_signals &= ~PERL_SIGNALS_UNSAFE_FLAG;
          else
-              Perl_croak(aTHX_ "PERL_SIGNALS illegal: \"%s\"", s);
+              croak("PERL_SIGNALS illegal: \"%s\"", s);
     }
     }
 
@@ -3856,7 +3856,7 @@ Perl_moreswitches(pTHX_ const char *s)
                 s++;
         }
         else
-            Perl_croak(aTHX_ "No directory specified for -I");
+            croak("No directory specified for -I");
         return s;
     case 'l':
         PL_minus_l = TRUE;
@@ -3890,7 +3890,7 @@ Perl_moreswitches(pTHX_ const char *s)
         if (*++s)
             s = S_moreswitch_m(aTHX_ option, s);
         else
-            Perl_croak(aTHX_ "Missing argument to -%c", option);
+            croak("Missing argument to -%c", option);
         return s;
     case 'n':
         PL_minus_n = TRUE;
@@ -3966,9 +3966,9 @@ Perl_moreswitches(pTHX_ const char *s)
     case 'S':
 #endif
     case 'V':
-        Perl_croak(aTHX_ "Can't emulate -%.1s on #! line",s);
+        croak("Can't emulate -%.1s on #! line",s);
     default:
-        Perl_croak(aTHX_
+        croak(
             "Unrecognized switch: -%.1s  (-h will show valid options)",s
         );
     }
@@ -4219,10 +4219,10 @@ S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
                  * Still, can we be sure we got the right thing?
                  */
                 if (*s != '/') {
-                    Perl_croak(aTHX_ "Wrong syntax (suid) fd script name \"%s\"\n", s);
+                    croak("Wrong syntax (suid) fd script name \"%s\"\n", s);
                 }
                 if (! *(s+1)) {
-                    Perl_croak(aTHX_ "Missing (suid) fd script name\n");
+                    croak("Missing (suid) fd script name\n");
                 }
                 scriptname = savepv(s + 1);
                 Safefree(PL_origfilename);
@@ -4263,7 +4263,7 @@ S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
                 scriptname = tmpname;
                 close(tmpfd);
             } else
-                Perl_croak(aTHX_ "Failed to create a fake bit bucket");
+                croak("Failed to create a fake bit bucket");
         }
 #endif
         rsfp = PerlIO_open(scriptname,PERL_SCRIPT_MODE);
@@ -4279,9 +4279,9 @@ S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
     if (!rsfp) {
         /* PSz 16 Sep 03  Keep neat error message */
         if (PL_e_script)
-            Perl_croak(aTHX_ "Can't open " BIT_BUCKET ": %s\n", Strerror(errno));
+            croak("Can't open " BIT_BUCKET ": %s\n", Strerror(errno));
         else
-            Perl_croak(aTHX_ "Can't open perl script \"%s\": %s\n",
+            croak("Can't open perl script \"%s\": %s\n",
                     CopFILE(PL_curcop), Strerror(errno));
     }
     fd = PerlIO_fileno(rsfp);
@@ -4289,7 +4289,7 @@ S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
     if (fd < 0 ||
         (PerlLIO_fstat(fd, &tmpstatbuf) >= 0
          && S_ISDIR(tmpstatbuf.st_mode)))
-        Perl_croak(aTHX_ "Can't open perl script \"%s\": %s\n",
+        croak("Can't open perl script \"%s\": %s\n",
             CopFILE(PL_curcop),
             Strerror(EISDIR));
 
@@ -4336,7 +4336,7 @@ S_validate_suid(pTHX_ PerlIO *rsfp)
             (my_egid != my_gid && my_egid == statbuf.st_gid && statbuf.st_mode & S_ISGID)
             )
             if (!PL_do_undump)
-                Perl_croak(aTHX_ "YOU HAVEN'T DISABLED SET-ID SCRIPTS IN THE KERNEL YET!\n\
+                croak("YOU HAVEN'T DISABLED SET-ID SCRIPTS IN THE KERNEL YET!\n\
 FIX YOUR KERNEL, PUT A C WRAPPER AROUND THIS SCRIPT, OR USE -u AND UNDUMP!\n");
         /* not set-id, must be wrapped */
     }
@@ -4355,7 +4355,7 @@ S_find_beginning(pTHX_ SV* linestr_sv, PerlIO *rsfp)
 
     do {
         if ((s = sv_gets(linestr_sv, rsfp, 0)) == NULL)
-            Perl_croak(aTHX_ "No Perl script found in input\n");
+            croak("No Perl script found in input\n");
         s2 = s;
     } while (!(*s == '#' && s[1] == '!' && ((s = instr(s,"perl")) || (s = instr(s2,"PERL")))));
     PerlIO_ungetc(rsfp, '\n');		/* to keep line count right */
@@ -4455,12 +4455,12 @@ S_forbid_setid(pTHX_ const char flag, const bool suidscript) /* g */
 
 #ifdef SETUID_SCRIPTS_ARE_SECURE_NOW
     if (PerlProc_getuid() != PerlProc_geteuid())
-        Perl_croak(aTHX_ "No %s allowed while running setuid", message);
+        croak("No %s allowed while running setuid", message);
     if (PerlProc_getgid() != PerlProc_getegid())
-        Perl_croak(aTHX_ "No %s allowed while running setgid", message);
+        croak("No %s allowed while running setgid", message);
 #endif /* SETUID_SCRIPTS_ARE_SECURE_NOW */
     if (suidscript)
-        Perl_croak(aTHX_ "No %s allowed with (suid) fdscript", message);
+        croak("No %s allowed with (suid) fdscript", message);
 }
 
 void
@@ -4476,7 +4476,7 @@ Perl_init_dbargs(pTHX)
            "leak" until global destruction.  */
         av_clear(args);
         if (SvTIED_mg((const SV *)args, PERL_MAGIC_tied))
-            Perl_croak(aTHX_ "Cannot set tied @DB::args");
+            croak("Cannot set tied @DB::args");
     }
     AvREIFY_only(PL_dbargs);
 }
@@ -5337,7 +5337,7 @@ Perl_call_list(pTHX_ I32 oldscope, AV *paramList)
                 while (PL_scopestack_ix > oldscope)
                     LEAVE;
                 JMPENV_POP;
-                Perl_croak(aTHX_ "%" SVf, SVfARG(atsv));
+                croak("%" SVf, SVfARG(atsv));
             }
             break;
         case 1:

--- a/perlio.c
+++ b/perlio.c
@@ -760,7 +760,7 @@ perlio_mg_set(pTHX_ SV *sv, MAGIC *mg)
         IO * const io = GvIOn(GV_FROM_REF(sv));
         PerlIO * const ifp = IoIFP(io);
         PerlIO * const ofp = IoOFP(io);
-        Perl_warn(aTHX_ "set %" SVf " %p %p %p",
+        warn("set %" SVf " %p %p %p",
                   SVfARG(sv), (void*)io, (void*)ifp, (void*)ofp);
     }
     return 0;
@@ -773,7 +773,7 @@ perlio_mg_get(pTHX_ SV *sv, MAGIC *mg)
         IO * const io = GvIOn(GV_FROM_REF(sv));
         PerlIO * const ifp = IoIFP(io);
         PerlIO * const ofp = IoOFP(io);
-        Perl_warn(aTHX_ "get %" SVf " %p %p %p",
+        warn("get %" SVf " %p %p %p",
                   SVfARG(sv), (void*)io, (void*)ifp, (void*)ofp);
     }
     return 0;
@@ -782,14 +782,14 @@ perlio_mg_get(pTHX_ SV *sv, MAGIC *mg)
 static int
 perlio_mg_clear(pTHX_ SV *sv, MAGIC *mg)
 {
-    Perl_warn(aTHX_ "clear %" SVf, SVfARG(sv));
+    warn("clear %" SVf, SVfARG(sv));
     return 0;
 }
 
 static int
 perlio_mg_free(pTHX_ SV *sv, MAGIC *mg)
 {
-    Perl_warn(aTHX_ "free %" SVf, SVfARG(sv));
+    warn("free %" SVf, SVfARG(sv));
     return 0;
 }
 
@@ -815,7 +815,7 @@ XS(XS_io_MODIFY_SCALAR_ATTRIBUTES)
     mg = mg_find(sv, PERL_MAGIC_ext);
     mg->mg_virtual = &perlio_vtab;
     mg_magical(sv);
-    Perl_warn(aTHX_ "attrib %" SVf, SVfARG(sv));
+    warn("attrib %" SVf, SVfARG(sv));
     for (i = 2; i < items; i++) {
         STRLEN len;
         const char * const name = SvPV_const(ST(i), len);

--- a/perlio.c
+++ b/perlio.c
@@ -2747,20 +2747,19 @@ PerlIOUnix_refcnt_inc(int fd)
 int
 PerlIOUnix_refcnt_dec(int fd)
 {
+    dTHX;
     int cnt = 0;
     if (fd >= 0) {
-#ifdef DEBUGGING
-        dTHX;
-#endif
+
         MUTEX_LOCK(&PL_perlio_mutex);
         if (fd >= PL_perlio_fd_refcnt_size) {
             /* diag_listed_as: refcnt_dec: fd %d%s */
-            Perl_croak_nocontext("refcnt_dec: fd %d >= refcnt_size %d\n",
+            croak("refcnt_dec: fd %d >= refcnt_size %d\n",
                        fd, PL_perlio_fd_refcnt_size);
         }
         if (PL_perlio_fd_refcnt[fd] <= 0) {
             /* diag_listed_as: refcnt_dec: fd %d%s */
-            Perl_croak_nocontext("refcnt_dec: fd %d: %d <= 0\n",
+            croak("refcnt_dec: fd %d: %d <= 0\n",
                        fd, PL_perlio_fd_refcnt[fd]);
         }
         cnt = --PL_perlio_fd_refcnt[fd];
@@ -2768,7 +2767,7 @@ PerlIOUnix_refcnt_dec(int fd)
         MUTEX_UNLOCK(&PL_perlio_mutex);
     } else {
         /* diag_listed_as: refcnt_dec: fd %d%s */
-        Perl_croak_nocontext("refcnt_dec: fd %d < 0\n", fd);
+        croak("refcnt_dec: fd %d < 0\n", fd);
     }
     return cnt;
 }
@@ -5289,8 +5288,8 @@ Perl_PerlIO_stderr(pTHX)
 char *
 PerlIO_getname(PerlIO *f, char *buf)
 {
-#ifdef VMS
     dTHX;
+#ifdef VMS
     char *name = NULL;
     bool exported = FALSE;
     FILE *stdio = PerlIOSelf(f, PerlIOStdio)->stdio;
@@ -5306,7 +5305,7 @@ PerlIO_getname(PerlIO *f, char *buf)
 #else
     PERL_UNUSED_ARG(f);
     PERL_UNUSED_ARG(buf);
-    Perl_croak_nocontext("Don't know how to get file name");
+    croak("Don't know how to get file name");
     return NULL;
 #endif
 }

--- a/perlio.c
+++ b/perlio.c
@@ -211,7 +211,7 @@ PerlIO_apply_layers(pTHX_ PerlIO *f, const char *mode, const char *names)
        ) {
         return 0;
     }
-    Perl_croak(aTHX_ "Cannot apply \"%s\" in non-PerlIO perl", names);
+    croak("Cannot apply \"%s\" in non-PerlIO perl", names);
     /*
      * NOTREACHED
      */
@@ -268,7 +268,7 @@ PerlIO_openn(pTHX_ const char *layers, const char *mode, int fd,
 {
     if (narg) {
         if (narg > 1) {
-            Perl_croak(aTHX_ "More than one argument to open");
+            croak("More than one argument to open");
         }
         if (*args == &PL_sv_undef)
             return PerlIO_tmpfile();
@@ -302,7 +302,7 @@ XS(XS_PerlIO__Layer__find)
 {
     dXSARGS;
     if (items < 2)
-        Perl_croak(aTHX_ "Usage class->find(name[,load])");
+        croak("Usage class->find(name[,load])");
     else {
         const char * const name = SvPV_nolen_const(ST(1));
         ST(0) = (strEQ(name, "crlf")
@@ -726,7 +726,7 @@ PerlIO_find_layer(pTHX_ const char *name, STRLEN len, int load)
     if (load && PL_subname && PL_def_layerlist
         && PL_def_layerlist->cur >= 2) {
         if (PL_in_load_module) {
-            Perl_croak(aTHX_ "Recursive call to Perl_load_module in PerlIO_find_layer");
+            croak("Recursive call to Perl_load_module in PerlIO_find_layer");
             return NULL;
         } else {
             SV * const pkgsv = newSVpvs("PerlIO");
@@ -861,7 +861,7 @@ XS(XS_PerlIO__Layer__find)
 {
     dXSARGS;
     if (items < 2)
-        Perl_croak(aTHX_ "Usage class->find(name[,load])");
+        croak("Usage class->find(name[,load])");
     else {
         STRLEN len;
         const char * const name = SvPV_const(ST(1), len);
@@ -1002,7 +1002,7 @@ PerlIO_layer_fetch(pTHX_ PerlIO_list_t *av, IV n, PerlIO_funcs *def)
         return av->array[n].funcs;
     }
     if (!def)
-        Perl_croak(aTHX_ "panic: PerlIO layer array corrupt");
+        croak("panic: PerlIO layer array corrupt");
     return def;
 }
 
@@ -1554,18 +1554,18 @@ PerlIO_push(pTHX_ PerlIO *f, PERLIO_FUNCS_DECL(*tab), const char *mode, SV *arg)
 {
     VERIFY_HEAD(f);
     if (tab->fsize != sizeof(PerlIO_funcs)) {
-        Perl_croak( aTHX_
-            "%s (%" UVuf ") does not match %s (%" UVuf ")",
-            "PerlIO layer function table size", (UV)tab->fsize,
-            "size expected by this perl", (UV)sizeof(PerlIO_funcs) );
+        croak(
+            "PerlIO layer function table size (%" UVuf ") does not match size expected by this perl (%" UVuf ")",
+            (UV)tab->fsize,
+            (UV)sizeof(PerlIO_funcs) );
     }
     if (tab->size) {
         PerlIOl *l;
         if (tab->size < sizeof(PerlIOl)) {
-            Perl_croak( aTHX_
-                "%s (%" UVuf ") smaller than %s (%" UVuf ")",
-                "PerlIO layer instance size", (UV)tab->size,
-                "size expected by this perl", (UV)sizeof(PerlIOl) );
+            croak(
+                "PerlIO layer instance size (%" UVuf ") smaller than size expected by this perl (%" UVuf ")",
+                (UV)tab->size,
+                (UV)sizeof(PerlIOl) );
         }
         /* Real layer with a data area */
         if (f) {
@@ -1959,7 +1959,7 @@ PerlIO_openn(pTHX_ const char *layers, const char *mode, int fd,
              * Found that layer 'n' can do opens - call it
              */
             if (narg > 1 && !(tab->kind & PERLIO_K_MULTIARG)) {
-                Perl_croak(aTHX_ "More than one argument to open(,':%s')",tab->name);
+                croak("More than one argument to open(,':%s')",tab->name);
             }
             DEBUG_i( PerlIO_debug("openn(%s,'%s','%s',%d,%x,%o,%p,%d,%p)\n",
                                   tab->name, layers ? layers : "(Null)", mode, fd,
@@ -2731,7 +2731,7 @@ PerlIOUnix_refcnt_inc(int fd)
         PL_perlio_fd_refcnt[fd]++;
         if (PL_perlio_fd_refcnt[fd] <= 0) {
             /* diag_listed_as: refcnt_inc: fd %d%s */
-            Perl_croak(aTHX_ "refcnt_inc: fd %d: %d <= 0\n",
+            croak("refcnt_inc: fd %d: %d <= 0\n",
                        fd, PL_perlio_fd_refcnt[fd]);
         }
         DEBUG_i( PerlIO_debug("refcnt_inc: fd %d refcnt=%d\n",
@@ -2740,7 +2740,7 @@ PerlIOUnix_refcnt_inc(int fd)
         MUTEX_UNLOCK(&PL_perlio_mutex);
     } else {
         /* diag_listed_as: refcnt_inc: fd %d%s */
-        Perl_croak(aTHX_ "refcnt_inc: fd %d < 0\n", fd);
+        croak("refcnt_inc: fd %d < 0\n", fd);
     }
 }
 
@@ -2782,19 +2782,19 @@ PerlIOUnix_refcnt(int fd)
         MUTEX_LOCK(&PL_perlio_mutex);
         if (fd >= PL_perlio_fd_refcnt_size) {
             /* diag_listed_as: refcnt: fd %d%s */
-            Perl_croak(aTHX_ "refcnt: fd %d >= refcnt_size %d\n",
+            croak("refcnt: fd %d >= refcnt_size %d\n",
                        fd, PL_perlio_fd_refcnt_size);
         }
         if (PL_perlio_fd_refcnt[fd] <= 0) {
             /* diag_listed_as: refcnt: fd %d%s */
-            Perl_croak(aTHX_ "refcnt: fd %d: %d <= 0\n",
+            croak("refcnt: fd %d: %d <= 0\n",
                        fd, PL_perlio_fd_refcnt[fd]);
         }
         cnt = PL_perlio_fd_refcnt[fd];
         MUTEX_UNLOCK(&PL_perlio_mutex);
     } else {
         /* diag_listed_as: refcnt: fd %d%s */
-        Perl_croak(aTHX_ "refcnt: fd %d < 0\n", fd);
+        croak("refcnt: fd %d < 0\n", fd);
     }
     return cnt;
 }
@@ -5131,7 +5131,7 @@ PerlIOCrlf_set_ptrcnt(pTHX_ PerlIO *f, STDCHAR * ptr, SSize_t cnt)
         chk -= cnt;
 
         if (ptr != chk ) {
-            Perl_croak(aTHX_ "ptr wrong %p != %p fl=%08" UVxf
+            croak("ptr wrong %p != %p fl=%08" UVxf
                        " nl=%p e=%p for %d", (void*)ptr, (void*)chk,
                        flags, c->nl, b->end, cnt);
         }

--- a/perly.act
+++ b/perly.act
@@ -1041,7 +1041,7 @@ case 2: /* @1: %empty  */
 #line 912 "perly.y"
                         {
 			    if (!FEATURE_SIGNATURES_IS_ENABLED && !CvIsMETHOD(PL_compcv))
-			        Perl_croak(aTHX_ "Experimental "
+			        croak("Experimental "
                                     "subroutine signatures not enabled");
 
                             /* We shouldn't get here otherwise */
@@ -2285,6 +2285,6 @@ case 2: /* @1: %empty  */
     
 
 /* Generated from:
- * 453a810482a42d27feedcc7688cd6ced725b9dee5ec9d7dea0a8c789a368e038 perly.y
+ * 57ef509d481a8f100fca417b83deb7d66655912f27495b2f6daa0699748ea44f perly.y
  * f13e9c08cea6302f0c1d1f467405bd0e0880d0ea92d0669901017a7f7e94ab28 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.h
+++ b/perly.h
@@ -244,6 +244,6 @@ int yyparse (void);
 
 
 /* Generated from:
- * 453a810482a42d27feedcc7688cd6ced725b9dee5ec9d7dea0a8c789a368e038 perly.y
+ * 57ef509d481a8f100fca417b83deb7d66655912f27495b2f6daa0699748ea44f perly.y
  * f13e9c08cea6302f0c1d1f467405bd0e0880d0ea92d0669901017a7f7e94ab28 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.tab
+++ b/perly.tab
@@ -1599,6 +1599,6 @@ static const toketypes yy_type_tab[] =
 };
 
 /* Generated from:
- * 453a810482a42d27feedcc7688cd6ced725b9dee5ec9d7dea0a8c789a368e038 perly.y
+ * 57ef509d481a8f100fca417b83deb7d66655912f27495b2f6daa0699748ea44f perly.y
  * f13e9c08cea6302f0c1d1f467405bd0e0880d0ea92d0669901017a7f7e94ab28 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.y
+++ b/perly.y
@@ -911,7 +911,7 @@ subsigguts:
                 optsiglist
 			{
 			    if (!FEATURE_SIGNATURES_IS_ENABLED && !CvIsMETHOD(PL_compcv))
-			        Perl_croak(aTHX_ "Experimental "
+			        croak("Experimental "
                                     "subroutine signatures not enabled");
 
                             /* We shouldn't get here otherwise */

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2283,11 +2283,6 @@ L<builtin> by using the C<unimport> method (likely via C<no builtin ...>
 syntax), but the requested function has not been imported into the current
 scope.
 
-=item %s (%d) does not match %s (%d)
-
-(P) The size of a PerlIO function table passed by an extension is smaller than
-expected.
-
 =item Don't know how to get file name
 
 (P) C<PerlIO_getname>, a perl internal I/O function specific to VMS, was
@@ -5378,6 +5373,14 @@ are as follows.
 Both numeric and string values are accepted, but note that string values are
 case sensitive.  The default for this setting is "RANDOM" or 1.
 
+=item PerlIO layer function table size (%d) does not match size expected by this perl (%d)
+
+(P) The size of a PerlIO function table passed by an extension is smaller than expected.
+
+=item PerlIO layer instance size (%d) smaller than size expected by this perl (%d)
+
+(P) The size of a PerlIO instance passed by an extension is smaller than expected.
+
 =item pid %x not a child
 
 (W exec) A warning peculiar to VMS.  Waitpid() was asked to wait for a
@@ -6243,11 +6246,6 @@ requested.
 (F) In a subroutine signature, you put something after a slurpy (array or
 hash) parameter.  The slurpy parameter takes all the available arguments,
 so there can't be any left to fill later parameters.
-
-=item %s (%d) smaller than %s (%d)
-
-(P) The size of a PerlIO instance passed by an extension is smaller than
-expected.
 
 =item Smart matching a non-overloaded object breaks encapsulation
 

--- a/pp.c
+++ b/pp.c
@@ -289,7 +289,7 @@ PP(pp_rv2sv)
             else if (gv)
                 sv = save_scalar(gv);
             else
-                Perl_croak(aTHX_ "%s", PL_no_localize_ref);
+                croak("%s", PL_no_localize_ref);
         }
         else if (PL_op->op_private & OPpDEREF)
             sv = vivify_ref(sv, PL_op->op_private & OPpDEREF);
@@ -593,7 +593,7 @@ PP(pp_bless)
       curstash:
         stash = CopSTASH(PL_curcop);
         if (SvTYPE(stash) != SVt_PVHV)
-            Perl_croak(aTHX_ "Attempt to bless into a freed package");
+            croak("Attempt to bless into a freed package");
     }
     else {
         SV * const ssv = *sp--;
@@ -607,7 +607,7 @@ PP(pp_bless)
         if (SvROK(ssv)) {
           if (!SvAMAGIC(ssv)) {
            frog:
-            Perl_croak(aTHX_ "Attempt to bless into a reference");
+            croak("Attempt to bless into a reference");
           }
           /* SvAMAGIC is on here, but it only means potentially overloaded,
              so after stringification: */
@@ -1848,7 +1848,7 @@ PP_wrapped(pp_repeat,
 
             if ( items > SSize_t_MAX / (SSize_t)sizeof(SV *) / count )
                 /* diag_listed_as: Out of memory during %s extend */
-                Perl_croak(aTHX_ "Out of memory during list extend");
+                croak("Out of memory during list extend");
             max = items * count;
             MEXTEND(MARK, max);
 
@@ -1887,7 +1887,7 @@ PP_wrapped(pp_repeat,
                 if (   len > (MEM_SIZE_MAX-1) / (UV)count /* max would overflow */
                 )
                     /* diag_listed_as: Out of memory during %s extend */
-                    Perl_croak(aTHX_ "Out of memory during string extend");
+                    croak("Out of memory during string extend");
                 max = (UV)count * len + 1;
                 SvGROW(TARG, max);
 
@@ -2791,7 +2791,7 @@ S_scomplement(pTHX_ SV *targ, SV *sv)
 
         if (SvUTF8(TARG)) {
             if (len && ! utf8_to_bytes_overwrite(&tmps, &len)) {
-                Perl_croak(aTHX_ FATAL_ABOVE_FF_MSG, PL_op_desc[PL_op->op_type]);
+                croak(FATAL_ABOVE_FF_MSG, PL_op_desc[PL_op->op_type]);
             }
             SvCUR_set(TARG, len);
             SvUTF8_off(TARG);
@@ -3716,7 +3716,7 @@ PP_wrapped(pp_substr,
 
   bound_fail:
     if (repl)
-        Perl_croak(aTHX_ "substr outside of string");
+        croak("substr outside of string");
     Perl_ck_warner(aTHX_ packWARN(WARN_SUBSTR), "substr outside of string");
     RETPUSHUNDEF;
 }
@@ -4065,7 +4065,7 @@ PP(pp_chr)
     if (UNLIKELY(SvAMAGIC(top)))
         top = sv_2num(top);
     if (UNLIKELY(isinfnansv(top)))
-        Perl_croak(aTHX_ "Cannot chr %" NVgf, SvNV(top));
+        croak("Cannot chr %" NVgf, SvNV(top));
     else {
         if (!IN_BYTES /* under bytes, chr(-1) eq chr(0xff), etc. */
             && ((SvIOKp(top) && !SvIsUV(top) && SvIV_nomg(top) < 0)
@@ -5424,7 +5424,7 @@ PP(pp_kvaslice)
        if (flags) {
            if (!(flags & OPpENTERSUB_INARGS))
                /* diag_listed_as: Can't modify %s in %s */
-               Perl_croak(aTHX_ "Can't modify index/value array slice in list assignment");
+               croak("Can't modify index/value array slice in list assignment");
            lval = flags;
        }
     }
@@ -5519,7 +5519,7 @@ PP_wrapped(pp_akeys, 1, 0)
         const I32 flags = is_lvalue_sub();
         if (flags && !(flags & OPpENTERSUB_INARGS))
             /* diag_listed_as: Can't modify %s in %s */
-            Perl_croak(aTHX_
+            croak(
                       "Can't modify keys on array in list assignment");
       }
       {
@@ -5939,7 +5939,7 @@ PP(pp_kvhslice)
        if (flags) {
            if (!(flags & OPpENTERSUB_INARGS))
                /* diag_listed_as: Can't modify %s in %s */
-               Perl_croak(aTHX_ "Can't modify key/value hash slice in %s assignment",
+               croak("Can't modify key/value hash slice in %s assignment",
                                  GIMME_V == G_LIST ? "list" : "scalar");
            lval = flags;
        }
@@ -7274,7 +7274,7 @@ PP_wrapped(pp_coreargs, 0, 0)
     else if(numargs > maxargs) err = "Too many";
     if (err)
         /* diag_listed_as: Too many arguments for %s */
-        Perl_croak(aTHX_
+        croak(
           "%s arguments for %s", err,
            opnum ? PL_op_desc[opnum] : SvPV_nolen_const(cSVOP_sv)
         );
@@ -7454,7 +7454,7 @@ S_localise_aelem_lval(pTHX_ AV * const av, SV * const keysv,
     if (can_preserve ? av_exists(av, ix) : TRUE) {
         SV ** const svp = av_fetch(av, ix, 1);
         if (!svp || !*svp)
-            Perl_croak(aTHX_ PL_no_aelem, ix);
+            croak(PL_no_aelem, ix);
         save_aelem(av, ix, svp);
     }
     else
@@ -7469,7 +7469,7 @@ S_localise_helem_lval(pTHX_ HV * const hv, SV * const keysv,
         HE * const he = hv_fetch_ent(hv, keysv, 1, 0);
         SV ** const svp = he ? &HeVAL(he) : NULL;
         if (!svp || !*svp)
-            Perl_croak(aTHX_ PL_no_helem_sv, SVfARG(keysv));
+            croak(PL_no_helem_sv, SVfARG(keysv));
         save_helem_flags(hv, keysv, svp, 0);
     }
     else

--- a/pp.c
+++ b/pp.c
@@ -115,7 +115,7 @@ S_rv2gv(pTHX_ SV *sv, const bool vivify_sv, const bool strict,
             sv = MUTABLE_SV(gv);
         }
         else if (!isGV_with_GP(sv)) {
-            Perl_die(aTHX_ "Not a GLOB reference");
+            die("Not a GLOB reference");
         }
     }
     else {
@@ -143,7 +143,7 @@ S_rv2gv(pTHX_ SV *sv, const bool vivify_sv, const bool strict,
                     goto wasref;
                 }
                 if (PL_op->op_flags & OPf_REF || strict) {
-                    Perl_die(aTHX_ PL_no_usym, "a symbol");
+                    die(PL_no_usym, "a symbol");
                 }
                 if (ckWARN(WARN_UNINITIALIZED))
                     report_uninit(sv);
@@ -158,7 +158,7 @@ S_rv2gv(pTHX_ SV *sv, const bool vivify_sv, const bool strict,
             }
             else {
                 if (strict) {
-                    Perl_die(aTHX_
+                    die(
                              PL_no_symref_sv,
                              sv,
                              (SvPOKp(sv) && SvCUR(sv)>32 ? "..." : ""),
@@ -223,16 +223,16 @@ Perl_softref2xv(pTHX_ SV *const sv, const char *const what,
 
     if (PL_op->op_private & HINT_STRICT_REFS) {
         if (SvOK(sv))
-            Perl_die(aTHX_ PL_no_symref_sv, sv,
+            die(PL_no_symref_sv, sv,
                      (SvPOKp(sv) && SvCUR(sv)>32 ? "..." : ""), what);
         else
-            Perl_die(aTHX_ PL_no_usym, what);
+            die(PL_no_usym, what);
     }
     if (!SvOK(sv)) {
         if (
           PL_op->op_flags & OPf_REF
         )
-            Perl_die(aTHX_ PL_no_usym, what);
+            die(PL_no_usym, what);
         if (ckWARN(WARN_UNINITIALIZED))
             report_uninit(sv);
         if (type != SVt_PV && GIMME_V == G_LIST) {

--- a/pp.c
+++ b/pp.c
@@ -3171,7 +3171,7 @@ PP(pp_sin)
               char * mesg;
               LC_NUMERIC_LOCK(0);
               SET_NUMERIC_STANDARD();
-              mesg = Perl_form(aTHX_ "Can't take %s of %" NVgf, neg_report, value);
+              mesg = form("Can't take %s of %" NVgf, neg_report, value);
               LC_NUMERIC_UNLOCK;
 
               /* diag_listed_as: Can't take log of %g */

--- a/pp.c
+++ b/pp.c
@@ -128,7 +128,7 @@ S_rv2gv(pTHX_ SV *sv, const bool vivify_sv, const bool strict,
                     GV *gv;
                     HV *stash;
                     if (SvREADONLY(sv))
-                        Perl_croak_no_modify();
+                        croak_no_modify();
                     gv = MUTABLE_GV(newSV_type(SVt_NULL));
                     stash = CopSTASH(PL_curcop);
                     if (SvTYPE(stash) != SVt_PVHV) stash = NULL;
@@ -787,7 +787,7 @@ S_do_chomp(pTHX_ SV *retval, SV *sv, bool chomping)
         return count;
     }
     else if (SvREADONLY(sv)) {
-            Perl_croak_no_modify();
+            croak_no_modify();
     }
 
     s = SvPV(sv, len);
@@ -6198,7 +6198,7 @@ PP_wrapped(pp_splice, 0, 1)
     }
 
     if (SvREADONLY(ary))
-        Perl_croak_no_modify();
+        croak_no_modify();
 
     SP++;
 
@@ -6419,7 +6419,7 @@ PP(pp_push)
         U16 old_delaymagic = PL_delaymagic;
 
         if (SvREADONLY(ary) && MARK < PL_stack_sp)
-            Perl_croak_no_modify();
+            croak_no_modify();
         PL_delaymagic = DM_DELAY;
         for (++MARK; MARK <= PL_stack_sp; MARK++) {
             SV *sv;

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -924,13 +924,13 @@ PP_wrapped(pp_formline, 0, 1)
                 {
                     int len;
                     if (!quadmath_format_valid(fmt))
-                        Perl_croak_nocontext("panic: quadmath invalid format \"%s\"", fmt);
+                        croak("panic: quadmath invalid format \"%s\"", fmt);
                     WITH_LC_NUMERIC_SET_TO_NEEDED(
                         len = quadmath_snprintf(t, max, fmt, (int) fieldsize,
                                                (int) arg, value);
                     );
                     if (len == -1)
-                        Perl_croak_nocontext("panic: quadmath_snprintf failed, format \"%s\"", fmt);
+                        croak("panic: quadmath_snprintf failed, format \"%s\"", fmt);
                 }
 #else
                 /* we generate fmt ourselves so it is safe */

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -1946,7 +1946,7 @@ Perl_qerror(pTHX_ SV *err)
         else if (PL_errors)
             sv_catsv(PL_errors, err);
         else
-            Perl_warn(aTHX_ "%" SVf, SVfARG(err));
+            warn("%" SVf, SVfARG(err));
 
         if (PL_parser) {
             ++PL_parser->error_count;

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -273,7 +273,7 @@ PP(pp_substcont)
             }
             else {
                 SV_CHECK_THINKFIRST_COW_DROP(targ);
-                if (isGV(targ)) Perl_croak_no_modify();
+                if (isGV(targ)) croak_no_modify();
                 SvPV_free(targ);
                 SvPV_set(targ, SvPVX(dstr));
                 SvCUR_set(targ, SvCUR(dstr));

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -6767,7 +6767,7 @@ S_doparseform(pTHX_ SV *sv)
     mg->mg_flags |= MGf_REFCOUNTED;
 
     if (unchopnum && repeat)
-        Perl_die(aTHX_ "Repeated format line will never terminate (~~ and @#)");
+        die("Repeated format line will never terminate (~~ and @#)");
 
     return mg;
 }

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4859,7 +4859,7 @@ S_require_file(pTHX_ SV *sv)
                         }
                     }
 
-                    Perl_sv_setpvf(aTHX_ namesv, "/loader/0x%" UVxf "/%s",
+                    sv_setpvf(namesv, "/loader/0x%" UVxf "/%s",
                                    diruv, name);
                     tryname = SvPVX_const(namesv);
                     tryrsfp = NULL;
@@ -5099,7 +5099,7 @@ S_require_file(pTHX_ SV *sv)
                     sv_catpv(namesv, unixname);
 #else
                     /* The equivalent of		    
-                       Perl_sv_setpvf(aTHX_ namesv, "%s/%s", dir, name);
+                       sv_setpvf(namesv, "%s/%s", dir, name);
                        but without the need to parse the format string, or
                        call strlen on either pointer, and with the correct
                        allocation up front.  */
@@ -5440,7 +5440,7 @@ PP(pp_entereval)
 
     if (PERLDB_NAMEEVAL && CopLINE(PL_curcop)) {
         SV * const temp_sv = sv_newmortal();
-        Perl_sv_setpvf(aTHX_ temp_sv, "_<(eval %lu)[%s:%" LINE_Tf "]",
+        sv_setpvf(temp_sv, "_<(eval %lu)[%s:%" LINE_Tf "]",
                        (unsigned long)++PL_evalseq,
                        CopFILE(PL_curcop), CopLINE(PL_curcop));
         tmpbuf = SvPVX(temp_sv);

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -175,7 +175,7 @@ PP(pp_regcomp)
     if (!RX_PRELEN(PM_GETRE(pm)) && PL_curpm) {
         if (PL_curpm == PL_reg_curpm) {
             if (PL_curpm_under && PL_curpm_under == PL_reg_curpm) {
-                Perl_croak(aTHX_ "Infinite recursion via empty pattern");
+                croak("Infinite recursion via empty pattern");
             }
         }
     }
@@ -1492,7 +1492,7 @@ PP_wrapped(pp_flop, (GIMME_V == G_LIST) ? 2 : 1, 0)
                         overflow = TRUE;
                 }
                 if (overflow)
-                    Perl_croak(aTHX_ "Out of memory during list extend");
+                    croak("Out of memory during list extend");
                 EXTEND_MORTAL(n);
                 EXTEND(SP, n);
             }
@@ -1655,7 +1655,7 @@ Perl_block_gimme(pTHX)
 
     gimme = (cxstack[cxix].blk_gimme & G_WANT);
     if (!gimme)
-        Perl_croak(aTHX_ "panic: bad gimme: %d\n", gimme);
+        croak("panic: bad gimme: %d\n", gimme);
     return gimme;
 }
 
@@ -1970,10 +1970,10 @@ Perl_qerror(pTHX_ SV *err)
         else
         if (raw_error_count >= PERL_STOP_PARSING_AFTER_N_ERRORS) {
             if (errsv) {
-                Perl_croak(aTHX_ "%" SVf "%s has too many errors.\n",
+                croak("%" SVf "%s has too many errors.\n",
                     SVfARG(errsv), name);
             } else {
-                Perl_croak(aTHX_ "%s has too many errors.\n", name);
+                croak("%s has too many errors.\n", name);
             }
         }
     }
@@ -2021,7 +2021,7 @@ S_pop_eval_context_maybe_croak(pTHX_ PERL_CONTEXT *cx, SV *errsv, int action)
                 errsv = newSVpvs_flags("Unknown error\n", SVs_TEMP);
         }
 
-        Perl_croak(aTHX_ fmt, SVfARG(errsv));
+        croak(fmt, SVfARG(errsv));
     }
 }
 
@@ -2804,7 +2804,7 @@ PP(pp_leavesublv)
                     what = "undef";
                 }
               croak:
-                Perl_croak(aTHX_
+                croak(
                           "Can't return %s from lvalue subroutine", what);
             }
 
@@ -2878,7 +2878,7 @@ PP(pp_return)
             if(CxTYPE(&cxstack[i]) == CXt_DEFER)
                 /* diag_listed_as: Can't "%s" out of a "defer" block */
                 /* diag_listed_as: Can't "%s" out of a "finally" block */
-                Perl_croak(aTHX_ "Can't \"%s\" out of a \"%s\" block",
+                croak("Can't \"%s\" out of a \"%s\" block",
                         "return", S_defer_blockname(&cxstack[i]));
         }
         if (cxix < 0) {
@@ -3005,7 +3005,7 @@ S_unwind_loop(pTHX)
         cxix = dopoptoloop(cxstack_ix);
         if (cxix < 0)
             /* diag_listed_as: Can't "last" outside a loop block */
-            Perl_croak(aTHX_ "Can't \"%s\" outside a loop block",
+            croak("Can't \"%s\" outside a loop block",
                 OP_NAME(PL_op));
     }
     else {
@@ -3029,7 +3029,7 @@ S_unwind_loop(pTHX)
         cxix = dopoptolabel(label, label_len, label_flags);
         if (cxix < 0)
             /* diag_listed_as: Label not found for "last %s" */
-            Perl_croak(aTHX_ "Label not found for \"%s %" SVf "\"",
+            croak("Label not found for \"%s %" SVf "\"",
                                        OP_NAME(PL_op),
                                        SVfARG(PL_op->op_flags & OPf_STACKED
                                               && !SvGMAGICAL(sv)
@@ -3048,7 +3048,7 @@ S_unwind_loop(pTHX)
             if(CxTYPE(&cxstack[i]) == CXt_DEFER)
                 /* diag_listed_as: Can't "%s" out of a "defer" block */
                 /* diag_listed_as: Can't "%s" out of a "finally" block */
-                Perl_croak(aTHX_ "Can't \"%s\" out of a \"%s\" block",
+                croak("Can't \"%s\" out of a \"%s\" block",
                         OP_NAME(PL_op), S_defer_blockname(&cxstack[i]));
         }
         dounwind(cxix);
@@ -3131,7 +3131,7 @@ S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstac
     PERL_ARGS_ASSERT_DOFINDLABEL;
 
     if (ops >= oplimit)
-        Perl_croak(aTHX_ "%s", too_deep);
+        croak("%s", too_deep);
     if (o->op_type == OP_LEAVE ||
         o->op_type == OP_SCOPE ||
         o->op_type == OP_LEAVELOOP ||
@@ -3159,7 +3159,7 @@ S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstac
       }
     }
     if (ops >= oplimit)
-        Perl_croak(aTHX_ "%s", too_deep);
+        croak("%s", too_deep);
     *ops = 0;
     if (o->op_flags & OPf_KIDS) {
         OP *kid;
@@ -3205,7 +3205,7 @@ S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstac
             }
             if ((o = dofindlabel(kid, label, len, flags, ops, oplimit))) {
                 if (kid->op_type == OP_PUSHDEFER)
-                    Perl_croak(aTHX_ "Can't \"goto\" into a \"defer\" block");
+                    croak("Can't \"goto\" into a \"defer\" block");
                 return o;
             }
             if (first_kid_of_binary)
@@ -3224,13 +3224,13 @@ S_check_op_type(pTHX_ OP * const o)
      * for each op.  For now, we punt on the hard ones. */
     /* XXX This comment seems to me like wishful thinking.  --sprout */
     if (o == UNENTERABLE)
-        Perl_croak(aTHX_
+        croak(
                   "Can't \"goto\" into a binary or list expression");
     if (o->op_type == OP_ENTERITER)
-        Perl_croak(aTHX_
+        croak(
                   "Can't \"goto\" into the middle of a foreach loop");
     if (o->op_type == OP_ENTERGIVEN)
-        Perl_croak(aTHX_
+        croak(
                   "Can't \"goto\" into a \"given\" block");
 }
 
@@ -3303,7 +3303,7 @@ PP(pp_goto)
             for(ix = cxstack_ix; ix > cxix; ix--) {
                 if(CxTYPE(&cxstack[ix]) == CXt_DEFER)
                     /* diag_listed_as: Can't "%s" out of a "defer" block */
-                    Perl_croak(aTHX_ "Can't \"%s\" out of a \"%s\" block",
+                    croak("Can't \"%s\" out of a \"%s\" block",
                             "goto", S_defer_blockname(&cxstack[ix]));
             }
 
@@ -5919,7 +5919,7 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
 
     if (SvROK(e) && SvOBJECT(SvRV(e)) && (SvTYPE(SvRV(e)) != SVt_REGEXP)) {
         DEBUG_M(Perl_deb(aTHX_ "    applying rule Any-Object\n"));
-        Perl_croak(aTHX_ "Smart matching a non-overloaded object breaks encapsulation");
+        croak("Smart matching a non-overloaded object breaks encapsulation");
     }
     if (SvROK(d) && SvOBJECT(SvRV(d)) && (SvTYPE(SvRV(d)) != SVt_REGEXP))
         object_on_left = TRUE;
@@ -6544,7 +6544,7 @@ S_doparseform(pTHX_ SV *sv)
     PERL_ARGS_ASSERT_DOPARSEFORM;
 
     if (len == 0)
-        Perl_croak(aTHX_ "Null picture in formline");
+        croak("Null picture in formline");
 
     if (SvTYPE(sv) >= SVt_PVMG) {
         /* This might, of course, still return NULL.  */

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -2330,7 +2330,7 @@ PP(pp_padav)
         if (flags && !(flags & OPpENTERSUB_INARGS)) {
             if (GIMME_V == G_SCALAR)
                 /* diag_listed_as: Can't return %s to lvalue scalar context */
-                Perl_croak(aTHX_ "Can't return array to lvalue scalar context");
+                croak("Can't return array to lvalue scalar context");
             goto ret;
        }
     }
@@ -2384,7 +2384,7 @@ PP(pp_padhv)
         if (flags && !(flags & OPpENTERSUB_INARGS)) {
             if (GIMME_V == G_SCALAR)
                 /* diag_listed_as: Can't return %s to lvalue scalar context */
-                Perl_croak(aTHX_ "Can't return hash to lvalue scalar context");
+                croak("Can't return hash to lvalue scalar context");
             rpp_push_1(TARG);
             return NORMAL;
         }
@@ -2422,7 +2422,7 @@ PP(pp_rv2av)
             DIE(aTHX_ "Not %s reference", is_pp_rv2av ? an_array : a_hash);
         else if (UNLIKELY(PL_op->op_flags & OPf_MOD
                 && PL_op->op_private & OPpLVAL_INTRO))
-            Perl_croak(aTHX_ "%s", PL_no_localize_ref);
+            croak("%s", PL_no_localize_ref);
     }
     else if (UNLIKELY(SvTYPE(sv) != type)) {
             GV *gv;
@@ -2497,7 +2497,7 @@ PP(pp_rv2av)
     return NORMAL;
 
  croak_cant_return:
-    Perl_croak(aTHX_ "Can't return %s to lvalue scalar context",
+    croak("Can't return %s to lvalue scalar context",
                is_pp_rv2av ? "array" : "hash");
 }
 
@@ -2641,7 +2641,7 @@ S_aassign_copy_common(pTHX_ SV **firstlelem, SV **lastlelem,
 #ifdef DEBUGGING
             if (fake) {
                 /* op_dump(PL_op); */
-                Perl_croak(aTHX_
+                croak(
                     "panic: aassign skipped needed copy of common RH elem %"
                         UVuf, (UV)(relem - firstrelem));
             }
@@ -2658,7 +2658,7 @@ S_aassign_copy_common(pTHX_ SV **firstlelem, SV **lastlelem,
                (It's relying on a panic, not a "semi-panic" from newSVsv()
                and then an assertion failure below.)  */
             if (UNLIKELY(SvIS_FREED(svr))) {
-                Perl_croak(aTHX_ "panic: attempt to copy freed scalar %p",
+                croak("panic: attempt to copy freed scalar %p",
                            (void*)svr);
             }
 #endif
@@ -3763,7 +3763,7 @@ PP(pp_match)
         if (PL_curpm == PL_reg_curpm) {
             if (PL_curpm_under) {
                 if (PL_curpm_under == PL_reg_curpm) {
-                    Perl_croak(aTHX_ "Infinite recursion via empty pattern");
+                    croak("Infinite recursion via empty pattern");
                 } else {
                     pm = PL_curpm_under;
                 }
@@ -5072,7 +5072,7 @@ PP(pp_iter)
             if (LIKELY(sv)) {
                 if (UNLIKELY(SvIS_FREED(sv))) {
                     *itersvp = NULL;
-                    Perl_croak(aTHX_ "Use of freed value in iteration");
+                    croak("Use of freed value in iteration");
                 }
                 if (SvPADTMP(sv)) {
                     sv = newSVsv(sv);
@@ -5319,7 +5319,7 @@ PP(pp_subst)
         if (PL_curpm == PL_reg_curpm) {
             if (PL_curpm_under) {
                 if (PL_curpm_under == PL_reg_curpm) {
-                    Perl_croak(aTHX_ "Infinite recursion via empty pattern");
+                    croak("Infinite recursion via empty pattern");
                 } else {
                     pm = PL_curpm_under;
                 }
@@ -6743,7 +6743,7 @@ S_opmethod_stash(pTHX_ SV* meth)
     HV* stash;
 
     SV* const sv = PL_stack_base + TOPMARK == PL_stack_sp
-        ? (Perl_croak(aTHX_ "Can't call method \"%" SVf "\" without a "
+        ? (croak("Can't call method \"%" SVf "\" without a "
                             "package or object reference", SVfARG(meth)),
            (SV *)NULL)
         : *(PL_stack_base + TOPMARK + 1);
@@ -6752,7 +6752,7 @@ S_opmethod_stash(pTHX_ SV* meth)
 
     if (UNLIKELY(!sv))
        undefined:
-        Perl_croak(aTHX_ "Can't call method \"%" SVf "\" on an undefined value",
+        croak("Can't call method \"%" SVf "\" on an undefined value",
                    SVfARG(meth));
 
     if (UNLIKELY(SvGMAGICAL(sv))) mg_get(sv);
@@ -6766,7 +6766,7 @@ S_opmethod_stash(pTHX_ SV* meth)
     else if (!SvOK(sv)) goto undefined;
     else if (isGV_with_GP(sv)) {
         if (!GvIO(sv))
-            Perl_croak(aTHX_ "Can't call method \"%" SVf "\" "
+            croak("Can't call method \"%" SVf "\" "
                              "without a package or object reference",
                               SVfARG(meth));
         ob = sv;
@@ -6807,7 +6807,7 @@ S_opmethod_stash(pTHX_ SV* meth)
             /* this isn't the name of a filehandle either */
             if (!packlen)
             {
-                Perl_croak(aTHX_ "Can't call method \"%" SVf "\" "
+                croak("Can't call method \"%" SVf "\" "
                                  "without a package or object reference",
                                   SVfARG(meth));
             }
@@ -6838,7 +6838,7 @@ S_opmethod_stash(pTHX_ SV* meth)
                      && (ob = MUTABLE_SV(GvIO((const GV *)ob)))
                      && SvOBJECT(ob))))
     {
-        Perl_croak(aTHX_ "Can't call method \"%" SVf "\" on unblessed reference",
+        croak("Can't call method \"%" SVf "\" on unblessed reference",
                    SVfARG((SvPOK(meth) && SvPVX(meth) == PL_isa_DOES)
                                         ? newSVpvs_flags("DOES", SVs_TEMP)
                                         : meth));

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -5278,7 +5278,7 @@ PP(pp_subst)
                 || ( ((SvTYPE(TARG) == SVt_PVGV && isGV_with_GP(TARG))
                       || SvTYPE(TARG) > SVt_PVLV)
                      && !(SvTYPE(TARG) == SVt_PVGV && SvFAKE(TARG)))))
-            Perl_croak_no_modify();
+            croak_no_modify();
     }
 
     orig = SvPV_nomg(TARG, len);
@@ -6710,7 +6710,7 @@ Perl_vivify_ref(pTHX_ SV *sv, U32 to_what)
     SvGETMAGIC(sv);
     if (!SvOK(sv)) {
         if (SvREADONLY(sv))
-            Perl_croak_no_modify();
+            croak_no_modify();
         prepare_SV_for_RV(sv);
         switch (to_what) {
         case OPpDEREF_SV:

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -6551,7 +6551,7 @@ PP(pp_entersub)
          * in scalar context.
         */
         if (PL_curstackinfo->si_stack_hwm < PL_stack_sp - PL_stack_base)
-            Perl_croak_nocontext(
+            croak(
                 "panic: XSUB %s::%s (%s) failed to extend arg stack: "
                 "base=%p, sp=%p, hwm=%p\n",
                     HvNAME(GvSTASH(CvGV(cv))), GvNAME(CvGV(cv)), CvFILE(cv),

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -2748,7 +2748,7 @@ S_aassign_uid(pTHX)
 #  endif /* HAS_SETEUID */
         if (PL_delaymagic & DM_UID) {
             if (PL_delaymagic_uid != PL_delaymagic_euid)
-                Perl_die(aTHX_ "No setreuid available");
+                die("No setreuid available");
             PERL_UNUSED_RESULT(PerlProc_setuid(PL_delaymagic_uid));
         }
 #endif /* HAS_SETRESUID */
@@ -2783,7 +2783,7 @@ S_aassign_uid(pTHX)
 #  endif /* HAS_SETEGID */
         if (PL_delaymagic & DM_GID) {
             if (PL_delaymagic_gid != PL_delaymagic_egid)
-                Perl_die(aTHX_ "No setregid available");
+                die("No setregid available");
             PERL_UNUSED_RESULT(PerlProc_setgid(PL_delaymagic_gid));
         }
 #endif /* HAS_SETRESGID */
@@ -4427,13 +4427,13 @@ S_softref2xv_lite(pTHX_ SV *const sv, const char *const what,
 {
     if (PL_op->op_private & HINT_STRICT_REFS) {
         if (SvOK(sv))
-            Perl_die(aTHX_ PL_no_symref_sv, sv,
+            die(PL_no_symref_sv, sv,
                      (SvPOKp(sv) && SvCUR(sv)>32 ? "..." : ""), what);
         else
-            Perl_die(aTHX_ PL_no_usym, what);
+            die(PL_no_usym, what);
     }
     if (!SvOK(sv))
-        Perl_die(aTHX_ PL_no_usym, what);
+        die(PL_no_usym, what);
     return gv_fetchsv_nomg(sv, GV_ADD, type);
 }
 

--- a/pp_pack.c
+++ b/pp_pack.c
@@ -257,7 +257,7 @@ utf8_to_byte(pTHX_ const char **s, const char *end, I32 datumtype)
                          ckWARN(WARN_UTF8) ? 0 : UTF8_ALLOW_ANY);
     if (retlen == (STRLEN) -1)
       croak:
-        Perl_croak(aTHX_ "Malformed UTF-8 string in '%c' format in unpack",
+        croak("Malformed UTF-8 string in '%c' format in unpack",
                    (int) TYPE_NO_MODIFIERS(datumtype));
     if (val >= 0x100) {
         Perl_ck_warner(aTHX_ packWARN(WARN_UNPACK),
@@ -361,14 +361,14 @@ STMT_START {							\
 #define SAFE_UTF8_EXPAND(var)	\
 STMT_START {				\
     if ((var) > SSize_t_MAX / UTF8_EXPAND) \
-        Perl_croak(aTHX_ "Out of memory during pack()"); \
+        croak("Out of memory during pack()"); \
     (var) = (var) * UTF8_EXPAND; \
 } STMT_END
 
 #define GROWING2(utf8, cat, start, cur, item_size, item_count)	\
 STMT_START {							\
     if (SSize_t_MAX / (item_size) < (item_count))		\
-        Perl_croak(aTHX_ "Out of memory during pack()");	\
+        croak("Out of memory during pack()");	                \
     GROWING((utf8), (cat), (start), (cur), (item_size) * (item_count)); \
 } STMT_END
 
@@ -378,8 +378,8 @@ STMT_START {					\
     STRLEN catcur = (STRLEN)((cur) - (start));	\
     if (utf8) SAFE_UTF8_EXPAND(glen);		\
     if (SSize_t_MAX - glen < catcur)		\
-        Perl_croak(aTHX_ "Out of memory during pack()"); \
-    if (catcur + glen >= SvLEN(cat)) {	\
+        croak("Out of memory during pack()");   \
+    if (catcur + glen >= SvLEN(cat)) {	        \
         (start) = sv_exp_grow(cat, glen);	\
         (cur) = (start) + SvCUR(cat);		\
     }						\
@@ -415,7 +415,7 @@ STMT_START {							\
     val = utf8n_to_uvchr((U8 *) str, end-str, &retlen, utf8_flags);	\
     if (retlen == (STRLEN) -1) {			        \
         *cur = '\0';						\
-        Perl_croak(aTHX_ "Malformed UTF-8 string in pack");	\
+        croak("Malformed UTF-8 string in pack");	        \
     }								\
     str += retlen;						\
 } STMT_END
@@ -438,7 +438,7 @@ S_measure_struct(pTHX_ tempsym_t* symptr)
 
         switch (symptr->howlen) {
           case e_star:
-            Perl_croak(aTHX_ "Within []-length '*' not allowed in %s",
+            croak("Within []-length '*' not allowed in %s",
                         _action( symptr ) );
 
           default:
@@ -454,7 +454,7 @@ S_measure_struct(pTHX_ tempsym_t* symptr)
             switch(TYPE_NO_ENDIANNESS(symptr->code)) {
             default:
                 /* diag_listed_as: Invalid type '%s' in %s */
-                Perl_croak(aTHX_ "Invalid type '%c' in %s",
+                croak("Invalid type '%c' in %s",
                            (int)TYPE_NO_MODIFIERS(symptr->code),
                            _action( symptr ) );
             case '.' | TYPE_IS_SHRIEKING:
@@ -465,7 +465,7 @@ S_measure_struct(pTHX_ tempsym_t* symptr)
             case 'U':			/* XXXX Is it correct? */
             case 'w':
             case 'u':
-                Perl_croak(aTHX_ "Within []-length '%c' not allowed in %s",
+                croak("Within []-length '%c' not allowed in %s",
                            (int) TYPE_NO_MODIFIERS(symptr->code),
                            _action( symptr ) );
             case '%':
@@ -494,7 +494,7 @@ S_measure_struct(pTHX_ tempsym_t* symptr)
             case 'X':
                 size = -1;
                 if (total < len)
-                    Perl_croak(aTHX_ "'X' outside of string in %s", _action( symptr ) );
+                    croak("'X' outside of string in %s", _action( symptr ) );
                 break;
             case 'x' | TYPE_IS_SHRIEKING:
                 if (!len)		/* Avoid division by 0 */
@@ -556,11 +556,11 @@ S_group_end(pTHX_ const char *patptr, const char *patend, char ender)
             ++opened;
         else if (c == ')' || c == ']') {
             if (opened == 0)
-                Perl_croak(aTHX_ "Mismatched brackets in template");
+                croak("Mismatched brackets in template");
             --opened;
         }
     }
-    Perl_croak(aTHX_ "No group ending character '%c' found in template",
+    croak("No group ending character '%c' found in template",
                ender);
     NOT_REACHED; /* NOTREACHED */
 }
@@ -580,7 +580,7 @@ S_get_num(pTHX_ const char *patptr, SSize_t *lenptr )
   while (isDIGIT(*patptr)) {
     SSize_t nlen = (len * 10) + (*patptr++ - '0');
     if (nlen < 0 || nlen/10 != len)
-      Perl_croak(aTHX_ "pack/unpack repeat count overflow");
+      croak("pack/unpack repeat count overflow");
     len = nlen;
   }
   *lenptr = len;
@@ -629,12 +629,12 @@ S_next_symbol(pTHX_ tempsym_t* symptr )
       /* for '(', skip to ')' */
       if (code == '(') {
         if( isDIGIT(*patptr) || *patptr == '*' || *patptr == '[' )
-          Perl_croak(aTHX_ "()-group starts with a count in %s",
+          croak("()-group starts with a count in %s",
                         _action( symptr ) );
         symptr->grpbeg = patptr;
         patptr = 1 + ( symptr->grpend = group_end(patptr, patend, ')') );
         if( symptr->level >= MAX_SUB_TEMPLATE_LEVEL )
-          Perl_croak(aTHX_ "Too deeply nested ()-groups in %s",
+          croak("Too deeply nested ()-groups in %s",
                         _action( symptr ) );
       }
 
@@ -671,15 +671,15 @@ S_next_symbol(pTHX_ tempsym_t* symptr )
           break;
 
         if (!strchr(allowed, TYPE_NO_MODIFIERS(code)))
-          Perl_croak(aTHX_ "'%c' allowed only after types %s in %s", *patptr,
+          croak("'%c' allowed only after types %s in %s", *patptr,
                         allowed, _action( symptr ) );
 
         if (TYPE_ENDIANNESS(code | modifier) == TYPE_ENDIANNESS_MASK)
-          Perl_croak(aTHX_ "Can't use both '<' and '>' after type '%c' in %s",
+          croak("Can't use both '<' and '>' after type '%c' in %s",
                      (int) TYPE_NO_MODIFIERS(code), _action( symptr ) );
         else if (TYPE_ENDIANNESS(code | modifier | inherited_modifiers) ==
                  TYPE_ENDIANNESS_MASK)
-          Perl_croak(aTHX_ "Can't use '%c' in a group with different byte-order in %s",
+          croak("Can't use '%c' in a group with different byte-order in %s",
                      *patptr, _action( symptr ) );
 
         if ((code & modifier)) {
@@ -714,7 +714,7 @@ S_next_symbol(pTHX_ tempsym_t* symptr )
           if (isDIGIT(*lenptr)) {
             lenptr = get_num( lenptr, &symptr->length );
             if( *lenptr != ']' )
-              Perl_croak(aTHX_ "Malformed integer in [] in %s",
+              croak("Malformed integer in [] in %s",
                             _action( symptr ) );
           } else {
             tempsym_t savsym = *symptr;
@@ -744,7 +744,7 @@ S_next_symbol(pTHX_ tempsym_t* symptr )
               patptr++;
               if (patptr < patend &&
                   (isDIGIT(*patptr) || *patptr == '*' || *patptr == '['))
-                Perl_croak(aTHX_ "'/' does not take a repeat count in %s",
+                croak("'/' does not take a repeat count in %s",
                             _action( symptr ) );
             }
             break;
@@ -922,7 +922,7 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
         switch(TYPE_NO_ENDIANNESS(datumtype)) {
         default:
             /* diag_listed_as: Invalid type '%s' in %s */
-            Perl_croak(aTHX_ "Invalid type '%c' in unpack", (int)TYPE_NO_MODIFIERS(datumtype) );
+            croak("Invalid type '%c' in unpack", (int)TYPE_NO_MODIFIERS(datumtype) );
 
         case '%':
             if (howlen == e_no_len)
@@ -981,10 +981,10 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
             if (utf8  && !(datumtype & TYPE_IS_SHRIEKING)) {
                 s = (char *) utf8_hop_forward((U8 *) s, len, (U8 *) strend);
                 if (s >= strend)
-                    Perl_croak(aTHX_ "'@' outside of string in unpack");
+                    croak("'@' outside of string in unpack");
             } else {
                 if (strend-s < len)
-                    Perl_croak(aTHX_ "'@' outside of string in unpack");
+                    croak("'@' outside of string in unpack");
                 s += len;
             }
             break;
@@ -1003,7 +1003,7 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
                     }
                 }
                 if (last > s)
-                    Perl_croak(aTHX_ "Malformed UTF-8 string in unpack");
+                    croak("Malformed UTF-8 string in unpack");
                 s = last;
                 break;
             }
@@ -1013,10 +1013,10 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
             if (utf8) {
                 s = (char *) utf8_hop_back((U8 *) s, -len, (U8 *) strbeg);
                 if (s <= strbeg)
-                    Perl_croak(aTHX_ "'X' outside of string in unpack");
+                    croak("'X' outside of string in unpack");
             } else {
                 if (len > s - strbeg)
-                    Perl_croak(aTHX_ "'X' outside of string in unpack" );
+                    croak("'X' outside of string in unpack" );
                 s -= len;
             }
             break;
@@ -1034,18 +1034,18 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
             if (utf8) {
                 while (len>0) {
                     if (s >= strend)
-                        Perl_croak(aTHX_ "'x' outside of string in unpack");
+                        croak("'x' outside of string in unpack");
                     s += UTF8SKIP(s);
                     len--;
                 }
             } else {
                 if (len > strend - s)
-                    Perl_croak(aTHX_ "'x' outside of string in unpack");
+                    croak("'x' outside of string in unpack");
                 s += len;
             }
             break;
         case '/':
-            Perl_croak(aTHX_ "'/' must follow a numeric type in unpack");
+            croak("'/' must follow a numeric type in unpack");
 
         case 'A':
         case 'Z':
@@ -1061,12 +1061,12 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
                 for (l=len, hop=s; l>0; l--, hop += UTF8SKIP(hop)) {
                     if (hop >= strend) {
                         if (hop > strend)
-                            Perl_croak(aTHX_ "Malformed UTF-8 string in unpack");
+                            croak("Malformed UTF-8 string in unpack");
                         break;
                     }
                 }
                 if (hop > strend)
-                    Perl_croak(aTHX_ "Malformed UTF-8 string in unpack");
+                    croak("Malformed UTF-8 string in unpack");
                 len = hop - s;
             } else if (len > strend - s)
                 len = strend - s;
@@ -1094,7 +1094,7 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
                     if (ptr >= s) ptr += UTF8SKIP(ptr);
                     else ptr++;
                     if (ptr > s+len)
-                        Perl_croak(aTHX_ "Malformed UTF-8 string in unpack");
+                        croak("Malformed UTF-8 string in unpack");
                 } else {
                     for (ptr = s+len-1; ptr >= s; ptr--)
                         if (*ptr != 0 && !isSPACE(*ptr)) break;
@@ -1236,7 +1236,7 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
                     aint = utf8n_to_uvchr((U8 *) s, strend-s, &retlen,
                                  ckWARN(WARN_UTF8) ? 0 : UTF8_ALLOW_ANY);
                     if (retlen == (STRLEN) -1)
-                        Perl_croak(aTHX_ "Malformed UTF-8 string in unpack");
+                        croak("Malformed UTF-8 string in unpack");
                     s += retlen;
                   }
                 else
@@ -1259,7 +1259,7 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
                     UV val;
                     if (! utf8_to_uv((const U8 *) s, (const U8 *) strend,
                                      &val, &retlen)) {
-                        Perl_croak(aTHX_ "Malformed UTF-8 string in unpack");
+                        croak("Malformed UTF-8 string in unpack");
                     }
                     s += retlen;
                     if (!checksum)
@@ -1286,7 +1286,7 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
                     if (symptr->flags & FLAG_DO_UTF8) utf8 = 0;
                     else
                         /* Should be impossible due to the need_utf8() test */
-                        Perl_croak(aTHX_ "U0 mode on a byte string");
+                        croak("U0 mode on a byte string");
                 }
                 break;
             }
@@ -1318,7 +1318,7 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
                     auv = utf8n_to_uvchr((U8*)s, strend - s, &retlen,
                                          UTF8_ALLOW_DEFAULT);
                     if (retlen == (STRLEN) -1)
-                        Perl_croak(aTHX_ "Malformed UTF-8 string in unpack");
+                        croak("Malformed UTF-8 string in unpack");
                     s += retlen;
                 }
                 if (!checksum)
@@ -1616,12 +1616,12 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
                     }
                 }
                 if ((s >= strend) && bytes)
-                    Perl_croak(aTHX_ "Unterminated compressed integer in unpack");
+                    croak("Unterminated compressed integer in unpack");
             }
             break;
         case 'P':
             if (symptr->howlen == e_star)
-                Perl_croak(aTHX_ "'P' must have an explicit size in unpack");
+                croak("'P' must have an explicit size in unpack");
             EXTEND(SP, 1);
             if (s + sizeof(char*) <= strend) {
                 char *aptr;
@@ -1812,18 +1812,18 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
                 break;
             if( next_symbol(symptr) ){
               if( symptr->howlen == e_number )
-                Perl_croak(aTHX_ "Count after length/code in unpack" );
+                croak("Count after length/code in unpack" );
               if( beyond ){
                 /* ...end of char buffer then no decent length available */
-                Perl_croak(aTHX_ "length/code after end of string in unpack" );
+                croak("length/code after end of string in unpack" );
               } else {
                 /* take top of stack (hope it's numeric) */
                 len = POPi;
                 if( len < 0 )
-                    Perl_croak(aTHX_ "Negative '/' count in unpack" );
+                    croak("Negative '/' count in unpack" );
               }
             } else {
-                Perl_croak(aTHX_ "Code missing after '/' in unpack" );
+                croak("Code missing after '/' in unpack" );
             }
             datumtype = symptr->code;
             explicit_length = FALSE;
@@ -2028,7 +2028,7 @@ marked_upgrade(pTHX_ SV *sv, tempsym_t *sym_ptr) {
     if (m != marks + sym_ptr->level+1) {
         Safefree(marks);
         Safefree(to_start);
-        Perl_croak(aTHX_ "panic: marks beyond string end, m=%p, marks=%p, "
+        croak("panic: marks beyond string end, m=%p, marks=%p, "
                    "level=%d", m, marks, sym_ptr->level);
     }
     for (group=sym_ptr; group; group = group->previous)
@@ -2078,9 +2078,9 @@ S_sv_check_infnan(pTHX_ SV *sv, I32 datumtype)
         const I32 c = TYPE_NO_MODIFIERS(datumtype);
         const NV nv = SvNV_nomg(sv);
         if (c == 'w')
-            Perl_croak(aTHX_ "Cannot compress %" NVgf " in pack", nv);
+            croak("Cannot compress %" NVgf " in pack", nv);
         else
-            Perl_croak(aTHX_ "Cannot pack %" NVgf " with '%c'", nv, (int) c);
+            croak("Cannot pack %" NVgf " with '%c'", nv, (int) c);
     }
     return sv;
 }
@@ -2150,7 +2150,7 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
         found = next_symbol(&lookahead);
         if (symptr->flags & FLAG_SLASH) {
             IV count;
-            if (!found) Perl_croak(aTHX_ "Code missing after '/' in pack");
+            if (!found) croak("Code missing after '/' in pack");
             if (memCHRs("aAZ", lookahead.code)) {
                 if (lookahead.howlen == e_number) count = lookahead.length;
                 else {
@@ -2178,10 +2178,10 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
         switch (TYPE_NO_ENDIANNESS(datumtype)) {
         default:
             /* diag_listed_as: Invalid type '%s' in %s */
-            Perl_croak(aTHX_ "Invalid type '%c' in pack",
+            croak("Invalid type '%c' in pack",
                        (int) TYPE_NO_MODIFIERS(datumtype));
         case '%':
-            Perl_croak(aTHX_ "'%%' may not be used in pack");
+            croak("'%%' may not be used in pack");
 
         case '.' | TYPE_IS_SHRIEKING:
         case '.':
@@ -2207,7 +2207,7 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
                         len--;
                     }
                     if (from > cur)
-                        Perl_croak(aTHX_ "Malformed UTF-8 string in pack");
+                        croak("Malformed UTF-8 string in pack");
                     if (len) {
                         /* Here we know from == cur */
                       grow:
@@ -2273,7 +2273,7 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
                     }
                 }
                 if (last > cur)
-                    Perl_croak(aTHX_ "Malformed UTF-8 string in pack");
+                    croak("Malformed UTF-8 string in pack");
                 cur = last;
                 break;
             }
@@ -2285,11 +2285,11 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
               utf8_shrink:
                 while (len > 0) {
                     if (cur <= start)
-                        Perl_croak(aTHX_ "'%c' outside of string in pack",
+                        croak("'%c' outside of string in pack",
                                    (int) TYPE_NO_MODIFIERS(datumtype));
                     while (--cur, UTF8_IS_CONTINUATION(*cur)) {
                         if (cur <= start)
-                            Perl_croak(aTHX_ "'%c' outside of string in pack",
+                            croak("'%c' outside of string in pack",
                                        (int) TYPE_NO_MODIFIERS(datumtype));
                     }
                     len--;
@@ -2297,7 +2297,7 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
             } else {
               shrink:
                 if (cur - start < len)
-                    Perl_croak(aTHX_ "'%c' outside of string in pack",
+                    croak("'%c' outside of string in pack",
                                (int) TYPE_NO_MODIFIERS(datumtype));
                 cur -= len;
             }
@@ -2353,7 +2353,7 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
                     fromlen--;
                 }
                 if (s > end)
-                    Perl_croak(aTHX_ "Malformed UTF-8 string in pack");
+                    croak("Malformed UTF-8 string in pack");
                 if (utf8) {
                     len = fromlen;
                     if (datumtype == 'Z') len++;
@@ -2371,7 +2371,7 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
                 GROWING(0, cat, start, cur, len);
                 if (!S_utf8_to_bytes(aTHX_ &aptr, end, cur, fromlen,
                                   datumtype | TYPE_IS_PACK))
-                    Perl_croak(aTHX_ "panic: predicted utf8 length not available, "
+                    croak("panic: predicted utf8 length not available, "
                                "for '%c', aptr=%p end=%p cur=%p, fromlen=%zu",
                                (int)datumtype, aptr, end, cur, fromlen);
                 cur += fromlen;
@@ -2870,7 +2870,7 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
                 if (anv < 0) {
                     *cur = '\0';
                     SvCUR_set(cat, cur - start);
-                    Perl_croak(aTHX_ "Cannot compress negative numbers in pack");
+                    croak("Cannot compress negative numbers in pack");
                 }
 
                 /* 0xFFFFFFFFFFFFFFFF may cast to 18446744073709551616.0,
@@ -2916,7 +2916,7 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
                     do {
                         const NV next = Perl_floor(anv / 128);
                         if (in <= buf)  /* this cannot happen ;-) */
-                            Perl_croak(aTHX_ "Cannot compress integer in pack");
+                            croak("Cannot compress integer in pack");
                         *--in = (unsigned char)(anv - (next * 128)) | 0x80;
                         anv = next;
                     } while (anv > 0);
@@ -2934,7 +2934,7 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
                     /* Copy string and check for compliance */
                     from = SvPV_nomg_const(fromstr, len);
                     if ((norm = is_an_int(from, len)) == NULL)
-                        Perl_croak(aTHX_ "Can only compress unsigned integers in pack");
+                        croak("Can only compress unsigned integers in pack");
 
                     Newx(result, len, char);
                     in = result + len;
@@ -3106,7 +3106,7 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
                                       'u' | TYPE_IS_PACK)) {
                         *cur = '\0';
                         SvCUR_set(cat, cur - start);
-                        Perl_croak(aTHX_ "panic: string is shorter than advertised, "
+                        croak("panic: string is shorter than advertised, "
                                    "aptr=%p, aend=%p, buffer=%p, todo=%zd",
                                    aptr, aend, buffer, todo);
                     }

--- a/pp_sort.c
+++ b/pp_sort.c
@@ -816,7 +816,7 @@ PP(pp_sort)
         (void)POPMARK; /* remove mark associated with ex-OP_AASSIGN */
         av = MUTABLE_AV((*PL_stack_sp));
         if (SvREADONLY(av))
-            Perl_croak_no_modify();
+            croak_no_modify();
         max = AvFILL(av) + 1;
 
         I32 oldmark = MARK - PL_stack_base;

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -576,7 +576,7 @@ PP_wrapped(pp_warn, 0, 1)
       }
     }
     if (SvROK(exsv) && !PL_warnhook)
-         Perl_warn(aTHX_ "%" SVf, SVfARG(exsv));
+         warn("%" SVf, SVfARG(exsv));
     else warn_sv(exsv);
     RETSETYES;
 }

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -1382,7 +1382,7 @@ PP_wrapped(pp_sselect, 4, 0)
             continue;
         if (SvREADONLY(sv)) {
             if (!(SvPOK(sv) && SvCUR(sv) == 0))
-                Perl_croak_no_modify();
+                croak_no_modify();
         }
         else if (SvIsCOW(sv)) sv_force_normal_flags(sv, 0);
         if (SvPOK(sv)) {

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -232,7 +232,7 @@ S_emulate_eaccess(pTHX_ const char* path, Mode_t mode)
     int res;
 
 #if !defined(HAS_SETREUID) && !defined(HAS_SETRESUID)
-    Perl_croak(aTHX_ "switching effective uid is not implemented");
+    croak("switching effective uid is not implemented");
 #else
 #  ifdef HAS_SETREUID
     if (setreuid(euid, ruid))
@@ -240,11 +240,11 @@ S_emulate_eaccess(pTHX_ const char* path, Mode_t mode)
     if (setresuid(euid, ruid, (Uid_t)-1))
 #  endif
         /* diag_listed_as: entering effective %s failed */
-        Perl_croak(aTHX_ "entering effective uid failed");
+        croak("entering effective uid failed");
 #endif
 
 #if !defined(HAS_SETREGID) && !defined(HAS_SETRESGID)
-    Perl_croak(aTHX_ "switching effective gid is not implemented");
+    croak("switching effective gid is not implemented");
 #else
 #  ifdef HAS_SETREGID
     if (setregid(egid, rgid))
@@ -252,7 +252,7 @@ S_emulate_eaccess(pTHX_ const char* path, Mode_t mode)
     if (setresgid(egid, rgid, (Gid_t)-1))
 #  endif
         /* diag_listed_as: entering effective %s failed */
-        Perl_croak(aTHX_ "entering effective gid failed");
+        croak("entering effective gid failed");
 #endif
 
     res = access(path, mode);
@@ -263,7 +263,7 @@ S_emulate_eaccess(pTHX_ const char* path, Mode_t mode)
     if (setresuid(ruid, euid, (Uid_t)-1))
 #endif
         /* diag_listed_as: leaving effective %s failed */
-        Perl_croak(aTHX_ "leaving effective uid failed");
+        croak("leaving effective uid failed");
 
 #ifdef HAS_SETREGID
     if (setregid(rgid, egid))
@@ -271,7 +271,7 @@ S_emulate_eaccess(pTHX_ const char* path, Mode_t mode)
     if (setresgid(rgid, egid, (Gid_t)-1))
 #endif
         /* diag_listed_as: leaving effective %s failed */
-        Perl_croak(aTHX_ "leaving effective gid failed");
+        croak("leaving effective gid failed");
 
     return res;
 }
@@ -827,7 +827,7 @@ PP_wrapped(pp_open, 0, 1)
         IoFLAGS(GvIOp(gv)) &= ~IOf_UNTAINT;
 
         if (IoDIRP(io))
-            Perl_croak(aTHX_ "Cannot open %" HEKf " as a filehandle: it is already open as a dirhandle",
+            croak("Cannot open %" HEKf " as a filehandle: it is already open as a dirhandle",
                              HEKfARG(GvENAME_HEK(gv)));
 
         mg = SvTIED_mg((const SV *)io, PERL_MAGIC_tiedscalar);
@@ -1100,7 +1100,7 @@ PP_wrapped(pp_tie, 0, 1)
             methname = "TIEARRAY";
             if (!AvREAL(varsv)) {
                 if (!AvREIFY(varsv))
-                    Perl_croak(aTHX_ "Cannot tie unreifiable array");
+                    croak("Cannot tie unreifiable array");
                 av_clear((AV *)varsv);
                 AvREIFY_off(varsv);
                 AvREAL_on(varsv);
@@ -1199,7 +1199,7 @@ PP_wrapped(pp_tie, 0, 1)
         if (varsv == SvRV(sv) &&
             (SvTYPE(varsv) == SVt_PVAV ||
              SvTYPE(varsv) == SVt_PVHV))
-            Perl_croak(aTHX_
+            croak(
                        "Self-ties of arrays and hashes are not supported");
         sv_magic(varsv, (SvRV(sv) == varsv ? NULL : sv), how, NULL, 0);
     }
@@ -1975,7 +1975,7 @@ PP_wrapped(pp_sysread, 0, 1)
 
     if ((fp_utf8 = PerlIO_isutf8(IoIFP(io))) && !IN_BYTES) {
         if (PL_op->op_type == OP_SYSREAD || PL_op->op_type == OP_RECV) {
-            Perl_croak(aTHX_
+            croak(
                        "%s() isn't allowed on :utf8 handles",
                        OP_DESC(PL_op));
         }
@@ -2234,7 +2234,7 @@ PP_wrapped(pp_syswrite, 0, 1)
     doing_utf8 = DO_UTF8(bufsv);
 
     if (PerlIO_isutf8(IoIFP(io))) {
-        Perl_croak(aTHX_
+        croak(
                    "%s() isn't allowed on :utf8 handles",
                    OP_DESC(PL_op));
     }
@@ -2243,7 +2243,7 @@ PP_wrapped(pp_syswrite, 0, 1)
             doing_utf8 = false;
         }
         else {
-            Perl_croak(aTHX_ "Wide character in %s", OP_DESC(PL_op));
+            croak("Wide character in %s", OP_DESC(PL_op));
         }
     }
 
@@ -3073,7 +3073,7 @@ PP_wrapped(pp_stat, !(PL_op->op_flags & OPf_REF), 0)
                                         : &PL_sv_no));
             } else if (PL_laststype != OP_LSTAT)
                 /* diag_listed_as: The stat preceding %s wasn't an lstat */
-                Perl_croak(aTHX_ "The stat preceding lstat() wasn't an lstat");
+                croak("The stat preceding lstat() wasn't an lstat");
         }
 
         if (gv == PL_defgv) {
@@ -4255,7 +4255,7 @@ PP_wrapped(pp_open_dir, 2, 0)
     IO * const io = GvIOn(gv);
 
     if ((IoIFP(io) || IoOFP(io)))
-        Perl_croak(aTHX_ "Cannot open %" HEKf " as a dirhandle: it is already open as a filehandle",
+        croak("Cannot open %" HEKf " as a dirhandle: it is already open as a filehandle",
                          HEKfARG(GvENAME_HEK(gv)));
     if (IoDIRP(io))
         PerlDir_close(IoDIRP(io));

--- a/proto.h
+++ b/proto.h
@@ -3357,7 +3357,7 @@ Perl_op_scope(pTHX_ OP *o);
 #define PERL_ARGS_ASSERT_OP_SCOPE
 
 PERL_CALLCONV OP *
-Perl_op_sibling_splice(OP *parent, OP *start, int del_count, OP *insert);
+Perl_op_sibling_splice(pTHX_ OP *parent, OP *start, int del_count, OP *insert);
 #define PERL_ARGS_ASSERT_OP_SIBLING_SPLICE
 
 PERL_CALLCONV OP *

--- a/regcomp.c
+++ b/regcomp.c
@@ -9114,10 +9114,10 @@ redo_curchar:
         result_string = newSVpvs("");
         while (invlist_iternext(final, &start, &end)) {
             if (start == end) {
-                Perl_sv_catpvf(aTHX_ result_string, "\\x{%" UVXf "}", start);
+                sv_catpvf(result_string, "\\x{%" UVXf "}", start);
             }
             else {
-                Perl_sv_catpvf(aTHX_ result_string, "\\x{%" UVXf "}-\\x{%"
+                sv_catpvf(result_string, "\\x{%" UVXf "}-\\x{%"
                                                         UVXf "}", start, end);
             }
         }
@@ -10013,7 +10013,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                                     if (cp > 255) {
                                         REQUIRE_UTF8(flagp);
                                     }
-                                    Perl_sv_catpvf(aTHX_ final, "\\x{%" UVXf "}",
+                                    sv_catpvf(final, "\\x{%" UVXf "}",
                                                                         cp);
                                     SvREFCNT_dec_NN(character);
                                 }
@@ -10522,7 +10522,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                                                       foldbuf + foldlen);
                         SV* multi_fold = newSVpvs_flags("", SVs_TEMP);
 
-                        Perl_sv_catpvf(aTHX_ multi_fold, "\\x{%" UVXf "}", value);
+                        sv_catpvf(multi_fold, "\\x{%" UVXf "}", value);
 
                         multi_char_matches
                                         = add_multi_match(multi_char_matches,
@@ -14295,7 +14295,7 @@ S_handle_user_defined_property(pTHX_
                 }
                 if (SvCUR(msg) > 0) sv_catpvs(msg, "; ");
                 sv_catpv(msg, overflow_msg);
-                Perl_sv_catpvf(aTHX_ msg, "%" UTF8f,
+                sv_catpvf(msg, "%" UTF8f,
                                      UTF8fARG(is_contents_utf8, s - s0, s0));
                 sv_catpvs(msg, "\"");
                 goto return_failure;
@@ -14330,7 +14330,7 @@ S_handle_user_defined_property(pTHX_
                     }
                     if (SvCUR(msg) > 0) sv_catpvs(msg, "; ");
                     sv_catpv(msg, overflow_msg);
-                    Perl_sv_catpvf(aTHX_ msg, "%" UTF8f,
+                    sv_catpvf(msg, "%" UTF8f,
                                       UTF8fARG(is_contents_utf8, s - s0, s0));
                     sv_catpvs(msg, "\"");
                     goto return_failure;
@@ -14358,7 +14358,7 @@ S_handle_user_defined_property(pTHX_
         else if (max < min) {
             if (SvCUR(msg) > 0) sv_catpvs(msg, "; ");
             sv_catpvs(msg, "Illegal range in \"");
-            Perl_sv_catpvf(aTHX_ msg, "%" UTF8f,
+            sv_catpvf(msg, "%" UTF8f,
                                 UTF8fARG(is_contents_utf8, s - s0, s0));
             sv_catpvs(msg, "\"");
             goto return_failure;
@@ -14377,7 +14377,7 @@ S_handle_user_defined_property(pTHX_
                                             (UNICODE_IS_PERL_EXTENDED(min))
                                             ? min : max));
             sv_catpvs(msg, " in \"");
-            Perl_sv_catpvf(aTHX_ msg, "%" UTF8f,
+            sv_catpvf(msg, "%" UTF8f,
                                  UTF8fARG(is_contents_utf8, s - s0, s0));
             sv_catpvs(msg, "\"");
         }
@@ -14484,7 +14484,7 @@ S_handle_user_defined_property(pTHX_
 
     if (name_len > 0) {
         sv_catpvs(msg, " in expansion of ");
-        Perl_sv_catpvf(aTHX_ msg, "%" UTF8f, UTF8fARG(is_utf8, name_len, name));
+        sv_catpvf(msg, "%" UTF8f, UTF8fARG(is_utf8, name_len, name));
     }
 
     return running_definition;
@@ -14558,12 +14558,12 @@ S_get_fq_name(pTHX_
                          : CopSTASH(PL_curcop);
         const char* pkgname = HvNAME(pkg);
 
-        Perl_sv_catpvf(aTHX_ fq_name, "%" UTF8f,
+        sv_catpvf(fq_name, "%" UTF8f,
                       UTF8fARG(is_utf8, strlen(pkgname), pkgname));
         sv_catpvs(fq_name, "::");
     }
 
-    Perl_sv_catpvf(aTHX_ fq_name, "%" UTF8f,
+    sv_catpvf(fq_name, "%" UTF8f,
                          UTF8fARG(is_utf8, name_len, name));
     return fq_name;
 }
@@ -15535,7 +15535,7 @@ S_parse_uniprop_string(pTHX_
 
                 if (name_len > 0) {
                     sv_catpvs(msg, " in expansion of ");
-                    Perl_sv_catpvf(aTHX_ msg, "%" UTF8f, UTF8fARG(is_utf8,
+                    sv_catpvf(msg, "%" UTF8f, UTF8fARG(is_utf8,
                                                                   name_len,
                                                                   name));
                 }
@@ -15948,7 +15948,7 @@ S_parse_uniprop_string(pTHX_
         const char * suffix = (runtime && level == 0) ?  "}" : "\"";
 
         sv_catpv(msg, prefix);
-        Perl_sv_catpvf(aTHX_ msg, "%" UTF8f, UTF8fARG(is_utf8, name_len, name));
+        sv_catpvf(msg, "%" UTF8f, UTF8fARG(is_utf8, name_len, name));
         sv_catpv(msg, suffix);
     }
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -15696,13 +15696,13 @@ S_parse_uniprop_string(pTHX_
                 /* If the value is an integer, the canonical value is integral
                  * */
                 if (Perl_ceil(value) == value) {
-                    canonical = Perl_form(aTHX_ "%.*s%.0" NVff,
+                    canonical = form("%.*s%.0" NVff,
                                             equals_pos, lookup_name, value);
                 }
                 else {  /* Otherwise, it is %e with a known precision */
                     char * exp_ptr;
 
-                    canonical = Perl_form(aTHX_ "%.*s%.*" NVef,
+                    canonical = form("%.*s%.*" NVef,
                                                 equals_pos, lookup_name,
                                                 PL_E_FORMAT_PRECISION, value);
 
@@ -15806,7 +15806,7 @@ S_parse_uniprop_string(pTHX_
                 numerator /= gcd;
                 denominator /= gcd;
 
-                canonical = Perl_form(aTHX_ "%.*s%s%" UVuf "/%" UVuf,
+                canonical = form("%.*s%s%" UVuf "/%" UVuf,
                         equals_pos, lookup_name, sign, numerator, denominator);
             }
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -16343,7 +16343,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
             for (j = low; j <= high; j++) { /* For each code point in the series */
 
                 /* Get its name, and see if it matches the subpattern */
-                Perl_sv_setpvf(aTHX_ algo_name, "%s-%X", SvPVX(prefix),
+                sv_setpvf(algo_name, "%s-%X", SvPVX(prefix),
                                      (unsigned) j);
 
                 if (execute_wildcard(subpattern_re,

--- a/regcomp.c
+++ b/regcomp.c
@@ -1024,7 +1024,7 @@ S_compile_runtime_code(pTHX_ RExC_state_t * const pRExC_state,
             SV * const errsv = ERRSV;
             if (SvTRUE_NN(errsv))
                 /* use croak_sv ? */
-                Perl_croak_nocontext("%" SVf, SVfARG(errsv));
+                croak("%" SVf, SVfARG(errsv));
         }
         assert(SvROK(qr_ref));
         qr = SvRV(qr_ref);

--- a/regcomp.c
+++ b/regcomp.c
@@ -732,7 +732,7 @@ S_concat_pat(pTHX_ RExC_state_t * const pRExC_state,
                 if (SvROK(sv))
                     sv = SvRV(sv);
                 if (SvTYPE(sv) != SVt_REGEXP)
-                    Perl_croak(aTHX_ "Overloaded qr did not return a REGEXP");
+                    croak("Overloaded qr did not return a REGEXP");
                 msv = sv;
             }
         }
@@ -1665,7 +1665,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
     if (runtime_code) {
         assert(TAINTING_get || !TAINT_get);
         if (TAINT_get)
-            Perl_croak(aTHX_ "Eval-group in insecure regular expression");
+            croak("Eval-group in insecure regular expression");
 
         if (!S_compile_runtime_code(aTHX_ pRExC_state, exp, plen)) {
             /* whoops, we have a non-utf8 pattern, whilst run-time code
@@ -1792,7 +1792,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
     }
     else if (! MUST_RESTART(flags)) {
         ReREFCNT_dec(Rx);
-        Perl_croak(aTHX_ "panic: reg returned failure to re_op_compile, flags: %#" UVxf, (UV) flags);
+        croak("panic: reg returned failure to re_op_compile, flags: %#" UVxf, (UV) flags);
     }
 
     /* Here, we either have success, or we have to redo the parse for some reason */
@@ -2534,7 +2534,7 @@ S_reg_scan_name(pTHX_ RExC_state_t *pRExC_state, U32 flags)
         HE *he_str = NULL;
         SV *sv_dat = NULL;
         if ( ! sv_name )      /* should not happen*/
-            Perl_croak(aTHX_ "panic: no svname in reg_scan_name");
+            croak("panic: no svname in reg_scan_name");
         if (RExC_paren_names)
             he_str = hv_fetch_ent( RExC_paren_names, sv_name, 0, 0 );
         if ( he_str )
@@ -2554,7 +2554,7 @@ S_reg_scan_name(pTHX_ RExC_state_t *pRExC_state, U32 flags)
         return sv_dat;
     }
 
-    Perl_croak(aTHX_ "panic: bad flag %lx in reg_scan_name",
+    croak("panic: bad flag %lx in reg_scan_name",
                      (unsigned long) flags);
 }
 
@@ -3559,7 +3559,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                         HE *he_str;
                         SV *sv_dat = NULL;
                         if (!svname) /* shouldn't happen */
-                            Perl_croak(aTHX_
+                            croak(
                                 "panic: reg_scan_name returned NULL");
                         if (!RExC_paren_names) {
                             RExC_paren_names = newHV();
@@ -3574,7 +3574,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                             sv_dat = HeVAL(he_str);
                         if ( ! sv_dat ) {
                             /* croak baby croak */
-                            Perl_croak(aTHX_
+                            croak(
                                 "panic: paren_name hash element allocation failed");
                         } else if ( SvPOK(sv_dat) ) {
                             /* (?|...) can mean we have dupes so scan to check
@@ -5261,7 +5261,7 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
             if (! hv_store(RExC_unlexed_names, RExC_parse, name_len,
                            value_sv, 0))
             {
-                Perl_croak(aTHX_ "panic: hv_store() unexpectedly failed");
+                croak("panic: hv_store() unexpectedly failed");
             }
         }
 
@@ -12518,7 +12518,7 @@ Perl_get_re_gclass_aux_data(pTHX_ const regexp *prog, const regnode* node, bool 
                     if (SvCUR(msg)) {
                         assert(prop_definition == NULL);
 
-                        Perl_croak(aTHX_ "%" UTF8f,
+                        croak("%" UTF8f,
                                 UTF8fARG(SvUTF8(msg), SvCUR(msg), SvPVX(msg)));
                     }
 
@@ -13574,7 +13574,7 @@ Perl_regfree_internal(pTHX_ REGEXP * const rx)
                 assert(n == 0);
                 break;
             default:
-                Perl_croak(aTHX_ "panic: regfree data code '%c'",
+                croak("panic: regfree data code '%c'",
                                                     ri->data->what[n]);
             }
         }
@@ -13822,7 +13822,7 @@ Perl_regdupe_internal(pTHX_ REGEXP * const rx, CLONE_PARAMS *param)
                 d->data[i]= ri->data->data[i];
                 break;
             default:
-                Perl_croak(aTHX_ "panic: re_dup_guts unknown data code '%c'",
+                croak("panic: re_dup_guts unknown data code '%c'",
                                                            ri->data->what[i]);
             }
         }
@@ -13874,7 +13874,7 @@ S_re_croak(pTHX_ bool utf8, const char* pat,...)
         len = 512;
     Copy(message, buf, len , char);
     /* len-1 to avoid \n */
-    Perl_croak(aTHX_ "%" UTF8f, UTF8fARG(utf8, len-1, buf));
+    croak("%" UTF8f, UTF8fARG(utf8, len-1, buf));
 }
 
 /* XXX Here's a total kludge.  But we need to re-enter for swash routines. */
@@ -14452,7 +14452,7 @@ S_handle_user_defined_property(pTHX_
                                         this_definition, &running_definition);
                 break;
             default:
-                Perl_croak(aTHX_ "panic: %s: %d: Unexpected operation %d",
+                croak("panic: %s: %d: Unexpected operation %d",
                                  __FILE__, __LINE__, op);
                 break;
         }
@@ -15002,7 +15002,7 @@ S_parse_uniprop_string(pTHX_
 
             lookup_loose = get_cvs("_charnames::_loose_regcomp_lookup", 0);
             if (! lookup_loose) {
-                Perl_croak(aTHX_
+                croak(
                        "panic: Can't find '_charnames::_loose_regcomp_lookup");
             }
 
@@ -16030,7 +16030,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
      * for any errors generated */
     get_names_info = get_cv("_charnames::_get_names_info", 0);
     if (! get_names_info) {
-        Perl_croak(aTHX_ "panic: Can't find '_charnames::_get_names_info");
+        croak("panic: Can't find '_charnames::_get_names_info");
     }
 
     /* Get the charnames data */

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -547,7 +547,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
                   (int)op, (int)REGNODE_MAX);
         }
         else {
-            Perl_croak(aTHX_ "panic: corrupted regexp opcode %d > %d",
+            croak("panic: corrupted regexp opcode %d > %d",
                              (int)op, (int)REGNODE_MAX);
         }
     }

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -555,10 +555,10 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
 
     k = REGNODE_TYPE(op);
     if (op == BRANCH) {
-        Perl_sv_catpvf(aTHX_ sv, " (buf:%" IVdf "/%" IVdf ")", (IV)ARG1a(o),(IV)ARG1b(o));
+        sv_catpvf(sv, " (buf:%" IVdf "/%" IVdf ")", (IV)ARG1a(o),(IV)ARG1b(o));
     }
     else if (op == BRANCHJ) {
-        Perl_sv_catpvf(aTHX_ sv, " (buf:%" IVdf "/%" IVdf ")", (IV)ARG2a(o),(IV)ARG2b(o));
+        sv_catpvf(sv, " (buf:%" IVdf "/%" IVdf ")", (IV)ARG2a(o),(IV)ARG2b(o));
     }
     else if (k == EXACT) {
         sv_catpvs(sv, " ");
@@ -584,11 +584,11 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         const reg_trie_data * const trie
             = (reg_trie_data*)progi->data->data[!IS_TRIE_AC(op) ? n : ac->trie];
 
-        Perl_sv_catpvf(aTHX_ sv, "-%s", REGNODE_NAME(FLAGS(o)));
+        sv_catpvf(sv, "-%s", REGNODE_NAME(FLAGS(o)));
         DEBUG_TRIE_COMPILE_r({
           if (trie->jump)
             sv_catpvs(sv, "(JUMP)");
-          Perl_sv_catpvf(aTHX_ sv,
+          sv_catpvf(sv,
             "<S:%" UVuf "/%" IVdf " W:%" UVuf " L:%" UVuf "/%" UVuf " C:%" UVuf "/%" UVuf ">",
             (UV)trie->startstate,
             (IV)trie->statecount-1, /* -1 because of the unused 0 element */
@@ -614,23 +614,23 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
             sv_catpvs(sv, "]");
         }
         if (trie->before_paren || trie->after_paren)
-            Perl_sv_catpvf(aTHX_ sv, " (buf:%" IVdf "/%" IVdf ")",
+            sv_catpvf(sv, " (buf:%" IVdf "/%" IVdf ")",
                     (IV)trie->before_paren,(IV)trie->after_paren);
     } else if (k == CURLY) {
         U32 lo = ARG1i(o), hi = ARG2i(o);
         if (ARG3u(o)) /* check both ARG3a and ARG3b at the same time */
-            Perl_sv_catpvf(aTHX_ sv, "<%d:%d>", ARG3a(o),ARG3b(o)); /* paren before, paren after */
+            sv_catpvf(sv, "<%d:%d>", ARG3a(o),ARG3b(o)); /* paren before, paren after */
         if (op == CURLYM || op == CURLYN || op == CURLYX)
-            Perl_sv_catpvf(aTHX_ sv, "[%d]", FLAGS(o)); /* Parenth number */
-        Perl_sv_catpvf(aTHX_ sv, "{%u,", (unsigned) lo);
+            sv_catpvf(sv, "[%d]", FLAGS(o)); /* Parenth number */
+        sv_catpvf(sv, "{%u,", (unsigned) lo);
         if (hi == REG_INFTY)
             sv_catpvs(sv, "INFTY");
         else
-            Perl_sv_catpvf(aTHX_ sv, "%u", (unsigned) hi);
+            sv_catpvf(sv, "%u", (unsigned) hi);
         sv_catpvs(sv, "}");
     }
     else if (k == WHILEM && FLAGS(o))                   /* Ordinal/of */
-        Perl_sv_catpvf(aTHX_ sv, "[%d/%d]", FLAGS(o) & 0xf, FLAGS(o)>>4);
+        sv_catpvf(sv, "[%d/%d]", FLAGS(o) & 0xf, FLAGS(o)>>4);
     else if (k == REF || k == OPEN || k == CLOSE
              || k == GROUPP || op == ACCEPT)
     {
@@ -649,13 +649,13 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
                 if (prog->parno_to_logical)
                     logical_parno = prog->parno_to_logical[parno];
 
-                Perl_sv_catpvf(aTHX_ sv, "%" UVuf, (UV)logical_parno);     /* Parenth number */
+                sv_catpvf(sv, "%" UVuf, (UV)logical_parno);     /* Parenth number */
                 if (parno != logical_parno)
-                    Perl_sv_catpvf(aTHX_ sv, "/%" UVuf, (UV)parno);        /* Parenth number */
+                    sv_catpvf(sv, "/%" UVuf, (UV)parno);        /* Parenth number */
 
                 SV **name= av_fetch_simple(name_list, parno, 0 );
                 if (name)
-                    Perl_sv_catpvf(aTHX_ sv, " '%" SVf "'", SVfARG(*name));
+                    sv_catpvf(sv, " '%" SVf "'", SVfARG(*name));
             }
             else
             if (parno > 0) {
@@ -672,10 +672,10 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
                 I32 n;
                 if (name) {
                     for ( n = 0; n < SvIVX(sv_dat); n++ ) {
-                        Perl_sv_catpvf(aTHX_ sv, "%s%" IVdf,
+                        sv_catpvf(sv, "%s%" IVdf,
                                     (n ? "," : ""), (IV)nums[n]);
                     }
-                    Perl_sv_catpvf(aTHX_ sv, " '%" SVf "'", SVfARG(*name));
+                    sv_catpvf(sv, " '%" SVf "'", SVfARG(*name));
                 }
             }
         } else if (parno > 0) {
@@ -683,24 +683,24 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
             if (prog->parno_to_logical)
                 logical_parno = prog->parno_to_logical[parno];
 
-            Perl_sv_catpvf(aTHX_ sv, "%" UVuf, (UV)logical_parno);     /* Parenth number */
+            sv_catpvf(sv, "%" UVuf, (UV)logical_parno);     /* Parenth number */
             if (logical_parno != parno)
-                Perl_sv_catpvf(aTHX_ sv, "/%" UVuf, (UV)parno);     /* Parenth number */
+                sv_catpvf(sv, "/%" UVuf, (UV)parno);     /* Parenth number */
 
         }
         if ( k == REF ) {
-            Perl_sv_catpvf(aTHX_ sv, " <%" IVdf ">", (IV)ARG2i(o));
+            sv_catpvf(sv, " <%" IVdf ">", (IV)ARG2i(o));
         }
         if ( k == REF && reginfo) {
             U32 n = ARG1u(o);  /* which paren pair */
             I32 ln = RXp_OFFS_START(prog,n);
             if (RXp_LASTPAREN(prog) < n || ln == -1 || RXp_OFFS_END(prog,n) == -1)
-                Perl_sv_catpvf(aTHX_ sv, ": FAIL");
+                sv_catpvf(sv, ": FAIL");
             else if (ln == RXp_OFFS_END(prog,n))
-                Perl_sv_catpvf(aTHX_ sv, ": ACCEPT - EMPTY STRING");
+                sv_catpvf(sv, ": ACCEPT - EMPTY STRING");
             else {
                 const char *s = reginfo->strbeg + ln;
-                Perl_sv_catpvf(aTHX_ sv, ": ");
+                sv_catpvf(sv, ": ");
                 Perl_pv_pretty( aTHX_ sv, s, RXp_OFFS_END(prog,n) - RXp_OFFS_START(prog,n), 32, 0, 0,
                     PERL_PV_ESCAPE_UNI_DETECT|PERL_PV_PRETTY_NOCLEAR|PERL_PV_PRETTY_ELLIPSES|PERL_PV_PRETTY_QUOTE );
             }
@@ -718,21 +718,21 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         }
 
         /* Paren and offset */
-        Perl_sv_catpvf(aTHX_ sv, "%" IVdf, logical_parno);
+        sv_catpvf(sv, "%" IVdf, logical_parno);
         if (logical_parno != parno)
-            Perl_sv_catpvf(aTHX_ sv, "/%" IVdf, parno);
+            sv_catpvf(sv, "/%" IVdf, parno);
 
-        Perl_sv_catpvf(aTHX_ sv, "[%+d:%d]", (int)ARG2i(o),
+        sv_catpvf(sv, "[%+d:%d]", (int)ARG2i(o),
                 (int)((o + (int)ARG2i(o)) - progi->program) );
         if (name_list) {
             SV **name= av_fetch_simple(name_list, ARG1u(o), 0 );
             if (name)
-                Perl_sv_catpvf(aTHX_ sv, " '%" SVf "'", SVfARG(*name));
+                sv_catpvf(sv, " '%" SVf "'", SVfARG(*name));
         }
     }
     else if (k == LOGICAL)
         /* 2: embedded, otherwise 1 */
-        Perl_sv_catpvf(aTHX_ sv, "[%d]", FLAGS(o));
+        sv_catpvf(sv, "[%d]", FLAGS(o));
     else if (k == ANYOF || k == ANYOFH || k == ANYOFR) {
         U8 flags;
         char * bitmap;
@@ -826,7 +826,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         }
 
         /* Ready to start outputting.  First, the initial left bracket */
-        Perl_sv_catpvf(aTHX_ sv, "[%s", PL_colors[0]);
+        sv_catpvf(sv, "[%s", PL_colors[0]);
 
         if (   bitmap
             || bitmap_range_not_in_bitmap
@@ -865,7 +865,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
                     sv_catpvs(sv, "{");
                 }
                 else if (do_sep) {
-                    Perl_sv_catpvf(aTHX_ sv,"%s][%s", PL_colors[1],
+                    sv_catpvf(sv,"%s][%s", PL_colors[1],
                                                       PL_colors[0]);
                 }
                 sv_catsv(sv, unresolved);
@@ -899,7 +899,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
 
             /* This is output in a separate [] */
             if (do_sep) {
-                Perl_sv_catpvf(aTHX_ sv,"%s][%s", PL_colors[1], PL_colors[0]);
+                sv_catpvf(sv,"%s][%s", PL_colors[1], PL_colors[0]);
             }
 
             /* And, for easy of understanding, it is shown in the
@@ -942,10 +942,10 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         }
 
         /* And finally the matching, closing ']' */
-        Perl_sv_catpvf(aTHX_ sv, "%s]", PL_colors[1]);
+        sv_catpvf(sv, "%s]", PL_colors[1]);
 
         if (op == ANYOFHs) {
-            Perl_sv_catpvf(aTHX_ sv, " (Leading UTF-8 bytes = %s", 
+            sv_catpvf(sv, " (Leading UTF-8 bytes = %s", 
                 _byte_dump_string((U8 *) ((struct regnode_anyofhs *) o)->string, 
                 FLAGS(o), 1));
         }
@@ -962,11 +962,11 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
             if (op != ANYOFR || ! isASCII(ANYOFRbase(o) + ANYOFRdelta(o)))
 #endif
             {
-                Perl_sv_catpvf(aTHX_ sv, " (First UTF-8 byte = %02X", lowest);
+                sv_catpvf(sv, " (First UTF-8 byte = %02X", lowest);
                 if (lowest != highest) {
-                    Perl_sv_catpvf(aTHX_ sv, "-%02X", highest);
+                    sv_catpvf(sv, "-%02X", highest);
                 }
-                Perl_sv_catpvf(aTHX_ sv, ")");
+                sv_catpvf(sv, ")");
             }
         }
 
@@ -975,24 +975,24 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
     else if (k == ANYOFM) {
         SV * cp_list = get_ANYOFM_contents(o);
 
-        Perl_sv_catpvf(aTHX_ sv, "[%s", PL_colors[0]);
+        sv_catpvf(sv, "[%s", PL_colors[0]);
         if (op == NANYOFM) {
             _invlist_invert(cp_list);
         }
 
         put_charclass_bitmap_innards(sv, NULL, cp_list, NULL, NULL, 0, true);
-        Perl_sv_catpvf(aTHX_ sv, "%s]", PL_colors[1]);
+        sv_catpvf(sv, "%s]", PL_colors[1]);
 
         SvREFCNT_dec(cp_list);
     }
     else if (k == ANYOFHbbm) {
         SV * cp_list = get_ANYOFHbbm_contents(o);
-        Perl_sv_catpvf(aTHX_ sv, "[%s", PL_colors[0]);
+        sv_catpvf(sv, "[%s", PL_colors[0]);
 
         sv_catsv(sv, invlist_contents(cp_list,
                                       false /* output suitable for catsv */
                                      ));
-        Perl_sv_catpvf(aTHX_ sv, "%s]", PL_colors[1]);
+        sv_catpvf(sv, "%s]", PL_colors[1]);
 
         SvREFCNT_dec(cp_list);
     }
@@ -1008,7 +1008,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
             }
         }
         else {
-            Perl_sv_catpvf(aTHX_ sv, "[illegal type = %d])", index);
+            sv_catpvf(sv, "[illegal type = %d])", index);
         }
     }
     else if (k == BOUND || k == NBOUND) {
@@ -1024,23 +1024,23 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         sv_catpv(sv, bounds[FLAGS(o)]);
     }
     else if (k == BRANCHJ && (op == UNLESSM || op == IFMATCH)) {
-        Perl_sv_catpvf(aTHX_ sv, "[%d", -(FLAGS(o)));
+        sv_catpvf(sv, "[%d", -(FLAGS(o)));
         if (NEXT_OFF(o)) {
-            Perl_sv_catpvf(aTHX_ sv, "..-%d", FLAGS(o) - NEXT_OFF(o));
+            sv_catpvf(sv, "..-%d", FLAGS(o) - NEXT_OFF(o));
         }
-        Perl_sv_catpvf(aTHX_ sv, "]");
+        sv_catpvf(sv, "]");
     }
     else if (op == SBOL)
-        Perl_sv_catpvf(aTHX_ sv, " /%s/", FLAGS(o) ? "\\A" : "^");
+        sv_catpvf(sv, " /%s/", FLAGS(o) ? "\\A" : "^");
     else if (op == EVAL) {
         if (FLAGS(o) & EVAL_OPTIMISTIC_FLAG)
-            Perl_sv_catpvf(aTHX_ sv, " optimistic");
+            sv_catpvf(sv, " optimistic");
     }
 
     /* add on the verb argument if there is one */
     if ( ( k == VERB || op == ACCEPT || op == OPFAIL ) && FLAGS(o)) {
         if ( ARG1u(o) )
-            Perl_sv_catpvf(aTHX_ sv, ":%" SVf,
+            sv_catpvf(sv, ":%" SVf,
                        SVfARG((MUTABLE_SV(progi->data->data[ ARG1u( o ) ]))));
         else
             sv_catpvs(sv, ":NULL");
@@ -1063,7 +1063,7 @@ S_put_code_point(pTHX_ SV *sv, UV c)
     PERL_ARGS_ASSERT_PUT_CODE_POINT;
 
     if (c > 255) {
-        Perl_sv_catpvf(aTHX_ sv, "\\x{%04" UVXf "}", c);
+        sv_catpvf(sv, "\\x{%04" UVXf "}", c);
     }
     else if (isPRINT(c)) {
         const char string = (char) c;
@@ -1075,10 +1075,10 @@ S_put_code_point(pTHX_ SV *sv, UV c)
         sv_catpvn(sv, &string, 1);
     }
     else if (isMNEMONIC_CNTRL(c)) {
-        Perl_sv_catpvf(aTHX_ sv, "%s", cntrl_to_mnemonic((U8) c));
+        sv_catpvf(sv, "%s", cntrl_to_mnemonic((U8) c));
     }
     else {
-        Perl_sv_catpvf(aTHX_ sv, "\\x%02X", (U8) c);
+        sv_catpvf(sv, "\\x%02X", (U8) c);
     }
 }
 
@@ -1258,7 +1258,7 @@ S_put_range(pTHX_ SV *sv, UV start, const UV end, const bool allow_literals)
         format = "\\x%02" UVXf "-\\x%02" UVXf;
 #endif
         GCC_DIAG_IGNORE_STMT(-Wformat-nonliteral);
-        Perl_sv_catpvf(aTHX_ sv, format, start, this_end);
+        sv_catpvf(sv, format, start, this_end);
         GCC_DIAG_RESTORE_STMT;
         break;
     }
@@ -1354,17 +1354,17 @@ S_put_charclass_bitmap_innards_common(pTHX_
     }
 
     if (only_utf8 && _invlist_len(only_utf8)) {
-        Perl_sv_catpvf(aTHX_ output, "%s{utf8}%s", PL_colors[1], PL_colors[0]);
+        sv_catpvf(output, "%s{utf8}%s", PL_colors[1], PL_colors[0]);
         put_charclass_bitmap_innards_invlist(output, only_utf8);
     }
 
     if (not_utf8 && _invlist_len(not_utf8)) {
-        Perl_sv_catpvf(aTHX_ output, "%s{not utf8}%s", PL_colors[1], PL_colors[0]);
+        sv_catpvf(output, "%s{not utf8}%s", PL_colors[1], PL_colors[0]);
         put_charclass_bitmap_innards_invlist(output, not_utf8);
     }
 
     if (only_utf8_locale && _invlist_len(only_utf8_locale)) {
-        Perl_sv_catpvf(aTHX_ output, "%s{utf8 locale}%s", PL_colors[1], PL_colors[0]);
+        sv_catpvf(output, "%s{utf8 locale}%s", PL_colors[1], PL_colors[0]);
         put_charclass_bitmap_innards_invlist(output, only_utf8_locale);
 
         /* This is the only list in this routine that can legally contain code

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -856,7 +856,7 @@ static const scan_data_t zero_scan_data = {
               ? eI - sI   /* Length before the <--HERE */                   \
               : ((xI_offset(xC) >= 0)                                       \
                  ? xI_offset(xC)                                            \
-                 : (Perl_croak(aTHX_ "panic: %s: %d: negative offset: %"    \
+                 : (croak("panic: %s: %d: negative offset: %"               \
                                     IVdf " trying to output message for "   \
                                     " pattern %.*s",                        \
                                     __FILE__, __LINE__, (IV) xI_offset(xC), \
@@ -888,22 +888,22 @@ static const scan_data_t zero_scan_data = {
 } STMT_END
 
 #define FAIL(msg) _FAIL(                            \
-    Perl_croak(aTHX_ "%s in regex m/%" UTF8f "%s/",         \
+    croak("%s in regex m/%" UTF8f "%s/",         \
             msg, UTF8fARG(UTF, len, RExC_precomp), ellipses))
 
 #define FAIL2(msg,arg) _FAIL(                       \
-    Perl_croak(aTHX_ msg " in regex m/%" UTF8f "%s/",       \
+    croak(msg " in regex m/%" UTF8f "%s/",       \
             arg, UTF8fARG(UTF, len, RExC_precomp), ellipses))
 
 #define FAIL3(msg,arg1,arg2) _FAIL(                         \
-    Perl_croak(aTHX_ msg " in regex m/%" UTF8f "%s/",       \
+    croak(msg " in regex m/%" UTF8f "%s/",                  \
      arg1, arg2, UTF8fARG(UTF, len, RExC_precomp), ellipses))
 
 /*
  * Simple_vFAIL -- like FAIL, but marks the current location in the scan
  */
 #define Simple_vFAIL(m) STMT_START {                                    \
-    Perl_croak(aTHX_ "%s" REPORT_LOCATION,                              \
+    croak("%s" REPORT_LOCATION,                                         \
             m, REPORT_LOCATION_ARGS(RExC_parse));                       \
 } STMT_END
 
@@ -965,7 +965,7 @@ static const scan_data_t zero_scan_data = {
 #define _WARN_HELPER(loc, warns, code)                                  \
     STMT_START {                                                        \
         if (! RExC_copy_start_in_constructed) {                         \
-            Perl_croak( aTHX_ "panic! %s: %d: Tried to warn when none"  \
+            croak("panic! %s: %d: Tried to warn when none"              \
                               " expected at '%s'",                      \
                               __FILE__, __LINE__, loc);                 \
         }                                                               \

--- a/regcomp_invlist.c
+++ b/regcomp_invlist.c
@@ -350,7 +350,7 @@ Perl__new_invlist_C_array(pTHX_ const UV* const list)
     PERL_ARGS_ASSERT__NEW_INVLIST_C_ARRAY;
 
     if (version_id != INVLIST_VERSION_ID) {
-        Perl_croak(aTHX_ "panic: Incorrect version for previously generated inversion list");
+        croak("panic: Incorrect version for previously generated inversion list");
     }
 
     /* The generated array passed in includes header elements that aren't part
@@ -409,7 +409,7 @@ S__append_range_to_invlist(pTHX_ SV* const invlist,
         if (   array[final_element] > start
             || ELEMENT_RANGE_MATCHES_INVLIST(final_element))
         {
-            Perl_croak(aTHX_ "panic: attempting to append to an inversion list, but "
+            croak("panic: attempting to append to an inversion list, but "
                              "wasn't at the end of the list, final = %" UVuf 
                              ", start = %" UVuf ", match = %c",
                      array[final_element], start,

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -2858,7 +2858,7 @@ Perl_study_chunk(pTHX_
                 continue;
 
             default:
-                Perl_croak(aTHX_ "panic: unexpected varying REx opcode %d",
+                croak("panic: unexpected varying REx opcode %d",
                                                                     OP(scan));
             case REF:
             case CLUMP:
@@ -2938,7 +2938,7 @@ Perl_study_chunk(pTHX_
 
                 default:
 #ifdef DEBUGGING
-                   Perl_croak(aTHX_ "panic: unexpected simple REx opcode %d",
+                   croak("panic: unexpected simple REx opcode %d",
                                                                      OP(scan));
 #endif
                 case SANY:
@@ -3587,7 +3587,7 @@ Perl_study_chunk(pTHX_
 #endif /* TRIE_STUDY_OPT */
 
         else if (OP(scan) == REGEX_SET) {
-            Perl_croak(aTHX_ "panic: %s regnode should be resolved"
+            croak("panic: %s regnode should be resolved"
                              " before optimization", REGNODE_NAME(REGEX_SET));
         }
 

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -595,7 +595,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         case EXACTFU:
         case EXACTFLU8: folder = PL_fold_latin1; break;
         case EXACTF:  folder = PL_fold; break;
-        default: Perl_croak( aTHX_ "panic! In trie construction, unknown node type %u %s", (unsigned) flags, REGNODE_NAME(flags) );
+        default: croak("panic! In trie construction, unknown node type %u %s", (unsigned) flags, REGNODE_NAME(flags) );
     }
 
     /* create the trie struct, all zeroed */
@@ -816,7 +816,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                 svpp = hv_fetch( widecharmap, (char*)&uvc, sizeof( UV ), 1 );
 
                 if ( !svpp )
-                    Perl_croak( aTHX_ "error creating/fetching widecharmap entry for 0x%" UVXf, uvc );
+                    croak("error creating/fetching widecharmap entry for 0x%" UVXf, uvc );
 
                 if ( !SvTRUE( *svpp ) ) {
                     sv_setiv( *svpp, ++trie->uniquecharcount );
@@ -975,7 +975,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                         }
                         state = newstate;
                     } else {
-                        Perl_croak( aTHX_ "panic! In trie construction, no char mapping for %" IVdf, uvc );
+                        croak("panic! In trie construction, no char mapping for %" IVdf, uvc );
                     }
                 }
             } else {
@@ -1186,7 +1186,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                         }
                         state = trie->trans[ state + charid ].next;
                     } else {
-                        Perl_croak( aTHX_ "panic! In trie construction, no char mapping for %" IVdf, uvc );
+                        croak("panic! In trie construction, no char mapping for %" IVdf, uvc );
                     }
                     /* charid is now 0 if we dont know the char read, or
                      * nonzero if we do */

--- a/regexec.c
+++ b/regexec.c
@@ -12003,7 +12003,7 @@ Perl_reg_named_buff(pTHX_ REGEXP * const rx, SV * const key, SV * const value,
     if (flags & RXapif_FETCH) {
         return reg_named_buff_fetch(rx, key, flags);
     } else if (flags & (RXapif_STORE | RXapif_DELETE | RXapif_CLEAR)) {
-        Perl_croak_no_modify();
+        croak_no_modify();
         return NULL;
     } else if (flags & RXapif_EXISTS) {
         return reg_named_buff_exists(rx, key, flags)
@@ -12352,7 +12352,7 @@ Perl_reg_numbered_buff_store(pTHX_ REGEXP * const rx, const I32 paren,
     PERL_UNUSED_ARG(value);
 
     if (!PL_localizing)
-        Perl_croak_no_modify();
+        croak_no_modify();
 }
 
 I32

--- a/regexec.c
+++ b/regexec.c
@@ -243,12 +243,12 @@ S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEP
     PERL_ARGS_ASSERT_REGCPPUSH;
 
     if (paren_elems_to_push < 0)
-        Perl_croak(aTHX_ "panic: paren_elems_to_push, %i < 0, maxopenparen: %i parenfloor: %i",
+        croak("panic: paren_elems_to_push, %i < 0, maxopenparen: %i parenfloor: %i",
                    (int)paren_elems_to_push, (int)maxopenparen,
                    (int)parenfloor);
 
     if ((elems_shifted >> SAVE_TIGHT_SHIFT) != total_elems)
-        Perl_croak(aTHX_ "panic: paren_elems_to_push offset %" UVuf
+        croak("panic: paren_elems_to_push offset %" UVuf
                    " out of range (%lu-%ld)",
                    total_elems,
                    (unsigned long)maxopenparen,
@@ -549,7 +549,7 @@ S_isFOO_lc(pTHX_ const U8 classnum, const U8 character)
             break;
     }
 
-    Perl_croak(aTHX_
+    croak(
                "panic: isFOO_lc() has an unexpected character class '%d'",
                classnum);
 
@@ -1134,7 +1134,7 @@ Perl_re_intuit_start(pTHX_
 
 #ifdef DEBUGGING	/* 7/99: reports of failure (with the older version) */
     if (end_shift < 0)
-        Perl_croak(aTHX_ "panic: end_shift: %" IVdf " pattern:\n%s\n ",
+        croak("panic: end_shift: %" IVdf " pattern:\n%s\n ",
                    (IV)end_shift, RX_PRECOMP(rx));
 #endif
 
@@ -3505,7 +3505,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
         assert(0);
 
       default:
-        Perl_croak(aTHX_ "panic: unknown regstclass %d", (int)OP(c));
+        croak("panic: unknown regstclass %d", (int)OP(c));
     } /* End of switch on node type */
 
     return 0;
@@ -3716,7 +3716,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
 
     /* Be paranoid... */
     if (prog == NULL) {
-        Perl_croak(aTHX_ "NULL regexp parameter");
+        croak("NULL regexp parameter");
     }
 
     DEBUG_EXECUTE_r(
@@ -3850,7 +3850,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
 
     /* Check validity of program. */
     if (UCHARAT(progi->program) != REG_MAGIC) {
-        Perl_croak(aTHX_ "corrupted regexp program");
+        croak("corrupted regexp program");
     }
 
     RXp_MATCH_TAINTED_off(prog);
@@ -8175,7 +8175,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
             arg = ARG1u(scan);
             if (cur_eval && cur_eval->locinput == locinput) {
                 if ( ++nochange_depth > max_nochange_depth )
-                    Perl_croak(aTHX_
+                    croak(
                         "Pattern subroutine nesting without pos change"
                         " exceeded limit in regex");
             } else {
@@ -8197,7 +8197,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
             if ( rex->recurse_locinput[arg] == locinput ) {
                 /* FIXME: we should show the regop that is failing as part
                  * of the error message. */
-                Perl_croak(aTHX_ "Infinite recursion in regex");
+                croak("Infinite recursion in regex");
             } else {
                 ST.prev_recurse_locinput= rex->recurse_locinput[arg];
                 rex->recurse_locinput[arg]= locinput;
@@ -8224,7 +8224,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
         case EVAL:  /*   /(?{...})B/   /(??{A})B/  and  /(?(?{...})X|Y)B/   */
             if (logical == 2 && cur_eval && cur_eval->locinput == locinput) {
                 if ( ++nochange_depth > max_nochange_depth )
-                    Perl_croak(aTHX_ "EVAL without pos change exceeded limit in regex");
+                    croak("EVAL without pos change exceeded limit in regex");
             } else {
                 nochange_depth = 0;
             }
@@ -10020,7 +10020,7 @@ NULL
         default:
             PerlIO_printf(Perl_error_log, "%" UVxf " %d\n",
                           PTR2UV(scan), OP(scan));
-            Perl_croak(aTHX_ "regexp memory corruption");
+            croak("regexp memory corruption");
 
         /* this is a point to jump to in order to increment
          * locinput by one character */
@@ -10103,7 +10103,7 @@ NULL
     * We get here only if there's trouble -- normally "case END" is
     * the terminating point.
     */
-    Perl_croak(aTHX_ "corrupted regexp pointers");
+    croak("corrupted regexp pointers");
     NOT_REACHED; /* NOTREACHED */
 
   yes:
@@ -10895,7 +10895,7 @@ S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
         break;
 
     default:
-        Perl_croak(aTHX_ "panic: regrepeat() called with unrecognized"
+        croak("panic: regrepeat() called with unrecognized"
                          " node type %d='%s'", OP(p), REGNODE_NAME(OP(p)));
         NOT_REACHED; /* NOTREACHED */
 
@@ -12014,7 +12014,7 @@ Perl_reg_named_buff(pTHX_ REGEXP * const rx, SV * const key, SV * const value,
     } else if (flags & (RXapif_SCALAR | RXapif_REGNAMES_COUNT)) {
         return reg_named_buff_scalar(rx, flags);
     } else {
-        Perl_croak(aTHX_ "panic: Unknown flags %d in named_buff", (int)flags);
+        croak("panic: Unknown flags %d in named_buff", (int)flags);
         return NULL;
     }
 }
@@ -12031,7 +12031,7 @@ Perl_reg_named_buff_iter(pTHX_ REGEXP * const rx, const SV * const lastkey,
     else if (flags & RXapif_NEXTKEY)
         return reg_named_buff_nextkey(rx, flags);
     else {
-        Perl_croak(aTHX_ "panic: Unknown flags %d in named_buff_iter",
+        croak("panic: Unknown flags %d in named_buff_iter",
                                             (int)flags);
         return NULL;
     }
@@ -12168,7 +12168,7 @@ Perl_reg_named_buff_scalar(pTHX_ REGEXP * const r, const U32 flags)
             SvREFCNT_dec_NN(ret);
             return newSViv(length);
         } else {
-            Perl_croak(aTHX_ "panic: Unknown flags %d in named_buff_scalar",
+            croak("panic: Unknown flags %d in named_buff_scalar",
                                                 (int)flags);
             return NULL;
         }

--- a/reginline.h
+++ b/reginline.h
@@ -14,7 +14,7 @@ Perl_regnext(pTHX_ const regnode *p)
         return(NULL);
 
     if (OP(p) > REGNODE_MAX) {                /* regnode.type is unsigned */
-        Perl_croak(aTHX_ "Corrupted regexp opcode %d > %d",
+        croak("Corrupted regexp opcode %d > %d",
                                                 (int)OP(p), (int)REGNODE_MAX);
     }
 

--- a/scope.c
+++ b/scope.c
@@ -1960,7 +1960,7 @@ Perl_magic_freedestruct(pTHX_ SV* sv, MAGIC* mg) {
 
     IV nargs = 0;
     if (PL_phase == PERL_PHASE_DESTRUCT) {
-        Perl_warn(aTHX_ "Can't call destructor for 0x%p in global destruction\n", sv);
+        warn("Can't call destructor for 0x%p in global destruction\n", sv);
         return 1;
     }
 

--- a/scope.c
+++ b/scope.c
@@ -36,7 +36,7 @@ Perl_stack_grow(pTHX_ SV **sp, SV **p, SSize_t n)
     PERL_ARGS_ASSERT_STACK_GROW;
 
     if (UNLIKELY(n < 0))
-        Perl_croak(aTHX_
+        croak(
             "panic: stack_grow() negative count (%" IVdf ")", (IV)n);
 
     PL_stack_sp = sp;
@@ -53,7 +53,7 @@ Perl_stack_grow(pTHX_ SV **sp, SV **p, SSize_t n)
                  || current + extra > Stack_off_t_MAX - n
     ))
         /* diag_listed_as: Out of memory during %s extend */
-        Perl_croak(aTHX_ "Out of memory during stack extend");
+        croak("Out of memory during stack extend");
 
     av_extend(PL_curstack, current + n + extra);
 #ifdef PERL_USE_HWM
@@ -205,7 +205,7 @@ Perl_savestack_grow_cnt(pTHX_ I32 need)
      * and we have rolled over from I32_MAX to a small value */
     if (new_max > I32_MAX || new_max < PL_savestack_max) {
         if (new_floor > I32_MAX || new_floor < PL_savestack_max) {
-            Perl_croak(aTHX_ "panic: savestack overflows I32_MAX");
+            croak("panic: savestack overflows I32_MAX");
         }
         new_max = new_floor;
     }
@@ -803,7 +803,7 @@ Perl_save_clearsv(pTHX_ SV **svp)
     assert(*svp);
     SvPADSTALE_off(*svp); /* mark lexical as active */
     if (UNLIKELY((offset_shifted >> SAVE_TIGHT_SHIFT) != offset)) {
-        Perl_croak(aTHX_ "panic: pad offset %" UVuf " out of range (%p-%p)",
+        croak("panic: pad offset %" UVuf " out of range (%p-%p)",
                    offset, svp, PL_curpad);
     }
 
@@ -1078,7 +1078,7 @@ Perl_save_alloc(pTHX_ SSize_t size, I32 pad)
     const UV elems_shifted = elems << SAVE_TIGHT_SHIFT;
 
     if (UNLIKELY((elems_shifted >> SAVE_TIGHT_SHIFT) != elems))
-        Perl_croak(aTHX_
+        croak(
             "panic: save_alloc elems %" UVuf " out of range (%" IVdf "-%" IVdf ")",
                    elems, (IV)size, (IV)pad);
 
@@ -1107,7 +1107,7 @@ Perl_leave_scope(pTHX_ I32 base)
     bool was = TAINT_get;
 
     if (UNLIKELY(base < -1))
-        Perl_croak(aTHX_ "panic: corrupt saved stack index %ld", (long) base);
+        croak("panic: corrupt saved stack index %ld", (long) base);
     DEBUG_l(Perl_deb(aTHX_ "savestack: releasing items %ld -> %ld\n",
                         (long)PL_savestack_ix, (long)base));
     while (PL_savestack_ix > base) {
@@ -1731,7 +1731,7 @@ Perl_leave_scope(pTHX_ I32 base)
             break;
 
         default:
-            Perl_croak(aTHX_ "panic: leave_scope inconsistency %u",
+            croak("panic: leave_scope inconsistency %u",
                     (U8)uv & SAVE_MASK);
         }
     }

--- a/sv.c
+++ b/sv.c
@@ -13770,7 +13770,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                 && ckWARN(WARN_PRINTF))
             {
                 SV * const msg = sv_newmortal();
-                Perl_sv_setpvf(aTHX_ msg, "Invalid conversion in %sprintf: ",
+                sv_setpvf(msg, "Invalid conversion in %sprintf: ",
                           (PL_op->op_type == OP_PRTF) ? "" : "s");
                 if (fmtstart < patend) {
                     const char * const fmtend = q < patend ? q : patend;

--- a/sv.c
+++ b/sv.c
@@ -13780,7 +13780,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                         if (isPRINT(*f)) {
                             sv_catpvn_nomg(msg, f, 1);
                         } else {
-                            Perl_sv_catpvf(aTHX_ msg, "\\%03o", (U8) *f);
+                            sv_catpvf(msg, "\\%03o", (U8) *f);
                         }
                     }
                     sv_catpvs(msg, "\"");
@@ -16884,14 +16884,14 @@ Perl_varname(pTHX_ const GV *const gv, const char gvtype, PADOFFSET targ,
         const char * const pv = SvPV_nomg_const((SV*)keyname, len);
 
         *SvPVX(name) = '$';
-        Perl_sv_catpvf(aTHX_ name, "{%s}",
+        sv_catpvf(name, "{%s}",
             pv_pretty(sv, pv, len, 32, NULL, NULL,
                     PERL_PV_PRETTY_DUMP | PERL_PV_ESCAPE_UNI_DETECT ));
         SvREFCNT_dec_NN(sv);
     }
     else if (subscript_type == FUV_SUBSCRIPT_ARRAY) {
         *SvPVX(name) = '$';
-        Perl_sv_catpvf(aTHX_ name, "[%" IVdf "]", (IV)aindex);
+        sv_catpvf(name, "[%" IVdf "]", (IV)aindex);
     }
     else if (subscript_type == FUV_SUBSCRIPT_WITHIN) {
         /* We know that name has no magic, so can use 0 instead of SV_GMAGIC */

--- a/sv.c
+++ b/sv.c
@@ -1063,12 +1063,12 @@ Perl_sv_upgrade(pTHX_ SV *const sv, svtype new_type)
         break;
     default:
         if (UNLIKELY(old_type_details->cant_upgrade))
-            Perl_croak(aTHX_ "Can't upgrade %s (%" UVuf ") to %" UVuf,
+            croak("Can't upgrade %s (%" UVuf ") to %" UVuf,
                        sv_reftype(sv, 0), (UV) old_type, (UV) new_type);
     }
 
     if (UNLIKELY(old_type > new_type))
-        Perl_croak(aTHX_ "sv_upgrade from type %d down to type %d",
+        croak("sv_upgrade from type %d down to type %d",
                 (int)old_type, (int)new_type);
 
     new_type_details = bodies_by_type + new_type;
@@ -1258,7 +1258,7 @@ Perl_sv_upgrade(pTHX_ SV *const sv, svtype new_type)
         }
         break;
     default:
-        Perl_croak(aTHX_ "panic: sv_upgrade to unknown type %lu",
+        croak("panic: sv_upgrade to unknown type %lu",
                    (unsigned long)new_type);
     }
 
@@ -1544,7 +1544,7 @@ Perl_sv_setiv(pTHX_ SV *const sv, const IV i)
     case SVt_PVFM:
     case SVt_PVIO:
         /* diag_listed_as: Can't coerce %s to %s in %s */
-        Perl_croak(aTHX_ "Can't coerce %s to integer in %s", sv_reftype(sv,0),
+        croak("Can't coerce %s to integer in %s", sv_reftype(sv,0),
                    OP_DESC(PL_op));
         NOT_REACHED; /* NOTREACHED */
         break;
@@ -1656,7 +1656,7 @@ Perl_sv_setnv(pTHX_ SV *const sv, const NV num)
     case SVt_PVFM:
     case SVt_PVIO:
         /* diag_listed_as: Can't coerce %s to %s in %s */
-        Perl_croak(aTHX_ "Can't coerce %s to number in %s", sv_reftype(sv,0),
+        croak("Can't coerce %s to number in %s", sv_reftype(sv,0),
                    OP_DESC(PL_op));
         NOT_REACHED; /* NOTREACHED */
         break;
@@ -3661,10 +3661,10 @@ Perl_sv_utf8_downgrade_flags(pTHX_ SV *const sv, const bool fail_ok, const U32 f
                     return FALSE;
                 else {
                     if (PL_op)
-                        Perl_croak(aTHX_ "Wide character in %s",
+                        croak("Wide character in %s",
                                    OP_DESC(PL_op));
                     else
-                        Perl_croak(aTHX_ "Wide character");
+                        croak("Wide character");
                 }
             }
             SvCUR_set(sv, len);
@@ -4820,7 +4820,7 @@ Perl_sv_set_undef(pTHX_ SV *sv)
     }
 
     if (SvIS_FREED(sv))
-        Perl_croak(aTHX_ "panic: attempt to undefine a freed scalar %p",
+        croak("panic: attempt to undefine a freed scalar %p",
             (void *)sv);
 
     SV_CHECK_THINKFIRST_COW_DROP(sv);
@@ -5074,7 +5074,7 @@ Perl_sv_setpvn(pTHX_ SV *const sv, const char *const ptr, const STRLEN len)
         /* len is STRLEN which is unsigned, need to copy to signed */
         const IV iv = len;
         if (iv < 0)
-            Perl_croak(aTHX_ "panic: sv_setpvn called with negative strlen %"
+            croak("panic: sv_setpvn called with negative strlen %"
                        IVdf, iv);
     }
     SvUPGRADE(sv, SVt_PV);
@@ -5111,7 +5111,7 @@ Perl_sv_setpvn_fresh(pTHX_ SV *const sv, const char *const ptr, const STRLEN len
         const IV iv = len;
         /* len is STRLEN which is unsigned, need to copy to signed */
         if (iv < 0)
-            Perl_croak(aTHX_ "panic: sv_setpvn_fresh called with negative strlen %"
+            croak("panic: sv_setpvn_fresh called with negative strlen %"
                        IVdf, iv);
 
         dptr = sv_grow_fresh(sv, len + 1);
@@ -5552,7 +5552,7 @@ Perl_sv_chop(pTHX_ SV *const sv, const char *const ptr)
     }
     max_delta = SvLEN(sv) ? SvLEN(sv) : SvCUR(sv);
     if (delta > max_delta)
-        Perl_croak(aTHX_ "panic: sv_chop ptr=%p, start=%p, end=%p",
+        croak("panic: sv_chop ptr=%p, start=%p, end=%p",
                    ptr, SvPVX_const(sv), SvPVX_const(sv) + max_delta);
     /* SvPVX(sv) may move in SV_CHECK_THINKFIRST(sv), so don't use ptr any more */
     SV_CHECK_THINKFIRST(sv);
@@ -5987,7 +5987,7 @@ Perl_sv_magic(pTHX_ SV *const sv, SV *const obj, const int how,
         || ((flags = PL_magic_data[how]),
             (vtable_index = flags & PERL_MAGIC_VTABLE_MASK)
             > magic_vtable_max))
-        Perl_croak(aTHX_ "Don't know how to handle magic of type \\%o", how);
+        croak("Don't know how to handle magic of type \\%o", how);
 
     /* PERL_MAGIC_ext is reserved for use by extensions not perl internals.
        Useful for attaching extension internal data to perl vars.
@@ -6125,7 +6125,7 @@ Perl_sv_rvweaken(pTHX_ SV *const sv)
     if (!SvOK(sv))  /* let undefs pass */
         return sv;
     if (!SvROK(sv))
-        Perl_croak(aTHX_ "Can't weaken a nonreference");
+        croak("Can't weaken a nonreference");
     else if (SvWEAKREF(sv)) {
         Perl_ck_warner(aTHX_ packWARN(WARN_MISC), "Reference is already weak");
         return sv;
@@ -6159,7 +6159,7 @@ Perl_sv_rvunweaken(pTHX_ SV *const sv)
     if (!SvOK(sv)) /* let undefs pass */
         return sv;
     if (!SvROK(sv))
-        Perl_croak(aTHX_ "Can't unweaken a nonreference");
+        croak("Can't unweaken a nonreference");
     else if (!SvWEAKREF(sv)) {
         Perl_ck_warner(aTHX_ packWARN(WARN_MISC), "Reference is not weak");
         return sv;
@@ -6342,7 +6342,7 @@ Perl_sv_del_backref(pTHX_ SV *const tsv, SV *const sv)
     }
 
     if (!svp)
-        Perl_croak(aTHX_ "panic: del_backref, svp=0");
+        croak("panic: del_backref, svp=0");
     if (!*svp) {
         /* It's possible that sv is being freed recursively part way through the
            freeing of tsv. If this happens, the backreferences array of tsv has
@@ -6350,7 +6350,7 @@ Perl_sv_del_backref(pTHX_ SV *const tsv, SV *const sv)
            we should not panic. Instead, nothing needs doing, so return.  */
         if (PL_phase == PERL_PHASE_DESTRUCT && SvREFCNT(tsv) == 0)
             return;
-        Perl_croak(aTHX_ "panic: del_backref, *svp=%p phase=%s refcnt=%" UVuf,
+        croak("panic: del_backref, *svp=%p phase=%s refcnt=%" UVuf,
                    (void*)*svp, PL_phase_names[PL_phase], (UV)SvREFCNT(tsv));
     }
 
@@ -6410,7 +6410,7 @@ Perl_sv_del_backref(pTHX_ SV *const tsv, SV *const sv)
     else {
         /* optimisation: only a single backref, stored directly */
         if (*svp != sv)
-            Perl_croak(aTHX_ "panic: del_backref, *svp=%p, sv=%p",
+            croak("panic: del_backref, *svp=%p, sv=%p",
                        (void*)*svp, (void*)sv);
         *svp = NULL;
     }
@@ -6435,7 +6435,7 @@ Perl_sv_kill_backrefs(pTHX_ SV *const sv, AV *const av)
     if (SvIS_FREED(av)) {
         if (PL_in_clean_all) /* All is fair */
             return;
-        Perl_croak(aTHX_
+        croak(
                    "panic: magic_killbackrefs (freed backref AV/SV)");
     }
 
@@ -6489,7 +6489,7 @@ Perl_sv_kill_backrefs(pTHX_ SV *const sv, AV *const av)
                     }
 
                 } else {
-                    Perl_croak(aTHX_
+                    croak(
                                "panic: magic_killbackrefs (flags=%" UVxf ")",
                                (UV)SvFLAGS(referrer));
                 }
@@ -6580,7 +6580,7 @@ Perl_sv_insert_flags(pTHX_ SV *const bigstr, const STRLEN offset, const STRLEN l
     bigend = big + SvCUR(bigstr);
 
     if (midend > bigend)
-        Perl_croak(aTHX_ "panic: sv_insert, midend=%p, bigend=%p",
+        croak("panic: sv_insert, midend=%p, bigend=%p",
                    midend, bigend);
 
     if (mid - big > bigend - midend) {	/* faster to shorten from end */
@@ -6637,7 +6637,7 @@ Perl_sv_replace(pTHX_ SV *const sv, SV *const nsv)
 
     SV_CHECK_THINKFIRST_COW_DROP(sv);
     if (SvREFCNT(nsv) != 1) {
-        Perl_croak(aTHX_ "panic: reference miscount on nsv in sv_replace()"
+        croak("panic: reference miscount on nsv in sv_replace()"
                    " (%" UVuf " != 1)", (UV) SvREFCNT(nsv));
     }
     if (SvMAGICAL(sv)) {
@@ -7275,7 +7275,7 @@ S_curse(pTHX_ SV * const sv, const bool check_refcnt) {
 
         if (check_refcnt && SvREFCNT(sv)) {
             if (PL_in_clean_objs)
-                Perl_croak(aTHX_
+                croak(
                   "DESTROY created new reference to dead object '%" HEKf "'",
                    HEKfARG(HvNAME_HEK(stash)));
             /* DESTROY gave object new lease on life */
@@ -8015,7 +8015,7 @@ Perl_sv_pos_b2u_flags(pTHX_ SV *const sv, STRLEN const offset, U32 flags)
     s = (const U8*)SvPV_flags(sv, blen, flags);
 
     if (blen < offset)
-        Perl_croak(aTHX_ "panic: sv_pos_b2u: bad byte offset, blen=%" UVuf
+        croak("panic: sv_pos_b2u: bad byte offset, blen=%" UVuf
                    ", byte=%" UVuf, (UV)blen, (UV)offset);
 
     send = s + offset;
@@ -8120,7 +8120,7 @@ S_assert_uft8_cache_coherent(pTHX_ const char *const func, STRLEN from_cache,
        while printing error messages.  */
     SAVEI8(PL_utf8cache);
     PL_utf8cache = 0;
-    Perl_croak(aTHX_ "panic: %s cache %" UVuf " real %" UVuf " for %" SVf,
+    croak("panic: %s cache %" UVuf " real %" UVuf " for %" SVf,
                func, (UV) from_cache, (UV) real, SVfARG(sv));
 }
 
@@ -8919,7 +8919,7 @@ Perl_sv_gets(pTHX_ SV *const sv, PerlIO *const fp, SSize_t append)
         else {
             if (SvUTF8(PL_rs)) {
                 if (!sv_utf8_downgrade(PL_rs, TRUE)) {
-                    Perl_croak(aTHX_ "Wide character in $/");
+                    croak("Wide character in $/");
                 }
             }
             /* extract the raw pointer to the record separator */
@@ -10321,14 +10321,14 @@ Perl_sv_2io(pTHX_ SV *const sv)
             gv = MUTABLE_GV(sv);
             io = GvIO(gv);
             if (!io)
-                Perl_croak(aTHX_ "Bad filehandle: %" HEKf,
+                croak("Bad filehandle: %" HEKf,
                                     HEKfARG(GvNAME_HEK(gv)));
             break;
         }
         /* FALLTHROUGH */
     default:
         if (!SvOK(sv))
-            Perl_croak(aTHX_ PL_no_usym, "filehandle");
+            croak(PL_no_usym, "filehandle");
         if (SvROK(sv)) {
             SvGETMAGIC(SvRV(sv));
             return sv_2io(SvRV(sv));
@@ -10343,7 +10343,7 @@ Perl_sv_2io(pTHX_ SV *const sv)
             if (SvGMAGICAL(sv)) {
                 newsv = sv_mortalcopy_flags(sv, SV_DO_COW_SVSETSV);
             }
-            Perl_croak(aTHX_ "Bad filehandle: %" SVf, SVfARG(newsv));
+            croak("Bad filehandle: %" SVf, SVfARG(newsv));
         }
         break;
     }
@@ -10399,7 +10399,7 @@ Perl_sv_2cv(pTHX_ SV *sv, HV **const st, GV **const gvp, const I32 lref)
             else if(SvGETMAGIC(sv), isGV_with_GP(sv))
                 gv = MUTABLE_GV(sv);
             else
-                Perl_croak(aTHX_ "Not a subroutine reference");
+                croak("Not a subroutine reference");
         }
         else if (isGV_with_GP(sv)) {
             gv = MUTABLE_GV(sv);
@@ -10503,7 +10503,7 @@ Perl_sv_pvn_force_flags(pTHX_ SV *const sv, STRLEN *const lp, const U32 flags)
         if (SvTYPE(sv) > SVt_PVLV
             || isGV_with_GP(sv))
             /* diag_listed_as: Can't coerce %s to %s in %s */
-            Perl_croak(aTHX_ "Can't coerce %s to string in %s", sv_reftype(sv,0),
+            croak("Can't coerce %s to string in %s", sv_reftype(sv,0),
                 OP_DESC(PL_op));
         s = sv_2pv_flags(sv, &len, flags &~ SV_GMAGIC);
         if (!s) {
@@ -10931,16 +10931,16 @@ Perl_sv_bless(pTHX_ SV *const sv, HV *const stash)
 
     SvGETMAGIC(sv);
     if (!SvROK(sv))
-        Perl_croak(aTHX_ "Can't bless non-reference value");
+        croak("Can't bless non-reference value");
     if (HvSTASH_IS_CLASS(stash))
-        Perl_croak(aTHX_ "Attempt to bless into a class");
+        croak("Attempt to bless into a class");
 
     tmpRef = SvRV(sv);
     if (SvFLAGS(tmpRef) & (SVs_OBJECT|SVf_READONLY|SVf_PROTECT)) {
         if (SvREADONLY(tmpRef))
             Perl_croak_no_modify();
         if (SvTYPE(tmpRef) == SVt_PVOBJ)
-            Perl_croak(aTHX_ "Can't bless an object reference");
+            croak("Can't bless an object reference");
         if (SvOBJECT(tmpRef)) {
             oldstash = SvSTASH(tmpRef);
         }
@@ -11455,7 +11455,7 @@ static void
 S_croak_overflow()
 {
     dTHX;
-    Perl_croak(aTHX_ "Integer overflow in format string for %s",
+    croak("Integer overflow in format string for %s",
                     (PL_op ? OP_DESC(PL_op) : "sv_vcatpvfn"));
 }
 
@@ -11752,7 +11752,7 @@ S_hextract(pTHX_ const NV nv, int* exponent, bool *subnormal,
     *subnormal = FALSE;
     if (vend && (vend <= vhex || vend > vmaxend)) {
         /* diag_listed_as: Hexadecimal float: internal error (%s) */
-        Perl_croak(aTHX_ "Hexadecimal float: internal error (entry)");
+        croak("Hexadecimal float: internal error (entry)");
     }
     {
         /* First check if using long doubles. */
@@ -11972,7 +11972,7 @@ S_hextract(pTHX_ const NV nv, int* exponent, bool *subnormal,
         ixmin < 0 || ixmax >= NVSIZE ||
         (vend && v != vend)) {
         /* diag_listed_as: Hexadecimal float: internal error (%s) */
-        Perl_croak(aTHX_ "Hexadecimal float: internal error (overflow)");
+        croak("Hexadecimal float: internal error (overflow)");
     }
     return v;
 }
@@ -12240,7 +12240,7 @@ S_format_hexfp(pTHX_ char * const buf, const STRLEN bufsize, const char c,
     /* sanity checks */
     if (elen >= bufsize || width >= bufsize)
         /* diag_listed_as: Hexadecimal float: internal error (%s) */
-        Perl_croak(aTHX_ "Hexadecimal float: internal error (overflow)");
+        croak("Hexadecimal float: internal error (overflow)");
 
     elen += my_snprintf(p, bufsize - elen,
                         "%c%+d", lower ? 'p' : 'P',
@@ -13394,7 +13394,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
 
             if (Perl_isinfnan(nv)) {
                 if (c == 'c')
-                    Perl_croak(aTHX_ "Cannot printf %" NVgf " with '%c'",
+                    croak("Cannot printf %" NVgf " with '%c'",
                                nv, (int)c);
 
                 elen = S_infnan_2pv(nv, ebuf, sizeof(ebuf), plus);
@@ -13599,7 +13599,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                 /* snprintf() returns an int, and we use that return value,
                    so die horribly if the expected size is too large for int
                 */
-                Perl_croak(aTHX_ "Numeric format result too large");
+                croak("Numeric format result too large");
             }
 
             if (PL_efloatsize <= float_need) {
@@ -15117,7 +15117,7 @@ Perl_cx_dup(pTHX_ PERL_CONTEXT *cxs, I32 ix, I32 max, CLONE_PARAMS* param)
     while (ix >= 0) {
         PERL_CONTEXT * const ncx = &ncxs[ix];
         if (CxTYPE(ncx) == CXt_SUBST) {
-            Perl_croak(aTHX_ "Cloning substitution context is unimplemented");
+            croak("Cloning substitution context is unimplemented");
         }
         else {
             ncx->blk_oldcop = (COP*)any_dup(ncx->blk_oldcop, param->proto_perl);
@@ -15596,7 +15596,7 @@ Perl_ss_dup(pTHX_ PerlInterpreter *proto_perl, CLONE_PARAMS* param)
             TOPPTR(nss,ix) = parser_dup((const yy_parser*)ptr, param);
             break;
         default:
-            Perl_croak(aTHX_
+            croak(
                        "panic: ss_dup inconsistency (%" IVdf ")", (IV) type);
         }
     }
@@ -16762,7 +16762,7 @@ Perl_sv_cat_decode(pTHX_ SV *dsv, SV *encoding,
         LEAVE;
     }
     else
-        Perl_croak(aTHX_ "Invalid argument to sv_cat_decode");
+        croak("Invalid argument to sv_cat_decode");
     return ret;
 
 }
@@ -17758,11 +17758,11 @@ void S_croak_sv_setsv_flags(pTHX_ SV * const dsv, SV * const ssv)
 {
     OP *op = PL_op;
     if (SvIS_FREED(dsv)) {
-        Perl_croak(aTHX_ "panic: attempt to copy value %" SVf
+        croak("panic: attempt to copy value %" SVf
                    " to a freed scalar %p", SVfARG(ssv), (void *)dsv);
     }
     if (SvIS_FREED(ssv)) {
-        Perl_croak(aTHX_ "panic: attempt to copy freed scalar %p to %p",
+        croak("panic: attempt to copy freed scalar %p to %p",
                    (void*)ssv, (void*)dsv);
     }
 
@@ -17771,17 +17771,17 @@ void S_croak_sv_setsv_flags(pTHX_ SV * const dsv, SV * const ssv)
         const char * const type = sv_reftype(ssv,0);
         if (op)
             /* diag_listed_as: Bizarre copy of %s */
-            Perl_croak(aTHX_ "Bizarre copy of %s in %s", type, OP_DESC(op));
+            croak("Bizarre copy of %s in %s", type, OP_DESC(op));
         else
-            Perl_croak(aTHX_ "Bizarre copy of %s", type);
+            croak("Bizarre copy of %s", type);
     }
 
     const char * const type = sv_reftype(dsv,0);
     if (op)
         /* diag_listed_as: Cannot copy to %s */
-        Perl_croak(aTHX_ "Cannot copy to %s in %s", type, OP_DESC(op));
+        croak("Cannot copy to %s in %s", type, OP_DESC(op));
     else
-        Perl_croak(aTHX_ "Cannot copy to %s", type);
+        croak("Cannot copy to %s", type);
 
 }
 

--- a/sv.c
+++ b/sv.c
@@ -4163,7 +4163,7 @@ Perl_sv_buf_to_ro(pTHX_ SV *sv)
     if (!header->readonly) header->readonly = 1;
 # endif
     if (mprotect(header, len, PROT_READ))
-        Perl_warn(aTHX_ "mprotect RW for COW string %p %lu failed with %d",
+        warn("mprotect RW for COW string %p %lu failed with %d",
                          header, len, errno);
 }
 
@@ -4175,7 +4175,7 @@ S_sv_buf_to_rw(pTHX_ SV *sv)
     const MEM_SIZE len = header->size;
     PERL_ARGS_ASSERT_SV_BUF_TO_RW;
     if (mprotect(header, len, PROT_READ|PROT_WRITE))
-        Perl_warn(aTHX_ "mprotect for COW string %p %lu failed with %d",
+        warn("mprotect for COW string %p %lu failed with %d",
                          header, len, errno);
 # ifdef PERL_TRACK_MEMPOOL
     header->readonly = 0;

--- a/sv.c
+++ b/sv.c
@@ -4252,7 +4252,7 @@ Perl_sv_setsv_flags(pTHX_ SV *dsv, SV* ssv, const I32 flags)
 
         /* minimal subset of SV_CHECK_THINKFIRST_COW_DROP(dsv) */
         if (SvREADONLY(dsv))
-            Perl_croak_no_modify();
+            croak_no_modify();
         if (SvROK(dsv)) {
             if (SvWEAKREF(dsv))
                 sv_unref_flags(dsv, 0);
@@ -4802,7 +4802,7 @@ Perl_sv_set_undef(pTHX_ SV *sv)
              * variable? Some XS code does this */
             if (sv == &PL_sv_undef)
                 return;
-            Perl_croak_no_modify();
+            croak_no_modify();
         }
 
         if (SvROK(sv)) {
@@ -5065,7 +5065,7 @@ Perl_sv_setpvn(pTHX_ SV *const sv, const char *const ptr, const STRLEN len)
 
     SV_CHECK_THINKFIRST_COW_DROP(sv);
     if (isGV_with_GP(sv))
-        Perl_croak_no_modify();
+        croak_no_modify();
     if (!ptr) {
         (void)SvOK_off(sv);
         return;
@@ -5438,7 +5438,7 @@ Perl_sv_force_normal_flags(pTHX_ SV *const sv, const U32 flags)
     PERL_ARGS_ASSERT_SV_FORCE_NORMAL_FLAGS;
 
     if (SvREADONLY(sv))
-        Perl_croak_no_modify();
+        croak_no_modify();
     else if (SvIsCOW(sv) && LIKELY(SvTYPE(sv) != SVt_PVHV))
         S_sv_uncow(aTHX_ sv, flags);
     if (SvROK(sv))
@@ -6002,7 +6002,7 @@ Perl_sv_magic(pTHX_ SV *const sv, SV *const obj, const int how,
             !PERL_MAGIC_TYPE_READONLY_ACCEPTABLE(how)
            )
         {
-            Perl_croak_no_modify();
+            croak_no_modify();
         }
     }
     if (SvMAGICAL(sv) || (how == PERL_MAGIC_taint && SvTYPE(sv) >= SVt_PVMG)) {
@@ -9306,7 +9306,7 @@ Perl_sv_inc_nomg(pTHX_ SV *const sv)
         return;
     if (SvTHINKFIRST(sv)) {
         if (SvREADONLY(sv)) {
-                Perl_croak_no_modify();
+                croak_no_modify();
         }
         if (SvROK(sv)) {
             IV i;
@@ -9371,7 +9371,7 @@ Perl_sv_inc_nomg(pTHX_ SV *const sv)
 
     /* treat AV/HV/CV/FM/IO and non-fake GVs as immutable */
     if (SvTYPE(sv) >= SVt_PVAV || (isGV_with_GP(sv) && !SvFAKE(sv)))
-        Perl_croak_no_modify();
+        croak_no_modify();
 
     if (!(flags & SVp_POK) || !*SvPVX_const(sv)) {
         if ((flags & SVTYPEMASK) < SVt_PVIV)
@@ -9490,7 +9490,7 @@ Perl_sv_dec_nomg(pTHX_ SV *const sv)
         return;
     if (SvTHINKFIRST(sv)) {
         if (SvREADONLY(sv)) {
-                Perl_croak_no_modify();
+                croak_no_modify();
         }
         if (SvROK(sv)) {
             IV i;
@@ -9558,7 +9558,7 @@ Perl_sv_dec_nomg(pTHX_ SV *const sv)
 
     /* treat AV/HV/CV/FM/IO and non-fake GVs as immutable */
     if (SvTYPE(sv) >= SVt_PVAV || (isGV_with_GP(sv) && !SvFAKE(sv)))
-        Perl_croak_no_modify();
+        croak_no_modify();
 
     if (!(flags & SVp_POK)) {
         if ((flags & SVTYPEMASK) < SVt_PVIV)
@@ -10938,7 +10938,7 @@ Perl_sv_bless(pTHX_ SV *const sv, HV *const stash)
     tmpRef = SvRV(sv);
     if (SvFLAGS(tmpRef) & (SVs_OBJECT|SVf_READONLY|SVf_PROTECT)) {
         if (SvREADONLY(tmpRef))
-            Perl_croak_no_modify();
+            croak_no_modify();
         if (SvTYPE(tmpRef) == SVt_PVOBJ)
             croak("Can't bless an object reference");
         if (SvOBJECT(tmpRef)) {

--- a/sv.c
+++ b/sv.c
@@ -13508,7 +13508,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                 int i = PERL_INT_MIN;
                 (void)Perl_frexp((NV)fv, &i);
                 if (i == PERL_INT_MIN)
-                    Perl_die(aTHX_ "panic: frexp: %" VCATPVFN_FV_GF, fv);
+                    die("panic: frexp: %" VCATPVFN_FV_GF, fv);
 
                 if (i > 0) {
                     digits = BIT_DIGITS(i);

--- a/sv.c
+++ b/sv.c
@@ -12459,7 +12459,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
             width = expect_number(&q);
             if (*q == '$') {
                 if (args)
-                    Perl_croak_nocontext(
+                    croak(
                         "Cannot yet reorder sv_vcatpvfn() arguments from va_list");
                 ++q;
                 efix = (Size_t)width;
@@ -12527,7 +12527,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                 ix = expect_number(&q);
                 if (*q++ == '$') {
                     if (args)
-                        Perl_croak_nocontext(
+                        croak(
                             "Cannot yet reorder sv_vcatpvfn() arguments from va_list");
                     no_redundant_warning = TRUE;
                 } else
@@ -12612,7 +12612,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                     ix = expect_number(&q);
                     if (*q++ == '$') {
                         if (args)
-                            Perl_croak_nocontext(
+                            croak(
                                 "Cannot yet reorder sv_vcatpvfn() arguments from va_list");
                         no_redundant_warning = TRUE;
                     } else
@@ -13676,13 +13676,13 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
 #ifdef USE_QUADMATH
                 {
                     if (!quadmath_format_valid(ptr))
-                        Perl_croak_nocontext("panic: quadmath invalid format \"%s\"", ptr);
+                        croak("panic: quadmath invalid format \"%s\"", ptr);
                     WITH_LC_NUMERIC_SET_TO_NEEDED_IN(in_lc_numeric,
                         elen = quadmath_snprintf(PL_efloatbuf, PL_efloatsize,
                                                  ptr, nv);
                     );
                     if ((IV)elen == -1) {
-                        Perl_croak_nocontext("panic: quadmath_snprintf failed, format \"%s\"", ptr);
+                        croak("panic: quadmath_snprintf failed, format \"%s\"", ptr);
                     }
                 }
 #elif defined(HAS_LONG_DOUBLE)
@@ -13751,7 +13751,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                 }
                 else {
                     if (arg_missing)
-                        Perl_croak_nocontext(
+                        croak(
                             "Missing argument for %%n in %s",
                                 PL_op ? OP_DESC(PL_op) : "sv_vcatpvfn()");
                     sv_setuv_mg(argsv, has_utf8

--- a/taint.c
+++ b/taint.c
@@ -80,7 +80,7 @@ Perl_taint_proper(pTHX_ const char *f, const char *const s)
             Perl_ck_warner_d(aTHX_ packWARN(WARN_TAINT), f, s, ug);
         }
         else {
-            Perl_croak(aTHX_ f, s, ug);
+            croak(f, s, ug);
         }
         GCC_DIAG_RESTORE_STMT;
 

--- a/toke.c
+++ b/toke.c
@@ -566,33 +566,33 @@ S_tokereport(pTHX_ I32 rv, const YYSTYPE* lvalp)
             Perl_sv_catpv(aTHX_ report, name);
         else if (isGRAPH(rv))
         {
-            Perl_sv_catpvf(aTHX_ report, "'%c'", (char)rv);
+            sv_catpvf(report, "'%c'", (char)rv);
             if ((char)rv == 'p')
                 sv_catpvs(report, " (pending identifier)");
         }
         else if (!rv)
             sv_catpvs(report, "EOF");
         else
-            Perl_sv_catpvf(aTHX_ report, "?? %" IVdf, (IV)rv);
+            sv_catpvf(report, "?? %" IVdf, (IV)rv);
         switch (type) {
         case TOKENTYPE_NONE:
             break;
         case TOKENTYPE_IVAL:
-            Perl_sv_catpvf(aTHX_ report, "(ival=%" IVdf ")", (IV)lvalp->ival);
+            sv_catpvf(report, "(ival=%" IVdf ")", (IV)lvalp->ival);
             break;
         case TOKENTYPE_OPNUM:
-            Perl_sv_catpvf(aTHX_ report, "(ival=op_%s)",
+            sv_catpvf(report, "(ival=op_%s)",
                                     PL_op_name[lvalp->ival]);
             break;
         case TOKENTYPE_PVAL:
-            Perl_sv_catpvf(aTHX_ report, "(pval=%p)", lvalp->pval);
+            sv_catpvf(report, "(pval=%p)", lvalp->pval);
             break;
         case TOKENTYPE_OPVAL:
             if (lvalp->opval) {
-                Perl_sv_catpvf(aTHX_ report, "(opval=op_%s)",
+                sv_catpvf(report, "(opval=op_%s)",
                                     PL_op_name[lvalp->opval->op_type]);
                 if (lvalp->opval->op_type == OP_CONST) {
-                    Perl_sv_catpvf(aTHX_ report, " %s",
+                    sv_catpvf(report, " %s",
                         SvPEEK(cSVOPx_sv(lvalp->opval)));
                 }
 
@@ -9217,7 +9217,7 @@ yyl_try(pTHX_ char *s)
                         {
                             /* strchr is ok, because -F pattern can't contain
                              * embedded NULs */
-                            Perl_sv_catpvf(aTHX_ PL_linestr, "our @F=split(%s);", PL_splitstr);
+                            sv_catpvf(PL_linestr, "our @F=split(%s);", PL_splitstr);
                         }
                         else {
                             /* "q\0${splitstr}\0" is legal perl. Yes, even NUL
@@ -12963,29 +12963,29 @@ Perl_yyerror_pvn(pTHX_ const char *const s, STRLEN len, U32 flags)
         else {
             sv_catpvs(where_sv, "next char ");
             if (yychar < 32)
-                Perl_sv_catpvf(aTHX_ where_sv, "^%c", toCTRL(yychar));
+                sv_catpvf(where_sv, "^%c", toCTRL(yychar));
             else if (isPRINT_LC(yychar)) {
                 const char string = yychar;
                 sv_catpvn(where_sv, &string, 1);
             }
             else
-                Perl_sv_catpvf(aTHX_ where_sv, "\\%03o", yychar & 255);
+                sv_catpvf(where_sv, "\\%03o", yychar & 255);
         }
         msg = newSVpvn_flags(s, len, (flags & SVf_UTF8) | SVs_TEMP);
-        Perl_sv_catpvf(aTHX_ msg, " at %s line %" LINE_Tf ", ",
+        sv_catpvf(msg, " at %s line %" LINE_Tf ", ",
             OutCopFILE(PL_curcop),
             (PL_parser->preambling == NOLINE
                    ? CopLINE(PL_curcop)
                    : PL_parser->preambling));
         if (context)
-            Perl_sv_catpvf(aTHX_ msg, "near \"%" UTF8f "\"\n",
+            sv_catpvf(msg, "near \"%" UTF8f "\"\n",
                                  UTF8fARG(UTF, contlen, context));
         else
-            Perl_sv_catpvf(aTHX_ msg, "%" SVf "\n", SVfARG(where_sv));
+            sv_catpvf(msg, "%" SVf "\n", SVfARG(where_sv));
         if (   PL_multi_start < PL_multi_end
             && (U32)(CopLINE(PL_curcop) - PL_multi_end) <= 1)
         {
-            Perl_sv_catpvf(aTHX_ msg,
+            sv_catpvf(msg,
             "  (Might be a runaway multi-line %c%c string starting on"
             " line %" LINE_Tf ")\n",
                     (int)PL_multi_open,(int)PL_multi_close,(line_t)PL_multi_start);

--- a/toke.c
+++ b/toke.c
@@ -4961,7 +4961,7 @@ Perl_filter_del(pTHX_ filter_t funcp)
         return;
     }
     /* we need to search for the correct entry and clear it	*/
-    Perl_die(aTHX_ "filter_del can only delete in reverse order (currently)");
+    die("filter_del can only delete in reverse order (currently)");
 }
 
 

--- a/toke.c
+++ b/toke.c
@@ -787,7 +787,7 @@ S_missingterm(pTHX_ char *s, STRLEN len)
     }
 
     q = memchr(s, '"', len) ? '\'' : '"';
-    Perl_croak(aTHX_ "Can't find string terminator %c%" UTF8f "%c"
+    croak("Can't find string terminator %c%" UTF8f "%c"
                      " anywhere before EOF", q, UTF8fARG(uni, len, s), q);
 }
 
@@ -882,7 +882,7 @@ Perl_lex_start(pTHX_ SV *line, PerlIO *rsfp, U32 flags)
     yy_parser *parser, *oparser;
 
     if (flags && flags & ~LEX_START_FLAGS)
-        Perl_croak(aTHX_ "Lexing code internal error (%s)", "lex_start");
+        croak("Lexing code internal error (%s)", "lex_start");
 
     /* create and initialise a parser */
 
@@ -1216,7 +1216,7 @@ Perl_lex_stuff_pvn(pTHX_ const char *pv, STRLEN len, U32 flags)
     char *bufptr;
     PERL_ARGS_ASSERT_LEX_STUFF_PVN;
     if (flags & ~(LEX_STUFF_UTF8))
-        Perl_croak(aTHX_ "Lexing code internal error (%s)", "lex_stuff_pvn");
+        croak("Lexing code internal error (%s)", "lex_stuff_pvn");
     if (UTF) {
         if (flags & LEX_STUFF_UTF8) {
             goto plain_copy;
@@ -1243,7 +1243,7 @@ Perl_lex_stuff_pvn(pTHX_ const char *pv, STRLEN len, U32 flags)
             for (p = pv; p != e; p++) {
                 U8 c = (U8)*p;
                 if (UTF8_IS_ABOVE_LATIN1(c)) {
-                    Perl_croak(aTHX_ "Lexing code attempted to stuff "
+                    croak("Lexing code attempted to stuff "
                                 "non-Latin-1 character into Latin-1 input");
                 } else if (UTF8_IS_NEXT_CHAR_DOWNGRADEABLE(p, e)) {
                     p++;
@@ -1296,7 +1296,7 @@ Perl_lex_stuff_sv(pTHX_ SV *sv, U32 flags)
     STRLEN len;
     PERL_ARGS_ASSERT_LEX_STUFF_SV;
     if (flags)
-        Perl_croak(aTHX_ "Lexing code internal error (%s)", "lex_stuff_sv");
+        croak("Lexing code internal error (%s)", "lex_stuff_sv");
     pv = SvPV(sv, len);
     lex_stuff_pvn(pv, len, flags | (SvUTF8(sv) ? LEX_STUFF_UTF8 : 0));
 }
@@ -1323,12 +1323,12 @@ Perl_lex_unstuff(pTHX_ char *ptr)
     PERL_ARGS_ASSERT_LEX_UNSTUFF;
     buf = PL_parser->bufptr;
     if (ptr < buf)
-        Perl_croak(aTHX_ "Lexing code internal error (%s)", "lex_unstuff");
+        croak("Lexing code internal error (%s)", "lex_unstuff");
     if (ptr == buf)
         return;
     bufend = PL_parser->bufend;
     if (ptr > bufend)
-        Perl_croak(aTHX_ "Lexing code internal error (%s)", "lex_unstuff");
+        croak("Lexing code internal error (%s)", "lex_unstuff");
     unstuff_len = ptr - buf;
     Move(ptr, buf, bufend+1-ptr, char);
     SvCUR_set(PL_parser->linestr, SvCUR(PL_parser->linestr) - unstuff_len);
@@ -1357,7 +1357,7 @@ Perl_lex_read_to(pTHX_ char *ptr)
     PERL_ARGS_ASSERT_LEX_READ_TO;
     s = PL_parser->bufptr;
     if (ptr < s || ptr > PL_parser->bufend)
-        Perl_croak(aTHX_ "Lexing code internal error (%s)", "lex_read_to");
+        croak("Lexing code internal error (%s)", "lex_read_to");
     for (; s != ptr; s++)
         if (*s == '\n') {
             COPLINE_INC_WITH_HERELINES;
@@ -1394,11 +1394,11 @@ Perl_lex_discard_to(pTHX_ char *ptr)
     PERL_ARGS_ASSERT_LEX_DISCARD_TO;
     buf = SvPVX(PL_parser->linestr);
     if (ptr < buf)
-        Perl_croak(aTHX_ "Lexing code internal error (%s)", "lex_discard_to");
+        croak("Lexing code internal error (%s)", "lex_discard_to");
     if (ptr == buf)
         return;
     if (ptr > PL_parser->bufptr)
-        Perl_croak(aTHX_ "Lexing code internal error (%s)", "lex_discard_to");
+        croak("Lexing code internal error (%s)", "lex_discard_to");
     discard_len = ptr - buf;
     if (PL_parser->oldbufptr < ptr)
         PL_parser->oldbufptr = ptr;
@@ -1478,7 +1478,7 @@ Perl_lex_next_chunk(pTHX_ U32 flags)
     bool got_some;
 
     if (flags & ~(LEX_KEEP_PREVIOUS|LEX_FAKE_EOF|LEX_NO_TERM))
-        Perl_croak(aTHX_ "Lexing code internal error (%s)", "lex_next_chunk");
+        croak("Lexing code internal error (%s)", "lex_next_chunk");
     if (!(flags & LEX_NO_TERM) && PL_lex_inwhat)
         return FALSE;
     linestr = PL_parser->linestr;
@@ -1612,7 +1612,7 @@ Perl_lex_peek_unichar(pTHX_ U32 flags)
 {
     char *s, *bufend;
     if (flags & ~(LEX_KEEP_PREVIOUS))
-        Perl_croak(aTHX_ "Lexing code internal error (%s)", "lex_peek_unichar");
+        croak("Lexing code internal error (%s)", "lex_peek_unichar");
     s = PL_parser->bufptr;
     bufend = PL_parser->bufend;
     if (UTF) {
@@ -1675,7 +1675,7 @@ Perl_lex_read_unichar(pTHX_ U32 flags)
 {
     I32 c;
     if (flags & ~(LEX_KEEP_PREVIOUS))
-        Perl_croak(aTHX_ "Lexing code internal error (%s)", "lex_read_unichar");
+        croak("Lexing code internal error (%s)", "lex_read_unichar");
     c = lex_peek_unichar(flags);
     if (c != -1) {
         if (c == '\n')
@@ -1715,7 +1715,7 @@ Perl_lex_read_space(pTHX_ U32 flags)
     const bool can_incline = !(flags & LEX_NO_INCLINE);
     bool need_incline = 0;
     if (flags & ~(LEX_KEEP_PREVIOUS|LEX_NO_NEXT_CHUNK|LEX_NO_INCLINE))
-        Perl_croak(aTHX_ "Lexing code internal error (%s)", "lex_read_space");
+        croak("Lexing code internal error (%s)", "lex_read_space");
     s = PL_parser->bufptr;
     bufend = PL_parser->bufend;
     while (1) {
@@ -3277,7 +3277,7 @@ S_scan_const(pTHX_ char *start)
                 }
                 else {  /* Is a '-' in the context where it means a range */
                     if (didrange) { /* Something like y/A-C-Z// */
-                        Perl_croak(aTHX_ "Ambiguous range in transliteration"
+                        croak("Ambiguous range in transliteration"
                                          " operator");
                     }
 
@@ -3394,14 +3394,14 @@ S_scan_const(pTHX_ char *start)
                      * ASCII printables; otherwise some visible representation
                      * of them */
                     if (isPRINT_A(range_min) && isPRINT_A(range_max)) {
-                        Perl_croak(aTHX_
+                        croak(
                          "Invalid range \"%c-%c\" in transliteration operator",
                          (char)range_min, (char)range_max);
                     }
 #ifdef EBCDIC
                     else if (convert_unicode) {
         /* diag_listed_as: Invalid range "%s" in transliteration operator */
-                        Perl_croak(aTHX_
+                        croak(
                            "Invalid range \"\\N{U+%04" UVXf "}-\\N{U+%04"
                            UVXf "}\" in transliteration operator",
                            range_min, range_max);
@@ -3409,7 +3409,7 @@ S_scan_const(pTHX_ char *start)
 #endif
                     else {
         /* diag_listed_as: Invalid range "%s" in transliteration operator */
-                        Perl_croak(aTHX_
+                        croak(
                            "Invalid range \"\\x{%04" UVXf "}-\\x{%04" UVXf "}\""
                            " in transliteration operator",
                            range_min, range_max);
@@ -4399,7 +4399,7 @@ S_scan_const(pTHX_ char *start)
 
             if (off > SvLEN(sv))
 #endif
-                Perl_croak(aTHX_ "panic: constant overflowed allocated space,"
+                croak("panic: constant overflowed allocated space,"
                         " %" UVuf " >= %" UVuf, (UV)off, (UV)SvLEN(sv));
 
             /* Whew!  Here we don't have room for the terminating NUL, but
@@ -4875,7 +4875,7 @@ Perl_filter_add(pTHX_ filter_t funcp, SV *datasv)
         return NULL;
 
     if (PL_parser->lex_flags & LEX_IGNORE_UTF8_HINTS)
-        Perl_croak(aTHX_ "Source filters apply only to byte streams");
+        croak("Source filters apply only to byte streams");
 
     if (!PL_rsfp_filters)
         PL_rsfp_filters = newAV();
@@ -5574,7 +5574,7 @@ yyl_sub(pTHX_ char *s, const int key)
         if (key == KEY_my || key == KEY_our || key==KEY_state) {
             *d = '\0';
             /* diag_listed_as: Missing name in "%s sub" */
-            Perl_croak(aTHX_
+            croak(
                       "Missing name in \"%s\"", PL_bufptr);
         }
         PL_expect = XATTRTERM;
@@ -5596,7 +5596,7 @@ yyl_sub(pTHX_ char *s, const int key)
     if (*s == '(' && !is_sigsub) {
         s = scan_str(s,FALSE,FALSE,FALSE,NULL);
         if (!s)
-            Perl_croak(aTHX_ "Prototype not terminated");
+            croak("Prototype not terminated");
         COPLINE_SET_FROM_MULTI_END;
         (void)validate_proto(PL_subname, PL_lex_stuff,
                              ckWARN(WARN_ILLEGALPROTO), 0);
@@ -5617,9 +5617,9 @@ yyl_sub(pTHX_ char *s, const int key)
                key == KEY_my || key == KEY_state ||
                key == KEY_our);
         if (!have_name)
-            Perl_croak(aTHX_ "Illegal declaration of anonymous subroutine");
+            croak("Illegal declaration of anonymous subroutine");
         else if (*s != ';' && *s != '}')
-            Perl_croak(aTHX_ "Illegal declaration of subroutine %" SVf, SVfARG(PL_subname));
+            croak("Illegal declaration of subroutine %" SVf, SVfARG(PL_subname));
     }
 
     if (have_proto) {
@@ -5655,7 +5655,7 @@ yyl_interpcasemod(pTHX_ char *s)
 {
 #ifdef DEBUGGING
     if (PL_bufptr != PL_bufend && *PL_bufptr != '\\')
-        Perl_croak(aTHX_
+        croak(
                    "panic: INTERPCASEMOD bufptr=%p, bufend=%p, *bufptr=%u",
                    PL_bufptr, PL_bufend, *PL_bufptr);
 #endif
@@ -5729,7 +5729,7 @@ yyl_interpcasemod(pTHX_ char *s)
             else if (*s == 'F')
                 NEXTVAL_NEXTTOKE.ival = OP_FC;
             else
-                Perl_croak(aTHX_ "panic: yylex, *s=%u", *s);
+                croak("panic: yylex, *s=%u", *s);
             PL_bufptr = s + 1;
         }
         force_next(FUNC);
@@ -5795,7 +5795,7 @@ yyl_secondclass_keyword(pTHX_ char *s, STRLEN len, int key, I32 *orig_keyword,
     else {			/* no override */
         key = -key;
         if (key == KEY_dump) {
-            Perl_croak(aTHX_ "dump() must be written as CORE::dump() as of Perl 5.30");
+            croak("dump() must be written as CORE::dump() as of Perl 5.30");
         }
         *pgv = NULL;
         *pgvp = 0;
@@ -6121,7 +6121,7 @@ yyl_colon(pTHX_ char *s)
             break;
         PL_bufptr = s;	/* update in case we back off */
         if (*s == '=') {
-            Perl_croak(aTHX_
+            croak(
                        "Use of := for an empty attribute list is not allowed");
         }
         goto grabattrs;
@@ -6168,7 +6168,7 @@ yyl_colon(pTHX_ char *s)
                     op_free(attrs);
                     ASSUME(sv && SvREFCNT(sv) == 1);
                     SvREFCNT_dec(sv);
-                    Perl_croak(aTHX_ "Unterminated attribute parameter in attribute list");
+                    croak("Unterminated attribute parameter in attribute list");
                 }
                 COPLINE_SET_FROM_MULTI_END;
             }
@@ -6222,7 +6222,7 @@ yyl_colon(pTHX_ char *s)
             /* see comment about about sig_seen and parser error
              * handling */
             op_free(attrs);
-            Perl_croak(aTHX_ "Subroutine attributes must come "
+            croak("Subroutine attributes must come "
                              "before the signature");
         }
         if (attrs) {
@@ -7038,7 +7038,7 @@ yyl_croak_unrecognised(pTHX_ char *s)
         d = UTF ? (char *) utf8_hop_back((U8 *) s, -UNRECOGNIZED_PRECEDE_COUNT, (U8 *)d) : s - UNRECOGNIZED_PRECEDE_COUNT;
     }
 
-    Perl_croak(aTHX_  "Unrecognized character %s; marked by <-- HERE after %" UTF8f "<-- HERE near column %d", c,
+    croak("Unrecognized character %s; marked by <-- HERE after %" UTF8f "<-- HERE near column %d", c,
                       UTF8fARG(UTF, (s - d), d),
                      (int) len + 1);
 }
@@ -7129,7 +7129,7 @@ yyl_foreach(pTHX_ char *s)
             }
         }
         if (saw_core && !core_valid) {
-            Perl_croak(aTHX_ "Missing $ on loop variable");
+            croak("Missing $ on loop variable");
         }
 
         if (maybe_package && !saw_core) {
@@ -7147,7 +7147,7 @@ yyl_foreach(pTHX_ char *s)
         }
         else if (UNLIKELY(*p != '$' && *p != '\\')) {
             /* "for myfoo (" will end up here, but with p pointing at the 'f' */
-            Perl_croak(aTHX_ "Missing $ on loop variable");
+            croak("Missing $ on loop variable");
         }
         /* The buffer may have been reallocated, update s */
         s = SvPVX(PL_linestr) + s_off;
@@ -7220,7 +7220,7 @@ yyl_my(pTHX_ char *s, I32 my)
     }
     else if (*s == '\\') {
         if (!FEATURE_MYREF_IS_ENABLED)
-            Perl_croak(aTHX_ "The experimental declared_refs "
+            croak("The experimental declared_refs "
                              "feature is not enabled");
         Perl_ck_warner_d(aTHX_
              packWARN(WARN_EXPERIMENTAL__DECLARED_REFS),
@@ -7474,7 +7474,7 @@ yyl_fake_eof(pTHX_ U32 fake_eof, bool bof, char *s)
                 PERL_FPU_PRE_EXEC
                 PerlProc_execv(ipath, EXEC_ARGV_CAST(newargv));
                 PERL_FPU_POST_EXEC
-                Perl_croak(aTHX_ "Can't exec %s", ipath);
+                croak("Can't exec %s", ipath);
             }
             if (d) {
                 while (*d && !isSPACE(*d))
@@ -7501,7 +7501,7 @@ yyl_fake_eof(pTHX_ U32 fake_eof, bool bof, char *s)
                             const char * const m = d1;
                             while (*d1 && !isSPACE(*d1))
                                 d1++;
-                            Perl_croak(aTHX_ "Too late for \"-%.*s\" option",
+                            croak("Too late for \"-%.*s\" option",
                                   (int)(d1 - m), m);
                         }
                         d1 = moreswitches(d1);
@@ -7685,7 +7685,7 @@ yyl_just_a_word(pTHX_ char *s, STRLEN len, I32 orig_keyword, struct code c)
             no_op_error = FALSE;
         }
         if (!morelen)
-            Perl_croak(aTHX_ "Bad name after %" UTF8f "%s",
+            croak("Bad name after %" UTF8f "%s",
                     UTF8fARG(UTF, len, PL_tokenbuf),
                     *s == '\'' ? "'" : "::");
         len += morelen;
@@ -8881,7 +8881,7 @@ yyl_key_core(pTHX_ char *s, STRLEN len, struct code c)
         return yyl_just_a_word(aTHX_ d, olen, 0, c);
     }
     if (!key)
-        Perl_croak(aTHX_ "CORE::%" UTF8f " is not a keyword",
+        croak("CORE::%" UTF8f " is not a keyword",
                           UTF8fARG(UTF, len, PL_tokenbuf));
     if (key < 0)
         key = -key;
@@ -8995,7 +8995,7 @@ yyl_keylookup(pTHX_ char *s, GV *gv)
             if (!PL_nexttoke) PL_expect = XOPERATOR;
             return REPORT(PLUGEXPR);
         } else {
-            Perl_croak(aTHX_ "Bad plugin affecting keyword '%s'", PL_tokenbuf);
+            croak("Bad plugin affecting keyword '%s'", PL_tokenbuf);
         }
     }
 
@@ -9006,7 +9006,7 @@ yyl_keylookup(pTHX_ char *s, GV *gv)
         result = PL_infix_plugin(aTHX_ PL_tokenbuf, len, &def);
         if(result) {
             if(result != len)
-                Perl_croak(aTHX_ "Bad infix plugin result (%zd) - did not consume entire identifier <%s>\n",
+                croak("Bad infix plugin result (%zd) - did not consume entire identifier <%s>\n",
                     result, PL_tokenbuf);
             PL_bufptr = s = d;
             struct Perl_custom_infix_result *result;
@@ -9780,7 +9780,7 @@ Perl_yylex(pTHX)
             && SvEVALED(PL_lex_repl))
         {
             if (PL_bufptr != PL_bufend)
-                Perl_croak(aTHX_ "Bad evalled substitution pattern");
+                croak("Bad evalled substitution pattern");
             PL_lex_repl = NULL;
         }
         /* Paranoia.  re_eval_start is adjusted when S_scan_heredoc sets
@@ -9791,7 +9791,7 @@ Perl_yylex(pTHX)
          || PL_parser->lex_shared->re_eval_str) {
             SV *sv;
             if (*PL_bufptr != ')')
-                Perl_croak(aTHX_ "Sequence (?{...}) not terminated with ')'");
+                croak("Sequence (?{...}) not terminated with ')'");
             PL_bufptr++;
             /* having compiled a (?{..}) expression, return the original
              * text too, as a const */
@@ -9817,7 +9817,7 @@ Perl_yylex(pTHX)
     case LEX_INTERPCONCAT:
 #ifdef DEBUGGING
         if (PL_lex_brackets)
-            Perl_croak(aTHX_ "panic: INTERPCONCAT, lex_brackets=%ld",
+            croak("panic: INTERPCONCAT, lex_brackets=%ld",
                        (long) PL_lex_brackets);
 #endif
         if (PL_bufptr == PL_bufend)
@@ -10145,7 +10145,7 @@ S_checkcomma(pTHX_ const char *s, const char *name, const char *what)
                 off = pad_findmy_pvn(tmpbuf, s-w+1, 0);
                 if (off != NOT_IN_PAD) return;
             }
-            Perl_croak(aTHX_ "No comma allowed after %s", what);
+            croak("No comma allowed after %s", what);
         }
     }
 }
@@ -10277,7 +10277,7 @@ S_parse_ident(pTHX_ char **s, char **d, char * const e, int allow_package,
 
     while (*s < PL_bufend) {
         if (*d >= e)
-            Perl_croak(aTHX_ "%s", ident_too_long);
+            croak("%s", ident_too_long);
         if (is_utf8 && isIDFIRST_utf8_safe(*s, PL_bufend)) {
              /* The UTF-8 case must come first, otherwise things
              * like c\N{COMBINING TILDE} would start failing, as the
@@ -10289,7 +10289,7 @@ S_parse_ident(pTHX_ char **s, char **d, char * const e, int allow_package,
                 t += UTF8SKIP(t);
             }
             if (*d + (t - *s) > e)
-                Perl_croak(aTHX_ "%s", ident_too_long);
+                croak("%s", ident_too_long);
             Copy(*s, *d, t - *s, char);
             *d += t - *s;
             *s = t;
@@ -10366,11 +10366,11 @@ S_scan_ident(pTHX_ char *s, char *dest, STRLEN destlen, I32 ck_uni)
         *d++ = *s++;
         while (s < PL_bufend && isDIGIT(*s)) {
             if (d >= e)
-                Perl_croak(aTHX_ "%s", ident_too_long);
+                croak("%s", ident_too_long);
             *d++ = *s++;
         }
         if (is_zero && d - digit_start > 1)
-            Perl_croak(aTHX_ ident_var_zero_multi_digit);
+            croak(ident_var_zero_multi_digit);
     }
     else {  /* See if it is a "normal" identifier */
         parse_ident(&s, &d, e, 1, is_utf8, FALSE);
@@ -10463,11 +10463,11 @@ S_scan_ident(pTHX_ char *s, char *dest, STRLEN destlen, I32 ck_uni)
         while (s < PL_bufend && isDIGIT(*s)) {
             d++;
             if (d >= e)
-                Perl_croak(aTHX_ "%s", ident_too_long);
+                croak("%s", ident_too_long);
             *d= *s++;
         }
         if (is_zero && d - digit_start >= 1) /* d points at the last digit */
-            Perl_croak(aTHX_ ident_var_zero_multi_digit);
+            croak(ident_var_zero_multi_digit);
         d[1] = '\0';
     }
 
@@ -10507,7 +10507,7 @@ S_scan_ident(pTHX_ char *s, char *dest, STRLEN destlen, I32 ck_uni)
                     *d++ = *s++;
                 }
                 if (d >= e)
-                    Perl_croak(aTHX_ "%s", ident_too_long);
+                    croak("%s", ident_too_long);
                 *d = '\0';
             }
             tmp_copline = CopLINE(PL_curcop);
@@ -10706,7 +10706,7 @@ S_scan_pat(pTHX_ char *start, I32 type)
 
     s = scan_str(start,TRUE,FALSE, (PL_in_eval & EVAL_RE_REPARSING), NULL);
     if (!s)
-        Perl_croak(aTHX_ "Search pattern not terminated");
+        croak("Search pattern not terminated");
 
     pm = (PMOP*)newPMOP(type, 0);
     if (PL_multi_open == '?') {
@@ -10788,7 +10788,7 @@ S_scan_subst(pTHX_ char *start)
     s = scan_str(start, TRUE, FALSE, FALSE, &t);
 
     if (!s)
-        Perl_croak(aTHX_ "Substitution pattern not terminated");
+        croak("Substitution pattern not terminated");
 
     s = t;
 
@@ -10798,7 +10798,7 @@ S_scan_subst(pTHX_ char *start)
     if (!s) {
         SvREFCNT_dec_NN(PL_lex_stuff);
         PL_lex_stuff = NULL;
-        Perl_croak(aTHX_ "Substitution replacement not terminated");
+        croak("Substitution replacement not terminated");
     }
     PL_multi_start = first_start;	/* so whole substitution is taken together */
 
@@ -10873,7 +10873,7 @@ S_scan_trans(pTHX_ char *start)
 
     s = scan_str(start,FALSE,FALSE,FALSE,&t);
     if (!s)
-        Perl_croak(aTHX_ "Transliteration pattern not terminated");
+        croak("Transliteration pattern not terminated");
 
     s = t;
 
@@ -10881,7 +10881,7 @@ S_scan_trans(pTHX_ char *start)
     if (!s) {
         SvREFCNT_dec_NN(PL_lex_stuff);
         PL_lex_stuff = NULL;
-        Perl_croak(aTHX_ "Transliteration replacement not terminated");
+        croak("Transliteration replacement not terminated");
     }
 
     complement = del = squash = 0;
@@ -10979,7 +10979,7 @@ S_scan_heredoc(pTHX_ char *s)
         term = *s++;
         s = delimcpy(d, e, s, PL_bufend, term, &len);
         if (s == PL_bufend)
-            Perl_croak(aTHX_ "Unterminated delimiter for here document");
+            croak("Unterminated delimiter for here document");
         d += len;
         s++;
     }
@@ -10991,7 +10991,7 @@ S_scan_heredoc(pTHX_ char *s)
             term = '"';
 
         if (! isWORDCHAR_lazy_if_safe(s, PL_bufend, UTF))
-            Perl_croak(aTHX_ "Use of bare << to mean <<\"\" is forbidden");
+            croak("Use of bare << to mean <<\"\" is forbidden");
 
         peek = s;
 
@@ -11006,7 +11006,7 @@ S_scan_heredoc(pTHX_ char *s)
     }
 
     if (d >= PL_tokenbuf + sizeof PL_tokenbuf - 1)
-        Perl_croak(aTHX_ "Delimiter for here document is too long");
+        croak("Delimiter for here document is too long");
 
     *d++ = '\n';
     *d = '\0';
@@ -11343,7 +11343,7 @@ S_scan_heredoc(pTHX_ char *s)
             }
             else {
                 Safefree(indent);
-                Perl_croak(aTHX_
+                croak(
                     "Indentation on line %d of here-doc doesn't match delimiter",
                     (int)linecount
                 );
@@ -11425,9 +11425,9 @@ S_scan_inputsymbol(pTHX_ char *start)
     */
 
     if (len >= (I32)sizeof PL_tokenbuf)
-        Perl_croak(aTHX_ "Excessively long <> operator");
+        croak("Excessively long <> operator");
     if (s >= end)
-        Perl_croak(aTHX_ "Unterminated <> operator");
+        croak("Unterminated <> operator");
 
     s++;
 
@@ -11456,7 +11456,7 @@ S_scan_inputsymbol(pTHX_ char *start)
         pl_yylval.ival = OP_GLOB;
         s = scan_str(start,FALSE,FALSE,FALSE,NULL);
         if (!s)
-           Perl_croak(aTHX_ "Glob not terminated");
+           croak("Glob not terminated");
         return s;
     }
     else {
@@ -11983,7 +11983,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 
     switch (*s) {
     default:
-        Perl_croak(aTHX_ "panic: scan_num, *s=%d", *s);
+        croak("panic: scan_num, *s=%d", *s);
 
     /* if it starts with a 0, it could be an octal number, a decimal in
        0.13 disguise, or a hexadecimal number, or a binary number. */
@@ -12400,7 +12400,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
             else {
                 /* check for end of fixed-length buffer */
                 if (d >= e)
-                    Perl_croak(aTHX_ "%s", number_too_long);
+                    croak("%s", number_too_long);
                 /* if we're ok, copy the character */
                 *d++ = *s++;
             }
@@ -12432,7 +12432,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
             {
                 /* fixed length buffer check */
                 if (d >= e)
-                    Perl_croak(aTHX_ "%s", number_too_long);
+                    croak("%s", number_too_long);
                 if (*s == '_') {
                    if (lastub && s == lastub + 1)
                         WARN_ABOUT_UNDERSCORE();
@@ -12494,7 +12494,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
                 if (isDIGIT(*s)) {
                     ++exp_digits;
                     if (d >= e)
-                        Perl_croak(aTHX_ "%s", number_too_long);
+                        croak("%s", number_too_long);
                     *d++ = *s++;
                 }
                 else {
@@ -12870,16 +12870,16 @@ Perl_abort_execution(pTHX_ SV* msg_sv, const char * const name)
 
     if (msg_sv) {
         if (PL_minus_c)
-            Perl_croak(aTHX_ "%" SVf "%s had compilation errors.\n", SVfARG(msg_sv), name);
+            croak("%" SVf "%s had compilation errors.\n", SVfARG(msg_sv), name);
         else {
-            Perl_croak(aTHX_
+            croak(
                     "%" SVf "Execution of %s aborted due to compilation errors.\n", SVfARG(msg_sv), name);
         }
     } else {
         if (PL_minus_c)
-            Perl_croak(aTHX_ "%s had compilation errors.\n", name);
+            croak("%s had compilation errors.\n", name);
         else {
-            Perl_croak(aTHX_
+            croak(
                     "Execution of %s aborted due to compilation errors.\n", name);
         }
     }
@@ -13022,7 +13022,7 @@ S_swallow_bom(pTHX_ U8 *s)
             /* UTF-16 little-endian? (or UTF-32LE?) */
             if (s[2] == 0 && s[3] == 0)  /* UTF-32 little-endian */
                 /* diag_listed_as: Unsupported script encoding %s */
-                Perl_croak(aTHX_ "Unsupported script encoding UTF-32LE");
+                croak("Unsupported script encoding UTF-32LE");
 #ifndef PERL_NO_UTF16_FILTER
 #ifdef DEBUGGING
             if (DEBUG_p_TEST || DEBUG_T_TEST) PerlIO_printf(Perl_debug_log, "UTF-16LE script encoding (BOM)\n");
@@ -13033,7 +13033,7 @@ S_swallow_bom(pTHX_ U8 *s)
             }
 #else
             /* diag_listed_as: Unsupported script encoding %s */
-            Perl_croak(aTHX_ "Unsupported script encoding UTF-16LE");
+            croak("Unsupported script encoding UTF-16LE");
 #endif
         }
         break;
@@ -13049,7 +13049,7 @@ S_swallow_bom(pTHX_ U8 *s)
             }
 #else
             /* diag_listed_as: Unsupported script encoding %s */
-            Perl_croak(aTHX_ "Unsupported script encoding UTF-16BE");
+            croak("Unsupported script encoding UTF-16BE");
 #endif
         }
         break;
@@ -13068,7 +13068,7 @@ S_swallow_bom(pTHX_ U8 *s)
                   if (s[2] == 0xFE && s[3] == 0xFF) {
                        /* UTF-32 big-endian */
                        /* diag_listed_as: Unsupported script encoding %s */
-                       Perl_croak(aTHX_ "Unsupported script encoding UTF-32BE");
+                       croak("Unsupported script encoding UTF-32BE");
                   }
              }
              else if (s[2] == 0 && s[3] != 0) {
@@ -13082,7 +13082,7 @@ S_swallow_bom(pTHX_ U8 *s)
                   s = add_utf16_textfilter(s, FALSE);
 #else
                   /* diag_listed_as: Unsupported script encoding %s */
-                  Perl_croak(aTHX_ "Unsupported script encoding UTF-16BE");
+                  croak("Unsupported script encoding UTF-16BE");
 #endif
              }
         }
@@ -13100,7 +13100,7 @@ S_swallow_bom(pTHX_ U8 *s)
               s = add_utf16_textfilter(s, TRUE);
 #else
               /* diag_listed_as: Unsupported script encoding %s */
-              Perl_croak(aTHX_ "Unsupported script encoding UTF-16LE");
+              croak("Unsupported script encoding UTF-16LE");
 #endif
          }
     }
@@ -13132,10 +13132,10 @@ S_utf16_textfilter(pTHX_ int idx, SV *sv, int maxlen)
        from this file, we can be sure that we're not called in block mode. Hence
        don't bother writing code to deal with block mode.  */
     if (maxlen) {
-        Perl_croak(aTHX_ "panic: utf16_textfilter called in block mode (for %d characters)", maxlen);
+        croak("panic: utf16_textfilter called in block mode (for %d characters)", maxlen);
     }
     if (status < 0) {
-        Perl_croak(aTHX_ "panic: utf16_textfilter called after error (status=%" IVdf ")", status);
+        croak("panic: utf16_textfilter called after error (status=%" IVdf ")", status);
     }
     DEBUG_P(PerlIO_printf(Perl_debug_log,
                           "utf16_textfilter(%p,%ce): idx=%d maxlen=%d status=%" IVdf " utf16=%" UVuf " utf8=%" UVuf "\n",
@@ -13531,7 +13531,7 @@ S_parse_expr(pTHX_ I32 fakeeof, U32 flags)
 {
     OP *exprop;
     if (flags & ~PARSE_OPTIONAL)
-        Perl_croak(aTHX_ "Parsing code internal error (%s)", "parse_expr");
+        croak("Parsing code internal error (%s)", "parse_expr");
     exprop = parse_recdescent_for_op(GRAMEXPR, fakeeof);
     if (!exprop && !(flags & PARSE_OPTIONAL)) {
         if (!PL_parser->error_count)
@@ -13705,7 +13705,7 @@ OP *
 Perl_parse_block(pTHX_ U32 flags)
 {
     if (flags)
-        Perl_croak(aTHX_ "Parsing code internal error (%s)", "parse_block");
+        croak("Parsing code internal error (%s)", "parse_block");
     return parse_recdescent_for_op(GRAMBLOCK, LEX_FAKEEOF_NEVER);
 }
 
@@ -13743,7 +13743,7 @@ OP *
 Perl_parse_barestmt(pTHX_ U32 flags)
 {
     if (flags)
-        Perl_croak(aTHX_ "Parsing code internal error (%s)", "parse_barestmt");
+        croak("Parsing code internal error (%s)", "parse_barestmt");
     return parse_recdescent_for_op(GRAMBARESTMT, LEX_FAKEEOF_NEVER);
 }
 
@@ -13771,7 +13771,7 @@ SV *
 Perl_parse_label(pTHX_ U32 flags)
 {
     if (flags & ~PARSE_OPTIONAL)
-        Perl_croak(aTHX_ "Parsing code internal error (%s)", "parse_label");
+        croak("Parsing code internal error (%s)", "parse_label");
     if (PL_nexttoke) {
         PL_parser->yychar = yylex();
         if (PL_parser->yychar == LABEL) {
@@ -13848,7 +13848,7 @@ OP *
 Perl_parse_fullstmt(pTHX_ U32 flags)
 {
     if (flags)
-        Perl_croak(aTHX_ "Parsing code internal error (%s)", "parse_fullstmt");
+        croak("Parsing code internal error (%s)", "parse_fullstmt");
     return parse_recdescent_for_op(GRAMFULLSTMT, LEX_FAKEEOF_NEVER);
 }
 
@@ -13888,7 +13888,7 @@ Perl_parse_stmtseq(pTHX_ U32 flags)
     OP *stmtseqop;
     I32 c;
     if (flags)
-        Perl_croak(aTHX_ "Parsing code internal error (%s)", "parse_stmtseq");
+        croak("Parsing code internal error (%s)", "parse_stmtseq");
     stmtseqop = parse_recdescent_for_op(GRAMSTMTSEQ, LEX_FAKEEOF_CLOSING);
     c = lex_peek_unichar(0);
     if (c != -1 && c != /*{*/'}')
@@ -13924,7 +13924,7 @@ OP *
 Perl_parse_subsignature(pTHX_ U32 flags)
 {
     if (flags)
-        Perl_croak(aTHX_ "Parsing code internal error (%s)", "parse_subsignature");
+        croak("Parsing code internal error (%s)", "parse_subsignature");
     return parse_recdescent_for_op(GRAMSUBSIGNATURE, LEX_FAKEEOF_NONEXPR);
 }
 

--- a/toke.c
+++ b/toke.c
@@ -809,7 +809,7 @@ S_yyerror_non_ascii_message(pTHX_ const U8 * const s)
 {
     PERL_ARGS_ASSERT_YYERROR_NON_ASCII_MESSAGE;
 
-    yyerror_pv(Perl_form(aTHX_ "Use of non-ASCII character 0x%02X"
+    yyerror_pv(form("Use of non-ASCII character 0x%02X"
                                " illegal when 'use source::encoding"
                                " \"ascii\"' is in effect", *s), 0);
 }
@@ -2888,7 +2888,7 @@ Perl_get_and_check_backslash_N_name(pTHX_ const char* s,
     if (!SvCUR(char_name)) {
         SvREFCNT_dec_NN(char_name);
         /* diag_listed_as: Unknown charname '%s' */
-        *error_msg = Perl_form(aTHX_ "Unknown charname ''");
+        *error_msg = form("Unknown charname ''");
         return NULL;
     }
 
@@ -2903,7 +2903,7 @@ Perl_get_and_check_backslash_N_name(pTHX_ const char* s,
     res = new_constant( NULL, 0, "charnames", char_name, NULL,
                         context, context_len, error_msg);
     if (*error_msg) {
-        *error_msg = Perl_form(aTHX_ "Unknown charname '%s'", SvPVX(char_name));
+        *error_msg = form("Unknown charname '%s'", SvPVX(char_name));
 
         SvREFCNT_dec(res);
         return NULL;
@@ -3005,7 +3005,7 @@ Perl_get_and_check_backslash_N_name(pTHX_ const char* s,
         /* diag_listed_as: charnames alias definitions may not contain
                            trailing white-space; marked by <-- HERE in %s
          */
-        *error_msg = Perl_form(aTHX_
+        *error_msg = form(
             "charnames alias definitions may not contain trailing "
             "white-space; marked by <-- HERE in %.*s<-- HERE %.*s",
             (int)(s - context + 1), context,
@@ -3026,7 +3026,7 @@ Perl_get_and_check_backslash_N_name(pTHX_ const char* s,
                                               MALFORMED_UTF8_WARN);
             /* diag_listed_as: Malformed UTF-8 returned by \N{%s}
                                immediately after '%s' */
-            *error_msg = Perl_form(aTHX_
+            *error_msg = form(
                 "Malformed UTF-8 returned by %.*s immediately after '%.*s'",
                  (int) context_len, context,
                  (int) ((char *) first_bad_char_loc - str), str);
@@ -3042,7 +3042,7 @@ Perl_get_and_check_backslash_N_name(pTHX_ const char* s,
          * that this print won't run off the end of the string */
         /* diag_listed_as: Invalid character in \N{...}; marked by <-- HERE
                            in \N{%s} */
-        *error_msg = Perl_form(aTHX_
+        *error_msg = form(
             "Invalid character in \\N{...}; marked by <-- HERE in %.*s<-- HERE %.*s",
             (int)(s - context + 1), context,
             (int)(e - s + 1), s + 1);
@@ -3053,7 +3053,7 @@ Perl_get_and_check_backslash_N_name(pTHX_ const char* s,
         /* diag_listed_as: charnames alias definitions may not contain a
                            sequence of multiple spaces; marked by <-- HERE
                            in %s */
-        *error_msg = Perl_form(aTHX_
+        *error_msg = form(
             "charnames alias definitions may not contain a sequence of "
             "multiple spaces; marked by <-- HERE in %.*s<-- HERE %.*s",
             (int)(s - context + 1), context,
@@ -4210,7 +4210,7 @@ S_scan_const(pTHX_ char *start)
                                        ? UTF8SKIP(str)
                                        : 1U))
                             {
-                                yyerror(Perl_form(aTHX_
+                                yyerror(form(
                                     "%.*s must not be a named sequence"
                                     " in transliteration operator",
                                         /*  +1 to include the "}" */
@@ -5140,7 +5140,7 @@ S_tokenize_use(pTHX_ int is_use, char *s) {
 
     if (PL_expect != XSTATE)
         /* diag_listed_as: "use" not allowed in expression */
-        yyerror(Perl_form(aTHX_ "\"%s\" not allowed in expression",
+        yyerror(form("\"%s\" not allowed in expression",
                     is_use ? "use" : "no"));
     PL_expect = XTERM;
     s = skipspace(s);
@@ -6210,7 +6210,7 @@ yyl_colon(pTHX_ char *s)
             PL_bufptr = s;
             yyerror( (const char *)
                      (*s
-                      ? Perl_form(aTHX_ "Invalid separator character "
+                      ? form("Invalid separator character "
                                   "%c%c%c in attribute list", q, *s, q)
                       : "Unterminated attribute list" ) );
             op_free(attrs);
@@ -7019,7 +7019,7 @@ yyl_croak_unrecognised(pTHX_ char *s)
                            10, UNI_DISPLAY_ISPRINT);
     }
     else {
-        c = Perl_form(aTHX_ "\\x%02X", (unsigned char)*s);
+        c = form("\\x%02X", (unsigned char)*s);
     }
 
     if (s >= PL_linestart) {
@@ -7190,7 +7190,7 @@ yyl_my(pTHX_ char *s, I32 my)
 {
     if (PL_in_my) {
         PL_bufptr = s;
-        yyerror(Perl_form(aTHX_
+        yyerror(form(
                           "Can't redeclare \"%s\" in \"%s\"",
                            my       == KEY_my    ? "my" :
                            my       == KEY_state ? "state" : "our",
@@ -9966,7 +9966,7 @@ S_pending_ident(pTHX)
             if (has_colon)
                 /* diag_listed_as: No package name allowed for variable %s
                                    in "our" */
-                yyerror_pv(Perl_form(aTHX_ "No package name allowed for "
+                yyerror_pv(form("No package name allowed for "
                                   "%s %s in \"our\"",
                                   *PL_tokenbuf=='&' ? "subroutine" : "variable",
                                   PL_tokenbuf), UTF ? SVf_UTF8 : 0);
@@ -9978,7 +9978,7 @@ S_pending_ident(pTHX)
                 /* "my" variable %s can't be in a package */
                 /* PL_no_myglob is constant */
                 GCC_DIAG_IGNORE_STMT(-Wformat-nonliteral);
-                yyerror_pv(Perl_form(aTHX_ PL_no_myglob,
+                yyerror_pv(form(PL_no_myglob,
                             PL_in_my == KEY_my ? "my" :
                             PL_in_my == KEY_field ? "field" : "state",
                             *PL_tokenbuf == '&' ? "subroutine" : "variable",
@@ -10255,7 +10255,7 @@ S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen,
 
   report:
 
-    msg = Perl_form(aTHX_ "Constant(%.*s)%s %s%s%s",
+    msg = form("Constant(%.*s)%s %s%s%s",
                         (int)(type ? typelen : len),
                         (type ? type: s),
                         optional_colon,
@@ -10613,7 +10613,7 @@ S_pmflag(pTHX_ const char* const valid_flags, U32 * pmfl, char** s, char* charse
 
     if ( charlen != 1 || ! strchr(valid_flags, c) ) {
         if (isWORDCHAR_lazy_if_safe( *s, PL_bufend, UTF)) {
-            yyerror_pv(Perl_form(aTHX_ "Unknown regexp modifier \"/%.*s\"", (int)charlen, *s),
+            yyerror_pv(form("Unknown regexp modifier \"/%.*s\"", (int)charlen, *s),
                        UTF ? SVf_UTF8 : 0);
             (*s) += charlen;
             /* Pretend that it worked, so will continue processing before
@@ -10677,14 +10677,14 @@ S_pmflag(pTHX_ const char* const valid_flags, U32 * pmfl, char** s, char* charse
 
     multiple_charsets:
         if (*charset != c) {
-            yyerror(Perl_form(aTHX_ "Regexp modifiers \"/%c\" and \"/%c\" are mutually exclusive", *charset, c));
+            yyerror(form("Regexp modifiers \"/%c\" and \"/%c\" are mutually exclusive", *charset, c));
         }
         else if (c == 'a') {
   /* diag_listed_as: Regexp modifier "/%c" may appear a maximum of twice */
             yyerror("Regexp modifier \"/a\" may appear a maximum of twice");
         }
         else {
-            yyerror(Perl_form(aTHX_ "Regexp modifier \"/%c\" may not appear twice", c));
+            yyerror(form("Regexp modifier \"/%c\" may not appear twice", c));
         }
 
         /* Pretend that it worked, so will continue processing before dieing */
@@ -12065,14 +12065,14 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
                 /* 8 and 9 are not octal */
                 case '8': case '9':
                     if (shift == 3)
-                        yyerror(Perl_form(aTHX_ "Illegal octal digit '%c'", *s));
+                        yyerror(form("Illegal octal digit '%c'", *s));
                     /* FALLTHROUGH */
 
                 /* octal digits */
                 case '2': case '3': case '4':
                 case '5': case '6': case '7':
                     if (shift == 1)
-                        yyerror(Perl_form(aTHX_ "Illegal binary digit '%c'", *s));
+                        yyerror(form("Illegal binary digit '%c'", *s));
                     /* FALLTHROUGH */
 
                 case '0': case '1':
@@ -12317,7 +12317,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
                 char *oldbp = PL_bufptr;
                 if (*d) ++d; /* so the user sees the bad non-digit */
                 PL_bufptr = (char *)d; /* so yyerror reports the context */
-                yyerror(Perl_form(aTHX_ "No digits found for %s literal",
+                yyerror(form("No digits found for %s literal",
                                   bases[shift]));
                 PL_bufptr = oldbp;
             }

--- a/universal.c
+++ b/universal.c
@@ -385,7 +385,7 @@ works out the package name and subroutine name from C<cv>, and then calls
 C<croak()>.  Hence if C<cv> is C<&ouch::awk>, it would call C<croak> as:
 
  diag_listed_as: SKIPME
- Perl_croak(aTHX_ "Usage: %" SVf "::%" SVf "(%s)", "ouch" "awk",
+ croak("Usage: %" SVf "::%" SVf "(%s)", "ouch" "awk",
                                                      "eee_yow");
 
 =cut
@@ -418,7 +418,7 @@ Perl_croak_xs_usage(const CV *const cv, const char *const params)
 
         /* Pants. I don't think that it should be possible to get here. */
         /* diag_listed_as: SKIPME */
-        Perl_croak(aTHX_ "Usage: CODE(0x%" UVxf ")(%s)", PTR2UV(cv), params);
+        croak("Usage: CODE(0x%" UVxf ")(%s)", PTR2UV(cv), params);
     }
 }
 
@@ -451,7 +451,7 @@ XS(XS_UNIVERSAL_import_unimport)
     if (items > 1) {
         char *class_pv= SvPV_nolen(ST(0));
         if (strEQ(class_pv,"UNIVERSAL"))
-            Perl_croak(aTHX_ "UNIVERSAL does not export anything");
+            croak("UNIVERSAL does not export anything");
         /* _charnames is special - ignore it for now as the code that
          * depends on it has its own "no import" logic that produces better
          * warnings than this does. */
@@ -528,7 +528,7 @@ XS(XS_UNIVERSAL_DOES)
     PERL_UNUSED_ARG(cv);
 
     if (items != 2)
-        Perl_croak(aTHX_ "Usage: invocant->DOES(kind)");
+        croak("Usage: invocant->DOES(kind)");
     else {
         SV * const sv = ST(0);
         if (sv_does_sv( sv, ST(1), 0 ))
@@ -826,7 +826,7 @@ XS(XS_PerlIO_get_layers)
                        goto fail;
                   default:
                   fail:
-                       Perl_croak(aTHX_
+                       croak(
                                   "get_layers: unknown argument '%s'",
                                   key);
                   }
@@ -1024,7 +1024,7 @@ XS(XS_re_regnames)
         
         if (!entry)
             /* diag_listed_as: SKIPME */
-            Perl_croak(aTHX_ "NULL array element in re::regnames()");
+            croak("NULL array element in re::regnames()");
 
         mPUSHs(SvREFCNT_inc_simple_NN(*entry));
     }

--- a/universal.c
+++ b/universal.c
@@ -1230,7 +1230,7 @@ XS(XS_NamedCapture_FETCH)
 
         if (!rx || !SvROK(ST(0))) {
             if (ix & UNDEF_FATAL)
-                Perl_croak_no_modify();
+                croak_no_modify();
             else
                 XSRETURN_UNDEF;
         }

--- a/universal.c
+++ b/universal.c
@@ -418,7 +418,7 @@ Perl_croak_xs_usage(const CV *const cv, const char *const params)
 
         /* Pants. I don't think that it should be possible to get here. */
         /* diag_listed_as: SKIPME */
-        croak("Usage: CODE(0x%" UVxf ")(%s)", PTR2UV(cv), params);
+        Perl_croak_nocontext("Usage: CODE(0x%" UVxf ")(%s)", PTR2UV(cv), params);
     }
 }
 

--- a/utf8.c
+++ b/utf8.c
@@ -4847,7 +4847,7 @@ Perl_pv_uni_display(pTHX_ SV *dsv, const U8 *spv, STRLEN len, STRLEN pvlim,
             }
         }
         if (!ok)
-            Perl_sv_catpvf(aTHX_ dsv, "\\x{%" UVxf "}", u);
+            sv_catpvf(dsv, "\\x{%" UVxf "}", u);
     }
     if (truncated)
          sv_catpvs(dsv, "...");

--- a/utf8.c
+++ b/utf8.c
@@ -240,7 +240,7 @@ Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, UV flags, HV** msgs)
             U32 category = packWARN2(WARN_NON_UNICODE, WARN_PORTABLE);
             const char * format = PL_extended_cp_format;
             if (msgs) {
-                *msgs = new_msg_hv(Perl_form(aTHX_ format, input_uv),
+                *msgs = new_msg_hv(form(format, input_uv),
                                    category,
                                    (flags & UNICODE_WARN_PERL_EXTENDED)
                                    ? UNICODE_GOT_PERL_EXTENDED
@@ -285,7 +285,7 @@ Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, UV flags, HV** msgs)
                 const char * format = super_cp_format;
 
                 if (msgs) {
-                    *msgs = new_msg_hv(Perl_form(aTHX_ format, input_uv),
+                    *msgs = new_msg_hv(form(format, input_uv),
                                        category,
                                        UNICODE_GOT_SUPER);
                 }
@@ -317,7 +317,7 @@ Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, UV flags, HV** msgs)
                     U32 category = packWARN(WARN_NONCHAR);
                     const char * format = nonchar_cp_format;
                     if (msgs) {
-                        *msgs = new_msg_hv(Perl_form(aTHX_ format, input_uv),
+                        *msgs = new_msg_hv(form(format, input_uv),
                                            category,
                                            UNICODE_GOT_NONCHAR);
                     }
@@ -334,7 +334,7 @@ Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, UV flags, HV** msgs)
                     U32 category = packWARN(WARN_SURROGATE);
                     const char * format = surrogate_cp_format;
                     if (msgs) {
-                        *msgs = new_msg_hv(Perl_form(aTHX_ format, input_uv),
+                        *msgs = new_msg_hv(form(format, input_uv),
                                            category,
                                            UNICODE_GOT_SURROGATE);
                     }
@@ -985,7 +985,7 @@ S_unexpected_non_continuation_text(pTHX_ const U8 * const s,
 
     const char * const where = (non_cont_byte_pos == 1)
                                ? "immediately"
-                               : Perl_form(aTHX_ "%d bytes",
+                               : form("%d bytes",
                                                  (int) non_cont_byte_pos);
     const U8 * x = s + non_cont_byte_pos;
     const U8 * e = s + print_len;
@@ -1006,7 +1006,7 @@ S_unexpected_non_continuation_text(pTHX_ const U8 * const s,
         }
     }
 
-    return Perl_form(aTHX_ "%s: %s (unexpected non-continuation byte 0x%02x,"
+    return form("%s: %s (unexpected non-continuation byte 0x%02x,"
                            " %s after start byte 0x%02x; need %d bytes, got %d)",
                            malformed_text,
                            _byte_dump_string(s, x - s, 0),
@@ -2269,7 +2269,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
 
               case UTF8_GOT_CONTINUATION:
                 COMMON_DEFAULT_REJECTS(,);
-                message = Perl_form(aTHX_
+                message = form(
                                 "%s: %s (unexpected continuation byte 0x%02x,"
                                 " with no preceding start byte)",
                                 malformed_text,
@@ -2279,7 +2279,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
 
               case UTF8_GOT_SHORT:
                 COMMON_DEFAULT_REJECTS(,);
-                message = Perl_form(aTHX_
+                message = form(
                              "%s: %s (too short; %d byte%s available, need %d)",
                              malformed_text,
                              _byte_dump_string(s0, avail_len, 0),
@@ -2298,7 +2298,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
                 int printlen = (flags & UTF8_NO_CONFIDENCE_IN_CURLEN_)
                                 ? (int) (s - s0)
                                 : (int) (avail_len);
-                message = Perl_form(aTHX_ "%s",
+                message = form("%s",
                                     unexpected_non_continuation_text(s0,
                                                             printlen,
                                                             s - s0,
@@ -2407,8 +2407,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
                                              |UTF8_GOT_LONG_WITH_VALUE
                                              |UTF8_GOT_PERL_EXTENDED
                                              |UTF8_GOT_NONCHAR)));
-                message = Perl_form(aTHX_ nonchar_cp_format, input_uv);
-
+                message = form(nonchar_cp_format, input_uv);
                 break;
 
                 /* The final three cases are all closely related.  They are
@@ -3911,7 +3910,7 @@ S_warn_on_first_deprecated_use(pTHX_ U32 category,
 
     if (ckWARN_d(category)) {
 
-        key = Perl_form(aTHX_ "%s;%d;%s;%d", name, use_locale, file, line);
+        key = form("%s;%d;%s;%d", name, use_locale, file, line);
         if (! hv_fetch(PL_seen_deprecated_macro, key, strlen(key), 0)) {
             if (! PL_seen_deprecated_macro) {
                 PL_seen_deprecated_macro = newHV();

--- a/utf8.c
+++ b/utf8.c
@@ -77,8 +77,8 @@ Perl_force_out_malformed_utf8_message_(pTHX_
     (void) utf8_to_uv_errors(p, e, &dummy, NULL, flags, &errors);
 
     if (! errors) {
-        Perl_croak(aTHX_ "panic: force_out_malformed_utf8_message_ should"
-                         " be called only when there are errors found");
+        croak("panic: force_out_malformed_utf8_message_ should"
+                  " be called only when there are errors found");
     }
 }
 
@@ -232,7 +232,7 @@ Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, UV flags, HV** msgs)
         if (   UNLIKELY(input_uv > MAX_LEGAL_CP
             && UNLIKELY(! (flags & UNICODE_ALLOW_ABOVE_IV_MAX))))
         {
-            Perl_croak(aTHX_ "%s", form_cp_too_large_msg(16, /* Hex output */
+            croak("%s", form_cp_too_large_msg(16, /* Hex output */
                                                          NULL, 0, input_uv));
         }
 
@@ -2240,7 +2240,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
 
             switch (this_problem) {
               default:
-                Perl_croak(aTHX_ "panic: Unexpected case value in "
+                croak("panic: Unexpected case value in "
                                  " utf8n_to_uvchr_msgs() %" U32uf,
                            this_problem);
                 /* NOTREACHED */
@@ -2585,7 +2585,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
 
         if (disallowed) {
             if ((flags & ~UTF8_CHECK_ONLY) & UTF8_DIE_IF_MALFORMED) {
-                Perl_croak(aTHX_ "Malformed UTF-8 character (fatal)");
+                croak("Malformed UTF-8 character (fatal)");
             }
 
             success = false;
@@ -3431,7 +3431,7 @@ Perl_utf16_to_utf8_base(pTHX_ U8* p, U8* d, Size_t bytelen, Size_t *newlen,
     PERL_ARGS_ASSERT_UTF16_TO_UTF8_BASE;
 
     if (bytelen & 1)
-        Perl_croak(aTHX_ "panic: utf16_to_utf8%s: odd bytelen %" UVuf,
+        croak("panic: utf16_to_utf8%s: odd bytelen %" UVuf,
                 ((high_byte == 0) ? "" : "_reversed"), (UV)bytelen);
     pend = p + bytelen;
 
@@ -3454,14 +3454,14 @@ Perl_utf16_to_utf8_base(pTHX_ U8* p, U8* d, Size_t bytelen, Size_t *newlen,
 #define FIRST_IN_PLANE1      0x10000
 
             if (UNLIKELY(p >= pend) || UNLIKELY(uv > LAST_HIGH_SURROGATE)) {
-                Perl_croak(aTHX_ "Malformed UTF-16 surrogate");
+                croak("Malformed UTF-16 surrogate");
             }
             else {
                 U32 low_surrogate = (p[(U8) high_byte] << 8) + p[(U8) low_byte];
                 if (UNLIKELY(! inRANGE(low_surrogate, FIRST_LOW_SURROGATE,
                                                        LAST_LOW_SURROGATE)))
                 {
-                    Perl_croak(aTHX_ "Malformed UTF-16 surrogate");
+                    croak("Malformed UTF-16 surrogate");
                 }
 
                 p += 2;
@@ -3626,7 +3626,7 @@ Perl__to_upper_title_latin1(pTHX_ const U8 c, U8* p, STRLEN *lenp,
                 return 'S';
 #endif
             default:
-                Perl_croak(aTHX_ "panic: to_upper_title_latin1 did not expect"
+                croak("panic: to_upper_title_latin1 did not expect"
                                  " '%c' to map to '%c'",
                                  c, LATIN_SMALL_LETTER_Y_WITH_DIAERESIS);
                 NOT_REACHED; /* NOTREACHED */
@@ -3919,7 +3919,7 @@ S_warn_on_first_deprecated_use(pTHX_ U32 category,
             if (! hv_store(PL_seen_deprecated_macro, key,
                            strlen(key), &PL_sv_undef, 0))
             {
-                Perl_croak(aTHX_ "panic: hv_store() unexpectedly failed");
+                croak("panic: hv_store() unexpectedly failed");
             }
 
             if (instr(file, "mathoms.c")) {
@@ -4024,7 +4024,7 @@ S_to_case_cp_list(pTHX_
             }
             else if (UNLIKELY(UNICODE_IS_SUPER(original))) {
                 if (UNLIKELY(original > MAX_LEGAL_CP)) {
-                    Perl_croak(aTHX_ "%s", form_cp_too_large_msg(16, NULL, 0, original));
+                    croak("%s", form_cp_too_large_msg(16, NULL, 0, original));
                 }
                 if (ckWARN_d(WARN_NON_UNICODE)) {
                     const char* desc = (PL_op) ? OP_DESC(PL_op) : normal;

--- a/util.c
+++ b/util.c
@@ -1637,7 +1637,7 @@ Perl_mess_sv(pTHX_ SV *basemsg, bool consume)
                 cop = PL_curcop;
 
             if (CopLINE(cop))
-                Perl_sv_catpvf(aTHX_ sv, " at %s line %" LINE_Tf,
+                sv_catpvf(sv, " at %s line %" LINE_Tf,
                                 OutCopFILE(cop), CopLINE(cop));
         }
 
@@ -1648,7 +1648,7 @@ Perl_mess_sv(pTHX_ SV *basemsg, bool consume)
             STRLEN l;
             const bool line_mode = (RsSIMPLE(PL_rs) &&
                                    *SvPV_const(PL_rs,l) == '\n' && l == 1);
-            Perl_sv_catpvf(aTHX_ sv, ", <%" SVf "> %s %" IVdf,
+            sv_catpvf(sv, ", <%" SVf "> %s %" IVdf,
                            SVfARG(PL_last_in_gv == PL_argvgv
                                  ? &PL_sv_no
                                  : newSVhek_mortal(GvNAME_HEK(PL_last_in_gv))),
@@ -5673,10 +5673,10 @@ S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p,
             string = vstringify(pmsv);
 
             if (vn) {
-                Perl_sv_catpvf(aTHX_ xpt, "$%" SVf "::%s %" SVf, SVfARG(module), vn,
+                sv_catpvf(xpt, "$%" SVf "::%s %" SVf, SVfARG(module), vn,
                                SVfARG(string));
             } else {
-                Perl_sv_catpvf(aTHX_ xpt, "bootstrap parameter %" SVf, SVfARG(string));
+                sv_catpvf(xpt, "bootstrap parameter %" SVf, SVfARG(string));
             }
             SvREFCNT_dec(string);
 
@@ -6587,31 +6587,31 @@ Perl_get_c_backtrace_dump(pTHX_ int depth, int skip)
         UV i;
         for (i = 0, frame = bt->frame_info;
              i < bt->header.frame_count; i++, frame++) {
-            Perl_sv_catpvf(aTHX_ dsv, "%d", (int)i);
-            Perl_sv_catpvf(aTHX_ dsv, "\t%p", frame->addr ? frame->addr : "-");
+            sv_catpvf(dsv, "%d", (int)i);
+            sv_catpvf(dsv, "\t%p", frame->addr ? frame->addr : "-");
             /* Symbol (function) names might disappear without debug info.
              *
              * The source code location might disappear in case of the
              * optimizer inlining or otherwise rearranging the code. */
             if (frame->symbol_addr) {
-                Perl_sv_catpvf(aTHX_ dsv, ":%04x",
+                sv_catpvf(dsv, ":%04x",
                                (int)
                                ((char*)frame->addr - (char*)frame->symbol_addr));
             }
-            Perl_sv_catpvf(aTHX_ dsv, "\t%s",
+            sv_catpvf(dsv, "\t%s",
                            frame->symbol_name_size &&
                            frame->symbol_name_offset ?
                            (char*)bt + frame->symbol_name_offset : "-");
             if (frame->source_name_size &&
                 frame->source_name_offset &&
                 frame->source_line_number) {
-                Perl_sv_catpvf(aTHX_ dsv, "\t%s:%" UVuf,
+                sv_catpvf(dsv, "\t%s:%" UVuf,
                                (char*)bt + frame->source_name_offset,
                                (UV)frame->source_line_number);
             } else {
-                Perl_sv_catpvf(aTHX_ dsv, "\t-");
+                sv_catpvf(dsv, "\t-");
             }
-            Perl_sv_catpvf(aTHX_ dsv, "\t%s",
+            sv_catpvf(dsv, "\t%s",
                            frame->object_name_size &&
                            frame->object_name_offset ?
                            (char*)bt + frame->object_name_offset : "-");

--- a/util.c
+++ b/util.c
@@ -1420,7 +1420,7 @@ Perl_form_nocontext(const char* pat, ...)
 These each take a sprintf-style format pattern and conventional
 (non-SV) arguments and return the formatted string.
 
-    (char *) Perl_form(aTHX_ const char* pat, ...)
+    (char *) form(const char* pat, ...)
 
 They can be used any place a string (char *) is required:
 
@@ -5653,10 +5653,10 @@ S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p,
     else {
         /* XXX GV_ADDWARN */
         vn = "XS_VERSION";
-        sv = get_sv(Perl_form(aTHX_ "%" SVf "::%s", SVfARG(module), vn), 0);
+        sv = get_sv(form("%" SVf "::%s", SVfARG(module), vn), 0);
         if (!sv || !SvOK(sv)) {
             vn = "VERSION";
-            sv = get_sv(Perl_form(aTHX_ "%" SVf "::%s", SVfARG(module), vn), 0);
+            sv = get_sv(form("%" SVf "::%s", SVfARG(module), vn), 0);
         }
     }
     if (sv) {

--- a/util.c
+++ b/util.c
@@ -1948,7 +1948,7 @@ Perl_croak(pTHX_ const char *pat, ...)
 
 This encapsulates a common reason for dying, generating terser object code than
 using the generic C<Perl_croak>.  It is exactly equivalent to
-C<Perl_croak(aTHX_ "%s", PL_no_modify)> (which expands to something like
+C<croak("%s", PL_no_modify)> (which expands to something like
 "Modification of a read-only value attempted").
 
 Less code used on exception code paths reduces CPU cache pressure.
@@ -2606,7 +2606,7 @@ Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
             int pid2, status;
             PerlLIO_close(p[This]);
             if (read_total != sizeof(int))
-                Perl_croak(aTHX_ "panic: kid popen errno read, n=%u", read_total);
+                croak("panic: kid popen errno read, n=%u", read_total);
             do {
                 pid2 = wait4pid(pid, &status, 0);
             } while (pid2 == -1 && errno == EINTR);
@@ -2636,7 +2636,7 @@ Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
 #  elif defined(WIN32)
     return win32_popenlist(mode, n, args);
 #  else
-    Perl_croak(aTHX_ "List form of piped open not implemented");
+    croak("List form of piped open not implemented");
     return (PerlIO *) NULL;
 #  endif
 #endif
@@ -2693,7 +2693,7 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode)
                 PerlLIO_close(pp[1]);
             }
             if (!doexec)
-                Perl_croak(aTHX_ "Can't fork: %s", Strerror(errno));
+                croak("Can't fork: %s", Strerror(errno));
             return NULL;
         }
         Perl_ck_warner(aTHX_ packWARN(WARN_PIPE), "Can't fork, trying again in 5 seconds");
@@ -2789,7 +2789,7 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode)
             int pid2, status;
             PerlLIO_close(p[This]);
             if (n != sizeof(int))
-                Perl_croak(aTHX_ "panic: kid popen errno read, n=%u", n);
+                croak("panic: kid popen errno read, n=%u", n);
             do {
                 pid2 = wait4pid(pid, &status, 0);
             } while (pid2 == -1 && errno == EINTR);
@@ -3251,7 +3251,7 @@ Perl_wait4pid(pTHX_ Pid_t pid, int *statusp, int flags)
 #endif
     {
         if (flags)
-            Perl_croak(aTHX_ "Can't do waitpid with flags");
+            croak("Can't do waitpid with flags");
         else {
             while ((result = PerlProc_wait(statusp)) != pid && pid > 0 && result >= 0)
                 pidgone(result,*statusp);
@@ -3603,7 +3603,7 @@ Perl_find_script(pTHX_ const char *scriptname, bool dosearch,
         if (!xfound) {
             if (flags & 1) {			/* do or die? */
                 /* diag_listed_as: Can't execute %s */
-                Perl_croak(aTHX_ "Can't %s %s%s%s",
+                croak("Can't %s %s%s%s",
                       (xfailed ? "execute" : "find"),
                       (xfailed ? xfailed : scriptname),
                       (xfailed ? "" : " on PATH"),
@@ -4243,7 +4243,7 @@ Perl_getcwd_sv(pTHX_ SV *sv)
     cino = statbuf.st_ino;
 
     if (cdev != orig_cdev || cino != orig_cino) {
-        Perl_croak(aTHX_ "Unstable directory path, "
+        croak("Unstable directory path, "
                    "current directory changed unexpectedly");
     }
 
@@ -4588,11 +4588,11 @@ Perl_parse_unicode_opts(pTHX_ const char **popt)
                     if (isSPACE(*p))
                         goto the_end_of_the_opts_parser;
                     else
-                        Perl_croak(aTHX_ "Unknown Unicode option letter '%c'", *p);
+                        croak("Unknown Unicode option letter '%c'", *p);
                 }
             }
             else {
-                Perl_croak(aTHX_ "Invalid number '%s' for -C option.\n", p);
+                croak("Invalid number '%s' for -C option.\n", p);
             }
         }
         else {
@@ -4622,7 +4622,7 @@ Perl_parse_unicode_opts(pTHX_ const char **popt)
                       if (*p != '\n' && *p != '\r') {
                         if(isSPACE(*p)) goto the_end_of_the_opts_parser;
                         else
-                          Perl_croak(aTHX_
+                          croak(
                                      "Unknown Unicode option letter '%c'", *p);
                       }
                  }
@@ -4635,7 +4635,7 @@ Perl_parse_unicode_opts(pTHX_ const char **popt)
   the_end_of_the_opts_parser:
 
   if (opt & ~PERL_UNICODE_ALL_FLAGS)
-       Perl_croak(aTHX_ "Unknown Unicode option value %" UVuf,
+       croak("Unknown Unicode option value %" UVuf,
                   (UV) (opt & ~PERL_UNICODE_ALL_FLAGS));
 
   *popt = p;

--- a/util.c
+++ b/util.c
@@ -269,7 +269,7 @@ Perl_safesysrealloc(Malloc_t where,MEM_SIZE size)
 
 # ifdef PERL_TRACK_MEMPOOL
             if (header->interpreter != aTHX) {
-                Perl_croak_nocontext("panic: realloc %p from wrong pool, %p!=%p",
+                croak("panic: realloc %p from wrong pool, %p!=%p",
                                      where, header->interpreter, aTHX);
             }
             assert(header->next->prev == header);
@@ -289,7 +289,7 @@ Perl_safesysrealloc(Malloc_t where,MEM_SIZE size)
 #endif
 #ifdef DEBUGGING
         if ((SSize_t)size < 0)
-            Perl_croak_nocontext("panic: realloc %p , size=%" UVuf,
+            croak("panic: realloc %p , size=%" UVuf,
                                  where, (UV)size);
 #endif
 #ifdef PERL_DEBUG_READONLY_COW
@@ -390,17 +390,17 @@ Perl_safesysfree(Malloc_t where)
 # endif
 # ifdef PERL_TRACK_MEMPOOL
             if (header->interpreter != aTHX) {
-                Perl_croak_nocontext("panic: free %p from wrong pool, %p!=%p",
+                croak("panic: free %p from wrong pool, %p!=%p",
                                      where, header->interpreter, aTHX);
             }
             if (!header->prev) {
-                Perl_croak_nocontext("panic: duplicate free");
+                croak("panic: duplicate free");
             }
             if (!(header->next))
-                Perl_croak_nocontext("panic: bad free of %p, header->next==NULL",
+                croak("panic: bad free of %p, header->next==NULL",
                                      where);
             if (header->next->prev != header || header->prev->next != header) {
-                Perl_croak_nocontext("panic: bad free of %p, ->next->prev=%p, "
+                croak("panic: bad free of %p, ->next->prev=%p, "
                                      "header=%p, ->prev->next=%p",
                                      where, header->next->prev, header,
                                      header->prev->next);
@@ -469,7 +469,7 @@ Perl_safesyscalloc(MEM_SIZE count, MEM_SIZE size)
 #endif
 #ifdef DEBUGGING
     if ((SSize_t)size < 0 || (SSize_t)count < 0)
-        Perl_croak_nocontext("panic: calloc, size=%" UVuf ", count=%" UVuf,
+        croak("panic: calloc, size=%" UVuf ", count=%" UVuf,
                              (UV)size, (UV)count);
 #endif
 #ifdef PERL_DEBUG_READONLY_COW
@@ -3646,7 +3646,7 @@ Perl_set_context(void *t)
     {
         const int error = pthread_setspecific(PL_thr_key, t);
         if (error)
-            Perl_croak_nocontext("panic: pthread_setspecific, error=%d", error);
+            croak_nocontext("panic: pthread_setspecific, error=%d", error);
     }
 #  endif
 
@@ -5266,7 +5266,7 @@ Perl_my_snprintf(char *buffer, const Size_t len, const char *format, ...)
                 retval = quadmath_snprintf(buffer, len, format, va_arg(ap, NV));
             );
             if (retval == -1) {
-                Perl_croak_nocontext("panic: quadmath_snprintf failed, format \"%s\"", format);
+                croak("panic: quadmath_snprintf failed, format \"%s\"", format);
             }
             quadmath_valid = TRUE;
         }
@@ -5292,7 +5292,7 @@ Perl_my_snprintf(char *buffer, const Size_t len, const char *format, ...)
          * If quadmath_format_needed() returns false, we are reasonably
          * certain that we can call vnsprintf() or vsprintf() safely. */
         if (!quadmath_valid && quadmath_format_needed(format))
-          Perl_croak_nocontext("panic: quadmath_snprintf failed, format \"%s\"", format);
+          croak("panic: quadmath_snprintf failed, format \"%s\"", format);
 
     }
 #endif
@@ -5319,7 +5319,7 @@ Perl_my_snprintf(char *buffer, const Size_t len, const char *format, ...)
         (len > 0 && (Size_t)retval >= len)
 #endif
     )
-        Perl_croak_nocontext("panic: my_snprintf buffer overflow");
+        croak("panic: my_snprintf buffer overflow");
     return retval;
 }
 
@@ -5621,7 +5621,7 @@ Perl_xs_handshake(const U32 key, void * v_my_perl, const char * file, ...)
             if(apiverlen != sizeof("v" PERL_API_VERSION_STRING)-1
                 || memNE(api_p, "v" PERL_API_VERSION_STRING,
                          sizeof("v" PERL_API_VERSION_STRING)-1))
-                Perl_croak_nocontext("Perl API version %s of %" SVf " does not match %s",
+                croak("Perl API version %s of %" SVf " does not match %s",
                                     api_p, SVfARG(PL_stack_base[ax + 0]),
                                     "v" PERL_API_VERSION_STRING);
         }

--- a/util.c
+++ b/util.c
@@ -93,7 +93,7 @@ S_maybe_protect_rw(pTHX_ struct perl_memory_debug_header *header)
 {
     if (header->readonly
      && mprotect(header, header->size, PROT_READ|PROT_WRITE))
-        Perl_warn(aTHX_ "mprotect for COW string %p %lu failed with %d",
+        warn("mprotect for COW string %p %lu failed with %d",
                          header, header->size, errno);
 }
 
@@ -102,7 +102,7 @@ S_maybe_protect_ro(pTHX_ struct perl_memory_debug_header *header)
 {
     if (header->readonly
      && mprotect(header, header->size, PROT_READ))
-        Perl_warn(aTHX_ "mprotect RW for COW string %p %lu failed with %d",
+        warn("mprotect RW for COW string %p %lu failed with %d",
                          header, header->size, errno);
 }
 # define maybe_protect_rw(foo) S_maybe_protect_rw(aTHX_ foo)
@@ -4799,7 +4799,7 @@ Perl_get_hash_seed(pTHX_ unsigned char * const seed_buffer)
             env_pv++;
 
         if (*env_pv && !isXDIGIT(*env_pv)) {
-            Perl_warn(aTHX_ "perl: warning: Non hex character in '$ENV{PERL_HASH_SEED}', seed only partially set\n");
+            warn("perl: warning: Non hex character in '$ENV{PERL_HASH_SEED}', seed only partially set\n");
         }
         /* should we check for unparsed crap? */
         /* should we warn about unused hex? */
@@ -4826,7 +4826,7 @@ Perl_get_hash_seed(pTHX_ unsigned char * const seed_buffer)
         } else if (strEQ(env_pv,"2") || strEQ(env_pv,"DETERMINISTIC")) {
             PL_hash_rand_bits_enabled= 2;
         } else {
-            Perl_warn(aTHX_ "perl: warning: strange setting in '$ENV{PERL_PERTURB_KEYS}': '%s'\n", env_pv);
+            warn("perl: warning: strange setting in '$ENV{PERL_PERTURB_KEYS}': '%s'\n", env_pv);
         }
     }
 #  endif

--- a/vms/vms.c
+++ b/vms/vms.c
@@ -1406,7 +1406,7 @@ prime_env_iter(void)
       buf[retlen] = '\0';
       if (iosb[1] != subpid) {
         if (iosb[1]) {
-          Perl_croak(aTHX_ "Unknown process %x sent message to prime_env_iter: %s",buf);
+          croak("Unknown process %x sent message to prime_env_iter: %s",buf);
         }
         continue;
       }
@@ -12622,7 +12622,7 @@ rmsexpand_fromperl(pTHX_ CV *cv)
   fs_utf8 = 0;
   dfs_utf8 = 0;
   if (!items || items > 2)
-    Perl_croak(aTHX_ "Usage: VMS::Filespec::rmsexpand(spec[,defspec])");
+    croak("Usage: VMS::Filespec::rmsexpand(spec[,defspec])");
   fspec = SvPV(ST(0),n_a);
   fs_utf8 = SvUTF8(ST(0));
   if (!fspec || !*fspec) XSRETURN_UNDEF;
@@ -12649,7 +12649,7 @@ vmsify_fromperl(pTHX_ CV *cv)
   STRLEN n_a;
   int utf8_fl;
 
-  if (items != 1) Perl_croak(aTHX_ "Usage: VMS::Filespec::vmsify(spec)");
+  if (items != 1) croak("Usage: VMS::Filespec::vmsify(spec)");
   utf8_fl = SvUTF8(ST(0));
   vmsified = do_tovmsspec(SvPV(ST(0),n_a),NULL,1,&utf8_fl);
   ST(0) = sv_newmortal();
@@ -12670,7 +12670,7 @@ unixify_fromperl(pTHX_ CV *cv)
   STRLEN n_a;
   int utf8_fl;
 
-  if (items != 1) Perl_croak(aTHX_ "Usage: VMS::Filespec::unixify(spec)");
+  if (items != 1) croak("Usage: VMS::Filespec::unixify(spec)");
   utf8_fl = SvUTF8(ST(0));
   unixified = do_tounixspec(SvPV(ST(0),n_a),NULL,1,&utf8_fl);
   ST(0) = sv_newmortal();
@@ -12691,7 +12691,7 @@ fileify_fromperl(pTHX_ CV *cv)
   STRLEN n_a;
   int utf8_fl;
 
-  if (items != 1) Perl_croak(aTHX_ "Usage: VMS::Filespec::fileify(spec)");
+  if (items != 1) croak("Usage: VMS::Filespec::fileify(spec)");
   utf8_fl = SvUTF8(ST(0));
   fileified = do_fileify_dirspec(SvPV(ST(0),n_a),NULL,1,&utf8_fl);
   ST(0) = sv_newmortal();
@@ -12712,7 +12712,7 @@ pathify_fromperl(pTHX_ CV *cv)
   STRLEN n_a;
   int utf8_fl;
 
-  if (items != 1) Perl_croak(aTHX_ "Usage: VMS::Filespec::pathify(spec)");
+  if (items != 1) croak("Usage: VMS::Filespec::pathify(spec)");
   utf8_fl = SvUTF8(ST(0));
   pathified = do_pathify_dirspec(SvPV(ST(0),n_a),NULL,1,&utf8_fl);
   ST(0) = sv_newmortal();
@@ -12733,7 +12733,7 @@ vmspath_fromperl(pTHX_ CV *cv)
   STRLEN n_a;
   int utf8_fl;
 
-  if (items != 1) Perl_croak(aTHX_ "Usage: VMS::Filespec::vmspath(spec)");
+  if (items != 1) croak("Usage: VMS::Filespec::vmspath(spec)");
   utf8_fl = SvUTF8(ST(0));
   vmspath = do_tovmspath(SvPV(ST(0),n_a),NULL,1,&utf8_fl);
   ST(0) = sv_newmortal();
@@ -12754,7 +12754,7 @@ unixpath_fromperl(pTHX_ CV *cv)
   STRLEN n_a;
   int utf8_fl;
 
-  if (items != 1) Perl_croak(aTHX_ "Usage: VMS::Filespec::unixpath(spec)");
+  if (items != 1) croak("Usage: VMS::Filespec::unixpath(spec)");
   utf8_fl = SvUTF8(ST(0));
   unixpath = do_tounixpath(SvPV(ST(0),n_a),NULL,1,&utf8_fl);
   ST(0) = sv_newmortal();
@@ -12776,7 +12776,7 @@ candelete_fromperl(pTHX_ CV *cv)
   IO *io;
   STRLEN n_a;
 
-  if (items != 1) Perl_croak(aTHX_ "Usage: VMS::Filespec::candelete(spec)");
+  if (items != 1) croak("Usage: VMS::Filespec::candelete(spec)");
 
   mysv = SvROK(ST(0)) ? SvRV(ST(0)) : ST(0);
   Newx(fspec, VMS_MAXRSS, char);
@@ -12815,7 +12815,7 @@ rmscopy_fromperl(pTHX_ CV *cv)
   STRLEN n_a;
 
   if (items < 2 || items > 3)
-    Perl_croak(aTHX_ "Usage: File::Copy::rmscopy(from,to[,date_flag])");
+    croak("Usage: File::Copy::rmscopy(from,to[,date_flag])");
 
   mysv = SvROK(ST(0)) ? SvRV(ST(0)) : ST(0);
   Newx(inspec, VMS_MAXRSS, char);
@@ -13249,7 +13249,7 @@ unixrealpath_fromperl(pTHX_ CV *cv)
     STRLEN n_a;
 
     if (!items || items != 1)
-        Perl_croak(aTHX_ "Usage: VMS::Filespec::unixrealpath(spec)");
+        croak("Usage: VMS::Filespec::unixrealpath(spec)");
 
     fspec = SvPV(ST(0),n_a);
     if (!fspec || !*fspec) XSRETURN_UNDEF;
@@ -13277,7 +13277,7 @@ vmsrealpath_fromperl(pTHX_ CV *cv)
     STRLEN n_a;
 
     if (!items || items != 1)
-        Perl_croak(aTHX_ "Usage: VMS::Filespec::vmsrealpath(spec)");
+        croak("Usage: VMS::Filespec::vmsrealpath(spec)");
 
     fspec = SvPV(ST(0),n_a);
     if (!fspec || !*fspec) XSRETURN_UNDEF;

--- a/vms/vms.c
+++ b/vms/vms.c
@@ -931,7 +931,7 @@ Perl_vmstrnenv(const char *lnm, char *eqv, unsigned long int idx,
                     "Can't read CRTL environ\n");
             } else
 #endif
-                Perl_warn(aTHX_ "Can't read CRTL environ\n");
+                warn("Can't read CRTL environ\n");
             continue;
           }
           retsts = SS$_NOLOGNAM;
@@ -10921,7 +10921,7 @@ Perl_vms_do_aexec(pTHX_ SV *really,SV **mark,SV **sp)
   if (vfork_called) {           /* this follows a vfork - act Unixish */
     vfork_called--;
     if (vfork_called < 0) {
-      Perl_warn(aTHX_ "Internal inconsistency in tracking vforks");
+      warn("Internal inconsistency in tracking vforks");
       vfork_called = 0;
     }
     else return do_aexec(really,mark,sp);
@@ -10949,7 +10949,7 @@ Perl_vms_do_exec(pTHX_ const char *cmd)
   if (vfork_called) {             /* this follows a vfork - act Unixish */
     vfork_called--;
     if (vfork_called < 0) {
-      Perl_warn(aTHX_ "Internal inconsistency in tracking vforks");
+      warn("Internal inconsistency in tracking vforks");
       vfork_called = 0;
     }
     else return do_exec(cmd);
@@ -11382,7 +11382,7 @@ fillpasswd (pTHX_ const char *name, struct passwd *pwd)
         pwd->pw_gid= uic.uic$v_group;
     }
     else
-      Perl_warn(aTHX_ "getpwnam returned invalid UIC %#o for user \"%s\"");
+      warn("getpwnam returned invalid UIC %#o for user \"%s\"");
     pwd->pw_passwd=  pw_passwd;
     pwd->pw_gecos=   owner.pw_gecos;
     pwd->pw_dir=     defdev.pw_dir;
@@ -11595,7 +11595,7 @@ Perl_my_time(pTHX_ time_t *timep)
       if (!vmstrnenv("SYS$TIMEZONE_DIFFERENTIAL",off,0,fildev,0)) {
         gmtime_emulation_type++;
         utc_offset_secs = 0;
-        Perl_warn(aTHX_ "no UTC offset information; assuming local time is UTC");
+        warn("no UTC offset information; assuming local time is UTC");
       }
       else { utc_offset_secs = atol(off); }
     }

--- a/vutil.c
+++ b/vutil.c
@@ -1013,7 +1013,7 @@ Perl_vnumify(pTHX_ SV *vs)
     {
         SV * tsv = *av_fetch(av, i, 0);
         digit = SvIV(tsv);
-        Perl_sv_catpvf(aTHX_ sv, "%03d", (int)digit);
+        sv_catpvf(sv, "%03d", (int)digit);
     }
 
     if ( len == 0 ) {
@@ -1071,7 +1071,7 @@ Perl_vnormal(pTHX_ SV *vs)
     for ( i = 1 ; i <= len ; i++ ) {
         SV * tsv = *av_fetch(av, i, 0);
         digit = SvIV(tsv);
-        Perl_sv_catpvf(aTHX_ sv, ".%" IVdf, (IV)digit);
+        sv_catpvf(sv, ".%" IVdf, (IV)digit);
     }
 
     if ( len <= 2 ) { /* short version, must be at least three */

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -2745,7 +2745,7 @@ do_raise(pTHX_ int sig)
 void
 sig_terminate(pTHX_ int sig)
 {
-    Perl_warn(aTHX_ "Terminating on signal SIG%s(%d)\n",PL_sig_name[sig], sig);
+    warn("Terminating on signal SIG%s(%d)\n",PL_sig_name[sig], sig);
     /* exit() seems to be safe, my_exit() or die() is a problem in ^C 
        thread 
      */
@@ -5669,7 +5669,7 @@ win32_csighandler(int sig)
 {
 #if 0
     dTHXa(PERL_GET_SIG_CONTEXT);
-    Perl_warn(aTHX_ "Got signal %d",sig);
+    warn("Got signal %d",sig);
 #endif
     PERL_UNUSED_ARG(sig);
     /* Does nothing */

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -1436,7 +1436,7 @@ get_hwnd_delay(pTHX, long child, DWORD tries)
         }
     }
 
-    Perl_croak(aTHX_ "panic: child pseudo-process was never scheduled");
+    croak("panic: child pseudo-process was never scheduled");
 }
 #endif
 


### PR DESCRIPTION
Before d933027ef0a56c99aee8cc3c88ff4f9981ac9fc2, we could not efficiently support calling vararg PerlAPI functions (typically of the printf family) by their short name, so we used their long name. In particular `Perl_croak(aTHX_ "format", ...)` instead of `croak("format", ...)`. This converts the codebase for the following functions:

* `croak`
* `warn`
* `die`
* `form`
* `sv_setpvf`
* `sv_catpvf`

This change is not user-visible and should not change any behavior, and hence should not need a perldelta entry.