### PR TITLE
Minor typo correction to Poll.pm POD

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -362,6 +362,7 @@ Hans Mulder <hansmu@xs4all.nl> Hans Mulder <hansm@euronet.nl>
 Hans Mulder <hansmu@xs4all.nl> Hans Mulder <hansm@icgned.nl>
 Hans Mulder <hansmu@xs4all.nl> Unknown Contributor <hansm@euronet.nl>
 Harald Jörg <harald.joerg@arcor.de> Harald Jörg <haj@posteo.de>
+hbmaclean <81651480+hbmaclean@users.noreply.github.com> H Barry MacLean <81651480+hbmaclean@users.noreply.github.com>
 Heiko Eissfeldt <heiko.eissfeldt@hexco.de> hexcoder <heiko.eissfeldt@hexco.de>
 Helmut Jarausch <jarausch@numa1.igpm.rwth-aachen.de> <helmutjarausch@unknown>
 Hojung Youn <amoc.yn@gmail.com> Hojung Yoon <amoc.yn@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -571,6 +571,7 @@ Harmon S. Nine                 <hnine@netarx.com>
 Harri Pasanen                  <harri.pasanen@trema.com>
 Harry Edmon                    <harry@atmos.washington.edu>
 Hauke D                        <haukex@zero-g.net>
+hbmaclean                      <81651480+hbmaclean@users.noreply.github.com>
 Heiko Eissfeldt                <heiko.eissfeldt@hexco.de>
 Helmut Jarausch                <jarausch@numa1.igpm.rwth-aachen.de>
 Henrik Tougaard                <ht.000@foa.dk>

--- a/dist/IO/lib/IO/Poll.pm
+++ b/dist/IO/lib/IO/Poll.pm
@@ -12,7 +12,7 @@ use IO::Handle;
 use Exporter ();
 
 our @ISA = qw(Exporter);
-our $VERSION = "1.55";
+our $VERSION = "1.56";
 
 our @EXPORT = qw( POLLIN
 	      POLLOUT
@@ -186,7 +186,7 @@ Remove IO from the list of file descriptors for the next poll.
 Returns a list of handles. If EVENT_MASK is not given then a list of all
 handles known will be returned. If EVENT_MASK is given then a list
 of handles will be returned which had one of the events specified by
-EVENT_MASK happen during the last call ti C<poll>
+EVENT_MASK happen during the last call to C<poll>.
 
 =back
 


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
IO::Poll POD has, "the last call ti `poll`"
Correcting that to, "the last call to `poll`"
<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
