### PR TITLE
porting/libperl.t: detect LTO builds via -Doptimize

### DIFF
--- a/t/porting/libperl.t
+++ b/t/porting/libperl.t
@@ -56,7 +56,7 @@ if ($Config{cc} =~ /g\+\+/) {
 }
 
 # ccname is gcc for both gcc and clang
-if ($Config{ccname} eq "gcc" && $Config{ccflags} =~ /-flto\b/) {
+if ($Config{ccname} eq "gcc" && "$Config{ccflags} $Config{optimize}" =~ /-flto\b/) {
     # If we compile with gcc nm marks PL_no_mem as "D" (normal data) rather than a R (read only)
     # but the symbol still ends up in the .rodata section of the image on linking.
     # If we compile with clang 14, nm marks PL_no_mem as "T" (text, aka code) rather than R


### PR DESCRIPTION
Link-time optimization (LTO) may be enabled via -flto using either -Dccflags='-flto' or -Doptimize='-O2 -flto', so check both variables to detect an LTO build.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
