### PR TITLE
Makefile.SH: use standard tags file name for ctags

### DIFF
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -1750,7 +1750,7 @@ TAGS: $(c_base) $(h)
 $spitshell >>$Makefile <<!GROK!THIS!
 
 ctags:
-	ctags -f Tags -N --totals --languages=c --langmap=c:+.h $ctags_exclude *.c *.h
+	ctags -N --languages=c --langmap=c:+.h $ctags_exclude *.c *.h
 
 # AUTOMATICALLY GENERATED MAKE DEPENDENCIES--PUT NOTHING BELOW THIS LINE
 # If this runs make out of memory, delete /usr/include lines.


### PR DESCRIPTION
By default, vim only looks for a tags file literally called `tags` (or `TAGS` if emacs compatibility is enabled). `Tags` won't be found with default settings, at least on a case-sensitive file system. Also, remove `--totals` to make the command less noisy.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
