### PR TITLE
Revert "op.c: re-enable coderef-in-stash optimization"

### DIFF
--- a/op.c
+++ b/op.c
@@ -11061,9 +11061,12 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
            Also, we may be called from load_module at run time, so
            PL_curstash (which sets CvSTASH) may not point to the stash the
            sub is stored in.  */
+        /* XXX This optimization is currently disabled for packages other
+               than main, since there was too much CPAN breakage.  */
         const I32 flags =
            ec ? GV_NOADD_NOINIT
               :   (IN_PERL_RUNTIME && PL_curstash != CopSTASH(PL_curcop))
+               || PL_curstash != PL_defstash
                || memchr(name, ':', namlen) || memchr(name, '\'', namlen)
                     ? gv_fetch_flags
                     : GV_ADDMULTI | GV_NOINIT | GV_NOTQUAL;

--- a/t/op/sub.t
+++ b/t/op/sub.t
@@ -398,7 +398,10 @@ is ref($main::{rt_129916}), 'CODE', 'simple sub stored as CV in stash (main::)';
     package RT129916;
     sub foo { 42 }
 }
-is ref($RT129916::{foo}), 'CODE', 'simple sub stored as CV in stash (non-main::)';
+{
+    local $::TODO = "disabled for now";
+    is ref($RT129916::{foo}), 'CODE', 'simple sub stored as CV in stash (non-main::)';
+}
 
 # Calling xsub via ampersand syntax when @_ has holes
 SKIP: {


### PR DESCRIPTION
This reverts commit b9eeeef8c043fb0238a07e64636815bf327a6562.

See #23015.