### PR TITLE
op.c: call class_wrap_method_body() for lexical methods

### DIFF
--- a/op.c
+++ b/op.c
@@ -10657,6 +10657,8 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
     }
 
     if (block) {
+        if (CvIsMETHOD(PL_compcv))
+            block = class_wrap_method_body(block);
         /* This makes sub {}; work as expected.  */
         if (block->op_type == OP_STUB) {
             const line_t l = PL_parser->copline;

--- a/t/class/method.t
+++ b/t/class/method.t
@@ -106,8 +106,10 @@ no warnings 'experimental::class';
 # ->& operator can invoke methods with lexical scope
 {
     class Testcase8 {
+        field $f = "private-result";
+
         my method priv {
-            return "private-result";
+            return $f;
         }
 
         method notpriv {
@@ -132,6 +134,24 @@ no warnings 'experimental::class';
 
     is(Testcase8Derived->new->pkgm, "pkg-result",
         '->&m operator does not follow inheritance');
+}
+
+# lexical methods with signatures work correctly (GH#23030)
+{
+    class Testcase9 {
+        field $x = 123;
+
+        my method priv ( $y ) {
+            return "X is $x and Y is $y for $self";
+        }
+
+        method test {
+            $self->&priv(456);
+        }
+    }
+
+    like(Testcase9->new->test, qr/^X is 123 and Y is 456 for Testcase9=OBJECT\(0x.*\)$/,
+        'lexical method with signature counts $self correctly');
 }
 
 done_testing;


### PR DESCRIPTION
Fixes #23030 

Will take opinions on whether this needs a perldelta entry. I don't feel it hugely important because this fixes a bug in the previous point release; it'd be squashed away in the next production release anyway. But I can write up a quick note if required.