### PR TITLE
regatom: e is initialized and only used to update itself

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -6018,7 +6018,6 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                 I32 num;
                 char * endbrace = NULL;
                 char * s = RExC_parse;
-                char * e = RExC_end;
 
                 if (*s == 'g') {
                     bool isrel = 0;
@@ -6054,12 +6053,6 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
 
                         while (isBLANK(*s)) {
                             s++;
-                        }
-
-                        /* Ignore trailing blanks */
-                        e = endbrace;
-                        while (s < e && isBLANK(*(e - 1))) {
-                            e--;
                         }
                     }
 


### PR DESCRIPTION
e is initialized, but the only uses are to update itself.

It does appear to have been used when originally added, but it no longer is.  Possibly there's a test missing.

Picked up by clang static analyzer.

@khwilliamson originally introduced this

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->


<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
