### PR TITLE
I no longer manage a calendar of Perl events

### DIFF
--- a/pod/perlcommunity.pod
+++ b/pod/perlcommunity.pod
@@ -170,17 +170,6 @@ Open Source Developers Conference or OSDC. First held in Australia, it
 also spread to Israel and France. More information can be found at:
 L<http://www.osdc.org.il> for Israel, and L<http://www.osdc.fr/> for France.
 
-=head2 Calendar of Perl Events
-
-The Perl Review, L<http://www.theperlreview.com> maintains a website
-and Google calendar for tracking
-workshops, hackathons, Perl Mongers meetings, and other events. A view
-of this calendar is available at L<https://www.perl.org/events.html>.
-
-Not every event or Perl Mongers group is on that calendar, so don't lose
-heart if you don't see yours posted. To have your event or group listed,
-contact brian d foy (brian@theperlreview.com).
-
 =head1 AUTHOR
 
 Edgar "Trizor" Bering <trizor@gmail.com>


### PR DESCRIPTION
Update perlcommunity.pod to remove reference to a calendar I no longer support.

* This set of changes does not require a perldelta entry.
