### PR TITLE
fix recursive code block regexes

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -979,6 +979,13 @@ S_do_pmop_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const PMOP *pm)
 
     kidbar = ((bar << 1) | cBOOL(pm->op_flags & OPf_KIDS)) << 1;
 
+#ifdef USE_ITHREADS
+    S_opdump_indent(aTHX_ (OP*)pm, level, bar, file,
+                    "PMOFFSET = %" IVdf "\n", (IV)pm->op_pmoffset);
+#endif
+    S_opdump_indent(aTHX_ (OP*)pm, level, bar, file,
+                    "REGEX = 0x%" UVxf "\n", PTR2UV(PM_GETRE(pm)));
+
     if (PM_GETRE(pm)) {
         char ch = (pm->op_pmflags & PMf_ONCE) ? '?' : '/';
         S_opdump_indent(aTHX_ (OP*)pm, level, bar, file, "PMf_PRE %c%.*s%c\n",

--- a/op.h
+++ b/op.h
@@ -298,9 +298,16 @@ struct pmop {
     OP *	op_code_list;	/* list of (?{}) code blocks */
 };
 
+/* The PM_GETRE_raw/PM_SETRE_raw variants get/set the slot without any
+ * processing or asserts */
 #ifdef USE_ITHREADS
+#define PM_GETRE_raw(o)	(REGEXP*)(PL_regex_pad[(o)->op_pmoffset])
 #define PM_GETRE(o)	(SvTYPE(PL_regex_pad[(o)->op_pmoffset]) == SVt_REGEXP \
                          ? (REGEXP*)(PL_regex_pad[(o)->op_pmoffset]) : NULL)
+
+#define PM_SETRE_raw(o,r)	STMT_START {					\
+                            PL_regex_pad[(o)->op_pmoffset] = MUTABLE_SV(r); \
+                        } STMT_END
 /* The assignment is just to enforce type safety (or at least get a warning).
  */
 /* With first class regexps not via a reference one needs to assign
@@ -315,7 +322,9 @@ struct pmop {
                             PL_regex_pad[(o)->op_pmoffset] = MUTABLE_SV(_pm_setre); \
                         } STMT_END
 #else
+#define PM_GETRE_raw(o) ((o)->op_pmregexp)
 #define PM_GETRE(o)     ((o)->op_pmregexp)
+#define PM_SETRE_raw(o,r) ((o)->op_pmregexp = (r))
 #define PM_SETRE(o,r)   ((o)->op_pmregexp = (r))
 #endif
 

--- a/regexec.c
+++ b/regexec.c
@@ -3504,7 +3504,14 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
     return s;
 }
 
-/* set RX_SAVED_COPY, RX_SUBBEG etc.
+/* S_reg_set_capture_string():
+ * Save a pointer (RX_SUBBEG) to the just-matched string, so that $1 etc
+ * will have retrievable values. Typically it will make a copy rather than
+ * pointing direct (flags & REXEC_COPY_STR), so that subsequent
+ * modifications to the string won't affect the value of $1 etc. If so,
+ * the RXp_MATCH_COPIED flag will be set. It can sometimes avoid copying
+ * by using COW.
+ *
  * flags have same meanings as with regexec_flags() */
 
 static void
@@ -11299,10 +11306,12 @@ S_setup_eval_state(pTHX_ regmatch_info *const reginfo)
     eval_state->curpm = PL_curpm;
     PL_curpm_under = PL_curpm;
     PL_curpm = PL_reg_curpm;
+    /* Temporarily set RXp_SUBBEG to the current string so that $1 etc
+     * are valid during code execution. If the current subbeg is a copy,
+     * then restore it at the end so that it gets properly freed when
+     * subbeg is finally updated after a successful match.
+     */
     if (RXp_MATCH_COPIED(rex)) {
-        /*  Here is a serious problem: we cannot rewrite subbeg,
-            since it may be needed if this match fails.  Thus
-            $` inside (?{}) could fail... */
         eval_state->subbeg     = RXp_SUBBEG(rex);
         eval_state->sublen     = RXp_SUBLEN(rex);
         eval_state->suboffset  = RXp_SUBOFFSET(rex);

--- a/regexec.c
+++ b/regexec.c
@@ -4354,14 +4354,23 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
 }
 
 
-/* Set which rex is pointed to by PL_reg_curpm, handling ref counting.
- * Do inc before dec, in case old and new rex are the same */
-#define SET_reg_curpm(Re2)                          \
-    if (reginfo->info_aux_eval) {                   \
-        (void)ReREFCNT_inc(Re2);		    \
-        ReREFCNT_dec(PM_GETRE(PL_reg_curpm));	    \
-        PM_SETRE((PL_reg_curpm), (Re2));	    \
-    }
+/* Set which rex is pointed to by PL_reg_curpm (which is the fake global
+ * PMOP used to make $1 etc available while executing (?{...}) code).
+ * Handles ref counting.
+ */
+
+static void
+S_set_reg_curpm(pTHX_ REGEXP *rx, regmatch_info *reginfo)
+{
+    if (!reginfo->info_aux_eval)
+        return;
+
+    REGEXP *old_rx = PM_GETRE(PL_reg_curpm);
+    /* Do inc before dec, in case old and new rex are the same. */
+    SvREFCNT_inc(rx);
+    PM_SETRE(PL_reg_curpm, rx);
+    SvREFCNT_dec(old_rx);
+}
 
 
 /*
@@ -8518,7 +8527,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 ST.prev_rex = rex_sv;
                 ST.prev_curlyx = cur_curlyx;
                 rex_sv = re_sv;
-                SET_reg_curpm(rex_sv);
+                S_set_reg_curpm(aTHX_ rex_sv, reginfo);
                 rex = re;
                 rexi = rei;
                 cur_curlyx = NULL;
@@ -8554,7 +8563,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
             rex_sv = ST.prev_rex;
             is_utf8_pat = reginfo->is_utf8_pat = cBOOL(RX_UTF8(rex_sv));
-            SET_reg_curpm(rex_sv);
+            S_set_reg_curpm(aTHX_ rex_sv, reginfo);
             rex = ReANY(rex_sv);
             rexi = RXi_GET(rex);
             {
@@ -8597,7 +8606,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
             rex_sv = ST.prev_rex;
             is_utf8_pat = reginfo->is_utf8_pat = cBOOL(RX_UTF8(rex_sv));
-            SET_reg_curpm(rex_sv);
+            S_set_reg_curpm(aTHX_ rex_sv, reginfo);
             rex = ReANY(rex_sv);
             rexi = RXi_GET(rex);
 
@@ -9685,7 +9694,7 @@ NULL
                 st->u.eval.cp = regcppush(rex, 0, maxopenparen);
                 rex_sv = CUR_EVAL.prev_rex;
                 is_utf8_pat = reginfo->is_utf8_pat = cBOOL(RX_UTF8(rex_sv));
-                SET_reg_curpm(rex_sv);
+                S_set_reg_curpm(aTHX_ rex_sv, reginfo);
                 rex = ReANY(rex_sv);
                 rexi = RXi_GET(rex);
 
@@ -11265,7 +11274,7 @@ S_setup_eval_state(pTHX_ regmatch_info *const reginfo)
         }
 #endif
     }
-    SET_reg_curpm(reginfo->prog);
+    S_set_reg_curpm(aTHX_ reginfo->prog, reginfo);
     eval_state->curpm = PL_curpm;
     PL_curpm_under = PL_curpm;
     PL_curpm = PL_reg_curpm;

--- a/regexec.c
+++ b/regexec.c
@@ -11233,8 +11233,9 @@ S_setup_eval_state(pTHX_ regmatch_info *const reginfo)
     regexp *const rex = ReANY(reginfo->prog);
     regmatch_info_aux_eval *eval_state = reginfo->info_aux_eval;
 
-    eval_state->rex = rex;
-    eval_state->sv  = reginfo->sv;
+    eval_state->rx = reginfo->prog;
+    SvREFCNT_inc(eval_state->rx);
+    eval_state->sv = reginfo->sv;
 
     if (reginfo->sv) {
         /* Make $_ available to executed code. */
@@ -11274,6 +11275,26 @@ S_setup_eval_state(pTHX_ regmatch_info *const reginfo)
         }
 #endif
     }
+
+    /* if we're currently executing a MATCHish op, the only ref to the
+     * current regex might be from that op. If recursive code called from
+     * (?{...}) recompiles that regex, the old regex will be lost -
+     * meaning that $1 etc will stuff refer to the value from the inner
+     * match. So if possible restore the PMOPs regex to the outer value at
+     * the end of the outer match */
+    if (   PL_op
+        && (PL_opargs[PL_op->op_type] & OA_CLASS_MASK) == OA_PMOP
+        && PM_GETRE((PMOP*)PL_op))
+    {
+        eval_state->old_op     = (PMOP*)PL_op;
+        eval_state->old_op_val = PM_GETRE((PMOP*)PL_op);
+        SvREFCNT_inc(eval_state->old_op_val);
+    }
+    else
+        eval_state->old_op = NULL;
+
+    eval_state->old_regcurpm_val = PM_GETRE_raw(PL_reg_curpm);
+    SvREFCNT_inc(eval_state->old_regcurpm_val);
     S_set_reg_curpm(aTHX_ reginfo->prog, reginfo);
     eval_state->curpm = PL_curpm;
     PL_curpm_under = PL_curpm;
@@ -11316,7 +11337,7 @@ S_cleanup_regmatch_info_aux(pTHX_ void *arg)
         /* undo the effects of S_setup_eval_state() */
 
         if (eval_state->subbeg) {
-            regexp * const rex = eval_state->rex;
+            regexp * const rex = ReANY(eval_state->rx);
             RXp_SUBBEG(rex) = eval_state->subbeg;
             RXp_SUBLEN(rex)     = eval_state->sublen;
             RXp_SUBOFFSET(rex)  = eval_state->suboffset;
@@ -11336,6 +11357,17 @@ S_cleanup_regmatch_info_aux(pTHX_ void *arg)
 
         PL_curpm = eval_state->curpm;
         SvREFCNT_dec(eval_state->sv);
+        SvREFCNT_dec(eval_state->rx);
+
+        REGEXP *old_rx = PM_GETRE(PL_reg_curpm);
+        PM_SETRE_raw(PL_reg_curpm, eval_state->old_regcurpm_val);
+        SvREFCNT_dec(old_rx);
+
+        if (eval_state->old_op) {
+            old_rx = PM_GETRE(eval_state->old_op);
+            PM_SETRE(eval_state->old_op, eval_state->old_op_val);
+            SvREFCNT_dec(old_rx);
+        }
     }
 
     PL_regmatch_state = aux->old_regmatch_state;

--- a/regexp.h
+++ b/regexp.h
@@ -776,7 +776,10 @@ struct regmatch_slab;
  * regmatch_state stack at the start of execution */
 
 typedef struct {
-    regexp *rex;
+    REGEXP *rx;
+    PMOP   *old_op;           /* saved value of PL_op and ... */
+    REGEXP *old_op_val;       /* ... saved value of PM_GETRE(PL_op) if any */
+    REGEXP *old_regcurpm_val; /* saved value of PM_GETRE(PL_reg_curpm) */
     PMOP    *curpm;     /* saved PL_curpm */
 #ifdef PERL_ANY_COW
     SV      *saved_copy; /* saved saved_copy field from rex */


### PR DESCRIPTION
GH #22869
Fix crashes when code within a regex code block /(?{...})/ recursively executes the same pattern.
There is one main commit which fixes the issue, plus a few other commits which tidy code, tweak comments etc for things I noticed while trying to identify and fix the bug.

---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and I haven't written it yet.
