### PR TITLE
inline.h: fix conversion warnings under MSVC

### DIFF
--- a/cop.h
+++ b/cop.h
@@ -1302,7 +1302,13 @@ typedef struct stackinfo PERL_SI;
 
 #ifdef DEBUGGING
 #  define SET_MARK_OFFSET \
-    PL_curstackinfo->si_markoff = PL_markstack_ptr - PL_markstack
+    STMT_START {                                                                \
+        /* ensure .si_markoff is an I32 and can hold the pointer difference */  \
+        STATIC_ASSERT_STMT(sizeof PL_curstackinfo->si_markoff == sizeof (I32)); \
+        assert(PL_markstack_ptr >= PL_markstack);                               \
+        assert(PL_markstack_ptr - PL_markstack <= (ptrdiff_t)I32_MAX);          \
+        PL_curstackinfo->si_markoff = (I32)(PL_markstack_ptr - PL_markstack);   \
+    } STMT_END
 #else
 #  define SET_MARK_OFFSET NOOP
 #endif

--- a/inline.h
+++ b/inline.h
@@ -1144,9 +1144,9 @@ Perl_rpp_is_lone(pTHX_ SV *sv)
     assert(AvREAL(PL_curstack));
 #endif
 
-    return SvREFCNT(sv) <= cBOOL(SvTEMP(sv))
+    return SvREFCNT(sv) <= (U32)cBOOL(SvTEMP(sv))
 #ifdef PERL_RC_STACK
-                         + 1
+                         + 1u
             && !SvIMMORTAL(sv) /* PL_sv_undef etc are never stealable */
 #endif
     ;


### PR DESCRIPTION
The following warnings show up repeatedly when building with MSVC:

    D:\a\perl5\perl5\inline.h(1147): warning C4018: '<=': signed/unsigned mismatch
    D:\a\perl5\perl5\inline.h(3946): warning C4244: '=': conversion from '__int64' to 'I32', possible loss of data

This patch should silence them without a change in functionality.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
