### PR TITLE
remove Ptrdiff_t, use ptrdiff_t instead

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -5342,7 +5342,7 @@ ES	|AV *	|add_multi_match|NULLOK AV *multi_char_matches		\
 				|const STRLEN cp_count
 ES	|void	|change_engine_size					\
 				|NN RExC_state_t *pRExC_state		\
-				|const Ptrdiff_t size
+				|const ptrdiff_t size
 ERS	|REGEXP *|compile_wildcard					\
 				|NN const char *subpattern		\
 				|const STRLEN len			\

--- a/handy.h
+++ b/handy.h
@@ -717,16 +717,16 @@ based on the underlying C library functions):
 #define strBEGINs(s1,s2) (strncmp(s1,ASSERT_IS_LITERAL(s2), sizeof(s2)-1) == 0)
 
 #define memBEGINs(s1, l, s2)                                                \
-            (   (Ptrdiff_t) (l) >= (Ptrdiff_t) sizeof(s2) - 1               \
+            (   (ptrdiff_t) (l) >= (ptrdiff_t) sizeof(s2) - 1               \
              && memEQ(s1, ASSERT_IS_LITERAL(s2), sizeof(s2)-1))
 #define memBEGINPs(s1, l, s2)                                               \
-            (   (Ptrdiff_t) (l) > (Ptrdiff_t) sizeof(s2) - 1                \
+            (   (ptrdiff_t) (l) > (ptrdiff_t) sizeof(s2) - 1                \
              && memEQ(s1, ASSERT_IS_LITERAL(s2), sizeof(s2)-1))
 #define memENDs(s1, l, s2)                                                  \
-            (   (Ptrdiff_t) (l) >= (Ptrdiff_t) sizeof(s2) - 1               \
+            (   (ptrdiff_t) (l) >= (ptrdiff_t) sizeof(s2) - 1               \
              && memEQ(s1 + (l) - (sizeof(s2) - 1), ASSERT_IS_LITERAL(s2), sizeof(s2)-1))
 #define memENDPs(s1, l, s2)                                                 \
-            (   (Ptrdiff_t) (l) > (Ptrdiff_t) sizeof(s2)                    \
+            (   (ptrdiff_t) (l) > (ptrdiff_t) sizeof(s2)                    \
              && memEQ(s1 + (l) - (sizeof(s2) - 1), ASSERT_IS_LITERAL(s2), sizeof(s2)-1))
 #endif  /* End of making macros private */
 

--- a/perl.h
+++ b/perl.h
@@ -1694,21 +1694,7 @@ Use L</UV> to declare variables of the maximum usable size on this platform.
 #  define STRUCT_OFFSET(s,m)  offsetof(s,m)
 #endif
 
-/* ptrdiff_t is C11, so undef it under pedantic builds.  (Actually it is
- * in C89, but apparently there are platforms where it doesn't exist.  See
- * thread beginning at http://nntp.perl.org/group/perl.perl5.porters/251541.)
- * */
-#ifdef PERL_GCC_PEDANTIC
-#   undef HAS_PTRDIFF_T
-#endif
-
-#ifdef HAS_PTRDIFF_T
-#  define Ptrdiff_t ptrdiff_t
-#else
-#  define Ptrdiff_t SSize_t
-#endif
-
-#  include <string.h>
+#include <string.h>
 
 /* This comes after <stdlib.h> so we don't try to change the standard
  * library prototypes; we'll use our own in proto.h instead. */

--- a/pod/perl5300delta.pod
+++ b/pod/perl5300delta.pod
@@ -1061,7 +1061,7 @@ L<[GH #16461]|https://github.com/Perl/perl5/issues/16461>.
 
 =item *
 
-It is now forbidden to malloc more than C<PTRDIFF_T_MAX> bytes.  Much
+It is now forbidden to malloc more than C<PTRDIFF_MAX> bytes.  Much
 code (including C optimizers) assumes that all data structures will not
 be larger than this, so this catches such attempts before overflow
 happens.

--- a/proto.h
+++ b/proto.h
@@ -8265,7 +8265,7 @@ S_add_multi_match(pTHX_ AV *multi_char_matches, SV *multi_string, const STRLEN c
         assert(!multi_char_matches || SvTYPE(multi_char_matches) == SVt_PVAV)
 
 STATIC void
-S_change_engine_size(pTHX_ RExC_state_t *pRExC_state, const Ptrdiff_t size);
+S_change_engine_size(pTHX_ RExC_state_t *pRExC_state, const ptrdiff_t size);
 # define PERL_ARGS_ASSERT_CHANGE_ENGINE_SIZE    \
         assert(pRExC_state)
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -6264,7 +6264,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
              * multi-char folds, so allocate extra space for that.   We can't
              * make any other length assumptions, as a byte input sequence
              * could shrink down. */
-            Ptrdiff_t current_string_nodes = STR_SZ(max_string_len
+            ptrdiff_t current_string_nodes = STR_SZ(max_string_len
                                                  + ((! FOLD)
                                                     ? 0
                                                     : 2 * ((UTF)
@@ -7168,7 +7168,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                             Size_t new_size = size
                                             + (oldp - redo_p)
                                             + UTF8_MAXBYTES_CASE + 1;
-                            Ptrdiff_t e_offset = redo_e - locfold_buf;
+                            ptrdiff_t e_offset = redo_e - locfold_buf;
 
                             Renew(locfold_buf, new_size, char);
                             Renew(loc_correspondence, new_size, Size_t);
@@ -7445,7 +7445,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
             /* Free up any over-allocated space; cast is to silence bogus
              * warning in MS VC */
             change_engine_size(pRExC_state,
-                        - (Ptrdiff_t) (current_string_nodes - STR_SZ(len)));
+                        - (ptrdiff_t) (current_string_nodes - STR_SZ(len)));
 
             /* I (khw) don't know if you can get here with zero length, but the
              * old code handled this situation by creating a zero-length EXACT
@@ -12781,7 +12781,7 @@ S_nextchar(pTHX_ RExC_state_t *pRExC_state)
 }
 
 STATIC void
-S_change_engine_size(pTHX_ RExC_state_t *pRExC_state, const Ptrdiff_t size)
+S_change_engine_size(pTHX_ RExC_state_t *pRExC_state, const ptrdiff_t size)
 {
     /* 'size' is the delta number of smallest regnode equivalents to add or
      * subtract from the current memory allocated to the regex engine being
@@ -12820,7 +12820,7 @@ S_regnode_guts(pTHX_ RExC_state_t *pRExC_state, const STRLEN extra_size)
     PERL_ARGS_ASSERT_REGNODE_GUTS;
 
     SIZE_ALIGN(RExC_size);
-    change_engine_size(pRExC_state, (Ptrdiff_t) 1 + extra_size);
+    change_engine_size(pRExC_state, (ptrdiff_t) 1 + extra_size);
     NODE_ALIGN_FILL(REGNODE_p(ret));
     return(ret);
 }
@@ -12940,7 +12940,7 @@ S_reginsert(pTHX_ RExC_state_t *pRExC_state, const U8 op,
     assert(!RExC_study_started); /* I believe we should never use reginsert once we have started
                                     studying. If this is wrong then we need to adjust RExC_recurse
                                     below like we do with RExC_open_parens/RExC_close_parens. */
-    change_engine_size(pRExC_state, (Ptrdiff_t) size);
+    change_engine_size(pRExC_state, (ptrdiff_t) size);
     src = REGNODE_p(RExC_emit);
     RExC_emit += size;
     dst = REGNODE_p(RExC_emit);

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -949,7 +949,7 @@ static const scan_data_t zero_scan_data = {
  * generate any warnings */
 #define TO_OUTPUT_WARNINGS(loc)                                         \
   (   RExC_copy_start_in_constructed                                    \
-   && ((xI(loc)) - RExC_precomp) > (Ptrdiff_t) RExC_latest_warn_offset)
+   && ((xI(loc)) - RExC_precomp) > (ptrdiff_t) RExC_latest_warn_offset)
 
 /* After we've emitted a warning, we save the position in the input so we don't
  * output it again */

--- a/sv.c
+++ b/sv.c
@@ -13113,9 +13113,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                         case 'l':  iv = va_arg(*args, long);       break;
                         case 'V':  iv = va_arg(*args, IV);         break;
                         case 'z':  iv = va_arg(*args, SSize_t);    break;
-#ifdef HAS_PTRDIFF_T
                         case 't':  iv = va_arg(*args, ptrdiff_t);  break;
-#endif
                         default:   iv = va_arg(*args, int);        break;
                         case 'j':  iv = (IV) va_arg(*args, PERL_INTMAX_T); break;
                         case 'q':
@@ -13168,11 +13166,9 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                         case 'l': uv = va_arg(*args, unsigned long); break;
                         case 'V': uv = va_arg(*args, UV);            break;
                         case 'z': uv = va_arg(*args, Size_t);        break;
-#ifdef HAS_PTRDIFF_T
                                   /* will sign extend, but there is no
                                    * uptrdiff_t, so oh well */
                         case 't': uv = va_arg(*args, ptrdiff_t);     break;
-#endif
                         case 'j': uv = (UV) va_arg(*args, PERL_UINTMAX_T); break;
                         default:  uv = va_arg(*args, unsigned);      break;
                         case 'q':
@@ -13730,9 +13726,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                     case 'l':  *(va_arg(*args, long*))      = i; break;
                     case 'V':  *(va_arg(*args, IV*))        = i; break;
                     case 'z':  *(va_arg(*args, SSize_t*))   = i; break;
-#ifdef HAS_PTRDIFF_T
                     case 't':  *(va_arg(*args, ptrdiff_t*)) = i; break;
-#endif
                     case 'j':  *(va_arg(*args, PERL_INTMAX_T*)) = i; break;
                     case 'q':
 #if IVSIZE >= 8

--- a/utf8.c
+++ b/utf8.c
@@ -696,7 +696,7 @@ S_does_utf8_overflow(const U8 * const s, const U8 * e)
      *              \xff\x80\x80\x80\x80\x80\x80\x83 = 2**32 */
 #  define OVERFLOWS_MIN_STRING  "\xff\x80\x80\x80\x80\x80\x80\x82"
 
-    if (e - s < (Ptrdiff_t) STRLENs(OVERFLOWS_MIN_STRING)) {
+    if (e - s < (ptrdiff_t) STRLENs(OVERFLOWS_MIN_STRING)) {
         return ALMOST_CERTAINLY_OVERFLOWS;  /* Not enough info to be sure */
     }
 
@@ -2613,7 +2613,7 @@ Perl_utf8_length(pTHX_ const U8 * const s0, const U8 * const e)
             /* Take extra care to not exceed 'e' (which would be undefined
              * behavior) should the input be malformed, with a partial
              * character at the end */
-            Ptrdiff_t expected_byte_count = UTF8SKIP(s);
+            ptrdiff_t expected_byte_count = UTF8SKIP(s);
             if (UNLIKELY(e - s  < expected_byte_count)) {
                 goto warn_and_return;
             }
@@ -2698,7 +2698,7 @@ Perl_utf8_length(pTHX_ const U8 * const s0, const U8 * const e)
 
         /* Here is a starter byte.  Use UTF8SKIP from now on */
         do {
-            Ptrdiff_t expected_byte_count = UTF8SKIP(s);
+            ptrdiff_t expected_byte_count = UTF8SKIP(s);
             if (UNLIKELY(e - s  < expected_byte_count)) {
                 break;
             }

--- a/util.c
+++ b/util.c
@@ -613,8 +613,8 @@ Perl_delimcpy_no_escape(char *to, const char *to_end,
                         const int delim, I32 *retlen)
 {
     const char * delim_pos;
-    Ptrdiff_t from_len = from_end - from;
-    Ptrdiff_t to_len = to_end - to;
+    ptrdiff_t from_len = from_end - from;
+    ptrdiff_t to_len = to_end - to;
     SSize_t copy_len;
 
     PERL_ARGS_ASSERT_DELIMCPY_NO_ESCAPE;
@@ -718,7 +718,7 @@ Perl_delimcpy(char *to, const char *to_end,
               const int delim, I32 *retlen)
 {
     const char * const orig_to = to;
-    Ptrdiff_t copy_len = 0;
+    ptrdiff_t copy_len = 0;
     bool stopped_early = FALSE;     /* Ran out of room to copy to */
 
     PERL_ARGS_ASSERT_DELIMCPY;
@@ -896,8 +896,8 @@ such occurrence.
 char *
 Perl_rninstr(const char *big, const char *bigend, const char *little, const char *lend)
 {
-    const Ptrdiff_t little_len = lend - little;
-    const Ptrdiff_t big_len = bigend - big;
+    const ptrdiff_t little_len = lend - little;
+    const ptrdiff_t big_len = bigend - big;
 
     PERL_ARGS_ASSERT_RNINSTR;
 


### PR DESCRIPTION
There is no reason for Ptrdiff_t to exist; ptrdiff_t is a completely standard C89 type. (I don't know what the ifdef PERL_GCC_PEDANTIC -> undef HAS_PTRDIFF_T logic was about; gcc -pedantic doesn't affect ptrdiff_t.)

(Also, we really don't need to probe for ptrdiff_t because we've had unguarded uses of ptrdiff_t in core (op.c, utf8.c) for at least a year and no one has complained.)


---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
