### PR TITLE
cflags.SH: don't try to add both -Wextra and -W

### DIFF
--- a/Cross/cflags-cross-arm
+++ b/Cross/cflags-cross-arm
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Extra warnings, used e.g. for gcc.
-warn="-Wall   -W -Wextra -Wendif-labels -Wc++-compat"
+warn="-Wall -Wextra -Wendif-labels -Wc++-compat"
 # Extra standardness.
 stdflags=" -std=c99"
 # Extra extra.

--- a/cflags.SH
+++ b/cflags.SH
@@ -182,13 +182,12 @@ Intel*) ;; # # Is that you, Intel C++?
 #   longer then the ANSI C99 minimum of 4095 bytes.
 #
 # NOTE 3: the relative order of these options matters:
-# -Wextra before -W
-# -W before -Wno-long-long -Wno-declaration-after-statement
+# -Wextra before -Wno-long-long -Wno-declaration-after-statement
 #
 *) warns="$pedantic \
 	-Werror=pointer-arith \
 	-Werror=vla \
-	-Wextra -W \
+	-Wextra \
 	-Wno-long-long -Wno-declaration-after-statement \
 	-Wc++-compat -Wwrite-strings"
    case " $ccflags " in
@@ -220,17 +219,6 @@ Intel*) ;; # # Is that you, Intel C++?
                -std*)
                  echo "cflags.SH: Adding $opt."
                  stdflags="$stdflags $opt"
-                 ;;
-               -W)
-                 # -Wextra is the modern form of -W, so add
-                 # -W only if -Wextra is not there already.
-                 case " $warn " in
-                 *-Wextra*) ;;
-                 *)
-                   echo "cflags.SH: Adding $opt."
-                   warn="$warn $opt"
-                   ;;
-                 esac
                  ;;
                -Werror=pointer-arith)
                   # -pedantic* covers -Werror=p-a


### PR DESCRIPTION
`-W` is just the older spelling of `-Wextra`, so don't try to add both. Also, remove the special-case logic for `-W` that skips adding it if `-Wextra` was already added.

Background: `-W` was officially renamed to `-Wextra` in gcc 3.4 <https://gcc.gnu.org/gcc-3.4/changes.html>, released in April 2004. So the only case where this code had any effect was 20+ years old releases of gcc that understood `-W`, but not `-Wextra`. I don't think we need to cater to those compilers for modern perl development.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
