### PR TITLE
regcomp.c: Use utf8_to-uv_or_die not utf8_to_uvchr_buf

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -8155,7 +8155,9 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
                 p++;
             }
             else {
-                input_text[name_len++] = utf8_to_uvchr_buf((U8 *) p, e, NULL);
+                input_text[name_len++] = utf8_to_uv_or_die((const U8 *) p,
+                                                           (const U8 *) e,
+                                                           NULL);
                 p+= UTF8SKIP(p);
             }
 


### PR DESCRIPTION

* This set of changes does not require a perldelta entry.
