### PR TITLE
regexec.c: Use utf8_to-uv_or_die not utf8_to_uvchr_buf

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -616,7 +616,7 @@ S_isFOO_utf8_lc(pTHX_ const U8 classnum, const U8* character, const U8* e)
         case CC_ENUM_VERTSPACE_: return is_VERTWS_high(character);
         default:
             return _invlist_contains_cp(PL_XPosix_ptrs[classnum],
-                                        utf8_to_uvchr_buf(character, e, NULL));
+                                        utf8_to_uv_or_die(character, e, NULL));
     }
     NOT_REACHED; /* NOTREACHED */
 }

--- a/regexec.c
+++ b/regexec.c
@@ -2399,7 +2399,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
         REXEC_FBC_UTF8_CLASS_SCAN(
               (   (U8) NATIVE_UTF8_TO_I8(*s) >= ANYOF_FLAGS(c)
                && _invlist_contains_cp(anyofh_list,
-                                       utf8_to_uvchr_buf((U8 *) s,
+                                       utf8_to_uv_or_die((U8 *) s,
                                                          (U8 *) strend,
                                                          NULL))));
         break;
@@ -2413,7 +2413,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
             anyofh_list = GET_ANYOFH_INVLIST(prog, c);
             REXEC_FBC_FIND_NEXT_UTF8_BYTE_SCAN(first_byte,
                    _invlist_contains_cp(anyofh_list,
-                                           utf8_to_uvchr_buf((U8 *) s,
+                                           utf8_to_uv_or_die((U8 *) s,
                                                               (U8 *) strend,
                                                               NULL)));
         }
@@ -2441,7 +2441,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                                 LOWEST_ANYOF_HRx_BYTE(ANYOF_FLAGS(c)),
                                 HIGHEST_ANYOF_HRx_BYTE(ANYOF_FLAGS(c)))
                    && _invlist_contains_cp(anyofh_list,
-                                           utf8_to_uvchr_buf((U8 *) s,
+                                           utf8_to_uv_or_die((U8 *) s,
                                                               (U8 *) strend,
                                                               NULL))));
         break;
@@ -2454,7 +2454,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                         /* Note FLAGS is the string length in this regnode */
                         ((struct regnode_anyofhs *) c)->string + FLAGS(c),
                         _invlist_contains_cp(anyofh_list,
-                                             utf8_to_uvchr_buf((U8 *) s,
+                                             utf8_to_uv_or_die((U8 *) s,
                                                                (U8 *) strend,
                                                                NULL)));
         break;
@@ -2469,7 +2469,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
       case ANYOFR_t8_p8:
         REXEC_FBC_UTF8_CLASS_SCAN(
                             (   NATIVE_UTF8_TO_I8(*s) >= ANYOF_FLAGS(c)
-                             && withinCOUNT(utf8_to_uvchr_buf((U8 *) s,
+                             && withinCOUNT(utf8_to_uv_or_die((U8 *) s,
                                                               (U8 *) strend,
                                                               NULL),
                                             ANYOFRbase(c), ANYOFRdelta(c))));
@@ -2487,7 +2487,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
             U8 first_byte = FLAGS(c);
 
             REXEC_FBC_FIND_NEXT_UTF8_BYTE_SCAN(first_byte,
-                                withinCOUNT(utf8_to_uvchr_buf((U8 *) s,
+                                withinCOUNT(utf8_to_uv_or_die((U8 *) s,
                                                               (U8 *) strend,
                                                               NULL),
                                             ANYOFRbase(c), ANYOFRdelta(c)));
@@ -3203,7 +3203,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
             REXEC_FBC_UTF8_CLASS_SCAN(
                         to_complement ^ cBOOL(_invlist_contains_cp(
                                                 PL_XPosix_ptrs[classnum],
-                                                utf8_to_uvchr_buf((U8 *) s,
+                                                utf8_to_uv_or_die((U8 *) s,
                                                                 (U8 *) strend,
                                                                 NULL))));
             break;

--- a/regexec.c
+++ b/regexec.c
@@ -7605,7 +7605,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 ||   ANYOF_FLAGS(scan) > NATIVE_UTF8_TO_I8(*locinput)
                 || ! (anyofh_list = GET_ANYOFH_INVLIST(rex, scan))
                 || ! _invlist_contains_cp(anyofh_list,
-                                          utf8_to_uvchr_buf((U8 *) locinput,
+                                          utf8_to_uv_or_die((U8 *) locinput,
                                                             (U8 *) loceol,
                                                             NULL)))
             {
@@ -7620,7 +7620,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 ||   ANYOF_FLAGS(scan) != (U8) *locinput
                 || ! (anyofh_list = GET_ANYOFH_INVLIST(rex, scan))
                 || ! _invlist_contains_cp(anyofh_list,
-                                          utf8_to_uvchr_buf((U8 *) locinput,
+                                          utf8_to_uv_or_die((U8 *) locinput,
                                                             (U8 *) loceol,
                                                             NULL)))
             {
@@ -7650,7 +7650,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                              HIGHEST_ANYOF_HRx_BYTE(ANYOF_FLAGS(scan)))
                 || ! (anyofh_list = GET_ANYOFH_INVLIST(rex, scan))
                 || ! _invlist_contains_cp(anyofh_list,
-                                          utf8_to_uvchr_buf((U8 *) locinput,
+                                          utf8_to_uv_or_die((U8 *) locinput,
                                                             (U8 *) loceol,
                                                             NULL)))
             {
@@ -7666,7 +7666,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 ||   memNE(locinput, ((struct regnode_anyofhs *) scan)->string, FLAGS(scan))
                 || ! (anyofh_list = GET_ANYOFH_INVLIST(rex, scan))
                 || ! _invlist_contains_cp(anyofh_list,
-                                          utf8_to_uvchr_buf((U8 *) locinput,
+                                          utf8_to_uv_or_die((U8 *) locinput,
                                                             (U8 *) loceol,
                                                             NULL)))
             {
@@ -7682,7 +7682,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
             if (utf8_target) {
                 if (    ANYOF_FLAGS(scan) > NATIVE_UTF8_TO_I8(*locinput)
-                   || ! withinCOUNT(utf8_to_uvchr_buf((U8 *) locinput,
+                   || ! withinCOUNT(utf8_to_uv_or_die((U8 *) locinput,
                                                 (U8 *) reginfo->strend,
                                                 NULL),
                                     ANYOFRbase(scan), ANYOFRdelta(scan)))
@@ -7707,7 +7707,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
             if (utf8_target) {
                 if (     ANYOF_FLAGS(scan) != (U8) *locinput
-                    || ! withinCOUNT(utf8_to_uvchr_buf((U8 *) locinput,
+                    || ! withinCOUNT(utf8_to_uv_or_die((U8 *) locinput,
                                                 (U8 *) reginfo->strend,
                                                 NULL),
                                      ANYOFRbase(scan), ANYOFRdelta(scan)))
@@ -7854,7 +7854,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                         if (! (to_complement
                            ^ cBOOL(_invlist_contains_cp(
                                       PL_XPosix_ptrs[classnum],
-                                      utf8_to_uvchr_buf((U8 *) locinput,
+                                      utf8_to_uv_or_die((U8 *) locinput,
                                                         (U8 *) reginfo->strend,
                                                         NULL)))))
                         {

--- a/regexec.c
+++ b/regexec.c
@@ -2204,7 +2204,7 @@ S_get_break_val_cp_checked(SV* const invlist, const UV cp_in) {
 #define _generic_GET_BREAK_VAL_UTF8(cp_macro, pos, strend)                     \
              (__ASSERT_(pos < strend)                                          \
                  /* Note assumes is valid UTF-8 */                             \
-             (cp_macro(utf8_to_uvchr_buf((pos), (strend), NULL))))
+             (cp_macro(utf8_to_uv_or_die((pos), (strend), NULL))))
 
 /* Returns the GCB value for the input code point */
 #define getGCB_VAL_CP(cp)                                                      \


### PR DESCRIPTION

* This set of changes does not require a perldelta entry.
