### PR TITLE
utf8.c: Use utf8_to-uv_or_die not utf8_to_uvchr_buf

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -4704,7 +4704,7 @@ Perl_check_utf8_print(pTHX_ const U8* s, const STRLEN len)
                     /* This has a different warning than the one the called
                      * function would output, so can't just call it, unlike we
                      * do for the non-chars and above-unicodes */
-                    UV uv = utf8_to_uvchr_buf(s, e, NULL);
+                    UV uv = utf8_to_uv_or_die(s, e, NULL);
                     Perl_warner(aTHX_ packWARN(WARN_SURROGATE),
                         "Unicode surrogate U+%04" UVXf " is illegal in UTF-8",
                                              uv);

--- a/utf8.c
+++ b/utf8.c
@@ -4795,7 +4795,7 @@ Perl_pv_uni_display(pTHX_ SV *dsv, const U8 *spv, STRLEN len, STRLEN pvlim,
              break;
         }
 
-        u = utf8_to_uvchr_buf(s, e, &next_len);
+        u = utf8_to_uv_or_die(s, e, &next_len);
         assert(next_len > 0);
 
         if (u < 256) {

--- a/utf8.c
+++ b/utf8.c
@@ -4290,7 +4290,7 @@ S_turkic_lc(pTHX_ const U8 * const p0, const U8 * const e,
             /* For the dot above to modify the 'I', it must be part of a
              * combining sequence immediately following the 'I', and no other
              * modifier with a ccc of 230 may intervene */
-            cp = utf8_to_uvchr_buf(p, e, NULL);
+            cp = utf8_to_uv_or_die(p, e, NULL);
             if (! _invlist_contains_cp(PL_CCC_non0_non230, cp)) {
                 break;
             }


### PR DESCRIPTION

* This set of changes does not require a perldelta entry.
