### PR TITLE
perl.h: Use utf8_to-uv_or_die not utf8_to_uvchr_buf

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -7557,13 +7557,12 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
 #    define _CHECK_AND_OUTPUT_WIDE_LOCALE_UTF8_MSG(s, send)                 \
         STMT_START { /* Check if to warn before doing the conversion work */\
             if (! IN_UTF8_CTYPE_LOCALE && ckWARN(WARN_LOCALE)) {            \
-                UV cp = utf8_to_uvchr_buf((U8 *) (s), (U8 *) (send), NULL); \
+                UV cp = utf8_to_uv_or_die((const U8 *) (s),                 \
+                                          (const U8 *) (send),              \
+                                          NULL);                            \
                 Perl_warner(aTHX_ packWARN(WARN_LOCALE),                    \
-                    "Wide character (U+%" UVXf ") in %s",                   \
-                    (cp == 0)                                               \
-                     ? UNICODE_REPLACEMENT                                  \
-                     : (UV) cp,                                             \
-                    OP_DESC(PL_op));                                        \
+                        "Wide character (U+%" UVXf ") in %s",               \
+                        (UV) cp, OP_DESC(PL_op));                           \
             }                                                               \
         }  STMT_END
 


### PR DESCRIPTION
This is in the _CHECK_AND_OUTPUT_WIDE_LOCALE_UTF8_MSG macro.

That macro had some complexity due to the unwieldy API of `utf8_to_uvchr_buf`, which can now be removed.


* This set of changes does not require a perldelta entry.
