### PR TITLE
{regcomp,regexec}*.c: consistently use C99 spelling of true/false

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -401,7 +401,7 @@ Perl_current_re_engine(pTHX)
 
         if (!table || !(PL_hints & HINT_LOCALIZE_HH))
             return &PL_core_reg_engine;
-        ptr = hv_fetchs(table, "regcomp", FALSE);
+        ptr = hv_fetchs(table, "regcomp", false);
         if ( !(ptr && SvIOK(*ptr) && SvIV(*ptr)))
             return &PL_core_reg_engine;
         return INT2PTR(regexp_engine*, SvIV(*ptr));
@@ -619,15 +619,15 @@ S_concat_pat(pTHX_ RExC_state_t * const pRExC_state,
                 OP *oplist, bool *recompile_p, SV *delim)
 {
     SV **svp;
-    bool use_delim = FALSE;
-    bool alloced = FALSE;
+    bool use_delim = false;
+    bool alloced = false;
 
     /* if we know we have at least two args, create an empty string,
      * then concatenate args to that. For no args, return an empty string */
     if (!pat && pat_count != 1) {
         pat = newSVpvs("");
         SAVEFREESV(pat);
-        alloced = TRUE;
+        alloced = true;
     }
 
     for (svp = patternp; svp < patternp + pat_count; svp++) {
@@ -643,10 +643,10 @@ S_concat_pat(pTHX_ RExC_state_t * const pRExC_state,
          * time round */
         if (use_delim) {
             svp--;
-            use_delim = FALSE;
+            use_delim = false;
         }
         else if (delim)
-            use_delim = TRUE;
+            use_delim = true;
 
         if (SvTYPE(msv) == SVt_PVAV) {
             /* we've encountered an interpolated array within
@@ -670,7 +670,7 @@ S_concat_pat(pTHX_ RExC_state_t * const pRExC_state,
                 Newx(array, maxarg, SV*);
                 SAVEFREEPV(array);
                 for (i = 0; i < maxarg; i++) {
-                    SV ** const svp = av_fetch(av, i, FALSE);
+                    SV ** const svp = av_fetch(av, i, false);
                     array[i] = svp ? *svp : &PL_sv_undef;
                 }
             }
@@ -918,7 +918,7 @@ S_has_runtime_code(pTHX_ RExC_state_t * const pRExC_state,
  * and merge them with any code blocks of the original regexp.
  *
  * If the pat is non-UTF8, while the evalled qr is UTF8, don't merge;
- * instead, just save the qr and return FALSE; this tells our caller that
+ * instead, just save the qr and return false; this tells our caller that
  * the original pattern needs upgrading to utf8.
  */
 
@@ -1139,7 +1139,7 @@ S_setup_longest(pTHX_ RExC_state_t *pRExC_state,
             /* See comments for join_exact for why REG_UNFOLDED_MULTI_SEEN */
         || (RExC_seen & REG_UNFOLDED_MULTI_SEEN))
     {
-        return FALSE;
+        return false;
     }
 
     /* copy the information about the longest from the reg_scan_data
@@ -1168,7 +1168,7 @@ S_setup_longest(pTHX_ RExC_state_t *pRExC_state,
          && (! meol || (RExC_flags & RXf_PMf_MULTILINE)));
     fbm_compile(sub->str, t ? FBMcf_TAIL : 0);
 
-    return TRUE;
+    return true;
 }
 
 STATIC void
@@ -1310,7 +1310,7 @@ S_is_ssc_worth_it(const RExC_state_t * pRExC_state, const regnode_ssc * ssc)
      * having the overhead of using it.  This function uses some very crude
      * heuristics to decide if to use the ssc or not.
      *
-     * It returns TRUE if 'ssc' rules out more than half what it considers to
+     * It returns true if 'ssc' rules out more than half what it considers to
      * be the "likely" possible matches, but of course it doesn't know what the
      * actual things being matched are going to be; these are only guesses
      *
@@ -1349,11 +1349,11 @@ S_is_ssc_worth_it(const RExC_state_t * pRExC_state, const regnode_ssc * ssc)
         count += end - start + 1;
         if (count >= max_match) {
             invlist_iterfinish(ssc->invlist);
-            return FALSE;
+            return false;
         }
     }
 
-    return TRUE;
+    return true;
 }
 
 static void
@@ -1488,7 +1488,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
     });
 
     if (is_bare_re)
-        *is_bare_re = FALSE;
+        *is_bare_re = false;
 
     if (expr && (expr->op_type == OP_LIST ||
                 (expr->op_type == OP_NULL && expr->op_targ == OP_LIST))) {
@@ -1566,7 +1566,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
             re = SvRV(re);
         if (SvTYPE(re) == SVt_REGEXP) {
             if (is_bare_re)
-                *is_bare_re = TRUE;
+                *is_bare_re = true;
             SvREFCNT_inc(re);
             DEBUG_PARSE_r(Perl_re_printf( aTHX_
                 "Precompiled pattern%s\n",
@@ -2131,7 +2131,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
             &data, -1, 0, NULL,
             SCF_DO_SUBSTR | SCF_WHILEM_VISITED_POS | stclass_flag
                           | (restudied ? SCF_TRIE_DOING_RESTUDY : 0),
-            0, TRUE);
+            0, true);
         /* search for "restudy" in this file for a detailed explanation
          * of 'restudied' and SCF_TRIE_DOING_RESTUDY */
 
@@ -2264,7 +2264,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
             SCF_DO_STCLASS_AND|SCF_WHILEM_VISITED_POS|(restudied
                                                       ? SCF_TRIE_DOING_RESTUDY
                                                       : 0),
-            0, TRUE);
+            0, true);
         /* search for "restudy" in this file for a detailed explanation
          * of 'restudied' and SCF_TRIE_DOING_RESTUDY */
 
@@ -2619,7 +2619,7 @@ S_parse_lparen_question_flags(pTHX_ RExC_state_t *pRExC_state)
     U32 *flagsp = &posflags;
     char has_charset_modifier = '\0';
     regex_charset cs;
-    bool has_use_defaults = FALSE;
+    bool has_use_defaults = false;
     const char* const seqstart = RExC_parse - 1; /* Point to the '?' */
     int x_mod_count = 0;
 
@@ -2628,7 +2628,7 @@ S_parse_lparen_question_flags(pTHX_ RExC_state_t *pRExC_state)
     /* '^' as an initial flag sets certain defaults */
     if (UCHARAT(RExC_parse) == '^') {
         RExC_parse_inc_by(1);
-        has_use_defaults = TRUE;
+        has_use_defaults = true;
         STD_PMMOD_FLAGS_CLEAR(&RExC_flags);
         cs = (toUSE_UNI_CHARSET_NOT_DEPENDS)
              ? REGEX_UNICODE_CHARSET
@@ -2948,7 +2948,7 @@ S_reg_la_NOTHING(pTHX_ RExC_state_t *pRExC_state, U32 flags,
     PERL_ARGS_ASSERT_REG_LA_NOTHING;
 
     /* false below so we do not force /x */
-    skip_to_be_ignored_text(pRExC_state, &RExC_parse, FALSE);
+    skip_to_be_ignored_text(pRExC_state, &RExC_parse, false);
 
     if (RExC_parse >= RExC_end)
         vFAIL2("Sequence (%s... not terminated", type);
@@ -2996,8 +2996,8 @@ S_reg_la_OPFAIL(pTHX_ RExC_state_t *pRExC_state, U32 flags,
 
     PERL_ARGS_ASSERT_REG_LA_OPFAIL;
 
-    /* FALSE so we don't force to /x below */;
-    skip_to_be_ignored_text(pRExC_state, &RExC_parse, FALSE);
+    /* false so we don't force to /x below */;
+    skip_to_be_ignored_text(pRExC_state, &RExC_parse, false);
 
     if (RExC_parse >= RExC_end)
         vFAIL2("Sequence (%s... not terminated", type);
@@ -3161,7 +3161,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
             unsigned char op = 0;
             int arg_required = 0;
             int internal_argval = -1; /* if > -1 no argument allowed */
-            bool has_upper = FALSE;
+            bool has_upper = false;
             U32 seen_flag_set = 0; /* RExC_seen flags we must set */
 
             if (has_intervening_patws) {
@@ -3183,7 +3183,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                 }
                 else if (! UTF) {
                     if (isUPPER(*RExC_parse)) {
-                        has_upper = TRUE;
+                        has_upper = true;
                     }
                     RExC_parse_inc_by(1);
                 }
@@ -3692,12 +3692,12 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                 RExC_parse_set((char *) seqstart + 1);  /* Point to the digit */
               parse_recursion:
                 {
-                    bool is_neg = FALSE;
+                    bool is_neg = false;
                     UV unum;
                     segment_parse_start = RExC_parse - 1;
                     if (*RExC_parse == '-') {
                         RExC_parse_inc_by(1);
-                        is_neg = TRUE;
+                        is_neg = true;
                     }
                     endptr = RExC_end;
                     if (grok_atoUV(RExC_parse, &unum, &endptr)
@@ -4021,7 +4021,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                         RExC_parse_set((char*)endptr);
                     }
                     else {
-                        vFAIL("panic: grok_atoUV returned FALSE");
+                        vFAIL("panic: grok_atoUV returned false");
                     }
                     ret = reg1node(pRExC_state, GROUPP, parno);
 
@@ -4559,7 +4559,7 @@ S_regbranch(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, I32 first, U32 depth)
     *flagp = 0;			/* Initialize. */
 
     skip_to_be_ignored_text(pRExC_state, &RExC_parse,
-                            FALSE /* Don't force to /x */ );
+                            false /* Don't force to /x */ );
     while (RExC_parse < RExC_end && *RExC_parse != '|' && *RExC_parse != ')') {
         flags &= ~TRYAGAIN;
         latest = regpiece(pRExC_state, &flags, depth+1);
@@ -4613,7 +4613,7 @@ Perl_regcurly(const char *s, const char *e, const char * result[5])
      * {m,n} quantifier.
      *
      * When called with a non-NULL final parameter, and when the function
-     * returns TRUE, it additionally stores information into the array
+     * returns true, it additionally stores information into the array
      * specified by that parameter about what it found in the parse.  The
      * parameter must be a pointer into a 5 element array of 'const char *'
      * elements.  The returned information is as follows:
@@ -4644,12 +4644,12 @@ Perl_regcurly(const char *s, const char *e, const char * result[5])
     const char * min_end = NULL;
     const char * max_end = NULL;
 
-    bool has_comma = FALSE;
+    bool has_comma = false;
 
     PERL_ARGS_ASSERT_REGCURLY;
 
     if (s >= e || *s++ != '{')
-        return FALSE;
+        return false;
 
     while (s < e && isBLANK(*s)) {
         s++;
@@ -4668,7 +4668,7 @@ Perl_regcurly(const char *s, const char *e, const char * result[5])
     }
 
     if (*s == ',') {
-        has_comma = TRUE;
+        has_comma = true;
         s++;
 
         while (s < e && isBLANK(*s)) {
@@ -4689,7 +4689,7 @@ Perl_regcurly(const char *s, const char *e, const char * result[5])
     }
                                /* Need at least one number */
     if (s >= e || *s != '}' || (! min_start && ! max_end)) {
-        return FALSE;
+        return false;
     }
 
     if (result) {
@@ -4717,7 +4717,7 @@ Perl_regcurly(const char *s, const char *e, const char * result[5])
         }
     }
 
-    return TRUE;
+    return true;
 }
 #endif
 
@@ -5049,11 +5049,11 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
   *
   * If <code_point_p> is not NULL, the context is expecting the result to be a
   * single code point.  If this \N instance turns out to a single code point,
-  * the function returns TRUE and sets *code_point_p to that code point.
+  * the function returns true and sets *code_point_p to that code point.
   *
   * If <node_p> is not NULL, the context is expecting the result to be one of
   * the things representable by a regnode.  If this \N instance turns out to be
-  * one such, the function generates the regnode, returns TRUE and sets *node_p
+  * one such, the function generates the regnode, returns true and sets *node_p
   * to point to the offset of that regnode into the regex engine program being
   * compiled.
   *
@@ -5066,12 +5066,12 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
   * *flagp has been updated as needed.
   *
   * When there is some problem with the current context and this \N instance,
-  * the function returns FALSE, without advancing RExC_parse, nor setting
+  * the function returns false, without advancing RExC_parse, nor setting
   * *node_p, nor *code_point_p, nor *flagp.
   *
   * If <cp_count> is not NULL, the caller wants to know the length (in code
   * points) that this \N sequence matches.  This is set, and the input is
-  * parsed for errors, even if the function returns FALSE, as detailed below.
+  * parsed for errors, even if the function returns false, as detailed below.
   *
   * There are 6 possibilities here, as detailed in the next 6 paragraphs.
   *
@@ -5099,7 +5099,7 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
   * changes from /d to /u rules, or when the pattern needs to be upgraded to
   * UTF-8.  The latter occurs only when the fifth possibility would otherwise
   * be in effect, and is because one of those code points requires the pattern
-  * to be recompiled as UTF-8.  The function returns FALSE, and sets the
+  * to be recompiled as UTF-8.  The function returns false, and sets the
   * RESTART_PARSE and NEED_UTF8 flags in *flagp, as appropriate.  When this
   * happens, the caller needs to desist from continuing parsing, and return
   * this information to its caller.  This is not set for when there is only one
@@ -5145,7 +5145,7 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
      * within the braces), so use a temporary until we find out which we are
      * being called with */
     skip_to_be_ignored_text(pRExC_state, &p,
-                            FALSE /* Don't force to /x */ );
+                            false /* Don't force to /x */ );
 
     /* Disambiguate between \N meaning a named character versus \N meaning
      * [^\n].  The latter is assumed when the {...} following the \N is a legal
@@ -5157,13 +5157,13 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
         }
 
         if (! node_p) {
-            return FALSE;
+            return false;
         }
 
         *node_p = reg_node(pRExC_state, REG_ANY);
         *flagp |= HASWIDTH|SIMPLE;
         MARK_NAUGHTY(1);
-        return TRUE;
+        return true;
     }
 
     /* The test above made sure that the next real character is a '{', but
@@ -5183,7 +5183,7 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
 
     /* Here, we have decided it should be a named character or sequence.  These
      * imply Unicode semantics */
-    REQUIRE_UNI_RULES(flagp, FALSE);
+    REQUIRE_UNI_RULES(flagp, false);
 
     /* \N{_} is what toke.c returns to us to indicate a name that evaluates to
      * nothing at all (not allowed under strict) */
@@ -5199,11 +5199,11 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
         }
         nextchar(pRExC_state);
         if (! node_p) {
-            return FALSE;
+            return false;
         }
 
         *node_p = reg_node(pRExC_state, NOTHING);
-        return TRUE;
+        return true;
     }
 
     while (isBLANK(*RExC_parse)) {
@@ -5277,7 +5277,7 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
              * fail */
             if (! code_point_p) {
                 RExC_parse_set(p);
-                return FALSE;
+                return false;
             }
 
             /* Convert from string to numeric code point */
@@ -5289,11 +5289,11 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
              * has already been set to 1, so don't do it again. */
             RExC_parse_set(endbrace);
             nextchar(pRExC_state);
-            return TRUE;
+            return true;
         } /* End of is a single code point */
 
         /* Count the code points, if caller desires.  The API says to do this
-         * even if we will later return FALSE */
+         * even if we will later return false */
         if (cp_count) {
             *cp_count = 0;
 
@@ -5310,7 +5310,7 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
             if (! cp_count) {
                 RExC_parse_set(p);
             }
-            return FALSE;
+            return false;
         }
 
         /* Convert this to a sub-pattern of the form "(?: ... )", and then call
@@ -5370,14 +5370,14 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
                 /* Here, is a single code point; fail if doesn't want that */
                 if (! code_point_p) {
                     RExC_parse_set(p);
-                    return FALSE;
+                    return false;
                 }
 
                 /* A single code point is easy to handle; just return it */
                 *code_point_p = UNI_TO_NATIVE(cp);
                 RExC_parse_set(endbrace);
                 nextchar(pRExC_state);
-                return TRUE;
+                return true;
             }
 
             /* Here, the parse stopped bfore the ending brace.  This is legal
@@ -5399,7 +5399,7 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
              * if that's not what the caller wants.  But continue with counting
              * and error checking if they still want a count */
             if (! node_p && ! cp_count) {
-                return FALSE;
+                return false;
             }
 
             /* What is done here is to convert this to a sub-pattern of the
@@ -5435,7 +5435,7 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
             assert (cp_count);
 
             *cp_count = count;
-            return FALSE;
+            return false;
         }
 
         sv_catpvs(substitute_parse, ")");
@@ -5481,7 +5481,7 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
 
     nextchar(pRExC_state);
 
-    return TRUE;
+    return true;
 }
 
 
@@ -5648,11 +5648,11 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
     {
         char * const cc_parse_start = ++RExC_parse;
         ret = regclass(pRExC_state, flagp, depth+1,
-                       FALSE, /* means parse the whole char class */
-                       TRUE, /* allow multi-char folds */
-                       FALSE, /* don't silence non-portable warnings. */
+                       false, /* means parse the whole char class */
+                       true, /* allow multi-char folds */
+                       false, /* don't silence non-portable warnings. */
                        (bool) RExC_strict,
-                       TRUE, /* Allow an optimized regnode result */
+                       true, /* Allow an optimized regnode result */
                        NULL);
         if (ret == 0) {
             RETURN_FAIL_ON_RESTART_FLAGP(flagp);
@@ -5887,7 +5887,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
             }
 
             if (op == BOUND) {
-                RExC_seen_d_op = TRUE;
+                RExC_seen_d_op = true;
             }
             else if (op == BOUNDL) {
                 RExC_contains_locale = 1;
@@ -5926,13 +5926,13 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
             RExC_parse--;
 
             ret = regclass(pRExC_state, flagp, depth+1,
-                           TRUE, /* means just parse this element */
-                           FALSE, /* don't allow multi-char folds */
-                           FALSE, /* don't silence non-portable warnings.  It
+                           true, /* means just parse this element */
+                           false, /* don't allow multi-char folds */
+                           false, /* don't silence non-portable warnings.  It
                                      would be a bug if these returned
                                      non-portables */
                            (bool) RExC_strict,
-                           TRUE, /* Allow an optimized regnode result */
+                           true, /* Allow an optimized regnode result */
                            NULL);
             RETURN_FAIL_ON_RESTART_FLAGP(flagp);
             /* regclass() can only return RESTART_PARSE and NEED_UTF8 if
@@ -6028,7 +6028,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                 char * e = RExC_end;
 
                 if (*s == 'g') {
-                    bool isrel = FALSE;
+                    bool isrel = false;
 
                     s++;
                     if (*s == '{') {
@@ -6074,7 +6074,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                      * surrounding braces */
 
                     if (*s == '-') {
-                        isrel = TRUE;
+                        isrel = true;
                         s++;
                     }
 
@@ -6214,12 +6214,12 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                 if (RExC_nestroot && num >= RExC_nestroot)
                     FLAGS(REGNODE_p(ret)) = VOLATILE_REF;
                 if (OP(REGNODE_p(ret)) == REFF) {
-                    RExC_seen_d_op = TRUE;
+                    RExC_seen_d_op = true;
                 }
                 *flagp |= HASWIDTH;
 
                 skip_to_be_ignored_text(pRExC_state, &RExC_parse,
-                                        FALSE /* Don't force to /x */ );
+                                        false /* Don't force to /x */ );
             }
             break;
         case '\0':
@@ -6315,13 +6315,13 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
 
             /* Does this node contain something that can't match unless the
              * target string is (also) in UTF-8 */
-            bool requires_utf8_target = FALSE;
+            bool requires_utf8_target = false;
 
             /* The sequence 'ss' is problematic in non-UTF-8 patterns. */
-            bool has_ss = FALSE;
+            bool has_ss = false;
 
             /* So is the MICRO SIGN */
-            bool has_micro_sign = FALSE;
+            bool has_micro_sign = false;
 
             /* Set when we fill up the current node and there is still more
              * text to process */
@@ -6347,9 +6347,9 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
             oldp = NULL;
             maybe_exactfu = FOLD && (DEPENDS_SEMANTICS || LOC);
             maybe_SIMPLE = SIMPLE;
-            requires_utf8_target = FALSE;
-            has_ss = FALSE;
-            has_micro_sign = FALSE;
+            requires_utf8_target = false;
+            has_ss = false;
+            has_micro_sign = false;
 
           continue_parse:
 
@@ -6367,7 +6367,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                    || UTF8_IS_INVARIANT(UCHARAT(RExC_parse))
                    || UTF8_IS_START(UCHARAT(RExC_parse)));
 
-            overflowed = FALSE;
+            overflowed = false;
 
             /* Here, we have a literal character.  Find the maximal string of
              * them in the input that we can fit into a single EXACTish node.
@@ -6515,7 +6515,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                                             &message,
                                             &packed_warn,
                                             (bool) RExC_strict,
-                                            FALSE, /* No illegal cp's */
+                                            false, /* No illegal cp's */
                                             UTF))
                         {
                             RExC_parse_set(p); /* going to die anyway; point to
@@ -6534,7 +6534,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                                             &message,
                                             &packed_warn,
                                             (bool) RExC_strict,
-                                            FALSE, /* No illegal cp's */
+                                            false, /* No illegal cp's */
                                             UTF))
                         {
                             RExC_parse_set(p);        /* going to die anyway; point
@@ -6621,7 +6621,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                                 reg_warn_non_literal_string(
                                      p + 1,
                                      form_alien_digit_msg(8, numlen, p,
-                                                        RExC_end, UTF, FALSE));
+                                                        RExC_end, UTF, false));
                             }
                         }
                         break;
@@ -6712,7 +6712,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                  * ignored, which, as a side effect, positions <p> for the next
                  * loop iteration */
                 skip_to_be_ignored_text(pRExC_state, &p,
-                                        FALSE /* Don't force to /x */ );
+                                        false /* Don't force to /x */ );
 
                 /* If the next thing is a quantifier, it applies to this
                  * character only, which means that this character has to be in
@@ -6740,7 +6740,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                                                       ? UVCHR_SKIP(ender)
                                                       : 1)))
                     {
-                        overflowed = TRUE;
+                        overflowed = true;
                         break;
                     }
 
@@ -6753,7 +6753,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                         s = (char *) new_s;
 
                         if (ender > 255)  {
-                            requires_utf8_target = TRUE;
+                            requires_utf8_target = true;
                         }
                     }
                 }
@@ -6775,7 +6775,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
 
                     /* This problematic code point means we can't simplify
                      * things */
-                    maybe_exactfu = FALSE;
+                    maybe_exactfu = false;
 
                     /* Although these two characters have folds that are
                      * locale-problematic, they also have folds to above Latin1
@@ -6833,7 +6833,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                                    patterns */
                         if (UVCHR_IS_INVARIANT(ender)) {
                             if (UNLIKELY(len + 1 > max_string_len)) {
-                                overflowed = TRUE;
+                                overflowed = true;
                                 break;
                             }
 
@@ -6855,7 +6855,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                                     ? FOLD_FLAGS_NOMIX_ASCII
                                     : 0));
                             if (UNLIKELY(len + added_len > max_string_len)) {
-                                overflowed = TRUE;
+                                overflowed = true;
                                 break;
                             }
 
@@ -6866,7 +6866,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                             {
                                 /* U+B5 folds to the MU, so its possible for a
                                  * non-UTF-8 target to match it */
-                                requires_utf8_target = TRUE;
+                                requires_utf8_target = true;
                             }
                         }
                     }
@@ -6880,7 +6880,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                          * the two character fold, we check again, before
                          * setting any flags) */
                         if (UNLIKELY(len + 1 > max_string_len)) {
-                            overflowed = TRUE;
+                            overflowed = true;
                             break;
                         }
 
@@ -6897,16 +6897,16 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                              * than a single char).  And in some cases it will
                              * match 'ss', so set that flag */
                             maybe_SIMPLE = 0;
-                            has_ss = TRUE;
+                            has_ss = true;
 
                             /* It can't change to be an EXACTFU (unless already
                              * is one).  We fold it iff under /u rules. */
                             if (node_type != EXACTFU) {
-                                maybe_exactfu = FALSE;
+                                maybe_exactfu = false;
                             }
                             else {
                                 if (UNLIKELY(len + 2 > max_string_len)) {
-                                    overflowed = TRUE;
+                                    overflowed = true;
                                     break;
                                 }
 
@@ -6926,20 +6926,20 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                              * should match SHARP S; otherwise it won't.  So,
                              * here we have to exclude the possibility of this
                              * node moving to /u.*/
-                            has_ss = TRUE;
-                            maybe_exactfu = FALSE;
+                            has_ss = true;
+                            maybe_exactfu = false;
                         }
 #endif
                         /* Here, the fold will be a single character */
 
                         if (UNLIKELY(ender == MICRO_SIGN)) {
-                            has_micro_sign = TRUE;
+                            has_micro_sign = true;
                         }
                         else if (PL_fold[ender] != PL_fold_latin1[ender]) {
 
                             /* If the character's fold differs between /d and
                              * /u, this can't change to be an EXACTFU node */
-                            maybe_exactfu = FALSE;
+                            maybe_exactfu = false;
                         }
 
                         *(s++) = (DEPENDS_SEMANTICS)
@@ -7046,8 +7046,8 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                 goto continue_parse;
             }
             else if (FOLD) {
-                bool splittable = FALSE;
-                bool backed_up = FALSE;
+                bool splittable = false;
+                bool backed_up = false;
                 char * e;       /* should this be U8? */
                 char * s_start; /* should this be U8? */
 
@@ -7292,7 +7292,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                         if (isPUNCT(*p)) {
                             s = (char *) utf8_hop_back((U8 *) s, -1,
                                        (U8 *) s_start);
-                            backed_up = TRUE;
+                            backed_up = true;
                         }
                         else {
                             /* Here, since it's not punctuation, it must be a
@@ -7329,7 +7329,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                          * one char and try again */
                         if (UNLIKELY(is_MULTI_CHAR_FOLD_utf8_safe(s, e))) {
                             s = prev_s;
-                            backed_up = TRUE;
+                            backed_up = true;
                             continue;
                         }
 
@@ -7342,13 +7342,13 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                         {
                             s = prev_s;
                             s = (char *) utf8_hop_back((U8 *) s, -1, (U8 *) s_start);
-                            backed_up = TRUE;
+                            backed_up = true;
                             continue;
                         }
 
                         /* Here there's no multi-char fold between s and the
                          * next character following it.  We can split */
-                        splittable = TRUE;
+                        splittable = true;
                         break;
 
                     } while (s > s_start); /* End of loops backing up through the node */
@@ -7379,7 +7379,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                     {
                         if (isPUNCT(*p)) {
                             s--;
-                            backed_up = TRUE;
+                            backed_up = true;
                         }
                         else {
                             if (   UCHARAT(p) != LATIN_SMALL_LETTER_SHARP_S
@@ -7398,7 +7398,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                     do {
                         if (UNLIKELY(is_MULTI_CHAR_FOLD_latin1_safe(s, e))) {
                             s--;
-                            backed_up = TRUE;
+                            backed_up = true;
                             continue;
                         }
 
@@ -7406,11 +7406,11 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                             && UNLIKELY(is_THREE_CHAR_FOLD_latin1_safe(s - 1, e)))
                         {
                             s -= 2;
-                            backed_up = TRUE;
+                            backed_up = true;
                             continue;
                         }
 
-                        splittable = TRUE;
+                        splittable = true;
                         break;
 
                     } while (s > s_start);
@@ -7539,7 +7539,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                          * of the target string, so it can become an EXACTFU
                          * node */
                         if (! maybe_exactfu) {
-                            RExC_seen_d_op = TRUE;
+                            RExC_seen_d_op = true;
                         }
                         else if (   isALPHA_FOLD_EQ(first_char, 's')
                                  || isALPHA_FOLD_EQ(ender, 's'))
@@ -7592,7 +7592,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
 
     /* Position parse to next real character */
     skip_to_be_ignored_text(pRExC_state, &RExC_parse,
-                                            FALSE /* Don't force to /x */ );
+                                            false /* Don't force to /x */ );
     if (   *RExC_parse == '{'
         && OP(REGNODE_p(ret)) != SBOL && ! regcurly(RExC_parse, RExC_end, NULL))
     {
@@ -7628,7 +7628,7 @@ Perl_populate_anyof_bitmap_from_invlist(pTHX_ regnode *node, SV** invlist_ptr)
     if (*invlist_ptr) {
 
         /* This gets set if we actually need to modify things */
-        bool change_invlist = FALSE;
+        bool change_invlist = false;
 
         UV start, end;
 
@@ -7643,7 +7643,7 @@ Perl_populate_anyof_bitmap_from_invlist(pTHX_ regnode *node, SV** invlist_ptr)
                 break;
             }
 
-            change_invlist = TRUE;
+            change_invlist = true;
 
             /* Set all the bits in the range, up to the max that we are doing */
             high = (end < NUM_ANYOF_CODE_POINTS - 1)
@@ -7750,7 +7750,7 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
      *      raised.
      *
      * In b) there may be errors or warnings generated.  If 'check_only' is
-     * TRUE, then any errors are discarded.  Warnings are returned to the
+     * true, then any errors are discarded.  Warnings are returned to the
      * caller via an AV* created into '*posix_warnings' if it is not NULL.  If
      * instead it is NULL, warnings are suppressed.
      *
@@ -7820,9 +7820,9 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
     const char* p             = s;
     const char * const e      = RExC_end;
     unsigned complement       = 0;      /* If to complement the class */
-    bool found_problem        = FALSE;  /* Assume OK until proven otherwise */
-    bool has_opening_bracket  = FALSE;
-    bool has_opening_colon    = FALSE;
+    bool found_problem        = false;  /* Assume OK until proven otherwise */
+    bool has_opening_bracket  = false;
+    bool has_opening_colon    = false;
     int class_number          = OOB_NAMEDCLASS; /* Out-of-bounds until find
                                                    valid class */
     const char * possible_end = NULL;   /* used for a 2nd parse pass */
@@ -7849,16 +7849,16 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
 
     if (*(p - 1) != '[') {
         ADD_POSIX_WARNING(p, "it doesn't start with a '['");
-        found_problem = TRUE;
+        found_problem = true;
     }
     else {
-        has_opening_bracket = TRUE;
+        has_opening_bracket = true;
     }
 
     /* They could be confused and think you can put spaces between the
      * components */
     if (isBLANK(*p)) {
-        found_problem = TRUE;
+        found_problem = true;
 
         do {
             p++;
@@ -7947,13 +7947,13 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
      * we have the first real character.  It could be they think the '^' comes
      * first */
     if (*p == '^') {
-        found_problem = TRUE;
+        found_problem = true;
         ADD_POSIX_WARNING(p + 1, "the '^' must come after the colon");
         complement = 1;
         p++;
 
         if (isBLANK(*p)) {
-            found_problem = TRUE;
+            found_problem = true;
 
             do {
                 p++;
@@ -7968,16 +7968,16 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
      * distinguish from a colon, so treat that as a colon).  */
     if (*p == ':') {
         p++;
-        has_opening_colon = TRUE;
+        has_opening_colon = true;
     }
     else if (*p == ';') {
-        found_problem = TRUE;
+        found_problem = true;
         p++;
         ADD_POSIX_WARNING(p, SEMI_COLON_POSIX_WARNING);
-        has_opening_colon = TRUE;
+        has_opening_colon = true;
     }
     else {
-        found_problem = TRUE;
+        found_problem = true;
         ADD_POSIX_WARNING(p, "there must be a starting ':'");
 
         /* Consider an initial punctuation (not one of the recognized ones) to
@@ -7989,7 +7989,7 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
 
     /* They may think that you can put spaces between the components */
     if (isBLANK(*p)) {
-        found_problem = TRUE;
+        found_problem = true;
 
         do {
             p++;
@@ -8012,7 +8012,7 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
 
     /* Again, they may think that you can put spaces between the components */
     if (isBLANK(*p)) {
-        found_problem = TRUE;
+        found_problem = true;
 
         do {
             p++;
@@ -8039,7 +8039,7 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
         p--;
 
         if (*p == ';') {
-            found_problem = TRUE;
+            found_problem = true;
             ADD_POSIX_WARNING(p, SEMI_COLON_POSIX_WARNING);
         }
         else if (*p != ':') {
@@ -8053,7 +8053,7 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
         /* Here we have something like 'foo:]'.  There was no initial colon,
          * and we back up over 'foo.  XXX Unlike the going forward case, we
          * don't handle typos of non-word chars in the middle */
-        has_opening_colon = FALSE;
+        has_opening_colon = false;
         p--;
 
         while (p > RExC_start && isWORDCHAR(*p)) {
@@ -8091,11 +8091,11 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
     name_start = p;
   parse_name:
     {
-        bool has_blank               = FALSE;
-        bool has_upper               = FALSE;
-        bool has_terminating_colon   = FALSE;
-        bool has_terminating_bracket = FALSE;
-        bool has_semi_colon          = FALSE;
+        bool has_blank               = false;
+        bool has_upper               = false;
+        bool has_terminating_colon   = false;
+        bool has_terminating_bracket = false;
+        bool has_semi_colon          = false;
         unsigned int name_len        = 0;
         int punct_count              = 0;
 
@@ -8103,8 +8103,8 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
 
             /* Squeeze out blanks when looking up the class name below */
             if (isBLANK(*p) ) {
-                has_blank = TRUE;
-                found_problem = TRUE;
+                has_blank = true;
+                found_problem = true;
                 p++;
                 continue;
             }
@@ -8121,24 +8121,24 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
                  * loop at the bottom (eventually), so skip it here. */
                 if (*p != ']') {
                     if (peek < e && isBLANK(*peek)) {
-                        has_blank = TRUE;
-                        found_problem = TRUE;
+                        has_blank = true;
+                        found_problem = true;
                         do {
                             peek++;
                         } while (peek < e && isBLANK(*peek));
                     }
 
                     if (peek < e && *peek == ']') {
-                        has_terminating_bracket = TRUE;
+                        has_terminating_bracket = true;
                         if (*p == ':') {
-                            has_terminating_colon = TRUE;
+                            has_terminating_colon = true;
                         }
                         else if (*p == ';') {
-                            has_semi_colon = TRUE;
-                            has_terminating_colon = TRUE;
+                            has_semi_colon = true;
+                            has_terminating_colon = true;
                         }
                         else {
-                            found_problem = TRUE;
+                            found_problem = true;
                         }
                         p = peek + 1;
                         goto try_posix;
@@ -8170,8 +8170,8 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
             }
             else if (isUPPER(*p)) { /* Use lowercase for lookup */
                 input_text[name_len++] = toLOWER(*p);
-                has_upper = TRUE;
-                found_problem = TRUE;
+                has_upper = true;
+                found_problem = true;
                 p++;
             } else if (! UTF || UTF8_IS_INVARIANT(*p)) {
                 input_text[name_len++] = *p;
@@ -8200,7 +8200,7 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
          *   4) we decided it was more characters than anyone could have
          *      intended to be one. */
 
-        found_problem = TRUE;
+        found_problem = true;
 
         /* In the final two cases, we know that looking up what we've
          * accumulated won't lead to a match, even a fuzzy one. */
@@ -8230,7 +8230,7 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
 
         if (p < e && isPUNCT(*p)) {
             if (*p == ']') {
-                has_terminating_bracket = TRUE;
+                has_terminating_bracket = true;
 
                 /* If this is a 2nd ']', and the first one is just below this
                  * one, consider that to be the real terminator.  This gives a
@@ -8250,11 +8250,11 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
             }
             else {
                 if (*p == ':') {
-                    has_terminating_colon = TRUE;
+                    has_terminating_colon = true;
                 }
                 else if (*p == ';') {
-                    has_semi_colon = TRUE;
-                    has_terminating_colon = TRUE;
+                    has_semi_colon = true;
+                    has_terminating_colon = true;
                 }
                 p++;
             }
@@ -8648,7 +8648,7 @@ S_handle_regex_sets(pTHX_ RExC_state_t *pRExC_state, SV** return_invlist,
         SV* only_to_avoid_leaks;
 
         skip_to_be_ignored_text(pRExC_state, &RExC_parse,
-                                TRUE /* Force /x */ );
+                                true /* Force /x */ );
         if (RExC_parse >= RExC_end) {   /* Fail */
             break;
         }
@@ -8728,13 +8728,13 @@ redo_curchar:
                     /* If the top entry on the stack is an operator, it had
                      * better be a '!', otherwise the entry below the top
                      * operand should be an operator */
-                    if (   ! (top_ptr = av_fetch(stack, top_index, FALSE))
+                    if (   ! (top_ptr = av_fetch(stack, top_index, false))
                         || (IS_OPERATOR(*top_ptr) && SvUV(*top_ptr) != '!')
                         || (   IS_OPERAND(*top_ptr)
                             && (   top_index - fence < 1
                                 || ! (stacked_ptr = av_fetch(stack,
                                                              top_index - 1,
-                                                             FALSE))
+                                                             false))
                                 || ! IS_OPERATOR(*stacked_ptr))))
                     {
                         RExC_parse_inc_by(1);
@@ -8751,11 +8751,11 @@ redo_curchar:
                 /* regclass() can only return RESTART_PARSE and NEED_UTF8 if
                  * multi-char folds are allowed.  */
                 if (!regclass(pRExC_state, flagp, depth+1,
-                              TRUE, /* means parse just the next thing */
-                              FALSE, /* don't allow multi-char folds */
-                              FALSE, /* don't silence non-portable warnings.  */
-                              TRUE,  /* strict */
-                              FALSE, /* Require return to be an ANYOF */
+                              true, /* means parse just the next thing */
+                              false, /* don't allow multi-char folds */
+                              false, /* don't silence non-portable warnings.  */
+                              true,  /* strict */
+                              false, /* Require return to be an ANYOF */
                               &current))
                 {
                     RETURN_FAIL_ON_RESTART(*flagp, flagp);
@@ -8777,7 +8777,7 @@ redo_curchar:
                                                 RExC_parse + 1,
                                                 NULL,
                                                 NULL,
-                                                TRUE /* checking only */));
+                                                true /* checking only */));
                 /* If it is a posix class, leave the parse pointer at the '['
                  * to fool regclass() into thinking it is part of a
                  * '[[:posix:]]'. */
@@ -8791,10 +8791,10 @@ redo_curchar:
                                 is_posix_class, /* parse the whole char
                                                     class only if not a
                                                     posix class */
-                                FALSE, /* don't allow multi-char folds */
-                                TRUE, /* silence non-portable warnings. */
-                                TRUE, /* strict */
-                                FALSE, /* Require return to be an ANYOF */
+                                false, /* don't allow multi-char folds */
+                                true, /* silence non-portable warnings. */
+                                true, /* strict */
+                                false, /* Require return to be an ANYOF */
                                 &current))
                 {
                     RETURN_FAIL_ON_RESTART(*flagp, flagp);
@@ -8872,7 +8872,7 @@ redo_curchar:
                  * parsed */
                 if (   top_index - fence < 0
                     || top_index - fence == 1
-                    || ( ! (top_ptr = av_fetch(stack, top_index, FALSE)))
+                    || ( ! (top_ptr = av_fetch(stack, top_index, false)))
                     || ! IS_OPERAND(*top_ptr))
                 {
                     goto unexpected_binary;
@@ -8899,7 +8899,7 @@ redo_curchar:
 
                 /* The operator on the stack is supposed to be below both its
                  * operands */
-                if (   ! (stacked_ptr = av_fetch(stack, top_index - 2, FALSE))
+                if (   ! (stacked_ptr = av_fetch(stack, top_index - 2, false))
                     || IS_OPERAND(*stacked_ptr))
                 {
                     /* But if not, it's legal and indicates we are completely
@@ -8996,7 +8996,7 @@ redo_curchar:
 
                 /* If what's already at the top of the stack is another '!",
                  * they just cancel each other out */
-                if (   (top_ptr = av_fetch(stack, top_index, FALSE))
+                if (   (top_ptr = av_fetch(stack, top_index, false))
                     && (IS_OPERATOR(*top_ptr) && SvUV(*top_ptr) == '!'))
                 {
                     only_to_avoid_leaks = av_pop(stack);
@@ -9027,7 +9027,7 @@ redo_curchar:
                 /* If the top entry on the stack is an operator, it had better
                  * be a '!', otherwise the entry below the top operand should
                  * be an operator */
-                top_ptr = av_fetch(stack, top_index, FALSE);
+                top_ptr = av_fetch(stack, top_index, false);
                 assert(top_ptr);
                 if (IS_OPERATOR(*top_ptr)) {
 
@@ -9055,7 +9055,7 @@ redo_curchar:
                          || (top_index - fence > 0
                              && (! (stacked_ptr = av_fetch(stack,
                                                            top_index - 1,
-                                                           FALSE))
+                                                           false))
                                  || IS_OPERAND(*stacked_ptr))))
                 {
                     SvREFCNT_dec(current);
@@ -9142,12 +9142,12 @@ redo_curchar:
         /* regclass() can only return RESTART_PARSE and NEED_UTF8 if multi-char
          * folds are allowed.  */
         node = regclass(pRExC_state, flagp, depth+1,
-                        FALSE, /* means parse the whole char class */
-                        FALSE, /* don't allow multi-char folds */
-                        TRUE, /* silence non-portable warnings.  The above may
+                        false, /* means parse the whole char class */
+                        false, /* don't allow multi-char folds */
+                        true, /* silence non-portable warnings.  The above may
                                  very well have generated non-portable code
                                  points, but they're valid on this machine */
-                        FALSE, /* similarly, no need for strict */
+                        false, /* similarly, no need for strict */
 
                         /* We can optimize into something besides an ANYOF,
                          * except under /l, which needs to be ANYOF because of
@@ -9226,7 +9226,7 @@ S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state,
     else {
         PerlIO_printf(Perl_debug_log, "Stack: (fence:%d)\n", (int) fence);
         for (i = stack_top; i >= 0; i--) {
-            SV ** element_ptr = av_fetch(stack, i, FALSE);
+            SV ** element_ptr = av_fetch(stack, i, false);
             if (! element_ptr) {
             }
 
@@ -9247,7 +9247,7 @@ S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state,
     else {
         PerlIO_printf(Perl_debug_log, "Fence_stack: \n");
         for (i = fence_stack_top; i >= 0; i--) {
-            SV ** element_ptr = av_fetch_simple(fence_stack, i, FALSE);
+            SV ** element_ptr = av_fetch_simple(fence_stack, i, false);
             if (! element_ptr) {
             }
 
@@ -9432,7 +9432,7 @@ S_add_multi_match(pTHX_ AV* multi_char_matches, SV* multi_string, const STRLEN c
     }
 
     if (av_exists(multi_char_matches, cp_count)) {
-        this_array_ptr = (AV**) av_fetch_simple(multi_char_matches, cp_count, FALSE);
+        this_array_ptr = (AV**) av_fetch_simple(multi_char_matches, cp_count, false);
         this_array = *this_array_ptr;
     }
     else {
@@ -9574,8 +9574,8 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
     /* Is the range unicode? which means on a platform that isn't 1-1 native
      * to Unicode (i.e. non-ASCII), each code point in it should be considered
      * to be a Unicode value.  */
-    bool unicode_range = FALSE;
-    bool invert = FALSE;    /* Is this class to be complemented */
+    bool unicode_range = false;
+    bool invert = false;    /* Is this class to be complemented */
 
     bool warn_super = ALWAYS_WARN_SUPER;
 
@@ -9618,7 +9618,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
     /* If wants an inversion list returned, we can't optimize to something
      * else. */
     if (ret_invlist) {
-        optimizable = FALSE;
+        optimizable = false;
     }
 
     DEBUG_PARSE("clas");
@@ -9626,7 +9626,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
 #if UNICODE_MAJOR_VERSION < 3 /* no multifolds in early Unicode */      \
     || (UNICODE_MAJOR_VERSION == 3 && UNICODE_DOT_VERSION == 0          \
                                    && UNICODE_DOT_DOT_VERSION == 0)
-    allow_mutiple_chars = FALSE;
+    allow_mutiple_chars = false;
 #endif
 
     /* We include the /i status at the beginning of this so that we can
@@ -9641,8 +9641,8 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
 
     if (UCHARAT(RExC_parse) == '^') {	/* Complement the class */
         RExC_parse_inc_by(1);
-        invert = TRUE;
-        allow_mutiple_chars = FALSE;
+        invert = true;
+        allow_mutiple_chars = false;
         MARK_NAUGHTY(1);
         SKIP_BRACKETED_WHITE_SPACE(skip_white, RExC_parse, RExC_end);
     }
@@ -9653,7 +9653,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                                                 RExC_parse,
                                                 &not_posix_region_end,
                                                 NULL,
-                                                TRUE /* checking only */);
+                                                true /* checking only */);
         if (maybe_class >= OOB_NAMEDCLASS && do_posix_warnings) {
             ckWARN4reg(not_posix_region_end,
                     "POSIX syntax [%c %c] belongs inside character classes%s",
@@ -9729,7 +9729,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                                                RExC_parse,
                                                &posix_class_end,
                                                do_posix_warnings ? &posix_warnings : NULL,
-                                               FALSE    /* die if error */);
+                                               false    /* die if error */);
             if (namedclass > OOB_NAMEDCLASS) {
 
                 /* If there was an earlier attempt to parse this particular
@@ -9761,7 +9761,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                                             advanced */
                         &not_posix_region_end,
                         do_posix_warnings ? &posix_warnings : NULL,
-                        TRUE /* checking only */);
+                        true /* checking only */);
         }
         else if (  strict && ! skip_white
                  && (   generic_isCC_(value, CC_VERTSPACE_)
@@ -9875,7 +9875,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                     }
 
                     /* Here, is a single code point, and <value> contains it */
-                    unicode_range = TRUE;   /* \N{} are Unicode */
+                    unicode_range = true;   /* \N{} are Unicode */
                 }
                 break;
             case 'p':
@@ -9950,14 +9950,14 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                     /* Any message returned about expanding the definition */
                     SV* msg = newSVpvs_flags("", SVs_TEMP);
 
-                    /* If set TRUE, the property is user-defined as opposed to
+                    /* If set true, the property is user-defined as opposed to
                      * official Unicode */
-                    bool user_defined = FALSE;
+                    bool user_defined = false;
                     AV * strings = NULL;
 
                     SV * prop_definition = parse_uniprop_string(
                                             name, n, UTF, FOLD,
-                                            FALSE, /* This is compile-time */
+                                            false, /* This is compile-time */
 
                                             /* We can't defer this defn when
                                              * the full result is required in
@@ -9975,7 +9975,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                         if (SvUTF8(msg)) {  /* msg being UTF-8 makes the whole
                                                thing so, or else the display is
                                                mojibake */
-                            RExC_utf8 = TRUE;
+                            RExC_utf8 = true;
                         }
                         /* diag_listed_as: Can't find Unicode property definition "%s" in regex; marked by <-- HERE in m/%s/ */
                         vFAIL2utf8f("%" UTF8f, UTF8fARG(SvUTF8(msg),
@@ -10090,7 +10090,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                                 && (! (_invlist_len(prop_definition) == 1
                                        && *invlist_array(prop_definition) == 0))))
                         {
-                            warn_super = TRUE;
+                            warn_super = true;
                         }
 
                         /* Invert if asking for the complement */
@@ -10201,7 +10201,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                             reg_warn_non_literal_string(
                                  RExC_parse + 1,
                                  form_alien_digit_msg(8, numlen, RExC_parse,
-                                                        RExC_end, UTF, FALSE));
+                                                        RExC_end, UTF, false));
                         }
                     }
                     if (value < 256) {
@@ -10740,7 +10740,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
         Size_t constructed_prefix_len = 0; /* This gives the length of the
                                               constructed portion of the
                                               substitute parse. */
-        bool first_time = TRUE;     /* First multi-char occurrence doesn't get
+        bool first_time = true;     /* First multi-char occurrence doesn't get
                                        a "|" */
         I32 reg_flags;
 
@@ -10766,14 +10766,14 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                 SV* this_sequence;
 
                 this_array_ptr = (AV**) av_fetch_simple(multi_char_matches,
-                                                 cp_count, FALSE);
+                                                 cp_count, false);
                 while ((this_sequence = av_pop(*this_array_ptr)) !=
                                                                 &PL_sv_undef)
                 {
                     if (! first_time) {
                         sv_catpvs(substitute_parse, "|");
                     }
-                    first_time = FALSE;
+                    first_time = false;
 
                     sv_catpv(substitute_parse, SvPVX(this_sequence));
                 }
@@ -11152,7 +11152,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
 
             /* Because an ANYOF node is the only one that warns, this node
              * can't be optimized into something else */
-            optimizable = FALSE;
+            optimizable = false;
         }
     }
 
@@ -11213,7 +11213,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                  || (  anyof_flags
                      & ANYOFD_NON_UTF8_MATCHES_ALL_NON_ASCII__shared)))
     {
-        RExC_seen_d_op = TRUE;
+        RExC_seen_d_op = true;
         has_runtime_dependency |= HAS_D_RUNTIME_DEPENDENCY;
     }
 
@@ -11226,7 +11226,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
         _invlist_invert(cp_list);
 
         /* Clear the invert flag since have just done it here */
-        invert = FALSE;
+        invert = false;
     }
 
     /* All possible optimizations below still have these characteristics.
@@ -11368,7 +11368,7 @@ S_optimize_regclass(pTHX_
     UV partial_cp_count = 0;
     UV start[MAX_FOLD_FROMS+1] = { 0 }; /* +1 for the folded-to char */
     UV   end[MAX_FOLD_FROMS+1] = { 0 };
-    bool single_range = FALSE;
+    bool single_range = false;
     UV lowest_cp = 0, highest_cp = 0;
 
     PERL_ARGS_ASSERT_OPTIMIZE_REGCLASS;
@@ -11386,7 +11386,7 @@ S_optimize_regclass(pTHX_
         }
 
         if (i == 1) {
-            single_range = TRUE;
+            single_range = true;
         }
         invlist_iterfinish(cp_list);
 
@@ -11461,7 +11461,7 @@ S_optimize_regclass(pTHX_
                                                 PL_XPosix_ptrs[classnum],
                                                 already_inverted,
                                                 &class_above_latin1);
-            are_equivalent = _invlistEQ(class_above_latin1, cp_list, FALSE);
+            are_equivalent = _invlistEQ(class_above_latin1, cp_list, false);
             SvREFCNT_dec_NN(class_above_latin1);
 
             if (are_equivalent) {
@@ -11877,7 +11877,7 @@ S_optimize_regclass(pTHX_
             UV lowest_cp = UV_MAX;  /* init'ed to suppress compiler warn */
             U8 bits_differing = 0;
             Size_t full_cp_count = 0;
-            bool first_time = TRUE;
+            bool first_time = true;
 
             /* Go through the bytes and find the bit positions that differ */
             invlist_iterinit(cp_list);
@@ -11889,7 +11889,7 @@ S_optimize_regclass(pTHX_
                         goto done_anyofm;
                     }
 
-                    first_time = FALSE;
+                    first_time = false;
                     lowest_cp = this_start;
 
                     /* We have set up the code point to compare with.  Don't
@@ -12371,7 +12371,7 @@ Perl_set_ANYOF_arg(pTHX_ RExC_state_t* const pRExC_state,
             /* If the inversion lists aren't equivalent, can't share */
             if (cp_list && ! _invlistEQ(cp_list,
                                         *stored_cp_list_ptr,
-                                        FALSE /* don't complement */))
+                                        false /* don't complement */))
             {
                 continue;
             }
@@ -12390,7 +12390,7 @@ Perl_set_ANYOF_arg(pTHX_ RExC_state_t* const pRExC_state,
             if (only_utf8_locale_list && ! _invlistEQ(
                                          only_utf8_locale_list,
                                          *stored_only_utf8_locale_list_ptr,
-                                         FALSE /* don't complement */))
+                                         false /* don't complement */))
             {
                 continue;
             }
@@ -12510,12 +12510,12 @@ Perl_get_re_gclass_aux_data(pTHX_ const regexp *prog, const regnode* node, bool 
                     SV * msg = newSVpvs_flags("", SVs_TEMP);
 
                     SV * prop_definition = handle_user_defined_property(
-                            "", 0, FALSE,   /* There is no \p{}, \P{} */
+                            "", 0, false,   /* There is no \p{}, \P{} */
                             SvPVX_const(si)[1] - '0',   /* /i or not has been
                                                            stored here for just
                                                            this occasion */
-                            TRUE,           /* run time */
-                            FALSE,          /* This call must find the defn */
+                            true,           /* run time */
+                            false,          /* This call must find the defn */
                             si,             /* The property definition  */
                             &user_defined,
                             msg,
@@ -12670,7 +12670,7 @@ Perl_get_re_gclass_aux_data(pTHX_ const regexp *prog, const regnode* node, bool 
                     matches_string = newSVpvs("\n");
                 }
                 sv_catsv(matches_string, invlist_contents(invlist,
-                                                  TRUE /* traditional style */
+                                                  true /* traditional style */
                                                   ));
             }
             else if (! *output_invlist) {
@@ -12726,7 +12726,7 @@ S_skip_to_be_ignored_text(pTHX_ RExC_state_t *pRExC_state,
                          )
 {
     /* If the text at the current parse position '*p' is a '(?#...)' comment,
-     * or if we are under /x or 'force_to_xmod' is TRUE, and the text at '*p'
+     * or if we are under /x or 'force_to_xmod' is true, and the text at '*p'
      * is /x whitespace, advance '*p' so that on exit it points to the first
      * byte past all such white space and comments */
 
@@ -12799,7 +12799,7 @@ S_nextchar(pTHX_ RExC_state_t *pRExC_state)
         RExC_parse_inc_safe();
 
         skip_to_be_ignored_text(pRExC_state, &RExC_parse,
-                                FALSE /* Don't force /x */ );
+                                false /* Don't force /x */ );
     }
 }
 
@@ -13013,7 +13013,7 @@ S_reginsert(pTHX_ RExC_state_t *pRExC_state, const U8 op,
 
 /*
 - regtail - set the next-pointer at the end of a node chain of p to val.  If
-            that value won't fit in the space available, instead returns FALSE.
+            that value won't fit in the space available, instead returns false.
             (Except asserts if we can't fit in the largest space the regex
             engine is designed for.)
 - SEE ALSO: regtail_study
@@ -13063,12 +13063,12 @@ S_regtail(pTHX_ RExC_state_t * pRExC_state,
              * lead to a crash if the caller ignores the failure return, and
              * execution continues */
             NEXT_OFF(REGNODE_p(scan)) = U16_MAX;
-            return FALSE;
+            return false;
         }
         NEXT_OFF(REGNODE_p(scan)) = val - scan;
     }
 
-    return TRUE;
+    return true;
 }
 
 #ifdef DEBUGGING
@@ -13116,7 +13116,7 @@ S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p,
             bool unfolded_multi_char;	/* Unexamined in this routine */
             if (join_exact(pRExC_state, scan, &min,
                            &unfolded_multi_char, 1, REGNODE_p(val), depth+1))
-                return TRUE; /* Was return EXACT */
+                return true; /* Was return EXACT */
         }
 #endif
         if ( exact ) {
@@ -13162,12 +13162,12 @@ S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p,
              * lead to a crash if the caller ignores the failure return, and
              * execution continues */
             NEXT_OFF(REGNODE_p(scan)) = U16_MAX;
-            return FALSE;
+            return false;
         }
         NEXT_OFF(REGNODE_p(scan)) = val - scan;
     }
 
-    return TRUE; /* Was 'return exact' */
+    return true; /* Was 'return exact' */
 }
 #endif
 
@@ -14229,7 +14229,7 @@ S_handle_user_defined_property(pTHX_
     const bool deferrable,      /* Is it ok for this property's full definition
                                    to be deferred until later? */
     SV* contents,               /* The property's definition */
-    bool *user_defined_ptr,     /* This will be set TRUE as we wouldn't be
+    bool *user_defined_ptr,     /* This will be set true as we wouldn't be
                                    getting called unless this is thought to be
                                    a user-defined property */
     SV * msg,                   /* Any error or warning msg(s) are appended to
@@ -14249,7 +14249,7 @@ S_handle_user_defined_property(pTHX_
 
     PERL_ARGS_ASSERT_HANDLE_USER_DEFINED_PROPERTY;
 
-    *user_defined_ptr = TRUE;
+    *user_defined_ptr = true;
 
     /* Look at each line */
     while (s0 < e) {
@@ -14602,13 +14602,13 @@ S_parse_uniprop_string(pTHX_
                                    trailing space */
     const bool is_utf8,         /* ? Is 'name' encoded in UTF-8 */
     const bool to_fold,         /* ? Is this under /i */
-    const bool runtime,         /* TRUE if this is being called at run time */
-    const bool deferrable,      /* TRUE if it's ok for the definition to not be
+    const bool runtime,         /* true if this is being called at run time */
+    const bool deferrable,      /* true if it's ok for the definition to not be
                                    known at this call */
     AV ** strings,              /* To return string property values, like named
                                    sequences */
     bool *user_defined_ptr,     /* Upon return from this function it will be
-                                   set to TRUE if any component is a
+                                   set to true if any component is a
                                    user-defined property */
     SV * msg,                   /* Any error or warning msg(s) are appended to
                                    this */
@@ -14624,20 +14624,20 @@ S_parse_uniprop_string(pTHX_
     /* nv = or numeric_value=, or possibly one of the cjk numeric properties
      * (though it requires extra effort to download them from Unicode and
      * compile perl to know about them) */
-    bool is_nv_type = FALSE;
+    bool is_nv_type = false;
 
     unsigned int i = 0, i_zero = 0, j = 0;
     int equals_pos = -1;    /* Where the '=' is found, or negative if none */
     int slash_pos  = -1;    /* Where the '/' is found, or negative if none */
     int table_index = 0;    /* The entry number for this property in the table
                                of all Unicode property names */
-    bool starts_with_Is = FALSE;  /* ? Does the name start with 'Is' */
+    bool starts_with_Is = false;  /* ? Does the name start with 'Is' */
     Size_t lookup_offset = 0;   /* Used to ignore the first few characters of
                                    the normalized name in certain situations */
     Size_t non_pkg_begin = 0;   /* Offset of first byte in 'name' that isn't
                                    part of a package name */
     Size_t lun_non_pkg_begin = 0;   /* Similarly for 'lookup_name' */
-    bool could_be_user_defined = TRUE;  /* ? Could this be a user-defined
+    bool could_be_user_defined = true;  /* ? Could this be a user-defined
                                              property rather than a Unicode
                                              one. */
     SV * prop_definition = NULL;  /* The returned definition of 'name' or NULL
@@ -14647,9 +14647,9 @@ S_parse_uniprop_string(pTHX_
                                      name of 'name' */
     SV * fq_name = NULL;        /* For user-defined properties, the fully
                                    qualified name */
-    bool invert_return = FALSE; /* ? Do we need to complement the result before
+    bool invert_return = false; /* ? Do we need to complement the result before
                                      returning it */
-    bool stripped_utf8_pkg = FALSE; /* Set TRUE if the input includes an
+    bool stripped_utf8_pkg = false; /* Set true if the input includes an
                                        explicit utf8:: package that we strip
                                        off  */
     /* The expansion of properties that could be either user-defined or
@@ -14657,7 +14657,7 @@ S_parse_uniprop_string(pTHX_
      * those that might be in the latter category.  This boolean indicates if
      * we've seen that marker.  If not, what we're parsing can't be such an
      * official Unicode property whose expansion was deferred */
-    bool could_be_deferred_official = FALSE;
+    bool could_be_deferred_official = false;
 
     PERL_ARGS_ASSERT_PARSE_UNIPROP_STRING;
 
@@ -14689,7 +14689,7 @@ S_parse_uniprop_string(pTHX_
             /* The first character in a user-defined name must be of this type.
              * */
             if (i - non_pkg_begin == 0 && ! isIDFIRST_A(cur)) {
-                could_be_user_defined = FALSE;
+                could_be_user_defined = false;
             }
 
             continue;
@@ -14701,7 +14701,7 @@ S_parse_uniprop_string(pTHX_
          * them, and we have to reparse, but we don't have enough information
          * yet to make that decision */
         if (cur == '-' || isSPACE_A(cur)) {
-            could_be_user_defined = FALSE;
+            could_be_user_defined = false;
             continue;
         }
 
@@ -14712,7 +14712,7 @@ S_parse_uniprop_string(pTHX_
         {
             lookup_name[j++] = '='; /* Treat the colon as an '=' */
             equals_pos = j; /* Note where it occurred in the input */
-            could_be_user_defined = FALSE;
+            could_be_user_defined = false;
             break;
         }
 
@@ -14725,7 +14725,7 @@ S_parse_uniprop_string(pTHX_
             &&   i == name_len - 1)
         {
             name_len--;
-            could_be_deferred_official = TRUE;
+            could_be_deferred_official = true;
             continue;
         }
 
@@ -14748,7 +14748,7 @@ S_parse_uniprop_string(pTHX_
             lun_non_pkg_begin = j;
         }
         else { /* Only word chars (and '::') can be in a user-defined name */
-            could_be_user_defined = FALSE;
+            could_be_user_defined = false;
         }
     } /* End of parsing through the lhs of the property name (or all of it if
          no rhs) */
@@ -14765,7 +14765,7 @@ S_parse_uniprop_string(pTHX_
                                                from the beginning, it has to be
                                                set past what we're stripping
                                                off */
-        stripped_utf8_pkg = TRUE;
+        stripped_utf8_pkg = true;
     }
 
     /* Here, we are either done with the whole property name, if it was simple;
@@ -14874,7 +14874,7 @@ S_parse_uniprop_string(pTHX_
                  * ignored. */
                 subpattern_re = compile_wildcard(name + i,
                                                  name_len - i - 1 - escaped,
-                                                 TRUE /* /i */
+                                                 true /* /i */
                                                 );
 
                 /* For each legal property value, see if the supplied pattern
@@ -15277,11 +15277,11 @@ S_parse_uniprop_string(pTHX_
         /* Names that start with In have different characteristics than those
          * that start with Is */
         if (name[non_pkg_begin+1] == 's') {
-            starts_with_Is = TRUE;
+            starts_with_Is = true;
         }
     }
     else {
-        could_be_user_defined = FALSE;
+        could_be_user_defined = false;
     }
 
     if (could_be_user_defined) {
@@ -15293,7 +15293,7 @@ S_parse_uniprop_string(pTHX_
          * a bug in the perl code, but this is a change of behavior for Perl,
          * so we handle it.  This means that intentionally returning nothing
          * will not be resolved until runtime */
-        bool empty_return = FALSE;
+        bool empty_return = false;
 
         /* Here, the name could be for a user defined property, which are
          * implemented as subs. */
@@ -15343,7 +15343,7 @@ S_parse_uniprop_string(pTHX_
             DECLARATION_FOR_GLOBAL_CONTEXT;
 
             /* If we get here, we know this property is user-defined */
-            *user_defined_ptr = TRUE;
+            *user_defined_ptr = true;
 
             /* We refuse to call a potentially tainted subroutine; returning an
              * error instead */
@@ -15560,7 +15560,7 @@ S_parse_uniprop_string(pTHX_
                 if (      deferrable
                     && (! SvPOK(contents) || SvCUR(contents) == 0))
                 {
-                        empty_return = TRUE;
+                        empty_return = true;
                 }
                 else { /* Otherwise, call a function to check for valid syntax,
                           and handle it */
@@ -15829,7 +15829,7 @@ S_parse_uniprop_string(pTHX_
      * A negative return signifies that the real index is the absolute value,
      * but the result needs to be inverted */
     if (table_index < 0) {
-        invert_return = TRUE;
+        invert_return = true;
         table_index = -table_index;
     }
 
@@ -15988,7 +15988,7 @@ S_parse_uniprop_string(pTHX_
         /* We also need a trailing newline */
         sv_catpvs(fq_name, "\n");
 
-        *user_defined_ptr = TRUE;
+        *user_defined_ptr = true;
         return fq_name;
     }
 }
@@ -15999,7 +15999,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
                               SV ** prop_definition,
                               AV ** strings)
 {
-    /* Deal with Name property wildcard subpatterns; returns TRUE if there were
+    /* Deal with Name property wildcard subpatterns; returns true if there were
      * any matches, adding them to prop_definition */
 
     dSP;
@@ -16014,7 +16014,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
                                    (non-algorithmic) character name */
     char * cur_pos;             /* We match, effectively using /gc; this is
                                    where we are now */
-    bool found_matches = FALSE; /* Did any name match so far? */
+    bool found_matches = false; /* Did any name match so far? */
     SV * empty;                 /* For matching zero length names */
     SV * must_sv;               /* Contains the substring, if any, that must be
                                    in a name for the subpattern to match */
@@ -16073,7 +16073,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
     {   /* Perhaps should panic instead XXX */
         SvREFCNT_dec(names_string);
         SvREFCNT_dec(algorithmic_names);
-        return FALSE;
+        return false;
     }
 
     names_string = sv_2mortal(SvRV(names_string));
@@ -16083,7 +16083,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
     algorithmic_names = sv_2mortal(SvRV(algorithmic_names));
 
     /* Compile the subpattern consisting of the name being looked for */
-    subpattern_re = compile_wildcard(wname, wname_len, FALSE /* /-i */ );
+    subpattern_re = compile_wildcard(wname, wname_len, false /* /-i */ );
 
     must_sv = re_intuit_string(subpattern_re);
     if (must_sv) {
@@ -16132,7 +16132,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
             char * cp_end;
             UV cp = 0;      /* Silences some compilers */
             AV * this_string = NULL;
-            bool is_multi = FALSE;
+            bool is_multi = false;
 
             /* If matched nothing, advance to next possible match */
             if (this_name_start == this_name_end) {
@@ -16196,7 +16196,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
             }
 
             /* We matched!  Add this to the list */
-            found_matches = TRUE;
+            found_matches = true;
 
             /* Loop through all the code points in the sequence */
             while (cp_start < cp_end) {
@@ -16215,7 +16215,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
                         this_string = newAV();
                     }
 
-                    is_multi = TRUE;
+                    is_multi = true;
                     av_push_simple(this_string, newSVuv(cp));
                 }
             }
@@ -16305,7 +16305,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
                     {
                         *prop_definition = add_cp_to_invlist(*prop_definition,
                                                              cp);
-                        found_matches = TRUE;
+                        found_matches = true;
                     }
 
                     cp++;
@@ -16361,7 +16361,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
                                     0))
                 {
                     *prop_definition = add_cp_to_invlist(*prop_definition, j);
-                    found_matches = TRUE;
+                    found_matches = true;
                 }
             }
         }
@@ -16394,7 +16394,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
         SvREFCNT_dec_NN(subtract);
 
         _invlist_union(*prop_definition, empty_names, prop_definition);
-        found_matches = TRUE;
+        found_matches = true;
         SvREFCNT_dec_NN(empty_names);
     }
     SvREFCNT_dec_NN(empty);
@@ -16420,7 +16420,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
             _invlist_union_complement_2nd(*prop_definition, empties, prop_definition);
             SvREFCNT_dec_NN(empties);
 
-            found_matches = TRUE;
+            found_matches = true;
         }
         SvREFCNT_dec_NN(empty);
     }

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -609,7 +609,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
                                                 NULL,
                                                 NULL,
                                                 0,
-                                                FALSE
+                                                false
                                                );
             sv_catpvs(sv, "]");
         }
@@ -806,7 +806,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
                                                       UV_MAX);
         }
         else if (ANYOF_HAS_AUX(o)) {
-                (void) GET_REGCLASS_AUX_DATA(prog, o, FALSE,
+                (void) GET_REGCLASS_AUX_DATA(prog, o, false,
                                                 &unresolved,
                                                 &only_utf8_locale_invlist,
                                                 &nonbitmap_invlist);
@@ -912,7 +912,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
             }
 
             contents = invlist_contents(nonbitmap_invlist,
-                                        FALSE /* output suitable for catsv */
+                                        false /* output suitable for catsv */
                                        );
 
             /* If the output is shorter than the permissible maximum, just do it. */
@@ -980,7 +980,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
             _invlist_invert(cp_list);
         }
 
-        put_charclass_bitmap_innards(sv, NULL, cp_list, NULL, NULL, 0, TRUE);
+        put_charclass_bitmap_innards(sv, NULL, cp_list, NULL, NULL, 0, true);
         Perl_sv_catpvf(aTHX_ sv, "%s]", PL_colors[1]);
 
         SvREFCNT_dec(cp_list);
@@ -990,7 +990,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         Perl_sv_catpvf(aTHX_ sv, "[%s", PL_colors[0]);
 
         sv_catsv(sv, invlist_contents(cp_list,
-                                      FALSE /* output suitable for catsv */
+                                      false /* output suitable for catsv */
                                      ));
         Perl_sv_catpvf(aTHX_ sv, "%s]", PL_colors[1]);
 
@@ -1148,7 +1148,7 @@ S_put_range(pTHX_ SV *sv, UV start, const UV end, const bool allow_literals)
                 /* Output the first part of the split range: the part that
                  * doesn't have printables, with the parameter set to not look
                  * for literals (otherwise we would infinitely recurse) */
-                put_range(sv, start, temp_end - 1, FALSE);
+                put_range(sv, start, temp_end - 1, false);
 
                 /* The 2nd part of the range (if any) starts here. */
                 start = temp_end;
@@ -1181,7 +1181,7 @@ S_put_range(pTHX_ SV *sv, UV start, const UV end, const bool allow_literals)
                 /* For short ranges, don't duplicate the code above to output
                  * them; just call recursively */
                 if (temp_end - start < min_range_count) {
-                    put_range(sv, start, temp_end, FALSE);
+                    put_range(sv, start, temp_end, false);
                 }
                 else {  /* Output as a range */
                     put_code_point(sv, start);
@@ -1228,7 +1228,7 @@ S_put_range(pTHX_ SV *sv, UV start, const UV end, const bool allow_literals)
 
                 /* And separately output the interior range that doesn't start
                  * or end with mnemonics */
-                put_range(sv, start, temp_end, FALSE);
+                put_range(sv, start, temp_end, false);
 
                 /* Then output the mnemonic trailing controls */
                 start = temp_end + 1;
@@ -1271,7 +1271,7 @@ S_put_charclass_bitmap_innards_invlist(pTHX_ SV *sv, SV* invlist)
      * 'invlist' */
 
     UV start, end;
-    bool allow_literals = TRUE;
+    bool allow_literals = true;
 
     PERL_ARGS_ASSERT_PUT_CHARCLASS_BITMAP_INNARDS_INVLIST;
 
@@ -1299,7 +1299,7 @@ S_put_charclass_bitmap_innards_invlist(pTHX_ SV *sv, SV* invlist)
                 start = ' ';
             }
             if (end - start >= MAX_PRINT_A - ' ' - 2) {
-                allow_literals = FALSE;
+                allow_literals = false;
             }
             break;
         }
@@ -1422,9 +1422,9 @@ S_put_charclass_bitmap_innards(pTHX_ SV *sv,
      *      above two parameters are not null, and is passed so that this
      *      routine can tease apart the various reasons for them.
      *  'flags' is the flags field of 'node'
-     *  'force_as_is_display' is TRUE if this routine should definitely NOT try
+     *  'force_as_is_display' is true if this routine should definitely NOT try
      *      to invert things to see if that leads to a cleaner display.  If
-     *      FALSE, this routine is free to use its judgment about doing this.
+     *      false, this routine is free to use its judgment about doing this.
      *
      * It returns 0 if nothing was actually output.  (It may be that
      *              the bitmap, etc is empty.)
@@ -1433,7 +1433,7 @@ S_put_charclass_bitmap_innards(pTHX_ SV *sv,
      *
      * When called for outputting the bitmap of a non-ANYOF node, just pass the
      * bitmap, with the succeeding parameters set to NULL, and the final one to
-     * FALSE.
+     * false.
      */
 
     /* In general, it tries to display the 'cleanest' representation of the
@@ -1501,7 +1501,7 @@ S_put_charclass_bitmap_innards(pTHX_ SV *sv,
              * determinable except during execution, so don't know enough here
              * to invert */
             if (flags & (ANYOFL_FOLD|ANYOF_MATCHES_POSIXL)) {
-                inverting_allowed = FALSE;
+                inverting_allowed = false;
             }
 
             /* What the posix classes match also varies at runtime, so these
@@ -1556,7 +1556,7 @@ S_put_charclass_bitmap_innards(pTHX_ SV *sv,
          * form of this list when it has things above the bitmap, so don't even
          * try */
         if (invlist_highest(only_utf8_locale) >= NUM_ANYOF_CODE_POINTS) {
-            inverting_allowed = FALSE;
+            inverting_allowed = false;
         }
     }
 
@@ -1584,12 +1584,12 @@ S_put_charclass_bitmap_innards(pTHX_ SV *sv,
          * the '^' */
         bool trial_invert;
         if (invert) {
-            trial_invert = FALSE;
+            trial_invert = false;
             as_is_bias = bias;
             inverted_bias = 0;
         }
         else {
-            trial_invert = TRUE;
+            trial_invert = true;
             as_is_bias = 0;
             inverted_bias = bias;
         }

--- a/regcomp_invlist.c
+++ b/regcomp_invlist.c
@@ -140,8 +140,8 @@ S__invlist_array_init(SV* const invlist, const bool will_have_0)
      * array begins depends on whether the list has the code point U+0000 in it
      * or not.  The other parameter tells it whether the code that follows this
      * call is about to put a 0 in the inversion list or not.  The first
-     * element is either the element reserved for 0, if TRUE, or the element
-     * after it, if FALSE */
+     * element is either the element reserved for 0, if true, or the element
+     * after it, if false */
 
     bool* offset = get_invlist_offset_addr(invlist);
     UV* zero_addr = (UV *) SvPVX(invlist);
@@ -568,7 +568,7 @@ Perl__invlist_union_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
      * even 'a' or 'b').  If to an inversion list, the contents of the original
      * list will be replaced by the union.  The first list, 'a', may be
      * NULL, in which case a copy of the second list is placed in '*output'.
-     * If 'complement_b' is TRUE, the union is taken of the complement
+     * If 'complement_b' is true, the union is taken of the complement
      * (inversion) of 'b' instead of b itself.
      *
      * The basis for this comes from "Unicode Demystified" Chapter 13 by
@@ -846,7 +846,7 @@ Perl__invlist_intersection_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
      * even 'a' or 'b').  If to an inversion list, the contents of the original
      * list will be replaced by the intersection.  The first list, 'a', may be
      * NULL, in which case '*i' will be an empty list.  If 'complement_b' is
-     * TRUE, the result will be the intersection of 'a' and the complement (or
+     * true, the result will be the intersection of 'a' and the complement (or
      * inversion) of 'b' instead of 'b' directly.
      *
      * The basis for this comes from "Unicode Demystified" Chapter 13 by
@@ -1475,7 +1475,7 @@ bool
 Perl__invlistEQ(pTHX_ SV* const a, SV* const b, const bool complement_b)
 {
     /* Return a boolean as to if the two passed in inversion lists are
-     * identical.  The final argument, if TRUE, says to take the complement of
+     * identical.  The final argument, if true, says to take the complement of
      * the second inversion list before doing the comparison */
 
     const UV len_a = _invlist_len(a);

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -317,9 +317,9 @@ S_ssc_anything(pTHX_ regnode_ssc *ssc)
 STATIC int
 S_ssc_is_anything(const regnode_ssc *ssc)
 {
-    /* Returns TRUE if the SSC 'ssc' can match the empty string and any code
-     * point; FALSE otherwise.  Thus, this is used to see if using 'ssc' buys
-     * us anything: if the function returns TRUE, 'ssc' hasn't been restricted
+    /* Returns true if the SSC 'ssc' can match the empty string and any code
+     * point; false otherwise.  Thus, this is used to see if using 'ssc' buys
+     * us anything: if the function returns true, 'ssc' hasn't been restricted
      * in any way, so there's no point in using it */
 
     UV start = 0, end = 0;  /* Initialize due to messages from dumb compiler */
@@ -330,7 +330,7 @@ S_ssc_is_anything(const regnode_ssc *ssc)
     assert(is_ANYOF_SYNTHETIC(ssc));
 
     if (! (ANYOF_FLAGS(ssc) & SSC_MATCHES_EMPTY_STRING)) {
-        return FALSE;
+        return false;
     }
 
     /* See if the list consists solely of the range 0 - Infinity */
@@ -342,7 +342,7 @@ S_ssc_is_anything(const regnode_ssc *ssc)
     invlist_iterfinish(ssc->invlist);
 
     if (ret) {
-        return TRUE;
+        return true;
     }
 
     /* If e.g., both \w and \W are set, matches everything */
@@ -350,12 +350,12 @@ S_ssc_is_anything(const regnode_ssc *ssc)
         int i;
         for (i = 0; i < ANYOF_POSIXL_MAX; i += 2) {
             if (ANYOF_POSIXL_TEST(ssc, i) && ANYOF_POSIXL_TEST(ssc, i+1)) {
-                return TRUE;
+                return true;
             }
         }
     }
 
-    return FALSE;
+    return false;
 }
 
 void
@@ -390,7 +390,7 @@ STATIC int
 S_ssc_is_cp_posixl_init(const RExC_state_t *pRExC_state,
                         const regnode_ssc *ssc)
 {
-    /* Returns TRUE if the SSC 'ssc' is in its initial state with regard only
+    /* Returns true if the SSC 'ssc' is in its initial state with regard only
      * to the list of code points matched, and locale posix classes; hence does
      * not check its flags) */
 
@@ -409,14 +409,14 @@ S_ssc_is_cp_posixl_init(const RExC_state_t *pRExC_state,
     invlist_iterfinish(ssc->invlist);
 
     if (! ret) {
-        return FALSE;
+        return false;
     }
 
     if (RExC_contains_locale && ! ANYOF_POSIXL_SSC_TEST_ALL_SET(ssc)) {
-        return FALSE;
+        return false;
     }
 
-    return TRUE;
+    return true;
 }
 
 
@@ -432,7 +432,7 @@ S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state,
 
     SV* invlist = NULL;
     SV* only_utf8_locale_invlist = NULL;
-    bool new_node_has_latin1 = FALSE;
+    bool new_node_has_latin1 = false;
     const U8 flags = (REGNODE_TYPE(OP(node)) == ANYOF)
                       ? ANYOF_FLAGS(node)
                       : 0;
@@ -503,7 +503,7 @@ S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state,
                     /* empty */
                 }
                 invlist = _add_range_to_invlist(invlist, start, i-1);
-                new_node_has_latin1 = TRUE;
+                new_node_has_latin1 = true;
             }
         }
     }
@@ -670,7 +670,7 @@ S_ssc_and(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc,
 
         ssc_intersection(ssc,
                          anded_cp_list,
-                         FALSE /* Has already been inverted */
+                         false /* Has already been inverted */
                          );
 
         /* If either P1 or P2 is empty, the intersection will be also; can skip
@@ -747,10 +747,10 @@ S_ssc_and(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc,
             if (and_with_flags & ANYOF_MATCHES_POSIXL) {
                 ANYOF_POSIXL_AND((regnode_charclass_posixl*) and_with, ssc);
             }
-            ssc_union(ssc, anded_cp_list, FALSE);
+            ssc_union(ssc, anded_cp_list, false);
         }
         else { /* P1 = P2 = empty */
-            ssc_intersection(ssc, anded_cp_list, FALSE);
+            ssc_intersection(ssc, anded_cp_list, false);
         }
     }
 }
@@ -834,7 +834,7 @@ S_ssc_or(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc,
 
     ssc_union(ssc,
               ored_cp_list,
-              FALSE /* Already has been inverted */
+              false /* Already has been inverted */
               );
 }
 
@@ -889,7 +889,7 @@ S_ssc_cp_and(pTHX_ regnode_ssc *ssc, const UV cp)
 
     cp_list = add_cp_to_invlist(cp_list, cp);
     ssc_intersection(ssc, cp_list,
-                     FALSE /* Not inverted */
+                     false /* Not inverted */
                      );
     SvREFCNT_dec_NN(cp_list);
 }
@@ -1252,7 +1252,7 @@ Perl_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan,
     }
 
     *min_subtract = 0;
-    *unfolded_multi_char = FALSE;
+    *unfolded_multi_char = false;
 
     /* Here, all the adjacent mergeable EXACTish nodes have been merged.  We
      * can now analyze for sequences of problematic code points.  (Prior to
@@ -1302,7 +1302,7 @@ Perl_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan,
                         d += s_len;
                     }
                     else if (is_FOLDS_TO_MULTI_utf8(s)) {
-                        *unfolded_multi_char = TRUE;
+                        *unfolded_multi_char = true;
                         Copy(s, d, s_len, U8);
                         d += s_len;
                     }
@@ -1394,7 +1394,7 @@ Perl_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan,
             while (s < s_end) {
                 if (*s == LATIN_SMALL_LETTER_SHARP_S) {
                     OP(scan) = EXACTFAA_NO_TRIE;
-                    *unfolded_multi_char = TRUE;
+                    *unfolded_multi_char = true;
                     break;
                 }
                 s++;
@@ -1418,7 +1418,7 @@ Perl_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan,
                     if (*s == LATIN_SMALL_LETTER_SHARP_S
                         && (OP(scan) == EXACTF || OP(scan) == EXACTFL))
                     {
-                        *unfolded_multi_char = TRUE;
+                        *unfolded_multi_char = true;
                     }
                     s++;
                     continue;
@@ -1483,8 +1483,8 @@ Perl_study_chunk(pTHX_
     regnode_ssc *and_withp, /* Valid if flags & SCF_DO_STCLASS_OR */
     U32 flags,              /* flags controlling this call, see SCF_ flags */
     U32 depth,              /* how deep have we recursed period */
-    bool was_mutate_ok      /* TRUE if in-place optimizations are allowed.
-                               FALSE only if the caller (recursively) was
+    bool was_mutate_ok      /* true if in-place optimizations are allowed.
+                               false only if the caller (recursively) was
                                prohibited from modifying the regops, because
                                a higher caller is holding a ptr to them. */
 )
@@ -1571,7 +1571,7 @@ Perl_study_chunk(pTHX_
         UV min_subtract = 0;    /* How mmany chars to subtract from the minimum
                                    node length to get a real minimum (because
                                    the folded version may be shorter) */
-        bool unfolded_multi_char = FALSE;
+        bool unfolded_multi_char = false;
         /* avoid mutating ops if we are anywhere within the recursed or
          * enframed handling for a GOSUB: the outermost level will handle it.
          */
@@ -2369,10 +2369,10 @@ Perl_study_chunk(pTHX_
                         ssc_clear_locale(data->start_class);
                     ANYOF_FLAGS(data->start_class) &= ~SSC_MATCHES_EMPTY_STRING;
                     ANYOF_POSIXL_ZERO(data->start_class);
-                    ssc_intersection(data->start_class, EXACTF_invlist, FALSE);
+                    ssc_intersection(data->start_class, EXACTF_invlist, false);
                 }
                 else {  /* SCF_DO_STCLASS_OR */
-                    ssc_union(data->start_class, EXACTF_invlist, FALSE);
+                    ssc_union(data->start_class, EXACTF_invlist, false);
                     ssc_and(pRExC_state, data->start_class, (regnode_charclass *) and_withp);
 
                     /* See commit msg 749e076fceedeb708a624933726e7989f2302f6a */
@@ -2886,7 +2886,7 @@ Perl_study_chunk(pTHX_
             if (flags & SCF_DO_STCLASS) {
                 if (flags & SCF_DO_STCLASS_AND) {
                     ssc_intersection(data->start_class,
-                                    PL_XPosix_ptrs[CC_VERTSPACE_], FALSE);
+                                    PL_XPosix_ptrs[CC_VERTSPACE_], false);
                     ssc_clear_locale(data->start_class);
                     ANYOF_FLAGS(data->start_class)
                                                 &= ~SSC_MATCHES_EMPTY_STRING;
@@ -2894,7 +2894,7 @@ Perl_study_chunk(pTHX_
                 else if (flags & SCF_DO_STCLASS_OR) {
                     ssc_union(data->start_class,
                               PL_XPosix_ptrs[CC_VERTSPACE_],
-                              FALSE);
+                              false);
                     ssc_and(pRExC_state, data->start_class, (regnode_charclass *) and_withp);
 
                     /* See commit msg for
@@ -2954,14 +2954,14 @@ Perl_study_chunk(pTHX_
                         if (flags & SCF_DO_STCLASS_OR) {
                             ssc_union(data->start_class,
                                       REG_ANY_invlist,
-                                      TRUE /* TRUE => invert, hence all but \n
+                                      true /* true => invert, hence all but \n
                                             */
                                       );
                         }
                         else if (flags & SCF_DO_STCLASS_AND) {
                             ssc_intersection(data->start_class,
                                              REG_ANY_invlist,
-                                             TRUE  /* TRUE => invert */
+                                             true  /* true => invert */
                                              );
                             ssc_clear_locale(data->start_class);
                         }
@@ -3002,7 +3002,7 @@ Perl_study_chunk(pTHX_
 
                 case NANYOFM: /* NANYOFM already contains the inversion of the
                                  input ANYOF data, so, unlike things like
-                                 NPOSIXA, don't change 'invert' to TRUE */
+                                 NPOSIXA, don't change 'invert' to true */
                     /* FALLTHROUGH */
                 case ANYOFM:
                   {

--- a/regexec.c
+++ b/regexec.c
@@ -554,7 +554,7 @@ S_isFOO_lc(pTHX_ const U8 classnum, const U8 character)
                classnum);
 
     NOT_REACHED; /* NOTREACHED */
-    return FALSE;
+    return false;
 }
 
 PERL_STATIC_INLINE I32
@@ -1892,7 +1892,7 @@ STMT_START {                                                                \
                 startpos, doutf8, depth)
 
 #define GET_ANYOFH_INVLIST(prog, n)                                         \
-                        GET_REGCLASS_AUX_DATA(prog, n, TRUE, 0, NULL, NULL)
+                        GET_REGCLASS_AUX_DATA(prog, n, true, 0, NULL, NULL)
 
 #define REXEC_FBC_UTF8_SCAN(CODE)                           \
     STMT_START {                                            \
@@ -1948,7 +1948,7 @@ STMT_START {                                                                \
 
 /* We keep track of where the next character should start after an occurrence
  * of the one we're looking for.  Knowing that, we can see right away if the
- * next occurrence is adjacent to the previous.  When 'doevery' is FALSE, we
+ * next occurrence is adjacent to the previous.  When 'doevery' is false, we
  * don't accept the 2nd and succeeding adjacent occurrences */
 #define FBC_CHECK_AND_TRY                                           \
         if (   (   doevery                                          \
@@ -2274,7 +2274,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
     const char *strend, regmatch_info *reginfo)
 {
 
-    /* TRUE if x+ need not match at just the 1st pos of run of x's */
+    /* true if x+ need not match at just the 1st pos of run of x's */
     const I32 doevery = (prog->intflags & PREGf_SKIP) == 0;
 
     char *pat_string;   /* The pattern's exactish string */
@@ -2298,7 +2298,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
     const bool utf8_target = reginfo->is_utf8_target;
     UV utf8_fold_flags = 0;
     const bool is_utf8_pat = reginfo->is_utf8_pat;
-    bool to_complement = FALSE; /* Invert the result?  Taking the xor of this
+    bool to_complement = false; /* Invert the result?  Taking the xor of this
                                    with a result inverts that result, as 0^1 =
                                    1 and 1^1 = 0 */
     char_class_number_ classnum;
@@ -3852,7 +3852,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
     reginfo->prog = rx;	 /* Yes, sorry that this is confusing.  */
     reginfo->intuit = 0;
     reginfo->is_utf8_pat = cBOOL(RX_UTF8(rx));
-    reginfo->warned = FALSE;
+    reginfo->warned = false;
     reginfo->sv = sv;
     reginfo->poscache_maxiter = 0; /* not yet started a countdown */
     /* see how far we have to get to not match where we matched before */
@@ -4687,7 +4687,7 @@ S_setup_EXACTISH_ST(pTHX_ const regnode * const text_node,
      * could be used for one or the other eventualities.
      *
      * If this function determines that no possible character in the target
-     * string can match, it returns FALSE; otherwise TRUE.  (The FALSE
+     * string can match, it returns false; otherwise true.  (The false
      * situation occurs if the first character in <text_node> requires UTF-8 to
      * represent, and the target string isn't in UTF-8.)
      *
@@ -4728,7 +4728,7 @@ S_setup_EXACTISH_ST(pTHX_ const regnode * const text_node,
     /* Even if the first character in the node can match something in Latin1,
      * if there is anything in the node that can't, the match must fail */
     if (! utf8_target && isEXACT_REQ8(op)) {
-        return FALSE;
+        return false;
     }
 
 /* Define a temporary op for use in this function, using an existing one that
@@ -4809,7 +4809,7 @@ S_setup_EXACTISH_ST(pTHX_ const regnode * const text_node,
                                                                      pat[1]));
                     pat_len = 1;
                     pat = mod_pat;
-                    utf8_pat = FALSE;
+                    utf8_pat = false;
                 }
                 else {  /* Code point above 255, or needs special handling */
                     _to_utf8_fold_flags(pat, pat + pat_len,
@@ -4857,7 +4857,7 @@ S_setup_EXACTISH_ST(pTHX_ const regnode * const text_node,
         Copy(LATIN_SMALL_LETTER_LONG_S_UTF8
              LATIN_SMALL_LETTER_LONG_S_UTF8, mod_pat, pat_len, U8);
         pat = mod_pat;
-        utf8_pat = TRUE;
+        utf8_pat = true;
     }
 
     /* Here, we have taken care of the initial work for a few very problematic
@@ -5076,7 +5076,7 @@ S_setup_EXACTISH_ST(pTHX_ const regnode * const text_node,
 
     if (m->count == 0) {    /* If nothing found, can't match */
         m->min_length = 0;
-        return FALSE;
+        return false;
     }
 
     /* Have calculated all possible matches.  Now calculate the mask and AND
@@ -5183,7 +5183,7 @@ S_setup_EXACTISH_ST(pTHX_ const regnode * const text_node,
     }
 
 
-    return TRUE;
+    return true;
 }
 
 PERL_STATIC_FORCE_INLINE    /* We want speed at the expense of size */
@@ -5198,7 +5198,7 @@ S_test_EXACTISH_ST(const char * loc,
 
     /* Check the first byte */
     if (((U8) loc[0] & info.first_byte_mask) != info.first_byte_anded)
-        return FALSE;
+        return false;
 
     /* Pack the next up-to-4 bytes into a 32 bit word */
     switch (info.min_length) {
@@ -5215,7 +5215,7 @@ S_test_EXACTISH_ST(const char * loc,
             input32 |= (U8) loc[1];
             break;
         case 1:
-            return TRUE;    /* We already tested and passed the 0th byte */
+            return true;    /* We already tested and passed the 0th byte */
         case 0:
             ASSUME(0);
     }
@@ -5235,10 +5235,10 @@ S_isGCB(pTHX_ const GCB_enum before, const GCB_enum after, const U8 * const strb
 
     switch (GCB_table[before][after]) {
         case GCB_BREAKABLE:
-            return TRUE;
+            return true;
 
         case GCB_NOBREAK:
-            return FALSE;
+            return false;
 
         case GCB_RI_then_RI:
             {
@@ -5303,7 +5303,7 @@ S_isGCB(pTHX_ const GCB_enum before, const GCB_enum after, const U8 * const strb
                                   before, after, GCB_table[before][after]);
     assert(0);
 #endif
-    return TRUE;
+    return true;
 }
 
 STATIC GCB_enum
@@ -5381,11 +5381,11 @@ S_isLB(pTHX_ LB_enum before,
     before = prev;
     switch (LB_table[before][after]) {
         case LB_BREAKABLE:
-            return TRUE;
+            return true;
 
         case LB_NOBREAK:
         case LB_NOBREAK_EVEN_WITH_SP_BETWEEN:
-            return FALSE;
+            return false;
 
         case LB_SP_foo + LB_BREAKABLE:
         case LB_SP_foo + LB_NOBREAK:
@@ -5430,7 +5430,7 @@ S_isLB(pTHX_ LB_enum before,
              * So if we have a ZW just before this span, and to get here this
              * is the final space in the span. */
             if (prev == LB_ZWSpace) {
-                return TRUE;
+                return true;
             }
 
             /* Here, not ZW SP+.  There are several rules that have higher
@@ -5443,7 +5443,7 @@ S_isLB(pTHX_ LB_enum before,
             if (LB_table[LB_Space][after] - LB_SP_foo
                                             == LB_NOBREAK_EVEN_WITH_SP_BETWEEN)
             {
-                return FALSE;
+                return false;
             }
 
             /* If we get here, we have to XXX consider combining marks. */
@@ -5496,7 +5496,7 @@ S_isLB(pTHX_ LB_enum before,
             if (backup_one_LB(strbeg, &temp_pos, utf8_target)
                                                           == LB_Hebrew_Letter)
             {
-                return FALSE;
+                return false;
             }
 
             return LB_table[prev][after] - LB_HY_or_BA_then_foo == LB_BREAKABLE;
@@ -5506,7 +5506,7 @@ S_isLB(pTHX_ LB_enum before,
 
             /* LB25a (PR | PO) × ( OP | HY )? NU */
             if (advance_one_LB(&temp_pos, strend, utf8_target) == LB_Numeric) {
-                return FALSE;
+                return false;
             }
 
             return LB_table[prev][after] - LB_PR_or_PO_then_OP_or_HY
@@ -5523,7 +5523,7 @@ S_isLB(pTHX_ LB_enum before,
             }
             while (temp == LB_Break_Symbols || temp == LB_Infix_Numeric);
             if (temp == LB_Numeric) {
-                return FALSE;
+                return false;
             }
 
             return LB_table[prev][after] - LB_SY_or_IS_then_various
@@ -5544,7 +5544,7 @@ S_isLB(pTHX_ LB_enum before,
                 temp = backup_one_LB(strbeg, &temp_pos, utf8_target);
             }
             if (temp == LB_Numeric) {
-                return FALSE;
+                return false;
             }
             return LB_various_then_PO_or_PR;
         }
@@ -5580,7 +5580,7 @@ S_isLB(pTHX_ LB_enum before,
                                   before, after, LB_table[before][after]);
     assert(0);
 #endif
-    return TRUE;
+    return true;
 }
 
 STATIC LB_enum
@@ -5666,8 +5666,8 @@ S_isSB(pTHX_ SB_enum before,
      * between the inputs.  See https://www.unicode.org/reports/tr29/ */
 
     U8 * lpos = (U8 *) curpos;
-    bool has_para_sep = FALSE;
-    bool has_sp = FALSE;
+    bool has_para_sep = false;
+    bool has_sp = false;
 
     PERL_ARGS_ASSERT_ISSB;
 
@@ -5681,7 +5681,7 @@ S_isSB(pTHX_ SB_enum before,
 
     /* SB 3: Do not break within CRLF. */
     if (before == SB_CR && after == SB_LF) {
-        return FALSE;
+        return false;
     }
 
     /* Break after paragraph separators.  CR and LF are considered
@@ -5690,7 +5690,7 @@ S_isSB(pTHX_ SB_enum before,
      * care of wrapping without there being hard line-breaks in the text *./
        SB4.  Sep | CR | LF  ÷ */
     if (before == SB_Sep || before == SB_CR || before == SB_LF) {
-        return TRUE;
+        return true;
     }
 
     /* Ignore Format and Extend characters, except after sot, Sep, CR, or LF.
@@ -5702,7 +5702,7 @@ S_isSB(pTHX_ SB_enum before,
          * immediately prior to them except for those separator-type
          * characters.  And the rules earlier have already handled the case
          * when one of those immediately precedes the extend char */
-        return FALSE;
+        return false;
     }
 
     if (before == SB_Extend || before == SB_Format) {
@@ -5720,7 +5720,7 @@ S_isSB(pTHX_ SB_enum before,
         /* Here, both 'before' and 'backup' are these types; implied is that we
          * don't break between them */
         if (backup == SB_Extend || backup == SB_Format) {
-            return FALSE;
+            return false;
         }
     }
 
@@ -5734,7 +5734,7 @@ S_isSB(pTHX_ SB_enum before,
 
      * SB6. ATerm  ×  Numeric */
     if (before == SB_ATerm && after == SB_Numeric) {
-        return FALSE;
+        return false;
     }
 
     /* SB7.  (Upper | Lower) ATerm  ×  Upper */
@@ -5742,7 +5742,7 @@ S_isSB(pTHX_ SB_enum before,
         U8 * temp_pos = lpos;
         SB_enum backup = backup_one_SB(strbeg, &temp_pos, utf8_target);
         if (backup == SB_Upper || backup == SB_Lower) {
-            return FALSE;
+            return false;
         }
     }
 
@@ -5753,12 +5753,12 @@ S_isSB(pTHX_ SB_enum before,
      * separator are found */
 
     if (before == SB_Sep || before == SB_CR || before == SB_LF) {
-        has_para_sep = TRUE;
+        has_para_sep = true;
         before = backup_one_SB(strbeg, &lpos, utf8_target);
     }
 
     if (before == SB_Sp) {
-        has_sp = TRUE;
+        has_sp = true;
         do {
             before = backup_one_SB(strbeg, &lpos, utf8_target);
         }
@@ -5805,7 +5805,7 @@ S_isSB(pTHX_ SB_enum before,
                     later = advance_one_SB(&rpos, strend, utf8_target);
                 }
                 if (later == SB_Lower) {
-                    return FALSE;
+                    return false;
                 }
             }
 
@@ -5813,7 +5813,7 @@ S_isSB(pTHX_ SB_enum before,
                 || after == SB_STerm
                 || after == SB_ATerm)
             {
-                return FALSE;
+                return false;
             }
 
             if (! has_sp) {     /* SB9 applies only if there was no Sp* */
@@ -5823,7 +5823,7 @@ S_isSB(pTHX_ SB_enum before,
                     || after == SB_CR
                     || after == SB_LF)
                 {
-                    return FALSE;
+                    return false;
                 }
             }
 
@@ -5835,18 +5835,18 @@ S_isSB(pTHX_ SB_enum before,
                 || after == SB_CR
                 || after == SB_LF)
             {
-                return FALSE;
+                return false;
             }
         }
 
         /* SB11.  */
-        return TRUE;
+        return true;
     }
 
     /* Otherwise, do not break.
     SB12.  Any  ×  Any */
 
-    return FALSE;
+    return false;
 }
 
 STATIC SB_enum
@@ -5962,14 +5962,14 @@ S_isWB(pTHX_ WB_enum previous,
     before = prev;
     switch (WB_table[before][after]) {
         case WB_BREAKABLE:
-            return TRUE;
+            return true;
 
         case WB_NOBREAK:
-            return FALSE;
+            return false;
 
         case WB_hs_then_hs:     /* 2 horizontal spaces in a row */
             next = advance_one_WB(&after_pos, strend, utf8_target,
-                                 FALSE /* Don't skip Extend nor Format */ );
+                                 false /* Don't skip Extend nor Format */ );
             /* A space immediately preceding an Extend or Format is attached
              * to by them, and hence gets separated from previous spaces.
              * Otherwise don't break between horizontal white space */
@@ -5998,7 +5998,7 @@ S_isWB(pTHX_ WB_enum previous,
             if (backup_one_WB(&previous, strbeg, &before_pos, utf8_target)
                                                             == WB_Hebrew_Letter)
             {
-                return FALSE;
+                return false;
             }
 
              return WB_table[before][after] - WB_DQ_then_HL == WB_BREAKABLE;
@@ -6009,10 +6009,10 @@ S_isWB(pTHX_ WB_enum previous,
             /* WB7b  Hebrew_Letter  ×  Double_Quote Hebrew_Letter */
 
             if (advance_one_WB(&after_pos, strend, utf8_target,
-                                       TRUE /* Do skip Extend and Format */ )
+                                       true /* Do skip Extend and Format */ )
                                                             == WB_Hebrew_Letter)
             {
-                return FALSE;
+                return false;
             }
 
             return WB_table[before][after] - WB_HL_then_DQ == WB_BREAKABLE;
@@ -6024,11 +6024,11 @@ S_isWB(pTHX_ WB_enum previous,
              *       | Single_Quote) (ALetter | Hebrew_Letter) */
 
             next = advance_one_WB(&after_pos, strend, utf8_target,
-                                       TRUE /* Do skip Extend and Format */ );
+                                       true /* Do skip Extend and Format */ );
 
             if (next == WB_ALetter || next == WB_Hebrew_Letter)
             {
-                return FALSE;
+                return false;
             }
 
             return WB_table[before][after]
@@ -6043,7 +6043,7 @@ S_isWB(pTHX_ WB_enum previous,
             prev = backup_one_WB(&previous, strbeg, &before_pos, utf8_target);
             if (prev == WB_ALetter || prev == WB_Hebrew_Letter)
             {
-                return FALSE;
+                return false;
             }
 
             return WB_table[before][after]
@@ -6058,7 +6058,7 @@ S_isWB(pTHX_ WB_enum previous,
             if (backup_one_WB(&previous, strbeg, &before_pos, utf8_target)
                                                             == WB_Numeric)
             {
-                return FALSE;
+                return false;
             }
 
             return WB_table[before][after]
@@ -6070,10 +6070,10 @@ S_isWB(pTHX_ WB_enum previous,
             /* WB12  Numeric  ×  (MidNum | MidNumLet | Single_Quote) Numeric */
 
             if (advance_one_WB(&after_pos, strend, utf8_target,
-                                       TRUE /* Do skip Extend and Format */ )
+                                       true /* Do skip Extend and Format */ )
                                                             == WB_Numeric)
             {
-                return FALSE;
+                return false;
             }
 
             return WB_table[before][after]
@@ -6112,7 +6112,7 @@ S_isWB(pTHX_ WB_enum previous,
                                   before, after, WB_table[before][after]);
     assert(0);
 #endif
-    return TRUE;
+    return true;
 }
 
 STATIC WB_enum
@@ -6525,11 +6525,11 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
     int to_complement;  /* Invert the result? */
     char_class_number_ classnum;
     bool is_utf8_pat = reginfo->is_utf8_pat;
-    bool match = FALSE;
+    bool match = false;
     I32 orig_savestack_ix = PL_savestack_ix;
     U8 * script_run_begin = NULL;
     char *match_end= NULL; /* where a match MUST end to be considered successful */
-    bool is_accepted = FALSE; /* have we hit an ACCEPT opcode? */
+    bool is_accepted = false; /* have we hit an ACCEPT opcode? */
     re_fold_t folder = NULL;  /* used by various EXACTish regops */
     const U8 * fold_array = NULL; /* used by various EXACTish regops */
 
@@ -6788,7 +6788,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 ST.j_after_paren= trie->j_after_paren;
                 ST.me = scan;
                 ST.firstpos = NULL;
-                ST.longfold = FALSE; /* char longer if folded => it's harder */
+                ST.longfold = false; /* char longer if folded => it's harder */
                 ST.nextword = 0;
 
                 /* fully traverse the TRIE; note the position of the
@@ -6829,7 +6829,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                                              foldbuf, uniflags);
                         charcount++;
                         if (foldlen > 0)
-                            ST.longfold = TRUE;
+                            ST.longfold = true;
                         if (charid &&
                              ( ((offset =
                               base + charid - 1 - trie->uniquecharcount)) >= 0)
@@ -7373,7 +7373,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
           boundu:
             if (UNLIKELY(reginfo->strbeg >= reginfo->strend)) {
-                match = FALSE;
+                match = false;
             }
             else if (utf8_target) {
               bound_utf8:
@@ -7399,7 +7399,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                     }
                     case GCB_BOUND:
                         if (locinput == reginfo->strbeg || NEXTCHR_IS_EOS) {
-                            match = TRUE; /* GCB always matches at begin and
+                            match = true; /* GCB always matches at begin and
                                              end */
                         }
                         else {
@@ -7420,10 +7420,10 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
                     case LB_BOUND:
                         if (locinput == reginfo->strbeg) {
-                            match = FALSE;
+                            match = false;
                         }
                         else if (NEXTCHR_IS_EOS) {
-                            match = TRUE;
+                            match = true;
                         }
                         else {
                             match = isLB(getLB_VAL_UTF8(
@@ -7442,7 +7442,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
                     case SB_BOUND: /* Always matches at begin and end */
                         if (locinput == reginfo->strbeg || NEXTCHR_IS_EOS) {
-                            match = TRUE;
+                            match = true;
                         }
                         else {
                             match = isSB(getSB_VAL_UTF8(
@@ -7461,7 +7461,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
                     case WB_BOUND:
                         if (locinput == reginfo->strbeg || NEXTCHR_IS_EOS) {
-                            match = TRUE;
+                            match = true;
                         }
                         else {
                             match = isWB(WB_UNKNOWN,
@@ -7497,7 +7497,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
                     case GCB_BOUND:
                         if (locinput == reginfo->strbeg || NEXTCHR_IS_EOS) {
-                            match = TRUE; /* GCB always matches at begin and
+                            match = true; /* GCB always matches at begin and
                                              end */
                         }
                         else {  /* Only CR-LF combo isn't a GCB in 0-255
@@ -7509,10 +7509,10 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
                     case LB_BOUND:
                         if (locinput == reginfo->strbeg) {
-                            match = FALSE;
+                            match = false;
                         }
                         else if (NEXTCHR_IS_EOS) {
-                            match = TRUE;
+                            match = true;
                         }
                         else {
                             match = isLB(getLB_VAL_CP(UCHARAT(locinput -1)),
@@ -7526,7 +7526,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
                     case SB_BOUND: /* Always matches at begin and end */
                         if (locinput == reginfo->strbeg || NEXTCHR_IS_EOS) {
-                            match = TRUE;
+                            match = true;
                         }
                         else {
                             match = isSB(getSB_VAL_CP(UCHARAT(locinput -1)),
@@ -7540,7 +7540,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
                     case WB_BOUND:
                         if (locinput == reginfo->strbeg || NEXTCHR_IS_EOS) {
-                            match = TRUE;
+                            match = true;
                         }
                         else {
                             match = isWB(WB_UNKNOWN,
@@ -9846,11 +9846,11 @@ NULL
             }
 
             /* Here, all starting positions have been tried. */
-            matched = FALSE;
+            matched = false;
             goto ifmatch_done;
 
         case IFMATCH_A: /* body of (?...A) succeeded */
-            matched = TRUE;
+            matched = true;
           ifmatch_done:
             sw = matched == ST.wanted;
             match_end = ST.prev_match_end;
@@ -10508,7 +10508,7 @@ S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
       case ANYOF_t8:
         while (   hardcount < max
                && scan < this_eol
-               && reginclass(prog, p, (U8*)scan, (U8*) this_eol, TRUE))
+               && reginclass(prog, p, (U8*)scan, (U8*) this_eol, true))
         {
             scan += UTF8SKIP(scan);
             hardcount++;
@@ -10927,7 +10927,7 @@ S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const
     const char flags = (inRANGE(OP(n), ANYOFH, ANYOFHs))
                         ? 0
                         : ANYOF_FLAGS(n);
-    bool match = FALSE;
+    bool match = false;
     UV c = *p;
 
     PERL_ARGS_ASSERT_REGINCLASS;
@@ -10955,20 +10955,20 @@ S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const
     /* If this character is potentially in the bitmap, check it */
     if (c < NUM_ANYOF_CODE_POINTS && ! inRANGE(OP(n), ANYOFH, ANYOFHb)) {
         if (ANYOF_BITMAP_TEST(n, c))
-            match = TRUE;
+            match = true;
         else if (  (flags & ANYOFD_NON_UTF8_MATCHES_ALL_NON_ASCII__shared)
                  && OP(n) == ANYOFD
                  && ! utf8_target
                  && ! isASCII(c))
         {
-            match = TRUE;
+            match = true;
         }
         else if (flags & ANYOF_LOCALE_FLAGS) {
             if (  (flags & ANYOFL_FOLD)
                 && c < 256
                 && ANYOF_BITMAP_TEST(n, PL_fold_locale[c]))
             {
-                match = TRUE;
+                match = true;
             }
             else if (   ANYOF_POSIXL_TEST_ANY_SET(n)
                      && c <= U8_MAX  /* param to isFOO_lc() */
@@ -10997,7 +10997,7 @@ S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const
                     U8 bit_pos = lsbit_pos32(posixl_bits);
 
                     if (bit_pos % 2 ^ cBOOL(isFOO_lc(bit_pos/2, (U8) c))) {
-                        match = TRUE;
+                        match = true;
                         break;
                     }
 
@@ -11051,12 +11051,12 @@ S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const
                  * definitions of user-defined properties, if any.  It croaks
                  * if there is such a property but which still has no definition
                  * available */
-                SV * const definition = GET_REGCLASS_AUX_DATA(prog, n, TRUE, 0,
+                SV * const definition = GET_REGCLASS_AUX_DATA(prog, n, true, 0,
                                                       &only_utf8_locale, NULL);
                 if (definition) {
                     /* Most likely is the outside-the-bitmap inversion list. */
                     if (_invlist_contains_cp(definition, c)) {
-                        match = TRUE;
+                        match = true;
                     }
                     else /* Failing that, hardcode the two tests for a Turkic
                             locale */
@@ -11069,13 +11069,13 @@ S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const
                             if (_invlist_contains_cp(definition,
                                          LATIN_CAPITAL_LETTER_I_WITH_DOT_ABOVE))
                             {
-                                match = TRUE;
+                                match = true;
                             }
                         }
                         else if (_invlist_contains_cp(definition,
                                                  LATIN_SMALL_LETTER_DOTLESS_I))
                         {
-                            match = TRUE;
+                            match = true;
                         }
                     }
                 }
@@ -11095,12 +11095,12 @@ S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const
                 if (utf8_target) {
                     if (c == LATIN_CAPITAL_LETTER_I_WITH_DOT_ABOVE) {
                         if (ANYOF_BITMAP_TEST(n, 'i')) {
-                            match = TRUE;
+                            match = true;
                         }
                     }
                     else if (c == LATIN_SMALL_LETTER_DOTLESS_I) {
                         if (ANYOF_BITMAP_TEST(n, 'I')) {
-                            match = TRUE;
+                            match = true;
                         }
                     }
                 }
@@ -11112,12 +11112,12 @@ S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const
                     if (ANYOF_BITMAP_TEST(n,
                                         LATIN_CAPITAL_LETTER_I_WITH_DOT_ABOVE))
                     {
-                        match = TRUE;
+                        match = true;
                     }
                 }
                 else if (*p == 'I') {
                     if (ANYOF_BITMAP_TEST(n, LATIN_SMALL_LETTER_DOTLESS_I)) {
-                        match = TRUE;
+                        match = true;
                     }
                 }
 #endif
@@ -11397,7 +11397,7 @@ STATIC bool
 S_to_byte_substr(pTHX_ regexp *prog)
 {
     /* Converts substr fields in prog from UTF-8 to bytes, calling fbm_compile
-     * on the converted value; returns FALSE if can't be converted. */
+     * on the converted value; returns false if can't be converted. */
 
     int i = 1;
 
@@ -11407,9 +11407,9 @@ S_to_byte_substr(pTHX_ regexp *prog)
         if (prog->substrs->data[i].utf8_substr
             && !prog->substrs->data[i].substr) {
             SV* sv = newSVsv(prog->substrs->data[i].utf8_substr);
-            if (! sv_utf8_downgrade(sv, TRUE)) {
+            if (! sv_utf8_downgrade(sv, true)) {
                 SvREFCNT_dec_NN(sv);
-                return FALSE;
+                return false;
             }
             if (SvVALID(prog->substrs->data[i].utf8_substr)) {
                 if (SvTAIL(prog->substrs->data[i].utf8_substr)) {
@@ -11426,7 +11426,7 @@ S_to_byte_substr(pTHX_ regexp *prog)
         }
     } while (i--);
 
-    return TRUE;
+    return true;
 }
 
 #ifndef PERL_IN_XSUB_RE
@@ -11453,14 +11453,14 @@ Perl_is_grapheme(pTHX_ const U8 * strbeg, const U8 * s, const U8 * strend, const
         || UNLIKELY(UNICODE_IS_NONCHAR(cp)))
     {
         /* These are considered graphemes */
-        return TRUE;
+        return true;
     }
 
     /* Otherwise, unassigned code points are forbidden */
     if (UNLIKELY(! ELEMENT_RANGE_MATCHES_INVLIST(
                                     _invlist_search(PL_Assigned_invlist, cp))))
     {
-        return FALSE;
+        return false;
     }
 
     cp_gcb_val = getGCB_VAL_CP(cp);
@@ -11476,9 +11476,9 @@ Perl_is_grapheme(pTHX_ const U8 * strbeg, const U8 * s, const U8 * strend, const
 
     /* And check that is a grapheme boundary */
     if (! isGCB(prev_cp_gcb_val, cp_gcb_val, strbeg, s,
-                TRUE /* is UTF-8 encoded */ ))
+                true /* is UTF-8 encoded */ ))
     {
-        return FALSE;
+        return false;
     }
 
     /* Similarly verify there is a break between the current character and the
@@ -11491,7 +11491,7 @@ Perl_is_grapheme(pTHX_ const U8 * strbeg, const U8 * s, const U8 * strend, const
         next_cp_gcb_val = getGCB_VAL_UTF8(s, strend);
     }
 
-    return isGCB(cp_gcb_val, next_cp_gcb_val, strbeg, s, TRUE);
+    return isGCB(cp_gcb_val, next_cp_gcb_val, strbeg, s, true);
 }
 
 /*
@@ -11500,33 +11500,33 @@ Perl_is_grapheme(pTHX_ const U8 * strbeg, const U8 * s, const U8 * strend, const
 =for apidoc isSCRIPT_RUN
 
 Returns a bool as to whether or not the sequence of bytes from C<s> up to but
-not including C<send> form a "script run".  C<utf8_target> is TRUE iff the
+not including C<send> form a "script run".  C<utf8_target> is true iff the
 sequence starting at C<s> is to be treated as UTF-8.  To be precise, except for
-two degenerate cases given below, this function returns TRUE iff all code
+two degenerate cases given below, this function returns true iff all code
 points in it come from any combination of three "scripts" given by the Unicode
 "Script Extensions" property: Common, Inherited, and possibly one other.
 Additionally all decimal digits must come from the same consecutive sequence of
 10.
 
 For example, if all the characters in the sequence are Greek, or Common, or
-Inherited, this function will return TRUE, provided any decimal digits in it
+Inherited, this function will return true, provided any decimal digits in it
 are from the same block of digits in Common.  (These are the ASCII digits
 "0".."9" and additionally a block for full width forms of these, and several
 others used in mathematical notation.)   For scripts (unlike Greek) that have
 their own digits defined this will accept either digits from that set or from
 one of the Common digit sets, but not a combination of the two.  Some scripts,
 such as Arabic, have more than one set of digits.  All digits must come from
-the same set for this function to return TRUE.
+the same set for this function to return true.
 
-C<*ret_script>, if C<ret_script> is not NULL, will on return of TRUE
+C<*ret_script>, if C<ret_script> is not NULL, will on return of true
 contain the script found, using the C<SCX_enum> typedef.  Its value will be
-C<SCX_INVALID> if the function returns FALSE.
+C<SCX_INVALID> if the function returns false.
 
-If the sequence is empty, TRUE is returned, but C<*ret_script> (if asked for)
+If the sequence is empty, true is returned, but C<*ret_script> (if asked for)
 will be C<SCX_INVALID>.
 
 If the sequence contains a single code point which is unassigned to a character
-in the version of Unicode being used, the function will return TRUE, and the
+in the version of Unicode being used, the function will return true, and the
 script will be C<SCX_Unknown>.  Any other combination of unassigned code points
 in the input sequence will result in the function treating the input as not
 being a script run.
@@ -11569,7 +11569,7 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 * s, const U8 * send, const bool utf8_target)
     SV * decimals_invlist = PL_XPosix_ptrs[CC_DIGIT_];
     UV * decimals_array = invlist_array(decimals_invlist);
 
-    /* What code point is the digit '0' of the script run? (0 meaning FALSE if
+    /* What code point is the digit '0' of the script run? (0 meaning false if
      * not currently known) */
     UV zero_of_run = 0;
 
@@ -11581,7 +11581,7 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 * s, const U8 * send, const bool utf8_target)
     SCX_enum * intersection = NULL;
     PERL_UINT_FAST8_T intersection_len = 0;
 
-    bool retval = TRUE;
+    bool retval = true;
     SCX_enum * ret_script = NULL;
 
     assert(send >= s);
@@ -11593,20 +11593,20 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 * s, const U8 * send, const bool utf8_target)
      * script it is. */
     if (! utf8_target && LIKELY(send > s)) {
         if (ret_script == NULL) {
-            return TRUE;
+            return true;
         }
 
         /* If any character is Latin, the run is Latin */
         while (s < send) {
             if (isALPHA_L1(*s) && LIKELY(*s != MICRO_SIGN_NATIVE)) {
                 *ret_script = SCX_Latin;
-                return TRUE;
+                return true;
             }
         }
 
         /* Here, all are Common */
         *ret_script = SCX_Common;
-        return TRUE;
+        return true;
     }
 
     /* Look at each character in the sequence */
@@ -11623,12 +11623,12 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 * s, const U8 * send, const bool utf8_target)
          * encountered.  digit ranges in Common are not similarly blessed) */
         if (UNLIKELY(isDIGIT(*s))) {
             if (UNLIKELY(script_of_run == SCX_Unknown)) {
-                retval = FALSE;
+                retval = false;
                 break;
             }
             if (zero_of_run) {
                 if (zero_of_run != '0') {
-                    retval = FALSE;
+                    retval = false;
                     break;
                 }
             }
@@ -11681,7 +11681,7 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 * s, const U8 * send, const bool utf8_target)
             || UNLIKELY(   script_of_run != SCX_INVALID
                         && script_of_char == SCX_Unknown))
         {
-            retval = FALSE;
+            retval = false;
             break;
         }
 
@@ -11732,7 +11732,7 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 * s, const U8 * send, const bool utf8_target)
         /* Too early a Unicode version to have a code point belonging to more
          * than one script, so, if the scripts don't exactly match, fail */
         PERL_UNUSED_VAR(intersection_len);
-        retval = FALSE;
+        retval = false;
         break;
 
 #else
@@ -11750,7 +11750,7 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 * s, const U8 * send, const bool utf8_target)
             PERL_UINT_FAST8_T i;
 
             if (LIKELY(script_of_run >= 0)) {
-                retval = FALSE;
+                retval = false;
                 break;
             }
 
@@ -11772,7 +11772,7 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 * s, const U8 * send, const bool utf8_target)
                 }
             }
 
-            retval = FALSE;
+            retval = false;
             break;
         }
         else if (LIKELY(script_of_run >= 0)) {
@@ -11790,7 +11790,7 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 * s, const U8 * send, const bool utf8_target)
                 }
             }
 
-            retval = FALSE;
+            retval = false;
             break;
         }
         else {
@@ -11845,7 +11845,7 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 * s, const U8 * send, const bool utf8_target)
             /* Here we've looked through everything.  If they have no scripts
              * in common, not a run */
             if (intersection_len == 0) {
-                retval = FALSE;
+                retval = false;
                 break;
             }
 
@@ -11924,7 +11924,7 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 * s, const U8 * send, const bool utf8_target)
          * they better be the same. */
         if (zero_of_run) {
             if (zero_of_run != zero_of_char) {
-                retval = FALSE;
+                retval = false;
                 break;
             }
         }
@@ -12047,13 +12047,13 @@ Perl_reg_named_buff_exists(pTHX_ REGEXP * const r, SV * const key,
             SV *sv = CALLREG_NAMED_BUFF_FETCH(r, key, flags);
             if (sv) {
                 SvREFCNT_dec_NN(sv);
-                return TRUE;
+                return true;
             } else {
-                return FALSE;
+                return false;
             }
         }
     } else {
-        return FALSE;
+        return false;
     }
 }
 
@@ -12069,7 +12069,7 @@ Perl_reg_named_buff_firstkey(pTHX_ REGEXP * const r, const U32 flags)
 
         return CALLREG_NAMED_BUFF_NEXTKEY(r, NULL, flags & ~RXapif_FIRSTKEY);
     } else {
-        return FALSE;
+        return NULL;
     }
 }
 


### PR DESCRIPTION
... which mostly means lowercasing TRUE/FALSE, except for Perl_reg_named_buff_firstkey, which (since it returns a pointer) never should've tried to return FALSE in the first place.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
