### PR TITLE
 is_utf8_common: Use utf8_to_uv_or_die

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -6111,7 +6111,7 @@ RTi	|int	|isFF_overlong	|NN const U8 * const s			\
 				|const STRLEN len
 Ri	|bool	|is_utf8_common |NN const U8 * const p			\
 				|NN const U8 * const e			\
-				|NULLOK SV * const invlist
+				|NN SV * const invlist
 RTi	|int	|is_utf8_overlong					\
 				|NN const U8 * const s			\
 				|const STRLEN len

--- a/proto.h
+++ b/proto.h
@@ -9507,7 +9507,7 @@ PERL_STATIC_INLINE bool
 S_is_utf8_common(pTHX_ const U8 * const p, const U8 * const e, SV * const invlist)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_IS_UTF8_COMMON      \
-        assert(p); assert(e)
+        assert(p); assert(e); assert(invlist)
 
 PERL_STATIC_INLINE int
 S_is_utf8_overlong(const U8 * const s, const STRLEN len)

--- a/utf8.c
+++ b/utf8.c
@@ -3858,13 +3858,7 @@ S_is_utf8_common(pTHX_ const U8 *const p, const U8 * const e,
      * starts at <p>, and extending no further than <e - 1> is in the inversion
      * list <invlist>. */
 
-    UV cp = utf8n_to_uvchr(p, e - p, NULL, 0);
-
-    if (cp == 0 && (p >= e || *p != '\0')) {
-        force_out_malformed_utf8_message_(p, e, 0, MALFORMED_UTF8_DIE);
-        NOT_REACHED; /* NOTREACHED */
-    }
-
+    UV cp = utf8_to_uv_or_die(p, e, NULL);
     return _invlist_contains_cp(invlist, cp);
 }
 

--- a/utf8.c
+++ b/utf8.c
@@ -3852,20 +3852,19 @@ PERL_STATIC_INLINE bool
 S_is_utf8_common(pTHX_ const U8 *const p, const U8 * const e,
                        SV* const invlist)
 {
+    PERL_ARGS_ASSERT_IS_UTF8_COMMON;
+
     /* returns a boolean giving whether or not the UTF8-encoded character that
      * starts at <p>, and extending no further than <e - 1> is in the inversion
      * list <invlist>. */
 
     UV cp = utf8n_to_uvchr(p, e - p, NULL, 0);
 
-    PERL_ARGS_ASSERT_IS_UTF8_COMMON;
-
     if (cp == 0 && (p >= e || *p != '\0')) {
         force_out_malformed_utf8_message_(p, e, 0, MALFORMED_UTF8_DIE);
         NOT_REACHED; /* NOTREACHED */
     }
 
-    assert(invlist);
     return _invlist_contains_cp(invlist, cp);
 }
 


### PR DESCRIPTION
Replace this longer code by this newer function which encapsulates the
functionality in one line.

* This set of changes does not require a perldelta entry.
