### PR TITLE
amagic_call: quieten Coverity complaint about PL_op

### DIFF
--- a/gv.c
+++ b/gv.c
@@ -4170,7 +4170,7 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int flags)
                  * with the context of individual concats being scalar,
                  * regardless of the overall context of the multiconcat op
                  */
-    U8 gimme = (force_scalar || (PL_op && PL_op->op_type == OP_MULTICONCAT))
+    U8 gimme = (force_scalar || !PL_op || PL_op->op_type == OP_MULTICONCAT)
                     ? G_SCALAR : GIMME_V;
 
     CATCH_SET(TRUE);


### PR DESCRIPTION
Coverity complained here since if force_scalar were false while PL_op was NULL, with the previous code this would call GIMME_V which immediately dereferences PL_op, which would be UB.

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->


<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
