### PR TITLE
pp_hot.c: delete dead assignment

### DIFF
--- a/pp_hot.c
+++ b/pp_hot.c
@@ -1142,7 +1142,6 @@ PP(pp_multiconcat)
             Copy(svpv_p->pv, targ_pv, len, char);
             targ_pv += len;
         }
-        const_lens += (svpv_end - svpv_base + 1);
     }
     else {
         /* Note that we iterate the loop nargs+1 times: to append nargs


### PR DESCRIPTION
There is no point in updating `const_lens` because the variable isn't used past this point.


---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
