### PR TITLE
S_scan_const: Use utf8_to_uv_or_die not utf8n_to_uvchr

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -4155,10 +4155,10 @@ S_scan_const(pTHX_ char *start)
                                 char hex_string[2 * UTF8_MAXBYTES + 5];
 
                                 /* Get the first character of the result. */
-                                U32 uv = utf8n_to_uvchr((U8 *) str,
-                                                        len,
-                                                        &char_length,
-                                                        UTF8_ALLOW_ANYUV);
+                                U32 uv = utf8_to_uv_or_die(
+                                                         (const U8 *) str,
+                                                         (const U8 *) str_end,
+                                                         &char_length);
                                 /* Convert first code point to Unicode hex,
                                  * including the boiler plate before it. */
                                 output_length =
@@ -4179,10 +4179,10 @@ S_scan_const(pTHX_ char *start)
                                 * its Unicode code point in hex */
                                 while ((str += char_length) < str_end) {
                                     const STRLEN off = d - SvPVX_const(sv);
-                                    U32 uv = utf8n_to_uvchr((U8 *) str,
-                                                            str_end - str,
-                                                            &char_length,
-                                                            UTF8_ALLOW_ANYUV);
+                                    U32 uv = utf8_to_uv_or_die(
+                                                         (const U8 *) str,
+                                                         (const U8 *) str_end,
+                                                         &char_length);
                                     output_length =
                                         my_snprintf(hex_string,
                                              sizeof(hex_string),


### PR DESCRIPTION
This will now croak if the input is malformed instead of wrongly turning it into a NUL.

* This set of changes does not require a perldelta entry.
