### PR TITLE
Use favored name uv_to_utf8

### DIFF
--- a/perl.c
+++ b/perl.c
@@ -3706,7 +3706,7 @@ Perl_moreswitches(pTHX_ const char *s)
               }
               PL_rs = newSV((STRLEN)(UVCHR_SKIP(rschar) + 1));
               tmps = (U8*)SvPVCLEAR_FRESH(PL_rs);
-              uvchr_to_utf8(tmps, rschar);
+              uv_to_utf8(tmps, rschar);
               SvCUR_set(PL_rs, UVCHR_SKIP(rschar));
               SvUTF8_on(PL_rs);
          }

--- a/utf8.c
+++ b/utf8.c
@@ -3437,7 +3437,7 @@ Perl_utf16_to_utf8_base(pTHX_ U8* p, U8* d, Size_t bytelen, Size_t *newlen,
         }
 
         /* Here, 'uv' is the real U32 we want to find the UTF-8 of */
-        d = uvchr_to_utf8(d, uv);
+        d = uv_to_utf8(d, uv);
     }
 
     *newlen = d - dstart;
@@ -3842,7 +3842,7 @@ Perl__to_uni_fold_flags(pTHX_ UV c, U8* p, STRLEN *lenp, U8 flags)
         U8 utf8_c[UTF8_MAXBYTES + 1];
 
       needs_full_generality:
-        uvchr_to_utf8(utf8_c, c);
+        uv_to_utf8(utf8_c, c);
         return _toFOLD_utf8_flags(utf8_c, utf8_c + C_ARRAY_LENGTH(utf8_c),
                                   p, lenp, flags);
     }
@@ -4077,10 +4077,10 @@ S__to_utf8_case(pTHX_ const UV original, const U8 *p,
         U8 * d = ustrp;
         Size_t i;
 
-        d = uvchr_to_utf8(d, first);
+        d = uv_to_utf8(d, first);
 
         for (i = 0; i < remaining_count; i++) {
-            d = uvchr_to_utf8(d, remaining_list[i]);
+            d = uv_to_utf8(d, remaining_list[i]);
         }
 
         *d = '\0';


### PR DESCRIPTION
This replaces its synonym with the more modern name.  There should be no difference in the generated assembly language.


* This set of changes does not require a perldelta entry.
