### PR TITLE
sv_vcatpvfn_flags: Use utf8_to_uv

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -13090,8 +13090,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                 if (!veclen)
                     goto done_valid_conversion;
                 if (vec_utf8)
-                    uv = utf8n_to_uvchr(vecstr, veclen, &ulen,
-                                        UTF8_ALLOW_ANYUV);
+                    (void) utf8_to_uv(vecstr, vecstr + veclen, &uv, &ulen);
                 else {
                     uv = *vecstr;
                     ulen = 1;


### PR DESCRIPTION
This is a change in behavior for malformed input.  Previously it warned and substituted 0; the warnings remain, but now it substitutes the REPLACEMENT CHARACTER.


* This set of changes does not require a perldelta entry.
