### PR TITLE
pv_uni_display: Revert use of utf8_to_uv_or_die

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -4781,7 +4781,7 @@ Perl_pv_uni_display(pTHX_ SV *dsv, const U8 *spv, STRLEN len, STRLEN pvlim,
              break;
         }
 
-        u = utf8_to_uv_or_die(s, e, &next_len);
+        (void) utf8_to_uv(s, e, &u, &next_len);
         assert(next_len > 0);
 
         if (u < 256) {


### PR DESCRIPTION
This fixes #23089

Croaking when someone is trying to output a malformed UTF-8 sequence turns out to be a bad idea.  That should have been obvious to me.

But instead of going back to the problematic utf8_to_uvchr_buf(), thiscommit uses the non-croaking utf8_to_uv().

Croaking should not be done when at the user interface.  It makes sense, for example, when things should have already been validated and there is no good option to proceed.


* This set of changes does not require a perldelta entry.
