### PR TITLE
Revert "utf8n_to_uvuni: Use utf8_to_uv()"

### DIFF
--- a/mathoms.c
+++ b/mathoms.c
@@ -199,9 +199,7 @@ Perl_utf8n_to_uvuni(pTHX_ const U8 *s, STRLEN curlen, STRLEN *retlen, U32 flags)
 {
     PERL_ARGS_ASSERT_UTF8N_TO_UVUNI;
 
-    UV cp;
-    (void) utf8_to_uv_flags(s, s + curlen, &cp, retlen, flags);
-    return NATIVE_TO_UNI(cp);
+    return NATIVE_TO_UNI(utf8n_to_uvchr(s, curlen, retlen, flags));
 }
 
 UV


### PR DESCRIPTION
This reverts commit d62b9faceeab661e8ad54242581ee292f1dbd8c8. That commit turns out to be ill advised.  I forgot that the function call it replaced also calls utf8_to_uv() and then munges its return value. This commit to succeed would have needed the same munging.  But rather than repeat that logic, just call the original function, by simply reverting this commit.

This plus #23093 fixes #23053.  I haven't tested them, but it likely also takes care of #22820, #23086, and #22977

Note added later: This doesn't, in fact, handle #22820

* This set of changes does not require a perldelta entry.
