### PR TITLE
perldata: document binary/octal floating-point constants

### DIFF
--- a/pod/perldata.pod
+++ b/pod/perldata.pod
@@ -444,6 +444,9 @@ integer formats:
  0o12_345            # alternative octal (introduced in Perl 5.33.5)
  0b011011            # binary
  0x1.999ap-4         # hexadecimal floating point (the 'p' is required)
+ 07.65p2             # octal floating point (the 'p' is required)
+ 0o7.65p2            # alternative octal floating point
+ 0b101.01p-1         # binary floating point (the 'p' is required)
 
 You are allowed to use underscores (underbars) in numeric literals
 between digits for legibility (but not multiple underscores in a row:
@@ -477,6 +480,9 @@ platforms use the 64-bit IEEE 754 floating point, not all do.  Another
 potential source of (low-order) differences are the floating point
 rounding modes, which can differ between CPUs, operating systems,
 and compilers, and which Perl doesn't control.
+
+Octal and binary floating point numbers use the same format as hexadecimal
+floating point numbers, but limited to binary and octal digits, respectively.
 
 You can also embed newlines directly in your strings, i.e., they can end
 on a different line than they begin.  This is nice, but if you forget

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -174,13 +174,17 @@ section.
 
 Additionally, the following selected changes have been made:
 
-=head3 L<XXX>
+=head3 L<perldata>
 
 =over 4
 
 =item *
 
-XXX Description of the change here
+Binary and octal floating-point constants (such as C<012.345p-2> and
+C<0b101.11p-1>) are now documented. This feature was first introduced in perl
+5.22.0 together with hexadecimal floating-point constants and had a few bug
+fixes in perl 5.28.0, but it was never formally documented.
+[GH #18664]
 
 =back
 


### PR DESCRIPTION
This (possibly accidental) feature has had tests since commit 58be57636a and bug fixes such as commit 2cb5a7e8af. See also the discussion in GH issues #16114 and #14791, particularly jhi's comment in <https://github.com/Perl/perl5/issues/16114#issuecomment-544090886>:

> Relatedly: I remember there being a known "loophole" so that the
> scanning code currently accidentally, falling naturally out of the
> implementation, is also doing "binary fp" and "octal fp". Ah yes:
>
>     ./miniperl -wle 'print 0b11.1p0'
>     3.5
>     ./miniperl -wle 'print 011.1p0'
>     9.125
>
> This is probably not documented anywhere. I can't now think of the
> right search terms to find any previous discussion, there was something
> about should this be rejected, or not. If not (as is currently the
> case), maybe this possibly should be tested, documented, and made
> official?

With the documentation in this patch and the existing tests, I guess the feature is now official.

Fixes #18664.

---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
