### PR TITLE
Makefile.SH: add generated *.inc files to ctags scan

### DIFF
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -1750,7 +1750,7 @@ TAGS: $(c_base) $(h)
 $spitshell >>$Makefile <<!GROK!THIS!
 
 ctags:
-	ctags -N --languages=c --langmap=c:+.h $ctags_exclude *.c *.h
+	ctags -N --languages=c --langmap=c:+.h.inc $ctags_exclude *.c *.h *.inc
 
 # AUTOMATICALLY GENERATED MAKE DEPENDENCIES--PUT NOTHING BELOW THIS LINE
 # If this runs make out of memory, delete /usr/include lines.


### PR DESCRIPTION
Otherwise the tags file won't have entries for symbols like 'AboveLatin1_invlist'.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
