### PR TITLE
perlapi: there is no utf8_uvchr

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -1224,7 +1224,7 @@ Because of these quirks, C<utf8_to_uvchr_buf> is very difficult to use
 correctly and handle all cases.  Generally, you need to bail out at the first
 failure it finds.
 
-The deprecated C<utf8_uvchr> behaves the same way as C<utf8_to_uvchr_buf> for
+The deprecated C<utf8_to_uvchr> behaves the same way as C<utf8_to_uvchr_buf> for
 well-formed input, and for the malformations it is capable of finding, but
 doesn't find all of them, and it can read beyond the end of the input buffer,
 which is why it is deprecated.


### PR DESCRIPTION
Noticed while reviewing 23088
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
