### PR TITLE
Perl_vnewSVpvf - use the pattern length to size the new PV buffer

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -10009,9 +10009,11 @@ Perl_vnewSVpvf(pTHX_ const char *const pat, va_list *const args)
 
     PERL_ARGS_ASSERT_VNEWSVPVF;
 
-    sv = newSV(1);
+    STRLEN patlen = strlen(pat);
+
+    sv = newSV(patlen);
     SvPVCLEAR_FRESH(sv);
-    sv_vcatpvfn_flags(sv, pat, strlen(pat), args, NULL, 0, NULL, 0);
+    sv_vcatpvfn_flags(sv, pat, patlen, args, NULL, 0, NULL, 0);
     return sv;
 }
 


### PR DESCRIPTION
This function currently creates a new `SVt_PV` with a minimum string length buffer via:

    sv = newSV(1);

Simple measurements from compiling perl show that this is often sufficient.

When it isn't, the final buffer length is often close to `strlen(pat)`. Common cases that require a `realloc()` now will not with this commit. In other cases, `realloc()`s will still be required, but the number will likely be smaller by one.

Although min length & alloc behaviour can vary across platforms and compilers, the following numbers are likely indicative:

|strlen(pat)|Inital SvLEN before|Initial SvLEN now|Final SvLEN|
|-----------|-------------------|-----------------|-----------|
|  4|16| 16| 16|
| 58|16| 60| 60|
| 71|16| 73|120|
|104|16|106|106|
|104|16|106|200|
|122|16|124|124|
|123|16|125|125|
|123|16|125|168|
|377|16|379|379|

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
