### PR TITLE
release_schedule: remove Zefram from release engineer backup list

### DIFF
--- a/Porting/release_schedule.pod
+++ b/Porting/release_schedule.pod
@@ -90,7 +90,6 @@ consent of the Steering Council.)
   Tatsuhiko Miyagawa <miyagawa@bulknews.net>
   Tony Cook <tony@develop-help.com>
   Yves Orton <demerphq@gmail.com>
-  Zefram <zefram@fysh.org>
   Ævar Arnfjörð Bjarmason <avar@cpan.org>
 
 =head1 AUTHOR


### PR DESCRIPTION
RIP Zefram.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
