### PR TITLE
various tests: replace BEGIN/require/import by use

### DIFF
--- a/dist/I18N-Collate/t/I18N-Collate.t
+++ b/dist/I18N-Collate/t/I18N-Collate.t
@@ -6,8 +6,8 @@
 use strict;
 no warnings;
 
+use Config;
 BEGIN {
-    require Config; Config->import;
     if (!$::Config{d_setlocale} || $::Config{ccflags} =~ /\bD?NO_LOCALE\b/) {
 	print "1..0\n";
 	exit;

--- a/dist/IO/t/io_linenum.t
+++ b/dist/IO/t/io_linenum.t
@@ -7,8 +7,8 @@ my $File;
 
 BEGIN {
     $File = __FILE__;
-    require strict; strict->import();
 }
+use strict;
 
 use Test::More tests => 12;
 

--- a/dist/Safe/t/safe1.t
+++ b/dist/Safe/t/safe1.t
@@ -1,7 +1,7 @@
 #!./perl -w
 $|=1;
+use Config;
 BEGIN {
-    require Config; Config->import;
     if ($Config{'extensions'} !~ /\bOpcode\b/ && $Config{'osname'} ne 'VMS') {
         print "1..0\n";
         exit 0;

--- a/dist/Safe/t/safe2.t
+++ b/dist/Safe/t/safe2.t
@@ -1,7 +1,7 @@
 #!./perl -w
 $|=1;
+use Config;
 BEGIN {
-    require Config; Config->import;
     if ($Config{'extensions'} !~ /\bOpcode\b/ && $Config{'osname'} ne 'VMS') {
         print "1..0\n";
         exit 0;

--- a/dist/Safe/t/safe3.t
+++ b/dist/Safe/t/safe3.t
@@ -1,7 +1,7 @@
 #!perl -w
 
+use Config;
 BEGIN {
-    require Config; Config->import;
     if ($Config{'extensions'} !~ /\bOpcode\b/
 	&& $Config{'extensions'} !~ /\bPOSIX\b/
 	&& $Config{'osname'} ne 'VMS')

--- a/dist/Safe/t/safeload.t
+++ b/dist/Safe/t/safeload.t
@@ -1,8 +1,7 @@
 #!perl
 
+use Config;
 BEGIN {
-    require Config;
-    Config->import;
     if ($Config{'extensions'} !~ /\bOpcode\b/) {
 	print "1..0\n";
 	exit 0;

--- a/dist/Safe/t/saferegexp.t
+++ b/dist/Safe/t/saferegexp.t
@@ -1,7 +1,7 @@
 #!perl -w
 
+use Config;
 BEGIN {
-    require Config; Config->import;
     if ($Config{'extensions'} !~ /\bOpcode\b/) {
         print "1..0\n";
         exit 0;

--- a/dist/Safe/t/safesecurity.t
+++ b/dist/Safe/t/safesecurity.t
@@ -1,8 +1,7 @@
 #!perl
 
+use Config;
 BEGIN {
-    require Config;
-    Config->import;
     if ($Config{'extensions'} !~ /\bOpcode\b/) {
 	print "1..0\n";
 	exit 0;

--- a/dist/Safe/t/safesig.t
+++ b/dist/Safe/t/safesig.t
@@ -1,8 +1,7 @@
 #!perl
 
+use Config;
 BEGIN {
-    require Config;
-    Config->import;
     if ($Config{'extensions'} !~ /\bOpcode\b/) {
         print "1..0\n";
         exit 0;

--- a/dist/Safe/t/safesort.t
+++ b/dist/Safe/t/safesort.t
@@ -1,7 +1,7 @@
 #!perl -w
 $|=1;
+use Config;
 BEGIN {
-    require Config; Config->import;
     if ($Config{'extensions'} !~ /\bOpcode\b/ && $Config{'osname'} ne 'VMS') {
         print "1..0\n";
         exit 0;

--- a/dist/Safe/t/safeuniversal.t
+++ b/dist/Safe/t/safeuniversal.t
@@ -1,8 +1,7 @@
 #!perl
 
+use Config;
 BEGIN {
-    require Config;
-    Config->import;
     if ($Config{'extensions'} !~ /\bOpcode\b/) {
 	print "1..0\n";
 	exit 0;

--- a/dist/Safe/t/safeutf8.t
+++ b/dist/Safe/t/safeutf8.t
@@ -1,7 +1,7 @@
 #!perl -w
 $|=1;
+use Config;
 BEGIN {
-    require Config; Config->import;
     if ($Config{'extensions'} !~ /\bOpcode\b/ && $Config{'osname'} ne 'VMS') {
         print "1..0\n";
         exit 0;

--- a/dist/Safe/t/safewrap.t
+++ b/dist/Safe/t/safewrap.t
@@ -1,8 +1,8 @@
 #!perl -w
 
 $|=1;
+use Config;
 BEGIN {
-    require Config; Config->import;
     if ($Config{'extensions'} !~ /\bOpcode\b/ && $Config{'osname'} ne 'VMS') {
         print "1..0\n";
         exit 0;

--- a/ext/Devel-Peek/t/Peek.t
+++ b/ext/Devel-Peek/t/Peek.t
@@ -1,7 +1,7 @@
 #!./perl -T
 
+use Config;
 BEGIN {
-    require Config; Config->import;
     if ($Config{'extensions'} !~ /\bDevel\/Peek\b/) {
         print "1..0 # Skip: Devel::Peek was not built\n";
         exit 0;

--- a/ext/Fcntl/t/syslfs.t
+++ b/ext/Fcntl/t/syslfs.t
@@ -2,15 +2,15 @@
 # stdio: open(), tell(), seek(), print(), read() is tested in t/op/lfs.t.
 # If you modify/add tests here, remember to update also t/op/lfs.t.
 
+use Config;
 BEGIN {
-	require Config; Config->import;
 	# Don't bother if there are no quad offsets.
 	if ($Config{lseeksize} < 8) {
 		print "1..0 # Skip: no 64-bit file offsets\n";
 		exit(0);
 	}
-	require Fcntl; Fcntl->import(qw(/^O_/ /^SEEK_/));
 }
+use Fcntl qw(/^O_/ /^SEEK_/);
 
 use strict;
 use File::Temp 'tempfile';

--- a/ext/IPC-Open3/t/IPC-Open3.t
+++ b/ext/IPC-Open3/t/IPC-Open3.t
@@ -1,7 +1,7 @@
 #!./perl -w
 
+use Config;
 BEGIN {
-    require Config; Config->import;
     if (!$Config{'d_fork'}
        # open2/3 supported on win32
        && $^O ne 'MSWin32')

--- a/ext/Opcode/t/Opcode.t
+++ b/ext/Opcode/t/Opcode.t
@@ -2,8 +2,8 @@
 
 $|=1;
 
+use Config;
 BEGIN {
-    require Config; Config->import;
     if ($Config{'extensions'} !~ /\bOpcode\b/ && $Config{'osname'} ne 'VMS') {
         print "1..0\n";
         exit 0;

--- a/ext/Opcode/t/ops.t
+++ b/ext/Opcode/t/ops.t
@@ -1,7 +1,7 @@
 #!./perl
 
+use Config;
 BEGIN {
-    require Config; Config->import;
     if ($Config{'extensions'} !~ /\bOpcode\b/ && $Config{'osname'} ne 'VMS') {
         print "1..0\n";
         exit 0;

--- a/ext/POSIX/t/mb.t
+++ b/ext/POSIX/t/mb.t
@@ -7,8 +7,8 @@
 # the Perl one.  So we run the tests in a separate "fresh_perl" process
 # with the correct LC_CTYPE set in the environment.
 
+use Config;
 BEGIN {
-    require Config; Config->import;
     if ($^O ne 'VMS' and $Config{'extensions'} !~ /\bPOSIX\b/) {
 	print "1..0\n";
 	exit 0;

--- a/ext/POSIX/t/posix.t
+++ b/ext/POSIX/t/posix.t
@@ -1,7 +1,7 @@
 #!./perl
 
+use Config;
 BEGIN {
-    require Config; Config->import;
     if ($^O ne 'VMS' and $Config{'extensions'} !~ /\bPOSIX\b/) {
 	print "1..0\n";
 	exit 0;

--- a/ext/POSIX/t/taint.t
+++ b/ext/POSIX/t/taint.t
@@ -1,7 +1,7 @@
 #!./perl -Tw
 
+use Config;
 BEGIN {
-    require Config; Config->import;
     if ($^O ne 'VMS' and $Config{'extensions'} !~ /\bPOSIX\b/) {
 	print "1..0\n";
 	exit 0;

--- a/ext/Sys-Hostname/t/Hostname.t
+++ b/ext/Sys-Hostname/t/Hostname.t
@@ -1,7 +1,7 @@
 #!./perl
 
+use Config;
 BEGIN {
-    require Config; Config->import;
     if ($Config{'extensions'} !~ /\bSys\/Hostname\b/) {
       print "1..0 # Skip: Sys::Hostname was not built\n";
       exit 0;

--- a/ext/XS-APItest/t/my_cxt.t
+++ b/ext/XS-APItest/t/my_cxt.t
@@ -4,8 +4,8 @@
 # DAPM Dec 2005
 
 my $threads;
+use Config;
 BEGIN {
-    require Config; Config->import;
     $threads = $Config{'useithreads'};
     # must 'use threads' before 'use Test::More'
     eval 'use threads' if $threads;

--- a/ext/XS-Typemap/t/Typemap.t
+++ b/ext/XS-Typemap/t/Typemap.t
@@ -1,5 +1,5 @@
+use Config;
 BEGIN {
-    require Config; Config->import;
     if ($Config{'extensions'} !~ /\bXS\/Typemap\b/) {
         print "1..0 # Skip: XS::Typemap was not built\n";
         exit 0;

--- a/lib/AnyDBM_File.t
+++ b/lib/AnyDBM_File.t
@@ -3,10 +3,10 @@
 BEGIN {
     chdir 't' if -d 't';
     @INC = '../lib';
-    require Config; Config->import;
-    require Test::More; Test::More->import;
-    plan(tests, 12);
 }
+use Config;
+use Test::More;
+plan(tests, 12);
 
 require AnyDBM_File;
 use Fcntl;

--- a/lib/Net/hostent.t
+++ b/lib/Net/hostent.t
@@ -6,9 +6,9 @@ BEGIN {
 }
 
 use Test::More;
+use Config;
 
 BEGIN {
-    require Config; Config->import;
     if ($Config{'extensions'} !~ /\bSocket\b/ && 
         !(($^O eq 'VMS') && $Config{d_socket})) 
     {
@@ -18,8 +18,6 @@ BEGIN {
 	plan skip_all => "Test relies on resolution of localhost, fails on $^O ($Config{osvers})";
     }
 }
-
-use Test::More;
 
 BEGIN { use_ok 'Net::hostent' }
 

--- a/lib/locale.t
+++ b/lib/locale.t
@@ -54,8 +54,8 @@ BEGIN {
 	exit;
     }
     $| = 1;
-    require Config; Config->import;
 }
+use Config;
 
 use feature 'fc';
 my @langinfo;

--- a/lib/open.t
+++ b/lib/open.t
@@ -3,10 +3,10 @@
 BEGIN {
 	chdir 't' if -d 't';
 	@INC = '../lib';
-	require Config; Config->import;
 	require './test.pl';
 	require './charset_tools.pl';
 }
+use Config;
 
 plan 11;
 

--- a/t/io/errnosig.t
+++ b/t/io/errnosig.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc( qw(. ../lib) );
 }
 
-require Config; Config->import;
+use Config;
 plan(tests => 1);
 
 SKIP: {

--- a/t/io/pipe.t
+++ b/t/io/pipe.t
@@ -4,8 +4,8 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib');
-    require Config; Config->import;
 }
+use Config;
 if (!$Config{'d_fork'}) {
     skip_all("fork required to pipe");
 }

--- a/t/io/semctl.t
+++ b/t/io/semctl.t
@@ -3,8 +3,8 @@ BEGIN {
   @INC = '../lib' if -d '../lib' && -d '../ext';
 
   require "./test.pl";
-  require Config; Config->import;
 }
+use Config;
 
 use strict;
 use warnings;

--- a/t/lib/commonsense.t
+++ b/t/lib/commonsense.t
@@ -5,10 +5,9 @@ BEGIN {
     @INC = '../lib';
     require './test.pl';
 }
+use Config;
 
 plan( tests => 1);
-
-require Config; Config->import;
 
 if (($Config{'extensions'} !~ /\bFcntl\b/) ){
   BAIL_OUT("Perl configured without Fcntl module");

--- a/t/op/lc.t
+++ b/t/op/lc.t
@@ -9,7 +9,6 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib');
-    require Config; Config->import;
     skip_all_without_unicode_tables();
     require './charset_tools.pl';
     require './loc_tools.pl';   # Contains find_utf8_ctype_locale()

--- a/t/op/quotemeta.t
+++ b/t/op/quotemeta.t
@@ -4,9 +4,9 @@ BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
     set_up_inc(  qw(../lib .) );
-    require Config; Config->import;
     require "./loc_tools.pl";
 }
+use Config;
 
 plan tests => 60;
 

--- a/t/re/anyof.t
+++ b/t/re/anyof.t
@@ -16,9 +16,9 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib','.','../ext/re');
-    require Config; Config->import;
     skip_all('no re module') unless defined &DynaLoader::boot_DynaLoader;
 }
+use Config;
 
 # An array is used instead of a hash, so that the tests are carried out in the
 # order given by this file.  Even-numbered indices are the regexes to compile.

--- a/t/re/fold_grind.pl
+++ b/t/re/fold_grind.pl
@@ -12,7 +12,6 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib');
-    require Config; Config->import;
     skip_all_if_miniperl("no dynamic loading on miniperl, no Encode nor POSIX");
     if ($^O eq 'dec_osf') {
       skip_all("$^O cannot handle this test");

--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -18,10 +18,10 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib', '.', '../ext/re');
-    require Config; Config->import;
     require './charset_tools.pl';
     require './loc_tools.pl';
 }
+use Config;
 
 skip_all_without_unicode_tables();
 

--- a/t/re/speed.t
+++ b/t/re/speed.t
@@ -18,8 +18,8 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib','.','../ext/re');
-    require Config; Config->import;
 }
+use Config;
 
 skip_all('no re module') unless defined &DynaLoader::boot_DynaLoader;
 skip_all_without_unicode_tables();

--- a/t/re/stclass_threads.t
+++ b/t/re/stclass_threads.t
@@ -15,7 +15,6 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib', '.', '../ext/re');
-    require Config; Config->import;
 }
 
 skip_all_without_config('useithreads');

--- a/t/re/subst.t
+++ b/t/re/subst.t
@@ -4,12 +4,11 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib');
-    require Config; Config->import;
-    require constant;
-    constant->import(constcow => *Config::{NAME});
     require './charset_tools.pl';
     require './loc_tools.pl';
 }
+use Config;
+use constant constcow => *Config::{NAME};
 
 plan(tests => 281);
 

--- a/t/run/runenv_hashseed.t
+++ b/t/run/runenv_hashseed.t
@@ -45,9 +45,8 @@ BEGIN {
     chdir 't' if -d 't';
     @INC = '../lib';
     require './test.pl';
-    require Config;
-    Config->import;
 }
+use Config;
 
 skip_all_without_config('d_fork');
 skip_all("NO_PERL_HASH_ENV or NO_PERL_HASH_SEED_DEBUG set")

--- a/t/run/runenv_randseed.t
+++ b/t/run/runenv_randseed.t
@@ -4,9 +4,8 @@ BEGIN {
     chdir 't' if -d 't';
     @INC = '../lib';
     require './test.pl';
-    require Config;
-    Config->import;
 }
+use Config;
 
 skip_all_without_config('d_fork');
 skip_all("This perl is built with NO_PERL_RAND_SEED")

--- a/t/run/switchM.t
+++ b/t/run/switchM.t
@@ -3,10 +3,8 @@
 BEGIN {
     chdir 't' if -d 't';
     @INC = '../lib';
-    require Config;
-    Config->import;
-
 }
+use Config;
 use strict;
 use warnings;
 

--- a/t/run/switches.t
+++ b/t/run/switches.t
@@ -7,10 +7,9 @@
 BEGIN {
     chdir 't' if -d 't';
     @INC = '../lib';
-    require Config; Config->import;
+    require "./test.pl";
+    require "./loc_tools.pl";
 }
-
-BEGIN { require "./test.pl";  require "./loc_tools.pl"; }
 
 use Config;
 

--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -5,8 +5,8 @@ BEGIN {
     set_up_inc('../lib', '.', '../ext/re');
     require './charset_tools.pl';
     require './loc_tools.pl';
-    require Config; Config->import;
 }
+use Config;
 
 use strict;
 use warnings;

--- a/t/uni/fold.t
+++ b/t/uni/fold.t
@@ -10,7 +10,6 @@ BEGIN {
     set_up_inc('../lib');
     skip_all_without_unicode_tables();
     skip_all_if_miniperl("miniperl, no Unicode::Normalize");
-    require Config; Config->import;
     require './charset_tools.pl';
     require './loc_tools.pl';   # Contains find_utf8_ctype_locale()
 }

--- a/t/uni/overload.t
+++ b/t/uni/overload.t
@@ -4,7 +4,6 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc( '../lib' );
-    require Config; Config->import;
     require './charset_tools.pl';
     require './loc_tools.pl';
 }

--- a/t/win32/runenv.t
+++ b/t/win32/runenv.t
@@ -8,8 +8,6 @@
 BEGIN {
     chdir 't' if -d 't';
     @INC = '../lib';
-    require Config; Config->import;
-    require File::Temp; File::Temp->import(qw/:POSIX/);
 
     require Win32;
     ($::os_id, $::os_major) = ( Win32::GetOSVersion() )[ 4, 1 ];
@@ -22,6 +20,8 @@ BEGIN {
 
     require './test.pl';
 }
+use Config;
+use File::Temp qw/:POSIX/;
 
 skip_all "requires compilation with PERL_IMPLICIT_SYS"
   unless $Config{ccflags} =~/(?:\A|\s)-DPERL_IMPLICIT_SYS\b/;


### PR DESCRIPTION
That is, turn

    BEGIN {
        require Foo;
        Foo->import(...);
    }

into

    use Foo ...;

(Except for a few tests that did the `require Config; Config->import` dance without actually using `%Config` anywhere, so I just deleted the import code.)

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
