### PR TITLE
perldelta for year of ExtUtils::ParseXS changes

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -171,6 +171,38 @@ On platforms that don't support Inf/NaN values in floating-point numbers (such
 as VAX), C<builtin::inf> and C<builtin::nan> now throw a runtime error (rather
 than breaking the perl build). [GH #22882]
 
+=item *
+
+L<ExtUtils::ParseXS> has been extensively refactored internally and
+extensive tests have been added. Most of these changes shouldn't be
+visible externally with a few exceptions, the main ones being:
+
+The generated C code, especially for returning values, may have changed
+slightly, and in some cases be slightly more efficient (in particular,
+using TARG more often to return a value rather than creating a new
+temporary).
+
+The parser is more likely to give warnings now on XS errors which
+previously would have just silently generated invalid C code.
+
+One XS bug has been fixed in a way that may be highly visible. Previously
+when parsing the parameters of an XS sub declaration, if a parameter
+couldn't be parsed, it was quietly ignored. This meant that it would still
+consume an argument, but wouldn't declare a C variable: a bit like the
+Perl-level C<my ($a, undef, $c) = @_>. Now, it gives a compile error. This
+will break XS code that does (for example):
+
+    void
+    foo(int a, /* skip arg */, int c)
+
+because C-comments aren't part of XS syntax, and so the parameter was a
+syntax error and was quietly skipped. This is better written as
+
+    void
+    foo(int a, b, int c)
+
+since parameters which are not assigned a type act as placeholders.
+
 =back
 
 =head2 Removed Modules and Pragmata


### PR DESCRIPTION
Add a perldelta entry mentioning that ParseXS has been heavily refactored over the last year.

I haven't been adding entries for each monthly release as it was a work in progress, and most changes weren't externally visible.

It's still a work in progress, but I'm intending to defer any further changes until after the 5.42.0 release, so now seems good time for the perldelta entry.
