### PR TITLE
Search::Dict: clean up code

### DIFF
--- a/dist/Search-Dict/lib/Search/Dict.pm
+++ b/dist/Search-Dict/lib/Search/Dict.pm
@@ -1,19 +1,18 @@
 package Search::Dict;
-require 5.000;
-require Exporter;
+use strict;
+use Exporter;
 
-my $fc_available;
 BEGIN {
-  $fc_available = '5.015008';
-  if ( $] ge $fc_available ) {
-    require feature;
-    'feature'->import('fc'); # string avoids warning on old Perls <sigh>
-  }
+    if ("$]" >= 5.015008) {
+        require feature;
+        'feature'->import('fc'); # string avoids warning on old Perls <sigh>
+    } else {
+        # ($) prototype, not (_), for perl 5.8 compatibility, just in case
+        *fc = sub ($) { lc $_[0] };
+    }
 }
 
-use strict;
-
-our $VERSION = '1.07';
+our $VERSION = '1.08';
 our @ISA = qw(Exporter);
 our @EXPORT = qw(look);
 
@@ -27,7 +26,7 @@ Search::Dict - look - search for key in dictionary file
     look *FILEHANDLE, $key, $dict, $fold;
 
     use Search::Dict;
-    look *FILEHANDLE, $params;
+    look *FILEHANDLE, $key, $params;
 
 =head1 DESCRIPTION
 
@@ -80,7 +79,7 @@ sub look {
     $blksize ||= 8192;
     $key =~ s/[^\w\s]//g if $dict;
     if ( $fold ) {
-      $key = $] ge $fc_available ? fc($key) : lc($key);
+      $key = fc($key);
     }
     # find the right block
     my($min, $max) = (0, int($size / $blksize));
@@ -95,7 +94,7 @@ sub look {
 	chomp;
 	s/[^\w\s]//g if $dict;
         if ( $fold ) {
-          $_ = $] ge $fc_available ? fc($_) : lc($_);
+          $_ = fc($_);
         }
 	if (defined($_) && $comp->($_, $key) < 0) {
 	    $min = $mid;
@@ -117,7 +116,7 @@ sub look {
 	chomp;
 	s/[^\w\s]//g if $dict;
         if ( $fold ) {
-          $_ = $] ge $fc_available ? fc($_) : lc($_);
+          $_ = fc($_);
         }
 	last if $comp->($_, $key) >= 0;
     }

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -165,6 +165,12 @@ XXX If there was something important to note about this change, include that her
 
 =item *
 
+L<Search::Dict> has been upgraded from version 1.07 to 1.08.
+
+A missing parameter has been added to the sample code in the SYNOPSIS.
+
+=item *
+
 L<builtin> has been upgraded from version 0.017 to 0.018.
 
 On platforms that don't support Inf/NaN values in floating-point numbers (such


### PR DESCRIPTION
- Remove `require 5.000`. In theory, this would give a nice runtime error message when run under perl4; in practice, this file doesn't even parse as perl4 due to `use strict`, `our`, and `->` method calls.
- Use numeric comparison with `$]`, not string comparison. (In practice, this would probably only start failing once we reach perl 10, but still.)
- Don't repeatedly check `$fc_available` at runtime. Just define a fallback fc() in terms of lc() if CORE::fc is not available.
- Add missing `$key` argument to sample code in SYNOPSIS. This fixes <https://rt.cpan.org/Ticket/Display.html?id=97189>.

---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
