### PR TITLE
Safe: clean up some tests

### DIFF
--- a/dist/Safe/Safe.pm
+++ b/dist/Safe/Safe.pm
@@ -3,7 +3,7 @@ package Safe;
 use 5.003_11;
 use Scalar::Util qw(reftype refaddr);
 
-$Safe::VERSION = "2.46";
+$Safe::VERSION = "2.47";
 
 # *** Don't declare any lexicals above this point ***
 #

--- a/dist/Safe/t/safe1.t
+++ b/dist/Safe/t/safe1.t
@@ -6,7 +6,6 @@ BEGIN {
         print "1..0\n";
         exit 0;
     }
-
 }
 
 # Tests Todo:
@@ -24,11 +23,11 @@ use Test::More;
 
 my $cpt;
 # create and destroy some automatic Safe compartments first
-$cpt = new Safe or die;
-$cpt = new Safe or die;
-$cpt = new Safe or die;
+$cpt = Safe->new or die;
+$cpt = Safe->new or die;
+$cpt = Safe->new or die;
 
-$cpt = new Safe "Root" or die;
+$cpt = Safe->new("Root") or die;
 
 foreach(1..3) {
 	$foo = 42;

--- a/dist/Safe/t/safe2.t
+++ b/dist/Safe/t/safe2.t
@@ -28,10 +28,10 @@ $Root::foo .= "";
 
 my $cpt;
 # create and destroy a couple of automatic Safe compartments first
-$cpt = new Safe or die;
-$cpt = new Safe or die;
+$cpt = Safe->new or die;
+$cpt = Safe->new or die;
 
-$cpt = new Safe "Root";
+$cpt = Safe->new("Root");
 
 $cpt->permit(qw(:base_io));
 

--- a/dist/Safe/t/safe3.t
+++ b/dist/Safe/t/safe3.t
@@ -1,23 +1,19 @@
 #!perl -w
 
 use Config;
-BEGIN {
-    if ($Config{'extensions'} !~ /\bOpcode\b/
-	&& $Config{'extensions'} !~ /\bPOSIX\b/
-	&& $Config{'osname'} ne 'VMS')
-    {
-	print "1..0\n";
-	exit 0;
-    }
-}
+use Test::More
+    $Config{'extensions'} =~ /\bOpcode\b/
+	|| $Config{'extensions'} =~ /\bPOSIX\b/
+	|| $Config{'osname'} eq 'VMS'
+    ? (tests => 2)
+    : (skip_all => "no Opcode and POSIX extensions and we're not on VMS");
 
 use strict;
 use warnings;
 use POSIX qw(ceil);
-use Test::More tests => 2;
 use Safe;
 
-my $safe = new Safe;
+my $safe = Safe->new;
 $safe->deny('add');
 
 my $masksize = ceil( Opcode::opcodes / 8 );
@@ -30,7 +26,7 @@ $safe->reval( q{$x + $y} );
 ok( $@ =~ /^'?addition \(\+\)'? trapped by operation mask/,
 	    'opmask still in place with reval' );
 
-my $safe2 = new Safe;
+my $safe2 = Safe->new;
 $safe2->deny('add');
 
 open my $fh, '>nasty.pl' or die "Can't write nasty.pl: $!\n";

--- a/dist/Safe/t/safeload.t
+++ b/dist/Safe/t/safeload.t
@@ -1,25 +1,16 @@
 #!perl
 
 use Config;
-BEGIN {
-    if ($Config{'extensions'} !~ /\bOpcode\b/) {
-	print "1..0\n";
-	exit 0;
-    }
-    # Can we load the version module ?
-    eval { require version; 1 } or do {
-	print "1..0 # no version.pm\n";
-	exit 0;
-    };
-    delete $INC{"version.pm"};
-}
+use Test::More
+    $Config{'extensions'} =~ /\bOpcode\b/
+        && eval { require version; delete $INC{"version.pm"}; 1 }
+    ? (tests => 4)
+    : (skip_all => "no Opcode extension or can't load version.pm");
 
 use strict;
-use Test::More;
 use Safe;
-plan(tests => 4);
 
-my $c = new Safe;
+my $c = Safe->new;
 $c->permit(qw(require caller entereval unpack rand));
 my $r = $c->reval(q{ use version; 1 });
 ok( defined $r, "Can load version.pm in a Safe compartment" ) or diag $@;

--- a/dist/Safe/t/safenamedcap.t
+++ b/dist/Safe/t/safenamedcap.t
@@ -1,20 +1,10 @@
-BEGIN {
-    if ($] < 5.010) {
-	print "1..0\n";
-	exit 0;
-    }
-    require Config;
-    Config->import;
-    if ($Config{'extensions'} !~ /\bOpcode\b/) {
-	print "1..0\n";
-	exit 0;
-    }
-}
-
 use strict;
-use Test::More;
+use Config;
+use Test::More
+    $] >= 5.010 && $Config{'extensions'} =~ /\bOpcode\b/
+        ? (tests => 1)
+        : (skip_all => "pre-5.10 perl or no Opcode extension");
 use Safe;
-plan(tests => 1);
 
 BEGIN { Safe->new }
 "foo" =~ /(?<foo>fo*)/;

--- a/dist/Safe/t/safeops.t
+++ b/dist/Safe/t/safeops.t
@@ -46,7 +46,7 @@ sub testop {
     my ($op, $opname, $code) = @_;
     pass("$op : skipped") and return if $code =~ /^SKIP/;
     pass("$op : skipped") and return if $code =~ m://|~~: && $] < 5.010;
-    my $c = new Safe;
+    my $c = Safe->new;
     $c->deny_only($op);
     $c->reval($code);
     like($@, qr/'\Q$opname\E' trapped by operation mask/, $op);

--- a/dist/Safe/t/saferegexp.t
+++ b/dist/Safe/t/saferegexp.t
@@ -1,14 +1,10 @@
 #!perl -w
 
 use Config;
-BEGIN {
-    if ($Config{'extensions'} !~ /\bOpcode\b/) {
-        print "1..0\n";
-        exit 0;
-    }
-}
-
-use Test::More tests => 3;
+use Test::More
+    $Config{'extensions'} =~ /\bOpcode\b/
+        ? (tests => 3)
+        : (skip_all => "no Opcode extension");
 use Safe;
 
 my $c; my $r;
@@ -16,7 +12,7 @@ my $snippet = q{
     my $foo = qr/foo/;
     ref $foo;
 };
-$c = new Safe;
+$c = Safe->new;
 $r = $c->reval($snippet);
 is( $r, "Safe::Root0::Regexp" );
 $r or diag $@;
@@ -28,7 +24,7 @@ is( $r, "Safe::Root0::Regexp" );
 $r or diag $@;
 
 # try with a new compartment
-$c = new Safe;
+$c = Safe->new;
 $r = $c->reval($snippet);
 is( $r, "Safe::Root1::Regexp" );
 $r or diag $@;

--- a/dist/Safe/t/safesecurity.t
+++ b/dist/Safe/t/safesecurity.t
@@ -1,20 +1,15 @@
 #!perl
 
-use Config;
-BEGIN {
-    if ($Config{'extensions'} !~ /\bOpcode\b/) {
-	print "1..0\n";
-	exit 0;
-    }
-}
-
 use strict;
 use warnings;
-use Test::More;
+use Config;
+use Test::More
+    $Config{'extensions'} =~ /\bOpcode\b/
+        ? (tests => 1)
+        : (skip_all => "no Opcode extension");
 use Safe;
-plan(tests => 1);
 
-my $c = new Safe;
+my $c = Safe->new;
 
 {
     package My::Controller;

--- a/dist/Safe/t/safesig.t
+++ b/dist/Safe/t/safesig.t
@@ -1,18 +1,13 @@
 #!perl
-
-use Config;
-BEGIN {
-    if ($Config{'extensions'} !~ /\bOpcode\b/) {
-        print "1..0\n";
-        exit 0;
-    }
-}
-
 use strict;
 use warnings;
-use Test::More;
+
+use Config;
+use Test::More
+    $Config{'extensions'} =~ /\bOpcode\b/
+        ? (tests => 2)
+        : (skip_all => "no Opcode extension");
 use Safe;
-plan(tests => 2);
 
 $SIG{$_} = $_ for keys %SIG;
 my %saved_SIG = %SIG;

--- a/dist/Safe/t/safesort.t
+++ b/dist/Safe/t/safesort.t
@@ -1,15 +1,13 @@
 #!perl -w
-$|=1;
 use Config;
-BEGIN {
-    if ($Config{'extensions'} !~ /\bOpcode\b/ && $Config{'osname'} ne 'VMS') {
-        print "1..0\n";
-        exit 0;
-    }
-}
+use Test::More
+    $Config{'extensions'} =~ /\bOpcode\b/ || $Config{'osname'} eq 'VMS'
+        ? (tests => 10)
+        : (skip_all => "no Opcode extension and we're not on VMS");
 
 use Safe 1.00;
-use Test::More tests => 10;
+
+$| = 1;
 
 my $safe = Safe->new('PLPerl');
 $safe->permit_only(qw(:default sort));

--- a/dist/Safe/t/safeuniversal.t
+++ b/dist/Safe/t/safeuniversal.t
@@ -1,20 +1,16 @@
 #!perl
 
 use Config;
-BEGIN {
-    if ($Config{'extensions'} !~ /\bOpcode\b/) {
-	print "1..0\n";
-	exit 0;
-    }
-}
+use Test::More
+    $Config{'extensions'} =~ /\bOpcode\b/
+        ? (tests => 6)
+        : (skip_all => "no Opcode extension");
 
 use strict;
 use warnings;
-use Test::More;
 use Safe;
-plan(tests => 6);
 
-my $c = new Safe;
+my $c = Safe->new;
 $c->permit(qw(require caller));
 
 my $no_warn_redef = ($] != 5.008009)

--- a/dist/Safe/t/safeutf8.t
+++ b/dist/Safe/t/safeutf8.t
@@ -1,18 +1,14 @@
 #!perl -w
-$|=1;
 use Config;
-BEGIN {
-    if ($Config{'extensions'} !~ /\bOpcode\b/ && $Config{'osname'} ne 'VMS') {
-        print "1..0\n";
-        exit 0;
-    }
-}
-
-use Test::More tests => 7;
+use Test::More
+    $Config{'extensions'} =~ /\bOpcode\b/ || $Config{'osname'} eq 'VMS'
+        ? (tests => 7)
+        : (skip_all => "no Opcode extension and we're not on VMS");
 
 use Safe 1.00;
 use Opcode qw(full_opset);
 
+$| = 1;
 pass;
 
 my $safe = Safe->new('PLPerl');

--- a/dist/Safe/t/safewrap.t
+++ b/dist/Safe/t/safewrap.t
@@ -1,17 +1,15 @@
 #!perl -w
 
-$|=1;
 use Config;
-BEGIN {
-    if ($Config{'extensions'} !~ /\bOpcode\b/ && $Config{'osname'} ne 'VMS') {
-        print "1..0\n";
-        exit 0;
-    }
-}
+use Test::More
+    $Config{'extensions'} =~ /\bOpcode\b/ || $Config{'osname'} eq 'VMS'
+        ? (tests => 10)
+        : (skip_all => "no Opcode extension and we're not on VMS");
 
 use strict;
 use Safe 1.00;
-use Test::More tests => 10;
+
+$| = 1;
 
 my $safe = Safe->new('PLPerl');
 $safe->permit_only(qw(:default sort));


### PR DESCRIPTION
- `BEGIN { require Config; Config->import; }` -> `use Config;`
- `new Safe` -> `Safe->new`
- more use of Test::More skip_all instead of manual print/exit

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
