### PR TITLE
Thread::Queue: clean up some tests

### DIFF
--- a/dist/Thread-Queue/t/01_basic.t
+++ b/dist/Thread-Queue/t/01_basic.t
@@ -1,8 +1,8 @@
 use strict;
 use warnings;
 
+use Config;
 BEGIN {
-    use Config;
     if (! $Config{'useithreads'}) {
         print("1..0 # SKIP Perl not compiled with 'useithreads'\n");
         exit(0);
@@ -11,16 +11,7 @@ BEGIN {
 
 use threads;
 use Thread::Queue;
-
-BEGIN { # perl RT 133382
-if ($] == 5.008) {
-    require 't/test.pl';   # Test::More work-alike for Perl 5.8.0
-} else {
-    require Test::More;
-}
-Test::More->import();
-} # end BEGIN
-plan('tests' => 81);
+use Test::More 'tests' => 81;
 
 ### Basic usage with multiple threads ###
 

--- a/dist/Thread-Queue/t/02_refs.t
+++ b/dist/Thread-Queue/t/02_refs.t
@@ -1,8 +1,8 @@
 use strict;
 use warnings;
 
+use Config;
 BEGIN {
-    use Config;
     if (! $Config{'useithreads'}) {
         print("1..0 # SKIP Perl not compiled with 'useithreads'\n");
         exit(0);
@@ -12,16 +12,7 @@ BEGIN {
 use threads;
 use threads::shared;
 use Thread::Queue;
-
-BEGIN { # perl RT 133382
-if ($] == 5.008) {
-    require 't/test.pl';   # Test::More work-alike for Perl 5.8.0
-} else {
-    require Test::More;
-}
-Test::More->import();
-} # end BEGIN
-plan('tests' => 46);
+use Test::More 'tests' => 46;
 
 # Regular array
 my @ary1 = qw/foo bar baz/;

--- a/dist/Thread-Queue/t/03_peek.t
+++ b/dist/Thread-Queue/t/03_peek.t
@@ -1,8 +1,8 @@
 use strict;
 use warnings;
 
+use Config;
 BEGIN {
-    use Config;
     if (! $Config{'useithreads'}) {
         print("1..0 # SKIP Perl not compiled with 'useithreads'\n");
         exit(0);
@@ -11,16 +11,7 @@ BEGIN {
 
 use threads;
 use Thread::Queue;
-
-BEGIN { # perl RT 133382
-if ($] == 5.008) {
-    require 't/test.pl';   # Test::More work-alike for Perl 5.8.0
-} else {
-    require Test::More;
-}
-Test::More->import();
-} # end BEGIN
-plan('tests' => 19);
+use Test::More 'tests' => 19;
 
 my $q = Thread::Queue->new(1..10);
 ok($q, 'New queue');

--- a/dist/Thread-Queue/t/05_extract.t
+++ b/dist/Thread-Queue/t/05_extract.t
@@ -11,16 +11,7 @@ BEGIN {
 
 use threads;
 use Thread::Queue;
-
-BEGIN { # perl RT 133382
-if ($] == 5.008) {
-    require 't/test.pl';   # Test::More work-alike for Perl 5.8.0
-} else {
-    require Test::More;
-}
-Test::More->import();
-} # end BEGIN
-plan('tests' => 20);
+use Test::More 'tests' => 20;
 
 my $q = Thread::Queue->new(1..10);
 ok($q, 'New queue');

--- a/dist/Thread-Queue/t/06_insert.t
+++ b/dist/Thread-Queue/t/06_insert.t
@@ -11,16 +11,7 @@ BEGIN {
 
 use threads;
 use Thread::Queue;
-
-BEGIN { # perl RT 133382
-if ($] == 5.008) {
-    require 't/test.pl';   # Test::More work-alike for Perl 5.8.0
-} else {
-    require Test::More;
-}
-Test::More->import();
-} # end BEGIN
-plan('tests' => 16);
+use Test::More 'tests' => 16;
 
 my $q = Thread::Queue->new(1..10);
 ok($q, 'New queue');

--- a/dist/Thread-Queue/t/07_lock.t
+++ b/dist/Thread-Queue/t/07_lock.t
@@ -12,16 +12,7 @@ BEGIN {
 use threads;
 use Thread::Queue;
 use Thread::Semaphore;
-
-BEGIN { # perl RT 133382
-if ($] == 5.008) {
-    require 't/test.pl';   # Test::More work-alike for Perl 5.8.0
-} else {
-    require Test::More;
-}
-Test::More->import();
-} # end BEGIN
-plan('tests' => 3);
+use Test::More 'tests' => 3;
 
 # The following tests locking a queue
 

--- a/dist/Thread-Queue/t/10_timed.t
+++ b/dist/Thread-Queue/t/10_timed.t
@@ -11,16 +11,7 @@ BEGIN {
 
 use threads;
 use Thread::Queue;
-
-BEGIN { # perl RT 133382
-if ($] == 5.008) {
-    require 't/test.pl';   # Test::More work-alike for Perl 5.8.0
-} else {
-    require Test::More;
-}
-Test::More->import();
-} # end BEGIN
-plan('tests' => 19);
+use Test::More 'tests' => 19;
 
 ### ->dequeue_timed(TIMEOUT, COUNT) test ###
 

--- a/dist/Thread-Queue/t/11_limit.t
+++ b/dist/Thread-Queue/t/11_limit.t
@@ -17,9 +17,7 @@ BEGIN {
 use threads;
 use Thread::Queue;
 
-use Test::More;
-
-plan tests => 13;
+use Test::More tests => 13;
 
 my $q = Thread::Queue->new();
 my $rpt = Thread::Queue->new();


### PR DESCRIPTION
Some of the tests (04_errs.t, 08_nothreads.t, 09_ended.t) already use Test::More unconditionally, so remove the conditional loading code from the other tests. Also, `use Config` doesn't need to be in a BEGIN block.


---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
