### PR TITLE
Thread::Semaphore: clean up some tests

### DIFF
--- a/dist/Thread-Semaphore/t/01_basic.t
+++ b/dist/Thread-Semaphore/t/01_basic.t
@@ -12,14 +12,7 @@ BEGIN {
 use threads;
 use threads::shared;
 use Thread::Semaphore;
-
-if ($] == 5.008) {
-    require './t/test.pl';   # Test::More work-alike for Perl 5.8.0
-} else {
-    require Test::More;
-}
-Test::More->import();
-plan('tests' => 10);
+use Test::More 'tests' => 10;
 
 ### Basic usage with multiple threads ###
 

--- a/dist/Thread-Semaphore/t/04_nonblocking.t
+++ b/dist/Thread-Semaphore/t/04_nonblocking.t
@@ -12,14 +12,7 @@ BEGIN {
 use threads;
 use threads::shared;
 use Thread::Semaphore;
-
-if ($] == 5.008) {
-    require './t/test.pl';   # Test::More work-alike for Perl 5.8.0
-} else {
-    require Test::More;
-}
-Test::More->import();
-plan('tests' => 12);
+use Test::More 'tests' => 12;
 
 ### Basic usage with multiple threads ###
 

--- a/dist/Thread-Semaphore/t/05_force.t
+++ b/dist/Thread-Semaphore/t/05_force.t
@@ -12,14 +12,7 @@ BEGIN {
 use threads;
 use threads::shared;
 use Thread::Semaphore;
-
-if ($] == 5.008) {
-    require './t/test.pl';   # Test::More work-alike for Perl 5.8.0
-} else {
-    require Test::More;
-}
-Test::More->import();
-plan('tests' => 8);
+use Test::More 'tests' => 8;
 
 ### Basic usage with multiple threads ###
 

--- a/dist/Thread-Semaphore/t/06_timed.t
+++ b/dist/Thread-Semaphore/t/06_timed.t
@@ -12,14 +12,7 @@ BEGIN {
 use threads;
 use threads::shared;
 use Thread::Semaphore;
-
-if ($] == 5.008) {
-    require 't/test.pl';   # Test::More work-alike for Perl 5.8.0
-} else {
-    require Test::More;
-}
-Test::More->import();
-plan('tests' => 10);
+use Test::More 'tests' => 10;
 
 ### Basic usage with multiple threads ###
 


### PR DESCRIPTION
Some of the tests (02_errs.t, 03_nothreads.t) already use Test::More unconditionally, so remove the conditional loading code from the other tests.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
