### PR TITLE
t/porting/diag.t: fix oversights in message extraction regex

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2283,6 +2283,11 @@ L<builtin> by using the C<unimport> method (likely via C<no builtin ...>
 syntax), but the requested function has not been imported into the current
 scope.
 
+=item %s (%d) does not match %s (%d)
+
+(P) The size of a PerlIO function table passed by an extension is smaller than
+expected.
+
 =item Don't know how to get file name
 
 (P) C<PerlIO_getname>, a perl internal I/O function specific to VMS, was
@@ -2402,6 +2407,10 @@ specifications in either VMS or Unix syntax, it converts them to a
 single form when it must operate on them directly.  Either you've passed
 an invalid file specification to Perl, or you've found a case the
 conversion routines don't handle.  Drat.
+
+=item error creating/fetching widecharmap entry for 0x%X
+
+(P) A failure happened when folding a character for a regex trie.
 
 =item Error %s in expansion of %s
 
@@ -5082,6 +5091,14 @@ the glob and a destructor that adds a new object to the glob.
 
 (P) The lexer got into a bad state parsing a string with brackets.
 
+=item panic! In trie construction, no char mapping for %d
+
+(P) A failure happened in the construction of a regex trie.
+
+=item panic! In trie construction, unknown node type %u %s
+
+(P) An unexpected node type was encountered in regex trie construction.
+
 =item panic: kid popen errno read
 
 (F) A forked child returned an incomprehensible message about its errno.
@@ -6216,6 +6233,11 @@ requested.
 (F) In a subroutine signature, you put something after a slurpy (array or
 hash) parameter.  The slurpy parameter takes all the available arguments,
 so there can't be any left to fill later parameters.
+
+=item %s (%d) smaller than %s (%d)
+
+(P) The size of a PerlIO instance passed by an extension is smaller than
+expected.
 
 =item Smart matching a non-overloaded object breaks encapsulation
 

--- a/t/porting/diag.t
+++ b/t/porting/diag.t
@@ -64,7 +64,7 @@ my $source_msg_re =
    "(?<routine>\\bDIE\\b|$function_re)";
 my $text_re = '"(?<text>(?:\\\\"|[^"]|"\s*[A-Z_]+\s*")*)"';
 my $source_msg_call_re = qr/$source_msg_re(?:_nocontext)? \s*
-    \( (?: \s* Perl_form \( )? (?:aTHX_)? \s*
+    \( (?: \s* (?: Perl_ )? form \( )? (?: \s* aTHX_)? \s*
     (?:packWARN\d*\((?<category>.*?)\),)? \s*
     (?:(?<category>WARN_DEPRECATED__\w+)\s*,(?:\s*(?<version_string>"[^"]+")\s*,)?)? \s*
     $text_re /x;


### PR DESCRIPTION
- recognize the short form() as well as Perl_form()
- accept/ignore spaces between `Perl_croak(` and `aTHX_`

With this change, diag.t now recognizes several diagnostic messages that went undetected previously (note the space before `aTHX_`):

- perlio.c

            Perl_croak( aTHX_
                "%s (%" UVuf ") does not match %s (%" UVuf ")",

                Perl_croak( aTHX_
                    "%s (%" UVuf ") smaller than %s (%" UVuf ")",

- regcomp_trie.c

                        Perl_croak( aTHX_ "error creating/fetching widecharmap entry for 0x%" UVXf, uvc );

            default: Perl_croak( aTHX_ "panic! In trie construction, unknown node type %u %s", (unsigned) flags, REGNODE_NAME(flags) );

                            Perl_croak( aTHX_ "panic! In trie construction, no char mapping for %" IVdf, uvc );

This PR partially overlaps with #23017. Merging either will cause conflicts in the other that will have to be resolved manually.

(In particular, if this PR is merged first, the diag.t changes from #23017 can be dropped, as can some of the perldiag.pod additions. But that PR also modifies the perlio.c messages, so their old forms added here ("%s (%d) does not match %s (%d)", "%s (%d) smaller than %s (%d)") will have to be deleted.)

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
