### PR TITLE
turn croak("%s", "foo") into croak("foo")

### DIFF
--- a/malloc.c
+++ b/malloc.c
@@ -1251,7 +1251,7 @@ Perl_malloc(size_t nbytes)
         BARK_64K_LIMIT("Allocation",nbytes,nbytes);
 #ifdef DEBUGGING
         if ((long)nbytes < 0)
-            croak("%s", "panic: malloc");
+            croak("panic: malloc");
 #endif
 
         bucket = adjust_size_and_find_bucket(&nbytes);
@@ -1817,7 +1817,7 @@ Perl_mfree(Malloc_t where)
                 return;
 #ifdef DEBUGGING
         if (PTR2UV(cp) & (MEM_ALIGNBYTES - 1))
-            croak("%s", "wrong alignment in free()");
+            croak("wrong alignment in free()");
 #endif
         ovp = (union overhead *)((caddr_t)cp 
                                 - sizeof (union overhead) * CHUNK_SHIFT);
@@ -1918,7 +1918,7 @@ Perl_realloc(void *mp, size_t nbytes)
         MEM_SIZE size = nbytes;
 
         if ((long)nbytes < 0)
-            croak("%s", "panic: realloc");
+            croak("panic: realloc");
 #endif
 
         BARK_64K_LIMIT("Reallocation",nbytes,size);

--- a/perl.c
+++ b/perl.c
@@ -4257,14 +4257,13 @@ S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
         char tmpname[sizeof(FAKE_BIT_BUCKET_TEMPLATE)] = {
             FAKE_BIT_BUCKET_TEMPLATE
         };
-        const char * const err = "Failed to create a fake bit bucket";
         if (strEQ(scriptname, BIT_BUCKET)) {
             int tmpfd = Perl_my_mkstemp_cloexec(tmpname);
             if (tmpfd > -1) {
                 scriptname = tmpname;
                 close(tmpfd);
             } else
-                Perl_croak(aTHX_ err);
+                Perl_croak(aTHX_ "Failed to create a fake bit bucket");
         }
 #endif
         rsfp = PerlIO_open(scriptname,PERL_SCRIPT_MODE);

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2588,6 +2588,11 @@ queue of such routines has been prematurely ended.
 (F) Closing an output file from in-place editing, as with the C<-i>
 command-line switch, failed.
 
+=item Failed to create a fake bit bucket
+
+(F) You tried to call perl with the B<-e> switch, but you're on a Cray system
+and perl's F</dev/null> emulation was unable to create an empty temporary file.
+
 =item False [] range "%s" in regex; marked by S<<-- HERE> in m/%s/
 
 (W regexp)(F) A character class range must start and end at a literal
@@ -4931,6 +4936,11 @@ the largest possible memory allocation.
 remaining memory (or virtual memory) to satisfy the request.  However,
 the request was judged large enough (compile-time default is 64K), so a
 possibility to shut down by trapping this error is granted.
+
+=item Out of memory during pack()
+
+(F) An attempt was made to extend a string beyond the largest possible memory
+allocation.
 
 =item Out of memory during request for %s
 
@@ -8293,6 +8303,10 @@ Warning is given and the operation is not done.
 
 (W closed) The filehandle you're writing to got itself closed sometime
 before now.  Check your control flow.
+
+=item wrong alignment in free()
+
+(P) An invalid pointer was passed to C<Perl_mfree> (also known as C<Safefree>).
 
 =item %s "\x%X" does not map to Unicode
 

--- a/pp.c
+++ b/pp.c
@@ -1847,7 +1847,8 @@ PP_wrapped(pp_repeat,
             SSize_t max;
 
             if ( items > SSize_t_MAX / (SSize_t)sizeof(SV *) / count )
-               Perl_croak(aTHX_ "%s","Out of memory during list extend");
+                /* diag_listed_as: Out of memory during %s extend */
+                Perl_croak(aTHX_ "Out of memory during list extend");
             max = items * count;
             MEXTEND(MARK, max);
 
@@ -1885,8 +1886,8 @@ PP_wrapped(pp_repeat,
 
                 if (   len > (MEM_SIZE_MAX-1) / (UV)count /* max would overflow */
                 )
-                     Perl_croak(aTHX_ "%s",
-                                        "Out of memory during string extend");
+                    /* diag_listed_as: Out of memory during %s extend */
+                    Perl_croak(aTHX_ "Out of memory during string extend");
                 max = (UV)count * len + 1;
                 SvGROW(TARG, max);
 

--- a/pp_pack.c
+++ b/pp_pack.c
@@ -361,14 +361,14 @@ STMT_START {							\
 #define SAFE_UTF8_EXPAND(var)	\
 STMT_START {				\
     if ((var) > SSize_t_MAX / UTF8_EXPAND) \
-        Perl_croak(aTHX_ "%s", "Out of memory during pack()"); \
+        Perl_croak(aTHX_ "Out of memory during pack()"); \
     (var) = (var) * UTF8_EXPAND; \
 } STMT_END
 
 #define GROWING2(utf8, cat, start, cur, item_size, item_count)	\
 STMT_START {							\
     if (SSize_t_MAX / (item_size) < (item_count))		\
-        Perl_croak(aTHX_ "%s", "Out of memory during pack()");	\
+        Perl_croak(aTHX_ "Out of memory during pack()");	\
     GROWING((utf8), (cat), (start), (cur), (item_size) * (item_count)); \
 } STMT_END
 
@@ -378,7 +378,7 @@ STMT_START {					\
     STRLEN catcur = (STRLEN)((cur) - (start));	\
     if (utf8) SAFE_UTF8_EXPAND(glen);		\
     if (SSize_t_MAX - glen < catcur)		\
-        Perl_croak(aTHX_ "%s", "Out of memory during pack()"); \
+        Perl_croak(aTHX_ "Out of memory during pack()"); \
     if (catcur + glen >= SvLEN(cat)) {	\
         (start) = sv_exp_grow(cat, glen);	\
         (cur) = (start) + SvCUR(cat);		\


### PR DESCRIPTION
There is no point in using a separate format string if the whole error message is written right next to it. Not only does this change lead to simpler code (passing one argument instead of two), it also exposes more error messages to t/porting/diag.t, which relies on croak's first argument to supply the message template.

Also make an equivalent change to `S_open_script`, which passes a constant string in the form of an `err` variable that is not used anywhere else. (It used to be, but that code was deleted in commit 5bc7d00e3e.)

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
