### PR TITLE
regexp_unicode_prop.t: Fix up test for Unicode 16.0

### DIFF
--- a/t/re/regexp_unicode_prop.t
+++ b/t/re/regexp_unicode_prop.t
@@ -74,7 +74,7 @@ my @CLASSES = (
    'Lowercase Letter'         => ["h", "!H"],
 
     Common                    => ["!i", "3"],
-    Inherited                 => ["!j", '\x{300}'],
+    Inherited                 => ["!j", '\x{31A}'],
 
     InBasicLatin              => ['\N{LATIN CAPITAL LETTER A}'],
     InLatin1Supplement        => ['\N{LATIN CAPITAL LETTER A WITH GRAVE}'],


### PR DESCRIPTION
This test was assuming that U+0300 (COMBINING GRAVE ACCENT) matches \p{Inherited}, since it is a combining mark.  However Unicode 16.0 has gone through such marks and decided that some are limited to actually just a few scripts, so it is not generally inherited.  (One of those scripts is Latin, so it is effectively inherited in French, Spanish, etc.)  But it isn't always inheritied, and so it loses that status, and the test fails.

I would never have expected this test to be brittle, but so it is.  What this commit does is to change to another code point that is till considered Inherited, and the test passes.


* This set of changes does not require a perldelta entry.
