### PR TITLE
eliminate more trivial format strings ("%s", "...")

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -540,14 +540,14 @@ Perl_sv_peek(pTHX_ SV *sv)
             }
         }
         if (is_tmp || SvREFCNT(sv) > 1 || SvPADTMP(sv)) {
-            sv_catpvf(t, "<");
+            sv_catpvs(t, "<");
             if (SvREFCNT(sv) > 1)
                 sv_catpvf(t, "%" UVuf, (UV)SvREFCNT(sv));
             if (SvPADTMP(sv))
-                sv_catpvf(t, "%s",  "P");
+                sv_catpvs(t, "P");
             if (is_tmp)
-                sv_catpvf(t, "%s", SvTEMP(t) ? "T" : "t");
-            sv_catpvf(t, ">");
+                sv_catpv(t, SvTEMP(t) ? "T" : "t");
+            sv_catpvs(t, ">");
         }
     }
 

--- a/malloc.c
+++ b/malloc.c
@@ -1704,7 +1704,7 @@ morecore(int bucket)
 #endif
         if (bucket == sizeof(MEM_SIZE)*8*BUCKETS_PER_POW2) {
             MALLOC_UNLOCK;
-            croak2("%s", "Out of memory during ridiculously large request");
+            croak2("Out of memory during ridiculously large request");
         }
         if (bucket > max_bucket)
             max_bucket = bucket;
@@ -1842,16 +1842,20 @@ Perl_mfree(Malloc_t where)
 #ifdef RCHECK
                 {
                     dTHX;
-                    if (!PERL_IS_ALIVE || !PL_curcop)
-                        Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC), "%s free() ignored (RMAGIC, PERL_CORE)",
-                                         ovp->ov_rmagic == RMAGIC - 1 ?
-                                         "Duplicate" : "Bad");
+                    if (!PERL_IS_ALIVE || !PL_curcop) {
+                        if (ovp->ov_rmagic == RMAGIC - 1)
+                            Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC),
+                                             "Duplicate free() ignored (%s)", "RMAGIC, PERL_CORE");
+                        else
+                            Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC),
+                                             "Bad free() ignored (%s)", "RMAGIC, PERL_CORE");
+                    }
                 }
 #else
                 {
                     dTHX;
                     if (!PERL_IS_ALIVE || !PL_curcop)
-                        Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC), "%s", "Bad free() ignored (PERL_CORE)");
+                        Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC), "Bad free() ignored (%s)", "PERL_CORE");
                 }
 #endif
                 return;				/* sanity */
@@ -1947,18 +1951,18 @@ Perl_realloc(void *mp, size_t nbytes)
 #ifdef RCHECK
                 {
                     dTHX;
-                    if (!PERL_IS_ALIVE || !PL_curcop)
-                        Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC), "%srealloc() %signored",
-                                         (ovp->ov_rmagic == RMAGIC - 1 ? "" : "Bad "),
-                                         ovp->ov_rmagic == RMAGIC - 1
-                                         ? "of freed memory " : "");
+                    if (!PERL_IS_ALIVE || !PL_curcop) {
+                        if (ovp->ov_rmagic == RMAGIC - 1)
+                            Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC), "realloc() of freed memory ignored");
+                        else
+                            Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC), "Bad realloc() ignored");
+                    }
                 }
 #else
                 {
                     dTHX;
                     if (!PERL_IS_ALIVE || !PL_curcop)
-                        Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC), "%s",
-                                         "Bad realloc() ignored");
+                        Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC), "Bad realloc() ignored");
                 }
 #endif
                 return NULL;			/* sanity */

--- a/malloc.c
+++ b/malloc.c
@@ -269,9 +269,9 @@
 #  define MALLOC_UNLOCK		MUTEX_UNLOCK(&PL_malloc_mutex)
 #endif 
 
-#  ifndef fatalcroak				/* make depend */
-#    define fatalcroak(mess)	(write(2, (mess), strlen(mess)), exit(2))
-#  endif 
+#ifndef fatalcroak
+#  define fatalcroak(mess)      STMT_START { PERL_UNUSED_RESULT(write(2, (mess), strlen(mess))); exit(2); } STMT_END
+#endif
 
 #ifdef DEBUGGING
 #  undef DEBUG_m

--- a/os2/perlrexx.c
+++ b/os2/perlrexx.c
@@ -135,7 +135,7 @@ ULONG PERL (PCSZ name, LONG rargc, const RXSTRING *rargv,
         ret = 1;
     else {
         ret = 0;
-        sprintf(retstr->strptr, "%s", "ok");
+        strcpy(retstr->strptr, "ok");
         retstr->strlength = strlen (retstr->strptr);
     }
     PERL_SYS_TERM1(0);
@@ -162,7 +162,7 @@ ULONG PERLTERM (PCSZ name, LONG rargc, const RXSTRING *rargv,
     perl_free(my_perl);
     my_perl = 0;
 
-    sprintf(retstr->strptr, "%s", "ok");
+    strcpy(retstr->strptr, "ok");
     retstr->strlength = strlen (retstr->strptr);
     return 0;
 }
@@ -176,7 +176,7 @@ ULONG PERLINIT (PCSZ name, LONG rargc, const RXSTRING *rargv,
     if (!init_perl(1))
         return 1;
 
-    sprintf(retstr->strptr, "%s", "ok");
+    strcpy(retstr->strptr, "ok");
     retstr->strlength = strlen (retstr->strptr);
     return 0;
 }

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -476,7 +476,7 @@ most likely an unexpected right brace '}'.
 symbol has no filehandle associated with it.  Perhaps you didn't do an
 open(), or did it in another package.
 
-=item Bad free() ignored
+=item Bad free() ignored (%s)
 
 (S malloc) An internal routine called free() on something that had never
 been malloc()ed in the first place.  Mandatory, but can be disabled by
@@ -2324,7 +2324,7 @@ See L<perlfunc/dump>.
 
 (F) Your machine doesn't support dump/undump.
 
-=item Duplicate free() ignored
+=item Duplicate free() ignored (%s)
 
 (S malloc) An internal routine called free() on something that had
 already been freed.

--- a/t/porting/diag.t
+++ b/t/porting/diag.t
@@ -701,7 +701,6 @@ setnetent not implemented!
 setprotoent not implemented!
 set %s %p %p %p
 setservent not implemented!
-%s free() ignored (RMAGIC, PERL_CORE)
 %s has too many errors.
 SIG%s handler "%s" not defined.
 %s in %s
@@ -709,7 +708,6 @@ Size magic not implemented
 %s: name `%s' too long
 %s not implemented!
 %s number > %s non-portable
-%srealloc() %signored
 %s on %s %s
 %s: %s
 Starting Full Screen process with flag=%d, mytype=%d


### PR DESCRIPTION
As a follow-up to commit 71d1d453e7, turn more trivial format strings (i.e. `"%s"` followed by a string literal) into just that string literal.

- dump.c: String literals are more efficiently appended using `sv_catpvs`; C strings using `sv_patv`. No need to invoke the entire `sv_catpvf` machinery to parse a static "format string" of length 1.
- malloc.c: Disentangle some warning messages and make them properly match their (previously orphaned) perldiag entries again.
- os2/perlrexx.c: Turn `sprintf(x, "...")` into `strcpy(x, "...")`.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
