### PR TITLE
malloc.c: fix compilation error, clean up more

### DIFF
--- a/malloc.c
+++ b/malloc.c
@@ -25,9 +25,7 @@
   returns it to the state as of Perl 5.000.
 
   Note that some of the settings below may be ignored in the code based
-  on values of other macros.  The PERL_CORE symbol is only defined when
-  perl itself is being compiled (so malloc can make some assumptions
-  about perl's facilities being available to it).
+  on values of other macros.
 
   Each config option has a short description, followed by its name,
   default value, and a comment about the default (if applicable).  Some
@@ -238,11 +236,6 @@
 #include "EXTERN.h"
 #define PERL_IN_MALLOC_C
 #include "perl.h"
-#if defined(MULTIPLICITY)
-#    define croak2	Perl_croak_nocontext
-#else
-#    define croak2	croak
-#endif
 #ifdef USE_ITHREADS
 #     define PERL_MAYBE_ALIVE	PL_thr_key
 #else
@@ -931,7 +924,7 @@ static char *emergency_buffer_prepared;
 #  endif
 
 #  ifndef emergency_sbrk_croak
-#    define emergency_sbrk_croak	croak2
+#    define emergency_sbrk_croak  Perl_croak_nocontext
 #  endif
 
 static char *
@@ -1251,7 +1244,7 @@ Perl_malloc(size_t nbytes)
         BARK_64K_LIMIT("Allocation",nbytes,nbytes);
 #ifdef DEBUGGING
         if ((long)nbytes < 0)
-            croak("panic: malloc");
+            Perl_croak_nocontext("panic: malloc");
 #endif
 
         bucket = adjust_size_and_find_bucket(&nbytes);
@@ -1704,7 +1697,7 @@ morecore(int bucket)
 #endif
         if (bucket == sizeof(MEM_SIZE)*8*BUCKETS_PER_POW2) {
             MALLOC_UNLOCK;
-            croak2("Out of memory during ridiculously large request");
+            Perl_croak_nocontext("Out of memory during ridiculously large request");
         }
         if (bucket > max_bucket)
             max_bucket = bucket;
@@ -1817,7 +1810,7 @@ Perl_mfree(Malloc_t where)
                 return;
 #ifdef DEBUGGING
         if (PTR2UV(cp) & (MEM_ALIGNBYTES - 1))
-            croak("wrong alignment in free()");
+            Perl_croak_nocontext("wrong alignment in free()");
 #endif
         ovp = (union overhead *)((caddr_t)cp 
                                 - sizeof (union overhead) * CHUNK_SHIFT);
@@ -1839,26 +1832,19 @@ Perl_mfree(Malloc_t where)
                 }
                 if (!bad_free_warn)
                     return;
-#ifdef RCHECK
                 {
                     dTHX;
                     if (!PERL_IS_ALIVE || !PL_curcop) {
-                        if (ovp->ov_rmagic == RMAGIC - 1)
-                            Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC),
-                                             "Duplicate free() ignored (%s)", "RMAGIC, PERL_CORE");
-                        else
-                            Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC),
-                                             "Bad free() ignored (%s)", "RMAGIC, PERL_CORE");
+#ifdef RCHECK
+                        if (ovp->ov_rmagic == RMAGIC - 1) {
+                            Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC), "Duplicate free() ignored");
+                            return;
+                        }
+#endif
+                        Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC), "Bad free() ignored");
                     }
                 }
-#else
-                {
-                    dTHX;
-                    if (!PERL_IS_ALIVE || !PL_curcop)
-                        Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC), "Bad free() ignored (%s)", "PERL_CORE");
-                }
-#endif
-                return;				/* sanity */
+                return;  /* sanity */
             }
 #ifdef RCHECK
         ASSERT(ovp->ov_rmagic == RMAGIC, "chunk's head overwrite");
@@ -1922,7 +1908,7 @@ Perl_realloc(void *mp, size_t nbytes)
         MEM_SIZE size = nbytes;
 
         if ((long)nbytes < 0)
-            croak("panic: realloc");
+            Perl_croak_nocontext("panic: realloc");
 #endif
 
         BARK_64K_LIMIT("Reallocation",nbytes,size);
@@ -1948,24 +1934,19 @@ Perl_realloc(void *mp, size_t nbytes)
                 }
                 if (!bad_free_warn)
                     return NULL;
-#ifdef RCHECK
                 {
                     dTHX;
                     if (!PERL_IS_ALIVE || !PL_curcop) {
-                        if (ovp->ov_rmagic == RMAGIC - 1)
+#ifdef RCHECK
+                        if (ovp->ov_rmagic == RMAGIC - 1) {
                             Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC), "realloc() of freed memory ignored");
-                        else
-                            Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC), "Bad realloc() ignored");
+                            return NULL;
+                        }
+#endif
+                        Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC), "Bad realloc() ignored");
                     }
                 }
-#else
-                {
-                    dTHX;
-                    if (!PERL_IS_ALIVE || !PL_curcop)
-                        Perl_ck_warner_d(aTHX_ packWARN(WARN_MALLOC), "Bad realloc() ignored");
-                }
-#endif
-                return NULL;			/* sanity */
+                return NULL;  /* sanity */
             }
 
         onb = BUCKET_SIZE_REAL(bucket);

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -476,7 +476,7 @@ most likely an unexpected right brace '}'.
 symbol has no filehandle associated with it.  Perhaps you didn't do an
 open(), or did it in another package.
 
-=item Bad free() ignored (%s)
+=item Bad free() ignored
 
 (S malloc) An internal routine called free() on something that had never
 been malloc()ed in the first place.  Mandatory, but can be disabled by
@@ -2324,7 +2324,7 @@ See L<perlfunc/dump>.
 
 (F) Your machine doesn't support dump/undump.
 
-=item Duplicate free() ignored (%s)
+=item Duplicate free() ignored
 
 (S malloc) An internal routine called free() on something that had
 already been freed.


### PR DESCRIPTION
When configured with `-DEBUGGING -Dusethreads -Dusemymalloc`, malloc.c didn't compile anymore (see below for the full error message). This was probably broken by commits 8e3a36a4b3 and 13e5ba49b2. What they missed was that all uses of warn/croak in this file were supposed to have no context parameter (aTHX/pTHX) and the only reason croak2 was introduced was that C89 didn't have variable-argument macros, so croak() was hardcoded with one argument and croak2() with two arguments.

Instead, we can simply replace all uses of croak/croak2 with Perl_croak_nocontext. On threaded builds, this is a function with no extra pTHX_ parameter; on non-threaded builds, this just turns into regular croak. Now we don't need to manually check for MULTIPLICITY ourselves.

Back in the day (perl 5.005), malloc.c was supposed to be usable outside of perl, so it had checks for PERL_CORE being defined. These were removed in b9e5552c5b, but some vestiges remained: PERL_CORE was still mentioned as a configuration option in a comment and Perl_mfree (but none of the other functions) tagged its warning messages with the configuration options in play (`PERL_CORE`, `RMAGIC`, or `RMAGIC, PERL_CORE`, added in commit 52c6645e67). With the removal of non-PERL_CORE support, these don't make much sense anymore, so I removed them.

This change in turn enables further improvements: Common code in the RCHECK and non-RCHECK branches can be extracted, making the `#ifdef RCHECK` conditional sections smaller and eliminating the `#else` sections entirely.

------------------------------------------------------------------------

    In file included from malloc.c:240:
    malloc.c: In function ‘Perl_malloc’:
    perl.h:225:17: error: ‘my_perl’ undeclared (first use in this function)
      225 | #  define aTHX  my_perl
          |                 ^~~~~~~
    perl.h:230:25: note: in expansion of macro ‘aTHX’
      230 | #  define aTHX_         aTHX,
          |                         ^~~~
    embed.h:966:60: note: in expansion of macro ‘aTHX_’
      966 | #   define croak(...)                           Perl_croak(aTHX_ __VA_ARGS__)
          |                                                            ^~~~~
    malloc.c:1254:13: note: in expansion of macro ‘croak’
     1254 |             croak("panic: malloc");
          |             ^~~~~
    perl.h:225:17: note: each undeclared identifier is reported only once for each function it appears in
      225 | #  define aTHX  my_perl
          |                 ^~~~~~~
    perl.h:230:25: note: in expansion of macro ‘aTHX’
      230 | #  define aTHX_         aTHX,
          |                         ^~~~
    embed.h:966:60: note: in expansion of macro ‘aTHX_’
      966 | #   define croak(...)                           Perl_croak(aTHX_ __VA_ARGS__)
          |                                                            ^~~~~
    malloc.c:1254:13: note: in expansion of macro ‘croak’
     1254 |             croak("panic: malloc");
          |             ^~~~~
    malloc.c: In function ‘Perl_mfree’:
    perl.h:225:17: error: ‘my_perl’ undeclared (first use in this function)
      225 | #  define aTHX  my_perl
          |                 ^~~~~~~
    perl.h:230:25: note: in expansion of macro ‘aTHX’
      230 | #  define aTHX_         aTHX,
          |                         ^~~~
    embed.h:966:60: note: in expansion of macro ‘aTHX_’
      966 | #   define croak(...)                           Perl_croak(aTHX_ __VA_ARGS__)
          |                                                            ^~~~~
    malloc.c:1820:13: note: in expansion of macro ‘croak’
     1820 |             croak("wrong alignment in free()");
          |             ^~~~~
    malloc.c: In function ‘Perl_realloc’:
    perl.h:225:17: error: ‘my_perl’ undeclared (first use in this function)
      225 | #  define aTHX  my_perl
          |                 ^~~~~~~
    perl.h:230:25: note: in expansion of macro ‘aTHX’
      230 | #  define aTHX_         aTHX,
          |                         ^~~~
    embed.h:966:60: note: in expansion of macro ‘aTHX_’
      966 | #   define croak(...)                           Perl_croak(aTHX_ __VA_ARGS__)
          |                                                            ^~~~~
    malloc.c:1925:13: note: in expansion of macro ‘croak’
     1925 |             croak("panic: realloc");
          |             ^~~~~
    make: *** [makefile:265: malloc.o] Error 1


---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
