### PR TITLE
Storable.xs: remove outdated comment

### DIFF
--- a/dist/Storable/Storable.xs
+++ b/dist/Storable/Storable.xs
@@ -2616,8 +2616,6 @@ static int store_scalar(pTHX_ stcxt_t *cxt, SV *sv)
 
 #ifdef SvVOK
         if ((vstr_pv = SvVSTRING(sv, vstr_len))) {
-            /* The macro passes this by address, not value, and a lot of
-               called code assumes that it's 32 bits without checking.  */
             /* we no longer accept vstrings over I32_SIZE-1, so don't emit
                them, also, older Storables handle them badly.
             */


### PR DESCRIPTION
This comment has been obsolete since commit 1cb8a344aa (and hasn't made much sense since that commit changed `len`'s type from `int` back to `SSize_t`.)

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
