### PR TITLE
t/porting/podcheck.t: allow ' in English words

### DIFF
--- a/t/porting/podcheck.t
+++ b/t/porting/podcheck.t
@@ -1034,15 +1034,15 @@ package My::Pod::Checker {      # Extend Pod::Checker
         return unless defined $running_CFL_text{$addr};
 
         while ($running_CFL_text{$addr} =~ m{
-                                ( (?: \w+ \s+ )* )  # The phrase before, if any
-                                \b [Ss]ee \s+
-                                ( ( [^L] )
-                                  <
-                                  ( [^<]*? )  # The not < excludes nested C<L<...
-                                  >
-                                )
-                                ( \s+ (?: under | in ) \s+ L< )?
-                            }xg)
+                ( (?: \w+ (?: ' (?: d | ll | m | re | s | ve ) )? \s+ )* )  # The phrase before, if any
+                \b [Ss]ee \s+
+                ( ( [^L] )
+                <
+                ( [^<]*? )  # The not < excludes nested C<L<...
+                >
+                )
+                ( \s+ (?: under | in ) \s+ L< )?
+            }xg)
         {
             my $prefix = $1 // "";
             my $construct = $2;     # The whole thing, like C<...>


### PR DESCRIPTION
podcheck.t uses a crude heuristic to identify links that use the wrong POD syntax (e.g. `C<Some::Module>` instead of `L<Some::Module>`): It checks whether the word before the `C<...>` markup was "see". This has the potential for a lot of false positives, so it adds an additional check: If the words before "see" include the word "you", we don't count it as a link attempt. This is to rule out cases like `you may see C<mtfnpy> in the output`.

However, that heuristic failed on this example from perlport:

    on Unix you'll see C<"a.">

This is because ' is not a word character, so the leading context was just "ll", which doesn't contain "you":

    not ok 241 - POD of pod/perlport.pod
    #   "? Should you be using L<...> instead of"
    #     C<"a."> near line 1104 of pod/perlport.pod

This patch teaches podcheck.t about common English short forms such as "you'll", "you're", or "you'd".

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
