### PR TITLE
Remove redundant code that handles mg_obj of PERL_MAGIC_symtab

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -2394,12 +2394,6 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
             (void)PerlIO_putc(file, '\n');
         }
         {
-            MAGIC * const mg = mg_find(sv, PERL_MAGIC_symtab);
-            if (mg && mg->mg_obj) {
-                Perl_dump_indent(aTHX_ level, file, "  PMROOT = 0x%" UVxf "\n", PTR2UV(mg->mg_obj));
-            }
-        }
-        {
             const char * const hvname = HvNAME_get(sv);
             if (hvname) {
                 SV* tmpsv = newSVpvs_flags("", SVs_TEMP);

--- a/sv.c
+++ b/sv.c
@@ -5895,7 +5895,6 @@ Perl_sv_magicext(pTHX_ SV *const sv, SV *const obj, const int how,
         how == PERL_MAGIC_arylen ||
         how == PERL_MAGIC_regdata ||
         how == PERL_MAGIC_regdatum ||
-        how == PERL_MAGIC_symtab ||
         (SvTYPE(obj) == SVt_PVGV &&
             (GvSV(obj) == sv || GvHV(obj) == (const HV *)sv
              || GvAV(obj) == (const AV *)sv || GvCV(obj) == (const CV *)sv


### PR DESCRIPTION
The (badly-named) PERL_MAGIC_symtab no longer uses the `mg_obj` field. It is only applied in one place (at time of writing, toke.c line 10711) with the `obj` field set to NULL. Therefore, there is no point having code in `dump.c` to print it if non-NULL, nor in `sv.c` to special-case setting a non-NULL value in `sv_magicext()`.

* This set of changes does not require a perldelta entry.