### PR TITLE
win32/perlhost.h: revert changes to SETUPEXCHANGE

### DIFF
--- a/win32/perlhost.h
+++ b/win32/perlhost.h
@@ -2143,11 +2143,11 @@ CPerlHost::CPerlHost(void)
 #define SETUPEXCHANGE(xptr, iptr, table) \
     STMT_START {				\
         if (xptr) {				\
-            *(void**)&iptr = (void*)xptr;			\
-            *(void**)&xptr = (void*)&table;			\
+            iptr = *xptr;			\
+            *xptr = &table;			\
         }					\
         else {					\
-            *(void**)&iptr = (void*)&table;			\
+            iptr = &table;			\
         }					\
     } STMT_END
 


### PR DESCRIPTION
This was broken by 48bda52b92, which removed the `*` before `xptr`. Without `*`, we set our `iptr` (a class member) to a bogus pointer, and the assignment to `xptr` (which is a function parameter and hence a local variable) is effectively dead code.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
