### PR TITLE
Fix finding the correct cplusplus compiler

### DIFF
--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder.pm
@@ -7,7 +7,7 @@ use Perl::OSType qw/os_type/;
 
 use warnings;
 use strict;
-our $VERSION = '0.280240'; # VERSION
+our $VERSION = '0.280241'; # VERSION
 our @ISA;
 
 # We only use this once - don't waste a symbol table entry on it.

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
@@ -24,6 +24,7 @@ my %cc2cxx = (
     xlc => [ 'xlC' ], # IBM C/C++ Set, xlc without thread-safety
     xlc_r => [ 'xlC_r' ], # IBM C/C++ Set, xlc with thread-safety
     cl    => [ 'cl' ], # Microsoft Visual Studio
+    clang => [ 'clang++' ], # LLVM compiler frontend
 );
 
 sub new {

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
@@ -60,7 +60,7 @@ sub new {
 
           if( can_run( $cxx1 ) ) {
               $self->{config}{cxx} = $cxx1;
-	            last;
+              last;
           }
 
       }
@@ -69,12 +69,12 @@ sub new {
 
           if( can_run( $cxx2 ) ) {
               $self->{config}{cxx} = $cxx2;
-	            last;
+              last;
           }
 
           if( can_run( $cxx ) ) {
               $self->{config}{cxx} = $cxx;
-	            last;
+              last;
           }
 
       }

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Base.pm
@@ -9,7 +9,7 @@ use Text::ParseWords;
 use IPC::Cmd qw(can_run);
 use File::Temp qw(tempfile);
 
-our $VERSION = '0.280240'; # VERSION
+our $VERSION = '0.280241'; # VERSION
 
 # More details about C/C++ compilers:
 # http://developers.sun.com/sunstudio/documentation/product/compiler.jsp
@@ -51,24 +51,31 @@ sub new {
 
     ## If the path is just "cc", fileparse returns $ccpath as "./"
     $ccpath = "" if $self->{config}{cc} =~ /^\Q$ccbase$ccsfx\E$/;
-      
+
     foreach my $cxx (@{$cc2cxx{$ccbase}}) {
-      my $cxx1 = File::Spec->catfile( $ccpath, $cxx . $ccsfx);
 
-      if( can_run( $cxx1 ) ) {
-        $self->{config}{cxx} = $cxx1;
-	last;
+      if ( $ccpath ) {
+          my $cxx1 = File::Spec->catfile( $ccpath, $cxx . $ccsfx);
+
+          if( can_run( $cxx1 ) ) {
+              $self->{config}{cxx} = $cxx1;
+	            last;
+          }
+
       }
-      my $cxx2 = $cxx . $ccsfx;
+      else {
+          my $cxx2 = $cxx . $ccsfx;
 
-      if( can_run( $cxx2 ) ) {
-        $self->{config}{cxx} = $cxx2;
-	last;
-      }
+          if( can_run( $cxx2 ) ) {
+              $self->{config}{cxx} = $cxx2;
+	            last;
+          }
 
-      if( can_run( $cxx ) ) {
-        $self->{config}{cxx} = $cxx;
-	last;
+          if( can_run( $cxx ) ) {
+              $self->{config}{cxx} = $cxx;
+	            last;
+          }
+
       }
     }
     unless ( exists $self->{config}{cxx} ) {

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Unix.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Unix.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Base;
 
-our $VERSION = '0.280240'; # VERSION
+our $VERSION = '0.280241'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Base);
 
 sub link_executable {

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/VMS.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/VMS.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Base;
 
-our $VERSION = '0.280240'; # VERSION
+our $VERSION = '0.280241'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Base);
 
 use File::Spec::Functions qw(catfile catdir);

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows.pm
@@ -8,7 +8,7 @@ use File::Spec;
 use ExtUtils::CBuilder::Base;
 use IO::File;
 
-our $VERSION = '0.280240'; # VERSION
+our $VERSION = '0.280241'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Base);
 
 =begin comment

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/BCC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/BCC.pm
@@ -1,6 +1,6 @@
 package ExtUtils::CBuilder::Platform::Windows::BCC;
 
-our $VERSION = '0.280240'; # VERSION
+our $VERSION = '0.280241'; # VERSION
 
 use strict;
 use warnings;

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/GCC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/GCC.pm
@@ -1,6 +1,6 @@
 package ExtUtils::CBuilder::Platform::Windows::GCC;
 
-our $VERSION = '0.280240'; # VERSION
+our $VERSION = '0.280241'; # VERSION
 
 use warnings;
 use strict;

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/MSVC.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/Windows/MSVC.pm
@@ -1,6 +1,6 @@
 package ExtUtils::CBuilder::Platform::Windows::MSVC;
 
-our $VERSION = '0.280240'; # VERSION
+our $VERSION = '0.280241'; # VERSION
 
 use warnings;
 use strict;

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/aix.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/aix.pm
@@ -5,7 +5,7 @@ use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 use File::Spec;
 
-our $VERSION = '0.280240'; # VERSION
+our $VERSION = '0.280241'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub need_prelink { 1 }

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/android.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/android.pm
@@ -6,7 +6,7 @@ use File::Spec;
 use ExtUtils::CBuilder::Platform::Unix;
 use Config;
 
-our $VERSION = '0.280240'; # VERSION
+our $VERSION = '0.280241'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 # The Android linker will not recognize symbols from

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/cygwin.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/cygwin.pm
@@ -5,7 +5,7 @@ use strict;
 use File::Spec;
 use ExtUtils::CBuilder::Platform::Unix;
 
-our $VERSION = '0.280240'; # VERSION
+our $VERSION = '0.280241'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 # TODO: If a specific exe_file name is requested, if the exe created

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/darwin.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/darwin.pm
@@ -5,7 +5,7 @@ use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 use Config;
 
-our $VERSION = '0.280240'; # VERSION
+our $VERSION = '0.280241'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 my ($osver) = split /\./, $Config{osvers};

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/dec_osf.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/dec_osf.pm
@@ -5,7 +5,7 @@ use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 use File::Spec;
 
-our $VERSION = '0.280240'; # VERSION
+our $VERSION = '0.280241'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub link_executable {

--- a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/os2.pm
+++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/os2.pm
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use ExtUtils::CBuilder::Platform::Unix;
 
-our $VERSION = '0.280240'; # VERSION
+our $VERSION = '0.280241'; # VERSION
 our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
 
 sub need_prelink { 1 }

--- a/dist/ExtUtils-CBuilder/t/03-cplusplus.t
+++ b/dist/ExtUtils-CBuilder/t/03-cplusplus.t
@@ -26,7 +26,18 @@ else {
   plan tests => 7;
 }
 
-ok $b, "created EU::CB object";
+{
+    # GH #23146
+    my $fake_cc = File::Spec->rel2abs(File::Spec->catfile(qw(some directory what doesnt exist), 'cc'));
+    my $b = ExtUtils::CBuilder->new(
+        quiet => $quiet,
+        config => {
+            cc => $fake_cc,
+        },
+    );
+
+    is $b->{config}{cxx}, $fake_cc, "did not search PATH for C++ compiler when given absolute path to C compiler";
+}
 
 ok $b->have_cplusplus, "have_cplusplus";
 

--- a/dist/ExtUtils-CBuilder/t/03-cplusplus.t
+++ b/dist/ExtUtils-CBuilder/t/03-cplusplus.t
@@ -16,6 +16,19 @@ use File::Spec;
 my $quiet = $ENV{PERL_CORE} && !$ENV{HARNESS_ACTIVE};
 my ($source_file, $object_file, $lib_file);
 
+{
+    # GH #23146
+    my $fake_cc = File::Spec->rel2abs(File::Spec->catfile(qw(some directory what doesnt exist), 'cc'));
+    my $cb = ExtUtils::CBuilder->new(
+        quiet => $quiet,
+        config => {
+            cc => $fake_cc,
+        },
+    );
+
+    is $cb->{config}{cxx}, $fake_cc, "did not search PATH for C++ compiler when given absolute path to C compiler";
+}
+
 my $b = ExtUtils::CBuilder->new(quiet => $quiet);
 
 # test plan
@@ -24,19 +37,6 @@ if ( ! $b->have_cplusplus ) {
 }
 else {
   plan tests => 7;
-}
-
-{
-    # GH #23146
-    my $fake_cc = File::Spec->rel2abs(File::Spec->catfile(qw(some directory what doesnt exist), 'cc'));
-    my $b = ExtUtils::CBuilder->new(
-        quiet => $quiet,
-        config => {
-            cc => $fake_cc,
-        },
-    );
-
-    is $b->{config}{cxx}, $fake_cc, "did not search PATH for C++ compiler when given absolute path to C compiler";
 }
 
 ok $b->have_cplusplus, "have_cplusplus";

--- a/dist/ExtUtils-CBuilder/t/03-cplusplus.t
+++ b/dist/ExtUtils-CBuilder/t/03-cplusplus.t
@@ -16,6 +16,16 @@ use File::Spec;
 my $quiet = $ENV{PERL_CORE} && !$ENV{HARNESS_ACTIVE};
 my ($source_file, $object_file, $lib_file);
 
+my $b = ExtUtils::CBuilder->new(quiet => $quiet);
+
+# test plan
+if ( ! $b->have_cplusplus ) {
+  plan skip_all => "no compiler available for testing";
+}
+else {
+  plan tests => 7;
+}
+
 {
     # GH #23146
     my $fake_cc = File::Spec->rel2abs(File::Spec->catfile(qw(some directory what doesnt exist), 'cc'));
@@ -27,16 +37,6 @@ my ($source_file, $object_file, $lib_file);
     );
 
     is $cb->{config}{cxx}, $fake_cc, "did not search PATH for C++ compiler when given absolute path to C compiler";
-}
-
-my $b = ExtUtils::CBuilder->new(quiet => $quiet);
-
-# test plan
-if ( ! $b->have_cplusplus ) {
-  plan skip_all => "no compiler available for testing";
-}
-else {
-  plan tests => 7;
 }
 
 ok $b->have_cplusplus, "have_cplusplus";

--- a/dist/ExtUtils-CBuilder/t/03-cplusplus.t
+++ b/dist/ExtUtils-CBuilder/t/03-cplusplus.t
@@ -26,19 +26,6 @@ else {
   plan tests => 7;
 }
 
-{
-    # GH #23146
-    my $fake_cc = File::Spec->rel2abs(File::Spec->catfile(qw(some directory what doesnt exist), 'cc'));
-    my $cb = ExtUtils::CBuilder->new(
-        quiet => $quiet,
-        config => {
-            cc => $fake_cc,
-        },
-    );
-
-    is $cb->{config}{cxx}, $fake_cc, "did not search PATH for C++ compiler when given absolute path to C compiler";
-}
-
 ok $b->have_cplusplus, "have_cplusplus";
 
 $source_file = File::Spec->catfile('t', 'cplust.cc');
@@ -71,5 +58,18 @@ for ($source_file, $object_file, $lib_file) {
 if ($^O eq 'VMS') {
    1 while unlink 'CPLUST.LIS';
    1 while unlink 'CPLUST.OPT';
+}
+
+{
+    # GH #23146
+    my $fake_cc = File::Spec->rel2abs(File::Spec->catfile(qw(some directory what doesnt exist), 'cc'));
+    my $cb = ExtUtils::CBuilder->new(
+        quiet => $quiet,
+        config => {
+            cc => $fake_cc,
+        },
+    );
+
+    is $cb->{config}{cxx}, $fake_cc, "did not search PATH for C++ compiler when given absolute path to C compiler";
 }
 


### PR DESCRIPTION
ExtUtils::CBuilder was using a slightly maverick method for finding the matching cplusplus compiler to the c compiler used to build perl.

On a Linux system with a perl built with the Oracle Developer cc cc='/opt/oracle/developerstudio12.6/bin/cc'

Errors were observed:
"c++: error: unrecognized command line option ‘-KPIC’; did you mean ‘-fPIC’?"

The cplusplus command for Oracle Developer suite is CC not c++ and the detection was picking up the system c++ (g++).

If there is a ccpath, the code should exhaust all the options and not fail through to using no path.

Clang/Clang++ were missing from the C/C++ mappings so I have added those as well.