### PR TITLE
Replace some sv_2mortal() instances with more direct equivalents

### DIFF
--- a/class.c
+++ b/class.c
@@ -472,7 +472,7 @@ static void S_ensure_module_version(pTHX_ SV *module, SV *version)
 static void S_split_attr_nameval(pTHX_ SV *sv, SV **namp, SV **valp)
 {
     STRLEN svlen = SvCUR(sv);
-    bool do_utf8 = SvUTF8(sv);
+    U32 do_utf8 = SvUTF8(sv) ? SVf_UTF8 : 0;
 
     const char *paren_at = (const char *)memchr(SvPVX(sv), '(', svlen);
     if(paren_at) {
@@ -486,7 +486,7 @@ static void S_split_attr_nameval(pTHX_ SV *sv, SV **namp, SV **valp)
              */
             /* diag_listed_as: SKIPME */
             croak("Malformed attribute string");
-        *namp = sv_2mortal(newSVpvn_utf8(SvPVX(sv), namelen, do_utf8));
+        *namp = newSVpvn_flags(SvPVX(sv), namelen, SVs_TEMP|do_utf8);
 
         const char *value_at = paren_at + 1;
         const char *value_max = SvPVX(sv) + svlen - 2;
@@ -500,7 +500,7 @@ static void S_split_attr_nameval(pTHX_ SV *sv, SV **namp, SV **valp)
             value_max -= 1;
 
         if(value_max >= value_at)
-            *valp = sv_2mortal(newSVpvn_utf8(value_at, value_max - value_at + 1, do_utf8));
+            *valp = newSVpvn_flags(value_at, value_max - value_at + 1, SVs_TEMP|do_utf8);
         else
             *valp = NULL;
     }

--- a/hv.c
+++ b/hv.c
@@ -650,7 +650,7 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
                     if (!keysv) {
                         keysv = newSVpvn_flags(key, klen, SVf_UTF8|SVs_TEMP);
                     } else {
-                        keysv = sv_2mortal(newSVsv(keysv));
+                        keysv = sv_mortalcopy_flags(keysv, SV_GMAGIC|SV_NOSTEAL);
                     }
                     mg_copy(MUTABLE_SV(hv), sv, (char *)keysv, HEf_SVKEY);
                 } else {

--- a/hv.c
+++ b/hv.c
@@ -648,11 +648,11 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
 
                 if (keysv || is_utf8) {
                     if (!keysv) {
-                        keysv = newSVpvn_utf8(key, klen, TRUE);
+                        keysv = newSVpvn_flags(key, klen, SVf_UTF8|SVs_TEMP);
                     } else {
-                        keysv = newSVsv(keysv);
+                        keysv = sv_2mortal(newSVsv(keysv));
                     }
-                    mg_copy(MUTABLE_SV(hv), sv, (char *)sv_2mortal(keysv), HEf_SVKEY);
+                    mg_copy(MUTABLE_SV(hv), sv, (char *)keysv, HEf_SVKEY);
                 } else {
                     mg_copy(MUTABLE_SV(hv), sv, key, klen);
                 }

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -4189,7 +4189,8 @@ Perl_do_readline(pTHX)
     }
     else {
         /* XXX on RC builds, push on stack rather than mortalize ? */
-        sv = sv_2mortal(newSV(80));
+        sv = newSV_type_mortal(SVt_PV);
+        sv_grow_fresh(sv, 81);
         offset = 0;
     }
 
@@ -4316,7 +4317,8 @@ Perl_do_readline(pTHX)
                 SvPV_shrink_to_cur(sv);
             }
             /* XXX on RC builds, push on stack rather than mortalize ? */
-            sv = sv_2mortal(newSV(80));
+            sv = newSV_type_mortal(SVt_PV);
+            sv_grow_fresh(sv, 81);
             continue;
         }
 

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -4612,8 +4612,7 @@ PP_wrapped(pp_system, 0, 1)
          * as numeric, not just retain the string value.
          */
         if (SvNIOK(origsv) || SvNIOKp(origsv)) {
-            copysv = newSV_type(SVt_PVNV);
-            sv_2mortal(copysv);
+            copysv = newSV_type_mortal(SVt_PVNV);
             if (SvPOK(origsv) || SvPOKp(origsv)) {
                 pv = SvPV_nomg(origsv, len);
                 sv_setpvn_fresh(copysv, pv, len);

--- a/regcomp.c
+++ b/regcomp.c
@@ -3562,11 +3562,9 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                             Perl_croak(aTHX_
                                 "panic: reg_scan_name returned NULL");
                         if (!RExC_paren_names) {
-                            RExC_paren_names = newHV();
-                            sv_2mortal(MUTABLE_SV(RExC_paren_names));
+                            RExC_paren_names = MUTABLE_HV(newSV_type_mortal(SVt_PVHV));
 #ifdef DEBUGGING
-                            RExC_paren_name_list = newAV();
-                            sv_2mortal(MUTABLE_SV(RExC_paren_name_list));
+                            RExC_paren_name_list = MUTABLE_AV(newSV_type_mortal(SVt_PVAV));
 #endif
                         }
                         he_str = hv_fetch_ent( RExC_paren_names, svname, 1, 0 );
@@ -7685,8 +7683,8 @@ Perl_populate_anyof_bitmap_from_invlist(pTHX_ regnode *node, SV** invlist_ptr)
 #define ADD_POSIX_WARNING(p, text)  STMT_START {                            \
         if (posix_warnings) {                                               \
             if (! RExC_warn_text ) RExC_warn_text =                         \
-                                         (AV *) sv_2mortal((SV *) newAV()); \
-            av_push_simple(RExC_warn_text, Perl_newSVpvf(aTHX_                     \
+                                   MUTABLE_AV(newSV_type_mortal(SVt_PVAV)); \
+            av_push_simple(RExC_warn_text, Perl_newSVpvf(aTHX_              \
                                              WARNING_PREFIX                 \
                                              text                           \
                                              REPORT_LOCATION,               \


### PR DESCRIPTION
A few commits making this sort of change:
* `sv_2mortal(newSVpvn_utf8(SvPVX(sv), namelen, do_utf8));`
      -> `newSVpvn_flags(SvPVX(sv), namelen, SVs_TEMP|do_utf8);`
* `newSVpvn_utf8(key, klen, TRUE);` + `sv_2mortal()`
      -> `newSVpvn_flags(key, klen, SVf_UTF8|SVs_TEMP);`
* `(AV *) sv_2mortal((SV *) newAV())`
      -> `MUTABLE_AV(newSV_type_mortal(SVt_PVAV));`

The changes are intended to be functionally equivalent but do the work
through one function call rather than two.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
