### PR TITLE
Nuke the MGf_PERSIST flag, freeing a bit in ->mg_flags

### DIFF
--- a/mg.c
+++ b/mg.c
@@ -2899,7 +2899,7 @@ Perl_magic_setlvref(pTHX_ SV *sv, MAGIC *mg)
         (void)hv_store_ent((HV *)mg->mg_obj, (SV *)mg->mg_ptr,
                            SvREFCNT_inc_simple_NN(SvRV(sv)), 0);
     }
-    if (mg->mg_flags & MGf_PERSIST)
+    if (mg->mg_private & OPpLVREF_ITER)
         NOOP; /* This sv is in use as an iterator var and will be reused,
                  so we must leave the magic.  */
     else

--- a/mg.h
+++ b/mg.h
@@ -40,7 +40,6 @@ struct magic {
 #define MGf_DUP     0x10 	/* has an svt_dup   MGVTBL entry */
 #define MGf_LOCAL   0x20	/* has an svt_local MGVTBL entry */
 #define MGf_BYTES   0x40        /* PERL_MAGIC_regex_global only */
-#define MGf_PERSIST    0x80     /* PERL_MAGIC_lvref only */
 
 #define MgTAINTEDDIR(mg)	(mg->mg_flags & MGf_TAINTEDDIR)
 #define MgTAINTEDDIR_on(mg)	(mg->mg_flags |= MGf_TAINTEDDIR)

--- a/pp.c
+++ b/pp.c
@@ -7598,8 +7598,6 @@ PP_wrapped(pp_lvref,
                                    &PL_vtbl_lvref, (char *)elem,
                                    elem ? HEf_SVKEY : (I32)ARGTARG);
     mg->mg_private = PL_op->op_private;
-    if (PL_op->op_private & OPpLVREF_ITER)
-        mg->mg_flags |= MGf_PERSIST;
     if (UNLIKELY(PL_op->op_private & OPpLVAL_INTRO)) {
       if (elem) {
         assert(arg);


### PR DESCRIPTION
The MGf_PERSIST flag is only used by PERL_MAGIC_lvref, and there it simply contains a shadow copy of the OPpLVREF_ITER flag in op_private. Since the mg_priv field is set as a copy of op_private anyway, the code that checks this bit might as well look there instead.

As a result of this change, the 0x80 bit of the mg_flags field is now free for other purposes.

* This set of changes does not require a perldelta entry.