### PR TITLE
pp.c: pp_clonecv reorder TARGs init vs use, universal.c: remove a strlen

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -62,12 +62,13 @@ PP(pp_introcv)
 
 PP(pp_clonecv)
 {
-    dTARGET;
+
     CV * const protocv = PadnamePROTOCV(
         PadlistNAMESARRAY(CvPADLIST(find_runcv(NULL)))[ARGTARG]
     );
-    assert(SvTYPE(TARG) == SVt_PVCV);
     assert(protocv);
+    dTARGET;
+    assert(SvTYPE(TARG) == SVt_PVCV);
     if (CvISXSUB(protocv)) { /* constant */
         /* XXX Should we clone it here? */
         /* If this changes to use SAVECLEARSV, we can move the SAVECLEARSV

--- a/universal.c
+++ b/universal.c
@@ -1436,8 +1436,10 @@ Perl_boot_core_UNIVERSAL(pTHX)
 
     /* Providing a Regexp::DESTROY fixes #21347. See test in t/op/ref.t  */
     {
-        CV * const cv =
-            newCONSTSUB(get_hv("Regexp::", GV_ADD), "DESTROY", NULL);
+        GV* const gv = gv_fetchpvs("Regexp::", GV_ADD, SVt_PVHV);
+        HV* const stash = GvHV(gv);
+        CV* const cv =
+            newCONSTSUB_flags(stash, "DESTROY", STRLENs("DESTROY"), 0, NULL);
         char ** cvfile = &CvFILE(cv);
         char * oldfile = *cvfile;
         CvDYNFILE_off(cv);


### PR DESCRIPTION
dTARGET macro, and macro ARGTARG both deref PL_op. find_runcv() is a fn. Reorder dTARGET to be after the find_runcv() call so the CC dedupes find the OP * with ARGTARG.

Remove 2 strlen() calls at proc start inside Perl_boot_core_UNIVERSAL().

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
