### PR TITLE
Dumper.xs: use new SvVSTRING API

### DIFF
--- a/dist/Data-Dumper/Dumper.xs
+++ b/dist/Data-Dumper/Dumper.xs
@@ -6,6 +6,7 @@
 #define NEED_my_sprintf
 #define NEED_sv_2pv_flags
 #define NEED_utf8_to_uvchr_buf
+#define NEED_sv_vstring_get
 #include "ppport.h"
 
 #ifndef strlcpy
@@ -1240,7 +1241,8 @@ DD_dump(pTHX_ SV *val, const char *name, STRLEN namelen, SV *retval, HV *seenhv,
     }
     else {
 	STRLEN i;
-	const MAGIC *mg;
+	STRLEN vstr_len;
+	const char *vstr_pv;
 	
 	if (namelen) {
 	    id_buffer = PTR2UV(val);
@@ -1386,17 +1388,17 @@ DD_dump(pTHX_ SV *val, const char *name, STRLEN namelen, SV *retval, HV *seenhv,
 	    sv_catpvs(retval, "undef");
 	}
 #ifdef SvVOK
-	else if (SvMAGICAL(val) && (mg = mg_find(val, PERL_MAGIC_vstring))) {
+	else if (SvVOK(val) && (vstr_pv = SvVSTRING(val, vstr_len))) {
 # if !defined(PL_vtbl_vstring) && PERL_VERSION_LT(5,17,0)
 	    SV * const vecsv = sv_newmortal();
 #  if PERL_VERSION_LT(5,10,0)
-	    scan_vstring(mg->mg_ptr, vecsv);
+	    scan_vstring(vstr_pv, vecsv);
 #  else
-	    scan_vstring(mg->mg_ptr, mg->mg_ptr + mg->mg_len, vecsv);
+	    scan_vstring(vstr_pv, vstr_pv + vstr_len, vecsv);
 #  endif
 	    if (!sv_eq(vecsv, val)) goto integer_came_from_string;
 # endif
-	    sv_catpvn(retval, (const char *)mg->mg_ptr, mg->mg_len);
+	    sv_catpvn(retval, vstr_pv, vstr_len);
 	}
 #endif
 
@@ -1701,13 +1703,13 @@ Data_Dumper__vstring(sv)
 	CODE:
 	{
 #ifdef SvVOK
-	    const MAGIC *mg;
-	    RETVAL =
-		SvMAGICAL(sv) && (mg = mg_find(sv, PERL_MAGIC_vstring))
-		 ? newSVpvn((const char *)mg->mg_ptr, mg->mg_len)
-		 : &PL_sv_undef;
-#else
-	    RETVAL = &PL_sv_undef;
+	    if(SvVOK(sv)) {
+		STRLEN vstr_len;
+		const char *vstr_pv = SvVSTRING(sv, vstr_len);
+		RETVAL = newSVpvn(vstr_pv, vstr_len);
+	    }
+	    else
 #endif
+	    RETVAL = &PL_sv_undef;
 	}
 	OUTPUT: RETVAL


### PR DESCRIPTION
Use the new abstraction API rather than direct access to the MAGIC structures.

* This set of changes does not require a perldelta entry.