### PR TITLE
PathTools: check Config values early before chdir

### DIFF
--- a/dist/PathTools/Cwd.pm
+++ b/dist/PathTools/Cwd.pm
@@ -3,7 +3,7 @@ use strict;
 use Exporter;
 
 
-our $VERSION = '3.92';
+our $VERSION = '3.94';
 my $xs_version = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/dist/PathTools/lib/File/Spec.pm
+++ b/dist/PathTools/lib/File/Spec.pm
@@ -4,7 +4,7 @@ use strict;
 
 # Keep $VERSION consistent in all *.pm files in this distribution, including
 # Cwd.pm.
-our $VERSION = '3.93';
+our $VERSION = '3.94';
 $VERSION =~ tr/_//d;
 
 my %module = (

--- a/dist/PathTools/lib/File/Spec/AmigaOS.pm
+++ b/dist/PathTools/lib/File/Spec/AmigaOS.pm
@@ -3,7 +3,7 @@ package File::Spec::AmigaOS;
 use strict;
 require File::Spec::Unix;
 
-our $VERSION = '3.93';
+our $VERSION = '3.94';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Cygwin.pm
+++ b/dist/PathTools/lib/File/Spec/Cygwin.pm
@@ -3,7 +3,7 @@ package File::Spec::Cygwin;
 use strict;
 require File::Spec::Unix;
 
-our $VERSION = '3.93';
+our $VERSION = '3.94';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Epoc.pm
+++ b/dist/PathTools/lib/File/Spec/Epoc.pm
@@ -2,7 +2,7 @@ package File::Spec::Epoc;
 
 use strict;
 
-our $VERSION = '3.93';
+our $VERSION = '3.94';
 $VERSION =~ tr/_//d;
 
 require File::Spec::Unix;

--- a/dist/PathTools/lib/File/Spec/Functions.pm
+++ b/dist/PathTools/lib/File/Spec/Functions.pm
@@ -3,7 +3,7 @@ package File::Spec::Functions;
 use File::Spec;
 use strict;
 
-our $VERSION = '3.93';
+our $VERSION = '3.94';
 $VERSION =~ tr/_//d;
 
 require Exporter;

--- a/dist/PathTools/lib/File/Spec/Mac.pm
+++ b/dist/PathTools/lib/File/Spec/Mac.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.93';
+our $VERSION = '3.94';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/OS2.pm
+++ b/dist/PathTools/lib/File/Spec/OS2.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.93';
+our $VERSION = '3.94';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Unix.pm
+++ b/dist/PathTools/lib/File/Spec/Unix.pm
@@ -3,7 +3,7 @@ package File::Spec::Unix;
 use strict;
 use Cwd ();
 
-our $VERSION = '3.93';
+our $VERSION = '3.94';
 $VERSION =~ tr/_//d;
 
 =head1 NAME

--- a/dist/PathTools/lib/File/Spec/VMS.pm
+++ b/dist/PathTools/lib/File/Spec/VMS.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.93';
+our $VERSION = '3.94';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Win32.pm
+++ b/dist/PathTools/lib/File/Spec/Win32.pm
@@ -5,7 +5,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.93';
+our $VERSION = '3.94';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/t/cwd_enoent.t
+++ b/dist/PathTools/t/cwd_enoent.t
@@ -10,6 +10,8 @@ if($^O eq "cygwin") {
     # This test skipping should be removed when the Cygwin bug is fixed.
     plan skip_all => "getcwd() fails to fail on Cygwin [perl #132733]";
 }
+my $prefix = $Config{prefix};
+my $osvers = $Config{osvers};
 
 my $tmp = tempdir(CLEANUP => 1);
 unless(mkdir("$tmp/testdir") && chdir("$tmp/testdir") && rmdir("$tmp/testdir")){
@@ -24,11 +26,11 @@ foreach my $type (qw(regular perl)) {
     SKIP: {
 	skip "_perl_abs_path() not expected to work", 4
 	    if $type eq "perl" &&
-		!(($Config{prefix} =~ m/\//) && $^O ne "cygwin");
+		!(($prefix =~ m/\//) && $^O ne "cygwin");
 
         # https://github.com/Perl/perl5/issues/16525
         # https://bugs.dragonflybsd.org/issues/3250
-        my @vlist = ($Config{osvers} =~ /(\d+)/g);
+        my @vlist = ($osvers =~ /(\d+)/g);
         my $osver = sprintf("%d%03d", map { defined() ? $_ : '0' } @vlist[0,1]);
 	skip "getcwd() doesn't fail on non-existent directories on this platform", 4
 	    if $type eq 'regular' && $^O eq 'dragonfly' && $osver < 6002;


### PR DESCRIPTION
In a perl core build, the `@INC` paths will be relative. If you change directories before loading all of the files needed, they won't be able to be found. `Config.pm` loads some of its values at runtime, so if they are accessed after a `chdir`, it may fail.

One of the `PathTools` tests was relying on the fact that `Config_heavy.pl` would be loaded by `Test::More`, before it did a `chdir`. Newer `Test::More` won't do that, so the test would fail. Accessing the required `Config` values early will prevent this failure.

This same issue is unlikely to impact anything outside core, as it requires the perl core paths in `@INC` to be relative paths, which is normally not the case.

Fixes #23164

* This set of changes does not require a perldelta entry.

