### PR TITLE
dist-modules: fix selection of a threaded perl

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -819,8 +819,8 @@ jobs:
         perl-version:
           - '5.38'
           - '5.24'
+          - '5.18'
           - '5.10'
-          - '5.8'
         threads:
           - enable: true
             label: -Dusethreads

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -833,7 +833,7 @@ jobs:
         uses: shogo82148/actions-setup-perl@v1.30.0
         with:
           perl-version: ${{ matrix.perl-version }}
-          multi-thread: ${{ matrix.threads.id }}
+          multi-thread: ${{ matrix.threads.enable }}
           install-modules:
             ExtUtils::MakeMaker
             Perl::OSType


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
I looked at the test results of a PR recently and when drilling down into the threaded results noticed we weren't actually testing against old threaded perls.

I suspect I broke this when I re-worked it to add the pretty labels, since the original patch set here did fix some threaded build issues detected by these tests.

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
