### PR TITLE
RMG - Make last_version handle smoothly provided RC version numbers

### DIFF
--- a/Porting/make-rmg-checklist
+++ b/Porting/make-rmg-checklist
@@ -152,7 +152,8 @@ my $passthru_headers = qr/^= (?: over | item | back | cut )/xms;
 # version used when generating diffs (acknowledgements, Module::CoreList etc)
 # 5.36.0 -> 5.34.0
 # 5.36.1 -> 5.36.0
-my ($major, $minor, $point) = split(/\./, $version);
+my ($major, $minor, $point_with_maybe_rc) = split(/\./, $version);
+my ($point) = split(/-/, $point_with_maybe_rc);
 my $last_version = join('.', $major, ($point == 0 ? ($minor - 2, 0) : ($minor, $point-1)));
 
 


### PR DESCRIPTION
# Description
Current release manager guide generator (`make-rmg-checklist`) complains about RC versions:

```
$ perl make-rmg-checklist --version 5.42.0-RC1 --html | head
Argument "0-RC1" isn't numeric in numeric eq (==) at make-rmg-checklist line 156.
...
```

@karenetheridge

---------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
