### PR TITLE
RMG - Run perlivp in install path

### DIFF
--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -1121,9 +1121,10 @@ which is why you should test from the tarball.
 
 =head4 Run the Installation Verification Procedure utility
 
- $ ./perl -Ilib ./utils/perlivp
+ $ bin/perlivp
+
  # Or, perhaps:
- $ ./perl5.X.Y ./utils/perlivp5.X.Y
+ $ bin/perlivp5.X.Y
  ...
  All tests successful.
  $


### PR DESCRIPTION
# Description
Run `perlivp` from install path. 
- Guide is asking to move to install path earlier and more actions are run from this place right after (e.g. "Bootstrap the CPAN client")
- Even if working from source directory, [initial intention](https://github.com/Perl/perl5/commit/459fc3ca45067f8a2b7f262f7aac0a99372c2a88) was to run this from install path

Fixes #23145  

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
