### PR TITLE
RMG - For commit message related to preparation of Module::Corelist for next release, do not specify version

### DIFF
--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -1604,7 +1604,7 @@ about blead's current version.
 Commit and push your changes.
 
  $ git add -u
- $ git commit -m "Prepare Module::Corelist for 5.X.Y"
+ $ git commit -m "Prepare Module::Corelist"
  $ git push origin
 
 =back


### PR DESCRIPTION
# Description
At this step, the preparation of Module::Corelist is no longer for 5.X.Y so do not specify the version in the proposed commit message.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
