### PR TITLE
Fix potential conflict of __attribute__((noreturn))

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -438,7 +438,7 @@ Now a no-op.
 #  define __attribute__nonnull__(a)         __attribute__((nonnull(a)))
 #endif
 #ifdef HASATTRIBUTE_NORETURN
-#  define __attribute__noreturn__           __attribute__((noreturn))
+#  define __attribute__noreturn__           __attribute__((__noreturn__))
 #endif
 #ifdef HASATTRIBUTE_PURE
 #  define __attribute__pure__               __attribute__((pure))


### PR DESCRIPTION
If `<stdnoreturn.h>` is included first, then `noreturn` is defined to `_Noreturn`, and then `__attribute__((noreturn))` will end up being `__attribute__((_Noreturn))`, which would not be recognized and might result in a compiler warning.  To avoid this, use the alternative spelling `__attribute__((__noreturn__))` instead.  This is supported by the same compiler versions.

* This set of changes does not require a perldelta entry.
