### PR TITLE
win32: allow build with USE_ITHREADS=undef but USE_IMP_SYS=define

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -330,9 +330,10 @@ L</Modules and Pragmata> section.
 
 =over 4
 
-=item XXX-some-platform
+=item Win32
 
-XXX
+Fix builds with C<USE_IMP_SYS> defined but C<USE_ITHREADS> not
+defined.
 
 =back
 

--- a/win32/perllib.c
+++ b/win32/perllib.c
@@ -51,6 +51,7 @@ xs_init(pTHX)
 void
 win32_checkTLS(PerlInterpreter *host_perl)
 {
+#ifdef USE_ITHREADS
 /* GCurThdId() is lightweight, but b/c of the ctrl-c/signals sometimes firing
   in other random WinOS threads, that make the TIDs go out of sync.
   This isn't always an error, although high chance of a SEGV in the next
@@ -67,6 +68,13 @@ win32_checkTLS(PerlInterpreter *host_perl)
         }
         host_perl->Isys_intern.cur_tid = tid;
     }
+#else
+    dTHX;
+    if (host_perl != my_perl) {
+        int *nowhere = NULL;
+        abort();
+    }
+#endif
 }
 
 EXTERN_C void

--- a/win32/perllib.c
+++ b/win32/perllib.c
@@ -63,7 +63,6 @@ win32_checkTLS(PerlInterpreter *host_perl)
     if(tid != host_perl->Isys_intern.cur_tid) {
         dTHX; /* heavyweight */
         if (host_perl != my_perl) {
-            int *nowhere = NULL;
             abort();
         }
         host_perl->Isys_intern.cur_tid = tid;
@@ -71,7 +70,6 @@ win32_checkTLS(PerlInterpreter *host_perl)
 #else
     dTHX;
     if (host_perl != my_perl) {
-        int *nowhere = NULL;
         abort();
     }
 #endif

--- a/win32/perllib.c
+++ b/win32/perllib.c
@@ -76,7 +76,7 @@ win32_checkTLS(PerlInterpreter *host_perl)
         }
         host_perl->Isys_intern.cur_tid = tid;
     }
-#else
+#elif defined(PERL_MULTIPLICITY)
     dTHX;
     if (host_perl != my_perl) {
         panic_thread_id();

--- a/win32/perllib.c
+++ b/win32/perllib.c
@@ -48,6 +48,13 @@ xs_init(pTHX)
 
 #include "perlhost.h"
 
+#define PANIC_THREAD_ID_MSG "panic: thread id mismatch\n"
+
+#define panic_thread_id() \
+    (void)WriteFile(GetStdHandle(STD_ERROR_HANDLE),         \
+        PANIC_THREAD_ID_MSG, sizeof(PANIC_THREAD_ID_MSG)-1, \
+        NULL, NULL)
+
 void
 win32_checkTLS(PerlInterpreter *host_perl)
 {
@@ -63,6 +70,8 @@ win32_checkTLS(PerlInterpreter *host_perl)
     if(tid != host_perl->Isys_intern.cur_tid) {
         dTHX; /* heavyweight */
         if (host_perl != my_perl) {
+            panic_thread_id();
+            DebugBreak();
             abort();
         }
         host_perl->Isys_intern.cur_tid = tid;
@@ -70,6 +79,8 @@ win32_checkTLS(PerlInterpreter *host_perl)
 #else
     dTHX;
     if (host_perl != my_perl) {
+        panic_thread_id();
+        DebugBreak();
         abort();
     }
 #endif


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
While testing #17601 the build failed with:

```
perllib.c(62): error C2039: 'cur_tid': is not a member of 'interp_intern'
...\perl\win32\win32.h(566): note: see declaration of 'interp_intern'
perllib.c(68): error C2039: 'cur_tid': is not a member of 'interp_intern'
...\perl\git\perl\win32\win32.h(566): note: see declaration of 'interp_intern'
```

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
