### PR TITLE
perl5180delta: fix link

### DIFF
--- a/pod/perl5180delta.pod
+++ b/pod/perl5180delta.pod
@@ -1922,7 +1922,7 @@ C<< Can't do {n,m} with n > m in regex; marked by <-- HERE in m/%s/ >>
 
 This fatal error has been turned into a warning that reads:
 
-L<< Quantifier {n,m} with n > m can't match in regex | perldiag/Quantifier {n,m} with n > m can't match in regex >>
+L<< Quantifier {n,m} with n > m can't match in regex|perldiag/Quantifier {n,m} with n > m can't match in regex >>
 
 (W regexp) Minima should be less than or equal to maxima.  If you really want
 your regexp to match something 0 times, just put {0}.

--- a/pod/perl5240delta.pod
+++ b/pod/perl5240delta.pod
@@ -1083,8 +1083,8 @@ L<Sequence (?PE<gt>... not terminated in regex; marked by E<lt>-- HERE in mE<sol
 
 =item *
 
-L<Assuming NOT a POSIX class since %s in regex; marked by E<lt>-- HERE in mE<sol>%sE<sol>|
-perldiag/Assuming NOT a POSIX class since %s in regex; marked by <-- HERE in mE<sol>%sE<sol>>
+L<Assuming NOT a POSIX class since %s in regex; marked by E<lt>-- HERE in
+mE<sol>%sE<sol>|perldiag/Assuming NOT a POSIX class since %s in regex; marked by <-- HERE in mE<sol>%sE<sol>>
 
 =item *
 


### PR DESCRIPTION
The multiple brackets syntax for POD links requires whitespace next to the brackets, but the whitespace within the directive is still significant. This resulted in a broken link to " perldiag".

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
