### PR TITLE
Don't try to link to INSTALL which is not linkable documentation

### DIFF
--- a/Porting/todo.pod
+++ b/Porting/todo.pod
@@ -288,7 +288,7 @@ to do this manually are roughly
 =item *
 
 do a normal C<Configure>, but include Devel::Cover as a module to install
-(see L<INSTALL> for how to do this)
+(see F<INSTALL> for how to do this)
 
 =item *
 

--- a/README.bs2000
+++ b/README.bs2000
@@ -219,7 +219,7 @@ Thomas Dorner
 
 =head1 SEE ALSO
 
-L<INSTALL>, L<perlport>.
+F<INSTALL>, L<perlport>.
 
 =head2 Mailing list
 

--- a/autodoc.pl
+++ b/autodoc.pl
@@ -1224,21 +1224,24 @@ sub parse_config_h {
                                         | sh | SH | exe ) \b
                                     !xx;
                 my $path_name_qr = qr! (?: / \w+ )+ !x;
-                for my $re ($file_name_qr, $path_name_qr) {
-                    s! (*nlb:[ < \w / ]) ( $re ) !<$1>!gxx;
-                }
+                my $file_or_path_name_qr = qr!
+                        $file_name_qr
+                    |
+                        $path_name_qr
+                    |
+                        INSTALL \b
+                !x;
+                s! (*nlb:[ < \w / ]) ( $file_or_path_name_qr ) !<$1>!gxx;
 
                 # Enclose <... file/path names with F<...> (but no double
                 # angle brackets)
-                for my $re ($file_name_qr, $path_name_qr) {
-                    s! < ( $re ) > !F<$1>!gxx;
-                }
+                s! < ( $file_or_path_name_qr ) > !F<$1>!gxx;
 
                 # Explain metaconfig units
                 s/ ( \w+ \. U \b ) /$1 (part of metaconfig)/gx;
 
                 # Convert "See foo" to "See C<L</foo>>" if foo is described in
-                # this file.  Also create a link to the known file INSTALL.
+                # this file.
                 # And, to be more general, handle "See also foo and bar", and
                 # "See also foo, bar, and baz"
                 while (m/ \b [Ss]ee \s+
@@ -1249,10 +1252,7 @@ sub parse_config_h {
                     push @links, $2 if defined $2;
                     push @links, $3 if defined $3;
                     foreach my $link (@links) {
-                        if ($link eq 'INSTALL') {
-                            s/ \b INSTALL \b /C<L<INSTALL>>/xg;
-                        }
-                        elsif (grep { $link =~ / \b $_ \b /x } keys %configs) {
+                        if (grep { $link =~ / \b $_ \b /x } keys %configs) {
                             s| \b $link \b |C<L</$link>>|xg;
                             $configs{$link}{linked} = 1;
                             $configs{$name}{linked} = 1;
@@ -1261,7 +1261,6 @@ sub parse_config_h {
                 }
 
                 # Enclose what we think are symbols with C<...>.
-                no warnings 'experimental::vlb';
                 s/ (*nlb:<)
                    (
                         # Any word followed immediately with parens or
@@ -1269,7 +1268,7 @@ sub parse_config_h {
                         \b \w+ (?: \( [^)]* \)    # parameter list
                                  | \[ [^]]* \]    # or array reference
                                )
-                    | (*plb: ^ | \s ) -D \w+    # Also -Dsymbols.
+                    | (*nlb: \S ) -D \w+    # Also -Dsymbols.
                     | \b (?: struct | union ) \s \w+
 
                         # Words that contain underscores (which are

--- a/pod/perl5122delta.pod
+++ b/pod/perl5122delta.pod
@@ -122,7 +122,7 @@ role in the exception mechanism.
 
 =item *
 
-Perl's L<INSTALL> file has been clarified to explicitly state that Perl
+Perl's F<INSTALL> file has been clarified to explicitly state that Perl
 requires a C89 compliant ANSI C Compiler.
 
 =item *

--- a/pod/perlrun.pod
+++ b/pod/perlrun.pod
@@ -444,7 +444,7 @@ B<-D14> is equivalent to B<-Dtls>):
 All these flags require B<-DDEBUGGING> when you compile the Perl
 executable (but see C<:opd> in L<Devel::Peek> or L<re/'debug' mode>
 which may change this).
-See the L<INSTALL> file in the Perl source distribution
+See the F<INSTALL> file in the Perl source distribution
 for how to do this.
 
 If you're just trying to get a print out of each line of Perl code

--- a/pod/perlunicode.pod
+++ b/pod/perlunicode.pod
@@ -2086,7 +2086,7 @@ Download the files in the desired version of Unicode from the Unicode web
 site L<https://www.unicode.org>).  These should replace the existing files in
 F<lib/unicore> in the Perl source tree.  Follow the instructions in
 F<README.perl> in that directory to change some of their names, and then build
-perl (see L<INSTALL>).
+perl (see F<INSTALL>).
 
 =head2 Porting code from perl-5.6.X
 

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -594,7 +594,7 @@ Then
     $^M = 'a' x (1 << 16);
 
 would allocate a 64K buffer for use in an emergency.  See the
-L<INSTALL> file in the Perl distribution for information on how to
+F<INSTALL> file in the Perl distribution for information on how to
 add custom C compilation flags when compiling perl.  To discourage casual
 use of this advanced feature, there is no L<English|English> long name for
 this variable.


### PR DESCRIPTION
Also remove the code in autodoc.pl which attempts to create these links.

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
