### PR TITLE
perl5280delta - fix manpage link

### DIFF
--- a/pod/perl5280delta.pod
+++ b/pod/perl5280delta.pod
@@ -1868,7 +1868,7 @@ A new function, L<C<Perl_langinfo()>|perlapi/Perl_langinfo> has been
 added.  It is an (almost) drop-in replacement for the system
 C<nl_langinfo(3)>, but works on platforms that lack that; as well as
 being more thread-safe, and hiding some gotchas with locale handling
-from the caller.  Code that uses this, needn't use L<C<localeconv(3)>>
+from the caller.  Code that uses this, needn't use C<L<localeconv(3)>>
 (and be affected by the gotchas) to find the decimal point, thousands
 separator, or currency symbol.  See L<perlapi/Perl_langinfo>.
 


### PR DESCRIPTION
C<> inside L<> causes it to be interpreted as a module link rather than the intended manpage link.

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
