### PR TITLE
POSIX: fix man page links

### DIFF
--- a/ext/POSIX/lib/POSIX.pod
+++ b/ext/POSIX/lib/POSIX.pod
@@ -1132,7 +1132,7 @@ Not implemented.  C<malloc()> is C-specific.  Perl does memory management transp
 
 This is the same as the C function C<mblen()> on unthreaded perls.  On
 threaded perls, it transparently (almost) substitutes the more
-thread-safe L<C<mbrlen>(3)>, if available, instead of C<mblen>.
+thread-safe C<L<mbrlen(3)>>, if available, instead of C<mblen>.
 
 Core Perl does not have any support for wide and multibyte locales,
 except Unicode UTF-8 locales.  This function, in conjunction with
@@ -1161,7 +1161,7 @@ actual length of the first parameter string.
 
 This is the same as the C function C<mbtowc()> on unthreaded perls.  On
 threaded perls, it transparently (almost) substitutes the more
-thread-safe L<C<mbrtowc>(3)>, if available, instead of C<mbtowc>.
+thread-safe C<L<mbrtowc(3)>>, if available, instead of C<mbtowc>.
 
 Core Perl does not have any support for wide and multibyte locales,
 except Unicode UTF-8 locales.  This function, in conjunction with
@@ -2265,7 +2265,7 @@ See L</mblen>.
 
 This is the same as the C function C<wctomb()> on unthreaded perls.  On
 threaded perls, it transparently (almost) substitutes the more
-thread-safe L<C<wcrtomb>(3)>, if available, instead of C<wctomb>.
+thread-safe C<L<wcrtomb(3)>>, if available, instead of C<wctomb>.
 
 Core Perl does not have any support for wide and multibyte locales,
 except Unicode UTF-8 locales.  This function, in conjunction with


### PR DESCRIPTION
C<> inside the L<> causes the links to be interpreted as module links rather than the intended links to manpages.


<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
