### PR TITLE
perl5300delta: fix link to perldeprecation

### DIFF
--- a/pod/perl5300delta.pod
+++ b/pod/perl5300delta.pod
@@ -216,7 +216,7 @@ by default, JSON::PP also enabled allow_nonref by default.
 This deprecation was scheduled to become fatal in 5.30, but has been
 delayed to 5.32 due to problems that showed up with some CPAN modules.
 For details of what's affected, see
-L<perldeprecation|perldeprecation/In XS code, use of various macros dealing with UTF-8.>.
+L<perldeprecation|perldeprecation/In XS code, use of various macros dealing with UTF-8>.
 
 =head1 Performance Enhancements
 

--- a/pod/perl5300delta.pod
+++ b/pod/perl5300delta.pod
@@ -215,8 +215,8 @@ by default, JSON::PP also enabled allow_nonref by default.
 
 This deprecation was scheduled to become fatal in 5.30, but has been
 delayed to 5.32 due to problems that showed up with some CPAN modules.
-For details of what's affected, see L<perldeprecation|
-perldeprecation/In XS code, use of various macros dealing with UTF-8.>.
+For details of what's affected, see
+L<perldeprecation|perldeprecation/In XS code, use of various macros dealing with UTF-8.>.
 
 =head1 Performance Enhancements
 


### PR DESCRIPTION
Extra whitespace in L<> results in an invalid link.

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
