### PR TITLE
fix manpage links for generated apidocs

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -875,7 +875,7 @@ That is, each returns a boolean indicating whether the specified character is
 one of C<[A-Za-z0-9]>, analogous to C<m/[[:alnum:]]/>.
 
 The C<C> suffix in the names was meant to indicate that they correspond to the
-C language L<C<isalnum(3)>>.
+C language C<L<isalnum(3)>>.
 
 =for apidoc Am|bool|isASCII|UV ch
 =for apidoc_item ||isASCII_A|UV ch

--- a/locale.c
+++ b/locale.c
@@ -4423,7 +4423,7 @@ S_native_querylocale_i(pTHX_ const locale_category_index cat_index)
 /*
 =for apidoc Perl_setlocale
 
-This is an (almost) drop-in replacement for the system L<C<setlocale(3)>>,
+This is an (almost) drop-in replacement for the system C<L<setlocale(3)>>,
 taking the same parameters, and returning the same information, except that it
 returns the correct underlying C<LC_NUMERIC> locale.  Regular C<setlocale> will
 instead return C<C> if the underlying locale has a non-dot decimal point
@@ -10826,7 +10826,7 @@ change the locale (though changing the locale is antisocial and dangerous on
 multi-threaded systems that don't have multi-thread safe locale operations.
 (See L<perllocale/Multi-threaded operation>).
 
-Using the libc L<C<setlocale(3)>> function should be avoided.  Nevertheless,
+Using the libc C<L<setlocale(3)>> function should be avoided.  Nevertheless,
 certain non-Perl libraries called from XS, do call it, and their behavior may
 not be able to be changed.  This function, along with
 C<L</switch_to_global_locale>>, can be used to get seamless behavior in these

--- a/numeric.c
+++ b/numeric.c
@@ -1516,7 +1516,7 @@ Perl_my_atof(pTHX_ const char* s)
 =for apidoc      my_atof
 =for apidoc_item Atof
 
-These each are L<C<atof>(3)>, but properly work with Perl locale handling,
+These each are C<L<atof(3)>>, but properly work with Perl locale handling,
 accepting a dot radix character always, but also the current locale's radix
 character if and only if called from within the lexical scope of a Perl C<use
 locale> statement.


### PR DESCRIPTION
C<> within L<> will cause the links to be interpreted as module links instead of the intended manpage links. These are all within C comments that end up as part of the generated perlapi doc page.

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
