### PR TITLE
perldiag: fix broken link to perlunicode

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -7910,9 +7910,9 @@ compile if the currently unassigned delimiter ends up being something
 that isn't a stand-alone grapheme.  Because Unicode is never going to
 assign
 L<non-character code points|perlunicode/Noncharacter code points>, nor
-L<code points that are above the legal Unicode maximum|
-perlunicode/Beyond Unicode code points>, those can be delimiters, and
-their use is legal.
+L<code points that are above the legal Unicode
+maximum|perlunicode/Beyond Unicode code points>, those can be delimiters,
+and their use is legal.
 
 =item Use of uninitialized value%s
 


### PR DESCRIPTION
whitespace within L<> is significant, so a newline after the bar results in a link to " perlunicode"

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
