### PR TITLE
Try to force inlining of newSV_type (i -> I in embed.fnc)

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2339,7 +2339,7 @@ ARdp	|SV *	|newSVsv_flags	|NULLOK SV * const old			\
 				|I32 flags
 ARdm	|SV *	|newSVsv_nomg	|NULLOK SV * const old
 ARdp	|SV *	|newSV_true
-ARdip	|SV *	|newSV_type	|const svtype type
+AIRdp	|SV *	|newSV_type	|const svtype type
 AIRdp	|SV *	|newSV_type_mortal					\
 				|const svtype type
 ARdp	|SV *	|newSVuv	|const UV u

--- a/proto.h
+++ b/proto.h
@@ -9878,9 +9878,10 @@ Perl_newRV_noinc(pTHX_ SV * const tmpRef)
 # define PERL_ARGS_ASSERT_NEWRV_NOINC           \
         assert(tmpRef)
 
-PERL_STATIC_INLINE SV *
+PERL_STATIC_FORCE_INLINE SV *
 Perl_newSV_type(pTHX_ const svtype type)
-        __attribute__warn_unused_result__;
+        __attribute__warn_unused_result__
+        __attribute__always_inline__;
 # define PERL_ARGS_ASSERT_NEWSV_TYPE
 
 PERL_STATIC_FORCE_INLINE SV *


### PR DESCRIPTION
When `Perl_newSV_type` became an inline function, the idea was that using it to create a specific type known at compile time should result in the call being completely inlined into the call site.

So something like this would always be inlined by gcc/clang under default build settings:

    SV* mySV = newSV_type(SVt_PV)

At some point in the past couple of dev cycles, this inlining seems to have stopped happening. Possibly additions just tipped it over a size threshold within the C compiler optimization passes.

This commit changes the inline flag in embed.fnc from `i` ("please try to inline") to `I` ("always inline", where supported). This restores the intended behaviour.

The more aggressive inlining flag wasn't originally specified out of caution if it causing the perl binary size to grow excessively. On the present codebase though, building with this flag and gcc 12 actually resulted in the binary size shrinking by 312 bytes.

`Perl_newSV` is a good function to disassemble to check if the `Perl_newSV_type` call
is inlined or not.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
