### PR TITLE
cpan/Math-BigInt - Update to version 2.005003

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -765,8 +765,8 @@ our %Modules = (
     },
 
     'Math::BigInt' => {
-        'DISTRIBUTION' => 'PJACKLAM/Math-BigInt-2.005002.tar.gz',
-        'SYNCINFO'     => 'jkeenan on Thu Apr 10 20:38:17 2025',
+        'DISTRIBUTION' => 'PJACKLAM/Math-BigInt-2.005003.tar.gz',
+        'SYNCINFO'     => 'jkeenan on Sun Apr 13 14:50:24 2025',
         'FILES'        => q[cpan/Math-BigInt],
         'EXCLUDED'     => [
             qr{^xt/},

--- a/cpan/Math-BigInt/lib/Math/BigInt/Calc.pm
+++ b/cpan/Math-BigInt/lib/Math/BigInt/Calc.pm
@@ -7,7 +7,7 @@ use warnings;
 use Carp qw< carp croak >;
 use Math::BigInt::Lib;
 
-our $VERSION = '2.005002';
+our $VERSION = '2.005003';
 $VERSION =~ tr/_//d;
 
 our @ISA = ('Math::BigInt::Lib');

--- a/cpan/Math-BigInt/lib/Math/BigInt/Lib.pm
+++ b/cpan/Math-BigInt/lib/Math/BigInt/Lib.pm
@@ -4,7 +4,7 @@ use 5.006001;
 use strict;
 use warnings;
 
-our $VERSION = '2.005002';
+our $VERSION = '2.005003';
 $VERSION =~ tr/_//d;
 
 use Carp;

--- a/cpan/Math-BigInt/lib/Math/BigRat.pm
+++ b/cpan/Math-BigInt/lib/Math/BigRat.pm
@@ -22,7 +22,7 @@ use Carp            qw< carp croak >;
 use Scalar::Util    qw< blessed >;
 use Math::BigFloat  qw<>;
 
-our $VERSION = '2.005002';
+our $VERSION = '2.005003';
 $VERSION =~ tr/_//d;
 
 require Exporter;
@@ -677,6 +677,37 @@ sub from_ieee754 {
     my @r      = @_;
 
     my $tmp = Math::BigFloat -> from_ieee754($in, $format, @r);
+
+    $tmp = $tmp -> as_rat();
+
+    # If called as a class method, initialize a new object.
+
+    $self = $class -> bzero(@r) unless $selfref;
+    $self -> {sign} = $tmp -> {sign};
+    $self -> {_n}   = $tmp -> {_n};
+    $self -> {_d}   = $tmp -> {_d};
+
+    $self -> _dng() if $self -> is_int();
+    return $self;
+}
+
+sub from_fp80 {
+    my $self    = shift;
+    my $selfref = ref $self;
+    my $class   = $selfref || $self;
+
+    # Make "require" work.
+
+    $class -> import() if $IMPORT == 0;
+
+    # Don't modify constant (read-only) objects.
+
+    return $self if $selfref && $self -> modify('from_fp80');
+
+    my $in = shift;
+    my @r  = @_;
+
+    my $tmp = Math::BigFloat -> from_fp80($in, @r);
 
     $tmp = $tmp -> as_rat();
 
@@ -3070,7 +3101,7 @@ sub bblsft {
 
     # Don't modify constant (read-only) objects.
 
-    return $x if $x -> modify('bblsft');
+    return $x if ref($x) && $x -> modify('bblsft');
 
     # Let Math::BigInt do the job.
 
@@ -3117,7 +3148,7 @@ sub bbrsft {
 
     # Don't modify constant (read-only) objects.
 
-    return $x if $x -> modify('bbrsft');
+    return $x if ref($x) && $x -> modify('bbrsft');
 
     # Let Math::BigInt do the job.
 
@@ -3520,16 +3551,32 @@ sub fparts {
     my $x = shift;
     my $class = ref $x;
 
-    croak("fparts() is an instance method") unless $class;
+    # NaN => NaN/NaN
 
-    return ($class -> bnan(),
-            $class -> bnan()) if $x -> is_nan();
+    if ($x -> is_nan()) {
+        return $class -> bnan(), $class -> bnan() if wantarray;
+        return $class -> bnan();
+    }
+
+    # ±Inf => ±Inf/1
+
+    if ($x -> is_inf()) {
+        return $class -> binf($x -> sign()), $class -> bone() if wantarray;
+        return $class -> binf($x -> sign());
+    }
+
+    # -3/2 -> -3/1
 
     my $numer = $x -> copy();
-    my $denom = $class -> bzero();
-
-    $denom -> {_n} = $numer -> {_d};
     $numer -> {_d} = $LIB -> _one();
+    return $numer unless wantarray;
+
+    # -3/2 -> 2/1
+
+    my $denom = $x -> copy();
+    $denom -> {sign} = "+";
+    $denom -> {_n}   = $denom -> {_d};
+    $denom -> {_d}   = $LIB -> _one();
 
     return $numer, $denom;
 }
@@ -3773,6 +3820,13 @@ sub to_ieee754 {
     return $x -> as_float() -> to_ieee754($format);
 }
 
+sub to_fp80 {
+    my ($class, $x, @r) = ref($_[0]) ? (ref($_[0]), @_)
+                                              : objectify(1, @_);
+
+    return $x -> as_float(@r) -> to_fp80();
+}
+
 sub as_hex {
     my ($class, $x) = ref($_[0]) ? (undef, $_[0]) : objectify(1, @_);
 
@@ -3977,6 +4031,7 @@ Math::BigRat - arbitrary size rational number math package
   $x = Math::BigRat->from_base('why', 36);  # from any base
   $x = Math::BigRat->from_base_num([1, 0], 2);  # from any base
   $x = Math::BigRat->from_ieee754($b, $fmt);    # from IEEE-754 bytes
+  $x = Math::BigRat->from_fp80($b);         # from x86 80-bit
   $x = Math::BigRat->bzero();               # create a +0
   $x = Math::BigRat->bone();                # create a +1
   $x = Math::BigRat->bone('-');             # create a -1
@@ -4132,6 +4187,7 @@ Math::BigRat - arbitrary size rational number math package
   $x->to_base($b);        # as string in any base
   $x->to_base_num($b);    # as array of integers in any base
   $x->to_ieee754($fmt);   # to bytes encoded according to IEEE 754-2008
+  $x->to_fp80();          # encode value in x86 80-bit format
 
   $x->as_hex();           # as signed hexadecimal string with "0x" prefix
   $x->as_bin();           # as signed binary string with "0b" prefix
@@ -4242,6 +4298,17 @@ See L<Math::BigInt/from_bytes()>.
 Interpret the input as a value encoded as described in IEEE754-2008.
 
 See L<Math::BigFloat/from_ieee754()>.
+
+=item from_fp80()
+
+    # set $x to 14488038916154245685/4611686018427387904, the closest value
+    # to pi that can be represented in the x86 80-bit format
+    $x = Math::BigRat -> from_fp80("4000c90fdaa22168c235");
+
+Interpret the input as a value encoded in the x86 extended-precision 80-bit
+format.
+
+See L<Math::BigFloat/from_fp80()>.
 
 =item from_base()
 
@@ -4749,6 +4816,10 @@ See L<Math::BigInt/to_bytes()>.
 =item to_ieee754()
 
 See L<Math::BigFloat/to_ieee754()>.
+
+=item to_fp80()
+
+See L<Math::BigFloat/to_fp80()>.
 
 =item as_hex()
 


### PR DESCRIPTION
2.005003 2025-04-13

* Add new methods to_fp80() and from_fp80() for encoding and decoding values in the x86 extended-precision 80 bit format.

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
TODO: fill description here

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
* This set of changes requires a perldelta entry, and I need help writing it.
* This set of changes does not require a perldelta entry.
