### PR TITLE
regcomp_invlist.c -> S_invlist_trim -> SvPV_renew wasteful NOOP (bug demo, ! a PR)

### DIFF
--- a/regcomp_invlist.c
+++ b/regcomp_invlist.c
@@ -247,13 +247,13 @@ S_invlist_trim(SV* invlist)
 
     /* But don't free up the space needed for the 0 UV that is always at the
      * beginning of the list, nor the trailing NUL */
-    const UV min_size = TO_INTERNAL_SIZE(1) + 1;
+    const UV min_size = TO_INTERNAL_SIZE(1) + 1; /* XXX 64bit UVs malloc()s on 32b CPU ? */
 
     PERL_ARGS_ASSERT_INVLIST_TRIM;
 
     assert(is_invlist(invlist));
 
-    SvPV_renew(invlist, MAX(min_size, SvCUR(invlist) + 1));
+    SvPV_renew(invlist, MAX(min_size, SvCUR(invlist) + 1)); /* XXX bug ??? */
 }
 
 PERL_STATIC_INLINE void

--- a/sv.h
+++ b/sv.h
@@ -1570,8 +1570,9 @@ why not just use C<SvGROW> if you're not sure about the provenance?
 
 =cut
 */
-#define SvPV_renew(sv,n) \
-        STMT_START { SvLEN_set(sv, n); \
+#define SvPV_renew(sv,n) STMT_START { \
+                assert(SvLEN(sv) > n && n > 0);\
+                SvLEN_set(sv, n); \
                 SvPV_set((sv), (MEM_WRAP_CHECK_(n,char)			\
                                 (char*)saferealloc((Malloc_t)SvPVX(sv), \
                                                    (MEM_SIZE)((n)))));  \

--- a/toke.c
+++ b/toke.c
@@ -11878,7 +11878,7 @@ Perl_scan_str(pTHX_ char *start, int keep_bracketed_quoted, int keep_delims, int
 
     /* if we allocated too much space, give some back */
     if (SvCUR(sv) + 5 < SvLEN(sv)) {
-        SvLEN_set(sv, SvCUR(sv) + 1);
+        /* XXX SvLEN_set(sv, SvCUR(sv) + 1); */
         SvPV_shrink_to_cur(sv);
     }
 


### PR DESCRIPTION
https://github.com/Perl/perl5/blob/7946d6a39ecd42bbb39400c0df1c3bf3a7edfa71/sv.h#L1574

https://github.com/Perl/perl5/blob/7946d6a39ecd42bbb39400c0df1c3bf3a7edfa71/sv.h#L1593

https://github.com/Perl/perl5/blob/7946d6a39ecd42bbb39400c0df1c3bf3a7edfa71/toke.c#L11876


https://github.com/Perl/perl5/commit/0e72d900876f109acabe46b7351b57937e08051a

[khwilliamson](https://github.com/Perl/perl5/commits?author=khwilliamson) committed on Aug 22, 2020
toke.c: Use SvPV_shrink_to_cur

https://github.com/Perl/perl5/commit/b7e9a5c2d751f7ed3b8a703e57ac933ded5b16ce

[nwc10](https://github.com/Perl/perl5/commits?author=nwc10) committed on Apr 18, 2005
Replace Renew(SvPVX(...)...) with SvPV_renew, which avoids an LVALUE

https://github.com/Perl/perl5/commit/93a17b20b6d176db3f04f51a63b0a781e5ffd11c#diff-eab4115a843bf91f2d20457b59e6b0c6c747ffa64ba1022d3ff958512da8df12R3612

Larry Wall committed on Oct 9, 1993
perl 5.0 alpha 3

https://github.com/Perl/perl5/commit/3001ef3e68934e089812f995b52451b8eb8f24e9#diff-dc8c62daf844c4b19510dfce777053a52ac4821852ef9818e3de8912dd3c4edbR113-L8440

[khwilliamson](https://github.com/Perl/perl5/commits?author=khwilliamson) committed on Feb 27, 2016
regcomp.c: Improve free-ing up unused inversion list space

slightly related to https://github.com/Perl/perl5/issues/22623

What is going on inside `S_invlist_trim()`??? 1 out of 4 BP hits while running mktables shows `SvPV_renew()` is getting called on new len value 9, while `SvLEN()` says it already is 9 long. A trip through libc `realloc()` for no reason at all. Windows OS'es malloc() impl always will move the 9 byte mem block and return a new ptr every time in my observation, and alternate between the exact same 2 ptrs addrs if someone does a NOOP like that. Other 50% or 75% of BP hits `S_invlist_trim()` were a number like 0x38 or 0x3C. but its approx 0x3_. Forgot the last digit. So 0x38 -> 0x09 sounds correct to me. Its atleast 2*PTRSIZE delta. so it will jump buckets on most OSes probably.

Why is it 0x09 and not 8/sizeof(UV) anyway? SVt_INVLIST objs are undocumented for CPAN and unreachable from PP. And if the first 4/8 bytes are NULL, its already nul term-ed and unprintable binary. 0x09 vs 0x8 matters for WinPerl since its P5P created mem pool API has a 3 x `void*`/24 byte long header, and reverse engineering/hex dump proves on my  particular Win64 build number, I have an 8 byte OS malloc header in AMD64 mode. Not sure if that means the minimum end user malloc() bucket size on Win64 is just 8 bytes and not 16 bytes or 24 bytes, and increases in 8 byte units, not 2 x PTRSIZE (16) byte units. These assumptions (bucket sizes/granularity/alignment aka SSE drama, 8 bytes vs 16 bytes malloc() internals on 64b CPU) are generally way too OS vendor+build number+security update specific, to hard code into the Perl interp. Easier to get rid of the +1 nul char instead of calculating if it wastes 0 bytes, 7 or 15 bytes on a certain line number on whose server or PC or phone.

Anyways, the `+1` on a non-text C struct, and then wasting 15 more bytes, is a persistent bug hazard in the Perl C API. See https://github.com/Perl/perl5/pull/22879

This is a smoke test, or bug report, not a PR.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.

