### PR TITLE
Fcntl: add __END__ tag, don't parse ~16 KB of POD

### DIFF
--- a/ext/Fcntl/Fcntl.pm
+++ b/ext/Fcntl/Fcntl.pm
@@ -1,5 +1,150 @@
 package Fcntl;
 
+use strict;
+
+use Exporter 'import';
+require XSLoader;
+our $VERSION = '1.20';
+
+XSLoader::load();
+
+# Named groups of exports
+our %EXPORT_TAGS = (
+    'flock'   => [qw(LOCK_SH LOCK_EX LOCK_NB LOCK_UN)],
+    'Fcompat' => [qw(FAPPEND FASYNC FCREAT FDEFER FDSYNC FEXCL FLARGEFILE
+		     FNDELAY FNONBLOCK FRSYNC FSYNC FTRUNC)],
+    'seek'    => [qw(SEEK_SET SEEK_CUR SEEK_END)],
+    'mode'    => [qw(S_ISUID S_ISGID S_ISVTX S_ISTXT
+		     _S_IFMT S_IFREG S_IFDIR S_IFLNK
+		     S_IFSOCK S_IFBLK S_IFCHR S_IFIFO S_IFWHT S_ENFMT
+		     S_IRUSR S_IWUSR S_IXUSR S_IRWXU
+		     S_IRGRP S_IWGRP S_IXGRP S_IRWXG
+		     S_IROTH S_IWOTH S_IXOTH S_IRWXO
+		     S_IREAD S_IWRITE S_IEXEC
+		     S_ISREG S_ISDIR S_ISLNK S_ISSOCK
+		     S_ISBLK S_ISCHR S_ISFIFO
+		     S_ISWHT
+		     S_IFMT S_IMODE
+                  )],
+);
+
+# Items to export into callers namespace by default
+# (move infrequently used names to @EXPORT_OK below)
+our @EXPORT =
+  qw(
+	FD_CLOEXEC
+	F_ALLOCSP
+	F_ALLOCSP64
+	F_COMPAT
+	F_DUP2FD
+	F_DUPFD
+	F_EXLCK
+	F_FREESP
+	F_FREESP64
+	F_FSYNC
+	F_FSYNC64
+	F_GETFD
+	F_GETFL
+	F_GETLK
+	F_GETLK64
+	F_GETOWN
+	F_NODNY
+	F_POSIX
+	F_RDACC
+	F_RDDNY
+	F_RDLCK
+	F_RWACC
+	F_RWDNY
+	F_SETFD
+	F_SETFL
+	F_SETLK
+	F_SETLK64
+	F_SETLKW
+	F_SETLKW64
+	F_SETOWN
+	F_SHARE
+	F_SHLCK
+	F_UNLCK
+	F_UNSHARE
+	F_WRACC
+	F_WRDNY
+	F_WRLCK
+	O_ACCMODE
+	O_ALIAS
+	O_APPEND
+	O_ASYNC
+	O_BINARY
+	O_CREAT
+	O_DEFER
+	O_DIRECT
+	O_DIRECTORY
+	O_DSYNC
+	O_EXCL
+	O_EXLOCK
+	O_LARGEFILE
+	O_NDELAY
+	O_NOCTTY
+	O_NOFOLLOW
+	O_NOINHERIT
+	O_NONBLOCK
+	O_RANDOM
+	O_RAW
+	O_RDONLY
+	O_RDWR
+	O_RSRC
+	O_RSYNC
+	O_SEQUENTIAL
+	O_SHLOCK
+	O_SYNC
+	O_TEMPORARY
+	O_TEXT
+	O_TRUNC
+	O_WRONLY
+     );
+
+# Other items we are prepared to export if requested
+our @EXPORT_OK = (qw(
+	DN_ACCESS
+	DN_ATTRIB
+	DN_CREATE
+	DN_DELETE
+	DN_MODIFY
+	DN_MULTISHOT
+	DN_RENAME
+	F_ADD_SEALS
+	F_GETLEASE
+	F_GETPIPE_SZ
+	F_GET_SEALS
+	F_GETSIG
+	F_NOTIFY
+	F_SEAL_FUTURE_WRITE
+	F_SEAL_GROW
+	F_SEAL_SEAL
+	F_SEAL_SHRINK
+	F_SEAL_WRITE
+	F_SETLEASE
+	F_SETPIPE_SZ
+	F_SETSIG
+	LOCK_MAND
+	LOCK_READ
+	LOCK_RW
+	LOCK_WRITE
+        O_ALT_IO
+        O_EVTONLY
+	O_IGNORE_CTTY
+	O_NOATIME
+	O_NOLINK
+        O_NOSIGPIPE
+	O_NOTRANS
+        O_SYMLINK
+        O_TMPFILE
+        O_TTY_INIT
+), map {@{$_}} values %EXPORT_TAGS);
+
+1;
+
+__END__
+
 =head1 NAME
 
 Fcntl - various flag constants and helper functions from C's fcntl.h
@@ -847,146 +992,3 @@ By default, if you say C<use Fcntl;>, the following symbols are exported:
     O_WRONLY
 
 =cut
-
-use strict;
-
-use Exporter 'import';
-require XSLoader;
-our $VERSION = '1.19';
-
-XSLoader::load();
-
-# Named groups of exports
-our %EXPORT_TAGS = (
-    'flock'   => [qw(LOCK_SH LOCK_EX LOCK_NB LOCK_UN)],
-    'Fcompat' => [qw(FAPPEND FASYNC FCREAT FDEFER FDSYNC FEXCL FLARGEFILE
-		     FNDELAY FNONBLOCK FRSYNC FSYNC FTRUNC)],
-    'seek'    => [qw(SEEK_SET SEEK_CUR SEEK_END)],
-    'mode'    => [qw(S_ISUID S_ISGID S_ISVTX S_ISTXT
-		     _S_IFMT S_IFREG S_IFDIR S_IFLNK
-		     S_IFSOCK S_IFBLK S_IFCHR S_IFIFO S_IFWHT S_ENFMT
-		     S_IRUSR S_IWUSR S_IXUSR S_IRWXU
-		     S_IRGRP S_IWGRP S_IXGRP S_IRWXG
-		     S_IROTH S_IWOTH S_IXOTH S_IRWXO
-		     S_IREAD S_IWRITE S_IEXEC
-		     S_ISREG S_ISDIR S_ISLNK S_ISSOCK
-		     S_ISBLK S_ISCHR S_ISFIFO
-		     S_ISWHT
-		     S_IFMT S_IMODE
-                  )],
-);
-
-# Items to export into callers namespace by default
-# (move infrequently used names to @EXPORT_OK below)
-our @EXPORT =
-  qw(
-	FD_CLOEXEC
-	F_ALLOCSP
-	F_ALLOCSP64
-	F_COMPAT
-	F_DUP2FD
-	F_DUPFD
-	F_EXLCK
-	F_FREESP
-	F_FREESP64
-	F_FSYNC
-	F_FSYNC64
-	F_GETFD
-	F_GETFL
-	F_GETLK
-	F_GETLK64
-	F_GETOWN
-	F_NODNY
-	F_POSIX
-	F_RDACC
-	F_RDDNY
-	F_RDLCK
-	F_RWACC
-	F_RWDNY
-	F_SETFD
-	F_SETFL
-	F_SETLK
-	F_SETLK64
-	F_SETLKW
-	F_SETLKW64
-	F_SETOWN
-	F_SHARE
-	F_SHLCK
-	F_UNLCK
-	F_UNSHARE
-	F_WRACC
-	F_WRDNY
-	F_WRLCK
-	O_ACCMODE
-	O_ALIAS
-	O_APPEND
-	O_ASYNC
-	O_BINARY
-	O_CREAT
-	O_DEFER
-	O_DIRECT
-	O_DIRECTORY
-	O_DSYNC
-	O_EXCL
-	O_EXLOCK
-	O_LARGEFILE
-	O_NDELAY
-	O_NOCTTY
-	O_NOFOLLOW
-	O_NOINHERIT
-	O_NONBLOCK
-	O_RANDOM
-	O_RAW
-	O_RDONLY
-	O_RDWR
-	O_RSRC
-	O_RSYNC
-	O_SEQUENTIAL
-	O_SHLOCK
-	O_SYNC
-	O_TEMPORARY
-	O_TEXT
-	O_TRUNC
-	O_WRONLY
-     );
-
-# Other items we are prepared to export if requested
-our @EXPORT_OK = (qw(
-	DN_ACCESS
-	DN_ATTRIB
-	DN_CREATE
-	DN_DELETE
-	DN_MODIFY
-	DN_MULTISHOT
-	DN_RENAME
-	F_ADD_SEALS
-	F_GETLEASE
-	F_GETPIPE_SZ
-	F_GET_SEALS
-	F_GETSIG
-	F_NOTIFY
-	F_SEAL_FUTURE_WRITE
-	F_SEAL_GROW
-	F_SEAL_SEAL
-	F_SEAL_SHRINK
-	F_SEAL_WRITE
-	F_SETLEASE
-	F_SETPIPE_SZ
-	F_SETSIG
-	LOCK_MAND
-	LOCK_READ
-	LOCK_RW
-	LOCK_WRITE
-        O_ALT_IO
-        O_EVTONLY
-	O_IGNORE_CTTY
-	O_NOATIME
-	O_NOLINK
-        O_NOSIGPIPE
-	O_NOTRANS
-        O_SYMLINK
-        O_TMPFILE
-        O_TTY_INIT
-), map {@{$_}} values %EXPORT_TAGS);
-
-1;


### PR DESCRIPTION
This module since it was created decades ago only had a tiny amount of (no?) POD until this recent commit which finally added full detailed docs. But now 16 KB POD must be parsed on startup, and this core module is very high on the "river", probably through Cwd/Test2/POSIX.

8cacb84717 - 1/22/2024 6:38:46 AM - Fcntl: add module documentation

---------------------------------------------------------------------------------
DON'T KNOW - too minor to document in Changes
* This set of changes requires a perldelta entry, and it is included.
* This set of changes requires a perldelta entry, and I need help writing it.

