### PR TITLE
xsubpp: fix C23 incompatibility in XSINTERFACE_* macros (another attempt)

### DIFF
--- a/XSUB.h
+++ b/XSUB.h
@@ -188,15 +188,19 @@ is a lexical C<$_> in scope.
 
 #define dXSI32 I32 ix = XSANY.any_i32
 
-#ifdef __cplusplus
-#  define XSINTERFACE_CVT(ret,name) ret (*name)(...)
-#  define XSINTERFACE_CVT_ANON(ret) ret (*)(...)
+#if __STDC_VERSION__ >= 202311L || defined(__GNUC__)
+#  define XSINTERFACE_CVT(ret, name, example_func_name) typeof(&example_func_name) name
+#  define XSINTERFACE_CVT_ANON(ret, example_func_name) typeof(&example_func_name)
+#elif defined(__cplusplus)
+#  define XSINTERFACE_CVT(ret, name, example_func_name) decltype(&example_func_name) name
+#  define XSINTERFACE_CVT_ANON(ret, example_func_name) decltype(&example_func_name)
 #else
-#  define XSINTERFACE_CVT(ret,name) ret (*name)()
-#  define XSINTERFACE_CVT_ANON(ret) ret (*)()
+#  define XSINTERFACE_CVT(ret,name, example_func_name) ret (*name)()
+#  define XSINTERFACE_CVT_ANON(ret, example_func_name) ret (*)()
 #endif
-#define dXSFUNCTION(ret)		XSINTERFACE_CVT(ret,XSFUNCTION)
-#define XSINTERFACE_FUNC(ret,cv,f)     ((XSINTERFACE_CVT_ANON(ret))(f))
+
+#define dXSFUNCTION(ret, example_func_name) XSINTERFACE_CVT(ret, XSFUNCTION, example_func_name)
+#define XSINTERFACE_FUNC(ret,cv,f,example_func_name) ((XSINTERFACE_CVT_ANON(ret, example_func_name))(f))
 #define XSINTERFACE_FUNC_SET(cv,f)	\
                 CvXSUBANY(cv).any_dxptr = (void (*) (pTHX_ void*))(f)
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -64,7 +64,7 @@ use Symbol;
 
 our $VERSION;
 BEGIN {
-  $VERSION = '3.57';
+  $VERSION = '3.58';
   require ExtUtils::ParseXS::Constants; ExtUtils::ParseXS::Constants->VERSION($VERSION);
   require ExtUtils::ParseXS::CountLines; ExtUtils::ParseXS::CountLines->VERSION($VERSION);
   require ExtUtils::ParseXS::Node; ExtUtils::ParseXS::Node->VERSION($VERSION);
@@ -896,10 +896,6 @@ EOF
 
     print Q(<<"EOF") if $self->{xsub_seen_ALIAS};
       |    dXSI32;
-EOF
-
-    print Q(<<"EOF") if $self->{xsub_seen_INTERFACE};
-      |    dXSFUNCTION($self->{xsub_return_type});
 EOF
 
 
@@ -2244,13 +2240,17 @@ sub INTERFACE_handler {
 
   trim_whitespace($in);
 
+  # used for function pointer type inference
+  my $example_interface_function;
   foreach (split /[\s,]+/, $in) {
     my $iface_name = $_;
     $iface_name =~ s/^$self->{PREFIX_pattern}//;
     $self->{xsub_map_interface_name_short_to_original}->{$iface_name} = $_;
+    $example_interface_function = $_;
   }
+
   print Q(<<"EOF");
-    |    XSFUNCTION = $self->{xsub_interface_macro}($self->{xsub_return_type},cv,XSANY.any_dptr);
+    |    dXSFUNCTION($self->{xsub_return_type}, $example_interface_function) = $self->{xsub_interface_macro}($self->{xsub_return_type},cv,XSANY.any_dptr,$example_interface_function);
 EOF
   $self->{xsub_seen_INTERFACE_or_MACRO} = 1;  # local
   $self->{seen_INTERFACE_or_MACRO} = 1;       # global

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Symbol;
 
-our $VERSION = '3.57';
+our $VERSION = '3.58';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
@@ -1,7 +1,7 @@
 package ExtUtils::ParseXS::CountLines;
 use strict;
 
-our $VERSION = '3.57';
+our $VERSION = '3.58';
 
 our $SECTION_END_MARKER;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
@@ -2,7 +2,7 @@ package ExtUtils::ParseXS::Eval;
 use strict;
 use warnings;
 
-our $VERSION = '3.57';
+our $VERSION = '3.58';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
@@ -2,7 +2,7 @@ package ExtUtils::ParseXS::Node;
 use strict;
 use warnings;
 
-our $VERSION = '3.57';
+our $VERSION = '3.58';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
@@ -5,7 +5,7 @@ use Exporter;
 use File::Spec;
 use ExtUtils::ParseXS::Constants ();
 
-our $VERSION = '3.57';
+our $VERSION = '3.58';
 
 our (@ISA, @EXPORT_OK);
 @ISA = qw(Exporter);

--- a/dist/ExtUtils-ParseXS/lib/perlxs.pod
+++ b/dist/ExtUtils-ParseXS/lib/perlxs.pod
@@ -2209,7 +2209,7 @@ this model, the less likely conflicts will occur.
 =head1 XS VERSION
 
 This document covers features supported by C<ExtUtils::ParseXS>
-(also known as C<xsubpp>) 3.57.
+(also known as C<xsubpp>) 3.58.
 
 =head1 AUTHOR DIAGNOSTICS
 


### PR DESCRIPTION
This is a proof of concept, not sure if this is the right direction.