### PR TITLE
util.h: fix broken casts in Perl_instr() parameters

### DIFF
--- a/util.h
+++ b/util.h
@@ -241,7 +241,7 @@ returning NULL if not found.  The terminating NUL bytes are not compared.
 */
 
 
-#define Perl_instr(haystack, needle) strstr((char *) haystack, (char *) needle)
+#define Perl_instr(haystack, needle) strstr(haystack, needle)
 
 #ifdef HAS_MEMMEM
 #   define ninstr(big, bigend, little, lend)                                \


### PR DESCRIPTION
Why broken? Because haystack/needle are effectively macros (they expand to token sequences), so a call like

    Perl_instr(a + b, x ? y : z)

expands to

    strstr((char *)a + b, (char *)x ? y : z)

which is just wrong.

Normally I'd simply add the missing parentheses (`(char *)(haystack)`, etc), but it's not clear to me why the casts were added in the first place (and fairly recently, too, in commit 4e52881229).

Background:

instr() was originally implemented in pre-standard C (without const and without a prototype) in util.c, perl-1.0. The consts were added fairly early on in 08105a92a3 (1997): `char *
instr(register const char *big, register const char *little);`

The hand-written C code was replaced by a call to strstr() in 5d1d68e202. It cast away const from the arguments to strstr() for no reason I can see: strstr() takes pointers to const char (just like Perl_instr), so the pointers were immediately implicitly re-consted by the prototype of strstr().

Commit fea1d2dd5d straight up turned instr() into an alias for strstr(), which was apparently fine without any casts for 4.5 years. The C code in Perl_instr() was moved from util.c to mathoms.c in commit 534dad4824.


<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
