### PR TITLE
signatures: don't leak an OP_NULL for a '$ =' sigscalarelem 

### DIFF
--- a/op.c
+++ b/op.c
@@ -16551,6 +16551,9 @@ Perl_subsignature_append_positional(pTHX_ OP *varop, OPCODE defmode, OP *defexpr
 
         if(defexpr->op_type == OP_NULL && !(defexpr->op_flags & OPf_KIDS))
         {
+            /* caller passed in newOP(OP_NULL, 0), so we should not leak it */
+            op_free(defexpr);
+
             /* handle '$=' special case */
             if(varop)
                 yyerror("Optional parameter lacks default expression");

--- a/op.c
+++ b/op.c
@@ -16543,12 +16543,6 @@ Perl_subsignature_append_positional(pTHX_ OP *varop, OPCODE defmode, OP *defexpr
     if(defexpr) {
         signature->optelems++;
 
-        I32 flags = 0;
-        if(defmode == OP_DORASSIGN)
-            flags |= OPpARG_IF_UNDEF << 8;
-        if(defmode == OP_ORASSIGN)
-            flags |= OPpARG_IF_FALSE << 8;
-
         if(defexpr->op_type == OP_NULL && !(defexpr->op_flags & OPf_KIDS))
         {
             /* caller passed in newOP(OP_NULL, 0), so we should not leak it */
@@ -16559,6 +16553,12 @@ Perl_subsignature_append_positional(pTHX_ OP *varop, OPCODE defmode, OP *defexpr
                 yyerror("Optional parameter lacks default expression");
         }
         else {
+            I32 flags = 0;
+            if(defmode == OP_DORASSIGN)
+                flags |= OPpARG_IF_UNDEF << 8;
+            if(defmode == OP_ORASSIGN)
+                flags |= OPpARG_IF_FALSE << 8;
+
             /* a normal '=default' expression */
             OP *defop = newARGDEFELEMOP(flags, defexpr, argix);
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -401,6 +401,11 @@ Class initializers and C<ADJUST> blocks, per L<perlclass>, that
 called C<last> or other loop exits would crash perl.  Same cause as
 for [GH #16608].
 
+=item *
+
+Prevent a signature parameter of the form C<$ => from leaking an OP at
+compile-time.  [GH #23187]
+
 =back
 
 =head1 Known Problems


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
Fixes #23187

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
