### PR TITLE
dist/IO.xs remove a dTHX call

### DIFF
--- a/dist/IO/ChangeLog
+++ b/dist/IO/ChangeLog
@@ -1,3 +1,7 @@
+IO 1.56
+    * A very minor optimization was done in perl's emulated poll() on the OSes
+      that use need that use Perl's implementation.
+
 IO 1.55
     * XS changes for getline/getlines to support reference counted stacks
     * moved the binmode method from IO::File to IO::Handle, since all types

--- a/dist/IO/IO.pm
+++ b/dist/IO/IO.pm
@@ -7,7 +7,7 @@ use Carp;
 use strict;
 use warnings;
 
-our $VERSION = "1.55";
+our $VERSION = "1.56";
 XSLoader::load 'IO', $VERSION;
 
 sub import {

--- a/dist/IO/poll.c
+++ b/dist/IO/poll.c
@@ -10,6 +10,7 @@
  *
  */
 
+#define PERL_NO_GET_CONTEXT
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
@@ -40,8 +41,13 @@
 
 # define POLL_EVENTS_MASK (POLL_CAN_READ | POLL_CAN_WRITE | POLL_HAS_EXCP)
 
+#if defined(PERL_IMPLICIT_SYS)
 int
-poll(struct pollfd *fds, unsigned long nfds, int timeout)
+Perl_my_poll_cxt(pTHX_ struct pollfd *fds, unsigned long nfds, int timeout)
+#else
+int
+Perl_my_poll(struct pollfd *fds, unsigned long nfds, int timeout)
+#endif
 {
     int i,err;
     fd_set rfd,wfd,efd,ifd;

--- a/dist/IO/poll.h
+++ b/dist/IO/poll.h
@@ -29,7 +29,12 @@
 #ifdef poll
 # undef poll
 #endif
-#define poll Perl_my_poll
+
+#if defined(PERL_IMPLICIT_SYS)
+#  define poll(_fds, _nfds, _tm) Perl_my_poll_cxt(aTHX_ _fds, _nfds, _tm)
+#else
+#  define poll Perl_my_poll
+#endif
 
 #if WINVER < 0x0600
 typedef struct pollfd {
@@ -55,7 +60,11 @@ typedef struct pollfd {
 
 #endif
 
-int poll (struct pollfd *, unsigned long, int);
+#if defined(PERL_IMPLICIT_SYS)
+  int Perl_my_poll_cxt(pTHX_ struct pollfd *, unsigned long, int);
+#else
+  int Perl_my_poll(struct pollfd *, unsigned long, int);
+#endif
 
 #ifndef HAS_POLL
 #  define HAS_POLL


### PR DESCRIPTION
- threaded perls without CPerlHost/iperlsys.h (ie all threaded unix perls) dont need a my_perl ptr, and don't assume all CCes have perfect LTO/LTCG and all OSes have a perfect designed bin image loader, to optimize away an unused my_perl var. This symbol crosses 2 separate TUs. ELF interposition, on paper, doesn't allow shifting over and dropping out args, but in real life, things are probably different. Write it correctly than assume optimizations will happen.
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
* This set of changes requires a perldelta entry, and I need help writing it.
* This set of changes does not require a perldelta entry.
