### PR TITLE
Turn off locale collation in Darwin

### DIFF
--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -371,6 +371,12 @@ ccflags="$ccflags -DNO_POSIX_2008_LOCALE"
 # See comments in locale.c about this #define
 ccflags="$ccflags -DHAS_BROKEN_LANGINFO_CODESET"
 
+# Get: "Assertion failed: (p->val == key), function lookup_substsearch, file
+# collate.c, line 596."
+if [ "$darwin_major" -ge 24 && "$perl_revision" -ge 5 -a ( "$perl_version" -ge 42 -o ( "$perl_version" -eq 41 -a "$perl_subversion" -ge 11 ) ) ]; then
+    ccflags="$ccflags -DNO_LOCALE_COLLATE"
+fi
+
 ldlibpthname='DYLD_LIBRARY_PATH';
 
 # useshrplib=true results in much slower startup times.

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -264,14 +264,6 @@ L</Platform Support> section, instead.
 
 [ List changes as an =item entry ].
 
-=over 4
-
-=item *
-
-XXX
-
-=back
-
 =head1 Testing
 
 XXX Any significant changes to the testing of a freshly built perl should be
@@ -344,9 +336,10 @@ L</Modules and Pragmata> section.
 
 =over 4
 
-=item XXX-some-platform
+=item MacOS (Darwin)
 
-XXX
+Collation of strings using locales on MacOS 15 (Darwin 24) and up has
+been turned off due to a failed assertion in its libc.
 
 =back
 


### PR DESCRIPTION
With 5.41.11, macOS 15 is failing in its libc with:

```Assertion failed: (p->val == key), function lookup_substsearch, file collate.c, line 596.```

This started after we upgraded to Unicode 16.0.


* This set of changes requires a perldelta entry, and it is included.
