### PR TITLE
pp_hot.c: shave off some CPU instructions in pp_const()

### DIFF
--- a/pp_hot.c
+++ b/pp_hot.c
@@ -224,7 +224,9 @@ Perl_rpp_free_2_(pTHX_ SV *const sv1,  SV *const sv2,
 
 PP(pp_const)
 {
-    rpp_xpush_1(cSVOP_sv);
+    rpp_extend(1);      /* Keep together all PL_op derefs (cSVOP_sv/NORMAL) */
+    SV* sv = cSVOP_sv;  /* in this hot pp op. stack_grow() is a function. */
+    rpp_push_1(sv);     /* Previously rpp_xpush_1(). */
     return NORMAL;
 }
 


### PR DESCRIPTION
FROM COMMIT

CC is MSVC 2022 x64 -O1. Before, 0x67 bytes long. After, 0x5E bytes long. This savings obtained by not digging inside PL_op AKA my_perl->Iop->op_*** twice, and the CC not having save a C auto var around a function call. I profiled Perl_pp_const() to be between #2 to #4 most executed pp_*() function, per process on any workload. For extra details about this commit see the GH PR associated with this commit.

There is an alternative I privately prototyped but I decided not to finish 3/4s of the way which is creating pre/post arg eval variants of function/macro rpp_xpush_1(). It was getting too invasive and complex by lines of src code modified to finish, so that conceptual fix isn't done here, and something best left for the future.

EXTRA INFO

Perl_pp_const()
before, 0x67 bytes long.
```
/* ----------------------------------------------------------- */
PP(pp_const)
{
000007FE92FF7324 48 89 5C 24 08       mov         qword ptr [rsp+8],rbx  
000007FE92FF7329 57                   push        rdi  
000007FE92FF732A 48 83 EC 20          sub         rsp,20h  
000007FE92FF732E 48 8B D9             mov         rbx,rcx  
    rpp_xpush_1(cSVOP_sv);
000007FE92FF7331 48 8B 49 08          mov         rcx,qword ptr [rcx+8]  
000007FE92FF7335 48 8B 79 28          mov         rdi,qword ptr [rcx+28h]  
000007FE92FF7339 48 85 FF             test        rdi,rdi  
000007FE92FF733C 75 0C                jne         Perl_pp_const+26h (07FE92FF734Ah)  
000007FE92FF733E 48 8B 49 18          mov         rcx,qword ptr [rcx+18h]  
000007FE92FF7342 48 8B 43 10          mov         rax,qword ptr [rbx+10h]  
000007FE92FF7346 48 8B 3C C8          mov         rdi,qword ptr [rax+rcx*8]  
000007FE92FF734A 48 8B 43 20          mov         rax,qword ptr [rbx+20h]  
000007FE92FF734E 48 2B 03             sub         rax,qword ptr [rbx]  
000007FE92FF7351 48 83 E0 F8          and         rax,0FFFFFFFFFFFFFFF8h  
000007FE92FF7355 48 83 F8 08          cmp         rax,8  
000007FE92FF7359 7D 14                jge         Perl_pp_const+4Bh (07FE92FF736Fh)  
000007FE92FF735B 4C 8B 03             mov         r8,qword ptr [rbx]  
000007FE92FF735E 41 B9 01 00 00 00    mov         r9d,1  
000007FE92FF7364 49 8B D0             mov         rdx,r8  
000007FE92FF7367 48 8B CB             mov         rcx,rbx  
000007FE92FF736A E8 09 B4 06 00       call        Perl_stack_grow (07FE93062778h)  
000007FE92FF736F 48 83 03 08          add         qword ptr [rbx],8  
000007FE92FF7373 48 8B 03             mov         rax,qword ptr [rbx]  
000007FE92FF7376 48 89 38             mov         qword ptr [rax],rdi  
    return NORMAL;
000007FE92FF7379 48 8B 43 08          mov         rax,qword ptr [rbx+8]  
}
000007FE92FF737D 48 8B 5C 24 30       mov         rbx,qword ptr [rsp+30h]  
000007FE92FF7382 48 8B 00             mov         rax,qword ptr [rax]  
000007FE92FF7385 48 83 C4 20          add         rsp,20h  
000007FE92FF7389 5F                   pop         rdi  
000007FE92FF738A C3                   ret  
000007FE92FF738B CC                   int         3  
--- C:\sources\perl5\pp_hot.c --------------------------------------------------
```
after, 0x5E bytes long.
```
/* ----------------------------------------------------------- */
PP(pp_const)
{
000007FEE555A438 40 53                push        rbx  
000007FEE555A43A 48 83 EC 20          sub         rsp,20h  
    rpp_extend(1);      /* Keep together all PL_op derefs (cSVOP_sv/NORMAL) */
000007FEE555A43E 48 8B 11             mov         rdx,qword ptr [rcx]  
/* ----------------------------------------------------------- */
PP(pp_const)
{
000007FEE555A441 48 8B D9             mov         rbx,rcx  
    rpp_extend(1);      /* Keep together all PL_op derefs (cSVOP_sv/NORMAL) */
000007FEE555A444 48 8B 41 20          mov         rax,qword ptr [rcx+20h]  
000007FEE555A448 48 2B C2             sub         rax,rdx  
000007FEE555A44B 48 83 E0 F8          and         rax,0FFFFFFFFFFFFFFF8h  
000007FEE555A44F 48 83 F8 08          cmp         rax,8  
000007FEE555A453 7D 11                jge         Perl_pp_const+2Eh (07FEE555A466h)  
000007FEE555A455 41 B9 01 00 00 00    mov         r9d,1  
000007FEE555A45B 4C 8B C2             mov         r8,rdx  
000007FEE555A45E E8 B5 C0 06 00       call        Perl_stack_grow (07FEE55C6518h)  
000007FEE555A463 48 8B 13             mov         rdx,qword ptr [rbx]  
    SV* sv = cSVOP_sv;  /* in this hot pp op. stack_grow() is a function. */
000007FEE555A466 48 8B 43 08          mov         rax,qword ptr [rbx+8]  
000007FEE555A46A 48 8B 48 28          mov         rcx,qword ptr [rax+28h]  
000007FEE555A46E 48 85 C9             test        rcx,rcx  
000007FEE555A471 75 0C                jne         Perl_pp_const+47h (07FEE555A47Fh)  
000007FEE555A473 48 8B 48 18          mov         rcx,qword ptr [rax+18h]  
000007FEE555A477 48 8B 43 10          mov         rax,qword ptr [rbx+10h]  
000007FEE555A47B 48 8B 0C C8          mov         rcx,qword ptr [rax+rcx*8]  
    rpp_push_1(sv);     /* Previously rpp_xpush_1(). */
000007FEE555A47F 48 8D 42 08          lea         rax,[rdx+8]  
000007FEE555A483 48 89 03             mov         qword ptr [rbx],rax  
000007FEE555A486 48 89 08             mov         qword ptr [rax],rcx  
    return NORMAL;
000007FEE555A489 48 8B 43 08          mov         rax,qword ptr [rbx+8]  
000007FEE555A48D 48 8B 00             mov         rax,qword ptr [rax]  
}
000007FEE555A490 48 83 C4 20          add         rsp,20h  
000007FEE555A494 5B                   pop         rbx  
000007FEE555A495 C3                   ret  
--- No source file -------------------------------------------------------------
000007FEE555A496 CC                   int         3  
```

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
