### PR TITLE
better suggestions for builtin::trim equivalence (Resolves #23212)

### DIFF
--- a/lib/builtin.pm
+++ b/lib/builtin.pm
@@ -1,4 +1,4 @@
-package builtin 0.018;
+package builtin 0.019;
 
 use v5.40;
 
@@ -42,6 +42,10 @@ can be requested for convenience.
 
 Individual named functions can be imported by listing them as import
 parameters on the C<use> statement for this pragma.
+
+The L<builtin::compat> module from CPAN provides versions of many of these
+functions that can be used on Perl versions where C<builtin> or specific
+functions are not yet available.
 
 B<Warning>:  At present, many of the functions in the C<builtin> namespace are
 experimental.  Calling them will trigger warnings of the
@@ -414,14 +418,11 @@ A complete list is in L<perlrecharclass/Whitespace>.
 
 C<trim> is equivalent to:
 
-    $str =~ s/\A\s+|\s+\z//urg;
+    my $trimmed = $str =~ s/\A\s+//ur =~ s/\s+\z//ur;
 
 Available starting with Perl 5.36. Since Perl 5.40, it is no longer
 experimental and it is included in the 5.40 and higher builtin version
 bundles.
-
-For Perl versions where this function is not available look at the
-L<String::Util> module for a comparable implementation.
 
 =head2 is_tainted
 
@@ -487,4 +488,4 @@ Available starting with Perl 5.40.
 
 =head1 SEE ALSO
 
-L<perlop>, L<perlfunc>, L<Scalar::Util>
+L<perlop>, L<perlfunc>, L<Scalar::Util>, L<builtin::compat>

--- a/t/porting/known_pod_issues.dat
+++ b/t/porting/known_pod_issues.dat
@@ -40,6 +40,7 @@ bc(1)
 Benchmark::Perl::Formance
 bind(2)
 BSD::Resource
+builtin::compat
 ByteLoader
 bzip2(1)
 Carp::Always


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
There isn't really a reason to recommend a specific trim alternative anymore, instead we can recommend builtin::compat as a general solution for alternatives. Also suggest a better equivalent statement to the trim function. As suggested in #23212

Resolves #23212 

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
