### PR TITLE
5.41.12 delta.pod: Fix advice about Darwin locale collation

### DIFF
--- a/pod/perl54112delta.pod
+++ b/pod/perl54112delta.pod
@@ -28,8 +28,9 @@ As in release 5.41.11, collation of strings using locales on MacOS 15 (Darwin
 
 If earlier versions are also experiencing issues (such as failures in
 F<locale.t>), you can explicitly disable locale collation by adding the
-C<-DNO_LOCALE_COLLATE> option to your invocation of C<./Configure>,
-or to the C<ccflags> and C<cppflags> variables in F<config.sh>.
+C<-Accflags=-DNO_LOCALE_COLLATE> option to your invocation of C<./Configure>,
+or just C<-DNO_LOCALE_COLLATE> to the C<ccflags> and C<cppflags>
+variables in F<config.sh>.
 
 =back
 


### PR DESCRIPTION
Configure requires `-Accflags` to actually have an effect here

* This set of changes is a perldelta entry, and it is included.
