### PR TITLE
we aren't going to run late INIT blocks, so don't save them

### DIFF
--- a/op.c
+++ b/op.c
@@ -11717,11 +11717,17 @@ S_process_special_blocks(pTHX_ I32 floor, const char *const fullname,
 
                 }
 #endif
-                if (PL_main_start)
+                if (PL_main_start) {
                     /* diag_listed_as: Too late to run %s block */
                     ck_warner(packWARN(WARN_VOID),
                               "Too late to run INIT block");
-                Perl_av_create_and_push(aTHX_ &PL_initav, MUTABLE_SV(cv));
+                    /* callers may touch cv after we return so don't
+                       just release it.
+                    */
+                    SAVEFREESV(cv);
+                }
+                else
+                    Perl_av_create_and_push(aTHX_ &PL_initav, MUTABLE_SV(cv));
             }
             else
                 return FALSE;


### PR DESCRIPTION
I was looking over #1674, where it was suggested that late INIT blocks behave like BEGIN, and Larry approved of that (25 years ago).

But history has moved on, we have 25 years of code developed under the current behaviour of INIT and I suspect such a change is more likely to break existing code than fix anything.

But looking at the code in S_process_special_blocks() we do still push the CV onto PL_initav, even though that CV will never be called.

So don't push the CV if it's too late to call it.

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
