### PR TITLE
perldiag: remove `for my (...) is experimental`

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2716,12 +2716,6 @@ some time before now.  Check your control flow.  flock() operates on
 filehandles.  Are you attempting to call flock() on a dirhandle by the
 same name?
 
-=item for my (...) is experimental
-
-(S experimental::for_list) This warning is emitted if you use C<for> to
-iterate multiple values at a time. This syntax is currently experimental
-and its behaviour may change in future releases of Perl.
-
 =item Forked open '%s' not meaningful in <>
 
 (S inplace) You had C<|-> or C<-|> in C<@ARGV> and tried to use C<< <>


### PR DESCRIPTION
The experiment was accepted in perl 5.40.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
