### PR TITLE
Executing test file leaves temporary file

### DIFF
--- a/cpan/Encode/t/Unicode_trailing_nul.t
+++ b/cpan/Encode/t/Unicode_trailing_nul.t
@@ -16,7 +16,7 @@ use File::Spec;
 
 my $foo = Encode::decode("UTF-16LE", "/\0v\0a\0r\0/\0f\0f\0f\0f\0f\0f\0/\0u\0s\0e\0r\0s\0/\0s\0u\0p\0e\0r\0m\0a\0n\0");
 
-my ($fh, $path) = File::Temp::tempfile( CLEANUP => 1 );
+my ($fh, $path) = File::Temp::tempfile( UNLINK => 1 );
 
 note "temp file: $path";
 


### PR DESCRIPTION
Executing this test file leaves a temporary file in /tmp.

File::Temp::tempfile() takes 'UNLINK'.
('CLEANUP' is associated with File::Temp::tempdir().)

As noted by Sevan Janiyn, this has already been fixed upstream (https://rt.cpan.org/Ticket/Display.html?id=152013), but a new CPAN release of Encode has not yet been issued.

Fixes: https://github.com/Perl/perl5/issues/23221
