### PR TITLE
hints/darwin.sh: skip ldflags in lddlflags

### DIFF
--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -315,7 +315,7 @@ case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
 
 *** Unexpected MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET
 ***
-*** Please either set it to a valid macOS version number (e.g., 10.15) or to empty.
+*** Please either set it to a valid macOS version number (e.g., 10.15 or 11.0) or to empty.
 
 EOM
       exit 1

--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -322,28 +322,6 @@ EOM
       ;;
     esac
 
-    # Keep the prodvers leading whitespace (Configure magic).
-    # Cannot use $osvers here since that is the kernel version.
-    # sw_vers output                 what we want
-    # "ProductVersion:    10.10.5"   "10.10"
-    # "ProductVersion:    10.11"     "10.11"
-        prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
-    case "$prodvers" in
-    [1-9][0-9].*)
-      add_macosx_version_min ccflags $prodvers
-      add_macosx_version_min ldflags $prodvers
-      ;;
-    *)
-      cat <<EOM >&4
-
-*** Unexpected product version $prodvers.
-***
-*** Try running sw_vers and see what its ProductVersion says.
-
-EOM
-      exit 1
-    esac
-
     darwin_major=$(echo $osvers|awk -F. '{print $1}')
 
     # macOS 10.12 (darwin 16.0.0) deprecated syscall().

--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -295,6 +295,7 @@ case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
    esac
    ;;
 *)        # OS X 10.5.x - current
+   lddlflags="-bundle -undefined dynamic_lookup"
    # The MACOSX_DEPLOYMENT_TARGET is not needed,
    # but the -mmacosx-version-min option is always used.
 
@@ -304,6 +305,7 @@ case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
     [1-9][0-9].*)
       add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
       add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
+      add_macosx_version_min lddlflags $MACOSX_DEPLOYMENT_TARGET
       ;;
     '')
       # Empty MACOSX_DEPLOYMENT_TARGET is okay.
@@ -357,7 +359,6 @@ EOM
         esac
     fi
 
-   lddlflags="-bundle -undefined dynamic_lookup"
    ;;
 esac
 

--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -277,18 +277,18 @@ add_macosx_version_min () {
 # But starting from perl 5.8.1/Darwin 7 the default is the two-level.
 case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
 1.[0-3].*) # OS X 10.0.x
-   lddlflags="${ldflags} -bundle -undefined suppress"
+   lddlflags="-bundle -undefined suppress"
    ;;
 1.*)       # OS X 10.1
    ldflags="${ldflags} -flat_namespace"
-   lddlflags="${ldflags} -bundle -undefined suppress"
+   lddlflags="-bundle -undefined suppress"
    ;;
 [2-6].*)   # OS X 10.1.x - 10.2.x (though [2-4] never existed publicly)
    ldflags="${ldflags} -flat_namespace"
-   lddlflags="${ldflags} -bundle -undefined suppress"
+   lddlflags="-bundle -undefined suppress"
    ;;
 [7-8].*)   # OS X 10.3.x - 10.4.x
-   lddlflags="${ldflags} -bundle -undefined dynamic_lookup"
+   lddlflags="-bundle -undefined dynamic_lookup"
    case "$ld" in
        *MACOSX_DEPLOYMENT_TARGET*) ;;
        *) ld="env MACOSX_DEPLOYMENT_TARGET=10.3 ${ld}" ;;
@@ -357,7 +357,7 @@ EOM
         esac
     fi
 
-   lddlflags="${ldflags} -bundle -undefined dynamic_lookup"
+   lddlflags="-bundle -undefined dynamic_lookup"
    ;;
 esac
 


### PR DESCRIPTION
It has not effect.
"adopting flags from ldflags is supposed to happen in Configure, not in hints." - leont

Configuring a build of perl with -Aappend:ldflags=" -L/var/empty" and checking the output of 'perl -V:ldflags -V:lddlflags' shows

ldflags=' -L/var/empty';
lddlflags='-bundle -undefined dynamic_lookup -L/var/empty';

Found when analysing issue #9437
Tested on OS X 10.4 aka Darwin 8.
