### PR TITLE
Fix recently broken Deparse

### DIFF
--- a/Porting/deparse-skips.txt
+++ b/Porting/deparse-skips.txt
@@ -273,7 +273,11 @@ uni/variables.t
 ../ext/XS-APItest/t/call_checker.t
 ../ext/XS-APItest/t/cleanup.t
 ../ext/XS-APItest/t/fetch_pad_names.t
+../ext/XS-APItest/t/regex_global_pos.t  # string literals under 'use utf8'
+                                        # are deparsed wrongly
 ../ext/XS-APItest/t/synthetic_scope.t
+../ext/XS-APItest/t/valid_identifier.t  # string literals under 'use utf8'
+                                        # are deparsed wrongly
 ../lib/Config.t                         # Config_heavy.pl fns getting output
 ../lib/charnames.t
 ../lib/dumpvar.t

--- a/lib/B/Deparse.pm
+++ b/lib/B/Deparse.pm
@@ -7,7 +7,7 @@
 # This is based on the module of the same name by Malcolm Beattie,
 # but essentially none of his code remains.
 
-package B::Deparse 1.83;
+package B::Deparse 1.84;
 use strict;
 use Carp;
 use B qw(class main_root main_start main_cv svref_2object opnumber perlstring
@@ -3485,7 +3485,7 @@ sub pp_substr_left {
 
    my $val = 'substr(' . $self->deparse($op->first->sibling, $cx)
              . ', 0, ' . $self->deparse($op->first->sibling->sibling->sibling, $cx)
-             . ( (($op->private & 7) == 3) ? '' : ", '')" );
+             . ( (($op->private & 7) == 3) ? ')' : ", '')" );
 
     if ($lex) {
         my $targ = $op->targ;

--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -1825,6 +1825,14 @@ print sort(foo('bar'));
 substr(my $a, 0, 0) = (foo(), bar());
 $a++;
 ####
+# 3-arg substr (non-chop)
+my $str = 'ABCD';
+my $bbb = substr($str, 1, 1);
+####
+# 3-arg substr (chop)
+my $str = 'ABCD';
+my $aaa = substr($str, 0, 1);
+####
 # 4-arg substr (non-chop)
 my $str = 'ABCD';
 my $bbb = substr($str, 1, 1, '');


### PR DESCRIPTION
Deparsing of 'substr($lex, 0, N)'  was broken in 5.41.8. The two commits in this PR fix it and update deparse-skips.txt to skip a couple of recently-added tests. I propose that this PR be merged now, in time for 5.42.0.

* This set of changes does not require a perldelta entry.
