### PR TITLE
cpan/experimental - Update to version 0.035

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -434,8 +434,8 @@ our %Modules = (
     },
 
     'experimental' => {
-        'DISTRIBUTION' => 'LEONT/experimental-0.034.tar.gz',
-        'SYNCINFO'     => 'mauke on Sun Jan 12 01:01:29 2025',
+        'DISTRIBUTION' => 'LEONT/experimental-0.035.tar.gz',
+        'SYNCINFO'     => 'jkeenan on Thu May  1 06:44:57 2025',
         'FILES'        => q[cpan/experimental],
         'EXCLUDED'     => [qr{^xt/}],
     },

--- a/cpan/experimental/lib/experimental.pm
+++ b/cpan/experimental/lib/experimental.pm
@@ -1,5 +1,5 @@
 package experimental;
-$experimental::VERSION = '0.034';
+$experimental::VERSION = '0.035';
 use strict;
 use warnings;
 use version ();
@@ -47,11 +47,13 @@ my %min_version = (
 	try             => '5.34.0',
 	unicode_eval    => '5.16.0',
 	unicode_strings => '5.12.0',
+	win32_perlio    => '5.8.0',
 );
 my %removed_in_version = (
 	array_base      => '5.30.0',
 	autoderef       => '5.24.0',
 	lexical_topic   => '5.24.0',
+	win32_perlio    => '5.36.0',
 );
 
 $_ = version->new($_) for values %min_version;
@@ -140,7 +142,7 @@ experimental - Experimental features made easy
 
 =head1 VERSION
 
-version 0.034
+version 0.035
 
 =head1 SYNOPSIS
 
@@ -244,7 +246,11 @@ This was added in perl 5.22.0.
 
 =item * C<regex_sets> - allow extended bracketed character classes in regexps
 
-This was added in perl 5.18.0.
+This was added in perl 5.18.0, and became non-experimental (and always
+enabled) in 5.36.0.
+
+This is documented at
+L<perlrecharclass/Extended Bracketed Character Classes>.
 
 =item * C<signatures> - allow subroutine signatures (for named arguments)
 
@@ -255,13 +261,14 @@ This was added in perl 5.20.0.
 This was added in perl 5.10.0, but it should be noted there are significant
 incompatibilities between 5.10.0 and 5.10.1.
 
-The feature is going to be deprecated in perl 5.38.0, and removed in 5.42.0.
+The feature was deprecated in perl 5.38.0, and undeprecated in 5.42.0.
 
 =item * C<switch> - allow the use of C<~~>, given, and when
 
 This was added in perl 5.10.0.
 
-The feature is going to be deprecated in perl 5.38.0, and removed in 5.42.0.
+The feature was deprecated in perl 5.38.0, and undeprecated in
+5.42.0.
 
 =item * C<try> - allow the use of C<try> and C<catch>
 

--- a/cpan/experimental/lib/stable.pm
+++ b/cpan/experimental/lib/stable.pm
@@ -1,5 +1,5 @@
 package stable;
-$stable::VERSION = '0.034';
+$stable::VERSION = '0.035';
 use strict;
 use warnings;
 use version ();
@@ -55,7 +55,7 @@ stable - Experimental features made easy, once we know they're stable
 
 =head1 VERSION
 
-version 0.034
+version 0.035
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
0.035     2025-05-01 11:35:41+02:00 Europe/Berlin
          - regex_sets no longer experimental
          - switch/smartmatch were deprecated then undeprecated
          - Properly handle the win32_perlio warning

