### PR TITLE
Update copies of GPL to match recent FSF changes

### DIFF
--- a/Copying
+++ b/Copying
@@ -3,7 +3,7 @@
                      Version 1, February 1989
 
  Copyright (C) 1989 Free Software Foundation, Inc.
-                    51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+               <https://fsf.org/>
 
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
@@ -217,8 +217,7 @@ the exclusion of warranty; and each file should have at least the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston MA  02110-1301 USA
+    along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
 Also add information on how to contact you by electronic and paper mail.
@@ -245,7 +244,7 @@ necessary.  Here a sample; alter the names:
   program `Gnomovision' (a program to direct compilers to make passes
   at assemblers) written by James Hacker.
 
-  <signature of Ty Coon>, 1 April 1989
-  Ty Coon, President of Vice
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
 
 That's all there is to it!

--- a/README
+++ b/README
@@ -94,10 +94,8 @@ You should have received a copy of the Artistic License with this
 Kit, in the file named "Artistic".  If not, I'll be glad to provide one.
 
 You should also have received a copy of the GNU General Public License
-along with this program in the file named "Copying". If not, write to the
-Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-Boston, MA 02110-1301, USA or visit their web page on the internet at
-https://www.gnu.org/copyleft/gpl.html.
+along with this program in the file named "Copying". If not, see
+<https://www.gnu.org/licenses/>.
 
 For those of you that choose to use the GNU General Public License,
 my interpretation of the GNU General Public License is that no Perl

--- a/dist/ExtUtils-CBuilder/LICENSE
+++ b/dist/ExtUtils-CBuilder/LICENSE
@@ -22,7 +22,7 @@ This is free software, licensed under:
                      Version 1, February 1989
 
  Copyright (C) 1989 Free Software Foundation, Inc.
- 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+                    <https://fsf.org/>
 
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
@@ -236,8 +236,7 @@ the exclusion of warranty; and each file should have at least the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston MA  02110-1301 USA
+    along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
 Also add information on how to contact you by electronic and paper mail.
@@ -264,8 +263,8 @@ necessary.  Here a sample; alter the names:
   program `Gnomovision' (a program to direct compilers to make passes
   at assemblers) written by James Hacker.
 
-  <signature of Ty Coon>, 1 April 1989
-  Ty Coon, President of Vice
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
 
 That's all there is to it!
 

--- a/dist/SelfLoader/lib/SelfLoader.pm
+++ b/dist/SelfLoader/lib/SelfLoader.pm
@@ -2,7 +2,7 @@ package SelfLoader;
 use 5.008;
 use strict;
 use IO::Handle;
-our $VERSION = "1.27";
+our $VERSION = "1.28";
 
 # The following bit of eval-magic is necessary to make this work on
 # perls < 5.009005.
@@ -425,10 +425,8 @@ You should have received a copy of the Artistic License with this
 Kit, in the file named "Artistic".  If not, I'll be glad to provide one.
 
 You should also have received a copy of the GNU General Public License
-along with this program in the file named "Copying". If not, write to the
-Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
-MA 02110-1301, USA or visit their web page on the internet at
-L<http://www.gnu.org/copyleft/gpl.html>.
+along with this program in the file named "Copying". If not, see
+<https://www.gnu.org/licenses/>.
 
 For those of you that choose to use the GNU General Public License,
 my interpretation of the GNU General Public License is that no Perl

--- a/dist/Tie-File/lib/Tie/File.pm
+++ b/dist/Tie-File/lib/Tie/File.pm
@@ -9,7 +9,7 @@ use Fcntl 'O_CREAT', 'O_RDWR', 'LOCK_EX', 'LOCK_SH', 'O_WRONLY', 'O_RDONLY';
 use constant O_ACCMODE => O_RDONLY | O_RDWR | O_WRONLY;
 
 
-our $VERSION = "1.09";
+our $VERSION = "1.10";
 my $DEFAULT_MEMORY_SIZE = 1<<21;    # 2 megabytes
 my $DEFAULT_AUTODEFER_THRESHHOLD = 3; # 3 records
 my $DEFAULT_AUTODEFER_FILELEN_THRESHHOLD = 65536; # 16 disk blocksful
@@ -2556,8 +2556,7 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this library program; it should be in the file C<COPYING>.
-If not, write to the Free Software Foundation, Inc., 51 Franklin Street,
-Fifth Floor, Boston, MA  02110-1301, USA
+If not, see <https://www.gnu.org/licenses/>.
 
 For licensing inquiries, contact the author at:
 

--- a/pod/perlgpl.pod
+++ b/pod/perlgpl.pod
@@ -37,7 +37,7 @@ For the Perl Artistic License, see L<perlartistic>.
                      Version 1, February 1989
 
   Copyright (C) 1989 Free Software Foundation, Inc.
-                51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+                     <https://fsf.org/>
 
   Everyone is permitted to copy and distribute verbatim copies
   of this license document, but changing it is not allowed.
@@ -254,9 +254,7 @@ For the Perl Artistic License, see L<perlartistic>.
      GNU General Public License for more details.
 
      You should have received a copy of the GNU General Public License
-     along with this program; if not, write to the Free Software
-     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston MA
-     02110-1301 USA
+     along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
  Also add information on how to contact you by electronic and paper
@@ -285,8 +283,8 @@ For the Perl Artistic License, see L<perlartistic>.
    program 'Gnomovision' (a program to direct compilers to make passes
    at assemblers) written by James Hacker.
 
-   <signature of Ty Coon>, 1 April 1989
-   Ty Coon, President of Vice
+   <signature of Moe Ghoul>, 1 April 1989
+   Moe Ghoul, President of Vice
 
  That's all there is to it!
 


### PR DESCRIPTION
#22952 points out that FSF has made copyedits to GPL to remove their (obsolete) mailing address and change a metasyntactic name placeholder. This is an alternative patch to address this which is minimal (does not switch apostrophe style or rewrap the text, nor touches anything other than the licenses) but comprehensive (covers all copies, not just `perlgpl.pod`).

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
