### PR TITLE
lib/Unicode/UCD.pm:  tidy indents in list of exports

### DIFF
--- a/charclass_invlists.inc
+++ b/charclass_invlists.inc
@@ -456662,7 +456662,7 @@ static const U8 WB_dfa_table[] = {
 #endif	/* defined(PERL_IN_REGEXEC_C) */
 
 /* Generated from:
- * b7f46fc1010fd83f5a678b268a23fef0142a18d0ab2a142edd0bb03328e667c3 lib/Unicode/UCD.pm
+ * 6cbf3f0fc04bbb22420eb9689126b5030bd714ad06397d0904702714feabe28e lib/Unicode/UCD.pm
  * 764f420cedfc8b43d9fec251c957a5d55fc45d40f6573f162990ed1dce7e36e0 lib/unicore/ArabicShaping.txt
  * b8f32554c6f658821fb0ee742d21c5b1f2086b9bf13071fed04894b022f93d67 lib/unicore/BidiBrackets.txt
  * d7afdadd1bbd66f5a663ac0e8f7958f18fd9491fc0bc59ec5877cb82db71db7d lib/unicore/BidiMirroring.txt

--- a/lib/Unicode/UCD.pm
+++ b/lib/Unicode/UCD.pm
@@ -5,7 +5,7 @@ use warnings;
 no warnings 'surrogate';    # surrogates can be inputs to this
 use charnames ();
 
-our $VERSION = '0.81';
+our $VERSION = '0.82';
 
 sub DEBUG () { 0 }
 $|=1 if DEBUG;
@@ -14,25 +14,26 @@ require Exporter;
 
 our @ISA = qw(Exporter);
 
-our @EXPORT_OK = qw(charinfo
-		    charblock charscript
-		    charblocks charscripts
-		    charinrange
-		    charprop
-		    charprops_all
-		    general_categories bidi_types
-		    compexcl
-		    casefold all_casefolds casespec
-		    namedseq
-                    num
-                    prop_aliases
-                    prop_value_aliases
-                    prop_values
-                    prop_invlist
-                    prop_invmap
-                    search_invlist
-                    MAX_CP
-                );
+our @EXPORT_OK = qw(
+    charinfo
+    charblock charscript
+    charblocks charscripts
+    charinrange
+    charprop
+    charprops_all
+    general_categories bidi_types
+    compexcl
+    casefold all_casefolds casespec
+    namedseq
+    num
+    prop_aliases
+    prop_value_aliases
+    prop_values
+    prop_invlist
+    prop_invmap
+    search_invlist
+    MAX_CP
+);
 
 use Carp;
 

--- a/lib/unicore/uni_keywords.pl
+++ b/lib/unicore/uni_keywords.pl
@@ -1353,7 +1353,7 @@
 1;
 
 # Generated from:
-# b7f46fc1010fd83f5a678b268a23fef0142a18d0ab2a142edd0bb03328e667c3 lib/Unicode/UCD.pm
+# 6cbf3f0fc04bbb22420eb9689126b5030bd714ad06397d0904702714feabe28e lib/Unicode/UCD.pm
 # 764f420cedfc8b43d9fec251c957a5d55fc45d40f6573f162990ed1dce7e36e0 lib/unicore/ArabicShaping.txt
 # b8f32554c6f658821fb0ee742d21c5b1f2086b9bf13071fed04894b022f93d67 lib/unicore/BidiBrackets.txt
 # d7afdadd1bbd66f5a663ac0e8f7958f18fd9491fc0bc59ec5877cb82db71db7d lib/unicore/BidiMirroring.txt

--- a/regcharclass.h
+++ b/regcharclass.h
@@ -3801,7 +3801,7 @@
 #endif /* PERL_REGCHARCLASS_H_ */
 
 /* Generated from:
- * b7f46fc1010fd83f5a678b268a23fef0142a18d0ab2a142edd0bb03328e667c3 lib/Unicode/UCD.pm
+ * 6cbf3f0fc04bbb22420eb9689126b5030bd714ad06397d0904702714feabe28e lib/Unicode/UCD.pm
  * 764f420cedfc8b43d9fec251c957a5d55fc45d40f6573f162990ed1dce7e36e0 lib/unicore/ArabicShaping.txt
  * b8f32554c6f658821fb0ee742d21c5b1f2086b9bf13071fed04894b022f93d67 lib/unicore/BidiBrackets.txt
  * d7afdadd1bbd66f5a663ac0e8f7958f18fd9491fc0bc59ec5877cb82db71db7d lib/unicore/BidiMirroring.txt

--- a/regexp_constants.h
+++ b/regexp_constants.h
@@ -29,7 +29,7 @@
 #define MAX_FOLD_FROMS 3
 
 /* Generated from:
- * b7f46fc1010fd83f5a678b268a23fef0142a18d0ab2a142edd0bb03328e667c3 lib/Unicode/UCD.pm
+ * 6cbf3f0fc04bbb22420eb9689126b5030bd714ad06397d0904702714feabe28e lib/Unicode/UCD.pm
  * 764f420cedfc8b43d9fec251c957a5d55fc45d40f6573f162990ed1dce7e36e0 lib/unicore/ArabicShaping.txt
  * b8f32554c6f658821fb0ee742d21c5b1f2086b9bf13071fed04894b022f93d67 lib/unicore/BidiBrackets.txt
  * d7afdadd1bbd66f5a663ac0e8f7958f18fd9491fc0bc59ec5877cb82db71db7d lib/unicore/BidiMirroring.txt

--- a/uni_keywords.h
+++ b/uni_keywords.h
@@ -7997,7 +7997,7 @@ match_uniprop( const unsigned char * const key, const U16 key_len ) {
 #endif /* #if defined(PERL_CORE) || defined(PERL_EXT_RE_BUILD) */
 
 /* Generated from:
- * b7f46fc1010fd83f5a678b268a23fef0142a18d0ab2a142edd0bb03328e667c3 lib/Unicode/UCD.pm
+ * 6cbf3f0fc04bbb22420eb9689126b5030bd714ad06397d0904702714feabe28e lib/Unicode/UCD.pm
  * 764f420cedfc8b43d9fec251c957a5d55fc45d40f6573f162990ed1dce7e36e0 lib/unicore/ArabicShaping.txt
  * b8f32554c6f658821fb0ee742d21c5b1f2086b9bf13071fed04894b022f93d67 lib/unicore/BidiBrackets.txt
  * d7afdadd1bbd66f5a663ac0e8f7958f18fd9491fc0bc59ec5877cb82db71db7d lib/unicore/BidiMirroring.txt


### PR DESCRIPTION
Increment $VERSION.

For 'make test_porting', committer had to run:

  ./perl -Ilib regen/regcharclass.pl
  ./perl -Ilib regen/mk_invlists.pl

