### PR TITLE
perlref: Add example of lhs postfix deref

### DIFF
--- a/pod/perlref.pod
+++ b/pod/perlref.pod
@@ -732,6 +732,8 @@ For example:
     $r = [ 1, [ 2, 3 ], 4 ];
     $r->[1]->@*;  # equivalent to @{ $r->[1] }
 
+    $aref->@* = (1, 2, 3);  # same as @{ $aref } = (1, 2, 3)
+
 In Perl 5.20 and 5.22, this syntax must be enabled with C<use feature
 'postderef'>. As of Perl 5.24, no feature declarations are required to make
 it available.


### PR DESCRIPTION
Fixes #22130

I'm uncertain about @epa 's opinion, so I didn't do anything about it.

* This set of changes does not require a perldelta entry.
