### PR TITLE
perlop/perlvar: Mention diamond operators

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -3357,6 +3357,7 @@ mean C</^/m>.
 =head2 I/O Operators
 X<operator, i/o> X<operator, io> X<io> X<while> X<filehandle>
 X<< <> >> X<< <<>> >> X<@ARGV>
+X<diamond operator> X<double diamond operator>
 
 There are several I/O operators you should know about.
 
@@ -3488,7 +3489,7 @@ and call it with S<C<perl dangerous.pl 'rm -rfv *|'>>, it actually opens a
 pipe, executes the C<rm> command and reads C<rm>'s output from that pipe.
 If you want all items in C<@ARGV> to be interpreted as file names, you
 can use the module C<ARGV::readonly> from CPAN, or use the double
-diamond bracket:
+diamond operator:
 
     while (<<>>) {
         print;

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -1635,7 +1635,7 @@ command name itself.  See L</$0> for the command name.
 X<ARGV>
 
 The special filehandle that iterates over command-line filenames in
-C<@ARGV>.  Usually written as the null filehandle in the angle operator
+C<@ARGV>.  Usually written as the null filehandle in the diamond operator
 C<< <> >>.  Note that currently C<ARGV> only has its magical effect
 within the C<< <> >> operator; elsewhere it is just a plain filehandle
 corresponding to the last file opened by C<< <> >>.  In particular,
@@ -2455,7 +2455,8 @@ The functions C<accept()>, C<open()>, C<pipe()>, C<readpipe()> (as well
 as the related C<qx> and C<`STRING`> operators), C<socket()>,
 C<socketpair()>, and C<sysopen()> are affected by the lexical value of
 this variable.  The implicit L</ARGV> handle opened by C<readline()> (or
-the related C<< <> >> and C<<< <<>> >>> operators) on passed filenames is
+the related C<< <> >> (diamond) and C<<< <<>> >>> (double diamond)
+operators) on passed filenames is
 also affected (but not if it opens C<STDIN>).  If this variable is not
 set, these functions will set the default layers as described in
 L<PerlIO/Defaults and how to override them>.


### PR DESCRIPTION
Related to #23100


* This set of changes does not require a perldelta entry.
