### PR TITLE
perlpacktut: Remove some jargon

### DIFF
--- a/pod/perlpacktut.pod
+++ b/pod/perlpacktut.pod
@@ -41,11 +41,10 @@ of these two functions.
 
 To see how (un)packing works, we'll start with a simple template
 code where the conversion is in low gear: between the contents of a byte
-sequence and a string of hexadecimal digits. Let's use C<unpack>, since
-this is likely to remind you of a dump program, or some desperate last
-message unfortunate programs are wont to throw at you before they expire
-into the wild blue yonder. Assuming that the variable C<$mem> holds a 
-sequence of bytes that we'd like to inspect without assuming anything 
+sequence and a string of hexadecimal digits.  The example we've chosen
+looks like a crash dump, and shows how C<unpack> can be used to make
+sense of things like this.  Assuming that the variable C<$mem> holds a
+sequence of bytes that we'd like to inspect without assuming anything
 about its meaning, we can write
 
    my( $hex ) = unpack( 'H*', $mem );
@@ -58,17 +57,21 @@ corresponding to a byte:
 
 What was in this chunk of memory? Numbers, characters, or a mixture of
 both? Assuming that we're on a computer where ASCII (or some similar)
-encoding is used: hexadecimal values in the range C<0x40> - C<0x5A>
+encoding is used: hexadecimal values in the range C<0x41> - C<0x5A>
 indicate an uppercase letter, and C<0x20> encodes a space. So we might
-assume it is a piece of text, which some are able to read like a tabloid;
-but others will have to get hold of an ASCII table and relive that
-firstgrader feeling. Not caring too much about which way to read this,
+assume it is a piece of ASCII text.  We can verify that by doing
+
+ print unpack( 'A*', $mem), "\n"
+
+ A MAN A PLAN A CANAL PANAMA
+
+Going back to the original C<H*> for the purposes of this tutorial,
 we note that C<unpack> with the template code C<H> converts the contents
 of a sequence of bytes into the customary hexadecimal notation. Since
 "a sequence of" is a pretty vague indication of quantity, C<H> has been
 defined to convert just a single hexadecimal digit unless it is followed
 by a repeat count. An asterisk for the repeat count means to use whatever
-remains.
+remains.  That is also the case for the C<A*> above.
 
 The inverse operation - packing byte contents from a string of hexadecimal
 digits - is just as easily written. For instance:


### PR DESCRIPTION
Fixes #22697

That a native English speaker could be confused by this is prima facie evidence that the wording should be improved.  It's al right to be clever, but not at the expense of clarity.

* This set of changes does not require a perldelta entry.
