### PR TITLE
op.c: Make ifdef structure of argument to S_op_clear_gv() less objectionable to syntax parsers

### DIFF
--- a/op.c
+++ b/op.c
@@ -1027,11 +1027,13 @@ Perl_op_free(pTHX_ OP *o)
 /* S_op_clear_gv(): free a GV attached to an OP */
 
 STATIC
-#ifdef USE_ITHREADS
-void S_op_clear_gv(pTHX_ OP *o, PADOFFSET *ixp)
-#else
-void S_op_clear_gv(pTHX_ OP *o, SV**svp)
-#endif
+void S_op_clear_gv(pTHX_ OP *o,
+    #ifdef USE_ITHREADS
+        PADOFFSET *ixp
+    #else
+        SV**svp
+    #endif
+)
 {
 
     GV *gv = (o->op_type == OP_GV || o->op_type == OP_GVSV


### PR DESCRIPTION
The prior structure of this syntax made it look to tree-sitter-based parsers as if two separate functions were being defined, though only the second of which was ever finished. This resulted in the entire rest of the file appearing to be nested inside the first function, meaning no top-level function analysis was performed on them. This has various knock-on effects on code analysis in tooling such as editors or browsers.

For example, see the two separate fold regions in this editor screenshot:
![Screenshot_2025-05-04_09-48-40](https://github.com/user-attachments/assets/c09b8b3d-d7dc-433a-be6a-ff853c8a0aaa)

When this function is folded, it appears to be a 15800-line long function that consumes the entire rest of the file:
![Screenshot_2025-05-04_09-49-07](https://github.com/user-attachments/assets/af75c702-b7e1-491a-98e2-74a709e6a58c)

The fix for it moves the `#ifdef` syntax inside the argument parentheses to ensure that only one function appears to be created, so the entire rest of the file is parsed as normal.

* This set of changes does not require a perldelta entry.