### PR TITLE
Win32: eliminate the sys_intern fdpid aka w32_fdpid

### DIFF
--- a/doio.c
+++ b/doio.c
@@ -1026,9 +1026,6 @@ S_openn_cleanup(pTHX_ GV *gv, IO *io, PerlIO *fp, char *mode, const char *oname,
             }
 #endif
 
-#if !defined(WIN32)
-           /* PL_fdpid isn't used on Windows, so avoid this useless work.
-            * XXX Probably the same for a lot of other places. */
             {
                 Pid_t pid;
                 SV *sv;
@@ -1041,7 +1038,6 @@ S_openn_cleanup(pTHX_ GV *gv, IO *io, PerlIO *fp, char *mode, const char *oname,
                 SvUPGRADE(sv, SVt_IV);
                 SvIV_set(sv, pid);
             }
-#endif
 
             if (was_fdopen) {
                 /* need to close fp without closing underlying fd */

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -502,6 +502,11 @@ When a scalar variable used as the target of a filehandle is C<undef>'ed
 while being output, garbage bytes would be left in that scalar.
 [GH #24008]
 
+=item *
+
+C<close(STDOUT)> when C<STDOUT> has been opened as a pipe will now
+properly wait for the child to exit on Windows.  [GH #4106]
+
 =back
 
 =head1 Known Problems

--- a/t/io/closepid.t
+++ b/t/io/closepid.t
@@ -6,9 +6,6 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan tests => 3;
-watchdog(10, $^O eq 'MSWin32' ? "alarm" : '');
-
 use Config;
 $| = 1;
 $SIG{PIPE} = 'IGNORE';
@@ -21,10 +18,28 @@ my $perl = which_perl();
 my $killsig = 'HUP';
 $killsig = 1 unless $Config{sig_name} =~ /\bHUP\b/;
 
+{
+    local $::TODO = $^O eq "MSWin32" ? "not fixed yet #4106" : undef;
+    # github #4106
+    open my $saveout, ">&", \*STDOUT or die;
+    my $start = time();
+    open STDOUT, "|-", $perl, "-e", "sleep 2"
+        or die;
+    print STDOUT "Hi\n" for 1..2;
+    my $close_ok = close STDOUT;
+    open STDOUT, ">&", $saveout;
+    ok($close_ok, "close pipe to child success");
+    cmp_ok(time(), '>', $start, "close waited at least a bit");
+}
+
+watchdog(10, $^O eq 'MSWin32' ? "alarm" : '');
+
 SKIP:
 {
     skip("Not relevant to $^O", 3)
-      if $^O eq "MSWin32" || $^O eq "VMS";
+        if $^O eq "VMS";
+    skip "Waits for any child on Windows", 3
+        if $^O eq "MSWin32";
     skip("only matters for waitpid or wait4", 3)
       unless $Config{d_waitpid} || $Config{d_wait4};
     # [perl #119893]
@@ -44,3 +59,5 @@ SKIP:
 }
 
 watchdog(0);
+
+done_testing();

--- a/t/io/closepid.t
+++ b/t/io/closepid.t
@@ -19,7 +19,6 @@ my $killsig = 'HUP';
 $killsig = 1 unless $Config{sig_name} =~ /\bHUP\b/;
 
 {
-    local $::TODO = $^O eq "MSWin32" ? "not fixed yet #4106" : undef;
     # github #4106
     open my $saveout, ">&", \*STDOUT or die;
     my $start = time();
@@ -38,8 +37,6 @@ SKIP:
 {
     skip("Not relevant to $^O", 3)
         if $^O eq "VMS";
-    skip "Waits for any child on Windows", 3
-        if $^O eq "MSWin32";
     skip("only matters for waitpid or wait4", 3)
       unless $Config{d_waitpid} || $Config{d_wait4};
     # [perl #119893]

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -51,6 +51,8 @@
 #define PERL_NO_GET_CONTEXT
 #include "XSUB.h"
 
+#include "perliol.h" /* For PerlIOUnix_refcnt */
+
 #include <fcntl.h>
 #ifndef __GNUC__
 /* assert.h conflicts with #define of assert in perl.h */
@@ -3622,7 +3624,7 @@ do_popen(const char *mode, const char *command, IV narg, SV **args) {
 
         win32_close(p[child]);
 
-        sv_setiv(*av_fetch(w32_fdpid, p[parent], TRUE), childpid);
+        sv_setiv(*av_fetch(PL_fdpid, p[parent], TRUE), childpid);
 
         /* set process id so that it can be returned by perl's open() */
         PL_forkprocess = childpid;
@@ -3665,34 +3667,38 @@ win32_pclose(PerlIO *pf)
 #ifdef USE_RTL_POPEN
     return _pclose(pf);
 #else
+    /* this should roughly match Perl_my_pclose() in util.c */
     dTHX;
-    int childpid, status;
-    SV *sv;
+    int fd = PerlIO_fileno(pf);
 
-    sv = *av_fetch(w32_fdpid, PerlIO_fileno(pf), TRUE);
+    SV **svp = av_fetch(PL_fdpid, fd, FALSE);
+    int childpid = -1;
+    if (svp) {
+        childpid = (SvTYPE(*svp) == SVt_IV) ? SvIVX(*svp) : -1;
+        SvREFCNT_dec(*svp);
+        *svp = NULL;
+    }
 
-    if (SvIOK(sv))
-        childpid = SvIVX(sv);
-    else
-        childpid = 0;
+    bool should_wait = PerlIOUnix_refcnt(fd) == 1 && childpid > 0;
 
-    if (!childpid) {
-        errno = EBADF;
+    bool close_failed = (PerlIO_close(pf) == EOF);
+
+    int status;
+    dSAVE_ERRNO;
+    int wait_result;
+    if (should_wait) {
+        wait_result = win32_waitpid(childpid, &status, 0);
+    }
+
+    if (close_failed) {
+        RESTORE_ERRNO; /* error from the close */
         return -1;
     }
 
-#ifdef USE_PERLIO
-    PerlIO_close(pf);
-#else
-    fclose(pf);
-#endif
-    SvIVX(sv) = 0;
-
-    if (win32_waitpid(childpid, &status, 0) == -1)
-        return -1;
-
-    return status;
-
+    return should_wait
+        ? (wait_result < 0 ? wait_result :
+           (status == 0 ? 0 : (errno = 0, status)))
+        : 0;
 #endif /* USE_RTL_POPEN */
 }
 
@@ -5685,7 +5691,6 @@ Perl_sys_intern_init(pTHX)
     w32_perlshell_tokens	= NULL;
     w32_perlshell_vec		= (char**)NULL;
     w32_perlshell_items		= 0;
-    w32_fdpid			= newAV();
     Newx(w32_children, 1, child_tab);
     w32_num_children		= 0;
 #  ifdef USE_ITHREADS
@@ -5728,7 +5733,6 @@ Perl_sys_intern_clear(pTHX)
 
     Safefree(w32_perlshell_tokens);
     Safefree(w32_perlshell_vec);
-    /* NOTE: w32_fdpid is freed by sv_clean_all() */
     Safefree(w32_children);
     if (w32_timerid) {
         KillTimer(w32_message_hwnd, w32_timerid);
@@ -5767,7 +5771,6 @@ Perl_sys_intern_dup(pTHX_ struct interp_intern *src, struct interp_intern *dst)
     dst->perlshell_tokens	= NULL;
     dst->perlshell_vec		= (char**)NULL;
     dst->perlshell_items	= 0;
-    dst->fdpid			= newAV();
     Newxz(dst->children, 1, child_tab);
     dst->pseudo_id		= 0;
     dst->cur_tid = 0;

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -43,8 +43,6 @@
 /* #include "config.h" */
 
 
-#define PerlIO FILE
-
 #include <sys/stat.h>
 #include "EXTERN.h"
 #include "perl.h"

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -568,7 +568,6 @@ struct interp_intern {
     char *	perlshell_tokens;
     char **	perlshell_vec;
     long	perlshell_items;
-    struct av *	fdpid;
     child_tab *	children;
 #ifdef USE_ITHREADS
     DWORD	pseudo_id;


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
This duplicated the PL_fdpid already used by every other platform but didn't handle the transfer done when STD handles were reopened as pipes.

Along with re-working win32_pclose() to behave much closer to Perl_my_pclose() from util.c and enabling the PID transfer done for STD handles on Win32, this fixes #4106

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
