### PR TITLE
openbsd: ensure we link to the built libperl.a, not the system libperl.a

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -800,6 +800,10 @@ Adp	|SV *	|amagic_deref_call					\
 p	|bool	|amagic_is_enabled					\
 				|int method
 
+CTdp	|void	|api_version_assert					\
+				|size_t interp_size			\
+				|NULLOK void *v_my_perl 		\
+				|NN const char *api_version
 ETXip	|void	|append_utf8_from_native_byte				\
 				|const U8 byte				\
 				|NN U8 **dest

--- a/embed.h
+++ b/embed.h
@@ -61,6 +61,7 @@
 # define SvUV_nomg(a)                           Perl_SvUV_nomg(aTHX_ a)
 # define amagic_call(a,b,c,d)                   Perl_amagic_call(aTHX_ a,b,c,d)
 # define amagic_deref_call(a,b)                 Perl_amagic_deref_call(aTHX_ a,b)
+# define api_version_assert                     Perl_api_version_assert
 # define apply_attrs_string(a,b,c,d)            Perl_apply_attrs_string(aTHX_ a,b,c,d)
 # define apply_builtin_cv_attributes(a,b)       Perl_apply_builtin_cv_attributes(aTHX_ a,b)
 # define atfork_child                           Perl_atfork_child

--- a/lib/ExtUtils/t/Embed.t
+++ b/lib/ExtUtils/t/Embed.t
@@ -103,13 +103,26 @@ if ($^O eq 'VMS') {
    elsif ($^O eq 'os390' && $Config{usedl}) {
     push(@cmd,"-L$lib", ldopts());
    } else { # Not MSWin32 or OS/390 (z/OS) dynamic.
-    push(@cmd,"-L$lib",'-lperl');
+    my $ldopts = ldopts();
+    if ($^O eq 'openbsd' && $Config{useshrplib} eq "false") {
+        # see github #22125
+        # with OpenBSD, the packaged gcc (tries to) link
+        # against the system libperl, this will be fine once
+        # this perl gets installed, but that's not so good when
+        # testing against the uninstalled perl.
+        # This also matches how Makefile.SH links the perl executable
+        push @cmd, "$lib/libperl.a";
+        $ldopts =~ s/ -lperl\b//;
+    }
+    else {
+        push(@cmd,"-L$lib",'-lperl');
+    }
     local $SIG{__WARN__} = sub {
 	warn $_[0] unless $_[0] =~ /No library found for .*perl/
     };
     push(@cmd, '-Zlinker', '/PM:VIO')	# Otherwise puts a warning to STDOUT!
 	if $^O eq 'os2' and $Config{ldflags} =~ /(?<!\S)-Zomf\b/;
-    push(@cmd,ldopts());
+    push(@cmd, $ldopts);
    }
 
    if ($^O eq 'aix') { # AIX needs an explicit symbol export list.
@@ -196,7 +209,7 @@ int main(int argc, char **argv, char **env) {
     perl_construct(my_perl);
     PL_exit_flags |= PERL_EXIT_WARN;
 
-    PERL_API_VERSION_CHECK;
+    PERL_API_VERSION_ASSERT;
 
     my_puts("ok 3");
 

--- a/lib/ExtUtils/t/Embed.t
+++ b/lib/ExtUtils/t/Embed.t
@@ -196,6 +196,8 @@ int main(int argc, char **argv, char **env) {
     perl_construct(my_perl);
     PL_exit_flags |= PERL_EXIT_WARN;
 
+    PERL_API_VERSION_CHECK;
+
     my_puts("ok 3");
 
     perl_parse(my_perl, NULL, (sizeof(cmds)/sizeof(char *))-1, (char **)cmds, env);

--- a/perl.h
+++ b/perl.h
@@ -9276,6 +9276,14 @@ END_EXTERN_C
 #  define PERL_STACK_REALIGN
 #endif
 
+#ifdef MULTIPLICITY
+#  define PERL_API_VERSION_ASSERT \
+  Perl_api_version_assert(sizeof(PerlInterpreter), aTHX, PERL_API_VERSION_STRING)
+#else
+#  define PERL_API_VERSION_ASSERT \
+  Perl_api_version_assert(sizeof(PerlInterpreter), NULL, PERL_API_VERSION_STRING)
+#endif
+
 /*
 
    (KEEP THIS LAST IN perl.h!)

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -309,6 +309,11 @@ made:
 
 XXX
 
+=item *
+
+When testing embedding, add a sanity check to ensure the C<libperl> we
+link against matches the perl we are building.  [GH #22125]
+
 =back
 
 =head1 Platform Support
@@ -357,6 +362,11 @@ L</Modules and Pragmata> section.
 =item XXX-some-platform
 
 XXX
+
+=item OpenBSD
+
+When testing embedding, ensure we link against the correct static
+libperl. [GH #22125]
 
 =back
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -4071,6 +4071,11 @@ See L</500 Server error>.
 by a missing delimiter on a string or pattern, because it eventually
 ended earlier on the current line.
 
+=item Mismatch between expected and libperl %s
+
+(F) For an embedded perl, the perl headers and configuration you built
+your binary against don't match the library you've linked with.
+
 =item Mismatched brackets in template
 
 (F) A pack template could not be parsed because pairs of C<[...]> or

--- a/proto.h
+++ b/proto.h
@@ -123,6 +123,11 @@ Perl_amagic_is_enabled(pTHX_ int method)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AMAGIC_IS_ENABLED
 
+PERL_CALLCONV void
+Perl_api_version_assert(size_t interp_size, void *v_my_perl, const char *api_version);
+#define PERL_ARGS_ASSERT_API_VERSION_ASSERT     \
+        assert(api_version)
+
 PERL_CALLCONV SSize_t
 Perl_apply(pTHX_ I32 type, SV **mark, SV **sp)
         __attribute__visibility__("hidden");

--- a/util.c
+++ b/util.c
@@ -5656,6 +5656,52 @@ S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p,
     }
 }
 
+/*
+=for apidoc api_version_assert
+
+Used by the PERL_API_VERSION_CHECK macro to compare the perl the
+object was built with and the perl that C<libperl> was built with.
+
+This can be used to ensure that these match and produces a more
+diagnosable than random crashes and mis-behaviour.
+
+=cut
+*/
+
+void
+Perl_api_version_assert(size_t interp_size, void *v_my_perl,
+                        const char *api_version) {
+    dTHX;
+
+    PERL_ARGS_ASSERT_API_VERSION_ASSERT;
+
+    if (interp_size != sizeof(PerlInterpreter)) {
+        /* detects various types of configuration mismatches */
+        /* diag_listed_as: Mismatch between expected and libperl %s */
+        Perl_croak(aTHX_
+                   "Mismatch between expected and libperl interpreter structure size %zd vs %zd",
+                   interp_size, sizeof(PerlInterpreter));
+    }
+    if (
+#ifdef MULTIPLICITY
+      v_my_perl != my_perl
+#else
+      v_my_perl != NULL
+#endif
+        ) {
+        /* detect threads vs non-threads mismatch */
+        /* diag_listed_as: Mismatch between expected and libperl %s */
+        Perl_croak(aTHX_
+                   "Mismatch between expected and libperl interpreter pointer");
+    }
+    if (strNE(api_version, PERL_API_VERSION_STRING)) {
+        /* diag_listed_as: Mismatch between expected and libperl %s */
+        Perl_croak(aTHX_
+                   "Mismatch between expected and libperl API versions %s vs %s",
+                   api_version, PERL_API_VERSION_STRING);
+    }
+}
+
 PERL_STATIC_INLINE bool
 S_gv_has_usable_name(pTHX_ GV *gv)
 {


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
When building with gcc, lib/ExtUtils/t/Embed.t would link against the system libperl.a rather than the newly built libperl.a.
    
Due to the limited API used by the sample code this typically didn't crash, but some configuration changes could result in a crash or a link error.
    
For OpenBSD, change the link options to more closely match those used when building the perl executable, which results in linking against the correct library.
    
Fixes #22125

Also adds a test to ensure we are linking against the correct libperl.

Smoke reports from before a trivial rebase at https://perl.develop-help.com/?b=smoke-me%2Ftonyc%2F22125-openbsd-embed

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
