### PR TITLE
t/run/locale.t: uninitialized value warnings on OpenBSD

### DIFF
--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -592,7 +592,7 @@ SKIP:
 {
     skip "didn't find a suitable non-UTF-8 locale", 1 unless
                                                             @non_utf8_locales;
-    my $locale = $non_utf8_locales[0];
+    my $locale = $non_utf8_locales[0] // '';
 
     fresh_perl_is(<<"EOF", "ok\n", {}, "cmp() handles above Latin1 and NUL in non-UTF8 locale");
 use locale;
@@ -613,7 +613,7 @@ EOF
 SKIP:
 {
     skip "didn't find a suitable UTF-8 locale", 1 unless $utf8_ref;
-    my $locale = $utf8_ref->[0];
+    my $locale = $non_utf8_locales[0] // '';
 
     fresh_perl_is(<<"EOF", "ok\n", {}, "Handles above Unicode in a UTF8 locale");
 use locale;
@@ -636,7 +636,7 @@ SKIP:
     my $is64bit = length sprintf("%x", ~0) > 8;
     skip "32-bit ASCII platforms can't physically have extended UTF-8", 1
                                                    if $::IS_ASCII  && ! $is64bit;
-    my $locale = $utf8_ref->[0];
+    my $locale = $non_utf8_locales[0] // '';
 
     fresh_perl_is(<<"EOF", "ok\n", {}, "cmp() handles Perl extended UTF-8");
 use locale;
@@ -686,7 +686,7 @@ SKIP: {   # GH #20054
                     && $Config{d_setlocale_accepts_any_locale_name} eq 'define';
 	
     my @lc_all_locales = find_locales('LC_ALL');
-    my $locale = $lc_all_locales[0];
+    my $locale = $non_utf8_locales[0] // '';
     skip "LC_ALL not enabled on this platform", 1 unless $locale;
     my $fallback = ($^O eq "MSWin32")
                     ? "system default"


### PR DESCRIPTION
In the course of testing https://github.com/Perl/perl5/pull/23265 on OpenBSD-6.9, I observed previously unnoticed uninitialized value warnings.
```
Use of uninitialized value $locale in concatenation (.) or string at run/locale.t line 618.
Use of uninitialized value $locale in concatenation (.) or string at run/locale.t line 641.
```
See, *e.g.,* https://perl.develop-help.com/dblog/5511983.

These warnings began to appear in my own OpenBSD smoke-test logs in early March.  In all likelihood these warnings began to be emitted following this commit:
```
commit fecfa476ebefab8d99c628450d82a8b28a2fff42
Author:     Karl Williamson <khw@cpan.org>
AuthorDate: Thu Jan 30 18:09:27 2025 -0700
Commit:     Karl Williamson <khw@cpan.org>
CommitDate: Sun Feb 9 16:36:20 2025 -0700

    run/locale.t: Add test for UTF-8 string non-UTF8 locale
    
    This was suggested by Tony Cook at
    https://github.com/Perl/perl5/pull/22811#discussion_r1868633416
```
... as that commit contained 4 instances of:
```
+    my $locale = $non_utf8_locales[0];
```
... which were not checked for definedness before being used.

The branch in this pull request guarantees that `$locale` is initialized to an empty string if not otherwise defined.  Please review.
