### PR TITLE
Note regex_sets is a synonym

### DIFF
--- a/pod/perlrecharclass.pod
+++ b/pod/perlrecharclass.pod
@@ -1027,7 +1027,10 @@ either construct raises an exception.
 
 =head3 Extended Bracketed Character Classes
 X<character class>
+X<regex_sets>
 X<set operations>
+
+(Also called C<regex_sets>.)
 
 This is a fancy bracketed character class that can be used for more
 readable and less error-prone classes, and to perform set operations,


### PR DESCRIPTION
Fixes #23232

"Extended Bracketed Character Classes" is the formal name documented; but "regex_sets" is what you specify to 'feature' to enable/disable it. Add a bit of text so that if you know one name, you can find the other.


* This set of changes does not require a perldelta entry.
