### PR TITLE
run/locale.t: Skip tests if no appropriate locale

### DIFF
--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -17,7 +17,7 @@ use warnings;
 BEGIN {
     eval { require POSIX; POSIX->import("locale_h") };
     if ($@) {
-	skip_all("could not load the POSIX module"); # running minitest?
+        skip_all("could not load the POSIX module"); # running minitest?
     }
 }
 use Config;
@@ -685,7 +685,7 @@ SKIP: {   # GH #20054
     skip "Even illegal locale names are accepted", 1
                     if $Config{d_setlocale_accepts_any_locale_name}
                     && $Config{d_setlocale_accepts_any_locale_name} eq 'define';
-	
+
     my @lc_all_locales = find_locales('LC_ALL');
     my $locale = $lc_all_locales[0];
     skip "LC_ALL not enabled on this platform", 1 unless $locale;

--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -612,7 +612,8 @@ EOF
 
 SKIP:
 {
-    skip "didn't find a suitable UTF-8 locale", 1 unless $utf8_ref;
+    skip "didn't find a suitable UTF-8 locale", 1
+                                            unless $utf8_ref && $utf8_ref->@*;
     my $locale = $utf8_ref->[0];
 
     fresh_perl_is(<<"EOF", "ok\n", {}, "Handles above Unicode in a UTF8 locale");
@@ -632,7 +633,8 @@ EOF
 
 SKIP:
 {
-    skip "didn't find a suitable UTF-8 locale", 1 unless $utf8_ref;
+    skip "didn't find a suitable UTF-8 locale", 1
+                                            unless $utf8_ref && $utf8_ref->@*;
     my $is64bit = length sprintf("%x", ~0) > 8;
     skip "32-bit ASCII platforms can't physically have extended UTF-8", 1
                                                    if $::IS_ASCII  && ! $is64bit;
@@ -655,7 +657,8 @@ EOF
 }
 
 SKIP: {   # GH #20085
-    skip "didn't find a suitable UTF-8 locale", 1 unless $utf8_ref;
+    skip "didn't find a suitable UTF-8 locale", 1
+                                            unless $utf8_ref && $utf8_ref->@*;
     local $ENV{LC_CTYPE} = $utf8_ref->[0];
     local $ENV{LC_ALL} = undef;
     fresh_perl_is(<<~'EOF', "ok\n", {}, "check that setlocale overrides startup");

--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -655,10 +655,8 @@ EOF
 }
 
 SKIP: {   # GH #20085
-    my @utf8_locales = find_utf8_ctype_locales();
-    skip "didn't find a UTF-8 locale", 1 unless @utf8_locales;
-
-    local $ENV{LC_CTYPE} = $utf8_locales[0];
+    skip "didn't find a suitable UTF-8 locale", 1 unless $utf8_ref;
+    local $ENV{LC_CTYPE} = $utf8_ref->[0];
     local $ENV{LC_ALL} = undef;
     fresh_perl_is(<<~'EOF', "ok\n", {}, "check that setlocale overrides startup");
         use POSIX;


### PR DESCRIPTION
Supercedes https://github.com/Perl/perl5/pull/23268, which didn't really get to the core problem.

These were generating uninitialized variable warnings on OpenBSD, due to
the reference existing, but the array being empty.

* This set of changes does not require a perldelta entry.
