### PR TITLE
Skip porting/header_parser.t on EBCDIC

### DIFF
--- a/t/porting/header_parser.t
+++ b/t/porting/header_parser.t
@@ -19,6 +19,9 @@ require './regen/HeaderParser.pm';
 
 skip_all_if_miniperl("needs Data::Dumper");
 
+# It could fairly easily be ported, but no need to do so, so far
+skip_all("HeaderParser hasn't been ported to EBCDIC") if $::IS_EBCDIC;
+
 require Data::Dumper;
 
 my $update_key= "PERL_DEV_UPDATE_TESTFILE";


### PR DESCRIPTION
This generates a few errors on EBCDIC, which could be fixed; but it is not currently used there.

* This set of changes does not require a perldelta entry.
