### PR TITLE
perlguts: Note that an IV may be larger than a pointer

### DIFF
--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -36,7 +36,8 @@ Each typedef has specific routines that manipulate the various data types.
 =head2 What is an "IV"?
 
 Perl uses a special typedef IV which is a simple signed integer type that is
-guaranteed to be large enough to hold a pointer (as well as an integer).
+guaranteed to be large enough to hold a pointer, but may be larger,
+depending on how perl is Configured.
 Additionally, there is the UV, which is simply an unsigned IV.
 
 Perl also uses several special typedefs to declare variables to hold


### PR DESCRIPTION
With 9e9b2f9f441cf58161363c17b82f46063a7d3ee5, Configure guarantees an IV can hold a pointer.  But it may be larger.  This commit takes Tony Cook's suggestion about extra wording.

This fixes #18995


* This set of changes does not require a perldelta entry.
