### PR TITLE
perlre: fix incorrect pod escape

### DIFF
--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -765,7 +765,7 @@ for it (unfortunately) is "Default".
 
 Whenever you can, use the
 L<< C<unicode_strings>|feature/"The 'unicode_strings' feature" >>
-to cause X</u> to be the default instead.
+to cause C</u> to be the default instead.
 
 =head4 /a (and /aa)
 


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
X</u> was clearly not intended here, as it doesn't render to anything visually.

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
