### PR TITLE
Silence "used only once" warning in porting test

### DIFF
--- a/t/porting/header_parser.t
+++ b/t/porting/header_parser.t
@@ -20,6 +20,7 @@ require './regen/HeaderParser.pm';
 skip_all_if_miniperl("needs Data::Dumper");
 
 # It could fairly easily be ported, but no need to do so, so far
+our $IS_EBCDIC;
 skip_all("HeaderParser hasn't been ported to EBCDIC") if $::IS_EBCDIC;
 
 require Data::Dumper;


### PR DESCRIPTION
As suggested by Dave M. in
https://github.com/Perl/perl5/pull/23278#issuecomment-2879530280.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.

@iabyn 