### PR TITLE
Pod/Simple/HTMLLegacy.pm is no longer CUSTOMIZED

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -971,8 +971,7 @@ our %Modules = (
         'EXCLUDED' => [
             qw{.ChangeLog.swp},
             qr{^\.github/}
-	],
-        'CUSTOMIZED'   => ['lib/Pod/Simple/HTMLLegacy.pm'],
+        ],
     },
 
     'Pod::Usage' => {


### PR DESCRIPTION
$VERSION is now in synch with what's on CPAN.  We no longer need the corrective applied in 6ea7dace3401e25dcf8318146be82c03e07a6a72.


* This set of changes does not require a perldelta entry.
