### PR TITLE
uni/method.t: Update, and don't test specific garbage

### DIFF
--- a/t/uni/method.t
+++ b/t/uni/method.t
@@ -111,12 +111,12 @@ like( Føø::Bær->nèw, qr/Føø::Bær=HASH/u, 'Can access nèw as a method thr
 is( ref Føø::Bær->new, 'Føø::Bær');
 
 my $new_ascii = "new";
-my $new_latin = "nèw";
-my $e_with_grave = byte_utf8a_to_utf8n("\303\250");
-my $e_with_grave_escaped= $e_with_grave=~s/\x{a8}/\\\\x\\{a8\\}/r;
-my $new_utf8  = "n${e_with_grave}w";
-my $newoct    = "n${e_with_grave}w";
-utf8::decode($new_utf8);
+my $new_utf8 = "nèw";
+my $new_latin = $new_utf8;
+utf8::downgrade($new_latin);
+
+my $newoct = $new_utf8;
+utf8::encode($newoct);
 
 like( Føø::Bær->$new_ascii, qr/Føø::Bær=HASH/u, "Can access \$new_ascii, [$new_ascii], stored in a scalar, as a method, through a UTF-8 package." );
 like( Føø::Bær->$new_latin, qr/Føø::Bær=HASH/u, "Can access \$new_latin, [$new_latin], stored in a scalar, as a method, through a UTF-8 package." );
@@ -124,7 +124,7 @@ like( Føø::Bær->$new_utf8, qr/Føø::Bær=HASH/u, "Can access \$new_utf8, [$n
 {
     local $@;
     eval { Føø::Bær->$newoct };
-    like($@, qr/Can't locate object method "n${e_with_grave_escaped}w" via package "Føø::Bær"/u,
+    like($@, qr/Can't locate object method "[^"]+" via package "Føø::Bær"/u,
         "Can't access [$newoct], stored in a scalar, as a method through a UTF-8 package." );
 }
 
@@ -143,7 +143,7 @@ like( $pkg_latin_1->$new_utf8, qr/Føø::Bær=HASH/u, "Can access \$new_utf8, [$
     local $@;
 
     eval { $pkg_latin_1->$newoct };
-    like($@, qr/Can't locate object method "n${e_with_grave_escaped}w" via package "Føø::Bær"/u,
+    like($@, qr/Can't locate object method "[^"]*" via package "Føø::Bær"/u,
         "Can't access [$newoct], stored in a scalar, as a method, when the UTF-8 package name is also in a scalar.");
 }
 

--- a/t/uni/method.t
+++ b/t/uni/method.t
@@ -118,33 +118,48 @@ utf8::downgrade($new_latin);
 my $newoct = $new_utf8;
 utf8::encode($newoct);
 
-like( Føø::Bær->$new_ascii, qr/Føø::Bær=HASH/u, "Can access \$new_ascii, [$new_ascii], stored in a scalar, as a method, through a UTF-8 package." );
-like( Føø::Bær->$new_latin, qr/Føø::Bær=HASH/u, "Can access \$new_latin, [$new_latin], stored in a scalar, as a method, through a UTF-8 package." );
-like( Føø::Bær->$new_utf8, qr/Føø::Bær=HASH/u, "Can access \$new_utf8, [$new_utf8], stored in a scalar, as a method, through a UTF-8 package." );
+like( Føø::Bær->$new_ascii, qr/Føø::Bær=HASH/u,
+     "Can access \$new_ascii, [$new_ascii], stored in a scalar, as a method,"
+   . " through a UTF-8 package." );
+like( Føø::Bær->$new_latin, qr/Føø::Bær=HASH/u,
+     "Can access \$new_latin, [$new_latin], stored in a scalar, as a method,"
+   . " through a UTF-8 package." );
+like( Føø::Bær->$new_utf8, qr/Føø::Bær=HASH/u,
+     "Can access \$new_utf8, [$new_utf8], stored in a scalar, as a method,"
+   . " through a UTF-8 package." );
 {
     local $@;
     eval { Føø::Bær->$newoct };
     like($@, qr/Can't locate object method "[^"]+" via package "Føø::Bær"/u,
-        "Can't access [$newoct], stored in a scalar, as a method through a UTF-8 package." );
+         "Can't access [$newoct], stored in a scalar, as a method through a"
+       . " UTF-8 package." );
 }
 
-
-like( nèw Føø::Bær, qr/Føø::Bær=HASH/u, "Can access [nèw] as a method through a UTF-8 indirect object package.");
+like( nèw Føø::Bær, qr/Føø::Bær=HASH/u,
+     "Can access [nèw] as a method through a UTF-8 indirect object package.");
 
 my $pkg_latin_1 = 'Føø::Bær';
 
-like( $pkg_latin_1->new, qr/Føø::Bær=HASH/u, 'Can access new as a method when the UTF-8 package name is in a scalar.');
-like( $pkg_latin_1->nèw, qr/Føø::Bær=HASH/u, 'Can access nèw as a method when the UTF-8 package name is in a scalar.');
+like( $pkg_latin_1->new, qr/Føø::Bær=HASH/u,
+     'Can access new as a method when the UTF-8 package name is in a scalar.');
+like( $pkg_latin_1->nèw, qr/Føø::Bær=HASH/u,
+     'Can access nèw as a method when the UTF-8 package name is in a scalar.');
 
-like( $pkg_latin_1->$new_ascii, qr/Føø::Bær=HASH/u, "Can access \$new_ascii, [$new_ascii], stored in a scalar, as a method, when the UTF-8 package name is also in a scalar.");
-like( $pkg_latin_1->$new_latin, qr/Føø::Bær=HASH/u, "Can access \$new_latin, [$new_latin], stored in a scalar, as a method, when the UTF-8 package name is also in a scalar.");
-like( $pkg_latin_1->$new_utf8, qr/Føø::Bær=HASH/u, "Can access \$new_utf8, [$new_utf8], stored in a scalar, as a method, when the UTF-8 package name is also in a scalar." );
+like( $pkg_latin_1->$new_ascii, qr/Føø::Bær=HASH/u,
+     "Can access \$new_ascii, [$new_ascii], stored in a scalar, as a method,"
+   . " when the UTF-8 package name is also in a scalar.");
+like( $pkg_latin_1->$new_latin, qr/Føø::Bær=HASH/u,
+     "Can access \$new_latin, [$new_latin], stored in a scalar, as a method,"
+   . " when the UTF-8 package name is also in a scalar.");
+like( $pkg_latin_1->$new_utf8, qr/Føø::Bær=HASH/u,
+     "Can access \$new_utf8, [$new_utf8], stored in a scalar, as a method,"
+   . " when the UTF-8 package name is also in a scalar." );
 {
     local $@;
-
     eval { $pkg_latin_1->$newoct };
     like($@, qr/Can't locate object method "[^"]*" via package "Føø::Bær"/u,
-        "Can't access [$newoct], stored in a scalar, as a method, when the UTF-8 package name is also in a scalar.");
+         "Can't access [$newoct], stored in a scalar, as a method, when the"
+       . " UTF-8 package name is also in a scalar.");
 }
 
 ok !!Føø::Bær->can($new_ascii), "->can works for [$new_ascii]";


### PR DESCRIPTION
The modern way to change UTF-8 to its component bytes is to use
utf8::encode

Some of the tests are making sure that those component bytes aren't
mistaken for being UTF-8.  What those component bytes are is not
actually relevant, but the tests were looking at the specific expected
values of them.  The problem is that these differ on EBCDIC vs ASCII
platforms.  Several commits had been added to try to get the correct
values on both types, but EBCDIC still was getting failures.  And, there
is no need to test for the specific values of these irrelevant bytes.
What is important is that they were not misinterpreted as if they were
UTF-8.

This commit goes back to the original tests before those other commits
were added, and changes the matching pattern to not look for the
specific irrelevant byte values.

Doing so makes the tests pass on both types of platforms.<!--

* This set of changes does not require a perldelta entry.
