### PR TITLE
feature: switch no longer being removed

### DIFF
--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -4,7 +4,7 @@
 # Any changes made here will be lost!
 
 package feature;
-our $VERSION = '1.95';
+our $VERSION = '1.96';
 
 our %feature = (
     fc                              => 'feature_fc',
@@ -196,21 +196,13 @@ See L<perlop/"Smartmatch Operator"> for details.
 
 =head2 The 'switch' feature
 
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
-
-    no warnings "experimental::smartmatch";
-
 C<use feature 'switch'> tells the compiler to enable the Raku
 given/when construct.
 
 See L<perlsyn/"Switch Statements"> for details.
 
-This feature is available starting with Perl 5.10.
-It is deprecated starting with Perl 5.38, and using
-C<given>, C<when> or smartmatch will throw a warning.
-It will be removed in Perl 5.42.
+This feature is available starting with Perl 5.10.  It is enabled by
+feature bundles 5.10 through 5.34.
 
 =head2 The 'unicode_strings' feature
 

--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -682,13 +682,21 @@ C<use v5.36> (or higher) declaration in the current scope.
 
 =head2 Smartmatch Operator
 
-First available in Perl 5.10.1 (the 5.10.0 version behaved differently),
-binary C<~~> does a "smartmatch" between its arguments.  This is mostly
+The C<smartmatch> feature is discouraged for new code and retained for
+backward compatibility.
+
+The smartmatch operator was introduced in 5.10.0 had significant
+changes in 5.10.1.  It is enabled by default and in all feature
+bundles up to 5.40.  To use smartmatch with a later feature bundle you
+will need enable it explicitly:
+
+  use v5.42;
+  use feature "smartmatch";
+
+Binary C<~~> does a "smartmatch" between its arguments.  This is mostly
 used implicitly in the C<when> construct described in L<perlsyn>, although
 not all C<when> clauses call the smartmatch operator.  Unique among all of
-Perl's operators, the smartmatch operator can recurse.  The smartmatch
-operator is L<experimental|perlpolicy/experimental> and its behavior is
-subject to change.
+Perl's operators, the smartmatch operator can recurse.
 
 It is also unique in that all other Perl operators impose a context
 (usually string or numeric context) on their operands, autoconverting

--- a/pod/perlsyn.pod
+++ b/pod/perlsyn.pod
@@ -863,12 +863,15 @@ C<defer>.
 
 X<switch> X<case> X<given> X<when> X<default>
 
+The C<switch> feature is discouraged for new code and is retained for
+backward compatibility.
+
 Starting from Perl 5.10.1 (well, 5.10.0, but it didn't work
 right), you can say
 
     use feature "switch";
 
-to enable an experimental switch feature.  This is loosely based on an
+to enable the switch feature.  This is loosely based on an
 old version of a Raku proposal, but it no longer resembles the Raku
 construct.  You also get the switch feature whenever you declare that your
 code prefers to run under a version of Perl between 5.10 and 5.34.  For
@@ -876,7 +879,7 @@ example:
 
     use v5.14;
 
-Under the "switch" feature, Perl gains the experimental keywords
+Under the "switch" feature, Perl gains the keywords
 C<given>, C<when>, C<default>, C<continue>, and C<break>.
 Starting from Perl 5.16, one can prefix the switch
 keywords with C<CORE::> to access the feature without a C<use feature>
@@ -893,8 +896,8 @@ in the previous section could be rewritten as
         default       { $nothing = 1 }
     }
 
-The C<foreach> is the non-experimental way to set a topicalizer.
-If you wish to use the highly experimental C<given>, that could be
+The C<foreach> is another way to set a topicalizer.
+If you wish to use C<given>, that could be
 written like this:
 
     use v5.10.1;

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -618,7 +618,7 @@ read_only_bottom_close_and_rename($h);
 
 __END__
 package feature;
-our $VERSION = '1.95';
+our $VERSION = '1.96';
 
 FEATURES
 
@@ -727,21 +727,13 @@ See L<perlop/"Smartmatch Operator"> for details.
 
 =head2 The 'switch' feature
 
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
-
-    no warnings "experimental::smartmatch";
-
 C<use feature 'switch'> tells the compiler to enable the Raku
 given/when construct.
 
 See L<perlsyn/"Switch Statements"> for details.
 
-This feature is available starting with Perl 5.10.
-It is deprecated starting with Perl 5.38, and using
-C<given>, C<when> or smartmatch will throw a warning.
-It will be removed in Perl 5.42.
+This feature is available starting with Perl 5.10.  It is enabled by
+feature bundles 5.10 through 5.34.
 
 =head2 The 'unicode_strings' feature
 


### PR DESCRIPTION
It no longer produces experimental warnings.

Fixes #23282

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->


<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
