### PR TITLE
SvPV_shrink_to_cur: include space for COW

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1157,6 +1157,7 @@ AOdp	|SV *	|eval_pv	|NN const char *p			\
 				|I32 croak_on_error
 AOdp	|SSize_t|eval_sv	|NN SV *sv				\
 				|I32 flags
+EMTpx	|Size_t |expected_size	|UV size
 ATdmp	|bool	|extended_utf8_to_uv					\
 				|NN const U8 * const s			\
 				|NN const U8 * const e			\

--- a/perl.h
+++ b/perl.h
@@ -1686,6 +1686,23 @@ Use L</UV> to declare variables of the maximum usable size on this platform.
 #  define PERL_STRLEN_EXPAND_SHIFT 2
 #endif
 
+/* "expected_size" is a functional stub for building on in the future.
+ * The intention is to pass it a number of bytes, prior to using that
+ * number in a call to something like malloc() or realloc(), and a best-
+ * guess at the size to be allocated will be returned. ("Best-guess"
+ * may vary by platform and malloc implementation.)
+ * This will be useful to (1) grow strings (or anything else) in a way
+ * that results in SvLEN more accurately reflecting the usable space
+ * that has been allocated, and (2) we don't try to shrink an
+ * allocation that won't actually shrink in practice.
+ * Right now, this macro just rounds up a given number to the nearest
+ * multiple of PTRSIZE, for a minimum of PERL_STRLEN_NEW_MIN. This is
+ * not entirely useless, just not terribly accurate.
+ */
+#define expected_size(n) ( ((n) > PERL_STRLEN_NEW_MIN)               \
+                            ? (((n) + PTRSIZE - 1) & ~(PTRSIZE - 1)) \
+                            : PERL_STRLEN_NEW_MIN )
+
 /* This use of offsetof() requires /Zc:offsetof- for VS2017 (and presumably
  * onwards) when building Socket.xs, but we can just use a different definition
  * for STRUCT_OFFSET instead. */

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -350,6 +350,26 @@ well.
 
 XXX
 
+=item *
+
+C<Perl_expected_size> has been added as an experimental stub macro. The
+intention is to build on this such that it can be passed a size in bytes,
+then returns the interpreter's best informed guess of what actual usable
+allocation size would be returned by the malloc implementation in use.
+
+This would help with sizing allocations such that SvLEN is more accurate
+and not trying to shrink string buffers to save size when the intended
+saving is unrealistic.
+
+=item *
+
+C<SvPV_shrink_to_cur> has been revised to include a byte for COW, so that
+the resulting string could be COWed in the future.
+
+It also now uses C<Perl_expected_size>, compared against the current
+buffer size, and does not try to do a reallocation if the requested
+memory saving is unrealistic.
+
 =back
 
 =head1 Selected Bug Fixes

--- a/proto.h
+++ b/proto.h
@@ -1101,6 +1101,11 @@ Perl_eval_sv(pTHX_ SV *sv, I32 flags);
 #define PERL_ARGS_ASSERT_EVAL_SV                \
         assert(sv)
 
+PERL_CALLCONV Size_t
+Perl_expected_size(UV size)
+        __attribute__visibility__("hidden");
+#define PERL_ARGS_ASSERT_EXPECTED_SIZE
+
 /* PERL_CALLCONV bool
 Perl_extended_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p); */
 

--- a/sv.h
+++ b/sv.h
@@ -1590,9 +1590,22 @@ L</C<SV_CHECK_THINKFIRST_COW_DROP>> before calling this.
 =cut
 */
 
-#define SvPV_shrink_to_cur(sv) STMT_START { \
-                   const STRLEN _lEnGtH = SvCUR(sv) + 1; \
-                   SvPV_renew(sv, _lEnGtH); \
+/* Notes: Ensure the buffer is big enough to be COWed in the future, so
+          + 1 for the trailing null byte + 1 for the COW count.
+ * The `expected_size` call will, at worst, ensure that the buffer size
+ * is no smaller than the expected minimim allocation and that the given
+ * size is rounded up to the closest PTRSIZE boundary. Depending on
+ * per-malloc implementation, it might return the exact size that would
+ * be allocated for the specified _lEnGtH. If the return value from
+ * `expected_size` is not smaller than the current buffer allocation,
+ * there is no point in calling SvPV_renew.
+*/
+
+#define SvPV_shrink_to_cur(sv) STMT_START {                       \
+                   const STRLEN _lEnGtH = SvCUR(sv) + 2;          \
+                   const STRLEN _eXpEcT = expected_size(_lEnGtH); \
+                   if (SvLEN(sv) > _eXpEcT)                       \
+                       SvPV_renew(sv, _eXpEcT);                   \
                  } STMT_END
 
 /*

--- a/toke.c
+++ b/toke.c
@@ -4422,9 +4422,7 @@ S_scan_const(pTHX_ char *start)
     }
 
     /* shrink the sv if we allocated more than we used */
-    if (SvCUR(sv) + 5 < SvLEN(sv)) {
-        SvPV_shrink_to_cur(sv);
-    }
+    SvPV_shrink_to_cur(sv);
 
     /* return the substring (via pl_yylval) only if we parsed anything */
     if (s > start) {
@@ -11348,9 +11346,7 @@ S_scan_heredoc(pTHX_ char *s)
         SvREFCNT_dec_NN(newstr);
     }
 
-    if (SvCUR(tmpstr) + 5 < SvLEN(tmpstr)) {
-        SvPV_shrink_to_cur(tmpstr);
-    }
+    SvPV_shrink_to_cur(tmpstr);
 
     if (!IN_BYTES) {
         if (UTF && is_utf8_string((U8*)SvPVX_const(tmpstr), SvCUR(tmpstr)))
@@ -11877,10 +11873,7 @@ Perl_scan_str(pTHX_ char *start, int keep_bracketed_quoted, int keep_delims, int
     PL_parser->herelines = herelines;
 
     /* if we allocated too much space, give some back */
-    if (SvCUR(sv) + 5 < SvLEN(sv)) {
-        SvLEN_set(sv, SvCUR(sv) + 1);
-        SvPV_shrink_to_cur(sv);
-    }
+    SvPV_shrink_to_cur(sv);
 
     /* decide whether this is the first or second quoted string we've read
        for this op


### PR DESCRIPTION
The `SvPV_shrink_to_cur` macro shrinks an allocation to `SvCUR(sv) + 1`, which does not include an additional byte for Copy-On-Write (COW).

GH#22116 - a902d92a78262a0fd111789742f9c9e2a7fa2f42 - short-circuited constant folding on CONST OPs, as this should be unnecessary. However, Dave Mitchell noticed that it had the inadvertent effect of disabling COW on SVs holding UTF8 string literals (e.g. `"\x{100}abcd"`).

When a CONST OP is created, `Perl_ck_svconst` should mark its SV as being COW-able. But SVs built via `S_scan_const`, when that has called `SvPV_shrink_to_cur`, have resulting `SvLEN(sv)` values that fail the `SvCANCOW(sv)` test. Previously, constant folding had the effect of copying the literal into a buffer large enough for COW.

This commit modifies `SvPV_shrink_to_cur` so that it accounts for an additional byte for COW.

Additionally, this macro will no longer try to shrink the buffer below PERL_STRLEN_NEW_MIN, since that is likely to have no effect.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
