### PR TITLE
Perl_op_convert_list - only short circuit CONST OPs with an IsCOW SV

### DIFF
--- a/op.c
+++ b/op.c
@@ -5571,7 +5571,7 @@ Perl_op_convert_list(pTHX_ I32 type, I32 flags, OP *o)
             flags |= OPf_SPECIAL;
     }
     if (type == OP_STRINGIFY && OP_TYPE_IS(o, OP_CONST) &&
-        !(flags & OPf_FOLDED) ) {
+        !(flags & OPf_FOLDED) && SvIsCOW(cSVOPx_sv(o)) ){
         assert(!OpSIBLING(o));
         /* Don't wrap a single CONST in a list, process that list,
          * then constant fold the list back to the starting OP.


### PR DESCRIPTION
Currently, a CONST OP's SV will not have the `IsCOW` flag set if the PV buffer was truncated such that it is too small to be COWed. In which case, not short circuting `Perl_op_convert_list` causes the OP to undergo constant folding, resulting in a CONST OP with an SV that can participate in COW.

This means that the commit which introduced the short-circuit for CONST OPs accidentally introduced a performance regression:
https://github.com/Perl/perl5/commit/a902d92a78262a0fd111789742f9c9e2a7fa2f42

This commit adds an additional check to ensure that short circuiting does not happen when the CONST OP SV cannot be COWed. This is a short term workaround given the proximity to the next stable release. https://github.com/Perl/perl5/pull/23290 seems like the more appropriate fix, but is a bigger change, so will be held until the next development cycle.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
