### PR TITLE
[Win32]Allow for new version of libmcfgthread dll in GNUmakefile.

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -1825,6 +1825,7 @@ test-prep-gcc :
 	if exist $(CCDLLDIR)\libwinpthread-1.dll $(XCOPY) $(CCDLLDIR)\libwinpthread-1.dll ..\t\$(NULL)
 	if exist $(CCDLLDIR)\libquadmath-0.dll $(XCOPY) $(CCDLLDIR)\libquadmath-0.dll ..\t\$(NULL)
 	if exist $(CCDLLDIR)\libmcfgthread-1.dll $(XCOPY) $(CCDLLDIR)\libmcfgthread-1.dll ..\t\$(NULL)
+	if exist $(CCDLLDIR)\libmcfgthread-2.dll $(XCOPY) $(CCDLLDIR)\libmcfgthread-2.dll ..\t\$(NULL)
 
 endif
 


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
With the release of gcc-15.1.0, libmcfgthread-1.dll has been renamed to libmcfgthread-2.dll.
The win32/GNUmakefile needs to allow for both names - which is what this PR achieves.

Hopefully this PR can be applied prior to the release of 5.41.13 (and 5.42.0).

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
