### PR TITLE
perlunicook: Example needs 'use utf8'

### DIFF
--- a/charclass_invlists.inc
+++ b/charclass_invlists.inc
@@ -456662,7 +456662,7 @@ static const U8 WB_dfa_table[] = {
 #endif	/* defined(PERL_IN_REGEXEC_C) */
 
 /* Generated from:
- * b7f46fc1010fd83f5a678b268a23fef0142a18d0ab2a142edd0bb03328e667c3 lib/Unicode/UCD.pm
+ * 7c6a2550576273917f328032defbefc3bef43047bac1297166e95a179d9e492a lib/Unicode/UCD.pm
  * 764f420cedfc8b43d9fec251c957a5d55fc45d40f6573f162990ed1dce7e36e0 lib/unicore/ArabicShaping.txt
  * b8f32554c6f658821fb0ee742d21c5b1f2086b9bf13071fed04894b022f93d67 lib/unicore/BidiBrackets.txt
  * d7afdadd1bbd66f5a663ac0e8f7958f18fd9491fc0bc59ec5877cb82db71db7d lib/unicore/BidiMirroring.txt

--- a/lib/Unicode/UCD.pm
+++ b/lib/Unicode/UCD.pm
@@ -2460,18 +2460,6 @@ is passed, it would be set to 1 if the return is valid; or 0 if the return is
 C<undef>.  Note that the numeric value returned need not be a whole number.
 C<num("\N{TIBETAN DIGIT HALF ZERO}")>, for example returns -0.5.
 
-=cut
-
-#A few characters to which Unicode doesn't officially
-#assign a numeric value are considered numeric by C<num>.
-#These are:
-
-# EULER CONSTANT             0.5772...  (this is NOT Euler's number)
-# SCRIPT SMALL E             2.71828... (this IS Euler's number)
-# GREEK SMALL LETTER PI      3.14159...
-
-=pod
-
 If the string is more than one character, C<undef> is returned unless
 all its characters are decimal digits (that is, they would match C<\d+>),
 from the same script.  For example if you have an ASCII '0' and a Bengali

--- a/lib/Unicode/UCD.pm
+++ b/lib/Unicode/UCD.pm
@@ -2532,6 +2532,8 @@ change these into digits, and then call C<num> on the result.
 
 sub num ($;$) {
     my ($string, $retlen_ref) = @_;
+    croak __PACKAGE__, "::num: second parameter must be a scalar reference"
+                        if defined $retlen_ref && ref $retlen_ref ne "SCALAR";
 
     use feature 'unicode_strings';
 

--- a/lib/unicore/uni_keywords.pl
+++ b/lib/unicore/uni_keywords.pl
@@ -1353,7 +1353,7 @@
 1;
 
 # Generated from:
-# b7f46fc1010fd83f5a678b268a23fef0142a18d0ab2a142edd0bb03328e667c3 lib/Unicode/UCD.pm
+# 7c6a2550576273917f328032defbefc3bef43047bac1297166e95a179d9e492a lib/Unicode/UCD.pm
 # 764f420cedfc8b43d9fec251c957a5d55fc45d40f6573f162990ed1dce7e36e0 lib/unicore/ArabicShaping.txt
 # b8f32554c6f658821fb0ee742d21c5b1f2086b9bf13071fed04894b022f93d67 lib/unicore/BidiBrackets.txt
 # d7afdadd1bbd66f5a663ac0e8f7958f18fd9491fc0bc59ec5877cb82db71db7d lib/unicore/BidiMirroring.txt

--- a/pod/perlunicook.pod
+++ b/pod/perlunicook.pod
@@ -442,6 +442,7 @@ ASCII digits only, but Perl’s implicit string-to-number
 conversion does not currently recognize these.  Here’s how to
 convert such strings manually.
 
+ use utf8;
  use v5.14;  # needed for num() function
  use Unicode::UCD qw(num);
  my $str = "got Ⅻ and ४५६७ and ⅞ and 兆 here";

--- a/regcharclass.h
+++ b/regcharclass.h
@@ -3801,7 +3801,7 @@
 #endif /* PERL_REGCHARCLASS_H_ */
 
 /* Generated from:
- * b7f46fc1010fd83f5a678b268a23fef0142a18d0ab2a142edd0bb03328e667c3 lib/Unicode/UCD.pm
+ * 7c6a2550576273917f328032defbefc3bef43047bac1297166e95a179d9e492a lib/Unicode/UCD.pm
  * 764f420cedfc8b43d9fec251c957a5d55fc45d40f6573f162990ed1dce7e36e0 lib/unicore/ArabicShaping.txt
  * b8f32554c6f658821fb0ee742d21c5b1f2086b9bf13071fed04894b022f93d67 lib/unicore/BidiBrackets.txt
  * d7afdadd1bbd66f5a663ac0e8f7958f18fd9491fc0bc59ec5877cb82db71db7d lib/unicore/BidiMirroring.txt

--- a/regexp_constants.h
+++ b/regexp_constants.h
@@ -29,7 +29,7 @@
 #define MAX_FOLD_FROMS 3
 
 /* Generated from:
- * b7f46fc1010fd83f5a678b268a23fef0142a18d0ab2a142edd0bb03328e667c3 lib/Unicode/UCD.pm
+ * 7c6a2550576273917f328032defbefc3bef43047bac1297166e95a179d9e492a lib/Unicode/UCD.pm
  * 764f420cedfc8b43d9fec251c957a5d55fc45d40f6573f162990ed1dce7e36e0 lib/unicore/ArabicShaping.txt
  * b8f32554c6f658821fb0ee742d21c5b1f2086b9bf13071fed04894b022f93d67 lib/unicore/BidiBrackets.txt
  * d7afdadd1bbd66f5a663ac0e8f7958f18fd9491fc0bc59ec5877cb82db71db7d lib/unicore/BidiMirroring.txt

--- a/uni_keywords.h
+++ b/uni_keywords.h
@@ -7997,7 +7997,7 @@ match_uniprop( const unsigned char * const key, const U16 key_len ) {
 #endif /* #if defined(PERL_CORE) || defined(PERL_EXT_RE_BUILD) */
 
 /* Generated from:
- * b7f46fc1010fd83f5a678b268a23fef0142a18d0ab2a142edd0bb03328e667c3 lib/Unicode/UCD.pm
+ * 7c6a2550576273917f328032defbefc3bef43047bac1297166e95a179d9e492a lib/Unicode/UCD.pm
  * 764f420cedfc8b43d9fec251c957a5d55fc45d40f6573f162990ed1dce7e36e0 lib/unicore/ArabicShaping.txt
  * b8f32554c6f658821fb0ee742d21c5b1f2086b9bf13071fed04894b022f93d67 lib/unicore/BidiBrackets.txt
  * d7afdadd1bbd66f5a663ac0e8f7958f18fd9491fc0bc59ec5877cb82db71db7d lib/unicore/BidiMirroring.txt


### PR DESCRIPTION

* This set of changes does not require a perldelta entry.
