### PR TITLE
MY_CXT: don't SEGV on a 1-byte struct.

### DIFF
--- a/util.c
+++ b/util.c
@@ -5491,8 +5491,9 @@ Perl_my_cxt_init(pTHX_ int *indexp, size_t size)
             Newx(PL_my_cxt_list, PL_my_cxt_size, void *);
         }
     }
-    /* newSV() allocates one more than needed */
-    p = (void*)SvPVX(newSV(size-1));
+    /* newSV() allocates one more than needed, hence the size-1.
+     * But if its arg is zero, it doesn't allocate a PVX at all. */
+    p = (void*)SvPVX(newSV(size > 1 ? size-1 : 1));
     PL_my_cxt_list[index] = p;
     Zero(p, size, char);
     return p;


### PR DESCRIPTION
The MY_CXT mechanism allows XS code to declare a 'static' struct which is actually per-interpreter. Behind the scenes, the memory for this struct is allocated as the PVX buf of an SV. If the size of the struct is 1 (e.g. '{ char foo }' ) then newSV(size-1) gets called as newSV(0), which skips allocating a PVX buffer. SEGVs ensue.

* This set of changes does not require a perldelta entry.
