### PR TITLE
croak_xs_usage pod: remove unnecessary diag_listed_as

### DIFF
--- a/universal.c
+++ b/universal.c
@@ -384,8 +384,7 @@ A specialised variant of C<croak()> for emitting the usage message for xsubs
 works out the package name and subroutine name from C<cv>, and then calls
 C<croak()>.  Hence if C<cv> is C<&ouch::awk>, it would call C<croak> as:
 
- diag_listed_as: SKIPME
- croak("Usage: %" SVf "::%" SVf "(%s)", "ouch" "awk",
+ croak("Usage: %" SVf "::%" SVf "(%s)", "ouch", "awk",
                                                      "eee_yow");
 
 =cut


### PR DESCRIPTION
This ended up in the documentation for croak_xs_usage() where it was more confusing than useful.

Also fix a missing "," in the provided equivalent code.

Fixes #23310

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
TODO: fill description here

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
