### PR TITLE
Synch Pod-Simple-3.47 into blead

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1943,6 +1943,8 @@ cpan/Pod-Simple/t/fcodes.t				Pod::Simple test file
 cpan/Pod-Simple/t/fcodes_e.t				Pod::Simple test file
 cpan/Pod-Simple/t/fcodes_l.t				Pod::Simple test file
 cpan/Pod-Simple/t/fcodes_s.t				Pod::Simple test file
+cpan/Pod-Simple/t/filter.t				Pod-Simple
+cpan/Pod-Simple/t/filter-html.t				Pod-Simple
 cpan/Pod-Simple/t/for.t					Pod::Simple test file
 cpan/Pod-Simple/t/fornot.t				Pod::Simple test file
 cpan/Pod-Simple/t/github_issue_79.t			Test file related to Pod::Simple

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -966,8 +966,8 @@ our %Modules = (
     },
 
     'Pod::Simple' => {
-        'DISTRIBUTION' => 'KHW/Pod-Simple-3.45.tar.gz',
-        'SYNCINFO'     => 'jkeenan on Wed Aug  2 19:32:39 2023',
+        'DISTRIBUTION' => 'KHW/Pod-Simple-3.47.tar.gz',
+        'SYNCINFO'     => 'jkeenan on Fri May 23 17:15:52 2025',
         'FILES'        => q[cpan/Pod-Simple],
         'EXCLUDED' => [
             qw{.ChangeLog.swp},

--- a/cpan/Pod-Simple/lib/Pod/Simple.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple.pm
@@ -11,9 +11,9 @@ use Pod::Simple::TiedOutFH;
 #use utf8;
 
 our @ISA = ('Pod::Simple::BlackBox');
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 
-our @Known_formatting_codes = qw(I B C L E F S X Z);
+our @Known_formatting_codes = qw(I B C L E F S U X Z);
 our %Known_formatting_codes = map(($_=>1), @Known_formatting_codes);
 our @Known_directives       = qw(head1 head2 head3 head4 head5 head6 item over back);
 our %Known_directives       = map(($_=>'Plain'), @Known_directives);
@@ -33,8 +33,8 @@ BEGIN {
     die "MANY_LINES is too small (", MANY_LINES(), ")!\nAborting";
   }
   if(defined &UNICODE) { }
-  elsif($] >= 5.008)   { *UNICODE = sub() {1}  }
-  else                 { *UNICODE = sub() {''} }
+  elsif( do { no integer; "$]" >= 5.008 } ) { *UNICODE = sub() {1}  }
+  else                                      { *UNICODE = sub() {''} }
 }
 if(DEBUG > 2) {
   print STDERR "# We are ", ASCII ? '' : 'not ', "in ASCII-land\n";
@@ -42,8 +42,8 @@ if(DEBUG > 2) {
 }
 
 # The NO BREAK SPACE and SOFT HYHPEN are used in several submodules.
-if ($] ge 5.007_003) {  # On sufficiently modern Perls we can handle any
-                        # character set
+if ( do { no integer; "$]" >= 5.007_003 } ) {  # On sufficiently modern Perls we can handle any
+                          # character set
   $Pod::Simple::nbsp = chr utf8::unicode_to_native(0xA0);
   $Pod::Simple::shy  = chr utf8::unicode_to_native(0xAD);
 }
@@ -754,7 +754,7 @@ sub _remap_sequences {
         ref($map->{$_}) ? join(",", @{$map->{$_}}) : $map->{$_}
       ),
       sort keys %$map ),
-    ("B~C~E~F~I~L~S~X~Z" eq join '~', sort keys %$map)
+    ("B~C~E~F~I~L~S~U~X~Z" eq join '~', sort keys %$map)
      ? "  (all normal)\n" : "\n"
   ;
 

--- a/cpan/Pod-Simple/lib/Pod/Simple.pod
+++ b/cpan/Pod-Simple/lib/Pod/Simple.pod
@@ -5,7 +5,19 @@ Pod::Simple - framework for parsing Pod
 
 =head1 SYNOPSIS
 
- TODO
+    # using an existing formatter
+    use Pod::Simple::XHTML;
+    my $parser = Pod::Simple::XHTML->new;
+    $parser->parse_file('path/to/file.pod');
+
+    # creating a new formatter
+    package Pod::Simple::SomeFormatter;
+    use parent qw(Pod::Simple);
+    sub _handle_element_start {
+        my ($parser, $element_name, $attr_hash_r) = @_;
+        ...
+    }
+    ...
 
 =head1 DESCRIPTION
 
@@ -256,7 +268,7 @@ effected.
 
 =item C<< $parser->accept_code( @codes ) >>X<accept_code>
 
-Alias for L<< accept_codes >>.
+Alias for L<< accept_codes|/$parser->accept_codes( @codes ) >>.
 
 =item C<< $parser->accept_codes( @codes ) >>X<accept_codes>
 
@@ -285,11 +297,11 @@ can be used to implement user-defined directives.
 
 =item C<< $parser->accept_target( @targets ) >>X<accept_target>
 
-Alias for L<< accept_targets >>.
+Alias for L<< accept_targets|/$parser->accept_targets( @targets ) >>.
 
 =item C<< $parser->accept_target_as_text( @targets ) >>X<accept_target_as_text>
 
-Alias for L<< accept_targets_as_text >>.
+Alias for L<< accept_targets_as_text|/$parser->accept_targets_as_text( @targets ) >>.
 
 =item C<< $parser->accept_targets( @targets ) >>X<accept_targets>
 
@@ -339,7 +351,7 @@ Log an error that can't be ignored.
 
 =item C<< $parser->unaccept_code( @codes ) >>X<unaccept_code>
 
-Alias for L<< unaccept_codes >>.
+Alias for L<< unaccept_codes|/$parser->unaccept_codes( @codes ) >>.
 
 =item C<< $parser->unaccept_codes( @codes ) >>X<unaccept_codes>
 
@@ -347,7 +359,7 @@ Removes C<< @codes >> as valid codes for the parse.
 
 =item C<< $parser->unaccept_directive( @directives ) >>X<unaccept_directive>
 
-Alias for L<< unaccept_directives >>.
+Alias for L<< unaccept_directives|/$parser->unaccept_directives( @directives ) >>.
 
 =item C<< $parser->unaccept_directives( @directives ) >>X<unaccept_directives>
 
@@ -355,7 +367,7 @@ Removes C<< @directives >> as valid directives for the parse.
 
 =item C<< $parser->unaccept_target( @targets ) >>X<unaccept_target>
 
-Alias for L<< unaccept_targets >>.
+Alias for L<< unaccept_targets|/$parser->unaccept_targets( @targets ) >>.
 
 =item C<< $parser->unaccept_targets( @targets ) >>X<unaccept_targets>
 

--- a/cpan/Pod-Simple/lib/Pod/Simple/BlackBox.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/BlackBox.pm
@@ -22,7 +22,7 @@ use integer; # vroom!
 use strict;
 use warnings;
 use Carp ();
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 #use constant DEBUG => 7;
 
 sub my_qr ($$) {
@@ -35,7 +35,7 @@ sub my_qr ($$) {
     my ($input_re, $should_match) = @_;
     # XXX could have a third parameter $shouldnt_match for extra safety
 
-    my $use_utf8 = ($] le 5.006002) ? 'use utf8;' : "";
+    my $use_utf8 = do { no integer; $] <= 5.006002 } ? 'use utf8;' : "";
 
     my $re = eval "no warnings; $use_utf8 qr/$input_re/";
     #print STDERR  __LINE__, ": $input_re: $@\n" if $@;
@@ -93,7 +93,7 @@ my $deprecated_re = my_qr('\p{IsDeprecated}', "\x{149}");
 $deprecated_re = qr/\x{149}/ unless $deprecated_re;
 
 my $utf8_bom;
-if (($] ge 5.007_003)) {
+if ( do { no integer; "$]" >= 5.007_003 }) {
   $utf8_bom = "\x{FEFF}";
   utf8::encode($utf8_bom);
 } else {
@@ -266,13 +266,13 @@ sub parse_lines {             # Usage: $parser->parse_lines(@lines)
       # XXX probably if the line has E<foo> that evaluates to illegal CP1252,
       # then it is UTF-8.  But we haven't processed E<> yet.
 
-      goto set_1252 if $] lt 5.006_000;    # No UTF-8 on very early perls
+      goto set_1252 if do { no integer; "$]" < 5.006_000 };    # No UTF-8 on very early perls
 
       my $copy;
 
       no warnings 'utf8';
 
-      if ($] ge 5.007_003) {
+      if ( do { no integer; "$]" >= 5.007_003 } ) {
         $copy = $line;
 
         # On perls that have this function, we can use it to easily see if the
@@ -286,7 +286,7 @@ sub parse_lines {             # Usage: $parser->parse_lines(@lines)
       }
       else { # ASCII, no decode(): do it ourselves using the fundamental
              # characteristics of UTF-8
-        use if $] le 5.006002, 'utf8';
+        use if do { no integer; "$]" <= 5.006002 }, 'utf8';
 
         my $char_ord;
         my $needed;         # How many continuation bytes to gobble up
@@ -600,6 +600,158 @@ sub parse_lines {             # Usage: $parser->parse_lines(@lines)
 }
 
 #@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+sub _maybe_handle_element_start {
+  my $self = shift;
+  return $self->_handle_element_start(@_)
+    if !$self->{heading_filter};
+
+  my ($element_name, $attr) = @_;
+
+  if ($element_name =~ /\Ahead(\d)\z/) {
+    $self->{_in_head} = {
+      element => $element_name,
+      level   => $1 + 0,
+      events  => [],
+      text    => '',
+    };
+  }
+
+  if (my $head = $self->{_in_head}) {
+    push @{ $head->{events} }, [ '_handle_element_start', @_ ];
+    return;
+  }
+
+  return
+    if !$self->{_filter_allowed};
+
+  $self->_handle_element_start(@_);
+}
+
+sub _maybe_handle_element_end {
+  my $self = shift;
+  return $self->_handle_element_end(@_)
+    if !$self->{heading_filter};
+
+  my ($element_name, $attr) = @_;
+
+  if (my $head = $self->{_in_head}) {
+    if ($element_name ne $head->{element}) {
+      push @{ $head->{events} }, [ '_handle_element_end', @_ ];
+      return;
+    }
+
+    delete $self->{_in_head};
+
+    my $headings = $self->{_current_headings} ||= [];
+    @$headings = (@{$headings}[0 .. $head->{level} - 2], $head->{text});
+
+    my $allowed = $self->{_filter_allowed} = $self->_filter_allows(@$headings);
+
+    if ($allowed) {
+      for my $event (@{ $head->{events} }) {
+        my ($method, @args) = @$event;
+        $self->$method(@args);
+      }
+    }
+  }
+
+  return
+    if !$self->{_filter_allowed};
+
+  $self->_handle_element_end(@_);
+}
+
+sub _maybe_handle_text {
+  my $self = shift;
+  return $self->_handle_text(@_)
+    if !$self->{heading_filter};
+
+  my ($text) = @_;
+
+  if (my $head = $self->{_in_head}) {
+    push @{ $head->{events} }, [ '_handle_text', @_ ];
+    $head->{text} .= $text;
+    return;
+  }
+
+  return
+    if !$self->{_filter_allowed};
+
+  $self->_handle_text(@_);
+}
+
+sub _filter_allows {
+  my $self = shift;
+  my @headings = @_;
+
+  my $filter = $self->{heading_filter}
+    or return 1;
+
+  SPEC: for my $spec ( @$filter ) {
+    for my $i (0 .. $#$spec) {
+      my $regex = $spec->[$i];
+      my $heading = $headings[$i];
+      $heading = ''
+        if !defined $heading;
+      next SPEC
+        if $heading !~ $regex;
+    }
+    return 1;
+  }
+
+  return 0;
+}
+
+sub set_heading_select {
+  my $self = shift;
+  my (@selections) = @_;
+
+  my $filter = $self->{heading_filter} ||= [];
+  if (@selections && $selections[0] eq '+') {
+    shift @selections;
+  }
+  else {
+    @$filter = ();
+  }
+
+  for my $spec (@selections) {
+    eval {
+      push @$filter, $self->_compile_heading_spec($spec);
+      1;
+    } or do {
+      warn $@;
+      warn qq{Ignoring section spec "$spec"!\n};
+    };
+  }
+}
+
+sub _compile_heading_spec {
+  my $self = shift;
+  my ($spec) = @_;
+
+  my @bad;
+  my @parts = $spec =~ m{(?:\A|\G/)((?:[^/\\]|\\.)*)}g;
+  for my $part (@parts) {
+    $part =~ s{\\(.)}{$1}g;
+    my $negate = $part =~ s{\A!}{};
+    $part = '.*'
+      if !length $part;
+
+    eval {
+      $part = $negate ? qr{^(?!$part$)} : qr{^$part$};
+      1;
+    } or do {
+      push @bad, qq{Bad regular expression /$part/ in "$spec": $@\n};
+    };
+  }
+
+  Carp::croak(join '', @bad)
+    if @bad;
+
+  return \@parts;
+}
+
 
 sub _handle_encoding_line {
   my($self, $line) = @_;
@@ -1346,7 +1498,7 @@ sub _ponder_begin {
     DEBUG > 1 and print STDERR "Ignoring ignorable =begin\n";
   } else {
     $self->{'content_seen'} ||= 1 unless $self->{'~tried_gen_errata'};
-    $self->_handle_element_start((my $scratch='for'), $para->[1]);
+    $self->_maybe_handle_element_start((my $scratch='for'), $para->[1]);
   }
 
   return 1;
@@ -1414,7 +1566,7 @@ sub _ponder_end {
       # what's that for?
 
     $self->{'content_seen'} ||= 1 unless $self->{'~tried_gen_errata'};
-    $self->_handle_element_end( my $scratch = 'for', $para->[1]);
+    $self->_maybe_handle_element_end( my $scratch = 'for', $para->[1]);
   }
   DEBUG > 1 and print STDERR "Popping $curr_open->[-1][0] $curr_open->[-1][1]{'target'} because of =end $content\n";
   pop @$curr_open;
@@ -1536,7 +1688,7 @@ sub _ponder_over {
   DEBUG > 1 and print STDERR "=over found of type $list_type\n";
 
   $self->{'content_seen'} ||= 1 unless $self->{'~tried_gen_errata'};
-  $self->_handle_element_start((my $scratch = 'over-' . $list_type), $para->[1]);
+  $self->_maybe_handle_element_start((my $scratch = 'over-' . $list_type), $para->[1]);
 
   return;
 }
@@ -1558,7 +1710,7 @@ sub _ponder_back {
     # Expected case: we're closing the most recently opened thing
     #my $over = pop @$curr_open;
     $self->{'content_seen'} ||= 1 unless $self->{'~tried_gen_errata'};
-    $self->_handle_element_end( my $scratch =
+    $self->_maybe_handle_element_end( my $scratch =
       'over-' . ( (pop @$curr_open)->[1]{'~type'} ), $para->[1]
     );
   } else {
@@ -1843,7 +1995,7 @@ sub _traverse_treelet_bit {  # for use only by the routine above
   my($self, $name) = splice @_,0,2;
 
   my $scratch;
-  $self->_handle_element_start(($scratch=$name), shift @_);
+  $self->_maybe_handle_element_start(($scratch=$name), shift @_);
 
   while (@_) {
     my $x = shift;
@@ -1851,11 +2003,11 @@ sub _traverse_treelet_bit {  # for use only by the routine above
       &_traverse_treelet_bit($self, @$x);
     } else {
       $x .= shift while @_ && !ref($_[0]);
-      $self->_handle_text($x);
+      $self->_maybe_handle_text($x);
     }
   }
 
-  $self->_handle_element_end($scratch=$name);
+  $self->_maybe_handle_element_end($scratch=$name);
   return;
 }
 
@@ -2426,7 +2578,7 @@ sub reinit {
   foreach (qw(source_dead source_filename doc_has_started
 start_of_pod_block content_seen last_was_blank paras curr_open
 line_count pod_para_count in_pod ~tried_gen_errata all_errata errata errors_seen
-Title)) {
+Title _current_headings _in_head _filter_allowed)) {
 
     delete $self->{$_};
   }

--- a/cpan/Pod-Simple/lib/Pod/Simple/Checker.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/Checker.pm
@@ -8,7 +8,7 @@ use warnings;
 use Carp ();
 use Pod::Simple::Methody ();
 use Pod::Simple ();
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 our @ISA = ('Pod::Simple::Methody');
 BEGIN { *DEBUG = defined(&Pod::Simple::DEBUG)
           ? \&Pod::Simple::DEBUG

--- a/cpan/Pod-Simple/lib/Pod/Simple/Debug.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/Debug.pm
@@ -1,6 +1,6 @@
 package Pod::Simple::Debug;
 use strict;
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 
 sub import {
   my($value,$variable);

--- a/cpan/Pod-Simple/lib/Pod/Simple/DumpAsText.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/DumpAsText.pm
@@ -1,6 +1,6 @@
 package Pod::Simple::DumpAsText;
 use strict;
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 use Pod::Simple ();
 BEGIN { our @ISA = ('Pod::Simple')}
 

--- a/cpan/Pod-Simple/lib/Pod/Simple/DumpAsXML.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/DumpAsXML.pm
@@ -1,6 +1,6 @@
 package Pod::Simple::DumpAsXML;
 use strict;
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 use Pod::Simple ();
 BEGIN {our @ISA = ('Pod::Simple')}
 
@@ -67,7 +67,7 @@ sub _handle_element_end {
 sub _xml_escape {
   foreach my $x (@_) {
     # Escape things very cautiously:
-    if ($] ge 5.007_003) {
+    if ("$]" >= 5.007_003) {
       $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(utf8::native_to_unicode(ord($1))).';'/eg;
     } else { # Is broken for non-ASCII platforms on early perls
       $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(ord($1)).';'/eg;

--- a/cpan/Pod-Simple/lib/Pod/Simple/HTML.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/HTML.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Pod::Simple::PullParser ();
 our @ISA = ('Pod::Simple::PullParser');
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 BEGIN {
   if(defined &DEBUG) { } # no-op
   elsif( defined &Pod::Simple::DEBUG ) { *DEBUG = \&Pod::Simple::DEBUG }
@@ -35,8 +35,8 @@ $Perldoc_URL_Postfix = ''
  unless defined $Perldoc_URL_Postfix;
 
 
-our $Man_URL_Prefix  = 'http://man.he.net/man';
-our $Man_URL_Postfix = '';
+our $Man_URL_Prefix  = 'https://man7.org/linux/man-pages/man';
+our $Man_URL_Postfix = '.html';
 
 our $Title_Prefix;
 $Title_Prefix  = '' unless defined $Title_Prefix;
@@ -59,7 +59,7 @@ __PACKAGE__->_accessorize(
    # In turning L<crontab(5)> into http://whatever/man/1/crontab, what
    #  to put before the "1/crontab".
  'man_url_postfix',
-   #  what to put after the "1/crontab" in the URL. Normally "".
+   #  what to put after the "1/crontab" in the URL. Normally ".html".
 
  'batch_mode', # whether we're in batch mode
  'batch_mode_current_level',
@@ -125,7 +125,7 @@ our %Tagmap = (
 
   changes(qw(
     Para=p
-    B=b I=i
+    B=b I=i U=u
     over-bullet=ul
     over-number=ol
     over-text=dl
@@ -164,6 +164,7 @@ our %Tagmap = (
 
   'B'      =>  "<b>",                  '/B'     =>  "</b>",
   'I'      =>  "<i>",                  '/I'     =>  "</i>",
+  'U'      =>  "<u>",                  '/U'     =>  "</u>",
   'F'      =>  "<em$Computerese>",     '/F'     =>  "</em>",
   'C'      =>  "<code$Computerese>",   '/C'     =>  "</code>",
   'L'  =>  "<a href='YOU_SHOULD_NEVER_SEE_THIS'>", # ideally never used!
@@ -701,7 +702,7 @@ sub section_name_tidy {
   $section =~ s/^\s+//;
   $section =~ s/\s+$//;
   $section =~ tr/ /_/;
-  if ($] ge 5.006) {
+  if ("$]" >= 5.006) {
     $section =~ s/[[:cntrl:][:^ascii:]]//g; # drop crazy characters
   } elsif ('A' eq chr(65)) { # But not on early EBCDIC
     $section =~ tr/\x00-\x1F\x80-\x9F//d;
@@ -724,7 +725,7 @@ sub general_url_escape {
   # A pretty conservative escaping, behoovey even for query components
   #  of a URL (see RFC 2396)
 
-  if ($] ge 5.007_003) {
+  if ("$]" >= 5.007_003) {
     $string =~ s/([^-_\.!~*()abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/sprintf('%%%02X',utf8::native_to_unicode(ord($1)))/eg;
   } else { # Is broken for non-ASCII platforms on early perls
     $string =~ s/([^-_\.!~*()abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/sprintf('%%%02X',ord($1))/eg;
@@ -796,7 +797,7 @@ sub resolve_man_page_link {
   $section ||= 1;
 
   return $self->man_url_prefix . "$section/"
-      . $self->manpage_url_escape($page)
+      . $self->manpage_url_escape($page) . ".$section"
       . $self->man_url_postfix;
 }
 
@@ -862,7 +863,7 @@ sub esc { # a function.
       @_ = splice @_; # break aliasing
     } else {
       my $x = shift;
-      if ($] ge 5.007_003) {
+      if ("$]" >= 5.007_003) {
         $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(utf8::native_to_unicode(ord($1))).';'/eg;
       } else { # Is broken for non-ASCII platforms on early perls
         $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(ord($1)).';'/eg;
@@ -873,7 +874,7 @@ sub esc { # a function.
   foreach my $x (@_) {
     # Escape things very cautiously:
     if (defined $x) {
-      if ($] ge 5.007_003) {
+      if ("$]" >= 5.007_003) {
         $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(utf8::native_to_unicode(ord($1))).';'/eg
       } else { # Is broken for non-ASCII platforms on early perls
         $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(ord($1)).';'/eg
@@ -1134,14 +1135,6 @@ under the same terms as Perl itself.
 This program is distributed in the hope that it will be useful, but
 without any warranty; without even the implied warranty of
 merchantability or fitness for a particular purpose.
-
-=head1 ACKNOWLEDGEMENTS
-
-Thanks to L<Hurricane Electric|http://he.net/> for permission to use its
-L<Linux man pages online|http://man.he.net/> site for man page links.
-
-Thanks to L<search.cpan.org|http://search.cpan.org/> for permission to use the
-site for Perl module links.
 
 =head1 AUTHOR
 

--- a/cpan/Pod-Simple/lib/Pod/Simple/HTMLBatch.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/HTMLBatch.pm
@@ -1,6 +1,6 @@
 package Pod::Simple::HTMLBatch;
 use strict;
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 our @ISA = ();  # Yup, we're NOT a subclass of Pod::Simple::HTML!
 
 # TODO: nocontents stylesheets. Strike some of the color variations?
@@ -1112,7 +1112,7 @@ Example:
 =item $batchconv = Pod::Simple::HTMLBatch->new;
 
 This creates a new batch converter.  The method doesn't take parameters.
-To change the converter's attributes, use the L<"/ACCESSOR METHODS">
+To change the converter's attributes, use the L</"ACCESSOR METHODS">
 below.
 
 =item $batchconv->batch_convert( I<indirs>, I<outdir> );

--- a/cpan/Pod-Simple/lib/Pod/Simple/JustPod.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/JustPod.pm
@@ -214,6 +214,7 @@ sub start_E { _start_fcode('E', @_); }
 sub start_F { _start_fcode('F', @_); }
 sub start_I { _start_fcode('I', @_); }
 sub start_S { _start_fcode('S', @_); }
+sub start_U { _start_fcode('U', @_); }
 sub start_X { _start_fcode('X', @_); }
 sub start_Z { _start_fcode('Z', @_); }
 
@@ -242,6 +243,7 @@ sub _end_fcode {
 *end_F   = *_end_fcode;
 *end_I   = *_end_fcode;
 *end_S   = *_end_fcode;
+*end_U   = *_end_fcode;
 *end_X   = *_end_fcode;
 *end_Z   = *_end_fcode;
 

--- a/cpan/Pod-Simple/lib/Pod/Simple/LinkSection.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/LinkSection.pm
@@ -4,7 +4,7 @@ package Pod::Simple::LinkSection;
 use strict;
 use warnings;
 use Pod::Simple::BlackBox;
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 
 use overload( # So it'll stringify nice
   '""'   => \&Pod::Simple::BlackBox::stringify_lol,

--- a/cpan/Pod-Simple/lib/Pod/Simple/Methody.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/Methody.pm
@@ -2,7 +2,7 @@ package Pod::Simple::Methody;
 use strict;
 use warnings;
 use Pod::Simple ();
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 our @ISA = ('Pod::Simple');
 
 # Yes, we could use named variables, but I want this to be impose

--- a/cpan/Pod-Simple/lib/Pod/Simple/Progress.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/Progress.pm
@@ -2,7 +2,7 @@ package Pod::Simple::Progress;
 use strict;
 use warnings;
 
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 
 # Objects of this class are used for noting progress of an
 #  operation every so often.  Messages delivered more often than that

--- a/cpan/Pod-Simple/lib/Pod/Simple/PullParser.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/PullParser.pm
@@ -1,6 +1,6 @@
 package Pod::Simple::PullParser;
 use strict;
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 use Pod::Simple ();
 BEGIN {our @ISA = ('Pod::Simple')}
 

--- a/cpan/Pod-Simple/lib/Pod/Simple/PullParserEndToken.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/PullParserEndToken.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Pod::Simple::PullParserToken ();
 our @ISA = ('Pod::Simple::PullParserToken');
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 
 sub new {  # Class->new(tagname);
   my $class = shift;

--- a/cpan/Pod-Simple/lib/Pod/Simple/PullParserStartToken.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/PullParserStartToken.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Pod::Simple::PullParserToken ();
 our @ISA = ('Pod::Simple::PullParserToken');
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 
 sub new {  # Class->new(tagname, optional_attrhash);
   my $class = shift;

--- a/cpan/Pod-Simple/lib/Pod/Simple/PullParserTextToken.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/PullParserTextToken.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Pod::Simple::PullParserToken ();
 our @ISA = ('Pod::Simple::PullParserToken');
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 
 sub new {  # Class->new(text);
   my $class = shift;

--- a/cpan/Pod-Simple/lib/Pod/Simple/PullParserToken.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/PullParserToken.pm
@@ -1,7 +1,7 @@
 package Pod::Simple::PullParserToken;
  # Base class for tokens gotten from Pod::Simple::PullParser's $parser->get_token
 our @ISA = ();
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 use strict;
 
 sub new {  # Class->new('type', stuff...);  ## Overridden in derived classes anyway

--- a/cpan/Pod-Simple/lib/Pod/Simple/RTF.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/RTF.pm
@@ -6,7 +6,7 @@ use warnings;
 #sub Pod::Simple::DEBUG () {4};
 #sub Pod::Simple::PullParser::DEBUG () {4};
 
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 use Pod::Simple::PullParser ();
 our @ISA;
 BEGIN {@ISA = ('Pod::Simple::PullParser')}
@@ -18,7 +18,7 @@ sub to_uni ($) {    # Convert native code point to Unicode
     my $x = shift;
 
     # Broken for early EBCDICs
-    $x = chr utf8::native_to_unicode(ord $x) if $] ge 5.007_003
+    $x = chr utf8::native_to_unicode(ord $x) if "$]" >= 5.007_003
                                              && ord("A") != 65;
     return $x;
 }
@@ -86,6 +86,7 @@ our %Tagmap = (
  _openclose(
   'B=cs18\b',
   'I=cs16\i',
+  'U=cs30\ul',
   'C=cs19\f1\lang1024\noproof',
   'F=cs17\i\lang1024\noproof',
 
@@ -413,6 +414,7 @@ sub stylesheet {
 {\*\cs17 \additive \i\lang1024\noproof \sbasedon10 pod-F;}
 {\*\cs18 \additive \b \sbasedon10 pod-B;}
 {\*\cs19 \additive \f1\lang1024\noproof\sbasedon10 pod-C;}
+{\*\cs30 \additive \ul \sbasedon10 pod-U;}
 {\s20\ql \li0\ri0\sa180\widctlpar\f1\fs%s\lang1024\noproof\sbasedon0 \snext0 pod-codeblock;}
 {\*\cs21 \additive \lang1024\noproof \sbasedon10 pod-computerese;}
 {\*\cs22 \additive \i\lang1024\noproof\sbasedon10 pod-L-pod;}
@@ -549,7 +551,7 @@ my $other_unicode =
         Pod::Simple::BlackBox::my_qr('([\x{10000}-\x{10FFFF}])', "\x{10000}");
 
 sub esc_uni($) {
-    use if $] le 5.006002, 'utf8';
+    use if do { no integer; "$]" <= 5.006002 }, 'utf8';
 
     my $x = shift;
 

--- a/cpan/Pod-Simple/lib/Pod/Simple/Search.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/Search.pm
@@ -2,7 +2,7 @@ package Pod::Simple::Search;
 use strict;
 use warnings;
 
-our $VERSION = '3.45';   ## Current version of this package
+our $VERSION = '3.47';   ## Current version of this package
 
 BEGIN { *DEBUG = sub () {0} unless defined &DEBUG; }   # set DEBUG level
 use Carp ();

--- a/cpan/Pod-Simple/lib/Pod/Simple/SimpleTree.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/SimpleTree.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Carp ();
 use Pod::Simple ();
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 BEGIN {
   our @ISA = ('Pod::Simple');
   *DEBUG = \&Pod::Simple::DEBUG unless defined &DEBUG;

--- a/cpan/Pod-Simple/lib/Pod/Simple/Subclassing.pod
+++ b/cpan/Pod-Simple/lib/Pod/Simple/Subclassing.pod
@@ -38,10 +38,10 @@ existing Pod formatter, instead see its documentation and see also the
 docs in L<Pod::Simple>.
 
 B<The zeroeth step> in writing a Pod formatter is to make sure that there
-isn't already a decent one in CPAN. See L<http://search.cpan.org/>, and
+isn't already a decent one in CPAN. See L<https://metacpan.org/>, and
 run a search on the name of the format you want to render to. Also
 consider joining the Pod People list
-L<http://lists.perl.org/showlist.cgi?name=pod-people> and asking whether
+L<https://lists.perl.org/showlist.cgi?name=pod-people> and asking whether
 anyone has a formatter for that format -- maybe someone cobbled one
 together but just hasn't released it.
 
@@ -172,7 +172,7 @@ produces this event structure:
       in the document.
     </Para>
 
-=item events with an element_name of B, C, F, or I.
+=item events with an element_name of B, C, F, I, or U.
 
 Parsing a BE<lt>...E<gt> formatting code (or of course any of its
 semantically identical syntactic variants
@@ -190,7 +190,7 @@ Parsing C, F, or I codes produce the same structure, with only a
 different element name.
 
 If your parser object has been set to accept other formatting codes,
-then they will be presented like these B/C/F/I codes -- i.e., without
+then they will be presented like these B/C/F/I/U codes -- i.e., without
 any attributes.
 
 =item events with an element_name of S
@@ -212,7 +212,7 @@ means non-breaking space.
 =item events with an element_name of X
 
 Normally, parsing an XE<lt>...E<gt> sequence produces this event
-structure, just as if it were a B/C/F/I code:
+structure, just as if it were a B/C/F/I/U code:
 
       <X>
         ...stuff...
@@ -367,7 +367,7 @@ produces this event structure:
   </L>
 
 In cases of links to a section in a different Pod document,
-there are both a I<section> attribute and a L<to> attribute.
+there are both a I<section> attribute and a I<to> attribute.
 For example, this Pod source:
 
   L<perlsyn/"Basic BLOCKs and Switch Statements">
@@ -775,7 +775,7 @@ At time of writing, I don't think you'll need to use this.
 =item C<< $parser->accept_codes( I<Codename>, I<Codename>...  ) >>
 
 This tells the parser that you accept additional formatting codes,
-beyond just the standard ones (I B C L F S X, plus the two weird ones
+beyond just the standard ones (I B C L F S U X, plus the two weird ones
 you don't actually see in the parse tree, Z and E). For example, to also
 accept codes "N", "R", and "W":
 

--- a/cpan/Pod-Simple/lib/Pod/Simple/Text.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/Text.pm
@@ -4,7 +4,7 @@ use warnings;
 use Carp ();
 use Pod::Simple::Methody ();
 use Pod::Simple ();
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 our @ISA = ('Pod::Simple::Methody');
 BEGIN { *DEBUG = defined(&Pod::Simple::DEBUG)
           ? \&Pod::Simple::DEBUG

--- a/cpan/Pod-Simple/lib/Pod/Simple/TextContent.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/TextContent.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Carp ();
 use Pod::Simple ();
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 our @ISA = ('Pod::Simple');
 
 sub new {

--- a/cpan/Pod-Simple/lib/Pod/Simple/TiedOutFH.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/TiedOutFH.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Symbol ('gensym');
 use Carp ();
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/cpan/Pod-Simple/lib/Pod/Simple/Transcode.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/Transcode.pm
@@ -1,6 +1,6 @@
 package Pod::Simple::Transcode;
 use strict;
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 
 BEGIN {
   if(defined &DEBUG) {;} # Okay

--- a/cpan/Pod-Simple/lib/Pod/Simple/TranscodeDumb.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/TranscodeDumb.pm
@@ -1,6 +1,6 @@
 package Pod::Simple::TranscodeDumb;
 use strict;
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 # This module basically pretends it knows how to transcode, except
 #  only for null-transcodings!  We use this when Encode isn't
 #  available.

--- a/cpan/Pod-Simple/lib/Pod/Simple/TranscodeSmart.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/TranscodeSmart.pm
@@ -7,7 +7,7 @@ use strict;
 use warnings;
 use Pod::Simple;
 use Encode;
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 
 sub is_dumb  {0}
 sub is_smart {1}

--- a/cpan/Pod-Simple/lib/Pod/Simple/XHTML.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/XHTML.pm
@@ -45,7 +45,7 @@ use warnings;
 
 package Pod::Simple::XHTML;
 use strict;
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 use Pod::Simple::Methody ();
 our @ISA = ('Pod::Simple::Methody');
 
@@ -118,7 +118,7 @@ the call to C<parse_file>:
 
 =head2 perldoc_url_prefix
 
-In turning L<Foo::Bar> into http://whatever/Foo%3a%3aBar, what
+In turning LE<lt>Foo::BarE<gt> into http://whatever/Foo%3a%3aBar, what
 to put before the "Foo%3a%3aBar". The default value is
 "https://metacpan.org/pod/".
 
@@ -129,13 +129,14 @@ default.
 
 =head2 man_url_prefix
 
-In turning C<< L<crontab(5)> >> into http://whatever/man/1/crontab, what
-to put before the "1/crontab". The default value is
-"http://man.he.net/man".
+In turning C<< LE<lt>crontab(5)E<gt> >> into http://whatever/man/1/crontab.1, what
+to put before the "1/crontab.1". The default value is
+"https://man7.org/linux/man-pages/man".
 
 =head2 man_url_postfix
 
-What to put after "1/crontab" in the URL. This option is not set by default.
+What to put after "1/crontab.1" in the URL.
+This option is set to ".html" by default.
 
 =head2 title_prefix, title_postfix
 
@@ -276,7 +277,8 @@ sub new {
   my $new = $self->SUPER::new(@_);
   $new->{'output_fh'} ||= *STDOUT{IO};
   $new->perldoc_url_prefix('https://metacpan.org/pod/');
-  $new->man_url_prefix('http://man.he.net/man');
+  $new->man_url_prefix('https://man7.org/linux/man-pages/man');
+  $new->man_url_postfix('.html');
   $new->html_charset('ISO-8859-1');
   $new->nix_X_codes(1);
   $new->{'scratch'} = '';
@@ -458,7 +460,7 @@ sub start_item_text   {
 }
 
 sub start_over_bullet { $_[0]{'scratch'} = '<ul>'; push @{$_[0]{'in_li'}}, 0; $_[0]->emit }
-sub start_over_block  { $_[0]{'scratch'} = '<ul>'; $_[0]->emit }
+sub start_over_block  { $_[0]{'scratch'} = '<blockquote>'; $_[0]->emit }
 sub start_over_number { $_[0]{'scratch'} = '<ol>'; push @{$_[0]{'in_li'}}, 0; $_[0]->emit }
 sub start_over_text   {
     $_[0]{'scratch'} = '<dl>';
@@ -467,7 +469,7 @@ sub start_over_text   {
     $_[0]->emit
 }
 
-sub end_over_block  { $_[0]{'scratch'} .= '</ul>'; $_[0]->emit }
+sub end_over_block  { $_[0]{'scratch'} .= '</blockquote>'; $_[0]->emit }
 
 sub end_over_number   {
     $_[0]{'scratch'} = "</li>\n" if ( pop @{$_[0]{'in_li'}} );
@@ -699,6 +701,9 @@ sub end_F   { $_[0]{'scratch'} .= '</i>' }
 sub start_I { $_[0]{'scratch'} .= '<i>' }
 sub end_I   { $_[0]{'scratch'} .= '</i>' }
 
+sub start_U { $_[0]{'scratch'} .= '<u>' }
+sub end_U   { $_[0]{'scratch'} .= '</u>' }
+
 sub start_L {
   my ($self, $flags) = @_;
     my ($type, $to, $section) = @{$flags}{'type', 'to', 'section'};
@@ -771,25 +776,25 @@ sub resolve_pod_page_link {
 Resolves a man page link target and numeric section to a URL. The resulting
 link will be returned for the above examples as:
 
-    http://man.he.net/man5/crontab
-    http://man.he.net/man1/crontab
+    https://man7.org/linux/man-pages/man5/crontab.5.html
+    https://man7.org/linux/man-pages/man1/crontab.1.html
 
 Note that the first argument is required. The section number will be parsed
 from it, and if it's missing will default to 1. The second argument is
-currently ignored, as L<man.he.net|http://man.he.net> does not currently
-include linkable IDs or anchor names in its pages. Subclass to link to a
-different man page HTTP server.
+currently ignored. Subclass to link to a different man page HTTP server.
 
 =cut
 
 sub resolve_man_page_link {
     my ($self, $to, $section) = @_;
     return undef unless defined $to;
+
     my ($page, $part) = $to =~ /^([^(]+)(?:[(](\d+)[)])?$/;
     return undef unless $page;
+
     return ($self->man_url_prefix || '')
         . ($part || 1) . "/" . $self->encode_entities($page)
-        . ($self->man_url_postfix || '');
+        . "." . ($part || 1) . ($self->man_url_postfix || '');
 
 }
 
@@ -902,17 +907,9 @@ This program is distributed in the hope that it will be useful, but
 without any warranty; without even the implied warranty of
 merchantability or fitness for a particular purpose.
 
-=head1 ACKNOWLEDGEMENTS
-
-Thanks to L<Hurricane Electric|http://he.net/> for permission to use its
-L<Linux man pages online|http://man.he.net/> site for man page links.
-
-Thanks to L<search.cpan.org|http://search.cpan.org/> for permission to use the
-site for Perl module links.
-
 =head1 AUTHOR
 
-Pod::Simpele::XHTML was created by Allison Randal <allison@perl.org>.
+Pod::Simple::XHTML was created by Allison Randal <allison@perl.org>.
 
 Pod::Simple was created by Sean M. Burke <sburke@cpan.org>.
 But don't bother him, he's retired.

--- a/cpan/Pod-Simple/lib/Pod/Simple/XMLOutStream.pm
+++ b/cpan/Pod-Simple/lib/Pod/Simple/XMLOutStream.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Carp ();
 use Pod::Simple ();
-our $VERSION = '3.45';
+our $VERSION = '3.47';
 BEGIN {
   our @ISA = ('Pod::Simple');
   *DEBUG = \&Pod::Simple::DEBUG unless defined &DEBUG;
@@ -76,7 +76,7 @@ sub _handle_element_end {
 sub _xml_escape {
   foreach my $x (@_) {
     # Escape things very cautiously:
-    if ($] ge 5.007_003) {
+    if ("$]" >= 5.007_003) {
       $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(utf8::native_to_unicode(ord($1))).';'/eg;
     } else { # Is broken for non-ASCII platforms on early perls
       $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(ord($1)).';'/eg;

--- a/cpan/Pod-Simple/t/JustPod_corpus.t
+++ b/cpan/Pod-Simple/t/JustPod_corpus.t
@@ -13,20 +13,21 @@ BEGIN {
 use File::Find;
 use File::Spec;
 use Test::More;
+use File::Basename;
 
 use Pod::Simple::JustPod;
 
 my @test_files;
 
 BEGIN {
-  my $test_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+  my $test_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
   print "# TESTDIR: $test_dir\n";
 
   sub wanted {
     push @test_files, $File::Find::name
       if $File::Find::name =~ /\.pod$/
-      && $File::Find::name !~ /temp/; # ignore any files named temp,
+      && basename($File::Find::name) !~ /temp/; # ignore any files named temp,
                                       # a different test file may have
                                       # created it
   }

--- a/cpan/Pod-Simple/t/ascii_order.pl
+++ b/cpan/Pod-Simple/t/ascii_order.pl
@@ -5,7 +5,7 @@ sub native_to_uni($) {  # Convert from platform character set to Unicode
     my $string = shift;
 
     return $string if ord("A") == 65
-                      || $] lt 5.007_003; # Doesn't work on early EBCDIC Perls
+                      || "$]" < 5.007_003; # Doesn't work on early EBCDIC Perls
     my $output = "";
     for my $i (0 .. length($string) - 1) {
         $output .= chr(utf8::native_to_unicode(ord(substr($string, $i, 1))));

--- a/cpan/Pod-Simple/t/encod01.t
+++ b/cpan/Pod-Simple/t/encod01.t
@@ -13,11 +13,10 @@ use Pod::Simple::DumpAsXML;
 my $thefile;
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
 BEGIN {
-  my $corpusdir = File::Spec->catdir(File::Basename::dirname(Cwd::abs_path(__FILE__)), 'corpus');
+  my $corpusdir = File::Spec->catdir(File::Basename::dirname(File::Spec->rel2abs(__FILE__)), 'corpus');
   $thefile = File::Spec->catfile($corpusdir, 'nonesuch.txt');
 }
 

--- a/cpan/Pod-Simple/t/encod04.t
+++ b/cpan/Pod-Simple/t/encod04.t
@@ -18,7 +18,7 @@ use Pod::Simple::XMLOutStream;
 my $x97;
 my $x91;
 my $dash;
-if ($] ge 5.007_003) {
+if ("$]" >= 5.007_003) {
     $x97 = chr utf8::unicode_to_native(0x97);
     $x91 = chr utf8::unicode_to_native(0x91);
     $dash = '&#8212';

--- a/cpan/Pod-Simple/t/fcodes_s.t
+++ b/cpan/Pod-Simple/t/fcodes_s.t
@@ -215,7 +215,8 @@ is(
 # Test HTML output of links.
 use Pod::Simple::HTML;
 my $PERLDOC = "https://metacpan.org/pod";
-my $MANURL = "http://man.he.net/man";
+my $MANURL = "https://man7.org/linux/man-pages/man";
+my $MANURL_POSTFIX = ".html";
 sub x {
     Pod::Simple::HTML->_out(
         sub {  $_[0]->bare_output(1)  },
@@ -240,7 +241,7 @@ is(
 
 is(
     x(qq{L<crontab(5)>\n}),
-    qq{\n<p><a href="${MANURL}5/crontab" class="podlinkman"\n>crontab(5)</a></p>\n}
+    qq{\n<p><a href="${MANURL}5/crontab.5${MANURL_POSTFIX}" class="podlinkman"\n>crontab(5)</a></p>\n}
 );
 
 is(
@@ -300,12 +301,12 @@ is(
 
 is(
     x(qq{L<things|crontab(5)>\n}),
-    qq{\n<p><a href="${MANURL}5/crontab" class="podlinkman"\n>things</a></p>\n}
+    qq{\n<p><a href="${MANURL}5/crontab.5${MANURL_POSTFIX}" class="podlinkman"\n>things</a></p>\n}
 );
 
 is(
     x(qq{L<things|crontab(5)/ENVIRONMENT>\n}),
-    qq{\n<p><a href="${MANURL}5/crontab" class="podlinkman"\n>things</a></p>\n}
+    qq{\n<p><a href="${MANURL}5/crontab.5${MANURL_POSTFIX}" class="podlinkman"\n>things</a></p>\n}
 );
 
 is(
@@ -362,7 +363,7 @@ is(
 
 is(
     o(qq{L<crontab(5)>}),
-    qq{<p><a href="${MANURL}5/crontab">crontab(5)</a></p>\n\n}
+    qq{<p><a href="${MANURL}5/crontab.5${MANURL_POSTFIX}">crontab(5)</a></p>\n\n}
 );
 
 is(
@@ -422,12 +423,12 @@ is(
 
 is(
     o(qq{L<things|crontab(5)>}),
-    qq{<p><a href="${MANURL}5/crontab">things</a></p>\n\n}
+    qq{<p><a href="${MANURL}5/crontab.5${MANURL_POSTFIX}">things</a></p>\n\n}
 );
 
 is(
     o(qq{L<things|crontab(5)/ENVIRONMENT>}),
-    qq{<p><a href="${MANURL}5/crontab">things</a></p>\n\n}
+    qq{<p><a href="${MANURL}5/crontab.5${MANURL_POSTFIX}">things</a></p>\n\n}
 );
 
 is(

--- a/cpan/Pod-Simple/t/filter-html.t
+++ b/cpan/Pod-Simple/t/filter-html.t
@@ -1,0 +1,63 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Pod::Simple::XHTML;
+
+sub convert {
+  my ($pod, $select) = @_;
+
+  my $out = '';
+  my $parser = Pod::Simple::XHTML->new;
+  $parser->html_header('');
+  $parser->html_footer('');
+  $parser->output_string(\$out);
+  $parser->set_heading_select(@$select);
+
+  $parser->parse_string_document($pod);
+  return $out;
+}
+
+sub compare {
+  my ($in, $want, $select, $name) = @_;
+  for my $pod ($in, $want) {
+    if ($pod =~ /\A([\t ]+)/) {
+      my $prefix = $1;
+      $pod =~ s{^$prefix}{}gm;
+    }
+  }
+  my $got = convert($in, $select);
+  local $Test::Builder::Level = $Test::Builder::Level + 1;
+  is $got, $want, $name;
+}
+
+compare <<'END_POD', <<'END_HTML', [ 'DESCRIPTION/guff' ];
+  =head1 NAME
+
+  NAME content
+
+  =head2 welp
+
+  welp content
+
+  =head3 hork
+
+  hork content
+
+  =head1 DESCRIPTION
+
+  DESCRIPTION content
+
+  =head2 guff
+
+  guff content
+
+  =cut
+END_POD
+  <h2 id="guff">guff</h2>
+
+  <p>guff content</p>
+
+END_HTML
+
+done_testing;

--- a/cpan/Pod-Simple/t/filter.t
+++ b/cpan/Pod-Simple/t/filter.t
@@ -1,0 +1,62 @@
+use strict;
+use warnings;
+use Test::More;
+use Pod::Simple::JustPod;
+
+sub convert {
+  my ($pod, $select) = @_;
+
+  my $out = '';
+  my $parser = Pod::Simple::JustPod->new;
+  $parser->output_string(\$out);
+  $parser->set_heading_select(@$select);
+
+  $parser->parse_string_document($pod);
+  return $out;
+}
+
+sub compare {
+  my ($in, $want, $select, $name) = @_;
+  for my $pod ($in, $want) {
+    if ($pod =~ /\A([\t ]+)/) {
+      my $prefix = $1;
+      $pod =~ s{^$prefix}{}gm;
+    }
+  }
+  my $got = convert($in, $select);
+  $got =~ s/\A=pod\n\n//;
+  local $Test::Builder::Level = $Test::Builder::Level + 1;
+  is $got, $want, $name;
+}
+
+compare <<'END_IN_POD', <<'END_OUT_POD', [ 'DESCRIPTION/guff' ];
+  =head1 NAME
+
+  NAME content
+
+  =head2 welp
+
+  welp content
+
+  =head3 hork
+
+  hork content
+
+  =head1 DESCRIPTION
+
+  DESCRIPTION content
+
+  =head2 guff
+
+  guff content
+
+  =cut
+END_IN_POD
+  =head2 guff
+
+  guff content
+
+  =cut
+END_OUT_POD
+
+done_testing;

--- a/cpan/Pod-Simple/t/html02.t
+++ b/cpan/Pod-Simple/t/html02.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 6;
+use Test::More tests => 7;
 
 #use Pod::Simple::Debug (10);
 use Pod::Simple::HTML;
@@ -20,6 +20,7 @@ my @pairs = (
 [ 'C<code>'         => qq{\n<p><code>code</code></p>\n} ],
 [ 'F</tmp/foo>'     => qq{\n<p><em>/tmp/foo</em></p>\n} ],
 [ 'F</tmp/foo>'     => qq{\n<p><em>/tmp/foo</em></p>\n} ],
+[ 'U<underlined>'   => qq{\n<p><u>underlined</u></p>\n} ],
 );
 
 

--- a/cpan/Pod-Simple/t/output.t
+++ b/cpan/Pod-Simple/t/output.t
@@ -5,10 +5,9 @@ use warnings;
 use Test::More tests => 36;
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 for my $format (qw(XHTML HTML Text RTF)) {
     my $class = "Pod::Simple::$format";

--- a/cpan/Pod-Simple/t/reinit.t
+++ b/cpan/Pod-Simple/t/reinit.t
@@ -3,7 +3,6 @@ use warnings;
 use Test::More tests => 5;
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
 use Pod::Simple::Text;
@@ -18,7 +17,7 @@ foreach my $file (
   "perlfaq.pod",
   "perlvar.pod",
 ) {
-    my $full_file = File::Spec->catfile(File::Basename::dirname(Cwd::abs_path(__FILE__)), $file);
+    my $full_file = File::Spec->catfile(File::Basename::dirname(File::Spec->rel2abs(__FILE__)), $file);
 
     unless(-e $full_file) {
         ok 0;

--- a/cpan/Pod-Simple/t/render.t
+++ b/cpan/Pod-Simple/t/render.t
@@ -14,7 +14,6 @@ $Pod::Simple::Text::FREAKYMODE = 1;
 use Pod::Simple::TiedOutFH ();
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
 my $outfile = '10000';
@@ -26,7 +25,7 @@ foreach my $file (
   "perlfaq.pod",
   "perlvar.pod",
 ) {
-  my $full_file = File::Spec->catfile(File::Basename::dirname(Cwd::abs_path(__FILE__)), $file);
+  my $full_file = File::Spec->catfile(File::Basename::dirname(File::Spec->rel2abs(__FILE__)), $file);
 
   unless(-e $full_file) {
     ok 0;

--- a/cpan/Pod-Simple/t/rtf_utf8.t
+++ b/cpan/Pod-Simple/t/rtf_utf8.t
@@ -11,10 +11,9 @@ else {
 }
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $expected = join "", <DATA>;
 
@@ -85,6 +84,7 @@ __DATA__
 {\*\cs17 \additive \i\lang1024\noproof \sbasedon10 pod-F;}
 {\*\cs18 \additive \b \sbasedon10 pod-B;}
 {\*\cs19 \additive \f1\lang1024\noproof\sbasedon10 pod-C;}
+{\*\cs30 \additive \ul \sbasedon10 pod-U;}
 {\s20\ql \li0\ri0\sa180\widctlpar\f1\fs18\lang1024\noproof\sbasedon0 \snext0 pod-codeblock;}
 {\*\cs21 \additive \lang1024\noproof \sbasedon10 pod-computerese;}
 {\*\cs22 \additive \i\lang1024\noproof\sbasedon10 pod-L-pod;}

--- a/cpan/Pod-Simple/t/search10.t
+++ b/cpan/Pod-Simple/t/search10.t
@@ -15,10 +15,9 @@ die "Couldn't make an object!?" unless ok defined $x;
 $x->inc(0);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here = File::Spec->catdir($t_dir, 'testlib1');
 

--- a/cpan/Pod-Simple/t/search12.t
+++ b/cpan/Pod-Simple/t/search12.t
@@ -13,10 +13,9 @@ die "Couldn't make an object!?" unless ok defined $x;
 $x->inc(0);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here = File::Spec->catdir($t_dir, 'testlib1');
 

--- a/cpan/Pod-Simple/t/search20.t
+++ b/cpan/Pod-Simple/t/search20.t
@@ -17,10 +17,9 @@ $x->callback(sub {
 });
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here1 = File::Spec->catdir($t_dir, 'testlib1');
 my $here2 = File::Spec->catdir($t_dir, 'testlib2');

--- a/cpan/Pod-Simple/t/search22.t
+++ b/cpan/Pod-Simple/t/search22.t
@@ -14,10 +14,9 @@ $x->inc(0);
 $x->shadows(1);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here1 = File::Spec->catdir($t_dir, 'testlib1');
 my $here2 = File::Spec->catdir($t_dir, 'testlib2');

--- a/cpan/Pod-Simple/t/search25.t
+++ b/cpan/Pod-Simple/t/search25.t
@@ -16,10 +16,9 @@ $x->inc(0);
 $x->shadows(1);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here1 = File::Spec->catdir($t_dir, 'testlib1');
 my $here2 = File::Spec->catdir($t_dir, 'testlib2');

--- a/cpan/Pod-Simple/t/search26.t
+++ b/cpan/Pod-Simple/t/search26.t
@@ -18,10 +18,9 @@ $x->inc(0);
 $x->shadows(1);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here1 = File::Spec->catdir($t_dir, 'testlib1');
 my $here2 = File::Spec->catdir($t_dir, 'testlib2');

--- a/cpan/Pod-Simple/t/search27.t
+++ b/cpan/Pod-Simple/t/search27.t
@@ -13,10 +13,9 @@ $x->inc(0);
 $x->shadows(1);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here1 = File::Spec->catdir($t_dir, 'testlib1');
 my $here2 = File::Spec->catdir($t_dir, 'testlib2');

--- a/cpan/Pod-Simple/t/search28.t
+++ b/cpan/Pod-Simple/t/search28.t
@@ -13,10 +13,9 @@ $x->inc(0);
 $x->shadows(1);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here1 = File::Spec->catdir($t_dir, 'testlib1');
 my $here2 = File::Spec->catdir($t_dir, 'testlib2');

--- a/cpan/Pod-Simple/t/search29.t
+++ b/cpan/Pod-Simple/t/search29.t
@@ -13,10 +13,9 @@ $x->inc(0);
 $x->shadows(1);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here1 = File::Spec->catdir($t_dir, 'testlib1');
 my $here2 = File::Spec->catdir($t_dir, 'testlib2');

--- a/cpan/Pod-Simple/t/search50.t
+++ b/cpan/Pod-Simple/t/search50.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More skip_all => 'slow';
 
 #sub Pod::Simple::Search::DEBUG () {5};
 

--- a/cpan/Pod-Simple/t/search60.t
+++ b/cpan/Pod-Simple/t/search60.t
@@ -13,10 +13,9 @@ $x->inc(0);
 $x->is_case_insensitive(0);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $A = File::Spec->catdir($t_dir, 'search60', 'A');
 my $B = File::Spec->catdir($t_dir, 'search60', 'B');

--- a/cpan/Pod-Simple/t/xhtml01.t
+++ b/cpan/Pod-Simple/t/xhtml01.t
@@ -1,7 +1,7 @@
 # t/xhtml01.t - check basic output from Pod::Simple::XHTML
 use strict;
 use warnings;
-use Test::More tests => 64;
+use Test::More tests => 66;
 
 use_ok('Pod::Simple::XHTML') or exit;
 
@@ -11,7 +11,8 @@ isa_ok ($parser, 'Pod::Simple::XHTML');
 my $results;
 
 my $PERLDOC = "https://metacpan.org/pod";
-my $MANURL = "http://man.he.net/man";
+my $MANURL = "https://man7.org/linux/man-pages/man";
+my $MANURL_POSTFIX = ".html";
 
 initialize($parser, $results);
 $parser->parse_string_document( "=head1 Poit!" );
@@ -457,6 +458,27 @@ is($results, <<'EOHTML', 'multiparagraph nested lists');
 
 EOHTML
 
+
+initialize($parser, $results);
+$parser->parse_string_document(<<'EOPOD');
+=over
+
+Over section without any =item directives.
+
+=back
+
+EOPOD
+
+is($results, <<'EOHTML', 'multiparagraph nested lists');
+<blockquote>
+
+<p>Over section without any =item directives.</p>
+
+</blockquote>
+
+EOHTML
+
+
 initialize($parser, $results);
 $parser->parse_string_document(<<'EOPOD');
 =pod
@@ -622,6 +644,18 @@ is($results, <<"EOHTML", "File name in a paragraph");
 
 EOHTML
 
+initialize($parser, $results);
+$parser->parse_string_document(<<'EOPOD');
+=pod
+
+A plain paragraph with U<underlined text>.
+EOPOD
+is($results, <<"EOHTML", "Underlined text in a paragraph");
+<p>A plain paragraph with <u>underlined text</u>.</p>
+
+EOHTML
+
+
 # It's not important that 's (apostrophes) be encoded for XHTML output.
 initialize($parser, $results);
 $parser->parse_string_document(<<'EOPOD');
@@ -755,11 +789,11 @@ is $parser->resolve_pod_page_link('perlpod', 'this that'),
     'POD link with fragment with space';
 
 is $parser->resolve_man_page_link('crontab(5)', 'EXAMPLE CRON FILE'),
-    "${MANURL}5/crontab", 'Man link with fragment';
+    "${MANURL}5/crontab.5${MANURL_POSTFIX}", 'Man link with fragment';
 is $parser->resolve_man_page_link('crontab(5)'),
-    "${MANURL}5/crontab", 'Man link without fragment';
+    "${MANURL}5/crontab.5${MANURL_POSTFIX}", 'Man link without fragment';
 is $parser->resolve_man_page_link('crontab'),
-    "${MANURL}1/crontab", 'Man link without section';
+    "${MANURL}1/crontab.1${MANURL_POSTFIX}", 'Man link without section';
 
 # Make sure that batch_mode_page_object_init() works.
 ok $parser->batch_mode_page_object_init(0, 0, 0, 0, 6),

--- a/ext/Pod-Html/t/htmlview.t
+++ b/ext/Pod-Html/t/htmlview.t
@@ -107,7 +107,7 @@ my $module = My::Module-&gt;new();</code></pre>
 
 <p>The bar item.</p>
 
-<ul>
+<blockquote>
 
 <p>This is a list within a list</p>
 
@@ -119,7 +119,7 @@ my $module = My::Module-&gt;new();</code></pre>
 
 <p>The waz item.</p>
 
-</ul>
+</blockquote>
 
 </dd>
 <dt id="baz">baz</dt>

--- a/ext/Pod-Html/t/poderr.t
+++ b/ext/Pod-Html/t/poderr.t
@@ -55,7 +55,7 @@ __DATA__
 
 <p>Test POD ERROR section</p>
 
-<ul>
+<blockquote>
 
 <p>This text is not allowed</p>
 
@@ -67,7 +67,7 @@ __DATA__
 
 <p>The waz item.</p>
 
-</ul>
+</blockquote>
 
 <h1 id="POD-ERRORS">POD ERRORS</h1>
 

--- a/ext/Pod-Html/t/podnoerr.t
+++ b/ext/Pod-Html/t/podnoerr.t
@@ -55,7 +55,7 @@ __DATA__
 
 <p>Test POD ERROR section</p>
 
-<ul>
+<blockquote>
 
 <p>This text is not allowed</p>
 
@@ -67,7 +67,7 @@ __DATA__
 
 <p>The waz item.</p>
 
-</ul>
+</blockquote>
 
 
 </body>


### PR DESCRIPTION
From Changelog:

3.47 2025-05-15 Karl Williamson <khw@cpan.org>
        - No git-related files in MANIFEST  James Keenan++
        - Rename method and field to avoid conflicts  Graham Knop++
3.46 2025-05-12 Karl Williamson <khw@cpan.org>
        - XHTML: =over without =item should render as a blockquote Graham Knop++
        - Add support for underlined text U<> formatting Graham Knop++
        - Make 'temp' name checking more succinct Max Maischein++
        - github: fix and add tests  Lukas Mai++  rwp0++
        - Makefile.PL: add missing 'warnings' prereq  Lukas Mai++
        - Add select method compatible with Pod::Select  Graham Knop++
        - Modernize htmlbat.t, corpus.t  Lukas Mai++, Graham Knop++
        - Fix links, typos, acknowledgments  James Keenan++ rwp0++, Dan Book++
        - Add documentation on sublcassing  Graham Knop++
        - Fix version checking  Philippe Bruhat++
        - Fix version number  Thibault Duponchelle++
        - Use rel2abs instead of abs_path  Andrew Fresh++

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
TODO: fill description here

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
* This set of changes requires a perldelta entry, and I need help writing it.
* This set of changes does not require a perldelta entry.
