### PR TITLE
Mark clone_params_(del|new) as internal, not public API

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -6304,9 +6304,9 @@ EXop	|void	|dtrace_probe_phase					\
 Adpx	|PADOFFSET|alloccopstash|NN HV *hv
 CRp	|void * |any_dup	|NULLOK void *v 			\
 				|NN const PerlInterpreter *proto_perl
-ATop	|void	|clone_params_del					\
+CTop	|void	|clone_params_del					\
 				|NN CLONE_PARAMS *param
-ARTop	|CLONE_PARAMS *|clone_params_new				\
+CRTop	|CLONE_PARAMS *|clone_params_new				\
 				|NN PerlInterpreter * const from	\
 				|NN PerlInterpreter * const to
 Cip	|AV *	|cop_file_avn	|NN const COP *cop


### PR DESCRIPTION
See #22291

* This set of changes does not require a perldelta entry.
