### PR TITLE
Improve -Dx, -Dt etc output, especially in threaded builds

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -1093,6 +1093,123 @@ S_pm_description(pTHX_ const PMOP *pm)
     return desc;
 }
 
+
+/* S_get_sv_from_pad(): a helper function for op_dump().
+ *
+ * On threaded builds, try to find the SV indexed by the OP o (e.g. via
+ * op_targ or op_padix) at pad offset po.
+ * Since an op can be dumped at any time, there is no guarantee that the
+ * OP is associated with the current PL_curpad. So try to find the currently
+ * running CV or eval, and see if it contains the OP. Or if it's
+ * compile-time, see if the op is contained within one of the op subtrees
+ * on the parser stack.
+ *
+ * Return NULL if it can't be found.
+ *
+ * Since this may be called during debugging and things may not be in a
+ * sane state, be conservative, and if in doubt, return NULL.
+ */
+
+#ifdef USE_ITHREADS
+static SV *
+S_get_sv_from_pad(pTHX_ const OP *o, PADOFFSET po)
+{
+    PADLIST *padlist; /* declare early to work round compiler quirks */
+
+    if (!po)
+        return NULL;
+
+    CV *cv = NULL;
+
+    /* Find the root of the optree this op is embedded in. For a compiled
+     * sub, this root will typically be a leavesub or similar attached to
+     * a CV. If compiling, this may be a small subtree on the parser
+     * stack. Limit the number of hops, in case there is some sort of
+     * loop or other weirdness.
+     */
+    int n = 100;
+    OP *oproot = (OP*)o;
+    while (1) {
+        if (--n <= 0)
+            return NULL;
+        OP *p = op_parent(oproot);
+        if (!p)
+            break;
+        oproot = p;
+    }
+
+    /* We may be compiling; so first look for the op within the subtrees
+     * on the parse stack, if any */
+    if (PL_parser && PL_parser->stack) {
+        yy_stack_frame *ps;
+
+        for (ps = PL_parser->ps; ps > PL_parser->stack; ps--) {
+            if (ps->val.opval == oproot) {
+                cv = ps->compcv;
+                if (!cv)
+                    return NULL; /* this shouldn't actually happen */
+                goto got_cv;
+            }
+        }
+    }
+
+    /* Find the currently running CV or eval, if any, and see if our op
+     * is part of that CV's optree. If no contexts are found, we're
+     * probably running the main program.
+     */
+    I32 i;
+    for (i = cxstack_ix; i >= 0; i--) {
+        const PERL_CONTEXT * const cx = &cxstack[i];
+        switch (CxTYPE(cx)) {
+        default:
+            continue;
+        case CXt_EVAL:
+            if (CxTRY(cx)) /* eval { } doesn't have a separate optree */
+                continue;
+            cv = cxstack[i].blk_eval.cv;
+            /* XXX note that an EVAL's CV doesn't actually hold a pointer
+             * to the optree's root; we have to hope that PL_eval_root
+             * does instead */
+            if (!cv || !CvEVAL(cv) || oproot != PL_eval_root)
+                continue;
+            goto got_cv;
+        case CXt_SUB:
+            if (cx->cx_type & CXp_SUB_RE_FAKE)
+                continue;
+            /* FALLTHROUGH */
+        case CXt_FORMAT:
+            cv = cxstack[i].blk_sub.cv;
+            if (!cv || CvISXSUB(cv) || oproot != CvROOT(cv))
+                continue;
+            goto got_cv;
+        }
+    }
+
+    if (PL_main_cv && PL_main_root == oproot) {
+        cv = PL_main_cv;
+        goto got_cv;
+    }
+    return NULL;
+
+   /* Lookup the entry in the pad associated with this CV.
+    * Note that for SVs moved into the pad, they are shared at all pad
+    * depths, so we only have to look at depth 1 and not worry about
+    * CvDEPTH(). */
+   got_cv:
+    padlist = CvPADLIST(cv);
+    if (!padlist)
+        return NULL;
+    PAD *comppad = PadlistARRAY(padlist)[1];
+    if (!comppad)
+        return NULL;
+    SV **curpad = AvARRAY(comppad);
+    if (!curpad)
+        return NULL;
+    return curpad[po];
+}
+#endif
+
+
 /*
 =for apidoc pmop_dump
 
@@ -1346,15 +1463,21 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
     case OP_AELEMFAST:
     case OP_GVSV:
     case OP_GV:
+    {
+        GV *gv;
 #ifdef USE_ITHREADS
         S_opdump_indent(aTHX_ o, level, bar, file,
                         "PADIX = %" IVdf "\n", (IV)cPADOPo->op_padix);
+        gv = (GV*)S_get_sv_from_pad(aTHX_ o, cPADOPx(o)->op_padix);
 #else
-        S_opdump_indent(aTHX_ o, level, bar, file,
-            "GV = %" SVf " (0x%" UVxf ")\n",
-            SVfARG(S_gv_display(aTHX_ cGVOPo_gv)), PTR2UV(cGVOPo_gv));
+        gv = (GV*)cSVOPx(o)->op_sv;
 #endif
+        if (gv)
+            S_opdump_indent(aTHX_ o, level, bar, file,
+                "GV = %" SVf " (0x%" UVxf ")\n",
+                SVfARG(S_gv_display(aTHX_ gv)), PTR2UV(gv));
         break;
+    }
 
     case OP_MULTIDEREF:
     {
@@ -1388,15 +1511,23 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
          * op_relocate_sv() and indexed by op_targ.
          * XXX Currently the SV isn't relocated for OP_COREARGS.
          */
-        S_opdump_indent(aTHX_ o, level, bar, file,
-                            "OP_SV = 0x%" UVxf "\n", cSVOPo->op_sv);
+        {
+            SV *sv = cSVOPo->op_sv;
+            if (!sv) {
+                S_opdump_indent(aTHX_ o, level, bar, file,
+                            "OP_SV = 0x0\n");
 #ifdef USE_ITHREADS
-        /* SV is stored in the pad, and the right pad may not be active
-         * here, so skip dumping the SV */
-#else
-        S_opdump_indent(aTHX_ o, level, bar, file, "SV = %s\n",
-                        SvPEEK(cSVOP_sv));
+                sv = S_get_sv_from_pad(aTHX_ o, o->op_targ);
 #endif
+            }
+
+            if (sv)
+                S_opdump_indent(aTHX_ o, level, bar, file,
+                        "%s = %s (0x%" UVxf ")\n",
+                        cSVOPo->op_sv ? "OP_SV" : "SV",
+                        SvPEEK(sv),
+                        PTR2UV(sv));
+        }
         break;
 
     case OP_METHOD:             /* $obj->$foo             */
@@ -1406,19 +1537,40 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
     case OP_METHOD_SUPER:       /* $obj->SUPER::foo       */
     case OP_METHOD_REDIR:       /* $obj->BAR::foo         */
     case OP_METHOD_REDIR_SUPER: /* $obj->BAR::SUPER::foo  */
-#ifndef USE_ITHREADS
-        /* with ITHREADS, consts are stored in the pad, and the right pad
-         * may not be active here, so skip */
-        /* display method name (e.g. 'foo') */
-        S_opdump_indent(aTHX_ o, level, bar, file, "SV = %s\n",
-                        SvPEEK(cMETHOPo_meth));
-
-        /* display redirect class (e.g. 'BAR') */
-        if (optype == OP_METHOD_REDIR || optype == OP_METHOD_REDIR_SUPER) {
-            S_opdump_indent(aTHX_ o, level, bar, file, "RCLASS = %s\n",
-                        SvPEEK(cMETHOPo_rclass));
-        }
+        {
+            /* display method name (e.g. 'foo') */
+            SV *sv = cMETHOPo->op_u.op_meth_sv;
+            if (!sv) {
+                S_opdump_indent(aTHX_ o, level, bar, file,
+                            "OP_METH_SV = 0x0\n");
+#ifdef USE_ITHREADS
+                sv = S_get_sv_from_pad(aTHX_ o, o->op_targ);
 #endif
+            }
+
+            if (sv)
+                S_opdump_indent(aTHX_ o, level, bar, file,
+                        "%s = %s (0x%" UVxf ")\n",
+                        cMETHOPo->op_u.op_meth_sv ? "OP_METH_SV" : "METH",
+                        SvPEEK(sv),
+                        PTR2UV(sv));
+
+            if (optype == OP_METHOD_REDIR || optype == OP_METHOD_REDIR_SUPER) {
+                /* display redirect class (e.g. 'BAR') */
+#ifdef USE_ITHREADS
+                S_opdump_indent(aTHX_ o, level, bar, file,
+                    "RCLASS_TARG = %" IVdf "\n", (IV)cMETHOPo->op_rclass_targ);
+                sv = S_get_sv_from_pad(aTHX_ o, cMETHOPo->op_rclass_targ);
+#else
+                sv = cMETHOPo->op_rclass_sv;
+#endif
+                if (sv)
+                    S_opdump_indent(aTHX_ o, level, bar, file,
+                        "RCLASS = %s (0x%" UVxf ")\n",
+                        SvPEEK(sv),
+                        PTR2UV(sv));
+            }
+        }
         break;
 
     case OP_NULL:

--- a/dump.c
+++ b/dump.c
@@ -3519,15 +3519,40 @@ Perl_debop(pTHX_ const OP *o)
         break;
     case OP_GVSV:
     case OP_GV:
+    case OP_AELEMFAST:
+    case OP_RCATLINE:
         PerlIO_printf(Perl_debug_log, "(%" SVf ")",
                 SVfARG(S_gv_display(aTHX_ cGVOPo_gv)));
+        if (o->op_type == OP_AELEMFAST)
+          do_fast_ix:
+            PerlIO_printf(Perl_debug_log, "[%" IVdf "]",
+                (IV)(I8)o->op_private);
+        break;
+
+    case OP_METHOD_NAMED:       /* $obj->foo              */
+    case OP_METHOD_SUPER:       /* $obj->SUPER::foo       */
+    case OP_METHOD_REDIR:       /* $obj->BAR::foo         */
+    case OP_METHOD_REDIR_SUPER: /* $obj->BAR::SUPER::foo  */
+        PerlIO_printf(Perl_debug_log, "(%s)",
+                SvPEEK(cMETHOPo_meth));
+        if (   o->op_type == OP_METHOD_REDIR
+            || o->op_type == OP_METHOD_REDIR_SUPER)
+        {
+            PerlIO_printf(Perl_debug_log, "(%s)",
+                SvPEEK(cMETHOPo_rclass));
+        }
         break;
 
     case OP_PADSV:
     case OP_PADAV:
     case OP_PADHV:
     case OP_ARGELEM:
+    case OP_PADSV_STORE:
+    case OP_AELEMFAST_LEX:
+      do_lex:
         S_deb_padvar(aTHX_ o->op_targ, 1, 1);
+        if (o->op_type == OP_AELEMFAST_LEX)
+            goto do_fast_ix;
         break;
 
     case OP_PADRANGE:
@@ -3546,6 +3571,10 @@ Perl_debop(pTHX_ const OP *o)
         break;
 
     default:
+        if (   (PL_opargs[o->op_type] & OA_TARGLEX)
+            && (o->op_private & OPpTARGET_MY))
+          goto do_lex;
+
         break;
     }
     PerlIO_printf(Perl_debug_log, "\n");

--- a/dump.c
+++ b/dump.c
@@ -1399,15 +1399,25 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
 #endif
         break;
 
-    case OP_METHOD_NAMED:
-    case OP_METHOD_SUPER:
-    case OP_METHOD_REDIR:
-    case OP_METHOD_REDIR_SUPER:
+    case OP_METHOD:             /* $obj->$foo             */
+        break;
+
+    case OP_METHOD_NAMED:       /* $obj->foo              */
+    case OP_METHOD_SUPER:       /* $obj->SUPER::foo       */
+    case OP_METHOD_REDIR:       /* $obj->BAR::foo         */
+    case OP_METHOD_REDIR_SUPER: /* $obj->BAR::SUPER::foo  */
 #ifndef USE_ITHREADS
         /* with ITHREADS, consts are stored in the pad, and the right pad
          * may not be active here, so skip */
+        /* display method name (e.g. 'foo') */
         S_opdump_indent(aTHX_ o, level, bar, file, "SV = %s\n",
                         SvPEEK(cMETHOPo_meth));
+
+        /* display redirect class (e.g. 'BAR') */
+        if (optype == OP_METHOD_REDIR || optype == OP_METHOD_REDIR_SUPER) {
+            S_opdump_indent(aTHX_ o, level, bar, file, "RCLASS = %s\n",
+                        SvPEEK(cMETHOPo_rclass));
+        }
 #endif
         break;
 

--- a/dump.c
+++ b/dump.c
@@ -1478,6 +1478,7 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o,
     case OP_AELEMFAST:
     case OP_GVSV:
     case OP_GV:
+    case OP_RCATLINE:
     {
         GV *gv;
 #ifdef USE_ITHREADS
@@ -1519,6 +1520,7 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o,
     case OP_CONST:
     case OP_HINTSEVAL:
     case OP_COREARGS:
+    case OP_ANONCODE:
         /* an SVOP. On non-threaded builds, these OPs use op_sv to hold
          * the SV associated with the const / hints hash / op num.
          * On threaded builds, op_sv initially holds the SV, then at the

--- a/dump.c
+++ b/dump.c
@@ -1380,6 +1380,25 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
 
     case OP_CONST:
     case OP_HINTSEVAL:
+    case OP_COREARGS:
+        /* an SVOP. On non-threaded builds, these OPs use op_sv to hold
+         * the SV associated with the const / hints hash / op num.
+         * On threaded builds, op_sv initially holds the SV, then at the
+         * end of compiling the sub, the SV is moved into the pad by
+         * op_relocate_sv() and indexed by op_targ.
+         * XXX Currently the SV isn't relocated for OP_COREARGS.
+         */
+        S_opdump_indent(aTHX_ o, level, bar, file,
+                            "OP_SV = 0x%" UVxf "\n", cSVOPo->op_sv);
+#ifdef USE_ITHREADS
+        /* SV is stored in the pad, and the right pad may not be active
+         * here, so skip dumping the SV */
+#else
+        S_opdump_indent(aTHX_ o, level, bar, file, "SV = %s\n",
+                        SvPEEK(cSVOP_sv));
+#endif
+        break;
+
     case OP_METHOD_NAMED:
     case OP_METHOD_SUPER:
     case OP_METHOD_REDIR:
@@ -1391,6 +1410,7 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
                         SvPEEK(cMETHOPo_meth));
 #endif
         break;
+
     case OP_NULL:
         if (o->op_targ != OP_NEXTSTATE && o->op_targ != OP_DBSTATE)
             break;

--- a/dump.c
+++ b/dump.c
@@ -873,6 +873,12 @@ Perl_dump_sub(pTHX_ const GV *gv)
     dump_sub_perl(gv, FALSE);
 }
 
+
+/* forward decl */
+static void
+S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o);
+
+
 void
 Perl_dump_sub_perl(pTHX_ const GV *gv, bool justperl)
 {
@@ -901,7 +907,7 @@ Perl_dump_sub_perl(pTHX_ const GV *gv, bool justperl)
             PTR2UV(CvXSUB(cv)),
             (int)CvXSUBANY(cv).any_i32);
     else if (CvROOT(cv))
-        op_dump(CvROOT(cv));
+        S_do_op_dump_bar(aTHX_ 0, 0, Perl_debug_log, CvROOT(cv));
     else
         Perl_dump_indent(aTHX_ 0, Perl_debug_log, "<undef>\n");
 }
@@ -964,11 +970,6 @@ S_gv_display(pTHX_ GV *gv)
     return name;
 }
 
-
-
-/* forward decl */
-static void
-S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o);
 
 
 static void

--- a/dump.c
+++ b/dump.c
@@ -876,7 +876,8 @@ Perl_dump_sub(pTHX_ const GV *gv)
 
 /* forward decl */
 static void
-S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o);
+S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o,
+                    CV* rootcv);
 
 
 void
@@ -907,7 +908,7 @@ Perl_dump_sub_perl(pTHX_ const GV *gv, bool justperl)
             PTR2UV(CvXSUB(cv)),
             (int)CvXSUBANY(cv).any_i32);
     else if (CvROOT(cv))
-        S_do_op_dump_bar(aTHX_ 0, 0, Perl_debug_log, CvROOT(cv));
+        S_do_op_dump_bar(aTHX_ 0, 0, Perl_debug_log, CvROOT(cv), cv);
     else
         Perl_dump_indent(aTHX_ 0, Perl_debug_log, "<undef>\n");
 }
@@ -973,7 +974,8 @@ S_gv_display(pTHX_ GV *gv)
 
 
 static void
-S_do_pmop_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const PMOP *pm)
+S_do_pmop_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const PMOP *pm,
+                   CV* rootcv)
 {
     UV kidbar;
 
@@ -1013,7 +1015,7 @@ S_do_pmop_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const PMOP *pm)
             S_opdump_indent(aTHX_ (OP*)pm, level, bar, file, "PMf_REPL =\n");
             S_do_op_dump_bar(aTHX_ level + 2,
                 (kidbar|cBOOL(OpHAS_SIBLING(pm->op_pmreplrootu.op_pmreplroot))),
-                file, pm->op_pmreplrootu.op_pmreplroot);
+                file, pm->op_pmreplrootu.op_pmreplroot, rootcv);
         }
     }
 
@@ -1022,7 +1024,7 @@ S_do_pmop_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const PMOP *pm)
             S_opdump_indent(aTHX_ (OP*)pm, level, bar, file, "CODE_LIST =\n");
             S_do_op_dump_bar(aTHX_ level + 2,
                             (kidbar | cBOOL(OpHAS_SIBLING(pm->op_code_list))),
-                            file, pm->op_code_list);
+                            file, pm->op_code_list, rootcv);
         }
         else
             S_opdump_indent(aTHX_ (OP*)pm, level, bar, file,
@@ -1035,7 +1037,7 @@ void
 Perl_do_pmop_dump(pTHX_ I32 level, PerlIO *file, const PMOP *pm)
 {
     PERL_ARGS_ASSERT_DO_PMOP_DUMP;
-    S_do_pmop_dump_bar(aTHX_ level, 0, file, pm);
+    S_do_pmop_dump_bar(aTHX_ level, 0, file, pm, NULL);
 }
 
 
@@ -1107,13 +1109,16 @@ S_pm_description(pTHX_ const PMOP *pm)
  *
  * Return NULL if it can't be found.
  *
+ * Sometimes the caller *does* know what CV is being dumped; if so, it
+ * is passed as rootcv.
+ *
  * Since this may be called during debugging and things may not be in a
  * sane state, be conservative, and if in doubt, return NULL.
  */
 
 #ifdef USE_ITHREADS
 static SV *
-S_get_sv_from_pad(pTHX_ const OP *o, PADOFFSET po)
+S_get_sv_from_pad(pTHX_ const OP *o, PADOFFSET po, CV *rootcv)
 {
     PADLIST *padlist; /* declare early to work round compiler quirks */
 
@@ -1121,6 +1126,11 @@ S_get_sv_from_pad(pTHX_ const OP *o, PADOFFSET po)
         return NULL;
 
     CV *cv = NULL;
+
+    if (rootcv) {
+        cv = rootcv;
+        goto got_cv;
+    }
 
     /* Find the root of the optree this op is embedded in. For a compiled
      * sub, this root will typically be a leavesub or similar attached to
@@ -1296,10 +1306,14 @@ const char * const op_class_names[] = {
  * For heavily nested output, the level may exceed the number of bits
  * in bar; in this case the first few columns in the output will simply
  * not have a bar, which is harmless.
+ *
+ * rootcv is the CV (if any) whose CvROOT() is the root of the optree
+ * currently being dumped.
  */
 
 static void
-S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
+S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o,
+                 CV* rootcv)
 {
     const OPCODE optype = o->op_type;
 
@@ -1469,7 +1483,7 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
 #ifdef USE_ITHREADS
         S_opdump_indent(aTHX_ o, level, bar, file,
                         "PADIX = %" IVdf "\n", (IV)cPADOPo->op_padix);
-        gv = (GV*)S_get_sv_from_pad(aTHX_ o, cPADOPx(o)->op_padix);
+        gv = (GV*)S_get_sv_from_pad(aTHX_ o, cPADOPx(o)->op_padix, rootcv);
 #else
         gv = (GV*)cSVOPx(o)->op_sv;
 #endif
@@ -1518,7 +1532,7 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
                 S_opdump_indent(aTHX_ o, level, bar, file,
                             "OP_SV = 0x0\n");
 #ifdef USE_ITHREADS
-                sv = S_get_sv_from_pad(aTHX_ o, o->op_targ);
+                sv = S_get_sv_from_pad(aTHX_ o, o->op_targ, rootcv);
 #endif
             }
 
@@ -1545,7 +1559,7 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
                 S_opdump_indent(aTHX_ o, level, bar, file,
                             "OP_METH_SV = 0x0\n");
 #ifdef USE_ITHREADS
-                sv = S_get_sv_from_pad(aTHX_ o, o->op_targ);
+                sv = S_get_sv_from_pad(aTHX_ o, o->op_targ, rootcv);
 #endif
             }
 
@@ -1561,7 +1575,8 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
 #ifdef USE_ITHREADS
                 S_opdump_indent(aTHX_ o, level, bar, file,
                     "RCLASS_TARG = %" IVdf "\n", (IV)cMETHOPo->op_rclass_targ);
-                sv = S_get_sv_from_pad(aTHX_ o, cMETHOPo->op_rclass_targ);
+                sv = S_get_sv_from_pad(aTHX_ o, cMETHOPo->op_rclass_targ,
+                                        rootcv);
 #else
                 sv = cMETHOPo->op_rclass_sv;
 #endif
@@ -1651,7 +1666,7 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
     case OP_MATCH:
     case OP_QR:
     case OP_SUBST:
-        S_do_pmop_dump_bar(aTHX_ level, bar, file, cPMOPo);
+        S_do_pmop_dump_bar(aTHX_ level, bar, file, cPMOPo, rootcv);
         break;
     case OP_LEAVE:
     case OP_LEAVEEVAL:
@@ -1788,7 +1803,7 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
         for (kid = cUNOPo->op_first; kid; kid = OpSIBLING(kid))
             S_do_op_dump_bar(aTHX_ level,
                             (bar | cBOOL(OpHAS_SIBLING(kid))),
-                            file, kid);
+                            file, kid, rootcv);
     }
 }
 
@@ -1796,7 +1811,7 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o)
 void
 Perl_do_op_dump(pTHX_ I32 level, PerlIO *file, const OP *o)
 {
-    S_do_op_dump_bar(aTHX_ level, 0, file, o);
+    S_do_op_dump_bar(aTHX_ level, 0, file, o, NULL);
 }
 
 

--- a/ext/Devel-Peek/t/Peek.t
+++ b/ext/Devel-Peek/t/Peek.t
@@ -1607,10 +1607,11 @@ dumpindent is 4 at -e line 1.
                  |   
 7                +--gv SVOP(0xNNN) ===> 5 [entersub 0xNNN]
                      FLAGS = (SCALAR,SLABBED)
-                     GV_OR_PADIX
+                     OPT_PADIX
+                     GV = t::DumpProg (0xNNN)
 EODUMP
 
-    $e =~ s/GV_OR_PADIX/$threads ? "PADIX = 2" : "GV = t::DumpProg (0xNNN)"/e;
+    $e =~ s/^(\s+)OPT_PADIX\n/$threads ? "${1}PADIX = 2\n" : ""/me;
     $e =~ s/SVOP/PADOP/g if $threads;
     my $out = t::runperl
                  switches => ['-Ilib'],


### PR DESCRIPTION
This series of commits improves the way various OPs are displayed by Perl_op_dump() (as used by perl -Dx) and by Perl_debop() (as used by perl -Dt). 

In particular it tries, where possible, to display information about an SV or GV attached to the OP when that SV has been moved to the pad on threaded builds.


* This set of changes does not require a perldelta entry.
