### PR TITLE
Pass clone parameter to CLONE methods as a UV

### DIFF
--- a/ext/Hash-Util-FieldHash/FieldHash.xs
+++ b/ext/Hash-Util-FieldHash/FieldHash.xs
@@ -429,7 +429,7 @@ OUTPUT:
     RETVAL
 
 void
-CLONE(char* classname)
+CLONE(char* classname, ...)
 CODE:
     if (strEQ(classname, "Hash::Util::FieldHash")) {
         HUF_global(aTHX_ HUF_CLONE);

--- a/ext/Hash-Util-FieldHash/lib/Hash/Util/FieldHash.pm
+++ b/ext/Hash-Util-FieldHash/lib/Hash/Util/FieldHash.pm
@@ -5,7 +5,7 @@ use warnings;
 no warnings 'experimental::builtin';
 use builtin qw(reftype);
 
-our $VERSION = '1.27';
+our $VERSION = '1.28';
 
 use Exporter 'import';
 our %EXPORT_TAGS = (

--- a/pod/perlmod.pod
+++ b/pod/perlmod.pod
@@ -610,10 +610,10 @@ you need to do,
 like for example handle the cloning of non-Perl data, if necessary.
 C<CLONE> will be called once as a class method for every package that has it
 defined (or inherits it).  It will be called in the context of the new thread,
-so all modifications are made in the new area.  Currently CLONE is called with
-no parameters other than the invocant package name, but code should not assume
-that this will remain unchanged, as it is likely that in future extra parameters
-will be passed in to give more information about the state of cloning.
+so all modifications are made in the new area.  CLONE is called with
+the invocant package name and a C<CLONE_PARAMS*> cast into an integer. But in
+older releases no such argument was passed and code may have to take into
+account both cases (e.g. by giving it a default value).
 
 If you want to CLONE all objects you will need to keep track of them per
 package. This is simply done using a hash and Scalar::Util::weaken().

--- a/sv.c
+++ b/sv.c
@@ -16373,6 +16373,9 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
     /* Call the ->CLONE method, if it exists, for each of the stashes
        identified by sv_dup() above.
     */
+
+    SV *param_sv = newSVuv(PTR2UV(param));
+
     while(av_count(param->stashes) != 0) {
         HV* const stash = MUTABLE_HV(av_shift(param->stashes));
         GV* const cloner = gv_fetchmethod_autoload(stash, "CLONE", 0);
@@ -16380,16 +16383,21 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
             ENTER;
             SAVETMPS;
             PUSHMARK(PL_stack_sp);
-            rpp_extend(1);
+            rpp_extend(2);
             SV *newsv = newSVhek(HvNAME_HEK(stash));
             *++PL_stack_sp = newsv;
-            if (!rpp_stack_is_rc())
+            *++PL_stack_sp = param_sv;
+            if (rpp_stack_is_rc())
+                SvREFCNT_inc(param_sv);
+            else
                 sv_2mortal(newsv);
             call_sv(MUTABLE_SV(GvCV(cloner)), G_DISCARD);
             FREETMPS;
             LEAVE;
         }
     }
+
+    SvREFCNT_dec(param_sv);
 
     if (!(flags & CLONEf_KEEP_PTR_TABLE)) {
         ptr_table_free(PL_ptr_table);


### PR DESCRIPTION
Any CLONE method that needs to call `sv_clone()` and friends needs to pass this on as an argument.

On older releases such an argument would not be passed, so they would need to take it as an optional argument to work in both cases. E.g.

```
void CLONE(SV* classname, UV uv_params = 0)
CODE:
    CLONE_PARAMS* params = INT2PTR(params);
```

That means this change can break XS modules not taking the extra argument into account. Fortunately most modules have cargo-culted a CLONE(...) from perlxs so they're safe from this change.  A quick grep suggests only four CPAN dists are affected such, [Data::UUID](https://grep.metacpan.org/search?qci=&q=%5CbCLONE%5Cb&qft=.xs%2C%20%2A.c&qd=Data-UUID&=l2d_qifl=),  [Net::LDNS](https://grep.metacpan.org/search?qci=&q=%5CbCLONE%5Cb&qft=.xs&qd=Net-LDNS&=l2d_qifl=), [GObject](https://grep.metacpan.org/search?qci=&q=%5CbCLONE%5Cb&qft=.xs%2C%20%2A.c&qd=Glib&=l2d_qifl=&f=GObject.xs), and [Zonemaster::LDNS](https://grep.metacpan.org/search?qci=&q=%5CbCLONE%5Cb&qft=.xs%2C%20%2A.c&qd=Zonemaster-LDNS&=l2d_qifl=)


* This set of changes requires a perldelta entry, and I'll write it for 5.43 because adding it now will only cause merge conflicts.