### PR TITLE
Fix spelling and typos in pod files

### DIFF
--- a/pod/perldebguts.pod
+++ b/pod/perldebguts.pod
@@ -784,7 +784,7 @@ will be lost.
                              rules.
  REFFL            num 2      Match already matched string, using /li
                              rules.
- REFFU            num 2      Match already matched string, usng /ui.
+ REFFU            num 2      Match already matched string, using /ui.
  REFFA            num 2      Match already matched string, using /aai
                              rules.
 

--- a/pod/perlebcdic.pod
+++ b/pod/perlebcdic.pod
@@ -1581,7 +1581,7 @@ characters then apply:
 then C<sort()>.  If you have a choice, it's better to lowercase things
 to avoid the problems of the two Latin-1 characters whose uppercase is
 outside Latin-1: "E<yuml>" (small C<y WITH DIAERESIS>) and "E<micro>"
-(C<MICRO SIGN>).  If you do need to upppercase, you can; with a
+(C<MICRO SIGN>).  If you do need to uppercase, you can; with a
 Unicode-enabled Perl, do:
 
     tr/ÿ/\x{178}/;

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -7363,7 +7363,7 @@ required code itself had thrown an exception.
 
 The C<${^HOOK}{require__before}> hook may return a code reference, in
 which case the code reference will be executed (in an eval with the
-filname as a parameter) after the require completes. It will be executed
+filename as a parameter) after the require completes. It will be executed
 regardless of how the compilation completed, and even if the require
 throws a fatal exception.  The function may consult C<%INC> to determine
 if the require failed or not.  For instance the following code will print

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -4883,7 +4883,7 @@ in summary:
  rpp_xpush_1(sv)         XPUSHs(sv)
  rpp_xpush_2(sv1, sv2))  EXTEND(SP,2); PUSHs(sv1); PUSHs(sv2);
 
- rpp_push_1_norc(sv)     mPUSHs(sv)     // on RC bulds, skips RC++;
+ rpp_push_1_norc(sv)     mPUSHs(sv)     // on RC builds, skips RC++;
                                         // on non-RC builds, mortalises
  rpp_popfree_1()         (void)POPs;
  rpp_popfree_2()         (void)POPs; (void)POPs;

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -3760,7 +3760,7 @@ in a single byte.
 
 =head2 How do I compare strings?
 
-L<perlapi/sv_cmp> and L<perlapi/sv_cmp_flags> do a lexigraphic
+L<perlapi/sv_cmp> and L<perlapi/sv_cmp_flags> do a lexicographic
 comparison of two SVs, and handle UTF-8ness properly.  Note, however,
 that Unicode specifies a much fancier mechanism for collation, available
 via the L<Unicode::Collate> module.

--- a/pod/perlhack.pod
+++ b/pod/perlhack.pod
@@ -857,7 +857,7 @@ Run F<miniperl> on F<t/base>, F<t/comp>, F<t/cmd>, F<t/run>, F<t/io>,
 F<t/op>, F<t/uni> and F<t/mro> tests.
 
 F<miniperl> is a minimalistic perl built to bootstrap building
-extensions, utilties, documentation etc.  It doesn't support dynamic
+extensions, utilities, documentation etc.  It doesn't support dynamic
 loading and depending on the point in the build process will only have
 access to a limited set of core modules.  F<miniperl> is not intended
 for day to day use.

--- a/pod/perlhacktips.pod
+++ b/pod/perlhacktips.pod
@@ -385,7 +385,7 @@ Perl also has conflicts with that.
 
 Perl reserves for its use any symbol beginning with C<Perl>, C<perl>,
 or C<PL_>.  Any time you introduce a macro into a header file that
-doesn't follow that convention, you are creating the possiblity of a
+doesn't follow that convention, you are creating the possibility of a
 namespace clash with an existing XS module, unless you restrict it by,
 say,
 

--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -2642,7 +2642,7 @@ Unless the C</r> option is used, the string specified with C<=~> must be a
 scalar variable, an array element, a hash element, or an assignment to one
 of those; in other words, an lvalue.
 
-The characters delimitting I<SEARCHLIST> and I<REPLACEMENTLIST>
+The characters delimiting I<SEARCHLIST> and I<REPLACEMENTLIST>
 can be any printable character, not just forward slashes.  If they
 are single quotes (C<tr'I<SEARCHLIST>'I<REPLACEMENTLIST>'>), the only
 interpolation is removal of C<\> from pairs of C<\\>; so hyphens are

--- a/pod/perlopentut.pod
+++ b/pod/perlopentut.pod
@@ -364,7 +364,7 @@ the first example like this:
 When you call C<open> this way, Perl invokes the given command directly,
 bypassing the shell. As such, the shell won't try to interpret any
 special characters within the command's argument list, which might
-overwise have unwanted effects. This can make for safer, less
+otherwise have unwanted effects. This can make for safer, less
 error-prone C<open> calls, useful in cases such as passing in variables
 as arguments, or even just referring to filenames with spaces in them.
 

--- a/pod/perlopentut.pod
+++ b/pod/perlopentut.pod
@@ -235,7 +235,7 @@ Here's an example of how to copy a binary file:
 
     my $BUFSIZ   = 64 * (2 ** 10);
     my $name_in  = "/some/input/file";
-    my $name_out = "/some/output/flie";
+    my $name_out = "/some/output/file";
 
     my($in_fh, $out_fh, $buffer);
 
@@ -312,7 +312,7 @@ separate program, rather than an ordinary filehandle into a file.
 
 Note that the third argument to C<open> is a string containing the
 program name (C<sort>) plus all its arguments: in this case, C<-u> to
-specify unqiue sort, and then a fileglob specifying the files to sort.
+specify unique sort, and then a fileglob specifying the files to sort.
 The resulting filehandle C<$sort_fh> works just like a read-only (C<<
 "<" >>) filehandle, and your program can subsequently read data
 from it as if it were opened onto an ordinary, single file.

--- a/pod/perlreapi.pod
+++ b/pod/perlreapi.pod
@@ -660,7 +660,7 @@ values.
            the distinction between physical and logical capture buffers */
         U32 nparens;                    /* physical number of capture buffers */
         U32 logical_nparens;            /* logical_number of capture buffers */
-        I32 *logical_to_parno;          /* map logical parno to first physcial */
+        I32 *logical_to_parno;          /* map logical parno to first physical */
         I32 *parno_to_logical;          /* map every physical parno to logical */
         I32 *parno_to_logical_next;     /* map every physical parno to the next
                                            physical with the same logical id */

--- a/pod/perlrebackslash.pod
+++ b/pod/perlrebackslash.pod
@@ -195,7 +195,7 @@ sequences by using the L<charnames> module.  These custom names are
 lexically scoped, and so a given code point may have different names
 in different scopes.  The name used is what is in effect at the time the
 C<\N{}> is expanded.  For patterns in double-quotish context, that means
-at the time the pattern is parsed.  But for patterns that are delimitted
+at the time the pattern is parsed.  But for patterns that are delimited
 by single quotes, the expansion is deferred until pattern compilation
 time, which may very well have a different C<charnames> translator in
 effect.

--- a/pod/perlunicode.pod
+++ b/pod/perlunicode.pod
@@ -1135,7 +1135,7 @@ in any (single) script
  # digits.  When specifying a subset of these, we must include \d to
  # prevent things like U+00B2 SUPERSCRIPT TWO from matching
  my $zero_through_255 =
-  qr/ \b (*sr:                                  # All from same sript
+  qr/ \b (*sr:                                  # All from same script
             (?[ \p{nv=0} & \d ])*               # Optional leading zeros
         (                                       # Then one of:
                                   \d{1,2}       #   0 - 99
@@ -1541,7 +1541,7 @@ UTF-8.
 
 UTF-16, UTF-16BE, UTF-16LE, Surrogates, and C<BOM>'s (Byte Order Marks)
 
-The followings items are mostly for reference and general Unicode
+The following items are mostly for reference and general Unicode
 knowledge, Perl doesn't use these constructs internally.
 
 Like UTF-8, UTF-16 is a variable-width encoding, but where

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -76,7 +76,7 @@ names in the current package.  Some even have medium names, generally
 borrowed from B<awk>.  For more info, please see L<English>.
 
 Before you continue, note the sort order for variables.  In general, we
-first list the variables in case-insensitive, almost-lexigraphical
+first list the variables in case-insensitive, almost-lexicographical
 order (ignoring the C<{> or C<^> preceding words, as in C<${^UNICODE}>
 or C<$^T>), although C<$_> and C<@_> move up to the top of the pile.
 For variables with the same identifier, we list it in order of scalar,
@@ -1016,7 +1016,7 @@ Consider the following code:
 Notice that each successful match in the exact same scope overrides the
 match context of the previous successful match, but that unsuccessful
 matches do not. Also note that in an inner nested scope the previous
-state from an outer dynamic scope persists until it has been overriden
+state from an outer dynamic scope persists until it has been overridden
 by another successful match, but that when the inner nested scope exits
 whatever match context was in effect before the inner successful match
 is restored when the scope concludes.

--- a/regcomp.sym
+++ b/regcomp.sym
@@ -239,7 +239,7 @@ REFFL       REF,        num 2 V   ; Match already matched string, using /li rule
 # N?REFF[AU] could have been implemented using the FLAGS field of the
 # regnode, but by having a separate node type, we can use the existing switch
 # statement to avoid some tests
-REFFU       REF,        num 2 V   ; Match already matched string, usng /ui.
+REFFU       REF,        num 2 V   ; Match already matched string, using /ui.
 REFFA       REF,        num 2 V   ; Match already matched string, using /aai rules.
 
 #*Named references.  Code in regcomp.c assumes that these all are after

--- a/regexp.h
+++ b/regexp.h
@@ -157,7 +157,7 @@ typedef struct regexp {
        the distinction between physical and logical capture buffers */
     U32 nparens;                    /* physical number of capture buffers */
     U32 logical_nparens;            /* logical_number of capture buffers */
-    I32 *logical_to_parno;          /* map logical parno to first physcial */
+    I32 *logical_to_parno;          /* map logical parno to first physical */
     I32 *parno_to_logical;          /* map every physical parno to logical */
     I32 *parno_to_logical_next;     /* map every physical parno to the next
                                        physical with the same logical id */

--- a/regnodes.h
+++ b/regnodes.h
@@ -912,7 +912,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define REFFL_t8_p8                       303  /*      0x12f */
 
 #define REFFU                        76        /* 0x4c Match already matched
-                                                  string, usng /ui. */
+                                                  string, using /ui. */
 #define REFFU_tb                       152     /*      0x098 */
 #define REFFU_t8                       153     /*      0x099 */
 #define REFFU_tb_pb                       304  /*      0x130 */


### PR DESCRIPTION
I noticed a misspelling in a pod file, and then went through and found and fixed a few more.

Some parts of the pod files were generated, so I also updated comments in `regcomp.sym` & `regexp.h`, and ran `make regen`.

I imagine this is probably safe for 5.41.13.

* This set of changes does not require a perldelta entry.
