### PR TITLE
perlintern: my_cxt_init is not string handling

### DIFF
--- a/util.c
+++ b/util.c
@@ -5440,6 +5440,7 @@ Perl_my_clearenv(pTHX)
 #ifdef MULTIPLICITY
 
 /*
+=for apidoc_section $XS
 =for apidoc my_cxt_init
 
 Implements the L<perlxs/C<MY_CXT_INIT>> macro, which you should use instead.


### PR DESCRIPTION
Instead, the other cxt API elements are in XS


* This set of changes does not require a perldelta entry.
