### PR TITLE
Win32: htonl/htons/ntohl/ntohs change slow winsock exports -> 1 CPU op/ins

### DIFF
--- a/XSUB.h
+++ b/XSUB.h
@@ -603,10 +603,12 @@ Rethrows a previously caught exception.  See L<perlguts/"Exception Handling">.
 #    define signal		PerlProc_signal
 #    define getpid		PerlProc_getpid
 #    define gettimeofday	PerlProc_gettimeofday
+#ifndef PERL_MY_HOST_NET_BYTE_SWAP
 #    define htonl		PerlSock_htonl
 #    define htons		PerlSock_htons
 #    define ntohl		PerlSock_ntohl
 #    define ntohs		PerlSock_ntohs
+#endif
 #    define accept		PerlSock_accept
 #    define bind		PerlSock_bind
 #    define connect		PerlSock_connect

--- a/embed.fnc
+++ b/embed.fnc
@@ -6468,7 +6468,13 @@ p	|bool	|get_win32_message_utf8ness				\
 				|NULLOK const char *string
 Teor	|void	|win32_croak_not_implemented				\
 				|NN const char *fname
-#else
+# if !defined(PERL_MY_HOST_NET_BYTE_SWAP)
+DTbo	|u_long |win32_htonl	|u_long hostlong
+DTbo	|u_short|win32_htons	|u_short hostshort
+DTbo	|u_long |win32_ntohl	|u_long netlong
+DTbo	|u_short|win32_ntohs	|u_short netshort
+# endif
+#else /* if !defined(WIN32) */
 p	|bool	|do_exec3	|NN const char *incmd			\
 				|int fd 				\
 				|int do_report

--- a/iperlsys.h
+++ b/iperlsys.h
@@ -1144,10 +1144,12 @@ struct IPerlProcInfo
 /* PerlSock             */
 struct IPerlSock;
 struct IPerlSockInfo;
+#ifndef PERL_MY_HOST_NET_BYTE_SWAP
 typedef u_long          (*LPHtonl)(const struct IPerlSock**, u_long);
 typedef u_short         (*LPHtons)(const struct IPerlSock**, u_short);
 typedef u_long          (*LPNtohl)(const struct IPerlSock**, u_long);
 typedef u_short         (*LPNtohs)(const struct IPerlSock**, u_short);
+#endif
 typedef SOCKET          (*LPAccept)(const struct IPerlSock**, SOCKET,
                             struct sockaddr*, int*);
 typedef int             (*LPBind)(const struct IPerlSock**, SOCKET,
@@ -1208,10 +1210,12 @@ typedef int             (*LPClosesocket)(const struct  IPerlSock**, SOCKET s);
 
 struct IPerlSock
 {
+#ifndef PERL_MY_HOST_NET_BYTE_SWAP
     LPHtonl             pHtonl;
     LPHtons             pHtons;
     LPNtohl             pNtohl;
     LPNtohs             pNtohs;
+#endif
     LPAccept            pAccept;
     LPBind              pBind;
     LPConnect           pConnect;
@@ -1262,6 +1266,19 @@ struct IPerlSockInfo
     struct IPerlSock    perlSockList;
 };
 
+#ifdef PERL_MY_HOST_NET_BYTE_SWAP
+   /* perl.h has provides a much more efficient inlined implementation of
+      htonl(), htons(), ntohl(), ntohs() compared to the "native" exported
+      extern linkage functions exported by ws2_32.dll. Both Mingw GCCs
+      and MSVCs headers, only offer exports from ws2_32.dll for those 4
+      tokens, without any alternative. Writing "r = htonl(n);" a C Windows
+      app is an improper anti-pattern. The official, correct, identifier is
+      RtlUlongByteSwap() on the Windows Platform. */
+#  define PerlSock_htonl(x)             htonl(x)
+#  define PerlSock_htons(x)             htons(x)
+#  define PerlSock_ntohl(x)             ntohl(x)
+#  define PerlSock_ntohs(x)             ntohs(x)
+#else
 #  define PerlSock_htonl(x)                                             \
         ((*(PL_Sock))->pHtonl)(PL_Sock, x)
 #  define PerlSock_htons(x)                                             \
@@ -1270,6 +1287,8 @@ struct IPerlSockInfo
         ((*(PL_Sock))->pNtohl)(PL_Sock, x)
 #  define PerlSock_ntohs(x)                                             \
         ((*(PL_Sock))->pNtohs)(PL_Sock, x)
+#endif
+
 #  define PerlSock_accept(s, a, l)                                      \
         ((*(PL_Sock))->pAccept)(PL_Sock, s, a, l)
 #  define PerlSock_bind(s, n, l)                                        \

--- a/mathoms.c
+++ b/mathoms.c
@@ -883,6 +883,57 @@ Perl_utf8_to_uvchr(pTHX_ const U8 *s, STRLEN *retlen)
     return utf8_to_uvchr_buf(s, s + UTF8_CHK_SKIP(s), retlen);
 }
 
+/* These 4 exported functions are unused/deprecated/mathoms. WinPerl hooks
+   and replaces the htonl(), ntohl(), etc symbols provided by Mingw GCC and
+   MSVC headers, which are exported extern "C" functions from ws2_32.dll,
+   with 1 CPU instruction big, inline intrinsics. ws2_32.dll's implementation
+   is 11-15 instructions long. Clang and GCC for WinOS correctly convert
+   expression "& << |" to 1 CPU instruction, MSVC build numbers released prior
+   to Fall 2023 don't do that 1 CPU opcode optimization.
+   Because of frozen public API src code compatibility and object code linker
+   reasons, neither (Mingw or MS SDK) Clang, Mingw GCC or MSVC compilers can
+   correct the day 1 1993 mistake that tokens htonl(), ntohl(), etc, are
+   external linkage symbols from ws2_32.dll,
+
+   cpangrep shows exactly 1 module uses WinPerl's win32_*() prefixed sockets API
+   byte order swappers.
+
+   cpangrep: win32_htonl|win32_htons|win32_ntohl|win32_ntohs
+   https://metacpan.org/release/Prima/source/win32/files.c#L750
+
+   For now, these symbols are still exported, incase they are linked by a
+   XS .dll, that has a TU/.o/.c that doesn't #include "perl.h" and
+   declared function win32_htonl() themselves or they are using GetProcAddress(). */
+
+#undef win32_htonl
+#undef win32_htons
+#undef win32_ntohl
+#undef win32_ntohs
+
+u_long
+win32_htonl(u_long hostlong)
+{
+    return htonl(hostlong);
+}
+
+u_short
+win32_htons(u_short hostshort)
+{
+    return htons(hostshort);
+}
+
+u_long
+win32_ntohl(u_long netlong)
+{
+    return ntohl(netlong);
+}
+
+u_short
+win32_ntohs(u_short netshort)
+{
+    return ntohs(netshort);
+}
+
 GCC_DIAG_RESTORE
 
 #endif /* NO_MATHOMS */

--- a/perl.h
+++ b/perl.h
@@ -4571,23 +4571,61 @@ struct ptr_tbl {
     struct ptr_tbl_ent		*tbl_arena_end;
 };
 
-#if defined(htonl) && !defined(HAS_HTONL)
-#define HAS_HTONL
+/* Override the C compiler's built in byte order swapping functions and
+   implement our own BE/LE conversion functions. All modern CCs on all CPU archs
+   should be using an inline intrinsic, that maps to 1 CPU instructions, max 3.
+   Worst possible correct and incompetent implementation a C compiler can do:
+
+   libperl calls symbol htonl() through PLT/GOT to libc, libc then declares
+   stack 2 x unsigned char buf[4]; plus 2 calls through PLT/GOT to symbol
+   memcpy(); plus for( i=0; i<4; i++) {} loop.
+
+   Before defining PERL_MY_HOST_NET_BYTE_SWAP, remember to read the -O1 or -O2
+   optimized assembly code created by a production grade C compiler, to see
+   if there actually is a defect/flaw or not with the permutation of CC/CPU/OS
+   you are using. Don't accidentally turn 1 CPU op into 6 CPU ops, and document
+   that change as an "optimization".
+
+   The only known flawed CC is MSVC all versions and build numbers of
+   cl.exe/link.exe released to the pubic before Fall 2023. It has a 1 of 5
+   stars, if C token "htonl()" is used (perl uses Win32's PLT/GOT).
+   2 of 5 stars if "& << |" expression is used. Build numbers of MSVC released
+   during or after Fall 2023, produce correct and perfect machine code identical
+   to what GCC/Clang would emit. */
+
+#ifdef PERL_MY_HOST_NET_BYTE_SWAP
+#  undef htonl
+#  undef HAS_HTONL
+#  undef htons
+#  undef HAS_HTONS
+#  undef ntohl
+#  undef HAS_NTOHL
+#  undef ntohl
+#  undef HAS_NTOHL
+#  undef ntohs
+#  undef HAS_NTOHS
+#  undef htonll
+#  undef HAS_HTONLL
+#else
+#  if defined(htonl) && !defined(HAS_HTONL)
+#    define HAS_HTONL
+#  endif
+#  if defined(htons) && !defined(HAS_HTONS)
+#    define HAS_HTONS
+#  endif
+#  if defined(ntohl) && !defined(HAS_NTOHL)
+#    define HAS_NTOHL
+#  endif
+#  if defined(ntohs) && !defined(HAS_NTOHS)
+#    define HAS_NTOHS
+#  endif
 #endif
-#if defined(htons) && !defined(HAS_HTONS)
-#define HAS_HTONS
-#endif
-#if defined(ntohl) && !defined(HAS_NTOHL)
-#define HAS_NTOHL
-#endif
-#if defined(ntohs) && !defined(HAS_NTOHS)
-#define HAS_NTOHS
-#endif
+
 #ifndef HAS_HTONL
-#define HAS_HTONS
-#define HAS_HTONL
-#define HAS_NTOHS
-#define HAS_NTOHL
+#  define HAS_HTONS
+#  define HAS_HTONL
+#  define HAS_NTOHS
+#  define HAS_NTOHL
 #  if (BYTEORDER & 0xffff) == 0x4321
 /* Big endian system, so ntohl, ntohs, htonl and htons do not need to
    re-order their values. However, to behave identically to the alternative
@@ -4604,21 +4642,65 @@ struct ptr_tbl {
    that *declare* the various functions are still seen. If we declare our own
    htonl etc they will clash with the declarations in the Win32 headers.  */
 
+#    ifdef _MSC_VER
+#      pragma intrinsic(_byteswap_ulong)
+#      pragma intrinsic(_byteswap_ushort)
+#    endif
+
+#    if !defined(_MSC_VER) || (defined(_MSC_VER) && defined(DEBUGGING))
 PERL_STATIC_INLINE U32
 my_swap32(const U32 x) {
+#      ifdef _MSC_VER
+    return _byteswap_ulong(x);
+#      else
     return ((x & 0xFF) << 24) | ((x >> 24) & 0xFF)
         | ((x & 0x0000FF00) << 8) | ((x & 0x00FF0000) >> 8);
+#      endif
 }
 
 PERL_STATIC_INLINE U16
 my_swap16(const U16 x) {
-    return ((x & 0xFF) << 8) | ((x >> 8) & 0xFF);
-}
 
-#    define htonl(x)    my_swap32(x)
-#    define ntohl(x)    my_swap32(x)
-#    define ntohs(x)    my_swap16(x)
-#    define htons(x)    my_swap16(x)
+#      ifdef _MSC_VER
+    return _byteswap_ushort(x);
+#      else
+    return ((x & 0xFF) << 8) | ((x >> 8) & 0xFF);
+#      endif
+}
+#    endif
+
+/* all CCs except MSVC use the static inlines above, unoptimized MSVC Perl
+   built with -DDEBUGGING, also uses the statics above, to make single stepping
+   and breakpoints easier to use. MSVC's C/C++ front end parser does not
+   recogize the traditional "& << |" expression as a synonym for i386/x64/ARM's
+   byteswap CPU instruction. This MSVC bug was fixed in MSVC 2022 build number
+   19.37/17.7 released Aug 8 2023. All MSVC 2022 build numbers <= 19.36/17.6
+   have the bug. Explicitly tell MSVC to use the byte swap opcode solves the
+   problem. VC's _byteswap_ulong() is declared as an intrinsic function.
+   It will not cause multi-eval problems the way a macro would. So skip the
+   my_swap() wrappers.
+
+   TODO: add special casing for __bswap_32(), __builtin_bswap32(),
+   bswap_32(), cpu_to_be32(), swap32(), read_be32(), write_be32(), htobe32(),
+   OSSwapInt32(), and on April 1st, impliment RtlUlongByteSwap(). Remember to
+   the history and HW compatibility of each of these CC tokens before adding
+   them. If hello_world.c executes and the Desktop GUI works, the defaults
+   in Configure can't produce a binary that SIGILLs on 1 of 2 systems,
+   made 2 years apart, running the same OS version, after a copy paste or
+   cloud server deployment of a /usr/bin/perl file.
+*/
+
+#    if !defined(_MSC_VER) || (defined(_MSC_VER) && defined(DEBUGGING))
+#      define htonl(x)    my_swap32(x)
+#      define ntohl(x)    my_swap32(x)
+#      define ntohs(x)    my_swap16(x)
+#      define htons(x)    my_swap16(x)
+#    else
+#      define htonl(x)    _byteswap_ulong(x)
+#      define ntohl(x)    _byteswap_ulong(x)
+#      define ntohs(x)    _byteswap_ushort(x)
+#      define htons(x)    _byteswap_ushort(x)
+#    endif
 #  else
 #    error "Unsupported byteorder"
 /* The C pre-processor doesn't let us return the value of BYTEORDER as part of
@@ -4632,6 +4714,51 @@ my_swap16(const U16 x) {
    If you have a system with a different byte order, please see
    pod/perlhack.pod for how to submit a patch to add supporting code.
 */
+#  endif
+#endif
+
+#if defined(htonll) && !defined(HAS_HTONLL)
+#  define HAS_HTONLL
+#endif
+
+#ifndef HAS_HTONLL
+#  define HAS_HTONLL
+#  if (BYTEORDER & 0xffff) == 0x4321
+#    define ntohll(x)    ((x)&0xFFFFFFFFFFFFFFFF)
+#    define htonll(x)    ntohll(x)
+#  elif BYTEORDER == 0x1234 || BYTEORDER == 0x12345678
+#    ifdef _MSC_VER
+#      pragma intrinsic(_byteswap_uint64)
+#    endif
+
+#    if !defined(_MSC_VER) || (defined(_MSC_VER) && defined(DEBUGGING))
+PERL_STATIC_INLINE U64
+my_swap64(const U64 x) {
+#      ifdef _MSC_VER
+    return _byteswap_uint64(x);
+#      else
+/*  return ( ((x & 0xff00000000000000) >> 56) | ((x & 0x00ff000000000000) >> 40)
+           | ((x & 0x0000ff0000000000) >> 24) | ((x & 0x000000ff00000000) >> 8)
+           | ((x & 0x00000000ff000000) << 8)  | ((x & 0x0000000000ff0000) << 24)
+           | ((x & 0x000000000000ff00) << 40) | ((x & 0x00000000000000ff) << 56));
+    return ((U64)htonl(x & 0xFFFFFFFF) << 32) | htonl(x >> 32); */
+    U64 r;
+    r = (x & 0x00000000FFFFFFFF) << 32 | (x & 0xFFFFFFFF00000000) >> 32;
+    r = (r & 0x0000FFFF0000FFFF) << 16 | (r & 0xFFFF0000FFFF0000) >> 16;
+    r = (r & 0x00FF00FF00FF00FF) << 8  | (r & 0xFF00FF00FF00FF00) >> 8;
+    return r;
+#      endif
+}
+#    endif
+#    if !defined(_MSC_VER) || (defined(_MSC_VER) && defined(DEBUGGING))
+#      define htonll(x)    my_swap64(x)
+#      define ntohll(x)    my_swap64(x)
+#    else
+#      define htonll(x)    _byteswap_uint64(x)
+#      define ntohll(x)    _byteswap_uint64(x)
+#    endif
+#  else
+#    error "Unsupported byteorder"
 #  endif
 #endif
 

--- a/proto.h
+++ b/proto.h
@@ -11044,6 +11044,31 @@ win32_croak_not_implemented(const char *fname)
 # define PERL_ARGS_ASSERT_WIN32_CROAK_NOT_IMPLEMENTED \
         assert(fname)
 
+# if !defined(PERL_MY_HOST_NET_BYTE_SWAP)
+
+#   if !defined(NO_MATHOMS)
+PERL_CALLCONV u_long
+win32_htonl(u_long hostlong)
+        __attribute__deprecated__;
+#     define PERL_ARGS_ASSERT_WIN32_HTONL
+
+PERL_CALLCONV u_short
+win32_htons(u_short hostshort)
+        __attribute__deprecated__;
+#     define PERL_ARGS_ASSERT_WIN32_HTONS
+
+PERL_CALLCONV u_long
+win32_ntohl(u_long netlong)
+        __attribute__deprecated__;
+#     define PERL_ARGS_ASSERT_WIN32_NTOHL
+
+PERL_CALLCONV u_short
+win32_ntohs(u_short netshort)
+        __attribute__deprecated__;
+#     define PERL_ARGS_ASSERT_WIN32_NTOHS
+
+#   endif /* !defined(NO_MATHOMS) */
+# endif /* !defined(PERL_MY_HOST_NET_BYTE_SWAP) */
 #else /* if !defined(WIN32) */
 PERL_CALLCONV bool
 Perl_do_exec3(pTHX_ const char *incmd, int fd, int do_report)

--- a/win32/include/sys/socket.h
+++ b/win32/include/sys/socket.h
@@ -62,13 +62,17 @@ int win32_ioctlsocket (SOCKET s, long cmd, u_long *argp);
 int win32_getpeername (SOCKET s, struct sockaddr *name, int * namelen);
 int win32_getsockname (SOCKET s, struct sockaddr *name, int * namelen);
 int win32_getsockopt (SOCKET s, int level, int optname, char * optval, int *optlen);
+#ifndef PERL_MY_HOST_NET_BYTE_SWAP
 u_long win32_htonl (u_long hostlong);
 u_short win32_htons (u_short hostshort);
+#endif
 unsigned long win32_inet_addr (const char * cp);
 char * win32_inet_ntoa (struct in_addr in);
 int win32_listen (SOCKET s, int backlog);
+#ifndef PERL_MY_HOST_NET_BYTE_SWAP
 u_long win32_ntohl (u_long netlong);
 u_short win32_ntohs (u_short netshort);
+#endif
 int win32_recv (SOCKET s, char * buf, int len, int flags);
 int win32_recvfrom (SOCKET s, char * buf, int len, int flags,
                          struct sockaddr *from, int * fromlen);
@@ -109,10 +113,33 @@ void win32_endservent(void);
 
 /* direct to our version */
 
-#define htonl		win32_htonl
-#define htons		win32_htons
-#define ntohl		win32_ntohl
-#define ntohs		win32_ntohs
+#ifndef PERL_MY_HOST_NET_BYTE_SWAP
+
+/* Because of hysterical raisins involving Trumpet Winsock, force the POSIX
+   name, to redirect into perl5XX.dll, which goes through [unimplimented/NOOP]
+   iperlsys.h/CPerlHost emulation on threaded WinPerls, which then redirects to
+   ws2_32.dll's implementation.
+
+   No-thread WinPerl immediatly redirects to ws2_32.dll's implementation. */
+#  define htonl		win32_htonl
+#  define htons		win32_htons
+#  define ntohl		win32_ntohl
+#  define ntohs		win32_ntohs
+#else
+/* These 4 win32_*() prefixed byte swap functions are macros
+   if #include "perl.h" is done in a TU. A manual function declaration in
+   a Perl XS unaware TU/.c file, that is linked with another perl aware .xs TU.
+   Then both TUs are linked into a XSUB/DynaLoader/EU::PXS .dll, is the
+   theoretical BBC risk. Hence if a TU does #include "perl.h" they get the
+   macro, if the TU is Perl XS unaware but manually declared these byte swappers
+   that TU will wind up at the ws2_32.dll exported implementation. */
+
+#  define win32_htonl		htonl /* redirect to perl.h's very fast impl */
+#  define win32_htons		htons
+#  define win32_ntohl		ntohl
+#  define win32_ntohs		ntohs
+#endif
+
 #define inet_addr	win32_inet_addr
 #define inet_ntoa	win32_inet_ntoa
 

--- a/win32/perlhost.h
+++ b/win32/perlhost.h
@@ -1291,6 +1291,9 @@ const struct IPerlDir perlDir =
 
 
 /* IPerlSock */
+
+#ifndef PERL_MY_HOST_NET_BYTE_SWAP
+
 u_long
 PerlSockHtonl(const struct IPerlSock** piPerl, u_long hostlong)
 {
@@ -1318,6 +1321,8 @@ PerlSockNtohs(const struct IPerlSock** piPerl, u_short netshort)
     PERL_UNUSED_ARG(piPerl);
     return win32_ntohs(netshort);
 }
+
+#endif
 
 SOCKET PerlSockAccept(const struct IPerlSock** piPerl, SOCKET s, struct sockaddr* addr, int* addrlen)
 {
@@ -1607,10 +1612,12 @@ PerlSockIoctlsocket(const struct IPerlSock** piPerl, SOCKET s, long cmd, u_long 
 
 const struct IPerlSock perlSock =
 {
+#ifndef PERL_MY_HOST_NET_BYTE_SWAP
     PerlSockHtonl,
     PerlSockHtons,
     PerlSockNtohl,
     PerlSockNtohs,
+#endif
     PerlSockAccept,
     PerlSockBind,
     PerlSockConnect,

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -25,6 +25,17 @@
 #  define PERL_TEXTMODE_SCRIPTS
 #endif
 
+/* Don't use ws2_32.dll's extern "C" implementation of these 4 tokens.
+   perl.h's implementation of these is just a 1 CPU instruction big intrinsic.
+   ws2_32.dll's implementation is 13 CPU instructions long. Perl_pp_pack() and
+   Perl_pp_unpack() have no good rational, to transfer control flow to a TCPIP
+   driver. */
+#undef HAS_NTOHL
+#undef HAS_HTONL
+#undef HAS_HTONS
+#undef HAS_NTOHS
+#define PERL_MY_HOST_NET_BYTE_SWAP
+
 #if defined(PERL_IMPLICIT_SYS)
 #  define DYNAMIC_ENV_FETCH
 #  define HAS_GETENV_LEN

--- a/win32/win32sck.c
+++ b/win32/win32sck.c
@@ -316,32 +316,6 @@ convert_errno_to_wsa_error(int err)
 }
 #endif /* ERRNO_HAS_POSIX_SUPPLEMENT */
 
-u_long
-win32_htonl(u_long hostlong)
-{
-    return htonl(hostlong);
-}
-
-u_short
-win32_htons(u_short hostshort)
-{
-    return htons(hostshort);
-}
-
-u_long
-win32_ntohl(u_long netlong)
-{
-    return ntohl(netlong);
-}
-
-u_short
-win32_ntohs(u_short netshort)
-{
-    return ntohs(netshort);
-}
-
-
-
 SOCKET
 win32_accept(SOCKET s, struct sockaddr *addr, int *addrlen)
 {


### PR DESCRIPTION
This patch started when I saw this call stack while single stepping Storeable.pm/.xs. And to my horror, why on earth is Storeable.pm **trying to go on the WWW**. It has nothing to do with TCP/IP, or IP4/IP6. What Storeable.xs was really wanting to do is execute C function `htonl()` which is 100% okay safe sane normal. It wasn't trying to *go online*.

But for personal performance wishlist reasons, I don't want to see ws2_32.dll getting mapped into addr space just for that tiny `htonl` function.

```
>	ntdll.dll!LdrGetProcedureAddress ()	Unknown
  | KernelBase.dll!GetProcAddress()	Unknown
  | perl541.dll!__delayLoadHelper2(const ImgDelayDescr * pidd, __int64(*)() * ppfnIATEntry) Line 352	C++
  | perl541.dll!__tailMerge_ws2_32_dll ()	Unknown
  | Storable.dll!store_hash(interpreter * my_perl, stcxt * cxt, hv * hv) Line 2927	C
  | Storable.dll!store(interpreter * my_perl, stcxt * cxt, sv * sv) Line 4516	C
  | Storable.dll!do_store(interpreter * my_perl, _PerlIO * * f, sv * sv, int optype, int network_order, sv * * res) Line 4700	C
  | Storable.dll!XS_Storable_mstore(interpreter * my_perl, cv * cv) Line 7902	C
  | [Inline Frame] perl541.dll!Perl_rpp_invoke_xs(interpreter *) Line 1177	C++
  | perl541.dll!Perl_pp_entersub(interpreter * my_perl) Line 6529	C++
  | perl541.dll!Perl_runops_standard(interpreter * my_perl) Line 41	C++
  | perl541.dll!Perl_call_sv(interpreter * my_perl, sv * sv, long arg_flags) Line 3253	C++
  | threads.dll!S_jmpenv_run(interpreter * my_perl, int action, _ithread * thread, int * len_p, int * exit_app_p, int * exit_code_p) Line 521	C++
  | threads.dll!S_ithread_run(void * arg) Line 640	C++
  | kernel32.dll!BaseThreadInitThunk ()	Unknown
  | ntdll.dll!RtlUserThreadStart ()	Unknown
```

sample of how Storable.xs uses htonl

```
#ifdef HAS_HTONL
#define WLEN(x)                                                         \
    STMT_START {                                                        \
        ASSERT(sizeof(x) == sizeof(int), ("WLEN writing an int"));      \
        if (cxt->netorder) {                                            \
            int y = (int) htonl(x);                                     \
            if (!cxt->fio)                                              \
                MBUF_PUTINT(y);                                         \
            else if (PerlIO_write(cxt->fio,oI(&y),oS(sizeof(y))) != oS(sizeof(y))) \
                return -1;                                              \
        } else {                                                        \
            if (!cxt->fio)                                              \
                MBUF_PUTINT(x);                                         \
            else if (PerlIO_write(cxt->fio,oI(&x),                      \
                                  oS(sizeof(x))) != oS(sizeof(x)))      \
                return -1;                                              \
        }                                                               \
    } STMT_END
```

Next problem, after CPP hooking htonl() and its friends, to perl.h's backup implementation of htonl(), MSVC 2022 x64 -O1 was producing horrible machine code, instead of x64's `bswap` instruction.

```
  | ###########################################################
  | #  elif BYTEORDER == 0x1234 \|\| BYTEORDER == 0x12345678
  | #    define htonl(x)    st_my_swap32(x)
  | #    define ntohl(x)    st_my_swap32(x)
  |  
  | PERL_STATIC_INLINE U32
  | st_my_swap32(const U32 x) {
  | return ((x & 0xFF) << 24) \| ((x >> 24) & 0xFF)
  | \| ((x & 0x0000FF00) << 8) \| ((x & 0x00FF0000) >> 8);
  | }
  | ###########################################################
  | mov     ecx, [rbp+arg_18]
  | mov     edx, ecx
  | and     edx, 0FF0000h
  | mov     eax, ecx
  | shr     eax, 10h
  | or      edx, eax
  | mov     eax, ecx
  | shl     eax, 10h
  | and     ecx, 0FF00h
  | or      eax, ecx
  | shr     edx, 8
  | shl     eax, 8
  | or      edx, eax
  | mov     [rbp+Src], edx
  | test    r10, r10
  | jnz     short loc_180004B65
```

disassembling `ws2_32.dll`'s  htonl shows the same bad machine code as above. Here is a screenshot I found of someone else complaining about using the long Pure ISO C macro with  a modern MSVC CC. The flaw in this screenshot was a production grade `.a`/`.lib` compiled and distributed by another entity containing a `-Od` `-O0` machine code version of C++ ecosystem's htonl().

![msvc-odhtonl-failure](https://github.com/user-attachments/assets/e3db048d-e62a-47bb-8153-674d3318fc1a)

Strawberry/Mingw correctly recognizes the pure ISO C expression as a euphemism for the current CPU's arch specific endian/byte swap instruction, regardless of its ascii identifier name for that CPU. BUT WinPerl built with Strawberry/Mingw, still will execute PE symbol table's extern C `htonl()`  function ptr, if you type `htonl` in src code instead of typing the long Pure ISO C macro/expression. Ubuntu `libperl.so` doesnt import a htonl C linker symbol at all.

In writing and researching this PR on IRC there was a long talk
```
[22:06] <TonyC> https://godbolt.org/z/1bGh9eWsM both gcc and MSVC optimize it pretty well
```

The VC 2022 I have and the VC 2022 TonyC has, werent producing the same mach code output.

```
01[22:10] <bulk88> TonyC I wonder what build number of MSVC 2022 is being used by godbolt, since MS offical blog says they "fixed it" in November 2022 https://devblogs.microsoft.com/cppblog/a-tour-of-4-msvc-backend-improvements/
01[22:11] <bulk88> but in Feb 2023 users are complaining that blog article was BS and lies https://developercommunity.visualstudio.com/t/MSVC-Not-using-bswap-when-possible/917784
[22:12] <TonyC> you can select different versions from the compiler dropdown
01[22:18] <bulk88> https://godbolt.org/z/W79hxYG95 using MSVC 2022 latest, using the exact P5P blead code, I broke your example tony
01[22:18] <bulk88> P5P is using U8 and U16 const literal ints operands, your version is 100% U64 const literal ints
[22:22] <TonyC> you picked a 32-bit compiler, but even that gets it right if the parameter to g() is a U64 rather than U32
01[22:23] <bulk88> bswap op x86-32 was not a day 1 opcode, it was added in the release of the 486, so CC devs have a legit rational to never ever use the bswap opcode unless the end user tells the CC to do it
01[22:24] <bulk88> IDK how C lang spec, and ones compliment sign extend promotion, are involved in this
```

eventually the different mach code output between 2 people both with "VC 2022" mystery was solved using godbolt's collection of very many (monthly) point releases of MSVC 2022 as

```
01[22:28] <bulk88> MSVC x64  version 19.37  17.7 was the first build number that has the "perfection" 1 op code machine code
01[22:29] <bulk88> 19.36 and lower have the 10 op code medicore version
01[22:30] <bulk88>  build number Visual Studio 2022 version 17.7 was published on Aug 8th 2023
01[22:38] <bulk88> I have build number  19.36.32535 installed, therefore I have the bug
```

More research shows MS publicly want the public to write `_byteswap_uint64`, `_byteswap_ulong`, `_byteswap_ushort`, and not misuse/abuse functional calls from a source code compatibility layer in a C language TCPIP driver library (aka BSD sockets). 

So to fix everything, WinPerl, regardless of CC vendor, will always CPP hook from perl.h token `htonl` and its friends on WinOS, so the `htonl()` the linker symbol from `ws2_32.dll ` will never ever again be reachable from Perl in C. which forever, on WinOS, will always be coming from the export table. All MS CRT, past, present, and future, will forever use ascii name `byteswap_ulong` for what Linux API calls `htonl`. `byteswap_ulong()` on MSVC is both a CPU inline intrinsic, if you turn that intrinsic "on" during CC compile time, but it is also a real extern "C" function exported from `ucrtbase.dll`, for spec compliance/GetProcAddress/Linker symbol/`-O0 -Od` reasons.

The `ucrtbase.dll` version I found on my system is just as terrible as the `ws2_32.dll` version. MS devs in .c/.cpp lang probably wrote the CPU arch independent formal linker symbol extern "C" backup function using the same ` return ((x & 0xFF) << 24) | ((x >> 24) & 0xFF) | ((x & 0x0000FF00) << 8) | ((x & 0x00FF0000) >> 8); ` macro Perl is using.

```
; unsigned int __cdecl byteswap_ulong(unsigned int Long)
public _byteswap_ulong
_byteswap_ulong proc near
mov     eax, ecx
mov     r8d, 0FF00h
and     eax, r8d
mov     edx, ecx
shl     edx, 10h
add     eax, edx
mov     edx, ecx
shl     eax, 8
shr     edx, 8
and     edx, r8d
shr     ecx, 18h
add     eax, edx
add     eax, ecx
retn
_byteswap_ulong endp
```

Now after detangling `ws2_32.dll` from WinPerl, next problem to fix is `0.25 stars` codegen on VC 2022  build number 19.36 released May 16, 2023 and lower.

So to fix that codegen problem, just replace that long macro with `byteswap_ulong()` and
```
#    ifdef _MSC_VER
#      pragma intrinsic(_byteswap_ulong)
#      pragma intrinsic(_byteswap_ushort)
#    endif
```
Now all WinPerl binaries are identical to what all LinPerl binaries have been doing since forever. Bug is fixed, defect removed. End of story.

Now my commit above, I didn't fully think out certain parts and they need input from the public.

Is there any reason for WinPerl to ever again use **slow** `htonl()` from WinSock.dll for any reason?

Is this build option to revert back to  **slow** `htonl()`  in Windows only, a waste of screen space, tarball space, and repo space?

I am keeping the Win32 MSVC specific intrinsic logic in perl.h right next to the P5P Pure ISO C polyfill version instead the byte swaping backends living in 2 different .h files.

I also believe, there are Linux/Commercial Unix C compilers out there, that also have this optimization bug, where ` return ((x & 0xFF) << 24) | ((x >> 24) & 0xFF) | ((x & 0x0000FF00) << 8) | ((x & 0x00FF0000) >> 8); ` is not regexp-ed by the closed source Unix CC at compile time, into the appropriate 1 opcode line CPU instruction for whatever CPU arch that Unix is running on. I think this optimization was invented by GCC, copy-catted by Clang because of public outrage, and doesn't exist in any other open or closed source C compilers.

Its reasonable for the dev team of a C compiler, to assume, someone writing ` return ((x & 0xFF) << 24) | ((x >> 24) & 0xFF) | ((x & 0x0000FF00) << 8) | ((x & 0x00FF0000) >> 8); ` instead of reading the man page for their C compiler, is an incompetent fool and "We" (CC authors) will not correct such "user error/user incompetent" C code. `memcpy()/strlen()/memcmp()` are more reasonable to assume they can turn into 1 CPU opcode inline intrinsic, since all 3 are just "1 node/1 C struct/1 AST node" inside the C compiler.  ` return ((x & 0xFF) << 24) | ((x >> 24) & 0xFF) | ((x & 0x0000FF00) << 8) | ((x & 0x00FF0000) >> 8); `  requires a regexp inside the C compiler matching atleast "23 nodes/23 C structs/23 AST nodes" before doing the optimization to `bswap` instruction. Now the C compiler has an `O(n*23)` CPU usage problem from what used to be `O(1)`.

BTW, for `htons()` on i386/x64, its done with `roll16((U16) n, 8)` or `(U16)n = ((U16)n) >ROLL> 8;`, I dont think a `bswap16` exists on Intel CPUs. But remember folks, ISO C, has never, and never will add math operators roll, pop_count(), count_leading_0s(), **, and count_leading_1s().

`exp()` is a linker symbol, not a C math operator, please contact the authors of man page of `libc.so` to learn more about linker symbol `exp()`. Maybe it is an abbreviation of **expires** and opens `gdb` instantly when you call it and pauses the process.

I think its a very bad idea for perl.h to override htonl()/etc, 100% of the time, on all CCs and all CPUs and all OSes. Lets assume all CCs on earth do the RIGHT THING like GCC and Clang do, until some human uses a dis-assembler, and proves Foo C Compiler v0.0 -O2 did something wrong. The OS authors/OS .h authors/CC authors will always know more, and keep better routine maintenance and watch over what C token `htonl()` does under the hood on their own products/projects, than P5P volunteers can do.

But !!!! P5P can't predict what current or future CCs, and what future CPU archs, will need perl.h to re-implement `htonl()`, hence I'm leaving provisions that Perl on Linux/Android/Solaris/AIX/IBM Z/OS, will need the same hooking WinPerl needs.

My risk assessment is, ` return ((x & 0xFF) << 24) | ((x >> 24) & 0xFF) | ((x & 0x0000FF00) << 8) | ((x & 0x00FF0000) >> 8); ` will fail to optimize or fail to inline, in machine code of current or future RISCV CPUs and WASM CPUs. WASM is a real CPU ISA BTW. The spec was written so a hardware CPU can be lithographied  that runs un-recompile WASM  byte sequences right off the DDR ram sticks. ARM32 can execute the byte stream in unmodified `.class` disk files remember, if your load the correct DRM license key into the ARM CPU at runtime to enable the feature.

Also, the commit in this PR needs less src code comments.

But I don't know where and how to document this new "hooking htonl()" feature. 

- 1 large comment in 1 place, single line comments every where else?
- 1 large comment in 1 place, no comments anywhere else?
- alot of 1 line comments saying "go read PR # 987654"?

<details><summary>my failed attempt at humor that Im going to hide instead of deleting</summary>
What does "host" mean in the spec? Whose host, which address, which room and year in history?

What is "endianness" in ISO C?

Your app has lost the portability game, it is now aware of the OS Vendor's ascii string name and aware of the ascii string name of a CPU arch, which is a big no no to "portable" SW.  Remember Abstract OS v𝑖*⌃*²  changes the byteorder using an RNG of your C program and its integer math operators each time your create a new process to run it, to 1 of 8 possible byte orders for doing math using C type `uint32_t`. Write a unit test involving, `htonl()`, `memcpy()`,  `fwrite()`,  and a usb stick being walked between 2 random Linux or Unix systems anywhere on earth jkjk
</details>

commit msg below

---------------

Since day 1 of Win32/64, C symbols/tokens htonl(), htons(), ntohs(), and ntohs() have been extern "C" PE symbol table exported functions from ws2_32.dll. WinSock aka WinOS's front end public facing lib for TCP/IP along with alot of legacy support for a dozen other protocols that nobody remembers. These 4 functions do 1 things and 1 thing only, swap bytes around. Windows 16-64 has and forever will be a LE OS regardless of CPU archs/HW. Mixed endian systems don't exist. Undumping a process between BE/LE HW Unix boxes or any OS kernels doesn't exist.

Storable.xs and PP keywords pack/unpack heavily use these 4 functions, but they have nothing to do with ethernet, token ring, or TCPIP. All modern CPUs (i386/x64/ARM) have a dedicated CPU opcode for BE/LE swapping. x86 introduced the 32 bit/U32 bswap instruction with the release of the i486. U16 variables can use i386's "ror eax, 8" (bitwise roll 8 bits).

Both Mingw GCC and MSVC CCs, will never optimize htonl/htons/ntohl/ntohs to 1 opcode, ask for the C linker symbol, and you will get the linker symbol. So Storable.xs and PP pack/unpack on both CCs, are calling Winsock's exported functions to do the swap. This is slow. It has overhead.

MSVC 2022 CC binaries prior to build number 19.37 (released Aug 2023), don't even recognize "((x & 0xFF)<<24)|((x>>24) & 0xFF)|((x & 0x0000FF00) <<8)|((x & 0x00FF0000)>>8)" as a C level euphemism for "I want the byte swap CPU instruction".  To fix all this, hook the 4 functions with the CPP to prevent the 4 tokens from calling the Winsock export table implimentations. 2nd, with all MSVC CCs versions use the official proper MS specific way to do a "byte swap". Which is instrinsic function _byteswap_ulong(). Theoretically RtlUlongByteSwap() also exists, but its much less mentioned on MSDN and the general WWW, and lives in "wdm.h" which is intended for Ring 0 kernel drivers, so header clashes can occur now, or in the future, trying to use a Ring 0 .h in a mostly user mode .h #include chain.

Since _byteswap_ulong() is an intrinsic function and not a macro, S_my_swap32() isn't needed to prevent multi-eval problems.

htonll()/ntohll() were added simply because it was easy to write them. 2 different algorithms for htonll() are included, I picked the one with less C src code ops, but I didn't check if neither, 1 or the other, or both are auto-detected by GCC and Clang as a 64 bit byte-swap instrinsic request without formally asking for the instrinsic with a named identifier.

The vtable hooks that CPerlHost/iperlsys.h use to implement psuedo-fork and ithreads, also had to be disabled for the 4 functions. Or else XSUB.h will redirect all CPAN XS mods (not -DPERL_CORE !), to the CPerlHost and iperlsys.h vtables, which then redirect to winsock, negating this fix.

Other less-than-perfect CC/CPUs/OSes combos might be discovered in the future, so PERL_MY_HOST_NET_BYTE_SWAP define is cross OS and not Win32 specific. S_my_swap32() isn't being turned on for any OSes/CCs other than Mingw and MSVC on Win32, because "if it ain't broke, don't fix it". If the CCs and .h'es for Linux/Android/OSX are already perfect, if Perl attempts to hook, intercept, or use a token or identifier from 6 years ago, not 18 months ago, more harm (deoptimization) can happen that good. MSVC produced 11-15 CPU ops for S_my_swap32()'s "ISO C" macro, before VC 2022 19.37 Aug 2023. Winsock has the same exact machine code.

I'll assume MS/other major Windows corporate users, assumed that "ISO C" byte swap macro is fundamentally wrong, since acknowleging that endianness exists in IT, violates "ISO C", and that code base is now "some Vendor's C", so why fix htonl() or that long non-CPU arch specific macro, instead of the intrinsic? That program already is aware of OS and Vendor and platform names and isn't portable,

---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and I need help writing it. <<<<< TODO: THIS ONE

