### PR TITLE
scope.c S_save_scalar_at() pick right type from the start

### DIFF
--- a/scope.c
+++ b/scope.c
@@ -309,8 +309,11 @@ S_save_scalar_at(pTHX_ SV **sptr, const U32 flags)
     if (flags & SAVEf_KEEPOLDELEM)
         sv = osv;
     else {
-        sv  = (*sptr = newSV_type(SVt_NULL));
-        if (SvTYPE(osv) >= SVt_PVMG && SvMAGIC(osv))
+        U8 old_type = SvTYPE(osv);
+        bool is_mg = old_type >= SVt_PVMG && SvMAGIC(osv);
+        sv  = (*sptr = newSV_type(is_mg && /* GV*s can't circulate with all nulls */
+            (old_type == SVt_PVMG || old_type == SVt_PVLV) ? old_type : SVt_NULL));
+        if (is_mg)
             mg_localize(osv, sv, cBOOL(flags & SAVEf_SETMAGIC));
     }
 


### PR DESCRIPTION
-type PVGV and GV* API will eventually SEGV through GvNAME and PP tie
 so bounds limit it to the 2 scalar string types, that are capable of MG
 and not any other higher order aggregate types

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
