### PR TITLE
op/readline_nb: non-threaded win32 croaks instead of failing on ioctl…

### DIFF
--- a/t/op/readline_nb.t
+++ b/t/op/readline_nb.t
@@ -9,6 +9,9 @@ BEGIN {
     skip_all_if_miniperl();
 }
 
+$^O eq "MSWin32"
+    and skip_all("Win32 can't make a pipe non-blocking");
+
 use strict;
 use IO::Select;
 


### PR DESCRIPTION
…(nonsocket)

And since it never succeeds on Win32, just skip.

Fixes #23335


---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
