### PR TITLE
ExtUtils-CBuilder: fix test failure when CXX env var is set

### DIFF
--- a/dist/ExtUtils-CBuilder/t/03-cplusplus.t
+++ b/dist/ExtUtils-CBuilder/t/03-cplusplus.t
@@ -61,6 +61,8 @@ if ($^O eq 'VMS') {
 }
 
 {
+    local $ENV{CXX};
+    delete $ENV{CXX};
     # GH #23146
     my $fake_cc = File::Spec->rel2abs(File::Spec->catfile(qw(some directory what doesnt exist), 'cc'));
     my $cb = ExtUtils::CBuilder->new(


### PR DESCRIPTION
The test is checking how searching for a C++ compiler behaves, so ignoring an external CXX environment variable is appropriate.

Fixes #23277