### PR TITLE
factor out 3 high usage COND_*() API croak() messages on Win32

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -6463,6 +6463,9 @@ Cp	|int	|do_spawn	|NN char *cmd
 Cp	|int	|do_spawn_nowait|NN char *cmd
 #endif
 #if defined(WIN32)
+TXpr	|void	|die_cbrod
+TXpr	|void	|die_csig
+TXpr	|void	|die_cwait
 CRTdp	|void * |get_context
 p	|bool	|get_win32_message_utf8ness				\
 				|NULLOK const char *string

--- a/embed.h
+++ b/embed.h
@@ -1767,6 +1767,9 @@
 #     define quadmath_format_valid              Perl_quadmath_format_valid
 #   endif
 #   if defined(WIN32)
+#     define die_cbrod                          Perl_die_cbrod
+#     define die_csig                           Perl_die_csig
+#     define die_cwait                          Perl_die_cwait
 #     define get_win32_message_utf8ness(a)      Perl_get_win32_message_utf8ness(aTHX_ a)
 #   else
 #     define do_exec3(a,b,c)                    Perl_do_exec3(aTHX_ a,b,c)

--- a/proto.h
+++ b/proto.h
@@ -11028,6 +11028,21 @@ Perl_do_spawn_nowait(pTHX_ char *cmd);
 
 #endif /* defined(VMS) || defined(WIN32) */
 #if defined(WIN32)
+PERL_CALLCONV_NO_RET void
+Perl_die_cbrod(void)
+        __attribute__noreturn__;
+# define PERL_ARGS_ASSERT_DIE_CBROD
+
+PERL_CALLCONV_NO_RET void
+Perl_die_csig(void)
+        __attribute__noreturn__;
+# define PERL_ARGS_ASSERT_DIE_CSIG
+
+PERL_CALLCONV_NO_RET void
+Perl_die_cwait(void)
+        __attribute__noreturn__;
+# define PERL_ARGS_ASSERT_DIE_CWAIT
+
 PERL_CALLCONV void *
 Perl_get_context(void)
         __attribute__warn_unused_result__;

--- a/util.c
+++ b/util.c
@@ -2004,6 +2004,47 @@ Perl_croak_popstack(void)
     my_exit(1);
 }
 
+
+/* Helpers for COND_BROADCAST(c), COND_SIGNAL(c), and COND_WAIT(c) macros
+   which are long and verbose, and get embedded directly in their callers
+   and have dozens of callsites inside libperl and certain categories of
+   CPAN XS modules. The other COND_*() macros are very unlikely to ever
+   be used outside of libperl's perl_construct()/perl_destruct().
+
+   The pthreads variants of COND_BROADCAST/COND_SIGNAL/COND_WAIT currently
+   have assert() style error strings that are too big to factor out. */
+
+#ifdef WIN32
+
+STATIC void
+Perl_die_w32err(const char *context)
+{
+    DWORD e = GetLastError();
+    Perl_croak_nocontext("panic: %s (%ld)", context, e);
+}
+
+/* These 3 helpers prevent the same const C string literals appearing in many
+   .dll files over and over. */
+void
+Perl_die_cbrod(void)
+{
+    Perl_die_w32err("COND_BROADCAST");
+}
+
+void
+Perl_die_cwait(void)
+{
+    Perl_die_w32err("COND_WAIT");
+}
+
+void
+Perl_die_csig(void)
+{
+    Perl_die_w32err("COND_SIGNAL");
+}
+
+#endif
+
 /*
 =for apidoc warn_sv
 

--- a/win32/win32thread.h
+++ b/win32/win32thread.h
@@ -21,6 +21,10 @@ typedef CRITICAL_SECTION perl_mutex;
 
 #else
 
+/* This backend is unused since
+   commit d55594aef6 - Gurusamy Sarathy - 11/9/1997 7:57:53 PM
+   Initial (untested) merge of all non-ansi changes on ansiperl branch */
+
 typedef HANDLE perl_mutex;
 #  define MUTEX_INIT(m) \
     STMT_START {						\
@@ -46,7 +50,7 @@ typedef HANDLE perl_mutex;
             Perl_croak_nocontext("panic: MUTEX_DESTROY");	\
     } STMT_END
 
-#endif
+#endif /* DONT_USE_CRITICAL_SECTION */
 
 /* These macros assume that the mutex associated with the condition
  * will always be held before COND_{SIGNAL,BROADCAST,WAIT,DESTROY},
@@ -57,21 +61,21 @@ typedef HANDLE perl_mutex;
         (c)->waiters = 0;					\
         (c)->sem = Win_CreateSemaphore(NULL,0,LONG_MAX,NULL);	\
         if ((c)->sem == NULL)					\
-            Perl_croak_nocontext("panic: COND_INIT (%ld)",GetLastError());	\
+            Perl_die_cwait();	\
     } STMT_END
 
 #define COND_SIGNAL(c) \
     STMT_START {						\
         if ((c)->waiters > 0 &&					\
             ReleaseSemaphore((c)->sem,1,NULL) == 0)		\
-            Perl_croak_nocontext("panic: COND_SIGNAL (%ld)",GetLastError());	\
+            Perl_die_csig();	\
     } STMT_END
 
 #define COND_BROADCAST(c) \
     STMT_START {						\
         if ((c)->waiters > 0 &&					\
             ReleaseSemaphore((c)->sem,(c)->waiters,NULL) == 0)	\
-            Perl_croak_nocontext("panic: COND_BROADCAST (%ld)",GetLastError());\
+            Perl_die_cbrod();\
     } STMT_END
 
 #define COND_WAIT(c, m) \
@@ -82,7 +86,7 @@ typedef HANDLE perl_mutex;
          * COND_BROADCAST() on another thread will have seen the\
          * right number of waiters (i.e. including this one) */	\
         if (WaitForSingleObject((c)->sem,INFINITE)==WAIT_FAILED)\
-            Perl_croak_nocontext("panic: COND_WAIT (%ld)",GetLastError());	\
+            Perl_die_cwait();	\
         /* XXX there may be an inconsequential race here */	\
         MUTEX_LOCK(m);						\
         (c)->waiters--;						\


### PR DESCRIPTION
- high usage in perl5xx.dll and because these are macros, high usage in both P5P/.git and CPAN XS .dll of a certain category.
- pthreads variants of COND_*(), have error messages that are too long and too detailed for me to think its worth it in this commit. They pass a minimum of 2 arguments best case scenario, __ FILE ___ and __ LINE __. In addition, it isn't my native OS. Changing the pthread variants is best for another day.
- C sym names are spelled as short as possible to not waste space in each .dll file's Import table. Embedding C literal "COND_WAIT" in each XS .dll vs importing const global data var "PL_COND_WAIT" through the PE symbol table, for such a short string, starts to have a trade off debate. See PR associated with this commit for details & rejected optimizations.
---------------------------------------------------------------------------------
"COND_WAIT"10+6_pading_to_eight+7_load_eff_addr_PIC_U32+5_call_fn_PIC_U32

 is very close in size to

"Perl_die_cwait"15+4_PIC_RVA+4_PIC_RVA+5_call_PIC_U32

but

5_call_PIC_U32 x 5 call_sites_per_dll

is smaller vs

(7_load_eff_addr_PIC_U32 + 5_call_fn_PIC_U32 ) x 5 call_sites_per_dll

I also considered a `PL_die_cond[3]` array of 3 function pointers for a short time, but IIRC some permutation of `(MSVC || GCC || Both) && (C89_C99 || C++ || Both)` prohibits `declspec noreturn` or `attribute noreturn` on a function pointer [data] type. No return vtable methods are plain illegal or longer version "this TC ballot proposal was already rejected 10x, you are now rejected" *[that dev is an idiot]*.


Even if I know how to get MSVC or GCC to break its own C/C++ grammar and machine code generate rules, to truly eliminate the stack cleanup epilog after each no return function pointer call. That war crime I did doesn't look like best-in-class production quality C code, so I'm not putting what I did in a PR intended for widespread use FOSS SW.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
