### PR TITLE
Clean up PL_strtab hash with NULL in perl_destruct

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1223,6 +1223,7 @@ Robert Spier                   <rspier@pobox.com>
 Roberto C. Sanchez             <roberto@connexer.com>
 Robin Barker                   <RMBarker@cpan.org>
 Robin Houston                  <robin@cpan.org>
+Robin Ragged                   <robin.ragged@paranoici.org>
 Rocco Caputo                   <troc@netrus.net>
 Roderick Schertler             <roderick@argon.org>
 Rodger Anderson                <rodger@boi.hp.com>

--- a/perl.c
+++ b/perl.c
@@ -1389,6 +1389,7 @@ perl_destruct(pTHXx)
         HvTOTALKEYS(PL_strtab) = 0;
     }
     SvREFCNT_dec(PL_strtab);
+    PL_strtab = NULL;
 
 #ifdef USE_ITHREADS
     /* free the pointer tables used for cloning */


### PR DESCRIPTION
As it's not required to pre-allocate PL_strtab hash before perl_construct() and PL_strtab is not initialized with NULL by default, SIGSEGV could happen in certain circumstances.

Particularly, when application links libperl and compiled with ASAN. PL_strtab remains unitialized as at start-up it contains garbage and initialization in perl_construct() is skipped because !PL_strtab check is skipped.

See also: c82f4881ef (Allow custom PL_strtab hash in perl_construct.)

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
Crash log may look like this:
```
ASAN_OPTIONS=report_globals=0:detect_leaks=1:handle_segv=1:handle_sigbus=1:handle_abort=1 ./fuzz -jobs=1 -runs=1 -seed=666 </dev/null
./fuzz -runs=1 -seed=666 >fuzz-0.log 2>&1
================== Job 0 exited with exit code 1 ============
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 666
INFO: A corpus is not provided, starting from an empty corpus
AddressSanitizer:DEADLYSIGNAL
=================================================================
==22328==ERROR: AddressSanitizer: SEGV on unknown address 0x000000081880 (pc 0x5599c1528155 bp 0x7ffe87a38d70 sp 0x7ffe87a38d00 T0)
==22328==The signal is caused by a READ memory access.
    #0 0x5599c1528155 in S_share_hek_flags /mnt/downloads/temp/_code/PERL/perl5/hv.c:3426:11
    #1 0x5599c15280ce in Perl_share_hek /mnt/downloads/temp/_code/PERL/perl5/hv.c:3399:12
    #2 0x5599c168db46 in Perl_newSVpvn_share /mnt/downloads/temp/_code/PERL/perl5/sv.c:9923:5
    #3 0x5599c14eca43 in S_init_main_stash /mnt/downloads/temp/_code/PERL/perl5/perl.c:4140:20
    #4 0x5599c14e88a0 in S_parse_body /mnt/downloads/temp/_code/PERL/perl5/perl.c:2223:5
    #5 0x5599c14e81b1 in perl_parse /mnt/downloads/temp/_code/PERL/perl5/perl.c:1932:9
...
```
<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
