### PR TITLE
maint-5.38: porting test failure; must run make regen

### DIFF
--- a/uconfig.h
+++ b/uconfig.h
@@ -108,7 +108,7 @@
 /*#define HAS_FCNTL		/ **/
 
 /* HAS_FDOPENDIR:
- * This symbol, if defined, indicates that the fdopen routine is
+ * This symbol, if defined, indicates that the fdopendir routine is
  * available to open a directory descriptor.
  */
 /*#define HAS_FDOPENDIR		/ **/
@@ -5388,6 +5388,6 @@
 #endif
 
 /* Generated from:
- * c796c0132aa033f4707372996512746e1e011e74dea6362470008afc9fbc6d6c config_h.SH
+ * 4cfa1b44dbf1bf89d68499a49713f020f11d1a6c812073902b43e2d61cc2721b config_h.SH
  * da4c4a7e80d19de664a97a9ed97e2a362b015a320553fa72ec4b98e57dee58c3 uconfig.sh
  * ex: set ro ft=c: */


### PR DESCRIPTION
When smoke-testing the maint-5.38 branch on FreeBSD-14, I got failures in each run of `t/porting/regen.t`.  See: https://perl.develop-help.com/db/5514634.

The individual test failure looks like this:
```
$ cd t;./perl harness -v porting/regen.t; cd -

ok 1 - generated keywords.c is up to date
ok 2 - generated keywords.h is up to date
ok 3 - generated perly.act is up to date
ok 4 - generated perly.h is up to date
ok 5 - generated perly.tab is up to date
ok 6 - generated charclass_invlists.h is up to date
ok 7 - generated uni_keywords.h is up to date
not ok 8 - generated uconfig.h is up to date
# Failed test 8 - generated uconfig.h is up to date at porting/regen.t line 122
#      got "config_h.SH"
# expected ""
ok 9 - generated regcharclass.h is up to date
```
I confirmed this failure on Ubuntu Linux.

Running `make regen` updated `uconfig.h` and appears to have fixed the test failures.  (This problem appears to be just on maint-5.38, not maint-5.40.)  Please review.