### PR TITLE
Make OP_DEFINED eligible for constant folding

### DIFF
--- a/op.c
+++ b/op.c
@@ -5011,6 +5011,12 @@ S_fold_constants(pTHX_ OP *const o)
         if (cUNOPx(cUNOPo->op_first)->op_first->op_type != OP_CONST
          || SvPADTMP(cSVOPx_sv(cUNOPx(cUNOPo->op_first)->op_first)))
             goto nope;
+        break;
+    case OP_DEFINED:
+        if ( (cUNOPo->op_first->op_type != OP_CONST)
+          || cUNOPo->op_first->op_moresib )
+            goto nope;
+        break;
     }
 
     if (PL_parser && PL_parser->error_count)

--- a/opcode.h
+++ b/opcode.h
@@ -1915,7 +1915,7 @@ EXTCONST U32 PL_opargs[] INIT({
 	0x00009b8c,	/* schop */
 	0x00002b1d,	/* chomp */
 	0x00009b9c,	/* schomp */
-	0x00009b84,	/* defined */
+	0x00009b86,	/* defined */
 	0x0000fb04,	/* undef */
 	0x00009b84,	/* study */
 	0x0000fb8c,	/* pos */

--- a/regen/opcodes
+++ b/regen/opcodes
@@ -101,7 +101,7 @@ chop		chop			ck_spair	mts%	L
 schop		scalar chop		ck_null		stu%	S?
 chomp		chomp			ck_spair	mTs%	L
 schomp		scalar chomp		ck_null		sTu%	S?
-defined		defined operator	ck_defined	isu%	S?
+defined		defined operator	ck_defined	ifsu%	S?
 undef		undef operator		ck_fun		s%	R?
 study		study			ck_fun		su%	S?
 pos		match position		ck_fun		stu%	R?

--- a/t/perf/opcount.t
+++ b/t/perf/opcount.t
@@ -1106,4 +1106,12 @@ test_opcount(0, "substr with const zero offset  (gv)",
                     sassign      => 1
                 });
 
+# defined(SOMECONST) gets constant folded
+test_opcount(0, "defined(ABC) gets constant folded",
+                sub { use constant ABC => 1; my $x = (defined(ABC)) ? 1 : 0 },
+                {
+                    cond_expr    => 0,
+                    defined      => 0,
+                });
+
 done_testing();


### PR DESCRIPTION
Prior to this, the condition in the following example did not fold:

    'use constant ONE => 1; my $x = (defined(ONE)) ? 1 : 0;'

With this commit, the final op tree produced for the above is just:

    5  <@> leave[1 ref] vKP/REFC ->(end)
    1     <0> enter v ->2
    2     <;> nextstate(main 193 -e:1) v:%,us,{,fea=15 ->3
    4     <1> padsv_store[$x:193,194] vKS/LVINTRO ->5
    3        <$> const[IV 1] s/FOLD ->4
    -        <0> ex-padsv sRM*/LVINTRO ->4

Closes #16266 

---------------------------------------------------------------------------------
* This seems like a bit of an edge case, so I don't think it needs a perldelta entry.
