### PR TITLE
Add details tag to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-perlbug-core.md
+++ b/.github/ISSUE_TEMPLATE/01-perlbug-core.md
@@ -30,6 +30,10 @@ Module:
 
 **Perl configuration**
 <!-- Please paste `perl -V` output just below. -->
+<details>
+
 ```
 # perl -V output goes here
 ```
+
+</details>


### PR DESCRIPTION
Closes https://github.com/Perl/perl5/issues/21133

We can also move "Perl Configuration" to the `<summary>` tag, but I think it is clearer like so.

The templates could also be updated to the .yml format and the comments would be much clearer.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
