### PR TITLE
WIP Add resolving of $PROGRAM_NAME from /dev/fd/number

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -988,6 +988,7 @@ Michael Somos                  <somos@grail.cba.csuohio.edu>
 Michael Stevens                <mstevens@etla.org>
 Michael van Elst               <mlelstv@serpens.de>
 Michael Witten                 <mfwitten@gmail.com>
+Michal Josef Špaček            <mspacek@redhat.com>
 Michele Sardo
 Michiel Beijen                 <mb@x14.nl>
 Mik Firestone                  <fireston@lexmark.com>

--- a/perl.c
+++ b/perl.c
@@ -4227,6 +4227,19 @@ S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
                 Safefree(PL_origfilename);
                 PL_origfilename = (char *)scriptname;
             }
+            else {
+                char proc_fd_path[64];
+                snprintf(proc_fd_path, sizeof(proc_fd_path), "/proc/self/fd/%d", fdscript);
+                char target_path[MAXPATHLEN];
+                SSize_t len = readlink(proc_fd_path, target_path, sizeof(target_path) - 1);
+                if (len != -1) {
+                    Stat_t statbuf;
+                    target_path[len] = '\0';
+                    if (PerlLIO_stat(target_path, &statbuf) == 0 && S_ISREG(statbuf.st_mode)) {
+                        scriptname = PL_origfilename = find_script(target_path, dosearch, NULL, 1);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
There are situations when ```$PROGRAM_NAME``` is something /dev/fd/number
1) example like ```sudo /usr/local/bin/<tool>``` with checksum verification - https://github.com/Perl/perl5/issues/23351
→ Resolves to the tool path
2) example with pipe: ```perl <( echo '#!perl -DA'; echo 'print "$0\n"');```
→ Stay with /dev/fd/number

* This set of changes requires a perldelta entry, and I need help writing it.
