### PR TITLE
Use PerlLIO_dup_cloexec in Perl_dirp_dup to set O_CLOEXEC

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -14111,7 +14111,7 @@ Perl_dirp_dup(pTHX_ DIR *const dp, CLONE_PARAMS *const param)
 
     PERL_UNUSED_ARG(param);
 
-    ret = fdopendir(dup(my_dirfd(dp)));
+    ret = fdopendir(PerlLIO_dup_cloexec(my_dirfd(dp)));
 
 #elif defined(WIN32)
     ret = win32_dirp_dup(dp, param);


### PR DESCRIPTION
`dup` doesn't mark the new descriptor as close-on-exec, which can lead to a descriptor leaking to the new process.