### PR TITLE
win32_isatty() dont call a mostly failing syscall, NT->WIN err conv is slow

### DIFF
--- a/win32/win32.c
+++ b/win32/win32.c
@@ -4000,7 +4000,10 @@ win32_isatty(int fd)
         return 0;
     }
 
-    if (GetConsoleMode(fh, &mode))
+    /* Prevent executing RtlNtStatusToDosError() for disk files and sockets
+       inside GetConsoleMode(). RtlNtStatusToDosError() does a slow linear
+       search. For details, see PR for this commit.*/
+    if (GetFileType(fh) == FILE_TYPE_CHAR && GetConsoleMode(fh, &mode))
         return 1;
 
     errno = ENOTTY;


### PR DESCRIPTION
    GetFileType() has shortcuts, it first checks against -1 -2 -3, then checks
    against PEB's 3 master IN, OUT, ERR kernel handles, then checks if it is
    tagged/unaligned [open secret, not frozen API], and only then does the
    NtRequestWaitReplyPort() RPC call to csrss.exe instead of
    NtQueryVolumeInformationFile(). GetFileType() from kernel32.dll is different
    from GetFileType() in kernelbase.dll.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.