### PR TITLE
regcomp_invlist.c: Perl_populate_bitmap_from_invlist() optimize asserts

### DIFF
--- a/regcomp_invlist.c
+++ b/regcomp_invlist.c
@@ -23,13 +23,19 @@ void
 Perl_populate_bitmap_from_invlist(pTHX_ SV * invlist, const UV offset, const U8 * bitmap, const Size_t len)
 {
     PERL_ARGS_ASSERT_POPULATE_BITMAP_FROM_INVLIST;
+    ASSUME(invlist && bitmap);
 
     /* As the name says.  The zeroth bit corresponds to the code point given by
      * 'offset' */
 
     UV start, end;
 
-    Zero(bitmap, len, U8);
+    if (len == sizeof(U64)
+        && (    ((STRUCT_OFFSET(struct regnode_bbm, bitmap) % 8) == 0)
+                || (PTR2nat(bitmap) & 0x7) == 0))
+        *(U64*)bitmap = 0;
+    else
+        Zero(bitmap, len, U8);
 
     invlist_iterinit(invlist);
     while (invlist_iternext(invlist, &start, &end)) {


### PR DESCRIPTION


Inside re.xs/re.dll,  Perl_populate_bitmap_from_invlist() has half a dozen if(!invlist) _assert_libc() call sites. Atleast
PERL_ARGS_ASSERT_POPULATE_BITMAP_FROM_INVLIST, invlist_iterinit(), invlist_iternext(), invlist_iterfinish() are all testing a C auto var that was proven inside PERL_ARGS_ASSERT_POPULATE_BITMAP_FROM_INVLIST to be true. "SV * invlist" is a C auto and I don't belive it is "reachable" under ISO C. Perl_populate_bitmap_from_invlist() never does & operator on it. But atleast MSVC 2022 is constantly re-reading this C auto. Also Perl_populate_bitmap_from_invlist() has only 1 call site, and MSVC hoisted/folded/inlined away "const Size_t len" since its always 8.

#define REGNODE_BBM_BITMAP_LEN /* 6 info bits requires 64 bits; 5 => 32 */ ((1 << (UTF_CONTINUATION_BYTE_INFO_BITS)) / CHARBITS)

since MSVC doesnt inline memcpy symbol func calls b/c WinPerl doesnt request it, make it obvious here to skip the libc call on all platforms.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
