### PR TITLE
sv.c: fix crash with newSVpvf("")

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5156,6 +5156,7 @@ ext/XS-APItest/t/my_strtod.t			XS::APItest: test my_strtod
 ext/XS-APItest/t/newAV.t			XS::APItest: test newAV* functions
 ext/XS-APItest/t/newCONSTSUB.t			XS::APItest: test newCONSTSUB(_flags)
 ext/XS-APItest/t/newDEFSVOP.t			XS::APItest: test newDEFSVOP
+ext/XS-APItest/t/newSVpvf.t			XS::APItest: test newSVpvf
 ext/XS-APItest/t/Null.pm			Helper for ./blockhooks.t
 ext/XS-APItest/t/op.t				XS::APItest: tests for OP related APIs
 ext/XS-APItest/t/op_contextualize.t		test op_contextualize() API

--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.42';
+our $VERSION = '1.43';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -5032,6 +5032,15 @@ sv_regex_global_pos_set(SV *sv, STRLEN pos, U32 flags = 0)
 void
 sv_regex_global_pos_clear(SV *sv)
 
+SV *
+newSVpvf_blank()
+    CODE:
+        GCC_DIAG_IGNORE_STMT(-Wformat-zero-length);
+        RETVAL = newSVpvf("");
+        GCC_DIAG_RESTORE_STMT;
+    OUTPUT:
+        RETVAL
+
 MODULE = XS::APItest PACKAGE = XS::APItest::AUTOLOADtest
 
 int

--- a/ext/XS-APItest/t/newSVpvf.t
+++ b/ext/XS-APItest/t/newSVpvf.t
@@ -1,0 +1,12 @@
+#!perl
+use strict;
+use warnings;
+
+use Test::More;
+
+use XS::APItest qw(newSVpvf_blank);
+
+# gh #23393 - empty format string crashes newSVpvf
+is newSVpvf_blank, "", 'newSVpvf("") returns "" without crashing';
+
+done_testing;

--- a/sv.c
+++ b/sv.c
@@ -10004,13 +10004,12 @@ Perl_newSVpvf(pTHX_ const char *const pat, ...)
 SV *
 Perl_vnewSVpvf(pTHX_ const char *const pat, va_list *const args)
 {
-    SV *sv;
-
     PERL_ARGS_ASSERT_VNEWSVPVF;
 
     STRLEN patlen = strlen(pat);
 
-    sv = newSV(patlen);
+    /* newSV(0) would allocate a blank bodyless SV */
+    SV *sv = newSV(patlen ? patlen : 1);
     SvPVCLEAR_FRESH(sv);
     sv_vcatpvfn_flags(sv, pat, patlen, args, NULL, 0, NULL, 0);
     return sv;


### PR DESCRIPTION
Fixes #23393.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
