### PR TITLE
Avoid z/OS function pointer comparison undefined behavior

### DIFF
--- a/opcode.h
+++ b/opcode.h
@@ -1881,7 +1881,26 @@ INIT({
 	Perl_ck_null,		/* multiparam */
 	Perl_ck_null,		/* paramtest */
 	Perl_ck_null,		/* paramstore */
+
+/* The final entries are function pointers not attached to an opcode.
+ * These are to be used to compare with function pointers in the earlier
+ * part of the array, since in some platforms (notably z/OS), it is
+ * undefined behavior to compare function pointers for equality, even
+ * though calling them will invoke the same function.  IBM personnel say
+ * that the comparisons do work when the pointers are compiled in the same
+ * translation unit.  Hence, ck_null in all positions in the array will
+ * have the same value.  See GH #23399 */
+	Perl_ck_null,	
+	Perl_ck_exists,	
+	Perl_ck_delete,	
 });
+
+/* Indexes into PL_check for the comparison function pointers */
+#ifdef PERL_IN_PEEP_C
+  #define PERL_CK_NULL  429
+  #define PERL_CK_EXISTS  430
+  #define PERL_CK_DELETE  431
+#endif
 
 EXTCONST U32 PL_opargs[] INIT({
 	0x00000000,	/* null */

--- a/peep.c
+++ b/peep.c
@@ -2205,14 +2205,14 @@ S_maybe_multideref(pTHX_ OP *start, OP *orig_o, UV orig_action, U8 hints)
             /* if a custom array/hash access checker is in scope,
              * abandon optimisation attempt */
             if (  (o->op_type == OP_AELEM || o->op_type == OP_HELEM)
-               && PL_check[o->op_type] != Perl_ck_null)
+               && PL_check[o->op_type] != PL_check[PERL_CK_NULL])
                 return;
             /* similarly for customised exists and delete */
             if (  (o->op_type == OP_EXISTS)
-               && PL_check[o->op_type] != Perl_ck_exists)
+               && PL_check[o->op_type] != PL_check[PERL_CK_EXISTS])
                 return;
             if (  (o->op_type == OP_DELETE)
-               && PL_check[o->op_type] != Perl_ck_delete)
+               && PL_check[o->op_type] != PL_check[PERL_CK_DELETE])
                 return;
 
             if (   o->op_type != OP_AELEM

--- a/peep.c
+++ b/peep.c
@@ -2205,14 +2205,14 @@ S_maybe_multideref(pTHX_ OP *start, OP *orig_o, UV orig_action, U8 hints)
             /* if a custom array/hash access checker is in scope,
              * abandon optimisation attempt */
             if (  (o->op_type == OP_AELEM || o->op_type == OP_HELEM)
-               && PL_check[o->op_type] != PL_check[PERL_CK_NULL])
+               && UNLIKELY(PL_check[o->op_type] != PL_check[PERL_CK_NULL]))
                 return;
             /* similarly for customised exists and delete */
             if (  (o->op_type == OP_EXISTS)
-               && PL_check[o->op_type] != PL_check[PERL_CK_EXISTS])
+               && UNLIKELY(PL_check[o->op_type] != PL_check[PERL_CK_EXISTS]))
                 return;
             if (  (o->op_type == OP_DELETE)
-               && PL_check[o->op_type] != PL_check[PERL_CK_DELETE])
+               && UNLIKELY(PL_check[o->op_type] != PL_check[PERL_CK_DELETE]))
                 return;
 
             if (   o->op_type != OP_AELEM

--- a/regen/opcode.pl
+++ b/regen/opcode.pl
@@ -1114,13 +1114,40 @@ sub generate_opcode_h_pl_check {
     INIT({
     END
 
+
     for (@ops) {
         print "\t", tab(3, "Perl_$check{$_},"), "\t/* $_ */\n";
     }
 
     print <<~'END';
-    });
+
+    /* The final entries are function pointers not attached to an opcode.
+     * These are to be used to compare with function pointers in the earlier
+     * part of the array, since in some platforms (notably z/OS), it is
+     * undefined behavior to compare function pointers for equality, even
+     * though calling them will invoke the same function.  IBM personnel say
+     * that the comparisons do work when the pointers are compiled in the same
+     * translation unit.  Hence, ck_null in all positions in the array will
+     * have the same value.  See GH #23399 */
     END
+    my @perl_internal_extras = qw(ck_null ck_exists ck_delete);
+    for (@perl_internal_extras) {
+        print "\t", tab(3, "Perl_$_,"), "\n";
+    }
+
+    print <<~'END';
+    });
+
+    /* Indexes into PL_check for the comparison function pointers */
+    #ifdef PERL_IN_PEEP_C
+    END
+
+    for (my $i = 0; $i < @perl_internal_extras; $i++) {
+        my $index = @ops + $i;
+        my $define = uc $perl_internal_extras[$i];
+        print "  #define PERL_$define  $index\n";
+    }
+    print "#endif\n";
 }
 
 sub generate_opcode_h_pl_opargs {


### PR DESCRIPTION
Prior to this commit, code in peep.c that checks to see if a PL_check[] function had been overridden would always return true on z/OS.  This would turn off optimization for multideref, causing tests to fail that expected it to be on.

One solution would be to just not have multideref on that box, and to skip the failing tests.  I'd rather not turn off optimizations unless absolutely necessary.

The check for being overridden was to simply compare two function pointers for equality.  From information relayed to me on an IBM Discord z/OS chat channel, function pointer equality comparisons will never compare equal across different translation units.  To get a valid comparison, you must use pointers from the same translation unit.  I had first looked at the documentation.  It required more background knowledge of the jargon used, and the z/OS design than I was willing to spend the time learning.  But there may be a way around this, but if so it's complicated.  That's when I turned to the chat channel.

The PL_check[] table of the function pointers is declared extern, and when peep.c is compiled, it doesn't have access to that table; it gets linked to later.  So these are different translation units, and so the pointers never will be equal.  However within the table itself, all the pointers to function X will have the same address, as it is going to be in the same translation unit.

What this commit does is to add three extra elements to PL_check[], initialized with the function pointers that peep.c wants to compare against.  Those pointers are unknown to any other code, so will never be changed away from pointing to these function pointers.

And the commit changes peep.c to use the appropriate array entry, which will contain a valid value, instead of using the function pointer directly.  This solution works for z/OS and all other current implementations.

It, unfortunately, isn't a general solution.  We would have to do a similar game if there were other function pointers that were compared across translation units.  But this appears to be the only current case this happens.  As long as the function pointers to be compared are known in the same translation unit, it works.

This commit builds upon some ideas from Dave Mitchell and Richard Leach.  People on the z/OS chat independently came up with the same general solution.

This set of changes does not require a perldelta entry.
