### PR TITLE
add a new warning against using \ in qw()

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -206,7 +206,14 @@ XXX L<message|perldiag/"message">
 
 =item *
 
-XXX L<message|perldiag/"message">
+L<Possible attempt to escape whitespace in qw() list|perldiag/"Possible attempt to escape whitespace in qw() list">
+
+(W qw) qw() lists contain items separated by whitespace; contrary to
+what some might expect, backslash characters cannot be used to "protect"
+whitespace from being split, but are instead treated as literal data.
+
+Note that this warnings is I<only> emitted when the backslash is followed
+by actual whitespace (that C<qw> splits on).
 
 =back
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -5467,6 +5467,33 @@ character class, just escape the square brackets with the backslash: "\[="
 and "=\]".  The S<<-- HERE> shows whereabouts in the regular expression the
 problem was discovered.  See L<perlre>.
 
+=item Possible attempt to escape whitespace in qw() list
+
+(W qw) qw() lists contain items separated by whitespace; contrary to
+what some might expect, backslash characters cannot be used to "protect"
+whitespace from being split, but are instead treated as literal data.
+(You may have used different delimiters than the parentheses shown here;
+braces are also frequently used.)
+
+You probably wrote something like this:
+
+    @list = qw(
+        a\ string
+        another
+    );
+
+expecting to get a two elements list containing the strings C<'a string'>
+and C<'another'>.  Instead the list will hold four elements: C<'a\'>
+(with a literal backslash), C<'string'> and C<'another'>.
+
+If you really want whitespace in your strings, build your list the
+old-fashioned way, with quotes and commas:
+
+    @list = ( 'a string', 'another' );
+
+Note that this warnings is I<only> emitted when the backslash is followed
+by actual whitespace (that C<qw> splits on).
+
 =item Possible attempt to put comments in qw() list
 
 (W qw) qw() lists contain items separated by whitespace; as with literal

--- a/t/lib/warnings/toke
+++ b/t/lib/warnings/toke
@@ -49,6 +49,9 @@ toke.c	AOK
      Possible attempt to put comments in qw() list 
 	@a = qw(a b # c) ;
 
+     Possible attempt to escape whitespace in qw() list
+	@a = qw( foo bar\ baz ) ;
+
      %s (...) interpreted as function 
 	print ("")
 	printf ("")
@@ -364,6 +367,12 @@ no warnings 'qw' ;
 EXPECT
 Possible attempt to separate words with commas at - line 3.
 Possible attempt to put comments in qw() list at - line 3.
+########
+# toke.c
+use warnings 'qw';
+@a = qw( foo bar\ baz );
+EXPECT
+Possible attempt to escape whitespace in qw() list at - line 3.
 ########
 # toke.c
 use warnings 'syntax' ;

--- a/toke.c
+++ b/toke.c
@@ -5821,6 +5821,7 @@ yyl_qw(pTHX_ char *s, STRLEN len)
     if (SvCUR(PL_lex_stuff)) {
         int warned_comma = !ckWARN(WARN_QW);
         int warned_comment = warned_comma;
+        int warned_escape = warned_comma;
         char *d = SvPV_force(PL_lex_stuff, len);
         while (len) {
             for (; isSPACE(*d) && len; --len, ++d)
@@ -5839,6 +5840,11 @@ yyl_qw(pTHX_ char *s, STRLEN len)
                             warner(packWARN(WARN_QW),
                                    "Possible attempt to put comments in qw() list");
                             ++warned_comment;
+                        }
+                        else if (!warned_escape && *d == '\\' && len > 1 && isSPACE(*(d+1)) ) {
+                            warner(packWARN(WARN_QW),
+                                   "Possible attempt to escape whitespace in qw() list");
+                            ++warned_escape;
                         }
                     }
                 }


### PR DESCRIPTION
I've seen AI-generated code try to use `qw()` to create lists containing strings with embedded whitespace using `\` to "protect" the whitespace. Things like:

    my @list = qw(
        foo
        bar\ baz
    );

Just like occurences of ',' and '#', I believe this should warn.

Note that the warning will only be emitted when the \ is followed by actual whitespace, so code like the following (from lib/App/Cpan.pm) will not warn:

    my $epic_fail_words = join '|',
            qw( Error stop(?:ping)? problems force not unsupported
                    fail(?:ed)? Cannot\s+install );


* This set of changes requires a perldelta entry, and it is included.