### PR TITLE
ParseXS: fix handling of empty C_ARGS etc

### DIFF
--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
@@ -3648,7 +3648,7 @@ sub parse {
     $self->SUPER::parse($pxs); # set file/line_no, read lines
 
     my @lines = @{$self->{lines}};
-    shift @lines while $lines[0] !~ /\S/;
+    shift @lines while @lines && $lines[0] !~ /\S/;
     # XXX ParseXS originally didn't include a trailing \n,
     # so we carry on doing the same.
     $self->{text} = join "\n", @lines;

--- a/dist/ExtUtils-ParseXS/t/001-basic.t
+++ b/dist/ExtUtils-ParseXS/t/001-basic.t
@@ -1657,6 +1657,16 @@ EOF
         ],
 
         [
+            "autocall args empty C_ARGS",
+            [ Q(<<'EOF') ],
+                |void
+                |foo(int  a)
+                |    C_ARGS:
+EOF
+            [ 0, 0, qr/\Qfoo()/,  "" ],
+        ],
+
+        [
             # Whether this is sensible or not is another matter.
             # For now, just check that it works as-is.
             "autocall args C_ARGS multi-line",


### PR DESCRIPTION
GH#23407

My recent refactoring work on ParseXS made the parser go into an infinite loop on multiline_merged nodes such as C_ARGS when there was no text, e.g.

    void
    foo(int  a)
        C_ARGS:

* This set of changes does not require a perldelta entry.
