### PR TITLE
perlop: Clarify empty pattern section not valid for qr//

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -2272,6 +2272,9 @@ The bottom line is that using C</o> is almost never a good idea.
 
 =item The empty pattern C<//>
 
+(This subsection applies to C<//>, C<m//>, and C<s///>, but not to
+C<qr//>.)
+
 If the I<PATTERN> evaluates to the empty string, the last
 I<successfully> matched regular expression in the current dynamic
 scope is used instead (see also L<perlvar/Scoping Rules of Regex Variables>).


### PR DESCRIPTION
Fixes GH #23410


* This set of changes does not require a perldelta entry.
