### PR TITLE
(diff name?) perl.h add SVVALIDIVX()/SVVALIDRV/SVVALILDNVX/SVVALIDPVX bitfield testers

### DIFF
--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.43';
+our $VERSION = '1.44';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -1999,6 +1999,158 @@ test_mismatch_xs_handshake_api_ver(...)
 #endif
     }
 
+bool
+PL_valid_types_IRNPVX_arrays()
+    PREINIT:
+        int i;
+        int t;
+        SV fksv;
+        const bool * arr;
+        const bool * p_arrs [] = {
+            PL_valid_types_IVX,
+            PL_valid_types_NVX,
+            PL_valid_types_PVX,
+            PL_valid_types_RV,
+            PL_valid_types_IV_set,
+            PL_valid_types_NV_set
+        };
+    CODE:
+        for(i=0; i< C_ARRAY_LENGTH(p_arrs); i++){
+            arr = p_arrs[i];
+            switch(i) {
+                case 0:
+                    for(t = 0; t <SVt_LAST; t++) {
+                        SvFLAGS(&fksv) = t;
+                        if (cBOOL(SVVALIDIVX(&fksv))
+                            != cBOOL(arr[SvTYPE(&fksv) & SVt_MASK]))
+                            goto failed;
+                    }
+                    break;
+                case 1:
+                    for(t = 0; t <SVt_LAST; t++) {
+                        SvFLAGS(&fksv) = t;
+                        if (cBOOL(SVVALIDNVX(&fksv))
+                            != cBOOL(arr[SvTYPE(&fksv) & SVt_MASK]))
+                            goto failed;
+                    }
+                    break;
+                case 2:
+                    for(t = 0; t <SVt_LAST; t++) {
+                        SvFLAGS(&fksv) = t;
+                        if (cBOOL(SVVALIDPVX(&fksv))
+                            != cBOOL(arr[SvTYPE(&fksv) & SVt_MASK]))
+                            goto failed;
+                    }
+                    break;
+                case 3:
+                    for(t = 0; t <SVt_LAST; t++) {
+                        SvFLAGS(&fksv) = t;
+                        if (cBOOL(SVVALIDRV(&fksv))
+                            != cBOOL(arr[SvTYPE(&fksv) & SVt_MASK]))
+                            goto failed;
+                    }
+                    break;
+                case 4:
+                    for(t = 0; t <SVt_LAST; t++) {
+                        SvFLAGS(&fksv) = t;
+                        if (cBOOL(SVVALIDIV_set(&fksv))
+                            != cBOOL(arr[SvTYPE(&fksv) & SVt_MASK]))
+                            goto failed;
+                    }
+                    break;
+                case 5:
+                    for(t = 0; t <SVt_LAST; t++) {
+                        SvFLAGS(&fksv) = t;
+                        if (cBOOL(SVVALIDNV_set(&fksv))
+                            != cBOOL(arr[SvTYPE(&fksv) & SVt_MASK]))
+                            goto failed;
+                    }
+                    break;
+            }
+        }
+        RETVAL = TRUE;
+        if (0){
+            failed:
+            RETVAL = FALSE;
+        }
+    OUTPUT:
+        RETVAL
+
+bool
+PL_valid_types_IRNPVX_arrays_part2()
+    PREINIT:
+        SV * svnl = newSV_type_mortal(SVt_NULL);
+        SV * sviv = newSV_type_mortal(SVt_IV);
+        SV * svnv = newSV_type_mortal(SVt_NV);
+        SV * svpv = newSV_type_mortal(SVt_PV);
+    CODE:
+#define OLD_IVX(_svivx) (PL_valid_types_IVX[SvTYPE(_svivx) & SVt_MASK])
+#define OLD_NVX(_svnvx) (PL_valid_types_NVX[SvTYPE(_svnvx) & SVt_MASK])
+#define OLD_PVX(_svpvx) (PL_valid_types_PVX[SvTYPE(_svpvx) & SVt_MASK])
+        /* NULL */
+        if(SVVALIDIVX(svnl))
+            goto failed;
+        if(OLD_IVX(svnl))
+            goto failed;
+        if(SVVALIDNVX(svnl))
+            goto failed;
+        if(OLD_NVX(svnl))
+            goto failed;
+        if(SVVALIDPVX(svnl))
+            goto failed;
+        if(OLD_PVX(svnl))
+            goto failed;
+        /* IV */
+        if(!SVVALIDIVX(sviv))
+            goto failed;
+        if(!OLD_IVX(sviv))
+            goto failed;
+        if(SVVALIDNVX(sviv))
+            goto failed;
+        if(OLD_NVX(sviv))
+            goto failed;
+        if(SVVALIDPVX(sviv))
+            goto failed;
+        if(OLD_PVX(sviv))
+            goto failed;
+        /* NV */
+        if(SVVALIDIVX(svnv))
+            goto failed;
+        if(OLD_IVX(svnv))
+            goto failed;
+        if(!SVVALIDNVX(svnv))
+            goto failed;
+        if(!OLD_NVX(svnv))
+            goto failed;
+        if(SVVALIDPVX(svnv))
+            goto failed;
+        if(OLD_PVX(svnv))
+            goto failed;
+        /* PV */
+        if(SVVALIDIVX(svpv))
+            goto failed;
+        if(OLD_IVX(svpv))
+            goto failed;
+        if(SVVALIDNVX(svpv))
+            goto failed;
+        if(OLD_NVX(svpv))
+            goto failed;
+        if(!SVVALIDPVX(svpv))
+            goto failed;
+        if(!OLD_PVX(svpv))
+            goto failed;
+        if(0) {
+            failed:
+            RETVAL = FALSE;
+        }
+        else
+            RETVAL = TRUE;
+#undef OLD_IVX
+#undef OLD_NVX
+#undef OLD_PVX
+    OUTPUT:
+        RETVAL
+
 
 MODULE = XS::APItest:Hash               PACKAGE = XS::APItest::Hash
 

--- a/ext/XS-APItest/t/xsub_h.t
+++ b/ext/XS-APItest/t/xsub_h.t
@@ -150,5 +150,9 @@ is scalar @xs_empty, 0, 'XSRETURN_EMPTY returns empty list in array context';
 my $xs_empty = XS::APItest::XSUB::xsreturn_empty();
 is $xs_empty, undef, 'XSRETURN_EMPTY returns undef in scalar context';
 
+ok( XS::APItest::XSUB::PL_valid_types_IRNPVX_arrays(),
+    "APItest::XSUB::PL_valid_types_IRNPVX_arrays returned true");
+ok( XS::APItest::XSUB::PL_valid_types_IRNPVX_arrays_part2(),
+    "APItest::XSUB::PL_valid_types_IRNPVX_arrays_part2 returned true");
 
 done_testing();

--- a/perl.h
+++ b/perl.h
@@ -6265,6 +6265,51 @@ EXTCONST U8 PL_magic_data[256] =
 EXTCONST U8 PL_magic_data[256];
 #endif
 
+#define SVtVALIDIVX ((0<<0)/*NL*/|(1<<1)/*IV*/|(0<<2)/*NV*/|(0<<3)/*PV*/ \
+    |(0<<4)/*INV*/|(1<<5)/*PI*/|(1<<6)/*PN*/|(1<<7)/*MG*/|(0<<8)/*RX*/ \
+    |(1<<9)/*GV*/|(1<<10)/*LV*/|(0<<11)/*AV*/|(0<<12)/*HV*/|(0<<13)/*CV*/ \
+    |(0<<14)/*FM*/|(0<<15)/*IO*/|(0<<16)/*OBJ*/)
+#define SVtVALIDNVX ((0<<0)/*NL*/|(0<<1)/*IV*/|(1<<2)/*NV*/|(0<<3)/*PV*/ \
+    |(0<<4)/*INV*/|(0<<5)/*PI*/|(1<<6)/*PN*/|(1<<7)/*MG*/|(0<<8)/*RX*/ \
+    |(1<<9)/*GV*/|(1<<10)/*LV*/|(0<<11)/*AV*/|(0<<12)/*HV*/|(0<<13)/*CV*/ \
+    |(0<<14)/*FM*/|(0<<15)/*IO*/|(0<<16)/*OBJ*/)
+#define SVtVALIDPVX ((0<<0)/*NL*/|(0<<1)/*IV*/|(0<<2)/*NV*/|(1<<3)/*PV*/ \
+    |(1<<4)/*INV*/|(1<<5)/*PI*/|(1<<6)/*PN*/|(1<<7)/*MG*/|(1<<8)/*RX*/ \
+    |(1<<9)/*GV*/|(1<<10)/*LV*/|(0<<11)/*AV*/|(0<<12)/*HV*/|(1<<13)/*CV*/ \
+    |(1<<14)/*FM*/|(1<<15)/*IO*/|(0<<16)/*OBJ*/)
+#define SVtVALIDRV ((0<<0)/*NL*/|(1<<1)/*IV*/|(0<<2)/*NV*/|(1<<3)/*PV*/ \
+    |(0<<4)/*INV*/|(1<<5)/*PI*/|(1<<6)/*PN*/|(1<<7)/*MG*/|(1<<8)/*RX*/ \
+    |(1<<9)/*GV*/|(1<<10)/*LV*/|(0<<11)/*AV*/|(0<<12)/*HV*/|(0<<13)/*CV*/ \
+    |(0<<14)/*FM*/|(1<<15)/*IO*/|(0<<16)/*OBJ*/)
+#define SVtVALIDIV_set ((0<<0)/*NL*/|(1<<1)/*IV*/|(0<<2)/*NV*/|(0<<3)/*PV*/ \
+    |(0<<4)/*INV*/|(1<<5)/*PI*/|(1<<6)/*PN*/|(1<<7)/*MG*/|(1<<8)/*RX*/ \
+    |(1<<9)/*GV*/|(1<<10)/*LV*/|(0<<11)/*AV*/|(0<<12)/*HV*/|(0<<13)/*CV*/ \
+    |(1<<14)/*FM*/|(1<<15)/*IO*/|(0<<16)/*OBJ*/)
+#define SVtVALIDNV_set ((0<<0)/*NL*/|(0<<1)/*IV*/|(1<<2)/*NV*/|(0<<3)/*PV*/ \
+    |(0<<4)/*INV*/|(0<<5)/*PI*/|(1<<6)/*PN*/|(1<<7)/*MG*/|(1<<8)/*RX*/ \
+    |(1<<9)/*GV*/|(1<<10)/*LV*/|(0<<11)/*AV*/|(0<<12)/*HV*/|(0<<13)/*CV*/ \
+    |(0<<14)/*FM*/|(0<<15)/*IO*/|(0<<16)/*OBJ*/)
+
+/* Experimental. Only for PERL_CORE. Not for CPAN XS or private XS code.
+ *
+ * Faster but identical to the assert tests inside sv.h that look like :
+ *
+ *      assert(PL_valid_types_PVX[SvTYPE(_svcur) & SVt_MASK]);
+ *
+ * These macros don't do an extra memory read from a 17 byte array like
+ * the assert() above.  The intent is these macros could be used in
+ * -O1/-O2 non-DEBUGGING builds, either temporarily in blead, or permanently
+ * in stable releases. Probably the only useful macro is SVVALIDPVX() vs
+ *      if ((type >= SVt_PV && type <= SVt_PVLV) || type == SVt_PVCV) { 0; }
+ */
+
+#define SVVALIDIVX(_sv) ((1<<SvTYPE(_sv))&SVtVALIDIVX)
+#define SVVALIDNVX(_sv) ((1<<SvTYPE(_sv))&SVtVALIDNVX)
+#define SVVALIDPVX(_sv) ((1<<SvTYPE(_sv))&SVtVALIDPVX)
+#define SVVALIDRV(_sv) ((1<<SvTYPE(_sv))&SVtVALIDRV)
+#define SVVALIDIV_set(_sv) ((1<<SvTYPE(_sv))&SVtVALIDIV_set)
+#define SVVALIDNV_set(_sv) ((1<<SvTYPE(_sv))&SVtVALIDNV_set)
+
 #ifdef DOINIT
                         /* NL IV NV PV INV PI PN MG RX GV LV AV HV CV FM IO OBJ */
 EXTCONST bool


### PR DESCRIPTION
edit: this commit originally had a misspelled in english title and misspelled in english macros, now fixed

I think the spelling and capitalization of the macros SVVALIDIVX()/SVVALIDRV/SVVALIDNVX/SVVALIDPVX could be better. But I couldn't think of anything better than what is in this commit. Anyone have ideas for better identifiers?

I cant think of much use right now for these macros as production perl code except for future improvements to `CV*` API, since various `sv_cat*()`/`sv_set*()` and other parts of the SVPV APIs hate dealing with `CV*`s. Either they have breakage, SEGVs or -DDEBUGGING only assert() fails. `CV*`s are ultimately POK strings considering XS AUTOLOAD sub name passing, and that prototype string grammar has a rarely used provision for random 3P strings like HTTP URLs, JSON, and REST IDLs.

Another reason I made them is, I really really don't like that SVt_PVGV sits below SVt_PVLV as a SEGV bomb. Since SVt_PVLV is the last traditional POK-able type. An algo that down cast to U8, shift,  &, against a bitfield literal is much more production/runtime/speed reasonable, vs these 17 byte arrays. And XS modules will need an angel to save them from double or triple indirection to reach libperl data vars on WinOS and ELF.

 SVt_PVCVs can not be passed to `SvPV();` IIRC but its been a year since I tried doing that. I did prove that cv_name()/GvNAME/CvNAME are unreachable from miniperl and PP.  stringifying a `CV*` the way `croak_xs_usage()`/`cv_name()` do it, AFAIK is impossible from PP space using a  standalone libperl.

---

- Add faster versions of the PL_valid_types_IVX[], PL_valid_types_PVX[], etc array tests intended for use in -O2/not -DDEBUGGING builds.

- Currently the PL_valid_types_*VX[] arrays are all 17 bytes long and only used for -DDEBUGGING assert()s in sv.h.  The same information can be stored in a U32 literal integer instead.  By making these macros use a U32 literal integer instead of a const array of bool/8 vars, there is no performance or overhead concerns anymore, if someone finds a reason to use these macros, in an optimized perl build. The U32 literal integers are now part of the CPU's instruction stream like in all other SV* flag tests.
- It is not known yet if there is any good reason to these faster macros, or the old slower PL_valid_types_*VX[]s arrays, in an optimized blead perl or optimized stable perl. All "correct enough" code either in CORE or on CPAN already has macros or expressions using existing macros, to test whatever flags they need to test inside a SV* head struct.

---------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
