### PR TITLE
Use ASCII apostrophe, not  Unicode in a couple of .t files

### DIFF
--- a/t/op/magic.t
+++ b/t/op/magic.t
@@ -765,7 +765,7 @@ fresh_perl_is
 # ${^OPEN} and $^H interaction
 # Setting ${^OPEN} causes $^H to change, but setting $^H would only some-
 # times make ${^OPEN} change, depending on whether it was in the same BEGIN
-# block.  Don’t test actual values (subject to change); just test for
+# block.  Don't test actual values (subject to change); just test for
 # consistency.
 my @stuff;
 eval '

--- a/t/test.pl
+++ b/t/test.pl
@@ -110,7 +110,7 @@ sub is_miniperl {
 }
 
 sub set_up_inc {
-    # Don’t clobber @INC under miniperl
+    # Don't clobber @INC under miniperl
     @INC = () unless is_miniperl;
     unshift @INC, @_;
 }


### PR DESCRIPTION
There is no need for these files to contain non-ASCII characters<!--

* This set of changes does not require a perldelta entry.
