### PR TITLE
t/io/nargv.t: Fix obsolete usage: @foo[-1]

### DIFF
--- a/t/io/nargv.t
+++ b/t/io/nargv.t
@@ -134,7 +134,7 @@ sub mkfiles {
 	$files[$_] ||= tempfile();
     }
     my @results = @files[@_];
-    return wantarray ? @results : @results[-1];
+    return wantarray ? @results : $results[-1];
 }
 
 END { unlink_all map { ($_, "$_.bak") } @files }


### PR DESCRIPTION
Use $ to reference an array element


* This set of changes does not require a perldelta entry.
