### PR TITLE
Turn off locale handling if conditions not met

### DIFF
--- a/locale_table.h
+++ b/locale_table.h
@@ -30,7 +30,7 @@
  */
 
 #ifdef LC_CTYPE
-#  if defined(NO_LOCALE) || defined(NO_LOCALE_CTYPE)
+#  if ! defined(USE_LOCALE) || defined(NO_LOCALE_CTYPE)
 
     PERL_LOCALE_TABLE_ENTRY(CTYPE, NULL)
 
@@ -47,7 +47,7 @@
 #  define LC_CTYPE_AVAIL_  0
 #endif
 #ifdef LC_NUMERIC
-#  if defined(NO_LOCALE) || defined(NO_LOCALE_NUMERIC)
+#  if ! defined(USE_LOCALE) || defined(NO_LOCALE_NUMERIC)
 
     PERL_LOCALE_TABLE_ENTRY(NUMERIC, NULL)
 
@@ -68,7 +68,7 @@
         /* Perl outsources all its collation efforts to the libc strxfrm(), so
          * if it isn't available on the system, default "C" locale collation
          * gets used */
-#  if defined(NO_LOCALE) || defined(NO_LOCALE_COLLATE) || ! defined(HAS_STRXFRM)
+#  if ! defined(USE_LOCALE) || defined(NO_LOCALE_COLLATE) || ! defined(HAS_STRXFRM)
 
     PERL_LOCALE_TABLE_ENTRY(COLLATE, NULL)
 
@@ -88,7 +88,7 @@
 
     PERL_LOCALE_TABLE_ENTRY(TIME, NULL)
 
-#  if defined(NO_LOCALE) || defined(NO_LOCALE_TIME)
+#  if ! defined(USE_LOCALE) || defined(NO_LOCALE_TIME)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
 #    define LC_TIME_AVAIL_  0
 #  else
@@ -102,7 +102,7 @@
 
     PERL_LOCALE_TABLE_ENTRY(MESSAGES, NULL)
 
-#  if defined(NO_LOCALE) || defined(NO_LOCALE_MESSAGES)
+#  if ! defined(USE_LOCALE) || defined(NO_LOCALE_MESSAGES)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
 #    define LC_MESSAGES_AVAIL_  0
 #  else
@@ -116,7 +116,7 @@
 
     PERL_LOCALE_TABLE_ENTRY(MONETARY, NULL)
 
-#  if defined(NO_LOCALE) || defined(NO_LOCALE_MONETARY)
+#  if ! defined(USE_LOCALE) || defined(NO_LOCALE_MONETARY)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
 #    define LC_MONETARY_AVAIL_  0
 #  else
@@ -130,7 +130,7 @@
 
     PERL_LOCALE_TABLE_ENTRY(ADDRESS, NULL)
 
-#  if defined(NO_LOCALE) || defined(NO_LOCALE_ADDRESS)
+#  if ! defined(USE_LOCALE) || defined(NO_LOCALE_ADDRESS)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
 #    define LC_ADDRESS_AVAIL_  0
 #  else
@@ -144,7 +144,7 @@
 
     PERL_LOCALE_TABLE_ENTRY(IDENTIFICATION, NULL)
 
-#  if defined(NO_LOCALE) || defined(NO_LOCALE_IDENTIFICATION)
+#  if ! defined(USE_LOCALE) || defined(NO_LOCALE_IDENTIFICATION)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
 #    define LC_IDENTIFICATION_AVAIL_  0
 #  else
@@ -158,7 +158,7 @@
 
     PERL_LOCALE_TABLE_ENTRY(MEASUREMENT, NULL)
 
-#  if defined(NO_LOCALE) || defined(NO_LOCALE_MEASUREMENT)
+#  if ! defined(USE_LOCALE) || defined(NO_LOCALE_MEASUREMENT)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
 #    define LC_MEASUREMENT_AVAIL_  0
 #  else
@@ -172,7 +172,7 @@
 
     PERL_LOCALE_TABLE_ENTRY(PAPER, NULL)
 
-#  if defined(NO_LOCALE) || defined(NO_LOCALE_PAPER)
+#  if ! defined(USE_LOCALE) || defined(NO_LOCALE_PAPER)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
 #    define LC_PAPER_AVAIL_  0
 #  else
@@ -186,7 +186,7 @@
 
     PERL_LOCALE_TABLE_ENTRY(TELEPHONE, NULL)
 
-#  if defined(NO_LOCALE) || defined(NO_LOCALE_TELEPHONE)
+#  if ! defined(USE_LOCALE) || defined(NO_LOCALE_TELEPHONE)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
 #    define LC_TELEPHONE_AVAIL_  0
 #  else
@@ -200,7 +200,7 @@
 
     PERL_LOCALE_TABLE_ENTRY(NAME, NULL)
 
-#  if defined(NO_LOCALE) || defined(NO_LOCALE_NAME)
+#  if ! defined(USE_LOCALE) || defined(NO_LOCALE_NAME)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
 #    define LC_NAME_AVAIL_  0
 #  else
@@ -214,7 +214,7 @@
 
     PERL_LOCALE_TABLE_ENTRY(SYNTAX, NULL)
 
-#  if defined(NO_LOCALE) || defined(NO_LOCALE_SYNTAX)
+#  if ! defined(USE_LOCALE) || defined(NO_LOCALE_SYNTAX)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
 #    define LC_SYNTAX_AVAIL_  0
 #  else
@@ -228,7 +228,7 @@
 
     PERL_LOCALE_TABLE_ENTRY(TOD, NULL)
 
-#  if defined(NO_LOCALE) || defined(NO_LOCALE_TOD)
+#  if ! defined(USE_LOCALE) || defined(NO_LOCALE_TOD)
 #    define HAS_IGNORED_LOCALE_CATEGORIES_
 #    define LC_TOD_AVAIL_  0
 #  else

--- a/makedef.pl
+++ b/makedef.pl
@@ -145,6 +145,9 @@ if (! $define{NO_LOCALE}) {
     elsif ($define{HAS_SETLOCALE}) {
         $define{USE_LOCALE} = 1;
     }
+    else {
+        undef $define{USE_LOCALE};
+    }
 }
 
 # https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering

--- a/perl.h
+++ b/perl.h
@@ -1175,6 +1175,8 @@ violations are fatal.
 #    define USE_LOCALE
 #  elif defined(HAS_SETLOCALE)
 #    define USE_LOCALE
+#  else
+#    undef USE_LOCALE
 #  endif
 #endif
 

--- a/regen/locale.pl
+++ b/regen/locale.pl
@@ -84,7 +84,7 @@ while (<DATA>) { # Read in the categories
 
     my $extra = "";
     $extra = $extra_conditional{$name} if defined $extra_conditional{$name};
-    print $l "#  if defined(NO_LOCALE) || defined(NO_LOCALE_${name})$extra\n";
+    print $l "#  if ! defined(USE_LOCALE) || defined(NO_LOCALE_${name})$extra\n";
 
     print $l "\n    $macro_unless_name\n\n" if $macro_unless_name;
     print $l <<~EOF;


### PR DESCRIPTION
This #if ... #elif ... sequence ended in an #elif, neglecting the
possibility that none of the conditions are true.  This commit adds a
final #else to account for that eventuality.

And what that means should that final #else be taken is that the
platform under the given Configuration can't handle locales; so they are
turned off.

This happens on z/OS under threading.  The OS refuses to change the
locale at all once a second thread is started.  Perl relies on the
ability to change the locale at will to accommodate locales that have a
comma be the radix (decimal point) character and the huge amount of code
that has been written expecting that at all times a dot is the radix
character.  This includes core code (which we could change) and XS code
(which would be overwhelming to change).

Thus Perl won't work on many locales on z/OS when two or more threads
are running.  The only reasonable option is to just turn off the whole
thing.

* This set of changes requires a perldelta entry, to be written

