### PR TITLE
Add obituary for Matt S. Trout

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -272,6 +272,7 @@ Chris Lamb                     <lamby@debian.org>
 Chris Lightfoot                <chris@ex-parrot.com>
 Chris Nandor                   <pudge@pobox.com>
 Chris Pepper
+Chris Prather                  <chris@prather.org>
 Chris R. Donnelly              <chris.donnelly@vauto.com>
 Chris Travers                  <chris.travers@gmail.com>
 Chris Tubutis                  <chris@broadband.att.com>

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -404,8 +404,9 @@ the F<perldelta> of a previous release.
 
 =head1 Obituary
 
-"WELL VOLUNTEERED!" echoed across conferences and IRC. Matt S. Trout's battle
-cry that transformed reluctant volunteers into community leaders. With profound
+"WELL VOLUNTEERED!" echoed across conference rooms and IRC channels. Matt S. Trout's battle
+cry that transformed reluctant volunteers into community leaders.
+With profound
 sadness, we announce Matt's passing. Since the early 2000s, Matt shaped Perl
 through sheer force of will: IRC operator, PAUSE administrator, ShadowCat
 co-founder, architect of DBIx::Class. His opinions came wrapped in profanity

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -409,7 +409,7 @@ cry that transformed reluctant volunteers into community leaders.
 
 With profound sadness, we announce Matt's passing. Since the early 2000s, Matt
 shaped Perl through sheer force of will: IRC operator, PAUSE administrator,
-ShadowCat co-founder, architect of DBIx::Class. His opinions came wrapped in
+Shadowcat Systems co-founder, architect of DBIx::Class. His opinions came wrapped in
 profanity and delivered at maximum volume. He suffered no fools and grew to
 sometimes realize he should apologize. Yet this same abrasive exterior
 protected fierce dedication to mentoring, developers he harangued into

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -404,8 +404,18 @@ the F<perldelta> of a previous release.
 
 =head1 Obituary
 
-XXX If any significant core contributor or member of the CPAN community has
-died, add a short obituary here.
+"WELL VOLUNTEERED!" echoed across conferences and IRC. Matt S. Trout's battle
+cry that transformed reluctant volunteers into community leaders. With profound
+sadness, we announce Matt's passing. Since the early 2000s, Matt shaped Perl
+through sheer force of will: IRC operator, PAUSE administrator, ShadowCat
+co-founder, architect of DBIx::Class. His opinions came wrapped in profanity
+and delivered at maximum volume. He suffered no fools and grew to sometimes
+realize he should apologize. Yet this same abrasive exterior protected fierce
+dedication to mentoring, developers he harangued into volunteering now lead the
+community themselves. Matt's deliberately mind-bending code pushed Perl
+forward. Every modern Perl developer touches his legacy daily.
+
+Well volunteered, Matt. Rest in peace.
 
 =head1 Acknowledgements
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -406,15 +406,16 @@ the F<perldelta> of a previous release.
 
 "WELL VOLUNTEERED!" echoed across conference rooms and IRC channels. Matt S. Trout's battle
 cry that transformed reluctant volunteers into community leaders.
-With profound
-sadness, we announce Matt's passing. Since the early 2000s, Matt shaped Perl
-through sheer force of will: IRC operator, PAUSE administrator, ShadowCat
-co-founder, architect of DBIx::Class. His opinions came wrapped in profanity
-and delivered at maximum volume. He suffered no fools and grew to sometimes
-realize he should apologize. Yet this same abrasive exterior protected fierce
-dedication to mentoring, developers he harangued into volunteering now lead the
-community themselves. Matt's deliberately mind-bending code pushed Perl
-forward. Every modern Perl developer touches his legacy daily.
+
+With profound sadness, we announce Matt's passing. Since the early 2000s, Matt
+shaped Perl through sheer force of will: IRC operator, PAUSE administrator,
+ShadowCat co-founder, architect of DBIx::Class. His opinions came wrapped in
+profanity and delivered at maximum volume. He suffered no fools and grew to
+sometimes realize he should apologize. Yet this same abrasive exterior
+protected fierce dedication to mentoring, developers he harangued into
+volunteering now lead the community themselves. Matt's deliberately
+mind-bending code pushed Perl forward. Every modern Perl developer touches his
+legacy daily.
 
 Well volunteered, Matt. Rest in peace.
 


### PR DESCRIPTION
Matt was a pivotal member of the Perl community who passed away recently. This obituary acknowledges his extensive contributions, roles and projects that shaped modern Perl.