### PR TITLE
sv.c: sv_2mortal() move SvTEMP_on(sv); for RISC CPUs

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -9739,8 +9739,8 @@ Perl_sv_2mortal(pTHX_ SV *const sv)
         return sv;
     if (SvIMMORTAL(sv))
         return sv;
-    PUSH_EXTEND_MORTAL__SV_C(sv);
-    SvTEMP_on(sv);
+    SvTEMP_on(sv); /* optimize for RISC, SvIMMORTAL() contains SvREADONLY() */
+    PUSH_EXTEND_MORTAL__SV_C(sv);;
     return sv;
 }
 


### PR DESCRIPTION
RISC CPUs can not read from memory and do anything else in 1 opcode. These x64 instructions are impossible to do in 1 opcode on ARM.

F7 42 0C 00 00 01 08       test    dword ptr [rdx+0Ch], 8010000h
and
0F BA 6B 0C 13             bts     dword ptr [rbx+0Ch], 13h

Since editing macro SvIMMORTAL() to remove SvREADONLY() is out of scope, flip the order around, so the contents sv->sv_flags can be reused, and not re-read around fn call Perl_tmps_grow_p().

sv_2mortal() is a libperl export, it doesn't inline. "SvTEMP_on(sv);" can not have any CC inline synergy/de-duping opportunities with its caller frame, regardless if SvTEMP_on() is on the top or bottom of sv_2mortal(). sv.c itself never calls sv_2mortal(). All functions inside sv.c use the lightweight PUSH_EXTEND_MORTAL__SV_C() macro, not sv_2mortal().

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
