### PR TITLE
op.c toke.c add gv_override_pvs() change manual string lit. lens to macros

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -468,6 +468,10 @@ Perl_xxx(aTHX_ ...) form for any API calls where it's used.
             Perl_gv_fetchpvn_flags(aTHX_ STR_WITH_LEN(name), flags, sv_type)
 #define  gv_fetchpvn  gv_fetchpvn_flags
 
+/* gv_override() is not exported from libperl */
+#ifdef PERL_CORE
+#  define gv_override_pvs(name) Perl_gv_override(aTHX_ STR_WITH_LEN(name))
+#endif
 
 /*
 =for apidoc_defn mx|void|lex_stuff_pvs|"pv"|U32 flags

--- a/op.c
+++ b/op.c
@@ -8506,7 +8506,7 @@ Perl_dofile(pTHX_ OP *term, I32 force_builtin)
 
     PERL_ARGS_ASSERT_DOFILE;
 
-    if (!force_builtin && (gv = gv_override("do", 2))) {
+    if (!force_builtin && (gv = gv_override_pvs("do"))) {
         doop = S_new_entersubop(aTHX_ gv, term);
     }
     else {
@@ -12482,7 +12482,7 @@ Perl_ck_backtick(pTHX_ OP *o)
     o = ck_fun(o);
     /* qx and `` have a null pushmark; CORE::readpipe has only one kid. */
     if (o->op_flags & OPf_KIDS && (sibl = OpSIBLING(cUNOPo->op_first))
-     && (gv = gv_override("readpipe",8)))
+     && (gv = gv_override_pvs("readpipe")))
     {
         /* detach rest of siblings from o and its first child */
         op_sibling_splice(o, cUNOPo->op_first, -1, NULL);
@@ -13441,7 +13441,7 @@ Perl_ck_glob(pTHX_ OP *o)
     if ((o->op_flags & OPf_KIDS) && !OpHAS_SIBLING(cLISTOPo->op_first))
         op_append_elem(OP_GLOB, o, newDEFSVOP()); /* glob() => glob($_) */
 
-    if (!(o->op_flags & OPf_SPECIAL) && (gv = gv_override("glob", 4)))
+    if (!(o->op_flags & OPf_SPECIAL) && (gv = gv_override_pvs("glob")))
     {
         /* convert
          *     glob
@@ -14118,7 +14118,7 @@ Perl_ck_require(pTHX_ OP *o)
 
     if (!(o->op_flags & OPf_SPECIAL) /* Wasn't written as CORE::require */
         /* handle override, if any */
-     && (gv = gv_override("require", 7))) {
+     && (gv = gv_override_pvs("require"))) {
         OP *kid, *newop;
         if (o->op_flags & OPf_KIDS) {
             kid = cUNOPo->op_first;

--- a/toke.c
+++ b/toke.c
@@ -11462,7 +11462,7 @@ S_scan_inputsymbol(pTHX_ char *start)
             Copy("ARGV",d,5,char);
 
         /* Check whether readline() is overridden */
-        if ((gv_readline = gv_override("readline",8)))
+        if ((gv_readline = gv_override_pvs("readline")))
             readline_overridden = TRUE;
 
         /* if <$fh>, create the ops to turn the variable into a


### PR DESCRIPTION
- gv_override() is not exported from libperl on any OS
- gv_overridepvs() is harder to read, gv_overrides() is an obfuscated name

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
