### PR TITLE
cpan/Scalar-List-Utils - Re-Update to version 1.69

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1010,16 +1010,8 @@ our %Modules = (
 
     'Scalar::Util' => {
         'DISTRIBUTION' => 'PEVANS/Scalar-List-Utils-1.69.tar.gz',
-        'SYNCINFO'     => 'jkeenan on Thu Apr 10 21:01:49 2025',
+        'SYNCINFO'     => 'jkeenan on Fri Jul 11 19:22:58 2025',
         'FILES'        => q[cpan/Scalar-List-Utils],
-        'CUSTOMIZED'   => [
-            'ListUtil.xs',
-            'lib/List/Util.pm',
-            'lib/List/Util/XS.pm',
-            'lib/Scalar/Util.pm',
-            'lib/Sub/Util.pm',
-            't/exotic_names.t'
-         ],
     },
 
     'Search::Dict' => {

--- a/cpan/Scalar-List-Utils/ListUtil.xs
+++ b/cpan/Scalar-List-Utils/ListUtil.xs
@@ -1852,10 +1852,10 @@ CODE:
 #ifdef SvVOK
     SvGETMAGIC(sv);
     ST(0) = boolSV(SvVOK(sv));
-    XSRETURN(1);
 #else
-    croak("vstrings are not implemented in this release of perl");
+    ST(0) = boolSV(0);
 #endif
+    XSRETURN(1);
 
 SV *
 looks_like_number(sv)
@@ -1951,8 +1951,10 @@ PREINIT:
     STRLEN namelen;
     const char* nameptr = SvPV(name, namelen);
     int utf8flag = SvUTF8(name);
+#if PERL_VERSION_LT(5, 41, 3)
     int quotes_seen = 0;
     bool need_subst = FALSE;
+#endif
 PPCODE:
     if (!SvROK(sub) && SvGMAGICAL(sub))
         mg_get(sub);
@@ -1975,18 +1977,23 @@ PPCODE:
         if (s > nameptr && *s == ':' && s[-1] == ':') {
             end = s - 1;
             begin = ++s;
+#if PERL_VERSION_LT(5, 41, 3)
             if (quotes_seen)
                 need_subst = TRUE;
+#endif
         }
+#if PERL_VERSION_LT(5, 41, 3)
         else if (s > nameptr && *s != '\0' && s[-1] == '\'') {
             end = s - 1;
             begin = s;
             if (quotes_seen++)
                 need_subst = TRUE;
         }
+#endif
     }
     s--;
     if (end) {
+#if PERL_VERSION_LT(5, 41, 3)
         SV* tmp;
         if (need_subst) {
             STRLEN length = end - nameptr + quotes_seen - (*end == '\'' ? 1 : 0);
@@ -2006,6 +2013,7 @@ PPCODE:
             stash = gv_stashpvn(left, length, GV_ADD | utf8flag);
         }
         else
+#endif
             stash = gv_stashpvn(nameptr, end - nameptr, GV_ADD | utf8flag);
         nameptr = begin;
         namelen -= begin - nameptr;
@@ -2101,20 +2109,9 @@ BOOT:
     HV *lu_stash = gv_stashpvn("List::Util", 10, TRUE);
     GV *rmcgv = *(GV**)hv_fetch(lu_stash, "REAL_MULTICALL", 14, TRUE);
     SV *rmcsv;
-#if !defined(SvVOK)
-    HV *su_stash = gv_stashpvn("Scalar::Util", 12, TRUE);
-    GV *vargv = *(GV**)hv_fetch(su_stash, "EXPORT_FAIL", 11, TRUE);
-    AV *varav;
-    if(SvTYPE(vargv) != SVt_PVGV)
-        gv_init(vargv, su_stash, "Scalar::Util", 12, TRUE);
-    varav = GvAVn(vargv);
-#endif
     if(SvTYPE(rmcgv) != SVt_PVGV)
         gv_init(rmcgv, lu_stash, "List::Util", 10, TRUE);
     rmcsv = GvSVn(rmcgv);
-#ifndef SvVOK
-    av_push(varav, newSVpv("isvstring",9));
-#endif
 #ifdef REAL_MULTICALL
     sv_setsv(rmcsv, &PL_sv_yes);
 #else

--- a/cpan/Scalar-List-Utils/lib/List/Util.pm
+++ b/cpan/Scalar-List-Utils/lib/List/Util.pm
@@ -16,7 +16,7 @@ our @EXPORT_OK  = qw(
   sample shuffle uniq uniqint uniqnum uniqstr zip zip_longest zip_shortest mesh mesh_longest mesh_shortest
   head tail pairs unpairs pairkeys pairvalues pairmap pairgrep pairfirst
 );
-our $VERSION    = "1.68_01";
+our $VERSION    = "1.69";
 our $XS_VERSION = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/cpan/Scalar-List-Utils/lib/List/Util/XS.pm
+++ b/cpan/Scalar-List-Utils/lib/List/Util/XS.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use List::Util;
 
-our $VERSION = "1.68_01";       # FIXUP
+our $VERSION = "1.69";       # FIXUP
 $VERSION =~ tr/_//d;         # FIXUP
 
 1;

--- a/cpan/Scalar-List-Utils/lib/Scalar/Util.pm
+++ b/cpan/Scalar-List-Utils/lib/Scalar/Util.pm
@@ -17,7 +17,7 @@ our @EXPORT_OK = qw(
   dualvar isdual isvstring looks_like_number openhandle readonly set_prototype
   tainted
 );
-our $VERSION    = "1.68_01";
+our $VERSION    = "1.69";
 $VERSION =~ tr/_//d;
 
 require List::Util; # List::Util loads the XS
@@ -34,16 +34,6 @@ if( $] >= 5.040 ) {
 
   *$_ = \&{ $builtins->{$_} } for (qw( blessed refaddr reftype weaken unweaken ));
   *isweak = \&{ $builtins->{is_weak} };  # renamed
-}
-
-# populating @EXPORT_FAIL is done in the XS code
-sub export_fail {
-  if (grep { /^isvstring$/ } @_ ) {
-    require Carp;
-    Carp::croak("Vstrings are not implemented in this version of perl");
-  }
-
-  @_;
 }
 
 # set_prototype has been moved to Sub::Util with a different interface

--- a/cpan/Scalar-List-Utils/lib/Sub/Util.pm
+++ b/cpan/Scalar-List-Utils/lib/Sub/Util.pm
@@ -15,7 +15,7 @@ our @EXPORT_OK = qw(
   subname set_subname
 );
 
-our $VERSION    = "1.68_01";
+our $VERSION    = "1.69";
 $VERSION =~ tr/_//d;
 
 require List::Util; # as it has the XS

--- a/cpan/Scalar-List-Utils/t/exotic_names.t
+++ b/cpan/Scalar-List-Utils/t/exotic_names.t
@@ -45,7 +45,7 @@ sub caller3_ok {
         ),
     );
 
-    $expected =~ s/'/::/g if $] < 5.037009 || $] >= 5.041_004;
+    $expected =~ s/'/::/g if $] < 5.041_003;
 
     # this is apparently how things worked before 5.16
     utf8::encode($expected) if $] < 5.016 and $ord > 255;
@@ -72,7 +72,7 @@ my @ordinal = (
     ($] >= 5.014 ? ( 0 ) : ()),
     1 .. 38,
     # single quote ' separators are deprecated in 5.37.9
-    ($] < 5.037009 || $] >= 5.041_004 ? ( 39 ) : ()),
+    ($] < 5.037009 ? ( 39 ) : ()),
     40 .. 255,
     # Unicode in 5.6 is not sane (crashes etc)
     ($] >= 5.008 ? (
@@ -85,7 +85,7 @@ my @ordinal = (
 
 my $legal_ident_char = join('',
     "A-Z_a-z0-9",
-    ($] < 5.037009 || $] >= 5.041_004 ? q['] : ()),
+    ($] < 5.037009 ? q['] : ()),
     ($] > 5.008 ? (
         map chr, 0x100, 0x498
     ) : ()),


### PR DESCRIPTION
1.69 -- 2025-04-01
	[CHANGES]
	 * Always allow `isvstring` to be exported even on Perl 5.6, where it just returns false
	 * Fix string comparison logic that compares versions with `$]`

Committer: De-customize entry for Scalar::Util

Fixes: GH #23432

