### PR TITLE
'try' and 'catch' are no longer experimental

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -11141,8 +11141,10 @@ documented in L<perlsyn/"Switch Statements">.
 
 =item finally
 
-These flow-control keywords related to the experimental C<try> feature are
-documented in L<perlsyn/"Try Catch Exception Handling">.
+These flow-control keywords related to the C<try> feature are
+documented in L<perlsyn/"Try Catch Exception Handling">.  C<finally> is still
+deemed to be experimental; C<try> and C<catch> are considered non-experimental
+as of perl-5.40.
 
 =back
 


### PR DESCRIPTION
Responding to report from William Lindley in GH #23436.

This pull request addresses only the issue raised with respect to `pod/perlfunc.pod`.  Changes to `pod/perlsyn.pod` remain for discussion in that ticket.

