### PR TITLE
Add some missing bits in features documentation: class, keyword_any, keyword_all

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -965,6 +965,7 @@ Mattia Barbon                  <mattia@barbon.org>
 Maurizio Loreti                <maurizio.loreti@pd.infn.it>
 Max Baker                      <max@warped.org>
 Max Maischein                  <corion@corion.net>
+Maxim Vuets                    <maxim.vuets@gmail.com>
 Maxwell Carey                  <maxwellhaydn@gmail.com>
 Merijn Broeren                 <merijnb@iloquent.nl>
 Michael A Chase                <mchase@ix.netcom.com>

--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -4,7 +4,7 @@
 # Any changes made here will be lost!
 
 package feature;
-our $VERSION = '1.98';
+our $VERSION = '1.99';
 
 our %feature = (
     fc                              => 'feature_fc',
@@ -535,6 +535,8 @@ warn when you use the feature, unless you have explicitly disabled the warning:
 This feature enables the C<class> block syntax and other associated keywords
 which implement the "new" object system, previously codenamed "Corinna".
 
+This feature is available starting in Perl 5.38.
+
 =head2 The 'apostrophe_as_package_separator' feature
 
 This feature enables use C<'> (apostrophe) as an alternative to using
@@ -559,6 +561,8 @@ This feature enables the L<C<any>|perlfunc/any BLOCK LIST> operator keyword.
 This allow testing whether any of the values in a list satisfy a given
 condition, with short-circuiting behaviour as soon as it finds one.
 
+This feature is available starting in Perl 5.42.
+
 =head2 The 'keyword_all' feature
 
 B<WARNING>: This feature is still experimental and the implementation may
@@ -571,6 +575,8 @@ This feature enables the L<C<all>|perlfunc/all BLOCK LIST> operator keyword.
 This allow testing whether all of the values in a list satisfy a given
 condition, with short-circuiting behaviour as soon as it finds one that does
 not.
+
+This feature is available starting in Perl 5.42.
 
 =head1 FEATURE BUNDLES
 

--- a/pod/perlexperiment.pod
+++ b/pod/perlexperiment.pod
@@ -173,6 +173,18 @@ example:
 The ticket for this experiment is
 L<[perl #19765]|https://github.com/Perl/perl5/issues/19765>.
 
+=item New object system and C<class> syntax
+
+Introduced in Perl 5.37.9.
+
+Using this feature triggers warnings in the category C<experimental::class>.
+
+This feature enables the new object system and its associated keywords
+C<class>, C<field>, C<method>.
+
+The ticket for this experiment is
+L<[perl #22139]|https://github.com/Perl/perl5/issues/22139>.
+
 =item C<any> and C<all> list processing operators
 
 Introduced in Perl 5.41.7.

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -621,7 +621,7 @@ read_only_bottom_close_and_rename($h);
 
 __END__
 package feature;
-our $VERSION = '1.98';
+our $VERSION = '1.99';
 
 FEATURES
 
@@ -1067,6 +1067,8 @@ warn when you use the feature, unless you have explicitly disabled the warning:
 This feature enables the C<class> block syntax and other associated keywords
 which implement the "new" object system, previously codenamed "Corinna".
 
+This feature is available starting in Perl 5.38.
+
 =head2 The 'apostrophe_as_package_separator' feature
 
 This feature enables use C<'> (apostrophe) as an alternative to using
@@ -1091,6 +1093,8 @@ This feature enables the L<C<any>|perlfunc/any BLOCK LIST> operator keyword.
 This allow testing whether any of the values in a list satisfy a given
 condition, with short-circuiting behaviour as soon as it finds one.
 
+This feature is available starting in Perl 5.42.
+
 =head2 The 'keyword_all' feature
 
 B<WARNING>: This feature is still experimental and the implementation may
@@ -1103,6 +1107,8 @@ This feature enables the L<C<all>|perlfunc/all BLOCK LIST> operator keyword.
 This allow testing whether all of the values in a list satisfy a given
 condition, with short-circuiting behaviour as soon as it finds one that does
 not.
+
+This feature is available starting in Perl 5.42.
 
 =head1 FEATURE BUNDLES
 


### PR DESCRIPTION
I was adding missing features to experimental.pm. I couldn't find direct answers in which Perl versions the missing features (class, keyword_any, and keyword_all) were introduced. I had to do some code spelunking to figure it out. This patch is the result of my tiny investigation.
