### PR TITLE
perlapi: Remove non-existent #define

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -1619,7 +1619,6 @@ The caller, of course, is responsible for freeing any returned AV.
 =for apidoc Amnh||UTF8_ALLOW_LONG
 =for apidoc Amnh||UTF8_ALLOW_NON_CONTINUATION
 =for apidoc Amnh||UTF8_ALLOW_OVERFLOW
-=for apidoc Amnh||UTF8_ALLOW_PERL_EXTENDED
 =for apidoc Amnh||UTF8_ALLOW_SHORT
 =for apidoc Amnh||UTF8_CHECK_ONLY
 =for apidoc Amnh||UTF8_DISALLOW_ILLEGAL_C9_INTERCHANGE


### PR DESCRIPTION
This generated a spurious index entry, as this symbol doesn't actually  exist.

* This set of changes does not require a perldelta entry.
