### PR TITLE
Remove unused override_recoding flag in struct RExC_state_t

### DIFF
--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -142,7 +142,6 @@ struct RExC_state_t {
     U32         study_chunk_recursed_bytes;  /* bytes in bitmap */
     I32         in_lookaround;
     I32         contains_locale;
-    I32         override_recoding;
     I32         recode_x_to_native;
     I32         in_multi_char_class;
     int         code_index;             /* next code_blocks[] slot */


### PR DESCRIPTION
Commit fc54a9b2090b5f71905241c319706e3cca18acc9 removed the use of it, but failed to remove the actual field from the struct.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
