### PR TITLE
cpan/Socket - Update to version 2.040

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1034,8 +1034,8 @@ our %Modules = (
     },
 
     'Socket' => {
-        'DISTRIBUTION' => 'PEVANS/Socket-2.038.tar.gz',
-        'SYNCINFO'     => 'LeoNerd on Sat Apr 27 09:57:02 2024',
+        'DISTRIBUTION' => 'PEVANS/Socket-2.040.tar.gz',
+        'SYNCINFO'     => 'jkeenan on Wed Jul 16 09:34:44 2025',
         'FILES'        => q[cpan/Socket],
         'EXCLUDED'     => ['.editorconfig'],
     },

--- a/cpan/Socket/Socket.pm
+++ b/cpan/Socket/Socket.pm
@@ -3,7 +3,7 @@ package Socket;
 use v5.6.1;
 use strict;
 
-our $VERSION = '2.038';
+our $VERSION = '2.040';
 
 =head1 NAME
 

--- a/cpan/Socket/Socket.xs
+++ b/cpan/Socket/Socket.xs
@@ -997,17 +997,21 @@ pack_sockaddr_in(port_sv, ip_address_sv)
         STRLEN addrlen;
         unsigned short port = 0;
         char * ip_address;
+
+        SvGETMAGIC(port_sv);
         if (SvOK(port_sv)) {
-            port = SvUV(port_sv);
-            if (SvUV(port_sv) > 0xFFFF)
+            port = SvUV_nomg(port_sv);
+            if (SvUV_nomg(port_sv) > 0xFFFF)
                 warn("Port number above 0xFFFF, will be truncated to %d for %s",
                         port, "Socket::pack_sockaddr_in");
         }
+
+        SvGETMAGIC(ip_address_sv);
         if (!SvOK(ip_address_sv))
             croak("Undefined address for %s", "Socket::pack_sockaddr_in");
+        ip_address = SvPVbyte_nomg(ip_address_sv, addrlen);
         if (DO_UTF8(ip_address_sv) && !sv_utf8_downgrade(ip_address_sv, 1))
             croak("Wide character in %s", "Socket::pack_sockaddr_in");
-        ip_address = SvPVbyte(ip_address_sv, addrlen);
         if (addrlen == sizeof(addr) || addrlen == 4)
             addr.s_addr =
                 (unsigned int)(ip_address[0] & 0xFF) << 24 |
@@ -1073,17 +1077,21 @@ pack_sockaddr_in6(port_sv, sin6_addr, scope_id=0, flowinfo=0)
         struct sockaddr_in6 sin6;
         char * addrbytes;
         STRLEN addrlen;
+
+        SvGETMAGIC(port_sv);
         if (SvOK(port_sv)) {
-            port = SvUV(port_sv);
-            if (SvUV(port_sv) > 0xFFFF)
+            port = SvUV_nomg(port_sv);
+            if (SvUV_nomg(port_sv) > 0xFFFF)
                 warn("Port number above 0xFFFF, will be truncated to %d for %s",
                         port, "Socket::pack_sockaddr_in6");
         }
+
+        SvGETMAGIC(sin6_addr);
         if (!SvOK(sin6_addr))
             croak("Undefined address for %s", "Socket::pack_sockaddr_in6");
+        addrbytes = SvPVbyte_nomg(sin6_addr, addrlen);
         if (DO_UTF8(sin6_addr) && !sv_utf8_downgrade(sin6_addr, 1))
             croak("Wide character in %s", "Socket::pack_sockaddr_in6");
-        addrbytes = SvPVbyte(sin6_addr, addrlen);
         if (addrlen != sizeof(sin6.sin6_addr))
             croak("Bad arg length %s, length is %" UVuf ", should be %" UVuf,
                     "Socket::pack_sockaddr_in6", (UV)addrlen, (UV)sizeof(sin6.sin6_addr));

--- a/cpan/Socket/t/sockaddr.t
+++ b/cpan/Socket/t/sockaddr.t
@@ -12,7 +12,7 @@ use Socket qw(
     sockaddr_family
     sockaddr_un
 );
-use Test::More tests => 50;
+use Test::More tests => 52;
 
 # inet_aton, inet_ntoa
 {
@@ -99,13 +99,19 @@ SKIP: {
         'pack_sockaddr_in oversized port is allowed' );
     like( $warnings, qr/^Port number above 0xFFFF, will be truncated to 33229 for Socket::pack_sockaddr_in at /,
         'pack_sockaddr_in oversized port warning' );
+
+    # GETMAGIC is invoked (RT166524)
+    local $1;
+    "2057" =~ m/^(\d+)$/;
+    $sin = pack_sockaddr_in $1, inet_aton("10.20.30.40");
+    is( (unpack_sockaddr_in($sin))[0], 2057, 'pack_sockaddr_in invokes GETMAGIC on port argument' );
 }
 
 # pack_sockaddr_in6, unpack_sockaddr_in6
 # sockaddr_in6
 SKIP: {
-    skip "No AF_INET6", 15 unless my $AF_INET6 = eval { Socket::AF_INET6() };
-    skip "Cannot pack_sockaddr_in6()", 15 unless my $sin6 = eval { Socket::pack_sockaddr_in6(0x1234, "0123456789abcdef", 0, 89) };
+    skip "No AF_INET6", 16 unless my $AF_INET6 = eval { Socket::AF_INET6() };
+    skip "Cannot pack_sockaddr_in6()", 16 unless my $sin6 = eval { Socket::pack_sockaddr_in6(0x1234, "0123456789abcdef", 0, 89) };
 
     ok(defined $sin6, 'pack_sockaddr_in6 defined');
 
@@ -140,6 +146,12 @@ SKIP: {
         'pack_sockaddr_in6 oversized port is allowed' );
     like( $warnings, qr/^Port number above 0xFFFF, will be truncated to 33229 for Socket::pack_sockaddr_in6 at /,
         'pack_sockaddr_in6 oversized port warning' );
+
+    # GETMAGIC is invoked (RT166524)
+    local $1;
+    "2057" =~ m/^(\d+)$/;
+    $sin6 = Socket::pack_sockaddr_in6 $1, "0123456789abcdef";
+    is( (Socket::unpack_sockaddr_in6($sin6))[0], 2057, 'pack_sockaddr_in6 invokes GETMAGIC on port argument' );
 }
 
 # sockaddr_un on abstract paths


### PR DESCRIPTION
2.040   2025-07-16
        [BUGFIXES]
         * Fix test skip count for INET6 sockaddr tests (RT168005)
           (no code change other than unit tests)

2.039   2025-06-25
        [BUGFIXES]
         * Make sure to invoke GETMAGIC on arguments to `pack_sockaddr_in` and
           `pack_sockaddr_in6` (RT166524)

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
TODO: fill description here

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
* This set of changes requires a perldelta entry, and I need help writing it.
* This set of changes does not require a perldelta entry.
