### PR TITLE
Apply scalar context to LSLICE and ASLICE more thoroughly

### DIFF
--- a/op.c
+++ b/op.c
@@ -2027,6 +2027,10 @@ Perl_scalar(pTHX_ OP *o)
         case OP_LIST:
             kid = cLISTOPo->op_first;
             goto do_kids;
+        case OP_LSLICE:
+                assert(OP_TYPE_IS_OR_WAS(cLISTOPo->op_first, OP_LIST));
+                kid = cLISTOPx(cLISTOPo->op_first)->op_first;
+                goto do_kids;
         case OP_LEAVE:
         case OP_LEAVETRY:
             kid = cLISTOPo->op_first;

--- a/op.c
+++ b/op.c
@@ -2027,6 +2027,19 @@ Perl_scalar(pTHX_ OP *o)
         case OP_LIST:
             kid = cLISTOPo->op_first;
             goto do_kids;
+        case OP_ASLICE: {
+                OP * first = cLISTOPo->op_first;
+                assert(OP_TYPE_IS(first, OP_PUSHMARK));
+                assert(first->op_moresib);
+                OP * sib = OpSIBLING(first);
+                if(OP_TYPE_IS_OR_WAS(sib, OP_LIST)) {
+                    kid = cLISTOPx(sib)->op_first;
+                    goto do_kids;
+                }
+                if (o->op_flags & OPf_KIDS)
+                    next_kid = cUNOPo->op_first; /* do all kids */
+                break;
+            }
         case OP_LSLICE:
                 assert(OP_TYPE_IS_OR_WAS(cLISTOPo->op_first, OP_LIST));
                 kid = cLISTOPx(cLISTOPo->op_first)->op_first;

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -220,6 +220,21 @@ XXX Changes (i.e. rewording) of diagnostic messages go here
 
 XXX Describe change here
 
+=item *
+
+L<Useless use of %s in void context|perldiag/"Useless use of %s in void context">
+
+Scalar context was not always applied to arguments passed to list/array
+slices in the same way that is is applied elsewhere. This has been improved
+to reduce unnecessary OPs being executed at runtime. As a consequence, some
+statements may now trigger warnings when they previously did not.
+
+For example, in C<my $x = (caller)[4,3,2];> or C<my $x = @y[4,3,2];>,
+warnings will now be emitted for the C<4> and C<3> arguments.
+
+Note that the existing, documented behaviour of not warning for numerical
+constants equal to C<0> or C<1> still applies.
+
 =back
 
 =head1 Utility Changes


### PR DESCRIPTION
`Perl_scalar` is used to apply scalar context to OPs. This process can also
result in some KID OPs being nulled out. However, this has not happened
to `OP_LSLICE` and `OP_ASLICE` trees to the extent that seems possible.

For example, with `my $x = (1,2,3)`, the resulting optree (pre-peephole
optimisation) is:
```
2     <;> nextstate(main 2 -e:1) v:%,us,{,fea=15 ->3
7     <2> sassign vKS/2 ->8
5        <@> list sKP ->6
3           <0> pushmark v ->4
-           <0> ex-const v ->-
-           <0> ex-const v ->4
4           <$> const[IV 3] s ->5
6        <0> padsv[$x:2,3] sRM*/LVINTRO ->7
```
The interpreter only needs to execute the one `CONST` OP in scalar
context to get the correct behaviour.

This PR adds `OP_LSLICE` and `OP_ASLICE` cases to the switch
statement within `Perl_scalar` so that the same optimisation
occurs for those optrees. Previously, it did not, meaning that
unnecessary operations would be performed at runtime, with the
results then just ignored.

Note that the following seem desirable, but would need a broader
refactoring of `Perl_scalar`, and are so out of scope of this PR:
* Discarding, rather than just nulling, the unnecessary `CONST` OPs
* Extracting the remaining valid OP and discarding the `list`/`ex-list` container and its `pushmark` OP.

i.e. Future work could try to get the above optree down to:
```
2     <;> nextstate(main 2 -e:1) v:%,us,{,fea=15 ->3
5     <2> sassign vKS/2 ->6
3        <$> const[IV 3] s ->4
4        <0> padsv[$x:2,3] sRM*/LVINTRO ->5
```

---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
