### PR TITLE
perlintro: fix minor grammar mistake

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -74,6 +74,7 @@ Alexander Gernler              <alexander_gernler@genua.de>
 Alexander Gough                <alex-p5p@earth.li>
 Alexander Hartmaier            <abraxxa@cpan.org>
 Alexander Kanavin              <alex@linutronix.de>
+Alexander Karelas              <karjala@cpan.org>
 Alexander Klimov               <ask@wisdom.weizmann.ac.il>
 Alexander Nikolov              <sasho648@gmail.com>
 Alexander Smishlajev           <als@turnhere.com>

--- a/pod/perlintro.pod
+++ b/pod/perlintro.pod
@@ -284,7 +284,7 @@ To get at hash elements:
  $fruit_color{"apple"};           # gives "red"
 
 Note again the use of the C<$> sigil to access a single hash element.
-The curly braces C<{...}> indicate that it is an hash that we are
+The curly braces C<{...}> indicate that it is a hash that we are
 getting the value from.
 
 And we can get multiple values using a slice


### PR DESCRIPTION
Fix "an hash" grammar mistake in perlintro doc page, to "a hash".