### PR TITLE
 Improve documentation of sv_dup and sv_dup_inc 

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -6364,9 +6364,9 @@ CRdp	|PERL_SI *|si_dup	|NULLOK PERL_SI *si			\
 				|NN CLONE_PARAMS *param
 CRdp	|ANY *	|ss_dup 	|NN PerlInterpreter *proto_perl 	\
 				|NN CLONE_PARAMS *param
-CRdp	|SV *	|sv_dup 	|NULLOK const SV * const ssv		\
+ARdp	|SV *	|sv_dup 	|NULLOK const SV * const ssv		\
 				|NN CLONE_PARAMS * const param
-CRdp	|SV *	|sv_dup_inc	|NULLOK const SV * const ssv		\
+ARdp	|SV *	|sv_dup_inc	|NULLOK const SV * const ssv		\
 				|NN CLONE_PARAMS * const param
 # if defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C)
 p	|void	|op_relocate_sv |NN SV **svp				\

--- a/sv.c
+++ b/sv.c
@@ -14974,18 +14974,18 @@ S_sv_dup_common(pTHX_ const SV *const ssv, CLONE_PARAMS *const param)
 
 In spite of their generic names, these are very specialized functions mainly
 for use when cloning an interpreter instance.  You are probably looking for
-L<perlapi/newSVsv>.
+L<perlapi/newSVsv>. Generally speaking you will only want to use these in
+either a C<svt_dup> magic handler, or a C<CLONE> method.
 
 They duplicate an SV of any type (not just a plain SV, but including AV, HV
-I<etc>.), returning a pointer to the cloned object.  The difference is that the
-new SV under C<sv_dup> has a reference count of 0, but 1 under C<sv_dup_inc>.
-Only specialized cases will want a zero reference count, almost certainly only
-when you aren't already holding a reference.  Thus, you almost always want to
-use the C<sv_dup_inc> form.
+I<etc>.), returning a pointer to the cloned object. The cloning process uses a
+lookup table, so that if a particular source SV address has already been duped,
+that duped SV is returned rather than creating a second duplicate.
 
-The cloning process uses a cache, so that if a particular SV address has
-already been duped, that duped SV is returned again rather than creating a
-second duplicate.
+The difference is that the new SV under C<sv_dup> will not have its reference count incremented
+(potentially causing it to be zero), unlike under C<sv_dup_inc>. This is only
+desirable when cloning a non-owning pointer. Thus, you almost always want to use
+the C<sv_dup_inc> form.
 
 C<param> has type S<C<CLONE_PARAMS *>>.  This is mostly for internal core use
 when duplicating something more complicated than an SV (code in common is


### PR DESCRIPTION
This is a follow-up on #22291

This reverts marking these functions as core-only. They really need to be API because it's often impossible to write thread-safe XS modules without them.

I've added an explanation of when exactly you need these functions, without that it's rather unclear when you'd need them (and when not).

This also clarifies that the pointer table is in fact not a cache, but an essential element of the cloning process. Without it, an non-incremented `sv_dup` wouldn't even make sense (something else would need to dup and increment it).

I haven't touched the last paragraph because that needs #23325 to be resolved first.

* This set of changes does not require a perldelta entry.
