### PR TITLE
embed.fnc: _invlist_union() not publicly accessible

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4363,7 +4363,7 @@ m	|void	|_invlist_subtract					\
 				|NN SV * const a			\
 				|NN SV * const b			\
 				|NN SV **result
-Cm	|void	|_invlist_union |NULLOK SV * const a			\
+m	|void	|_invlist_union |NULLOK SV * const a			\
 				|NN SV * const b			\
 				|NN SV **output
 EXp	|void	|_invlist_union_maybe_complement_2nd			\


### PR DESCRIPTION
This macro is defined only when for certain .c files, so should not be marked as publicly accessible


* This set of changes does not require a perldelta entry.
