### PR TITLE
regen/embed.pl  Use /xx to clarify regex

### DIFF
--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -122,7 +122,7 @@ sub generate_proto_h {
         my $inner_ind= $ind ? "  " : " ";
 
         my ($flags,$retval,$plain_func,$args) = @{$embed}{qw(flags return_type name args)};
-        if ($flags =~ / ( [^AabCDdEefFGhIiMmNnOoPpRrSsTUuvWXx;] ) /x) {
+        if ($flags =~ / ( [^ AabCDdEefFGhIiMmNnOoPpRrSsTUuvWXx;] ) /xx) {
             die_at_end "flag $1 is not legal (for function $plain_func)";
         }
         my @nonnull;


### PR DESCRIPTION
The '^' meaning to complement this bracketed character class got lost to the eye in the thicket of all the other characters in it.  This adds white space to separate it out


* This set of changes does not require a perldelta entry.
