### PR TITLE
Convert Perl_uvoffuni_to_utf8_flags to a macro

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3855,7 +3855,7 @@ Admp	|U8 *	|uvchr_to_utf8_flags_msgs				\
 				|UV uv					\
 				|UV flags				\
 				|NULLOK HV **msgs
-CMdp	|U8 *	|uvoffuni_to_utf8_flags 				\
+Cdmp	|U8 *	|uvoffuni_to_utf8_flags 				\
 				|NN U8 *d				\
 				|UV uv					\
 				|UV flags

--- a/embed.h
+++ b/embed.h
@@ -2371,6 +2371,7 @@
 #   define Perl_uvchr_to_utf8(mTHX,a,b)         uvchr_to_utf8(a,b)
 #   define Perl_uvchr_to_utf8_flags(mTHX,a,b,c) uvchr_to_utf8_flags(a,b,c)
 #   define Perl_uvchr_to_utf8_flags_msgs(mTHX,a,b,c,d) uvchr_to_utf8_flags_msgs(a,b,c,d)
+#   define Perl_uvoffuni_to_utf8_flags(mTHX,a,b,c) uvoffuni_to_utf8_flags(a,b,c)
 #   define Perl_whichsig(mTHX,a)                whichsig(a)
 #   define thread_locale_init()                 Perl_thread_locale_init(aTHX)
 #   define thread_locale_term()                 Perl_thread_locale_term(aTHX)
@@ -2471,6 +2472,7 @@
 #   define Perl_uvchr_to_utf8                   uvchr_to_utf8
 #   define Perl_uvchr_to_utf8_flags             uvchr_to_utf8_flags
 #   define Perl_uvchr_to_utf8_flags_msgs        uvchr_to_utf8_flags_msgs
+#   define Perl_uvoffuni_to_utf8_flags          uvoffuni_to_utf8_flags
 #   define Perl_whichsig                        whichsig
 #   if defined(PERL_DONT_CREATE_GVSV)
 #     define Perl_gv_SVadd                      gv_SVadd

--- a/proto.h
+++ b/proto.h
@@ -5483,10 +5483,8 @@ Perl_uvchr_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags); */
 /* PERL_CALLCONV U8 *
 Perl_uvchr_to_utf8_flags_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs); */
 
-PERL_CALLCONV U8 *
-Perl_uvoffuni_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags);
-#define PERL_ARGS_ASSERT_UVOFFUNI_TO_UTF8_FLAGS \
-        assert(d)
+/* PERL_CALLCONV U8 *
+Perl_uvoffuni_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags); */
 
 PERL_CALLCONV U8 *
 Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, const UV flags, HV **msgs);

--- a/utf8.c
+++ b/utf8.c
@@ -105,30 +105,6 @@ S_new_msg_hv(pTHX_ const char * const message, /* The message text */
     return msg_hv;
 }
 
-/*
-=for apidoc uvoffuni_to_utf8_flags
-
-THIS FUNCTION SHOULD BE USED IN ONLY VERY SPECIALIZED CIRCUMSTANCES.
-Instead, B<Almost all code should use L<perlapi/uv_to_utf8> or
-L<perlapi/uv_to_utf8_flags>>.
-
-This function is like them, but the input is a strict Unicode
-(as opposed to native) code point.  Only in very rare circumstances should code
-not be using the native code point.
-
-For details, see the description for L<perlapi/uv_to_utf8_flags>.
-
-=cut
-*/
-
-U8 *
-Perl_uvoffuni_to_utf8_flags(pTHX_ U8 *d, UV uv, const UV flags)
-{
-    PERL_ARGS_ASSERT_UVOFFUNI_TO_UTF8_FLAGS;
-
-    return uvoffuni_to_utf8_flags_msgs(d, uv, flags, NULL);
-}
-
 /* All these formats take a single UV code point argument */
 const char surrogate_cp_format[] = "UTF-16 surrogate U+%04" UVXf;
 const char nonchar_cp_format[]   = "Unicode non-character U+%04" UVXf

--- a/utf8.h
+++ b/utf8.h
@@ -139,6 +139,21 @@ typedef enum {
 #define is_ascii_string(s, len)     is_utf8_invariant_string(s, len)
 #define is_invariant_string(s, len) is_utf8_invariant_string(s, len)
 
+/*
+=for apidoc uvoffuni_to_utf8_flags
+
+THIS FUNCTION SHOULD BE USED IN ONLY VERY SPECIALIZED CIRCUMSTANCES.
+Instead, B<Almost all code should use L<perlapi/uv_to_utf8> or
+L<perlapi/uv_to_utf8_flags>>.
+
+This function is like them, but the input is a strict Unicode
+(as opposed to native) code point.  Only in very rare circumstances should code
+not be using the native code point.
+
+For details, see the description for L<perlapi/uv_to_utf8_flags>.
+
+=cut
+*/
 #define uvoffuni_to_utf8_flags(d,uv,flags)                                     \
                                uvoffuni_to_utf8_flags_msgs(d, uv, flags, 0)
 


### PR DESCRIPTION
The function is hereby removed in favor of calling the plain uvoffuni_to_utf8_flags macro that already exists

* This set of changes does not require a perldelta entry.
