### PR TITLE
regcomp_trie: stringify *tmp before accessing string fields

### DIFF
--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -224,9 +224,11 @@ S_dump_trie_interim_table(pTHX_ const struct _reg_trie_data *trie,
     for( charid = 0 ; charid < trie->uniquecharcount ; charid++ ) {
         SV ** const tmp = av_fetch_simple( revcharmap, charid, 0);
         if ( tmp ) {
+            STRLEN n;
+            const char *s = SvPV_const(*tmp, n);
             Perl_re_printf( aTHX_  "%*s",
                 colwidth,
-                pv_pretty(sv, SvPV_nolen_const(*tmp), SvCUR(*tmp), colwidth,
+                pv_pretty(sv, s, n, colwidth,
                             PL_colors[0], PL_colors[1],
                             (SvUTF8(*tmp) ? PERL_PV_ESCAPE_UNI : 0) |
                             PERL_PV_ESCAPE_FIRSTCHAR


### PR DESCRIPTION
... such as SvCUR(*tmp) and SvUTF8(*tmp).

Fixes Coverity ID 582459: Evaluation order violation (EVALUATION_ORDER)

> read_write_order: In argument #<span></span>3 of `Perl_pv_pretty(my_perl, sv, (char const *)Perl_SvPV_helper(my_perl, *tmp, NULL, 2U, SvPVnormal_type_, Perl_sv_2pv_flags, false, 32U), *({...; &((XPV *)({...; p_;}))->xpv_cur;}), colwidth, my_perl->Icolors[0], my_perl->Icolors[1], (((*tmp)->sv_flags & 0x20000000U) ? 256 : 0) | 0x800)`, a call is made to `Perl_SvPV_helper(my_perl, *tmp, NULL, 2U, SvPVnormal_type_, Perl_sv_2pv_flags, false, 32U)`. In argument #<span></span>2 of this function, the object `(*tmp)->sv_flags` is modified. This object is also used in `(((*tmp)->sv_flags & 0x20000000U) ? 256 : 0) | 0x800`, the argument #<span></span>8 of the outer function call. The order in which these arguments are evaluated is not specified, and will vary between platforms.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
