### PR TITLE
Resolve any symlinks to cwd in dylib install name

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1243,6 +1243,7 @@ Russ Allbery                   <eagle@eyrie.org>
 Russel O'Connor                <roconnor@world.std.com>
 Russell Fulton                 <russell@ccu1.auckland.ac.nz>
 Russell Mosemann               <mose@ccsn.edu>
+Ryan Carsten Schmidt           <git@ryandesign.com>
 Ryan Herbert                   <rherbert@sycamorehq.com>
 Ryan Voots                     <simcop2387@simcop2387.info>
 Salvador Fandiño               <sfandino@yahoo.com>

--- a/Makefile.SH
+++ b/Makefile.SH
@@ -64,7 +64,7 @@ true)
 				${revision}.${patchlevel}.${subversion}"
 		case "$osvers" in
 	        1[5-9]*|[2-9]*)
-			shrpldflags="$shrpldflags -install_name `pwd`/\$@ -Xlinker -headerpad_max_install_names"
+			shrpldflags="$shrpldflags -install_name `pwd -P`/\$@ -Xlinker -headerpad_max_install_names"
 			exeldflags="-Xlinker -headerpad_max_install_names"
 			;;
 		*)


### PR DESCRIPTION
When the perl executable is installed by the installperl script, its function `fix_dep_names` uses the perl function `getcwd` to determine the current directory and uses it to change the path by which libperl.dylib is referenced from the perl executable. `getcwd` resolves symlinks.

At build time, the install name was set using a path constructed using the shell command `pwd` which returns the current directory without resolving symlinks.

This mismatch causes the executable to be installed with the wrong path reference to the library in the case where the user has created a symlink to the source directory and `cd`'d to that symlink rather than to the real source directory. This was discovered while building perl in MacPorts 2.11.2 which does exactly that.

See https://trac.macports.org/ticket/72715

Fix by using `pwd -P` instead which does resolve symlinks.

* I do not know whether this change merits a perldelta entry and one is not included.
