### PR TITLE
AvFILL: Evaluate argument exactly once

### DIFF
--- a/av.h
+++ b/av.h
@@ -114,8 +114,7 @@ If all you need is to look up an array element, then prefer C<av_fetch>.
 =for apidoc_defn ARm|SSize_t|av_top_index |NN AV *av
 =cut
 */
-#define AvFILL(av)	((SvRMAGICAL((const SV *) (av))) \
-                         ? mg_size(MUTABLE_SV(av)) : AvFILLp(av))
+#define AvFILL(av)       AvFILL_(MUTABLE_AV(av))
 #define av_top_index(av) AvFILL(av)
 #define av_tindex(av)    av_top_index(av)
 

--- a/embed.fnc
+++ b/embed.fnc
@@ -707,6 +707,7 @@ ARdp	|SV **	|av_fetch	|NN AV *av				\
 CRdip	|SV **	|av_fetch_simple|NN AV *av				\
 				|SSize_t key				\
 				|I32 lval
+CRip	|SSize_t|AvFILL_	|NN AV *av
 Adp	|void	|av_fill	|NN AV *av				\
 				|SSize_t fill
 Cop	|IV *	|av_iter_p	|NN AV *av

--- a/embed.h
+++ b/embed.h
@@ -99,6 +99,7 @@
 
 /* Hide global symbols */
 
+# define AvFILL_(a)                             Perl_AvFILL_(aTHX_ a)
 # define Gv_AMupdate(a,b)                       Perl_Gv_AMupdate(aTHX_ a,b)
 # define SvAMAGIC_off                           Perl_SvAMAGIC_off
 # define SvAMAGIC_on                            Perl_SvAMAGIC_on

--- a/inline.h
+++ b/inline.h
@@ -61,6 +61,18 @@ Perl_av_count(pTHX_ AV *av)
     return AvFILL(av) + 1;
 }
 
+PERL_STATIC_INLINE SSize_t
+Perl_AvFILL_(pTHX_ AV *av)
+{
+    PERL_ARGS_ASSERT_AVFILL_;
+
+    if (SvRMAGICAL((const SV *) (av))) {
+        return mg_size((SV *) av);
+    }
+
+    return AvFILLp(av);
+}
+
 /* ------------------------------- av.c ------------------------------- */
 
 /*

--- a/proto.h
+++ b/proto.h
@@ -20,6 +20,7 @@
  */
 
 START_EXTERN_C
+
 PERL_CALLCONV int
 Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing);
 #define PERL_ARGS_ASSERT_GV_AMUPDATE            \
@@ -9703,6 +9704,12 @@ Perl_mem_log_realloc(const UV n, const UV typesize, const char *type_name, Mallo
 
 #endif /* defined(PERL_MEM_LOG) */
 #if !defined(PERL_NO_INLINE_FUNCTIONS)
+PERL_STATIC_INLINE SSize_t
+Perl_AvFILL_(pTHX_ AV *av)
+        __attribute__warn_unused_result__;
+# define PERL_ARGS_ASSERT_AVFILL_               \
+        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+
 PERL_STATIC_INLINE I32 *
 Perl_CvDEPTH(const CV * const sv);
 # define PERL_ARGS_ASSERT_CVDEPTH               \


### PR DESCRIPTION
Macros should not evaluate their arguments more than once due to the possibility of the argument being an expression with side effects.

This commit creates an inlined helper function to do the main processing.


* This set of changes does not require a perldelta entry.
