### PR TITLE
perl.h: include locale related headers after we decide to use locales

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -1142,15 +1142,6 @@ violations are fatal.
 #   include <xlocale.h>
 #endif
 
-/* Even if not using locales, this header should be #included so as to #define
- * some symbols which avoid #ifdefs to get things to compile.  But make sure
- * the macro it calls does nothing */
-#undef PERL_LOCALE_TABLE_ENTRY
-#define PERL_LOCALE_TABLE_ENTRY(name, call_back)
-#include "locale_table.h"
-
-#include "perl_langinfo.h"    /* Needed for _NL_LOCALE_NAME */
-
 /* =========================================================================
  * The defines from here to the following ===== line are unfortunately
  * duplicated in makedef.pl, and changes here MUST also be made there */
@@ -1182,6 +1173,15 @@ violations are fatal.
 
 /* end of makedef.pl logic duplication.  But there are other groups below.
  * ========================================================================= */
+
+/* Even if not using locales, this header should be #included so as to #define
+ * some symbols which avoid #ifdefs to get things to compile.  But make sure
+ * the macro it calls does nothing */
+#undef PERL_LOCALE_TABLE_ENTRY
+#define PERL_LOCALE_TABLE_ENTRY(name, call_back)
+#include "locale_table.h"
+
+#include "perl_langinfo.h"    /* Needed for _NL_LOCALE_NAME */
 
 #ifdef USE_LOCALE
 #   define HAS_SKIP_LOCALE_INIT /* Solely for XS code to test for this


### PR DESCRIPTION
This was causing warnings, since the initial include of locale_table.h assumed no locales while later includes might see them enabled.

Fixes #23464

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->


<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.

(it fixes a build issue from a (so far) unreleased commit)
