### PR TITLE
Attempt to remove deprecated uvuni_to_utf8()

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3847,8 +3847,6 @@ Admp	|U8 *	|uv_to_utf8_msgs|NN U8 *d				\
 				|UV uv					\
 				|UV flags				\
 				|NULLOK HV **msgs
-CDbp	|U8 *	|uvuni_to_utf8	|NN U8 *d				\
-				|UV uv
 EXdpx	|bool	|validate_proto |NN SV *name				\
 				|NULLOK SV *proto			\
 				|bool warn				\

--- a/embed.h
+++ b/embed.h
@@ -929,7 +929,6 @@
 #   define utf8_to_uvchr(a,b)                   Perl_utf8_to_uvchr(aTHX_ a,b)
 #   define utf8_to_uvuni(a,b)                   Perl_utf8_to_uvuni(aTHX_ a,b)
 #   define utf8n_to_uvuni(a,b,c,d)              Perl_utf8n_to_uvuni(aTHX_ a,b,c,d)
-#   define uvuni_to_utf8(a,b)                   Perl_uvuni_to_utf8(aTHX_ a,b)
 # endif
 # if defined(PERL_CORE)
 #   define PerlLIO_dup2_cloexec(a,b)            Perl_PerlLIO_dup2_cloexec(aTHX_ a,b)

--- a/mathoms.c
+++ b/mathoms.c
@@ -180,14 +180,6 @@ Perl_utf8_to_uvuni(pTHX_ const U8 *s, STRLEN *retlen)
     return NATIVE_TO_UNI(valid_utf8_to_uvchr(s, retlen));
 }
 
-U8 *
-Perl_uvuni_to_utf8(pTHX_ U8 *d, UV uv)
-{
-    PERL_ARGS_ASSERT_UVUNI_TO_UTF8;
-
-    return uvoffuni_to_utf8_flags(d, uv, 0);
-}
-
 /*
 =for apidoc_section $unicode
 =for apidoc utf8n_to_uvuni

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -351,6 +351,10 @@ well.
 
 XXX
 
+=item *
+
+Removed the deprecated (since 5.32) function C<uvuni_to_utf8()>
+
 =back
 
 =head1 Selected Bug Fixes

--- a/proto.h
+++ b/proto.h
@@ -6036,12 +6036,6 @@ Perl_utf8n_to_uvuni(pTHX_ const U8 *s, STRLEN curlen, STRLEN *retlen, U32 flags)
 # define PERL_ARGS_ASSERT_UTF8N_TO_UVUNI        \
         assert(s)
 
-PERL_CALLCONV U8 *
-Perl_uvuni_to_utf8(pTHX_ U8 *d, UV uv)
-        __attribute__deprecated__;
-# define PERL_ARGS_ASSERT_UVUNI_TO_UTF8         \
-        assert(d)
-
 # if defined(PERL_IN_MATHOMS_C) || defined(PERL_IN_OP_C) || \
      defined(PERL_IN_PERLY_C)   || defined(PERL_IN_TOKE_C)
 PERL_CALLCONV OP *


### PR DESCRIPTION
It has been deprecated since 5.32, emitting a compiler warning if actually called (for most modern compilers).

I think it is time to see what breaks when we remove it.

* This set of changes requires a perldelta entry, and it is included.

