### PR TITLE
Note when functions were first deprecated

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -344,7 +344,12 @@
 :        * makes the short name defined for everywhere, not just for PERL_CORE
 :          or PERL_EXT
 :
-:   'D'  Function is deprecated:
+:   'D'  Function is deprecated.
+:
+:	(Add a comment to the function source when adding this flag indicating
+:	what release it is first being deprecated in.  This will prevent having
+:	to dig up this information when deciding if enough releases have passed
+:	to actually remove the function.)
 :
 :        proto.h: add __attribute__deprecated__
 :        autodoc.pl adds a note to this effect in the doc entry

--- a/mathoms.c
+++ b/mathoms.c
@@ -791,6 +791,8 @@ next possible position in C<s> that could begin a non-malformed character.
 See L<perlapi/utf8n_to_uvchr> for details on when the REPLACEMENT CHARACTER is returned.
 
 =cut
+
+Deprecated since 5.38 
 */
 
 UV
@@ -860,7 +862,7 @@ convert to Unicode using L<perlapi/C<NATIVE_TO_UNI>>.
 UV
 Perl_utf8n_to_uvuni(pTHX_ const U8 *s, STRLEN curlen, STRLEN *retlen, U32 flags)
 {
-    PERL_ARGS_ASSERT_UTF8N_TO_UVUNI;
+    PERL_ARGS_ASSERT_UTF8N_TO_UVUNI; /* Deprecated since 5.38 */
 
     return NATIVE_TO_UNI(utf8n_to_uvchr(s, curlen, retlen, flags));
 }
@@ -868,7 +870,7 @@ Perl_utf8n_to_uvuni(pTHX_ const U8 *s, STRLEN curlen, STRLEN *retlen, U32 flags)
 UV
 Perl_utf8_to_uvchr(pTHX_ const U8 *s, STRLEN *retlen)
 {
-    PERL_ARGS_ASSERT_UTF8_TO_UVCHR;
+    PERL_ARGS_ASSERT_UTF8_TO_UVCHR; /* Deprecated since 5.38 */
 
     /* This function is unsafe if malformed UTF-8 input is given it, which is
      * why the function is deprecated.  If the first byte of the input

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -1634,6 +1634,9 @@ S_dopoptolabel(pTHX_ const char *label, STRLEN len, U32 flags)
 Implements the deprecated L<perlapi/C<GIMME>>.
 
 =cut
+
+Deprecated since 5.38
+
 */
 
 U8

--- a/util.c
+++ b/util.c
@@ -3667,6 +3667,8 @@ Given an opcode from the enum in F<opcodes.h>, C<PL_op_name[opcode]> returns a
 pointer to a C language string giving its name.
 
 =cut
+
+Deprecated since 5.38
 */
 
 char **
@@ -3684,6 +3686,8 @@ Given an opcode from the enum in F<opcodes.h>, C<PL_op_desc[opcode]> returns a
 pointer to a C language string giving its description.
 
 =cut
+
+Deprecated since 5.38
 */
 
 char **
@@ -3696,21 +3700,21 @@ Perl_get_op_descs(pTHX)
 const char *
 Perl_get_no_modify(pTHX)
 {
-    PERL_UNUSED_CONTEXT;
+    PERL_UNUSED_CONTEXT;    /* Deprecated since 5.38 */
     return PL_no_modify;
 }
 
 U32 *
 Perl_get_opargs(pTHX)
 {
-    PERL_UNUSED_CONTEXT;
+    PERL_UNUSED_CONTEXT;    /* Deprecated since 5.38 */
     return (U32 *)PL_opargs;
 }
 
 PPADDR_t*
 Perl_get_ppaddr(pTHX)
 {
-    PERL_UNUSED_CONTEXT;
+    PERL_UNUSED_CONTEXT;    /* Deprecated since 5.38 */
     return (PPADDR_t*)PL_ppaddr;
 }
 


### PR DESCRIPTION
We should eventually remove deprecated functions, after a suitable interval.  This commit notes when all the current deprecated functions were made so.  This saves time in the future in deciding if it is ok to actually remove them.


* This set of changes does not require a perldelta entry.
