### PR TITLE
Skip one test under miniperl; can't handle threads

### DIFF
--- a/t/op/signatures.t
+++ b/t/op/signatures.t
@@ -1728,6 +1728,7 @@ SKIP: {
 SKIP: {
     use Config;
     $Config{useithreads} or skip "No threads", 1;
+    skip_if_miniperl("no dynamic loading on miniperl, no threads", 1);
 
     ok(eval <<'EOPERL',
         no warnings 'closure';


### PR DESCRIPTION
Fixes GH #23469

* This set of changes does not require a perldelta entry.
