### PR TITLE
perlfunc - warn of platform specific quirks in gethost* and co.

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -3398,9 +3398,12 @@ X<endnetent> X<endprotoent> X<endservent>
 
 =for Pod::Functions be done using services file
 
-These routines are the same as their counterparts in the
-system C library.  In list context, the return values from the
-various get routines are as follows:
+These routines are the same as their counterparts in the system
+C library. (This means that platform-specific quirks may be
+encountered, please refer to L<perlport> for examples.)
+
+In list context, the return values from the various get routines
+are as follows:
 
  #    0        1          2           3         4
  my ( $name,   $passwd,   $gid,       $members  ) = getgr*

--- a/pod/perlport.pod
+++ b/pod/perlport.pod
@@ -1782,6 +1782,12 @@ Not implemented.
 C<gethostbyname('localhost')> does not work everywhere: you may have
 to use C<gethostbyname('127.0.0.1')>.
 
+(S<Win32>)
+If the C<NAME> argument is an empty string (C<"">) or something that
+coerces to it (such as C<undef>), the F<winsock.f> implementation treats
+this as a C<gethostname> call and will return the standard hostname for
+the local computer.
+
 =item gethostent
 
 (Win32)


### PR DESCRIPTION
This is a small commit in response to #23463 warning that platform-specific
quirks could be encountered with these functions. (The specific case
encountered is given as an example, but the warning is meant to be
generic to this bit of perlfunc.)

A bigger revision of that pod may be warranted, but this PR won't be it.

---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
