### PR TITLE
Revert "Attempt to remove deprecated sv_locking/unlocking"

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3274,7 +3274,10 @@ ARdp	|SV *	|sv_mortalcopy_flags					\
 				|U32 flags
 ARdp	|SV *	|sv_newmortal
 Cdp	|SV *	|sv_newref	|NULLOK SV * const sv
+ADbdp	|void	|sv_nolocking	|NULLOK SV *sv
+
 Adp	|void	|sv_nosharing	|NULLOK SV *sv
+ADbdp	|void	|sv_nounlocking |NULLOK SV *sv
 : Used in pp.c, pp_hot.c, sv.c
 dpx	|SV *	|sv_2num	|NN SV * const sv
 Adm	|bool	|sv_numeq	|NULLOK SV *sv1 			\

--- a/embed.h
+++ b/embed.h
@@ -923,6 +923,8 @@
 #   endif
 # endif
 # if !defined(NO_MATHOMS)
+#   define sv_nolocking(a)                      Perl_sv_nolocking(aTHX_ a)
+#   define sv_nounlocking(a)                    Perl_sv_nounlocking(aTHX_ a)
 #   define utf8_to_uvchr(a,b)                   Perl_utf8_to_uvchr(aTHX_ a,b)
 #   define utf8_to_uvuni(a,b)                   Perl_utf8_to_uvuni(aTHX_ a,b)
 #   define utf8n_to_uvuni(a,b,c,d)              Perl_utf8n_to_uvuni(aTHX_ a,b,c,d)

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -936,7 +936,13 @@ PERLVARI(I, lockhook,	share_proc_t, Perl_sv_nosharing)
 GCC_DIAG_IGNORE(-Wdeprecated-declarations)
 MSVC_DIAG_IGNORE(4996)
 
-PERLVARI(I, unlockhook,	share_proc_t, Perl_sv_nosharing)
+#ifdef NO_MATHOMS
+#  define PERL_UNLOCK_HOOK Perl_sv_nosharing
+#else
+/* This reference ensures that the mathoms are linked with perl */
+#  define PERL_UNLOCK_HOOK Perl_sv_nounlocking
+#endif
+PERLVARI(I, unlockhook,	share_proc_t, PERL_UNLOCK_HOOK)
 
 MSVC_DIAG_RESTORE
 GCC_DIAG_RESTORE

--- a/mathoms.c
+++ b/mathoms.c
@@ -437,6 +437,51 @@ Perl_do_aexec(pTHX_ SV *really, SV **mark, SV **sp)
 }
 #endif
 
+/*
+=for apidoc_section $SV
+=for apidoc sv_nolocking
+
+Dummy routine which "locks" an SV when there is no locking module present.
+Exists to avoid test for a C<NULL> function pointer and because it could
+potentially warn under some level of strict-ness.
+
+"Superseded" by C<sv_nosharing()>.
+
+=cut
+*/
+
+void
+Perl_sv_nolocking(pTHX_ SV *sv)
+{
+    PERL_UNUSED_CONTEXT;
+    PERL_UNUSED_ARG(sv);
+}
+
+
+/*
+=for apidoc_section $SV
+=for apidoc sv_nounlocking
+
+Dummy routine which "unlocks" an SV when there is no locking module present.
+Exists to avoid test for a C<NULL> function pointer and because it could
+potentially warn under some level of strict-ness.
+
+"Superseded" by C<sv_nosharing()>.
+
+=cut
+
+PERL_UNLOCK_HOOK in intrpvar.h is the macro that refers to this, and guarantees
+that mathoms gets loaded.
+
+*/
+
+void
+Perl_sv_nounlocking(pTHX_ SV *sv)
+{
+    PERL_UNUSED_CONTEXT;
+    PERL_UNUSED_ARG(sv);
+}
+
 void
 Perl_sv_usepvn_mg(pTHX_ SV *sv, char *ptr, STRLEN len)
 {

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -349,8 +349,7 @@ well.
 
 =item *
 
-Removed the deprecated (since 5.32) functions C<sv_locking()> and
-C<sv_unlocking>.
+XXX
 
 =back
 

--- a/proto.h
+++ b/proto.h
@@ -6052,6 +6052,16 @@ Perl_sv_mortalcopy(pTHX_ SV * const oldsv)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_MORTALCOPY
 
+PERL_CALLCONV void
+Perl_sv_nolocking(pTHX_ SV *sv)
+        __attribute__deprecated__;
+# define PERL_ARGS_ASSERT_SV_NOLOCKING
+
+PERL_CALLCONV void
+Perl_sv_nounlocking(pTHX_ SV *sv)
+        __attribute__deprecated__;
+# define PERL_ARGS_ASSERT_SV_NOUNLOCKING
+
 PERL_CALLCONV char *
 Perl_sv_pv(pTHX_ SV *sv)
         __attribute__warn_unused_result__;


### PR DESCRIPTION
This reverts commit 3afafdb6cda45b8879aa284d5fb90c3446584bfc.

It turns out that Perl_sv_nounlocking() is the mechanism that is used to make sure mathoms.c gets loaded, as the comments in the reverted commit say, but which I had not noticed.

Without this function being in mathoms.c, some build configurations will not load mathoms, leaving other functions in mathoms.c undefined, as happened with the two issues this fixes.

This commit could be reinstated if another method is created to force mathoms to be loaded;

This fixes #23473
This fixes #23474


* This set of changes requires a perldelta entry, and it is included.
