### PR TITLE
Allow AIX to use openxlC as the C compiler

### DIFF
--- a/README.aix
+++ b/README.aix
@@ -28,7 +28,8 @@ the AIX Toolbox which is shipped with AIX.
 
 Currently all versions of IBM's "xlc", "xlc_r", "cc", "cc_r" or
 "vac" ANSI/C compiler will work for building Perl if that compiler
-works on your system.
+works on your system. ibm-clang and ibm-clang_r will work as well,
+which is recommended on AIX 7.2 and 7.3.
 
 If you plan to link Perl to any module that requires thread-support,
 like DBD::Oracle, it is better to use the _r version of the compiler.
@@ -55,10 +56,20 @@ from IBM (April 2009 PTF for XL C/C++ Enterprise Edition for AIX, V9.0).
 If you choose XL C/C++ V11 you need the April 2010 PTF (or newer)
 installed otherwise you will not get a working Perl version.
 
-Perl can be compiled with either IBM's ANSI C compiler or with gcc.
-The former is recommended, as not only it can compile Perl with no
-difficulty, but also can take advantage of features listed later
-that require the use of IBM compiler-specific command-line flags.
+I<IBM Open XL C/C++ for AIX> is also supported for AIX 7.2 and 7.3.
+As of 2025-07, the following version is supported:
+
+    IBM Open XL C/C++ for AIX V17
+
+If you choose the Open XL C/C++ compiler (ibm-clang/ibm-clang_r), it should
+work out of the box.
+
+Perl can be compiled with either IBM's ANSI C compiler, IBM's Open XL clang
+compiler, or with gcc. It is recommended to use the Open XL clang compiler, as
+not only can it compile Perl with no difficulty, but also can take advantage
+of features listed later that require the use of IBM compiler-specific
+command-line flags and support newer compiler features only available in clang
+and gcc.
 
 If you decide to use gcc, make sure your installation is recent and
 complete, and be sure to read the Perl INSTALL file for more gcc-specific
@@ -127,7 +138,7 @@ Should yield no problems.
 
 =head2 Threaded Perl
 
-Should yield no problems with AIX 5.1 / 5.2 / 5.3 / 6.1 / 7.1.
+Should yield no problems with AIX 5.1 / 5.2 / 5.3 / 6.1 / 7.1 / 7.2 / 7.3.
 
 IBM uses the AIX system Perl (V5.6.0 on AIX 5.1 and V5.8.2 on
 AIX 5.2 / 5.3 and 6.1; V5.8.8 on AIX 5.3 TL11 and AIX 6.1 TL4; V5.10.1
@@ -175,6 +186,22 @@ enable long doubles, for most of the broken things Perl has implemented
 workarounds, but the handling of the special values infinity and NaN
 remains badly broken: for example infinity plus zero results in NaN.
 
+=head2 Recommended Options AIX 7.2 and 7.3 (threaded/32-bit)
+
+With the following options you get a threaded Perl version which
+passes all make tests in threaded 32-bit mode.
+
+    rm config.sh
+    ./Configure \
+    -d \
+    -Dcc=/opt/IBM/openxlC/17.1.3/bin/ibm-clang_r
+    -Duseshrplib \
+    -Dusethreads \
+    -Dprefix=/usr/opt/perl5_32
+
+The -Dprefix option will install Perl in a directory parallel to the
+IBM AIX system Perl installation.
+
 =head2 Recommended Options AIX 5.1/5.2/5.3/6.1 and 7.1 (threaded/32-bit)
 
 With the following options you get a threaded Perl version which
@@ -189,12 +216,27 @@ configuration for the Perl builds that AIX ships with.
     -Dusethreads \
     -Dprefix=/usr/opt/perl5_32
 
-The -Dprefix option will install Perl in a directory parallel to the 
+The -Dprefix option will install Perl in a directory parallel to the
+IBM AIX system Perl installation.
+
+=head2 Recommended Options AIX 7.2 and 7.3 (32-bit)
+
+With the following options you get a Perl version which passes
+all make tests in 32-bit mode.
+
+    rm config.sh
+    ./Configure \
+    -d \
+    -Dcc=/opt/IBM/openxlC/17.1.3/bin/ibm-clang_r
+    -Duseshrplib \
+    -Dprefix=/usr/opt/perl5_32
+
+The -Dprefix option will install Perl in a directory parallel to the
 IBM AIX system Perl installation.
 
 =head2 Recommended Options AIX 5.1/5.2/5.3/6.1 and 7.1 (32-bit)
 
-With the following options you get a Perl version which passes 
+With the following options you get a Perl version which passes
 all make tests in 32-bit mode.
 
     rm config.sh
@@ -207,36 +249,72 @@ all make tests in 32-bit mode.
 The -Dprefix option will install Perl in a directory parallel to the
 IBM AIX system Perl installation.
 
+=head2 Recommended Options AIX 7.2 and 7.3 (threaded/64-bit)
+
+With the following options you get a threaded Perl version which
+passes all make tests in threaded 64-bit mode.
+
+    export OBJECT_MODE=64
+    # or (depending on your shell)
+    setenv OBJECT_MODE 64
+    rm config.sh
+    ./Configure \
+    -d \
+    -Dcc=/opt/IBM/openxlC/17.1.3/bin/ibm-clang_r
+    -Duseshrplib \
+    -Dusethreads \
+    -Duse64bitall \
+    -Dprefix=/usr/opt/perl5_64
+
 =head2 Recommended Options AIX 5.1/5.2/5.3/6.1 and 7.1 (threaded/64-bit)
 
 With the following options you get a threaded Perl version which
 passes all make tests in 64-bit mode.
 
- export OBJECT_MODE=64 / setenv OBJECT_MODE 64 (depending on your shell)
+    export OBJECT_MODE=64
+    # or (depending on your shell)
+    setenv OBJECT_MODE 64
+    rm config.sh
+    ./Configure \
+    -d \
+    -Dcc=cc_r \
+    -Duseshrplib \
+    -Dusethreads \
+    -Duse64bitall \
+    -Dprefix=/usr/opt/perl5_64
 
- rm config.sh
- ./Configure \
- -d \
- -Dcc=cc_r \
- -Duseshrplib \
- -Dusethreads \
- -Duse64bitall \
- -Dprefix=/usr/opt/perl5_64
+=head2 Recommended Options AIX 7.2 and 7.3 (64-bit)
+
+With the following options you get a threaded Perl version which
+passes all make tests in threaded 64-bit mode.
+
+    export OBJECT_MODE=64
+    # or (depending on your shell)
+    setenv OBJECT_MODE 64
+    rm config.sh
+    ./Configure \
+    -d \
+    -Dcc=/opt/IBM/openxlC/17.1.3/bin/ibm-clang_r
+    -Duseshrplib \
+    -Duse64bitall \
+    -Dprefix=/usr/opt/perl5_64
+
 
 =head2 Recommended Options AIX 5.1/5.2/5.3/6.1 and 7.1 (64-bit)
 
 With the following options you get a Perl version which passes all
-make tests in 64-bit mode. 
+make tests in 64-bit mode.
 
- export OBJECT_MODE=64 / setenv OBJECT_MODE 64 (depending on your shell)
-
- rm config.sh
- ./Configure \
- -d \
- -Dcc=cc_r \
- -Duseshrplib \
- -Duse64bitall \
- -Dprefix=/usr/opt/perl5_64
+     export OBJECT_MODE=64
+     # or (depending on your shell)
+     setenv OBJECT_MODE 64
+     rm config.sh
+     ./Configure \
+     -d \
+     -Dcc=cc_r \
+     -Duseshrplib \
+     -Duse64bitall \
+     -Dprefix=/usr/opt/perl5_64
 
 The -Dprefix option will install Perl in a directory parallel to the
 IBM AIX system Perl installation.
@@ -246,7 +324,6 @@ following option:
 
     -Dcc='gcc -maix64'
 
-
 =head2 Compiling Perl 5 on AIX 7.1.0
 
 A regression in AIX 7 causes a failure in make test in Time::Piece during
@@ -254,7 +331,6 @@ daylight savings time.  APAR IV16514 provides the fix for this.  A quick
 test to see if it's required, assuming it is currently daylight savings
 in Eastern Time, would be to run C< TZ=EST5 date +%Z >.  This will come
 back with C<EST> normally, but nothing if you have the problem.
-
 
 =head2 Compiling Perl 5 on older AIX versions up to 4.3.3
 
@@ -482,7 +558,7 @@ threads are used in combination with 64-bit configurations.
 
 You may get a warning when doing a threaded build:
 
-  "pp_sys.c", line 4640.39: 1506-280 (W) Function argument assignment 
+  "pp_sys.c", line 4640.39: 1506-280 (W) Function argument assignment
   between types "unsigned char*" and "const void*" is not allowed.
 
 The exact line number may vary, but if the warning (W) comes from a line

--- a/hints/aix.sh
+++ b/hints/aix.sh
@@ -90,7 +90,12 @@ case "$archname" in
     '') archname="$osname" ;;
     esac
 
-cc=${cc:-cc}
+default_cc=cc
+which ibm-clang_r >/dev/null 2>&1 && ibm_clang=ibm-clang_r
+[ -z "$ibm_clang" ] && ibm_clang=$(find /opt/IBM/openxlC -name ibm-clang_r | tail -1)
+[ -n "$ibm_clang" ] && default_cc="$ibm_clang"
+
+cc=${cc:-"$default_cc"}
 
 ccflags="$ccflags -D_ALL_SOURCE -D_ANSI_C_SOURCE -D_POSIX_SOURCE"
 case "$cc" in

--- a/hints/aix.sh
+++ b/hints/aix.sh
@@ -94,7 +94,7 @@ cc=${cc:-cc}
 
 ccflags="$ccflags -D_ALL_SOURCE -D_ANSI_C_SOURCE -D_POSIX_SOURCE"
 case "$cc" in
-    *gcc*|*g++*) ;;
+    *gcc*|*g++*|*clang*) ;;
     *) ccflags="$ccflags -qmaxmem=-1 -qnoansialias -qlanglvl=extc99" ;;
     esac
 nm_opt='-B'
@@ -109,7 +109,7 @@ d_setreuid='undef'
 cccdlflags='none'	# All AIX code is position independent
    cc_type=xlc		# do not export to config.sh
 case "$cc" in
-    *gcc*|*g++*)
+    *gcc*|*g++*|*clang*)
 	cc_type=gcc
 	ccdlflags='-Xlinker'
 	if [ "X$gccversion" = "X" ]; then
@@ -189,7 +189,7 @@ case $cc_type in
     esac
 
 case "$cc" in
-    *gcc*|*g++*) ;;
+    *gcc*|*g++*|*clang*) ;;
 
     cc*|xlc*) # cc should've been set by line 116 or so if empty.
 	if test ! -x /usr/bin/$cc -a -x /usr/vac/bin/$cc; then
@@ -236,9 +236,8 @@ case "$usethreads" in
 	d_srandom_r='undef'
 	d_strerror_r='undef'
 
-	ccflags="$ccflags -DNEED_PTHREAD_INIT"
 	case "$cc" in
-	    *gcc*|*g++*)
+	    *gcc*|*g++*|*clang*)
 	      ccflags="-D_THREAD_SAFE $ccflags"
 	      ;;
 	    cc_r)
@@ -429,7 +428,7 @@ EOM
 	ccflags="`echo $ccflags | sed -e 's@-q32@@'`"
 	ldflags="`echo $ldflags | sed -e 's@-b32@@'`"
 	case "$cc" in
-	    *gcc*|*g++*)
+	    *gcc*|*g++*|*clang*)
 		ccflags="`echo $ccflags | sed -e 's@-q64@-maix64@'`"
 		ccflags_uselargefiles="`echo $ccflags_uselargefiles | sed -e 's@-q64@-maix64@'`"
 		qacflags="`echo $qacflags | sed -e 's@-q64@-maix64@'`"
@@ -474,10 +473,10 @@ if test $usenativedlopen = 'true' ; then
     #			    libraries. AIX allows both .so and .a libraries to
     #			    contain dynamic shared objects.
     case "$cc" in
-	*gcc*|*g++*) ldflags="$ldflags -Wl,-brtl -Wl,-bdynamic" ;;
+	*gcc*|*g++*|*clang*) ldflags="$ldflags -Wl,-brtl -Wl,-bdynamic" ;;
 	*)           ldflags="$ldflags -brtl -bdynamic" ;;
 	esac
-elif test -f /lib/libC.a -a X"`$cc -v 2>&1 | grep gcc`" = X; then
+elif test -f /lib/libC.a -a X"`$cc -v 2>&1 | grep -E 'gcc|clang'`" = X; then
     # If the C++ libraries, libC and libC_r, are available we will
     # prefer them over the vanilla libc, because the libC contain
     # loadAndInit() and terminateAndUnload() which work correctly

--- a/hints/aix_3.sh
+++ b/hints/aix_3.sh
@@ -229,7 +229,6 @@ case "$usethreads" in
 	d_setpwent_r='undef'
 	d_srand48_r='undef'
 	d_strerror_r='undef'
-	ccflags="$ccflags -DNEED_PTHREAD_INIT"
 	case "$cc" in
 	    *gcc*)
 		ccflags="-D_THREAD_SAFE $ccflags"

--- a/hints/aix_4.sh
+++ b/hints/aix_4.sh
@@ -315,7 +315,6 @@ case "$usethreads" in
 	d_srand48_r='undef'
 	d_strerror_r='undef'
 
-	ccflags="$ccflags -DNEED_PTHREAD_INIT"
 	case "$cc" in
 	    *gcc*)
 		ccflags="-D_THREAD_SAFE $ccflags"

--- a/makedef.pl
+++ b/makedef.pl
@@ -1166,6 +1166,13 @@ elsif (PLATFORM eq 'os2') {
 		 ));
 }
 
+if ($define{USE_ITHREADS} && $define{I_PTHREAD}) {
+    try_symbols(qw(
+		      perl_tsa_mutex_lock
+		      perl_tsa_mutex_unlock
+		 ));
+}
+
 # When added this code was only run for Win32 (and WinCE at the time)
 # Currently only Win32 links static extensions into the shared library.
 # For *nix (and presumably OS/2) with a shared libperl, Makefile.SH compiles

--- a/perl.h
+++ b/perl.h
@@ -3751,6 +3751,9 @@ EXTERN_C int perl_tsa_mutex_lock(perl_mutex* mutex)
 EXTERN_C int perl_tsa_mutex_unlock(perl_mutex* mutex)
   PERL_TSA_RELEASE(*mutex)
   PERL_TSA_NO_TSA;
+#elif defined(USE_ITHREADS) && defined(I_PTHREAD)
+EXTERN_C int perl_tsa_mutex_lock(perl_mutex* mutex);
+EXTERN_C int perl_tsa_mutex_unlock(perl_mutex* mutex);
 #endif
 
 #if defined(WIN32)

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -19,6 +19,16 @@ L<perl5431delta>, which describes differences between 5.43.0 and 5.43.1.
 
 XXX Any important notices here
 
+=over
+
+=item *
+
+The ibm-clang/ibm-clang_r IBM Open XL C/C++ compiler is now supported for AIX
+7.2 and 7.3. This is the recommended compiler to use when compiling Perl on
+these versions of AIX.
+
+=back
+
 =head1 Core Enhancements
 
 XXX New core language features go here. Summarize user-visible core language

--- a/thread.h
+++ b/thread.h
@@ -436,12 +436,6 @@ extern PERL_THREAD_LOCAL void *PL_current_context;
 #  endif /* PERL_SET_CONTEXT */
 #endif /* PERL_THREAD_LOCAL */
 
-#ifndef INIT_THREADS
-#  ifdef NEED_PTHREAD_INIT
-#    define INIT_THREADS pthread_init()
-#  endif
-#endif
-
 #ifndef ALLOC_THREAD_KEY
 #  define ALLOC_THREAD_KEY \
     STMT_START {						\


### PR DESCRIPTION
The recommended compiler for AIX is now the openxlC compiler (ibm-clang).

This PR updates AIX hints so that it can be used. Additionally, it fixes an issue with Perl's implementation of Clang TSA so that the perl_tsa_mutex_* functions are accessible to ext/re. This was required in order for AIX to build cleanly.

We also remove NEED_PTHREAD_INIT, since pthread_init doesn't exist on AIX (nor anywhere from what I can tell). https://www.ibm.com/docs/en/aix/7.3.0?topic=options-supported-interfaces

I'm also updating the AIX documentation to recommend ibm-clang_r over cc/xlc.

Addresses #23333


---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
