### PR TITLE
Make sure mathoms gets loaded; then rm sv_no(un)?locking

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3275,10 +3275,7 @@ ARdp	|SV *	|sv_mortalcopy_flags					\
 				|U32 flags
 ARdp	|SV *	|sv_newmortal
 Cdp	|SV *	|sv_newref	|NULLOK SV * const sv
-ADbdp	|void	|sv_nolocking	|NULLOK SV *sv
-
 Adp	|void	|sv_nosharing	|NULLOK SV *sv
-ADbdp	|void	|sv_nounlocking |NULLOK SV *sv
 : Used in pp.c, pp_hot.c, sv.c
 dpx	|SV *	|sv_2num	|NN SV * const sv
 Adm	|bool	|sv_numeq	|NULLOK SV *sv1 			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -1807,6 +1807,7 @@ ERXp	|HV *	|load_charnames |NN SV *char_name			\
 				|NN const char *context 		\
 				|const STRLEN context_len		\
 				|NN const char **error_msg
+MTbp	|void	|load_mathoms
 AFdpv	|void	|load_module	|U32 flags				\
 				|NN SV *name				\
 				|NULLOK SV *ver 			\

--- a/embed.h
+++ b/embed.h
@@ -924,8 +924,6 @@
 #   endif
 # endif
 # if !defined(NO_MATHOMS)
-#   define sv_nolocking(a)                      Perl_sv_nolocking(aTHX_ a)
-#   define sv_nounlocking(a)                    Perl_sv_nounlocking(aTHX_ a)
 #   define utf8_to_uvchr(a,b)                   Perl_utf8_to_uvchr(aTHX_ a,b)
 #   define utf8_to_uvuni(a,b)                   Perl_utf8_to_uvuni(aTHX_ a,b)
 #   define utf8n_to_uvuni(a,b,c,d)              Perl_utf8n_to_uvuni(aTHX_ a,b,c,d)

--- a/embedvar.h
+++ b/embedvar.h
@@ -164,6 +164,7 @@
 # define PL_less_dicey_locale_buf               (vTHX->Iless_dicey_locale_buf)
 # define PL_less_dicey_locale_bufsize           (vTHX->Iless_dicey_locale_bufsize)
 # define PL_LIO                                 (vTHX->ILIO)
+# define PL_load_mathoms                        (vTHX->Iload_mathoms)
 # define PL_locale_mutex_depth                  (vTHX->Ilocale_mutex_depth)
 # define PL_localizing                          (vTHX->Ilocalizing)
 # define PL_localpatches                        (vTHX->Ilocalpatches)

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -1101,6 +1101,18 @@ PERLVAR(I, prevailing_version, U16)
 PERLVARI(I, in_diehook, bool, FALSE)
 PERLVARI(I, in_warnhook, bool, FALSE)
 
+/* Perl_load_mathoms is defined in mathoms.c, so this forces the loading of the
+ * functions in that file when NO_MATHOMS isn't defined.  Otherwise, it is just
+ * a pointer to a function that is always going to exist.  The use of
+ * Perl_noshutdownhook is solely because there is a typedef for its signature
+ * and has no arguments that need to be passed */
+#ifdef NO_MATHOMS
+#  define PERL_LOAD_MATHOMS_HOOK  Perl_noshutdownhook
+#else
+#  define PERL_LOAD_MATHOMS_HOOK  Perl_load_mathoms
+#endif
+PERLVARI(I, load_mathoms, shutdown_proc_t, PERL_LOAD_MATHOMS_HOOK)
+
 /* If you are adding a U8 or U16, check to see if there are 'Space' comments
  * above on where there are gaps which currently will be structure padding.  */
 

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -936,13 +936,7 @@ PERLVARI(I, lockhook,	share_proc_t, Perl_sv_nosharing)
 GCC_DIAG_IGNORE(-Wdeprecated-declarations)
 MSVC_DIAG_IGNORE(4996)
 
-#ifdef NO_MATHOMS
-#  define PERL_UNLOCK_HOOK Perl_sv_nosharing
-#else
-/* This reference ensures that the mathoms are linked with perl */
-#  define PERL_UNLOCK_HOOK Perl_sv_nounlocking
-#endif
-PERLVARI(I, unlockhook,	share_proc_t, PERL_UNLOCK_HOOK)
+PERLVARI(I, unlockhook,	share_proc_t, Perl_sv_nosharing)
 
 MSVC_DIAG_RESTORE
 GCC_DIAG_RESTORE

--- a/mathoms.c
+++ b/mathoms.c
@@ -73,6 +73,13 @@
  * without a compiler warning */
 GCC_DIAG_IGNORE(-Wdeprecated-declarations)
 
+void
+Perl_load_mathoms()
+{
+    /* This exists only to make sure the functions in this file get loaded, as
+     * it is referred to by a structure element in intrpvar.h */
+}
+
 /* ref() is now a macro using Perl_doref;
  * this version provided for binary compatibility only.
  */

--- a/mathoms.c
+++ b/mathoms.c
@@ -107,51 +107,6 @@ Perl_huge(void)
 #endif
 
 /*
-=for apidoc_section $SV
-=for apidoc sv_nolocking
-
-Dummy routine which "locks" an SV when there is no locking module present.
-Exists to avoid test for a C<NULL> function pointer and because it could
-potentially warn under some level of strict-ness.
-
-"Superseded" by C<sv_nosharing()>.
-
-=cut
-*/
-
-void
-Perl_sv_nolocking(pTHX_ SV *sv)
-{
-    PERL_UNUSED_CONTEXT;
-    PERL_UNUSED_ARG(sv);
-}
-
-
-/*
-=for apidoc_section $SV
-=for apidoc sv_nounlocking
-
-Dummy routine which "unlocks" an SV when there is no locking module present.
-Exists to avoid test for a C<NULL> function pointer and because it could
-potentially warn under some level of strict-ness.
-
-"Superseded" by C<sv_nosharing()>.
-
-=cut
-
-PERL_UNLOCK_HOOK in intrpvar.h is the macro that refers to this, and guarantees
-that mathoms gets loaded.
-
-*/
-
-void
-Perl_sv_nounlocking(pTHX_ SV *sv)
-{
-    PERL_UNUSED_CONTEXT;
-    PERL_UNUSED_ARG(sv);
-}
-
-/*
 =for apidoc_section $unicode
 =for apidoc utf8_to_uvuni
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -349,7 +349,8 @@ well.
 
 =item *
 
-XXX
+Removed the deprecated (since 5.32) functions C<sv_locking()> and
+C<sv_unlocking>.
 
 =back
 

--- a/proto.h
+++ b/proto.h
@@ -6009,6 +6009,10 @@ Perl_malloced_size(void *p)
 #endif /* defined(MYMALLOC) */
 #if !defined(NO_MATHOMS)
 PERL_CALLCONV void
+Perl_load_mathoms(void);
+# define PERL_ARGS_ASSERT_LOAD_MATHOMS
+
+PERL_CALLCONV void
 Perl_sv_nolocking(pTHX_ SV *sv)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_SV_NOLOCKING

--- a/proto.h
+++ b/proto.h
@@ -6012,16 +6012,6 @@ PERL_CALLCONV void
 Perl_load_mathoms(void);
 # define PERL_ARGS_ASSERT_LOAD_MATHOMS
 
-PERL_CALLCONV void
-Perl_sv_nolocking(pTHX_ SV *sv)
-        __attribute__deprecated__;
-# define PERL_ARGS_ASSERT_SV_NOLOCKING
-
-PERL_CALLCONV void
-Perl_sv_nounlocking(pTHX_ SV *sv)
-        __attribute__deprecated__;
-# define PERL_ARGS_ASSERT_SV_NOUNLOCKING
-
 PERL_CALLCONV UV
 Perl_utf8_to_uvchr(pTHX_ const U8 *s, STRLEN *retlen)
         __attribute__deprecated__;


### PR DESCRIPTION
Pull request #23467 had to be reverted because one of the deprecated  functions it removed served double duty to make sure the functions in mathoms get loaded.  This p.r. creates a new dummy function that serves the purpose instead of the deprecated one, and then reapplies the commit of #23467 

* This set of changes requires a perldelta entry, and it is included.

