### PR TITLE
Explicitly reject length(NAME) with typemaps other than T_PV

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -528,7 +528,7 @@ our %Modules = (
     },
 
     'ExtUtils::ParseXS' => {
-        'DISTRIBUTION' => 'LEONT/ExtUtils-ParseXS-3.57.tar.gz',
+        'DISTRIBUTION' => 'LEONT/ExtUtils-ParseXS-3.58.tar.gz',
         'FILES'        => q[dist/ExtUtils-ParseXS],
     },
 

--- a/dist/ExtUtils-ParseXS/Changes
+++ b/dist/ExtUtils-ParseXS/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension ExtUtils::ParseXS.
 
+3.59
+  - Throw an exception when combining the length operator with a
+    typemap other than T_PV
+
 3.58 Sun Jul 20 09:10:41 PM CEST 2025
   - ExtUtils::ParseXS has been extensively restructured internally.
     Most of these changes shouldn't be visible externally, but might

--- a/dist/ExtUtils-ParseXS/Changes
+++ b/dist/ExtUtils-ParseXS/Changes
@@ -1,5 +1,14 @@
 Revision history for Perl extension ExtUtils::ParseXS.
 
+3.58 Sun Jul 20 09:10:41 PM CEST 2025
+  - ExtUtils::ParseXS has been extensively restructured internally.
+    Most of these changes shouldn't be visible externally, but might
+	affect XS code which was using invalid or unsupported syntax.
+
+3.57 Fri May  2 05:40:59 PM CEST 2025
+  - Rewrite half of the internals to facilitate refcounted stack
+    later on
+
 3.51 - Tue May 9 09:32:04 2023 AEST
   - Initialize $self correctly in EU::PXS::Utilities::death()
   - C++ builds: avoid generating C<< extern "C" extern "C" >>

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -64,7 +64,7 @@ use Symbol;
 
 our $VERSION;
 BEGIN {
-  $VERSION = '3.58';
+  $VERSION = '3.59';
   require ExtUtils::ParseXS::Constants; ExtUtils::ParseXS::Constants->VERSION($VERSION);
   require ExtUtils::ParseXS::CountLines; ExtUtils::ParseXS::CountLines->VERSION($VERSION);
   require ExtUtils::ParseXS::Node; ExtUtils::ParseXS::Node->VERSION($VERSION);

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Symbol;
 
-our $VERSION = '3.58';
+our $VERSION = '3.59';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
@@ -1,7 +1,7 @@
 package ExtUtils::ParseXS::CountLines;
 use strict;
 
-our $VERSION = '3.58';
+our $VERSION = '3.59';
 
 our $SECTION_END_MARKER;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
@@ -2,7 +2,7 @@ package ExtUtils::ParseXS::Eval;
 use strict;
 use warnings;
 
-our $VERSION = '3.58';
+our $VERSION = '3.59';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
@@ -1407,7 +1407,9 @@ sub lookup_input_typemap {
         # as a pseudo-parameter, then override the normal typedef - which
         # would emit SvPV_nolen(...) - and instead, emit SvPV(...,
         # STRLEN_length_of_foo)
-        if ($xstype eq 'T_PV' and $self->{has_length}) {
+        if ($self->{has_length}) {
+            die "length(NAME) not supported with typemaps other than T_PV"
+                if $xstype ne 'T_PV';
             die "default value not supported with length(NAME) supplied"
                 if defined $default;
             return "($type)SvPV($arg, STRLEN_length_of_$var);",

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
@@ -2,7 +2,7 @@ package ExtUtils::ParseXS::Node;
 use strict;
 use warnings;
 
-our $VERSION = '3.58';
+our $VERSION = '3.59';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
@@ -5,7 +5,7 @@ use Exporter;
 use File::Spec;
 use ExtUtils::ParseXS::Constants ();
 
-our $VERSION = '3.58';
+our $VERSION = '3.59';
 
 our (@ISA, @EXPORT_OK);
 @ISA = qw(Exporter);

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.58';
+our $VERSION = '3.59';
 
 require ExtUtils::ParseXS;
 require ExtUtils::ParseXS::Constants;

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Cmd.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Cmd.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::Cmd;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.58';
+our $VERSION = '3.59';
 
 use ExtUtils::Typemaps;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/InputMap.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/InputMap.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::InputMap;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.58';
+our $VERSION = '3.59';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/OutputMap.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/OutputMap.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::OutputMap;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.58';
+our $VERSION = '3.59';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Type.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Type.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 require ExtUtils::Typemaps;
 
-our $VERSION = '3.58';
+our $VERSION = '3.59';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/perlxs.pod
+++ b/dist/ExtUtils-ParseXS/lib/perlxs.pod
@@ -2231,7 +2231,7 @@ this model, the less likely conflicts will occur.
 =head1 XS VERSION
 
 This document covers features supported by C<ExtUtils::ParseXS>
-(also known as C<xsubpp>) 3.58.
+(also known as C<xsubpp>) 3.59.
 
 =head1 AUTHOR DIAGNOSTICS
 

--- a/dist/ExtUtils-ParseXS/t/001-basic.t
+++ b/dist/ExtUtils-ParseXS/t/001-basic.t
@@ -967,7 +967,7 @@ EOF
         |
         |int
         |foo(  a   ,  char   * b  , OUT  int  c  ,  OUTLIST int  d   ,    \
-        |      IN_OUT char * * e    =   1  + 2 ,   long length(e)   ,    \
+        |      IN_OUT char * * e    =   1  + 2 ,   long length(b)   ,    \
         |      char* f="abc"  ,     g  =   0  ,   ...     )
 EOF
 
@@ -1607,6 +1607,13 @@ EOF
             [ 1, 0, qr{\QError: length() on non-parameter 's'\E.*line 6},
                    "got expected error" ],
         ],
+
+		[
+			'length of int is invalid',
+			['int', 'foo(int a, size_t length(a))'],
+			[ 1, 0 , qr/length\(NAME\) not supported with typemaps other than T_PV/, 'Got expected error about length' ],
+		],
+
     );
 
     test_many($preamble, 'XS_Foo_', \@test_fns);


### PR DESCRIPTION
Previously, the length operator on typemaps other than T_PV would lead to that length value not being initialized, leading to segfaults and worse. Worse yet, ExtUtils::ParseXS would silently emit this erroneous code.
    
For now it will at least give a clear error, in the future we should perhaps consider eliminating this limitation altogether.

* This contains a changelog entry for ExtUtils::ParseXS instead of a perldelta