### PR TITLE
Silence autodoc warning

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -3289,8 +3289,8 @@ Perl_uv_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
 /*
 =for apidoc_section $utility
 
-=for apidoc        is_safe_syscall
-=for apidoc_item ||IS_SAFE_SYSCALL|
+=for apidoc         is_safe_syscall
+=for apidoc_item m||IS_SAFE_SYSCALL
 
 These are synonymous.
 


### PR DESCRIPTION
This was recently introduced in 194d4eac2f635f5c4cfc1e3709146be8063d6773 The warning was that IS_SAFE_SYSCALL has no long name.  We currently don't typically have long names for macros.  The solution is to mark it as a macro; autodoc thought it must be a function.

Spotted by Dave Mitchell.


* This set of changes does not require a perldelta entry.
