### PR TITLE
todo test for 14615 (<<>> deparses same as <>)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1254,6 +1254,7 @@ Sam Vilain                     <sam@vilain.net>
 Samanta Navarro                <ferivoz@riseup.net>
 Samuel Smith                   <esaym@cpan.org>
 Samuel Thibault                <sthibault@debian.org>
+Samuel Young                   <samyoung12788@gmail.com>
 Samuli Kärkkäinen              <skarkkai@woods.iki.fi>
 Santtu Ojanperä                <santtuojanpera98@gmail.com>
 Sascha Blank

--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -35,6 +35,21 @@ my $switches = "";
 our $TODO;
 
 TODO: {
+    local $::TODO = "GH 14615";
+    my $results = fresh_perl(<<~'EOF', {});
+        use B::Deparse;
+        my $deparse = B::Deparse->new();
+        my $body = $deparse->coderef2text(
+            sub { while(<<>>){ print $_ } }
+        );
+        print $body;
+        EOF
+    is($?, 0, 'No assertion failure');
+
+    like $results, qr/defined\(\$_ = <<>>\)/, 'while(<<>>) deparses as while (defined($_ = <<>>))'
+}
+
+TODO: {
     local $::TODO = "GH 16008";
     my $results = fresh_perl(<<~'EOF', {} );
         open my $h, ">", \my $x;


### PR DESCRIPTION
Submitting this PR as a response to the talk Karl gave about improving Perl. The test I added tests that `while(<<>>)` deparses correctly as `while(defined($_ = <<>>))`. 