### PR TITLE
Convert RT ticket reference to GH

### DIFF
--- a/caretx.c
+++ b/caretx.c
@@ -21,7 +21,7 @@
 /* This file contains a single function, set_caret_X, to set the $^X
  * variable.  It's only used in perl.c, but has various OS dependencies,
  * so its been moved to its own file to reduce header pollution.
- * See RT 120314 for details.
+ * See GH #13363 for details.
  */
 
 #if defined(PERL_IS_MINIPERL) && !defined(USE_SITECUSTOMIZE)


### PR DESCRIPTION
A reference to an old ticket in rt.perl.org found within a C comment was not converted to point to a GH ticket.

Observed while evaluating GH #23483.

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
TODO: fill description here

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
* This set of changes requires a perldelta entry, and I need help writing it.
* This set of changes does not require a perldelta entry.
