### PR TITLE
Add ASSERT_() a legal synonym for __ASSERT_()

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -350,12 +350,22 @@ don't, so that you can portably take advantage of this C99 feature.
 
 /*
 =for apidoc_section $directives
-=for apidoc Am||__ASSERT_|bool expr
+=for apidoc      Am||ASSERT_|bool expr
+=for apidoc_item  D|| __ASSERT_
 
-This is a helper macro to avoid preprocessor issues, replaced by nothing
-unless under DEBUGGING, where it expands to an assert of its argument,
-followed by a comma (hence the comma operator).  If we just used a straight
-assert(), we would get a comma with nothing before it when not DEBUGGING.
+These are synonymous.
+
+They are helper macros to avoid preprocessor issues, replaced by nothing
+unless under DEBUGGING, where they expand to an assert() of their argument,
+followed by a comma (hence the trailing underscore in their names, and the
+comma operators in their expansions).  If we just used a straight assert(), we
+would get a comma with nothing before it when not DEBUGGING.
+
+C<ASSERT_> is preferred, as C<__ASSERT_> actually creates undefined behavior in
+C and C++, because the leading underscores yield a name form that is reserved
+for the compiler's use.  See L<perlhacktips/Choosing legal symbol names>.
+
+C<__ASSERT_> is kept only for backwards compatibility.
 
 =cut
 
@@ -365,10 +375,11 @@ detects that and gets all excited. */
 
 #if   defined(DEBUGGING) && !defined(__COVERITY__)                        \
  && ! defined(PERL_SMALL_MACRO_BUFFER)
-#   define __ASSERT_(statement)  assert(statement),
+#  define ASSERT_(statement)  assert(statement),
 #else
-#   define __ASSERT_(statement)
+#  define ASSERT_(statement)
 #endif
+#define __ASSERT_(statement)  ASSERT_(statement)
 
 /*
 =for apidoc_section $SV


### PR DESCRIPTION
Two consecutive underscores in a name is undefined behavior in C++; a single leading underscore is undefined behavior in C in the global name space.


* This set of changes does not require a perldelta entry.
