### PR TITLE
Rm obsolete apidoc mro_get_linear_isa_c3()

### DIFF
--- a/ext/mro/mro.pm
+++ b/ext/mro/mro.pm
@@ -12,7 +12,7 @@ use warnings;
 
 # mro.pm versions < 1.00 reserved for MRO::Compat
 #  for partial back-compat to 5.[68].x
-our $VERSION = '1.29';
+our $VERSION = '1.30';
 
 require XSLoader;
 XSLoader::load('mro');

--- a/ext/mro/mro.xs
+++ b/ext/mro/mro.xs
@@ -11,7 +11,6 @@ static const struct mro_alg c3_alg =
     {S_mro_get_linear_isa_c3, "c3", 2, 0, 0};
 
 /*
-=for apidoc mro_get_linear_isa_c3
 
 Returns the C3 linearization of C<@ISA>
 the given stash.  The return value is a read-only AV*
@@ -25,7 +24,6 @@ semi-permanently (otherwise it might be deleted
 out from under you the next time the cache is
 invalidated).
 
-=cut
 */
 
 static AV*


### PR DESCRIPTION
This function was public API only in perl-5.10. The corresponding line in the code generating API documentation should have been removed when the function ceased to be public API.



* This set of changes does not require a perldelta entry.
