### PR TITLE
regen/HeaderParser: Pass line embed.fnc line number on

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -2512,13 +2512,9 @@ foreach (@{(setup_embed())[0]}) {
     my $embed= $_->{embed}
         or next;
     my $file = $_->{source};
-    my ($flags, $ret_type, $func, $args) =
-                                 @{$embed}{qw(flags return_type name args)};
-    check_and_add_proto_defn($func, $file,
-                             # embed.fnc data doesn't currently furnish the
-                             # line number
-                             undef,
-
+    my ($flags, $ret_type, $func, $args, $line_num) =
+                    @{$embed}{qw(flags return_type name args start_line_num)};
+    check_and_add_proto_defn($func, $file, $line_num,
                              $flags, $ret_type, $args,
 
                              # This is like an 'apidoc_defn' line, in that it

--- a/regen/HeaderParser.pm
+++ b/regen/HeaderParser.pm
@@ -794,6 +794,7 @@ sub tidy_embed_fnc_entry {
         return_type => $ret,
         name        => $name,
         args        => \@args,
+        start_line_num => $line_data->{start_line_num},
     );
     $line =~ s/\s+\z/\n/;
     $line_data->{line}= $line;
@@ -1587,6 +1588,7 @@ sub EmbedLine::flags       { $_[0]->{flags} }
 sub EmbedLine::return_type { $_[0]->{return_type} }
 sub EmbedLine::name        { $_[0]->{name} }
 sub EmbedLine::args        { $_[0]->{args} }          # array ref
+sub EmbedLine::line_num    { $_[0]->{start_line_num} }
 
 1;
 

--- a/regen/HeaderParser.pm
+++ b/regen/HeaderParser.pm
@@ -790,10 +790,10 @@ sub tidy_embed_fnc_entry {
     ($line)= unexpand($line);
 
     $line_data->{embed}= EmbedLine->new(
-        flags       => $flags,
-        return_type => $ret,
-        name        => $name,
-        args        => \@args,
+        flags          => $flags,
+        return_type    => $ret,
+        name           => $name,
+        args           => \@args,
         start_line_num => $line_data->{start_line_num},
     );
     $line =~ s/\s+\z/\n/;


### PR DESCRIPTION
This adds the line number in the embed.fnc file that gives the definition to the
structure describing the definition, for potential downstream use.

* This set of changes does not require a perldelta entry.
