### PR TITLE
perlapi: Restore pod/warn-unused-result for sv_pv()

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3306,7 +3306,7 @@ Adp	|STRLEN |sv_pos_u2b_flags					\
 				|U32 flags
 Admp	|char * |sv_2pv 	|NN SV *sv				\
 				|NULLOK STRLEN *lp
-Cdmp	|char * |sv_pv		|NN SV *sv
+CRdmp	|char * |sv_pv		|NN SV *sv
 Admp	|char * |sv_2pvbyte	|NN SV *sv				\
 				|NULLOK STRLEN * const lp
 CRdmp	|char * |sv_pvbyte	|NN SV *sv

--- a/proto.h
+++ b/proto.h
@@ -4889,7 +4889,8 @@ Perl_sv_pos_u2b_flags(pTHX_ SV * const sv, STRLEN uoffset, STRLEN * const lenp, 
         assert(sv)
 
 /* PERL_CALLCONV char *
-Perl_sv_pv(pTHX_ SV *sv); */
+Perl_sv_pv(pTHX_ SV *sv)
+        __attribute__warn_unused_result__; */
 
 /* PERL_CALLCONV char *
 Perl_sv_pvbyte(pTHX_ SV *sv)

--- a/sv.h
+++ b/sv.h
@@ -2212,8 +2212,14 @@ immediately written again.
                                     sv_force_normal_flags(sv, 0)
 
 
-/* all these 'functions' are now just macros */
+/* all these 'functions' are now just macros
+ *
+=for apidoc sv_pv
 
+Use the C<SvPV_nolen> macro instead
+
+=cut
+*/
 #define sv_pv(sv) SvPV_nolen(sv)
 
 /*


### PR DESCRIPTION
Mistakenly removed in 5df7a2e2277b18032ce45c73ac07c2b42393251b


* This set of changes does not require a perldelta entry.
