### PR TITLE
iperlsys.h,perl_inc_macro.h: Use std recursion guard name

### DIFF
--- a/iperlsys.h
+++ b/iperlsys.h
@@ -9,8 +9,8 @@
  * GSAR 21-JUN-98
  */
 
-#ifndef __Inc__IPerl___
-#define __Inc__IPerl___
+#ifndef IPERLSYS_H
+#define IPERLSYS_H
 
 /*
  *      PerlXXX_YYY explained - DickH and DougL @ ActiveState.com

--- a/perl_inc_macro.h
+++ b/perl_inc_macro.h
@@ -17,10 +17,10 @@
 * - INCPUSH_PERL_OTHERLIBDIRS_ARCHONLY
 */
 
-#ifndef DEFINE_INC_MACROS
+#ifndef PERL_INC_MACROS_H
 
 /* protect against multiple inclusions */
-#define DEFINE_INC_MACROS 1
+#define PERL_INC_MACROS_H 1
 
 #ifdef APPLLIB_EXP
 #	define INCPUSH_APPLLIB_EXP  S_incpush_use_sep(aTHX_ STR_WITH_LEN(APPLLIB_EXP), \


### PR DESCRIPTION
These are the two outlier header files that didn't have their #inclusion recursion guard name end in _H.  It's a small thing, but having that standard simplifies a pattern in changes I'm making to Devel::PPPort


* This set of changes does not require a perldelta entry.
