### PR TITLE
Reapply "op.c: re-enable coderef-in-stash optimization"

### DIFF
--- a/class.c
+++ b/class.c
@@ -697,10 +697,13 @@ S_class_cleanup_definition(pTHX_ HV *stash) {
                 SvREFCNT_dec_NN(cv);
                 GvCV_set((GV*)entry, NULL);
             }
-            else if (SvTYPE(entry) == SVt_PVCV
-                     && (CvIsMETHOD((CV*)entry) || memEQs(kpv, klen, "new"))) {
-                (void)hv_delete(stash, kpv, HeUTF8(he) ? -(I32)klen : (I32)klen,
-                                G_DISCARD);
+            else if (SvROK(entry)) {
+                SV *sv = SvRV(entry);
+                if (SvTYPE(sv) == SVt_PVCV
+                         && (CvIsMETHOD((CV*)sv) || memEQs(kpv, klen, "new"))) {
+                    (void)hv_delete(stash, kpv, HeUTF8(he) ? -(I32)klen : (I32)klen,
+                                    G_DISCARD);
+                }
             }
         }
         ++PL_sub_generation;

--- a/op.c
+++ b/op.c
@@ -11102,12 +11102,9 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
            Also, we may be called from load_module at run time, so
            PL_curstash (which sets CvSTASH) may not point to the stash the
            sub is stored in.  */
-        /* XXX This optimization is currently disabled for packages other
-               than main, since there was too much CPAN breakage.  */
         const I32 flags =
            ec ? GV_NOADD_NOINIT
               :   (IN_PERL_RUNTIME && PL_curstash != CopSTASH(PL_curcop))
-               || PL_curstash != PL_defstash
                || memchr(name, ':', namlen) || memchr(name, '\'', namlen)
                     ? gv_fetch_flags
                     : GV_ADDMULTI | GV_NOINIT | GV_NOTQUAL;

--- a/t/op/sub.t
+++ b/t/op/sub.t
@@ -398,10 +398,7 @@ is ref($main::{rt_129916}), 'CODE', 'simple sub stored as CV in stash (main::)';
     package RT129916;
     sub foo { 42 }
 }
-{
-    local $::TODO = "disabled for now";
-    is ref($RT129916::{foo}), 'CODE', 'simple sub stored as CV in stash (non-main::)';
-}
+is ref($RT129916::{foo}), 'CODE', 'simple sub stored as CV in stash (non-main::)';
 
 # Calling xsub via ampersand syntax when @_ has holes
 SKIP: {


### PR DESCRIPTION
When seeing 'sub foo { ... }', perl does not need to allocate a full typeglob (with the subroutine being stored in the CODE slot). Instead, it can just store a coderef directly in the stash.

This optimization was first announced in perl5220delta:

> - Subroutines in packages no longer need to be stored in typeglobs:
>   declaring a subroutine will now put a simple sub reference directly
>   in the stash if possible, saving memory. The typeglob still
>   notionally exists, so accessing it will cause the stash entry to be
>   upgraded to a typeglob (i.e. this is just an internal implementation
>   detail).  This optimization does not currently apply to XSUBs or
>   exported subroutines, and method calls will undo it, since they
>   cache things in typeglobs.  [GH #13392]

However, due to a bug this optimization didn't actually work except for package main (GH #15671). The issue was fixed in v5.27.5, but the fix was backed out again in v5.27.9 because of CPAN breakage. It was enabled again in v5.41.9, but backed out again again in v5.41.10 because of too much CPAN breakage this late in the development cycle.

This reverts commit 51f234647f80e4fd56b09f001aab877f4edf1c18.

Also fix class_cleanup_definition: We actually store a reference-to-CV in the stash, not a bare CV, so we need to dereference once to recognize methods defined this way.

See #23131 for details (and expected CPAN breakage).

<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
* This set of changes requires a perldelta entry, and I need help writing it.
* This set of changes does not require a perldelta entry.
