### PR TITLE
Sync Scalar-List-Utils with CPAN version 1.70

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1009,17 +1009,9 @@ our %Modules = (
     },
 
     'Scalar::Util' => {
-        'DISTRIBUTION' => 'PEVANS/Scalar-List-Utils-1.69.tar.gz',
-        'SYNCINFO'     => 'jkeenan on Thu Apr 10 21:01:49 2025',
+        'DISTRIBUTION' => 'PEVANS/Scalar-List-Utils-1.70.tar.gz',
+        'SYNCINFO'     => 'leo on Wed Jul 30 12:31:45 2025',
         'FILES'        => q[cpan/Scalar-List-Utils],
-        'CUSTOMIZED'   => [
-            'ListUtil.xs',
-            'lib/List/Util.pm',
-            'lib/List/Util/XS.pm',
-            'lib/Scalar/Util.pm',
-            'lib/Sub/Util.pm',
-            't/exotic_names.t'
-         ],
     },
 
     'Search::Dict' => {

--- a/cpan/Scalar-List-Utils/ListUtil.xs
+++ b/cpan/Scalar-List-Utils/ListUtil.xs
@@ -1852,10 +1852,10 @@ CODE:
 #ifdef SvVOK
     SvGETMAGIC(sv);
     ST(0) = boolSV(SvVOK(sv));
-    XSRETURN(1);
 #else
-    croak("vstrings are not implemented in this release of perl");
+    ST(0) = boolSV(0);
 #endif
+    XSRETURN(1);
 
 SV *
 looks_like_number(sv)
@@ -1951,8 +1951,10 @@ PREINIT:
     STRLEN namelen;
     const char* nameptr = SvPV(name, namelen);
     int utf8flag = SvUTF8(name);
+#if PERL_VERSION_LT(5, 41, 3) || PERL_VERSION_GT(5, 41, 5)
     int quotes_seen = 0;
     bool need_subst = FALSE;
+#endif
 PPCODE:
     if (!SvROK(sub) && SvGMAGICAL(sub))
         mg_get(sub);
@@ -1975,18 +1977,23 @@ PPCODE:
         if (s > nameptr && *s == ':' && s[-1] == ':') {
             end = s - 1;
             begin = ++s;
+#if PERL_VERSION_LT(5, 41, 3) || PERL_VERSION_GT(5, 41, 5)
             if (quotes_seen)
                 need_subst = TRUE;
+#endif
         }
+#if PERL_VERSION_LT(5, 41, 3) || PERL_VERSION_GT(5, 41, 5)
         else if (s > nameptr && *s != '\0' && s[-1] == '\'') {
             end = s - 1;
             begin = s;
             if (quotes_seen++)
                 need_subst = TRUE;
         }
+#endif
     }
     s--;
     if (end) {
+#if PERL_VERSION_LT(5, 41, 3) || PERL_VERSION_GT(5, 41, 5)
         SV* tmp;
         if (need_subst) {
             STRLEN length = end - nameptr + quotes_seen - (*end == '\'' ? 1 : 0);
@@ -2006,6 +2013,7 @@ PPCODE:
             stash = gv_stashpvn(left, length, GV_ADD | utf8flag);
         }
         else
+#endif
             stash = gv_stashpvn(nameptr, end - nameptr, GV_ADD | utf8flag);
         nameptr = begin;
         namelen -= begin - nameptr;
@@ -2101,20 +2109,9 @@ BOOT:
     HV *lu_stash = gv_stashpvn("List::Util", 10, TRUE);
     GV *rmcgv = *(GV**)hv_fetch(lu_stash, "REAL_MULTICALL", 14, TRUE);
     SV *rmcsv;
-#if !defined(SvVOK)
-    HV *su_stash = gv_stashpvn("Scalar::Util", 12, TRUE);
-    GV *vargv = *(GV**)hv_fetch(su_stash, "EXPORT_FAIL", 11, TRUE);
-    AV *varav;
-    if(SvTYPE(vargv) != SVt_PVGV)
-        gv_init(vargv, su_stash, "Scalar::Util", 12, TRUE);
-    varav = GvAVn(vargv);
-#endif
     if(SvTYPE(rmcgv) != SVt_PVGV)
         gv_init(rmcgv, lu_stash, "List::Util", 10, TRUE);
     rmcsv = GvSVn(rmcgv);
-#ifndef SvVOK
-    av_push(varav, newSVpv("isvstring",9));
-#endif
 #ifdef REAL_MULTICALL
     sv_setsv(rmcsv, &PL_sv_yes);
 #else

--- a/cpan/Scalar-List-Utils/lib/List/Util.pm
+++ b/cpan/Scalar-List-Utils/lib/List/Util.pm
@@ -16,7 +16,7 @@ our @EXPORT_OK  = qw(
   sample shuffle uniq uniqint uniqnum uniqstr zip zip_longest zip_shortest mesh mesh_longest mesh_shortest
   head tail pairs unpairs pairkeys pairvalues pairmap pairgrep pairfirst
 );
-our $VERSION    = "1.68_01";
+our $VERSION    = "1.70";
 our $XS_VERSION = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/cpan/Scalar-List-Utils/lib/List/Util/XS.pm
+++ b/cpan/Scalar-List-Utils/lib/List/Util/XS.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use List::Util;
 
-our $VERSION = "1.68_01";       # FIXUP
+our $VERSION = "1.70";       # FIXUP
 $VERSION =~ tr/_//d;         # FIXUP
 
 1;

--- a/cpan/Scalar-List-Utils/lib/Scalar/List/Utils.pm
+++ b/cpan/Scalar-List-Utils/lib/Scalar/List/Utils.pm
@@ -2,7 +2,7 @@ package Scalar::List::Utils;
 use strict;
 use warnings;
 
-our $VERSION    = "1.69";
+our $VERSION    = "1.70";
 $VERSION =~ tr/_//d;
 
 1;

--- a/cpan/Scalar-List-Utils/lib/Scalar/Util.pm
+++ b/cpan/Scalar-List-Utils/lib/Scalar/Util.pm
@@ -17,7 +17,7 @@ our @EXPORT_OK = qw(
   dualvar isdual isvstring looks_like_number openhandle readonly set_prototype
   tainted
 );
-our $VERSION    = "1.68_01";
+our $VERSION    = "1.70";
 $VERSION =~ tr/_//d;
 
 require List::Util; # List::Util loads the XS
@@ -34,16 +34,6 @@ if( $] >= 5.040 ) {
 
   *$_ = \&{ $builtins->{$_} } for (qw( blessed refaddr reftype weaken unweaken ));
   *isweak = \&{ $builtins->{is_weak} };  # renamed
-}
-
-# populating @EXPORT_FAIL is done in the XS code
-sub export_fail {
-  if (grep { /^isvstring$/ } @_ ) {
-    require Carp;
-    Carp::croak("Vstrings are not implemented in this version of perl");
-  }
-
-  @_;
 }
 
 # set_prototype has been moved to Sub::Util with a different interface

--- a/cpan/Scalar-List-Utils/lib/Sub/Util.pm
+++ b/cpan/Scalar-List-Utils/lib/Sub/Util.pm
@@ -15,7 +15,7 @@ our @EXPORT_OK = qw(
   subname set_subname
 );
 
-our $VERSION    = "1.68_01";
+our $VERSION    = "1.70";
 $VERSION =~ tr/_//d;
 
 require List::Util; # as it has the XS

--- a/cpan/Scalar-List-Utils/t/exotic_names.t
+++ b/cpan/Scalar-List-Utils/t/exotic_names.t
@@ -45,7 +45,7 @@ sub caller3_ok {
         ),
     );
 
-    $expected =~ s/'/::/g if $] < 5.037009 || $] >= 5.041_004;
+    $expected =~ s/'/::/g if $] < 5.041_003 || $] >= 5.041_006;
 
     # this is apparently how things worked before 5.16
     utf8::encode($expected) if $] < 5.016 and $ord > 255;
@@ -71,8 +71,8 @@ my @ordinal = (
     # 5.14 is the first perl to start properly handling \0 in identifiers
     ($] >= 5.014 ? ( 0 ) : ()),
     1 .. 38,
-    # single quote ' separators are deprecated in 5.37.9
-    ($] < 5.037009 || $] >= 5.041_004 ? ( 39 ) : ()),
+    # single quote ' separators are deprecated in 5.37.9, removed in 5.41.3, readded in 5.41.6
+    ($] < 5.037_009 || $] >= 5.041_006 ? ( 39 ) : ()),
     40 .. 255,
     # Unicode in 5.6 is not sane (crashes etc)
     ($] >= 5.008 ? (
@@ -85,7 +85,7 @@ my @ordinal = (
 
 my $legal_ident_char = join('',
     "A-Z_a-z0-9",
-    ($] < 5.037009 || $] >= 5.041_004 ? q['] : ()),
+    ($] < 5.037_009 || $] >= 5.041_006 ? q['] : ()),
     ($] > 5.008 ? (
         map chr, 0x100, 0x498
     ) : ()),

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -10,12 +10,6 @@ MIME::Base64 cpan/MIME-Base64/Base64.xs ad617fe2d01932c35b92defa26d40aba601a95a8
 MIME::Base64 cpan/MIME-Base64/lib/MIME/Base64.pm 18e38d197c7c83f96b24f48bef514e93908e6a82
 MIME::Base64 cpan/MIME-Base64/lib/MIME/QuotedPrint.pm 36cbb455ab57b9bbca7e86f50987c8b1df1a8122
 Pod::Perldoc cpan/Pod-Perldoc/lib/Pod/Perldoc.pm 582be34c077c9ff44d99914724a0cc2140bcd48c
-Scalar::Util cpan/Scalar-List-Utils/lib/List/Util.pm 98dbc1cb98d448bd929fe42cf0fc47da978df196
-Scalar::Util cpan/Scalar-List-Utils/lib/List/Util/XS.pm 0e2ef5dcbebb5d808edd4b7adec8f6553cdde916
-Scalar::Util cpan/Scalar-List-Utils/lib/Scalar/Util.pm dddbfb9e26de572f88598cdf06353902718eb2ec
-Scalar::Util cpan/Scalar-List-Utils/lib/Sub/Util.pm 4be8e62dea87acce5ba50d11e7246baa0bfc5be0
-Scalar::Util cpan/Scalar-List-Utils/ListUtil.xs 3d0ba62cd4222599bf00956e8b963817f3afcfe2
-Scalar::Util cpan/Scalar-List-Utils/t/exotic_names.t a62bcb9dc667d5e51cbe061705b15f202ede8351
 Win32 cpan/Win32/Win32.pm 07a777ca9c5f642f068f92895a79a096a4a54469
 Win32 cpan/Win32/Win32.xs ff7efeb6b7bfa67e22411b6e3db761c730213a52
 Win32API::File cpan/Win32API-File/File.pm 8fd212857f821cb26648878b96e57f13bf21b99e


### PR DESCRIPTION
* This set of changes does not require a perldelta entry.
