### PR TITLE
Move comment to the referenced lines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,13 +4,13 @@ and give context to the reviewers to aid them in their reviews.
 -->
 TODO: fill description here
 
+-------------------------------------------------------------------------------
 <!--
 Significant changes to Perl must be documented in perldelta.
 
 Consider if the changes in this pull request are worthy of a perldelta
 entry, then pick the appropriate line below and remove the others.
 -->
----------------------------------------------------------------------------------
 * This set of changes requires a perldelta entry, and it is included.
 * This set of changes requires a perldelta entry, and I need help writing it.
 * This set of changes does not require a perldelta entry.


### PR DESCRIPTION
When the hard-rule line was added, it separated the comment from the lines to which the comment talks about. This change moves the comment to once again be directly above the referenced text and reduces the length of the line from 81 dashes to fewer than 80 (79).
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
