### PR TITLE
class.c: gracefully handle reader definition after 'strict' error

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6002,6 +6002,7 @@ t/class/construct.t			See if class constructors work
 t/class/destruct.t			See if class destruction works
 t/class/field.t				See if class field declarations work
 t/class/gh22169.t			Test defining a class that previously failed to define
+t/class/gh23511.t			Test defining a reader after a strict 'vars' violation
 t/class/inherit.t			See if class inheritance works
 t/class/method.t			See if class method declarations work
 t/class/phasers.t			See if class phaser blocks work

--- a/class.c
+++ b/class.c
@@ -1140,7 +1140,8 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
     OP *nameop = newSVOP(OP_CONST, 0, value);
 
     CV *cv = newATTRSUB(floor_ix, nameop, NULL, NULL, ops);
-    CvIsMETHOD_on(cv);
+    if (cv)
+        CvIsMETHOD_on(cv);
 }
 
 /* If '@_' is called "snail", then elements of it can be called "slugs"; i.e.
@@ -1238,7 +1239,8 @@ apply_field_attribute_writer(pTHX_ PADNAME *pn, SV *value)
     OP *nameop = newSVOP(OP_CONST, 0, value);
 
     CV *cv = newATTRSUB(floor_ix, nameop, NULL, NULL, ops);
-    CvIsMETHOD_on(cv);
+    if (cv)
+        CvIsMETHOD_on(cv);
 }
 
 static struct {

--- a/t/class/gh23511.t
+++ b/t/class/gh23511.t
@@ -1,0 +1,23 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+}
+
+use v5.36;
+use feature 'class';
+no warnings 'experimental::class';
+
+# this used to segfault: GH #23511
+eval <<'CLASS';
+class MyTest {
+    $id = 6;
+    field $f1 :reader;
+    field $f2 :writer;
+}
+CLASS
+like $@, qr/^Global symbol "\$id" requires explicit package name /, "we get the expected 'undeclared variable' error";
+
+done_testing;


### PR DESCRIPTION
Fixes #23511.

-------------------------------------------------------------------------------
<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
