### PR TITLE
Peephole optimizations for NULLs in lists and scalar lists

### DIFF
--- a/peep.c
+++ b/peep.c
@@ -3142,6 +3142,26 @@ Perl_rpeep(pTHX_ OP *o)
             }
 
             /* Given
+                   list (in scalar context)
+                     pushmark
+                     something
+               The pushmark & list OPs are unnecessary.
+            */
+
+            {
+                OP *nn = o->op_next->op_next;
+                if (OP_TYPE_IS(nn, OP_LIST) &&
+                    ((nn->op_flags & OPf_WANT) == OPf_WANT_SCALAR) ) {
+                    if (oldop)
+                        oldop->op_next = o->op_next;
+                    o->op_next->op_next = nn->op_next;
+                    op_null(nn);
+                    op_null(o);
+                    oldop = NULL; oldoldop = NULL;
+                }
+            }
+
+            /* Given
                  5 repeat/DOLIST
                  3   ex-list
                  1     pushmark

--- a/peep.c
+++ b/peep.c
@@ -3125,6 +3125,23 @@ Perl_rpeep(pTHX_ OP *o)
         case OP_PUSHMARK:
 
             /* Given
+                   pushmark
+                   null
+                   something_else
+               Take out the null wherever possible.
+            */
+            while (OP_TYPE_IS(o->op_next, OP_NULL)) {
+                OP* next = o->op_next;
+                o->op_next = next->op_next;
+                if (OpSIBLING(o) == next &&
+                    next->op_moresib &&
+                    !(next->op_flags & OPf_KIDS)) {
+                    op_sibling_splice(NULL, o, 1, NULL);
+                    op_free(next);
+                }
+            }
+
+            /* Given
                  5 repeat/DOLIST
                  3   ex-list
                  1     pushmark


### PR DESCRIPTION
`my $x = (1,2,3);` produces the following OP tree in blead:
```
2     <;> nextstate(main 1 -e:1) v:{ ->3
6     <1> padsv_store[$x:1,2] vKS/LVINTRO ->7
5        <@> list sKP ->6
3           <0> pushmark v ->4
-           <0> ex-const v ->-
-           <0> ex-const v ->4
4           <$> const(IV 3) s ->5
-        <0> ex-padsv sRM*/LVINTRO ->6
```
This is functionally equivalent to `my $x = 3;`:
```
2     <;> nextstate(main 1 -e:1) v:{ ->3
4     <1> padsv_store[$x:1,2] vKS/LVINTRO ->5
3        <$> const(IV 3) s ->4
-        <0> ex-padsv sRM*/LVINTRO ->4
```
Refactoring `Perl_scalar` / `Perl_scalarvoid` to allow the transformation of the first  tree into the second is proabably not worth the churn, given that constructing the first tree will typically emit "_Useless use of X in scalar context_" warnings. Some cases may silently slip through though, such as when the consts `0` and `1` are excluded from these warnings.

The attached commits enable the peephole optimizer to do two things:
1. Remove `OP_NULL` list nodes, when they have no kids and have a sibling.
2. Adjust the `op_next` pointers to skip over the unnecessary `OP_PUSHMARK` and `OP_LIST` nodes.

That gives an OP tree like this:
```
2     <;> nextstate(main 1 -e:1) v:{ ->3
4     <1> padsv_store[$x:1,2] vKS/LVINTRO ->5
-        <1> ex-list sKP ->4
-           <0> ex-pushmark v ->3
3           <$> const[IV 3] s ->4
-        <0> ex-padsv sRM*/LVINTRO ->4
```

Closes: #23448

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
