### PR TITLE
trying to TODO-test GH 15419 (Cloning STDOUT loses encoding)

### DIFF
--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -35,6 +35,20 @@ my $switches = "";
 our $TODO;
 
 TODO: {
+    local $::TODO = 'GH 15419';
+    my $results = fresh_perl(<<~'EOF', { stderr => 1 } );
+        use strict;
+        use warnings;
+        binmode *STDOUT, ":encoding(utf8)";
+        open(my $copy, '>&', STDOUT);
+        print $copy "\x{11e}\n";
+        EOF
+    is($?, 0, "No assertion failure");
+    is $results, "\x{11e}", "print returned the expected output";
+    unlike $results, qr/Wide character in print/, "print did not warn about wide characters";
+}
+
+TODO: {
     local $::TODO = "GH 16008";
     my $results = fresh_perl(<<~'EOF', {} );
         open my $h, ">", \my $x;


### PR DESCRIPTION
I'm trying to contribute a TODO test following Karl Williamson's call, which was brought to my attention by Brain D. Foy over at reddit. I've run into issues and Brian [suggested I'd open a PR here](https://www.reddit.com/r/perl/comments/1mbdp7b/comment/n6l96dq/). 

---

Hello, I'm trying to get my head around this in order to contribute. I don't know if it is a good or even valid issue to try, but I've picked [GH 15419](https://github.com/Perl/perl5/issues/15419) for my first steps.

First, I've reproduced the actual problem - running this:

    use strict;
    use warnings;
    binmode *STDOUT, ":encoding(utf8)";
    open(my $copy, '>&', STDOUT);
    print $copy "\x{11e}\n";

...with blead perl does indeed give the reported warning:

    $ ./perl -Ilib ./gh15419.pl
    Wide character in print at ./gh15419.pl line 5.
    Ğ

Now if I add a new test into t/run/todo.pl like so:

    TODO: {
        local $::TODO = 'GH 15419';
        my $results = fresh_perl(<<~'EOF', { stderr => 1 } );
            use strict;
            use warnings;
            binmode *STDOUT, ":encoding(utf8)";
            open(my $copy, '>&', STDOUT);
            print $copy "\x{11e}\n";
            EOF
        is($?, 0, "No assertion failure");
        is $results, "\x{11e}", "print returned the expected output";
        unlike $results, qr/Wide character in print/, "print did not warn about wide characters";
    }

...I get:

    ok 2 - No assertion failure # TODO GH 15419
    not ok 3 - print returned the expected output # TODO GH 15419
    # Failed test 3 - print returned the expected output at t/run/todo.t line 47
    #      got "Ğ"
    # expected "\x{11e}"
    ok 4 - print did not warn about wide characters # TODO GH 15419

So there's two problems:

1. Matching of the output fails. I get an unicode escape for the expectation, while the "got" value is printed as an true unicode character.
2. The expected warning is not actually issued here. I guess this means running with t/test.pl somehow corrects for the behavior seen in the standalone script?