### PR TITLE
toke.c dont call libc's memcmp() to test 1 byte in Perl_scan_str()

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -11645,9 +11645,12 @@ Perl_scan_str(pTHX_ char *start, int keep_bracketed_quoted, int keep_delims, int
         open_delim_str[0] =      *s;
         delim_byte_len = 1;
     }
-    else {
+    else { /* don't let delim_byte_len escape and be a volatile mem addr */
+        STRLEN delim_byte_len_tmp;
         open_delim_code = utf8_to_uv_or_die((U8*)s, (U8*)PL_bufend,
-                                            &delim_byte_len);
+                                            &delim_byte_len_tmp);
+        /* CC can safely keep delim_byte_len in a register until the end */
+        delim_byte_len = delim_byte_len_tmp;
         if (UNLIKELY(! is_grapheme((U8 *) start,
                                    (U8 *) s,
                                    (U8 *) PL_bufend,
@@ -11764,9 +11767,9 @@ Perl_scan_str(pTHX_ char *start, int keep_bracketed_quoted, int keep_delims, int
     s += delim_byte_len;
     for (;;) {
         /* extend sv if need be */
-        SvGROW(sv, SvCUR(sv) + (PL_bufend - s) + 1);
+        char * pv = SvGROW(sv, SvCUR(sv) + (PL_bufend - s) + 1);
         /* set 'to' to the next character in the sv's string */
-        to = SvPVX(sv)+SvCUR(sv);
+        to = pv + SvCUR(sv);
 
         /* read until we run out of string, or we find the closing delimiter */
         while (s < PL_bufend) {
@@ -11784,18 +11787,22 @@ Perl_scan_str(pTHX_ char *start, int keep_bracketed_quoted, int keep_delims, int
                  * discard those that escape the closing delimiter, just
                  * discard this one */
                 if (   !  keep_bracketed_quoted
-                    &&   (    memEQ(s + 1,  open_delim_str, delim_byte_len)
-                          ||  (   PL_multi_open == PL_multi_close
-                               && re_reparse && s[1] == '\\')
-                          ||  memEQ(s + 1, close_delim_str, delim_byte_len)))
-                {
+                    &&   ((delim_byte_len == 1
+                            ? (s[1] == open_delim_str[0]
+                                || s[1] == close_delim_str[0])
+                            : (memEQ(s + 1, open_delim_str, delim_byte_len)
+                                || memEQ(s + 1, close_delim_str, delim_byte_len)))
+                         || (PL_multi_open == PL_multi_close
+                             && re_reparse && s[1] == '\\'))) {
                     s++;
                 }
                 else /* any other escapes are simply copied straight through */
                     *to++ = *s++;
             }
             else if (   s < PL_bufend - (delim_byte_len - 1)
-                     && memEQ(s, close_delim_str, delim_byte_len)
+                     && (delim_byte_len == 1
+                        ? s[0] == close_delim_str[0]
+                        : memEQ(s, close_delim_str, delim_byte_len))
                      && --brackets <= 0)
             {
                 /* Found unescaped closing delimiter, unnested if we care about
@@ -11824,7 +11831,9 @@ Perl_scan_str(pTHX_ char *start, int keep_bracketed_quoted, int keep_delims, int
                         /* No nesting if open eq close */
             else if (   PL_multi_open != PL_multi_close
                      && s < PL_bufend - (delim_byte_len - 1)
-                     && memEQ(s, open_delim_str, delim_byte_len))
+                     && (delim_byte_len == 1
+                         ? s[0] == open_delim_str[0]
+                         : memEQ(s, open_delim_str, delim_byte_len)))
             {
                 brackets++;
             }


### PR DESCRIPTION
delim_byte_len is almost always 1, open_delim_str is almost always '"' or '\'' or something similar. I'm not sure which exact string of PP code will make delim_byte_len not be 1, but it would be too rare to optimize for but still must be supported.

Just test the char directly if its length of 1. Invoking libc memcmp() requires 4 ABI inputs on any CPU, and while most of the code paths above the memEQ() lines are constants directly initialized inside Perl_scan_str(), one branch uses "utf8_to_uv_or_die(,,&delim_byte_len)" which optimizes to Perl_utf8_to_uvchr_buf_helper(,,,&delim_byte_len) making the value in STRLEN delim_byte_len unbounded according to all CC. All CCs must assume the value Perl_utf8_to_uvchr_buf_helper() put inside delim_byte_len could be a 4.7GB DVD or 25GB BD .iso file.

Put the retval of SvGROW() to use.

Don't let C auto var delim_byte_len escape with "&" op thru utf8_to_uv_or_die(). Var delim_byte_len can never be stored in a register again by any CC if it escapes and must be reread from C stack after ever possible call if it escapes.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
