### PR TITLE
fix t/run/todo.t under miniperl

### DIFF
--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -39,6 +39,7 @@ my $is_debugging_build = $Config{cppflags} =~ /-DDEBUGGING/;
 our $TODO;
 
 TODO: {     # Should be moved to  lib/B/Deparse.t
+    todo_skip "Test needs B", 1 if is_miniperl();
     my $results = fresh_perl(<<~'EOF', {});
         use B::Deparse;
         my $deparse = B::Deparse->new();


### PR DESCRIPTION
The B module isn't available under miniperl, so skip a test.

* This set of changes does not require a perldelta entry.
