### PR TITLE
 dump.c: Fix broken c++ compilations in

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -1126,6 +1126,8 @@ S_get_sv_from_pad(pTHX_ const OP *o, PADOFFSET po, CV *rootcv)
         return NULL;
 
     CV *cv = NULL;
+    int n;
+    OP *oproot;
 
     if (rootcv) {
         cv = rootcv;
@@ -1138,8 +1140,8 @@ S_get_sv_from_pad(pTHX_ const OP *o, PADOFFSET po, CV *rootcv)
      * stack. Limit the number of hops, in case there is some sort of
      * loop or other weirdness.
      */
-    int n = 100;
-    OP *oproot = (OP*)o;
+    n = 100;
+    oproot = (OP*)o;
     while (1) {
         if (--n <= 0)
             return NULL;


### PR DESCRIPTION
Commit bce5eba453b71437b5d508b1e717646587dda0db broke c++ compilations because a goto now crosses declarations with initialization.

This commit merely separates the declarations from their initialization, and moves the declarations to before the goto.

The alternative could just as easily have been to move the goto to after the initialization, but the initialization would then be (a bit of) extra work, and more importantly, that would break the code flow of immediately using the initialized values.


* This set of changes does not require a perldelta entry.
