### PR TITLE
Remove redundant assert() statements

### DIFF
--- a/av.c
+++ b/av.c
@@ -25,7 +25,6 @@ Perl_av_reify(pTHX_ AV *av)
     SSize_t key;
 
     PERL_ARGS_ASSERT_AV_REIFY;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     if (AvREAL(av))
         return;
@@ -68,7 +67,6 @@ Perl_av_extend(pTHX_ AV *av, SSize_t key)
     MAGIC *mg;
 
     PERL_ARGS_ASSERT_AV_EXTEND;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     mg = SvTIED_mg((const SV *)av, PERL_MAGIC_tied);
     if (mg) {
@@ -272,7 +270,6 @@ Perl_av_fetch(pTHX_ AV *av, SSize_t key, I32 lval)
     SSize_t size;
 
     PERL_ARGS_ASSERT_AV_FETCH;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     if (UNLIKELY(SvRMAGICAL(av))) {
         const MAGIC * const tied_magic
@@ -342,7 +339,6 @@ Perl_av_store(pTHX_ AV *av, SSize_t key, SV *val)
     SV** ary;
 
     PERL_ARGS_ASSERT_AV_STORE;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     /* S_regclass relies on being able to pass in a NULL sv
        (unicode_alternate may be NULL).
@@ -637,7 +633,6 @@ Perl_av_clear(pTHX_ AV *av)
     SSize_t orig_ix = 0;
 
     PERL_ARGS_ASSERT_AV_CLEAR;
-    assert(SvTYPE(av) == SVt_PVAV);
 
 #ifdef DEBUGGING
     if (SvREFCNT(av) == 0) {
@@ -711,7 +706,6 @@ Perl_av_undef(pTHX_ AV *av)
     SSize_t orig_ix = PL_tmps_ix; /* silence bogus warning about possible uninitialized use */
 
     PERL_ARGS_ASSERT_AV_UNDEF;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     /* Give any tie a chance to cleanup first */
     if (SvTIED_mg((const SV *)av, PERL_MAGIC_tied)) 
@@ -793,7 +787,6 @@ Perl_av_push(pTHX_ AV *av, SV *val)
     MAGIC *mg;
 
     PERL_ARGS_ASSERT_AV_PUSH;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     if (SvREADONLY(av))
         croak_no_modify();
@@ -825,7 +818,6 @@ Perl_av_pop(pTHX_ AV *av)
     MAGIC* mg;
 
     PERL_ARGS_ASSERT_AV_POP;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     if (SvREADONLY(av))
         croak_no_modify();
@@ -884,7 +876,6 @@ Perl_av_unshift(pTHX_ AV *av, SSize_t num)
     MAGIC* mg;
 
     PERL_ARGS_ASSERT_AV_UNSHIFT;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     if (SvREADONLY(av))
         croak_no_modify();
@@ -951,7 +942,6 @@ Perl_av_shift(pTHX_ AV *av)
     MAGIC* mg;
 
     PERL_ARGS_ASSERT_AV_SHIFT;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     if (SvREADONLY(av))
         croak_no_modify();
@@ -1027,7 +1017,6 @@ Perl_av_fill(pTHX_ AV *av, SSize_t fill)
     MAGIC *mg;
 
     PERL_ARGS_ASSERT_AV_FILL;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     if (fill < 0)
         fill = -1;
@@ -1080,7 +1069,6 @@ Perl_av_delete(pTHX_ AV *av, SSize_t key, I32 flags)
     SV *sv;
 
     PERL_ARGS_ASSERT_AV_DELETE;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     if (SvREADONLY(av))
         croak_no_modify();
@@ -1155,7 +1143,6 @@ bool
 Perl_av_exists(pTHX_ AV *av, SSize_t key)
 {
     PERL_ARGS_ASSERT_AV_EXISTS;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     if (SvRMAGICAL(av)) {
         const MAGIC * const tied_magic
@@ -1213,7 +1200,6 @@ S_get_aux_mg(pTHX_ AV *av) {
     MAGIC *mg;
 
     PERL_ARGS_ASSERT_GET_AUX_MG;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     mg = mg_find((const SV *)av, PERL_MAGIC_arylen_p);
 
@@ -1232,7 +1218,6 @@ Perl_av_arylen_p(pTHX_ AV *av) {
     MAGIC *const mg = get_aux_mg(av);
 
     PERL_ARGS_ASSERT_AV_ARYLEN_P;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     return &(mg->mg_obj);
 }
@@ -1242,7 +1227,6 @@ Perl_av_iter_p(pTHX_ AV *av) {
     MAGIC *const mg = get_aux_mg(av);
 
     PERL_ARGS_ASSERT_AV_ITER_P;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     if (sizeof(IV) == sizeof(SSize_t)) {
         return (IV *)&(mg->mg_len);

--- a/inline.h
+++ b/inline.h
@@ -56,7 +56,6 @@ PERL_STATIC_INLINE Size_t
 Perl_av_count(pTHX_ AV *av)
 {
     PERL_ARGS_ASSERT_AV_COUNT;
-    assert(SvTYPE(av) == SVt_PVAV);
 
     return AvFILL(av) + 1;
 }
@@ -100,7 +99,6 @@ Perl_av_store_simple(pTHX_ AV *av, SSize_t key, SV *val)
     SV** ary;
 
     PERL_ARGS_ASSERT_AV_STORE_SIMPLE;
-    assert(SvTYPE(av) == SVt_PVAV);
     assert(!SvMAGICAL(av));
     assert(!SvREADONLY(av));
     assert(AvREAL(av));
@@ -143,7 +141,6 @@ PERL_STATIC_INLINE SV**
 Perl_av_fetch_simple(pTHX_ AV *av, SSize_t key, I32 lval)
 {
     PERL_ARGS_ASSERT_AV_FETCH_SIMPLE;
-    assert(SvTYPE(av) == SVt_PVAV);
     assert(!SvMAGICAL(av));
     assert(!SvREADONLY(av));
     assert(AvREAL(av));
@@ -160,7 +157,6 @@ PERL_STATIC_INLINE void
 Perl_av_push_simple(pTHX_ AV *av, SV *val)
 {
     PERL_ARGS_ASSERT_AV_PUSH_SIMPLE;
-    assert(SvTYPE(av) == SVt_PVAV);
     assert(!SvMAGICAL(av));
     assert(!SvREADONLY(av));
     assert(AvREAL(av));
@@ -3885,7 +3881,6 @@ Perl_clear_defarray_simple(pTHX_ AV *av)
 {
     PERL_ARGS_ASSERT_CLEAR_DEFARRAY_SIMPLE;
 
-    assert(SvTYPE(av) == SVt_PVAV);
     assert(!SvREADONLY(av));
     assert(!SvMAGICAL(av));
     assert(SvREFCNT(av) == 1);

--- a/sv.c
+++ b/sv.c
@@ -1297,7 +1297,6 @@ Perl_hv_auxalloc(pTHX_ HV *hv) {
     void *new_body;
 
     PERL_ARGS_ASSERT_HV_AUXALLOC;
-    assert(SvTYPE(hv) == SVt_PVHV);
     assert(!HvHasAUX(hv));
 
 #ifdef PURIFY


### PR DESCRIPTION
These assertions have been redundant since
2463f19365f941f68e9d5eed2f787341df8ccdef, July 2024.


* This set of changes does not require a perldelta entry.
