### PR TITLE
todo test for GH 16865 (Assertion failure in Perl_pp_sort/S_POPMARK)

### DIFF
--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -64,6 +64,12 @@ TODO: {
 }
 
 TODO: {
+    local $::TODO = 'GH 16865';
+    fresh_perl('\(sort { 0 } 0, 0 .. "a")', { stderr => 'devnull' });
+    is($?, 0, "No assertion failure");
+}
+
+TODO: {
     todo_skip "Test needs -DDEBUGGING", 1 unless $is_debugging_build;
     local $::TODO = 'GH 16876';
     fresh_perl('$_ = "a"; s{ x | (?{ s{}{x} }) }{}gx;',


### PR DESCRIPTION
This PR adds a test for #16865, which still appears to be broken.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
