### PR TITLE
Even less cheating in `class.c`

### DIFF
--- a/class.c
+++ b/class.c
@@ -1099,25 +1099,17 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
 
     I32 save_ix = block_start(TRUE);
 
+    subsignature_start();
+
     PADOFFSET padix;
 
     padix = pad_add_name_pvs("$self", 0, NULL, NULL);
     assert(padix == PADIX_SELF);
 
+    OP *sigop = subsignature_finish();
+
     padix = pad_import_field(pn);
     intro_my();
-
-    OP *argcheckop;
-    {
-        struct op_argcheck_aux *aux = (struct op_argcheck_aux *)
-            PerlMemShared_malloc(sizeof(*aux));
-
-        aux->params     = 0;
-        aux->opt_params = 0;
-        aux->slurpy     = 0;
-
-        argcheckop = newUNOP_AUX(OP_ARGCHECK, 0, NULL, (UNOP_AUX_item *)aux);
-    }
 
     OP *retop;
     {
@@ -1135,7 +1127,7 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
     }
 
     OP *ops = newLISTOPn(OP_LINESEQ, 0,
-            argcheckop,
+            sigop,
             retop,
             NULL);
 
@@ -1147,18 +1139,6 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
     CV *cv = newATTRSUB(floor_ix, nameop, NULL, NULL, ops);
     if (cv)
         CvIsMETHOD_on(cv);
-}
-
-/* If '@_' is called "snail", then elements of it can be called "slugs"; i.e.
- * snails out of their container. */
-#define newSLUGOP(idx)  S_newSLUGOP(aTHX_ idx)
-static OP *
-S_newSLUGOP(pTHX_ IV idx)
-{
-    assert(idx >= 0 && idx <= 255);
-    OP *op = newGVOP(OP_AELEMFAST, 0, PL_defgv);
-    op->op_private = idx;
-    return op;
 }
 
 static void
@@ -1186,28 +1166,27 @@ apply_field_attribute_writer(pTHX_ PADNAME *pn, SV *value)
 
     I32 save_ix = block_start(TRUE);
 
+    subsignature_start();
+
     PADOFFSET padix;
 
     padix = pad_add_name_pvs("$self", 0, NULL, NULL);
     assert(padix == PADIX_SELF);
 
+    /* param pad variable doesn't technically need a name, so don't bother as
+     * reusing the field name will provoke a warning */
+    PADOFFSET param_padix = padix = pad_add_name_pvn("$", 1, 0, NULL, NULL);
+    intro_my();
+
+    subsignature_append_positional(param_padix, 0, NULL);
+
+    OP *sigop = subsignature_finish();
+
     padix = pad_import_field(pn);
     intro_my();
 
-    OP *argcheckop;
-    {
-        struct op_argcheck_aux *aux = (struct op_argcheck_aux *)
-            PerlMemShared_malloc(sizeof(*aux));
-
-        aux->params     = 1;
-        aux->opt_params = 0;
-        aux->slurpy     = 0;
-
-        argcheckop = newUNOP_AUX(OP_ARGCHECK, 0, NULL, (UNOP_AUX_item *)aux);
-    }
-
     OP *assignop = newBINOP(OP_SASSIGN, 0,
-            newSLUGOP(0),
+            newPADxVOP(OP_PADSV, 0, param_padix),
             newPADxVOP(OP_PADSV, OPf_MOD|OPf_REF, padix));
 
     OP *retop = newLISTOP(OP_RETURN, 0,
@@ -1215,7 +1194,7 @@ apply_field_attribute_writer(pTHX_ PADNAME *pn, SV *value)
             newPADxVOP(OP_PADSV, 0, PADIX_SELF));
 
     OP *ops = newLISTOPn(OP_LINESEQ, 0,
-            argcheckop,
+            sigop,
             assignop,
             retop,
             NULL);

--- a/embed.fnc
+++ b/embed.fnc
@@ -3111,12 +3111,12 @@ CRp	|NV	|str_to_version |NN SV *sv
 p	|void	|sub_crush_depth|NN CV *cv
 : Used in perly.y
 p	|void	|subsignature_append_positional 			\
-				|NULLOK OP *varop			\
+				|PADOFFSET padix			\
 				|OPCODE defmode 			\
 				|NULLOK OP *defexpr
 p	|void	|subsignature_append_slurpy				\
 				|I32 sigil				\
-				|NULLOK OP *varop
+				|PADOFFSET padix
 p	|OP *	|subsignature_finish
 p	|void	|subsignature_start
 Adp	|void	|suspend_compcv |NN struct suspended_compcv *buffer

--- a/op.c
+++ b/op.c
@@ -16519,17 +16519,15 @@ Perl_subsignature_start(pTHX)
 }
 
 /* Appends another positional scalar parameter to the accumulated set of
- * subroutine params. `varop` may be NULL, but if not it must be an OP_ARGELEM
- * whose op_targ refers to an already-declared pad lexical. That lexical must
- * be a scalar. It is not necessary to set the argument index in the op_aux
- * field; that will be filled in by this function.
+ * subroutine params. `padix` may be zero, but if not it must be the pad
+ * index of a scalar pad lexical to store the incoming argument value into.
  * If `defexpr` is not NULL, it gives a defaulting expression to be evaluated
  * if required, according to `defmode` - one of zero, `OP_DORASSIGN` or
  * `OP_ORASSIGN`.
  */
 
 void
-Perl_subsignature_append_positional(pTHX_ OP *varop, OPCODE defmode, OP *defexpr)
+Perl_subsignature_append_positional(pTHX_ PADOFFSET padix, OPCODE defmode, OP *defexpr)
 {
     PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_POSITIONAL;
     assert(PL_parser);
@@ -16541,13 +16539,13 @@ Perl_subsignature_append_positional(pTHX_ OP *varop, OPCODE defmode, OP *defexpr
 
     UV argix = signature->elems;
 
-    if(varop) {
-        assert(varop->op_type == OP_ARGELEM);
-        assert((varop->op_private & OPpARGELEM_MASK) == OPpARGELEM_SV);
-        assert(varop->op_targ);
-        assert(PadnamePV(PadnamelistARRAY(PL_comppad_name)[varop->op_targ])[0] == '$');
+    OP *varop = NULL;
+    if(padix) {
+        assert(PadnamePV(PadnamelistARRAY(PL_comppad_name)[padix])[0] == '$');
 
-        /* Now fill in the argix */
+        varop = newUNOP_AUX(OP_ARGELEM, 0, NULL, NULL);
+        varop->op_private |= OPpARGELEM_SV;
+        varop->op_targ = padix;
         cUNOP_AUXx(varop)->op_aux = INT2PTR(UNOP_AUX_item *, argix);
     }
 
@@ -16604,14 +16602,13 @@ Perl_subsignature_append_positional(pTHX_ OP *varop, OPCODE defmode, OP *defexpr
 }
 
 /* Appends a final slurpy parameter to the accumulated set of subroutine
- * params. `varop` may be NULL, but if not it must be an OP_ARGELEM whose
- * op_targ refers to an already-declared pad lexical. That lexical must match
- * the `sigil` parameter. It is not necessary to set the argument index in the
- * op_aux field; that will be filled in by this function.
+ * params. `padix` may be zero, but if not it must be the pad index of an
+ * array or hash lexical to store the remaining argument values into. Its
+ * sigil must match the `sigil` parameter.
  */
 
 void
-Perl_subsignature_append_slurpy(pTHX_ I32 sigil, OP *varop)
+Perl_subsignature_append_slurpy(pTHX_ I32 sigil, PADOFFSET padix)
 {
     PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_SLURPY;
     assert(PL_parser);
@@ -16624,21 +16621,19 @@ Perl_subsignature_append_slurpy(pTHX_ I32 sigil, OP *varop)
 
     UV argix = signature->elems;
 
-    if(varop) {
-        assert(varop->op_type == OP_ARGELEM);
-        assert((varop->op_private & OPpARGELEM_MASK) ==
-                ((sigil == '@') ? OPpARGELEM_AV : OPpARGELEM_HV));
-        assert(varop->op_targ);
-        assert(PadnamePV(PadnamelistARRAY(PL_comppad_name)[varop->op_targ])[0] == sigil);
-
-        /* Now fill in the argix */
-        cUNOP_AUXx(varop)->op_aux = INT2PTR(UNOP_AUX_item *, argix);
-    }
-
     signature->slurpy = (char)sigil;
 
-    if(varop) {
-        /* TODO: assert() the sigil of the pad variable matches */
+    if(padix) {
+        assert(PadnamePV(PadnamelistARRAY(PL_comppad_name)[padix])[0] == sigil);
+
+        OP *varop = newUNOP_AUX(OP_ARGELEM, 0, NULL, NULL);
+        if(sigil == '@')
+            varop->op_private |= OPpARGELEM_AV;
+        if(sigil == '%')
+            varop->op_private |= OPpARGELEM_HV;
+        varop->op_targ = padix;
+        cUNOP_AUXx(varop)->op_aux = INT2PTR(UNOP_AUX_item *, argix);
+
         signature->elemops = op_append_list(OP_LINESEQ, signature->elemops,
                 newSTATEOP(0, NULL, varop));
     }

--- a/perly.act
+++ b/perly.act
@@ -933,15 +933,15 @@ case 2: /* @1: %empty  */
 
     break;
 
-  case 119: /* sigvarname: %empty  */
+  case 119: /* sigvar: %empty  */
 #line 826 "perly.y"
-                        { parser->in_my = 0; (yyval.opval) = NULL; }
+                        { parser->in_my = 0; (yyval.ival) = 0; }
 
     break;
 
-  case 120: /* sigvarname: PRIVATEREF  */
+  case 120: /* sigvar: PRIVATEREF  */
 #line 828 "perly.y"
-                        { parser->in_my = 0; (yyval.opval) = (ps[0].val.opval); }
+                        { parser->in_my = 0; (yyval.ival) = (ps[0].val.opval)->op_targ; op_free((ps[0].val.opval)); }
 
     break;
 
@@ -957,16 +957,16 @@ case 2: /* @1: %empty  */
 
     break;
 
-  case 123: /* sigslurpelem: sigslurpsigil sigvarname  */
+  case 123: /* sigslurpelem: sigslurpsigil sigvar  */
 #line 839 "perly.y"
                         {
-                            subsignature_append_slurpy((ps[-1].val.ival), (ps[0].val.opval));
+                            subsignature_append_slurpy((ps[-1].val.ival), (ps[0].val.ival));
                             (yyval.opval) = NULL;
                         }
 
     break;
 
-  case 124: /* sigslurpelem: sigslurpsigil sigvarname ASSIGNOP  */
+  case 124: /* sigslurpelem: sigslurpsigil sigvar ASSIGNOP  */
 #line 844 "perly.y"
                         {
 			    yyerror("A slurpy parameter may not have a default value");
@@ -974,7 +974,7 @@ case 2: /* @1: %empty  */
 
     break;
 
-  case 125: /* sigslurpelem: sigslurpsigil sigvarname ASSIGNOP term  */
+  case 125: /* sigslurpelem: sigslurpsigil sigvar ASSIGNOP term  */
 #line 848 "perly.y"
                         {
 			    yyerror("A slurpy parameter may not have a default value");
@@ -982,28 +982,28 @@ case 2: /* @1: %empty  */
 
     break;
 
-  case 126: /* sigscalarelem: PERLY_DOLLAR sigvarname  */
+  case 126: /* sigscalarelem: PERLY_DOLLAR sigvar  */
 #line 856 "perly.y"
                         {
-                            subsignature_append_positional((ps[0].val.opval), 0, NULL);
+                            subsignature_append_positional((ps[0].val.ival), 0, NULL);
                             (yyval.opval) = NULL;
                         }
 
     break;
 
-  case 127: /* sigscalarelem: PERLY_DOLLAR sigvarname ASSIGNOP  */
+  case 127: /* sigscalarelem: PERLY_DOLLAR sigvar ASSIGNOP  */
 #line 861 "perly.y"
                         {
-                            subsignature_append_positional((ps[-1].val.opval), (ps[0].val.ival), newOP(OP_NULL, 0));
+                            subsignature_append_positional((ps[-1].val.ival), (ps[0].val.ival), newOP(OP_NULL, 0));
                             (yyval.opval) = NULL;
                         }
 
     break;
 
-  case 128: /* sigscalarelem: PERLY_DOLLAR sigvarname ASSIGNOP term  */
+  case 128: /* sigscalarelem: PERLY_DOLLAR sigvar ASSIGNOP term  */
 #line 866 "perly.y"
                         {
-                            subsignature_append_positional((ps[-2].val.opval), (ps[-1].val.ival), (ps[0].val.opval));
+                            subsignature_append_positional((ps[-2].val.ival), (ps[-1].val.ival), (ps[0].val.opval));
                             (yyval.opval) = NULL;
                         }
 
@@ -2303,6 +2303,6 @@ case 2: /* @1: %empty  */
     
 
 /* Generated from:
- * c0af31db816b03f7b0aa8c3f33f53d00fc1eb497776acea4416cd6d4f45c0f8c perly.y
+ * a66533df84b2ea4db3ab085ffee3685d0e63a6946a65e9ce91b2621b7bd4e01e perly.y
  * f13e9c08cea6302f0c1d1f467405bd0e0880d0ea92d0669901017a7f7e94ab28 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.h
+++ b/perly.h
@@ -246,6 +246,6 @@ int yyparse (void);
 
 
 /* Generated from:
- * c0af31db816b03f7b0aa8c3f33f53d00fc1eb497776acea4416cd6d4f45c0f8c perly.y
+ * a66533df84b2ea4db3ab085ffee3685d0e63a6946a65e9ce91b2621b7bd4e01e perly.y
  * f13e9c08cea6302f0c1d1f467405bd0e0880d0ea92d0669901017a7f7e94ab28 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.tab
+++ b/perly.tab
@@ -197,7 +197,7 @@ enum yysymbol_kind_t
   YYSYMBOL_proto = 186,                    /* proto  */
   YYSYMBOL_subattrlist = 187,              /* subattrlist  */
   YYSYMBOL_myattrlist = 188,               /* myattrlist  */
-  YYSYMBOL_sigvarname = 189,               /* sigvarname  */
+  YYSYMBOL_sigvar = 189,                   /* sigvar  */
   YYSYMBOL_sigslurpsigil = 190,            /* sigslurpsigil  */
   YYSYMBOL_sigslurpelem = 191,             /* sigslurpelem  */
   YYSYMBOL_sigscalarelem = 192,            /* sigscalarelem  */
@@ -418,7 +418,7 @@ static const char *const yytname[] =
   "formline", "formarg", "condition", "sideff", "else", "cont", "finally",
   "mintro", "nexpr", "texpr", "iexpr", "mexpr", "mnexpr", "formname",
   "startsub", "startanonsub", "startanonmethod", "startformsub", "subname",
-  "proto", "subattrlist", "myattrlist", "sigvarname", "sigslurpsigil",
+  "proto", "subattrlist", "myattrlist", "sigvar", "sigslurpsigil",
   "sigslurpelem", "sigscalarelem", "sigelem", "siglist", "optsiglist",
   "optsubsignature", "subsignature", "subsigguts", "$@20", "optsubbody",
   "subbody", "optsigsubbody", "sigsubbody", "$@21", "expr", "listexpr",
@@ -1590,7 +1590,7 @@ static const toketypes yy_type_tab[] =
   toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
   toketype_ival, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_opval,
-  toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_ival,
+  toketype_opval, toketype_opval, toketype_opval, toketype_ival, toketype_ival,
   toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
   toketype_opval, toketype_opval, toketype_opval, toketype_ival, toketype_opval,
   toketype_opval, toketype_opval, toketype_opval, toketype_ival, toketype_opval, toketype_opval,
@@ -1604,6 +1604,6 @@ static const toketypes yy_type_tab[] =
 };
 
 /* Generated from:
- * c0af31db816b03f7b0aa8c3f33f53d00fc1eb497776acea4416cd6d4f45c0f8c perly.y
+ * a66533df84b2ea4db3ab085ffee3685d0e63a6946a65e9ce91b2621b7bd4e01e perly.y
  * f13e9c08cea6302f0c1d1f467405bd0e0880d0ea92d0669901017a7f7e94ab28 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.y
+++ b/perly.y
@@ -114,8 +114,8 @@
 %type <opval> optfieldattrlist fielddecl
 %type <opval> termbinop termunop anonymous termdo
 %type <opval> termrelop relopchain termeqop eqopchain
-%type <ival>  sigslurpsigil
-%type <opval> sigvarname sigscalarelem sigslurpelem
+%type <ival>  sigslurpsigil sigvar
+%type <opval> sigscalarelem sigslurpelem
 %type <opval> sigelem siglist optsiglist subsigguts subsignature optsubsignature
 %type <opval> subbody optsubbody sigsubbody optsigsubbody
 %type <opval> formstmtseq formline formarg
@@ -822,10 +822,10 @@ myattrlist:	COLONATTR THING
  */
 
 /* the '' or 'foo' part of a '$' or '@foo' etc signature variable  */
-sigvarname:     %empty
-			{ parser->in_my = 0; $$ = NULL; }
+sigvar:     %empty
+			{ parser->in_my = 0; $$ = 0; }
         |       PRIVATEREF
-                        { parser->in_my = 0; $$ = $PRIVATEREF; }
+                        { parser->in_my = 0; $$ = $PRIVATEREF->op_targ; op_free($PRIVATEREF); }
 	;
 
 sigslurpsigil:
@@ -835,16 +835,16 @@ sigslurpsigil:
                         { $$ = '%'; }
 
 /* @, %, @foo, %foo */
-sigslurpelem: sigslurpsigil sigvarname
+sigslurpelem: sigslurpsigil sigvar
                         {
-                            subsignature_append_slurpy($sigslurpsigil, $sigvarname);
+                            subsignature_append_slurpy($sigslurpsigil, $sigvar);
                             $$ = NULL;
                         }
-        |     sigslurpsigil sigvarname ASSIGNOP
+        |     sigslurpsigil sigvar ASSIGNOP
                         {
 			    yyerror("A slurpy parameter may not have a default value");
                         }
-        |     sigslurpsigil sigvarname ASSIGNOP term
+        |     sigslurpsigil sigvar ASSIGNOP term
                         {
 			    yyerror("A slurpy parameter may not have a default value");
                         }
@@ -852,19 +852,19 @@ sigslurpelem: sigslurpsigil sigvarname
 
 /* subroutine signature scalar element: e.g. '$x', '$=', '$x = $default' */
 sigscalarelem:
-                PERLY_DOLLAR sigvarname
+                PERLY_DOLLAR sigvar
                         {
-                            subsignature_append_positional($sigvarname, 0, NULL);
+                            subsignature_append_positional($sigvar, 0, NULL);
                             $$ = NULL;
                         }
-        |       PERLY_DOLLAR sigvarname ASSIGNOP
+        |       PERLY_DOLLAR sigvar ASSIGNOP
                         {
-                            subsignature_append_positional($sigvarname, $ASSIGNOP, newOP(OP_NULL, 0));
+                            subsignature_append_positional($sigvar, $ASSIGNOP, newOP(OP_NULL, 0));
                             $$ = NULL;
                         }
-        |       PERLY_DOLLAR sigvarname ASSIGNOP term[defop]
+        |       PERLY_DOLLAR sigvar ASSIGNOP term[defop]
                         {
-                            subsignature_append_positional($sigvarname, $ASSIGNOP, $defop);
+                            subsignature_append_positional($sigvar, $ASSIGNOP, $defop);
                             $$ = NULL;
                         }
         ;

--- a/proto.h
+++ b/proto.h
@@ -4446,12 +4446,12 @@ Perl_sub_crush_depth(pTHX_ CV *cv)
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
-Perl_subsignature_append_positional(pTHX_ OP *varop, OPCODE defmode, OP *defexpr)
+Perl_subsignature_append_positional(pTHX_ PADOFFSET padix, OPCODE defmode, OP *defexpr)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_POSITIONAL
 
 PERL_CALLCONV void
-Perl_subsignature_append_slurpy(pTHX_ I32 sigil, OP *varop)
+Perl_subsignature_append_slurpy(pTHX_ I32 sigil, PADOFFSET padix)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_SLURPY
 

--- a/toke.c
+++ b/toke.c
@@ -9997,25 +9997,7 @@ S_pending_ident(pTHX)
                 GCC_DIAG_RESTORE_STMT;
             }
 
-            if (PL_in_my == KEY_sigvar) {
-                /* A signature 'padop' needs in addition, an op_first to
-                 * point to a child sigdefelem, and an extra field to hold
-                 * the signature index. We can achieve both by using an
-                 * UNOP_AUX and (ab)using the op_aux field to hold the
-                 * index. If we ever need more fields, use a real malloced
-                 * aux strut instead.
-                 */
-                assert(PL_parser->signature);
-                /* We don't yet know the argindex but subsignature_append_*()
-                 * will fill it in
-                 */
-                o = newUNOP_AUX(OP_ARGELEM, 0, NULL, NULL);
-                o->op_private |= (  PL_tokenbuf[0] == '$' ? OPpARGELEM_SV
-                                  : PL_tokenbuf[0] == '@' ? OPpARGELEM_AV
-                                  :                         OPpARGELEM_HV);
-            }
-            else
-                o = newOP(OP_PADANY, 0);
+            o = newOP(OP_PADANY, 0);
             o->op_targ = allocmy(PL_tokenbuf, tokenbuf_len,
                                                         UTF ? SVf_UTF8 : 0);
             if (PL_in_my == KEY_sigvar)


### PR DESCRIPTION
Building on top of ec78f9b1c1, this sequence of commits further removes special-case code in `class.c` by getting the subsignature API to build the signature ops for generated accessor methods, rather than performing custom work itself.

Part of this change also involves simplifying the API for `subsignature_append_positional()` and `subsignature_append_slurpy()`, which also simplifies code in `toke.c` as a side benefit.

All of these changes are in support of better signature generation code that ultimately helps with the `faster-signatures` branch and named parameter support.