### PR TITLE
Move fixed tests from t/run/todo to final .t files

### DIFF
--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -28,7 +28,7 @@ skip_all_without_unicode_tables();
 my $has_locales = locales_enabled('LC_CTYPE');
 my $utf8_locale = find_utf8_ctype_locale();
 
-plan tests => 1295;  # Update this when adding/deleting tests.
+plan tests => 1296;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -2643,6 +2643,12 @@ local $SIG{__WARN__} = sub { die; };
 eval "qr/()x{/;" for 1..10;
 PROG
     }
+
+    {   # GH 16894 Fixed by acababb42be12ff2986b73c1bfa963b70bb5d54e
+        "abab" =~ /(?:[^b]*(?=(b)|(a))ab)*/;
+        is($1, undef, "GH #16894");
+    }
+
 } # End of sub run_tests
 
 1;

--- a/t/re/pat_advanced.t
+++ b/t/re/pat_advanced.t
@@ -2713,6 +2713,16 @@ EOF_DEBUG_OUT
         $x =~ s/^[\x{0301}\x{030C}]+//;
     }
 
+    {   # GH 16627
+        fresh_perl('use re "eval";
+                    my @r;
+                    for $0 (qw(0 0)) {
+                        push @r, qr/@r(?{})/;
+                    }',
+                   { stderr => 'devnull' });
+        is($?, 0, "No segfault; [GH 16627]");
+    }
+
 
     # !!! NOTE that tests that aren't at all likely to crash perl should go
     # a ways above, above these last ones.  There's a comment there that, like

--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -92,12 +92,6 @@ my $switches = "";
 
 my $is_debugging_build = $Config{cppflags} =~ /-DDEBUGGING/;
 
-
-{   # Fixed by acababb42be12ff2986b73c1bfa963b70bb5d54e
-    "abab" =~ /(?:[^b]*(?=(b)|(a))ab)*/;
-    is($1, undef, "GH #16894");
-}
-
 our $TODO;
 
 TODO: {

--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -181,12 +181,4 @@ TODO: {
 
 }
 
-{
-    fresh_perl('use re "eval";
-                my @r;
-                for$0(qw(0 0)){push@r,qr/@r(?{})/};',
-               { stderr => 'devnull' });
-    is($?, 0, "No assertion failure");
-}
-
 done_testing();


### PR DESCRIPTION
Partially fixes #23566

 This set of changes does not require a perldelta entry.
