### PR TITLE
regcomp.c: get_fq_name(): simplify current package name formatting

### DIFF
--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -3290,11 +3290,13 @@ messages where the string is assumed to be a class name.
 
 =for apidoc Amnh||HvNAMEf
 =for apidoc Amnh||HvNAMEf_QUOTEDPREFIX
+=for apidoc Amh||HvNAMEfARG|HV *hv
 
 C<HvNAMEf> and C<HvNAMEf_QUOTEDPREFIX> are similar to C<SVf> except they
-extract the string, length and utf8 flags from the argument using the
-C<HvNAME()>, C<HvNAMELEN()>, C<HvNAMEUTF8()> macros. This is intended
-for stringifying a class name directly from an stash HV.
+extract the string, length and utf8 flags from the argument given to
+C<HvNAMEfARG()> using the C<HvNAME()>, C<HvNAMELEN()>, C<HvNAMEUTF8()>
+macros. This is intended for stringifying a class name directly from an
+stash HV.
 
 =head2 Formatted Printing of Strings
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -14567,11 +14567,8 @@ S_get_fq_name(pTHX_
         const HV * pkg = (IN_PERL_COMPILETIME)
                          ? PL_curstash
                          : CopSTASH(PL_curcop);
-        const char* pkgname = HvNAME(pkg);
 
-        sv_catpvf(fq_name, "%" UTF8f,
-                      UTF8fARG(is_utf8, strlen(pkgname), pkgname));
-        sv_catpvs(fq_name, "::");
+        sv_catpvf(fq_name, "%" HvNAMEf "::", HvNAMEfARG(pkg));
     }
 
     sv_catpvf(fq_name, "%" UTF8f,


### PR DESCRIPTION
Use `HvNAMEf` (which didn't exist when this code was written) to
simplify the prepending of the current package to the given name.

In passing, document `HvNAMEfARG`.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
