### PR TITLE
perlunicode: Note user-defined property names must be ASCII

### DIFF
--- a/pod/perlunicode.pod
+++ b/pod/perlunicode.pod
@@ -1162,7 +1162,8 @@ You can define your own binary character properties by defining subroutines
 whose names begin with C<"In"> or C<"Is">.  (The regex sets feature
 L<perlre/(?[ ])> provides an alternative which allows more complex
 definitions.)  The subroutines can be defined in any
-package.  They override any Unicode properties expressed as the same
+package.  Like all official Unicode properties, their names must be
+ASCII only, and override any Unicode properties using the same
 names.  The user-defined properties can be used in the regular
 expression
 C<\p{}> and C<\P{}> constructs; if you are using a user-defined property from a


### PR DESCRIPTION

* This set of changes does not require a perldelta entry.
