### PR TITLE
Convert Perl utf16 to utf8 functions to macros

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3880,7 +3880,7 @@ Adip	|bool	|utf8_to_bytes_overwrite				\
 Adip	|bool	|utf8_to_bytes_temp_pv					\
 				|NN U8 const **s_ptr			\
 				|NN STRLEN *lenp
-EMXp	|U8 *	|utf16_to_utf8	|NN U8 *p				\
+Emp	|U8 *	|utf16_to_utf8	|NN U8 *p				\
 				|NN U8 *d				\
 				|Size_t bytelen 			\
 				|NN Size_t *newlen
@@ -3898,7 +3898,7 @@ EXpx	|U8 *	|utf8_to_utf16_base					\
 				|NN Size_t *newlen			\
 				|const bool high			\
 				|const bool low
-EMXp	|U8 *	|utf16_to_utf8_reversed 				\
+Emp	|U8 *	|utf16_to_utf8_reversed 				\
 				|NN U8 *p				\
 				|NN U8 *d				\
 				|Size_t bytelen 			\

--- a/embed.h
+++ b/embed.h
@@ -285,6 +285,8 @@
 #     undef invlist_intersection_
 #     undef invlist_subtract_
 #     undef invlist_union_
+#     undef utf16_to_utf8
+#     undef utf16_to_utf8_reversed
 #   endif
 # endif /* !defined(PERL_CORE) */
 #else /* if !defined(PERL_DO_UNDEFS) */
@@ -2615,6 +2617,10 @@
 #   define Perl_whichsig(mTHX,a)                whichsig(a)
 #   define thread_locale_init()                 Perl_thread_locale_init(aTHX)
 #   define thread_locale_term()                 Perl_thread_locale_term(aTHX)
+#   if defined(PERL_CORE) || defined(PERL_EXT)
+#     define Perl_utf16_to_utf8(mTHX,a,b,c,d)   utf16_to_utf8(a,b,c,d)
+#     define Perl_utf16_to_utf8_reversed(mTHX,a,b,c,d) utf16_to_utf8_reversed(a,b,c,d)
+#   endif
 #   if defined(PERL_DONT_CREATE_GVSV)
 #     define Perl_gv_SVadd(mTHX,a)              gv_SVadd(a)
 #   endif
@@ -2713,6 +2719,10 @@
 #   define Perl_uvchr_to_utf8_flags_msgs        uvchr_to_utf8_flags_msgs
 #   define Perl_uvoffuni_to_utf8_flags          uvoffuni_to_utf8_flags
 #   define Perl_whichsig                        whichsig
+#   if defined(PERL_CORE) || defined(PERL_EXT)
+#     define Perl_utf16_to_utf8                 utf16_to_utf8
+#     define Perl_utf16_to_utf8_reversed        utf16_to_utf8_reversed
+#   endif
 #   if defined(PERL_DONT_CREATE_GVSV)
 #     define Perl_gv_SVadd                      gv_SVadd
 #   endif

--- a/proto.h
+++ b/proto.h
@@ -5344,13 +5344,7 @@ Perl_upg_version(pTHX_ SV *ver, bool qv);
 #define PERL_ARGS_ASSERT_UPG_VERSION            \
         assert(ver)
 
-#define PERL_ARGS_ASSERT_UTF16_TO_UTF8          \
-        assert(p); assert(d); assert(newlen)
-
 #define PERL_ARGS_ASSERT_UTF16_TO_UTF8_BASE     \
-        assert(p); assert(d); assert(newlen)
-
-#define PERL_ARGS_ASSERT_UTF16_TO_UTF8_REVERSED \
         assert(p); assert(d); assert(newlen)
 
 /* PERL_CALLCONV U8 *
@@ -6129,12 +6123,12 @@ Perl_skipspace_flags(pTHX_ char *s, U32 flags)
         __attribute__warn_unused_result__;
 PERL_CALLCONV MAGIC *
 Perl_sv_magicext_mglob(pTHX_ SV *sv);
-PERL_CALLCONV U8 *
-Perl_utf16_to_utf8(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen);
+/* PERL_CALLCONV U8 *
+Perl_utf16_to_utf8(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen); */
 PERL_CALLCONV U8 *
 Perl_utf16_to_utf8_base(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low);
-PERL_CALLCONV U8 *
-Perl_utf16_to_utf8_reversed(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen);
+/* PERL_CALLCONV U8 *
+Perl_utf16_to_utf8_reversed(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen); */
 PERL_CALLCONV U8 *
 Perl_utf8_to_utf16_base(pTHX_ U8 *s, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low);
 PERL_CALLCONV bool

--- a/utf8.c
+++ b/utf8.c
@@ -3449,22 +3449,6 @@ Perl_utf16_to_utf8_base(pTHX_ U8* p, U8* d, Size_t bytelen, Size_t *newlen,
     return d;
 }
 
-U8*
-Perl_utf16_to_utf8(pTHX_ U8* p, U8* d, Size_t bytelen, Size_t *newlen)
-{
-    PERL_ARGS_ASSERT_UTF16_TO_UTF8;
-
-    return utf16_to_utf8(p, d, bytelen, newlen);
-}
-
-U8*
-Perl_utf16_to_utf8_reversed(pTHX_ U8* p, U8* d, Size_t bytelen, Size_t *newlen)
-{
-    PERL_ARGS_ASSERT_UTF16_TO_UTF8_REVERSED;
-
-    return utf16_to_utf8_reversed(p, d, bytelen, newlen);
-}
-
 /*
  * Convert UTF-8 to native UTF-16. Called via the macros utf8_to_utf16() for
  * big-endian and utf8_to_utf16_reversed() for little-endian,


### PR DESCRIPTION
These functions are hereby removed in favor of calling the plain macros that already exist


* This set of changes does not require a perldelta entry.
