### PR TITLE
Rename _isQUOTEMETA to isQUOTEMETA_

### DIFF
--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -6723,7 +6723,7 @@ test_UTF8_IS_REPLACEMENT(char *s, STRLEN len)
 bool
 test_isQUOTEMETA(UV ord)
     CODE:
-        RETVAL = _isQUOTEMETA(ord);
+        RETVAL = isQUOTEMETA(ord);
     OUTPUT:
         RETVAL
 

--- a/handy.h
+++ b/handy.h
@@ -1691,7 +1691,9 @@ END_EXTERN_C
       (   (! cBOOL(FITS_IN_8_BITS(c)))                                      \
        || (PL_charclass[(U8) (c)] & CC_mask_(CC_NONLATIN1_FOLD_)))
 
-#   define _isQUOTEMETA(c) generic_isCC_(c, CC_QUOTEMETA_)
+#  if defined(PERL_CORE) || defined(PERL_IN_XS_APITEST)
+#    define isQUOTEMETA(c) generic_isCC_(c, CC_QUOTEMETA_)
+#  endif
 
 /* is c a control character for which we have a mnemonic? */
 #  if defined(PERL_CORE) || defined(PERL_EXT)
@@ -1822,7 +1824,9 @@ END_EXTERN_C
     /* The following are not fully accurate in the above-ASCII range.  I (khw)
      * don't think it's necessary to be so for the purposes where this gets
      * compiled */
-#   define isQUOTEMETA_(c)      (FITS_IN_8_BITS(c) && ! isWORDCHAR_L1(c))
+#   if defined(PERL_CORE) || defined(PERL_IN_XS_APITEST)
+#     define isQUOTEMETA(c)      (FITS_IN_8_BITS(c) && ! isWORDCHAR_L1(c))
+#   endif
 
     /* Many of the macros later in this file are defined in terms of these.  By
      * implementing them with a function, which converts the class number into

--- a/pp.c
+++ b/pp.c
@@ -5073,7 +5073,7 @@ PP(pp_quotemeta)
                 bool to_quote = FALSE;
 
                 if (UTF8_IS_INVARIANT(*s)) {
-                    if (_isQUOTEMETA(*s)) {
+                    if (isQUOTEMETA(*s)) {
                         to_quote = TRUE;
                     }
                 }
@@ -5086,7 +5086,7 @@ PP(pp_quotemeta)
                     IN_LC_RUNTIME(LC_CTYPE)
                         ||
 #endif
-                        _isQUOTEMETA(EIGHT_BIT_UTF8_TO_NATIVE(*s, *(s + 1))))
+                        isQUOTEMETA(EIGHT_BIT_UTF8_TO_NATIVE(*s, *(s + 1))))
                     {
                         to_quote = TRUE;
                     }
@@ -5108,7 +5108,7 @@ PP(pp_quotemeta)
         }
         else if (IN_UNI_8_BIT) {
             while (len--) {
-                if (_isQUOTEMETA(*s))
+                if (isQUOTEMETA(*s))
                     *d++ = '\\';
                 *d++ = *s++;
             }


### PR DESCRIPTION
The former is undefined behavior in C in some situations.


* This set of changes does not require a perldelta entry.
