### PR TITLE
Revert "Perl_op_convert_list - only short circuit [some]CONST OPs

### DIFF
--- a/op.c
+++ b/op.c
@@ -5582,7 +5582,7 @@ Perl_op_convert_list(pTHX_ I32 type, I32 flags, OP *o)
             flags |= OPf_SPECIAL;
     }
     if (type == OP_STRINGIFY && OP_TYPE_IS(o, OP_CONST) &&
-        !(flags & OPf_FOLDED) && SvIsCOW(cSVOPx_sv(o)) ){
+        !(flags & OPf_FOLDED) ) {
         assert(!OpSIBLING(o));
         /* Don't wrap a single CONST in a list, process that list,
          * then constant fold the list back to the starting OP.


### PR DESCRIPTION
This reverts commit 80d3e79d3833d7ebe9723958157b6fd354612a94.

That commit was always intended as a stopgap to be replaced by b1f270f0cbf67fc18c949626d91f0f1856747fe5.

The history behind this was as follows:
* GH#22116 - a902d92 - short-circuited constant folding on CONST OPs, as this should be unnecessary. However, Dave Mitchell noticed that it had the inadvertent effect of disabling COW on SVs holding UTF8 string literals (e.g. `"\x{100}abcd"`).
* b1f270f0cbf67fc18c949626d91f0f1856747fe5 always seemed like the best fix, but given the apparent proximity to the 5.42 release date that commit seemed to be too big a change.
* GH#23296 brought in the now-reverted commit as a stop gap that retained some of the older, now-unnecessary behaviour.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
