### PR TITLE
regexec.c: Use utf8_to_uv_or_die over utf8n_to_uvchr

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -2084,8 +2084,7 @@ STMT_START {                                                                \
     }                                                                       \
     else { /* Back-up to the start of the previous character */             \
         U8 * const r = reghop3((U8*)s, -1, (U8*)reginfo->strbeg);           \
-        tmp = utf8n_to_uvchr(r, (U8*) reginfo->strend - r,                  \
-                         0, UTF8_ALLOW_DEFAULT);                            \
+        tmp = utf8_to_uv_or_die(r, (U8*) reginfo->strend, 0);           \
     }                                                                       \
     tmp = TEST_UV(tmp);                                                     \
     REXEC_FBC_UTF8_SCAN(/* advances s while s < strend */                   \


### PR DESCRIPTION
This will now die if the input is malformed.  We decided for 5.42 that it is pointless to continue on in pattern matching in the face of malformed input.  This was the final occurrence of a to_uvchr() function in this file; the rest were converted for 5.42.  This was deferred because of the lateness of the development cycle, and it didn't fix an obvious bug


* This set of changes does not require a perldelta entry.
