### PR TITLE
Add limits to the size of the string repetition multiplier

### DIFF
--- a/op.c
+++ b/op.c
@@ -169,6 +169,9 @@ recursive, but it's recursive on basic blocks, not on tree nodes.
 #define CALL_PEEP(o) PL_peepp(aTHX_ o)
 #define CALL_OPFREEHOOK(o) if (PL_opfreehook) PL_opfreehook(aTHX_ o)
 
+#ifndef PERL_FOLD_REPEAT_LIMIT
+#define PERL_FOLD_REPEAT_LIMIT (1024 * 1024)
+#endif
 static const char array_passed_to_stat[] = "Array passed to stat will be coerced to a scalar";
 
 /* remove any leading "empty" ops from the op_next chain whose first
@@ -5057,6 +5060,30 @@ S_fold_constants(pTHX_ OP *const o)
         break;
     case OP_REPEAT:
         if (o->op_private & OPpREPEAT_DOLIST) goto nope;
+
+        /* Don't constant fold above a certain threshold.
+         * (GH#13793 & GH#20586)
+         *
+         * Implementation note: pp_pow returns powers of 2 as an NV
+         *     e.g. my $x = "A" x (2**3);
+         */
+        if (OP_TYPE_IS(cBINOPo->op_last, OP_CONST)) {
+            SV *constsv = cSVOPx_sv(cBINOPo->op_last);
+
+            if (SvIOK(constsv)) {
+                if (SvIOK_UV(constsv)) {
+                    if (SvUVX(constsv) > (UV)PERL_FOLD_REPEAT_LIMIT)
+                        goto nope;
+                } else {
+                    if (SvIVX(constsv) > (IV)PERL_FOLD_REPEAT_LIMIT)
+                        goto nope;
+                }
+            } else {
+                NV rhs = 0.0; rhs = SvNV_nomg(constsv);
+                if (rhs > (NV)PERL_FOLD_REPEAT_LIMIT)
+                    goto nope;
+            }
+        }
         break;
     case OP_SREFGEN:
         if (cUNOPx(cUNOPo->op_first)->op_first->op_type != OP_CONST

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -501,6 +501,13 @@ This change shouldn't affect any C<XS> module code that is using the test
 macros correctly, though might cause confusion to code that attempts to analyse
 C<SvFLAGS> bits directly outside of the helper macros.
 
+=item *
+
+An upper limit has been applied to the multiplier operand of the
+repetition operator. Constant folding will not be attempted if the
+operand is a numerical constant above C<PERL_FOLD_REPEAT_LIMIT>.
+See [GH #20586] and [GH #23561] for background.
+
 =back
 
 =head1 Selected Bug Fixes

--- a/t/perf/opcount.t
+++ b/t/perf/opcount.t
@@ -1332,4 +1332,11 @@ test_opcount(0, "basic any/all",
                 }
             );
 
+# GH #13793, GH #20586
+test_opcount(0, "Don't fold string repetition above a multiplier threshold",
+                sub { my $x = "A" x (2**22) },
+                {
+                    repeat      => 1,
+                });
+
 done_testing();


### PR DESCRIPTION
Historically, given a statement like `my $x = "A" x SOMECONSTANT;`, no examination of the size of the multiplier (`SOMECONSTANT` in this example) was done at compile time. Depending upon the constant folding behaviour, this might mean:
* The buffer allocation needed at runtime could be clearly bigger than the system can support, but Perl would happily compile the statement and let the author find this out at runtime.
* Constants resulting from folding could be very large and the memory taken up undesirable, especially in cases where the constant resides in cold code.

This commit adds some compile time checking such that:
* A string size beyond or close to the likely limit of support triggers a fatal error.
* Strings above a certain static size do not get constant folded.

Things could obviously still go bad at runtime when the multiplier isn't a simple
constant, but that's not for this PR.

Closes #13324, closes #13793, closes #20586.

Besides general correctness checking, the arbitrary cut-off numbers are up for discussion, and please could reviewers suggest any improvements to the_perldiag.pod_ that come to mind.

-------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and I will write one post-bikeshedding.