### PR TITLE
Filter-Simple:  Correct ambiguous assignment to INSTALLDIRS

### DIFF
--- a/dist/Filter-Simple/Changes
+++ b/dist/Filter-Simple/Changes
@@ -52,12 +52,12 @@ Revision history for Perl extension Filter::Simple
 
 	- Added automatic preservation of existing &import subroutines
 
-	- Added automatic preservation of Exporter semantics 
+	- Added automatic preservation of Exporter semantics
 
 
 0.76	Fri Nov 16 15:08:42 2001
 
-	- Modified call to explicit &import so as to be invoked in original 
+	- Modified call to explicit &import so as to be invoked in original
 	  call context
 
 
@@ -90,7 +90,7 @@ Revision history for Perl extension Filter::Simple
     - Added Sarathy's patch for \r\n newlinery (thanks Jarkko)
 
     - Added recognition of comments as whitespace (thanks Jeff)
-    
+
     - Added @components variable (thanks Dean)
 
     - Fixed handling of vars in FILTER_ONLY code=>... (thanks Lasse)
@@ -99,16 +99,16 @@ Revision history for Perl extension Filter::Simple
 
     - Added INSTALLDIRS=>core to Makefile.PL
 
-    
+
 0.82    Mon Jun 27 02:31:06 GMT 2005
-    
+
     - Fixed INSTALLDIRS=>perl in Makefile.PL (thanks all)
 
     - Fixed other problems caused by de-schwernification
 
 
 0.83    Sat Oct 18 18:51:51 CET 2008
-    
+
     - Updated contact details: Maintained by the Perl5-Porters.
     - Some tiny distribution fixes.
 
@@ -155,4 +155,14 @@ Revision history for Perl extension Filter::Simple
         no MyFilter;
       In this case it should simply not filter anything.
 
+0.95    Nov 11 2017
 
+    - Modernize syntax: 'use vars' -> 'our'
+
+0.96    Nov 25 2019
+
+    -  Fix for GH #17122 and sanity check for executable_no_comments
+
+0.97    Mon Aug 11 05:35:34 PM EDT 2025
+
+    - Correct ambiguous double assignment to INSTALLDIRS in Makefile.PL

--- a/dist/Filter-Simple/Makefile.PL
+++ b/dist/Filter-Simple/Makefile.PL
@@ -4,7 +4,6 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
     'NAME'          => 'Filter::Simple',
     'VERSION_FROM'  => 'lib/Filter/Simple.pm',
-    'INSTALLDIRS'   => 'perl',
     'LICENSE'       => 'perl_5',
     'INSTALLDIRS'   => ( $] < 5.011 ? 'perl' : 'site' ),
     'ABSTRACT_FROM' => 'lib/Filter/Simple.pm',

--- a/dist/Filter-Simple/lib/Filter/Simple.pm
+++ b/dist/Filter-Simple/lib/Filter/Simple.pm
@@ -2,7 +2,7 @@ package Filter::Simple;
 
 use Text::Balanced ':ALL';
 
-our $VERSION = '0.96';
+our $VERSION = '0.97';
 
 use Filter::Util::Call;
 use Carp;


### PR DESCRIPTION
Consider this excerpt from `dist/Filter-Simple/Makefile.PL`:
```
  1 require 5.006; # uses 'our'
  2 use strict;
  3 use ExtUtils::MakeMaker;
  4 WriteMakefile(
  5     'NAME'          => 'Filter::Simple',
  6     'VERSION_FROM'  => 'lib/Filter/Simple.pm',
  7     'INSTALLDIRS'   => 'perl',
  8     'LICENSE'       => 'perl_5',
  9     'INSTALLDIRS'   => ( $] < 5.011 ? 'perl' : 'site' ),
...
```
Note that `INSTALLDIRS` gets assigned to twice, once at line 7 and once at line 9.  This is potentially confusing to any future maintainer of this library or anyone who does a CPAN release.

Please review this pull request.

**And speaking of CPAN releases ...**

In blead, Filter-Simple is at version 0.96.  Up on CPAN, it's still at version 0.94 and hasn't had a CPAN release since August 2017.
