### PR TITLE
pp_schop: suppress Coverity defect report

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -901,7 +901,7 @@ PP(pp_schop)
 
     const size_t count = do_chomp(TARG, *PL_stack_sp, chomping);
     if (chomping)
-        sv_setiv(TARG, count);
+        sv_setiv(TARG, (IV)count);
     SvSETMAGIC(TARG);
     rpp_replace_1_1_NN(TARG);
     return NORMAL;


### PR DESCRIPTION
This also fixes a similar warning with -Wconversion.

Fixes CID584015


-------------------------------------------------------------------------------
<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
