### PR TITLE
todo tests for GH 16364 (array element lazily created at wrong index)

### DIFF
--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -138,6 +138,38 @@ TODO: {
 }
 
 TODO: {
+    local $::TODO = 'GH 16364';
+
+    my @arr;
+    my sub foo {
+        unshift @arr, 7;
+        $_[0] = 3;
+    }
+
+    @arr = ();
+    $arr[1] = 1;
+    foo($arr[0]);
+    is($arr[1], 3,
+       'Array element within array range created at correct index from subroutine @_ alias; GH 16364');
+
+    @arr = ();
+    $arr[1] = 1;
+    foo($arr[5]);
+    is($arr[6], 3,
+       'Array element outside array range created at correct index from subroutine @_ alias; GH 16364');
+
+    @arr = ();
+    $arr[1] = 1;
+    foreach (@arr) {
+        unshift @arr, 7;
+        $_ = 3;
+        last;
+    }
+    is($arr[1], 3, 'Array element created at correct index from foreach $_ alias; GH 16364');
+
+}
+
+TODO: {
     local $::TODO = 'GH 16865';
     fresh_perl('\(sort { 0 } 0, 0 .. "a")', { stderr => 'devnull' });
     is($?, 0, "No assertion failure");


### PR DESCRIPTION
This PR adds some todo tests for #16364 that test the following behavior:
* An array element that was previously uninitialized is created at the correct index when assigned from a subroutine's @_ alias which modifies the element's original array. The element is within the array.
* The same as the above but the element is outside of the array's range.
* An array element that was previously uninitialized is created at the correct index when assigned from a foreach loop's $_ alias which modifies the element's original array.

The first test seems to pass, the other two do not.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
