### PR TITLE
Request SvPV_helper to be always inline

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3358,7 +3358,7 @@ CRdmp	|char * |sv_2pvbyte_nolen					\
 Adp	|char * |sv_2pv_flags	|NN SV * const sv			\
 				|NULLOK STRLEN * const lp		\
 				|const U32 flags
-Cip	|char * |SvPV_helper	|NN SV * const sv				\
+CIp	|char * |SvPV_helper	|NN SV * const sv				\
 				|NN STRLEN * const lp				\
 				|const U32 flags				\
 				|const PL_SvPVtype type 			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -3358,6 +3358,13 @@ CRdmp	|char * |sv_2pvbyte_nolen					\
 Adp	|char * |sv_2pv_flags	|NN SV * const sv			\
 				|NULLOK STRLEN * const lp		\
 				|const U32 flags
+Cip	|char * |SvPV_helper	|NN SV * const sv				\
+				|NN STRLEN * const lp				\
+				|const U32 flags				\
+				|const PL_SvPVtype type 			\
+				|NN Perl_SvPV_helper_non_trivial_t  non_trivial \
+				|const bool or_null				\
+				|const U32 return_flags
 Cdmp	|char * |sv_pvn_force	|NN SV *sv				\
 				|NULLOK STRLEN *lp
 Adp	|char * |sv_pvn_force_flags					\

--- a/embed.h
+++ b/embed.h
@@ -109,6 +109,7 @@
 # define SvNV(a)                                Perl_SvNV(aTHX_ a)
 # define SvNV_nomg(a)                           Perl_SvNV_nomg(aTHX_ a)
 # define SvPVXtrue(a)                           Perl_SvPVXtrue(aTHX_ a)
+# define SvPV_helper(a,b,c,d,e,f,g)             Perl_SvPV_helper(aTHX_ a,b,c,d,e,f,g)
 # define SvREFCNT_dec_ret_NULL(a)               Perl_SvREFCNT_dec_ret_NULL(aTHX_ a)
 # define SvTRUE(a)                              Perl_SvTRUE(aTHX_ a)
 # define SvTRUE_NN(a)                           Perl_SvTRUE_NN(aTHX_ a)

--- a/proto.h
+++ b/proto.h
@@ -9680,8 +9680,9 @@ Perl_SvPVXtrue(pTHX_ SV *sv)
 # define PERL_ARGS_ASSERT_SVPVXTRUE             \
         assert(sv)
 
-PERL_STATIC_INLINE char *
-Perl_SvPV_helper(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags, const PL_SvPVtype type, Perl_SvPV_helper_non_trivial_t  non_trivial, const bool or_null, const U32 return_flags);
+PERL_STATIC_FORCE_INLINE char *
+Perl_SvPV_helper(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags, const PL_SvPVtype type, Perl_SvPV_helper_non_trivial_t  non_trivial, const bool or_null, const U32 return_flags)
+        __attribute__always_inline__;
 # define PERL_ARGS_ASSERT_SVPV_HELPER           \
         assert(sv); assert(lp); assert(non_trivial)
 

--- a/proto.h
+++ b/proto.h
@@ -9680,6 +9680,11 @@ Perl_SvPVXtrue(pTHX_ SV *sv)
 # define PERL_ARGS_ASSERT_SVPVXTRUE             \
         assert(sv)
 
+PERL_STATIC_INLINE char *
+Perl_SvPV_helper(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags, const PL_SvPVtype type, Perl_SvPV_helper_non_trivial_t  non_trivial, const bool or_null, const U32 return_flags);
+# define PERL_ARGS_ASSERT_SVPV_HELPER           \
+        assert(sv); assert(lp); assert(non_trivial)
+
 PERL_STATIC_INLINE void
 Perl_SvREFCNT_dec(pTHX_ SV *sv);
 # define PERL_ARGS_ASSERT_SVREFCNT_DEC

--- a/sv.h
+++ b/sv.h
@@ -1958,16 +1958,8 @@ typedef enum {
     SvPVbyte_pure_type_
 } PL_SvPVtype;
 
-START_EXTERN_C
-
-/* When this code was written, embed.fnc could not handle function pointer
- * parameters; perhaps it still can't */
-#ifndef PERL_NO_INLINE_FUNCTIONS
-PERL_STATIC_INLINE char*
-Perl_SvPV_helper(pTHX_ SV *const sv, STRLEN *const lp, const U32 flags, const PL_SvPVtype type, char * (*non_trivial)(pTHX_ SV *, STRLEN * const, const U32), const bool or_null, const U32 return_flags);
-#endif
-
-END_EXTERN_C
+typedef char * (*Perl_SvPV_helper_non_trivial_t)(pTHX_ SV *, STRLEN * const,
+                                                       const U32);
 
 /* This test is "is there a cached PV that we can use directly?"
  * We can if


### PR DESCRIPTION
I compiled toke.s using -O0 and looked at the output.  It had a full copy of SvPV_helper in it.  But this function is called with various constants that make much of the code dead when constant folded.  That was not being done here.

This commit changes to force inlining.  Looking at a revised toke.s, I saw that SvPV_helper was inserted multiple times in the code, and that each occurrence had significantly fewer instructions than the original.  I infer that the compiler did the constant folding and pruned out the dead code for each instance.

* This set of changes does not require a perldelta entry.
