### PR TITLE
Add  name Perl_assert_; Convert  __ASSERT_() calls to assert_()

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -2681,7 +2681,7 @@ for my $which_pod (keys %docs) {
                 # how this item is displayed.
                 if ($element->{flags}) {
                     $element->{flags} .=
-                                       $leader->{flags} =~ s/$item_flags_re//r;
+                                    $leader->{flags} =~ s/$item_flags_re//gr;
                 }
                 else {
                     $element->{flags} = $leader->{flags};

--- a/av.h
+++ b/av.h
@@ -122,7 +122,7 @@ If all you need is to look up an array element, then prefer C<av_fetch>.
  *      SvGETMAGIC(av); IV x = av_tindex_nomg(av);
  */
 #   define av_top_index_skip_len_mg(av)                                     \
-                            (__ASSERT_(SvTYPE(av) == SVt_PVAV) AvFILLp(av))
+                            (assert(SvTYPE(av) == SVt_PVAV), AvFILLp(av))
 #   define av_tindex_skip_len_mg(av)  av_top_index_skip_len_mg(av)
 
 #define NEGATIVE_INDICES_VAR "NEGATIVE_INDICES"

--- a/handy.h
+++ b/handy.h
@@ -1414,7 +1414,7 @@ or casts
  *
  * NOT suitable for void*
  */
-#define ASSERT_IS_PTR(x) (__ASSERT_(sizeof(*(x))) (x))
+#define ASSERT_IS_PTR(x) (assert(sizeof(*(x))), (x))
 
 /* FITS_IN_8_BITS(c) returns true if c doesn't have  a bit set other than in
  * the lower 8.  It is designed to be hopefully bomb-proof, making sure that no
@@ -1439,8 +1439,8 @@ or casts
  * needed.  (The NV casts stop any warnings about comparison always being true
  * if called with an unsigned.  The cast preserves the sign, which is all we
  * care about.) */
-#define withinCOUNT(c, l, n)  (__ASSERT_((NV) (l) >= 0)                 \
-                               __ASSERT_((NV) (n) >= 0)                 \
+#define withinCOUNT(c, l, n)  (assert((NV) (l) >= 0),                   \
+                               assert((NV) (n) >= 0),                   \
                                withinCOUNT_KNOWN_VALID_((c), (l), (n)))
 
 /* For internal use only, this can be used in places where it is known that the
@@ -1455,11 +1455,11 @@ or casts
 /* Returns true if c is in the range l..u, where 'l' is non-negative
  * Written this way so that after optimization, only one conditional test is
  * needed. */
-#define inRANGE(c, l, u) (__ASSERT_((NV) (l) >= 0) __ASSERT_((u) >= (l))    \
+#define inRANGE(c, l, u) (assert((NV) (l) >= 0), assert((u) >= (l)),        \
    (  (sizeof(c) == sizeof(U8))  ? inRANGE_helper_(U8, (c), (l), ((u)))     \
     : (sizeof(c) == sizeof(U16)) ? inRANGE_helper_(U16,(c), (l), ((u)))     \
     : (sizeof(c) == sizeof(U32)) ? inRANGE_helper_(U32,(c), (l), ((u)))     \
-             : (__ASSERT_(sizeof(c) == sizeof(WIDEST_UTYPE))                \
+             : (assert(sizeof(c) == sizeof(WIDEST_UTYPE)),                  \
                           inRANGE_helper_(WIDEST_UTYPE,(c), (l), ((u))))))
 
 /* For internal use, this is used by machine-generated code which generates
@@ -2098,7 +2098,7 @@ END_EXTERN_C
            : ((UNLIKELY(((U8) (c)) == LATIN_SMALL_LETTER_Y_WITH_DIAERESIS)  \
               ? LATIN_CAPITAL_LETTER_Y_WITH_DIAERESIS                       \
               : (UNLIKELY(((U8)(c)) == LATIN_SMALL_LETTER_SHARP_S)          \
-                ? (__ASSERT_(0) (c)) /* Fail on Sharp S in DEBUGGING */     \
+                ? (assert(0), (c)) /* Fail on Sharp S in DEBUGGING */       \
                 : PL_mod_latin1_uc[ (U8) (c) ]))))))
 
 /* In this macro, note that the result can be larger than a byte in a UTF-8
@@ -2110,8 +2110,8 @@ END_EXTERN_C
 #  define toFOLD_LC(c)                                                      \
                 ((UNLIKELY((c) == MICRO_SIGN) && IN_UTF8_CTYPE_LOCALE)      \
                  ? GREEK_SMALL_LETTER_MU                                    \
-                 : (__ASSERT_(   ! IN_UTF8_CTYPE_LOCALE                     \
-                              || LIKELY((c) != LATIN_SMALL_LETTER_SHARP_S)) \
+                 : (assert(   ! IN_UTF8_CTYPE_LOCALE                        \
+                           || LIKELY((c) != LATIN_SMALL_LETTER_SHARP_S)),   \
                     toLOWER_LC(c)))
 #endif
 
@@ -2286,7 +2286,7 @@ END_EXTERN_C
  * class is TRUE for.  Hence it can skip the tests for this range.
  * 'above_latin1' should include its arguments */
 #define generic_utf8_safe_no_upper_latin1_(classnum, p, e, above_latin1)    \
-         (__ASSERT_(utf8_safe_assert_(p, e))                                \
+         (assert(utf8_safe_assert_(p, e)),                                  \
          (isASCII(*(p)))                                                    \
           ? generic_isCC_(*(p), classnum)                                   \
           : (UTF8_IS_DOWNGRADEABLE_START(*(p)))                             \
@@ -2504,9 +2504,9 @@ END_EXTERN_C
  * The conversion works both ways, so toCTRL('D') is 4, and toCTRL(4) is D,
  * etc. */
 #ifndef EBCDIC
-#  define toCTRL(c)    (__ASSERT_(FITS_IN_8_BITS(c)) toUPPER(((U8)(c))) ^ 64)
+#  define toCTRL(c)    (assert(FITS_IN_8_BITS(c)), toUPPER(((U8)(c))) ^ 64)
 #else
-#  define toCTRL(c)   (__ASSERT_(FITS_IN_8_BITS(c))                     \
+#  define toCTRL(c)   (assert(FITS_IN_8_BITS(c)),                       \
                       ((isPRINT_A(c))                                   \
                        ? (UNLIKELY((c) == '?')                          \
                          ? QUESTION_MARK_CTRL                           \
@@ -2550,7 +2550,7 @@ typedef U32 line_t;
  * position, and then to the eights position.  Both are added together to form
  * 0 if the input is '0'-'9' and to form 9 if alpha.  This is added to the
  * final four bits of the input to form the correct value. */
-#define XDIGIT_VALUE(c) (__ASSERT_(isXDIGIT(c))                             \
+#define XDIGIT_VALUE(c) (assert(isXDIGIT(c)),                               \
            ((NATIVE_TO_LATIN1(c) >> 6) & 1)  /* 1 if alpha; 0 if not */     \
          + ((NATIVE_TO_LATIN1(c) >> 3) & 8)  /* 8 if alpha; 0 if not */     \
          + ((c) & 0xF))   /* 0-9 if input valid hex digit */
@@ -2561,7 +2561,7 @@ typedef U32 line_t;
 /* Converts a character known to represent an octal digit (0-7) to its numeric
  * value.  The input is validated only by an assert() in DEBUGGING builds.  In
  * both ASCII and EBCDIC the last 3 bits of the octal digits range from 0-7. */
-#define OCTAL_VALUE(c) (__ASSERT_(isOCTAL(c)) (7 & (c)))
+#define OCTAL_VALUE(c) (assert(isOCTAL(c)), (7 & (c)))
 
 /* Efficiently returns a boolean as to if two native characters are equivalent
  * case-insensitively.  At least one of the characters must be one of [A-Za-z];
@@ -2578,7 +2578,7 @@ typedef U32 line_t;
  * just a single 0, in the bit position where the upper- and lowercase differ.
  * */
 #define isALPHA_FOLD_EQ(c1, c2)                                         \
-                      (__ASSERT_(isALPHA_A(c1) || isALPHA_A(c2))        \
+                      (assert(isALPHA_A(c1) || isALPHA_A(c2)),          \
                       ((c1) & ~('A' ^ 'a')) ==  ((c2) & ~('A' ^ 'a')))
 #define isALPHA_FOLD_NE(c1, c2) (! isALPHA_FOLD_EQ((c1), (c2)))
 

--- a/locale.c
+++ b/locale.c
@@ -2776,11 +2776,11 @@ S_bool_setlocale_2008_i(pTHX_
  * calculate_LC_ALL_string() for that. */
 #ifdef USE_LOCALE_NUMERIC
 #  define query_nominal_locale_i(i)                                         \
-      (__ASSERT_(i != LC_ALL_INDEX_)                                        \
+      (assert(i != LC_ALL_INDEX_),                                          \
        ((i == LC_NUMERIC_INDEX_) ? PL_numeric_name : querylocale_i(i)))
 #elif defined(USE_LOCALE)
 #  define query_nominal_locale_i(i)                                         \
-      (__ASSERT_(i != LC_ALL_INDEX_) querylocale_i(i))
+      (assert(i != LC_ALL_INDEX_), querylocale_i(i))
 #else
 #  define query_nominal_locale_i(i)  "C"
 #endif

--- a/perl.h
+++ b/perl.h
@@ -5178,8 +5178,8 @@ Gid_t getegid (void);
                     __FILE__, __LINE__));
 /*
 =for apidoc_section $directives
-=for apidoc    Am|void|assert_|bool expr
-=for apidoc_item |    |__ASSERT_
+=for apidoc     ATmp|void|assert_|bool expr
+=for apidoc_item  Tm|    |__ASSERT_
 
 These are synonymous, used to wrap the libc C<assert()> call in comma
 expressions in macro expansions, but you probably don't want to use them nor
@@ -5233,13 +5233,13 @@ contexts in C, and in all contexts in C++.
                                  " file \"" __FILE__ "\", line %" LINE_Tf,  \
                                  STRINGIFY(what), (line_t) __LINE__),       \
             (void) 0))
-#  define assert_(what)         assert(what),
-#  define __ASSERT_(statement)  assert(statement),
+#  define Perl_assert_(what)    assert(what),
 #else
 #  define Perl_assert(what)  ((void) 0)
-#  define assert_(what)
-#  define __ASSERT_(statement)
+#  define Perl_assert_(what)
 #endif
+#define assert_(what)         Perl_assert_(what)
+#define __ASSERT_(statement)  Perl_assert_(statement)
 
 struct ufuncs {
     I32 (*uf_val)(pTHX_ IV, SV*);

--- a/regcomp.h
+++ b/regcomp.h
@@ -488,9 +488,9 @@ struct regnode_ssc {
 #define FLAGS(p)        ((p)->head.data.u_8.flags) /* Caution: Doesn't apply to all      \
                                            regnode types.  For some, it's the \
                                            character set of the regnode */
-#define STR_LENs(p)	(__ASSERT_(OP(p) != LEXACT && OP(p) != LEXACT_REQ8)  \
+#define STR_LENs(p)	(assert(OP(p) != LEXACT && OP(p) != LEXACT_REQ8),   \
                                     STR_LEN_U8((struct regnode_string *)p))
-#define STRINGs(p)	(__ASSERT_(OP(p) != LEXACT && OP(p) != LEXACT_REQ8)  \
+#define STRINGs(p)	(assert(OP(p) != LEXACT && OP(p) != LEXACT_REQ8),   \
                                     ((struct regnode_string *)p)->string)
 #define OPERANDs(p)	STRINGs(p)
 
@@ -510,9 +510,9 @@ struct regnode_ssc {
  * node to be an ARG2L, using the second 32 bit field for the length, and not
  * using the flags nor next_off fields at all.  One could have an llstring node
  * and even an lllstring type. */
-#define STR_LENl(p)	(__ASSERT_(OP(p) == LEXACT || OP(p) == LEXACT_REQ8)  \
+#define STR_LENl(p)	(assert(OP(p) == LEXACT || OP(p) == LEXACT_REQ8),   \
                                     (((struct regnode_lstring *)p)->str_len_u32))
-#define STRINGl(p)	(__ASSERT_(OP(p) == LEXACT || OP(p) == LEXACT_REQ8)  \
+#define STRINGl(p)	(assert(OP(p) == LEXACT || OP(p) == LEXACT_REQ8),   \
                                     (((struct regnode_lstring *)p)->string))
 #define OPERANDl(p)	STRINGl(p)
 

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -1100,7 +1100,7 @@ static const scan_data_t zero_scan_data = {
 /* Convert between a pointer to a node and its offset from the beginning of the
  * program */
 #define REGNODE_p(offset)    (RExC_emit_start + (offset))
-#define REGNODE_OFFSET(node) (__ASSERT_((node) >= RExC_emit_start)      \
+#define REGNODE_OFFSET(node) (assert((node) >= RExC_emit_start),        \
                               (SSize_t) ((node) - RExC_emit_start))
 
 #define ProgLen(ri) ri->proglen

--- a/regen/regcomp.pl
+++ b/regen/regcomp.pl
@@ -302,10 +302,10 @@ sub print_process_EXACTish {
     print $out <<EOP,
 
 /* Is 'op', known to be of type EXACT, folding? */
-#define isEXACTFish(op) (__ASSERT_(REGNODE_TYPE(op) == EXACT) (PL_EXACTFish_bitmask & (1U << (op - EXACT))))
+#define isEXACTFish(op) (assert(REGNODE_TYPE(op) == EXACT), (PL_EXACTFish_bitmask & (1U << (op - EXACT))))
 
 /* Do only UTF-8 target strings match 'op', known to be of type EXACT? */
-#define isEXACT_REQ8(op) (__ASSERT_(REGNODE_TYPE(op) == EXACT) (PL_EXACT_REQ8_bitmask & (1U << (op - EXACT))))
+#define isEXACT_REQ8(op) (assert(REGNODE_TYPE(op) == EXACT), (PL_EXACT_REQ8_bitmask & (1U << (op - EXACT))))
 
 #ifndef DOINIT
 EXTCONST U32 PL_EXACTFish_bitmask;

--- a/regexec.c
+++ b/regexec.c
@@ -2211,7 +2211,7 @@ S_get_break_val_cp_checked(SV* const invlist, const UV cp_in) {
  * And it takes the particular macro name that finds the desired value given a
  * code point.  Merely convert the UTF-8 to code point and call the cp macro */
 #define generic_GET_BREAK_VAL_UTF8_(cp_macro, pos, strend)                     \
-             (__ASSERT_(pos < strend)                                          \
+             (assert(pos < strend),                                            \
                  /* Note assumes is valid UTF-8 */                             \
              (cp_macro(utf8_to_uv_or_die((pos), (strend), NULL))))
 

--- a/regnodes.h
+++ b/regnodes.h
@@ -2962,10 +2962,10 @@ EXTCONST U8 PL_simple_bitmask[] = {
 #endif /* DOINIT */
 
 /* Is 'op', known to be of type EXACT, folding? */
-#define isEXACTFish(op) (__ASSERT_(REGNODE_TYPE(op) == EXACT) (PL_EXACTFish_bitmask & (1U << (op - EXACT))))
+#define isEXACTFish(op) (assert(REGNODE_TYPE(op) == EXACT), (PL_EXACTFish_bitmask & (1U << (op - EXACT))))
 
 /* Do only UTF-8 target strings match 'op', known to be of type EXACT? */
-#define isEXACT_REQ8(op) (__ASSERT_(REGNODE_TYPE(op) == EXACT) (PL_EXACT_REQ8_bitmask & (1U << (op - EXACT))))
+#define isEXACT_REQ8(op) (assert(REGNODE_TYPE(op) == EXACT), (PL_EXACT_REQ8_bitmask & (1U << (op - EXACT))))
 
 #ifndef DOINIT
 EXTCONST U32 PL_EXACTFish_bitmask;

--- a/utf8.h
+++ b/utf8.h
@@ -310,8 +310,8 @@ adding no time nor space requirements to the implementation.
 =cut
 */
 
-#define NATIVE_TO_LATIN1(ch)  (__ASSERT_(FITS_IN_8_BITS(ch)) ((U8) (ch)))
-#define LATIN1_TO_NATIVE(ch)  (__ASSERT_(FITS_IN_8_BITS(ch)) ((U8) (ch)))
+#define NATIVE_TO_LATIN1(ch)  (assert(FITS_IN_8_BITS(ch)), ((U8) (ch)))
+#define LATIN1_TO_NATIVE(ch)  (assert(FITS_IN_8_BITS(ch)), ((U8) (ch)))
 
 /* I8 is an intermediate version of UTF-8 used only in UTF-EBCDIC.  We thus
  * consider it to be identical to UTF-8 on ASCII platforms.  Strictly speaking
@@ -319,8 +319,8 @@ adding no time nor space requirements to the implementation.
  * because they are 8-bit encodings that serve the same purpose in Perl, and
  * rarely do we need to distinguish them.  The term "NATIVE_UTF8" applies to
  * whichever one is applicable on the current platform */
-#define NATIVE_UTF8_TO_I8(ch)  (__ASSERT_(FITS_IN_8_BITS(ch)) ((U8) (ch)))
-#define I8_TO_NATIVE_UTF8(ch)  (__ASSERT_(FITS_IN_8_BITS(ch)) ((U8) (ch)))
+#define NATIVE_UTF8_TO_I8(ch)  (assert(FITS_IN_8_BITS(ch)), ((U8) (ch)))
+#define I8_TO_NATIVE_UTF8(ch)  (assert(FITS_IN_8_BITS(ch)), ((U8) (ch)))
 
 #define UNI_TO_NATIVE(ch)        ((UV) ASSERT_NOT_PTR(ch))
 #define NATIVE_TO_UNI(ch)        ((UV) ASSERT_NOT_PTR(ch))
@@ -443,7 +443,7 @@ are in the character. */
 
 /* Is the byte 'c' part of a multi-byte UTF8-8 encoded sequence, and not the
  * first byte thereof? */
-#define UTF8_IS_CONTINUATION(c)     (__ASSERT_(FITS_IN_8_BITS(c))           \
+#define UTF8_IS_CONTINUATION(c)     (assert(FITS_IN_8_BITS(c)),             \
             (((NATIVE_UTF8_TO_I8(c) & UTF_IS_CONTINUATION_MASK)             \
                                                 == UTF_CONTINUATION_MARK)))
 
@@ -636,8 +636,8 @@ encoded as UTF-8.  C<cp> is a native (ASCII or EBCDIC) code point if less than
  *
  * Note that on EBCDIC platforms, this is actually the I8 */
 #define UTF_START_BYTE(uv, bits)                                            \
-           (__ASSERT_((uv) >> ((bits) - 1)) /* At least 'bits' */           \
-            __ASSERT_(((uv) & ~nBIT_MASK(bits)) == 0) /* No extra bits */   \
+           (assert((uv) >> ((bits) - 1)), /* At least 'bits' */             \
+            assert(((uv) & ~nBIT_MASK(bits)) == 0), /* No extra bits */     \
               UTF_START_MARK(UNISKIP_BY_MSB_((bits) - 1))                   \
             | ((uv) >> (((bits) / UTF_CONTINUATION_BYTE_INFO_BITS)          \
                                 * UTF_CONTINUATION_BYTE_INFO_BITS)))
@@ -652,8 +652,8 @@ encoded as UTF-8.  C<cp> is a native (ASCII or EBCDIC) code point if less than
  *
  * Note that on EBCDIC platforms, this is actually the I8 */
 #define UTF_FIRST_CONT_BYTE(uv, bits)                                       \
-   (__ASSERT_((uv) >> ((bits) - 1)) /* At least 'bits' */                   \
-    __ASSERT_(((uv) & ~nBIT_MASK(bits)) == 0) /* No extra bits */           \
+   (assert((uv) >> ((bits) - 1)), /* At least 'bits' */                     \
+    assert(((uv) & ~nBIT_MASK(bits)) == 0), /* No extra bits */             \
        UTF_CONTINUATION_MARK                                                \
     | (   UTF_CONTINUATION_MASK                                             \
        & ((uv) >> ((((bits) / UTF_CONTINUATION_BYTE_INFO_BITS) - 1)         \
@@ -667,7 +667,7 @@ encoded as UTF-8.  C<cp> is a native (ASCII or EBCDIC) code point if less than
  * C0-C4 I8 start bytes on EBCDIC ones.  On EBCDIC E0 can't start a
  * non-overlong sequence, so we define a base macro and for those platforms,
  * extend it to also exclude E0 */
-#define UTF8_IS_START_base(c)    (__ASSERT_(FITS_IN_8_BITS(c))              \
+#define UTF8_IS_START_base(c)    (assert(FITS_IN_8_BITS(c)),                \
                              (NATIVE_UTF8_TO_I8(c) >= UTF_MIN_START_BYTE))
 #ifdef EBCDIC
 #  define UTF8_IS_START(c)                                                  \
@@ -680,13 +680,13 @@ encoded as UTF-8.  C<cp> is a native (ASCII or EBCDIC) code point if less than
 
 /* Is the UTF8-encoded byte 'c' the first byte of a sequence of bytes that
  * represent a code point > 255? */
-#define UTF8_IS_ABOVE_LATIN1(c)     (__ASSERT_(FITS_IN_8_BITS(c))           \
+#define UTF8_IS_ABOVE_LATIN1(c)     (assert(FITS_IN_8_BITS(c)),             \
                         (NATIVE_UTF8_TO_I8(c) >= UTF_MIN_ABOVE_LATIN1_BYTE))
 
 /* Is the UTF8-encoded byte 'c' the first byte of a two byte sequence?  Use
  * UTF8_IS_NEXT_CHAR_DOWNGRADEABLE() instead if the input isn't known to
  * be well-formed. */
-#define UTF8_IS_DOWNGRADEABLE_START(c)  (__ASSERT_(FITS_IN_8_BITS(c))       \
+#define UTF8_IS_DOWNGRADEABLE_START(c)  (assert(FITS_IN_8_BITS(c)),         \
                 inRANGE_helper_(U8, NATIVE_UTF8_TO_I8(c),                   \
                         UTF_MIN_START_BYTE, UTF_MIN_ABOVE_LATIN1_BYTE - 1))
 
@@ -753,7 +753,7 @@ uppercase/lowercase/titlecase/fold into.
  * that this is asymmetric on EBCDIC platforms, in that the 'new' parameter is
  * the UTF-EBCDIC byte, whereas the 'old' parameter is a Unicode (not EBCDIC)
  * code point in process of being generated */
-#define UTF8_ACCUMULATE(old, new) (__ASSERT_(FITS_IN_8_BITS(new))              \
+#define UTF8_ACCUMULATE(old, new) (assert(FITS_IN_8_BITS(new)),                \
                                    ((old) << UTF_ACCUMULATION_SHIFT)           \
                                    | ((NATIVE_UTF8_TO_I8(new))                 \
                                        & UTF_CONTINUATION_MASK))
@@ -777,8 +777,8 @@ uppercase/lowercase/titlecase/fold into.
  *  LO: continuation.
  * */
 #define EIGHT_BIT_UTF8_TO_NATIVE(HI, LO)                                        \
-    ( __ASSERT_(UTF8_IS_DOWNGRADEABLE_START(HI))                                \
-      __ASSERT_(UTF8_IS_CONTINUATION(LO))                                       \
+    ( assert(UTF8_IS_DOWNGRADEABLE_START(HI)),                                  \
+      assert(UTF8_IS_CONTINUATION(LO)),                                         \
      LATIN1_TO_NATIVE(UTF8_ACCUMULATE((                                         \
                             NATIVE_UTF8_TO_I8(HI) & UTF_START_MASK(2)), (LO))))
 
@@ -788,11 +788,11 @@ uppercase/lowercase/titlecase/fold into.
  * Note that the result can be larger than 255 if the input character is not
  * downgradable */
 #define TWO_BYTE_UTF8_TO_NATIVE(HI, LO) \
-    (__ASSERT_(FITS_IN_8_BITS(HI))                                              \
-     __ASSERT_(FITS_IN_8_BITS(LO))                                              \
-     __ASSERT_(PL_utf8skip[(U8) HI] == 2)                                            \
-     __ASSERT_(UTF8_IS_CONTINUATION(LO))                                        \
-     UNI_TO_NATIVE(UTF8_ACCUMULATE((NATIVE_UTF8_TO_I8(HI) & UTF_START_MASK(2)), \
+    (assert(FITS_IN_8_BITS(HI)),                                              \
+     assert(FITS_IN_8_BITS(LO)),                                              \
+     assert(PL_utf8skip[(U8) HI] == 2),                                       \
+     assert(UTF8_IS_CONTINUATION(LO)),                                        \
+     UNI_TO_NATIVE(UTF8_ACCUMULATE((NATIVE_UTF8_TO_I8(HI) & UTF_START_MASK(2)),\
                                    (LO))))
 
 /* Should never be used, and be deprecated */
@@ -847,7 +847,7 @@ C<L</UTF8_SAFE_SKIP>>, for example when interfacing with a C library.
 #define UTF8_SKIP(s) UTF8SKIP(s)
 #define UTF8_CHK_SKIP(s)                                                       \
      (UNLIKELY(s[0] == '\0') ? 1 : my_strnlen((const char *) (s), UTF8SKIP(s)))
-#define UTF8_SAFE_SKIP(s, e)  (__ASSERT_((e) >= (s))                \
+#define UTF8_SAFE_SKIP(s, e)  (assert((e) >= (s)),                  \
                               UNLIKELY(((e) - (s)) <= 0)            \
                                ? 0                                  \
                                : MIN(((e) - (s)), UTF8_SKIP(s)))
@@ -883,7 +883,7 @@ implementation of the latter. */
 
 /* Misleadingly named: is the UTF8-encoded byte 'c' part of a variant sequence
  * in UTF-8?  This is the inverse of UTF8_IS_INVARIANT. */
-#define UTF8_IS_CONTINUED(c)  (__ASSERT_(FITS_IN_8_BITS(c))                 \
+#define UTF8_IS_CONTINUED(c)  (assert(FITS_IN_8_BITS(c)),                 \
                                (! UTF8_IS_INVARIANT(c)))
 
 /* The macros in the next 4 sets are used to generate the two utf8 or utfebcdic
@@ -895,11 +895,11 @@ implementation of the latter. */
  * (which works for code points up through 0xFF) or NATIVE_TO_UNI which works
  * for any code point */
 #define __BASE_TWO_BYTE_HI(c, translate_function)                               \
-           (__ASSERT_(! UVCHR_IS_INVARIANT(c))                                  \
+           (assert(! UVCHR_IS_INVARIANT(c)),                                    \
             I8_TO_NATIVE_UTF8((translate_function(c) >> UTF_ACCUMULATION_SHIFT) \
                               | UTF_START_MARK(2)))
 #define __BASE_TWO_BYTE_LO(c, translate_function)                               \
-             (__ASSERT_(! UVCHR_IS_INVARIANT(c))                                \
+             (assert(! UVCHR_IS_INVARIANT(c)),                                  \
               I8_TO_NATIVE_UTF8((translate_function(c) & UTF_CONTINUATION_MASK) \
                                  | UTF_CONTINUATION_MARK))
 
@@ -911,9 +911,9 @@ implementation of the latter. */
 
 /* The next two macros are used when the source should be a single byte
  * character; checked for under DEBUGGING */
-#define UTF8_EIGHT_BIT_HI(c) (__ASSERT_(FITS_IN_8_BITS(c))                    \
+#define UTF8_EIGHT_BIT_HI(c) (assert(FITS_IN_8_BITS(c)),                    \
                              ( __BASE_TWO_BYTE_HI(c, NATIVE_TO_LATIN1)))
-#define UTF8_EIGHT_BIT_LO(c) (__ASSERT_(FITS_IN_8_BITS(c))                    \
+#define UTF8_EIGHT_BIT_LO(c) (assert(FITS_IN_8_BITS(c)),                    \
                              (__BASE_TWO_BYTE_LO(c, NATIVE_TO_LATIN1)))
 
 /* These final two macros in the series are used when the source can be any
@@ -923,12 +923,12 @@ implementation of the latter. */
  * MAX_UTF8_TWO_BYTE should be exactly all one bits in the lower few
  * places, so the ~ works */
 #define UTF8_TWO_BYTE_HI(c)                                                    \
-       (__ASSERT_((sizeof(c) ==  1)                                            \
-                  || !(((WIDEST_UTYPE)(c)) & ~MAX_UTF8_TWO_BYTE))              \
+       (assert((sizeof(c) ==  1)                                               \
+                  || !(((WIDEST_UTYPE)(c)) & ~MAX_UTF8_TWO_BYTE)),             \
         (__BASE_TWO_BYTE_HI(c, NATIVE_TO_UNI)))
 #define UTF8_TWO_BYTE_LO(c)                                                    \
-       (__ASSERT_((sizeof(c) ==  1)                                            \
-                  || !(((WIDEST_UTYPE)(c)) & ~MAX_UTF8_TWO_BYTE))              \
+       (assert((sizeof(c) ==  1)                                               \
+                  || !(((WIDEST_UTYPE)(c)) & ~MAX_UTF8_TWO_BYTE)),             \
         (__BASE_TWO_BYTE_LO(c, NATIVE_TO_UNI)))
 
 /* This is illegal in any well-formed UTF-8 in both EBCDIC and ASCII

--- a/utfebcdic.h
+++ b/utfebcdic.h
@@ -133,12 +133,12 @@ END_EXTERN_C
 /* EBCDIC-happy ways of converting native code to UTF-8 */
 
 /* Use these when ch is known to be < 256 */
-#define NATIVE_TO_LATIN1(ch)            (__ASSERT_(FITS_IN_8_BITS(ch)) PL_e2a[(U8)(ch)])
-#define LATIN1_TO_NATIVE(ch)            (__ASSERT_(FITS_IN_8_BITS(ch)) PL_a2e[(U8)(ch)])
+#define NATIVE_TO_LATIN1(ch)  (assert(FITS_IN_8_BITS(ch)), PL_e2a[(U8)(ch)])
+#define LATIN1_TO_NATIVE(ch)  (assert(FITS_IN_8_BITS(ch)), PL_a2e[(U8)(ch)])
 
 /* Use these on bytes */
-#define NATIVE_UTF8_TO_I8(b)           (__ASSERT_(FITS_IN_8_BITS(b)) PL_e2utf[(U8)(b)])
-#define I8_TO_NATIVE_UTF8(b)           (__ASSERT_(FITS_IN_8_BITS(b)) PL_utf2e[(U8)(b)])
+#define NATIVE_UTF8_TO_I8(b)  (assert(FITS_IN_8_BITS(b)), PL_e2utf[(U8)(b)])
+#define I8_TO_NATIVE_UTF8(b)  (assert(FITS_IN_8_BITS(b)), PL_utf2e[(U8)(b)])
 
 /* Transforms in wide UV chars */
 #define NATIVE_TO_UNI(ch)                                                   \

--- a/util.h
+++ b/util.h
@@ -245,8 +245,8 @@ returning NULL if not found.  The terminating NUL bytes are not compared.
 
 #ifdef HAS_MEMMEM
 #   define ninstr(big, bigend, little, lend)                                \
-            (__ASSERT_(bigend >= big)                                       \
-             __ASSERT_(lend >= little)                                      \
+            (assert(bigend >= big),                                         \
+             assert(lend >= little),                                        \
              (char *) memmem((big), (bigend) - (big),                       \
                              (little), (lend) - (little)))
 #else


### PR DESCRIPTION
`Perl_assert_` is a long name for `assert`. The name `__ASSERT_` is undefined behavior in C and C++.

* This set of changes does not require a perldelta entry.
