### PR TITLE
signatures.t: Correct typo in $::TODO assignment

### DIFF
--- a/t/op/signatures.t
+++ b/t/op/signatures.t
@@ -1501,7 +1501,7 @@ is scalar(t145()), undef;
         "$a:$b";
     }
     {
-        local $::TODO = q{can't handle commonaility};
+        local $::TODO = q{can't handle commonality};
         is t162x(), "y:x", 'handle commonality in scalar parms';
     }
 }


### PR DESCRIPTION

* This set of changes does not require a perldelta entry.
