### PR TITLE
perlapi - HeVAL operates on HEs, not HVs

### DIFF
--- a/hv.h
+++ b/hv.h
@@ -246,8 +246,8 @@ Returns the value slot (type C<SV*>)
 stored in the hash entry.  Can be assigned
 to.
 
-  SV *foo= HeVAL(hv);
-  HeVAL(hv)= sv;
+  SV *foo= HeVAL(he);
+  HeVAL(he)= sv;
 
 
 =for apidoc Am|U32|HeHASH|HE* he


### PR DESCRIPTION
The _perlapi_ example for `HeVAL` is misleading/confusing.

Instead of:

    SV *foo= HeVAL(hv);
    HeVAL(hv)= sv;

It should read:

    SV *foo= HeVAL(he);
    HeVAL(he)= sv;

Rationale: `hv` is the variable name commonly given to a `HV*`, `he` is a logical name to give a `HE*`. `HeVAL` operates on the latter.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
