### PR TITLE
fix type of S_clear_yystack()

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -220,9 +220,12 @@ do {					\
  * parse stack, thus avoiding leaks if we die  */
 
 static void
-S_clear_yystack(pTHX_  const yy_parser *parser)
+S_clear_yystack(pTHX_ void *arg)
 {
-    yy_stack_frame *ps     = parser->ps;
+    /* arg must be void * for this function to be compatible with
+       SAVEDESTRUCTOR_X/any_dxptr */
+    const yy_parser *parser = (const yy_parser *)arg;
+    yy_stack_frame *ps      = parser->ps;
     int i = 0;
 
     if (!parser->stack)


### PR DESCRIPTION
Functions registered with SAVEDESTRUCTOR_X must be of type 'void (pTHX_ void *)' because that's how scope.c stores and calls them.

Should fix this ASan error:

    scope.c:1537:13: runtime error: call to function S_clear_yystack through pointer to incorrect function type 'void (*)(struct interpreter *, void *)'



-------------------------------------------------------------------------------
<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
