### PR TITLE
avoid '0 + ptr' to create rvalues in macros

### DIFF
--- a/gv.h
+++ b/gv.h
@@ -76,7 +76,7 @@ the need to cast the result to the appropriate type.
 #  define GvNAMELEN_get(gv)	({ assert(GvNAME_HEK(gv)); HEK_LEN(GvNAME_HEK(gv)); })
 #  define GvNAMEUTF8(gv)	({ assert(GvNAME_HEK(gv)); HEK_UTF8(GvNAME_HEK(gv)); })
 #else
-#  define GvGP(gv)	(0+(gv)->sv_u.svu_gp)
+#  define GvGP(gv)              ((GP *)(gv)->sv_u.svu_gp)
 #  define GvGP_set(gv,gp)	((gv)->sv_u.svu_gp = (gp))
 #  define GvFLAGS(gv)	(GvXPVGV(gv)->xpv_cur)
 #  define GvSTASH(gv)	(GvXPVGV(gv)->xnv_u.xgv_stash)

--- a/op.h
+++ b/op.h
@@ -1096,7 +1096,7 @@ C<sib> is non-null. For a higher-level interface, see C<L</op_sibling_splice>>.
 #define OP_IS_STAT(op) (OP_IS_FILETEST(op) || (op) == OP_LSTAT || (op) == OP_STAT)
 
 #define OpHAS_SIBLING(o)	(cBOOL((o)->op_moresib))
-#define OpSIBLING(o)		(0 + (o)->op_moresib ? (o)->op_sibparent : NULL)
+#define OpSIBLING(o)		((o)->op_moresib ? (o)->op_sibparent : NULL)
 #define OpMORESIB_set(o, sib) ((o)->op_moresib = 1, (o)->op_sibparent = (sib))
 #define OpLASTSIB_set(o, parent) \
     ((o)->op_moresib = 0, (o)->op_sibparent = (parent))

--- a/sv.h
+++ b/sv.h
@@ -1350,11 +1350,11 @@ object type. Exposed to perl code via Internals::SvREADONLY().
 #  define SvIVX(sv) (0 + ((XPVIV*) SvANY(sv))->xiv_iv)
 #  define SvUVX(sv) (0 + ((XPVUV*) SvANY(sv))->xuv_uv)
 #  define SvNVX(sv) (-0.0 + ((XPVNV*) SvANY(sv))->xnv_u.xnv_nv)
-#  define SvRV(sv) (0 + (sv)->sv_u.svu_rv)
-#  define SvRV_const(sv) (0 + (sv)->sv_u.svu_rv)
+#  define SvRV_const(sv) ((SV *)(sv)->sv_u.svu_rv)
+#  define SvRV(sv) SvRV_const(sv)
 /* Don't test the core XS code yet.  */
 #  if defined (PERL_CORE) && PERL_DEBUG_COW > 1
-#    define SvPVX(sv) (0 + (assert_(!SvREADONLY(sv)) (sv)->sv_u.svu_pv))
+#    define SvPVX(sv) (assert_(!SvREADONLY(sv)) (char *)(sv)->sv_u.svu_pv)
 #  else
 #  define SvPVX(sv) SvPVX_mutable(sv)
 #  endif
@@ -1362,8 +1362,8 @@ object type. Exposed to perl code via Internals::SvREADONLY().
 #  define SvLEN(sv) (0 + ((XPV*) SvANY(sv))->xpv_len)
 #  define SvEND(sv) ((sv)->sv_u.svu_pv + ((XPV*)SvANY(sv))->xpv_cur)
 
-#  define SvMAGIC(sv)	(0 + *(assert_(SvTYPE(sv) >= SVt_PVMG) &((XPVMG*)  SvANY(sv))->xmg_u.xmg_magic))
-#  define SvSTASH(sv)	(0 + *(assert_(SvTYPE(sv) >= SVt_PVMG) &((XPVMG*)  SvANY(sv))->xmg_stash))
+#  define SvMAGIC(sv)	(assert_(SvTYPE(sv) >= SVt_PVMG) (MAGIC *)((XPVMG *)SvANY(sv))->xmg_u.xmg_magic)
+#  define SvSTASH(sv)	(assert_(SvTYPE(sv) >= SVt_PVMG) (HV *)((XPVMG *)SvANY(sv))->xmg_stash)
 #else   /* Below is not PERL_DEBUG_COW */
 # ifdef PERL_CORE
 #  define SvLEN(sv) (0 + ((XPV*) SvANY(sv))->xpv_len)
@@ -1452,7 +1452,7 @@ object type. Exposed to perl code via Internals::SvREADONLY().
 #    define SvUVX(sv) ((XPVUV*) SvANY(sv))->xuv_uv
 #    define SvNVX(sv) ((XPVNV*) SvANY(sv))->xnv_u.xnv_nv
 #    define SvRV(sv) ((sv)->sv_u.svu_rv)
-#    define SvRV_const(sv) (0 + (sv)->sv_u.svu_rv)
+#    define SvRV_const(sv) ((SV *)(sv)->sv_u.svu_rv)
 #    define SvMAGIC(sv)	((XPVMG*)  SvANY(sv))->xmg_u.xmg_magic
 #    define SvSTASH(sv)	((XPVMG*)  SvANY(sv))->xmg_stash
 #  endif


### PR DESCRIPTION
Pointer arithmetic (including 0 + ptr) has undefined behavior on null pointers. That's why the (0 + x->field) trick to provide rvalue access to struct fields is not generally safe with pointers.

Instead use no-op casts, which also produce rvalues.

Should fix these ASan errors (both from GvGP):

    gv.c:2920:44: runtime error: applying zero offset to null pointer

    sv.c:3855:25: runtime error: applying zero offset to null pointer



-------------------------------------------------------------------------------
<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
