### PR TITLE
Assert sanity of name+len arguments to allocmy()

### DIFF
--- a/op.c
+++ b/op.c
@@ -766,6 +766,8 @@ Perl_allocmy(pTHX_ const char *const name, const STRLEN len, const U32 flags)
     const bool is_our = (PL_parser->in_my == KEY_our);
 
     PERL_ARGS_ASSERT_ALLOCMY;
+    assert(len >= 2);
+    assert(name[0] && name[1]);
 
     if (flags & ~SVf_UTF8)
         croak("panic: allocmy illegal flag bits 0x%" UVxf,


### PR DESCRIPTION
Recent discussons on github [1] found a bug when calling this function as

  allocmy("", 0, 0)

This ought not be allowed. The length must be at least 2, because the function checks the first two characters of `name`.

[1]: https://github.com/Perl/perl5/pull/23574#discussion_r2278085750

* This set of changes does not require a perldelta entry.