### PR TITLE
Update PSC after 2025 elections

### DIFF
--- a/pod/perlgov.pod
+++ b/pod/perlgov.pod
@@ -494,9 +494,9 @@ how the membership has changed over time.
 
 =item * Aristotle Pagaltzis
 
-=item * Graham Knop
+=item * Leon Timmermans
 
-=item * Philippe Bruhat
+=item * Paul Evans
 
 =back
 


### PR DESCRIPTION
Edit PSC members following the recent election for 2025/2026 term