### PR TITLE
Fix ASan errors (functions called via pointers of incorrect types)

### DIFF
--- a/dist/threads-shared/lib/threads/shared.pm
+++ b/dist/threads-shared/lib/threads/shared.pm
@@ -8,7 +8,7 @@ use Config;
 
 use Scalar::Util qw(reftype refaddr blessed);
 
-our $VERSION = '1.70'; # Please update the pod, too.
+our $VERSION = '1.71'; # Please update the pod, too.
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -196,7 +196,7 @@ threads::shared - Perl extension for sharing data structures between threads
 
 =head1 VERSION
 
-This document describes threads::shared version 1.70
+This document describes threads::shared version 1.71
 
 =head1 SYNOPSIS
 

--- a/dist/threads-shared/shared.xs
+++ b/dist/threads-shared/shared.xs
@@ -212,8 +212,9 @@ recursive_lock_destroy(pTHX_ recursive_lock_t *lock)
 }
 
 static void
-recursive_lock_release(pTHX_ recursive_lock_t *lock)
+recursive_lock_release(pTHX_ void *ptr)
 {
+    recursive_lock_t *lock = (recursive_lock_t *)ptr;
     MUTEX_LOCK(&lock->mutex);
     if (lock->owner == aTHX) {
         if (--lock->locks == 0) {

--- a/embed.fnc
+++ b/embed.fnc
@@ -1909,7 +1909,7 @@ p	|int	|magic_freeutf8 |NN SV *sv				\
 p	|int	|magic_get	|NN SV *sv				\
 				|NN MAGIC *mg
 p	|int	|magic_getarylen|NN SV *sv				\
-				|NN const MAGIC *mg
+				|NN MAGIC *mg
 p	|int	|magic_getdebugvar					\
 				|NN SV *sv				\
 				|NN MAGIC *mg

--- a/embed.fnc
+++ b/embed.fnc
@@ -5679,7 +5679,7 @@ ES	|void	|ssc_union	|NN regnode_ssc *ssc			\
 				|NN SV * const invlist			\
 				|const bool invert_2nd
 ES	|void	|unwind_scan_frames					\
-				|NN const void *p
+				|NN void *p
 #endif /* defined(PERL_IN_REGCOMP_STUDY_C) */
 #if defined(PERL_IN_REGEXEC_C)
 ERS	|LB_enum|advance_one_LB |NN U8 **curpos 			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -4825,13 +4825,13 @@ S	|SV *	|magic_methcall1|NN SV *sv				\
 S	|int	|magic_methpack |NN SV *sv				\
 				|NN const MAGIC *mg			\
 				|NN SV *meth
-S	|void	|restore_magic	|NULLOK const void *p
+S	|void	|restore_magic	|NULLOK void *p
 S	|void	|save_magic_flags					\
 				|SSize_t mgs_ix 			\
 				|NN SV *sv				\
 				|U32 flags
 S	|void	|unwind_handler_stack					\
-				|NULLOK const void *p
+				|NULLOK void *p
 #endif
 #if defined(PERL_IN_MG_C) || defined(PERL_IN_PP_C)
 Tp	|bool	|translate_substr_offsets				\

--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -1629,16 +1629,17 @@ not_here(const char *s)
 #include "const-c.inc"
 
 static void
-restore_sigmask(pTHX_ SV *osset_sv)
+restore_sigmask(pTHX_ void *ptr)
 {
-     /* Fortunately, restoring the signal mask can't fail, because
-      * there's nothing we can do about it if it does -- we're not
-      * supposed to return -1 from sigaction unless the disposition
-      * was unaffected.
-      */
+    /* Fortunately, restoring the signal mask can't fail, because
+     * there's nothing we can do about it if it does -- we're not
+     * supposed to return -1 from sigaction unless the disposition
+     * was unaffected.
+     */
 #if !(defined(__amigaos4__) && defined(__NEWLIB__))
-     sigset_t *ossetp = (sigset_t *) SvPV_nolen( osset_sv );
-     (void)sigprocmask(SIG_SETMASK, ossetp, (sigset_t *)0);
+    SV *osset_sv = (SV *)ptr;
+    sigset_t *ossetp = (sigset_t *) SvPV_nolen( osset_sv );
+    (void)sigprocmask(SIG_SETMASK, ossetp, (sigset_t *)0);
 #endif
 }
 

--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our ($AUTOLOAD, %SIGRT);
 
-our $VERSION = '2.23';
+our $VERSION = '2.24';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -1597,8 +1597,8 @@ XSPP_wrapped(my_pp_anonlist, 0, 1)
 #include "const-c.inc"
 
 void
-destruct_test(pTHX_ void *p) {
-    warn("In destruct_test: %" SVf "\n", (SV*)p);
+destruct_test(pTHX_ SV *p) {
+    warn("In destruct_test: %" SVf "\n", p);
 }
 
 #if defined(USE_ITHREADS) && !defined(WIN32)

--- a/mg.c
+++ b/mg.c
@@ -3824,7 +3824,7 @@ Perl_perly_sighandler(int sig, Siginfo_t *sip PERL_UNUSED_DECL,
 
 
 static void
-S_restore_magic(pTHX_ const void *p)
+S_restore_magic(pTHX_ void *p)
 {
     MGS* const mgs = SSPTR(PTR2IV(p), MGS*);
     SV* const sv = mgs->mgs_sv;
@@ -3881,7 +3881,7 @@ S_restore_magic(pTHX_ const void *p)
  * skipped over. */
 
 static void
-S_unwind_handler_stack(pTHX_ const void *p)
+S_unwind_handler_stack(pTHX_ void *p)
 {
     PERL_UNUSED_ARG(p);
 

--- a/mg.c
+++ b/mg.c
@@ -2364,7 +2364,7 @@ Perl_magic_setdbline(pTHX_ SV *sv, MAGIC *mg)
 }
 
 int
-Perl_magic_getarylen(pTHX_ SV *sv, const MAGIC *mg)
+Perl_magic_getarylen(pTHX_ SV *sv, MAGIC *mg)
 {
     AV * const obj = MUTABLE_AV(mg->mg_obj);
 

--- a/mg.c
+++ b/mg.c
@@ -1472,8 +1472,9 @@ Perl_magic_clear_all_env(pTHX_ SV *sv, MAGIC *mg)
 
 #ifdef HAS_SIGPROCMASK
 static void
-restore_sigmask(pTHX_ SV *save_sv)
+restore_sigmask(pTHX_ void *ptr)
 {
+    SV *save_sv = (SV *)ptr;
     const sigset_t * const ossetp = (const sigset_t *) SvPV_nolen_const( save_sv );
     (void)sigprocmask(SIG_SETMASK, ossetp, NULL);
 }

--- a/mg_vtable.h
+++ b/mg_vtable.h
@@ -165,7 +165,7 @@ EXTCONST char * const PL_magic_vtable_names[magic_vtable_max];
 
 #ifdef DOINIT
 EXT_MGVTBL PL_magic_vtables[magic_vtable_max] = {
-  { (int (*)(pTHX_ SV *, MAGIC *))Perl_magic_getarylen, Perl_magic_setarylen, 0, 0, 0, 0, 0, 0 },
+  { Perl_magic_getarylen, Perl_magic_setarylen, 0, 0, 0, 0, 0, 0 },
   { 0, 0, 0, Perl_magic_cleararylen_p, Perl_magic_freearylen_p, 0, 0, 0 },
   { 0, 0, 0, 0, Perl_magic_killbackrefs, 0, 0, 0 },
   { 0, 0, 0, 0, 0, Perl_magic_copycallchecker, 0, 0 },

--- a/pad.c
+++ b/pad.c
@@ -2963,6 +2963,12 @@ Perl_suspend_compcv(pTHX_ struct suspended_compcv *buffer)
     buffer->pad_reset_pending = PL_pad_reset_pending;
 }
 
+/* interface compatible with SAVEDESTRUCTOR_X */
+static void
+S_suspend_compcv_destruct(pTHX_ void *p) {
+    suspend_compcv((struct suspended_compcv *)p);
+}
+
 /*
 =for apidoc resume_compcv_final
 
@@ -3001,7 +3007,7 @@ Perl_resume_compcv(pTHX_ struct suspended_compcv *buffer, bool save)
     SAVEBOOL(PL_pad_reset_pending); PL_pad_reset_pending = buffer->pad_reset_pending;
 
     if(save)
-        SAVEDESTRUCTOR_X(&Perl_suspend_compcv, buffer);
+        SAVEDESTRUCTOR_X(S_suspend_compcv_destruct, buffer);
 }
 
 /*

--- a/perlio.c
+++ b/perlio.c
@@ -2872,7 +2872,7 @@ typedef struct {
 } PerlIOUnix;
 
 static void
-S_lockcnt_dec(pTHX_ const void* f)
+S_lockcnt_dec(pTHX_ void* f)
 {
 #ifndef PERL_IMPLICIT_SYS
     PERL_UNUSED_CONTEXT;

--- a/proto.h
+++ b/proto.h
@@ -7327,7 +7327,7 @@ S_magic_methpack(pTHX_ SV *sv, const MAGIC *mg, SV *meth);
         assert(sv); assert(mg); assert(meth)
 
 STATIC void
-S_restore_magic(pTHX_ const void *p);
+S_restore_magic(pTHX_ void *p);
 # define PERL_ARGS_ASSERT_RESTORE_MAGIC
 
 STATIC void
@@ -7336,7 +7336,7 @@ S_save_magic_flags(pTHX_ SSize_t mgs_ix, SV *sv, U32 flags);
         assert(sv)
 
 STATIC void
-S_unwind_handler_stack(pTHX_ const void *p);
+S_unwind_handler_stack(pTHX_ void *p);
 # define PERL_ARGS_ASSERT_UNWIND_HANDLER_STACK
 
 #endif /* defined(PERL_IN_MG_C) */

--- a/proto.h
+++ b/proto.h
@@ -8745,7 +8745,7 @@ S_ssc_union(pTHX_ regnode_ssc *ssc, SV * const invlist, const bool invert_2nd);
         assert(ssc); assert(invlist)
 
 STATIC void
-S_unwind_scan_frames(pTHX_ const void *p);
+S_unwind_scan_frames(pTHX_ void *p);
 # define PERL_ARGS_ASSERT_UNWIND_SCAN_FRAMES    \
         assert(p)
 

--- a/proto.h
+++ b/proto.h
@@ -2207,7 +2207,7 @@ Perl_magic_get(pTHX_ SV *sv, MAGIC *mg)
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
-Perl_magic_getarylen(pTHX_ SV *sv, const MAGIC *mg)
+Perl_magic_getarylen(pTHX_ SV *sv, MAGIC *mg)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETARYLEN        \
         assert(sv); assert(mg)

--- a/regcomp.c
+++ b/regcomp.c
@@ -485,8 +485,9 @@ Perl_re_compile(pTHX_ SV * const pattern, U32 rx_flags)
 }
 
 static void
-S_free_codeblocks(pTHX_ struct reg_code_blocks *cbs)
+S_free_codeblocks(pTHX_ void *ptr)
 {
+    struct reg_code_blocks *cbs = (struct reg_code_blocks *)ptr;
     int n;
 
     if (--cbs->refcnt > 0)

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -25,7 +25,7 @@
 
 
 STATIC void
-S_unwind_scan_frames(pTHX_ const void *p)
+S_unwind_scan_frames(pTHX_ void *p)
 {
     PERL_ARGS_ASSERT_UNWIND_SCAN_FRAMES;
     scan_frame *f= (scan_frame *)p;

--- a/regen/mg_vtable.pl
+++ b/regen/mg_vtable.pl
@@ -245,11 +245,6 @@ my %mg =
 #       prefix the vtable with the specified entry (e.g. '#ifdef FOO')
 #       and suffix it with '#else { 0, 0, 0, 0, 0, 0, 0, 0 } #endif'
 #
-#    const
-#       special-case cast a 'get' function whose signature expects
-#       a pointer to constant magic, so that it can be added to a vtable
-#       which expects pointers to functions without the 'const'.
-#
 #    get
 #    set
 #    len
@@ -277,7 +272,7 @@ my %vtable_conf =
      'dbline' => {set => 'setdbline'},
      'isa' => {set => 'setisa', clear => 'clearisa'},
      'isaelem' => {set => 'setisa'},
-     'arylen' => {get => 'getarylen', set => 'setarylen', const => 1},
+     'arylen' => {get => 'getarylen', set => 'setarylen'},
      'arylen_p' => {clear => 'cleararylen_p', free => 'freearylen_p'},
      'mglob'    => {set   => 'setmglob',
                     free  => 'freemglob' },
@@ -528,7 +523,6 @@ while (my $name = shift @names) {
         $data->{$_} ? "Perl_magic_$data->{$_}" : 0;
     } qw(get set len clear free copy dup local);
 
-    $funcs[0] = "(int (*)(pTHX_ SV *, MAGIC *))" . $funcs[0] if $data->{const};
     my $funcs = join ", ", @funcs;
 
     # Because we can't have a , after the last {...}


### PR DESCRIPTION
Whenever a function is registered to be called through a function pointer, its type needs to match the calling pointer exactly. In particular, functions registered with `SAVEDESTRUCTOR_X` must have type `void (pTHX_ void *)` and functions registered with `MORTALSVFUNC_X` must have type `void (pTHX_ SV *)`. You can't just cast a function of a similar-ish type and hope for the best.

Actually, you probably can on most platforms, but it is a violation of strict standard C and it shows up as noise in ASan diagnostics, so fix it.

-------------------------------------------------------------------------------
<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
