### PR TITLE
dump.c: Use valid_utf8_to_uv for known valid

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -233,7 +233,7 @@ Perl_pv_escape( pTHX_ SV *dsv, char const * const str,
     
     for ( ; pv < end ; pv += readsize ) {
         const UV u = (isuni)  /* Here known to be valid; checked just above */
-                     ? utf8_to_uv_or_die((U8*)pv, (U8*) end, &readsize)
+                     ? valid_utf8_to_uv( (U8*) pv, &readsize)
                      : (U8) *pv;
         const U8 c = (U8)u;
         const char *source_buf = octbuf;


### PR DESCRIPTION
We have a function that is designed for just this purpose where we know that the UTF-8 is valid.


* This set of changes does not require a perldelta entry.
