### PR TITLE
don't blame $x if reftype($x)/refaddr($x) is undef

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -17532,6 +17532,8 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
     case OP_SYSOPEN:
     case OP_SYSSEEK:
     case OP_SPLICE: /* scalar splice(@x, $i, 0) ==> undef */
+    case OP_REFADDR:
+    case OP_REFTYPE:
         match = 1;
         goto do_op;
 

--- a/t/lib/warnings/9uninit
+++ b/t/lib/warnings/9uninit
@@ -2303,3 +2303,12 @@ Use of uninitialized value shift(@ARGV) in lc at - line 26.
 Use of uninitialized value shift() in lc at - line 27.
 Use of uninitialized value pop(@ARGV) in lc at - line 28.
 Use of uninitialized value pop() in lc at - line 29.
+########
+# GH #19273
+use warnings 'uninitialized';
+my $x = 'fine';
+$_ = builtin::refaddr($x) == 1;
+$_ = builtin::reftype($x) eq '';
+EXPECT
+Use of uninitialized value in numeric eq (==) at - line 4.
+Use of uninitialized value in string eq at - line 5.


### PR DESCRIPTION
When the "Use of uninitialized value" warning tries to find the source of the problem, it skips over builtin::reftype/builtin::refaddr operations and blames their arguments:

    $ perl -wE 'my $x = 42; $_ = reftype($x) eq ""'
    Use of uninitialized value $x in string eq at -e line 1.
    $ perl -wE 'my $x = 42; $_ = refaddr($x) eq ""'
    Use of uninitialized value $x in string eq at -e line 1.

This is wrong because $x is clearly defined.

This patch teaches S_find_uninit_var that reftype/refaddr can return undef even if their arguments are perfectly defined.

Fixes #19273.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
