### PR TITLE
Assert that Copy's source and destination do not overlap

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -2855,9 +2855,26 @@ enum mem_log_type {
 #define Zero(d,n,t)	((void)ZeroD(d, n, t))
 
 /* Like above, but returns a pointer to 'd' */
-#define MoveD(s,d,n,t)	(MEM_WRAP_CHECK_(n,t) perl_assert_ptr(d), perl_assert_ptr(s), memmove((char*)(d),(const char*)(s), (n) * sizeof(t)))
-#define CopyD(s,d,n,t)	(MEM_WRAP_CHECK_(n,t) perl_assert_ptr(d), perl_assert_ptr(s), memcpy((char*)(d),(const char*)(s), (n) * sizeof(t)))
-#define ZeroD(d,n,t)	(MEM_WRAP_CHECK_(n,t) perl_assert_ptr(d), memzero((char*)(d), (n) * sizeof(t)))
+#define MoveD(s,d,n,t)	\
+    ( \
+        MEM_WRAP_CHECK_(n,t) \
+        perl_assert_ptr(d), \
+        perl_assert_ptr(s), \
+        memmove((char*)(d),(const char*)(s), (n) * sizeof(t)) \
+    )
+#define CopyD(s,d,n,t)	\
+    ( \
+        MEM_WRAP_CHECK_(n,t) \
+        perl_assert_ptr(d), \
+        perl_assert_ptr(s), \
+        memcpy((char*)(d),(const char*)(s), (n) * sizeof(t)) \
+    )
+#define ZeroD(d,n,t)	\
+    ( \
+        MEM_WRAP_CHECK_(n,t) \
+        perl_assert_ptr(d), \
+        memzero((char*)(d), (n) * sizeof(t)) \
+    )
 
 #define NewCopy(s,d,n,t) STMT_START {   \
     Newx(d,n,t);                        \

--- a/handy.h
+++ b/handy.h
@@ -2867,6 +2867,11 @@ enum mem_log_type {
         MEM_WRAP_CHECK_(n,t) \
         perl_assert_ptr(d), \
         perl_assert_ptr(s), \
+        assert_( \
+            PTR2UV((char *)(d) + (n) * sizeof (t)) <= PTR2UV((const char *)(s)) \
+            || \
+            PTR2UV((const char *)(s) + (n) * sizeof (t)) <= PTR2UV((char *)(d)) \
+        ) \
         memcpy((char*)(d),(const char*)(s), (n) * sizeof(t)) \
     )
 #define ZeroD(d,n,t)	\

--- a/handy.h
+++ b/handy.h
@@ -2850,9 +2850,9 @@ enum mem_log_type {
 #define perl_assert_ptr(p) assert( ((void*)(p)) != 0 )
 
 
-#define Move(s,d,n,t)	(MEM_WRAP_CHECK_(n,t) perl_assert_ptr(d), perl_assert_ptr(s), (void)memmove((char*)(d),(const char*)(s), (n) * sizeof(t)))
-#define Copy(s,d,n,t)	(MEM_WRAP_CHECK_(n,t) perl_assert_ptr(d), perl_assert_ptr(s), (void)memcpy((char*)(d),(const char*)(s), (n) * sizeof(t)))
-#define Zero(d,n,t)	(MEM_WRAP_CHECK_(n,t) perl_assert_ptr(d), (void)memzero((char*)(d), (n) * sizeof(t)))
+#define Move(s,d,n,t)	((void)MoveD(s, d, n, t))
+#define Copy(s,d,n,t)	((void)CopyD(s, d, n, t))
+#define Zero(d,n,t)	((void)ZeroD(d, n, t))
 
 /* Like above, but returns a pointer to 'd' */
 #define MoveD(s,d,n,t)	(MEM_WRAP_CHECK_(n,t) perl_assert_ptr(d), perl_assert_ptr(s), memmove((char*)(d),(const char*)(s), (n) * sizeof(t)))


### PR DESCRIPTION
`memcpy` has undefined behavior if the source/destination ranges overlap, so assert that they don't.


-------------------------------------------------------------------------------
<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
