### PR TITLE
pp_reverse: Use isUTF8_CHAR() for validity check

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -6633,10 +6633,11 @@ PP_wrapped(pp_reverse, 0, 1)
                         continue;
                     }
                     else {
-                        if (!utf8_to_uvchr_buf(s, send, 0))
+                        Size_t advance = isUTF8_CHAR(s, send);
+                        if (advance == 0)
                             break;
                         up = (char*)s;
-                        s += UTF8SKIP(s);
+                        s += advance;
                         down = (char*)(s - 1);
                         /* reverse this character */
                         while (down > up) {


### PR DESCRIPTION
The code was converting a UTF-8 single character string to its code point, just to find out if the string was wellformed or not.  It had no need of the returned code point.  It is more efficient to just use the function that checks for validity without trying to get the code point.

The validity checking function returns 0 on failure; else how many bytes were in the string.  Use this value instead of calling UTF8SKIP to re-derive it.

And the former function utf8_to_uvchr_buf() is discouraged from use anyway.  This commit removes the final core use of the discouraged _uvchr functions,


* This set of changes does not require a perldelta entry.
