### PR TITLE
perlapi: Add info about finding  when API item added to Perl

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -2780,6 +2780,20 @@ $api{hdr} = <<"_EOB_";
 |to be documented.  Patches welcome!  The interfaces of these are subject to
 |change without notice.
 |
+|To find out what release an element came into being, use
+|
+| perl dist/ppport.h --api-info=element
+|
+|You may also use a pattern
+|
+| perl dist/ppport.h --api-info=/./
+|
+|displays all possible public api elements, but not items in L<perlintern>.
+|Some elements have been backported in L<Devel::PPPort> so that they are
+|usable in earlier versions than they otherwise would be available.  The
+|display also includes information as to what the earliest possible version
+|such an element may be used in; as well as some hints and cautions.
+|
 |Some of the functions documented here are consolidated so that a single entry
 |serves for multiple functions which all do basically the same thing, but have
 |some slight differences.  For example, one form might process magic, while

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -219,7 +219,8 @@ Additionally, the following selected changes have been made:
 
 =item *
 
-XXX Description of the change here
+L<perlapi> now contains information about how to find what release of
+Perl first contained an API element 
 
 =back
 


### PR DESCRIPTION
This adds text to this pod that shows how to use ppport to find when an
API element came into being in perl

* This set of changes requires a perldelta entry, and it is included.

