### PR TITLE
Expose some short form macros unconditionally

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -875,10 +875,10 @@ Adp	|OP *	|ck_entersub_args_proto_or_list 			\
 
 CPop	|bool	|ckwarn 	|U32 w
 CPop	|bool	|ckwarn_d	|U32 w
-Adfpv	|void	|ck_warner	|U32 err				\
+Adfp	|void	|ck_warner	|U32 err				\
 				|NN const char *pat			\
 				|...
-Adfpv	|void	|ck_warner_d	|U32 err				\
+Adfp	|void	|ck_warner_d	|U32 err				\
 				|NN const char *pat			\
 				|...
 
@@ -928,7 +928,7 @@ px	|void	|create_eval_scope					\
 : croak()'s first parm can be NULL.  Otherwise, mod_perl breaks.
 Adfprv	|void	|croak		|NULLOK const char *pat 		\
 				|...
-Tfprv	|void	|croak_caller	|NULLOK const char *pat 		\
+Tfpr	|void	|croak_caller	|NULLOK const char *pat 		\
 				|...
 CTrs	|void	|croak_memory_wrap
 Tpr	|void	|croak_no_mem
@@ -1179,7 +1179,7 @@ Adp	|void	|dump_all
 p	|void	|dump_all_perl	|bool justperl
 Adhp	|void	|dump_eval
 Adp	|void	|dump_form	|NN const GV *gv
-Cfpv	|void	|dump_indent	|I32 level				\
+Cfp	|void	|dump_indent	|I32 level				\
 				|NN PerlIO *file			\
 				|NN const char *pat			\
 				|...
@@ -1210,7 +1210,7 @@ ATdmp	|bool	|extended_utf8_to_uv					\
 				|NN const U8 * const e			\
 				|NN UV *cp_p				\
 				|NULLOK Size_t *advance_p
-Adfpv	|void	|fatal_warner	|U32 err				\
+Adfp	|void	|fatal_warner	|U32 err				\
 				|NN const char *pat			\
 				|...
 Adp	|void	|fbm_compile	|NN SV *sv				\
@@ -1942,7 +1942,7 @@ p	|int	|magic_getvec	|NN SV *sv				\
 p	|int	|magic_killbackrefs					\
 				|NN SV *sv				\
 				|NN MAGIC *mg
-Fdopv	|SV *	|magic_methcall |NN SV *sv				\
+Fdop	|SV *	|magic_methcall |NN SV *sv				\
 				|NN const MAGIC *mg			\
 				|NN SV *meth				\
 				|U32 flags				\
@@ -2141,7 +2141,7 @@ Cdp	|PerlIO *|my_popen_list |NN const char *mode			\
 Adp	|void	|my_setenv	|NULLOK const char *nam 		\
 				|NULLOK const char *val
 
-AMTdfpv |int	|my_snprintf	|NN char *buffer			\
+AMTdfp	|int	|my_snprintf	|NN char *buffer			\
 				|const Size_t len			\
 				|NN const char *format			\
 				|...
@@ -2419,7 +2419,7 @@ AMPTdp	|char * |ninstr 	|NN const char *big			\
 
 p	|void	|no_bareword_filehandle 				\
 				|NN const char *fhname
-Tefprv	|void	|noperl_die	|NN const char *pat			\
+Tefpr	|void	|noperl_die	|NN const char *pat			\
 				|...
 CTdp	|void	|noshutdownhook
 Adp	|int	|nothreadhook
@@ -2620,7 +2620,7 @@ Cdp	|void	|pop_scope
 Cipx	|void	|pop_stackinfo
 
 : Used in perl.c and toke.c
-Fopv	|void	|populate_isa	|NN const char *name			\
+Fop	|void	|populate_isa	|NN const char *name			\
 				|STRLEN len				\
 				|...
 Adhp	|REGEXP *|pregcomp	|NN SV * const pattern			\
@@ -2691,7 +2691,7 @@ Adp	|REGEXP *|re_compile	|NN SV * const pattern			\
 				|U32 orig_rx_flags
 Cp	|void	|reentrant_free
 Cp	|void	|reentrant_init
-CFTpv	|void * |reentrant_retry|NN const char *f			\
+CFTp	|void * |reentrant_retry|NN const char *f			\
 				|...
 
 Cp	|void	|reentrant_size
@@ -3642,7 +3642,7 @@ Cdp	|void	|taint_env
 Cdp	|void	|taint_proper	|NULLOK const char *f			\
 				|NN const char * const s
 
-Fpv	|OP *	|tied_method	|NN SV *methname			\
+Fp	|OP *	|tied_method	|NN SV *methname			\
 				|NN SV **mark				\
 				|NN SV * const sv			\
 				|NN const MAGIC * const mg		\
@@ -3974,7 +3974,7 @@ Adp	|void	|wrap_op_checker|Optype opcode				\
 p	|void	|write_to_stderr|NN SV *msv
 Xp	|void	|xs_boot_epilog |const SSize_t ax
 
-FTXopv	|Stack_off_t|xs_handshake					\
+FTXop	|Stack_off_t|xs_handshake					\
 				|const U32 key				\
 				|NN void *v_my_perl			\
 				|NN const char *file			\
@@ -5472,7 +5472,7 @@ ES	|SV *	|parse_uniprop_string					\
 				|NN bool *user_defined_ptr		\
 				|NN SV *msg				\
 				|const STRLEN level
-Sfrv	|void	|re_croak	|bool utf8				\
+Sfr	|void	|re_croak	|bool utf8				\
 				|NN const char *pat			\
 				|...
 ES	|regnode_offset|reg	|NN RExC_state_t *pRExC_state		\
@@ -5821,7 +5821,7 @@ ES	|void	|dump_exec_pos	|NN const char *locinput		\
 				|const bool do_utf8			\
 				|const U32 depth
 
-EFpv	|int	|re_exec_indentf|NN const char *fmt			\
+EFp	|int	|re_exec_indentf|NN const char *fmt			\
 				|U32 depth				\
 				|...
 # endif
@@ -5864,10 +5864,10 @@ Ep	|void	|regprop	|NULLOK const regexp *prog		\
 				|NN const regnode *o			\
 				|NULLOK const regmatch_info *reginfo	\
 				|NULLOK const RExC_state_t *pRExC_state
-EFpv	|int	|re_indentf	|NN const char *fmt			\
+EFp	|int	|re_indentf	|NN const char *fmt			\
 				|U32 depth				\
 				|...
-Efpv	|int	|re_printf	|NN const char *fmt			\
+Efp	|int	|re_printf	|NN const char *fmt			\
 				|...
 # endif
 # if defined(PERL_EXT_RE_BUILD)

--- a/embed.h
+++ b/embed.h
@@ -177,6 +177,8 @@
 # define ck_entersub_args_list(a)               Perl_ck_entersub_args_list(aTHX_ a)
 # define ck_entersub_args_proto(a,b,c)          Perl_ck_entersub_args_proto(aTHX_ a,b,c)
 # define ck_entersub_args_proto_or_list(a,b,c)  Perl_ck_entersub_args_proto_or_list(aTHX_ a,b,c)
+# define ck_warner(a,...)                       Perl_ck_warner(aTHX_ a,__VA_ARGS__)
+# define ck_warner_d(a,...)                     Perl_ck_warner_d(aTHX_ a,__VA_ARGS__)
 # define clear_defarray(a,b)                    Perl_clear_defarray(aTHX_ a,b)
 # define clear_defarray_simple(a)               Perl_clear_defarray_simple(aTHX_ a)
 # define cop_fetch_label(a,b,c)                 Perl_cop_fetch_label(aTHX_ a,b,c)
@@ -222,12 +224,14 @@
 # define dump_all()                             Perl_dump_all(aTHX)
 # define dump_eval()                            Perl_dump_eval(aTHX)
 # define dump_form(a)                           Perl_dump_form(aTHX_ a)
+# define dump_indent(a,b,...)                   Perl_dump_indent(aTHX_ a,b,__VA_ARGS__)
 # define dump_packsubs(a)                       Perl_dump_packsubs(aTHX_ a)
 # define dump_sub(a)                            Perl_dump_sub(aTHX_ a)
 # define dump_vindent(a,b,c,d)                  Perl_dump_vindent(aTHX_ a,b,c,d)
 # define eval_pv(a,b)                           Perl_eval_pv(aTHX_ a,b)
 # define eval_sv(a,b)                           Perl_eval_sv(aTHX_ a,b)
 # define Perl_extended_utf8_to_uv               extended_utf8_to_uv
+# define fatal_warner(a,...)                    Perl_fatal_warner(aTHX_ a,__VA_ARGS__)
 # define fbm_compile(a,b)                       Perl_fbm_compile(aTHX_ a,b)
 # define fbm_instr(a,b,c,d)                     Perl_fbm_instr(aTHX_ a,b,c,d)
 # define filter_add(a,b)                        Perl_filter_add(aTHX_ a,b)
@@ -907,13 +911,9 @@
 # endif /* defined(MULTIPLICITY) */
 # if !defined(MULTIPLICITY) || defined(PERL_CORE) || \
       defined(PERL_WANT_VARARGS)
-#   define ck_warner(a,...)                     Perl_ck_warner(aTHX_ a,__VA_ARGS__)
-#   define ck_warner_d(a,...)                   Perl_ck_warner_d(aTHX_ a,__VA_ARGS__)
 #   define croak(...)                           Perl_croak(aTHX_ __VA_ARGS__)
 #   define deb(...)                             Perl_deb(aTHX_ __VA_ARGS__)
 #   define die(...)                             Perl_die(aTHX_ __VA_ARGS__)
-#   define dump_indent(a,b,...)                 Perl_dump_indent(aTHX_ a,b,__VA_ARGS__)
-#   define fatal_warner(a,...)                  Perl_fatal_warner(aTHX_ a,__VA_ARGS__)
 #   define form(...)                            Perl_form(aTHX_ __VA_ARGS__)
 #   define load_module(a,b,...)                 Perl_load_module(aTHX_ a,b,__VA_ARGS__)
 #   define mess(...)                            Perl_mess(aTHX_ __VA_ARGS__)
@@ -1176,6 +1176,7 @@
 #   define sv_pvutf8n_force_wrapper(a,b,c)      Perl_sv_pvutf8n_force_wrapper(aTHX_ a,b,c)
 #   define sv_resetpvn(a,b,c)                   Perl_sv_resetpvn(aTHX_ a,b,c)
 #   define sv_sethek(a,b)                       Perl_sv_sethek(aTHX_ a,b)
+#   define tied_method(a,b,c,d,e,...)           Perl_tied_method(aTHX_ a,b,c,d,e,__VA_ARGS__)
 #   define tmps_grow_p(a)                       Perl_tmps_grow_p(aTHX_ a)
 #   define utilize(a,b,c,d,e)                   Perl_utilize(aTHX_ a,b,c,d,e)
 #   define vivify_ref(a,b)                      Perl_vivify_ref(aTHX_ a,b)
@@ -1231,13 +1232,6 @@
 #     define magic_regdatum_set(a,b)            Perl_magic_regdatum_set(aTHX_ a,b)
 #   else
 #     define magic_regdatum_set(a,b)            Perl_magic_regdatum_set(aTHX_ a,b)
-#   endif
-#   if !defined(MULTIPLICITY) || defined(PERL_CORE) || \
-        defined(PERL_WANT_VARARGS)
-#     define tied_method(a,b,c,d,e,...)         Perl_tied_method(aTHX_ a,b,c,d,e,__VA_ARGS__)
-#     if defined(PERL_IN_REGCOMP_C)
-#       define re_croak(a,...)                  S_re_croak(aTHX_ a,__VA_ARGS__)
-#     endif
 #   endif
 #   if defined(PERL_DEBUG_READONLY_COW)
 #     define sv_buf_to_ro(a)                    Perl_sv_buf_to_ro(aTHX_ a)
@@ -1660,6 +1654,9 @@
 #       define dooneliner(a,b)                  S_dooneliner(aTHX_ a,b)
 #     endif
 #   endif
+#   if defined(PERL_IN_REGCOMP_C)
+#     define re_croak(a,...)                    S_re_croak(aTHX_ a,__VA_ARGS__)
+#   endif
 #   if defined(PERL_IN_REGCOMP_INVLIST_C) && !defined(PERL_EXT_RE_BUILD)
 #     define initialize_invlist_guts(a,b)       S_initialize_invlist_guts(aTHX_ a,b)
 #   endif
@@ -2067,10 +2064,7 @@
 #     if defined(DEBUGGING)
 #       define debug_start_match(a,b,c,d,e)     S_debug_start_match(aTHX_ a,b,c,d,e)
 #       define dump_exec_pos(a,b,c,d,e,f,g)     S_dump_exec_pos(aTHX_ a,b,c,d,e,f,g)
-#       if !defined(MULTIPLICITY) || defined(PERL_CORE) || \
-            defined(PERL_WANT_VARARGS)
-#         define re_exec_indentf(a,...)         Perl_re_exec_indentf(aTHX_ a,__VA_ARGS__)
-#       endif
+#       define re_exec_indentf(a,...)           Perl_re_exec_indentf(aTHX_ a,__VA_ARGS__)
 #     endif
 #   endif /* defined(PERL_IN_REGEXEC_C) */
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
@@ -2108,14 +2102,10 @@
 #     define debug_show_study_flags(a,b,c)      Perl_debug_show_study_flags(aTHX_ a,b,c)
 #     define debug_studydata(a,b,c,d,e,f,g)     Perl_debug_studydata(aTHX_ a,b,c,d,e,f,g)
 #     define dumpuntil(a,b,c,d,e,f,g,h)         Perl_dumpuntil(aTHX_ a,b,c,d,e,f,g,h)
+#     define re_indentf(a,...)                  Perl_re_indentf(aTHX_ a,__VA_ARGS__)
+#     define re_printf(...)                     Perl_re_printf(aTHX_ __VA_ARGS__)
 #     define regprop(a,b,c,d,e)                 Perl_regprop(aTHX_ a,b,c,d,e)
-#     if !defined(MULTIPLICITY) || defined(PERL_CORE) || \
-          defined(PERL_WANT_VARARGS)
-#       define re_indentf(a,...)                Perl_re_indentf(aTHX_ a,__VA_ARGS__)
-#       define re_printf(...)                   Perl_re_printf(aTHX_ __VA_ARGS__)
-#     endif
-#   endif /*   defined(DEBUGGING) &&
-             ( defined(PERL_CORE) || defined(PERL_EXT) ) */
+#   endif
 #   if defined(PERL_EXT_RE_BUILD)
 #     if defined(PERL_CORE) || defined(PERL_EXT)
 #       define get_re_gclass_aux_data(a,b,c,d,e,f) Perl_get_re_gclass_aux_data(aTHX_ a,b,c,d,e,f)


### PR DESCRIPTION
Until C99 we couldn't use the type of macro we have that hides the need for thread context to call a function that needed both a thread context parameter and a format with varying numbers of parameters.  Therefore you had to call the function directly with aTHX_.  For some such functions, there were parallel functions created that omitted the thread context parameter (re-deriving it themselves).  And there were compatibility macros created that called these.  So, for example warn() would call Perl_warn_nocontext().

That changed in C99, and the calls in core to such functions were changed to use the macro that now expanded to Perl_warn().

Not all functions with this problem had '_nocontext()' versions.  It turns out that the way the macros were #defined in embed.h, a definition existed for core, and non-threaded builds, but not threaded ones.  This meant that, likely unknown to you, if you wrote an XS module, and used one of those macros, such as ck_warner(), it would compile and run on a non-threaded system, but would not compile on a threaded build.

Commits 13e5ba49b2cfe0add44db552ecbebb2f785aecbc and d933027ef0a56c99aee8cc3c88ff4f9981ac9fc2 did not affect the '_nocontext()' versions.  This commit exposes their macros to the public.  There is no need to worry about breaking existing code, as these macros existed only on non-threaded builds, and they still work there.  They now work on threaded builds as well, as long as you have an aTHX variable available.  This is no different than any newly created macro for which we are also requiring aTHX availability.

* This set of changes does not require a perldelta entry because it is the first commit in an eventual series
