### PR TITLE
fix false positive on attempt to escape whitespace in qw()

### DIFF
--- a/t/lib/warnings/toke
+++ b/t/lib/warnings/toke
@@ -375,6 +375,39 @@ EXPECT
 Possible attempt to escape whitespace in qw() list at - line 3.
 ########
 # toke.c
+use warnings 'qw';
+@a = qw( foo bar \ baz );
+EXPECT
+Possible attempt to escape whitespace in qw() list at - line 3.
+########
+# toke.c
+use warnings 'qw';
+@a = qw(\ );
+EXPECT
+Possible attempt to escape whitespace in qw() list at - line 3.
+########
+# toke.c
+use warnings 'qw';
+@a = qw(\\\ )
+EXPECT
+Possible attempt to escape whitespace in qw() list at - line 3.
+########
+# toke.c
+use warnings 'qw';
+@a = qw(\\ );
+EXPECT
+########
+# toke.c
+use warnings 'qw';
+@a = qw( \\ );
+EXPECT
+########
+# toke.c
+use warnings 'qw';
+@a = qw( foo bar \\ baz );
+EXPECT
+########
+# toke.c
 use warnings 'syntax' ;
 print ("");
 print ("") and $x = 1;

--- a/toke.c
+++ b/toke.c
@@ -5826,7 +5826,7 @@ yyl_qw(pTHX_ char *s, STRLEN len)
             if (len) {
                 SV *sv;
                 const char *b = d;
-                if (!warned_comma || !warned_comment) {
+                if (!warned_comma || !warned_comment || !warned_escape) {
                     for (; !isSPACE(*d) && len; --len, ++d) {
                         if (!warned_comma && *d == ',') {
                             warner(packWARN(WARN_QW),
@@ -5838,10 +5838,15 @@ yyl_qw(pTHX_ char *s, STRLEN len)
                                    "Possible attempt to put comments in qw() list");
                             ++warned_comment;
                         }
-                        else if (!warned_escape && *d == '\\' && len > 1 && isSPACE(*(d+1)) ) {
-                            warner(packWARN(WARN_QW),
-                                   "Possible attempt to escape whitespace in qw() list");
-                            ++warned_escape;
+                        else if (!warned_escape && *d == '\\' && len > 1) {
+                            if (*(d+1) == '\\') {
+                                --len, ++d;
+                            }
+                            else if (isSPACE(*(d+1))) {
+                                warner(packWARN(WARN_QW),
+                                       "Possible attempt to escape whitespace in qw() list");
+                                ++warned_escape;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
..originally added in GH #23403.

* This set of changes does not require a perldelta entry.
