### PR TITLE
Create PERL_UNIQUE_NAME and use it to avoid name collisions

### DIFF
--- a/op.h
+++ b/op.h
@@ -64,12 +64,14 @@ typedef PERL_BITFIELD16 Optype;
     U8		op_private;
 #endif
 
+#define o1_     PERL_UNIQUE_NAME(o)
+#define type1_  PERL_UNIQUE_NAME(type)
 #define OpTYPE_set(o,type)                      \
     STMT_START {                                \
-        OP *o_ = (OP *)o;                       \
-        OPCODE type_ = type;                    \
-        o_->op_type = type_;                    \
-        o_->op_ppaddr = PL_ppaddr[type_];       \
+        OP *o1_ = (OP *)o;                      \
+        OPCODE type1_ = type;                   \
+        o1_->op_type = type1_;                  \
+        o1_->op_ppaddr = PL_ppaddr[type1_];     \
     } STMT_END
 
 /* If op_type:9 is changed to :10, also change cx_pusheval()

--- a/perl.h
+++ b/perl.h
@@ -4208,6 +4208,14 @@ Obsolete form of C<UVuf>, which you should convert to instead use
 #  define UVf UVuf
 #endif
 
+/* Use this like:
+ *  #define sv1_ PERL_UNIQUE_NAME(sv)
+ * and it will expand to something very likely unique to your file, beginning
+ * with 'PL_' which means there should be no name collision with the caller.
+ * an underscore.  If two 'sv1_' are attempted to be defined, a compiler
+ * warning will get raised, so you can change one of them. */
+#define PERL_UNIQUE_NAME(name)  CAT2(PL_, CAT2(name, __LINE__))
+
 #if !defined(DEBUGGING) && !defined(NDEBUG)
 #  define NDEBUG 1
 #endif
@@ -4323,15 +4331,9 @@ where it has parity with the other two forms.
  * We use a bit-field instead of an array because gcc accepts
         typedef char x[n]
    where n is not a compile-time constant.  We want to enforce constantness.
- *
- * We need the FOOL macros to get proper cpp parameter concatanation. */
-#  define STATIC_ASSERT_STRUCT_NAME_FOOL_CPP_2_(line)                       \
-                                 static_assertion_failed_##line
-#  define STATIC_ASSERT_STRUCT_NAME_FOOL_CPP_(line)                         \
-                                STATIC_ASSERT_STRUCT_NAME_FOOL_CPP_2_(line)
+ */
     /* Return the struct and element name */
-#  define STATIC_ASSERT_STRUCT_NAME_                                        \
-                            STATIC_ASSERT_STRUCT_NAME_FOOL_CPP_(__LINE__)
+#  define STATIC_ASSERT_STRUCT_NAME_ PERL_UNIQUE_NAME(static_assertion_failed_)
 
     /* Return the struct body */
 #  define STATIC_ASSERT_STRUCT_BODY_(COND, NAME)                            \


### PR DESCRIPTION
`PERL_UNIQUE_NAME` is a factory creating a preprocessor symbol that is based on an input skeleton name, and the line number it is called from.  The skeleton name would likely be something like `sv1_` or `PL_sv1`.  These should be chosen to not have conflicts with the XS code.  The advantage of this approach is that you won't be using the same variable name in a bunch of macros and they collide.  

* This set of changes does not require a perldelta entry.
