### PR TITLE
Document uvuni_to_utf8()

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3890,7 +3890,7 @@ Admp	|U8 *	|uv_to_utf8_msgs|NN U8 *d				\
 				|UV uv					\
 				|UV flags				\
 				|NULLOK HV **msgs
-CDbp	|U8 *	|uvuni_to_utf8	|NN U8 *d				\
+ADbdp	|U8 *	|uvuni_to_utf8	|NN U8 *d				\
 				|UV uv
 EXdpx	|bool	|validate_proto |NN SV *name				\
 				|NULLOK SV *proto			\

--- a/mathoms.c
+++ b/mathoms.c
@@ -142,6 +142,15 @@ Perl_utf8_to_uvuni(pTHX_ const U8 *s, STRLEN *retlen)
     return NATIVE_TO_UNI(valid_utf8_to_uvchr(s, retlen));
 }
 
+/*
+=for apidoc_section $unicode
+=for apidoc uvuni_to_utf8
+
+Instead use L<perlapi/uv_to_utf8>.
+
+=cut
+*/
+
 U8 *
 Perl_uvuni_to_utf8(pTHX_ U8 *d, UV uv)
 {


### PR DESCRIPTION
This is deprecated, but we should give enough information to tell people what to do.  And this moves it to the public API so that its deprecation gets more prominence.

* This set of changes does not require a perldelta entry.
