### PR TITLE
Remove trailing blanks in three .c files

### DIFF
--- a/gv.c
+++ b/gv.c
@@ -618,7 +618,7 @@ S_maybe_add_coresub(pTHX_ HV * const stash, GV *gv,
     case KEY_finally:
     case KEY_for     : case KEY_foreach: case KEY_format: case KEY_ge     :
     case KEY_given   : case KEY_goto   : case KEY_grep  : case KEY_gt     :
-    case KEY_if      : case KEY_isa    : 
+    case KEY_if      : case KEY_isa    :
     case KEY_last   :
     case KEY_le      : case KEY_local  : case KEY_lt    : case KEY_m      :
     case KEY_map     : case KEY_method : case KEY_my    :
@@ -1325,8 +1325,8 @@ In C<gv_autoload_sv>, C<*namesv> is an SV, and the name is the PV extracted
 from that using L</C<SvPV>>.  If the SV is marked as being in UTF-8, the
 extracted PV will also be.
 
-The other way to indicate that the name is encoded as UTF-8 is to set the 
-C<SVf_UTF8> bit in C<flags> for the forms that have that parameter.  
+The other way to indicate that the name is encoded as UTF-8 is to set the
+C<SVf_UTF8> bit in C<flags> for the forms that have that parameter.
 The name is never considered to be UTF-8 in C<gv_autoload4>.
 
 The C<method> parameter in C<gv_autoload4> is used only to indicate that the

--- a/pad.c
+++ b/pad.c
@@ -114,7 +114,7 @@ write is called (if necessary).
 The flag C<SVs_PADSTALE> is cleared on lexicals each time the C<my()> is executed,
 and set on scope exit.  This allows the
 C<"Variable $x is not available"> warning
-to be generated in evals, such as 
+to be generated in evals, such as
 
     { my $x = 1; sub f { eval '$x'} } f();
 
@@ -1183,7 +1183,7 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV* cv,
                 DEBUG_Xv(PerlIO_printf(Perl_debug_log,
                     "Pad findlex cv=0x%" UVxf " matched: offset=%ld flags=0x%lx index=%lu\n",
                     PTR2UV(cv), (long)offset, (unsigned long)*out_flags,
-                    (unsigned long) PARENT_PAD_INDEX(*out_name) 
+                    (unsigned long) PARENT_PAD_INDEX(*out_name)
                 ));
             }
 
@@ -2012,7 +2012,7 @@ S_cv_clone_pad(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned,
                     S_unavailable(aTHX_ namesv);
                     sv = NULL;
                 }
-                else 
+                else
                     SvREFCNT_inc_simple_void_NN(sv);
             }
             if (!sv) {
@@ -2573,8 +2573,8 @@ Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
                                interacts with lexicals.  */
                             pad1a[ix] = sv_dup_inc(oldpad[ix], param);
                         } else {
-                            SV *sv; 
-                            
+                            SV *sv;
+
                             if (sigil == '@')
                                 sv = MUTABLE_SV(newAV());
                             else if (sigil == '%')

--- a/util.c
+++ b/util.c
@@ -1681,9 +1681,9 @@ Perl_write_to_stderr(pTHX_ SV* msv)
 
     PERL_ARGS_ASSERT_WRITE_TO_STDERR;
 
-    if (PL_stderrgv && SvREFCNT(PL_stderrgv) 
+    if (PL_stderrgv && SvREFCNT(PL_stderrgv)
         && (io = GvIO(PL_stderrgv))
-        && (mg = SvTIED_mg((const SV *)io, PERL_MAGIC_tiedscalar))) 
+        && (mg = SvTIED_mg((const SV *)io, PERL_MAGIC_tiedscalar)))
         Perl_magic_methcall(aTHX_ MUTABLE_SV(io), mg, SV_CONST(PRINT),
                             G_SCALAR | G_DISCARD | G_WRITING_TO_STDERR, 1, msv);
     else {
@@ -2174,7 +2174,7 @@ argument list.
 void
 Perl_warner_nocontext(U32 err, const char *pat, ...)
 {
-    dTHX; 
+    dTHX;
     va_list args;
     PERL_ARGS_ASSERT_WARNER_NOCONTEXT;
     va_start(args, pat);
@@ -2307,7 +2307,7 @@ S_ckwarn_common(pTHX_ U32 w)
     } else if (!unpackWARN3(w)) {
         assert(!unpackWARN4(w));
     }
-        
+
     /* Right, dealt with all the special cases, which are implemented as non-
        pointers, so there is a pointer to a real warnings mask.  */
     do {
@@ -2466,7 +2466,7 @@ Perl_unlnk(pTHX_ const char *f)	/* unlink all versions of a file */
 
 #if defined(OEMVS)
   #if (__CHARSET_LIB == 1)
-  static int chgfdccsid(int fd, unsigned short ccsid) 
+  static int chgfdccsid(int fd, unsigned short ccsid)
   {
     attrib_t attr;
     memset(&attr, 0, sizeof(attr));
@@ -2748,7 +2748,7 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode)
       filedescriptors directly, need to manually switch to the
       default, binary, low-level mode; see PerlIOBuf_open(). */
    PerlLIO_setmode((*mode == 'r'), O_BINARY);
-#endif 
+#endif
         PL_forkprocess = 0;
 #ifdef PERL_USES_PL_PIDSTATUS
         hv_clear(PL_pidstatus);	/* we have no children */
@@ -4953,7 +4953,7 @@ Perl_debug_hash_seed(pTHX_ bool via_debug_h)
 # endif
 
 static void
-S_mem_log_common(enum mem_log_type mlt, const UV n, 
+S_mem_log_common(enum mem_log_type mlt, const UV n,
                  const UV typesize, const char *type_name, const SV *sv,
                  Malloc_t oldalloc, Malloc_t newalloc,
                  const char *filename, const int linenumber,
@@ -5089,7 +5089,7 @@ S_mem_log_common(enum mem_log_type mlt, const UV n,
 
 Malloc_t
 Perl_mem_log_alloc(const UV n, const UV typesize, const char *type_name,
-                   Malloc_t newalloc, 
+                   Malloc_t newalloc,
                    const char *filename, const int linenumber,
                    const char *funcname)
 {
@@ -5103,32 +5103,32 @@ Perl_mem_log_alloc(const UV n, const UV typesize, const char *type_name,
 
 Malloc_t
 Perl_mem_log_realloc(const UV n, const UV typesize, const char *type_name,
-                     Malloc_t oldalloc, Malloc_t newalloc, 
-                     const char *filename, const int linenumber, 
+                     Malloc_t oldalloc, Malloc_t newalloc,
+                     const char *filename, const int linenumber,
                      const char *funcname)
 {
     PERL_ARGS_ASSERT_MEM_LOG_REALLOC;
 
     mem_log_common_if(MLT_REALLOC, n, typesize, type_name,
-                      NULL, oldalloc, newalloc, 
+                      NULL, oldalloc, newalloc,
                       filename, linenumber, funcname);
     return newalloc;
 }
 
 Malloc_t
-Perl_mem_log_free(Malloc_t oldalloc, 
-                  const char *filename, const int linenumber, 
+Perl_mem_log_free(Malloc_t oldalloc,
+                  const char *filename, const int linenumber,
                   const char *funcname)
 {
     PERL_ARGS_ASSERT_MEM_LOG_FREE;
 
-    mem_log_common_if(MLT_FREE, 0, 0, "", NULL, oldalloc, NULL, 
+    mem_log_common_if(MLT_FREE, 0, 0, "", NULL, oldalloc, NULL,
                       filename, linenumber, funcname);
     return oldalloc;
 }
 
 void
-Perl_mem_log_new_sv(const SV *sv, 
+Perl_mem_log_new_sv(const SV *sv,
                     const char *filename, const int linenumber,
                     const char *funcname)
 {
@@ -5140,12 +5140,12 @@ Perl_mem_log_new_sv(const SV *sv,
 
 void
 Perl_mem_log_del_sv(const SV *sv,
-                    const char *filename, const int linenumber, 
+                    const char *filename, const int linenumber,
                     const char *funcname)
 {
     PERL_ARGS_ASSERT_MEM_LOG_DEL_SV;
 
-    mem_log_common_if(MLT_DEL_SV, 0, 0, "", sv, NULL, NULL, 
+    mem_log_common_if(MLT_DEL_SV, 0, 0, "", sv, NULL, NULL,
                       filename, linenumber, funcname);
 }
 
@@ -5796,7 +5796,7 @@ Perl_get_db_sub(pTHX_ SV **svp, CV *cv)
                  !( (SvTYPE(*svp) == SVt_PVGV)
                     && (GvCV((const GV *)*svp) == cv)
                     /* Use GV from the stack as a fallback. */
-                    && S_gv_has_usable_name(aTHX_ gv = (GV *)*svp) 
+                    && S_gv_has_usable_name(aTHX_ gv = (GV *)*svp)
                   )
                 )
         ) {
@@ -5849,7 +5849,7 @@ Perl_my_dirfd(DIR * dir) {
     Perl_croak_nocontext(PL_no_func, "dirfd");
     NOT_REACHED; /* NOTREACHED */
     return 0;
-#endif 
+#endif
 }
 
 #if !defined(HAS_MKOSTEMP) || !defined(HAS_MKSTEMP)
@@ -5944,7 +5944,7 @@ Perl_get_re_arg(pTHX_ SV *sv) {
         if (SvTYPE(sv) == SVt_REGEXP)
             return (REGEXP*) sv;
     }
- 
+
     return NULL;
 }
 


### PR DESCRIPTION
I found these annoying when working on other patches

* This set of changes does not require a perldelta entry.
