### PR TITLE
perlapi: Combine sv_setref_pv[ns] entries

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -363,10 +363,6 @@ a string/length pair.
 Like C<newSVpvn_share>, but takes a literal string instead of
 a string/length pair and omits the hash parameter.
 
-=for apidoc Am|SV *|sv_setref_pvs|SV *const rv|const char *const classname|"literal string"
-Like C<sv_setref_pvn>, but takes a literal string instead of
-a string/length pair.
-
 =cut
 */
 
@@ -418,6 +414,12 @@ Perl_xxx(aTHX_ ...) form for any API calls where it's used.
 #define sv_setpvs(dsv, str) Perl_sv_setpvn(aTHX_ dsv, STR_WITH_LEN(str))
 #define sv_setpvs_mg(dsv, str) Perl_sv_setpvn_mg(aTHX_ dsv, STR_WITH_LEN(str))
 
+/*
+=for apidoc_defn Am|SV *|sv_setref_pvs|SV *const rv|const char *const classname|"literal string"
+a string/length pair.
+
+=cut
+*/
 #define sv_setref_pvs(rv, classname, str) \
     Perl_sv_setref_pvn(aTHX_ rv, classname, STR_WITH_LEN(str))
 

--- a/sv.c
+++ b/sv.c
@@ -10901,16 +10901,24 @@ Perl_sv_setref_nv(pTHX_ SV *const rv, const char *const classname, const NV nv)
 }
 
 /*
-=for apidoc sv_setref_pvn
+=for apidoc      sv_setref_pvn
+=for apidoc_item sv_setref_pvs
 
-Copies a string into a new SV, optionally blessing the SV.  The length of the
-string must be specified with C<n>.  The C<rv> argument will be upgraded to
-an RV.  That RV will be modified to point to the new SV.  The C<classname>
-argument indicates the package for the blessing.  Set C<classname> to
-C<NULL> to avoid the blessing.  The new SV will have a reference count
-of 1, and the RV will be returned.
+These each copy a string into a new SV, optionally blessing the SV.
+The C<rv> argument will be upgraded to an RV.  That RV will be modified to
+point to the new SV.
+The C<classname> argument indicates the package for the blessing.
+Set C<classname> to C<NULL> to avoid the blessing.
+The new SV will have a reference count of 1, and the RV will be returned.
 
-Note that C<sv_setref_pv> copies the pointer while this copies the string.
+The forms differ only in how the source string is specified.
+
+C<sv_setref_pvs> takes a C string literal enclosed in double quotes.
+
+In C<sv_setref_pvn>, C<n> is the length of the string parameter C<pv> in
+bytes.  Hence the latter may contain embedded NUL characters.
+
+Note that C<L</sv_setref_pv>> copies the pointer while these copy the string.
 
 =cut
 */


### PR DESCRIPTION
These entries differ only in details.  They are better explained in one unit, comparing and contrasting.


* This set of changes does not require a perldelta entry.
