### PR TITLE
todo test for GH 16863 (Assertion failure in S_maybe_multiconcat)

### DIFF
--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -255,6 +255,16 @@ TODO: {
 }
 
 TODO: {
+    todo_skip "Test needs -DDEBUGGING", 1 unless $is_debugging_build;
+    local $::TODO = 'GH 16863';
+    fresh_perl(<<~'HERE', { stderr => 'devnull' });
+        END { exit 0 }
+        00.=my$0=00.0
+        HERE
+    is($?, 0, 'No assertion failure; GH 16863');
+}
+
+TODO: {
     local $::TODO = 'GH 16865';
     fresh_perl('\(sort { 0 } 0, 0 .. "a")', { stderr => 'devnull' });
     is($?, 0, "No assertion failure; GH 16865");


### PR DESCRIPTION
This PR adds a todo test for #16863. It tests that perl can parse '00.=my$0=00.0' without encountering an assertion failure. The test still appears to fail.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
