### PR TITLE
Document STATIC_ASSERT; add STATIC_ASSERT_EXPR

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -315,15 +315,17 @@
 : like 'int' or 'char', and 'cast' by perhaps 'struct foo'.
 :
 : The complete list of conventions is:
-:  block    the argument is a C brace-enclosed block
-:  cast     the argument names a type which the macro casts to
-:  number   the argument is a C numeric constant, like 3
-:  SP       the argument is the stack pointer, SP
-:  "string" the argument is a literal C double-quoted string; what's important
-:	    here are the quotes; for clarity, you can say whatever you want
-:	    inside them
-:  token    the argument is a generic C preprocessor token, like abc
-:  type     the argument names a type
+:  block      the argument is a C brace-enclosed block
+:  cast       the argument names a type which the macro casts to
+:  const_expr the argument is an expression whose result is known at compile
+:	      time
+:  number     the argument is a C numeric constant, like 3
+:  SP         the argument is the stack pointer, SP
+:  "string"   the argument is a literal C double-quoted string; what's important
+:	      here are the quotes; for clarity, you can say whatever you want
+:	      inside them
+:  token      the argument is a generic C preprocessor token, like abc
+:  type       the argument names a type
 :
 : Unlike other arguments, none of these is of the form 'int name'.  There is no
 : 'name'.

--- a/embed.fnc
+++ b/embed.fnc
@@ -315,15 +315,15 @@
 : like 'int' or 'char', and 'cast' by perhaps 'struct foo'.
 :
 : The complete list of conventions is:
-:  type     the argument names a type
-:  cast     the argument names a type which the macro casts to
-:  SP       the argument is the stack pointer, SP
 :  block    the argument is a C brace-enclosed block
+:  cast     the argument names a type which the macro casts to
 :  number   the argument is a C numeric constant, like 3
-:  token    the argument is a generic C preprocessor token, like abc
+:  SP       the argument is the stack pointer, SP
 :  "string" the argument is a literal C double-quoted string; what's important
 :	    here are the quotes; for clarity, you can say whatever you want
 :	    inside them
+:  token    the argument is a generic C preprocessor token, like abc
+:  type     the argument names a type
 :
 : Unlike other arguments, none of these is of the form 'int name'.  There is no
 : name.

--- a/embed.fnc
+++ b/embed.fnc
@@ -326,7 +326,7 @@
 :  type     the argument names a type
 :
 : Unlike other arguments, none of these is of the form 'int name'.  There is no
-: name.
+: 'name'.
 :
 : If any argument or return value is not one of the above, and isn't legal C
 : language, the entry still can be specified, using the 'u' flag.

--- a/perl.h
+++ b/perl.h
@@ -4309,18 +4309,31 @@ function or at file scope (outside of any function).
  * We use a bit-field instead of an array because gcc accepts
         typedef char x[n]
    where n is not a compile-time constant.  We want to enforce constantness.
-*/
-#  define STATIC_ASSERT_2(COND, SUFFIX) \
-    typedef struct { \
-        unsigned int _static_assertion_failed_##SUFFIX : (COND) ? 1 : -1; \
-    } _static_assertion_failed_##SUFFIX PERL_UNUSED_DECL
-#  define STATIC_ASSERT_1(COND, SUFFIX) STATIC_ASSERT_2(COND, SUFFIX)
-#  define STATIC_ASSERT_DECL(COND)    STATIC_ASSERT_1(COND, __LINE__)
+ *
+ * We need the FOOL macros to get proper cpp parameter concatanation. */
+#  define STATIC_ASSERT_STRUCT_NAME_FOOL_CPP_2_(line)                       \
+                                 static_assertion_failed_##line
+#  define STATIC_ASSERT_STRUCT_NAME_FOOL_CPP_(line)                         \
+                                STATIC_ASSERT_STRUCT_NAME_FOOL_CPP_2_(line)
+    /* Return the struct and element name */
+#  define STATIC_ASSERT_STRUCT_NAME_                                        \
+                            STATIC_ASSERT_STRUCT_NAME_FOOL_CPP_(__LINE__)
+
+    /* Return the struct body */
+#  define STATIC_ASSERT_STRUCT_BODY_(COND, NAME)                            \
+                              struct { unsigned NAME : (COND) ? 1 : -1; }
+
+#  define STATIC_ASSERT_DECL(COND)                                          \
+     typedef STATIC_ASSERT_STRUCT_BODY_(COND, STATIC_ASSERT_STRUCT_NAME_)   \
+                    STATIC_ASSERT_STRUCT_NAME_ PERL_UNUSED_DECL
+
 #endif
+
 /* We need this wrapper even in C11 because 'case X: static_assert(...);' is an
    error (static_assert is a declaration, and only statements can have labels).
 */
-#define STATIC_ASSERT_STMT(COND)      STMT_START { STATIC_ASSERT_DECL(COND); } STMT_END
+#define STATIC_ASSERT_STMT(COND)                                            \
+                        STMT_START { STATIC_ASSERT_DECL(COND); } STMT_END
 
 #ifndef __has_builtin
 #  define __has_builtin(x) 0 /* not a clang style compiler */

--- a/perl.h
+++ b/perl.h
@@ -4282,9 +4282,33 @@ function or at file scope (outside of any function).
 */
 #  define STATIC_ASSERT_DECL(COND) static_assert(COND, #COND)
 #else
-/* We use a bit-field instead of an array because gcc accepts
-   'typedef char x[n]' where n is not a compile-time constant.
-   We want to enforce constantness.
+
+/* This generates a struct with a bit field like so:
+ *
+ *      struct { unsigned int name#: size; } name#
+ *
+ * 'name#' is the name followed by the line number this is used on.  The
+ * name is 'static_assertion_failed_', so that a typical name would be
+ *
+ *      static_assertion_failed_123
+ *
+ * The first name# will show up in the compiler's error message, clueing in the
+ * reader as to the problem and where.  The second one makes sure that the
+ * struct name is unique to the compilation unit.
+ *
+ * 'size' is expressed as a ternary: '((cond) ? 1 : -1)'
+ *
+ * If 'cond' is true the size is 1, which is legal; if false, the size is -1.
+ * It is illegal to have a negatively-sized bit field, so the compilation will
+ * abort iff 'cond' is false, giving an appropriate error message.
+ *
+ * The basic struct is used in different ways depending on whether the
+ * application is for a declaration (typedef struct), or statement
+ * (STMT_START { struct } STMT_END).
+ *
+ * We use a bit-field instead of an array because gcc accepts
+        typedef char x[n]
+   where n is not a compile-time constant.  We want to enforce constantness.
 */
 #  define STATIC_ASSERT_2(COND, SUFFIX) \
     typedef struct { \

--- a/perl.h
+++ b/perl.h
@@ -4250,17 +4250,27 @@ hint to the compiler that this condition is likely to be false.
 /* placeholder */
 #endif
 
-/* STATIC_ASSERT_DECL/STATIC_ASSERT_STMT are like assert(), but for compile
-   time invariants. That is, their argument must be a constant expression that
-   can be verified by the compiler. This expression can contain anything that's
-   known to the compiler, e.g. #define constants, enums, or sizeof (...). If
-   the expression evaluates to 0, compilation fails.
-   Because they generate no runtime code (i.e.  their use is "free"), they're
-   always active, even under non-DEBUGGING builds.
-   STATIC_ASSERT_DECL expands to a declaration and is suitable for use at
-   file scope (outside of any function).
-   STATIC_ASSERT_STMT expands to a statement and is suitable for use inside a
-   function.
+/*
+=for apidoc   Am||STATIC_ASSERT_DECL|const_expr
+=for apidoc_item  STATIC_ASSERT_STMT
+
+These are like assert(), but for compile time invariants. That is, their
+argument must be a constant expression that can be verified by the compiler.
+This expression can contain anything that's known to the compiler, e.g. #define
+constants, enums, or sizeof (...). If the expression evaluates to 0,
+compilation fails.
+
+Because they generate no runtime code (i.e.  their use is "free"), they're
+always active, even under non-DEBUGGING builds.
+
+C<STATIC_ASSERT_STMT> expands to a statement and is suitable for use inside a
+function.
+
+C<STATIC_ASSERT_DECL> expands to a declaration and is suitable for use inside a
+function or at file scope (outside of any function).
+
+=cut
+
 */
 #if (! defined(__IBMC__) || __IBMC__ >= 1210)                               \
  && ((   defined(static_assert) && (   defined(_ISOC11_SOURCE)              \

--- a/perl.h
+++ b/perl.h
@@ -4252,6 +4252,7 @@ hint to the compiler that this condition is likely to be false.
 
 /*
 =for apidoc   Am||STATIC_ASSERT_DECL|const_expr
+=for apidoc_item  STATIC_ASSERT_EXPR
 =for apidoc_item  STATIC_ASSERT_STMT
 
 These are like assert(), but for compile time invariants. That is, their
@@ -4269,9 +4270,22 @@ function.
 C<STATIC_ASSERT_DECL> expands to a declaration and is suitable for use inside a
 function or at file scope (outside of any function).
 
-=cut
+C<STATIC_ASSERT_EXPR> expands to an expression and is suitable anywhere an
+expression is usable.  It has some limitations compared to the other two when
+used on a platform without L</C<PERL_USE_GCC_BRACE_GROUPS>>.  On those
+platforms it expands to an ASSUME().  When called with a compile-time
+expression, the compiler should optimize out the expression, so that the use of
+this is "free", but constness is not enforced.  On non-DEBUGGING builds, this
+will expand to a no-op, so again it is "free", but no checking is done.
 
+Thus code that uses this macro can be ported to all platforms without needing
+to change, and it will work as well as is possible on that platform.
+Presumably it will get compiled at some point before release on a platform
+where it has parity with the other two forms.
+
+=cut
 */
+
 #if (! defined(__IBMC__) || __IBMC__ >= 1210)                               \
  && ((   defined(static_assert) && (   defined(_ISOC11_SOURCE)              \
                                     || (__STDC_VERSION__ - 0) >= 201101L))  \
@@ -4334,6 +4348,12 @@ function or at file scope (outside of any function).
 */
 #define STATIC_ASSERT_STMT(COND)                                            \
                         STMT_START { STATIC_ASSERT_DECL(COND); } STMT_END
+
+#ifdef PERL_USE_GCC_BRACE_GROUPS
+#  define STATIC_ASSERT_EXPR(COND) ({ STATIC_ASSERT_DECL(COND); })
+#else
+#  define STATIC_ASSERT_EXPR(COND)  ASSUME(COND)
+#endif
 
 #ifndef __has_builtin
 #  define __has_builtin(x) 0 /* not a clang style compiler */

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -383,6 +383,17 @@ now make use of the new function to streamline the process.
 C<Perl_newSVsv_flags> is now essentially a NULL pointer check and wrapper
 around the new function, so has been moved into F<sv_inline.h>.
 
+=item *
+
+L<perlapi/C<STATIC_ASSERT_DECL>> and C<STATIC_ASSERT_STMT> are like
+C<assert()>, but are evaluated at compile time.  That means their
+argument must be a constant expression that can be verified by the
+compiler, and so they effectively have no cost, not appearing in the
+code that gets executed.  These were added in v5.28, but not until now
+have we opened their use up to XS writers.  At the same time, a new
+variant has been added, C<STATIC_ASSERT_EXPR> which is suitable for use
+in an expression, such as a comma expression in a C macro.
+
 =back
 
 =head1 Selected Bug Fixes


### PR DESCRIPTION
The STATIC_ASSERT macros are useful and have been stable for long enough to be made API.

This also adds `STATIC_ASSERT_EXPR` suitable for use in macros.  It doesn't achieve parity with the others except on systems where gcc brace groups are used, falling back to less or no checking otherwise.  But that's good enough to be useful and any problems will be caught when the code is attempted to be compiled on a brace group platform.

* This set of changes requires a perldelta entry, which is included

