### PR TITLE
todo test for GH 16869 (Assertion failure in glob3)

### DIFF
--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -262,6 +262,16 @@ TODO: {
 
 TODO: {
     todo_skip "Test needs -DDEBUGGING", 1 unless $is_debugging_build;
+    local $::TODO = 'GH 16869';
+    fresh_perl(<<~'HERE', {});
+        my $glob = ("0" x 4094) . "?";
+        glob $glob;
+        HERE
+    is($?, 0, 'No assertion failure; GH 16869');
+}
+
+TODO: {
+    todo_skip "Test needs -DDEBUGGING", 1 unless $is_debugging_build;
     local $::TODO = 'GH 16876';
     fresh_perl('$_ = "a"; s{ x | (?{ s{}{x} }) }{}gx;',
                { stderr => 'devnull' });


### PR DESCRIPTION
This PR adds a todo test for #16869. It tests that glob does not encounter an assertion failure when globbing a 4095-byte long pattern. This test still appears to fail.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
