### PR TITLE
Time::HiRes::sleep: use (;$) prototype, like CORE::sleep

### DIFF
--- a/dist/Time-HiRes/Changes
+++ b/dist/Time-HiRes/Changes
@@ -19,6 +19,7 @@ Revision history for the Perl extension Time::HiRes.
    build failures with MSVC.
  - don't try to suppress C++ compatibility warnings in C++ builds, since
    that warns.
+ - Fix sleep's prototype to match CORE::sleep (;$).
 
 1.9764 [2020-08-10]
  - Fix a bunch of repeated-word typos

--- a/dist/Time-HiRes/HiRes.pm
+++ b/dist/Time-HiRes/HiRes.pm
@@ -50,7 +50,7 @@ our @EXPORT_OK = qw (usleep sleep ualarm alarm gettimeofday time tv_interval
                  stat lstat utime
                 );
 
-our $VERSION = '1.9778';
+our $VERSION = '1.9779';
 our $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 

--- a/dist/Time-HiRes/HiRes.xs
+++ b/dist/Time-HiRes/HiRes.xs
@@ -1019,6 +1019,7 @@ nanosleep(nsec)
 
 NV
 sleep(...)
+PROTOTYPE: ;$
     PREINIT:
         struct timeval Ta, Tb;
     CODE:

--- a/dist/Time-HiRes/t/alarm.t
+++ b/dist/Time-HiRes/t/alarm.t
@@ -11,9 +11,9 @@ use Config;
 my $limit = 0.25; # 25% is acceptable slosh for testing timers
 
 my $xdefine = '';
-if (open(XDEFINE, "<", "xdefine")) {
-    chomp($xdefine = <XDEFINE> || "");
-    close(XDEFINE);
+if (open(my $fh, "<", "xdefine")) {
+    chomp($xdefine = <$fh> || "");
+    close($fh);
 }
 
 my $can_subsecond_alarm =
@@ -224,5 +224,3 @@ SKIP: {
         ok $got == 0 or print("# $got\n");
     }
 }
-
-1;

--- a/dist/Time-HiRes/t/clock.t
+++ b/dist/Time-HiRes/t/clock.t
@@ -97,5 +97,3 @@ SKIP: {
         $clock[2] > $clock[1] &&
         $clock[3] > $clock[2];
 }
-
-1;

--- a/dist/Time-HiRes/t/gettimeofday.t
+++ b/dist/Time-HiRes/t/gettimeofday.t
@@ -30,5 +30,3 @@ ok $f - $two[0] < 2 or print("# $f - $two[0] >= 2\n");
 my $r = [Time::HiRes::gettimeofday()];
 my $g = Time::HiRes::tv_interval $r;
 ok $g < 2 or print("# $g\n");
-
-1;

--- a/dist/Time-HiRes/t/itimer.t
+++ b/dist/Time-HiRes/t/itimer.t
@@ -66,5 +66,3 @@ print("# at end, i=$i\n");
 is($virt, 0, "time left should be zero");
 
 $SIG{VTALRM} = 'DEFAULT';
-
-1;

--- a/dist/Time-HiRes/t/nanosleep.t
+++ b/dist/Time-HiRes/t/nanosleep.t
@@ -34,5 +34,3 @@ SKIP: {
     skip "flapping test - more than 0.9 sec could be necessary...", 1 if $ENV{CI};
     cmp_ok $d, '<', 0.9 or diag("# slept $d secs $f to $f2\n");
 }
-
-1;

--- a/dist/Time-HiRes/t/sleep.t
+++ b/dist/Time-HiRes/t/sleep.t
@@ -15,9 +15,9 @@ SKIP: {
 }
 
 my $xdefine = '';
-if (open(XDEFINE, "<", "xdefine")) {
-    chomp($xdefine = <XDEFINE> || "");
-    close(XDEFINE);
+if (open(my $fh, "<", "xdefine")) {
+    chomp($xdefine = <$fh> || "");
+    close($fh);
 }
 
 my $can_subsecond_alarm =

--- a/dist/Time-HiRes/t/sleep.t
+++ b/dist/Time-HiRes/t/sleep.t
@@ -1,12 +1,18 @@
 use strict;
 
-use Test::More tests => 4;
+use Test::More tests => 5;
 BEGIN { push @INC, '.' }
 use t::Watchdog;
 
 BEGIN { require_ok "Time::HiRes"; }
 
 use Config;
+
+SKIP: {
+    skip "no hi-res sleep", 1 unless defined &Time::HiRes::sleep;
+    is prototype(\&Time::HiRes::sleep), prototype('CORE::sleep'),
+        "Time::HiRes::sleep's prototype matches CORE::sleep's";
+}
 
 my $xdefine = '';
 if (open(XDEFINE, "<", "xdefine")) {
@@ -35,5 +41,3 @@ SKIP: {
     printf("# sleep...%s\n", Time::HiRes::tv_interval($r));
     ok 1;
 }
-
-1;

--- a/dist/Time-HiRes/t/stat.t
+++ b/dist/Time-HiRes/t/stat.t
@@ -22,9 +22,9 @@ my @mtime;
 for (1..5) {
     note "cycle $_";
     Time::HiRes::sleep(rand(0.1) + 0.1);
-    open(X, '>', $$);
-    print X $$;
-    close(X);
+    open(my $fh, '>', $$);
+    print $fh $$;
+    close($fh);
     my($a, $stat, $b) = ("a", [Time::HiRes::stat($$)], "b");
     is $a, "a", "stat stack discipline";
     is $b, "b", "stat stack discipline";
@@ -43,9 +43,9 @@ for (1..5) {
         }
         is_deeply $lstat, $stat, "write: stat and lstat returned same values";
         Time::HiRes::sleep(rand(0.1) + 0.1);
-        open(X, '<', $$);
-        <X>;
-        close(X);
+        open(my $fh, '<', $$);
+        <$fh>;
+        close($fh);
         $stat = [Time::HiRes::stat($$)];
         push @atime, $stat->[8];
         $lstat = [Time::HiRes::lstat($$)];
@@ -88,9 +88,9 @@ SKIP: {
 my $targetname = "tgt$$";
 my $linkname = "link$$";
 SKIP: {
-    open(X, '>', $targetname);
-    print X $$;
-    close(X);
+    open(my $fh, '>', $targetname);
+    print $fh $$;
+    close($fh);
     eval { symlink $targetname, $linkname or die "can't symlink: $!"; };
     skip "can't symlink", 7 if $@ ne "";
     note "compare Time::HiRes::stat with ::lstat";
@@ -111,5 +111,3 @@ SKIP: {
 }
 1 while unlink $linkname;
 1 while unlink $targetname;
-
-1;

--- a/dist/Time-HiRes/t/time.t
+++ b/dist/Time-HiRes/t/time.t
@@ -1,10 +1,16 @@
 use strict;
 
-use Test::More tests => 2;
+use Test::More tests => 3;
 BEGIN { push @INC, '.' }
 use t::Watchdog;
 
 BEGIN { require_ok "Time::HiRes"; }
+
+SKIP: {
+    skip "no hi-res time", 1 unless defined &Time::HiRes::time;
+    is prototype(\&Time::HiRes::time), prototype('CORE::time'),
+        "Time::HiRes::time's prototype matches CORE::time's";
+}
 
 SKIP: {
     skip "no gettimeofday", 1 unless &Time::HiRes::d_gettimeofday;
@@ -20,5 +26,3 @@ SKIP: {
         or print("# Time::HiRes::time() not close to CORE::time()\n");
     printf("# s = $s, n = $n, s/n = %s\n", abs($s)/$n);
 }
-
-1;

--- a/dist/Time-HiRes/t/tv_interval.t
+++ b/dist/Time-HiRes/t/tv_interval.t
@@ -6,5 +6,3 @@ BEGIN { require_ok "Time::HiRes"; }
 
 my $f = Time::HiRes::tv_interval [5, 100_000], [10, 500_000];
 ok abs($f - 5.4) < 0.001 or print("# $f\n");
-
-1;

--- a/dist/Time-HiRes/t/ualarm.t
+++ b/dist/Time-HiRes/t/ualarm.t
@@ -109,5 +109,3 @@ for my $n (100_000, 1_100_000, 2_200_000, 4_300_000) {
     my $got2 = Time::HiRes::ualarm(0);
     ok $got2 == 0 or print("# $got2\n");
 }
-
-1;

--- a/dist/Time-HiRes/t/usleep.t
+++ b/dist/Time-HiRes/t/usleep.t
@@ -75,5 +75,3 @@ SKIP: {
         ok $a < $limit or print("# $msg\n");
     }
 }
-
-1;

--- a/dist/Time-HiRes/t/utime.t
+++ b/dist/Time-HiRes/t/utime.t
@@ -248,5 +248,3 @@ print "# negative mtime dies;\n";
 };
 
 done_testing();
-
-1;

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -125,9 +125,21 @@ XXX Remove this section if F<Porting/corelist-perldelta.pl> did not add any cont
 
 =item *
 
-L<XXX> has been upgraded from version A.xx to B.yy.
+L<Time::HiRes> has been upgraded from version 1.9778 to 1.9779.
 
-XXX If there was something important to note about this change, include that here.
+The subsecond-resolution C<sleep> function provided by L<Time::HiRes> now has
+the same prototype as perl's built-in L<sleep function|perlfunc/sleep>. This
+means it now requires a scalar argument, not a list, just like C<CORE::sleep>:
+
+    use Time::HiRes qw(sleep);
+
+    sleep(1, "foo", "bar");  # Syntax error.
+    # It used to silently ignore the extra arguments.
+
+    my @t = 42;
+    sleep @t;
+    # Evaluates @t in scalar context (giving the number of elements)
+    # and sleeps for one second. It used to sleep for 42 seconds.
 
 =back
 


### PR DESCRIPTION
Time::HiRes::sleep is supposed to be a drop-in replacement for CORE::sleep, but before this patch Time::HiRes::sleep had no prototype, leading to the following incompatibilities:
    
```perl
CORE::sleep(1, "foo", "bar");  # syntax error
Time::HiRes::sleep(1, "foo", "bar");  # OK, ignores all but 1st argument

my @t = 42;
CORE::sleep @t;  # sleeps for one second (number of elements in @t)
Time::HiRes::sleep @t;  # sleeps for 42 seconds (@t in list context)

CORE::sleep 1, next if $foo;
# if $foo, then sleep for one second and start next loop iteration

Time::HiRes::sleep 1, next if $foo;
# parses as: Time::HiRes::sleep(1, next) if $foo;
# if $foo, then start next loop iteration; no delay
```

Fixes #23628.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes requires a perldelta entry, and it is included.
