### PR TITLE
z/OS does not use Shmat_t

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -599,6 +599,7 @@ Ian Phillipps                  <Ian.Phillipps@iname.com>
 Ichinose Shogo                 <shogo82148@gmail.com>
 Ignasi Roca Carrió             <ignasi.roca@fujitsu-siemens.com>
 Igor Sutton                    <izut@cpan.org>
+Igor Todorovski                <itodorov@ca.ibm.com>
 Igor Zaytsev                   <igor.zaytsev@gmail.com>
 Ilmari Karonen                 <iltzu@sci.fi>
 Ilya Martynov                  <ilya@martynov.org>

--- a/doio.c
+++ b/doio.c
@@ -35,7 +35,7 @@
 #endif
 #ifdef HAS_SHM
 #include <sys/shm.h>
-# ifndef HAS_SHMAT_PROTOTYPE
+# if ! defined(HAS_SHMAT_PROTOTYPE) && ! defined(__MVS__)
     extern Shmat_t shmat (int, char *, int);
 # endif
 #endif


### PR DESCRIPTION

* This set of changes does not require a perldelta entry.
