### PR TITLE
op/magic.t: Pass more common parameter to ps

### DIFF
--- a/t/op/magic.t
+++ b/t/op/magic.t
@@ -930,7 +930,7 @@ SKIP: {
             $0 = $arg if defined $arg;
             # In FreeBSD the ps -o command= will cause
             # an empty header line, grab only the last line.
-            my $ps = (`ps -o command= -p $$ 2>&1`)[-1];
+            my $ps = (`ps -o command= -pid $$ 2>&1`)[-1];
             return if $?;
             chomp $ps;
             $ps;


### PR DESCRIPTION
-p is an abbreviation that isn't as widely used as -pid

* This set of changes does not require a perldelta entry.
