### PR TITLE
Add __attribute__nonnull__() for non-DEBUGGING builds

### DIFF
--- a/cflags.SH
+++ b/cflags.SH
@@ -184,11 +184,20 @@ Intel*) ;; # # Is that you, Intel C++?
 # NOTE 3: the relative order of these options matters:
 # -Wextra before -Wno-long-long -Wno-declaration-after-statement
 #
+# NOTE 4: If a function has __attribute__nonnull__(n), gcc generates many
+#         warnings for macros that have the generality to check for NULLness on
+#         parameter n.  We could write versions of those macros that eliminate
+#         that check, but why?.  It complicates our code and gains no
+#         perceptible performance except in very hot code that the compiler
+#         has chosen to not optimize away.  So turn these off with
+#         -Wno-nonnull-compare
+
 *) warns="$pedantic \
 	-Werror=pointer-arith \
 	-Werror=vla \
 	-Wextra \
 	-Wno-long-long -Wno-declaration-after-statement \
+        -Wno-nonnull-compare \
 	-Wc++-compat -Wwrite-strings"
    case " $ccflags " in
    *" -std="*) ;; # Already have -std=...
@@ -296,7 +305,7 @@ case "$gccversion" in
 *"Apple LLVM "[34]*|*"Apple LLVM version "[34]*)
   for f in -Wno-unused-value
   do
-    echo "cflags.SH: Adding $f because clang version '$gccversion'" 
+    echo "cflags.SH: Adding $f because clang version '$gccversion'"
     warn="$warn $f"
   done
   ;;
@@ -505,3 +514,4 @@ done
 !NO!SUBS!
 chmod 755 cflags
 $eunicefix cflags
+

--- a/dump.c
+++ b/dump.c
@@ -984,18 +984,19 @@ S_do_pmop_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const PMOP *pm,
     S_opdump_indent(aTHX_ (OP*)pm, level, bar, file,
                     "PMOFFSET = %" IVdf "\n", (IV)pm->op_pmoffset);
 #endif
+    REGEXP * re = PM_GETRE(pm);
     S_opdump_indent(aTHX_ (OP*)pm, level, bar, file,
-                    "REGEX = 0x%" UVxf "\n", PTR2UV(PM_GETRE(pm)));
+                    "REGEX = 0x%" UVxf "\n", PTR2UV(re));
 
-    if (PM_GETRE(pm)) {
+    if (re) {
         char ch = (pm->op_pmflags & PMf_ONCE) ? '?' : '/';
         S_opdump_indent(aTHX_ (OP*)pm, level, bar, file, "PMf_PRE %c%.*s%c\n",
-             ch,(int)RX_PRELEN(PM_GETRE(pm)), RX_PRECOMP(PM_GETRE(pm)), ch);
+             ch,(int)RX_PRELEN(re), RX_PRECOMP(re), ch);
     }
     else
         S_opdump_indent(aTHX_ (OP*)pm, level, bar, file, "PMf_PRE (RUNTIME)\n");
 
-    if (pm->op_pmflags || PM_GETRE(pm)) {
+    if (pm->op_pmflags || re) {
         SV * const tmpsv = pm_description(pm);
         S_opdump_indent(aTHX_ (OP*)pm, level, bar, file, "PMFLAGS = (%s)\n",
                         SvCUR(tmpsv) ? SvPVX_const(tmpsv) + 1 : "");

--- a/embed.fnc
+++ b/embed.fnc
@@ -158,8 +158,11 @@
 :   'foo()', the generated macro will be named 'PERL_ARGS_ASSERT_FOO'.  You
 :   should place a call to that macro in foo() before any other code.  It will
 :   automatically expand to whatever checking is currently generated for 'foo'
-:   (often none).  These are in the form of assert() calls, so they are only
-:   activated for DEBUGGING builds.
+:   (often none).  These are mostly in the form of assert() calls, so they are
+:   only activated for DEBUGGING builds.  But for non-DEBUGGING builds, pointer
+:   parameters that must not point to NULL have a compiler directive that means
+:   the same as GCC and Clang's '__attribute__nonnull__' generated for them for
+:   compilers that we know understand it.
 :
 :   Currently, it is optional to include an empty ARGS_ASSERT macro in your
 :   functions.  But a porting test enforces that a non-empty one does get

--- a/embed.h
+++ b/embed.h
@@ -33,6 +33,8 @@
 #   undef isIDCONT_lazy_if_safe
 #   undef new_XPV
 #   undef new_XPVIV
+#   undef pTHX_10
+#   undef pTHX_11
 #   undef SHY_NATIVE
 #   undef sv_2num
 #   undef SvRVx

--- a/op.c
+++ b/op.c
@@ -2101,8 +2101,9 @@ Perl_scalar(pTHX_ OP *o)
 
             kid = cLISTOPo->op_first;
             kid = OpSIBLING(kid); /* get past pushmark */
-            assert(OpSIBLING(kid));
-            name = op_varname(OpSIBLING(kid));
+            OP *sibling = OpSIBLING(kid);
+            assert(sibling);
+            name = op_varname(sibling);
             if (!name) /* XS module fiddling with the op tree */
                 break;
             warn_elem_scalar_context(kid, name, o->op_type == OP_KVHSLICE, false);

--- a/op.c
+++ b/op.c
@@ -8071,11 +8071,13 @@ Perl_pmruntime(pTHX_ OP *o, OP *expr, OP *repl, UV flags, I32 floor)
             konst = TRUE;
         }
         else konst = FALSE;
-        if (konst
-            && !(repl_has_vars
-                 && (!PM_GETRE(pm)
-                     || !RX_PRELEN(PM_GETRE(pm))
-                     || RX_EXTFLAGS(PM_GETRE(pm)) & RXf_EVAL_SEEN)))
+
+        REGEXP * re;
+        if (     konst
+            && ! (   repl_has_vars
+                  &&   (  ! (re = PM_GETRE(pm))
+                         || ! RX_PRELEN(re)
+                         || (RX_EXTFLAGS(re) & RXf_EVAL_SEEN))))
         {
             pm->op_pmflags |= PMf_CONST;	/* const for long enough */
             op_prepend_elem(o->op_type, scalar(repl), o);

--- a/op.h
+++ b/op.h
@@ -304,12 +304,12 @@ struct pmop {
  * processing or asserts */
 #ifdef USE_ITHREADS
 #define PM_GETRE_raw(o)	(REGEXP*)(PL_regex_pad[(o)->op_pmoffset])
-#define PM_GETRE(o)	(SvTYPE(PL_regex_pad[(o)->op_pmoffset]) == SVt_REGEXP \
-                         ? (REGEXP*)(PL_regex_pad[(o)->op_pmoffset]) : NULL)
+#define PM_GETRE(o)	(SvTYPE(PM_GETRE_raw(o)) == SVt_REGEXP      \
+                         ? PM_GETRE_raw(o) : NULL)
 
-#define PM_SETRE_raw(o,r)	STMT_START {					\
-                            PL_regex_pad[(o)->op_pmoffset] = MUTABLE_SV(r); \
-                        } STMT_END
+#define PM_SETRE_raw(o,r)  STMT_START {					     \
+                              PL_regex_pad[(o)->op_pmoffset] = MUTABLE_SV(r);\
+                           } STMT_END
 /* The assignment is just to enforce type safety (or at least get a warning).
  */
 /* With first class regexps not via a reference one needs to assign
@@ -321,13 +321,13 @@ struct pmop {
 #define PM_SETRE(o,r)	STMT_START {					\
                             REGEXP *const pm_setre_ = (r);		\
                             assert(pm_setre_);				\
-                            PL_regex_pad[(o)->op_pmoffset] = MUTABLE_SV(pm_setre_); \
+                            PM_SETRE_raw(o, pm_setre_);                 \
                         } STMT_END
 #else
 #define PM_GETRE_raw(o) ((o)->op_pmregexp)
-#define PM_GETRE(o)     ((o)->op_pmregexp)
+#define PM_GETRE(o)     PM_GETRE_raw(o)
 #define PM_SETRE_raw(o,r) ((o)->op_pmregexp = (r))
-#define PM_SETRE(o,r)   ((o)->op_pmregexp = (r))
+#define PM_SETRE(o,r)   PM_SETRE_raw(o,r)
 #endif
 
 /* Currently these PMf flags occupy a single 32-bit word.  Not all bits are

--- a/peep.c
+++ b/peep.c
@@ -76,8 +76,9 @@ S_scalar_slice_warning(pTHX_ const OP *o)
     if (kid->op_type == OP_NULL && kid->op_targ == OP_LIST)
         return;
 
-    assert(OpSIBLING(kid));
-    name = op_varname(OpSIBLING(kid));
+    OP *varop = OpSIBLING(kid);
+    assert(varop);
+    name = op_varname(varop);
     if (!name) /* XS module fiddling with the op tree */
         return;
     warn_elem_scalar_context(kid, name, is_hash, true);
@@ -754,7 +755,9 @@ S_maybe_multiconcat(pTHX_ OP *o)
         lastkidop = cLISTOPx(topop)->op_last;
         kid = cUNOPx(topop)->op_first; /* pushmark */
         op_null(kid);
-        op_null(OpSIBLING(kid));       /* const */
+        OP * const const_op = OpSIBLING(kid);
+        ASSUME(const_op);
+        op_null(const_op);       /* const */
         if (o != topop) {
             kid = op_sibling_splice(topop, NULL, -1, NULL); /* cut all args */
             op_sibling_splice(o, NULL, 0, kid); /* and attach to o */

--- a/perl.h
+++ b/perl.h
@@ -238,6 +238,8 @@ Now a synonym for C<L</dTHXa>>.
 #  define pTHX_7	8
 #  define pTHX_8	9
 #  define pTHX_9	10
+#  define pTHX_10	11
+#  define pTHX_11	12
 #  define pTHX_12	13
 #  if defined(DEBUGGING) && !defined(PERL_TRACK_MEMPOOL)
 #    define PERL_TRACK_MEMPOOL
@@ -731,6 +733,8 @@ code.
 #  define pTHX_7	7
 #  define pTHX_8	8
 #  define pTHX_9	9
+#  define pTHX_10	10
+#  define pTHX_11	11
 #  define pTHX_12	12
 #endif
 

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -172,7 +172,7 @@ PP(pp_regcomp)
     }
 
     /* handle the empty pattern */
-    if (!RX_PRELEN(PM_GETRE(pm)) && PL_curpm) {
+    if (!RX_PRELEN(new_re) && PL_curpm) {
         if (PL_curpm == PL_reg_curpm) {
             if (PL_curpm_under && PL_curpm_under == PL_reg_curpm) {
                 croak("Infinite recursion via empty pattern");

--- a/proto.h
+++ b/proto.h
@@ -25,31 +25,42 @@
 #  define Perl_attribute_nonnull_(which)  __attribute__nonnull__(which)
 #endif
 
+#if defined(MULTIPLICITY)
+#  define Perl_attribute_nonnull_aTHX_ __attribute__nonnull__(1)
+#else
+#  define Perl_attribute_nonnull_aTHX_
+#endif
+
 START_EXTERN_C
 
 PERL_CALLCONV int
 Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_AMUPDATE            \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV const char *
-Perl_PerlIO_context_layers(pTHX_ const char *mode);
+Perl_PerlIO_context_layers(pTHX_ const char *mode)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PERLIO_CONTEXT_LAYERS
 
 PERL_CALLCONV int
 Perl_PerlLIO_dup2_cloexec(pTHX_ int oldfd, int newfd)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PERLLIO_DUP2_CLOEXEC
 
 PERL_CALLCONV int
 Perl_PerlLIO_dup_cloexec(pTHX_ int oldfd)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PERLLIO_DUP_CLOEXEC
 
 PERL_CALLCONV int
 Perl_PerlLIO_open3_cloexec(pTHX_ const char *file, int flag, int perm)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -58,6 +69,7 @@ Perl_PerlLIO_open3_cloexec(pTHX_ const char *file, int flag, int perm)
 
 PERL_CALLCONV int
 Perl_PerlLIO_open_cloexec(pTHX_ const char *file, int flag)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -75,7 +87,8 @@ Perl_langinfo8(const nl_item item, utf8ness_t *utf8ness)
         assert(utf8ness)
 
 PERL_CALLCONV HV *
-Perl_localeconv(pTHX);
+Perl_localeconv(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PERL_LOCALECONV
 
 PERL_CALLCONV const char *
@@ -84,20 +97,24 @@ Perl_setlocale(const int category, const char *locale);
 
 PERL_CALLCONV void *
 Perl_Slab_Alloc(pTHX_ size_t sz)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SLAB_ALLOC
 
 PERL_CALLCONV void
 Perl_Slab_Free(pTHX_ void *op)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SLAB_FREE              \
         assert(op)
 
 /* PERL_CALLCONV void
-Perl_SvREFCNT_dec_set_NULL(pTHX_ SV *sv); */
+Perl_SvREFCNT_dec_set_NULL(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV_NO_RET void
 Perl_abort_execution(pTHX_ SV *msg_sv, const char * const name)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__noreturn__
         __attribute__visibility__("hidden");
@@ -106,11 +123,13 @@ Perl_abort_execution(pTHX_ SV *msg_sv, const char * const name)
 
 PERL_CALLCONV LOGOP *
 Perl_alloc_LOGOP(pTHX_ I32 type, OP *first, OP *other)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_ALLOC_LOGOP
 
 PERL_CALLCONV PADOFFSET
 Perl_allocmy(pTHX_ const char * const name, const STRLEN len, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_ALLOCMY                \
@@ -118,12 +137,14 @@ Perl_allocmy(pTHX_ const char * const name, const STRLEN len, const U32 flags)
 
 PERL_CALLCONV bool
 Perl_amagic_applies(pTHX_ SV *sv, int method, int flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AMAGIC_APPLIES         \
         assert(sv)
 
 PERL_CALLCONV SV *
 Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int dir)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_AMAGIC_CALL            \
@@ -131,12 +152,14 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int dir)
 
 PERL_CALLCONV SV *
 Perl_amagic_deref_call(pTHX_ SV *ref, int method)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AMAGIC_DEREF_CALL      \
         assert(ref)
 
 PERL_CALLCONV bool
 Perl_amagic_is_enabled(pTHX_ int method)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AMAGIC_IS_ENABLED
 
@@ -148,6 +171,7 @@ Perl_api_version_assert(size_t interp_size, void *v_my_perl, const char *api_ver
 
 PERL_CALLCONV SSize_t
 Perl_apply(pTHX_ I32 type, SV **mark, SV **sp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
@@ -156,6 +180,7 @@ Perl_apply(pTHX_ I32 type, SV **mark, SV **sp)
 
 PERL_CALLCONV void
 Perl_apply_attrs_string(pTHX_ const char *stashpv, CV *cv, const char *attrstr, STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -166,6 +191,7 @@ Perl_apply_attrs_string(pTHX_ const char *stashpv, CV *cv, const char *attrstr, 
 
 PERL_CALLCONV OP *
 Perl_apply_builtin_cv_attributes(pTHX_ CV *cv, OP *attrlist)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_APPLY_BUILTIN_CV_ATTRIBUTES \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
@@ -184,18 +210,21 @@ Perl_atfork_unlock(void);
 
 PERL_CALLCONV SV **
 Perl_av_arylen_p(pTHX_ AV *av)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_ARYLEN_P            \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_clear(pTHX_ AV *av)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_CLEAR               \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_create_and_push(pTHX_ AV ** const avp, SV * const val)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_AV_CREATE_AND_PUSH     \
@@ -203,6 +232,7 @@ Perl_av_create_and_push(pTHX_ AV ** const avp, SV * const val)
 
 PERL_CALLCONV SV **
 Perl_av_create_and_unshift_one(pTHX_ AV ** const avp, SV * const val)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_AV_CREATE_AND_UNSHIFT_ONE \
@@ -210,17 +240,20 @@ Perl_av_create_and_unshift_one(pTHX_ AV ** const avp, SV * const val)
 
 PERL_CALLCONV SV *
 Perl_av_delete(pTHX_ AV *av, SSize_t key, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_DELETE              \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
-Perl_av_dump(pTHX_ AV *av);
+Perl_av_dump(pTHX_ AV *av)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_AV_DUMP                \
         assert(!av || SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV bool
 Perl_av_exists(pTHX_ AV *av, SSize_t key)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_EXISTS              \
@@ -228,12 +261,14 @@ Perl_av_exists(pTHX_ AV *av, SSize_t key)
 
 PERL_CALLCONV void
 Perl_av_extend(pTHX_ AV *av, SSize_t key)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_EXTEND              \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp, SV ***arrayp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
         Perl_attribute_nonnull_(pTHX_5)
@@ -244,6 +279,7 @@ Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp, SV *
 
 PERL_CALLCONV SV **
 Perl_av_fetch(pTHX_ AV *av, SSize_t key, I32 lval)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_FETCH               \
@@ -251,18 +287,21 @@ Perl_av_fetch(pTHX_ AV *av, SSize_t key, I32 lval)
 
 PERL_CALLCONV void
 Perl_av_fill(pTHX_ AV *av, SSize_t fill)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_FILL                \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV IV *
 Perl_av_iter_p(pTHX_ AV *av)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_ITER_P              \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV SSize_t
 Perl_av_len(pTHX_ AV *av)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_LEN                 \
@@ -270,6 +309,7 @@ Perl_av_len(pTHX_ AV *av)
 
 PERL_CALLCONV AV *
 Perl_av_make(pTHX_ SSize_t size, SV **strp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_MAKE                \
@@ -277,6 +317,7 @@ Perl_av_make(pTHX_ SSize_t size, SV **strp)
 
 PERL_CALLCONV SV *
 Perl_av_nonelem(pTHX_ AV *av, SSize_t ix)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AV_NONELEM             \
@@ -284,12 +325,14 @@ Perl_av_nonelem(pTHX_ AV *av, SSize_t ix)
 
 PERL_CALLCONV SV *
 Perl_av_pop(pTHX_ AV *av)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_POP                 \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_push(pTHX_ AV *av, SV *val)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_AV_PUSH                \
@@ -300,6 +343,7 @@ Perl_av_push(pTHX_ AV *av, SV *val)
 
 PERL_CALLCONV SV *
 Perl_av_shift(pTHX_ AV *av)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_SHIFT               \
@@ -307,24 +351,28 @@ Perl_av_shift(pTHX_ AV *av)
 
 PERL_CALLCONV SV **
 Perl_av_store(pTHX_ AV *av, SSize_t key, SV *val)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_STORE               \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_undef(pTHX_ AV *av)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_UNDEF               \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_unshift(pTHX_ AV *av, SSize_t num)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_UNSHIFT             \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV OP *
 Perl_bind_match(pTHX_ I32 type, OP *left, OP *right)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__
@@ -334,47 +382,56 @@ Perl_bind_match(pTHX_ I32 type, OP *left, OP *right)
 
 PERL_CALLCONV OP *
 Perl_block_end(pTHX_ I32 floor, OP *seq)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_BLOCK_END
 
 PERL_CALLCONV U8
 Perl_block_gimme(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_BLOCK_GIMME
 
 PERL_CALLCONV int
 Perl_block_start(pTHX_ int full)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_BLOCK_START
 
 PERL_CALLCONV void
 Perl_blockhook_register(pTHX_ BHK *hk)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_BLOCKHOOK_REGISTER     \
         assert(hk)
 
 PERL_CALLCONV void
 Perl_boot_core_PerlIO(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_BOOT_CORE_PERLIO
 
 PERL_CALLCONV void
 Perl_boot_core_UNIVERSAL(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_BOOT_CORE_UNIVERSAL
 
 PERL_CALLCONV void
 Perl_boot_core_builtin(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_BOOT_CORE_BUILTIN
 
 PERL_CALLCONV void
 Perl_boot_core_mro(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_BOOT_CORE_MRO
 
 PERL_CALLCONV OP *
 Perl_build_infix_plugin(pTHX_ OP *lhs, OP *rhs, void *tokendata)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -386,6 +443,7 @@ Perl_build_infix_plugin(pTHX_ OP *lhs, OP *rhs, void *tokendata)
 
 PERL_CALLCONV int
 Perl_bytes_cmp_utf8(pTHX_ const U8 *b, STRLEN blen, const U8 *u, STRLEN ulen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_BYTES_CMP_UTF8         \
@@ -393,6 +451,7 @@ Perl_bytes_cmp_utf8(pTHX_ const U8 *b, STRLEN blen, const U8 *u, STRLEN ulen)
 
 PERL_CALLCONV U8 *
 Perl_bytes_from_utf8(pTHX_ const U8 *s, STRLEN *lenp, bool *is_utf8p)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -401,6 +460,7 @@ Perl_bytes_from_utf8(pTHX_ const U8 *s, STRLEN *lenp, bool *is_utf8p)
 
 PERL_CALLCONV U8 *
 Perl_bytes_to_utf8_free_me(pTHX_ const U8 *s, STRLEN *lenp, void **free_me)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_BYTES_TO_UTF8_FREE_ME  \
@@ -411,41 +471,48 @@ Perl_c9strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_
 
 PERL_CALLCONV SSize_t
 Perl_call_argv(pTHX_ const char *sub_name, I32 flags, char **argv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_CALL_ARGV              \
         assert(sub_name); assert(argv)
 
 PERL_CALLCONV void
-Perl_call_atexit(pTHX_ ATEXIT_t fn, void *ptr);
+Perl_call_atexit(pTHX_ ATEXIT_t fn, void *ptr)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_CALL_ATEXIT
 
 PERL_CALLCONV void
 Perl_call_list(pTHX_ I32 oldscope, AV *paramList)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_CALL_LIST              \
         assert(paramList); assert(SvTYPE(paramList) == SVt_PVAV)
 
 PERL_CALLCONV SSize_t
 Perl_call_method(pTHX_ const char *methname, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CALL_METHOD            \
         assert(methname)
 
 PERL_CALLCONV SSize_t
 Perl_call_pv(pTHX_ const char *sub_name, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CALL_PV                \
         assert(sub_name)
 
 PERL_CALLCONV SSize_t
 Perl_call_sv(pTHX_ SV *sv, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CALL_SV                \
         assert(sv)
 
 PERL_CALLCONV const PERL_CONTEXT *
-Perl_caller_cx(pTHX_ I32 level, const PERL_CONTEXT **dbcxp);
+Perl_caller_cx(pTHX_ I32 level, const PERL_CONTEXT **dbcxp)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_CALLER_CX
 
 PERL_CALLCONV Malloc_t
@@ -456,6 +523,7 @@ Perl_calloc(MEM_SIZE elements, MEM_SIZE size)
 
 PERL_CALLCONV bool
 Perl_cando(pTHX_ Mode_t mode, bool effective, const Stat_t *statbufp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -484,6 +552,7 @@ Perl_cast_uv(NV f)
 
 PERL_CALLCONV bool
 Perl_check_utf8_print(pTHX_ const U8 *s, const STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CHECK_UTF8_PRINT       \
@@ -491,6 +560,7 @@ Perl_check_utf8_print(pTHX_ const U8 *s, const STRLEN len)
 
 PERL_CALLCONV OP *
 Perl_ck_entersub_args_core(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -500,12 +570,14 @@ Perl_ck_entersub_args_core(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
 
 PERL_CALLCONV OP *
 Perl_ck_entersub_args_list(pTHX_ OP *entersubop)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_LIST  \
         assert(entersubop)
 
 PERL_CALLCONV OP *
 Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -514,6 +586,7 @@ Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
 
 PERL_CALLCONV OP *
 Perl_ck_entersub_args_proto_or_list(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -522,6 +595,7 @@ Perl_ck_entersub_args_proto_or_list(pTHX_ OP *entersubop, GV *namegv, SV *protos
 
 PERL_CALLCONV void
 Perl_ck_warner(pTHX_ U32 err, const char *pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_CK_WARNER              \
@@ -529,6 +603,7 @@ Perl_ck_warner(pTHX_ U32 err, const char *pat, ...)
 
 PERL_CALLCONV void
 Perl_ck_warner_d(pTHX_ U32 err, const char *pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_CK_WARNER_D            \
@@ -536,24 +611,28 @@ Perl_ck_warner_d(pTHX_ U32 err, const char *pat, ...)
 
 PERL_CALLCONV bool
 Perl_ckwarn(pTHX_ U32 w)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_CKWARN
 
 PERL_CALLCONV bool
 Perl_ckwarn_d(pTHX_ U32 w)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_CKWARN_D
 
 PERL_CALLCONV void
 Perl_clear_defarray(pTHX_ AV *av, bool abandon)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CLEAR_DEFARRAY         \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV const COP *
 Perl_closest_cop(pTHX_ const COP *cop, const OP *o, const OP *curop, bool opnext)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CLOSEST_COP            \
@@ -561,6 +640,7 @@ Perl_closest_cop(pTHX_ const COP *cop, const OP *o, const OP *curop, bool opnext
 
 PERL_CALLCONV OP *
 Perl_cmpchain_extend(pTHX_ I32 type, OP *ch, OP *right)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -569,6 +649,7 @@ Perl_cmpchain_extend(pTHX_ I32 type, OP *ch, OP *right)
 
 PERL_CALLCONV OP *
 Perl_cmpchain_finish(pTHX_ OP *ch)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -577,6 +658,7 @@ Perl_cmpchain_finish(pTHX_ OP *ch)
 
 PERL_CALLCONV OP *
 Perl_cmpchain_start(pTHX_ I32 type, OP *left, OP *right)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CMPCHAIN_START
@@ -585,30 +667,35 @@ Perl_cmpchain_start(pTHX_ I32 type, OP *left, OP *right)
 
 PERL_CALLCONV void
 Perl_cop_disable_warning(pTHX_ COP *cop, int warn_bit)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_DISABLE_WARNING    \
         assert(cop)
 
 PERL_CALLCONV void
 Perl_cop_enable_warning(pTHX_ COP *cop, int warn_bit)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_ENABLE_WARNING     \
         assert(cop)
 
 PERL_CALLCONV const char *
 Perl_cop_fetch_label(pTHX_ COP * const cop, STRLEN *len, U32 *flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_FETCH_LABEL        \
         assert(cop)
 
 PERL_CALLCONV bool
 Perl_cop_has_warning(pTHX_ const COP *cop, int warn_bit)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_HAS_WARNING        \
         assert(cop)
 
 PERL_CALLCONV void
 Perl_cop_store_label(pTHX_ COP * const cop, const char *label, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_COP_STORE_LABEL        \
@@ -616,6 +703,7 @@ Perl_cop_store_label(pTHX_ COP * const cop, const char *label, STRLEN len, U32 f
 
 PERL_CALLCONV SV *
 Perl_core_prototype(pTHX_ SV *sv, const char *name, const int code, int * const opnum)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CORE_PROTOTYPE         \
@@ -623,6 +711,7 @@ Perl_core_prototype(pTHX_ SV *sv, const char *name, const int code, int * const 
 
 PERL_CALLCONV OP *
 Perl_coresub_op(pTHX_ SV * const coreargssv, const int code, const int opnum)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CORESUB_OP             \
@@ -630,6 +719,7 @@ Perl_coresub_op(pTHX_ SV * const coreargssv, const int code, const int opnum)
 
 PERL_CALLCONV void
 Perl_create_eval_scope(pTHX_ OP *retop, SV **sp, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CREATE_EVAL_SCOPE      \
@@ -637,6 +727,7 @@ Perl_create_eval_scope(pTHX_ OP *retop, SV **sp, U32 flags)
 
 PERL_CALLCONV_NO_RET void
 Perl_croak(pTHX_ const char *pat, ...)
+        Perl_attribute_nonnull_aTHX_
         __attribute__noreturn__
         __attribute__format__null_ok__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_CROAK
@@ -679,6 +770,7 @@ Perl_croak_popstack(void)
 
 PERL_CALLCONV_NO_RET void
 Perl_croak_sv(pTHX_ SV *baseex)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_CROAK_SV               \
@@ -704,6 +796,7 @@ Perl_csighandler3(int sig, Siginfo_t *info, void *uap);
 
 PERL_CALLCONV XOPRETANY
 Perl_custom_op_get_field(pTHX_ const OP *o, const xop_flags_enum field)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_CUSTOM_OP_GET_FIELD    \
@@ -711,6 +804,7 @@ Perl_custom_op_get_field(pTHX_ const OP *o, const xop_flags_enum field)
 
 PERL_CALLCONV void
 Perl_custom_op_register(pTHX_ Perl_ppaddr_t ppaddr, const XOP *xop)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_CUSTOM_OP_REGISTER     \
@@ -721,6 +815,7 @@ Perl_custom_op_register(pTHX_ Perl_ppaddr_t ppaddr, const XOP *xop)
 
 PERL_CALLCONV CV *
 Perl_cv_clone(pTHX_ CV *proto)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CV_CLONE               \
         assert(proto); \
@@ -728,6 +823,7 @@ Perl_cv_clone(pTHX_ CV *proto)
 
 PERL_CALLCONV CV *
 Perl_cv_clone_into(pTHX_ CV *proto, CV *target)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -750,12 +846,14 @@ Perl_cv_const_sv_or_av(const CV * const cv)
 
 PERL_CALLCONV void
 Perl_cv_forget_slab(pTHX_ CV *cv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CV_FORGET_SLAB         \
         assert(!cv || SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
 Perl_cv_get_call_checker(pTHX_ CV *cv, Perl_call_checker *ckfun_p, SV **ckobj_p)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -765,6 +863,7 @@ Perl_cv_get_call_checker(pTHX_ CV *cv, Perl_call_checker *ckfun_p, SV **ckobj_p)
 
 PERL_CALLCONV void
 Perl_cv_get_call_checker_flags(pTHX_ CV *cv, U32 gflags, Perl_call_checker *ckfun_p, SV **ckobj_p, U32 *ckflags_p)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
@@ -775,12 +874,14 @@ Perl_cv_get_call_checker_flags(pTHX_ CV *cv, U32 gflags, Perl_call_checker *ckfu
 
 PERL_CALLCONV SV *
 Perl_cv_name(pTHX_ CV *cv, SV *sv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CV_NAME                \
         assert(cv)
 
 PERL_CALLCONV void
 Perl_cv_set_call_checker(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -790,6 +891,7 @@ Perl_cv_set_call_checker(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj)
 
 PERL_CALLCONV void
 Perl_cv_set_call_checker_flags(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj, U32 ckflags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -799,12 +901,14 @@ Perl_cv_set_call_checker_flags(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj,
 
 PERL_CALLCONV void
 Perl_cv_undef(pTHX_ CV *cv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CV_UNDEF               \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
 Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CV_UNDEF_FLAGS         \
@@ -812,18 +916,21 @@ Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
 
 PERL_CALLCONV GV *
 Perl_cvgv_from_hek(pTHX_ CV *cv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CVGV_FROM_HEK          \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
 Perl_cvgv_set(pTHX_ CV *cv, GV *gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CVGV_SET               \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
 Perl_cvstash_set(pTHX_ CV *cv, HV *stash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CVSTASH_SET            \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
@@ -831,17 +938,20 @@ Perl_cvstash_set(pTHX_ CV *cv, HV *stash)
 
 PERL_CALLCONV void
 Perl_cx_dump(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CX_DUMP                \
         assert(cx)
 
 PERL_CALLCONV I32
 Perl_cxinc(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_CXINC
 
 PERL_CALLCONV void
 Perl_deb(pTHX_ const char *pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_DEB                    \
@@ -849,34 +959,41 @@ Perl_deb(pTHX_ const char *pat, ...)
 
 PERL_CALLCONV void
 Perl_deb_stack_all(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DEB_STACK_ALL
 
 PERL_CALLCONV I32
 Perl_debop(pTHX_ const OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_DEBOP                  \
         assert(o)
 
 PERL_CALLCONV void
-Perl_debprofdump(pTHX);
+Perl_debprofdump(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_DEBPROFDUMP
 
 PERL_CALLCONV I32
-Perl_debstack(pTHX);
+Perl_debstack(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_DEBSTACK
 
 PERL_CALLCONV I32
-Perl_debstackptrs(pTHX);
+Perl_debstackptrs(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_DEBSTACKPTRS
 
 PERL_CALLCONV void
 Perl_debug_hash_seed(pTHX_ bool via_debug_h)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DEBUG_HASH_SEED
 
 PERL_CALLCONV SV *
 Perl_defelem_target(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -885,6 +1002,7 @@ Perl_defelem_target(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV void
 Perl_delete_eval_scope(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DELETE_EVAL_SCOPE
 
@@ -904,17 +1022,20 @@ Perl_delimcpy(char *to, const char *to_end, const char *from, const char *from_e
         assert(retlen); assert(to <= to_end); assert(from <= from_end)
 
 PERL_CALLCONV void
-Perl_despatch_signals(pTHX);
+Perl_despatch_signals(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_DESPATCH_SIGNALS
 
 PERL_CALLCONV_NO_RET OP *
 Perl_die(pTHX_ const char *pat, ...)
+        Perl_attribute_nonnull_aTHX_
         __attribute__noreturn__
         __attribute__format__null_ok__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_DIE
 
 PERL_CALLCONV_NO_RET OP *
 Perl_die_sv(pTHX_ SV *baseex)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_DIE_SV                 \
@@ -922,6 +1043,7 @@ Perl_die_sv(pTHX_ SV *baseex)
 
 PERL_CALLCONV_NO_RET void
 Perl_die_unwind(pTHX_ SV *msv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__noreturn__
         __attribute__visibility__("hidden");
@@ -930,6 +1052,7 @@ Perl_die_unwind(pTHX_ SV *msv)
 
 PERL_CALLCONV bool
 Perl_do_aexec5(pTHX_ SV *really, SV **mark, SV **sp, int fd, int do_report)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
@@ -937,11 +1060,13 @@ Perl_do_aexec5(pTHX_ SV *really, SV **mark, SV **sp, int fd, int do_report)
         assert(mark); assert(sp)
 
 PERL_CALLCONV bool
-Perl_do_close(pTHX_ GV *gv, bool is_explicit);
+Perl_do_close(pTHX_ GV *gv, bool is_explicit)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_DO_CLOSE
 
 PERL_CALLCONV void
 Perl_do_dump_pad(pTHX_ I32 level, PerlIO *file, PADLIST *padlist, int full)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_DUMP_PAD            \
@@ -949,6 +1074,7 @@ Perl_do_dump_pad(pTHX_ I32 level, PerlIO *file, PADLIST *padlist, int full)
 
 PERL_CALLCONV bool
 Perl_do_eof(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_EOF                 \
@@ -956,6 +1082,7 @@ Perl_do_eof(pTHX_ GV *gv)
 
 PERL_CALLCONV void
 Perl_do_gv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_GV_DUMP             \
@@ -963,6 +1090,7 @@ Perl_do_gv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
 
 PERL_CALLCONV void
 Perl_do_gvgv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_GVGV_DUMP           \
@@ -970,6 +1098,7 @@ Perl_do_gvgv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
 
 PERL_CALLCONV void
 Perl_do_hv_dump(pTHX_ I32 level, PerlIO *file, const char *name, HV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_HV_DUMP             \
@@ -977,6 +1106,7 @@ Perl_do_hv_dump(pTHX_ I32 level, PerlIO *file, const char *name, HV *sv)
 
 PERL_CALLCONV void
 Perl_do_join(pTHX_ SV *sv, SV *delim, SV **mark, SV **sp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -986,12 +1116,14 @@ Perl_do_join(pTHX_ SV *sv, SV *delim, SV **mark, SV **sp)
 
 PERL_CALLCONV void
 Perl_do_magic_dump(pTHX_ I32 level, PerlIO *file, const MAGIC *mg, I32 nest, I32 maxnest, bool dumpops, STRLEN pvlim)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_MAGIC_DUMP          \
         assert(file)
 
 PERL_CALLCONV I32
 Perl_do_ncmp(pTHX_ SV * const left, SV * const right)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__
@@ -1001,15 +1133,18 @@ Perl_do_ncmp(pTHX_ SV * const left, SV * const right)
 
 PERL_CALLCONV void
 Perl_do_op_dump(pTHX_ I32 level, PerlIO *file, const OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_OP_DUMP             \
         assert(file)
 
 /* PERL_CALLCONV bool
-Perl_do_open(pTHX_ GV *gv, const char *name, I32 len, int as_raw, int rawmode, int rawperm, PerlIO *supplied_fp); */
+Perl_do_open(pTHX_ GV *gv, const char *name, I32 len, int as_raw, int rawmode, int rawperm, PerlIO *supplied_fp)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV bool
 Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len, PerlIO *supplied_fp, SV **svp, U32 num)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -1018,6 +1153,7 @@ Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len, PerlIO *supplied_fp, 
 
 PERL_CALLCONV bool
 Perl_do_open_raw(pTHX_ GV *gv, const char *oname, STRLEN len, int rawmode, int rawperm, Stat_t *statbufp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -1026,6 +1162,7 @@ Perl_do_open_raw(pTHX_ GV *gv, const char *oname, STRLEN len, int rawmode, int r
 
 PERL_CALLCONV bool
 Perl_do_openn(pTHX_ GV *gv, const char *oname, I32 len, int as_raw, int rawmode, int rawperm, PerlIO *supplied_fp, SV **svp, I32 num)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_OPENN               \
@@ -1033,12 +1170,14 @@ Perl_do_openn(pTHX_ GV *gv, const char *oname, I32 len, int as_raw, int rawmode,
 
 PERL_CALLCONV void
 Perl_do_pmop_dump(pTHX_ I32 level, PerlIO *file, const PMOP *pm)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_PMOP_DUMP           \
         assert(file)
 
 PERL_CALLCONV bool
 Perl_do_print(pTHX_ SV *sv, PerlIO *fp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_PRINT               \
@@ -1046,17 +1185,20 @@ Perl_do_print(pTHX_ SV *sv, PerlIO *fp)
 
 PERL_CALLCONV OP *
 Perl_do_readline(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_READLINE
 
 PERL_CALLCONV bool
 Perl_do_seek(pTHX_ GV *gv, Off_t pos, int whence)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_SEEK
 
 PERL_CALLCONV void
 Perl_do_sprintf(pTHX_ SV *sv, SSize_t len, SV **sarg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_SPRINTF             \
@@ -1064,12 +1206,14 @@ Perl_do_sprintf(pTHX_ SV *sv, SSize_t len, SV **sarg)
 
 PERL_CALLCONV void
 Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bool dumpops, STRLEN pvlim)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_SV_DUMP             \
         assert(file)
 
 PERL_CALLCONV Off_t
 Perl_do_sysseek(pTHX_ GV *gv, Off_t pos, int whence)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_SYSSEEK             \
@@ -1077,6 +1221,7 @@ Perl_do_sysseek(pTHX_ GV *gv, Off_t pos, int whence)
 
 PERL_CALLCONV Off_t
 Perl_do_tell(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -1085,6 +1230,7 @@ Perl_do_tell(pTHX_ GV *gv)
 
 PERL_CALLCONV Size_t
 Perl_do_trans(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_TRANS               \
@@ -1095,6 +1241,7 @@ Perl_do_trans(pTHX_ SV *sv)
 
 PERL_CALLCONV UV
 Perl_do_vecget(pTHX_ SV *sv, STRLEN offset, int size)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_VECGET              \
@@ -1102,6 +1249,7 @@ Perl_do_vecget(pTHX_ SV *sv, STRLEN offset, int size)
 
 PERL_CALLCONV void
 Perl_do_vecset(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_VECSET              \
@@ -1109,6 +1257,7 @@ Perl_do_vecset(pTHX_ SV *sv)
 
 PERL_CALLCONV void
 Perl_do_vop(pTHX_ I32 optype, SV *sv, SV *left, SV *right)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
@@ -1118,6 +1267,7 @@ Perl_do_vop(pTHX_ I32 optype, SV *sv, SV *left, SV *right)
 
 PERL_CALLCONV OP *
 Perl_dofile(pTHX_ OP *term, I32 force_builtin)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DOFILE                 \
@@ -1130,16 +1280,19 @@ Perl_doing_taint(int argc, char **argv, char **env)
 
 PERL_CALLCONV OP *
 Perl_doref(pTHX_ OP *o, I32 type, bool set_op_ref)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_DOREF                  \
         assert(o)
 
 PERL_CALLCONV void
-Perl_dounwind(pTHX_ I32 cxix);
+Perl_dounwind(pTHX_ I32 cxix)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_DOUNWIND
 
 PERL_CALLCONV U8
 Perl_dowantarray(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__deprecated__
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_DOWANTARRAY
@@ -1157,26 +1310,31 @@ Perl_drand48_r(perl_drand48_t *random_state)
         assert(random_state)
 
 PERL_CALLCONV void
-Perl_dump_all(pTHX);
+Perl_dump_all(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_DUMP_ALL
 
 PERL_CALLCONV void
 Perl_dump_all_perl(pTHX_ bool justperl)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DUMP_ALL_PERL
 
 PERL_CALLCONV void
-Perl_dump_eval(pTHX);
+Perl_dump_eval(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_DUMP_EVAL
 
 PERL_CALLCONV void
 Perl_dump_form(pTHX_ const GV *gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_DUMP_FORM              \
         assert(gv)
 
 PERL_CALLCONV void
 Perl_dump_indent(pTHX_ I32 level, PerlIO *file, const char *pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__format__(__printf__,pTHX_3,pTHX_4);
@@ -1185,12 +1343,14 @@ Perl_dump_indent(pTHX_ I32 level, PerlIO *file, const char *pat, ...)
 
 PERL_CALLCONV void
 Perl_dump_packsubs(pTHX_ const HV *stash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_DUMP_PACKSUBS          \
         assert(stash)
 
 PERL_CALLCONV void
 Perl_dump_packsubs_perl(pTHX_ const HV *stash, bool justperl)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DUMP_PACKSUBS_PERL     \
@@ -1198,12 +1358,14 @@ Perl_dump_packsubs_perl(pTHX_ const HV *stash, bool justperl)
 
 PERL_CALLCONV void
 Perl_dump_sub(pTHX_ const GV *gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_DUMP_SUB               \
         assert(gv)
 
 PERL_CALLCONV void
 Perl_dump_sub_perl(pTHX_ const GV *gv, bool justperl)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DUMP_SUB_PERL          \
@@ -1211,6 +1373,7 @@ Perl_dump_sub_perl(pTHX_ const GV *gv, bool justperl)
 
 PERL_CALLCONV void
 Perl_dump_vindent(pTHX_ I32 level, PerlIO *file, const char *pat, va_list *args)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_DUMP_VINDENT           \
@@ -1223,12 +1386,14 @@ Perl_dump_vindent(pTHX_ I32 level, PerlIO *file, const char *pat, va_list *args)
 
 PERL_CALLCONV SV *
 Perl_eval_pv(pTHX_ const char *p, I32 croak_on_error)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_EVAL_PV                \
         assert(p)
 
 PERL_CALLCONV SSize_t
 Perl_eval_sv(pTHX_ SV *sv, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_EVAL_SV                \
         assert(sv)
@@ -1240,6 +1405,7 @@ Perl_extended_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_
 
 PERL_CALLCONV void
 Perl_fatal_warner(pTHX_ U32 err, const char *pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_FATAL_WARNER           \
@@ -1247,12 +1413,14 @@ Perl_fatal_warner(pTHX_ U32 err, const char *pat, ...)
 
 PERL_CALLCONV void
 Perl_fbm_compile(pTHX_ SV *sv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_FBM_COMPILE            \
         assert(sv)
 
 PERL_CALLCONV char *
 Perl_fbm_instr(pTHX_ unsigned char *big, unsigned char *bigend, SV *littlestr, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -1261,17 +1429,20 @@ Perl_fbm_instr(pTHX_ unsigned char *big, unsigned char *bigend, SV *littlestr, U
         assert(big); assert(bigend); assert(littlestr); assert(big <= bigend)
 
 PERL_CALLCONV SV *
-Perl_filter_add(pTHX_ filter_t funcp, SV *datasv);
+Perl_filter_add(pTHX_ filter_t funcp, SV *datasv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_FILTER_ADD
 
 PERL_CALLCONV void
 Perl_filter_del(pTHX_ filter_t funcp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_FILTER_DEL             \
         assert(funcp)
 
 PERL_CALLCONV I32
 Perl_filter_read(pTHX_ int idx, SV *buf_sv, int maxlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_FILTER_READ            \
@@ -1279,36 +1450,43 @@ Perl_filter_read(pTHX_ int idx, SV *buf_sv, int maxlen)
 
 PERL_CALLCONV CV *
 Perl_find_lexical_cv(pTHX_ PADOFFSET off)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_FIND_LEXICAL_CV
 
 PERL_CALLCONV CV *
 Perl_find_runcv(pTHX_ U32 *db_seqp)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_FIND_RUNCV
 
 PERL_CALLCONV CV *
 Perl_find_runcv_where(pTHX_ U8 cond, IV arg, U32 *db_seqp)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_FIND_RUNCV_WHERE
 
 PERL_CALLCONV SV *
-Perl_find_rundefsv(pTHX);
+Perl_find_rundefsv(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_FIND_RUNDEFSV
 
 PERL_CALLCONV char *
 Perl_find_script(pTHX_ const char *scriptname, bool dosearch, const char * const * const search_ext, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_FIND_SCRIPT            \
         assert(scriptname)
 
 /* PERL_CALLCONV I32
-Perl_foldEQ_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2); */
+Perl_foldEQ_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV I32
 Perl_foldEQ_utf8_flags(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_5);
 #define PERL_ARGS_ASSERT_FOLDEQ_UTF8_FLAGS      \
@@ -1316,6 +1494,7 @@ Perl_foldEQ_utf8_flags(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const c
 
 PERL_CALLCONV void
 Perl_forbid_outofblock_ops(pTHX_ OP *o, const char *blockname)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_FORBID_OUTOFBLOCK_OPS  \
@@ -1323,11 +1502,13 @@ Perl_forbid_outofblock_ops(pTHX_ OP *o, const char *blockname)
 
 PERL_CALLCONV void
 Perl_force_locale_unlock(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_FORCE_LOCALE_UNLOCK
 
 PERL_CALLCONV void
 Perl_force_out_malformed_utf8_message_(pTHX_ const U8 * const p, const U8 * const e, U32 flags, const bool die_here)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_FORCE_OUT_MALFORMED_UTF8_MESSAGE_ \
@@ -1335,6 +1516,7 @@ Perl_force_out_malformed_utf8_message_(pTHX_ const U8 * const p, const U8 * cons
 
 PERL_CALLCONV char *
 Perl_form(pTHX_ const char *pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_FORM                   \
@@ -1342,11 +1524,13 @@ Perl_form(pTHX_ const char *pat, ...)
 
 PERL_CALLCONV void
 Perl_free_tied_hv_pool(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_FREE_TIED_HV_POOL
 
 PERL_CALLCONV void
-Perl_free_tmps(pTHX);
+Perl_free_tmps(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_FREE_TMPS
 
 #define PERL_ARGS_ASSERT_GET_AND_CHECK_BACKSLASH_N_NAME \
@@ -1354,24 +1538,28 @@ Perl_free_tmps(pTHX);
 
 PERL_CALLCONV AV *
 Perl_get_av(pTHX_ const char *name, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_AV                 \
         assert(name)
 
 PERL_CALLCONV CV *
 Perl_get_cv(pTHX_ const char *name, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_CV                 \
         assert(name)
 
 PERL_CALLCONV CV *
 Perl_get_cvn_flags(pTHX_ const char *name, STRLEN len, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_CVN_FLAGS          \
         assert(name)
 
 PERL_CALLCONV void
 Perl_get_db_sub(pTHX_ SV **svp, CV *cv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GET_DB_SUB             \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
@@ -1385,6 +1573,7 @@ Perl_get_extended_os_errno(void)
 
 PERL_CALLCONV void
 Perl_get_hash_seed(pTHX_ unsigned char * const seed_buffer)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_GET_HASH_SEED          \
@@ -1392,12 +1581,14 @@ Perl_get_hash_seed(pTHX_ unsigned char * const seed_buffer)
 
 PERL_CALLCONV HV *
 Perl_get_hv(pTHX_ const char *name, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_HV                 \
         assert(name)
 
 PERL_CALLCONV const char *
 Perl_get_no_modify(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__deprecated__
         __attribute__warn_unused_result__
         __attribute__pure__
@@ -1406,6 +1597,7 @@ Perl_get_no_modify(pTHX)
 
 PERL_CALLCONV char **
 Perl_get_op_descs(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__deprecated__
         __attribute__warn_unused_result__
         __attribute__pure__;
@@ -1413,6 +1605,7 @@ Perl_get_op_descs(pTHX)
 
 PERL_CALLCONV char **
 Perl_get_op_names(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__deprecated__
         __attribute__warn_unused_result__
         __attribute__pure__;
@@ -1420,6 +1613,7 @@ Perl_get_op_names(pTHX)
 
 PERL_CALLCONV U32 *
 Perl_get_opargs(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__deprecated__
         __attribute__warn_unused_result__
         __attribute__pure__
@@ -1428,6 +1622,7 @@ Perl_get_opargs(pTHX)
 
 PERL_CALLCONV PPADDR_t *
 Perl_get_ppaddr(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__deprecated__
         __attribute__warn_unused_result__
         __attribute__pure__;
@@ -1438,27 +1633,32 @@ Perl_get_ppaddr(pTHX)
 #define PERL_ARGS_ASSERT_GET_PROP_VALUES
 
 PERL_CALLCONV REGEXP *
-Perl_get_re_arg(pTHX_ SV *sv);
+Perl_get_re_arg(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_GET_RE_ARG
 
 PERL_CALLCONV SV *
 Perl_get_sv(pTHX_ const char *name, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_SV                 \
         assert(name)
 
 PERL_CALLCONV int
 Perl_getcwd_sv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GETCWD_SV              \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_gp_free(pTHX_ GV *gv);
+Perl_gp_free(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_GP_FREE
 
 PERL_CALLCONV GP *
-Perl_gp_ref(pTHX_ GP *gp);
+Perl_gp_ref(pTHX_ GP *gp)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_GP_REF
 
 PERL_CALLCONV bool
@@ -1470,6 +1670,7 @@ Perl_grok_atoUV(const char *pv, UV *valptr, const char **endptr)
 
 PERL_CALLCONV UV
 Perl_grok_bin_oct_hex(pTHX_ const char * const start, STRLEN *len_p, I32 *flags, NV *result, const unsigned shift, const U32 lookup_bit, const char prefix)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -1478,6 +1679,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start, STRLEN *len_p, I32 *flags,
 
 PERL_CALLCONV int
 Perl_grok_infnan(pTHX_ const char **sp, const char *send)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GROK_INFNAN            \
@@ -1485,18 +1687,21 @@ Perl_grok_infnan(pTHX_ const char **sp, const char *send)
 
 PERL_CALLCONV int
 Perl_grok_number(pTHX_ const char *pv, STRLEN len, UV *valuep)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GROK_NUMBER            \
         assert(pv)
 
 PERL_CALLCONV int
 Perl_grok_number_flags(pTHX_ const char *pv, STRLEN len, UV *valuep, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GROK_NUMBER_FLAGS      \
         assert(pv)
 
 PERL_CALLCONV bool
 Perl_grok_numeric_radix(pTHX_ const char **sp, const char *send)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -1504,20 +1709,25 @@ Perl_grok_numeric_radix(pTHX_ const char **sp, const char *send)
         assert(sp); assert(*sp); assert(send); assert(*sp <= send)
 
 /* PERL_CALLCONV GV *
-Perl_gv_AVadd(pTHX_ GV *gv); */
+Perl_gv_AVadd(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV GV *
-Perl_gv_HVadd(pTHX_ GV *gv); */
+Perl_gv_HVadd(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV GV *
-Perl_gv_IOadd(pTHX_ GV *gv); */
+Perl_gv_IOadd(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV GV *
-Perl_gv_add_by_type(pTHX_ GV *gv, svtype type);
+Perl_gv_add_by_type(pTHX_ GV *gv, svtype type)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_GV_ADD_BY_TYPE
 
 PERL_CALLCONV GV *
 Perl_gv_autoload_pv(pTHX_ HV *stash, const char *namepv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_AUTOLOAD_PV         \
@@ -1525,6 +1735,7 @@ Perl_gv_autoload_pv(pTHX_ HV *stash, const char *namepv, U32 flags)
 
 PERL_CALLCONV GV *
 Perl_gv_autoload_pvn(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_AUTOLOAD_PVN        \
@@ -1532,6 +1743,7 @@ Perl_gv_autoload_pvn(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags)
 
 PERL_CALLCONV GV *
 Perl_gv_autoload_sv(pTHX_ HV *stash, SV *namesv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_AUTOLOAD_SV         \
@@ -1539,26 +1751,31 @@ Perl_gv_autoload_sv(pTHX_ HV *stash, SV *namesv, U32 flags)
 
 PERL_CALLCONV void
 Perl_gv_check(pTHX_ HV *stash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_CHECK               \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV SV *
 Perl_gv_const_sv(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_CONST_SV            \
         assert(gv)
 
 PERL_CALLCONV void
-Perl_gv_dump(pTHX_ GV *gv);
+Perl_gv_dump(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_GV_DUMP
 
 /* PERL_CALLCONV void
-Perl_gv_efullname3(pTHX_ SV *sv, const GV *gv, const char *prefix); */
+Perl_gv_efullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_gv_efullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_EFULLNAME4          \
@@ -1566,63 +1783,75 @@ Perl_gv_efullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain
 
 PERL_CALLCONV GV *
 Perl_gv_fetchfile(pTHX_ const char *name)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHFILE           \
         assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchfile_flags(pTHX_ const char * const name, const STRLEN len, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHFILE_FLAGS     \
         assert(name)
 
 /* PERL_CALLCONV GV *
-Perl_gv_fetchmeth(pTHX_ HV *stash, const char *name, STRLEN len, I32 level); */
+Perl_gv_fetchmeth(pTHX_ HV *stash, const char *name, STRLEN len, I32 level)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV GV *
-Perl_gv_fetchmeth_autoload(pTHX_ HV *stash, const char *name, STRLEN len, I32 level); */
+Perl_gv_fetchmeth_autoload(pTHX_ HV *stash, const char *name, STRLEN len, I32 level)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_pv(pTHX_ HV *stash, const char *name, I32 level, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PV        \
         assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_pv_autoload(pTHX_ HV *stash, const char *name, I32 level, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PV_AUTOLOAD \
         assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_pvn(pTHX_ HV *stash, const char *name, STRLEN len, I32 level, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PVN       \
         assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_pvn_autoload(pTHX_ HV *stash, const char *name, STRLEN len, I32 level, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PVN_AUTOLOAD \
         assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_sv(pTHX_ HV *stash, SV *namesv, I32 level, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_SV        \
         assert(namesv)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_sv_autoload(pTHX_ HV *stash, SV *namesv, I32 level, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_SV_AUTOLOAD \
         assert(namesv)
 
 /* PERL_CALLCONV GV *
-Perl_gv_fetchmethod(pTHX_ HV *stash, const char *name); */
+Perl_gv_fetchmethod(pTHX_ HV *stash, const char *name)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmethod_autoload(pTHX_ HV *stash, const char *name, I32 autoload)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_AUTOLOAD \
@@ -1630,6 +1859,7 @@ Perl_gv_fetchmethod_autoload(pTHX_ HV *stash, const char *name, I32 autoload)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmethod_pv_flags(pTHX_ HV *stash, const char *name, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_PV_FLAGS \
@@ -1637,6 +1867,7 @@ Perl_gv_fetchmethod_pv_flags(pTHX_ HV *stash, const char *name, U32 flags)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_PVN_FLAGS \
@@ -1644,6 +1875,7 @@ Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN le
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmethod_sv_flags(pTHX_ HV *stash, SV *namesv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_SV_FLAGS \
@@ -1651,27 +1883,32 @@ Perl_gv_fetchmethod_sv_flags(pTHX_ HV *stash, SV *namesv, U32 flags)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchpv(pTHX_ const char *nambeg, I32 flags, const svtype sv_type)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHPV             \
         assert(nambeg)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchpvn_flags(pTHX_ const char *name, STRLEN len, I32 flags, const svtype sv_type)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHPVN_FLAGS      \
         assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchsv(pTHX_ SV *name, I32 flags, const svtype sv_type)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHSV             \
         assert(name)
 
 /* PERL_CALLCONV void
-Perl_gv_fullname3(pTHX_ SV *sv, const GV *gv, const char *prefix); */
+Perl_gv_fullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_gv_fullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FULLNAME4           \
@@ -1679,15 +1916,18 @@ Perl_gv_fullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
 
 PERL_CALLCONV CV *
 Perl_gv_handler(pTHX_ HV *stash, I32 id)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_HANDLER             \
         assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
 /* PERL_CALLCONV void
-Perl_gv_init(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, int multi); */
+Perl_gv_init(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, int multi)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_gv_init_pv(pTHX_ GV *gv, HV *stash, const char *name, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT_PV             \
@@ -1695,6 +1935,7 @@ Perl_gv_init_pv(pTHX_ GV *gv, HV *stash, const char *name, U32 flags)
 
 PERL_CALLCONV void
 Perl_gv_init_pvn(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT_PVN            \
@@ -1702,6 +1943,7 @@ Perl_gv_init_pvn(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, U32 flag
 
 PERL_CALLCONV void
 Perl_gv_init_sv(pTHX_ GV *gv, HV *stash, SV *namesv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT_SV             \
@@ -1709,6 +1951,7 @@ Perl_gv_init_sv(pTHX_ GV *gv, HV *stash, SV *namesv, U32 flags)
 
 PERL_CALLCONV void
 Perl_gv_name_set(pTHX_ GV *gv, const char *name, U32 len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_NAME_SET            \
@@ -1716,12 +1959,14 @@ Perl_gv_name_set(pTHX_ GV *gv, const char *name, U32 len, U32 flags)
 
 PERL_CALLCONV GV *
 Perl_gv_override(pTHX_ const char * const name, const STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_OVERRIDE            \
         assert(name)
 
 PERL_CALLCONV void
 Perl_gv_setref(pTHX_ SV * const dsv, SV * const ssv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -1730,30 +1975,35 @@ Perl_gv_setref(pTHX_ SV * const dsv, SV * const ssv)
 
 PERL_CALLCONV HV *
 Perl_gv_stashpv(pTHX_ const char *name, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_STASHPV             \
         assert(name)
 
 PERL_CALLCONV HV *
 Perl_gv_stashpvn(pTHX_ const char *name, U32 namelen, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_STASHPVN            \
         assert(name)
 
 PERL_CALLCONV HV *
 Perl_gv_stashsv(pTHX_ SV *sv, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_STASHSV             \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_gv_try_downgrade(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_TRY_DOWNGRADE       \
         assert(gv)
 
 PERL_CALLCONV struct xpvhv_aux *
 Perl_hv_auxalloc(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_AUXALLOC            \
@@ -1761,6 +2011,7 @@ Perl_hv_auxalloc(pTHX_ HV *hv)
 
 PERL_CALLCONV AV **
 Perl_hv_backreferences_p(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_BACKREFERENCES_P    \
@@ -1768,50 +2019,60 @@ Perl_hv_backreferences_p(pTHX_ HV *hv)
 
 PERL_CALLCONV SV *
 Perl_hv_bucket_ratio(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_BUCKET_RATIO        \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
-Perl_hv_clear(pTHX_ HV *hv);
+Perl_hv_clear(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_HV_CLEAR               \
         assert(!hv || SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_clear_placeholders(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_CLEAR_PLACEHOLDERS  \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void *
-Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen, int flags, int action, SV *val, U32 hash);
+Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen, int flags, int action, SV *val, U32 hash)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_HV_COMMON
 
 PERL_CALLCONV HV *
 Perl_hv_copy_hints_hv(pTHX_ HV * const ohv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_COPY_HINTS_HV       \
         assert(!ohv || SvTYPE(ohv) == SVt_PVHV)
 
 PERL_CALLCONV void
-Perl_hv_delayfree_ent(pTHX_ HV *notused, HE *entry);
+Perl_hv_delayfree_ent(pTHX_ HV *notused, HE *entry)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_HV_DELAYFREE_ENT       \
         assert(!notused || SvTYPE(notused) == SVt_PVHV)
 
 /* PERL_CALLCONV SV *
-Perl_hv_delete(pTHX_ HV *hv, const char *key, I32 klen, I32 flags); */
+Perl_hv_delete(pTHX_ HV *hv, const char *key, I32 klen, I32 flags)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV SV *
-Perl_hv_delete_ent(pTHX_ HV *hv, SV *keysv, I32 flags, U32 hash); */
+Perl_hv_delete_ent(pTHX_ HV *hv, SV *keysv, I32 flags, U32 hash)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
-Perl_hv_dump(pTHX_ HV *hv);
+Perl_hv_dump(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_HV_DUMP                \
         assert(!hv || SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV HE **
 Perl_hv_eiter_p(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_EITER_P             \
@@ -1819,12 +2080,14 @@ Perl_hv_eiter_p(pTHX_ HV *hv)
 
 PERL_CALLCONV void
 Perl_hv_eiter_set(pTHX_ HV *hv, HE *eiter)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_EITER_SET           \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_ename_add(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -1833,6 +2096,7 @@ Perl_hv_ename_add(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
 
 PERL_CALLCONV void
 Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -1841,37 +2105,45 @@ Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
 
 /* PERL_CALLCONV bool
 Perl_hv_exists(pTHX_ HV *hv, const char *key, I32 klen)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 /* PERL_CALLCONV bool
 Perl_hv_exists_ent(pTHX_ HV *hv, SV *keysv, U32 hash)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 /* PERL_CALLCONV SV **
-Perl_hv_fetch(pTHX_ HV *hv, const char *key, I32 klen, I32 lval); */
+Perl_hv_fetch(pTHX_ HV *hv, const char *key, I32 klen, I32 lval)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV HE *
-Perl_hv_fetch_ent(pTHX_ HV *hv, SV *keysv, I32 lval, U32 hash); */
+Perl_hv_fetch_ent(pTHX_ HV *hv, SV *keysv, I32 lval, U32 hash)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV STRLEN
 Perl_hv_fill(pTHX_ HV * const hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_FILL                \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
-Perl_hv_free_ent(pTHX_ HV *notused, HE *entry);
+Perl_hv_free_ent(pTHX_ HV *notused, HE *entry)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_HV_FREE_ENT            \
         assert(!notused || SvTYPE(notused) == SVt_PVHV)
 
 PERL_CALLCONV I32
 Perl_hv_iterinit(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_ITERINIT            \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV char *
 Perl_hv_iterkey(pTHX_ HE *entry, I32 *retlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -1880,6 +2152,7 @@ Perl_hv_iterkey(pTHX_ HE *entry, I32 *retlen)
 
 PERL_CALLCONV SV *
 Perl_hv_iterkeysv(pTHX_ HE *entry)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERKEYSV           \
@@ -1887,10 +2160,12 @@ Perl_hv_iterkeysv(pTHX_ HE *entry)
 
 /* PERL_CALLCONV HE *
 Perl_hv_iternext(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 PERL_CALLCONV HE *
 Perl_hv_iternext_flags(pTHX_ HV *hv, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERNEXT_FLAGS      \
@@ -1898,6 +2173,7 @@ Perl_hv_iternext_flags(pTHX_ HV *hv, I32 flags)
 
 PERL_CALLCONV SV *
 Perl_hv_iternextsv(pTHX_ HV *hv, char **key, I32 *retlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -1907,6 +2183,7 @@ Perl_hv_iternextsv(pTHX_ HV *hv, char **key, I32 *retlen)
 
 PERL_CALLCONV SV *
 Perl_hv_iterval(pTHX_ HV *hv, HE *entry)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -1915,21 +2192,25 @@ Perl_hv_iterval(pTHX_ HV *hv, HE *entry)
 
 PERL_CALLCONV void
 Perl_hv_ksplit(pTHX_ HV *hv, IV newmax)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_KSPLIT              \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 /* PERL_CALLCONV void
-Perl_hv_magic(pTHX_ HV *hv, GV *gv, int how); */
+Perl_hv_magic(pTHX_ HV *hv, GV *gv, int how)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_hv_name_set(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_NAME_SET            \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV I32
 Perl_hv_placeholders_get(pTHX_ const HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_PLACEHOLDERS_GET    \
@@ -1937,6 +2218,7 @@ Perl_hv_placeholders_get(pTHX_ const HV *hv)
 
 PERL_CALLCONV SSize_t *
 Perl_hv_placeholders_p(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_PLACEHOLDERS_P      \
@@ -1944,12 +2226,14 @@ Perl_hv_placeholders_p(pTHX_ HV *hv)
 
 PERL_CALLCONV void
 Perl_hv_placeholders_set(pTHX_ HV *hv, I32 ph)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_PLACEHOLDERS_SET    \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_pushkv(pTHX_ HV *hv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_PUSHKV              \
@@ -1957,12 +2241,14 @@ Perl_hv_pushkv(pTHX_ HV *hv, U32 flags)
 
 PERL_CALLCONV void
 Perl_hv_rand_set(pTHX_ HV *hv, U32 new_xhv_rand)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_RAND_SET            \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV I32 *
 Perl_hv_riter_p(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_RITER_P             \
@@ -1970,49 +2256,60 @@ Perl_hv_riter_p(pTHX_ HV *hv)
 
 PERL_CALLCONV void
 Perl_hv_riter_set(pTHX_ HV *hv, I32 riter)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_RITER_SET           \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV SV *
 Perl_hv_scalar(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_SCALAR              \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 /* PERL_CALLCONV SV **
-Perl_hv_store(pTHX_ HV *hv, const char *key, I32 klen, SV *val, U32 hash); */
+Perl_hv_store(pTHX_ HV *hv, const char *key, I32 klen, SV *val, U32 hash)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV HE *
-Perl_hv_store_ent(pTHX_ HV *hv, SV *key, SV *val, U32 hash); */
+Perl_hv_store_ent(pTHX_ HV *hv, SV *key, SV *val, U32 hash)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV SV **
-Perl_hv_store_flags(pTHX_ HV *hv, const char *key, I32 klen, SV *val, U32 hash, int flags); */
+Perl_hv_store_flags(pTHX_ HV *hv, const char *key, I32 klen, SV *val, U32 hash, int flags)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV void
-Perl_hv_undef(pTHX_ HV *hv); */
+Perl_hv_undef(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
-Perl_hv_undef_flags(pTHX_ HV *hv, U32 flags);
+Perl_hv_undef_flags(pTHX_ HV *hv, U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_HV_UNDEF_FLAGS         \
         assert(!hv || SvTYPE(hv) == SVt_PVHV)
 
 /* PERL_CALLCONV I32
 Perl_ibcmp(pTHX_ const char *a, const char *b, I32 len)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__
         __attribute__pure__; */
 
 /* PERL_CALLCONV I32
 Perl_ibcmp_locale(pTHX_ const char *a, const char *b, I32 len)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__
         __attribute__pure__; */
 
 /* PERL_CALLCONV I32
-Perl_ibcmp_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2); */
+Perl_ibcmp_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV STRLEN
 Perl_infix_plugin_standard(pTHX_ char *operator_ptr, STRLEN operator_len, struct Perl_custom_infix **def)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_INFIX_PLUGIN_STANDARD  \
@@ -2020,6 +2317,7 @@ Perl_infix_plugin_standard(pTHX_ char *operator_ptr, STRLEN operator_len, struct
 
 PERL_CALLCONV void
 Perl_init_argv_symbols(pTHX_ int argc, char **argv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INIT_ARGV_SYMBOLS      \
@@ -2027,25 +2325,30 @@ Perl_init_argv_symbols(pTHX_ int argc, char **argv)
 
 PERL_CALLCONV void
 Perl_init_constants(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INIT_CONSTANTS
 
 PERL_CALLCONV void
 Perl_init_dbargs(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INIT_DBARGS
 
 PERL_CALLCONV void
 Perl_init_debugger(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INIT_DEBUGGER
 
 PERL_CALLCONV int
-Perl_init_i18nl10n(pTHX_ int printwarn);
+Perl_init_i18nl10n(pTHX_ int printwarn)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_INIT_I18NL10N
 
 PERL_CALLCONV void
 Perl_init_named_cv(pTHX_ CV *cv, OP *nameop)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_INIT_NAMED_CV          \
@@ -2053,17 +2356,20 @@ Perl_init_named_cv(pTHX_ CV *cv, OP *nameop)
         assert(nameop)
 
 PERL_CALLCONV void
-Perl_init_stacks(pTHX);
+Perl_init_stacks(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_INIT_STACKS
 
 PERL_CALLCONV void
 Perl_init_tm(pTHX_ struct tm *ptm)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_INIT_TM                \
         assert(ptm)
 
 PERL_CALLCONV void
 Perl_init_uniprops(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INIT_UNIPROPS
 
@@ -2073,7 +2379,8 @@ Perl_instr(const char *big, const char *little)
         __attribute__pure__; */
 
 PERL_CALLCONV U32
-Perl_intro_my(pTHX);
+Perl_intro_my(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_INTRO_MY
 
 #define PERL_ARGS_ASSERT_INVERSE_FOLDS_         \
@@ -2081,12 +2388,14 @@ Perl_intro_my(pTHX);
 
 PERL_CALLCONV OP *
 Perl_invert(pTHX_ OP *cmd)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INVERT
 
 PERL_CALLCONV void
 Perl_invmap_dump(pTHX_ SV *invlist, UV *map)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2095,6 +2404,7 @@ Perl_invmap_dump(pTHX_ SV *invlist, UV *map)
 
 PERL_CALLCONV bool
 Perl_io_close(pTHX_ IO *io, GV *gv, bool is_explicit, bool warn_on_fail)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_IO_CLOSE               \
@@ -2108,11 +2418,13 @@ Perl_is_c9strict_utf8_string(const U8 *s, STRLEN len)
 Perl_is_c9strict_utf8_string_loc(const U8 *s, STRLEN len, const U8 **ep); */
 
 PERL_CALLCONV bool
-Perl_is_in_locale_category_(pTHX_ const bool compiling, const int category);
+Perl_is_in_locale_category_(pTHX_ const bool compiling, const int category)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_IS_IN_LOCALE_CATEGORY_
 
 PERL_CALLCONV I32
 Perl_is_lvalue_sub(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_LVALUE_SUB
 
@@ -2125,16 +2437,19 @@ Perl_is_strict_utf8_string_loc(const U8 *s, STRLEN len, const U8 **ep); */
 
 PERL_CALLCONV bool
 Perl_is_uni_FOO_(pTHX_ const U8 classnum, const UV c)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UNI_FOO_
 
 PERL_CALLCONV bool
 Perl_is_uni_perl_idcont_(pTHX_ UV c)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UNI_PERL_IDCONT_
 
 PERL_CALLCONV bool
 Perl_is_uni_perl_idstart_(pTHX_ UV c)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UNI_PERL_IDSTART_
 
@@ -2149,6 +2464,7 @@ Perl_is_utf8_FF_helper_(const U8 * const s0, const U8 * const e, const bool requ
 
 PERL_CALLCONV Size_t
 Perl_is_utf8_FOO_(pTHX_ const U8 classnum, const U8 *p, const U8 * const e)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
@@ -2175,6 +2491,7 @@ Perl_is_utf8_fixed_width_buf_loc_flags(const U8 * const s, STRLEN len, const U8 
 
 PERL_CALLCONV Size_t
 Perl_is_utf8_perl_idcont_(pTHX_ const U8 *p, const U8 * const e)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -2183,6 +2500,7 @@ Perl_is_utf8_perl_idcont_(pTHX_ const U8 *p, const U8 * const e)
 
 PERL_CALLCONV Size_t
 Perl_is_utf8_perl_idstart_(pTHX_ const U8 *p, const U8 * const e)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -2212,6 +2530,7 @@ Perl_isinfnan(NV nv)
 
 PERL_CALLCONV bool
 Perl_isinfnansv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_ISINFNANSV             \
@@ -2219,6 +2538,7 @@ Perl_isinfnansv(pTHX_ SV *sv)
 
 PERL_CALLCONV OP *
 Perl_jmaybe(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_JMAYBE                 \
@@ -2226,6 +2546,7 @@ Perl_jmaybe(pTHX_ OP *o)
 
 PERL_CALLCONV I32
 Perl_keyword(pTHX_ const char *name, I32 len, bool all_keywords)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__pure__
@@ -2235,6 +2556,7 @@ Perl_keyword(pTHX_ const char *name, I32 len, bool all_keywords)
 
 PERL_CALLCONV int
 Perl_keyword_plugin_standard(pTHX_ char *keyword_ptr, STRLEN keyword_len, OP **op_ptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_KEYWORD_PLUGIN_STANDARD \
@@ -2242,81 +2564,97 @@ Perl_keyword_plugin_standard(pTHX_ char *keyword_ptr, STRLEN keyword_len, OP **o
 
 PERL_CALLCONV void
 Perl_leave_adjust_stacks(pTHX_ SV **from_sp, SV **to_sp, U8 gimme, int filter)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_LEAVE_ADJUST_STACKS    \
         assert(from_sp); assert(to_sp)
 
 PERL_CALLCONV void
-Perl_leave_scope(pTHX_ I32 base);
+Perl_leave_scope(pTHX_ I32 base)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_LEAVE_SCOPE
 
 PERL_CALLCONV bool
-Perl_lex_bufutf8(pTHX);
+Perl_lex_bufutf8(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_LEX_BUFUTF8
 
 PERL_CALLCONV void
 Perl_lex_discard_to(pTHX_ char *ptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_DISCARD_TO         \
         assert(ptr)
 
 PERL_CALLCONV char *
-Perl_lex_grow_linestr(pTHX_ STRLEN len);
+Perl_lex_grow_linestr(pTHX_ STRLEN len)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_LEX_GROW_LINESTR
 
 PERL_CALLCONV bool
-Perl_lex_next_chunk(pTHX_ U32 flags);
+Perl_lex_next_chunk(pTHX_ U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_LEX_NEXT_CHUNK
 
 PERL_CALLCONV I32
-Perl_lex_peek_unichar(pTHX_ U32 flags);
+Perl_lex_peek_unichar(pTHX_ U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_LEX_PEEK_UNICHAR
 
 PERL_CALLCONV void
-Perl_lex_read_space(pTHX_ U32 flags);
+Perl_lex_read_space(pTHX_ U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_LEX_READ_SPACE
 
 PERL_CALLCONV void
 Perl_lex_read_to(pTHX_ char *ptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_READ_TO            \
         assert(ptr)
 
 PERL_CALLCONV I32
-Perl_lex_read_unichar(pTHX_ U32 flags);
+Perl_lex_read_unichar(pTHX_ U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_LEX_READ_UNICHAR
 
 PERL_CALLCONV void
-Perl_lex_start(pTHX_ SV *line, PerlIO *rsfp, U32 flags);
+Perl_lex_start(pTHX_ SV *line, PerlIO *rsfp, U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_LEX_START
 
 PERL_CALLCONV void
 Perl_lex_stuff_pv(pTHX_ const char *pv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_STUFF_PV           \
         assert(pv)
 
 PERL_CALLCONV void
 Perl_lex_stuff_pvn(pTHX_ const char *pv, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_STUFF_PVN          \
         assert(pv)
 
 PERL_CALLCONV void
 Perl_lex_stuff_sv(pTHX_ SV *sv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_STUFF_SV           \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_lex_unstuff(pTHX_ char *ptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_UNSTUFF            \
         assert(ptr)
 
 PERL_CALLCONV OP *
 Perl_list(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_LIST
 
@@ -2325,6 +2663,7 @@ Perl_list(pTHX_ OP *o)
 
 PERL_CALLCONV void
 Perl_load_module(pTHX_ U32 flags, SV *name, SV *ver, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_LOAD_MODULE            \
         assert(name)
@@ -2339,6 +2678,7 @@ Perl_locale_panic(const char *msg, const line_t immediate_caller_line, const cha
 
 PERL_CALLCONV OP *
 Perl_localize(pTHX_ OP *o, I32 lex)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_LOCALIZE               \
@@ -2353,6 +2693,7 @@ Perl_long_valid_utf8_to_uv(const U8 * const s, const U8 * const e)
 
 PERL_CALLCONV I32
 Perl_looks_like_number(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_LOOKS_LIKE_NUMBER      \
@@ -2360,6 +2701,7 @@ Perl_looks_like_number(pTHX_ SV * const sv)
 
 PERL_CALLCONV int
 Perl_magic_clear_all_env(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2368,6 +2710,7 @@ Perl_magic_clear_all_env(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_cleararylen_p(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2376,6 +2719,7 @@ Perl_magic_cleararylen_p(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_clearenv(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2384,6 +2728,7 @@ Perl_magic_clearenv(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_clearhint(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2392,6 +2737,7 @@ Perl_magic_clearhint(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_clearhints(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2400,6 +2746,7 @@ Perl_magic_clearhints(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_clearhook(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARHOOK        \
@@ -2407,6 +2754,7 @@ Perl_magic_clearhook(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_clearhookall(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARHOOKALL     \
@@ -2414,6 +2762,7 @@ Perl_magic_clearhookall(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_clearisa(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARISA         \
@@ -2421,6 +2770,7 @@ Perl_magic_clearisa(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_clearpack(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2429,6 +2779,7 @@ Perl_magic_clearpack(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_clearsig(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2437,6 +2788,7 @@ Perl_magic_clearsig(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_copycallchecker(pTHX_ SV *sv, MAGIC *mg, SV *nsv, const char *name, I32 namlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -2445,11 +2797,13 @@ Perl_magic_copycallchecker(pTHX_ SV *sv, MAGIC *mg, SV *nsv, const char *name, I
         assert(sv); assert(mg); assert(nsv)
 
 PERL_CALLCONV void
-Perl_magic_dump(pTHX_ const MAGIC *mg);
+Perl_magic_dump(pTHX_ const MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_MAGIC_DUMP
 
 PERL_CALLCONV int
 Perl_magic_existspack(pTHX_ SV *sv, const MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2458,6 +2812,7 @@ Perl_magic_existspack(pTHX_ SV *sv, const MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_freearylen_p(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2466,6 +2821,7 @@ Perl_magic_freearylen_p(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_freedestruct(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2474,6 +2830,7 @@ Perl_magic_freedestruct(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_freemglob(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2482,6 +2839,7 @@ Perl_magic_freemglob(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_freeovrld(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2490,6 +2848,7 @@ Perl_magic_freeovrld(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_freeutf8(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2498,6 +2857,7 @@ Perl_magic_freeutf8(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_get(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2506,6 +2866,7 @@ Perl_magic_get(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_getarylen(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2514,6 +2875,7 @@ Perl_magic_getarylen(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_getdebugvar(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2522,6 +2884,7 @@ Perl_magic_getdebugvar(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_getdefelem(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2530,6 +2893,7 @@ Perl_magic_getdefelem(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_getnkeys(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2538,6 +2902,7 @@ Perl_magic_getnkeys(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_getpack(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2546,6 +2911,7 @@ Perl_magic_getpack(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_getpos(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2554,6 +2920,7 @@ Perl_magic_getpos(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_getsig(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2562,6 +2929,7 @@ Perl_magic_getsig(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_getsubstr(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2570,6 +2938,7 @@ Perl_magic_getsubstr(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_gettaint(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2578,6 +2947,7 @@ Perl_magic_gettaint(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_getuvar(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2586,6 +2956,7 @@ Perl_magic_getuvar(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_getvec(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2594,6 +2965,7 @@ Perl_magic_getvec(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_killbackrefs(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2602,6 +2974,7 @@ Perl_magic_killbackrefs(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV SV *
 Perl_magic_methcall(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, U32 argc, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -2611,6 +2984,7 @@ Perl_magic_methcall(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, U32 argc
 
 PERL_CALLCONV int
 Perl_magic_nextpack(pTHX_ SV *sv, MAGIC *mg, SV *key)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -2620,6 +2994,7 @@ Perl_magic_nextpack(pTHX_ SV *sv, MAGIC *mg, SV *key)
 
 PERL_CALLCONV U32
 Perl_magic_regdata_cnt(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2628,6 +3003,7 @@ Perl_magic_regdata_cnt(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_regdatum_get(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2636,6 +3012,7 @@ Perl_magic_regdatum_get(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV SV *
 Perl_magic_scalarpack(pTHX_ HV *hv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2644,6 +3021,7 @@ Perl_magic_scalarpack(pTHX_ HV *hv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2652,6 +3030,7 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_set_all_env(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2660,6 +3039,7 @@ Perl_magic_set_all_env(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setarylen(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2668,6 +3048,7 @@ Perl_magic_setarylen(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setdbline(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2676,6 +3057,7 @@ Perl_magic_setdbline(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setdebugvar(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2684,6 +3066,7 @@ Perl_magic_setdebugvar(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setdefelem(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2692,6 +3075,7 @@ Perl_magic_setdefelem(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setenv(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2700,6 +3084,7 @@ Perl_magic_setenv(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_sethint(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2708,6 +3093,7 @@ Perl_magic_sethint(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_sethook(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETHOOK          \
@@ -2715,6 +3101,7 @@ Perl_magic_sethook(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_sethookall(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2723,6 +3110,7 @@ Perl_magic_sethookall(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setisa(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2731,6 +3119,7 @@ Perl_magic_setisa(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setlvref(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2739,6 +3128,7 @@ Perl_magic_setlvref(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setmglob(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2747,6 +3137,7 @@ Perl_magic_setmglob(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setnkeys(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2755,6 +3146,7 @@ Perl_magic_setnkeys(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setnonelem(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2763,6 +3155,7 @@ Perl_magic_setnonelem(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setpack(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2771,6 +3164,7 @@ Perl_magic_setpack(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setpos(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2779,6 +3173,7 @@ Perl_magic_setpos(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setregexp(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2787,6 +3182,7 @@ Perl_magic_setregexp(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setsig(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETSIG           \
@@ -2794,6 +3190,7 @@ Perl_magic_setsig(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setsigall(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2802,6 +3199,7 @@ Perl_magic_setsigall(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setsubstr(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2810,6 +3208,7 @@ Perl_magic_setsubstr(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_settaint(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2818,6 +3217,7 @@ Perl_magic_settaint(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setutf8(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2826,6 +3226,7 @@ Perl_magic_setutf8(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setuvar(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2834,6 +3235,7 @@ Perl_magic_setuvar(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setvec(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2842,6 +3244,7 @@ Perl_magic_setvec(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV U32
 Perl_magic_sizepack(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2850,6 +3253,7 @@ Perl_magic_sizepack(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_wipepack(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2863,13 +3267,15 @@ Perl_malloc(MEM_SIZE nbytes)
 #define PERL_ARGS_ASSERT_MALLOC
 
 PERL_CALLCONV Stack_off_t *
-Perl_markstack_grow(pTHX);
+Perl_markstack_grow(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_MARKSTACK_GROW
 
 #define PERL_ARGS_ASSERT_MBTOWC_
 
 PERL_CALLCONV SV *
 Perl_mess(pTHX_ const char *pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_MESS                   \
@@ -2877,6 +3283,7 @@ Perl_mess(pTHX_ const char *pat, ...)
 
 PERL_CALLCONV SV *
 Perl_mess_sv(pTHX_ SV *basemsg, bool consume)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MESS_SV                \
         assert(basemsg)
@@ -2887,12 +3294,14 @@ Perl_mfree(Malloc_t where);
 
 PERL_CALLCONV int
 Perl_mg_clear(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_CLEAR               \
         assert(sv)
 
 PERL_CALLCONV int
 Perl_mg_copy(pTHX_ SV *sv, SV *nsv, const char *key, I32 klen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_MG_COPY                \
@@ -2913,30 +3322,35 @@ Perl_mg_findext(const SV *sv, int type, const MGVTBL *vtbl)
 
 PERL_CALLCONV int
 Perl_mg_free(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_FREE                \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_mg_free_type(pTHX_ SV *sv, int how)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_FREE_TYPE           \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_mg_freeext(pTHX_ SV *sv, int how, const MGVTBL *vtbl)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_FREEEXT             \
         assert(sv)
 
 PERL_CALLCONV int
 Perl_mg_get(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_GET                 \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_mg_localize(pTHX_ SV *sv, SV *nsv, bool setmagic)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -2951,12 +3365,14 @@ Perl_mg_magical(SV *sv)
 
 PERL_CALLCONV int
 Perl_mg_set(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_SET                 \
         assert(sv)
 
 PERL_CALLCONV I32
 Perl_mg_size(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_SIZE                \
         assert(sv)
@@ -2969,47 +3385,56 @@ Perl_mini_mktime(struct tm *ptm)
 
 PERL_CALLCONV int
 Perl_mode_from_discipline(pTHX_ const char *s, STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MODE_FROM_DISCIPLINE
 
 PERL_CALLCONV void *
-Perl_more_bodies(pTHX_ const svtype sv_type);
+Perl_more_bodies(pTHX_ const svtype sv_type)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_MORE_BODIES
 
 PERL_CALLCONV SV *
-Perl_more_sv(pTHX);
+Perl_more_sv(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_MORE_SV
 
 PERL_CALLCONV const char *
 Perl_moreswitches(pTHX_ const char *s)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MORESWITCHES           \
         assert(s)
 
 PERL_CALLCONV void
 Perl_mortal_destructor_sv(pTHX_ SV *coderef, SV *args)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MORTAL_DESTRUCTOR_SV   \
         assert(coderef)
 
 PERL_CALLCONV void
-Perl_mortal_svfunc_x(pTHX_ SVFUNC_t f, SV *p);
+Perl_mortal_svfunc_x(pTHX_ SVFUNC_t f, SV *p)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_MORTAL_SVFUNC_X
 
 PERL_CALLCONV const struct mro_alg *
 Perl_mro_get_from_name(pTHX_ SV *name)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_GET_FROM_NAME      \
         assert(name)
 
 PERL_CALLCONV AV *
 Perl_mro_get_linear_isa(pTHX_ HV *stash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_GET_LINEAR_ISA     \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV SV *
 Perl_mro_get_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_alg * const which)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_MRO_GET_PRIVATE_DATA   \
@@ -3017,6 +3442,7 @@ Perl_mro_get_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_
 
 PERL_CALLCONV void
 Perl_mro_isa_changed_in(pTHX_ HV *stash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MRO_ISA_CHANGED_IN     \
@@ -3024,18 +3450,21 @@ Perl_mro_isa_changed_in(pTHX_ HV *stash)
 
 PERL_CALLCONV struct mro_meta *
 Perl_mro_meta_init(pTHX_ HV *stash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_META_INIT          \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_mro_method_changed_in(pTHX_ HV *stash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_METHOD_CHANGED_IN  \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_mro_package_moved(pTHX_ HV * const stash, HV * const oldstash, const GV * const gv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_MRO_PACKAGE_MOVED      \
         assert(!stash || SvTYPE(stash) == SVt_PVHV); \
@@ -3043,12 +3472,14 @@ Perl_mro_package_moved(pTHX_ HV * const stash, HV * const oldstash, const GV * c
 
 PERL_CALLCONV void
 Perl_mro_register(pTHX_ const struct mro_alg *mro)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_REGISTER           \
         assert(mro)
 
 PERL_CALLCONV void
 Perl_mro_set_mro(pTHX_ struct mro_meta * const meta, SV * const name)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_MRO_SET_MRO            \
@@ -3056,6 +3487,7 @@ Perl_mro_set_mro(pTHX_ struct mro_meta * const meta, SV * const name)
 
 PERL_CALLCONV SV *
 Perl_mro_set_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_alg * const which, SV * const data)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -3071,12 +3503,14 @@ Perl_mro_set_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_
 
 PERL_CALLCONV NV
 Perl_my_atof(pTHX_ const char *s)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MY_ATOF                \
         assert(s)
 
 PERL_CALLCONV char *
 Perl_my_atof2(pTHX_ const char *orig, NV *value)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_MY_ATOF2               \
@@ -3084,6 +3518,7 @@ Perl_my_atof2(pTHX_ const char *orig, NV *value)
 
 PERL_CALLCONV char *
 Perl_my_atof3(pTHX_ const char *orig, NV *value, const STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_MY_ATOF3               \
@@ -3091,13 +3526,15 @@ Perl_my_atof3(pTHX_ const char *orig, NV *value, const STRLEN len)
 
 PERL_CALLCONV OP *
 Perl_my_attrs(pTHX_ OP *o, OP *attrs)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MY_ATTRS               \
         assert(o)
 
 PERL_CALLCONV void
-Perl_my_clearenv(pTHX);
+Perl_my_clearenv(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_MY_CLEARENV
 
 PERL_CALLCONV int
@@ -3106,16 +3543,19 @@ Perl_my_dirfd(DIR *dir);
 
 PERL_CALLCONV_NO_RET void
 Perl_my_exit(pTHX_ U32 status)
+        Perl_attribute_nonnull_aTHX_
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_MY_EXIT
 
 PERL_CALLCONV_NO_RET void
 Perl_my_failure_exit(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_MY_FAILURE_EXIT
 
 PERL_CALLCONV I32
-Perl_my_fflush_all(pTHX);
+Perl_my_fflush_all(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_MY_FFLUSH_ALL
 
 PERL_CALLCONV Pid_t
@@ -3123,7 +3563,8 @@ Perl_my_fork(void);
 #define PERL_ARGS_ASSERT_MY_FORK
 
 PERL_CALLCONV I32
-Perl_my_lstat_flags(pTHX_ const U32 flags);
+Perl_my_lstat_flags(pTHX_ const U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_MY_LSTAT_FLAGS
 
 PERL_CALLCONV int
@@ -3144,13 +3585,15 @@ Perl_my_mkstemp_cloexec(char *templte)
 
 PERL_CALLCONV PerlIO *
 Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_MY_POPEN_LIST          \
         assert(mode); assert(args)
 
 PERL_CALLCONV void
-Perl_my_setenv(pTHX_ const char *nam, const char *val);
+Perl_my_setenv(pTHX_ const char *nam, const char *val)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_MY_SETENV
 
 PERL_CALLCONV int
@@ -3166,11 +3609,13 @@ Perl_my_socketpair(int family, int type, int protocol, int fd[2]);
 #define PERL_ARGS_ASSERT_MY_SOCKETPAIR
 
 PERL_CALLCONV I32
-Perl_my_stat_flags(pTHX_ const U32 flags);
+Perl_my_stat_flags(pTHX_ const U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_MY_STAT_FLAGS
 
 PERL_CALLCONV const char *
 Perl_my_strerror(pTHX_ const int errnum, utf8ness_t *utf8ness)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MY_STRERROR            \
@@ -3178,6 +3623,7 @@ Perl_my_strerror(pTHX_ const int errnum, utf8ness_t *utf8ness)
 
 PERL_CALLCONV char *
 Perl_my_strftime(pTHX_ const char *fmt, int sec, int min, int hour, int mday, int mon, int year, int wday, int yday, int isdst)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__format__(__strftime__,pTHX_1,0);
 #define PERL_ARGS_ASSERT_MY_STRFTIME            \
@@ -3192,6 +3638,7 @@ Perl_my_strtod(const char * const s, char **e)
 
 PERL_CALLCONV void
 Perl_my_unexec(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MY_UNEXEC
 
@@ -3203,25 +3650,30 @@ Perl_my_vsnprintf(char *buffer, const Size_t len, const char *format, va_list ap
         assert(buffer); assert(format)
 
 PERL_CALLCONV OP *
-Perl_newANONATTRSUB(pTHX_ I32 floor, OP *proto, OP *attrs, OP *block);
+Perl_newANONATTRSUB(pTHX_ I32 floor, OP *proto, OP *attrs, OP *block)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_NEWANONATTRSUB
 
 PERL_CALLCONV OP *
 Perl_newANONHASH(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWANONHASH
 
 PERL_CALLCONV OP *
 Perl_newANONLIST(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWANONLIST
 
 PERL_CALLCONV OP *
-Perl_newANONSUB(pTHX_ I32 floor, OP *proto, OP *block);
+Perl_newANONSUB(pTHX_ I32 floor, OP *proto, OP *block)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_NEWANONSUB
 
 PERL_CALLCONV OP *
 Perl_newARGDEFELEMOP(pTHX_ I32 flags, OP *expr, I32 argindex)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWARGDEFELEMOP        \
@@ -3229,22 +3681,27 @@ Perl_newARGDEFELEMOP(pTHX_ I32 flags, OP *expr, I32 argindex)
 
 PERL_CALLCONV OP *
 Perl_newASSIGNOP(pTHX_ I32 flags, OP *left, I32 optype, OP *right)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWASSIGNOP
 
 /* PERL_CALLCONV CV *
-Perl_newATTRSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block); */
+Perl_newATTRSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV CV *
-Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block, bool o_is_gv);
+Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block, bool o_is_gv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_NEWATTRSUB_X
 
 /* PERL_CALLCONV AV *
 Perl_newAV(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 PERL_CALLCONV OP *
 Perl_newAVREF(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWAVREF               \
@@ -3252,57 +3709,68 @@ Perl_newAVREF(pTHX_ OP *o)
 
 /* PERL_CALLCONV AV *
 Perl_newAV_alloc_x(pTHX_ SSize_t size)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 /* PERL_CALLCONV AV *
 Perl_newAV_alloc_xz(pTHX_ SSize_t size)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 /* PERL_CALLCONV AV *
 Perl_newAV_mortal(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 PERL_CALLCONV AV *
 Perl_newAVav(pTHX_ AV *oav)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWAVAV                \
         assert(!oav || SvTYPE(oav) == SVt_PVAV)
 
 PERL_CALLCONV AV *
 Perl_newAVhv(pTHX_ HV *ohv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWAVHV                \
         assert(!ohv || SvTYPE(ohv) == SVt_PVHV)
 
 PERL_CALLCONV OP *
 Perl_newBINOP(pTHX_ I32 type, I32 flags, OP *first, OP *last)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWBINOP
 
 PERL_CALLCONV OP *
 Perl_newCONDOP(pTHX_ I32 flags, OP *first, OP *trueop, OP *falseop)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWCONDOP              \
         assert(first)
 
 PERL_CALLCONV CV *
-Perl_newCONSTSUB(pTHX_ HV *stash, const char *name, SV *sv);
+Perl_newCONSTSUB(pTHX_ HV *stash, const char *name, SV *sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_NEWCONSTSUB            \
         assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV CV *
-Perl_newCONSTSUB_flags(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags, SV *sv);
+Perl_newCONSTSUB_flags(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags, SV *sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_NEWCONSTSUB_FLAGS      \
         assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV OP *
 Perl_newCVREF(pTHX_ I32 flags, OP *o)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWCVREF
 
 PERL_CALLCONV OP *
 Perl_newDEFEROP(pTHX_ I32 flags, OP *block)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWDEFEROP             \
@@ -3310,15 +3778,18 @@ Perl_newDEFEROP(pTHX_ I32 flags, OP *block)
 
 PERL_CALLCONV OP *
 Perl_newDEFSVOP(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWDEFSVOP
 
 PERL_CALLCONV void
-Perl_newFORM(pTHX_ I32 floor, OP *o, OP *block);
+Perl_newFORM(pTHX_ I32 floor, OP *o, OP *block)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_NEWFORM
 
 PERL_CALLCONV OP *
 Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWFOROP               \
@@ -3326,6 +3797,7 @@ Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
 
 PERL_CALLCONV OP *
 Perl_newGIVENOP(pTHX_ OP *cond, OP *block, PADOFFSET defsv_off)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -3334,12 +3806,14 @@ Perl_newGIVENOP(pTHX_ OP *cond, OP *block, PADOFFSET defsv_off)
 
 PERL_CALLCONV GP *
 Perl_newGP(pTHX_ GV * const gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_NEWGP                  \
         assert(gv)
 
 PERL_CALLCONV OP *
 Perl_newGVOP(pTHX_ I32 type, I32 flags, GV *gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWGVOP                \
@@ -3347,14 +3821,17 @@ Perl_newGVOP(pTHX_ I32 type, I32 flags, GV *gv)
 
 PERL_CALLCONV OP *
 Perl_newGVREF(pTHX_ I32 type, OP *o)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWGVREF
 
 /* PERL_CALLCONV GV *
-Perl_newGVgen(pTHX_ const char *pack); */
+Perl_newGVgen(pTHX_ const char *pack)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV GV *
 Perl_newGVgen_flags(pTHX_ const char *pack, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWGVGEN_FLAGS         \
@@ -3362,10 +3839,12 @@ Perl_newGVgen_flags(pTHX_ const char *pack, U32 flags)
 
 /* PERL_CALLCONV HV *
 Perl_newHV(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 PERL_CALLCONV OP *
 Perl_newHVREF(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWHVREF               \
@@ -3373,26 +3852,31 @@ Perl_newHVREF(pTHX_ OP *o)
 
 PERL_CALLCONV HV *
 Perl_newHVhv(pTHX_ HV *ohv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWHVHV                \
         assert(!ohv || SvTYPE(ohv) == SVt_PVHV)
 
 /* PERL_CALLCONV IO *
 Perl_newIO(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 PERL_CALLCONV OP *
 Perl_newLISTOP(pTHX_ I32 type, I32 flags, OP *first, OP *last)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLISTOP
 
 PERL_CALLCONV OP *
 Perl_newLISTOPn(pTHX_ I32 type, I32 flags, ...)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLISTOPN
 
 PERL_CALLCONV OP *
 Perl_newLOGOP(pTHX_ I32 optype, I32 flags, OP *first, OP *other)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
@@ -3401,6 +3885,7 @@ Perl_newLOGOP(pTHX_ I32 optype, I32 flags, OP *first, OP *other)
 
 PERL_CALLCONV OP *
 Perl_newLOOPEX(pTHX_ I32 type, OP *label)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLOOPEX              \
@@ -3408,6 +3893,7 @@ Perl_newLOOPEX(pTHX_ I32 type, OP *label)
 
 PERL_CALLCONV OP *
 Perl_newLOOPOP(pTHX_ I32 flags, I32 debuggable, OP *expr, OP *block)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLOOPOP              \
@@ -3415,6 +3901,7 @@ Perl_newLOOPOP(pTHX_ I32 flags, I32 debuggable, OP *expr, OP *block)
 
 PERL_CALLCONV OP *
 Perl_newMETHOP(pTHX_ I32 type, I32 flags, OP *dynamic_meth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWMETHOP              \
@@ -3422,6 +3909,7 @@ Perl_newMETHOP(pTHX_ I32 type, I32 flags, OP *dynamic_meth)
 
 PERL_CALLCONV OP *
 Perl_newMETHOP_named(pTHX_ I32 type, I32 flags, SV * const_meth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWMETHOP_NAMED        \
@@ -3429,17 +3917,20 @@ Perl_newMETHOP_named(pTHX_ I32 type, I32 flags, SV * const_meth)
 
 PERL_CALLCONV CV *
 Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_NEWMYSUB               \
         assert(o)
 
 PERL_CALLCONV OP *
 Perl_newNULLLIST(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWNULLLIST
 
 PERL_CALLCONV OP *
 Perl_newOP(pTHX_ I32 optype, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWOP
 
@@ -3464,22 +3955,26 @@ Perl_newPADNAMEpvn(const char *s, STRLEN len)
 
 PERL_CALLCONV OP *
 Perl_newPMOP(pTHX_ I32 type, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWPMOP
 
 PERL_CALLCONV void
 Perl_newPROG(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_NEWPROG                \
         assert(o)
 
 PERL_CALLCONV OP *
 Perl_newPVOP(pTHX_ I32 type, I32 flags, char *pv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWPVOP
 
 PERL_CALLCONV OP *
 Perl_newRANGE(pTHX_ I32 flags, OP *left, OP *right)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
@@ -3488,6 +3983,7 @@ Perl_newRANGE(pTHX_ I32 flags, OP *left, OP *right)
 
 PERL_CALLCONV SV *
 Perl_newRV(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWRV                  \
@@ -3495,31 +3991,37 @@ Perl_newRV(pTHX_ SV * const sv)
 
 PERL_CALLCONV OP *
 Perl_newSLICEOP(pTHX_ I32 flags, OP *subscript, OP *listop)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSLICEOP
 
 PERL_CALLCONV OP *
 Perl_newSTATEOP(pTHX_ I32 flags, char *label, OP *o)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSTATEOP
 
 PERL_CALLCONV CV *
 Perl_newSTUB(pTHX_ GV *gv, bool fake)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEWSTUB                \
         assert(gv)
 
 /* PERL_CALLCONV CV *
-Perl_newSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *block); */
+Perl_newSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *block)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV SV *
 Perl_newSV(pTHX_ const STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSV
 
 PERL_CALLCONV OP *
 Perl_newSVOP(pTHX_ I32 type, I32 flags, SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVOP                \
@@ -3527,6 +4029,7 @@ Perl_newSVOP(pTHX_ I32 type, I32 flags, SV *sv)
 
 PERL_CALLCONV OP *
 Perl_newSVREF(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVREF               \
@@ -3534,16 +4037,19 @@ Perl_newSVREF(pTHX_ OP *o)
 
 PERL_CALLCONV SV *
 Perl_newSV_false(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSV_FALSE
 
 PERL_CALLCONV SV *
 Perl_newSV_true(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSV_TRUE
 
 PERL_CALLCONV SV *
 Perl_newSVavdefelem(pTHX_ AV *av, SSize_t ix, bool extendible)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -3552,41 +4058,49 @@ Perl_newSVavdefelem(pTHX_ AV *av, SSize_t ix, bool extendible)
 
 PERL_CALLCONV SV *
 Perl_newSVbool(pTHX_ const bool bool_val)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVBOOL
 
 PERL_CALLCONV SV *
 Perl_newSVhek(pTHX_ const HEK * const hek)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVHEK
 
 PERL_CALLCONV SV *
 Perl_newSVhek_mortal(pTHX_ const HEK * const hek)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVHEK_MORTAL
 
 PERL_CALLCONV SV *
 Perl_newSViv(pTHX_ const IV i)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVIV
 
 PERL_CALLCONV SV *
 Perl_newSVnv(pTHX_ const NV n)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVNV
 
 PERL_CALLCONV SV *
 Perl_newSVpv(pTHX_ const char * const s, const STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVPV
 
 PERL_CALLCONV SV *
 Perl_newSVpv_share(pTHX_ const char *s, U32 hash)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVPV_SHARE
 
 PERL_CALLCONV SV *
 Perl_newSVpvf(pTHX_ const char * const pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
@@ -3595,36 +4109,43 @@ Perl_newSVpvf(pTHX_ const char * const pat, ...)
 
 PERL_CALLCONV SV *
 Perl_newSVpvn(pTHX_ const char * const s, const STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVPVN
 
 PERL_CALLCONV SV *
 Perl_newSVpvn_flags(pTHX_ const char * const s, const STRLEN len, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVPVN_FLAGS
 
 PERL_CALLCONV SV *
 Perl_newSVpvn_share(pTHX_ const char *s, I32 len, U32 hash)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVPVN_SHARE
 
 PERL_CALLCONV SV *
 Perl_newSVpvz(pTHX_ const STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVPVZ
 
 PERL_CALLCONV SV *
 Perl_newSVrv(pTHX_ SV * const rv, const char * const classname)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_NEWSVRV                \
         assert(rv)
 
 /* PERL_CALLCONV SV *
 Perl_newSVsv(pTHX_ SV * const old)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 PERL_CALLCONV SV *
 Perl_newSVsv_flags_NN(pTHX_ SV * const old, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVSV_FLAGS_NN       \
@@ -3632,15 +4153,18 @@ Perl_newSVsv_flags_NN(pTHX_ SV * const old, I32 flags)
 
 /* PERL_CALLCONV SV *
 Perl_newSVsv_nomg(pTHX_ SV * const old)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 PERL_CALLCONV SV *
 Perl_newSVuv(pTHX_ const UV u)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVUV
 
 PERL_CALLCONV OP *
 Perl_newTRYCATCHOP(pTHX_ I32 flags, OP *tryblock, OP *catchvar, OP *catchblock)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
@@ -3650,16 +4174,19 @@ Perl_newTRYCATCHOP(pTHX_ I32 flags, OP *tryblock, OP *catchvar, OP *catchblock)
 
 PERL_CALLCONV OP *
 Perl_newUNOP(pTHX_ I32 type, I32 flags, OP *first)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWUNOP
 
 PERL_CALLCONV OP *
 Perl_newUNOP_AUX(pTHX_ I32 type, I32 flags, OP *first, UNOP_AUX_item *aux)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWUNOP_AUX
 
 PERL_CALLCONV OP *
 Perl_newWHENOP(pTHX_ OP *cond, OP *block)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWWHENOP              \
@@ -3667,11 +4194,13 @@ Perl_newWHENOP(pTHX_ OP *cond, OP *block)
 
 PERL_CALLCONV OP *
 Perl_newWHILEOP(pTHX_ I32 flags, I32 debuggable, LOOP *loop, OP *expr, OP *block, OP *cont, I32 has_my)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWWHILEOP
 
 PERL_CALLCONV CV *
 Perl_newXS(pTHX_ const char *name, XSUBADDR_t subaddr, const char *filename)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_NEWXS                  \
@@ -3679,6 +4208,7 @@ Perl_newXS(pTHX_ const char *name, XSUBADDR_t subaddr, const char *filename)
 
 PERL_CALLCONV CV *
 Perl_newXS_deffile(pTHX_ const char *name, XSUBADDR_t subaddr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_NEWXS_DEFFILE          \
@@ -3686,6 +4216,7 @@ Perl_newXS_deffile(pTHX_ const char *name, XSUBADDR_t subaddr)
 
 PERL_CALLCONV CV *
 Perl_newXS_flags(pTHX_ const char *name, XSUBADDR_t subaddr, const char * const filename, const char * const proto, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_NEWXS_FLAGS            \
@@ -3693,6 +4224,7 @@ Perl_newXS_flags(pTHX_ const char *name, XSUBADDR_t subaddr, const char * const 
 
 PERL_CALLCONV CV *
 Perl_newXS_len_flags(pTHX_ const char *name, STRLEN len, XSUBADDR_t subaddr, const char * const filename, const char * const proto, SV ** const_svp, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEWXS_LEN_FLAGS        \
@@ -3700,6 +4232,7 @@ Perl_newXS_len_flags(pTHX_ const char *name, STRLEN len, XSUBADDR_t subaddr, con
 
 PERL_CALLCONV OP *
 Perl_new_block_statement(pTHX_ OP *block, OP *cont)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEW_BLOCK_STATEMENT    \
@@ -3707,16 +4240,19 @@ Perl_new_block_statement(pTHX_ OP *block, OP *cont)
 
 PERL_CALLCONV PERL_SI *
 Perl_new_stackinfo(pTHX_ I32 stitems, I32 cxitems)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEW_STACKINFO
 
 PERL_CALLCONV PERL_SI *
 Perl_new_stackinfo_flags(pTHX_ I32 stitems, I32 cxitems, UV flags)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEW_STACKINFO_FLAGS
 
 PERL_CALLCONV SV *
 Perl_new_version(pTHX_ SV *ver)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_NEW_VERSION            \
         assert(ver)
@@ -3726,6 +4262,7 @@ Perl_new_version(pTHX_ SV *ver)
 
 PERL_CALLCONV PerlIO *
 Perl_nextargv(pTHX_ GV *gv, bool nomagicopen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEXTARGV               \
@@ -3745,6 +4282,7 @@ Perl_ninstr(const char *big, const char *bigend, const char *little, const char 
 
 PERL_CALLCONV void
 Perl_no_bareword_filehandle(pTHX_ const char *fhname)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NO_BAREWORD_FILEHANDLE \
@@ -3763,16 +4301,19 @@ Perl_noshutdownhook(void);
 #define PERL_ARGS_ASSERT_NOSHUTDOWNHOOK
 
 PERL_CALLCONV int
-Perl_nothreadhook(pTHX);
+Perl_nothreadhook(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_NOTHREADHOOK
 
 PERL_CALLCONV void
 Perl_notify_parser_that_encoding_changed(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NOTIFY_PARSER_THAT_ENCODING_CHANGED
 
 PERL_CALLCONV OP *
 Perl_oopsAV(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -3781,6 +4322,7 @@ Perl_oopsAV(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_oopsHV(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -3788,15 +4330,18 @@ Perl_oopsHV(pTHX_ OP *o)
         assert(o)
 
 PERL_CALLCONV OP *
-Perl_op_append_elem(pTHX_ I32 optype, OP *first, OP *last);
+Perl_op_append_elem(pTHX_ I32 optype, OP *first, OP *last)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_OP_APPEND_ELEM
 
 PERL_CALLCONV OP *
-Perl_op_append_list(pTHX_ I32 optype, OP *first, OP *last);
+Perl_op_append_list(pTHX_ I32 optype, OP *first, OP *last)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_OP_APPEND_LIST
 
 PERL_CALLCONV OPclass
-Perl_op_class(pTHX_ const OP *o);
+Perl_op_class(pTHX_ const OP *o)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_OP_CLASS
 
 #define PERL_ARGS_ASSERT_OP_CLEAR               \
@@ -3804,44 +4349,53 @@ Perl_op_class(pTHX_ const OP *o);
 
 PERL_CALLCONV OP *
 Perl_op_contextualize(pTHX_ OP *o, I32 context)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_CONTEXTUALIZE       \
         assert(o)
 
 PERL_CALLCONV OP *
 Perl_op_convert_list(pTHX_ I32 optype, I32 flags, OP *o)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_OP_CONVERT_LIST
 
 PERL_CALLCONV void
 Perl_op_dump(pTHX_ const OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_DUMP                \
         assert(o)
 
 PERL_CALLCONV OP *
-Perl_op_force_list(pTHX_ OP *o);
+Perl_op_force_list(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_OP_FORCE_LIST
 
 PERL_CALLCONV void
-Perl_op_free(pTHX_ OP *arg);
+Perl_op_free(pTHX_ OP *arg)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_OP_FREE
 
 PERL_CALLCONV OP *
 Perl_op_linklist(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_LINKLIST            \
         assert(o)
 
 /* PERL_CALLCONV OP *
-Perl_op_lvalue(pTHX_ OP *o, I32 type); */
+Perl_op_lvalue(pTHX_ OP *o, I32 type)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV OP *
-Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags);
+Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_OP_LVALUE_FLAGS
 
 PERL_CALLCONV void
 Perl_op_null(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_NULL                \
         assert(o)
@@ -3853,32 +4407,39 @@ Perl_op_parent(OP *o)
         assert(o)
 
 PERL_CALLCONV OP *
-Perl_op_prepend_elem(pTHX_ I32 optype, OP *first, OP *last);
+Perl_op_prepend_elem(pTHX_ I32 optype, OP *first, OP *last)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_OP_PREPEND_ELEM
 
 PERL_CALLCONV void
-Perl_op_refcnt_lock(pTHX);
+Perl_op_refcnt_lock(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_OP_REFCNT_LOCK
 
 PERL_CALLCONV void
-Perl_op_refcnt_unlock(pTHX);
+Perl_op_refcnt_unlock(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_OP_REFCNT_UNLOCK
 
 PERL_CALLCONV OP *
-Perl_op_scope(pTHX_ OP *o);
+Perl_op_scope(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_OP_SCOPE
 
 PERL_CALLCONV OP *
-Perl_op_sibling_splice(pTHX_ OP *parent, OP *start, int del_count, OP *insert);
+Perl_op_sibling_splice(pTHX_ OP *parent, OP *start, int del_count, OP *insert)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_OP_SIBLING_SPLICE
 
 PERL_CALLCONV OP *
 Perl_op_unscope(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_OP_UNSCOPE
 
 PERL_CALLCONV OP *
 Perl_op_wrap_finally(pTHX_ OP *block, OP *finally)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -3887,6 +4448,7 @@ Perl_op_wrap_finally(pTHX_ OP *block, OP *finally)
 
 PERL_CALLCONV void
 Perl_opdump_printf(pTHX_ struct Perl_OpDumpContext *ctx, const char *pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
@@ -3895,11 +4457,13 @@ Perl_opdump_printf(pTHX_ struct Perl_OpDumpContext *ctx, const char *pat, ...)
 
 PERL_CALLCONV void
 Perl_output_non_portable(pTHX_ const U8 shift)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_OUTPUT_NON_PORTABLE
 
 PERL_CALLCONV void
 Perl_package(pTHX_ OP *name, OP *version)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PACKAGE                \
@@ -3907,6 +4471,7 @@ Perl_package(pTHX_ OP *name, OP *version)
 
 PERL_CALLCONV void
 Perl_packlist(pTHX_ SV *cat, const char *pat, const char *patend, SV **beglist, SV **endlist)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -3918,6 +4483,7 @@ Perl_packlist(pTHX_ SV *cat, const char *pat, const char *patend, SV **beglist, 
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_add_anon(pTHX_ CV *func, I32 optype)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_ANON           \
         assert(func); \
@@ -3925,6 +4491,7 @@ Perl_pad_add_anon(pTHX_ CV *func, I32 optype)
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_add_name_pv(pTHX_ const char *name, const U32 flags, HV *typestash, HV *ourstash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_NAME_PV        \
         assert(name); assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
@@ -3932,6 +4499,7 @@ Perl_pad_add_name_pv(pTHX_ const char *name, const U32 flags, HV *typestash, HV 
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_add_name_pvn(pTHX_ const char *namepv, STRLEN namelen, U32 flags, HV *typestash, HV *ourstash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_NAME_PVN       \
         assert(namepv); assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
@@ -3939,6 +4507,7 @@ Perl_pad_add_name_pvn(pTHX_ const char *namepv, STRLEN namelen, U32 flags, HV *t
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_add_name_sv(pTHX_ SV *name, U32 flags, HV *typestash, HV *ourstash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_NAME_SV        \
         assert(name); assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
@@ -3946,6 +4515,7 @@ Perl_pad_add_name_sv(pTHX_ SV *name, U32 flags, HV *typestash, HV *ourstash)
 
 PERL_CALLCONV void
 Perl_pad_add_weakref(pTHX_ CV *func)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_ADD_WEAKREF        \
@@ -3953,34 +4523,40 @@ Perl_pad_add_weakref(pTHX_ CV *func)
         assert(SvTYPE(func) == SVt_PVCV || SvTYPE(func) == SVt_PVFM)
 
 PERL_CALLCONV PADOFFSET
-Perl_pad_alloc(pTHX_ I32 optype, U32 tmptype);
+Perl_pad_alloc(pTHX_ I32 optype, U32 tmptype)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PAD_ALLOC
 
 PERL_CALLCONV void
 Perl_pad_block_start(pTHX_ int full)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_BLOCK_START
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_findmy_pv(pTHX_ const char *name, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_FINDMY_PV          \
         assert(name)
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_findmy_pvn(pTHX_ const char *namepv, STRLEN namelen, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_FINDMY_PVN         \
         assert(namepv)
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_findmy_sv(pTHX_ SV *name, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_FINDMY_SV          \
         assert(name)
 
 PERL_CALLCONV void
 Perl_pad_fixup_inner_anons(pTHX_ PADLIST *padlist, CV *old_cv, CV *new_cv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -3993,36 +4569,43 @@ Perl_pad_fixup_inner_anons(pTHX_ PADLIST *padlist, CV *old_cv, CV *new_cv)
 
 PERL_CALLCONV void
 Perl_pad_free(pTHX_ PADOFFSET po)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_FREE
 
 PERL_CALLCONV OP *
 Perl_pad_leavemy(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_LEAVEMY
 
 PERL_CALLCONV PADLIST *
 Perl_pad_new(pTHX_ int flags)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_PAD_NEW
 
 PERL_CALLCONV void
 Perl_pad_push(pTHX_ PADLIST *padlist, int depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_PUSH               \
         assert(padlist)
 
 PERL_CALLCONV void
 Perl_pad_swipe(pTHX_ PADOFFSET po, bool refadjust)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_SWIPE
 
 PERL_CALLCONV void
-Perl_pad_tidy(pTHX_ padtidy_type type);
+Perl_pad_tidy(pTHX_ padtidy_type type)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PAD_TIDY
 
 PERL_CALLCONV PAD **
 Perl_padlist_store(pTHX_ PADLIST *padlist, I32 key, PAD *val)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PADLIST_STORE          \
@@ -4030,6 +4613,7 @@ Perl_padlist_store(pTHX_ PADLIST *padlist, I32 key, PAD *val)
 
 PERL_CALLCONV void
 Perl_padname_free(pTHX_ PADNAME *pn)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PADNAME_FREE           \
         assert(pn)
@@ -4043,61 +4627,74 @@ Perl_padnamelist_fetch(PADNAMELIST *pnl, SSize_t key)
 
 PERL_CALLCONV void
 Perl_padnamelist_free(pTHX_ PADNAMELIST *pnl)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PADNAMELIST_FREE       \
         assert(pnl)
 
 PERL_CALLCONV PADNAME **
 Perl_padnamelist_store(pTHX_ PADNAMELIST *pnl, SSize_t key, PADNAME *val)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PADNAMELIST_STORE      \
         assert(pnl)
 
 PERL_CALLCONV OP *
-Perl_parse_arithexpr(pTHX_ U32 flags);
+Perl_parse_arithexpr(pTHX_ U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PARSE_ARITHEXPR
 
 PERL_CALLCONV OP *
-Perl_parse_barestmt(pTHX_ U32 flags);
+Perl_parse_barestmt(pTHX_ U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PARSE_BARESTMT
 
 PERL_CALLCONV OP *
-Perl_parse_block(pTHX_ U32 flags);
+Perl_parse_block(pTHX_ U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PARSE_BLOCK
 
 PERL_CALLCONV OP *
-Perl_parse_fullexpr(pTHX_ U32 flags);
+Perl_parse_fullexpr(pTHX_ U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PARSE_FULLEXPR
 
 PERL_CALLCONV OP *
-Perl_parse_fullstmt(pTHX_ U32 flags);
+Perl_parse_fullstmt(pTHX_ U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PARSE_FULLSTMT
 
 #define PERL_ARGS_ASSERT_PARSE_IDENT_MSG        \
         assert(s); assert(end); assert(s < end)
 
 PERL_CALLCONV SV *
-Perl_parse_label(pTHX_ U32 flags);
+Perl_parse_label(pTHX_ U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PARSE_LABEL
 
 PERL_CALLCONV OP *
-Perl_parse_listexpr(pTHX_ U32 flags);
+Perl_parse_listexpr(pTHX_ U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PARSE_LISTEXPR
 
 PERL_CALLCONV OP *
-Perl_parse_stmtseq(pTHX_ U32 flags);
+Perl_parse_stmtseq(pTHX_ U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PARSE_STMTSEQ
 
 PERL_CALLCONV OP *
-Perl_parse_subsignature(pTHX_ U32 flags);
+Perl_parse_subsignature(pTHX_ U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PARSE_SUBSIGNATURE
 
 PERL_CALLCONV OP *
-Perl_parse_termexpr(pTHX_ U32 flags);
+Perl_parse_termexpr(pTHX_ U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PARSE_TERMEXPR
 
 PERL_CALLCONV U32
 Perl_parse_unicode_opts(pTHX_ const char **popt)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PARSE_UNICODE_OPTS     \
@@ -4105,6 +4702,7 @@ Perl_parse_unicode_opts(pTHX_ const char **popt)
 
 PERL_CALLCONV void
 Perl_parser_free(pTHX_ const yy_parser *parser)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PARSER_FREE            \
@@ -4112,6 +4710,7 @@ Perl_parser_free(pTHX_ const yy_parser *parser)
 
 PERL_CALLCONV void
 Perl_peep(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PEEP
 
@@ -4154,14 +4753,17 @@ Perl_perly_sighandler(int sig, Siginfo_t *info, void *uap, bool safe);
 #define PERL_ARGS_ASSERT_PERLY_SIGHANDLER
 
 /* PERL_CALLCONV const char *
-Perl_phase_name(pTHX_ enum perl_phase phase); */
+Perl_phase_name(pTHX_ enum perl_phase phase)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
-Perl_pmop_dump(pTHX_ PMOP *pm);
+Perl_pmop_dump(pTHX_ PMOP *pm)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PMOP_DUMP
 
 PERL_CALLCONV OP *
 Perl_pmruntime(pTHX_ OP *o, OP *expr, OP *repl, UV flags, I32 floor)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -4169,11 +4771,13 @@ Perl_pmruntime(pTHX_ OP *o, OP *expr, OP *repl, UV flags, I32 floor)
         assert(o); assert(expr)
 
 PERL_CALLCONV void
-Perl_pop_scope(pTHX);
+Perl_pop_scope(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_POP_SCOPE
 
 PERL_CALLCONV void
 Perl_populate_isa(pTHX_ const char *name, STRLEN len, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_POPULATE_ISA           \
@@ -4181,12 +4785,14 @@ Perl_populate_isa(pTHX_ const char *name, STRLEN len, ...)
 
 PERL_CALLCONV REGEXP *
 Perl_pregcomp(pTHX_ SV * const pattern, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PREGCOMP               \
         assert(pattern)
 
 PERL_CALLCONV I32
 Perl_pregexec(pTHX_ REGEXP * const prog, char *stringarg, char *strend, char *strbeg, SSize_t minend, SV *screamer, U32 nosave)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -4198,56 +4804,66 @@ Perl_pregexec(pTHX_ REGEXP * const prog, char *stringarg, char *strend, char *st
         assert(stringarg <= strend)
 
 PERL_CALLCONV void
-Perl_pregfree(pTHX_ REGEXP *r);
+Perl_pregfree(pTHX_ REGEXP *r)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PREGFREE
 
 PERL_CALLCONV void
 Perl_pregfree2(pTHX_ REGEXP *rx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PREGFREE2              \
         assert(rx)
 
 PERL_CALLCONV const char *
 Perl_prescan_version(pTHX_ const char *s, bool strict, const char **errstr, bool *sqv, int *ssaw_decimal, int *swidth, bool *salpha)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PRESCAN_VERSION        \
         assert(s)
 
 PERL_CALLCONV void *
 Perl_ptr_table_fetch(pTHX_ PTR_TBL_t * const tbl, const void * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_PTR_TABLE_FETCH        \
         assert(tbl)
 
 PERL_CALLCONV void
-Perl_ptr_table_free(pTHX_ PTR_TBL_t * const tbl);
+Perl_ptr_table_free(pTHX_ PTR_TBL_t * const tbl)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PTR_TABLE_FREE
 
 PERL_CALLCONV PTR_TBL_t *
 Perl_ptr_table_new(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_PTR_TABLE_NEW
 
 PERL_CALLCONV void
 Perl_ptr_table_split(pTHX_ PTR_TBL_t * const tbl)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PTR_TABLE_SPLIT        \
         assert(tbl)
 
 PERL_CALLCONV void
 Perl_ptr_table_store(pTHX_ PTR_TBL_t * const tbl, const void * const oldsv, void * const newsv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_PTR_TABLE_STORE        \
         assert(tbl); assert(newsv)
 
 PERL_CALLCONV void
-Perl_push_scope(pTHX);
+Perl_push_scope(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_PUSH_SCOPE
 
 PERL_CALLCONV char *
 Perl_pv_display(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pvlim)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_DISPLAY             \
@@ -4255,12 +4871,14 @@ Perl_pv_display(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pv
 
 PERL_CALLCONV char *
 Perl_pv_escape(pTHX_ SV *dsv, char const * const str, const STRLEN count, STRLEN max, STRLEN * const escaped, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_ESCAPE              \
         assert(str)
 
 PERL_CALLCONV char *
 Perl_pv_pretty(pTHX_ SV *dsv, char const * const str, const STRLEN count, const STRLEN max, char const * const start_color, char const * const end_color, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_PRETTY              \
@@ -4268,6 +4886,7 @@ Perl_pv_pretty(pTHX_ SV *dsv, char const * const str, const STRLEN count, const 
 
 PERL_CALLCONV char *
 Perl_pv_uni_display(pTHX_ SV *dsv, const U8 *spv, STRLEN len, STRLEN pvlim, UV flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_UNI_DISPLAY         \
@@ -4276,27 +4895,32 @@ Perl_pv_uni_display(pTHX_ SV *dsv, const U8 *spv, STRLEN len, STRLEN pvlim, UV f
 #define PERL_ARGS_ASSERT_QERROR
 
 PERL_CALLCONV char *
-Perl_rcpv_copy(pTHX_ char * const pv);
+Perl_rcpv_copy(pTHX_ char * const pv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_RCPV_COPY
 
 PERL_CALLCONV char *
-Perl_rcpv_free(pTHX_ char * const pv);
+Perl_rcpv_free(pTHX_ char * const pv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_RCPV_FREE
 
 PERL_CALLCONV char *
 Perl_rcpv_new(pTHX_ const char * const pv, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         __attribute__malloc__
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_RCPV_NEW
 
 PERL_CALLCONV REGEXP *
 Perl_re_compile(pTHX_ SV * const pattern, U32 orig_rx_flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_RE_COMPILE             \
         assert(pattern)
 
 PERL_CALLCONV char *
 Perl_re_intuit_start(pTHX_ REGEXP * const rx, SV *sv, const char * const strbeg, char *strpos, char *strend, const U32 flags, re_scream_pos_data *data)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
@@ -4307,12 +4931,14 @@ Perl_re_intuit_start(pTHX_ REGEXP * const rx, SV *sv, const char * const strbeg,
 
 PERL_CALLCONV SV *
 Perl_re_intuit_string(pTHX_ REGEXP * const r)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_RE_INTUIT_STRING       \
         assert(r)
 
 PERL_CALLCONV REGEXP *
 Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count, OP *expr, const regexp_engine *eng, REGEXP *old_re, bool *is_bare_re, const U32 rx_flags, const U32 pm_flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_4);
 #define PERL_ARGS_ASSERT_RE_OP_COMPILE          \
         assert(eng)
@@ -4323,11 +4949,13 @@ Perl_realloc(Malloc_t where, MEM_SIZE nbytes)
 #define PERL_ARGS_ASSERT_REALLOC
 
 PERL_CALLCONV void
-Perl_reentrant_free(pTHX);
+Perl_reentrant_free(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_REENTRANT_FREE
 
 PERL_CALLCONV void
-Perl_reentrant_init(pTHX);
+Perl_reentrant_init(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_REENTRANT_INIT
 
 PERL_CALLCONV void *
@@ -4337,53 +4965,63 @@ Perl_reentrant_retry(const char *f, ...)
         assert(f)
 
 PERL_CALLCONV void
-Perl_reentrant_size(pTHX);
+Perl_reentrant_size(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_REENTRANT_SIZE
 
 PERL_CALLCONV HV *
-Perl_refcounted_he_chain_2hv(pTHX_ const struct refcounted_he *c, U32 flags);
+Perl_refcounted_he_chain_2hv(pTHX_ const struct refcounted_he *c, U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_CHAIN_2HV
 
 PERL_CALLCONV SV *
 Perl_refcounted_he_fetch_pv(pTHX_ const struct refcounted_he *chain, const char *key, U32 hash, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_PV \
         assert(key)
 
 PERL_CALLCONV SV *
 Perl_refcounted_he_fetch_pvn(pTHX_ const struct refcounted_he *chain, const char *keypv, STRLEN keylen, U32 hash, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_PVN \
         assert(keypv)
 
 PERL_CALLCONV SV *
 Perl_refcounted_he_fetch_sv(pTHX_ const struct refcounted_he *chain, SV *key, U32 hash, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_SV \
         assert(key)
 
 PERL_CALLCONV void
-Perl_refcounted_he_free(pTHX_ struct refcounted_he *he);
+Perl_refcounted_he_free(pTHX_ struct refcounted_he *he)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_FREE
 
 PERL_CALLCONV struct refcounted_he *
-Perl_refcounted_he_inc(pTHX_ struct refcounted_he *he);
+Perl_refcounted_he_inc(pTHX_ struct refcounted_he *he)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_INC
 
 PERL_CALLCONV struct refcounted_he *
 Perl_refcounted_he_new_pv(pTHX_ struct refcounted_he *parent, const char *key, U32 hash, SV *value, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_PV   \
         assert(key)
 
 PERL_CALLCONV struct refcounted_he *
 Perl_refcounted_he_new_pvn(pTHX_ struct refcounted_he *parent, const char *keypv, STRLEN keylen, U32 hash, SV *value, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_PVN  \
         assert(keypv)
 
 PERL_CALLCONV struct refcounted_he *
 Perl_refcounted_he_new_sv(pTHX_ struct refcounted_he *parent, SV *key, U32 hash, SV *value, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_SV   \
         assert(key)
@@ -4393,12 +5031,14 @@ Perl_refcounted_he_new_sv(pTHX_ struct refcounted_he *parent, SV *key, U32 hash,
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_all(pTHX_ REGEXP * const rx, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_ALL     \
         assert(rx)
 
 PERL_CALLCONV bool
 Perl_reg_named_buff_exists(pTHX_ REGEXP * const rx, SV * const key, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_EXISTS  \
@@ -4406,6 +5046,7 @@ Perl_reg_named_buff_exists(pTHX_ REGEXP * const rx, SV * const key, const U32 fl
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_fetch(pTHX_ REGEXP * const rx, SV * const namesv, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_FETCH   \
@@ -4413,6 +5054,7 @@ Perl_reg_named_buff_fetch(pTHX_ REGEXP * const rx, SV * const namesv, const U32 
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_firstkey(pTHX_ REGEXP * const rx, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_FIRSTKEY \
         assert(rx)
@@ -4422,12 +5064,14 @@ Perl_reg_named_buff_firstkey(pTHX_ REGEXP * const rx, const U32 flags)
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_nextkey(pTHX_ REGEXP * const rx, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_NEXTKEY \
         assert(rx)
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_scalar(pTHX_ REGEXP * const rx, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_SCALAR  \
         assert(rx)
@@ -4452,12 +5096,14 @@ Perl_reg_named_buff_scalar(pTHX_ REGEXP * const rx, const U32 flags)
 
 PERL_CALLCONV void
 Perl_regdump(pTHX_ const regexp *r)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REGDUMP                \
         assert(r)
 
 PERL_CALLCONV I32
 Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend, char *strbeg, SSize_t minend, SV *sv, void *data, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -4469,16 +5115,19 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend, char 
 
 PERL_CALLCONV void
 Perl_regfree_internal(pTHX_ REGEXP * const rx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REGFREE_INTERNAL       \
         assert(rx)
 
 PERL_CALLCONV void
-Perl_reginitcolors(pTHX);
+Perl_reginitcolors(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_REGINITCOLORS
 
 PERL_CALLCONV void
 Perl_release_RExC_state(pTHX_ void *vstate)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_RELEASE_REXC_STATE     \
@@ -4493,6 +5142,7 @@ Perl_repeatcpy(char *to, const char *from, SSize_t len, IV count)
 
 PERL_CALLCONV void
 Perl_report_evil_fh(pTHX_ const GV *gv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_REPORT_EVIL_FH
 
@@ -4500,26 +5150,31 @@ Perl_report_evil_fh(pTHX_ const GV *gv)
 
 PERL_CALLCONV void
 Perl_report_wrongway_fh(pTHX_ const GV *gv, const char have)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_REPORT_WRONGWAY_FH
 
 PERL_CALLCONV void
 Perl_require_pv(pTHX_ const char *pv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REQUIRE_PV             \
         assert(pv)
 
 PERL_CALLCONV void
 Perl_resume_compcv(pTHX_ struct suspended_compcv *buffer, bool save)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_RESUME_COMPCV          \
         assert(buffer)
 
 /* PERL_CALLCONV void
-Perl_resume_compcv_and_save(pTHX_ struct suspended_compcv *buffer); */
+Perl_resume_compcv_and_save(pTHX_ struct suspended_compcv *buffer)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV void
-Perl_resume_compcv_final(pTHX_ struct suspended_compcv *buffer); */
+Perl_resume_compcv_final(pTHX_ struct suspended_compcv *buffer)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV char *
 Perl_rninstr(const char *big, const char *bigend, const char *little, const char *lend)
@@ -4535,56 +5190,67 @@ Perl_rninstr(const char *big, const char *bigend, const char *little, const char
 
 PERL_CALLCONV void
 Perl_rpeep(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_RPEEP
 
 PERL_CALLCONV void
 Perl_rpp_free_2_(pTHX_ SV * const sv1, SV * const sv2, const U32 rc1, const U32 rc2)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_RPP_FREE_2_            \
         assert(sv1); assert(sv2)
 
 PERL_CALLCONV void
-Perl_rpp_obliterate_stack_to(pTHX_ I32 ix);
+Perl_rpp_obliterate_stack_to(pTHX_ I32 ix)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_RPP_OBLITERATE_STACK_TO
 
 PERL_CALLCONV Sighandler_t
-Perl_rsignal(pTHX_ int i, Sighandler_t t);
+Perl_rsignal(pTHX_ int i, Sighandler_t t)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_RSIGNAL
 
 PERL_CALLCONV int
 Perl_rsignal_restore(pTHX_ int i, Sigsave_t *t)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_RSIGNAL_RESTORE
 
 PERL_CALLCONV int
 Perl_rsignal_save(pTHX_ int i, Sighandler_t t1, Sigsave_t *save)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_RSIGNAL_SAVE           \
         assert(save)
 
 PERL_CALLCONV Sighandler_t
-Perl_rsignal_state(pTHX_ int i);
+Perl_rsignal_state(pTHX_ int i)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_RSIGNAL_STATE
 
 PERL_CALLCONV int
-Perl_runops_debug(pTHX);
+Perl_runops_debug(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_RUNOPS_DEBUG
 
 PERL_CALLCONV int
-Perl_runops_standard(pTHX);
+Perl_runops_standard(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_RUNOPS_STANDARD
 
 PERL_CALLCONV CV *
 Perl_rv2cv_op_cv(pTHX_ OP *cvop, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_RV2CV_OP_CV            \
         assert(cvop)
 
 PERL_CALLCONV void
 Perl_rxres_save(pTHX_ void **rsp, REGEXP *rx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -4614,68 +5280,80 @@ Perl_safesysrealloc(Malloc_t where, MEM_SIZE nbytes)
 
 PERL_CALLCONV void
 Perl_save_I16(pTHX_ I16 *intp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_I16               \
         assert(intp)
 
 PERL_CALLCONV void
 Perl_save_I32(pTHX_ I32 *intp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_I32               \
         assert(intp)
 
 PERL_CALLCONV void
 Perl_save_I8(pTHX_ I8 *bytep)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_I8                \
         assert(bytep)
 
 PERL_CALLCONV void
 Perl_save_adelete(pTHX_ AV *av, SSize_t key)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_ADELETE           \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 /* PERL_CALLCONV void
-Perl_save_aelem(pTHX_ AV *av, SSize_t idx, SV **sptr); */
+Perl_save_aelem(pTHX_ AV *av, SSize_t idx, SV **sptr)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_save_aelem_flags(pTHX_ AV *av, SSize_t idx, SV **sptr, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SAVE_AELEM_FLAGS       \
         assert(av); assert(SvTYPE(av) == SVt_PVAV); assert(sptr)
 
 PERL_CALLCONV SSize_t
-Perl_save_alloc(pTHX_ SSize_t size, I32 pad);
+Perl_save_alloc(pTHX_ SSize_t size, I32 pad)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SAVE_ALLOC
 
 PERL_CALLCONV void
 Perl_save_aptr(pTHX_ AV **aptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_APTR              \
         assert(aptr)
 
 PERL_CALLCONV AV *
 Perl_save_ary(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_ARY               \
         assert(gv)
 
 PERL_CALLCONV void
 Perl_save_bool(pTHX_ bool *boolp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_BOOL              \
         assert(boolp)
 
 PERL_CALLCONV void
 Perl_save_clearsv(pTHX_ SV **svp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_CLEARSV           \
         assert(svp)
 
 PERL_CALLCONV void
 Perl_save_delete(pTHX_ HV *hv, char *key, I32 klen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SAVE_DELETE            \
@@ -4683,65 +5361,78 @@ Perl_save_delete(pTHX_ HV *hv, char *key, I32 klen)
 
 PERL_CALLCONV void
 Perl_save_destructor(pTHX_ DESTRUCTORFUNC_NOCONTEXT_t f, void *p)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SAVE_DESTRUCTOR        \
         assert(p)
 
 PERL_CALLCONV void
-Perl_save_destructor_x(pTHX_ DESTRUCTORFUNC_t f, void *p);
+Perl_save_destructor_x(pTHX_ DESTRUCTORFUNC_t f, void *p)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SAVE_DESTRUCTOR_X
 
 /* PERL_CALLCONV void
-Perl_save_freeop(pTHX_ OP *o); */
+Perl_save_freeop(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV void
-Perl_save_freepv(pTHX_ char *pv); */
+Perl_save_freepv(pTHX_ char *pv)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_save_freercpv(pTHX_ char *rcpv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_FREERCPV          \
         assert(rcpv)
 
 /* PERL_CALLCONV void
-Perl_save_freesv(pTHX_ SV *sv); */
+Perl_save_freesv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_save_generic_pvref(pTHX_ char **str)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_GENERIC_PVREF     \
         assert(str)
 
 PERL_CALLCONV void
 Perl_save_generic_svref(pTHX_ SV **sptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_GENERIC_SVREF     \
         assert(sptr)
 
 PERL_CALLCONV void
 Perl_save_gp(pTHX_ GV *gv, I32 empty)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_GP                \
         assert(gv)
 
 PERL_CALLCONV HV *
 Perl_save_hash(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_HASH              \
         assert(gv)
 
 PERL_CALLCONV void
 Perl_save_hdelete(pTHX_ HV *hv, SV *keysv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SAVE_HDELETE           \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(keysv)
 
 /* PERL_CALLCONV void
-Perl_save_helem(pTHX_ HV *hv, SV *key, SV **sptr); */
+Perl_save_helem(pTHX_ HV *hv, SV *key, SV **sptr)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_save_helem_flags(pTHX_ HV *hv, SV *key, SV **sptr, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -4749,121 +5440,144 @@ Perl_save_helem_flags(pTHX_ HV *hv, SV *key, SV **sptr, const U32 flags)
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(key); assert(sptr)
 
 PERL_CALLCONV void
-Perl_save_hints(pTHX);
+Perl_save_hints(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SAVE_HINTS
 
 PERL_CALLCONV void
 Perl_save_hptr(pTHX_ HV **hptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_HPTR              \
         assert(hptr)
 
 PERL_CALLCONV void
 Perl_save_int(pTHX_ int *intp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_INT               \
         assert(intp)
 
 PERL_CALLCONV void
 Perl_save_item(pTHX_ SV *item)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_ITEM              \
         assert(item)
 
 PERL_CALLCONV void
 Perl_save_iv(pTHX_ IV *ivp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_IV                \
         assert(ivp)
 
 /* PERL_CALLCONV void
-Perl_save_mortalizesv(pTHX_ SV *sv); */
+Perl_save_mortalizesv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV void
-Perl_save_op(pTHX); */
+Perl_save_op(pTHX)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
-Perl_save_padsv_and_mortalize(pTHX_ PADOFFSET off);
+Perl_save_padsv_and_mortalize(pTHX_ PADOFFSET off)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SAVE_PADSV_AND_MORTALIZE
 
 PERL_CALLCONV void
 Perl_save_pptr(pTHX_ char **pptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_PPTR              \
         assert(pptr)
 
 PERL_CALLCONV void
-Perl_save_pushi32ptr(pTHX_ const I32 i, void * const ptr, const int type);
+Perl_save_pushi32ptr(pTHX_ const I32 i, void * const ptr, const int type)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SAVE_PUSHI32PTR
 
 PERL_CALLCONV void
-Perl_save_pushptr(pTHX_ void * const ptr, const int type);
+Perl_save_pushptr(pTHX_ void * const ptr, const int type)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SAVE_PUSHPTR
 
 PERL_CALLCONV void
-Perl_save_pushptrptr(pTHX_ void * const ptr1, void * const ptr2, const int type);
+Perl_save_pushptrptr(pTHX_ void * const ptr1, void * const ptr2, const int type)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SAVE_PUSHPTRPTR
 
 PERL_CALLCONV void
 Perl_save_rcpv(pTHX_ char **prcpv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_RCPV              \
         assert(prcpv)
 
 PERL_CALLCONV void
-Perl_save_re_context(pTHX);
+Perl_save_re_context(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SAVE_RE_CONTEXT
 
 PERL_CALLCONV SV *
 Perl_save_scalar(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SCALAR            \
         assert(gv)
 
 PERL_CALLCONV void
 Perl_save_set_svflags(pTHX_ SV *sv, U32 mask, U32 val)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SET_SVFLAGS       \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_save_shared_pvref(pTHX_ char **str)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SHARED_PVREF      \
         assert(str)
 
 PERL_CALLCONV void
 Perl_save_sptr(pTHX_ SV **sptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SPTR              \
         assert(sptr)
 
 PERL_CALLCONV void
 Perl_save_strlen(pTHX_ STRLEN *ptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_STRLEN            \
         assert(ptr)
 
 PERL_CALLCONV SV *
 Perl_save_svref(pTHX_ SV **sptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SVREF             \
         assert(sptr)
 
 PERL_CALLCONV void
 Perl_save_vptr(pTHX_ void *ptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_VPTR              \
         assert(ptr)
 
 PERL_CALLCONV char *
 Perl_savesharedpv(pTHX_ const char *pv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__malloc__
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SAVESHAREDPV
 
 PERL_CALLCONV char *
 Perl_savesharedpvn(pTHX_ const char * const pv, const STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__malloc__
         __attribute__warn_unused_result__;
@@ -4871,29 +5585,35 @@ Perl_savesharedpvn(pTHX_ const char * const pv, const STRLEN len)
         assert(pv)
 
 PERL_CALLCONV void
-Perl_savestack_grow(pTHX);
+Perl_savestack_grow(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SAVESTACK_GROW
 
 PERL_CALLCONV void
-Perl_savestack_grow_cnt(pTHX_ I32 need);
+Perl_savestack_grow_cnt(pTHX_ I32 need)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SAVESTACK_GROW_CNT
 
 PERL_CALLCONV void
-Perl_savetmps(pTHX);
+Perl_savetmps(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SAVETMPS
 
 PERL_CALLCONV OP *
 Perl_sawparens(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SAWPARENS
 
 PERL_CALLCONV OP *
 Perl_scalar(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SCALAR
 
 PERL_CALLCONV OP *
 Perl_scalarvoid(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SCALARVOID             \
@@ -4901,6 +5621,7 @@ Perl_scalarvoid(pTHX_ OP *o)
 
 PERL_CALLCONV NV
 Perl_scan_bin(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SCAN_BIN               \
@@ -4908,6 +5629,7 @@ Perl_scan_bin(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
 
 PERL_CALLCONV NV
 Perl_scan_hex(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SCAN_HEX               \
@@ -4915,6 +5637,7 @@ Perl_scan_hex(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
 
 PERL_CALLCONV char *
 Perl_scan_num(pTHX_ const char *start, YYSTYPE *lvalp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SCAN_NUM               \
@@ -4922,6 +5645,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE *lvalp)
 
 PERL_CALLCONV NV
 Perl_scan_oct(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SCAN_OCT               \
@@ -4932,6 +5656,7 @@ Perl_scan_oct(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
 
 PERL_CALLCONV const char *
 Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SCAN_VERSION           \
@@ -4939,6 +5664,7 @@ Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv)
 
 PERL_CALLCONV char *
 Perl_scan_vstring(pTHX_ const char *s, const char * const e, SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -4949,11 +5675,13 @@ Perl_scan_vstring(pTHX_ const char *s, const char * const e, SV *sv)
         assert(s); assert(dest); assert(slp)
 
 PERL_CALLCONV U64
-Perl_seed(pTHX);
+Perl_seed(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SEED
 
 PERL_CALLCONV void
-Perl_set_caret_X(pTHX);
+Perl_set_caret_X(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SET_CARET_X
 
 PERL_CALLCONV void
@@ -4964,18 +5692,21 @@ Perl_set_context(void *t)
 
 PERL_CALLCONV void
 Perl_set_numeric_standard(pTHX_ const char *file, const line_t caller_line)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SET_NUMERIC_STANDARD   \
         assert(file)
 
 PERL_CALLCONV void
 Perl_set_numeric_underlying(pTHX_ const char *file, const line_t caller_line)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SET_NUMERIC_UNDERLYING \
         assert(file)
 
 PERL_CALLCONV void
 Perl_setdefout(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SETDEFOUT              \
         assert(gv)
@@ -4987,11 +5718,13 @@ Perl_setfd_cloexec(int fd)
 
 PERL_CALLCONV void
 Perl_setfd_cloexec_for_nonsysfd(pTHX_ int fd)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SETFD_CLOEXEC_FOR_NONSYSFD
 
 PERL_CALLCONV void
 Perl_setfd_cloexec_or_inhexec_by_sysfdness(pTHX_ int fd)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SETFD_CLOEXEC_OR_INHEXEC_BY_SYSFDNESS
 
@@ -5002,11 +5735,13 @@ Perl_setfd_inhexec(int fd)
 
 PERL_CALLCONV void
 Perl_setfd_inhexec_for_sysfd(pTHX_ int fd)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SETFD_INHEXEC_FOR_SYSFD
 
 PERL_CALLCONV HEK *
 Perl_share_hek(pTHX_ const char *str, SSize_t len, U32 hash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SHARE_HEK              \
         assert(str)
@@ -5026,18 +5761,21 @@ Perl_sighandler3(int sig, Siginfo_t *info, void *uap)
 
 PERL_CALLCONV void
 Perl_sortsv(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SORTSV                 \
         assert(cmp)
 
 PERL_CALLCONV void
 Perl_sortsv_flags(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SORTSV_FLAGS           \
         assert(cmp)
 
 PERL_CALLCONV SV **
 Perl_stack_grow(pTHX_ SV **sp, SV **p, SSize_t n)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_STACK_GROW             \
@@ -5045,6 +5783,7 @@ Perl_stack_grow(pTHX_ SV **sp, SV **p, SSize_t n)
 
 PERL_CALLCONV PerlIO *
 Perl_start_glob(pTHX_ SV *tmpglob, IO *io)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -5052,11 +5791,13 @@ Perl_start_glob(pTHX_ SV *tmpglob, IO *io)
         assert(tmpglob); assert(io)
 
 PERL_CALLCONV I32
-Perl_start_subparse(pTHX_ I32 is_format, U32 flags);
+Perl_start_subparse(pTHX_ I32 is_format, U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_START_SUBPARSE
 
 PERL_CALLCONV NV
 Perl_str_to_version(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_STR_TO_VERSION         \
@@ -5067,6 +5808,7 @@ Perl_strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t 
 
 PERL_CALLCONV void
 Perl_sub_crush_depth(pTHX_ CV *cv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUB_CRUSH_DEPTH        \
@@ -5074,6 +5816,7 @@ Perl_sub_crush_depth(pTHX_ CV *cv)
 
 PERL_CALLCONV void
 Perl_subsignature_append_fence_op(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_FENCE_OP \
@@ -5081,6 +5824,7 @@ Perl_subsignature_append_fence_op(pTHX_ OP *o)
 
 PERL_CALLCONV void
 Perl_subsignature_append_named(pTHX_ const char *paramname, PADOFFSET padix, OPCODE defmode, OP *defexpr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_NAMED \
@@ -5088,41 +5832,49 @@ Perl_subsignature_append_named(pTHX_ const char *paramname, PADOFFSET padix, OPC
 
 PERL_CALLCONV void
 Perl_subsignature_append_positional(pTHX_ PADOFFSET padix, OPCODE defmode, OP *defexpr)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_POSITIONAL
 
 PERL_CALLCONV void
 Perl_subsignature_append_slurpy(pTHX_ I32 sigil, PADOFFSET padix)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_SLURPY
 
 PERL_CALLCONV OP *
 Perl_subsignature_finish(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_FINISH
 
 PERL_CALLCONV void
 Perl_subsignature_start(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_START
 
 PERL_CALLCONV void
 Perl_suspend_compcv(pTHX_ struct suspended_compcv *buffer)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SUSPEND_COMPCV         \
         assert(buffer)
 
 /* PERL_CALLCONV bool
-Perl_sv_2bool(pTHX_ SV * const sv); */
+Perl_sv_2bool(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV bool
 Perl_sv_2bool_flags(pTHX_ SV *sv, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2BOOL_FLAGS         \
         assert(sv)
 
 PERL_CALLCONV CV *
 Perl_sv_2cv(pTHX_ SV *sv, HV ** const st, GV ** const gvp, const I32 lref)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SV_2CV                 \
@@ -5130,25 +5882,30 @@ Perl_sv_2cv(pTHX_ SV *sv, HV ** const st, GV ** const gvp, const I32 lref)
 
 PERL_CALLCONV IO *
 Perl_sv_2io(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2IO                 \
         assert(sv)
 
 /* PERL_CALLCONV IV
-Perl_sv_2iv(pTHX_ SV *sv); */
+Perl_sv_2iv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV IV
 Perl_sv_2iv_flags(pTHX_ SV * const sv, const I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2IV_FLAGS           \
         assert(sv)
 
 PERL_CALLCONV SV *
-Perl_sv_2mortal(pTHX_ SV * const sv);
+Perl_sv_2mortal(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_2MORTAL
 
 PERL_CALLCONV SV *
 Perl_sv_2num_flags(pTHX_ SV * const sv, int flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SV_2NUM_FLAGS          \
@@ -5156,54 +5913,66 @@ Perl_sv_2num_flags(pTHX_ SV * const sv, int flags)
 
 PERL_CALLCONV NV
 Perl_sv_2nv_flags(pTHX_ SV * const sv, const I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2NV_FLAGS           \
         assert(sv)
 
 /* PERL_CALLCONV char *
-Perl_sv_2pv(pTHX_ SV *sv, STRLEN *lp); */
+Perl_sv_2pv(pTHX_ SV *sv, STRLEN *lp)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV char *
 Perl_sv_2pv_flags(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PV_FLAGS           \
         assert(sv)
 
 /* PERL_CALLCONV char *
 Perl_sv_2pv_nolen(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 /* PERL_CALLCONV char *
-Perl_sv_2pvbyte(pTHX_ SV *sv, STRLEN * const lp); */
+Perl_sv_2pvbyte(pTHX_ SV *sv, STRLEN * const lp)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV char *
 Perl_sv_2pvbyte_flags(pTHX_ SV *sv, STRLEN * const lp, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PVBYTE_FLAGS       \
         assert(sv)
 
 /* PERL_CALLCONV char *
 Perl_sv_2pvbyte_nolen(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 /* PERL_CALLCONV char *
-Perl_sv_2pvutf8(pTHX_ SV *sv, STRLEN * const lp); */
+Perl_sv_2pvutf8(pTHX_ SV *sv, STRLEN * const lp)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV char *
 Perl_sv_2pvutf8_flags(pTHX_ SV *sv, STRLEN * const lp, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PVUTF8_FLAGS       \
         assert(sv)
 
 /* PERL_CALLCONV char *
 Perl_sv_2pvutf8_nolen(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 /* PERL_CALLCONV UV
-Perl_sv_2uv(pTHX_ SV *sv); */
+Perl_sv_2uv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV UV
 Perl_sv_2uv_flags(pTHX_ SV * const sv, const I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2UV_FLAGS           \
         assert(sv)
@@ -5216,6 +5985,7 @@ Perl_sv_backoff(SV * const sv)
 
 PERL_CALLCONV SV *
 Perl_sv_bless(pTHX_ SV * const sv, HV * const stash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_BLESS               \
@@ -5223,12 +5993,14 @@ Perl_sv_bless(pTHX_ SV * const sv, HV * const stash)
 
 PERL_CALLCONV bool
 Perl_sv_can_swipe_pv_buf(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CAN_SWIPE_PV_BUF    \
         assert(sv)
 
 PERL_CALLCONV bool
 Perl_sv_cat_decode(pTHX_ SV *dsv, SV *encoding, SV *ssv, int *offset, char *tstr, int tlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -5239,12 +6011,14 @@ Perl_sv_cat_decode(pTHX_ SV *dsv, SV *encoding, SV *ssv, int *offset, char *tstr
 
 PERL_CALLCONV void
 Perl_sv_catpv(pTHX_ SV * const dsv, const char *sstr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CATPV               \
         assert(dsv)
 
 PERL_CALLCONV void
 Perl_sv_catpv_flags(pTHX_ SV * const dsv, const char *sstr, const I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_CATPV_FLAGS         \
@@ -5252,12 +6026,14 @@ Perl_sv_catpv_flags(pTHX_ SV * const dsv, const char *sstr, const I32 flags)
 
 PERL_CALLCONV void
 Perl_sv_catpv_mg(pTHX_ SV * const dsv, const char * const sstr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CATPV_MG            \
         assert(dsv)
 
 PERL_CALLCONV void
 Perl_sv_catpvf(pTHX_ SV * const sv, const char * const pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
@@ -5266,6 +6042,7 @@ Perl_sv_catpvf(pTHX_ SV * const sv, const char * const pat, ...)
 
 PERL_CALLCONV void
 Perl_sv_catpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
@@ -5273,91 +6050,111 @@ Perl_sv_catpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
         assert(sv); assert(pat)
 
 /* PERL_CALLCONV void
-Perl_sv_catpvn(pTHX_ SV * const dsv, const char *sstr, STRLEN len); */
+Perl_sv_catpvn(pTHX_ SV * const dsv, const char *sstr, STRLEN len)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_sv_catpvn_flags(pTHX_ SV * const dsv, const char *sstr, const STRLEN len, const I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_CATPVN_FLAGS        \
         assert(dsv); assert(sstr)
 
 /* PERL_CALLCONV void
-Perl_sv_catpvn_mg(pTHX_ SV * const dsv, const char *sstr, STRLEN len); */
+Perl_sv_catpvn_mg(pTHX_ SV * const dsv, const char *sstr, STRLEN len)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV void
-Perl_sv_catsv(pTHX_ SV * const dsv, SV * const sstr); */
+Perl_sv_catsv(pTHX_ SV * const dsv, SV * const sstr)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_sv_catsv_flags(pTHX_ SV * const dsv, SV * const sstr, const I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CATSV_FLAGS         \
         assert(dsv)
 
 /* PERL_CALLCONV void
-Perl_sv_catsv_mg(pTHX_ SV * const dsv, SV * const sstr); */
+Perl_sv_catsv_mg(pTHX_ SV * const dsv, SV * const sstr)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_sv_chop(pTHX_ SV * const sv, const char * const ptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CHOP                \
         assert(sv)
 
 PERL_CALLCONV SSize_t
 Perl_sv_clean_all(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SV_CLEAN_ALL
 
 PERL_CALLCONV void
 Perl_sv_clean_objs(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SV_CLEAN_OBJS
 
 PERL_CALLCONV void
 Perl_sv_clear(pTHX_ SV * const orig_sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CLEAR               \
         assert(orig_sv)
 
 PERL_CALLCONV I32
-Perl_sv_cmp(pTHX_ SV * const sv1, SV * const sv2);
+Perl_sv_cmp(pTHX_ SV * const sv1, SV * const sv2)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_CMP
 
 PERL_CALLCONV I32
-Perl_sv_cmp_flags(pTHX_ SV * const sv1, SV * const sv2, const U32 flags);
+Perl_sv_cmp_flags(pTHX_ SV * const sv1, SV * const sv2, const U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_CMP_FLAGS
 
 PERL_CALLCONV I32
-Perl_sv_cmp_locale(pTHX_ SV * const sv1, SV * const sv2);
+Perl_sv_cmp_locale(pTHX_ SV * const sv1, SV * const sv2)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_CMP_LOCALE
 
 PERL_CALLCONV I32
-Perl_sv_cmp_locale_flags(pTHX_ SV * const sv1, SV * const sv2, const U32 flags);
+Perl_sv_cmp_locale_flags(pTHX_ SV * const sv1, SV * const sv2, const U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_CMP_LOCALE_FLAGS
 
 /* PERL_CALLCONV void
-Perl_sv_copypv(pTHX_ SV * const dsv, SV * const ssv); */
+Perl_sv_copypv(pTHX_ SV * const dsv, SV * const ssv)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_sv_copypv_flags(pTHX_ SV * const dsv, SV * const ssv, const I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_COPYPV_FLAGS        \
         assert(dsv); assert(ssv)
 
 /* PERL_CALLCONV void
-Perl_sv_copypv_nomg(pTHX_ SV * const dsv, SV * const ssv); */
+Perl_sv_copypv_nomg(pTHX_ SV * const dsv, SV * const ssv)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
-Perl_sv_dec(pTHX_ SV * const sv);
+Perl_sv_dec(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_DEC
 
 PERL_CALLCONV void
-Perl_sv_dec_nomg(pTHX_ SV * const sv);
+Perl_sv_dec_nomg(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_DEC_NOMG
 
 PERL_CALLCONV void
 Perl_sv_del_backref(pTHX_ SV * const tsv, SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_DEL_BACKREF         \
@@ -5365,6 +6162,7 @@ Perl_sv_del_backref(pTHX_ SV * const tsv, SV * const sv)
 
 PERL_CALLCONV bool
 Perl_sv_derived_from(pTHX_ SV *sv, const char * const name)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -5373,6 +6171,7 @@ Perl_sv_derived_from(pTHX_ SV *sv, const char * const name)
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_hv(pTHX_ SV *sv, HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -5381,6 +6180,7 @@ Perl_sv_derived_from_hv(pTHX_ SV *sv, HV *hv)
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_pv(pTHX_ SV *sv, const char * const name, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -5389,6 +6189,7 @@ Perl_sv_derived_from_pv(pTHX_ SV *sv, const char * const name, U32 flags)
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_pvn(pTHX_ SV *sv, const char * const name, const STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -5397,6 +6198,7 @@ Perl_sv_derived_from_pvn(pTHX_ SV *sv, const char * const name, const STRLEN len
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -5404,11 +6206,13 @@ Perl_sv_derived_from_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
         assert(sv); assert(namesv)
 
 PERL_CALLCONV bool
-Perl_sv_destroyable(pTHX_ SV *sv);
+Perl_sv_destroyable(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_DESTROYABLE
 
 PERL_CALLCONV bool
 Perl_sv_does(pTHX_ SV *sv, const char * const name)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -5417,6 +6221,7 @@ Perl_sv_does(pTHX_ SV *sv, const char * const name)
 
 PERL_CALLCONV bool
 Perl_sv_does_pv(pTHX_ SV *sv, const char * const name, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -5425,6 +6230,7 @@ Perl_sv_does_pv(pTHX_ SV *sv, const char * const name, U32 flags)
 
 PERL_CALLCONV bool
 Perl_sv_does_pvn(pTHX_ SV *sv, const char * const name, const STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -5433,6 +6239,7 @@ Perl_sv_does_pvn(pTHX_ SV *sv, const char * const name, const STRLEN len, U32 fl
 
 PERL_CALLCONV bool
 Perl_sv_does_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -5440,41 +6247,50 @@ Perl_sv_does_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
         assert(sv); assert(namesv)
 
 PERL_CALLCONV void
-Perl_sv_dump(pTHX_ SV *sv);
+Perl_sv_dump(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_DUMP
 
 PERL_CALLCONV void
-Perl_sv_dump_depth(pTHX_ SV *sv, I32 depth);
+Perl_sv_dump_depth(pTHX_ SV *sv, I32 depth)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_DUMP_DEPTH
 
 /* PERL_CALLCONV I32
-Perl_sv_eq(pTHX_ SV *sv1, SV *sv2); */
+Perl_sv_eq(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV I32
-Perl_sv_eq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags);
+Perl_sv_eq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_EQ_FLAGS
 
 /* PERL_CALLCONV void
-Perl_sv_force_normal(pTHX_ SV *sv); */
+Perl_sv_force_normal(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_sv_force_normal_flags(pTHX_ SV * const sv, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_FORCE_NORMAL_FLAGS  \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_free(pTHX_ SV * const sv);
+Perl_sv_free(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_FREE
 
 PERL_CALLCONV void
 Perl_sv_free2(pTHX_ SV * const sv, const U32 refcnt)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_FREE2               \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_free_arenas(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SV_FREE_ARENAS
 
@@ -5486,6 +6302,7 @@ Perl_sv_get_backrefs(SV * const sv)
 
 PERL_CALLCONV char *
 Perl_sv_gets(pTHX_ SV * const sv, PerlIO * const fp, SSize_t append)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_GETS                \
@@ -5493,29 +6310,35 @@ Perl_sv_gets(pTHX_ SV * const sv, PerlIO * const fp, SSize_t append)
 
 PERL_CALLCONV char *
 Perl_sv_grow(pTHX_ SV * const sv, STRLEN newlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_GROW                \
         assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_grow_fresh(pTHX_ SV * const sv, STRLEN newlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_GROW_FRESH          \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_inc(pTHX_ SV * const sv);
+Perl_sv_inc(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_INC
 
 PERL_CALLCONV void
-Perl_sv_inc_nomg(pTHX_ SV * const sv);
+Perl_sv_inc_nomg(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_INC_NOMG
 
 /* PERL_CALLCONV void
-Perl_sv_insert(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN len, const char * const little, const STRLEN littlelen); */
+Perl_sv_insert(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN len, const char * const little, const STRLEN littlelen)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_sv_insert_flags(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN len, const char *little, const STRLEN littlelen, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_4);
 #define PERL_ARGS_ASSERT_SV_INSERT_FLAGS        \
@@ -5523,12 +6346,14 @@ Perl_sv_insert_flags(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN 
 
 PERL_CALLCONV int
 Perl_sv_isa(pTHX_ SV *sv, const char * const name)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_ISA                 \
         assert(name)
 
 PERL_CALLCONV bool
 Perl_sv_isa_sv(pTHX_ SV *sv, SV *namesv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -5536,35 +6361,42 @@ Perl_sv_isa_sv(pTHX_ SV *sv, SV *namesv)
         assert(sv); assert(namesv)
 
 PERL_CALLCONV int
-Perl_sv_isobject(pTHX_ SV *sv);
+Perl_sv_isobject(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_ISOBJECT
 
 PERL_CALLCONV SV *
-Perl_sv_langinfo(pTHX_ const nl_item item);
+Perl_sv_langinfo(pTHX_ const nl_item item)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_LANGINFO
 
 PERL_CALLCONV STRLEN
-Perl_sv_len(pTHX_ SV * const sv);
+Perl_sv_len(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_LEN
 
 PERL_CALLCONV STRLEN
-Perl_sv_len_utf8(pTHX_ SV * const sv);
+Perl_sv_len_utf8(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_LEN_UTF8
 
 PERL_CALLCONV STRLEN
 Perl_sv_len_utf8_nomg(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_LEN_UTF8_NOMG       \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_magic(pTHX_ SV * const sv, SV * const obj, const int how, const char * const name, const I32 namlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_MAGIC               \
         assert(sv)
 
 PERL_CALLCONV MAGIC *
 Perl_sv_magicext(pTHX_ SV * const sv, SV * const obj, const int how, const MGVTBL * const vtbl, const char * const name, const I32 namlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_MAGICEXT            \
         assert(sv)
@@ -5574,138 +6406,170 @@ Perl_sv_magicext(pTHX_ SV * const sv, SV * const obj, const int how, const MGVTB
 
 /* PERL_CALLCONV SV *
 Perl_sv_mortalcopy(pTHX_ SV * const oldsv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 PERL_CALLCONV SV *
 Perl_sv_mortalcopy_flags(pTHX_ SV * const oldsv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_MORTALCOPY_FLAGS
 
 PERL_CALLCONV SV *
 Perl_sv_newmortal(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_NEWMORTAL
 
 PERL_CALLCONV SV *
-Perl_sv_newref(pTHX_ SV * const sv);
+Perl_sv_newref(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_NEWREF
 
 PERL_CALLCONV void
-Perl_sv_nosharing(pTHX_ SV *sv);
+Perl_sv_nosharing(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_NOSHARING
 
 /* PERL_CALLCONV I32
-Perl_sv_numcmp(pTHX_ SV *sv1, SV *sv2); */
+Perl_sv_numcmp(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV I32
-Perl_sv_numcmp_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags);
+Perl_sv_numcmp_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_NUMCMP_FLAGS
 
 /* PERL_CALLCONV bool
-Perl_sv_numeq(pTHX_ SV *sv1, SV *sv2); */
+Perl_sv_numeq(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV bool
-Perl_sv_numeq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags);
+Perl_sv_numeq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_NUMEQ_FLAGS
 
 /* PERL_CALLCONV bool
-Perl_sv_numge(pTHX_ SV *sv1, SV *sv2); */
+Perl_sv_numge(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV bool
-Perl_sv_numge_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags);
+Perl_sv_numge_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_NUMGE_FLAGS
 
 /* PERL_CALLCONV bool
-Perl_sv_numgt(pTHX_ SV *sv1, SV *sv2); */
+Perl_sv_numgt(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV bool
-Perl_sv_numgt_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags);
+Perl_sv_numgt_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_NUMGT_FLAGS
 
 /* PERL_CALLCONV bool
-Perl_sv_numle(pTHX_ SV *sv1, SV *sv2); */
+Perl_sv_numle(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV bool
-Perl_sv_numle_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags);
+Perl_sv_numle_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_NUMLE_FLAGS
 
 /* PERL_CALLCONV bool
-Perl_sv_numlt(pTHX_ SV *sv1, SV *sv2); */
+Perl_sv_numlt(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV bool
-Perl_sv_numlt_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags);
+Perl_sv_numlt_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_NUMLT_FLAGS
 
 /* PERL_CALLCONV bool
-Perl_sv_numne(pTHX_ SV *sv1, SV *sv2); */
+Perl_sv_numne(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV bool
-Perl_sv_numne_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags);
+Perl_sv_numne_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_NUMNE_FLAGS
 
 PERL_CALLCONV char *
-Perl_sv_peek(pTHX_ SV *sv);
+Perl_sv_peek(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_PEEK
 
 PERL_CALLCONV void
 Perl_sv_pos_b2u(pTHX_ SV * const sv, I32 * const offsetp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_POS_B2U             \
         assert(offsetp)
 
 PERL_CALLCONV STRLEN
 Perl_sv_pos_b2u_flags(pTHX_ SV * const sv, STRLEN const offset, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_POS_B2U_FLAGS       \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_pos_u2b(pTHX_ SV * const sv, I32 * const offsetp, I32 * const lenp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_POS_U2B             \
         assert(offsetp)
 
 PERL_CALLCONV STRLEN
 Perl_sv_pos_u2b_flags(pTHX_ SV * const sv, STRLEN uoffset, STRLEN * const lenp, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_POS_U2B_FLAGS       \
         assert(sv)
 
 /* PERL_CALLCONV char *
 Perl_sv_pv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 /* PERL_CALLCONV char *
 Perl_sv_pvbyte(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 PERL_CALLCONV char *
 Perl_sv_pvbyten_force(pTHX_ SV * const sv, STRLEN * const lp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_PVBYTEN_FORCE       \
         assert(sv)
 
 /* PERL_CALLCONV char *
-Perl_sv_pvn_force(pTHX_ SV *sv, STRLEN *lp); */
+Perl_sv_pvn_force(pTHX_ SV *sv, STRLEN *lp)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV char *
 Perl_sv_pvn_force_flags(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_PVN_FORCE_FLAGS     \
         assert(sv)
 
 /* PERL_CALLCONV char *
 Perl_sv_pvutf8(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__; */
 
 PERL_CALLCONV char *
 Perl_sv_pvutf8n_force(pTHX_ SV * const sv, STRLEN * const lp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_PVUTF8N_FORCE       \
         assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_recode_to_utf8(pTHX_ SV *sv, SV *encoding)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_RECODE_TO_UTF8      \
@@ -5713,12 +6577,14 @@ Perl_sv_recode_to_utf8(pTHX_ SV *sv, SV *encoding)
 
 PERL_CALLCONV SV *
 Perl_sv_ref(pTHX_ SV *dst, const SV * const sv, const int ob)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_REF                 \
         assert(sv)
 
 PERL_CALLCONV const char *
 Perl_sv_reftype(pTHX_ const SV * const sv, const int ob)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_REFTYPE             \
@@ -5726,12 +6592,14 @@ Perl_sv_reftype(pTHX_ const SV * const sv, const int ob)
 
 PERL_CALLCONV void
 Perl_sv_regex_global_pos_clear(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_REGEX_GLOBAL_POS_CLEAR \
         assert(sv)
 
 PERL_CALLCONV bool
 Perl_sv_regex_global_pos_get(pTHX_ SV *sv, STRLEN *posp, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -5740,118 +6608,138 @@ Perl_sv_regex_global_pos_get(pTHX_ SV *sv, STRLEN *posp, U32 flags)
 
 PERL_CALLCONV void
 Perl_sv_regex_global_pos_set(pTHX_ SV *sv, STRLEN pos, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_REGEX_GLOBAL_POS_SET \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_replace(pTHX_ SV * const sv, SV * const nsv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_REPLACE             \
         assert(sv); assert(nsv)
 
 PERL_CALLCONV void
-Perl_sv_report_used(pTHX);
+Perl_sv_report_used(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_REPORT_USED
 
 PERL_CALLCONV void
 Perl_sv_reset(pTHX_ const char *s, HV * const stash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_RESET               \
         assert(s); assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_sv_resetpvn(pTHX_ const char *s, STRLEN len, HV * const stash)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SV_RESETPVN
 
 PERL_CALLCONV SV *
 Perl_sv_rvunweaken(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_RVUNWEAKEN          \
         assert(sv)
 
 PERL_CALLCONV SV *
 Perl_sv_rvweaken(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_RVWEAKEN            \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_set_bool(pTHX_ SV *sv, const bool bool_val)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_BOOL            \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_set_false(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_FALSE           \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_set_true(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_TRUE            \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_set_undef(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_UNDEF           \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_sethek(pTHX_ SV * const sv, const HEK * const hek)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETHEK              \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setiv(pTHX_ SV * const sv, const IV num)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETIV               \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setiv_mg(pTHX_ SV * const sv, const IV i)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETIV_MG            \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setnv(pTHX_ SV * const sv, const NV num)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETNV               \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setnv_mg(pTHX_ SV * const sv, const NV num)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETNV_MG            \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setpv(pTHX_ SV * const sv, const char * const ptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPV               \
         assert(sv)
 
 PERL_CALLCONV char  *
 Perl_sv_setpv_bufsize(pTHX_ SV * const sv, const STRLEN cur, const STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPV_BUFSIZE       \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setpv_mg(pTHX_ SV * const sv, const char * const ptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPV_MG            \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setpvf(pTHX_ SV * const sv, const char * const pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
@@ -5860,6 +6748,7 @@ Perl_sv_setpvf(pTHX_ SV * const sv, const char * const pat, ...)
 
 PERL_CALLCONV void
 Perl_sv_setpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
@@ -5868,18 +6757,21 @@ Perl_sv_setpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
 
 PERL_CALLCONV void
 Perl_sv_setpvn(pTHX_ SV * const sv, const char * const ptr, const STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPVN              \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setpvn_fresh(pTHX_ SV * const sv, const char * const ptr, const STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPVN_FRESH        \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setpvn_mg(pTHX_ SV * const sv, const char * const ptr, const STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETPVN_MG           \
@@ -5887,24 +6779,28 @@ Perl_sv_setpvn_mg(pTHX_ SV * const sv, const char * const ptr, const STRLEN len)
 
 PERL_CALLCONV SV *
 Perl_sv_setref_iv(pTHX_ SV * const rv, const char * const classname, const IV iv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_IV           \
         assert(rv)
 
 PERL_CALLCONV SV *
 Perl_sv_setref_nv(pTHX_ SV * const rv, const char * const classname, const NV nv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_NV           \
         assert(rv)
 
 PERL_CALLCONV SV *
 Perl_sv_setref_pv(pTHX_ SV * const rv, const char * const classname, void * const pv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_PV           \
         assert(rv)
 
 PERL_CALLCONV SV *
 Perl_sv_setref_pvn(pTHX_ SV * const rv, const char * const classname, const char * const pv, const STRLEN n)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SV_SETREF_PVN          \
@@ -5912,12 +6808,14 @@ Perl_sv_setref_pvn(pTHX_ SV * const rv, const char * const classname, const char
 
 PERL_CALLCONV SV *
 Perl_sv_setref_uv(pTHX_ SV * const rv, const char * const classname, const UV uv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_UV           \
         assert(rv)
 
 PERL_CALLCONV void
 Perl_sv_setrv_inc(pTHX_ SV * const sv, SV * const ref)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_INC           \
@@ -5925,6 +6823,7 @@ Perl_sv_setrv_inc(pTHX_ SV * const sv, SV * const ref)
 
 PERL_CALLCONV void
 Perl_sv_setrv_inc_mg(pTHX_ SV * const sv, SV * const ref)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_INC_MG        \
@@ -5932,6 +6831,7 @@ Perl_sv_setrv_inc_mg(pTHX_ SV * const sv, SV * const ref)
 
 PERL_CALLCONV void
 Perl_sv_setrv_noinc(pTHX_ SV * const sv, SV * const ref)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_NOINC         \
@@ -5939,78 +6839,93 @@ Perl_sv_setrv_noinc(pTHX_ SV * const sv, SV * const ref)
 
 PERL_CALLCONV void
 Perl_sv_setrv_noinc_mg(pTHX_ SV * const sv, SV * const ref)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_NOINC_MG      \
         assert(sv); assert(ref)
 
 /* PERL_CALLCONV void
-Perl_sv_setsv(pTHX_ SV *dsv, SV *ssv); */
+Perl_sv_setsv(pTHX_ SV *dsv, SV *ssv)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_sv_setsv_flags(pTHX_ SV *dsv, SV *ssv, const I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETSV_FLAGS         \
         assert(dsv)
 
 PERL_CALLCONV void
 Perl_sv_setsv_mg(pTHX_ SV * const dsv, SV * const ssv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETSV_MG            \
         assert(dsv)
 
 PERL_CALLCONV void
 Perl_sv_setuv(pTHX_ SV * const sv, const UV num)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETUV               \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setuv_mg(pTHX_ SV * const sv, const UV u)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETUV_MG            \
         assert(sv)
 
 /* PERL_CALLCONV bool
-Perl_sv_streq(pTHX_ SV *sv1, SV *sv2); */
+Perl_sv_streq(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV bool
-Perl_sv_streq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags);
+Perl_sv_streq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_STREQ_FLAGS
 
 PERL_CALLCONV SV *
 Perl_sv_strftime_ints(pTHX_ SV *fmt, int sec, int min, int hour, int mday, int mon, int year, int isdst)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_STRFTIME_INTS       \
         assert(fmt)
 
 PERL_CALLCONV SV *
 Perl_sv_strftime_tm(pTHX_ SV *fmt, const struct tm *mytm)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_STRFTIME_TM         \
         assert(fmt); assert(mytm)
 
 PERL_CALLCONV SV *
-Perl_sv_string_from_errnum(pTHX_ int errnum, SV *tgtsv);
+Perl_sv_string_from_errnum(pTHX_ int errnum, SV *tgtsv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_STRING_FROM_ERRNUM
 
 /* PERL_CALLCONV void
-Perl_sv_taint(pTHX_ SV *sv); */
+Perl_sv_taint(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV bool
 Perl_sv_tainted(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_TAINTED             \
         assert(sv)
 
 PERL_CALLCONV I32
-Perl_sv_true(pTHX_ SV * const sv);
+Perl_sv_true(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SV_TRUE
 
 PERL_CALLCONV char *
 Perl_sv_uni_display(pTHX_ SV *dsv, SV *ssv, STRLEN pvlim, UV flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -6019,90 +6934,109 @@ Perl_sv_uni_display(pTHX_ SV *dsv, SV *ssv, STRLEN pvlim, UV flags)
 
 PERL_CALLCONV int
 Perl_sv_unmagic(pTHX_ SV * const sv, const int type)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNMAGIC             \
         assert(sv)
 
 PERL_CALLCONV int
 Perl_sv_unmagicext(pTHX_ SV * const sv, const int type, const MGVTBL *vtbl)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNMAGICEXT          \
         assert(sv)
 
 /* PERL_CALLCONV void
-Perl_sv_unref(pTHX_ SV *sv); */
+Perl_sv_unref(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_sv_unref_flags(pTHX_ SV * const ref, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNREF_FLAGS         \
         assert(ref)
 
 PERL_CALLCONV void
 Perl_sv_untaint(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNTAINT             \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_upgrade(pTHX_ SV * const sv, svtype new_type)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UPGRADE             \
         assert(sv)
 
 /* PERL_CALLCONV void
-Perl_sv_usepvn(pTHX_ SV *sv, char *ptr, STRLEN len); */
+Perl_sv_usepvn(pTHX_ SV *sv, char *ptr, STRLEN len)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_sv_usepvn_flags(pTHX_ SV * const sv, char *ptr, const STRLEN len, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_USEPVN_FLAGS        \
         assert(sv)
 
 /* PERL_CALLCONV void
-Perl_sv_usepvn_mg(pTHX_ SV *sv, char *ptr, STRLEN len); */
+Perl_sv_usepvn_mg(pTHX_ SV *sv, char *ptr, STRLEN len)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV bool
 Perl_sv_utf8_decode(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_DECODE         \
         assert(sv)
 
 /* PERL_CALLCONV bool
-Perl_sv_utf8_downgrade(pTHX_ SV * const sv, const bool fail_ok); */
+Perl_sv_utf8_downgrade(pTHX_ SV * const sv, const bool fail_ok)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV bool
 Perl_sv_utf8_downgrade_flags(pTHX_ SV * const sv, const bool fail_ok, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_DOWNGRADE_FLAGS \
         assert(sv)
 
 /* PERL_CALLCONV bool
-Perl_sv_utf8_downgrade_nomg(pTHX_ SV * const sv, const bool fail_ok); */
+Perl_sv_utf8_downgrade_nomg(pTHX_ SV * const sv, const bool fail_ok)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_sv_utf8_encode(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_ENCODE         \
         assert(sv)
 
 /* PERL_CALLCONV STRLEN
-Perl_sv_utf8_upgrade(pTHX_ SV *sv); */
+Perl_sv_utf8_upgrade(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV STRLEN
-Perl_sv_utf8_upgrade_flags(pTHX_ SV * const sv, const I32 flags); */
+Perl_sv_utf8_upgrade_flags(pTHX_ SV * const sv, const I32 flags)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV STRLEN
 Perl_sv_utf8_upgrade_flags_grow(pTHX_ SV * const sv, const I32 flags, STRLEN extra)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE_FLAGS_GROW \
         assert(sv)
 
 /* PERL_CALLCONV STRLEN
-Perl_sv_utf8_upgrade_nomg(pTHX_ SV *sv); */
+Perl_sv_utf8_upgrade_nomg(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV void
 Perl_sv_vcatpvf(pTHX_ SV * const sv, const char * const pat, va_list * const args)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVF             \
@@ -6110,6 +7044,7 @@ Perl_sv_vcatpvf(pTHX_ SV * const sv, const char * const pat, va_list * const arg
 
 PERL_CALLCONV void
 Perl_sv_vcatpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const args)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVF_MG          \
@@ -6117,6 +7052,7 @@ Perl_sv_vcatpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const 
 
 PERL_CALLCONV void
 Perl_sv_vcatpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patlen, va_list * const args, SV ** const svargs, const Size_t sv_count, bool * const maybe_tainted)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVFN            \
@@ -6124,6 +7060,7 @@ Perl_sv_vcatpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patle
 
 PERL_CALLCONV void
 Perl_sv_vcatpvfn_flags(pTHX_ SV * const sv, const char * const pat, const STRLEN patlen, va_list * const args, SV ** const svargs, const Size_t sv_count, bool * const maybe_tainted, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVFN_FLAGS      \
@@ -6131,6 +7068,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV * const sv, const char * const pat, const STRLEN
 
 PERL_CALLCONV void
 Perl_sv_vsetpvf(pTHX_ SV * const sv, const char * const pat, va_list * const args)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VSETPVF             \
@@ -6138,6 +7076,7 @@ Perl_sv_vsetpvf(pTHX_ SV * const sv, const char * const pat, va_list * const arg
 
 PERL_CALLCONV void
 Perl_sv_vsetpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const args)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VSETPVF_MG          \
@@ -6145,6 +7084,7 @@ Perl_sv_vsetpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const 
 
 PERL_CALLCONV void
 Perl_sv_vsetpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patlen, va_list * const args, SV ** const svargs, const Size_t sv_count, bool * const maybe_tainted)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VSETPVFN            \
@@ -6152,16 +7092,19 @@ Perl_sv_vsetpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patle
 
 PERL_CALLCONV const char *
 Perl_sv_vstring_get(pTHX_ SV * const sv, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_VSTRING_GET         \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_switch_to_global_locale(pTHX);
+Perl_switch_to_global_locale(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SWITCH_TO_GLOBAL_LOCALE
 
 PERL_CALLCONV bool
-Perl_sync_locale(pTHX);
+Perl_sync_locale(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_SYNC_LOCALE
 
 PERL_CALLCONV void
@@ -6184,17 +7127,20 @@ Perl_sys_term(void);
 #define PERL_ARGS_ASSERT_SYS_TERM
 
 PERL_CALLCONV void
-Perl_taint_env(pTHX);
+Perl_taint_env(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_TAINT_ENV
 
 PERL_CALLCONV void
 Perl_taint_proper(pTHX_ const char *f, const char * const s)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_TAINT_PROPER           \
         assert(s)
 
 PERL_CALLCONV OP *
 Perl_tied_method(pTHX_ SV *methname, SV **mark, SV * const sv, const MAGIC * const mg, const U32 flags, U32 argc, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -6204,14 +7150,17 @@ Perl_tied_method(pTHX_ SV *methname, SV **mark, SV * const sv, const MAGIC * con
         assert(methname); assert(mark); assert(sv); assert(mg)
 
 PERL_CALLCONV SSize_t
-Perl_tmps_grow_p(pTHX_ SSize_t ix);
+Perl_tmps_grow_p(pTHX_ SSize_t ix)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_TMPS_GROW_P
 
 /* PERL_CALLCONV UV
-Perl_to_uni_fold(pTHX_ UV c, U8 *p, STRLEN *lenp); */
+Perl_to_uni_fold(pTHX_ UV c, U8 *p, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV UV
 Perl_to_uni_fold_flags_(pTHX_ UV c, U8 *p, STRLEN *lenp, U8 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_FOLD_FLAGS_     \
@@ -6219,6 +7168,7 @@ Perl_to_uni_fold_flags_(pTHX_ UV c, U8 *p, STRLEN *lenp, U8 flags)
 
 PERL_CALLCONV UV
 Perl_to_uni_lower(pTHX_ UV c, U8 *p, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_LOWER           \
@@ -6226,6 +7176,7 @@ Perl_to_uni_lower(pTHX_ UV c, U8 *p, STRLEN *lenp)
 
 PERL_CALLCONV UV
 Perl_to_uni_title(pTHX_ UV c, U8 *p, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_TITLE           \
@@ -6233,6 +7184,7 @@ Perl_to_uni_title(pTHX_ UV c, U8 *p, STRLEN *lenp)
 
 PERL_CALLCONV UV
 Perl_to_uni_upper(pTHX_ UV c, U8 *p, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_UPPER           \
@@ -6240,6 +7192,7 @@ Perl_to_uni_upper(pTHX_ UV c, U8 *p, STRLEN *lenp)
 
 PERL_CALLCONV UV
 Perl_to_utf8_fold_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, U8 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -6248,6 +7201,7 @@ Perl_to_utf8_fold_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp
 
 PERL_CALLCONV UV
 Perl_to_utf8_lower_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, bool flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -6256,6 +7210,7 @@ Perl_to_utf8_lower_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *len
 
 PERL_CALLCONV UV
 Perl_to_utf8_title_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, bool flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -6264,6 +7219,7 @@ Perl_to_utf8_title_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *len
 
 PERL_CALLCONV UV
 Perl_to_utf8_upper_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, bool flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -6271,11 +7227,13 @@ Perl_to_utf8_upper_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *len
         assert(p); assert(e); assert(ustrp); assert(p < e)
 
 PERL_CALLCONV bool
-Perl_try_amagic_bin(pTHX_ int method, int flags);
+Perl_try_amagic_bin(pTHX_ int method, int flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_TRY_AMAGIC_BIN
 
 PERL_CALLCONV bool
-Perl_try_amagic_un(pTHX_ int method, int flags);
+Perl_try_amagic_un(pTHX_ int method, int flags)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_TRY_AMAGIC_UN
 
 PERL_CALLCONV char *
@@ -6288,6 +7246,7 @@ Perl_uiv_2buf(char * const buf, const IV iv, UV uv, const int is_uv, char ** con
 
 PERL_CALLCONV SSize_t
 Perl_unpackstring(pTHX_ const char *pat, const char *patend, const char *s, const char *strend, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -6297,15 +7256,18 @@ Perl_unpackstring(pTHX_ const char *pat, const char *patend, const char *s, cons
         assert(pat <= patend); assert(s <= strend)
 
 PERL_CALLCONV void
-Perl_unshare_hek(pTHX_ HEK *hek);
+Perl_unshare_hek(pTHX_ HEK *hek)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_UNSHARE_HEK
 
 PERL_CALLCONV void
-Perl_unsharepvn(pTHX_ const char *sv, I32 len, U32 hash);
+Perl_unsharepvn(pTHX_ const char *sv, I32 len, U32 hash)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_UNSHAREPVN
 
 PERL_CALLCONV SV *
 Perl_upg_version(pTHX_ SV *ver, bool qv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_UPG_VERSION            \
         assert(ver)
@@ -6327,6 +7289,7 @@ Perl_utf8_hop_safe(const U8 *s, SSize_t off, const U8 * const start, const U8 * 
 
 PERL_CALLCONV STRLEN
 Perl_utf8_length(pTHX_ const U8 *s0, const U8 *e)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -6335,6 +7298,7 @@ Perl_utf8_length(pTHX_ const U8 *s0, const U8 *e)
 
 PERL_CALLCONV U8 *
 Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_UTF8_TO_BYTES          \
@@ -6342,6 +7306,7 @@ Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
 
 PERL_CALLCONV bool
 Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp, void **free_me, Perl_utf8_to_bytes_arg result_as)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -6376,34 +7341,42 @@ Perl_utf8n_to_uvchr_error(const U8 *s, STRLEN curlen, STRLEN *retlen, const U32 
 
 PERL_CALLCONV void
 Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_4)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_UTILIZE                \
         assert(idop)
 
 /* PERL_CALLCONV U8 *
-Perl_uv_to_utf8_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs); */
+Perl_uv_to_utf8_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV U8 *
-Perl_uvchr_to_utf8(pTHX_ U8 *d, UV uv); */
+Perl_uvchr_to_utf8(pTHX_ U8 *d, UV uv)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV U8 *
-Perl_uvchr_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags); */
+Perl_uvchr_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV U8 *
-Perl_uvchr_to_utf8_flags_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs); */
+Perl_uvchr_to_utf8_flags_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs)
+        Perl_attribute_nonnull_aTHX_; */
 
 /* PERL_CALLCONV U8 *
-Perl_uvoffuni_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags); */
+Perl_uvoffuni_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV U8 *
 Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, const UV flags, HV **msgs)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_UVOFFUNI_TO_UTF8_FLAGS_MSGS \
         assert(d)
 
 PERL_CALLCONV bool
 Perl_valid_identifier_pve(pTHX_ const char *s, const char *end, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_VALID_IDENTIFIER_PVE   \
@@ -6411,12 +7384,14 @@ Perl_valid_identifier_pve(pTHX_ const char *s, const char *end, U32 flags)
 
 PERL_CALLCONV bool
 Perl_valid_identifier_pvn(pTHX_ const char *s, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VALID_IDENTIFIER_PVN   \
         assert(s)
 
 PERL_CALLCONV bool
-Perl_valid_identifier_sv(pTHX_ SV *sv);
+Perl_valid_identifier_sv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_VALID_IDENTIFIER_SV
 
 /* PERL_CALLCONV UV
@@ -6428,6 +7403,7 @@ Perl_valid_utf8_to_uvchr(const U8 *s, STRLEN *retlen)
 
 PERL_CALLCONV int
 Perl_vcmp(pTHX_ SV *lhv, SV *rhv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_VCMP                   \
@@ -6435,23 +7411,27 @@ Perl_vcmp(pTHX_ SV *lhv, SV *rhv)
 
 PERL_CALLCONV_NO_RET void
 Perl_vcroak(pTHX_ const char *pat, va_list *args)
+        Perl_attribute_nonnull_aTHX_
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_VCROAK
 
 PERL_CALLCONV void
 Perl_vdeb(pTHX_ const char *pat, va_list *args)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VDEB                   \
         assert(pat)
 
 PERL_CALLCONV void
 Perl_vfatal_warner(pTHX_ U32 err, const char *pat, va_list *args)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_VFATAL_WARNER          \
         assert(pat)
 
 PERL_CALLCONV char *
 Perl_vform(pTHX_ const char *pat, va_list *args)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VFORM                  \
         assert(pat)
@@ -6461,6 +7441,7 @@ Perl_vform(pTHX_ const char *pat, va_list *args)
 
 PERL_CALLCONV SV *
 Perl_vivify_ref(pTHX_ SV *sv, U32 to_what)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -6469,18 +7450,21 @@ Perl_vivify_ref(pTHX_ SV *sv, U32 to_what)
 
 PERL_CALLCONV void
 Perl_vload_module(pTHX_ U32 flags, SV *name, SV *ver, va_list *args)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_VLOAD_MODULE           \
         assert(name)
 
 PERL_CALLCONV SV *
 Perl_vmess(pTHX_ const char *pat, va_list *args)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VMESS                  \
         assert(pat)
 
 PERL_CALLCONV SV *
 Perl_vnewSVpvf(pTHX_ const char * const pat, va_list * const args)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_VNEWSVPVF              \
@@ -6488,42 +7472,49 @@ Perl_vnewSVpvf(pTHX_ const char * const pat, va_list * const args)
 
 PERL_CALLCONV SV *
 Perl_vnormal(pTHX_ SV *vs)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VNORMAL                \
         assert(vs)
 
 PERL_CALLCONV SV *
 Perl_vnumify(pTHX_ SV *vs)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VNUMIFY                \
         assert(vs)
 
 PERL_CALLCONV SV *
 Perl_vstringify(pTHX_ SV *vs)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VSTRINGIFY             \
         assert(vs)
 
 PERL_CALLCONV SV *
 Perl_vverify(pTHX_ SV *vs)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VVERIFY                \
         assert(vs)
 
 PERL_CALLCONV void
 Perl_vwarn(pTHX_ const char *pat, va_list *args)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VWARN                  \
         assert(pat)
 
 PERL_CALLCONV void
 Perl_vwarner(pTHX_ U32 err, const char *pat, va_list *args)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_VWARNER                \
         assert(pat)
 
 PERL_CALLCONV I32
 Perl_wait4pid(pTHX_ Pid_t pid, int *statusp, int flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_WAIT4PID               \
@@ -6531,6 +7522,7 @@ Perl_wait4pid(pTHX_ Pid_t pid, int *statusp, int flags)
 
 PERL_CALLCONV void
 Perl_warn(pTHX_ const char *pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_WARN                   \
@@ -6538,12 +7530,14 @@ Perl_warn(pTHX_ const char *pat, ...)
 
 PERL_CALLCONV void
 Perl_warn_sv(pTHX_ SV *baseex)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_WARN_SV                \
         assert(baseex)
 
 PERL_CALLCONV void
 Perl_warner(pTHX_ U32 err, const char *pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_WARNER                 \
@@ -6551,39 +7545,46 @@ Perl_warner(pTHX_ U32 err, const char *pat, ...)
 
 PERL_CALLCONV I32
 Perl_was_lvalue_sub(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_WAS_LVALUE_SUB
 
 PERL_CALLCONV void
 Perl_watch(pTHX_ char **addr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_WATCH                  \
         assert(addr)
 
 /* PERL_CALLCONV I32
-Perl_whichsig(pTHX_ const char *sig); */
+Perl_whichsig(pTHX_ const char *sig)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV I32
 Perl_whichsig_pv(pTHX_ const char *sig)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_WHICHSIG_PV            \
         assert(sig)
 
 PERL_CALLCONV I32
 Perl_whichsig_pvn(pTHX_ const char *sig, STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_WHICHSIG_PVN           \
         assert(sig)
 
 PERL_CALLCONV I32
 Perl_whichsig_sv(pTHX_ SV *sigsv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_WHICHSIG_SV            \
         assert(sigsv)
 
 PERL_CALLCONV void
 Perl_wrap_infix_plugin(pTHX_ Perl_infix_plugin_t new_plugin, Perl_infix_plugin_t *old_plugin_p)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_WRAP_INFIX_PLUGIN      \
@@ -6591,6 +7592,7 @@ Perl_wrap_infix_plugin(pTHX_ Perl_infix_plugin_t new_plugin, Perl_infix_plugin_t
 
 PERL_CALLCONV void
 Perl_wrap_keyword_plugin(pTHX_ Perl_keyword_plugin_t new_plugin, Perl_keyword_plugin_t *old_plugin_p)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_WRAP_KEYWORD_PLUGIN    \
@@ -6598,6 +7600,7 @@ Perl_wrap_keyword_plugin(pTHX_ Perl_keyword_plugin_t new_plugin, Perl_keyword_pl
 
 PERL_CALLCONV void
 Perl_wrap_op_checker(pTHX_ Optype opcode, Perl_check_t new_checker, Perl_check_t *old_checker_p)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_WRAP_OP_CHECKER        \
@@ -6605,13 +7608,15 @@ Perl_wrap_op_checker(pTHX_ Optype opcode, Perl_check_t new_checker, Perl_check_t
 
 PERL_CALLCONV void
 Perl_write_to_stderr(pTHX_ SV *msv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_WRITE_TO_STDERR        \
         assert(msv)
 
 PERL_CALLCONV void
-Perl_xs_boot_epilog(pTHX_ const SSize_t ax);
+Perl_xs_boot_epilog(pTHX_ const SSize_t ax)
+        Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_XS_BOOT_EPILOG
 
 PERL_CALLCONV Stack_off_t
@@ -6623,6 +7628,7 @@ Perl_xs_handshake(const U32 key, void *v_my_perl, const char *file, ...)
 
 PERL_CALLCONV int
 Perl_yyerror(pTHX_ const char * const s)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYERROR                \
@@ -6630,6 +7636,7 @@ Perl_yyerror(pTHX_ const char * const s)
 
 PERL_CALLCONV int
 Perl_yyerror_pv(pTHX_ const char * const s, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYERROR_PV             \
@@ -6637,6 +7644,7 @@ Perl_yyerror_pv(pTHX_ const char * const s, U32 flags)
 
 PERL_CALLCONV int
 Perl_yyerror_pvn(pTHX_ const char * const s, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYERROR_PVN
 
@@ -6644,22 +7652,26 @@ Perl_yyerror_pvn(pTHX_ const char * const s, STRLEN len, U32 flags)
 
 PERL_CALLCONV int
 Perl_yyparse(pTHX_ int gramtype)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYPARSE
 
 PERL_CALLCONV void
 Perl_yyquit(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYQUIT
 
 PERL_CALLCONV void
 Perl_yyunlex(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYUNLEX
 
 #if defined(DEBUGGING)
 PERL_CALLCONV int
 Perl_get_debug_opts(pTHX_ const char **s, bool givehelp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -6668,18 +7680,21 @@ Perl_get_debug_opts(pTHX_ const char **s, bool givehelp)
 
 PERL_CALLCONV void
 Perl_hv_assert(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_ASSERT             \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_pad_setsv(pTHX_ PADOFFSET po, SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_PAD_SETSV             \
         assert(sv)
 
 PERL_CALLCONV SV *
-Perl_pad_sv(pTHX_ PADOFFSET po);
+Perl_pad_sv(pTHX_ PADOFFSET po)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PAD_SV
 
 PERL_CALLCONV void
@@ -6692,15 +7707,17 @@ Perl_set_padlist(CV *cv, PADLIST *padlist)
 #if defined(DEBUG_LEAKING_SCALARS_FORK_DUMP)
 PERL_CALLCONV void
 Perl_dump_sv_child(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DUMP_SV_CHILD         \
         assert(sv)
 
-#endif
+#endif /* defined(DEBUG_LEAKING_SCALARS_FORK_DUMP) */
 #if defined(F_FREESP) && !defined(HAS_CHSIZE) && !defined(HAS_TRUNCATE)
 PERL_CALLCONV I32
 Perl_my_chsize(pTHX_ int fd, Off_t length)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MY_CHSIZE
 
@@ -6708,6 +7725,7 @@ Perl_my_chsize(pTHX_ int fd, Off_t length)
 #if !defined(HAS_GETENV_LEN)
 PERL_CALLCONV char *
 Perl_getenv_len(pTHX_ const char *env_elem, unsigned long *len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -6736,6 +7754,7 @@ Perl_my_mkstemp(char *templte)
 #if defined(HAS_MSG) || defined(HAS_SEM) || defined(HAS_SHM)
 PERL_CALLCONV I32
 Perl_do_ipcctl(pTHX_ I32 optype, SV **mark, SV **sp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
@@ -6744,6 +7763,7 @@ Perl_do_ipcctl(pTHX_ I32 optype, SV **mark, SV **sp)
 
 PERL_CALLCONV I32
 Perl_do_ipcget(pTHX_ I32 optype, SV **mark, SV **sp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
@@ -6752,6 +7772,7 @@ Perl_do_ipcget(pTHX_ I32 optype, SV **mark, SV **sp)
 
 PERL_CALLCONV SSize_t
 Perl_do_msgrcv(pTHX_ SV **mark, SV **sp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -6760,6 +7781,7 @@ Perl_do_msgrcv(pTHX_ SV **mark, SV **sp)
 
 PERL_CALLCONV I32
 Perl_do_msgsnd(pTHX_ SV **mark, SV **sp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -6768,6 +7790,7 @@ Perl_do_msgsnd(pTHX_ SV **mark, SV **sp)
 
 PERL_CALLCONV I32
 Perl_do_semop(pTHX_ SV **mark, SV **sp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -6776,6 +7799,7 @@ Perl_do_semop(pTHX_ SV **mark, SV **sp)
 
 PERL_CALLCONV I32
 Perl_do_shmio(pTHX_ I32 optype, SV **mark, SV **sp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
@@ -6786,6 +7810,7 @@ Perl_do_shmio(pTHX_ I32 optype, SV **mark, SV **sp)
 #if defined(HAS_PIPE)
 PERL_CALLCONV int
 Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -6796,6 +7821,7 @@ Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd)
 #if !defined(HAS_RENAME)
 PERL_CALLCONV I32
 Perl_same_dirent(pTHX_ const char *a, const char *b)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -6814,12 +7840,14 @@ Perl_signbit(NV f)
 #if defined(HAS_SOCKET)
 PERL_CALLCONV int
 Perl_PerlSock_accept_cloexec(pTHX_ int listenfd, struct sockaddr *addr, Sock_size_t *addrlen)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PERLSOCK_ACCEPT_CLOEXEC
 
 PERL_CALLCONV int
 Perl_PerlSock_socket_cloexec(pTHX_ int domain, int type, int protocol)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PERLSOCK_SOCKET_CLOEXEC
@@ -6830,6 +7858,7 @@ Perl_PerlSock_socket_cloexec(pTHX_ int domain, int type, int protocol)
       defined(SOCK_DGRAM) )
 PERL_CALLCONV int
 Perl_PerlSock_socketpair_cloexec(pTHX_ int domain, int type, int protocol, int *pairfd)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -6858,26 +7887,30 @@ Perl_my_strnlen(const char *str, Size_t maxlen)
 #endif /* !defined(HAS_STRNLEN) */
 #if defined(HAVE_INTERP_INTERN)
 PERL_CALLCONV void
-Perl_sys_intern_clear(pTHX);
+Perl_sys_intern_clear(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_SYS_INTERN_CLEAR
 
 PERL_CALLCONV void
-Perl_sys_intern_init(pTHX);
+Perl_sys_intern_init(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_SYS_INTERN_INIT
 
 # if defined(USE_ITHREADS)
 PERL_CALLCONV void
 Perl_sys_intern_dup(pTHX_ struct interp_intern *src, struct interp_intern *dst)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_SYS_INTERN_DUP      \
         assert(src); assert(dst)
 
-# endif
+# endif /* defined(USE_ITHREADS) */
 #endif /* defined(HAVE_INTERP_INTERN) */
 #if defined(_MSC_VER)
 PERL_CALLCONV int
 Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -6887,6 +7920,7 @@ Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
 #else /* if !defined(_MSC_VER) */
 PERL_CALLCONV_NO_RET int
 Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__noreturn__
@@ -6937,6 +7971,7 @@ Perl_mess_nocontext(const char *pat, ...)
 
 PERL_CALLCONV void *
 Perl_my_cxt_init(pTHX_ int *indexp, size_t size)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_MY_CXT_INIT           \
         assert(indexp)
@@ -6998,12 +8033,14 @@ Perl_warner_nocontext(U32 err, const char *pat, ...)
 #if defined(MYMALLOC)
 PERL_CALLCONV void
 Perl_dump_mstats(pTHX_ const char *s)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DUMP_MSTATS           \
         assert(s)
 
 PERL_CALLCONV int
 Perl_get_mstats(pTHX_ perl_mstats_t *buf, int buflen, int level)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_GET_MSTATS            \
         assert(buf)
@@ -7030,6 +8067,7 @@ Perl_load_mathoms(void);
 
 PERL_CALLCONV UV
 Perl_utf8_to_uvchr(pTHX_ const U8 *s, STRLEN *retlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UTF8_TO_UVCHR         \
@@ -7037,6 +8075,7 @@ Perl_utf8_to_uvchr(pTHX_ const U8 *s, STRLEN *retlen)
 
 PERL_CALLCONV UV
 Perl_utf8_to_uvuni(pTHX_ const U8 *s, STRLEN *retlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UTF8_TO_UVUNI         \
@@ -7044,6 +8083,7 @@ Perl_utf8_to_uvuni(pTHX_ const U8 *s, STRLEN *retlen)
 
 PERL_CALLCONV UV
 Perl_utf8n_to_uvuni(pTHX_ const U8 *s, STRLEN curlen, STRLEN *retlen, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UTF8N_TO_UVUNI        \
@@ -7051,6 +8091,7 @@ Perl_utf8n_to_uvuni(pTHX_ const U8 *s, STRLEN curlen, STRLEN *retlen, U32 flags)
 
 PERL_CALLCONV U8 *
 Perl_uvuni_to_utf8(pTHX_ U8 *d, UV uv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UVUNI_TO_UTF8         \
@@ -7059,7 +8100,8 @@ Perl_uvuni_to_utf8(pTHX_ U8 *d, UV uv)
 # if defined(PERL_IN_MATHOMS_C) || defined(PERL_IN_OP_C) || \
      defined(PERL_IN_PERLY_C)   || defined(PERL_IN_TOKE_C)
 PERL_CALLCONV OP *
-Perl_ref(pTHX_ OP *o, I32 type);
+Perl_ref(pTHX_ OP *o, I32 type)
+        Perl_attribute_nonnull_aTHX_;
 #   define PERL_ARGS_ASSERT_REF
 
 # endif
@@ -7071,12 +8113,14 @@ Perl_ref(pTHX_ OP *o, I32 type);
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
 Perl_sv_setsv_cow(pTHX_ SV *dsv, SV *ssv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 # endif
 #endif /* defined(PERL_ANY_COW) */
 #if defined(PERL_CORE)
 PERL_CALLCONV void
 Perl_opslab_force_free(pTHX_ OPSLAB *slab)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OPSLAB_FORCE_FREE     \
@@ -7084,6 +8128,7 @@ Perl_opslab_force_free(pTHX_ OPSLAB *slab)
 
 PERL_CALLCONV void
 Perl_opslab_free(pTHX_ OPSLAB *slab)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OPSLAB_FREE           \
@@ -7091,6 +8136,7 @@ Perl_opslab_free(pTHX_ OPSLAB *slab)
 
 PERL_CALLCONV void
 Perl_opslab_free_nopad(pTHX_ OPSLAB *slab)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OPSLAB_FREE_NOPAD     \
@@ -7098,6 +8144,7 @@ Perl_opslab_free_nopad(pTHX_ OPSLAB *slab)
 
 PERL_CALLCONV void
 Perl_parser_free_nexttoke_ops(pTHX_ yy_parser *parser, OPSLAB *slab)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -7107,12 +8154,14 @@ Perl_parser_free_nexttoke_ops(pTHX_ yy_parser *parser, OPSLAB *slab)
 # if defined(PERL_DEBUG_READONLY_OPS)
 PERL_CALLCONV void
 Perl_Slab_to_ro(pTHX_ OPSLAB *slab)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_SLAB_TO_RO          \
         assert(slab)
 
 PERL_CALLCONV void
 Perl_Slab_to_rw(pTHX_ OPSLAB * const slab)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_SLAB_TO_RW          \
         assert(slab)
@@ -7131,16 +8180,20 @@ S_should_warn_nl(const char *pv)
 #if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
 Perl_av_reify(pTHX_ AV *av)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV const char *
-Perl_byte_dump_string_(pTHX_ const U8 * const start, const STRLEN len, const bool format);
+Perl_byte_dump_string_(pTHX_ const U8 * const start, const STRLEN len, const bool format)
+        Perl_attribute_nonnull_aTHX_;
 PERL_CALLCONV const char *
 Perl_cntrl_to_mnemonic(const U8 c)
         __attribute__warn_unused_result__;
 PERL_CALLCONV regexp_engine const *
-Perl_current_re_engine(pTHX);
+Perl_current_re_engine(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 PERL_CALLCONV void
 Perl_cv_ckproto_len_flags(pTHX_ const CV *cv, const GV *gv, const char *p, const STRLEN len, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV char *
 Perl_delimcpy_no_escape(char *to, const char *to_end, const char *from, const char *from_end, const int delim, I32 *retlen)
@@ -7154,9 +8207,11 @@ Perl_do_uniprop_match(const char * const key, const U16 key_len)
         Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 PERL_CALLCONV char  *
-Perl_dup_warnings(pTHX_ char *warnings);
+Perl_dup_warnings(pTHX_ char *warnings)
+        Perl_attribute_nonnull_aTHX_;
 PERL_CALLCONV void
 Perl_emulate_cop_io(pTHX_ const COP * const c, SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 PERL_CALLCONV Size_t
@@ -7164,6 +8219,7 @@ Perl_expected_size(UV size)
         __attribute__visibility__("hidden");
 PERL_CALLCONV SV *
 Perl_get_and_check_backslash_N_name(pTHX_ const char *s, const char *e, const bool is_utf8, const char **error_msg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_4)
@@ -7173,113 +8229,145 @@ Perl_get_deprecated_property_msg(const Size_t warning_offset)
         __attribute__warn_unused_result__;
 PERL_CALLCONV SV *
 Perl_get_prop_definition(pTHX_ const int table_index)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 PERL_CALLCONV const char * const *
 Perl_get_prop_values(const int table_index)
         __attribute__warn_unused_result__;
 PERL_CALLCONV Size_t
 Perl_inverse_folds_(pTHX_ const UV cp, U32 *first_folds_to, const U32 **remaining_folds_to)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 PERL_CALLCONV HV *
 Perl_load_charnames(pTHX_ SV *char_name, const char *context, const STRLEN context_len, const char **error_msg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 PERL_CALLCONV int
-Perl_mbtowc_(pTHX_ const wchar_t *pwc, const char *s, const Size_t len);
+Perl_mbtowc_(pTHX_ const wchar_t *pwc, const char *s, const Size_t len)
+        Perl_attribute_nonnull_aTHX_;
 PERL_CALLCONV MAGIC *
 Perl_mg_find_mglob(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 PERL_CALLCONV SV *
 Perl_multiconcat_stringify(pTHX_ const OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV SV *
 Perl_multideref_stringify(pTHX_ const OP *o, CV *cv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV char *
 Perl_new_warnings_bitfield(pTHX_ char *buffer, const char * const bits, STRLEN size)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 PERL_CALLCONV void
 Perl_op_clear(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV char *
 Perl_parse_ident_msg(pTHX_ const char *s, const char *end, bool is_utf8, HV **failure_details, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 PERL_CALLCONV void
-Perl_qerror(pTHX_ SV *err);
+Perl_qerror(pTHX_ SV *err)
+        Perl_attribute_nonnull_aTHX_;
 PERL_CALLCONV SV *
 Perl_reg_named_buff(pTHX_ REGEXP * const rx, SV * const key, SV * const value, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV SV *
 Perl_reg_named_buff_iter(pTHX_ REGEXP * const rx, const SV * const lastkey, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV void
 Perl_reg_numbered_buff_fetch(pTHX_ REGEXP * const re, const I32 paren, SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV void
 Perl_reg_numbered_buff_fetch_flags(pTHX_ REGEXP * const re, const I32 paren, SV * const sv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV I32
 Perl_reg_numbered_buff_length(pTHX_ REGEXP * const rx, const SV * const sv, const I32 paren)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 PERL_CALLCONV void
 Perl_reg_numbered_buff_store(pTHX_ REGEXP * const rx, const I32 paren, SV const * const value)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV SV *
 Perl_reg_qr_package(pTHX_ REGEXP * const rx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV REGEXP *
 Perl_reg_temp_copy(pTHX_ REGEXP *dsv, REGEXP *ssv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 PERL_CALLCONV void
-Perl_report_uninit(pTHX_ const SV *uninit_sv);
+Perl_report_uninit(pTHX_ const SV *uninit_sv)
+        Perl_attribute_nonnull_aTHX_;
 PERL_CALLCONV char *
 Perl_scan_str(pTHX_ char *start, int keep_quoted, int keep_delims, int re_reparse, char **delimp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 PERL_CALLCONV char *
 Perl_scan_word(pTHX_ char *s, char *dest, STRLEN destlen, int allow_package, STRLEN *slp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_5);
 PERL_CALLCONV char *
 Perl_skipspace_flags(pTHX_ char *s, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 PERL_CALLCONV MAGIC *
 Perl_sv_magicext_mglob(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 /* PERL_CALLCONV U8 *
-Perl_utf16_to_utf8(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen); */
+Perl_utf16_to_utf8(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen)
+        Perl_attribute_nonnull_aTHX_; */
 PERL_CALLCONV U8 *
 Perl_utf16_to_utf8_base(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_4);
 /* PERL_CALLCONV U8 *
-Perl_utf16_to_utf8_reversed(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen); */
+Perl_utf16_to_utf8_reversed(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen)
+        Perl_attribute_nonnull_aTHX_; */
 PERL_CALLCONV U8 *
 Perl_utf8_to_utf16_base(pTHX_ U8 *s, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_4);
 PERL_CALLCONV bool
 Perl_validate_proto(pTHX_ SV *name, SV *proto, bool warn, bool curstash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV void
 Perl_vivify_defelem(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV int
-Perl_yylex(pTHX);
+Perl_yylex(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 PERL_CALLCONV bool
 Perl_isSCRIPT_RUN(pTHX_ const U8 *s, const U8 *send, const bool utf8_target)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -7302,29 +8390,38 @@ Perl_invlist_search_(SV * const invlist, const UV cp)
      defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C)
 PERL_CALLCONV SV *
 Perl_add_range_to_invlist_(pTHX_ SV *invlist, UV start, UV end)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 /* PERL_CALLCONV void
-invlist_intersection_(pTHX_ SV * const a, SV * const b, SV **i); */
+invlist_intersection_(pTHX_ SV * const a, SV * const b, SV **i)
+        Perl_attribute_nonnull_aTHX_; */
 PERL_CALLCONV void
 Perl_invlist_intersection_maybe_complement_2nd_(pTHX_ SV * const a, SV * const b, const bool complement_b, SV **i)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_4);
 PERL_CALLCONV void
 Perl_invlist_invert_(pTHX_ SV * const invlist)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 /* PERL_CALLCONV void
-invlist_subtract_(pTHX_ SV * const a, SV * const b, SV **result); */
+invlist_subtract_(pTHX_ SV * const a, SV * const b, SV **result)
+        Perl_attribute_nonnull_aTHX_; */
 /* PERL_CALLCONV void
-invlist_union_(pTHX_ SV * const a, SV * const b, SV **output); */
+invlist_union_(pTHX_ SV * const a, SV * const b, SV **output)
+        Perl_attribute_nonnull_aTHX_; */
 PERL_CALLCONV void
 Perl_invlist_union_maybe_complement_2nd_(pTHX_ SV * const a, SV * const b, const bool complement_b, SV **output)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_4);
 PERL_CALLCONV SV *
 Perl_new_invlist_(pTHX_ IV initial_size)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 PERL_CALLCONV SV *
 Perl_setup_canned_invlist_(pTHX_ const STRLEN size, const UV element0, UV **other_elements_ptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 # endif /* defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) ||
@@ -7333,16 +8430,19 @@ Perl_setup_canned_invlist_(pTHX_ const STRLEN size, const UV element0, UV **othe
      defined(PERL_IN_TOKE_C)
 PERL_CALLCONV const char *
 Perl_form_alien_digit_msg(pTHX_ const U8 which, const STRLEN valids_len, const char * const first_bad, const char * const send, const bool UTF, const bool braced)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 PERL_CALLCONV bool
 Perl_grok_bslash_c(pTHX_ const char source, U8 *result, const char **message, U32 *packed_warn)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 PERL_CALLCONV bool
 Perl_grok_bslash_o(pTHX_ char **s, const char * const send, UV *uv, const char **message, U32 *packed_warn, const bool strict, const bool allow_UV_MAX, const bool utf8)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -7350,6 +8450,7 @@ Perl_grok_bslash_o(pTHX_ char **s, const char * const send, UV *uv, const char *
         __attribute__warn_unused_result__;
 PERL_CALLCONV bool
 Perl_grok_bslash_x(pTHX_ char **s, const char * const send, UV *uv, const char **message, U32 *packed_warn, const bool strict, const bool allow_UV_MAX, const bool utf8)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -7361,12 +8462,14 @@ Perl_grok_bslash_x(pTHX_ char **s, const char * const send, UV *uv, const char *
      defined(PERL_IN_TOKE_C)   || defined(PERL_IN_UTF8_C)
 PERL_CALLCONV const char *
 Perl_form_cp_too_large_msg(pTHX_ const U8 which, const char *string, const Size_t len, const UV cp)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # endif
 # if defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) || \
      defined(PERL_IN_REGCOMP_ANY)
 PERL_CALLCONV void
 Perl_invlist_dump_(pTHX_ PerlIO *file, I32 level, const char * const indent, SV * const invlist)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4);
@@ -7375,17 +8478,21 @@ Perl_invlist_dump_(pTHX_ PerlIO *file, I32 level, const char * const indent, SV 
      defined(PERL_IN_UTF8_C)
 PERL_CALLCONV bool
 Perl_invlistEQ_(pTHX_ SV * const a, SV * const b, const bool complement_b)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 PERL_CALLCONV SV *
 Perl_new_invlist_C_array_(pTHX_ const UV * const list)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
-# endif
+# endif /* defined(PERL_IN_PERL_C) || defined(PERL_IN_REGCOMP_ANY) ||
+           defined(PERL_IN_UTF8_C) */
 # if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
      defined(PERL_IN_TOKE_C)
 PERL_CALLCONV bool
 Perl_is_grapheme(pTHX_ const U8 *strbeg, const U8 *s, const U8 *strend, const UV cp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -7402,35 +8509,44 @@ Perl_to_fold_latin1_(const U8 c, U8 *p, STRLEN *lenp, const unsigned int flags)
 # if defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING)
 static U8
 S_put_charclass_bitmap_innards(pTHX_ SV *sv, char *bitmap, SV *nonbitmap_invlist, SV *only_utf8_locale_invlist, const regnode * const node, const U8 flags, const bool force_as_is_display)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static SV *
 S_put_charclass_bitmap_innards_common(pTHX_ SV *invlist, SV *posixes, SV *only_utf8, SV *not_utf8, SV *only_utf8_locale, const bool invert)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static void
 S_put_charclass_bitmap_innards_invlist(pTHX_ SV *sv, SV *invlist)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 static void
 S_put_code_point(pTHX_ SV *sv, UV c)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static void
 S_put_range(pTHX_ SV *sv, UV start, const UV end, const bool allow_literals)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static void
-S_regdump_extflags(pTHX_ const char *lead, const U32 flags);
+S_regdump_extflags(pTHX_ const char *lead, const U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 static void
-S_regdump_intflags(pTHX_ const char *lead, const U32 flags);
+S_regdump_intflags(pTHX_ const char *lead, const U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 # endif /* defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING) */
 #endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 #if defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API)
 PERL_CALLCONV void
 Perl_finalize_optree(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FINALIZE_OPTREE       \
         assert(o)
 
 PERL_CALLCONV void
 Perl_optimize_optree(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_OPTIMIZE_OPTREE       \
         assert(o)
@@ -7439,44 +8555,50 @@ Perl_optimize_optree(pTHX_ OP *o)
 #if defined(PERL_DEBUG_READONLY_COW)
 PERL_CALLCONV void
 Perl_sv_buf_to_ro(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SV_BUF_TO_RO          \
         assert(sv)
 
-#endif
+#endif /* defined(PERL_DEBUG_READONLY_COW) */
 #if defined(PERL_DEBUG_READONLY_OPS)
 PERL_CALLCONV PADOFFSET
 Perl_op_refcnt_dec(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_OP_REFCNT_DEC         \
         assert(o)
 
 PERL_CALLCONV OP *
-Perl_op_refcnt_inc(pTHX_ OP *o);
+Perl_op_refcnt_inc(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_OP_REFCNT_INC
 
 #endif /* defined(PERL_DEBUG_READONLY_OPS) */
 #if defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION)
 PERL_CALLCONV bool
 Perl_do_exec(pTHX_ const char *cmd)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_EXEC               \
         assert(cmd)
 
-#else
+#else /* if !defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION) */
 PERL_CALLCONV bool
 Perl_do_exec(pTHX_ const char *cmd)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_EXEC               \
         assert(cmd)
 
-#endif
+#endif /* !defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION) */
 #if defined(PERL_DONT_CREATE_GVSV)
 /* PERL_CALLCONV GV *
-Perl_gv_SVadd(pTHX_ GV *gv); */
+Perl_gv_SVadd(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_; */
 
 #endif
 #if defined(PERL_IMPLICIT_SYS)
@@ -7515,11 +8637,13 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags, const struct IPerlMem **
 # endif /* defined(USE_ITHREADS) */
 #else /* if !defined(PERL_IMPLICIT_SYS) */
 PERL_CALLCONV I32
-Perl_my_pclose(pTHX_ PerlIO *ptr);
+Perl_my_pclose(pTHX_ PerlIO *ptr)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_MY_PCLOSE
 
 PERL_CALLCONV PerlIO *
 Perl_my_popen(pTHX_ const char *cmd, const char *mode)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_MY_POPEN              \
@@ -7530,6 +8654,7 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode)
 #   if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE bool
 S_PerlEnv_putenv(pTHX_ char *str)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #     define PERL_ARGS_ASSERT_PERLENV_PUTENV    \
         assert(str)
@@ -7540,6 +8665,7 @@ S_PerlEnv_putenv(pTHX_ char *str)
 #if defined(PERL_IN_AV_C)
 static MAGIC *
 S_get_aux_mg(pTHX_ AV *av)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_GET_AUX_MG            \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
@@ -7548,6 +8674,7 @@ S_get_aux_mg(pTHX_ AV *av)
 #if defined(PERL_IN_BUILTIN_C) || defined(PERL_IN_OP_C)
 PERL_CALLCONV void
 Perl_XS_builtin_indexed(pTHX_ CV *cv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_XS_BUILTIN_INDEXED    \
@@ -7555,16 +8682,19 @@ Perl_XS_builtin_indexed(pTHX_ CV *cv)
 
 PERL_CALLCONV void
 Perl_finish_export_lexical(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_FINISH_EXPORT_LEXICAL
 
 PERL_CALLCONV void
 Perl_import_builtin_bundle(pTHX_ U16 ver)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_IMPORT_BUILTIN_BUNDLE
 
 PERL_CALLCONV void
 Perl_prepare_export_lexical(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PREPARE_EXPORT_LEXICAL
 
@@ -7572,6 +8702,7 @@ Perl_prepare_export_lexical(pTHX)
 #if defined(PERL_IN_CLASS_C)
 static void
 S_class_cleanup_definition(pTHX_ HV *stash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_CLEANUP_DEFINITION \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
@@ -7581,6 +8712,7 @@ S_class_cleanup_definition(pTHX_ HV *stash)
     defined(PERL_IN_OP_C)    || defined(PERL_IN_PEEP_C)
 PERL_CALLCONV OP *
 Perl_ck_anoncode(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7589,6 +8721,7 @@ Perl_ck_anoncode(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_backtick(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7597,6 +8730,7 @@ Perl_ck_backtick(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_bitop(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7605,6 +8739,7 @@ Perl_ck_bitop(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_classname(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7613,6 +8748,7 @@ Perl_ck_classname(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_cmp(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7621,6 +8757,7 @@ Perl_ck_cmp(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_concat(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7629,6 +8766,7 @@ Perl_ck_concat(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_defined(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7637,6 +8775,7 @@ Perl_ck_defined(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_delete(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7645,6 +8784,7 @@ Perl_ck_delete(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_each(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7653,6 +8793,7 @@ Perl_ck_each(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_eof(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7661,6 +8802,7 @@ Perl_ck_eof(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_eval(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7669,6 +8811,7 @@ Perl_ck_eval(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_exec(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7677,6 +8820,7 @@ Perl_ck_exec(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_exists(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7685,6 +8829,7 @@ Perl_ck_exists(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_ftst(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7693,6 +8838,7 @@ Perl_ck_ftst(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_fun(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7701,6 +8847,7 @@ Perl_ck_fun(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_glob(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7709,6 +8856,7 @@ Perl_ck_glob(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_grep(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7717,6 +8865,7 @@ Perl_ck_grep(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_helemexistsor(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7725,6 +8874,7 @@ Perl_ck_helemexistsor(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_index(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7733,6 +8883,7 @@ Perl_ck_index(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_isa(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7741,6 +8892,7 @@ Perl_ck_isa(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_join(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7749,6 +8901,7 @@ Perl_ck_join(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_length(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7757,6 +8910,7 @@ Perl_ck_length(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_lfun(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7765,6 +8919,7 @@ Perl_ck_lfun(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_listiob(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7773,6 +8928,7 @@ Perl_ck_listiob(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_match(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7781,6 +8937,7 @@ Perl_ck_match(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_method(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7789,6 +8946,7 @@ Perl_ck_method(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_null(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7797,6 +8955,7 @@ Perl_ck_null(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_open(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7805,6 +8964,7 @@ Perl_ck_open(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_prototype(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7813,6 +8973,7 @@ Perl_ck_prototype(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_readline(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7821,6 +8982,7 @@ Perl_ck_readline(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_refassign(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7829,6 +8991,7 @@ Perl_ck_refassign(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_repeat(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7837,6 +9000,7 @@ Perl_ck_repeat(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_require(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7845,6 +9009,7 @@ Perl_ck_require(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_return(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7853,6 +9018,7 @@ Perl_ck_return(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_rfun(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7861,6 +9027,7 @@ Perl_ck_rfun(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_rvconst(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7869,6 +9036,7 @@ Perl_ck_rvconst(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_sassign(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7877,6 +9045,7 @@ Perl_ck_sassign(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_scmp(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7885,6 +9054,7 @@ Perl_ck_scmp(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_select(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7893,6 +9063,7 @@ Perl_ck_select(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_shift(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7901,6 +9072,7 @@ Perl_ck_shift(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_smartmatch(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7909,6 +9081,7 @@ Perl_ck_smartmatch(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_sort(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7917,6 +9090,7 @@ Perl_ck_sort(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_spair(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7925,6 +9099,7 @@ Perl_ck_spair(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_split(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7933,6 +9108,7 @@ Perl_ck_split(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_stringify(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7941,6 +9117,7 @@ Perl_ck_stringify(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_subr(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7949,6 +9126,7 @@ Perl_ck_subr(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_substr(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7957,6 +9135,7 @@ Perl_ck_substr(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_svconst(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7965,6 +9144,7 @@ Perl_ck_svconst(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_tell(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7973,6 +9153,7 @@ Perl_ck_tell(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_trunc(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7981,6 +9162,7 @@ Perl_ck_trunc(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_trycatch(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -7994,6 +9176,7 @@ Perl_ck_trycatch(pTHX_ OP *o)
     defined(PERL_IN_TOKE_C)
 PERL_CALLCONV void
 Perl_class_add_ADJUST(pTHX_ HV *stash, CV *cv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_CLASS_ADD_ADJUST      \
@@ -8002,6 +9185,7 @@ Perl_class_add_ADJUST(pTHX_ HV *stash, CV *cv)
 
 PERL_CALLCONV void
 Perl_class_add_field(pTHX_ HV *stash, PADNAME *pn)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_CLASS_ADD_FIELD       \
@@ -8009,34 +9193,40 @@ Perl_class_add_field(pTHX_ HV *stash, PADNAME *pn)
 
 PERL_CALLCONV void
 Perl_class_apply_attributes(pTHX_ HV *stash, OP *attrlist)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_APPLY_ATTRIBUTES \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_class_apply_field_attributes(pTHX_ PADNAME *pn, OP *attrlist)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_APPLY_FIELD_ATTRIBUTES \
         assert(pn)
 
 PERL_CALLCONV void
-Perl_class_prepare_initfield_parse(pTHX);
+Perl_class_prepare_initfield_parse(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_CLASS_PREPARE_INITFIELD_PARSE
 
 PERL_CALLCONV void
 Perl_class_prepare_method_parse(pTHX_ CV *cv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_PREPARE_METHOD_PARSE \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
 Perl_class_seal_stash(pTHX_ HV *stash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_SEAL_STASH      \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_class_set_field_defop(pTHX_ PADNAME *pn, OPCODE defmode, OP *defop)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_CLASS_SET_FIELD_DEFOP \
@@ -8044,16 +9234,19 @@ Perl_class_set_field_defop(pTHX_ PADNAME *pn, OPCODE defmode, OP *defop)
 
 PERL_CALLCONV void
 Perl_class_setup_stash(pTHX_ HV *stash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_SETUP_STASH     \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV OP *
-Perl_class_wrap_method_body(pTHX_ OP *o);
+Perl_class_wrap_method_body(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_CLASS_WRAP_METHOD_BODY
 
 PERL_CALLCONV void
 Perl_croak_kw_unless_class(pTHX_ const char *kw)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CROAK_KW_UNLESS_CLASS \
         assert(kw)
@@ -8064,6 +9257,7 @@ Perl_croak_kw_unless_class(pTHX_ const char *kw)
 #if defined(PERL_IN_DEB_C)
 static void
 S_deb_stack_n(pTHX_ SV **stack_base, SSize_t stack_min, SSize_t stack_max, SSize_t mark_min, SSize_t mark_max, SSize_t nonrc_base)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DEB_STACK_N           \
         assert(stack_base)
@@ -8072,6 +9266,7 @@ S_deb_stack_n(pTHX_ SV **stack_base, SSize_t stack_min, SSize_t stack_max, SSize
 #if defined(PERL_IN_DOIO_C)
 static bool
 S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explicit)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_ARGVOUT_FINAL         \
@@ -8079,6 +9274,7 @@ S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explicit)
 
 static void
 S_exec_failed(pTHX_ const char *cmd, int fd, int do_report)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_EXEC_FAILED           \
         assert(cmd)
@@ -8091,6 +9287,7 @@ S_is_fork_open(const char *name)
 
 static bool
 S_openn_cleanup(pTHX_ GV *gv, IO *io, PerlIO *fp, char *mode, const char *oname, PerlIO *saveifp, PerlIO *saveofp, int savefd, char savetype, int writing, bool was_fdopen, const char *type, Stat_t *statbufp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_4)
@@ -8100,6 +9297,7 @@ S_openn_cleanup(pTHX_ GV *gv, IO *io, PerlIO *fp, char *mode, const char *oname,
 
 static IO *
 S_openn_setup(pTHX_ GV *gv, char *mode, PerlIO **saveifp, PerlIO **saveofp, int *savefd, char *savetype)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -8113,6 +9311,7 @@ S_openn_setup(pTHX_ GV *gv, char *mode, PerlIO **saveifp, PerlIO **saveofp, int 
 # if !defined(DOSISH)
 static bool
 S_ingroup(pTHX_ Gid_t testgid, bool effective)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_INGROUP
 
@@ -8121,6 +9320,7 @@ S_ingroup(pTHX_ Gid_t testgid, bool effective)
 #if defined(PERL_IN_DOOP_C)
 static Size_t
 S_do_trans_complex(pTHX_ SV * const sv, const OPtrans_map * const tbl)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -8129,6 +9329,7 @@ S_do_trans_complex(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 
 static Size_t
 S_do_trans_count(pTHX_ SV * const sv, const OPtrans_map * const tbl)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -8137,6 +9338,7 @@ S_do_trans_count(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 
 static Size_t
 S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -8145,6 +9347,7 @@ S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
 
 static Size_t
 S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -8153,6 +9356,7 @@ S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
 
 static Size_t
 S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -8221,30 +9425,35 @@ S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 #endif
 #if defined(PERL_IN_DUMP_C)
 static CV *
-S_deb_curcv(pTHX_ I32 ix);
+S_deb_curcv(pTHX_ I32 ix)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_DEB_CURCV
 
 static void
 S_debprof(pTHX_ const OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DEBPROF               \
         assert(o)
 
 static SV *
 S_pm_description(pTHX_ const PMOP *pm)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_PM_DESCRIPTION        \
         assert(pm)
 
 static char *
 S_pv_display_flags(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pvlim, I32 pretty_flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_PV_DISPLAY_FLAGS      \
         assert(dsv); assert(pv)
 
 static UV
-S_sequence_num(pTHX_ const OP *o);
+S_sequence_num(pTHX_ const OP *o)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_SEQUENCE_NUM
 
 #endif /* defined(PERL_IN_DUMP_C) */
@@ -8252,12 +9461,14 @@ S_sequence_num(pTHX_ const OP *o);
     defined(PERL_IN_SCOPE_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV void
 Perl_hv_kill_backrefs(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_HV_KILL_BACKREFS      \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
-#endif
+#endif /* defined(PERL_IN_DUMP_C)  || defined(PERL_IN_HV_C) ||
+          defined(PERL_IN_SCOPE_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY)
 # define PERL_ARGS_ASSERT_INVLIST_DUMP_         \
@@ -8267,6 +9478,7 @@ Perl_hv_kill_backrefs(pTHX_ HV *hv)
 #if defined(PERL_IN_GV_C)
 static bool
 S_find_default_stash(pTHX_ HV **stash, const char *name, STRLEN len, const U32 is_utf8, const I32 add, const svtype sv_type)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_DEFAULT_STASH    \
@@ -8274,18 +9486,21 @@ S_find_default_stash(pTHX_ HV **stash, const char *name, STRLEN len, const U32 i
 
 static void
 S_gv_init_svtype(pTHX_ GV *gv, const svtype sv_type)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_GV_INIT_SVTYPE        \
         assert(gv)
 
 static bool
 S_gv_is_in_main(pTHX_ const char *name, STRLEN len, const U32 is_utf8)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_GV_IS_IN_MAIN         \
         assert(name)
 
 static bool
 S_gv_magicalize(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, const svtype sv_type)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -8295,12 +9510,14 @@ S_gv_magicalize(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, const svt
 
 static void
 S_gv_magicalize_isa(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_GV_MAGICALIZE_ISA     \
         assert(gv)
 
 static void
 S_maybe_multimagic_gv(pTHX_ GV *gv, const char *name, const svtype sv_type)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_MAYBE_MULTIMAGIC_GV   \
@@ -8308,6 +9525,7 @@ S_maybe_multimagic_gv(pTHX_ GV *gv, const char *name, const svtype sv_type)
 
 static bool
 S_parse_gv_stash_name(pTHX_ HV **stash, GV **gv, const char **name, STRLEN *len, const char *nambeg, STRLEN full_len, const U32 is_utf8, const I32 add)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -8319,6 +9537,7 @@ S_parse_gv_stash_name(pTHX_ HV **stash, GV **gv, const char **name, STRLEN *len,
 
 static void
 S_require_tie_mod(pTHX_ GV *gv, const char varname, const char *name, STRLEN len, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_REQUIRE_TIE_MOD       \
@@ -8326,12 +9545,14 @@ S_require_tie_mod(pTHX_ GV *gv, const char varname, const char *name, STRLEN len
 
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE GV *
-S_gv_fetchmeth_internal(pTHX_ HV *stash, SV *meth, const char *name, STRLEN len, I32 level, U32 flags);
+S_gv_fetchmeth_internal(pTHX_ HV *stash, SV *meth, const char *name, STRLEN len, I32 level, U32 flags)
+        Perl_attribute_nonnull_aTHX_;
 #   define PERL_ARGS_ASSERT_GV_FETCHMETH_INTERNAL \
         assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
 PERL_STATIC_INLINE HV *
 S_gv_stashpvn_internal(pTHX_ const char *name, U32 namelen, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_GV_STASHPVN_INTERNAL \
         assert(name)
@@ -8342,6 +9563,7 @@ S_gv_stashpvn_internal(pTHX_ const char *name, U32 namelen, I32 flags)
     defined(PERL_IN_PAD_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV void
 Perl_sv_add_backref(pTHX_ SV * const tsv, SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -8357,41 +9579,48 @@ Perl_sv_add_backref(pTHX_ SV * const tsv, SV * const sv)
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV HV *
 Perl_gv_stashsvpvn_cached(pTHX_ SV *namesv, const char *name, U32 namelen, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 # endif
 #endif /* defined(PERL_IN_GV_C) || defined(PERL_IN_UNIVERSAL_C) */
 #if defined(PERL_IN_HV_C)
 static void
 S_clear_placeholders(pTHX_ HV *hv, U32 items)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLEAR_PLACEHOLDERS    \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 static void
 S_hsplit(pTHX_ HV *hv, STRLEN const oldsize, STRLEN newsize)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_HSPLIT                \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 static struct xpvhv_aux *
 S_hv_auxinit(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_AUXINIT            \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 static SV *
-S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen, int k_flags, I32 d_flags, U32 hash);
+S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen, int k_flags, I32 d_flags, U32 hash)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_HV_DELETE_COMMON      \
         assert(!hv || SvTYPE(hv) == SVt_PVHV)
 
 static SV *
 S_hv_free_ent_ret(pTHX_ HE *entry)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_FREE_ENT_RET       \
         assert(entry)
 
 static void
 S_hv_free_entries(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_FREE_ENTRIES       \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
@@ -8407,6 +9636,7 @@ S_hv_magic_check(HV *hv, bool *needs_copy, bool *needs_store)
 
 PERL_STATIC_NO_RET void
 S_hv_notallowed(pTHX_ int flags, const char *key, I32 klen, const char *msg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_4)
         __attribute__noreturn__;
@@ -8415,6 +9645,7 @@ S_hv_notallowed(pTHX_ int flags, const char *key, I32 klen, const char *msg)
 
 static SV *
 S_refcounted_he_value(pTHX_ const struct refcounted_he *he)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_REFCOUNTED_HE_VALUE   \
         assert(he)
@@ -8429,18 +9660,21 @@ S_save_hek_flags(const char *str, I32 len, U32 hash, int flags)
 
 static HEK *
 S_share_hek_flags(pTHX_ const char *str, STRLEN len, U32 hash, int flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SHARE_HEK_FLAGS       \
         assert(str)
 
 static void
-S_unshare_hek_or_pvn(pTHX_ const HEK *hek, const char *str, I32 len, U32 hash);
+S_unshare_hek_or_pvn(pTHX_ const HEK *hek, const char *str, I32 len, U32 hash)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_UNSHARE_HEK_OR_PVN
 
 # if !defined(PURIFY)
 static HE *
 S_new_he(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_NEW_HE
 
@@ -8449,15 +9683,18 @@ S_new_he(pTHX)
 #if defined(PERL_IN_HV_C) || defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV void
 Perl_sv_kill_backrefs(pTHX_ SV * const sv, AV * const av)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SV_KILL_BACKREFS      \
         assert(sv)
 
-#endif
+#endif /* defined(PERL_IN_HV_C) || defined(PERL_IN_MG_C) ||
+          defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_HV_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV SV *
 Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -8467,11 +9704,13 @@ Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
 #endif /* defined(PERL_IN_HV_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_LOCALE_C)
 static utf8ness_t
-S_get_locale_string_utf8ness_i(pTHX_ const char *string, const locale_utf8ness_t known_utf8, const char *locale, const locale_category_index cat_index);
+S_get_locale_string_utf8ness_i(pTHX_ const char *string, const locale_utf8ness_t known_utf8, const char *locale, const locale_category_index cat_index)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_GET_LOCALE_STRING_UTF8NESS_I
 
 static void
 S_ints_to_tm(pTHX_ struct tm *my_tm, const char *locale, int sec, int min, int hour, int mday, int mon, int year, int isdst)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_INTS_TO_TM            \
@@ -8479,16 +9718,19 @@ S_ints_to_tm(pTHX_ struct tm *my_tm, const char *locale, int sec, int min, int h
 
 static bool
 S_is_locale_utf8(pTHX_ const char *locale)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_IS_LOCALE_UTF8        \
         assert(locale)
 
 static HV *
-S_my_localeconv(pTHX_ const int item);
+S_my_localeconv(pTHX_ const int item)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_MY_LOCALECONV
 
 static void
 S_populate_hash_from_C_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2])
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_4)
@@ -8499,6 +9741,7 @@ S_populate_hash_from_C_localeconv(pTHX_ HV *hv, const char *locale, const U32 wh
 
 static bool
 S_strftime8(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm *mytm, const utf8ness_t fmt_utf8ness, utf8ness_t *result_utf8ness, const bool called_externally)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -8510,6 +9753,7 @@ S_strftime8(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm *
 
 static bool
 S_strftime_tm(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm *mytm)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -8520,6 +9764,7 @@ S_strftime_tm(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm
 
 static SV *
 S_sv_strftime_common(pTHX_ SV *fmt, const char *locale, const struct tm *mytm)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -8529,63 +9774,75 @@ S_sv_strftime_common(pTHX_ SV *fmt, const char *locale, const struct tm *mytm)
 # if defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO)
 static const char *
 S_emulate_langinfo(pTHX_ const PERL_INTMAX_T item, const char *locale, SV *sv, utf8ness_t *utf8ness)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 #   define PERL_ARGS_ASSERT_EMULATE_LANGINFO    \
         assert(locale); assert(sv)
 
-# endif
+# endif /* defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO) */
 # if defined(USE_LOCALE)
 static const char *
-S_calculate_LC_ALL_string(pTHX_ const char **category_locales_list, const calc_LC_ALL_format format, const calc_LC_ALL_return returning, const line_t caller_line);
+S_calculate_LC_ALL_string(pTHX_ const char **category_locales_list, const calc_LC_ALL_format format, const calc_LC_ALL_return returning, const line_t caller_line)
+        Perl_attribute_nonnull_aTHX_;
 #   define PERL_ARGS_ASSERT_CALCULATE_LC_ALL_STRING
 
 static const char *
 S_external_call_langinfo(pTHX_ const nl_item item, SV *sv, utf8ness_t *utf8ness)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_EXTERNAL_CALL_LANGINFO \
         assert(sv)
 
 static locale_category_index
 S_get_category_index_helper(pTHX_ const int category, bool *success, const line_t caller_line)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_GET_CATEGORY_INDEX_HELPER
 
 static const char *
-S_native_querylocale_i(pTHX_ const locale_category_index cat_index);
+S_native_querylocale_i(pTHX_ const locale_category_index cat_index)
+        Perl_attribute_nonnull_aTHX_;
 #   define PERL_ARGS_ASSERT_NATIVE_QUERYLOCALE_I
 
 static void
 S_new_LC_ALL(pTHX_ const char *lc_all, bool force)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_NEW_LC_ALL          \
         assert(lc_all)
 
 static void
-S_output_check_environment_warning(pTHX_ const char * const language, const char * const lc_all, const char * const lang);
+S_output_check_environment_warning(pTHX_ const char * const language, const char * const lc_all, const char * const lang)
+        Perl_attribute_nonnull_aTHX_;
 #   define PERL_ARGS_ASSERT_OUTPUT_CHECK_ENVIRONMENT_WARNING
 
 static parse_LC_ALL_string_return
 S_parse_LC_ALL_string(pTHX_ const char *string, const char **output, const parse_LC_ALL_STRING_action, bool always_use_full_array, const bool panic_on_error, const line_t caller_line)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_PARSE_LC_ALL_STRING \
         assert(string); assert(output)
 
 static void
-S_restore_toggled_locale_i(pTHX_ const locale_category_index cat_index, const char *original_locale, const line_t caller_line);
+S_restore_toggled_locale_i(pTHX_ const locale_category_index cat_index, const char *original_locale, const line_t caller_line)
+        Perl_attribute_nonnull_aTHX_;
 #   define PERL_ARGS_ASSERT_RESTORE_TOGGLED_LOCALE_I
 
 static const char *
-S_save_to_buffer(pTHX_ const char *string, char **buf, Size_t *buf_size);
+S_save_to_buffer(pTHX_ const char *string, char **buf, Size_t *buf_size)
+        Perl_attribute_nonnull_aTHX_;
 #   define PERL_ARGS_ASSERT_SAVE_TO_BUFFER
 
 static void
-S_set_save_buffer_min_size(pTHX_ const Size_t min_len, char **buf, Size_t *buf_size);
+S_set_save_buffer_min_size(pTHX_ const Size_t min_len, char **buf, Size_t *buf_size)
+        Perl_attribute_nonnull_aTHX_;
 #   define PERL_ARGS_ASSERT_SET_SAVE_BUFFER_MIN_SIZE
 
 PERL_STATIC_NO_RET void
 S_setlocale_failure_panic_via_i(pTHX_ const locale_category_index cat_index, const char *current, const char *failed, const line_t proxy_caller_line, const line_t immediate_caller_line, const char *higher_caller_file, const line_t higher_caller_line)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_6)
         __attribute__noreturn__;
@@ -8594,6 +9851,7 @@ S_setlocale_failure_panic_via_i(pTHX_ const locale_category_index cat_index, con
 
 static const char *
 S_toggle_locale_i(pTHX_ const locale_category_index cat_index, const char *new_locale, const line_t caller_line)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_TOGGLE_LOCALE_I     \
         assert(new_locale)
@@ -8601,6 +9859,7 @@ S_toggle_locale_i(pTHX_ const locale_category_index cat_index, const char *new_l
 #   if defined(DEBUGGING)
 static char *
 S_my_setlocale_debug_string_i(pTHX_ const locale_category_index cat_index, const char *locale, const char *retval, const line_t line)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #     define PERL_ARGS_ASSERT_MY_SETLOCALE_DEBUG_STRING_I
 
@@ -8609,6 +9868,7 @@ S_my_setlocale_debug_string_i(pTHX_ const locale_category_index cat_index, const
        ( defined(USE_LOCALE_MONETARY) || defined(USE_LOCALE_NUMERIC) )
 static void
 S_populate_hash_from_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2])
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_4)
@@ -8623,15 +9883,17 @@ S_populate_hash_from_localeconv(pTHX_ HV *hv, const char *locale, const U32 whic
 #   if defined(HAS_NL_LANGINFO)
 static const char *
 S_langinfo_sv_i(pTHX_ const nl_item item, locale_category_index cat_index, const char *locale, SV *sv, utf8ness_t *utf8ness)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4);
 #     define PERL_ARGS_ASSERT_LANGINFO_SV_I     \
         assert(locale); assert(sv)
 
-#   endif
+#   endif /* defined(HAS_NL_LANGINFO) */
 #   if defined(LC_ALL)
 static void
 S_give_perl_locale_control(pTHX_ const char *lc_all_string, const line_t caller_line)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
         assert(lc_all_string)
@@ -8639,6 +9901,7 @@ S_give_perl_locale_control(pTHX_ const char *lc_all_string, const line_t caller_
 #   else
 static void
 S_give_perl_locale_control(pTHX_ const char **curlocales, const line_t caller_line)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
         assert(curlocales)
@@ -8647,6 +9910,7 @@ S_give_perl_locale_control(pTHX_ const char **curlocales, const line_t caller_li
 #   if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE const char *
 S_mortalized_pv_copy(pTHX_ const char * const pv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #     define PERL_ARGS_ASSERT_MORTALIZED_PV_COPY
 
@@ -8654,6 +9918,7 @@ S_mortalized_pv_copy(pTHX_ const char * const pv)
 #   if defined(USE_LOCALE_COLLATE)
 static void
 S_new_collate(pTHX_ const char *newcoll, bool force)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #     define PERL_ARGS_ASSERT_NEW_COLLATE       \
         assert(newcoll)
@@ -8661,12 +9926,13 @@ S_new_collate(pTHX_ const char *newcoll, bool force)
 #     if defined(DEBUGGING)
 static void
 S_print_collxfrm_input_and_return(pTHX_ const char *s, const char *e, const char *xbuf, const STRLEN xlen, const bool is_utf8)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #       define PERL_ARGS_ASSERT_PRINT_COLLXFRM_INPUT_AND_RETURN \
         assert(s); assert(e); assert(s <= e)
 
-#     endif
+#     endif /* defined(DEBUGGING) */
 #   endif /* defined(USE_LOCALE_COLLATE) */
 #   if defined(USE_LOCALE_CTYPE)
 static bool
@@ -8677,6 +9943,7 @@ S_is_codeset_name_UTF8(const char *name)
 
 static void
 S_new_ctype(pTHX_ const char *newctype, bool force)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #     define PERL_ARGS_ASSERT_NEW_CTYPE         \
         assert(newctype)
@@ -8685,6 +9952,7 @@ S_new_ctype(pTHX_ const char *newctype, bool force)
 #   if defined(USE_LOCALE_NUMERIC)
 static void
 S_new_numeric(pTHX_ const char *newnum, bool force)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #     define PERL_ARGS_ASSERT_NEW_NUMERIC       \
         assert(newnum)
@@ -8692,28 +9960,33 @@ S_new_numeric(pTHX_ const char *newnum, bool force)
 #   endif
 #   if defined(USE_PERL_SWITCH_LOCALE_CONTEXT) || defined(DEBUGGING)
 static const char *
-S_get_LC_ALL_display(pTHX);
+S_get_LC_ALL_display(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #     define PERL_ARGS_ASSERT_GET_LC_ALL_DISPLAY
 
 #   endif
 #   if defined(USE_POSIX_2008_LOCALE)
 static bool
 S_bool_setlocale_2008_i(pTHX_ const locale_category_index index, const char *new_locale, const line_t caller_line)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #     define PERL_ARGS_ASSERT_BOOL_SETLOCALE_2008_I \
         assert(new_locale)
 
 static const char *
-S_querylocale_2008_i(pTHX_ const locale_category_index index, const line_t line);
+S_querylocale_2008_i(pTHX_ const locale_category_index index, const line_t line)
+        Perl_attribute_nonnull_aTHX_;
 #     define PERL_ARGS_ASSERT_QUERYLOCALE_2008_I
 
 static locale_t
-S_use_curlocale_scratch(pTHX);
+S_use_curlocale_scratch(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 #     define PERL_ARGS_ASSERT_USE_CURLOCALE_SCRATCH
 
 #     if !defined(USE_QUERYLOCALE)
 static void
 S_update_PL_curlocales_i(pTHX_ const locale_category_index index, const char *new_locale, const line_t caller_line)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #       define PERL_ARGS_ASSERT_UPDATE_PL_CURLOCALES_I \
         assert(new_locale)
@@ -8725,12 +9998,14 @@ S_update_PL_curlocales_i(pTHX_ const locale_category_index index, const char *ne
          !defined(USE_POSIX_2008_LOCALE) */
 static bool
 S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char *locale)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #     define PERL_ARGS_ASSERT_LESS_DICEY_BOOL_SETLOCALE_R \
         assert(locale)
 
 static const char *
-S_less_dicey_setlocale_r(pTHX_ const int category, const char *locale);
+S_less_dicey_setlocale_r(pTHX_ const int category, const char *locale)
+        Perl_attribute_nonnull_aTHX_;
 #     define PERL_ARGS_ASSERT_LESS_DICEY_SETLOCALE_R
 
 #   endif /*  defined(USE_LOCALE_THREADS) &&
@@ -8747,18 +10022,21 @@ S_Win_wstring_to_byte_string(const UINT code_page, const wchar_t *wstring);
 #     define PERL_ARGS_ASSERT_WIN_WSTRING_TO_BYTE_STRING
 
 static const char *
-S_win32_setlocale(pTHX_ int category, const char *locale);
+S_win32_setlocale(pTHX_ int category, const char *locale)
+        Perl_attribute_nonnull_aTHX_;
 #     define PERL_ARGS_ASSERT_WIN32_SETLOCALE
 
 static const char *
-S_wrap_wsetlocale(pTHX_ const int category, const char *locale);
+S_wrap_wsetlocale(pTHX_ const int category, const char *locale)
+        Perl_attribute_nonnull_aTHX_;
 #     define PERL_ARGS_ASSERT_WRAP_WSETLOCALE
 
 #   endif /* defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) */
 #   if   defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) || \
        ( defined(USE_POSIX_2008_LOCALE) && !defined(USE_QUERYLOCALE) )
 static const char *
-S_find_locale_from_environment(pTHX_ const locale_category_index index);
+S_find_locale_from_environment(pTHX_ const locale_category_index index)
+        Perl_attribute_nonnull_aTHX_;
 #     define PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT
 
 #   endif
@@ -8766,12 +10044,13 @@ S_find_locale_from_environment(pTHX_ const locale_category_index index);
 # if defined(USE_LOCALE) || defined(DEBUGGING)
 static const char *
 S_get_displayable_string(pTHX_ const char * const s, const char * const e, const bool is_utf8)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_GET_DISPLAYABLE_STRING \
         assert(s); assert(e); assert(s <= e)
 
-# endif
+# endif /* defined(USE_LOCALE) || defined(DEBUGGING) */
 #endif /* defined(PERL_IN_LOCALE_C) */
 #if defined(PERL_IN_MALLOC_C)
 static int
@@ -8781,15 +10060,21 @@ S_adjust_size_and_find_bucket(size_t *nbytes_p)
         assert(nbytes_p)
 
 #endif
+#if defined(PERL_IN_MATHOMS_C) || defined(PERL_IN_OP_C) || \
+    defined(PERL_IN_PERLY_C)   || defined(PERL_IN_TOKE_C)
+
+#endif
 #if defined(PERL_IN_MG_C)
 static void
 S_fixup_errno_string(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FIXUP_ERRNO_STRING    \
         assert(sv)
 
 static SV *
 S_magic_methcall1(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, int n, SV *val)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -8798,6 +10083,7 @@ S_magic_methcall1(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, int n, SV 
 
 static int
 S_magic_methpack(pTHX_ SV *sv, const MAGIC *mg, SV *meth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -8805,17 +10091,20 @@ S_magic_methpack(pTHX_ SV *sv, const MAGIC *mg, SV *meth)
         assert(sv); assert(mg); assert(meth)
 
 static void
-S_restore_magic(pTHX_ void *p);
+S_restore_magic(pTHX_ void *p)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_RESTORE_MAGIC
 
 static void
 S_save_magic_flags(pTHX_ SSize_t mgs_ix, SV *sv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_SAVE_MAGIC_FLAGS      \
         assert(sv)
 
 static void
-S_unwind_handler_stack(pTHX_ void *p);
+S_unwind_handler_stack(pTHX_ void *p)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_UNWIND_HANDLER_STACK
 
 #endif /* defined(PERL_IN_MG_C) */
@@ -8832,6 +10121,7 @@ Perl_translate_substr_offsets(STRLEN curlen, IV pos1_iv, bool pos1_is_uv, IV len
 #if defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV void
 Perl_mg_free_struct(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -8842,6 +10132,7 @@ Perl_mg_free_struct(pTHX_ SV *sv, MAGIC *mg)
 #if defined(PERL_IN_MRO_C)
 static void
 S_mro_clean_isarev(pTHX_ HV * const isa, const char * const name, const STRLEN len, HV * const exceptions, U32 hash, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_MRO_CLEAN_ISAREV      \
@@ -8850,6 +10141,7 @@ S_mro_clean_isarev(pTHX_ HV * const isa, const char * const name, const STRLEN l
 
 static void
 S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes, HV *stash, HV *oldstash, SV *namesv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_5);
@@ -8861,6 +10153,7 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes, HV *s
 
 static AV *
 S_mro_get_linear_isa_dfs(pTHX_ HV *stash, U32 level)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_MRO_GET_LINEAR_ISA_DFS \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
@@ -8869,6 +10162,7 @@ S_mro_get_linear_isa_dfs(pTHX_ HV *stash, U32 level)
 #if defined(PERL_IN_OP_C)
 static void
 S_apply_attrs(pTHX_ HV *stash, SV *target, OP *attrs)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_APPLY_ATTRS           \
@@ -8876,6 +10170,7 @@ S_apply_attrs(pTHX_ HV *stash, SV *target, OP *attrs)
 
 static void
 S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **imopsp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_4);
@@ -8885,11 +10180,13 @@ S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **imopsp)
 
 static I32
 S_assignment_type(pTHX_ const OP *o)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ASSIGNMENT_TYPE
 
 static void
 S_bad_type_gv(pTHX_ I32 n, GV *gv, const OP *kid, const char *t)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4);
@@ -8898,6 +10195,7 @@ S_bad_type_gv(pTHX_ I32 n, GV *gv, const OP *kid, const char *t)
 
 static void
 S_bad_type_pv(pTHX_ I32 n, const char *t, const OP *o, const OP *kid)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4);
@@ -8906,6 +10204,7 @@ S_bad_type_pv(pTHX_ I32 n, const char *t, const OP *o, const OP *kid)
 
 static CV *
 S_clear_special_blocks(pTHX_ const char * const fullname, GV * const gv, CV * const cv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -8915,44 +10214,52 @@ S_clear_special_blocks(pTHX_ const char * const fullname, GV * const gv, CV * co
 
 static void
 S_cop_free(pTHX_ COP *cop)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_COP_FREE              \
         assert(cop)
 
 static OP *
 S_dup_attrlist(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DUP_ATTRLIST          \
         assert(o)
 
 static void
 S_find_and_forget_pmops(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FIND_AND_FORGET_PMOPS \
         assert(o)
 
 static OP *
 S_fold_constants(pTHX_ OP * const o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FOLD_CONSTANTS        \
         assert(o)
 
 static OP *
-S_force_list(pTHX_ OP *arg, bool nullit);
+S_force_list(pTHX_ OP *arg, bool nullit)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_FORCE_LIST
 
 static void
 S_forget_pmop(pTHX_ PMOP * const o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FORGET_PMOP           \
         assert(o)
 
 static void
-S_gen_constant_list(pTHX_ OP *o);
+S_gen_constant_list(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_GEN_CONSTANT_LIST
 
 static void
 S_inplace_aassign(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_INPLACE_AASSIGN       \
         assert(o)
@@ -8971,21 +10278,25 @@ S_is_handle_constructor(const OP *o, I32 numargs)
         assert(o)
 
 static OP *
-S_listkids(pTHX_ OP *o);
+S_listkids(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_LISTKIDS
 
 static bool
 S_looks_like_bool(pTHX_ const OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_LOOKS_LIKE_BOOL       \
         assert(o)
 
 static OP *
-S_modkids(pTHX_ OP *o, I32 type);
+S_modkids(pTHX_ OP *o, I32 type)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_MODKIDS
 
 static void
 S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV *name, bool curstash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -8994,18 +10305,21 @@ S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV *name, bool curstash)
 
 static OP *
 S_my_kid(pTHX_ OP *o, OP *attrs, OP **imopsp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_MY_KID                \
         assert(imopsp)
 
 static OP *
 S_newGIVWHENOP(pTHX_ OP *cond, OP *block, I32 enter_opcode, I32 leave_opcode, PADOFFSET entertarg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_NEWGIVWHENOP          \
         assert(block)
 
 static OP *
 S_new_logop(pTHX_ I32 type, I32 flags, OP **firstp, OP **otherp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
@@ -9014,6 +10328,7 @@ S_new_logop(pTHX_ I32 type, I32 flags, OP **firstp, OP **otherp)
 
 static OP *
 S_no_fh_allowed(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NO_FH_ALLOWED         \
@@ -9021,6 +10336,7 @@ S_no_fh_allowed(pTHX_ OP *o)
 
 static OP *
 S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -9029,6 +10345,7 @@ S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
 
 static bool
 S_process_special_blocks(pTHX_ I32 floor, const char * const fullname, GV * const gv, CV * const cv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4);
@@ -9037,11 +10354,13 @@ S_process_special_blocks(pTHX_ I32 floor, const char * const fullname, GV * cons
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 static OP *
-S_ref_array_or_hash(pTHX_ OP *cond);
+S_ref_array_or_hash(pTHX_ OP *cond)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_REF_ARRAY_OR_HASH
 
 static OP *
-S_refkids(pTHX_ OP *o, I32 type);
+S_refkids(pTHX_ OP *o, I32 type)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_REFKIDS
 
 static bool
@@ -9051,16 +10370,19 @@ S_scalar_mod_type(const OP *o, I32 type)
 
 static OP *
 S_scalarboolean(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SCALARBOOLEAN         \
         assert(o)
 
 static OP *
-S_scalarkids(pTHX_ OP *o);
+S_scalarkids(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_SCALARKIDS
 
 static OP *
 S_search_const(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SEARCH_CONST          \
@@ -9068,12 +10390,14 @@ S_search_const(pTHX_ OP *o)
 
 static void
 S_simplify_sort(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SIMPLIFY_SORT         \
         assert(o)
 
 static OP *
 S_too_few_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -9082,18 +10406,21 @@ S_too_few_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
 
 static OP *
 S_too_many_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_TOO_MANY_ARGUMENTS_PV \
         assert(o); assert(name)
 
 static OP *
-S_voidnonfinal(pTHX_ OP *o);
+S_voidnonfinal(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_VOIDNONFINAL
 
 # if defined(DEBUGGING)
 static const char *
 S_get_displayable_tr_operand(pTHX_ const U8 *s, STRLEN len, bool is_utf8)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_GET_DISPLAYABLE_TR_OPERAND \
         assert(s)
@@ -9107,17 +10434,20 @@ S_is_standard_filehandle_name(const char *fhname)
         assert(fhname)
 
 PERL_STATIC_INLINE OP *
-S_newMETHOP_internal(pTHX_ I32 type, I32 flags, OP *dynamic_meth, SV * const_meth);
+S_newMETHOP_internal(pTHX_ I32 type, I32 flags, OP *dynamic_meth, SV * const_meth)
+        Perl_attribute_nonnull_aTHX_;
 #   define PERL_ARGS_ASSERT_NEWMETHOP_INTERNAL
 
 PERL_STATIC_INLINE OP *
 S_op_integerize(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_OP_INTEGERIZE       \
         assert(o)
 
 PERL_STATIC_INLINE OP *
 S_op_std_init(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_OP_STD_INIT         \
         assert(o)
@@ -9141,11 +10471,13 @@ S_size_to_psize(size_t size);
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C)
 PERL_CALLCONV void
 Perl_check_hash_fields_and_hekify(pTHX_ UNOP *rop, SVOP *key_op, int real)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CHECK_HASH_FIELDS_AND_HEKIFY
 
 PERL_CALLCONV void
 Perl_no_bareword_allowed(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_NO_BAREWORD_ALLOWED   \
@@ -9160,6 +10492,7 @@ Perl_op_prune_chain_head(OP **op_p)
 
 PERL_CALLCONV SV *
 Perl_op_varname(pTHX_ const OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OP_VARNAME            \
@@ -9167,6 +10500,7 @@ Perl_op_varname(pTHX_ const OP *o)
 
 PERL_CALLCONV void
 Perl_warn_elem_scalar_context(pTHX_ const OP *o, SV *name, bool is_hash, bool is_slice)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -9180,6 +10514,7 @@ Perl_warn_elem_scalar_context(pTHX_ const OP *o, SV *name, bool is_hash, bool is
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV void
 Perl_report_redefined_cv(pTHX_ const SV *name, const CV *old_cv, SV * const *new_const_svp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -9188,6 +10523,7 @@ Perl_report_redefined_cv(pTHX_ const SV *name, const CV *old_cv, SV * const *new
 
 PERL_CALLCONV SV *
 Perl_varname(pTHX_ const GV * const gv, const char gvtype, PADOFFSET targ, const SV * const keyname, SSize_t aindex, int subscript_type)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_VARNAME
@@ -9196,18 +10532,21 @@ Perl_varname(pTHX_ const GV * const gv, const char gvtype, PADOFFSET targ, const
 #if defined(PERL_IN_PAD_C)
 static PADOFFSET
 S_pad_alloc_name(pTHX_ PADNAME *name, U32 flags, HV *typestash, HV *ourstash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_PAD_ALLOC_NAME        \
         assert(name); assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
 static void
 S_pad_check_dup(pTHX_ PADNAME *name, U32 flags, const HV *ourstash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_PAD_CHECK_DUP         \
         assert(name)
 
 static PADOFFSET
 S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV *cv, U32 seq, int warn, SV **out_capture, PADNAME **out_name, int *out_flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_4)
         Perl_attribute_nonnull_(pTHX_8)
@@ -9216,34 +10555,39 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV *cv,
         assert(namepv); assert(cv); assert(out_name); assert(out_flags)
 
 static void
-S_pad_reset(pTHX);
+S_pad_reset(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PAD_RESET
 
 # if defined(DEBUGGING)
 static void
 S_cv_dump(pTHX_ const CV *cv, const char *title)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_CV_DUMP             \
         assert(cv); assert(title)
 
-# endif
+# endif /* defined(DEBUGGING) */
 #endif /* defined(PERL_IN_PAD_C) */
 #if defined(PERL_IN_PEEP_C)
 static void
 S_finalize_op(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FINALIZE_OP           \
         assert(o)
 
 static void
 S_optimize_op(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_OPTIMIZE_OP           \
         assert(o)
 
 static OP *
 S_traverse_op_tree(pTHX_ OP *top, OP *o)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_TRAVERSE_OP_TREE      \
@@ -9253,97 +10597,116 @@ S_traverse_op_tree(pTHX_ OP *top, OP *o)
 #if defined(PERL_IN_PERL_C)
 static void
 S_find_beginning(pTHX_ SV *linestr_sv, PerlIO *rsfp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_BEGINNING        \
         assert(linestr_sv); assert(rsfp)
 
 static void
-S_forbid_setid(pTHX_ const char flag, const bool suidscript);
+S_forbid_setid(pTHX_ const char flag, const bool suidscript)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_FORBID_SETID
 
 static void
 S_incpush(pTHX_ const char * const dir, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_INCPUSH               \
         assert(dir)
 
 static void
 S_incpush_use_sep(pTHX_ const char *p, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_INCPUSH_USE_SEP       \
         assert(p)
 
 static void
-S_init_ids(pTHX);
+S_init_ids(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_INIT_IDS
 
 static void
-S_init_interp(pTHX);
+S_init_interp(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_INIT_INTERP
 
 static void
-S_init_main_stash(pTHX);
+S_init_main_stash(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_INIT_MAIN_STASH
 
 static void
-S_init_perllib(pTHX);
+S_init_perllib(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_INIT_PERLLIB
 
 static void
 S_init_postdump_symbols(pTHX_ int argc, char **argv, char **env)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_INIT_POSTDUMP_SYMBOLS \
         assert(argv)
 
 static void
-S_init_predump_symbols(pTHX);
+S_init_predump_symbols(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_INIT_PREDUMP_SYMBOLS
 
 static SV *
 S_mayberelocate(pTHX_ const char * const dir, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_MAYBERELOCATE         \
         assert(dir)
 
 PERL_STATIC_NO_RET void
 S_minus_v(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_MINUS_V
 
 PERL_STATIC_NO_RET void
 S_my_exit_jump(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_MY_EXIT_JUMP
 
 static void
-S_nuke_stacks(pTHX);
+S_nuke_stacks(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_NUKE_STACKS
 
 static PerlIO *
 S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_OPEN_SCRIPT           \
         assert(scriptname); assert(suidscript)
 
 static void *
-S_parse_body(pTHX_ char **env, XSINIT_t xsinit);
+S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PARSE_BODY
 
 PERL_STATIC_NO_RET void
 S_run_body(pTHX_ I32 oldscope)
+        Perl_attribute_nonnull_aTHX_
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_RUN_BODY
 
 PERL_STATIC_NO_RET void
 S_usage(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_USAGE
 
 # if !defined(PERL_IS_MINIPERL)
 static SV *
 S_incpush_if_exists(pTHX_ AV * const av, SV *dir, SV * const stem)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -9354,6 +10717,7 @@ S_incpush_if_exists(pTHX_ AV * const av, SV *dir, SV * const stem)
 # if !defined(SETUID_SCRIPTS_ARE_SECURE_NOW)
 static void
 S_validate_suid(pTHX_ PerlIO *rsfp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_VALIDATE_SUID       \
         assert(rsfp)
@@ -9372,17 +10736,20 @@ S_validate_suid(pTHX_ PerlIO *rsfp)
 #if defined(PERL_IN_PP_C)
 static size_t
 S_do_chomp(pTHX_ SV *retval, SV *sv, bool chomping)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_DO_CHOMP              \
         assert(retval); assert(sv)
 
 static OP *
-S_do_delete_local(pTHX);
+S_do_delete_local(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_DO_DELETE_LOCAL
 
 static SV *
 S_refto(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_REFTO                 \
@@ -9393,6 +10760,7 @@ S_refto(pTHX_ SV *sv)
 
 PERL_CALLCONV GV *
 Perl_softref2xv(pTHX_ SV * const sv, const char * const what, const svtype type)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -9407,6 +10775,7 @@ Perl_softref2xv(pTHX_ SV * const sv, const char * const what, const svtype type)
 #if defined(PERL_IN_PP_C) || defined(PERL_IN_UTF8_C)
 PERL_CALLCONV UV
 Perl_to_upper_title_latin1_(pTHX_ const U8 c, U8 *p, STRLEN *lenp, const char S_or_s)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
@@ -9417,6 +10786,7 @@ Perl_to_upper_title_latin1_(pTHX_ const U8 c, U8 *p, STRLEN *lenp, const char S_
 #if defined(PERL_IN_PP_CTL_C)
 static PerlIO *
 S_check_type_and_open(pTHX_ SV *name)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_CHECK_TYPE_AND_OPEN   \
@@ -9424,29 +10794,34 @@ S_check_type_and_open(pTHX_ SV *name)
 
 static void
 S_destroy_matcher(pTHX_ PMOP *matcher)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DESTROY_MATCHER       \
         assert(matcher)
 
 static OP *
-S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied);
+S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_DO_SMARTMATCH         \
         assert(!seen_this || SvTYPE(seen_this) == SVt_PVHV); \
         assert(!seen_other || SvTYPE(seen_other) == SVt_PVHV)
 
 static OP *
 S_docatch(pTHX_ Perl_ppaddr_t firstpp)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOCATCH
 
 static bool
-S_doeval_compile(pTHX_ U8 gimme, CV *outside, U32 seq, HV *hh);
+S_doeval_compile(pTHX_ U8 gimme, CV *outside, U32 seq, HV *hh)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_DOEVAL_COMPILE        \
         assert(!outside || SvTYPE(outside) == SVt_PVCV || SvTYPE(outside) == SVt_PVFM); \
         assert(!hh || SvTYPE(hh) == SVt_PVHV)
 
 static OP *
 S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstack, OP **oplimit)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_5)
@@ -9457,22 +10832,26 @@ S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstac
 
 static MAGIC *
 S_doparseform(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DOPARSEFORM           \
         assert(sv)
 
 static I32
 S_dopoptoeval(pTHX_ I32 startingblock)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOEVAL
 
 static I32
 S_dopoptogivenfor(pTHX_ I32 startingblock)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOGIVENFOR
 
 static I32
 S_dopoptolabel(pTHX_ const char *label, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOLABEL          \
@@ -9480,11 +10859,13 @@ S_dopoptolabel(pTHX_ const char *label, STRLEN len, U32 flags)
 
 static I32
 S_dopoptoloop(pTHX_ I32 startingblock)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOLOOP
 
 static I32
 S_dopoptosub_at(pTHX_ const PERL_CONTEXT *cxstk, I32 startingblock)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOSUB_AT         \
@@ -9492,11 +10873,13 @@ S_dopoptosub_at(pTHX_ const PERL_CONTEXT *cxstk, I32 startingblock)
 
 static I32
 S_dopoptowhen(pTHX_ I32 startingblock)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOWHEN
 
 static PMOP *
 S_make_matcher(pTHX_ REGEXP *re)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MAKE_MATCHER          \
@@ -9504,6 +10887,7 @@ S_make_matcher(pTHX_ REGEXP *re)
 
 static bool
 S_matcher_matches_sv(pTHX_ PMOP *matcher, SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -9517,6 +10901,7 @@ S_num_overflow(NV value, I32 fldsize, I32 frcsize)
 
 static I32
 S_run_user_filter(pTHX_ int idx, SV *buf_sv, int maxlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_RUN_USER_FILTER       \
@@ -9524,12 +10909,14 @@ S_run_user_filter(pTHX_ int idx, SV *buf_sv, int maxlen)
 
 static void
 S_rxres_free(pTHX_ void **rsp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RXRES_FREE            \
         assert(rsp)
 
 static void
 S_rxres_restore(pTHX_ void **rsp, REGEXP *rx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_RXRES_RESTORE         \
@@ -9537,6 +10924,7 @@ S_rxres_restore(pTHX_ void **rsp, REGEXP *rx)
 
 static void
 S_save_lines(pTHX_ AV *array, SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_SAVE_LINES            \
         assert(!array || SvTYPE(array) == SVt_PVAV); assert(sv)
@@ -9544,12 +10932,13 @@ S_save_lines(pTHX_ AV *array, SV *sv)
 # if !defined(PERL_DISABLE_PMC)
 static PerlIO *
 S_doopen_pm(pTHX_ SV *name)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_DOOPEN_PM           \
         assert(name)
 
-# endif
+# endif /* !defined(PERL_DISABLE_PMC) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE bool
 S_path_is_searchable(const char *name)
@@ -9563,6 +10952,7 @@ S_path_is_searchable(const char *name)
 #if defined(PERL_IN_PP_CTL_C) || defined(PERL_IN_UTIL_C)
 PERL_CALLCONV bool
 Perl_invoke_exception_hook(pTHX_ SV *ex, bool warn)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_INVOKE_EXCEPTION_HOOK
 
@@ -9570,6 +10960,7 @@ Perl_invoke_exception_hook(pTHX_ SV *ex, bool warn)
 #if defined(PERL_IN_PP_HOT_C)
 static void
 S_do_oddball(pTHX_ SV **oddkey, SV **firstkey)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_DO_ODDBALL            \
@@ -9578,12 +10969,14 @@ S_do_oddball(pTHX_ SV **oddkey, SV **firstkey)
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE HV *
 S_opmethod_stash(pTHX_ SV *meth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_OPMETHOD_STASH      \
         assert(meth)
 
 PERL_STATIC_FORCE_INLINE bool
 S_should_we_output_Debug_r(pTHX_ regexp *prog)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__always_inline__;
@@ -9595,6 +10988,7 @@ S_should_we_output_Debug_r(pTHX_ regexp *prog)
 #if defined(PERL_IN_PP_PACK_C)
 static int
 S_div128(pTHX_ SV *pnum, bool *done)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_DIV128                \
@@ -9609,6 +11003,7 @@ S_first_symbol(const char *pat, const char *patend)
 
 static const char *
 S_get_num(pTHX_ const char *patptr, SSize_t *lenptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -9617,6 +11012,7 @@ S_get_num(pTHX_ const char *patptr, SSize_t *lenptr)
 
 static const char *
 S_group_end(pTHX_ const char *patptr, const char *patend, char ender)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_GROUP_END             \
@@ -9624,6 +11020,7 @@ S_group_end(pTHX_ const char *patptr, const char *patend, char ender)
 
 static SV *
 S_is_an_int(pTHX_ const char *s, STRLEN l)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_AN_INT             \
@@ -9631,12 +11028,14 @@ S_is_an_int(pTHX_ const char *s, STRLEN l)
 
 static SSize_t
 S_measure_struct(pTHX_ struct tempsym *symptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_MEASURE_STRUCT        \
         assert(symptr)
 
 static SV *
 S_mul128(pTHX_ SV *sv, U8 m)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_MUL128                \
         assert(sv)
@@ -9658,12 +11057,14 @@ S_need_utf8(const char *pat, const char *patend)
 
 static bool
 S_next_symbol(pTHX_ struct tempsym *symptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_NEXT_SYMBOL           \
         assert(symptr)
 
 static SV **
 S_pack_rec(pTHX_ SV *cat, struct tempsym *symptr, SV **beglist, SV **endlist)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -9673,6 +11074,7 @@ S_pack_rec(pTHX_ SV *cat, struct tempsym *symptr, SV **beglist, SV **endlist)
 
 static char *
 S_sv_exp_grow(pTHX_ SV *sv, STRLEN needed)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_EXP_GROW           \
@@ -9680,6 +11082,7 @@ S_sv_exp_grow(pTHX_ SV *sv, STRLEN needed)
 
 static SSize_t
 S_unpack_rec(pTHX_ struct tempsym *symptr, const char *s, const char *strbeg, const char *strend, const char **new_s)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -9693,6 +11096,7 @@ S_unpack_rec(pTHX_ struct tempsym *symptr, const char *s, const char *strbeg, co
 
 static I32
 S_sortcv(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_SORTCV                \
@@ -9700,6 +11104,7 @@ S_sortcv(pTHX_ SV * const a, SV * const b)
 
 static I32
 S_sortcv_stacked(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_SORTCV_STACKED        \
@@ -9707,6 +11112,7 @@ S_sortcv_stacked(pTHX_ SV * const a, SV * const b)
 
 static I32
 S_sortcv_xsub(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_SORTCV_XSUB           \
@@ -9715,6 +11121,7 @@ S_sortcv_xsub(pTHX_ SV * const a, SV * const b)
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE I32
 S_amagic_cmp(pTHX_ SV * const str1, SV * const str2)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_CMP          \
@@ -9722,6 +11129,7 @@ S_amagic_cmp(pTHX_ SV * const str1, SV * const str2)
 
 PERL_STATIC_INLINE I32
 S_amagic_cmp_desc(pTHX_ SV * const str1, SV * const str2)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_CMP_DESC     \
@@ -9729,6 +11137,7 @@ S_amagic_cmp_desc(pTHX_ SV * const str1, SV * const str2)
 
 PERL_STATIC_INLINE I32
 S_amagic_i_ncmp(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_I_NCMP       \
@@ -9736,6 +11145,7 @@ S_amagic_i_ncmp(pTHX_ SV * const a, SV * const b)
 
 PERL_STATIC_INLINE I32
 S_amagic_i_ncmp_desc(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_I_NCMP_DESC  \
@@ -9743,6 +11153,7 @@ S_amagic_i_ncmp_desc(pTHX_ SV * const a, SV * const b)
 
 PERL_STATIC_INLINE I32
 S_amagic_ncmp(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_NCMP         \
@@ -9750,6 +11161,7 @@ S_amagic_ncmp(pTHX_ SV * const a, SV * const b)
 
 PERL_STATIC_INLINE I32
 S_amagic_ncmp_desc(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_NCMP_DESC    \
@@ -9757,6 +11169,7 @@ S_amagic_ncmp_desc(pTHX_ SV * const a, SV * const b)
 
 PERL_STATIC_INLINE I32
 S_cmp_desc(pTHX_ SV * const str1, SV * const str2)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_CMP_DESC            \
@@ -9764,6 +11177,7 @@ S_cmp_desc(pTHX_ SV * const str1, SV * const str2)
 
 PERL_STATIC_FORCE_INLINE void
 S_sortsv_flags_impl(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__always_inline__;
 #   define PERL_ARGS_ASSERT_SORTSV_FLAGS_IMPL   \
@@ -9771,6 +11185,7 @@ S_sortsv_flags_impl(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp, U32 flag
 
 PERL_STATIC_INLINE I32
 S_sv_i_ncmp(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_I_NCMP           \
@@ -9778,6 +11193,7 @@ S_sv_i_ncmp(pTHX_ SV * const a, SV * const b)
 
 PERL_STATIC_INLINE I32
 S_sv_i_ncmp_desc(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_I_NCMP_DESC      \
@@ -9785,6 +11201,7 @@ S_sv_i_ncmp_desc(pTHX_ SV * const a, SV * const b)
 
 PERL_STATIC_INLINE I32
 S_sv_ncmp(pTHX_ SV *a, SV *b)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_NCMP             \
@@ -9792,6 +11209,7 @@ S_sv_ncmp(pTHX_ SV *a, SV *b)
 
 PERL_STATIC_INLINE I32
 S_sv_ncmp_desc(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_NCMP_DESC        \
@@ -9800,6 +11218,7 @@ S_sv_ncmp_desc(pTHX_ SV * const a, SV * const b)
 #   if defined(USE_LOCALE_COLLATE)
 PERL_STATIC_INLINE I32
 S_amagic_cmp_locale(pTHX_ SV * const str1, SV * const str2)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #     define PERL_ARGS_ASSERT_AMAGIC_CMP_LOCALE \
@@ -9807,6 +11226,7 @@ S_amagic_cmp_locale(pTHX_ SV * const str1, SV * const str2)
 
 PERL_STATIC_INLINE I32
 S_amagic_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #     define PERL_ARGS_ASSERT_AMAGIC_CMP_LOCALE_DESC \
@@ -9814,6 +11234,7 @@ S_amagic_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2)
 
 PERL_STATIC_INLINE I32
 S_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #     define PERL_ARGS_ASSERT_CMP_LOCALE_DESC   \
@@ -9828,6 +11249,7 @@ S_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2)
 #if defined(PERL_IN_PP_SYS_C)
 static OP *
 S_doform(pTHX_ CV *cv, GV *gv, OP *retop)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_DOFORM                \
@@ -9835,11 +11257,13 @@ S_doform(pTHX_ CV *cv, GV *gv, OP *retop)
         assert(gv)
 
 static SV *
-S_space_join_names_mortal(pTHX_ char * const *array);
+S_space_join_names_mortal(pTHX_ char * const *array)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_SPACE_JOIN_NAMES_MORTAL
 
 static void
 S_warn_not_dirhandle(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_WARN_NOT_DIRHANDLE    \
         assert(gv)
@@ -9847,6 +11271,7 @@ S_warn_not_dirhandle(pTHX_ GV *gv)
 # if !defined(HAS_MKDIR) || !defined(HAS_RMDIR)
 static int
 S_dooneliner(pTHX_ const char *cmd, const char *filename)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -9898,26 +11323,31 @@ S_dooneliner(pTHX_ const char *cmd, const char *filename)
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
 Perl_add_above_Latin1_folds(pTHX_ RExC_state_t *pRExC_state, const U8 cp, SV **invlist)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 PERL_CALLCONV regnode *
 Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *source, U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 PERL_CALLCONV SV *
 Perl_get_ANYOFHbbm_contents(pTHX_ const regnode *n)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 PERL_CALLCONV SV *
 Perl_get_ANYOFM_contents(pTHX_ const regnode *n)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 PERL_CALLCONV U32
 Perl_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan, UV *min_subtract, bool *unfolded_multi_char, U32 flags, regnode *val, U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -9925,6 +11355,7 @@ Perl_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan, UV *min_subtract
         __attribute__visibility__("hidden");
 PERL_CALLCONV I32
 Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch, regnode *first, regnode *last, regnode *tail, U32 word_count, U32 flags, U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -9933,6 +11364,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch, regnode *f
         __attribute__visibility__("hidden");
 PERL_CALLCONV void
 Perl_populate_anyof_bitmap_from_invlist(pTHX_ regnode *node, SV **invlist_ptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -9944,22 +11376,26 @@ Perl_reg_add_data(RExC_state_t * const pRExC_state, const char * const s, const 
         __attribute__visibility__("hidden");
 PERL_CALLCONV void
 Perl_scan_commit(pTHX_ const RExC_state_t *pRExC_state, struct scan_data_t *data, SSize_t *minlenp, int is_inf)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 PERL_CALLCONV void
 Perl_set_ANYOF_arg(pTHX_ RExC_state_t * const pRExC_state, regnode * const node, SV * const cp_list, SV * const runtime_defns, SV * const only_utf8_locale_list)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 PERL_CALLCONV void
 Perl_ssc_init(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 PERL_CALLCONV SSize_t
 Perl_study_chunk(pTHX_ RExC_state_t *pRExC_state, regnode **scanp, SSize_t *minlenp, SSize_t *deltap, regnode *last, struct scan_data_t *data, I32 stopparen, U32 recursed_depth, regnode_ssc *and_withp, U32 flags, U32 depth, bool was_mutate_ok)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -9969,14 +11405,17 @@ Perl_study_chunk(pTHX_ RExC_state_t *pRExC_state, regnode **scanp, SSize_t *minl
 #   if defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING)
 static void
 S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 static void
 S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 next_alloc, U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 static void
 S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 next_alloc, U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 #   endif /* defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING) */
@@ -10011,6 +11450,7 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie, HV *widecharm
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE SV *
 S_invlist_contents(pTHX_ SV * const invlist, const bool traditional_style)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE UV
@@ -10035,6 +11475,7 @@ S_invlist_lowest(SV * const invlist)
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
 Perl_invlist_clone(pTHX_ SV * const invlist, SV *newlist)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # endif
 #endif /* defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_SV_C) */
@@ -10103,6 +11544,7 @@ Perl_invlist_clone(pTHX_ SV * const invlist, SV *newlist)
 
 PERL_STATIC_NO_RET void
 S_re_croak(pTHX_ bool utf8, const char *pat, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__noreturn__
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
@@ -10182,12 +11624,15 @@ S_re_croak(pTHX_ bool utf8, const char *pat, ...)
 # if defined(PERL_CORE) || defined(PERL_EXT)
 static AV *
 S_add_multi_match(pTHX_ AV *multi_char_matches, SV *multi_string, const STRLEN cp_count)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 static void
 S_change_engine_size(pTHX_ RExC_state_t *pRExC_state, const ptrdiff_t size)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static REGEXP *
 S_compile_wildcard(pTHX_ const char *subpattern, const STRLEN len, const bool ignore_case)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 static U8
@@ -10200,6 +11645,7 @@ S_edit_distance(const UV *src, const UV *tgt, const STRLEN x, const STRLEN y, co
         __attribute__warn_unused_result__;
 static I32
 S_execute_wildcard(pTHX_ REGEXP * const prog, char *stringarg, char *strend, char *strbeg, SSize_t minend, SV *screamer, U32 nosave)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -10207,33 +11653,40 @@ S_execute_wildcard(pTHX_ REGEXP * const prog, char *stringarg, char *strend, cha
         Perl_attribute_nonnull_(pTHX_6);
 static U32
 S_get_quantifier_value(pTHX_ RExC_state_t *pRExC_state, const char *start, const char *end)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 static bool
 S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state, regnode_offset *nodep, UV *code_point_p, int *cp_count, I32 *flagp, const bool strict, const U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_5);
 static regnode_offset
 S_handle_named_backref(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, char *backref_parse_start, char ch)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 static bool
 S_handle_names_wildcard(pTHX_ const char *wname, const STRLEN wname_len, SV **prop_definition, AV **strings)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4);
 static int
 S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state, const char * const s, char **updated_parse_ptr, AV **posix_warnings, const bool check_only)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 static regnode_offset
 S_handle_regex_sets(pTHX_ RExC_state_t *pRExC_state, SV **return_invlist, I32 *flagp, U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 static SV *
 S_handle_user_defined_property(pTHX_ const char *name, const STRLEN name_len, const bool is_utf8, const bool to_fold, const bool runtime, const bool deferrable, SV *contents, bool *user_defined_ptr, SV *msg, const STRLEN level)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_7)
         Perl_attribute_nonnull_(pTHX_8)
@@ -10244,9 +11697,11 @@ S_is_ssc_worth_it(const RExC_state_t *pRExC_state, const regnode_ssc *ssc)
         Perl_attribute_nonnull_(2);
 static void
 S_nextchar(pTHX_ RExC_state_t *pRExC_state)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static U8
 S_optimize_regclass(pTHX_ RExC_state_t *pRExC_state, SV *cp_list, SV *only_utf8_locale_list, SV *upper_latin1_only_utf8_matches, const U32 has_runtime_dependency, const U32 posixl, U8 *anyof_flags, bool *invert, regnode_offset *ret, I32 *flagp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_7)
         Perl_attribute_nonnull_(pTHX_8)
@@ -10254,50 +11709,63 @@ S_optimize_regclass(pTHX_ RExC_state_t *pRExC_state, SV *cp_list, SV *only_utf8_
         Perl_attribute_nonnull_(pTHX_10);
 static void
 S_output_posix_warnings(pTHX_ RExC_state_t *pRExC_state, AV *posix_warnings)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 static void
 S_parse_lparen_question_flags(pTHX_ RExC_state_t *pRExC_state)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static SV *
 S_parse_uniprop_string(pTHX_ const char * const name, Size_t name_len, const bool is_utf8, const bool to_fold, const bool runtime, const bool deferrable, AV **strings, bool *user_defined_ptr, SV *msg, const STRLEN level)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_8)
         Perl_attribute_nonnull_(pTHX_9);
 static regnode_offset
 S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 static regnode_offset
 S_reg1node(pTHX_ RExC_state_t *pRExC_state, U8 op, U32 arg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static regnode_offset
 S_reg2node(pTHX_ RExC_state_t *pRExC_state, const U8 op, const U32 arg1, const I32 arg2)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static regnode_offset
 S_reg_la_NOTHING(pTHX_ RExC_state_t *pRExC_state, U32 flags, const char *type)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 static regnode_offset
 S_reg_la_OPFAIL(pTHX_ RExC_state_t *pRExC_state, U32 flags, const char *type)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 static regnode_offset
 S_reg_node(pTHX_ RExC_state_t *pRExC_state, U8 op)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static SV *
 S_reg_scan_name(pTHX_ RExC_state_t *pRExC_state, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static regnode_offset
 S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 static regnode_offset
 S_regbranch(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, I32 first, U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 static regnode_offset
 S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth, const bool stop_at_1, bool allow_multi_fold, const bool silence_non_portable, const bool strict, bool optimizable, SV **ret_invlist)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 static unsigned int
@@ -10305,40 +11773,50 @@ S_regex_set_precedence(const U8 my_operator)
         __attribute__warn_unused_result__;
 static void
 S_reginsert(pTHX_ RExC_state_t *pRExC_state, const U8 op, const regnode_offset operand, const U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static regnode_offset
 S_regnode_guts(pTHX_ RExC_state_t *pRExC_state, const STRLEN extra_len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static regnode_offset
 S_regpiece(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 static regnode_offset
 S_regpnode(pTHX_ RExC_state_t *pRExC_state, U8 op, SV *arg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 static bool
 S_regtail(pTHX_ RExC_state_t *pRExC_state, const regnode_offset p, const regnode_offset val, const U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 static void
 S_set_regex_pv(pTHX_ RExC_state_t *pRExC_state, REGEXP *Rx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 static void
 S_skip_to_be_ignored_text(pTHX_ RExC_state_t *pRExC_state, char **p, const bool force_to_xmod)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 static void
 S_ssc_finalize(pTHX_ RExC_state_t *pRExC_state, regnode_ssc *ssc)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   if defined(DEBUGGING)
 static regnode_offset
 S_regnode_guts_debug(pTHX_ RExC_state_t *pRExC_state, const U8 op, const STRLEN extra_len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static bool
 S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p, const regnode_offset val, U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -10346,6 +11824,7 @@ S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p, const regnode
 #     if defined(ENABLE_REGEX_SETS_DEBUGGING)
 static void
 S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state, AV *stack, const IV fence, AV *fence_stack)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_4);
@@ -10381,11 +11860,13 @@ S_reg_skipcomment(RExC_state_t *pRExC_state, char *p)
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
 Perl_populate_bitmap_from_invlist(pTHX_ SV *invlist, const UV offset, const U8 *bitmap, const Size_t len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 PERL_CALLCONV void
 Perl_populate_invlist_from_bitmap(pTHX_ const U8 *bitmap, const Size_t bitmap_len, SV **invlist, const UV offset)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
@@ -10443,6 +11924,7 @@ Perl_regcurly(const char *s, const char *e, const char *result[5])
 
 static void
 S_initialize_invlist_guts(pTHX_ SV *invlist, const Size_t initial_size)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_INITIALIZE_INVLIST_GUTS \
         assert(invlist)
@@ -10453,12 +11935,14 @@ S_initialize_invlist_guts(pTHX_ SV *invlist, const Size_t initial_size)
 # if defined(PERL_CORE) || defined(PERL_EXT)
 static void
 S_append_range_to_invlist_(pTHX_ SV * const invlist, const UV start, const UV end)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static void
 S_invlist_replace_list_destroys_src(pTHX_ SV *dest, SV *src)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
-# endif
+# endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 #   define PERL_ARGS_ASSERT_GET_INVLIST_PREVIOUS_INDEX_ADDR \
         assert(invlist)
@@ -10492,6 +11976,7 @@ S_invlist_array_init_(SV * const invlist, const bool will_have_0)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE void
 S_invlist_clear(pTHX_ SV *invlist)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_STATIC_INLINE UV
 S_invlist_max(const SV * const invlist)
@@ -10556,35 +12041,43 @@ S_invlist_trim(SV *invlist)
 # if defined(PERL_CORE) || defined(PERL_EXT)
 static SV *
 S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state, const regnode_charclass * const node)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 static SV *
 S_make_exactf_invlist(pTHX_ RExC_state_t *pRExC_state, regnode *node)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static void
 S_rck_elide_nothing(pTHX_ regnode *node)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static void
 S_ssc_add_range(pTHX_ regnode_ssc *ssc, UV const start, UV const end)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static void
 S_ssc_and(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc, const regnode_charclass *and_with)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 static void
 S_ssc_anything(pTHX_ regnode_ssc *ssc)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static void
 S_ssc_clear_locale(regnode_ssc *ssc)
         Perl_attribute_nonnull_(1);
 static void
 S_ssc_cp_and(pTHX_ regnode_ssc *ssc, UV const cp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static void
 S_ssc_intersection(pTHX_ regnode_ssc *ssc, SV * const invlist, const bool invert_2nd)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 static int
@@ -10598,15 +12091,18 @@ S_ssc_is_cp_posixl_init(const RExC_state_t *pRExC_state, const regnode_ssc *ssc)
         __attribute__warn_unused_result__;
 static void
 S_ssc_or(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc, const regnode_charclass *or_with)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 static void
 S_ssc_union(pTHX_ regnode_ssc *ssc, SV * const invlist, const bool invert_2nd)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 static void
 S_unwind_scan_frames(pTHX_ void *p)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 #endif /* defined(PERL_IN_REGCOMP_STUDY_C) */
@@ -10724,42 +12220,50 @@ S_unwind_scan_frames(pTHX_ void *p)
 # if defined(PERL_CORE) || defined(PERL_EXT)
 static LB_enum
 S_advance_one_LB(pTHX_ U8 **curpos, const U8 * const strend, const bool utf8_target)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static SB_enum
 S_advance_one_SB(pTHX_ U8 **curpos, const U8 * const strend, const bool utf8_target)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static WB_enum
 S_advance_one_WB_(pTHX_ U8 **curpos, const U8 * const strend, const bool utf8_target, const bool skip_Extend_Format)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static GCB_enum
 S_backup_one_GCB(pTHX_ const U8 * const strbeg, U8 **curpos, const bool utf8_target)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static LB_enum
 S_backup_one_LB_(pTHX_ const U8 * const strbeg, U8 **curpos, const bool utf8_target, bool skip_CM_ZWJ)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static SB_enum
 S_backup_one_SB(pTHX_ const U8 * const strbeg, U8 **curpos, const bool utf8_target)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static WB_enum
 S_backup_one_WB_but_over_Extend_FO(pTHX_ WB_enum *previous, const U8 * const strbeg, U8 **curpos, const bool utf8_target)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 static char *
 S_find_byclass(pTHX_ regexp *prog, const regnode *c, char *s, const char *strend, regmatch_info *reginfo)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -10782,31 +12286,37 @@ S_find_span_end_mask(U8 *s, const U8 *send, const U8 span_byte, const U8 mask)
         __attribute__warn_unused_result__;
 static bool
 S_isFOO_lc(pTHX_ const U8 classnum, const U8 character)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 static bool
 S_isFOO_utf8_lc(pTHX_ const U8 classnum, const U8 *character, const U8 *e)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 static bool
 S_isGCB(pTHX_ const GCB_enum before, const GCB_enum after, const U8 * const strbeg, const U8 * const curpos, const bool utf8_target)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 static bool
 S_isLB(pTHX_ LB_enum before, LB_enum after, const U8 * const strbeg, const U8 * const curpos, const U8 * const strend, const bool utf8_target)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
         Perl_attribute_nonnull_(pTHX_5)
         __attribute__warn_unused_result__;
 static bool
 S_isSB(pTHX_ SB_enum before, SB_enum after, const U8 * const strbeg, const U8 * const curpos, const U8 * const strend, const bool utf8_target)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
         Perl_attribute_nonnull_(pTHX_5)
         __attribute__warn_unused_result__;
 static bool
 S_isWB(pTHX_ WB_enum previous, WB_enum before, WB_enum after, const U8 * const strbeg, const U8 * const curpos, const U8 * const strend, const bool utf8_target)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_4)
         Perl_attribute_nonnull_(pTHX_5)
         Perl_attribute_nonnull_(pTHX_6)
@@ -10818,14 +12328,17 @@ S_reg_check_named_buff_matched(const regexp *rex, const regnode *scan)
         __attribute__warn_unused_result__;
 static void
 S_regcp_restore(pTHX_ regexp *rex, I32 ix, U32 *maxopenparen_p comma_pDEPTH)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 static void
 S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 static CHECKPOINT
 S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEPTH)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static U8 *
 S_reghop3(U8 *s, SSize_t off, const U8 *lim)
@@ -10839,18 +12352,21 @@ S_reghopmaybe3(U8 *s, SSize_t off, const U8 * const lim)
         __attribute__warn_unused_result__;
 static bool
 S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8 * const p, const U8 * const p_end, bool const utf8_target)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 static SSize_t
 S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 static I32
 S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p, char *loceol, regmatch_info * const reginfo, I32 max comma_pDEPTH)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -10859,24 +12375,29 @@ S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p, char *loceol
         __attribute__warn_unused_result__;
 static bool
 S_regtry(pTHX_ regmatch_info *reginfo, char **startposp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static bool
 S_to_byte_substr(pTHX_ regexp *prog)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 static void
 S_to_utf8_substr(pTHX_ regexp *prog)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   if defined(DEBUGGING)
 static void
 S_debug_start_match(pTHX_ const REGEXP *prog, const bool do_utf8, const char *start, const char *end, const char *blurb)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
         Perl_attribute_nonnull_(pTHX_5);
 static void
 S_dump_exec_pos(pTHX_ const char *locinput, const regnode *scan, const char *loc_regeol, const char *loc_bostr, const char *loc_reg_starttry, const bool do_utf8, const U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -10884,6 +12405,7 @@ S_dump_exec_pos(pTHX_ const char *locinput, const regnode *scan, const char *loc
         Perl_attribute_nonnull_(pTHX_5);
 PERL_CALLCONV int
 Perl_re_exec_indentf(pTHX_ const char *fmt, U32 depth, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #   endif /* defined(DEBUGGING) */
@@ -10901,14 +12423,17 @@ Perl_re_exec_indentf(pTHX_ const char *fmt, U32 depth, ...)
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE void
 S_capture_clear(pTHX_ regexp *rex, U16 from_ix, U16 to_ix, const char *str comma_pDEPTH)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_4);
 PERL_STATIC_INLINE I32
 S_foldEQ_latin1_s2_folded(pTHX_ const char *a, const char *b, I32 len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 PERL_STATIC_INLINE void
 S_unwind_paren(pTHX_ regexp *rex, U32 lp, U32 lcp comma_pDEPTH)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
@@ -10940,20 +12465,24 @@ S_unwind_paren(pTHX_ regexp *rex, U32 lp, U32 lcp comma_pDEPTH)
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
 Perl_debug_peep(pTHX_ const char *str, const RExC_state_t *pRExC_state, regnode *scan, U32 depth, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 PERL_CALLCONV void
 Perl_debug_show_study_flags(pTHX_ U32 flags, const char *open_str, const char *close_str)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 PERL_CALLCONV void
 Perl_debug_studydata(pTHX_ const char *where, scan_data_t *data, U32 depth, int is_inf, SSize_t min, SSize_t stopmin, SSize_t delta)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 PERL_CALLCONV const regnode *
 Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node, const regnode *last, const regnode *plast, SV *sv, I32 indent, U32 depth)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -10961,15 +12490,18 @@ Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
         __attribute__visibility__("hidden");
 PERL_CALLCONV int
 Perl_re_indentf(pTHX_ const char *fmt, U32 depth, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 PERL_CALLCONV int
 Perl_re_printf(pTHX_ const char *fmt, ...)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden")
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 PERL_CALLCONV void
 Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_info *reginfo, const RExC_state_t *pRExC_state)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
@@ -10982,6 +12514,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
 Perl_get_re_gclass_aux_data(pTHX_ const regexp *prog, const struct regnode *node, bool doinit, SV **listsvp, SV **lonly_utf8_locale, SV **output_invlist)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #   endif
@@ -10992,6 +12525,7 @@ Perl_get_re_gclass_aux_data(pTHX_ const regexp *prog, const struct regnode *node
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
 Perl_get_regclass_aux_data(pTHX_ const regexp *prog, const struct regnode *node, bool doinit, SV **listsvp, SV **lonly_utf8_locale, SV **output_invlist)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #   endif
@@ -10999,16 +12533,19 @@ Perl_get_regclass_aux_data(pTHX_ const regexp *prog, const struct regnode *node,
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE bool
 Perl_check_regnode_after(pTHX_ const regnode *p, const STRLEN extra)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_CHECK_REGNODE_AFTER
 
 PERL_STATIC_INLINE regnode *
 Perl_regnext(pTHX_ const regnode *p)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_REGNEXT
 
 PERL_STATIC_INLINE regnode *
 Perl_regnode_after(pTHX_ const regnode *p, bool varies)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_REGNODE_AFTER
 
@@ -11016,11 +12553,13 @@ Perl_regnode_after(pTHX_ const regnode *p, bool varies)
 #endif /* defined(PERL_IN_REGEX_ENGINE) */
 #if defined(PERL_IN_SCOPE_C)
 static void
-S_save_pushptri32ptr(pTHX_ void * const ptr1, const I32 i, void * const ptr2, const int type);
+S_save_pushptri32ptr(pTHX_ void * const ptr1, const I32 i, void * const ptr2, const int type)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_SAVE_PUSHPTRI32PTR
 
 static SV *
 S_save_scalar_at(pTHX_ SV **sptr, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SAVE_SCALAR_AT        \
         assert(sptr)
@@ -11036,6 +12575,7 @@ S_F0convert(NV nv, char * const endbuf, STRLEN * const len)
 
 static void
 S_anonymise_cv_maybe(pTHX_ GV *gv, CV *cv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_ANONYMISE_CV_MAYBE    \
@@ -11044,6 +12584,7 @@ S_anonymise_cv_maybe(pTHX_ GV *gv, CV *cv)
 
 static void
 S_assert_uft8_cache_coherent(pTHX_ const char * const func, STRLEN from_cache, STRLEN real, SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_ASSERT_UFT8_CACHE_COHERENT \
@@ -11051,6 +12592,7 @@ S_assert_uft8_cache_coherent(pTHX_ const char * const func, STRLEN from_cache, S
 
 static void
 S_croak_sv_setsv_flags(pTHX_ SV * const dsv, SV * const ssv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_CROAK_SV_SETSV_FLAGS  \
@@ -11058,12 +12600,14 @@ S_croak_sv_setsv_flags(pTHX_ SV * const dsv, SV * const ssv)
 
 static bool
 S_curse(pTHX_ SV * const sv, const bool check_refcnt)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CURSE                 \
         assert(sv)
 
 static STRLEN
 S_expect_number(pTHX_ const char ** const pattern)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_EXPECT_NUMBER         \
@@ -11071,30 +12615,35 @@ S_expect_number(pTHX_ const char ** const pattern)
 
 static SSize_t
 S_find_array_subscript(pTHX_ const AV * const av, const SV * const val)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_ARRAY_SUBSCRIPT  \
         assert(val)
 
 static SV *
 S_find_hash_subscript(pTHX_ const HV * const hv, const SV * const val)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_HASH_SUBSCRIPT   \
         assert(val)
 
 static SV *
 S_find_uninit_var(pTHX_ const OP * const obase, const SV * const uninit_sv, bool match, const char **desc_p)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_FIND_UNINIT_VAR       \
         assert(desc_p)
 
 static bool
 S_glob_2number(pTHX_ GV * const gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_GLOB_2NUMBER          \
         assert(gv)
 
 static void
 S_glob_assign_glob(pTHX_ SV * const dsv, SV * const ssv, const int dtype)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_GLOB_ASSIGN_GLOB      \
@@ -11102,12 +12651,14 @@ S_glob_assign_glob(pTHX_ SV * const dsv, SV * const ssv, const int dtype)
 
 static void
 S_not_a_number(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_NOT_A_NUMBER          \
         assert(sv)
 
 static void
 S_not_incrementable(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_NOT_INCREMENTABLE     \
         assert(sv)
@@ -11121,18 +12672,21 @@ S_ptr_table_find(PTR_TBL_t * const tbl, const void * const sv)
 
 static bool
 S_sv_2iuv_common(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_2IUV_COMMON        \
         assert(sv)
 
 static void
 S_sv_add_arena(pTHX_ char * const ptr, const U32 size, const U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_ADD_ARENA          \
         assert(ptr)
 
 static const char *
 S_sv_display(pTHX_ SV * const sv, char *tmpbuf, STRLEN tmpbuf_size)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_SV_DISPLAY            \
@@ -11140,12 +12694,14 @@ S_sv_display(pTHX_ SV * const sv, char *tmpbuf, STRLEN tmpbuf_size)
 
 static bool
 S_sv_numcmp_common(pTHX_ SV **sv1, SV **sv2, const U32 flags, int method, SV **result)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_5);
 # define PERL_ARGS_ASSERT_SV_NUMCMP_COMMON      \
         assert(result)
 
 static STRLEN
 S_sv_pos_b2u_midway(pTHX_ const U8 * const s, const U8 * const target, const U8 *end, STRLEN endu)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -11155,6 +12711,7 @@ S_sv_pos_b2u_midway(pTHX_ const U8 * const s, const U8 * const target, const U8 
 
 static STRLEN
 S_sv_pos_u2b_cached(pTHX_ SV * const sv, MAGIC ** const mgp, const U8 * const start, const U8 * const send, STRLEN uoffset, STRLEN uoffset0, STRLEN boffset0)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -11183,6 +12740,7 @@ S_sv_pos_u2b_midway(const U8 * const start, const U8 *send, STRLEN uoffset, cons
 
 static void
 S_utf8_mg_len_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN ulen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_MG_LEN_CACHE_UPDATE \
@@ -11190,6 +12748,7 @@ S_utf8_mg_len_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN
 
 static void
 S_utf8_mg_pos_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN byte, const STRLEN utf8, const STRLEN blen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_MG_POS_CACHE_UPDATE \
@@ -11197,6 +12756,7 @@ S_utf8_mg_pos_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN
 
 static SSize_t
 S_visit(pTHX_ SVFUNC_t f, const U32 flags, const U32 mask)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_VISIT                 \
         assert(f)
@@ -11204,17 +12764,20 @@ S_visit(pTHX_ SVFUNC_t f, const U32 flags, const U32 mask)
 # if defined(DEBUGGING)
 static void
 S_del_sv(pTHX_ SV *p)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_DEL_SV              \
         assert(p)
 
 PERL_CALLCONV void
 Perl_sv_mark_arenas(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #   define PERL_ARGS_ASSERT_SV_MARK_ARENAS
 
 PERL_CALLCONV void
 Perl_sv_sweep_arenas(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 #   define PERL_ARGS_ASSERT_SV_SWEEP_ARENAS
 
@@ -11223,6 +12786,7 @@ Perl_sv_sweep_arenas(pTHX)
 #   if defined(DEBUGGING)
 static int
 S_sv_2iuv_non_preserve(pTHX_ SV * const sv, I32 numtype)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #     define PERL_ARGS_ASSERT_SV_2IUV_NON_PRESERVE \
         assert(sv)
@@ -11230,6 +12794,7 @@ S_sv_2iuv_non_preserve(pTHX_ SV * const sv, I32 numtype)
 #   else
 static int
 S_sv_2iuv_non_preserve(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #     define PERL_ARGS_ASSERT_SV_2IUV_NON_PRESERVE \
         assert(sv)
@@ -11239,6 +12804,7 @@ S_sv_2iuv_non_preserve(pTHX_ SV * const sv)
 # if defined(PERL_DEBUG_READONLY_COW)
 static void
 S_sv_buf_to_rw(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_SV_BUF_TO_RW        \
         assert(sv)
@@ -11247,6 +12813,7 @@ S_sv_buf_to_rw(pTHX_ SV *sv)
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE void
 S_sv_unglob(pTHX_ SV * const sv, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_SV_UNGLOB           \
         assert(sv)
@@ -11255,6 +12822,7 @@ S_sv_unglob(pTHX_ SV * const sv, U32 flags)
 # if defined(USE_ITHREADS)
 static SV *
 S_sv_dup_common(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -11263,6 +12831,7 @@ S_sv_dup_common(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
 
 static void
 S_sv_dup_hvaux(pTHX_ const SV * const ssv, SV *dsv, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -11271,6 +12840,7 @@ S_sv_dup_hvaux(pTHX_ const SV * const ssv, SV *dsv, CLONE_PARAMS * const param)
 
 static SV **
 S_sv_dup_inc_multiple(pTHX_ SV * const *source, SV **dest, SSize_t items, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_4);
@@ -11279,6 +12849,7 @@ S_sv_dup_inc_multiple(pTHX_ SV * const *source, SV **dest, SSize_t items, CLONE_
 
 static void
 S_unreferenced_to_tmp_stack(pTHX_ AV * const unreferenced)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_UNREFERENCED_TO_TMP_STACK \
         assert(unreferenced); assert(SvTYPE(unreferenced) == SVt_PVAV)
@@ -11287,15 +12858,18 @@ S_unreferenced_to_tmp_stack(pTHX_ AV * const unreferenced)
 #endif /* defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_TOKE_C)
 static int
-S_ao(pTHX_ int toketype);
+S_ao(pTHX_ int toketype)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_AO
 
 static void
-S_check_unary(pTHX);
+S_check_unary(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_CHECK_UNARY
 
 static void
 S_checkcomma(pTHX_ const char *s, const char *name, const char *what)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -11304,6 +12878,7 @@ S_checkcomma(pTHX_ const char *s, const char *name, const char *what)
 
 static char *
 S_filter_gets(pTHX_ SV *sv, STRLEN append)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_FILTER_GETS           \
@@ -11311,6 +12886,7 @@ S_filter_gets(pTHX_ SV *sv, STRLEN append)
 
 static HV *
 S_find_in_my_stash(pTHX_ const char *pkgname, STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_FIND_IN_MY_STASH      \
@@ -11318,38 +12894,45 @@ S_find_in_my_stash(pTHX_ const char *pkgname, STRLEN len)
 
 static void
 S_force_ident(pTHX_ const char *s, int kind)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_IDENT           \
         assert(s)
 
 static void
-S_force_ident_maybe_lex(pTHX_ char pit);
+S_force_ident_maybe_lex(pTHX_ char pit)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_FORCE_IDENT_MAYBE_LEX
 
 static void
-S_force_next(pTHX_ I32 type);
+S_force_next(pTHX_ I32 type)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_FORCE_NEXT
 
 static char *
 S_force_strict_version(pTHX_ char *s)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_STRICT_VERSION  \
         assert(s)
 
 static char *
 S_force_version(pTHX_ char *s, int guessing)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_VERSION         \
         assert(s)
 
 static char *
 S_force_word(pTHX_ char *start, int token, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_WORD            \
         assert(start)
 
 static SV *
 S_get_and_check_backslash_N_name_wrapper(pTHX_ const char *s, const char * const e)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -11358,6 +12941,7 @@ S_get_and_check_backslash_N_name_wrapper(pTHX_ const char *s, const char * const
 
 static void
 S_incline(pTHX_ const char *s, const char *end)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_INCLINE               \
@@ -11365,12 +12949,14 @@ S_incline(pTHX_ const char *s, const char *end)
 
 static int
 S_intuit_method(pTHX_ char *start, SV *ioname, CV *cv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_INTUIT_METHOD         \
         assert(start)
 
 static int
 S_intuit_more(pTHX_ char *s, char *e, U8 caller_context, char *caller_s, Size_t caller_length)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_INTUIT_MORE           \
@@ -11378,23 +12964,27 @@ S_intuit_more(pTHX_ char *s, char *e, U8 caller_context, char *caller_s, Size_t 
 
 static bool
 S_is_existing_identifier(pTHX_ char *s, Size_t len, char sigil, bool is_utf8)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_IS_EXISTING_IDENTIFIER \
         assert(s)
 
 static I32
 S_lop(pTHX_ enum yytokentype t, I32 f, U8 x, char *s)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_LOP                   \
         assert(s)
 
 PERL_STATIC_NO_RET void
 S_missingterm(pTHX_ char *s, STRLEN len)
+        Perl_attribute_nonnull_aTHX_
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_MISSINGTERM
 
 static SV *
 S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen, SV *sv, SV *pv, const char *type, STRLEN typelen, const char **error_msg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_5);
 # define PERL_ARGS_ASSERT_NEW_CONSTANT          \
@@ -11402,6 +12992,7 @@ S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen, 
 
 static char *
 S_parse_ident(pTHX_ const char *s, const char * const s_end, char **d, char * const e, bool is_utf8, HV **failure_details, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -11412,17 +13003,20 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end, char **d, char * co
 
 static char *
 S_parse_ident_no_copy(pTHX_ const char *s, const char * const s_end, bool is_utf8, HV **failure_details, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_PARSE_IDENT_NO_COPY   \
         assert(s); assert(s_end); assert(s < s_end)
 
 static int
-S_pending_ident(pTHX);
+S_pending_ident(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PENDING_IDENT
 
 static char *
 S_scan_const(pTHX_ char *start)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_CONST            \
@@ -11430,6 +13024,7 @@ S_scan_const(pTHX_ char *start)
 
 static char *
 S_scan_formline(pTHX_ char *s)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_FORMLINE         \
@@ -11437,6 +13032,7 @@ S_scan_formline(pTHX_ char *s)
 
 static char *
 S_scan_heredoc(pTHX_ char *s)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_HEREDOC          \
@@ -11444,6 +13040,7 @@ S_scan_heredoc(pTHX_ char *s)
 
 static char *
 S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -11452,6 +13049,7 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, U32 flags)
 
 static char *
 S_scan_inputsymbol(pTHX_ char *start)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_INPUTSYMBOL      \
@@ -11459,6 +13057,7 @@ S_scan_inputsymbol(pTHX_ char *start)
 
 static char *
 S_scan_pat(pTHX_ char *start, I32 type)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_PAT              \
@@ -11466,6 +13065,7 @@ S_scan_pat(pTHX_ char *start, I32 type)
 
 static char *
 S_scan_subst(pTHX_ char *start)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_SUBST            \
@@ -11473,6 +13073,7 @@ S_scan_subst(pTHX_ char *start)
 
 static char *
 S_scan_trans(pTHX_ char *start)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_TRANS            \
@@ -11480,21 +13081,25 @@ S_scan_trans(pTHX_ char *start)
 
 static I32
 S_sublex_done(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SUBLEX_DONE
 
 static I32
 S_sublex_push(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SUBLEX_PUSH
 
 static I32
 S_sublex_start(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SUBLEX_START
 
 static char *
 S_swallow_bom(pTHX_ U8 *s)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SWALLOW_BOM           \
@@ -11502,6 +13107,7 @@ S_swallow_bom(pTHX_ U8 *s)
 
 static char *
 S_tokenize_use(pTHX_ int is_use, char *s)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_TOKENIZE_USE          \
@@ -11509,28 +13115,33 @@ S_tokenize_use(pTHX_ int is_use, char *s)
 
 static SV *
 S_tokeq(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_TOKEQ                 \
         assert(sv)
 
 static void
-S_update_debugger_info(pTHX_ SV *orig_sv, const char * const buf, STRLEN len);
+S_update_debugger_info(pTHX_ SV *orig_sv, const char * const buf, STRLEN len)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_UPDATE_DEBUGGER_INFO
 
 static void
 S_warn_expect_operator(pTHX_ const char * const what, char *s, I32 pop_oldbufptr)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_WARN_EXPECT_OPERATOR  \
         assert(what)
 
 static void
 S_yyerror_non_ascii_message(pTHX_ const U8 * const s)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_YYERROR_NON_ASCII_MESSAGE \
         assert(s)
 
 static int
 S_yywarn(pTHX_ const char * const s, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_YYWARN                \
         assert(s)
@@ -11538,6 +13149,7 @@ S_yywarn(pTHX_ const char * const s, U32 flags)
 # if defined(DEBUGGING)
 static void
 S_printbuf(pTHX_ const char * const fmt, const char * const s)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_1,0);
@@ -11546,6 +13158,7 @@ S_printbuf(pTHX_ const char * const fmt, const char * const s)
 
 static int
 S_tokereport(pTHX_ I32 rv, const YYSTYPE *lvalp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_TOKEREPORT          \
         assert(lvalp)
@@ -11554,12 +13167,14 @@ S_tokereport(pTHX_ I32 rv, const YYSTYPE *lvalp)
 # if !defined(PERL_NO_UTF16_FILTER)
 static U8 *
 S_add_utf16_textfilter(pTHX_ U8 * const s, bool reversed)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_ADD_UTF16_TEXTFILTER \
         assert(s)
 
 static I32
 S_utf16_textfilter(pTHX_ int idx, SV *sv, int maxlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_UTF16_TEXTFILTER    \
         assert(sv)
@@ -11569,12 +13184,14 @@ S_utf16_textfilter(pTHX_ int idx, SV *sv, int maxlen)
 #if defined(PERL_IN_UNIVERSAL_C)
 static bool
 S_isa_lookup(pTHX_ HV *stash, SV *namesv, const char *name, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_ISA_LOOKUP            \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV); assert(namesv || name)
 
 static bool
 S_sv_derived_from_svpvn(pTHX_ SV *sv, SV *namesv, const char *name, const STRLEN len, U32 flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_DERIVED_FROM_SVPVN \
         assert(sv); assert(namesv || name)
@@ -11583,6 +13200,7 @@ S_sv_derived_from_svpvn(pTHX_ SV *sv, SV *namesv, const char *name, const STRLEN
 #if defined(PERL_IN_UTF8_C)
 static UV
 S_check_locale_boundary_crossing(pTHX_ const U8 * const p, const UV result, U8 * const ustrp, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
@@ -11592,6 +13210,7 @@ S_check_locale_boundary_crossing(pTHX_ const U8 * const p, const UV result, U8 *
 
 static HV *
 S_new_msg_hv(pTHX_ const char * const message, U32 categories, U32 flag)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEW_MSG_HV            \
@@ -11599,6 +13218,7 @@ S_new_msg_hv(pTHX_ const char * const message, U32 categories, U32 flag)
 
 static UV
 S_to_case_cp_list(pTHX_ const UV original, const U32 ** const remaining_list, Size_t *remaining_count, SV *invlist, const I32 * const invmap, const U32 * const * const aux_tables, const U8 * const aux_table_lengths, const char * const normal)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_4)
         Perl_attribute_nonnull_(pTHX_5)
         Perl_attribute_nonnull_(pTHX_8);
@@ -11612,6 +13232,7 @@ S_to_lower_latin1(const U8 c, U8 *p, STRLEN *lenp, const char dummy)
 
 static UV
 S_to_utf8_case_(pTHX_ const UV original, const U8 *p, U8 *ustrp, STRLEN *lenp, SV *invlist, const I32 * const invmap, const U32 * const * const aux_tables, const U8 * const aux_table_lengths, const char * const normal)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
         Perl_attribute_nonnull_(pTHX_5)
@@ -11623,6 +13244,7 @@ S_to_utf8_case_(pTHX_ const UV original, const U8 *p, U8 *ustrp, STRLEN *lenp, S
 
 static UV
 S_turkic_fc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -11632,6 +13254,7 @@ S_turkic_fc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *len
 
 static UV
 S_turkic_lc(pTHX_ const U8 * const p0, const U8 * const e, U8 *ustrp, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -11641,6 +13264,7 @@ S_turkic_lc(pTHX_ const U8 * const p0, const U8 * const e, U8 *ustrp, STRLEN *le
 
 static UV
 S_turkic_uc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
@@ -11650,6 +13274,7 @@ S_turkic_uc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *len
 
 static char *
 S_unexpected_non_continuation_text(pTHX_ const U8 * const s, STRLEN print_len, const STRLEN non_cont_byte_pos, const STRLEN expect_len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UNEXPECTED_NON_CONTINUATION_TEXT \
@@ -11658,6 +13283,7 @@ S_unexpected_non_continuation_text(pTHX_ const U8 * const s, STRLEN print_len, c
 # if 0
 static void
 S_warn_on_first_deprecated_use(pTHX_ U32 category, const char * const name, const char * const alternative, const bool use_locale, const char * const file, const unsigned line)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_5);
@@ -11692,21 +13318,25 @@ S_is_utf8_overlong(const U8 * const s, const STRLEN len)
 #endif /* defined(PERL_IN_UTF8_C) */
 #if defined(PERL_IN_UTIL_C)
 static bool
-S_ckwarn_common(pTHX_ U32 w);
+S_ckwarn_common(pTHX_ U32 w)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_CKWARN_COMMON
 
 static SV *
-S_mess_alloc(pTHX);
+S_mess_alloc(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_MESS_ALLOC
 
 static SV *
 S_with_queued_errors(pTHX_ SV *ex)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_WITH_QUEUED_ERRORS    \
         assert(ex)
 
 static void
 S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p, STRLEN xs_len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_XS_VERSION_BOOTCHECK  \
         assert(xs_p)
@@ -11723,7 +13353,8 @@ S_mem_log_common(enum mem_log_type mlt, const UV n, const UV typesize, const cha
 # endif /* defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL) */
 # if defined(PERL_USES_PL_PIDSTATUS)
 static void
-S_pidgone(pTHX_ Pid_t pid, int status);
+S_pidgone(pTHX_ Pid_t pid, int status)
+        Perl_attribute_nonnull_aTHX_;
 #   define PERL_ARGS_ASSERT_PIDGONE
 
 # endif
@@ -11772,6 +13403,7 @@ Perl_mem_log_realloc(const UV n, const UV typesize, const char *type_name, Mallo
 #if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE SSize_t
 Perl_AvFILL_(pTHX_ AV *av)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_AVFILL_               \
@@ -11785,12 +13417,14 @@ Perl_CvDEPTH(const CV * const sv)
 
 PERL_STATIC_INLINE GV *
 Perl_CvGV(pTHX_ CV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CVGV                  \
         assert(sv); assert(SvTYPE(sv) == SVt_PVCV || SvTYPE(sv) == SVt_PVFM)
 
 PERL_STATIC_INLINE Stack_off_t
-Perl_POPMARK(pTHX);
+Perl_POPMARK(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_POPMARK
 
 PERL_STATIC_INLINE struct regexp *
@@ -11813,36 +13447,42 @@ Perl_SvAMAGIC_on(SV *sv)
 
 PERL_STATIC_INLINE void
 Perl_SvGETMAGIC(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVGETMAGIC            \
         assert(sv)
 
 PERL_STATIC_INLINE IV
 Perl_SvIV(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVIV                  \
         assert(sv)
 
 PERL_STATIC_INLINE IV
 Perl_SvIV_nomg(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVIV_NOMG             \
         assert(sv)
 
 PERL_STATIC_INLINE NV
 Perl_SvNV(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVNV                  \
         assert(sv)
 
 PERL_STATIC_INLINE NV
 Perl_SvNV_nomg(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVNV_NOMG             \
         assert(sv)
 
 PERL_STATIC_FORCE_INLINE bool
 Perl_SvPVXtrue(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__always_inline__;
 # define PERL_ARGS_ASSERT_SVPVXTRUE             \
@@ -11850,6 +13490,7 @@ Perl_SvPVXtrue(pTHX_ SV *sv)
 
 PERL_STATIC_FORCE_INLINE char *
 Perl_SvPV_helper(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags, const PL_SvPVtype type, Perl_SvPV_helper_non_trivial_t non_trivial, const bool or_null, const U32 return_flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_5)
         __attribute__always_inline__;
@@ -11857,17 +13498,20 @@ Perl_SvPV_helper(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags, const 
         assert(sv); assert(non_trivial)
 
 PERL_STATIC_INLINE void
-Perl_SvREFCNT_dec(pTHX_ SV *sv);
+Perl_SvREFCNT_dec(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_SVREFCNT_DEC
 
 PERL_STATIC_INLINE void
 Perl_SvREFCNT_dec_NN(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVREFCNT_DEC_NN       \
         assert(sv)
 
 PERL_STATIC_INLINE SV *
-Perl_SvREFCNT_dec_ret_NULL(pTHX_ SV *sv);
+Perl_SvREFCNT_dec_ret_NULL(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_SVREFCNT_DEC_RET_NULL
 
 PERL_STATIC_INLINE SV *
@@ -11885,39 +13529,46 @@ Perl_SvREFCNT_inc_void(SV *sv);
 # define PERL_ARGS_ASSERT_SVREFCNT_INC_VOID
 
 PERL_STATIC_INLINE bool
-Perl_SvTRUE(pTHX_ SV *sv);
+Perl_SvTRUE(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_SVTRUE
 
 PERL_STATIC_INLINE bool
 Perl_SvTRUE_NN(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVTRUE_NN             \
         assert(sv)
 
 PERL_STATIC_INLINE bool
 Perl_SvTRUE_common(pTHX_ SV *sv, const bool sv_2bool_is_fallback)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVTRUE_COMMON         \
         assert(sv)
 
 PERL_STATIC_INLINE bool
-Perl_SvTRUE_nomg(pTHX_ SV *sv);
+Perl_SvTRUE_nomg(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_SVTRUE_NOMG
 
 PERL_STATIC_INLINE UV
 Perl_SvUV(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVUV                  \
         assert(sv)
 
 PERL_STATIC_INLINE UV
 Perl_SvUV_nomg(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVUV_NOMG             \
         assert(sv)
 
 PERL_STATIC_INLINE Stack_off_t
-Perl_TOPMARK(pTHX);
+Perl_TOPMARK(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_TOPMARK
 
 # define PERL_ARGS_ASSERT_APPEND_UTF8_FROM_NATIVE_BYTE \
@@ -11925,6 +13576,7 @@ Perl_TOPMARK(pTHX);
 
 PERL_STATIC_INLINE Size_t
 Perl_av_count(pTHX_ AV *av)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_AV_COUNT              \
@@ -11932,6 +13584,7 @@ Perl_av_count(pTHX_ AV *av)
 
 PERL_STATIC_INLINE SV **
 Perl_av_fetch_simple(pTHX_ AV *av, SSize_t key, I32 lval)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_AV_FETCH_SIMPLE       \
@@ -11939,12 +13592,14 @@ Perl_av_fetch_simple(pTHX_ AV *av, SSize_t key, I32 lval)
 
 PERL_STATIC_INLINE AV *
 Perl_av_new_alloc(pTHX_ SSize_t size, bool zeroflag)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_AV_NEW_ALLOC          \
         assert(size > 0)
 
 PERL_STATIC_INLINE void
 Perl_av_push_simple(pTHX_ AV *av, SV *val)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_AV_PUSH_SIMPLE        \
@@ -11952,18 +13607,21 @@ Perl_av_push_simple(pTHX_ AV *av, SV *val)
 
 PERL_STATIC_INLINE void
 Perl_av_remove_offset(pTHX_ AV *av)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_AV_REMOVE_OFFSET      \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_STATIC_INLINE SV **
 Perl_av_store_simple(pTHX_ AV *av, SSize_t key, SV *val)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_AV_STORE_SIMPLE       \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_STATIC_INLINE U8 *
 Perl_bytes_to_utf8(pTHX_ const U8 *s, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_BYTES_TO_UTF8         \
@@ -11971,6 +13629,7 @@ Perl_bytes_to_utf8(pTHX_ const U8 *s, STRLEN *lenp)
 
 PERL_STATIC_INLINE U8 *
 Perl_bytes_to_utf8_temp_pv(pTHX_ const U8 *s, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_BYTES_TO_UTF8_TEMP_PV \
@@ -11978,12 +13637,14 @@ Perl_bytes_to_utf8_temp_pv(pTHX_ const U8 *s, STRLEN *lenp)
 
 PERL_STATIC_INLINE void
 Perl_clear_defarray_simple(pTHX_ AV *av)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLEAR_DEFARRAY_SIMPLE \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_STATIC_INLINE I32
 Perl_foldEQ(pTHX_ const char *a, const char *b, I32 len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FOLDEQ                \
@@ -11991,6 +13652,7 @@ Perl_foldEQ(pTHX_ const char *a, const char *b, I32 len)
 
 PERL_STATIC_INLINE I32
 Perl_foldEQ_latin1(pTHX_ const char *a, const char *b, I32 len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FOLDEQ_LATIN1         \
@@ -11998,6 +13660,7 @@ Perl_foldEQ_latin1(pTHX_ const char *a, const char *b, I32 len)
 
 PERL_STATIC_INLINE I32
 Perl_foldEQ_locale(pTHX_ const char *a, const char *b, I32 len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FOLDEQ_LOCALE         \
@@ -12005,11 +13668,13 @@ Perl_foldEQ_locale(pTHX_ const char *a, const char *b, I32 len)
 
 PERL_STATIC_INLINE MGVTBL *
 Perl_get_vtbl(pTHX_ int vtbl_id)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GET_VTBL
 
 PERL_STATIC_INLINE UV
 Perl_grok_bin(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -12018,6 +13683,7 @@ Perl_grok_bin(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
 
 PERL_STATIC_INLINE UV
 Perl_grok_hex(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -12026,6 +13692,7 @@ Perl_grok_hex(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
 
 PERL_STATIC_INLINE UV
 Perl_grok_oct(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -12034,6 +13701,7 @@ Perl_grok_oct(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
 
 PERL_STATIC_INLINE void *
 Perl_hv_common_key_len(pTHX_ HV *hv, const char *key, I32 klen_i32, const int action, SV *val, const U32 hash)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_HV_COMMON_KEY_LEN     \
         assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
@@ -12078,6 +13746,7 @@ Perl_is_c9strict_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRL
 
 PERL_STATIC_INLINE bool
 Perl_is_safe_syscall(pTHX_ const char *pv, STRLEN len, const char *what, const char *op_name)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3)
         Perl_attribute_nonnull_(pTHX_4)
@@ -12150,11 +13819,13 @@ Perl_msbit_pos32(U32 word)
 
 PERL_STATIC_INLINE OP *
 Perl_newPADxVOP(pTHX_ I32 type, I32 flags, PADOFFSET padix)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEWPADXVOP
 
 PERL_STATIC_INLINE SV *
 Perl_newRV_noinc(pTHX_ SV * const tmpRef)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEWRV_NOINC           \
@@ -12162,103 +13833,123 @@ Perl_newRV_noinc(pTHX_ SV * const tmpRef)
 
 PERL_STATIC_INLINE SV *
 Perl_newSV_type(pTHX_ const svtype type)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEWSV_TYPE
 
 PERL_STATIC_FORCE_INLINE SV *
 Perl_newSV_type_mortal(pTHX_ const svtype type)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__
         __attribute__always_inline__;
 # define PERL_ARGS_ASSERT_NEWSV_TYPE_MORTAL
 
 PERL_STATIC_INLINE SV *
 Perl_newSVsv_flags(pTHX_ SV * const old, I32 flags)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEWSVSV_FLAGS
 
 PERL_STATIC_INLINE SV *
 Perl_new_sv(pTHX_ const char *file, int line, const char *func)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_NEW_SV                \
         assert(file); assert(func)
 
 PERL_STATIC_INLINE void
-Perl_pop_stackinfo(pTHX);
+Perl_pop_stackinfo(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_POP_STACKINFO
 
 PERL_STATIC_INLINE void
-Perl_push_stackinfo(pTHX_ I32 type, UV flags);
+Perl_push_stackinfo(pTHX_ I32 type, UV flags)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PUSH_STACKINFO
 
 PERL_STATIC_INLINE void
 Perl_rpp_context(pTHX_ SV **mark, U8 gimme, SSize_t extra)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_CONTEXT           \
         assert(mark)
 
 PERL_STATIC_INLINE void
-Perl_rpp_extend(pTHX_ SSize_t n);
+Perl_rpp_extend(pTHX_ SSize_t n)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_RPP_EXTEND
 
 PERL_STATIC_INLINE void
 Perl_rpp_invoke_xs(pTHX_ CV *cv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_INVOKE_XS         \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_STATIC_INLINE bool
 Perl_rpp_is_lone(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_IS_LONE           \
         assert(sv)
 
 PERL_STATIC_INLINE SV *
-Perl_rpp_pop_1_norc(pTHX);
+Perl_rpp_pop_1_norc(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_RPP_POP_1_NORC
 
 PERL_STATIC_INLINE void
-Perl_rpp_popfree_1(pTHX);
+Perl_rpp_popfree_1(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_RPP_POPFREE_1
 
 PERL_STATIC_INLINE void
-Perl_rpp_popfree_1_NN(pTHX);
+Perl_rpp_popfree_1_NN(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_RPP_POPFREE_1_NN
 
 PERL_STATIC_INLINE void
-Perl_rpp_popfree_2(pTHX);
+Perl_rpp_popfree_2(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_RPP_POPFREE_2
 
 PERL_STATIC_INLINE void
-Perl_rpp_popfree_2_NN(pTHX);
+Perl_rpp_popfree_2_NN(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_RPP_POPFREE_2_NN
 
 PERL_STATIC_INLINE void
 Perl_rpp_popfree_to(pTHX_ SV **sp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_POPFREE_TO        \
         assert(sp)
 
 PERL_STATIC_INLINE void
 Perl_rpp_popfree_to_NN(pTHX_ SV **sp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_POPFREE_TO_NN     \
         assert(sp)
 
 PERL_STATIC_INLINE void
 Perl_rpp_push_1(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_PUSH_1            \
         assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_push_1_norc(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_PUSH_1_NORC       \
         assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_push_2(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_PUSH_2            \
@@ -12266,54 +13957,63 @@ Perl_rpp_push_2(pTHX_ SV *sv1, SV *sv2)
 
 PERL_STATIC_INLINE void
 Perl_rpp_push_IMM(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_PUSH_IMM          \
         assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_1_1(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_1_1       \
         assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_1_1_NN(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_1_1_NN    \
         assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_1_IMM_NN(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_1_IMM_NN  \
         assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_2_1(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_1       \
         assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_2_1_COMMON(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_1_COMMON \
         assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_2_1_NN(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_1_NN    \
         assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_2_IMM_NN(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_IMM_NN  \
         assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_at(pTHX_ SV **sp, SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT        \
@@ -12321,6 +14021,7 @@ Perl_rpp_replace_at(pTHX_ SV **sp, SV *sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_at_NN(pTHX_ SV **sp, SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT_NN     \
@@ -12328,6 +14029,7 @@ Perl_rpp_replace_at_NN(pTHX_ SV **sp, SV *sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_at_norc(pTHX_ SV **sp, SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT_NORC   \
@@ -12335,31 +14037,37 @@ Perl_rpp_replace_at_norc(pTHX_ SV **sp, SV *sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_at_norc_NN(pTHX_ SV **sp, SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT_NORC_NN \
         assert(sp); assert(sv)
 
 PERL_STATIC_INLINE bool
-Perl_rpp_stack_is_rc(pTHX);
+Perl_rpp_stack_is_rc(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_RPP_STACK_IS_RC
 
 PERL_STATIC_INLINE bool
-Perl_rpp_try_AMAGIC_1(pTHX_ int method, int flags);
+Perl_rpp_try_AMAGIC_1(pTHX_ int method, int flags)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_RPP_TRY_AMAGIC_1
 
 PERL_STATIC_INLINE bool
-Perl_rpp_try_AMAGIC_2(pTHX_ int method, int flags);
+Perl_rpp_try_AMAGIC_2(pTHX_ int method, int flags)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_RPP_TRY_AMAGIC_2
 
 PERL_STATIC_INLINE void
 Perl_rpp_xpush_1(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_XPUSH_1           \
         assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_xpush_2(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_XPUSH_2           \
@@ -12367,24 +14075,28 @@ Perl_rpp_xpush_2(pTHX_ SV *sv1, SV *sv2)
 
 PERL_STATIC_INLINE void
 Perl_rpp_xpush_IMM(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_XPUSH_IMM         \
         assert(sv)
 
 PERL_STATIC_INLINE char *
 Perl_savepv(pTHX_ const char *pv)
+        Perl_attribute_nonnull_aTHX_
         __attribute__malloc__
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SAVEPV
 
 PERL_STATIC_INLINE char *
 Perl_savepvn(pTHX_ const char *pv, Size_t len)
+        Perl_attribute_nonnull_aTHX_
         __attribute__malloc__
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SAVEPVN
 
 PERL_STATIC_INLINE char *
 Perl_savesharedsvpv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__malloc__
         __attribute__warn_unused_result__;
@@ -12393,6 +14105,7 @@ Perl_savesharedsvpv(pTHX_ SV *sv)
 
 PERL_STATIC_INLINE char *
 Perl_savesvpv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__malloc__
         __attribute__warn_unused_result__;
@@ -12409,30 +14122,35 @@ Perl_single_1bit_pos32(U32 word)
 
 PERL_STATIC_INLINE char *
 Perl_sv_pvbyten_force_wrapper(pTHX_ SV * const sv, STRLEN * const lp, const U32 dummy)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_PVBYTEN_FORCE_WRAPPER \
         assert(sv)
 
 PERL_STATIC_INLINE char *
 Perl_sv_pvutf8n_force_wrapper(pTHX_ SV * const sv, STRLEN * const lp, const U32 dummy)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_PVUTF8N_FORCE_WRAPPER \
         assert(sv)
 
 PERL_STATIC_INLINE char  *
 Perl_sv_setpv_freshbuf(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_SETPV_FRESHBUF     \
         assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_switch_argstack(pTHX_ AV *to)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SWITCH_ARGSTACK       \
         assert(to); assert(SvTYPE(to) == SVt_PVAV)
 
 PERL_STATIC_INLINE IV
 Perl_utf8_distance(pTHX_ const U8 *a, const U8 *b)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -12474,6 +14192,7 @@ Perl_utf8_hop_overshoot(const U8 *s, SSize_t off, const U8 * const start, const 
 
 PERL_STATIC_INLINE bool
 Perl_utf8_to_bytes_new_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp, void **free_me)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -12482,6 +14201,7 @@ Perl_utf8_to_bytes_new_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp, void **free_me)
 
 PERL_STATIC_INLINE bool
 Perl_utf8_to_bytes_overwrite(pTHX_ U8 **s_ptr, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_TO_BYTES_OVERWRITE \
@@ -12489,6 +14209,7 @@ Perl_utf8_to_bytes_overwrite(pTHX_ U8 **s_ptr, STRLEN *lenp)
 
 PERL_STATIC_INLINE bool
 Perl_utf8_to_bytes_temp_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_TO_BYTES_TEMP_PV \
@@ -12511,6 +14232,7 @@ Perl_utf8_to_uv_or_die(const U8 * const s, const U8 *e, Size_t *advance_p)
 
 PERL_STATIC_INLINE UV
 Perl_utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_TO_UVCHR_BUF     \
@@ -12524,12 +14246,14 @@ Perl_utf8n_to_uvchr_msgs(const U8 * const s0, STRLEN curlen, STRLEN *retlen, con
 
 PERL_STATIC_INLINE U8 *
 Perl_uv_to_utf8(pTHX_ U8 *d, UV uv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_UV_TO_UTF8            \
         assert(d)
 
 PERL_STATIC_INLINE U8 *
 Perl_uv_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_UV_TO_UTF8_FLAGS      \
         assert(d)
@@ -12548,72 +14272,84 @@ Perl_variant_byte_number(PERL_UINTMAX_T word)
 
 PERL_STATIC_INLINE void
 Perl_cx_popblock(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPBLOCK           \
         assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_popeval(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPEVAL            \
         assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_popformat(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPFORMAT          \
         assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_popgiven(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPGIVEN           \
         assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_poploop(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPLOOP            \
         assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_popsub(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPSUB             \
         assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_popsub_args(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPSUB_ARGS        \
         assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_popsub_common(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPSUB_COMMON      \
         assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_popwhen(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPWHEN            \
         assert(cx)
 
 PERL_STATIC_INLINE PERL_CONTEXT *
 Perl_cx_pushblock(pTHX_ U8 type, U8 gimme, SV **sp, I32 saveix)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_CX_PUSHBLOCK          \
         assert(sp)
 
 PERL_STATIC_INLINE void
 Perl_cx_pusheval(pTHX_ PERL_CONTEXT *cx, OP *retop, SV *namesv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHEVAL           \
         assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_pushformat(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, GV *gv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_CX_PUSHFORMAT         \
@@ -12622,12 +14358,14 @@ Perl_cx_pushformat(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, GV *gv)
 
 PERL_STATIC_INLINE void
 Perl_cx_pushgiven(pTHX_ PERL_CONTEXT *cx, SV *orig_defsv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHGIVEN          \
         assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_pushloop_for(pTHX_ PERL_CONTEXT *cx, void *itervarp, SV *itersave)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_CX_PUSHLOOP_FOR       \
@@ -12635,12 +14373,14 @@ Perl_cx_pushloop_for(pTHX_ PERL_CONTEXT *cx, void *itervarp, SV *itersave)
 
 PERL_STATIC_INLINE void
 Perl_cx_pushloop_plain(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHLOOP_PLAIN     \
         assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_pushsub(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, bool hasargs)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_CX_PUSHSUB            \
@@ -12649,24 +14389,28 @@ Perl_cx_pushsub(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, bool hasargs)
 
 PERL_STATIC_INLINE void
 Perl_cx_pushtry(pTHX_ PERL_CONTEXT *cx, OP *retop)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHTRY            \
         assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_pushwhen(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHWHEN           \
         assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_topblock(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_TOPBLOCK           \
         assert(cx)
 
 PERL_STATIC_INLINE U8
-Perl_gimme_V(pTHX);
+Perl_gimme_V(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_GIMME_V
 
 # if !defined(HAS_STRLCAT)
@@ -12691,6 +14435,7 @@ Perl_is_utf8_non_invariant_string(const U8 * const s, STRLEN len)
 
 PERL_STATIC_INLINE STRLEN
 S_sv_or_pv_pos_u2b(pTHX_ SV *sv, const char *pv, STRLEN pos, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_OR_PV_POS_U2B    \
@@ -12743,9 +14488,11 @@ S_is_invlist(const SV * const invlist)
        defined(PERL_IN_REGCOMP_ANY)
 PERL_STATIC_INLINE SV *
 S_add_cp_to_invlist(pTHX_ SV *invlist, const UV cp)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE void
 S_invlist_extend(pTHX_ SV * const invlist, const UV len)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_STATIC_INLINE UV
 S_invlist_highest(SV * const invlist)
@@ -12753,6 +14500,7 @@ S_invlist_highest(SV * const invlist)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE void
 S_invlist_set_len(pTHX_ SV * const invlist, const UV len, const bool offset)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   endif /* defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) ||
              defined(PERL_IN_REGCOMP_ANY) */
@@ -12875,6 +14623,7 @@ Perl_single_1bit_pos64(U64 word)
 # if defined(USE_ITHREADS)
 PERL_STATIC_INLINE AV *
 Perl_cop_file_avn(pTHX_ const COP *cop)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_COP_FILE_AVN        \
         assert(cop)
@@ -12893,11 +14642,13 @@ Perl_get_context(void)
         assert(real_pp_fn)
 
 PERL_CALLCONV int
-Perl_runops_wrap(pTHX);
+Perl_runops_wrap(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_RUNOPS_WRAP
 
 PERL_CALLCONV void
 Perl_xs_wrap(pTHX_ XSUBADDR_t xsub, CV *cv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_XS_WRAP               \
@@ -12907,6 +14658,7 @@ Perl_xs_wrap(pTHX_ XSUBADDR_t xsub, CV *cv)
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV OP *
 Perl_pp_wrap(pTHX_ Perl_ppaddr_t real_pp_fn, I32 nargs, int nlists)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # endif
 #endif /* defined(PERL_RC_STACK) */
@@ -12937,6 +14689,7 @@ Perl_sighandler(int sig)
 #if defined(UNLINK_ALL_VERSIONS)
 PERL_CALLCONV I32
 Perl_unlnk(pTHX_ const char *f)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_UNLNK                 \
         assert(f)
@@ -12945,17 +14698,20 @@ Perl_unlnk(pTHX_ const char *f)
 #if defined(USE_C_BACKTRACE)
 PERL_CALLCONV bool
 Perl_dump_c_backtrace(pTHX_ PerlIO *fp, int max_depth, int skip)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DUMP_C_BACKTRACE      \
         assert(fp)
 
 PERL_CALLCONV Perl_c_backtrace *
 Perl_get_c_backtrace(pTHX_ int max_depth, int skip)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_GET_C_BACKTRACE
 
 PERL_CALLCONV SV *
-Perl_get_c_backtrace_dump(pTHX_ int max_depth, int skip);
+Perl_get_c_backtrace_dump(pTHX_ int max_depth, int skip)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_GET_C_BACKTRACE_DUMP
 
 #endif /* defined(USE_C_BACKTRACE) */
@@ -12974,26 +14730,32 @@ Perl_get_c_backtrace_dump(pTHX_ int max_depth, int skip);
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
 Perl_dtrace_probe_call(pTHX_ CV *cv, bool is_call)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV void
 Perl_dtrace_probe_load(pTHX_ const char *name, bool is_loading)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV void
 Perl_dtrace_probe_op(pTHX_ const OP *op)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV void
-Perl_dtrace_probe_phase(pTHX_ enum perl_phase phase);
+Perl_dtrace_probe_phase(pTHX_ enum perl_phase phase)
+        Perl_attribute_nonnull_aTHX_;
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 #endif /* defined(USE_DTRACE) */
 #if defined(USE_ITHREADS)
 PERL_CALLCONV PADOFFSET
 Perl_alloccopstash(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_ALLOCCOPSTASH         \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void *
 Perl_any_dup(pTHX_ void *v, const PerlInterpreter *proto_perl)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ANY_DUP               \
@@ -13015,6 +14777,7 @@ Perl_clone_params_new(PerlInterpreter * const from, PerlInterpreter * const to)
 
 PERL_CALLCONV PERL_CONTEXT *
 Perl_cx_dup(pTHX_ PERL_CONTEXT *cx, I32 ix, I32 max, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_CX_DUP                \
@@ -13022,6 +14785,7 @@ Perl_cx_dup(pTHX_ PERL_CONTEXT *cx, I32 ix, I32 max, CLONE_PARAMS *param)
 
 PERL_CALLCONV DIR *
 Perl_dirp_dup(pTHX_ DIR * const dp, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DIRP_DUP              \
@@ -13029,12 +14793,14 @@ Perl_dirp_dup(pTHX_ DIR * const dp, CLONE_PARAMS * const param)
 
 PERL_CALLCONV PerlIO *
 Perl_fp_dup(pTHX_ PerlIO * const fp, const char type, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_FP_DUP                \
         assert(param)
 
 PERL_CALLCONV GP *
 Perl_gp_dup(pTHX_ GP * const gp, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GP_DUP                \
@@ -13042,6 +14808,7 @@ Perl_gp_dup(pTHX_ GP * const gp, CLONE_PARAMS * const param)
 
 PERL_CALLCONV HE *
 Perl_he_dup(pTHX_ const HE *e, bool shared, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_HE_DUP                \
@@ -13049,6 +14816,7 @@ Perl_he_dup(pTHX_ const HE *e, bool shared, CLONE_PARAMS *param)
 
 PERL_CALLCONV HEK *
 Perl_hek_dup(pTHX_ HEK *e, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_HEK_DUP               \
@@ -13056,6 +14824,7 @@ Perl_hek_dup(pTHX_ HEK *e, CLONE_PARAMS *param)
 
 PERL_CALLCONV MAGIC *
 Perl_mg_dup(pTHX_ MAGIC *mg, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MG_DUP                \
@@ -13063,6 +14832,7 @@ Perl_mg_dup(pTHX_ MAGIC *mg, CLONE_PARAMS * const param)
 
 PERL_CALLCONV struct mro_meta *
 Perl_mro_meta_dup(pTHX_ struct mro_meta *smeta, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -13071,6 +14841,7 @@ Perl_mro_meta_dup(pTHX_ struct mro_meta *smeta, CLONE_PARAMS *param)
 
 PERL_CALLCONV OP *
 Perl_newPADOP(pTHX_ I32 type, I32 flags, SV *sv)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEWPADOP              \
@@ -13078,6 +14849,7 @@ Perl_newPADOP(pTHX_ I32 type, I32 flags, SV *sv)
 
 PERL_CALLCONV PADLIST *
 Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__
@@ -13087,6 +14859,7 @@ Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
 
 PERL_CALLCONV PADNAME *
 Perl_padname_dup(pTHX_ PADNAME *src, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__
@@ -13096,6 +14869,7 @@ Perl_padname_dup(pTHX_ PADNAME *src, CLONE_PARAMS *param)
 
 PERL_CALLCONV PADNAMELIST *
 Perl_padnamelist_dup(pTHX_ PADNAMELIST *srcpad, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
@@ -13104,6 +14878,7 @@ Perl_padnamelist_dup(pTHX_ PADNAMELIST *srcpad, CLONE_PARAMS *param)
 
 PERL_CALLCONV yy_parser *
 Perl_parser_dup(pTHX_ const yy_parser * const proto, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_PARSER_DUP            \
         assert(param)
@@ -13116,6 +14891,7 @@ perl_clone(PerlInterpreter *proto_perl, UV flags)
 
 PERL_CALLCONV void
 Perl_re_dup_guts(pTHX_ const REGEXP *sstr, REGEXP *dstr, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -13124,6 +14900,7 @@ Perl_re_dup_guts(pTHX_ const REGEXP *sstr, REGEXP *dstr, CLONE_PARAMS *param)
 
 PERL_CALLCONV void *
 Perl_regdupe_internal(pTHX_ REGEXP * const r, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_REGDUPE_INTERNAL      \
@@ -13131,6 +14908,7 @@ Perl_regdupe_internal(pTHX_ REGEXP * const r, CLONE_PARAMS *param)
 
 PERL_CALLCONV void
 Perl_rvpv_dup(pTHX_ SV * const dsv, const SV * const ssv, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
@@ -13139,6 +14917,7 @@ Perl_rvpv_dup(pTHX_ SV * const dsv, const SV * const ssv, CLONE_PARAMS * const p
 
 PERL_CALLCONV PERL_SI *
 Perl_si_dup(pTHX_ PERL_SI *si, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SI_DUP                \
@@ -13146,6 +14925,7 @@ Perl_si_dup(pTHX_ PERL_SI *si, CLONE_PARAMS *param)
 
 PERL_CALLCONV ANY *
 Perl_ss_dup(pTHX_ PerlInterpreter *proto_perl, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
@@ -13154,6 +14934,7 @@ Perl_ss_dup(pTHX_ PerlInterpreter *proto_perl, CLONE_PARAMS *param)
 
 PERL_CALLCONV SV *
 Perl_sv_dup(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_DUP                \
@@ -13161,6 +14942,7 @@ Perl_sv_dup(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
 
 PERL_CALLCONV SV *
 Perl_sv_dup_inc(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_DUP_INC            \
@@ -13169,6 +14951,7 @@ Perl_sv_dup_inc(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
 # if defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C)
 PERL_CALLCONV void
 Perl_op_relocate_sv(pTHX_ SV **svp, PADOFFSET *targp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -13178,12 +14961,14 @@ Perl_op_relocate_sv(pTHX_ SV **svp, PADOFFSET *targp)
 # endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
 #else /* if !defined(USE_ITHREADS) */
 /* PERL_CALLCONV void
-Perl_CopFILEGV_set(pTHX_ COP *c, GV *gv); */
+Perl_CopFILEGV_set(pTHX_ COP *c, GV *gv)
+        Perl_attribute_nonnull_aTHX_; */
 
 #endif
 #if defined(USE_LOCALE_COLLATE)
 PERL_CALLCONV int
 Perl_magic_freecollxfrm(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -13192,6 +14977,7 @@ Perl_magic_freecollxfrm(pTHX_ SV *sv, MAGIC *mg)
 
 PERL_CALLCONV int
 Perl_magic_setcollxfrm(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
@@ -13202,10 +14988,12 @@ Perl_magic_setcollxfrm(pTHX_ SV *sv, MAGIC *mg)
         assert(src)
 
 /* PERL_CALLCONV char *
-Perl_sv_collxfrm(pTHX_ SV * const sv, STRLEN * const nxp); */
+Perl_sv_collxfrm(pTHX_ SV * const sv, STRLEN * const nxp)
+        Perl_attribute_nonnull_aTHX_; */
 
 PERL_CALLCONV char *
 Perl_sv_collxfrm_flags(pTHX_ SV * const sv, STRLEN * const nxp, I32 const flags)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_SV_COLLXFRM_FLAGS     \
@@ -13214,11 +15002,13 @@ Perl_sv_collxfrm_flags(pTHX_ SV * const sv, STRLEN * const nxp, I32 const flags)
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
 Perl_strxfrm(pTHX_ SV *src)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #   if defined(PERL_IN_LOCALE_C) || defined(PERL_IN_MATHOMS_C) || \
        defined(PERL_IN_SV_C)
 PERL_CALLCONV char *
 Perl_mem_collxfrm_(pTHX_ const char *input_string, STRLEN len, STRLEN *xlen, bool utf8)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
@@ -13239,108 +15029,132 @@ Perl_warn_problematic_locale(void);
 #endif
 #if defined(USE_PERLIO)
 PERL_CALLCONV void
-Perl_PerlIO_clearerr(pTHX_ PerlIO *f);
+Perl_PerlIO_clearerr(pTHX_ PerlIO *f)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_CLEARERR
 
 PERL_CALLCONV int
-Perl_PerlIO_close(pTHX_ PerlIO *f);
+Perl_PerlIO_close(pTHX_ PerlIO *f)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_CLOSE
 
 PERL_CALLCONV int
-Perl_PerlIO_eof(pTHX_ PerlIO *f);
+Perl_PerlIO_eof(pTHX_ PerlIO *f)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_EOF
 
 PERL_CALLCONV int
-Perl_PerlIO_error(pTHX_ PerlIO *f);
+Perl_PerlIO_error(pTHX_ PerlIO *f)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_ERROR
 
 PERL_CALLCONV int
-Perl_PerlIO_fileno(pTHX_ PerlIO *f);
+Perl_PerlIO_fileno(pTHX_ PerlIO *f)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_FILENO
 
 PERL_CALLCONV int
-Perl_PerlIO_fill(pTHX_ PerlIO *f);
+Perl_PerlIO_fill(pTHX_ PerlIO *f)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_FILL
 
 PERL_CALLCONV int
-Perl_PerlIO_flush(pTHX_ PerlIO *f);
+Perl_PerlIO_flush(pTHX_ PerlIO *f)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_FLUSH
 
 PERL_CALLCONV STDCHAR *
-Perl_PerlIO_get_base(pTHX_ PerlIO *f);
+Perl_PerlIO_get_base(pTHX_ PerlIO *f)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_GET_BASE
 
 PERL_CALLCONV SSize_t
 Perl_PerlIO_get_bufsiz(pTHX_ PerlIO *f)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_PERLIO_GET_BUFSIZ
 
 PERL_CALLCONV SSize_t
 Perl_PerlIO_get_cnt(pTHX_ PerlIO *f)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_PERLIO_GET_CNT
 
 PERL_CALLCONV STDCHAR *
-Perl_PerlIO_get_ptr(pTHX_ PerlIO *f);
+Perl_PerlIO_get_ptr(pTHX_ PerlIO *f)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_GET_PTR
 
 PERL_CALLCONV SSize_t
 Perl_PerlIO_read(pTHX_ PerlIO *f, void *vbuf, Size_t count)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_PERLIO_READ           \
         assert(vbuf)
 
 PERL_CALLCONV void
-Perl_PerlIO_restore_errno(pTHX_ PerlIO *f);
+Perl_PerlIO_restore_errno(pTHX_ PerlIO *f)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_RESTORE_ERRNO
 
 PERL_CALLCONV void
-Perl_PerlIO_save_errno(pTHX_ PerlIO *f);
+Perl_PerlIO_save_errno(pTHX_ PerlIO *f)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_SAVE_ERRNO
 
 PERL_CALLCONV int
-Perl_PerlIO_seek(pTHX_ PerlIO *f, Off_t offset, int whence);
+Perl_PerlIO_seek(pTHX_ PerlIO *f, Off_t offset, int whence)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_SEEK
 
 PERL_CALLCONV void
-Perl_PerlIO_set_cnt(pTHX_ PerlIO *f, SSize_t cnt);
+Perl_PerlIO_set_cnt(pTHX_ PerlIO *f, SSize_t cnt)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_SET_CNT
 
 PERL_CALLCONV void
-Perl_PerlIO_set_ptrcnt(pTHX_ PerlIO *f, STDCHAR *ptr, SSize_t cnt);
+Perl_PerlIO_set_ptrcnt(pTHX_ PerlIO *f, STDCHAR *ptr, SSize_t cnt)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_SET_PTRCNT
 
 PERL_CALLCONV void
-Perl_PerlIO_setlinebuf(pTHX_ PerlIO *f);
+Perl_PerlIO_setlinebuf(pTHX_ PerlIO *f)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_SETLINEBUF
 
 PERL_CALLCONV PerlIO *
 Perl_PerlIO_stderr(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_PERLIO_STDERR
 
 PERL_CALLCONV PerlIO *
 Perl_PerlIO_stdin(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_PERLIO_STDIN
 
 PERL_CALLCONV PerlIO *
 Perl_PerlIO_stdout(pTHX)
+        Perl_attribute_nonnull_aTHX_
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_PERLIO_STDOUT
 
 PERL_CALLCONV Off_t
-Perl_PerlIO_tell(pTHX_ PerlIO *f);
+Perl_PerlIO_tell(pTHX_ PerlIO *f)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_PERLIO_TELL
 
 PERL_CALLCONV SSize_t
 Perl_PerlIO_unread(pTHX_ PerlIO *f, const void *vbuf, Size_t count)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_PERLIO_UNREAD         \
         assert(vbuf)
 
 PERL_CALLCONV SSize_t
 Perl_PerlIO_write(pTHX_ PerlIO *f, const void *vbuf, Size_t count)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_PERLIO_WRITE          \
         assert(vbuf)
@@ -13348,7 +15162,8 @@ Perl_PerlIO_write(pTHX_ PerlIO *f, const void *vbuf, Size_t count)
 #endif /* defined(USE_PERLIO) */
 #if defined(USE_PERL_SWITCH_LOCALE_CONTEXT)
 PERL_CALLCONV void
-Perl_switch_locale_context(pTHX);
+Perl_switch_locale_context(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_SWITCH_LOCALE_CONTEXT
 
 #endif
@@ -13370,17 +15185,20 @@ Perl_quadmath_format_valid(const char *format)
 #endif /* defined(USE_QUADMATH) */
 #if defined(USE_THREADS)
 PERL_CALLCONV void
-Perl_thread_locale_init(pTHX);
+Perl_thread_locale_init(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_THREAD_LOCALE_INIT
 
 PERL_CALLCONV void
-Perl_thread_locale_term(pTHX);
+Perl_thread_locale_term(pTHX)
+        Perl_attribute_nonnull_aTHX_;
 # define PERL_ARGS_ASSERT_THREAD_LOCALE_TERM
 
-#endif
+#endif /* defined(USE_THREADS) */
 #if defined(VMS) || defined(WIN32)
 PERL_CALLCONV int
 Perl_do_aspawn(pTHX_ SV *really, SV **mark, SV **sp)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_2)
         Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_DO_ASPAWN             \
@@ -13388,12 +15206,14 @@ Perl_do_aspawn(pTHX_ SV *really, SV **mark, SV **sp)
 
 PERL_CALLCONV int
 Perl_do_spawn(pTHX_ char *cmd)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DO_SPAWN              \
         assert(cmd)
 
 PERL_CALLCONV int
 Perl_do_spawn_nowait(pTHX_ char *cmd)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DO_SPAWN_NOWAIT       \
         assert(cmd)
@@ -13407,6 +15227,7 @@ Perl_get_context(void)
 
 PERL_CALLCONV bool
 Perl_get_win32_message_utf8ness(pTHX_ const char *string)
+        Perl_attribute_nonnull_aTHX_
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_GET_WIN32_MESSAGE_UTF8NESS
 
@@ -13420,6 +15241,7 @@ win32_croak_not_implemented(const char *fname)
 #else /* if !defined(WIN32) */
 PERL_CALLCONV bool
 Perl_do_exec3(pTHX_ const char *incmd, int fd, int do_report)
+        Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_EXEC3              \

--- a/proto.h
+++ b/proto.h
@@ -19,10 +19,17 @@
  * Edit those files and run 'make regen_headers' to effect changes.
  */
 
+#ifdef DEBUGGING    /* See GH #23641 */
+#  define Perl_attribute_nonnull_(which)
+#else
+#  define Perl_attribute_nonnull_(which)  __attribute__nonnull__(which)
+#endif
+
 START_EXTERN_C
 
 PERL_CALLCONV int
-Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing);
+Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_AMUPDATE            \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
@@ -43,6 +50,7 @@ Perl_PerlLIO_dup_cloexec(pTHX_ int oldfd)
 
 PERL_CALLCONV int
 Perl_PerlLIO_open3_cloexec(pTHX_ const char *file, int flag, int perm)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PERLLIO_OPEN3_CLOEXEC  \
@@ -50,6 +58,7 @@ Perl_PerlLIO_open3_cloexec(pTHX_ const char *file, int flag, int perm)
 
 PERL_CALLCONV int
 Perl_PerlLIO_open_cloexec(pTHX_ const char *file, int flag)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PERLLIO_OPEN_CLOEXEC   \
@@ -60,7 +69,8 @@ Perl_langinfo(const nl_item item);
 #define PERL_ARGS_ASSERT_PERL_LANGINFO
 
 PERL_CALLCONV const char *
-Perl_langinfo8(const nl_item item, utf8ness_t *utf8ness);
+Perl_langinfo8(const nl_item item, utf8ness_t *utf8ness)
+        Perl_attribute_nonnull_(2);
 #define PERL_ARGS_ASSERT_PERL_LANGINFO8         \
         assert(utf8ness)
 
@@ -78,7 +88,8 @@ Perl_Slab_Alloc(pTHX_ size_t sz)
 #define PERL_ARGS_ASSERT_SLAB_ALLOC
 
 PERL_CALLCONV void
-Perl_Slab_Free(pTHX_ void *op);
+Perl_Slab_Free(pTHX_ void *op)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SLAB_FREE              \
         assert(op)
 
@@ -87,6 +98,7 @@ Perl_SvREFCNT_dec_set_NULL(pTHX_ SV *sv); */
 
 PERL_CALLCONV_NO_RET void
 Perl_abort_execution(pTHX_ SV *msg_sv, const char * const name)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__noreturn__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_ABORT_EXECUTION        \
@@ -99,22 +111,27 @@ Perl_alloc_LOGOP(pTHX_ I32 type, OP *first, OP *other)
 
 PERL_CALLCONV PADOFFSET
 Perl_allocmy(pTHX_ const char * const name, const STRLEN len, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_ALLOCMY                \
         assert(name)
 
 PERL_CALLCONV bool
-Perl_amagic_applies(pTHX_ SV *sv, int method, int flags);
+Perl_amagic_applies(pTHX_ SV *sv, int method, int flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AMAGIC_APPLIES         \
         assert(sv)
 
 PERL_CALLCONV SV *
-Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int dir);
+Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int dir)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_AMAGIC_CALL            \
         assert(left); assert(right)
 
 PERL_CALLCONV SV *
-Perl_amagic_deref_call(pTHX_ SV *ref, int method);
+Perl_amagic_deref_call(pTHX_ SV *ref, int method)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AMAGIC_DEREF_CALL      \
         assert(ref)
 
@@ -124,25 +141,32 @@ Perl_amagic_is_enabled(pTHX_ int method)
 #define PERL_ARGS_ASSERT_AMAGIC_IS_ENABLED
 
 PERL_CALLCONV void
-Perl_api_version_assert(size_t interp_size, void *v_my_perl, const char *api_version);
+Perl_api_version_assert(size_t interp_size, void *v_my_perl, const char *api_version)
+        Perl_attribute_nonnull_(3);
 #define PERL_ARGS_ASSERT_API_VERSION_ASSERT     \
         assert(api_version)
 
 PERL_CALLCONV SSize_t
 Perl_apply(pTHX_ I32 type, SV **mark, SV **sp)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_APPLY                  \
         assert(mark); assert(sp)
 
 PERL_CALLCONV void
-Perl_apply_attrs_string(pTHX_ const char *stashpv, CV *cv, const char *attrstr, STRLEN len);
+Perl_apply_attrs_string(pTHX_ const char *stashpv, CV *cv, const char *attrstr, STRLEN len)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_APPLY_ATTRS_STRING     \
         assert(stashpv); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
         assert(attrstr)
 
 PERL_CALLCONV OP *
-Perl_apply_builtin_cv_attributes(pTHX_ CV *cv, OP *attrlist);
+Perl_apply_builtin_cv_attributes(pTHX_ CV *cv, OP *attrlist)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_APPLY_BUILTIN_CV_ATTRIBUTES \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
@@ -159,27 +183,34 @@ Perl_atfork_unlock(void);
 #define PERL_ARGS_ASSERT_ATFORK_UNLOCK
 
 PERL_CALLCONV SV **
-Perl_av_arylen_p(pTHX_ AV *av);
+Perl_av_arylen_p(pTHX_ AV *av)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_ARYLEN_P            \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
-Perl_av_clear(pTHX_ AV *av);
+Perl_av_clear(pTHX_ AV *av)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_CLEAR               \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
-Perl_av_create_and_push(pTHX_ AV ** const avp, SV * const val);
+Perl_av_create_and_push(pTHX_ AV ** const avp, SV * const val)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_AV_CREATE_AND_PUSH     \
         assert(avp); assert(val)
 
 PERL_CALLCONV SV **
-Perl_av_create_and_unshift_one(pTHX_ AV ** const avp, SV * const val);
+Perl_av_create_and_unshift_one(pTHX_ AV ** const avp, SV * const val)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_AV_CREATE_AND_UNSHIFT_ONE \
         assert(avp); assert(val)
 
 PERL_CALLCONV SV *
-Perl_av_delete(pTHX_ AV *av, SSize_t key, I32 flags);
+Perl_av_delete(pTHX_ AV *av, SSize_t key, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_DELETE              \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
@@ -190,17 +221,22 @@ Perl_av_dump(pTHX_ AV *av);
 
 PERL_CALLCONV bool
 Perl_av_exists(pTHX_ AV *av, SSize_t key)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_EXISTS              \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
-Perl_av_extend(pTHX_ AV *av, SSize_t key);
+Perl_av_extend(pTHX_ AV *av, SSize_t key)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_EXTEND              \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp, SV ***arrayp)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AV_EXTEND_GUTS         \
         assert(!av || SvTYPE(av) == SVt_PVAV); assert(maxp); assert(allocp); \
@@ -208,45 +244,54 @@ Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp, SV *
 
 PERL_CALLCONV SV **
 Perl_av_fetch(pTHX_ AV *av, SSize_t key, I32 lval)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_FETCH               \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
-Perl_av_fill(pTHX_ AV *av, SSize_t fill);
+Perl_av_fill(pTHX_ AV *av, SSize_t fill)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_FILL                \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV IV *
-Perl_av_iter_p(pTHX_ AV *av);
+Perl_av_iter_p(pTHX_ AV *av)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_ITER_P              \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV SSize_t
 Perl_av_len(pTHX_ AV *av)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_LEN                 \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV AV *
 Perl_av_make(pTHX_ SSize_t size, SV **strp)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_MAKE                \
         assert(strp)
 
 PERL_CALLCONV SV *
 Perl_av_nonelem(pTHX_ AV *av, SSize_t ix)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AV_NONELEM             \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV SV *
-Perl_av_pop(pTHX_ AV *av);
+Perl_av_pop(pTHX_ AV *av)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_POP                 \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
-Perl_av_push(pTHX_ AV *av, SV *val);
+Perl_av_push(pTHX_ AV *av, SV *val)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_AV_PUSH                \
         assert(av); assert(SvTYPE(av) == SVt_PVAV); assert(val)
 
@@ -255,27 +300,33 @@ Perl_av_push(pTHX_ AV *av, SV *val);
 
 PERL_CALLCONV SV *
 Perl_av_shift(pTHX_ AV *av)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_SHIFT               \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV SV **
-Perl_av_store(pTHX_ AV *av, SSize_t key, SV *val);
+Perl_av_store(pTHX_ AV *av, SSize_t key, SV *val)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_STORE               \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
-Perl_av_undef(pTHX_ AV *av);
+Perl_av_undef(pTHX_ AV *av)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_UNDEF               \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
-Perl_av_unshift(pTHX_ AV *av, SSize_t num);
+Perl_av_unshift(pTHX_ AV *av, SSize_t num)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_UNSHIFT             \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV OP *
 Perl_bind_match(pTHX_ I32 type, OP *left, OP *right)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_BIND_MATCH             \
@@ -297,7 +348,8 @@ Perl_block_start(pTHX_ int full)
 #define PERL_ARGS_ASSERT_BLOCK_START
 
 PERL_CALLCONV void
-Perl_blockhook_register(pTHX_ BHK *hk);
+Perl_blockhook_register(pTHX_ BHK *hk)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_BLOCKHOOK_REGISTER     \
         assert(hk)
 
@@ -323,6 +375,9 @@ Perl_boot_core_mro(pTHX)
 
 PERL_CALLCONV OP *
 Perl_build_infix_plugin(pTHX_ OP *lhs, OP *rhs, void *tokendata)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_BUILD_INFIX_PLUGIN     \
         assert(lhs); assert(rhs); assert(tokendata)
@@ -330,17 +385,24 @@ Perl_build_infix_plugin(pTHX_ OP *lhs, OP *rhs, void *tokendata)
 #define PERL_ARGS_ASSERT_BYTE_DUMP_STRING_
 
 PERL_CALLCONV int
-Perl_bytes_cmp_utf8(pTHX_ const U8 *b, STRLEN blen, const U8 *u, STRLEN ulen);
+Perl_bytes_cmp_utf8(pTHX_ const U8 *b, STRLEN blen, const U8 *u, STRLEN ulen)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_BYTES_CMP_UTF8         \
         assert(b); assert(u)
 
 PERL_CALLCONV U8 *
-Perl_bytes_from_utf8(pTHX_ const U8 *s, STRLEN *lenp, bool *is_utf8p);
+Perl_bytes_from_utf8(pTHX_ const U8 *s, STRLEN *lenp, bool *is_utf8p)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_BYTES_FROM_UTF8        \
         assert(s); assert(lenp); assert(is_utf8p)
 
 PERL_CALLCONV U8 *
-Perl_bytes_to_utf8_free_me(pTHX_ const U8 *s, STRLEN *lenp, void **free_me);
+Perl_bytes_to_utf8_free_me(pTHX_ const U8 *s, STRLEN *lenp, void **free_me)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_BYTES_TO_UTF8_FREE_ME  \
         assert(s); assert(lenp)
 
@@ -348,7 +410,9 @@ Perl_bytes_to_utf8_free_me(pTHX_ const U8 *s, STRLEN *lenp, void **free_me);
 Perl_c9strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p); */
 
 PERL_CALLCONV SSize_t
-Perl_call_argv(pTHX_ const char *sub_name, I32 flags, char **argv);
+Perl_call_argv(pTHX_ const char *sub_name, I32 flags, char **argv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_CALL_ARGV              \
         assert(sub_name); assert(argv)
 
@@ -357,22 +421,26 @@ Perl_call_atexit(pTHX_ ATEXIT_t fn, void *ptr);
 #define PERL_ARGS_ASSERT_CALL_ATEXIT
 
 PERL_CALLCONV void
-Perl_call_list(pTHX_ I32 oldscope, AV *paramList);
+Perl_call_list(pTHX_ I32 oldscope, AV *paramList)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_CALL_LIST              \
         assert(paramList); assert(SvTYPE(paramList) == SVt_PVAV)
 
 PERL_CALLCONV SSize_t
-Perl_call_method(pTHX_ const char *methname, I32 flags);
+Perl_call_method(pTHX_ const char *methname, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CALL_METHOD            \
         assert(methname)
 
 PERL_CALLCONV SSize_t
-Perl_call_pv(pTHX_ const char *sub_name, I32 flags);
+Perl_call_pv(pTHX_ const char *sub_name, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CALL_PV                \
         assert(sub_name)
 
 PERL_CALLCONV SSize_t
-Perl_call_sv(pTHX_ SV *sv, I32 flags);
+Perl_call_sv(pTHX_ SV *sv, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CALL_SV                \
         assert(sv)
 
@@ -388,6 +456,7 @@ Perl_calloc(MEM_SIZE elements, MEM_SIZE size)
 
 PERL_CALLCONV bool
 Perl_cando(pTHX_ Mode_t mode, bool effective, const Stat_t *statbufp)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CANDO                  \
@@ -415,39 +484,52 @@ Perl_cast_uv(NV f)
 
 PERL_CALLCONV bool
 Perl_check_utf8_print(pTHX_ const U8 *s, const STRLEN len)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CHECK_UTF8_PRINT       \
         assert(s)
 
 PERL_CALLCONV OP *
 Perl_ck_entersub_args_core(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_CORE  \
         assert(entersubop); assert(namegv); assert(protosv)
 
 PERL_CALLCONV OP *
-Perl_ck_entersub_args_list(pTHX_ OP *entersubop);
+Perl_ck_entersub_args_list(pTHX_ OP *entersubop)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_LIST  \
         assert(entersubop)
 
 PERL_CALLCONV OP *
-Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv);
+Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_PROTO \
         assert(entersubop); assert(namegv); assert(protosv)
 
 PERL_CALLCONV OP *
-Perl_ck_entersub_args_proto_or_list(pTHX_ OP *entersubop, GV *namegv, SV *protosv);
+Perl_ck_entersub_args_proto_or_list(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_PROTO_OR_LIST \
         assert(entersubop); assert(namegv); assert(protosv)
 
 PERL_CALLCONV void
 Perl_ck_warner(pTHX_ U32 err, const char *pat, ...)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_CK_WARNER              \
         assert(pat)
 
 PERL_CALLCONV void
 Perl_ck_warner_d(pTHX_ U32 err, const char *pat, ...)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_CK_WARNER_D            \
         assert(pat)
@@ -465,18 +547,21 @@ Perl_ckwarn_d(pTHX_ U32 w)
 #define PERL_ARGS_ASSERT_CKWARN_D
 
 PERL_CALLCONV void
-Perl_clear_defarray(pTHX_ AV *av, bool abandon);
+Perl_clear_defarray(pTHX_ AV *av, bool abandon)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CLEAR_DEFARRAY         \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV const COP *
 Perl_closest_cop(pTHX_ const COP *cop, const OP *o, const OP *curop, bool opnext)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CLOSEST_COP            \
         assert(cop)
 
 PERL_CALLCONV OP *
 Perl_cmpchain_extend(pTHX_ I32 type, OP *ch, OP *right)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CMPCHAIN_EXTEND        \
@@ -484,6 +569,7 @@ Perl_cmpchain_extend(pTHX_ I32 type, OP *ch, OP *right)
 
 PERL_CALLCONV OP *
 Perl_cmpchain_finish(pTHX_ OP *ch)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CMPCHAIN_FINISH        \
@@ -498,44 +584,53 @@ Perl_cmpchain_start(pTHX_ I32 type, OP *left, OP *right)
 #define PERL_ARGS_ASSERT_CNTRL_TO_MNEMONIC
 
 PERL_CALLCONV void
-Perl_cop_disable_warning(pTHX_ COP *cop, int warn_bit);
+Perl_cop_disable_warning(pTHX_ COP *cop, int warn_bit)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_DISABLE_WARNING    \
         assert(cop)
 
 PERL_CALLCONV void
-Perl_cop_enable_warning(pTHX_ COP *cop, int warn_bit);
+Perl_cop_enable_warning(pTHX_ COP *cop, int warn_bit)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_ENABLE_WARNING     \
         assert(cop)
 
 PERL_CALLCONV const char *
-Perl_cop_fetch_label(pTHX_ COP * const cop, STRLEN *len, U32 *flags);
+Perl_cop_fetch_label(pTHX_ COP * const cop, STRLEN *len, U32 *flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_FETCH_LABEL        \
         assert(cop)
 
 PERL_CALLCONV bool
-Perl_cop_has_warning(pTHX_ const COP *cop, int warn_bit);
+Perl_cop_has_warning(pTHX_ const COP *cop, int warn_bit)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_HAS_WARNING        \
         assert(cop)
 
 PERL_CALLCONV void
-Perl_cop_store_label(pTHX_ COP * const cop, const char *label, STRLEN len, U32 flags);
+Perl_cop_store_label(pTHX_ COP * const cop, const char *label, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_COP_STORE_LABEL        \
         assert(cop); assert(label)
 
 PERL_CALLCONV SV *
 Perl_core_prototype(pTHX_ SV *sv, const char *name, const int code, int * const opnum)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CORE_PROTOTYPE         \
         assert(name)
 
 PERL_CALLCONV OP *
 Perl_coresub_op(pTHX_ SV * const coreargssv, const int code, const int opnum)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CORESUB_OP             \
         assert(coreargssv)
 
 PERL_CALLCONV void
 Perl_create_eval_scope(pTHX_ OP *retop, SV **sp, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CREATE_EVAL_SCOPE      \
         assert(sp)
@@ -566,6 +661,7 @@ Perl_croak_no_mem(void)
 
 PERL_CALLCONV_NO_RET void
 Perl_croak_no_mem_ext(const char *context, STRLEN len)
+        Perl_attribute_nonnull_(1)
         __attribute__noreturn__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CROAK_NO_MEM_EXT       \
@@ -583,12 +679,15 @@ Perl_croak_popstack(void)
 
 PERL_CALLCONV_NO_RET void
 Perl_croak_sv(pTHX_ SV *baseex)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_CROAK_SV               \
         assert(baseex)
 
 PERL_CALLCONV_NO_RET void
 Perl_croak_xs_usage(const CV * const cv, const char * const params)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_CROAK_XS_USAGE         \
         assert(cv); assert(params)
@@ -605,12 +704,15 @@ Perl_csighandler3(int sig, Siginfo_t *info, void *uap);
 
 PERL_CALLCONV XOPRETANY
 Perl_custom_op_get_field(pTHX_ const OP *o, const xop_flags_enum field)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_CUSTOM_OP_GET_FIELD    \
         assert(o)
 
 PERL_CALLCONV void
-Perl_custom_op_register(pTHX_ Perl_ppaddr_t ppaddr, const XOP *xop);
+Perl_custom_op_register(pTHX_ Perl_ppaddr_t ppaddr, const XOP *xop)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_CUSTOM_OP_REGISTER     \
         assert(ppaddr); assert(xop)
 
@@ -618,13 +720,16 @@ Perl_custom_op_register(pTHX_ Perl_ppaddr_t ppaddr, const XOP *xop);
         assert(cv)
 
 PERL_CALLCONV CV *
-Perl_cv_clone(pTHX_ CV *proto);
+Perl_cv_clone(pTHX_ CV *proto)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CV_CLONE               \
         assert(proto); \
         assert(SvTYPE(proto) == SVt_PVCV || SvTYPE(proto) == SVt_PVFM)
 
 PERL_CALLCONV CV *
 Perl_cv_clone_into(pTHX_ CV *proto, CV *target)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CV_CLONE_INTO          \
         assert(proto); \
@@ -650,63 +755,83 @@ Perl_cv_forget_slab(pTHX_ CV *cv)
         assert(!cv || SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
-Perl_cv_get_call_checker(pTHX_ CV *cv, Perl_call_checker *ckfun_p, SV **ckobj_p);
+Perl_cv_get_call_checker(pTHX_ CV *cv, Perl_call_checker *ckfun_p, SV **ckobj_p)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_CV_GET_CALL_CHECKER    \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
         assert(ckfun_p); assert(ckobj_p)
 
 PERL_CALLCONV void
-Perl_cv_get_call_checker_flags(pTHX_ CV *cv, U32 gflags, Perl_call_checker *ckfun_p, SV **ckobj_p, U32 *ckflags_p);
+Perl_cv_get_call_checker_flags(pTHX_ CV *cv, U32 gflags, Perl_call_checker *ckfun_p, SV **ckobj_p, U32 *ckflags_p)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5);
 #define PERL_ARGS_ASSERT_CV_GET_CALL_CHECKER_FLAGS \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
         assert(ckfun_p); assert(ckobj_p); assert(ckflags_p)
 
 PERL_CALLCONV SV *
-Perl_cv_name(pTHX_ CV *cv, SV *sv, U32 flags);
+Perl_cv_name(pTHX_ CV *cv, SV *sv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CV_NAME                \
         assert(cv)
 
 PERL_CALLCONV void
-Perl_cv_set_call_checker(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj);
+Perl_cv_set_call_checker(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_CV_SET_CALL_CHECKER    \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
         assert(ckfun); assert(ckobj)
 
 PERL_CALLCONV void
-Perl_cv_set_call_checker_flags(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj, U32 ckflags);
+Perl_cv_set_call_checker_flags(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj, U32 ckflags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_CV_SET_CALL_CHECKER_FLAGS \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
         assert(ckfun); assert(ckobj)
 
 PERL_CALLCONV void
-Perl_cv_undef(pTHX_ CV *cv);
+Perl_cv_undef(pTHX_ CV *cv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CV_UNDEF               \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
 Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CV_UNDEF_FLAGS         \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV GV *
-Perl_cvgv_from_hek(pTHX_ CV *cv);
+Perl_cvgv_from_hek(pTHX_ CV *cv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CVGV_FROM_HEK          \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
-Perl_cvgv_set(pTHX_ CV *cv, GV *gv);
+Perl_cvgv_set(pTHX_ CV *cv, GV *gv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CVGV_SET               \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
-Perl_cvstash_set(pTHX_ CV *cv, HV *stash);
+Perl_cvstash_set(pTHX_ CV *cv, HV *stash)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CVSTASH_SET            \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
         assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
-Perl_cx_dump(pTHX_ PERL_CONTEXT *cx);
+Perl_cx_dump(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_CX_DUMP                \
         assert(cx)
 
@@ -717,6 +842,7 @@ Perl_cxinc(pTHX)
 
 PERL_CALLCONV void
 Perl_deb(pTHX_ const char *pat, ...)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_DEB                    \
         assert(pat)
@@ -727,7 +853,8 @@ Perl_deb_stack_all(pTHX)
 #define PERL_ARGS_ASSERT_DEB_STACK_ALL
 
 PERL_CALLCONV I32
-Perl_debop(pTHX_ const OP *o);
+Perl_debop(pTHX_ const OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_DEBOP                  \
         assert(o)
 
@@ -750,6 +877,7 @@ Perl_debug_hash_seed(pTHX_ bool via_debug_h)
 
 PERL_CALLCONV SV *
 Perl_defelem_target(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DEFELEM_TARGET         \
@@ -761,7 +889,12 @@ Perl_delete_eval_scope(pTHX)
 #define PERL_ARGS_ASSERT_DELETE_EVAL_SCOPE
 
 PERL_CALLCONV char *
-Perl_delimcpy(char *to, const char *to_end, const char *from, const char *from_end, const int delim, I32 *retlen);
+Perl_delimcpy(char *to, const char *to_end, const char *from, const char *from_end, const int delim, I32 *retlen)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(3)
+        Perl_attribute_nonnull_(4)
+        Perl_attribute_nonnull_(6);
 #define PERL_ARGS_ASSERT_DELIMCPY               \
         assert(to); assert(to_end); assert(from); assert(from_end); \
         assert(retlen); assert(to <= to_end); assert(from <= from_end)
@@ -782,12 +915,14 @@ Perl_die(pTHX_ const char *pat, ...)
 
 PERL_CALLCONV_NO_RET OP *
 Perl_die_sv(pTHX_ SV *baseex)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_DIE_SV                 \
         assert(baseex)
 
 PERL_CALLCONV_NO_RET void
 Perl_die_unwind(pTHX_ SV *msv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__noreturn__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DIE_UNWIND             \
@@ -795,6 +930,8 @@ Perl_die_unwind(pTHX_ SV *msv)
 
 PERL_CALLCONV bool
 Perl_do_aexec5(pTHX_ SV *really, SV **mark, SV **sp, int fd, int do_report)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_AEXEC5              \
         assert(mark); assert(sp)
@@ -805,50 +942,66 @@ Perl_do_close(pTHX_ GV *gv, bool is_explicit);
 
 PERL_CALLCONV void
 Perl_do_dump_pad(pTHX_ I32 level, PerlIO *file, PADLIST *padlist, int full)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_DUMP_PAD            \
         assert(file)
 
 PERL_CALLCONV bool
 Perl_do_eof(pTHX_ GV *gv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_EOF                 \
         assert(gv)
 
 PERL_CALLCONV void
-Perl_do_gv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv);
+Perl_do_gv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_GV_DUMP             \
         assert(file); assert(name)
 
 PERL_CALLCONV void
-Perl_do_gvgv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv);
+Perl_do_gvgv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_GVGV_DUMP           \
         assert(file); assert(name)
 
 PERL_CALLCONV void
-Perl_do_hv_dump(pTHX_ I32 level, PerlIO *file, const char *name, HV *sv);
+Perl_do_hv_dump(pTHX_ I32 level, PerlIO *file, const char *name, HV *sv)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_HV_DUMP             \
         assert(file); assert(name); assert(!sv || SvTYPE(sv) == SVt_PVHV)
 
 PERL_CALLCONV void
-Perl_do_join(pTHX_ SV *sv, SV *delim, SV **mark, SV **sp);
+Perl_do_join(pTHX_ SV *sv, SV *delim, SV **mark, SV **sp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4);
 #define PERL_ARGS_ASSERT_DO_JOIN                \
         assert(sv); assert(delim); assert(mark); assert(sp)
 
 PERL_CALLCONV void
-Perl_do_magic_dump(pTHX_ I32 level, PerlIO *file, const MAGIC *mg, I32 nest, I32 maxnest, bool dumpops, STRLEN pvlim);
+Perl_do_magic_dump(pTHX_ I32 level, PerlIO *file, const MAGIC *mg, I32 nest, I32 maxnest, bool dumpops, STRLEN pvlim)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_MAGIC_DUMP          \
         assert(file)
 
 PERL_CALLCONV I32
 Perl_do_ncmp(pTHX_ SV * const left, SV * const right)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_NCMP                \
         assert(left); assert(right)
 
 PERL_CALLCONV void
-Perl_do_op_dump(pTHX_ I32 level, PerlIO *file, const OP *o);
+Perl_do_op_dump(pTHX_ I32 level, PerlIO *file, const OP *o)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_OP_DUMP             \
         assert(file)
 
@@ -857,28 +1010,36 @@ Perl_do_open(pTHX_ GV *gv, const char *name, I32 len, int as_raw, int rawmode, i
 
 PERL_CALLCONV bool
 Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len, PerlIO *supplied_fp, SV **svp, U32 num)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_OPEN6               \
         assert(gv); assert(oname)
 
 PERL_CALLCONV bool
 Perl_do_open_raw(pTHX_ GV *gv, const char *oname, STRLEN len, int rawmode, int rawperm, Stat_t *statbufp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_OPEN_RAW            \
         assert(gv); assert(oname)
 
 PERL_CALLCONV bool
-Perl_do_openn(pTHX_ GV *gv, const char *oname, I32 len, int as_raw, int rawmode, int rawperm, PerlIO *supplied_fp, SV **svp, I32 num);
+Perl_do_openn(pTHX_ GV *gv, const char *oname, I32 len, int as_raw, int rawmode, int rawperm, PerlIO *supplied_fp, SV **svp, I32 num)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_OPENN               \
         assert(gv); assert(oname)
 
 PERL_CALLCONV void
-Perl_do_pmop_dump(pTHX_ I32 level, PerlIO *file, const PMOP *pm);
+Perl_do_pmop_dump(pTHX_ I32 level, PerlIO *file, const PMOP *pm)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_PMOP_DUMP           \
         assert(file)
 
 PERL_CALLCONV bool
 Perl_do_print(pTHX_ SV *sv, PerlIO *fp)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_PRINT               \
         assert(fp)
@@ -895,23 +1056,28 @@ Perl_do_seek(pTHX_ GV *gv, Off_t pos, int whence)
 #define PERL_ARGS_ASSERT_DO_SEEK
 
 PERL_CALLCONV void
-Perl_do_sprintf(pTHX_ SV *sv, SSize_t len, SV **sarg);
+Perl_do_sprintf(pTHX_ SV *sv, SSize_t len, SV **sarg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_SPRINTF             \
         assert(sv); assert(sarg)
 
 PERL_CALLCONV void
-Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bool dumpops, STRLEN pvlim);
+Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bool dumpops, STRLEN pvlim)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_SV_DUMP             \
         assert(file)
 
 PERL_CALLCONV Off_t
 Perl_do_sysseek(pTHX_ GV *gv, Off_t pos, int whence)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_SYSSEEK             \
         assert(gv)
 
 PERL_CALLCONV Off_t
 Perl_do_tell(pTHX_ GV *gv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_TELL                \
@@ -919,6 +1085,7 @@ Perl_do_tell(pTHX_ GV *gv)
 
 PERL_CALLCONV Size_t
 Perl_do_trans(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_TRANS               \
         assert(sv)
@@ -928,24 +1095,30 @@ Perl_do_trans(pTHX_ SV *sv)
 
 PERL_CALLCONV UV
 Perl_do_vecget(pTHX_ SV *sv, STRLEN offset, int size)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_VECGET              \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_do_vecset(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_VECSET              \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_do_vop(pTHX_ I32 optype, SV *sv, SV *left, SV *right)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_VOP                 \
         assert(sv); assert(left); assert(right)
 
 PERL_CALLCONV OP *
 Perl_dofile(pTHX_ OP *term, I32 force_builtin)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DOFILE                 \
         assert(term)
@@ -956,7 +1129,8 @@ Perl_doing_taint(int argc, char **argv, char **env)
 #define PERL_ARGS_ASSERT_DOING_TAINT
 
 PERL_CALLCONV OP *
-Perl_doref(pTHX_ OP *o, I32 type, bool set_op_ref);
+Perl_doref(pTHX_ OP *o, I32 type, bool set_op_ref)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_DOREF                  \
         assert(o)
 
@@ -971,12 +1145,14 @@ Perl_dowantarray(pTHX)
 #define PERL_ARGS_ASSERT_DOWANTARRAY
 
 PERL_CALLCONV void
-Perl_drand48_init_r(perl_drand48_t *random_state, U32 seed);
+Perl_drand48_init_r(perl_drand48_t *random_state, U32 seed)
+        Perl_attribute_nonnull_(1);
 #define PERL_ARGS_ASSERT_DRAND48_INIT_R         \
         assert(random_state)
 
 PERL_CALLCONV double
-Perl_drand48_r(perl_drand48_t *random_state);
+Perl_drand48_r(perl_drand48_t *random_state)
+        Perl_attribute_nonnull_(1);
 #define PERL_ARGS_ASSERT_DRAND48_R              \
         assert(random_state)
 
@@ -994,40 +1170,49 @@ Perl_dump_eval(pTHX);
 #define PERL_ARGS_ASSERT_DUMP_EVAL
 
 PERL_CALLCONV void
-Perl_dump_form(pTHX_ const GV *gv);
+Perl_dump_form(pTHX_ const GV *gv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_DUMP_FORM              \
         assert(gv)
 
 PERL_CALLCONV void
 Perl_dump_indent(pTHX_ I32 level, PerlIO *file, const char *pat, ...)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__format__(__printf__,pTHX_3,pTHX_4);
 #define PERL_ARGS_ASSERT_DUMP_INDENT            \
         assert(file); assert(pat)
 
 PERL_CALLCONV void
-Perl_dump_packsubs(pTHX_ const HV *stash);
+Perl_dump_packsubs(pTHX_ const HV *stash)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_DUMP_PACKSUBS          \
         assert(stash)
 
 PERL_CALLCONV void
 Perl_dump_packsubs_perl(pTHX_ const HV *stash, bool justperl)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DUMP_PACKSUBS_PERL     \
         assert(stash)
 
 PERL_CALLCONV void
-Perl_dump_sub(pTHX_ const GV *gv);
+Perl_dump_sub(pTHX_ const GV *gv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_DUMP_SUB               \
         assert(gv)
 
 PERL_CALLCONV void
 Perl_dump_sub_perl(pTHX_ const GV *gv, bool justperl)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DUMP_SUB_PERL          \
         assert(gv)
 
 PERL_CALLCONV void
-Perl_dump_vindent(pTHX_ I32 level, PerlIO *file, const char *pat, va_list *args);
+Perl_dump_vindent(pTHX_ I32 level, PerlIO *file, const char *pat, va_list *args)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_DUMP_VINDENT           \
         assert(file); assert(pat)
 
@@ -1037,12 +1222,14 @@ Perl_dump_vindent(pTHX_ I32 level, PerlIO *file, const char *pat, va_list *args)
         assert(c); assert(sv)
 
 PERL_CALLCONV SV *
-Perl_eval_pv(pTHX_ const char *p, I32 croak_on_error);
+Perl_eval_pv(pTHX_ const char *p, I32 croak_on_error)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_EVAL_PV                \
         assert(p)
 
 PERL_CALLCONV SSize_t
-Perl_eval_sv(pTHX_ SV *sv, I32 flags);
+Perl_eval_sv(pTHX_ SV *sv, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_EVAL_SV                \
         assert(sv)
 
@@ -1053,17 +1240,22 @@ Perl_extended_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_
 
 PERL_CALLCONV void
 Perl_fatal_warner(pTHX_ U32 err, const char *pat, ...)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_FATAL_WARNER           \
         assert(pat)
 
 PERL_CALLCONV void
-Perl_fbm_compile(pTHX_ SV *sv, U32 flags);
+Perl_fbm_compile(pTHX_ SV *sv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_FBM_COMPILE            \
         assert(sv)
 
 PERL_CALLCONV char *
 Perl_fbm_instr(pTHX_ unsigned char *big, unsigned char *bigend, SV *littlestr, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_FBM_INSTR              \
         assert(big); assert(bigend); assert(littlestr); assert(big <= bigend)
@@ -1073,12 +1265,14 @@ Perl_filter_add(pTHX_ filter_t funcp, SV *datasv);
 #define PERL_ARGS_ASSERT_FILTER_ADD
 
 PERL_CALLCONV void
-Perl_filter_del(pTHX_ filter_t funcp);
+Perl_filter_del(pTHX_ filter_t funcp)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_FILTER_DEL             \
         assert(funcp)
 
 PERL_CALLCONV I32
 Perl_filter_read(pTHX_ int idx, SV *buf_sv, int maxlen)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_FILTER_READ            \
         assert(buf_sv)
@@ -1105,6 +1299,7 @@ Perl_find_rundefsv(pTHX);
 
 PERL_CALLCONV char *
 Perl_find_script(pTHX_ const char *scriptname, bool dosearch, const char * const * const search_ext, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_FIND_SCRIPT            \
         assert(scriptname)
@@ -1113,12 +1308,16 @@ Perl_find_script(pTHX_ const char *scriptname, bool dosearch, const char * const
 Perl_foldEQ_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2); */
 
 PERL_CALLCONV I32
-Perl_foldEQ_utf8_flags(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2, U32 flags);
+Perl_foldEQ_utf8_flags(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_5);
 #define PERL_ARGS_ASSERT_FOLDEQ_UTF8_FLAGS      \
         assert(s1); assert(s2)
 
 PERL_CALLCONV void
-Perl_forbid_outofblock_ops(pTHX_ OP *o, const char *blockname);
+Perl_forbid_outofblock_ops(pTHX_ OP *o, const char *blockname)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_FORBID_OUTOFBLOCK_OPS  \
         assert(o); assert(blockname)
 
@@ -1128,12 +1327,15 @@ Perl_force_locale_unlock(pTHX)
 #define PERL_ARGS_ASSERT_FORCE_LOCALE_UNLOCK
 
 PERL_CALLCONV void
-Perl_force_out_malformed_utf8_message_(pTHX_ const U8 * const p, const U8 * const e, U32 flags, const bool die_here);
+Perl_force_out_malformed_utf8_message_(pTHX_ const U8 * const p, const U8 * const e, U32 flags, const bool die_here)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_FORCE_OUT_MALFORMED_UTF8_MESSAGE_ \
         assert(p); assert(e); assert(p < e)
 
 PERL_CALLCONV char *
 Perl_form(pTHX_ const char *pat, ...)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_FORM                   \
         assert(pat)
@@ -1151,22 +1353,26 @@ Perl_free_tmps(pTHX);
         assert(s); assert(e); assert(error_msg); assert(s <= e)
 
 PERL_CALLCONV AV *
-Perl_get_av(pTHX_ const char *name, I32 flags);
+Perl_get_av(pTHX_ const char *name, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_AV                 \
         assert(name)
 
 PERL_CALLCONV CV *
-Perl_get_cv(pTHX_ const char *name, I32 flags);
+Perl_get_cv(pTHX_ const char *name, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_CV                 \
         assert(name)
 
 PERL_CALLCONV CV *
-Perl_get_cvn_flags(pTHX_ const char *name, STRLEN len, I32 flags);
+Perl_get_cvn_flags(pTHX_ const char *name, STRLEN len, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_CVN_FLAGS          \
         assert(name)
 
 PERL_CALLCONV void
-Perl_get_db_sub(pTHX_ SV **svp, CV *cv);
+Perl_get_db_sub(pTHX_ SV **svp, CV *cv)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GET_DB_SUB             \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
@@ -1179,12 +1385,14 @@ Perl_get_extended_os_errno(void)
 
 PERL_CALLCONV void
 Perl_get_hash_seed(pTHX_ unsigned char * const seed_buffer)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_GET_HASH_SEED          \
         assert(seed_buffer)
 
 PERL_CALLCONV HV *
-Perl_get_hv(pTHX_ const char *name, I32 flags);
+Perl_get_hv(pTHX_ const char *name, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_HV                 \
         assert(name)
 
@@ -1234,12 +1442,14 @@ Perl_get_re_arg(pTHX_ SV *sv);
 #define PERL_ARGS_ASSERT_GET_RE_ARG
 
 PERL_CALLCONV SV *
-Perl_get_sv(pTHX_ const char *name, I32 flags);
+Perl_get_sv(pTHX_ const char *name, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_SV                 \
         assert(name)
 
 PERL_CALLCONV int
-Perl_getcwd_sv(pTHX_ SV *sv);
+Perl_getcwd_sv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GETCWD_SV              \
         assert(sv)
 
@@ -1252,32 +1462,43 @@ Perl_gp_ref(pTHX_ GP *gp);
 #define PERL_ARGS_ASSERT_GP_REF
 
 PERL_CALLCONV bool
-Perl_grok_atoUV(const char *pv, UV *valptr, const char **endptr);
+Perl_grok_atoUV(const char *pv, UV *valptr, const char **endptr)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2);
 #define PERL_ARGS_ASSERT_GROK_ATOUV             \
         assert(pv); assert(valptr)
 
 PERL_CALLCONV UV
-Perl_grok_bin_oct_hex(pTHX_ const char * const start, STRLEN *len_p, I32 *flags, NV *result, const unsigned shift, const U32 lookup_bit, const char prefix);
+Perl_grok_bin_oct_hex(pTHX_ const char * const start, STRLEN *len_p, I32 *flags, NV *result, const unsigned shift, const U32 lookup_bit, const char prefix)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_GROK_BIN_OCT_HEX       \
         assert(start); assert(len_p); assert(flags)
 
 PERL_CALLCONV int
-Perl_grok_infnan(pTHX_ const char **sp, const char *send);
+Perl_grok_infnan(pTHX_ const char **sp, const char *send)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GROK_INFNAN            \
         assert(sp); assert(*sp); assert(send); assert(*sp <= send)
 
 PERL_CALLCONV int
-Perl_grok_number(pTHX_ const char *pv, STRLEN len, UV *valuep);
+Perl_grok_number(pTHX_ const char *pv, STRLEN len, UV *valuep)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GROK_NUMBER            \
         assert(pv)
 
 PERL_CALLCONV int
-Perl_grok_number_flags(pTHX_ const char *pv, STRLEN len, UV *valuep, U32 flags);
+Perl_grok_number_flags(pTHX_ const char *pv, STRLEN len, UV *valuep, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GROK_NUMBER_FLAGS      \
         assert(pv)
 
 PERL_CALLCONV bool
 Perl_grok_numeric_radix(pTHX_ const char **sp, const char *send)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GROK_NUMERIC_RADIX     \
         assert(sp); assert(*sp); assert(send); assert(*sp <= send)
@@ -1297,29 +1518,34 @@ Perl_gv_add_by_type(pTHX_ GV *gv, svtype type);
 
 PERL_CALLCONV GV *
 Perl_gv_autoload_pv(pTHX_ HV *stash, const char *namepv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_AUTOLOAD_PV         \
         assert(namepv)
 
 PERL_CALLCONV GV *
 Perl_gv_autoload_pvn(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_AUTOLOAD_PVN        \
         assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_autoload_sv(pTHX_ HV *stash, SV *namesv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_AUTOLOAD_SV         \
         assert(namesv)
 
 PERL_CALLCONV void
-Perl_gv_check(pTHX_ HV *stash);
+Perl_gv_check(pTHX_ HV *stash)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_CHECK               \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV SV *
 Perl_gv_const_sv(pTHX_ GV *gv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_CONST_SV            \
         assert(gv)
@@ -1332,17 +1558,21 @@ Perl_gv_dump(pTHX_ GV *gv);
 Perl_gv_efullname3(pTHX_ SV *sv, const GV *gv, const char *prefix); */
 
 PERL_CALLCONV void
-Perl_gv_efullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain);
+Perl_gv_efullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_EFULLNAME4          \
         assert(sv); assert(gv)
 
 PERL_CALLCONV GV *
-Perl_gv_fetchfile(pTHX_ const char *name);
+Perl_gv_fetchfile(pTHX_ const char *name)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHFILE           \
         assert(name)
 
 PERL_CALLCONV GV *
-Perl_gv_fetchfile_flags(pTHX_ const char * const name, const STRLEN len, const U32 flags);
+Perl_gv_fetchfile_flags(pTHX_ const char * const name, const STRLEN len, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHFILE_FLAGS     \
         assert(name)
 
@@ -1353,32 +1583,38 @@ Perl_gv_fetchmeth(pTHX_ HV *stash, const char *name, STRLEN len, I32 level); */
 Perl_gv_fetchmeth_autoload(pTHX_ HV *stash, const char *name, STRLEN len, I32 level); */
 
 PERL_CALLCONV GV *
-Perl_gv_fetchmeth_pv(pTHX_ HV *stash, const char *name, I32 level, U32 flags);
+Perl_gv_fetchmeth_pv(pTHX_ HV *stash, const char *name, I32 level, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PV        \
         assert(name)
 
 PERL_CALLCONV GV *
-Perl_gv_fetchmeth_pv_autoload(pTHX_ HV *stash, const char *name, I32 level, U32 flags);
+Perl_gv_fetchmeth_pv_autoload(pTHX_ HV *stash, const char *name, I32 level, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PV_AUTOLOAD \
         assert(name)
 
 PERL_CALLCONV GV *
-Perl_gv_fetchmeth_pvn(pTHX_ HV *stash, const char *name, STRLEN len, I32 level, U32 flags);
+Perl_gv_fetchmeth_pvn(pTHX_ HV *stash, const char *name, STRLEN len, I32 level, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PVN       \
         assert(name)
 
 PERL_CALLCONV GV *
-Perl_gv_fetchmeth_pvn_autoload(pTHX_ HV *stash, const char *name, STRLEN len, I32 level, U32 flags);
+Perl_gv_fetchmeth_pvn_autoload(pTHX_ HV *stash, const char *name, STRLEN len, I32 level, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PVN_AUTOLOAD \
         assert(name)
 
 PERL_CALLCONV GV *
-Perl_gv_fetchmeth_sv(pTHX_ HV *stash, SV *namesv, I32 level, U32 flags);
+Perl_gv_fetchmeth_sv(pTHX_ HV *stash, SV *namesv, I32 level, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_SV        \
         assert(namesv)
 
 PERL_CALLCONV GV *
-Perl_gv_fetchmeth_sv_autoload(pTHX_ HV *stash, SV *namesv, I32 level, U32 flags);
+Perl_gv_fetchmeth_sv_autoload(pTHX_ HV *stash, SV *namesv, I32 level, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_SV_AUTOLOAD \
         assert(namesv)
 
@@ -1386,37 +1622,48 @@ Perl_gv_fetchmeth_sv_autoload(pTHX_ HV *stash, SV *namesv, I32 level, U32 flags)
 Perl_gv_fetchmethod(pTHX_ HV *stash, const char *name); */
 
 PERL_CALLCONV GV *
-Perl_gv_fetchmethod_autoload(pTHX_ HV *stash, const char *name, I32 autoload);
+Perl_gv_fetchmethod_autoload(pTHX_ HV *stash, const char *name, I32 autoload)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_AUTOLOAD \
         assert(stash); assert(name)
 
 PERL_CALLCONV GV *
-Perl_gv_fetchmethod_pv_flags(pTHX_ HV *stash, const char *name, U32 flags);
+Perl_gv_fetchmethod_pv_flags(pTHX_ HV *stash, const char *name, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_PV_FLAGS \
         assert(stash); assert(name)
 
 PERL_CALLCONV GV *
-Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN len, U32 flags);
+Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_PVN_FLAGS \
         assert(stash); assert(name)
 
 PERL_CALLCONV GV *
-Perl_gv_fetchmethod_sv_flags(pTHX_ HV *stash, SV *namesv, U32 flags);
+Perl_gv_fetchmethod_sv_flags(pTHX_ HV *stash, SV *namesv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_SV_FLAGS \
         assert(stash); assert(namesv)
 
 PERL_CALLCONV GV *
-Perl_gv_fetchpv(pTHX_ const char *nambeg, I32 flags, const svtype sv_type);
+Perl_gv_fetchpv(pTHX_ const char *nambeg, I32 flags, const svtype sv_type)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHPV             \
         assert(nambeg)
 
 PERL_CALLCONV GV *
-Perl_gv_fetchpvn_flags(pTHX_ const char *name, STRLEN len, I32 flags, const svtype sv_type);
+Perl_gv_fetchpvn_flags(pTHX_ const char *name, STRLEN len, I32 flags, const svtype sv_type)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHPVN_FLAGS      \
         assert(name)
 
 PERL_CALLCONV GV *
-Perl_gv_fetchsv(pTHX_ SV *name, I32 flags, const svtype sv_type);
+Perl_gv_fetchsv(pTHX_ SV *name, I32 flags, const svtype sv_type)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHSV             \
         assert(name)
 
@@ -1424,7 +1671,9 @@ Perl_gv_fetchsv(pTHX_ SV *name, I32 flags, const svtype sv_type);
 Perl_gv_fullname3(pTHX_ SV *sv, const GV *gv, const char *prefix); */
 
 PERL_CALLCONV void
-Perl_gv_fullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain);
+Perl_gv_fullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FULLNAME4           \
         assert(sv); assert(gv)
 
@@ -1438,70 +1687,88 @@ Perl_gv_handler(pTHX_ HV *stash, I32 id)
 Perl_gv_init(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, int multi); */
 
 PERL_CALLCONV void
-Perl_gv_init_pv(pTHX_ GV *gv, HV *stash, const char *name, U32 flags);
+Perl_gv_init_pv(pTHX_ GV *gv, HV *stash, const char *name, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT_PV             \
         assert(gv); assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
 
 PERL_CALLCONV void
-Perl_gv_init_pvn(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, U32 flags);
+Perl_gv_init_pvn(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT_PVN            \
         assert(gv); assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
 
 PERL_CALLCONV void
-Perl_gv_init_sv(pTHX_ GV *gv, HV *stash, SV *namesv, U32 flags);
+Perl_gv_init_sv(pTHX_ GV *gv, HV *stash, SV *namesv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT_SV             \
         assert(gv); assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(namesv)
 
 PERL_CALLCONV void
-Perl_gv_name_set(pTHX_ GV *gv, const char *name, U32 len, U32 flags);
+Perl_gv_name_set(pTHX_ GV *gv, const char *name, U32 len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_NAME_SET            \
         assert(gv); assert(name)
 
 PERL_CALLCONV GV *
-Perl_gv_override(pTHX_ const char * const name, const STRLEN len);
+Perl_gv_override(pTHX_ const char * const name, const STRLEN len)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_OVERRIDE            \
         assert(name)
 
 PERL_CALLCONV void
 Perl_gv_setref(pTHX_ SV * const dsv, SV * const ssv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_GV_SETREF              \
         assert(dsv); assert(ssv)
 
 PERL_CALLCONV HV *
-Perl_gv_stashpv(pTHX_ const char *name, I32 flags);
+Perl_gv_stashpv(pTHX_ const char *name, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_STASHPV             \
         assert(name)
 
 PERL_CALLCONV HV *
-Perl_gv_stashpvn(pTHX_ const char *name, U32 namelen, I32 flags);
+Perl_gv_stashpvn(pTHX_ const char *name, U32 namelen, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_STASHPVN            \
         assert(name)
 
 PERL_CALLCONV HV *
-Perl_gv_stashsv(pTHX_ SV *sv, I32 flags);
+Perl_gv_stashsv(pTHX_ SV *sv, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_STASHSV             \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_gv_try_downgrade(pTHX_ GV *gv);
+Perl_gv_try_downgrade(pTHX_ GV *gv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_TRY_DOWNGRADE       \
         assert(gv)
 
 PERL_CALLCONV struct xpvhv_aux *
 Perl_hv_auxalloc(pTHX_ HV *hv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_AUXALLOC            \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV AV **
 Perl_hv_backreferences_p(pTHX_ HV *hv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_BACKREFERENCES_P    \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV SV *
 Perl_hv_bucket_ratio(pTHX_ HV *hv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_BUCKET_RATIO        \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
@@ -1512,7 +1779,8 @@ Perl_hv_clear(pTHX_ HV *hv);
         assert(!hv || SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
-Perl_hv_clear_placeholders(pTHX_ HV *hv);
+Perl_hv_clear_placeholders(pTHX_ HV *hv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_CLEAR_PLACEHOLDERS  \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
@@ -1544,23 +1812,29 @@ Perl_hv_dump(pTHX_ HV *hv);
 
 PERL_CALLCONV HE **
 Perl_hv_eiter_p(pTHX_ HV *hv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_EITER_P             \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
-Perl_hv_eiter_set(pTHX_ HV *hv, HE *eiter);
+Perl_hv_eiter_set(pTHX_ HV *hv, HE *eiter)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_EITER_SET           \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_ename_add(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_ENAME_ADD           \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(name)
 
 PERL_CALLCONV void
 Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_ENAME_DELETE        \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(name)
@@ -1580,7 +1854,8 @@ Perl_hv_fetch(pTHX_ HV *hv, const char *key, I32 klen, I32 lval); */
 Perl_hv_fetch_ent(pTHX_ HV *hv, SV *keysv, I32 lval, U32 hash); */
 
 PERL_CALLCONV STRLEN
-Perl_hv_fill(pTHX_ HV * const hv);
+Perl_hv_fill(pTHX_ HV * const hv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_FILL                \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
@@ -1590,18 +1865,22 @@ Perl_hv_free_ent(pTHX_ HV *notused, HE *entry);
         assert(!notused || SvTYPE(notused) == SVt_PVHV)
 
 PERL_CALLCONV I32
-Perl_hv_iterinit(pTHX_ HV *hv);
+Perl_hv_iterinit(pTHX_ HV *hv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_ITERINIT            \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV char *
 Perl_hv_iterkey(pTHX_ HE *entry, I32 *retlen)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERKEY             \
         assert(entry); assert(retlen)
 
 PERL_CALLCONV SV *
 Perl_hv_iterkeysv(pTHX_ HE *entry)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERKEYSV           \
         assert(entry)
@@ -1612,24 +1891,31 @@ Perl_hv_iternext(pTHX_ HV *hv)
 
 PERL_CALLCONV HE *
 Perl_hv_iternext_flags(pTHX_ HV *hv, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERNEXT_FLAGS      \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV SV *
 Perl_hv_iternextsv(pTHX_ HV *hv, char **key, I32 *retlen)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERNEXTSV          \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(key); assert(retlen)
 
 PERL_CALLCONV SV *
 Perl_hv_iterval(pTHX_ HV *hv, HE *entry)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERVAL             \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(entry)
 
 PERL_CALLCONV void
-Perl_hv_ksplit(pTHX_ HV *hv, IV newmax);
+Perl_hv_ksplit(pTHX_ HV *hv, IV newmax)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_KSPLIT              \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
@@ -1637,51 +1923,60 @@ Perl_hv_ksplit(pTHX_ HV *hv, IV newmax);
 Perl_hv_magic(pTHX_ HV *hv, GV *gv, int how); */
 
 PERL_CALLCONV void
-Perl_hv_name_set(pTHX_ HV *hv, const char *name, U32 len, U32 flags);
+Perl_hv_name_set(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_NAME_SET            \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV I32
 Perl_hv_placeholders_get(pTHX_ const HV *hv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_PLACEHOLDERS_GET    \
         assert(hv)
 
 PERL_CALLCONV SSize_t *
 Perl_hv_placeholders_p(pTHX_ HV *hv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_PLACEHOLDERS_P      \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
-Perl_hv_placeholders_set(pTHX_ HV *hv, I32 ph);
+Perl_hv_placeholders_set(pTHX_ HV *hv, I32 ph)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_PLACEHOLDERS_SET    \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_pushkv(pTHX_ HV *hv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_PUSHKV              \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
-Perl_hv_rand_set(pTHX_ HV *hv, U32 new_xhv_rand);
+Perl_hv_rand_set(pTHX_ HV *hv, U32 new_xhv_rand)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_RAND_SET            \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV I32 *
 Perl_hv_riter_p(pTHX_ HV *hv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_RITER_P             \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
-Perl_hv_riter_set(pTHX_ HV *hv, I32 riter);
+Perl_hv_riter_set(pTHX_ HV *hv, I32 riter)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_RITER_SET           \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV SV *
 Perl_hv_scalar(pTHX_ HV *hv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_SCALAR              \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
@@ -1717,12 +2012,15 @@ Perl_ibcmp_locale(pTHX_ const char *a, const char *b, I32 len)
 Perl_ibcmp_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2); */
 
 PERL_CALLCONV STRLEN
-Perl_infix_plugin_standard(pTHX_ char *operator_ptr, STRLEN operator_len, struct Perl_custom_infix **def);
+Perl_infix_plugin_standard(pTHX_ char *operator_ptr, STRLEN operator_len, struct Perl_custom_infix **def)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_INFIX_PLUGIN_STANDARD  \
         assert(operator_ptr); assert(def)
 
 PERL_CALLCONV void
 Perl_init_argv_symbols(pTHX_ int argc, char **argv)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INIT_ARGV_SYMBOLS      \
         assert(argv)
@@ -1747,7 +2045,9 @@ Perl_init_i18nl10n(pTHX_ int printwarn);
 #define PERL_ARGS_ASSERT_INIT_I18NL10N
 
 PERL_CALLCONV void
-Perl_init_named_cv(pTHX_ CV *cv, OP *nameop);
+Perl_init_named_cv(pTHX_ CV *cv, OP *nameop)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_INIT_NAMED_CV          \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
         assert(nameop)
@@ -1757,7 +2057,8 @@ Perl_init_stacks(pTHX);
 #define PERL_ARGS_ASSERT_INIT_STACKS
 
 PERL_CALLCONV void
-Perl_init_tm(pTHX_ struct tm *ptm);
+Perl_init_tm(pTHX_ struct tm *ptm)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_INIT_TM                \
         assert(ptm)
 
@@ -1786,12 +2087,15 @@ Perl_invert(pTHX_ OP *cmd)
 
 PERL_CALLCONV void
 Perl_invmap_dump(pTHX_ SV *invlist, UV *map)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INVMAP_DUMP            \
         assert(invlist); assert(map)
 
 PERL_CALLCONV bool
 Perl_io_close(pTHX_ IO *io, GV *gv, bool is_explicit, bool warn_on_fail)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_IO_CLOSE               \
         assert(io)
@@ -1836,6 +2140,8 @@ Perl_is_uni_perl_idstart_(pTHX_ UV c)
 
 PERL_CALLCONV Size_t
 Perl_is_utf8_FF_helper_(const U8 * const s0, const U8 * const e, const bool require_partial)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_IS_UTF8_FF_HELPER_     \
@@ -1843,6 +2149,8 @@ Perl_is_utf8_FF_helper_(const U8 * const s0, const U8 * const e, const bool requ
 
 PERL_CALLCONV Size_t
 Perl_is_utf8_FOO_(pTHX_ const U8 classnum, const U8 *p, const U8 * const e)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UTF8_FOO_           \
         assert(p); assert(e); assert(p < e)
@@ -1852,6 +2160,8 @@ Perl_is_utf8_char_buf(const U8 *buf, const U8 *buf_end); */
 
 PERL_CALLCONV STRLEN
 Perl_is_utf8_char_helper_(const U8 * const s, const U8 *e, const U32 flags)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_IS_UTF8_CHAR_HELPER_   \
@@ -1865,12 +2175,16 @@ Perl_is_utf8_fixed_width_buf_loc_flags(const U8 * const s, STRLEN len, const U8 
 
 PERL_CALLCONV Size_t
 Perl_is_utf8_perl_idcont_(pTHX_ const U8 *p, const U8 * const e)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UTF8_PERL_IDCONT_   \
         assert(p); assert(e); assert(p < e)
 
 PERL_CALLCONV Size_t
 Perl_is_utf8_perl_idstart_(pTHX_ const U8 *p, const U8 * const e)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UTF8_PERL_IDSTART_  \
         assert(p); assert(e); assert(p < e)
@@ -1898,18 +2212,21 @@ Perl_isinfnan(NV nv)
 
 PERL_CALLCONV bool
 Perl_isinfnansv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_ISINFNANSV             \
         assert(sv)
 
 PERL_CALLCONV OP *
 Perl_jmaybe(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_JMAYBE                 \
         assert(o)
 
 PERL_CALLCONV I32
 Perl_keyword(pTHX_ const char *name, I32 len, bool all_keywords)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__pure__
         __attribute__visibility__("hidden");
@@ -1917,12 +2234,16 @@ Perl_keyword(pTHX_ const char *name, I32 len, bool all_keywords)
         assert(name)
 
 PERL_CALLCONV int
-Perl_keyword_plugin_standard(pTHX_ char *keyword_ptr, STRLEN keyword_len, OP **op_ptr);
+Perl_keyword_plugin_standard(pTHX_ char *keyword_ptr, STRLEN keyword_len, OP **op_ptr)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_KEYWORD_PLUGIN_STANDARD \
         assert(keyword_ptr); assert(op_ptr)
 
 PERL_CALLCONV void
-Perl_leave_adjust_stacks(pTHX_ SV **from_sp, SV **to_sp, U8 gimme, int filter);
+Perl_leave_adjust_stacks(pTHX_ SV **from_sp, SV **to_sp, U8 gimme, int filter)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_LEAVE_ADJUST_STACKS    \
         assert(from_sp); assert(to_sp)
 
@@ -1935,7 +2256,8 @@ Perl_lex_bufutf8(pTHX);
 #define PERL_ARGS_ASSERT_LEX_BUFUTF8
 
 PERL_CALLCONV void
-Perl_lex_discard_to(pTHX_ char *ptr);
+Perl_lex_discard_to(pTHX_ char *ptr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_DISCARD_TO         \
         assert(ptr)
 
@@ -1956,7 +2278,8 @@ Perl_lex_read_space(pTHX_ U32 flags);
 #define PERL_ARGS_ASSERT_LEX_READ_SPACE
 
 PERL_CALLCONV void
-Perl_lex_read_to(pTHX_ char *ptr);
+Perl_lex_read_to(pTHX_ char *ptr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_READ_TO            \
         assert(ptr)
 
@@ -1969,22 +2292,26 @@ Perl_lex_start(pTHX_ SV *line, PerlIO *rsfp, U32 flags);
 #define PERL_ARGS_ASSERT_LEX_START
 
 PERL_CALLCONV void
-Perl_lex_stuff_pv(pTHX_ const char *pv, U32 flags);
+Perl_lex_stuff_pv(pTHX_ const char *pv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_STUFF_PV           \
         assert(pv)
 
 PERL_CALLCONV void
-Perl_lex_stuff_pvn(pTHX_ const char *pv, STRLEN len, U32 flags);
+Perl_lex_stuff_pvn(pTHX_ const char *pv, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_STUFF_PVN          \
         assert(pv)
 
 PERL_CALLCONV void
-Perl_lex_stuff_sv(pTHX_ SV *sv, U32 flags);
+Perl_lex_stuff_sv(pTHX_ SV *sv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_STUFF_SV           \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_lex_unstuff(pTHX_ char *ptr);
+Perl_lex_unstuff(pTHX_ char *ptr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_UNSTUFF            \
         assert(ptr)
 
@@ -1997,95 +2324,122 @@ Perl_list(pTHX_ OP *o)
         assert(char_name); assert(context); assert(error_msg)
 
 PERL_CALLCONV void
-Perl_load_module(pTHX_ U32 flags, SV *name, SV *ver, ...);
+Perl_load_module(pTHX_ U32 flags, SV *name, SV *ver, ...)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_LOAD_MODULE            \
         assert(name)
 
 PERL_CALLCONV_NO_RET void
 Perl_locale_panic(const char *msg, const line_t immediate_caller_line, const char * const higher_caller_file, const line_t higher_caller_line)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(3)
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_LOCALE_PANIC           \
         assert(msg); assert(higher_caller_file)
 
 PERL_CALLCONV OP *
 Perl_localize(pTHX_ OP *o, I32 lex)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_LOCALIZE               \
         assert(o)
 
 PERL_CALLCONV UV
-Perl_long_valid_utf8_to_uv(const U8 * const s, const U8 * const e);
+Perl_long_valid_utf8_to_uv(const U8 * const s, const U8 * const e)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2);
 #define PERL_ARGS_ASSERT_LONG_VALID_UTF8_TO_UV  \
         assert(s); assert(e); assert(s < e)
 
 PERL_CALLCONV I32
 Perl_looks_like_number(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_LOOKS_LIKE_NUMBER      \
         assert(sv)
 
 PERL_CALLCONV int
 Perl_magic_clear_all_env(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEAR_ALL_ENV    \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_cleararylen_p(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARARYLEN_P    \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearenv(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARENV         \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearhint(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARHINT        \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearhints(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARHINTS       \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearhook(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARHOOK        \
         assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearhookall(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARHOOKALL     \
         assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearisa(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARISA         \
         assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearpack(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARPACK        \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearsig(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARSIG         \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_copycallchecker(pTHX_ SV *sv, MAGIC *mg, SV *nsv, const char *name, I32 namlen)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_COPYCALLCHECKER  \
         assert(sv); assert(mg); assert(nsv)
@@ -2096,306 +2450,408 @@ Perl_magic_dump(pTHX_ const MAGIC *mg);
 
 PERL_CALLCONV int
 Perl_magic_existspack(pTHX_ SV *sv, const MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_EXISTSPACK       \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_freearylen_p(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_FREEARYLEN_P     \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_freedestruct(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_FREEDESTRUCT     \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_freemglob(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_FREEMGLOB        \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_freeovrld(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_FREEOVRLD        \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_freeutf8(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_FREEUTF8         \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_get(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GET              \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getarylen(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETARYLEN        \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getdebugvar(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETDEBUGVAR      \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getdefelem(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETDEFELEM       \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getnkeys(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETNKEYS         \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getpack(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETPACK          \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getpos(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETPOS           \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getsig(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETSIG           \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getsubstr(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETSUBSTR        \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_gettaint(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETTAINT         \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getuvar(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETUVAR          \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getvec(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETVEC           \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_killbackrefs(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_KILLBACKREFS     \
         assert(sv); assert(mg)
 
 PERL_CALLCONV SV *
 Perl_magic_methcall(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, U32 argc, ...)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_METHCALL         \
         assert(sv); assert(mg); assert(meth)
 
 PERL_CALLCONV int
 Perl_magic_nextpack(pTHX_ SV *sv, MAGIC *mg, SV *key)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_NEXTPACK         \
         assert(sv); assert(mg); assert(key)
 
 PERL_CALLCONV U32
 Perl_magic_regdata_cnt(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_REGDATA_CNT      \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_regdatum_get(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_REGDATUM_GET     \
         assert(sv); assert(mg)
 
 PERL_CALLCONV SV *
 Perl_magic_scalarpack(pTHX_ HV *hv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SCALARPACK       \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SET              \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_set_all_env(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SET_ALL_ENV      \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setarylen(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETARYLEN        \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setdbline(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETDBLINE        \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setdebugvar(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETDEBUGVAR      \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setdefelem(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETDEFELEM       \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setenv(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETENV           \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_sethint(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETHINT          \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_sethook(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETHOOK          \
         assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_sethookall(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETHOOKALL       \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setisa(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETISA           \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setlvref(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETLVREF         \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setmglob(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETMGLOB         \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setnkeys(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETNKEYS         \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setnonelem(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETNONELEM       \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setpack(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETPACK          \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setpos(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETPOS           \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setregexp(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETREGEXP        \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setsig(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETSIG           \
         assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setsigall(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETSIGALL        \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setsubstr(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETSUBSTR        \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_settaint(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETTAINT         \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setutf8(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETUTF8          \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setuvar(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETUVAR          \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setvec(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETVEC           \
         assert(sv); assert(mg)
 
 PERL_CALLCONV U32
 Perl_magic_sizepack(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SIZEPACK         \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_wipepack(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_WIPEPACK         \
         assert(sv); assert(mg)
@@ -2414,12 +2870,14 @@ Perl_markstack_grow(pTHX);
 
 PERL_CALLCONV SV *
 Perl_mess(pTHX_ const char *pat, ...)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_MESS                   \
         assert(pat)
 
 PERL_CALLCONV SV *
-Perl_mess_sv(pTHX_ SV *basemsg, bool consume);
+Perl_mess_sv(pTHX_ SV *basemsg, bool consume)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MESS_SV                \
         assert(basemsg)
 
@@ -2428,12 +2886,15 @@ Perl_mfree(Malloc_t where);
 #define PERL_ARGS_ASSERT_MFREE
 
 PERL_CALLCONV int
-Perl_mg_clear(pTHX_ SV *sv);
+Perl_mg_clear(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_CLEAR               \
         assert(sv)
 
 PERL_CALLCONV int
-Perl_mg_copy(pTHX_ SV *sv, SV *nsv, const char *key, I32 klen);
+Perl_mg_copy(pTHX_ SV *sv, SV *nsv, const char *key, I32 klen)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_MG_COPY                \
         assert(sv); assert(nsv)
 
@@ -2451,48 +2912,58 @@ Perl_mg_findext(const SV *sv, int type, const MGVTBL *vtbl)
 #define PERL_ARGS_ASSERT_MG_FINDEXT
 
 PERL_CALLCONV int
-Perl_mg_free(pTHX_ SV *sv);
+Perl_mg_free(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_FREE                \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_mg_free_type(pTHX_ SV *sv, int how);
+Perl_mg_free_type(pTHX_ SV *sv, int how)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_FREE_TYPE           \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_mg_freeext(pTHX_ SV *sv, int how, const MGVTBL *vtbl);
+Perl_mg_freeext(pTHX_ SV *sv, int how, const MGVTBL *vtbl)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_FREEEXT             \
         assert(sv)
 
 PERL_CALLCONV int
-Perl_mg_get(pTHX_ SV *sv);
+Perl_mg_get(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_GET                 \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_mg_localize(pTHX_ SV *sv, SV *nsv, bool setmagic)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MG_LOCALIZE            \
         assert(sv); assert(nsv)
 
 PERL_CALLCONV void
-Perl_mg_magical(SV *sv);
+Perl_mg_magical(SV *sv)
+        Perl_attribute_nonnull_(1);
 #define PERL_ARGS_ASSERT_MG_MAGICAL             \
         assert(sv)
 
 PERL_CALLCONV int
-Perl_mg_set(pTHX_ SV *sv);
+Perl_mg_set(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_SET                 \
         assert(sv)
 
 PERL_CALLCONV I32
-Perl_mg_size(pTHX_ SV *sv);
+Perl_mg_size(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_SIZE                \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_mini_mktime(struct tm *ptm);
+Perl_mini_mktime(struct tm *ptm)
+        Perl_attribute_nonnull_(1);
 #define PERL_ARGS_ASSERT_MINI_MKTIME            \
         assert(ptm)
 
@@ -2510,12 +2981,14 @@ Perl_more_sv(pTHX);
 #define PERL_ARGS_ASSERT_MORE_SV
 
 PERL_CALLCONV const char *
-Perl_moreswitches(pTHX_ const char *s);
+Perl_moreswitches(pTHX_ const char *s)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MORESWITCHES           \
         assert(s)
 
 PERL_CALLCONV void
-Perl_mortal_destructor_sv(pTHX_ SV *coderef, SV *args);
+Perl_mortal_destructor_sv(pTHX_ SV *coderef, SV *args)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MORTAL_DESTRUCTOR_SV   \
         assert(coderef)
 
@@ -2524,54 +2997,68 @@ Perl_mortal_svfunc_x(pTHX_ SVFUNC_t f, SV *p);
 #define PERL_ARGS_ASSERT_MORTAL_SVFUNC_X
 
 PERL_CALLCONV const struct mro_alg *
-Perl_mro_get_from_name(pTHX_ SV *name);
+Perl_mro_get_from_name(pTHX_ SV *name)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_GET_FROM_NAME      \
         assert(name)
 
 PERL_CALLCONV AV *
-Perl_mro_get_linear_isa(pTHX_ HV *stash);
+Perl_mro_get_linear_isa(pTHX_ HV *stash)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_GET_LINEAR_ISA     \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV SV *
-Perl_mro_get_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_alg * const which);
+Perl_mro_get_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_alg * const which)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_MRO_GET_PRIVATE_DATA   \
         assert(smeta); assert(which)
 
 PERL_CALLCONV void
 Perl_mro_isa_changed_in(pTHX_ HV *stash)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MRO_ISA_CHANGED_IN     \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV struct mro_meta *
-Perl_mro_meta_init(pTHX_ HV *stash);
+Perl_mro_meta_init(pTHX_ HV *stash)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_META_INIT          \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
-Perl_mro_method_changed_in(pTHX_ HV *stash);
+Perl_mro_method_changed_in(pTHX_ HV *stash)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_METHOD_CHANGED_IN  \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
-Perl_mro_package_moved(pTHX_ HV * const stash, HV * const oldstash, const GV * const gv, U32 flags);
+Perl_mro_package_moved(pTHX_ HV * const stash, HV * const oldstash, const GV * const gv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_MRO_PACKAGE_MOVED      \
         assert(!stash || SvTYPE(stash) == SVt_PVHV); \
         assert(!oldstash || SvTYPE(oldstash) == SVt_PVHV); assert(gv)
 
 PERL_CALLCONV void
-Perl_mro_register(pTHX_ const struct mro_alg *mro);
+Perl_mro_register(pTHX_ const struct mro_alg *mro)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_REGISTER           \
         assert(mro)
 
 PERL_CALLCONV void
-Perl_mro_set_mro(pTHX_ struct mro_meta * const meta, SV * const name);
+Perl_mro_set_mro(pTHX_ struct mro_meta * const meta, SV * const name)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_MRO_SET_MRO            \
         assert(meta); assert(name)
 
 PERL_CALLCONV SV *
-Perl_mro_set_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_alg * const which, SV * const data);
+Perl_mro_set_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_alg * const which, SV * const data)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_MRO_SET_PRIVATE_DATA   \
         assert(smeta); assert(which); assert(data)
 
@@ -2583,22 +3070,28 @@ Perl_mro_set_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_
         assert(!cv || SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV NV
-Perl_my_atof(pTHX_ const char *s);
+Perl_my_atof(pTHX_ const char *s)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_MY_ATOF                \
         assert(s)
 
 PERL_CALLCONV char *
-Perl_my_atof2(pTHX_ const char *orig, NV *value);
+Perl_my_atof2(pTHX_ const char *orig, NV *value)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_MY_ATOF2               \
         assert(orig); assert(value)
 
 PERL_CALLCONV char *
-Perl_my_atof3(pTHX_ const char *orig, NV *value, const STRLEN len);
+Perl_my_atof3(pTHX_ const char *orig, NV *value, const STRLEN len)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_MY_ATOF3               \
         assert(orig); assert(value)
 
 PERL_CALLCONV OP *
 Perl_my_attrs(pTHX_ OP *o, OP *attrs)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MY_ATTRS               \
         assert(o)
@@ -2635,6 +3128,7 @@ Perl_my_lstat_flags(pTHX_ const U32 flags);
 
 PERL_CALLCONV int
 Perl_my_mkostemp_cloexec(char *templte, int flags)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MY_MKOSTEMP_CLOEXEC    \
@@ -2642,13 +3136,16 @@ Perl_my_mkostemp_cloexec(char *templte, int flags)
 
 PERL_CALLCONV int
 Perl_my_mkstemp_cloexec(char *templte)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MY_MKSTEMP_CLOEXEC     \
         assert(templte)
 
 PERL_CALLCONV PerlIO *
-Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args);
+Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_MY_POPEN_LIST          \
         assert(mode); assert(args)
 
@@ -2658,6 +3155,8 @@ Perl_my_setenv(pTHX_ const char *nam, const char *val);
 
 PERL_CALLCONV int
 Perl_my_snprintf(char *buffer, const Size_t len, const char *format, ...)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(3)
         __attribute__format__(__printf__,3,4);
 #define PERL_ARGS_ASSERT_MY_SNPRINTF            \
         assert(buffer); assert(format)
@@ -2672,18 +3171,21 @@ Perl_my_stat_flags(pTHX_ const U32 flags);
 
 PERL_CALLCONV const char *
 Perl_my_strerror(pTHX_ const int errnum, utf8ness_t *utf8ness)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MY_STRERROR            \
         assert(utf8ness)
 
 PERL_CALLCONV char *
 Perl_my_strftime(pTHX_ const char *fmt, int sec, int min, int hour, int mday, int mon, int year, int wday, int yday, int isdst)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__format__(__strftime__,pTHX_1,0);
 #define PERL_ARGS_ASSERT_MY_STRFTIME            \
         assert(fmt)
 
 PERL_CALLCONV NV
 Perl_my_strtod(const char * const s, char **e)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_MY_STRTOD              \
         assert(s)
@@ -2694,7 +3196,9 @@ Perl_my_unexec(pTHX)
 #define PERL_ARGS_ASSERT_MY_UNEXEC
 
 PERL_CALLCONV int
-Perl_my_vsnprintf(char *buffer, const Size_t len, const char *format, va_list ap);
+Perl_my_vsnprintf(char *buffer, const Size_t len, const char *format, va_list ap)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(3);
 #define PERL_ARGS_ASSERT_MY_VSNPRINTF           \
         assert(buffer); assert(format)
 
@@ -2718,6 +3222,7 @@ Perl_newANONSUB(pTHX_ I32 floor, OP *proto, OP *block);
 
 PERL_CALLCONV OP *
 Perl_newARGDEFELEMOP(pTHX_ I32 flags, OP *expr, I32 argindex)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWARGDEFELEMOP        \
         assert(expr)
@@ -2740,6 +3245,7 @@ Perl_newAV(pTHX)
 
 PERL_CALLCONV OP *
 Perl_newAVREF(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWAVREF               \
         assert(o)
@@ -2775,6 +3281,7 @@ Perl_newBINOP(pTHX_ I32 type, I32 flags, OP *first, OP *last)
 
 PERL_CALLCONV OP *
 Perl_newCONDOP(pTHX_ I32 flags, OP *first, OP *trueop, OP *falseop)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWCONDOP              \
         assert(first)
@@ -2796,6 +3303,7 @@ Perl_newCVREF(pTHX_ I32 flags, OP *o)
 
 PERL_CALLCONV OP *
 Perl_newDEFEROP(pTHX_ I32 flags, OP *block)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWDEFEROP             \
         assert(block)
@@ -2811,23 +3319,28 @@ Perl_newFORM(pTHX_ I32 floor, OP *o, OP *block);
 
 PERL_CALLCONV OP *
 Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWFOROP               \
         assert(expr)
 
 PERL_CALLCONV OP *
 Perl_newGIVENOP(pTHX_ OP *cond, OP *block, PADOFFSET defsv_off)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWGIVENOP             \
         assert(cond); assert(block)
 
 PERL_CALLCONV GP *
-Perl_newGP(pTHX_ GV * const gv);
+Perl_newGP(pTHX_ GV * const gv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_NEWGP                  \
         assert(gv)
 
 PERL_CALLCONV OP *
 Perl_newGVOP(pTHX_ I32 type, I32 flags, GV *gv)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWGVOP                \
         assert(gv)
@@ -2842,6 +3355,7 @@ Perl_newGVgen(pTHX_ const char *pack); */
 
 PERL_CALLCONV GV *
 Perl_newGVgen_flags(pTHX_ const char *pack, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWGVGEN_FLAGS         \
         assert(pack)
@@ -2852,6 +3366,7 @@ Perl_newHV(pTHX)
 
 PERL_CALLCONV OP *
 Perl_newHVREF(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWHVREF               \
         assert(o)
@@ -2878,36 +3393,43 @@ Perl_newLISTOPn(pTHX_ I32 type, I32 flags, ...)
 
 PERL_CALLCONV OP *
 Perl_newLOGOP(pTHX_ I32 optype, I32 flags, OP *first, OP *other)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLOGOP               \
         assert(first); assert(other)
 
 PERL_CALLCONV OP *
 Perl_newLOOPEX(pTHX_ I32 type, OP *label)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLOOPEX              \
         assert(label)
 
 PERL_CALLCONV OP *
 Perl_newLOOPOP(pTHX_ I32 flags, I32 debuggable, OP *expr, OP *block)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLOOPOP              \
         assert(expr)
 
 PERL_CALLCONV OP *
 Perl_newMETHOP(pTHX_ I32 type, I32 flags, OP *dynamic_meth)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWMETHOP              \
         assert(dynamic_meth)
 
 PERL_CALLCONV OP *
 Perl_newMETHOP_named(pTHX_ I32 type, I32 flags, SV * const_meth)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWMETHOP_NAMED        \
         assert(const_meth)
 
 PERL_CALLCONV CV *
-Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block);
+Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_NEWMYSUB               \
         assert(o)
 
@@ -2928,12 +3450,14 @@ Perl_newPADNAMELIST(size_t max)
 
 PERL_CALLCONV PADNAME *
 Perl_newPADNAMEouter(PADNAME *outer)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWPADNAMEOUTER        \
         assert(outer)
 
 PERL_CALLCONV PADNAME *
 Perl_newPADNAMEpvn(const char *s, STRLEN len)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWPADNAMEPVN          \
         assert(s)
@@ -2944,7 +3468,8 @@ Perl_newPMOP(pTHX_ I32 type, I32 flags)
 #define PERL_ARGS_ASSERT_NEWPMOP
 
 PERL_CALLCONV void
-Perl_newPROG(pTHX_ OP *o);
+Perl_newPROG(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_NEWPROG                \
         assert(o)
 
@@ -2955,12 +3480,15 @@ Perl_newPVOP(pTHX_ I32 type, I32 flags, char *pv)
 
 PERL_CALLCONV OP *
 Perl_newRANGE(pTHX_ I32 flags, OP *left, OP *right)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWRANGE               \
         assert(left); assert(right)
 
 PERL_CALLCONV SV *
 Perl_newRV(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWRV                  \
         assert(sv)
@@ -2977,6 +3505,7 @@ Perl_newSTATEOP(pTHX_ I32 flags, char *label, OP *o)
 
 PERL_CALLCONV CV *
 Perl_newSTUB(pTHX_ GV *gv, bool fake)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEWSTUB                \
         assert(gv)
@@ -2991,12 +3520,14 @@ Perl_newSV(pTHX_ const STRLEN len)
 
 PERL_CALLCONV OP *
 Perl_newSVOP(pTHX_ I32 type, I32 flags, SV *sv)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVOP                \
         assert(sv)
 
 PERL_CALLCONV OP *
 Perl_newSVREF(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVREF               \
         assert(o)
@@ -3013,6 +3544,7 @@ Perl_newSV_true(pTHX)
 
 PERL_CALLCONV SV *
 Perl_newSVavdefelem(pTHX_ AV *av, SSize_t ix, bool extendible)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEWSVAVDEFELEM         \
@@ -3055,6 +3587,7 @@ Perl_newSVpv_share(pTHX_ const char *s, U32 hash)
 
 PERL_CALLCONV SV *
 Perl_newSVpvf(pTHX_ const char * const pat, ...)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_NEWSVPVF               \
@@ -3081,7 +3614,8 @@ Perl_newSVpvz(pTHX_ const STRLEN len)
 #define PERL_ARGS_ASSERT_NEWSVPVZ
 
 PERL_CALLCONV SV *
-Perl_newSVrv(pTHX_ SV * const rv, const char * const classname);
+Perl_newSVrv(pTHX_ SV * const rv, const char * const classname)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_NEWSVRV                \
         assert(rv)
 
@@ -3091,6 +3625,7 @@ Perl_newSVsv(pTHX_ SV * const old)
 
 PERL_CALLCONV SV *
 Perl_newSVsv_flags_NN(pTHX_ SV * const old, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVSV_FLAGS_NN       \
         assert(old)
@@ -3106,6 +3641,9 @@ Perl_newSVuv(pTHX_ const UV u)
 
 PERL_CALLCONV OP *
 Perl_newTRYCATCHOP(pTHX_ I32 flags, OP *tryblock, OP *catchvar, OP *catchblock)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWTRYCATCHOP          \
         assert(tryblock); assert(catchvar); assert(catchblock)
@@ -3122,6 +3660,7 @@ Perl_newUNOP_AUX(pTHX_ I32 type, I32 flags, OP *first, UNOP_AUX_item *aux)
 
 PERL_CALLCONV OP *
 Perl_newWHENOP(pTHX_ OP *cond, OP *block)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWWHENOP              \
         assert(block)
@@ -3132,28 +3671,36 @@ Perl_newWHILEOP(pTHX_ I32 flags, I32 debuggable, LOOP *loop, OP *expr, OP *block
 #define PERL_ARGS_ASSERT_NEWWHILEOP
 
 PERL_CALLCONV CV *
-Perl_newXS(pTHX_ const char *name, XSUBADDR_t subaddr, const char *filename);
+Perl_newXS(pTHX_ const char *name, XSUBADDR_t subaddr, const char *filename)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_NEWXS                  \
         assert(subaddr); assert(filename)
 
 PERL_CALLCONV CV *
-Perl_newXS_deffile(pTHX_ const char *name, XSUBADDR_t subaddr);
+Perl_newXS_deffile(pTHX_ const char *name, XSUBADDR_t subaddr)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_NEWXS_DEFFILE          \
         assert(name); assert(subaddr)
 
 PERL_CALLCONV CV *
-Perl_newXS_flags(pTHX_ const char *name, XSUBADDR_t subaddr, const char * const filename, const char * const proto, U32 flags);
+Perl_newXS_flags(pTHX_ const char *name, XSUBADDR_t subaddr, const char * const filename, const char * const proto, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_NEWXS_FLAGS            \
         assert(subaddr); assert(filename)
 
 PERL_CALLCONV CV *
 Perl_newXS_len_flags(pTHX_ const char *name, STRLEN len, XSUBADDR_t subaddr, const char * const filename, const char * const proto, SV ** const_svp, U32 flags)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEWXS_LEN_FLAGS        \
         assert(subaddr)
 
 PERL_CALLCONV OP *
 Perl_new_block_statement(pTHX_ OP *block, OP *cont)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEW_BLOCK_STATEMENT    \
         assert(block)
@@ -3169,7 +3716,8 @@ Perl_new_stackinfo_flags(pTHX_ I32 stitems, I32 cxitems, UV flags)
 #define PERL_ARGS_ASSERT_NEW_STACKINFO_FLAGS
 
 PERL_CALLCONV SV *
-Perl_new_version(pTHX_ SV *ver);
+Perl_new_version(pTHX_ SV *ver)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_NEW_VERSION            \
         assert(ver)
 
@@ -3178,12 +3726,17 @@ Perl_new_version(pTHX_ SV *ver);
 
 PERL_CALLCONV PerlIO *
 Perl_nextargv(pTHX_ GV *gv, bool nomagicopen)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEXTARGV               \
         assert(gv)
 
 PERL_CALLCONV char *
 Perl_ninstr(const char *big, const char *bigend, const char *little, const char *lend)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(3)
+        Perl_attribute_nonnull_(4)
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_NINSTR                 \
@@ -3192,12 +3745,14 @@ Perl_ninstr(const char *big, const char *bigend, const char *little, const char 
 
 PERL_CALLCONV void
 Perl_no_bareword_filehandle(pTHX_ const char *fhname)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NO_BAREWORD_FILEHANDLE \
         assert(fhname)
 
 PERL_CALLCONV_NO_RET void
 Perl_noperl_die(const char *pat, ...)
+        Perl_attribute_nonnull_(1)
         __attribute__noreturn__
         __attribute__format__(__printf__,1,2);
 #define PERL_ARGS_ASSERT_NOPERL_DIE             \
@@ -3218,6 +3773,7 @@ Perl_notify_parser_that_encoding_changed(pTHX)
 
 PERL_CALLCONV OP *
 Perl_oopsAV(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_OOPSAV                 \
@@ -3225,6 +3781,7 @@ Perl_oopsAV(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_oopsHV(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_OOPSHV                 \
@@ -3246,7 +3803,8 @@ Perl_op_class(pTHX_ const OP *o);
         assert(o)
 
 PERL_CALLCONV OP *
-Perl_op_contextualize(pTHX_ OP *o, I32 context);
+Perl_op_contextualize(pTHX_ OP *o, I32 context)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_CONTEXTUALIZE       \
         assert(o)
 
@@ -3256,7 +3814,8 @@ Perl_op_convert_list(pTHX_ I32 optype, I32 flags, OP *o)
 #define PERL_ARGS_ASSERT_OP_CONVERT_LIST
 
 PERL_CALLCONV void
-Perl_op_dump(pTHX_ const OP *o);
+Perl_op_dump(pTHX_ const OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_DUMP                \
         assert(o)
 
@@ -3269,7 +3828,8 @@ Perl_op_free(pTHX_ OP *arg);
 #define PERL_ARGS_ASSERT_OP_FREE
 
 PERL_CALLCONV OP *
-Perl_op_linklist(pTHX_ OP *o);
+Perl_op_linklist(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_LINKLIST            \
         assert(o)
 
@@ -3281,12 +3841,14 @@ Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags);
 #define PERL_ARGS_ASSERT_OP_LVALUE_FLAGS
 
 PERL_CALLCONV void
-Perl_op_null(pTHX_ OP *o);
+Perl_op_null(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_NULL                \
         assert(o)
 
 PERL_CALLCONV OP *
-Perl_op_parent(OP *o);
+Perl_op_parent(OP *o)
+        Perl_attribute_nonnull_(1);
 #define PERL_ARGS_ASSERT_OP_PARENT              \
         assert(o)
 
@@ -3317,12 +3879,16 @@ Perl_op_unscope(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_op_wrap_finally(pTHX_ OP *block, OP *finally)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_OP_WRAP_FINALLY        \
         assert(block); assert(finally)
 
 PERL_CALLCONV void
 Perl_opdump_printf(pTHX_ struct Perl_OpDumpContext *ctx, const char *pat, ...)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_OPDUMP_PRINTF          \
         assert(ctx); assert(pat)
@@ -3334,42 +3900,53 @@ Perl_output_non_portable(pTHX_ const U8 shift)
 
 PERL_CALLCONV void
 Perl_package(pTHX_ OP *name, OP *version)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PACKAGE                \
         assert(name)
 
 PERL_CALLCONV void
-Perl_packlist(pTHX_ SV *cat, const char *pat, const char *patend, SV **beglist, SV **endlist);
+Perl_packlist(pTHX_ SV *cat, const char *pat, const char *patend, SV **beglist, SV **endlist)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5);
 #define PERL_ARGS_ASSERT_PACKLIST               \
         assert(cat); assert(pat); assert(patend); assert(beglist); \
         assert(endlist); assert(pat <= patend); assert(*patend == '\0')
 
 PERL_CALLCONV PADOFFSET
-Perl_pad_add_anon(pTHX_ CV *func, I32 optype);
+Perl_pad_add_anon(pTHX_ CV *func, I32 optype)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_ANON           \
         assert(func); \
         assert(SvTYPE(func) == SVt_PVCV || SvTYPE(func) == SVt_PVFM)
 
 PERL_CALLCONV PADOFFSET
-Perl_pad_add_name_pv(pTHX_ const char *name, const U32 flags, HV *typestash, HV *ourstash);
+Perl_pad_add_name_pv(pTHX_ const char *name, const U32 flags, HV *typestash, HV *ourstash)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_NAME_PV        \
         assert(name); assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
         assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
 PERL_CALLCONV PADOFFSET
-Perl_pad_add_name_pvn(pTHX_ const char *namepv, STRLEN namelen, U32 flags, HV *typestash, HV *ourstash);
+Perl_pad_add_name_pvn(pTHX_ const char *namepv, STRLEN namelen, U32 flags, HV *typestash, HV *ourstash)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_NAME_PVN       \
         assert(namepv); assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
         assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
 PERL_CALLCONV PADOFFSET
-Perl_pad_add_name_sv(pTHX_ SV *name, U32 flags, HV *typestash, HV *ourstash);
+Perl_pad_add_name_sv(pTHX_ SV *name, U32 flags, HV *typestash, HV *ourstash)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_NAME_SV        \
         assert(name); assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
         assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_pad_add_weakref(pTHX_ CV *func)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_ADD_WEAKREF        \
         assert(func); \
@@ -3385,22 +3962,28 @@ Perl_pad_block_start(pTHX_ int full)
 #define PERL_ARGS_ASSERT_PAD_BLOCK_START
 
 PERL_CALLCONV PADOFFSET
-Perl_pad_findmy_pv(pTHX_ const char *name, U32 flags);
+Perl_pad_findmy_pv(pTHX_ const char *name, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_FINDMY_PV          \
         assert(name)
 
 PERL_CALLCONV PADOFFSET
-Perl_pad_findmy_pvn(pTHX_ const char *namepv, STRLEN namelen, U32 flags);
+Perl_pad_findmy_pvn(pTHX_ const char *namepv, STRLEN namelen, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_FINDMY_PVN         \
         assert(namepv)
 
 PERL_CALLCONV PADOFFSET
-Perl_pad_findmy_sv(pTHX_ SV *name, U32 flags);
+Perl_pad_findmy_sv(pTHX_ SV *name, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_FINDMY_SV          \
         assert(name)
 
 PERL_CALLCONV void
 Perl_pad_fixup_inner_anons(pTHX_ PADLIST *padlist, CV *old_cv, CV *new_cv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_FIXUP_INNER_ANONS  \
         assert(padlist); assert(old_cv); \
@@ -3424,7 +4007,8 @@ Perl_pad_new(pTHX_ int flags)
 #define PERL_ARGS_ASSERT_PAD_NEW
 
 PERL_CALLCONV void
-Perl_pad_push(pTHX_ PADLIST *padlist, int depth);
+Perl_pad_push(pTHX_ PADLIST *padlist, int depth)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_PUSH               \
         assert(padlist)
 
@@ -3439,28 +4023,33 @@ Perl_pad_tidy(pTHX_ padtidy_type type);
 
 PERL_CALLCONV PAD **
 Perl_padlist_store(pTHX_ PADLIST *padlist, I32 key, PAD *val)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PADLIST_STORE          \
         assert(padlist)
 
 PERL_CALLCONV void
-Perl_padname_free(pTHX_ PADNAME *pn);
+Perl_padname_free(pTHX_ PADNAME *pn)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PADNAME_FREE           \
         assert(pn)
 
 PERL_CALLCONV PADNAME *
 Perl_padnamelist_fetch(PADNAMELIST *pnl, SSize_t key)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_PADNAMELIST_FETCH      \
         assert(pnl)
 
 PERL_CALLCONV void
-Perl_padnamelist_free(pTHX_ PADNAMELIST *pnl);
+Perl_padnamelist_free(pTHX_ PADNAMELIST *pnl)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PADNAMELIST_FREE       \
         assert(pnl)
 
 PERL_CALLCONV PADNAME **
-Perl_padnamelist_store(pTHX_ PADNAMELIST *pnl, SSize_t key, PADNAME *val);
+Perl_padnamelist_store(pTHX_ PADNAMELIST *pnl, SSize_t key, PADNAME *val)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PADNAMELIST_STORE      \
         assert(pnl)
 
@@ -3509,12 +4098,14 @@ Perl_parse_termexpr(pTHX_ U32 flags);
 
 PERL_CALLCONV U32
 Perl_parse_unicode_opts(pTHX_ const char **popt)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PARSE_UNICODE_OPTS     \
         assert(popt)
 
 PERL_CALLCONV void
 Perl_parser_free(pTHX_ const yy_parser *parser)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PARSER_FREE            \
         assert(parser)
@@ -3529,27 +4120,32 @@ perl_alloc(void);
 #define PERL_ARGS_ASSERT_PERL_ALLOC
 
 PERL_CALLCONV void
-perl_construct(PerlInterpreter *my_perl);
+perl_construct(PerlInterpreter *my_perl)
+        Perl_attribute_nonnull_(1);
 #define PERL_ARGS_ASSERT_PERL_CONSTRUCT         \
         assert(my_perl)
 
 PERL_CALLCONV int
-perl_destruct(PerlInterpreter *my_perl);
+perl_destruct(PerlInterpreter *my_perl)
+        Perl_attribute_nonnull_(1);
 #define PERL_ARGS_ASSERT_PERL_DESTRUCT          \
         assert(my_perl)
 
 PERL_CALLCONV void
-perl_free(PerlInterpreter *my_perl);
+perl_free(PerlInterpreter *my_perl)
+        Perl_attribute_nonnull_(1);
 #define PERL_ARGS_ASSERT_PERL_FREE              \
         assert(my_perl)
 
 PERL_CALLCONV int
-perl_parse(PerlInterpreter *my_perl, XSINIT_t xsinit, int argc, char **argv, char **env);
+perl_parse(PerlInterpreter *my_perl, XSINIT_t xsinit, int argc, char **argv, char **env)
+        Perl_attribute_nonnull_(1);
 #define PERL_ARGS_ASSERT_PERL_PARSE             \
         assert(my_perl)
 
 PERL_CALLCONV int
-perl_run(PerlInterpreter *my_perl);
+perl_run(PerlInterpreter *my_perl)
+        Perl_attribute_nonnull_(1);
 #define PERL_ARGS_ASSERT_PERL_RUN               \
         assert(my_perl)
 
@@ -3566,6 +4162,8 @@ Perl_pmop_dump(pTHX_ PMOP *pm);
 
 PERL_CALLCONV OP *
 Perl_pmruntime(pTHX_ OP *o, OP *expr, OP *repl, UV flags, I32 floor)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PMRUNTIME              \
         assert(o); assert(expr)
@@ -3576,17 +4174,24 @@ Perl_pop_scope(pTHX);
 
 PERL_CALLCONV void
 Perl_populate_isa(pTHX_ const char *name, STRLEN len, ...)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_POPULATE_ISA           \
         assert(name)
 
 PERL_CALLCONV REGEXP *
-Perl_pregcomp(pTHX_ SV * const pattern, const U32 flags);
+Perl_pregcomp(pTHX_ SV * const pattern, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PREGCOMP               \
         assert(pattern)
 
 PERL_CALLCONV I32
-Perl_pregexec(pTHX_ REGEXP * const prog, char *stringarg, char *strend, char *strbeg, SSize_t minend, SV *screamer, U32 nosave);
+Perl_pregexec(pTHX_ REGEXP * const prog, char *stringarg, char *strend, char *strbeg, SSize_t minend, SV *screamer, U32 nosave)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_6);
 #define PERL_ARGS_ASSERT_PREGEXEC               \
         assert(prog); assert(stringarg); assert(strend); assert(strbeg); \
         assert(screamer); assert(strbeg <= stringarg); \
@@ -3597,17 +4202,20 @@ Perl_pregfree(pTHX_ REGEXP *r);
 #define PERL_ARGS_ASSERT_PREGFREE
 
 PERL_CALLCONV void
-Perl_pregfree2(pTHX_ REGEXP *rx);
+Perl_pregfree2(pTHX_ REGEXP *rx)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PREGFREE2              \
         assert(rx)
 
 PERL_CALLCONV const char *
-Perl_prescan_version(pTHX_ const char *s, bool strict, const char **errstr, bool *sqv, int *ssaw_decimal, int *swidth, bool *salpha);
+Perl_prescan_version(pTHX_ const char *s, bool strict, const char **errstr, bool *sqv, int *ssaw_decimal, int *swidth, bool *salpha)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PRESCAN_VERSION        \
         assert(s)
 
 PERL_CALLCONV void *
 Perl_ptr_table_fetch(pTHX_ PTR_TBL_t * const tbl, const void * const sv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_PTR_TABLE_FETCH        \
         assert(tbl)
@@ -3622,12 +4230,15 @@ Perl_ptr_table_new(pTHX)
 #define PERL_ARGS_ASSERT_PTR_TABLE_NEW
 
 PERL_CALLCONV void
-Perl_ptr_table_split(pTHX_ PTR_TBL_t * const tbl);
+Perl_ptr_table_split(pTHX_ PTR_TBL_t * const tbl)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_PTR_TABLE_SPLIT        \
         assert(tbl)
 
 PERL_CALLCONV void
-Perl_ptr_table_store(pTHX_ PTR_TBL_t * const tbl, const void * const oldsv, void * const newsv);
+Perl_ptr_table_store(pTHX_ PTR_TBL_t * const tbl, const void * const oldsv, void * const newsv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_PTR_TABLE_STORE        \
         assert(tbl); assert(newsv)
 
@@ -3636,22 +4247,29 @@ Perl_push_scope(pTHX);
 #define PERL_ARGS_ASSERT_PUSH_SCOPE
 
 PERL_CALLCONV char *
-Perl_pv_display(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pvlim);
+Perl_pv_display(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pvlim)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_DISPLAY             \
         assert(dsv); assert(pv)
 
 PERL_CALLCONV char *
-Perl_pv_escape(pTHX_ SV *dsv, char const * const str, const STRLEN count, STRLEN max, STRLEN * const escaped, U32 flags);
+Perl_pv_escape(pTHX_ SV *dsv, char const * const str, const STRLEN count, STRLEN max, STRLEN * const escaped, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_ESCAPE              \
         assert(str)
 
 PERL_CALLCONV char *
-Perl_pv_pretty(pTHX_ SV *dsv, char const * const str, const STRLEN count, const STRLEN max, char const * const start_color, char const * const end_color, const U32 flags);
+Perl_pv_pretty(pTHX_ SV *dsv, char const * const str, const STRLEN count, const STRLEN max, char const * const start_color, char const * const end_color, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_PRETTY              \
         assert(dsv); assert(str)
 
 PERL_CALLCONV char *
-Perl_pv_uni_display(pTHX_ SV *dsv, const U8 *spv, STRLEN len, STRLEN pvlim, UV flags);
+Perl_pv_uni_display(pTHX_ SV *dsv, const U8 *spv, STRLEN len, STRLEN pvlim, UV flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_UNI_DISPLAY         \
         assert(dsv); assert(spv)
 
@@ -3672,23 +4290,30 @@ Perl_rcpv_new(pTHX_ const char * const pv, STRLEN len, U32 flags)
 #define PERL_ARGS_ASSERT_RCPV_NEW
 
 PERL_CALLCONV REGEXP *
-Perl_re_compile(pTHX_ SV * const pattern, U32 orig_rx_flags);
+Perl_re_compile(pTHX_ SV * const pattern, U32 orig_rx_flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_RE_COMPILE             \
         assert(pattern)
 
 PERL_CALLCONV char *
-Perl_re_intuit_start(pTHX_ REGEXP * const rx, SV *sv, const char * const strbeg, char *strpos, char *strend, const U32 flags, re_scream_pos_data *data);
+Perl_re_intuit_start(pTHX_ REGEXP * const rx, SV *sv, const char * const strbeg, char *strpos, char *strend, const U32 flags, re_scream_pos_data *data)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5);
 #define PERL_ARGS_ASSERT_RE_INTUIT_START        \
         assert(rx); assert(strbeg); assert(strpos); assert(strend); \
         assert(strbeg <= strpos)
 
 PERL_CALLCONV SV *
-Perl_re_intuit_string(pTHX_ REGEXP * const r);
+Perl_re_intuit_string(pTHX_ REGEXP * const r)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_RE_INTUIT_STRING       \
         assert(r)
 
 PERL_CALLCONV REGEXP *
-Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count, OP *expr, const regexp_engine *eng, REGEXP *old_re, bool *is_bare_re, const U32 rx_flags, const U32 pm_flags);
+Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count, OP *expr, const regexp_engine *eng, REGEXP *old_re, bool *is_bare_re, const U32 rx_flags, const U32 pm_flags)
+        Perl_attribute_nonnull_(pTHX_4);
 #define PERL_ARGS_ASSERT_RE_OP_COMPILE          \
         assert(eng)
 
@@ -3706,7 +4331,8 @@ Perl_reentrant_init(pTHX);
 #define PERL_ARGS_ASSERT_REENTRANT_INIT
 
 PERL_CALLCONV void *
-Perl_reentrant_retry(const char *f, ...);
+Perl_reentrant_retry(const char *f, ...)
+        Perl_attribute_nonnull_(1);
 #define PERL_ARGS_ASSERT_REENTRANT_RETRY        \
         assert(f)
 
@@ -3719,17 +4345,20 @@ Perl_refcounted_he_chain_2hv(pTHX_ const struct refcounted_he *c, U32 flags);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_CHAIN_2HV
 
 PERL_CALLCONV SV *
-Perl_refcounted_he_fetch_pv(pTHX_ const struct refcounted_he *chain, const char *key, U32 hash, U32 flags);
+Perl_refcounted_he_fetch_pv(pTHX_ const struct refcounted_he *chain, const char *key, U32 hash, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_PV \
         assert(key)
 
 PERL_CALLCONV SV *
-Perl_refcounted_he_fetch_pvn(pTHX_ const struct refcounted_he *chain, const char *keypv, STRLEN keylen, U32 hash, U32 flags);
+Perl_refcounted_he_fetch_pvn(pTHX_ const struct refcounted_he *chain, const char *keypv, STRLEN keylen, U32 hash, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_PVN \
         assert(keypv)
 
 PERL_CALLCONV SV *
-Perl_refcounted_he_fetch_sv(pTHX_ const struct refcounted_he *chain, SV *key, U32 hash, U32 flags);
+Perl_refcounted_he_fetch_sv(pTHX_ const struct refcounted_he *chain, SV *key, U32 hash, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_SV \
         assert(key)
 
@@ -3742,17 +4371,20 @@ Perl_refcounted_he_inc(pTHX_ struct refcounted_he *he);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_INC
 
 PERL_CALLCONV struct refcounted_he *
-Perl_refcounted_he_new_pv(pTHX_ struct refcounted_he *parent, const char *key, U32 hash, SV *value, U32 flags);
+Perl_refcounted_he_new_pv(pTHX_ struct refcounted_he *parent, const char *key, U32 hash, SV *value, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_PV   \
         assert(key)
 
 PERL_CALLCONV struct refcounted_he *
-Perl_refcounted_he_new_pvn(pTHX_ struct refcounted_he *parent, const char *keypv, STRLEN keylen, U32 hash, SV *value, U32 flags);
+Perl_refcounted_he_new_pvn(pTHX_ struct refcounted_he *parent, const char *keypv, STRLEN keylen, U32 hash, SV *value, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_PVN  \
         assert(keypv)
 
 PERL_CALLCONV struct refcounted_he *
-Perl_refcounted_he_new_sv(pTHX_ struct refcounted_he *parent, SV *key, U32 hash, SV *value, U32 flags);
+Perl_refcounted_he_new_sv(pTHX_ struct refcounted_he *parent, SV *key, U32 hash, SV *value, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_SV   \
         assert(key)
 
@@ -3760,22 +4392,28 @@ Perl_refcounted_he_new_sv(pTHX_ struct refcounted_he *parent, SV *key, U32 hash,
         assert(rx)
 
 PERL_CALLCONV SV *
-Perl_reg_named_buff_all(pTHX_ REGEXP * const rx, const U32 flags);
+Perl_reg_named_buff_all(pTHX_ REGEXP * const rx, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_ALL     \
         assert(rx)
 
 PERL_CALLCONV bool
-Perl_reg_named_buff_exists(pTHX_ REGEXP * const rx, SV * const key, const U32 flags);
+Perl_reg_named_buff_exists(pTHX_ REGEXP * const rx, SV * const key, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_EXISTS  \
         assert(rx); assert(key)
 
 PERL_CALLCONV SV *
-Perl_reg_named_buff_fetch(pTHX_ REGEXP * const rx, SV * const namesv, const U32 flags);
+Perl_reg_named_buff_fetch(pTHX_ REGEXP * const rx, SV * const namesv, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_FETCH   \
         assert(rx); assert(namesv)
 
 PERL_CALLCONV SV *
-Perl_reg_named_buff_firstkey(pTHX_ REGEXP * const rx, const U32 flags);
+Perl_reg_named_buff_firstkey(pTHX_ REGEXP * const rx, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_FIRSTKEY \
         assert(rx)
 
@@ -3783,12 +4421,14 @@ Perl_reg_named_buff_firstkey(pTHX_ REGEXP * const rx, const U32 flags);
         assert(rx)
 
 PERL_CALLCONV SV *
-Perl_reg_named_buff_nextkey(pTHX_ REGEXP * const rx, const U32 flags);
+Perl_reg_named_buff_nextkey(pTHX_ REGEXP * const rx, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_NEXTKEY \
         assert(rx)
 
 PERL_CALLCONV SV *
-Perl_reg_named_buff_scalar(pTHX_ REGEXP * const rx, const U32 flags);
+Perl_reg_named_buff_scalar(pTHX_ REGEXP * const rx, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_SCALAR  \
         assert(rx)
 
@@ -3811,18 +4451,25 @@ Perl_reg_named_buff_scalar(pTHX_ REGEXP * const rx, const U32 flags);
         assert(ssv)
 
 PERL_CALLCONV void
-Perl_regdump(pTHX_ const regexp *r);
+Perl_regdump(pTHX_ const regexp *r)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REGDUMP                \
         assert(r)
 
 PERL_CALLCONV I32
-Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend, char *strbeg, SSize_t minend, SV *sv, void *data, U32 flags);
+Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend, char *strbeg, SSize_t minend, SV *sv, void *data, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_6);
 #define PERL_ARGS_ASSERT_REGEXEC_FLAGS          \
         assert(rx); assert(stringarg); assert(strend); assert(strbeg); \
         assert(sv); assert(strbeg <= stringarg); assert(stringarg <= strend)
 
 PERL_CALLCONV void
-Perl_regfree_internal(pTHX_ REGEXP * const rx);
+Perl_regfree_internal(pTHX_ REGEXP * const rx)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REGFREE_INTERNAL       \
         assert(rx)
 
@@ -3832,12 +4479,15 @@ Perl_reginitcolors(pTHX);
 
 PERL_CALLCONV void
 Perl_release_RExC_state(pTHX_ void *vstate)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_RELEASE_REXC_STATE     \
         assert(vstate)
 
 PERL_CALLCONV void
-Perl_repeatcpy(char *to, const char *from, SSize_t len, IV count);
+Perl_repeatcpy(char *to, const char *from, SSize_t len, IV count)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2);
 #define PERL_ARGS_ASSERT_REPEATCPY              \
         assert(to); assert(from)
 
@@ -3854,12 +4504,14 @@ Perl_report_wrongway_fh(pTHX_ const GV *gv, const char have)
 #define PERL_ARGS_ASSERT_REPORT_WRONGWAY_FH
 
 PERL_CALLCONV void
-Perl_require_pv(pTHX_ const char *pv);
+Perl_require_pv(pTHX_ const char *pv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REQUIRE_PV             \
         assert(pv)
 
 PERL_CALLCONV void
-Perl_resume_compcv(pTHX_ struct suspended_compcv *buffer, bool save);
+Perl_resume_compcv(pTHX_ struct suspended_compcv *buffer, bool save)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_RESUME_COMPCV          \
         assert(buffer)
 
@@ -3871,6 +4523,10 @@ Perl_resume_compcv_final(pTHX_ struct suspended_compcv *buffer); */
 
 PERL_CALLCONV char *
 Perl_rninstr(const char *big, const char *bigend, const char *little, const char *lend)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(3)
+        Perl_attribute_nonnull_(4)
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_RNINSTR                \
@@ -3883,7 +4539,9 @@ Perl_rpeep(pTHX_ OP *o)
 #define PERL_ARGS_ASSERT_RPEEP
 
 PERL_CALLCONV void
-Perl_rpp_free_2_(pTHX_ SV * const sv1, SV * const sv2, const U32 rc1, const U32 rc2);
+Perl_rpp_free_2_(pTHX_ SV * const sv1, SV * const sv2, const U32 rc1, const U32 rc2)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_RPP_FREE_2_            \
         assert(sv1); assert(sv2)
 
@@ -3902,6 +4560,7 @@ Perl_rsignal_restore(pTHX_ int i, Sigsave_t *t)
 
 PERL_CALLCONV int
 Perl_rsignal_save(pTHX_ int i, Sighandler_t t1, Sigsave_t *save)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_RSIGNAL_SAVE           \
         assert(save)
@@ -3919,12 +4578,15 @@ Perl_runops_standard(pTHX);
 #define PERL_ARGS_ASSERT_RUNOPS_STANDARD
 
 PERL_CALLCONV CV *
-Perl_rv2cv_op_cv(pTHX_ OP *cvop, U32 flags);
+Perl_rv2cv_op_cv(pTHX_ OP *cvop, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_RV2CV_OP_CV            \
         assert(cvop)
 
 PERL_CALLCONV void
 Perl_rxres_save(pTHX_ void **rsp, REGEXP *rx)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_RXRES_SAVE             \
         assert(rsp); assert(rx)
@@ -3951,22 +4613,26 @@ Perl_safesysrealloc(Malloc_t where, MEM_SIZE nbytes)
 #define PERL_ARGS_ASSERT_SAFESYSREALLOC
 
 PERL_CALLCONV void
-Perl_save_I16(pTHX_ I16 *intp);
+Perl_save_I16(pTHX_ I16 *intp)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_I16               \
         assert(intp)
 
 PERL_CALLCONV void
-Perl_save_I32(pTHX_ I32 *intp);
+Perl_save_I32(pTHX_ I32 *intp)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_I32               \
         assert(intp)
 
 PERL_CALLCONV void
-Perl_save_I8(pTHX_ I8 *bytep);
+Perl_save_I8(pTHX_ I8 *bytep)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_I8                \
         assert(bytep)
 
 PERL_CALLCONV void
-Perl_save_adelete(pTHX_ AV *av, SSize_t key);
+Perl_save_adelete(pTHX_ AV *av, SSize_t key)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_ADELETE           \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
@@ -3974,7 +4640,9 @@ Perl_save_adelete(pTHX_ AV *av, SSize_t key);
 Perl_save_aelem(pTHX_ AV *av, SSize_t idx, SV **sptr); */
 
 PERL_CALLCONV void
-Perl_save_aelem_flags(pTHX_ AV *av, SSize_t idx, SV **sptr, const U32 flags);
+Perl_save_aelem_flags(pTHX_ AV *av, SSize_t idx, SV **sptr, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SAVE_AELEM_FLAGS       \
         assert(av); assert(SvTYPE(av) == SVt_PVAV); assert(sptr)
 
@@ -3983,32 +4651,39 @@ Perl_save_alloc(pTHX_ SSize_t size, I32 pad);
 #define PERL_ARGS_ASSERT_SAVE_ALLOC
 
 PERL_CALLCONV void
-Perl_save_aptr(pTHX_ AV **aptr);
+Perl_save_aptr(pTHX_ AV **aptr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_APTR              \
         assert(aptr)
 
 PERL_CALLCONV AV *
-Perl_save_ary(pTHX_ GV *gv);
+Perl_save_ary(pTHX_ GV *gv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_ARY               \
         assert(gv)
 
 PERL_CALLCONV void
-Perl_save_bool(pTHX_ bool *boolp);
+Perl_save_bool(pTHX_ bool *boolp)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_BOOL              \
         assert(boolp)
 
 PERL_CALLCONV void
-Perl_save_clearsv(pTHX_ SV **svp);
+Perl_save_clearsv(pTHX_ SV **svp)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_CLEARSV           \
         assert(svp)
 
 PERL_CALLCONV void
-Perl_save_delete(pTHX_ HV *hv, char *key, I32 klen);
+Perl_save_delete(pTHX_ HV *hv, char *key, I32 klen)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SAVE_DELETE            \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(key)
 
 PERL_CALLCONV void
-Perl_save_destructor(pTHX_ DESTRUCTORFUNC_NOCONTEXT_t f, void *p);
+Perl_save_destructor(pTHX_ DESTRUCTORFUNC_NOCONTEXT_t f, void *p)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SAVE_DESTRUCTOR        \
         assert(p)
 
@@ -4023,7 +4698,8 @@ Perl_save_freeop(pTHX_ OP *o); */
 Perl_save_freepv(pTHX_ char *pv); */
 
 PERL_CALLCONV void
-Perl_save_freercpv(pTHX_ char *rcpv);
+Perl_save_freercpv(pTHX_ char *rcpv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_FREERCPV          \
         assert(rcpv)
 
@@ -4031,27 +4707,33 @@ Perl_save_freercpv(pTHX_ char *rcpv);
 Perl_save_freesv(pTHX_ SV *sv); */
 
 PERL_CALLCONV void
-Perl_save_generic_pvref(pTHX_ char **str);
+Perl_save_generic_pvref(pTHX_ char **str)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_GENERIC_PVREF     \
         assert(str)
 
 PERL_CALLCONV void
-Perl_save_generic_svref(pTHX_ SV **sptr);
+Perl_save_generic_svref(pTHX_ SV **sptr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_GENERIC_SVREF     \
         assert(sptr)
 
 PERL_CALLCONV void
-Perl_save_gp(pTHX_ GV *gv, I32 empty);
+Perl_save_gp(pTHX_ GV *gv, I32 empty)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_GP                \
         assert(gv)
 
 PERL_CALLCONV HV *
-Perl_save_hash(pTHX_ GV *gv);
+Perl_save_hash(pTHX_ GV *gv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_HASH              \
         assert(gv)
 
 PERL_CALLCONV void
-Perl_save_hdelete(pTHX_ HV *hv, SV *keysv);
+Perl_save_hdelete(pTHX_ HV *hv, SV *keysv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SAVE_HDELETE           \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(keysv)
 
@@ -4059,7 +4741,10 @@ Perl_save_hdelete(pTHX_ HV *hv, SV *keysv);
 Perl_save_helem(pTHX_ HV *hv, SV *key, SV **sptr); */
 
 PERL_CALLCONV void
-Perl_save_helem_flags(pTHX_ HV *hv, SV *key, SV **sptr, const U32 flags);
+Perl_save_helem_flags(pTHX_ HV *hv, SV *key, SV **sptr, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SAVE_HELEM_FLAGS       \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(key); assert(sptr)
 
@@ -4068,22 +4753,26 @@ Perl_save_hints(pTHX);
 #define PERL_ARGS_ASSERT_SAVE_HINTS
 
 PERL_CALLCONV void
-Perl_save_hptr(pTHX_ HV **hptr);
+Perl_save_hptr(pTHX_ HV **hptr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_HPTR              \
         assert(hptr)
 
 PERL_CALLCONV void
-Perl_save_int(pTHX_ int *intp);
+Perl_save_int(pTHX_ int *intp)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_INT               \
         assert(intp)
 
 PERL_CALLCONV void
-Perl_save_item(pTHX_ SV *item);
+Perl_save_item(pTHX_ SV *item)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_ITEM              \
         assert(item)
 
 PERL_CALLCONV void
-Perl_save_iv(pTHX_ IV *ivp);
+Perl_save_iv(pTHX_ IV *ivp)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_IV                \
         assert(ivp)
 
@@ -4098,7 +4787,8 @@ Perl_save_padsv_and_mortalize(pTHX_ PADOFFSET off);
 #define PERL_ARGS_ASSERT_SAVE_PADSV_AND_MORTALIZE
 
 PERL_CALLCONV void
-Perl_save_pptr(pTHX_ char **pptr);
+Perl_save_pptr(pTHX_ char **pptr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_PPTR              \
         assert(pptr)
 
@@ -4115,7 +4805,8 @@ Perl_save_pushptrptr(pTHX_ void * const ptr1, void * const ptr2, const int type)
 #define PERL_ARGS_ASSERT_SAVE_PUSHPTRPTR
 
 PERL_CALLCONV void
-Perl_save_rcpv(pTHX_ char **prcpv);
+Perl_save_rcpv(pTHX_ char **prcpv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_RCPV              \
         assert(prcpv)
 
@@ -4124,37 +4815,44 @@ Perl_save_re_context(pTHX);
 #define PERL_ARGS_ASSERT_SAVE_RE_CONTEXT
 
 PERL_CALLCONV SV *
-Perl_save_scalar(pTHX_ GV *gv);
+Perl_save_scalar(pTHX_ GV *gv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SCALAR            \
         assert(gv)
 
 PERL_CALLCONV void
-Perl_save_set_svflags(pTHX_ SV *sv, U32 mask, U32 val);
+Perl_save_set_svflags(pTHX_ SV *sv, U32 mask, U32 val)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SET_SVFLAGS       \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_save_shared_pvref(pTHX_ char **str);
+Perl_save_shared_pvref(pTHX_ char **str)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SHARED_PVREF      \
         assert(str)
 
 PERL_CALLCONV void
-Perl_save_sptr(pTHX_ SV **sptr);
+Perl_save_sptr(pTHX_ SV **sptr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SPTR              \
         assert(sptr)
 
 PERL_CALLCONV void
-Perl_save_strlen(pTHX_ STRLEN *ptr);
+Perl_save_strlen(pTHX_ STRLEN *ptr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_STRLEN            \
         assert(ptr)
 
 PERL_CALLCONV SV *
-Perl_save_svref(pTHX_ SV **sptr);
+Perl_save_svref(pTHX_ SV **sptr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SVREF             \
         assert(sptr)
 
 PERL_CALLCONV void
-Perl_save_vptr(pTHX_ void *ptr);
+Perl_save_vptr(pTHX_ void *ptr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_VPTR              \
         assert(ptr)
 
@@ -4166,6 +4864,7 @@ Perl_savesharedpv(pTHX_ const char *pv)
 
 PERL_CALLCONV char *
 Perl_savesharedpvn(pTHX_ const char * const pv, const STRLEN len)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SAVESHAREDPVN          \
@@ -4195,27 +4894,36 @@ Perl_scalar(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_scalarvoid(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SCALARVOID             \
         assert(o)
 
 PERL_CALLCONV NV
-Perl_scan_bin(pTHX_ const char *start, STRLEN len, STRLEN *retlen);
+Perl_scan_bin(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SCAN_BIN               \
         assert(start); assert(retlen)
 
 PERL_CALLCONV NV
-Perl_scan_hex(pTHX_ const char *start, STRLEN len, STRLEN *retlen);
+Perl_scan_hex(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SCAN_HEX               \
         assert(start); assert(retlen)
 
 PERL_CALLCONV char *
-Perl_scan_num(pTHX_ const char *start, YYSTYPE *lvalp);
+Perl_scan_num(pTHX_ const char *start, YYSTYPE *lvalp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SCAN_NUM               \
         assert(start); assert(lvalp)
 
 PERL_CALLCONV NV
-Perl_scan_oct(pTHX_ const char *start, STRLEN len, STRLEN *retlen);
+Perl_scan_oct(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SCAN_OCT               \
         assert(start); assert(retlen)
 
@@ -4223,12 +4931,17 @@ Perl_scan_oct(pTHX_ const char *start, STRLEN len, STRLEN *retlen);
         assert(start)
 
 PERL_CALLCONV const char *
-Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv);
+Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SCAN_VERSION           \
         assert(s); assert(rv)
 
 PERL_CALLCONV char *
-Perl_scan_vstring(pTHX_ const char *s, const char * const e, SV *sv);
+Perl_scan_vstring(pTHX_ const char *s, const char * const e, SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SCAN_VSTRING           \
         assert(s); assert(e); assert(sv); assert(s < e)
 
@@ -4244,22 +4957,26 @@ Perl_set_caret_X(pTHX);
 #define PERL_ARGS_ASSERT_SET_CARET_X
 
 PERL_CALLCONV void
-Perl_set_context(void *t);
+Perl_set_context(void *t)
+        Perl_attribute_nonnull_(1);
 #define PERL_ARGS_ASSERT_SET_CONTEXT            \
         assert(t)
 
 PERL_CALLCONV void
-Perl_set_numeric_standard(pTHX_ const char *file, const line_t caller_line);
+Perl_set_numeric_standard(pTHX_ const char *file, const line_t caller_line)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SET_NUMERIC_STANDARD   \
         assert(file)
 
 PERL_CALLCONV void
-Perl_set_numeric_underlying(pTHX_ const char *file, const line_t caller_line);
+Perl_set_numeric_underlying(pTHX_ const char *file, const line_t caller_line)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SET_NUMERIC_UNDERLYING \
         assert(file)
 
 PERL_CALLCONV void
-Perl_setdefout(pTHX_ GV *gv);
+Perl_setdefout(pTHX_ GV *gv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SETDEFOUT              \
         assert(gv)
 
@@ -4289,7 +5006,8 @@ Perl_setfd_inhexec_for_sysfd(pTHX_ int fd)
 #define PERL_ARGS_ASSERT_SETFD_INHEXEC_FOR_SYSFD
 
 PERL_CALLCONV HEK *
-Perl_share_hek(pTHX_ const char *str, SSize_t len, U32 hash);
+Perl_share_hek(pTHX_ const char *str, SSize_t len, U32 hash)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SHARE_HEK              \
         assert(str)
 
@@ -4307,22 +5025,28 @@ Perl_sighandler3(int sig, Siginfo_t *info, void *uap)
         assert(s)
 
 PERL_CALLCONV void
-Perl_sortsv(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp);
+Perl_sortsv(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SORTSV                 \
         assert(cmp)
 
 PERL_CALLCONV void
-Perl_sortsv_flags(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp, U32 flags);
+Perl_sortsv_flags(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp, U32 flags)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SORTSV_FLAGS           \
         assert(cmp)
 
 PERL_CALLCONV SV **
-Perl_stack_grow(pTHX_ SV **sp, SV **p, SSize_t n);
+Perl_stack_grow(pTHX_ SV **sp, SV **p, SSize_t n)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_STACK_GROW             \
         assert(sp); assert(p)
 
 PERL_CALLCONV PerlIO *
 Perl_start_glob(pTHX_ SV *tmpglob, IO *io)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_START_GLOB             \
         assert(tmpglob); assert(io)
@@ -4333,6 +5057,7 @@ Perl_start_subparse(pTHX_ I32 is_format, U32 flags);
 
 PERL_CALLCONV NV
 Perl_str_to_version(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_STR_TO_VERSION         \
         assert(sv)
@@ -4342,18 +5067,21 @@ Perl_strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t 
 
 PERL_CALLCONV void
 Perl_sub_crush_depth(pTHX_ CV *cv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUB_CRUSH_DEPTH        \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
 Perl_subsignature_append_fence_op(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_FENCE_OP \
         assert(o)
 
 PERL_CALLCONV void
 Perl_subsignature_append_named(pTHX_ const char *paramname, PADOFFSET padix, OPCODE defmode, OP *defexpr)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_NAMED \
         assert(paramname)
@@ -4379,7 +5107,8 @@ Perl_subsignature_start(pTHX)
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_START
 
 PERL_CALLCONV void
-Perl_suspend_compcv(pTHX_ struct suspended_compcv *buffer);
+Perl_suspend_compcv(pTHX_ struct suspended_compcv *buffer)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SUSPEND_COMPCV         \
         assert(buffer)
 
@@ -4387,17 +5116,21 @@ Perl_suspend_compcv(pTHX_ struct suspended_compcv *buffer);
 Perl_sv_2bool(pTHX_ SV * const sv); */
 
 PERL_CALLCONV bool
-Perl_sv_2bool_flags(pTHX_ SV *sv, I32 flags);
+Perl_sv_2bool_flags(pTHX_ SV *sv, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2BOOL_FLAGS         \
         assert(sv)
 
 PERL_CALLCONV CV *
-Perl_sv_2cv(pTHX_ SV *sv, HV ** const st, GV ** const gvp, const I32 lref);
+Perl_sv_2cv(pTHX_ SV *sv, HV ** const st, GV ** const gvp, const I32 lref)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SV_2CV                 \
         assert(st); assert(gvp)
 
 PERL_CALLCONV IO *
-Perl_sv_2io(pTHX_ SV * const sv);
+Perl_sv_2io(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2IO                 \
         assert(sv)
 
@@ -4405,7 +5138,8 @@ Perl_sv_2io(pTHX_ SV * const sv);
 Perl_sv_2iv(pTHX_ SV *sv); */
 
 PERL_CALLCONV IV
-Perl_sv_2iv_flags(pTHX_ SV * const sv, const I32 flags);
+Perl_sv_2iv_flags(pTHX_ SV * const sv, const I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2IV_FLAGS           \
         assert(sv)
 
@@ -4415,12 +5149,14 @@ Perl_sv_2mortal(pTHX_ SV * const sv);
 
 PERL_CALLCONV SV *
 Perl_sv_2num_flags(pTHX_ SV * const sv, int flags)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SV_2NUM_FLAGS          \
         assert(sv)
 
 PERL_CALLCONV NV
-Perl_sv_2nv_flags(pTHX_ SV * const sv, const I32 flags);
+Perl_sv_2nv_flags(pTHX_ SV * const sv, const I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2NV_FLAGS           \
         assert(sv)
 
@@ -4428,7 +5164,8 @@ Perl_sv_2nv_flags(pTHX_ SV * const sv, const I32 flags);
 Perl_sv_2pv(pTHX_ SV *sv, STRLEN *lp); */
 
 PERL_CALLCONV char *
-Perl_sv_2pv_flags(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags);
+Perl_sv_2pv_flags(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PV_FLAGS           \
         assert(sv)
 
@@ -4440,7 +5177,8 @@ Perl_sv_2pv_nolen(pTHX_ SV *sv)
 Perl_sv_2pvbyte(pTHX_ SV *sv, STRLEN * const lp); */
 
 PERL_CALLCONV char *
-Perl_sv_2pvbyte_flags(pTHX_ SV *sv, STRLEN * const lp, const U32 flags);
+Perl_sv_2pvbyte_flags(pTHX_ SV *sv, STRLEN * const lp, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PVBYTE_FLAGS       \
         assert(sv)
 
@@ -4452,7 +5190,8 @@ Perl_sv_2pvbyte_nolen(pTHX_ SV *sv)
 Perl_sv_2pvutf8(pTHX_ SV *sv, STRLEN * const lp); */
 
 PERL_CALLCONV char *
-Perl_sv_2pvutf8_flags(pTHX_ SV *sv, STRLEN * const lp, const U32 flags);
+Perl_sv_2pvutf8_flags(pTHX_ SV *sv, STRLEN * const lp, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PVUTF8_FLAGS       \
         assert(sv)
 
@@ -4464,53 +5203,71 @@ Perl_sv_2pvutf8_nolen(pTHX_ SV *sv)
 Perl_sv_2uv(pTHX_ SV *sv); */
 
 PERL_CALLCONV UV
-Perl_sv_2uv_flags(pTHX_ SV * const sv, const I32 flags);
+Perl_sv_2uv_flags(pTHX_ SV * const sv, const I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2UV_FLAGS           \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_backoff(SV * const sv);
+Perl_sv_backoff(SV * const sv)
+        Perl_attribute_nonnull_(1);
 #define PERL_ARGS_ASSERT_SV_BACKOFF             \
         assert(sv)
 
 PERL_CALLCONV SV *
-Perl_sv_bless(pTHX_ SV * const sv, HV * const stash);
+Perl_sv_bless(pTHX_ SV * const sv, HV * const stash)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_BLESS               \
         assert(sv); assert(stash)
 
 PERL_CALLCONV bool
-Perl_sv_can_swipe_pv_buf(pTHX_ SV *sv);
+Perl_sv_can_swipe_pv_buf(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CAN_SWIPE_PV_BUF    \
         assert(sv)
 
 PERL_CALLCONV bool
-Perl_sv_cat_decode(pTHX_ SV *dsv, SV *encoding, SV *ssv, int *offset, char *tstr, int tlen);
+Perl_sv_cat_decode(pTHX_ SV *dsv, SV *encoding, SV *ssv, int *offset, char *tstr, int tlen)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5);
 #define PERL_ARGS_ASSERT_SV_CAT_DECODE          \
         assert(dsv); assert(encoding); assert(ssv); assert(offset); assert(tstr)
 
 PERL_CALLCONV void
-Perl_sv_catpv(pTHX_ SV * const dsv, const char *sstr);
+Perl_sv_catpv(pTHX_ SV * const dsv, const char *sstr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CATPV               \
         assert(dsv)
 
 PERL_CALLCONV void
-Perl_sv_catpv_flags(pTHX_ SV * const dsv, const char *sstr, const I32 flags);
+Perl_sv_catpv_flags(pTHX_ SV * const dsv, const char *sstr, const I32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_CATPV_FLAGS         \
         assert(dsv); assert(sstr)
 
 PERL_CALLCONV void
-Perl_sv_catpv_mg(pTHX_ SV * const dsv, const char * const sstr);
+Perl_sv_catpv_mg(pTHX_ SV * const dsv, const char * const sstr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CATPV_MG            \
         assert(dsv)
 
 PERL_CALLCONV void
 Perl_sv_catpvf(pTHX_ SV * const sv, const char * const pat, ...)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_SV_CATPVF              \
         assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_catpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_SV_CATPVF_MG           \
         assert(sv); assert(pat)
@@ -4519,7 +5276,9 @@ Perl_sv_catpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
 Perl_sv_catpvn(pTHX_ SV * const dsv, const char *sstr, STRLEN len); */
 
 PERL_CALLCONV void
-Perl_sv_catpvn_flags(pTHX_ SV * const dsv, const char *sstr, const STRLEN len, const I32 flags);
+Perl_sv_catpvn_flags(pTHX_ SV * const dsv, const char *sstr, const STRLEN len, const I32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_CATPVN_FLAGS        \
         assert(dsv); assert(sstr)
 
@@ -4530,7 +5289,8 @@ Perl_sv_catpvn_mg(pTHX_ SV * const dsv, const char *sstr, STRLEN len); */
 Perl_sv_catsv(pTHX_ SV * const dsv, SV * const sstr); */
 
 PERL_CALLCONV void
-Perl_sv_catsv_flags(pTHX_ SV * const dsv, SV * const sstr, const I32 flags);
+Perl_sv_catsv_flags(pTHX_ SV * const dsv, SV * const sstr, const I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CATSV_FLAGS         \
         assert(dsv)
 
@@ -4538,7 +5298,8 @@ Perl_sv_catsv_flags(pTHX_ SV * const dsv, SV * const sstr, const I32 flags);
 Perl_sv_catsv_mg(pTHX_ SV * const dsv, SV * const sstr); */
 
 PERL_CALLCONV void
-Perl_sv_chop(pTHX_ SV * const sv, const char * const ptr);
+Perl_sv_chop(pTHX_ SV * const sv, const char * const ptr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CHOP                \
         assert(sv)
 
@@ -4553,7 +5314,8 @@ Perl_sv_clean_objs(pTHX)
 #define PERL_ARGS_ASSERT_SV_CLEAN_OBJS
 
 PERL_CALLCONV void
-Perl_sv_clear(pTHX_ SV * const orig_sv);
+Perl_sv_clear(pTHX_ SV * const orig_sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CLEAR               \
         assert(orig_sv)
 
@@ -4577,7 +5339,9 @@ Perl_sv_cmp_locale_flags(pTHX_ SV * const sv1, SV * const sv2, const U32 flags);
 Perl_sv_copypv(pTHX_ SV * const dsv, SV * const ssv); */
 
 PERL_CALLCONV void
-Perl_sv_copypv_flags(pTHX_ SV * const dsv, SV * const ssv, const I32 flags);
+Perl_sv_copypv_flags(pTHX_ SV * const dsv, SV * const ssv, const I32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_COPYPV_FLAGS        \
         assert(dsv); assert(ssv)
 
@@ -4593,36 +5357,48 @@ Perl_sv_dec_nomg(pTHX_ SV * const sv);
 #define PERL_ARGS_ASSERT_SV_DEC_NOMG
 
 PERL_CALLCONV void
-Perl_sv_del_backref(pTHX_ SV * const tsv, SV * const sv);
+Perl_sv_del_backref(pTHX_ SV * const tsv, SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_DEL_BACKREF         \
         assert(tsv); assert(sv)
 
 PERL_CALLCONV bool
 Perl_sv_derived_from(pTHX_ SV *sv, const char * const name)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM        \
         assert(sv); assert(name)
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_hv(pTHX_ SV *sv, HV *hv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM_HV     \
         assert(sv); assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_pv(pTHX_ SV *sv, const char * const name, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM_PV     \
         assert(sv); assert(name)
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_pvn(pTHX_ SV *sv, const char * const name, const STRLEN len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM_PVN    \
         assert(sv); assert(name)
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM_SV     \
         assert(sv); assert(namesv)
@@ -4633,24 +5409,32 @@ Perl_sv_destroyable(pTHX_ SV *sv);
 
 PERL_CALLCONV bool
 Perl_sv_does(pTHX_ SV *sv, const char * const name)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DOES                \
         assert(sv); assert(name)
 
 PERL_CALLCONV bool
 Perl_sv_does_pv(pTHX_ SV *sv, const char * const name, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DOES_PV             \
         assert(sv); assert(name)
 
 PERL_CALLCONV bool
 Perl_sv_does_pvn(pTHX_ SV *sv, const char * const name, const STRLEN len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DOES_PVN            \
         assert(sv); assert(name)
 
 PERL_CALLCONV bool
 Perl_sv_does_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DOES_SV             \
         assert(sv); assert(namesv)
@@ -4674,7 +5458,8 @@ Perl_sv_eq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags);
 Perl_sv_force_normal(pTHX_ SV *sv); */
 
 PERL_CALLCONV void
-Perl_sv_force_normal_flags(pTHX_ SV * const sv, const U32 flags);
+Perl_sv_force_normal_flags(pTHX_ SV * const sv, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_FORCE_NORMAL_FLAGS  \
         assert(sv)
 
@@ -4683,7 +5468,8 @@ Perl_sv_free(pTHX_ SV * const sv);
 #define PERL_ARGS_ASSERT_SV_FREE
 
 PERL_CALLCONV void
-Perl_sv_free2(pTHX_ SV * const sv, const U32 refcnt);
+Perl_sv_free2(pTHX_ SV * const sv, const U32 refcnt)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_FREE2               \
         assert(sv)
 
@@ -4693,22 +5479,27 @@ Perl_sv_free_arenas(pTHX)
 #define PERL_ARGS_ASSERT_SV_FREE_ARENAS
 
 PERL_CALLCONV SV *
-Perl_sv_get_backrefs(SV * const sv);
+Perl_sv_get_backrefs(SV * const sv)
+        Perl_attribute_nonnull_(1);
 #define PERL_ARGS_ASSERT_SV_GET_BACKREFS        \
         assert(sv)
 
 PERL_CALLCONV char *
-Perl_sv_gets(pTHX_ SV * const sv, PerlIO * const fp, SSize_t append);
+Perl_sv_gets(pTHX_ SV * const sv, PerlIO * const fp, SSize_t append)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_GETS                \
         assert(sv); assert(fp)
 
 PERL_CALLCONV char *
-Perl_sv_grow(pTHX_ SV * const sv, STRLEN newlen);
+Perl_sv_grow(pTHX_ SV * const sv, STRLEN newlen)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_GROW                \
         assert(sv)
 
 PERL_CALLCONV char *
-Perl_sv_grow_fresh(pTHX_ SV * const sv, STRLEN newlen);
+Perl_sv_grow_fresh(pTHX_ SV * const sv, STRLEN newlen)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_GROW_FRESH          \
         assert(sv)
 
@@ -4724,17 +5515,22 @@ Perl_sv_inc_nomg(pTHX_ SV * const sv);
 Perl_sv_insert(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN len, const char * const little, const STRLEN littlelen); */
 
 PERL_CALLCONV void
-Perl_sv_insert_flags(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN len, const char *little, const STRLEN littlelen, const U32 flags);
+Perl_sv_insert_flags(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN len, const char *little, const STRLEN littlelen, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_4);
 #define PERL_ARGS_ASSERT_SV_INSERT_FLAGS        \
         assert(bigstr); assert(little)
 
 PERL_CALLCONV int
-Perl_sv_isa(pTHX_ SV *sv, const char * const name);
+Perl_sv_isa(pTHX_ SV *sv, const char * const name)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_ISA                 \
         assert(name)
 
 PERL_CALLCONV bool
 Perl_sv_isa_sv(pTHX_ SV *sv, SV *namesv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_ISA_SV              \
         assert(sv); assert(namesv)
@@ -4756,17 +5552,20 @@ Perl_sv_len_utf8(pTHX_ SV * const sv);
 #define PERL_ARGS_ASSERT_SV_LEN_UTF8
 
 PERL_CALLCONV STRLEN
-Perl_sv_len_utf8_nomg(pTHX_ SV * const sv);
+Perl_sv_len_utf8_nomg(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_LEN_UTF8_NOMG       \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_magic(pTHX_ SV * const sv, SV * const obj, const int how, const char * const name, const I32 namlen);
+Perl_sv_magic(pTHX_ SV * const sv, SV * const obj, const int how, const char * const name, const I32 namlen)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_MAGIC               \
         assert(sv)
 
 PERL_CALLCONV MAGIC *
-Perl_sv_magicext(pTHX_ SV * const sv, SV * const obj, const int how, const MGVTBL * const vtbl, const char * const name, const I32 namlen);
+Perl_sv_magicext(pTHX_ SV * const sv, SV * const obj, const int how, const MGVTBL * const vtbl, const char * const name, const I32 namlen)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_MAGICEXT            \
         assert(sv)
 
@@ -4849,22 +5648,26 @@ Perl_sv_peek(pTHX_ SV *sv);
 #define PERL_ARGS_ASSERT_SV_PEEK
 
 PERL_CALLCONV void
-Perl_sv_pos_b2u(pTHX_ SV * const sv, I32 * const offsetp);
+Perl_sv_pos_b2u(pTHX_ SV * const sv, I32 * const offsetp)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_POS_B2U             \
         assert(offsetp)
 
 PERL_CALLCONV STRLEN
-Perl_sv_pos_b2u_flags(pTHX_ SV * const sv, STRLEN const offset, U32 flags);
+Perl_sv_pos_b2u_flags(pTHX_ SV * const sv, STRLEN const offset, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_POS_B2U_FLAGS       \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_pos_u2b(pTHX_ SV * const sv, I32 * const offsetp, I32 * const lenp);
+Perl_sv_pos_u2b(pTHX_ SV * const sv, I32 * const offsetp, I32 * const lenp)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_POS_U2B             \
         assert(offsetp)
 
 PERL_CALLCONV STRLEN
-Perl_sv_pos_u2b_flags(pTHX_ SV * const sv, STRLEN uoffset, STRLEN * const lenp, U32 flags);
+Perl_sv_pos_u2b_flags(pTHX_ SV * const sv, STRLEN uoffset, STRLEN * const lenp, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_POS_U2B_FLAGS       \
         assert(sv)
 
@@ -4877,7 +5680,8 @@ Perl_sv_pvbyte(pTHX_ SV *sv)
         __attribute__warn_unused_result__; */
 
 PERL_CALLCONV char *
-Perl_sv_pvbyten_force(pTHX_ SV * const sv, STRLEN * const lp);
+Perl_sv_pvbyten_force(pTHX_ SV * const sv, STRLEN * const lp)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_PVBYTEN_FORCE       \
         assert(sv)
 
@@ -4885,7 +5689,8 @@ Perl_sv_pvbyten_force(pTHX_ SV * const sv, STRLEN * const lp);
 Perl_sv_pvn_force(pTHX_ SV *sv, STRLEN *lp); */
 
 PERL_CALLCONV char *
-Perl_sv_pvn_force_flags(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags);
+Perl_sv_pvn_force_flags(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_PVN_FORCE_FLAGS     \
         assert(sv)
 
@@ -4894,44 +5699,55 @@ Perl_sv_pvutf8(pTHX_ SV *sv)
         __attribute__warn_unused_result__; */
 
 PERL_CALLCONV char *
-Perl_sv_pvutf8n_force(pTHX_ SV * const sv, STRLEN * const lp);
+Perl_sv_pvutf8n_force(pTHX_ SV * const sv, STRLEN * const lp)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_PVUTF8N_FORCE       \
         assert(sv)
 
 PERL_CALLCONV char *
-Perl_sv_recode_to_utf8(pTHX_ SV *sv, SV *encoding);
+Perl_sv_recode_to_utf8(pTHX_ SV *sv, SV *encoding)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_RECODE_TO_UTF8      \
         assert(sv); assert(encoding)
 
 PERL_CALLCONV SV *
-Perl_sv_ref(pTHX_ SV *dst, const SV * const sv, const int ob);
+Perl_sv_ref(pTHX_ SV *dst, const SV * const sv, const int ob)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_REF                 \
         assert(sv)
 
 PERL_CALLCONV const char *
 Perl_sv_reftype(pTHX_ const SV * const sv, const int ob)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_REFTYPE             \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_regex_global_pos_clear(pTHX_ SV *sv);
+Perl_sv_regex_global_pos_clear(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_REGEX_GLOBAL_POS_CLEAR \
         assert(sv)
 
 PERL_CALLCONV bool
 Perl_sv_regex_global_pos_get(pTHX_ SV *sv, STRLEN *posp, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_REGEX_GLOBAL_POS_GET \
         assert(sv); assert(posp)
 
 PERL_CALLCONV void
-Perl_sv_regex_global_pos_set(pTHX_ SV *sv, STRLEN pos, U32 flags);
+Perl_sv_regex_global_pos_set(pTHX_ SV *sv, STRLEN pos, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_REGEX_GLOBAL_POS_SET \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_replace(pTHX_ SV * const sv, SV * const nsv);
+Perl_sv_replace(pTHX_ SV * const sv, SV * const nsv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_REPLACE             \
         assert(sv); assert(nsv)
 
@@ -4940,7 +5756,8 @@ Perl_sv_report_used(pTHX);
 #define PERL_ARGS_ASSERT_SV_REPORT_USED
 
 PERL_CALLCONV void
-Perl_sv_reset(pTHX_ const char *s, HV * const stash);
+Perl_sv_reset(pTHX_ const char *s, HV * const stash)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_RESET               \
         assert(s); assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
@@ -4950,144 +5767,180 @@ Perl_sv_resetpvn(pTHX_ const char *s, STRLEN len, HV * const stash)
 #define PERL_ARGS_ASSERT_SV_RESETPVN
 
 PERL_CALLCONV SV *
-Perl_sv_rvunweaken(pTHX_ SV * const sv);
+Perl_sv_rvunweaken(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_RVUNWEAKEN          \
         assert(sv)
 
 PERL_CALLCONV SV *
-Perl_sv_rvweaken(pTHX_ SV * const sv);
+Perl_sv_rvweaken(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_RVWEAKEN            \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_set_bool(pTHX_ SV *sv, const bool bool_val);
+Perl_sv_set_bool(pTHX_ SV *sv, const bool bool_val)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_BOOL            \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_set_false(pTHX_ SV *sv);
+Perl_sv_set_false(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_FALSE           \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_set_true(pTHX_ SV *sv);
+Perl_sv_set_true(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_TRUE            \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_set_undef(pTHX_ SV *sv);
+Perl_sv_set_undef(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_UNDEF           \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_sethek(pTHX_ SV * const sv, const HEK * const hek);
+Perl_sv_sethek(pTHX_ SV * const sv, const HEK * const hek)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETHEK              \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_setiv(pTHX_ SV * const sv, const IV num);
+Perl_sv_setiv(pTHX_ SV * const sv, const IV num)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETIV               \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_setiv_mg(pTHX_ SV * const sv, const IV i);
+Perl_sv_setiv_mg(pTHX_ SV * const sv, const IV i)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETIV_MG            \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_setnv(pTHX_ SV * const sv, const NV num);
+Perl_sv_setnv(pTHX_ SV * const sv, const NV num)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETNV               \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_setnv_mg(pTHX_ SV * const sv, const NV num);
+Perl_sv_setnv_mg(pTHX_ SV * const sv, const NV num)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETNV_MG            \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_setpv(pTHX_ SV * const sv, const char * const ptr);
+Perl_sv_setpv(pTHX_ SV * const sv, const char * const ptr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPV               \
         assert(sv)
 
 PERL_CALLCONV char  *
-Perl_sv_setpv_bufsize(pTHX_ SV * const sv, const STRLEN cur, const STRLEN len);
+Perl_sv_setpv_bufsize(pTHX_ SV * const sv, const STRLEN cur, const STRLEN len)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPV_BUFSIZE       \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_setpv_mg(pTHX_ SV * const sv, const char * const ptr);
+Perl_sv_setpv_mg(pTHX_ SV * const sv, const char * const ptr)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPV_MG            \
         assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setpvf(pTHX_ SV * const sv, const char * const pat, ...)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_SV_SETPVF              \
         assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_setpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_SV_SETPVF_MG           \
         assert(sv); assert(pat)
 
 PERL_CALLCONV void
-Perl_sv_setpvn(pTHX_ SV * const sv, const char * const ptr, const STRLEN len);
+Perl_sv_setpvn(pTHX_ SV * const sv, const char * const ptr, const STRLEN len)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPVN              \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_setpvn_fresh(pTHX_ SV * const sv, const char * const ptr, const STRLEN len);
+Perl_sv_setpvn_fresh(pTHX_ SV * const sv, const char * const ptr, const STRLEN len)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPVN_FRESH        \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_setpvn_mg(pTHX_ SV * const sv, const char * const ptr, const STRLEN len);
+Perl_sv_setpvn_mg(pTHX_ SV * const sv, const char * const ptr, const STRLEN len)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETPVN_MG           \
         assert(sv); assert(ptr)
 
 PERL_CALLCONV SV *
-Perl_sv_setref_iv(pTHX_ SV * const rv, const char * const classname, const IV iv);
+Perl_sv_setref_iv(pTHX_ SV * const rv, const char * const classname, const IV iv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_IV           \
         assert(rv)
 
 PERL_CALLCONV SV *
-Perl_sv_setref_nv(pTHX_ SV * const rv, const char * const classname, const NV nv);
+Perl_sv_setref_nv(pTHX_ SV * const rv, const char * const classname, const NV nv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_NV           \
         assert(rv)
 
 PERL_CALLCONV SV *
-Perl_sv_setref_pv(pTHX_ SV * const rv, const char * const classname, void * const pv);
+Perl_sv_setref_pv(pTHX_ SV * const rv, const char * const classname, void * const pv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_PV           \
         assert(rv)
 
 PERL_CALLCONV SV *
-Perl_sv_setref_pvn(pTHX_ SV * const rv, const char * const classname, const char * const pv, const STRLEN n);
+Perl_sv_setref_pvn(pTHX_ SV * const rv, const char * const classname, const char * const pv, const STRLEN n)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_SV_SETREF_PVN          \
         assert(rv); assert(pv)
 
 PERL_CALLCONV SV *
-Perl_sv_setref_uv(pTHX_ SV * const rv, const char * const classname, const UV uv);
+Perl_sv_setref_uv(pTHX_ SV * const rv, const char * const classname, const UV uv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_UV           \
         assert(rv)
 
 PERL_CALLCONV void
-Perl_sv_setrv_inc(pTHX_ SV * const sv, SV * const ref);
+Perl_sv_setrv_inc(pTHX_ SV * const sv, SV * const ref)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_INC           \
         assert(sv); assert(ref)
 
 PERL_CALLCONV void
-Perl_sv_setrv_inc_mg(pTHX_ SV * const sv, SV * const ref);
+Perl_sv_setrv_inc_mg(pTHX_ SV * const sv, SV * const ref)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_INC_MG        \
         assert(sv); assert(ref)
 
 PERL_CALLCONV void
-Perl_sv_setrv_noinc(pTHX_ SV * const sv, SV * const ref);
+Perl_sv_setrv_noinc(pTHX_ SV * const sv, SV * const ref)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_NOINC         \
         assert(sv); assert(ref)
 
 PERL_CALLCONV void
-Perl_sv_setrv_noinc_mg(pTHX_ SV * const sv, SV * const ref);
+Perl_sv_setrv_noinc_mg(pTHX_ SV * const sv, SV * const ref)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_NOINC_MG      \
         assert(sv); assert(ref)
 
@@ -5095,22 +5948,26 @@ Perl_sv_setrv_noinc_mg(pTHX_ SV * const sv, SV * const ref);
 Perl_sv_setsv(pTHX_ SV *dsv, SV *ssv); */
 
 PERL_CALLCONV void
-Perl_sv_setsv_flags(pTHX_ SV *dsv, SV *ssv, const I32 flags);
+Perl_sv_setsv_flags(pTHX_ SV *dsv, SV *ssv, const I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETSV_FLAGS         \
         assert(dsv)
 
 PERL_CALLCONV void
-Perl_sv_setsv_mg(pTHX_ SV * const dsv, SV * const ssv);
+Perl_sv_setsv_mg(pTHX_ SV * const dsv, SV * const ssv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETSV_MG            \
         assert(dsv)
 
 PERL_CALLCONV void
-Perl_sv_setuv(pTHX_ SV * const sv, const UV num);
+Perl_sv_setuv(pTHX_ SV * const sv, const UV num)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETUV               \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_setuv_mg(pTHX_ SV * const sv, const UV u);
+Perl_sv_setuv_mg(pTHX_ SV * const sv, const UV u)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETUV_MG            \
         assert(sv)
 
@@ -5122,12 +5979,15 @@ Perl_sv_streq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags);
 #define PERL_ARGS_ASSERT_SV_STREQ_FLAGS
 
 PERL_CALLCONV SV *
-Perl_sv_strftime_ints(pTHX_ SV *fmt, int sec, int min, int hour, int mday, int mon, int year, int isdst);
+Perl_sv_strftime_ints(pTHX_ SV *fmt, int sec, int min, int hour, int mday, int mon, int year, int isdst)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_STRFTIME_INTS       \
         assert(fmt)
 
 PERL_CALLCONV SV *
-Perl_sv_strftime_tm(pTHX_ SV *fmt, const struct tm *mytm);
+Perl_sv_strftime_tm(pTHX_ SV *fmt, const struct tm *mytm)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_STRFTIME_TM         \
         assert(fmt); assert(mytm)
 
@@ -5140,6 +6000,7 @@ Perl_sv_taint(pTHX_ SV *sv); */
 
 PERL_CALLCONV bool
 Perl_sv_tainted(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_TAINTED             \
         assert(sv)
@@ -5150,17 +6011,21 @@ Perl_sv_true(pTHX_ SV * const sv);
 
 PERL_CALLCONV char *
 Perl_sv_uni_display(pTHX_ SV *dsv, SV *ssv, STRLEN pvlim, UV flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_UNI_DISPLAY         \
         assert(dsv); assert(ssv)
 
 PERL_CALLCONV int
-Perl_sv_unmagic(pTHX_ SV * const sv, const int type);
+Perl_sv_unmagic(pTHX_ SV * const sv, const int type)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNMAGIC             \
         assert(sv)
 
 PERL_CALLCONV int
-Perl_sv_unmagicext(pTHX_ SV * const sv, const int type, const MGVTBL *vtbl);
+Perl_sv_unmagicext(pTHX_ SV * const sv, const int type, const MGVTBL *vtbl)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNMAGICEXT          \
         assert(sv)
 
@@ -5168,17 +6033,20 @@ Perl_sv_unmagicext(pTHX_ SV * const sv, const int type, const MGVTBL *vtbl);
 Perl_sv_unref(pTHX_ SV *sv); */
 
 PERL_CALLCONV void
-Perl_sv_unref_flags(pTHX_ SV * const ref, const U32 flags);
+Perl_sv_unref_flags(pTHX_ SV * const ref, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNREF_FLAGS         \
         assert(ref)
 
 PERL_CALLCONV void
-Perl_sv_untaint(pTHX_ SV * const sv);
+Perl_sv_untaint(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNTAINT             \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_sv_upgrade(pTHX_ SV * const sv, svtype new_type);
+Perl_sv_upgrade(pTHX_ SV * const sv, svtype new_type)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UPGRADE             \
         assert(sv)
 
@@ -5186,7 +6054,8 @@ Perl_sv_upgrade(pTHX_ SV * const sv, svtype new_type);
 Perl_sv_usepvn(pTHX_ SV *sv, char *ptr, STRLEN len); */
 
 PERL_CALLCONV void
-Perl_sv_usepvn_flags(pTHX_ SV * const sv, char *ptr, const STRLEN len, const U32 flags);
+Perl_sv_usepvn_flags(pTHX_ SV * const sv, char *ptr, const STRLEN len, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_USEPVN_FLAGS        \
         assert(sv)
 
@@ -5194,7 +6063,8 @@ Perl_sv_usepvn_flags(pTHX_ SV * const sv, char *ptr, const STRLEN len, const U32
 Perl_sv_usepvn_mg(pTHX_ SV *sv, char *ptr, STRLEN len); */
 
 PERL_CALLCONV bool
-Perl_sv_utf8_decode(pTHX_ SV * const sv);
+Perl_sv_utf8_decode(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_DECODE         \
         assert(sv)
 
@@ -5202,7 +6072,8 @@ Perl_sv_utf8_decode(pTHX_ SV * const sv);
 Perl_sv_utf8_downgrade(pTHX_ SV * const sv, const bool fail_ok); */
 
 PERL_CALLCONV bool
-Perl_sv_utf8_downgrade_flags(pTHX_ SV * const sv, const bool fail_ok, const U32 flags);
+Perl_sv_utf8_downgrade_flags(pTHX_ SV * const sv, const bool fail_ok, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_DOWNGRADE_FLAGS \
         assert(sv)
 
@@ -5210,7 +6081,8 @@ Perl_sv_utf8_downgrade_flags(pTHX_ SV * const sv, const bool fail_ok, const U32 
 Perl_sv_utf8_downgrade_nomg(pTHX_ SV * const sv, const bool fail_ok); */
 
 PERL_CALLCONV void
-Perl_sv_utf8_encode(pTHX_ SV * const sv);
+Perl_sv_utf8_encode(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_ENCODE         \
         assert(sv)
 
@@ -5221,7 +6093,8 @@ Perl_sv_utf8_upgrade(pTHX_ SV *sv); */
 Perl_sv_utf8_upgrade_flags(pTHX_ SV * const sv, const I32 flags); */
 
 PERL_CALLCONV STRLEN
-Perl_sv_utf8_upgrade_flags_grow(pTHX_ SV * const sv, const I32 flags, STRLEN extra);
+Perl_sv_utf8_upgrade_flags_grow(pTHX_ SV * const sv, const I32 flags, STRLEN extra)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE_FLAGS_GROW \
         assert(sv)
 
@@ -5229,42 +6102,57 @@ Perl_sv_utf8_upgrade_flags_grow(pTHX_ SV * const sv, const I32 flags, STRLEN ext
 Perl_sv_utf8_upgrade_nomg(pTHX_ SV *sv); */
 
 PERL_CALLCONV void
-Perl_sv_vcatpvf(pTHX_ SV * const sv, const char * const pat, va_list * const args);
+Perl_sv_vcatpvf(pTHX_ SV * const sv, const char * const pat, va_list * const args)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVF             \
         assert(sv); assert(pat)
 
 PERL_CALLCONV void
-Perl_sv_vcatpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const args);
+Perl_sv_vcatpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const args)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVF_MG          \
         assert(sv); assert(pat)
 
 PERL_CALLCONV void
-Perl_sv_vcatpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patlen, va_list * const args, SV ** const svargs, const Size_t sv_count, bool * const maybe_tainted);
+Perl_sv_vcatpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patlen, va_list * const args, SV ** const svargs, const Size_t sv_count, bool * const maybe_tainted)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVFN            \
         assert(sv); assert(pat)
 
 PERL_CALLCONV void
-Perl_sv_vcatpvfn_flags(pTHX_ SV * const sv, const char * const pat, const STRLEN patlen, va_list * const args, SV ** const svargs, const Size_t sv_count, bool * const maybe_tainted, const U32 flags);
+Perl_sv_vcatpvfn_flags(pTHX_ SV * const sv, const char * const pat, const STRLEN patlen, va_list * const args, SV ** const svargs, const Size_t sv_count, bool * const maybe_tainted, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVFN_FLAGS      \
         assert(sv); assert(pat)
 
 PERL_CALLCONV void
-Perl_sv_vsetpvf(pTHX_ SV * const sv, const char * const pat, va_list * const args);
+Perl_sv_vsetpvf(pTHX_ SV * const sv, const char * const pat, va_list * const args)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VSETPVF             \
         assert(sv); assert(pat)
 
 PERL_CALLCONV void
-Perl_sv_vsetpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const args);
+Perl_sv_vsetpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const args)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VSETPVF_MG          \
         assert(sv); assert(pat)
 
 PERL_CALLCONV void
-Perl_sv_vsetpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patlen, va_list * const args, SV ** const svargs, const Size_t sv_count, bool * const maybe_tainted);
+Perl_sv_vsetpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patlen, va_list * const args, SV ** const svargs, const Size_t sv_count, bool * const maybe_tainted)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VSETPVFN            \
         assert(sv); assert(pat)
 
 PERL_CALLCONV const char *
-Perl_sv_vstring_get(pTHX_ SV * const sv, STRLEN *lenp);
+Perl_sv_vstring_get(pTHX_ SV * const sv, STRLEN *lenp)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_VSTRING_GET         \
         assert(sv)
 
@@ -5277,12 +6165,17 @@ Perl_sync_locale(pTHX);
 #define PERL_ARGS_ASSERT_SYNC_LOCALE
 
 PERL_CALLCONV void
-Perl_sys_init(int *argc, char ***argv);
+Perl_sys_init(int *argc, char ***argv)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2);
 #define PERL_ARGS_ASSERT_SYS_INIT               \
         assert(argc); assert(argv)
 
 PERL_CALLCONV void
-Perl_sys_init3(int *argc, char ***argv, char ***env);
+Perl_sys_init3(int *argc, char ***argv, char ***env)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(3);
 #define PERL_ARGS_ASSERT_SYS_INIT3              \
         assert(argc); assert(argv); assert(env)
 
@@ -5295,12 +6188,17 @@ Perl_taint_env(pTHX);
 #define PERL_ARGS_ASSERT_TAINT_ENV
 
 PERL_CALLCONV void
-Perl_taint_proper(pTHX_ const char *f, const char * const s);
+Perl_taint_proper(pTHX_ const char *f, const char * const s)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_TAINT_PROPER           \
         assert(s)
 
 PERL_CALLCONV OP *
 Perl_tied_method(pTHX_ SV *methname, SV **mark, SV * const sv, const MAGIC * const mg, const U32 flags, U32 argc, ...)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_TIED_METHOD            \
         assert(methname); assert(mark); assert(sv); assert(mg)
@@ -5313,42 +6211,62 @@ Perl_tmps_grow_p(pTHX_ SSize_t ix);
 Perl_to_uni_fold(pTHX_ UV c, U8 *p, STRLEN *lenp); */
 
 PERL_CALLCONV UV
-Perl_to_uni_fold_flags_(pTHX_ UV c, U8 *p, STRLEN *lenp, U8 flags);
+Perl_to_uni_fold_flags_(pTHX_ UV c, U8 *p, STRLEN *lenp, U8 flags)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_FOLD_FLAGS_     \
         assert(p); assert(lenp)
 
 PERL_CALLCONV UV
-Perl_to_uni_lower(pTHX_ UV c, U8 *p, STRLEN *lenp);
+Perl_to_uni_lower(pTHX_ UV c, U8 *p, STRLEN *lenp)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_LOWER           \
         assert(p); assert(lenp)
 
 PERL_CALLCONV UV
-Perl_to_uni_title(pTHX_ UV c, U8 *p, STRLEN *lenp);
+Perl_to_uni_title(pTHX_ UV c, U8 *p, STRLEN *lenp)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_TITLE           \
         assert(p); assert(lenp)
 
 PERL_CALLCONV UV
-Perl_to_uni_upper(pTHX_ UV c, U8 *p, STRLEN *lenp);
+Perl_to_uni_upper(pTHX_ UV c, U8 *p, STRLEN *lenp)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_UPPER           \
         assert(p); assert(lenp)
 
 PERL_CALLCONV UV
-Perl_to_utf8_fold_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, U8 flags);
+Perl_to_utf8_fold_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, U8 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UTF8_FOLD_FLAGS_    \
         assert(p); assert(e); assert(ustrp); assert(p < e)
 
 PERL_CALLCONV UV
-Perl_to_utf8_lower_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, bool flags);
+Perl_to_utf8_lower_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, bool flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UTF8_LOWER_FLAGS_   \
         assert(p); assert(e); assert(ustrp); assert(p < e)
 
 PERL_CALLCONV UV
-Perl_to_utf8_title_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, bool flags);
+Perl_to_utf8_title_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, bool flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UTF8_TITLE_FLAGS_   \
         assert(p); assert(e); assert(ustrp); assert(p < e)
 
 PERL_CALLCONV UV
-Perl_to_utf8_upper_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, bool flags);
+Perl_to_utf8_upper_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, bool flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UTF8_UPPER_FLAGS_   \
         assert(p); assert(e); assert(ustrp); assert(p < e)
 
@@ -5362,12 +6280,18 @@ Perl_try_amagic_un(pTHX_ int method, int flags);
 
 PERL_CALLCONV char *
 Perl_uiv_2buf(char * const buf, const IV iv, UV uv, const int is_uv, char ** const peob)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(5)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_UIV_2BUF               \
         assert(buf); assert(peob)
 
 PERL_CALLCONV SSize_t
-Perl_unpackstring(pTHX_ const char *pat, const char *patend, const char *s, const char *strend, U32 flags);
+Perl_unpackstring(pTHX_ const char *pat, const char *patend, const char *s, const char *strend, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4);
 #define PERL_ARGS_ASSERT_UNPACKSTRING           \
         assert(pat); assert(patend); assert(s); assert(strend); \
         assert(pat <= patend); assert(s <= strend)
@@ -5381,7 +6305,8 @@ Perl_unsharepvn(pTHX_ const char *sv, I32 len, U32 hash);
 #define PERL_ARGS_ASSERT_UNSHAREPVN
 
 PERL_CALLCONV SV *
-Perl_upg_version(pTHX_ SV *ver, bool qv);
+Perl_upg_version(pTHX_ SV *ver, bool qv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_UPG_VERSION            \
         assert(ver)
 
@@ -5402,17 +6327,24 @@ Perl_utf8_hop_safe(const U8 *s, SSize_t off, const U8 * const start, const U8 * 
 
 PERL_CALLCONV STRLEN
 Perl_utf8_length(pTHX_ const U8 *s0, const U8 *e)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_UTF8_LENGTH            \
         assert(s0); assert(e); assert(s0 <= e)
 
 PERL_CALLCONV U8 *
-Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp);
+Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_UTF8_TO_BYTES          \
         assert(s); assert(lenp)
 
 PERL_CALLCONV bool
-Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp, void **free_me, Perl_utf8_to_bytes_arg result_as);
+Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp, void **free_me, Perl_utf8_to_bytes_arg result_as)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_UTF8_TO_BYTES_         \
         assert(s_ptr); assert(lenp); assert(free_me)
 
@@ -5429,7 +6361,10 @@ Perl_utf8_to_uv_errors(const U8 * const s, const U8 * const e, UV *cp_p, Size_t 
 Perl_utf8_to_uv_flags(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags); */
 
 PERL_CALLCONV bool
-Perl_utf8_to_uv_msgs_helper_(const U8 * const s0, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors, AV **msgs);
+Perl_utf8_to_uv_msgs_helper_(const U8 * const s0, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors, AV **msgs)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(3);
 #define PERL_ARGS_ASSERT_UTF8_TO_UV_MSGS_HELPER_ \
         assert(s0); assert(e); assert(cp_p); assert(s0 <= e)
 
@@ -5441,6 +6376,7 @@ Perl_utf8n_to_uvchr_error(const U8 *s, STRLEN curlen, STRLEN *retlen, const U32 
 
 PERL_CALLCONV void
 Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_UTILIZE                \
         assert(idop)
@@ -5461,17 +6397,21 @@ Perl_uvchr_to_utf8_flags_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs); */
 Perl_uvoffuni_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags); */
 
 PERL_CALLCONV U8 *
-Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, const UV flags, HV **msgs);
+Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, const UV flags, HV **msgs)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_UVOFFUNI_TO_UTF8_FLAGS_MSGS \
         assert(d)
 
 PERL_CALLCONV bool
-Perl_valid_identifier_pve(pTHX_ const char *s, const char *end, U32 flags);
+Perl_valid_identifier_pve(pTHX_ const char *s, const char *end, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_VALID_IDENTIFIER_PVE   \
         assert(s); assert(end); assert(s <= end)
 
 PERL_CALLCONV bool
-Perl_valid_identifier_pvn(pTHX_ const char *s, STRLEN len, U32 flags);
+Perl_valid_identifier_pvn(pTHX_ const char *s, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VALID_IDENTIFIER_PVN   \
         assert(s)
 
@@ -5487,7 +6427,9 @@ Perl_valid_utf8_to_uvchr(const U8 *s, STRLEN *retlen)
         assert(name)
 
 PERL_CALLCONV int
-Perl_vcmp(pTHX_ SV *lhv, SV *rhv);
+Perl_vcmp(pTHX_ SV *lhv, SV *rhv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_VCMP                   \
         assert(lhv); assert(rhv)
 
@@ -5497,17 +6439,20 @@ Perl_vcroak(pTHX_ const char *pat, va_list *args)
 #define PERL_ARGS_ASSERT_VCROAK
 
 PERL_CALLCONV void
-Perl_vdeb(pTHX_ const char *pat, va_list *args);
+Perl_vdeb(pTHX_ const char *pat, va_list *args)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VDEB                   \
         assert(pat)
 
 PERL_CALLCONV void
-Perl_vfatal_warner(pTHX_ U32 err, const char *pat, va_list *args);
+Perl_vfatal_warner(pTHX_ U32 err, const char *pat, va_list *args)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_VFATAL_WARNER          \
         assert(pat)
 
 PERL_CALLCONV char *
-Perl_vform(pTHX_ const char *pat, va_list *args);
+Perl_vform(pTHX_ const char *pat, va_list *args)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VFORM                  \
         assert(pat)
 
@@ -5516,76 +6461,90 @@ Perl_vform(pTHX_ const char *pat, va_list *args);
 
 PERL_CALLCONV SV *
 Perl_vivify_ref(pTHX_ SV *sv, U32 to_what)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_VIVIFY_REF             \
         assert(sv)
 
 PERL_CALLCONV void
-Perl_vload_module(pTHX_ U32 flags, SV *name, SV *ver, va_list *args);
+Perl_vload_module(pTHX_ U32 flags, SV *name, SV *ver, va_list *args)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_VLOAD_MODULE           \
         assert(name)
 
 PERL_CALLCONV SV *
-Perl_vmess(pTHX_ const char *pat, va_list *args);
+Perl_vmess(pTHX_ const char *pat, va_list *args)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VMESS                  \
         assert(pat)
 
 PERL_CALLCONV SV *
 Perl_vnewSVpvf(pTHX_ const char * const pat, va_list * const args)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_VNEWSVPVF              \
         assert(pat)
 
 PERL_CALLCONV SV *
-Perl_vnormal(pTHX_ SV *vs);
+Perl_vnormal(pTHX_ SV *vs)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VNORMAL                \
         assert(vs)
 
 PERL_CALLCONV SV *
-Perl_vnumify(pTHX_ SV *vs);
+Perl_vnumify(pTHX_ SV *vs)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VNUMIFY                \
         assert(vs)
 
 PERL_CALLCONV SV *
-Perl_vstringify(pTHX_ SV *vs);
+Perl_vstringify(pTHX_ SV *vs)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VSTRINGIFY             \
         assert(vs)
 
 PERL_CALLCONV SV *
-Perl_vverify(pTHX_ SV *vs);
+Perl_vverify(pTHX_ SV *vs)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VVERIFY                \
         assert(vs)
 
 PERL_CALLCONV void
-Perl_vwarn(pTHX_ const char *pat, va_list *args);
+Perl_vwarn(pTHX_ const char *pat, va_list *args)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_VWARN                  \
         assert(pat)
 
 PERL_CALLCONV void
-Perl_vwarner(pTHX_ U32 err, const char *pat, va_list *args);
+Perl_vwarner(pTHX_ U32 err, const char *pat, va_list *args)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_VWARNER                \
         assert(pat)
 
 PERL_CALLCONV I32
 Perl_wait4pid(pTHX_ Pid_t pid, int *statusp, int flags)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_WAIT4PID               \
         assert(statusp)
 
 PERL_CALLCONV void
 Perl_warn(pTHX_ const char *pat, ...)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_WARN                   \
         assert(pat)
 
 PERL_CALLCONV void
-Perl_warn_sv(pTHX_ SV *baseex);
+Perl_warn_sv(pTHX_ SV *baseex)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_WARN_SV                \
         assert(baseex)
 
 PERL_CALLCONV void
 Perl_warner(pTHX_ U32 err, const char *pat, ...)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_WARNER                 \
         assert(pat)
@@ -5597,6 +6556,7 @@ Perl_was_lvalue_sub(pTHX)
 
 PERL_CALLCONV void
 Perl_watch(pTHX_ char **addr)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_WATCH                  \
         assert(addr)
@@ -5605,37 +6565,47 @@ Perl_watch(pTHX_ char **addr)
 Perl_whichsig(pTHX_ const char *sig); */
 
 PERL_CALLCONV I32
-Perl_whichsig_pv(pTHX_ const char *sig);
+Perl_whichsig_pv(pTHX_ const char *sig)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_WHICHSIG_PV            \
         assert(sig)
 
 PERL_CALLCONV I32
-Perl_whichsig_pvn(pTHX_ const char *sig, STRLEN len);
+Perl_whichsig_pvn(pTHX_ const char *sig, STRLEN len)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_WHICHSIG_PVN           \
         assert(sig)
 
 PERL_CALLCONV I32
-Perl_whichsig_sv(pTHX_ SV *sigsv);
+Perl_whichsig_sv(pTHX_ SV *sigsv)
+        Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_WHICHSIG_SV            \
         assert(sigsv)
 
 PERL_CALLCONV void
-Perl_wrap_infix_plugin(pTHX_ Perl_infix_plugin_t new_plugin, Perl_infix_plugin_t *old_plugin_p);
+Perl_wrap_infix_plugin(pTHX_ Perl_infix_plugin_t new_plugin, Perl_infix_plugin_t *old_plugin_p)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_WRAP_INFIX_PLUGIN      \
         assert(new_plugin); assert(old_plugin_p)
 
 PERL_CALLCONV void
-Perl_wrap_keyword_plugin(pTHX_ Perl_keyword_plugin_t new_plugin, Perl_keyword_plugin_t *old_plugin_p);
+Perl_wrap_keyword_plugin(pTHX_ Perl_keyword_plugin_t new_plugin, Perl_keyword_plugin_t *old_plugin_p)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_WRAP_KEYWORD_PLUGIN    \
         assert(new_plugin); assert(old_plugin_p)
 
 PERL_CALLCONV void
-Perl_wrap_op_checker(pTHX_ Optype opcode, Perl_check_t new_checker, Perl_check_t *old_checker_p);
+Perl_wrap_op_checker(pTHX_ Optype opcode, Perl_check_t new_checker, Perl_check_t *old_checker_p)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #define PERL_ARGS_ASSERT_WRAP_OP_CHECKER        \
         assert(new_checker); assert(old_checker_p)
 
 PERL_CALLCONV void
 Perl_write_to_stderr(pTHX_ SV *msv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_WRITE_TO_STDERR        \
         assert(msv)
@@ -5645,18 +6615,22 @@ Perl_xs_boot_epilog(pTHX_ const SSize_t ax);
 #define PERL_ARGS_ASSERT_XS_BOOT_EPILOG
 
 PERL_CALLCONV Stack_off_t
-Perl_xs_handshake(const U32 key, void *v_my_perl, const char *file, ...);
+Perl_xs_handshake(const U32 key, void *v_my_perl, const char *file, ...)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(3);
 #define PERL_ARGS_ASSERT_XS_HANDSHAKE           \
         assert(v_my_perl); assert(file)
 
 PERL_CALLCONV int
 Perl_yyerror(pTHX_ const char * const s)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYERROR                \
         assert(s)
 
 PERL_CALLCONV int
 Perl_yyerror_pv(pTHX_ const char * const s, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYERROR_PV             \
         assert(s)
@@ -5686,18 +6660,21 @@ Perl_yyunlex(pTHX)
 #if defined(DEBUGGING)
 PERL_CALLCONV int
 Perl_get_debug_opts(pTHX_ const char **s, bool givehelp)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_GET_DEBUG_OPTS        \
         assert(s)
 
 PERL_CALLCONV void
-Perl_hv_assert(pTHX_ HV *hv);
+Perl_hv_assert(pTHX_ HV *hv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_ASSERT             \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
-Perl_pad_setsv(pTHX_ PADOFFSET po, SV *sv);
+Perl_pad_setsv(pTHX_ PADOFFSET po, SV *sv)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_PAD_SETSV             \
         assert(sv)
 
@@ -5706,7 +6683,8 @@ Perl_pad_sv(pTHX_ PADOFFSET po);
 # define PERL_ARGS_ASSERT_PAD_SV
 
 PERL_CALLCONV void
-Perl_set_padlist(CV *cv, PADLIST *padlist);
+Perl_set_padlist(CV *cv, PADLIST *padlist)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_SET_PADLIST           \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
@@ -5714,6 +6692,7 @@ Perl_set_padlist(CV *cv, PADLIST *padlist);
 #if defined(DEBUG_LEAKING_SCALARS_FORK_DUMP)
 PERL_CALLCONV void
 Perl_dump_sv_child(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DUMP_SV_CHILD         \
         assert(sv)
@@ -5729,14 +6708,17 @@ Perl_my_chsize(pTHX_ int fd, Off_t length)
 #if !defined(HAS_GETENV_LEN)
 PERL_CALLCONV char *
 Perl_getenv_len(pTHX_ const char *env_elem, unsigned long *len)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_GETENV_LEN            \
         assert(env_elem); assert(len)
 
-#endif
+#endif /* !defined(HAS_GETENV_LEN) */
 #if !defined(HAS_MKOSTEMP)
 PERL_CALLCONV int
 Perl_my_mkostemp(char *templte, int flags)
+        Perl_attribute_nonnull_(1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MY_MKOSTEMP           \
         assert(templte)
@@ -5745,6 +6727,7 @@ Perl_my_mkostemp(char *templte, int flags)
 #if !defined(HAS_MKSTEMP)
 PERL_CALLCONV int
 Perl_my_mkstemp(char *templte)
+        Perl_attribute_nonnull_(1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MY_MKSTEMP            \
         assert(templte)
@@ -5753,36 +6736,48 @@ Perl_my_mkstemp(char *templte)
 #if defined(HAS_MSG) || defined(HAS_SEM) || defined(HAS_SHM)
 PERL_CALLCONV I32
 Perl_do_ipcctl(pTHX_ I32 optype, SV **mark, SV **sp)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_IPCCTL             \
         assert(mark); assert(sp)
 
 PERL_CALLCONV I32
 Perl_do_ipcget(pTHX_ I32 optype, SV **mark, SV **sp)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_IPCGET             \
         assert(mark); assert(sp)
 
 PERL_CALLCONV SSize_t
 Perl_do_msgrcv(pTHX_ SV **mark, SV **sp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_MSGRCV             \
         assert(mark); assert(sp)
 
 PERL_CALLCONV I32
 Perl_do_msgsnd(pTHX_ SV **mark, SV **sp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_MSGSND             \
         assert(mark); assert(sp)
 
 PERL_CALLCONV I32
 Perl_do_semop(pTHX_ SV **mark, SV **sp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_SEMOP              \
         assert(mark); assert(sp)
 
 PERL_CALLCONV I32
 Perl_do_shmio(pTHX_ I32 optype, SV **mark, SV **sp)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_SHMIO              \
         assert(mark); assert(sp)
@@ -5791,20 +6786,23 @@ Perl_do_shmio(pTHX_ I32 optype, SV **mark, SV **sp)
 #if defined(HAS_PIPE)
 PERL_CALLCONV int
 Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PERLPROC_PIPE_CLOEXEC \
         assert(pipefd)
 
-#endif
+#endif /* defined(HAS_PIPE) */
 #if !defined(HAS_RENAME)
 PERL_CALLCONV I32
 Perl_same_dirent(pTHX_ const char *a, const char *b)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SAME_DIRENT           \
         assert(a); assert(b)
 
-#endif
+#endif /* !defined(HAS_RENAME) */
 #if !defined(HAS_SIGNBIT)
 PERL_CALLCONV int
 Perl_signbit(NV f)
@@ -5832,18 +6830,32 @@ Perl_PerlSock_socket_cloexec(pTHX_ int domain, int type, int protocol)
       defined(SOCK_DGRAM) )
 PERL_CALLCONV int
 Perl_PerlSock_socketpair_cloexec(pTHX_ int domain, int type, int protocol, int *pairfd)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PERLSOCK_SOCKETPAIR_CLOEXEC \
         assert(pairfd)
 
-#endif
+#endif /*   defined(HAS_SOCKETPAIR) ||
+          ( defined(AF_INET) && defined(HAS_SOCKET) && defined(PF_INET) &&
+            defined(SOCK_DGRAM) ) */
 #if !defined(HAS_STRLCPY)
 static Size_t
 Perl_my_strlcpy(char *dst, const char *src, Size_t size);
 # define PERL_ARGS_ASSERT_MY_STRLCPY
 
 #endif
+#if !defined(HAS_STRNLEN)
+
+# if !defined(PERL_NO_INLINE_FUNCTIONS)
+PERL_STATIC_INLINE Size_t
+Perl_my_strnlen(const char *str, Size_t maxlen)
+        Perl_attribute_nonnull_(1);
+#   define PERL_ARGS_ASSERT_MY_STRNLEN          \
+        assert(str)
+
+# endif
+#endif /* !defined(HAS_STRNLEN) */
 #if defined(HAVE_INTERP_INTERN)
 PERL_CALLCONV void
 Perl_sys_intern_clear(pTHX);
@@ -5855,7 +6867,9 @@ Perl_sys_intern_init(pTHX);
 
 # if defined(USE_ITHREADS)
 PERL_CALLCONV void
-Perl_sys_intern_dup(pTHX_ struct interp_intern *src, struct interp_intern *dst);
+Perl_sys_intern_dup(pTHX_ struct interp_intern *src, struct interp_intern *dst)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_SYS_INTERN_DUP      \
         assert(src); assert(dst)
 
@@ -5864,19 +6878,23 @@ Perl_sys_intern_dup(pTHX_ struct interp_intern *src, struct interp_intern *dst);
 #if defined(_MSC_VER)
 PERL_CALLCONV int
 Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MAGIC_REGDATUM_SET    \
         assert(sv); assert(mg)
 
-#else
+#else /* if !defined(_MSC_VER) */
 PERL_CALLCONV_NO_RET int
 Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__noreturn__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MAGIC_REGDATUM_SET    \
         assert(sv); assert(mg)
 
-#endif
+#endif /* !defined(_MSC_VER) */
 #if defined(MULTIPLICITY)
 PERL_CALLCONV_NO_RET void
 Perl_croak_nocontext(const char *pat, ...)
@@ -5886,6 +6904,7 @@ Perl_croak_nocontext(const char *pat, ...)
 
 PERL_CALLCONV void
 Perl_deb_nocontext(const char *pat, ...)
+        Perl_attribute_nonnull_(1)
         __attribute__format__(__printf__,1,2);
 # define PERL_ARGS_ASSERT_DEB_NOCONTEXT         \
         assert(pat)
@@ -5898,64 +6917,79 @@ Perl_die_nocontext(const char *pat, ...)
 
 PERL_CALLCONV char *
 Perl_form_nocontext(const char *pat, ...)
+        Perl_attribute_nonnull_(1)
         __attribute__format__(__printf__,1,2);
 # define PERL_ARGS_ASSERT_FORM_NOCONTEXT        \
         assert(pat)
 
 PERL_CALLCONV void
-Perl_load_module_nocontext(U32 flags, SV *name, SV *ver, ...);
+Perl_load_module_nocontext(U32 flags, SV *name, SV *ver, ...)
+        Perl_attribute_nonnull_(2);
 # define PERL_ARGS_ASSERT_LOAD_MODULE_NOCONTEXT \
         assert(name)
 
 PERL_CALLCONV SV *
 Perl_mess_nocontext(const char *pat, ...)
+        Perl_attribute_nonnull_(1)
         __attribute__format__(__printf__,1,2);
 # define PERL_ARGS_ASSERT_MESS_NOCONTEXT        \
         assert(pat)
 
 PERL_CALLCONV void *
-Perl_my_cxt_init(pTHX_ int *indexp, size_t size);
+Perl_my_cxt_init(pTHX_ int *indexp, size_t size)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_MY_CXT_INIT           \
         assert(indexp)
 
 PERL_CALLCONV SV *
 Perl_newSVpvf_nocontext(const char * const pat, ...)
+        Perl_attribute_nonnull_(1)
         __attribute__format__(__printf__,1,2);
 # define PERL_ARGS_ASSERT_NEWSVPVF_NOCONTEXT    \
         assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_catpvf_mg_nocontext(SV * const sv, const char * const pat, ...)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__format__(__printf__,2,3);
 # define PERL_ARGS_ASSERT_SV_CATPVF_MG_NOCONTEXT \
         assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_catpvf_nocontext(SV * const sv, const char * const pat, ...)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__format__(__printf__,2,3);
 # define PERL_ARGS_ASSERT_SV_CATPVF_NOCONTEXT   \
         assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_setpvf_mg_nocontext(SV * const sv, const char * const pat, ...)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__format__(__printf__,2,3);
 # define PERL_ARGS_ASSERT_SV_SETPVF_MG_NOCONTEXT \
         assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_setpvf_nocontext(SV * const sv, const char * const pat, ...)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__format__(__printf__,2,3);
 # define PERL_ARGS_ASSERT_SV_SETPVF_NOCONTEXT   \
         assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_warn_nocontext(const char *pat, ...)
+        Perl_attribute_nonnull_(1)
         __attribute__format__(__printf__,1,2);
 # define PERL_ARGS_ASSERT_WARN_NOCONTEXT        \
         assert(pat)
 
 PERL_CALLCONV void
 Perl_warner_nocontext(U32 err, const char *pat, ...)
+        Perl_attribute_nonnull_(2)
         __attribute__format__(__printf__,2,3);
 # define PERL_ARGS_ASSERT_WARNER_NOCONTEXT      \
         assert(pat)
@@ -5963,12 +6997,14 @@ Perl_warner_nocontext(U32 err, const char *pat, ...)
 #endif /* defined(MULTIPLICITY) */
 #if defined(MYMALLOC)
 PERL_CALLCONV void
-Perl_dump_mstats(pTHX_ const char *s);
+Perl_dump_mstats(pTHX_ const char *s)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DUMP_MSTATS           \
         assert(s)
 
 PERL_CALLCONV int
-Perl_get_mstats(pTHX_ perl_mstats_t *buf, int buflen, int level);
+Perl_get_mstats(pTHX_ perl_mstats_t *buf, int buflen, int level)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_GET_MSTATS            \
         assert(buf)
 
@@ -5980,6 +7016,7 @@ Perl_malloc_good_size(size_t nbytes)
 
 PERL_CALLCONV MEM_SIZE
 Perl_malloced_size(void *p)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MALLOCED_SIZE         \
@@ -5993,24 +7030,28 @@ Perl_load_mathoms(void);
 
 PERL_CALLCONV UV
 Perl_utf8_to_uvchr(pTHX_ const U8 *s, STRLEN *retlen)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UTF8_TO_UVCHR         \
         assert(s)
 
 PERL_CALLCONV UV
 Perl_utf8_to_uvuni(pTHX_ const U8 *s, STRLEN *retlen)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UTF8_TO_UVUNI         \
         assert(s)
 
 PERL_CALLCONV UV
 Perl_utf8n_to_uvuni(pTHX_ const U8 *s, STRLEN curlen, STRLEN *retlen, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UTF8N_TO_UVUNI        \
         assert(s)
 
 PERL_CALLCONV U8 *
 Perl_uvuni_to_utf8(pTHX_ U8 *d, UV uv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UVUNI_TO_UTF8         \
         assert(d)
@@ -6029,42 +7070,50 @@ Perl_ref(pTHX_ OP *o, I32 type);
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
-Perl_sv_setsv_cow(pTHX_ SV *dsv, SV *ssv);
+Perl_sv_setsv_cow(pTHX_ SV *dsv, SV *ssv)
+        Perl_attribute_nonnull_(pTHX_2);
 # endif
-#endif
+#endif /* defined(PERL_ANY_COW) */
 #if defined(PERL_CORE)
 PERL_CALLCONV void
 Perl_opslab_force_free(pTHX_ OPSLAB *slab)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OPSLAB_FORCE_FREE     \
         assert(slab)
 
 PERL_CALLCONV void
 Perl_opslab_free(pTHX_ OPSLAB *slab)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OPSLAB_FREE           \
         assert(slab)
 
 PERL_CALLCONV void
 Perl_opslab_free_nopad(pTHX_ OPSLAB *slab)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OPSLAB_FREE_NOPAD     \
         assert(slab)
 
 PERL_CALLCONV void
 Perl_parser_free_nexttoke_ops(pTHX_ yy_parser *parser, OPSLAB *slab)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PARSER_FREE_NEXTTOKE_OPS \
         assert(parser); assert(slab)
 
 # if defined(PERL_DEBUG_READONLY_OPS)
 PERL_CALLCONV void
-Perl_Slab_to_ro(pTHX_ OPSLAB *slab);
+Perl_Slab_to_ro(pTHX_ OPSLAB *slab)
+        Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_SLAB_TO_RO          \
         assert(slab)
 
 PERL_CALLCONV void
-Perl_Slab_to_rw(pTHX_ OPSLAB * const slab);
+Perl_Slab_to_rw(pTHX_ OPSLAB * const slab)
+        Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_SLAB_TO_RW          \
         assert(slab)
 
@@ -6072,6 +7121,7 @@ Perl_Slab_to_rw(pTHX_ OPSLAB * const slab);
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE bool
 S_should_warn_nl(const char *pv)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_SHOULD_WARN_NL      \
         assert(pv)
@@ -6080,7 +7130,8 @@ S_should_warn_nl(const char *pv)
 #endif /* defined(PERL_CORE) */
 #if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
-Perl_av_reify(pTHX_ AV *av);
+Perl_av_reify(pTHX_ AV *av)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV const char *
 Perl_byte_dump_string_(pTHX_ const U8 * const start, const STRLEN len, const bool format);
 PERL_CALLCONV const char *
@@ -6089,21 +7140,33 @@ Perl_cntrl_to_mnemonic(const U8 c)
 PERL_CALLCONV regexp_engine const *
 Perl_current_re_engine(pTHX);
 PERL_CALLCONV void
-Perl_cv_ckproto_len_flags(pTHX_ const CV *cv, const GV *gv, const char *p, const STRLEN len, const U32 flags);
+Perl_cv_ckproto_len_flags(pTHX_ const CV *cv, const GV *gv, const char *p, const STRLEN len, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV char *
-Perl_delimcpy_no_escape(char *to, const char *to_end, const char *from, const char *from_end, const int delim, I32 *retlen);
+Perl_delimcpy_no_escape(char *to, const char *to_end, const char *from, const char *from_end, const int delim, I32 *retlen)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(3)
+        Perl_attribute_nonnull_(4)
+        Perl_attribute_nonnull_(6);
 PERL_CALLCONV I16
 Perl_do_uniprop_match(const char * const key, const U16 key_len)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 PERL_CALLCONV char  *
 Perl_dup_warnings(pTHX_ char *warnings);
 PERL_CALLCONV void
-Perl_emulate_cop_io(pTHX_ const COP * const c, SV * const sv);
+Perl_emulate_cop_io(pTHX_ const COP * const c, SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 PERL_CALLCONV Size_t
 Perl_expected_size(UV size)
         __attribute__visibility__("hidden");
 PERL_CALLCONV SV *
 Perl_get_and_check_backslash_N_name(pTHX_ const char *s, const char *e, const bool is_utf8, const char **error_msg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 PERL_CALLCONV const char *
 Perl_get_deprecated_property_msg(const Size_t warning_offset)
@@ -6116,82 +7179,123 @@ Perl_get_prop_values(const int table_index)
         __attribute__warn_unused_result__;
 PERL_CALLCONV Size_t
 Perl_inverse_folds_(pTHX_ const UV cp, U32 *first_folds_to, const U32 **remaining_folds_to)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 PERL_CALLCONV HV *
 Perl_load_charnames(pTHX_ SV *char_name, const char *context, const STRLEN context_len, const char **error_msg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 PERL_CALLCONV int
 Perl_mbtowc_(pTHX_ const wchar_t *pwc, const char *s, const Size_t len);
 PERL_CALLCONV MAGIC *
 Perl_mg_find_mglob(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 PERL_CALLCONV SV *
-Perl_multiconcat_stringify(pTHX_ const OP *o);
+Perl_multiconcat_stringify(pTHX_ const OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV SV *
-Perl_multideref_stringify(pTHX_ const OP *o, CV *cv);
+Perl_multideref_stringify(pTHX_ const OP *o, CV *cv)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV char *
 Perl_new_warnings_bitfield(pTHX_ char *buffer, const char * const bits, STRLEN size)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 PERL_CALLCONV void
-Perl_op_clear(pTHX_ OP *o);
+Perl_op_clear(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV char *
-Perl_parse_ident_msg(pTHX_ const char *s, const char *end, bool is_utf8, HV **failure_details, U32 flags);
+Perl_parse_ident_msg(pTHX_ const char *s, const char *end, bool is_utf8, HV **failure_details, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 PERL_CALLCONV void
 Perl_qerror(pTHX_ SV *err);
 PERL_CALLCONV SV *
-Perl_reg_named_buff(pTHX_ REGEXP * const rx, SV * const key, SV * const value, const U32 flags);
+Perl_reg_named_buff(pTHX_ REGEXP * const rx, SV * const key, SV * const value, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV SV *
-Perl_reg_named_buff_iter(pTHX_ REGEXP * const rx, const SV * const lastkey, const U32 flags);
+Perl_reg_named_buff_iter(pTHX_ REGEXP * const rx, const SV * const lastkey, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV void
-Perl_reg_numbered_buff_fetch(pTHX_ REGEXP * const re, const I32 paren, SV * const sv);
+Perl_reg_numbered_buff_fetch(pTHX_ REGEXP * const re, const I32 paren, SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV void
-Perl_reg_numbered_buff_fetch_flags(pTHX_ REGEXP * const re, const I32 paren, SV * const sv, U32 flags);
+Perl_reg_numbered_buff_fetch_flags(pTHX_ REGEXP * const re, const I32 paren, SV * const sv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV I32
-Perl_reg_numbered_buff_length(pTHX_ REGEXP * const rx, const SV * const sv, const I32 paren);
+Perl_reg_numbered_buff_length(pTHX_ REGEXP * const rx, const SV * const sv, const I32 paren)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 PERL_CALLCONV void
-Perl_reg_numbered_buff_store(pTHX_ REGEXP * const rx, const I32 paren, SV const * const value);
+Perl_reg_numbered_buff_store(pTHX_ REGEXP * const rx, const I32 paren, SV const * const value)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV SV *
-Perl_reg_qr_package(pTHX_ REGEXP * const rx);
+Perl_reg_qr_package(pTHX_ REGEXP * const rx)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV REGEXP *
-Perl_reg_temp_copy(pTHX_ REGEXP *dsv, REGEXP *ssv);
+Perl_reg_temp_copy(pTHX_ REGEXP *dsv, REGEXP *ssv)
+        Perl_attribute_nonnull_(pTHX_2);
 PERL_CALLCONV void
 Perl_report_uninit(pTHX_ const SV *uninit_sv);
 PERL_CALLCONV char *
 Perl_scan_str(pTHX_ char *start, int keep_quoted, int keep_delims, int re_reparse, char **delimp)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 PERL_CALLCONV char *
-Perl_scan_word(pTHX_ char *s, char *dest, STRLEN destlen, int allow_package, STRLEN *slp);
+Perl_scan_word(pTHX_ char *s, char *dest, STRLEN destlen, int allow_package, STRLEN *slp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_5);
 PERL_CALLCONV char *
 Perl_skipspace_flags(pTHX_ char *s, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 PERL_CALLCONV MAGIC *
-Perl_sv_magicext_mglob(pTHX_ SV *sv);
+Perl_sv_magicext_mglob(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 /* PERL_CALLCONV U8 *
 Perl_utf16_to_utf8(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen); */
 PERL_CALLCONV U8 *
-Perl_utf16_to_utf8_base(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low);
+Perl_utf16_to_utf8_base(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_4);
 /* PERL_CALLCONV U8 *
 Perl_utf16_to_utf8_reversed(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen); */
 PERL_CALLCONV U8 *
-Perl_utf8_to_utf16_base(pTHX_ U8 *s, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low);
+Perl_utf8_to_utf16_base(pTHX_ U8 *s, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_4);
 PERL_CALLCONV bool
-Perl_validate_proto(pTHX_ SV *name, SV *proto, bool warn, bool curstash);
+Perl_validate_proto(pTHX_ SV *name, SV *proto, bool warn, bool curstash)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV void
-Perl_vivify_defelem(pTHX_ SV *sv);
+Perl_vivify_defelem(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV int
 Perl_yylex(pTHX);
 PERL_CALLCONV bool
 Perl_isSCRIPT_RUN(pTHX_ const U8 *s, const U8 *send, const bool utf8_target)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ISSCRIPT_RUN          \
         assert(s); assert(send); assert(s <= send)
 
+# if !defined(HAS_MEMRCHR)
+
+# endif
 # if defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
      defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
      defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
      defined(PERL_IN_UTF8_C)
 PERL_CALLCONV SSize_t
 Perl_invlist_search_(SV * const invlist, const UV cp)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 # endif
 # if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
@@ -6202,20 +7306,26 @@ Perl_add_range_to_invlist_(pTHX_ SV *invlist, UV start, UV end)
 /* PERL_CALLCONV void
 invlist_intersection_(pTHX_ SV * const a, SV * const b, SV **i); */
 PERL_CALLCONV void
-Perl_invlist_intersection_maybe_complement_2nd_(pTHX_ SV * const a, SV * const b, const bool complement_b, SV **i);
+Perl_invlist_intersection_maybe_complement_2nd_(pTHX_ SV * const a, SV * const b, const bool complement_b, SV **i)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_4);
 PERL_CALLCONV void
-Perl_invlist_invert_(pTHX_ SV * const invlist);
+Perl_invlist_invert_(pTHX_ SV * const invlist)
+        Perl_attribute_nonnull_(pTHX_1);
 /* PERL_CALLCONV void
 invlist_subtract_(pTHX_ SV * const a, SV * const b, SV **result); */
 /* PERL_CALLCONV void
 invlist_union_(pTHX_ SV * const a, SV * const b, SV **output); */
 PERL_CALLCONV void
-Perl_invlist_union_maybe_complement_2nd_(pTHX_ SV * const a, SV * const b, const bool complement_b, SV **output);
+Perl_invlist_union_maybe_complement_2nd_(pTHX_ SV * const a, SV * const b, const bool complement_b, SV **output)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_4);
 PERL_CALLCONV SV *
 Perl_new_invlist_(pTHX_ IV initial_size)
         __attribute__warn_unused_result__;
 PERL_CALLCONV SV *
 Perl_setup_canned_invlist_(pTHX_ const STRLEN size, const UV element0, UV **other_elements_ptr)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 # endif /* defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) ||
            defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C) */
@@ -6223,15 +7333,27 @@ Perl_setup_canned_invlist_(pTHX_ const STRLEN size, const UV element0, UV **othe
      defined(PERL_IN_TOKE_C)
 PERL_CALLCONV const char *
 Perl_form_alien_digit_msg(pTHX_ const U8 which, const STRLEN valids_len, const char * const first_bad, const char * const send, const bool UTF, const bool braced)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 PERL_CALLCONV bool
 Perl_grok_bslash_c(pTHX_ const char source, U8 *result, const char **message, U32 *packed_warn)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 PERL_CALLCONV bool
 Perl_grok_bslash_o(pTHX_ char **s, const char * const send, UV *uv, const char **message, U32 *packed_warn, const bool strict, const bool allow_UV_MAX, const bool utf8)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 PERL_CALLCONV bool
 Perl_grok_bslash_x(pTHX_ char **s, const char * const send, UV *uv, const char **message, U32 *packed_warn, const bool strict, const bool allow_UV_MAX, const bool utf8)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 # endif /* defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) ||
            defined(PERL_IN_TOKE_C) */
@@ -6244,39 +7366,56 @@ Perl_form_cp_too_large_msg(pTHX_ const U8 which, const char *string, const Size_
 # if defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) || \
      defined(PERL_IN_REGCOMP_ANY)
 PERL_CALLCONV void
-Perl_invlist_dump_(pTHX_ PerlIO *file, I32 level, const char * const indent, SV * const invlist);
+Perl_invlist_dump_(pTHX_ PerlIO *file, I32 level, const char * const indent, SV * const invlist)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4);
 # endif
 # if defined(PERL_IN_PERL_C) || defined(PERL_IN_REGCOMP_ANY) || \
      defined(PERL_IN_UTF8_C)
 PERL_CALLCONV bool
-Perl_invlistEQ_(pTHX_ SV * const a, SV * const b, const bool complement_b);
+Perl_invlistEQ_(pTHX_ SV * const a, SV * const b, const bool complement_b)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 PERL_CALLCONV SV *
 Perl_new_invlist_C_array_(pTHX_ const UV * const list)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # endif
 # if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
      defined(PERL_IN_TOKE_C)
 PERL_CALLCONV bool
 Perl_is_grapheme(pTHX_ const U8 *strbeg, const U8 *s, const U8 *strend, const UV cp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # endif
 # if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
      defined(PERL_IN_UTF8_C)
 PERL_CALLCONV UV
-Perl_to_fold_latin1_(const U8 c, U8 *p, STRLEN *lenp, const unsigned int flags);
+Perl_to_fold_latin1_(const U8 c, U8 *p, STRLEN *lenp, const unsigned int flags)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(3);
 # endif
 # if defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING)
 static U8
-S_put_charclass_bitmap_innards(pTHX_ SV *sv, char *bitmap, SV *nonbitmap_invlist, SV *only_utf8_locale_invlist, const regnode * const node, const U8 flags, const bool force_as_is_display);
+S_put_charclass_bitmap_innards(pTHX_ SV *sv, char *bitmap, SV *nonbitmap_invlist, SV *only_utf8_locale_invlist, const regnode * const node, const U8 flags, const bool force_as_is_display)
+        Perl_attribute_nonnull_(pTHX_1);
 static SV *
-S_put_charclass_bitmap_innards_common(pTHX_ SV *invlist, SV *posixes, SV *only_utf8, SV *not_utf8, SV *only_utf8_locale, const bool invert);
+S_put_charclass_bitmap_innards_common(pTHX_ SV *invlist, SV *posixes, SV *only_utf8, SV *not_utf8, SV *only_utf8_locale, const bool invert)
+        Perl_attribute_nonnull_(pTHX_1);
 static void
-S_put_charclass_bitmap_innards_invlist(pTHX_ SV *sv, SV *invlist);
+S_put_charclass_bitmap_innards_invlist(pTHX_ SV *sv, SV *invlist)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 static void
-S_put_code_point(pTHX_ SV *sv, UV c);
+S_put_code_point(pTHX_ SV *sv, UV c)
+        Perl_attribute_nonnull_(pTHX_1);
 static void
-S_put_range(pTHX_ SV *sv, UV start, const UV end, const bool allow_literals);
+S_put_range(pTHX_ SV *sv, UV start, const UV end, const bool allow_literals)
+        Perl_attribute_nonnull_(pTHX_1);
 static void
 S_regdump_extflags(pTHX_ const char *lead, const U32 flags);
 static void
@@ -6285,12 +7424,14 @@ S_regdump_intflags(pTHX_ const char *lead, const U32 flags);
 #endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 #if defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API)
 PERL_CALLCONV void
-Perl_finalize_optree(pTHX_ OP *o);
+Perl_finalize_optree(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FINALIZE_OPTREE       \
         assert(o)
 
 PERL_CALLCONV void
-Perl_optimize_optree(pTHX_ OP *o);
+Perl_optimize_optree(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_OPTIMIZE_OPTREE       \
         assert(o)
 
@@ -6298,6 +7439,7 @@ Perl_optimize_optree(pTHX_ OP *o);
 #if defined(PERL_DEBUG_READONLY_COW)
 PERL_CALLCONV void
 Perl_sv_buf_to_ro(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SV_BUF_TO_RO          \
         assert(sv)
@@ -6305,7 +7447,8 @@ Perl_sv_buf_to_ro(pTHX_ SV *sv)
 #endif
 #if defined(PERL_DEBUG_READONLY_OPS)
 PERL_CALLCONV PADOFFSET
-Perl_op_refcnt_dec(pTHX_ OP *o);
+Perl_op_refcnt_dec(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_OP_REFCNT_DEC         \
         assert(o)
 
@@ -6317,6 +7460,7 @@ Perl_op_refcnt_inc(pTHX_ OP *o);
 #if defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION)
 PERL_CALLCONV bool
 Perl_do_exec(pTHX_ const char *cmd)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_EXEC               \
         assert(cmd)
@@ -6324,6 +7468,7 @@ Perl_do_exec(pTHX_ const char *cmd)
 #else
 PERL_CALLCONV bool
 Perl_do_exec(pTHX_ const char *cmd)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_EXEC               \
         assert(cmd)
@@ -6336,33 +7481,66 @@ Perl_gv_SVadd(pTHX_ GV *gv); */
 #endif
 #if defined(PERL_IMPLICIT_SYS)
 PERL_CALLCONV PerlInterpreter *
-perl_alloc_using(const struct IPerlMem **ipM, const struct IPerlMem **ipMS, const struct IPerlMem **ipMP, const struct IPerlEnv **ipE, const struct IPerlStdIO **ipStd, const struct IPerlLIO **ipLIO, const struct IPerlDir **ipD, const struct IPerlSock **ipS, const struct IPerlProc **ipP);
+perl_alloc_using(const struct IPerlMem **ipM, const struct IPerlMem **ipMS, const struct IPerlMem **ipMP, const struct IPerlEnv **ipE, const struct IPerlStdIO **ipStd, const struct IPerlLIO **ipLIO, const struct IPerlDir **ipD, const struct IPerlSock **ipS, const struct IPerlProc **ipP)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(3)
+        Perl_attribute_nonnull_(4)
+        Perl_attribute_nonnull_(5)
+        Perl_attribute_nonnull_(6)
+        Perl_attribute_nonnull_(7)
+        Perl_attribute_nonnull_(8)
+        Perl_attribute_nonnull_(9);
 # define PERL_ARGS_ASSERT_PERL_ALLOC_USING      \
         assert(ipM); assert(ipMS); assert(ipMP); assert(ipE); assert(ipStd); \
         assert(ipLIO); assert(ipD); assert(ipS); assert(ipP)
 
 # if defined(USE_ITHREADS)
 PERL_CALLCONV PerlInterpreter *
-perl_clone_using(PerlInterpreter *proto_perl, UV flags, const struct IPerlMem **ipM, const struct IPerlMem **ipMS, const struct IPerlMem **ipMP, const struct IPerlEnv **ipE, const struct IPerlStdIO **ipStd, const struct IPerlLIO **ipLIO, const struct IPerlDir **ipD, const struct IPerlSock **ipS, const struct IPerlProc **ipP);
+perl_clone_using(PerlInterpreter *proto_perl, UV flags, const struct IPerlMem **ipM, const struct IPerlMem **ipMS, const struct IPerlMem **ipMP, const struct IPerlEnv **ipE, const struct IPerlStdIO **ipStd, const struct IPerlLIO **ipLIO, const struct IPerlDir **ipD, const struct IPerlSock **ipS, const struct IPerlProc **ipP)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(3)
+        Perl_attribute_nonnull_(4)
+        Perl_attribute_nonnull_(5)
+        Perl_attribute_nonnull_(6)
+        Perl_attribute_nonnull_(7)
+        Perl_attribute_nonnull_(8)
+        Perl_attribute_nonnull_(9)
+        Perl_attribute_nonnull_(10)
+        Perl_attribute_nonnull_(11);
 #   define PERL_ARGS_ASSERT_PERL_CLONE_USING    \
         assert(proto_perl); assert(ipM); assert(ipMS); assert(ipMP); assert(ipE); \
         assert(ipStd); assert(ipLIO); assert(ipD); assert(ipS); assert(ipP)
 
-# endif
+# endif /* defined(USE_ITHREADS) */
 #else /* if !defined(PERL_IMPLICIT_SYS) */
 PERL_CALLCONV I32
 Perl_my_pclose(pTHX_ PerlIO *ptr);
 # define PERL_ARGS_ASSERT_MY_PCLOSE
 
 PERL_CALLCONV PerlIO *
-Perl_my_popen(pTHX_ const char *cmd, const char *mode);
+Perl_my_popen(pTHX_ const char *cmd, const char *mode)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_MY_POPEN              \
         assert(cmd); assert(mode)
 
+# if defined(USE_ITHREADS)
+
+#   if !defined(PERL_NO_INLINE_FUNCTIONS)
+PERL_STATIC_INLINE bool
+S_PerlEnv_putenv(pTHX_ char *str)
+        Perl_attribute_nonnull_(pTHX_1);
+#     define PERL_ARGS_ASSERT_PERLENV_PUTENV    \
+        assert(str)
+
+#   endif
+# endif /* defined(USE_ITHREADS) */
 #endif /* !defined(PERL_IMPLICIT_SYS) */
 #if defined(PERL_IN_AV_C)
 static MAGIC *
-S_get_aux_mg(pTHX_ AV *av);
+S_get_aux_mg(pTHX_ AV *av)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_GET_AUX_MG            \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
@@ -6370,6 +7548,7 @@ S_get_aux_mg(pTHX_ AV *av);
 #if defined(PERL_IN_BUILTIN_C) || defined(PERL_IN_OP_C)
 PERL_CALLCONV void
 Perl_XS_builtin_indexed(pTHX_ CV *cv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_XS_BUILTIN_INDEXED    \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
@@ -6392,7 +7571,8 @@ Perl_prepare_export_lexical(pTHX)
 #endif /* defined(PERL_IN_BUILTIN_C) || defined(PERL_IN_OP_C) */
 #if defined(PERL_IN_CLASS_C)
 static void
-S_class_cleanup_definition(pTHX_ HV *stash);
+S_class_cleanup_definition(pTHX_ HV *stash)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_CLEANUP_DEFINITION \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
@@ -6401,6 +7581,7 @@ S_class_cleanup_definition(pTHX_ HV *stash);
     defined(PERL_IN_OP_C)    || defined(PERL_IN_PEEP_C)
 PERL_CALLCONV OP *
 Perl_ck_anoncode(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_ANONCODE           \
@@ -6408,6 +7589,7 @@ Perl_ck_anoncode(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_backtick(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_BACKTICK           \
@@ -6415,6 +7597,7 @@ Perl_ck_backtick(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_bitop(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_BITOP              \
@@ -6422,6 +7605,7 @@ Perl_ck_bitop(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_classname(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_CLASSNAME          \
@@ -6429,6 +7613,7 @@ Perl_ck_classname(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_cmp(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_CMP                \
@@ -6436,6 +7621,7 @@ Perl_ck_cmp(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_concat(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_CONCAT             \
@@ -6443,6 +7629,7 @@ Perl_ck_concat(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_defined(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_DEFINED            \
@@ -6450,6 +7637,7 @@ Perl_ck_defined(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_delete(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_DELETE             \
@@ -6457,6 +7645,7 @@ Perl_ck_delete(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_each(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_EACH               \
@@ -6464,6 +7653,7 @@ Perl_ck_each(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_eof(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_EOF                \
@@ -6471,6 +7661,7 @@ Perl_ck_eof(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_eval(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_EVAL               \
@@ -6478,6 +7669,7 @@ Perl_ck_eval(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_exec(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_EXEC               \
@@ -6485,6 +7677,7 @@ Perl_ck_exec(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_exists(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_EXISTS             \
@@ -6492,6 +7685,7 @@ Perl_ck_exists(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_ftst(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_FTST               \
@@ -6499,6 +7693,7 @@ Perl_ck_ftst(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_fun(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_FUN                \
@@ -6506,6 +7701,7 @@ Perl_ck_fun(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_glob(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_GLOB               \
@@ -6513,6 +7709,7 @@ Perl_ck_glob(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_grep(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_GREP               \
@@ -6520,6 +7717,7 @@ Perl_ck_grep(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_helemexistsor(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_HELEMEXISTSOR      \
@@ -6527,6 +7725,7 @@ Perl_ck_helemexistsor(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_index(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_INDEX              \
@@ -6534,6 +7733,7 @@ Perl_ck_index(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_isa(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_ISA                \
@@ -6541,6 +7741,7 @@ Perl_ck_isa(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_join(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_JOIN               \
@@ -6548,6 +7749,7 @@ Perl_ck_join(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_length(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_LENGTH             \
@@ -6555,6 +7757,7 @@ Perl_ck_length(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_lfun(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_LFUN               \
@@ -6562,6 +7765,7 @@ Perl_ck_lfun(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_listiob(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_LISTIOB            \
@@ -6569,6 +7773,7 @@ Perl_ck_listiob(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_match(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_MATCH              \
@@ -6576,6 +7781,7 @@ Perl_ck_match(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_method(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_METHOD             \
@@ -6583,6 +7789,7 @@ Perl_ck_method(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_null(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_NULL               \
@@ -6590,6 +7797,7 @@ Perl_ck_null(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_open(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_OPEN               \
@@ -6597,6 +7805,7 @@ Perl_ck_open(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_prototype(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_PROTOTYPE          \
@@ -6604,6 +7813,7 @@ Perl_ck_prototype(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_readline(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_READLINE           \
@@ -6611,6 +7821,7 @@ Perl_ck_readline(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_refassign(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_REFASSIGN          \
@@ -6618,6 +7829,7 @@ Perl_ck_refassign(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_repeat(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_REPEAT             \
@@ -6625,6 +7837,7 @@ Perl_ck_repeat(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_require(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_REQUIRE            \
@@ -6632,6 +7845,7 @@ Perl_ck_require(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_return(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_RETURN             \
@@ -6639,6 +7853,7 @@ Perl_ck_return(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_rfun(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_RFUN               \
@@ -6646,6 +7861,7 @@ Perl_ck_rfun(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_rvconst(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_RVCONST            \
@@ -6653,6 +7869,7 @@ Perl_ck_rvconst(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_sassign(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SASSIGN            \
@@ -6660,6 +7877,7 @@ Perl_ck_sassign(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_scmp(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SCMP               \
@@ -6667,6 +7885,7 @@ Perl_ck_scmp(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_select(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SELECT             \
@@ -6674,6 +7893,7 @@ Perl_ck_select(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_shift(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SHIFT              \
@@ -6681,6 +7901,7 @@ Perl_ck_shift(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_smartmatch(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SMARTMATCH         \
@@ -6688,6 +7909,7 @@ Perl_ck_smartmatch(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_sort(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SORT               \
@@ -6695,6 +7917,7 @@ Perl_ck_sort(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_spair(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SPAIR              \
@@ -6702,6 +7925,7 @@ Perl_ck_spair(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_split(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SPLIT              \
@@ -6709,6 +7933,7 @@ Perl_ck_split(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_stringify(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_STRINGIFY          \
@@ -6716,6 +7941,7 @@ Perl_ck_stringify(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_subr(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SUBR               \
@@ -6723,6 +7949,7 @@ Perl_ck_subr(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_substr(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SUBSTR             \
@@ -6730,6 +7957,7 @@ Perl_ck_substr(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_svconst(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SVCONST            \
@@ -6737,6 +7965,7 @@ Perl_ck_svconst(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_tell(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_TELL               \
@@ -6744,6 +7973,7 @@ Perl_ck_tell(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_trunc(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_TRUNC              \
@@ -6751,6 +7981,7 @@ Perl_ck_trunc(pTHX_ OP *o)
 
 PERL_CALLCONV OP *
 Perl_ck_trycatch(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_TRYCATCH           \
@@ -6762,23 +7993,29 @@ Perl_ck_trycatch(pTHX_ OP *o)
     defined(PERL_IN_PAD_C)   || defined(PERL_IN_PERLY_C) || \
     defined(PERL_IN_TOKE_C)
 PERL_CALLCONV void
-Perl_class_add_ADJUST(pTHX_ HV *stash, CV *cv);
+Perl_class_add_ADJUST(pTHX_ HV *stash, CV *cv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_CLASS_ADD_ADJUST      \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
-Perl_class_add_field(pTHX_ HV *stash, PADNAME *pn);
+Perl_class_add_field(pTHX_ HV *stash, PADNAME *pn)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_CLASS_ADD_FIELD       \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV); assert(pn)
 
 PERL_CALLCONV void
-Perl_class_apply_attributes(pTHX_ HV *stash, OP *attrlist);
+Perl_class_apply_attributes(pTHX_ HV *stash, OP *attrlist)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_APPLY_ATTRIBUTES \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
-Perl_class_apply_field_attributes(pTHX_ PADNAME *pn, OP *attrlist);
+Perl_class_apply_field_attributes(pTHX_ PADNAME *pn, OP *attrlist)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_APPLY_FIELD_ATTRIBUTES \
         assert(pn)
 
@@ -6787,22 +8024,27 @@ Perl_class_prepare_initfield_parse(pTHX);
 # define PERL_ARGS_ASSERT_CLASS_PREPARE_INITFIELD_PARSE
 
 PERL_CALLCONV void
-Perl_class_prepare_method_parse(pTHX_ CV *cv);
+Perl_class_prepare_method_parse(pTHX_ CV *cv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_PREPARE_METHOD_PARSE \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
-Perl_class_seal_stash(pTHX_ HV *stash);
+Perl_class_seal_stash(pTHX_ HV *stash)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_SEAL_STASH      \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
-Perl_class_set_field_defop(pTHX_ PADNAME *pn, OPCODE defmode, OP *defop);
+Perl_class_set_field_defop(pTHX_ PADNAME *pn, OPCODE defmode, OP *defop)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_CLASS_SET_FIELD_DEFOP \
         assert(pn); assert(defop)
 
 PERL_CALLCONV void
-Perl_class_setup_stash(pTHX_ HV *stash);
+Perl_class_setup_stash(pTHX_ HV *stash)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_SETUP_STASH     \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
@@ -6811,7 +8053,8 @@ Perl_class_wrap_method_body(pTHX_ OP *o);
 # define PERL_ARGS_ASSERT_CLASS_WRAP_METHOD_BODY
 
 PERL_CALLCONV void
-Perl_croak_kw_unless_class(pTHX_ const char *kw);
+Perl_croak_kw_unless_class(pTHX_ const char *kw)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CROAK_KW_UNLESS_CLASS \
         assert(kw)
 
@@ -6820,34 +8063,49 @@ Perl_croak_kw_unless_class(pTHX_ const char *kw);
           defined(PERL_IN_TOKE_C) */
 #if defined(PERL_IN_DEB_C)
 static void
-S_deb_stack_n(pTHX_ SV **stack_base, SSize_t stack_min, SSize_t stack_max, SSize_t mark_min, SSize_t mark_max, SSize_t nonrc_base);
+S_deb_stack_n(pTHX_ SV **stack_base, SSize_t stack_min, SSize_t stack_max, SSize_t mark_min, SSize_t mark_max, SSize_t nonrc_base)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DEB_STACK_N           \
         assert(stack_base)
 
 #endif
 #if defined(PERL_IN_DOIO_C)
 static bool
-S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explicit);
+S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explicit)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_ARGVOUT_FINAL         \
         assert(mg); assert(io)
 
 static void
-S_exec_failed(pTHX_ const char *cmd, int fd, int do_report);
+S_exec_failed(pTHX_ const char *cmd, int fd, int do_report)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_EXEC_FAILED           \
         assert(cmd)
 
 static bool
-S_is_fork_open(const char *name);
+S_is_fork_open(const char *name)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_IS_FORK_OPEN          \
         assert(name)
 
 static bool
-S_openn_cleanup(pTHX_ GV *gv, IO *io, PerlIO *fp, char *mode, const char *oname, PerlIO *saveifp, PerlIO *saveofp, int savefd, char savetype, int writing, bool was_fdopen, const char *type, Stat_t *statbufp);
+S_openn_cleanup(pTHX_ GV *gv, IO *io, PerlIO *fp, char *mode, const char *oname, PerlIO *saveifp, PerlIO *saveofp, int savefd, char savetype, int writing, bool was_fdopen, const char *type, Stat_t *statbufp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5);
 # define PERL_ARGS_ASSERT_OPENN_CLEANUP         \
         assert(gv); assert(io); assert(mode); assert(oname)
 
 static IO *
-S_openn_setup(pTHX_ GV *gv, char *mode, PerlIO **saveifp, PerlIO **saveofp, int *savefd, char *savetype);
+S_openn_setup(pTHX_ GV *gv, char *mode, PerlIO **saveifp, PerlIO **saveofp, int *savefd, char *savetype)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5)
+        Perl_attribute_nonnull_(pTHX_6);
 # define PERL_ARGS_ASSERT_OPENN_SETUP           \
         assert(gv); assert(mode); assert(saveifp); assert(saveofp); \
         assert(savefd); assert(savetype)
@@ -6863,30 +8121,40 @@ S_ingroup(pTHX_ Gid_t testgid, bool effective)
 #if defined(PERL_IN_DOOP_C)
 static Size_t
 S_do_trans_complex(pTHX_ SV * const sv, const OPtrans_map * const tbl)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_COMPLEX      \
         assert(sv); assert(tbl)
 
 static Size_t
 S_do_trans_count(pTHX_ SV * const sv, const OPtrans_map * const tbl)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_COUNT        \
         assert(sv); assert(tbl)
 
 static Size_t
 S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_COUNT_INVMAP \
         assert(sv); assert(invmap); assert(SvTYPE(invmap) == SVt_PVAV)
 
 static Size_t
 S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_INVMAP       \
         assert(sv); assert(invmap); assert(SvTYPE(invmap) == SVt_PVAV)
 
 static Size_t
 S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_SIMPLE       \
         assert(sv); assert(tbl)
@@ -6957,17 +8225,21 @@ S_deb_curcv(pTHX_ I32 ix);
 # define PERL_ARGS_ASSERT_DEB_CURCV
 
 static void
-S_debprof(pTHX_ const OP *o);
+S_debprof(pTHX_ const OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DEBPROF               \
         assert(o)
 
 static SV *
-S_pm_description(pTHX_ const PMOP *pm);
+S_pm_description(pTHX_ const PMOP *pm)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_PM_DESCRIPTION        \
         assert(pm)
 
 static char *
-S_pv_display_flags(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pvlim, I32 pretty_flags);
+S_pv_display_flags(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pvlim, I32 pretty_flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_PV_DISPLAY_FLAGS      \
         assert(dsv); assert(pv)
 
@@ -6980,6 +8252,7 @@ S_sequence_num(pTHX_ const OP *o);
     defined(PERL_IN_SCOPE_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV void
 Perl_hv_kill_backrefs(pTHX_ HV *hv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_HV_KILL_BACKREFS      \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
@@ -6993,44 +8266,61 @@ Perl_hv_kill_backrefs(pTHX_ HV *hv)
 #endif
 #if defined(PERL_IN_GV_C)
 static bool
-S_find_default_stash(pTHX_ HV **stash, const char *name, STRLEN len, const U32 is_utf8, const I32 add, const svtype sv_type);
+S_find_default_stash(pTHX_ HV **stash, const char *name, STRLEN len, const U32 is_utf8, const I32 add, const svtype sv_type)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_DEFAULT_STASH    \
         assert(stash); assert(name)
 
 static void
-S_gv_init_svtype(pTHX_ GV *gv, const svtype sv_type);
+S_gv_init_svtype(pTHX_ GV *gv, const svtype sv_type)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_GV_INIT_SVTYPE        \
         assert(gv)
 
 static bool
-S_gv_is_in_main(pTHX_ const char *name, STRLEN len, const U32 is_utf8);
+S_gv_is_in_main(pTHX_ const char *name, STRLEN len, const U32 is_utf8)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_GV_IS_IN_MAIN         \
         assert(name)
 
 static bool
-S_gv_magicalize(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, const svtype sv_type);
+S_gv_magicalize(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, const svtype sv_type)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_GV_MAGICALIZE         \
         assert(gv); assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
         assert(name)
 
 static void
-S_gv_magicalize_isa(pTHX_ GV *gv);
+S_gv_magicalize_isa(pTHX_ GV *gv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_GV_MAGICALIZE_ISA     \
         assert(gv)
 
 static void
-S_maybe_multimagic_gv(pTHX_ GV *gv, const char *name, const svtype sv_type);
+S_maybe_multimagic_gv(pTHX_ GV *gv, const char *name, const svtype sv_type)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_MAYBE_MULTIMAGIC_GV   \
         assert(gv); assert(name)
 
 static bool
-S_parse_gv_stash_name(pTHX_ HV **stash, GV **gv, const char **name, STRLEN *len, const char *nambeg, STRLEN full_len, const U32 is_utf8, const I32 add);
+S_parse_gv_stash_name(pTHX_ HV **stash, GV **gv, const char **name, STRLEN *len, const char *nambeg, STRLEN full_len, const U32 is_utf8, const I32 add)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5);
 # define PERL_ARGS_ASSERT_PARSE_GV_STASH_NAME   \
         assert(stash); assert(gv); assert(name); assert(*name); assert(len); \
         assert(nambeg); assert(nambeg <= *name)
 
 static void
-S_require_tie_mod(pTHX_ GV *gv, const char varname, const char *name, STRLEN len, const U32 flags);
+S_require_tie_mod(pTHX_ GV *gv, const char varname, const char *name, STRLEN len, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_REQUIRE_TIE_MOD       \
         assert(gv); assert(name)
 
@@ -7041,7 +8331,8 @@ S_gv_fetchmeth_internal(pTHX_ HV *stash, SV *meth, const char *name, STRLEN len,
         assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
 PERL_STATIC_INLINE HV *
-S_gv_stashpvn_internal(pTHX_ const char *name, U32 namelen, I32 flags);
+S_gv_stashpvn_internal(pTHX_ const char *name, U32 namelen, I32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_GV_STASHPVN_INTERNAL \
         assert(name)
 
@@ -7051,11 +8342,14 @@ S_gv_stashpvn_internal(pTHX_ const char *name, U32 namelen, I32 flags);
     defined(PERL_IN_PAD_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV void
 Perl_sv_add_backref(pTHX_ SV * const tsv, SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SV_ADD_BACKREF        \
         assert(tsv); assert(sv)
 
-#endif
+#endif /* defined(PERL_IN_GV_C)  || defined(PERL_IN_OP_C) ||
+          defined(PERL_IN_PAD_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_GV_C) || defined(PERL_IN_UNIVERSAL_C)
 # define PERL_ARGS_ASSERT_GV_STASHSVPVN_CACHED  \
         assert(namesv || name)
@@ -7068,17 +8362,20 @@ Perl_gv_stashsvpvn_cached(pTHX_ SV *namesv, const char *name, U32 namelen, I32 f
 #endif /* defined(PERL_IN_GV_C) || defined(PERL_IN_UNIVERSAL_C) */
 #if defined(PERL_IN_HV_C)
 static void
-S_clear_placeholders(pTHX_ HV *hv, U32 items);
+S_clear_placeholders(pTHX_ HV *hv, U32 items)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLEAR_PLACEHOLDERS    \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 static void
-S_hsplit(pTHX_ HV *hv, STRLEN const oldsize, STRLEN newsize);
+S_hsplit(pTHX_ HV *hv, STRLEN const oldsize, STRLEN newsize)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_HSPLIT                \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 static struct xpvhv_aux *
-S_hv_auxinit(pTHX_ HV *hv);
+S_hv_auxinit(pTHX_ HV *hv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_AUXINIT            \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
@@ -7088,34 +8385,43 @@ S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen, int k_
         assert(!hv || SvTYPE(hv) == SVt_PVHV)
 
 static SV *
-S_hv_free_ent_ret(pTHX_ HE *entry);
+S_hv_free_ent_ret(pTHX_ HE *entry)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_FREE_ENT_RET       \
         assert(entry)
 
 static void
-S_hv_free_entries(pTHX_ HV *hv);
+S_hv_free_entries(pTHX_ HV *hv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_FREE_ENTRIES       \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 static void
-S_hv_magic_check(HV *hv, bool *needs_copy, bool *needs_store);
+S_hv_magic_check(HV *hv, bool *needs_copy, bool *needs_store)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(3);
 # define PERL_ARGS_ASSERT_HV_MAGIC_CHECK        \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(needs_copy); \
         assert(needs_store)
 
 PERL_STATIC_NO_RET void
 S_hv_notallowed(pTHX_ int flags, const char *key, I32 klen, const char *msg)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_HV_NOTALLOWED         \
         assert(key); assert(msg)
 
 static SV *
-S_refcounted_he_value(pTHX_ const struct refcounted_he *he);
+S_refcounted_he_value(pTHX_ const struct refcounted_he *he)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_REFCOUNTED_HE_VALUE   \
         assert(he)
 
 static HEK *
 S_save_hek_flags(const char *str, I32 len, U32 hash, int flags)
+        Perl_attribute_nonnull_(1)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SAVE_HEK_FLAGS        \
@@ -7123,6 +8429,7 @@ S_save_hek_flags(const char *str, I32 len, U32 hash, int flags)
 
 static HEK *
 S_share_hek_flags(pTHX_ const char *str, STRLEN len, U32 hash, int flags)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SHARE_HEK_FLAGS       \
         assert(str)
@@ -7142,6 +8449,7 @@ S_new_he(pTHX)
 #if defined(PERL_IN_HV_C) || defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV void
 Perl_sv_kill_backrefs(pTHX_ SV * const sv, AV * const av)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SV_KILL_BACKREFS      \
         assert(sv)
@@ -7150,23 +8458,28 @@ Perl_sv_kill_backrefs(pTHX_ SV * const sv, AV * const av)
 #if defined(PERL_IN_HV_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV SV *
 Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_HFREE_NEXT_ENTRY      \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(indexp)
 
-#endif
+#endif /* defined(PERL_IN_HV_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_LOCALE_C)
 static utf8ness_t
 S_get_locale_string_utf8ness_i(pTHX_ const char *string, const locale_utf8ness_t known_utf8, const char *locale, const locale_category_index cat_index);
 # define PERL_ARGS_ASSERT_GET_LOCALE_STRING_UTF8NESS_I
 
 static void
-S_ints_to_tm(pTHX_ struct tm *my_tm, const char *locale, int sec, int min, int hour, int mday, int mon, int year, int isdst);
+S_ints_to_tm(pTHX_ struct tm *my_tm, const char *locale, int sec, int min, int hour, int mday, int mon, int year, int isdst)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_INTS_TO_TM            \
         assert(my_tm); assert(locale)
 
 static bool
-S_is_locale_utf8(pTHX_ const char *locale);
+S_is_locale_utf8(pTHX_ const char *locale)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_IS_LOCALE_UTF8        \
         assert(locale)
 
@@ -7175,31 +8488,49 @@ S_my_localeconv(pTHX_ const int item);
 # define PERL_ARGS_ASSERT_MY_LOCALECONV
 
 static void
-S_populate_hash_from_C_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2]);
+S_populate_hash_from_C_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2])
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5);
 # define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_C_LOCALECONV \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(locale); \
         assert(strings); assert(integers)
 
 static bool
-S_strftime8(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm *mytm, const utf8ness_t fmt_utf8ness, utf8ness_t *result_utf8ness, const bool called_externally);
+S_strftime8(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm *mytm, const utf8ness_t fmt_utf8ness, utf8ness_t *result_utf8ness, const bool called_externally)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_6);
 # define PERL_ARGS_ASSERT_STRFTIME8             \
         assert(fmt); assert(sv); assert(locale); assert(mytm); \
         assert(result_utf8ness)
 
 static bool
 S_strftime_tm(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm *mytm)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__format__(__strftime__,pTHX_1,0);
 # define PERL_ARGS_ASSERT_STRFTIME_TM           \
         assert(fmt); assert(sv); assert(locale); assert(mytm)
 
 static SV *
-S_sv_strftime_common(pTHX_ SV *fmt, const char *locale, const struct tm *mytm);
+S_sv_strftime_common(pTHX_ SV *fmt, const char *locale, const struct tm *mytm)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_SV_STRFTIME_COMMON    \
         assert(fmt); assert(locale); assert(mytm)
 
 # if defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO)
 static const char *
-S_emulate_langinfo(pTHX_ const PERL_INTMAX_T item, const char *locale, SV *sv, utf8ness_t *utf8ness);
+S_emulate_langinfo(pTHX_ const PERL_INTMAX_T item, const char *locale, SV *sv, utf8ness_t *utf8ness)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #   define PERL_ARGS_ASSERT_EMULATE_LANGINFO    \
         assert(locale); assert(sv)
 
@@ -7210,7 +8541,8 @@ S_calculate_LC_ALL_string(pTHX_ const char **category_locales_list, const calc_L
 #   define PERL_ARGS_ASSERT_CALCULATE_LC_ALL_STRING
 
 static const char *
-S_external_call_langinfo(pTHX_ const nl_item item, SV *sv, utf8ness_t *utf8ness);
+S_external_call_langinfo(pTHX_ const nl_item item, SV *sv, utf8ness_t *utf8ness)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_EXTERNAL_CALL_LANGINFO \
         assert(sv)
 
@@ -7224,7 +8556,8 @@ S_native_querylocale_i(pTHX_ const locale_category_index cat_index);
 #   define PERL_ARGS_ASSERT_NATIVE_QUERYLOCALE_I
 
 static void
-S_new_LC_ALL(pTHX_ const char *lc_all, bool force);
+S_new_LC_ALL(pTHX_ const char *lc_all, bool force)
+        Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_NEW_LC_ALL          \
         assert(lc_all)
 
@@ -7233,7 +8566,9 @@ S_output_check_environment_warning(pTHX_ const char * const language, const char
 #   define PERL_ARGS_ASSERT_OUTPUT_CHECK_ENVIRONMENT_WARNING
 
 static parse_LC_ALL_string_return
-S_parse_LC_ALL_string(pTHX_ const char *string, const char **output, const parse_LC_ALL_STRING_action, bool always_use_full_array, const bool panic_on_error, const line_t caller_line);
+S_parse_LC_ALL_string(pTHX_ const char *string, const char **output, const parse_LC_ALL_STRING_action, bool always_use_full_array, const bool panic_on_error, const line_t caller_line)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_PARSE_LC_ALL_STRING \
         assert(string); assert(output)
 
@@ -7251,12 +8586,15 @@ S_set_save_buffer_min_size(pTHX_ const Size_t min_len, char **buf, Size_t *buf_s
 
 PERL_STATIC_NO_RET void
 S_setlocale_failure_panic_via_i(pTHX_ const locale_category_index cat_index, const char *current, const char *failed, const line_t proxy_caller_line, const line_t immediate_caller_line, const char *higher_caller_file, const line_t higher_caller_line)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_6)
         __attribute__noreturn__;
 #   define PERL_ARGS_ASSERT_SETLOCALE_FAILURE_PANIC_VIA_I \
         assert(failed); assert(higher_caller_file)
 
 static const char *
-S_toggle_locale_i(pTHX_ const locale_category_index cat_index, const char *new_locale, const line_t caller_line);
+S_toggle_locale_i(pTHX_ const locale_category_index cat_index, const char *new_locale, const line_t caller_line)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_TOGGLE_LOCALE_I     \
         assert(new_locale)
 
@@ -7270,28 +8608,38 @@ S_my_setlocale_debug_string_i(pTHX_ const locale_category_index cat_index, const
 #   if   defined(HAS_LOCALECONV) && \
        ( defined(USE_LOCALE_MONETARY) || defined(USE_LOCALE_NUMERIC) )
 static void
-S_populate_hash_from_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2]);
+S_populate_hash_from_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2])
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5);
 #     define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_LOCALECONV \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(locale); \
         assert(strings); assert(integers)
 
-#   endif
+#   endif /*   defined(HAS_LOCALECONV) &&
+             ( defined(USE_LOCALE_MONETARY) ||
+               defined(USE_LOCALE_NUMERIC) ) */
 #   if defined(HAS_NL_LANGINFO)
 static const char *
-S_langinfo_sv_i(pTHX_ const nl_item item, locale_category_index cat_index, const char *locale, SV *sv, utf8ness_t *utf8ness);
+S_langinfo_sv_i(pTHX_ const nl_item item, locale_category_index cat_index, const char *locale, SV *sv, utf8ness_t *utf8ness)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4);
 #     define PERL_ARGS_ASSERT_LANGINFO_SV_I     \
         assert(locale); assert(sv)
 
 #   endif
 #   if defined(LC_ALL)
 static void
-S_give_perl_locale_control(pTHX_ const char *lc_all_string, const line_t caller_line);
+S_give_perl_locale_control(pTHX_ const char *lc_all_string, const line_t caller_line)
+        Perl_attribute_nonnull_(pTHX_1);
 #     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
         assert(lc_all_string)
 
 #   else
 static void
-S_give_perl_locale_control(pTHX_ const char **curlocales, const line_t caller_line);
+S_give_perl_locale_control(pTHX_ const char **curlocales, const line_t caller_line)
+        Perl_attribute_nonnull_(pTHX_1);
 #     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
         assert(curlocales)
 
@@ -7305,13 +8653,16 @@ S_mortalized_pv_copy(pTHX_ const char * const pv)
 #   endif
 #   if defined(USE_LOCALE_COLLATE)
 static void
-S_new_collate(pTHX_ const char *newcoll, bool force);
+S_new_collate(pTHX_ const char *newcoll, bool force)
+        Perl_attribute_nonnull_(pTHX_1);
 #     define PERL_ARGS_ASSERT_NEW_COLLATE       \
         assert(newcoll)
 
 #     if defined(DEBUGGING)
 static void
-S_print_collxfrm_input_and_return(pTHX_ const char *s, const char *e, const char *xbuf, const STRLEN xlen, const bool is_utf8);
+S_print_collxfrm_input_and_return(pTHX_ const char *s, const char *e, const char *xbuf, const STRLEN xlen, const bool is_utf8)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #       define PERL_ARGS_ASSERT_PRINT_COLLXFRM_INPUT_AND_RETURN \
         assert(s); assert(e); assert(s <= e)
 
@@ -7319,19 +8670,22 @@ S_print_collxfrm_input_and_return(pTHX_ const char *s, const char *e, const char
 #   endif /* defined(USE_LOCALE_COLLATE) */
 #   if defined(USE_LOCALE_CTYPE)
 static bool
-S_is_codeset_name_UTF8(const char *name);
+S_is_codeset_name_UTF8(const char *name)
+        Perl_attribute_nonnull_(1);
 #     define PERL_ARGS_ASSERT_IS_CODESET_NAME_UTF8 \
         assert(name)
 
 static void
-S_new_ctype(pTHX_ const char *newctype, bool force);
+S_new_ctype(pTHX_ const char *newctype, bool force)
+        Perl_attribute_nonnull_(pTHX_1);
 #     define PERL_ARGS_ASSERT_NEW_CTYPE         \
         assert(newctype)
 
 #   endif /* defined(USE_LOCALE_CTYPE) */
 #   if defined(USE_LOCALE_NUMERIC)
 static void
-S_new_numeric(pTHX_ const char *newnum, bool force);
+S_new_numeric(pTHX_ const char *newnum, bool force)
+        Perl_attribute_nonnull_(pTHX_1);
 #     define PERL_ARGS_ASSERT_NEW_NUMERIC       \
         assert(newnum)
 
@@ -7344,7 +8698,8 @@ S_get_LC_ALL_display(pTHX);
 #   endif
 #   if defined(USE_POSIX_2008_LOCALE)
 static bool
-S_bool_setlocale_2008_i(pTHX_ const locale_category_index index, const char *new_locale, const line_t caller_line);
+S_bool_setlocale_2008_i(pTHX_ const locale_category_index index, const char *new_locale, const line_t caller_line)
+        Perl_attribute_nonnull_(pTHX_2);
 #     define PERL_ARGS_ASSERT_BOOL_SETLOCALE_2008_I \
         assert(new_locale)
 
@@ -7358,7 +8713,8 @@ S_use_curlocale_scratch(pTHX);
 
 #     if !defined(USE_QUERYLOCALE)
 static void
-S_update_PL_curlocales_i(pTHX_ const locale_category_index index, const char *new_locale, const line_t caller_line);
+S_update_PL_curlocales_i(pTHX_ const locale_category_index index, const char *new_locale, const line_t caller_line)
+        Perl_attribute_nonnull_(pTHX_2);
 #       define PERL_ARGS_ASSERT_UPDATE_PL_CURLOCALES_I \
         assert(new_locale)
 
@@ -7368,7 +8724,8 @@ S_update_PL_curlocales_i(pTHX_ const locale_category_index index, const char *ne
          !defined(USE_THREAD_SAFE_LOCALE_EMULATION) /* &&
          !defined(USE_POSIX_2008_LOCALE) */
 static bool
-S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char *locale);
+S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char *locale)
+        Perl_attribute_nonnull_(pTHX_2);
 #     define PERL_ARGS_ASSERT_LESS_DICEY_BOOL_SETLOCALE_R \
         assert(locale)
 
@@ -7408,7 +8765,9 @@ S_find_locale_from_environment(pTHX_ const locale_category_index index);
 # endif /* defined(USE_LOCALE) */
 # if defined(USE_LOCALE) || defined(DEBUGGING)
 static const char *
-S_get_displayable_string(pTHX_ const char * const s, const char * const e, const bool is_utf8);
+S_get_displayable_string(pTHX_ const char * const s, const char * const e, const bool is_utf8)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_GET_DISPLAYABLE_STRING \
         assert(s); assert(e); assert(s <= e)
 
@@ -7416,24 +8775,32 @@ S_get_displayable_string(pTHX_ const char * const s, const char * const e, const
 #endif /* defined(PERL_IN_LOCALE_C) */
 #if defined(PERL_IN_MALLOC_C)
 static int
-S_adjust_size_and_find_bucket(size_t *nbytes_p);
+S_adjust_size_and_find_bucket(size_t *nbytes_p)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_ADJUST_SIZE_AND_FIND_BUCKET \
         assert(nbytes_p)
 
 #endif
 #if defined(PERL_IN_MG_C)
 static void
-S_fixup_errno_string(pTHX_ SV *sv);
+S_fixup_errno_string(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FIXUP_ERRNO_STRING    \
         assert(sv)
 
 static SV *
-S_magic_methcall1(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, int n, SV *val);
+S_magic_methcall1(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, int n, SV *val)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_MAGIC_METHCALL1       \
         assert(sv); assert(mg); assert(meth)
 
 static int
-S_magic_methpack(pTHX_ SV *sv, const MAGIC *mg, SV *meth);
+S_magic_methpack(pTHX_ SV *sv, const MAGIC *mg, SV *meth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_MAGIC_METHPACK        \
         assert(sv); assert(mg); assert(meth)
 
@@ -7442,7 +8809,8 @@ S_restore_magic(pTHX_ void *p);
 # define PERL_ARGS_ASSERT_RESTORE_MAGIC
 
 static void
-S_save_magic_flags(pTHX_ SSize_t mgs_ix, SV *sv, U32 flags);
+S_save_magic_flags(pTHX_ SSize_t mgs_ix, SV *sv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_SAVE_MAGIC_FLAGS      \
         assert(sv)
 
@@ -7454,28 +8822,37 @@ S_unwind_handler_stack(pTHX_ void *p);
 #if defined(PERL_IN_MG_C) || defined(PERL_IN_PP_C)
 PERL_CALLCONV bool
 Perl_translate_substr_offsets(STRLEN curlen, IV pos1_iv, bool pos1_is_uv, IV len_iv, bool len_is_uv, STRLEN *posp, STRLEN *lenp)
+        Perl_attribute_nonnull_(6)
+        Perl_attribute_nonnull_(7)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_TRANSLATE_SUBSTR_OFFSETS \
         assert(posp); assert(lenp)
 
-#endif
+#endif /* defined(PERL_IN_MG_C) || defined(PERL_IN_PP_C) */
 #if defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV void
 Perl_mg_free_struct(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MG_FREE_STRUCT        \
         assert(sv); assert(mg)
 
-#endif
+#endif /* defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_MRO_C)
 static void
-S_mro_clean_isarev(pTHX_ HV * const isa, const char * const name, const STRLEN len, HV * const exceptions, U32 hash, U32 flags);
+S_mro_clean_isarev(pTHX_ HV * const isa, const char * const name, const STRLEN len, HV * const exceptions, U32 hash, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_MRO_CLEAN_ISAREV      \
         assert(isa); assert(SvTYPE(isa) == SVt_PVHV); assert(name); \
         assert(!exceptions || SvTYPE(exceptions) == SVt_PVHV)
 
 static void
-S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes, HV *stash, HV *oldstash, SV *namesv);
+S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes, HV *stash, HV *oldstash, SV *namesv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_5);
 # define PERL_ARGS_ASSERT_MRO_GATHER_AND_RENAME \
         assert(stashes); assert(SvTYPE(stashes) == SVt_PVHV); \
         assert(seen_stashes); assert(SvTYPE(seen_stashes) == SVt_PVHV); \
@@ -7483,19 +8860,25 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes, HV *s
         assert(!oldstash || SvTYPE(oldstash) == SVt_PVHV); assert(namesv)
 
 static AV *
-S_mro_get_linear_isa_dfs(pTHX_ HV *stash, U32 level);
+S_mro_get_linear_isa_dfs(pTHX_ HV *stash, U32 level)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_MRO_GET_LINEAR_ISA_DFS \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 #endif /* defined(PERL_IN_MRO_C) */
 #if defined(PERL_IN_OP_C)
 static void
-S_apply_attrs(pTHX_ HV *stash, SV *target, OP *attrs);
+S_apply_attrs(pTHX_ HV *stash, SV *target, OP *attrs)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_APPLY_ATTRS           \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV); assert(target)
 
 static void
-S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **imopsp);
+S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **imopsp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_APPLY_ATTRS_MY        \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV); assert(target); \
         assert(imopsp)
@@ -7506,38 +8889,51 @@ S_assignment_type(pTHX_ const OP *o)
 # define PERL_ARGS_ASSERT_ASSIGNMENT_TYPE
 
 static void
-S_bad_type_gv(pTHX_ I32 n, GV *gv, const OP *kid, const char *t);
+S_bad_type_gv(pTHX_ I32 n, GV *gv, const OP *kid, const char *t)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_BAD_TYPE_GV           \
         assert(gv); assert(kid); assert(t)
 
 static void
-S_bad_type_pv(pTHX_ I32 n, const char *t, const OP *o, const OP *kid);
+S_bad_type_pv(pTHX_ I32 n, const char *t, const OP *o, const OP *kid)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_BAD_TYPE_PV           \
         assert(t); assert(o); assert(kid)
 
 static CV *
-S_clear_special_blocks(pTHX_ const char * const fullname, GV * const gv, CV * const cv);
+S_clear_special_blocks(pTHX_ const char * const fullname, GV * const gv, CV * const cv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_CLEAR_SPECIAL_BLOCKS  \
         assert(fullname); assert(gv); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 static void
-S_cop_free(pTHX_ COP *cop);
+S_cop_free(pTHX_ COP *cop)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_COP_FREE              \
         assert(cop)
 
 static OP *
-S_dup_attrlist(pTHX_ OP *o);
+S_dup_attrlist(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DUP_ATTRLIST          \
         assert(o)
 
 static void
-S_find_and_forget_pmops(pTHX_ OP *o);
+S_find_and_forget_pmops(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FIND_AND_FORGET_PMOPS \
         assert(o)
 
 static OP *
-S_fold_constants(pTHX_ OP * const o);
+S_fold_constants(pTHX_ OP * const o)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FOLD_CONSTANTS        \
         assert(o)
 
@@ -7546,7 +8942,8 @@ S_force_list(pTHX_ OP *arg, bool nullit);
 # define PERL_ARGS_ASSERT_FORCE_LIST
 
 static void
-S_forget_pmop(pTHX_ PMOP * const o);
+S_forget_pmop(pTHX_ PMOP * const o)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FORGET_PMOP           \
         assert(o)
 
@@ -7555,17 +8952,20 @@ S_gen_constant_list(pTHX_ OP *o);
 # define PERL_ARGS_ASSERT_GEN_CONSTANT_LIST
 
 static void
-S_inplace_aassign(pTHX_ OP *o);
+S_inplace_aassign(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_INPLACE_AASSIGN       \
         assert(o)
 
 static bool
-S_is_dup_mode(const OP *o);
+S_is_dup_mode(const OP *o)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_IS_DUP_MODE           \
         assert(o)
 
 static bool
 S_is_handle_constructor(const OP *o, I32 numargs)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_HANDLE_CONSTRUCTOR \
         assert(o)
@@ -7575,7 +8975,8 @@ S_listkids(pTHX_ OP *o);
 # define PERL_ARGS_ASSERT_LISTKIDS
 
 static bool
-S_looks_like_bool(pTHX_ const OP *o);
+S_looks_like_bool(pTHX_ const OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_LOOKS_LIKE_BOOL       \
         assert(o)
 
@@ -7584,39 +8985,53 @@ S_modkids(pTHX_ OP *o, I32 type);
 # define PERL_ARGS_ASSERT_MODKIDS
 
 static void
-S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV *name, bool curstash);
+S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV *name, bool curstash)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_MOVE_PROTO_ATTR       \
         assert(proto); assert(attrs); assert(name)
 
 static OP *
-S_my_kid(pTHX_ OP *o, OP *attrs, OP **imopsp);
+S_my_kid(pTHX_ OP *o, OP *attrs, OP **imopsp)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_MY_KID                \
         assert(imopsp)
 
 static OP *
-S_newGIVWHENOP(pTHX_ OP *cond, OP *block, I32 enter_opcode, I32 leave_opcode, PADOFFSET entertarg);
+S_newGIVWHENOP(pTHX_ OP *cond, OP *block, I32 enter_opcode, I32 leave_opcode, PADOFFSET entertarg)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_NEWGIVWHENOP          \
         assert(block)
 
 static OP *
 S_new_logop(pTHX_ I32 type, I32 flags, OP **firstp, OP **otherp)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEW_LOGOP             \
         assert(firstp); assert(otherp)
 
 static OP *
 S_no_fh_allowed(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NO_FH_ALLOWED         \
         assert(o)
 
 static OP *
-S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl);
+S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_PMTRANS               \
         assert(o); assert(expr); assert(repl)
 
 static bool
-S_process_special_blocks(pTHX_ I32 floor, const char * const fullname, GV * const gv, CV * const cv);
+S_process_special_blocks(pTHX_ I32 floor, const char * const fullname, GV * const gv, CV * const cv)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_PROCESS_SPECIAL_BLOCKS \
         assert(fullname); assert(gv); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
@@ -7635,7 +9050,8 @@ S_scalar_mod_type(const OP *o, I32 type)
 # define PERL_ARGS_ASSERT_SCALAR_MOD_TYPE
 
 static OP *
-S_scalarboolean(pTHX_ OP *o);
+S_scalarboolean(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SCALARBOOLEAN         \
         assert(o)
 
@@ -7645,23 +9061,29 @@ S_scalarkids(pTHX_ OP *o);
 
 static OP *
 S_search_const(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SEARCH_CONST          \
         assert(o)
 
 static void
-S_simplify_sort(pTHX_ OP *o);
+S_simplify_sort(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SIMPLIFY_SORT         \
         assert(o)
 
 static OP *
 S_too_few_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_TOO_FEW_ARGUMENTS_PV  \
         assert(o); assert(name)
 
 static OP *
-S_too_many_arguments_pv(pTHX_ OP *o, const char *name, U32 flags);
+S_too_many_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_TOO_MANY_ARGUMENTS_PV \
         assert(o); assert(name)
 
@@ -7671,14 +9093,16 @@ S_voidnonfinal(pTHX_ OP *o);
 
 # if defined(DEBUGGING)
 static const char *
-S_get_displayable_tr_operand(pTHX_ const U8 *s, STRLEN len, bool is_utf8);
+S_get_displayable_tr_operand(pTHX_ const U8 *s, STRLEN len, bool is_utf8)
+        Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_GET_DISPLAYABLE_TR_OPERAND \
         assert(s)
 
 # endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE bool
-S_is_standard_filehandle_name(const char *fhname);
+S_is_standard_filehandle_name(const char *fhname)
+        Perl_attribute_nonnull_(1);
 #   define PERL_ARGS_ASSERT_IS_STANDARD_FILEHANDLE_NAME \
         assert(fhname)
 
@@ -7687,17 +9111,21 @@ S_newMETHOP_internal(pTHX_ I32 type, I32 flags, OP *dynamic_meth, SV * const_met
 #   define PERL_ARGS_ASSERT_NEWMETHOP_INTERNAL
 
 PERL_STATIC_INLINE OP *
-S_op_integerize(pTHX_ OP *o);
+S_op_integerize(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_OP_INTEGERIZE       \
         assert(o)
 
 PERL_STATIC_INLINE OP *
-S_op_std_init(pTHX_ OP *o);
+S_op_std_init(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_OP_STD_INIT         \
         assert(o)
 
 PERL_STATIC_INLINE U16
-S_opslab_slot_offset(const OPSLAB *slab, const OPSLOT *slot);
+S_opslab_slot_offset(const OPSLAB *slab, const OPSLOT *slot)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2);
 #   define PERL_ARGS_ASSERT_OPSLAB_SLOT_OFFSET  \
         assert(slab); assert(slot)
 
@@ -7707,6 +9135,9 @@ S_size_to_psize(size_t size);
 
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_OP_C) */
+#if defined(PERL_IN_OP_C) || defined(PERL_IN_PAD_C)
+
+#endif
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C)
 PERL_CALLCONV void
 Perl_check_hash_fields_and_hekify(pTHX_ UNOP *rop, SVOP *key_op, int real)
@@ -7715,24 +9146,29 @@ Perl_check_hash_fields_and_hekify(pTHX_ UNOP *rop, SVOP *key_op, int real)
 
 PERL_CALLCONV void
 Perl_no_bareword_allowed(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_NO_BAREWORD_ALLOWED   \
         assert(o)
 
 PERL_CALLCONV void
 Perl_op_prune_chain_head(OP **op_p)
+        Perl_attribute_nonnull_(1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OP_PRUNE_CHAIN_HEAD   \
         assert(op_p)
 
 PERL_CALLCONV SV *
 Perl_op_varname(pTHX_ const OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OP_VARNAME            \
         assert(o)
 
 PERL_CALLCONV void
 Perl_warn_elem_scalar_context(pTHX_ const OP *o, SV *name, bool is_hash, bool is_slice)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_WARN_ELEM_SCALAR_CONTEXT \
         assert(o); assert(name)
@@ -7744,6 +9180,8 @@ Perl_warn_elem_scalar_context(pTHX_ const OP *o, SV *name, bool is_hash, bool is
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV void
 Perl_report_redefined_cv(pTHX_ const SV *name, const CV *old_cv, SV * const *new_const_svp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_REPORT_REDEFINED_CV   \
         assert(name); assert(old_cv)
@@ -7757,17 +9195,23 @@ Perl_varname(pTHX_ const GV * const gv, const char gvtype, PADOFFSET targ, const
 #endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_PAD_C)
 static PADOFFSET
-S_pad_alloc_name(pTHX_ PADNAME *name, U32 flags, HV *typestash, HV *ourstash);
+S_pad_alloc_name(pTHX_ PADNAME *name, U32 flags, HV *typestash, HV *ourstash)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_PAD_ALLOC_NAME        \
         assert(name); assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
 static void
-S_pad_check_dup(pTHX_ PADNAME *name, U32 flags, const HV *ourstash);
+S_pad_check_dup(pTHX_ PADNAME *name, U32 flags, const HV *ourstash)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_PAD_CHECK_DUP         \
         assert(name)
 
 static PADOFFSET
-S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV *cv, U32 seq, int warn, SV **out_capture, PADNAME **out_name, int *out_flags);
+S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV *cv, U32 seq, int warn, SV **out_capture, PADNAME **out_name, int *out_flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_8)
+        Perl_attribute_nonnull_(pTHX_9);
 # define PERL_ARGS_ASSERT_PAD_FINDLEX           \
         assert(namepv); assert(cv); assert(out_name); assert(out_flags)
 
@@ -7777,7 +9221,9 @@ S_pad_reset(pTHX);
 
 # if defined(DEBUGGING)
 static void
-S_cv_dump(pTHX_ const CV *cv, const char *title);
+S_cv_dump(pTHX_ const CV *cv, const char *title)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_CV_DUMP             \
         assert(cv); assert(title)
 
@@ -7785,24 +9231,30 @@ S_cv_dump(pTHX_ const CV *cv, const char *title);
 #endif /* defined(PERL_IN_PAD_C) */
 #if defined(PERL_IN_PEEP_C)
 static void
-S_finalize_op(pTHX_ OP *o);
+S_finalize_op(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FINALIZE_OP           \
         assert(o)
 
 static void
-S_optimize_op(pTHX_ OP *o);
+S_optimize_op(pTHX_ OP *o)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_OPTIMIZE_OP           \
         assert(o)
 
 static OP *
-S_traverse_op_tree(pTHX_ OP *top, OP *o);
+S_traverse_op_tree(pTHX_ OP *top, OP *o)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_TRAVERSE_OP_TREE      \
         assert(top); assert(o)
 
 #endif /* defined(PERL_IN_PEEP_C) */
 #if defined(PERL_IN_PERL_C)
 static void
-S_find_beginning(pTHX_ SV *linestr_sv, PerlIO *rsfp);
+S_find_beginning(pTHX_ SV *linestr_sv, PerlIO *rsfp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_BEGINNING        \
         assert(linestr_sv); assert(rsfp)
 
@@ -7811,12 +9263,14 @@ S_forbid_setid(pTHX_ const char flag, const bool suidscript);
 # define PERL_ARGS_ASSERT_FORBID_SETID
 
 static void
-S_incpush(pTHX_ const char * const dir, STRLEN len, U32 flags);
+S_incpush(pTHX_ const char * const dir, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_INCPUSH               \
         assert(dir)
 
 static void
-S_incpush_use_sep(pTHX_ const char *p, STRLEN len, U32 flags);
+S_incpush_use_sep(pTHX_ const char *p, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_INCPUSH_USE_SEP       \
         assert(p)
 
@@ -7837,7 +9291,8 @@ S_init_perllib(pTHX);
 # define PERL_ARGS_ASSERT_INIT_PERLLIB
 
 static void
-S_init_postdump_symbols(pTHX_ int argc, char **argv, char **env);
+S_init_postdump_symbols(pTHX_ int argc, char **argv, char **env)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_INIT_POSTDUMP_SYMBOLS \
         assert(argv)
 
@@ -7846,7 +9301,8 @@ S_init_predump_symbols(pTHX);
 # define PERL_ARGS_ASSERT_INIT_PREDUMP_SYMBOLS
 
 static SV *
-S_mayberelocate(pTHX_ const char * const dir, STRLEN len, U32 flags);
+S_mayberelocate(pTHX_ const char * const dir, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_MAYBERELOCATE         \
         assert(dir)
 
@@ -7865,7 +9321,9 @@ S_nuke_stacks(pTHX);
 # define PERL_ARGS_ASSERT_NUKE_STACKS
 
 static PerlIO *
-S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript);
+S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_OPEN_SCRIPT           \
         assert(scriptname); assert(suidscript)
 
@@ -7885,14 +9343,18 @@ S_usage(pTHX)
 
 # if !defined(PERL_IS_MINIPERL)
 static SV *
-S_incpush_if_exists(pTHX_ AV * const av, SV *dir, SV * const stem);
+S_incpush_if_exists(pTHX_ AV * const av, SV *dir, SV * const stem)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #   define PERL_ARGS_ASSERT_INCPUSH_IF_EXISTS   \
         assert(av); assert(SvTYPE(av) == SVt_PVAV); assert(dir); assert(stem)
 
-# endif
+# endif /* !defined(PERL_IS_MINIPERL) */
 # if !defined(SETUID_SCRIPTS_ARE_SECURE_NOW)
 static void
-S_validate_suid(pTHX_ PerlIO *rsfp);
+S_validate_suid(pTHX_ PerlIO *rsfp)
+        Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_VALIDATE_SUID       \
         assert(rsfp)
 
@@ -7909,7 +9371,9 @@ S_validate_suid(pTHX_ PerlIO *rsfp);
 #endif
 #if defined(PERL_IN_PP_C)
 static size_t
-S_do_chomp(pTHX_ SV *retval, SV *sv, bool chomping);
+S_do_chomp(pTHX_ SV *retval, SV *sv, bool chomping)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_DO_CHOMP              \
         assert(retval); assert(sv)
 
@@ -7919,6 +9383,7 @@ S_do_delete_local(pTHX);
 
 static SV *
 S_refto(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_REFTO                 \
         assert(sv)
@@ -7928,28 +9393,38 @@ S_refto(pTHX_ SV *sv)
 
 PERL_CALLCONV GV *
 Perl_softref2xv(pTHX_ SV * const sv, const char * const what, const svtype type)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SOFTREF2XV            \
         assert(sv); assert(what)
+
+#endif /* defined(PERL_IN_PP_C) || defined(PERL_IN_PP_HOT_C) */
+#if defined(PERL_IN_PP_C)   || defined(PERL_IN_REGCOMP_ANY) || \
+    defined(PERL_IN_TOKE_C) || defined(PERL_IN_UNIVERSAL_C)
 
 #endif
 #if defined(PERL_IN_PP_C) || defined(PERL_IN_UTF8_C)
 PERL_CALLCONV UV
 Perl_to_upper_title_latin1_(pTHX_ const U8 c, U8 *p, STRLEN *lenp, const char S_or_s)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_TO_UPPER_TITLE_LATIN1_ \
         assert(p); assert(lenp)
 
-#endif
+#endif /* defined(PERL_IN_PP_C) || defined(PERL_IN_UTF8_C) */
 #if defined(PERL_IN_PP_CTL_C)
 static PerlIO *
 S_check_type_and_open(pTHX_ SV *name)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_CHECK_TYPE_AND_OPEN   \
         assert(name)
 
 static void
-S_destroy_matcher(pTHX_ PMOP *matcher);
+S_destroy_matcher(pTHX_ PMOP *matcher)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DESTROY_MATCHER       \
         assert(matcher)
 
@@ -7972,12 +9447,17 @@ S_doeval_compile(pTHX_ U8 gimme, CV *outside, U32 seq, HV *hh);
 
 static OP *
 S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstack, OP **oplimit)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_5)
+        Perl_attribute_nonnull_(pTHX_6)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOFINDLABEL           \
         assert(o); assert(label); assert(opstack); assert(oplimit)
 
 static MAGIC *
-S_doparseform(pTHX_ SV *sv);
+S_doparseform(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DOPARSEFORM           \
         assert(sv)
 
@@ -7993,6 +9473,7 @@ S_dopoptogivenfor(pTHX_ I32 startingblock)
 
 static I32
 S_dopoptolabel(pTHX_ const char *label, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOLABEL          \
         assert(label)
@@ -8004,6 +9485,7 @@ S_dopoptoloop(pTHX_ I32 startingblock)
 
 static I32
 S_dopoptosub_at(pTHX_ const PERL_CONTEXT *cxstk, I32 startingblock)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOSUB_AT         \
         assert(cxstk)
@@ -8015,12 +9497,15 @@ S_dopoptowhen(pTHX_ I32 startingblock)
 
 static PMOP *
 S_make_matcher(pTHX_ REGEXP *re)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MAKE_MATCHER          \
         assert(re)
 
 static bool
 S_matcher_matches_sv(pTHX_ PMOP *matcher, SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MATCHER_MATCHES_SV    \
         assert(matcher); assert(sv)
@@ -8032,28 +9517,34 @@ S_num_overflow(NV value, I32 fldsize, I32 frcsize)
 
 static I32
 S_run_user_filter(pTHX_ int idx, SV *buf_sv, int maxlen)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_RUN_USER_FILTER       \
         assert(buf_sv)
 
 static void
-S_rxres_free(pTHX_ void **rsp);
+S_rxres_free(pTHX_ void **rsp)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RXRES_FREE            \
         assert(rsp)
 
 static void
-S_rxres_restore(pTHX_ void **rsp, REGEXP *rx);
+S_rxres_restore(pTHX_ void **rsp, REGEXP *rx)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_RXRES_RESTORE         \
         assert(rsp); assert(rx)
 
 static void
-S_save_lines(pTHX_ AV *array, SV *sv);
+S_save_lines(pTHX_ AV *array, SV *sv)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_SAVE_LINES            \
         assert(!array || SvTYPE(array) == SVt_PVAV); assert(sv)
 
 # if !defined(PERL_DISABLE_PMC)
 static PerlIO *
 S_doopen_pm(pTHX_ SV *name)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_DOOPEN_PM           \
         assert(name)
@@ -8062,6 +9553,7 @@ S_doopen_pm(pTHX_ SV *name)
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE bool
 S_path_is_searchable(const char *name)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_PATH_IS_SEARCHABLE  \
         assert(name)
@@ -8077,18 +9569,22 @@ Perl_invoke_exception_hook(pTHX_ SV *ex, bool warn)
 #endif
 #if defined(PERL_IN_PP_HOT_C)
 static void
-S_do_oddball(pTHX_ SV **oddkey, SV **firstkey);
+S_do_oddball(pTHX_ SV **oddkey, SV **firstkey)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_DO_ODDBALL            \
         assert(oddkey); assert(firstkey)
 
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE HV *
-S_opmethod_stash(pTHX_ SV *meth);
+S_opmethod_stash(pTHX_ SV *meth)
+        Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_OPMETHOD_STASH      \
         assert(meth)
 
 PERL_STATIC_FORCE_INLINE bool
 S_should_we_output_Debug_r(pTHX_ regexp *prog)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__always_inline__;
 #   define PERL_ARGS_ASSERT_SHOULD_WE_OUTPUT_DEBUG_R \
@@ -8098,176 +9594,242 @@ S_should_we_output_Debug_r(pTHX_ regexp *prog)
 #endif /* defined(PERL_IN_PP_HOT_C) */
 #if defined(PERL_IN_PP_PACK_C)
 static int
-S_div128(pTHX_ SV *pnum, bool *done);
+S_div128(pTHX_ SV *pnum, bool *done)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_DIV128                \
         assert(pnum); assert(done)
 
 static char
-S_first_symbol(const char *pat, const char *patend);
+S_first_symbol(const char *pat, const char *patend)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2);
 # define PERL_ARGS_ASSERT_FIRST_SYMBOL          \
         assert(pat); assert(patend); assert(pat <= patend)
 
 static const char *
 S_get_num(pTHX_ const char *patptr, SSize_t *lenptr)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GET_NUM               \
         assert(patptr); assert(lenptr)
 
 static const char *
-S_group_end(pTHX_ const char *patptr, const char *patend, char ender);
+S_group_end(pTHX_ const char *patptr, const char *patend, char ender)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_GROUP_END             \
         assert(patptr); assert(patend); assert(patptr <= patend)
 
 static SV *
 S_is_an_int(pTHX_ const char *s, STRLEN l)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_AN_INT             \
         assert(s)
 
 static SSize_t
-S_measure_struct(pTHX_ struct tempsym *symptr);
+S_measure_struct(pTHX_ struct tempsym *symptr)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_MEASURE_STRUCT        \
         assert(symptr)
 
 static SV *
-S_mul128(pTHX_ SV *sv, U8 m);
+S_mul128(pTHX_ SV *sv, U8 m)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_MUL128                \
         assert(sv)
 
 static char *
 S_my_bytes_to_utf8(const U8 *start, STRLEN len, char *dest, const bool needs_swap)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MY_BYTES_TO_UTF8      \
         assert(start); assert(dest)
 
 static bool
-S_need_utf8(const char *pat, const char *patend);
+S_need_utf8(const char *pat, const char *patend)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2);
 # define PERL_ARGS_ASSERT_NEED_UTF8             \
         assert(pat); assert(patend); assert(pat <= patend)
 
 static bool
-S_next_symbol(pTHX_ struct tempsym *symptr);
+S_next_symbol(pTHX_ struct tempsym *symptr)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_NEXT_SYMBOL           \
         assert(symptr)
 
 static SV **
-S_pack_rec(pTHX_ SV *cat, struct tempsym *symptr, SV **beglist, SV **endlist);
+S_pack_rec(pTHX_ SV *cat, struct tempsym *symptr, SV **beglist, SV **endlist)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_PACK_REC              \
         assert(cat); assert(symptr); assert(beglist); assert(endlist)
 
 static char *
 S_sv_exp_grow(pTHX_ SV *sv, STRLEN needed)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_EXP_GROW           \
         assert(sv)
 
 static SSize_t
-S_unpack_rec(pTHX_ struct tempsym *symptr, const char *s, const char *strbeg, const char *strend, const char **new_s);
+S_unpack_rec(pTHX_ struct tempsym *symptr, const char *s, const char *strbeg, const char *strend, const char **new_s)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_UNPACK_REC            \
         assert(symptr); assert(s); assert(strbeg); assert(strend); \
         assert(strbeg <= s); assert(s <= strend)
 
 #endif /* defined(PERL_IN_PP_PACK_C) */
 #if defined(PERL_IN_PP_SORT_C)
+
 static I32
-S_sortcv(pTHX_ SV * const a, SV * const b);
+S_sortcv(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_SORTCV                \
         assert(a); assert(b)
 
 static I32
-S_sortcv_stacked(pTHX_ SV * const a, SV * const b);
+S_sortcv_stacked(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_SORTCV_STACKED        \
         assert(a); assert(b)
 
 static I32
-S_sortcv_xsub(pTHX_ SV * const a, SV * const b);
+S_sortcv_xsub(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_SORTCV_XSUB           \
         assert(a); assert(b)
 
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE I32
-S_amagic_cmp(pTHX_ SV * const str1, SV * const str2);
+S_amagic_cmp(pTHX_ SV * const str1, SV * const str2)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_CMP          \
         assert(str1); assert(str2)
 
 PERL_STATIC_INLINE I32
-S_amagic_cmp_desc(pTHX_ SV * const str1, SV * const str2);
+S_amagic_cmp_desc(pTHX_ SV * const str1, SV * const str2)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_CMP_DESC     \
         assert(str1); assert(str2)
 
 PERL_STATIC_INLINE I32
-S_amagic_i_ncmp(pTHX_ SV * const a, SV * const b);
+S_amagic_i_ncmp(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_I_NCMP       \
         assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
-S_amagic_i_ncmp_desc(pTHX_ SV * const a, SV * const b);
+S_amagic_i_ncmp_desc(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_I_NCMP_DESC  \
         assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
-S_amagic_ncmp(pTHX_ SV * const a, SV * const b);
+S_amagic_ncmp(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_NCMP         \
         assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
-S_amagic_ncmp_desc(pTHX_ SV * const a, SV * const b);
+S_amagic_ncmp_desc(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_NCMP_DESC    \
         assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
-S_cmp_desc(pTHX_ SV * const str1, SV * const str2);
+S_cmp_desc(pTHX_ SV * const str1, SV * const str2)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_CMP_DESC            \
         assert(str1); assert(str2)
 
 PERL_STATIC_FORCE_INLINE void
 S_sortsv_flags_impl(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp, U32 flags)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__always_inline__;
 #   define PERL_ARGS_ASSERT_SORTSV_FLAGS_IMPL   \
         assert(cmp)
 
 PERL_STATIC_INLINE I32
-S_sv_i_ncmp(pTHX_ SV * const a, SV * const b);
+S_sv_i_ncmp(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_I_NCMP           \
         assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
-S_sv_i_ncmp_desc(pTHX_ SV * const a, SV * const b);
+S_sv_i_ncmp_desc(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_I_NCMP_DESC      \
         assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
-S_sv_ncmp(pTHX_ SV *a, SV *b);
+S_sv_ncmp(pTHX_ SV *a, SV *b)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_NCMP             \
         assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
-S_sv_ncmp_desc(pTHX_ SV * const a, SV * const b);
+S_sv_ncmp_desc(pTHX_ SV * const a, SV * const b)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_NCMP_DESC        \
         assert(a); assert(b)
 
 #   if defined(USE_LOCALE_COLLATE)
 PERL_STATIC_INLINE I32
-S_amagic_cmp_locale(pTHX_ SV * const str1, SV * const str2);
+S_amagic_cmp_locale(pTHX_ SV * const str1, SV * const str2)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #     define PERL_ARGS_ASSERT_AMAGIC_CMP_LOCALE \
         assert(str1); assert(str2)
 
 PERL_STATIC_INLINE I32
-S_amagic_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2);
+S_amagic_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #     define PERL_ARGS_ASSERT_AMAGIC_CMP_LOCALE_DESC \
         assert(str1); assert(str2)
 
 PERL_STATIC_INLINE I32
-S_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2);
+S_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #     define PERL_ARGS_ASSERT_CMP_LOCALE_DESC   \
         assert(str1); assert(str2)
 
 #   endif /* defined(USE_LOCALE_COLLATE) */
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
+# if defined(USE_LOCALE_COLLATE)
+
+# endif
 #endif /* defined(PERL_IN_PP_SORT_C) */
 #if defined(PERL_IN_PP_SYS_C)
 static OP *
-S_doform(pTHX_ CV *cv, GV *gv, OP *retop);
+S_doform(pTHX_ CV *cv, GV *gv, OP *retop)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_DOFORM                \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
         assert(gv)
@@ -8277,18 +9839,21 @@ S_space_join_names_mortal(pTHX_ char * const *array);
 # define PERL_ARGS_ASSERT_SPACE_JOIN_NAMES_MORTAL
 
 static void
-S_warn_not_dirhandle(pTHX_ GV *gv);
+S_warn_not_dirhandle(pTHX_ GV *gv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_WARN_NOT_DIRHANDLE    \
         assert(gv)
 
 # if !defined(HAS_MKDIR) || !defined(HAS_RMDIR)
 static int
 S_dooneliner(pTHX_ const char *cmd, const char *filename)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_DOONELINER          \
         assert(cmd); assert(filename)
 
-# endif
+# endif /* !defined(HAS_MKDIR) || !defined(HAS_RMDIR) */
 #endif /* defined(PERL_IN_PP_SYS_C) */
 #if defined(PERL_IN_REGCOMP_ANY)
 # define PERL_ARGS_ASSERT_ADD_ABOVE_LATIN1_FOLDS \
@@ -8333,51 +9898,88 @@ S_dooneliner(pTHX_ const char *cmd, const char *filename)
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
 Perl_add_above_Latin1_folds(pTHX_ RExC_state_t *pRExC_state, const U8 cp, SV **invlist)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 PERL_CALLCONV regnode *
 Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *source, U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 PERL_CALLCONV SV *
 Perl_get_ANYOFHbbm_contents(pTHX_ const regnode *n)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 PERL_CALLCONV SV *
 Perl_get_ANYOFM_contents(pTHX_ const regnode *n)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 PERL_CALLCONV U32
 Perl_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan, UV *min_subtract, bool *unfolded_multi_char, U32 flags, regnode *val, U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__visibility__("hidden");
 PERL_CALLCONV I32
 Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch, regnode *first, regnode *last, regnode *tail, U32 word_count, U32 flags, U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5)
         __attribute__visibility__("hidden");
 PERL_CALLCONV void
 Perl_populate_anyof_bitmap_from_invlist(pTHX_ regnode *node, SV **invlist_ptr)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 PERL_CALLCONV U32
 Perl_reg_add_data(RExC_state_t * const pRExC_state, const char * const s, const U32 n)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 PERL_CALLCONV void
 Perl_scan_commit(pTHX_ const RExC_state_t *pRExC_state, struct scan_data_t *data, SSize_t *minlenp, int is_inf)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 PERL_CALLCONV void
 Perl_set_ANYOF_arg(pTHX_ RExC_state_t * const pRExC_state, regnode * const node, SV * const cp_list, SV * const runtime_defns, SV * const only_utf8_locale_list)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 PERL_CALLCONV void
 Perl_ssc_init(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 PERL_CALLCONV SSize_t
 Perl_study_chunk(pTHX_ RExC_state_t *pRExC_state, regnode **scanp, SSize_t *minlenp, SSize_t *deltap, regnode *last, struct scan_data_t *data, I32 stopparen, U32 recursed_depth, regnode_ssc *and_withp, U32 flags, U32 depth, bool was_mutate_ok)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5)
         __attribute__visibility__("hidden");
 #   if defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING)
 static void
-S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 depth);
+S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 static void
-S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 next_alloc, U32 depth);
+S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 next_alloc, U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 static void
-S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 next_alloc, U32 depth);
-#   endif
+S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 next_alloc, U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
+#   endif /* defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING) */
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING)
 #   define PERL_ARGS_ASSERT_DUMP_TRIE           \
@@ -8409,15 +10011,19 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie, HV *widecharm
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE SV *
 S_invlist_contents(pTHX_ SV * const invlist, const bool traditional_style)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE UV
 S_invlist_highest_range_start(SV * const invlist)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE bool
 S_invlist_is_iterating(const SV * const invlist)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE UV
 S_invlist_lowest(SV * const invlist)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 #   endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
@@ -8428,9 +10034,10 @@ S_invlist_lowest(SV * const invlist)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
-Perl_invlist_clone(pTHX_ SV * const invlist, SV *newlist);
+Perl_invlist_clone(pTHX_ SV * const invlist, SV *newlist)
+        Perl_attribute_nonnull_(pTHX_1);
 # endif
-#endif
+#endif /* defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_REGCOMP_C)
 # define PERL_ARGS_ASSERT_ADD_MULTI_MATCH       \
         assert(!multi_char_matches || SvTYPE(multi_char_matches) == SVt_PVAV); \
@@ -8496,6 +10103,7 @@ Perl_invlist_clone(pTHX_ SV * const invlist, SV *newlist);
 
 PERL_STATIC_NO_RET void
 S_re_croak(pTHX_ bool utf8, const char *pat, ...)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__noreturn__
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 # define PERL_ARGS_ASSERT_RE_CROAK              \
@@ -8573,94 +10181,174 @@ S_re_croak(pTHX_ bool utf8, const char *pat, ...)
 # endif /* defined(DEBUGGING) */
 # if defined(PERL_CORE) || defined(PERL_EXT)
 static AV *
-S_add_multi_match(pTHX_ AV *multi_char_matches, SV *multi_string, const STRLEN cp_count);
+S_add_multi_match(pTHX_ AV *multi_char_matches, SV *multi_string, const STRLEN cp_count)
+        Perl_attribute_nonnull_(pTHX_2);
 static void
-S_change_engine_size(pTHX_ RExC_state_t *pRExC_state, const ptrdiff_t size);
+S_change_engine_size(pTHX_ RExC_state_t *pRExC_state, const ptrdiff_t size)
+        Perl_attribute_nonnull_(pTHX_1);
 static REGEXP *
 S_compile_wildcard(pTHX_ const char *subpattern, const STRLEN len, const bool ignore_case)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 static U8
-S_compute_EXACTish(RExC_state_t *pRExC_state);
+S_compute_EXACTish(RExC_state_t *pRExC_state)
+        Perl_attribute_nonnull_(1);
 static int
 S_edit_distance(const UV *src, const UV *tgt, const STRLEN x, const STRLEN y, const SSize_t maxDistance)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 static I32
-S_execute_wildcard(pTHX_ REGEXP * const prog, char *stringarg, char *strend, char *strbeg, SSize_t minend, SV *screamer, U32 nosave);
+S_execute_wildcard(pTHX_ REGEXP * const prog, char *stringarg, char *strend, char *strbeg, SSize_t minend, SV *screamer, U32 nosave)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_6);
 static U32
-S_get_quantifier_value(pTHX_ RExC_state_t *pRExC_state, const char *start, const char *end);
+S_get_quantifier_value(pTHX_ RExC_state_t *pRExC_state, const char *start, const char *end)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 static bool
-S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state, regnode_offset *nodep, UV *code_point_p, int *cp_count, I32 *flagp, const bool strict, const U32 depth);
+S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state, regnode_offset *nodep, UV *code_point_p, int *cp_count, I32 *flagp, const bool strict, const U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_5);
 static regnode_offset
-S_handle_named_backref(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, char *backref_parse_start, char ch);
+S_handle_named_backref(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, char *backref_parse_start, char ch)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 static bool
-S_handle_names_wildcard(pTHX_ const char *wname, const STRLEN wname_len, SV **prop_definition, AV **strings);
+S_handle_names_wildcard(pTHX_ const char *wname, const STRLEN wname_len, SV **prop_definition, AV **strings)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4);
 static int
-S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state, const char * const s, char **updated_parse_ptr, AV **posix_warnings, const bool check_only);
+S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state, const char * const s, char **updated_parse_ptr, AV **posix_warnings, const bool check_only)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 static regnode_offset
-S_handle_regex_sets(pTHX_ RExC_state_t *pRExC_state, SV **return_invlist, I32 *flagp, U32 depth);
+S_handle_regex_sets(pTHX_ RExC_state_t *pRExC_state, SV **return_invlist, I32 *flagp, U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 static SV *
-S_handle_user_defined_property(pTHX_ const char *name, const STRLEN name_len, const bool is_utf8, const bool to_fold, const bool runtime, const bool deferrable, SV *contents, bool *user_defined_ptr, SV *msg, const STRLEN level);
+S_handle_user_defined_property(pTHX_ const char *name, const STRLEN name_len, const bool is_utf8, const bool to_fold, const bool runtime, const bool deferrable, SV *contents, bool *user_defined_ptr, SV *msg, const STRLEN level)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_7)
+        Perl_attribute_nonnull_(pTHX_8)
+        Perl_attribute_nonnull_(pTHX_9);
 static bool
-S_is_ssc_worth_it(const RExC_state_t *pRExC_state, const regnode_ssc *ssc);
+S_is_ssc_worth_it(const RExC_state_t *pRExC_state, const regnode_ssc *ssc)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2);
 static void
-S_nextchar(pTHX_ RExC_state_t *pRExC_state);
+S_nextchar(pTHX_ RExC_state_t *pRExC_state)
+        Perl_attribute_nonnull_(pTHX_1);
 static U8
-S_optimize_regclass(pTHX_ RExC_state_t *pRExC_state, SV *cp_list, SV *only_utf8_locale_list, SV *upper_latin1_only_utf8_matches, const U32 has_runtime_dependency, const U32 posixl, U8 *anyof_flags, bool *invert, regnode_offset *ret, I32 *flagp);
+S_optimize_regclass(pTHX_ RExC_state_t *pRExC_state, SV *cp_list, SV *only_utf8_locale_list, SV *upper_latin1_only_utf8_matches, const U32 has_runtime_dependency, const U32 posixl, U8 *anyof_flags, bool *invert, regnode_offset *ret, I32 *flagp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_7)
+        Perl_attribute_nonnull_(pTHX_8)
+        Perl_attribute_nonnull_(pTHX_9)
+        Perl_attribute_nonnull_(pTHX_10);
 static void
-S_output_posix_warnings(pTHX_ RExC_state_t *pRExC_state, AV *posix_warnings);
+S_output_posix_warnings(pTHX_ RExC_state_t *pRExC_state, AV *posix_warnings)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 static void
-S_parse_lparen_question_flags(pTHX_ RExC_state_t *pRExC_state);
+S_parse_lparen_question_flags(pTHX_ RExC_state_t *pRExC_state)
+        Perl_attribute_nonnull_(pTHX_1);
 static SV *
-S_parse_uniprop_string(pTHX_ const char * const name, Size_t name_len, const bool is_utf8, const bool to_fold, const bool runtime, const bool deferrable, AV **strings, bool *user_defined_ptr, SV *msg, const STRLEN level);
+S_parse_uniprop_string(pTHX_ const char * const name, Size_t name_len, const bool is_utf8, const bool to_fold, const bool runtime, const bool deferrable, AV **strings, bool *user_defined_ptr, SV *msg, const STRLEN level)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_8)
+        Perl_attribute_nonnull_(pTHX_9);
 static regnode_offset
-S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth);
+S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 static regnode_offset
-S_reg1node(pTHX_ RExC_state_t *pRExC_state, U8 op, U32 arg);
+S_reg1node(pTHX_ RExC_state_t *pRExC_state, U8 op, U32 arg)
+        Perl_attribute_nonnull_(pTHX_1);
 static regnode_offset
-S_reg2node(pTHX_ RExC_state_t *pRExC_state, const U8 op, const U32 arg1, const I32 arg2);
+S_reg2node(pTHX_ RExC_state_t *pRExC_state, const U8 op, const U32 arg1, const I32 arg2)
+        Perl_attribute_nonnull_(pTHX_1);
 static regnode_offset
-S_reg_la_NOTHING(pTHX_ RExC_state_t *pRExC_state, U32 flags, const char *type);
+S_reg_la_NOTHING(pTHX_ RExC_state_t *pRExC_state, U32 flags, const char *type)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 static regnode_offset
-S_reg_la_OPFAIL(pTHX_ RExC_state_t *pRExC_state, U32 flags, const char *type);
+S_reg_la_OPFAIL(pTHX_ RExC_state_t *pRExC_state, U32 flags, const char *type)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 static regnode_offset
-S_reg_node(pTHX_ RExC_state_t *pRExC_state, U8 op);
+S_reg_node(pTHX_ RExC_state_t *pRExC_state, U8 op)
+        Perl_attribute_nonnull_(pTHX_1);
 static SV *
-S_reg_scan_name(pTHX_ RExC_state_t *pRExC_state, U32 flags);
+S_reg_scan_name(pTHX_ RExC_state_t *pRExC_state, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 static regnode_offset
-S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth);
+S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 static regnode_offset
-S_regbranch(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, I32 first, U32 depth);
+S_regbranch(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, I32 first, U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 static regnode_offset
-S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth, const bool stop_at_1, bool allow_multi_fold, const bool silence_non_portable, const bool strict, bool optimizable, SV **ret_invlist);
+S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth, const bool stop_at_1, bool allow_multi_fold, const bool silence_non_portable, const bool strict, bool optimizable, SV **ret_invlist)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 static unsigned int
 S_regex_set_precedence(const U8 my_operator)
         __attribute__warn_unused_result__;
 static void
-S_reginsert(pTHX_ RExC_state_t *pRExC_state, const U8 op, const regnode_offset operand, const U32 depth);
+S_reginsert(pTHX_ RExC_state_t *pRExC_state, const U8 op, const regnode_offset operand, const U32 depth)
+        Perl_attribute_nonnull_(pTHX_1);
 static regnode_offset
-S_regnode_guts(pTHX_ RExC_state_t *pRExC_state, const STRLEN extra_len);
+S_regnode_guts(pTHX_ RExC_state_t *pRExC_state, const STRLEN extra_len)
+        Perl_attribute_nonnull_(pTHX_1);
 static regnode_offset
-S_regpiece(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth);
+S_regpiece(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 static regnode_offset
-S_regpnode(pTHX_ RExC_state_t *pRExC_state, U8 op, SV *arg);
+S_regpnode(pTHX_ RExC_state_t *pRExC_state, U8 op, SV *arg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 static bool
 S_regtail(pTHX_ RExC_state_t *pRExC_state, const regnode_offset p, const regnode_offset val, const U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 static void
-S_set_regex_pv(pTHX_ RExC_state_t *pRExC_state, REGEXP *Rx);
+S_set_regex_pv(pTHX_ RExC_state_t *pRExC_state, REGEXP *Rx)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 static void
-S_skip_to_be_ignored_text(pTHX_ RExC_state_t *pRExC_state, char **p, const bool force_to_xmod);
+S_skip_to_be_ignored_text(pTHX_ RExC_state_t *pRExC_state, char **p, const bool force_to_xmod)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 static void
-S_ssc_finalize(pTHX_ RExC_state_t *pRExC_state, regnode_ssc *ssc);
+S_ssc_finalize(pTHX_ RExC_state_t *pRExC_state, regnode_ssc *ssc)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   if defined(DEBUGGING)
 static regnode_offset
-S_regnode_guts_debug(pTHX_ RExC_state_t *pRExC_state, const U8 op, const STRLEN extra_len);
+S_regnode_guts_debug(pTHX_ RExC_state_t *pRExC_state, const U8 op, const STRLEN extra_len)
+        Perl_attribute_nonnull_(pTHX_1);
 static bool
 S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p, const regnode_offset val, U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 #     if defined(ENABLE_REGEX_SETS_DEBUGGING)
 static void
-S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state, AV *stack, const IV fence, AV *fence_stack);
+S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state, AV *stack, const IV fence, AV *fence_stack)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_4);
 #     endif
 #   endif /* defined(DEBUGGING) */
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
@@ -8673,9 +10361,13 @@ S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state, AV *stack, const I
 
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE Size_t
-S_find_first_differing_byte_pos(const U8 *s1, const U8 *s2, const Size_t max);
+S_find_first_differing_byte_pos(const U8 *s1, const U8 *s2, const Size_t max)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2);
 PERL_STATIC_INLINE char *
-S_reg_skipcomment(RExC_state_t *pRExC_state, char *p);
+S_reg_skipcomment(RExC_state_t *pRExC_state, char *p)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2);
 #   endif
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_REGCOMP_C) */
@@ -8689,11 +10381,15 @@ S_reg_skipcomment(RExC_state_t *pRExC_state, char *p);
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
 Perl_populate_bitmap_from_invlist(pTHX_ SV *invlist, const UV offset, const U8 *bitmap, const Size_t len)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 PERL_CALLCONV void
 Perl_populate_invlist_from_bitmap(pTHX_ const U8 *bitmap, const Size_t bitmap_len, SV **invlist, const UV offset)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
-# endif
+# endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 #endif /* defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGCOMP_INVLIST_C) */
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
     defined(PERL_IN_TOKE_C)
@@ -8715,6 +10411,8 @@ Perl_populate_invlist_from_bitmap(pTHX_ const U8 *bitmap, const Size_t bitmap_le
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV bool
 Perl_regcurly(const char *s, const char *e, const char *result[5])
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 # endif
 #endif /* defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_TOKE_C) */
@@ -8744,7 +10442,8 @@ Perl_regcurly(const char *s, const char *e, const char *result[5])
         assert(invlist)
 
 static void
-S_initialize_invlist_guts(pTHX_ SV *invlist, const Size_t initial_size);
+S_initialize_invlist_guts(pTHX_ SV *invlist, const Size_t initial_size)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_INITIALIZE_INVLIST_GUTS \
         assert(invlist)
 
@@ -8753,9 +10452,12 @@ S_initialize_invlist_guts(pTHX_ SV *invlist, const Size_t initial_size);
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 static void
-S_append_range_to_invlist_(pTHX_ SV * const invlist, const UV start, const UV end);
+S_append_range_to_invlist_(pTHX_ SV * const invlist, const UV start, const UV end)
+        Perl_attribute_nonnull_(pTHX_1);
 static void
-S_invlist_replace_list_destroys_src(pTHX_ SV *dest, SV *src);
+S_invlist_replace_list_destroys_src(pTHX_ SV *dest, SV *src)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 #   define PERL_ARGS_ASSERT_GET_INVLIST_PREVIOUS_INDEX_ADDR \
@@ -8782,22 +10484,29 @@ S_invlist_replace_list_destroys_src(pTHX_ SV *dest, SV *src);
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE IV *
 S_get_invlist_previous_index_addr(SV *invlist)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE UV *
 S_invlist_array_init_(SV * const invlist, const bool will_have_0)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE void
-S_invlist_clear(pTHX_ SV *invlist);
+S_invlist_clear(pTHX_ SV *invlist)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_STATIC_INLINE UV
 S_invlist_max(const SV * const invlist)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE IV
 S_invlist_previous_index(SV * const invlist)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE void
-S_invlist_set_previous_index(SV * const invlist, const IV index);
+S_invlist_set_previous_index(SV * const invlist, const IV index)
+        Perl_attribute_nonnull_(1);
 PERL_STATIC_INLINE void
-S_invlist_trim(SV *invlist);
+S_invlist_trim(SV *invlist)
+        Perl_attribute_nonnull_(1);
 #   endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_REGCOMP_INVLIST_C) && !defined(PERL_EXT_RE_BUILD) */
@@ -8846,36 +10555,59 @@ S_invlist_trim(SV *invlist);
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 static SV *
-S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state, const regnode_charclass * const node);
+S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state, const regnode_charclass * const node)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 static SV *
 S_make_exactf_invlist(pTHX_ RExC_state_t *pRExC_state, regnode *node)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static void
-S_rck_elide_nothing(pTHX_ regnode *node);
+S_rck_elide_nothing(pTHX_ regnode *node)
+        Perl_attribute_nonnull_(pTHX_1);
 static void
-S_ssc_add_range(pTHX_ regnode_ssc *ssc, UV const start, UV const end);
+S_ssc_add_range(pTHX_ regnode_ssc *ssc, UV const start, UV const end)
+        Perl_attribute_nonnull_(pTHX_1);
 static void
-S_ssc_and(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc, const regnode_charclass *and_with);
+S_ssc_and(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc, const regnode_charclass *and_with)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 static void
-S_ssc_anything(pTHX_ regnode_ssc *ssc);
+S_ssc_anything(pTHX_ regnode_ssc *ssc)
+        Perl_attribute_nonnull_(pTHX_1);
 static void
-S_ssc_clear_locale(regnode_ssc *ssc);
+S_ssc_clear_locale(regnode_ssc *ssc)
+        Perl_attribute_nonnull_(1);
 static void
-S_ssc_cp_and(pTHX_ regnode_ssc *ssc, UV const cp);
+S_ssc_cp_and(pTHX_ regnode_ssc *ssc, UV const cp)
+        Perl_attribute_nonnull_(pTHX_1);
 static void
-S_ssc_intersection(pTHX_ regnode_ssc *ssc, SV * const invlist, const bool invert_2nd);
+S_ssc_intersection(pTHX_ regnode_ssc *ssc, SV * const invlist, const bool invert_2nd)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 static int
 S_ssc_is_anything(const regnode_ssc *ssc)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 static int
 S_ssc_is_cp_posixl_init(const RExC_state_t *pRExC_state, const regnode_ssc *ssc)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 static void
-S_ssc_or(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc, const regnode_charclass *or_with);
+S_ssc_or(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc, const regnode_charclass *or_with)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 static void
-S_ssc_union(pTHX_ regnode_ssc *ssc, SV * const invlist, const bool invert_2nd);
+S_ssc_union(pTHX_ regnode_ssc *ssc, SV * const invlist, const bool invert_2nd)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 static void
-S_unwind_scan_frames(pTHX_ void *p);
+S_unwind_scan_frames(pTHX_ void *p)
+        Perl_attribute_nonnull_(pTHX_1);
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 #endif /* defined(PERL_IN_REGCOMP_STUDY_C) */
 #if defined(PERL_IN_REGEXEC_C)
@@ -8992,95 +10724,169 @@ S_unwind_scan_frames(pTHX_ void *p);
 # if defined(PERL_CORE) || defined(PERL_EXT)
 static LB_enum
 S_advance_one_LB(pTHX_ U8 **curpos, const U8 * const strend, const bool utf8_target)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static SB_enum
 S_advance_one_SB(pTHX_ U8 **curpos, const U8 * const strend, const bool utf8_target)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static WB_enum
 S_advance_one_WB_(pTHX_ U8 **curpos, const U8 * const strend, const bool utf8_target, const bool skip_Extend_Format)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static GCB_enum
 S_backup_one_GCB(pTHX_ const U8 * const strbeg, U8 **curpos, const bool utf8_target)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static LB_enum
 S_backup_one_LB_(pTHX_ const U8 * const strbeg, U8 **curpos, const bool utf8_target, bool skip_CM_ZWJ)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static SB_enum
 S_backup_one_SB(pTHX_ const U8 * const strbeg, U8 **curpos, const bool utf8_target)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static WB_enum
 S_backup_one_WB_but_over_Extend_FO(pTHX_ WB_enum *previous, const U8 * const strbeg, U8 **curpos, const bool utf8_target)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 static char *
 S_find_byclass(pTHX_ regexp *prog, const regnode *c, char *s, const char *strend, regmatch_info *reginfo)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 static U8 *
 S_find_next_masked(U8 *s, const U8 *send, const U8 byte, const U8 mask)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 static U8 *
 S_find_span_end(U8 *s, const U8 *send, const U8 span_byte)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 static U8 *
 S_find_span_end_mask(U8 *s, const U8 *send, const U8 span_byte, const U8 mask)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 static bool
 S_isFOO_lc(pTHX_ const U8 classnum, const U8 character)
         __attribute__warn_unused_result__;
 static bool
 S_isFOO_utf8_lc(pTHX_ const U8 classnum, const U8 *character, const U8 *e)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 static bool
 S_isGCB(pTHX_ const GCB_enum before, const GCB_enum after, const U8 * const strbeg, const U8 * const curpos, const bool utf8_target)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 static bool
 S_isLB(pTHX_ LB_enum before, LB_enum after, const U8 * const strbeg, const U8 * const curpos, const U8 * const strend, const bool utf8_target)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5)
         __attribute__warn_unused_result__;
 static bool
 S_isSB(pTHX_ SB_enum before, SB_enum after, const U8 * const strbeg, const U8 * const curpos, const U8 * const strend, const bool utf8_target)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5)
         __attribute__warn_unused_result__;
 static bool
 S_isWB(pTHX_ WB_enum previous, WB_enum before, WB_enum after, const U8 * const strbeg, const U8 * const curpos, const U8 * const strend, const bool utf8_target)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5)
+        Perl_attribute_nonnull_(pTHX_6)
         __attribute__warn_unused_result__;
 static I32
 S_reg_check_named_buff_matched(const regexp *rex, const regnode *scan)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 static void
-S_regcp_restore(pTHX_ regexp *rex, I32 ix, U32 *maxopenparen_p comma_pDEPTH);
+S_regcp_restore(pTHX_ regexp *rex, I32 ix, U32 *maxopenparen_p comma_pDEPTH)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 static void
-S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH);
+S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 static CHECKPOINT
-S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEPTH);
+S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEPTH)
+        Perl_attribute_nonnull_(pTHX_1);
 static U8 *
 S_reghop3(U8 *s, SSize_t off, const U8 *lim)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(3)
         __attribute__warn_unused_result__;
 static U8 *
 S_reghopmaybe3(U8 *s, SSize_t off, const U8 * const lim)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(3)
         __attribute__warn_unused_result__;
 static bool
 S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8 * const p, const U8 * const p_end, bool const utf8_target)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 static SSize_t
 S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 static I32
 S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p, char *loceol, regmatch_info * const reginfo, I32 max comma_pDEPTH)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5)
         __attribute__warn_unused_result__;
 static bool
 S_regtry(pTHX_ regmatch_info *reginfo, char **startposp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 static bool
-S_to_byte_substr(pTHX_ regexp *prog);
+S_to_byte_substr(pTHX_ regexp *prog)
+        Perl_attribute_nonnull_(pTHX_1);
 static void
-S_to_utf8_substr(pTHX_ regexp *prog);
+S_to_utf8_substr(pTHX_ regexp *prog)
+        Perl_attribute_nonnull_(pTHX_1);
 #   if defined(DEBUGGING)
 static void
-S_debug_start_match(pTHX_ const REGEXP *prog, const bool do_utf8, const char *start, const char *end, const char *blurb);
+S_debug_start_match(pTHX_ const REGEXP *prog, const bool do_utf8, const char *start, const char *end, const char *blurb)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5);
 static void
-S_dump_exec_pos(pTHX_ const char *locinput, const regnode *scan, const char *loc_regeol, const char *loc_bostr, const char *loc_reg_starttry, const bool do_utf8, const U32 depth);
+S_dump_exec_pos(pTHX_ const char *locinput, const regnode *scan, const char *loc_regeol, const char *loc_bostr, const char *loc_reg_starttry, const bool do_utf8, const U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5);
 PERL_CALLCONV int
 Perl_re_exec_indentf(pTHX_ const char *fmt, U32 depth, ...)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
-#   endif
+#   endif /* defined(DEBUGGING) */
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 #   define PERL_ARGS_ASSERT_CAPTURE_CLEAR       \
@@ -9094,12 +10900,17 @@ Perl_re_exec_indentf(pTHX_ const char *fmt, U32 depth, ...)
 
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE void
-S_capture_clear(pTHX_ regexp *rex, U16 from_ix, U16 to_ix, const char *str comma_pDEPTH);
+S_capture_clear(pTHX_ regexp *rex, U16 from_ix, U16 to_ix, const char *str comma_pDEPTH)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_4);
 PERL_STATIC_INLINE I32
-S_foldEQ_latin1_s2_folded(pTHX_ const char *a, const char *b, I32 len);
+S_foldEQ_latin1_s2_folded(pTHX_ const char *a, const char *b, I32 len)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 PERL_STATIC_INLINE void
-S_unwind_paren(pTHX_ regexp *rex, U32 lp, U32 lcp comma_pDEPTH);
-#   endif
+S_unwind_paren(pTHX_ regexp *rex, U32 lp, U32 lcp comma_pDEPTH)
+        Perl_attribute_nonnull_(pTHX_1);
+#   endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_REGEXEC_C) */
 #if defined(PERL_IN_REGEX_ENGINE)
@@ -9129,25 +10940,38 @@ S_unwind_paren(pTHX_ regexp *rex, U32 lp, U32 lcp comma_pDEPTH);
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
 Perl_debug_peep(pTHX_ const char *str, const RExC_state_t *pRExC_state, regnode *scan, U32 depth, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 PERL_CALLCONV void
 Perl_debug_show_study_flags(pTHX_ U32 flags, const char *open_str, const char *close_str)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 PERL_CALLCONV void
 Perl_debug_studydata(pTHX_ const char *where, scan_data_t *data, U32 depth, int is_inf, SSize_t min, SSize_t stopmin, SSize_t delta)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 PERL_CALLCONV const regnode *
 Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node, const regnode *last, const regnode *plast, SV *sv, I32 indent, U32 depth)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_6)
         __attribute__visibility__("hidden");
 PERL_CALLCONV int
 Perl_re_indentf(pTHX_ const char *fmt, U32 depth, ...)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 PERL_CALLCONV int
 Perl_re_printf(pTHX_ const char *fmt, ...)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden")
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 PERL_CALLCONV void
 Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_info *reginfo, const RExC_state_t *pRExC_state)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 #   endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # endif /* defined(DEBUGGING) */
@@ -9158,6 +10982,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
 Perl_get_re_gclass_aux_data(pTHX_ const regexp *prog, const struct regnode *node, bool doinit, SV **listsvp, SV **lonly_utf8_locale, SV **output_invlist)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #   endif
 # else /* if !defined(PERL_EXT_RE_BUILD) */
@@ -9167,6 +10992,7 @@ Perl_get_re_gclass_aux_data(pTHX_ const regexp *prog, const struct regnode *node
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
 Perl_get_regclass_aux_data(pTHX_ const regexp *prog, const struct regnode *node, bool doinit, SV **listsvp, SV **lonly_utf8_locale, SV **output_invlist)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #   endif
 # endif /* !defined(PERL_EXT_RE_BUILD) */
@@ -9194,146 +11020,191 @@ S_save_pushptri32ptr(pTHX_ void * const ptr1, const I32 i, void * const ptr2, co
 # define PERL_ARGS_ASSERT_SAVE_PUSHPTRI32PTR
 
 static SV *
-S_save_scalar_at(pTHX_ SV **sptr, const U32 flags);
+S_save_scalar_at(pTHX_ SV **sptr, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SAVE_SCALAR_AT        \
         assert(sptr)
 
 #endif /* defined(PERL_IN_SCOPE_C) */
 #if defined(PERL_IN_SV_C)
 static char *
-S_F0convert(NV nv, char * const endbuf, STRLEN * const len);
+S_F0convert(NV nv, char * const endbuf, STRLEN * const len)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(3);
 # define PERL_ARGS_ASSERT_F0CONVERT             \
         assert(endbuf); assert(len)
 
 static void
-S_anonymise_cv_maybe(pTHX_ GV *gv, CV *cv);
+S_anonymise_cv_maybe(pTHX_ GV *gv, CV *cv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_ANONYMISE_CV_MAYBE    \
         assert(gv); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 static void
-S_assert_uft8_cache_coherent(pTHX_ const char * const func, STRLEN from_cache, STRLEN real, SV * const sv);
+S_assert_uft8_cache_coherent(pTHX_ const char * const func, STRLEN from_cache, STRLEN real, SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_ASSERT_UFT8_CACHE_COHERENT \
         assert(func); assert(sv)
 
 static void
-S_croak_sv_setsv_flags(pTHX_ SV * const dsv, SV * const ssv);
+S_croak_sv_setsv_flags(pTHX_ SV * const dsv, SV * const ssv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_CROAK_SV_SETSV_FLAGS  \
         assert(dsv); assert(ssv)
 
 static bool
-S_curse(pTHX_ SV * const sv, const bool check_refcnt);
+S_curse(pTHX_ SV * const sv, const bool check_refcnt)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CURSE                 \
         assert(sv)
 
 static STRLEN
 S_expect_number(pTHX_ const char ** const pattern)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_EXPECT_NUMBER         \
         assert(pattern)
 
 static SSize_t
-S_find_array_subscript(pTHX_ const AV * const av, const SV * const val);
+S_find_array_subscript(pTHX_ const AV * const av, const SV * const val)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_ARRAY_SUBSCRIPT  \
         assert(val)
 
 static SV *
-S_find_hash_subscript(pTHX_ const HV * const hv, const SV * const val);
+S_find_hash_subscript(pTHX_ const HV * const hv, const SV * const val)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_HASH_SUBSCRIPT   \
         assert(val)
 
 static SV *
-S_find_uninit_var(pTHX_ const OP * const obase, const SV * const uninit_sv, bool match, const char **desc_p);
+S_find_uninit_var(pTHX_ const OP * const obase, const SV * const uninit_sv, bool match, const char **desc_p)
+        Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_FIND_UNINIT_VAR       \
         assert(desc_p)
 
 static bool
-S_glob_2number(pTHX_ GV * const gv);
+S_glob_2number(pTHX_ GV * const gv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_GLOB_2NUMBER          \
         assert(gv)
 
 static void
-S_glob_assign_glob(pTHX_ SV * const dsv, SV * const ssv, const int dtype);
+S_glob_assign_glob(pTHX_ SV * const dsv, SV * const ssv, const int dtype)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_GLOB_ASSIGN_GLOB      \
         assert(dsv); assert(ssv)
 
 static void
-S_not_a_number(pTHX_ SV * const sv);
+S_not_a_number(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_NOT_A_NUMBER          \
         assert(sv)
 
 static void
-S_not_incrementable(pTHX_ SV * const sv);
+S_not_incrementable(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_NOT_INCREMENTABLE     \
         assert(sv)
 
 static PTR_TBL_ENT_t *
 S_ptr_table_find(PTR_TBL_t * const tbl, const void * const sv)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_PTR_TABLE_FIND        \
         assert(tbl)
 
 static bool
-S_sv_2iuv_common(pTHX_ SV * const sv);
+S_sv_2iuv_common(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_2IUV_COMMON        \
         assert(sv)
 
 static void
-S_sv_add_arena(pTHX_ char * const ptr, const U32 size, const U32 flags);
+S_sv_add_arena(pTHX_ char * const ptr, const U32 size, const U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_ADD_ARENA          \
         assert(ptr)
 
 static const char *
-S_sv_display(pTHX_ SV * const sv, char *tmpbuf, STRLEN tmpbuf_size);
+S_sv_display(pTHX_ SV * const sv, char *tmpbuf, STRLEN tmpbuf_size)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_SV_DISPLAY            \
         assert(sv); assert(tmpbuf)
 
 static bool
-S_sv_numcmp_common(pTHX_ SV **sv1, SV **sv2, const U32 flags, int method, SV **result);
+S_sv_numcmp_common(pTHX_ SV **sv1, SV **sv2, const U32 flags, int method, SV **result)
+        Perl_attribute_nonnull_(pTHX_5);
 # define PERL_ARGS_ASSERT_SV_NUMCMP_COMMON      \
         assert(result)
 
 static STRLEN
-S_sv_pos_b2u_midway(pTHX_ const U8 * const s, const U8 * const target, const U8 *end, STRLEN endu);
+S_sv_pos_b2u_midway(pTHX_ const U8 * const s, const U8 * const target, const U8 *end, STRLEN endu)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_SV_POS_B2U_MIDWAY     \
         assert(s); assert(target); assert(end); assert(s <= target); \
         assert(target <= end)
 
 static STRLEN
-S_sv_pos_u2b_cached(pTHX_ SV * const sv, MAGIC ** const mgp, const U8 * const start, const U8 * const send, STRLEN uoffset, STRLEN uoffset0, STRLEN boffset0);
+S_sv_pos_u2b_cached(pTHX_ SV * const sv, MAGIC ** const mgp, const U8 * const start, const U8 * const send, STRLEN uoffset, STRLEN uoffset0, STRLEN boffset0)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_SV_POS_U2B_CACHED     \
         assert(sv); assert(mgp); assert(start); assert(send); \
         assert(start < send)
 
 static STRLEN
-S_sv_pos_u2b_forwards(const U8 * const start, const U8 * const send, STRLEN * const uoffset, bool * const at_end, bool *canonical_position);
+S_sv_pos_u2b_forwards(const U8 * const start, const U8 * const send, STRLEN * const uoffset, bool * const at_end, bool *canonical_position)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(3)
+        Perl_attribute_nonnull_(4)
+        Perl_attribute_nonnull_(5);
 # define PERL_ARGS_ASSERT_SV_POS_U2B_FORWARDS   \
         assert(start); assert(send); assert(uoffset); assert(at_end); \
         assert(canonical_position); assert(start < send)
 
 static STRLEN
-S_sv_pos_u2b_midway(const U8 * const start, const U8 *send, STRLEN uoffset, const STRLEN uend);
+S_sv_pos_u2b_midway(const U8 * const start, const U8 *send, STRLEN uoffset, const STRLEN uend)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2);
 # define PERL_ARGS_ASSERT_SV_POS_U2B_MIDWAY     \
         assert(start); assert(send); assert(start < send)
 
 static void
-S_utf8_mg_len_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN ulen);
+S_utf8_mg_len_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN ulen)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_MG_LEN_CACHE_UPDATE \
         assert(sv); assert(mgp)
 
 static void
-S_utf8_mg_pos_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN byte, const STRLEN utf8, const STRLEN blen);
+S_utf8_mg_pos_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN byte, const STRLEN utf8, const STRLEN blen)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_MG_POS_CACHE_UPDATE \
         assert(sv); assert(mgp)
 
 static SSize_t
-S_visit(pTHX_ SVFUNC_t f, const U32 flags, const U32 mask);
+S_visit(pTHX_ SVFUNC_t f, const U32 flags, const U32 mask)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_VISIT                 \
         assert(f)
 
 # if defined(DEBUGGING)
 static void
-S_del_sv(pTHX_ SV *p);
+S_del_sv(pTHX_ SV *p)
+        Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_DEL_SV              \
         assert(p)
 
@@ -9351,13 +11222,15 @@ Perl_sv_sweep_arenas(pTHX)
 # if !defined(NV_PRESERVES_UV)
 #   if defined(DEBUGGING)
 static int
-S_sv_2iuv_non_preserve(pTHX_ SV * const sv, I32 numtype);
+S_sv_2iuv_non_preserve(pTHX_ SV * const sv, I32 numtype)
+        Perl_attribute_nonnull_(pTHX_1);
 #     define PERL_ARGS_ASSERT_SV_2IUV_NON_PRESERVE \
         assert(sv)
 
 #   else
 static int
-S_sv_2iuv_non_preserve(pTHX_ SV * const sv);
+S_sv_2iuv_non_preserve(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #     define PERL_ARGS_ASSERT_SV_2IUV_NON_PRESERVE \
         assert(sv)
 
@@ -9365,14 +11238,16 @@ S_sv_2iuv_non_preserve(pTHX_ SV * const sv);
 # endif /* !defined(NV_PRESERVES_UV) */
 # if defined(PERL_DEBUG_READONLY_COW)
 static void
-S_sv_buf_to_rw(pTHX_ SV *sv);
+S_sv_buf_to_rw(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_SV_BUF_TO_RW        \
         assert(sv)
 
 # endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE void
-S_sv_unglob(pTHX_ SV * const sv, U32 flags);
+S_sv_unglob(pTHX_ SV * const sv, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_SV_UNGLOB           \
         assert(sv)
 
@@ -9380,22 +11255,31 @@ S_sv_unglob(pTHX_ SV * const sv, U32 flags);
 # if defined(USE_ITHREADS)
 static SV *
 S_sv_dup_common(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_SV_DUP_COMMON       \
         assert(ssv); assert(param)
 
 static void
-S_sv_dup_hvaux(pTHX_ const SV * const ssv, SV *dsv, CLONE_PARAMS * const param);
+S_sv_dup_hvaux(pTHX_ const SV * const ssv, SV *dsv, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 #   define PERL_ARGS_ASSERT_SV_DUP_HVAUX        \
         assert(ssv); assert(dsv); assert(param)
 
 static SV **
-S_sv_dup_inc_multiple(pTHX_ SV * const *source, SV **dest, SSize_t items, CLONE_PARAMS * const param);
+S_sv_dup_inc_multiple(pTHX_ SV * const *source, SV **dest, SSize_t items, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_4);
 #   define PERL_ARGS_ASSERT_SV_DUP_INC_MULTIPLE \
         assert(source); assert(dest); assert(param)
 
 static void
-S_unreferenced_to_tmp_stack(pTHX_ AV * const unreferenced);
+S_unreferenced_to_tmp_stack(pTHX_ AV * const unreferenced)
+        Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_UNREFERENCED_TO_TMP_STACK \
         assert(unreferenced); assert(SvTYPE(unreferenced) == SVt_PVAV)
 
@@ -9411,24 +11295,30 @@ S_check_unary(pTHX);
 # define PERL_ARGS_ASSERT_CHECK_UNARY
 
 static void
-S_checkcomma(pTHX_ const char *s, const char *name, const char *what);
+S_checkcomma(pTHX_ const char *s, const char *name, const char *what)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_CHECKCOMMA            \
         assert(s); assert(name); assert(what)
 
 static char *
 S_filter_gets(pTHX_ SV *sv, STRLEN append)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_FILTER_GETS           \
         assert(sv)
 
 static HV *
 S_find_in_my_stash(pTHX_ const char *pkgname, STRLEN len)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_FIND_IN_MY_STASH      \
         assert(pkgname)
 
 static void
-S_force_ident(pTHX_ const char *s, int kind);
+S_force_ident(pTHX_ const char *s, int kind)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_IDENT           \
         assert(s)
 
@@ -9441,48 +11331,60 @@ S_force_next(pTHX_ I32 type);
 # define PERL_ARGS_ASSERT_FORCE_NEXT
 
 static char *
-S_force_strict_version(pTHX_ char *s);
+S_force_strict_version(pTHX_ char *s)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_STRICT_VERSION  \
         assert(s)
 
 static char *
-S_force_version(pTHX_ char *s, int guessing);
+S_force_version(pTHX_ char *s, int guessing)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_VERSION         \
         assert(s)
 
 static char *
-S_force_word(pTHX_ char *start, int token, U32 flags);
+S_force_word(pTHX_ char *start, int token, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_WORD            \
         assert(start)
 
 static SV *
 S_get_and_check_backslash_N_name_wrapper(pTHX_ const char *s, const char * const e)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GET_AND_CHECK_BACKSLASH_N_NAME_WRAPPER \
         assert(s); assert(e); assert(s <= e)
 
 static void
-S_incline(pTHX_ const char *s, const char *end);
+S_incline(pTHX_ const char *s, const char *end)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_INCLINE               \
         assert(s); assert(end); assert(s <= end); assert(*end == '\0')
 
 static int
-S_intuit_method(pTHX_ char *start, SV *ioname, CV *cv);
+S_intuit_method(pTHX_ char *start, SV *ioname, CV *cv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_INTUIT_METHOD         \
         assert(start)
 
 static int
-S_intuit_more(pTHX_ char *s, char *e, U8 caller_context, char *caller_s, Size_t caller_length);
+S_intuit_more(pTHX_ char *s, char *e, U8 caller_context, char *caller_s, Size_t caller_length)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_INTUIT_MORE           \
         assert(s); assert(e); assert(s <= e); assert(*e == '\0')
 
 static bool
-S_is_existing_identifier(pTHX_ char *s, Size_t len, char sigil, bool is_utf8);
+S_is_existing_identifier(pTHX_ char *s, Size_t len, char sigil, bool is_utf8)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_IS_EXISTING_IDENTIFIER \
         assert(s)
 
 static I32
-S_lop(pTHX_ enum yytokentype t, I32 f, U8 x, char *s);
+S_lop(pTHX_ enum yytokentype t, I32 f, U8 x, char *s)
+        Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_LOP                   \
         assert(s)
 
@@ -9492,18 +11394,26 @@ S_missingterm(pTHX_ char *s, STRLEN len)
 # define PERL_ARGS_ASSERT_MISSINGTERM
 
 static SV *
-S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen, SV *sv, SV *pv, const char *type, STRLEN typelen, const char **error_msg);
+S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen, SV *sv, SV *pv, const char *type, STRLEN typelen, const char **error_msg)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_5);
 # define PERL_ARGS_ASSERT_NEW_CONSTANT          \
         assert(key); assert(sv)
 
 static char *
-S_parse_ident(pTHX_ const char *s, const char * const s_end, char **d, char * const e, bool is_utf8, HV **failure_details, U32 flags);
+S_parse_ident(pTHX_ const char *s, const char * const s_end, char **d, char * const e, bool is_utf8, HV **failure_details, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_PARSE_IDENT           \
         assert(s); assert(s_end); assert(d); assert(*d); assert(e); \
         assert(s <= s_end); assert(*d < e)
 
 static char *
-S_parse_ident_no_copy(pTHX_ const char *s, const char * const s_end, bool is_utf8, HV **failure_details, U32 flags);
+S_parse_ident_no_copy(pTHX_ const char *s, const char * const s_end, bool is_utf8, HV **failure_details, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_PARSE_IDENT_NO_COPY   \
         assert(s); assert(s_end); assert(s < s_end)
 
@@ -9513,47 +11423,57 @@ S_pending_ident(pTHX);
 
 static char *
 S_scan_const(pTHX_ char *start)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_CONST            \
         assert(start)
 
 static char *
 S_scan_formline(pTHX_ char *s)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_FORMLINE         \
         assert(s)
 
 static char *
 S_scan_heredoc(pTHX_ char *s)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_HEREDOC          \
         assert(s)
 
 static char *
-S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, U32 flags);
+S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_SCAN_IDENT            \
         assert(s); assert(dest); assert(dest_end); assert(dest < dest_end)
 
 static char *
 S_scan_inputsymbol(pTHX_ char *start)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_INPUTSYMBOL      \
         assert(start)
 
 static char *
 S_scan_pat(pTHX_ char *start, I32 type)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_PAT              \
         assert(start)
 
 static char *
 S_scan_subst(pTHX_ char *start)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_SUBST            \
         assert(start)
 
 static char *
 S_scan_trans(pTHX_ char *start)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_TRANS            \
         assert(start)
@@ -9575,18 +11495,21 @@ S_sublex_start(pTHX)
 
 static char *
 S_swallow_bom(pTHX_ U8 *s)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SWALLOW_BOM           \
         assert(s)
 
 static char *
 S_tokenize_use(pTHX_ int is_use, char *s)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_TOKENIZE_USE          \
         assert(s)
 
 static SV *
-S_tokeq(pTHX_ SV *sv);
+S_tokeq(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_TOKEQ                 \
         assert(sv)
 
@@ -9595,41 +11518,49 @@ S_update_debugger_info(pTHX_ SV *orig_sv, const char * const buf, STRLEN len);
 # define PERL_ARGS_ASSERT_UPDATE_DEBUGGER_INFO
 
 static void
-S_warn_expect_operator(pTHX_ const char * const what, char *s, I32 pop_oldbufptr);
+S_warn_expect_operator(pTHX_ const char * const what, char *s, I32 pop_oldbufptr)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_WARN_EXPECT_OPERATOR  \
         assert(what)
 
 static void
-S_yyerror_non_ascii_message(pTHX_ const U8 * const s);
+S_yyerror_non_ascii_message(pTHX_ const U8 * const s)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_YYERROR_NON_ASCII_MESSAGE \
         assert(s)
 
 static int
-S_yywarn(pTHX_ const char * const s, U32 flags);
+S_yywarn(pTHX_ const char * const s, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_YYWARN                \
         assert(s)
 
 # if defined(DEBUGGING)
 static void
 S_printbuf(pTHX_ const char * const fmt, const char * const s)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__format__(__printf__,pTHX_1,0);
 #   define PERL_ARGS_ASSERT_PRINTBUF            \
         assert(fmt); assert(s)
 
 static int
-S_tokereport(pTHX_ I32 rv, const YYSTYPE *lvalp);
+S_tokereport(pTHX_ I32 rv, const YYSTYPE *lvalp)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_TOKEREPORT          \
         assert(lvalp)
 
 # endif /* defined(DEBUGGING) */
 # if !defined(PERL_NO_UTF16_FILTER)
 static U8 *
-S_add_utf16_textfilter(pTHX_ U8 * const s, bool reversed);
+S_add_utf16_textfilter(pTHX_ U8 * const s, bool reversed)
+        Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_ADD_UTF16_TEXTFILTER \
         assert(s)
 
 static I32
-S_utf16_textfilter(pTHX_ int idx, SV *sv, int maxlen);
+S_utf16_textfilter(pTHX_ int idx, SV *sv, int maxlen)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_UTF16_TEXTFILTER    \
         assert(sv)
 
@@ -9637,12 +11568,14 @@ S_utf16_textfilter(pTHX_ int idx, SV *sv, int maxlen);
 #endif /* defined(PERL_IN_TOKE_C) */
 #if defined(PERL_IN_UNIVERSAL_C)
 static bool
-S_isa_lookup(pTHX_ HV *stash, SV *namesv, const char *name, STRLEN len, U32 flags);
+S_isa_lookup(pTHX_ HV *stash, SV *namesv, const char *name, STRLEN len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_ISA_LOOKUP            \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV); assert(namesv || name)
 
 static bool
-S_sv_derived_from_svpvn(pTHX_ SV *sv, SV *namesv, const char *name, const STRLEN len, U32 flags);
+S_sv_derived_from_svpvn(pTHX_ SV *sv, SV *namesv, const char *name, const STRLEN len, U32 flags)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_DERIVED_FROM_SVPVN \
         assert(sv); assert(namesv || name)
 
@@ -9650,18 +11583,25 @@ S_sv_derived_from_svpvn(pTHX_ SV *sv, SV *namesv, const char *name, const STRLEN
 #if defined(PERL_IN_UTF8_C)
 static UV
 S_check_locale_boundary_crossing(pTHX_ const U8 * const p, const UV result, U8 * const ustrp, STRLEN *lenp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_CHECK_LOCALE_BOUNDARY_CROSSING \
         assert(p); assert(ustrp); assert(lenp)
 
 static HV *
 S_new_msg_hv(pTHX_ const char * const message, U32 categories, U32 flag)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEW_MSG_HV            \
         assert(message)
 
 static UV
-S_to_case_cp_list(pTHX_ const UV original, const U32 ** const remaining_list, Size_t *remaining_count, SV *invlist, const I32 * const invmap, const U32 * const * const aux_tables, const U8 * const aux_table_lengths, const char * const normal);
+S_to_case_cp_list(pTHX_ const UV original, const U32 ** const remaining_list, Size_t *remaining_count, SV *invlist, const I32 * const invmap, const U32 * const * const aux_tables, const U8 * const aux_table_lengths, const char * const normal)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5)
+        Perl_attribute_nonnull_(pTHX_8);
 # define PERL_ARGS_ASSERT_TO_CASE_CP_LIST       \
         assert(invlist); assert(invmap); assert(normal)
 
@@ -9671,54 +11611,79 @@ S_to_lower_latin1(const U8 c, U8 *p, STRLEN *lenp, const char dummy)
 # define PERL_ARGS_ASSERT_TO_LOWER_LATIN1
 
 static UV
-S_to_utf8_case_(pTHX_ const UV original, const U8 *p, U8 *ustrp, STRLEN *lenp, SV *invlist, const I32 * const invmap, const U32 * const * const aux_tables, const U8 * const aux_table_lengths, const char * const normal);
+S_to_utf8_case_(pTHX_ const UV original, const U8 *p, U8 *ustrp, STRLEN *lenp, SV *invlist, const I32 * const invmap, const U32 * const * const aux_tables, const U8 * const aux_table_lengths, const char * const normal)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
+        Perl_attribute_nonnull_(pTHX_5)
+        Perl_attribute_nonnull_(pTHX_6)
+        Perl_attribute_nonnull_(pTHX_9);
 # define PERL_ARGS_ASSERT_TO_UTF8_CASE_         \
         assert(ustrp); assert(lenp); assert(invlist); assert(invmap); \
         assert(normal)
 
 static UV
-S_turkic_fc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *lenp);
+S_turkic_fc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *lenp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_TURKIC_FC             \
         assert(p); assert(e); assert(ustrp); assert(lenp); assert(p < e)
 
 static UV
-S_turkic_lc(pTHX_ const U8 * const p0, const U8 * const e, U8 *ustrp, STRLEN *lenp);
+S_turkic_lc(pTHX_ const U8 * const p0, const U8 * const e, U8 *ustrp, STRLEN *lenp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_TURKIC_LC             \
         assert(p0); assert(e); assert(ustrp); assert(lenp); assert(p0 < e)
 
 static UV
-S_turkic_uc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *lenp);
+S_turkic_uc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *lenp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_TURKIC_UC             \
         assert(p); assert(e); assert(ustrp); assert(lenp); assert(p < e)
 
 static char *
 S_unexpected_non_continuation_text(pTHX_ const U8 * const s, STRLEN print_len, const STRLEN non_cont_byte_pos, const STRLEN expect_len)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UNEXPECTED_NON_CONTINUATION_TEXT \
         assert(s)
 
 # if 0
 static void
-S_warn_on_first_deprecated_use(pTHX_ U32 category, const char * const name, const char * const alternative, const bool use_locale, const char * const file, const unsigned line);
+S_warn_on_first_deprecated_use(pTHX_ U32 category, const char * const name, const char * const alternative, const bool use_locale, const char * const file, const unsigned line)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_5);
 #   define PERL_ARGS_ASSERT_WARN_ON_FIRST_DEPRECATED_USE \
         assert(name); assert(alternative); assert(file)
 
-# endif
+# endif /* 0 */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE int
 S_does_utf8_overflow(const U8 * const s, const U8 *e)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_DOES_UTF8_OVERFLOW  \
         assert(s); assert(e); assert(s < e)
 
 PERL_STATIC_INLINE int
 S_isFF_overlong(const U8 * const s, const STRLEN len)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_ISFF_OVERLONG       \
         assert(s)
 
 PERL_STATIC_INLINE SSize_t
 S_is_utf8_overlong(const U8 * const s, const STRLEN len)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_IS_UTF8_OVERLONG    \
         assert(s)
@@ -9735,22 +11700,27 @@ S_mess_alloc(pTHX);
 # define PERL_ARGS_ASSERT_MESS_ALLOC
 
 static SV *
-S_with_queued_errors(pTHX_ SV *ex);
+S_with_queued_errors(pTHX_ SV *ex)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_WITH_QUEUED_ERRORS    \
         assert(ex)
 
 static void
-S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p, STRLEN xs_len);
+S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p, STRLEN xs_len)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_XS_VERSION_BOOTCHECK  \
         assert(xs_p)
 
 # if defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL)
 static void
-S_mem_log_common(enum mem_log_type mlt, const UV n, const UV typesize, const char *type_name, const SV *sv, Malloc_t oldalloc, Malloc_t newalloc, const char *filename, const int linenumber, const char *funcname);
+S_mem_log_common(enum mem_log_type mlt, const UV n, const UV typesize, const char *type_name, const SV *sv, Malloc_t oldalloc, Malloc_t newalloc, const char *filename, const int linenumber, const char *funcname)
+        Perl_attribute_nonnull_(4)
+        Perl_attribute_nonnull_(8)
+        Perl_attribute_nonnull_(10);
 #   define PERL_ARGS_ASSERT_MEM_LOG_COMMON      \
         assert(type_name); assert(filename); assert(funcname)
 
-# endif
+# endif /* defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL) */
 # if defined(PERL_USES_PL_PIDSTATUS)
 static void
 S_pidgone(pTHX_ Pid_t pid, int status);
@@ -9760,27 +11730,41 @@ S_pidgone(pTHX_ Pid_t pid, int status);
 #endif /* defined(PERL_IN_UTIL_C) */
 #if defined(PERL_MEM_LOG)
 PERL_CALLCONV Malloc_t
-Perl_mem_log_alloc(const UV nconst, UV typesize, const char *type_name, Malloc_t newalloc, const char *filename, const int linenumber, const char *funcname);
+Perl_mem_log_alloc(const UV nconst, UV typesize, const char *type_name, Malloc_t newalloc, const char *filename, const int linenumber, const char *funcname)
+        Perl_attribute_nonnull_(3)
+        Perl_attribute_nonnull_(5)
+        Perl_attribute_nonnull_(7);
 # define PERL_ARGS_ASSERT_MEM_LOG_ALLOC         \
         assert(type_name); assert(filename); assert(funcname)
 
 PERL_CALLCONV void
-Perl_mem_log_del_sv(const SV *sv, const char *filename, int linenumber, const char *funcname);
+Perl_mem_log_del_sv(const SV *sv, const char *filename, int linenumber, const char *funcname)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(4);
 # define PERL_ARGS_ASSERT_MEM_LOG_DEL_SV        \
         assert(sv); assert(filename); assert(funcname)
 
 PERL_CALLCONV Malloc_t
-Perl_mem_log_free(Malloc_t oldalloc, const char *filename, const int linenumber, const char *funcname);
+Perl_mem_log_free(Malloc_t oldalloc, const char *filename, const int linenumber, const char *funcname)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(4);
 # define PERL_ARGS_ASSERT_MEM_LOG_FREE          \
         assert(filename); assert(funcname)
 
 PERL_CALLCONV void
-Perl_mem_log_new_sv(const SV *sv, const char *filename, int linenumber, const char *funcname);
+Perl_mem_log_new_sv(const SV *sv, const char *filename, int linenumber, const char *funcname)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(4);
 # define PERL_ARGS_ASSERT_MEM_LOG_NEW_SV        \
         assert(sv); assert(filename); assert(funcname)
 
 PERL_CALLCONV Malloc_t
-Perl_mem_log_realloc(const UV n, const UV typesize, const char *type_name, Malloc_t oldalloc, Malloc_t newalloc, const char *filename, const int linenumber, const char *funcname);
+Perl_mem_log_realloc(const UV n, const UV typesize, const char *type_name, Malloc_t oldalloc, Malloc_t newalloc, const char *filename, const int linenumber, const char *funcname)
+        Perl_attribute_nonnull_(3)
+        Perl_attribute_nonnull_(6)
+        Perl_attribute_nonnull_(8);
 # define PERL_ARGS_ASSERT_MEM_LOG_REALLOC       \
         assert(type_name); assert(filename); assert(funcname)
 
@@ -9788,17 +11772,20 @@ Perl_mem_log_realloc(const UV n, const UV typesize, const char *type_name, Mallo
 #if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE SSize_t
 Perl_AvFILL_(pTHX_ AV *av)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_AVFILL_               \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_STATIC_INLINE I32 *
-Perl_CvDEPTH(const CV * const sv);
+Perl_CvDEPTH(const CV * const sv)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_CVDEPTH               \
         assert(sv)
 
 PERL_STATIC_INLINE GV *
-Perl_CvGV(pTHX_ CV *sv);
+Perl_CvGV(pTHX_ CV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CVGV                  \
         assert(sv); assert(SvTYPE(sv) == SVt_PVCV || SvTYPE(sv) == SVt_PVFM)
 
@@ -9807,53 +11794,64 @@ Perl_POPMARK(pTHX);
 # define PERL_ARGS_ASSERT_POPMARK
 
 PERL_STATIC_INLINE struct regexp *
-Perl_ReANY(const REGEXP * const re);
+Perl_ReANY(const REGEXP * const re)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_REANY                 \
         assert(re)
 
 PERL_STATIC_INLINE void
-Perl_SvAMAGIC_off(SV *sv);
+Perl_SvAMAGIC_off(SV *sv)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_SVAMAGIC_OFF          \
         assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_SvAMAGIC_on(SV *sv);
+Perl_SvAMAGIC_on(SV *sv)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_SVAMAGIC_ON           \
         assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_SvGETMAGIC(pTHX_ SV *sv);
+Perl_SvGETMAGIC(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVGETMAGIC            \
         assert(sv)
 
 PERL_STATIC_INLINE IV
-Perl_SvIV(pTHX_ SV *sv);
+Perl_SvIV(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVIV                  \
         assert(sv)
 
 PERL_STATIC_INLINE IV
-Perl_SvIV_nomg(pTHX_ SV *sv);
+Perl_SvIV_nomg(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVIV_NOMG             \
         assert(sv)
 
 PERL_STATIC_INLINE NV
-Perl_SvNV(pTHX_ SV *sv);
+Perl_SvNV(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVNV                  \
         assert(sv)
 
 PERL_STATIC_INLINE NV
-Perl_SvNV_nomg(pTHX_ SV *sv);
+Perl_SvNV_nomg(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVNV_NOMG             \
         assert(sv)
 
 PERL_STATIC_FORCE_INLINE bool
 Perl_SvPVXtrue(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__always_inline__;
 # define PERL_ARGS_ASSERT_SVPVXTRUE             \
         assert(sv)
 
 PERL_STATIC_FORCE_INLINE char *
 Perl_SvPV_helper(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags, const PL_SvPVtype type, Perl_SvPV_helper_non_trivial_t non_trivial, const bool or_null, const U32 return_flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_5)
         __attribute__always_inline__;
 # define PERL_ARGS_ASSERT_SVPV_HELPER           \
         assert(sv); assert(non_trivial)
@@ -9863,7 +11861,8 @@ Perl_SvREFCNT_dec(pTHX_ SV *sv);
 # define PERL_ARGS_ASSERT_SVREFCNT_DEC
 
 PERL_STATIC_INLINE void
-Perl_SvREFCNT_dec_NN(pTHX_ SV *sv);
+Perl_SvREFCNT_dec_NN(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVREFCNT_DEC_NN       \
         assert(sv)
 
@@ -9876,7 +11875,8 @@ Perl_SvREFCNT_inc(SV *sv);
 # define PERL_ARGS_ASSERT_SVREFCNT_INC
 
 PERL_STATIC_INLINE SV *
-Perl_SvREFCNT_inc_NN(SV *sv);
+Perl_SvREFCNT_inc_NN(SV *sv)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_SVREFCNT_INC_NN       \
         assert(sv)
 
@@ -9889,12 +11889,14 @@ Perl_SvTRUE(pTHX_ SV *sv);
 # define PERL_ARGS_ASSERT_SVTRUE
 
 PERL_STATIC_INLINE bool
-Perl_SvTRUE_NN(pTHX_ SV *sv);
+Perl_SvTRUE_NN(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVTRUE_NN             \
         assert(sv)
 
 PERL_STATIC_INLINE bool
-Perl_SvTRUE_common(pTHX_ SV *sv, const bool sv_2bool_is_fallback);
+Perl_SvTRUE_common(pTHX_ SV *sv, const bool sv_2bool_is_fallback)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVTRUE_COMMON         \
         assert(sv)
 
@@ -9903,12 +11905,14 @@ Perl_SvTRUE_nomg(pTHX_ SV *sv);
 # define PERL_ARGS_ASSERT_SVTRUE_NOMG
 
 PERL_STATIC_INLINE UV
-Perl_SvUV(pTHX_ SV *sv);
+Perl_SvUV(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVUV                  \
         assert(sv)
 
 PERL_STATIC_INLINE UV
-Perl_SvUV_nomg(pTHX_ SV *sv);
+Perl_SvUV_nomg(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SVUV_NOMG             \
         assert(sv)
 
@@ -9921,12 +11925,14 @@ Perl_TOPMARK(pTHX);
 
 PERL_STATIC_INLINE Size_t
 Perl_av_count(pTHX_ AV *av)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_AV_COUNT              \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_STATIC_INLINE SV **
 Perl_av_fetch_simple(pTHX_ AV *av, SSize_t key, I32 lval)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_AV_FETCH_SIMPLE       \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
@@ -9938,47 +11944,62 @@ Perl_av_new_alloc(pTHX_ SSize_t size, bool zeroflag)
         assert(size > 0)
 
 PERL_STATIC_INLINE void
-Perl_av_push_simple(pTHX_ AV *av, SV *val);
+Perl_av_push_simple(pTHX_ AV *av, SV *val)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_AV_PUSH_SIMPLE        \
         assert(av); assert(SvTYPE(av) == SVt_PVAV); assert(val)
 
 PERL_STATIC_INLINE void
-Perl_av_remove_offset(pTHX_ AV *av);
+Perl_av_remove_offset(pTHX_ AV *av)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_AV_REMOVE_OFFSET      \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_STATIC_INLINE SV **
-Perl_av_store_simple(pTHX_ AV *av, SSize_t key, SV *val);
+Perl_av_store_simple(pTHX_ AV *av, SSize_t key, SV *val)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_AV_STORE_SIMPLE       \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_STATIC_INLINE U8 *
-Perl_bytes_to_utf8(pTHX_ const U8 *s, STRLEN *lenp);
+Perl_bytes_to_utf8(pTHX_ const U8 *s, STRLEN *lenp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_BYTES_TO_UTF8         \
         assert(s); assert(lenp)
 
 PERL_STATIC_INLINE U8 *
-Perl_bytes_to_utf8_temp_pv(pTHX_ const U8 *s, STRLEN *lenp);
+Perl_bytes_to_utf8_temp_pv(pTHX_ const U8 *s, STRLEN *lenp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_BYTES_TO_UTF8_TEMP_PV \
         assert(s); assert(lenp)
 
 PERL_STATIC_INLINE void
-Perl_clear_defarray_simple(pTHX_ AV *av);
+Perl_clear_defarray_simple(pTHX_ AV *av)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CLEAR_DEFARRAY_SIMPLE \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_STATIC_INLINE I32
-Perl_foldEQ(pTHX_ const char *a, const char *b, I32 len);
+Perl_foldEQ(pTHX_ const char *a, const char *b, I32 len)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FOLDEQ                \
         assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
-Perl_foldEQ_latin1(pTHX_ const char *a, const char *b, I32 len);
+Perl_foldEQ_latin1(pTHX_ const char *a, const char *b, I32 len)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FOLDEQ_LATIN1         \
         assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
-Perl_foldEQ_locale(pTHX_ const char *a, const char *b, I32 len);
+Perl_foldEQ_locale(pTHX_ const char *a, const char *b, I32 len)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FOLDEQ_LOCALE         \
         assert(a); assert(b)
 
@@ -9988,94 +12009,124 @@ Perl_get_vtbl(pTHX_ int vtbl_id)
 # define PERL_ARGS_ASSERT_GET_VTBL
 
 PERL_STATIC_INLINE UV
-Perl_grok_bin(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result);
+Perl_grok_bin(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_GROK_BIN              \
         assert(start); assert(len_p); assert(flags)
 
 PERL_STATIC_INLINE UV
-Perl_grok_hex(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result);
+Perl_grok_hex(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_GROK_HEX              \
         assert(start); assert(len_p); assert(flags)
 
 PERL_STATIC_INLINE UV
-Perl_grok_oct(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result);
+Perl_grok_oct(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_GROK_OCT              \
         assert(start); assert(len_p); assert(flags)
 
 PERL_STATIC_INLINE void *
-Perl_hv_common_key_len(pTHX_ HV *hv, const char *key, I32 klen_i32, const int action, SV *val, const U32 hash);
+Perl_hv_common_key_len(pTHX_ HV *hv, const char *key, I32 klen_i32, const int action, SV *val, const U32 hash)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_HV_COMMON_KEY_LEN     \
         assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
 
 PERL_STATIC_INLINE Size_t
 Perl_isC9_STRICT_UTF8_CHAR(const U8 * const s0, const U8 * const e)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ISC9_STRICT_UTF8_CHAR \
         assert(s0); assert(e); assert(s0 <= e)
 
 PERL_STATIC_INLINE Size_t
 Perl_isSTRICT_UTF8_CHAR(const U8 * const s0, const U8 * const e)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ISSTRICT_UTF8_CHAR    \
         assert(s0); assert(e); assert(s0 <= e)
 
 PERL_STATIC_INLINE Size_t
 Perl_isUTF8_CHAR(const U8 * const s0, const U8 * const e)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ISUTF8_CHAR           \
         assert(s0); assert(e); assert(s0 <= e)
 
 PERL_STATIC_INLINE Size_t
 Perl_isUTF8_CHAR_flags(const U8 * const s0, const U8 * const e, const U32 flags)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ISUTF8_CHAR_FLAGS     \
         assert(s0); assert(e); assert(s0 <= e)
 
 PERL_STATIC_INLINE bool
-Perl_is_c9strict_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el);
+Perl_is_c9strict_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_IS_C9STRICT_UTF8_STRING_LOCLEN \
         assert(s)
 
 PERL_STATIC_INLINE bool
 Perl_is_safe_syscall(pTHX_ const char *pv, STRLEN len, const char *what, const char *op_name)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_SAFE_SYSCALL       \
         assert(pv); assert(what); assert(op_name)
 
 PERL_STATIC_INLINE bool
-Perl_is_strict_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el);
+Perl_is_strict_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_IS_STRICT_UTF8_STRING_LOCLEN \
         assert(s)
 
 PERL_STATIC_INLINE bool
-Perl_is_utf8_fixed_width_buf_loclen_flags(const U8 * const s, STRLEN len, const U8 **ep, STRLEN *el, const U32 flags);
+Perl_is_utf8_fixed_width_buf_loclen_flags(const U8 * const s, STRLEN len, const U8 **ep, STRLEN *el, const U32 flags)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_IS_UTF8_FIXED_WIDTH_BUF_LOCLEN_FLAGS \
         assert(s)
 
 PERL_STATIC_INLINE bool
 Perl_is_utf8_invariant_string_loc(const U8 * const s, STRLEN len, const U8 **ep)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_UTF8_INVARIANT_STRING_LOC \
         assert(s)
 
 PERL_STATIC_INLINE bool
 Perl_is_utf8_string_flags(const U8 *s, STRLEN len, const U32 flags)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_UTF8_STRING_FLAGS  \
         assert(s)
 
 PERL_STATIC_INLINE bool
-Perl_is_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el);
+Perl_is_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_IS_UTF8_STRING_LOCLEN \
         assert(s)
 
 PERL_STATIC_INLINE bool
-Perl_is_utf8_string_loclen_flags(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el, const U32 flags);
+Perl_is_utf8_string_loclen_flags(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el, const U32 flags)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_IS_UTF8_STRING_LOCLEN_FLAGS \
         assert(s)
 
 PERL_STATIC_INLINE bool
 Perl_is_utf8_valid_partial_char_flags(const U8 * const s0, const U8 * const e, const U32 flags)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_UTF8_VALID_PARTIAL_CHAR_FLAGS \
         assert(s0); assert(e); assert(s0 < e)
@@ -10087,6 +12138,7 @@ Perl_lsbit_pos32(U32 word)
 
 PERL_STATIC_INLINE char *
 Perl_mortal_getenv(const char *str)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MORTAL_GETENV         \
         assert(str)
@@ -10103,6 +12155,7 @@ Perl_newPADxVOP(pTHX_ I32 type, I32 flags, PADOFFSET padix)
 
 PERL_STATIC_INLINE SV *
 Perl_newRV_noinc(pTHX_ SV * const tmpRef)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEWRV_NOINC           \
         assert(tmpRef)
@@ -10124,7 +12177,9 @@ Perl_newSVsv_flags(pTHX_ SV * const old, I32 flags)
 # define PERL_ARGS_ASSERT_NEWSVSV_FLAGS
 
 PERL_STATIC_INLINE SV *
-Perl_new_sv(pTHX_ const char *file, int line, const char *func);
+Perl_new_sv(pTHX_ const char *file, int line, const char *func)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_NEW_SV                \
         assert(file); assert(func)
 
@@ -10137,7 +12192,8 @@ Perl_push_stackinfo(pTHX_ I32 type, UV flags);
 # define PERL_ARGS_ASSERT_PUSH_STACKINFO
 
 PERL_STATIC_INLINE void
-Perl_rpp_context(pTHX_ SV **mark, U8 gimme, SSize_t extra);
+Perl_rpp_context(pTHX_ SV **mark, U8 gimme, SSize_t extra)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_CONTEXT           \
         assert(mark)
 
@@ -10146,12 +12202,14 @@ Perl_rpp_extend(pTHX_ SSize_t n);
 # define PERL_ARGS_ASSERT_RPP_EXTEND
 
 PERL_STATIC_INLINE void
-Perl_rpp_invoke_xs(pTHX_ CV *cv);
+Perl_rpp_invoke_xs(pTHX_ CV *cv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_INVOKE_XS         \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_STATIC_INLINE bool
-Perl_rpp_is_lone(pTHX_ SV *sv);
+Perl_rpp_is_lone(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_IS_LONE           \
         assert(sv)
 
@@ -10176,87 +12234,109 @@ Perl_rpp_popfree_2_NN(pTHX);
 # define PERL_ARGS_ASSERT_RPP_POPFREE_2_NN
 
 PERL_STATIC_INLINE void
-Perl_rpp_popfree_to(pTHX_ SV **sp);
+Perl_rpp_popfree_to(pTHX_ SV **sp)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_POPFREE_TO        \
         assert(sp)
 
 PERL_STATIC_INLINE void
-Perl_rpp_popfree_to_NN(pTHX_ SV **sp);
+Perl_rpp_popfree_to_NN(pTHX_ SV **sp)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_POPFREE_TO_NN     \
         assert(sp)
 
 PERL_STATIC_INLINE void
-Perl_rpp_push_1(pTHX_ SV *sv);
+Perl_rpp_push_1(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_PUSH_1            \
         assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_rpp_push_1_norc(pTHX_ SV *sv);
+Perl_rpp_push_1_norc(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_PUSH_1_NORC       \
         assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_rpp_push_2(pTHX_ SV *sv1, SV *sv2);
+Perl_rpp_push_2(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_PUSH_2            \
         assert(sv1); assert(sv2)
 
 PERL_STATIC_INLINE void
-Perl_rpp_push_IMM(pTHX_ SV *sv);
+Perl_rpp_push_IMM(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_PUSH_IMM          \
         assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_rpp_replace_1_1(pTHX_ SV *sv);
+Perl_rpp_replace_1_1(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_1_1       \
         assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_rpp_replace_1_1_NN(pTHX_ SV *sv);
+Perl_rpp_replace_1_1_NN(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_1_1_NN    \
         assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_rpp_replace_1_IMM_NN(pTHX_ SV *sv);
+Perl_rpp_replace_1_IMM_NN(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_1_IMM_NN  \
         assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_rpp_replace_2_1(pTHX_ SV *sv);
+Perl_rpp_replace_2_1(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_1       \
         assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_rpp_replace_2_1_COMMON(pTHX_ SV *sv);
+Perl_rpp_replace_2_1_COMMON(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_1_COMMON \
         assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_rpp_replace_2_1_NN(pTHX_ SV *sv);
+Perl_rpp_replace_2_1_NN(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_1_NN    \
         assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_rpp_replace_2_IMM_NN(pTHX_ SV *sv);
+Perl_rpp_replace_2_IMM_NN(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_IMM_NN  \
         assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_rpp_replace_at(pTHX_ SV **sp, SV *sv);
+Perl_rpp_replace_at(pTHX_ SV **sp, SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT        \
         assert(sp); assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_rpp_replace_at_NN(pTHX_ SV **sp, SV *sv);
+Perl_rpp_replace_at_NN(pTHX_ SV **sp, SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT_NN     \
         assert(sp); assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_rpp_replace_at_norc(pTHX_ SV **sp, SV *sv);
+Perl_rpp_replace_at_norc(pTHX_ SV **sp, SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT_NORC   \
         assert(sp); assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_rpp_replace_at_norc_NN(pTHX_ SV **sp, SV *sv);
+Perl_rpp_replace_at_norc_NN(pTHX_ SV **sp, SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT_NORC_NN \
         assert(sp); assert(sv)
 
@@ -10273,17 +12353,21 @@ Perl_rpp_try_AMAGIC_2(pTHX_ int method, int flags);
 # define PERL_ARGS_ASSERT_RPP_TRY_AMAGIC_2
 
 PERL_STATIC_INLINE void
-Perl_rpp_xpush_1(pTHX_ SV *sv);
+Perl_rpp_xpush_1(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_XPUSH_1           \
         assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_rpp_xpush_2(pTHX_ SV *sv1, SV *sv2);
+Perl_rpp_xpush_2(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_XPUSH_2           \
         assert(sv1); assert(sv2)
 
 PERL_STATIC_INLINE void
-Perl_rpp_xpush_IMM(pTHX_ SV *sv);
+Perl_rpp_xpush_IMM(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_XPUSH_IMM         \
         assert(sv)
 
@@ -10301,6 +12385,7 @@ Perl_savepvn(pTHX_ const char *pv, Size_t len)
 
 PERL_STATIC_INLINE char *
 Perl_savesharedsvpv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SAVESHAREDSVPV        \
@@ -10308,6 +12393,7 @@ Perl_savesharedsvpv(pTHX_ SV *sv)
 
 PERL_STATIC_INLINE char *
 Perl_savesvpv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SAVESVPV              \
@@ -10322,103 +12408,135 @@ Perl_single_1bit_pos32(U32 word)
         assert(sv)
 
 PERL_STATIC_INLINE char *
-Perl_sv_pvbyten_force_wrapper(pTHX_ SV * const sv, STRLEN * const lp, const U32 dummy);
+Perl_sv_pvbyten_force_wrapper(pTHX_ SV * const sv, STRLEN * const lp, const U32 dummy)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_PVBYTEN_FORCE_WRAPPER \
         assert(sv)
 
 PERL_STATIC_INLINE char *
-Perl_sv_pvutf8n_force_wrapper(pTHX_ SV * const sv, STRLEN * const lp, const U32 dummy);
+Perl_sv_pvutf8n_force_wrapper(pTHX_ SV * const sv, STRLEN * const lp, const U32 dummy)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_PVUTF8N_FORCE_WRAPPER \
         assert(sv)
 
 PERL_STATIC_INLINE char  *
-Perl_sv_setpv_freshbuf(pTHX_ SV * const sv);
+Perl_sv_setpv_freshbuf(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_SETPV_FRESHBUF     \
         assert(sv)
 
 PERL_STATIC_INLINE void
-Perl_switch_argstack(pTHX_ AV *to);
+Perl_switch_argstack(pTHX_ AV *to)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_SWITCH_ARGSTACK       \
         assert(to); assert(SvTYPE(to) == SVt_PVAV)
 
 PERL_STATIC_INLINE IV
 Perl_utf8_distance(pTHX_ const U8 *a, const U8 *b)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UTF8_DISTANCE         \
         assert(a); assert(b)
 
 PERL_STATIC_INLINE U8 *
 Perl_utf8_hop(const U8 *s, SSize_t off)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UTF8_HOP              \
         assert(s)
 
 PERL_STATIC_INLINE U8 *
 Perl_utf8_hop_back_overshoot(const U8 *s, SSize_t off, const U8 * const start, SSize_t *remaining)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UTF8_HOP_BACK_OVERSHOOT \
         assert(s); assert(start); assert(start <= s)
 
 PERL_STATIC_INLINE U8 *
 Perl_utf8_hop_forward_overshoot(const U8 *s, SSize_t off, const U8 * const end, SSize_t *remaining)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UTF8_HOP_FORWARD_OVERSHOOT \
         assert(s); assert(end); assert(s <= end)
 
 PERL_STATIC_INLINE U8 *
 Perl_utf8_hop_overshoot(const U8 *s, SSize_t off, const U8 * const start, const U8 * const end, SSize_t *remaining)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(3)
+        Perl_attribute_nonnull_(4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UTF8_HOP_OVERSHOOT    \
         assert(s); assert(start); assert(end); assert(start <= s); \
         assert(s <= end)
 
 PERL_STATIC_INLINE bool
-Perl_utf8_to_bytes_new_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp, void **free_me);
+Perl_utf8_to_bytes_new_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp, void **free_me)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_UTF8_TO_BYTES_NEW_PV  \
         assert(s_ptr); assert(lenp); assert(free_me)
 
 PERL_STATIC_INLINE bool
-Perl_utf8_to_bytes_overwrite(pTHX_ U8 **s_ptr, STRLEN *lenp);
+Perl_utf8_to_bytes_overwrite(pTHX_ U8 **s_ptr, STRLEN *lenp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_TO_BYTES_OVERWRITE \
         assert(s_ptr); assert(lenp)
 
 PERL_STATIC_INLINE bool
-Perl_utf8_to_bytes_temp_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp);
+Perl_utf8_to_bytes_temp_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_TO_BYTES_TEMP_PV \
         assert(s_ptr); assert(lenp)
 
 PERL_STATIC_INLINE bool
-Perl_utf8_to_uv_msgs(const U8 * const s0, const U8 *e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors, AV **msgs);
+Perl_utf8_to_uv_msgs(const U8 * const s0, const U8 *e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors, AV **msgs)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(3);
 # define PERL_ARGS_ASSERT_UTF8_TO_UV_MSGS       \
         assert(s0); assert(e); assert(cp_p); assert(s0 <= e)
 
 PERL_STATIC_INLINE UV
-Perl_utf8_to_uv_or_die(const U8 * const s, const U8 *e, Size_t *advance_p);
+Perl_utf8_to_uv_or_die(const U8 * const s, const U8 *e, Size_t *advance_p)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2);
 # define PERL_ARGS_ASSERT_UTF8_TO_UV_OR_DIE     \
         assert(s); assert(e); assert(s <= e)
 
 PERL_STATIC_INLINE UV
-Perl_utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen);
+Perl_utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_TO_UVCHR_BUF     \
         assert(s); assert(send); assert(s <= send)
 
 PERL_STATIC_INLINE UV
-Perl_utf8n_to_uvchr_msgs(const U8 * const s0, STRLEN curlen, STRLEN *retlen, const U32 flags, U32 *errors, AV **msgs);
+Perl_utf8n_to_uvchr_msgs(const U8 * const s0, STRLEN curlen, STRLEN *retlen, const U32 flags, U32 *errors, AV **msgs)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_UTF8N_TO_UVCHR_MSGS   \
         assert(s0)
 
 PERL_STATIC_INLINE U8 *
-Perl_uv_to_utf8(pTHX_ U8 *d, UV uv);
+Perl_uv_to_utf8(pTHX_ U8 *d, UV uv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_UV_TO_UTF8            \
         assert(d)
 
 PERL_STATIC_INLINE U8 *
-Perl_uv_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags);
+Perl_uv_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_UV_TO_UTF8_FLAGS      \
         assert(d)
 
 PERL_STATIC_INLINE UV
 Perl_valid_utf8_to_uv(const U8 *s, STRLEN *retlen)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_VALID_UTF8_TO_UV      \
         assert(s)
@@ -10429,99 +12547,121 @@ Perl_variant_byte_number(PERL_UINTMAX_T word)
 # define PERL_ARGS_ASSERT_VARIANT_BYTE_NUMBER
 
 PERL_STATIC_INLINE void
-Perl_cx_popblock(pTHX_ PERL_CONTEXT *cx);
+Perl_cx_popblock(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPBLOCK           \
         assert(cx)
 
 PERL_STATIC_INLINE void
-Perl_cx_popeval(pTHX_ PERL_CONTEXT *cx);
+Perl_cx_popeval(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPEVAL            \
         assert(cx)
 
 PERL_STATIC_INLINE void
-Perl_cx_popformat(pTHX_ PERL_CONTEXT *cx);
+Perl_cx_popformat(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPFORMAT          \
         assert(cx)
 
 PERL_STATIC_INLINE void
-Perl_cx_popgiven(pTHX_ PERL_CONTEXT *cx);
+Perl_cx_popgiven(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPGIVEN           \
         assert(cx)
 
 PERL_STATIC_INLINE void
-Perl_cx_poploop(pTHX_ PERL_CONTEXT *cx);
+Perl_cx_poploop(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPLOOP            \
         assert(cx)
 
 PERL_STATIC_INLINE void
-Perl_cx_popsub(pTHX_ PERL_CONTEXT *cx);
+Perl_cx_popsub(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPSUB             \
         assert(cx)
 
 PERL_STATIC_INLINE void
-Perl_cx_popsub_args(pTHX_ PERL_CONTEXT *cx);
+Perl_cx_popsub_args(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPSUB_ARGS        \
         assert(cx)
 
 PERL_STATIC_INLINE void
-Perl_cx_popsub_common(pTHX_ PERL_CONTEXT *cx);
+Perl_cx_popsub_common(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPSUB_COMMON      \
         assert(cx)
 
 PERL_STATIC_INLINE void
-Perl_cx_popwhen(pTHX_ PERL_CONTEXT *cx);
+Perl_cx_popwhen(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPWHEN            \
         assert(cx)
 
 PERL_STATIC_INLINE PERL_CONTEXT *
-Perl_cx_pushblock(pTHX_ U8 type, U8 gimme, SV **sp, I32 saveix);
+Perl_cx_pushblock(pTHX_ U8 type, U8 gimme, SV **sp, I32 saveix)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_CX_PUSHBLOCK          \
         assert(sp)
 
 PERL_STATIC_INLINE void
-Perl_cx_pusheval(pTHX_ PERL_CONTEXT *cx, OP *retop, SV *namesv);
+Perl_cx_pusheval(pTHX_ PERL_CONTEXT *cx, OP *retop, SV *namesv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHEVAL           \
         assert(cx)
 
 PERL_STATIC_INLINE void
-Perl_cx_pushformat(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, GV *gv);
+Perl_cx_pushformat(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, GV *gv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_CX_PUSHFORMAT         \
         assert(cx); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_STATIC_INLINE void
-Perl_cx_pushgiven(pTHX_ PERL_CONTEXT *cx, SV *orig_defsv);
+Perl_cx_pushgiven(pTHX_ PERL_CONTEXT *cx, SV *orig_defsv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHGIVEN          \
         assert(cx)
 
 PERL_STATIC_INLINE void
-Perl_cx_pushloop_for(pTHX_ PERL_CONTEXT *cx, void *itervarp, SV *itersave);
+Perl_cx_pushloop_for(pTHX_ PERL_CONTEXT *cx, void *itervarp, SV *itersave)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_CX_PUSHLOOP_FOR       \
         assert(cx); assert(itervarp)
 
 PERL_STATIC_INLINE void
-Perl_cx_pushloop_plain(pTHX_ PERL_CONTEXT *cx);
+Perl_cx_pushloop_plain(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHLOOP_PLAIN     \
         assert(cx)
 
 PERL_STATIC_INLINE void
-Perl_cx_pushsub(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, bool hasargs);
+Perl_cx_pushsub(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, bool hasargs)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_CX_PUSHSUB            \
         assert(cx); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_STATIC_INLINE void
-Perl_cx_pushtry(pTHX_ PERL_CONTEXT *cx, OP *retop);
+Perl_cx_pushtry(pTHX_ PERL_CONTEXT *cx, OP *retop)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHTRY            \
         assert(cx)
 
 PERL_STATIC_INLINE void
-Perl_cx_pushwhen(pTHX_ PERL_CONTEXT *cx);
+Perl_cx_pushwhen(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHWHEN           \
         assert(cx)
 
 PERL_STATIC_INLINE void
-Perl_cx_topblock(pTHX_ PERL_CONTEXT *cx);
+Perl_cx_topblock(pTHX_ PERL_CONTEXT *cx)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_TOPBLOCK           \
         assert(cx)
 
@@ -10535,38 +12675,39 @@ Perl_my_strlcat(char *dst, const char *src, Size_t size);
 #   define PERL_ARGS_ASSERT_MY_STRLCAT
 
 # endif
-# if !defined(HAS_STRNLEN)
-PERL_STATIC_INLINE Size_t
-Perl_my_strnlen(const char *str, Size_t maxlen);
-#   define PERL_ARGS_ASSERT_MY_STRNLEN          \
-        assert(str)
-
-# endif
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE void
-Perl_append_utf8_from_native_byte(const U8 byte, U8 **dest);
+Perl_append_utf8_from_native_byte(const U8 byte, U8 **dest)
+        Perl_attribute_nonnull_(2);
 PERL_STATIC_INLINE bool
-Perl_sv_only_taint_gmagic(SV *sv);
+Perl_sv_only_taint_gmagic(SV *sv)
+        Perl_attribute_nonnull_(1);
 PERL_STATIC_INLINE bool
 Perl_is_utf8_non_invariant_string(const U8 * const s, STRLEN len)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_IS_UTF8_NON_INVARIANT_STRING \
         assert(s)
 
 PERL_STATIC_INLINE STRLEN
-S_sv_or_pv_pos_u2b(pTHX_ SV *sv, const char *pv, STRLEN pos, STRLEN *lenp);
+S_sv_or_pv_pos_u2b(pTHX_ SV *sv, const char *pv, STRLEN pos, STRLEN *lenp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_OR_PV_POS_U2B    \
         assert(sv); assert(pv)
 
 PERL_STATIC_INLINE Size_t
 S_variant_under_utf8_count(const U8 * const s, const U8 * const e)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_VARIANT_UNDER_UTF8_COUNT \
         assert(s); assert(e); assert(s <= e)
 
 #   if !defined(HAS_MEMRCHR)
 PERL_STATIC_INLINE void *
-S_my_memrchr(const char *s, const char c, const STRLEN len);
+S_my_memrchr(const char *s, const char c, const STRLEN len)
+        Perl_attribute_nonnull_(1);
 #     define PERL_ARGS_ASSERT_MY_MEMRCHR        \
         assert(s)
 
@@ -10577,15 +12718,19 @@ S_my_memrchr(const char *s, const char c, const STRLEN len);
        defined(PERL_IN_UTF8_C)
 PERL_STATIC_INLINE bool *
 S_get_invlist_offset_addr(SV *invlist)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE UV *
 S_invlist_array(SV * const invlist)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE bool
 S_invlist_contains_cp_(SV * const invlist, const UV cp)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE UV
 S_invlist_len_(SV * const invlist)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE bool
 S_is_invlist(const SV * const invlist)
@@ -10600,18 +12745,22 @@ PERL_STATIC_INLINE SV *
 S_add_cp_to_invlist(pTHX_ SV *invlist, const UV cp)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE void
-S_invlist_extend(pTHX_ SV * const invlist, const UV len);
+S_invlist_extend(pTHX_ SV * const invlist, const UV len)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_STATIC_INLINE UV
 S_invlist_highest(SV * const invlist)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE void
-S_invlist_set_len(pTHX_ SV * const invlist, const UV len, const bool offset);
+S_invlist_set_len(pTHX_ SV * const invlist, const UV len, const bool offset)
+        Perl_attribute_nonnull_(pTHX_1);
 #   endif /* defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) ||
              defined(PERL_IN_REGCOMP_ANY) */
 #   if defined(PERL_IN_PP_C)   || defined(PERL_IN_REGCOMP_ANY) || \
        defined(PERL_IN_TOKE_C) || defined(PERL_IN_UNIVERSAL_C)
 PERL_STATIC_INLINE const char *
-S_get_regex_charset_name(const U32 flags, STRLEN * const lenp);
+S_get_regex_charset_name(const U32 flags, STRLEN * const lenp)
+        Perl_attribute_nonnull_(2);
 #   endif
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
@@ -10653,7 +12802,8 @@ S_get_regex_charset_name(const U32 flags, STRLEN * const lenp);
            defined(PERL_IN_REGCOMP_ANY) */
 # if defined(PERL_IN_OP_C) || defined(PERL_IN_PAD_C)
 PERL_STATIC_INLINE bool
-S_PadnameIN_SCOPE(const PADNAME * const pn, const U32 seq);
+S_PadnameIN_SCOPE(const PADNAME * const pn, const U32 seq)
+        Perl_attribute_nonnull_(1);
 #   define PERL_ARGS_ASSERT_PADNAMEIN_SCOPE     \
         assert(pn)
 
@@ -10674,19 +12824,26 @@ S_PadnameIN_SCOPE(const PADNAME * const pn, const U32 seq);
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE STRLEN *
 S_get_invlist_iter_addr(SV *invlist)
+        Perl_attribute_nonnull_(1)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE void
-S_invlist_iterfinish(SV *invlist);
+S_invlist_iterfinish(SV *invlist)
+        Perl_attribute_nonnull_(1);
 PERL_STATIC_INLINE void
-S_invlist_iterinit(SV *invlist);
+S_invlist_iterinit(SV *invlist)
+        Perl_attribute_nonnull_(1);
 PERL_STATIC_INLINE bool
 S_invlist_iternext(SV *invlist, UV *start, UV *end)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
+        Perl_attribute_nonnull_(3)
         __attribute__warn_unused_result__;
 #   endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY) */
 # if defined(PERL_IN_PP_C) || defined(PERL_IN_PP_HOT_C)
 PERL_STATIC_INLINE bool
 S_lossless_NV_to_IV(const NV nv, IV *ivp)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_LOSSLESS_NV_TO_IV   \
         assert(ivp)
@@ -10717,18 +12874,12 @@ Perl_single_1bit_pos64(U64 word)
 # endif /* defined(U64TYPE) */
 # if defined(USE_ITHREADS)
 PERL_STATIC_INLINE AV *
-Perl_cop_file_avn(pTHX_ const COP *cop);
+Perl_cop_file_avn(pTHX_ const COP *cop)
+        Perl_attribute_nonnull_(pTHX_1);
 #   define PERL_ARGS_ASSERT_COP_FILE_AVN        \
         assert(cop)
 
-#   if !defined(PERL_IMPLICIT_SYS)
-PERL_STATIC_INLINE bool
-S_PerlEnv_putenv(pTHX_ char *str);
-#     define PERL_ARGS_ASSERT_PERLENV_PUTENV    \
-        assert(str)
-
-#   endif
-# endif /* defined(USE_ITHREADS) */
+# endif
 # if !defined(WIN32)
 PERL_STATIC_INLINE void *
 Perl_get_context(void)
@@ -10746,14 +12897,17 @@ Perl_runops_wrap(pTHX);
 # define PERL_ARGS_ASSERT_RUNOPS_WRAP
 
 PERL_CALLCONV void
-Perl_xs_wrap(pTHX_ XSUBADDR_t xsub, CV *cv);
+Perl_xs_wrap(pTHX_ XSUBADDR_t xsub, CV *cv)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_XS_WRAP               \
         assert(xsub); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV OP *
-Perl_pp_wrap(pTHX_ Perl_ppaddr_t real_pp_fn, I32 nargs, int nlists);
+Perl_pp_wrap(pTHX_ Perl_ppaddr_t real_pp_fn, I32 nargs, int nlists)
+        Perl_attribute_nonnull_(pTHX_1);
 # endif
 #endif /* defined(PERL_RC_STACK) */
 #if defined(PERL_USE_3ARG_SIGHANDLER)
@@ -10782,14 +12936,16 @@ Perl_sighandler(int sig)
 #endif
 #if defined(UNLINK_ALL_VERSIONS)
 PERL_CALLCONV I32
-Perl_unlnk(pTHX_ const char *f);
+Perl_unlnk(pTHX_ const char *f)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_UNLNK                 \
         assert(f)
 
 #endif
 #if defined(USE_C_BACKTRACE)
 PERL_CALLCONV bool
-Perl_dump_c_backtrace(pTHX_ PerlIO *fp, int max_depth, int skip);
+Perl_dump_c_backtrace(pTHX_ PerlIO *fp, int max_depth, int skip)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DUMP_C_BACKTRACE      \
         assert(fp)
 
@@ -10817,93 +12973,113 @@ Perl_get_c_backtrace_dump(pTHX_ int max_depth, int skip);
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
-Perl_dtrace_probe_call(pTHX_ CV *cv, bool is_call);
+Perl_dtrace_probe_call(pTHX_ CV *cv, bool is_call)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV void
-Perl_dtrace_probe_load(pTHX_ const char *name, bool is_loading);
+Perl_dtrace_probe_load(pTHX_ const char *name, bool is_loading)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV void
-Perl_dtrace_probe_op(pTHX_ const OP *op);
+Perl_dtrace_probe_op(pTHX_ const OP *op)
+        Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV void
 Perl_dtrace_probe_phase(pTHX_ enum perl_phase phase);
-# endif
+# endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 #endif /* defined(USE_DTRACE) */
 #if defined(USE_ITHREADS)
 PERL_CALLCONV PADOFFSET
-Perl_alloccopstash(pTHX_ HV *hv);
+Perl_alloccopstash(pTHX_ HV *hv)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_ALLOCCOPSTASH         \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void *
 Perl_any_dup(pTHX_ void *v, const PerlInterpreter *proto_perl)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ANY_DUP               \
         assert(proto_perl)
 
 PERL_CALLCONV void
-Perl_clone_params_del(CLONE_PARAMS *param);
+Perl_clone_params_del(CLONE_PARAMS *param)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_CLONE_PARAMS_DEL      \
         assert(param)
 
 PERL_CALLCONV CLONE_PARAMS *
 Perl_clone_params_new(PerlInterpreter * const from, PerlInterpreter * const to)
+        Perl_attribute_nonnull_(1)
+        Perl_attribute_nonnull_(2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_CLONE_PARAMS_NEW      \
         assert(from); assert(to)
 
 PERL_CALLCONV PERL_CONTEXT *
 Perl_cx_dup(pTHX_ PERL_CONTEXT *cx, I32 ix, I32 max, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_CX_DUP                \
         assert(param)
 
 PERL_CALLCONV DIR *
 Perl_dirp_dup(pTHX_ DIR * const dp, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DIRP_DUP              \
         assert(param)
 
 PERL_CALLCONV PerlIO *
-Perl_fp_dup(pTHX_ PerlIO * const fp, const char type, CLONE_PARAMS * const param);
+Perl_fp_dup(pTHX_ PerlIO * const fp, const char type, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_FP_DUP                \
         assert(param)
 
 PERL_CALLCONV GP *
 Perl_gp_dup(pTHX_ GP * const gp, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GP_DUP                \
         assert(param)
 
 PERL_CALLCONV HE *
 Perl_he_dup(pTHX_ const HE *e, bool shared, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_HE_DUP                \
         assert(param)
 
 PERL_CALLCONV HEK *
 Perl_hek_dup(pTHX_ HEK *e, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_HEK_DUP               \
         assert(param)
 
 PERL_CALLCONV MAGIC *
 Perl_mg_dup(pTHX_ MAGIC *mg, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MG_DUP                \
         assert(param)
 
 PERL_CALLCONV struct mro_meta *
 Perl_mro_meta_dup(pTHX_ struct mro_meta *smeta, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MRO_META_DUP          \
         assert(smeta); assert(param)
 
 PERL_CALLCONV OP *
 Perl_newPADOP(pTHX_ I32 type, I32 flags, SV *sv)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEWPADOP              \
         assert(sv)
 
 PERL_CALLCONV PADLIST *
 Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PADLIST_DUP           \
@@ -10911,6 +13087,8 @@ Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
 
 PERL_CALLCONV PADNAME *
 Perl_padname_dup(pTHX_ PADNAME *src, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PADNAME_DUP           \
@@ -10918,56 +13096,72 @@ Perl_padname_dup(pTHX_ PADNAME *src, CLONE_PARAMS *param)
 
 PERL_CALLCONV PADNAMELIST *
 Perl_padnamelist_dup(pTHX_ PADNAMELIST *srcpad, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PADNAMELIST_DUP       \
         assert(param)
 
 PERL_CALLCONV yy_parser *
-Perl_parser_dup(pTHX_ const yy_parser * const proto, CLONE_PARAMS * const param);
+Perl_parser_dup(pTHX_ const yy_parser * const proto, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_PARSER_DUP            \
         assert(param)
 
 PERL_CALLCONV PerlInterpreter *
-perl_clone(PerlInterpreter *proto_perl, UV flags);
+perl_clone(PerlInterpreter *proto_perl, UV flags)
+        Perl_attribute_nonnull_(1);
 # define PERL_ARGS_ASSERT_PERL_CLONE            \
         assert(proto_perl)
 
 PERL_CALLCONV void
-Perl_re_dup_guts(pTHX_ const REGEXP *sstr, REGEXP *dstr, CLONE_PARAMS *param);
+Perl_re_dup_guts(pTHX_ const REGEXP *sstr, REGEXP *dstr, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_RE_DUP_GUTS           \
         assert(sstr); assert(dstr); assert(param)
 
 PERL_CALLCONV void *
-Perl_regdupe_internal(pTHX_ REGEXP * const r, CLONE_PARAMS *param);
+Perl_regdupe_internal(pTHX_ REGEXP * const r, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_REGDUPE_INTERNAL      \
         assert(r); assert(param)
 
 PERL_CALLCONV void
-Perl_rvpv_dup(pTHX_ SV * const dsv, const SV * const ssv, CLONE_PARAMS * const param);
+Perl_rvpv_dup(pTHX_ SV * const dsv, const SV * const ssv, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_RVPV_DUP              \
         assert(dsv); assert(ssv); assert(param)
 
 PERL_CALLCONV PERL_SI *
 Perl_si_dup(pTHX_ PERL_SI *si, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SI_DUP                \
         assert(param)
 
 PERL_CALLCONV ANY *
 Perl_ss_dup(pTHX_ PerlInterpreter *proto_perl, CLONE_PARAMS *param)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SS_DUP                \
         assert(proto_perl); assert(param)
 
 PERL_CALLCONV SV *
 Perl_sv_dup(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_DUP                \
         assert(param)
 
 PERL_CALLCONV SV *
 Perl_sv_dup_inc(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_DUP_INC            \
         assert(param)
@@ -10975,11 +13169,13 @@ Perl_sv_dup_inc(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
 # if defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C)
 PERL_CALLCONV void
 Perl_op_relocate_sv(pTHX_ SV **svp, PADOFFSET *targp)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 #   define PERL_ARGS_ASSERT_OP_RELOCATE_SV      \
         assert(svp); assert(targp)
 
-# endif
+# endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
 #else /* if !defined(USE_ITHREADS) */
 /* PERL_CALLCONV void
 Perl_CopFILEGV_set(pTHX_ COP *c, GV *gv); */
@@ -10988,12 +13184,16 @@ Perl_CopFILEGV_set(pTHX_ COP *c, GV *gv); */
 #if defined(USE_LOCALE_COLLATE)
 PERL_CALLCONV int
 Perl_magic_freecollxfrm(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MAGIC_FREECOLLXFRM    \
         assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setcollxfrm(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MAGIC_SETCOLLXFRM     \
         assert(sv); assert(mg)
@@ -11005,20 +13205,25 @@ Perl_magic_setcollxfrm(pTHX_ SV *sv, MAGIC *mg)
 Perl_sv_collxfrm(pTHX_ SV * const sv, STRLEN * const nxp); */
 
 PERL_CALLCONV char *
-Perl_sv_collxfrm_flags(pTHX_ SV * const sv, STRLEN * const nxp, I32 const flags);
+Perl_sv_collxfrm_flags(pTHX_ SV * const sv, STRLEN * const nxp, I32 const flags)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_SV_COLLXFRM_FLAGS     \
         assert(sv); assert(nxp)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
-Perl_strxfrm(pTHX_ SV *src);
+Perl_strxfrm(pTHX_ SV *src)
+        Perl_attribute_nonnull_(pTHX_1);
 #   if defined(PERL_IN_LOCALE_C) || defined(PERL_IN_MATHOMS_C) || \
        defined(PERL_IN_SV_C)
 PERL_CALLCONV char *
 Perl_mem_collxfrm_(pTHX_ const char *input_string, STRLEN len, STRLEN *xlen, bool utf8)
+        Perl_attribute_nonnull_(pTHX_1)
+        Perl_attribute_nonnull_(pTHX_3)
         __attribute__visibility__("hidden");
 #   endif
-# endif
+# endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if defined(PERL_IN_LOCALE_C) || defined(PERL_IN_MATHOMS_C) || \
      defined(PERL_IN_SV_C)
 #   define PERL_ARGS_ASSERT_MEM_COLLXFRM_       \
@@ -11080,7 +13285,8 @@ Perl_PerlIO_get_ptr(pTHX_ PerlIO *f);
 # define PERL_ARGS_ASSERT_PERLIO_GET_PTR
 
 PERL_CALLCONV SSize_t
-Perl_PerlIO_read(pTHX_ PerlIO *f, void *vbuf, Size_t count);
+Perl_PerlIO_read(pTHX_ PerlIO *f, void *vbuf, Size_t count)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_PERLIO_READ           \
         assert(vbuf)
 
@@ -11128,12 +13334,14 @@ Perl_PerlIO_tell(pTHX_ PerlIO *f);
 # define PERL_ARGS_ASSERT_PERLIO_TELL
 
 PERL_CALLCONV SSize_t
-Perl_PerlIO_unread(pTHX_ PerlIO *f, const void *vbuf, Size_t count);
+Perl_PerlIO_unread(pTHX_ PerlIO *f, const void *vbuf, Size_t count)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_PERLIO_UNREAD         \
         assert(vbuf)
 
 PERL_CALLCONV SSize_t
-Perl_PerlIO_write(pTHX_ PerlIO *f, const void *vbuf, Size_t count);
+Perl_PerlIO_write(pTHX_ PerlIO *f, const void *vbuf, Size_t count)
+        Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_PERLIO_WRITE          \
         assert(vbuf)
 
@@ -11147,12 +13355,14 @@ Perl_switch_locale_context(pTHX);
 #if defined(USE_QUADMATH)
 PERL_CALLCONV bool
 Perl_quadmath_format_needed(const char *format)
+        Perl_attribute_nonnull_(1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_QUADMATH_FORMAT_NEEDED \
         assert(format)
 
 PERL_CALLCONV bool
 Perl_quadmath_format_valid(const char *format)
+        Perl_attribute_nonnull_(1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_QUADMATH_FORMAT_VALID \
         assert(format)
@@ -11170,17 +13380,21 @@ Perl_thread_locale_term(pTHX);
 #endif
 #if defined(VMS) || defined(WIN32)
 PERL_CALLCONV int
-Perl_do_aspawn(pTHX_ SV *really, SV **mark, SV **sp);
+Perl_do_aspawn(pTHX_ SV *really, SV **mark, SV **sp)
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3);
 # define PERL_ARGS_ASSERT_DO_ASPAWN             \
         assert(mark); assert(sp)
 
 PERL_CALLCONV int
-Perl_do_spawn(pTHX_ char *cmd);
+Perl_do_spawn(pTHX_ char *cmd)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DO_SPAWN              \
         assert(cmd)
 
 PERL_CALLCONV int
-Perl_do_spawn_nowait(pTHX_ char *cmd);
+Perl_do_spawn_nowait(pTHX_ char *cmd)
+        Perl_attribute_nonnull_(pTHX_1);
 # define PERL_ARGS_ASSERT_DO_SPAWN_NOWAIT       \
         assert(cmd)
 
@@ -11198,6 +13412,7 @@ Perl_get_win32_message_utf8ness(pTHX_ const char *string)
 
 PERL_CALLCONV_NO_RET void
 win32_croak_not_implemented(const char *fname)
+        Perl_attribute_nonnull_(1)
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_WIN32_CROAK_NOT_IMPLEMENTED \
         assert(fname)
@@ -11205,11 +13420,12 @@ win32_croak_not_implemented(const char *fname)
 #else /* if !defined(WIN32) */
 PERL_CALLCONV bool
 Perl_do_exec3(pTHX_ const char *incmd, int fd, int do_report)
+        Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_EXEC3              \
         assert(incmd)
 
-#endif
+#endif /* !defined(WIN32) */
 
 #ifdef PERL_CORE
 #  include "pp_proto.h"

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4453,7 +4453,7 @@ sub generate_proto_h {
         # used.
         $ret = "#${ind}if defined(PERL_CORE) || defined(PERL_EXT)\n"
              . $ret
-             . " \n#${ind}endif"
+             . "\n#${ind}endif"
           if $extensions_only;
 
         # We don't hide the ARGS_ASSERT macro; having that defined does no

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4500,14 +4500,15 @@ sub generate_proto_h {
     my $clean= normalize_group_content($proto_buffer);
 
     my $fh = open_print_header("proto.h");
+
     print $fh <<~"EOF";
-    START_EXTERN_C
-    $clean
-    #ifdef PERL_CORE
-    #  include "pp_proto.h"
-    #endif
-    END_EXTERN_C
-    EOF
+        START_EXTERN_C
+        $clean
+        #ifdef PERL_CORE
+        #  include "pp_proto.h"
+        #endif
+        END_EXTERN_C
+        EOF
 
     read_only_bottom_close_and_rename($fh) if ! $error_count;
 }

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4016,6 +4016,7 @@ sub generate_proto_h {
         my $can_ignore = $flags !~ /[RP]/ && !$is_malloc;
         my $extensions_only = ( $flags =~ /E/ );
         my @asserts;
+        my @attrs;
         my $func;
 
         if (! $can_ignore && $retval eq 'void') {
@@ -4379,7 +4380,6 @@ sub generate_proto_h {
 
         push @asserts, @$assertions if $assertions;
 
-        my @attrs;
         if ( $flags =~ /r/ ) {
             push @attrs, "__attribute__noreturn__";
         }

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4448,6 +4448,8 @@ sub generate_proto_h {
                      . " f or F flag";
         }
 
+        unshift @attrs, "Perl_attribute_nonnull_aTHX_" if $has_context;
+
         if ( @attrs ) {
             $ret .= "\n"
                  .  join( "\n", map { (" " x 8) . $_ } @attrs);
@@ -4513,6 +4515,12 @@ sub generate_proto_h {
         #  define Perl_attribute_nonnull_(which)
         #else
         #  define Perl_attribute_nonnull_(which)  __attribute__nonnull__(which)
+        #endif
+
+        #if defined(MULTIPLICITY)
+        #  define Perl_attribute_nonnull_aTHX_ __attribute__nonnull__(1)
+        #else
+        #  define Perl_attribute_nonnull_aTHX_
         #endif
 
         START_EXTERN_C

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4201,8 +4201,14 @@ sub generate_proto_h {
                     my $argname = $1;
 
                     if (defined $argname && (! $has_mflag || $binarycompat)) {
-                        if ($nn||$nz) {
+                        if ($nn || $nz) {
                             push @asserts, "assert($argname)";
+                            if ($nn) {
+                                my $string_n = $n;
+                                $string_n = "pTHX_$string_n" if $has_context;
+                                push @attrs,
+                                     "Perl_attribute_nonnull_($string_n)";
+                            }
                         }
 
                         if (   ! $nocheck
@@ -4441,11 +4447,12 @@ sub generate_proto_h {
             die_at_end "$plain_func: Function with '...' arguments must have"
                      . " f or F flag";
         }
+
         if ( @attrs ) {
-            $ret .= "\n";
-            $ret .= join( "\n", map { (" " x 8) . $_ } @attrs );
+            $ret .= "\n"
+                 .  join( "\n", map { (" " x 8) . $_ } @attrs);
         }
-        $ret .= ";";
+        $ret .= ';';
         $ret = "/* $ret */" if $has_mflag;
 
         # Hide the prototype from non-authorized code.  This acts kind of like
@@ -4502,6 +4509,12 @@ sub generate_proto_h {
     my $fh = open_print_header("proto.h");
 
     print $fh <<~"EOF";
+        #ifdef DEBUGGING    /* See GH #23641 */
+        #  define Perl_attribute_nonnull_(which)
+        #else
+        #  define Perl_attribute_nonnull_(which)  __attribute__nonnull__(which)
+        #endif
+
         START_EXTERN_C
         $clean
         #ifdef PERL_CORE


### PR DESCRIPTION
  proto.h contains a generated PERL_ARGS_ASSERT macro for every function.   It asserts that each parameter that isn't allowed to be NULL actually isn't (except there are no asserts for the aTHX parameter.)
     
These asserts are disabled when not DEBUGGING.  But many compilers allow a compile-time assertion to be made for this situation, so we can add an extra measure of protection for free.  And this gives hints to the compiler for optimizations when the asserts() aren't there.

In addition it adds a compile time assertion for the aTHX parameter.

* This set of changes does not require a perldelta entry.
