### PR TITLE
Revert "assert under DEBUGGING that Copy's arguments don't overlap"

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -2867,11 +2867,6 @@ enum mem_log_type {
         MEM_WRAP_CHECK_(n,t) \
         perl_assert_ptr(d), \
         perl_assert_ptr(s), \
-        assert_( \
-            PTR2UV((char *)(d) + (n) * sizeof (t)) <= PTR2UV((const char *)(s)) \
-            || \
-            PTR2UV((const char *)(s) + (n) * sizeof (t)) <= PTR2UV((char *)(d)) \
-        ) \
         memcpy((char*)(d),(const char*)(s), (n) * sizeof(t)) \
     )
 #define ZeroD(d,n,t)	\


### PR DESCRIPTION
This reverts commit 0045848ab5706364652e927c3453cfc212f218a4.

This check was intended to prevent undefined behavior in case memcpy's source/destination objects overlap. Unfortunately, the check itself causes compiler warnings if one of the arguments is a string literal:

    regexec.c:4810:25: warning: result of comparison against a string literal is unspecified (use an explicit string comparison function instead) [-Wstring-compare]
                            Copy("fi", mod_pat, pat_len, U8);
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ./handy.h:2871:52: note: expanded from macro 'CopyD'
                PTR2UV((char *)(d) + (n) * sizeof (t)) <= PTR2UV((const char *)(s)) \

Indeed, `Copy("foo", d, n)` could trip the assert even if no overlap is possible: Each instance of `s` in the macro body expands to a separate copy of `"foo"`. Compilers are not required to coalesce string literals (i.e. allocate only a single copy of each distinct string), so the two comparisons could be looking at different objects. It is at least theoretically possible that the compiler places one copy of `"foo"` before `d` in memory and the other `"foo"` after `d`, such that neither condition holds.

We could work around the problem if we had a compile-time "is this token sequence a string literal?" check, but I'm not aware of such a thing. So instead of adding more complexity, just take the check out again.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
