### PR TITLE
Add tests for GH 15545 (my sub using our sub segfaults)

### DIFF
--- a/t/op/lexsub.t
+++ b/t/op/lexsub.t
@@ -8,7 +8,7 @@ BEGIN {
     *bar::like = *like;
 }
 
-plan 156;
+plan 158;
 
 # -------------------- our -------------------- #
 
@@ -114,6 +114,24 @@ our sub foo;
 0 if sub { eval "" if 0; \&foo if 0; };
 print "ok";
 PROG
+
+# https://github.com/Perl/perl5/issues/15545
+fresh_perl(<<'PROG', {});
+our sub speak {}
+my sub meow {
+    speak();
+}
+PROG
+is $?, 0, 'referencing our sub from closure sub does not crash; GH 15545';
+fresh_perl(<<'PROG', {});
+our sub speak {}
+package Cat {
+    my sub meow {
+        speak();
+    }
+}
+PROG
+is $?, 0, 'referencing our sub from closure sub in seperate package does not crash; GH 15545';
 
 # -------------------- state -------------------- #
 


### PR DESCRIPTION
This PR adds todo tests for #15545, which tests that a my subroutine does not segfault when using an our sub. The tests appear to pass, which I believe means that the original ticket can be closed.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
