### PR TITLE
Consistently use `size_t` as array count/index in OP_MULTIPARAM

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -1786,13 +1786,13 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o,
     case OP_MULTIPARAM:
     {
         struct op_multiparam_aux *aux = (struct op_multiparam_aux *)cUNOP_AUXo->op_aux;
-        UV min_args = aux->min_args;
-        UV n_positional = aux->n_positional;
+        size_t min_args = aux->min_args;
+        size_t n_positional = aux->n_positional;
         if(n_positional > min_args)
-            S_opdump_indent(aTHX_ o, level, bar, file, "ARGS = %" UVuf " .. %" UVuf "\n",
+            S_opdump_indent(aTHX_ o, level, bar, file, "ARGS = %zu .. %zu\n",
                     min_args, n_positional);
         else
-            S_opdump_indent(aTHX_ o, level, bar, file, "ARGS = %" UVuf "\n",
+            S_opdump_indent(aTHX_ o, level, bar, file, "ARGS = %zu\n",
                     min_args);
 
         for(Size_t i = 0; i < n_positional; i++) {

--- a/ext/B/B.xs
+++ b/ext/B/B.xs
@@ -1397,12 +1397,12 @@ aux_list(o, cv)
         case OP_MULTIPARAM:
             {
                 struct op_multiparam_aux *p = (struct op_multiparam_aux *)aux;
-                UV nparams = p->n_positional;
+                size_t nparams = p->n_positional;
                 EXTEND(SP, (IV)(3 + nparams + 1));
                 mPUSHu(p->min_args);
                 mPUSHu(p->n_positional);
                 PUSHs(sv_2mortal(p->slurpy ? newSVpvf("%c", p->slurpy) : &PL_sv_no));
-                for(UV parami = 0; parami < nparams; parami++)
+                for(size_t parami = 0; parami < nparams; parami++)
                     mPUSHu(p->param_padix[parami]);
                 mPUSHu(p->slurpy_padix);
                 XSRETURN(3 + nparams + 1);

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -1204,14 +1204,14 @@ static OP *THX_parse_keyword_subsignature(pTHX)
                 struct op_multiparam_aux *p =
                     (struct op_multiparam_aux *)(cUNOP_AUXx(kid)->op_aux);
                 PADNAMELIST *names = PadlistNAMES(CvPADLIST(find_runcv(0)));
-                SV *retsv = newSVpvf("multiparam:%" UVuf "..%" UVuf ":%c",
+                SV *retsv = newSVpvf("multiparam:%zu..%zu:%c",
                         p->min_args, p->n_positional, p->slurpy ? p->slurpy : '-');
-                for (UV paramidx = 0; paramidx < p->n_positional; paramidx++) {
+                for (size_t paramidx = 0; paramidx < p->n_positional; paramidx++) {
                     char *namepv = PadnamePV(padnamelist_fetch(names, p->param_padix[paramidx]));
                     if(namepv)
-                        sv_catpvf(retsv, ":%s=%" UVf, namepv, paramidx);
+                        sv_catpvf(retsv, ":%s=%zu", namepv, paramidx);
                     else
-                        sv_catpvf(retsv, ":(anon)=%" UVf, paramidx);
+                        sv_catpvf(retsv, ":(anon)=%zu", paramidx);
                     if(paramidx >= p->min_args)
                         sv_catpvs(retsv, "?");
                 }

--- a/op.c
+++ b/op.c
@@ -16562,7 +16562,7 @@ Perl_rcpv_copy(pTHX_ char *pv) {
 /* Subroutine signature parsing */
 
 struct yy_parser_signature_param {
-    UV         argix;        /* positional index of the param */
+    size_t     argix;        /* positional index of the param */
     PADOFFSET  padix;        /* pad index of the var holding the param */
     OP        *defcop;
     OPCODE     defmode;
@@ -16595,7 +16595,7 @@ destroy_subsignature_context(pTHX_ void *p)
     yy_parser_signature *signature = (yy_parser_signature *)p;
 
     if(signature->params) {
-        for(UV parami = 0; parami < signature->nparams; parami++) {
+        for(size_t parami = 0; parami < signature->nparams; parami++) {
             struct yy_parser_signature_param *param = signature->params + parami;
 
             if(param->defcop)
@@ -16830,7 +16830,7 @@ Perl_subsignature_finish(pTHX)
     sigops = op_append_elem(OP_LINESEQ, sigops,
             newSTATEOP(0, NULL, NULL));
 
-    UV end_argix = signature->next_argix;
+    size_t end_argix = signature->next_argix;
 
     struct op_multiparam_aux *aux = (struct op_multiparam_aux *)PerlMemShared_malloc(
             sizeof(struct op_multiparam_aux) + (end_argix * sizeof(PADOFFSET)));
@@ -16861,12 +16861,12 @@ Perl_subsignature_finish(pTHX)
     }
 
     struct yy_parser_signature_param *params = signature->params;
-    UV max_argix = 0;
+    size_t max_argix = 0;
 
-    for(UV parami = 0; parami < signature->nparams; parami++) {
+    for(size_t parami = 0; parami < signature->nparams; parami++) {
         struct yy_parser_signature_param *param = params + parami;
 
-        UV argix        = param->argix;
+        size_t argix    = param->argix;
         PADOFFSET padix = param->padix;
 
         while(max_argix < argix) {

--- a/op.h
+++ b/op.h
@@ -1192,8 +1192,8 @@ struct op_argcheck_aux {
 /* for OP_MULTIPARAM */
 
 struct op_multiparam_aux {
-    UV    min_args;     /* = the number of mandatory scalar parameters */
-    UV    n_positional; /* = the number of mandatory + optional scalar parameters, not counting a final slurpy */
+    size_t min_args;     /* = the number of mandatory scalar parameters */
+    size_t n_positional; /* = the number of mandatory + optional scalar parameters, not counting a final slurpy */
     char  slurpy;
     PADOFFSET *param_padix; /* points at storage allocated along with the struct itself, immediately following */
     PADOFFSET slurpy_padix;

--- a/pp.c
+++ b/pp.c
@@ -7889,17 +7889,17 @@ PP(pp_argcheck)
 PP(pp_multiparam)
 {
     struct op_multiparam_aux *aux = (struct op_multiparam_aux *)cUNOP_AUX->op_aux;
-    UV nparams = aux->n_positional;
+    size_t nparams = aux->n_positional;
     char slurpy = aux->slurpy;
     PADOFFSET *param_padix = aux->param_padix;
     AV  *defav = GvAV(PL_defgv); /* @_ */
 
     assert(!SvMAGICAL(defav));
-    UV argc = (UV)(AvFILLp(defav) + 1);
+    size_t argc = (AvFILLp(defav) + 1);
 
     S_check_argc(aTHX_ argc, nparams, nparams - aux->min_args, slurpy);
 
-    UV parami;
+    size_t parami;
     for(parami = 0; parami < nparams; parami++) {
         PADOFFSET padix = param_padix[parami];
         if(!padix) {
@@ -7949,7 +7949,7 @@ PP(pp_multiparam)
 
         av_extend(av, argc);
 
-        IV avidx = 0;
+        size_t avidx = 0;
         for(; argc; parami++, argc--) {
             SV **valp = av_fetch(defav, parami, FALSE);
             SV *val = valp ? *valp : &PL_sv_undef;


### PR DESCRIPTION
Recently-added code was written largely by copying existing practices in various places. In particular, much of the original code was using `UV` typed variables to store sizes and indexes in various list or array structures, counts of parameters, and so on.

On fully 64-bit platforms this is all fine, but on 32-bit platforms with -Duse64bitint enabled, this is a 64-bit integer that won't ever be counting that high. These values might as well be stored as 32-bit integers in that case.

* This set of changes does not require a perldelta entry.