### PR TITLE
t/op/goto.t: Remove superfluous 'exit;' statement

### DIFF
--- a/t/op/goto.t
+++ b/t/op/goto.t
@@ -74,7 +74,6 @@ sub bar {
 }
 
 &bar;
-exit;
 
 FINALE:
 is(curr_test(), 20, 'FINALE');

--- a/t/op/goto.t
+++ b/t/op/goto.t
@@ -74,6 +74,8 @@ sub bar {
 }
 
 &bar;
+fail('goto bypass');
+exit;
 
 FINALE:
 is(curr_test(), 20, 'FINALE');


### PR DESCRIPTION
This is an excerpt from `t/op/goto.t` in blead:
```
 60 my $ok = 0;
 61 sub foo {
 62     goto bar;
 63     return;
 64 bar:
 65     $ok = 1;
 66 }
 67 
 68 &foo;
 69 ok($ok, 'goto in sub');
 70     
 71 sub bar {
 72     my $x = 'bypass';
 73     eval "goto $x";
 74 }
 75 
 76 &bar;
 77 exit;   # <== What is this doing here?
 78 
 79 FINALE:
 80 is(curr_test(), 20, 'FINALE');
```
Note the `exit;` statement in line 77.  I can't figure out what effect this is having there.  The program certainly continues past this point in the code.  This statement was added by Larry 35 years ago!
```
commit 79072805bf63abe5b5978b5928ab00d360ea3e7f (tag: perl-5a2)
Author:     Larry Wall <larry@wall.org>
AuthorDate: Thu Oct 7 23:00:00 1993 +0000
Commit:     Larry Wall <larry@wall.org>
CommitDate: Thu Oct 7 23:00:00 1993 +0000

    perl 5.0 alpha 2
    
    [editor's note: from history.perl.org.  The sparc executables
    originally included in the distribution are not in this commit.]

...
diff --git a/t/op/goto.t b/t/op/goto.t
old mode 100644
new mode 100755
index 29bf797a58..0b89921b94
--- a/t/op/goto.t
+++ b/t/op/goto.t
...
+
+sub foo {
+    goto bar;
+    print "not ok 4\n";
+    return;
+bar:
+    print "ok 4\n";
+}
+
+&foo;
+
+sub bar {
+    $x = 'exitcode';
+    eval "goto $x";    # Do not take this as exemplary code!!!
+}
+
+&bar;
+exit;
+exitcode:
+print "ok 5\n";
```
Although I'm very reluctant to remove Larry code, we should consider doing so if it has no demonstrable effect.  Submitting p.r.


* This set of changes does not require a perldelta entry.
