### PR TITLE
pack: allocate msgs AV before pushing to it

### DIFF
--- a/pp_pack.c
+++ b/pp_pack.c
@@ -308,7 +308,7 @@ S_utf8_to_bytes(pTHX_ const char **s, const char *end, const char *buf, SSize_t 
          * */
         if (this_msgs) {
             while (av_count(this_msgs) > 0) {
-                av_push(msgs, av_shift(this_msgs));
+                Perl_av_create_and_push(aTHX_ &msgs, av_shift(this_msgs));
             }
 
             Safefree(this_msgs);


### PR DESCRIPTION
This is an oversight from commit b0c3c5f582be. We need to make sure msgs is not NULL before we can start pushing values.

Fixes a Coverity report:

    324         if (msgs) {
    >>>     CID 584148:         Possible Control flow issues  (DEADCODE)
    >>>     Execution cannot reach this statement: "while (Perl_av_count(my_per...".
    325             while (av_count(msgs) > 0) {

(Coverity thinks the code is unreachable because it is guarded by an 'if (msgs)' statement, and 'msgs' is initialized to NULL and never modified afterwards. In reality, it would probably crash in av_push() if any warnings were to be generated.)


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
