### PR TITLE
todo tests for GH 22192 (lvalue vec() does not propagate tainting)

### DIFF
--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -352,4 +352,31 @@ TODO: {
     );
 }
 
+TODO: {
+    todo_skip 2 if is_miniperl();
+    local $::TODO = 'GH 22192';
+    fresh_perl_is(
+        <<~'HERE',
+            use Scalar::Util qw(tainted);
+            my $y = <STDIN>;
+            vec( my $x = "", 0, 8 ) = $y;
+            print tainted($x);
+            HERE
+        '1',
+        { stdin => '123', switches => [ '-t' ] },
+        'lvalue vec() propagates tainting on empty string; GH 22192'
+    );
+    fresh_perl_is(
+        <<~'HERE',
+            use Scalar::Util qw(tainted);
+            my $y = <STDIN>;
+            vec( my $x = "X", 0, 8 ) = $y;
+            print tainted($x);
+            HERE
+        '1',
+        { stdin => '123', switches => [ '-t' ] },
+        'lvalue vec() propagates tainting on non-empty string; GH 22192'
+    );
+}
+
 done_testing();


### PR DESCRIPTION
This PR adds todo tests for #22192. It tests that vec() propagates tainting on both empty strings and non-empty strings, like it does on an uninitialized scalar. These tests still appear to fail.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
