### PR TITLE
find_script: avoid potential integer overflow

### DIFF
--- a/util.c
+++ b/util.c
@@ -3410,7 +3410,7 @@ Perl_find_script(pTHX_ const char *scriptname, bool dosearch,
     char *xfailed = NULL;
     char tmpbuf[MAXPATHLEN];
     char *s;
-    I32 len = 0;
+    size_t len = 0;
     int retval;
     char *bufend;
 #if defined(DOSISH) && !defined(OS2)
@@ -3550,13 +3550,26 @@ Perl_find_script(pTHX_ const char *scriptname, bool dosearch,
             if (len < sizeof tmpbuf)
                 tmpbuf[len] = '\0';
 #  else
-            s = delimcpy_no_escape(tmpbuf, tmpbuf + sizeof tmpbuf, s, bufend,
-                                   ':', &len);
+            {
+                I32 n;
+                s = delimcpy_no_escape(tmpbuf, tmpbuf + sizeof tmpbuf, s,
+                                       bufend, ':', &n);
+                assert(n >= 0);
+                len = n;
+            }
 #  endif
             if (s < bufend)
                 s++;
-            if (len + 1 + strlen(scriptname) + MAX_EXT_LEN >= sizeof tmpbuf)
-                continue;	/* don't search dir with too-long name */
+            {
+                const size_t
+                    available_len = sizeof tmpbuf - MAX_EXT_LEN - 1,
+                    scriptname_len = strlen(scriptname);
+                if (
+                    scriptname_len >= available_len ||
+                    len >= available_len - scriptname_len
+                )
+                    continue;   /* don't search dir with too-long name */
+            }
             if (len
 #  ifdef DOSISH
                 && tmpbuf[len - 1] != '/'


### PR DESCRIPTION
Fixes a Coverity issue:

    >>>     function_return: Function Perl_delimcpy_no_escape(tmpbuf, tmpbuf + 4096UL, s, bufend, 58, &len) modifies its argument, assigning 2147483647 to len.
    3553            s = delimcpy_no_escape(tmpbuf, tmpbuf + sizeof tmpbuf, s, bufend,
    3554                                   ':', &len);
    >>>     CID 583353: (#1 of 1): Overflowed constant (INTEGER_OVERFLOW)
    >>>     overflow_const: Expression len + 1, where len is known to be equal to 2147483647, overflows the type of len + 1, which is type int.
    3558            if (len + 1 + strlen(scriptname) + MAX_EXT_LEN >= sizeof tmpbuf)
    3559                continue;       /* don't search dir with too-long name */

If there is not enough available space in tmpbuf, delimcpy_no_escape sets len to I32_MAX, but the following code does not check for this. (I believe this case is reachable simply by setting PATH to a huge string.)

Avoid the potential overflow by rewriting

    A + B >= C

as

    A >= C - B

(Also, make 'len' unsigned (specifically, size_t) to match the type of sizeof/strlen() and avoid warnings about comparisons between signed and unsigned integers.)


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
