### PR TITLE
Perl_newSVsv_flags_NN_PVxx: do not copy the SVprv_WEAKREF flag

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -750,6 +750,7 @@ Richard Foley <richard.foley@rfi.net> <richard.foley@ubs.com>
 Richard Foley <richard.foley@rfi.net> <richard.foley@ubsw.com>
 Richard L. Maus, Jr. <rmaus@monmouth.com> Richard L. Maus <rmaus@monmouth.com>
 Richard Leach <rich+perl@hyphen-dash-hyphen.info> Richard Leach <richardleach@users.noreply.github.com>
+Richard Leach <rich+perl@hyphen-dash-hyphen.info> richardleach <richardleach@users.noreply.github.com>
 Richard Soderberg <p5-authors@crystalflame.net> <perl@crystalflame.net>
 Richard Soderberg <p5-authors@crystalflame.net> <rs@crystalflame.net>
 Richard Soderberg <p5-authors@crystalflame.net> <rs@oregonnet.com>

--- a/sv.c
+++ b/sv.c
@@ -5046,6 +5046,10 @@ S_newSVsv_flags_NN_PVxx(pTHX_ SV* dsv, SV* ssv, const I32 flags)
             SvNV_set(dsv, SvNVX(ssv));
             break;
         case SVf_ROK:  /* [ 3% ]*/
+            /* Another corner case here. SVf_IVisUV and SVprv_WEAKREF
+             * have the same underlying value. We do not want to
+             * propagate the latter. */
+             SvFLAGS(dsv) &= ~SVprv_WEAKREF;
             SvRV_set(dsv, SvREFCNT_inc(SvRV(ssv)));
             return dsv;
         default:  /* [ 2% ]*/

--- a/t/op/svflags.t
+++ b/t/op/svflags.t
@@ -10,7 +10,7 @@ BEGIN {
 # Tests the new documented mechanism for determining the original type
 # of an SV.
 
-plan tests => 16;
+plan tests => 22;
 use strict;
 use B qw(svref_2object SVf_IOK SVf_NOK SVf_POK);
 
@@ -83,3 +83,33 @@ is($xobj->FLAGS & (SVf_IOK | SVf_POK), SVf_POK, "correct base flags on PV");
 $y = $x + 10;
 
 is($xobj->FLAGS & (SVf_IOK | SVf_POK), (SVf_IOK | SVf_POK), "POK still set on PV used as number");
+
+
+# GH #23637, GH #23646 - newSVsv_flags_NN erroneously copied WEAKREF in *some* code paths
+
+my $ref = [];
+my ($wref, $cref);
+
+# Weakened reference SV is an SVt_IV
+$wref = $ref;
+builtin::weaken($wref);
+ok(builtin::is_weak($wref), 'a weakened SVt_IV ref has WEAKREF set');
+$cref = [ $wref ];
+ok(!builtin::is_weak( $cref->[0] ), 'SVt_IV copies do NOT have WEAKREF set');
+
+# Weakened reference SV is an SVt_PV
+$wref = 'blip';
+$wref = $ref;
+builtin::weaken($wref);
+ok(builtin::is_weak($wref), 'a weakened SVt_PV ref has WEAKREF set');
+$cref = [ $wref ];
+ok(!builtin::is_weak( $cref->[0] ), 'SVt_PV copies do NOT have WEAKREF set');
+
+# Weakened reference SV is an SVt_PVIV
+$wref = 1;
+$wref = $ref;
+builtin::weaken($wref);
+ok(builtin::is_weak($wref), 'a weakened SVt_PVIV ref has WEAKREF set');
+$cref = [ $wref ];
+ok(!builtin::is_weak( $cref->[0] ), 'SVt_PVIV copies do NOT have WEAKREF set');
+


### PR DESCRIPTION
When copying source SV flags to the new destination SV, this function
failed to account for SVprv_WEAKREF and SVf_IVisUV flags having the
same numerical value - 0x80000000. The SVprv_WEAKREF flag was
consequently erroneously propagated when copying weakened references.

This didn't trip existing tests because SVt_IVs (the predominant SV type
for RVs) are copied using different code paths.

This commit:
  * Always drops the SVprv_WEAKREF flag in the affected code path
  * Adds additional tests for copying weakened SVs

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
