### PR TITLE
Add todo-test for GH 13307 (hash elem ref in @_ disappears)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -504,6 +504,7 @@ Juerd Waalboer <#####@juerd.nl> Juerd <juerd@convolution.nl>
 Juerd Waalboer <#####@juerd.nl> Juerd <juerd@cpan.org>
 Juerd Waalboer <#####@juerd.nl> Juerd Waalboer <juerd@c3.convolution.nl>
 Justin Case <unknown> Justin Case <>
+Jörg Thomas <zebster@spr.at> zb226 <zebster@spr.at>
 Kaoru Maeda <maeda@src.ricoh.co.jp> Unknown Ricoh Contributor II <maeda@src.ricoh.co.jp>
 Karen Etheridge <ether@cpan.org> Karen Etheridge <github@froods.org>
 Karl Williamson <khw@cpan.org> Karl <khw@karl.(none)>

--- a/AUTHORS
+++ b/AUTHORS
@@ -780,6 +780,7 @@ juna                           <ggl.20.jj...@spamgourmet.com>
 Jungshik Shin                  <jshin@mailaps.org>
 Justin Banks                   <justinb@cray.com>
 Justin Case
+Jörg Thomas                    <zebster@spr.at>
 Jörg Walter                    <jwalt@cpan.org>
 Ka-Ping Yee                    <kpyee@aw.sgi.com>
 kafka                          <kafka@madrognon.net>

--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -206,6 +206,29 @@ TODO: {
 }
 
 TODO: {
+    my $is_rc_stack = "$Config{cc} $Config{ccflags} $Config{optimize}" =~ /-DPERL_RC_STACK\b/;
+    local $::TODO = $is_rc_stack ? undef : "GH 13307";
+
+    my $results = fresh_perl(<<~'EOF', {});
+        my $iter;
+        my %llll;
+        sub bbbb { }
+        sub aaaa {
+            \@_ if $iter & 1;
+            bbbb($_[1]) if $iter & 2;
+            delete $llll{p};
+            print $_[0] // "undef", "\n";
+        }
+        for(0..3) {
+            $iter = $_;
+            %llll = (p => "oooo");
+            aaaa($llll{p}, undef);
+        }
+    EOF
+    is($results, "oooo\noooo\noooo\noooo", 'Hashref element reference in @_ disappeared; GH 13307');
+}
+
+TODO: {
     local $::TODO = "GH 16008";
     my $results = fresh_perl(<<~'EOF', {} );
         open my $h, ">", \my $x;


### PR DESCRIPTION
This PR adds a todo-test for #13307 where a changed behavior involving `@_` from perl 5.19.4 on was noted. Current blead perl still shows the same behavior.

---

* This set of changes does not require a perldelta entry.