### PR TITLE
Attribute-Handlers: update VERSION in %Maintainers::Modules

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -145,7 +145,7 @@ our %Modules = (
     },
 
     'Attribute::Handlers' => {
-        'DISTRIBUTION' => 'RJBS/Attribute-Handlers-0.99.tar.gz',
+        'DISTRIBUTION' => 'RJBS/Attribute-Handlers-1.03.tar.gz',
         'FILES'        => q[dist/Attribute-Handlers],
     },
 


### PR DESCRIPTION
This is needed so that `perl Porting/core-cpan-diff -ax` DWIMs.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
