### PR TITLE
ParseXS: fix space translation for $ntype

### DIFF
--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
@@ -2872,9 +2872,10 @@ sub lookup_input_typemap {
 
         my $typemaps = $pxs->{typemaps_object};
 
-        # Normalised type ('Foo *' becomes 'FooPtr): one of the valid vars
-        # which can appear within a typemap template.
+        # Normalised type ('struct Foo *' becomes 'struct_FooPtr' etc):
+        # one of the valid vars which can appear within a typemap template.
         (my $ntype = $type) =~ s/\s*\*/Ptr/g;
+        $ntype =~ s/\s+/_/g;
 
         # $subtype is really just for the T_ARRAY / DO_ARRAY_ELEM code below,
         # where it's the type of each array element. But it's also passed to
@@ -3077,9 +3078,10 @@ sub lookup_output_typemap {
         return;
     }
 
-    # $ntype: normalised type ('Foo *' becomes 'FooPtr' etc): one of the
-    # valid vars which can appear within a typemap template.
+    # $ntype: normalised type ('struct Foo *' becomes 'struct_FooPtr' etc):
+    # one of the valid vars which can appear within a typemap template.
     (my $ntype = $type) =~ s/\s*\*/Ptr/g;
+    $ntype =~ s/\s+/_/g;
     $ntype =~ s/\(\)//g;
 
     # $subtype is really just for the T_ARRAY / DO_ARRAY_ELEM code below,

--- a/dist/ExtUtils-ParseXS/lib/perlxstypemap.pod
+++ b/dist/ExtUtils-ParseXS/lib/perlxstypemap.pod
@@ -230,8 +230,9 @@ e.g. for a type of C<Foo::Bar>, I<$type> is C<Foo__Bar>
 
 =item *
 
-I<$ntype> - the supplied type with C<*> replaced with C<Ptr>.
-e.g. for a type of C<Foo*>, I<$ntype> is C<FooPtr>
+I<$ntype> - the supplied type with C<*> replaced with C<Ptr> and
+C<\s> replaced with C<_>.
+e.g. for a type of C<struct Foo*>, I<$ntype> is C<struct_FooPtr>
 
 =item *
 


### PR DESCRIPTION
Variable $ntype is used in T_PACKED and T_PACKEDARRAY AS-IS making impossible to use these typemaps with any types containing spaces, like 'struct Foo'.  This commit replaces spaces with underscores. 

------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
