### PR TITLE
toke.c: Use_SvGrow_return

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -11751,9 +11751,11 @@ Perl_scan_str(pTHX_ char *start, int keep_bracketed_quoted, int keep_delims, int
     s += delim_byte_len;
     for (;;) {
         /* extend sv if need be */
-        SvGROW(sv, SvCUR(sv) + (PL_bufend - s) + 1);
+
+        STRLEN sv_len = SvCUR(sv);
+        char * pv = SvGROW(sv, sv_len + (PL_bufend - s) + 1);
         /* set 'to' to the next character in the sv's string */
-        to = SvPVX(sv)+SvCUR(sv);
+        to = pv + sv_len;
 
         /* read until we run out of string, or we find the closing delimiter */
         while (s < PL_bufend) {


### PR DESCRIPTION
Prior to this commit, the return from SvGROW() was ignored, and the value re-derived a few lines later.

This commit was extracted from GH #23533

* This set of changes does not require a perldelta entry.
