### PR TITLE
result of ^^ is not the last evaluated expression.

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -1089,7 +1089,7 @@ cannot).  This is very useful for
 providing default values for variables.  If you actually want to test if
 at least one of C<$x> and C<$y> is defined, use S<C<defined($x // $y)>>.
 
-The C<||>, C<^^> and C<//> operators return the last value evaluated
+The C<||> and C<//> operators return the last value evaluated
 (unlike C's C<||> which returns 0 or 1).  Thus, a reasonably
 portable way to find out the home directory might be:
 


### PR DESCRIPTION
The ^^ operator can't return the last evaluated expression since it could either be true or false, and would not indicate the success of the XOR. You can see this by using ^^:

    $ perl -E 'say q(A) ^^ q(B)'

    $ perl -E 'say q(0) ^^ q(B)'
    1

* This set of changes does not require a perldelta entry.

The docs may need further revisions to distinguish `^^` from the other logical operators. I think the re-organization of the separate sections for `||`, `//`, and `^^` was a mistake that will cause more confusion for people since these three are dissimilar enough to need sections that distinguish them sufficiently.