### PR TITLE
test.pl: Use END blocks to cancel watchdog timers

### DIFF
--- a/t/io/closepid.t
+++ b/t/io/closepid.t
@@ -42,5 +42,3 @@ SKIP:
     kill $killsig, $pid;
     open STDIN, "<&", $savein;
 }
-
-watchdog(0);

--- a/t/io/openpid.t
+++ b/t/io/openpid.t
@@ -101,5 +101,3 @@ next_test();
 print "# waiting for process $pid4 to exit\n";
 $reap_pid = waitpid $pid4, 0;
 is( $reap_pid, $pid4, 'fourth process reaped' );
-
-watchdog(0);

--- a/t/op/sigdispatch.t
+++ b/t/op/sigdispatch.t
@@ -167,5 +167,3 @@ like $@, qr/No such hook: __DIE__\\0whoops at/;
     is($int_called, 1);
     is($@, "died");
 }
-
-watchdog(0);

--- a/t/op/signame_canonical.t
+++ b/t/op/signame_canonical.t
@@ -72,6 +72,3 @@ foreach my $dupe (@duplicate_signals) {
     is( $SIG{$dupe},           undef, "The signal $dupe is cleared after local goes out of scope." );
     is( $SIG{$canonical_name}, undef, "The signal $canonical_name is cleared after local goes out of scope." );
 }
-
-watchdog(0);
-

--- a/t/op/study.t
+++ b/t/op/study.t
@@ -158,5 +158,3 @@ TODO: {
     push @got, $_ foreach $a =~ /[^x]d(?{$a .= ''})[^x]d/g;
     is("@got", 'ydyd ydyd', '#92696 $a .= \'\' inside (?{}), $a studied');
 }
-
-watchdog(0);

--- a/t/op/time.t
+++ b/t/op/time.t
@@ -248,5 +248,3 @@ SKIP: {
     is scalar gmtime("NaN"), undef, '[perl #123495] gmtime(NaN)';
     is scalar localtime("NaN"), undef, 'localtime(NaN)';
 }
-
-watchdog(0);

--- a/t/op/time_loop.t
+++ b/t/op/time_loop.t
@@ -14,5 +14,3 @@ watchdog(2);
 local $SIG{__WARN__} = sub {};
 is gmtime(2**69),    undef;
 is localtime(2**69), undef;
-
-watchdog(0);

--- a/t/op/waitpid.t
+++ b/t/op/waitpid.t
@@ -35,6 +35,5 @@ watchdog(10);
 
     pass("didn't block on waitpid(0, ...)");
 }
-watchdog(0);
 
 done_testing();

--- a/t/perf/speed.t
+++ b/t/perf/speed.t
@@ -42,6 +42,4 @@ SKIP: {
     pass("COW 1Mb strings");
 }
 
-watchdog(0);
-
 1;

--- a/t/perf/taint.t
+++ b/t/perf/taint.t
@@ -61,6 +61,4 @@ my $taint = substr($ENV{PATH}, 0, 0); # and empty tainted string
     pass("RT #130584 pos on tainted utf8 string");
 }
 
-watchdog(0);
-
 1;

--- a/t/re/fold_grind.pl
+++ b/t/re/fold_grind.pl
@@ -1101,7 +1101,6 @@ foreach my $test (sort { numerically } keys %{$tests_ref}) {
 }
 }
 
-watchdog(0);
 plan($count);
 
 1

--- a/t/test.pl
+++ b/t/test.pl
@@ -38,6 +38,7 @@ $::IS_EBCDIC = ord 'A' == 193;
 our $TODO = 0;
 our $NO_ENDING = 0;
 our $Tests_Are_Passing = 1;
+our @watchdog_threads_;
 
 # Use this instead of print to avoid interference while testing globals.
 sub _print {
@@ -1834,8 +1835,7 @@ sub warning_like {
 # NOTE:  If the test file uses 'threads', then call the watchdog() function
 #        _AFTER_ the 'threads' module is loaded.
 { # Closure
-    my $watchdog;
-    my $watchdog_thread;
+    my $cancel_string;
 
 sub watchdog ($;$)
 {
@@ -1844,28 +1844,17 @@ sub watchdog ($;$)
     # If cancelling, use the state variables to know which method was used to
     # create the watchdog.
     if ($timeout == 0) {
-        if ($watchdog_thread) {
-            $watchdog_thread->kill('KILL');
-            undef $watchdog_thread;
-        }
-        elsif ($watchdog) {
-            kill('KILL', $watchdog);
-            undef $watchdog;
-        }
-        else {
-            alarm(0);
-        }
-
+        eval $cancel_string if defined $cancel_string;
         return;
     }
-
-    # Make sure these aren't defined.
-    undef $watchdog;
-    undef $watchdog_thread;
 
     my $method = shift || "";
 
     my $timeout_msg = 'Test process timed out - terminating';
+
+    # Common to all cancellation types; HERE gets replaced below by the
+    # individual code
+    $cancel_string = 'local $! = 0; local $? = 0; HERE; undef $cancel_string';
 
     # Accept either spelling
     my $timeout_factor = $ENV{PERL_TEST_TIME_OUT_FACTOR}
@@ -1894,6 +1883,8 @@ sub watchdog ($;$)
         || (defined $ENV{PERL_SIGNALS} && $ENV{PERL_SIGNALS} eq "unsafe")
         || $method eq "process")
     {
+        my $watchdog;
+
         # On Windows and VMS, try launching a watchdog process
         #   using system(1, ...) (see perlport.pod).  system() returns
         #   immediately on these platforms with effectively a pid of the new
@@ -1911,7 +1902,6 @@ sub watchdog ($;$)
             return if ($pid_to_kill <= 0);
 
             # Launch watchdog process
-            undef $watchdog;
             eval {
                 local $SIG{'__WARN__'} = sub {
                     _diag("Watchdog warning: $_[0]");
@@ -1954,20 +1944,19 @@ sub watchdog ($;$)
 
             # Add END block to parent to terminate and clean up watchdog
             # process
-            eval("END { local \$! = 0; local \$? = 0;
-                        wait() if kill('KILL', $watchdog); };");
+            $cancel_string =~ s/HERE/wait() if kill('KILL', $watchdog)/;
+            eval("END { $cancel_string };");
             return;
         }
 
         # Try using fork() to generate a watchdog process
-        undef $watchdog;
         eval { $watchdog = fork() };
         if (defined($watchdog)) {
             if ($watchdog) {   # Parent process
                 # Add END block to parent to terminate and clean up watchdog
                 # process
-                eval "END { local \$! = 0; local \$? = 0;
-                            wait() if kill('KILL', $watchdog); };";
+                $cancel_string =~ s/HERE/wait() if kill('KILL', $watchdog)/;
+                eval("END { $cancel_string };");
                 return;
             }
 
@@ -2005,7 +1994,9 @@ sub watchdog ($;$)
     # Use a watchdog thread because either 'threads' is loaded, or fork()
     # failed
     if (eval {require threads; 1}) {
-        $watchdog_thread = 'threads'->create(sub {
+
+        # Use an array so can handle multiple timers
+        push @watchdog_threads_, 'threads'->create(sub {
                 # Load POSIX if available
                 eval { require POSIX; };
 
@@ -2029,12 +2020,16 @@ sub watchdog ($;$)
                 kill($sig, $pid_to_kill);
         });
 
+        #my $index = scalar @watchd
+        $cancel_string =~ s/HERE/\$watchdog_threads_[$#watchdog_threads_]->kill('KILL')/;
+        eval "END { $cancel_string }";
+
         # Don't proceed until the watchdog has set up its signal handler.
         # (Otherwise there is a possibility that we will exit with threads
         # running.)  The watchdog tells us that the handler is set by
         # detaching itself.  (The 'is_running()' is a fail-safe.)
-        while (     $watchdog_thread->is_running()
-               && ! $watchdog_thread->is_detached())
+        while (     $watchdog_threads_[-1]->is_running()
+               && ! $watchdog_threads_[-1]->is_detached())
         {
             'threads'->yield();
         }
@@ -2057,6 +2052,9 @@ WATCHDOG_VIA_ALARM:
             my $sig = $is_vms ? 'TERM' : 'KILL';
             kill($sig, $pid_to_kill);
         };
+
+        $cancel_string =~ s/HERE/alarm(0)/;
+        eval "END { $cancel_string }";
     }
 }
 } # End closure

--- a/t/test.pl
+++ b/t/test.pl
@@ -1888,8 +1888,7 @@ sub watchdog ($;$)
     # shut up use only once warning
     my $threads_on = $threads::threads && $threads::threads;
 
-    # Don't use a watchdog process if 'threads' is loaded -
-    #   use a watchdog thread instead
+    # Use a watchdog process unless 'threads' is loaded
     if (!$threads_on || $method eq "process") {
 
         # On Windows and VMS, try launching a watchdog process
@@ -1950,8 +1949,8 @@ sub watchdog ($;$)
                 return;
             }
 
-            # Add END block to parent to terminate and
-            #   clean up watchdog process
+            # Add END block to parent to terminate and clean up watchdog
+            # process
             eval("END { local \$! = 0; local \$? = 0;
                         wait() if kill('KILL', $watchdog); };");
             return;
@@ -1962,8 +1961,8 @@ sub watchdog ($;$)
         eval { $watchdog = fork() };
         if (defined($watchdog)) {
             if ($watchdog) {   # Parent process
-                # Add END block to parent to terminate and
-                #   clean up watchdog process
+                # Add END block to parent to terminate and clean up watchdog
+                # process
                 eval "END { local \$! = 0; local \$? = 0;
                             wait() if kill('KILL', $watchdog); };";
                 return;
@@ -2000,8 +1999,8 @@ sub watchdog ($;$)
         # fork() failed - fall through and try using a thread
     }
 
-    # Use a watchdog thread because either 'threads' is loaded,
-    #   or fork() failed
+    # Use a watchdog thread because either 'threads' is loaded, or fork()
+    # failed
     if (eval {require threads; 1}) {
         $watchdog_thread = 'threads'->create(sub {
                 # Load POSIX if available
@@ -2040,7 +2039,8 @@ sub watchdog ($;$)
         return;
     }
 
-    # If everything above fails, then just use an alarm timeout
+    # If everything above fails, then just use an alarm timeout.  There can
+    # only be one in effect at a time.  This cancels any previous one.
 WATCHDOG_VIA_ALARM:
     if (eval { alarm($timeout); 1; }) {
         # Load POSIX if available

--- a/t/test.pl
+++ b/t/test.pl
@@ -1888,9 +1888,12 @@ sub watchdog ($;$)
     # shut up use only once warning
     my $threads_on = $threads::threads && $threads::threads;
 
-    # Use a watchdog process unless 'threads' is loaded
-    if (!$threads_on || $method eq "process") {
-
+    # Use a watchdog process unless 'threads' is loaded and is killable by a
+    # signal
+    if (   ! $threads_on
+        || (defined $ENV{PERL_SIGNALS} && $ENV{PERL_SIGNALS} eq "unsafe")
+        || $method eq "process")
+    {
         # On Windows and VMS, try launching a watchdog process
         #   using system(1, ...) (see perlport.pod).  system() returns
         #   immediately on these platforms with effectively a pid of the new

--- a/t/win32/popen.t
+++ b/t/win32/popen.t
@@ -24,6 +24,4 @@ for(1..100) {
 }
 PERL
 
-watchdog(0);
-
 done_testing();


### PR DESCRIPTION
In doing follow up work to a7f3f23
"Turn off watchdog when done in tests", I realized that my solution was
suboptimal, and that the code already existed in test.pl to do things
better.

What that code does is to create an END block to cancel the watchdog
upon program exit.  I think that is a better solution than to force
the addition of explicit calls to watchdog(0).  This commit creates a
standard way to specify the code that does the cancellation, and to use
it, not only when the END block does, but also when the timer is
explicitly cancelled.

This means the calls to watchdog(0) that occur at the end of the file
that were added in a7f3f23 aren't
necessary.  The END block takes care of it.  The reason to keep them is
if we want to add a porting test that every watchdog is cleared.

* This set of changes does not require a perldelta entry.
