### PR TITLE
Handle empty subroutine signatures in `parse_subsignature()` (fixes #17689)

### DIFF
--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.45';
+our $VERSION = '1.46';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -1221,11 +1221,6 @@ static OP *THX_parse_keyword_subsignature(pTHX)
                 retop = op_append_list(OP_LIST, retop, newSVOP(OP_CONST, 0, retsv));
                 break;
             }
-            case OP_PARAMTEST:
-                break;
-            default:
-                fprintf(stderr, "TODO: examine kid %p (optype=%s)\n", kid, PL_op_name[kid->op_type]);
-                break;
         }
     }
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -1181,7 +1181,7 @@ static OP *THX_parse_keyword_subsignature(pTHX)
                 seen_nextstate++;
                 retop = op_append_list(OP_LIST, retop, newSVOP(OP_CONST, 0,
                     /* newSVpvf("nextstate:%s:%d", CopFILE(cCOPx(kid)), cCOPx(kid)->cop_line))); */
-                    newSVpvf("nextstate:%u", (unsigned int)cCOPx(kid)->cop_line)));
+                    newSVpvf("nextstate:%" LINE_Tf, CopLINE(cCOPx(kid)))));
                 break;
             case OP_ARGCHECK: {
                 struct op_argcheck_aux *p =

--- a/ext/XS-APItest/t/subsignature.t
+++ b/ext/XS-APItest/t/subsignature.t
@@ -16,6 +16,12 @@ eval q{
 	push @t, (subsignature @rest);
 	push @t, (subsignature %rest);
 	push @t, (subsignature $one = 1);
+
+	# these should all appear empty
+	push @t, (subsignature );
+	push @t, (subsignature);
+	push @t, (subsignature #empty
+		    );
 };
 is $@, "";
 is_deeply \@t, [
@@ -24,6 +30,10 @@ is_deeply \@t, [
 	['nextstate:6', 'multiparam:0..0:@:@rest=*'],
 	['nextstate:7', 'multiparam:0..0:%:%rest=*'],
 	['nextstate:8', 'multiparam:0..1:-:$one=0?'],
+
+	['nextstate:11', 'multiparam:0..0:-'],
+	['nextstate:12', 'multiparam:0..0:-'],
+	['nextstate:13', 'multiparam:0..0:-'],
 ];
 
 done_testing;

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -412,6 +412,16 @@ manager will later use a regex to expand these into links.
 
 XXX
 
+=item * C<parse_subsignature()> can now handle empty subroutine signatures
+
+Previously, calling the C<parse_subsignature()> API function with an empty
+signature would cause a "Syntax error" failure, requiring code which calls it
+to detect the special case and take appropriate steps.  This is now fixed,
+returning the same optree that the parser would yield for a regular empty
+signature during normal parse time.
+
+[GH#17689]
+
 =back
 
 =head1 Known Problems

--- a/toke.c
+++ b/toke.c
@@ -13922,6 +13922,18 @@ Perl_parse_subsignature(pTHX_ U32 flags)
 {
     if (flags)
         croak("Parsing code internal error (%s)", "parse_subsignature");
+    /* sub signatures might be empty, but perly.y can't cope with the
+     * ambiguity of an empty construction. We'll detect it manually and do
+     * something suitable in that case. */
+    lex_read_space(0);
+    if (lex_peek_unichar(0) == ')') {
+        /* pretend we saw an empty signature and do the same steps perly.y
+         * would have performed. */
+        subsignature_start();
+        OP *sigops = subsignature_finish();
+        CvSIGNATURE_on(PL_compcv);
+        return sigops;
+    }
     return parse_recdescent_for_op(GRAMSUBSIGNATURE, LEX_FAKEEOF_NONEXPR);
 }
 


### PR DESCRIPTION
(As per comment in code), perly.y can't cope with an empty subsignature when recursing directly into a grammar node, because the optionality was already handled in the regular grammar at a higher level than this. Instead, we must detect the empty signature by noticing an immediately-following close parenthesis, and side-step the grammar to perform the appropriate action steps manually.

Also tidies up some noisy warnings from XS-APItest at test time.