### PR TITLE
Fix two flaws in Configure

### DIFF
--- a/Configure
+++ b/Configure
@@ -4817,6 +4817,7 @@ else
 fi
 chmod 755 cppstdin
 wrapper=`pwd`/cppstdin
+cppstdin=$wrapper
 ok='false'
 cd UU
 
@@ -4826,7 +4827,7 @@ if $test "X$cppstdin" != "X" && \
 then
 	echo "You used to use $cppstdin $cppminus so we'll use that again."
 	case "$cpprun" in
-	'') echo "But let's see if we can live without a wrapper..." ;;
+	'') ok=true;;
 	*)
 		if $cpprun $cpplast <testcpp.c >testcpp.out 2>&1 && \
 			$contains 'abc.*xyz' testcpp.out >/dev/null 2>&1


### PR DESCRIPTION
Configure conflated the file 'cppstdin' and the variable $cppstdin, failing to initialize the latter.

It also overrode the hints file wrapper for feeding stdin to the C preprocessor.  It did this without asking, but ran a simple test, and if it passed, did the override.  This behavior dates to the mid 1990s.  The problem is that on z/OS the simple test passes, but not all inputs do.

Some system header files on z/OS have C trigraphs, which cause modern compilers to warn about them.  The hints file wrapper, which dates from the late 1990's, did an "fgrep -v" to get rid of them, but it doesn't end up getting used.  The simple test that Configure ends up of course would not think to try trigraphs.  (There may be other issues as well, but this one really pops out.)

This commit initializes $cppstdin, and doesn't try to override a furnished cppstdin from the hints.


* This set of changes does not require a perldelta entry.
