### PR TITLE
todo test for GH 20491 (defer inside do block is broken)

### DIFF
--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -352,6 +352,16 @@ TODO: {
 }
 
 TODO: {
+    local $::TODO = 'GH 20491';
+    use experimental 'defer';
+    my $deferred = 0;
+    do {
+        defer { $deferred = 1 };
+    };
+    is($deferred, 1, 'defer in single-expression do block runs when exiting block; GH 20491');
+}
+
+TODO: {
     todo_skip 1 if is_miniperl();
     local $::TODO = 'GH 22168';
     fresh_perl_is(


### PR DESCRIPTION
This PR adds a todo test for GH #20491. It tests that a defer block in a single-expression do block runs when exiting said do block, instead of the block holding the do block. This behavior still appears to be the same.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
