### PR TITLE
perlrebackslash: Fix false statements

### DIFF
--- a/pod/perlrebackslash.pod
+++ b/pod/perlrebackslash.pod
@@ -72,9 +72,10 @@ as C<Not in [].>
  \d                Match any digit character.
  \D                Match any character that isn't a digit.
  \e                Escape character.
- \E                Turn off \Q, \L and \U processing.  Not in [].
+ \E                Turn off \Q, \L and \U processing.  Not in [] unless
+                   is terminating one of those also in the [].
  \f                Form feed.
- \F                Foldcase till \E.  Not in [].
+ \F                Foldcase till \E.
  \g{}, \g1         Named, absolute or relative backreference.
                    Not in [].
  \G                Pos assertion.  Not in [].
@@ -82,8 +83,8 @@ as C<Not in [].>
  \H                Match any character that isn't horizontal whitespace.
  \k{}, \k<>, \k''  Named backreference.  Not in [].
  \K                Keep the stuff left of \K.  Not in [].
- \l                Lowercase next character.  Not in [].
- \L                Lowercase till \E.  Not in [].
+ \l                Lowercase next character.
+ \L                Lowercase till \E.
  \n                (Logical) newline character.
  \N                Match any character but newline.  Not in [].
  \N{}              Named or numbered (Unicode) character or sequence.
@@ -91,14 +92,15 @@ as C<Not in [].>
  \p{}, \pP         Match any character with the given Unicode property.
  \P{}, \PP         Match any character without the given property.
  \Q                Quote (disable) pattern metacharacters till \E.
-                   (Also called "escape".)  Not in [].
+                   (Also called "escape".)  Not in [] unless there's a
+                   terminating \E before the ']';
  \r                Return character.
  \R                Generic new line.  Not in [].
  \s                Match any whitespace character.
  \S                Match any character that isn't a whitespace.
  \t                Tab character.
- \u                Titlecase next character.  Not in [].
- \U                Uppercase till \E.  Not in [].
+ \u                Titlecase next character.
+ \U                Uppercase till \E.
  \v                Match any vertical whitespace character.
  \V                Match any character that isn't vertical whitespace
  \w                Match any word character.

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -2172,6 +2172,39 @@ ABCF|BCDE|C(G)	ABCDE	y	$&	BCDE	-	# GH 22892 - AHO-CORASICK bug
 ABCF|BCDE|C[Gg]	ABCDE	y	$&	BCDE	-	# GH 22892 - AHO-CORASICK bug
 ABCF|BCD[Ee]|C[Gg]	ABCDE	y	$&	BCDE	-	# GH 22892 - AHO-CORASICK bug
 
+# The next few tests are of constructs thought not to work in [].  But they
+# (perhaps accidentally) do, and were documented as such in GH 23688.  The ones
+# that failed regex_sets_compat.t were marked to skip there, without any
+# investigation.  Presumably its a result of limitations in the code that
+# translates these to set notation, and isn't worth fixing.
+/[\lAB]c/	ac	yS	$&	ac	-	\l works in []
+/[\lAB]c/	Bc	y	$&	Bc	-	\l works in []
+
+/[\uab]c/	Ac	yS	$&	Ac	-	\u works in []
+/[\uab]c/	bc	y	$&	bc	-	\u works in []
+
+/[\LA\EB]c/	ac	y	$&	ac	-	\L...\E works in []
+/[\LA\EB]c/	Bc	y	$&	Bc	-	\L...\E works in []
+
+/[\Ua\EB]c/	Ac	y	$&	Ac	-	\L...\E works in []
+/[\Ua\EB]c/	Bc	y	$&	Bc	-	\L...\E works in []
+
+/[\FA\EB]c/	ac	y	$&	ac	-	\L...\E works in []
+/[\FA\EB]c/	Bc	y	$&	Bc	-	\L...\E works in []
+
+/[a\Q]\E]c/	ac	yS	$&	ac	-	\Q...\E works in []
+/[a\Q]\E]c/	]c	yS	$&	]c	-	\Q...\E works in []
+
+/[a\Q]]\Ec/	]c	cS	-	Unmatched [	-	\Q...\E can't straddle []
+/[\LA]B\Ec/	abc	y	$&	abc	-	Straddling [ \L ] \E works
+/[\FA]B\Ec/	abc	y	$&	abc	-	Straddling [ \F ] \E works
+/[\Ua]B\Ec/	ABc	y	$&	ABc	-	Straddling [ \U ] \E works
+
+/[A\EB]c/	Bc	c	-	Useless use of \\E	-	\E in [] needs prior \[FLUQ]
+/\L[A]B\Ec/	abc	y	$&	abc	-	Straddling \L [ \E ] works
+/\F[A]B\Ec/	abc	y	$&	abc	-	Straddling \F [ \E ] works
+/\U[a]B\Ec/	ABc	y	$&	ABc	-	Straddling \U [ \E ] works
+
 # Keep these lines at the end of the file
 # pat	string	y/n/etc	expr	expected-expr	skip-reason	comment
 # vim: softtabstop=0 noexpandtab


### PR DESCRIPTION
Prior to this commit, it was claimed that certain sequences should not occur in regular expression pattern bracketed character classes.  I tried each one changed here, and they worked fine.

* This set of changes does not require a perldelta entry.
