### PR TITLE
pp_aasign: silence "var set but not used" warning

### DIFF
--- a/pp_hot.c
+++ b/pp_hot.c
@@ -3144,7 +3144,9 @@ PP(pp_aassign)
         case SVt_PVHV: {				/* normal hash */
 
             SV **svp;
+#ifndef PERL_RC_STACK
             SSize_t i;
+#endif
             SSize_t nelems = lastrelem - relem + 1;
             HV *hash = MUTABLE_HV(lsv);
 
@@ -3323,7 +3325,12 @@ PP(pp_aassign)
                 SV **svp;
                 SV **topelem = relem;
 
-                for (i = 0, svp = relem; svp <= lastrelem; i++, svp++) {
+#ifdef PERL_RC_STACK
+                for (svp = relem; svp <= lastrelem; svp++)
+#else
+                for (i = 0, svp = relem; svp <= lastrelem; i++, svp++)
+#endif
+                {
                     SV *key = *svp++;
                     SV *val = *svp;
                     /* remove duplicates from list we return */
@@ -3368,7 +3375,12 @@ PP(pp_aassign)
             }
             else {
                 SV **svp;
-                for (i = 0, svp = relem; svp <= lastrelem; i++, svp++) {
+#ifdef PERL_RC_STACK
+                for (svp = relem; svp <= lastrelem; svp++)
+#else
+                for (i = 0, svp = relem; svp <= lastrelem; i++, svp++)
+#endif
+                {
                     SV *key = *svp++;
                     SV *val = *svp;
 #ifdef PERL_RC_STACK


### PR DESCRIPTION
PERL_RC_STACK builds were giving this warning:

    pp_hot.c:3147:21: warning: variable 'i' set but not used
    [-Wunused-but-set-variable]

which was true: under that build, the i variable was being set but not used in a couple of places (it's value is only used on non-PERL_RC_STACK builds).

So avoid that var under PERL_RC_STACK builds.

* This set of changes does not require a perldelta entry.
