### PR TITLE
t/op/magic.t redirect stderr to /dev/null

### DIFF
--- a/t/op/magic.t
+++ b/t/op/magic.t
@@ -412,7 +412,8 @@ EOP
     # work (like if the system doesn't have a ps(1) for whatever
     # reason) just bail out gracefully.
     my $maybe_ps = sub {
-        my ($cmd) = @_;
+        my ($cmd) = @_ ;
+        $cmd .= " 2>$::devnull";
         local ($?, $!);
 
         no warnings;


### PR DESCRIPTION
This file calls ps(1), assuming that ps accepts the 'h' and 'hc' options.  This is non-portable.  The comments in the code indicate that these tests are optional; just skip them if the ps doesn't work.  The problem is that noise gets generated on such platforms.  Simply redirect stderr to /dev/null, suppressing any warnings.

* This set of changes does not require a perldelta entry.
