### PR TITLE
Add todo test for GH 21827 (localtime(HUGEVAL) reports wrong number)

### DIFF
--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -385,6 +385,16 @@ TODO: {
 }
 
 TODO: {
+    local $::TODO = 'GH 21827';
+    my $test = 18446744073709550592;
+    warnings_like(
+        sub { localtime $test },
+        [ (qr/localtime\($test\)/) x 2 ],
+        'localtime() warning reports correct value when given too large of a number; GH 21827'
+    );
+}
+
+TODO: {
     todo_skip 1 if is_miniperl();
     local $::TODO = 'GH 22168';
     fresh_perl_is(


### PR DESCRIPTION
This PR adds a todo test for #21827, which tests that localtime reports the correct value when given too large of a time as argument. This behavior still appears to be broken.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
