### PR TITLE
Revert "Explicitly reject length(NAME) with typemaps other than T_PV"

### DIFF
--- a/dist/ExtUtils-ParseXS/Changes
+++ b/dist/ExtUtils-ParseXS/Changes
@@ -1,5 +1,12 @@
 Revision history for Perl extension ExtUtils::ParseXS.
 
+3.60
+  - Fix INTERFACE for C23
+  - support perl package names in INTERFACE
+  - Cleanup typemap file-finding code and change priority
+  - Revert throwing an exception when combining the length operator
+    with a typemap other than T_PV
+
 3.59
   - Throw an exception when combining the length operator with a
     typemap other than T_PV

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
@@ -1412,9 +1412,7 @@ sub lookup_input_typemap {
         # as a pseudo-parameter, then override the normal typedef - which
         # would emit SvPV_nolen(...) - and instead, emit SvPV(...,
         # STRLEN_length_of_foo)
-        if ($self->{has_length}) {
-            die "length(NAME) not supported with typemaps other than T_PV"
-                if $xstype ne 'T_PV';
+        if ($xstype eq 'T_PV' and $self->{has_length}) {
             die "default value not supported with length(NAME) supplied"
                 if defined $default;
             return "($type)SvPV($arg, STRLEN_length_of_$var);",

--- a/dist/ExtUtils-ParseXS/t/001-basic.t
+++ b/dist/ExtUtils-ParseXS/t/001-basic.t
@@ -967,7 +967,7 @@ EOF
         |
         |int
         |foo(  a   ,  char   * b  , OUT  int  c  ,  OUTLIST int  d   ,    \
-        |      IN_OUT char * * e    =   1  + 2 ,   long length(b)   ,    \
+        |      IN_OUT char * * e    =   1  + 2 ,   long length(e)   ,    \
         |      char* f="abc"  ,     g  =   0  ,   ...     )
 EOF
 
@@ -1607,13 +1607,6 @@ EOF
             [ 1, 0, qr{\QError: length() on non-parameter 's'\E.*line 6},
                    "got expected error" ],
         ],
-
-		[
-			'length of int is invalid',
-			['int', 'foo(int a, size_t length(a))'],
-			[ 1, 0 , qr/length\(NAME\) not supported with typemaps other than T_PV/, 'Got expected error about length' ],
-		],
-
     );
 
     test_many($preamble, 'XS_Foo_', \@test_fns);


### PR DESCRIPTION
This reverts a129015cce91e645d1b392c5ea942014eb697cc1 because it broke [Harfbuz-Shaper](https://github.com/sciurius/perl-HarfBuzz-Shaper/issues/10) (and potentially other modules). We will have to come up with a [better solution](https://github.com/Perl/perl5/pull/23479#issuecomment-3284407033).

It also updates the Changes file which wasn't updated with the previous PRs on ParseXS.