### PR TITLE
Fix B::Concise BEGIN skip count

### DIFF
--- a/ext/B/B/Concise.pm
+++ b/ext/B/B/Concise.pm
@@ -10,11 +10,11 @@ package B::Concise;
 # -MO=Concise counts as use #1.
 
 use strict; # use #2
-use warnings; # uses #3 and #4, since warnings uses Carp
+use warnings; # use #3
 
-use Exporter 'import'; # use #5
+use Exporter 'import'; # uses #4-6, since Exporter does use strict, no strict
 
-our $VERSION   = "1.007";
+our $VERSION   = "1.008";
 our @EXPORT_OK = qw( set_style set_style_standard add_callback
 		     concise_subref concise_cv concise_main
 		     add_style walk_output compile reset_sequence );
@@ -24,7 +24,8 @@ our %EXPORT_TAGS =
       cb	=> [qw( add_callback )],
       mech	=> [qw( concise_subref concise_cv concise_main )],  );
 
-# use #6
+# uses #7-10, since B->import loads Exporter::Heavy which does use strict,
+# no strict, no warnings.
 use B qw(class ppname main_start main_root main_cv cstring svref_2object
 	 SVf_IOK SVf_NOK SVf_POK SVf_IVisUV SVf_FAKE OPf_KIDS OPf_SPECIAL
          OPf_STACKED
@@ -113,7 +114,7 @@ sub add_callback {
 
 # output handle, used with all Concise-output printing
 our $walkHandle;	# public for your convenience
-BEGIN { $walkHandle = \*STDOUT }
+BEGIN { $walkHandle = \*STDOUT } # use #11
 
 sub walk_output { # updates $walkHandle
     my $handle = shift;
@@ -179,7 +180,7 @@ sub concise_cv_obj {
 	return;
     }
     if (class($cv->START) eq "NULL") {
-	no strict 'refs';
+	no strict 'refs'; # use #12
 	if (ref $name eq 'CODE') {
 	    print $walkHandle "coderef $name has no START\n";
 	}
@@ -229,7 +230,7 @@ sub concise_specials {
     my($name, $order, @cv_s) = @_;
     my $i = 1;
     if ($name eq "BEGIN") {
-	splice(@cv_s, 0, 8); # skip 7 BEGIN blocks in this file. NOW 8 ??
+	splice(@cv_s, 0, 16); # skip 16 BEGIN blocks from this file
     } elsif ($name eq "CHECK") {
 	pop @cv_s; # skip the CHECK block that calls us
     }
@@ -301,7 +302,7 @@ sub compileOpts {
 	}
 	elsif ($o =~ /^-stash=(.*)/) {
 	    my $pkg = $1;
-	    no strict 'refs';
+	    no strict 'refs'; # use #13
 	    if (! %{$pkg.'::'}) {
 		eval "require $pkg";
 	    } else {
@@ -366,7 +367,7 @@ sub compile {
 		    next;
 		} else {
 		    $objname = "main::" . $objname unless $objname =~ /::/;
-		    no strict 'refs';
+		    no strict 'refs'; # use #14
 		    my $glob = \*$objname;
 		    unless (*$glob{CODE} || *$glob{FORMAT}) {
 			print $walkHandle "$objname:\n" if $banner;
@@ -386,7 +387,7 @@ sub compile {
 	    }
 	}
 	for my $pkg (@render_packs) {
-	    no strict 'refs';
+	    no strict 'refs'; # use #15
 	    concise_stashref($order, \%{$pkg.'::'});
 	}
 
@@ -406,7 +407,7 @@ my %opclass = ('OP' => "0", 'UNOP' => "1", 'BINOP' => "2", 'LOGOP' => "|",
 	       'PVOP' => '"', 'LOOP' => "{", 'COP' => ";", 'PADOP' => "#",
 	       'METHOP' => '.', UNOP_AUX => '+');
 
-no warnings 'qw'; # "Possible attempt to put comments..."; use #7
+no warnings 'qw'; # "Possible attempt to put comments..."; use #16
 my @linenoise =
   qw'#  () sc (  @? 1  $* gv *{ m$ m@ m% m? p/ *$ $  $# & a& pt \\ s\\ rf bl
      `  *? <> ?? ?/ r/ c/ // qr s/ /c y/ =  @= C  sC Cp sp df un BM po +1 +I

--- a/ext/B/t/optree_specials.t
+++ b/ext/B/t/optree_specials.t
@@ -25,19 +25,11 @@ BEGIN {
 # import checkOptree(), and %gOpts (containing test state)
 use OptreeCheck;	# ALSO DOES @ARGV HANDLING !!!!!!
 
-plan tests => 15;
+plan tests => 13;
 
 require_ok("B::Concise");
 
-my $out = runperl(
-    switches => ["-MO=Concise,BEGIN,CHECK,INIT,END,-exec"],
-    prog => q{$a=$b && print q/foo/},
-    stderr => 1 );
-
-#print "out:$out\n";
-
 my $src = q[our ($beg, $chk, $init, $end, $uc) = qq{'foo'}; BEGIN { $beg++ } CHECK { $chk++ } INIT { $init++ } END { $end++ } UNITCHECK {$uc++}];
-
 
 checkOptree ( name	=> 'BEGIN',
 	      bcopts	=> 'BEGIN',
@@ -45,238 +37,20 @@ checkOptree ( name	=> 'BEGIN',
 	      strip_open_hints => 1,
 	      expect	=> <<'EOT_EOT', expect_nt => <<'EONT_EONT');
 # BEGIN 1:
-# a  <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->a
-# 1        <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$ ->2
-# 3        <1> require sK/1 ->4
-# 2           <$> const[PV "strict.pm"] s/BARE ->3
-# -        <;> ex-nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$ ->4
-# -        <@> lineseq K ->-
-# 4           <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) :*,&,{,x*,x&,x$,$ ->5
-# 9           <1> entersub[t1] KRS/TARG,STRICT ->a
-# 5              <0> pushmark s ->6
-# 6              <$> const[PV "strict"] sM ->7
-# 7              <$> const[PV "refs"] sM ->8
-# 8              <.> method_named[PV "unimport"] ->9
-# BEGIN 2:
-# k  <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->k
-# b        <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$ ->c
-# d        <1> require sK/1 ->e
-# c           <$> const[PV "warnings.pm"] s/BARE ->d
-# -        <;> ex-nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$ ->e
-# -        <@> lineseq K ->-
-# e           <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) :*,&,{,x*,x&,x$ ->f
-# j           <1> entersub[t1] KRS/TARG ->k
-# f              <0> pushmark s ->g
-# g              <$> const[PV "warnings"] sM ->h
-# h              <$> const[PV "once"] sM ->i
-# i              <.> method_named[PV "unimport"] ->j
-# BEGIN 3:
-# r  <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->r
-# l        <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$ ->m
-# q        <2> sassign sKS/2 ->r
-# o           <1> srefgen sK/1 ->p
-# -              <1> ex-list lKRM ->o
-# n                 <1> rv2gv sKRM/STRICT,1 ->o
-# m                    <#> gv[*STDOUT] s ->n
-# -           <1> ex-rv2sv sKRM*/STRICT,1 ->q
-# p              <#> gvsv[*B::Concise::walkHandle] s ->q
-# BEGIN 4:
-# 11 <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq K ->11
-# s        <;> nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$ ->t
-# u        <1> require sK/1 ->v
-# t           <$> const[PV "strict.pm"] s/BARE ->u
-# -        <;> ex-nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$ ->v
-# -        <@> lineseq K ->-
-# v           <;> nextstate(B::Concise -1134 Concise.pm:183) :*,&,x*,x&,x$,$ ->w
-# 10          <1> entersub[t1] KRS/TARG,STRICT ->11
-# w              <0> pushmark s ->x
-# x              <$> const[PV "strict"] sM ->y
-# y              <$> const[PV "refs"] sM ->z
-# z              <.> method_named[PV "unimport"] ->10
-# BEGIN 5:
-# 1b <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq K ->1b
-# 12       <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$ ->13
-# 14       <1> require sK/1 ->15
-# 13          <$> const[PV "strict.pm"] s/BARE ->14
-# -        <;> ex-nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$ ->15
-# -        <@> lineseq K ->-
-# 15          <;> nextstate(B::Concise -1031 Concise.pm:305) :*,&,x*,x&,x$,$ ->16
-# 1a          <1> entersub[t1] KRS/TARG,STRICT ->1b
-# 16             <0> pushmark s ->17
-# 17             <$> const[PV "strict"] sM ->18
-# 18             <$> const[PV "refs"] sM ->19
-# 19             <.> method_named[PV "unimport"] ->1a
-# BEGIN 6:
-# 1l <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->1l
-# 1c       <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$ ->1d
-# 1e       <1> require sK/1 ->1f
-# 1d          <$> const[PV "strict.pm"] s/BARE ->1e
-# -        <;> ex-nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$ ->1f
-# -        <@> lineseq K ->-
-# 1f          <;> nextstate(B::Concise -984 Concise.pm:370) :*,&,{,x*,x&,x$,$ ->1g
-# 1k          <1> entersub[t1] KRS/TARG,STRICT ->1l
-# 1g             <0> pushmark s ->1h
-# 1h             <$> const[PV "strict"] sM ->1i
-# 1i             <$> const[PV "refs"] sM ->1j
-# 1j             <.> method_named[PV "unimport"] ->1k
-# BEGIN 7:
-# 1v <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq K ->1v
-# 1m       <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$ ->1n
-# 1o       <1> require sK/1 ->1p
-# 1n          <$> const[PV "strict.pm"] s/BARE ->1o
-# -        <;> ex-nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$ ->1p
-# -        <@> lineseq K ->-
-# 1p          <;> nextstate(B::Concise -959 Concise.pm:390) :*,&,x*,x&,x$,$ ->1q
-# 1u          <1> entersub[t1] KRS/TARG,STRICT ->1v
-# 1q             <0> pushmark s ->1r
-# 1r             <$> const[PV "strict"] sM ->1s
-# 1s             <$> const[PV "refs"] sM ->1t
-# 1t             <.> method_named[PV "unimport"] ->1u
-# BEGIN 8:
-# 25 <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->25
-# 1w       <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$ ->1x
-# 1y       <1> require sK/1 ->1z
-# 1x          <$> const[PV "warnings.pm"] s/BARE ->1y
-# -        <;> ex-nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$ ->1z
-# -        <@> lineseq K ->-
-# 1z          <;> nextstate(B::Concise -945 Concise.pm:410) :*,&,{,x*,x&,x$,$ ->20
-# 24          <1> entersub[t1] KRS/TARG,STRICT ->25
-# 20             <0> pushmark s ->21
-# 21             <$> const[PV "warnings"] sM ->22
-# 22             <$> const[PV "qw"] sM ->23
-# 23             <.> method_named[PV "unimport"] ->24
-# BEGIN 9:
-# 29 <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->29
-# 26       <;> nextstate(main 3 -e:1) v:{ ->27
-# 28       <1> postinc[t3] sK/1 ->29
-# -           <1> ex-rv2sv sKRM/1 ->28
-# 27             <#> gvsv[*beg] s ->28
+# 4  <1> leavesub[1 ref] K/REFC,1 ->(end)
+# -     <@> lineseq KP ->4
+# 1        <;> nextstate(main 3 -e:1) v:{ ->2
+# 3        <1> postinc[t3] sK/1 ->4
+# -           <1> ex-rv2sv sKRM/1 ->3
+# 2              <#> gvsv[*beg] s ->3
 EOT_EOT
 # BEGIN 1:
-# a  <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->a
-# 1        <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$ ->2
-# 3        <1> require sK/1 ->4
-# 2           <$> const(PV "strict.pm") s/BARE ->3
-# -        <;> ex-nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$ ->4
-# -        <@> lineseq K ->-
-# 4           <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) :*,&,{,x*,x&,x$,$ ->5
-# 9           <1> entersub[t1] KRS/TARG,STRICT ->a
-# 5              <0> pushmark s ->6
-# 6              <$> const(PV "strict") sM ->7
-# 7              <$> const(PV "refs") sM ->8
-# 8              <.> method_named(PV "unimport") ->9
-# BEGIN 2:
-# k  <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->k
-# b        <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$ ->c
-# d        <1> require sK/1 ->e
-# c           <$> const(PV "warnings.pm") s/BARE ->d
-# -        <;> ex-nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$ ->e
-# -        <@> lineseq K ->-
-# e           <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) :*,&,{,x*,x&,x$ ->f
-# j           <1> entersub[t1] KRS/TARG ->k
-# f              <0> pushmark s ->g
-# g              <$> const(PV "warnings") sM ->h
-# h              <$> const(PV "once") sM ->i
-# i              <.> method_named(PV "unimport") ->j
-# BEGIN 3:
-# r  <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->r
-# l        <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$ ->m
-# q        <2> sassign sKS/2 ->r
-# o           <1> srefgen sK/1 ->p
-# -              <1> ex-list lKRM ->o
-# n                 <1> rv2gv sKRM/STRICT,1 ->o
-# m                    <$> gv(*STDOUT) s ->n
-# -           <1> ex-rv2sv sKRM*/STRICT,1 ->q
-# p              <$> gvsv(*B::Concise::walkHandle) s ->q
-# BEGIN 4:
-# 11 <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq K ->11
-# s        <;> nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$ ->t
-# u        <1> require sK/1 ->v
-# t           <$> const(PV "strict.pm") s/BARE ->u
-# -        <;> ex-nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$ ->v
-# -        <@> lineseq K ->-
-# v           <;> nextstate(B::Concise -1134 Concise.pm:183) :*,&,x*,x&,x$,$ ->w
-# 10          <1> entersub[t1] KRS/TARG,STRICT ->11
-# w              <0> pushmark s ->x
-# x              <$> const(PV "strict") sM ->y
-# y              <$> const(PV "refs") sM ->z
-# z              <.> method_named(PV "unimport") ->10
-# BEGIN 5:
-# 1b <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq K ->1b
-# 12       <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$ ->13
-# 14       <1> require sK/1 ->15
-# 13          <$> const(PV "strict.pm") s/BARE ->14
-# -        <;> ex-nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$ ->15
-# -        <@> lineseq K ->-
-# 15          <;> nextstate(B::Concise -1031 Concise.pm:305) :*,&,x*,x&,x$,$ ->16
-# 1a          <1> entersub[t1] KRS/TARG,STRICT ->1b
-# 16             <0> pushmark s ->17
-# 17             <$> const(PV "strict") sM ->18
-# 18             <$> const(PV "refs") sM ->19
-# 19             <.> method_named(PV "unimport") ->1a
-# BEGIN 6:
-# 1l <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->1l
-# 1c       <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$ ->1d
-# 1e       <1> require sK/1 ->1f
-# 1d          <$> const(PV "strict.pm") s/BARE ->1e
-# -        <;> ex-nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$ ->1f
-# -        <@> lineseq K ->-
-# 1f          <;> nextstate(B::Concise -984 Concise.pm:370) :*,&,{,x*,x&,x$,$ ->1g
-# 1k          <1> entersub[t1] KRS/TARG,STRICT ->1l
-# 1g             <0> pushmark s ->1h
-# 1h             <$> const(PV "strict") sM ->1i
-# 1i             <$> const(PV "refs") sM ->1j
-# 1j             <.> method_named(PV "unimport") ->1k
-# BEGIN 7:
-# 1v <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq K ->1v
-# 1m       <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$ ->1n
-# 1o       <1> require sK/1 ->1p
-# 1n          <$> const(PV "strict.pm") s/BARE ->1o
-# -        <;> ex-nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$ ->1p
-# -        <@> lineseq K ->-
-# 1p          <;> nextstate(B::Concise -959 Concise.pm:390) :*,&,x*,x&,x$,$ ->1q
-# 1u          <1> entersub[t1] KRS/TARG,STRICT ->1v
-# 1q             <0> pushmark s ->1r
-# 1r             <$> const(PV "strict") sM ->1s
-# 1s             <$> const(PV "refs") sM ->1t
-# 1t             <.> method_named(PV "unimport") ->1u
-# BEGIN 8:
-# 25 <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->25
-# 1w       <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$ ->1x
-# 1y       <1> require sK/1 ->1z
-# 1x          <$> const(PV "warnings.pm") s/BARE ->1y
-# -        <;> ex-nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$ ->1z
-# -        <@> lineseq K ->-
-# 1z          <;> nextstate(B::Concise -945 Concise.pm:410) :*,&,{,x*,x&,x$,$ ->20
-# 24          <1> entersub[t1] KRS/TARG,STRICT ->25
-# 20             <0> pushmark s ->21
-# 21             <$> const(PV "warnings") sM ->22
-# 22             <$> const(PV "qw") sM ->23
-# 23             <.> method_named(PV "unimport") ->24
-# BEGIN 9:
-# 29 <1> leavesub[1 ref] K/REFC,1 ->(end)
-# -     <@> lineseq KP ->29
-# 26       <;> nextstate(main 3 -e:1) v:{ ->27
-# 28       <1> postinc[t2] sK/1 ->29
-# -           <1> ex-rv2sv sKRM/1 ->28
-# 27             <$> gvsv(*beg) s ->28
+# 4  <1> leavesub[1 ref] K/REFC,1 ->(end)
+# -     <@> lineseq KP ->4
+# 1        <;> nextstate(main 3 -e:1) v:{ ->2
+# 3        <1> postinc[t2] sK/1 ->4
+# -           <1> ex-rv2sv sKRM/1 ->3
+# 2              <$> gvsv(*beg) s ->3
 EONT_EONT
 
 checkOptree ( name	=> 'END',
@@ -347,7 +121,6 @@ EONT_EONT
 
 checkOptree ( name	=> 'INIT',
 	      bcopts	=> 'INIT',
-	      #todo	=> 'get working',
 	      prog	=> $src,
 	      strip_open_hints => 1,
 	      expect	=> <<'EOT_EOT', expect_nt => <<'EONT_EONT');
@@ -374,403 +147,54 @@ checkOptree ( name	=> 'all of BEGIN END INIT CHECK UNITCHECK -exec',
 	      strip_open_hints => 1,
 	      expect	=> <<'EOT_EOT', expect_nt => <<'EONT_EONT');
 # BEGIN 1:
-# 1  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$
-# 2  <$> const[PV "strict.pm"] s/BARE
-# 3  <1> require sK/1
-# 4  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) :*,&,{,x*,x&,x$,$
-# 5  <0> pushmark s
-# 6  <$> const[PV "strict"] sM
-# 7  <$> const[PV "refs"] sM
-# 8  <.> method_named[PV "unimport"] 
-# 9  <1> entersub[t1] KRS/TARG,STRICT
-# a  <1> leavesub[1 ref] K/REFC,1
-# BEGIN 2:
-# b  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$
-# c  <$> const[PV "warnings.pm"] s/BARE
-# d  <1> require sK/1
-# e  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) :*,&,{,x*,x&,x$
-# f  <0> pushmark s
-# g  <$> const[PV "warnings"] sM
-# h  <$> const[PV "once"] sM
-# i  <.> method_named[PV "unimport"] 
-# j  <1> entersub[t1] KRS/TARG
-# k  <1> leavesub[1 ref] K/REFC,1
-# BEGIN 3:
-# l  <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$
-# m  <#> gv[*STDOUT] s
-# n  <1> rv2gv sKRM/STRICT,1
-# o  <1> srefgen sK/1
-# p  <#> gvsv[*B::Concise::walkHandle] s
-# q  <2> sassign sKS/2
-# r  <1> leavesub[1 ref] K/REFC,1
-# BEGIN 4:
-# s  <;> nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$
-# t  <$> const[PV "strict.pm"] s/BARE
-# u  <1> require sK/1
-# v  <;> nextstate(B::Concise -1134 Concise.pm:183) :*,&,x*,x&,x$,$
-# w  <0> pushmark s
-# x  <$> const[PV "strict"] sM
-# y  <$> const[PV "refs"] sM
-# z  <.> method_named[PV "unimport"] 
-# 10 <1> entersub[t1] KRS/TARG,STRICT
-# 11 <1> leavesub[1 ref] K/REFC,1
-# BEGIN 5:
-# 12 <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$
-# 13 <$> const[PV "strict.pm"] s/BARE
-# 14 <1> require sK/1
-# 15 <;> nextstate(B::Concise -1031 Concise.pm:305) :*,&,x*,x&,x$,$
-# 16 <0> pushmark s
-# 17 <$> const[PV "strict"] sM
-# 18 <$> const[PV "refs"] sM
-# 19 <.> method_named[PV "unimport"] 
-# 1a <1> entersub[t1] KRS/TARG,STRICT
-# 1b <1> leavesub[1 ref] K/REFC,1
-# BEGIN 6:
-# 1c <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$
-# 1d <$> const[PV "strict.pm"] s/BARE
-# 1e <1> require sK/1
-# 1f <;> nextstate(B::Concise -984 Concise.pm:370) :*,&,{,x*,x&,x$,$
-# 1g <0> pushmark s
-# 1h <$> const[PV "strict"] sM
-# 1i <$> const[PV "refs"] sM
-# 1j <.> method_named[PV "unimport"] 
-# 1k <1> entersub[t1] KRS/TARG,STRICT
-# 1l <1> leavesub[1 ref] K/REFC,1
-# BEGIN 7:
-# 1m <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$
-# 1n <$> const[PV "strict.pm"] s/BARE
-# 1o <1> require sK/1
-# 1p <;> nextstate(B::Concise -959 Concise.pm:390) :*,&,x*,x&,x$,$
-# 1q <0> pushmark s
-# 1r <$> const[PV "strict"] sM
-# 1s <$> const[PV "refs"] sM
-# 1t <.> method_named[PV "unimport"] 
-# 1u <1> entersub[t1] KRS/TARG,STRICT
-# 1v <1> leavesub[1 ref] K/REFC,1
-# BEGIN 8:
-# 1w <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$
-# 1x <$> const[PV "warnings.pm"] s/BARE
-# 1y <1> require sK/1
-# 1z <;> nextstate(B::Concise -945 Concise.pm:410) :*,&,{,x*,x&,x$,$
-# 20 <0> pushmark s
-# 21 <$> const[PV "warnings"] sM
-# 22 <$> const[PV "qw"] sM
-# 23 <.> method_named[PV "unimport"] 
-# 24 <1> entersub[t1] KRS/TARG,STRICT
-# 25 <1> leavesub[1 ref] K/REFC,1
-# BEGIN 9:
-# 26 <;> nextstate(main 3 -e:1) v:{
-# 27 <#> gvsv[*beg] s
-# 28 <1> postinc[t3] sK/1
-# 29 <1> leavesub[1 ref] K/REFC,1
+# 1  <;> nextstate(main 3 -e:1) v:{
+# 2  <#> gvsv[*beg] s
+# 3  <1> postinc[t3] sK/1
+# 4  <1> leavesub[1 ref] K/REFC,1
 # END 1:
-# 2a <;> nextstate(main 9 -e:1) v:{
-# 2b <#> gvsv[*end] s
-# 2c <1> postinc[t3] sK/1
-# 2d <1> leavesub[1 ref] K/REFC,1
+# 5  <;> nextstate(main 9 -e:1) v:{
+# 6  <#> gvsv[*end] s
+# 7  <1> postinc[t3] sK/1
+# 8  <1> leavesub[1 ref] K/REFC,1
 # INIT 1:
-# 2e <;> nextstate(main 7 -e:1) v:{
-# 2f <#> gvsv[*init] s
-# 2g <1> postinc[t3] sK/1
-# 2h <1> leavesub[1 ref] K/REFC,1
+# 9  <;> nextstate(main 7 -e:1) v:{
+# a  <#> gvsv[*init] s
+# b  <1> postinc[t3] sK/1
+# c  <1> leavesub[1 ref] K/REFC,1
 # CHECK 1:
-# 2i <;> nextstate(main 5 -e:1) v:{
-# 2j <#> gvsv[*chk] s
-# 2k <1> postinc[t3] sK/1
-# 2l <1> leavesub[1 ref] K/REFC,1
+# d  <;> nextstate(main 5 -e:1) v:{
+# e  <#> gvsv[*chk] s
+# f  <1> postinc[t3] sK/1
+# g  <1> leavesub[1 ref] K/REFC,1
 # UNITCHECK 1:
-# 2m <;> nextstate(main 11 -e:1) v:{
-# 2n <#> gvsv[*uc] s
-# 2o <1> postinc[t3] sK/1
-# 2p <1> leavesub[1 ref] K/REFC,1
-EOT_EOT
-# BEGIN 1:
-# 1  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$
-# 2  <$> const(PV "strict.pm") s/BARE
-# 3  <1> require sK/1
-# 4  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) :*,&,{,x*,x&,x$,$
-# 5  <0> pushmark s
-# 6  <$> const(PV "strict") sM
-# 7  <$> const(PV "refs") sM
-# 8  <.> method_named(PV "unimport") 
-# 9  <1> entersub[t1] KRS/TARG,STRICT
-# a  <1> leavesub[1 ref] K/REFC,1
-# BEGIN 2:
-# b  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$
-# c  <$> const(PV "warnings.pm") s/BARE
-# d  <1> require sK/1
-# e  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) :*,&,{,x*,x&,x$
-# f  <0> pushmark s
-# g  <$> const(PV "warnings") sM
-# h  <$> const(PV "once") sM
-# i  <.> method_named(PV "unimport") 
-# j  <1> entersub[t1] KRS/TARG
+# h  <;> nextstate(main 11 -e:1) v:{
+# i  <#> gvsv[*uc] s
+# j  <1> postinc[t3] sK/1
 # k  <1> leavesub[1 ref] K/REFC,1
-# BEGIN 3:
-# l  <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$
-# m  <$> gv(*STDOUT) s
-# n  <1> rv2gv sKRM/STRICT,1
-# o  <1> srefgen sK/1
-# p  <$> gvsv(*B::Concise::walkHandle) s
-# q  <2> sassign sKS/2
-# r  <1> leavesub[1 ref] K/REFC,1
-# BEGIN 4:
-# s  <;> nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$
-# t  <$> const(PV "strict.pm") s/BARE
-# u  <1> require sK/1
-# v  <;> nextstate(B::Concise -1134 Concise.pm:183) :*,&,x*,x&,x$,$
-# w  <0> pushmark s
-# x  <$> const(PV "strict") sM
-# y  <$> const(PV "refs") sM
-# z  <.> method_named(PV "unimport") 
-# 10 <1> entersub[t1] KRS/TARG,STRICT
-# 11 <1> leavesub[1 ref] K/REFC,1
-# BEGIN 5:
-# 12 <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$
-# 13 <$> const(PV "strict.pm") s/BARE
-# 14 <1> require sK/1
-# 15 <;> nextstate(B::Concise -1031 Concise.pm:305) :*,&,x*,x&,x$,$
-# 16 <0> pushmark s
-# 17 <$> const(PV "strict") sM
-# 18 <$> const(PV "refs") sM
-# 19 <.> method_named(PV "unimport") 
-# 1a <1> entersub[t1] KRS/TARG,STRICT
-# 1b <1> leavesub[1 ref] K/REFC,1
-# BEGIN 6:
-# 1c <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$
-# 1d <$> const(PV "strict.pm") s/BARE
-# 1e <1> require sK/1
-# 1f <;> nextstate(B::Concise -984 Concise.pm:370) :*,&,{,x*,x&,x$,$
-# 1g <0> pushmark s
-# 1h <$> const(PV "strict") sM
-# 1i <$> const(PV "refs") sM
-# 1j <.> method_named(PV "unimport") 
-# 1k <1> entersub[t1] KRS/TARG,STRICT
-# 1l <1> leavesub[1 ref] K/REFC,1
-# BEGIN 7:
-# 1m <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$
-# 1n <$> const(PV "strict.pm") s/BARE
-# 1o <1> require sK/1
-# 1p <;> nextstate(B::Concise -959 Concise.pm:390) :*,&,x*,x&,x$,$
-# 1q <0> pushmark s
-# 1r <$> const(PV "strict") sM
-# 1s <$> const(PV "refs") sM
-# 1t <.> method_named(PV "unimport") 
-# 1u <1> entersub[t1] KRS/TARG,STRICT
-# 1v <1> leavesub[1 ref] K/REFC,1
-# BEGIN 8:
-# 1w <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$
-# 1x <$> const(PV "warnings.pm") s/BARE
-# 1y <1> require sK/1
-# 1z <;> nextstate(B::Concise -945 Concise.pm:410) :*,&,{,x*,x&,x$,$
-# 20 <0> pushmark s
-# 21 <$> const(PV "warnings") sM
-# 22 <$> const(PV "qw") sM
-# 23 <.> method_named(PV "unimport") 
-# 24 <1> entersub[t1] KRS/TARG,STRICT
-# 25 <1> leavesub[1 ref] K/REFC,1
-# BEGIN 9:
-# 26 <;> nextstate(main 3 -e:1) v:{
-# 27 <$> gvsv(*beg) s
-# 28 <1> postinc[t2] sK/1
-# 29 <1> leavesub[1 ref] K/REFC,1
+EOT_EOT
+BEGIN 1:
+# 1  <;> nextstate(main 3 -e:1) v:{
+# 2  <$> gvsv(*beg) s
+# 3  <1> postinc[t2] sK/1
+# 4  <1> leavesub[1 ref] K/REFC,1
 # END 1:
-# 2a <;> nextstate(main 9 -e:1) v:{
-# 2b <$> gvsv(*end) s
-# 2c <1> postinc[t2] sK/1
-# 2d <1> leavesub[1 ref] K/REFC,1
+# 5  <;> nextstate(main 9 -e:1) v:{
+# 6  <$> gvsv(*end) s
+# 7  <1> postinc[t2] sK/1
+# 8  <1> leavesub[1 ref] K/REFC,1
 # INIT 1:
-# 2e <;> nextstate(main 7 -e:1) v:{
-# 2f <$> gvsv(*init) s
-# 2g <1> postinc[t2] sK/1
-# 2h <1> leavesub[1 ref] K/REFC,1
+# 9  <;> nextstate(main 7 -e:1) v:{
+# a  <$> gvsv(*init) s
+# b  <1> postinc[t2] sK/1
+# c  <1> leavesub[1 ref] K/REFC,1
 # CHECK 1:
-# 2i <;> nextstate(main 5 -e:1) v:{
-# 2j <$> gvsv(*chk) s
-# 2k <1> postinc[t2] sK/1
-# 2l <1> leavesub[1 ref] K/REFC,1
+# d  <;> nextstate(main 5 -e:1) v:{
+# e  <$> gvsv(*chk) s
+# f  <1> postinc[t2] sK/1
+# g  <1> leavesub[1 ref] K/REFC,1
 # UNITCHECK 1:
-# 2m <;> nextstate(main 11 -e:1) v:{
-# 2n <$> gvsv(*uc) s
-# 2o <1> postinc[t2] sK/1
-# 2p <1> leavesub[1 ref] K/REFC,1
-EONT_EONT
-
-# perl "-I../lib" -MO=Concise,BEGIN,CHECK,INIT,END,-exec -e '$a=$b && print q/foo/'
-
-checkOptree ( name	=> 'regression test for patch 25352',
-	      bcopts	=> [qw/ BEGIN END INIT CHECK -exec /],
-	      prog	=> 'print q/foo/',
-	      expect	=> <<'EOT_EOT', expect_nt => <<'EONT_EONT');
-# BEGIN 1:
-# 1  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$
-# 2  <$> const[PV "strict.pm"] s/BARE
-# 3  <1> require sK/1
-# 4  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) :*,&,{,x*,x&,x$,$
-# 5  <0> pushmark s
-# 6  <$> const[PV "strict"] sM
-# 7  <$> const[PV "refs"] sM
-# 8  <.> method_named[PV "unimport"] 
-# 9  <1> entersub[t1] KRS/TARG,STRICT
-# a  <1> leavesub[1 ref] K/REFC,1
-# BEGIN 2:
-# b  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$
-# c  <$> const[PV "warnings.pm"] s/BARE
-# d  <1> require sK/1
-# e  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) :*,&,{,x*,x&,x$
-# f  <0> pushmark s
-# g  <$> const[PV "warnings"] sM
-# h  <$> const[PV "once"] sM
-# i  <.> method_named[PV "unimport"] 
-# j  <1> entersub[t1] KRS/TARG
+# h  <;> nextstate(main 11 -e:1) v:{
+# i  <$> gvsv(*uc) s
+# j  <1> postinc[t2] sK/1
 # k  <1> leavesub[1 ref] K/REFC,1
-# BEGIN 3:
-# l  <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$
-# m  <#> gv[*STDOUT] s
-# n  <1> rv2gv sKRM/STRICT,1
-# o  <1> srefgen sK/1
-# p  <#> gvsv[*B::Concise::walkHandle] s
-# q  <2> sassign sKS/2
-# r  <1> leavesub[1 ref] K/REFC,1
-# BEGIN 4:
-# s  <;> nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$
-# t  <$> const[PV "strict.pm"] s/BARE
-# u  <1> require sK/1
-# v  <;> nextstate(B::Concise -1134 Concise.pm:183) :*,&,x*,x&,x$,$
-# w  <0> pushmark s
-# x  <$> const[PV "strict"] sM
-# y  <$> const[PV "refs"] sM
-# z  <.> method_named[PV "unimport"] 
-# 10 <1> entersub[t1] KRS/TARG,STRICT
-# 11 <1> leavesub[1 ref] K/REFC,1
-# BEGIN 5:
-# 12 <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$
-# 13 <$> const[PV "strict.pm"] s/BARE
-# 14 <1> require sK/1
-# 15 <;> nextstate(B::Concise -1031 Concise.pm:305) :*,&,x*,x&,x$,$
-# 16 <0> pushmark s
-# 17 <$> const[PV "strict"] sM
-# 18 <$> const[PV "refs"] sM
-# 19 <.> method_named[PV "unimport"] 
-# 1a <1> entersub[t1] KRS/TARG,STRICT
-# 1b <1> leavesub[1 ref] K/REFC,1
-# BEGIN 6:
-# 1c <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$
-# 1d <$> const[PV "strict.pm"] s/BARE
-# 1e <1> require sK/1
-# 1f <;> nextstate(B::Concise -984 Concise.pm:370) :*,&,{,x*,x&,x$,$
-# 1g <0> pushmark s
-# 1h <$> const[PV "strict"] sM
-# 1i <$> const[PV "refs"] sM
-# 1j <.> method_named[PV "unimport"] 
-# 1k <1> entersub[t1] KRS/TARG,STRICT
-# 1l <1> leavesub[1 ref] K/REFC,1
-# BEGIN 7:
-# 1m <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$
-# 1n <$> const[PV "strict.pm"] s/BARE
-# 1o <1> require sK/1
-# 1p <;> nextstate(B::Concise -959 Concise.pm:390) :*,&,x*,x&,x$,$
-# 1q <0> pushmark s
-# 1r <$> const[PV "strict"] sM
-# 1s <$> const[PV "refs"] sM
-# 1t <.> method_named[PV "unimport"] 
-# 1u <1> entersub[t1] KRS/TARG,STRICT
-# 1v <1> leavesub[1 ref] K/REFC,1
-# BEGIN 8:
-# 1w <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$
-# 1x <$> const[PV "warnings.pm"] s/BARE
-# 1y <1> require sK/1
-# 1z <;> nextstate(B::Concise -945 Concise.pm:410) :*,&,{,x*,x&,x$,$
-# 20 <0> pushmark s
-# 21 <$> const[PV "warnings"] sM
-# 22 <$> const[PV "qw"] sM
-# 23 <.> method_named[PV "unimport"] 
-# 24 <1> entersub[t1] KRS/TARG,STRICT
-# 25 <1> leavesub[1 ref] K/REFC,1
-EOT_EOT
-# BEGIN 1:
-# 1  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) v:*,&,{,x*,x&,x$,$
-# 2  <$> const(PV "strict.pm") s/BARE
-# 3  <1> require sK/1
-# 4  <;> nextstate(Exporter::Heavy -1410 Heavy.pm:4) :*,&,{,x*,x&,x$,$
-# 5  <0> pushmark s
-# 6  <$> const(PV "strict") sM
-# 7  <$> const(PV "refs") sM
-# 8  <.> method_named(PV "unimport") 
-# 9  <1> entersub[t1] KRS/TARG,STRICT
-# a  <1> leavesub[1 ref] K/REFC,1
-# BEGIN 2:
-# b  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) v:*,&,{,x*,x&,x$
-# c  <$> const(PV "warnings.pm") s/BARE
-# d  <1> require sK/1
-# e  <;> nextstate(Exporter::Heavy -1251 Heavy.pm:202) :*,&,{,x*,x&,x$
-# f  <0> pushmark s
-# g  <$> const(PV "warnings") sM
-# h  <$> const(PV "once") sM
-# i  <.> method_named(PV "unimport") 
-# j  <1> entersub[t1] KRS/TARG
-# k  <1> leavesub[1 ref] K/REFC,1
-# BEGIN 3:
-# l  <;> nextstate(B::Concise -1175 Concise.pm:117) v:*,&,{,x*,x&,x$,$
-# m  <$> gv(*STDOUT) s
-# n  <1> rv2gv sKRM/STRICT,1
-# o  <1> srefgen sK/1
-# p  <$> gvsv(*B::Concise::walkHandle) s
-# q  <2> sassign sKS/2
-# r  <1> leavesub[1 ref] K/REFC,1
-# BEGIN 4:
-# s  <;> nextstate(B::Concise -1134 Concise.pm:183) v:*,&,x*,x&,x$,$
-# t  <$> const(PV "strict.pm") s/BARE
-# u  <1> require sK/1
-# v  <;> nextstate(B::Concise -1134 Concise.pm:183) :*,&,x*,x&,x$,$
-# w  <0> pushmark s
-# x  <$> const(PV "strict") sM
-# y  <$> const(PV "refs") sM
-# z  <.> method_named(PV "unimport") 
-# 10 <1> entersub[t1] KRS/TARG,STRICT
-# 11 <1> leavesub[1 ref] K/REFC,1
-# BEGIN 5:
-# 12 <;> nextstate(B::Concise -1031 Concise.pm:305) v:*,&,x*,x&,x$,$
-# 13 <$> const(PV "strict.pm") s/BARE
-# 14 <1> require sK/1
-# 15 <;> nextstate(B::Concise -1031 Concise.pm:305) :*,&,x*,x&,x$,$
-# 16 <0> pushmark s
-# 17 <$> const(PV "strict") sM
-# 18 <$> const(PV "refs") sM
-# 19 <.> method_named(PV "unimport") 
-# 1a <1> entersub[t1] KRS/TARG,STRICT
-# 1b <1> leavesub[1 ref] K/REFC,1
-# BEGIN 6:
-# 1c <;> nextstate(B::Concise -984 Concise.pm:370) v:*,&,{,x*,x&,x$,$
-# 1d <$> const(PV "strict.pm") s/BARE
-# 1e <1> require sK/1
-# 1f <;> nextstate(B::Concise -984 Concise.pm:370) :*,&,{,x*,x&,x$,$
-# 1g <0> pushmark s
-# 1h <$> const(PV "strict") sM
-# 1i <$> const(PV "refs") sM
-# 1j <.> method_named(PV "unimport") 
-# 1k <1> entersub[t1] KRS/TARG,STRICT
-# 1l <1> leavesub[1 ref] K/REFC,1
-# BEGIN 7:
-# 1m <;> nextstate(B::Concise -959 Concise.pm:390) v:*,&,x*,x&,x$,$
-# 1n <$> const(PV "strict.pm") s/BARE
-# 1o <1> require sK/1
-# 1p <;> nextstate(B::Concise -959 Concise.pm:390) :*,&,x*,x&,x$,$
-# 1q <0> pushmark s
-# 1r <$> const(PV "strict") sM
-# 1s <$> const(PV "refs") sM
-# 1t <.> method_named(PV "unimport") 
-# 1u <1> entersub[t1] KRS/TARG,STRICT
-# 1v <1> leavesub[1 ref] K/REFC,1
-# BEGIN 8:
-# 1w <;> nextstate(B::Concise -945 Concise.pm:410) v:*,&,{,x*,x&,x$,$
-# 1x <$> const(PV "warnings.pm") s/BARE
-# 1y <1> require sK/1
-# 1z <;> nextstate(B::Concise -945 Concise.pm:410) :*,&,{,x*,x&,x$,$
-# 20 <0> pushmark s
-# 21 <$> const(PV "warnings") sM
-# 22 <$> const(PV "qw") sM
-# 23 <.> method_named(PV "unimport") 
-# 24 <1> entersub[t1] KRS/TARG,STRICT
-# 25 <1> leavesub[1 ref] K/REFC,1
 EONT_EONT

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -149,6 +149,12 @@ been specified via C<xsubpp -typemap> arguments so that (as was the case
 prior to Perl 5.10.0) these files are applied last rather than first, and
 thus take priority over any system typemap files.
 
+=item *
+
+L<B::Concise> has been upgraded from version 1.007 to 1.008. It now correctly
+omits all its internal BEGIN blocks when asked to report BEGIN blocks in a
+caller's code. Previously it only omitted some of them.
+
 =back
 
 =head2 Removed Modules and Pragmata


### PR DESCRIPTION
B::Concise tries hard to hide its own BEGIN blocks when asked to report BEGIN blocks in end-user's code. It does this by maintaining a count of each BEGIN/use/no (and those of the dependencies) and then splicing these BEGIN blocks off before printing. However this count has drifted over time, which this commit fixes.

Before:
```
$ perl -MO=Concise,BEGIN,-exec -e 'BEGIN {1} BEGIN {2}'
... BEGIN 1-8 ...
BEGIN 9:
26 <;> nextstate(main 2 -e:1) v
27 <$> const[IV 1] s
28 <1> leavesub[1 ref] K/REFC,1
BEGIN 10:
29 <;> nextstate(main 4 -e:1) v
2a <$> const[IV 2] s
2b <1> leavesub[1 ref] K/REFC,1
-e syntax OK
```
After:
```
$ perl -MO=Concise,BEGIN,-exec -e 'BEGIN {1} BEGIN {2}'
BEGIN 1:
1  <;> nextstate(main 2 -e:1) v
2  <$> const[IV 1] s
3  <1> leavesub[1 ref] K/REFC,1
BEGIN 2:
4  <;> nextstate(main 4 -e:1) v
5  <$> const[IV 2] s
6  <1> leavesub[1 ref] K/REFC,1
-e syntax OK
```
The tests in ext/B/t/optree_specials.t now correctly only show the things being tested, but that also meant removing the bogus final test, as with this fix the code under test outputs nothing as it has no phase blocks in it.

 * This set of changes requires a perldelta entry, and it is included.