### PR TITLE
Make savesharedpvn arg Non-Null

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3014,7 +3014,7 @@ Cdp	|void	|save_set_svflags					\
 Aadp	|char * |savesharedpv	|NULLOK const char *pv
 
 : NULLOK only to suppress a compiler warning
-Aadp	|char * |savesharedpvn	|NULLOK const char * const pv		\
+Aadp	|char * |savesharedpvn	|NN const char * const pv		\
 				|const STRLEN len
 Cdp	|void	|save_shared_pvref					\
 				|NN char **str

--- a/proto.h
+++ b/proto.h
@@ -4162,7 +4162,8 @@ PERL_CALLCONV char *
 Perl_savesharedpvn(pTHX_ const char * const pv, const STRLEN len)
         __attribute__malloc__
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_SAVESHAREDPVN
+#define PERL_ARGS_ASSERT_SAVESHAREDPVN          \
+        assert(pv)
 
 PERL_CALLCONV void
 Perl_savestack_grow(pTHX);

--- a/util.c
+++ b/util.c
@@ -1359,10 +1359,10 @@ Perl_savesharedpv(pTHX_ const char *pv)
 char *
 Perl_savesharedpvn(pTHX_ const char *const pv, const STRLEN len)
 {
-    char *const newaddr = (char*)PerlMemShared_malloc(len + 1);
-
+    PERL_ARGS_ASSERT_SAVESHAREDPVN;
     PERL_UNUSED_CONTEXT;
-    /* PERL_ARGS_ASSERT_SAVESHAREDPVN; */
+
+    char *const newaddr = (char*)PerlMemShared_malloc(len + 1);
 
     if (!newaddr) {
         croak_no_mem_ext(STR_WITH_LEN("util:savesharedpvn"));


### PR DESCRIPTION
It was NULLOK only to stop a compiler warning.  No warning happens with c99 and a slight rearrangement; and NULLs are not acceptable input.

* This set of changes does not require a perldelta entry.
