### PR TITLE
perlintern: document newFORM

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2224,7 +2224,7 @@ ARdp	|OP *	|newCVREF	|I32 flags				\
 ARdpx	|OP *	|newDEFEROP	|I32 flags				\
 				|NN OP *block
 ARdp	|OP *	|newDEFSVOP
-Cp	|void	|newFORM	|I32 floor				\
+Cdp	|void	|newFORM	|I32 floor				\
 				|NULLOK OP *o				\
 				|NULLOK OP *block
 ARdp	|OP *	|newFOROP	|I32 flags				\

--- a/op.c
+++ b/op.c
@@ -12235,6 +12235,14 @@ Perl_newSTUB(pTHX_ GV *gv, bool fake)
     return cv;
 }
 
+/*
+=for apidoc newFORM
+
+Constructs, checks, and returns a format op.
+
+=cut
+*/
+
 void
 Perl_newFORM(pTHX_ I32 floor, OP *o, OP *block)
 {


### PR DESCRIPTION
This follows the same paradigm as various similar functions that are in perlapi.  This commit is from 2022, and I no longer remember why it goes in perlintern, or if that is a mistake.


* This set of changes does not require a perldelta entry.
