### PR TITLE
unTODO test in GH 21827 TODO tests

### DIFF
--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -387,11 +387,14 @@ TODO: {
 TODO: {
     local $::TODO = 'GH 21827';
     my $test = 18446744073709550592;
-    warnings_like(
-        sub { localtime $test },
-        [ (qr/localtime\($test\)/) x 2 ],
-        'localtime() warning reports correct value when given too large of a number; GH 21827'
-    );
+    my @warnings = capture_warnings(sub { localtime $test });
+    {
+        local $::TODO = 0;
+        is(scalar @warnings, 2, 'Correct number of warnings captured; GH 21827');
+    }
+    for my $w (@warnings) {
+        like($w, qr/localtime\($test\)/, 'localtime() warnings reports correct value when given too large of a number; GH 21827');
+    }
 }
 
 TODO: {


### PR DESCRIPTION
In response to the discussion under #23701.

This PR restructures the TODO tests for GH 21827 so that the test that passes is not marked as TODO while the failing tests still are. warnings_like() had to be swapped out for capture_warnings() with manual testing so that we could have granular control over the tests, as we did not have such granular control with the three tests that were originally generated by warnings_like().

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
