### PR TITLE
Remove superfluous &utf8::AUTOLOAD

### DIFF
--- a/lib/utf8.pm
+++ b/lib/utf8.pm
@@ -1,13 +1,16 @@
 package utf8;
 
+# This file only defines the import/unimport subs, the rest are implemented by
+# always-present functions in the perl interpreter itself.
+# See also `universal.c` in the perl source
+
 use strict;
 use warnings;
 
 our $utf8_hint_bits  = 0x00800000;
 our $ascii_hint_bits = 0x00000010;  # Turned off when utf8 turned on
 
-our $VERSION = '1.27';
-our $AUTOLOAD;
+our $VERSION = '1.28';
 
 sub import {
     $^H |= $utf8_hint_bits;
@@ -16,12 +19,6 @@ sub import {
 
 sub unimport {
     $^H &= ~$utf8_hint_bits;
-}
-
-sub AUTOLOAD {
-    goto &$AUTOLOAD if defined &$AUTOLOAD;
-    require Carp;
-    Carp::croak("Undefined subroutine $AUTOLOAD called");
 }
 
 1;

--- a/lib/utf8.t
+++ b/lib/utf8.t
@@ -557,8 +557,8 @@ SKIP: {
 
 {
     fresh_perl_like ('use utf8; utf8::moo()',
-		     qr/Undefined subroutine utf8::moo/, {stderr=>1},
-		    "Check Carp is loaded for AUTOLOADing errors")
+		     qr/Undefined subroutine &utf8::moo/, {stderr=>1},
+		    "Check undefined subroutines error")
 }
 
 {


### PR DESCRIPTION
Historically this was used to load utf8_heavy.pl before calling the real functions but now that utf8_heavy.pl is no longer a thing it doesn't serve any purpose. The error message upon calling an unknown sub changes by one character since it now comes from perl proper rather than a hand-rolled one in utf8.pm.

I've added a comment, modeled on the one in builtin.pm, to explain where the subs are actually defined.

* This set of changes does not require a perldelta entry.
