### PR TITLE
utf8_to_uv_msgs: Make warning message consistent

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -2240,7 +2240,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
                  * function */
 
                 assert(0);
-                message = Perl_form(aTHX_ "%s (empty string)", malformed_text);
+                message = Perl_form(aTHX_ "%s: (empty string)", malformed_text);
                 break;
 
               case UTF8_GOT_CONTINUATION:


### PR DESCRIPTION
This inserts a colon in the message to make it consistent with all the other similar ones.

It is safe to do this, as this code is executed only as a fallback under non-debugging builds.  The condition that gets to this warning is asserted against in debugging builds.


* This set of changes does not require a perldelta entry.
