### PR TITLE
Minor corrections to 'Possible attempt escape whitespace in qw() list'

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -5501,8 +5501,8 @@ You probably wrote something like this:
         another
     );
 
-expecting to get a two elements list containing the strings C<'a string'>
-and C<'another'>.  Instead the list will hold four elements: C<'a\'>
+expecting to get a two element list containing the strings C<'a string'>
+and C<'another'>.  Instead the list will hold three elements: C<'a\'>
 (with a literal backslash), C<'string'> and C<'another'>.
 
 If you really want whitespace in your strings, build your list the


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
The description for diagnostic `Possible attempt escape whitespace in qw() list` mis-states the actual number of elements produced by the example (the first commit) and contains a minor grammar error (the second commit). This pull request corrects both issues.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
