### PR TITLE
Configure: check usability of <stdckdint.h>, not only its existence

### DIFF
--- a/Configure
+++ b/Configure
@@ -24228,8 +24228,41 @@ set i_stdbool
 eval $setvar
 
 : see if C23 stdckdint is available
-set stdckdint.h i_stdckdint
-eval $inhdr
+: we want a real compile instead of Inhdr because some FreeBSD systems
+: have stdckdint.h, but it is not compatible with C++.
+case "$i_stdckdint" in
+'')
+    echo " "
+    $cat >try.c <<EOCP
+#include <stdio.h>
+#include <stdckdint.h>
+int func(long *resultptr, long a, long b)
+{
+    return (ckd_add(resultptr, a, b) ||
+	    ckd_sub(resultptr, a, b) ||
+	    ckd_mul(resultptr, a, b)) ? 1 : 0;
+}
+int main(int argc, char **argv)
+{
+    long result;
+    return func(&result, 42L, 53L);
+}
+EOCP
+    set try
+    if eval $compile; then
+	echo "<stdckdint.h> found." >&4
+	val="$define"
+    else
+	echo "<stdckdint.h> NOT found." >&4
+	val="$undef"
+    fi ;;
+*)
+    val="$i_stdckdint" ;;
+esac
+
+$rm_try
+set i_stdckdint
+eval $setvar
 
 : see if stdint is available
 set stdint.h i_stdint


### PR DESCRIPTION
Some FreeBSD systems have <stdckdint.h>, but it cannot be compiled with C++ compilers.  This patch modifies Configure to check whether `ckd_*` functions can be compiled, and leave I_STDCKDINT undefined (so that <stdckdint.h> won't be used in build time) if the compilation failed.

Will fix GH #23725.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.