### PR TITLE
Add "\" to characters that produce warnings in qw().

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -2089,10 +2089,11 @@ Some frequently seen examples:
     use POSIX qw( setlocale localeconv )
     @EXPORT = qw( foo bar baz );
 
-A common mistake is to try to separate the words with commas or to
-put comments into a multi-line C<qw>-string.  For this reason, the
-S<C<use warnings>> pragma and the B<-w> switch (that is, the C<$^W> variable)
-produces warnings if the I<STRING> contains the C<","> or the C<"#"> character.
+Common mistakes are trying to separate the words with commas, trying to
+put comments into a multi-line C<qw>-string, or trying to C<\>-escape
+the space between words. For this reason, the S<C<use warnings>> pragma
+and the B<-w> switch (that is, the C<$^W> variable) produce warnings if
+the I<STRING> contains the C<",">, C<"#">, or C<"\"> characters.
 
 =back
 


### PR DESCRIPTION
Perl 5.43.2 added diagnostic `Possible attempt to escape whitespace in qw() list`, which triggers on the detection of a reverse solidus. This commit rewrites the last paragraph in the section on `qw()` to add the reverse solidus to the list of characters that produce a warning.

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
