### PR TITLE
PerlIO::via: remove redundant NULL check

### DIFF
--- a/ext/PerlIO-via/via.pm
+++ b/ext/PerlIO-via/via.pm
@@ -1,5 +1,5 @@
 package PerlIO::via;
-our $VERSION = '0.20';
+our $VERSION = '0.21';
 require XSLoader;
 XSLoader::load();
 1;

--- a/ext/PerlIO-via/via.xs
+++ b/ext/PerlIO-via/via.xs
@@ -96,13 +96,12 @@ PerlIOVia_method(pTHX_ PerlIO * f, const char *method, CV ** save, int flags,
                 if (!package)
                     return Nullsv; /* can this ever happen? */
 		gv = newGVgen(package);
+                assert(gv);
 		GvIOp(gv) = newIO();
 		s->fh = newRV((SV *) gv);
 		s->io = GvIOp(gv);
-		if (gv) {
-		    /* shamelessly stolen from IO::File's new_tmpfile() */
-		    (void) hv_delete(GvSTASH(gv), GvNAME(gv), GvNAMELEN(gv), G_DISCARD);
-		}
+                /* shamelessly stolen from IO::File's new_tmpfile() */
+                (void) hv_delete(GvSTASH(gv), GvNAME(gv), GvNAMELEN(gv), G_DISCARD);
 	    }
 	    IoIFP(s->io) = PerlIONext(f);
 	    IoOFP(s->io) = PerlIONext(f);


### PR DESCRIPTION
The `if (gv)` check is pointless because `GvIOp(gv)` already dereferences `gv`, so if `gv` could be NULL, we'd already have undefined behavior (most likely a segfault) before reaching the `if`.

Make the code's implicit assumptions explicit by adding `assert(gv)` before dereferencing.

Fixes Coverity CID 584859.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
