### PR TITLE
chop/chomp: avoid signed integer overflow

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -901,7 +901,7 @@ PP(pp_schop)
 
     const size_t count = do_chomp(TARG, *PL_stack_sp, chomping);
     if (chomping)
-        sv_setiv(TARG, (IV)count);
+        sv_setuv(TARG, count);
     SvSETMAGIC(TARG);
     rpp_replace_1_1_NN(TARG);
     return NORMAL;
@@ -919,7 +919,7 @@ PP_wrapped(pp_chop, 0, 1)
     while (MARK < SP)
         count += do_chomp(TARG, *++MARK, chomping);
     if (chomping)
-        sv_setiv(TARG, count);
+        sv_setuv(TARG, count);
     SP = ORIGMARK;
     XPUSHTARG;
     RETURN;


### PR DESCRIPTION
Fixes Coverity CID 584015 ("underflow: The cast of count to a signed type could result in a negative number").

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
