### PR TITLE
test.pl: watchdog: Simplify, clarify, recover from failure

### DIFF
--- a/t/test.pl
+++ b/t/test.pl
@@ -1838,6 +1838,7 @@ sub warning_like {
 { # Closure
     my $watchdog_process;
     my $watchdog_thread;
+    my $watchdog_alarm;
 
 sub watchdog ($;$)
 {
@@ -1854,8 +1855,9 @@ sub watchdog ($;$)
         kill('KILL', $watchdog_process);
         undef $watchdog_process;
     }
-    else {
+    elsif ($watchdog_alarm) {
         alarm(0);
+        undef $watchdog_alarm;
     }
 
     return;
@@ -2060,6 +2062,7 @@ WATCHDOG_VIA_ALARM:
                              my $sig = ($is_vms) ? 'TERM' : 'KILL';
                              kill($sig, $pid_to_kill);
                            };
+        $watchdog_alarm = 1;
     }
 }
 } # End closure

--- a/t/test.pl
+++ b/t/test.pl
@@ -1947,11 +1947,12 @@ sub watchdog ($;$)
                     $watchdog = system(1, $cmd);
                 }
             };
-            if ($@ || ($watchdog <= 0)) {
-                _diag('Failed to start watchdog');
-                _diag($@) if $@;
+
+            if ($@ || $watchdog <= 0) {
+                $@ = "\n$@" if $@;
+                _diag("Failed to start watchdog$@\nTrying alternate method");
                 undef($watchdog);
-                return;
+                goto WATCHDOG_VIA_ALARM;
             }
 
             # Add END block to parent to terminate and clean up watchdog

--- a/t/test.pl
+++ b/t/test.pl
@@ -1836,7 +1836,7 @@ sub warning_like {
 # NOTE:  If the test file uses 'threads', then call the watchdog() function
 #        _AFTER_ the 'threads' module is loaded.
 { # Closure
-    my $watchdog;
+    my $watchdog_process;
     my $watchdog_thread;
 
 sub watchdog ($;$)
@@ -1850,9 +1850,9 @@ sub watchdog ($;$)
         $watchdog_thread->kill('KILL');
         undef $watchdog_thread;
     }
-    elsif ($watchdog) {
-        kill('KILL', $watchdog);
-        undef $watchdog;
+    elsif ($watchdog_process) {
+        kill('KILL', $watchdog_process);
+        undef $watchdog_process;
     }
     else {
         alarm(0);
@@ -1862,7 +1862,7 @@ sub watchdog ($;$)
     }
 
     # Make sure these aren't defined.
-    undef $watchdog;
+    undef $watchdog_process;
     undef $watchdog_thread;
 
     my $method = shift || "";
@@ -1913,7 +1913,7 @@ sub watchdog ($;$)
             return if ($pid_to_kill <= 0);
 
             # Launch watchdog process
-            undef $watchdog;
+            undef $watchdog_process;
             eval {
                 local $SIG{'__WARN__'} = sub {
                                              _diag("Watchdog warning: $_[0]");
@@ -1940,37 +1940,38 @@ sub watchdog ($;$)
                     if ($runperl =~ m/\s/) {
                         $runperl = qq{"$runperl"};
                     }
-                    $watchdog = system({ $runperl } 1, $runperl, '-e', $prog);
+                    $watchdog_process =
+                                system({ $runperl } 1, $runperl, '-e', $prog);
                 }
                 else {
                     my $cmd = _create_runperl(prog => $prog);
-                    $watchdog = system(1, $cmd);
+                    $watchdog_process = system(1, $cmd);
                 }
             };
 
-            if ($@ || $watchdog <= 0) {
+            if ($@ || $watchdog_process <= 0) {
                 $@ = "\n$@" if $@;
                 _diag("Failed to start watchdog$@\nTrying alternate method");
-                undef($watchdog);
+                undef($watchdog_process);
                 goto WATCHDOG_VIA_ALARM;
             }
 
             # Add END block to parent to terminate and clean up watchdog
             # process
             eval("END { local \$! = 0; local \$? = 0;
-                        wait() if kill('KILL', $watchdog); };");
+                        wait() if kill('KILL', $watchdog_process); };");
             return;
         }
 
         # Try using fork() to generate a watchdog process
-        undef $watchdog;
-        eval { $watchdog = fork() };
-        if (defined($watchdog)) {
-            if ($watchdog) {   # Parent process
+        undef $watchdog_process;
+        eval { $watchdog_process = fork() };
+        if (defined($watchdog_process)) {
+            if ($watchdog_process) {   # Parent process
                 # Add END block to parent to terminate and clean up watchdog
                 # process
                 eval "END { local \$! = 0; local \$? = 0;
-                            wait() if kill('KILL', $watchdog); };";
+                            wait() if kill('KILL', $watchdog_process); };";
                 return;
             }
 

--- a/t/test.pl
+++ b/t/test.pl
@@ -1851,11 +1851,11 @@ sub watchdog ($;$)
         $watchdog_thread->kill('KILL');
         undef $watchdog_thread;
     }
-    elsif ($watchdog_process) {
+    if ($watchdog_process) {
         kill('KILL', $watchdog_process);
         undef $watchdog_process;
     }
-    elsif ($watchdog_alarm) {
+    if ($watchdog_alarm) {
         alarm(0);
         undef $watchdog_alarm;
     }

--- a/t/test.pl
+++ b/t/test.pl
@@ -1840,6 +1840,9 @@ sub warning_like {
     my $watchdog_thread;
     my $watchdog_alarm;
 
+    # Add END block to terminate and clean up any watchdog
+    END { watchdog(0); };
+
 sub watchdog ($;$)
 {
     my $timeout = shift;
@@ -1953,23 +1956,13 @@ sub watchdog ($;$)
                 goto WATCHDOG_VIA_ALARM;
             }
 
-            # Add END block to parent to terminate and clean up watchdog
-            # process
-            eval("END { local \$! = 0; local \$? = 0;
-                        wait() if kill('KILL', $watchdog_process); };");
             return;
         }
 
         # Try using fork() to generate a watchdog process
         eval { $watchdog_process = fork() };
         if (defined($watchdog_process)) {
-            if ($watchdog_process) {   # Parent process
-                # Add END block to parent to terminate and clean up watchdog
-                # process
-                eval "END { local \$! = 0; local \$? = 0;
-                            wait() if kill('KILL', $watchdog_process); };";
-                return;
-            }
+            return if $watchdog_process;  # Parent process
 
             ### Watchdog process code
 

--- a/t/test.pl
+++ b/t/test.pl
@@ -1890,9 +1890,12 @@ sub watchdog ($;$)
     # shut up use only once warning
     my $threads_on = $threads::threads && $threads::threads;
 
-    # Use a watchdog process unless 'threads' is loaded
-    if (!$threads_on || $method eq "process") {
-
+    # Use a watchdog process unless 'threads' is loaded and is killable by a
+    # signal
+    if (   ! $threads_on
+        || (defined $ENV{PERL_SIGNALS} && $ENV{PERL_SIGNALS} eq "unsafe")
+        || $method eq "process")
+    {
         # On Windows and VMS, try launching a watchdog process
         #   using system(1, ...) (see perlport.pod).  system() returns
         #   immediately on these platforms with effectively a pid of the new

--- a/t/test.pl
+++ b/t/test.pl
@@ -1846,19 +1846,19 @@ sub watchdog ($;$)
     # If cancelling, use the state variables to know which method was used to
     # create the watchdog.
     if ($timeout == 0) {
-        if ($watchdog_thread) {
-            $watchdog_thread->kill('KILL');
-            undef $watchdog_thread;
-        }
-        elsif ($watchdog) {
-            kill('KILL', $watchdog);
-            undef $watchdog;
-        }
-        else {
-            alarm(0);
-        }
+    if ($watchdog_thread) {
+        $watchdog_thread->kill('KILL');
+        undef $watchdog_thread;
+    }
+    elsif ($watchdog) {
+        kill('KILL', $watchdog);
+        undef $watchdog;
+    }
+    else {
+        alarm(0);
+    }
 
-        return;
+    return;
     }
 
     # Make sure these aren't defined.
@@ -1890,8 +1890,7 @@ sub watchdog ($;$)
     # shut up use only once warning
     my $threads_on = $threads::threads && $threads::threads;
 
-    # Don't use a watchdog process if 'threads' is loaded -
-    #   use a watchdog thread instead
+    # Use a watchdog process unless 'threads' is loaded
     if (!$threads_on || $method eq "process") {
 
         # On Windows and VMS, try launching a watchdog process
@@ -1914,9 +1913,9 @@ sub watchdog ($;$)
             undef $watchdog;
             eval {
                 local $SIG{'__WARN__'} = sub {
-                    _diag("Watchdog warning: $_[0]");
-                };
-                my $sig = $is_vms ? 'TERM' : 'KILL';
+                                             _diag("Watchdog warning: $_[0]");
+                                             };
+                my $sig = ($is_vms) ? 'TERM' : 'KILL';
                 my $prog = "sleep($timeout);" .
                            "warn qq/# $timeout_msg" . '\n/;' .
                            "kill(q/$sig/, $pid_to_kill);";
@@ -1952,8 +1951,8 @@ sub watchdog ($;$)
                 return;
             }
 
-            # Add END block to parent to terminate and
-            #   clean up watchdog process
+            # Add END block to parent to terminate and clean up watchdog
+            # process
             eval("END { local \$! = 0; local \$? = 0;
                         wait() if kill('KILL', $watchdog); };");
             return;
@@ -1964,8 +1963,8 @@ sub watchdog ($;$)
         eval { $watchdog = fork() };
         if (defined($watchdog)) {
             if ($watchdog) {   # Parent process
-                # Add END block to parent to terminate and
-                #   clean up watchdog process
+                # Add END block to parent to terminate and clean up watchdog
+                # process
                 eval "END { local \$! = 0; local \$? = 0;
                             wait() if kill('KILL', $watchdog); };";
                 return;
@@ -2002,8 +2001,8 @@ sub watchdog ($;$)
         # fork() failed - fall through and try using a thread
     }
 
-    # Use a watchdog thread because either 'threads' is loaded,
-    #   or fork() failed
+    # Use a watchdog thread because either 'threads' is loaded, or fork()
+    # failed
     if (eval {require threads; 1}) {
         $watchdog_thread = 'threads'->create(sub {
                 # Load POSIX if available
@@ -2042,7 +2041,7 @@ sub watchdog ($;$)
         return;
     }
 
-    # If everything above fails, then just use an alarm timeout
+    # If everything above fails, then just use an alarm timeout.
 WATCHDOG_VIA_ALARM:
     if (eval { alarm($timeout); 1; }) {
         # Load POSIX if available
@@ -2050,12 +2049,12 @@ WATCHDOG_VIA_ALARM:
 
         # Alarm handler will do the actual 'killing'
         $SIG{'ALRM'} = sub {
-            select(STDERR); $| = 1;
-            _diag($timeout_msg);
-            POSIX::_exit(1) if (defined(&POSIX::_exit));
-            my $sig = $is_vms ? 'TERM' : 'KILL';
-            kill($sig, $pid_to_kill);
-        };
+                             select(STDERR); $| = 1;
+                             _diag($timeout_msg);
+                             POSIX::_exit(1) if (defined(&POSIX::_exit));
+                             my $sig = ($is_vms) ? 'TERM' : 'KILL';
+                             kill($sig, $pid_to_kill);
+                           };
     }
 }
 } # End closure

--- a/t/test.pl
+++ b/t/test.pl
@@ -1844,9 +1844,9 @@ sub watchdog ($;$)
 {
     my $timeout = shift;
 
-    # If cancelling, use the state variables to know which method was used to
-    # create the watchdog.
-    if ($timeout == 0) {
+    # Cancel any existing timer, so the caller can set multiple ones without
+    # cancelling first.  For safety, handle the case where somehow more than
+    # one type of watchdog got set.
     if ($watchdog_thread) {
         $watchdog_thread->kill('KILL');
         undef $watchdog_thread;
@@ -1860,12 +1860,8 @@ sub watchdog ($;$)
         undef $watchdog_alarm;
     }
 
-    return;
-    }
-
-    # Make sure these aren't defined.
-    undef $watchdog_process;
-    undef $watchdog_thread;
+    # We are done if this call was just to cancel
+    return if $timeout == 0;
 
     my $method = shift || "";
 
@@ -1915,7 +1911,6 @@ sub watchdog ($;$)
             return if ($pid_to_kill <= 0);
 
             # Launch watchdog process
-            undef $watchdog_process;
             eval {
                 local $SIG{'__WARN__'} = sub {
                                              _diag("Watchdog warning: $_[0]");
@@ -1966,7 +1961,6 @@ sub watchdog ($;$)
         }
 
         # Try using fork() to generate a watchdog process
-        undef $watchdog_process;
         eval { $watchdog_process = fork() };
         if (defined($watchdog_process)) {
             if ($watchdog_process) {   # Parent process

--- a/t/test_pl.pod
+++ b/t/test_pl.pod
@@ -489,8 +489,8 @@ Note: currently only used by F<test.pl> itself.
 
 =item watchdog($timeout, $method);
 
-Start a watchdog timer for C<$timeout> seconds.  If C<$timeout> is
-zero then disables any existing watchdog timer.
+Start a watchdog timer for C<$timeout> seconds, while disabling any
+existing one.  If C<$timeout> is zero no new timer is created.
 
 The timeout may be scaled by setting C<PERL_TEST_TIME_OUT_FACTOR> or
 C<PERL_TEST_TIMEOUT_FACTOR> in the environment.  If C<PERL_VALGRIND>


### PR DESCRIPTION
@tonycoz noticed a simplification this makes.

If something goes wrong on WIndows and VMS, previously it gave up; now it tries an `alarm`.

It now doesn't try to use the thread method unless safe signals are in effect.

Some comments are clarified

* This set of changes does not require a perldelta entry.
