### PR TITLE
Modernise SelectSaver

### DIFF
--- a/lib/SelectSaver.pm
+++ b/lib/SelectSaver.pm
@@ -1,6 +1,18 @@
-package SelectSaver;
+package SelectSaver 1.03;
 
-our $VERSION = '1.02';
+use v5.40;
+
+use Symbol 'qualify';
+
+sub new ($class, $filehandle = undef) {
+    my $fh = select;
+    select qualify $filehandle, caller if defined $filehandle;
+    return bless \$fh, $class;
+}
+
+sub DESTROY ($self) { select $$self }
+
+__END__
 
 =head1 NAME
 
@@ -31,24 +43,3 @@ file handle remains unchanged.
 
 When a C<SelectSaver> is destroyed, it re-selects the file handle
 that was selected when it was created.
-
-=cut
-
-require 5.000;
-use Carp;
-use Symbol;
-
-sub new {
-    @_ >= 1 && @_ <= 2 or croak 'usage: SelectSaver->new( [FILEHANDLE] )';
-    my $fh = select;
-    my $self = bless \$fh, $_[0];
-    select qualify($_[1], caller) if @_ > 1;
-    $self;
-}
-
-sub DESTROY {
-    my $self = $_[0];
-    select $$self;
-}
-
-1;

--- a/lib/SelectSaver.t
+++ b/lib/SelectSaver.t
@@ -5,24 +5,63 @@ BEGIN {
     @INC = '../lib';
 }
 
-print "1..3\n";
+use v5.40;
 
-use SelectSaver;
+use Test2::V0 -target => 'SelectSaver';
 
-open(FOO, ">", "foo-$$") || die;
+ok dies { SelectSaver::new() }, 'Too few arguments to new dies';
+ok dies { CLASS->new(undef, undef) }, 'Too many arguments to new dies';
 
-print "ok 1\n";
-{
-    my $saver = new SelectSaver(FOO);
-    print "foo\n";
-}
+subtest 'bareword filehandle' => sub {
+    use feature 'bareword_filehandles';
 
-# Get data written to file
-open(FOO, "<", "foo-$$") || die;
-chomp($foo = <FOO>);
-close FOO;
-unlink "foo-$$";
+    is refaddr(select), refaddr(*STDOUT), 'STDOUT is initially selected';
 
-print "ok 2\n" if $foo eq "foo";
+    open FOO, '>', undef;
 
-print "ok 3\n";
+    {
+        ok my $saver = CLASS->new(*FOO), 'SelectSaver->new(*FOO)';
+
+        is refaddr(select), refaddr(*FOO), 'FOO is now selected';
+    }
+
+    is refaddr(select), refaddr(*STDOUT), 'STDOUT is selected again';
+
+    {
+        ok my $saver = CLASS->new('FOO'), 'SelectSaver->new("FOO")';
+
+        is refaddr(select), refaddr(*FOO), 'FOO is now selected';
+    }
+
+    is refaddr(select), refaddr(*STDOUT), 'STDOUT is selected again';
+};
+
+subtest 'lexical filehandle' => sub {
+    is refaddr(select), refaddr(*STDOUT), 'STDOUT is initially selected';
+
+    open my $fh, '>', undef;
+
+    {
+        ok my $saver = CLASS->new($fh), 'SelectSaver->new($fh)';
+
+        is refaddr(select), refaddr($fh), '$fh is now selected';
+    }
+
+    is refaddr(select), refaddr(*STDOUT), 'STDOUT is selected again';
+};
+
+subtest 'no filehandle' => sub {
+    is refaddr(select), refaddr(*STDOUT), 'STDOUT is initially selected';
+
+    {
+        ok my $saver = CLASS->new, 'SelectSaver->new';
+
+        ok select(STDERR), 'select STDERR';
+
+        is refaddr(select), refaddr(*STDERR), 'STDERR is now selected';
+    }
+
+    is refaddr(select), refaddr(*STDOUT), 'STDOUT is selected again';
+};
+
+done_testing;


### PR DESCRIPTION
I've split this PR into two commits, the first modernises the test, the second the actual code, this way we can prove the test passes with both the existing and modernised library. See each commit for details of what changed.

This is the first test under lib to use Test2::V0 but it's my understanding that should be fine as we're not testing the language itself, just a library. Some tests under lib already use Test::More so this doesn't seem like much of a step up, and definitely beats the hand-printed TAP it had before.

* This set of changes does not require a perldelta entry.
