### PR TITLE
utf8.c: convert assertion from English to C

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -4143,12 +4143,13 @@ Perl_inverse_folds_(pTHX_ const UV cp, U32 * first_folds_to,
      * constructed with this size (to save space and memory), and we return
      * pointers, so they must be this size */
 
-    /* 'index' is guaranteed to be non-negative, as this is an inversion map
-     * that covers all possible inputs.  See [perl #133365] */
-    SSize_t index = _invlist_search(PL_utf8_foldclosures, cp);
-    I32 base = _Perl_IVCF_invmap[index];
-
     PERL_ARGS_ASSERT_INVERSE_FOLDS_;
+
+    /* 'index' is guaranteed to be non-negative, as this is an inversion map
+     * that covers all possible inputs.  See [GH #16624] */
+    SSize_t index = _invlist_search(PL_utf8_foldclosures, cp);
+    assert(index >= 0);
+    I32 base = _Perl_IVCF_invmap[index];
 
     if (base == 0) {            /* No fold */
         *first_folds_to = 0;


### PR DESCRIPTION
Coverity (CID 584855) complains that _invlist_search can return negative values. There is a comment that asserts this cannot happen here. Convert that comment to a C-level assert(). I don't know if that will silence Coverity, but it can't hurt to verify the invariant at least in debugging builds.

(Also, convert RT ticket ID to Github issue number and do the PERL_ARGS_ASSERT_... thing first.)

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
