### PR TITLE
regexec: assert we stay in bounds when matching \b{wb}

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -6273,6 +6273,7 @@ S_isWB(pTHX_ WB_enum previous,
         /* Here 'matched' is true if the DFA matched the input.  If so,
          * [index+1] contains the value to return */
         if (matched) {
+            assert(index+1 < C_ARRAY_LENGTH(WB_dfa_table));
             return WB_dfa_table[index+1];
         }
 


### PR DESCRIPTION
Coverity (CID 550207) complains that the loop condition only ensures 'index' stays in bounds of WB_dfa_table, not 'index+1'. I don't think the data in the table lets us go out of bounds here, but it doesn't hurt to assert() that assumption.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
