### PR TITLE
regexec: do index arithmetic/comparison in unsigned mode

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -6273,8 +6273,8 @@ S_isWB(pTHX_ WB_enum previous,
         /* Here 'matched' is true if the DFA matched the input.  If so,
          * [index+1] contains the value to return */
         if (matched) {
-            assert(index+1 < C_ARRAY_LENGTH(WB_dfa_table));
-            return WB_dfa_table[index+1];
+            assert(index+1u < C_ARRAY_LENGTH(WB_dfa_table));
+            return WB_dfa_table[index+1u];
         }
 
         /* Here, it didn't match.  In [index+2] is stored the index into the


### PR DESCRIPTION
Otherwise gcc warns when building:

    In file included from perl.h:4229,
                     from regexec.c:76:
    regexec.c: In function ‘S_isWB’:
    regexec.c:6276:28: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
     6276 |             assert(index+1 < C_ARRAY_LENGTH(WB_dfa_table));
          |                            ^

Fixes #23760.


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
