### PR TITLE
perlsub: correct pre-postderef language about "starts with"

### DIFF
--- a/pod/perlsub.pod
+++ b/pod/perlsub.pod
@@ -1523,10 +1523,21 @@ corresponding built-in.
     sub mytime ()           mytime
 
 Any backslashed prototype character represents an actual argument
-that must start with that character (optionally preceded by C<my>,
-C<our> or C<local>), with the exception of C<$>, which will
-accept any scalar lvalue expression, such as C<$foo = 7> or
-C<< my_function()->[0] >>.  The value passed as part of C<@_> will be a
+really using that character for type, with the exception of C<$>, which will
+accept any scalar lvalue expression, such as C<$foo = 7> or C<<
+my_function()->[0] >>.  "Using that character for type" means that the
+expression I<begins> with the sigil (optionally preceded by a declarator like
+C<my>) or I<ends> with the sigil's postfix dereference form.  Any of these, for
+example, satisfies C<\%>:
+
+    %hash
+    %$hashref
+    my %hash
+    $hashref->%*
+    %{ expr }
+    (expr)->*%
+
+The value passed as part of C<@_> will be a
 reference to the actual argument given in the subroutine call,
 obtained by applying C<\> to that argument.
 


### PR DESCRIPTION
It's no longer correct that `\%` means "must start with %", because it could instead end with ->%* -- and in fact one of the examples already showed that!

I also replaced the list of declarators with "my and others", to keep it more futureproof.  "state", for example, had been omitted.