### PR TITLE
More release manager guide edits

### DIFF
--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -929,8 +929,6 @@ Be sure to commit your changes:
 
 =head3 Update patchlevel.h
 
-I<You MUST SKIP this step for a BLEAD-POINT release>
-
 Update F<patchlevel.h> to add a C<-RC1>-or-whatever string; or, if this is
 a final release, remove it. For example:
 
@@ -1241,8 +1239,6 @@ which may be faster.
 
 =head3 Wait for indexing
 
-I<You MUST SKIP this step for RC and BLEAD-POINT>
-
 Wait until you receive notification emails from the PAUSE indexer
 confirming that your uploads have been received.  IMPORTANT -- you will
 probably get an email that indexing has failed, due to module permissions.
@@ -1251,8 +1247,6 @@ This is considered normal.
 =for checklist skip BLEAD-POINT
 
 =head3 Disarm patchlevel.h
-
-I<You MUST SKIP this step for BLEAD-POINT release>
 
 Disarm the F<patchlevel.h> change; for example,
 
@@ -1320,15 +1314,11 @@ release, update F<docs/shared/tpl/stats.html>.
 
 =head3 Release schedule
 
-I<You MUST SKIP this step for RC>
-
 Tick the entry for your release in F<Porting/release_schedule.pod>.
 
 =for checklist skip RC
 
 =head3 Module::CoreList nagging
-
-I<You MUST SKIP this step for RC>
 
 Remind the current maintainer of C<Module::CoreList> to push a new release
 to CPAN.
@@ -1336,8 +1326,6 @@ to CPAN.
 =for checklist skip RC
 
 =head3 New perldelta
-
-I<You MUST SKIP this step for RC>
 
 Create a new perldelta.
 
@@ -1524,8 +1512,6 @@ Finally, push any commits done above.
 
 =head3 Create maint branch
 
-I<You MUST SKIP this step for RC, BLEAD-POINT, MAINT>
-
 If this was a BLEAD-FINAL release (i.e. the first release of a new maint
 series, 5.x.0 where x is even), then create a new maint branch based on
 the commit tagged as the current release.
@@ -1538,8 +1524,6 @@ Assuming you're using git 1.7.x or newer:
 =for checklist skip BLEAD-POINT RC
 
 =head3 Copy perldelta.pod to blead
-
-I<You MUST SKIP this step for RC, BLEAD-POINT>
 
 Copy the perldelta.pod for this release into blead; for example:
 

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -483,10 +483,9 @@ You won't be able to automatically fill in the "Updated Modules" section until
 after L<Module::CoreList> is updated (as described below in
 L</"Update Module::CoreList">).
 
-=head3 Bump the version number
+=for checklist skip BLEAD-POINT
 
-Do not do this yet for a BLEAD-POINT release! You will do this at the end of
-the release process (after building the final tarball, tagging etc).
+=head3 Bump the version number
 
 Increase the version number (e.g. from 5.12.0 to 5.12.1).
 
@@ -1377,9 +1376,9 @@ At this point you may want to compare the commit with a previous bump to
 see if they look similar.  See commit ba03bc34a4 for an example of a
 previous version bump.
 
-=for checklist skip MAINT RC
+=for checklist skip BLEAD-POINT RC MAINT
 
-=head3 Bump version
+=head3 Bump the feature bundles
 
 I<You MUST SKIP this step for RC and MAINT>
 
@@ -1396,12 +1395,6 @@ marker); e.g.
 
 Run F<regen/feature.pl> to propagate the changes to F<lib/feature.pm>.
 
-Then follow the section L</"Bump the version number"> to bump the version
-in the remaining files and test and commit.
-
-If this was a BLEAD-POINT release, then just follow the section
-L</"Bump the version number">.
-
 After bumping the version, follow the section L</"Update INSTALL"> to
 ensure all version number references are correct.
 
@@ -1416,6 +1409,57 @@ reports to arise. (The opposite problem -- trying to figure out why there
 *is* a bug in something calling itself 5.20.1 when in fact the bug was
 introduced later -- shouldn't arise for MAINT releases since they should,
 in theory, only contain bug fixes but never regressions.))
+
+=for checklist skip RC MAINT
+
+=head3 Bump the version number
+
+Increase the version number (e.g. from 5.12.0 to 5.12.1).
+
+There is a tool to semi-automate this process:
+
+ $ ./perl -Ilib Porting/bump-perl-version -i 5.10.0 5.10.1
+
+Remember that this tool is largely just grepping for '5.10.0' or whatever,
+so it will generate false positives. Be careful not change text like
+"this was fixed in 5.10.0"!
+
+Use git status and git diff to select changes you want to keep.
+
+Be particularly careful with F<INSTALL>, which contains a mixture of
+C<5.10.0>-type strings, some of which need bumping on every release, and
+some of which need to be left unchanged.
+See below in L</"Update INSTALL"> for more details.
+
+After editing, you may need to regen opcodes:
+
+ $ ./perl -Ilib regen/opcode.pl
+
+Test your changes:
+
+ $ git clean -xdf   # careful if you don't have local files to keep!
+ $ ./Configure -des -Dusedevel
+ $ make
+ $ make test
+
+Do note that at this stage, porting tests will fail. They will continue
+to fail until you've updated Module::CoreList, as described below.
+
+Commit your changes:
+
+ $ git status
+ $ git diff
+ B<review the delta carefully>
+
+ $ git commit -a -m 'Bump the perl version in various places for 5.X.Y'
+
+At this point you may want to compare the commit with a previous bump to
+see if they look similar.  See commit f7cf42bb69 for an example of a
+previous version bump.
+
+When the version number is bumped, you should also update Module::CoreList
+(as described in L</"Update Module::CoreList">) to reflect the new
+version number.
 
 =head3 Clean build and test
 

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -577,7 +577,10 @@ blead release, so you may find nothing to do here.
 
 =head3 Update AUTHORS
 
-The AUTHORS file can be updated by running F<Porting/updateAUTHORS.pl>.
+The AUTHORS file can be updated by running:
+
+ $ perl Porting/updateAUTHORS.pl
+
 This shouldn't really be necessary anymore, and in theory nothing should
 change as our CI should not pass if a commit would result in AUTHORS
 needing to change, but do it anyway to be sure. Make sure all your changes
@@ -1170,7 +1173,7 @@ Test L<perlbug> with the following:
  Action (Send/Display/Edit/Subject/Save to File): f
  Name of file to save message in [perlbug.rep]:
 
-and carefully examine the output (in F<perlbug.rep]>), especially
+Then carefully examine the output (in F<perlbug.rep]>), especially
 the "Locally applied patches" section.
 
 =for checklist skip BLEAD-POINT
@@ -1347,7 +1350,8 @@ Confirm that you have a clean checkout with no local changes.
 =item *
 
 Run:
- perl Porting/new-perldelta.pl
+
+ $ perl Porting/new-perldelta.pl
 
 =item *
 
@@ -1355,13 +1359,24 @@ Run the C<git add> commands it outputs to add new and modified files.
 
 =item *
 
-Verify that the build still works, by running C<./Configure> and
-C<make test_porting>. (On Win32 use the appropriate make utility).
+Verify that the build still works, by running:
+
+ $ ./Configure
+ $ make test_porting
+
+(On Win32 use the appropriate make utility).
 
 =item *
 
-If F<t/porting/podcheck.t> spots errors in the new F<pod/perldelta.pod>,
-run C<./perl -MTestInit t/porting/podcheck.t | less> for more detail.
+Run:
+
+ $ ./perl t/porting/podcheck.t
+
+If it spots errors in the new F<pod/perldelta.pod>, run:
+
+ $ ./perl -MTestInit t/porting/podcheck.t | less
+
+It will give you more details.
 Skip to the end of its test output to see the options it offers you.
 
 =item *
@@ -1380,8 +1395,6 @@ previous version bump.
 
 =head3 Bump the feature bundles
 
-I<You MUST SKIP this step for RC and MAINT>
-
 If this was a BLEAD-FINAL release (i.e. the first release of a new maint
 series, 5.x.0 where x is even), then bump the version in the blead branch
 in git, e.g. 5.12.0 to 5.13.0.
@@ -1393,7 +1406,11 @@ marker); e.g.
       "5.14" => [qw(switch say state unicode_strings)],
  +    "5.15" => [qw(switch say state unicode_strings)],
 
-Run F<regen/feature.pl> to propagate the changes to F<lib/feature.pm>.
+Run:
+
+ $ ./perl regen/feature.pl
+
+It will propagate the changes to F<lib/feature.pm>.
 
 After bumping the version, follow the section L</"Update INSTALL"> to
 ensure all version number references are correct.
@@ -1449,8 +1466,7 @@ Commit your changes:
 
  $ git status
  $ git diff
- B<review the delta carefully>
-
+ # Review the delta carefully
  $ git commit -a -m 'Bump the perl version in various places for 5.X.Y'
 
 At this point you may want to compare the commit with a previous bump to

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -980,9 +980,9 @@ Then delete the temporary installation.
 
 =head3 Create the release tag
 
-Create the I<annotated> tag identifying this release (e.g.):
+Create the I<annotated> tag identifying this release:
 
- $ git tag v5.21.4 -m 'Perl 5.21.4'
+ $ git tag v5.X.Y -m 'Perl 5.X.Y'
 
 It is B<VERY> important that from this point forward, you not push
 your git changes to the Perl master repository.  If anything goes


### PR DESCRIPTION
## Changes
- More code snippets in code blocks
- Remove redundant "You MUST SKIP" since `=for checklist skip ...` and `make-rmg-checklist` already does the job
- Linear "Bump the version number" with use of `=for checklist skip ...` to generate correct sections
- More use of 5.X.Y (replaced by `make-rmg-checklist` by appropriate number)

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
