### PR TITLE
github: switch irc notifications action

### DIFF
--- a/.github/workflows/irc-notifications.yaml
+++ b/.github/workflows/irc-notifications.yaml
@@ -166,7 +166,6 @@ jobs:
           server: ${{ env.server }}
           port: ${{ env.port }}
           tls: true
-          join: true
           channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
           message: |-
@@ -179,7 +178,6 @@ jobs:
           server: ${{ env.server }}
           port: ${{ env.port }}
           tls: true
-          join: true
           channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
           message: |-
@@ -192,7 +190,6 @@ jobs:
           server: ${{ env.server }}
           port: ${{ env.port }}
           tls: true
-          join: true
           channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
           message: |-
@@ -205,7 +202,6 @@ jobs:
           server: ${{ env.server }}
           port: ${{ env.port }}
           tls: true
-          join: true
           channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
           message: |-
@@ -233,7 +229,6 @@ jobs:
           server: ${{ env.server }}
           port: ${{ env.port }}
           tls: true
-          join: true
           channel: ${{ env.channel_p5p }}
           nickname: GH-Issue
           message: |-
@@ -246,7 +241,6 @@ jobs:
           server: ${{ env.server }}
           port: ${{ env.port }}
           tls: true
-          join: true
           channel: ${{ env.channel_p5p }}
           nickname: GH-Issue
           message: |-
@@ -259,7 +253,6 @@ jobs:
           server: ${{ env.server }}
           port: ${{ env.port }}
           tls: true
-          join: true
           channel: ${{ env.channel_p5p }}
           nickname: GH-Issue
           message: |-

--- a/.github/workflows/irc-notifications.yaml
+++ b/.github/workflows/irc-notifications.yaml
@@ -94,11 +94,13 @@ jobs:
           echo "SUMUP: $SUMUP"
 
       - name: irc push
-        uses: rectalogic/notify-irc@v2
+        uses: mauke/notify-irc@v1
         if: github.event_name == 'push' && github.ref != 'refs/heads/blead'
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
+          tls: true
+          join: true
           channel: ${{ env.channel_noise }}
           nickname: Commit
           message: |-
@@ -107,11 +109,13 @@ jobs:
             ${{ github.event.compare }}
 
       - name: irc push to blead
-        uses: rectalogic/notify-irc@v2
+        uses: mauke/notify-irc@v1
         if: github.event_name == 'push' && github.ref == 'refs/heads/blead'
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
+          tls: true
+          join: true
           channel: ${{ env.channel_noise }}
           nickname: inBlead
           message: |-
@@ -156,55 +160,65 @@ jobs:
           echo "TITLE: $TITLE"
 
       - name: irc opened pull request
-        uses: rectalogic/notify-irc@v2
+        uses: mauke/notify-irc@v1
         if: github.event_name == 'pull_request' && github.event.action == 'opened'
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
+          tls: true
+          join: true
           channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
           message: |-
             ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} opened PR #${{ github.event.pull_request.number }}: ${{ env.TITLE }} - ${{ github.event.pull_request.html_url }}
 
       - name: irc reopened pull request
-        uses: rectalogic/notify-irc@v2
+        uses: mauke/notify-irc@v1
         if: github.event_name == 'pull_request' && github.event.action == 'reopened'
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
+          tls: true
+          join: true
           channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
           message: |-
             ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} reopened PR #${{ github.event.pull_request.number }}: ${{ env.TITLE }} - ${{ github.event.pull_request.html_url }}
 
       - name: irc merged pull request
-        uses: rectalogic/notify-irc@v2
+        uses: mauke/notify-irc@v1
         if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
+          tls: true
+          join: true
           channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
           message: |-
             ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} merged PR #${{ github.event.pull_request.number }}: ${{ env.TITLE }} - ${{ github.event.pull_request.html_url }}
 
       - name: irc closed pull request
-        uses: rectalogic/notify-irc@v2
+        uses: mauke/notify-irc@v1
         if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == false
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
+          tls: true
+          join: true
           channel: ${{ env.channel_p5p }}
           nickname: Pull-Request
           message: |-
             ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} closed PR #${{ github.event.pull_request.number }}: ${{ env.TITLE }} - ${{ github.event.pull_request.html_url }}
 
       - name: irc synchronize pull request
-        uses: rectalogic/notify-irc@v2
+        uses: mauke/notify-irc@v1
         if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
+          tls: true
+          join: true
           channel: ${{ env.channel_noise }}
           nickname: Pull-Request
           message: |-
@@ -213,33 +227,39 @@ jobs:
             ${{ github.event.pull_request.html_url }}
 
       - name: irc opened issue
-        uses: rectalogic/notify-irc@v2
+        uses: mauke/notify-irc@v1
         if: github.event_name == 'issues' && github.event.action == 'opened'
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
+          tls: true
+          join: true
           channel: ${{ env.channel_p5p }}
           nickname: GH-Issue
           message: |-
             ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} opened issue #${{ github.event.issue.number }}: ${{ env.TITLE }} - ${{ github.event.issue.html_url }}
 
       - name: irc reopened issue
-        uses: rectalogic/notify-irc@v2
+        uses: mauke/notify-irc@v1
         if: github.event_name == 'issues' && github.event.action == 'reopened'
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
+          tls: true
+          join: true
           channel: ${{ env.channel_p5p }}
           nickname: GH-Issue
           message: |-
             ${{ env.color_orange }}${{ github.actor }}${{ env.color_clear }} reopened issue #${{ github.event.issue.number }}: ${{ env.TITLE }} - ${{ github.event.issue.html_url }}
 
       - name: irc closed issue
-        uses: rectalogic/notify-irc@v2
+        uses: mauke/notify-irc@v1
         if: github.event_name == 'issues' && github.event.action == 'closed'
         with:
           server: ${{ env.server }}
           port: ${{ env.port }}
+          tls: true
+          join: true
           channel: ${{ env.channel_p5p }}
           nickname: GH-Issue
           message: |-


### PR DESCRIPTION
This one lets you customize whether the notification bot should join the channel first before announcing the news. If a channel doesn't have mode `+n` set, joining is not required to speak in it, and not doing so saves some join/part noise.


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
