### PR TITLE
[Win32] Define $Config{i_stdckdint} and 'I_STDCKDINT' when appropriate

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6788,6 +6788,7 @@ win32/config_H.gc			Win32 config header (MinGW build)
 win32/config_h.PL			Perl code to convert Win32 config.sh to config.h
 win32/config_H.vc			Win32 config header (Visual C++ build)
 win32/config_sh.PL			Perl code to update Win32 config.sh from Makefile
+win32/configure/have_stdckdint.c	check for availability of stdckdint.h
 win32/configure/rt.c			identify default runtime
 win32/create_perllibst_h.pl		creates perllibst.h file for inclusion from perllib.c
 win32/distclean.bat			Remove _ALL_ files not listed here in MANIFEST

--- a/win32/config_sh.PL
+++ b/win32/config_sh.PL
@@ -148,6 +148,12 @@ my $ver = `ver 2>nul`;
 $opt{osvers} = $ver =~ /\b(\d+(?:\.\d+)+)\b/ ? $1 : '4.0';
 
 if (exists $opt{cc}) {
+    `$opt{cc} -o have_stdckdint.exe configure/have_stdckdint.c 1>nul 2>&1`;
+    if  (-e 'have_stdckdint.exe') {
+        $opt{i_stdckdint} = 'define' if `have_stdckdint` eq '0';
+        unlink 'have_stdckdint.exe'; # have_stdckdint.exe no longer needed
+    }
+
     # cl version detection borrowed from Test::Smoke's configsmoke.pl
     if ($opt{cc} =~ /\b(?:cl|icl)/) { #MSVC can come as clarm.exe, icl=Intel C
         my $output = `$opt{cc} 2>&1`;


### PR DESCRIPTION
This PR , in conjunction with (the already merged) #23703, will define <code>$Config{i_stdckdint}</code> and <code>I_STDCKDINT</code> on Windows builds of perl whenever <code>stdckdint.h</code> is locatable and functional.

It currently applies only to mingw-built perls. (Microsoft compilers do not yet provide <code>stdckdint.h</code> and I could find nothing to suggest that they ever will.)

Hence, with this PR. stdckdint.h will be included only if perl on Windows is built using gcc-14 or later && <code>$Config{cc}</code> is <code>gcc</code>.
(I don't know if anyone builds perl on Windows with <code>g++</code>, but according to my testing <code>stdckdint.h</code> is  non-functional on Windows when the compiler is <code>g++</code>.)

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
