### PR TITLE
Do not fail on minimized systems

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -309,7 +309,9 @@ Eric Brine <ikegami@adaelis.com> ikegami <eric@fmdev10.(none)>
 Eric Fifer <egf7@columbia.edu> Fifer, Eric <efifer@sanwaint.com>
 Eric Melville <unknown> Eric Melville <perlbug@perl.org>
 Erik <erik@cs.uni-jena.de> erik@cs.uni-jena.de <erik@cs.uni-jena.de>
-Eugen Konkov <kes-kes@yandex.ru> Eugen Konkov <eugen@konkov.top>
+Eugen Konkov <unknown> Eugen Konkov <ekonkov@konkov>
+Eugen Konkov <unknown> Eugen Konkov <eugen@konkov.top>
+Eugen Konkov <unknown> Eugen Konkov <kes-kes@yandex.ru>
 Fabien Tassin <tassin@eerie.fr> Fabien TASSIN <tassin@eerie.fr>
 Father Chrysostomos <sprout@cpan.org> Father Chrysostomos (via RT) <perlbug-followup@perl.org>
 Father Chrysostomos <sprout@cpan.org> Father Chrysostomos <perlbug-followup@perl.org>

--- a/AUTHORS
+++ b/AUTHORS
@@ -19,7 +19,7 @@
 # you wish to remove yourself. If you wish to register a new email
 # against one of these names you should update the .mailmap file
 # instead.
--- 
+--
 A. C. Yardley                  <yardley@tanet.net>
 A. Sinan Unur                  <nanis@cpan.org>
 Aaron B. Dossett               <aaron@iglou.com>
@@ -473,7 +473,7 @@ Erik                           <erik@cs.uni-jena.de>
 Erik Huelsmann                 <ehuels@gmail.com>
 Eryq                           <eryq@zeegee.com>
 Etienne Grossman               <etienne@isr.isr.ist.utl.pt>
-Eugen Konkov                   <kes-kes@yandex.ru>
+Eugen Konkov
 Eugene Alterman                <Eugene.Alterman@bremer-inc.com>
 Eugene Alvin Villar            <seav80@gmail.com>
 Evan Miller                    <eam@frap.net>

--- a/lib/perl5db.t
+++ b/lib/perl5db.t
@@ -3012,6 +3012,10 @@ SKIP:
     local $ENV{LANG} = "C";
     local $ENV{LC_MESSAGES} = "C";
     local $ENV{LC_ALL} = "C";
+    my $out = `/usr/bin/man --version`;
+    if ($out =~ /^This system has been minimized/) {
+        skip "No man. This system has been minimized...", 1;
+    }
     my $wrapper = DebugWrap->new(
         {
             cmds =>


### PR DESCRIPTION
GH #23780
Perl installation fails on minimized systems.

Here we just add another test that `man` is available and SKIP `perldoc` section if it is not.


After the fix output looks like this:
```
ok 123 - Test that the debugger chdirs to the initial directory after a restart.
ok 124 # skip No man. This system has been minimized...
ok 125 - Test that the a command does not emit warnings on program exit.
```