### PR TITLE
regcomp: reduce some code duplication

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -395,26 +395,28 @@ Perl_reginitcolors(pTHX)
 regexp_engine const *
 Perl_current_re_engine(pTHX)
 {
+    SV *ptr;
     if (IN_PERL_COMPILETIME) {
         HV * const table = GvHV(PL_hintgv);
-        SV **ptr;
+        SV **pptr;
 
         if (!table || !(PL_hints & HINT_LOCALIZE_HH))
             return &PL_core_reg_engine;
-        ptr = hv_fetchs(table, "regcomp", false);
-        if ( !(ptr && SvIOK(*ptr) && SvIV(*ptr)))
+        pptr = hv_fetchs(table, "regcomp", false);
+        if (!pptr)
             return &PL_core_reg_engine;
-        return INT2PTR(regexp_engine*, SvIV(*ptr));
+        ptr = *pptr;
     }
     else {
-        SV *ptr;
         if (!PL_curcop->cop_hints_hash)
             return &PL_core_reg_engine;
         ptr = cop_hints_fetch_pvs(PL_curcop, "regcomp", 0);
-        if ( !(ptr && SvIOK(ptr) && SvIV(ptr)))
-            return &PL_core_reg_engine;
-        return INT2PTR(regexp_engine*, SvIV(ptr));
     }
+
+    IV iv;
+    if ( !(ptr && SvIOK(ptr) && (iv = SvIV(ptr))) )
+        return &PL_core_reg_engine;
+    return INT2PTR(regexp_engine*, iv);
 }
 
 


### PR DESCRIPTION
The tail of each branch is basically the same, so we can pull out the common code. Also, we don't need to SvIV() twice if we store the result of the first call in a local variable.

Addresses #23364.


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
