### PR TITLE
Update entry for EU::PXS to keep 'Porting/core-cpan-diff' happy

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -528,7 +528,7 @@ our %Modules = (
     },
 
     'ExtUtils::ParseXS' => {
-        'DISTRIBUTION' => 'LEONT/ExtUtils-ParseXS-3.59.tar.gz',
+        'DISTRIBUTION' => 'LEONT/ExtUtils-ParseXS-3.60.tar.gz',
         'FILES'        => q[dist/ExtUtils-ParseXS],
     },
 


### PR DESCRIPTION
Leon, AFAICT ParseXS-3.60 on CPAN is identical to what we have in core under `dist/`, but `%Maintainers::Modules` is still saying 3.59.  Agreed?

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
