### PR TITLE
hints/darwin.sh: Provide reference for poll issue

### DIFF
--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -149,7 +149,8 @@ dlext='bundle';
 usedl='define';
 
 # 10.4 can use dlopen.
-# 10.4 broke poll().
+# 10.4 broke poll(). - Apple bug number 3710161
+# https://lists.apple.com/archives/Darwin-dev/2005/May/msg00220.html
 case "$osvers" in
 [1-7].*)
     dlsrc='dl_dyld.xs';


### PR DESCRIPTION
From OpenSSH 8.9 release notes:
For character-special devices like /dev/null, Darwin's poll(2) returns POLLNVAL when polled with POLLIN. Apparently this is Apple bug 3710161 - not public but a websearch will find other OSS projects rediscovering it periodically since it was first identified in 2005.

https://www.openssh.com/txt/release-8.9