### PR TITLE
t/class/accessor.t - fix Writer copypasta

### DIFF
--- a/t/class/accessor.t
+++ b/t/class/accessor.t
@@ -50,11 +50,11 @@ no warnings 'experimental::class';
 
     # Write accessor wants exactly one argument
     ok(!eval { $o->set_s() },
-        'Reader accessor fails with no argument');
+        'Writer accessor fails with no argument');
     like($@, qr/^Too few arguments for subroutine \'Testcase2::set_s\' \(got 1; expected 2\) at /,
         'Failure from argument to accessor');
     ok(!eval { $o->set_s(1, 2) },
-        'Reader accessor fails with 2 arguments');
+        'Writer accessor fails with 2 arguments');
     like($@, qr/^Too many arguments for subroutine \'Testcase2::set_s\' \(got 3; expected 2\) at /,
         'Failure from argument to accessor');
 }


### PR DESCRIPTION
Writer tests in _t/class/accessor.t_ were presumably copied from reader tests but the test labels were not updated accordingly.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
