### PR TITLE
CLEAR_ERRSV: create a new SV if the existing one isGV_with_GP

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -1947,7 +1947,7 @@ any magic.
     SV ** const svp = &GvSV(PL_errgv);					\
     if (!*svp) {							\
         *svp = newSVpvs("");                                            \
-    } else if (SvREADONLY(*svp)) {					\
+    } else if (SvREADONLY(*svp) || isGV_with_GP(*svp)) {		\
         SvREFCNT_dec_NN(*svp);						\
         *svp = newSVpvs("");						\
     } else {								\

--- a/t/op/eval.t
+++ b/t/op/eval.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan(tests => 172);
+plan(tests => 173);
 
 eval 'pass();';
 
@@ -837,3 +837,5 @@ pass("eval in freed package does not crash");
     }->();
     is($w, 0, "nested eval and closure");
 }
+
+fresh_perl_is('for$@(*0){eval}', '', undef, 'GH #16885 - isGV_with_GP(PL_errgv)');


### PR DESCRIPTION
GH #16885 is a fuzzer-identified assert in Perl_sv_grow. Besides the question of how the program should behave, the actual assertion comes via the `SvPVCLEAR()` statement in `CLEAR_ERRSV`, where `svp` is unexpectedly a PVGV with GV. This commit treats this the same as if `svp` was READONLY - the refcount is decremented and `svp` assigned a brand new SVt_PV.

(I don't know whether #16885 should remain open until any other appropriate behaviour is decided.)

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
