### PR TITLE
Inline hv_common_key_len()

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1522,7 +1522,7 @@ Cp	|void * |hv_common	|NULLOK NOCHECK HV *hv			\
 				|int action				\
 				|NULLOK SV *val 			\
 				|U32 hash
-Cp	|void * |hv_common_key_len					\
+Cip	|void * |hv_common_key_len					\
 				|NULLOK HV *hv				\
 				|NN const char *key			\
 				|I32 klen_i32				\

--- a/hv.c
+++ b/hv.c
@@ -461,26 +461,6 @@ information on how to use this function on tied hashes.
 =cut
 */
 
-/* Common code for hv_delete()/hv_exists()/hv_fetch()/hv_store()  */
-void *
-Perl_hv_common_key_len(pTHX_ HV *hv, const char *key, I32 klen_i32,
-                       const int action, SV *val, const U32 hash)
-{
-    STRLEN klen;
-    int flags;
-
-    PERL_ARGS_ASSERT_HV_COMMON_KEY_LEN;
-
-    if (klen_i32 < 0) {
-        klen = -klen_i32;
-        flags = HVhek_UTF8;
-    } else {
-        klen = klen_i32;
-        flags = 0;
-    }
-    return hv_common(hv, NULL, key, klen, flags, action, val, hash);
-}
-
 void *
 Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
                int flags, int action, SV *val, U32 hash)

--- a/hv.h
+++ b/hv.h
@@ -558,10 +558,12 @@ whether it is valid to call C<HvAUX()>.
 #define hv_exists(hv, key, klen)					\
     cBOOL(hv_common_key_len((hv), (key), (klen), HV_FETCH_ISEXISTS, NULL, 0))
 
-#define hv_fetch(hv, key, klen, lval)					\
-    ((SV**) hv_common_key_len((hv), (key), (klen), (lval)		\
-                              ? (HV_FETCH_JUST_SV | HV_FETCH_LVALUE)	\
-                              : HV_FETCH_JUST_SV, NULL, 0))
+#define hv_fetch(hv, key, klen, lval)					    \
+    ((SV**) hv_common_key_len((hv), (key), (klen),                          \
+                              (HV_FETCH_JUST_SV | ((lval)                   \
+                                                   ? HV_FETCH_LVALUE        \
+                                                   : 0)),                   \
+                              NULL, 0))
 
 #define hv_delete(hv, key, klen, flags)					\
     (MUTABLE_SV(hv_common_key_len((hv), (key), (klen),			\

--- a/inline.h
+++ b/inline.h
@@ -291,6 +291,28 @@ S_strip_spaces(pTHX_ const char * orig, STRLEN * const len)
 }
 #endif
 
+/* ------------------------------- hv.c ------------------------------- */
+
+/* Common code for hv_delete()/hv_exists()/hv_fetch()/hv_store()  */
+PERL_STATIC_INLINE void *
+Perl_hv_common_key_len(pTHX_ HV *hv, const char *key, I32 klen_i32,
+                       const int action, SV *val, const U32 hash)
+{
+    PERL_ARGS_ASSERT_HV_COMMON_KEY_LEN;
+
+    STRLEN klen;
+    int flags;
+
+    if (klen_i32 < 0) {
+        klen = -klen_i32;
+        flags = HVhek_UTF8;
+    } else {
+        klen = klen_i32;
+        flags = 0;
+    }
+    return hv_common(hv, NULL, key, klen, flags, action, val, hash);
+}
+
 /* ------------------------------- iperlsys.h ------------------------------- */
 #if ! defined(PERL_IMPLICIT_SYS) && defined(USE_ITHREADS)
 

--- a/proto.h
+++ b/proto.h
@@ -1536,11 +1536,6 @@ PERL_CALLCONV void *
 Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen, int flags, int action, SV *val, U32 hash);
 #define PERL_ARGS_ASSERT_HV_COMMON
 
-PERL_CALLCONV void *
-Perl_hv_common_key_len(pTHX_ HV *hv, const char *key, I32 klen_i32, const int action, SV *val, const U32 hash);
-#define PERL_ARGS_ASSERT_HV_COMMON_KEY_LEN      \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
-
 PERL_CALLCONV HV *
 Perl_hv_copy_hints_hv(pTHX_ HV * const ohv)
         __attribute__warn_unused_result__;
@@ -9936,6 +9931,11 @@ PERL_STATIC_INLINE MGVTBL *
 Perl_get_vtbl(pTHX_ int vtbl_id)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GET_VTBL
+
+PERL_STATIC_INLINE void *
+Perl_hv_common_key_len(pTHX_ HV *hv, const char *key, I32 klen_i32, const int action, SV *val, const U32 hash);
+# define PERL_ARGS_ASSERT_HV_COMMON_KEY_LEN     \
+        assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
 
 PERL_STATIC_INLINE Size_t
 Perl_isC9_STRICT_UTF8_CHAR(const U8 * const s0, const U8 * const e)


### PR DESCRIPTION
This tiny function is called as an intermediary from several frequently used macros.

* This set of changes does not require a perldelta entry.
