### PR TITLE
Add todo-test for GH 16665 (surprising precedence issue: sort f()->@*)

### DIFF
--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -291,6 +291,12 @@ TODO: {
 }
 
 TODO: {
+    local $::TODO = 'GH 16665';
+    my $results = fresh_perl('sub f {[1,2,3]}; print sort f()->@*', {});
+    is($results, '123', 'function return value sorted before postfix dereference; GH 16665');
+}
+
+TODO: {
     todo_skip "Test needs -DDEBUGGING", 1 unless $is_debugging_build;
     local $::TODO = 'GH 16863';
     fresh_perl(<<~'HERE', { stderr => 'devnull' });


### PR DESCRIPTION
This PR adds a todo-test for #16665 where postfix dereferencing fails to work as [documented](https://perldoc.perl.org/perlref#Postfix-Dereference-Syntax):

> Postfix dereference should work in all circumstances where block (circumfix) dereference worked, and should be entirely equivalent. 

This snippet using the circumfix syntax prints `123`:

```
sub f {[1,2,3]}; print sort @​{f()}
```

However, the postfix variant produces no output:

```
sub f {[1,2,3]}; print sort f()->@*;
```

With warnings enabled, the postfix variant emits `Use of uninitialized value in array dereference`.

---


There are three related issues linked: #16548, #15733, #2305.
I'm wondering if this is the right issue to todo-test, or the others should even get separate tests.

---

* This set of changes does not require a perldelta entry.