### PR TITLE
[Win32] Define I_STDCKDINT and $Config{i_stdckdint} when appropriate.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6788,6 +6788,7 @@ win32/config_H.gc			Win32 config header (MinGW build)
 win32/config_h.PL			Perl code to convert Win32 config.sh to config.h
 win32/config_H.vc			Win32 config header (Visual C++ build)
 win32/config_sh.PL			Perl code to update Win32 config.sh from Makefile
+win32/configure/have_stdckdint.c	check for availability of stdckdint.h
 win32/configure/rt.c			identify default runtime
 win32/create_perllibst_h.pl		creates perllibst.h file for inclusion from perllib.c
 win32/distclean.bat			Remove _ALL_ files not listed here in MANIFEST

--- a/win32/config_sh.PL
+++ b/win32/config_sh.PL
@@ -148,6 +148,12 @@ my $ver = `ver 2>nul`;
 $opt{osvers} = $ver =~ /\b(\d+(?:\.\d+)+)\b/ ? $1 : '4.0';
 
 if (exists $opt{cc}) {
+    system "$opt{cc} -o have_stdckdint.exe configure/have_stdckdint.c 1>nul 2>&1";
+    if  (-e 'have_stdckdint.exe') {
+        $opt{i_stdckdint} = 'define' if `have_stdckdint` eq '0';
+        unlink 'have_stdckdint.exe'; # have_stdckdint.exe no longer needed
+    }
+
     # cl version detection borrowed from Test::Smoke's configsmoke.pl
     if ($opt{cc} =~ /\b(?:cl|icl)/) { #MSVC can come as clarm.exe, icl=Intel C
         my $output = `$opt{cc} 2>&1`;

--- a/win32/configure/have_stdckdint.c
+++ b/win32/configure/have_stdckdint.c
@@ -1,0 +1,42 @@
+/*
+ Check whether stdckdint.h functionality is available.
+ If it's available, then 'have_stdckdint.exe' will be created
+ by config_sh.PL.
+ $Config{i_stdckdint} and the XS symbol I_STDCKDINT will be
+ defined if and only if 'have_stdckdint.exe' prints '0'
+ when executed.
+ Else $Config{i_stdckdint} and I_STDCKDINT will be undef.
+*/
+
+#include <stdio.h>
+#include <stdckdint.h>
+static int func_l(long *resultptr, long a, long b) {
+    return (ckd_add(resultptr, a, b) ||
+	    ckd_sub(resultptr, a, b) ||
+	    ckd_mul(resultptr, a, b)) ? 1 : 0;
+}
+
+static int func_ll(long long *resultptr, long long a, long long b) {
+    return (ckd_add(resultptr, a, b) ||
+	    ckd_sub(resultptr, a, b) ||
+	    ckd_mul(resultptr, a, b)) ? 1 : 0;
+}
+
+int main(void) {
+    long lresult_1, lresult_2;
+    long long llresult_1, llresult_2;
+    int ret, lret_1, lret_2, llret_1, llret_2;
+    lret_1 = func_l(&lresult_1, 42L, 53L);
+    lret_2 = func_l(&lresult_2, 10485777L, 1048555L);
+    llret_1 = func_ll(&llresult_1, 42LL, 53LL);
+    llret_2 = func_ll(&llresult_2, 34359738333LL, 34359738887LL);
+
+    if(lret_1 == 0 && llret_1 == 0 &&
+       lret_2 == 1 && llret_2 == 1 &&
+       lresult_1 == 2226L && llresult_1 == 2226LL &&
+       lresult_2 == -202375525L && llresult_2 == 16630113351947LL )  ret = 0;
+    else ret = -1;
+    printf("%d", ret);
+    return 0;
+}
+


### PR DESCRIPTION
This PR replaces https://github.com/Perl/perl5/pull/23777 (which I botched and closed).

In conjunction with (the already merged) #23703, it will define $Config{i_stdckdint} and I_STDCKDINT on Windows builds of perl whenever stdckdint.h is locatable and functional.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
