### PR TITLE
Ignore "compilation failed" message in test.t

### DIFF
--- a/t/lib/croak/class
+++ b/t/lib/croak/class
@@ -96,7 +96,6 @@ class XXX {
 }
 EXPECT
 Global symbol "$self" requires explicit package name (did you forget to declare "my $self"?) at - line 5.
-Execution of - aborted due to compilation errors.
 ########
 # This test is known to leak: see GH #20812.
 no warnings 'experimental::class';

--- a/t/lib/croak/op
+++ b/t/lib/croak/op
@@ -3,13 +3,11 @@ __END__
 join,
 EXPECT
 Not enough arguments for join or string at - line 1, near "join,"
-Execution of - aborted due to compilation errors.
 ########
 # NAME my $<special>
 my $!;
 EXPECT
 Can't use global $! in "my" at - line 1, near "my $!"
-Execution of - aborted due to compilation errors.
 ########
 # NAME my $<non-ASCII> doesn't output garbage
 # \xB6 is same character in all three EBCDIC pages and Latin1
@@ -70,90 +68,76 @@ use feature 'bitwise';
 @a &= 1;
 EXPECT
 Can't modify array dereference in numeric bitwise and (&) at - line 2, near "1;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME Num-specific |= on @array
 use feature 'bitwise';
 @a |= 1;
 EXPECT
 Can't modify array dereference in numeric bitwise or (|) at - line 2, near "1;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME Num-specific ^= on @array
 use feature 'bitwise';
 @a ^= 1;
 EXPECT
 Can't modify array dereference in numeric bitwise xor (^) at - line 2, near "1;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME &.= on @array
 use feature 'bitwise';
 @a &.= 1;
 EXPECT
 Can't modify array dereference in string bitwise and (&.) at - line 2, near "1;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME |.= on @array
 use feature 'bitwise';
 @a |.= 1;
 EXPECT
 Can't modify array dereference in string bitwise or (|.) at - line 2, near "1;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME ^.= on @array
 use feature 'bitwise';
 @a ^.= 1;
 EXPECT
 Can't modify array dereference in string bitwise xor (^.) at - line 2, near "1;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME substr %h in scalar assignment
 substr(%h,0) = 3;
 EXPECT
 Can't modify hash dereference in substr at - line 1, near "3;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME substr %h in list assignment
 (substr %h,0) = 3;
 EXPECT
 Can't modify hash dereference in substr at - line 1, near "3;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME vec %h in scalar assignment
 vec(%h,1,1) = 3;
 EXPECT
 Can't modify hash dereference in vec at - line 1, near "3;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME vec %h in list assignment
 (vec %h,1,1) = 3;
 EXPECT
 Can't modify hash dereference in vec at - line 1, near "3;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME Can't declare conditional
 my($a?$b:$c)
 EXPECT
 Can't declare conditional expression in "my" at - line 1, at EOF
-Execution of - aborted due to compilation errors.
 ########
 # NAME Can't declare do block
 my(do{})
 EXPECT
 Can't declare do block in "my" at - line 1, at EOF
-Execution of - aborted due to compilation errors.
 ########
 # NAME ($_, state $x) = ...
 ($_, CORE::state $x) = ();
 EXPECT
 Initialization of state variables in list currently forbidden at - line 1, near ");"
-Execution of - aborted due to compilation errors.
 ########
 # NAME my $y; ($y, state $x) = ...
 my $y; ($y, CORE::state $x) = ();
 EXPECT
 Initialization of state variables in list currently forbidden at - line 1, near ");"
-Execution of - aborted due to compilation errors.
 ########
 # NAME delete BAD
 delete $x;
@@ -180,43 +164,36 @@ exists argument is not a subroutine name at - line 1.
 push FRED;
 EXPECT
 Type of arg 1 to push must be array (not constant item) at - line 1, near "FRED;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME pop BAREWORD
 pop FRED;
 EXPECT
 Type of arg 1 to pop must be array (not constant item) at - line 1, near "FRED;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME shift BAREWORD
 shift FRED;
 EXPECT
 Type of arg 1 to shift must be array (not constant item) at - line 1, near "FRED;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME unshift BAREWORD
 unshift FRED;
 EXPECT
 Type of arg 1 to unshift must be array (not constant item) at - line 1, near "FRED;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME keys BAREWORD
 @a = keys FRED ;
 EXPECT
 Type of arg 1 to keys must be hash or array (not constant item) at - line 1, near "FRED ;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME values BAREWORD
 @a = values FRED ;
 EXPECT
 Type of arg 1 to values must be hash or array (not constant item) at - line 1, near "FRED ;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME each BAREWORD
 @a = each FRED ;
 EXPECT
 Type of arg 1 to each must be hash or array (not constant item) at - line 1, near "FRED ;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME better messages for array-ops on non-arrays
 push %a, 1;
@@ -236,7 +213,6 @@ Type of arg 1 to push must be array (not ref-to-glob cast) at - line 5, near "1;
 Type of arg 1 to pop must be array (not ref-to-glob cast) at - line 6, near "*a;"
 Type of arg 1 to shift must be array (not ref-to-glob cast) at - line 7, near "*a;"
 Type of arg 1 to unshift must be array (not ref-to-glob cast) at - line 8, near "1;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME better messages for array-ops on non-arrays (part 2)
 # to check PADHV without hitting the reported error limit
@@ -250,7 +226,6 @@ Type of arg 1 to push must be array (not private hash) at - line 3, near "1;"
 Type of arg 1 to pop must be array (not private hash) at - line 4, near "%a;"
 Type of arg 1 to shift must be array (not private hash) at - line 5, near "%a;"
 Type of arg 1 to unshift must be array (not private hash) at - line 6, near "1;"
-Execution of - aborted due to compilation errors.
 ########
 use feature 'defer';
 no warnings 'experimental::defer';
@@ -307,7 +282,6 @@ sub xx {
 }
 EXPECT
 Missing comma after first argument to return at - line 2, near "5;"
-Execution of - aborted due to compilation errors.
 ########
 # subsequent use VERSION to 5.39
 use v5.20;
@@ -333,7 +307,6 @@ no warnings 'experimental::keyword_any';
 any length, qw( a b c )
 EXPECT
 syntax error at - line 4, near "any length"
-Execution of - aborted due to compilation errors.
 ########
 # all with deferred LIST expression
 use feature 'keyword_all';
@@ -341,4 +314,3 @@ no warnings 'experimental::keyword_all';
 all length, qw( a b c )
 EXPECT
 syntax error at - line 4, near "all length"
-Execution of - aborted due to compilation errors.

--- a/t/lib/croak/parser
+++ b/t/lib/croak/parser
@@ -4,4 +4,3 @@ sub all (&@);
 all { $_->[0] } map { [ }
 EXPECT
 syntax error at - line 2, near "[ }"
-Execution of - aborted due to compilation errors.

--- a/t/lib/croak/toke
+++ b/t/lib/croak/toke
@@ -4,7 +4,6 @@ myfunc 1,2,3
 EXPECT
 Number found where operator expected (Do you need to predeclare "myfunc"?) at - line 1, near "myfunc 1"
 syntax error at - line 1, near "myfunc 1"
-Execution of - aborted due to compilation errors.
 ########
 # NAME foo found where operator expected (after strict error, w/fatal warnings)
 use warnings FATAL => 'all';
@@ -15,21 +14,18 @@ EXPECT
 Global symbol "$foo" requires explicit package name (did you forget to declare "my $foo"?) at - line 3.
 Number found where operator expected (Do you need to predeclare "myfunc"?) at - line 4, near "myfunc 1"
 syntax error at - line 4, near "myfunc 1"
-Execution of - aborted due to compilation errors.
 ########
 # NAME (Missing operator before "${"?) [perl #123737]
 0${
 EXPECT
 Scalar found where operator expected (Missing operator before "${"?) at - line 1, near "0${"
 syntax error at - line 1, near "0$"
-Execution of - aborted due to compilation errors.
 ########
 # NAME (Missing operator before "$#{"?) [perl #123737]
 0$#{
 EXPECT
 Array length found where operator expected (Missing operator before "$#{"?) at - line 1, near "0$#{"
 syntax error at - line 1, near "0$#"
-Execution of - aborted due to compilation errors.
 ########
 # NAME (Missing operator before "@foo") [perl #123737]
 0@foo
@@ -37,14 +33,12 @@ EXPECT
 Array found where operator expected (Missing operator before "@foo"?) at - line 1, near "0@foo"
 syntax error at - line 1, near "0@foo
 "
-Execution of - aborted due to compilation errors.
 ########
 # NAME (Missing operator before "@{") [perl #123737]
 0@{
 EXPECT
 Array found where operator expected (Missing operator before "@{"?) at - line 1, near "0@{"
 syntax error at - line 1, near "0@"
-Execution of - aborted due to compilation errors.
 ########
 # NAME Unterminated here-doc in string eval
 eval "<<foo"; die $@
@@ -163,7 +157,6 @@ Can't find string terminator "《" anywhere before EOF at - line 3.
 /\N{/
 EXPECT
 Missing right brace on \N{} or unescaped left brace after \N at - line 1, within pattern
-Execution of - aborted due to compilation errors.
 ########
 # NAME map{for our *a...
 map{for our *a (1..10) {$_.=$x}}
@@ -190,7 +183,6 @@ Missing name in "state sub" at - line 2.
 our sub foo::bar;
 EXPECT
 No package name allowed for subroutine &foo::bar in "our" at - line 1, near "our sub foo::bar"
-Execution of - aborted due to compilation errors.
 ########
 # NAME my sub pack::foo
 use feature 'lexical_subs', 'state';
@@ -199,7 +191,6 @@ state sub foo::bear;
 EXPECT
 "my" subroutine &foo::bar can't be in a package at - line 2, near "my sub foo::bar"
 "state" subroutine &foo::bear can't be in a package at - line 3, near "state sub foo::bear"
-Execution of - aborted due to compilation errors.
 ########
 # NAME Integer constant overloading returning undef
 use overload;
@@ -207,7 +198,6 @@ BEGIN { overload::constant integer => sub {}; undef *^H }
 1
 EXPECT
 Constant(1) unknown at - line 3, at end of line
-Execution of - aborted due to compilation errors.
 ########
 # NAME Float constant overloading returning undef
 use overload;
@@ -215,7 +205,6 @@ BEGIN { overload::constant float => sub {}; undef *^H }
 1.1
 EXPECT
 Constant(1.1) unknown at - line 3, at end of line
-Execution of - aborted due to compilation errors.
 ########
 # NAME Binary constant overloading returning undef
 use overload;
@@ -223,7 +212,6 @@ BEGIN { overload::constant binary => sub {}; undef *^H }
 0x1
 EXPECT
 Constant(0x1) unknown at - line 3, at end of line
-Execution of - aborted due to compilation errors.
 ########
 # NAME String constant overloading returning undef
 use overload;
@@ -234,7 +222,6 @@ Constant(q) unknown at - line 3, near "'1'"
 Constant(qq) unknown at - line 3, within string
 Constant(tr) unknown at - line 3, within string
 Constant(s) unknown at - line 3, within string
-Execution of - aborted due to compilation errors.
 ########
 # NAME Regexp constant overloading when *^H is undefined
 use overload;
@@ -242,7 +229,6 @@ BEGIN { overload::constant qr => sub {}; undef *^H }
 /a/
 EXPECT
 Constant(qq) unknown at - line 3, within pattern
-Execution of - aborted due to compilation errors.
 ########
 # NAME Regexp constant overloading when *^H is undefined
 use overload;
@@ -250,7 +236,6 @@ BEGIN { overload::constant qr => sub {}; undef *^H }
 m'a'
 EXPECT
 Constant(q) unknown at - line 3, within pattern
-Execution of - aborted due to compilation errors.
 ########
 # NAME \N{...} when charnames fails to load but without an error
 # SKIP ? exists $ENV{PERL_UNICODE} ? "Unreliable under some PERL_UNICODE settings" : 0
@@ -258,7 +243,6 @@ BEGIN { ++$_ for @INC{"charnames.pm","_charnames.pm"} }
 "\N{a}"
 EXPECT
 Constant(\N{a}) unknown at - line 2, within string
-Execution of - aborted due to compilation errors.
 ########
 # NAME Integer constant overloading returning undef
 use overload;
@@ -266,7 +250,6 @@ BEGIN { overload::constant integer => sub {} }
 1
 EXPECT
 Constant(1): Call to &{$^H{integer}} did not return a defined value at - line 3, at end of line
-Execution of - aborted due to compilation errors.
 ########
 # NAME Float constant overloading returning undef
 use overload;
@@ -274,7 +257,6 @@ BEGIN { overload::constant float => sub {} }
 1.1
 EXPECT
 Constant(1.1): Call to &{$^H{float}} did not return a defined value at - line 3, at end of line
-Execution of - aborted due to compilation errors.
 ########
 # NAME Binary constant overloading returning undef
 use overload;
@@ -282,7 +264,6 @@ BEGIN { overload::constant binary => sub {} }
 0x1
 EXPECT
 Constant(0x1): Call to &{$^H{binary}} did not return a defined value at - line 3, at end of line
-Execution of - aborted due to compilation errors.
 ########
 # NAME String constant overloading returning undef
 use overload;
@@ -293,7 +274,6 @@ Constant(q): Call to &{$^H{q}} did not return a defined value at - line 3, near 
 Constant(qq): Call to &{$^H{q}} did not return a defined value at - line 3, within string
 Constant(tr): Call to &{$^H{q}} did not return a defined value at - line 3, within string
 Constant(s): Call to &{$^H{q}} did not return a defined value at - line 3, within string
-Execution of - aborted due to compilation errors.
 ########
 # NAME Regexp constant overloading returning undef
 use overload;
@@ -301,7 +281,6 @@ BEGIN { overload::constant qr => sub {} }
 /a/
 EXPECT
 Constant(qq): Call to &{$^H{qr}} did not return a defined value at - line 3, within pattern
-Execution of - aborted due to compilation errors.
 ########
 # NAME Regexp constant overloading returning undef
 use overload;
@@ -309,7 +288,6 @@ BEGIN { overload::constant qr => sub {} }
 m'a'
 EXPECT
 Constant(q): Call to &{$^H{qr}} did not return a defined value at - line 3, within pattern
-Execution of - aborted due to compilation errors.
 ########
 # NAME Failed constant overloading should not cause a double free
 use overload;
@@ -382,46 +360,39 @@ Unterminated delimiter for here document at - line 1.
 my (our $x);
 EXPECT
 Can't redeclare "our" in "my" at - line 1, near "(our"
-Execution of - aborted due to compilation errors.
 ########
 # NAME our (my $x) errors
 our (my $x);
 EXPECT
 Can't redeclare "my" in "our" at - line 1, near "(my"
-Execution of - aborted due to compilation errors.
 ########
 # NAME state (my $x) errors
 use feature 'state';
 state (my $x);
 EXPECT
 Can't redeclare "my" in "state" at - line 2, near "(my"
-Execution of - aborted due to compilation errors.
 ########
 # NAME our (state $x) errors
 use feature 'state';
 our (state $x);
 EXPECT
 Can't redeclare "state" in "our" at - line 2, near "(state"
-Execution of - aborted due to compilation errors.
 ########
 # NAME my (my $x) errors
 my (my $x, $y, $z);
 EXPECT
 Can't redeclare "my" in "my" at - line 1, near "(my"
-Execution of - aborted due to compilation errors.
 ########
 # NAME our (our $x) errors
 our ($x, our($y), $z);
 EXPECT
 Can't redeclare "our" in "our" at - line 1, near ", our"
-Execution of - aborted due to compilation errors.
 ########
 # NAME state (state $x) errors
 use feature 'state';
 state ($x, $y, state $z);
 EXPECT
 Can't redeclare "state" in "state" at - line 2, near ", state"
-Execution of - aborted due to compilation errors.
 ########
 # NAME catch (my $x) errors
 use feature 'try';
@@ -429,7 +400,6 @@ try {} catch (my $x) {}
 EXPECT
 Can't redeclare catch variable as "my" at - line 2, near "(my"
 syntax error at - line 2, near "(my "
-Execution of - aborted due to compilation errors.
 ########
 # NAME catch (our $x) errors
 use feature 'try';
@@ -437,7 +407,6 @@ try {} catch (our $x) {}
 EXPECT
 Can't redeclare catch variable as "our" at - line 2, near "(our"
 syntax error at - line 2, near "(our "
-Execution of - aborted due to compilation errors.
 ########
 # NAME catch (state $x) errors
 use feature 'try', 'state';
@@ -445,7 +414,6 @@ try {} catch (state $x) {}
 EXPECT
 Can't redeclare catch variable as "state" at - line 2, near "(state"
 syntax error at - line 2, near "(state "
-Execution of - aborted due to compilation errors.
 ########
 # NAME BEGIN <> [perl #125341]
 BEGIN <>
@@ -463,7 +431,6 @@ EXPECT
 Version control conflict marker at - line 1, near "<CONFLICT<"
 Version control conflict marker at - line 3, near "=CONFLICT="
 Version control conflict marker at - line 5, near ">CONFLICT>"
-Execution of - aborted due to compilation errors.
 ########
 # NAME (Might be a runaway multi-line...) with Latin-1 delimiters in utf8
 BEGIN { binmode STDERR, ':utf8' }
@@ -474,7 +441,6 @@ q«
 EXPECT
 syntax error at - line 5, near "« time"
   (Might be a runaway multi-line «« string starting on line 4)
-Execution of - aborted due to compilation errors.
 ########
 # NAME (Might be a runaway multi-line...) with non-Latin-1 delimiters
 BEGIN { binmode STDERR, ':utf8' }
@@ -484,14 +450,12 @@ q ϡ
 EXPECT
 syntax error at - line 4, near "ϡ time"
   (Might be a runaway multi-line ϡϡ string starting on line 3)
-Execution of - aborted due to compilation errors.
 ########
 # NAME tr/// handling of mis-formatted \o characters
 # may only fail with ASAN
 tr/\o-0//;
 EXPECT
 Missing braces on \o{} at - line 2, within string
-Execution of - aborted due to compilation errors.
 ########
 # NAME bare <<
 $a = <<;
@@ -515,7 +479,6 @@ Use of bare << to mean <<"" is forbidden at - line 1.
 EXPECT
 Bareword found where operator expected (Missing operator before "e"?) at - line 1, near "1e"
 syntax error at - line 1, near "1e"
-Execution of - aborted due to compilation errors.
 ########
 # NAME signature with non-"=" assignop #131777
 use feature 'signatures';
@@ -523,13 +486,11 @@ sub foo ($a += 1)
 EXPECT
 Illegal operator following parameter in a subroutine signature at - line 2, near "($a += 1"
 syntax error at - line 2, near "($a += 1"
-Execution of - aborted due to compilation errors.
 ########
 # NAME tr/// range with empty \N{} at the start
 tr//\N{}-0/;
 EXPECT
 Unknown charname '' at - line 1, within string
-Execution of - aborted due to compilation errors.
 ########
 # NAME octal fp with non-octal digits after the decimal point
 01.1234567p0;
@@ -537,7 +498,6 @@ Execution of - aborted due to compilation errors.
 EXPECT
 Bareword found where operator expected (Missing operator before "p0"?) at - line 2, near "8p0"
 syntax error at - line 2, near "8p0"
-Execution of - aborted due to compilation errors.
 ########
 # NAME binary fp with non-binary digits after the decimal point
 0b1.10p0;
@@ -545,7 +505,6 @@ Execution of - aborted due to compilation errors.
 EXPECT
 Bareword found where operator expected (Missing operator before "p0"?) at - line 2, near "2p0"
 syntax error at - line 2, near "2p0"
-Execution of - aborted due to compilation errors.
 ########
 # NAME dump() must be written as CORE::dump() as of Perl 5.30
 BEGIN { $^C = 1; }
@@ -567,7 +526,6 @@ format=
 =cut
 EXPECT
 syntax error at - line 4, next token ???
-Execution of - aborted due to compilation errors.
 ########
 # NAME [perl #134125] [gh #17010] incomplete hex number
 0x x 2;
@@ -579,13 +537,11 @@ No digits found for hexadecimal literal at - line 1, near "0x "
 No digits found for hexadecimal literal at - line 2, near "0xx"
 No digits found for hexadecimal literal at - line 3, near "0x_;"
 No digits found for binary literal at - line 4, near "0b;"
-Execution of - aborted due to compilation errors.
 ########
 # NAME [perl #130585] close paren in subparse
 qr!@{s{0})(?{!;
 EXPECT
 syntax error at - line 1, near "})"
-Execution of - aborted due to compilation errors.
 ########
 # NAME [perl #130585] close paren in subparse - a few more tests
 my ($x, %y, @z);
@@ -593,7 +549,6 @@ qq!$x\U $z[0] $y{a}\E $z[1]!;
 qq!$x\U@{s{0})(?{!;
 EXPECT
 syntax error at - line 3, near ")("
-Execution of - aborted due to compilation errors.
 ########
 # NAME [perl #134310] don't confuse S_no_op() with PL_bufptr after s
 0 0x@
@@ -601,7 +556,6 @@ EXPECT
 Number found where operator expected (Missing operator before "0x"?) at - line 1, near "0 0x"
 No digits found for hexadecimal literal at - line 1, near "0 0x@"
 syntax error at - line 1, near "0 0x"
-Execution of - aborted due to compilation errors.
 ########
 # NAME Forbid illegal \x{} code points
 use Config;
@@ -634,7 +588,6 @@ EXPECT
 syntax error at - line 2, near "[
 =="
   (Might be a runaway multi-line // string starting on line 1)
-Execution of - aborted due to compilation errors.
 ########
 # NAME tick in names: initial character of sub name (reverted)
 sub 'Hello'_he_said (_);
@@ -647,7 +600,6 @@ sub 'Hello'_he_said (_);
 EXPECT
 Bareword found where operator expected (Missing operator before "_he_said"?) at - line 2, near "'Hello'_he_said"
 Illegal declaration of anonymous subroutine at - line 2, near "sub 'Hello'"
-Execution of - aborted due to compilation errors.
 ########
 # NAME tick in names: initial character of format name (reverted)
     format 'one =
@@ -666,4 +618,3 @@ $test
 EXPECT
 syntax error at - line 3, near "ok @<< - format '"
   (Might be a runaway multi-line '' string starting on line 2)
-Execution of - aborted due to compilation errors.

--- a/t/lib/feature/bareword_filehandles
+++ b/t/lib/feature/bareword_filehandles
@@ -129,7 +129,6 @@ EXPECT
 OPTIONS fatal
 Number found where operator expected (Do you need to predeclare "FOO"?) at - line 2, near "FOO 1"
 Missing comma after first argument to atan2 function at - line 2, near "2)"
-Execution of - aborted due to compilation errors.
 ########
 # NAME print HANDLE LIST, printf HANDLE LIST, print HANDLE, printf HANDLE
 use File::Spec;
@@ -156,7 +155,6 @@ Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' 
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 10.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 11.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 12.
-Execution of - aborted due to compilation errors.
 ########
 # NAME say HANDLE LIST, say HANDLE
 use File::Spec;
@@ -172,7 +170,6 @@ EXPECT
 OPTIONS fatal
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 8.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 9.
-Execution of - aborted due to compilation errors.
 ########
 # NAME readline FOO, readline, <>, <FOO>
 use File::Spec;
@@ -200,7 +197,6 @@ Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' 
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 13.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 14.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 15.
-Execution of - aborted due to compilation errors.
 ########
 # NAME truncate
 use strict;
@@ -216,7 +212,6 @@ truncate FOO, 1;
 EXPECT
 OPTIONS fatal
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 10.
-Execution of - aborted due to compilation errors.
 ########
 # NAME stat, lstat, -X
 use File::Spec;
@@ -233,7 +228,6 @@ OPTIONS fatal
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 7.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 8.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 9.
-Execution of - aborted due to compilation errors.
 ########
 # NAME open, close, eof, fileno
 use File::Spec;
@@ -252,7 +246,6 @@ Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' 
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 8.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 9.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 10.
-Execution of - aborted due to compilation errors.
 ########
 # NAME flock
 use Fcntl ":flock";
@@ -263,7 +256,6 @@ flock FOO, LOCK_UN;
 EXPECT
 OPTIONS fatal
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 5.
-Execution of - aborted due to compilation errors.
 ########
 # NAME getc, read, seek, tell
 open FOO, "<", $0 or die;
@@ -282,7 +274,6 @@ Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' 
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 8.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 9.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 10.
-Execution of - aborted due to compilation errors.
 ########
 # NAME select
 open FOO, "<", $0 or die;
@@ -293,7 +284,6 @@ select $old;
 EXPECT
 OPTIONS fatal
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 4.
-Execution of - aborted due to compilation errors.
 ########
 # NAME sysopen, sysread, syswrite, sysseek
 use Fcntl;
@@ -314,7 +304,6 @@ Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' 
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 10.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 11.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 12.
-Execution of - aborted due to compilation errors.
 ########
 # NAME pipe
 my $fh;
@@ -331,7 +320,6 @@ Bareword filehandle "IN" not allowed under 'no feature "bareword_filehandles"' a
 Bareword filehandle "OUT" not allowed under 'no feature "bareword_filehandles"' at - line 7.
 Bareword filehandle "IN" not allowed under 'no feature "bareword_filehandles"' at - line 8.
 Bareword filehandle "OUT" not allowed under 'no feature "bareword_filehandles"' at - line 8.
-Execution of - aborted due to compilation errors.
 ########
 # NAME socket, connect, bind, listen
 my $fh;
@@ -351,7 +339,6 @@ Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' 
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 9.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 10.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 11.
-Execution of - aborted due to compilation errors.
 ########
 # NAME accept
 accept(FOO, CHILD);
@@ -368,7 +355,6 @@ Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' 
 Bareword filehandle "CHILD" not allowed under 'no feature "bareword_filehandles"' at - line 5.
 Bareword filehandle "CHILD" not allowed under 'no feature "bareword_filehandles"' at - line 6.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 7.
-Execution of - aborted due to compilation errors.
 ########
 # NAME accept some more
 accept FOO, CHILD ;
@@ -387,7 +373,6 @@ Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' 
 Bareword filehandle "CHILD" not allowed under 'no feature "bareword_filehandles"' at - line 5.
 Bareword filehandle "CHILD" not allowed under 'no feature "bareword_filehandles"' at - line 6.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 7.
-Execution of - aborted due to compilation errors.
 ########
 # NAME send, recv, setsockopt, getsockopt
 send FOO, "abc", 0;
@@ -405,7 +390,6 @@ Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' 
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 7.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 8.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 9.
-Execution of - aborted due to compilation errors.
 ########
 # NAME shutdown, getsockname, getpeername
 shutdown FOO, 0;
@@ -420,7 +404,6 @@ OPTIONS fatal
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 5.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 6.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 7.
-Execution of - aborted due to compilation errors.
 ########
 # NAME socketpair
 my $fh;
@@ -437,7 +420,6 @@ Bareword filehandle "IN" not allowed under 'no feature "bareword_filehandles"' a
 Bareword filehandle "OUT" not allowed under 'no feature "bareword_filehandles"' at - line 7.
 Bareword filehandle "IN" not allowed under 'no feature "bareword_filehandles"' at - line 8.
 Bareword filehandle "OUT" not allowed under 'no feature "bareword_filehandles"' at - line 8.
-Execution of - aborted due to compilation errors.
 ########
 # NAME binmode, ioctl, fcntl
 binmode FOO;
@@ -455,7 +437,6 @@ Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' 
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 7.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 8.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 9.
-Execution of - aborted due to compilation errors.
 ########
 # NAME opendir, closedir, readdir
 opendir FOO, ".";
@@ -473,7 +454,6 @@ Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' 
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 7.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 8.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 9.
-Execution of - aborted due to compilation errors.
 ########
 # NAME seekdir, telldir, rewinddir
 use strict;
@@ -489,7 +469,6 @@ OPTIONS fatal
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 6.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 7.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 8.
-Execution of - aborted due to compilation errors.
 ########
 # NAME file tests
 -T FOO;
@@ -502,7 +481,6 @@ EXPECT
 OPTIONS fatal
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 4.
 Bareword filehandle "FOO" not allowed under 'no feature "bareword_filehandles"' at - line 5.
-Execution of - aborted due to compilation errors.
 ########
 # NAME subroutine calls
 use feature "say";
@@ -567,4 +545,3 @@ open my $fh4, ">&", BAREWORD;
 EXPECT
 OPTIONS fatal
 Bareword filehandle "BAREWORD" not allowed under 'no feature "bareword_filehandles"' at - line 6.
-Execution of - aborted due to compilation errors.

--- a/t/lib/feature/bits
+++ b/t/lib/feature/bits
@@ -8,7 +8,6 @@ say "Fail";
 EXPECT
 String found where operator expected (Do you need to predeclare "say"?) at - line 3, near "say "Fail""
 syntax error at - line 3, near "say "Fail""
-Execution of - aborted due to compilation errors.
 ########
 # NAME check copying $^H restores the bits
 use feature 'say';
@@ -29,7 +28,6 @@ say "Goodbye";
 EXPECT
 String found where operator expected (Do you need to predeclare "say"?) at - line 4, near "say "Goodbye""
 syntax error at - line 4, near "say "Goodbye""
-Execution of - aborted due to compilation errors.
 ########
 # NAME check deleting entries (bypass feature.pm) clears the bits
 use feature 'say';
@@ -39,4 +37,3 @@ say "Goodbye";
 EXPECT
 String found where operator expected (Do you need to predeclare "say"?) at - line 4, near "say "Goodbye""
 syntax error at - line 4, near "say "Goodbye""
-Execution of - aborted due to compilation errors.

--- a/t/lib/feature/indirect
+++ b/t/lib/feature/indirect
@@ -25,7 +25,6 @@ EXPECT
 OPTIONS fatal
 Bareword found where operator expected (Do you need to predeclare "new"?) at - line 19, near "new Foo"
 syntax error at - line 19, near "new Foo"
-Execution of - aborted due to compilation errors.
 ########
 # NAME METHOD BLOCK
 use feature 'say';
@@ -61,7 +60,6 @@ my $z = new { $class };
 EXPECT
 OPTIONS fatal
 syntax error at - line 29, near "new { "
-Execution of - aborted due to compilation errors.
 ########
 # NAME METHOD SCALAR
 use feature 'say';
@@ -98,7 +96,6 @@ EXPECT
 OPTIONS fatal
 Scalar found where operator expected (Do you need to predeclare "new"?) at - line 29, near "new $class"
 syntax error at - line 29, near "new $class"
-Execution of - aborted due to compilation errors.
 ########
 # NAME FUNCMETH SCALAR
 use feature 'say';
@@ -135,4 +132,3 @@ EXPECT
 OPTIONS fatal
 Scalar found where operator expected (Do you need to predeclare "new"?) at - line 29, near "new $class"
 syntax error at - line 29, near "new $class "
-Execution of - aborted due to compilation errors.

--- a/t/lib/feature/say
+++ b/t/lib/feature/say
@@ -9,7 +9,6 @@ EXPECT
 Unquoted string "say" may clash with future reserved word at - line 3.
 String found where operator expected (Do you need to predeclare "say"?) at - line 3, near "say "Hello""
 syntax error at - line 3, near "say "Hello""
-Execution of - aborted due to compilation errors.
 ########
 # With say, should work
 use warnings;
@@ -33,7 +32,6 @@ EXPECT
 Unquoted string "say" may clash with future reserved word at - line 4.
 String found where operator expected (Do you need to predeclare "say"?) at - line 4, near "say "Hello""
 syntax error at - line 4, near "say "Hello""
-Execution of - aborted due to compilation errors.
 ########
 # 'no feature' should work
 use warnings;
@@ -45,7 +43,6 @@ EXPECT
 Unquoted string "say" may clash with future reserved word at - line 6.
 String found where operator expected (Do you need to predeclare "say"?) at - line 6, near "say "Hello""
 syntax error at - line 6, near "say "Hello""
-Execution of - aborted due to compilation errors.
 ########
 # 'no feature "say"' should work too
 use warnings;
@@ -57,4 +54,3 @@ EXPECT
 Unquoted string "say" may clash with future reserved word at - line 6.
 String found where operator expected (Do you need to predeclare "say"?) at - line 6, near "say "Hello""
 syntax error at - line 6, near "say "Hello""
-Execution of - aborted due to compilation errors.

--- a/t/lib/feature/smartmatch
+++ b/t/lib/feature/smartmatch
@@ -13,7 +13,6 @@ my $y = "b" ~~ @x;
 EXPECT
 OPTION fatal
 syntax error at - line 3, near ""b" ~"
-Execution of - aborted due to compilation errors.
 ########
 # NAME explicit enable
 use feature "smartmatch";
@@ -35,7 +34,6 @@ my $y = "b" ~~ @x;
 EXPECT
 OPTION fatal
 syntax error at - line 3, near ""b" ~"
-Execution of - aborted due to compilation errors.
 ########
 # NAME implicit disable then enable
 use v5.41;
@@ -67,7 +65,6 @@ OPTION fatal
 switch is not enabled
 smartmatch is enabled
 syntax error at - line 13, near ") {"
-Execution of - aborted due to compilation errors.
 ########
 # NAME smartmatch and switch features independent
 use feature "switch";
@@ -93,4 +90,3 @@ OPTION fatal
 switch is enabled
 smartmatch is not enabled
 syntax error at - line 18, near ""b" ~"
-Execution of - aborted due to compilation errors.

--- a/t/lib/strict/subs
+++ b/t/lib/strict/subs
@@ -30,7 +30,6 @@ my @a = (1..2);
 my $b = xyz;
 EXPECT
 Bareword "xyz" not allowed while "strict subs" in use at - line 5.
-Execution of - aborted due to compilation errors.
 ########
 
 # strict subs - error
@@ -38,7 +37,6 @@ use strict 'subs' ;
 Fred ;
 EXPECT
 Bareword "Fred" not allowed while "strict subs" in use at - line 4.
-Execution of - aborted due to compilation errors.
 ########
 
 # strict subs - error
@@ -47,7 +45,6 @@ my @a = (A..Z);
 EXPECT
 Bareword "A" not allowed while "strict subs" in use at - line 4.
 Bareword "Z" not allowed while "strict subs" in use at - line 4.
-Execution of - aborted due to compilation errors.
 ########
 
 # strict subs - error
@@ -56,7 +53,6 @@ my $a = (B..Y);
 EXPECT
 Bareword "B" not allowed while "strict subs" in use at - line 4.
 Bareword "Y" not allowed while "strict subs" in use at - line 4.
-Execution of - aborted due to compilation errors.
 ########
 
 # strict subs - error
@@ -64,7 +60,6 @@ use strict ;
 Fred ;
 EXPECT
 Bareword "Fred" not allowed while "strict subs" in use at - line 4.
-Execution of - aborted due to compilation errors.
 ########
 
 # strict subs - no error
@@ -84,7 +79,6 @@ use strict 'subs' ;
 my $a = Fred ;
 EXPECT
 Bareword "Fred" not allowed while "strict subs" in use at - line 8.
-Execution of - aborted due to compilation errors.
 ########
 
 # Check compile time scope of strict subs pragma
@@ -96,7 +90,6 @@ no strict;
 my $a = Fred ;
 EXPECT
 Bareword "Fred" not allowed while "strict subs" in use at - line 6.
-Execution of - aborted due to compilation errors.
 ########
 
 # Check compile time scope of strict vars pragma
@@ -109,7 +102,6 @@ $joe = 1 ;
 EXPECT
 Variable "$joe" is not imported at - line 8.
 Global symbol "$joe" requires explicit package name (did you forget to declare "my $joe"?) at - line 8.
-Execution of - aborted due to compilation errors.
 ########
 
 # Check compile time scope of strict vars pragma
@@ -121,7 +113,6 @@ no strict;
 $joe = 1 ;
 EXPECT
 Global symbol "$joe" requires explicit package name (did you forget to declare "my $joe"?) at - line 6.
-Execution of - aborted due to compilation errors.
 ########
 
 # Check runtime scope of strict refs pragma
@@ -167,7 +158,6 @@ use strict 'subs' ;
 my $a = Fred ;
 EXPECT
 Bareword "Fred" not allowed while "strict subs" in use at - line 3.
-Execution of - aborted due to compilation errors.
 ########
 
 --FILE-- abc
@@ -236,7 +226,6 @@ print STDERR $@;
 my $a = Fred ;
 EXPECT
 Bareword "Fred" not allowed while "strict subs" in use at - line 6.
-Execution of - aborted due to compilation errors.
 ########
 
 # Check scope of pragma with eval
@@ -249,7 +238,6 @@ my $a = Fred ;
 EXPECT
 Bareword "Fred" not allowed while "strict subs" in use at - line 5.
 Bareword "Fred" not allowed while "strict subs" in use at - line 8.
-Execution of - aborted due to compilation errors.
 ########
 
 # Check scope of pragma with eval
@@ -262,7 +250,6 @@ print STDERR $@;
 my $a = Fred ;
 EXPECT
 Bareword "Fred" not allowed while "strict subs" in use at - line 9.
-Execution of - aborted due to compilation errors.
 ########
 
 # Check scope of pragma with eval
@@ -303,7 +290,6 @@ eval '
 my $a = Fred ;
 EXPECT
 Bareword "Fred" not allowed while "strict subs" in use at - line 8.
-Execution of - aborted due to compilation errors.
 ########
 
 # see if Foo->Bar(...) etc work under strictures
@@ -333,7 +319,6 @@ use strict;
 "" =~ foo;
 EXPECT
 Bareword "foo" not allowed while "strict subs" in use at - line 4.
-Execution of - aborted due to compilation errors.
 
 ########
 
@@ -344,7 +329,6 @@ my $abc = XYZ ? 1 : 0;
 print "$abc\n";
 EXPECT
 Bareword "XYZ" not allowed while "strict subs" in use at - line 5.
-Execution of - aborted due to compilation errors.
 ########
 
 # [perl #10021]
@@ -353,14 +337,12 @@ use warnings;
 print "" if BAREWORD;
 EXPECT
 Bareword "BAREWORD" not allowed while "strict subs" in use at - line 5.
-Execution of - aborted due to compilation errors.
 ########
 # Ticket: 18927
 use strict 'subs';
 print 1..1, bad;
 EXPECT
 Bareword "bad" not allowed while "strict subs" in use at - line 3.
-Execution of - aborted due to compilation errors.
 ########
 eval q{ use strict; no strict refs; };
 print $@;
@@ -372,14 +354,12 @@ use strict;
 print "" if BAREWORD;
 EXPECT
 Bareword "BAREWORD" not allowed while "strict subs" in use at - line 3.
-Execution of - aborted due to compilation errors.
 ########
 # [perl #26910] hints not propagated into (?{...})
 use strict 'subs';
 qr/(?{my $x=foo})/;
 EXPECT
 Bareword "foo" not allowed while "strict subs" in use at - line 3.
-Execution of - aborted due to compilation errors.
 ########
 # Regexp compilation errors weren't UTF-8 clean
 use strict 'subs';
@@ -388,27 +368,23 @@ use open qw( :utf8 :std );
 qr/(?{my $x=fòò})/;
 EXPECT
 Bareword "fòò" not allowed while "strict subs" in use at - line 5.
-Execution of - aborted due to compilation errors.
 ########
 #  [perl #27628] strict 'subs' didn't warn on bareword array index
 use strict 'subs';
 my $x=$a[FOO];
 EXPECT
 Bareword "FOO" not allowed while "strict subs" in use at - line 3.
-Execution of - aborted due to compilation errors.
 ########
 use strict 'subs';
 my @a;my $x=$a[FOO];
 EXPECT
 Bareword "FOO" not allowed while "strict subs" in use at - line 2.
-Execution of - aborted due to compilation errors.
 ########
 # [perl #53806] No complain about bareword
 use strict 'subs';
 print FOO . "\n";
 EXPECT
 Bareword "FOO" not allowed while "strict subs" in use at - line 3.
-Execution of - aborted due to compilation errors.
 ########
 # [perl #53806] No complain about bareword
 use strict 'subs';
@@ -416,7 +392,6 @@ $ENV{PATH} = "";
 system(FOO . "\n");
 EXPECT
 Bareword "FOO" not allowed while "strict subs" in use at - line 4.
-Execution of - aborted due to compilation errors.
 ########
 use strict 'subs';
 my @players;
@@ -450,14 +425,12 @@ sub foo {
 }
 EXPECT
 Bareword "FOO" not allowed while "strict subs" in use at - line 5.
-Execution of - aborted due to compilation errors.
 ########
 # make sure checks are done within (?{})
 use strict 'subs';
 /(?{FOO})/
 EXPECT
 Bareword "FOO" not allowed while "strict subs" in use at - line 3.
-Execution of - aborted due to compilation errors.
 ########
 # [perl #126981] Strict subs vs. multideref
 my $h;
@@ -466,7 +439,6 @@ use strict 'subs';
 my $v2 = $h->{+CONST_TYPO};
 EXPECT
 Bareword "CONST_TYPO" not allowed while "strict subs" in use at - line 5.
-Execution of - aborted due to compilation errors.
 ########
 # NAME constant-folded barewords still trigger stricture
 my $x = !BARE1;
@@ -474,7 +446,6 @@ use strict 'subs';
 my $y = !BARE2;
 EXPECT
 Bareword "BARE2" not allowed while "strict subs" in use at - line 3.
-Execution of - aborted due to compilation errors.
 ########
 # NAME multiconcat and barewords gh #17254
 use strict;
@@ -482,4 +453,3 @@ sub foo { "foo" }
 print foo() . SLASH . "bar";
 EXPECT
 Bareword "SLASH" not allowed while "strict subs" in use at - line 3.
-Execution of - aborted due to compilation errors.

--- a/t/lib/strict/vars
+++ b/t/lib/strict/vars
@@ -50,7 +50,6 @@ use strict ;
 $fred ;
 EXPECT
 Global symbol "$fred" requires explicit package name (did you forget to declare "my $fred"?) at - line 4.
-Execution of - aborted due to compilation errors.
 ########
 
 # strict vars - error
@@ -58,7 +57,6 @@ use strict 'vars' ;
 <$fred> ;
 EXPECT
 Global symbol "$fred" requires explicit package name (did you forget to declare "my $fred"?) at - line 4.
-Execution of - aborted due to compilation errors.
 ########
 
 # strict vars - error
@@ -66,7 +64,6 @@ use strict 'vars' ;
 local $fred ;
 EXPECT
 Global symbol "$fred" requires explicit package name (did you forget to declare "my $fred"?) at - line 4.
-Execution of - aborted due to compilation errors.
 ########
 
 # Check compile time scope of strict vars pragma
@@ -79,7 +76,6 @@ $joe = 1 ;
 EXPECT
 Variable "$joe" is not imported at - line 8.
 Global symbol "$joe" requires explicit package name (did you forget to declare "my $joe"?) at - line 8.
-Execution of - aborted due to compilation errors.
 ########
 
 # Check compile time scope of strict vars pragma
@@ -94,7 +90,6 @@ $jòè = 1 ;
 EXPECT
 Variable "$jòè" is not imported at - line 10.
 Global symbol "$jòè" requires explicit package name (did you forget to declare "my $jòè"?) at - line 10.
-Execution of - aborted due to compilation errors.
 ########
 
 # Check compile time scope of strict vars pragma
@@ -106,7 +101,6 @@ no strict;
 $joe = 1 ;
 EXPECT
 Global symbol "$joe" requires explicit package name (did you forget to declare "my $joe"?) at - line 6.
-Execution of - aborted due to compilation errors.
 ########
 
 --FILE-- abc
@@ -239,7 +233,6 @@ print STDERR $@;
 $joe = 1 ;
 EXPECT
 Global symbol "$joe" requires explicit package name (did you forget to declare "my $joe"?) at - line 6.
-Execution of - aborted due to compilation errors.
 ########
 
 # Check scope of pragma with eval
@@ -252,7 +245,6 @@ $joe = 1 ;
 EXPECT
 Global symbol "$joe" requires explicit package name (did you forget to declare "my $joe"?) at - line 5.
 Global symbol "$joe" requires explicit package name (did you forget to declare "my $joe"?) at - line 8.
-Execution of - aborted due to compilation errors.
 ########
 
 # Check scope of pragma with eval
@@ -266,7 +258,6 @@ $joe = 1 ;
 EXPECT
 Variable "$joe" is not imported at - line 9.
 Global symbol "$joe" requires explicit package name (did you forget to declare "my $joe"?) at - line 9.
-Execution of - aborted due to compilation errors.
 ########
 
 # Check scope of pragma with eval
@@ -282,7 +273,6 @@ $jòè = 1 ;
 EXPECT
 Variable "$jòè" is not imported at - line 11.
 Global symbol "$jòè" requires explicit package name (did you forget to declare "my $jòè"?) at - line 11.
-Execution of - aborted due to compilation errors.
 ########
 
 # Check scope of pragma with eval
@@ -323,7 +313,6 @@ eval '
 $joe = 1 ;
 EXPECT
 Global symbol "$joe" requires explicit package name (did you forget to declare "my $joe"?) at - line 8.
-Execution of - aborted due to compilation errors.
 ########
 
 # Check if multiple evals produce same errors
@@ -395,7 +384,6 @@ $fred ;
 EXPECT
 Variable "$fred" is not imported at - line 8.
 Global symbol "$fred" requires explicit package name (did you forget to declare "my $fred"?) at - line 8.
-Execution of - aborted due to compilation errors.
 ########
 
 # strict vars with elapsed our - error
@@ -410,7 +398,6 @@ $frèd ;
 EXPECT
 Variable "$frèd" is not imported at - line 10.
 Global symbol "$frèd" requires explicit package name (did you forget to declare "my $frèd"?) at - line 10.
-Execution of - aborted due to compilation errors.
 ########
 
 # nested our with local - no error
@@ -498,7 +485,6 @@ no warnings;
 "@i_like_crackers";
 EXPECT
 Global symbol "@i_like_crackers" requires explicit package name (did you forget to declare "my @i_like_crackers"?) at - line 7.
-Execution of - aborted due to compilation errors.
 ########
 
 # [perl #21914] New bug > 5.8.0. Used to dump core.
@@ -507,14 +493,12 @@ use strict 'vars';
 EXPECT
 Global symbol "@k" requires explicit package name (did you forget to declare "my @k"?) at - line 4.
 Global symbol "$k" requires explicit package name (did you forget to declare "my $k"?) at - line 4.
-Execution of - aborted due to compilation errors.
 ########
 # [perl #26910] hints not propagated into (?{...})
 use strict 'vars';
 qr/(?{$foo++})/;
 EXPECT
 Global symbol "$foo" requires explicit package name (did you forget to declare "my $foo"?) at - line 3.
-Execution of - aborted due to compilation errors.
 ########
 # Regex compilation errors weren't UTF-8 clean.
 use strict 'vars';
@@ -523,7 +507,6 @@ use open qw( :utf8 :std );
 qr/(?{$fòò++})/;
 EXPECT
 Global symbol "$fòò" requires explicit package name (did you forget to declare "my $fòò"?) at - line 5.
-Execution of - aborted due to compilation errors.
 ########
 # [perl #73712] 'Variable is not imported' should be suppressible
 $dweck;

--- a/t/lib/subs/subs
+++ b/t/lib/subs/subs
@@ -6,7 +6,6 @@ sub Fred {}
 EXPECT
 Number found where operator expected (Do you need to predeclare "Fred"?) at - line 3, near "Fred 1"
 syntax error at - line 3, near "Fred 1"
-Execution of - aborted due to compilation errors.
 ########
 
 # Error - not predeclaring a sub in time
@@ -16,7 +15,6 @@ sub Fred {}
 EXPECT
 Number found where operator expected (Do you need to predeclare "Fred"?) at - line 3, near "Fred 1"
 syntax error at - line 3, near "Fred 1"
-Execution of - aborted due to compilation errors.
 ########
 
 # AOK
@@ -88,7 +86,6 @@ sub Frèd {}
 EXPECT
 Number found where operator expected (Do you need to predeclare "Frèd"?) at - line 5, near "Frèd 1"
 syntax error at - line 5, near "Frèd 1"
-Execution of - aborted due to compilation errors.
 ########
 
 # Error - not predeclaring a sub in time
@@ -100,4 +97,3 @@ sub ふれど {}
 EXPECT
 Number found where operator expected (Do you need to predeclare "ふれど"?) at - line 5, near "ふれど 1"
 syntax error at - line 5, near "ふれど 1"
-Execution of - aborted due to compilation errors.

--- a/t/lib/warnings/7fatal
+++ b/t/lib/warnings/7fatal
@@ -545,7 +545,6 @@ if (1 {
 }
 EXPECT
 syntax error at - line 4, near "1 {"
-Execution of - aborted due to compilation errors.
 ########
 
 # fatal warnings in DESTROY should be made non-fatal [perl #123398]

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -304,7 +304,6 @@ use warnings 'syntax';
 @a[]
 EXPECT
 syntax error at - line 4, near "[]"
-Execution of - aborted due to compilation errors.
 ########
 # op.c
 my %foo;

--- a/t/lib/warnings/regcomp
+++ b/t/lib/warnings/regcomp
@@ -90,14 +90,12 @@ EXPECT
 qr/[\N{}]/;
 EXPECT
 Unknown charname '' at - line 2, within pattern
-Execution of - aborted due to compilation errors.
 ########
 # NAME [perl #123417]
 # OPTION fatal
 qr/\N{}/;
 EXPECT
 Unknown charname '' at - line 2, within pattern
-Execution of - aborted due to compilation errors.
 ########
 # NAME [perl #131868]
 use warnings;

--- a/t/lib/warnings/toke
+++ b/t/lib/warnings/toke
@@ -210,7 +210,6 @@ OPTION fatal
 Unknown regexp modifier "/e" at - line 2, near "=~ "
 Unknown regexp modifier "/q" at - line 2, near "=~ "
 Unknown regexp modifier "/q" at - line 3, near "=~ "
-Execution of - aborted due to compilation errors.
 ########
 # toke.c
 use utf8;
@@ -225,7 +224,6 @@ Unknown regexp modifier "/ネ" at - line 4, near "=~ "
 Unknown regexp modifier "/q" at - line 4, near "=~ "
 Unknown regexp modifier "/ネ" at - line 5, near "=~ "
 Unknown regexp modifier "/q" at - line 5, near "=~ "
-Execution of - aborted due to compilation errors.
 ########
 # toke.c
 use warnings 'syntax' ;
@@ -265,7 +263,6 @@ Reversed %= operator at - line 6.
 Reversed &= operator at - line 7.
 Reversed .= operator at - line 8.
 syntax error at - line 8, near "=."
-Execution of - aborted due to compilation errors.
 ########
 # toke.c
 no warnings 'syntax' ;
@@ -281,7 +278,6 @@ $a =< 2 ;
 $a =/ 2 ;
 EXPECT
 syntax error at - line 8, near "=."
-Execution of - aborted due to compilation errors.
 ########
 # toke.c
 use warnings 'syntax' ;
@@ -1462,7 +1458,6 @@ use warnings;
 $a =~ ?rand?; # ? is not a regex match
 EXPECT
 syntax error at - line 3, near "=~ ?"
-Execution of - aborted due to compilation errors.
 ########
 # toke.c
 BEGIN {
@@ -1493,7 +1488,6 @@ my $a = "\c{ack}";
 EXPECT
 OPTION fatal
 Use ";" instead of "\c{" at - line 9, within string
-Execution of - aborted due to compilation errors.
 ########
 # toke.c
 BEGIN {
@@ -1507,14 +1501,12 @@ my $a = "\c{ack}";
 EXPECT
 OPTION fatal
 Sequence "\c{" invalid at - line 9, within string
-Execution of - aborted due to compilation errors.
 ########
 # toke.c
 my $a = "\câ";
 EXPECT
 OPTION fatal
 Character following "\c" must be printable ASCII at - line 2, within string
-Execution of - aborted due to compilation errors.
 ########
 # toke.c
 use warnings 'syntax' ;
@@ -1716,7 +1708,6 @@ use utf8;
 my $a = qr ̂foobar̂;
 EXPECT
 Use of unassigned code point or non-standalone grapheme for a delimiter is not allowed at - line 8, near "= "
-Execution of - aborted due to compilation errors.
 ########
 # NAME  [perl #130567] Assertion failure
 BEGIN {
@@ -1742,7 +1733,6 @@ BEGIN{$0="";$^H=hex join""=>A00000}p?
 EXPECT
 OPTION fatal
 syntax error at - line 1, at EOF
-Execution of - aborted due to compilation errors.
 ########
 # NAME  [perl #130655]
 use utf8;
@@ -1861,7 +1851,6 @@ foo bar;
 EXPECT
 warn: Bareword found where operator expected (Do you need to predeclare "foo"?) at - line 3, near "foo bar"
 syntax error at - line 3, near "foo bar"
-Execution of - aborted due to compilation errors.
 ########
 # NAME SIG assign heuristic warning [github #22145]
 use warnings;

--- a/t/op/tie.t
+++ b/t/op/tie.t
@@ -245,7 +245,6 @@ EXPECT
 tie FH, 'main';
 EXPECT
 Can't modify constant item in tie at - line 3, near "'main';"
-Execution of - aborted due to compilation errors.
 ########
 
 # localizing tied hash slices

--- a/t/test.pl
+++ b/t/test.pl
@@ -1491,7 +1491,7 @@ sub run_multiple_progs {
                                : (switches => [$switch])
                                 );
         my $status = $?;
-        $results =~ s/\n+$//;
+
         # allow expected output to be written as if $prog is on STDIN
         $results =~ s/$::tempfile_regexp/-/g;
         if ($^O eq 'VMS') {
@@ -1506,6 +1506,12 @@ sub run_multiple_progs {
         $results =~ s/^(syntax|parse) error/syntax error/mig;
         # allow all tests to run when there are leaks
         $results =~ s/Scalars leaked: \d+\n//g;
+
+        # avoid repetition in test expectation files, as this is a common message
+        $results =~ s/^Execution of - aborted due to compilation errors\.\n//m;
+
+        # trim multiple trailing blanks
+        $results =~ s/\n+$//;
 
         $expected =~ s/\n+$//;
         my $prefix = ($results =~ s#^PREFIX(\n|$)##) ;

--- a/t/test.pl
+++ b/t/test.pl
@@ -1359,10 +1359,11 @@ sub run_multiple_progs {
     my $up = shift;
     my @prgs;
     if ($up) {
-	# The tests in lib run in a temporary subdirectory of t, and always
-	# pass in a list of "programs" to run
-	@prgs = @_;
-    } else {
+        # The tests in lib run in a temporary subdirectory of t, and always
+        # pass in a list of "programs" to run
+        @prgs = @_;
+    }
+    else {
         # The tests below t run in t and pass in a file handle. In theory we
         # can pass (caller)[1] as the second argument to report errors with
         # the filename of our caller, as the handle is always DATA. However,
@@ -1380,7 +1381,8 @@ sub run_multiple_progs {
     if (! eval {require Config; 1}) {
         warn "test.pl had problems loading Config: $@";
         $taint_disabled = '';
-    } else {
+    }
+    else {
         $taint_disabled = $Config::Config{taint_disabled};
     }
 
@@ -1388,7 +1390,8 @@ sub run_multiple_progs {
 
     my $count_failures = 0;
     my ($file, $line);
-  PROGRAM:
+
+    PROGRAM:
     while (defined ($line = shift @prgs)) {
         $_ = shift @prgs;
         unless ($line) {
@@ -1396,14 +1399,14 @@ sub run_multiple_progs {
             if (defined $file) {
                 print "# From $file\n";
             }
-	    next;
-	}
-	my $switch = "";
-	my @temps ;
-	my @temp_path;
-	if (s/^(\s*-\w+)//) {
-	    $switch = $1;
-	}
+            next;
+        }
+        my $switch = "";
+        my @temps ;
+        my @temp_path;
+        if (s/^(\s*-\w+)//) {
+            $switch = $1;
+        }
 
         s/^# NOTE.*\n//mg; # remove any NOTE comments in the content
 
@@ -1412,192 +1415,194 @@ sub run_multiple_progs {
         # tests.
         s/([<=>])CONFLICT\1/$1 x 7/ge;
 
-	my ($prog, $expected) = split(/\nEXPECT(?:\n|$)/, $_, 2);
+        my ($prog, $expected) = split(/\nEXPECT(?:\n|$)/, $_, 2);
 
-	my %reason;
-	foreach my $what (qw(skip todo)) {
-	    $prog =~ s/^#\s*\U$what\E\s*(.*)\n//m and $reason{$what} = $1;
-	    # If the SKIP reason starts ? then it's taken as a code snippet to
-	    # evaluate. This provides the flexibility to have conditional SKIPs
-	    if ($reason{$what} && $reason{$what} =~ s/^\?//) {
-		my $temp = eval $reason{$what};
-		if ($@) {
-		    die "# In \U$what\E code reason:\n# $reason{$what}\n$@";
-		}
-		$reason{$what} = $temp;
-	    }
-	}
+        my %reason;
+        foreach my $what (qw(skip todo)) {
+            $prog =~ s/^#\s*\U$what\E\s*(.*)\n//m and $reason{$what} = $1;
+            # If the SKIP reason starts ? then it's taken as a code snippet to
+            # evaluate. This provides the flexibility to have conditional SKIPs
+            if ($reason{$what} && $reason{$what} =~ s/^\?//) {
+                my $temp = eval $reason{$what};
+                if ($@) {
+                    die "# In \U$what\E code reason:\n# $reason{$what}\n$@";
+                }
+                $reason{$what} = $temp;
+            }
+        }
 
-    my $name = '';
-    if ($prog =~ s/^#\s*NAME\s+(.+)\n//m) {
-        $name = $1;
-    } elsif (defined $file) {
-        $name = "test from $file at line $line";
-    }
+        my $name = '';
+        if ($prog =~ s/^#\s*NAME\s+(.+)\n//m) {
+            $name = $1;
+        }
+        elsif (defined $file) {
+            $name = "test from $file at line $line";
+        }
 
         if ($switch=~/[Tt]/ and $taint_disabled eq "define") {
             $reason{skip} ||= "This perl does not support taint";
         }
 
-	if ($reason{skip}) {
-	SKIP:
-	  {
-	    skip($name ? "$name - $reason{skip}" : $reason{skip}, 1);
-	  }
-	  next PROGRAM;
-	}
+        if ($reason{skip}) {
+        SKIP:
+            {
+                skip($name ? "$name - $reason{skip}" : $reason{skip}, 1);
+            }
+            next PROGRAM;
+        }
 
-	if ($prog =~ /--FILE--/) {
-	    my @files = split(/\n?--FILE--\s*([^\s\n]*)\s*\n/, $prog) ;
-	    shift @files ;
-	    die "Internal error: test $_ didn't split into pairs, got " .
-		scalar(@files) . "[" . join("%%%%", @files) ."]\n"
-		    if @files % 2;
-	    while (@files > 2) {
-		my $filename = shift @files;
-		my $code = shift @files;
-		push @temps, $filename;
-		if ($filename =~ m#(.*)/# && $filename !~ m#^\.\./#) {
-		    require File::Path;
-		    File::Path::mkpath($1);
-		    push(@temp_path, $1);
-		}
-		open my $fh, '>', $filename or die "Cannot open $filename: $!\n";
-		print $fh $code;
-		close $fh or die "Cannot close $filename: $!\n";
-	    }
-	    shift @files;
-	    $prog = shift @files;
-	}
+        if ($prog =~ /--FILE--/) {
+            my @files = split(/\n?--FILE--\s*([^\s\n]*)\s*\n/, $prog) ;
+            shift @files ;
+            die "Internal error: test $_ didn't split into pairs, got " .
+                scalar(@files) . "[" . join("%%%%", @files) ."]\n"
+                    if @files % 2;
+            while (@files > 2) {
+                my $filename = shift @files;
+                my $code = shift @files;
+                push @temps, $filename;
+                if ($filename =~ m#(.*)/# && $filename !~ m#^\.\./#) {
+                    require File::Path;
+                    File::Path::mkpath($1);
+                    push(@temp_path, $1);
+                }
+                open my $fh, '>', $filename or die "Cannot open $filename: $!\n";
+                print $fh $code;
+                close $fh or die "Cannot close $filename: $!\n";
+            }
+            shift @files;
+            $prog = shift @files;
+        }
 
-	open my $fh, '>', $tmpfile or die "Cannot open >$tmpfile: $!";
-	print $fh q{
+        open my $fh, '>', $tmpfile or die "Cannot open >$tmpfile: $!";
+        print $fh q{
         BEGIN {
             push @INC, '.';
             open STDERR, '>&', STDOUT
               or die "Can't dup STDOUT->STDERR: $!;";
         }
-	};
-	print $fh "\n#line 1\n";  # So the line numbers don't get messed up.
-	print $fh $prog,"\n";
-	close $fh or die "Cannot close $tmpfile: $!";
-	my $results = runperl( stderr => 1, progfile => $tmpfile,
-			       stdin => undef, $up
-			       ? (switches => ["-I$up/lib", $switch], nolib => 1)
-			       : (switches => [$switch])
-			        );
-	my $status = $?;
-	$results =~ s/\n+$//;
-	# allow expected output to be written as if $prog is on STDIN
-	$results =~ s/$::tempfile_regexp/-/g;
-	if ($^O eq 'VMS') {
-	    # some tests will trigger VMS messages that won't be expected
-	    $results =~ s/\n?%[A-Z]+-[SIWEF]-[A-Z]+,.*//;
+        };
+        print $fh "\n#line 1\n";  # So the line numbers don't get messed up.
+        print $fh $prog,"\n";
+        close $fh or die "Cannot close $tmpfile: $!";
+        my $results = runperl( stderr => 1, progfile => $tmpfile,
+                               stdin => undef, $up
+                               ? (switches => ["-I$up/lib", $switch], nolib => 1)
+                               : (switches => [$switch])
+                                );
+        my $status = $?;
+        $results =~ s/\n+$//;
+        # allow expected output to be written as if $prog is on STDIN
+        $results =~ s/$::tempfile_regexp/-/g;
+        if ($^O eq 'VMS') {
+            # some tests will trigger VMS messages that won't be expected
+            $results =~ s/\n?%[A-Z]+-[SIWEF]-[A-Z]+,.*//;
 
-	    # pipes double these sometimes
-	    $results =~ s/\n\n/\n/g;
-	}
-	# bison says 'parse error' instead of 'syntax error',
-	# various yaccs may or may not capitalize 'syntax'.
-	$results =~ s/^(syntax|parse) error/syntax error/mig;
-	# allow all tests to run when there are leaks
-	$results =~ s/Scalars leaked: \d+\n//g;
+            # pipes double these sometimes
+            $results =~ s/\n\n/\n/g;
+        }
+        # bison says 'parse error' instead of 'syntax error',
+        # various yaccs may or may not capitalize 'syntax'.
+        $results =~ s/^(syntax|parse) error/syntax error/mig;
+        # allow all tests to run when there are leaks
+        $results =~ s/Scalars leaked: \d+\n//g;
 
-	$expected =~ s/\n+$//;
-	my $prefix = ($results =~ s#^PREFIX(\n|$)##) ;
-	# any special options? (OPTIONS foo bar zap)
-	my $option_regex = 0;
-	my $option_random = 0;
-	my $fatal = $FATAL;
-	if ($expected =~ s/^OPTIONS? (.+)(?:\n|\Z)//) {
-	    foreach my $option (split(' ', $1)) {
-		if ($option eq 'regex') { # allow regular expressions
-		    $option_regex = 1;
-		}
-		elsif ($option eq 'random') { # all lines match, but in any order
-		    $option_random = 1;
-		}
-		elsif ($option eq 'fatal') { # perl should fail
-		    $fatal = 1;
-		}
+        $expected =~ s/\n+$//;
+        my $prefix = ($results =~ s#^PREFIX(\n|$)##) ;
+        # any special options? (OPTIONS foo bar zap)
+        my $option_regex = 0;
+        my $option_random = 0;
+        my $fatal = $FATAL;
+        if ($expected =~ s/^OPTIONS? (.+)(?:\n|\Z)//) {
+            foreach my $option (split(' ', $1)) {
+                if ($option eq 'regex') { # allow regular expressions
+                    $option_regex = 1;
+                }
+                elsif ($option eq 'random') { # all lines match, but in any order
+                    $option_random = 1;
+                }
+                elsif ($option eq 'fatal') { # perl should fail
+                    $fatal = 1;
+                }
                 elsif ($option eq 'nonfatal') {
                     # used to turn off default fatal
                     $fatal = 0;
                 }
-		else {
-		    die "$0: Unknown OPTION '$option'\n";
-		}
-	    }
-	}
-	die "$0: can't have OPTION regex and random\n"
-	    if $option_regex + $option_random > 1;
-	my $ok = 0;
-	if ($results =~ s/^SKIPPED\n//) {
-	    print "$results\n" ;
-	    $ok = 1;
-	}
-	else {
-	    if ($option_random) {
-	        my @got = sort split "\n", $results;
-	        my @expected = sort split "\n", $expected;
-
-	        $ok = "@got" eq "@expected";
-	    }
-	    elsif ($option_regex) {
-	        $ok = $results =~ /^$expected/;
-	    }
-	    elsif ($prefix) {
-	        $ok = $results =~ /^\Q$expected/;
-	    }
-	    else {
-	        $ok = $results eq $expected;
-	    }
-
-	    if ($ok && $fatal && !($status >> 8)) {
-		$ok = 0;
-	    }
-	}
-
-	local $::TODO = $reason{todo};
-
-	unless ($ok) {
-        my $err_line = '';
-        $err_line   .= "FILE: $file ; line $line\n" if defined $file;
-        $err_line   .= "PROG: $switch\n$prog\n" .
-			           "EXPECTED:\n$expected\n";
-        $err_line   .= "EXIT STATUS: != 0\n" if $fatal;
-        $err_line   .= "GOT:\n$results\n";
-        $err_line   .= "EXIT STATUS: " . ($status >> 8) . "\n" if $fatal;
-        if ($::TODO) {
-            $err_line =~ s/^/# /mg;
-            print $err_line;  # Harness can't filter it out from STDERR.
+                else {
+                    die "$0: Unknown OPTION '$option'\n";
+                }
+            }
+        }
+        die "$0: can't have OPTION regex and random\n"
+            if $option_regex + $option_random > 1;
+        my $ok = 0;
+        if ($results =~ s/^SKIPPED\n//) {
+            print "$results\n" ;
+            $ok = 1;
         }
         else {
-            print STDERR $err_line;
-            ++$count_failures;
-            die "PERL_TEST_ABORT_FIRST_FAILURE set Test Failure"
-                if $ENV{PERL_TEST_ABORT_FIRST_FAILURE};
+            if ($option_random) {
+                my @got = sort split "\n", $results;
+                my @expected = sort split "\n", $expected;
+
+                $ok = "@got" eq "@expected";
+            }
+            elsif ($option_regex) {
+                $ok = $results =~ /^$expected/;
+            }
+            elsif ($prefix) {
+                $ok = $results =~ /^\Q$expected/;
+            }
+            else {
+                $ok = $results eq $expected;
+            }
+
+            if ($ok && $fatal && !($status >> 8)) {
+                $ok = 0;
+            }
         }
-    }
+
+        local $::TODO = $reason{todo};
+
+        unless ($ok) {
+            my $err_line = '';
+            $err_line   .= "FILE: $file ; line $line\n" if defined $file;
+            $err_line   .= "PROG: $switch\n$prog\n" .
+                                       "EXPECTED:\n$expected\n";
+            $err_line   .= "EXIT STATUS: != 0\n" if $fatal;
+            $err_line   .= "GOT:\n$results\n";
+            $err_line   .= "EXIT STATUS: " . ($status >> 8) . "\n" if $fatal;
+            if ($::TODO) {
+                $err_line =~ s/^/# /mg;
+                print $err_line;  # Harness can't filter it out from STDERR.
+            }
+            else {
+                print STDERR $err_line;
+                ++$count_failures;
+                die "PERL_TEST_ABORT_FIRST_FAILURE set Test Failure"
+                    if $ENV{PERL_TEST_ABORT_FIRST_FAILURE};
+            }
+        }
 
         if (defined $file) {
             _ok($ok, "at $file line $line", $name);
-        } else {
+        }
+        else {
             # We don't have file and line number data for the test, so report
             # errors as coming from our caller.
             local $Level = $Level + 1;
             ok($ok, $name);
         }
 
-	foreach (@temps) {
-	    unlink $_ if $_;
-	}
-	foreach (@temp_path) {
-	    File::Path::rmtree $_ if -d $_;
-	}
+        foreach (@temps) {
+            unlink $_ if $_;
+        }
+        foreach (@temp_path) {
+            File::Path::rmtree $_ if -d $_;
+        }
     }
 
-    if ( $count_failures ) {
+    if ($count_failures) {
         print STDERR <<'EOS';
 #
 # Note: 'run_multiple_progs' run has one or more failures
@@ -1607,7 +1612,6 @@ sub run_multiple_progs {
 #
 EOS
     }
-
 
     return;
 }


### PR DESCRIPTION
This final line of output is often repeated across many tests, but its exact details aren't overly interesting from a testing perspective. It's easier just to ignore it in the output and then not have to rely on testing it all the time.
