### PR TITLE
Move tests to `t/lib/croak/signatures`

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6120,6 +6120,7 @@ t/lib/croak/pp_ctl			Test croak calls from pp_ctl.c
 t/lib/croak/pp_hot			Test croak calls from pp_hot.c
 t/lib/croak/pp_sys			Test croak calls from pp_sys.c
 t/lib/croak/regcomp			Test croak calls from regcomp.c
+t/lib/croak/signatures			Test croak calls from compiling subroutine signatures
 t/lib/croak/toke			Test croak calls from toke.c
 t/lib/croak/toke_l1			Test croak calls from toke.c; file is not UTF-8 encoded
 t/lib/cygwin.t				Builtin cygwin function tests

--- a/t/lib/croak/signatures
+++ b/t/lib/croak/signatures
@@ -1,0 +1,221 @@
+# PREAMBLE use feature 'signatures';
+__END__
+# NAME optional without default expression
+sub t024 ($a =) { }
+EXPECT
+Optional parameter lacks default expression at - line 2, near "=) "
+########
+# NAME mandatory follows optional
+sub t030 ($a = 222, $b) { }
+EXPECT
+Mandatory parameter follows optional parameter at - line 2, near "$b) "
+########
+# NAME mandatory follows optional twice
+sub t031 ($a = 222, $b = 333, $c, $d) { }
+EXPECT
+Mandatory parameter follows optional parameter at - line 2, near "$c,"
+Mandatory parameter follows optional parameter at - line 2, near "$d) "
+########
+# NAME slurpy array with default
+sub t136 (@abc = 222) { }
+EXPECT
+A slurpy parameter may not have a default value at - line 2, near "222) "
+########
+# NAME slurpy array with empty default
+sub t137 (@abc =) { }
+EXPECT
+A slurpy parameter may not have a default value at - line 2, near "=) "
+########
+# NAME anonymous slurpy array with default
+sub t138 (@ = 222) { }
+EXPECT
+A slurpy parameter may not have a default value at - line 2, near "222) "
+########
+# NAME anonymous slurpy array with empty default
+sub t139 (@ =) { }
+EXPECT
+A slurpy parameter may not have a default value at - line 2, near "=) "
+########
+# NAME slurpy hash with default
+sub t140 (%abc = 222) { }
+EXPECT
+A slurpy parameter may not have a default value at - line 2, near "222) "
+########
+# NAME slurpy hash with empty default
+sub t141 (%abc =) { }
+EXPECT
+A slurpy parameter may not have a default value at - line 2, near "=) "
+########
+# NAME anonymous slurpy hash with default
+sub t142 (% = 222) { }
+EXPECT
+A slurpy parameter may not have a default value at - line 2, near "222) "
+########
+# NAME anonymous slurpy hash with empty default
+sub t143 (% =) { }
+EXPECT
+A slurpy parameter may not have a default value at - line 2, near "=) "
+########
+sub t059 (@a, $b) { }
+EXPECT
+Slurpy parameter not last at - line 2, near "$b) "
+########
+sub t060 (@a, $b = 222) { }
+EXPECT
+Slurpy parameter not last at - line 2, near "222) "
+########
+sub t061 (@a, @b) { }
+EXPECT
+Multiple slurpy parameters not allowed at - line 2, near "@b) "
+########
+sub t062 (@a, %b) { }
+EXPECT
+Multiple slurpy parameters not allowed at - line 2, near "%b) "
+########
+sub t063 (@, $b) { }
+EXPECT
+Slurpy parameter not last at - line 2, near "$b) "
+########
+sub t064 (@, $b = 222) { }
+EXPECT
+Slurpy parameter not last at - line 2, near "222) "
+########
+sub t065 (@, @b) { }
+EXPECT
+Multiple slurpy parameters not allowed at - line 2, near "@b) "
+########
+sub t066 (@, %b) { }
+EXPECT
+Multiple slurpy parameters not allowed at - line 2, near "%b) "
+########
+sub t067 (@a, $) { }
+EXPECT
+Slurpy parameter not last at - line 2, near "$) "
+########
+sub t068 (@a, $ = 222) { }
+EXPECT
+Slurpy parameter not last at - line 2, near "222) "
+########
+sub t069 (@a, @) { }
+EXPECT
+Multiple slurpy parameters not allowed at - line 2, near "@) "
+########
+sub t070 (@a, %) { }
+EXPECT
+Multiple slurpy parameters not allowed at - line 2, near "%) "
+########
+sub t071 (@, $) { }
+EXPECT
+Slurpy parameter not last at - line 2, near "$) "
+########
+sub t072 (@, $ = 222) { }
+EXPECT
+Slurpy parameter not last at - line 2, near "222) "
+########
+sub t073 (@, @) { }
+EXPECT
+Multiple slurpy parameters not allowed at - line 2, near "@) "
+########
+sub t074 (@, %) { }
+EXPECT
+Multiple slurpy parameters not allowed at - line 2, near "%) "
+########
+sub t075 (%a, $b) { }
+EXPECT
+Slurpy parameter not last at - line 2, near "$b) "
+########
+sub t076 (%, $b) { }
+EXPECT
+Slurpy parameter not last at - line 2, near "$b) "
+########
+sub t077 ($a, @b, $c) { }
+EXPECT
+Slurpy parameter not last at - line 2, near "$c) "
+########
+sub t078 ($a, %b, $c) { }
+EXPECT
+Slurpy parameter not last at - line 2, near "$c) "
+########
+sub t079 ($a, @b, $c, $d) { }
+EXPECT
+Slurpy parameter not last at - line 2, near "$c,"
+Slurpy parameter not last at - line 2, near "$d) "
+########
+sub t082 (, $a) { }
+EXPECT
+syntax error at - line 2, near "(,"
+########
+sub t083 (,) { }
+EXPECT
+syntax error at - line 2, near "(,"
+########
+# NAME comment in signature is OK
+sub t088 ($ #foo
+a) { }
+
+sub t090 (@ #foo
+a) { }
+
+sub t092 (% #foo
+a) { }
+EXPECT
+OPTIONS nonfatal
+########
+sub t089 ($#foo
+a) { }
+EXPECT
+'#' not allowed immediately following a sigil in a subroutine signature at - line 2, near "($"
+syntax error at - line 3, near "a"
+########
+sub t091 (@#foo
+a) { }
+EXPECT
+'#' not allowed immediately following a sigil in a subroutine signature at - line 2, near "(@"
+syntax error at - line 3, near "a"
+########
+sub t093 (%#foo
+a) { }
+EXPECT
+'#' not allowed immediately following a sigil in a subroutine signature at - line 2, near "(%"
+syntax error at - line 3, near "a"
+########
+sub t094 (123) { }
+EXPECT
+A signature parameter must start with '$', '@' or '%' at - line 2, near "(1"
+syntax error at - line 2, near "(123"
+########
+sub t095 ($a, 123) { }
+EXPECT
+A signature parameter must start with '$', '@' or '%' at - line 2, near ", 1"
+syntax error at - line 2, near ", 123"
+########
+no warnings; sub t096 ($a 123) { }
+EXPECT
+Illegal operator following parameter in a subroutine signature at - line 2, near "($a 123"
+syntax error at - line 2, near "($a 123"
+########
+sub t097 ($a { }) { }
+EXPECT
+Illegal operator following parameter in a subroutine signature at - line 2, near "($a { }"
+syntax error at - line 2, near "($a { }"
+########
+sub t098 ($a; $b) { }
+EXPECT
+Illegal operator following parameter in a subroutine signature at - line 2, near "($a; "
+syntax error at - line 2, near "($a; "
+########
+sub t099 ($$) { }
+EXPECT
+Illegal character following sigil in a subroutine signature at - line 2, near "($"
+syntax error at - line 2, near "$$) "
+########
+# NAME global @_ in signature
+sub t101 (@_) { }
+EXPECT
+Can't use global @_ in subroutine signature at - line 2, near "(@_"
+########
+# NAME global %_ in signature
+sub t102 (%_) { }
+EXPECT
+Can't use global %_ in subroutine signature at - line 2, near "(%_"
+

--- a/t/op/signatures.t
+++ b/t/op/signatures.t
@@ -20,6 +20,7 @@ our $z;
     is $a, 123;
 }
 
+# easier not to put these tests in t/lib/croak/signatures
 eval "#line 8 foo\nsub t004 :method (\$a) { }";
 like $@, qr{syntax error at foo line 8}, "error when not enabled 1";
 
@@ -446,10 +447,6 @@ is eval("t131(456, 789, 987)"), undef;
 like $@, _create_flexible_mismatch_regexp('main::t131', 3, 2);
 is $a, 123;
 
-eval "#line 8 foo\nsub t024 (\$a =) { }";
-is $@,
-    qq{Optional parameter lacks default expression at foo line 8, near "=) "\n};
-
 sub t025 ($ = undef) { $a // "z" }
 is prototype(\&t025), undef;
 is eval("t025()"), 123;
@@ -589,15 +586,6 @@ is eval("t038(456, 789, 987)"), undef;
 like $@, _create_flexible_mismatch_regexp('main::t038', 3, 2);
 is $a, 123;
 
-eval "#line 8 foo\nsub t030 (\$a = 222, \$b) { }";
-is $@, qq{Mandatory parameter follows optional parameter at foo line 8, near "\$b) "\n};
-
-eval "#line 8 foo\nsub t031 (\$a = 222, \$b = 333, \$c, \$d) { }";
-is $@, <<EOF;
-Mandatory parameter follows optional parameter at foo line 8, near "\$c,"
-Mandatory parameter follows optional parameter at foo line 8, near "\$d) "
-EOF
-
 sub t206 ($x, $y //= 3) { return $x + $y }
 is eval("t206(5,4)"),     9, '//= present';
 is eval("t206(5)"),       8, '//= absent';
@@ -622,12 +610,6 @@ is eval("t034(456, 789, 987, 654, 321)"), "456/789/987/654/321;5";
 is eval("t034(456, 789, 987, 654, 321, 111)"), "456/789/987/654/321/111;6";
 is $a, 123;
 
-eval "#line 8 foo\nsub t136 (\@abc = 222) { }";
-is $@, qq{A slurpy parameter may not have a default value at foo line 8, near "222) "\n};
-
-eval "#line 8 foo\nsub t137 (\@abc =) { }";
-is $@, qq{A slurpy parameter may not have a default value at foo line 8, near "=) "\n};
-
 sub t035 (@) { $a }
 is prototype(\&t035), undef;
 is eval("t035()"), 123;
@@ -639,12 +621,6 @@ is eval("t035(456, 789, 987, 654)"), 123;
 is eval("t035(456, 789, 987, 654, 321)"), 123;
 is eval("t035(456, 789, 987, 654, 321, 111)"), 123;
 is $a, 123;
-
-eval "#line 8 foo\nsub t138 (\@ = 222) { }";
-is $@, qq{A slurpy parameter may not have a default value at foo line 8, near "222) "\n};
-
-eval "#line 8 foo\nsub t139 (\@ =) { }";
-is $@, qq{A slurpy parameter may not have a default value at foo line 8, near "=) "\n};
 
 sub t039 (%abc) { join("/", map { $_."=".$abc{$_} } sort keys %abc) }
 is prototype(\&t039), undef;
@@ -662,12 +638,6 @@ like $@, qr#\AOdd name/value argument for subroutine 'main::t039' at \(eval \d+\
 is eval("t039(456, 789, 987, 654, 321, 111)"), "321=111/456=789/987=654";
 is $a, 123;
 
-eval "#line 8 foo\nsub t140 (\%abc = 222) { }";
-is $@, qq{A slurpy parameter may not have a default value at foo line 8, near "222) "\n};
-
-eval "#line 8 foo\nsub t141 (\%abc =) { }";
-is $@, qq{A slurpy parameter may not have a default value at foo line 8, near "=) "\n};
-
 sub t040 (%) { $a }
 is prototype(\&t040), undef;
 is eval("t040()"), 123;
@@ -683,12 +653,6 @@ is eval("t040(456, 789, 987, 654, 321)"), undef;
 like $@, qr#\AOdd name/value argument for subroutine 'main::t040' at \(eval \d+\) line 1\.\n\z#;
 is eval("t040(456, 789, 987, 654, 321, 111)"), 123;
 is $a, 123;
-
-eval "#line 8 foo\nsub t142 (\% = 222) { }";
-is $@, qq{A slurpy parameter may not have a default value at foo line 8, near "222) "\n};
-
-eval "#line 8 foo\nsub t143 (\% =) { }";
-is $@, qq{A slurpy parameter may not have a default value at foo line 8, near "=) "\n};
 
 sub t041 ($a, @b) { $a.";".join("/", @b) }
 is prototype(\&t041), undef;
@@ -920,72 +884,6 @@ is eval("t058(456, 789, 987, 654, 321)"), "456;789;987/654/321;3";
 is eval("t058(456, 789, 987, 654, 321, 111)"), "456;789;987/654/321/111;4";
 is $a, 123;
 
-eval "#line 8 foo\nsub t059 (\@a, \$b) { }";
-is $@, qq{Slurpy parameter not last at foo line 8, near "\$b) "\n};
-
-eval "#line 8 foo\nsub t060 (\@a, \$b = 222) { }";
-is $@, qq{Slurpy parameter not last at foo line 8, near "222) "\n};
-
-eval "#line 8 foo\nsub t061 (\@a, \@b) { }";
-is $@, qq{Multiple slurpy parameters not allowed at foo line 8, near "\@b) "\n};
-
-eval "#line 8 foo\nsub t062 (\@a, \%b) { }";
-is $@, qq{Multiple slurpy parameters not allowed at foo line 8, near "%b) "\n};
-
-eval "#line 8 foo\nsub t063 (\@, \$b) { }";
-is $@, qq{Slurpy parameter not last at foo line 8, near "\$b) "\n};
-
-eval "#line 8 foo\nsub t064 (\@, \$b = 222) { }";
-is $@, qq{Slurpy parameter not last at foo line 8, near "222) "\n};
-
-eval "#line 8 foo\nsub t065 (\@, \@b) { }";
-is $@, qq{Multiple slurpy parameters not allowed at foo line 8, near "\@b) "\n};
-
-eval "#line 8 foo\nsub t066 (\@, \%b) { }";
-is $@, qq{Multiple slurpy parameters not allowed at foo line 8, near "%b) "\n};
-
-eval "#line 8 foo\nsub t067 (\@a, \$) { }";
-is $@, qq{Slurpy parameter not last at foo line 8, near "\$) "\n};
-
-eval "#line 8 foo\nsub t068 (\@a, \$ = 222) { }";
-is $@, qq{Slurpy parameter not last at foo line 8, near "222) "\n};
-
-eval "#line 8 foo\nsub t069 (\@a, \@) { }";
-is $@, qq{Multiple slurpy parameters not allowed at foo line 8, near "\@) "\n};
-
-eval "#line 8 foo\nsub t070 (\@a, \%) { }";
-is $@, qq{Multiple slurpy parameters not allowed at foo line 8, near "\%) "\n};
-
-eval "#line 8 foo\nsub t071 (\@, \$) { }";
-is $@, qq{Slurpy parameter not last at foo line 8, near "\$) "\n};
-
-eval "#line 8 foo\nsub t072 (\@, \$ = 222) { }";
-is $@, qq{Slurpy parameter not last at foo line 8, near "222) "\n};
-
-eval "#line 8 foo\nsub t073 (\@, \@) { }";
-is $@, qq{Multiple slurpy parameters not allowed at foo line 8, near "\@) "\n};
-
-eval "#line 8 foo\nsub t074 (\@, \%) { }";
-is $@, qq{Multiple slurpy parameters not allowed at foo line 8, near "\%) "\n};
-
-eval "#line 8 foo\nsub t075 (\%a, \$b) { }";
-is $@, qq{Slurpy parameter not last at foo line 8, near "\$b) "\n};
-
-eval "#line 8 foo\nsub t076 (\%, \$b) { }";
-is $@, qq{Slurpy parameter not last at foo line 8, near "\$b) "\n};
-
-eval "#line 8 foo\nsub t077 (\$a, \@b, \$c) { }";
-is $@, qq{Slurpy parameter not last at foo line 8, near "\$c) "\n};
-
-eval "#line 8 foo\nsub t078 (\$a, \%b, \$c) { }";
-is $@, qq{Slurpy parameter not last at foo line 8, near "\$c) "\n};
-
-eval "#line 8 foo\nsub t079 (\$a, \@b, \$c, \$d) { }";
-is $@, <<EOF;
-Slurpy parameter not last at foo line 8, near "\$c,"
-Slurpy parameter not last at foo line 8, near "\$d) "
-EOF
-
 sub t080 ($a,,, $b) { $a.$b }
 is prototype(\&t080), undef;
 is eval("t080()"), undef;
@@ -1011,12 +909,6 @@ like $@, _create_mismatch_regexp('main::t081', 3, 2);
 is eval("t081(456, 789, 987, 654)"), undef;
 like $@, _create_mismatch_regexp('main::t081', 4, 2);
 is $a, 123;
-
-eval "#line 8 foo\nsub t082 (, \$a) { }";
-is $@, qq{syntax error at foo line 8, near "(,"\nExecution of foo aborted due to compilation errors.\n};
-
-eval "#line 8 foo\nsub t083 (,) { }";
-is $@, qq{syntax error at foo line 8, near "(,"\nExecution of foo aborted due to compilation errors.\n};
 
 sub t084($a,$b){ $a.$b }
 is prototype(\&t084), undef;
@@ -1105,69 +997,6 @@ like $@, _create_flexible_mismatch_regexp('main::t087', 3, 2);
 is eval("t087(456, 789, 987, 654)"), undef;
 like $@, _create_flexible_mismatch_regexp('main::t087', 4, 2);
 is $a, 123;
-
-eval "#line 8 foo\nsub t088 (\$ #foo\na) { }";
-is $@, "";
-
-
-eval "#line 8 foo\nsub t089 (\$#foo\na) { }";
-like $@, qr{\A'#' not allowed immediately following a sigil in a subroutine signature at foo line 8, near "\(\$"\n};
-
-eval "#line 8 foo\nsub t090 (\@ #foo\na) { }";
-is $@, "";
-
-eval "#line 8 foo\nsub t091 (\@#foo\na) { }";
-like $@, qr{\A'#' not allowed immediately following a sigil in a subroutine signature at foo line 8, near "\(\@"\n};
-
-eval "#line 8 foo\nsub t092 (\% #foo\na) { }";
-is $@, "";
-
-eval "#line 8 foo\nsub t093 (\%#foo\na) { }";
-like $@, qr{\A'#' not allowed immediately following a sigil in a subroutine signature at foo line 8, near "\(%"\n};
-
-eval "#line 8 foo\nsub t094 (123) { }";
-like $@, qr{\AA signature parameter must start with '\$', '\@' or '%' at foo line 8, near "\(1"\n};
-
-eval "#line 8 foo\nsub t095 (\$a, 123) { }";
-is $@, <<EOF;
-A signature parameter must start with '\$', '\@' or '%' at foo line 8, near ", 1"
-syntax error at foo line 8, near ", 123"
-Execution of foo aborted due to compilation errors.
-EOF
-
-eval "#line 8 foo\nno warnings; sub t096 (\$a 123) { }";
-is $@, <<'EOF';
-Illegal operator following parameter in a subroutine signature at foo line 8, near "($a 123"
-syntax error at foo line 8, near "($a 123"
-Execution of foo aborted due to compilation errors.
-EOF
-
-eval "#line 8 foo\nsub t097 (\$a { }) { }";
-is $@, <<'EOF';
-Illegal operator following parameter in a subroutine signature at foo line 8, near "($a { }"
-syntax error at foo line 8, near "($a { }"
-Execution of foo aborted due to compilation errors.
-EOF
-
-eval "#line 8 foo\nsub t098 (\$a; \$b) { }";
-is $@, <<'EOF';
-Illegal operator following parameter in a subroutine signature at foo line 8, near "($a; "
-syntax error at foo line 8, near "($a; "
-Execution of foo aborted due to compilation errors.
-EOF
-
-eval "#line 8 foo\nsub t099 (\$\$) { }";
-is $@, <<EOF;
-Illegal character following sigil in a subroutine signature at foo line 8, near "(\$"
-syntax error at foo line 8, near "\$\$) "
-Execution of foo aborted due to compilation errors.
-EOF
-
-eval "#line 8 foo\nsub t101 (\@_) { }";
-like $@, qr/\ACan't use global \@_ in subroutine signature at foo line 8/;
-
-eval "#line 8 foo\nsub t102 (\%_) { }";
-like $@, qr/\ACan't use global \%_ in subroutine signature at foo line 8/;
 
 my $t103 = sub ($a) { $a || "z" };
 is prototype($t103), undef;

--- a/t/test.pl
+++ b/t/test.pl
@@ -1327,10 +1327,14 @@ sub setup_multiple_progs {
 
         open my $fh, '<', $file or die "Cannot open $file: $!\n" ;
         my $found;
+        my $preamble = "";
         while (<$fh>) {
             if (/^__END__/) {
                 $found = $found + 1; # don't use ++
                 last;
+            }
+            if (/^#\s+PREAMBLE\s+(.*)$/) {
+                $preamble .= "$1\n";
             }
         }
         # This is an internal error, and should never happen. All bar one of
@@ -1346,6 +1350,12 @@ sub setup_multiple_progs {
             unless $found;
 
         my ($t, @p) = _setup_one_file($fh, $file);
+        if (length $preamble) {
+            # @p consists of ($linenumber, $source) pairs, so we only want
+            # to prepend the preamble to the odd numbered elements.
+            # Additionally, the first two elements are (0, $filename).
+            $_ = $preamble . $_ for @p[ grep { $_ % 2 } 2 .. $#p ];
+        }
         $tests += $t;
         push @prgs, @p;
 


### PR DESCRIPTION
I'm planning to add a bunch more croak tests as part of the `signatures-named-params` branch, and was somewhat surprised to find we don't already use a file like this for that purpose. So I moved all the manual `eval and look at $@` tests out of signatures.t into this new file.