### PR TITLE
`.gitattributes`: `*.inc` recognized as Pawn

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,3 +26,5 @@ warnings.h linguist-generated
 *.t linguist-language=Perl
 *.h linguist-language=C
 *.fnc linguist-language=Text
+*.inc linguist-language=C
+cpan/Math-BigInt/t/*.inc linguist-language=Perl


### PR DESCRIPTION
Prevent that from happening in GH language stats.

It seems only `Math-BigInt` tests use `*.inc` for Perl code

https://github.com/search?q=repo%3APerl%2Fperl5%20path%3A*.inc&type=code

### Stats
<img width="216" height="126" alt="image" src="https://github.com/user-attachments/assets/27f7b16a-b318-4995-87b3-e48f5d40b698" />

10.6% is huge(ly mistaken here) 🙂

### Search
<img width="643" height="545" alt="image" src="https://github.com/user-attachments/assets/a6482db5-195c-460e-86f1-c26efbdd964c" />

A comparative excerpt from the link above (_where also `*.inc` with Perl in it is labeled as C++_).

[Pawn](https://fr.wikipedia.org/wiki/Pawn_(langage)) has *.inc as an extension (along with *.p and *.pwn which Perl, fortunately, doesn't use).