### PR TITLE
Turn off POSIX 2008 locales on AIX

### DIFF
--- a/hints/aix.sh
+++ b/hints/aix.sh
@@ -704,4 +704,7 @@ case "$osvers" in
     ;;
 esac
 
+# GH #23825
+d_duplocale='undef'
+
 # EOF

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -330,9 +330,10 @@ L</Modules and Pragmata> section.
 
 =over 4
 
-=item XXX-some-platform
+=item AIX
 
-XXX
+Thread-safe locale handling has been turned off on all releases due to
+apparent bugs in the underlying operating system support.
 
 =back
 


### PR DESCRIPTION
Fixes #23825

From the discussion in that ticket, it appears that the problem is the OS.


* This set of changes requires a perldelta entry, and it is included.

