### PR TITLE
Perl_newSVobject - adjusted for the default values

### DIFF
--- a/class.c
+++ b/class.c
@@ -38,14 +38,16 @@ Perl_newSVobject(pTHX_ Size_t fieldcount)
     SV *sv = newSV_type(SVt_PVOBJ);
 
     if (fieldcount) {
+        ObjectMAXFIELD(sv) = fieldcount - 1;
         Newx(ObjectFIELDS(sv), fieldcount, SV *);
         Zero(ObjectFIELDS(sv), fieldcount, SV *);
     }
+#ifdef DEBUGGING
     else {
-        ObjectFIELDS(sv) = NULL;
+        assert(!ObjectFIELDS(sv));
+        assert(ObjectMAXFIELD(sv) == -1);
     }
-    ObjectMAXFIELD(sv) = fieldcount - 1;
-
+#endif
     return sv;
 }
 


### PR DESCRIPTION
`newSV_type(SVt_PVOBJ)` does the following initialization:
* `ObjectMAXFIELD(sv) = -1;`
* `ObjectFIELDS(sv) = NULL;`

This commit makes two changes to `Perl_newSVobject` reflecting that:

1. There's no need for `Perl_newSVobject` to set either of these fields if `fieldcount` is zero, so that line is coverted into a DEBUGGING assert()` and one added for `ObjectMAXFIELD(sv)` for completeness.

2. When `fieldcount` is non-zero, setting `ObjectMAXFIELD(sv)` prior to the `Newx()` is more likely to result in the compiler realising that it only needs to do one `ObjectMAXFIELD(sv)` STORE rather than two.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
