### PR TITLE
perlclass.pod - remove mention of :writer from the TODO section

### DIFF
--- a/pod/perlclass.pod
+++ b/pod/perlclass.pod
@@ -401,22 +401,6 @@ mechanism that makes all field initializer expressions appear within the same
 CV on ADJUST blocks as well, merging them all into a single CV per class. This
 will make it faster to invoke if a class has more than one of them.
 
-=item * More accessor generator attributes
-
-Attributes to request that other kinds of accessor methods be generated for
-fields. Likely C<:writer>.
-
-    class X {
-        field $name :writer;
-    }
-
-Equivalent to
-
-    class X {
-        field $name;
-        method set_name ($new) { $name = $new; return $self; }
-    }
-
 =item * Metaprogramming
 
 An extension of the metaprogramming API (currently proposed by


### PR DESCRIPTION
As noted earlier in the file, it has been implemented and there don't seem to be any breaking changes planned to it.

Since constraints are being looked at, this commit adds mention of those instead.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
