### PR TITLE
toke.c: Generalize S_parse_ident()

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -6142,8 +6142,7 @@ S	|char * |force_version	|NN char *s				\
 				|int guessing
 S	|char * |force_word	|NN char *start 			\
 				|int token				\
-				|int check_keyword			\
-				|int allow_pack
+				|U32 flags
 RS	|SV *	|get_and_check_backslash_N_name_wrapper 		\
 				|SPTR const char *s			\
 				|EPTRQ const char * const e

--- a/embed.fnc
+++ b/embed.fnc
@@ -6168,8 +6168,8 @@ So	|SV *	|new_constant	|NULLOK const char *s			\
 				|NULLOK const char *type		\
 				|STRLEN typelen 			\
 				|NULLOK const char **error_msg
-S	|char * |parse_ident	|SPTR char *s				\
-				|EPTRQ char * const s_end		\
+S	|char * |parse_ident	|SPTR const char *s			\
+				|EPTRQ const char * const s_end 	\
 				|SPTR char **d				\
 				|EPTR char * const e			\
 				|bool is_utf8				\

--- a/embed.fnc
+++ b/embed.fnc
@@ -6174,6 +6174,11 @@ S	|char * |parse_ident	|SPTR const char *s			\
 				|EPTR char * const e			\
 				|bool is_utf8				\
 				|U32 flags
+S	|char * |parse_ident_no_copy					\
+				|SPTR const char *s			\
+				|EPTR const char * const s_end		\
+				|bool is_utf8				\
+				|U32 flags
 S	|int	|pending_ident
 RS	|char * |scan_const	|NN char *start
 RS	|char * |scan_formline	|NN char *s

--- a/embed.fnc
+++ b/embed.fnc
@@ -6171,9 +6171,8 @@ So	|SV *	|new_constant	|NULLOK const char *s			\
 S	|void	|parse_ident	|NN char **s				\
 				|SPTR char **d				\
 				|EPTR char * const e			\
-				|int allow_package			\
 				|bool is_utf8				\
-				|bool check_dollar
+				|U32 flags
 S	|int	|pending_ident
 RS	|char * |scan_const	|NN char *start
 RS	|char * |scan_formline	|NN char *s

--- a/embed.fnc
+++ b/embed.fnc
@@ -6168,7 +6168,8 @@ So	|SV *	|new_constant	|NULLOK const char *s			\
 				|NULLOK const char *type		\
 				|STRLEN typelen 			\
 				|NULLOK const char **error_msg
-S	|void	|parse_ident	|NN char **s				\
+S	|char * |parse_ident	|SPTR char *s				\
+				|EPTRQ char * const s_end		\
 				|SPTR char **d				\
 				|EPTR char * const e			\
 				|bool is_utf8				\

--- a/embed.fnc
+++ b/embed.fnc
@@ -6171,7 +6171,7 @@ So	|SV *	|new_constant	|NULLOK const char *s			\
 				|NULLOK const char **error_msg
 S	|void	|parse_ident	|NN char **s				\
 				|SPTR char **d				\
-				|EPTRQ char * const e			\
+				|EPTR char * const e			\
 				|int allow_package			\
 				|bool is_utf8				\
 				|bool check_dollar

--- a/embed.h
+++ b/embed.h
@@ -1688,6 +1688,7 @@
 #     define lop(a,b,c,d)                       S_lop(aTHX_ a,b,c,d)
 #     define missingterm(a,b)                   S_missingterm(aTHX_ a,b)
 #     define parse_ident(a,b,c,d,e,f)           S_parse_ident(aTHX_ a,b,c,d,e,f)
+#     define parse_ident_no_copy(a,b,c,d)       S_parse_ident_no_copy(aTHX_ a,b,c,d)
 #     define pending_ident()                    S_pending_ident(aTHX)
 #     define scan_const(a)                      S_scan_const(aTHX_ a)
 #     define scan_formline(a)                   S_scan_formline(aTHX_ a)

--- a/embed.h
+++ b/embed.h
@@ -1687,7 +1687,7 @@
 #     define intuit_more(a,b)                   S_intuit_more(aTHX_ a,b)
 #     define lop(a,b,c,d)                       S_lop(aTHX_ a,b,c,d)
 #     define missingterm(a,b)                   S_missingterm(aTHX_ a,b)
-#     define parse_ident(a,b,c,d,e,f)           S_parse_ident(aTHX_ a,b,c,d,e,f)
+#     define parse_ident(a,b,c,d,e)             S_parse_ident(aTHX_ a,b,c,d,e)
 #     define pending_ident()                    S_pending_ident(aTHX)
 #     define scan_const(a)                      S_scan_const(aTHX_ a)
 #     define scan_formline(a)                   S_scan_formline(aTHX_ a)

--- a/embed.h
+++ b/embed.h
@@ -1687,7 +1687,7 @@
 #     define intuit_more(a,b)                   S_intuit_more(aTHX_ a,b)
 #     define lop(a,b,c,d)                       S_lop(aTHX_ a,b,c,d)
 #     define missingterm(a,b)                   S_missingterm(aTHX_ a,b)
-#     define parse_ident(a,b,c,d,e)             S_parse_ident(aTHX_ a,b,c,d,e)
+#     define parse_ident(a,b,c,d,e,f)           S_parse_ident(aTHX_ a,b,c,d,e,f)
 #     define pending_ident()                    S_pending_ident(aTHX)
 #     define scan_const(a)                      S_scan_const(aTHX_ a)
 #     define scan_formline(a)                   S_scan_formline(aTHX_ a)

--- a/embed.h
+++ b/embed.h
@@ -1680,7 +1680,7 @@
 #     define force_next(a)                      S_force_next(aTHX_ a)
 #     define force_strict_version(a)            S_force_strict_version(aTHX_ a)
 #     define force_version(a,b)                 S_force_version(aTHX_ a,b)
-#     define force_word(a,b,c,d)                S_force_word(aTHX_ a,b,c,d)
+#     define force_word(a,b,c)                  S_force_word(aTHX_ a,b,c)
 #     define get_and_check_backslash_N_name_wrapper(a,b) S_get_and_check_backslash_N_name_wrapper(aTHX_ a,b)
 #     define incline(a,b)                       S_incline(aTHX_ a,b)
 #     define intuit_method(a,b,c)               S_intuit_method(aTHX_ a,b,c)

--- a/parser.h
+++ b/parser.h
@@ -10,6 +10,7 @@
  */
 
 #define YYEMPTY		(-2)
+#define PERL_IDENTIFIER_LENGTH  (256 * MAX_UNICODE_UTF8_BYTES)
 
 typedef struct {
     YYSTYPE val;    /* semantic value */
@@ -112,7 +113,7 @@ typedef struct yy_parser {
     U8		lex_fakeeof;	/* precedence at which to fake EOF */
     U8		lex_flags;
     COP		*saved_curcop;	/* the previous PL_curcop */
-    char	tokenbuf[ 256 * MAX_UNICODE_UTF8_BYTES ];
+    char	tokenbuf[ PERL_IDENTIFIER_LENGTH ];
     line_t	herelines;	/* number of lines in here-doc */
     line_t	preambling;	/* line # when processing $ENV{PERL5DB} */
 

--- a/proto.h
+++ b/proto.h
@@ -9462,7 +9462,7 @@ S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen, 
         assert(key); assert(sv)
 
 STATIC char *
-S_parse_ident(pTHX_ char *s, char * const s_end, char **d, char * const e, bool is_utf8, U32 flags);
+S_parse_ident(pTHX_ const char *s, const char * const s_end, char **d, char * const e, bool is_utf8, U32 flags);
 # define PERL_ARGS_ASSERT_PARSE_IDENT           \
         assert(s); assert(s_end); assert(d); assert(*d); assert(e); \
         assert(s <= s_end); assert(*d < e)

--- a/proto.h
+++ b/proto.h
@@ -9467,6 +9467,11 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end, char **d, char * co
         assert(s); assert(s_end); assert(d); assert(*d); assert(e); \
         assert(s <= s_end); assert(*d < e)
 
+STATIC char *
+S_parse_ident_no_copy(pTHX_ const char *s, const char * const s_end, bool is_utf8, U32 flags);
+# define PERL_ARGS_ASSERT_PARSE_IDENT_NO_COPY   \
+        assert(s); assert(s_end); assert(s < s_end)
+
 STATIC int
 S_pending_ident(pTHX);
 # define PERL_ARGS_ASSERT_PENDING_IDENT

--- a/proto.h
+++ b/proto.h
@@ -9464,7 +9464,7 @@ S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen, 
 STATIC void
 S_parse_ident(pTHX_ char **s, char **d, char * const e, int allow_package, bool is_utf8, bool check_dollar);
 # define PERL_ARGS_ASSERT_PARSE_IDENT           \
-        assert(s); assert(d); assert(*d); assert(e); assert(*d <= e)
+        assert(s); assert(d); assert(*d); assert(e); assert(*d < e)
 
 STATIC int
 S_pending_ident(pTHX);

--- a/proto.h
+++ b/proto.h
@@ -9461,10 +9461,11 @@ S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen, 
 # define PERL_ARGS_ASSERT_NEW_CONSTANT          \
         assert(key); assert(sv)
 
-STATIC void
-S_parse_ident(pTHX_ char **s, char **d, char * const e, bool is_utf8, U32 flags);
+STATIC char *
+S_parse_ident(pTHX_ char *s, char * const s_end, char **d, char * const e, bool is_utf8, U32 flags);
 # define PERL_ARGS_ASSERT_PARSE_IDENT           \
-        assert(s); assert(d); assert(*d); assert(e); assert(*d < e)
+        assert(s); assert(s_end); assert(d); assert(*d); assert(e); \
+        assert(s <= s_end); assert(*d < e)
 
 STATIC int
 S_pending_ident(pTHX);

--- a/proto.h
+++ b/proto.h
@@ -9462,7 +9462,7 @@ S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen, 
         assert(key); assert(sv)
 
 STATIC void
-S_parse_ident(pTHX_ char **s, char **d, char * const e, int allow_package, bool is_utf8, bool check_dollar);
+S_parse_ident(pTHX_ char **s, char **d, char * const e, bool is_utf8, U32 flags);
 # define PERL_ARGS_ASSERT_PARSE_IDENT           \
         assert(s); assert(d); assert(*d); assert(e); assert(*d < e)
 

--- a/proto.h
+++ b/proto.h
@@ -9421,7 +9421,7 @@ S_force_version(pTHX_ char *s, int guessing);
         assert(s)
 
 STATIC char *
-S_force_word(pTHX_ char *start, int token, int check_keyword, int allow_pack);
+S_force_word(pTHX_ char *start, int token, U32 flags);
 # define PERL_ARGS_ASSERT_FORCE_WORD            \
         assert(start)
 

--- a/toke.c
+++ b/toke.c
@@ -10331,7 +10331,8 @@ S_parse_ident(pTHX_ char **s, char **d, char * const e, int allow_package,
             * the code path that triggers the "Bad name after" warning
             * when looking for barewords.
             */
-           && !(check_dollar && (*s)[2] == '$')) {
+           && !(check_dollar && (*s)[2] == '$'))
+        {
             *(*d)++ = *(*s)++;
             *(*d)++ = *(*s)++;
         }
@@ -10395,6 +10396,7 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
     }
     *d = '\0';
     d = dest;
+
     if (*d) {
         /* Either a digit variable, or parse_ident() found an identifier
            (anything valid as a bareword), so job done and return.  */
@@ -10417,6 +10419,7 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
            Using ' as a leading package separator isn't allowed. :: is.   */
         return s;
     }
+
     /* Handle the opening { of @{...}, &{...}, *{...}, %{...}, ${...}  */
     if (*s == '{') {
         bracket = s - SvPVX(PL_linestr);
@@ -10426,7 +10429,6 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
             s = skipspace(s);
         }
     }
-
 
     /* Extract the first character of the variable name from 's' and
      * copy it, null terminated into 'd'. Note that this does not
@@ -10439,28 +10441,22 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
      *          1) control and space-type ones, like NUL, SOH, \t, and SPACE;
      *          2) '{'
      *     The final case currently doesn't get this far in the program, so we
-     *     don't test for it.  If that were to change, it would be ok to allow it.
+     *     don't test for it.  If that were to change, it would be ok to allow
+     *     it.
      *  b) When not under Unicode rules, any upper Latin1 character
      *  c) Otherwise, when unicode rules are used, all XIDS characters.
      *
-     *      Because all ASCII characters have the same representation whether
-     *      encoded in UTF-8 or not, we can use the foo_A macros below and '\0' and
-     *      '{' without knowing if is UTF-8 or not. */
+     * Because all ASCII characters have the same representation whether
+     * encoded in UTF-8 or not, we can use the foo_A macros below and '\0' and
+     * '{' without knowing if is UTF-8 or not. */
 
-    if ((s <= PL_bufend - ((is_utf8)
-                          ? UTF8SKIP(s)
-                          : 1))
-        && (
-            isGRAPH_A(*s)
-            ||
-            ( is_utf8
-              ? isIDFIRST_utf8_safe(s, PL_bufend)
-              : (isGRAPH_L1(*s)
-                 && LIKELY((U8) *s != LATIN1_TO_NATIVE(0xAD))
-                )
-            )
-        )
-    ){
+    if (   (s <= PL_bufend - ((is_utf8) ? UTF8SKIP(s) : 1))
+        && (  isGRAPH_A(*s)
+            || (is_utf8
+               ? isIDFIRST_utf8_safe(s, PL_bufend)
+               : (   isGRAPH_L1(*s)
+                  && LIKELY((U8) *s != LATIN1_TO_NATIVE(0xAD))))))
+    {
         if (is_utf8) {
             const STRLEN skip = UTF8SKIP(s);
             STRLEN i;
@@ -10474,7 +10470,7 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
         }
     }
 
-    /* special case to handle ${10}, ${11} the same way we handle ${1} etc */
+    /* special case to handle ${10}, ${11} the same way we handle $1 etc */
     if (isDIGIT(*d)) {
         bool is_zero= *d == '0' ? TRUE : FALSE;
         char *digit_start= d;
@@ -10504,8 +10500,8 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
         bool skip;
         char *s2;
         /* If we were processing {...} notation then...  */
-        if (isIDFIRST_lazy_if_safe(d, e, is_utf8)
-            || (!isPRINT(*d) /* isCNTRL(d), plus all non-ASCII */
+        if (   isIDFIRST_lazy_if_safe(d, e, is_utf8)
+            || (  ! isPRINT(*d) /* isCNTRL(d), plus all non-ASCII */
                  && isWORDCHAR(*s))
         ) {
             /* note we have to check for a normal identifier first,

--- a/toke.c
+++ b/toke.c
@@ -10331,8 +10331,6 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
     const bool check_dollar = flags & CHECK_DOLLAR;
 
     while (s < s_end) {
-        if (*d >= e)
-            croak("%s", ident_too_long);
 
         /* For non-UTF8, variables that match ASCII \w are a superset of
          * variables that start with IDFIRST, so we have to look at the
@@ -10352,8 +10350,9 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
 
             /* Here we have found the end of the identifier */
             Size_t this_length = t - s;
-            if (*d + this_length > e)
-                croak("%s", ident_too_long);
+            if (*d + this_length >= e) {
+                goto too_long;
+            }
 
             /* And copy the whole thing in one operation */
             Copy(s, *d, this_length, char);
@@ -10366,13 +10365,21 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
              * digit */
             do {
                 *(*d)++ = *s++;
-            } while (isWORDCHAR_A(*s) && *d < e);
+
+                if (*d >= e) {
+                    goto too_long;
+                }
+            } while (isWORDCHAR_A(*s));
         }
         else if (   allow_package
                  && *s == '\''
                  && FEATURE_APOS_AS_NAME_SEP_IS_ENABLED
                  && isIDFIRST_lazy_if_safe(s + 1, s_end, is_utf8))
         {   /* Convert the apostrophe to "::" */
+            if (*d >= e - 2) {
+                goto too_long;
+            }
+
             *(*d)++ = ':';
             *(*d)++ = ':';
             s++;
@@ -10384,6 +10391,10 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
             */
            && !(check_dollar && s[2] == '$'))
         {
+            if (*d >= e - 2) {
+                goto too_long;
+            }
+
             *(*d)++ = *s++;
             *(*d)++ = *s++;
         }
@@ -10398,6 +10409,9 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
      * function declares it as const so as to indicate that it doesn't change
      * it, and it can be called using a const parameter */
     return (char *) s;
+
+  too_long:
+    croak("%s", ident_too_long);
 }
 
 char *

--- a/toke.c
+++ b/toke.c
@@ -10372,24 +10372,16 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
             } while (isWORDCHAR_A(*s));
         }
         else if (   allow_package
-                 && *s == '\''
-                 && FEATURE_APOS_AS_NAME_SEP_IS_ENABLED
-                 && isIDFIRST_lazy_if_safe(s + 1, s_end, is_utf8))
-        {   /* Convert the apostrophe to "::" */
-            if (*d >= e - 2) {
-                goto too_long;
-            }
-
-            *(*d)++ = ':';
-            *(*d)++ = ':';
-            s++;
-        }
-        else if (allow_package && *s == ':' && s[1] == ':'
-           /* Disallow things like Foo::$bar. For the curious, this is
-            * the code path that triggers the "Bad name after" warning
-            * when looking for barewords.
-            */
-           && !(check_dollar && s[2] == '$'))
+                 && (   (   *s == '\''
+                         && FEATURE_APOS_AS_NAME_SEP_IS_ENABLED
+                         && isIDFIRST_lazy_if_safe(s+1, s_end, is_utf8))
+                            /* Below we convert the apostrophe to "::" */
+                     || (   *s == ':' && s[1] == ':'
+                            /* Disallow things like Foo::$bar. For the
+                             * curious, this is the code path that triggers
+                             * the "Bad name after" warning when looking for
+                             * barewords. */
+                          && !(check_dollar && s[2] == '$'))))
         {
             if (*d >= e - 2) {
                 goto too_long;
@@ -10397,7 +10389,7 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
 
             *(*d)++ = ':';
             *(*d)++ = ':';
-            s += 2;
+            s += (*s == ':') ? 2 : 1;
         }
         else    /* None of the above means have come to the end of any
                    identifier*/

--- a/toke.c
+++ b/toke.c
@@ -173,6 +173,7 @@ static const char ident_var_zero_multi_digit[] = "Numeric variables with more th
 #define CHECK_DOLLAR                (1 << 2)
 #define IDFIRST_ONLY                (1 << 3)
 #define STOP_AT_FIRST_NON_DIGIT     (1 << 4)
+#define CHECK_ONLY                  (1 << 5)
 
 #ifdef DEBUGGING
 static const char* const lex_state_names[] = {
@@ -10327,7 +10328,13 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
      * identifier ends in the input.  If no identifier was found, the return
      * will be the the input 's' unchanged.
      *
-     * If the identifier is illegal, the function croaks.
+     * If the identifier is illegal, the function croaks unless this flag is
+     * passed in: */
+    const bool check_only = flags & CHECK_ONLY;
+
+    /* In this case NULL is returned instead of croaking, and the contents
+     * of '*d' are undefined.
+     *
      * The possible reasons for failure are:
      *  1) There is not enough room for the entire source identifier to be
      *     copied
@@ -10396,8 +10403,12 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
             } while (isDIGIT_A(*s));
 
             /* Leading zeros are not permitted */
-            if (is_zero && *d - digit_start > 1)
+            if (is_zero && *d - digit_start > 1) {
+                if (check_only) {
+                    return NULL;
+                }
                 croak(ident_var_zero_multi_digit);
+            }
 
             break;
         }
@@ -10446,6 +10457,10 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
     return (char *) s;
 
   too_long:
+    if (check_only) {
+        return NULL;
+    }
+
     croak("%s", ident_too_long);
 }
 

--- a/toke.c
+++ b/toke.c
@@ -170,6 +170,7 @@ static const char ident_var_zero_multi_digit[] = "Numeric variables with more th
 /* Bits in the flags parameter of various functions */
 #define CHECK_KEYWORD               (1 << 0)
 #define ALLOW_PACKAGE               (1 << 1)
+#define CHECK_DOLLAR                (1 << 2)
 
 #ifdef DEBUGGING
 static const char* const lex_state_names[] = {
@@ -5262,8 +5263,7 @@ yyl_sigvar(pTHX_ char *s)
             char *dest = PL_tokenbuf + 1;
             /* read var name, including sigil, into PL_tokenbuf */
             PL_tokenbuf[0] = sigil;
-            parse_ident(&s, &dest, C_ARRAY_END(PL_tokenbuf),
-                0, cBOOL(UTF), FALSE);
+            parse_ident(&s, &dest, C_ARRAY_END(PL_tokenbuf), cBOOL(UTF), 0);
             *dest = '\0';
             assert(PL_tokenbuf[1]); /* we have a variable name */
         }
@@ -10291,8 +10291,8 @@ S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen,
 }
 
 STATIC void
-S_parse_ident(pTHX_ char **s, char **d, char * const e, int allow_package,
-                    bool is_utf8, bool check_dollar)
+S_parse_ident(pTHX_ char **s, char **d, char * const e, bool is_utf8,
+                    U32 flags)
 {
     PERL_ARGS_ASSERT_PARSE_IDENT;
 
@@ -10317,10 +10317,12 @@ S_parse_ident(pTHX_ char **s, char **d, char * const e, int allow_package,
      * variable path.  Each iteration of the loop below picks up one segment
      * of the path.  If the apostrophe is allowed as a package separator, it
      * is converted to "::", so later code doesn't have to concern itself with
-     * this possibility.
-     *
-     * 'check_dollar' is used to look for and stop parsing before the dollar
+     * this possibility. */
+    const bool allow_package = flags & ALLOW_PACKAGE;
+
+    /* 'check_dollar' is used to look for and stop parsing before the dollar
      * in things like Foo::$bar */
+    const bool check_dollar = flags & CHECK_DOLLAR;
 
     while (*s < PL_bufend) {
         if (*d >= e)
@@ -10394,7 +10396,8 @@ Perl_scan_word(pTHX_ char *s, char *dest, STRLEN destlen, int allow_package, STR
     char * const e = d + destlen - 3;  /* two-character token, ending NUL */
     bool is_utf8 = cBOOL(UTF);
 
-    parse_ident(&s, &d, e, allow_package, is_utf8, TRUE);
+    parse_ident(&s, &d, e, is_utf8,
+                (CHECK_DOLLAR | ((allow_package) ? ALLOW_PACKAGE : 0)));
     *d = '\0';
     *slp = d - dest;
     return s;
@@ -10435,7 +10438,7 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
             croak(ident_var_zero_multi_digit);
     }
     else {  /* See if it is a "normal" identifier */
-        parse_ident(&s, &d, e, 1, is_utf8, FALSE);
+        parse_ident(&s, &d, e, is_utf8, ALLOW_PACKAGE);
     }
     *d = '\0';
     d = dest;
@@ -10556,7 +10559,8 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
                    (the later check for } being at the expected point will trap
                    cases where this doesn't pan out.)  */
                 d += advance;
-                parse_ident(&s, &d, e, 1, is_utf8, TRUE);
+                parse_ident(&s, &d, e, is_utf8, ( ALLOW_PACKAGE
+                                                 |CHECK_DOLLAR));
                 *d = '\0';
             }
             else { /* caret word: ${^Foo} ${^CAPTURE[0]} */

--- a/toke.c
+++ b/toke.c
@@ -10351,12 +10351,13 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
             }
 
             /* Here we have found the end of the identifier */
-            if (*d + (t - s) > e)
+            Size_t this_length = t - s;
+            if (*d + this_length > e)
                 croak("%s", ident_too_long);
 
             /* And copy the whole thing in one operation */
-            Copy(s, *d, t - s, char);
-            *d += t - s;
+            Copy(s, *d, this_length, char);
+            *d += this_length;
             s = t;
         }
         else if ( isWORDCHAR_A(*s) ) {

--- a/toke.c
+++ b/toke.c
@@ -10395,8 +10395,9 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
                 goto too_long;
             }
 
-            *(*d)++ = *s++;
-            *(*d)++ = *s++;
+            *(*d)++ = ':';
+            *(*d)++ = ':';
+            s += 2;
         }
         else    /* None of the above means have come to the end of any
                    identifier*/

--- a/toke.c
+++ b/toke.c
@@ -5265,7 +5265,6 @@ yyl_sigvar(pTHX_ char *s)
             PL_tokenbuf[0] = sigil;
             s = parse_ident(s, PL_bufend, &dest, C_ARRAY_END(PL_tokenbuf),
                             cBOOL(UTF), 0);
-            *dest = '\0';
             assert(PL_tokenbuf[1]); /* we have a variable name */
         }
         else {
@@ -10309,8 +10308,9 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
      *
      * The function copies the identifier into the destination starting at *d
      * (whose upper bound is 'e') and advances *d to point to just beyond the
-     * end of the identifier.  The reason it needs to copy is that it may
-     * convert apostrophe package separators into double colons.
+     * end of the identifier, setting **d to a NUL character.  The reason it
+     * needs to copy is that it may convert apostrophe package separators into
+     * double colons.
      *
      * Upon success, it returns the position in s just beyond where the
      * identifier ends in the input.  If no identifier was found, the return
@@ -10392,6 +10392,8 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
             break;
     }
 
+    **d = '\0';
+
     /* Cast away const, because many of our callers don't have it; this
      * function declares it as const so as to indicate that it doesn't change
      * it, and it can be called using a const parameter */
@@ -10409,7 +10411,6 @@ Perl_scan_word(pTHX_ char *s, char *dest, STRLEN destlen, int allow_package, STR
 
     s = parse_ident(s, PL_bufend, &d, e, is_utf8,
                     (CHECK_DOLLAR | ((allow_package) ? ALLOW_PACKAGE : 0)));
-    *d = '\0';
     *slp = d - dest;
     return s;
 }
@@ -10447,11 +10448,11 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
         }
         if (is_zero && d - digit_start > 1)
             croak(ident_var_zero_multi_digit);
+        *d = '\0';
     }
     else {  /* See if it is a "normal" identifier */
         s = parse_ident(s, PL_bufend, &d, e, is_utf8, ALLOW_PACKAGE);
     }
-    *d = '\0';
     d = dest;
 
     if (*d) {
@@ -10572,7 +10573,6 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
                 d += advance;
                 s = parse_ident(s, PL_bufend, &d, e, is_utf8,
                                 (ALLOW_PACKAGE | CHECK_DOLLAR));
-                *d = '\0';
             }
             else { /* caret word: ${^Foo} ${^CAPTURE[0]} */
                 d++;

--- a/toke.c
+++ b/toke.c
@@ -10385,16 +10385,15 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
         else if (stop_at_first_non_digit && isDIGIT_A(*s)) {
             bool is_zero = *s == '0';
             char *digit_start= *d;
-            *(*d)++ = *s++;
 
             /* Stop at the first non-digit */
-            while (s < s_end && isDIGIT(*s)) {
+            do {
+                *(*d)++ = *s++;
+
                 if (*d >= e) {
                     goto too_long;
                 }
-
-                *(*d)++ = *s++;
-            }
+            } while (isDIGIT_A(*s));
 
             /* Leading zeros are not permitted */
             if (is_zero && *d - digit_start > 1)

--- a/toke.c
+++ b/toke.c
@@ -14104,34 +14104,8 @@ Perl_valid_identifier_pve(pTHX_ const char *s, const char *end, U32 flags)
     if(end <= s)
         return false;
 
-    if(flags & SVf_UTF8) {
-        if(!isIDFIRST_utf8_safe((U8 *)s, (U8 *)end))
-            return false;
-
-        while(s < end) {
-            s += UTF8SKIP((U8 *)s);
-            if(s == end)
-                break;
-            if(!isIDCONT_utf8_safe((U8 *)s, (U8 *)end))
-                return false;
-        }
-        return true;
-    }
-    else {
-        if(!isIDFIRST(s[0]))
-            return false;
-
-        while(s < end) {
-            s += 1;
-            if(s == end)
-                break;
-            if(!isIDCONT(s[0]))
-                return false;
-        }
-        return true;
-    }
-
-    return false;
+    return end == parse_ident_no_copy(s, end, cBOOL(flags & SVf_UTF8),
+                                      IDFIRST_ONLY);
 }
 
 /*

--- a/toke.c
+++ b/toke.c
@@ -10284,7 +10284,7 @@ S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen,
     return SvREFCNT_inc_simple_NN(sv);
 }
 
-PERL_STATIC_INLINE void
+STATIC void
 S_parse_ident(pTHX_ char **s, char **d, char * const e, int allow_package,
                     bool is_utf8, bool check_dollar)
 {

--- a/toke.c
+++ b/toke.c
@@ -167,6 +167,10 @@ static const char ident_var_zero_multi_digit[] = "Numeric variables with more th
 */
 #define YYL_RETRY (-1)
 
+/* Bits in the flags parameter of various functions */
+#define CHECK_KEYWORD               (1 << 0)
+#define ALLOW_PACKAGE               (1 << 1)
+
 #ifdef DEBUGGING
 static const char* const lex_state_names[] = {
     "KNOWNEXT",
@@ -238,7 +242,7 @@ static const char* const lex_state_names[] = {
 #define TERM(retval) return (CLINE, PL_expect = XOPERATOR, PL_bufptr = s, REPORT(retval))
 #define PHASERBLOCK(f) return (pl_yylval.ival=f, PL_expect = XBLOCK, PL_bufptr = s, REPORT((int)PHASER))
 #define POSTDEREF(f) return (PL_bufptr = s, S_postderef(aTHX_ REPORT(f),s[1]))
-#define LOOPX(f) return (PL_bufptr = force_word(s,BAREWORD,TRUE,FALSE), \
+#define LOOPX(f) return (PL_bufptr = force_word(s, BAREWORD, CHECK_KEYWORD), \
                          pl_yylval.ival=f, \
                          PL_expect = PL_nexttoke ? XOPERATOR : XTERM, \
                          REPORT((int)LOOPEX))
@@ -2263,10 +2267,12 @@ S_newSV_maybe_utf8(pTHX_ const char *const start, STRLEN len)
  */
 
 STATIC char *
-S_force_word(pTHX_ char *start, int token, int check_keyword, int allow_pack)
+S_force_word(pTHX_ char *start, int token, U32 flags)
 {
     char *s;
     STRLEN len;
+    const bool check_keyword = flags & CHECK_KEYWORD;
+    const bool allow_pack    = flags & ALLOW_PACKAGE;
 
     PERL_ARGS_ASSERT_FORCE_WORD;
 
@@ -5152,12 +5158,12 @@ S_tokenize_use(pTHX_ int is_use, char *s) {
             force_next(BAREWORD);
         }
         else if (*s == 'v') {
-            s = force_word(s,BAREWORD,FALSE,TRUE);
+            s = force_word(s, BAREWORD, ALLOW_PACKAGE);
             s = force_version(s, FALSE);
         }
     }
     else {
-        s = force_word(s,BAREWORD,FALSE,TRUE);
+        s = force_word(s, BAREWORD, ALLOW_PACKAGE);
         s = force_version(s, FALSE);
     }
     pl_yylval.ival = is_use;
@@ -5888,7 +5894,7 @@ yyl_hyphen(pTHX_ char *s)
             s++;
 
         if (memBEGINs(s, (STRLEN) (PL_bufend - s), "=>")) {
-            s = force_word(PL_bufptr,BAREWORD,FALSE,FALSE);
+            s = force_word(PL_bufptr, BAREWORD, 0);
             DEBUG_T( { printbuf("### Saw unary minus before =>, forcing word %s\n", s); } );
             OPERATOR(PERLY_MINUS);              /* unary minus */
         }
@@ -5970,7 +5976,7 @@ yyl_hyphen(pTHX_ char *s)
                 TOKEN(ARROW);
             }
             if (isIDFIRST_lazy_if_safe(s, PL_bufend, UTF)) {
-                s = force_word(s,METHCALL0,FALSE,TRUE);
+                s = force_word(s, METHCALL0, ALLOW_PACKAGE);
                 TOKEN(ARROW);
             }
             else if (*s == '$')
@@ -6347,7 +6353,7 @@ yyl_leftcurly(pTHX_ char *s, const U8 formbrack)
                 d++;
             if (*d == '}') {
                 const char minus = (PL_tokenbuf[0] == '-');
-                s = force_word(s + minus, BAREWORD, FALSE, TRUE);
+                s = force_word(s + minus, BAREWORD, ALLOW_PACKAGE);
                 if (minus)
                     force_next(PERLY_MINUS);
             }
@@ -7077,7 +7083,7 @@ yyl_require(pTHX_ char *s, I32 orig_keyword)
             || (s = force_version(s, TRUE), *s == 'v'))
     {
         *PL_tokenbuf = '\0';
-        s = force_word(s,BAREWORD,TRUE,TRUE);
+        s = force_word(s, BAREWORD, CHECK_KEYWORD | ALLOW_PACKAGE);
         if (isIDFIRST_lazy_if_safe(PL_tokenbuf,
                                    C_ARRAY_END(PL_tokenbuf),
                                    UTF))
@@ -8048,7 +8054,7 @@ yyl_word_or_keyword(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword, struct
     case KEY_class:
         ck_warner_d(packWARN(WARN_EXPERIMENTAL__CLASS), "class is experimental");
 
-        s = force_word(s,BAREWORD,FALSE,TRUE);
+        s = force_word(s, BAREWORD, ALLOW_PACKAGE);
         s = skipspace(s);
         s = force_strict_version(s);
         PL_expect = XATTRBLOCK;
@@ -8528,7 +8534,7 @@ yyl_word_or_keyword(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword, struct
         LOP(OP_PACK,XTERM);
 
     case KEY_package:
-        s = force_word(s,BAREWORD,FALSE,TRUE);
+        s = force_word(s, BAREWORD, ALLOW_PACKAGE);
         s = skipspace(s);
         s = force_strict_version(s);
         PREBLOCK(KW_PACKAGE);
@@ -8711,7 +8717,7 @@ yyl_word_or_keyword(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword, struct
         checkcomma(s,PL_tokenbuf,"subroutine name");
         s = skipspace(s);
         PL_expect = XTERM;
-        s = force_word(s,BAREWORD,TRUE,TRUE);
+        s = force_word(s, BAREWORD, CHECK_KEYWORD | ALLOW_PACKAGE);
         LOP(OP_SORT,XREF);
 
     case KEY_split:

--- a/toke.c
+++ b/toke.c
@@ -10296,29 +10296,65 @@ S_parse_ident(pTHX_ char **s, char **d, char * const e, int allow_package,
 {
     PERL_ARGS_ASSERT_PARSE_IDENT;
 
+    /* This function parses the string pointed to by '*s' (whose upper bound
+     * is 'send') looking for an identifier.  It stops at the first character
+     * that isn't in one of the types of identifiers looked for, which are:
+     *
+     * 1) A normal identifier whose first character matches IDFIRST followed
+     *    by any number of characters which match IDCONT.
+     * 2) An identifier that begins with an ASCII digit followed by any number
+     *    of ASCII \w characters
+     *
+     * The function copies the identifier into the destination starting at *d
+     * (whose upper bound is 'e') and advances *d to point to just beyond the
+     * end of the identifier.  The reason it needs to copy is that it may
+     * convert apostrophe package separators into double colons.
+     *
+     * The function croaks if there is not enough room for the entire source
+     * identifier to be copied.
+     *
+     * When 'allow_package' is non-zero, the function parses a full package
+     * variable path.  Each iteration of the loop below picks up one segment
+     * of the path.  If the apostrophe is allowed as a package separator, it
+     * is converted to "::", so later code doesn't have to concern itself with
+     * this possibility.
+     *
+     * 'check_dollar' is used to look for and stop parsing before the dollar
+     * in things like Foo::$bar */
+
     while (*s < PL_bufend) {
         if (*d >= e)
             croak("%s", ident_too_long);
+
+        /* For non-UTF8, variables that match ASCII \w are a superset of
+         * variables that start with IDFIRST, so we have to look at the
+         * Unicode definition only when UTF-8 is in effect.  We have to check
+         * for the subset before checking for the superset. */
         Size_t advance;
         if (is_utf8 && (advance = isIDFIRST_utf8_safe(*s, PL_bufend))) {
-             /* The UTF-8 case must come first, otherwise things
-             * like c\N{COMBINING TILDE} would start failing, as the
-             * isWORDCHAR_A case below would gobble the 'c' up.
-             */
 
+            /* Find the end of the identifier by accumulating characters until
+             * find a non-identifier character */
             char *t = *s + advance;
             while ((advance = isIDCONT_utf8_safe((const U8*) t,
                                                  (const U8*) PL_bufend)))
             {
                 t += advance;
             }
+
+            /* Here we have found the end of the identifier */
             if (*d + (t - *s) > e)
                 croak("%s", ident_too_long);
+
+            /* And copy the whole thing in one operation */
             Copy(*s, *d, t - *s, char);
             *d += t - *s;
             *s = t;
         }
         else if ( isWORDCHAR_A(**s) ) {
+
+            /* This is the superset; it accepts \w+, including an initial
+             * digit */
             do {
                 *(*d)++ = *(*s)++;
             } while (isWORDCHAR_A(**s) && *d < e);
@@ -10327,7 +10363,7 @@ S_parse_ident(pTHX_ char **s, char **d, char * const e, int allow_package,
                  && **s == '\''
                  && FEATURE_APOS_AS_NAME_SEP_IS_ENABLED
                  && isIDFIRST_lazy_if_safe((*s)+1, PL_bufend, is_utf8))
-        {
+        {   /* Convert the apostrophe to "::" */
             *(*d)++ = ':';
             *(*d)++ = ':';
             (*s)++;
@@ -10342,7 +10378,8 @@ S_parse_ident(pTHX_ char **s, char **d, char * const e, int allow_package,
             *(*d)++ = *(*s)++;
             *(*d)++ = *(*s)++;
         }
-        else
+        else    /* None of the above means have come to the end of any
+                   identifier*/
             break;
     }
     return;

--- a/toke.c
+++ b/toke.c
@@ -172,6 +172,7 @@ static const char ident_var_zero_multi_digit[] = "Numeric variables with more th
 #define ALLOW_PACKAGE               (1 << 1)
 #define CHECK_DOLLAR                (1 << 2)
 #define IDFIRST_ONLY                (1 << 3)
+#define STOP_AT_FIRST_NON_DIGIT     (1 << 4)
 
 #ifdef DEBUGGING
 static const char* const lex_state_names[] = {
@@ -10305,10 +10306,16 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
      * 1) A normal identifier whose first character matches IDFIRST followed
      *    by any number of characters which match IDCONT.
      * 2) An identifier that begins with an ASCII digit followed by any number
-     *    of ASCII \w characters.  This type can be prohibited, so that
-     *    anything that doesn't match type 1) is not considered an identifier.
-     */
+     *    of ASCII \w characters.  As a special case of this, it can
+     *    optionally stop parsing at the first non-digit, returning just the
+     *    initial digits.  */
+    const bool stop_at_first_non_digit = flags & STOP_AT_FIRST_NON_DIGIT;
+
+     /*    This type of identifier can be completely prohibited, so that
+      *    anything that doesn't match type 1) is not considered to be an
+      *    identifier. */
     const bool idfirst_only = flags & IDFIRST_ONLY;
+    assert((stop_at_first_non_digit && idfirst_only) == 0);
 
     /* The function copies the identifier into the destination starting at *d
      * (whose upper bound is 'e') and advances *d to point to just beyond the
@@ -10320,8 +10327,12 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
      * identifier ends in the input.  If no identifier was found, the return
      * will be the the input 's' unchanged.
      *
-     * The function croaks if there is not enough room for the entire source
-     * identifier to be copied.
+     * If the identifier is illegal, the function croaks.
+     * The possible reasons for failure are:
+     *  1) There is not enough room for the entire source identifier to be
+     *     copied
+     *  2) 'stop_at_first_non_digit' is in effect and the identifier name has
+     *     leading zeros
      *
      * When 'allow_package' is non-zero, the function parses a full package
      * variable path.  Each iteration of the loop below picks up one segment
@@ -10370,6 +10381,26 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
             /* And copy the whole thing in one operation */
             Copy(this_start, *d, this_length, char);
             *d += this_length;
+        }
+        else if (stop_at_first_non_digit && isDIGIT_A(*s)) {
+            bool is_zero = *s == '0';
+            char *digit_start= *d;
+            *(*d)++ = *s++;
+
+            /* Stop at the first non-digit */
+            while (s < s_end && isDIGIT(*s)) {
+                if (*d >= e) {
+                    goto too_long;
+                }
+
+                *(*d)++ = *s++;
+            }
+
+            /* Leading zeros are not permitted */
+            if (is_zero && *d - digit_start > 1)
+                croak(ident_var_zero_multi_digit);
+
+            break;
         }
         else if (! idfirst_only && isWORDCHAR_A(*s) ) {
 
@@ -10456,26 +10487,14 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
 
     if (isSPACE(*s) || !*s)
         s = skipspace(s);
-    if (isDIGIT(*s)) { /* handle $0 and $1 $2 and $10 and etc */
-        bool is_zero = *s == '0';
-        char *digit_start= d;
-        *d++ = *s++;
-        while (s < PL_bufend && isDIGIT(*s)) {
-            if (d >= e)
-                croak("%s", ident_too_long);
-            *d++ = *s++;
-        }
-        if (is_zero && d - digit_start > 1)
-            croak(ident_var_zero_multi_digit);
-        *d = '\0';
-    }
-    else {  /* See if it is a "normal" identifier */
-        s = parse_ident(s, PL_bufend, &d, e, is_utf8, ALLOW_PACKAGE);
-    }
+
+    /* See if it is a "normal" identifier */
+    s = parse_ident(s, PL_bufend, &d, e, is_utf8,
+                    (ALLOW_PACKAGE | STOP_AT_FIRST_NON_DIGIT));
     d = dest;
 
     if (*d) {
-        /* Either a digit variable, or parse_ident() found an identifier
+        /* Here parse_ident() found a digit variable or an identifier
            (anything valid as a bareword), so job done and return.  */
         if (PL_lex_state != LEX_NORMAL)
             PL_lex_state = LEX_INTERPENDMAYBE;

--- a/toke.c
+++ b/toke.c
@@ -10338,26 +10338,31 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
          * for the subset before checking for the superset. */
         Size_t advance;
         if (is_utf8 && (advance = isIDFIRST_utf8_safe(s, s_end))) {
+            const char *this_start = s;
+            s += advance;
 
             /* Find the end of the identifier by accumulating characters until
              * find a non-identifier character */
-            const char *t = s + advance;
-            while ((advance = isIDCONT_utf8_safe((const U8*) t,
-                                                 (const U8*) s_end)))
-            {
-                t += advance;
+            while (s < s_end) {
+                    advance = isIDCONT_utf8_safe((const U8*) s,
+                                                    (const U8*) s_end);
+                    if (advance == 0) { /* Not an identifier character */
+                        break;
+                    }
+
+                s += advance;
             }
 
             /* Here we have found the end of the identifier */
-            Size_t this_length = t - s;
+            Size_t this_length = s - this_start;
+
             if (*d + this_length >= e) {
                 goto too_long;
             }
 
             /* And copy the whole thing in one operation */
-            Copy(s, *d, this_length, char);
+            Copy(this_start, *d, this_length, char);
             *d += this_length;
-            s = t;
         }
         else if ( isWORDCHAR_A(*s) ) {
 

--- a/toke.c
+++ b/toke.c
@@ -10567,17 +10567,11 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
 
     /* special case to handle ${10}, ${11} the same way we handle $1 etc */
     if (isDIGIT(*d)) {
-        bool is_zero = *d == '0';
-        char *digit_start= d;
-        while (s < PL_bufend && isDIGIT(*s)) {
-            d++;
-            if (d >= e)
-                croak("%s", ident_too_long);
-            *d= *s++;
-        }
-        if (is_zero && d - digit_start >= 1) /* d points at the last digit */
-            croak(ident_var_zero_multi_digit);
-        d[1] = '\0';
+        s = parse_ident(s - 1, PL_bufend, &d, e, is_utf8,
+                        STOP_AT_FIRST_NON_DIGIT);
+
+        /* The code below is expecting d to point to the final digit */
+        d--;
     }
 
     /* Convert $^F, ${^F} and the ^F of ${^FOO} to control characters */

--- a/toke.c
+++ b/toke.c
@@ -10380,7 +10380,7 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
     if (isSPACE(*s) || !*s)
         s = skipspace(s);
     if (isDIGIT(*s)) { /* handle $0 and $1 $2 and $10 and etc */
-        bool is_zero= *s == '0' ? TRUE : FALSE;
+        bool is_zero = *s == '0';
         char *digit_start= d;
         *d++ = *s++;
         while (s < PL_bufend && isDIGIT(*s)) {
@@ -10472,7 +10472,7 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
 
     /* special case to handle ${10}, ${11} the same way we handle $1 etc */
     if (isDIGIT(*d)) {
-        bool is_zero= *d == '0' ? TRUE : FALSE;
+        bool is_zero = *d == '0';
         char *digit_start= d;
         while (s < PL_bufend && isDIGIT(*s)) {
             d++;

--- a/toke.c
+++ b/toke.c
@@ -171,6 +171,7 @@ static const char ident_var_zero_multi_digit[] = "Numeric variables with more th
 #define CHECK_KEYWORD               (1 << 0)
 #define ALLOW_PACKAGE               (1 << 1)
 #define CHECK_DOLLAR                (1 << 2)
+#define IDFIRST_ONLY                (1 << 3)
 
 #ifdef DEBUGGING
 static const char* const lex_state_names[] = {
@@ -10304,9 +10305,12 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
      * 1) A normal identifier whose first character matches IDFIRST followed
      *    by any number of characters which match IDCONT.
      * 2) An identifier that begins with an ASCII digit followed by any number
-     *    of ASCII \w characters
-     *
-     * The function copies the identifier into the destination starting at *d
+     *    of ASCII \w characters.  This type can be prohibited, so that
+     *    anything that doesn't match type 1) is not considered an identifier.
+     */
+    const bool idfirst_only = flags & IDFIRST_ONLY;
+
+    /* The function copies the identifier into the destination starting at *d
      * (whose upper bound is 'e') and advances *d to point to just beyond the
      * end of the identifier, setting **d to a NUL character.  The reason it
      * needs to copy is that it may convert apostrophe package separators into
@@ -10337,15 +10341,18 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
          * Unicode definition only when UTF-8 is in effect.  We have to check
          * for the subset before checking for the superset. */
         Size_t advance;
-        if (is_utf8 && (advance = isIDFIRST_utf8_safe(s, s_end))) {
+        if (   (advance = isIDFIRST_lazy_if_safe(s, s_end, is_utf8))
+            && (is_utf8 || idfirst_only))
+        {
             const char *this_start = s;
             s += advance;
 
             /* Find the end of the identifier by accumulating characters until
              * find a non-identifier character */
             while (s < s_end) {
-                    advance = isIDCONT_utf8_safe((const U8*) s,
-                                                    (const U8*) s_end);
+                    advance = isIDCONT_lazy_if_safe((const U8*) s,
+                                                    (const U8*) s_end,
+                                                    is_utf8);
                     if (advance == 0) { /* Not an identifier character */
                         break;
                     }
@@ -10364,7 +10371,7 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
             Copy(this_start, *d, this_length, char);
             *d += this_length;
         }
-        else if ( isWORDCHAR_A(*s) ) {
+        else if (! idfirst_only && isWORDCHAR_A(*s) ) {
 
             /* This is the superset; it accepts \w+, including an initial
              * digit */

--- a/toke.c
+++ b/toke.c
@@ -10464,6 +10464,22 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
     croak("%s", ident_too_long);
 }
 
+PERL_STATIC_INLINE char *
+S_parse_ident_no_copy(pTHX_ const char *s, const char * const s_end,
+                      bool is_utf8, U32 flags)
+{
+    PERL_ARGS_ASSERT_PARSE_IDENT_NO_COPY;
+
+    /* This just wraps parse_ident for functions that call it and don't need
+     * the actual identifier string returned.  For example, they might just
+     * want to test if the input is valid. */
+
+    char scratch[ PERL_IDENTIFIER_LENGTH ];
+    char * dest = scratch;
+
+    return parse_ident(s, s_end, &dest, C_ARRAY_END(scratch), is_utf8, flags);
+}
+
 char *
 Perl_scan_word(pTHX_ char *s, char *dest, STRLEN destlen, int allow_package, STRLEN *slp)
 {

--- a/toke.c
+++ b/toke.c
@@ -5263,7 +5263,8 @@ yyl_sigvar(pTHX_ char *s)
             char *dest = PL_tokenbuf + 1;
             /* read var name, including sigil, into PL_tokenbuf */
             PL_tokenbuf[0] = sigil;
-            parse_ident(&s, &dest, C_ARRAY_END(PL_tokenbuf), cBOOL(UTF), 0);
+            s = parse_ident(s, PL_bufend, &dest, C_ARRAY_END(PL_tokenbuf),
+                            cBOOL(UTF), 0);
             *dest = '\0';
             assert(PL_tokenbuf[1]); /* we have a variable name */
         }
@@ -10290,14 +10291,15 @@ S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen,
     return SvREFCNT_inc_simple_NN(sv);
 }
 
-STATIC void
-S_parse_ident(pTHX_ char **s, char **d, char * const e, bool is_utf8,
-                    U32 flags)
+STATIC char *
+S_parse_ident(pTHX_ char *s, char * const s_end,
+                    char **d, char * const e,
+                    bool is_utf8, U32 flags)
 {
     PERL_ARGS_ASSERT_PARSE_IDENT;
 
     /* This function parses the string pointed to by '*s' (whose upper bound
-     * is 'send') looking for an identifier.  It stops at the first character
+     * is 's_end') looking for an identifier.  It stops at the first character
      * that isn't in one of the types of identifiers looked for, which are:
      *
      * 1) A normal identifier whose first character matches IDFIRST followed
@@ -10309,6 +10311,10 @@ S_parse_ident(pTHX_ char **s, char **d, char * const e, bool is_utf8,
      * (whose upper bound is 'e') and advances *d to point to just beyond the
      * end of the identifier.  The reason it needs to copy is that it may
      * convert apostrophe package separators into double colons.
+     *
+     * Upon success, it returns the position in s just beyond where the
+     * identifier ends in the input.  If no identifier was found, the return
+     * will be the the input 's' unchanged.
      *
      * The function croaks if there is not enough room for the entire source
      * identifier to be copied.
@@ -10324,7 +10330,7 @@ S_parse_ident(pTHX_ char **s, char **d, char * const e, bool is_utf8,
      * in things like Foo::$bar */
     const bool check_dollar = flags & CHECK_DOLLAR;
 
-    while (*s < PL_bufend) {
+    while (s < s_end) {
         if (*d >= e)
             croak("%s", ident_too_long);
 
@@ -10333,58 +10339,58 @@ S_parse_ident(pTHX_ char **s, char **d, char * const e, bool is_utf8,
          * Unicode definition only when UTF-8 is in effect.  We have to check
          * for the subset before checking for the superset. */
         Size_t advance;
-        if (is_utf8 && (advance = isIDFIRST_utf8_safe(*s, PL_bufend))) {
+        if (is_utf8 && (advance = isIDFIRST_utf8_safe(s, s_end))) {
 
             /* Find the end of the identifier by accumulating characters until
              * find a non-identifier character */
-            char *t = *s + advance;
+            char *t = s + advance;
             while ((advance = isIDCONT_utf8_safe((const U8*) t,
-                                                 (const U8*) PL_bufend)))
+                                                 (const U8*) s_end)))
             {
                 t += advance;
             }
 
             /* Here we have found the end of the identifier */
-            if (*d + (t - *s) > e)
+            if (*d + (t - s) > e)
                 croak("%s", ident_too_long);
 
             /* And copy the whole thing in one operation */
-            Copy(*s, *d, t - *s, char);
-            *d += t - *s;
-            *s = t;
+            Copy(s, *d, t - s, char);
+            *d += t - s;
+            s = t;
         }
-        else if ( isWORDCHAR_A(**s) ) {
+        else if ( isWORDCHAR_A(*s) ) {
 
             /* This is the superset; it accepts \w+, including an initial
              * digit */
             do {
-                *(*d)++ = *(*s)++;
-            } while (isWORDCHAR_A(**s) && *d < e);
+                *(*d)++ = *s++;
+            } while (isWORDCHAR_A(*s) && *d < e);
         }
         else if (   allow_package
-                 && **s == '\''
+                 && *s == '\''
                  && FEATURE_APOS_AS_NAME_SEP_IS_ENABLED
-                 && isIDFIRST_lazy_if_safe((*s)+1, PL_bufend, is_utf8))
+                 && isIDFIRST_lazy_if_safe(s + 1, s_end, is_utf8))
         {   /* Convert the apostrophe to "::" */
             *(*d)++ = ':';
             *(*d)++ = ':';
-            (*s)++;
+            s++;
         }
-        else if (allow_package && **s == ':' && (*s)[1] == ':'
+        else if (allow_package && *s == ':' && s[1] == ':'
            /* Disallow things like Foo::$bar. For the curious, this is
             * the code path that triggers the "Bad name after" warning
             * when looking for barewords.
             */
-           && !(check_dollar && (*s)[2] == '$'))
+           && !(check_dollar && s[2] == '$'))
         {
-            *(*d)++ = *(*s)++;
-            *(*d)++ = *(*s)++;
+            *(*d)++ = *s++;
+            *(*d)++ = *s++;
         }
         else    /* None of the above means have come to the end of any
                    identifier*/
             break;
     }
-    return;
+    return s;
 }
 
 char *
@@ -10396,8 +10402,8 @@ Perl_scan_word(pTHX_ char *s, char *dest, STRLEN destlen, int allow_package, STR
     char * const e = d + destlen - 3;  /* two-character token, ending NUL */
     bool is_utf8 = cBOOL(UTF);
 
-    parse_ident(&s, &d, e, is_utf8,
-                (CHECK_DOLLAR | ((allow_package) ? ALLOW_PACKAGE : 0)));
+    s = parse_ident(s, PL_bufend, &d, e, is_utf8,
+                    (CHECK_DOLLAR | ((allow_package) ? ALLOW_PACKAGE : 0)));
     *d = '\0';
     *slp = d - dest;
     return s;
@@ -10438,7 +10444,7 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
             croak(ident_var_zero_multi_digit);
     }
     else {  /* See if it is a "normal" identifier */
-        parse_ident(&s, &d, e, is_utf8, ALLOW_PACKAGE);
+        s = parse_ident(s, PL_bufend, &d, e, is_utf8, ALLOW_PACKAGE);
     }
     *d = '\0';
     d = dest;
@@ -10559,8 +10565,8 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, bool chk_unary)
                    (the later check for } being at the expected point will trap
                    cases where this doesn't pan out.)  */
                 d += advance;
-                parse_ident(&s, &d, e, is_utf8, ( ALLOW_PACKAGE
-                                                 |CHECK_DOLLAR));
+                s = parse_ident(s, PL_bufend, &d, e, is_utf8,
+                                (ALLOW_PACKAGE | CHECK_DOLLAR));
                 *d = '\0';
             }
             else { /* caret word: ${^Foo} ${^CAPTURE[0]} */

--- a/toke.c
+++ b/toke.c
@@ -10292,7 +10292,7 @@ S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen,
 }
 
 STATIC char *
-S_parse_ident(pTHX_ char *s, char * const s_end,
+S_parse_ident(pTHX_ const char *s, const char * const s_end,
                     char **d, char * const e,
                     bool is_utf8, U32 flags)
 {
@@ -10343,7 +10343,7 @@ S_parse_ident(pTHX_ char *s, char * const s_end,
 
             /* Find the end of the identifier by accumulating characters until
              * find a non-identifier character */
-            char *t = s + advance;
+            const char *t = s + advance;
             while ((advance = isIDCONT_utf8_safe((const U8*) t,
                                                  (const U8*) s_end)))
             {
@@ -10390,7 +10390,11 @@ S_parse_ident(pTHX_ char *s, char * const s_end,
                    identifier*/
             break;
     }
-    return s;
+
+    /* Cast away const, because many of our callers don't have it; this
+     * function declares it as const so as to indicate that it doesn't change
+     * it, and it can be called using a const parameter */
+    return (char *) s;
 }
 
 char *


### PR DESCRIPTION
This p.r. generalizes this function so that it can be called in more circumstances; the final commit  calls it from one such place, as a demonstration.

The goal is to centralize here the sort of handling of names, like identifiers, so changes can be made in just one place, and we can get rid of the other places which have slightly different rules from each other.

Sly identifier names have been used in projects to slip in code (past reviewers) which did not do what on the surface it appeared to.  Unicode has in recent releases started to address that issue, and this p.r. will allow us to use their methods.

For example, I could see some sort of 'use strict' form that a perlcritic policy would enforce being used, and which would allow parse_ident() to reject problematic names.

* This set of changes does not require a perldelta entry.
