### PR TITLE
Change invlist function names to be legal

### DIFF
--- a/doop.c
+++ b/doop.c
@@ -375,7 +375,7 @@ S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
 
         /* Look the code point up in the data structure for this tr/// to get
          * what it maps to */
-        i = _invlist_search(from_invlist, from);
+        i = invlist_search_(from_invlist, from);
         assert(i >= 0);
 
         if (map[i] != (UV) TR_UNLISTED) {
@@ -491,7 +491,7 @@ S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
 
         /* Look the code point up in the data structure for this tr/// to get
          * what it maps to */
-        i = _invlist_search(from_invlist, from);
+        i = invlist_search_(from_invlist, from);
         assert(i >= 0);
 
         to = map[i];

--- a/dump.c
+++ b/dump.c
@@ -2444,7 +2444,7 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
             if (type == SVt_INVLIST) {
                 PerlIO_printf(file, "\n");
                 /* 4 blanks indents 2 beyond the PV, etc */
-                _invlist_dump(file, level, "    ", sv);
+                invlist_dump_(file, level, "    ", sv);
             }
             else {
                 PerlIO_printf(file, "%s", pv_display_for_dump(d, ptr, SvCUR(sv),

--- a/embed.fnc
+++ b/embed.fnc
@@ -4389,11 +4389,11 @@ RS	|Size_t |do_trans_simple|NN SV * const sv			\
 ERTi	|bool * |get_invlist_offset_addr				\
 				|NN SV *invlist
 ERTi	|UV *	|invlist_array	|NN SV * const invlist
-ERTi	|bool	|_invlist_contains_cp					\
+ERTi	|bool	|invlist_contains_cp_					\
 				|NN SV * const invlist			\
 				|const UV cp
-ERTi	|UV	|_invlist_len	|NN SV * const invlist
-ERTXp	|SSize_t|_invlist_search|NN SV * const invlist			\
+ERTi	|UV	|invlist_len_	|NN SV * const invlist
+ERTXp	|SSize_t|invlist_search_|NN SV * const invlist			\
 				|const UV cp
 ERTi	|bool	|is_invlist	|NULLOK const SV * const invlist
 #endif
@@ -4411,34 +4411,34 @@ Ei	|void	|invlist_set_len|NN SV * const invlist			\
 #endif
 #if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C)
-ERXp	|SV *	|_add_range_to_invlist					\
+ERXp	|SV *	|add_range_to_invlist_					\
 				|NULLOK SV *invlist			\
 				|UV start				\
 				|UV end
-m	|void	|_invlist_intersection					\
+m	|void	|invlist_intersection_					\
 				|NN SV * const a			\
 				|NN SV * const b			\
 				|NN SV **i
-EXp	|void	|_invlist_intersection_maybe_complement_2nd		\
+EXp	|void	|invlist_intersection_maybe_complement_2nd_		\
 				|NULLOK SV * const a			\
 				|NN SV * const b			\
 				|const bool complement_b		\
 				|NN SV **i
-EXp	|void	|_invlist_invert|NN SV * const invlist
-m	|void	|_invlist_subtract					\
+EXp	|void	|invlist_invert_|NN SV * const invlist
+m	|void	|invlist_subtract_					\
 				|NN SV * const a			\
 				|NN SV * const b			\
 				|NN SV **result
-m	|void	|_invlist_union |NULLOK SV * const a			\
+m	|void	|invlist_union_ |NULLOK SV * const a			\
 				|NN SV * const b			\
 				|NN SV **output
-EXp	|void	|_invlist_union_maybe_complement_2nd			\
+EXp	|void	|invlist_union_maybe_complement_2nd_			\
 				|NULLOK SV * const a			\
 				|NN SV * const b			\
 				|const bool complement_b		\
 				|NN SV **output
-ERXp	|SV *	|_new_invlist	|IV initial_size
-ERXp	|SV *	|_setup_canned_invlist					\
+ERXp	|SV *	|new_invlist_	|IV initial_size
+ERXp	|SV *	|setup_canned_invlist_					\
 				|const STRLEN size			\
 				|const UV element0			\
 				|NN UV **other_elements_ptr
@@ -4502,7 +4502,7 @@ opx	|void	|hv_kill_backrefs					\
 #endif
 #if defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY)
-EXp	|void	|_invlist_dump	|NN PerlIO *file			\
+EXp	|void	|invlist_dump_	|NN PerlIO *file			\
 				|I32 level				\
 				|NN const char * const indent		\
 				|NN SV * const invlist
@@ -5123,10 +5123,10 @@ So	|void	|validate_suid	|NN PerlIO *rsfp
 #endif /* defined(PERL_IN_PERL_C) */
 #if defined(PERL_IN_PERL_C) || defined(PERL_IN_REGCOMP_ANY) || \
     defined(PERL_IN_UTF8_C)
-EXp	|bool	|_invlistEQ	|NN SV * const a			\
+EXp	|bool	|invlistEQ_	|NN SV * const a			\
 				|NN SV * const b			\
 				|const bool complement_b
-ERXp	|SV *	|_new_invlist_C_array					\
+ERXp	|SV *	|new_invlist_C_array_					\
 				|NN const UV * const list
 #endif
 #if defined(PERL_IN_PP_C)
@@ -5659,7 +5659,7 @@ ES	|void	|regdump_intflags					\
 				|const U32 flags
 #endif
 #if defined(PERL_IN_REGCOMP_INVLIST_C) && !defined(PERL_EXT_RE_BUILD)
-ES	|void	|_append_range_to_invlist				\
+ES	|void	|append_range_to_invlist_				\
 				|NN SV * const invlist			\
 				|const UV start 			\
 				|const UV end
@@ -5668,7 +5668,7 @@ ERTi	|IV *	|get_invlist_previous_index_addr			\
 S	|void	|initialize_invlist_guts				\
 				|NN SV *invlist 			\
 				|const Size_t initial_size
-ERTi	|UV *	|_invlist_array_init					\
+ERTi	|UV *	|invlist_array_init_					\
 				|NN SV * const invlist			\
 				|const bool will_have_0
 Ei	|void	|invlist_clear	|NN SV *invlist

--- a/embed.h
+++ b/embed.h
@@ -1850,11 +1850,11 @@
        defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
        defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
        defined(PERL_IN_UTF8_C)
-#     define _invlist_contains_cp               S__invlist_contains_cp
-#     define _invlist_len                       S__invlist_len
-#     define _invlist_search                    Perl__invlist_search
 #     define get_invlist_offset_addr            S_get_invlist_offset_addr
 #     define invlist_array                      S_invlist_array
+#     define invlist_contains_cp_               S_invlist_contains_cp_
+#     define invlist_len_                       S_invlist_len_
+#     define invlist_search_                    Perl_invlist_search_
 #     define is_invlist                         S_is_invlist
 #   endif
 #   if defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
@@ -1866,12 +1866,12 @@
 #   endif
 #   if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
        defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C)
-#     define _add_range_to_invlist(a,b,c)       Perl__add_range_to_invlist(aTHX_ a,b,c)
-#     define _invlist_intersection_maybe_complement_2nd(a,b,c,d) Perl__invlist_intersection_maybe_complement_2nd(aTHX_ a,b,c,d)
-#     define _invlist_invert(a)                 Perl__invlist_invert(aTHX_ a)
-#     define _invlist_union_maybe_complement_2nd(a,b,c,d) Perl__invlist_union_maybe_complement_2nd(aTHX_ a,b,c,d)
-#     define _new_invlist(a)                    Perl__new_invlist(aTHX_ a)
-#     define _setup_canned_invlist(a,b,c)       Perl__setup_canned_invlist(aTHX_ a,b,c)
+#     define add_range_to_invlist_(a,b,c)       Perl_add_range_to_invlist_(aTHX_ a,b,c)
+#     define invlist_intersection_maybe_complement_2nd_(a,b,c,d) Perl_invlist_intersection_maybe_complement_2nd_(aTHX_ a,b,c,d)
+#     define invlist_invert_(a)                 Perl_invlist_invert_(aTHX_ a)
+#     define invlist_union_maybe_complement_2nd_(a,b,c,d) Perl_invlist_union_maybe_complement_2nd_(aTHX_ a,b,c,d)
+#     define new_invlist_(a)                    Perl_new_invlist_(aTHX_ a)
+#     define setup_canned_invlist_(a,b,c)       Perl_setup_canned_invlist_(aTHX_ a,b,c)
 #   endif
 #   if defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) || \
        defined(PERL_IN_TOKE_C)
@@ -1886,7 +1886,7 @@
 #   endif
 #   if defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) || \
        defined(PERL_IN_REGCOMP_ANY)
-#     define _invlist_dump(a,b,c,d)             Perl__invlist_dump(aTHX_ a,b,c,d)
+#     define invlist_dump_(a,b,c,d)             Perl_invlist_dump_(aTHX_ a,b,c,d)
 #   endif
 #   if defined(PERL_IN_GV_C) || defined(PERL_IN_UNIVERSAL_C)
 #     define gv_stashsvpvn_cached(a,b,c,d)      Perl_gv_stashsvpvn_cached(aTHX_ a,b,c,d)
@@ -1899,8 +1899,8 @@
 #   endif
 #   if defined(PERL_IN_PERL_C) || defined(PERL_IN_REGCOMP_ANY) || \
        defined(PERL_IN_UTF8_C)
-#     define _invlistEQ(a,b,c)                  Perl__invlistEQ(aTHX_ a,b,c)
-#     define _new_invlist_C_array(a)            Perl__new_invlist_C_array(aTHX_ a)
+#     define invlistEQ_(a,b,c)                  Perl_invlistEQ_(aTHX_ a,b,c)
+#     define new_invlist_C_array_(a)            Perl_new_invlist_C_array_(aTHX_ a)
 #   endif
 #   if defined(PERL_IN_PP_C)   || defined(PERL_IN_REGCOMP_ANY) || \
        defined(PERL_IN_TOKE_C) || defined(PERL_IN_UNIVERSAL_C)
@@ -2006,9 +2006,9 @@
 #     define regdump_intflags(a,b)              S_regdump_intflags(aTHX_ a,b)
 #   endif
 #   if defined(PERL_IN_REGCOMP_INVLIST_C) && !defined(PERL_EXT_RE_BUILD)
-#     define _append_range_to_invlist(a,b,c)    S__append_range_to_invlist(aTHX_ a,b,c)
-#     define _invlist_array_init                S__invlist_array_init
+#     define append_range_to_invlist_(a,b,c)    S_append_range_to_invlist_(aTHX_ a,b,c)
 #     define get_invlist_previous_index_addr    S_get_invlist_previous_index_addr
+#     define invlist_array_init_                S_invlist_array_init_
 #     define invlist_clear(a)                   S_invlist_clear(aTHX_ a)
 #     define invlist_max                        S_invlist_max
 #     define invlist_previous_index             S_invlist_previous_index

--- a/invlist_inline.h
+++ b/invlist_inline.h
@@ -45,12 +45,12 @@ S_get_invlist_offset_addr(SV* invlist)
 }
 
 PERL_STATIC_INLINE UV
-S__invlist_len(SV* const invlist)
+S_invlist_len_(SV* const invlist)
 {
     /* Returns the current number of elements stored in the inversion list's
      * array */
 
-    PERL_ARGS_ASSERT__INVLIST_LEN;
+    PERL_ARGS_ASSERT_INVLIST_LEN_;
 
     assert(is_invlist(invlist));
 
@@ -60,13 +60,13 @@ S__invlist_len(SV* const invlist)
 }
 
 PERL_STATIC_INLINE bool
-S__invlist_contains_cp(SV* const invlist, const UV cp)
+S_invlist_contains_cp_(SV* const invlist, const UV cp)
 {
     /* Does <invlist> contain code point <cp> as part of the set? */
 
-    IV index = _invlist_search(invlist, cp);
+    IV index = invlist_search_(invlist, cp);
 
-    PERL_ARGS_ASSERT__INVLIST_CONTAINS_CP;
+    PERL_ARGS_ASSERT_INVLIST_CONTAINS_CP_;
 
     return index >= 0 && ELEMENT_RANGE_MATCHES_INVLIST(index);
 }
@@ -82,7 +82,7 @@ S_invlist_array(SV* const invlist)
 
     /* Must not be empty.  If these fail, you probably didn't check for <len>
      * being non-zero before trying to get the array */
-    assert(_invlist_len(invlist));
+    assert(invlist_len_(invlist));
 
     /* The very first element always contains zero, The array begins either
      * there, or if the inversion list is offset, at the element after it.
@@ -128,7 +128,7 @@ S_invlist_set_len(pTHX_ SV* const invlist, const UV len, const bool offset)
 
 PERL_STATIC_INLINE SV*
 S_add_cp_to_invlist(pTHX_ SV* invlist, const UV cp) {
-    return _add_range_to_invlist(invlist, cp, cp);
+    return add_range_to_invlist_(invlist, cp, cp);
 }
 
 PERL_STATIC_INLINE UV
@@ -139,7 +139,7 @@ S_invlist_highest(SV* const invlist)
      * 0, or if the list is empty.  If this distinction matters to you, check
      * for emptiness before calling this function */
 
-    UV len = _invlist_len(invlist);
+    UV len = invlist_len_(invlist);
     UV *array;
 
     PERL_ARGS_ASSERT_INVLIST_HIGHEST;
@@ -172,7 +172,7 @@ S_invlist_highest_range_start(SV* const invlist)
      * distinction matters to you, check for emptiness before calling this
      * function. */
 
-    UV len = _invlist_len(invlist);
+    UV len = invlist_len_(invlist);
     UV *array;
 
     PERL_ARGS_ASSERT_INVLIST_HIGHEST_RANGE_START;
@@ -249,7 +249,7 @@ S_invlist_iternext(SV* invlist, UV* start, UV* end)
      * will start over at the beginning of the list */
 
     STRLEN* pos = get_invlist_iter_addr(invlist);
-    UV len = _invlist_len(invlist);
+    UV len = invlist_len_(invlist);
     UV *array;
 
     PERL_ARGS_ASSERT_INVLIST_ITERNEXT;
@@ -356,7 +356,7 @@ S_invlist_lowest(SV* const invlist)
      * 0, or if the list is empty.  If this distinction matters to you, check
      * for emptiness before calling this function */
 
-    UV len = _invlist_len(invlist);
+    UV len = invlist_len_(invlist);
     UV *array;
 
     PERL_ARGS_ASSERT_INVLIST_LOWEST;

--- a/op.c
+++ b/op.c
@@ -6110,7 +6110,7 @@ Perl_invmap_dump(pTHX_ SV* invlist, UV *map)
 
     const unsigned int indent = 4;
 
-    UV len = _invlist_len(invlist);
+    UV len = invlist_len_(invlist);
     UV * array = invlist_array(invlist);
 
     if (len == 0) {
@@ -6567,7 +6567,7 @@ S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
      * automatically keeps it sorted as we go along */
     if (complement) {
         UV start, end;
-        SV * inverted_tlist = _new_invlist(tlen);
+        SV * inverted_tlist = new_invlist_(tlen);
         Size_t temp_len;
 
         DEBUG_y(PerlIO_printf(Perl_debug_log,
@@ -6602,14 +6602,14 @@ S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
                     t_cp_end = valid_utf8_to_uv(t, &t_char_len);
                     t += t_char_len;
 
-                    inverted_tlist = _add_range_to_invlist(inverted_tlist,
+                    inverted_tlist = add_range_to_invlist_(inverted_tlist,
                                                       t_cp, t_cp_end);
                 }
             }
         } /* End of parse through tstr */
 
         /* The inversion list is done; now invert it */
-        _invlist_invert(inverted_tlist);
+        invlist_invert_(inverted_tlist);
 
         /* Now go through the inverted list and create a new tstr for the rest
          * of the routine to use.  Since the UTF-8 version can have ranges, and
@@ -6657,10 +6657,10 @@ S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
         rstr_utf8  = tstr_utf8;
     }
 
-    t_invlist = _new_invlist(1);
+    t_invlist = new_invlist_(1);
 
     /* Initialize to a single range */
-    t_invlist = _add_range_to_invlist(t_invlist, 0, UV_MAX);
+    t_invlist = add_range_to_invlist_(t_invlist, 0, UV_MAX);
 
     /* Below, we parse the (potentially adjusted) input, creating the inversion
      * map.  This is done in two passes.  The first pass is just to determine
@@ -6695,7 +6695,7 @@ S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
                      invmap_dump(t_invlist, r_map));
 
             /* In the second pass, we start with a single range */
-            t_invlist = _add_range_to_invlist(t_invlist, 0, UV_MAX);
+            t_invlist = add_range_to_invlist_(t_invlist, 0, UV_MAX);
             len = 1;
             t_array = invlist_array(t_invlist);
         }
@@ -6881,7 +6881,7 @@ S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
              * the return value is the index into the list's array of the range
              * that contains <cp>, that is, 'i' such that
              *      array[i] <= cp < * array[i+1] */
-            j = _invlist_search(t_invlist, t_cp);
+            j = invlist_search_(t_invlist, t_cp);
             assert(j >= 0);
             i = j;
 

--- a/pp.c
+++ b/pp.c
@@ -4530,7 +4530,7 @@ PP_wrapped(pp_uc, 1, 0)
             if (UNLIKELY(in_iota_subscript)) {
                 UV cp = utf8_to_uv_or_die(s, send, &this_len);
 
-                if (! _invlist_contains_cp(PL_utf8_mark, cp)) {
+                if (! invlist_contains_cp_(PL_utf8_mark, cp)) {
 
                     /* A non-mark.  Time to output the iota subscript */
                     *d++ = UTF8_TWO_BYTE_HI(GREEK_CAPITAL_LETTER_IOTA);

--- a/proto.h
+++ b/proto.h
@@ -6165,25 +6165,25 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 *s, const U8 *send, const bool utf8_target)
      defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
      defined(PERL_IN_UTF8_C)
 PERL_CALLCONV SSize_t
-Perl__invlist_search(SV * const invlist, const UV cp)
+Perl_invlist_search_(SV * const invlist, const UV cp)
         __attribute__warn_unused_result__;
 # endif
 # if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
      defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C)
 PERL_CALLCONV SV *
-Perl__add_range_to_invlist(pTHX_ SV *invlist, UV start, UV end)
+Perl_add_range_to_invlist_(pTHX_ SV *invlist, UV start, UV end)
         __attribute__warn_unused_result__;
 PERL_CALLCONV void
-Perl__invlist_intersection_maybe_complement_2nd(pTHX_ SV * const a, SV * const b, const bool complement_b, SV **i);
+Perl_invlist_intersection_maybe_complement_2nd_(pTHX_ SV * const a, SV * const b, const bool complement_b, SV **i);
 PERL_CALLCONV void
-Perl__invlist_invert(pTHX_ SV * const invlist);
+Perl_invlist_invert_(pTHX_ SV * const invlist);
 PERL_CALLCONV void
-Perl__invlist_union_maybe_complement_2nd(pTHX_ SV * const a, SV * const b, const bool complement_b, SV **output);
+Perl_invlist_union_maybe_complement_2nd_(pTHX_ SV * const a, SV * const b, const bool complement_b, SV **output);
 PERL_CALLCONV SV *
-Perl__new_invlist(pTHX_ IV initial_size)
+Perl_new_invlist_(pTHX_ IV initial_size)
         __attribute__warn_unused_result__;
 PERL_CALLCONV SV *
-Perl__setup_canned_invlist(pTHX_ const STRLEN size, const UV element0, UV **other_elements_ptr)
+Perl_setup_canned_invlist_(pTHX_ const STRLEN size, const UV element0, UV **other_elements_ptr)
         __attribute__warn_unused_result__;
 # endif /* defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) ||
            defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C) */
@@ -6212,14 +6212,14 @@ Perl_form_cp_too_large_msg(pTHX_ const U8 which, const char *string, const Size_
 # if defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) || \
      defined(PERL_IN_REGCOMP_ANY)
 PERL_CALLCONV void
-Perl__invlist_dump(pTHX_ PerlIO *file, I32 level, const char * const indent, SV * const invlist);
+Perl_invlist_dump_(pTHX_ PerlIO *file, I32 level, const char * const indent, SV * const invlist);
 # endif
 # if defined(PERL_IN_PERL_C) || defined(PERL_IN_REGCOMP_ANY) || \
      defined(PERL_IN_UTF8_C)
 PERL_CALLCONV bool
-Perl__invlistEQ(pTHX_ SV * const a, SV * const b, const bool complement_b);
+Perl_invlistEQ_(pTHX_ SV * const a, SV * const b, const bool complement_b);
 PERL_CALLCONV SV *
-Perl__new_invlist_C_array(pTHX_ const UV * const list)
+Perl_new_invlist_C_array_(pTHX_ const UV * const list)
         __attribute__warn_unused_result__;
 # endif
 # if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
@@ -6865,7 +6865,7 @@ S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
     defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
     defined(PERL_IN_UTF8_C)
 
-# define PERL_ARGS_ASSERT__INVLIST_SEARCH       \
+# define PERL_ARGS_ASSERT_INVLIST_SEARCH_       \
         assert(invlist)
 
 #endif /* defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        ||
@@ -6878,29 +6878,29 @@ S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 #endif
 #if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C)
-# define PERL_ARGS_ASSERT__ADD_RANGE_TO_INVLIST
+# define PERL_ARGS_ASSERT_ADD_RANGE_TO_INVLIST_
 
 /* PERL_CALLCONV void
-_invlist_intersection(pTHX_ SV * const a, SV * const b, SV **i); */
+invlist_intersection_(pTHX_ SV * const a, SV * const b, SV **i); */
 
-# define PERL_ARGS_ASSERT__INVLIST_INTERSECTION_MAYBE_COMPLEMENT_2ND \
+# define PERL_ARGS_ASSERT_INVLIST_INTERSECTION_MAYBE_COMPLEMENT_2ND_ \
         assert(b); assert(i)
 
-# define PERL_ARGS_ASSERT__INVLIST_INVERT       \
+# define PERL_ARGS_ASSERT_INVLIST_INVERT_       \
         assert(invlist)
 
 /* PERL_CALLCONV void
-_invlist_subtract(pTHX_ SV * const a, SV * const b, SV **result); */
+invlist_subtract_(pTHX_ SV * const a, SV * const b, SV **result); */
 
 /* PERL_CALLCONV void
-_invlist_union(pTHX_ SV * const a, SV * const b, SV **output); */
+invlist_union_(pTHX_ SV * const a, SV * const b, SV **output); */
 
-# define PERL_ARGS_ASSERT__INVLIST_UNION_MAYBE_COMPLEMENT_2ND \
+# define PERL_ARGS_ASSERT_INVLIST_UNION_MAYBE_COMPLEMENT_2ND_ \
         assert(b); assert(output)
 
-# define PERL_ARGS_ASSERT__NEW_INVLIST
+# define PERL_ARGS_ASSERT_NEW_INVLIST_
 
-# define PERL_ARGS_ASSERT__SETUP_CANNED_INVLIST \
+# define PERL_ARGS_ASSERT_SETUP_CANNED_INVLIST_ \
         assert(other_elements_ptr)
 
 #endif /* defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) ||
@@ -6962,7 +6962,7 @@ Perl_hv_kill_backrefs(pTHX_ HV *hv)
 #endif
 #if defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY)
-# define PERL_ARGS_ASSERT__INVLIST_DUMP         \
+# define PERL_ARGS_ASSERT_INVLIST_DUMP_         \
         assert(file); assert(indent); assert(invlist)
 
 #endif
@@ -7867,10 +7867,10 @@ S_validate_suid(pTHX_ PerlIO *rsfp);
 #endif /* defined(PERL_IN_PERL_C) */
 #if defined(PERL_IN_PERL_C) || defined(PERL_IN_REGCOMP_ANY) || \
     defined(PERL_IN_UTF8_C)
-# define PERL_ARGS_ASSERT__INVLISTEQ            \
+# define PERL_ARGS_ASSERT_INVLISTEQ_            \
         assert(a); assert(b)
 
-# define PERL_ARGS_ASSERT__NEW_INVLIST_C_ARRAY  \
+# define PERL_ARGS_ASSERT_NEW_INVLIST_C_ARRAY_  \
         assert(list)
 
 #endif
@@ -8704,7 +8704,7 @@ Perl_regcurly(const char *s, const char *e, const char *result[5])
 
 #endif /* defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING) */
 #if defined(PERL_IN_REGCOMP_INVLIST_C) && !defined(PERL_EXT_RE_BUILD)
-# define PERL_ARGS_ASSERT__APPEND_RANGE_TO_INVLIST \
+# define PERL_ARGS_ASSERT_APPEND_RANGE_TO_INVLIST_ \
         assert(invlist)
 
 STATIC void
@@ -8717,15 +8717,15 @@ S_initialize_invlist_guts(pTHX_ SV *invlist, const Size_t initial_size);
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 STATIC void
-S__append_range_to_invlist(pTHX_ SV * const invlist, const UV start, const UV end);
+S_append_range_to_invlist_(pTHX_ SV * const invlist, const UV start, const UV end);
 STATIC void
 S_invlist_replace_list_destroys_src(pTHX_ SV *dest, SV *src);
 # endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
-#   define PERL_ARGS_ASSERT__INVLIST_ARRAY_INIT \
+#   define PERL_ARGS_ASSERT_GET_INVLIST_PREVIOUS_INDEX_ADDR \
         assert(invlist)
 
-#   define PERL_ARGS_ASSERT_GET_INVLIST_PREVIOUS_INDEX_ADDR \
+#   define PERL_ARGS_ASSERT_INVLIST_ARRAY_INIT_ \
         assert(invlist)
 
 #   define PERL_ARGS_ASSERT_INVLIST_CLEAR       \
@@ -8744,11 +8744,11 @@ S_invlist_replace_list_destroys_src(pTHX_ SV *dest, SV *src);
         assert(invlist)
 
 #   if defined(PERL_CORE) || defined(PERL_EXT)
-PERL_STATIC_INLINE UV *
-S__invlist_array_init(SV * const invlist, const bool will_have_0)
-        __attribute__warn_unused_result__;
 PERL_STATIC_INLINE IV *
 S_get_invlist_previous_index_addr(SV *invlist)
+        __attribute__warn_unused_result__;
+PERL_STATIC_INLINE UV *
+S_invlist_array_init_(SV * const invlist, const bool will_have_0)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE void
 S_invlist_clear(pTHX_ SV *invlist);
@@ -10499,17 +10499,17 @@ S_my_memrchr(const char *s, const char c, const STRLEN len);
        defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
        defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
        defined(PERL_IN_UTF8_C)
-PERL_STATIC_INLINE bool
-S__invlist_contains_cp(SV * const invlist, const UV cp)
-        __attribute__warn_unused_result__;
-PERL_STATIC_INLINE UV
-S__invlist_len(SV * const invlist)
-        __attribute__warn_unused_result__;
 PERL_STATIC_INLINE bool *
 S_get_invlist_offset_addr(SV *invlist)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE UV *
 S_invlist_array(SV * const invlist)
+        __attribute__warn_unused_result__;
+PERL_STATIC_INLINE bool
+S_invlist_contains_cp_(SV * const invlist, const UV cp)
+        __attribute__warn_unused_result__;
+PERL_STATIC_INLINE UV
+S_invlist_len_(SV * const invlist)
         __attribute__warn_unused_result__;
 PERL_STATIC_INLINE bool
 S_is_invlist(const SV * const invlist)
@@ -10542,16 +10542,16 @@ S_get_regex_charset_name(const U32 flags, STRLEN * const lenp);
      defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \
      defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
      defined(PERL_IN_UTF8_C)
-#   define PERL_ARGS_ASSERT__INVLIST_CONTAINS_CP \
-        assert(invlist)
-
-#   define PERL_ARGS_ASSERT__INVLIST_LEN        \
-        assert(invlist)
-
 #   define PERL_ARGS_ASSERT_GET_INVLIST_OFFSET_ADDR \
         assert(invlist)
 
 #   define PERL_ARGS_ASSERT_INVLIST_ARRAY       \
+        assert(invlist)
+
+#   define PERL_ARGS_ASSERT_INVLIST_CONTAINS_CP_ \
+        assert(invlist)
+
+#   define PERL_ARGS_ASSERT_INVLIST_LEN_        \
         assert(invlist)
 
 #   define PERL_ARGS_ASSERT_IS_INVLIST

--- a/regcomp.c
+++ b/regcomp.c
@@ -6802,7 +6802,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                 else /* regular fold; see if actually is in a fold */
                      if (   (ender < 256 && ! IS_IN_SOME_FOLD_L1(ender))
                          || (ender > 255
-                            && ! _invlist_contains_cp(PL_in_some_fold, ender)))
+                            && ! invlist_contains_cp_(PL_in_some_fold, ender)))
                 {
                     /* Here, folding, but the character isn't in a fold.
                      *
@@ -7513,7 +7513,7 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                             node_type = EXACTFLU8;
                         }
                         else if (UNLIKELY(
-                             _invlist_contains_cp(PL_HasMultiCharFold, ender)))
+                             invlist_contains_cp_(PL_HasMultiCharFold, ender)))
                         {
                             /* A character that folds to more than one will
                              * match multiple characters, so can't be SIMPLE.
@@ -7660,11 +7660,11 @@ Perl_populate_anyof_bitmap_from_invlist(pTHX_ regnode *node, SV** invlist_ptr)
         /* Done with loop; remove any code points that are in the bitmap from
          * *invlist_ptr */
         if (change_invlist) {
-            _invlist_subtract(*invlist_ptr, PL_InBitmap, invlist_ptr);
+            invlist_subtract_(*invlist_ptr, PL_InBitmap, invlist_ptr);
         }
 
         /* If have completely emptied it, remove it completely */
-        if (_invlist_len(*invlist_ptr) == 0) {
+        if (invlist_len_(*invlist_ptr) == 0) {
             SvREFCNT_dec_NN(*invlist_ptr);
             *invlist_ptr = NULL;
         }
@@ -8960,16 +8960,16 @@ redo_curchar:
 
                 switch (stacked_operator) {
                     case '&':
-                        _invlist_intersection(lhs, rhs, &rhs);
+                        invlist_intersection_(lhs, rhs, &rhs);
                         break;
 
                     case '|':
                     case '+':
-                        _invlist_union(lhs, rhs, &rhs);
+                        invlist_union_(lhs, rhs, &rhs);
                         break;
 
                     case '-':
-                        _invlist_subtract(lhs, rhs, &rhs);
+                        invlist_subtract_(lhs, rhs, &rhs);
                         break;
 
                     case '^':   /* The union minus the intersection */
@@ -8977,9 +8977,9 @@ redo_curchar:
                         SV* i = NULL;
                         SV* u = NULL;
 
-                        _invlist_union(lhs, rhs, &u);
-                        _invlist_intersection(lhs, rhs, &i);
-                        _invlist_subtract(u, i, &rhs);
+                        invlist_union_(lhs, rhs, &u);
+                        invlist_intersection_(lhs, rhs, &i);
+                        invlist_subtract_(u, i, &rhs);
                         SvREFCNT_dec_NN(i);
                         SvREFCNT_dec_NN(u);
                         break;
@@ -9045,7 +9045,7 @@ redo_curchar:
                                 "preceding operand", curchar);
                     }
 
-                    _invlist_invert(current);
+                    invlist_invert_(current);
 
                     only_to_avoid_leaks = av_pop(stack);
                     SvREFCNT_dec(only_to_avoid_leaks);
@@ -10088,8 +10088,8 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                              * if the match would return true, except don't
                              * warn for \p{All}, which has exactly one element
                              * = 0 */
-                            (_invlist_contains_cp(prop_definition, 0x110000)
-                                && (! (_invlist_len(prop_definition) == 1
+                            (invlist_contains_cp_(prop_definition, 0x110000)
+                                && (! (invlist_len_(prop_definition) == 1
                                        && *invlist_array(prop_definition) == 0))))
                         {
                             warn_super = true;
@@ -10097,12 +10097,12 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
 
                         /* Invert if asking for the complement */
                         if (value == 'P') {
-                            _invlist_union_complement_2nd(properties,
+                            invlist_union_complement_2nd_(properties,
                                                           prop_definition,
                                                           &properties);
                         }
                         else {
-                            _invlist_union(properties, prop_definition, &properties);
+                            invlist_union_(properties, prop_definition, &properties);
                         }
                     }
                 }
@@ -10282,7 +10282,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                  * trust that the locale is well behaved, we leave this to
                  * runtime to sort out) */
                 if (POSIXL_TEST(posixl, namedclass ^ 1)) {
-                    cp_list = _add_range_to_invlist(cp_list, 0, UV_MAX);
+                    cp_list = add_range_to_invlist_(cp_list, 0, UV_MAX);
                     POSIXL_ZERO(posixl);
                     has_runtime_dependency &= ~HAS_L_RUNTIME_DEPENDENCY;
                     anyof_flags &= ~ANYOF_MATCHES_POSIXL;
@@ -10301,7 +10301,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
 
                     /* Get the list of the above-Latin1 code points this
                      * matches */
-                    _invlist_intersection_maybe_complement_2nd(PL_AboveLatin1,
+                    invlist_intersection_maybe_complement_2nd_(PL_AboveLatin1,
                                             PL_XPosix_ptrs[classnum],
 
                                             /* Odd numbers are complements,
@@ -10316,7 +10316,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                         cp_list = scratch_list;
                     }
                     else {
-                        _invlist_union(cp_list, scratch_list, &cp_list);
+                        invlist_union_(cp_list, scratch_list, &cp_list);
                         SvREFCNT_dec_NN(scratch_list);
                     }
                     continue;   /* Go get next character */
@@ -10341,7 +10341,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                             classnum = CC_BLANK_;
                         }
 
-                        _invlist_union_maybe_complement_2nd(
+                        invlist_union_maybe_complement_2nd_(
                                 cp_list,
                                 PL_XPosix_ptrs[classnum],
                                 namedclass % 2 != 0,    /* Complement if odd
@@ -10363,7 +10363,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                      * runtime differences under /d.  So we can special case
                      * these, and avoid some extra work below, and at runtime.
                      * */
-                    _invlist_union_maybe_complement_2nd(
+                    invlist_union_maybe_complement_2nd_(
                                                      simple_posixes,
                                                       ((AT_LEAST_ASCII_RESTRICTED)
                                                        ? PL_Posix_ptrs[classnum]
@@ -10376,7 +10376,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                     SV** posixes_ptr = namedclass % 2 == 0
                                        ? &posixes
                                        : &nposixes;
-                    _invlist_union_maybe_complement_2nd(
+                    invlist_union_maybe_complement_2nd_(
                                                      *posixes_ptr,
                                                      PL_XPosix_ptrs[classnum],
                                                      namedclass % 2 != 0,
@@ -10498,7 +10498,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
          * See [perl #89750] */
         if (FOLD && allow_mutiple_chars && value == prevvalue) {
             if (    value == LATIN_SMALL_LETTER_SHARP_S
-                || (value > 255 && _invlist_contains_cp(PL_HasMultiCharFold,
+                || (value > 255 && invlist_contains_cp_(PL_HasMultiCharFold,
                                                         value)))
             {
                 /* Here <value> is indeed a multi-char fold.  Get what it is */
@@ -10630,7 +10630,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                              * algorithm is just to check if both end points
                              * are in the same series, which is the same range.
                              * */
-                            index_start = _invlist_search(
+                            index_start = invlist_search_(
                                                     PL_XPosix_ptrs[CC_DIGIT_],
                                                     prevvalue);
 
@@ -10639,7 +10639,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                             if (   index_start >= 0
                                 && ELEMENT_RANGE_MATCHES_INVLIST(index_start)
                                 && (index_final =
-                                    _invlist_search(PL_XPosix_ptrs[CC_DIGIT_],
+                                    invlist_search_(PL_XPosix_ptrs[CC_DIGIT_],
                                                     value)) != index_start
                                 && index_final >= 0
                                 && ELEMENT_RANGE_MATCHES_INVLIST(index_final))
@@ -10684,7 +10684,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
         /* Deal with this element of the class */
 
 #ifndef EBCDIC
-        cp_foldable_list = _add_range_to_invlist(cp_foldable_list,
+        cp_foldable_list = add_range_to_invlist_(cp_foldable_list,
                                                     prevvalue, value);
 #else
         /* On non-ASCII platforms, for ranges that span all of 0..255, and ones
@@ -10698,7 +10698,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                                 || (isUPPER_A(prevvalue)
                                     && isUPPER_A(value)))))))
         {
-            cp_foldable_list = _add_range_to_invlist(cp_foldable_list,
+            cp_foldable_list = add_range_to_invlist_(cp_foldable_list,
                                                         prevvalue, value);
         }
         else {
@@ -10716,7 +10716,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                 cp_foldable_list = add_cp_to_invlist(cp_foldable_list, LATIN1_TO_NATIVE(j));
             }
             if (value > 255) {
-                cp_foldable_list = _add_range_to_invlist(cp_foldable_list,
+                cp_foldable_list = add_range_to_invlist_(cp_foldable_list,
                                                             256, value);
             }
         }
@@ -10867,7 +10867,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
              * be checked.  Get the intersection of this class and all the
              * possible characters that are foldable.  This can quickly narrow
              * down a large class */
-            _invlist_intersection(PL_in_some_fold, cp_foldable_list,
+            invlist_intersection_(PL_in_some_fold, cp_foldable_list,
                                   &fold_intersection);
 
             /* Now look at the foldable characters in this class individually */
@@ -10981,7 +10981,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
 
         /* Now that we have finished adding all the folds, there is no reason
          * to keep the foldable list separate */
-        _invlist_union(cp_list, cp_foldable_list, &cp_list);
+        invlist_union_(cp_list, cp_foldable_list, &cp_list);
         SvREFCNT_dec_NN(cp_foldable_list);
     }
 
@@ -10991,7 +10991,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
     if (simple_posixes) {   /* These are the classes known to be unaffected by
                                /a, /aa, and /d */
         if (cp_list) {
-            _invlist_union(cp_list, simple_posixes, &cp_list);
+            invlist_union_(cp_list, simple_posixes, &cp_list);
             SvREFCNT_dec_NN(simple_posixes);
         }
         else {
@@ -11005,7 +11005,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
              * 'nposixes' to the main list */
             if (posixes) {
                 if (cp_list) {
-                    _invlist_union(cp_list, posixes, &cp_list);
+                    invlist_union_(cp_list, posixes, &cp_list);
                     SvREFCNT_dec_NN(posixes);
                 }
                 else {
@@ -11014,7 +11014,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
             }
             if (nposixes) {
                 if (cp_list) {
-                    _invlist_union(cp_list, nposixes, &cp_list);
+                    invlist_union_(cp_list, nposixes, &cp_list);
                     SvREFCNT_dec_NN(nposixes);
                 }
                 else {
@@ -11037,7 +11037,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                  * matched regardless, so can just be added to the
                  * unconditional list */
                 if (cp_list) {
-                    _invlist_union(cp_list, nposixes, &cp_list);
+                    invlist_union_(cp_list, nposixes, &cp_list);
                     SvREFCNT_dec_NN(nposixes);
                     nposixes = NULL;
                 }
@@ -11046,13 +11046,13 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                 }
 
                 /* Likewise for 'posixes' */
-                _invlist_union(posixes, cp_list, &cp_list);
+                invlist_union_(posixes, cp_list, &cp_list);
                 SvREFCNT_dec(posixes);
 
                 /* Likewise for anything else in the range that matched only
                  * under UTF-8 */
                 if (upper_latin1_only_utf8_matches) {
-                    _invlist_union(cp_list,
+                    invlist_union_(cp_list,
                                    upper_latin1_only_utf8_matches,
                                    &cp_list);
                     SvREFCNT_dec_NN(upper_latin1_only_utf8_matches);
@@ -11062,9 +11062,9 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                 /* If we don't match all the upper Latin1 characters regardless
                  * of UTF-8ness, we have to set a flag to match the rest when
                  * not in UTF-8 */
-                _invlist_subtract(only_non_utf8_list, cp_list,
+                invlist_subtract_(only_non_utf8_list, cp_list,
                                   &only_non_utf8_list);
-                if (_invlist_len(only_non_utf8_list) != 0) {
+                if (invlist_len_(only_non_utf8_list) != 0) {
                     anyof_flags |= ANYOFD_NON_UTF8_MATCHES_ALL_NON_ASCII__shared;
                 }
                 SvREFCNT_dec_NN(only_non_utf8_list);
@@ -11078,21 +11078,21 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                  *
                  * First calculate what they are */
                 SV* nonascii_but_latin1_properties = NULL;
-                _invlist_intersection(posixes, PL_UpperLatin1,
+                invlist_intersection_(posixes, PL_UpperLatin1,
                                       &nonascii_but_latin1_properties);
 
                 /* And add them to the final list of such characters. */
-                _invlist_union(upper_latin1_only_utf8_matches,
+                invlist_union_(upper_latin1_only_utf8_matches,
                                nonascii_but_latin1_properties,
                                &upper_latin1_only_utf8_matches);
 
                 /* Remove them from what now becomes the unconditional list */
-                _invlist_subtract(posixes, nonascii_but_latin1_properties,
+                invlist_subtract_(posixes, nonascii_but_latin1_properties,
                                   &posixes);
 
                 /* And add those unconditional ones to the final list */
                 if (cp_list) {
-                    _invlist_union(cp_list, posixes, &cp_list);
+                    invlist_union_(cp_list, posixes, &cp_list);
                     SvREFCNT_dec_NN(posixes);
                     posixes = NULL;
                 }
@@ -11105,10 +11105,10 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                 /* Get rid of any characters from the conditional list that we
                  * now know are matched unconditionally, which may make that
                  * list empty */
-                _invlist_subtract(upper_latin1_only_utf8_matches,
+                invlist_subtract_(upper_latin1_only_utf8_matches,
                                   cp_list,
                                   &upper_latin1_only_utf8_matches);
-                if (_invlist_len(upper_latin1_only_utf8_matches) == 0) {
+                if (invlist_len_(upper_latin1_only_utf8_matches) == 0) {
                     SvREFCNT_dec_NN(upper_latin1_only_utf8_matches);
                     upper_latin1_only_utf8_matches = NULL;
                 }
@@ -11142,7 +11142,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                                ^ (UNICODE_IS_SUPER(invlist_highest(cp_list))));
             }
 
-            _invlist_union(properties, cp_list, &cp_list);
+            invlist_union_(properties, cp_list, &cp_list);
             SvREFCNT_dec_NN(properties);
         }
         else {
@@ -11177,19 +11177,19 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
          * other components.  Remove them, and clean up the list if it goes to
          * 0 elements */
         if (only_utf8_locale_list && cp_list) {
-            _invlist_subtract(only_utf8_locale_list, cp_list,
+            invlist_subtract_(only_utf8_locale_list, cp_list,
                               &only_utf8_locale_list);
 
-            if (_invlist_len(only_utf8_locale_list) == 0) {
+            if (invlist_len_(only_utf8_locale_list) == 0) {
                 SvREFCNT_dec_NN(only_utf8_locale_list);
                 only_utf8_locale_list = NULL;
             }
         }
         if (    only_utf8_locale_list
             || (    cp_list
-                && (   _invlist_contains_cp(cp_list,
+                && (   invlist_contains_cp_(cp_list,
                                         LATIN_CAPITAL_LETTER_I_WITH_DOT_ABOVE)
-                    || _invlist_contains_cp(cp_list,
+                    || invlist_contains_cp_(cp_list,
                                             LATIN_SMALL_LETTER_DOTLESS_I))))
         {
             has_runtime_dependency |= HAS_L_RUNTIME_DEPENDENCY;
@@ -11203,8 +11203,8 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
 
             /* In a Turkish locale these could match, notify the run-time code
              * to check for that */
-            if (   _invlist_contains_cp(cp_list, 'I')
-                || _invlist_contains_cp(cp_list, 'i'))
+            if (   invlist_contains_cp_(cp_list, 'I')
+                || invlist_contains_cp_(cp_list, 'i'))
             {
                 anyof_flags |= ANYOFL_FOLD|ANYOF_HAS_EXTRA_RUNTIME_MATCHES;
             }
@@ -11225,7 +11225,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
         &&   invert
         && ! has_runtime_dependency)
     {
-        _invlist_invert(cp_list);
+        invlist_invert_(cp_list);
 
         /* Clear the invert flag since have just done it here */
         invert = false;
@@ -11315,7 +11315,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
      * */
     if (upper_latin1_only_utf8_matches) {
         if (cp_list) {
-            _invlist_union(cp_list,
+            invlist_union_(cp_list,
                            upper_latin1_only_utf8_matches,
                            &cp_list);
             SvREFCNT_dec_NN(upper_latin1_only_utf8_matches);
@@ -11458,12 +11458,12 @@ S_optimize_regclass(pTHX_
              * the constructed node list is inverted, and restricted to only
              * the above latin1 code points, which are the only ones known at
              * compile time */
-            _invlist_intersection_maybe_complement_2nd(
+            invlist_intersection_maybe_complement_2nd_(
                                                 PL_AboveLatin1,
                                                 PL_XPosix_ptrs[classnum],
                                                 already_inverted,
                                                 &class_above_latin1);
-            are_equivalent = _invlistEQ(class_above_latin1, cp_list, false);
+            are_equivalent = invlistEQ_(class_above_latin1, cp_list, false);
             SvREFCNT_dec_NN(class_above_latin1);
 
             if (are_equivalent) {
@@ -11587,7 +11587,7 @@ S_optimize_regclass(pTHX_
             else {  /* /i, larger code point.  Since we are under /i, and have
                        just this code point, we know that it can't fold to
                        something else, so PL_InMultiCharFold applies to it */
-                op = (_invlist_contains_cp(PL_InMultiCharFold, lowest_cp))
+                op = (invlist_contains_cp_(PL_InMultiCharFold, lowest_cp))
                          ? EXACTFU_REQ8
                          : EXACT_REQ8;
                 }
@@ -11595,7 +11595,7 @@ S_optimize_regclass(pTHX_
                 value = lowest_cp;
         }
         else if (  ! (has_runtime_dependency & ~HAS_D_RUNTIME_DEPENDENCY)
-                 && _invlist_contains_cp(PL_in_some_fold, lowest_cp))
+                 && invlist_contains_cp_(PL_in_some_fold, lowest_cp))
         {
             /* Here, the only runtime dependency, if any, is from /d, and the
              * class matches more than one code point, and the lowest code
@@ -11648,7 +11648,7 @@ S_optimize_regclass(pTHX_
                 }
             }
             else if (  ! upper_latin1_only_utf8_matches
-                     || (   _invlist_len(upper_latin1_only_utf8_matches) == 2
+                     || (   invlist_len_(upper_latin1_only_utf8_matches) == 2
                          && PL_fold_latin1[
                            invlist_highest(upper_latin1_only_utf8_matches)]
                          == lowest_cp))
@@ -11693,7 +11693,7 @@ S_optimize_regclass(pTHX_
                                                             &first_fold,
                                                             &remaining_folds);
                 Size_t folds_count = folds_to_this_cp_count + 1;
-                SV * fold_list = _new_invlist(folds_count);
+                SV * fold_list = new_invlist_(folds_count);
                 unsigned int i;
 
                 /* If there are UTF-8 dependent matches, create a temporary
@@ -11702,9 +11702,9 @@ S_optimize_regclass(pTHX_
                 SV ** use_this_list = &cp_list;
 
                 if (upper_latin1_only_utf8_matches) {
-                    all_cp_list = _new_invlist(0);
+                    all_cp_list = new_invlist_(0);
                     use_this_list = &all_cp_list;
-                    _invlist_union(cp_list,
+                    invlist_union_(cp_list,
                                    upper_latin1_only_utf8_matches,
                                    use_this_list);
                 }
@@ -11724,7 +11724,7 @@ S_optimize_regclass(pTHX_
 
                 /* If the fold list is identical to what's in this ANYOF node,
                  * the node can be represented by an EXACTFish one instead */
-                if (_invlistEQ(*use_this_list, fold_list,
+                if (invlistEQ_(*use_this_list, fold_list,
                                0 /* Don't complement */ )
                 ) {
 
@@ -11739,7 +11739,7 @@ S_optimize_regclass(pTHX_
                      * are folding, and if not, if it is not part of a
                      * multi-char fold.  */
                     if (lowest_cp > 255) {    /* Highish code point */
-                        if (FOLD || ! _invlist_contains_cp(
+                        if (FOLD || ! invlist_contains_cp_(
                                                    PL_InMultiCharFold, folded))
                         {
                             op = (LOC)
@@ -11870,7 +11870,7 @@ S_optimize_regclass(pTHX_
          * that works we will instead later generate an NANYOFM, and invert
          * back when through */
         if (highest_cp > max_permissible) {
-            _invlist_invert(cp_list);
+            invlist_invert_(cp_list);
             inverted = 1;
         }
 
@@ -11946,7 +11946,7 @@ S_optimize_regclass(pTHX_
         }
 
         if (inverted) {
-            _invlist_invert(cp_list);
+            invlist_invert_(cp_list);
         }
 
         if (op != END) {
@@ -12017,9 +12017,9 @@ S_optimize_regclass(pTHX_
 
                         /* /d classes don't match anything non-ASCII below 256
                          * unconditionally (which cp_list contains) */
-                        _invlist_intersection(cp_list, PL_UpperLatin1,
+                        invlist_intersection_(cp_list, PL_UpperLatin1,
                                                        &intersection);
-                        if (_invlist_len(intersection) != 0) {
+                        if (invlist_len_(intersection) != 0) {
                             continue;
                         }
 
@@ -12031,7 +12031,7 @@ S_optimize_regclass(pTHX_
                          * we check below that these are identical to what the
                          * tested class should match */
                         if (upper_latin1_only_utf8_matches) {
-                            _invlist_union(
+                            invlist_union_(
                                         d_invlist,
                                         upper_latin1_only_utf8_matches,
                                         &d_invlist);
@@ -12054,7 +12054,7 @@ S_optimize_regclass(pTHX_
                      * ('*our_code_points') precisely matches those of the
                      * class we are currently checking against
                      * ('*official_code_points'). */
-                    if (_invlistEQ(*our_code_points,
+                    if (invlistEQ_(*our_code_points,
                                    *official_code_points,
                                    try_inverted))
                     {
@@ -12371,7 +12371,7 @@ Perl_set_ANYOF_arg(pTHX_ RExC_state_t* const pRExC_state,
             }
 
             /* If the inversion lists aren't equivalent, can't share */
-            if (cp_list && ! _invlistEQ(cp_list,
+            if (cp_list && ! invlistEQ_(cp_list,
                                         *stored_cp_list_ptr,
                                         false /* don't complement */))
             {
@@ -12389,7 +12389,7 @@ Perl_set_ANYOF_arg(pTHX_ RExC_state_t* const pRExC_state,
                 continue;
             }
 
-            if (only_utf8_locale_list && ! _invlistEQ(
+            if (only_utf8_locale_list && ! invlistEQ_(
                                          only_utf8_locale_list,
                                          *stored_only_utf8_locale_list_ptr,
                                          false /* don't complement */))
@@ -12531,7 +12531,7 @@ Perl_get_re_gclass_aux_data(pTHX_ const regexp *prog, const regnode* node, bool 
                     }
 
                     if (invlist) {
-                        _invlist_union(invlist, prop_definition, &invlist);
+                        invlist_union_(invlist, prop_definition, &invlist);
                         SvREFCNT_dec_NN(prop_definition);
                     }
                     else {
@@ -12602,7 +12602,7 @@ Perl_get_re_gclass_aux_data(pTHX_ const regexp *prog, const regnode* node, bool 
                      * up to the next \n */
                     if (   *(si_string + len) == '\n') {
                         if (count) {    /* 2nd code point on line */
-                            *output_invlist = _add_range_to_invlist(*output_invlist, prev_cp, cp);
+                            *output_invlist = add_range_to_invlist_(*output_invlist, prev_cp, cp);
                         }
                         else {
                             *output_invlist = add_cp_to_invlist(*output_invlist, cp);
@@ -12678,7 +12678,7 @@ Perl_get_re_gclass_aux_data(pTHX_ const regexp *prog, const regnode* node, bool 
                 *output_invlist = invlist_clone(invlist, NULL);
             }
             else {
-                _invlist_union(*output_invlist, invlist, output_invlist);
+                invlist_union_(*output_invlist, invlist, output_invlist);
             }
         }
 
@@ -13180,7 +13180,7 @@ Perl_get_ANYOFM_contents(pTHX_ const regnode * n) {
     /* Returns an inversion list of all the code points matched by the
      * ANYOFM/NANYOFM node 'n' */
 
-    SV * cp_list = _new_invlist(-1);
+    SV * cp_list = new_invlist_(-1);
     const U8 lowest = (U8) ARG1u(n);
     unsigned int i;
     U8 count = 0;
@@ -13202,7 +13202,7 @@ Perl_get_ANYOFM_contents(pTHX_ const regnode * n) {
     }
 
     if (OP(n) == NANYOFM) {
-        _invlist_invert(cp_list);
+        invlist_invert_(cp_list);
     }
     return cp_list;
 }
@@ -13955,79 +13955,79 @@ Perl_init_uniprops(pTHX)
 
     /* Set up the inversion list interpreter-level variables */
 
-    PL_XPosix_ptrs[CC_ASCII_] = _new_invlist_C_array(uni_prop_ptrs[UNI_ASCII]);
-    PL_XPosix_ptrs[CC_ALPHANUMERIC_] = _new_invlist_C_array(uni_prop_ptrs[UNI_XPOSIXALNUM]);
-    PL_XPosix_ptrs[CC_ALPHA_] = _new_invlist_C_array(uni_prop_ptrs[UNI_XPOSIXALPHA]);
-    PL_XPosix_ptrs[CC_BLANK_] = _new_invlist_C_array(uni_prop_ptrs[UNI_XPOSIXBLANK]);
-    PL_XPosix_ptrs[CC_CASED_] =  _new_invlist_C_array(uni_prop_ptrs[UNI_CASED]);
-    PL_XPosix_ptrs[CC_CNTRL_] = _new_invlist_C_array(uni_prop_ptrs[UNI_XPOSIXCNTRL]);
-    PL_XPosix_ptrs[CC_DIGIT_] = _new_invlist_C_array(uni_prop_ptrs[UNI_XPOSIXDIGIT]);
-    PL_XPosix_ptrs[CC_GRAPH_] = _new_invlist_C_array(uni_prop_ptrs[UNI_XPOSIXGRAPH]);
-    PL_XPosix_ptrs[CC_LOWER_] = _new_invlist_C_array(uni_prop_ptrs[UNI_XPOSIXLOWER]);
-    PL_XPosix_ptrs[CC_PRINT_] = _new_invlist_C_array(uni_prop_ptrs[UNI_XPOSIXPRINT]);
-    PL_XPosix_ptrs[CC_PUNCT_] = _new_invlist_C_array(uni_prop_ptrs[UNI_XPOSIXPUNCT]);
-    PL_XPosix_ptrs[CC_SPACE_] = _new_invlist_C_array(uni_prop_ptrs[UNI_XPOSIXSPACE]);
-    PL_XPosix_ptrs[CC_UPPER_] = _new_invlist_C_array(uni_prop_ptrs[UNI_XPOSIXUPPER]);
-    PL_XPosix_ptrs[CC_VERTSPACE_] = _new_invlist_C_array(uni_prop_ptrs[UNI_VERTSPACE]);
-    PL_XPosix_ptrs[CC_WORDCHAR_] = _new_invlist_C_array(uni_prop_ptrs[UNI_XPOSIXWORD]);
-    PL_XPosix_ptrs[CC_XDIGIT_] = _new_invlist_C_array(uni_prop_ptrs[UNI_XPOSIXXDIGIT]);
+    PL_XPosix_ptrs[CC_ASCII_] = new_invlist_C_array_(uni_prop_ptrs[UNI_ASCII]);
+    PL_XPosix_ptrs[CC_ALPHANUMERIC_] = new_invlist_C_array_(uni_prop_ptrs[UNI_XPOSIXALNUM]);
+    PL_XPosix_ptrs[CC_ALPHA_] = new_invlist_C_array_(uni_prop_ptrs[UNI_XPOSIXALPHA]);
+    PL_XPosix_ptrs[CC_BLANK_] = new_invlist_C_array_(uni_prop_ptrs[UNI_XPOSIXBLANK]);
+    PL_XPosix_ptrs[CC_CASED_] =  new_invlist_C_array_(uni_prop_ptrs[UNI_CASED]);
+    PL_XPosix_ptrs[CC_CNTRL_] = new_invlist_C_array_(uni_prop_ptrs[UNI_XPOSIXCNTRL]);
+    PL_XPosix_ptrs[CC_DIGIT_] = new_invlist_C_array_(uni_prop_ptrs[UNI_XPOSIXDIGIT]);
+    PL_XPosix_ptrs[CC_GRAPH_] = new_invlist_C_array_(uni_prop_ptrs[UNI_XPOSIXGRAPH]);
+    PL_XPosix_ptrs[CC_LOWER_] = new_invlist_C_array_(uni_prop_ptrs[UNI_XPOSIXLOWER]);
+    PL_XPosix_ptrs[CC_PRINT_] = new_invlist_C_array_(uni_prop_ptrs[UNI_XPOSIXPRINT]);
+    PL_XPosix_ptrs[CC_PUNCT_] = new_invlist_C_array_(uni_prop_ptrs[UNI_XPOSIXPUNCT]);
+    PL_XPosix_ptrs[CC_SPACE_] = new_invlist_C_array_(uni_prop_ptrs[UNI_XPOSIXSPACE]);
+    PL_XPosix_ptrs[CC_UPPER_] = new_invlist_C_array_(uni_prop_ptrs[UNI_XPOSIXUPPER]);
+    PL_XPosix_ptrs[CC_VERTSPACE_] = new_invlist_C_array_(uni_prop_ptrs[UNI_VERTSPACE]);
+    PL_XPosix_ptrs[CC_WORDCHAR_] = new_invlist_C_array_(uni_prop_ptrs[UNI_XPOSIXWORD]);
+    PL_XPosix_ptrs[CC_XDIGIT_] = new_invlist_C_array_(uni_prop_ptrs[UNI_XPOSIXXDIGIT]);
 
-    PL_Posix_ptrs[CC_ASCII_] = _new_invlist_C_array(uni_prop_ptrs[UNI_ASCII]);
-    PL_Posix_ptrs[CC_ALPHANUMERIC_] = _new_invlist_C_array(uni_prop_ptrs[UNI_POSIXALNUM]);
-    PL_Posix_ptrs[CC_ALPHA_] = _new_invlist_C_array(uni_prop_ptrs[UNI_POSIXALPHA]);
-    PL_Posix_ptrs[CC_BLANK_] = _new_invlist_C_array(uni_prop_ptrs[UNI_POSIXBLANK]);
+    PL_Posix_ptrs[CC_ASCII_] = new_invlist_C_array_(uni_prop_ptrs[UNI_ASCII]);
+    PL_Posix_ptrs[CC_ALPHANUMERIC_] = new_invlist_C_array_(uni_prop_ptrs[UNI_POSIXALNUM]);
+    PL_Posix_ptrs[CC_ALPHA_] = new_invlist_C_array_(uni_prop_ptrs[UNI_POSIXALPHA]);
+    PL_Posix_ptrs[CC_BLANK_] = new_invlist_C_array_(uni_prop_ptrs[UNI_POSIXBLANK]);
     PL_Posix_ptrs[CC_CASED_] = PL_Posix_ptrs[CC_ALPHA_];
-    PL_Posix_ptrs[CC_CNTRL_] = _new_invlist_C_array(uni_prop_ptrs[UNI_POSIXCNTRL]);
-    PL_Posix_ptrs[CC_DIGIT_] = _new_invlist_C_array(uni_prop_ptrs[UNI_POSIXDIGIT]);
-    PL_Posix_ptrs[CC_GRAPH_] = _new_invlist_C_array(uni_prop_ptrs[UNI_POSIXGRAPH]);
-    PL_Posix_ptrs[CC_LOWER_] = _new_invlist_C_array(uni_prop_ptrs[UNI_POSIXLOWER]);
-    PL_Posix_ptrs[CC_PRINT_] = _new_invlist_C_array(uni_prop_ptrs[UNI_POSIXPRINT]);
-    PL_Posix_ptrs[CC_PUNCT_] = _new_invlist_C_array(uni_prop_ptrs[UNI_POSIXPUNCT]);
-    PL_Posix_ptrs[CC_SPACE_] = _new_invlist_C_array(uni_prop_ptrs[UNI_POSIXSPACE]);
-    PL_Posix_ptrs[CC_UPPER_] = _new_invlist_C_array(uni_prop_ptrs[UNI_POSIXUPPER]);
+    PL_Posix_ptrs[CC_CNTRL_] = new_invlist_C_array_(uni_prop_ptrs[UNI_POSIXCNTRL]);
+    PL_Posix_ptrs[CC_DIGIT_] = new_invlist_C_array_(uni_prop_ptrs[UNI_POSIXDIGIT]);
+    PL_Posix_ptrs[CC_GRAPH_] = new_invlist_C_array_(uni_prop_ptrs[UNI_POSIXGRAPH]);
+    PL_Posix_ptrs[CC_LOWER_] = new_invlist_C_array_(uni_prop_ptrs[UNI_POSIXLOWER]);
+    PL_Posix_ptrs[CC_PRINT_] = new_invlist_C_array_(uni_prop_ptrs[UNI_POSIXPRINT]);
+    PL_Posix_ptrs[CC_PUNCT_] = new_invlist_C_array_(uni_prop_ptrs[UNI_POSIXPUNCT]);
+    PL_Posix_ptrs[CC_SPACE_] = new_invlist_C_array_(uni_prop_ptrs[UNI_POSIXSPACE]);
+    PL_Posix_ptrs[CC_UPPER_] = new_invlist_C_array_(uni_prop_ptrs[UNI_POSIXUPPER]);
     PL_Posix_ptrs[CC_VERTSPACE_] = NULL;
-    PL_Posix_ptrs[CC_WORDCHAR_] = _new_invlist_C_array(uni_prop_ptrs[UNI_POSIXWORD]);
-    PL_Posix_ptrs[CC_XDIGIT_] = _new_invlist_C_array(uni_prop_ptrs[UNI_POSIXXDIGIT]);
+    PL_Posix_ptrs[CC_WORDCHAR_] = new_invlist_C_array_(uni_prop_ptrs[UNI_POSIXWORD]);
+    PL_Posix_ptrs[CC_XDIGIT_] = new_invlist_C_array_(uni_prop_ptrs[UNI_POSIXXDIGIT]);
 
-    PL_GCB_invlist = _new_invlist_C_array(_Perl_GCB_invlist);
-    PL_SB_invlist = _new_invlist_C_array(_Perl_SB_invlist);
-    PL_WB_invlist = _new_invlist_C_array(_Perl_WB_invlist);
-    PL_LB_invlist = _new_invlist_C_array(_Perl_LB_invlist);
-    PL_SCX_invlist = _new_invlist_C_array(_Perl_SCX_invlist);
+    PL_GCB_invlist = new_invlist_C_array_(_Perl_GCB_invlist);
+    PL_SB_invlist = new_invlist_C_array_(_Perl_SB_invlist);
+    PL_WB_invlist = new_invlist_C_array_(_Perl_WB_invlist);
+    PL_LB_invlist = new_invlist_C_array_(_Perl_LB_invlist);
+    PL_SCX_invlist = new_invlist_C_array_(_Perl_SCX_invlist);
 
-    PL_InBitmap = _new_invlist_C_array(InBitmap_invlist);
-    PL_AboveLatin1 = _new_invlist_C_array(AboveLatin1_invlist);
-    PL_Latin1 = _new_invlist_C_array(Latin1_invlist);
-    PL_UpperLatin1 = _new_invlist_C_array(UpperLatin1_invlist);
+    PL_InBitmap = new_invlist_C_array_(InBitmap_invlist);
+    PL_AboveLatin1 = new_invlist_C_array_(AboveLatin1_invlist);
+    PL_Latin1 = new_invlist_C_array_(Latin1_invlist);
+    PL_UpperLatin1 = new_invlist_C_array_(UpperLatin1_invlist);
 
-    PL_Assigned_invlist = _new_invlist_C_array(uni_prop_ptrs[UNI_ASSIGNED]);
+    PL_Assigned_invlist = new_invlist_C_array_(uni_prop_ptrs[UNI_ASSIGNED]);
 
-    PL_utf8_perl_idstart = _new_invlist_C_array(uni_prop_ptrs[UNI__PERL_IDSTART]);
-    PL_utf8_perl_idcont = _new_invlist_C_array(uni_prop_ptrs[UNI__PERL_IDCONT]);
+    PL_utf8_perl_idstart = new_invlist_C_array_(uni_prop_ptrs[UNI__PERL_IDSTART]);
+    PL_utf8_perl_idcont = new_invlist_C_array_(uni_prop_ptrs[UNI__PERL_IDCONT]);
 
-    PL_utf8_charname_begin = _new_invlist_C_array(uni_prop_ptrs[UNI__PERL_CHARNAME_BEGIN]);
-    PL_utf8_charname_continue = _new_invlist_C_array(uni_prop_ptrs[UNI__PERL_CHARNAME_CONTINUE]);
+    PL_utf8_charname_begin = new_invlist_C_array_(uni_prop_ptrs[UNI__PERL_CHARNAME_BEGIN]);
+    PL_utf8_charname_continue = new_invlist_C_array_(uni_prop_ptrs[UNI__PERL_CHARNAME_CONTINUE]);
 
-    PL_in_some_fold = _new_invlist_C_array(uni_prop_ptrs[UNI__PERL_ANY_FOLDS]);
-    PL_HasMultiCharFold = _new_invlist_C_array(uni_prop_ptrs[
+    PL_in_some_fold = new_invlist_C_array_(uni_prop_ptrs[UNI__PERL_ANY_FOLDS]);
+    PL_HasMultiCharFold = new_invlist_C_array_(uni_prop_ptrs[
                                             UNI__PERL_FOLDS_TO_MULTI_CHAR]);
-    PL_InMultiCharFold = _new_invlist_C_array(uni_prop_ptrs[
+    PL_InMultiCharFold = new_invlist_C_array_(uni_prop_ptrs[
                                             UNI__PERL_IS_IN_MULTI_CHAR_FOLD]);
-    PL_utf8_toupper = _new_invlist_C_array(Uppercase_Mapping_invlist);
-    PL_utf8_tolower = _new_invlist_C_array(Lowercase_Mapping_invlist);
-    PL_utf8_totitle = _new_invlist_C_array(Titlecase_Mapping_invlist);
-    PL_utf8_tofold = _new_invlist_C_array(Case_Folding_invlist);
-    PL_utf8_tosimplefold = _new_invlist_C_array(Simple_Case_Folding_invlist);
-    PL_utf8_foldclosures = _new_invlist_C_array(_Perl_IVCF_invlist);
-    PL_utf8_mark = _new_invlist_C_array(uni_prop_ptrs[UNI_M]);
-    PL_CCC_non0_non230 = _new_invlist_C_array(_Perl_CCC_non0_non230_invlist);
-    PL_Private_Use = _new_invlist_C_array(uni_prop_ptrs[UNI_CO]);
+    PL_utf8_toupper = new_invlist_C_array_(Uppercase_Mapping_invlist);
+    PL_utf8_tolower = new_invlist_C_array_(Lowercase_Mapping_invlist);
+    PL_utf8_totitle = new_invlist_C_array_(Titlecase_Mapping_invlist);
+    PL_utf8_tofold = new_invlist_C_array_(Case_Folding_invlist);
+    PL_utf8_tosimplefold = new_invlist_C_array_(Simple_Case_Folding_invlist);
+    PL_utf8_foldclosures = new_invlist_C_array_(_Perl_IVCF_invlist);
+    PL_utf8_mark = new_invlist_C_array_(uni_prop_ptrs[UNI_M]);
+    PL_CCC_non0_non230 = new_invlist_C_array_(_Perl_CCC_non0_non230_invlist);
+    PL_Private_Use = new_invlist_C_array_(uni_prop_ptrs[UNI_CO]);
 
 #  ifdef UNI_XIDC
     /* The below are used only by deprecated functions.  They could be removed */
-    PL_utf8_xidcont  = _new_invlist_C_array(uni_prop_ptrs[UNI_XIDC]);
-    PL_utf8_idcont   = _new_invlist_C_array(uni_prop_ptrs[UNI_IDC]);
-    PL_utf8_xidstart = _new_invlist_C_array(uni_prop_ptrs[UNI_XIDS]);
+    PL_utf8_xidcont  = new_invlist_C_array_(uni_prop_ptrs[UNI_XIDC]);
+    PL_utf8_idcont   = new_invlist_C_array_(uni_prop_ptrs[UNI_IDC]);
+    PL_utf8_xidstart = new_invlist_C_array_(uni_prop_ptrs[UNI_XIDS]);
 #  endif
 }
 
@@ -14049,7 +14049,7 @@ Perl_get_prop_definition(pTHX_ const int table_index)
     PERL_ARGS_ASSERT_GET_PROP_DEFINITION;
 
     /* Create and return the inversion list */
-    return _new_invlist_C_array(uni_prop_ptrs[table_index]);
+    return new_invlist_C_array_(uni_prop_ptrs[table_index]);
 }
 
 const char * const *
@@ -14392,8 +14392,8 @@ S_handle_user_defined_property(pTHX_
 #  endif
 
         /* Here, this line contains a legal range */
-        this_definition = sv_2mortal(_new_invlist(2));
-        this_definition = _add_range_to_invlist(this_definition, min, max);
+        this_definition = sv_2mortal(new_invlist_(2));
+        this_definition = add_range_to_invlist_(this_definition, min, max);
         goto calculate;
 
       check_if_property:
@@ -14443,19 +14443,19 @@ S_handle_user_defined_property(pTHX_
 
         switch (op) {
             case '+':
-                _invlist_union(running_definition, this_definition,
+                invlist_union_(running_definition, this_definition,
                                                         &running_definition);
                 break;
             case '-':
-                _invlist_subtract(running_definition, this_definition,
+                invlist_subtract_(running_definition, this_definition,
                                                         &running_definition);
                 break;
             case '&':
-                _invlist_intersection(running_definition, this_definition,
+                invlist_intersection_(running_definition, this_definition,
                                                         &running_definition);
                 break;
             case '!':
-                _invlist_union_complement_2nd(running_definition,
+                invlist_union_complement_2nd_(running_definition,
                                         this_definition, &running_definition);
                 break;
             default:
@@ -14475,7 +14475,7 @@ S_handle_user_defined_property(pTHX_
         /* If the expansion was empty, the answer isn't nothing: its an empty
          * inversion list */
         if (running_definition == NULL) {
-            running_definition = _new_invlist(1);
+            running_definition = new_invlist_(1);
         }
 
         return running_definition;
@@ -14917,7 +14917,7 @@ S_parse_uniprop_string(pTHX_
                                                            user_defined_ptr,
                                                            msg,
                                                            level + 1);
-                        _invlist_union(prop_definition, sub_invlist,
+                        invlist_union_(prop_definition, sub_invlist,
                                        &prop_definition);
                     }
 
@@ -15922,10 +15922,10 @@ S_parse_uniprop_string(pTHX_
 
                 /* For now, as a safety measure, make sure that it doesn't
                  * override non-private use code points */
-                _invlist_intersection(pu_invlist, PL_Private_Use, &pu_invlist);
+                invlist_intersection_(pu_invlist, PL_Private_Use, &pu_invlist);
 
                 /* Add it to the list to be returned */
-                _invlist_union(prop_definition, pu_invlist,
+                invlist_union_(prop_definition, pu_invlist,
                                &expanded_prop_definition);
                 prop_definition = expanded_prop_definition;
                 cloned = true;
@@ -15938,7 +15938,7 @@ S_parse_uniprop_string(pTHX_
         if (! cloned) {
            prop_definition = sv_2mortal(invlist_clone(prop_definition, NULL));
         }
-        _invlist_invert(prop_definition);
+        invlist_invert_(prop_definition);
     }
     return prop_definition;
 
@@ -16393,15 +16393,15 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
 
         SV * subtract = get_prop_definition(UNI_CC);
 
-        _invlist_subtract(empty_names, subtract, &empty_names);
+        invlist_subtract_(empty_names, subtract, &empty_names);
         SvREFCNT_dec_NN(empty_names_ref);
         SvREFCNT_dec_NN(subtract);
 
         subtract = get_prop_definition(UNI_CF);
-        _invlist_subtract(empty_names, subtract, &empty_names);
+        invlist_subtract_(empty_names, subtract, &empty_names);
         SvREFCNT_dec_NN(subtract);
 
-        _invlist_union(*prop_definition, empty_names, prop_definition);
+        invlist_union_(*prop_definition, empty_names, prop_definition);
         found_matches = true;
         SvREFCNT_dec_NN(empty_names);
     }
@@ -16425,7 +16425,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
 
             (void) handle_names_wildcard(empties_pat, strlen(empties_pat), &empties);
 
-            _invlist_union_complement_2nd(*prop_definition, empties, prop_definition);
+            invlist_union_complement_2nd_(*prop_definition, empties, prop_definition);
             SvREFCNT_dec_NN(empties);
 
             found_matches = true;

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -783,25 +783,25 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
             if (start < NUM_ANYOF_CODE_POINTS) {
                 if (end < NUM_ANYOF_CODE_POINTS) {
                     bitmap_range_not_in_bitmap
-                          = _add_range_to_invlist(bitmap_range_not_in_bitmap,
+                          = add_range_to_invlist_(bitmap_range_not_in_bitmap,
                                                   start, end);
                 }
                 else {
                     bitmap_range_not_in_bitmap
-                          = _add_range_to_invlist(bitmap_range_not_in_bitmap,
+                          = add_range_to_invlist_(bitmap_range_not_in_bitmap,
                                                   start, NUM_ANYOF_CODE_POINTS);
                     start = NUM_ANYOF_CODE_POINTS;
                 }
             }
 
             if (start >= NUM_ANYOF_CODE_POINTS) {
-                nonbitmap_invlist = _add_range_to_invlist(nonbitmap_invlist,
+                nonbitmap_invlist = add_range_to_invlist_(nonbitmap_invlist,
                                                 ANYOFRbase(o),
                                                 ANYOFRbase(o) + ANYOFRdelta(o));
             }
         }
         else if (ANYOF_MATCHES_ALL_OUTSIDE_BITMAP(o)) {
-            nonbitmap_invlist = _add_range_to_invlist(nonbitmap_invlist,
+            nonbitmap_invlist = add_range_to_invlist_(nonbitmap_invlist,
                                                       NUM_ANYOF_CODE_POINTS,
                                                       UV_MAX);
         }
@@ -816,11 +816,11 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
              * resolved when this call was done; or much more likely because
              * there are matches that require UTF-8 to be valid, and so aren't
              * in the bitmap (or ANYOFR).  This is teased apart later */
-            _invlist_intersection(nonbitmap_invlist,
+            invlist_intersection_(nonbitmap_invlist,
                                   PL_InBitmap,
                                   &bitmap_range_not_in_bitmap);
             /* Leave just the things that don't fit into the bitmap */
-            _invlist_subtract(nonbitmap_invlist,
+            invlist_subtract_(nonbitmap_invlist,
                               PL_InBitmap,
                               &nonbitmap_invlist);
         }
@@ -882,14 +882,14 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
                  * everything above the lower display should also match, but
                  * there is no indication of that.  Add this range so the code
                  * below will add it to the display */
-                _invlist_union_complement_2nd(nonbitmap_invlist,
+                invlist_union_complement_2nd_(nonbitmap_invlist,
                                               PL_InBitmap,
                                               &nonbitmap_invlist);
             }
         }
 
         /* And, finally, add the above-the-bitmap stuff */
-        if (nonbitmap_invlist && _invlist_len(nonbitmap_invlist)) {
+        if (nonbitmap_invlist && invlist_len_(nonbitmap_invlist)) {
             SV* contents;
 
             /* See if truncation size is overridden */
@@ -907,8 +907,8 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
              * there are unresolved items, where the inversion has to be
              * delayed until runtime */
             if (inverted && ! unresolved) {
-                _invlist_invert(nonbitmap_invlist);
-                _invlist_subtract(nonbitmap_invlist, PL_InBitmap, &nonbitmap_invlist);
+                invlist_invert_(nonbitmap_invlist);
+                invlist_subtract_(nonbitmap_invlist, PL_InBitmap, &nonbitmap_invlist);
             }
 
             contents = invlist_contents(nonbitmap_invlist,
@@ -977,7 +977,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
 
         sv_catpvf(sv, "[%s", PL_colors[0]);
         if (op == NANYOFM) {
-            _invlist_invert(cp_list);
+            invlist_invert_(cp_list);
         }
 
         put_charclass_bitmap_innards(sv, NULL, cp_list, NULL, NULL, 0, true);
@@ -1353,17 +1353,17 @@ S_put_charclass_bitmap_innards_common(pTHX_
         sv_catsv(output, posixes);
     }
 
-    if (only_utf8 && _invlist_len(only_utf8)) {
+    if (only_utf8 && invlist_len_(only_utf8)) {
         sv_catpvf(output, "%s{utf8}%s", PL_colors[1], PL_colors[0]);
         put_charclass_bitmap_innards_invlist(output, only_utf8);
     }
 
-    if (not_utf8 && _invlist_len(not_utf8)) {
+    if (not_utf8 && invlist_len_(not_utf8)) {
         sv_catpvf(output, "%s{not utf8}%s", PL_colors[1], PL_colors[0]);
         put_charclass_bitmap_innards_invlist(output, not_utf8);
     }
 
-    if (only_utf8_locale && _invlist_len(only_utf8_locale)) {
+    if (only_utf8_locale && invlist_len_(only_utf8_locale)) {
         sv_catpvf(output, "%s{utf8 locale}%s", PL_colors[1], PL_colors[0]);
         put_charclass_bitmap_innards_invlist(output, only_utf8_locale);
 
@@ -1376,7 +1376,7 @@ S_put_charclass_bitmap_innards_common(pTHX_
             UV start, end;
             SV* above_bitmap = NULL;
 
-            _invlist_subtract(only_utf8_locale, PL_InBitmap, &above_bitmap);
+            invlist_subtract_(only_utf8_locale, PL_InBitmap, &above_bitmap);
 
             invlist_iterinit(above_bitmap);
             while (invlist_iternext(above_bitmap, &start, &end)) {
@@ -1476,7 +1476,7 @@ S_put_charclass_bitmap_innards(pTHX_ SV *sv,
         invlist = invlist_clone(nonbitmap_invlist, NULL);
     }
     else {  /* Worst case size is every other code point is matched */
-        invlist = _new_invlist(NUM_ANYOF_CODE_POINTS / 2);
+        invlist = new_invlist_(NUM_ANYOF_CODE_POINTS / 2);
     }
 
     if (flags) {
@@ -1486,8 +1486,8 @@ S_put_charclass_bitmap_innards(pTHX_ SV *sv,
              * nonbitmap list are precisely the ones that match only when the
              * target is UTF-8 (they should all be non-ASCII). */
             if (flags & ANYOF_HAS_EXTRA_RUNTIME_MATCHES) {
-                _invlist_intersection(invlist, PL_UpperLatin1, &only_utf8);
-                _invlist_subtract(invlist, only_utf8, &invlist);
+                invlist_intersection_(invlist, PL_UpperLatin1, &only_utf8);
+                invlist_subtract_(invlist, only_utf8, &invlist);
             }
 
             /* And this flag for matching all non-ASCII 0xFF and below */
@@ -1528,7 +1528,7 @@ S_put_charclass_bitmap_innards(pTHX_ SV *sv,
                      i < NUM_ANYOF_CODE_POINTS && BITMAP_TEST(bitmap, i);
                      i++)
                 { /* empty */ }
-                invlist = _add_range_to_invlist(invlist, start, i-1);
+                invlist = add_range_to_invlist_(invlist, start, i-1);
             }
         }
     }
@@ -1538,10 +1538,10 @@ S_put_charclass_bitmap_innards(pTHX_ SV *sv,
      * This could happen if the code that populates these misses some
      * duplication. */
     if (only_utf8) {
-        _invlist_subtract(only_utf8, invlist, &only_utf8);
+        invlist_subtract_(only_utf8, invlist, &only_utf8);
     }
     if (not_utf8) {
-        _invlist_subtract(not_utf8, invlist, &not_utf8);
+        invlist_subtract_(not_utf8, invlist, &not_utf8);
     }
 
     if (only_utf8_locale_invlist) {
@@ -1550,7 +1550,7 @@ S_put_charclass_bitmap_innards(pTHX_ SV *sv,
          * modifying it */
         only_utf8_locale = invlist_clone(only_utf8_locale_invlist, NULL);
 
-        _invlist_subtract(only_utf8_locale, invlist, &only_utf8_locale);
+        invlist_subtract_(only_utf8_locale, invlist, &only_utf8_locale);
 
         /* And, it can get really weird for us to try outputting an inverted
          * form of this list when it has things above the bitmap, so don't even
@@ -1600,15 +1600,15 @@ S_put_charclass_bitmap_innards(pTHX_ SV *sv,
         /* For the unconditional inversion list, we have to add in all the
          * conditional code points, so that when inverted, they will be gone
          * from it */
-        _invlist_union(only_utf8, invlist, &invlist);
-        _invlist_union(not_utf8, invlist, &invlist);
-        _invlist_union(only_utf8_locale, invlist, &invlist);
-        _invlist_invert(invlist);
-        _invlist_intersection(invlist, PL_InBitmap, &invlist);
+        invlist_union_(only_utf8, invlist, &invlist);
+        invlist_union_(not_utf8, invlist, &invlist);
+        invlist_union_(only_utf8_locale, invlist, &invlist);
+        invlist_invert_(invlist);
+        invlist_intersection_(invlist, PL_InBitmap, &invlist);
 
         if (only_utf8) {
-            _invlist_invert(only_utf8);
-            _invlist_intersection(only_utf8, PL_UpperLatin1, &only_utf8);
+            invlist_invert_(only_utf8);
+            invlist_intersection_(only_utf8, PL_UpperLatin1, &only_utf8);
         }
         else if (not_utf8) {
 
@@ -1620,8 +1620,8 @@ S_put_charclass_bitmap_innards(pTHX_ SV *sv,
         }
 
         if (only_utf8_locale) {
-            _invlist_invert(only_utf8_locale);
-            _invlist_intersection(only_utf8_locale,
+            invlist_invert_(only_utf8_locale);
+            invlist_intersection_(only_utf8_locale,
                                   PL_InBitmap,
                                   &only_utf8_locale);
         }

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -565,10 +565,10 @@ struct RExC_state_t {
 #define namedclass_to_classnum(class)  ((int) ((class) / 2))
 #define classnum_to_namedclass(classnum)  ((classnum) * 2)
 
-#define _invlist_union_complement_2nd(a, b, output) \
-                        _invlist_union_maybe_complement_2nd(a, b, TRUE, output)
-#define _invlist_intersection_complement_2nd(a, b, output) \
-                 _invlist_intersection_maybe_complement_2nd(a, b, TRUE, output)
+#define invlist_union_complement_2nd_(a, b, output) \
+                        invlist_union_maybe_complement_2nd_(a, b, TRUE, output)
+#define invlist_intersection_complement_2nd_(a, b, output) \
+                 invlist_intersection_maybe_complement_2nd_(a, b, TRUE, output)
 
 /* We add a marker if we are deferring expansion of a property that is both
  * 1) potentially user-defined; and

--- a/regcomp_invlist.c
+++ b/regcomp_invlist.c
@@ -64,7 +64,7 @@ Perl_populate_invlist_from_bitmap(pTHX_ const U8 * bitmap, const Size_t bitmap_l
                 i++;
             }
 
-            *invlist = _add_range_to_invlist(*invlist,
+            *invlist = add_range_to_invlist_(*invlist,
                                              start + offset,
                                              i + offset - 1);
         }
@@ -133,7 +133,7 @@ Perl_populate_invlist_from_bitmap(pTHX_ const U8 * bitmap, const Size_t bitmap_l
 #ifndef PERL_IN_XSUB_RE
 
 PERL_STATIC_INLINE UV*
-S__invlist_array_init(SV* const invlist, const bool will_have_0)
+S_invlist_array_init_(SV* const invlist, const bool will_have_0)
 {
     /* Returns a pointer to the first element in the inversion list's array.
      * This is called upon initialization of an inversion list.  Where the
@@ -146,10 +146,10 @@ S__invlist_array_init(SV* const invlist, const bool will_have_0)
     bool* offset = get_invlist_offset_addr(invlist);
     UV* zero_addr = (UV *) SvPVX(invlist);
 
-    PERL_ARGS_ASSERT__INVLIST_ARRAY_INIT;
+    PERL_ARGS_ASSERT_INVLIST_ARRAY_INIT_;
 
     /* Must be empty */
-    assert(! _invlist_len(invlist));
+    assert(! invlist_len_(invlist));
 
     *zero_addr = 0;
 
@@ -166,7 +166,7 @@ S_invlist_replace_list_destroys_src(pTHX_ SV * dest, SV * src)
      * is similar to what SvSetMagicSV() would do, if it were implemented on
      * inversion lists, though this routine avoids a copy */
 
-    const UV src_len          = _invlist_len(src);
+    const UV src_len          = invlist_len_(src);
     const bool src_offset     = *get_invlist_offset_addr(src);
     const STRLEN src_byte_len = SvLEN(src);
     char * array              = SvPVX(src);
@@ -235,7 +235,7 @@ S_invlist_set_previous_index(SV* const invlist, const IV index)
 
     PERL_ARGS_ASSERT_INVLIST_SET_PREVIOUS_INDEX;
 
-    assert(index == 0 || index < (int) _invlist_len(invlist));
+    assert(index == 0 || index < (int) invlist_len_(invlist));
 
     *get_invlist_previous_index_addr(invlist) = index;
 }
@@ -279,7 +279,7 @@ S_invlist_max(const SV* const invlist)
 
     /* Assumes worst case, in which the 0 element is not counted in the
      * inversion list, so subtracts 1 for that */
-    return SvLEN(invlist) == 0  /* This happens under _new_invlist_C_array */
+    return SvLEN(invlist) == 0  /* This happens under new_invlist_C_array_ */
            ? FROM_INTERNAL_SIZE(SvCUR(invlist)) - 1
            : FROM_INTERNAL_SIZE(SvLEN(invlist)) - 1;
 }
@@ -302,7 +302,7 @@ S_initialize_invlist_guts(pTHX_ SV* invlist, const Size_t initial_size)
 }
 
 SV*
-Perl__new_invlist(pTHX_ IV initial_size)
+Perl_new_invlist_(pTHX_ IV initial_size)
 {
 
     /* Return a pointer to a newly constructed inversion list, with enough
@@ -322,7 +322,7 @@ Perl__new_invlist(pTHX_ IV initial_size)
 }
 
 SV*
-Perl__new_invlist_C_array(pTHX_ const UV* const list)
+Perl_new_invlist_C_array_(pTHX_ const UV* const list)
 {
     /* Return a pointer to a newly constructed inversion list, initialized to
      * point to <list>, which has to be in the exact correct inversion list
@@ -347,7 +347,7 @@ Perl__new_invlist_C_array(pTHX_ const UV* const list)
 
     SV* invlist = newSV_type(SVt_INVLIST);
 
-    PERL_ARGS_ASSERT__NEW_INVLIST_C_ARRAY;
+    PERL_ARGS_ASSERT_NEW_INVLIST_C_ARRAY_;
 
     if (version_id != INVLIST_VERSION_ID) {
         croak("panic: Incorrect version for previously generated inversion list");
@@ -379,7 +379,7 @@ Perl__new_invlist_C_array(pTHX_ const UV* const list)
 }
 
 STATIC void
-S__append_range_to_invlist(pTHX_ SV* const invlist,
+S_append_range_to_invlist_(pTHX_ SV* const invlist,
                                  const UV start, const UV end)
 {
    /* Subject to change or removal.  Append the range from 'start' to 'end' at
@@ -388,14 +388,14 @@ S__append_range_to_invlist(pTHX_ SV* const invlist,
 
     UV* array;
     UV max = invlist_max(invlist);
-    UV len = _invlist_len(invlist);
+    UV len = invlist_len_(invlist);
     bool offset;
 
-    PERL_ARGS_ASSERT__APPEND_RANGE_TO_INVLIST;
+    PERL_ARGS_ASSERT_APPEND_RANGE_TO_INVLIST_;
 
     if (len == 0) { /* Empty lists must be initialized */
         offset = start != 0;
-        array = _invlist_array_init(invlist, ! offset);
+        array = invlist_array_init_(invlist, ! offset);
     }
     else {
         /* Here, the existing list is non-empty. The current max entry in the
@@ -467,7 +467,7 @@ S__append_range_to_invlist(pTHX_ SV* const invlist,
 }
 
 SSize_t
-Perl__invlist_search(SV* const invlist, const UV cp)
+Perl_invlist_search_(SV* const invlist, const UV cp)
 {
     /* Searches the inversion list for the entry that contains the input code
      * point <cp>.  If <cp> is not in the list, -1 is returned.  Otherwise, the
@@ -478,11 +478,11 @@ Perl__invlist_search(SV* const invlist, const UV cp)
 
     IV low = 0;
     IV mid;
-    IV high = _invlist_len(invlist);
+    IV high = invlist_len_(invlist);
     const IV highest_element = high - 1;
     const UV* array;
 
-    PERL_ARGS_ASSERT__INVLIST_SEARCH;
+    PERL_ARGS_ASSERT_INVLIST_SEARCH_;
 
     /* If list is empty, return failure. */
     if (UNLIKELY(high == 0)) {
@@ -560,7 +560,7 @@ Perl__invlist_search(SV* const invlist, const UV cp)
 }
 
 void
-Perl__invlist_union_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
+Perl_invlist_union_maybe_complement_2nd_(pTHX_ SV* const a, SV* const b,
                                          const bool complement_b, SV** output)
 {
     /* Take the union of two inversion lists and point '*output' to it.  On
@@ -601,11 +601,11 @@ Perl__invlist_union_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
      * inputs are in their sets.  */
     UV count = 0;
 
-    PERL_ARGS_ASSERT__INVLIST_UNION_MAYBE_COMPLEMENT_2ND;
+    PERL_ARGS_ASSERT_INVLIST_UNION_MAYBE_COMPLEMENT_2ND_;
     assert(a != b);
     assert(*output == NULL || is_invlist(*output));
 
-    len_b = _invlist_len(b);
+    len_b = invlist_len_(b);
     if (len_b == 0) {
 
         /* Here, 'b' is empty, hence it's complement is all possible code
@@ -613,7 +613,7 @@ Perl__invlist_union_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
          * everything, and we need not even look at 'a'.  It's easiest to
          * create a new inversion list that matches everything.  */
         if (complement_b) {
-            SV* everything = _add_range_to_invlist(NULL, 0, UV_MAX);
+            SV* everything = add_range_to_invlist_(NULL, 0, UV_MAX);
 
             if (*output == NULL) { /* If the output didn't exist, just point it
                                       at the new list */
@@ -631,9 +631,9 @@ Perl__invlist_union_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
          * the union will come entirely from 'a'.  If 'a' is NULL or empty, the
          * output will be empty */
 
-        if (a == NULL || _invlist_len(a) == 0) {
+        if (a == NULL || invlist_len_(a) == 0) {
             if (*output == NULL) {
-                *output = _new_invlist(0);
+                *output = new_invlist_(0);
             }
             else {
                 invlist_clear(*output);
@@ -665,7 +665,7 @@ Perl__invlist_union_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
 
     /* Here 'b' is not empty.  See about 'a' */
 
-    if (a == NULL || ((len_a = _invlist_len(a)) == 0)) {
+    if (a == NULL || ((len_a = invlist_len_(a)) == 0)) {
 
         /* Here, 'a' is empty (and b is not).  That means the union will come
          * entirely from 'b'.  If '*output' is NULL, we can directly return a
@@ -675,7 +675,7 @@ Perl__invlist_union_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
         SV ** dest = (*output == NULL) ? output : &u;
         *dest = invlist_clone(b, NULL);
         if (complement_b) {
-            _invlist_invert(*dest);
+            invlist_invert_(*dest);
         }
 
         if (dest == &u) {
@@ -711,10 +711,10 @@ Perl__invlist_union_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
 
     /* Size the union for the worst case: that the sets are completely
      * disjoint */
-    u = _new_invlist(len_a + len_b);
+    u = new_invlist_(len_a + len_b);
 
     /* Will contain U+0000 if either component does */
-    array_u = _invlist_array_init(u, (    len_a > 0 && array_a[0] == 0)
+    array_u = invlist_array_init_(u, (    len_a > 0 && array_a[0] == 0)
                                       || (len_b > 0 && array_b[0] == 0));
 
     /* Go through each input list item by item, stopping when have exhausted
@@ -815,7 +815,7 @@ Perl__invlist_union_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
     /* Set the result to the final length, which can change the pointer to
      * array_u, so re-find it.  (Note that it is unlikely that this will
      * change, as we are shrinking the space, not enlarging it) */
-    if (len_u != _invlist_len(u)) {
+    if (len_u != invlist_len_(u)) {
         invlist_set_len(u, len_u, *get_invlist_offset_addr(u));
         invlist_trim(u);
         array_u = invlist_array(u);
@@ -838,7 +838,7 @@ Perl__invlist_union_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
 }
 
 void
-Perl__invlist_intersection_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
+Perl_invlist_intersection_maybe_complement_2nd_(pTHX_ SV* const a, SV* const b,
                                                const bool complement_b, SV** i)
 {
     /* Take the intersection of two inversion lists and point '*i' to it.  On
@@ -879,13 +879,13 @@ Perl__invlist_intersection_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
      * Only when it is 2 are we in the intersection. */
     UV count = 0;
 
-    PERL_ARGS_ASSERT__INVLIST_INTERSECTION_MAYBE_COMPLEMENT_2ND;
+    PERL_ARGS_ASSERT_INVLIST_INTERSECTION_MAYBE_COMPLEMENT_2ND_;
     assert(a != b);
     assert(*i == NULL || is_invlist(*i));
 
     /* Special case if either one is empty */
-    len_a = (a == NULL) ? 0 : _invlist_len(a);
-    if ((len_a == 0) || ((len_b = _invlist_len(b)) == 0)) {
+    len_a = (a == NULL) ? 0 : invlist_len_(a);
+    if ((len_a == 0) || ((len_b = invlist_len_(b)) == 0)) {
         if (len_a != 0 && complement_b) {
 
             /* Here, 'a' is not empty, therefore from the enclosing 'if', 'b'
@@ -911,7 +911,7 @@ Perl__invlist_intersection_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
         /* Here, 'a' or 'b' is empty and not using the complement of 'b'.  The
          * intersection must be empty */
         if (*i == NULL) {
-            *i = _new_invlist(0);
+            *i = new_invlist_(0);
             return;
         }
 
@@ -944,10 +944,10 @@ Perl__invlist_intersection_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
 
     /* Size the intersection for the worst case: that the intersection ends up
      * fragmenting everything to be completely disjoint */
-    r = _new_invlist(len_a + len_b);
+    r = new_invlist_(len_a + len_b);
 
     /* Will contain U+0000 iff both components do */
-    array_r = _invlist_array_init(r,    len_a > 0 && array_a[0] == 0
+    array_r = invlist_array_init_(r,    len_a > 0 && array_a[0] == 0
                                      && len_b > 0 && array_b[0] == 0);
 
     /* Go through each list item by item, stopping when have exhausted one of
@@ -1049,7 +1049,7 @@ Perl__invlist_intersection_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
     /* Set the result to the final length, which can change the pointer to
      * array_r, so re-find it.  (Note that it is unlikely that this will
      * change, as we are shrinking the space, not enlarging it) */
-    if (len_r != _invlist_len(r)) {
+    if (len_r != invlist_len_(r)) {
         invlist_set_len(r, len_r, *get_invlist_offset_addr(r));
         invlist_trim(r);
         array_r = invlist_array(r);
@@ -1076,7 +1076,7 @@ Perl__invlist_intersection_maybe_complement_2nd(pTHX_ SV* const a, SV* const b,
 }
 
 SV*
-Perl__add_range_to_invlist(pTHX_ SV* invlist, UV start, UV end)
+Perl_add_range_to_invlist_(pTHX_ SV* invlist, UV start, UV end)
 {
     /* Add the range from 'start' to 'end' inclusive to the inversion list's
      * set.  A pointer to the inversion list is returned.  This may actually be
@@ -1101,15 +1101,15 @@ Perl__add_range_to_invlist(pTHX_ SV* invlist, UV start, UV end)
 
     /* This range becomes the whole inversion list if none already existed */
     if (invlist == NULL) {
-        invlist = _new_invlist(2);
-        _append_range_to_invlist(invlist, start, end);
+        invlist = new_invlist_(2);
+        append_range_to_invlist_(invlist, start, end);
         return invlist;
     }
 
     /* Likewise, if the inversion list is currently empty */
-    len = _invlist_len(invlist);
+    len = invlist_len_(invlist);
     if (len == 0) {
-        _append_range_to_invlist(invlist, start, end);
+        append_range_to_invlist_(invlist, start, end);
         return invlist;
     }
 
@@ -1122,12 +1122,12 @@ Perl__add_range_to_invlist(pTHX_ SV* invlist, UV start, UV end)
 
         /* If the whole range is higher, we can just append it */
         if (start > cur_highest) {
-            _append_range_to_invlist(invlist, start, end);
+            append_range_to_invlist_(invlist, start, end);
             return invlist;
         }
 
         /* Otherwise, add the portion that is higher ... */
-        _append_range_to_invlist(invlist, cur_highest + 1, end);
+        append_range_to_invlist_(invlist, cur_highest + 1, end);
 
         /* ... and continue on below to handle the rest.  As a result of the
          * above append, we know that the index of the end of the range is the
@@ -1154,10 +1154,10 @@ Perl__add_range_to_invlist(pTHX_ SV* invlist, UV start, UV end)
         if (UNLIKELY(start == 0)) {
             SV* range_invlist;
 
-            range_invlist = _new_invlist(2);
-            _append_range_to_invlist(range_invlist, start, end);
+            range_invlist = new_invlist_(2);
+            append_range_to_invlist_(range_invlist, start, end);
 
-            _invlist_union(invlist, range_invlist, &invlist);
+            invlist_union_(invlist, range_invlist, &invlist);
 
             SvREFCNT_dec_NN(range_invlist);
 
@@ -1183,7 +1183,7 @@ Perl__add_range_to_invlist(pTHX_ SV* invlist, UV start, UV end)
             * Find where in the list it should go.  This finds i_s, such that:
             *     invlist[i_s] <= start < array[i_s+1]
             */
-        i_s = _invlist_search(invlist, start);
+        i_s = invlist_search_(invlist, start);
     }
 
     /* At this point, any extending before the beginning of the inversion list
@@ -1198,7 +1198,7 @@ Perl__add_range_to_invlist(pTHX_ SV* invlist, UV start, UV end)
     if (i_e == 0) {
         i_e = (start == end)
               ? i_s
-              : _invlist_search(invlist, end);
+              : invlist_search_(invlist, end);
     }
 
     /* Here generally invlist[i_e] <= end < array[i_e+1].  But if invlist[i_e]
@@ -1336,7 +1336,7 @@ Perl__add_range_to_invlist(pTHX_ SV* invlist, UV start, UV end)
 }
 
 SV*
-Perl__setup_canned_invlist(pTHX_ const STRLEN size, const UV element0,
+Perl_setup_canned_invlist_(pTHX_ const STRLEN size, const UV element0,
                                  UV** other_elements_ptr)
 {
     /* Create and return an inversion list whose contents are to be populated
@@ -1351,10 +1351,10 @@ Perl__setup_canned_invlist(pTHX_ const STRLEN size, const UV element0,
      * (The first element needs to be passed in, as the underlying code does
      * things differently depending on whether it is zero or non-zero) */
 
-    SV* invlist = _new_invlist(size);
+    SV* invlist = new_invlist_(size);
     bool offset;
 
-    PERL_ARGS_ASSERT__SETUP_CANNED_INVLIST;
+    PERL_ARGS_ASSERT_SETUP_CANNED_INVLIST_;
 
     invlist = add_cp_to_invlist(invlist, element0);
     offset = *get_invlist_offset_addr(invlist);
@@ -1368,19 +1368,19 @@ Perl__setup_canned_invlist(pTHX_ const STRLEN size, const UV element0,
 
 #ifndef PERL_IN_XSUB_RE
 void
-Perl__invlist_invert(pTHX_ SV* const invlist)
+Perl_invlist_invert_(pTHX_ SV* const invlist)
 {
     /* Complement the input inversion list.  This adds a 0 if the list didn't
      * have a zero; removes it otherwise.  As described above, the data
      * structure is set up so that this is very efficient */
 
-    PERL_ARGS_ASSERT__INVLIST_INVERT;
+    PERL_ARGS_ASSERT_INVLIST_INVERT_;
 
     assert(! invlist_is_iterating(invlist));
 
     /* The inverse of matching nothing is matching everything */
-    if (_invlist_len(invlist) == 0) {
-        _append_range_to_invlist(invlist, 0, UV_MAX);
+    if (invlist_len_(invlist) == 0) {
+        append_range_to_invlist_(invlist, 0, UV_MAX);
         return;
     }
 
@@ -1393,14 +1393,14 @@ Perl_invlist_clone(pTHX_ SV* const invlist, SV* new_invlist)
     /* Return a new inversion list that is a copy of the input one, which is
      * unchanged.  The new list will not be mortal even if the old one was. */
 
-    const STRLEN nominal_length = _invlist_len(invlist);
+    const STRLEN nominal_length = invlist_len_(invlist);
     const STRLEN physical_length = SvCUR(invlist);
     const bool offset = *(get_invlist_offset_addr(invlist));
 
     PERL_ARGS_ASSERT_INVLIST_CLONE;
 
     if (new_invlist == NULL) {
-        new_invlist = _new_invlist(nominal_length);
+        new_invlist = new_invlist_(nominal_length);
     }
     else {
         sv_upgrade(new_invlist, SVt_INVLIST);
@@ -1419,7 +1419,7 @@ Perl_invlist_clone(pTHX_ SV* const invlist, SV* new_invlist)
 
 #ifndef PERL_IN_XSUB_RE
 void
-Perl__invlist_dump(pTHX_ PerlIO *file, I32 level,
+Perl_invlist_dump_(pTHX_ PerlIO *file, I32 level,
                          const char * const indent, SV* const invlist)
 {
     /* Designed to be called only by do_sv_dump().  Dumps out the ranges of the
@@ -1439,7 +1439,7 @@ Perl__invlist_dump(pTHX_ PerlIO *file, I32 level,
     UV start, end;
     STRLEN count = 0;
 
-    PERL_ARGS_ASSERT__INVLIST_DUMP;
+    PERL_ARGS_ASSERT_INVLIST_DUMP_;
 
     if (invlist_is_iterating(invlist)) {
         Perl_dump_indent(aTHX_ level, file,
@@ -1470,21 +1470,21 @@ Perl__invlist_dump(pTHX_ PerlIO *file, I32 level,
 
 #endif
 
-#if defined(PERL_ARGS_ASSERT__INVLISTEQ) && !defined(PERL_IN_XSUB_RE)
+#if defined(PERL_ARGS_ASSERT_INVLISTEQ_) && !defined(PERL_IN_XSUB_RE)
 bool
-Perl__invlistEQ(pTHX_ SV* const a, SV* const b, const bool complement_b)
+Perl_invlistEQ_(pTHX_ SV* const a, SV* const b, const bool complement_b)
 {
     /* Return a boolean as to if the two passed in inversion lists are
      * identical.  The final argument, if true, says to take the complement of
      * the second inversion list before doing the comparison */
 
-    const UV len_a = _invlist_len(a);
-    UV len_b = _invlist_len(b);
+    const UV len_a = invlist_len_(a);
+    UV len_b = invlist_len_(b);
 
     const UV* array_a = NULL;
     const UV* array_b = NULL;
 
-    PERL_ARGS_ASSERT__INVLISTEQ;
+    PERL_ARGS_ASSERT_INVLISTEQ_;
 
     /* This code avoids accessing the arrays unless it knows the length is
      * non-zero */

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -88,7 +88,7 @@ S_make_exactf_invlist(pTHX_ RExC_state_t *pRExC_state, regnode *node)
     SSize_t bytelen = STR_LEN(node);
     UV uc;
     /* Start out big enough for 2 separate code points */
-    SV* invlist = _new_invlist(4);
+    SV* invlist = new_invlist_(4);
 
     PERL_ARGS_ASSERT_MAKE_EXACTF_INVLIST;
 
@@ -104,14 +104,14 @@ S_make_exactf_invlist(pTHX_ RExC_state_t *pRExC_state, regnode *node)
          *  plus several other things; and making sure we have all the
          *  possibilities is hard. */
         if (is_MULTI_CHAR_FOLD_latin1_safe(s, s + bytelen)) {
-            invlist = _add_range_to_invlist(invlist, 0, UV_MAX);
+            invlist = add_range_to_invlist_(invlist, 0, UV_MAX);
         }
         else {
             /* Any Latin1 range character can potentially match any
              * other depending on the locale, and in Turkic locales, 'I' and
              * 'i' can match U+130 and U+131 */
             if (OP(node) == EXACTFL) {
-                _invlist_union(invlist, PL_Latin1, &invlist);
+                invlist_union_(invlist, PL_Latin1, &invlist);
                 if (isALPHA_FOLD_EQ(uc, 'I')) {
                     invlist = add_cp_to_invlist(invlist,
                                                 LATIN_SMALL_LETTER_DOTLESS_I);
@@ -190,7 +190,7 @@ S_make_exactf_invlist(pTHX_ RExC_state_t *pRExC_state, regnode *node)
          * multi-char fold  */
 
         if (is_MULTI_CHAR_FOLD_utf8_safe(s, e)) {
-            invlist = _add_range_to_invlist(invlist, 0, UV_MAX);
+            invlist = add_range_to_invlist_(invlist, 0, UV_MAX);
         }
         else {  /* Single char fold */
             unsigned int k;
@@ -310,7 +310,7 @@ S_ssc_anything(pTHX_ regnode_ssc *ssc)
     assert(is_ANYOF_SYNTHETIC(ssc));
 
     /* mortalize so won't leak */
-    ssc->invlist = sv_2mortal(_add_range_to_invlist(NULL, 0, UV_MAX));
+    ssc->invlist = sv_2mortal(add_range_to_invlist_(NULL, 0, UV_MAX));
     ANYOF_FLAGS(ssc) |= SSC_MATCHES_EMPTY_STRING;  /* Plus matches empty */
 }
 
@@ -441,8 +441,8 @@ S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state,
 
     /* Look at the data structure created by S_set_ANYOF_arg() */
     if (ANYOF_MATCHES_ALL_OUTSIDE_BITMAP(node)) {
-        invlist = sv_2mortal(_new_invlist(1));
-        invlist = _add_range_to_invlist(invlist, NUM_ANYOF_CODE_POINTS, UV_MAX);
+        invlist = sv_2mortal(new_invlist_(1));
+        invlist = add_range_to_invlist_(invlist, NUM_ANYOF_CODE_POINTS, UV_MAX);
     }
     else if (ANYOF_HAS_AUX(node)) {
         const U32 n = ARG1u(node);
@@ -454,8 +454,8 @@ S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state,
 
             /* Here there are things that won't be known until runtime -- we
              * have to assume it could be anything */
-            invlist = sv_2mortal(_new_invlist(1));
-            return _add_range_to_invlist(invlist, 0, UV_MAX);
+            invlist = sv_2mortal(new_invlist_(1));
+            return add_range_to_invlist_(invlist, 0, UV_MAX);
         }
         else if (ary[INVLIST_INDEX]) {
 
@@ -472,7 +472,7 @@ S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state,
     }
 
     if (! invlist) {
-        invlist = sv_2mortal(_new_invlist(0));
+        invlist = sv_2mortal(new_invlist_(0));
     }
 
     /* An ANYOF node contains a bitmap for the first NUM_ANYOF_CODE_POINTS
@@ -486,7 +486,7 @@ S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state,
      * have to do this here before we add the unconditionally matched code
      * points */
     if (flags & ANYOF_INVERT) {
-        _invlist_intersection_complement_2nd(invlist,
+        invlist_intersection_complement_2nd_(invlist,
                                              PL_UpperLatin1,
                                              &invlist);
     }
@@ -502,7 +502,7 @@ S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state,
                 {
                     /* empty */
                 }
-                invlist = _add_range_to_invlist(invlist, start, i-1);
+                invlist = add_range_to_invlist_(invlist, start, i-1);
                 new_node_has_latin1 = true;
             }
         }
@@ -516,39 +516,39 @@ S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state,
         &&  OP(node) == ANYOFD
         && (flags & ANYOFD_NON_UTF8_MATCHES_ALL_NON_ASCII__shared))
     {
-        _invlist_union(invlist, PL_UpperLatin1, &invlist);
+        invlist_union_(invlist, PL_UpperLatin1, &invlist);
     }
 
     /* Similarly for these */
     if (ANYOF_MATCHES_ALL_OUTSIDE_BITMAP(node)) {
-        _invlist_union_complement_2nd(invlist, PL_InBitmap, &invlist);
+        invlist_union_complement_2nd_(invlist, PL_InBitmap, &invlist);
     }
 
     if (flags & ANYOF_INVERT) {
-        _invlist_invert(invlist);
+        invlist_invert_(invlist);
     }
     else if (flags & ANYOFL_FOLD) {
         if (new_node_has_latin1) {
 
             /* These folds are potential in Turkic locales */
-            if (_invlist_contains_cp(invlist, 'i')) {
+            if (invlist_contains_cp_(invlist, 'i')) {
                 invlist = add_cp_to_invlist(invlist,
                                         LATIN_CAPITAL_LETTER_I_WITH_DOT_ABOVE);
             }
-            if (_invlist_contains_cp(invlist, 'I')) {
+            if (invlist_contains_cp_(invlist, 'I')) {
                 invlist = add_cp_to_invlist(invlist,
                                                 LATIN_SMALL_LETTER_DOTLESS_I);
             }
 
             /* Under /li, any 0-255 could fold to any other 0-255, depending on
              * the locale.  We can skip this if there are no 0-255 at all. */
-            _invlist_union(invlist, PL_Latin1, &invlist);
+            invlist_union_(invlist, PL_Latin1, &invlist);
         }
         else {
-            if (_invlist_contains_cp(invlist, LATIN_SMALL_LETTER_DOTLESS_I)) {
+            if (invlist_contains_cp_(invlist, LATIN_SMALL_LETTER_DOTLESS_I)) {
                 invlist = add_cp_to_invlist(invlist, 'I');
             }
-            if (_invlist_contains_cp(invlist,
+            if (invlist_contains_cp_(invlist,
                                         LATIN_CAPITAL_LETTER_I_WITH_DOT_ABOVE))
             {
                 invlist = add_cp_to_invlist(invlist, 'i');
@@ -560,7 +560,7 @@ S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state,
      * deferred until after the non-UTF-8 locale ones are taken care of just
      * above, or it leads to wrong results under ANYOF_INVERT */
     if (only_utf8_locale_invlist) {
-        _invlist_union_maybe_complement_2nd(invlist,
+        invlist_union_maybe_complement_2nd_(invlist,
                                             only_utf8_locale_invlist,
                                             flags & ANYOF_INVERT,
                                             &invlist);
@@ -845,7 +845,7 @@ S_ssc_union(pTHX_ regnode_ssc *ssc, SV* const invlist, const bool invert2nd)
 
     assert(is_ANYOF_SYNTHETIC(ssc));
 
-    _invlist_union_maybe_complement_2nd(ssc->invlist,
+    invlist_union_maybe_complement_2nd_(ssc->invlist,
                                         invlist,
                                         invert2nd,
                                         &ssc->invlist);
@@ -860,7 +860,7 @@ S_ssc_intersection(pTHX_ regnode_ssc *ssc,
 
     assert(is_ANYOF_SYNTHETIC(ssc));
 
-    _invlist_intersection_maybe_complement_2nd(ssc->invlist,
+    invlist_intersection_maybe_complement_2nd_(ssc->invlist,
                                                invlist,
                                                invert2nd,
                                                &ssc->invlist);
@@ -873,7 +873,7 @@ S_ssc_add_range(pTHX_ regnode_ssc *ssc, const UV start, const UV end)
 
     assert(is_ANYOF_SYNTHETIC(ssc));
 
-    ssc->invlist = _add_range_to_invlist(ssc->invlist, start, end);
+    ssc->invlist = add_range_to_invlist_(ssc->invlist, start, end);
 }
 
 STATIC void
@@ -881,7 +881,7 @@ S_ssc_cp_and(pTHX_ regnode_ssc *ssc, const UV cp)
 {
     /* AND just the single code point 'cp' into the SSC 'ssc' */
 
-    SV* cp_list = _new_invlist(2);
+    SV* cp_list = new_invlist_(2);
 
     PERL_ARGS_ASSERT_SSC_CP_AND;
 
@@ -2948,7 +2948,7 @@ Perl_study_chunk(pTHX_
 
                 case REG_ANY:
                     {
-                        SV* REG_ANY_invlist = _new_invlist(2);
+                        SV* REG_ANY_invlist = new_invlist_(2);
                         REG_ANY_invlist = add_cp_to_invlist(REG_ANY_invlist,
                                                             '\n');
                         if (flags & SCF_DO_STCLASS_OR) {
@@ -3024,7 +3024,7 @@ Perl_study_chunk(pTHX_
                   {
                     SV* cp_list = NULL;
 
-                    cp_list = _add_range_to_invlist(cp_list,
+                    cp_list = add_range_to_invlist_(cp_list,
                                         ANYOFRbase(scan),
                                         ANYOFRbase(scan) + ANYOFRdelta(scan));
 
@@ -3055,7 +3055,7 @@ Perl_study_chunk(pTHX_
                         }
                         /* No individual code points can now match */
                         data->start_class->invlist
-                                                = sv_2mortal(_new_invlist(0));
+                                                = sv_2mortal(new_invlist_(0));
                     }
                     else {
                         int complement = namedclass + ((invert) ? -1 : 1);
@@ -3101,7 +3101,7 @@ Perl_study_chunk(pTHX_
                      * invert, we want to get rid of all of them so that the
                      * inversion will match all */
                     if (OP(scan) == NPOSIXD) {
-                        _invlist_subtract(my_invlist, PL_UpperLatin1,
+                        invlist_subtract_(my_invlist, PL_UpperLatin1,
                                           &my_invlist);
                     }
 

--- a/regexec.c
+++ b/regexec.c
@@ -617,7 +617,7 @@ S_isFOO_utf8_lc(pTHX_ const U8 classnum, const U8* character, const U8* e)
         case CC_ENUM_XDIGIT_:    return is_XDIGIT_high(character);
         case CC_ENUM_VERTSPACE_: return is_VERTWS_high(character);
         default:
-            return _invlist_contains_cp(PL_XPosix_ptrs[classnum],
+            return invlist_contains_cp_(PL_XPosix_ptrs[classnum],
                                         utf8_to_uv_or_die(character, e, NULL));
     }
     NOT_REACHED; /* NOTREACHED */
@@ -2188,7 +2188,7 @@ STMT_START {                                                                \
 #ifdef DEBUGGING
 static IV
 S_get_break_val_cp_checked(SV* const invlist, const UV cp_in) {
-  IV cp_out = _invlist_search(invlist, cp_in);
+  IV cp_out = invlist_search_(invlist, cp_in);
   assert(cp_out >= 0);
   return cp_out;
 }
@@ -2196,7 +2196,7 @@ S_get_break_val_cp_checked(SV* const invlist, const UV cp_in) {
         invmap[S_get_break_val_cp_checked(invlist, cp)]
 #else
 #  define generic_GET_BREAK_VAL_CP_CHECKED_(invlist, invmap, cp) \
-        invmap[_invlist_search(invlist, cp)]
+        invmap[invlist_search_(invlist, cp)]
 #endif
 
 /* Takes a pointer to an inversion list, a pointer to its corresponding
@@ -2407,7 +2407,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
         anyofh_list = GET_ANYOFH_INVLIST(prog, c);
         REXEC_FBC_UTF8_CLASS_SCAN(
               (   (U8) NATIVE_UTF8_TO_I8(*s) >= ANYOF_FLAGS(c)
-               && _invlist_contains_cp(anyofh_list,
+               && invlist_contains_cp_(anyofh_list,
                                        utf8_to_uv_or_die((U8 *) s,
                                                          (U8 *) strend,
                                                          NULL))));
@@ -2421,7 +2421,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
 
             anyofh_list = GET_ANYOFH_INVLIST(prog, c);
             REXEC_FBC_FIND_NEXT_UTF8_BYTE_SCAN(first_byte,
-                   _invlist_contains_cp(anyofh_list,
+                   invlist_contains_cp_(anyofh_list,
                                            utf8_to_uv_or_die((U8 *) s,
                                                               (U8 *) strend,
                                                               NULL)));
@@ -2449,7 +2449,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                     (   inRANGE(NATIVE_UTF8_TO_I8(*s),
                                 LOWEST_ANYOF_HRx_BYTE(ANYOF_FLAGS(c)),
                                 HIGHEST_ANYOF_HRx_BYTE(ANYOF_FLAGS(c)))
-                   && _invlist_contains_cp(anyofh_list,
+                   && invlist_contains_cp_(anyofh_list,
                                            utf8_to_uv_or_die((U8 *) s,
                                                               (U8 *) strend,
                                                               NULL))));
@@ -2462,7 +2462,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                         ((struct regnode_anyofhs *) c)->string,
                         /* Note FLAGS is the string length in this regnode */
                         ((struct regnode_anyofhs *) c)->string + FLAGS(c),
-                        _invlist_contains_cp(anyofh_list,
+                        invlist_contains_cp_(anyofh_list,
                                              utf8_to_uv_or_die((U8 *) s,
                                                                (U8 *) strend,
                                                                NULL)));
@@ -3210,7 +3210,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
         switch (classnum) {
           default:
             REXEC_FBC_UTF8_CLASS_SCAN(
-                        to_complement ^ cBOOL(_invlist_contains_cp(
+                        to_complement ^ cBOOL(invlist_contains_cp_(
                                                 PL_XPosix_ptrs[classnum],
                                                 utf8_to_uv_or_die((U8 *) s,
                                                                 (U8 *) strend,
@@ -7795,7 +7795,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 ||   NEXTCHR_IS_EOS
                 ||   ANYOF_FLAGS(scan) > NATIVE_UTF8_TO_I8(*locinput)
                 || ! (anyofh_list = GET_ANYOFH_INVLIST(rex, scan))
-                || ! _invlist_contains_cp(anyofh_list,
+                || ! invlist_contains_cp_(anyofh_list,
                                           utf8_to_uv_or_die((U8 *) locinput,
                                                             (U8 *) loceol,
                                                             NULL)))
@@ -7810,7 +7810,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 ||   NEXTCHR_IS_EOS
                 ||   ANYOF_FLAGS(scan) != (U8) *locinput
                 || ! (anyofh_list = GET_ANYOFH_INVLIST(rex, scan))
-                || ! _invlist_contains_cp(anyofh_list,
+                || ! invlist_contains_cp_(anyofh_list,
                                           utf8_to_uv_or_die((U8 *) locinput,
                                                             (U8 *) loceol,
                                                             NULL)))
@@ -7840,7 +7840,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                              LOWEST_ANYOF_HRx_BYTE(ANYOF_FLAGS(scan)),
                              HIGHEST_ANYOF_HRx_BYTE(ANYOF_FLAGS(scan)))
                 || ! (anyofh_list = GET_ANYOFH_INVLIST(rex, scan))
-                || ! _invlist_contains_cp(anyofh_list,
+                || ! invlist_contains_cp_(anyofh_list,
                                           utf8_to_uv_or_die((U8 *) locinput,
                                                             (U8 *) loceol,
                                                             NULL)))
@@ -7856,7 +7856,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 ||   loceol - locinput < FLAGS(scan)
                 ||   memNE(locinput, ((struct regnode_anyofhs *) scan)->string, FLAGS(scan))
                 || ! (anyofh_list = GET_ANYOFH_INVLIST(rex, scan))
-                || ! _invlist_contains_cp(anyofh_list,
+                || ! invlist_contains_cp_(anyofh_list,
                                           utf8_to_uv_or_die((U8 *) locinput,
                                                             (U8 *) loceol,
                                                             NULL)))
@@ -8043,7 +8043,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 switch (classnum) {
                     default:
                         if (! (to_complement
-                           ^ cBOOL(_invlist_contains_cp(
+                           ^ cBOOL(invlist_contains_cp_(
                                       PL_XPosix_ptrs[classnum],
                                       utf8_to_uv_or_die((U8 *) locinput,
                                                         (U8 *) reginfo->strend,
@@ -10758,7 +10758,7 @@ S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
         while (  hardcount < max
                && scan < this_eol
                && NATIVE_UTF8_TO_I8(*scan) >= ANYOF_FLAGS(p)
-               && _invlist_contains_cp(anyofh_list,
+               && invlist_contains_cp_(anyofh_list,
                                        utf8_to_uv_or_die((U8 *) scan,
                                                          (U8 *) this_eol,
                                                          &advance)))
@@ -10774,7 +10774,7 @@ S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
         while (   hardcount < max
                && scan < this_eol
                && (U8) *scan == ANYOF_FLAGS(p)
-               && _invlist_contains_cp(anyofh_list,
+               && invlist_contains_cp_(anyofh_list,
                                        utf8_to_uv_or_die((U8 *) scan,
                                                          (U8 *) this_eol,
                                                          &advance)))
@@ -10804,7 +10804,7 @@ S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
                           LOWEST_ANYOF_HRx_BYTE(ANYOF_FLAGS(p)),
                           HIGHEST_ANYOF_HRx_BYTE(ANYOF_FLAGS(p)))
                && NATIVE_UTF8_TO_I8(*scan) >= ANYOF_FLAGS(p)
-               && _invlist_contains_cp(anyofh_list,
+               && invlist_contains_cp_(anyofh_list,
                                        utf8_to_uv_or_die((U8 *) scan,
                                                          (U8 *) this_eol,
                                                          &advance)))
@@ -10819,7 +10819,7 @@ S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
         while (   hardcount < max
                && scan + FLAGS(p) < this_eol
                && memEQ(scan, ((struct regnode_anyofhs *) p)->string, FLAGS(p))
-               && _invlist_contains_cp(anyofh_list,
+               && invlist_contains_cp_(anyofh_list,
                                        utf8_to_uv_or_die((U8 *) scan,
                                                          (U8 *) this_eol,
                                                          &advance)))
@@ -10972,7 +10972,7 @@ S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
           default:
             while (   hardcount < max && scan < this_eol
                    && to_complement
-                    ^ cBOOL(_invlist_contains_cp(PL_XPosix_ptrs[classnum],
+                    ^ cBOOL(invlist_contains_cp_(PL_XPosix_ptrs[classnum],
                        utf8_to_uv_or_die((U8 *) scan, (U8 *) this_eol, NULL))))
             {
                 scan += UTF8SKIP(scan);
@@ -11230,7 +11230,7 @@ S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const
                                                       &only_utf8_locale, NULL);
                 if (definition) {
                     /* Most likely is the outside-the-bitmap inversion list. */
-                    if (_invlist_contains_cp(definition, c)) {
+                    if (invlist_contains_cp_(definition, c)) {
                         match = true;
                     }
                     else /* Failing that, hardcode the two tests for a Turkic
@@ -11241,13 +11241,13 @@ S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const
                         /* Turkish locales have these hard-coded rules
                          * overriding normal ones */
                         if (*p == 'i') {
-                            if (_invlist_contains_cp(definition,
+                            if (invlist_contains_cp_(definition,
                                          LATIN_CAPITAL_LETTER_I_WITH_DOT_ABOVE))
                             {
                                 match = true;
                             }
                         }
-                        else if (_invlist_contains_cp(definition,
+                        else if (invlist_contains_cp_(definition,
                                                  LATIN_SMALL_LETTER_DOTLESS_I))
                         {
                             match = true;
@@ -11259,7 +11259,7 @@ S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const
                     && UNLIKELY(IN_UTF8_CTYPE_LOCALE)
                     && ! match)
                 {
-                    match = _invlist_contains_cp(only_utf8_locale, c);
+                    match = invlist_contains_cp_(only_utf8_locale, c);
                 }
             }
 
@@ -11667,7 +11667,7 @@ Perl_is_grapheme(pTHX_ const U8 * strbeg, const U8 * s, const U8 * strend, const
 
     /* Otherwise, unassigned code points are forbidden */
     if (UNLIKELY(! ELEMENT_RANGE_MATCHES_INVLIST(
-                                    _invlist_search(PL_Assigned_invlist, cp))))
+                                    invlist_search_(PL_Assigned_invlist, cp))))
     {
         return false;
     }
@@ -11881,7 +11881,7 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 * s, const U8 * send, const bool utf8_target)
         }
         else {
             script_of_char = _Perl_SCX_invmap[
-                                       _invlist_search(PL_SCX_invlist, cp)];
+                                       invlist_search_(PL_SCX_invlist, cp)];
         }
 
         /* We arbitrarily accept a single unassigned character, but not in
@@ -12102,7 +12102,7 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 * s, const U8 * send, const bool utf8_target)
         }
         else {  /* Need to look up if this character is a digit or not */
             SSize_t index_of_zero_of_char;
-            index_of_zero_of_char = _invlist_search(decimals_invlist, cp);
+            index_of_zero_of_char = invlist_search_(decimals_invlist, cp);
             if (     UNLIKELY(index_of_zero_of_char < 0)
                 || ! ELEMENT_RANGE_MATCHES_INVLIST(index_of_zero_of_char))
             {

--- a/regexp.h
+++ b/regexp.h
@@ -92,12 +92,12 @@ typedef struct regexp_paren_pair {
 } regexp_paren_pair;
 
 #  if defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C)
-#    define _invlist_union(a, b, output) _invlist_union_maybe_complement_2nd(a, b, FALSE, output)
-#    define _invlist_intersection(a, b, output) _invlist_intersection_maybe_complement_2nd(a, b, FALSE, output)
+#    define invlist_union_(a, b, output) invlist_union_maybe_complement_2nd_(a, b, FALSE, output)
+#    define invlist_intersection_(a, b, output) invlist_intersection_maybe_complement_2nd_(a, b, FALSE, output)
 
 /* Subtracting b from a leaves in a everything that was there that isn't in b,
  * that is the intersection of a with b's complement */
-#    define _invlist_subtract(a, b, output) _invlist_intersection_maybe_complement_2nd(a, b, TRUE, output)
+#    define invlist_subtract_(a, b, output) invlist_intersection_maybe_complement_2nd_(a, b, TRUE, output)
 #  endif
 
 /* record the position of a (?{...}) within a pattern */

--- a/toke.c
+++ b/toke.c
@@ -2969,7 +2969,7 @@ Perl_get_and_check_backslash_N_name(pTHX_ const char* s,
         }
         else {
             Size_t advance;
-            if (! _invlist_contains_cp(PL_utf8_charname_begin,
+            if (! invlist_contains_cp_(PL_utf8_charname_begin,
                                        utf8_to_uv_or_die((const U8 *) s,
                                                          (const U8 *) e,
                                                          &advance)))
@@ -2998,7 +2998,7 @@ Perl_get_and_check_backslash_N_name(pTHX_ const char* s,
             }
             else {
                 Size_t advance;
-                if (! _invlist_contains_cp(PL_utf8_charname_continue,
+                if (! invlist_contains_cp_(PL_utf8_charname_continue,
                                            utf8_to_uv_or_die((const U8 *) s,
                                                              (const U8 *) e,
                                                              &advance)))

--- a/utf8.c
+++ b/utf8.c
@@ -3564,19 +3564,19 @@ Perl_utf8_to_utf16_base(pTHX_ U8* s, U8* d, Size_t bytelen, Size_t *newlen,
 bool
 Perl_is_uni_FOO_(pTHX_ const U8 classnum, const UV c)
 {
-    return _invlist_contains_cp(PL_XPosix_ptrs[classnum], c);
+    return invlist_contains_cp_(PL_XPosix_ptrs[classnum], c);
 }
 
 bool
 Perl_is_uni_perl_idcont_(pTHX_ UV c)
 {
-    return _invlist_contains_cp(PL_utf8_perl_idcont, c);
+    return invlist_contains_cp_(PL_utf8_perl_idcont, c);
 }
 
 bool
 Perl_is_uni_perl_idstart_(pTHX_ UV c)
 {
-    return _invlist_contains_cp(PL_utf8_perl_idstart, c);
+    return invlist_contains_cp_(PL_utf8_perl_idstart, c);
 }
 
 UV
@@ -3931,7 +3931,7 @@ STATIC Size_t
 S_is_utf8_in_invlist(pTHX_ const U8 * p, const U8 * e, SV * const invlist)
 {
     Size_t advance;
-    if (_invlist_contains_cp(invlist, utf8_to_uv_or_die(p, e, &advance))) {
+    if (invlist_contains_cp_(invlist, utf8_to_uv_or_die(p, e, &advance))) {
         return advance;
     }
 
@@ -3998,7 +3998,7 @@ S_to_case_cp_list(pTHX_
 
     /* 'index' is guaranteed to be non-negative, as this is an inversion map
      * that covers all possible inputs.  See [perl #133365] */
-    index = _invlist_search(invlist, original);
+    index = invlist_search_(invlist, original);
     base = invmap[index];
 
     /* Most likely, the case change will contain just a single code point */
@@ -4148,7 +4148,7 @@ Perl_inverse_folds_(pTHX_ const UV cp, U32 * first_folds_to,
 
     /* 'index' is guaranteed to be non-negative, as this is an inversion map
      * that covers all possible inputs.  See [GH #16624] */
-    SSize_t index = _invlist_search(PL_utf8_foldclosures, cp);
+    SSize_t index = invlist_search_(PL_utf8_foldclosures, cp);
     assert(index >= 0);
     I32 base = _Perl_IVCF_invmap[index];
 
@@ -4311,7 +4311,7 @@ S_turkic_lc(pTHX_ const U8 * const p0, const U8 * const e,
              * modifier with a ccc of 230 may intervene */
             Size_t advance;
             cp = utf8_to_uv_or_die(p, e, &advance);
-            if (! _invlist_contains_cp(PL_CCC_non0_non230, cp)) {
+            if (! invlist_contains_cp_(PL_CCC_non0_non230, cp)) {
                 break;
             }
 


### PR DESCRIPTION
This continues the process started in #23592 to change names with leading underscores to be legal C.  See that p.r. or 4bb3572f7a1c1f3944b7f58b22b6e7a9ef5faba6 for extensive discussion.

This commit simply moves the leading underscore to be trailing


* This set of changes does not require a perldelta entry.
