### PR TITLE
toke.c: Fix inconsistency under 'use utf8'

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -393,6 +393,11 @@ consisted of only ASCII characters.  The real upper limit was as few as
 Chinese or Osage.  Now an identifier in any language may contain at
 least 255 characters.
 
+=item *
+
+Fixed parsing of array names starting with a digit in double-quotish
+context under C<use utf8;>.
+
 =back
 
 =head1 Known Problems

--- a/t/op/sub_lval.t
+++ b/t/op/sub_lval.t
@@ -5,7 +5,7 @@ BEGIN {
     require './test.pl';
     set_up_inc('../lib');
 }
-plan tests=>213;
+plan tests=>215;
 
 sub a : lvalue { my $a = 34; ${\(bless \$a)} }  # Return a temporary
 sub b : lvalue { ${\shift} }
@@ -1041,6 +1041,14 @@ sub else119797 : lvalue {
 eval { (else119797(0)) = 1..3 };
 is $@, "", '$@ after writing to array returned by else';
 is "@119797", "1 2 3", 'writing to array returned by else';
+
+{   # Being in UTF-8 used to break this
+    use utf8;
+    eval { (else119797(0)) = 1..3 };
+    is $@, "", '$@ after writing to array returned by else';
+    is "@119797", "1 2 3", 'writing to array returned by else';
+}
+
 eval { (else119797(1)) = 4..6 };
 is $@, "", '$@ after writing to array returned by if (with else)';
 is "@119797", "4 5 6", 'writing to array returned by if (with else)';

--- a/toke.c
+++ b/toke.c
@@ -3697,10 +3697,7 @@ S_scan_const(pTHX_ char *start)
              * (@foo, @::foo, @'foo, @{foo}, @$foo, @+, @-)
              */
         else if (*s == '@' && s[1]) {
-            if (UTF
-               ? isIDFIRST_utf8_safe(s+1, send)
-               : isWORDCHAR_A(s[1]))
-            {
+            if (isDIGIT_A(s[1]) || isIDFIRST_lazy_if_safe(s+1, send, UTF)) {
                 break;
             }
             if (memCHRs(":'{$", s[1]))


### PR DESCRIPTION
This code can't work properly:

    if (UTF ? isIDFIRST_utf8((U8*)s+1) : isWORDCHAR_A(s[1]))

Suppose you have a string composed entirely of ASCII characters beginning with a digit.  If the string isn't encoded in UTF-8, the condition is true, but it is false if the string happens to have the UTF-8 flag set for whatever reason.  One of those reasons simply is that the Perl program is being compiled under 'use utf8'.

The UTF-8 flag should not change the behavior of ASCII strings.

The code was introduced in 9d58dbc453a86c9cbb3a131adcd1559fe0445a08 in 2015, to fix [perl #123963] "@<fullwidth digit>".  The line it replaced was

    if (isWORDCHAR_lazy_if(s+1,UTF))

(The code was modified in 2016 by
fac0f7a38edc4e50a7250b738699165079b852d8 as part of a global substitution to use isIDFIRST_utf8_safe() so as to have no possibility of going off the end of the buffer), but that did not affect the logic.

The problem the original commit was trying to solve was that fullwidth digits (U+FF10 etc) were accepted when they shouldn't be, whereas [0-9] should remain as being accepted.  The defect is that [0-9] stopped being accepted when the UTF-8 flag is on.  The solution adopted here is to change it to instead be

    if (isDIGIT_A(s[1]) || isIDFIRST_lazy_if_safe(s+1, send, UTF))

This causes [0-9] to remain accepted regardless of the UTF-8 flag. So when it is on, the only difference between before this commit and after is that [0-9] are accepted.

In the ASCII range, the only difference between \w and IDFirst is that the former includes the digits 0-9, so when the UTF-8 flag is off this evaluates to isWORD_CHAR_A, as before.

(Changing to isIDFIRST from isWORDCHAR in the original commit did solve a bunch of other cases where a \w is not supposed to be the first character in a name.  There are about 4K such characters currently in Unicode.)


* This set of changes does not require a perldelta entry.  I don't think we should draw attention to the possibility of having identifiers whose names begin with digits
