### PR TITLE
fakesdio.h, utf8.h : Use legal macro name

### DIFF
--- a/fakesdio.h
+++ b/fakesdio.h
@@ -11,7 +11,7 @@
  * This is "source level" stdio compatibility mode.
  * We try and #define stdio functions in terms of PerlIO.
  */
-#define _CANNOT "CANNOT"
+#define CANNOT_ "CANNOT"
 #undef FILE
 #define FILE			PerlIO
 #undef clearerr
@@ -88,8 +88,8 @@
 #define fread(b,s,c,f)		PerlIO_read(f,b,(s*c))
 #define fwrite(b,s,c,f)		PerlIO_write(f,b,(s*c))
 #else
-#define fread(b,s,c,f)		_CANNOT fread
-#define fwrite(b,s,c,f)		_CANNOT fwrite
+#define fread(b,s,c,f)		CANNOT_ fread
+#define fwrite(b,s,c,f)		CANNOT_ fwrite
 #endif
 #define fseek(f,o,w)		PerlIO_seek(f,o,w)
 #define ftell(f)		PerlIO_tell(f)
@@ -102,25 +102,25 @@
 #define popen(c,m)		my_popen(c,m)
 #define pclose(f)		my_pclose(f)
 
-#define fsetpos(f,p)		_CANNOT _fsetpos_
-#define fgetpos(f,p)		_CANNOT _fgetpos_
+#define fsetpos(f,p)		CANNOT_ _fsetpos_
+#define fgetpos(f,p)		CANNOT_ _fgetpos_
 
-#define __filbuf(f)		_CANNOT __filbuf_
-#define _filbuf(f)		_CANNOT _filbuf_
-#define __flsbuf(c,f)		_CANNOT __flsbuf_
-#define _flsbuf(c,f)		_CANNOT _flsbuf_
-#define getw(f)			_CANNOT _getw_
-#define putw(v,f)		_CANNOT _putw_
+#define __filbuf(f)		CANNOT_ __filbuf_
+#define _filbuf(f)		CANNOT_ _filbuf_
+#define __flsbuf(c,f)		CANNOT_ __flsbuf_
+#define _flsbuf(c,f)		CANNOT_ _flsbuf_
+#define getw(f)			CANNOT_ _getw_
+#define putw(v,f)		CANNOT_ _putw_
 #if SFIO_VERSION < 20000101L
-#define flockfile(f)		_CANNOT _flockfile_
-#define ftrylockfile(f)		_CANNOT _ftrylockfile_
-#define funlockfile(f)		_CANNOT _funlockfile_
+#define flockfile(f)		CANNOT_ _flockfile_
+#define ftrylockfile(f)		CANNOT_ _ftrylockfile_
+#define funlockfile(f)		CANNOT_ _funlockfile_
 #endif
-#define freopen(p,m,f)		_CANNOT _freopen_
-#define setbuf(f,b)		_CANNOT _setbuf_
-#define setvbuf(f,b,x,s)	_CANNOT _setvbuf_
-#define fscanf			_CANNOT _fscanf_
-#define fgets(s,n,f)		_CANNOT _fgets_
+#define freopen(p,m,f)		CANNOT_ _freopen_
+#define setbuf(f,b)		CANNOT_ _setbuf_
+#define setvbuf(f,b,x,s)	CANNOT_ _setvbuf_
+#define fscanf			CANNOT_ _fscanf_
+#define fgets(s,n,f)		CANNOT_ _fgets_
 
 /*
  * ex: set ts=8 sts=4 sw=4 et:

--- a/utf8.h
+++ b/utf8.h
@@ -895,11 +895,11 @@ implementation of the latter. */
  * directly anywhere else.  'translate_function' is either NATIVE_TO_LATIN1
  * (which works for code points up through 0xFF) or NATIVE_TO_UNI which works
  * for any code point */
-#define __BASE_TWO_BYTE_HI(c, translate_function)                               \
+#define BASE_TWO_BYTE_HI_(c, translate_function)                               \
            (assert(! UVCHR_IS_INVARIANT(c)),                                    \
             I8_TO_NATIVE_UTF8((translate_function(c) >> UTF_ACCUMULATION_SHIFT) \
                               | UTF_START_MARK(2)))
-#define __BASE_TWO_BYTE_LO(c, translate_function)                               \
+#define BASE_TWO_BYTE_LO_(c, translate_function)                               \
              (assert(! UVCHR_IS_INVARIANT(c)),                                  \
               I8_TO_NATIVE_UTF8((translate_function(c) & UTF_CONTINUATION_MASK) \
                                  | UTF_CONTINUATION_MARK))
@@ -907,15 +907,15 @@ implementation of the latter. */
 /* The next two macros should not be used.  They were designed to be usable as
  * the case label of a switch statement, but this doesn't work for EBCDIC.  Use
  * regen/unicode_constants.pl instead */
-#define UTF8_TWO_BYTE_HI_nocast(c)  __BASE_TWO_BYTE_HI(c, NATIVE_TO_UNI)
-#define UTF8_TWO_BYTE_LO_nocast(c)  __BASE_TWO_BYTE_LO(c, NATIVE_TO_UNI)
+#define UTF8_TWO_BYTE_HI_nocast(c)  BASE_TWO_BYTE_HI_(c, NATIVE_TO_UNI)
+#define UTF8_TWO_BYTE_LO_nocast(c)  BASE_TWO_BYTE_LO_(c, NATIVE_TO_UNI)
 
 /* The next two macros are used when the source should be a single byte
  * character; checked for under DEBUGGING */
 #define UTF8_EIGHT_BIT_HI(c) (assert(FITS_IN_8_BITS(c)),                    \
-                             ( __BASE_TWO_BYTE_HI(c, NATIVE_TO_LATIN1)))
+                             ( BASE_TWO_BYTE_HI_(c, NATIVE_TO_LATIN1)))
 #define UTF8_EIGHT_BIT_LO(c) (assert(FITS_IN_8_BITS(c)),                    \
-                             (__BASE_TWO_BYTE_LO(c, NATIVE_TO_LATIN1)))
+                             (BASE_TWO_BYTE_LO_(c, NATIVE_TO_LATIN1)))
 
 /* These final two macros in the series are used when the source can be any
  * code point whose UTF-8 is known to occupy 2 bytes; they are less efficient
@@ -926,11 +926,11 @@ implementation of the latter. */
 #define UTF8_TWO_BYTE_HI(c)                                                    \
        (assert((sizeof(c) ==  1)                                               \
                   || !(((WIDEST_UTYPE)(c)) & ~MAX_UTF8_TWO_BYTE)),             \
-        (__BASE_TWO_BYTE_HI(c, NATIVE_TO_UNI)))
+        (BASE_TWO_BYTE_HI_(c, NATIVE_TO_UNI)))
 #define UTF8_TWO_BYTE_LO(c)                                                    \
        (assert((sizeof(c) ==  1)                                               \
                   || !(((WIDEST_UTYPE)(c)) & ~MAX_UTF8_TWO_BYTE)),             \
-        (__BASE_TWO_BYTE_LO(c, NATIVE_TO_UNI)))
+        (BASE_TWO_BYTE_LO_(c, NATIVE_TO_UNI)))
 
 /* This is illegal in any well-formed UTF-8 in both EBCDIC and ASCII
  * as it is only in overlongs. */


### PR DESCRIPTION
It is undefined behavior in C for a symbol name to begin with an
underscore followed by a capital letter or a second underscore.  It's a simple matter to move
the underscore to the end

* This set of changes does not require a perldelta entry.
