### PR TITLE
Make win32/perlexe high DPI aware

### DIFF
--- a/win32/perlexe.manifest
+++ b/win32/perlexe.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
     <assemblyIdentity version="0.0.0.0" name="Perl" type="Win32" />
     <description>Perl</description>
     <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
@@ -29,4 +29,10 @@
         <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       </application>
     </compatibility>
+    <asmv3:application>
+      <asmv3:windowsSettings>
+          <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+          <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
 </assembly>


### PR DESCRIPTION
On Windows 11 with a sufficiently high resolution and scaling not set to 100% (ie. 2560x1440 with 125% scaling), GUI apps that aren't high DPI aware will have rather blurry text. Not sure if this is really needed for GUI-based Perl applications, but given the presence of "Microsoft.Windows.Common-Controls" as a dependent assembly, better safe than sorry.

* This set of changes does not require a perldelta entry.
