### PR TITLE
Partially revert fd88a92 - it's GvCVGEN(gv), not CvGEN(cv)

### DIFF
--- a/gv.c
+++ b/gv.c
@@ -669,7 +669,7 @@ S_maybe_add_coresub(pTHX_ HV * const stash, GV *gv,
            get hairy. */
         cv = MUTABLE_CV(newSV_type(SVt_PVCV));
         GvCV_set(gv,cv);
-        assert(GvCVGEN(gv) == 0);
+        GvCVGEN(gv) = 0;
         CvISXSUB_on(cv);
         CvXSUB(cv) = core_xsub;
         PoisonPADLIST(cv);

--- a/op.c
+++ b/op.c
@@ -12320,7 +12320,7 @@ Perl_newSTUB(pTHX_ GV *gv, bool fake)
     PERL_ARGS_ASSERT_NEWSTUB;
     assert(!GvCVu(gv));
     GvCV_set(gv, cv);
-    assert(GvCVGEN(gv) == 0);
+    GvCVGEN(gv) = 0;
     if (!fake && GvSTASH(gv) && HvENAME_HEK(GvSTASH(gv)))
         gv_method_changed(gv);
     if (SvFAKE(gv)) {

--- a/t/op/stash.t
+++ b/t/op/stash.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc( qw(../lib) );
 }
 
-plan( tests => 55 );
+plan( tests => 56 );
 
 # Used to segfault (bug #15479)
 fresh_perl_like(
@@ -356,3 +356,22 @@ is runperl(
    ),
    "*main::main::\n",
    "[perl #129869] lookup %:: by name after clearing %::";
+
+is runperl(
+    prog => 'no strict q|refs|;
+             Stash->can(q|Trash|);
+             my $full_method = q|Stash::Trash|;
+             # Save method
+             my $mocked = \&{$full_method};
+             # Replace method
+             *{$full_method} = sub {};
+             # Restore original method
+             *{$full_method} = $mocked;
+             # Stash::Trash should now be undefined
+             my $coderef = sub { Stash::Trash() };
+             $coderef->();
+    ',
+    stderr => 1,
+   ),
+   "Undefined subroutine &Stash::Trash called at -e line 11.\n",
+   "[GH#23855], [GH#23856] Don't assume GvCVGEN(gv) value";


### PR DESCRIPTION
This commit partially reverts https://github.com/Perl/perl5/commit/fd88a926b5a38da5bc8cb2bb248b141b48e1c71f

In two places in that commit, setting `GvCVGEN` to zero was changed to just asserting that the value was already zero, because the CV had just been created (with a Zeroed body). However, the value is set on a pre-existing GV, not on the fresh CV, so no assumptions should be made about the current value of `GvCVGEN`.

Closes #23855
Closes #23856

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
