### PR TITLE
 makedef.pl: Eliminate need for embed.fnc sync

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2150,6 +2150,7 @@ p	|int	|mode_from_discipline					\
 
 : Used in sv.c and hv.c
 Cop	|void * |more_bodies	|const svtype sv_type
+Cp	|SV *	|more_sv
 Cp	|const char *|moreswitches					\
 				|NN const char *s
 Adp	|void	|mortal_destructor_sv					\
@@ -6036,7 +6037,6 @@ S	|void	|glob_assign_glob					\
 				|NN SV * const ssv			\
 				|const int dtype
 S	|bool	|glob_2number	|NN GV * const gv
-Cp	|SV *	|more_sv
 S	|void	|not_a_number	|NN SV * const sv
 S	|void	|not_incrementable					\
 				|NN SV * const sv

--- a/embed.fnc
+++ b/embed.fnc
@@ -620,9 +620,11 @@
 :
 :   'O'  Has a perl_ compatibility macro.
 :
-:        The really OLD name for API funcs.
+:        The really OLD name for API funcs.  These now also require the 'p'
+:	 flag so as to generate a modern name.  Obviously no new entries
+:	 should get this flag.
 :
-:        autodoc.pl adds a note that the perl_ form of this function is
+:        autodoc.pl adds a note that the 'perl_' form of this function is
 :        deprecated.
 :
 :   'o'  Has no Perl_foo or S_foo compatibility macro:

--- a/embed.h
+++ b/embed.h
@@ -375,6 +375,7 @@
 # define mg_set(a)                              Perl_mg_set(aTHX_ a)
 # define mg_size(a)                             Perl_mg_size(aTHX_ a)
 # define mini_mktime                            Perl_mini_mktime
+# define more_sv()                              Perl_more_sv(aTHX)
 # define moreswitches(a)                        Perl_moreswitches(aTHX_ a)
 # define mortal_destructor_sv(a,b)              Perl_mortal_destructor_sv(aTHX_ a,b)
 # define mortal_getenv                          Perl_mortal_getenv
@@ -1667,6 +1668,54 @@
 #     define save_pushptri32ptr(a,b,c,d)        S_save_pushptri32ptr(aTHX_ a,b,c,d)
 #     define save_scalar_at(a,b)                S_save_scalar_at(aTHX_ a,b)
 #   endif
+#   if defined(PERL_IN_SV_C)
+#     define F0convert                          S_F0convert
+#     define anonymise_cv_maybe(a,b)            S_anonymise_cv_maybe(aTHX_ a,b)
+#     define assert_uft8_cache_coherent(a,b,c,d) S_assert_uft8_cache_coherent(aTHX_ a,b,c,d)
+#     define croak_sv_setsv_flags(a,b)          S_croak_sv_setsv_flags(aTHX_ a,b)
+#     define curse(a,b)                         S_curse(aTHX_ a,b)
+#     define expect_number(a)                   S_expect_number(aTHX_ a)
+#     define find_array_subscript(a,b)          S_find_array_subscript(aTHX_ a,b)
+#     define find_hash_subscript(a,b)           S_find_hash_subscript(aTHX_ a,b)
+#     define find_uninit_var(a,b,c,d)           S_find_uninit_var(aTHX_ a,b,c,d)
+#     define glob_2number(a)                    S_glob_2number(aTHX_ a)
+#     define glob_assign_glob(a,b,c)            S_glob_assign_glob(aTHX_ a,b,c)
+#     define not_a_number(a)                    S_not_a_number(aTHX_ a)
+#     define not_incrementable(a)               S_not_incrementable(aTHX_ a)
+#     define ptr_table_find                     S_ptr_table_find
+#     define sv_2iuv_common(a)                  S_sv_2iuv_common(aTHX_ a)
+#     define sv_add_arena(a,b,c)                S_sv_add_arena(aTHX_ a,b,c)
+#     define sv_display(a,b,c)                  S_sv_display(aTHX_ a,b,c)
+#     define sv_pos_b2u_midway(a,b,c,d)         S_sv_pos_b2u_midway(aTHX_ a,b,c,d)
+#     define sv_pos_u2b_cached(a,b,c,d,e,f,g)   S_sv_pos_u2b_cached(aTHX_ a,b,c,d,e,f,g)
+#     define sv_pos_u2b_forwards                S_sv_pos_u2b_forwards
+#     define sv_pos_u2b_midway                  S_sv_pos_u2b_midway
+#     define sv_unglob(a,b)                     S_sv_unglob(aTHX_ a,b)
+#     define utf8_mg_len_cache_update(a,b,c)    S_utf8_mg_len_cache_update(aTHX_ a,b,c)
+#     define utf8_mg_pos_cache_update(a,b,c,d,e) S_utf8_mg_pos_cache_update(aTHX_ a,b,c,d,e)
+#     define visit(a,b,c)                       S_visit(aTHX_ a,b,c)
+#     if defined(DEBUGGING)
+#       define del_sv(a)                        S_del_sv(aTHX_ a)
+#       define sv_mark_arenas()                 Perl_sv_mark_arenas(aTHX)
+#       define sv_sweep_arenas()                Perl_sv_sweep_arenas(aTHX)
+#     endif
+#     if !defined(NV_PRESERVES_UV)
+#       if defined(DEBUGGING)
+#         define sv_2iuv_non_preserve(a,b)      S_sv_2iuv_non_preserve(aTHX_ a,b)
+#       else
+#         define sv_2iuv_non_preserve(a)        S_sv_2iuv_non_preserve(aTHX_ a)
+#       endif
+#     endif
+#     if defined(PERL_DEBUG_READONLY_COW)
+#       define sv_buf_to_rw(a)                  S_sv_buf_to_rw(aTHX_ a)
+#     endif
+#     if defined(USE_ITHREADS)
+#       define sv_dup_common(a,b)               S_sv_dup_common(aTHX_ a,b)
+#       define sv_dup_hvaux(a,b,c)              S_sv_dup_hvaux(aTHX_ a,b,c)
+#       define sv_dup_inc_multiple(a,b,c,d)     S_sv_dup_inc_multiple(aTHX_ a,b,c,d)
+#       define unreferenced_to_tmp_stack(a)     S_unreferenced_to_tmp_stack(aTHX_ a)
+#     endif
+#   endif /* defined(PERL_IN_SV_C) */
 #   if defined(PERL_IN_TOKE_C)
 #     define ao(a)                              S_ao(aTHX_ a)
 #     define check_unary()                      S_check_unary(aTHX)
@@ -2119,57 +2168,6 @@
 #     define get_regclass_aux_data(a,b,c,d,e,f) Perl_get_regclass_aux_data(aTHX_ a,b,c,d,e,f)
 #   endif
 # endif /* defined(PERL_IN_REGEX_ENGINE) */
-# if defined(PERL_IN_SV_C)
-#   define more_sv()                            Perl_more_sv(aTHX)
-#   if defined(PERL_CORE)
-#     define F0convert                          S_F0convert
-#     define anonymise_cv_maybe(a,b)            S_anonymise_cv_maybe(aTHX_ a,b)
-#     define assert_uft8_cache_coherent(a,b,c,d) S_assert_uft8_cache_coherent(aTHX_ a,b,c,d)
-#     define croak_sv_setsv_flags(a,b)          S_croak_sv_setsv_flags(aTHX_ a,b)
-#     define curse(a,b)                         S_curse(aTHX_ a,b)
-#     define expect_number(a)                   S_expect_number(aTHX_ a)
-#     define find_array_subscript(a,b)          S_find_array_subscript(aTHX_ a,b)
-#     define find_hash_subscript(a,b)           S_find_hash_subscript(aTHX_ a,b)
-#     define find_uninit_var(a,b,c,d)           S_find_uninit_var(aTHX_ a,b,c,d)
-#     define glob_2number(a)                    S_glob_2number(aTHX_ a)
-#     define glob_assign_glob(a,b,c)            S_glob_assign_glob(aTHX_ a,b,c)
-#     define not_a_number(a)                    S_not_a_number(aTHX_ a)
-#     define not_incrementable(a)               S_not_incrementable(aTHX_ a)
-#     define ptr_table_find                     S_ptr_table_find
-#     define sv_2iuv_common(a)                  S_sv_2iuv_common(aTHX_ a)
-#     define sv_add_arena(a,b,c)                S_sv_add_arena(aTHX_ a,b,c)
-#     define sv_display(a,b,c)                  S_sv_display(aTHX_ a,b,c)
-#     define sv_pos_b2u_midway(a,b,c,d)         S_sv_pos_b2u_midway(aTHX_ a,b,c,d)
-#     define sv_pos_u2b_cached(a,b,c,d,e,f,g)   S_sv_pos_u2b_cached(aTHX_ a,b,c,d,e,f,g)
-#     define sv_pos_u2b_forwards                S_sv_pos_u2b_forwards
-#     define sv_pos_u2b_midway                  S_sv_pos_u2b_midway
-#     define sv_unglob(a,b)                     S_sv_unglob(aTHX_ a,b)
-#     define utf8_mg_len_cache_update(a,b,c)    S_utf8_mg_len_cache_update(aTHX_ a,b,c)
-#     define utf8_mg_pos_cache_update(a,b,c,d,e) S_utf8_mg_pos_cache_update(aTHX_ a,b,c,d,e)
-#     define visit(a,b,c)                       S_visit(aTHX_ a,b,c)
-#     if defined(DEBUGGING)
-#       define del_sv(a)                        S_del_sv(aTHX_ a)
-#       define sv_mark_arenas()                 Perl_sv_mark_arenas(aTHX)
-#       define sv_sweep_arenas()                Perl_sv_sweep_arenas(aTHX)
-#     endif
-#     if !defined(NV_PRESERVES_UV)
-#       if defined(DEBUGGING)
-#         define sv_2iuv_non_preserve(a,b)      S_sv_2iuv_non_preserve(aTHX_ a,b)
-#       else
-#         define sv_2iuv_non_preserve(a)        S_sv_2iuv_non_preserve(aTHX_ a)
-#       endif
-#     endif
-#     if defined(PERL_DEBUG_READONLY_COW)
-#       define sv_buf_to_rw(a)                  S_sv_buf_to_rw(aTHX_ a)
-#     endif
-#     if defined(USE_ITHREADS)
-#       define sv_dup_common(a,b)               S_sv_dup_common(aTHX_ a,b)
-#       define sv_dup_hvaux(a,b,c)              S_sv_dup_hvaux(aTHX_ a,b,c)
-#       define sv_dup_inc_multiple(a,b,c,d)     S_sv_dup_inc_multiple(aTHX_ a,b,c,d)
-#       define unreferenced_to_tmp_stack(a)     S_unreferenced_to_tmp_stack(aTHX_ a)
-#     endif
-#   endif /* defined(PERL_CORE) */
-# endif /* defined(PERL_IN_SV_C) */
 # if defined(PERL_MEM_LOG)
 #   define mem_log_alloc                        Perl_mem_log_alloc
 #   define mem_log_del_sv                       Perl_mem_log_del_sv

--- a/embed.h
+++ b/embed.h
@@ -49,25 +49,23 @@
 # define sv_setptrref(rv,ptr)                   sv_setref_iv(rv,NULL,PTR2IV(ptr))
 # if !defined(PERL_NOCOMPAT)
 
-/* Compatibility for various misnamed functions.  All functions
-   in the API that begin with "perl_" (not "Perl_") take an explicit
-   interpreter context pointer.
-   The following are not like that, but since they had a "perl_"
-   prefix in previous versions, we provide compatibility macros.
- */
-#   define perl_atexit(a,b)                     call_atexit(a,b)
-#   define perl_call_argv(a,b,c)                call_argv(a,b,c)
-#   define perl_call_method(a,b)                call_method(a,b)
-#   define perl_call_pv(a,b)                    call_pv(a,b)
-#   define perl_call_sv(a,b)                    call_sv(a,b)
-#   define perl_eval_pv(a,b)                    eval_pv(a,b)
-#   define perl_eval_sv(a,b)                    eval_sv(a,b)
-#   define perl_get_av(a,b)                     get_av(a,b)
-#   define perl_get_cv(a,b)                     get_cv(a,b)
-#   define perl_get_hv(a,b)                     get_hv(a,b)
-#   define perl_get_sv(a,b)                     get_sv(a,b)
-#   define perl_init_i18nl10n(a)                init_i18nl10n(a)
-#   define perl_require_pv(a)                   require_pv(a)
+/* Compatibility for this renamed function. */
+#   define perl_atexit(a,b)                     Perl_call_atexit(aTHX_ a,b)
+
+/* Compatibility for these functions that had a 'perl_' prefix before
+ * 'Perl_' became the standard */
+#   define perl_call_argv(a,b,c)                Perl_call_argv(aTHX_ a,b,c)
+#   define perl_call_method(a,b)                Perl_call_method(aTHX_ a,b)
+#   define perl_call_pv(a,b)                    Perl_call_pv(aTHX_ a,b)
+#   define perl_call_sv(a,b)                    Perl_call_sv(aTHX_ a,b)
+#   define perl_eval_pv(a,b)                    Perl_eval_pv(aTHX_ a,b)
+#   define perl_eval_sv(a,b)                    Perl_eval_sv(aTHX_ a,b)
+#   define perl_get_av(a,b)                     Perl_get_av(aTHX_ a,b)
+#   define perl_get_cv(a,b)                     Perl_get_cv(aTHX_ a,b)
+#   define perl_get_hv(a,b)                     Perl_get_hv(aTHX_ a,b)
+#   define perl_get_sv(a,b)                     Perl_get_sv(aTHX_ a,b)
+#   define perl_init_i18nl10n(a)                Perl_init_i18nl10n(aTHX_ a)
+#   define perl_require_pv(a)                   Perl_require_pv(aTHX_ a)
 
 /* Before C99, macros could not wrap varargs functions. This
    provides a set of compatibility functions that don't take an

--- a/makedef.pl
+++ b/makedef.pl
@@ -794,7 +794,9 @@ unless ($Config{d_wcrtomb}) {
 {
     my %seen;
     my ($embed_array) = setup_embed($ARGS{TARG_DIR});
-    my $excludedre = $define{'NO_MATHOMS'} ? qr/[emiIsb]/ : qr/[emiIs]/;
+    my $excludedre = 'eiIms';
+    $excludedre .= 'b' if $define{'NO_MATHOMS'};
+    $excludedre = qr/[$excludedre]/;
 
     foreach my $entry (@$embed_array) {
         my $embed= $entry->{embed}

--- a/makedef.pl
+++ b/makedef.pl
@@ -813,7 +813,6 @@ unless ($Config{d_wcrtomb}) {
 	    # within the block, as the *first* definition may have flags which
 	    # mean "don't export"
 	    next if $seen{$func}++;
-	    # Should we also skip adding the Perl_ prefix if $flags =~ /o/ ?
 	    $func = "Perl_$func" if ($flags =~ /[psX]/ && $func !~ /^Perl_/);
 	    ++$export{$func} unless exists $skip{$func};
 	}

--- a/makedef.pl
+++ b/makedef.pl
@@ -796,8 +796,8 @@ unless ($Config{d_wcrtomb}) {
     my ($embed_array) = setup_embed($ARGS{TARG_DIR});
     my $excludedre = $define{'NO_MATHOMS'} ? qr/[emiIsb]/ : qr/[emiIs]/;
 
-    foreach (@$embed_array) {
-        my $embed= $_->{embed}
+    foreach my $entry (@$embed_array) {
+        my $embed= $entry->{embed}
             or next;
 	my ($flags, $retval, $func, $args) = @{$embed}{qw(flags return_type name args)};
 	next unless $func;

--- a/makedef.pl
+++ b/makedef.pl
@@ -2,6 +2,9 @@
 #
 # Create the export list for perl.
 #
+# WARNING: This file duplicates information from some of its source files, and
+# must be kept in sync with changes to them.
+#
 # Needed by WIN32 and OS/2 for creating perl.dll,
 # and by AIX for creating libperl.a when -Duseshrplib is in effect,
 # and by VMS for creating perlshr.exe.
@@ -19,7 +22,7 @@
 #    perlvars.h
 #    regen/opcodes
 #
-# plus long lists of function names hard-coded directly in this script.
+# plus long lists of function names (sadly) hard-coded directly in this script.
 #
 # Writes the result to STDOUT.
 #
@@ -37,7 +40,7 @@ use warnings;
 
 my $fold;
 my %ARGS;
-my %define;
+our %define;
 BEGIN {
     %ARGS = (CCTYPE => 'MSVC', TARG_DIR => '');
 
@@ -282,15 +285,6 @@ sub readvar {
 if (PLATFORM ne 'os2') {
     ++$skip{$_} foreach qw(
 		     PL_opsave
-		     Perl_dump_fds
-		     Perl_my_bcopy
-		     Perl_my_bzero
-		     Perl_my_chsize
-		     Perl_my_htonl
-		     Perl_my_memcmp
-		     Perl_my_memset
-		     Perl_my_ntohl
-		     Perl_my_swap
 			 );
     if (PLATFORM eq 'vms') {
 	++$skip{PL_statusvalue_posix};
@@ -319,48 +313,16 @@ if (PLATFORM ne 'vms') {
 			PL_sig_ignoring
 			PL_sig_defaulting
 			 );
-    if (PLATFORM ne 'win32') {
-	++$skip{$_} foreach qw(
-			    Perl_do_spawn
-			    Perl_do_spawn_nowait
-			    Perl_do_aspawn
-			     );
-    }
-}
-
-if (PLATFORM ne 'win32') {
-    ++$skip{$_} foreach qw(
-		    Perl_get_context
-		    Perl_get_win32_message_utf8ness
-		    Perl_Win_utf8_string_to_wstring
-		    Perl_Win_wstring_to_utf8_string
-			 );
-}
-
-unless ($define{UNLINK_ALL_VERSIONS}) {
-    ++$skip{Perl_unlnk};
 }
 
 unless ($define{'DEBUGGING'}) {
     ++$skip{$_} foreach qw(
-		    Perl_debop
-		    Perl_debprofdump
-		    Perl_debstack
-		    Perl_debstackptrs
-		    Perl_pad_sv
-		    Perl_pad_setsv
-		    Perl_set_padlist
-		    Perl_hv_assert
 		    PL_watchaddr
 		    PL_watchok
 			 );
 }
 
 if ($define{'PERL_IMPLICIT_SYS'}) {
-    ++$skip{$_} foreach qw(
-		    Perl_my_popen
-		    Perl_my_pclose
-			 );
     ++$export{$_} foreach qw(perl_get_host_info perl_alloc_override);
     ++$export{perl_clone_host} if $define{USE_ITHREADS};
 }
@@ -375,8 +337,6 @@ else {
 		    PL_Dir
 		    PL_Sock
 		    PL_Proc
-		    perl_alloc_using
-		    perl_clone_using
 			 );
 }
 
@@ -390,10 +350,6 @@ unless ($define{'USE_REENTRANT_API'}) {
 
 if ($define{'MYMALLOC'}) {
     try_symbols(qw(
-		    Perl_dump_mstats
-		    Perl_get_mstats
-		    Perl_strdup
-		    Perl_putenv
 		    MallocCfg_ptr
 		    MallocCfgP_ptr
 		    ));
@@ -404,8 +360,6 @@ if ($define{'MYMALLOC'}) {
 else {
     ++$skip{$_} foreach qw(
 		    PL_malloc_mutex
-		    Perl_dump_mstats
-		    Perl_get_mstats
 		    MallocCfg_ptr
 		    MallocCfgP_ptr
 			 );
@@ -436,37 +390,7 @@ unless ($define{'USE_ITHREADS'}) {
 		    PL_stashpadix
 		    PL_stashpadmax
                     PL_veto_switch_non_tTHX_context
-		    Perl_alloccopstash
-		    Perl_allocfilegv
-		    Perl_clone_params_del
-		    Perl_clone_params_new
-		    Perl_parser_dup
-		    Perl_dirp_dup
-		    Perl_cx_dup
-		    Perl_si_dup
-		    Perl_any_dup
-		    Perl_ss_dup
-		    Perl_fp_dup
-		    Perl_gp_dup
-		    Perl_he_dup
-		    Perl_mg_dup
-		    Perl_re_dup_guts
-		    Perl_sv_dup
-		    Perl_sv_dup_inc
-		    Perl_rvpv_dup
-		    Perl_hek_dup
-		    Perl_sys_intern_dup
-		    perl_clone
-		    perl_clone_using
-		    Perl_stashpv_hvname_match
-		    Perl_regdupe_internal
-		    Perl_newPADOP
 			 );
-}
-
-unless ($define{'USE_THREADS'}) {
-    ++$skip{Perl_thread_locale_init};
-    ++$skip{Perl_thread_locale_term};
 }
 
 if (!$define{USE_ITHREADS} || $define{WIN32}) {
@@ -495,13 +419,6 @@ unless ($define{USE_PL_CUR_LC_ALL})
     );
 }
 
-unless ($define{USE_PERL_SWITCH_LOCALE_CONTEXT})
-{
-    ++$skip{$_} foreach qw(
-        Perl_switch_locale_context
-    );
-}
-
 unless ($define{'MULTIPLICITY'}) {
     ++$skip{$_} foreach qw(
                     PL_cur_locale_obj
@@ -510,31 +427,7 @@ unless ($define{'MULTIPLICITY'}) {
 		    PL_my_cxt_size
 		    PL_my_cxt_keys
 		    PL_my_cxt_keys_size
-		    Perl_croak_nocontext
-		    Perl_die_nocontext
-		    Perl_deb_nocontext
-		    Perl_form_nocontext
-		    Perl_load_module_nocontext
-		    Perl_mess_nocontext
-		    Perl_warn_nocontext
-		    Perl_warner_nocontext
-		    Perl_newSVpvf_nocontext
-		    Perl_sv_catpvf_nocontext
-		    Perl_sv_setpvf_nocontext
-		    Perl_sv_catpvf_mg_nocontext
-		    Perl_sv_setpvf_mg_nocontext
-		    Perl_my_cxt_init
-		    Perl_my_cxt_index
 			 );
-}
-
-unless ($define{'USE_DTRACE'}) {
-    ++$skip{$_} foreach qw(
-                    Perl_dtrace_probe_call
-                    Perl_dtrace_probe_load
-                    Perl_dtrace_probe_op
-                    Perl_dtrace_probe_phase
-                );
 }
 
 unless ($define{'DEBUG_LEAKING_SCALARS'}) {
@@ -543,10 +436,6 @@ unless ($define{'DEBUG_LEAKING_SCALARS'}) {
 
 unless ($define{'DEBUG_LEAKING_SCALARS_FORK_DUMP'}) {
     ++$skip{PL_dumper_fd};
-}
-
-unless ($define{'PERL_DONT_CREATE_GVSV'}) {
-    ++$skip{Perl_gv_SVadd};
 }
 
 unless ($define{'PERL_USES_PL_PIDSTATUS'}) {
@@ -560,11 +449,6 @@ unless ($define{'PERL_TRACK_MEMPOOL'}) {
 unless ($define{'PERL_MEM_LOG'}) {
     ++$skip{$_} foreach qw(
                     PL_mem_log
-                    Perl_mem_log_alloc
-                    Perl_mem_log_realloc
-                    Perl_mem_log_free
-                    Perl_mem_log_new_sv
-                    Perl_mem_log_del_sv
                 );
 }
 
@@ -602,11 +486,6 @@ if (PLATFORM eq 'vms' && !$define{KILL_BY_SIGPRC}) {
     ++$skip{PL_sig_handlers_initted} unless !$define{HAS_SIGACTION};
 }
 
-if ($define{'HAS_STRNLEN'})
-{
-    ++$skip{Perl_my_strnlen};
-}
-
 unless ($define{USE_LOCALE_COLLATE}) {
     ++$skip{$_} foreach qw(
 		    PL_collation_ix
@@ -614,8 +493,6 @@ unless ($define{USE_LOCALE_COLLATE}) {
 		    PL_collation_standard
 		    PL_collxfrm_base
 		    PL_collxfrm_mult
-		    Perl_sv_collxfrm
-		    Perl_sv_collxfrm_flags
                     PL_strxfrm_NUL_replacement
                     PL_strxfrm_is_behaved
                     PL_strxfrm_max_cp
@@ -649,37 +526,16 @@ unless (   ! $define{HAS_NL_LANGINFO}
                               );
     }
 
-unless ($define{'USE_C_BACKTRACE'}) {
-    ++$skip{Perl_get_c_backtrace_dump};
-    ++$skip{Perl_dump_c_backtrace};
-}
-
 unless ($define{HAVE_INTERP_INTERN}) {
     ++$skip{$_} foreach qw(
-		    Perl_sys_intern_clear
-		    Perl_sys_intern_dup
-		    Perl_sys_intern_init
 		    PL_sys_intern
 			 );
 }
-
-if ($define{HAS_SIGNBIT}) {
-    ++$skip{Perl_signbit};
-}
-
 ++$skip{PL_op_exec_cnt}
     unless $define{PERL_TRACE_OPS};
 
 ++$skip{PL_hash_chars}
     unless $define{PERL_USE_SINGLE_CHAR_HASH_CACHE};
-
-unless ($define{PERL_RC_STACK}) {
-    ++$skip{$_} foreach qw(
-		    Perl_pp_wrap
-		    Perl_xs_wrap
-                    Perl_runops_wrap
-			 );
-}
 
 # functions from *.sym files
 
@@ -773,12 +629,6 @@ push @syms, 'perlio.sym';
 # PerlIO with layers - export implementation
 try_symbols(@layer_syms, 'perlsio_binmode');
 
-
-unless ($define{'USE_QUADMATH'}) {
-  ++$skip{Perl_quadmath_format_needed};
-  ++$skip{Perl_quadmath_format_single};
-}
-
 unless ($Config{d_mbrlen}) {
     ++$skip{PL_mbrlen_ps};
 }
@@ -819,7 +669,66 @@ unless ($Config{d_wcrtomb}) {
 	    # mean "don't export"
 	    next if $seen{$func}++;
 	    $func = "Perl_$func" if ($flags =~ /[psX]/ && $func !~ /^Perl_/);
-	    ++$export{$func} unless exists $skip{$func};
+
+            # If no conditions, export unconditionally.
+            if ($entry->{cond}->@* == 0) {
+                ++$export{$func} unless exists $skip{$func};
+            }
+            else {
+                # Replace what the HeaderLine object thinks is the output line
+                # with this trailing portion of a condition, with a marker
+                $entry->{line} =
+             ") { ++\$export{$func} unless exists \$skip{$func} }MAKEDEF_XXX";
+
+                # And get HeaderParser to surround that with any #if's that it
+                # found when parsing embed.fnc
+                my $hp= HeaderParser->new();
+                my $group = $hp->group_content([$entry]);
+                my $lines = $hp->lines_as_str($group);
+
+                # What that returns is something like
+                #   #if defined(USE_THREADS
+                #   ) { ++$export{foo} }MAKEDEF_XXX
+                #   #endif
+
+                #  The #if may have continuations; get rid of them; they
+                #  confuse perl
+                $lines =~ s/ \\ $ //mxg;
+
+                # Get rid of everything after the marker
+                $lines =~ s/ MAKEDEF_XXX .* //xs;
+
+                # Convert the C conditional(s) to be like
+                #   $define{USE_THREADS}
+                $lines =~ s: \b defined \( ( [^)]+ ) \) :\$define{$1}:xg;
+
+                # And change the #if so that the result (on a single line)
+                # looks like
+                #   if ($define{USE_THREADS} { ++export{foo}; }
+                $lines =~ s/ \#if / if ( /x;
+
+                # Unfortunately, we have to deal specially with some functions
+                # that have both the E and X flags.
+                my $is_EX = $flags =~ tr/EX// > 1;
+
+                # These should be visible to Perl extensions, so they need to
+                # be exported.  And the regular expression handling is quite
+                # special.  That is turned into a special module that has
+                # copies of the related .c files, and those need access to
+                # certain functions that normally aren't enabled outside those
+                # .c files.   What we do here is to locally override these few
+                # %define entries for just these flags.  (It might be that
+                # this could globally be done, but it is safer to restrict it
+                # to here.)
+                local $define{PERL_EXT} = 1 if $is_EX;
+                local $define{PERL_IN_REGCOMP_C} = 1 if $is_EX;
+                local $define{PERL_IN_REGEXEC_C} = 1 if $is_EX;
+                local $define{PERL_IN_REGCOMP_ANY} = 1 if $is_EX;
+
+                # And eval to do the export depending on the conditions
+                eval $lines;
+                die "eval '$lines' failed: $@" if $@;
+            }
 	}
     }
 }

--- a/makedef.pl
+++ b/makedef.pl
@@ -211,6 +211,15 @@ if ($define{MULTIPLICITY} && (   $define{USE_POSIX_2008_LOCALE}
     $define{USE_PERL_SWITCH_LOCALE_CONTEXT} = 1;
 }
 
+# enable PERL_COPY_ON_WRITE by default
+$define{PERL_COPY_ON_WRITE} = 1 unless $define{PERL_NO_COW};
+if ($define{PERL_COPY_ON_WRITE}) {
+    $define{PERL_ANY_COW} = 1;
+}
+else {
+    $define{PERL_SAWAMPERSAND} = 1;
+}
+
 # perl.h logic duplication ends
 #==========================================================================
 
@@ -369,10 +378,6 @@ else {
 		    perl_alloc_using
 		    perl_clone_using
 			 );
-}
-
-if (!$define{'PERL_COPY_ON_WRITE'} || $define{'PERL_NO_COW'}) {
-    ++$skip{Perl_sv_setsv_cow};
 }
 
 unless ($define{PERL_SAWAMPERSAND}) {

--- a/perl.h
+++ b/perl.h
@@ -1325,6 +1325,17 @@ typedef enum {
 #  endif
 #endif  /* End of USE_LOCALE */
 
+/* enable PERL_COPY_ON_WRITE by default */
+#if !defined(PERL_COPY_ON_WRITE) && !defined(PERL_NO_COW)
+#  define PERL_COPY_ON_WRITE
+#endif
+
+#ifdef PERL_COPY_ON_WRITE
+#  define PERL_ANY_COW
+#else
+# define PERL_SAWAMPERSAND
+#endif
+
 /* end of makedef.pl logic duplication
  * ========================================================================= */
 
@@ -3216,17 +3227,6 @@ typedef struct padname PADNAME;
 /* always enable PERL_OP_PARENT  */
 #if !defined(PERL_OP_PARENT)
 #  define PERL_OP_PARENT
-#endif
-
-/* enable PERL_COPY_ON_WRITE by default */
-#if !defined(PERL_COPY_ON_WRITE) && !defined(PERL_NO_COW)
-#  define PERL_COPY_ON_WRITE
-#endif
-
-#ifdef PERL_COPY_ON_WRITE
-#  define PERL_ANY_COW
-#else
-# define PERL_SAWAMPERSAND
 #endif
 
 #if defined(PERL_DEBUG_READONLY_OPS) && !defined(USE_ITHREADS)

--- a/proto.h
+++ b/proto.h
@@ -2524,6 +2524,10 @@ PERL_CALLCONV void *
 Perl_more_bodies(pTHX_ const svtype sv_type);
 #define PERL_ARGS_ASSERT_MORE_BODIES
 
+PERL_CALLCONV SV *
+Perl_more_sv(pTHX);
+#define PERL_ARGS_ASSERT_MORE_SV
+
 PERL_CALLCONV const char *
 Perl_moreswitches(pTHX_ const char *s);
 #define PERL_ARGS_ASSERT_MORESWITCHES           \
@@ -9228,10 +9232,6 @@ STATIC void
 S_glob_assign_glob(pTHX_ SV * const dsv, SV * const ssv, const int dtype);
 # define PERL_ARGS_ASSERT_GLOB_ASSIGN_GLOB      \
         assert(dsv); assert(ssv)
-
-PERL_CALLCONV SV *
-Perl_more_sv(pTHX);
-# define PERL_ARGS_ASSERT_MORE_SV
 
 STATIC void
 S_not_a_number(pTHX_ SV * const sv);

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -846,9 +846,9 @@ sub embed_h {
                 $ret .= ")\n";
                 if($has_compat_macro{$func}) {
                     # Make older ones available only when !MULTIPLICITY or
-                    # PERL_CORE or PERL_WANT_VARARGS These should not be done
-                    # uncondtionally because existing code might call e.g.
-                    # warn() without aTHX in scope.
+                    # PERL_CORE or PERL_WANT_VARARGS.  These should not be
+                    # done unconditionally because existing code might call
+                    # e.g.  warn() without aTHX in scope.
                     $ret = "#${ind}if !defined(MULTIPLICITY)"
                          . " || defined(PERL_CORE)"
                          . " || defined(PERL_WANT_VARARGS)\n"

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -155,6 +155,11 @@ sub generate_proto_h {
             die_at_end "flag $1 is not legal (for function $plain_func)";
         }
 
+        if ($flags =~ /O/) {
+            die_at_end "$plain_func: O flag requires p flag" if $flags !~ /p/;
+            die_at_end "$plain_func: O flag forbids T flag" if $flags =~ /T/;
+        }
+
         my @nonnull;
         my $args_assert_line = ( $flags !~ /m/ );
         my $has_depth = ( $flags =~ /W/ );

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -55,6 +55,7 @@ my @have_compatibility_macros = qw(
                                   );
 my %has_compat_macro;
 $has_compat_macro{$_} = 1 for @have_compatibility_macros;
+my %perl_compats;   # Have 'perl_' prefix
 
 my $unflagged_pointers;
 my @az = ('a'..'z');
@@ -848,7 +849,19 @@ sub embed_h {
                         die "Can't use W without other args (currently)";
                     }
                 }
-                $ret .= ")\n";
+                $ret .= ")";
+
+                # For functions that have an old 'perl_' name, create an entry
+                # here while we have all the information, for output later
+                # (when not under NO_SHORT_NAMES)
+                if ($flags =~ /O/) {
+                    my $extra_entry = $ret;
+                    $extra_entry =~ s/define /define perl_/;
+                    $perl_compats{$extra_entry} = 1;
+                }
+
+                $ret .= "\n";
+
                 if($has_compat_macro{$func}) {
                     # Make older ones available only when !MULTIPLICITY or
                     # PERL_CORE or PERL_WANT_VARARGS.  These should not be
@@ -860,6 +873,7 @@ sub embed_h {
                          . $ret
                          . "#${ind}endif\n";
                 }
+
             }
             $ret = "#${ind}ifndef NO_MATHOMS\n$ret#${ind}endif\n"
                                                              if $flags =~ /b/;
@@ -915,25 +929,15 @@ sub generate_embed_h {
 
     #if !defined(PERL_CORE) && !defined(PERL_NOCOMPAT)
 
-    /* Compatibility for various misnamed functions.  All functions
-       in the API that begin with "perl_" (not "Perl_") take an explicit
-       interpreter context pointer.
-       The following are not like that, but since they had a "perl_"
-       prefix in previous versions, we provide compatibility macros.
-     */
-    #  define perl_atexit(a,b)          call_atexit(a,b)
+    /* Compatibility for this renamed function. */
+    #  define perl_atexit(a,b)          Perl_call_atexit(aTHX_ a,b)
+
+    /* Compatibility for these functions that had a 'perl_' prefix before
+     * 'Perl_' became the standard */
     END
 
-    foreach (@$all) {
-        my $embed= $_->{embed} or next;
-        my ($flags, $retval, $func, $args) =
-                                @{$embed}{qw(flags return_type name args)};
-        next unless $flags =~ /O/;
-
-        my $alist = join ",", @az[0..$#$args];
-        my $ret = "#  define perl_$func($alist) ";
-        print $em add_indent($ret,"$func($alist)\n");
-    }
+    # These have been saved up for now
+    print $em map { "$_\n" } sort keys %perl_compats;
 
     print $em <<~'END';
 

--- a/sv_inline.h
+++ b/sv_inline.h
@@ -63,10 +63,6 @@
         ++PL_sv_count;                                  \
     } STMT_END
 
-/* Perl_more_sv lives in sv.c, we don't want to inline it.
- * but the function declaration seems to be needed. */
-SV* Perl_more_sv(pTHX);
-
 /* new_SV(): return a new, empty SV head */
 PERL_STATIC_INLINE SV*
 Perl_new_sv(pTHX_ const char *file, int line, const char *func)


### PR DESCRIPTION
makedef.pl has to manually be kept in sync with various other pieces of code.  This is extra work, and error prone.  This commit eliminates that need for embed.fnc syncing.

The relatively new HeaderParser already returns the information we need in its object for each entry.  This commit just takes advantage of that, and removes the many lines that were previously needed for this purpose.

Running this under Linux with PLATFORM=test revealed nearly 50 symbols that would have been needlessly exported, such as Perl_grok_bslash_x(), which is only defined in certain files, and not globally.


* This set of changes does not require a perldelta entry.
